### PR TITLE
chore: bump version to 0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,7 +279,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -335,7 +335,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-c"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "boxlite",
  "boxlite-shared",
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-guest"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -393,7 +393,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-node"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "boxlite",
  "boxlite-shared",
@@ -407,7 +407,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-python"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "boxlite",
  "futures",
@@ -420,7 +420,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-shared"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "prost",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = ["build/tmp", "target", ".venv", "examples/*/.venv"]
 resolver = "2"
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 authors = ["Dorian Zheng <https://github.com/dorianzheng>"]
 license = "Apache-2.0"

--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boxlite-ai/boxlite",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "BoxLite - Embeddable micro-VM runtime for secure, isolated code execution",
   "type": "module",
   "main": "dist/index.js",

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "boxlite"
-version = "0.5.0"
+version = "0.5.1"
 description = "Python bindings for Boxlite runtime"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Bump Rust version: 0.5.0 → 0.5.1
- Bump Python SDK version: 0.5.0 → 0.5.1
- Bump Node.js SDK version: 0.1.3 → 0.1.4

## Test plan
- [ ] CI passes