### PR TITLE
feat(dev): auto-link Node.js SDK to examples in make dev:node

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,6 +162,9 @@ dev\:c: runtime
 dev\:node: runtime-debug
 	@cd sdks/node && npm install --silent && npm run build:native && npm run build
 	@ln -sfn ../../../target/boxlite-runtime sdks/node/native/runtime
+	@echo "📦 Linking SDK to examples..."
+	@cd examples/node && npm install --silent
+	@echo "✅ Node.js SDK built and linked to examples"
 
 # Run all unit tests (excludes integration tests that require VMs)
 test:

--- a/examples/node/package.json
+++ b/examples/node/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "description": "Example scripts for BoxLite Node.js SDK",
   "type": "module",
+  "dependencies": {
+    "@boxlite-ai/boxlite": "file:../../sdks/node"
+  },
   "scripts": {
     "simplebox": "node simplebox.js",
     "codebox": "node codebox.js",


### PR DESCRIPTION
## Summary

- Add file-based dependency in `examples/node/package.json` pointing to the SDK (`file:../../sdks/node`)
- Update `make dev:node` to run `npm install` for examples after building the SDK

This eliminates the need for manual `npm link` commands during development. After running `make dev:node`, examples can be run directly without additional setup.

## Test plan

- [ ] Run `rm -rf examples/node/node_modules` to start clean
- [ ] Run `make dev:node`
- [ ] Verify `examples/node/node_modules/@boxlite-ai/boxlite` is symlinked to `sdks/node`
- [ ] Run an example: `cd examples/node && node shutdown.js`