### PR TITLE
chore: bump version to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,7 +264,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -320,7 +320,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-c"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "boxlite",
  "boxlite-shared",
@@ -347,7 +347,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-guest"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -388,7 +388,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-python"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "boxlite",
  "futures",
@@ -401,7 +401,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-shared"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "prost",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = ["build/tmp", "target", ".venv", "examples/*/.venv"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.5"
+version = "0.5.0"
 edition = "2024"
 authors = ["Dorian Zheng <https://github.com/dorianzheng>"]
 license = "Apache-2.0"

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "boxlite"
-version = "0.4.5"
+version = "0.5.0"
 description = "Python bindings for Boxlite runtime"
 requires-python = ">=3.10"
 authors = [{ name = "Dorian Zheng" }]


### PR DESCRIPTION
## Summary

Bump workspace and Python SDK version to 0.5.0 for the async runtime methods release.

## Changes

- `Cargo.toml`: workspace version 0.4.5 → 0.5.0
- `sdks/python/pyproject.toml`: Python SDK version 0.4.5 → 0.5.0
- `Cargo.lock`: updated automatically

## Release Notes

This release includes:
- Async runtime methods (`get()`, `get_info()`, `list_info()`, `exists()`, `metrics()`)
- Improved error messages for handle invalidation after `stop()`
- Updated all SDKs (Python, Node.js, C) to handle async methods