### PR TITLE
refactor: rename init stages for clarity

### DIFF
--- a/boxlite/src/litebox/init/pipeline.rs
+++ b/boxlite/src/litebox/init/pipeline.rs
@@ -154,7 +154,7 @@ impl InitPipeline {
             // Stage 2: Rootfs preparation (pulls image)
             async {
                 let start = Instant::now();
-                let result = stages::rootfs::run(RootfsInput {
+                let result = stages::container_rootfs::run(RootfsInput {
                     options: &self.options,
                     runtime: &self.runtime,
                 })
@@ -198,7 +198,7 @@ impl InitPipeline {
 
         // Stage 4: Config construction
         let stage4_start = Instant::now();
-        let config_output = stages::config::run(ConfigInput {
+        let config_output = stages::vmm_config::run(ConfigInput {
             options: &self.options,
             layout: &fs_output.layout,
             rootfs: &rootfs_output,
@@ -238,9 +238,9 @@ impl InitPipeline {
 
         // Stage 6: Guest initialization
         let stage6_start = Instant::now();
-        let guest_output = stages::guest::run(GuestInput {
+        let guest_output = stages::guest_init::run(GuestInput {
             guest_session: spawn_output.guest_session,
-            rootfs_result: rootfs_output.rootfs_result,
+            container_rootfs_result: rootfs_output.rootfs_result,
             container_config: rootfs_output.container_config,
             user_volumes: config_output.user_volumes,
             guest_shared_layout: fs_output.layout.guest_shared_layout(),

--- a/boxlite/src/litebox/init/stages/mod.rs
+++ b/boxlite/src/litebox/init/stages/mod.rs
@@ -16,9 +16,9 @@
 //! Sequential: Config → Spawn → Guest
 //! ```
 
-pub mod config;
+pub mod container_rootfs;
 pub mod filesystem;
-pub mod guest;
+pub mod guest_init;
 pub mod guest_rootfs;
-pub mod rootfs;
 pub mod spawn;
+pub mod vmm_config;

--- a/boxlite/src/litebox/init/types.rs
+++ b/boxlite/src/litebox/init/types.rs
@@ -93,7 +93,7 @@ pub fn resolve_user_volumes(volumes: &[VolumeSpec]) -> BoxliteResult<Vec<Resolve
 
 /// Result of rootfs preparation - either merged, separate layers, or disk image.
 #[derive(Debug)]
-pub enum RootfsPrepResult {
+pub enum ContainerRootfsPrepResult {
     /// Single merged directory (all layers merged on host)
     #[allow(dead_code)]
     Merged(PathBuf),
@@ -166,7 +166,7 @@ pub struct RootfsInput<'a> {
 /// Output from rootfs stage.
 pub struct RootfsOutput {
     pub container_config: ContainerConfig,
-    pub rootfs_result: RootfsPrepResult,
+    pub rootfs_result: ContainerRootfsPrepResult,
     pub image: ImageObject,
 }
 
@@ -220,7 +220,7 @@ pub struct SpawnOutput {
 /// Input for guest initialization stage.
 pub struct GuestInput {
     pub guest_session: GuestSession,
-    pub rootfs_result: RootfsPrepResult,
+    pub container_rootfs_result: ContainerRootfsPrepResult,
     pub container_config: ContainerConfig,
     pub user_volumes: Vec<ResolvedVolume>,
     /// Guest shared layout for constructing guest-side paths.

--- a/boxlite/src/volumes/container_volume.rs
+++ b/boxlite/src/volumes/container_volume.rs
@@ -1,6 +1,7 @@
-//! Container-level volume management.
+//! Container volume management.
 //!
-//! Manages bind mounts for the container layer.
+//! Manages bind mounts from guest VM paths into container namespace.
+//! Works with GuestVolumeManager to set up the underlying virtiofs shares.
 
 use std::path::PathBuf;
 

--- a/boxlite/src/volumes/guest_volume.rs
+++ b/boxlite/src/volumes/guest_volume.rs
@@ -1,6 +1,10 @@
-//! Guest-level volume management.
+//! Guest VM volume management.
 //!
-//! Manages virtiofs shares and block devices for the guest VM layer.
+//! Manages volumes visible to the guest VM:
+//! - Virtiofs shares (host directory → guest mount point)
+//! - Block devices (disk image → /dev/vdX)
+//!
+//! Generates configuration for both VMM layer and guest mount instructions.
 
 use std::path::{Path, PathBuf};
 

--- a/boxlite/src/volumes/mod.rs
+++ b/boxlite/src/volumes/mod.rs
@@ -3,7 +3,7 @@
 //! Provides volume configuration managers:
 //! - `GuestVolumeManager` - Manages virtiofs shares and block devices for guest VM
 //! - `ContainerVolumeManager` - Manages bind mounts for container namespace
-//! - `BlockDeviceManager` - Legacy block device manager (consider using GuestVolumeManager)
+//! - `BlockDeviceManager` - Low-level block device ID allocation (used by vmm_config stage)
 
 mod block_device;
 mod container_volume;


### PR DESCRIPTION
## Summary

- Rename `rootfs.rs` → `container_rootfs.rs` (Stage 2: container rootfs preparation)
- Rename `config.rs` → `vmm_config.rs` (Stage 4: VMM configuration)
- Rename `guest.rs` → `guest_init.rs` (Stage 6: guest initialization)
- Rename `RootfsPrepResult` → `ContainerRootfsPrepResult` for consistency
- Update doc comments to match new file names

## Rationale

The previous names were ambiguous:
- `rootfs.rs` - which rootfs? (we have guest rootfs too)
- `config.rs` - config for what?
- `guest.rs` - guest what?

New names clearly indicate what each stage does.

## Test plan

- [x] `cargo build -p boxlite` passes
- [ ] CI passes