### PR TITLE
feat: use PID file as single source of truth for process tracking

### DIFF
--- a/boxlite/src/jailer/common/mod.rs
+++ b/boxlite/src/jailer/common/mod.rs
@@ -3,12 +3,14 @@
 //! These modules provide:
 //! - [`fd`]: File descriptor cleanup (async-signal-safe for pre_exec)
 //! - [`rlimit`]: Resource limit management (async-signal-safe for pre_exec)
+//! - [`pid`]: PID file writing (async-signal-safe for pre_exec)
 //! - [`fs`]: Filesystem utilities (copy-if-newer, etc.)
 //!
 //! Note: Environment sanitization is handled by bwrap/sandbox-exec at spawn time.
 
 pub mod fd;
 pub mod fs;
+pub mod pid;
 pub mod rlimit;
 
 /// Get errno in an async-signal-safe way.

--- a/boxlite/src/jailer/common/pid.rs
+++ b/boxlite/src/jailer/common/pid.rs
@@ -1,0 +1,172 @@
+//! PID file writing for process tracking.
+//!
+//! Writes the current process PID to a file in an async-signal-safe manner.
+//! This is designed to be called from `pre_exec` hook after fork() but before exec().
+//!
+//! The PID file serves as the single source of truth for the shim process PID,
+//! enabling crash recovery and process tracking.
+
+/// Write current process PID to file - async-signal-safe version for pre_exec.
+///
+/// This function is designed to be called from a `pre_exec` hook, which runs
+/// after `fork()` but before `exec()`. Only async-signal-safe operations are
+/// allowed in this context.
+///
+/// # Safety
+///
+/// This function only uses async-signal-safe syscalls (getpid, open, write, close).
+/// Do NOT add:
+/// - Logging (tracing, println)
+/// - Memory allocation (Box, Vec, String)
+/// - Mutex operations
+/// - Most Rust stdlib functions
+///
+/// # Arguments
+/// * `path` - CString path to the PID file (pre-allocated by caller)
+///
+/// # Returns
+/// * `Ok(())` - PID file written successfully
+/// * `Err(errno)` - Failed (returns raw errno for io::Error conversion)
+pub fn write_pid_file_raw(path: &std::ffi::CStr) -> Result<(), i32> {
+    unsafe {
+        let pid = libc::getpid();
+
+        // Format PID as string using stack buffer (no allocation)
+        let mut buf = [0u8; 16];
+        let len = format_pid_to_buffer(pid, &mut buf);
+
+        // Open file: O_WRONLY | O_CREAT | O_TRUNC
+        // Mode 0o644: rw-r--r--
+        let fd = libc::open(
+            path.as_ptr(),
+            libc::O_WRONLY | libc::O_CREAT | libc::O_TRUNC,
+            0o644 as libc::c_uint,
+        );
+        if fd < 0 {
+            return Err(super::get_errno());
+        }
+
+        // Write PID
+        let written = libc::write(fd, buf.as_ptr() as *const libc::c_void, len);
+        let write_errno = if written < 0 {
+            Some(super::get_errno())
+        } else {
+            None
+        };
+
+        // Always close the file descriptor
+        libc::close(fd);
+
+        // Return write error if any
+        if let Some(errno) = write_errno {
+            return Err(errno);
+        }
+
+        Ok(())
+    }
+}
+
+/// Format i32 PID to buffer without allocation (async-signal-safe).
+///
+/// Returns the number of bytes written to the buffer.
+///
+/// # Safety
+///
+/// Uses only stack operations, no heap allocation.
+#[inline]
+fn format_pid_to_buffer(mut pid: i32, buf: &mut [u8; 16]) -> usize {
+    if pid == 0 {
+        buf[0] = b'0';
+        buf[1] = b'\n';
+        return 2;
+    }
+
+    // Handle negative PIDs (shouldn't happen, but be safe)
+    let negative = pid < 0;
+    if negative {
+        pid = -pid;
+    }
+
+    // Convert digits in reverse order
+    let mut len = 0;
+    let mut tmp = [0u8; 16];
+
+    while pid > 0 {
+        tmp[len] = b'0' + (pid % 10) as u8;
+        pid /= 10;
+        len += 1;
+    }
+
+    // Add negative sign if needed
+    let mut pos = 0;
+    if negative {
+        buf[pos] = b'-';
+        pos += 1;
+    }
+
+    // Reverse digits into output buffer
+    for i in 0..len {
+        buf[pos] = tmp[len - 1 - i];
+        pos += 1;
+    }
+
+    // Add newline for readability
+    buf[pos] = b'\n';
+    pos += 1;
+
+    pos
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CString;
+
+    #[test]
+    fn test_format_pid_to_buffer() {
+        let mut buf = [0u8; 16];
+
+        // Test positive PID
+        let len = format_pid_to_buffer(12345, &mut buf);
+        assert_eq!(&buf[..len], b"12345\n");
+
+        // Test single digit
+        let len = format_pid_to_buffer(7, &mut buf);
+        assert_eq!(&buf[..len], b"7\n");
+
+        // Test zero
+        let len = format_pid_to_buffer(0, &mut buf);
+        assert_eq!(&buf[..len], b"0\n");
+
+        // Test larger PID
+        let len = format_pid_to_buffer(1234567890, &mut buf);
+        assert_eq!(&buf[..len], b"1234567890\n");
+    }
+
+    #[test]
+    fn test_write_pid_file_raw() {
+        use std::io::Read;
+
+        // Create temp file path
+        let temp_dir = std::env::temp_dir();
+        let pid_file = temp_dir.join("test_pid_file.pid");
+        let path = CString::new(pid_file.to_string_lossy().as_bytes()).unwrap();
+
+        // Write PID file
+        write_pid_file_raw(&path).expect("Should write PID file");
+
+        // Read and verify
+        let mut content = String::new();
+        std::fs::File::open(&pid_file)
+            .expect("Should open file")
+            .read_to_string(&mut content)
+            .expect("Should read file");
+
+        let expected_pid = std::process::id();
+        let file_pid: u32 = content.trim().parse().expect("Should parse PID");
+        assert_eq!(file_pid, expected_pid);
+
+        // Cleanup
+        let _ = std::fs::remove_file(&pid_file);
+    }
+}

