### PR TITLE
refactor: rename InitRootfs to GuestRootfs for clarity

### DIFF
--- a/boxlite/src/controller/shim.rs
+++ b/boxlite/src/controller/shim.rs
@@ -189,7 +189,7 @@ impl VmmController for ShimController {
             guest_entrypoint: config.guest_entrypoint.clone(),
             transport: config.transport.clone(),
             ready_transport: config.ready_transport.clone(),
-            init_rootfs: config.init_rootfs.clone(),
+            guest_rootfs: config.guest_rootfs.clone(),
             network_backend_endpoint: config.network_backend_endpoint.clone(), // Pass connection info to subprocess
             home_dir: config.home_dir.clone(),
             console_output: config.console_output.clone(),

--- a/boxlite/src/litebox/init/stages/mod.rs
+++ b/boxlite/src/litebox/init/stages/mod.rs
@@ -10,15 +10,15 @@
 //!                 │
 //! Rootfs ─────────┼──→ Config ──→ Spawn ──→ Guest
 //!                 │
-//! InitImage ──────┘
+//! GuestRootfs ────┘
 //!
-//! Parallel:   [Filesystem, Rootfs, InitImage]
+//! Parallel:   [Filesystem, Rootfs, GuestRootfs]
 //! Sequential: Config → Spawn → Guest
 //! ```
 
 pub mod config;
 pub mod filesystem;
 pub mod guest;
-pub mod init_image;
+pub mod guest_rootfs;
 pub mod rootfs;
 pub mod spawn;

--- a/boxlite/src/litebox/init/types.rs
+++ b/boxlite/src/litebox/init/types.rs
@@ -9,7 +9,7 @@ use crate::metrics::BoxMetricsStorage;
 use crate::net::NetworkBackend;
 use crate::portal::GuestSession;
 use crate::runtime::RuntimeInner;
-use crate::runtime::initrf::InitRootfs;
+use crate::runtime::guest_rootfs::GuestRootfs;
 use crate::runtime::layout::BoxFilesystemLayout;
 use crate::runtime::options::{BoxOptions, VolumeSpec};
 use crate::runtime::types::ContainerId;
@@ -170,15 +170,15 @@ pub struct RootfsOutput {
     pub image: ImageObject,
 }
 
-/// Input for init image stage.
-pub struct InitImageInput<'a> {
+/// Input for guest rootfs stage.
+pub struct GuestRootfsInput<'a> {
     pub runtime: &'a RuntimeInner,
-    pub init_rootfs_cell: &'a Arc<OnceCell<InitRootfs>>,
+    pub guest_rootfs_cell: &'a Arc<OnceCell<GuestRootfs>>,
 }
 
-/// Output from init image stage.
-pub struct InitImageOutput {
-    pub init_rootfs: InitRootfs,
+/// Output from guest rootfs stage.
+pub struct GuestRootfsOutput {
+    pub guest_rootfs: GuestRootfs,
 }
 
 /// Input for config stage.
@@ -186,7 +186,7 @@ pub struct ConfigInput<'a> {
     pub options: &'a BoxOptions,
     pub layout: &'a BoxFilesystemLayout,
     pub rootfs: &'a RootfsOutput,
-    pub init_rootfs: &'a InitRootfs,
+    pub guest_rootfs: &'a GuestRootfs,
     pub home_dir: &'a PathBuf,
     pub container_id: &'a ContainerId,
 }

