### PR TITLE
feat: propagate working_dir from BoxOptions to command execution

### DIFF
--- a/boxlite/src/litebox/box_impl.rs
+++ b/boxlite/src/litebox/box_impl.rs
@@ -164,6 +164,14 @@ impl BoxImpl {
             )
         };
 
+        // Set working directory from BoxOptions if not set in command
+        let command = if command.working_dir.is_none() && self.config.options.working_dir.is_some()
+        {
+            command.working_dir(self.config.options.working_dir.as_ref().unwrap())
+        } else {
+            command
+        };
+
         let mut exec_interface = live.guest_session.execution().await?;
         let result = exec_interface.exec(command).await;
 


### PR DESCRIPTION
## Summary
- Propagate `working_dir` from `BoxOptions` to command execution when not explicitly set on the command
- Allows users to set working directory once at box creation and have it apply to all subsequent commands

## Test plan
- [ ] Verify commands use BoxOptions.working_dir when command.working_dir is not set
- [ ] Verify explicit command.working_dir takes precedence over BoxOptions.working_dir