### PR TITLE
refactor: move rootfs into BoxOptions and simplify ContainerRuntimeConfig

### DIFF
--- a/boxlite/src/db/boxes.rs
+++ b/boxlite/src/db/boxes.rs
@@ -355,10 +355,9 @@ mod tests {
             created_at: now,
             container: ContainerRuntimeConfig {
                 id: ContainerId::new(),
-                image: RootfsSpec::Image("test:latest".to_string()),
-                image_config: None,
             },
             options: BoxOptions {
+                rootfs: RootfsSpec::Image("test:latest".to_string()),
                 cpus: Some(2),
                 memory_mib: Some(512),
                 ..Default::default()

--- a/boxlite/src/litebox/config.rs
+++ b/boxlite/src/litebox/config.rs
@@ -1,6 +1,4 @@
 use crate::BoxID;
-use crate::images::ContainerImageConfig;
-use crate::runtime::options::RootfsSpec;
 use crate::runtime::types::ContainerId;
 use boxlite_shared::Transport;
 use chrono::{DateTime, Utc};
@@ -9,17 +7,12 @@ use std::path::PathBuf;
 
 /// Container runtime configuration.
 ///
-/// Holds the container's identity, image reference, and extracted image config.
+/// Holds the container's identity.
 /// Owned by BoxConfig since each box runs exactly one container.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ContainerRuntimeConfig {
     /// Container ID (64-char hex, generated at box creation).
     pub id: ContainerId,
-    /// Image reference or rootfs path.
-    pub image: RootfsSpec,
-    /// Container image config extracted from OCI image.
-    /// None until image is pulled during initialization.
-    pub image_config: Option<ContainerImageConfig>,
 }
 
 /// Static box configuration (set once at creation, never changes).
@@ -37,7 +30,7 @@ pub struct BoxConfig {
     pub created_at: DateTime<Utc>,
 
     // === Container Configuration ===
-    /// Container configuration (id, image, image_config).
+    /// Container configuration (id).
     pub container: ContainerRuntimeConfig,
 
     // === User Options (preserved for restart) ===

--- a/boxlite/src/litebox/init/tasks/container_rootfs.rs
+++ b/boxlite/src/litebox/init/tasks/container_rootfs.rs
@@ -32,7 +32,7 @@ impl PipelineTask<InitCtx> for ContainerRootfsTask {
                 .clone()
                 .ok_or_else(|| BoxliteError::Internal("filesystem task must run first".into()))?;
             (
-                ctx.config.container.image.clone(),
+                ctx.config.options.rootfs.clone(),
                 ctx.config.options.env.clone(),
                 ctx.runtime.clone(),
                 layout,

--- a/boxlite/src/litebox/manager.rs
+++ b/boxlite/src/litebox/manager.rs
@@ -217,10 +217,9 @@ mod tests {
             created_at: Utc::now(),
             container: ContainerRuntimeConfig {
                 id: ContainerId::new(),
-                image: RootfsSpec::Image("test:latest".to_string()),
-                image_config: None,
             },
             options: BoxOptions {
+                rootfs: RootfsSpec::Image("test:latest".to_string()),
                 cpus: Some(2),
                 memory_mib: Some(512),
                 ..Default::default()

--- a/boxlite/src/runtime/core.rs
+++ b/boxlite/src/runtime/core.rs
@@ -168,13 +168,8 @@ impl BoxliteRuntime {
     ///
     /// Returns immediately with a LiteBox handle. Heavy initialization (image pulling,
     /// Box startup) is deferred until the first API call on the handle.
-    pub fn create(
-        &self,
-        image: &str,
-        options: BoxOptions,
-        name: Option<String>,
-    ) -> BoxliteResult<LiteBox> {
-        self.rt_impl.create(image, options, name)
+    pub fn create(&self, options: BoxOptions, name: Option<String>) -> BoxliteResult<LiteBox> {
+        self.rt_impl.create(options, name)
     }
 
     /// Get a handle to an existing box by ID or name.

--- a/boxlite/src/runtime/options.rs
+++ b/boxlite/src/runtime/options.rs
@@ -28,15 +28,13 @@ impl Default for BoxliteOptions {
 }
 
 /// Options used when constructing a box.
-///
-/// These are user-provided options at creation time.
-/// The image/rootfs is specified separately via `ContainerRuntimeConfig`.
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct BoxOptions {
     pub cpus: Option<u8>,
     pub memory_mib: Option<u32>,
     pub working_dir: Option<String>,
     pub env: Vec<(String, String)>,
+    pub rootfs: RootfsSpec,
     pub volumes: Vec<VolumeSpec>,
     pub network: NetworkSpec,
     pub ports: Vec<PortSpec>,
@@ -73,6 +71,7 @@ impl Default for BoxOptions {
             memory_mib: None,
             working_dir: None,
             env: Vec::new(),
+            rootfs: RootfsSpec::default(),
             volumes: Vec::new(),
             network: NetworkSpec::default(),
             ports: Vec::new(),

--- a/boxlite/src/runtime/types.rs
+++ b/boxlite/src/runtime/types.rs
@@ -172,7 +172,7 @@ impl BoxInfo {
             last_updated: state.last_updated,
             pid: state.pid,
             transport: config.transport.clone(),
-            image: match &config.container.image {
+            image: match &config.options.rootfs {
                 RootfsSpec::Image(r) => r.clone(),
                 RootfsSpec::RootfsPath(p) => format!("rootfs:{}", p),
             },
@@ -237,10 +237,9 @@ mod tests {
             created_at: now,
             container: ContainerRuntimeConfig {
                 id: ContainerId::new(),
-                image: RootfsSpec::Image("python:3.11".to_string()),
-                image_config: None,
             },
             options: BoxOptions {
+                rootfs: RootfsSpec::Image("python:3.11".to_string()),
                 cpus: Some(4),
                 memory_mib: Some(1024),
                 ..Default::default()

--- a/boxlite/tests/lifecycle.rs
+++ b/boxlite/tests/lifecycle.rs
@@ -1,7 +1,7 @@
 //! Integration tests for box lifecycle (create, list, get, remove, stop).
 
 use boxlite::BoxliteRuntime;
-use boxlite::runtime::options::{BoxOptions, BoxliteOptions};
+use boxlite::runtime::options::{BoxOptions, BoxliteOptions, RootfsSpec};
 use boxlite::runtime::types::BoxStatus;
 use boxlite_shared::Transport;
 use tempfile::TempDir;
@@ -49,11 +49,23 @@ async fn create_generates_unique_ulid_ids() {
     let ctx = TestContext::new();
     let box1 = ctx
         .runtime
-        .create("alpine:latest", BoxOptions::default(), None)
+        .create(
+            BoxOptions {
+                rootfs: RootfsSpec::Image("alpine:latest".into()),
+                ..Default::default()
+            },
+            None,
+        )
         .unwrap();
     let box2 = ctx
         .runtime
-        .create("alpine:latest", BoxOptions::default(), None)
+        .create(
+            BoxOptions {
+                rootfs: RootfsSpec::Image("alpine:latest".into()),
+                ..Default::default()
+            },
+            None,
+        )
         .unwrap();
 
     // IDs should be unique
@@ -73,13 +85,14 @@ async fn create_generates_unique_ulid_ids() {
 #[tokio::test]
 async fn create_stores_custom_options() {
     let options = BoxOptions {
+        rootfs: RootfsSpec::Image("alpine:latest".into()),
         cpus: Some(4),
         memory_mib: Some(1024),
         ..Default::default()
     };
 
     let ctx = TestContext::new();
-    let handle = ctx.runtime.create("alpine:latest", options, None).unwrap();
+    let handle = ctx.runtime.create(options, None).unwrap();
     let box_id = handle.id().clone();
 
     let info = ctx.runtime.get_info(&box_id).unwrap().unwrap();
@@ -116,11 +129,23 @@ async fn list_info_returns_all_boxes() {
     // Create two boxes
     let box1 = ctx
         .runtime
-        .create("alpine:latest", BoxOptions::default(), None)
+        .create(
+            BoxOptions {
+                rootfs: RootfsSpec::Image("alpine:latest".into()),
+                ..Default::default()
+            },
+            None,
+        )
         .unwrap();
     let box2 = ctx
         .runtime
-        .create("alpine:latest", BoxOptions::default(), None)
+        .create(
+            BoxOptions {
+                rootfs: RootfsSpec::Image("alpine:latest".into()),
+                ..Default::default()
+            },
+            None,
+        )
         .unwrap();
 
     // List should show both boxes
@@ -145,17 +170,35 @@ async fn list_info_sorted_by_creation_time_newest_first() {
     // Create boxes with small delay to ensure different timestamps
     let box1 = ctx
         .runtime
-        .create("alpine:latest", BoxOptions::default(), None)
+        .create(
+            BoxOptions {
+                rootfs: RootfsSpec::Image("alpine:latest".into()),
+                ..Default::default()
+            },
+            None,
+        )
         .unwrap();
     tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
     let box2 = ctx
         .runtime
-        .create("alpine:latest", BoxOptions::default(), None)
+        .create(
+            BoxOptions {
+                rootfs: RootfsSpec::Image("alpine:latest".into()),
+                ..Default::default()
+            },
+            None,
+        )
         .unwrap();
     tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
     let box3 = ctx
         .runtime
-        .create("alpine:latest", BoxOptions::default(), None)
+        .create(
+            BoxOptions {
+                rootfs: RootfsSpec::Image("alpine:latest".into()),
+                ..Default::default()
+            },
+            None,
+        )
         .unwrap();
 
     // List should be sorted newest first
@@ -186,7 +229,13 @@ async fn get_info_returns_box_metadata() {
     let ctx = TestContext::new();
     let handle = ctx
         .runtime
-        .create("alpine:latest", BoxOptions::default(), None)
+        .create(
+            BoxOptions {
+                rootfs: RootfsSpec::Image("alpine:latest".into()),
+                ..Default::default()
+            },
+            None,
+        )
         .unwrap();
     let box_id = handle.id().clone();
 
@@ -215,7 +264,13 @@ async fn exists_returns_true_for_existing_box() {
     let ctx = TestContext::new();
     let handle = ctx
         .runtime
-        .create("alpine:latest", BoxOptions::default(), None)
+        .create(
+            BoxOptions {
+                rootfs: RootfsSpec::Image("alpine:latest".into()),
+                ..Default::default()
+            },
+            None,
+        )
         .unwrap();
     let box_id = handle.id().clone();
 
@@ -254,7 +309,13 @@ async fn remove_stopped_box_succeeds() {
     let ctx = TestContext::new();
     let handle = ctx
         .runtime
-        .create("alpine:latest", BoxOptions::default(), None)
+        .create(
+            BoxOptions {
+                rootfs: RootfsSpec::Image("alpine:latest".into()),
+                ..Default::default()
+            },
+            None,
+        )
         .unwrap();
     let box_id = handle.id().clone();
 
@@ -273,7 +334,13 @@ async fn remove_active_without_force_fails() {
     let ctx = TestContext::new();
     let handle = ctx
         .runtime
-        .create("alpine:latest", BoxOptions::default(), None)
+        .create(
+            BoxOptions {
+                rootfs: RootfsSpec::Image("alpine:latest".into()),
+                ..Default::default()
+            },
+            None,
+        )
         .unwrap();
     let box_id = handle.id().clone();
 
@@ -303,7 +370,13 @@ async fn remove_active_with_force_stops_and_removes() {
     let ctx = TestContext::new();
     let handle = ctx
         .runtime
-        .create("alpine:latest", BoxOptions::default(), None)
+        .create(
+            BoxOptions {
+                rootfs: RootfsSpec::Image("alpine:latest".into()),
+                ..Default::default()
+            },
+            None,
+        )
         .unwrap();
     let box_id = handle.id().clone();
 
@@ -323,7 +396,13 @@ async fn remove_deletes_box_from_database() {
     let ctx = TestContext::new();
     let handle = ctx
         .runtime
-        .create("alpine:latest", BoxOptions::default(), None)
+        .create(
+            BoxOptions {
+                rootfs: RootfsSpec::Image("alpine:latest".into()),
+                ..Default::default()
+            },
+            None,
+        )
         .unwrap();
     let box_id = handle.id().clone();
 
@@ -346,7 +425,13 @@ async fn stop_marks_box_as_stopped() {
     let ctx = TestContext::new();
     let handle = ctx
         .runtime
-        .create("alpine:latest", BoxOptions::default(), None)
+        .create(
+            BoxOptions {
+                rootfs: RootfsSpec::Image("alpine:latest".into()),
+                ..Default::default()
+            },
+            None,
+        )
         .unwrap();
     let box_id = handle.id().clone();
 
@@ -370,7 +455,13 @@ async fn litebox_info_returns_correct_metadata() {
     let ctx = TestContext::new();
     let handle = ctx
         .runtime
-        .create("alpine:latest", BoxOptions::default(), None)
+        .create(
+            BoxOptions {
+                rootfs: RootfsSpec::Image("alpine:latest".into()),
+                ..Default::default()
+            },
+            None,
+        )
         .unwrap();
     let box_id = handle.id().clone();
 
@@ -400,11 +491,23 @@ async fn multiple_runtimes_are_isolated() {
 
     let box1 = ctx1
         .runtime
-        .create("alpine:latest", BoxOptions::default(), None)
+        .create(
+            BoxOptions {
+                rootfs: RootfsSpec::Image("alpine:latest".into()),
+                ..Default::default()
+            },
+            None,
+        )
         .unwrap();
     let box2 = ctx2
         .runtime
-        .create("alpine:latest", BoxOptions::default(), None)
+        .create(
+            BoxOptions {
+                rootfs: RootfsSpec::Image("alpine:latest".into()),
+                ..Default::default()
+            },
+            None,
+        )
         .unwrap();
 
     // Each runtime should only see its own box
@@ -437,7 +540,13 @@ async fn boxes_persist_across_runtime_restart() {
         };
         let runtime = BoxliteRuntime::new(options).expect("Failed to create runtime");
         let litebox = runtime
-            .create("alpine:latest", BoxOptions::default(), None)
+            .create(
+                BoxOptions {
+                    rootfs: RootfsSpec::Image("alpine:latest".into()),
+                    ..Default::default()
+                },
+                None,
+            )
             .unwrap();
         box_id = litebox.id().clone();
 

--- a/examples/c/execute.c
+++ b/examples/c/execute.c
@@ -30,7 +30,7 @@ int main() {
     }
 
     // Create a box with Alpine Linux
-    const char* options_json = "{\"image\":{\"Reference\":\"alpine:3.19\"}}";
+    const char* options_json = "{\"rootfs\":{\"Image\":\"alpine:3.19\"}}";
     CBoxHandle* box = boxlite_create_box(runtime, options_json, &error);
     if (!box) {
         fprintf(stderr, "Failed to create box: %s\n", error);

--- a/sdks/c/include/boxlite.h
+++ b/sdks/c/include/boxlite.h
@@ -60,7 +60,7 @@ struct CBoxliteRuntime *boxlite_runtime_new(const char *home_dir, char **out_err
  * # Arguments
  * * `runtime` - BoxLite runtime instance
  * * `options_json` - JSON-encoded BoxOptions, e.g.:
- *                    `{"images": {"Reference": "alpine:3.19"}, "working_dir": "/workspace"}`
+ *                    `{"rootfs": {"Image": "alpine:3.19"}, "working_dir": "/workspace"}`
  * * `out_error` - Output parameter for error message
  *
  * # Returns
@@ -68,12 +68,11 @@ struct CBoxliteRuntime *boxlite_runtime_new(const char *home_dir, char **out_err
  *
  * # Example
  * ```c
- * const char *opts = "{\"images\":{\"Reference\":\"alpine:3.19\"}}";
- * BoxHandle *box = boxlite_create_box(runtime, image, opts, &error);
+ * const char *opts = "{\"rootfs\":{\"Image\":\"alpine:3.19\"}}";
+ * BoxHandle *box = boxlite_create_box(runtime, opts, &error);
  * ```
  */
 struct CBoxHandle *boxlite_create_box(struct CBoxliteRuntime *runtime,
-                                      const char *image,
                                       const char *options_json,
                                       char **out_error);
 

--- a/sdks/c/src/ffi.rs
+++ b/sdks/c/src/ffi.rs
@@ -148,7 +148,7 @@ pub unsafe extern "C" fn boxlite_runtime_new(
 /// # Arguments
 /// * `runtime` - BoxLite runtime instance
 /// * `options_json` - JSON-encoded BoxOptions, e.g.:
-///                    `{"images": {"Reference": "alpine:3.19"}, "working_dir": "/workspace"}`
+///                    `{"rootfs": {"Image": "alpine:3.19"}, "working_dir": "/workspace"}`
 /// * `out_error` - Output parameter for error message
 ///
 /// # Returns
@@ -156,13 +156,12 @@ pub unsafe extern "C" fn boxlite_runtime_new(
 ///
 /// # Example
 /// ```c
-/// const char *opts = "{\"images\":{\"Reference\":\"alpine:3.19\"}}";
-/// BoxHandle *box = boxlite_create_box(runtime, image, opts, &error);
+/// const char *opts = "{\"rootfs\":{\"Image\":\"alpine:3.19\"}}";
+/// BoxHandle *box = boxlite_create_box(runtime, opts, &error);
 /// ```
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn boxlite_create_box(
     runtime: *mut CBoxliteRuntime,
-    image: *const c_char,
     options_json: *const c_char,
     out_error: *mut *mut c_char,
 ) -> *mut CBoxHandle {
@@ -174,17 +173,6 @@ pub unsafe extern "C" fn boxlite_create_box(
     }
 
     let runtime_ref = &mut *runtime;
-
-    // Parse image string
-    let image_str = match c_str_to_string(image) {
-        Ok(s) => s,
-        Err(e) => {
-            if !out_error.is_null() {
-                *out_error = error_to_c_string(e);
-            }
-            return ptr::null_mut();
-        }
-    };
 
     // Parse JSON options
     let options_str = match c_str_to_string(options_json) {
@@ -211,7 +199,7 @@ pub unsafe extern "C" fn boxlite_create_box(
     };
 
     // Create box (no name support in C API yet)
-    let result = runtime_ref.runtime.create(&image_str, options, None);
+    let result = runtime_ref.runtime.create(options, None);
 
     match result {
         Ok(handle) => {

--- a/sdks/python/src/runtime.rs
+++ b/sdks/python/src/runtime.rs
@@ -40,11 +40,7 @@ impl PyBoxlite {
 
     #[pyo3(signature = (options, name=None))]
     fn create(&self, options: PyBoxOptions, name: Option<String>) -> PyResult<PyBox> {
-        let image = options.image_ref();
-        let handle = self
-            .runtime
-            .create(&image, options.into(), name)
-            .map_err(map_err)?;
+        let handle = self.runtime.create(options.into(), name).map_err(map_err)?;
 
         Ok(PyBox {
             handle: Arc::new(handle),


### PR DESCRIPTION
## Summary

- Add `rootfs: RootfsSpec` field back to `BoxOptions`
- Remove `image` parameter from `BoxliteRuntime::create()` signature
- Remove unused `image` and `image_config` fields from `ContainerRuntimeConfig`
- Update Python and C SDKs to match new API

## Rationale

The `image` was previously extracted as a separate parameter to `create()`, but it's more natural to have it as part of `BoxOptions`. The `image_config` field in `ContainerRuntimeConfig` was never actually used - it was always `None` and the actual image config is computed lazily during initialization and stored in `InitPipelineContext`.

## Test plan

- [x] `cargo clippy` passes
- [x] `cargo check` passes