### PR TITLE
  Fix container init failing for images with empty WorkingDir

### DIFF
--- a/guest/src/service/container.rs
+++ b/guest/src/service/container.rs
@@ -56,14 +56,6 @@ impl ContainerService for GuestServer {
                 })),
             }));
         }
-        if config.workdir.is_empty() {
-            error!("Invalid container config: workdir cannot be empty");
-            return Ok(Response::new(ContainerInitResponse {
-                result: Some(container_init_response::Result::Error(ContainerInitError {
-                    reason: "Invalid container config: workdir cannot be empty".to_string(),
-                })),
-            }));
-        }
 
         info!("🚀 Starting OCI container with received configuration");
         debug!(


### PR DESCRIPTION
## Summary
  - Remove workdir validation that rejected empty strings in container init
  - Fixes compatibility with OCI images that have empty WorkingDir (e.g., alpine)

  ## Problem
  Container initialization was failing with:
  Container init failed: Invalid container config: workdir cannot be empty

  This occurred because the OCI spec allows `WorkingDir` to be either omitted or an empty string, but our validation rejected empty strings.

  ## Root Cause
  Images like `alpine` have `"WorkingDir": ""` in their config, which is valid per the OCI image spec but was rejected by our validation in `guest/src/service/container.rs`.

  ## Test plan
  - [ ] Verify `alpine` image works with sandbox tool
  - [ ] Verify images with explicit workdir (e.g., `python:alpine`) still work