### PR TITLE
chore: bump version to 0.4.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,7 +264,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -319,7 +319,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-c"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "boxlite",
  "boxlite-shared",
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-guest"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -358,7 +358,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-python"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "boxlite",
  "futures",
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-shared"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "prost",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["build/tmp", "target", ".venv", "examples/*/.venv"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.3"
+version = "0.4.4"
 edition = "2024"
 authors = ["Dorian Zheng <https://github.com/dorianzheng>"]
 license = "Apache-2.0"


### PR DESCRIPTION
Bump version to 0.4.4 for lock recovery fix release.