### PR TITLE
[WIP] feat(build): switch guest toolchain to gnu for Debian-based rootfs

### DIFF
--- a/scripts/util.sh
+++ b/scripts/util.sh
@@ -24,10 +24,10 @@ map_arch_to_target() {
 
     case "$arch" in
         arm64|aarch64)
-            echo "aarch64-unknown-linux-musl"
+            echo "aarch64-unknown-linux-gnu"
             ;;
         x86_64|amd64)
-            echo "x86_64-unknown-linux-musl"
+            echo "x86_64-unknown-linux-gnu"
             ;;
         *)
             echo "ERROR: Unsupported architecture: $arch" >&2


### PR DESCRIPTION
Change guest binary from musl to glibc to support Debian-based guest rootfs images. Debian uses glibc with ld-linux dynamic linker and does not include musl runtime.

- Change target triples from *-unknown-linux-musl to *-unknown-linux-gnu
- Guest binary now uses /lib64/ld-linux-x86-64.so.2 as interpreter
- Enables compatibility with Debian/Ubuntu guest rootfs environments

