### PR TITLE
fix(ci): use unique tarball names per platform to prevent overwrite

### DIFF
--- a/.github/workflows/build-node.yml
+++ b/.github/workflows/build-node.yml
@@ -142,13 +142,13 @@ jobs:
       # GitHub Actions upload-artifact uses ZIP which doesn't preserve permissions.
       # See: https://github.com/actions/upload-artifact/issues/38
       - name: Create artifact tarball
-        run: tar -cvf sdks/node/artifacts.tar -C sdks/node native/boxlite.js npm/
+        run: tar -cvf sdks/node/artifacts-${{ matrix.target }}.tar -C sdks/node native/boxlite.js npm/
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: artifacts-${{ matrix.target }}
-          path: sdks/node/artifacts.tar
+          path: sdks/node/artifacts-${{ matrix.target }}.tar
           if-no-files-found: error
           retention-days: ${{ needs.config.outputs.artifact-retention-days }}
 
@@ -195,7 +195,7 @@ jobs:
 
       # Extract tar to restore file permissions (see build job comment)
       - name: Extract artifacts
-        run: tar -xvf sdks/node/artifacts.tar -C sdks/node
+        run: tar -xvf sdks/node/artifacts-${{ matrix.platform.target }}.tar -C sdks/node
 
       - name: Test package
         run: |


### PR DESCRIPTION
## Summary

- Fix tarball naming collision in Node.js CI workflow
- Each platform was creating `artifacts.tar`, but `merge-multiple: true` combines them into one directory
- One tarball was overwriting the other, causing corrupt/incomplete extraction

**Error from CI:**
```
tar: Skipping to next header
tar: Exiting with failure status due to previous errors
```

**Fix:** Use `artifacts-<target>.tar` (e.g., `artifacts-darwin-arm64.tar`, `artifacts-linux-x64-gnu.tar`)

## Test plan

- [ ] CI workflow passes (both platforms extract successfully)
- [ ] Publish job extracts all platform artifacts