### PR TITLE
Fix silent initialization failures

### DIFF
--- a/boxlite/src/controller/spawn.rs
+++ b/boxlite/src/controller/spawn.rs
@@ -46,10 +46,12 @@ pub(super) fn spawn_subprocess(
     cmd.stdout(Stdio::piped());
 
     cmd.spawn().map_err(|e| {
-        BoxliteError::Engine(format!(
+        let err_msg = format!(
             "Failed to spawn VM subprocess at {}: {}",
             binary_path.display(),
             e
-        ))
+        );
+        tracing::error!("{}", err_msg);
+        BoxliteError::Engine(err_msg)
     })
 }

--- a/sdks/python/boxlite/computerbox.py
+++ b/sdks/python/boxlite/computerbox.py
@@ -141,9 +141,14 @@ class ComputerBox(SimpleBox):
                 logger.debug(f"Desktop not ready yet (waited {elapsed:.1f}s), retrying...")
                 await asyncio.sleep(retry_delay)
 
-            except Exception as e:
+            except (ExecError, ConnectionError, OSError, asyncio.TimeoutError) as e:
+                # Transient errors - guest not ready yet, retry
                 logger.debug(f"Desktop not ready: {e}, retrying...")
                 await asyncio.sleep(retry_delay)
+            except Exception as e:
+                # Fatal errors - propagate immediately (e.g., spawn failure, permission denied)
+                logger.error(f"Fatal error in wait_until_ready: {e}")
+                raise
 
     # GUI Automation Methods
 


### PR DESCRIPTION
## Summary
- Add `tracing::error!` logging in Rust before errors propagate, so failures are visible even when caught by retry loops
- Fix Python `wait_until_ready()` to distinguish transient vs fatal errors

## Changes
- **spawn.rs**: Log subprocess spawn failures (e.g., "Permission denied")
- **pipeline.rs**: Log failures for all 6 init stages with `box_id` and `stage` context
- **shim.rs**: Log guest ready timeout and socket binding errors
- **computerbox.py**: Only retry transient errors (`ExecError`, `ConnectionError`, `OSError`, `TimeoutError`); propagate fatal errors immediately

## Test plan
- [ ] Run with `RUST_LOG=error` and verify init failures are logged
- [ ] Simulate spawn failure (e.g., remove execute permission from boxlite-shim) and verify error propagates immediately instead of timing out after 60s