### PR TITLE
fix(ci): add contents:read permission for npm publish

### DIFF
--- a/.github/workflows/build-node.yml
+++ b/.github/workflows/build-node.yml
@@ -151,6 +151,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+      contents: read
 
     steps:
       - name: Set up Node.js


### PR DESCRIPTION
## Summary
- Add `contents: read` permission to the npm publish job in the Node.js CI workflow
- Fixes npm publish failure caused by missing git permissions

## Problem
The publish job only had `id-token: write` permission for OIDC/provenance. When explicit permissions are set in GitHub Actions, all other permissions default to `none`. This caused the npm publish to fail with:
```
npm error code 128
npm error command git --no-replace-objects ls-remote ssh://git@github.com/packages/...
npm error git@github.com: Permission denied (publickey).
```

## Solution
Add `contents: read` as required by [npm trusted publishers](https://docs.npmjs.com/trusted-publishers).

## Test plan
- [ ] Re-run the Node.js publish workflow after merge
- [ ] Verify platform packages publish successfully
- [ ] Verify main package publishes successfully