### PR TITLE
fix(build): ensure cargo is in PATH for Node.js SDK build

### DIFF
--- a/scripts/build/build-node-sdk.sh
+++ b/scripts/build/build-node-sdk.sh
@@ -28,6 +28,7 @@ SCRIPT_BUILD_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT_DIR="$(cd "$SCRIPT_BUILD_DIR/.." && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 source "$SCRIPT_DIR/common.sh"
+ensure_cargo
 
 # SDK directories
 NODE_SDK_DIR="$PROJECT_ROOT/sdks/node"

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -60,6 +60,13 @@ command_exists() {
     command -v "$1" &> /dev/null
 }
 
+# Ensure cargo is in PATH (sources cargo env if available)
+ensure_cargo() {
+    if [ -f "$HOME/.cargo/env" ]; then
+        source "$HOME/.cargo/env"
+    fi
+}
+
 # Detect OS
 detect_os() {
     if [[ "$OSTYPE" == "darwin"* ]]; then


### PR DESCRIPTION
## Summary
- Add `ensure_cargo()` function to `common.sh` that scripts can call when they need cargo in PATH
- Call `ensure_cargo` in `build-node-sdk.sh` to fix "spawn cargo ENOENT" error in manylinux container

## Root Cause
In the manylinux Docker container:
1. `make setup` installs Rust and sources `$HOME/.cargo/env` in a subshell
2. When `build-node-sdk.sh` runs as a new bash process, cargo is not in PATH
3. `npx napi build` fails with "spawn cargo ENOENT"

macOS works because `actions-rust-lang/setup-rust-toolchain@v1` sets cargo in PATH at the GitHub Actions environment level, which persists across steps.

## Test plan
- [ ] Trigger `build-node` workflow and verify it passes