### PR TITLE
Bump SDK versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,7 +279,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -335,7 +335,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-c"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "boxlite",
  "boxlite-shared",
@@ -367,7 +367,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-guest"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -394,7 +394,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-node"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "boxlite",
  "boxlite-shared",
@@ -408,7 +408,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-python"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "boxlite",
  "futures",
@@ -421,7 +421,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-shared"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "prost",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = ["build/tmp", "target", ".venv", "examples/*/.venv"]
 resolver = "2"
 
 [workspace.package]
-version = "0.5.2"
+version = "0.5.3"
 edition = "2024"
 authors = ["Dorian Zheng <https://github.com/dorianzheng>"]
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 - **Storage**: volume mounts (ro/rw), persistent disks (QCOW2), copy-on-write
 - **Networking**: outbound internet, port forwarding (TCP/UDP), network metrics
 - **Images**: OCI pull + caching, custom rootfs support
-- **SDKs**: Python (stable), Node.js (v0.1.5); Go coming soon
+- **SDKs**: Python (stable), Node.js (v0.1.6); Go coming soon
 
 ## Architecture
 

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -80,7 +80,7 @@ Unlike Docker, BoxLite doesn't require a daemon process. It's an embeddable libr
 | SDK | Status | Best For |
 |-----|--------|----------|
 | **[Python](./quickstart-python.md)** | Stable (v0.4.4) | AI agents, scripting, rapid prototyping |
-| **[Node.js](./quickstart-nodejs.md)** | v0.1.5 | Web services, TypeScript projects |
+| **[Node.js](./quickstart-nodejs.md)** | v0.1.6 | Web services, TypeScript projects |
 | **[Rust](./quickstart-rust.md)** | Native | Performance-critical, embedded systems |
 | Go | Coming soon | — |
 

--- a/docs/reference/nodejs/README.md
+++ b/docs/reference/nodejs/README.md
@@ -2,7 +2,7 @@
 
 Complete API reference for the BoxLite Node.js/TypeScript SDK.
 
-**Version:** 0.1.5
+**Version:** 0.1.6
 **Node.js:** 18+
 **Platforms:** macOS (Apple Silicon), Linux (x86_64, ARM64)
 

--- a/docs/reference/python/README.md
+++ b/docs/reference/python/README.md
@@ -2,7 +2,7 @@
 
 Complete API reference for the BoxLite Python SDK.
 
-**Version:** 0.5.2
+**Version:** 0.5.3
 **Python:** 3.10+
 **Platforms:** macOS (Apple Silicon), Linux (x86_64, ARM64)
 

--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boxlite-ai/boxlite",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "BoxLite - Embeddable micro-VM runtime for secure, isolated code execution",
   "type": "module",
   "main": "dist/index.js",
@@ -22,8 +22,8 @@
     "vitest": "^2.0.0"
   },
   "optionalDependencies": {
-    "@boxlite-ai/boxlite-darwin-arm64": "0.1.0",
-    "@boxlite-ai/boxlite-linux-x64-gnu": "0.1.0"
+    "@boxlite-ai/boxlite-darwin-arm64": "0.1.6",
+    "@boxlite-ai/boxlite-linux-x64-gnu": "0.1.6"
   },
   "keywords": [
     "boxlite",

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "boxlite"
-version = "0.5.2"
+version = "0.5.3"
 description = "Python bindings for Boxlite runtime"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- bump workspace SDK version to 0.5.3 (Rust/C)
- bump Python SDK version to 0.5.3 (package + docs)
- bump Node SDK version to 0.1.6 (package + optional deps + docs)

## Testing
- not run (not requested)
