### PR TITLE
Build libkrun from source on macOS instead of using Homebrew

### DIFF
--- a/boxlite/deps/libkrun-sys/patches/macos-cross-compile.patch
+++ b/boxlite/deps/libkrun-sys/patches/macos-cross-compile.patch
@@ -1,0 +1,139 @@
+From a2eddd5cda847441f1d155c5aa4ab419a00f9fa6 Mon Sep 17 00:00:00 2001
+From: Sergio Lopez <slp@redhat.com>
+Date: Mon, 1 Dec 2025 18:10:43 +0100
+Subject: [PATCH] Makefile: add cross-compilation support
+
+Developed-by: Jan Noha <nohajc@gmail.com>
+---
+ Makefile | 79 ++++++++++++++++++++++++++++++++++++++++++++++++++++----
+ 1 file changed, 74 insertions(+), 5 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index cff066e..8cfc9c6 100644
+--- a/Makefile
++++ b/Makefile
+@@ -17,10 +17,19 @@ SNP_INIT_SRC =	init/tee/snp_attest.c		\
+ 		$(KBS_INIT_SRC)			\
+ 
+ TDX_INIT_SRC = $(KBS_INIT_SRC)
++NITRO_INIT_SRC = init/nitro/include/vsock.h		\
++		init/nitro/include/archive.h		\
++		init/nitro/include/fs.h			\
++		init/nitro/main.c			\
++		init/nitro/vsock.c			\
++		init/nitro/archive.c			\
++		init/nitro/fs.c				\
+ 
+ KBS_LD_FLAGS =	-lcurl -lidn2 -lssl -lcrypto -lzstd -lz -lbrotlidec-static \
+ 		-lbrotlicommon-static
+ 
++NITRO_INIT_LD_FLAGS = -larchive -lnsm
++
+ BUILD_INIT = 1
+ INIT_DEFS =
+ ifeq ($(SEV),1)
+@@ -73,6 +82,9 @@ ifeq ($(TIMESYNC),1)
+ endif
+ 
+ OS = $(shell uname -s)
++ARCH = $(shell uname -m)
++DEBIAN_DIST ?= bookworm
++ROOTFS_DIR = linux-sysroot
+ 
+ KRUN_BINARY_Linux = libkrun$(VARIANT).so.$(FULL_VERSION)
+ KRUN_SONAME_Linux = libkrun$(VARIANT).so.$(ABI_VERSION)
+@@ -94,17 +106,69 @@ ifeq ($(PREFIX),)
+     PREFIX := /usr/local
+ endif
+ 
+-.PHONY: install clean test test-prefix $(LIBRARY_RELEASE_$(OS)) $(LIBRARY_DEBUG_$(OS)) libkrun.pc
++.PHONY: install clean test test-prefix $(LIBRARY_RELEASE_$(OS)) $(LIBRARY_DEBUG_$(OS)) libkrun.pc clean-sysroot clean-all
+ 
+ all: $(LIBRARY_RELEASE_$(OS)) libkrun.pc
+ 
+ debug: $(LIBRARY_DEBUG_$(OS)) libkrun.pc
+ 
++ifeq ($(OS),Darwin)
++# If SYSROOT_LINUX is not set and we're on macOS, generate sysroot automatically
++ifeq ($(SYSROOT_LINUX),)
++SYSROOT_LINUX = $(ROOTFS_DIR)
++SYSROOT_TARGET = $(ROOTFS_DIR)/.sysroot_ready
++else
++SYSROOT_TARGET =
++endif
++# Cross-compile on macOS with the LLVM linker (brew install lld)
++CC_LINUX=/usr/bin/clang -target $(ARCH)-linux-gnu -fuse-ld=lld -Wl,-strip-debug --sysroot $(SYSROOT_LINUX) -Wno-c23-extensions
++else
++# Build on Linux host
++CC_LINUX=$(CC)
++SYSROOT_TARGET =
++endif
++
+ ifeq ($(BUILD_INIT),1)
+ INIT_BINARY = init/init
+-$(INIT_BINARY): $(INIT_SRC)
+-	gcc -O2 -static -Wall $(INIT_DEFS) -o $@ $(INIT_SRC) $(INIT_DEFS)
+-endif
++$(INIT_BINARY): $(INIT_SRC) $(SYSROOT_TARGET)
++	$(CC_LINUX) -O2 -static -Wall $(INIT_DEFS) -o $@ $(INIT_SRC) $(INIT_DEFS)
++endif
++
++NITRO_INIT_BINARY= init/nitro/init
++$(NITRO_INIT_BINARY): $(NITRO_INIT_SRC)
++	$(CC) -O2 -static -Wall $(NITRO_INIT_LD_FLAGS) -o $@ $(NITRO_INIT_SRC) $(NITRO_INIT_LD_FLAGS)
++
++# Sysroot preparation rules for cross-compilation on macOS
++DEBIAN_PACKAGES = libc6 libc6-dev libgcc-12-dev linux-libc-dev
++ROOTFS_TMP = $(ROOTFS_DIR)/.tmp
++PACKAGES_FILE = $(ROOTFS_TMP)/Packages.xz
++
++.INTERMEDIATE: $(PACKAGES_FILE)
++
++$(ROOTFS_DIR)/.sysroot_ready: $(PACKAGES_FILE)
++	@echo "Extracting Debian packages to $(ROOTFS_DIR)..."
++	@for pkg in $(DEBIAN_PACKAGES); do \
++		DEB_PATH=$$(xzcat $(PACKAGES_FILE) | sed '1,/Package: '$$pkg'$$/d' | grep Filename: | sed 's/^Filename: //' | head -n1); \
++		DEB_URL="https://deb.debian.org/debian/$$DEB_PATH"; \
++		DEB_NAME=$$(basename "$$DEB_PATH"); \
++		if [ ! -f "$(ROOTFS_TMP)/$$DEB_NAME" ]; then \
++			echo "Downloading $$DEB_URL"; \
++			curl -fL -o "$(ROOTFS_TMP)/$$DEB_NAME" "$$DEB_URL"; \
++		fi; \
++		cd $(ROOTFS_TMP) && ar x "$$DEB_NAME" && cd ../..; \
++		tar xf $(ROOTFS_TMP)/data.tar.* -C $(ROOTFS_DIR); \
++		rm -f $(ROOTFS_TMP)/*.deb $(ROOTFS_TMP)/data.tar.* $(ROOTFS_TMP)/control.tar.* $(ROOTFS_TMP)/debian-binary; \
++	done
++	@touch $@
++
++$(PACKAGES_FILE):
++	@echo "Downloading Debian package index for $(DEBIAN_DIST)/$(ARCH)..."
++	@mkdir -p $(ROOTFS_TMP)
++	@curl -fL -o $@ https://deb.debian.org/debian/dists/$(DEBIAN_DIST)/main/binary-$(ARCH)/Packages.xz
++
++clean-sysroot:
++	rm -rf $(ROOTFS_DIR)
++
+ 
+ $(LIBRARY_RELEASE_$(OS)): $(INIT_BINARY)
+ 	cargo build --release $(FEATURE_FLAGS)
+@@ -162,11 +226,16 @@ clean:
+ 	rm -rf test-prefix
+ 	cd tests; cargo clean
+ 
++clean-all: clean clean-sysroot
++
+ test-prefix/lib64/libkrun.pc: $(LIBRARY_RELEASE_$(OS))
+ 	mkdir -p test-prefix
+ 	PREFIX="$$(realpath test-prefix)" make install
+ 
+ test-prefix: test-prefix/lib64/libkrun.pc
+ 
++TEST ?= all
++TEST_FLAGS ?=
++
+ test: test-prefix
+-	cd tests; LD_LIBRARY_PATH="$$(realpath ../test-prefix/lib64/)" PKG_CONFIG_PATH="$$(realpath ../test-prefix/lib64/pkgconfig/)" ./run.sh
++	cd tests; RUST_LOG=trace LD_LIBRARY_PATH="$$(realpath ../test-prefix/lib64/)" PKG_CONFIG_PATH="$$(realpath ../test-prefix/lib64/pkgconfig/)" ./run.sh test --test-case "$(TEST)" $(TEST_FLAGS)
+-- 
+2.50.1
+


### PR DESCRIPTION
## Summary
- Remove dependency on homebrew-krun tap (had stale bottles causing build failures)
- Build libkrun and libkrunfw from source during `cargo build`
- On macOS: download prebuilt libkrunfw tarball, cross-compile init binary with clang + lld
- Vendor cross-compilation patch locally instead of downloading at build time
- Refactor build.rs to share common code between macOS and Linux builds

## Test plan
- [ ] Run `make setup` on macOS to install dependencies (lld, dtc)
- [ ] Run `cargo build -p libkrun-sys` and verify successful build
- [ ] Verify init binary is Linux ELF: `file vendor/libkrun/init/init`
- [ ] Verify dylibs have @rpath install names: `otool -D target/debug/build/libkrun-sys-*/out/libkrun/lib/libkrun.1.dylib`