### PR TITLE
Sample: llm driven simplebox

### DIFF
--- a/examples/python/llm_driven_simplebox_example.py
+++ b/examples/python/llm_driven_simplebox_example.py
@@ -11,12 +11,11 @@ Demonstrates how to let an LLM explore a sandbox via tool calls:
 
 import asyncio
 import json
+import os
 from contextlib import AsyncExitStack
 
 import boxlite
 from openai import AsyncOpenAI
-
-OPENAI_API_KEY = None # YOUR_OPENAI_API_KEY_HERE
 
 TOOLS = [
     {
@@ -39,9 +38,12 @@ TOOLS = [
 
 
 def build_client():
-    api_key = OPENAI_API_KEY
+    api_key = os.getenv('OPENAI_API_KEY')
     if not api_key:
-        raise RuntimeError('OPENAI_API_KEY is not set. Export it before running this example.')
+        raise RuntimeError(
+            "OPENAI_API_KEY is not set. Export it before running, e.g.: "
+            "`export OPENAI_API_KEY=sk-...`"
+        )
     return AsyncOpenAI(api_key=api_key)
 
 


### PR DESCRIPTION
Demonstrates how to let an LLM explore a sandbox via tool calls:
- Create a SimpleBox sandbox
- Expose a sandbox_exec tool to run commands
- Let the model decide which commands to run
- Print a human-readable report


==================================


### Execution Result:

[User Goal]
 Explore this sandbox. Show python version, installed packages, $PATH and list files. Then run a short python snippet that prints system info. Finally give a human readable report.

[System] Executing tool calls:   -> name='sandbox_exec', arguments='{"argv":["bash","-lc","python --version"]}'
  -> name='sandbox_exec', arguments='{"argv":["bash","-lc","python -m pip list --format=columns | sed -n \'1,200p\'"]}'
  -> name='sandbox_exec', arguments='{"argv":["bash","-lc","echo $PATH"]}'
  -> name='sandbox_exec', arguments='{"argv":["bash","-lc","ls -la"]}'
  -> name='sandbox_exec', arguments='{"argv":["bash","-lc","python - <<\'PY\'\\nimport platform, sys, os, site, json\\ninfo = {\\n    \'python_version\': sys.version,\\n    \'executable\': sys.executable,\\n    \'platform\': platform.platform(),\\n    \'uname\': platform.uname()._asdict(),\\n    \'cwd\': os.getcwd(),\\n    \'path\': os.environ.get(\'PATH\',\'\'),\\n    \'site_packages\': site.getsitepackages() if hasattr(site,\'getsitepackages\') else None,\\n}\\nprint(json.dumps(info, indent=2))\\nPY"]}'

[LLM]
 ## Sandbox exploration results

### Python version
```text
Python 3.14.2
```

### Installed Python packages (pip)
```text
Package Version
------- -------
pip     25.3
```
(Only `pip` is installed in this environment.)

### `$PATH`
```text
/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
```

### Files in current directory (`/`)
```text
total 68
drwxr-xr-x  18 root root  4096 Dec 31 10:46 .
drwxr-xr-x  18 root root  4096 Dec 31 10:46 ..
lrwxr-xr-x   1 root root     7 Nov  7 17:40 bin -> usr/bin
drwxr-xr-x   2 root root  4096 Nov  7 17:40 boot
drwxr-xr-x   4 root root   320 Dec 31 11:17 dev
drwxr-xr-x  29 root root  4096 Dec 31 11:17 etc
drwxr-xr-x   2 root root  4096 Nov  7 17:40 home
lrwxr-xr-x   1 root root     7 Nov  7 17:40 lib -> usr/lib
drwx------   2 root root 16384 Dec 31 10:46 lost+found
drwxr-xr-x   2 root root  4096 Dec 29 00:00 media
drwxr-xr-x   2 root root  4096 Dec 29 00:00 mnt
drwxr-xr-x   2 root root  4096 Dec 29 00:00 opt
dr-xr-xr-x 131 root root     0 Dec 31 11:17 proc
drwx------   2 root root  4096 Dec 30 00:36 root
drwxr-xr-x   3 root root  4096 Dec 29 00:00 run
lrwxr-xr-x   1 root root     8 Nov  7 17:40 sbin -> usr/sbin
drwxr-xr-x   2 root root  4096 Dec 29 00:00 srv
dr-xr-xr-x  12 root root     0 Dec 31 11:17 sys
drwxrwxrwt   2 root root    40 Dec 31 11:17 tmp
drwxr-xr-x  11 root root  4096 Dec 29 00:00 usr
drwxr-xr-x  11 root root  4096 Dec 29 00:00 var
```

---

## Python snippet run: system info
Output:
```json
{
  "python_version": "3.14.2 (main, Dec 30 2025, 00:40:39) [GCC 14.2.0]",
  "executable": "/usr/local/bin/python",
  "platform": "Linux-6.12.34-aarch64-with-glibc2.41",
  "uname": {
    "system": "Linux",
    "node": "boxlite",
    "release": "6.12.34",
    "version": "#1 SMP Thu Jun 26 12:45:10 CEST 2025",
    "machine": "aarch64",
    "processor": ""
  },
  "cwd": "/",
  "path": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
  "site_packages": [
    "/usr/local/lib/python3.14/site-packages"
  ]
}
```

---

## Human-readable report

- **Runtime:** Python **3.14.2** (GCC 14.2.0 build), executable at **`/usr/local/bin/python`**
- **OS/Kernel:** **Linux 6.12.34** on **aarch64** (ARM64), glibc **2.41**
- **Environment PATH:** Standard system paths plus `/usr/local/*` first
- **Python environment:** Very minimal—`pip 25.3` is installed and no other third-party packages are present.
- **Working directory:** `/` with a typical Linux filesystem layout (`/usr`, `/etc`, `/var`, `/tmp`, etc.).

[User Goal]
 What commands (executables) are available in this sandbox? Show them all, split by commas.

[System] Executing tool calls:   -> name='sandbox_exec', arguments='{"argv":["bash","-lc","compgen -c | sort -u"]}'

[LLM]
 !, ., :, [, [[, ]], add-shell, addgroup, adduser, agetty, alias, apt, apt-cache, apt-cdrom, apt-config, apt-get, apt-mark, arch, awk, b2sum, base32, base64, basename, basenc, bash, bashbug, bg, bind, blkdiscard, blkid, blkzone, blockdev, break, builtin, c_rehash, caller, captoinfo, case, cat, cd, chage, chcon, chcpu, chfn, chgpasswd, chgrp, chmem, chmod, choom, chown, chpasswd, chroot, chrt, chsh, cksum, clear, clear_console, cmp, comm, command, compgen, complete, compopt, continue, coproc, cp, csplit, cut, dash, date, dd, deb-systemd-helper, deb-systemd-invoke, debconf, debconf-apt-progress, debconf-communicate, debconf-copydb, debconf-escape, debconf-set-selections, debconf-show, declare, delgroup, deluser, df, diff, diff3, dir, dircolors, dirname, dirs, disown, dmesg, dnsdomainname, do, domainname, done, dpkg, dpkg-deb, dpkg-divert, dpkg-maintscript-helper, dpkg-preconfigure, dpkg-query, dpkg-realpath, dpkg-reconfigure, dpkg-split, dpkg-statoverride, dpkg-trigger, du, echo, egrep, elif, else, enable, env, esac, eval, exec, exit, expand, expiry, export, expr, factor, faillock, fallocate, false, fc, fg, fgrep, fi, find, findfs, findmnt, flock, fmt, fold, for, fsck, fsfreeze, fstab-decode, fstrim, function, getconf, getent, getopt, getopts, getty, gpasswd, grep, groupadd, groupdel, groupmod, groups, grpck, grpconv, grpunconv, gunzip, gzexe, gzip, hardlink, hash, head, help, history, hostid, hostname, iconv, iconvconfig, id, idle, idle3, idle3.14, if, in, infocmp, infotocap, install, installkernel, invoke-rc.d, ionice, ipcmk, ipcrm, ipcs, ischroot, isosize, jobs, join, kill, killall5, ld.so, ldattach, ldconfig, ldd, let, link, linux32, linux64, ln, local, locale, localedef, logger, login, logname, logout, losetup, ls, lsblk, lscpu, lsipc, lslocks, lslogins, lsmem, lsns, mapfile, mawk, mcookie, md5sum, mkdir, mkfifo, mkfs, mkhomedir_helper, mknod, mkswap, mktemp, more, mount, mountpoint, mv, namei, nawk, newgrp, newusers, nice, nisdomainname, nl, nohup, nologin, nproc, nsenter, numfmt, od, openssl, pager, pam-auth-update, pam_getenv, pam_namespace_helper, pam_timestamp_check, partx, passwd, paste, pathchk, perl, perl5.40.1, pidof, pinky, pip, pip3, pip3.14, pivot_root, pldd, policy-rc.d, popd, pr, printenv, printf, prlimit, ptx, pushd, pwck, pwconv, pwd, pwhistory_helper, pwunconv, pydoc, pydoc3, pydoc3.14, python, python-config, python3, python3-config, python3.14, python3.14-config, rbash, read, readarray, readlink, readonly, readprofile, realpath, remove-shell, rename.ul, renice, reset, return, rev, rgrep, rm, rmdir, rmt, rmt-tar, rtcwake, run-parts, runcon, runuser, savelog, script, scriptlive, scriptreplay, sdiff, sed, select, seq, service, set, setarch, setpriv, setsid, setterm, sg, sh, sha1sum, sha224sum, sha256sum, sha384sum, sha512sum, shadowconfig, shift, shopt, shred, shuf, sleep, sort, source, split, sqv, start-stop-daemon, stat, stdbuf, stty, su, sulogin, sum, suspend, swaplabel, swapoff, swapon, switch_root, sync, tabs, tac, tail, tar, tarcat, taskset, tee, tempfile, test, then, tic, time, timeout, times, toe, touch, tput, tr, trap, true, truncate, tset, tsort, tty, type, typeset, tzselect, uclampset, ulimit, umask, umount, unalias, uname, uncompress, unexpand, uniq, unix_chkpwd, unix_update, unlink, unset, unshare, until, update-alternatives, update-ca-certificates, update-passwd, update-rc.d, update-shells, useradd, userdel, usermod, users, vdir, vigr, vipw, wait, wall, wc, wdctl, whereis, which, which.debianutils, while, who, whoami, wipefs, xargs, yes, ypdomainname, zcat, zcmp, zdiff, zdump, zegrep, zfgrep, zforce, zgrep, zic, zless, zmore, znew, zramctl, {, }