### PR TITLE
feat: add get_or_create API and reuse_existing flag across SDKs

### DIFF
--- a/boxlite/src/lib.rs
+++ b/boxlite/src/lib.rs
@@ -27,6 +27,7 @@ mod rootfs;
 mod volumes;
 
 pub use litebox::LiteBox;
+pub use portal::GuestSession;
 pub use runtime::BoxliteRuntime;
 
 use boxlite_shared::errors::{BoxliteError, BoxliteResult};

--- a/boxlite/src/runtime/core.rs
+++ b/boxlite/src/runtime/core.rs
@@ -198,6 +198,19 @@ impl BoxliteRuntime {
         self.rt_impl.create(options, name).await
     }
 
+    /// Get an existing box by name, or create a new one if it doesn't exist.
+    ///
+    /// Returns `(LiteBox, true)` if a new box was created, or `(LiteBox, false)`
+    /// if an existing box with the given name was found. When an existing box is
+    /// returned, the provided `options` are ignored (no config drift validation).
+    pub async fn get_or_create(
+        &self,
+        options: BoxOptions,
+        name: Option<String>,
+    ) -> BoxliteResult<(LiteBox, bool)> {
+        self.rt_impl.get_or_create(options, name).await
+    }
+
     /// Get a handle to an existing box by ID or name.
     ///
     /// The `id_or_name` parameter can be either:

--- a/examples/node/simplebox.js
+++ b/examples/node/simplebox.js
@@ -40,8 +40,27 @@ async function main() {
     console.log(`   Info: ${JSON.stringify(info, null, 2)}\n`);
 
     console.log('✅ All commands completed successfully!');
+
+    console.log('\n5. Reuse existing box by name...');
+    const box2 = new SimpleBox({ image: 'alpine:latest', name: 'reuse-demo', reuseExisting: true });
+    try {
+      const r1 = await box2.exec('echo', 'first open');
+      console.log(`   Created: ${box2.created}`);
+      console.log(`   Output: ${r1.stdout.trim()}`);
+
+      // Second open reuses the same box
+      const box3 = new SimpleBox({ image: 'alpine:latest', name: 'reuse-demo', reuseExisting: true });
+      try {
+        const r2 = await box3.exec('echo', 'second open');
+        console.log(`   Reused (created=${box3.created}): ${r2.stdout.trim()}`);
+      } finally {
+        await box3.stop();
+      }
+    } finally {
+      await box2.stop();
+    }
   } finally {
-    console.log('\n5. Cleaning up...');
+    console.log('\n6. Cleaning up...');
     await box.stop();
     console.log('   Box stopped and removed.');
   }

--- a/examples/python/simplebox_example.py
+++ b/examples/python/simplebox_example.py
@@ -130,9 +130,33 @@ async def example_error_handling():
             print(f"Command failed with exit code: {result.exit_code}")
 
 
+async def example_reuse_existing():
+    """Example 6: Reuse existing box by name."""
+    print("\n\n=== Example 6: Reuse Existing Box ===")
+
+    name = "reuse-demo"
+
+    # First call creates a new box
+    async with boxlite.SimpleBox(
+        image="python:alpine", name=name, reuse_existing=True
+    ) as box1:
+        print(f"First open:  id={box1.id}, created={box1.created}")
+        await box1.exec("sh", "-c", "echo 'hello' > /tmp/marker")
+
+        # Second call with same name reuses the existing box
+        async with boxlite.SimpleBox(
+            image="python:alpine", name=name, reuse_existing=True
+        ) as box2:
+            print(f"Second open: id={box2.id}, created={box2.created}")
+            result = await box2.exec("cat", "/tmp/marker")
+            print(f"Marker file from reused box: {result.stdout.strip()}")
+
+    print("Reuse existing avoids duplicate-name errors and shares state.")
+
+
 async def example_pipeline():
-    """Example 6: Real-world data processing pipeline."""
-    print("\n\n=== Example 6: Data Processing Pipeline ===")
+    """Example 7: Real-world data processing pipeline."""
+    print("\n\n=== Example 7: Data Processing Pipeline ===")
 
     async with boxlite.SimpleBox(image="python:alpine") as box:
         print(f"✓ Running data pipeline in: {box.id}")
@@ -172,6 +196,7 @@ async def main():
     await example_environment()
     await example_working_directory()
     await example_error_handling()
+    await example_reuse_existing()
     await example_pipeline()
 
     print("\n" + "=" * 60)

