### PR TITLE
docs(jailer): add jailer architecture to README and documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,7 @@ scripts/              # Build and setup scripts
 - `runtime/` - BoxliteRuntime, main entry point
 - `litebox/` - LiteBox handle, command execution
 - `vmm/` - VM manager (libkrun, shim controller)
+- `jailer/` - Security isolation (seccomp, sandbox-exec, namespaces)
 - `portal/` - Host-guest gRPC communication
 - `images/` - OCI image management
 - `net/`, `volumes/`, `disk/` - Networking, storage, disks
@@ -138,6 +139,7 @@ make dist:python    # Build portable Python wheel
 
 **Architecture quirks:**
 - **Shim process**: boxlite-shim isolates boxes (libkrun does process takeover)
+- **Jailer**: OS-level sandbox (seccomp/sandbox-exec) wraps shim for defense-in-depth
 - **gRPC communication**: Host-guest communication via vsock (not TCP)
 - **~/.boxlite directory**: All runtime data stored here (images, boxes, db)
 


### PR DESCRIPTION
## Summary

Updates documentation to reflect the jailer security component that was recently migrated to build-time seccomp architecture (PR #165).

## Changes

### README.md
- Updated architecture diagram to show jailer boundary around VM/shim processes
- Added security features to the feature list (hardware isolation, OS sandboxing, resource limits)
- Added security layers explanation below the diagram

### docs/architecture/README.md
- Updated main architecture diagram to show jailer boundary with detailed annotations
- Added comprehensive "Jailer (Security Isolation)" section covering:
  - Key responsibilities
  - Security layers (Linux: seccomp/namespaces/chroot/cgroups vs macOS: sandbox-exec/rlimits)
  - Architecture diagram showing trust zones
  - Configuration examples
  - Reference to threat model documentation (THREAT_MODEL.md)

### CLAUDE.md
- Added `jailer/` to the key modules list
- Added jailer to the "Architecture quirks" section

## Context

The jailer implements defense-in-depth security inspired by Firecracker, providing OS-level process isolation for the shim process. This documentation update ensures the architecture docs accurately reflect this critical security component.

## Documentation Structure

```
README.md
  └─ High-level security features mention
     └─ docs/architecture/README.md
        └─ Detailed jailer architecture and configuration
           └─ boxlite/src/jailer/THREAT_MODEL.md
              └─ Complete security design and threat model
```