### PR TITLE
feat(setup): add Node.js installation to all setup scripts

### DIFF
--- a/.github/workflows/build-runtime.yml
+++ b/.github/workflows/build-runtime.yml
@@ -22,6 +22,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  SKIP_INSTALL_NODEJS: '1'
 
 jobs:
   config:

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -5,6 +5,9 @@ on:
     types: [ published ]
   workflow_dispatch:  # Allow manual triggering
 
+env:
+  SKIP_INSTALL_NODEJS: '1'
+
 jobs:
   # Load shared configuration
   config:

--- a/scripts/setup/setup-common.sh
+++ b/scripts/setup/setup-common.sh
@@ -113,6 +113,19 @@ check_go() {
     fi
 }
 
+# Check Node.js installation
+check_nodejs() {
+    print_step "Checking for Node.js... "
+    if command_exists node; then
+        local node_version=$(node --version)
+        print_success "Found ($node_version)"
+        return 0
+    else
+        print_error "Not found"
+        return 1
+    fi
+}
+
 # Check if musl toolchain is available (fail fast)
 require_musl() {
     local os=$(detect_os)

--- a/scripts/setup/setup-macos.sh
+++ b/scripts/setup/setup-macos.sh
@@ -176,6 +176,21 @@ setup_go() {
     echo ""
 }
 
+# Setup Node.js
+install_nodejs() {
+    if [ "${SKIP_INSTALL_NODEJS:-}" = "1" ]; then
+        print_step "Skipping Node.js (SKIP_INSTALL_NODEJS=1)"
+        echo ""
+        return 0
+    fi
+    if ! check_nodejs; then
+        echo -e "${YELLOW}Installing...${NC}"
+        brew install node
+        print_success "Node.js installed"
+    fi
+    echo ""
+}
+
 # Main installation flow
 main() {
     print_header "BoxLite Development Setup for macOS"
@@ -211,6 +226,8 @@ main() {
     setup_python
 
     setup_go
+
+    install_nodejs
 
     print_header "Setup Complete"
     echo ""

--- a/scripts/setup/setup-manylinux.sh
+++ b/scripts/setup/setup-manylinux.sh
@@ -166,6 +166,34 @@ install_protoc() {
     echo ""
 }
 
+# Install Node.js from nodejs.org (not available in manylinux repos)
+install_nodejs() {
+    if [ "${SKIP_INSTALL_NODEJS:-}" = "1" ]; then
+        print_step "Skipping Node.js (SKIP_INSTALL_NODEJS=1)"
+        echo ""
+        return 0
+    fi
+
+    print_section "📦 Installing Node.js..."
+
+    local NODE_VERSION="20.18.0"
+    local ARCH=$(uname -m)
+
+    print_step "Checking for Node.js... "
+    if command -v node &>/dev/null; then
+        local version=$(node --version)
+        print_success "Found ($version)"
+        echo ""
+        return 0
+    fi
+
+    echo -e "${YELLOW}Downloading Node.js $NODE_VERSION...${NC}"
+    curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${ARCH}.tar.xz" \
+        | tar -xJ -C /usr/local --strip-components=1
+    print_success "Node.js $NODE_VERSION installed"
+    echo ""
+}
+
 # Main installation flow
 main() {
     print_header "BoxLite Development Setup for manylinux"
@@ -182,6 +210,8 @@ main() {
     install_python_deps
 
     install_protoc
+
+    install_nodejs
 
     init_submodules
 

--- a/scripts/setup/setup-ubuntu.sh
+++ b/scripts/setup/setup-ubuntu.sh
@@ -106,6 +106,31 @@ install_system_deps() {
     echo ""
 }
 
+# Install Node.js
+install_nodejs() {
+    if [ "${SKIP_INSTALL_NODEJS:-}" = "1" ]; then
+        print_step "Skipping Node.js (SKIP_INSTALL_NODEJS=1)"
+        echo ""
+        return 0
+    fi
+
+    print_section "📦 Installing Node.js..."
+
+    local packages=(nodejs npm)
+
+    for pkg in "${packages[@]}"; do
+        print_step "Checking for $pkg... "
+        if apt_installed "$pkg"; then
+            print_success "Already installed"
+        else
+            echo -e "${YELLOW}Installing...${NC}"
+            $SUDO apt-get install -y -qq "$pkg"
+            print_success "$pkg installed"
+        fi
+    done
+    echo ""
+}
+
 # Install linuxdeploy
 install_linuxdeploy() {
     print_section "📦 Installing linuxdeploy..."
@@ -140,6 +165,8 @@ main() {
     update_apt
 
     install_system_deps
+
+    install_nodejs
 
     install_linuxdeploy
 


### PR DESCRIPTION
## Summary
- Add `check_nodejs()` helper to setup-common.sh
- Add `install_nodejs()` to setup-macos.sh (via brew)
- Add `install_nodejs()` to setup-ubuntu.sh (via apt)
- Add `install_nodejs()` to setup-manylinux.sh (download from nodejs.org)
- Support `SKIP_INSTALL_NODEJS=1` env var to skip installation
- Add `SKIP_INSTALL_NODEJS=1` to build-runtime.yml and build-wheels.yml

## Problem
The build-node workflow fails in manylinux container because:
1. `git rev-parse` fails due to directory ownership mismatch (fixed in main with `git config --global --add safe.directory`)
2. `npm` is not available in the manylinux image

## Test plan
- [ ] Trigger build-node workflow and verify it passes
- [ ] Verify build-wheels workflow still works (with skip)