### PR TITLE
refactor(ci): consolidate platform config and simplify Node.js workflow

### DIFF
--- a/.github/workflows/build-node.yml
+++ b/.github/workflows/build-node.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJson(needs.config.outputs.node-targets) }}
+        include: ${{ fromJson(needs.config.outputs.platforms) }}
 
     steps:
       - uses: actions/checkout@v4
@@ -55,136 +55,91 @@ jobs:
           shared-key: "boxlite"
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
-      - name: Build Node.js package
+      # Build guest on host BEFORE manylinux container because:
+      # - manylinux (AlmaLinux/RHEL) doesn't have musl packages in repos
+      # - Building musl-cross-make from source takes ~15 minutes
+      # - Ubuntu host has musl-tools via apt (~30 seconds)
+      # - Guest is static musl binary, doesn't need manylinux glibc compatibility
+      # - Shim/libkrun must be built IN container (needs glibc 2.28 for manylinux)
+      - name: Build guest binary (Linux only)
+        if: runner.os == 'Linux'
+        run: |
+          make setup guest
+
+          # Cache only the final binary (11MB), not entire target dir (2.3GB)
+          # Guest is not rebuilt in container (SKIP_GUEST_BUILD=1), so no incremental compilation needed
+          GUEST_TARGET=$(scripts/util.sh --target)
+          mkdir -p ".cache/$GUEST_TARGET/release"
+          cp "target/$GUEST_TARGET/release/boxlite-guest" ".cache/$GUEST_TARGET/release/"
+
+          # Clean up to save disk space
+          rm -rf target ~/.rustup ~/.cargo
+
+      - name: Build Node.js package (Linux)
+        if: runner.os == 'Linux'
+        uses: addnab/docker-run-action@v3
+        with:
+          image: quay.io/pypa/manylinux_2_28_${{ contains(matrix.target, 'arm64') && 'aarch64' || 'x86_64' }}
+          options: -v ${{ github.workspace }}:/work -w /work
+          run: |
+            set -ex
+
+            # Restore pre-built guest target directory
+            GUEST_TARGET=$(scripts/util.sh --target)
+            if [ -d ".cache/$GUEST_TARGET" ]; then
+              echo "Restoring guest from .cache/$GUEST_TARGET"
+              mkdir -p target
+              cp -a ".cache/$GUEST_TARGET" "target/$GUEST_TARGET"
+            fi
+
+            # Build with SKIP_GUEST_BUILD=1 to use pre-built guest
+            export SKIP_GUEST_BUILD=1
+            make setup runtime
+            bash scripts/build/build-node-sdk.sh --profile release
+
+      - name: Build Node.js package (macOS)
+        if: runner.os == 'macOS'
         run: |
           make setup
           make dist:node
 
-      - name: Get version
-        id: version
-        run: |
-          if [ "${{ github.event_name }}" = "release" ]; then
-            VERSION="${{ github.event.release.tag_name }}"
-            VERSION="${VERSION#v}"
-          else
-            VERSION=$(node -p "require('./sdks/node/package.json').version")
-          fi
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-      - name: Create platform package
-        run: |
-          mkdir -p package
-          cp "sdks/node/index.${{ matrix.target }}.node" package/
-
-          # Build libc field only for Linux
-          LIBC_LINE=""
-          if [ -n "${{ matrix.npm_libc }}" ]; then
-            LIBC_LINE='"libc": ["${{ matrix.npm_libc }}"],'
-          fi
-
-          cat > package/package.json << EOF
-          {
-            "name": "@boxlite-ai/boxlite-${{ matrix.target }}",
-            "version": "${{ steps.version.outputs.version }}",
-            "os": ["${{ matrix.npm_os }}"],
-            "cpu": ["${{ matrix.npm_cpu }}"],
-            $LIBC_LINE
-            "main": "index.${{ matrix.target }}.node",
-            "files": ["index.${{ matrix.target }}.node"],
-            "license": "Apache-2.0"
-          }
-          EOF
-
-          echo "=== Platform package ==="
-          cat package/package.json
-
-      - name: Upload platform package
+      - name: Upload packages
         uses: actions/upload-artifact@v4
         with:
