### PR TITLE
refactor: add FsLayoutConfig for bind mount configuration

### DIFF
--- a/boxlite/src/litebox/init/stages/config.rs
+++ b/boxlite/src/litebox/init/stages/config.rs
@@ -114,10 +114,7 @@ fn build_fs_shares(
 
     // Single "shared" virtiofs share for container directories
     // Guest mounts this to /run/boxlite/shared/
-    #[cfg(target_os = "linux")]
     shares.add(mount_tags::SHARED, layout.shared_dir(), false);
-    #[cfg(target_os = "macos")]
-    shares.add(mount_tags::SHARED, layout.mounts_dir().to_path_buf(), false);
 
     // Strategy-specific shares
     match rootfs_result {

--- a/boxlite/src/litebox/init/stages/filesystem.rs
+++ b/boxlite/src/litebox/init/stages/filesystem.rs
@@ -32,9 +32,8 @@ pub fn run(input: FilesystemInput<'_>) -> BoxliteResult<FilesystemOutput> {
     #[cfg(target_os = "linux")]
     let bind_mount = {
         use crate::fs::{BindMountConfig, create_bind_mount};
-        create_bind_mount(
-            &BindMountConfig::new(layout.mounts_dir(), &layout.shared_dir()).read_only(),
-        )?
+        let mounts_dir = layout.mounts_dir();
+        create_bind_mount(&BindMountConfig::new(&mounts_dir, &layout.shared_dir()).read_only())?
     };
 
     Ok(FilesystemOutput {

--- a/boxlite/src/litebox/init/types.rs
+++ b/boxlite/src/litebox/init/types.rs
@@ -149,9 +149,8 @@ pub struct FilesystemInput<'a> {
 /// Output from filesystem stage.
 pub struct FilesystemOutput {
     pub layout: BoxFilesystemLayout,
-    /// Bind mount handle for mounts/ → shared/ binding (Linux only).
+    /// Bind mount handle for mounts/ → shared/ binding.
     /// Kept alive for the duration of box lifecycle; cleaned up on drop.
-    /// On macOS, virtiofs doesn't handle symlinks, so we skip the bind mount.
     #[cfg(target_os = "linux")]
     pub _bind_mount: BindMountHandle,
 }


### PR DESCRIPTION
## Summary

- Add `FsLayoutConfig` struct with `is_bind_mount()` method to control filesystem layout behavior
- `FilesystemLayout` and `BoxFilesystemLayout` now store and use the config
- `mounts_dir()` returns appropriate directory based on bind mount support
- Platform-specific config: Linux uses bind mount, macOS does not
- Remove platform-specific conditionals from config.rs

## Why bind mount?

The bind mount pattern (mounts/ → shared/) enables:
1. Host writes to mounts/ with full read-write access
2. Guest sees shared/ as read-only (bind mount with MS_RDONLY)

This prevents guest from modifying host-prepared files while allowing the host to update content at any time.

## Test plan

- [x] `cargo check -p boxlite` passes