### PR TITLE
docs(readme): simplify and separate Python/Rust quick starts

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ hardware-level isolation — **no daemon required**.
 ## What is BoxLite?
 
 BoxLite lets you spin up **lightweight VMs** ("Boxes") and run **OCI containers inside them**. It's
-designed for use-cases like **AI agent sandboxes** and **multi-tenant code execution**, where Docker
+designed for use cases like **AI agent sandboxes** and **multi-tenant code execution**, where Docker
 alone isn't enough and full VM infrastructure is too heavy.
 
 **Why BoxLite**


### PR DESCRIPTION
- Make README more onboarding-focused for AI agent use cases

- Separate Python and Rust quick starts

- Restore architecture diagram (collapsed)

- Fix/trim links to avoid dead paths