### PR TITLE
feat(rootfs): Supports loading rootfs from local

### DIFF
--- a/boxlite/src/images/archive/tar.rs
+++ b/boxlite/src/images/archive/tar.rs
@@ -30,8 +30,46 @@ pub fn extract_layer_tarball_streaming(tarball_path: &Path, dest: &Path) -> Boxl
         ))
     })?;
 
-    let decoder = GzDecoder::new(BufReader::new(file));
-    apply_oci_layer(decoder, dest)
+    // Detect compression format by reading first 2 bytes
+    let mut header = [0u8; 2];
+    {
+        let file_ref = &file;
+        use std::io::Read;
+        file_ref
+            .take(2)
+            .read_exact(&mut header)
+            .map_err(|e| BoxliteError::Storage(format!("Failed to read layer header: {}", e)))?;
+    }
+
+    // Gzip magic number: 0x1f 0x8b
+    let reader: Box<dyn Read> = if header == [0x1f, 0x8b] {
+        // Gzip-compressed
+        debug!("Detected gzip compression for {}", tarball_path.display());
+        let file = fs::File::open(tarball_path).map_err(|e| {
+            BoxliteError::Storage(format!(
+                "Failed to reopen layer tarball {}: {}",
+                tarball_path.display(),
+                e
+            ))
+        })?;
+        Box::new(GzDecoder::new(BufReader::new(file)))
+    } else {
+        // Uncompressed
+        debug!(
+            "Detected uncompressed tarball for {}",
+            tarball_path.display()
+        );
+        let file = fs::File::open(tarball_path).map_err(|e| {
+            BoxliteError::Storage(format!(
+                "Failed to reopen layer tarball {}: {}",
+                tarball_path.display(),
+                e
+            ))
+        })?;
+        Box::new(BufReader::new(file))
+    };
+
+    apply_oci_layer(reader, dest)
 }
 
 /// Apply an OCI layer tar stream into `dest`, handling whiteouts inline.

--- a/boxlite/src/images/manager.rs
+++ b/boxlite/src/images/manager.rs
@@ -149,4 +149,36 @@ impl ImageManager {
 
         Ok(images)
     }
+
+    /// Load an OCI/Docker image from a local directory.
+    ///
+    /// Reads image manifest from `manifest.json` and returns an `ImageObject`.
+    /// Layers and configs are imported into the image store using hard links.
+    ///
+    /// Expected structure:
+    ///   ```text
+    ///   {path}/
+    ///     manifest.json     - Docker/OCI manifest with Config and Layers paths
+    ///     blobs/sha256/     - Content-addressed blobs
+    ///   ```
+    ///
+    /// # Arguments
+    /// * `path` - Path to local image directory
+    /// * `reference` - Image reference for display (e.g., "local/redis:latest")
+    ///
+    /// # Returns
+    /// `ImageObject` with access to layers and config
+    pub async fn load_from_local(
+        &self,
+        path: std::path::PathBuf,
+        reference: String,
+    ) -> BoxliteResult<ImageObject> {
+        let manifest = self.store.load_from_local(path).await?;
+
+        Ok(ImageObject::new(
+            reference,
+            manifest,
+            Arc::clone(&self.store),
+        ))
+    }
 }


### PR DESCRIPTION
Loading rootfs from local paths is currently not supported. Using a local rootfs will result in the error "Direct rootfs paths not yet supported".
This commit supports loading rootfs from local paths. Users can save Docker images using the following command.
```
docker save <image_name> -o <image_name>.tar
mkdir <image_name>
tar xvf <image_name>.tar -C <image_name>
```
Then pass the folder path to Boxlite.

fix: #37 