### PR TITLE
feat: add custom image registry support

### DIFF
--- a/boxlite-cli/src/cli.rs
+++ b/boxlite-cli/src/cli.rs
@@ -79,6 +79,7 @@ impl GlobalFlags {
         let options = if let Some(home) = &self.home {
             BoxliteOptions {
                 home_dir: home.clone(),
+                image_registries: vec![],
             }
         } else {
             BoxliteOptions::default()

--- a/boxlite-cli/src/commands/rm.rs
+++ b/boxlite-cli/src/commands/rm.rs
@@ -15,6 +15,7 @@ pub async fn execute(args: RmArgs, global: &crate::cli::GlobalFlags) -> anyhow::
     let options = if let Some(home) = &global.home {
         boxlite::BoxliteOptions {
             home_dir: home.clone(),
+            image_registries: vec![],
         }
     } else {
         boxlite::BoxliteOptions::default()

--- a/boxlite/src/images/manager.rs
+++ b/boxlite/src/images/manager.rs
@@ -80,8 +80,13 @@ impl std::fmt::Debug for ImageManager {
 
 impl ImageManager {
     /// Create a new image manager for the given images directory.
-    pub fn new(images_dir: PathBuf, db: Database) -> BoxliteResult<Self> {
-        let store = Arc::new(ImageStore::new(images_dir, db)?);
+    ///
+    /// # Arguments
+    /// * `images_dir` - Directory for image cache
+    /// * `db` - Database for image index
+    /// * `registries` - Registries to search for unqualified images (tried in order)
+    pub fn new(images_dir: PathBuf, db: Database, registries: Vec<String>) -> BoxliteResult<Self> {
+        let store = Arc::new(ImageStore::new(images_dir, db, registries)?);
         Ok(Self { store })
     }
 

--- a/boxlite/src/images/mod.rs
+++ b/boxlite/src/images/mod.rs
@@ -9,3 +9,244 @@ pub use archive::extract_layer_tarball_streaming;
 pub use config::ContainerImageConfig;
 pub use manager::ImageManager;
 pub use object::ImageObject;
+
+use oci_client::Reference;
+
+// ============================================================================
+// Registry Resolution (Reference Iterator)
+// ============================================================================
+
+/// Iterator that yields `Reference` candidates for an image.
+///
+/// For qualified images (e.g., `"ghcr.io/foo/bar"`), yields only the original.
+/// For unqualified images (e.g., `"alpine"`), yields one `Reference` per registry.
+///
+/// # Examples
+///
+/// ```ignore
+/// // Unqualified image with registries - yields one per registry
+/// let registries = vec!["docker.io".into(), "quay.io".into()];
+/// let iter = ReferenceIter::new("alpine:latest", &registries)?;
+/// for reference in iter {
+///     println!("{}", reference.whole());
+/// }
+/// // Prints: docker.io/alpine:latest, quay.io/alpine:latest
+///
+/// // Qualified image - yields original only
+/// let iter = ReferenceIter::new("ghcr.io/foo/bar:v1", &registries)?;
+/// // Yields only: ghcr.io/foo/bar:v1
+/// ```
+pub(crate) struct ReferenceIter<'a> {
+    /// The parsed base reference (before registry substitution).
+    base_ref: Reference,
+    /// List of registries to try for unqualified images (tried in order).
+    registries: &'a [String],
+    /// Current index in the registries list (for iteration state).
+    index: usize,
+    /// Whether the original image ref was fully qualified (has explicit registry).
+    /// If true, we skip registry substitution and yield the original only.
+    is_qualified: bool,
+    /// Whether we've already yielded the original reference.
+    /// Used for qualified refs or when registries list is empty.
+    yielded_original: bool,
+}
+
+impl<'a> ReferenceIter<'a> {
+    /// Create a new iterator for the given image reference and registries.
+    ///
+    /// # Arguments
+    ///
+    /// * `image_ref` - The image reference string (e.g., "alpine:latest" or "ghcr.io/foo/bar:v1")
+    /// * `registries` - List of registries to try for unqualified images
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the image reference cannot be parsed by oci_client.
+    pub fn new(image_ref: &str, registries: &'a [String]) -> Result<Self, oci_client::ParseError> {
+        let base_ref: Reference = image_ref.parse()?;
+        let is_qualified = is_fully_qualified(image_ref);
+
+        tracing::debug!(
+            image_ref = %image_ref,
+            is_qualified = %is_qualified,
+            registry_count = registries.len(),
+            "Created reference iterator for image resolution"
+        );
+
+        Ok(Self {
+            base_ref,
+            registries,
+            index: 0,
+            is_qualified,
+            yielded_original: false,
+        })
+    }
+}
+
+impl Iterator for ReferenceIter<'_> {
+    type Item = Reference;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // Qualified image: yield original once
+        if self.is_qualified {
+            if self.yielded_original {
+                return None;
+            }
+            self.yielded_original = true;
+            return Some(self.base_ref.clone());
+        }
+
+        // Unqualified with no registries: yield original once (docker.io default)
+        if self.registries.is_empty() {
+            if self.yielded_original {
+                return None;
+            }
+            self.yielded_original = true;
+            return Some(self.base_ref.clone());
+        }
+
+        // Unqualified: yield one Reference per registry
+        if self.index >= self.registries.len() {
+            return None;
+        }
+
+        let registry = &self.registries[self.index];
+        self.index += 1;
+
+        let tag = self.base_ref.tag().unwrap_or("latest").to_string();
+        Some(Reference::with_tag(
+            registry.clone(),
+            self.base_ref.repository().to_string(),
+            tag,
+        ))
+    }
+}
+
+/// Check if an image reference is fully qualified (contains a registry).
+///
+/// A reference is considered fully qualified if it contains a `/` and the
+/// part before the first `/` looks like a registry hostname:
+/// - Contains a `.` (e.g., `docker.io`, `ghcr.io`)
+/// - Contains a `:` (e.g., `localhost:5000`)
+/// - Is exactly `localhost`
+fn is_fully_qualified(image_ref: &str) -> bool {
+    if let Some(slash_pos) = image_ref.find('/') {
+        let first_part = &image_ref[..slash_pos];
+        first_part.contains('.') || first_part.contains(':') || first_part == "localhost"
+    } else {
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper to collect References as (registry, repository, tag) tuples for easy comparison
+    fn collect_refs(iter: ReferenceIter) -> Vec<(String, String, Option<String>)> {
+        iter.map(|r| {
+            (
+                r.registry().to_string(),
+                r.repository().to_string(),
+                r.tag().map(|t| t.to_string()),
+            )
+        })
+        .collect()
+    }
+
+    #[test]
+    fn test_empty_registries_yields_original() {
+        // Empty list - yields original once (docker.io default behavior)
+        let registries: Vec<String> = vec![];
+        let iter = ReferenceIter::new("alpine", &registries).unwrap();
+        let refs = collect_refs(iter);
+
+        assert_eq!(refs.len(), 1);
+        // oci_client normalizes "alpine" to docker.io/library/alpine
+        assert_eq!(refs[0].0, "docker.io");
+    }
+
+    #[test]
+    fn test_single_registry() {
+        let registries = vec!["ghcr.io".to_string()];
+        let iter = ReferenceIter::new("alpine", &registries).unwrap();
+        let refs = collect_refs(iter);
+
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0].0, "ghcr.io");
+        // Repository should be "library/alpine" (normalized by oci_client)
+    }
+
+    #[test]
+    fn test_multiple_registries() {
+        let registries = vec![
+            "ghcr.io".to_string(),
+            "quay.io".to_string(),
+            "docker.io".to_string(),
+        ];
+        let iter = ReferenceIter::new("alpine:3.18", &registries).unwrap();
+        let refs = collect_refs(iter);
+
+        assert_eq!(refs.len(), 3);
+        assert_eq!(refs[0].0, "ghcr.io");
+        assert_eq!(refs[1].0, "quay.io");
+        assert_eq!(refs[2].0, "docker.io");
+
+        // All should have the same tag
+        for r in &refs {
+            assert_eq!(r.2, Some("3.18".to_string()));
+        }
+    }
+
+    #[test]
+    fn test_qualified_bypasses_registries() {
+        let registries = vec!["ghcr.io".to_string()];
+
+        // docker.io is a registry - should yield only original
+        let iter = ReferenceIter::new("docker.io/library/alpine", &registries).unwrap();
+        let refs = collect_refs(iter);
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0].0, "docker.io");
+
+        // quay.io is a registry
+        let iter = ReferenceIter::new("quay.io/foo/bar:v1", &registries).unwrap();
+        let refs = collect_refs(iter);
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0].0, "quay.io");
+
+        // localhost is a registry
+        let iter = ReferenceIter::new("localhost/myimage", &registries).unwrap();
+        let refs = collect_refs(iter);
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0].0, "localhost");
+    }
+
+    #[test]
+    fn test_namespace_not_registry() {
+        // "library/alpine" - "library" is NOT a registry (no dot, no port, not localhost)
+        let registries = vec!["ghcr.io".to_string()];
+        let iter = ReferenceIter::new("library/alpine", &registries).unwrap();
+        let refs = collect_refs(iter);
+
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0].0, "ghcr.io");
+        // Repository includes the namespace
+        assert!(refs[0].1.contains("library"));
+    }
+
+    #[test]
+    fn test_is_fully_qualified() {
+        // Qualified (has registry)
+        assert!(is_fully_qualified("docker.io/library/alpine"));
+        assert!(is_fully_qualified("ghcr.io/owner/repo"));
+        assert!(is_fully_qualified("localhost/myimage"));
+        assert!(is_fully_qualified("localhost:5000/myimage"));
+        assert!(is_fully_qualified("my-registry.com:5000/image"));
+
+        // Not qualified (no registry)
+        assert!(!is_fully_qualified("alpine"));
+        assert!(!is_fully_qualified("alpine:latest"));
+        assert!(!is_fully_qualified("library/alpine"));
+        assert!(!is_fully_qualified("myorg/myimage:v1"));
+    }
+}

