### PR TITLE
Refactor ComputerBox: rename monitor to gui and remove endpoint API

### DIFF
--- a/examples/python/computerbox_example.py
+++ b/examples/python/computerbox_example.py
@@ -29,7 +29,7 @@ async def test_all_functions():
     print("=== ComputerBox - Testing All Functions ===\n")
 
     async with boxlite.ComputerBox(cpu=2, memory=2048) as desktop:
-        print(f"✓ Desktop ready: {desktop.endpoint()}\n")
+        print("✓ Desktop started\n")
 
         # 1. wait_until_ready()
         print("1. wait_until_ready()")
@@ -113,7 +113,7 @@ async def example_workflow():
     print("\n\n=== Example Workflow ===\n")
 
     async with boxlite.ComputerBox(cpu=2, memory=2048) as desktop:
-        print(f"Desktop: {desktop.endpoint()}\n")
+        print("Desktop started\n")
 
         # Wait for desktop
         await desktop.wait_until_ready()


### PR DESCRIPTION
## Summary
- Remove `endpoint()` method from ComputerBox (no longer needed)
- Rename `_GUEST_MONITOR_HTTP_PORT` to `_GUEST_GUI_HTTP_PORT`
- Rename `_GUEST_MONITOR_HTTPS_PORT` to `_GUEST_GUI_HTTPS_PORT`
- Rename `monitor_http_port` parameter to `gui_http_port`
- Rename `monitor_https_port` parameter to `gui_https_port`
- Update example file and docstrings accordingly

## Test plan
- [ ] Run computerbox_example.py to verify functionality
- [ ] Verify ComputerBox can still be instantiated with custom ports

🤖 Generated with [Claude Code](https://claude.com/claude-code)