--- a/examples/python/sync_simplebox_example.py
+++ b/examples/python/sync_simplebox_example.py
@@ -131,9 +131,37 @@ def example_error_handling():
             print(f"Command failed with exit code: {result.exit_code}")
 
 
+def example_reuse_existing():
+    """Example 6: Reuse existing box by name."""
+    print("\n\n=== Example 6: Reuse Existing Box ===")
+
+    from boxlite.sync_api import SyncBoxlite
+
+    name = "sync-reuse-demo"
+
+    # Nested SyncSimpleBox instances must share a single runtime,
+    # because the sync API runs one greenlet event loop that cannot
+    # be duplicated.
+    with SyncBoxlite.default() as runtime:
+        with boxlite.SyncSimpleBox(
+            image="python:alpine", name=name, reuse_existing=True, runtime=runtime
+        ) as box1:
+            print(f"First open:  id={box1.id}, created={box1.created}")
+            box1.exec("sh", "-c", "echo 'hello' > /tmp/marker")
+
+            with boxlite.SyncSimpleBox(
+                image="python:alpine", name=name, reuse_existing=True, runtime=runtime
+            ) as box2:
+                print(f"Second open: id={box2.id}, created={box2.created}")
+                result = box2.exec("cat", "/tmp/marker")
+                print(f"Marker file from reused box: {result.stdout.strip()}")
+
+    print("Reuse existing avoids duplicate-name errors and shares state.")
+
+
 def example_pipeline():
-    """Example 6: Real-world data processing pipeline."""
-    print("\n\n=== Example 6: Data Processing Pipeline ===")
+    """Example 7: Real-world data processing pipeline."""
+    print("\n\n=== Example 7: Data Processing Pipeline ===")
 
     with boxlite.SyncSimpleBox(image="python:alpine") as box:
         print(f"Running data pipeline in: {box.id}")
@@ -173,6 +201,7 @@ def main():
     example_environment()
     example_working_directory()
     example_error_handling()
+    example_reuse_existing()
     example_pipeline()
 
     print("\n" + "=" * 60)

--- a/sdks/python/boxlite/sync_api/_boxlite.py
+++ b/sdks/python/boxlite/sync_api/_boxlite.py
@@ -275,6 +275,29 @@ class SyncBoxlite:
         native_box = self._sync(self._boxlite.create(options, name=name))
         return SyncBox(self, native_box)
 
+    def get_or_create(
+        self,
+        options: "BoxOptions",
+        name: Optional[str] = None,
+    ) -> tuple["SyncBox", bool]:
+        """
+        Get an existing box by name, or create a new one.
+
+        Args:
+            options: BoxOptions specifying image, resources, etc.
+            name: Optional name to look up or assign. If None, always creates.
+
+        Returns:
+            Tuple of (SyncBox, created) where created is True if newly created.
+        """
+        self._require_started()
+        from ._box import SyncBox
+
+        native_box, created = self._sync(
+            self._boxlite.get_or_create(options, name=name)
+        )
+        return SyncBox(self, native_box), created
+
     def get(self, id_or_name: str) -> Optional["SyncBox"]:
         """
         Get an existing box by ID or name.


### PR DESCRIPTION
## Summary

- **Core runtime**: Add `get_or_create()` method with TOCTOU race recovery (retry on duplicate name conflict)
- **Python SDK**: Add `reuse_existing: bool = False` parameter to both `SimpleBox` (async) and `SyncSimpleBox` (sync) — opt-in to reuse existing boxes by name
- **Node SDK**: Add `reuseExisting?: boolean` option to `SimpleBox` and `getOrCreate()` to the runtime binding
- **CLI cp fix**: Preserve already-running boxes by checking `was_running` before start/stop
- **Shim improvements**: Better guest shutdown logging, `GUEST_SHUTDOWN_TIMEOUT_SECS` constant, handle Tokio runtime build failures
- **Portal visibility**: Narrow `pub mod portal` to `mod portal` + targeted `pub use portal::GuestSession` re-export
- **Tests**: 6 new integration tests (3 async, 3 sync) covering create-new, reuse-existing, and duplicate-name-error scenarios
- **Examples**: `reuse_existing` demos added to Python async, Python sync, and Node examples

## Test plan

- [x] `cargo check -p boxlite -p boxlite-cli` — compiles clean
- [x] `cargo test -p boxlite-cli "cp::"` — 4 cp unit tests pass
- [x] Python syntax checks on all modified `.py` files
- [x] `pytest` — 38 integration tests pass (including 6 new reuse_existing tests)
- [ ] CI pipeline