### PR TITLE
chore: bump version to 0.4.0-dev0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["build/tmp", "target", ".venv", "examples/*/.venv"]
 resolver = "2"
 
 [workspace.package]
-version = "0.3.2"
+version = "0.4.0-dev0"
 edition = "2024"
 authors = ["Dorian Zheng <https://github.com/dorianzheng>"]
 license = "Apache-2.0"

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "boxlite"
-version = "0.3.2"
+version = "0.4.0.dev0"
 description = "Python bindings for Boxlite runtime"
 requires-python = ">=3.10"
 authors = [{ name = "Dorian Zheng" }]


### PR DESCRIPTION
## Summary

Bump version to 0.4.0-dev0 for development.

- Rust workspace: `0.3.2` → `0.4.0-dev0`
- Python SDK: `0.3.2` → `0.4.0.dev0`