### PR TITLE
fix(ci): resolve Node.js SDK workflow issues

### DIFF
--- a/.github/workflows/build-node.yml
+++ b/.github/workflows/build-node.yml
@@ -99,6 +99,10 @@ jobs:
             export SKIP_GUEST_BUILD=1
             make setup runtime
 
+            # Add cargo to PATH for npm commands (matches Makefile pattern)
+            # (make installs cargo to ~/.cargo/bin but npm subprocesses don't inherit PATH)
+            export PATH="$HOME/.cargo/bin:$PATH"
+
             # Build Node.js artifacts (no pack - CI uploads raw artifacts)
             cd sdks/node
             npm install --silent
@@ -199,9 +203,40 @@ jobs:
       - name: Build TypeScript
         run: cd sdks/node && npm run build
 
+      # npm Trusted Publishing (OIDC) - no NPM_TOKEN needed
+      # Requires Trusted Publisher configured on npmjs.com for this repo
       - name: Publish (napi prepublish handles optionalDependencies)
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           cd sdks/node
           npm publish --provenance --access public
+
+  upload-to-release:
+    name: Upload to GitHub Release
+    needs: [ config, build, test ]
+    if: github.event_name == 'release' && github.event.action == 'published'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          pattern: artifacts-*
+          merge-multiple: true
+
+      - name: Create tarballs for release
+        run: |
+          cd artifacts
+          for dir in npm/*/; do
+            name=$(basename "$dir")
+            tar -czf "${name}.tar.gz" -C npm "$name"
+          done
+          ls -la *.tar.gz
+
+      - name: Upload to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: artifacts/*.tar.gz
+          fail_on_unmatched_files: true

--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -32,8 +32,7 @@
     "prepublishOnly": "napi prepublish -p npm",
     "pack:all": "mkdir -p packages && npm pack --pack-destination packages && npm pack --workspaces --pack-destination packages",
     "test": "vitest run",
-    "test:watch": "vitest",
-    "version": "napi version --npm-dir ./npm"
+    "test:watch": "vitest"
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.0.0-alpha.62",


### PR DESCRIPTION
## Summary

- **Cargo PATH fix**: Add cargo to PATH in manylinux container to fix `cargo ENOENT` error during `npm run build:native`
- **OIDC Trusted Publishing**: Switch from `NPM_TOKEN` secret to npm's OIDC authentication for more secure, short-lived tokens with provenance attestation
- **Upload to release**: Restore job that creates `.tar.gz` packages and attaches them to GitHub releases
- **Remove dead code**: Delete unused `version` script from package.json

## Test plan

- [ ] Trigger `workflow_dispatch` manually to verify Linux build passes (cargo PATH fix)
- [ ] Configure Trusted Publisher on npmjs.com for `@boxlite-ai/boxlite`:
  - Repository: `boxlite-ai/boxlite`
  - Workflow: `build-node.yml`
- [ ] Create test release to verify:
  - npm publish succeeds with OIDC
  - GitHub release has `.tar.gz` attachments