### PR TITLE
refactor(examples): remove hardcoded paths from example scripts

### DIFF
--- a/examples/python/computerbox_example.py
+++ b/examples/python/computerbox_example.py
@@ -28,8 +28,8 @@ async def test_all_functions():
     """Test all ComputerBox functions."""
     print("=== ComputerBox - Testing All Functions ===\n")
 
-    async with boxlite.ComputerBox(cpu=2, memory=2048, volumes=[("/Users/zhengzhiquan/Downloads/boxlite-computer-config", "/config")]) as desktop:
-    # async with boxlite.ComputerBox(cpu=2, memory=2048) as desktop:
+    async with boxlite.ComputerBox(cpu=2, memory=2048) as desktop:
+        # async with boxlite.ComputerBox(cpu=2, memory=2048) as desktop:
         print("✓ Desktop started\n")
 
         # 1. wait_until_ready()

--- a/examples/python/interactivebox_example.py
+++ b/examples/python/interactivebox_example.py
@@ -36,8 +36,7 @@ async def main():
         # This is all you need for an interactive shell!
         term_mode = os.environ.get("TERM", "xterm-256color")
         print(f"Terminal mode: {term_mode}")
-        # async with InteractiveBox(image="alpine:latest", env=[("TERM", term_mode)], volumes=[("/Users/zhengzhiquan/Workspace/boxlite", "/boxlite")]) as itbox:
-        async with InteractiveBox(image="alpine:latest", env=[("TERM", term_mode), ("BOXLITE_EXECUTOR", "guest")], volumes=[("/Users/zhengzhiquan/Workspace/boxlite", "/boxlite")]) as itbox:
+        async with InteractiveBox(image="alpine:latest", env=[("TERM", term_mode)]) as itbox:
             # You're now in an interactive shell
             # Everything you type goes to the container
             # Everything the container outputs comes back to your terminal


### PR DESCRIPTION
## Summary
- Remove hardcoded personal volume mount paths from `computerbox_example.py` and `interactivebox_example.py`
- Remove custom environment variables that referenced local paths
- Makes examples more portable and easier to run for new users

## Test plan
- [ ] Run `python examples/python/computerbox_example.py` to verify it works without custom paths
- [ ] Run `python examples/python/interactivebox_example.py` to verify it works without custom paths