### PR TITLE
feat(cli): implement create and list commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,6 +353,7 @@ dependencies = [
  "assert_cmd",
  "boxlite",
  "clap",
+ "comfy-table",
  "dirs 6.0.0",
  "futures",
  "nix 0.30.1",
@@ -580,6 +581,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "comfy-table"
+version = "7.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b03b7db8e0b4b2fdad6c551e634134e99ec000e5c8c3b6856c65e8bbaded7a3b"
+dependencies = [
+ "crossterm",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "const_format"
 version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -665,6 +677,29 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags 2.10.0",
+ "crossterm_winapi",
+ "document-features",
+ "parking_lot",
+ "rustix 1.1.3",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crypto-common"
@@ -835,6 +870,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -1738,6 +1782,12 @@ name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -3863,6 +3913,12 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"

--- a/boxlite-cli/Cargo.toml
+++ b/boxlite-cli/Cargo.toml
@@ -23,6 +23,7 @@ tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 
 # Runtime extraction
 dirs = "6.0"
+comfy-table = "7.2.1"
 
 [build-dependencies]
 dirs = "6.0"

--- a/boxlite-cli/src/commands/create.rs
+++ b/boxlite-cli/src/commands/create.rs
@@ -1,0 +1,52 @@
+use crate::cli::{GlobalFlags, ResourceFlags};
+use boxlite::{BoxOptions, RootfsSpec};
+use clap::Args;
+
+/// Create a new box
+#[derive(Args, Debug)]
+pub struct CreateArgs {
+    /// Image to create from
+    #[arg(index = 1)]
+    pub image: String,
+
+    /// Assign a name to the box
+    #[arg(long)]
+    pub name: Option<String>,
+
+    /// Automatically remove the box when it exits
+    #[arg(long)]
+    pub rm: bool,
+
+    /// Set environment variables
+    #[arg(short = 'e', long = "env")]
+    pub env: Vec<String>,
+
+    /// Working directory inside the box
+    #[arg(short = 'w', long = "workdir")]
+    pub workdir: Option<String>,
+
+    #[command(flatten)]
+    pub resource: ResourceFlags,
+}
+
+pub async fn execute(args: CreateArgs, global: &GlobalFlags) -> anyhow::Result<()> {
+    let rt = global.create_runtime()?;
+    let box_options = args.to_box_options();
+
+    let litebox = rt.create(box_options, args.name).await?;
+    println!("{}", litebox.id());
+
+    Ok(())
+}
+
+impl CreateArgs {
+    fn to_box_options(&self) -> BoxOptions {
+        let mut options = BoxOptions::default();
+        self.resource.apply_to(&mut options);
+        options.auto_remove = self.rm;
+        options.working_dir = self.workdir.clone();
+        crate::cli::apply_env_vars(&self.env, &mut options);
+        options.rootfs = RootfsSpec::Image(self.image.clone());
+        options
+    }
+}

--- a/boxlite-cli/src/commands/list.rs
+++ b/boxlite-cli/src/commands/list.rs
@@ -1,0 +1,67 @@
+use crate::cli::GlobalFlags;
+use boxlite::BoxInfo;
+use clap::Args;
+use comfy_table::{Attribute, Cell, Table, presets};
+
+/// List boxes
+#[derive(Args, Debug)]
+pub struct ListArgs {
+    /// Show all boxes (default just shows running)
+    #[arg(short = 'a', long)]
+    pub all: bool,
+
+    /// Only show IDs
+    #[arg(short, long)]
+    pub quiet: bool,
+}
+
+pub async fn execute(args: ListArgs, global: &GlobalFlags) -> anyhow::Result<()> {
+    let rt = global.create_runtime()?;
+    let boxes = rt.list_info().await?;
+
+    if args.quiet {
+        for info in boxes {
+            if !args.all && !info.status.is_active() {
+                continue;
+            }
+            println!("{}", info.id);
+        }
+        return Ok(());
+    }
+
+    print_info(boxes, args.all);
+
+    Ok(())
+}
+
+fn print_info(boxes: Vec<BoxInfo>, all: bool) {
+    let mut table = Table::new();
+    table
+        .load_preset(presets::UTF8_NO_BORDERS)
+        .set_content_arrangement(comfy_table::ContentArrangement::Dynamic);
+    table.set_header(vec![
+        Cell::new("ID").add_attribute(Attribute::Bold),
+        Cell::new("IMAGE").add_attribute(Attribute::Bold),
+        Cell::new("STATUS").add_attribute(Attribute::Bold),
+        Cell::new("CREATED").add_attribute(Attribute::Bold),
+        Cell::new("NAMES").add_attribute(Attribute::Bold),
+    ]);
+
+    for info in boxes {
+        if !all && !info.status.is_active() {
+            continue;
+        }
+
+        let created = info.created_at.format("%Y-%m-%d %H:%M:%S").to_string();
+
+        table.add_row(vec![
+            info.id.to_string(),
+            info.image.clone(),
+            format!("{:?}", info.status),
+            created,
+            info.name.clone().unwrap_or_else(|| "".to_string()),
+        ]);
+    }
+
+    println!("{table}");
+}

--- a/boxlite-cli/src/commands/mod.rs
+++ b/boxlite-cli/src/commands/mod.rs
@@ -1,2 +1,4 @@
+pub mod create;
+pub mod list;
 pub mod rm;
 pub mod run;

--- a/boxlite-cli/src/commands/run.rs
+++ b/boxlite-cli/src/commands/run.rs
@@ -1,6 +1,6 @@
 use crate::cli::{GlobalFlags, ManagementFlags, ProcessFlags, ResourceFlags};
 use boxlite::BoxCommand;
-use boxlite::{BoxOptions, BoxliteOptions, BoxliteRuntime, LiteBox, RootfsSpec};
+use boxlite::{BoxOptions, BoxliteRuntime, LiteBox, RootfsSpec};
 use clap::Args;
 use futures::StreamExt;
 use nix::sys::signal::Signal;
@@ -43,15 +43,7 @@ struct BoxRunner {
 
 impl BoxRunner {
     fn new(args: RunArgs, global: &GlobalFlags) -> anyhow::Result<Self> {
-        let options = if let Some(home) = &global.home {
-            BoxliteOptions {
-                home_dir: home.clone(),
-            }
-        } else {
-            BoxliteOptions::default()
-        };
-
-        let rt = BoxliteRuntime::new(options)?;
+        let rt = global.create_runtime()?;
 
         Ok(Self { args, rt })
     }

--- a/boxlite-cli/src/main.rs
+++ b/boxlite-cli/src/main.rs
@@ -34,6 +34,8 @@ async fn main() {
 
     let result = match cli.command {
         cli::Commands::Run(args) => commands::run::execute(args, &cli.global).await,
+        cli::Commands::Create(args) => commands::create::execute(args, &cli.global).await,
+        cli::Commands::List(args) => commands::list::execute(args, &cli.global).await,
         cli::Commands::Rm(args) => commands::rm::execute(args, &cli.global).await,
     };
 

--- a/boxlite-cli/tests/create.rs
+++ b/boxlite-cli/tests/create.rs
@@ -1,0 +1,71 @@
+use predicates::prelude::*;
+
+mod common;
+
+fn cleanup(ctx: &common::TestContext, name: &str) {
+    let mut cmd = ctx.new_cmd();
+    let _ = cmd.args(["rm", name, "--force"]).ok();
+}
+
+#[test]
+fn test_create_basic() {
+    let mut ctx = common::boxlite();
+    ctx.cmd
+        .arg("create")
+        .arg("alpine:latest")
+        .assert()
+        .success()
+        .stdout(predicate::str::is_match(r"^[0-9A-Z]{26}\n$").unwrap());
+}
+
+#[test]
+fn test_create_named() {
+    let name = "boxlite_create_named";
+    let mut ctx = common::boxlite();
+    cleanup(&ctx, name);
+    ctx.cmd
+        .arg("create")
+        .arg("--name")
+        .arg(name)
+        .arg("alpine:latest")
+        .assert()
+        .success()
+        .stdout(predicate::str::is_match(r"^[0-9A-Z]{26}\n$").unwrap());
+
+    let mut cmd_dup = ctx.new_cmd();
+    cmd_dup
+        .arg("create")
+        .arg("--name")
+        .arg(name)
+        .arg("alpine:latest")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("already exists"));
+
+    cleanup(&ctx, name);
+}
+
+#[test]
+fn test_create_with_resources() {
+    let name = "boxlite_create_resources";
+    let mut ctx = common::boxlite();
+    cleanup(&ctx, name);
+
+    ctx.cmd
+        .arg("create")
+        .arg("--name")
+        .arg(name)
+        .arg("--cpus")
+        .arg("1")
+        .arg("--memory")
+        .arg("128")
+        .arg("--env")
+        .arg("TEST_VAR=1")
+        .arg("--workdir")
+        .arg("/tmp")
+        .arg("alpine:latest")
+        .assert()
+        .success();
+
+    cleanup(&ctx, name);
+}

--- a/boxlite-cli/tests/list.rs
+++ b/boxlite-cli/tests/list.rs
@@ -1,0 +1,55 @@
+use predicates::prelude::*;
+
+mod common;
+
+fn cleanup(ctx: &common::TestContext, name: &str) {
+    let mut cmd = ctx.new_cmd();
+    let _ = cmd.args(["rm", name, "--force"]).ok();
+}
+
+#[test]
+fn test_list_empty_or_header() {
+    let mut ctx = common::boxlite();
+    ctx.cmd
+        .arg("list")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("ID"))
+        .stdout(predicate::str::contains("IMAGE"))
+        .stdout(predicate::str::contains("STATUS"));
+}
+
+#[test]
+fn test_list_lifecycle() {
+    let name = "boxlite_list";
+    let mut ctx = common::boxlite();
+    cleanup(&ctx, name);
+
+    let _ = ctx
+        .cmd
+        .args(["create", "--name", name, "alpine:latest"])
+        .output();
+
+    let mut list_cmd = ctx.new_cmd();
+    list_cmd
+        .arg("list")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(name).not());
+
+    let mut list_all = ctx.new_cmd();
+    list_all
+        .args(["list", "-a"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(name))
+        .stdout(predicate::str::contains("Configured"));
+
+    cleanup(&ctx, name);
+}
+
+#[test]
+fn test_list_alias_ls() {
+    let mut ctx = common::boxlite();
+    ctx.cmd.arg("ls").assert().success();
+}


### PR DESCRIPTION
## Info


issue: https://github.com/boxlite-ai/boxlite/issues/35

## Changed


implement boxlite-cli create and list commands

- Implement `create` command
- Implement `list` command (alia: ls). Need it to test `create` command
- Add `comfy-table` dependency for formatted list output
- Refactor runtime initialization into `GlobalFlags::create_runtime`
- Refactor environment variable parsing into helpers in `cli.rs`
- Add tests for create and list commands


## Tests


- [ ]  make test passed
- [ ]  make test:cli passed
- [ ] new tests passed



##  List command output

<img width="661" height="112" alt="image" src="https://github.com/user-attachments/assets/2d4942c3-d643-4149-bd0d-4f25a9481de6" />
