### PR TITLE
chore: bump version to 0.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,7 +264,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite"
-version = "0.4.0-dev0"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -319,7 +319,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-c"
-version = "0.4.0-dev0"
+version = "0.4.2"
 dependencies = [
  "boxlite",
  "boxlite-shared",
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-guest"
-version = "0.4.0-dev0"
+version = "0.4.2"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -358,7 +358,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-python"
-version = "0.4.0-dev0"
+version = "0.4.2"
 dependencies = [
  "boxlite",
  "futures",
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-shared"
-version = "0.4.0-dev0"
+version = "0.4.2"
 dependencies = [
  "prost",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["build/tmp", "target", ".venv", "examples/*/.venv"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.0-dev0"
+version = "0.4.2"
 edition = "2024"
 authors = ["Dorian Zheng <https://github.com/dorianzheng>"]
 license = "Apache-2.0"

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "boxlite"
-version = "0.4.0.dev0"
+version = "0.4.2"
 description = "Python bindings for Boxlite runtime"
 requires-python = ">=3.10"
 authors = [{ name = "Dorian Zheng" }]


### PR DESCRIPTION
## Summary
- Bump Rust workspace version to 0.4.2
- Bump Python SDK version to 0.4.2

## Test plan
- [ ] Verify version in Cargo.toml
- [ ] Verify version in pyproject.toml