### PR TITLE
fix(ci): use npm trusted publishing with OIDC

### DIFF
--- a/.github/workflows/build-node.yml
+++ b/.github/workflows/build-node.yml
@@ -157,7 +157,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Download all packages
@@ -176,8 +176,6 @@ jobs:
             echo "Publishing @boxlite-ai/boxlite-$target..."
             npm publish ./packages/boxlite-ai-boxlite-$target-*.tgz --provenance --access public
           done
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Wait for npm registry sync
         run: sleep 30
@@ -185,8 +183,6 @@ jobs:
       - name: Publish main package
         run: |
           npm publish ./packages/boxlite-ai-boxlite-[0-9]*.tgz --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   upload-to-release:
     name: Upload to GitHub Release


### PR DESCRIPTION
## Summary

- Upgrade to Node 24 in publish job for npm CLI 11.5.1+ (required for trusted publishing)
- Remove `NODE_AUTH_TOKEN` env vars (OIDC replaces token-based auth)

## Problem

The npm publish fails with `ENEEDAUTH` because:
1. `NODE_AUTH_TOKEN` is empty (no `NPM_TOKEN` secret)
2. Trusted publishing requires npm 11.5.1+, but Node 20 ships with npm 10.8.2

## Solution

Use npm's trusted publishing feature which authenticates via OIDC tokens from GitHub Actions instead of long-lived npm tokens.

**Changes:**
- Node 24 (for npm 11.5.1+) - only in publish job, doesn't affect SDK compatibility
- Remove `NODE_AUTH_TOKEN` env vars - OIDC handles authentication

## Compatibility

- SDK declares `engines: ">=18.0.0"` - Node 24 satisfies this
- Publish job only runs `npm publish`, not SDK code
- SDK is tested on Node 18, 20, 22 in separate test jobs

## Prerequisites

Ensure trusted publisher is configured on npmjs.com for each package:
- Organization: `boxlite-ai`
- Repository: `boxlite`
- Workflow: `build-node.yml` (case-sensitive!)

## Test plan

- [ ] Merge and re-trigger release workflow
- [ ] Verify npm CLI version is 11.5.1+
- [ ] Verify packages publish with OIDC authentication