### PR TITLE
feat(runtime): add detach option and change auto_remove default

### DIFF
--- a/boxlite/src/litebox/init/tasks/vmm_spawn.rs
+++ b/boxlite/src/litebox/init/tasks/vmm_spawn.rs
@@ -218,6 +218,8 @@ async fn build_config(
         network_backend_endpoint: None,
         home_dir: home_dir.to_path_buf(),
         console_output: None,
+        detach: options.detach,
+        parent_pid: std::process::id(),
     };
 
     Ok((instance_spec, volume_mgr, rootfs_init, container_mounts))

--- a/boxlite/src/vmm/controller/shim.rs
+++ b/boxlite/src/vmm/controller/shim.rs
@@ -197,6 +197,8 @@ impl VmmController for ShimController {
             network_backend_endpoint: None, // Will be populated by shim (not serialized)
             home_dir: config.home_dir.clone(),
             console_output: config.console_output.clone(),
+            detach: config.detach,
+            parent_pid: config.parent_pid,
         };
 
         // Serialize the config for passing to subprocess

--- a/boxlite/src/vmm/mod.rs
+++ b/boxlite/src/vmm/mod.rs
@@ -165,6 +165,12 @@ pub struct InstanceSpec {
     pub home_dir: PathBuf,
     /// Optional file path to redirect console output (kernel/init messages)
     pub console_output: Option<PathBuf>,
+    /// Whether the box should continue running when the parent process exits.
+    /// When false, a watchdog thread monitors parent PID and triggers shutdown.
+    pub detach: bool,
+    /// PID of the parent process that spawned this box.
+    /// Used by watchdog to detect when parent exits (if detach=false).
+    pub parent_pid: u32,
 }
 
 /// Entrypoint configuration that the guest should run.

