### PR TITLE
ci(workflow): disable automatic build-runtime triggers

### DIFF
--- a/.github/workflows/build-runtime.yml
+++ b/.github/workflows/build-runtime.yml
@@ -10,29 +10,30 @@
 name: Build Runtime
 
 on:
-  push:
-    branches: [ main, develop ]
-    paths:
-      - 'boxlite/**'
-      - 'boxlite-shared/**'
-      - 'guest/**'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - '.github/workflows/build-runtime.yml'
-      - '.github/workflows/config.yml'
-  pull_request:
-    branches: [ main ]
-    paths:
-      - 'boxlite/**'
-      - 'boxlite-shared/**'
-      - 'guest/**'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - '.github/workflows/build-runtime.yml'
-      - '.github/workflows/config.yml'
-  release:
-    types: [ published ]
-  workflow_dispatch:
+  # DISABLED: Uncomment to re-enable automatic triggers
+  # push:
+  #   branches: [ main, develop ]
+  #   paths:
+  #     - 'boxlite/**'
+  #     - 'boxlite-shared/**'
+  #     - 'guest/**'
+  #     - 'Cargo.toml'
+  #     - 'Cargo.lock'
+  #     - '.github/workflows/build-runtime.yml'
+  #     - '.github/workflows/config.yml'
+  # pull_request:
+  #   branches: [ main ]
+  #   paths:
+  #     - 'boxlite/**'
+  #     - 'boxlite-shared/**'
+  #     - 'guest/**'
+  #     - 'Cargo.toml'
+  #     - 'Cargo.lock'
+  #     - '.github/workflows/build-runtime.yml'
+  #     - '.github/workflows/config.yml'
+  # release:
+  #   types: [ published ]
+  workflow_dispatch:  # Keep manual trigger for testing
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary
- Comment out push, pull_request, and release triggers in build-runtime workflow
- Keep workflow_dispatch for manual builds via GitHub Actions UI
- SDK workflows (Python, Node.js) won't auto-trigger since they depend on Build Runtime completion

## Test plan
- [ ] Verify workflow can still be triggered manually via GitHub Actions UI
- [ ] Confirm no automatic triggers occur on push/PR