### PR TITLE
docs: add Windows WSL2 support documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,8 +129,8 @@ make dist:python    # Build portable Python wheel
 ### Critical for AI Assistants
 
 **Platform support:**
-- ✅ macOS ARM64 (Apple Silicon), Linux x86_64/ARM64
-- ❌ macOS Intel, Windows (not supported)
+- ✅ macOS ARM64 (Apple Silicon), Linux x86_64/ARM64, Windows (via WSL2)
+- ❌ macOS Intel (not supported)
 
 **Before building:**
 - ⚠️ **MUST** run `git submodule update --init --recursive` (vendored dependencies)

--- a/README.md
+++ b/README.md
@@ -163,21 +163,22 @@ For details, see [Architecture](./docs/architecture/).
 
 ## Supported Platforms
 
-| Platform | Architecture          | Status          |
-|----------|-----------------------|-----------------|
-| macOS    | Apple Silicon (ARM64) | ✅ Supported     |
-| Linux    | x86_64                | ✅ Supported     |
-| Linux    | ARM64                 | ✅ Supported     |
-| macOS    | Intel (x86_64)        | ❌ Not supported |
-| Windows  | —                     | ❌ Not supported |
+| Platform       | Architecture          | Status           |
+|----------------|-----------------------|------------------|
+| macOS          | Apple Silicon (ARM64) | ✅ Supported     |
+| Linux          | x86_64                | ✅ Supported     |
+| Linux          | ARM64                 | ✅ Supported     |
+| Windows (WSL2) | x86_64                | ✅ Supported     |
+| macOS          | Intel (x86_64)        | ❌ Not supported |
 
 ## System Requirements
 
-| Platform | Requirements                        |
-|----------|-------------------------------------|
-| macOS    | Apple Silicon, macOS 12+            |
-| Linux    | KVM enabled (`/dev/kvm` accessible) |
-| Python   | 3.10+                               |
+| Platform       | Requirements                                   |
+|----------------|------------------------------------------------|
+| macOS          | Apple Silicon, macOS 12+                       |
+| Linux          | KVM enabled (`/dev/kvm` accessible)            |
+| Windows (WSL2) | WSL2 with KVM support, user in `kvm` group     |
+| Python         | 3.10+                                          |
 
 ## Getting Help
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -47,15 +47,34 @@ sudo usermod -aG kvm $USER
 
 ### Can I use BoxLite on Windows?
 
-**No**, BoxLite is not supported on Windows.
+**Yes**, through WSL2 (Windows Subsystem for Linux).
 
-**Alternatives:**
-- Use WSL2 (Windows Subsystem for Linux) with Ubuntu
-- Deploy to a Linux VM or cloud instance
-- Consider cloud-based sandboxing solutions for Windows
+**Requirements:**
+- Windows 10 version 2004+ or Windows 11
+- WSL2 with a Linux distribution (Ubuntu recommended)
+- KVM support enabled in WSL2
 
-**Why not Windows?**
-BoxLite requires KVM (Linux) or Hypervisor.framework (macOS), neither of which are available on Windows.
+**Setup:**
+```bash
+# Inside WSL2, add your user to the kvm group
+sudo usermod -aG kvm $USER
+
+# Apply the new group membership (pick one):
+newgrp kvm
+# OR restart WSL from Windows PowerShell:
+# wsl.exe --shutdown
+
+# Verify KVM access
+python3 -c "open('/dev/kvm','rb').close(); print('kvm ok')"
+```
+
+**Common Issue:** If you see "Timeout waiting for guest ready (30s)" errors, your shell cannot open `/dev/kvm`. This happens when:
+- `/dev/kvm` is owned by `root:kvm` with mode `660`
+- Your user is not in the `kvm` group
+
+Run `sudo usermod -aG kvm $USER` and restart WSL with `wsl.exe --shutdown`.
+
+**Note:** Native Windows (without WSL2) is not supported. BoxLite requires KVM (Linux) or Hypervisor.framework (macOS).
 
 ### What Python versions are supported?
 

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -8,15 +8,15 @@ Get up and running with BoxLite in 5 minutes.
 
 BoxLite requires a platform with hardware virtualization support:
 
-| Platform | Architecture  | Requirements                        |
-|----------|---------------|-------------------------------------|
-| macOS    | Apple Silicon | macOS 12+ (Monterey or later)       |
-| Linux    | x86_64        | KVM enabled (`/dev/kvm` accessible) |
-| Linux    | ARM64         | KVM enabled (`/dev/kvm` accessible) |
+| Platform       | Architecture  | Requirements                        |
+|----------------|---------------|-------------------------------------|
+| macOS          | Apple Silicon | macOS 12+ (Monterey or later)       |
+| Linux          | x86_64        | KVM enabled (`/dev/kvm` accessible) |
+| Linux          | ARM64         | KVM enabled (`/dev/kvm` accessible) |
+| Windows (WSL2) | x86_64        | WSL2 with KVM support               |
 
 **Not Supported:**
 - macOS Intel (x86_64) - Hypervisor.framework stability issues
-- Windows - Use WSL2 with Linux requirements
 
 ### Verify Virtualization Support
 
@@ -45,6 +45,31 @@ sudo modprobe kvm_amd    # For AMD CPUs
 # Add user to kvm group (may require logout/login)
 sudo usermod -aG kvm $USER
 ```
+
+**Windows (WSL2):**
+```bash
+# Verify you're running WSL2 (should show "2")
+wsl.exe -l -v
+
+# Check if KVM is available
+ls -l /dev/kvm
+
+# Add user to kvm group
+sudo usermod -aG kvm $USER
+
+# Apply the new group membership (pick one):
+newgrp kvm
+# OR restart WSL from Windows PowerShell:
+# wsl.exe --shutdown
+
+# Verify group membership
+id -nG | tr ' ' '\n' | grep -x kvm
+
+# Verify KVM access
+python3 -c "open('/dev/kvm','rb').close(); print('kvm ok')"
+```
+
+**Note:** If you see "Timeout waiting for guest ready (30s)" errors, it's likely a KVM permission issue. Ensure your user is in the `kvm` group and restart WSL with `wsl.exe --shutdown`.
 
 ### No Daemon Required
 


### PR DESCRIPTION
## Summary
- Add documentation for running BoxLite on Windows through WSL2
- Update Supported Platforms tables across README.md and getting-started guide
- Add WSL2-specific setup instructions with KVM permission configuration
- Document common "Timeout waiting for guest ready" error and fix

## Test plan
- [ ] Review documentation changes for accuracy
- [ ] Verify links and cross-references work correctly
- [ ] Test WSL2 setup instructions on a Windows machine (if available)