### PR TITLE
fix: use runtime home_dir for shim logging and add console output path

### DIFF
--- a/sdks/node/lib/simplebox.ts
+++ b/sdks/node/lib/simplebox.ts
@@ -128,7 +128,7 @@ export class SimpleBox {
     if (options.runtime) {
       this._runtime = options.runtime;
     } else {
-      this._runtime = JsBoxlite.default();
+      this._runtime = JsBoxlite.withDefaultConfig();
     }
 
     // Convert options to BoxOptions format
@@ -253,14 +253,14 @@ export class SimpleBox {
     let stderr;
 
     try {
-      stdout = execution.stdout();
+      stdout = await execution.stdout();
     } catch (err) {
       // Stream not available (expected for some commands)
       stdout = null;
     }
 
     try {
-      stderr = execution.stderr();
+      stderr = await execution.stderr();
     } catch (err) {
       // Stream not available (expected for some commands)
       stderr = null;


### PR DESCRIPTION
## Summary
- Fix bug where `InstanceSpec.home_dir` received `box_home` (`~/.boxlite/boxes/{id}`) instead of runtime home (`~/.boxlite`), causing shim logs to be written to wrong location
- Add `console_output` path to `~/.boxlite/logs/{box_id}-console.log`

## Test plan
- [ ] Run box and verify `~/.boxlite/logs/boxlite-shim.log.*` is created
- [ ] Verify `~/.boxlite/logs/{box_id}-console.log` contains VM console output