### PR TITLE
fix(ci): resolve cibuildwheel curl download failure and optimize guest cache

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -34,12 +34,11 @@ jobs:
         run: |
           make setup guest
 
-          # Save entire guest target directory for cibuildwheel container
-          # (cibuildwheel uses tar which respects .gitignore, excluding target/)
-          # We need the full cache (not just binary) for cargo incremental compilation
+          # Cache only the final binary (11MB), not entire target dir (2.3GB)
+          # Guest is not rebuilt in container (SKIP_GUEST_BUILD=1), so no incremental compilation needed
           GUEST_TARGET=$(scripts/util.sh --target)
-          mkdir -p .cache
-          cp -a "target/$GUEST_TARGET" ".cache/$GUEST_TARGET"
+          mkdir -p ".cache/$GUEST_TARGET/release"
+          cp "target/$GUEST_TARGET/release/boxlite-guest" ".cache/$GUEST_TARGET/release/"
 
           # Clean up to save disk space
           rm -rf target ~/.rustup ~/.cargo

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -82,7 +82,8 @@ repair-wheel-command = ""  # Skip auditwheel repair
 # manylinux-aarch64-image = "manylinux_2_28"
 
 # Set Rust and library paths
-environment = { PATH = "$CARGO_HOME:$PATH", PKG_CONFIG_PATH = "/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig", LD_LIBRARY_PATH = "/usr/local/lib64:/usr/local/lib" }
+# SKIP_GUEST_BUILD=1: Use pre-built guest from Ubuntu host (manylinux lacks musl packages)
+environment = { SKIP_GUEST_BUILD = "1", PATH = "$CARGO_HOME:$PATH", PKG_CONFIG_PATH = "/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig", LD_LIBRARY_PATH = "/usr/local/lib64:/usr/local/lib" }
 
 # Retag wheel for PyPI compliance without bundling libs (we handle runtime deps ourselves)
 # Uses 'wheel tags' to change linux_x86_64 -> manylinux_2_28_x86_64


### PR DESCRIPTION
## Summary

- Fix libkrunfw download failure in build.rs (curl error 23)
- Optimize guest cache from 2.3GB to 11MB (only cache final binary)
- Add `SKIP_GUEST_BUILD=1` for Linux cibuildwheel builds

## Root Cause

The `download_libkrunfw_so()` function in build.rs tried to download files to a directory that didn't exist yet. `fs::create_dir_all(install_dir)` was called AFTER `download_file()`, causing curl to fail with error 23 (write error).

## Changes

1. **build.rs**: Move `fs::create_dir_all()` before `download_file()` call
2. **build-wheels.yml**: Cache only the 11MB guest binary instead of 2.3GB cargo target
3. **pyproject.toml**: Add `SKIP_GUEST_BUILD=1` to Linux environment

## Test plan

- [x] Build wheels locally with `cibuildwheel --platform linux sdks/python`
- [ ] CI workflow passes