### PR TITLE
Fix cross-device link error by using boxlite home for temp files

### DIFF
--- a/boxlite/src/litebox/init/stages/init_image.rs
+++ b/boxlite/src/litebox/init/stages/init_image.rs
@@ -39,7 +39,7 @@ pub async fn run(input: InitImageInput<'_>) -> BoxliteResult<InitImageOutput> {
 
 /// Prepare init rootfs as a disk image.
 async fn prepare_init_rootfs(
-    _runtime: &crate::runtime::RuntimeInner,
+    runtime: &crate::runtime::RuntimeInner,
     base_image: &crate::images::ImageObject,
     env: Vec<(String, String)>,
 ) -> BoxliteResult<InitRootfs> {
@@ -76,8 +76,9 @@ async fn prepare_init_rootfs(
     // No cached disk - create from layers
     tracing::info!("Creating init disk image from layers (first run)");
 
-    // Extract layers to temp directory
-    let temp_dir = tempfile::tempdir()
+    // Extract layers to temp directory within boxlite home (same filesystem as destination)
+    let temp_base = runtime.non_sync_state.layout.temp_dir();
+    let temp_dir = tempfile::tempdir_in(&temp_base)
         .map_err(|e| BoxliteError::Storage(format!("Failed to create temp directory: {}", e)))?;
     let merged_path = temp_dir.path().join("merged");
 

--- a/boxlite/src/runtime/layout.rs
+++ b/boxlite/src/runtime/layout.rs
@@ -44,6 +44,13 @@ impl FilesystemLayout {
         self.home_dir.join(const_dirs::BOXES_DIR)
     }
 
+    /// Temporary directory for transient files: ~/.boxlite/tmp
+    /// Used for disk image creation and other operations that need
+    /// temp files on the same filesystem as the final destination.
+    pub fn temp_dir(&self) -> PathBuf {
+        self.home_dir.join("tmp")
+    }
+
     /// Initialize the filesystem structure.
     ///
     /// Creates necessary directories (home_dir, sockets, images, etc.).
@@ -54,6 +61,11 @@ impl FilesystemLayout {
         let _ = std::fs::remove_dir_all(self.boxes_dir());
         std::fs::create_dir_all(self.boxes_dir())
             .map_err(|e| BoxliteError::Storage(format!("failed to create boxes dir: {e}")))?;
+
+        // Clean and recreate temp dir to avoid stale files from previous runs
+        let _ = std::fs::remove_dir_all(self.temp_dir());
+        std::fs::create_dir_all(self.temp_dir())
+            .map_err(|e| BoxliteError::Storage(format!("failed to create temp dir: {e}")))?;
 
         std::fs::create_dir_all(self.image_layers_dir())
             .map_err(|e| BoxliteError::Storage(format!("failed to create layers dir: {e}")))?;


### PR DESCRIPTION
## Summary
- Create temp directories within `~/.boxlite/tmp/` instead of system `/tmp`
- Ensures atomic renames work when installing disk images to the cache
- Follows containerd's pattern of keeping temp files within storage root

## Problem
When creating disk images, temp files were created in `/tmp`. Moving them to `~/.boxlite/images/disk-images/` failed with "Invalid cross-device link" (EXDEV) when `/tmp` and home are on different filesystems.

## Changes
- Add `temp_dir()` method to `FilesystemLayout` returning `~/.boxlite/tmp`
- Update `prepare()` to create and clean temp dir on startup
- Use `tempfile::tempdir_in()` in `init_image.rs` and `rootfs.rs`

## Test plan
- [ ] Start a computer on a system where `/tmp` is on a different filesystem than home