### PR TITLE
chore: bump SDK versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,7 +279,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -336,7 +336,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-c"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "boxlite",
  "boxlite-shared",
@@ -368,7 +368,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-guest"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -395,7 +395,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-node"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "boxlite",
  "boxlite-shared",
@@ -409,7 +409,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-python"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "boxlite",
  "futures",
@@ -422,7 +422,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-shared"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "prost",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = ["build/tmp", "target", ".venv", "examples/*/.venv"]
 resolver = "2"
 
 [workspace.package]
-version = "0.5.3"
+version = "0.5.4"
 edition = "2024"
 authors = ["Dorian Zheng <https://github.com/dorianzheng>"]
 license = "Apache-2.0"

--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boxlite-ai/boxlite",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "BoxLite - Embeddable micro-VM runtime for secure, isolated code execution",
   "type": "module",
   "main": "dist/index.js",
@@ -22,8 +22,8 @@
     "vitest": "^2.0.0"
   },
   "optionalDependencies": {
-    "@boxlite-ai/boxlite-darwin-arm64": "0.2.0",
-    "@boxlite-ai/boxlite-linux-x64-gnu": "0.2.0"
+    "@boxlite-ai/boxlite-darwin-arm64": "0.2.1",
+    "@boxlite-ai/boxlite-linux-x64-gnu": "0.2.1"
   },
   "keywords": [
     "boxlite",

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "boxlite"
-version = "0.5.3"
+version = "0.5.4"
 description = "Python bindings for Boxlite runtime"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Bump Rust/Python/C SDK version: 0.5.3 → 0.5.4
- Bump Node.js SDK version: 0.2.0 → 0.2.1

## Test plan
- [ ] CI passes