### PR TITLE
fix(node): use correct npm package name @boxlite-ai/boxlite

### DIFF
--- a/examples/node/browserbox.js
+++ b/examples/node/browserbox.js
@@ -7,7 +7,7 @@
  * - Connecting with Puppeteer (optional)
  */
 
-const { BrowserBox } = require('@boxlite/boxlite');
+const { BrowserBox } = require('@boxlite-ai/boxlite');
 
 async function main() {
   console.log('=== BrowserBox Example ===\n');

--- a/examples/node/codebox.js
+++ b/examples/node/codebox.js
@@ -8,7 +8,7 @@
  * - Error handling
  */
 
-const { CodeBox } = require('@boxlite/boxlite');
+const { CodeBox } = require('@boxlite-ai/boxlite');
 
 async function main() {
   console.log('=== CodeBox Example ===\n');

--- a/examples/node/computerbox.js
+++ b/examples/node/computerbox.js
@@ -9,7 +9,7 @@
  * - Web browser access
  */
 
-const { ComputerBox } = require('@boxlite/boxlite');
+const { ComputerBox } = require('@boxlite-ai/boxlite');
 const fs = require('fs');
 
 async function main() {

--- a/examples/node/interactivebox.js
+++ b/examples/node/interactivebox.js
@@ -7,7 +7,7 @@
  * - Real-time I/O
  */
 
-const { InteractiveBox } = require('@boxlite/boxlite');
+const { InteractiveBox } = require('@boxlite-ai/boxlite');
 
 async function main() {
   console.log('=== InteractiveBox Example ===\n');

--- a/examples/node/simplebox.js
+++ b/examples/node/simplebox.js
@@ -8,7 +8,7 @@
  * - Proper cleanup
  */
 
-const { SimpleBox } = require('@boxlite/boxlite');
+const { SimpleBox } = require('@boxlite-ai/boxlite');
 
 async function main() {
   console.log('=== SimpleBox Example ===\n');

--- a/sdks/node/lib/index.ts
+++ b/sdks/node/lib/index.ts
@@ -5,7 +5,7 @@
  *
  * @example
  * ```typescript
- * import { SimpleBox } from '@boxlite/boxlite';
+ * import { SimpleBox } from '@boxlite-ai/boxlite';
  *
  * const box = new SimpleBox({ image: 'alpine:latest' });
  * try {

--- a/sdks/node/lib/native.ts
+++ b/sdks/node/lib/native.ts
@@ -22,7 +22,7 @@ let _nativeModule: any = null;
 export function getNativeModule(): any {
   if (_nativeModule === null) {
     try {
-      _nativeModule = loadBinding(join(__dirname, '..'), 'boxlite', '@boxlite/boxlite');
+      _nativeModule = loadBinding(join(__dirname, '..'), 'boxlite', '@boxlite-ai/boxlite');
     } catch (err) {
       throw new Error(
         `BoxLite native extension not found: ${err}. ` +

--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boxlite-ai/boxlite",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "BoxLite - Embeddable micro-VM runtime for secure, isolated code execution",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- Update native.ts to load bindings from `@boxlite-ai/boxlite`
- Update all examples to import from `@boxlite-ai/boxlite`
- Bump version to 0.1.2

## Problem
The package was published to npm under `@boxlite-ai` scope but the code was still referencing the old `@boxlite` scope, causing "module not found" errors at runtime.

## Test plan
- [x] Published and tested v0.1.2 on npm
- [x] Verified `npm install @boxlite-ai/boxlite@0.1.2` works
- [x] Verified examples run correctly