### PR TITLE
fix(node): add --tag-style npm to prepack script

### DIFF
--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -29,7 +29,7 @@
     "build:native": "mkdir -p native && napi build --platform --js boxlite.js --esm --output-dir native",
     "artifacts": "napi create-npm-dirs --npm-dir npm && napi artifacts --output-dir native --npm-dir npm && node -e \"const{readdirSync,rmSync}=require('fs');readdirSync('npm').forEach(p=>{if(!readdirSync('npm/'+p).some(f=>f.endsWith('.node')))rmSync('npm/'+p,{recursive:true})})\"",
     "bundle:runtime": "node -e \"const{cpSync,readdirSync,readFileSync,writeFileSync}=require('fs');readdirSync('npm').forEach(p=>{cpSync('../../target/boxlite-runtime','npm/'+p+'/runtime',{recursive:true});const f='npm/'+p+'/package.json',pkg=JSON.parse(readFileSync(f));pkg.files.includes('runtime')||pkg.files.push('runtime');writeFileSync(f,JSON.stringify(pkg,null,2)+'\\n')})\"",
-    "prepack": "napi prepublish -p npm --skip-optional-publish",
+    "prepack": "napi prepublish -p npm --skip-optional-publish --tag-style npm",
     "pack:all": "mkdir -p packages && npm pack --pack-destination packages && npm pack --workspaces --pack-destination packages",
     "test": "vitest run",
     "test:watch": "vitest"


### PR DESCRIPTION
## Summary

Fixes `napi prepublish` failure during npm publish:
```
Type Error: No release commit found with @boxlite-ai/boxlite
```

## Root Cause

`napi prepublish` defaults to `--tag-style lerna`, which expects commit messages in lerna changelog format:
```
chore(release): publish
- @boxlite-ai/boxlite@0.2.2
- @boxlite-ai/boxlite-darwin-arm64@0.2.2
```

Our commits don't follow this format, causing the failure.

## The Fix

Add `--tag-style npm` to the prepack script. With this option, napi uses `v${version}` (e.g., `v0.2.2`) from package.json directly, which matches our release tag format.

**Before:**
```json
"prepack": "napi prepublish -p npm --skip-optional-publish"
```

**After:**
```json
"prepack": "napi prepublish -p npm --skip-optional-publish --tag-style npm"
```

## Why `--skip-optional-publish` is Still Needed

Platform packages (`@boxlite-ai/boxlite-darwin-arm64`, etc.) are published separately via `npm publish --workspaces` in CI. Without this flag, `napi prepublish` would try to re-publish them.

## Test Plan

- [ ] CI checks pass
- [ ] Will be validated on next release when publish workflow runs