### PR TITLE
feat: add configurable disk size option

### DIFF
--- a/boxlite/src/runtime/constants.rs
+++ b/boxlite/src/runtime/constants.rs
@@ -45,6 +45,9 @@ pub mod vm_defaults {
 
     /// Default memory in MiB allocated to a Box
     pub const DEFAULT_MEMORY_MIB: u32 = 2048;
+
+    /// Default disk size in GB for the container rootfs (sparse, grows as needed)
+    pub const DEFAULT_DISK_SIZE_GB: u64 = 10;
 }
 
 /// File naming patterns

--- a/boxlite/src/runtime/options.rs
+++ b/boxlite/src/runtime/options.rs
@@ -32,6 +32,12 @@ impl Default for BoxliteOptions {
 pub struct BoxOptions {
     pub cpus: Option<u8>,
     pub memory_mib: Option<u32>,
+    /// Disk size in GB for the container rootfs (sparse, grows as needed).
+    ///
+    /// The actual disk will be at least as large as the base image.
+    /// If set, the COW overlay will have this virtual size, allowing
+    /// the container to write more data than the base image size.
+    pub disk_size_gb: Option<u64>,
     pub working_dir: Option<String>,
     pub env: Vec<(String, String)>,
     pub rootfs: RootfsSpec,
@@ -69,6 +75,7 @@ impl Default for BoxOptions {
         Self {
             cpus: None,
             memory_mib: None,
+            disk_size_gb: None,
             working_dir: None,
             env: Vec::new(),
             rootfs: RootfsSpec::default(),

--- a/sdks/python/src/options.rs
+++ b/sdks/python/src/options.rs
@@ -52,6 +52,8 @@ pub(crate) struct PyBoxOptions {
     #[pyo3(get, set)]
     pub(crate) memory_mib: Option<u32>,
     #[pyo3(get, set)]
+    pub(crate) disk_size_gb: Option<u64>,
+    #[pyo3(get, set)]
     pub(crate) working_dir: Option<String>,
     #[pyo3(get, set)]
     pub(crate) env: Vec<(String, String)>,
@@ -71,6 +73,7 @@ impl PyBoxOptions {
         rootfs_path=None,
         cpus=None,
         memory_mib=None,
+        disk_size_gb=None,
         working_dir=None,
         env=vec![],
         volumes=vec![],
@@ -84,6 +87,7 @@ impl PyBoxOptions {
         rootfs_path: Option<String>,
         cpus: Option<u8>,
         memory_mib: Option<u32>,
+        disk_size_gb: Option<u64>,
         working_dir: Option<String>,
         env: Vec<(String, String)>,
         volumes: Vec<PyVolumeSpec>,
@@ -96,6 +100,7 @@ impl PyBoxOptions {
             rootfs_path,
             cpus,
             memory_mib,
+            disk_size_gb,
             working_dir,
             env,
             volumes,
@@ -141,6 +146,7 @@ impl From<PyBoxOptions> for BoxOptions {
         let mut opts = BoxOptions {
             cpus: py_opts.cpus,
             memory_mib: py_opts.memory_mib,
+            disk_size_gb: py_opts.disk_size_gb,
             working_dir: py_opts.working_dir,
             env: py_opts.env,
             rootfs,


### PR DESCRIPTION
## Summary

- Add `disk_size_gb` option to `BoxOptions` for configuring the container rootfs disk size
- The COW overlay disk uses the maximum of user-specified size and base image size
- Expose the option in Python SDK via `PyBoxOptions`

## Changes

- `boxlite/src/runtime/options.rs`: Add `disk_size_gb: Option<u64>` field
- `boxlite/src/runtime/constants.rs`: Add `DEFAULT_DISK_SIZE_GB` constant
- `boxlite/src/litebox/init/tasks/container_rootfs.rs`: Use configurable disk size when creating COW disk
- `sdks/python/src/options.rs`: Expose `disk_size_gb` in Python SDK

## Test plan

- [ ] Verify box creation with default disk size works as before
- [ ] Verify box creation with custom `disk_size_gb` creates larger virtual disk
- [ ] Verify Python SDK accepts `disk_size_gb` parameter