### PR TITLE
refactor(jailer): apply Rust API guidelines to jailer module

### DIFF
--- a/boxlite/src/jailer/builder.rs
+++ b/boxlite/src/jailer/builder.rs
@@ -1,0 +1,405 @@
+//! Jailer struct and builder pattern.
+//!
+//! This module provides the main `Jailer` type for process isolation,
+//! along with a fluent `JailerBuilder` for configuration.
+
+use crate::jailer::config::{ResourceLimits, SecurityOptions};
+use crate::runtime::options::VolumeSpec;
+use std::path::{Path, PathBuf};
+
+// ============================================================================
+// Jailer Struct
+// ============================================================================
+
+/// Jailer provides process isolation for boxlite-shim.
+///
+/// Encapsulates security configuration and provides methods for spawn-time
+/// isolation. All isolation (FD cleanup, rlimits, cgroups) is applied via
+/// `pre_exec` hook before exec, eliminating the attack window.
+///
+/// # Example
+///
+/// ```ignore
+/// use boxlite::jailer::{Jailer, JailerBuilder};
+///
+/// // Using constructor + builder pattern
+/// let jailer = Jailer::new(&box_id, &box_dir)
+///     .with_security(security);
+///
+/// // Or using JailerBuilder (non-consuming, C-BUILDER compliant)
+/// let jailer = JailerBuilder::new()
+///     .box_id(&box_id)
+///     .box_dir(&box_dir)
+///     .security(security)
+///     .build()?;
+///
+/// jailer.setup_pre_spawn()?;
+/// let cmd = jailer.build_command(&binary, &args);
+/// cmd.spawn()?;
+/// ```
+#[derive(Debug, Clone)]
+pub struct Jailer {
+    /// Security configuration options
+    pub(crate) security: SecurityOptions,
+    /// Volume mounts (for sandbox path restrictions)
+    pub(crate) volumes: Vec<VolumeSpec>,
+    /// Unique box identifier
+    pub(crate) box_id: String,
+    /// Box directory path
+    pub(crate) box_dir: PathBuf,
+}
+
+impl Jailer {
+    // ─────────────────────────────────────────────────────────────────────
+    // Constructors
+    // ─────────────────────────────────────────────────────────────────────
+
+    /// Create a new Jailer with default security options.
+    pub fn new(box_id: impl Into<String>, box_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            security: SecurityOptions::default(),
+            volumes: Vec::new(),
+            box_id: box_id.into(),
+            box_dir: box_dir.into(),
+        }
+    }
+
+    /// Create a builder for more flexible configuration.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let jailer = Jailer::builder()
+    ///     .box_id("my-box")
+    ///     .box_dir("/path/to/box")
+    ///     .security(SecurityOptions::standard())
+    ///     .build()?;
+    /// ```
+    pub fn builder() -> JailerBuilder {
+        JailerBuilder::new()
+    }
+
+    /// Set security options (consuming builder pattern - legacy API).
+    ///
+    /// Consider using `JailerBuilder` for more flexible configuration.
+    pub fn with_security(mut self, security: SecurityOptions) -> Self {
+        self.security = security;
+        self
+    }
+
+    /// Set volume mounts (consuming builder pattern - legacy API).
+    ///
+    /// Volumes are used for sandbox path restrictions (macOS).
+    /// All volumes are added to readable paths; writable volumes are also added to writable paths.
+    pub fn with_volumes(mut self, volumes: Vec<VolumeSpec>) -> Self {
+        self.volumes = volumes;
+        self
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Getters
+    // ─────────────────────────────────────────────────────────────────────
+
+    /// Get the security options.
+    pub fn security(&self) -> &SecurityOptions {
+        &self.security
+    }
+
+    /// Get mutable reference to security options.
+    pub fn security_mut(&mut self) -> &mut SecurityOptions {
+        &mut self.security
+    }
+
+    /// Get the volumes.
+    pub fn volumes(&self) -> &[VolumeSpec] {
+        &self.volumes
+    }
+
+    /// Get the box ID.
+    pub fn box_id(&self) -> &str {
+        &self.box_id
+    }
+
+    /// Get the box directory.
+    pub fn box_dir(&self) -> &Path {
+        &self.box_dir
+    }
+
+    /// Get the resource limits.
+    pub fn resource_limits(&self) -> &ResourceLimits {
+        &self.security.resource_limits
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Associated functions (static)
+    // ─────────────────────────────────────────────────────────────────────
+
+    /// Check if jailer isolation is supported on this platform.
+    pub fn is_supported() -> bool {
+        crate::jailer::platform::current().is_available()
+    }
+
+    /// Get the current platform name.
+    pub fn platform_name() -> &'static str {
+        crate::jailer::platform::current().name()
+    }
+}
+
+// ============================================================================
+// JailerBuilder (C-BUILDER compliant - non-consuming)
+// ============================================================================
+
+/// Builder for constructing a Jailer with custom options.
+///
+/// This builder follows the Rust API Guidelines C-BUILDER pattern:
+/// - Methods take `&mut self` and return `&mut Self` (non-consuming)
+/// - Supports both one-liner construction and complex conditional configuration
+///
+/// # Example (One-liner)
+///
+/// ```ignore
+/// let jailer = JailerBuilder::new()
+///     .box_id("my-box")
+///     .box_dir("/path/to/box")
+///     .security(SecurityOptions::standard())
+///     .build()?;
+/// ```
+///
+/// # Example (Complex Configuration)
+///
+/// ```ignore
+/// let mut builder = JailerBuilder::new();
+/// builder.box_id("my-box").box_dir("/path/to/box");
+///
+/// if enable_seccomp {
+///     let mut security = SecurityOptions::standard();
+///     security.seccomp_enabled = true;
+///     builder.security(security);
+/// }
+///
+/// let jailer = builder.build()?;
+/// ```
+#[derive(Debug, Clone)]
+pub struct JailerBuilder {
+    security: SecurityOptions,
+    volumes: Vec<VolumeSpec>,
+    box_id: Option<String>,
+    box_dir: Option<PathBuf>,
+}
+
+impl Default for JailerBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl JailerBuilder {
+    /// Create a new JailerBuilder with default settings.
+    pub fn new() -> Self {
+        Self {
+            security: SecurityOptions::default(),
+            volumes: Vec::new(),
+            box_id: None,
+            box_dir: None,
+        }
+    }
+
+    /// Set the box ID.
+    ///
+    /// # Arguments
+    /// * `id` - Unique identifier for this box
+    pub fn box_id(&mut self, id: impl Into<String>) -> &mut Self {
+        self.box_id = Some(id.into());
+        self
+    }
+
+    /// Set the box directory path.
+    ///
+    /// # Arguments
+    /// * `dir` - Path to the box's directory (e.g., `~/.boxlite/boxes/{box_id}`)
+    pub fn box_dir(&mut self, dir: impl Into<PathBuf>) -> &mut Self {
+        self.box_dir = Some(dir.into());
+        self
+    }
+
+    /// Set security options.
+    ///
+    /// # Arguments
+    /// * `security` - Security configuration (use presets like `SecurityOptions::standard()`)
+    pub fn security(&mut self, security: SecurityOptions) -> &mut Self {
+        self.security = security;
+        self
+    }
+
+    /// Set volume mounts.
+    ///
+    /// Volumes are used for sandbox path restrictions (macOS).
+    /// All volumes are added to readable paths; writable volumes are also added to writable paths.
+    ///
+    /// # Arguments
+    /// * `volumes` - List of volume specifications
+    pub fn volumes(&mut self, volumes: Vec<VolumeSpec>) -> &mut Self {
+        self.volumes = volumes;
+        self
+    }
+
+    /// Add a single volume mount.
+    ///
+    /// # Arguments
+    /// * `volume` - Volume specification to add
+    pub fn add_volume(&mut self, volume: VolumeSpec) -> &mut Self {
+        self.volumes.push(volume);
+        self
+    }
+
+    /// Enable or disable jailer isolation.
+    ///
+    /// Shorthand for modifying `security.jailer_enabled`.
+    pub fn jailer_enabled(&mut self, enabled: bool) -> &mut Self {
+        self.security.jailer_enabled = enabled;
+        self
+    }
+
+    /// Enable or disable seccomp filtering (Linux only).
+    ///
+    /// Shorthand for modifying `security.seccomp_enabled`.
+    pub fn seccomp_enabled(&mut self, enabled: bool) -> &mut Self {
+        self.security.seccomp_enabled = enabled;
+        self
+    }
+
+    /// Build the Jailer.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`JailerError::Config`] with [`ConfigError::InvalidConfig`] if:
+    /// - `box_id` was not set
+    /// - `box_dir` was not set
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let jailer = JailerBuilder::new()
+    ///     .box_id("my-box")
+    ///     .box_dir("/path/to/box")
+    ///     .build()?;
+    /// ```
+    pub fn build(&self) -> Result<Jailer, crate::jailer::JailerError> {
+        let box_id = self.box_id.clone().ok_or_else(|| {
+            crate::jailer::ConfigError::InvalidConfig("box_id is required".to_string())
+        })?;
+
+        let box_dir = self.box_dir.clone().ok_or_else(|| {
+            crate::jailer::ConfigError::InvalidConfig("box_dir is required".to_string())
+        })?;
+
+        Ok(Jailer {
+            security: self.security.clone(),
+            volumes: self.volumes.clone(),
+            box_id,
+            box_dir,
+        })
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_jailer_new() {
+        let jailer = Jailer::new("test-box", "/tmp/box");
+        assert_eq!(jailer.box_id(), "test-box");
+        assert_eq!(jailer.box_dir(), Path::new("/tmp/box"));
+    }
+
+    #[test]
+    fn test_jailer_with_security() {
+        let security = SecurityOptions::standard();
+        let jailer = Jailer::new("test-box", "/tmp/box").with_security(security);
+        assert!(jailer.security().jailer_enabled);
+    }
+
+    #[test]
+    fn test_builder_basic() {
+        let jailer = JailerBuilder::new()
+            .box_id("test-box")
+            .box_dir("/tmp/box")
+            .build()
+            .expect("Should build successfully");
+
+        assert_eq!(jailer.box_id(), "test-box");
+        assert_eq!(jailer.box_dir(), Path::new("/tmp/box"));
+    }
+
+    #[test]
+    fn test_builder_missing_box_id() {
+        let result = JailerBuilder::new().box_dir("/tmp/box").build();
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("box_id"));
+    }
+
+    #[test]
+    fn test_builder_missing_box_dir() {
+        let result = JailerBuilder::new().box_id("test-box").build();
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("box_dir"));
+    }
+
+    #[test]
+    fn test_builder_with_security() {
+        let jailer = JailerBuilder::new()
+            .box_id("test-box")
+            .box_dir("/tmp/box")
+            .security(SecurityOptions::maximum())
+            .build()
+            .expect("Should build successfully");
+
+        assert!(jailer.security().jailer_enabled);
+    }
+
+    #[test]
+    fn test_builder_non_consuming() {
+        // Verify that builder methods return &mut Self (non-consuming)
+        let mut builder = JailerBuilder::new();
+
+        // Should be able to call methods separately without move
+        builder.box_id("test-box");
+        builder.box_dir("/tmp/box");
+
+        // And still access builder after calls
+        builder.jailer_enabled(true);
+
+        let jailer = builder.build().expect("Should build successfully");
+        assert!(jailer.security().jailer_enabled);
+    }
+
+    #[test]
+    fn test_builder_add_volume() {
+        let jailer = JailerBuilder::new()
+            .box_id("test-box")
+            .box_dir("/tmp/box")
+            .add_volume(VolumeSpec {
+                host_path: "/data".to_string(),
+                guest_path: "/mnt/data".to_string(),
+                read_only: true,
+            })
+            .add_volume(VolumeSpec {
+                host_path: "/output".to_string(),
+                guest_path: "/mnt/output".to_string(),
+                read_only: false,
+            })
+            .build()
+            .expect("Should build successfully");
+
+        assert_eq!(jailer.volumes().len(), 2);
+    }
+}

