### PR TITLE
chore: bump SDK versions (0.5.7, node 0.2.4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,7 +279,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -338,7 +338,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-c"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "boxlite",
  "boxlite-shared",
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-guest"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -397,7 +397,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-node"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "boxlite",
  "boxlite-shared",
@@ -411,7 +411,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-python"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "boxlite",
  "futures",
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-shared"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "prost",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = ["build/tmp", "target", ".venv", "examples/*/.venv"]
 resolver = "2"
 
 [workspace.package]
-version = "0.5.6"
+version = "0.5.7"
 edition = "2024"
 authors = ["Dorian Zheng <https://github.com/dorianzheng>"]
 license = "Apache-2.0"

--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boxlite-ai/boxlite",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "BoxLite - Embeddable micro-VM runtime for secure, isolated code execution",
   "type": "module",
   "main": "dist/index.js",

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "boxlite"
-version = "0.5.6"
+version = "0.5.7"
 description = "Python bindings for Boxlite runtime"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Bump Rust/Python/C SDK version: 0.5.6 → 0.5.7
- Bump Node.js SDK version: 0.2.3 → 0.2.4

## Test plan
- [ ] CI passes