### PR TITLE
feat: improve disk resize with proper flag propagation and validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,7 +264,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -319,7 +319,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-c"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "boxlite",
  "boxlite-shared",
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-guest"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -358,7 +358,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-python"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "boxlite",
  "futures",
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-shared"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "prost",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["build/tmp", "target", ".venv", "examples/*/.venv"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.2"
+version = "0.4.3"
 edition = "2024"
 authors = ["Dorian Zheng <https://github.com/dorianzheng>"]
 license = "Apache-2.0"

--- a/boxlite-shared/proto/boxlite/v1/service.proto
+++ b/boxlite-shared/proto/boxlite/v1/service.proto
@@ -92,9 +92,17 @@ message VirtiofsSource {
 }
 
 // Block device volume source
+//
+// Controls how block devices are mounted in the guest:
+// - filesystem: Target filesystem type (only EXT4 supported for resize)
+// - need_format: If true, format device before mounting (use for fresh disks)
+// - need_resize: If true, resize filesystem after mounting to fill available space
+//                (use when QCOW2 virtual size > filesystem size)
 message BlockDeviceSource {
   string device = 1;           // device path (e.g., "/dev/vda")
-  Filesystem filesystem = 2;   // filesystem type
+  Filesystem filesystem = 2;   // target filesystem type (e.g., EXT4)
+  bool need_format = 3;        // if true, format device with filesystem before mount
+  bool need_resize = 4;        // if true, run resize2fs after mount to fill disk
 }
 
 // Supported filesystem types
@@ -123,8 +131,16 @@ message OverlayRootfs {
 }
 
 // Disk-based rootfs - block device mounted directly as container rootfs
+//
+// COW (copy-on-write) workflow:
+// - Base disk: Pre-built ext4 image with merged container layers
+// - COW disk: QCOW2 overlay that inherits from base, may have larger virtual size
+// - need_format: Usually false (COW inherits formatted base)
+// - need_resize: True if COW virtual size > base size (expands ext4 to fill disk)
 message DiskRootfs {
-  string device = 1;  // block device path (e.g., "/dev/vda")
+  string device = 1;           // block device path (e.g., "/dev/vda")
+  bool need_format = 2;        // if true, format device before mounting
+  bool need_resize = 3;        // if true, resize filesystem after mounting to fill disk
 }
 
 // Network initialization

--- a/boxlite/src/portal/interfaces/container.rs
+++ b/boxlite/src/portal/interfaces/container.rs
@@ -28,6 +28,10 @@ pub enum ContainerRootfsInitConfig {
     DiskImage {
         /// Block device path (e.g., "/dev/vda")
         device: String,
+        /// Whether to format the device before mounting
+        need_format: bool,
+        /// Whether to resize filesystem after mounting to fill disk
+        need_resize: bool,
     },
 }
 
@@ -50,9 +54,15 @@ impl ContainerRootfsInitConfig {
                     },
                 )),
             },
-            ContainerRootfsInitConfig::DiskImage { device } => RootfsInit {
+            ContainerRootfsInitConfig::DiskImage {
+                device,
+                need_format,
+                need_resize,
+            } => RootfsInit {
                 strategy: Some(boxlite_shared::rootfs_init::Strategy::Disk(DiskRootfs {
                     device,
+                    need_format,
+                    need_resize,
                 })),
             },
         }

--- a/boxlite/src/portal/interfaces/guest.rs
+++ b/boxlite/src/portal/interfaces/guest.rs
@@ -102,8 +102,12 @@ pub enum VolumeConfig {
         device: String,
         /// Mount point in guest
         mount_point: String,
-        /// Filesystem type (UNSPECIFIED = don't format, use existing)
+        /// Filesystem type
         filesystem: Filesystem,
+        /// If true, format device before mounting
+        need_format: bool,
+        /// If true, resize filesystem after mounting to fill disk
+        need_resize: bool,
     },
 }
 
@@ -128,11 +132,15 @@ impl VolumeConfig {
         device: impl Into<String>,
         mount_point: impl Into<String>,
         filesystem: Filesystem,
+        need_format: bool,
+        need_resize: bool,
     ) -> Self {
         Self::BlockDevice {
             device: device.into(),
             mount_point: mount_point.into(),
             filesystem,
+            need_format,
+            need_resize,
         }
     }
 
@@ -155,12 +163,16 @@ impl VolumeConfig {
                 device,
                 mount_point,
                 filesystem,
+                need_format,
+                need_resize,
             } => Volume {
                 mount_point,
                 source: Some(boxlite_shared::volume::Source::BlockDevice(
                     BlockDeviceSource {
                         device,
                         filesystem: filesystem.into(),
+                        need_format,
+                        need_resize,
                     },
                 )),
                 container_id: String::new(),

--- a/guest/src/service/container.rs
+++ b/guest/src/service/container.rs
@@ -69,11 +69,13 @@ fn prepare_rootfs(
             std::fs::create_dir_all(shared_rootfs)
                 .map_err(|e| format!("Failed to create shared rootfs directory: {}", e))?;
 
-            // Use Unspecified to skip formatting - the COW disk already contains the rootfs
+            // Mount container rootfs disk with options from host
             BlockDeviceMount::mount(
                 Path::new(&disk.device),
                 shared_rootfs,
-                Filesystem::Unspecified,
+                Filesystem::Ext4,
+                disk.need_format,
+                disk.need_resize,
             )
             .map_err(|e| format!("Failed to mount rootfs disk: {}", e))?;
 

--- a/guest/src/storage/volume.rs
+++ b/guest/src/storage/volume.rs
@@ -70,7 +70,13 @@ pub fn mount_volume(vol: &Volume) -> BoxliteResult<()> {
         Some(volume::Source::BlockDevice(block)) => {
             let mount_point = Path::new(&vol.mount_point);
             let filesystem = Filesystem::try_from(block.filesystem).unwrap_or(Filesystem::Ext4);
-            BlockDeviceMount::mount(Path::new(&block.device), mount_point, filesystem)
+            BlockDeviceMount::mount(
+                Path::new(&block.device),
+                mount_point,
+                filesystem,
+                block.need_format,
+                block.need_resize,
+            )
         }
         None => {
             tracing::warn!("Volume {} has no source, skipping", vol.mount_point);

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "boxlite"
-version = "0.4.2"
+version = "0.4.3"
 description = "Python bindings for Boxlite runtime"
 requires-python = ">=3.10"
 authors = [{ name = "Dorian Zheng" }]


### PR DESCRIPTION
## Summary

Refines the disk resize feature with cleaner design and proper state management:

- Add `need_format` and `need_resize` flags to `DiskRootfs` proto message
- Propagate resize flags from host through entire stack to guest mount operations
- Add filesystem type validation before resize (ext4 only)
- Remove brittle error handling (string matching on stderr)
- Add comprehensive documentation for COW disk workflow
- Bump version to 0.4.3

## Problem

The original implementation had several issues:
1. **Hardcoded behavior**: Guest always ran `resize2fs` regardless of config
2. **No validation**: Would attempt resize on non-ext4 filesystems
3. **Fragile errors**: String-matched stderr for "Nothing to do"
4. **Missing abstraction**: Flags weren't propagated through proto layer

## Solution

### 1. Proper Flag Propagation
```rust
// Host sets flags based on disk_size_gb option
let need_resize = options.disk_size_gb.is_some();

// Flags flow: Host → Proto → Guest
ContainerRootfsInitConfig::DiskImage {
    device,
    need_format: false,  // COW inherits formatted base
    need_resize,         // Only if disk was resized
}
```

### 2. Filesystem Validation
```rust
fn resize_filesystem(device: &Path, filesystem: Filesystem) -> BoxliteResult<()> {
    if filesystem != Filesystem::Ext4 {
        return Err(BoxliteError::Storage(format!(
            "Filesystem resize only supported for ext4, got {:?}",
            filesystem
        )));
    }
    // ... resize logic
}
```

### 3. Clean Error Handling
Removed brittle string matching - `resize2fs` is truly idempotent and returns success when nothing needs doing.

### 4. Documentation
Added clear comments explaining the COW disk workflow at each layer (proto, host, guest).

## Test Plan

- [ ] Build succeeds (`cargo check` passes)
- [ ] Existing containers work without resize
- [ ] Containers with `disk_size_gb` specified resize correctly
- [ ] Error on non-ext4 filesystem resize attempt

## Files Changed

- **Proto**: `boxlite-shared/proto/boxlite/v1/service.proto`
- **Host**: `boxlite/src/portal/interfaces/{container,guest}.rs`, `boxlite/src/litebox/init/tasks/vmm_spawn.rs`, `boxlite/src/volumes/guest_volume.rs`
- **Guest**: `guest/src/service/container.rs`, `guest/src/storage/{block_device,volume}.rs`
- **Version**: `Cargo.toml`, `sdks/python/pyproject.toml`