--- a/boxlite/src/litebox/init/types.rs
+++ b/boxlite/src/litebox/init/types.rs
@@ -183,7 +183,7 @@ impl Drop for CleanupGuard {
         // First mark as crashed so remove_box() doesn't fail the active check
         // TODO(@DorianZheng) Check if this is necessary
         if let Ok(mut state) = self.runtime.box_manager.update_box(&self.box_id) {
-            state.mark_crashed();
+            state.mark_stop();
             let _ = self.runtime.box_manager.save_box(&self.box_id, &state);
         }
         if let Err(e) = self.runtime.box_manager.remove_box(&self.box_id) {

--- a/boxlite/src/litebox/state.rs
+++ b/boxlite/src/litebox/state.rs
@@ -229,7 +229,7 @@ impl BoxState {
     /// In our simplified state model, crashed VMs become Stopped
     /// since the rootfs is preserved and can be restarted.
     /// PID is cleared since the process is no longer alive.
-    pub fn mark_crashed(&mut self) {
+    pub fn mark_stop(&mut self) {
         self.status = BoxStatus::Stopped;
         self.pid = None;
         self.last_updated = Utc::now();

--- a/boxlite/src/runtime/layout.rs
+++ b/boxlite/src/runtime/layout.rs
@@ -332,6 +332,15 @@ impl BoxFilesystemLayout {
         self.box_dir.join("console.log")
     }
 
+    /// PID file path: ~/.boxlite/boxes/{box_id}/shim.pid
+    ///
+    /// Written by the shim process in pre_exec (after fork, before exec).
+    /// This is the single source of truth for the shim process PID.
+    /// Database PID is a cache that can be reconstructed from this file.
+    pub fn pid_file_path(&self) -> PathBuf {
+        self.box_dir.join("shim.pid")
+    }
+
     // ========================================================================
     // PREPARATION AND CLEANUP
     // ========================================================================

--- a/boxlite/src/runtime/rt_impl.rs
+++ b/boxlite/src/runtime/rt_impl.rs
@@ -774,32 +774,55 @@ impl RuntimeImpl {
                 }
             }
 
-            // Validate PID if present
-            if let Some(pid) = state.pid {
-                if is_process_alive(pid) && is_same_process(pid, box_id.as_str()) {
-                    // Process is alive and it's our boxlite-shim - box stays Running
-                    if state.status == BoxStatus::Running {
-                        tracing::info!("Recovered box {} as Running (PID {})", box_id, pid);
+            // Check PID file (single source of truth for running processes)
+            let pid_file = self
+                .layout
+                .boxes_dir()
+                .join(box_id.as_str())
+                .join("shim.pid");
+
+            if pid_file.exists() {
+                match crate::util::read_pid_file(&pid_file) {
+                    Ok(pid) => {
+                        if is_process_alive(pid) && is_same_process(pid, box_id.as_str()) {
+                            // Process is alive and it's our boxlite-shim - box stays Running
+                            state.set_pid(Some(pid));
+                            state.set_status(BoxStatus::Running);
+                            tracing::info!(
+                                box_id = %box_id,
+                                pid = pid,
+                                "Recovered running box from PID file"
+                            );
+                        } else {
+                            // Process died or PID was reused - clean up and mark as Stopped
+                            let _ = std::fs::remove_file(&pid_file);
+                            state.mark_stop();
+                            tracing::warn!(
+                                box_id = %box_id,
+                                pid = pid,
+                                "Box process dead, cleaned up stale PID file"
+                            );
+                        }
                     }
-                } else {
-                    // Process died or PID was reused - mark as Stopped
-                    if state.status.is_active() {
-                        state.mark_crashed();
+                    Err(e) => {
+                        // Can't read PID file - clean up and mark as Stopped
+                        let _ = std::fs::remove_file(&pid_file);
+                        state.mark_stop();
                         tracing::warn!(
-                            "Box {} marked as Stopped (PID {} not found or different process)",
-                            box_id,
-                            pid
+                            box_id = %box_id,
+                            error = %e,
+                            "Failed to read PID file, marking as Stopped"
                         );
                     }
                 }
             } else {
-                // No PID - box was stopped gracefully or never started
-                // Note: Configured boxes won't have a PID (this is expected)
+                // No PID file - box was stopped gracefully or never started
+                // Note: Configured boxes won't have a PID file (this is expected)
                 if state.status == BoxStatus::Running {
                     state.set_status(BoxStatus::Stopped);
                     tracing::warn!(
-                        "Box {} was Running but had no PID, marked as Stopped",
-                        box_id
+                        box_id = %box_id,
+                        "Box was Running but no PID file found, marked as Stopped"
                     );
                 }
             }
@@ -968,6 +991,7 @@ impl RuntimeImpl {
     ///
     /// Use this when you need atomicity across multiple operations on
     /// box_manager or image_manager.
+    #[allow(unused)]
     pub(crate) fn acquire_write(
         &self,
     ) -> BoxliteResult<std::sync::RwLockWriteGuard<'_, SynchronizedState>> {

--- a/boxlite/src/util/mod.rs
+++ b/boxlite/src/util/mod.rs
@@ -12,8 +12,7 @@ use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{EnvFilter, fmt};
 
-// Re-export process utilities
-pub use process::{is_process_alive, is_same_process, kill_process};
+pub use process::{is_process_alive, is_same_process, kill_process, read_pid_file};
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 unsafe extern "C" {

--- a/boxlite/tests/pid_file.rs
+++ b/boxlite/tests/pid_file.rs
@@ -1,0 +1,995 @@
+//! Integration tests for PID file functionality.
+//!
+//! Tests the PID file as single source of truth for process tracking:
+//! - PID file created in pre_exec (after fork, before exec)
+//! - Recovery uses PID file instead of DB
+//! - Detached boxes survive parent exit and can be recovered
+//!
+//! Test categories:
+//! - P0 (Critical): Basic functionality, Detach mode, Recovery scenarios
+//! - P1 (Important): Edge cases, Cleanup, Process validation
+
+use boxlite::BoxliteRuntime;
+use boxlite::litebox::BoxCommand;
+use boxlite::runtime::options::{BoxOptions, BoxliteOptions, RootfsSpec};
+use boxlite::runtime::types::BoxStatus;
+use boxlite::util::{is_process_alive, is_same_process, read_pid_file};
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+// ============================================================================
+// TEST FIXTURES
+// ============================================================================
+
+/// Test context with isolated runtime, temp directory access, and automatic cleanup.
+struct TestContext {
+    runtime: BoxliteRuntime,
+    home_dir: PathBuf,
+    _temp_dir: TempDir, // Dropped after test
+}
+
+impl TestContext {
+    fn new() -> Self {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let home_dir = temp_dir.path().to_path_buf();
+        let options = BoxliteOptions {
+            home_dir: home_dir.clone(),
+            image_registries: vec![],
+        };
+        let runtime = BoxliteRuntime::new(options).expect("Failed to create runtime");
+        Self {
+            runtime,
+            home_dir,
+            _temp_dir: temp_dir,
+        }
+    }
+
+    /// Get the PID file path for a box.
+    fn pid_file_path(&self, box_id: &str) -> PathBuf {
+        self.home_dir.join("boxes").join(box_id).join("shim.pid")
+    }
+}
+
+// ============================================================================
+// CATEGORY 1: BASIC FUNCTIONALITY (P0)
+// ============================================================================
+
+#[tokio::test]
+async fn pid_file_created_on_box_start() {
+    let ctx = TestContext::new();
+    let handle = ctx
+        .runtime
+        .create(
+            BoxOptions {
+                rootfs: RootfsSpec::Image("alpine:latest".into()),
+                auto_remove: false,
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    // Run command to start the box
+    let _ = handle.exec(BoxCommand::new("true")).await;
+
+    // Verify PID file exists
+    let pid_file = ctx.pid_file_path(handle.id().as_str());
+    assert!(pid_file.exists(), "PID file should exist after run");
+
+    // Cleanup
+    handle.stop().await.unwrap();
+    ctx.runtime
+        .remove(handle.id().as_str(), false)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn pid_file_contains_correct_pid() {
+    let ctx = TestContext::new();
+    let handle = ctx
+        .runtime
+        .create(
+            BoxOptions {
+                rootfs: RootfsSpec::Image("alpine:latest".into()),
+                auto_remove: false,
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    // Start a long-running command
+    let _ = handle.exec(BoxCommand::new("sleep").args(["30"])).await;
+
+    let pid_file = ctx.pid_file_path(handle.id().as_str());
+    let pid_from_file = read_pid_file(&pid_file).expect("Should read PID file");
+
+    // Verify process is actually running
+    assert!(
+        is_process_alive(pid_from_file),
+        "PID {} should be a running process",
+        pid_from_file
+    );
+
+    // Verify it's our boxlite-shim
+    assert!(
+        is_same_process(pid_from_file, handle.id().as_str()),
+        "PID {} should belong to boxlite-shim for box {}",
+        pid_from_file,
+        handle.id()
+    );
+
+    // Cleanup
+    handle.stop().await.unwrap();
+    ctx.runtime
+        .remove(handle.id().as_str(), false)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn pid_file_deleted_on_normal_stop() {
+    let ctx = TestContext::new();
+    let handle = ctx
+        .runtime
+        .create(
+            BoxOptions {
+                rootfs: RootfsSpec::Image("alpine:latest".into()),
+                auto_remove: false,
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    let _ = handle.exec(BoxCommand::new("sleep").args(["30"])).await;
+
+    let pid_file = ctx.pid_file_path(handle.id().as_str());
+    assert!(pid_file.exists(), "PID file should exist before stop");
+
+    handle.stop().await.unwrap();
+
+    assert!(!pid_file.exists(), "PID file should be deleted after stop");
+
+    // Cleanup
+    ctx.runtime
+        .remove(handle.id().as_str(), false)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn pid_matches_box_info() {
+    let ctx = TestContext::new();
+    let handle = ctx
+        .runtime
+        .create(
+            BoxOptions {
+                rootfs: RootfsSpec::Image("alpine:latest".into()),
+                auto_remove: false,
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    let _ = handle.exec(BoxCommand::new("sleep").args(["30"])).await;
+
+    let pid_file = ctx.pid_file_path(handle.id().as_str());
+    let pid_from_file = read_pid_file(&pid_file).expect("Should read PID file");
+
+    let info = ctx
+        .runtime
+        .get_info(handle.id().as_str())
+        .await
+        .unwrap()
+        .expect("Box should exist");
+
+    assert_eq!(
+        info.pid,
+        Some(pid_from_file),
+        "BoxInfo.pid should match PID file"
+    );
+
+    // Cleanup
+    handle.stop().await.unwrap();
+    ctx.runtime
+        .remove(handle.id().as_str(), false)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn pid_available_immediately_after_run() {
+    let ctx = TestContext::new();
+
+    // Create and start box
+    let handle = ctx
+        .runtime
+        .create(
+            BoxOptions {
+                rootfs: RootfsSpec::Image("alpine:latest".into()),
+                auto_remove: false,
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    let _ = handle.exec(BoxCommand::new("sleep").args(["30"])).await;
+
+    // IMMEDIATELY check - no delay (this is the race condition fix)
+    let info = ctx
+        .runtime
+        .get_info(handle.id().as_str())
+        .await
+        .unwrap()
+        .expect("Box should exist");
+
+    assert!(
+        info.pid.is_some(),
+        "PID should be available immediately after run"
+    );
+    assert_eq!(info.status, BoxStatus::Running, "Status should be Running");
+
+    // PID file should also exist immediately
+    let pid_file = ctx.pid_file_path(handle.id().as_str());
+    assert!(pid_file.exists(), "PID file should exist immediately");
+
+    // Cleanup
+    handle.stop().await.unwrap();
+    ctx.runtime
+        .remove(handle.id().as_str(), false)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn pid_file_path_is_correct() {
+    let ctx = TestContext::new();
+    let handle = ctx
+        .runtime
+        .create(
+            BoxOptions {
+                rootfs: RootfsSpec::Image("alpine:latest".into()),
+                auto_remove: false,
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    let _ = handle.exec(BoxCommand::new("true")).await;
+
+    // Expected path: {home}/boxes/{box_id}/shim.pid
+    let expected = ctx.pid_file_path(handle.id().as_str());
+    assert!(expected.exists(), "PID file should be at expected path");
+
+    // Verify no PID file in wrong locations
+    let wrong1 = ctx.home_dir.join("shim.pid");
+    let wrong2 = ctx.home_dir.join("boxes").join("shim.pid");
+    assert!(!wrong1.exists(), "No PID file at home root");
+    assert!(!wrong2.exists(), "No PID file at boxes root");
+
+    // Cleanup
+    handle.stop().await.unwrap();
+    ctx.runtime
+        .remove(handle.id().as_str(), false)
+        .await
+        .unwrap();
+}
+
+// ============================================================================
+// CATEGORY 2: DETACH MODE (P0 - Original Issue)
+// ============================================================================
+
+#[tokio::test]
+async fn detached_box_creates_pid_file() {
+    let ctx = TestContext::new();
+    let handle = ctx
+        .runtime
+        .create(
+            BoxOptions {
+                rootfs: RootfsSpec::Image("alpine:latest".into()),
+                detach: true,
+                auto_remove: false,
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    let _ = handle.exec(BoxCommand::new("sleep").args(["300"])).await;
+
+    let pid_file = ctx.pid_file_path(handle.id().as_str());
+    assert!(pid_file.exists(), "Detached box should have PID file");
+
+    // Cleanup
+    ctx.runtime
+        .remove(handle.id().as_str(), true)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn detached_box_survives_runtime_drop() {
+    let temp_dir = TempDir::new().unwrap();
+    let home_dir = temp_dir.path().to_path_buf();
+    let box_id: String;
+    let original_pid: u32;
+
+    // Create detached box
+    {
+        let runtime = BoxliteRuntime::new(BoxliteOptions {
+            home_dir: home_dir.clone(),
+            image_registries: vec![],
+        })
+        .unwrap();
+
+        let handle = runtime
+            .create(
+                BoxOptions {
+                    rootfs: RootfsSpec::Image("alpine:latest".into()),
+                    detach: true,
+                    auto_remove: false,
+                    ..Default::default()
+                },
+                None,
+            )
+            .await
+            .unwrap();
+
+        let _ = handle.exec(BoxCommand::new("sleep").args(["300"])).await;
+        box_id = handle.id().to_string();
+
+        let pid_file = home_dir.join("boxes").join(&box_id).join("shim.pid");
+        original_pid = read_pid_file(&pid_file).unwrap();
+
+        // Runtime drops here - box should survive
+    }
+
+    // Wait a moment
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    // Verify process still alive
+    assert!(
+        is_process_alive(original_pid),
+        "Detached box process {} should survive runtime drop",
+        original_pid
+    );
+
+    // Cleanup
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir,
+        image_registries: vec![],
+    })
+    .unwrap();
+    runtime.remove(&box_id, true).await.unwrap();
+}
+
+#[tokio::test]
+async fn detached_box_recoverable_after_restart() {
+    let temp_dir = TempDir::new().unwrap();
+    let home_dir = temp_dir.path().to_path_buf();
+    let box_id: String;
+
+    // Create and run detached box
+    {
+        let runtime = BoxliteRuntime::new(BoxliteOptions {
+            home_dir: home_dir.clone(),
+            image_registries: vec![],
+        })
+        .unwrap();
+
+        let handle = runtime
+            .create(
+                BoxOptions {
+                    rootfs: RootfsSpec::Image("alpine:latest".into()),
+                    detach: true,
+                    auto_remove: false,
+                    ..Default::default()
+                },
+                None,
+            )
+            .await
+            .unwrap();
+
+        let _ = handle.exec(BoxCommand::new("sleep").args(["300"])).await;
+        box_id = handle.id().to_string();
+    }
+
+    // Create NEW runtime - should recover the box
+    {
+        let runtime = BoxliteRuntime::new(BoxliteOptions {
+            home_dir,
+            image_registries: vec![],
+        })
+        .unwrap();
+
+        // Should recover the box
+        let info = runtime
+            .get_info(&box_id)
+            .await
+            .unwrap()
+            .expect("Box should be recovered");
+
+        assert_eq!(
+            info.status,
+            BoxStatus::Running,
+            "Box should be recovered as Running"
+        );
+        assert!(info.pid.is_some(), "Recovered box should have PID");
+
+        // Should be able to stop it
+        let handle = runtime.get(&box_id).await.unwrap().unwrap();
+        handle.stop().await.unwrap();
+
+        let info = runtime
+            .get_info(&box_id)
+            .await
+            .unwrap()
+            .expect("Box should exist");
+        assert_eq!(info.status, BoxStatus::Stopped);
+
+        // Cleanup
+        runtime.remove(&box_id, false).await.unwrap();
+    }
+}
+
+#[tokio::test]
+async fn multiple_detached_boxes_each_have_pid_file() {
+    let ctx = TestContext::new();
+    let mut box_ids = Vec::new();
+
+    // Create 3 detached boxes
+    for _ in 0..3 {
+        let handle = ctx
+            .runtime
+            .create(
+                BoxOptions {
+                    rootfs: RootfsSpec::Image("alpine:latest".into()),
+                    detach: true,
+                    auto_remove: false,
+                    ..Default::default()
+                },
+                None,
+            )
+            .await
+            .unwrap();
+
+        let _ = handle.exec(BoxCommand::new("sleep").args(["300"])).await;
+        box_ids.push(handle.id().to_string());
+    }
+
+    // Verify each has unique PID file with different PID
+    let mut pids = std::collections::HashSet::new();
+    for box_id in &box_ids {
+        let pid_file = ctx.pid_file_path(box_id);
+        assert!(pid_file.exists(), "Box {} should have PID file", box_id);
+        let pid = read_pid_file(&pid_file).unwrap();
+        assert!(
+            pids.insert(pid),
+            "Each box should have unique PID, but {} is duplicate",
+            pid
+        );
+    }
+
+    // Cleanup
+    for box_id in box_ids {
+        ctx.runtime.remove(&box_id, true).await.unwrap();
+    }
+}
+
+// ============================================================================
+// CATEGORY 3: RECOVERY SCENARIOS (P0)
+// ============================================================================
+
+#[tokio::test]
+async fn recovery_with_live_process() {
+    let temp_dir = TempDir::new().unwrap();
+    let home_dir = temp_dir.path().to_path_buf();
+    let box_id: String;
+    let original_pid: u32;
+
+    // Create box with detach=true
+    {
+        let runtime = BoxliteRuntime::new(BoxliteOptions {
+            home_dir: home_dir.clone(),
+            image_registries: vec![],
+        })
+        .unwrap();
+
+        let handle = runtime
+            .create(
+                BoxOptions {
+                    rootfs: RootfsSpec::Image("alpine:latest".into()),
+                    detach: true,
+                    auto_remove: false,
+                    ..Default::default()
+                },
+                None,
+            )
+            .await
+            .unwrap();
+
+        let _ = handle.exec(BoxCommand::new("sleep").args(["300"])).await;
+        box_id = handle.id().to_string();
+
+        let pid_file = home_dir.join("boxes").join(&box_id).join("shim.pid");
+        original_pid = read_pid_file(&pid_file).unwrap();
+    }
+
+    // New runtime should recover
+    {
+        let runtime = BoxliteRuntime::new(BoxliteOptions {
+            home_dir,
+            image_registries: vec![],
+        })
+        .unwrap();
+
+        let info = runtime
+            .get_info(&box_id)
+            .await
+            .unwrap()
+            .expect("Box should exist");
+
+        assert_eq!(info.status, BoxStatus::Running);
+        assert_eq!(info.pid, Some(original_pid), "PID should match original");
+
+        // Cleanup
+        runtime.remove(&box_id, true).await.unwrap();
+    }
+}
+
+#[tokio::test]
+async fn recovery_with_dead_process() {
+    let temp_dir = TempDir::new().unwrap();
+    let home_dir = temp_dir.path().to_path_buf();
+    let box_id: String;
+    let original_pid: u32;
+
+    // Create box
+    {
+        let runtime = BoxliteRuntime::new(BoxliteOptions {
+            home_dir: home_dir.clone(),
+            image_registries: vec![],
+        })
+        .unwrap();
+
+        let handle = runtime
+            .create(
+                BoxOptions {
+                    rootfs: RootfsSpec::Image("alpine:latest".into()),
+                    detach: true,
+                    auto_remove: false,
+                    ..Default::default()
+                },
+                None,
+            )
+            .await
+            .unwrap();
+
+        let _ = handle.exec(BoxCommand::new("sleep").args(["300"])).await;
+        box_id = handle.id().to_string();
+
+        let pid_file = home_dir.join("boxes").join(&box_id).join("shim.pid");
+        original_pid = read_pid_file(&pid_file).unwrap();
+
+        // Kill process directly (simulate crash)
+        unsafe {
+            libc::kill(original_pid as i32, libc::SIGKILL);
+        }
+
+        // Wait for process to die
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+
+    // New runtime should detect dead process
+    {
+        let runtime = BoxliteRuntime::new(BoxliteOptions {
+            home_dir: home_dir.clone(),
+            image_registries: vec![],
+        })
+        .unwrap();
+
+        let info = runtime
+            .get_info(&box_id)
+            .await
+            .unwrap()
+            .expect("Box should exist");
+
+        assert_eq!(
+            info.status,
+            BoxStatus::Stopped,
+            "Dead process should be marked Stopped"
+        );
+        assert!(info.pid.is_none(), "Stopped box should have no PID");
+
+        // PID file should be deleted
+        let pid_file = home_dir.join("boxes").join(&box_id).join("shim.pid");
+        assert!(
+            !pid_file.exists(),
+            "Stale PID file should be deleted during recovery"
+        );
+
+        // Cleanup
+        runtime.remove(&box_id, false).await.unwrap();
+    }
+}
+
+#[tokio::test]
+async fn recovery_with_missing_pid_file() {
+    let temp_dir = TempDir::new().unwrap();
+    let home_dir = temp_dir.path().to_path_buf();
+    let box_id: String;
+
+    // Create box and delete PID file
+    {
+        let runtime = BoxliteRuntime::new(BoxliteOptions {
+            home_dir: home_dir.clone(),
+            image_registries: vec![],
+        })
+        .unwrap();
+
+        let handle = runtime
+            .create(
+                BoxOptions {
+                    rootfs: RootfsSpec::Image("alpine:latest".into()),
+                    detach: true,
+                    auto_remove: false,
+                    ..Default::default()
+                },
+                None,
+            )
+            .await
+            .unwrap();
+
+        let _ = handle.exec(BoxCommand::new("sleep").args(["300"])).await;
+        box_id = handle.id().to_string();
+
+        // Manually delete PID file
+        let pid_file = home_dir.join("boxes").join(&box_id).join("shim.pid");
+        std::fs::remove_file(&pid_file).unwrap();
+    }
+
+    // New runtime should handle missing PID file gracefully
+    {
+        let runtime = BoxliteRuntime::new(BoxliteOptions {
+            home_dir,
+            image_registries: vec![],
+        })
+        .unwrap();
+
+        let info = runtime
+            .get_info(&box_id)
+            .await
+            .unwrap()
+            .expect("Box should exist");
+
+        assert_eq!(
+            info.status,
+            BoxStatus::Stopped,
+            "Missing PID file should result in Stopped status"
+        );
+
+        // Cleanup
+        runtime.remove(&box_id, true).await.unwrap();
+    }
+}
+
+#[tokio::test]
+async fn recovery_with_corrupted_pid_file() {
+    let temp_dir = TempDir::new().unwrap();
+    let home_dir = temp_dir.path().to_path_buf();
+    let box_id: String;
+
+    // Create box and corrupt PID file
+    {
+        let runtime = BoxliteRuntime::new(BoxliteOptions {
+            home_dir: home_dir.clone(),
+            image_registries: vec![],
+        })
+        .unwrap();
+
+        let handle = runtime
+            .create(
+                BoxOptions {
+                    rootfs: RootfsSpec::Image("alpine:latest".into()),
+                    detach: true,
+                    auto_remove: false,
+                    ..Default::default()
+                },
+                None,
+            )
+            .await
+            .unwrap();
+
+        let _ = handle.exec(BoxCommand::new("sleep").args(["300"])).await;
+        box_id = handle.id().to_string();
+
+        // Corrupt PID file
+        let pid_file = home_dir.join("boxes").join(&box_id).join("shim.pid");
+        std::fs::write(&pid_file, "not-a-valid-pid").unwrap();
+    }
+
+    // New runtime should handle corrupted PID file gracefully
+    {
+        let runtime = BoxliteRuntime::new(BoxliteOptions {
+            home_dir: home_dir.clone(),
+            image_registries: vec![],
+        })
+        .unwrap();
+
+        let info = runtime
+            .get_info(&box_id)
+            .await
+            .unwrap()
+            .expect("Box should exist");
+
+        assert_eq!(
+            info.status,
+            BoxStatus::Stopped,
+            "Corrupted PID file should result in Stopped status"
+        );
+
+        // Corrupted PID file should be deleted
+        let pid_file = home_dir.join("boxes").join(&box_id).join("shim.pid");
+        assert!(!pid_file.exists(), "Corrupted PID file should be deleted");
+
+        // Cleanup
+        runtime.remove(&box_id, true).await.unwrap();
+    }
+}
+
+#[tokio::test]
+async fn recovery_preserves_stopped_boxes() {
+    let temp_dir = TempDir::new().unwrap();
+    let home_dir = temp_dir.path().to_path_buf();
+    let box_id: String;
+
+    // Create and stop box normally
+    {
+        let runtime = BoxliteRuntime::new(BoxliteOptions {
+            home_dir: home_dir.clone(),
+            image_registries: vec![],
+        })
+        .unwrap();
+
+        let handle = runtime
+            .create(
+                BoxOptions {
+                    rootfs: RootfsSpec::Image("alpine:latest".into()),
+                    auto_remove: false,
+                    ..Default::default()
+                },
+                None,
+            )
+            .await
+            .unwrap();
+
+        let _ = handle.exec(BoxCommand::new("true")).await;
+        box_id = handle.id().to_string();
+
+        // Stop normally
+        handle.stop().await.unwrap();
+
+        // Verify PID file is gone
+        let pid_file = home_dir.join("boxes").join(&box_id).join("shim.pid");
+        assert!(!pid_file.exists());
+    }
+
+    // New runtime should see stopped box
+    {
+        let runtime = BoxliteRuntime::new(BoxliteOptions {
+            home_dir,
+            image_registries: vec![],
+        })
+        .unwrap();
+
+        let info = runtime
+            .get_info(&box_id)
+            .await
+            .unwrap()
+            .expect("Box should exist");
+
+        assert_eq!(info.status, BoxStatus::Stopped);
+        assert!(info.pid.is_none());
+
+        // Cleanup
+        runtime.remove(&box_id, false).await.unwrap();
+    }
+}
+
+// ============================================================================
+// CATEGORY 4: EDGE CASES (P1)
+// ============================================================================
+
+#[test]
+fn read_pid_file_with_whitespace() {
+    let temp = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(temp.path(), "  12345\n\n").unwrap();
+
+    let pid = read_pid_file(temp.path()).unwrap();
+    assert_eq!(pid, 12345);
+}
+
+#[test]
+fn read_pid_file_invalid_content_rejected() {
+    let temp = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(temp.path(), "not-a-pid").unwrap();
+
+    let result = read_pid_file(temp.path());
+    assert!(result.is_err());
+}
+
+#[test]
+fn read_pid_file_empty_rejected() {
+    let temp = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(temp.path(), "").unwrap();
+
+    let result = read_pid_file(temp.path());
+    assert!(result.is_err());
+}
+
+#[test]
+fn read_pid_file_missing_returns_error() {
+    let result = read_pid_file(std::path::Path::new("/nonexistent/shim.pid"));
+    assert!(result.is_err());
+}
+
+#[test]
+fn read_pid_file_large_pid() {
+    let temp = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(temp.path(), "4194304").unwrap(); // Max PID on Linux
+
+    let pid = read_pid_file(temp.path()).unwrap();
+    assert_eq!(pid, 4194304);
+}
+
+#[test]
+fn read_pid_file_negative_rejected() {
+    let temp = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(temp.path(), "-1").unwrap();
+
+    let result = read_pid_file(temp.path());
+    assert!(result.is_err());
+}
+
+#[test]
+fn read_pid_file_overflow_rejected() {
+    let temp = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(temp.path(), "99999999999").unwrap();
+
+    let result = read_pid_file(temp.path());
+    assert!(result.is_err());
+}
+
+// ============================================================================
+// CATEGORY 5: CLEANUP (P1)
+// ============================================================================
+
+#[tokio::test]
+async fn force_remove_deletes_pid_file() {
+    let ctx = TestContext::new();
+    let handle = ctx
+        .runtime
+        .create(
+            BoxOptions {
+                rootfs: RootfsSpec::Image("alpine:latest".into()),
+                auto_remove: false,
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    let _ = handle.exec(BoxCommand::new("sleep").args(["300"])).await;
+    let box_id = handle.id().to_string();
+
+    let pid_file = ctx.pid_file_path(&box_id);
+    assert!(pid_file.exists());
+
+    // Force remove while running
+    ctx.runtime.remove(&box_id, true).await.unwrap();
+
+    assert!(
+        !pid_file.exists(),
+        "PID file should be deleted on force remove"
+    );
+}
+
+#[tokio::test]
+async fn box_directory_cleanup_includes_pid_file() {
+    let ctx = TestContext::new();
+    let handle = ctx
+        .runtime
+        .create(
+            BoxOptions {
+                rootfs: RootfsSpec::Image("alpine:latest".into()),
+                auto_remove: false,
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    let box_id = handle.id().to_string();
+    let _ = handle.exec(BoxCommand::new("true")).await;
+    handle.stop().await.unwrap();
+
+    ctx.runtime.remove(&box_id, false).await.unwrap();
+
+    // Entire box directory should be gone
+    let box_dir = ctx.home_dir.join("boxes").join(&box_id);
+    assert!(!box_dir.exists(), "Box directory should be removed");
+}
+
+// ============================================================================
+// CATEGORY 7: PROCESS VALIDATION (P1)
+// ============================================================================
+
+#[tokio::test]
+async fn is_same_process_validates_boxlite_shim() {
+    let ctx = TestContext::new();
+    let handle = ctx
+        .runtime
+        .create(
+            BoxOptions {
+                rootfs: RootfsSpec::Image("alpine:latest".into()),
+                auto_remove: false,
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    let _ = handle.exec(BoxCommand::new("sleep").args(["30"])).await;
+
+    let pid_file = ctx.pid_file_path(handle.id().as_str());
+    let pid = read_pid_file(&pid_file).unwrap();
+
+    // Should be true for actual shim
+    assert!(
+        is_same_process(pid, handle.id().as_str()),
+        "is_same_process should return true for actual shim process"
+    );
+
+    // Should be false for current test process
+    assert!(
+        !is_same_process(std::process::id(), handle.id().as_str()),
+        "is_same_process should return false for non-shim process"
+    );
+
+    // Cleanup
+    handle.stop().await.unwrap();
+    ctx.runtime
+        .remove(handle.id().as_str(), false)
+        .await
+        .unwrap();
+}
+
+#[test]
+fn is_process_alive_true_for_current() {
+    assert!(
+        is_process_alive(std::process::id()),
+        "Current process should be alive"
+    );
+}
+
+#[test]
+fn is_process_alive_false_for_invalid() {
+    // Very high PIDs unlikely to exist
+    assert!(!is_process_alive(999999999));
+    assert!(!is_process_alive(888888888));
+}

--- a/examples/python/cross_process_example.py
+++ b/examples/python/cross_process_example.py
@@ -25,7 +25,8 @@ async def _subprocess_start_box():
     # Use Options() to create a droppable runtime
     runtime = boxlite.Boxlite(boxlite.Options())
 
-    box = await runtime.create(boxlite.BoxOptions(image="alpine:latest"))
+    box = await runtime.create(
+        boxlite.BoxOptions(image="alpine:latest", detach=True, auto_remove=False))
     box_id = box.id
 
     # Execute command to ensure it's fully initialized
@@ -45,7 +46,8 @@ async def _subprocess_start_and_stop_box():
     # Use Options() to create a droppable runtime
     runtime = boxlite.Boxlite(boxlite.Options())
 
-    box = await runtime.create(boxlite.BoxOptions(image="alpine:latest"))
+    box = await runtime.create(
+        boxlite.BoxOptions(image="alpine:latest", detach=True, auto_remove=False))
     box_id = box.id
 
     # Execute command to ensure it's fully initialized


### PR DESCRIPTION
## Summary
- Fix race condition where PID saved to database could be lost
- Write PID file in pre_exec (after fork, before exec) as single source of truth
- Database PID becomes a cache, rebuilt from file on recovery

Fixes #118

## Changes
- New `boxlite/src/jailer/common/pid.rs` - Async-signal-safe PID file writing
- New `boxlite/tests/pid_file.rs` - 27 comprehensive E2E tests
- Modified recovery in `rt_impl.rs` to use PID file
- Added `pid_file_path()` to layout

## Test plan
- [x] Unit tests pass (read_pid_file, is_process_alive, is_same_process)
- [x] Cargo check passes
- [ ] Integration tests (require VM setup)