--- a/boxlite/src/metrics/box_metrics.rs
+++ b/boxlite/src/metrics/box_metrics.rs
@@ -28,8 +28,8 @@ pub struct BoxMetricsStorage {
     pub(crate) stage_filesystem_setup_ms: Option<u128>,
     /// Time to pull and prepare container image layers (Stage 2)
     pub(crate) stage_image_prepare_ms: Option<u128>,
-    /// Time to bootstrap init rootfs (Stage 3, lazy initialization)
-    pub(crate) stage_init_rootfs_ms: Option<u128>,
+    /// Time to bootstrap guest rootfs (Stage 3, lazy initialization)
+    pub(crate) stage_guest_rootfs_ms: Option<u128>,
     /// Time to build box configuration (Stage 4)
     pub(crate) stage_box_config_ms: Option<u128>,
     /// Time to spawn box subprocess (Stage 5, excludes guest boot)
@@ -49,7 +49,7 @@ impl Clone for BoxMetricsStorage {
             guest_boot_duration_ms: self.guest_boot_duration_ms,
             stage_filesystem_setup_ms: self.stage_filesystem_setup_ms,
             stage_image_prepare_ms: self.stage_image_prepare_ms,
-            stage_init_rootfs_ms: self.stage_init_rootfs_ms,
+            stage_guest_rootfs_ms: self.stage_guest_rootfs_ms,
             stage_box_config_ms: self.stage_box_config_ms,
             stage_box_spawn_ms: self.stage_box_spawn_ms,
             stage_container_init_ms: self.stage_container_init_ms,
@@ -83,9 +83,9 @@ impl BoxMetricsStorage {
         self.stage_image_prepare_ms = Some(duration_ms);
     }
 
-    /// Set init rootfs bootstrap stage duration.
-    pub(crate) fn set_stage_init_rootfs(&mut self, duration_ms: u128) {
-        self.stage_init_rootfs_ms = Some(duration_ms);
+    /// Set guest rootfs bootstrap stage duration.
+    pub(crate) fn set_stage_guest_rootfs(&mut self, duration_ms: u128) {
+        self.stage_guest_rootfs_ms = Some(duration_ms);
     }
 
     /// Set box config build stage duration.
@@ -162,8 +162,8 @@ pub struct BoxMetrics {
     pub stage_filesystem_setup_ms: Option<u128>,
     /// Time to pull and prepare container image layers (milliseconds)
     pub stage_image_prepare_ms: Option<u128>,
-    /// Time to bootstrap init rootfs (milliseconds)
-    pub stage_init_rootfs_ms: Option<u128>,
+    /// Time to bootstrap guest rootfs (milliseconds)
+    pub stage_guest_rootfs_ms: Option<u128>,
     /// Time to build box configuration (milliseconds)
     pub stage_box_config_ms: Option<u128>,
     /// Time to spawn box subprocess (milliseconds)
@@ -198,7 +198,7 @@ impl BoxMetrics {
             network_tcp_errors,
             stage_filesystem_setup_ms: storage.stage_filesystem_setup_ms,
             stage_image_prepare_ms: storage.stage_image_prepare_ms,
-            stage_init_rootfs_ms: storage.stage_init_rootfs_ms,
+            stage_guest_rootfs_ms: storage.stage_guest_rootfs_ms,
             stage_box_config_ms: storage.stage_box_config_ms,
             stage_box_spawn_ms: storage.stage_box_spawn_ms,
             stage_container_init_ms: storage.stage_container_init_ms,
@@ -238,7 +238,7 @@ impl BoxMetrics {
     /// Total time from create() call to box ready (milliseconds).
     ///
     /// Includes all initialization stages: filesystem setup, image pull,
-    /// init rootfs bootstrap, box config, box spawn, and container init.
+    /// guest rootfs bootstrap, box config, box spawn, and container init.
     /// Returns None if box not yet initialized.
     pub fn total_create_duration_ms(&self) -> Option<u128> {
         self.total_create_duration_ms
@@ -313,13 +313,13 @@ impl BoxMetrics {
         self.stage_image_prepare_ms
     }
 
-    /// Time to bootstrap init rootfs (milliseconds).
+    /// Time to bootstrap guest rootfs (milliseconds).
     ///
     /// Stage 3 of initialization pipeline.
     /// Only non-zero on first box creation (lazy initialization).
     /// Returns None if stage not yet completed.
-    pub fn stage_init_rootfs_ms(&self) -> Option<u128> {
-        self.stage_init_rootfs_ms
+    pub fn stage_guest_rootfs_ms(&self) -> Option<u128> {
+        self.stage_guest_rootfs_ms
     }
 
     /// Time to build box configuration (milliseconds).

--- a/boxlite/src/runtime/core.rs
+++ b/boxlite/src/runtime/core.rs
@@ -5,7 +5,7 @@ use std::sync::{Arc, OnceLock, RwLock};
 
 use crate::litebox::{BoxBuilder, LiteBox};
 use crate::runtime::constants::filenames;
-use crate::runtime::initrf::InitRootfs;
+use crate::runtime::guest_rootfs::GuestRootfs;
 use crate::runtime::layout::{FilesystemLayout, FsLayoutConfig};
 use crate::runtime::lock::RuntimeLock;
 use crate::runtime::options::{BoxOptions, BoxliteOptions, RootfsSpec};
@@ -87,7 +87,7 @@ pub struct SynchronizedState {
 /// RuntimeMetricsStorage lives here because it uses AtomicU64 internally - no lock needed!
 pub struct NonSynchronizedState {
     pub(crate) layout: FilesystemLayout,
-    pub(crate) init_rootfs: Arc<OnceCell<InitRootfs>>,
+    pub(crate) guest_rootfs: Arc<OnceCell<GuestRootfs>>,
     /// Runtime-wide metrics (AtomicU64 based, lock-free)
     pub(crate) runtime_metrics: RuntimeMetricsStorage,
     _runtime_lock: RuntimeLock,
@@ -160,7 +160,7 @@ impl BoxliteRuntime {
             }),
             non_sync_state: NonSynchronizedState {
                 layout,
-                init_rootfs: Arc::new(OnceCell::new()),
+                guest_rootfs: Arc::new(OnceCell::new()),
                 runtime_metrics: RuntimeMetricsStorage::new(),
                 _runtime_lock: runtime_lock,
             },

--- a/boxlite/src/runtime/guest_rootfs.rs
+++ b/boxlite/src/runtime/guest_rootfs.rs
@@ -1,17 +1,17 @@
-//! Resolved rootfs types and metadata.
+//! Guest rootfs types and metadata.
 
 use std::path::{Path, PathBuf};
 
 use boxlite_shared::errors::{BoxliteError, BoxliteResult};
 
-/// A fully resolved and ready-to-use rootfs.
+/// A fully resolved and ready-to-use guest rootfs.
 ///
-/// This struct represents the complete result of rootfs preparation:
+/// This struct represents the box's guest rootfs that runs boxlite-guest:
 /// - Image pulled (if needed)
 /// - Layers extracted/overlayed
 /// - Guest binary injected and validated
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
-pub struct InitRootfs {
+pub struct GuestRootfs {
     /// Path to the merged/final rootfs directory
     pub path: PathBuf,
 
@@ -63,8 +63,8 @@ pub enum Strategy {
 
     /// Disk-based rootfs (ext4 disk image)
     ///
-    /// The init rootfs is stored in an ext4 disk image that the VM boots from.
-    /// This provides better performance than virtiofs for the init rootfs.
+    /// The guest rootfs is stored in an ext4 disk image that the box boots from.
+    /// This provides better performance than virtiofs for the guest rootfs.
     Disk {
         /// Path to the ext4 disk image
         disk_path: PathBuf,
@@ -74,8 +74,8 @@ pub enum Strategy {
     },
 }
 
-impl InitRootfs {
-    /// Create a new InitRootfs, injecting the guest binary if needed.
+impl GuestRootfs {
+    /// Create a new GuestRootfs, injecting the guest binary if needed.
     pub fn new(
         path: PathBuf,
         strategy: Strategy,

--- a/boxlite/src/runtime/mod.rs
+++ b/boxlite/src/runtime/mod.rs
@@ -1,5 +1,5 @@
 pub mod constants;
-pub(crate) mod initrf;
+pub(crate) mod guest_rootfs;
 pub(crate) mod layout;
 pub(crate) mod lock;
 pub mod options;

--- a/boxlite/src/vmm/krun/engine.rs
+++ b/boxlite/src/vmm/krun/engine.rs
@@ -378,24 +378,24 @@ impl Vmm for Krun {
                 }
             }
 
-            // Configure root filesystem based on init rootfs strategy
-            if let crate::runtime::initrf::Strategy::Disk {
+            // Configure root filesystem based on guest rootfs strategy
+            if let crate::runtime::guest_rootfs::Strategy::Disk {
                 device_path: Some(device_path),
                 ..
-            } = &config.init_rootfs.strategy
+            } = &config.guest_rootfs.strategy
             {
                 // Disk-based boot: use set_root_disk_remount
-                tracing::info!("Configuring init disk remount: {}", device_path);
+                tracing::info!("Configuring guest rootfs disk remount: {}", device_path);
                 ctx.set_root_disk_remount(device_path, Some("ext4"), None)?;
             } else {
                 // Virtiofs-based boot: use set_rootfs
-                let rootfs_str = config.init_rootfs.path.to_str().ok_or_else(|| {
+                let rootfs_str = config.guest_rootfs.path.to_str().ok_or_else(|| {
                     BoxliteError::Engine(format!(
                         "Invalid rootfs path: {}",
-                        config.init_rootfs.path.display()
+                        config.guest_rootfs.path.display()
                     ))
                 })?;
-                tracing::debug!("Setting VM root filesystem (virtiofs): {}", rootfs_str);
+                tracing::debug!("Setting box root filesystem (virtiofs): {}", rootfs_str);
                 ctx.set_rootfs(rootfs_str)?;
             }
 

--- a/boxlite/src/vmm/mod.rs
+++ b/boxlite/src/vmm/mod.rs
@@ -19,7 +19,7 @@ pub mod factory;
 pub mod krun;
 pub mod registry;
 
-use crate::runtime::initrf::InitRootfs;
+use crate::runtime::guest_rootfs::GuestRootfs;
 pub use engine::{Vmm, VmmConfig, VmmInstance};
 pub use factory::VmmFactory;
 pub use registry::create_engine;
@@ -168,8 +168,8 @@ pub struct InstanceSpec {
     pub transport: boxlite_shared::Transport,
     /// Host-side transport for ready notification (host listens, guest connects when ready)
     pub ready_transport: boxlite_shared::Transport,
-    /// Resolved rootfs path and assembly strategy
-    pub init_rootfs: InitRootfs,
+    /// Resolved guest rootfs path and assembly strategy
+    pub guest_rootfs: GuestRootfs,
     /// Network connection info (serializable, passed to subprocess)
     /// Contains the socket path or connection method to use
     pub network_backend_endpoint: Option<crate::net::NetworkBackendEndpoint>,

--- a/sdks/python/src/metrics.rs
+++ b/sdks/python/src/metrics.rs
@@ -75,7 +75,7 @@ pub(crate) struct PyBoxMetrics {
     #[pyo3(get)]
     pub(crate) stage_image_prepare_ms: Option<u128>,
     #[pyo3(get)]
-    pub(crate) stage_init_rootfs_ms: Option<u128>,
+    pub(crate) stage_guest_rootfs_ms: Option<u128>,
     #[pyo3(get)]
     pub(crate) stage_box_config_ms: Option<u128>,
     #[pyo3(get)]
@@ -116,7 +116,7 @@ impl From<BoxMetrics> for PyBoxMetrics {
             network_tcp_errors: metrics.network_tcp_errors(),
             stage_filesystem_setup_ms: metrics.stage_filesystem_setup_ms(),
             stage_image_prepare_ms: metrics.stage_image_prepare_ms(),
-            stage_init_rootfs_ms: metrics.stage_init_rootfs_ms(),
+            stage_guest_rootfs_ms: metrics.stage_guest_rootfs_ms(),
             stage_box_config_ms: metrics.stage_box_config_ms(),
             stage_box_spawn_ms: metrics.stage_box_spawn_ms(),
             stage_container_init_ms: metrics.stage_container_init_ms(),


### PR DESCRIPTION
## Summary
- Rename `InitRootfs` to `GuestRootfs` for clearer naming - it represents the box's guest rootfs that runs boxlite-guest
- File renames preserve git history: `initrf.rs` → `guest_rootfs.rs`, `init_image.rs` → `guest_rootfs.rs`
- Update all type names, field names, and comments consistently

## Test plan
- [x] Build compiles successfully with `cargo check --package boxlite`
- [x] Git correctly detects file renames (76% and 93% similarity)
- [ ] Verify existing tests pass