--- a/boxlite/src/runtime/options.rs
+++ b/boxlite/src/runtime/options.rs
@@ -503,6 +503,28 @@ impl SecurityOptionsBuilder {
 #[derive(Clone, Debug)]
 pub struct BoxliteOptions {
     pub home_dir: PathBuf,
+    /// Registries to search for unqualified image references.
+    ///
+    /// When pulling an image without a registry prefix (e.g., `"alpine"`),
+    /// these registries are tried in order until one succeeds.
+    ///
+    /// - Empty list (default): Uses docker.io as the implicit default
+    /// - Non-empty list: Tries each registry in order, first success wins
+    /// - Fully qualified refs (e.g., `"quay.io/foo"`) bypass this list
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// BoxliteOptions {
+    ///     image_registries: vec![
+    ///         "ghcr.io/myorg".to_string(),
+    ///         "docker.io".to_string(),
+    ///     ],
+    ///     ..Default::default()
+    /// }
+    /// // "alpine" → tries ghcr.io/myorg/alpine, then docker.io/alpine
+    /// ```
+    pub image_registries: Vec<String>,
 }
 
 impl Default for BoxliteOptions {
@@ -515,7 +537,10 @@ impl Default for BoxliteOptions {
                 path
             });
 
-        Self { home_dir }
+        Self {
+            home_dir,
+            image_registries: Vec::new(),
+        }
     }
 }
 

