### PR TITLE
fix(ci): source cargo env after make setup in node SDK build

### DIFF
--- a/.github/workflows/build-node-sdk.yml
+++ b/.github/workflows/build-node-sdk.yml
@@ -85,6 +85,8 @@ jobs:
       - name: Build Node.js package
         run: |
           make setup
+          # Source cargo env (Linux reinstalls Rust after cleanup, PATH needs update)
+          [ -f "$HOME/.cargo/env" ] && source "$HOME/.cargo/env"
           if [ "${{ runner.os }}" = "Linux" ]; then
             KEEP_GUEST_BIN=1 make dist:node
           else


### PR DESCRIPTION
## Summary
After building guest on Linux, Rust is removed to save disk space (`rm -rf ~/.rustup ~/.cargo`). 
`make setup` reinstalls Rust, but the PATH isn't updated in the same shell, causing `cargo ENOENT`.

This adds sourcing of `$HOME/.cargo/env` to make cargo available for the build.

## Test plan
- [ ] Trigger build-node-sdk workflow