### PR TITLE
fix(node): preserve execute permissions on runtime binaries

### DIFF
--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -28,7 +28,7 @@
     "build": "tsc",
     "build:native": "mkdir -p native && napi build --platform --js boxlite.js --esm --output-dir native",
     "artifacts": "napi create-npm-dirs --npm-dir npm && napi artifacts --output-dir native --npm-dir npm && node -e \"const{readdirSync,rmSync}=require('fs');readdirSync('npm').forEach(p=>{if(!readdirSync('npm/'+p).some(f=>f.endsWith('.node')))rmSync('npm/'+p,{recursive:true})})\"",
-    "bundle:runtime": "node -e \"const{cpSync,readdirSync,readFileSync,writeFileSync}=require('fs');readdirSync('npm').forEach(p=>{cpSync('../../target/boxlite-runtime','npm/'+p+'/runtime',{recursive:true});const f='npm/'+p+'/package.json',pkg=JSON.parse(readFileSync(f));pkg.files.includes('runtime')||pkg.files.push('runtime');writeFileSync(f,JSON.stringify(pkg,null,2)+'\\n')})\"",
+    "bundle:runtime": "node -e \"const{cpSync,chmodSync,readdirSync,readFileSync,writeFileSync}=require('fs');const{join}=require('path');readdirSync('npm').forEach(p=>{const rd='npm/'+p+'/runtime';cpSync('../../target/boxlite-runtime',rd,{recursive:true});readdirSync(rd).filter(f=>!f.endsWith('.dylib')).forEach(f=>chmodSync(join(rd,f),0o755));const pf='npm/'+p+'/package.json',pkg=JSON.parse(readFileSync(pf));pkg.files.includes('runtime')||pkg.files.push('runtime');writeFileSync(pf,JSON.stringify(pkg,null,2)+'\\n')})\"",
     "prepack": "napi prepublish -p npm --skip-optional-publish --tag-style npm",
     "pack:all": "mkdir -p packages && npm pack --pack-destination packages && npm pack --workspaces --pack-destination packages",
     "test": "vitest run",


### PR DESCRIPTION
## Summary

Fixes "Permission denied" error when running BoxLite installed from npm:
```
Failed to run mke2fs (/path/to/node_modules/@boxlite-ai/boxlite-darwin-arm64/runtime/mke2fs): Permission denied (os error 13)
```

## Root Cause

Node.js `cpSync` doesn't preserve file permissions. When `bundle:runtime` copies runtime binaries, they lose their execute bit:

**Before bundling (source):**
```
-rwxr-xr-x  boxlite-shim
-rwxr-xr-x  mke2fs
```

**After npm install:**
```
-rw-r--r--  boxlite-shim
-rw-r--r--  mke2fs
```

## The Fix

After copying with `cpSync`, explicitly set execute permissions (0o755) on all non-dylib files:

```javascript
readdirSync(rd).filter(f=>!f.endsWith('.dylib')).forEach(f=>chmodSync(join(rd,f),0o755))
```

## Test Plan

- [ ] CI checks pass
- [ ] After next release, verify runtime binaries have correct permissions when installed from npm