### PR TITLE
feat(jailer): implement Firecracker copy-to-jail pattern for shim isolation

### DIFF
--- a/boxlite/src/bin/shim.rs
+++ b/boxlite/src/bin/shim.rs
@@ -260,7 +260,7 @@ const GRACEFUL_SHUTDOWN_TIMEOUT_SECS: u64 = 5;
 /// Start a watchdog thread that monitors the parent process.
 ///
 /// If the parent process exits (clean exit or crash), this triggers shutdown:
-/// 1. First attempts graceful shutdown via SIGTERM
+/// 1. Immediately sends SIGTERM for graceful shutdown
 /// 2. Waits for timeout
 /// 3. Force kills via SIGKILL if still running
 ///
@@ -279,7 +279,6 @@ fn start_parent_watchdog(parent_pid: u32) {
                 );
 
                 // Step 1: Try graceful shutdown via SIGTERM
-                tracing::info!("Sending SIGTERM for graceful shutdown");
                 unsafe {
                     libc::kill(self_pid as i32, libc::SIGTERM);
                 }


### PR DESCRIPTION
## Summary

Implements Firecracker's copy-to-jail pattern for boxlite-shim isolation:

- **Copies shim binary and bundled libraries** (libkrun, libkrunfw, libgvproxy) into `~/.boxlite/boxes/{box_id}/bin/` instead of bind-mounting from external paths
- **Fixes "Permission denied" errors** when running as root (bwrap's user namespace behavior differs for root)
- **Uses copy (not hard-link)** to ensure complete memory isolation between boxes (no shared .text section via page cache)

### Security Improvements

| Before | After |
|--------|-------|
| Shim bind-mounted from external path | Shim copied per-box |
| Shared page cache between boxes | Complete memory isolation |
| Root user fails with permission denied | Works for both user and root |

### Box Directory Structure

```
~/.boxlite/boxes/{box_id}/
├── bin/
│   ├── boxlite-shim        (copied)
│   ├── libkrun.so.1.16.0   (copied)
│   ├── libkrunfw.so.5      (copied)
│   └── libgvproxy.so       (copied)
├── sockets/
├── shared/
└── *.qcow2
```

### Future Work

Added TODO comment for eliminating `/usr`, `/lib` bind mounts via static linking with musl (requires rebuilding libkrun and libgvproxy with musl).

## Test plan

- [x] Tested as regular user on Linux (boxlite-dev)
- [x] Tested as root on Linux (boxlite-dev)
- [x] All 6 simplebox examples pass