### PR TITLE
fix(ci): prefix npm publish paths with ./ to avoid GitHub shorthand

### DIFF
--- a/.github/workflows/build-node.yml
+++ b/.github/workflows/build-node.yml
@@ -174,7 +174,7 @@ jobs:
         run: |
           for target in darwin-arm64 linux-x64-gnu; do
             echo "Publishing @boxlite-ai/boxlite-$target..."
-            npm publish packages/boxlite-ai-boxlite-$target-*.tgz --provenance --access public
+            npm publish ./packages/boxlite-ai-boxlite-$target-*.tgz --provenance --access public
           done
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -184,7 +184,7 @@ jobs:
 
       - name: Publish main package
         run: |
-          npm publish packages/boxlite-ai-boxlite-[0-9]*.tgz --provenance --access public
+          npm publish ./packages/boxlite-ai-boxlite-[0-9]*.tgz --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
## Summary

- Prefix npm publish paths with `./` to prevent npm from misinterpreting them as GitHub shorthand

## Problem

npm interprets `packages/file.tgz` as GitHub shorthand (`owner/repo` format), converting it to:
```
ssh://git@github.com/packages/boxlite-ai-boxlite-darwin-arm64-0.1.4.tgz.git
```

This causes the publish to fail with "Permission denied (publickey)".

## Solution

Prefix paths with `./` to make them unambiguously local file references:
```bash
# Before
npm publish packages/boxlite-ai-boxlite-$target-*.tgz

# After  
npm publish ./packages/boxlite-ai-boxlite-$target-*.tgz
```

## Verification

Tested locally:
- Without `./`: git error trying to resolve as GitHub repo
- With `./`: correctly recognizes tarball and shows package contents

## Test plan

- [ ] Merge this PR
- [ ] Re-trigger the release workflow
- [ ] Verify platform packages publish successfully
- [ ] Verify main package publishes successfully