### PR TITLE
fix: resolve lock allocation errors during box recovery on startup

### DIFF
--- a/boxlite/src/lock/memory.rs
+++ b/boxlite/src/lock/memory.rs
@@ -142,6 +142,13 @@ impl LockManager for InMemoryLockManager {
             .count() as u32;
         Ok(count)
     }
+
+    fn clear_all_locks(&self) -> BoxliteResult<()> {
+        for lock in &self.locks {
+            lock.allocated.store(false, Ordering::SeqCst);
+        }
+        Ok(())
+    }
 }
 
 /// Handle to an in-memory lock.

--- a/boxlite/src/lock/mod.rs
+++ b/boxlite/src/lock/mod.rs
@@ -94,6 +94,17 @@ pub trait LockManager: Send + Sync {
     /// Returns an error if the lock is already allocated or the ID is invalid.
     fn allocate_and_retrieve(&self, id: LockId) -> BoxliteResult<Arc<dyn Locker>>;
 
+    /// Clear all allocated locks.
+    ///
+    /// This removes all lock files and clears the internal allocation state.
+    /// Used during recovery to start with a clean slate before reclaiming locks.
+    ///
+    /// # Safety
+    ///
+    /// This method is only safe to call when holding the runtime lock, which
+    /// ensures no other process can be using these locks.
+    fn clear_all_locks(&self) -> BoxliteResult<()>;
+
     /// Free a lock, allowing it to be reallocated.
     ///
     /// After calling this, the lock ID may be returned by a future call

--- a/boxlite/src/runtime/rt_impl.rs
+++ b/boxlite/src/runtime/rt_impl.rs
@@ -611,6 +611,10 @@ impl RuntimeImpl {
         // Check for system reboot and reset active boxes
         self.box_manager.check_and_handle_reboot()?;
 
+        // Clear all locks before recovery - safe because we hold the runtime lock.
+        // This ensures a clean slate for lock allocation during recovery.
+        self.lock_manager.clear_all_locks()?;
+
         let persisted = self.box_manager.all_boxes(true)?;
 
         tracing::info!("Recovering {} boxes from database", persisted.len());


### PR DESCRIPTION
## Summary

Fixes lock allocation errors that occurred when recovering boxes from the database on startup.

## Problem

On startup, boxlite was attempting to recover 38 boxes from the database but all lock reclamations were failing with:
```
Failed to reclaim lock for recovered box box_id=... lock_id=X error=invalid state: lock X is already allocated
```

## Root Cause

1. `FileLockManager::new()` scans the lock directory and pre-populates the `allocated` HashSet with existing lock file IDs
2. `recover_boxes()` calls `allocate_and_retrieve(lock_id)` to reclaim each lock
3. `allocate_and_retrieve()` rejects lock IDs already in the `allocated` set

This created a semantic mismatch: the method was designed for claiming specific lock IDs that should be free, but recovery needed to reclaim locks that were previously allocated and still had persisted files.

## Solution

Clear all locks at the beginning of `recover_boxes()` before attempting to reclaim them. This approach:

- Leverages the existing runtime lock guarantee (ensures single instance)
- Provides a clean slate for lock allocation during recovery
- Allows the existing `allocate_and_retrieve()` logic to work correctly
- Maintains stable lock IDs across restarts (stored in database)

## Changes

- Added `clear_all_locks()` method to `LockManager` trait
- Implemented `clear_all_locks()` in both `FileLockManager` and `MemoryLockManager`
- Updated `recover_boxes()` to clear locks before recovery
- Added integration test to verify multiple boxes can recover without lock errors

## Testing

- [x] Builds successfully
- [x] Added integration test `multiple_boxes_persist_and_recover_without_lock_errors`
- [x] Test verifies 3 boxes can be created, persisted, and recovered across runtime restart

## Expected Outcome

- All boxes successfully recover their locks on startup
- No "lock already allocated" errors
- Lock files are recreated fresh but with stable IDs from the database