--- a/examples/python/detach_example.py
+++ b/examples/python/detach_example.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""
+Detach and Auto-Remove Options Example
+
+Demonstrates the lifecycle control options:
+1. auto_remove=True (default): Box is automatically removed when stopped
+2. auto_remove=False: Box is preserved after stop, can be restarted
+3. detach=False (default): Box stops when parent process exits
+4. detach=True: Box survives parent process exit
+
+These options are similar to Docker's --rm and -d flags.
+"""
+
+import asyncio
+
+import boxlite
+
+
+async def demo_auto_remove_true():
+    """Demo auto_remove=True behavior (default).
+
+    When auto_remove=True:
+    - Box is automatically removed when stop() is called
+    - No need to call runtime.remove() separately
+    - Similar to Docker's --rm flag
+    """
+    print("=== Demo 1: auto_remove=True (default) ===")
+    print("Box will be automatically removed when stopped.\n")
+
+    runtime = boxlite.Boxlite.default()
+
+    # Create box with default auto_remove=True
+    print("1. Creating box with auto_remove=True (default)...")
+    box = runtime.create(boxlite.BoxOptions(
+        image="alpine:latest",
+        auto_remove=True,  # This is the default, shown explicitly for clarity
+    ))
+    box_id = box.id
+    print(f"   Box created: {box_id}")
+
+    # Execute a command
+    print("\n2. Executing command...")
+    result = await box.exec("echo", ["Hello from auto-remove box!"])
+    print(f"   Output: {result.stdout()}")
+
+    # Check box exists before stop
+    info = runtime.get_info(box_id)
+    print(f"\n3. Box exists before stop: {info is not None}")
+
+    # Stop the box - this will automatically remove it
+    print("\n4. Stopping box (auto-remove will trigger)...")
+    await box.stop()
+    print("   Box stopped")
+
+    # Check box no longer exists
+    info = runtime.get_info(box_id)
+    print(f"\n5. Box exists after stop: {info is not None}")
+    if info is None:
+        print("   Box was automatically removed!")
+
+    runtime.close()
+    print("\nDemo 1 completed.\n")
+
+
+async def demo_auto_remove_false():
+    """Demo auto_remove=False behavior.
+
+    When auto_remove=False:
+    - Box is preserved after stop() is called
+    - Box can be restarted using runtime.get() + exec()
+    - Must call runtime.remove() to clean up
+    """
+    print("=== Demo 2: auto_remove=False ===")
+    print("Box will be preserved after stop, allowing restart.\n")
+
+    runtime = boxlite.Boxlite.default()
+
+    # Create box with auto_remove=False
+    print("1. Creating box with auto_remove=False...")
+    box = runtime.create(boxlite.BoxOptions(
+        image="alpine:latest",
+        auto_remove=False,  # Preserve box after stop
+    ))
+    box_id = box.id
+    print(f"   Box created: {box_id}")
+
+    # Execute a command
+    print("\n2. Executing command...")
+    result = await box.exec("echo", ["Hello!"])
+    print(f"   Output: {result.stdout()}")
+
+    # Stop the box
+    print("\n3. Stopping box...")
+    await box.stop()
+    print("   Box stopped")
+
+    # Check box still exists
+    info = runtime.get_info(box_id)
+    print(f"\n4. Box exists after stop: {info is not None}")
+    if info:
+        print(f"   Box state: {info.state}")
+
+    # Restart by getting handle and executing
+    print("\n5. Restarting box (get handle + exec)...")
+    restarted_box = runtime.get(box_id)
+    if restarted_box:
+        result = await restarted_box.exec("echo", ["Restarted!"])
+        print(f"   Output: {result.stdout()}")
+
+        # Clean up - stop then remove
+        print("\n6. Cleaning up (stop + remove)...")
+        await restarted_box.stop()
+        await runtime.remove(box_id, force=False)
+        print("   Box removed")
+    else:
+        print("   Failed to get box handle")
+
+    runtime.close()
+    print("\nDemo 2 completed.\n")
+
+
+async def demo_detach_false():
+    """Demo detach=False behavior (default).
+
+    When detach=False:
+    - Box is tied to parent process lifecycle
+    - Box will stop when the parent process exits
+    - This is the default behavior to prevent orphan boxes
+    """
+    print("=== Demo 3: detach=False (default) ===")
+    print("Box is tied to parent process - stops when parent exits.\n")
+
+    runtime = boxlite.Boxlite.default()
+
+    # Create box with default detach=False
+    print("1. Creating box with detach=False (default)...")
+    box = runtime.create(boxlite.BoxOptions(
+        image="alpine:latest",
+        detach=False,  # This is the default
+        auto_remove=True,
+    ))
+    box_id = box.id
+    print(f"   Box created: {box_id}")
+    print("   This box would stop automatically if this process exited.")
+
+    # Execute a command
+    print("\n2. Executing command...")
+    result = await box.exec("echo", ["I'm tied to parent!"])
+    print(f"   Output: {result.stdout()}")
+
+    # Clean up normally for this demo
+    print("\n3. Stopping box...")
+    await box.stop()
+    print("   Box stopped and auto-removed")
+
+    runtime.close()
+    print("\nDemo 3 completed.\n")
+
+
+async def demo_detach_true():
+    """Demo detach=True behavior.
+
+    When detach=True:
+    - Box runs independently of parent process
+    - Box survives if parent process exits
+    - Similar to Docker's -d (detach) flag
+    - Useful for long-running services
+    """
+    print("=== Demo 4: detach=True ===")
+    print("Box runs independently - survives parent exit.\n")
+
+    runtime = boxlite.Boxlite.default()
+
+    # Create box with detach=True
+    print("1. Creating box with detach=True...")
+    box = runtime.create(boxlite.BoxOptions(
+        image="alpine:latest",
+        detach=True,  # Run independently
+        auto_remove=False,  # Keep around for demo
+    ))
+    box_id = box.id
+    print(f"   Box created: {box_id}")
+    print("   This box would continue running if this process exited.")
+    print("   You could reattach using: runtime.get(box_id)")
+
+    # Execute a command
+    print("\n2. Executing command...")
+    result = await box.exec("echo", ["I'm detached!"])
+    print(f"   Output: {result.stdout()}")
+
+    # Show how to reattach
+    print("\n3. Simulating reattach (getting new handle)...")
+    new_handle = runtime.get(box_id)
+    if new_handle:
+        result = await new_handle.exec("echo", ["Via new handle!"])
+        print(f"   Output: {result.stdout()}")
+
+    # Clean up for demo
+    print("\n4. Cleaning up...")
+    await box.stop()
+    await runtime.remove(box_id, force=False)
+    print("   Box stopped and removed")
+
+    runtime.close()
+    print("\nDemo 4 completed.\n")
+
+
+async def demo_combined_options():
+    """Demo combining auto_remove and detach options."""
+    print("=== Demo 5: Combined Options ===")
+    print("Common option combinations and their use cases.\n")
+
+    runtime = boxlite.Boxlite.default()
+
+    # Combination 1: auto_remove=True, detach=False (default)
+    # Use case: Ephemeral sandbox for one-off tasks
+    print("1. Ephemeral sandbox (auto_remove=True, detach=False):")
+    print("   Use case: One-off code execution, testing")
+    box1 = runtime.create(boxlite.BoxOptions(
+        image="alpine:latest",
+        auto_remove=True,
+        detach=False,
+    ))
+    result = await box1.exec("echo", ["One-off task"])
+    print(f"   Output: {result.stdout()}")
+    await box1.stop()
+    print("   Box auto-removed on stop\n")
+
+    # Combination 2: auto_remove=False, detach=False
+    # Use case: Development/debugging - restart box with same state
+    print("2. Development sandbox (auto_remove=False, detach=False):")
+    print("   Use case: Iterative development, debugging")
+    box2 = runtime.create(boxlite.BoxOptions(
+        image="alpine:latest",
+        auto_remove=False,
+        detach=False,
+    ))
+    box2_id = box2.id
+    await box2.exec("touch", ["/tmp/dev-file"])
+    await box2.stop()
+    # Can restart and continue development
+    box2_restarted = runtime.get(box2_id)
+    result = await box2_restarted.exec("ls", ["/tmp/dev-file"])
+    print(f"   File persisted: '/tmp/dev-file' in {result.stdout()}")
+    await box2_restarted.stop()
+    await runtime.remove(box2_id)
+    print("   Box manually removed\n")
+
+    # Combination 3: auto_remove=False, detach=True
+    # Use case: Long-running service that survives parent exit
+    print("3. Background service (auto_remove=False, detach=True):")
+    print("   Use case: Long-running services, daemons")
+    box3 = runtime.create(boxlite.BoxOptions(
+        image="alpine:latest",
+        auto_remove=False,
+        detach=True,
+    ))
+    box3_id = box3.id
+    print(f"   Service box: {box3_id}")
+    print("   This box would survive parent process exit")
+    await box3.stop()
+    await runtime.remove(box3_id)
+    print("   Box manually stopped and removed\n")
+
+    runtime.close()
+    print("Demo 5 completed.\n")
+
+
+async def main():
+    """Run all demos."""
+    print("=" * 60)
+    print("BoxLite Detach and Auto-Remove Options Demo")
+    print("=" * 60)
+    print()
+    print("Options explained:")
+    print("  auto_remove: Control box cleanup on stop")
+    print("    - True (default):  Box removed when stop() called")
+    print("    - False:           Box preserved, can restart")
+    print()
+    print("  detach: Control parent process lifecycle tie")
+    print("    - False (default): Box stops when parent exits")
+    print("    - True:            Box survives parent exit")
+    print()
+    print("=" * 60)
+    print()
+
+    await demo_auto_remove_true()
+    await demo_auto_remove_false()
+    await demo_detach_false()
+    await demo_detach_true()
+    await demo_combined_options()
+
+    print("=" * 60)
+    print("All demos completed!")
+    print()
+    print("Summary:")
+    print("  - auto_remove=True (default): Ephemeral boxes, auto-cleanup")
+    print("  - auto_remove=False: Persistent boxes, manual cleanup")
+    print("  - detach=False (default): Tied to parent, prevents orphans")
+    print("  - detach=True: Independent boxes, survives parent exit")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "boxlite"
-version = "0.4.4"
+version = "0.4.5"
 description = "Python bindings for Boxlite runtime"
 requires-python = ">=3.10"
 authors = [{ name = "Dorian Zheng" }]

--- a/sdks/python/src/options.rs
+++ b/sdks/python/src/options.rs
@@ -63,6 +63,8 @@ pub(crate) struct PyBoxOptions {
     pub(crate) ports: Vec<PyPortSpec>,
     #[pyo3(get, set)]
     pub(crate) auto_remove: Option<bool>,
+    #[pyo3(get, set)]
+    pub(crate) detach: Option<bool>,
 }
 
 #[pymethods]
@@ -80,6 +82,7 @@ impl PyBoxOptions {
         network=None,
         ports=vec![],
         auto_remove=None,
+        detach=None,
     ))]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -94,6 +97,7 @@ impl PyBoxOptions {
         network: Option<String>,
         ports: Vec<PyPortSpec>,
         auto_remove: Option<bool>,
+        detach: Option<bool>,
     ) -> Self {
         Self {
             image,
@@ -107,6 +111,7 @@ impl PyBoxOptions {
             network,
             ports,
             auto_remove,
+            detach,
         }
     }
 
@@ -158,6 +163,10 @@ impl From<PyBoxOptions> for BoxOptions {
 
         if let Some(auto_remove) = py_opts.auto_remove {
             opts.auto_remove = auto_remove;
+        }
+
+        if let Some(detach) = py_opts.detach {
+            opts.detach = detach;
         }
 
         opts

--- a/sdks/python/tests/test_options.py
+++ b/sdks/python/tests/test_options.py
@@ -1,0 +1,257 @@
+"""
+Tests for BoxOptions - auto_remove and detach options.
+
+These tests verify the behavior of:
+- auto_remove: Controls whether box is removed on stop()
+- detach: Controls whether box is tied to parent process lifecycle
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Iterable
+
+import boxlite
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+def _candidate_library_dirs() -> Iterable[Path]:
+    """Yield directories that may hold libkrun/libkrunfw dylibs."""
+    package_dir = Path(boxlite.__file__).parent
+    bundled = package_dir / ".dylibs"
+    if bundled.exists():
+        yield bundled
+
+    # Homebrew layout on Apple Silicon
+    hb_root = Path("/opt/homebrew/opt")
+    hb_dirs = [hb_root / "libkrun" / "lib", hb_root / "libkrunfw" / "lib"]
+    if all(path.exists() for path in hb_dirs):
+        yield from hb_dirs
+
+
+@pytest.fixture(autouse=True)
+def _ensure_library_paths(monkeypatch):
+    """Populate the dynamic loader search path so libkrun can be found."""
+    dirs = [str(path) for path in _candidate_library_dirs()]
+    if not dirs:
+        pytest.skip("libkrun libraries are not available on this system")
+
+    joined = ":".join(dirs)
+    if sys.platform == "darwin":
+        vars_to_set = ["DYLD_LIBRARY_PATH", "LD_LIBRARY_PATH"]
+    else:
+        vars_to_set = ["LD_LIBRARY_PATH"]
+
+    for var in vars_to_set:
+        existing = os.environ.get(var)
+        value = joined if not existing else ":".join([joined, existing])
+        monkeypatch.setenv(var, value)
+
+
+@pytest.fixture
+def runtime():
+    """Create a runtime for testing."""
+    rt = boxlite.Boxlite(boxlite.Options())
+    try:
+        yield rt
+    finally:
+        rt.close()
+
+
+class TestBoxOptionsDefaults:
+    """Test BoxOptions default values."""
+
+    def test_auto_remove_default_is_none(self):
+        """Test that auto_remove defaults to None (uses Rust default)."""
+        opts = boxlite.BoxOptions()
+        # Python side defaults to None, Rust side defaults to True
+        assert opts.auto_remove is None
+
+    def test_detach_default_is_none(self):
+        """Test that detach defaults to None (uses Rust default)."""
+        opts = boxlite.BoxOptions()
+        # Python side defaults to None, Rust side defaults to False
+        assert opts.detach is None
+
+    def test_explicit_auto_remove_true(self):
+        """Test setting auto_remove=True explicitly."""
+        opts = boxlite.BoxOptions(image="alpine:latest", auto_remove=True)
+        assert opts.auto_remove == True
+
+    def test_explicit_auto_remove_false(self):
+        """Test setting auto_remove=False explicitly."""
+        opts = boxlite.BoxOptions(image="alpine:latest", auto_remove=False)
+        assert opts.auto_remove == False
+
+    def test_explicit_detach_true(self):
+        """Test setting detach=True explicitly."""
+        opts = boxlite.BoxOptions(image="alpine:latest", detach=True)
+        assert opts.detach == True
+
+    def test_explicit_detach_false(self):
+        """Test setting detach=False explicitly."""
+        opts = boxlite.BoxOptions(image="alpine:latest", detach=False)
+        assert opts.detach == False
+
+
+class TestAutoRemoveBehavior:
+    """Test auto_remove option behavior."""
+
+    def test_auto_remove_true_removes_box_on_stop(self, runtime):
+        """Test that auto_remove=True removes box when stop() is called."""
+        box = runtime.create(boxlite.BoxOptions(
+            image="alpine:latest",
+            auto_remove=True,
+        ))
+        box_id = box.id
+
+        # Box should exist before stop
+        assert runtime.get_info(box_id) is not None
+
+        # Stop the box
+        box.shutdown()
+
+        # Box should be removed
+        assert runtime.get_info(box_id) is None
+
+    def test_auto_remove_false_preserves_box_on_stop(self, runtime):
+        """Test that auto_remove=False preserves box when stop() is called."""
+        box = runtime.create(boxlite.BoxOptions(
+            image="alpine:latest",
+            auto_remove=False,
+        ))
+        box_id = box.id
+
+        # Stop the box
+        box.shutdown()
+
+        # Box should still exist
+        info = runtime.get_info(box_id)
+        assert info is not None
+        assert info.state == "stopped"
+
+        # Cleanup
+        runtime.remove(box_id)
+
+
+class TestDetachOption:
+    """Test detach option is accepted."""
+
+    def test_detach_false_creates_box(self, runtime):
+        """Test that detach=False creates box successfully."""
+        box = runtime.create(boxlite.BoxOptions(
+            image="alpine:latest",
+            detach=False,
+            auto_remove=True,
+        ))
+        assert box is not None
+        assert box.id is not None
+
+        # Cleanup
+        box.shutdown()
+
+    def test_detach_true_creates_box(self, runtime):
+        """Test that detach=True creates box successfully."""
+        # Note: detach=True requires auto_remove=False (they are incompatible)
+        box = runtime.create(boxlite.BoxOptions(
+            image="alpine:latest",
+            detach=True,
+            auto_remove=False,
+        ))
+        assert box is not None
+        assert box.id is not None
+
+        # Cleanup
+        box.shutdown()
+        runtime.remove(box.id)
+
+
+class TestInvalidCombinations:
+    """Test that invalid option combinations are rejected."""
+
+    def test_auto_remove_true_detach_true_rejected(self, runtime):
+        """Test that auto_remove=True + detach=True is rejected."""
+        with pytest.raises(RuntimeError) as exc_info:
+            runtime.create(boxlite.BoxOptions(
+                image="alpine:latest",
+                auto_remove=True,
+                detach=True,
+            ))
+        assert "incompatible" in str(exc_info.value).lower()
+
+
+class TestCombinedOptions:
+    """Test combinations of auto_remove and detach options."""
+
+    def test_ephemeral_sandbox(self, runtime):
+        """Test ephemeral sandbox: auto_remove=True, detach=False."""
+        box = runtime.create(boxlite.BoxOptions(
+            image="alpine:latest",
+            auto_remove=True,
+            detach=False,
+        ))
+        box_id = box.id
+
+        # Box exists
+        assert runtime.get_info(box_id) is not None
+
+        # Stop - should auto-remove
+        box.shutdown()
+
+        # Box gone
+        assert runtime.get_info(box_id) is None
+
+    def test_persistent_sandbox(self, runtime):
+        """Test persistent sandbox: auto_remove=False, detach=False."""
+        box = runtime.create(boxlite.BoxOptions(
+            image="alpine:latest",
+            auto_remove=False,
+            detach=False,
+        ))
+        box_id = box.id
+
+        # Stop - should preserve
+        box.shutdown()
+
+        # Box still exists
+        info = runtime.get_info(box_id)
+        assert info is not None
+        assert info.state == "stopped"
+
+        # Can get new handle
+        box2 = runtime.get(box_id)
+        assert box2 is not None
+
+        # Cleanup
+        box2.shutdown()
+        runtime.remove(box_id)
+
+    def test_detached_service(self, runtime):
+        """Test detached service: auto_remove=False, detach=True."""
+        box = runtime.create(boxlite.BoxOptions(
+            image="alpine:latest",
+            auto_remove=False,
+            detach=True,
+        ))
+        box_id = box.id
+
+        # Box exists
+        assert runtime.get_info(box_id) is not None
+
+        # Stop
+        box.shutdown()
+
+        # Still exists (auto_remove=False)
+        info = runtime.get_info(box_id)
+        assert info is not None
+
+        # Cleanup
+        runtime.remove(box_id)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

- Add `detach` option (default: `false`) to control box lifecycle relative to parent process
- Change `auto_remove` default from `false` to `true` for Docker-like behavior
- Add recovery cleanup for ephemeral and orphaned boxes
- Bump Python SDK version to 0.4.5

## Changes

### New `detach` option
- `detach=false` (default): Box stops when parent process exits via watchdog thread
- `detach=true`: Box runs independently, survives parent exit (like Docker's `-d` flag)

### `auto_remove` default changed
- Now defaults to `true` (like Docker's `--rm` flag)
- Boxes are automatically removed when stopped

### Validation
- `auto_remove=true` + `detach=true` is now invalid (confusing combination)

### Recovery cleanup
- Boxes with `auto_remove=true` are removed during runtime restart
- Active boxes (Starting/Running) without directories are removed as orphaned
- Stopped boxes without directories are kept (may never have been started)

## Test plan
- [x] Unit tests for option defaults and serde
- [x] Unit tests for validation rule
- [x] Integration tests for auto_remove behavior
- [x] Integration tests for recovery cleanup
- [x] Python SDK tests
- [x] All 26 lifecycle tests pass