### PR TITLE
feat(cli): add pull command

### DIFF
--- a/boxlite-cli/src/cli.rs
+++ b/boxlite-cli/src/cli.rs
@@ -66,6 +66,9 @@ pub enum Commands {
 
     /// Restart one or more boxes
     Restart(crate::commands::restart::RestartArgs),
+
+    /// Pull an image from a registry
+    Pull(crate::commands::pull::PullArgs),
 }
 
 // ============================================================================

--- a/boxlite-cli/src/commands/mod.rs
+++ b/boxlite-cli/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod create;
 pub mod list;
+pub mod pull;
 pub mod restart;
 pub mod rm;
 pub mod run;

--- a/boxlite-cli/src/commands/pull.rs
+++ b/boxlite-cli/src/commands/pull.rs
@@ -1,0 +1,29 @@
+use anyhow::Result;
+use clap::Args;
+
+use crate::cli::GlobalFlags;
+
+#[derive(Args, Debug)]
+pub struct PullArgs {
+    /// Image to pull
+    pub image: String,
+
+    /// Quiet mode - only show digest
+    #[arg(short, long)]
+    pub quiet: bool,
+}
+
+pub async fn execute(args: PullArgs, global: &GlobalFlags) -> Result<()> {
+    let runtime = global.create_runtime()?;
+
+    let image = runtime.pull_image(&args.image).await?;
+    if args.quiet {
+        println!("{}", image.config_digest());
+    } else {
+        println!("Pulled: {}", image.reference());
+        println!("Digest: {}", image.config_digest());
+        println!("Layers: {}", image.layer_count());
+    }
+
+    Ok(())
+}

--- a/boxlite-cli/src/main.rs
+++ b/boxlite-cli/src/main.rs
@@ -40,6 +40,7 @@ async fn main() {
         cli::Commands::Start(args) => commands::start::execute(args, &cli.global).await,
         cli::Commands::Stop(args) => commands::stop::execute(args, &cli.global).await,
         cli::Commands::Restart(args) => commands::restart::execute(args, &cli.global).await,
+        cli::Commands::Pull(args) => commands::pull::execute(args, &cli.global).await,
     };
 
     if let Err(error) = result {

--- a/boxlite-cli/tests/pull.rs
+++ b/boxlite-cli/tests/pull.rs
@@ -1,0 +1,75 @@
+use predicates::prelude::*;
+
+mod common;
+
+#[test]
+fn test_pull_basic() {
+    let mut ctx = common::boxlite();
+    ctx.cmd.args(["pull", "alpine:latest"]);
+    ctx.cmd.assert().success();
+}
+
+#[test]
+fn test_pull_without_tag() {
+    let mut ctx = common::boxlite();
+    ctx.cmd.args(["pull", "alpine"]);
+    ctx.cmd.assert().success();
+}
+
+#[test]
+fn test_pull_quiet() {
+    let mut ctx = common::boxlite();
+    ctx.cmd.args(["pull", "-q", "alpine:latest"]);
+    ctx.cmd
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty().not())
+        .stdout(predicate::function(|s: &str| s.lines().count() <= 2));
+}
+
+#[test]
+fn test_pull_nonexistent() {
+    let mut ctx = common::boxlite();
+    ctx.cmd.timeout(std::time::Duration::from_secs(30));
+    ctx.cmd.args(["pull", "nonexistent/image:doesnotexist"]);
+    ctx.cmd.assert().failure().stderr(
+        predicate::str::contains("failed to pull")
+            .or(predicate::str::contains("not found"))
+            .or(predicate::str::contains("manifest unknown"))
+            .or(predicate::str::contains("unauthorized")),
+    );
+}
+
+#[test]
+fn test_pull_idempotent() {
+    let mut ctx = common::boxlite();
+    ctx.cmd.args(["pull", "alpine:latest"]);
+    ctx.cmd.assert().success();
+
+    let mut cmd2 = ctx.new_cmd();
+    cmd2.args(["pull", "alpine:latest"]);
+    cmd2.assert().success();
+}
+
+#[test]
+fn test_pull_progress() {
+    let mut ctx = common::boxlite();
+    ctx.cmd.args(["pull", "python:alpine"]);
+    ctx.cmd.assert().success().stderr(
+        predicate::str::contains("Pulling")
+            .or(predicate::str::contains("Downloading"))
+            .or(predicate::str::contains("blob"))
+            .or(predicate::str::contains("Using cached image")),
+    );
+}
+
+#[test]
+fn test_pull_with_full_registry_name() {
+    let mut ctx = common::boxlite();
+    ctx.cmd.args(["pull", "docker.io/library/alpine:latest"]);
+    ctx.cmd.assert().success();
+
+    let mut cmd2 = ctx.new_cmd();
+    cmd2.args(["pull", "quay.io/libpod/alpine:latest"]);
+    cmd2.assert().success();
+}

--- a/boxlite/src/runtime/core.rs
+++ b/boxlite/src/runtime/core.rs
@@ -212,6 +212,28 @@ impl BoxliteRuntime {
     pub async fn remove(&self, id_or_name: &str, force: bool) -> BoxliteResult<()> {
         self.rt_impl.remove(id_or_name, force)
     }
+
+    // ========================================================================
+    // IMAGE OPERATIONS (delegate to ImageManager)
+    // ========================================================================
+
+    /// Pull an OCI image from a registry.
+    ///
+    /// Checks local cache first. If the image is already cached and complete,
+    /// returns immediately without network access. Otherwise pulls from registry.
+    ///
+    /// # Arguments
+    ///
+    /// * `image_ref` - Image reference (e.g., "alpine:latest", "docker.io/library/python:3.11")
+    ///
+    /// # Returns
+    ///
+    /// Returns an `ImageObject` that provides access to image metadata, layers,
+    /// and configuration.
+    ///
+    pub async fn pull_image(&self, image_ref: &str) -> BoxliteResult<crate::images::ImageObject> {
+        self.rt_impl.image_manager.pull(image_ref).await
+    }
 }
 
 // ============================================================================


### PR DESCRIPTION
## Info

- issue: https://github.com/boxlite-ai/boxlite/issues/35


## Changed

Add `boxlite pull` command to pull  images from registries.

- Support tag image(TODO:add digest-based support)
- Add --quiet flag for digest-only output
- Add tests for pull command




## Tests

- [x] make test passed
- [x] make test:cli  passed



## Output 

```
(base) goranka@shaynes-MacBook-Pro boxlite% ./target/debug/boxlite pull alpine:latest
2026-01-15T08:43:59.772248Z  INFO boxlite::litebox::manager: Detected system reboot, resetting active boxes to stopped
2026-01-15T08:43:59.773069Z  INFO boxlite::runtime::rt_impl: Recovering 0 boxes from database
2026-01-15T08:43:59.773079Z  INFO boxlite::runtime::rt_impl: Box recovery complete
2026-01-15T08:43:59.964144Z  INFO boxlite::images::store: Pulling image from registry: docker.io/library/alpine:latest
2026-01-15T08:44:02.569009Z  INFO boxlite::images::store: Pulling platform-specific manifest: sha256:410dabcd6f1d53f1f4e5c1ce9553efa298ca6bcdd086dfc976b8f659d58b46d2
Pulled: alpine:latest
Digest: sha256:e8f9ca9f1870bc194d961e259fd1340c641bf188e0d02e58b86b86445a4bc128
Layers: 1
```
