### PR TITLE
feat(core): add ImageInfo  model and expose list_images runtime API

### DIFF
--- a/boxlite/src/images/store.rs
+++ b/boxlite/src/images/store.rs
@@ -196,6 +196,14 @@ impl ImageStore {
         }
     }
 
+    /// List all cached images.
+    ///
+    /// Returns a vector of (reference, CachedImage) tuples ordered by cache time (Newest first).
+    pub async fn list(&self) -> BoxliteResult<Vec<(String, CachedImage)>> {
+        let inner = self.inner.read().await;
+        inner.index.list_all()
+    }
+
     /// Load config JSON for an image.
     ///
     /// Returns the raw JSON string. Use `serde_json::from_str()` to parse.

--- a/boxlite/src/runtime/core.rs
+++ b/boxlite/src/runtime/core.rs
@@ -234,6 +234,19 @@ impl BoxliteRuntime {
     pub async fn pull_image(&self, image_ref: &str) -> BoxliteResult<crate::images::ImageObject> {
         self.rt_impl.image_manager.pull(image_ref).await
     }
+
+    /// List all cached images.
+    ///
+    /// Returns a list of images available in the local content store.
+    /// The returned `ImageInfo` objects contain metadata suitable for listing (display),
+    /// such as reference, ID, creation time, and size.
+    ///
+    /// # Returns
+    ///
+    /// Returns a vector of `ImageInfo` structs containing metadata for all cached images.
+    pub async fn list_images(&self) -> BoxliteResult<Vec<crate::runtime::types::ImageInfo>> {
+        self.rt_impl.image_manager.list().await
+    }
 }
 
 // ============================================================================

--- a/boxlite/src/runtime/types.rs
+++ b/boxlite/src/runtime/types.rs
@@ -487,6 +487,35 @@ impl BoxStateInfo {
 }
 
 // ============================================================================
+// IMAGE INFO
+// ============================================================================
+
+/// Public metadata about a cached image.
+///
+/// Designed to provide all necessary information  without exposing internal storage details
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ImageInfo {
+    /// Full image reference (e.g., "docker.io/library/alpine:latest")
+    pub reference: String,
+
+    /// Parsed repository name (e.g. "docker.io/library/alpine")
+    pub repository: String,
+
+    /// Parsed image tag (e.g. "latest")
+    pub tag: String,
+
+    /// Image ID (Manifest Digest)
+    pub id: String,
+
+    /// When this image was pulled/cached locally.
+    /// Note: This is NOT the image build time (which requires reading config blob).
+    pub cached_at: DateTime<Utc>,
+
+    /// Image size in bytes (if available)
+    pub size: Option<Bytes>,
+}
+
+// ============================================================================
 // BOX CONFIG (Podman-style separation)
 // ============================================================================
 


### PR DESCRIPTION
## Info

https://github.com/boxlite-ai/boxlite/issues/35

This is the first part of the `boxlite images` command implementation, providing the necessary data structures and database queries.

## Key Changes
- Data Model: Added  `ImageInfo` to provide a view of image metadata (ID, Repository, Tag, Created Time, etc.).  Docker and podman have something like 'ImageSummary'.
- Runtime API: Exposed BoxliteRuntime::list_images() 
- Image Manager: Implemented ImageManager::list() 
- Database Layer: Added `ImageIndexStore::list_all() ` to perform ordered queries.
- Unit test for `ImageIndexStore::list_all() 


## Testing
- [x] make test:rust: test result: ok. 209 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.46s

**Agree on core library changes first**, then I'll submit a stacked PR to implement `images` command.