### PR TITLE
refactor(cli): refactor run command, consolidate terminal and io logic into shared streamer

### DIFF
--- a/boxlite-cli/src/commands/run.rs
+++ b/boxlite-cli/src/commands/run.rs
@@ -1,15 +1,10 @@
 use crate::cli::{GlobalFlags, ManagementFlags, ProcessFlags, ResourceFlags};
+use crate::terminal::StreamManager;
+use crate::util::to_shell_exit_code;
 use boxlite::BoxCommand;
 use boxlite::{BoxOptions, BoxliteRuntime, LiteBox, RootfsSpec};
 use clap::Args;
-use futures::StreamExt;
-use nix::sys::signal::Signal;
-use nix::sys::termios::{
-    InputFlags, LocalFlags, OutputFlags, SetArg, Termios, tcgetattr, tcsetattr,
-};
-use std::io::{self, IsTerminal, Write};
-use tokio::select;
-use tokio::signal::unix::{SignalKind, signal};
+use std::io::{self, IsTerminal};
 
 #[derive(Args, Debug)]
 pub struct RunArgs {
@@ -64,26 +59,17 @@ impl BoxRunner {
             return Ok(());
         }
 
-        let _raw_guard = self.setup_raw_mode()?;
+        // IO streaming and signal handling via shared StreamManager
+        let streamer = StreamManager::new(
+            &mut execution,
+            self.args.process.interactive,
+            self.args.process.tty,
+        );
 
-        // IO streaming and signal handling
-        let (completion_tasks, cancellation_tasks) = self.setup_io_streaming(&mut execution);
-
-        // Wait for box exit and handle IO completion
-        let status = self
-            .wait_for_completion(execution, completion_tasks, cancellation_tasks)
-            .await?;
-
+        let exit_code = streamer.start().await?;
         // Exit with box's exit code
-        if status.exit_code != 0 {
-            let code = match status.exit_code {
-                // Signal termination: BoxLite encodes signals as negative values.
-                // Convert to shell convention: 128 + signal_number
-                // e.g. -9 (encoded SIGKILL) -> 128 + 9 = 137
-                code if code < 0 => 128 + code.abs(),
-                code => code,
-            };
-            std::process::exit(code);
+        if exit_code != 0 {
+            std::process::exit(to_shell_exit_code(exit_code));
         }
 
         Ok(())
@@ -94,6 +80,11 @@ impl BoxRunner {
         self.args.resource.apply_to(&mut options);
         self.args.management.apply_to(&mut options);
         self.args.process.apply_to(&mut options)?;
+
+        // Runtime requires detached boxes to have manual lifecycle control (auto_remove=false)
+        if self.args.management.detach {
+            options.auto_remove = false;
+        }
 
         options.rootfs = RootfsSpec::Image(self.args.image.clone());
 
@@ -107,58 +98,9 @@ impl BoxRunner {
 
     fn prepare_command(&self) -> BoxCommand {
         let (program, args) = parse_command_args(&self.args.command);
-
         BoxCommand::new(program)
             .args(args)
             .tty(self.args.process.tty)
-    }
-
-    fn setup_io_streaming(
-        &self,
-        execution: &mut boxlite::Execution,
-    ) -> (
-        Vec<tokio::task::JoinHandle<()>>,
-        Vec<tokio::task::JoinHandle<()>>,
-    ) {
-        let mut completion_tasks = Vec::new(); // stdout, stderr
-        let mut cancellation_tasks = Vec::new(); // stdin only (signals now handled in main loop)
-
-        // IO Streaming
-        if let Some(mut stdout) = execution.stdout() {
-            completion_tasks.push(tokio::spawn(async move {
-                while let Some(line) = stdout.next().await {
-                    print!("{}", line);
-                    let _ = io::stdout().flush();
-                }
-            }));
-        }
-
-        if let Some(mut stderr) = execution.stderr() {
-            let is_tty = self.args.process.tty;
-            completion_tasks.push(tokio::spawn(async move {
-                while let Some(line) = stderr.next().await {
-                    if is_tty {
-                        // TTY mode: stderr also goes to stdout (merged output)
-                        print!("{}", line);
-                        let _ = io::stdout().flush();
-                    } else {
-                        // Non-TTY mode: stderr goes to stderr (separated output)
-                        eprint!("{}", line);
-                        let _ = io::stderr().flush();
-                    }
-                }
-            }));
-        }
-
-        if self.args.process.interactive
-            && let Some(stdin_tx) = execution.stdin()
-        {
-            cancellation_tasks.push(tokio::spawn(async move {
-                stream_stdin(stdin_tx).await;
-            }));
-        }
-
-        (completion_tasks, cancellation_tasks)
     }
 
     fn validate_flags(&self) -> anyhow::Result<()> {
@@ -169,168 +111,6 @@ impl BoxRunner {
 
         Ok(())
     }
-
-    fn setup_raw_mode(&self) -> anyhow::Result<Option<RawModeGuard>> {
-        if self.args.process.tty && self.args.process.interactive {
-            match enable_raw_mode() {
-                Ok(guard) => Ok(Some(guard)),
-                Err(e) => {
-                    eprintln!("Warning: Failed to enable raw mode: {}", e);
-                    eprintln!("Continuing in cooked mode. Some features may not work correctly.");
-                    Ok(None)
-                }
-            }
-        } else {
-            Ok(None)
-        }
-    }
-
-    async fn wait_for_completion(
-        &self,
-        mut execution: boxlite::Execution,
-        completion_tasks: Vec<tokio::task::JoinHandle<()>>,
-        cancellation_tasks: Vec<tokio::task::JoinHandle<()>>,
-    ) -> anyhow::Result<boxlite::ExecResult> {
-        // created in main task context for reliable delivery
-        let mut sig_int = signal(SignalKind::interrupt()).unwrap();
-        let mut sig_term = signal(SignalKind::terminate()).unwrap();
-        let mut sig_hup = signal(SignalKind::hangup()).unwrap();
-        let mut sig_winch = if self.args.process.tty {
-            Some(signal(SignalKind::window_change()).unwrap())
-        } else {
-            None
-        };
-
-        if let Some((w, h)) = self.args.process.tty.then(term_size::dimensions).flatten() {
-            let _ = execution.resize_tty(h as u32, w as u32).await;
-        }
-
-        let signal_exec = execution.clone();
-        let exit_fut = execution.wait();
-
-        let io_fut = async {
-            for handle in completion_tasks {
-                let _ = handle.await;
-            }
-        };
-
-        tokio::pin!(exit_fut);
-        tokio::pin!(io_fut);
-
-        let mut io_done = false;
-        let mut exit_status: Option<boxlite::ExecResult> = None;
-
-        // Handles IO, signals, and exit
-        loop {
-            select! {
-                status = &mut exit_fut, if exit_status.is_none() => {
-                    exit_status = Some(status?);
-                    // Stop stdin forwarding to avoid EPIPE
-                    for task in &cancellation_tasks {
-                        task.abort();
-                    }
-                    if io_done {
-                        return Ok(exit_status.unwrap());
-                    }
-                }
-
-                _ = &mut io_fut, if !io_done => {
-                    io_done = true;
-                    //  exit already happened
-                    if let Some(status) = exit_status {
-                        return Ok(status);
-                    }
-                }
-
-                _ = sig_int.recv() => {
-                    let _ = signal_exec.signal(Signal::SIGINT as i32).await;
-                }
-
-                _ = sig_term.recv() => {
-                    let _ = signal_exec.signal(Signal::SIGTERM as i32).await;
-                }
-
-                _ = sig_hup.recv() => {
-                    let _ = signal_exec.signal(Signal::SIGHUP as i32).await;
-                }
-
-                // TTY resize
-                Some(_) = async {
-                    match sig_winch.as_mut() {
-                        Some(s) => s.recv().await,
-                        None => std::future::pending().await,
-                    }
-                } => {
-                    if let Some((w, h)) = term_size::dimensions() {
-                        let _ = signal_exec.resize_tty(h as u32, w as u32).await;
-                    }
-                }
-            }
-        }
-    }
-}
-
-async fn stream_stdin(mut tx: boxlite::ExecStdin) {
-    let mut stdin = tokio::io::stdin();
-    let mut buf = [0u8; 1024];
-    loop {
-        match tokio::io::AsyncReadExt::read(&mut stdin, &mut buf).await {
-            Ok(0) => break, // EOF
-            Ok(n) => {
-                if tx.write(&buf[..n]).await.is_err() {
-                    break;
-                }
-            }
-            Err(e) => {
-                tracing::debug!("stdin read error: {}", e);
-                break;
-            }
-        }
-    }
-}
-
-// Raw Mode
-struct RawModeGuard {
-    original_termios: Termios,
-}
-
-impl Drop for RawModeGuard {
-    fn drop(&mut self) {
-        let stdin = io::stdin();
-        let _ = tcsetattr(&stdin, SetArg::TCSANOW, &self.original_termios);
-    }
-}
-
-fn enable_raw_mode() -> anyhow::Result<RawModeGuard> {
-    if !io::stdin().is_terminal() {
-        return Err(anyhow::anyhow!("stdin is not a terminal"));
-    }
-
-    let stdin = io::stdin();
-    let original = tcgetattr(&stdin)?;
-    let mut raw = original.clone();
-
-    // Standard Raw Mode flags
-    raw.input_flags &= !(InputFlags::IGNBRK
-        | InputFlags::BRKINT
-        | InputFlags::PARMRK
-        | InputFlags::ISTRIP
-        | InputFlags::INLCR
-        | InputFlags::IGNCR
-        | InputFlags::ICRNL
-        | InputFlags::IXON);
-    raw.output_flags &= !OutputFlags::OPOST;
-    raw.local_flags &= !(LocalFlags::ECHO
-        | LocalFlags::ECHONL
-        | LocalFlags::ICANON
-        | LocalFlags::ISIG
-        | LocalFlags::IEXTEN);
-
-    tcsetattr(&stdin, SetArg::TCSANOW, &raw)?;
-
-    Ok(RawModeGuard {
-        original_termios: original,
-    })
 }
 
 fn parse_command_args(input: &[String]) -> (&str, &[String]) {

--- a/boxlite-cli/src/terminal/mod.rs
+++ b/boxlite-cli/src/terminal/mod.rs
@@ -1,0 +1,258 @@
+use anyhow::Result;
+use boxlite::Execution;
+use futures::StreamExt;
+use nix::sys::signal::Signal;
+use nix::sys::termios::{
+    InputFlags, LocalFlags, OutputFlags, SetArg, Termios, tcgetattr, tcsetattr,
+};
+use std::io::IsTerminal;
+use std::os::fd::{AsFd, AsRawFd};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::select;
+use tokio::signal::unix::{SignalKind, signal};
+
+/// RAII guard to restore terminal mode on drop
+pub struct RawModeGuard {
+    original_termios: Option<Termios>,
+    #[allow(dead_code)]
+    fd: std::os::fd::RawFd,
+}
+
+impl RawModeGuard {
+    pub fn new() -> Result<Self> {
+        let stdin = std::io::stdin();
+        let fd = stdin.as_fd().as_raw_fd();
+
+        if !stdin.is_terminal() {
+            return Ok(Self {
+                original_termios: None,
+                fd,
+            });
+        }
+
+        let original_termios = tcgetattr(&stdin)?;
+        let mut raw = original_termios.clone();
+
+        // Raw mode flags strictly aligned with run.rs to ensure consistent behavior
+        raw.input_flags &= !(InputFlags::IGNBRK
+            | InputFlags::BRKINT
+            | InputFlags::PARMRK
+            | InputFlags::ISTRIP
+            | InputFlags::INLCR
+            | InputFlags::IGNCR
+            | InputFlags::ICRNL
+            | InputFlags::IXON);
+        raw.output_flags &= !OutputFlags::OPOST;
+        raw.local_flags &= !(LocalFlags::ECHO
+            | LocalFlags::ECHONL
+            | LocalFlags::ICANON
+            | LocalFlags::ISIG
+            | LocalFlags::IEXTEN);
+
+        tcsetattr(&stdin, SetArg::TCSANOW, &raw)?;
+
+        Ok(Self {
+            original_termios: Some(original_termios),
+            fd,
+        })
+    }
+}
+
+impl Drop for RawModeGuard {
+    fn drop(&mut self) {
+        if let Some(termios) = &self.original_termios {
+            let stdin = std::io::stdin();
+            let _ = tcsetattr(&stdin, SetArg::TCSANOW, termios);
+        }
+    }
+}
+
+pub struct StreamManager<'a> {
+    execution: &'a mut Execution,
+    interactive: bool,
+    tty: bool,
+}
+
+impl<'a> StreamManager<'a> {
+    pub fn new(execution: &'a mut Execution, interactive: bool, tty: bool) -> Self {
+        Self {
+            execution,
+            interactive,
+            tty,
+        }
+    }
+
+    pub async fn start(self) -> Result<i32> {
+        let _raw_guard = if self.tty && self.interactive {
+            match RawModeGuard::new() {
+                Ok(guard) => Some(guard),
+                Err(e) => {
+                    eprintln!("Warning: Failed to enable raw mode: {}", e);
+                    eprintln!("Continuing in cooked mode. Some features may not work correctly.");
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
+        // stdout
+        let stdout_stream = self.execution.stdout();
+        let stdout_handle = tokio::spawn(async move {
+            if let Some(mut stream) = stdout_stream {
+                let mut stdout = tokio::io::stdout();
+                while let Some(chunk) = stream.next().await {
+                    if let Err(e) = stdout.write_all(chunk.as_bytes()).await {
+                        if e.kind() != std::io::ErrorKind::BrokenPipe {
+                            tracing::debug!("stdout write error: {}", e);
+                        }
+                        break;
+                    }
+                    let _ = stdout.flush().await;
+                }
+            }
+        });
+
+        // stderr
+        let stderr_stream = self.execution.stderr();
+        let tty_mode = self.tty;
+        let stderr_handle = tokio::spawn(async move {
+            if let Some(mut stream) = stderr_stream {
+                let mut stderr = tokio::io::stderr();
+                let mut stdout = tokio::io::stdout();
+
+                while let Some(chunk) = stream.next().await {
+                    let res = if tty_mode {
+                        stdout.write_all(chunk.as_bytes()).await
+                    } else {
+                        stderr.write_all(chunk.as_bytes()).await
+                    };
+
+                    if let Err(e) = res {
+                        if e.kind() != std::io::ErrorKind::BrokenPipe {
+                            tracing::debug!("stderr write error: {}", e);
+                        }
+                        break;
+                    }
+
+                    if tty_mode {
+                        let _ = stdout.flush().await;
+                    } else {
+                        let _ = stderr.flush().await;
+                    }
+                }
+            }
+        });
+
+        // stdin (if interactive)
+        let stdin_handle = if self.interactive {
+            self.execution
+                .stdin()
+                .map(|stdin_tx| tokio::spawn(stream_stdin(stdin_tx)))
+        } else {
+            None
+        };
+
+        let mut sigint = signal(SignalKind::interrupt())?;
+        let mut sigterm = signal(SignalKind::terminate())?;
+        let mut sighup = signal(SignalKind::hangup())?;
+        let mut sigquit = signal(SignalKind::quit())?;
+
+        // SIGWINCH setup (only if TTY)
+        let mut sigwinch = if self.tty {
+            Some(signal(SignalKind::window_change())?)
+        } else {
+            None
+        };
+
+        // Initial resize
+        if self.tty
+            && let Some((w, h)) = term_size::dimensions()
+        {
+            let _ = self.execution.resize_tty(h as u32, w as u32).await;
+        }
+
+        let mut io_done = false;
+        let mut exit_status: Option<boxlite::ExecResult> = None;
+
+        let io_finished = async {
+            let _ = stdout_handle.await;
+            let _ = stderr_handle.await;
+        };
+        tokio::pin!(io_finished);
+
+        let exit_code = loop {
+            select! {
+                res = self.execution.wait(), if exit_status.is_none() => {
+                    match res {
+                        Ok(status) => {
+                            exit_status = Some(status);
+                            if let Some(h) = stdin_handle.as_ref() {
+                                h.abort();
+                            }
+                            if io_done {
+                                break exit_status.unwrap().exit_code;
+                            }
+                        }
+                        Err(e) => {
+                            tracing::error!("Wait error: {}", e);
+                            break 1;
+                        }
+                    }
+                }
+                _ = &mut io_finished, if !io_done => {
+                    io_done = true;
+                    if let Some(status) = &exit_status {
+                        break status.exit_code;
+                    }
+                }
+                _ = sigint.recv() => {
+                    let _ = self.execution.signal(Signal::SIGINT as i32).await;
+                }
+                _ = sigterm.recv() => {
+                    let _ = self.execution.signal(Signal::SIGTERM as i32).await;
+                }
+                _ = sighup.recv() => {
+                    let _ = self.execution.signal(Signal::SIGHUP as i32).await;
+                }
+                _ = sigquit.recv() => {
+                    let _ = self.execution.signal(Signal::SIGQUIT as i32).await;
+                }
+                Some(_) = async {
+                    if let Some(s) = sigwinch.as_mut() {
+                        s.recv().await
+                    } else {
+                        std::future::pending().await
+                    }
+                } => {
+                    if let Some((w, h)) = term_size::dimensions() {
+                        let _ = self.execution.resize_tty(h as u32, w as u32).await;
+                    }
+                }
+            }
+        };
+
+        Ok(exit_code)
+    }
+}
+
+async fn stream_stdin(mut stdin_tx: boxlite::ExecStdin) {
+    let mut stdin = tokio::io::stdin();
+    let mut buf = [0u8; 8192];
+
+    loop {
+        match stdin.read(&mut buf).await {
+            Ok(0) => break,
+            Ok(n) => {
+                if let Err(e) = stdin_tx.write(&buf[..n]).await {
+                    tracing::debug!("failed to forward stdin: {}", e);
+                    break;
+                }
+            }
+            Err(e) => {
+                tracing::debug!("stdin read error: {}", e);
+                break;
+            }
+        }
+    }
+}

--- a/boxlite-cli/src/util/mod.rs
+++ b/boxlite-cli/src/util/mod.rs
@@ -1,0 +1,48 @@
+//! Utility functions shared across commands
+
+/// Convert boxlite exit code to shell exit code.
+///
+/// Boxlite encodes signal termination as negative values (e.g., -9 for SIGKILL).
+/// Shell convention uses 128 + signal_number for signal termination.
+///
+/// # Examples
+///
+/// ```
+/// # use boxlite_cli::utils::to_shell_exit_code;
+/// assert_eq!(to_shell_exit_code(0), 0);      // Normal success
+/// assert_eq!(to_shell_exit_code(1), 1);      // Normal failure
+/// assert_eq!(to_shell_exit_code(-9), 137);   // SIGKILL: 128 + 9
+/// assert_eq!(to_shell_exit_code(-15), 143);  // SIGTERM: 128 + 15
+/// ```
+pub fn to_shell_exit_code(boxlite_code: i32) -> i32 {
+    match boxlite_code {
+        code if code < 0 => 128 + code.abs(),
+        code => code,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_to_shell_exit_code_success() {
+        assert_eq!(to_shell_exit_code(0), 0);
+    }
+
+    #[test]
+    fn test_to_shell_exit_code_normal_failure() {
+        assert_eq!(to_shell_exit_code(1), 1);
+        assert_eq!(to_shell_exit_code(127), 127);
+    }
+
+    #[test]
+    fn test_to_shell_exit_code_signal_termination() {
+        // SIGKILL (9)
+        assert_eq!(to_shell_exit_code(-9), 137);
+        // SIGTERM (15)
+        assert_eq!(to_shell_exit_code(-15), 143);
+        // SIGINT (2)
+        assert_eq!(to_shell_exit_code(-2), 130);
+    }
+}

--- a/boxlite-cli/tests/run.rs
+++ b/boxlite-cli/tests/run.rs
@@ -587,7 +587,7 @@ fn test_run_signal_exit_code_sigint() {
 #[test]
 fn test_run_invalid_image() {
     let mut ctx = common::boxlite();
-    ctx.cmd.timeout(std::time::Duration::from_secs(10));
+    ctx.cmd.timeout(std::time::Duration::from_secs(30));
     ctx.cmd
         .args(["run", "nonexistent-image:latest", "echo", "hi"]);
     ctx.cmd.assert().failure().stderr(


### PR DESCRIPTION
## Info

issue: https://github.com/boxlite-ai/boxlite/issues/35

**This is the first part of the `exec` command.** After this PR, I'll submit a PR **resuse** terminal streamer to implement `exec`  command.

## Key Changes
- Consolidates terminal raw mode and IO streaming into a shared StreamManager component.
- Fixes a terminal restoration bug by ensuring RawModeGuard is dropped before process exit.
- Improves IO reliability by ensuring all output is flushed before the CLI exits.
- Centralizes management flags (name, rm, detach) for consistency across commands.
- Moves tokio runtime initialization to a safe block to avoid environment variable race conditions.

## Testing

- [x] `make test:cli`
- [x] manually test  `./target/debug/run`