### PR TITLE
docs: add Rust style guide with Microsoft guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,12 +91,17 @@ make dist:python    # Build portable Python wheel
 
 ## Code Style
 
-**Rust:**
-- `cargo fmt` for formatting (enforced in CI)
-- `cargo clippy` for linting
+**Rust:** Follow [docs/development/rust-style.md](./docs/development/rust-style.md) which includes:
+- [Microsoft Rust Guidelines](https://microsoft.github.io/rust-guidelines) - external reference
+- `cargo fmt` for formatting, `cargo clippy` for linting (enforced in CI)
 - Async-first (Tokio runtime)
 - Error handling via centralized `BoxliteError` enum
 - `Send + Sync` for public types
+
+Key guidelines to internalize:
+- **M-PANIC-IS-STOP**: Panics terminate, don't use for error handling
+- **M-CONCISE-NAMES**: Avoid "Service", "Manager", "Factory" in type names
+- **M-UNSAFE**: Minimize and document all unsafe blocks
 
 **Python:**
 - Async/await for all I/O
@@ -104,7 +109,7 @@ make dist:python    # Build portable Python wheel
 - Type hints encouraged
 
 **For complete code style guidelines, see:**
-- [CONTRIBUTING.md](./CONTRIBUTING.md#code-style) - Detailed style guidelines
+- [docs/development/rust-style.md](./docs/development/rust-style.md) - Rust style guide with Microsoft guidelines
 - [boxlite-shared/src/errors.rs](./boxlite-shared/src/errors.rs) - Error handling patterns
 
 ## Workflows

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,13 @@ cargo test
 
 ### Code Style
 
-- Follow Rust standard formatting (`cargo fmt`)
+Follow the [Rust Style Guide](./docs/development/rust-style.md) which includes:
+- [Microsoft Rust Guidelines](https://microsoft.github.io/rust-guidelines)
+- BoxLite-specific patterns (async-first, centralized errors, thread-safe types)
+
+**Quick reference:**
+- `cargo fmt` for formatting (enforced in CI)
+- `cargo clippy` for linting
 - Keep functions focused (single responsibility)
 - Add tests for new functionality
 - Update documentation as needed

--- a/docs/development/rust-style.md
+++ b/docs/development/rust-style.md
@@ -1,0 +1,108 @@
+# Rust Style Guide
+
+This guide extends the [Microsoft Rust Guidelines](https://microsoft.github.io/rust-guidelines) with BoxLite-specific patterns.
+
+## External References
+
+- **Microsoft Rust Guidelines**: https://microsoft.github.io/rust-guidelines
+- **Rust API Guidelines**: https://rust-lang.github.io/api-guidelines/
+
+## Universal Guidelines (Must Follow)
+
+These guidelines from the Microsoft Rust Guidelines are particularly important for BoxLite:
+
+| Guideline | Summary |
+|-----------|---------|
+| **M-PANIC-IS-STOP** | Panics terminate the program - they are not exceptions |
+| **M-PANIC-ON-BUG** | Panic only on programming errors, never for expected failures |
+| **M-CONCISE-NAMES** | Avoid weasel words: "Service", "Manager", "Factory", "Handler" |
+| **M-LOG-STRUCTURED** | Use structured logging with meaningful fields |
+| **M-DOCUMENTED-MAGIC** | Document all magic numbers and constants |
+| **M-PUBLIC-DEBUG** | All public types must implement `Debug` |
+| **M-PUBLIC-DISPLAY** | User-facing types should implement `Display` |
+| **M-LINT-OVERRIDE-EXPECT** | Use `#[expect]` over `#[allow]` for lint overrides |
+| **M-REGULAR-FN** | Prefer regular functions over methods when `self` isn't needed |
+| **M-SMALLER-CRATES** | Keep crates focused on a single responsibility |
+
+## Safety Guidelines
+
+| Guideline | Summary |
+|-----------|---------|
+| **M-UNSAFE** | Minimize unsafe code; isolate it in small, well-documented functions |
+| **M-UNSAFE-IMPLIES-UB** | Document all undefined behavior conditions in unsafe code |
+| **M-UNSOUND** | Never expose unsound APIs; soundness must be guaranteed |
+
+## BoxLite-Specific Patterns
+
+### Async-First Architecture
+
+All I/O operations use async/await with Tokio runtime:
+
+```rust
+// ✅ Correct: async I/O
+async fn read_config(path: &Path) -> Result<Config> {
+    let contents = tokio::fs::read_to_string(path).await?;
+    Ok(toml::from_str(&contents)?)
+}
+
+// ❌ Wrong: blocking I/O in async context
+async fn read_config(path: &Path) -> Result<Config> {
+    let contents = std::fs::read_to_string(path)?;  // Blocks!
+    Ok(toml::from_str(&contents)?)
+}
+```
+
+### Centralized Error Handling
+
+Use the `BoxliteError` enum for all errors (see `boxlite-shared/src/errors.rs`):
+
+```rust
+// ✅ Correct: use BoxliteError with context
+std::fs::create_dir_all(&socket_dir).map_err(|e| {
+    BoxliteError::Storage(format!(
+        "Failed to create socket directory {}: {}", socket_dir.display(), e
+    ))
+})?;
+
+// ❌ Wrong: generic error without context
+std::fs::create_dir_all(&dir)?;
+```
+
+### Public Types Must Be `Send + Sync`
+
+All public types exposed through the API must be thread-safe:
+
+```rust
+// ✅ Correct: Arc for shared ownership across threads
+pub struct LiteBox {
+    inner: Arc<LiteBoxInner>,
+}
+
+// ❌ Wrong: Rc is not Send
+pub struct LiteBox {
+    inner: Rc<LiteBoxInner>,  // Not thread-safe!
+}
+```
+
+## Formatting and Linting
+
+- **Formatting**: `cargo fmt` (enforced in CI)
+- **Linting**: `cargo clippy` (warnings are errors in CI)
+
+Run before committing:
+
+```bash
+cargo fmt
+cargo clippy --all-targets --all-features
+```
+
+## Quick Reference
+
+When writing Rust code for BoxLite, ask yourself:
+
+1. **Is this panic necessary?** (M-PANIC-ON-BUG) - Only panic on bugs, use `Result` for errors
+2. **Is this name clear?** (M-CONCISE-NAMES) - Avoid "Manager", "Service", "Factory"
+3. **Is this unsafe minimized?** (M-UNSAFE) - Isolate and document unsafe code
+4. **Does this implement Debug?** (M-PUBLIC-DEBUG) - All public types need it
+5. **Is this async?** - All I/O should be async with Tokio
+6. **Is the error contextual?** - Use `BoxliteError` with descriptive messages


### PR DESCRIPTION
## Summary
- Create `docs/development/rust-style.md` as single source of truth for Rust code style
- Integrate [Microsoft Rust Guidelines](https://microsoft.github.io/rust-guidelines) with BoxLite-specific patterns
- Update CLAUDE.md and CONTRIBUTING.md to reference the new guide (DRY principle)

## Key additions
- Microsoft guidelines reference (M-PANIC-IS-STOP, M-CONCISE-NAMES, M-UNSAFE, etc.)
- BoxLite patterns documentation (async-first, BoxliteError, Send+Sync)
- Quick reference checklist for code review

## Test plan
- [ ] Verify `docs/development/rust-style.md` renders correctly on GitHub
- [ ] Verify links in CLAUDE.md and CONTRIBUTING.md work
- [ ] Verify external link to Microsoft Rust Guidelines works