--- a/boxlite/src/jailer/cgroup.rs
+++ b/boxlite/src/jailer/cgroup.rs
@@ -142,6 +142,14 @@ pub fn cgroup_path(box_id: &str) -> PathBuf {
 ///
 /// Creates the cgroup directory and configures resource limits.
 /// Must be called BEFORE spawning the process.
+///
+/// # Errors
+///
+/// Returns [`JailerError::Cgroup`] if:
+/// - Cgroup v2 is not available on the system
+/// - Failed to create the boxlite parent cgroup directory
+/// - Failed to create the box-specific cgroup directory
+/// - Failed to write resource limit configuration files
 pub fn setup_cgroup(box_id: &str, config: &CgroupConfig) -> Result<PathBuf, JailerError> {
     if !is_cgroup_v2_available() {
         tracing::warn!("Cgroup v2 not available, skipping cgroup setup");

--- a/boxlite/src/jailer/command.rs
+++ b/boxlite/src/jailer/command.rs
@@ -1,0 +1,314 @@
+//! Command building for isolated process execution.
+//!
+//! This module provides the command building logic for spawning
+//! boxlite-shim in an isolated environment.
+//!
+//! # Platform-specific Behavior
+//!
+//! - **Linux**: Wraps with bubblewrap (bwrap) for namespace isolation
+//! - **macOS**: Wraps with sandbox-exec for Seatbelt sandbox
+//! - **Other**: Falls back to direct execution with rlimits only
+//!
+//! # Pre-exec Hook
+//!
+//! All commands include a `pre_exec` hook that runs after `fork()` but
+//! before `exec()`. This hook applies:
+//! - FD cleanup (closes inherited file descriptors)
+//! - Resource limits (rlimits)
+//! - Cgroup membership (Linux only)
+
+use crate::jailer::builder::Jailer;
+use crate::jailer::pre_exec;
+use std::path::Path;
+use std::process::Command;
+
+impl Jailer {
+    // ─────────────────────────────────────────────────────────────────────
+    // Primary API (spawn-time)
+    // ─────────────────────────────────────────────────────────────────────
+
+    /// Setup pre-spawn isolation (cgroups on Linux, no-op on macOS).
+    ///
+    /// Call this before `build_command()` to set up isolation that
+    /// must be configured from the parent process.
+    ///
+    /// On Linux, this creates the cgroup directory and configures resource limits.
+    /// The child process will add itself to the cgroup in the pre_exec hook.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if cgroup creation fails on Linux. On macOS, this
+    /// function always succeeds (no-op).
+    ///
+    /// Note: Cgroup failures are treated as warnings, not errors, to allow
+    /// boxes to run without cgroup limits if the system doesn't support them.
+    pub fn setup_pre_spawn(&self) -> boxlite_shared::errors::BoxliteResult<()> {
+        #[cfg(target_os = "linux")]
+        {
+            use crate::jailer::cgroup::{CgroupConfig, setup_cgroup};
+
+            let cgroup_config = CgroupConfig::from(&self.security.resource_limits);
+
+            match setup_cgroup(&self.box_id, &cgroup_config) {
+                Ok(path) => {
+                    tracing::info!(
+                        box_id = %self.box_id,
+                        path = %path.display(),
+                        "Cgroup created for box"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        box_id = %self.box_id,
+                        error = %e,
+                        "Cgroup setup failed (continuing without cgroup limits)"
+                    );
+                }
+            }
+        }
+
+        #[cfg(target_os = "macos")]
+        {
+            tracing::debug!(
+                box_id = %self.box_id,
+                "Pre-spawn isolation: no-op on macOS (no cgroups)"
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Build an isolated command that wraps the given binary.
+    ///
+    /// On Linux: wraps with bwrap for namespace isolation
+    /// On macOS: wraps with sandbox-exec for Seatbelt sandbox
+    ///
+    /// The command includes a `pre_exec` hook that closes inherited file
+    /// descriptors before any code runs, eliminating the attack window.
+    ///
+    /// # Arguments
+    ///
+    /// * `binary` - Path to the shim binary to execute
+    /// * `args` - Arguments to pass to the shim
+    ///
+    /// # Returns
+    ///
+    /// A `Command` configured with appropriate isolation for the platform.
+    pub fn build_command(&self, binary: &Path, args: &[String]) -> Command {
+        #[cfg(target_os = "linux")]
+        {
+            self.build_command_linux(binary, args)
+        }
+        #[cfg(target_os = "macos")]
+        {
+            self.build_command_macos(binary, args)
+        }
+        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+        {
+            self.build_command_direct(binary, args)
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Linux command building
+    // ─────────────────────────────────────────────────────────────────────
+
+    #[cfg(target_os = "linux")]
+    fn build_command_linux(&self, binary: &Path, args: &[String]) -> Command {
+        use crate::jailer::{bwrap, cgroup};
+
+        let mut cmd = if bwrap::is_available() {
+            tracing::info!("Building bwrap-isolated command");
+            self.build_bwrap_command(binary, args)
+        } else {
+            tracing::warn!("bwrap not available, using direct command");
+            let mut cmd = Command::new(binary);
+            cmd.args(args);
+            cmd
+        };
+
+        let resource_limits = self.security.resource_limits.clone();
+        let cgroup_procs_path = cgroup::build_cgroup_procs_path(&self.box_id);
+
+        pre_exec::add_pre_exec_hook(&mut cmd, resource_limits, cgroup_procs_path);
+        cmd
+    }
+
+    #[cfg(target_os = "linux")]
+    fn build_bwrap_command(&self, binary: &Path, args: &[String]) -> Command {
+        use crate::jailer::{bwrap, shim_copy};
+
+        // =====================================================================
+        // Firecracker pattern: Copy shim binary and libraries to box directory
+        // =====================================================================
+        // This ensures:
+        // 1. No external bind mounts needed (works with root user)
+        // 2. Complete memory isolation between boxes (no shared .text section)
+        // 3. Each box has its own copy of the shim and libraries
+
+        let (shim_binary, bin_dir) = match shim_copy::copy_shim_to_box(binary, &self.box_dir) {
+            Ok(copied_shim) => {
+                let bin_dir = copied_shim.parent().unwrap_or(&self.box_dir).to_path_buf();
+                tracing::info!(
+                    original = %binary.display(),
+                    copied = %copied_shim.display(),
+                    "Using copied shim binary (Firecracker pattern)"
+                );
+                (copied_shim, bin_dir)
+            }
+            Err(e) => {
+                // Fallback to original binary if copy fails
+                tracing::warn!(
+                    error = %e,
+                    "Failed to copy shim to box directory, using original"
+                );
+                let bin_dir = binary.parent().unwrap_or(binary).to_path_buf();
+                (binary.to_path_buf(), bin_dir)
+            }
+        };
+
+        let mut bwrap = bwrap::BwrapCommand::new();
+
+        // =====================================================================
+        // Namespace and session isolation
+        // =====================================================================
+        bwrap
+            .with_default_namespaces()
+            .with_die_with_parent()
+            .with_new_session();
+
+        // =====================================================================
+        // System directories (read-only)
+        // =====================================================================
+        // TODO(security): Eliminate /usr, /lib, /bin, /sbin bind mounts by statically
+        // linking boxlite-shim with musl. This requires:
+        // 1. Build libkrun with musl (CC=musl-gcc)
+        // 2. Build libgvproxy with musl (CGO_ENABLED=1 CC=musl-gcc)
+        // 3. Build boxlite-shim with --target x86_64-unknown-linux-musl
+        // 4. Remove these ro_bind_if_exists calls below
+        bwrap
+            .ro_bind_if_exists("/usr", "/usr")
+            .ro_bind_if_exists("/lib", "/lib")
+            .ro_bind_if_exists("/lib64", "/lib64")
+            .ro_bind_if_exists("/bin", "/bin")
+            .ro_bind_if_exists("/sbin", "/sbin");
+
+        // =====================================================================
+        // Devices and special mounts
+        // =====================================================================
+        bwrap
+            .with_dev()
+            .dev_bind_if_exists("/dev/kvm", "/dev/kvm")
+            .dev_bind_if_exists("/dev/net/tun", "/dev/net/tun")
+            .with_proc()
+            .tmpfs("/tmp");
+
+        // =====================================================================
+        // Mount minimal directories for security isolation
+        // =====================================================================
+        // Only this box's directory and required runtime directories are accessible
+
+        // 1. Mount this box's directory (read-write)
+        //    Contains: bin/, sockets/, shared/, disk.qcow2, guest-rootfs.qcow2
+        //    The shim binary and libraries are now INSIDE this directory
+        bwrap.bind(&self.box_dir, &self.box_dir);
+        tracing::debug!(box_dir = %self.box_dir.display(), "bwrap: mounted box directory");
+
+        // Get boxlite home directory for other mounts
+        if let Some(boxes_dir) = self.box_dir.parent()
+            && let Some(home_dir) = boxes_dir.parent()
+        {
+            // 2. Mount logs directory (read-write for shim logging + console output)
+            let logs_dir = home_dir.join("logs");
+            if logs_dir.exists() {
+                bwrap.bind(&logs_dir, &logs_dir);
+                tracing::debug!(logs_dir = %logs_dir.display(), "bwrap: mounted logs directory");
+            }
+
+            // 3. Mount tmp directory (read-write for rootfs preparation)
+            //    Contains: temporary rootfs mounts during box creation
+            let tmp_dir = home_dir.join("tmp");
+            if tmp_dir.exists() {
+                bwrap.bind(&tmp_dir, &tmp_dir);
+                tracing::debug!(tmp_dir = %tmp_dir.display(), "bwrap: mounted tmp directory");
+            }
+
+            // 4. Mount images directory (read-only for extracted OCI layers)
+            //    Contains: extracted layer data used for rootfs
+            let images_dir = home_dir.join("images");
+            if images_dir.exists() {
+                bwrap.ro_bind(&images_dir, &images_dir);
+                tracing::debug!(images_dir = %images_dir.display(), "bwrap: mounted images directory (ro)");
+            }
+        }
+
+        // NOTE: No external shim directory bind mount needed!
+        // The shim and libraries are now copied into box_dir/bin/
+
+        // =====================================================================
+        // Environment sanitization
+        // =====================================================================
+        bwrap
+            .with_clearenv()
+            .setenv("PATH", "/usr/bin:/bin:/usr/sbin:/sbin")
+            .setenv("HOME", "/root");
+
+        // Set LD_LIBRARY_PATH to the copied libraries directory
+        // This is inside box_dir, so no external bind mount needed
+        bwrap.setenv("LD_LIBRARY_PATH", bin_dir.to_string_lossy().to_string());
+        tracing::debug!(ld_library_path = %bin_dir.display(), "Set LD_LIBRARY_PATH to copied libs directory");
+
+        // Preserve RUST_LOG for debugging
+        if let Ok(rust_log) = std::env::var("RUST_LOG") {
+            bwrap.setenv("RUST_LOG", rust_log);
+        }
+
+        bwrap.chdir("/");
+
+        bwrap.build(&shim_binary, args)
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // macOS command building
+    // ─────────────────────────────────────────────────────────────────────
+
+    #[cfg(target_os = "macos")]
+    fn build_command_macos(&self, binary: &Path, args: &[String]) -> Command {
+        use crate::jailer::platform::macos;
+
+        let mut cmd = if macos::is_sandbox_available() {
+            tracing::info!("Building sandbox-exec isolated command");
+            let (sandbox_cmd, sandbox_args) =
+                macos::get_sandbox_exec_args(&self.security, &self.box_dir, binary, &self.volumes);
+            let mut cmd = Command::new(sandbox_cmd);
+            cmd.args(sandbox_args);
+            cmd.arg(binary);
+            cmd.args(args);
+            cmd
+        } else {
+            tracing::warn!("sandbox-exec not available, using direct command");
+            let mut cmd = Command::new(binary);
+            cmd.args(args);
+            cmd
+        };
+
+        let resource_limits = self.security.resource_limits.clone();
+        pre_exec::add_pre_exec_hook(&mut cmd, resource_limits, None);
+        cmd
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Fallback for unsupported platforms
+    // ─────────────────────────────────────────────────────────────────────
+
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    fn build_command_direct(&self, binary: &Path, args: &[String]) -> Command {
+        tracing::warn!("No sandbox available on this platform");
+        let mut cmd = Command::new(binary);
+        cmd.args(args);
+
+        let resource_limits = self.security.resource_limits.clone();
+        pre_exec::add_pre_exec_hook(&mut cmd, resource_limits, None);
+        cmd
+    }
+}

--- a/boxlite/src/jailer/common/fs.rs
+++ b/boxlite/src/jailer/common/fs.rs
@@ -1,0 +1,154 @@
+//! Filesystem utilities for the jailer module.
+//!
+//! Cross-platform file operations used by the jailer.
+
+use std::fs;
+use std::io;
+use std::path::Path;
+
+/// Copy a file if the source is newer or sizes differ.
+///
+/// This implements a simple "copy-if-newer" pattern to avoid unnecessary
+/// file copies when the destination already has an up-to-date version.
+///
+/// # Arguments
+///
+/// * `src` - Source file path
+/// * `dest` - Destination file path
+///
+/// # Returns
+///
+/// * `Ok(true)` - File was copied
+/// * `Ok(false)` - File was skipped (destination is up-to-date)
+/// * `Err(e)` - Copy failed
+///
+/// # Example
+///
+/// ```ignore
+/// use boxlite::jailer::common::fs::copy_if_newer;
+///
+/// let copied = copy_if_newer("/path/to/src", "/path/to/dest")?;
+/// if copied {
+///     println!("File was copied");
+/// } else {
+///     println!("File was already up-to-date");
+/// }
+/// ```
+#[allow(dead_code)] // Utility function for future DRY refactoring
+pub fn copy_if_newer(src: &Path, dest: &Path) -> io::Result<bool> {
+    let should_copy = should_copy_file(src, dest);
+
+    if should_copy {
+        fs::copy(src, dest)?;
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}
+
+/// Check if a file should be copied based on modification time and size.
+///
+/// Returns `true` if:
+/// - Destination doesn't exist
+/// - Source is newer than destination
+/// - Source and destination have different sizes
+#[allow(dead_code)] // Used by copy_if_newer
+fn should_copy_file(src: &Path, dest: &Path) -> bool {
+    if !dest.exists() {
+        return true;
+    }
+
+    let src_meta = fs::metadata(src).ok();
+    let dst_meta = fs::metadata(dest).ok();
+
+    match (src_meta, dst_meta) {
+        (Some(src), Some(dst)) => {
+            // Copy if source is newer or sizes differ
+            src.modified().ok() > dst.modified().ok() || src.len() != dst.len()
+        }
+        // If we can't read metadata, copy to be safe
+        _ => true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_copy_if_newer_new_file() {
+        let dir = tempdir().unwrap();
+        let src = dir.path().join("src.txt");
+        let dest = dir.path().join("dest.txt");
+
+        fs::write(&src, "hello").unwrap();
+
+        let copied = copy_if_newer(&src, &dest).unwrap();
+        assert!(copied, "Should copy new file");
+        assert!(dest.exists(), "Destination should exist");
+        assert_eq!(fs::read_to_string(&dest).unwrap(), "hello");
+    }
+
+    #[test]
+    fn test_copy_if_newer_same_content() {
+        let dir = tempdir().unwrap();
+        let src = dir.path().join("src.txt");
+        let dest = dir.path().join("dest.txt");
+
+        fs::write(&src, "hello").unwrap();
+        fs::copy(&src, &dest).unwrap();
+
+        // Small delay to ensure timestamps could differ if copied
+        std::thread::sleep(std::time::Duration::from_millis(10));
+
+        let copied = copy_if_newer(&src, &dest).unwrap();
+        assert!(!copied, "Should not copy identical file");
+    }
+
+    #[test]
+    fn test_copy_if_newer_different_size() {
+        let dir = tempdir().unwrap();
+        let src = dir.path().join("src.txt");
+        let dest = dir.path().join("dest.txt");
+
+        fs::write(&src, "hello world").unwrap();
+        fs::write(&dest, "hi").unwrap();
+
+        let copied = copy_if_newer(&src, &dest).unwrap();
+        assert!(copied, "Should copy when sizes differ");
+        assert_eq!(fs::read_to_string(&dest).unwrap(), "hello world");
+    }
+
+    #[test]
+    fn test_copy_if_newer_source_newer() {
+        let dir = tempdir().unwrap();
+        let src = dir.path().join("src.txt");
+        let dest = dir.path().join("dest.txt");
+
+        // Create dest first
+        fs::write(&dest, "old").unwrap();
+
+        // Wait a bit, then create src
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        fs::write(&src, "new").unwrap();
+
+        let copied = copy_if_newer(&src, &dest).unwrap();
+        assert!(copied, "Should copy newer source");
+        assert_eq!(fs::read_to_string(&dest).unwrap(), "new");
+    }
+
+    #[test]
+    fn test_should_copy_file_nonexistent_dest() {
+        let dir = tempdir().unwrap();
+        let src = dir.path().join("src.txt");
+        let dest = dir.path().join("dest.txt");
+
+        fs::write(&src, "hello").unwrap();
+
+        assert!(
+            should_copy_file(&src, &dest),
+            "Should copy when dest doesn't exist"
+        );
+    }
+}

--- a/boxlite/src/jailer/common/mod.rs
+++ b/boxlite/src/jailer/common/mod.rs
@@ -1,12 +1,14 @@
 //! Cross-platform jailer utilities.
 //!
-//! These modules provide async-signal-safe operations for the `pre_exec` hook:
-//! - [`fd`]: File descriptor cleanup
-//! - [`rlimit`]: Resource limit management
+//! These modules provide:
+//! - [`fd`]: File descriptor cleanup (async-signal-safe for pre_exec)
+//! - [`rlimit`]: Resource limit management (async-signal-safe for pre_exec)
+//! - [`fs`]: Filesystem utilities (copy-if-newer, etc.)
 //!
 //! Note: Environment sanitization is handled by bwrap/sandbox-exec at spawn time.
 
 pub mod fd;
+pub mod fs;
 pub mod rlimit;
 
 /// Get errno in an async-signal-safe way.

--- a/boxlite/src/jailer/mod.rs
+++ b/boxlite/src/jailer/mod.rs
@@ -9,12 +9,22 @@
 //!
 //! ```text
 //! jailer/
-//! ├── mod.rs          (public API)
-//! ├── config/         (SecurityOptions, ResourceLimits)
-//! ├── error.rs        (hierarchical error types)
-//! ├── common/         (cross-platform: env, fd, rlimit)
+//! ├── mod.rs          (public API - this file)
+//! ├── builder.rs      (Jailer struct, JailerBuilder)
+//! ├── command.rs      (Command building for isolated processes)
+//! ├── pre_exec.rs     (Pre-exec hook for process isolation)
+//! ├── shim_copy.rs    (Firecracker copy-to-jail pattern)
+//! ├── config.rs       (Re-exports SecurityOptions, ResourceLimits)
+//! ├── error.rs        (Hierarchical error types)
+//! ├── seccomp.rs      (Seccomp BPF filter generation)
+//! ├── bwrap.rs        (Bubblewrap command builder)
+//! ├── cgroup.rs       (Cgroup v2 setup - Linux only)
+//! ├── common/         (Cross-platform utilities)
+//! │   ├── fd.rs       (File descriptor cleanup)
+//! │   ├── fs.rs       (Filesystem utilities)
+//! │   └── rlimit.rs   (Resource limit management)
 //! └── platform/       (PlatformIsolation trait)
-//!     ├── linux/      (namespaces, seccomp, chroot)
+//!     ├── linux/      (Namespaces, seccomp, chroot)
 //!     └── macos/      (sandbox-exec/Seatbelt)
 //! ```
 //!
@@ -34,546 +44,66 @@
 //! # Usage
 //!
 //! ```ignore
-//! // In spawn.rs (parent process)
+//! // Using the legacy API
 //! let jailer = Jailer::new(&box_id, &box_dir)
 //!     .with_security(security);
+//!
+//! // Or using JailerBuilder (C-BUILDER compliant)
+//! let jailer = Jailer::builder()
+//!     .box_id(&box_id)
+//!     .box_dir(&box_dir)
+//!     .security(security)
+//!     .build()?;
 //!
 //! jailer.setup_pre_spawn()?;  // Create cgroup (Linux)
 //! let cmd = jailer.build_command(&binary, &args);  // Includes pre_exec hook
 //! cmd.spawn()?;
 //! ```
 
+// ============================================================================
+// Module declarations
+// ============================================================================
+
+// Core modules
+mod builder;
+mod command;
 mod common;
 mod config;
 mod error;
+mod pre_exec;
+
+// Platform-specific modules
 pub mod platform;
-
-// Cgroup module (Linux only)
-#[cfg(target_os = "linux")]
-mod cgroup;
-
-// Seccomp module (cross-platform definitions, Linux-only implementation)
 pub mod seccomp;
 
-// Re-export bwrap utilities (Linux spawn integration)
-mod bwrap;
+// Linux-only modules
+#[cfg(target_os = "linux")]
+pub(crate) mod bwrap;
+#[cfg(target_os = "linux")]
+pub(crate) mod cgroup;
+#[cfg(target_os = "linux")]
+pub(crate) mod shim_copy;
+
+// ============================================================================
+// Public re-exports
+// ============================================================================
+
+// Core types
+pub use builder::{Jailer, JailerBuilder};
+pub use config::{ResourceLimits, SecurityOptions};
+pub use error::{ConfigError, IsolationError, JailerError, SystemError};
+pub use platform::{PlatformIsolation, SpawnIsolation};
+
+// Volume specification (convenience re-export)
+pub use crate::runtime::options::VolumeSpec;
+
+// Linux-specific exports
 #[cfg(target_os = "linux")]
 pub use bwrap::{build_shim_command, is_available as is_bwrap_available};
 
-// Re-export macOS sandbox utilities (spawn integration)
+// macOS-specific exports
 #[cfg(target_os = "macos")]
 pub use platform::macos::{
     SANDBOX_EXEC_PATH, get_base_policy, get_network_policy, get_sandbox_exec_args,
     is_sandbox_available,
 };
-
-// Public types
-pub use config::{ResourceLimits, SecurityOptions};
-pub use error::{ConfigError, IsolationError, JailerError, SystemError};
-pub use platform::{PlatformIsolation, SpawnIsolation};
-
-#[cfg(target_os = "linux")]
-use boxlite_shared::errors::BoxliteError;
-use boxlite_shared::errors::BoxliteResult;
-
-// ============================================================================
-// Shim Copy Utilities (Firecracker pattern)
-// ============================================================================
-
-use std::path::{Path, PathBuf};
-use std::process::Command;
-
-/// Copy shim binary and bundled libraries to box directory for jail isolation.
-///
-/// This follows Firecracker's approach: copy (not hard-link) binaries into the
-/// jail directory to ensure complete memory isolation between boxes.
-///
-/// Returns the path to the copied shim binary.
-#[cfg(target_os = "linux")]
-fn copy_shim_to_box(shim_path: &Path, box_dir: &Path) -> BoxliteResult<PathBuf> {
-    let bin_dir = box_dir.join("bin");
-    std::fs::create_dir_all(&bin_dir).map_err(|e| {
-        BoxliteError::Storage(format!(
-            "Failed to create bin directory {}: {}",
-            bin_dir.display(),
-            e
-        ))
-    })?;
-
-    // Copy shim binary
-    let shim_name = shim_path.file_name().unwrap_or_default();
-    let dest_shim = bin_dir.join(shim_name);
-
-    // Only copy if not already present or source is newer
-    let should_copy = if dest_shim.exists() {
-        let src_meta = std::fs::metadata(shim_path).ok();
-        let dst_meta = std::fs::metadata(&dest_shim).ok();
-        match (src_meta, dst_meta) {
-            (Some(src), Some(dst)) => {
-                src.modified().ok() > dst.modified().ok() || src.len() != dst.len()
-            }
-            _ => true,
-        }
-    } else {
-        true
-    };
-
-    if should_copy {
-        std::fs::copy(shim_path, &dest_shim).map_err(|e| {
-            BoxliteError::Storage(format!(
-                "Failed to copy shim {} to {}: {}",
-                shim_path.display(),
-                dest_shim.display(),
-                e
-            ))
-        })?;
-        tracing::debug!(
-            src = %shim_path.display(),
-            dst = %dest_shim.display(),
-            "Copied shim binary to box directory"
-        );
-    }
-
-    // Copy bundled libraries from shim's directory
-    if let Some(shim_dir) = shim_path.parent() {
-        copy_bundled_libraries(shim_dir, &bin_dir)?;
-    }
-
-    Ok(dest_shim)
-}
-
-/// Copy bundled libraries (libkrun, libkrunfw, libgvproxy) to destination.
-#[cfg(target_os = "linux")]
-fn copy_bundled_libraries(src_dir: &Path, dest_dir: &Path) -> BoxliteResult<()> {
-    let lib_patterns = ["libkrun.so", "libkrunfw.so", "libgvproxy.so"];
-
-    if let Ok(entries) = std::fs::read_dir(src_dir) {
-        for entry in entries.filter_map(|e| e.ok()) {
-            let name = entry.file_name();
-            let name_str = name.to_string_lossy();
-
-            // Check if this file matches any of our library patterns
-            if lib_patterns.iter().any(|p| name_str.starts_with(p)) {
-                let src_path = entry.path();
-                let dest_path = dest_dir.join(&name);
-
-                // Only copy if not already present or source is newer
-                let should_copy = if dest_path.exists() {
-                    let src_meta = std::fs::metadata(&src_path).ok();
-                    let dst_meta = std::fs::metadata(&dest_path).ok();
-                    match (src_meta, dst_meta) {
-                        (Some(src), Some(dst)) => {
-                            src.modified().ok() > dst.modified().ok() || src.len() != dst.len()
-                        }
-                        _ => true,
-                    }
-                } else {
-                    true
-                };
-
-                if should_copy {
-                    std::fs::copy(&src_path, &dest_path).map_err(|e| {
-                        BoxliteError::Storage(format!(
-                            "Failed to copy library {} to {}: {}",
-                            src_path.display(),
-                            dest_path.display(),
-                            e
-                        ))
-                    })?;
-                    tracing::debug!(
-                        lib = %name_str,
-                        dst = %dest_path.display(),
-                        "Copied bundled library to box directory"
-                    );
-                }
-            }
-        }
-    }
-
-    Ok(())
-}
-
-// ============================================================================
-// Jailer Struct
-// ============================================================================
-
-/// Jailer provides process isolation for boxlite-shim.
-///
-/// Encapsulates security configuration and provides methods for spawn-time
-/// isolation. All isolation (FD cleanup, rlimits, cgroups) is applied via
-/// `pre_exec` hook before exec, eliminating the attack window.
-///
-/// # Example
-///
-/// ```ignore
-/// use boxlite::jailer::Jailer;
-///
-/// // In spawn.rs (parent process)
-/// let jailer = Jailer::new(&box_id, &box_dir)
-///     .with_security(security);
-///
-/// jailer.setup_pre_spawn()?;  // Create cgroup (Linux)
-/// let cmd = jailer.build_command(&binary, &args);  // Includes pre_exec hook
-/// cmd.spawn()?;
-/// ```
-/// Volume specification (re-exported for convenience).
-pub use crate::runtime::options::VolumeSpec;
-
-#[derive(Debug, Clone)]
-pub struct Jailer {
-    /// Security configuration options
-    security: SecurityOptions,
-    /// Volume mounts (for sandbox path restrictions)
-    volumes: Vec<VolumeSpec>,
-    /// Unique box identifier
-    box_id: String,
-    /// Box directory path
-    box_dir: PathBuf,
-}
-
-impl Jailer {
-    // ─────────────────────────────────────────────────────────────────────
-    // Constructors
-    // ─────────────────────────────────────────────────────────────────────
-
-    /// Create a new Jailer with default security options.
-    pub fn new(box_id: impl Into<String>, box_dir: impl Into<PathBuf>) -> Self {
-        Self {
-            security: SecurityOptions::default(),
-            volumes: Vec::new(),
-            box_id: box_id.into(),
-            box_dir: box_dir.into(),
-        }
-    }
-
-    /// Set security options (builder pattern).
-    pub fn with_security(mut self, security: SecurityOptions) -> Self {
-        self.security = security;
-        self
-    }
-
-    /// Set volume mounts (builder pattern).
-    ///
-    /// Volumes are used for sandbox path restrictions (macOS).
-    /// All volumes are added to readable paths; writable volumes are also added to writable paths.
-    pub fn with_volumes(mut self, volumes: Vec<VolumeSpec>) -> Self {
-        self.volumes = volumes;
-        self
-    }
-
-    // ─────────────────────────────────────────────────────────────────────
-    // Getters
-    // ─────────────────────────────────────────────────────────────────────
-
-    /// Get the security options.
-    pub fn security(&self) -> &SecurityOptions {
-        &self.security
-    }
-
-    /// Get mutable reference to security options.
-    pub fn security_mut(&mut self) -> &mut SecurityOptions {
-        &mut self.security
-    }
-
-    /// Get the box ID.
-    pub fn box_id(&self) -> &str {
-        &self.box_id
-    }
-
-    /// Get the box directory.
-    pub fn box_dir(&self) -> &Path {
-        &self.box_dir
-    }
-
-    // ─────────────────────────────────────────────────────────────────────
-    // Primary API (spawn-time)
-    // ─────────────────────────────────────────────────────────────────────
-
-    /// Setup pre-spawn isolation (cgroups on Linux, no-op on macOS).
-    ///
-    /// Call this before `build_command()` to set up isolation that
-    /// must be configured from the parent process.
-    ///
-    /// On Linux, this creates the cgroup directory and configures resource limits.
-    /// The child process will add itself to the cgroup in the pre_exec hook.
-    pub fn setup_pre_spawn(&self) -> BoxliteResult<()> {
-        #[cfg(target_os = "linux")]
-        {
-            use crate::jailer::cgroup::{CgroupConfig, setup_cgroup};
-
-            let cgroup_config = CgroupConfig::from(&self.security.resource_limits);
-
-            match setup_cgroup(&self.box_id, &cgroup_config) {
-                Ok(path) => {
-                    tracing::info!(
-                        box_id = %self.box_id,
-                        path = %path.display(),
-                        "Cgroup created for box"
-                    );
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        box_id = %self.box_id,
-                        error = %e,
-                        "Cgroup setup failed (continuing without cgroup limits)"
-                    );
-                }
-            }
-        }
-
-        #[cfg(target_os = "macos")]
-        {
-            tracing::debug!(
-                box_id = %self.box_id,
-                "Pre-spawn isolation: no-op on macOS (no cgroups)"
-            );
-        }
-
-        Ok(())
-    }
-
-    /// Build an isolated command that wraps the given binary.
-    ///
-    /// On Linux: wraps with bwrap for namespace isolation
-    /// On macOS: wraps with sandbox-exec for Seatbelt sandbox
-    ///
-    /// The command includes a `pre_exec` hook that closes inherited file
-    /// descriptors before any code runs, eliminating the attack window.
-    pub fn build_command(&self, binary: &Path, args: &[String]) -> Command {
-        #[cfg(target_os = "linux")]
-        {
-            self.build_command_linux(binary, args)
-        }
-        #[cfg(target_os = "macos")]
-        {
-            self.build_command_macos(binary, args)
-        }
-        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
-        {
-            self.build_command_direct(binary, args)
-        }
-    }
-
-    // ─────────────────────────────────────────────────────────────────────
-    // Private platform implementations
-    // ─────────────────────────────────────────────────────────────────────
-
-    #[cfg(target_os = "linux")]
-    fn build_command_linux(&self, binary: &Path, args: &[String]) -> Command {
-        let mut cmd = if bwrap::is_available() {
-            tracing::info!("Building bwrap-isolated command");
-            self.build_bwrap_command(binary, args)
-        } else {
-            tracing::warn!("bwrap not available, using direct command");
-            let mut cmd = Command::new(binary);
-            cmd.args(args);
-            cmd
-        };
-
-        let resource_limits = self.security.resource_limits.clone();
-        let cgroup_procs_path = cgroup::build_cgroup_procs_path(&self.box_id);
-
-        Self::add_pre_exec_hook(&mut cmd, resource_limits, cgroup_procs_path);
-        cmd
-    }
-
-    #[cfg(target_os = "linux")]
-    fn build_bwrap_command(&self, binary: &Path, args: &[String]) -> Command {
-        // =====================================================================
-        // Firecracker pattern: Copy shim binary and libraries to box directory
-        // =====================================================================
-        // This ensures:
-        // 1. No external bind mounts needed (works with root user)
-        // 2. Complete memory isolation between boxes (no shared .text section)
-        // 3. Each box has its own copy of the shim and libraries
-
-        let (shim_binary, bin_dir) = match copy_shim_to_box(binary, &self.box_dir) {
-            Ok(copied_shim) => {
-                let bin_dir = copied_shim.parent().unwrap_or(&self.box_dir).to_path_buf();
-                tracing::info!(
-                    original = %binary.display(),
-                    copied = %copied_shim.display(),
-                    "Using copied shim binary (Firecracker pattern)"
-                );
-                (copied_shim, bin_dir)
-            }
-            Err(e) => {
-                // Fallback to original binary if copy fails
-                tracing::warn!(
-                    error = %e,
-                    "Failed to copy shim to box directory, using original"
-                );
-                let bin_dir = binary.parent().unwrap_or(binary).to_path_buf();
-                (binary.to_path_buf(), bin_dir)
-            }
-        };
-
-        let mut bwrap = bwrap::BwrapCommand::new()
-            .with_default_namespaces()
-            .with_die_with_parent()
-            .with_new_session()
-            // TODO(security): Eliminate /usr, /lib, /bin, /sbin bind mounts by statically
-            // linking boxlite-shim with musl. This requires:
-            // 1. Build libkrun with musl (CC=musl-gcc)
-            // 2. Build libgvproxy with musl (CGO_ENABLED=1 CC=musl-gcc)
-            // 3. Build boxlite-shim with --target x86_64-unknown-linux-musl
-            // 4. Remove these ro_bind_if_exists calls below
-            // System directories (read-only) - needed until static linking is implemented
-            .ro_bind_if_exists("/usr", "/usr")
-            .ro_bind_if_exists("/lib", "/lib")
-            .ro_bind_if_exists("/lib64", "/lib64")
-            .ro_bind_if_exists("/bin", "/bin")
-            .ro_bind_if_exists("/sbin", "/sbin")
-            // Devices
-            .with_dev()
-            .dev_bind_if_exists("/dev/kvm", "/dev/kvm")
-            .dev_bind_if_exists("/dev/net/tun", "/dev/net/tun")
-            .with_proc()
-            .tmpfs("/tmp");
-
-        // Mount minimal directories for security isolation
-        // Only this box's directory and required runtime directories are accessible
-
-        // 1. Mount this box's directory (read-write)
-        //    Contains: bin/, sockets/, shared/, disk.qcow2, guest-rootfs.qcow2
-        //    The shim binary and libraries are now INSIDE this directory
-        bwrap = bwrap.bind(&self.box_dir, &self.box_dir);
-        tracing::debug!(box_dir = %self.box_dir.display(), "bwrap: mounted box directory");
-
-        // Get boxlite home directory for other mounts
-        if let Some(boxes_dir) = self.box_dir.parent()
-            && let Some(home_dir) = boxes_dir.parent()
-        {
-            // 2. Mount logs directory (read-write for shim logging + console output)
-            let logs_dir = home_dir.join("logs");
-            if logs_dir.exists() {
-                bwrap = bwrap.bind(&logs_dir, &logs_dir);
-                tracing::debug!(logs_dir = %logs_dir.display(), "bwrap: mounted logs directory");
-            }
-
-            // 3. Mount tmp directory (read-write for rootfs preparation)
-            //    Contains: temporary rootfs mounts during box creation
-            let tmp_dir = home_dir.join("tmp");
-            if tmp_dir.exists() {
-                bwrap = bwrap.bind(&tmp_dir, &tmp_dir);
-                tracing::debug!(tmp_dir = %tmp_dir.display(), "bwrap: mounted tmp directory");
-            }
-
-            // 4. Mount images directory (read-only for extracted OCI layers)
-            //    Contains: extracted layer data used for rootfs
-            let images_dir = home_dir.join("images");
-            if images_dir.exists() {
-                bwrap = bwrap.ro_bind(&images_dir, &images_dir);
-                tracing::debug!(images_dir = %images_dir.display(), "bwrap: mounted images directory (ro)");
-            }
-        }
-
-        // NOTE: No external shim directory bind mount needed!
-        // The shim and libraries are now copied into box_dir/bin/
-
-        // Environment sanitization
-        bwrap = bwrap
-            .with_clearenv()
-            .setenv("PATH", "/usr/bin:/bin:/usr/sbin:/sbin")
-            .setenv("HOME", "/root");
-
-        // Set LD_LIBRARY_PATH to the copied libraries directory
-        // This is inside box_dir, so no external bind mount needed
-        bwrap = bwrap.setenv("LD_LIBRARY_PATH", bin_dir.to_string_lossy().to_string());
-        tracing::debug!(ld_library_path = %bin_dir.display(), "Set LD_LIBRARY_PATH to copied libs directory");
-
-        // Preserve RUST_LOG for debugging
-        if let Ok(rust_log) = std::env::var("RUST_LOG") {
-            bwrap = bwrap.setenv("RUST_LOG", rust_log);
-        }
-
-        bwrap.chdir("/").build(&shim_binary, args)
-    }
-
-    #[cfg(target_os = "macos")]
-    fn build_command_macos(&self, binary: &Path, args: &[String]) -> Command {
-        let mut cmd = if platform::macos::is_sandbox_available() {
-            tracing::info!("Building sandbox-exec isolated command");
-            let (sandbox_cmd, sandbox_args) = platform::macos::get_sandbox_exec_args(
-                &self.security,
-                &self.box_dir,
-                binary,
-                &self.volumes,
-            );
-            let mut cmd = Command::new(sandbox_cmd);
-            cmd.args(sandbox_args);
-            cmd.arg(binary);
-            cmd.args(args);
-            cmd
-        } else {
-            tracing::warn!("sandbox-exec not available, using direct command");
-            let mut cmd = Command::new(binary);
-            cmd.args(args);
-            cmd
-        };
-
-        let resource_limits = self.security.resource_limits.clone();
-        Self::add_pre_exec_hook(&mut cmd, resource_limits, None);
-        cmd
-    }
-
-    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
-    fn build_command_direct(&self, binary: &Path, args: &[String]) -> Command {
-        tracing::warn!("No sandbox available on this platform");
-        let mut cmd = Command::new(binary);
-        cmd.args(args);
-
-        let resource_limits = self.security.resource_limits.clone();
-        Self::add_pre_exec_hook(&mut cmd, resource_limits, None);
-        cmd
-    }
-
-    // ─────────────────────────────────────────────────────────────────────
-    // Private helpers
-    // ─────────────────────────────────────────────────────────────────────
-
-    /// Add pre_exec hook for process isolation (async-signal-safe).
-    ///
-    /// Runs after fork() but before exec() in the child process.
-    /// Applies: FD cleanup, rlimits, cgroup membership (Linux).
-    fn add_pre_exec_hook(
-        cmd: &mut Command,
-        resource_limits: ResourceLimits,
-        #[allow(unused_variables)] cgroup_procs_path: Option<std::ffi::CString>,
-    ) {
-        use std::os::unix::process::CommandExt;
-
-        unsafe {
-            cmd.pre_exec(move || {
-                // 1. Close inherited file descriptors
-                common::fd::close_inherited_fds_raw().map_err(std::io::Error::from_raw_os_error)?;
-
-                // 2. Apply resource limits (rlimits)
-                common::rlimit::apply_limits_raw(&resource_limits)
-                    .map_err(std::io::Error::from_raw_os_error)?;
-
-                // 3. Add self to cgroup (Linux only)
-                #[cfg(target_os = "linux")]
-                if let Some(ref path) = cgroup_procs_path {
-                    let _ = cgroup::add_self_to_cgroup_raw(path);
-                }
-
-                Ok(())
-            });
-        }
-    }
-
-    // ─────────────────────────────────────────────────────────────────────
-    // Associated functions (static)
-    // ─────────────────────────────────────────────────────────────────────
-
-    /// Check if jailer isolation is supported on this platform.
-    pub fn is_supported() -> bool {
-        platform::current().is_available()
-    }
-
-    /// Get the current platform name.
-    pub fn platform_name() -> &'static str {
-        platform::current().name()
-    }
-}

--- a/boxlite/src/jailer/pre_exec.rs
+++ b/boxlite/src/jailer/pre_exec.rs
@@ -1,0 +1,124 @@
+//! Pre-execution hook for process isolation.
+//!
+//! This module provides the pre-execution hook that runs after `fork()` but
+//! before the new program starts in the child process.
+//!
+//! # What it does
+//!
+//! 1. **Close inherited FDs** - Prevents information leakage
+//! 2. **Apply rlimits** - Resource limits (max files, memory, CPU time, etc.)
+//! 3. **Add to cgroup** - Linux only, for cgroup resource limits
+//!
+//! # Safety
+//!
+//! The hook runs in a very restricted context:
+//! - Only async-signal-safe syscalls are allowed
+//! - No memory allocation (no Box, Vec, String)
+//! - No mutex operations
+//! - No logging (tracing, println)
+//!
+//! See the [`common`](crate::jailer::common) module for async-signal-safe utilities.
+
+use crate::jailer::common;
+use crate::jailer::config::ResourceLimits;
+use std::process::Command;
+
+/// Add pre-execution hook for process isolation (async-signal-safe).
+///
+/// Runs after fork() but before the new program starts in the child process.
+/// Applies: FD cleanup, rlimits, cgroup membership (Linux).
+///
+/// # Arguments
+///
+/// * `cmd` - The Command to add the hook to
+/// * `resource_limits` - Resource limits to apply
+/// * `cgroup_procs_path` - Path to cgroup.procs file (Linux only, pre-computed)
+///
+/// # Safety
+///
+/// This function uses `unsafe` to set the hook. The hook itself
+/// only uses async-signal-safe operations:
+/// - `close()` / `close_range()` syscalls
+/// - `setrlimit()` syscall
+/// - `open()` / `write()` / `close()` syscalls (for cgroup)
+///
+/// **Do NOT add any of the following to the hook:**
+/// - Logging (tracing, println, eprintln)
+/// - Memory allocation (Box, Vec, String creation)
+/// - Mutex operations
+/// - Most Rust standard library functions
+///
+/// # Example
+///
+/// ```ignore
+/// use std::process::Command;
+/// use boxlite::jailer::pre_execution::add_hook;
+///
+/// let mut cmd = Command::new("/path/to/binary");
+/// let limits = ResourceLimits::default();
+///
+/// add_hook(&mut cmd, limits, None);
+///
+/// cmd.spawn()?;
+/// ```
+pub fn add_pre_exec_hook(
+    cmd: &mut Command,
+    resource_limits: ResourceLimits,
+    #[allow(unused_variables)] cgroup_procs_path: Option<std::ffi::CString>,
+) {
+    use std::os::unix::process::CommandExt;
+
+    // SAFETY: The hook only uses async-signal-safe syscalls.
+    // See module documentation for details.
+    unsafe {
+        cmd.pre_exec(move || {
+            // 1. Close inherited file descriptors
+            // This prevents information leakage through inherited FDs
+            common::fd::close_inherited_fds_raw().map_err(std::io::Error::from_raw_os_error)?;
+
+            // 2. Apply resource limits (rlimits)
+            // This is enforced by the kernel
+            common::rlimit::apply_limits_raw(&resource_limits)
+                .map_err(std::io::Error::from_raw_os_error)?;
+
+            // 3. Add self to cgroup (Linux only)
+            // This ensures the process is subject to cgroup resource limits
+            #[cfg(target_os = "linux")]
+            if let Some(ref path) = cgroup_procs_path {
+                // Ignore cgroup errors - the box can still run without cgroup limits
+                let _ = crate::jailer::cgroup::add_self_to_cgroup_raw(path);
+            }
+
+            Ok(())
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_add_hook_compiles() {
+        // Just verify the function compiles with various argument types
+        let mut cmd = Command::new("/bin/echo");
+        let limits = ResourceLimits::default();
+
+        add_pre_exec_hook(&mut cmd, limits, None);
+
+        // We can't actually test the hook without forking
+        // Integration tests should verify the actual behavior
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_add_hook_with_cgroup_path() {
+        use std::ffi::CString;
+
+        let mut cmd = Command::new("/bin/echo");
+        let limits = ResourceLimits::default();
+        let cgroup_path = CString::new("/sys/fs/cgroup/boxlite/test/cgroup.procs").ok();
+
+        add_pre_exec_hook(&mut cmd, limits, cgroup_path);
+    }
+}

--- a/boxlite/src/jailer/seccomp.rs
+++ b/boxlite/src/jailer/seccomp.rs
@@ -313,6 +313,12 @@ pub fn generate_bpf_filter() -> Result<Vec<u8>, JailerError> {
 /// Once applied, the filter cannot be removed. The process will be
 /// restricted to the syscalls allowed by the filter.
 ///
+/// # Errors
+///
+/// Returns [`JailerError::Isolation`] with [`IsolationError::Seccomp`] if:
+/// - The seccomp filter fails to apply (kernel rejection, invalid BPF program)
+/// - The process doesn't have permission to apply seccomp filters
+///
 /// # Safety
 ///
 /// This permanently restricts the process. Ensure all required syscalls

--- a/boxlite/src/jailer/shim_copy.rs
+++ b/boxlite/src/jailer/shim_copy.rs
@@ -1,0 +1,206 @@
+//! Shim binary and library copy utilities (Firecracker pattern).
+//!
+//! This module implements Firecracker's security isolation pattern:
+//! copy (not hard-link) binaries into the jail directory to ensure
+//! complete memory isolation between boxes.
+//!
+//! # Why Copy Instead of Hard-Link?
+//!
+//! 1. **Memory Isolation**: Hard-linked binaries share the same inode,
+//!    which means they share the same `.text` section in memory.
+//!    A vulnerability in one box could potentially exploit shared code.
+//!
+//! 2. **Independent Updates**: Each box has its own copy, so updates
+//!    to the shim don't affect running boxes.
+//!
+//! 3. **No External Dependencies**: The jail only needs access to files
+//!    inside the box directory, not external paths.
+//!
+//! # Usage
+//!
+//! ```ignore
+//! use boxlite::jailer::shim_copy::copy_shim_to_box;
+//!
+//! let copied_shim = copy_shim_to_box(&shim_path, &box_dir)?;
+//! // copied_shim is now at box_dir/bin/boxlite-shim
+//! ```
+
+use crate::jailer::common::fs::copy_if_newer;
+use boxlite_shared::errors::{BoxliteError, BoxliteResult};
+use std::path::{Path, PathBuf};
+
+/// Library file patterns to copy alongside the shim binary.
+const BUNDLED_LIB_PATTERNS: &[&str] = &["libkrun.so", "libkrunfw.so", "libgvproxy.so"];
+
+/// Copy shim binary and bundled libraries to box directory for jail isolation.
+///
+/// This follows Firecracker's approach: copy (not hard-link) binaries into the
+/// jail directory to ensure complete memory isolation between boxes.
+///
+/// # Arguments
+///
+/// * `shim_path` - Path to the original shim binary
+/// * `box_dir` - Path to the box directory (e.g., `~/.boxlite/boxes/{box_id}`)
+///
+/// # Returns
+///
+/// Path to the copied shim binary (inside `box_dir/bin/`).
+///
+/// # Errors
+///
+/// Returns [`BoxliteError::Storage`] if:
+/// - Failed to create the `bin/` directory
+/// - Failed to copy the shim binary
+/// - Failed to copy a bundled library
+///
+/// # Example
+///
+/// ```ignore
+/// let copied_shim = copy_shim_to_box(&shim_path, &box_dir)?;
+/// // Use copied_shim instead of original shim_path
+/// ```
+#[cfg(target_os = "linux")]
+pub fn copy_shim_to_box(shim_path: &Path, box_dir: &Path) -> BoxliteResult<PathBuf> {
+    let bin_dir = box_dir.join("bin");
+    std::fs::create_dir_all(&bin_dir).map_err(|e| {
+        BoxliteError::Storage(format!(
+            "Failed to create bin directory {}: {}",
+            bin_dir.display(),
+            e
+        ))
+    })?;
+
+    // Copy shim binary
+    let shim_name = shim_path.file_name().unwrap_or_default();
+    let dest_shim = bin_dir.join(shim_name);
+
+    let copied = copy_if_newer(shim_path, &dest_shim).map_err(|e| {
+        BoxliteError::Storage(format!(
+            "Failed to copy shim {} to {}: {}",
+            shim_path.display(),
+            dest_shim.display(),
+            e
+        ))
+    })?;
+
+    if copied {
+        tracing::debug!(
+            src = %shim_path.display(),
+            dst = %dest_shim.display(),
+            "Copied shim binary to box directory"
+        );
+    }
+
+    // Copy bundled libraries from shim's directory
+    if let Some(shim_dir) = shim_path.parent() {
+        copy_bundled_libraries(shim_dir, &bin_dir)?;
+    }
+
+    Ok(dest_shim)
+}
+
+/// Copy bundled libraries (libkrun, libkrunfw, libgvproxy) to destination.
+///
+/// Only copies libraries that match the patterns in `BUNDLED_LIB_PATTERNS`.
+/// Uses copy-if-newer to avoid unnecessary copies.
+///
+/// # Arguments
+///
+/// * `src_dir` - Directory containing the source libraries (same as shim binary)
+/// * `dest_dir` - Destination directory (`box_dir/bin/`)
+///
+/// # Errors
+///
+/// Returns [`BoxliteError::Storage`] if a library copy fails.
+#[cfg(target_os = "linux")]
+fn copy_bundled_libraries(src_dir: &Path, dest_dir: &Path) -> BoxliteResult<()> {
+    let entries = match std::fs::read_dir(src_dir) {
+        Ok(entries) => entries,
+        Err(e) => {
+            tracing::warn!(
+                src_dir = %src_dir.display(),
+                error = %e,
+                "Could not read source directory for bundled libraries"
+            );
+            return Ok(());
+        }
+    };
+
+    for entry in entries.filter_map(|e| e.ok()) {
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+
+        // Check if this file matches any of our library patterns
+        if BUNDLED_LIB_PATTERNS.iter().any(|p| name_str.starts_with(p)) {
+            let src_path = entry.path();
+            let dest_path = dest_dir.join(&name);
+
+            let copied = copy_if_newer(&src_path, &dest_path).map_err(|e| {
+                BoxliteError::Storage(format!(
+                    "Failed to copy library {} to {}: {}",
+                    src_path.display(),
+                    dest_path.display(),
+                    e
+                ))
+            })?;
+
+            if copied {
+                tracing::debug!(
+                    lib = %name_str,
+                    dst = %dest_path.display(),
+                    "Copied bundled library to box directory"
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Result of a shim copy operation.
+#[allow(dead_code)] // Prepared for future structured return type
+#[derive(Debug)]
+pub struct ShimCopyResult {
+    /// Path to the copied shim binary
+    pub shim_path: PathBuf,
+    /// Path to the bin directory containing shim and libraries
+    pub bin_dir: PathBuf,
+}
+
+#[allow(dead_code)]
+impl ShimCopyResult {
+    /// Get the LD_LIBRARY_PATH value for the copied libraries.
+    pub fn ld_library_path(&self) -> String {
+        self.bin_dir.to_string_lossy().to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bundled_lib_patterns() {
+        assert!(BUNDLED_LIB_PATTERNS.contains(&"libkrun.so"));
+        assert!(BUNDLED_LIB_PATTERNS.contains(&"libkrunfw.so"));
+        assert!(BUNDLED_LIB_PATTERNS.contains(&"libgvproxy.so"));
+    }
+
+    #[test]
+    fn test_lib_pattern_matching() {
+        let patterns = BUNDLED_LIB_PATTERNS;
+
+        // Should match
+        assert!(patterns.iter().any(|p| "libkrun.so.1.2.3".starts_with(p)));
+        assert!(patterns.iter().any(|p| "libkrunfw.so".starts_with(p)));
+        assert!(
+            patterns
+                .iter()
+                .any(|p| "libgvproxy.so.debug".starts_with(p))
+        );
+
+        // Should not match
+        assert!(!patterns.iter().any(|p| "libc.so.6".starts_with(p)));
+        assert!(!patterns.iter().any(|p| "boxlite-shim".starts_with(p)));
+    }
+}

--- a/sdks/python/src/lib.rs
+++ b/sdks/python/src/lib.rs
@@ -12,7 +12,7 @@ use crate::box_handle::PyBox;
 use crate::exec::{PyExecStderr, PyExecStdin, PyExecStdout, PyExecution};
 use crate::info::PyBoxInfo;
 use crate::metrics::{PyBoxMetrics, PyRuntimeMetrics};
-use crate::options::{PyBoxOptions, PyOptions};
+use crate::options::{PyBoxOptions, PyOptions, PySecurityOptions};
 use crate::runtime::PyBoxlite;
 use pyo3::prelude::*;
 
@@ -20,6 +20,7 @@ use pyo3::prelude::*;
 fn boxlite_python(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyOptions>()?;
     m.add_class::<PyBoxOptions>()?;
+    m.add_class::<PySecurityOptions>()?;
     m.add_class::<PyBoxlite>()?;
     m.add_class::<PyBox>()?;
     m.add_class::<PyExecution>()?;


### PR DESCRIPTION
## Summary

Comprehensive refactoring of the jailer module based on [Microsoft Rust Guidelines](https://microsoft.github.io/rust-guidelines/) and [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/checklist.html).

### Changes

**Module restructuring:**
- Split 580-line `mod.rs` into focused modules (`builder.rs`, `command.rs`, `pre_exec.rs`, `shim_copy.rs`)
- `mod.rs` now contains only re-exports (~50 lines)

**Type safety improvements (C-NEWTYPE):**
- Add `Bytes` newtype for memory/file size limits
- Add `Seconds` newtype for time limits
- Prevents mixing units (bytes vs counts, seconds vs milliseconds)

**Builder pattern standardization (C-BUILDER):**
- Update `BwrapCommand` to non-consuming pattern (`&mut Self -> &mut Self`)
- Add `SecurityOptionsBuilder` with fluent API
- Add `JailerBuilder` for constructing `Jailer` instances

**Documentation improvements (C-DOC-ERRORS):**
- Add `# Errors` sections to `seccomp::apply_filter()`
- Add `# Errors` sections to `cgroup::setup_cgroup()`

**DRY improvements:**
- Extract `copy_if_newer` utility to `common/fs.rs`

**Python SDK:**
- Add `PySecurityOptions` class with preset methods (`development()`, `standard()`, `maximum()`)
- Add `security` field to `PyBoxOptions`

## Test plan

- [x] `cargo test -p boxlite -- jailer` (41 tests pass)
- [x] `cargo test -p boxlite -- runtime` (42 tests pass)
- [x] `cargo clippy -p boxlite -p boxlite-python` (no warnings)
- [x] `cargo check -p boxlite-python` (compiles)