### PR TITLE
refactor(layout): improve mount isolation validation and API

### DIFF
--- a/boxlite/src/litebox/init/stages/filesystem.rs
+++ b/boxlite/src/litebox/init/stages/filesystem.rs
@@ -15,7 +15,7 @@ pub fn run(input: FilesystemInput<'_>) -> BoxliteResult<FilesystemOutput> {
         .runtime
         .non_sync_state
         .layout
-        .box_layout(input.box_id.as_str());
+        .box_layout(input.box_id.as_str(), input.isolate_mounts)?;
 
     layout.prepare()?;
 


### PR DESCRIPTION
## Summary

This PR improves the mount isolation validation and API design by centralizing validation logic in the layout layer.

## Changes

- **Rename** `is_bind_mount()` → `is_bind_mount_supported()` for better clarity
- **Change** `box_layout()` signature to return `BoxliteResult` for proper error handling
- **Add** explicit `isolate_mounts` parameter to `box_layout()` for better control
- **Add** validation in `box_layout()` that warns when mount isolation is requested but not supported
- **Update** `mounts_dir()` logic to check both system capability and user intent
- **Add** documentation for the `isolate_mounts` field

## Benefits

- Better separation of concerns - validation is now in the layout layer where it belongs
- Users get clear warnings when mount isolation is requested but unavailable
- More explicit control over mount isolation behavior
- Improved code clarity and maintainability

## Test Plan

- [x] Code compiles successfully
- [x] Clippy passes with no warnings
- [x] rustfmt applied automatically via pre-commit hook