### PR TITLE
Bump version to 0.2.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["build/tmp", "target", ".venv", "examples/*/.venv"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.2"
+version = "0.2.3"
 edition = "2024"
 authors = ["Dorian Zheng <https://github.com/dorianzheng>"]
 license = "Apache-2.0"

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "boxlite"
-version = "0.2.2"
+version = "0.2.3"
 description = "Python bindings for Boxlite runtime"
 requires-python = ">=3.10"
 authors = [{ name = "Dorian Zheng" }]


### PR DESCRIPTION
## Summary
- Bump workspace version in `Cargo.toml` to 0.2.3
- Bump Python SDK version in `sdks/python/pyproject.toml` to 0.2.3

## Test plan
- [ ] Verify build passes
- [ ] Verify version shows correctly in packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)