### PR TITLE
fix(ci): correct tar output path for artifact upload

### DIFF
--- a/.github/workflows/build-node.yml
+++ b/.github/workflows/build-node.yml
@@ -142,7 +142,7 @@ jobs:
       # GitHub Actions upload-artifact uses ZIP which doesn't preserve permissions.
       # See: https://github.com/actions/upload-artifact/issues/38
       - name: Create artifact tarball
-        run: tar -cvf artifacts.tar -C sdks/node native/boxlite.js npm/
+        run: tar -cvf sdks/node/artifacts.tar -C sdks/node native/boxlite.js npm/
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

- Fix tar output path in Node.js CI workflow
- The `tar -C` flag only changes directory for source files, not for the output file
- Upload step expects `sdks/node/artifacts.tar` but tar was creating `artifacts.tar` in repo root

**Error from CI:**
```
Error: No files were found with the provided path: sdks/node/artifacts.tar
```

## Test plan

- [ ] CI workflow passes (build job uploads artifact successfully)