### PR TITLE
feat(volumes): add GuestVolumeManager and ContainerVolumeManager

### DIFF
--- a/boxlite/src/volumes/container_volume.rs
+++ b/boxlite/src/volumes/container_volume.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 use super::guest_volume::GuestVolumeManager;
 
 /// Container bind mount entry.
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct ContainerMount {
     /// Source path in guest VM
@@ -19,15 +20,20 @@ pub struct ContainerMount {
 
 /// Manages container-level volume configuration.
 ///
-/// Tracks bind mounts from guest VM paths into container namespace.
-pub struct ContainerVolumeManager {
+/// Holds a reference to GuestVolumeManager and tracks bind mounts
+/// from guest VM paths into container namespace.
+#[allow(dead_code)]
+pub struct ContainerVolumeManager<'a> {
+    guest: &'a mut GuestVolumeManager,
     container_mounts: Vec<ContainerMount>,
 }
 
-impl ContainerVolumeManager {
+#[allow(dead_code)]
+impl<'a> ContainerVolumeManager<'a> {
     /// Create a new container volume manager.
-    pub fn new() -> Self {
+    pub fn new(guest: &'a mut GuestVolumeManager) -> Self {
         Self {
+            guest,
             container_mounts: Vec::new(),
         }
     }
@@ -37,15 +43,15 @@ impl ContainerVolumeManager {
     /// Sets up virtiofs share in guest, records bind mount for container.
     pub fn add_volume(
         &mut self,
-        guest: &mut GuestVolumeManager,
         host_path: PathBuf,
         guest_path: &str,
         container_path: &str,
         read_only: bool,
     ) {
         // Add virtiofs share to guest
-        let tag = guest.next_auto_tag();
-        guest.add_fs_share(&tag, host_path, guest_path, read_only);
+        let tag = self.guest.next_auto_tag();
+        self.guest
+            .add_fs_share(&tag, host_path, guest_path, read_only);
 
         // Record container bind mount
         self.container_mounts.push(ContainerMount {
@@ -69,11 +75,5 @@ impl ContainerVolumeManager {
     /// Build container mount configuration.
     pub fn build_container_mounts(&self) -> Vec<ContainerMount> {
         self.container_mounts.clone()
-    }
-}
-
-impl Default for ContainerVolumeManager {
-    fn default() -> Self {
-        Self::new()
     }
 }

--- a/boxlite/src/volumes/guest_volume.rs
+++ b/boxlite/src/volumes/guest_volume.rs
@@ -9,6 +9,7 @@ use crate::portal::interfaces::VolumeConfig;
 use crate::vmm::{BlockDevice, BlockDevices, FsShares};
 
 /// Tracked virtiofs share entry.
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct FsShareEntry {
     pub tag: String,
@@ -18,6 +19,7 @@ pub struct FsShareEntry {
 }
 
 /// Tracked block device entry.
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct BlockDeviceEntry {
     pub block_id: String,
@@ -28,6 +30,7 @@ pub struct BlockDeviceEntry {
 }
 
 /// VMM layer mount configuration.
+#[allow(dead_code)]
 pub struct VmmMountConfig {
     pub fs_shares: FsShares,
     pub block_devices: BlockDevices,
@@ -37,6 +40,7 @@ pub struct VmmMountConfig {
 ///
 /// Tracks virtiofs shares and block devices, generates VMM config
 /// and guest mount instructions.
+#[allow(dead_code)]
 pub struct GuestVolumeManager {
     fs_shares: Vec<FsShareEntry>,
     block_devices: Vec<BlockDeviceEntry>,
@@ -44,6 +48,7 @@ pub struct GuestVolumeManager {
     next_auto_tag_index: u32,
 }
 
+#[allow(dead_code)]
 impl GuestVolumeManager {
     /// Create a new guest volume manager.
     pub fn new() -> Self {
@@ -84,12 +89,6 @@ impl GuestVolumeManager {
         self.next_block_index += 1;
 
         let device_path = format!("/dev/{}", block_id);
-
-        // Convert disk::DiskFormat to vmm::DiskFormat
-        let vmm_format = match format {
-            DiskFormat::Ext4 => crate::vmm::DiskFormat::Raw,
-            DiskFormat::Qcow2 => crate::vmm::DiskFormat::Qcow2,
-        };
 
         self.block_devices.push(BlockDeviceEntry {
             block_id: block_id.clone(),

--- a/boxlite/src/volumes/mod.rs
+++ b/boxlite/src/volumes/mod.rs
@@ -10,5 +10,8 @@ mod container_volume;
 mod guest_volume;
 
 pub use block_device::BlockDeviceManager;
+
+#[allow(unused_imports)]
 pub use container_volume::{ContainerMount, ContainerVolumeManager};
+#[allow(unused_imports)]
 pub use guest_volume::{BlockDeviceEntry, FsShareEntry, GuestVolumeManager, VmmMountConfig};


### PR DESCRIPTION
## Summary

Adds layered volume management architecture with two new managers:

- **GuestVolumeManager**: manages virtiofs shares and block devices for guest VM
- **ContainerVolumeManager**: manages bind mounts for container namespace

## Design

```
ContainerVolumeManager (container layer)
    │
    └── uses GuestVolumeManager (guest layer)
            │
            └── outputs VMM config (lowest layer)
```

## API

```rust
let mut guest = GuestVolumeManager::new();
let mut container = ContainerVolumeManager::new();

// Guest-only mounts
guest.add_fs_share(tag, host_path, guest_path, read_only);
guest.add_block_device(disk_path, format, guest_mount);

// User volumes (guest + container)
container.add_volume(&mut guest, host_path, guest_path, container_path, read_only);

// Build outputs
let vmm = guest.build_vmm_config();
let guest_mounts = guest.build_guest_mounts();
let container_mounts = container.build_container_mounts();
```

## Design Principles

- **Decoupled**: Generic primitives, no domain-specific methods
- **Layered**: Each manager handles its own layer
- **Single Responsibility**: Clear separation of concerns