--- a/boxlite/src/runtime/rt_impl.rs
+++ b/boxlite/src/runtime/rt_impl.rs
@@ -141,13 +141,16 @@ impl RuntimeImpl {
             ))
         })?;
 
-        let image_manager = ImageManager::new(layout.images_dir(), db.clone()).map_err(|e| {
-            BoxliteError::Storage(format!(
-                "Failed to initialize image manager at {}: {}",
-                layout.images_dir().display(),
-                e
-            ))
-        })?;
+        let image_manager =
+            ImageManager::new(layout.images_dir(), db.clone(), options.image_registries).map_err(
+                |e| {
+                    BoxliteError::Storage(format!(
+                        "Failed to initialize image manager at {}: {}",
+                        layout.images_dir().display(),
+                        e
+                    ))
+                },
+            )?;
 
         let box_store = BoxStore::new(db);
 

--- a/boxlite/tests/lifecycle.rs
+++ b/boxlite/tests/lifecycle.rs
@@ -20,6 +20,7 @@ impl TestContext {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
         let options = BoxliteOptions {
             home_dir: temp_dir.path().to_path_buf(),
+            image_registries: vec![],
         };
         let runtime = BoxliteRuntime::new(options).expect("Failed to create runtime");
         Self {
@@ -582,6 +583,7 @@ async fn boxes_persist_across_runtime_restart() {
     {
         let options = BoxliteOptions {
             home_dir: home_dir.clone(),
+            image_registries: vec![],
         };
         let runtime = BoxliteRuntime::new(options).expect("Failed to create runtime");
         let litebox = runtime
@@ -607,7 +609,10 @@ async fn boxes_persist_across_runtime_restart() {
 
     // Create new runtime with same home directory (simulates restart)
     {
-        let options = BoxliteOptions { home_dir };
+        let options = BoxliteOptions {
+            home_dir,
+            image_registries: vec![],
+        };
         let runtime = BoxliteRuntime::new(options).expect("Failed to create runtime");
 
         // Box should be recovered from database
@@ -636,6 +641,7 @@ async fn multiple_boxes_persist_and_recover_without_lock_errors() {
     {
         let options = BoxliteOptions {
             home_dir: home_dir.clone(),
+            image_registries: vec![],
         };
         let runtime = BoxliteRuntime::new(options).expect("Failed to create runtime");
 
@@ -691,7 +697,10 @@ async fn multiple_boxes_persist_and_recover_without_lock_errors() {
     // Create new runtime with same home directory (simulates restart)
     // This should successfully recover all boxes without lock allocation errors
     {
-        let options = BoxliteOptions { home_dir };
+        let options = BoxliteOptions {
+            home_dir,
+            image_registries: vec![],
+        };
         let runtime = BoxliteRuntime::new(options).expect("Failed to create runtime after restart");
 
         // All boxes should be recovered from database
@@ -865,6 +874,7 @@ async fn recovery_removes_auto_remove_true_boxes() {
     {
         let options = BoxliteOptions {
             home_dir: home_dir.clone(),
+            image_registries: vec![],
         };
         let runtime = BoxliteRuntime::new(options).expect("Failed to create runtime");
 
@@ -911,7 +921,10 @@ async fn recovery_removes_auto_remove_true_boxes() {
 
     // Create new runtime with same home directory (simulates restart)
     {
-        let options = BoxliteOptions { home_dir };
+        let options = BoxliteOptions {
+            home_dir,
+            image_registries: vec![],
+        };
         let runtime = BoxliteRuntime::new(options).expect("Failed to create runtime after restart");
 
         // auto_remove=true box should be removed during recovery
@@ -949,6 +962,7 @@ async fn recovery_removes_orphaned_stopped_boxes_without_directory() {
     {
         let options = BoxliteOptions {
             home_dir: home_dir.clone(),
+            image_registries: vec![],
         };
         let runtime = BoxliteRuntime::new(options).expect("Failed to create runtime");
 
@@ -980,7 +994,10 @@ async fn recovery_removes_orphaned_stopped_boxes_without_directory() {
 
     // Create new runtime with same home directory (simulates restart)
     {
-        let options = BoxliteOptions { home_dir };
+        let options = BoxliteOptions {
+            home_dir,
+            image_registries: vec![],
+        };
         let runtime = BoxliteRuntime::new(options).expect("Failed to create runtime after restart");
 
         // Stopped box without directory should be KEPT (it might never have been started)

--- a/boxlite/tests/runtime.rs
+++ b/boxlite/tests/runtime.rs
@@ -13,12 +13,14 @@ fn test_runtime_prevents_concurrent_access() {
     // Create first runtime
     let config1 = BoxliteOptions {
         home_dir: temp_dir.path().to_path_buf(),
+        image_registries: vec![],
     };
     let runtime1 = BoxliteRuntime::new(config1).unwrap();
 
     // Try to create second runtime (should fail)
     let config2 = BoxliteOptions {
         home_dir: temp_dir.path().to_path_buf(),
+        image_registries: vec![],
     };
     let result = BoxliteRuntime::new(config2);
     assert!(result.is_err());
@@ -33,6 +35,7 @@ fn test_runtime_prevents_concurrent_access() {
     // Now should be able to create another
     let config3 = BoxliteOptions {
         home_dir: temp_dir.path().to_path_buf(),
+        image_registries: vec![],
     };
     let _runtime2 = BoxliteRuntime::new(config3).unwrap();
 }
@@ -45,6 +48,7 @@ fn test_runtime_lock_released_on_drop() {
     {
         let config = BoxliteOptions {
             home_dir: temp_dir.path().to_path_buf(),
+            image_registries: vec![],
         };
         let _runtime = BoxliteRuntime::new(config).unwrap();
     } // Lock released here
@@ -52,6 +56,7 @@ fn test_runtime_lock_released_on_drop() {
     // Should be able to create new runtime
     let config2 = BoxliteOptions {
         home_dir: temp_dir.path().to_path_buf(),
+        image_registries: vec![],
     };
     let _runtime2 = BoxliteRuntime::new(config2).unwrap();
 }
@@ -64,6 +69,7 @@ fn test_runtime_lock_across_threads() {
     // Acquire lock in main thread
     let config1 = BoxliteOptions {
         home_dir: dir_path.clone(),
+        image_registries: vec![],
     };
     let _runtime1 = BoxliteRuntime::new(config1).unwrap();
 
@@ -72,6 +78,7 @@ fn test_runtime_lock_across_threads() {
     let handle = thread::spawn(move || {
         let config = BoxliteOptions {
             home_dir: dir_clone,
+            image_registries: vec![],
         };
         BoxliteRuntime::new(config)
     });
@@ -88,12 +95,14 @@ fn test_different_home_dirs_independent() {
     // Create runtime in first directory
     let config1 = BoxliteOptions {
         home_dir: temp_dir1.path().to_path_buf(),
+        image_registries: vec![],
     };
     let _runtime1 = BoxliteRuntime::new(config1).unwrap();
 
     // Should be able to create runtime in second directory
     let config2 = BoxliteOptions {
         home_dir: temp_dir2.path().to_path_buf(),
+        image_registries: vec![],
     };
     let _runtime2 = BoxliteRuntime::new(config2).unwrap();
 
@@ -108,6 +117,7 @@ fn test_lock_file_created() {
 
     let config = BoxliteOptions {
         home_dir: temp_dir.path().to_path_buf(),
+        image_registries: vec![],
     };
     let _runtime = BoxliteRuntime::new(config).unwrap();
 
@@ -122,6 +132,7 @@ fn test_lock_survives_short_operations() {
 
     let config1 = BoxliteOptions {
         home_dir: temp_dir.path().to_path_buf(),
+        image_registries: vec![],
     };
     let runtime = BoxliteRuntime::new(config1).unwrap();
 
@@ -131,6 +142,7 @@ fn test_lock_survives_short_operations() {
     // Lock should still be held
     let config2 = BoxliteOptions {
         home_dir: temp_dir.path().to_path_buf(),
+        image_registries: vec![],
     };
     let result = BoxliteRuntime::new(config2);
     assert!(result.is_err());

--- a/examples/node/custom_registry.js
+++ b/examples/node/custom_registry.js
@@ -1,0 +1,83 @@
+/**
+ * Custom Registry Example - Using alternative container registries
+ *
+ * Demonstrates:
+ * - Configuring custom image registries for unqualified image references
+ * - Registry fallback behavior (tries each in order)
+ * - Using private/enterprise registries
+ */
+
+import { SimpleBox, JsBoxlite } from '@boxlite-ai/boxlite';
+
+async function exampleCustomRegistries() {
+  console.log('\n=== Example: Custom Image Registries ===');
+
+  // Configure runtime with custom registries
+  // Registries are tried in order; first successful pull wins
+  const runtime = new JsBoxlite({
+    imageRegistries: ['ghcr.io', 'quay.io', 'docker.io']
+  });
+
+  console.log('Configured registries: ghcr.io, quay.io, docker.io');
+  console.log("When pulling 'alpine', BoxLite will try:");
+  console.log('  1. ghcr.io/library/alpine');
+  console.log('  2. quay.io/library/alpine');
+  console.log('  3. docker.io/library/alpine');
+  console.log();
+
+  // Create a box using the configured registries
+  // The 'alpine' image will be resolved through the registry list
+  const box = new SimpleBox({
+    image: 'alpine:latest',
+    runtime: runtime,
+  });
+
+  try {
+    console.log(`Creating container...`);
+    const result = await box.exec('cat', '/etc/os-release');
+    console.log(`Container started: ${box.id}`);
+    console.log(`\nOS Info:\n${result.stdout}`);
+  } finally {
+    await box.stop();
+  }
+}
+
+function exampleDefaultVsCustom() {
+  console.log('\n=== Example: Default vs Custom Registry ===');
+
+  // Default behavior: uses docker.io for unqualified images
+  console.log('Default behavior (no custom registries):');
+  console.log("  'alpine' -> docker.io/library/alpine");
+
+  // Custom registries: tries each in order
+  console.log("\nWith custom registries ['ghcr.io', 'docker.io']:");
+  console.log("  'alpine' -> ghcr.io/library/alpine (try first)");
+  console.log("           -> docker.io/library/alpine (fallback)");
+
+  // Fully qualified images bypass registry resolution
+  console.log('\nFully qualified images bypass registry list:');
+  console.log("  'docker.io/library/alpine' -> docker.io/library/alpine (direct)");
+  console.log("  'ghcr.io/foo/bar:v1' -> ghcr.io/foo/bar:v1 (direct)");
+}
+
+async function main() {
+  console.log('Custom Registry Example');
+  console.log('='.repeat(60));
+
+  await exampleCustomRegistries();
+  exampleDefaultVsCustom();
+
+  console.log('\n' + '='.repeat(60));
+  console.log('Key Takeaways:');
+  console.log('  - Use new JsBoxlite({ imageRegistries: [...] }) to configure registries');
+  console.log('  - Pass runtime to SimpleBox: new SimpleBox({ runtime, image: ... })');
+  console.log('  - Registries are tried in order; first success wins');
+  console.log('  - Fully qualified images (e.g., docker.io/...) bypass the list');
+  console.log('  - Great for enterprise environments with private registries');
+}
+
+// Run the example
+main().catch(error => {
+  console.error('Error:', error);
+  process.exit(1);
+});

--- a/examples/python/custom_registry_example.py
+++ b/examples/python/custom_registry_example.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""
+Custom Registry Example - Using alternative container registries
+
+Demonstrates:
+- Configuring custom image registries for unqualified image references
+- Registry fallback behavior (tries each in order)
+- Using private/enterprise registries
+"""
+
+import asyncio
+import logging
+import sys
+
+import boxlite
+
+logger = logging.getLogger("custom_registry_example")
+
+
+def setup_logging():
+    """Configure stdout logging for the example."""
+    logging.basicConfig(
+        level=logging.ERROR,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        handlers=[logging.StreamHandler(sys.stdout)],
+    )
+
+
+async def example_custom_registries():
+    """Example: Configure custom image registries."""
+    print("\n=== Example: Custom Image Registries ===")
+
+    # Configure runtime with custom registries
+    # Registries are tried in order; first successful pull wins
+    options = boxlite.Options(
+        image_registries=["ghcr.io", "quay.io", "docker.io"]
+    )
+
+    print(f"Configured registries: {options.image_registries}")
+    print("When pulling 'alpine', BoxLite will try:")
+    print("  1. ghcr.io/library/alpine")
+    print("  2. quay.io/library/alpine")
+    print("  3. docker.io/library/alpine")
+    print()
+
+    # Create runtime with custom registries
+    runtime = boxlite.Boxlite(options)
+
+    # Create a box using the configured registries
+    # The 'alpine' image will be resolved through the registry list
+    async with boxlite.SimpleBox(
+        image="alpine:latest",
+        runtime=runtime,
+    ) as box:
+        print(f"Container started: {box.id}")
+
+        # Run a command to verify the container is working
+        result = await box.exec("cat", "/etc/os-release")
+        print(f"\nOS Info:\n{result.stdout}")
+
+
+async def example_default_vs_custom():
+    """Example: Compare default vs custom registry behavior."""
+    print("\n=== Example: Default vs Custom Registry ===")
+
+    # Default behavior: uses docker.io for unqualified images
+    print("Default behavior (no custom registries):")
+    print("  'alpine' -> docker.io/library/alpine")
+
+    # Custom registries: tries each in order
+    options = boxlite.Options(
+        image_registries=["ghcr.io", "docker.io"]
+    )
+    print("\nWith custom registries ['ghcr.io', 'docker.io']:")
+    print("  'alpine' -> ghcr.io/library/alpine (try first)")
+    print("           -> docker.io/library/alpine (fallback)")
+
+    # Fully qualified images bypass registry resolution
+    print("\nFully qualified images bypass registry list:")
+    print("  'docker.io/library/alpine' -> docker.io/library/alpine (direct)")
+    print("  'ghcr.io/foo/bar:v1' -> ghcr.io/foo/bar:v1 (direct)")
+
+
+async def main():
+    """Run all examples."""
+    print("Custom Registry Example")
+    print("=" * 60)
+
+    await example_custom_registries()
+    await example_default_vs_custom()
+
+    print("\n" + "=" * 60)
+    print("Key Takeaways:")
+    print("  - Use Options(image_registries=[...]) to configure registries")
+    print("  - Registries are tried in order; first success wins")
+    print("  - Fully qualified images (e.g., docker.io/...) bypass the list")
+    print("  - Great for enterprise environments with private registries")
+
+
+if __name__ == "__main__":
+    setup_logging()
+    asyncio.run(main())

--- a/sdks/c/include/boxlite.h
+++ b/sdks/c/include/boxlite.h
@@ -36,6 +36,9 @@ const char *boxlite_version(void);
  * # Arguments
  * * `home_dir` - Path to BoxLite home directory (stores images, rootfs, etc.)
  *                If NULL, uses default: ~/.boxlite
+ * * `registries_json` - JSON array of registries to search for unqualified images,
+ *                       e.g. `["ghcr.io", "quay.io"]`. If NULL, uses default (docker.io).
+ *                       Registries are tried in order; first successful pull wins.
  * * `out_error` - Output parameter for error message (caller must free with boxlite_free_string)
  *
  * # Returns
@@ -44,7 +47,8 @@ const char *boxlite_version(void);
  * # Example
  * ```c
  * char *error = NULL;
- * BoxliteRuntime *runtime = boxlite_runtime_new("/tmp/boxlite", &error);
+ * const char *registries = "[\"ghcr.io\", \"docker.io\"]";
+ * BoxliteRuntime *runtime = boxlite_runtime_new("/tmp/boxlite", registries, &error);
  * if (!runtime) {
  *     fprintf(stderr, "Error: %s\n", error);
  *     boxlite_free_string(error);
@@ -52,7 +56,9 @@ const char *boxlite_version(void);
  * }
  * ```
  */
-struct CBoxliteRuntime *boxlite_runtime_new(const char *home_dir, char **out_error);
+struct CBoxliteRuntime *boxlite_runtime_new(const char *home_dir,
+                                            const char *registries_json,
+                                            char **out_error);
 
 /**
  * Create a new box with the given options (JSON)

--- a/sdks/node/src/options.rs
+++ b/sdks/node/src/options.rs
@@ -14,6 +14,10 @@ use napi_derive::napi;
 pub struct JsOptions {
     /// Home directory for BoxLite data (defaults to ~/.boxlite)
     pub home_dir: Option<String>,
+    /// Registries to search for unqualified image references.
+    /// Tried in order; first successful pull wins.
+    /// Example: ["ghcr.io", "quay.io", "docker.io"]
+    pub image_registries: Option<Vec<String>>,
 }
 
 impl From<JsOptions> for BoxliteOptions {
@@ -22,6 +26,10 @@ impl From<JsOptions> for BoxliteOptions {
 
         if let Some(home_dir) = js_opts.home_dir {
             config.home_dir = PathBuf::from(home_dir);
+        }
+
+        if let Some(registries) = js_opts.image_registries {
+            config.image_registries = registries;
         }
 
         config

--- a/sdks/python/src/options.rs
+++ b/sdks/python/src/options.rs
@@ -14,18 +14,28 @@ use pyo3::types::{PyAnyMethods, PyDict, PyTuple};
 pub(crate) struct PyOptions {
     #[pyo3(get, set)]
     pub(crate) home_dir: Option<String>,
+    /// Registries to search for unqualified image references.
+    /// Tried in order; first successful pull wins.
+    #[pyo3(get, set)]
+    pub(crate) image_registries: Vec<String>,
 }
 
 #[pymethods]
 impl PyOptions {
     #[new]
-    #[pyo3(signature = (home_dir=None))]
-    fn new(home_dir: Option<String>) -> Self {
-        Self { home_dir }
+    #[pyo3(signature = (home_dir=None, image_registries=vec![]))]
+    fn new(home_dir: Option<String>, image_registries: Vec<String>) -> Self {
+        Self {
+            home_dir,
+            image_registries,
+        }
     }
 
     fn __repr__(&self) -> String {
-        format!("Options(home_dir={:?})", self.home_dir)
+        format!(
+            "Options(home_dir={:?}, image_registries={:?})",
+            self.home_dir, self.image_registries
+        )
     }
 }
 
@@ -36,6 +46,8 @@ impl From<PyOptions> for BoxliteOptions {
         if let Some(home_dir) = py_opts.home_dir {
             config.home_dir = PathBuf::from(home_dir);
         }
+
+        config.image_registries = py_opts.image_registries;
 
         config
     }


### PR DESCRIPTION
## Summary
- Add `image_registries` configuration option to `BoxliteOptions` for specifying custom registries
- Registries are tried in order when resolving unqualified image names (e.g., `alpine` instead of `docker.io/library/alpine`)
- Expose registry configuration across all SDKs (Python, Node.js, C)
- Add example scripts demonstrating custom registry usage

## Test plan
- [ ] Run existing tests: `cargo test`
- [ ] Test Python SDK with custom registry: `python examples/python/custom_registry_example.py`
- [ ] Test Node.js SDK with custom registry: `node examples/node/custom_registry.js`
- [ ] Verify default behavior unchanged when no registries configured