### PR TITLE
feat: add FUSE filesystem example

### DIFF
--- a/examples/python/fuse/fuse_example.py
+++ b/examples/python/fuse/fuse_example.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""Run a custom FUSE filesystem inside a BoxLite VM."""
+
+import asyncio
+from pathlib import Path
+
+import boxlite
+
+HERE = Path(__file__).parent
+
+
+async def main():
+    async with boxlite.SimpleBox(image="python:slim") as box:
+        await box.copy_in(str(HERE / "hellofs.py"), "/opt")
+        await box.copy_in(str(HERE / "run_fuse_demo.sh"), "/opt")
+
+        result = await box.exec("sh", "/opt/run_fuse_demo.sh")
+
+        print(result.stdout)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/python/fuse/hellofs.py
+++ b/examples/python/fuse/hellofs.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Minimal FUSE filesystem: serves one read-only virtual file /hello.txt."""
+
+import os
+import sys
+import stat
+import errno
+
+from fuse import FUSE, FuseOSError, Operations
+
+
+class HelloFS(Operations):
+    DATA = b"Hello from FUSE inside BoxLite!\n"
+
+    def getattr(self, path, fh=None):
+        if path == "/":
+            return {"st_mode": stat.S_IFDIR | 0o755, "st_nlink": 2}
+        if path == "/hello.txt":
+            return {"st_mode": stat.S_IFREG | 0o444, "st_size": len(self.DATA)}
+        raise FuseOSError(errno.ENOENT)
+
+    def readdir(self, path, fh):
+        return [".", "..", "hello.txt"]
+
+    def read(self, path, size, offset, fh):
+        return self.DATA[offset:offset + size]
+
+
+if __name__ == "__main__":
+    mountpoint = sys.argv[1] if len(sys.argv) > 1 else "/mnt/hello"
+    os.makedirs(mountpoint, exist_ok=True)
+    print(f"Mounting HelloFS at {mountpoint}", flush=True)
+    FUSE(HelloFS(), mountpoint, foreground=True, nothreads=True)

--- a/examples/python/fuse/run_fuse_demo.sh
+++ b/examples/python/fuse/run_fuse_demo.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Demo: install FUSE, mount a custom filesystem, read from it, cleanup.
+set -e
+
+# 1. Install FUSE + fusepy
+apt-get update -qq > /dev/null 2>&1
+apt-get install -y -qq fuse3 libfuse-dev > /dev/null 2>&1
+pip install -q fusepy > /dev/null 2>&1
+
+# 2. Ensure /dev/fuse exists (slim images may lack modprobe)
+if [ ! -e /dev/fuse ]; then
+    mknod /dev/fuse c 10 229
+    chmod 666 /dev/fuse
+fi
+
+# 3. Mount the FUSE filesystem in background
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+python3 "$SCRIPT_DIR/hellofs.py" /mnt/hello &
+sleep 2
+
+# 4. Demo: read from the virtual filesystem
+echo "=== ls /mnt/hello ==="
+ls -la /mnt/hello/
+echo "=== cat /mnt/hello/hello.txt ==="
+cat /mnt/hello/hello.txt
+echo "=== mount info ==="
+mount | grep hello
+
+# 5. Cleanup
+fusermount3 -u /mnt/hello
+echo "done"


### PR DESCRIPTION
## Summary
- Add example running a custom FUSE filesystem inside a BoxLite VM
- Three files: `fuse_example.py` (host entry point), `hellofs.py` (minimal FUSE FS), `run_fuse_demo.sh` (guest driver)
- Document known `copy_in` limitation on tmpfs-mounted destinations (`/tmp`, `/dev/shm`) in both Rust source and Python SDK docstring

## Test plan
- [ ] Run `python examples/python/fuse/fuse_example.py` and verify FUSE mount, file read, and cleanup output