### PR TITLE
fix(node): use prepack script and fix CI test artifacts

### DIFF
--- a/.github/workflows/build-node.yml
+++ b/.github/workflows/build-node.yml
@@ -127,7 +127,7 @@ jobs:
         with:
           name: artifacts-${{ matrix.target }}
           path: |
-            sdks/node/native/*.node
+            sdks/node/native/boxlite.js
             sdks/node/npm/
           if-no-files-found: error
           retention-days: ${{ needs.config.outputs.artifact-retention-days }}

--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -29,7 +29,7 @@
     "build:native": "mkdir -p native && napi build --platform --js boxlite.js --esm --output-dir native",
     "artifacts": "napi create-npm-dirs --npm-dir npm && napi artifacts --output-dir native --npm-dir npm && node -e \"const{readdirSync,rmSync}=require('fs');readdirSync('npm').forEach(p=>{if(!readdirSync('npm/'+p).some(f=>f.endsWith('.node')))rmSync('npm/'+p,{recursive:true})})\"",
     "bundle:runtime": "node -e \"const{cpSync,readdirSync,readFileSync,writeFileSync}=require('fs');readdirSync('npm').forEach(p=>{cpSync('../../target/boxlite-runtime','npm/'+p+'/runtime',{recursive:true});const f='npm/'+p+'/package.json',pkg=JSON.parse(readFileSync(f));pkg.files.includes('runtime')||pkg.files.push('runtime');writeFileSync(f,JSON.stringify(pkg,null,2)+'\\n')})\"",
-    "prepublishOnly": "napi prepublish -p npm",
+    "prepack": "napi prepublish -p npm --skip-optional-publish",
     "pack:all": "mkdir -p packages && npm pack --pack-destination packages && npm pack --workspaces --pack-destination packages",
     "test": "vitest run",
     "test:watch": "vitest"


### PR DESCRIPTION
## Summary

- **prepack script**: Replace `prepublishOnly` with `prepack` so that `napi prepublish` runs for both `npm pack` (local `make dist:node`) and `npm publish` (CI). Uses `--skip-optional-publish` to avoid registry verification for unpublished versions.

- **Fix CI test artifacts**: Upload `native/boxlite.js` (the JS loader) which was missing. Remove duplicate `native/*.node` files since `npm/*/` already contains them and npm workspaces links them to `node_modules/@boxlite-ai/`.

## Changes

| File | Change |
|------|--------|
| `sdks/node/package.json` | `prepublishOnly` → `prepack` with `--skip-optional-publish` |
| `.github/workflows/build-node.yml` | Upload `native/boxlite.js` instead of `native/*.node` |

## Test plan

- [ ] CI test job passes (verifies `boxlite.js` loader works with npm workspace fallback)
- [ ] Run `make dist:node` locally and verify packed main package has `optionalDependencies`