### PR TITLE
fix(python): add PyPI project metadata for package discoverability

### DIFF
--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -2,9 +2,32 @@
 name = "boxlite"
 version = "0.5.0"
 description = "Python bindings for Boxlite runtime"
+readme = "README.md"
 requires-python = ">=3.10"
 authors = [{ name = "Dorian Zheng" }]
 license = "Apache-2.0"
+keywords = ["sandbox", "virtual machine", "vm", "ai agents", "code execution", "isolation", "container", "security", "kvm", "hypervisor"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Rust",
+    "Operating System :: MacOS",
+    "Operating System :: POSIX :: Linux",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Security",
+    "Topic :: System :: Emulators",
+]
+
+[project.urls]
+Homepage = "https://github.com/boxlite-ai/boxlite"
+Documentation = "https://github.com/boxlite-ai/boxlite/tree/main/docs"
+Repository = "https://github.com/boxlite-ai/boxlite"
+Issues = "https://github.com/boxlite-ai/boxlite/issues"
 
 [project.optional-dependencies]
 dev = ["pytest>=7.0", "pytest-asyncio>=0.21"]


### PR DESCRIPTION
## Summary
- Add `readme = "README.md"` so PyPI displays the full project description
- Add keywords for search: sandbox, virtual machine, ai agents, etc.
- Add classifiers for filtering: Python versions, OS, topics
- Add project URLs: Homepage, Documentation, Repository, Issues

## Test plan
- [ ] Build wheel locally with `maturin build`
- [ ] Verify METADATA includes README content
- [ ] Publish to TestPyPI to preview the page (optional)