### PR TITLE
chore: bump Python SDK version to 0.4.4

### DIFF
--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "boxlite"
-version = "0.4.3"
+version = "0.4.4"
 description = "Python bindings for Boxlite runtime"
 requires-python = ">=3.10"
 authors = [{ name = "Dorian Zheng" }]


### PR DESCRIPTION
Bump Python SDK version to match Rust crate version 0.4.4.