### PR TITLE
fix: update npm package name for boxlite

### DIFF
--- a/examples/node/README.md
+++ b/examples/node/README.md
@@ -8,7 +8,7 @@ If you installed BoxLite via npm:
 
 ```bash
 # Install BoxLite
-npm install boxlite
+npm install @boxlite-ai/boxlite
 
 # Run examples directly
 node simplebox.js


### PR DESCRIPTION
I following the readme under the examples folder. the npm package is not botlite now.

https://www.npmjs.com/package/@boxlite-ai/boxlite