### PR TITLE
refactor(security): make security options opt-in by default

### DIFF
--- a/boxlite/src/jailer/platform/linux/mod.rs
+++ b/boxlite/src/jailer/platform/linux/mod.rs
@@ -155,8 +155,10 @@ mod tests {
     fn test_apply_isolation_with_seccomp_disabled() {
         use crate::runtime::layout::FsLayoutConfig;
 
-        let mut security = SecurityOptions::default();
-        security.seccomp_enabled = false; // Disable seccomp
+        let security = SecurityOptions {
+            seccomp_enabled: false,
+            ..Default::default()
+        };
 
         let layout = FilesystemLayout::new(PathBuf::from("/tmp/test"), FsLayoutConfig::default());
 

--- a/boxlite/src/runtime/options.rs
+++ b/boxlite/src/runtime/options.rs
@@ -23,14 +23,14 @@ pub struct SecurityOptions {
     /// - Linux: seccomp, namespaces, chroot, privilege drop
     /// - macOS: sandbox-exec profile
     ///
-    /// Default: true on Linux, true on macOS (sandbox-exec only)
+    /// Default: false (use `SecurityOptions::standard()` or `maximum()` to enable)
     #[serde(default = "default_jailer_enabled")]
     pub jailer_enabled: bool,
 
     /// Enable seccomp syscall filtering (Linux only).
     ///
     /// When true, applies a whitelist of allowed syscalls.
-    /// Default: true on Linux, ignored on macOS
+    /// Default: false (use `SecurityOptions::standard()` or `maximum()` to enable)
     #[serde(default = "default_seccomp_enabled")]
     pub seccomp_enabled: bool,
 
@@ -143,11 +143,11 @@ pub struct ResourceLimits {
 // Default value functions for SecurityOptions
 
 fn default_jailer_enabled() -> bool {
-    cfg!(any(target_os = "linux", target_os = "macos"))
+    false
 }
 
 fn default_seccomp_enabled() -> bool {
-    cfg!(target_os = "linux")
+    false
 }
 
 fn default_chroot_base() -> PathBuf {
@@ -220,8 +220,13 @@ impl SecurityOptions {
     /// Standard mode: recommended for most use cases.
     ///
     /// Provides good security without being overly restrictive.
+    /// Enables jailer on Linux/macOS, seccomp on Linux.
     pub fn standard() -> Self {
-        Self::default()
+        Self {
+            jailer_enabled: cfg!(any(target_os = "linux", target_os = "macos")),
+            seccomp_enabled: cfg!(target_os = "linux"),
+            ..Default::default()
+        }
     }
 
     /// Maximum mode: all isolation features enabled.


### PR DESCRIPTION
## Summary
- Change `SecurityOptions` defaults so `jailer_enabled` and `seccomp_enabled` are `false` by default
- Update `SecurityOptions::standard()` to explicitly enable security features on supported platforms
- Minor test refactor to use struct initialization pattern

## Motivation
Makes security behavior more explicit and predictable. Users must consciously opt-in to security features via `SecurityOptions::standard()` or `SecurityOptions::maximum()` rather than having them enabled implicitly.

## Test plan
- [x] Existing tests pass
- [x] Test updated to use new default pattern