### PR TITLE
chore: bump SDK and CLI versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,7 +299,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -360,7 +360,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-c"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "boxlite",
  "boxlite-shared",
@@ -372,7 +372,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-cli"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -396,7 +396,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-guest"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-node"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "boxlite",
  "boxlite-shared",
@@ -438,7 +438,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-python"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "boxlite",
  "futures",
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-shared"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "prost",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = ["build/tmp", "target", ".venv", "examples/*/.venv"]
 resolver = "2"
 
 [workspace.package]
-version = "0.5.7"
+version = "0.5.8"
 edition = "2024"
 authors = ["Dorian Zheng <https://github.com/dorianzheng>"]
 license = "Apache-2.0"

--- a/boxlite-cli/Cargo.toml
+++ b/boxlite-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "boxlite-cli"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boxlite-ai/boxlite",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "BoxLite - Embeddable micro-VM runtime for secure, isolated code execution",
   "type": "module",
   "main": "dist/index.js",

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "boxlite"
-version = "0.5.7"
+version = "0.5.8"
 description = "Python bindings for Boxlite runtime"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Workspace (Rust core, shared, Python Cargo, C, Node Cargo): 0.5.7 → 0.5.8
- CLI: 0.1.0 → 0.2.0
- Node.js npm package: 0.2.4 → 0.2.5
- Python pyproject.toml: 0.5.7 → 0.5.8

## Test plan
- [ ] `cargo check` passes with new workspace version
- [ ] Python SDK builds with `make dev:python`
- [ ] Node.js SDK builds