### PR TITLE
docs: add complete API references for all SDKs

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -2,48 +2,54 @@
 
 Complete reference for BoxLite APIs, configuration, and error handling.
 
-## API Reference
+## SDK API References
+
+Complete API documentation for each SDK:
+
+| SDK | Documentation | Description |
+|-----|---------------|-------------|
+| **Python** | [Python API Reference](python/README.md) | Async/sync API, box types, metrics |
+| **Node.js** | [Node.js API Reference](nodejs/README.md) | TypeScript definitions, box types, CDP endpoints |
+| **Rust** | [Rust API Reference](rust/README.md) | Core runtime, stream APIs, security options |
+| **C** | [C API Reference](c/README.md) | FFI bindings, JSON API, callback streaming |
+
+---
+
+## Quick Reference
 
 ### Python API
 
-For complete Python API documentation, see **[Python SDK README](../../sdks/python/README.md)**.
+For complete Python API documentation, see **[Python API Reference](python/README.md)**.
 
-**Quick Reference:**
+**Key Classes:**
 
-| Class/Function | Description |
-|----------------|-------------|
-| `boxlite.Boxlite` | Main runtime for creating and managing boxes |
-| `boxlite.BoxOptions` | Configuration options for creating a box |
-| `boxlite.Box` | Handle to a running or stopped box |
-| `boxlite.Execution` | Represents a running command execution |
-| `boxlite.SimpleBox` | Context manager for basic execution |
-| `boxlite.CodeBox` | Specialized box for Python code execution |
-| `boxlite.BrowserBox` | Box configured for browser automation |
-| `boxlite.ComputerBox` | Box with desktop automation capabilities |
-| `boxlite.InteractiveBox` | Box for interactive shell sessions |
-
-See [Python SDK Reference](../../sdks/python/README.md#core-api-reference) for detailed API documentation.
+| Class | Description |
+|-------|-------------|
+| `Boxlite` | Main runtime for creating and managing boxes |
+| `Box` | Handle to a running or stopped box |
+| `SimpleBox` | Context manager for basic execution |
+| `CodeBox` | Specialized box for Python code execution |
+| `BrowserBox` | Box configured for browser automation |
+| `ComputerBox` | Box with desktop automation capabilities |
+| `InteractiveBox` | Box for interactive shell sessions |
 
 ### Node.js API
 
-For complete Node.js API documentation, see **[Node.js SDK README](../../sdks/node/README.md)**.
+For complete Node.js API documentation, see **[Node.js API Reference](nodejs/README.md)**.
 
-**Quick Reference:**
+**Key Classes:**
 
-| Class/Function | Description |
-|----------------|-------------|
+| Class | Description |
+|-------|-------------|
 | `SimpleBox` | Basic container for command execution |
 | `CodeBox` | Python code execution sandbox |
 | `BrowserBox` | Browser automation with CDP endpoint |
-| `ComputerBox` | Desktop automation (14 functions) |
+| `ComputerBox` | Desktop automation (14 methods) |
 | `InteractiveBox` | PTY terminal sessions |
-| `ExecError` | Command execution failure |
-| `TimeoutError` | Operation timeout |
-| `ParseError` | Output parsing failure |
-
-See [Node.js SDK Reference](../../sdks/node/README.md#api-reference) for detailed API documentation.
 
 ### Rust API
+
+For complete Rust API documentation, see **[Rust API Reference](rust/README.md)**.
 
 **Core Types:**
 
@@ -53,70 +59,24 @@ use boxlite::{
     BoxOptions,       // Box configuration
     LiteBox,          // Box handle
     BoxCommand,       // Command builder
-    RootfsSpec,       // Rootfs specification (Image or Directory)
-    NetworkSpec,      // Network configuration
+    RootfsSpec,       // Rootfs specification
     VolumeSpec,       // Volume mount specification
     PortSpec,         // Port forwarding specification
 };
 ```
 
-**Runtime Creation:**
+### C API
 
-```rust
-// Default runtime (~/.boxlite)
-let runtime = BoxliteRuntime::default_runtime();
+For complete C API documentation, see **[C API Reference](c/README.md)**.
 
-// Custom runtime
-let runtime = BoxliteRuntime::new(RuntimeOptions {
-    home_dir: Some("/custom/path".into()),
-    ..Default::default()
-})?;
-```
+**Functions:**
 
-**Box Creation:**
-
-```rust
-let options = BoxOptions {
-    rootfs: RootfsSpec::Image("alpine:latest".into()),
-    cpus: Some(2),
-    memory_mib: Some(1024),
-    working_dir: Some("/app".into()),
-    env: vec![("KEY".into(), "value".into())],
-    volumes: vec![VolumeSpec {
-        host_path: "/host/data".into(),
-        guest_path: "/mnt/data".into(),
-        read_only: true,
-    }],
-    ports: vec![PortSpec {
-        host_port: 8080,
-        guest_port: 80,
-        protocol: Protocol::Tcp,
-    }],
-    ..Default::default()
-};
-
-let (box_id, litebox) = runtime.create(options)?;
-```
-
-**Command Execution:**
-
-```rust
-use futures::StreamExt;
-
-// Execute command
-let mut execution = litebox
-    .exec(BoxCommand::new("echo").arg("Hello"))
-    .await?;
-
-// Stream stdout
-let mut stdout = execution.stdout().unwrap();
-while let Some(line) = stdout.next().await {
-    println!("{}", line);
-}
-
-// Wait for exit
-let exit_code = execution.wait().await?;
-```
+| Function | Description |
+|----------|-------------|
+| `boxlite_runtime_new` | Create runtime instance |
+| `boxlite_create_box` | Create a new box |
+| `boxlite_execute` | Run command with streaming |
+| `boxlite_stop_box` | Stop and free box |
 
 ## Configuration Reference
 

--- a/docs/reference/c/README.md
+++ b/docs/reference/c/README.md
@@ -1,0 +1,808 @@
+# C SDK API Reference
+
+Complete API reference for the BoxLite C SDK.
+
+## Overview
+
+The C SDK provides C-compatible FFI bindings for integrating BoxLite into C/C++ applications. The API uses JSON for complex types to avoid ABI compatibility issues.
+
+**Library**: `libboxlite`
+**Header**: `boxlite.h`
+
+---
+
+## Table of Contents
+
+- [Quick Start](#quick-start)
+- [Runtime Management](#runtime-management)
+  - [boxlite_version](#boxlite_version)
+  - [boxlite_runtime_new](#boxlite_runtime_new)
+  - [boxlite_runtime_free](#boxlite_runtime_free)
+- [Box Management](#box-management)
+  - [boxlite_create_box](#boxlite_create_box)
+  - [boxlite_execute](#boxlite_execute)
+  - [boxlite_stop_box](#boxlite_stop_box)
+- [Memory Management](#memory-management)
+  - [boxlite_free_string](#boxlite_free_string)
+- [JSON Schema Reference](#json-schema-reference)
+  - [BoxOptions](#boxoptions-schema)
+  - [RootfsSpec](#rootfsspec-schema)
+  - [VolumeSpec](#volumespec-schema)
+  - [PortSpec](#portspec-schema)
+- [Error Handling](#error-handling)
+- [Thread Safety](#thread-safety)
+- [Platform Requirements](#platform-requirements)
+
+---
+
+## Quick Start
+
+```c
+#include <stdio.h>
+#include "boxlite.h"
+
+// Callback for streaming output
+void output_callback(const char* text, int is_stderr, void* user_data) {
+    if (is_stderr) {
+        fprintf(stderr, "%s", text);
+    } else {
+        printf("%s", text);
+    }
+}
+
+int main() {
+    char* error = NULL;
+
+    // Create runtime with default home directory
+    CBoxliteRuntime* runtime = boxlite_runtime_new(NULL, NULL, &error);
+    if (!runtime) {
+        fprintf(stderr, "Failed to create runtime: %s\n", error);
+        boxlite_free_string(error);
+        return 1;
+    }
+
+    // Create box with Alpine Linux
+    const char* options = "{\"rootfs\":{\"Image\":\"alpine:3.19\"}}";
+    CBoxHandle* box = boxlite_create_box(runtime, options, &error);
+    if (!box) {
+        fprintf(stderr, "Failed to create box: %s\n", error);
+        boxlite_free_string(error);
+        boxlite_runtime_free(runtime);
+        return 1;
+    }
+
+    // Execute a command
+    const char* args = "[\"-la\", \"/\"]";
+    int exit_code = boxlite_execute(box, "ls", args, output_callback, NULL, &error);
+    if (exit_code < 0) {
+        fprintf(stderr, "Execution failed: %s\n", error);
+        boxlite_free_string(error);
+    }
+
+    // Stop and cleanup
+    boxlite_stop_box(box, &error);
+    boxlite_runtime_free(runtime);
+
+    return exit_code < 0 ? 1 : exit_code;
+}
+```
+
+### Building
+
+```bash
+# Compile with the BoxLite library
+gcc -I/path/to/boxlite/sdks/c/include \
+    -L/path/to/boxlite/target/release \
+    -lboxlite \
+    my_program.c -o my_program
+
+# On macOS, you may need to set the library path
+export DYLD_LIBRARY_PATH=/path/to/boxlite/target/release:$DYLD_LIBRARY_PATH
+
+# On Linux
+export LD_LIBRARY_PATH=/path/to/boxlite/target/release:$LD_LIBRARY_PATH
+```
+
+---
+
+## Runtime Management
+
+### boxlite_version
+
+Get BoxLite version string.
+
+```c
+const char* boxlite_version(void);
+```
+
+#### Returns
+
+Static string containing the version (e.g., `"0.1.0"`).
+
+#### Example
+
+```c
+printf("BoxLite version: %s\n", boxlite_version());
+```
+
+#### Notes
+
+- Returns a static string - do not free.
+
+---
+
+### boxlite_runtime_new
+
+Create a new BoxLite runtime instance.
+
+```c
+CBoxliteRuntime* boxlite_runtime_new(
+    const char* home_dir,
+    const char* registries_json,
+    char** out_error
+);
+```
+
+#### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `home_dir` | `const char*` | Path to BoxLite home directory. `NULL` uses default (`~/.boxlite`). |
+| `registries_json` | `const char*` | JSON array of image registries, e.g. `["ghcr.io", "docker.io"]`. `NULL` uses default (docker.io). |
+| `out_error` | `char**` | Output parameter for error message. Caller must free with `boxlite_free_string`. |
+
+#### Returns
+
+- Pointer to `CBoxliteRuntime` on success
+- `NULL` on failure (check `out_error`)
+
+#### Example
+
+```c
+char* error = NULL;
+
+// Default configuration
+CBoxliteRuntime* runtime = boxlite_runtime_new(NULL, NULL, &error);
+
+// Custom home directory
+CBoxliteRuntime* runtime = boxlite_runtime_new("/var/lib/boxlite", NULL, &error);
+
+// Custom registries
+const char* registries = "[\"ghcr.io/myorg\", \"docker.io\"]";
+CBoxliteRuntime* runtime = boxlite_runtime_new(NULL, registries, &error);
+
+if (!runtime) {
+    fprintf(stderr, "Error: %s\n", error);
+    boxlite_free_string(error);
+    return 1;
+}
+```
+
+---
+
+### boxlite_runtime_free
+
+Free a runtime instance.
+
+```c
+void boxlite_runtime_free(CBoxliteRuntime* runtime);
+```
+
+#### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `runtime` | `CBoxliteRuntime*` | Runtime instance to free. Can be `NULL`. |
+
+#### Example
+
+```c
+boxlite_runtime_free(runtime);
+runtime = NULL;  // Good practice
+```
+
+---
+
+## Box Management
+
+### boxlite_create_box
+
+Create a new box with the given options.
+
+```c
+CBoxHandle* boxlite_create_box(
+    CBoxliteRuntime* runtime,
+    const char* options_json,
+    char** out_error
+);
+```
+
+#### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `runtime` | `CBoxliteRuntime*` | Runtime instance. |
+| `options_json` | `const char*` | JSON-encoded BoxOptions. |
+| `out_error` | `char**` | Output parameter for error message. |
+
+#### Returns
+
+- Pointer to `CBoxHandle` on success
+- `NULL` on failure (check `out_error`)
+
+#### Example
+
+```c
+// Minimal options (Alpine Linux)
+const char* options = "{\"rootfs\":{\"Image\":\"alpine:3.19\"}}";
+
+// Full options
+const char* full_options = "{"
+    "\"rootfs\":{\"Image\":\"python:3.11-slim\"},"
+    "\"cpus\":2,"
+    "\"memory_mib\":1024,"
+    "\"working_dir\":\"/app\","
+    "\"env\":[[\"PYTHONPATH\",\"/app\"]],"
+    "\"volumes\":[{\"host_path\":\"/home/user/code\",\"guest_path\":\"/app\",\"read_only\":true}],"
+    "\"ports\":[{\"host_port\":8080,\"guest_port\":80}]"
+"}";
+
+char* error = NULL;
+CBoxHandle* box = boxlite_create_box(runtime, options, &error);
+if (!box) {
+    fprintf(stderr, "Failed: %s\n", error);
+    boxlite_free_string(error);
+}
+```
+
+---
+
+### boxlite_execute
+
+Run a command in a box.
+
+```c
+int boxlite_execute(
+    CBoxHandle* handle,
+    const char* command,
+    const char* args_json,
+    void (*callback)(const char* text, int is_stderr, void* user_data),
+    void* user_data,
+    char** out_error
+);
+```
+
+#### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `handle` | `CBoxHandle*` | Box handle. |
+| `command` | `const char*` | Command to run. |
+| `args_json` | `const char*` | JSON array of arguments, e.g. `["arg1", "arg2"]`. Can be `NULL`. |
+| `callback` | function pointer | Optional callback for streaming output. |
+| `user_data` | `void*` | User data passed to callback. |
+| `out_error` | `char**` | Output parameter for error message. |
+
+#### Callback Signature
+
+```c
+void callback(const char* text, int is_stderr, void* user_data);
+```
+
+| Parameter | Description |
+|-----------|-------------|
+| `text` | Output text chunk |
+| `is_stderr` | `0` for stdout, `1` for stderr |
+| `user_data` | User data from `boxlite_execute` |
+
+#### Returns
+
+- Exit code on success (0-255)
+- `-1` on failure (check `out_error`)
+
+#### Example
+
+```c
+// Simple command without callback
+int exit_code = boxlite_execute(box, "echo", "[\"hello\", \"world\"]", NULL, NULL, &error);
+
+// With output callback
+void print_output(const char* text, int is_stderr, void* data) {
+    FILE* stream = is_stderr ? stderr : stdout;
+    fprintf(stream, "%s", text);
+}
+
+int exit_code = boxlite_execute(box, "ls", "[\"-la\"]", print_output, NULL, &error);
+
+// With user data
+typedef struct {
+    int line_count;
+} OutputState;
+
+void count_lines(const char* text, int is_stderr, void* data) {
+    OutputState* state = (OutputState*)data;
+    state->line_count++;
+    printf("[%d] %s", state->line_count, text);
+}
+
+OutputState state = {0};
+boxlite_execute(box, "cat", "[\"/etc/passwd\"]", count_lines, &state, &error);
+printf("Total lines: %d\n", state.line_count);
+```
+
+---
+
+### boxlite_stop_box
+
+Stop and free a box.
+
+```c
+int boxlite_stop_box(CBoxHandle* handle, char** out_error);
+```
+
+#### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `handle` | `CBoxHandle*` | Box handle. Will be consumed and freed. |
+| `out_error` | `char**` | Output parameter for error message. |
+
+#### Returns
+
+- `0` on success
+- `-1` on failure (check `out_error`)
+
+#### Example
+
+```c
+if (boxlite_stop_box(box, &error) != 0) {
+    fprintf(stderr, "Failed to stop: %s\n", error);
+    boxlite_free_string(error);
+}
+// box is now invalid, do not use
+box = NULL;
+```
+
+#### Notes
+
+- The handle is freed even on failure
+- Do not use the handle after calling this function
+
+---
+
+## Memory Management
+
+### boxlite_free_string
+
+Free a string allocated by BoxLite.
+
+```c
+void boxlite_free_string(char* str);
+```
+
+#### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `str` | `char*` | String to free. Can be `NULL`. |
+
+#### Example
+
+```c
+char* error = NULL;
+CBoxliteRuntime* runtime = boxlite_runtime_new(NULL, NULL, &error);
+if (!runtime) {
+    fprintf(stderr, "Error: %s\n", error);
+    boxlite_free_string(error);  // MUST free error strings
+    return 1;
+}
+```
+
+#### Notes
+
+- Always free error strings returned via `out_error` parameters
+- Safe to call with `NULL`
+
+---
+
+## JSON Schema Reference
+
+### BoxOptions Schema
+
+Complete schema for box configuration:
+
+```json
+{
+  "rootfs": {
+    "Image": "alpine:3.19"
+  },
+  "cpus": 2,
+  "memory_mib": 512,
+  "disk_size_gb": 10,
+  "working_dir": "/workspace",
+  "env": [
+    ["KEY", "value"],
+    ["ANOTHER_KEY", "another_value"]
+  ],
+  "volumes": [
+    {
+      "host_path": "/home/user/data",
+      "guest_path": "/data",
+      "read_only": false
+    }
+  ],
+  "network": "Isolated",
+  "ports": [
+    {
+      "host_port": 8080,
+      "guest_port": 80,
+      "protocol": "Tcp"
+    }
+  ],
+  "auto_remove": true,
+  "detach": false
+}
+```
+
+#### Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `rootfs` | object | Required | Root filesystem source |
+| `cpus` | integer | 2 | Number of CPUs |
+| `memory_mib` | integer | 512 | Memory in MiB |
+| `disk_size_gb` | integer | null | Disk size in GB (sparse) |
+| `working_dir` | string | null | Working directory inside box |
+| `env` | array | `[]` | Environment variables as `[key, value]` pairs |
+| `volumes` | array | `[]` | Volume mounts |
+| `network` | string | `"Isolated"` | Network mode |
+| `ports` | array | `[]` | Port mappings |
+| `auto_remove` | boolean | `true` | Remove box when stopped |
+| `detach` | boolean | `false` | Run independently of parent |
+
+### RootfsSpec Schema
+
+Two variants for specifying the root filesystem:
+
+#### Image Reference
+
+```json
+{
+  "rootfs": {
+    "Image": "python:3.11-slim"
+  }
+}
+```
+
+#### Local Rootfs Path
+
+```json
+{
+  "rootfs": {
+    "RootfsPath": "/path/to/rootfs"
+  }
+}
+```
+
+### VolumeSpec Schema
+
+```json
+{
+  "host_path": "/absolute/path/on/host",
+  "guest_path": "/path/in/guest",
+  "read_only": false
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `host_path` | string | Absolute path on host |
+| `guest_path` | string | Mount path inside guest |
+| `read_only` | boolean | Mount as read-only |
+
+### PortSpec Schema
+
+```json
+{
+  "host_port": 8080,
+  "guest_port": 80,
+  "protocol": "Tcp",
+  "host_ip": "127.0.0.1"
+}
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `host_port` | integer | null | Host port (null = dynamic) |
+| `guest_port` | integer | Required | Guest port |
+| `protocol` | string | `"Tcp"` | `"Tcp"` or `"Udp"` |
+| `host_ip` | string | null | Bind IP (null = 0.0.0.0) |
+
+---
+
+## Error Handling
+
+All functions that can fail use the `out_error` pattern:
+
+```c
+char* error = NULL;
+CBoxHandle* box = boxlite_create_box(runtime, options, &error);
+if (!box) {
+    fprintf(stderr, "Error: %s\n", error);
+    boxlite_free_string(error);  // MUST free
+    return 1;
+}
+```
+
+### Common Errors
+
+| Error Type | Description |
+|------------|-------------|
+| `"runtime is null"` | Passed NULL runtime to function |
+| `"handle is null"` | Passed NULL box handle to function |
+| `"Invalid JSON options: ..."` | Malformed JSON in options |
+| `"image error: ..."` | Failed to pull/resolve image |
+| `"box not found: ..."` | Box ID doesn't exist |
+| `"invalid state: ..."` | Operation not allowed in current state |
+
+### Error Handling Best Practices
+
+```c
+// Always check return values
+if (!runtime) {
+    // Handle error
+}
+
+// Always free error strings
+if (error) {
+    boxlite_free_string(error);
+    error = NULL;  // Good practice
+}
+
+// Use goto for cleanup
+int result = -1;
+char* error = NULL;
+CBoxliteRuntime* runtime = NULL;
+CBoxHandle* box = NULL;
+
+runtime = boxlite_runtime_new(NULL, NULL, &error);
+if (!runtime) goto cleanup;
+
+box = boxlite_create_box(runtime, options, &error);
+if (!box) goto cleanup;
+
+result = boxlite_execute(box, "echo", "[\"hello\"]", NULL, NULL, &error);
+
+cleanup:
+    if (error) {
+        fprintf(stderr, "Error: %s\n", error);
+        boxlite_free_string(error);
+    }
+    if (box) boxlite_stop_box(box, NULL);
+    if (runtime) boxlite_runtime_free(runtime);
+    return result;
+```
+
+---
+
+## Thread Safety
+
+| Component | Thread Safety |
+|-----------|---------------|
+| `CBoxliteRuntime` | Thread-safe (uses internal async runtime) |
+| `CBoxHandle` | NOT thread-safe. Do not share across threads. |
+| Callbacks | Invoked on the calling thread |
+| Error strings | Each thread gets its own error |
+
+### Multi-threaded Usage
+
+```c
+// CORRECT: Each thread creates its own box
+void* thread_func(void* arg) {
+    CBoxliteRuntime* runtime = (CBoxliteRuntime*)arg;
+    char* error = NULL;
+
+    // Each thread creates its own box
+    CBoxHandle* box = boxlite_create_box(runtime, options, &error);
+    if (!box) {
+        // Handle error
+        return NULL;
+    }
+
+    // Use box in this thread only
+    boxlite_execute(box, "echo", "[\"hello\"]", NULL, NULL, &error);
+    boxlite_stop_box(box, NULL);
+    return NULL;
+}
+
+// Create one runtime, share across threads
+CBoxliteRuntime* runtime = boxlite_runtime_new(NULL, NULL, &error);
+
+pthread_t threads[4];
+for (int i = 0; i < 4; i++) {
+    pthread_create(&threads[i], NULL, thread_func, runtime);
+}
+
+// Wait for threads
+for (int i = 0; i < 4; i++) {
+    pthread_join(threads[i], NULL);
+}
+
+boxlite_runtime_free(runtime);
+```
+
+---
+
+## Platform Requirements
+
+### macOS
+
+- **Architecture**: arm64 (Apple Silicon) or x86_64 (Intel)
+- **Requirements**: Hypervisor.framework entitlement
+- **Library**: `libboxlite.dylib`
+
+### Linux
+
+- **Architecture**: x86_64 or aarch64
+- **Requirements**: KVM enabled (`/dev/kvm` accessible)
+- **Library**: `libboxlite.so`
+
+### Checking Platform Support
+
+```c
+#include <stdio.h>
+#include "boxlite.h"
+
+int main() {
+    char* error = NULL;
+
+    CBoxliteRuntime* runtime = boxlite_runtime_new(NULL, NULL, &error);
+    if (!runtime) {
+        fprintf(stderr, "Platform not supported: %s\n", error);
+        boxlite_free_string(error);
+        return 1;
+    }
+
+    printf("BoxLite %s ready\n", boxlite_version());
+    boxlite_runtime_free(runtime);
+    return 0;
+}
+```
+
+---
+
+## Complete Example
+
+```c
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "boxlite.h"
+
+// Output buffer for collecting results
+typedef struct {
+    char* buffer;
+    size_t size;
+    size_t capacity;
+} OutputBuffer;
+
+void init_buffer(OutputBuffer* buf) {
+    buf->capacity = 1024;
+    buf->buffer = malloc(buf->capacity);
+    buf->buffer[0] = '\0';
+    buf->size = 0;
+}
+
+void append_buffer(OutputBuffer* buf, const char* text) {
+    size_t len = strlen(text);
+    while (buf->size + len + 1 > buf->capacity) {
+        buf->capacity *= 2;
+        buf->buffer = realloc(buf->buffer, buf->capacity);
+    }
+    strcpy(buf->buffer + buf->size, text);
+    buf->size += len;
+}
+
+void free_buffer(OutputBuffer* buf) {
+    free(buf->buffer);
+    buf->buffer = NULL;
+}
+
+void collect_output(const char* text, int is_stderr, void* user_data) {
+    if (!is_stderr) {
+        OutputBuffer* buf = (OutputBuffer*)user_data;
+        append_buffer(buf, text);
+    }
+}
+
+int main(int argc, char* argv[]) {
+    char* error = NULL;
+    int result = 1;
+
+    CBoxliteRuntime* runtime = NULL;
+    CBoxHandle* box = NULL;
+    OutputBuffer output;
+    init_buffer(&output);
+
+    // Print version
+    printf("BoxLite C SDK v%s\n", boxlite_version());
+
+    // Create runtime
+    runtime = boxlite_runtime_new(NULL, NULL, &error);
+    if (!runtime) {
+        fprintf(stderr, "Failed to create runtime: %s\n", error);
+        boxlite_free_string(error);
+        goto cleanup;
+    }
+
+    // Create Python box with volume mount
+    const char* options = "{"
+        "\"rootfs\":{\"Image\":\"python:3.11-slim\"},"
+        "\"cpus\":2,"
+        "\"memory_mib\":1024,"
+        "\"working_dir\":\"/app\""
+    "}";
+
+    box = boxlite_create_box(runtime, options, &error);
+    if (!box) {
+        fprintf(stderr, "Failed to create box: %s\n", error);
+        boxlite_free_string(error);
+        goto cleanup;
+    }
+
+    printf("Box created successfully\n");
+
+    // Run Python code
+    const char* python_code = "print('Hello from Python in BoxLite!')";
+    char args_json[512];
+    snprintf(args_json, sizeof(args_json), "[\"-c\", \"%s\"]", python_code);
+
+    int exit_code = boxlite_execute(box, "python3", args_json, collect_output, &output, &error);
+    if (exit_code < 0) {
+        fprintf(stderr, "Execution failed: %s\n", error);
+        boxlite_free_string(error);
+        goto cleanup;
+    }
+
+    printf("Output: %s", output.buffer);
+    printf("Exit code: %d\n", exit_code);
+
+    result = exit_code;
+
+cleanup:
+    free_buffer(&output);
+    if (box) {
+        if (boxlite_stop_box(box, &error) != 0) {
+            fprintf(stderr, "Warning: failed to stop box: %s\n", error);
+            boxlite_free_string(error);
+        }
+    }
+    if (runtime) {
+        boxlite_runtime_free(runtime);
+    }
+    return result;
+}
+```
+
+---
+
+## API Summary
+
+| Function | Description |
+|----------|-------------|
+| `boxlite_version()` | Get version string |
+| `boxlite_runtime_new()` | Create runtime instance |
+| `boxlite_runtime_free()` | Free runtime instance |
+| `boxlite_create_box()` | Create a new box |
+| `boxlite_execute()` | Run command in box |
+| `boxlite_stop_box()` | Stop and free box |
+| `boxlite_free_string()` | Free BoxLite-allocated string |
+
+---
+
+## See Also
+
+- [Getting Started Guide](../../getting-started/README.md)
+- [Rust API Reference](../rust/README.md)
+- [Configuration Reference](../README.md)
+- [Architecture Overview](../../architecture/README.md)

--- a/docs/reference/nodejs/README.md
+++ b/docs/reference/nodejs/README.md
@@ -1,0 +1,821 @@
+# Node.js SDK API Reference
+
+Complete API reference for the BoxLite Node.js/TypeScript SDK.
+
+**Version:** 0.1.5
+**Node.js:** 18+
+**Platforms:** macOS (Apple Silicon), Linux (x86_64, ARM64)
+
+## Table of Contents
+
+- [Runtime Management](#runtime-management)
+- [Box Handle](#box-handle)
+- [Command Execution](#command-execution)
+- [Box Types](#box-types)
+- [Error Types](#error-types)
+- [Metrics](#metrics)
+- [Type Definitions](#type-definitions)
+- [Constants](#constants)
+
+---
+
+## Runtime Management
+
+### `JsBoxlite` / `Boxlite`
+
+The main runtime for creating and managing boxes.
+
+```typescript
+import { JsBoxlite } from 'boxlite';
+// or use the wrapper classes
+import { SimpleBox } from 'boxlite';
+```
+
+#### Constructor
+
+```typescript
+new JsBoxlite(options: JsOptions)
+```
+
+#### Static Methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `withDefaultConfig()` | `() => JsBoxlite` | Get runtime with default config (`~/.boxlite`) |
+| `initDefault()` | `(options: JsOptions) => void` | Initialize default runtime with custom options |
+
+#### Instance Methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `create()` | `(options: JsBoxOptions, name?: string) => Promise<JsBox>` | Create a new box |
+| `listInfo()` | `() => Promise<JsBoxInfo[]>` | List all boxes |
+| `getInfo()` | `(idOrName: string) => Promise<JsBoxInfo \| null>` | Get box info |
+| `get()` | `(idOrName: string) => Promise<JsBox \| null>` | Get box handle |
+| `metrics()` | `() => Promise<JsRuntimeMetrics>` | Get runtime metrics |
+| `remove()` | `(idOrName: string, force?: boolean) => Promise<void>` | Remove a box |
+| `close()` | `() => void` | Close runtime (no-op) |
+
+#### Example
+
+```typescript
+// Default runtime
+const runtime = JsBoxlite.withDefaultConfig();
+
+// Custom runtime
+const runtime = new JsBoxlite({ homeDir: '/custom/path' });
+
+// Create a box
+const box = await runtime.create({
+  image: 'alpine:latest',
+  cpus: 2,
+  memoryMib: 512
+}, 'my-box');
+
+// List all boxes
+const boxes = await runtime.listInfo();
+boxes.forEach(info => console.log(`${info.id}: ${info.status}`));
+```
+
+---
+
+### `JsOptions`
+
+Runtime configuration options.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `homeDir` | `string` | `~/.boxlite` | Base directory for runtime data |
+
+---
+
+### `JsBoxOptions`
+
+Configuration options for creating a box.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `image` | `string` | - | OCI image URI |
+| `rootfsPath` | `string` | - | Pre-prepared rootfs directory (alternative to image) |
+| `cpus` | `number` | `1` | Number of CPU cores |
+| `memoryMib` | `number` | `512` | Memory limit in MiB |
+| `diskSizeGb` | `number` | - | Persistent disk size in GB |
+| `workingDir` | `string` | `"/root"` | Working directory inside container |
+| `env` | `JsEnvVar[]` | `[]` | Environment variables |
+| `volumes` | `JsVolumeSpec[]` | `[]` | Volume mounts |
+| `network` | `string` | `"isolated"` | Network mode |
+| `ports` | `JsPortSpec[]` | `[]` | Port mappings |
+| `autoRemove` | `boolean` | `false` | Auto cleanup when stopped |
+| `detach` | `boolean` | `false` | Survive parent process exit |
+
+#### `JsEnvVar`
+
+```typescript
+interface JsEnvVar {
+  key: string;
+  value: string;
+}
+```
+
+#### `JsVolumeSpec`
+
+```typescript
+interface JsVolumeSpec {
+  hostPath: string;    // Path on host
+  guestPath: string;   // Path in container
+  readOnly?: boolean;  // Default: false
+}
+```
+
+#### `JsPortSpec`
+
+```typescript
+interface JsPortSpec {
+  hostPort?: number;   // None = auto-assign
+  guestPort: number;   // Port inside container
+  protocol?: string;   // "tcp" or "udp" (default: "tcp")
+  hostIp?: string;     // Default: "0.0.0.0"
+}
+```
+
+---
+
+## Box Handle
+
+### `JsBox`
+
+Handle to a running or stopped box.
+
+#### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `id` | `string` | Unique box identifier (ULID) |
+| `name` | `string \| null` | User-defined name |
+
+#### Methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `info()` | `() => JsBoxInfo` | Get box metadata (sync) |
+| `exec()` | `(cmd, args?, env?, tty?) => Promise<JsExecution>` | Execute command |
+| `stop()` | `() => Promise<void>` | Stop the box |
+| `metrics()` | `() => Promise<JsBoxMetrics>` | Get resource metrics |
+
+---
+
+### `JsBoxInfo`
+
+Metadata about a box.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `string` | Unique box identifier (ULID) |
+| `name` | `string \| undefined` | User-defined name |
+| `status` | `string` | Current status: `"Starting"`, `"Running"`, `"Stopped"`, etc. |
+| `createdAt` | `string` | Creation timestamp (ISO 8601) |
+| `lastUpdated` | `string` | Last state change (ISO 8601) |
+| `pid` | `number \| undefined` | Process ID (if running) |
+
+---
+
+## Command Execution
+
+### `JsExecution`
+
+Handle for a running command.
+
+#### Methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `id()` | `() => Promise<string>` | Get execution ID |
+| `stdin()` | `() => Promise<JsExecStdin>` | Get stdin writer |
+| `stdout()` | `() => Promise<JsExecStdout>` | Get stdout reader |
+| `stderr()` | `() => Promise<JsExecStderr>` | Get stderr reader |
+| `wait()` | `() => Promise<JsExecResult>` | Wait for completion |
+| `kill()` | `() => Promise<void>` | Send SIGKILL |
+
+#### Example
+
+```typescript
+const execution = await box.exec('ls', ['-la', '/']);
+
+// Read stdout
+const stdout = await execution.stdout();
+while (true) {
+  const line = await stdout.next();
+  if (line === null) break;
+  console.log(line);
+}
+
+// Wait for completion
+const result = await execution.wait();
+console.log(`Exit code: ${result.exitCode}`);
+```
+
+---
+
+### `JsExecStdin`
+
+Writer for sending input to a running process.
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `write()` | `(data: Buffer) => Promise<void>` | Write bytes |
+| `writeString()` | `(text: string) => Promise<void>` | Write UTF-8 string |
+
+```typescript
+const stdin = await execution.stdin();
+await stdin.writeString('Hello, World!\n');
+await stdin.write(Buffer.from([10])); // newline
+```
+
+---
+
+### `JsExecStdout` / `JsExecStderr`
+
+Readers for streaming output.
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `next()` | `() => Promise<string \| null>` | Read next line (null = EOF) |
+
+**Stream Consumption:** Each stream can only be consumed once. After iterating to EOF, subsequent calls return `null`.
+
+```typescript
+const stdout = await execution.stdout();
+while (true) {
+  const line = await stdout.next();
+  if (line === null) break;
+  console.log(line);
+}
+```
+
+---
+
+### `JsExecResult`
+
+Result of a completed execution.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `exitCode` | `number` | Process exit code (0 = success) |
+
+---
+
+## Box Types
+
+### `SimpleBox`
+
+Context manager for basic command execution with automatic cleanup.
+
+```typescript
+import { SimpleBox } from 'boxlite';
+```
+
+#### Constructor Options
+
+```typescript
+interface SimpleBoxOptions {
+  image?: string;         // Default: "python:slim"
+  memoryMib?: number;     // Memory in MiB
+  cpus?: number;          // CPU cores
+  runtime?: JsBoxlite;    // Runtime instance
+  name?: string;          // Box name
+  autoRemove?: boolean;   // Default: true
+  detach?: boolean;       // Default: false
+  workingDir?: string;    // Working directory
+  env?: Record<string, string>;  // Environment variables
+  volumes?: VolumeSpec[]; // Volume mounts
+  ports?: PortSpec[];     // Port mappings
+}
+```
+
+#### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `id` | `string` | Box ID (throws if not started) |
+| `name` | `string \| undefined` | Box name |
+
+#### Methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `getId()` | `() => Promise<string>` | Get box ID (async) |
+| `getInfo()` | `() => Promise<JsBoxInfo>` | Get box info (async) |
+| `exec()` | `(cmd, ...args) => Promise<ExecResult>` | Execute and wait |
+| `stop()` | `() => Promise<void>` | Stop the box |
+| `[Symbol.asyncDispose]()` | `() => Promise<void>` | Async disposal |
+
+#### Example
+
+```typescript
+// With async disposal (TypeScript 5.2+)
+await using box = new SimpleBox({ image: 'alpine:latest' });
+const result = await box.exec('echo', 'Hello!');
+console.log(result.stdout);
+
+// Manual cleanup
+const box = new SimpleBox({ image: 'alpine:latest' });
+try {
+  const result = await box.exec('ls', '-la');
+  console.log(result.stdout);
+} finally {
+  await box.stop();
+}
+```
+
+---
+
+### `CodeBox`
+
+Python code execution sandbox.
+
+```typescript
+import { CodeBox } from 'boxlite';
+```
+
+#### Constructor Options
+
+```typescript
+interface CodeBoxOptions extends SimpleBoxOptions {
+  image?: string;  // Default: "python:slim"
+}
+```
+
+#### Methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `run()` | `(code: string) => Promise<string>` | Execute Python code |
+| `runScript()` | `(scriptPath: string) => Promise<string>` | Run script file |
+| `installPackage()` | `(pkg: string) => Promise<string>` | pip install |
+| `installPackages()` | `(...pkgs: string[]) => Promise<string>` | Install multiple |
+
+#### Example
+
+```typescript
+const codebox = new CodeBox({ memoryMib: 1024 });
+try {
+  await codebox.installPackage('requests');
+  const result = await codebox.run(`
+import requests
+print(requests.get('https://api.github.com/zen').text)
+  `);
+  console.log(result);
+} finally {
+  await codebox.stop();
+}
+```
+
+---
+
+### `BrowserBox`
+
+Browser automation with Chrome DevTools Protocol.
+
+```typescript
+import { BrowserBox, BrowserType } from 'boxlite';
+```
+
+#### Constructor Options
+
+```typescript
+interface BrowserBoxOptions {
+  browser?: BrowserType;  // "chromium" | "firefox" | "webkit"
+  memoryMib?: number;     // Default: 2048
+  cpus?: number;          // Default: 2
+}
+```
+
+#### Browser CDP Ports
+
+| Browser | Port | Image |
+|---------|------|-------|
+| `chromium` | 9222 | `mcr.microsoft.com/playwright:v1.47.2-jammy` |
+| `firefox` | 9223 | `browserless/firefox:latest` |
+| `webkit` | 9224 | `browserless/webkit:latest` |
+
+#### Methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `start()` | `(timeout?: number) => Promise<void>` | Start browser |
+| `endpoint()` | `() => string` | Get CDP endpoint URL |
+
+#### Example
+
+```typescript
+import puppeteer from 'puppeteer-core';
+
+const browser = new BrowserBox({ browser: 'chromium' });
+try {
+  await browser.start();
+  const endpoint = browser.endpoint();  // "http://localhost:9222"
+
+  const instance = await puppeteer.connect({ browserURL: endpoint });
+  const page = await instance.newPage();
+  await page.goto('https://example.com');
+  console.log(await page.title());
+} finally {
+  await browser.stop();
+}
+```
+
+---
+
+### `ComputerBox`
+
+Desktop automation with full GUI environment.
+
+```typescript
+import { ComputerBox } from 'boxlite';
+```
+
+#### Constructor Options
+
+```typescript
+interface ComputerBoxOptions {
+  cpus?: number;          // Default: 2
+  memoryMib?: number;     // Default: 2048
+  guiHttpPort?: number;   // Default: 3000
+  guiHttpsPort?: number;  // Default: 3001
+}
+```
+
+#### Mouse Methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `mouseMove()` | `(x: number, y: number) => Promise<void>` | Move cursor |
+| `leftClick()` | `() => Promise<void>` | Left click |
+| `rightClick()` | `() => Promise<void>` | Right click |
+| `middleClick()` | `() => Promise<void>` | Middle click |
+| `doubleClick()` | `() => Promise<void>` | Double click |
+| `tripleClick()` | `() => Promise<void>` | Triple click |
+| `leftClickDrag()` | `(startX, startY, endX, endY) => Promise<void>` | Drag |
+| `cursorPosition()` | `() => Promise<[number, number]>` | Get cursor pos |
+
+#### Keyboard Methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `type()` | `(text: string) => Promise<void>` | Type text |
+| `key()` | `(keySequence: string) => Promise<void>` | Press key(s) |
+
+##### Key Syntax Reference (xdotool format)
+
+| Key | Syntax |
+|-----|--------|
+| Enter | `Return` |
+| Tab | `Tab` |
+| Escape | `Escape` |
+| Backspace | `BackSpace` |
+| Delete | `Delete` |
+| Space | `space` |
+| Arrow keys | `Up`, `Down`, `Left`, `Right` |
+| Function keys | `F1`, `F2`, ... `F12` |
+| Page keys | `Page_Up`, `Page_Down`, `Home`, `End` |
+| Modifiers | `ctrl`, `alt`, `shift`, `super` |
+| Combinations | `ctrl+c`, `ctrl+shift+s`, `alt+Tab` |
+
+**Examples:**
+```typescript
+await desktop.key('Return');        // Press Enter
+await desktop.key('ctrl+c');        // Copy
+await desktop.key('ctrl+shift+s');  // Save As
+await desktop.key('alt+Tab');       // Switch window
+await desktop.key('ctrl+a Delete'); // Select all and delete
+```
+
+#### Display Methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `waitUntilReady()` | `(timeout?: number) => Promise<void>` | Wait for desktop |
+| `screenshot()` | `() => Promise<Screenshot>` | Capture screen |
+| `scroll()` | `(x, y, direction, amount?) => Promise<void>` | Scroll |
+| `getScreenSize()` | `() => Promise<[number, number]>` | Get dimensions |
+
+##### Screenshot Return Type
+
+```typescript
+interface Screenshot {
+  data: string;    // Base64-encoded PNG
+  width: number;   // 1024 (default)
+  height: number;  // 768 (default)
+  format: 'png';
+}
+```
+
+##### Scroll Directions
+
+| Direction | Description |
+|-----------|-------------|
+| `"up"` | Scroll up |
+| `"down"` | Scroll down |
+| `"left"` | Scroll left |
+| `"right"` | Scroll right |
+
+#### Example
+
+```typescript
+const desktop = new ComputerBox({ cpus: 4, memoryMib: 4096 });
+try {
+  await desktop.waitUntilReady(60);
+
+  // Take screenshot
+  const screenshot = await desktop.screenshot();
+  console.log(`${screenshot.width}x${screenshot.height}`);
+
+  // GUI interaction
+  await desktop.mouseMove(100, 200);
+  await desktop.leftClick();
+  await desktop.type('Hello, World!');
+  await desktop.key('Return');
+
+  // Access via browser: http://localhost:3000
+} finally {
+  await desktop.stop();
+}
+```
+
+---
+
+### `InteractiveBox`
+
+Interactive terminal sessions with PTY support.
+
+```typescript
+import { InteractiveBox } from 'boxlite';
+```
+
+#### Constructor Options
+
+```typescript
+interface InteractiveBoxOptions extends SimpleBoxOptions {
+  shell?: string;        // Default: "/bin/sh"
+  tty?: boolean;         // undefined = auto-detect
+}
+```
+
+##### TTY Mode
+
+| Value | Behavior |
+|-------|----------|
+| `undefined` | Auto-detect from stdin |
+| `true` | Force TTY with I/O forwarding |
+| `false` | No I/O forwarding |
+
+#### Methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `start()` | `() => Promise<void>` | Start PTY session |
+| `wait()` | `() => Promise<void>` | Wait for shell exit |
+
+#### Example
+
+```typescript
+const box = new InteractiveBox({
+  image: 'alpine:latest',
+  shell: '/bin/sh',
+  tty: true
+});
+try {
+  await box.start();
+  await box.wait();  // Blocks until shell exits
+} finally {
+  await box.stop();
+}
+```
+
+---
+
+## Error Types
+
+```typescript
+import { BoxliteError, ExecError, TimeoutError, ParseError } from 'boxlite';
+```
+
+### Exception Hierarchy
+
+```
+BoxliteError (base)
+├── ExecError       # Command failed
+├── TimeoutError    # Operation timeout
+└── ParseError      # Output parsing failed
+```
+
+### `BoxliteError`
+
+Base error class for all BoxLite errors.
+
+```typescript
+try {
+  await box.exec('invalid-command');
+} catch (err) {
+  if (err instanceof BoxliteError) {
+    console.error('BoxLite error:', err.message);
+  }
+}
+```
+
+### `ExecError`
+
+Command execution failed (non-zero exit code).
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `command` | `string` | Failed command |
+| `exitCode` | `number` | Non-zero exit code |
+| `stderr` | `string` | Standard error output |
+
+```typescript
+try {
+  await box.exec('false');
+} catch (err) {
+  if (err instanceof ExecError) {
+    console.error(`Command: ${err.command}`);
+    console.error(`Exit code: ${err.exitCode}`);
+    console.error(`Stderr: ${err.stderr}`);
+  }
+}
+```
+
+### `TimeoutError`
+
+Operation exceeded time limit.
+
+```typescript
+try {
+  await desktop.waitUntilReady(5);
+} catch (err) {
+  if (err instanceof TimeoutError) {
+    console.error('Desktop did not become ready');
+  }
+}
+```
+
+### `ParseError`
+
+Failed to parse command output.
+
+```typescript
+try {
+  const pos = await desktop.cursorPosition();
+} catch (err) {
+  if (err instanceof ParseError) {
+    console.error('Failed to parse cursor position');
+  }
+}
+```
+
+---
+
+## Metrics
+
+### `JsRuntimeMetrics`
+
+Runtime-wide metrics.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `boxesCreatedTotal` | `number` | Total boxes created |
+| `boxesFailedTotal` | `number` | Boxes that failed during creation |
+| `numRunningBoxes` | `number` | Currently running boxes |
+| `totalCommandsExecuted` | `number` | Total commands executed |
+| `totalExecErrors` | `number` | Total execution errors |
+
+```typescript
+const metrics = await runtime.metrics();
+console.log(`Boxes created: ${metrics.boxesCreatedTotal}`);
+console.log(`Running: ${metrics.numRunningBoxes}`);
+```
+
+---
+
+### `JsBoxMetrics`
+
+Per-box resource metrics.
+
+#### Counter Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `commandsExecutedTotal` | `number` | Commands executed on this box |
+| `execErrorsTotal` | `number` | Execution errors on this box |
+| `bytesSentTotal` | `number` | Bytes sent via stdin |
+| `bytesReceivedTotal` | `number` | Bytes received via stdout/stderr |
+
+#### Resource Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `cpuPercent` | `number \| undefined` | CPU usage (0.0-100.0) |
+| `memoryBytes` | `number \| undefined` | Memory usage in bytes |
+| `networkBytesSent` | `number \| undefined` | Network bytes sent |
+| `networkBytesReceived` | `number \| undefined` | Network bytes received |
+| `networkTcpConnections` | `number \| undefined` | Current TCP connections |
+| `networkTcpErrors` | `number \| undefined` | Total TCP errors |
+
+#### Timing Fields (milliseconds)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `totalCreateDurationMs` | `number \| undefined` | Total create time |
+| `guestBootDurationMs` | `number \| undefined` | Guest agent ready time |
+| `stageFilesystemSetupMs` | `number \| undefined` | Directory setup time |
+| `stageImagePrepareMs` | `number \| undefined` | Image pull/prepare time |
+| `stageGuestRootfsMs` | `number \| undefined` | Rootfs bootstrap time |
+| `stageBoxConfigMs` | `number \| undefined` | Configuration build time |
+| `stageBoxSpawnMs` | `number \| undefined` | Subprocess spawn time |
+| `stageContainerInitMs` | `number \| undefined` | Container init time |
+
+```typescript
+const metrics = await box.metrics();
+console.log(`CPU: ${metrics.cpuPercent}%`);
+console.log(`Memory: ${(metrics.memoryBytes || 0) / (1024 * 1024)} MB`);
+console.log(`Boot time: ${metrics.guestBootDurationMs}ms`);
+```
+
+---
+
+## Type Definitions
+
+### `ExecResult` (wrapper)
+
+Result from `SimpleBox.exec()`.
+
+```typescript
+interface ExecResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+```
+
+### `Screenshot`
+
+Screenshot capture result.
+
+```typescript
+interface Screenshot {
+  data: string;     // Base64-encoded PNG
+  width: number;
+  height: number;
+  format: 'png';
+}
+```
+
+### `BrowserType`
+
+Supported browser types.
+
+```typescript
+type BrowserType = 'chromium' | 'firefox' | 'webkit';
+```
+
+---
+
+## Constants
+
+Default values used by BoxLite.
+
+### Resource Defaults
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `DEFAULT_CPUS` | `1` | Default CPU cores |
+| `DEFAULT_MEMORY_MIB` | `512` | Default memory in MiB |
+
+### ComputerBox Defaults
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `COMPUTERBOX_CPUS` | `2` | Default CPUs |
+| `COMPUTERBOX_MEMORY_MIB` | `2048` | Default memory |
+| `COMPUTERBOX_DISPLAY_WIDTH` | `1024` | Screen width |
+| `COMPUTERBOX_DISPLAY_HEIGHT` | `768` | Screen height |
+| `COMPUTERBOX_GUI_HTTP_PORT` | `3000` | HTTP GUI port |
+| `COMPUTERBOX_GUI_HTTPS_PORT` | `3001` | HTTPS GUI port |
+| `DESKTOP_READY_TIMEOUT` | `60` | Ready timeout (seconds) |
+
+### BrowserBox Ports
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `BROWSERBOX_PORT_CHROMIUM` | `9222` | Chromium CDP port |
+| `BROWSERBOX_PORT_FIREFOX` | `9223` | Firefox CDP port |
+| `BROWSERBOX_PORT_WEBKIT` | `9224` | WebKit CDP port |
+
+---
+
+## See Also
+
+- [Node.js SDK README](../../../sdks/node/README.md) - Quick start and examples
+- [Getting Started Guide](../../getting-started/quickstart-nodejs.md) - Installation
+- [Configuration Reference](../README.md#configuration-reference) - BoxOptions details
+- [Error Codes](../README.md#error-codes--handling) - Error handling

--- a/docs/reference/python/README.md
+++ b/docs/reference/python/README.md
@@ -1,0 +1,802 @@
+# Python SDK API Reference
+
+Complete API reference for the BoxLite Python SDK.
+
+**Version:** 0.5.2
+**Python:** 3.10+
+**Platforms:** macOS (Apple Silicon), Linux (x86_64, ARM64)
+
+## Table of Contents
+
+- [Runtime Management](#runtime-management)
+- [Box Handle](#box-handle)
+- [Command Execution](#command-execution)
+- [Box Types](#box-types)
+- [Sync API](#sync-api)
+- [Error Types](#error-types)
+- [Metrics](#metrics)
+- [Constants](#constants)
+
+---
+
+## Runtime Management
+
+### `boxlite.Boxlite`
+
+The main runtime for creating and managing boxes.
+
+```python
+from boxlite import Boxlite, Options, BoxOptions
+```
+
+#### Class Methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `default()` | `() -> Boxlite` | Create runtime with default settings (`~/.boxlite`) |
+| `__init__()` | `(options: Options) -> Boxlite` | Create runtime with custom options |
+
+#### Instance Methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `create()` | `(options: BoxOptions, name: str = None) -> Box` | Create a new box (async) |
+| `get()` | `(box_id: str) -> Box` | Reattach to an existing box by ID (async) |
+| `list()` | `() -> List[BoxInfo]` | List all boxes (async) |
+| `metrics()` | `() -> RuntimeMetrics` | Get runtime-wide metrics (async) |
+
+#### Example
+
+```python
+# Default runtime
+runtime = Boxlite.default()
+
+# Custom runtime
+runtime = Boxlite(Options(home_dir="/custom/path"))
+
+# Create a box
+box = await runtime.create(BoxOptions(image="alpine:latest"))
+
+# List all boxes
+for info in await runtime.list():
+    print(f"{info.id}: {info.status}")
+```
+
+---
+
+### `boxlite.Options`
+
+Runtime configuration options.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `home_dir` | `str` | `~/.boxlite` | Base directory for runtime data |
+| `image_registries` | `List[str]` | `[]` | Custom image registries for unqualified references |
+
+---
+
+### `boxlite.BoxOptions`
+
+Configuration options for creating a box.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `image` | `str` | Required | OCI image URI (e.g., `"python:slim"`, `"alpine:latest"`) |
+| `cpus` | `int` | `1` | Number of CPU cores (1 to host CPU count) |
+| `memory_mib` | `int` | `512` | Memory limit in MiB (128-65536) |
+| `disk_size_gb` | `int \| None` | `None` | Persistent disk size in GB (None = ephemeral) |
+| `working_dir` | `str` | `"/root"` | Working directory inside container |
+| `env` | `List[Tuple[str, str]]` | `[]` | Environment variables as (key, value) pairs |
+| `volumes` | `List[Tuple[str, str, str]]` | `[]` | Volume mounts as (host_path, guest_path, mode) |
+| `ports` | `List[Tuple[int, int, str]]` | `[]` | Port forwarding as (host_port, guest_port, protocol) |
+| `auto_remove` | `bool` | `True` | Auto cleanup when stopped |
+| `detach` | `bool` | `False` | Survive parent process exit |
+
+#### Volume Mount Format
+
+```python
+volumes=[
+    ("/host/config", "/etc/app/config", "ro"),  # Read-only
+    ("/host/data", "/mnt/data", "rw"),          # Read-write
+]
+```
+
+#### Port Forwarding Format
+
+```python
+ports=[
+    (8080, 80, "tcp"),    # HTTP
+    (5432, 5432, "tcp"),  # PostgreSQL
+    (53, 53, "udp"),      # DNS
+]
+```
+
+---
+
+## Box Handle
+
+### `boxlite.Box`
+
+Handle to a running or stopped box.
+
+#### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `id` | `str` | Unique box identifier (ULID format) |
+
+#### Methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `exec()` | `(cmd, args, env, tty) -> Execution` | Execute command (async) |
+| `stop()` | `() -> None` | Stop the box gracefully (async) |
+| `remove()` | `() -> None` | Delete box and its data (async) |
+| `info()` | `() -> BoxInfo` | Get box metadata (async) |
+| `metrics()` | `() -> BoxMetrics` | Get resource usage metrics (async) |
+
+---
+
+### `boxlite.BoxInfo`
+
+Metadata about a box.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `str` | Unique box identifier (ULID) |
+| `name` | `str \| None` | Optional user-assigned name |
+| `status` | `str` | Current status: `"running"`, `"stopped"`, `"created"` |
+| `created_at` | `datetime` | Creation timestamp |
+| `pid` | `int \| None` | Process ID (if running) |
+| `image` | `str` | OCI image used |
+| `cpus` | `int` | Allocated CPU cores |
+| `memory_mib` | `int` | Allocated memory in MiB |
+
+---
+
+### `boxlite.BoxStateInfo`
+
+Detailed state information for a box.
+
+| Value | Description |
+|-------|-------------|
+| `Created` | Box created but not yet started |
+| `Starting` | Box is initializing |
+| `Running` | Box is running and ready |
+| `Stopping` | Box is shutting down |
+| `Stopped` | Box is stopped |
+| `Failed` | Box encountered an error |
+
+---
+
+## Command Execution
+
+### `boxlite.Execution`
+
+Represents a running command execution.
+
+#### Methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `stdout()` | `() -> ExecStdout` | Get stdout stream (async iterator) |
+| `stderr()` | `() -> ExecStderr` | Get stderr stream (async iterator) |
+| `stdin()` | `() -> ExecStdin` | Get stdin writer |
+| `wait()` | `() -> ExecResult` | Wait for completion (async) |
+| `kill()` | `(signal: int = 9) -> None` | Send signal to process (async) |
+
+#### Example
+
+```python
+# Execute with streaming output
+execution = await box.exec("python", ["-c", "for i in range(5): print(i)"])
+
+# Stream stdout
+async for line in execution.stdout():
+    print(f"Output: {line}")
+
+# Wait for completion
+result = await execution.wait()
+print(f"Exit code: {result.exit_code}")
+```
+
+---
+
+### `boxlite.ExecStdout` / `boxlite.ExecStderr`
+
+Async iterators for streaming output.
+
+```python
+# Stream stdout line by line
+stdout = execution.stdout()
+async for line in stdout:
+    print(line)
+
+# Stream stderr
+stderr = execution.stderr()
+async for line in stderr:
+    print(f"Error: {line}", file=sys.stderr)
+```
+
+**Note:** Each stream can only be iterated once. After iteration, the stream is consumed.
+
+---
+
+### `boxlite.ExecStdin`
+
+Writer for sending input to a running process.
+
+#### Methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `send_input()` | `(data: bytes) -> None` | Write bytes to stdin (async) |
+
+#### Example
+
+```python
+# Interactive input
+execution = await box.exec("cat")
+stdin = execution.stdin()
+
+# Send data
+await stdin.send_input(b"Hello\n")
+await stdin.send_input(b"World\n")
+
+# Wait for completion
+result = await execution.wait()
+```
+
+---
+
+### `boxlite.ExecResult`
+
+Result of a completed execution.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `exit_code` | `int` | Process exit code (0 = success) |
+
+**Note:** For higher-level APIs (`SimpleBox.exec()`), the result also includes `stdout` and `stderr` strings.
+
+---
+
+## Box Types
+
+### `boxlite.SimpleBox`
+
+Context manager for basic command execution with automatic cleanup.
+
+```python
+from boxlite import SimpleBox
+```
+
+#### Constructor
+
+```python
+SimpleBox(
+    image: str,
+    memory_mib: int = None,
+    cpus: int = None,
+    runtime: Boxlite = None,
+    name: str = None,
+    auto_remove: bool = True,
+    **kwargs
+)
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `image` | `str` | Required | Container image to use |
+| `memory_mib` | `int` | System default | Memory limit in MiB |
+| `cpus` | `int` | System default | Number of CPU cores |
+| `runtime` | `Boxlite` | Global default | Runtime instance |
+| `name` | `str` | None | Optional unique name |
+| `auto_remove` | `bool` | `True` | Remove box when stopped |
+| `**kwargs` | | | Additional options: `env`, `volumes`, `ports`, `working_dir` |
+
+#### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `id` | `str` | Box ID (raises if not started) |
+
+#### Methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `start()` | `() -> Self` | Explicitly start the box (async) |
+| `exec()` | `(cmd, *args, env=None) -> ExecResult` | Execute command and wait (async) |
+| `info()` | `() -> BoxInfo` | Get box metadata |
+| `shutdown()` | `() -> None` | Shutdown and release resources |
+
+#### Example
+
+```python
+async with SimpleBox(image="python:slim") as box:
+    result = await box.exec("python", "-c", "print('Hello!')")
+    print(result.stdout)   # "Hello!\n"
+    print(result.exit_code)  # 0
+```
+
+---
+
+### `boxlite.CodeBox`
+
+Specialized box for Python code execution with package management.
+
+```python
+from boxlite import CodeBox
+```
+
+#### Constructor
+
+```python
+CodeBox(
+    image: str = "python:slim",
+    memory_mib: int = None,
+    cpus: int = None,
+    runtime: Boxlite = None,
+    **kwargs
+)
+```
+
+#### Methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `run()` | `(code: str, timeout: int = None) -> str` | Execute Python code (async) |
+| `run_script()` | `(script_path: str) -> str` | Execute Python script file (async) |
+| `install_package()` | `(package: str) -> str` | Install package with pip (async) |
+| `install_packages()` | `(*packages: str) -> str` | Install multiple packages (async) |
+
+#### Example
+
+```python
+async with CodeBox() as cb:
+    # Install packages
+    await cb.install_package("requests")
+
+    # Run code
+    result = await cb.run("""
+import requests
+print(requests.get('https://api.github.com/zen').text)
+""")
+    print(result)
+```
+
+---
+
+### `boxlite.BrowserBox`
+
+Box configured for browser automation with Chrome DevTools Protocol.
+
+```python
+from boxlite import BrowserBox, BrowserBoxOptions
+```
+
+#### `BrowserBoxOptions`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `browser` | `str` | `"chromium"` | Browser type: `"chromium"`, `"firefox"`, `"webkit"` |
+| `memory` | `int` | `2048` | Memory in MiB |
+| `cpu` | `int` | `2` | Number of CPU cores |
+
+#### Browser CDP Ports
+
+| Browser | Port |
+|---------|------|
+| chromium | 9222 |
+| firefox | 9223 |
+| webkit | 9224 |
+
+#### Methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `endpoint()` | `() -> str` | Get CDP endpoint URL |
+
+#### Example
+
+```python
+from boxlite import BrowserBox, BrowserBoxOptions
+
+opts = BrowserBoxOptions(browser="chromium", memory=4096)
+async with BrowserBox(opts) as browser:
+    endpoint = browser.endpoint()  # "http://localhost:9222"
+
+    # Connect with Puppeteer or Playwright
+    # puppeteer.connect({ browserURL: endpoint })
+```
+
+---
+
+### `boxlite.ComputerBox`
+
+Box with full desktop environment and GUI automation capabilities.
+
+```python
+from boxlite import ComputerBox
+```
+
+#### Constructor
+
+```python
+ComputerBox(
+    cpu: int = 2,
+    memory: int = 2048,
+    gui_http_port: int = 3000,
+    gui_https_port: int = 3001,
+    runtime: Boxlite = None,
+    **kwargs
+)
+```
+
+#### Mouse Methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `mouse_move()` | `(x: int, y: int) -> None` | Move cursor to coordinates (async) |
+| `left_click()` | `() -> None` | Left click at current position (async) |
+| `right_click()` | `() -> None` | Right click at current position (async) |
+| `middle_click()` | `() -> None` | Middle click at current position (async) |
+| `double_click()` | `() -> None` | Double left click (async) |
+| `triple_click()` | `() -> None` | Triple left click (async) |
+| `left_click_drag()` | `(start_x, start_y, end_x, end_y) -> None` | Drag from start to end (async) |
+| `cursor_position()` | `() -> Tuple[int, int]` | Get current cursor (x, y) (async) |
+
+#### Keyboard Methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `type()` | `(text: str) -> None` | Type text characters (async) |
+| `key()` | `(text: str) -> None` | Press key or key combination (async) |
+
+##### Key Syntax Reference
+
+The `key()` method uses **xdotool key syntax**:
+
+| Key | Syntax |
+|-----|--------|
+| Enter | `Return` |
+| Tab | `Tab` |
+| Escape | `Escape` |
+| Backspace | `BackSpace` |
+| Delete | `Delete` |
+| Arrow keys | `Up`, `Down`, `Left`, `Right` |
+| Function keys | `F1`, `F2`, ... `F12` |
+| Modifiers | `ctrl`, `alt`, `shift`, `super` |
+| Combinations | `ctrl+c`, `ctrl+shift+s`, `alt+Tab` |
+
+**Examples:**
+```python
+await computer.key("Return")        # Press Enter
+await computer.key("ctrl+c")        # Copy
+await computer.key("ctrl+shift+s")  # Save As
+await computer.key("alt+Tab")       # Switch window
+await computer.key("ctrl+a Delete") # Select all and delete
+```
+
+#### Display Methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `wait_until_ready()` | `(timeout: int = 60) -> None` | Wait for desktop ready (async) |
+| `screenshot()` | `() -> dict` | Capture screen (async) |
+| `scroll()` | `(x, y, direction, amount=3) -> None` | Scroll at position (async) |
+| `get_screen_size()` | `() -> Tuple[int, int]` | Get screen dimensions (async) |
+
+##### Screenshot Return Format
+
+```python
+{
+    "data": str,    # Base64-encoded PNG
+    "width": int,   # 1024 (default)
+    "height": int,  # 768 (default)
+    "format": str   # "png"
+}
+```
+
+##### Scroll Directions
+
+| Direction | Description |
+|-----------|-------------|
+| `"up"` | Scroll up |
+| `"down"` | Scroll down |
+| `"left"` | Scroll left |
+| `"right"` | Scroll right |
+
+#### Example
+
+```python
+async with ComputerBox() as desktop:
+    await desktop.wait_until_ready()
+
+    # Take screenshot
+    screenshot = await desktop.screenshot()
+
+    # Mouse interaction
+    await desktop.mouse_move(100, 200)
+    await desktop.left_click()
+
+    # Type text
+    await desktop.type("Hello, World!")
+    await desktop.key("Return")
+
+    # Get screen size
+    width, height = await desktop.get_screen_size()
+```
+
+---
+
+### `boxlite.InteractiveBox`
+
+Box for interactive terminal sessions with PTY support.
+
+```python
+from boxlite import InteractiveBox
+```
+
+#### Constructor
+
+```python
+InteractiveBox(
+    image: str,
+    shell: str = "/bin/sh",
+    tty: bool = None,
+    memory_mib: int = None,
+    cpus: int = None,
+    runtime: Boxlite = None,
+    name: str = None,
+    auto_remove: bool = True,
+    **kwargs
+)
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `image` | `str` | Required | Container image |
+| `shell` | `str` | `"/bin/sh"` | Shell to run |
+| `tty` | `bool \| None` | `None` | TTY mode (see below) |
+
+##### TTY Mode
+
+| Value | Behavior |
+|-------|----------|
+| `None` | Auto-detect from `sys.stdin.isatty()` |
+| `True` | Force TTY mode with I/O forwarding |
+| `False` | No I/O forwarding (programmatic control) |
+
+#### Methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `wait()` | `() -> None` | Wait for shell to exit (async) |
+
+#### Example
+
+```python
+# Interactive shell session
+async with InteractiveBox(image="alpine:latest") as box:
+    # You're now in an interactive shell
+    # Type commands, see output in real-time
+    # Type "exit" to close
+    await box.wait()
+```
+
+---
+
+## Sync API
+
+Synchronous wrappers using greenlet fiber switching. Requires `pip install boxlite[sync]`.
+
+```python
+from boxlite import SyncBoxlite, SyncBox, SyncSimpleBox, SyncCodeBox
+```
+
+### When to Use
+
+| Use Case | API |
+|----------|-----|
+| New async applications | Async API (default) |
+| Existing sync codebase | Sync API |
+| Jupyter notebooks | Sync API |
+| REPL/interactive use | Sync API |
+| Inside async functions | Async API only |
+
+### Comparison Table
+
+| Async API | Sync API | Notes |
+|-----------|----------|-------|
+| `Boxlite` | `SyncBoxlite` | |
+| `Box` | `SyncBox` | |
+| `Execution` | `SyncExecution` | |
+| `ExecStdout` | `SyncExecStdout` | Regular iterator |
+| `ExecStderr` | `SyncExecStderr` | Regular iterator |
+| `SimpleBox` | `SyncSimpleBox` | |
+| `CodeBox` | `SyncCodeBox` | |
+
+### Classes
+
+#### `SyncBoxlite`
+
+```python
+from boxlite import SyncBoxlite, BoxOptions
+
+with SyncBoxlite.default() as runtime:
+    box = runtime.create(BoxOptions(image="alpine:latest"))
+    execution = box.exec("echo", ["Hello"])
+    for line in execution.stdout():
+        print(line)
+    box.stop()
+```
+
+#### `SyncSimpleBox`
+
+```python
+from boxlite import SyncSimpleBox
+
+with SyncSimpleBox(image="python:slim") as box:
+    result = box.exec("python", "-c", "print('Hello!')")
+    print(result.stdout)
+```
+
+#### `SyncCodeBox`
+
+```python
+from boxlite import SyncCodeBox
+
+with SyncCodeBox() as cb:
+    result = cb.run("print('Hello, World!')")
+    print(result)
+```
+
+### Architecture
+
+The sync API uses greenlet fiber switching:
+1. A dispatcher fiber runs the asyncio event loop
+2. User code runs in the main fiber
+3. Sync methods switch to dispatcher, await async operations, then switch back
+
+**Limitation:** Cannot be used inside an async context (when an event loop is already running).
+
+---
+
+## Error Types
+
+```python
+from boxlite import BoxliteError, ExecError, TimeoutError, ParseError
+```
+
+### Exception Hierarchy
+
+```
+BoxliteError (base)
+├── ExecError       # Command execution failed
+├── TimeoutError    # Operation timed out
+└── ParseError      # Output parsing failed
+```
+
+### `BoxliteError`
+
+Base exception for all BoxLite errors.
+
+```python
+try:
+    async with SimpleBox(image="invalid:image") as box:
+        pass
+except BoxliteError as e:
+    print(f"BoxLite error: {e}")
+```
+
+### `ExecError`
+
+Raised when a command execution fails (non-zero exit code).
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `command` | `str` | The command that failed |
+| `exit_code` | `int` | Non-zero exit code |
+| `stderr` | `str` | Standard error output |
+
+```python
+try:
+    result = await box.exec("false")  # Exit code 1
+except ExecError as e:
+    print(f"Command: {e.command}")
+    print(f"Exit code: {e.exit_code}")
+    print(f"Stderr: {e.stderr}")
+```
+
+### `TimeoutError`
+
+Raised when an operation times out.
+
+```python
+try:
+    await computer.wait_until_ready(timeout=5)
+except TimeoutError:
+    print("Desktop did not become ready in time")
+```
+
+### `ParseError`
+
+Raised when output parsing fails.
+
+```python
+try:
+    x, y = await computer.cursor_position()
+except ParseError:
+    print("Failed to parse cursor position")
+```
+
+---
+
+## Metrics
+
+### `boxlite.RuntimeMetrics`
+
+Aggregate metrics across all boxes.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `boxes_created` | `int` | Total boxes created |
+| `boxes_destroyed` | `int` | Total boxes destroyed |
+| `total_exec_calls` | `int` | Total command executions |
+| `active_boxes` | `int` | Currently running boxes |
+
+```python
+runtime = Boxlite.default()
+metrics = await runtime.metrics()
+
+print(f"Boxes created: {metrics.boxes_created}")
+print(f"Active boxes: {metrics.active_boxes}")
+```
+
+---
+
+### `boxlite.BoxMetrics`
+
+Per-box resource usage metrics.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `cpu_time_ms` | `int` | Total CPU time in milliseconds |
+| `memory_usage_bytes` | `int` | Current memory usage in bytes |
+| `network_bytes_sent` | `int` | Total bytes sent |
+| `network_bytes_received` | `int` | Total bytes received |
+
+```python
+metrics = await box.metrics()
+
+print(f"CPU time: {metrics.cpu_time_ms}ms")
+print(f"Memory: {metrics.memory_usage_bytes / (1024**2):.2f} MB")
+```
+
+---
+
+## Constants
+
+Default values used by BoxLite.
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `DEFAULT_CPUS` | `1` | Default CPU cores |
+| `DEFAULT_MEMORY_MIB` | `2048` | Default memory in MiB |
+| `COMPUTERBOX_CPUS` | `2` | ComputerBox default CPUs |
+| `COMPUTERBOX_MEMORY_MIB` | `2048` | ComputerBox default memory |
+| `COMPUTERBOX_DISPLAY_WIDTH` | `1024` | Screen width in pixels |
+| `COMPUTERBOX_DISPLAY_HEIGHT` | `768` | Screen height in pixels |
+| `COMPUTERBOX_GUI_HTTP_PORT` | `3000` | HTTP GUI port |
+| `COMPUTERBOX_GUI_HTTPS_PORT` | `3001` | HTTPS GUI port |
+| `DESKTOP_READY_TIMEOUT` | `60` | Desktop ready timeout (seconds) |
+
+---
+
+## See Also
+
+- [Python SDK README](../../../sdks/python/README.md) - Quick start and examples
+- [Getting Started Guide](../../getting-started/quickstart-python.md) - Installation
+- [Configuration Reference](../README.md#configuration-reference) - BoxOptions details
+- [Error Codes](../README.md#error-codes--handling) - Error handling

--- a/docs/reference/rust/README.md
+++ b/docs/reference/rust/README.md
@@ -1,0 +1,1114 @@
+# Rust API Reference
+
+Complete API reference for the BoxLite Rust SDK.
+
+## Overview
+
+The Rust SDK is the core implementation of BoxLite. It provides async-first APIs built on Tokio for creating and managing isolated VM environments.
+
+**Crate**: `boxlite`
+**Repository**: [github.com/anthropics/boxlite](https://github.com/anthropics/boxlite)
+
+---
+
+## Table of Contents
+
+- [Runtime Management](#runtime-management)
+  - [BoxliteRuntime](#boxliteruntime)
+  - [BoxliteOptions](#boxliteoptions)
+- [Box Handle](#box-handle)
+  - [LiteBox](#litebox)
+  - [BoxInfo](#boxinfo)
+  - [BoxStatus](#boxstatus)
+  - [BoxState](#boxstate)
+- [Command Execution](#command-execution)
+  - [BoxCommand](#boxcommand)
+  - [Execution](#execution)
+  - [ExecStdin](#execstdin)
+  - [ExecStdout / ExecStderr](#execstdout--execstderr)
+  - [ExecResult](#execresult)
+- [Box Configuration](#box-configuration)
+  - [BoxOptions](#boxoptions)
+  - [RootfsSpec](#rootfsspec)
+  - [VolumeSpec](#volumespec)
+  - [NetworkSpec](#networkspec)
+  - [PortSpec](#portspec)
+- [Security](#security)
+  - [SecurityOptions](#securityoptions)
+  - [SecurityOptionsBuilder](#securityoptionsbuilder)
+  - [ResourceLimits](#resourcelimits)
+- [Metrics](#metrics)
+  - [RuntimeMetrics](#runtimemetrics)
+  - [BoxMetrics](#boxmetrics)
+- [Type Utilities](#type-utilities)
+  - [Bytes](#bytes)
+  - [Seconds](#seconds)
+  - [BoxID](#boxid)
+  - [ContainerID](#containerid)
+- [Error Types](#error-types)
+  - [BoxliteError](#boxliteerror)
+  - [BoxliteResult](#boxliteresult)
+
+---
+
+## Runtime Management
+
+### BoxliteRuntime
+
+Main entry point for creating and managing boxes.
+
+```rust
+use boxlite::runtime::{BoxliteRuntime, BoxliteOptions, BoxOptions};
+
+// Create with default options
+let runtime = BoxliteRuntime::with_defaults()?;
+
+// Create with custom options
+let options = BoxliteOptions {
+    home_dir: PathBuf::from("/custom/boxlite"),
+    image_registries: vec!["ghcr.io/myorg".to_string()],
+};
+let runtime = BoxliteRuntime::new(options)?;
+
+// Use global default runtime
+let runtime = BoxliteRuntime::default_runtime();
+```
+
+#### Methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `new` | `fn new(options: BoxliteOptions) -> BoxliteResult<Self>` | Create runtime with options |
+| `with_defaults` | `fn with_defaults() -> BoxliteResult<Self>` | Create with default options |
+| `default_runtime` | `fn default_runtime() -> &'static Self` | Get/create global singleton |
+| `try_default_runtime` | `fn try_default_runtime() -> Option<&'static Self>` | Get global if initialized |
+| `init_default_runtime` | `fn init_default_runtime(options: BoxliteOptions) -> BoxliteResult<()>` | Initialize global with options |
+| `create` | `async fn create(&self, options: BoxOptions, name: Option<String>) -> BoxliteResult<LiteBox>` | Create a new box |
+| `get` | `async fn get(&self, id_or_name: &str) -> BoxliteResult<Option<LiteBox>>` | Get box by ID or name |
+| `get_info` | `async fn get_info(&self, id_or_name: &str) -> BoxliteResult<Option<BoxInfo>>` | Get box info without handle |
+| `list_info` | `async fn list_info(&self) -> BoxliteResult<Vec<BoxInfo>>` | List all boxes |
+| `exists` | `async fn exists(&self, id_or_name: &str) -> BoxliteResult<bool>` | Check if box exists |
+| `metrics` | `async fn metrics(&self) -> RuntimeMetrics` | Get runtime-wide metrics |
+| `remove` | `async fn remove(&self, id_or_name: &str, force: bool) -> BoxliteResult<()>` | Remove box completely |
+
+#### Example
+
+```rust
+use boxlite::runtime::{BoxliteRuntime, BoxOptions};
+use boxlite::BoxCommand;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let runtime = BoxliteRuntime::with_defaults()?;
+
+    // Create a box
+    let options = BoxOptions::default();
+    let litebox = runtime.create(options, Some("my-box".to_string())).await?;
+
+    // Run a command
+    let mut run = litebox.run(BoxCommand::new("echo").arg("Hello")).await?;
+    let result = run.wait().await?;
+
+    println!("Exit code: {}", result.exit_code);
+
+    // Stop the box
+    litebox.stop().await?;
+
+    Ok(())
+}
+```
+
+### BoxliteOptions
+
+Runtime configuration options.
+
+```rust
+pub struct BoxliteOptions {
+    /// Home directory for runtime data (~/.boxlite by default)
+    pub home_dir: PathBuf,
+
+    /// Registries to search for unqualified image references
+    /// Empty list uses docker.io as implicit default
+    pub image_registries: Vec<String>,
+}
+```
+
+#### Example
+
+```rust
+use boxlite::runtime::BoxliteOptions;
+use std::path::PathBuf;
+
+let options = BoxliteOptions {
+    home_dir: PathBuf::from("/var/lib/boxlite"),
+    image_registries: vec![
+        "ghcr.io/myorg".to_string(),
+        "docker.io".to_string(),
+    ],
+};
+// "alpine" → tries ghcr.io/myorg/alpine, then docker.io/alpine
+```
+
+---
+
+## Box Handle
+
+### LiteBox
+
+Handle to a box instance. Thin wrapper providing access to box operations.
+
+```rust
+pub struct LiteBox {
+    // ... internal fields
+}
+```
+
+#### Methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `id` | `fn id(&self) -> &BoxID` | Get box ID |
+| `name` | `fn name(&self) -> Option<&str>` | Get optional box name |
+| `info` | `fn info(&self) -> BoxInfo` | Get box info (no VM init) |
+| `start` | `async fn start(&self) -> BoxliteResult<()>` | Start the box |
+| `run` | `async fn run(&self, command: BoxCommand) -> BoxliteResult<Execution>` | Run command |
+| `metrics` | `async fn metrics(&self) -> BoxliteResult<BoxMetrics>` | Get box metrics |
+| `stop` | `async fn stop(&self) -> BoxliteResult<()>` | Stop the box |
+
+#### Lifecycle
+
+- `start()` initializes VM for `Configured` or `Stopped` boxes
+- Idempotent: calling on `Running` box is a no-op
+- `run()` implicitly calls `start()` if needed
+- `stop()` terminates VM; box can be restarted
+
+#### Example
+
+```rust
+let litebox = runtime.create(BoxOptions::default(), None).await?;
+
+// Start explicitly (optional, run does this automatically)
+litebox.start().await?;
+
+// Check metrics
+let metrics = litebox.metrics().await?;
+println!("CPU: {:?}%", metrics.cpu_percent());
+
+// Stop when done
+litebox.stop().await?;
+```
+
+### BoxInfo
+
+Public metadata about a box (returned by list operations).
+
+```rust
+pub struct BoxInfo {
+    /// Unique box identifier (ULID)
+    pub id: BoxID,
+
+    /// User-defined name (optional)
+    pub name: Option<String>,
+
+    /// Current lifecycle status
+    pub status: BoxStatus,
+
+    /// Creation timestamp (UTC)
+    pub created_at: DateTime<Utc>,
+
+    /// Last state change timestamp (UTC)
+    pub last_updated: DateTime<Utc>,
+
+    /// Process ID of VMM subprocess (None if not running)
+    pub pid: Option<u32>,
+
+    /// Image reference or rootfs path
+    pub image: String,
+
+    /// Allocated CPU count
+    pub cpus: u8,
+
+    /// Allocated memory in MiB
+    pub memory_mib: u32,
+
+    /// User-defined labels
+    pub labels: HashMap<String, String>,
+}
+```
+
+### BoxStatus
+
+Lifecycle status of a box.
+
+```rust
+pub enum BoxStatus {
+    /// Cannot determine state (error recovery)
+    Unknown,
+
+    /// Created and persisted, VM not started
+    Configured,
+
+    /// Running and accepting commands
+    Running,
+
+    /// Shutting down gracefully (transient)
+    Stopping,
+
+    /// Not running, can be restarted
+    Stopped,
+}
+```
+
+#### Methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `is_active` | `fn is_active(&self) -> bool` | True if VM process running |
+| `is_running` | `fn is_running(&self) -> bool` | True if Running |
+| `is_configured` | `fn is_configured(&self) -> bool` | True if Configured |
+| `is_stopped` | `fn is_stopped(&self) -> bool` | True if Stopped |
+| `is_transient` | `fn is_transient(&self) -> bool` | True if Stopping |
+| `can_start` | `fn can_start(&self) -> bool` | True if Configured or Stopped |
+| `can_stop` | `fn can_stop(&self) -> bool` | True if Running |
+| `can_remove` | `fn can_remove(&self) -> bool` | True if Configured, Stopped, or Unknown |
+| `can_run` | `fn can_run(&self) -> bool` | True if Configured, Running, or Stopped |
+
+#### State Machine
+
+```
+create() → Configured (persisted to DB, no VM)
+start()  → Running (VM initialized)
+stop()   → Stopped (VM terminated, can restart)
+```
+
+### BoxState
+
+Dynamic box state (changes during lifecycle).
+
+```rust
+pub struct BoxState {
+    /// Current lifecycle status
+    pub status: BoxStatus,
+
+    /// Process ID (None if not running)
+    pub pid: Option<u32>,
+
+    /// Container ID (64-char hex)
+    pub container_id: Option<ContainerID>,
+
+    /// Last state change timestamp (UTC)
+    pub last_updated: DateTime<Utc>,
+
+    /// Lock ID for multiprocess-safe locking
+    pub lock_id: Option<LockId>,
+}
+```
+
+---
+
+## Command Execution
+
+### BoxCommand
+
+Command builder for running programs in a box.
+
+```rust
+use boxlite::BoxCommand;
+use std::time::Duration;
+
+let cmd = BoxCommand::new("python3")
+    .args(["-c", "print('hello')"])
+    .env("PYTHONPATH", "/app")
+    .timeout(Duration::from_secs(30))
+    .working_dir("/workspace")
+    .tty(true);
+```
+
+#### Builder Methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `new` | `fn new(command: impl Into<String>) -> Self` | Create command |
+| `arg` | `fn arg(self, arg: impl Into<String>) -> Self` | Add single argument |
+| `args` | `fn args<I, S>(self, args: I) -> Self` | Add multiple arguments |
+| `env` | `fn env(self, key: impl Into<String>, val: impl Into<String>) -> Self` | Set env var |
+| `timeout` | `fn timeout(self, timeout: Duration) -> Self` | Set run timeout |
+| `working_dir` | `fn working_dir(self, dir: impl Into<String>) -> Self` | Set working directory |
+| `tty` | `fn tty(self, enable: bool) -> Self` | Enable pseudo-terminal |
+
+### Execution
+
+Handle to a running command.
+
+```rust
+use boxlite::BoxCommand;
+use futures::StreamExt;
+
+let mut run_handle = litebox.run(BoxCommand::new("ls").arg("-la")).await?;
+
+// Read stdout as stream
+let mut stdout = run_handle.stdout().unwrap();
+while let Some(line) = stdout.next().await {
+    println!("{}", line);
+}
+
+// Wait for completion
+let status = run_handle.wait().await?;
+println!("Exit code: {}", status.exit_code);
+```
+
+#### Methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `id` | `fn id(&self) -> &ExecutionId` | Get run ID |
+| `stdin` | `fn stdin(&mut self) -> Option<ExecStdin>` | Take stdin stream (once) |
+| `stdout` | `fn stdout(&mut self) -> Option<ExecStdout>` | Take stdout stream (once) |
+| `stderr` | `fn stderr(&mut self) -> Option<ExecStderr>` | Take stderr stream (once) |
+| `wait` | `async fn wait(&mut self) -> BoxliteResult<ExecResult>` | Wait for completion |
+| `kill` | `async fn kill(&mut self) -> BoxliteResult<()>` | Send SIGKILL |
+| `signal` | `async fn signal(&self, signal: i32) -> BoxliteResult<()>` | Send signal |
+| `resize_tty` | `async fn resize_tty(&self, rows: u32, cols: u32) -> BoxliteResult<()>` | Resize PTY |
+
+### ExecStdin
+
+Standard input stream (write-only).
+
+```rust
+pub struct ExecStdin {
+    // ...
+}
+
+impl ExecStdin {
+    /// Write data to stdin
+    pub async fn write(&mut self, data: &[u8]) -> BoxliteResult<()>;
+
+    /// Write all data to stdin
+    pub async fn write_all(&mut self, data: &[u8]) -> BoxliteResult<()>;
+}
+```
+
+#### Example
+
+```rust
+let mut run_handle = litebox.run(BoxCommand::new("cat")).await?;
+
+// Get stdin handle
+let mut stdin = run_handle.stdin().unwrap();
+
+// Write data
+stdin.write(b"Hello from stdin!\n").await?;
+stdin.write_all(b"More data\n").await?;
+
+// Drop stdin to close (signals EOF to process)
+drop(stdin);
+
+let result = run_handle.wait().await?;
+```
+
+### ExecStdout / ExecStderr
+
+Standard output/error streams (read-only). Implements `futures::Stream<Item = String>`.
+
+```rust
+use futures::StreamExt;
+
+let mut run_handle = litebox.run(BoxCommand::new("ls")).await?;
+
+// Read stdout
+let mut stdout = run_handle.stdout().unwrap();
+while let Some(line) = stdout.next().await {
+    println!("stdout: {}", line);
+}
+
+// Read stderr
+let mut stderr = run_handle.stderr().unwrap();
+while let Some(line) = stderr.next().await {
+    eprintln!("stderr: {}", line);
+}
+```
+
+#### Concurrent Reading
+
+```rust
+use futures::StreamExt;
+use tokio::select;
+
+let mut run_handle = litebox.run(BoxCommand::new("my-command")).await?;
+let mut stdout = run_handle.stdout().unwrap();
+let mut stderr = run_handle.stderr().unwrap();
+
+loop {
+    select! {
+        Some(line) = stdout.next() => println!("stdout: {}", line),
+        Some(line) = stderr.next() => eprintln!("stderr: {}", line),
+        else => break,
+    }
+}
+```
+
+### ExecResult
+
+Exit status of a process.
+
+```rust
+pub struct ExecResult {
+    /// Exit code (0 = success, negative = signal number)
+    pub exit_code: i32,
+}
+
+impl ExecResult {
+    /// Returns true if exit code was 0
+    pub fn success(&self) -> bool;
+
+    /// Get exit code
+    pub fn code(&self) -> i32;
+}
+```
+
+---
+
+## Box Configuration
+
+### BoxOptions
+
+Options for constructing a box.
+
+```rust
+pub struct BoxOptions {
+    /// Number of CPUs (default: 2)
+    pub cpus: Option<u8>,
+
+    /// Memory in MiB (default: 512)
+    pub memory_mib: Option<u32>,
+
+    /// Disk size in GB for rootfs (sparse, grows as needed)
+    pub disk_size_gb: Option<u64>,
+
+    /// Working directory inside box
+    pub working_dir: Option<String>,
+
+    /// Environment variables
+    pub env: Vec<(String, String)>,
+
+    /// Root filesystem source
+    pub rootfs: RootfsSpec,
+
+    /// Volume mounts
+    pub volumes: Vec<VolumeSpec>,
+
+    /// Network isolation mode
+    pub network: NetworkSpec,
+
+    /// Port mappings
+    pub ports: Vec<PortSpec>,
+
+    /// Enable bind mount isolation (Linux only)
+    pub isolate_mounts: bool,
+
+    /// Auto-remove box when stopped (default: true)
+    pub auto_remove: bool,
+
+    /// Run independently of parent process (default: false)
+    pub detach: bool,
+
+    /// Security isolation options
+    pub security: SecurityOptions,
+}
+```
+
+#### Example
+
+```rust
+use boxlite::runtime::options::{BoxOptions, RootfsSpec, VolumeSpec, PortSpec};
+
+let options = BoxOptions {
+    cpus: Some(4),
+    memory_mib: Some(2048),
+    rootfs: RootfsSpec::Image("python:3.11".to_string()),
+    env: vec![
+        ("PYTHONPATH".to_string(), "/app".to_string()),
+    ],
+    volumes: vec![
+        VolumeSpec {
+            host_path: "/home/user/project".to_string(),
+            guest_path: "/app".to_string(),
+            read_only: false,
+        },
+    ],
+    ports: vec![
+        PortSpec {
+            host_port: Some(8080),
+            guest_port: 80,
+            ..Default::default()
+        },
+    ],
+    auto_remove: false,  // Keep box after stop
+    detach: true,        // Run independently
+    ..Default::default()
+};
+```
+
+### RootfsSpec
+
+How to populate the box root filesystem.
+
+```rust
+pub enum RootfsSpec {
+    /// Pull/resolve this registry image reference
+    Image(String),
+
+    /// Use already prepared rootfs at host path
+    RootfsPath(String),
+}
+
+impl Default for RootfsSpec {
+    fn default() -> Self {
+        Self::Image("alpine:latest".into())
+    }
+}
+```
+
+### VolumeSpec
+
+Filesystem mount specification.
+
+```rust
+pub struct VolumeSpec {
+    /// Path on host
+    pub host_path: String,
+
+    /// Path inside guest
+    pub guest_path: String,
+
+    /// Mount as read-only
+    pub read_only: bool,
+}
+```
+
+### NetworkSpec
+
+Network isolation options.
+
+```rust
+pub enum NetworkSpec {
+    /// Isolated network with gvproxy (default)
+    Isolated,
+    // Host,    // Future: share host network
+    // Custom,  // Future: custom network config
+}
+```
+
+### PortSpec
+
+Port mapping specification (host → guest).
+
+```rust
+pub struct PortSpec {
+    /// Host port (None/0 = dynamically assigned)
+    pub host_port: Option<u16>,
+
+    /// Guest port to expose
+    pub guest_port: u16,
+
+    /// Protocol (TCP/UDP)
+    pub protocol: PortProtocol,
+
+    /// Bind IP (None = 0.0.0.0)
+    pub host_ip: Option<String>,
+}
+
+pub enum PortProtocol {
+    Tcp,  // default
+    Udp,
+}
+```
+
+---
+
+## Security
+
+### SecurityOptions
+
+Security isolation options for a box.
+
+```rust
+pub struct SecurityOptions {
+    /// Enable jailer isolation (Linux: seccomp/namespaces, macOS: sandbox-exec)
+    pub jailer_enabled: bool,
+
+    /// Enable seccomp syscall filtering (Linux only)
+    pub seccomp_enabled: bool,
+
+    /// UID to drop to (Linux only). None = auto-allocate
+    pub uid: Option<u32>,
+
+    /// GID to drop to (Linux only). None = auto-allocate
+    pub gid: Option<u32>,
+
+    /// Create new PID namespace (Linux only)
+    pub new_pid_ns: bool,
+
+    /// Create new network namespace (Linux only)
+    pub new_net_ns: bool,
+
+    /// Base directory for chroot jails (Linux)
+    pub chroot_base: PathBuf,
+
+    /// Enable chroot isolation (Linux only)
+    pub chroot_enabled: bool,
+
+    /// Close inherited file descriptors
+    pub close_fds: bool,
+
+    /// Sanitize environment variables
+    pub sanitize_env: bool,
+
+    /// Environment variables to preserve
+    pub env_allowlist: Vec<String>,
+
+    /// Resource limits
+    pub resource_limits: ResourceLimits,
+
+    /// Custom sandbox profile (macOS only)
+    pub sandbox_profile: Option<PathBuf>,
+
+    /// Enable network in sandbox (macOS only)
+    pub network_enabled: bool,
+}
+```
+
+#### Presets
+
+```rust
+// Development: minimal isolation for debugging
+let dev = SecurityOptions::development();
+// - jailer_enabled: false
+// - seccomp_enabled: false
+// - close_fds: false
+
+// Standard: recommended for most use cases
+let std = SecurityOptions::standard();
+// - jailer_enabled: true (Linux/macOS)
+// - seccomp_enabled: true (Linux)
+
+// Maximum: all isolation features
+let max = SecurityOptions::maximum();
+// - All isolation enabled
+// - uid/gid: 65534 (nobody)
+// - Resource limits applied
+```
+
+### SecurityOptionsBuilder
+
+Fluent builder for security options.
+
+```rust
+use boxlite::runtime::options::{SecurityOptions, SecurityOptionsBuilder};
+
+let security = SecurityOptionsBuilder::standard()
+    .jailer_enabled(true)
+    .max_open_files(2048)
+    .max_file_size_bytes(1024 * 1024 * 512)  // 512 MiB
+    .max_processes(100)
+    .allow_env("MY_VAR")
+    .build();
+
+// Or via SecurityOptions::builder()
+let security = SecurityOptions::builder()
+    .jailer_enabled(true)
+    .seccomp_enabled(false)
+    .build();
+```
+
+#### Builder Methods
+
+| Method | Description |
+|--------|-------------|
+| `new()` | Start from defaults |
+| `development()` | Start from dev preset |
+| `standard()` | Start from standard preset |
+| `maximum()` | Start from max preset |
+| `jailer_enabled(bool)` | Enable/disable jailer |
+| `seccomp_enabled(bool)` | Enable/disable seccomp |
+| `uid(u32)` | Set drop-to UID |
+| `gid(u32)` | Set drop-to GID |
+| `new_pid_ns(bool)` | Enable PID namespace |
+| `new_net_ns(bool)` | Enable network namespace |
+| `chroot_base(path)` | Set chroot base dir |
+| `chroot_enabled(bool)` | Enable chroot |
+| `close_fds(bool)` | Close inherited FDs |
+| `sanitize_env(bool)` | Sanitize environment |
+| `env_allowlist(vec)` | Set env allowlist |
+| `allow_env(var)` | Add to env allowlist |
+| `resource_limits(limits)` | Set all limits |
+| `max_open_files(n)` | RLIMIT_NOFILE |
+| `max_file_size_bytes(n)` | RLIMIT_FSIZE |
+| `max_processes(n)` | RLIMIT_NPROC |
+| `max_memory_bytes(n)` | RLIMIT_AS |
+| `max_cpu_time_seconds(n)` | RLIMIT_CPU |
+| `sandbox_profile(path)` | macOS sandbox profile |
+| `network_enabled(bool)` | macOS network access |
+| `build()` | Build SecurityOptions |
+
+### ResourceLimits
+
+Resource limits for the jailed process.
+
+```rust
+pub struct ResourceLimits {
+    /// Max open file descriptors (RLIMIT_NOFILE)
+    pub max_open_files: Option<u64>,
+
+    /// Max file size in bytes (RLIMIT_FSIZE)
+    pub max_file_size: Option<u64>,
+
+    /// Max number of processes (RLIMIT_NPROC)
+    pub max_processes: Option<u64>,
+
+    /// Max virtual memory in bytes (RLIMIT_AS)
+    pub max_memory: Option<u64>,
+
+    /// Max CPU time in seconds (RLIMIT_CPU)
+    pub max_cpu_time: Option<u64>,
+}
+```
+
+---
+
+## Metrics
+
+### RuntimeMetrics
+
+Runtime-wide metrics (aggregate across all boxes).
+
+```rust
+let metrics = runtime.metrics().await;
+println!("Boxes created: {}", metrics.boxes_created_total());
+println!("Commands run: {}", metrics.total_commands_run());
+```
+
+#### Methods
+
+| Method | Return | Description |
+|--------|--------|-------------|
+| `boxes_created_total()` | `u64` | Total boxes created |
+| `boxes_failed_total()` | `u64` | Total boxes that failed to start |
+| `num_running_boxes()` | `u64` | Currently running boxes |
+| `total_commands_run()` | `u64` | Total run() calls |
+| `total_run_errors()` | `u64` | Total run errors |
+
+### BoxMetrics
+
+Per-box metrics (individual LiteBox statistics).
+
+```rust
+let metrics = litebox.metrics().await?;
+println!("Boot time: {:?}ms", metrics.guest_boot_duration_ms());
+println!("CPU: {:?}%", metrics.cpu_percent());
+println!("Memory: {:?} bytes", metrics.memory_bytes());
+```
+
+#### Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `commands_run_total` | `u64` | Commands on this box |
+| `run_errors_total` | `u64` | Run errors on this box |
+| `bytes_sent_total` | `u64` | Bytes sent (stdin) |
+| `bytes_received_total` | `u64` | Bytes received (stdout/stderr) |
+| `total_create_duration_ms` | `Option<u128>` | Total init time |
+| `guest_boot_duration_ms` | `Option<u128>` | Guest boot time |
+| `cpu_percent` | `Option<f32>` | CPU usage (0-100) |
+| `memory_bytes` | `Option<u64>` | Memory usage |
+| `network_bytes_sent` | `Option<u64>` | Network TX |
+| `network_bytes_received` | `Option<u64>` | Network RX |
+| `network_tcp_connections` | `Option<u64>` | Active TCP connections |
+| `network_tcp_errors` | `Option<u64>` | TCP connection errors |
+
+#### Stage Timing
+
+| Field | Description |
+|-------|-------------|
+| `stage_filesystem_setup_ms` | Stage 1: Directory setup |
+| `stage_image_prepare_ms` | Stage 2: Image pull/extract |
+| `stage_guest_rootfs_ms` | Stage 3: Guest rootfs bootstrap |
+| `stage_box_config_ms` | Stage 4: Box config build |
+| `stage_box_spawn_ms` | Stage 5: Subprocess spawn |
+| `stage_container_init_ms` | Stage 6: Container init |
+
+---
+
+## Type Utilities
+
+### Bytes
+
+Semantic newtype for byte sizes.
+
+```rust
+use boxlite::runtime::types::Bytes;
+
+// Constructors
+let size = Bytes::from_bytes(1_000_000);
+let size = Bytes::from_kib(512);   // 512 * 1024
+let size = Bytes::from_mib(128);   // 128 * 1024²
+let size = Bytes::from_gib(2);     // 2 * 1024³
+
+// Accessors
+let bytes = size.as_bytes();
+let kib = size.as_kib();
+let mib = size.as_mib();
+
+// Display
+println!("{}", Bytes::from_mib(512));  // "512 MiB"
+```
+
+### Seconds
+
+Semantic newtype for durations.
+
+```rust
+use boxlite::runtime::types::Seconds;
+
+// Constructors
+let duration = Seconds::from_seconds(30);
+let duration = Seconds::from_minutes(5);   // 300 seconds
+let duration = Seconds::from_hours(1);     // 3600 seconds
+
+// Accessors
+let secs = duration.as_seconds();
+let mins = duration.as_minutes();
+
+// Display
+println!("{}", Seconds::from_minutes(30));  // "30 minutes"
+```
+
+### BoxID
+
+Box identifier in ULID format (26 characters, sortable).
+
+```rust
+use boxlite::runtime::types::BoxID;
+
+let id = BoxID::new();
+println!("Full: {}", id.as_str());   // "01HJK4TNRPQSXYZ8WM6NCVT9R5"
+println!("Short: {}", id.short());    // "01HJK4TN"
+
+// Validation
+let valid = BoxID::parse("01HJK4TNRPQSXYZ8WM6NCVT9R5");
+let invalid = BoxID::parse("too-short");  // None
+```
+
+### ContainerID
+
+Container identifier (64-char lowercase hex, OCI format).
+
+```rust
+use boxlite::runtime::types::ContainerID;
+
+let id = ContainerID::new();
+println!("Full: {}", id.as_str());   // 64 hex chars
+println!("Short: {}", id.short());    // 12 hex chars
+
+// Validation
+let valid = ContainerID::is_valid("a".repeat(64).as_str());  // true
+```
+
+---
+
+## Error Types
+
+### BoxliteError
+
+Central error enum for all BoxLite operations.
+
+```rust
+pub enum BoxliteError {
+    /// Unsupported engine kind
+    UnsupportedEngine,
+
+    /// Engine reported an error
+    Engine(String),
+
+    /// Configuration error
+    Config(String),
+
+    /// Storage/filesystem error
+    Storage(String),
+
+    /// Image pull/resolve error
+    Image(String),
+
+    /// Host-guest communication error
+    Portal(String),
+
+    /// Network error
+    Network(String),
+
+    /// gRPC error
+    Rpc(String),
+
+    /// gRPC transport error
+    RpcTransport(String),
+
+    /// Internal error
+    Internal(String),
+
+    /// Command run error
+    Run(String),
+
+    /// Unsupported operation
+    Unsupported(String),
+
+    /// Box not found
+    NotFound(String),
+
+    /// Resource already exists
+    AlreadyExists(String),
+
+    /// Invalid state for operation
+    InvalidState(String),
+
+    /// Database error
+    Database(String),
+
+    /// Metadata parsing error
+    MetadataError(String),
+
+    /// Invalid argument
+    InvalidArgument(String),
+}
+```
+
+### BoxliteResult
+
+Result type alias for BoxLite operations.
+
+```rust
+pub type BoxliteResult<T> = Result<T, BoxliteError>;
+```
+
+#### Error Handling Example
+
+```rust
+use boxlite::BoxliteError;
+
+match runtime.create(options, None).await {
+    Ok(litebox) => println!("Created box: {}", litebox.id()),
+    Err(BoxliteError::Image(msg)) => eprintln!("Image error: {}", msg),
+    Err(BoxliteError::Config(msg)) => eprintln!("Config error: {}", msg),
+    Err(e) => eprintln!("Other error: {}", e),
+}
+```
+
+---
+
+## Complete Example
+
+```rust
+use boxlite::runtime::{BoxliteRuntime, BoxOptions};
+use boxlite::runtime::options::{RootfsSpec, SecurityOptions, VolumeSpec};
+use boxlite::BoxCommand;
+use futures::StreamExt;
+use std::time::Duration;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Initialize runtime
+    let runtime = BoxliteRuntime::with_defaults()?;
+
+    // Configure box
+    let options = BoxOptions {
+        cpus: Some(2),
+        memory_mib: Some(1024),
+        rootfs: RootfsSpec::Image("python:3.11-slim".to_string()),
+        volumes: vec![
+            VolumeSpec {
+                host_path: "/home/user/code".to_string(),
+                guest_path: "/app".to_string(),
+                read_only: true,
+            },
+        ],
+        security: SecurityOptions::standard(),
+        ..Default::default()
+    };
+
+    // Create and name the box
+    let litebox = runtime.create(options, Some("python-sandbox".to_string())).await?;
+    println!("Created box: {}", litebox.id());
+
+    // Run Python code
+    let cmd = BoxCommand::new("python3")
+        .args(["-c", "import sys; print(f'Python {sys.version}')"])
+        .timeout(Duration::from_secs(30))
+        .working_dir("/app");
+
+    let mut run_handle = litebox.run(cmd).await?;
+
+    // Stream output
+    if let Some(mut stdout) = run_handle.stdout() {
+        while let Some(line) = stdout.next().await {
+            println!("{}", line);
+        }
+    }
+
+    // Check result
+    let result = run_handle.wait().await?;
+    if !result.success() {
+        eprintln!("Command failed with exit code: {}", result.exit_code);
+    }
+
+    // Check metrics
+    let metrics = litebox.metrics().await?;
+    if let Some(boot_ms) = metrics.guest_boot_duration_ms() {
+        println!("Boot time: {}ms", boot_ms);
+    }
+
+    // Cleanup
+    litebox.stop().await?;
+
+    Ok(())
+}
+```
+
+---
+
+## Thread Safety
+
+All public types are `Send + Sync`:
+
+- `BoxliteRuntime` - safely shareable across threads
+- `LiteBox` - safely shareable across threads
+- `Execution` - Clone + shareable
+
+```rust
+use std::sync::Arc;
+use tokio::task;
+
+let runtime = Arc::new(BoxliteRuntime::with_defaults()?);
+
+let handles: Vec<_> = (0..4).map(|i| {
+    let rt = runtime.clone();
+    task::spawn(async move {
+        let box_opts = BoxOptions::default();
+        let litebox = rt.create(box_opts, None).await?;
+        // Each task has its own box
+        Ok::<_, BoxliteError>(litebox.id().clone())
+    })
+}).collect();
+
+for handle in handles {
+    let id = handle.await??;
+    println!("Created: {}", id);
+}
+```
+
+---
+
+## See Also
+
+- [Getting Started Guide](../../getting-started/README.md)
+- [Architecture Overview](../../architecture/README.md)
+- [Configuration Reference](../README.md)
+- [Python SDK Reference](../python/README.md)
+- [Node.js SDK Reference](../nodejs/README.md)


### PR DESCRIPTION
## Summary

Adds complete API reference documentation for all BoxLite SDKs.

## New Documentation

| SDK | File | Content |
|-----|------|---------|
| **Python** | `docs/reference/python/README.md` | Runtime, box types, sync API, metrics |
| **Node.js** | `docs/reference/nodejs/README.md` | TypeScript types, CDP ports, metrics |
| **Rust** | `docs/reference/rust/README.md` | Streams, SecurityOptions, ResourceLimits |
| **C** | `docs/reference/c/README.md` | JSON schema, callbacks, memory management |

## Changes

- Created 4 new SDK API reference documents (~3500 lines total)
- Updated `docs/reference/README.md` with SDK links table
- Consistent structure across all references: runtime, box types, execution, configuration, errors

## Test plan

- [ ] Verify all internal links work
- [ ] Check code examples are syntactically correct
- [ ] Review SDK-specific sections match source code