### PR TITLE
fix(guest): prevent out-of-order stdout in PTY mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,7 +264,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -319,7 +319,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-c"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "boxlite",
  "boxlite-shared",
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-guest"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -358,7 +358,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-python"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "boxlite",
  "futures",
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-shared"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "prost",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["build/tmp", "target", ".venv", "examples/*/.venv"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.4"
+version = "0.4.5"
 edition = "2024"
 authors = ["Dorian Zheng <https://github.com/dorianzheng>"]
 license = "Apache-2.0"

--- a/guest/src/service/exec/exec_handle.rs
+++ b/guest/src/service/exec/exec_handle.rs
@@ -241,13 +241,22 @@ pub struct ExecHandle {
 }
 
 impl ExecHandle {
-    /// Create new execution handle
-    pub fn new(pid: Pid, stdin: OwnedFd, stdout: OwnedFd, stderr: OwnedFd) -> Self {
+    /// Create new execution handle.
+    ///
+    /// # Arguments
+    ///
+    /// * `pid` - Process ID
+    /// * `stdin` - Stdin file descriptor
+    /// * `stdout` - Stdout file descriptor
+    /// * `stderr` - Stderr file descriptor, or `None` in PTY mode (merged into stdout)
+    pub fn new(pid: Pid, stdin: OwnedFd, stdout: OwnedFd, stderr: Option<OwnedFd>) -> Self {
         Self {
             pid,
             stdin: Some(ExecStdin::new(stdin)),
             stdout: Some(ExecStdout::new(stdout)),
-            stderr: Some(ExecStderr::new(stderr)),
+            // In PTY mode, stderr is None because stdout/stderr are merged
+            // at the PTY level (single reader from PTY master)
+            stderr: stderr.map(ExecStderr::new),
             pty_controller: None,
             pty_config: None,
         }


### PR DESCRIPTION
## Summary

- Fix race condition in PTY mode where two readers competed for the same PTY master FD
- In PTY mode, stderr is now merged into stdout (single reader), following kata-containers pattern
- Non-PTY mode unchanged - still has separate stdout/stderr pipes

## Problem

In PTY mode, the code incorrectly created two separate readers from the same PTY master:
```rust
let stdout_fd = dup(master.as_raw_fd())  // reader #1
let stderr_fd = dup(master.as_raw_fd())  // reader #2 - SAME underlying FD!
```

Both readers had their own `BufReader`, causing:
- Race conditions when reading
- Out-of-order output (chunks captured by "wrong" reader)
- Data appearing on stderr when it should be on stdout

## Solution

Follow kata-containers pattern:
- Only ONE reader from PTY master → stdout
- Pass `None` for stderr in PTY mode
- All terminal output flows through single stdout stream

## Changes

| File | Change |
|------|--------|
| `exec_handle.rs` | `new()` accepts `Option<OwnedFd>` for stderr |
| `executor.rs` | PTY: pass `None`, non-PTY: `Some(stderr)` |
| `command.rs` | Same pattern, fix `reconcile_pty_fds` |

## Test Plan

- [ ] Run `interactivebox_example.py` and verify output ordering
- [ ] Test commands mixing stdout/stderr: `ls /nonexistent 2>&1`