-          name: package-${{ matrix.target }}
-          path: package/
-          if-no-files-found: error
-          retention-days: ${{ needs.config.outputs.artifact-retention-days }}
-
-      # Upload main package only once (from darwin-arm64 build)
-      - name: Create main package
-        if: matrix.target == 'darwin-arm64'
-        run: |
-          mkdir -p main-package
-          cp -r sdks/node/dist main-package/
-          cp sdks/node/index.js main-package/
-          cp sdks/node/index.d.ts main-package/
-
-          # Update package.json with version and optionalDependencies
-          VERSION="${{ steps.version.outputs.version }}"
-          node -e "
-            const pkg = require('./sdks/node/package.json');
-            pkg.version = '$VERSION';
-            pkg.optionalDependencies = {
-              '@boxlite-ai/boxlite-darwin-arm64': '$VERSION',
-              '@boxlite-ai/boxlite-darwin-x64': '$VERSION',
-              '@boxlite-ai/boxlite-linux-x64-gnu': '$VERSION',
-              '@boxlite-ai/boxlite-linux-arm64-gnu': '$VERSION'
-            };
-            require('fs').writeFileSync('./main-package/package.json', JSON.stringify(pkg, null, 2));
-          "
-
-          echo "=== Main package ==="
-          cat main-package/package.json
-
-      - name: Upload main package
-        if: matrix.target == 'darwin-arm64'
-        uses: actions/upload-artifact@v4
-        with:
-          name: package-main
-          path: main-package/
+          name: packages-${{ matrix.target }}
+          path: sdks/node/packages/*.tgz
           if-no-files-found: error
           retention-days: ${{ needs.config.outputs.artifact-retention-days }}
 
   test:
-    name: Test (${{ matrix.target }} / Node ${{ matrix.node-version }})
+    name: Test (${{ matrix.platform.target }} / Node ${{ matrix.node-version }})
     needs: [config, build]
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.platform.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-15, macos-13, ubuntu-latest, ubuntu-24.04-arm]
+        platform: ${{ fromJson(needs.config.outputs.platforms) }}
         node-version: ${{ fromJson(needs.config.outputs.node-versions) }}
-        include:
-          - os: macos-15
-            target: darwin-arm64
-          - os: macos-13
-            target: darwin-x64
-          - os: ubuntu-latest
-            target: linux-x64-gnu
-          - os: ubuntu-24.04-arm
-            target: linux-arm64-gnu
 
     steps:
-      - uses: actions/checkout@v4
-
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Download main package
+      - name: Download packages
         uses: actions/download-artifact@v4
         with:
-          name: package-main
-          path: sdks/node
-
-      - name: Download platform package
-        uses: actions/download-artifact@v4
-        with:
-          name: package-${{ matrix.target }}
-          path: sdks/node
+          name: packages-${{ matrix.platform.target }}
+          path: packages
 
       - name: Test package
         run: |
-          cd sdks/node
-          npm install --ignore-scripts
-          node -e "const boxlite = require('./dist'); console.log('BoxLite Node.js SDK loaded successfully')"
+          cd packages
+          # Install platform package first, then main package
+          npm install boxlite-ai-boxlite-${{ matrix.platform.target }}-*.tgz
+          npm install boxlite-ai-boxlite-[0-9]*.tgz
+          node -e "const boxlite = require('@boxlite-ai/boxlite'); console.log('BoxLite Node.js SDK loaded successfully')"
 
   publish:
     name: Publish to npm
@@ -205,16 +160,17 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: packages
-          pattern: package-*
+          pattern: packages-*
+          merge-multiple: true
 
       - name: List packages
-        run: find packages -type f | head -50
+        run: ls -la packages/
 
       - name: Publish platform packages
         run: |
-          for target in darwin-arm64 darwin-x64 linux-x64-gnu linux-arm64-gnu; do
+          for target in darwin-arm64 linux-x64-gnu; do
             echo "Publishing @boxlite-ai/boxlite-$target..."
-            (cd "packages/package-$target" && npm publish --provenance --access public)
+            npm publish packages/boxlite-ai-boxlite-$target-*.tgz --provenance --access public
           done
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -224,8 +180,7 @@ jobs:
 
       - name: Publish main package
         run: |
-          cd packages/package-main
-          npm publish --provenance --access public
+          npm publish packages/boxlite-ai-boxlite-[0-9]*.tgz --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -242,23 +197,11 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: packages
-          pattern: package-*
-
-      - name: Create archives
-        run: |
-          cd packages
-          tar -czvf boxlite-node.tar.gz package-main/
-          for target in darwin-arm64 darwin-x64 linux-x64-gnu linux-arm64-gnu; do
-            tar -czvf "boxlite-node-$target.tar.gz" "package-$target/"
-          done
+          pattern: packages-*
+          merge-multiple: true
 
       - name: Upload to release
         uses: softprops/action-gh-release@v2
         with:
-          files: |
-            packages/boxlite-node.tar.gz
-            packages/boxlite-node-darwin-arm64.tar.gz
-            packages/boxlite-node-darwin-x64.tar.gz
-            packages/boxlite-node-linux-x64-gnu.tar.gz
-            packages/boxlite-node-linux-arm64-gnu.tar.gz
+          files: packages/*.tgz
           fail_on_unmatched_files: true

--- a/.github/workflows/build-runtime.yml
+++ b/.github/workflows/build-runtime.yml
@@ -34,8 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Use simple 2-platform matrix (same as SDK workflows)
-        os: ${{ fromJson(needs.config.outputs.build-targets) }}
+        include: ${{ fromJson(needs.config.outputs.platforms) }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: ${{ fromJson(needs.config.outputs.build-targets) }}
+        include: ${{ fromJson(needs.config.outputs.platforms) }}
 
     steps:
       - name: Checkout code
@@ -69,13 +69,13 @@ jobs:
           retention-days: 7
 
   test_wheels:
-    name: Test wheel on ${{ matrix.os }} / Python ${{ matrix.python-version }}
+    name: Test wheel on ${{ matrix.platform.os }} / Python ${{ matrix.python-version }}
     needs: [ config, build_wheels ]
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.platform.os }}
     strategy:
       fail-fast: true
       matrix:
-        os: ${{ fromJson(needs.config.outputs.build-targets) }}
+        platform: ${{ fromJson(needs.config.outputs.platforms) }}
         python-version: ${{ fromJson(needs.config.outputs.python-versions) }}
 
     steps:

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -10,12 +10,9 @@ on:
   workflow_call:
     outputs:
       # === Platform/Matrix Configuration ===
-      build-targets:
-        description: 'JSON array of OS targets for builds and testing'
-        value: ${{ jobs.config.outputs.build-targets }}
-      node-targets:
-        description: 'JSON array of Node.js build targets with os/target pairs'
-        value: ${{ jobs.config.outputs.node-targets }}
+      platforms:
+        description: 'JSON array of platform configurations (os and target)'
+        value: ${{ jobs.config.outputs.platforms }}
 
       # === Version Configuration ===
       python-versions:
@@ -43,8 +40,7 @@ jobs:
     outputs:
       # === Platform/Matrix Configuration ===
       # Note: Using macos-15 for libkrun bottle compatibility (arm64_tahoe)
-      build-targets: '["ubuntu-latest", "macos-15"]'
-      node-targets: '[{"os":"macos-15","target":"darwin-arm64","npm_os":"darwin","npm_cpu":"arm64"},{"os":"macos-13","target":"darwin-x64","npm_os":"darwin","npm_cpu":"x64"},{"os":"ubuntu-latest","target":"linux-x64-gnu","npm_os":"linux","npm_cpu":"x64","npm_libc":"glibc"},{"os":"ubuntu-24.04-arm","target":"linux-arm64-gnu","npm_os":"linux","npm_cpu":"arm64","npm_libc":"glibc"}]'
+      platforms: '[{"os":"macos-15","target":"darwin-arm64"},{"os":"ubuntu-latest","target":"linux-x64-gnu"}]'
 
       # === Version Configuration ===
       python-versions: '["3.10", "3.11", "3.12", "3.13"]'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: ${{ fromJson(needs.config.outputs.build-targets) }}
+        include: ${{ fromJson(needs.config.outputs.platforms) }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,7 +374,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-node"
-version = "0.1.0"
+version = "0.5.0"
 dependencies = [
  "boxlite",
  "boxlite-shared",

--- a/sdks/node/Cargo.toml
+++ b/sdks/node/Cargo.toml
@@ -1,11 +1,10 @@
 [package]
 name = "boxlite-node"
-version = "0.1.0"
-edition = "2021"
-authors = ["Dorian Zheng <dorian@boxlite.dev>"]
-license = "Apache-2.0"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
 description = "Node.js bindings for BoxLite - embeddable VM runtime for secure code execution"
-repository = "https://github.com/boxlite-labs/boxlite"
 
 [lib]
 crate-type = ["cdylib"]

--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boxlite-ai/boxlite",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "BoxLite - Embeddable micro-VM runtime for secure, isolated code execution",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -22,9 +22,7 @@
   },
   "optionalDependencies": {
     "@boxlite-ai/boxlite-darwin-arm64": "0.1.0",
-    "@boxlite-ai/boxlite-darwin-x64": "0.1.0",
-    "@boxlite-ai/boxlite-linux-x64-gnu": "0.1.0",
-    "@boxlite-ai/boxlite-linux-arm64-gnu": "0.1.0"
+    "@boxlite-ai/boxlite-linux-x64-gnu": "0.1.0"
   },
   "keywords": [
     "boxlite",

--- a/sdks/node/platform-package.template.json
+++ b/sdks/node/platform-package.template.json
@@ -1,0 +1,22 @@
+{
+  "name": "@boxlite-ai/boxlite-{{PLATFORM}}",
+  "version": "{{VERSION}}",
+  "os": ["{{OS}}"],
+  "cpu": ["{{CPU}}"],
+  {{LIBC_LINE}}
+  "main": "{{NODE_FILE}}",
+  "files": [
+    "{{NODE_FILE}}",
+    "runtime"
+  ],
+  "description": "BoxLite native bindings for {{PLATFORM}}",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/boxlite-ai/boxlite.git",
+    "directory": "sdks/node"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}


### PR DESCRIPTION
## Summary

- Consolidates `build-targets` and `node-targets` into single `platforms` config for cleaner workflow matrix configuration
- Reduces to 2 platforms for initial release (darwin-arm64, linux-x64-gnu) - can expand later
- Simplifies Node.js workflow to use tarball-based artifacts throughout (build → test → publish)
- Adds `platform-package.template.json` for cleaner platform package generation
- Extracts reusable functions (`get_main_version()`, `generate_package_json()`) in build script
- Updates workflows README.md to accurately reflect current architecture

## Changes

### config.yml
- Replaced `build-targets` (string array) and `node-targets` (object array) with unified `platforms`
- Format: `[{"os":"macos-15","target":"darwin-arm64"},{"os":"ubuntu-latest","target":"linux-x64-gnu"}]`

### build-node.yml
- Uses tarball artifacts (`sdks/node/packages/*.tgz`) instead of directories
- Test job installs from tarballs directly
- Publish job publishes tarballs with `npm publish *.tgz`
- Simplified matrix using `platform` object from config

### build-wheels.yml, build-runtime.yml, lint.yml
- Updated to use `platforms` config with `matrix.include`

### scripts/build/build-node-sdk.sh
- Added `get_main_version()` - reads version from package.json
- Added `generate_package_json()` - template-based package.json generation
- Consolidated `build_native_addon` + `setup_rpath` + `create_platform_package` into `build_platform_package()`

### sdks/node/package.json
- Version bumped to 0.1.3
- Reduced optionalDependencies to 2 platforms

## Test plan

- [ ] Verify `make dist:node` builds successfully on macOS
- [ ] Verify tarball structure is correct (`npm pack --dry-run`)
- [ ] Manual workflow dispatch to test CI pipeline