### PR TITLE
fix(examples): use /tmp as working directory in the simplebox example

### DIFF
--- a/examples/python/simplebox_example.py
+++ b/examples/python/simplebox_example.py
@@ -88,7 +88,7 @@ async def example_working_directory():
 
     async with boxlite.SimpleBox(
             image="python:alpine",
-            working_dir="/workspace",
+            working_dir="/tmp",
             env=[("USER", "alice"), ("PROJECT", "data-pipeline")]
     ) as box:
         print(f"✓ Container with custom config: {box.id}")


### PR DESCRIPTION
The previous working_dir="/workspace" caused an "internal error: spawn_failed" because the directory does not exist in the python:alpine image. Changing it to /tmp ensures the example runs successfully out-of-the-box.



## Problem

Encouraged error like below:

```=== Example 4: Working Directory ===
✓ Container with custom config: 01KDT5CEZ3QHYWX4D7JCKQWA0X

Current directory:
Traceback (most recent call last):
  File "/Users/goranka/Engineer/ai/boxlite-labs/boxlite/examples/python/simplebox_example.py", line 193, in <module>
    asyncio.run(main())
  File "/Users/goranka/.pyenv/versions/3.10.9/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/Users/goranka/.pyenv/versions/3.10.9/lib/python3.10/asyncio/base_events.py", line 649, in run_until_complete
    return future.result()
  File "/Users/goranka/Engineer/ai/boxlite-labs/boxlite/examples/python/simplebox_example.py", line 175, in main
    await example_working_directory()
  File "/Users/goranka/Engineer/ai/boxlite-labs/boxlite/examples/python/simplebox_example.py", line 98, in example_working_directory
    result = await box.exec("pwd")
  File "/Users/goranka/Engineer/ai/boxlite-labs/boxlite/sdks/python/boxlite/simplebox.py", line 147, in exec
    execution = await self._box.exec(cmd, arg_list, env_list)
RuntimeError: internal error: spawn_failed: internal error: Failed to spawn 'pwd' with args ["pwd"]: failed to create container: exec process failed with error error in executing process : failed to unix syscall
```


## Fix

 `/tmp` might be a better choice.


## Execution Result

`=== Example 4: Working Directory ===
✓ Container with custom config: 01KDT89QAZJZPJQ927PQ3KJZ0H
Current directory:
  /tmp
Environment variables:
  USER=alice
  PROJECT=data-pipeline`


## Env Info

- Python: 3.10.9
- OS: macOS 26.0 Apple Silicon (arm64)
- Rust: 1.92.0