### PR TITLE
docs: document copy_in tmpfs limitation and add workaround examples

### DIFF
--- a/examples/node/cp_tmpfs_workaround.js
+++ b/examples/node/cp_tmpfs_workaround.js
@@ -1,0 +1,113 @@
+/**
+ * Workaround: copy files into tmpfs destinations (e.g. /tmp) inside a container.
+ *
+ * copy_in() writes to the rootfs layer, so files destined for tmpfs mounts
+ * are invisible to the running container. This is the same limitation as
+ * `docker cp` (see https://github.com/moby/moby/issues/22020).
+ *
+ * The fix is the same as Docker's recommendation: pipe a tar archive through
+ * a command running inside the container's mount namespace, which sees tmpfs.
+ */
+
+import { SimpleBox } from '@boxlite-ai/boxlite';
+import { writeFileSync, unlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+/**
+ * Create a minimal tar archive from a map of {filename: content}.
+ *
+ * Tar format: for each file, a 512-byte header + data padded to 512 bytes,
+ * followed by two 512-byte zero blocks as end-of-archive marker.
+ */
+function makeTar(files) {
+  const blocks = [];
+
+  for (const [name, content] of Object.entries(files)) {
+    const data = typeof content === 'string' ? Buffer.from(content) : content;
+
+    // Build 512-byte tar header
+    const header = Buffer.alloc(512);
+    // Name (0-99)
+    header.write(name, 0, Math.min(name.length, 100), 'utf8');
+    // Mode (100-107) - 0644
+    header.write('0000644\0', 100, 8, 'utf8');
+    // UID (108-115)
+    header.write('0000000\0', 108, 8, 'utf8');
+    // GID (116-123)
+    header.write('0000000\0', 116, 8, 'utf8');
+    // Size (124-135) - octal
+    header.write(data.length.toString(8).padStart(11, '0') + '\0', 124, 12, 'utf8');
+    // Mtime (136-147)
+    header.write('00000000000\0', 136, 12, 'utf8');
+    // Typeflag (156) - '0' = regular file
+    header.write('0', 156, 1, 'utf8');
+
+    // Checksum (148-155) - compute over header with checksum field as spaces
+    // First fill checksum field with spaces
+    header.write('        ', 148, 8, 'utf8');
+    let checksum = 0;
+    for (let i = 0; i < 512; i++) {
+      checksum += header[i];
+    }
+    header.write(checksum.toString(8).padStart(6, '0') + '\0 ', 148, 8, 'utf8');
+
+    blocks.push(header);
+
+    // Data blocks (padded to 512 bytes)
+    const paddedSize = Math.ceil(data.length / 512) * 512;
+    const dataBlock = Buffer.alloc(paddedSize);
+    data.copy(dataBlock);
+    blocks.push(dataBlock);
+  }
+
+  // End-of-archive: two 512-byte zero blocks
+  blocks.push(Buffer.alloc(1024));
+
+  return Buffer.concat(blocks);
+}
+
+async function main() {
+  const box = new SimpleBox({ image: 'alpine:latest', name: 'node-tmpfs-cp-demo' });
+
+  try {
+    // Ensure box is created
+    await box.getId();
+
+    // --- The problem: copy_in to /tmp silently fails ---
+    const hostFile = join(tmpdir(), `boxlite-test-${Date.now()}.txt`);
+    writeFileSync(hostFile, "you won't see me\n");
+
+    try {
+      await box._box.copyIn(hostFile, '/tmp/ghost.txt');
+      const result = await box.exec('ls', '/tmp/ghost.txt');
+      console.log(
+        `copy_in to /tmp:     exit=${result.exitCode}  ` +
+        `${result.exitCode === 0 ? 'FOUND' : 'NOT FOUND (expected)'}`
+      );
+    } finally {
+      unlinkSync(hostFile);
+    }
+
+    // --- The workaround: pipe tar through container process ---
+    const tarData = makeTar({ 'hello.txt': 'visible!\n' });
+
+    // Use low-level API to get stdin access (like: docker exec -i ... tar xf -)
+    const tarExec = await box._box.exec('tar', ['xf', '-', '-C', '/tmp']);
+    const stdin = await tarExec.stdin();
+    await stdin.write(tarData);
+    await stdin.close();
+    const tarResult = await tarExec.wait();
+    console.log(`tar via stdin:       exit=${tarResult.exitCode}`);
+
+    const catResult = await box.exec('cat', '/tmp/hello.txt');
+    console.log(`read /tmp/hello.txt: ${catResult.stdout.trim()}`);
+  } finally {
+    await box.stop();
+  }
+}
+
+main().catch(error => {
+  console.error('Error:', error);
+  process.exit(1);
+});

--- a/examples/node/package.json
+++ b/examples/node/package.json
@@ -16,6 +16,7 @@
     "browserbox-puppeteer": "node browserbox_puppeteer.js",
     "computerbox": "node computerbox.js",
     "interactivebox": "node interactivebox.js",
-    "claude": "node claude_in_boxlite.js"
+    "claude": "node claude_in_boxlite.js",
+    "cp-tmpfs-workaround": "node cp_tmpfs_workaround.js"
   }
 }

--- a/examples/python/cp_tmpfs_workaround_example.py
+++ b/examples/python/cp_tmpfs_workaround_example.py
@@ -1,0 +1,67 @@
+"""
+Workaround: copy files into tmpfs destinations (e.g. /tmp) inside a container.
+
+copy_in() writes to the rootfs layer, so files destined for tmpfs mounts
+are invisible to the running container. This is the same limitation as
+`docker cp` (see https://github.com/moby/moby/issues/22020).
+
+The fix is the same as Docker's recommendation: pipe a tar archive through
+a command running inside the container's mount namespace, which sees tmpfs.
+
+Requirements:
+  pip install boxlite
+"""
+
+import asyncio
+import io
+import tarfile
+
+from boxlite import SimpleBox
+
+
+def make_tar(files: dict[str, bytes]) -> bytes:
+    """Create an in-memory tar archive from a dict of {path: content}."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tar:
+        for name, data in files.items():
+            info = tarfile.TarInfo(name=name)
+            info.size = len(data)
+            tar.addfile(info, io.BytesIO(data))
+    return buf.getvalue()
+
+
+async def main():
+    async with SimpleBox("alpine:latest", name="tmpfs-cp-demo") as box:
+
+        # --- The problem: copy_in to /tmp silently fails ---
+        # Write a file on host, copy it into /tmp inside the container
+        import tempfile, os
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write("you won't see me\n")
+            host_file = f.name
+
+        try:
+            await box.copy_in(host_file, "/tmp/ghost.txt")
+            result = await box.exec("ls", "/tmp/ghost.txt")
+            print(f"copy_in to /tmp:     exit={result.exit_code}  "
+                  f"{'FOUND' if result.exit_code == 0 else 'NOT FOUND (expected)'}")
+        finally:
+            os.unlink(host_file)
+
+        # --- The workaround: pipe tar through container process ---
+        tar_data = make_tar({"hello.txt": b"visible!\n"})
+
+        # Use low-level API to get stdin access (like: docker exec -i ... tar xf -)
+        execution = await box._box.exec("tar", args=["xf", "-", "-C", "/tmp"])
+        stdin = execution.stdin()
+        await stdin.send_input(tar_data)
+        await stdin.close()
+        result = await execution.wait()
+        print(f"tar via stdin:       exit={result.exit_code}")
+
+        result = await box.exec("cat", "/tmp/hello.txt")
+        print(f"read /tmp/hello.txt: {result.stdout.strip()}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/python/sync_cp_tmpfs_workaround_example.py
+++ b/examples/python/sync_cp_tmpfs_workaround_example.py
@@ -1,0 +1,64 @@
+"""
+Workaround (sync): copy files into tmpfs destinations inside a container.
+
+Synchronous version of cp_tmpfs_workaround_example.py.
+See that file for background on the tmpfs limitation.
+
+Requirements:
+  pip install boxlite[sync]
+"""
+
+import io
+import os
+import tarfile
+import tempfile
+
+from boxlite import SyncSimpleBox
+
+
+def make_tar(files: dict[str, bytes]) -> bytes:
+    """Create an in-memory tar archive from a dict of {path: content}."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tar:
+        for name, data in files.items():
+            info = tarfile.TarInfo(name=name)
+            info.size = len(data)
+            tar.addfile(info, io.BytesIO(data))
+    return buf.getvalue()
+
+
+def main():
+    with SyncSimpleBox("alpine:latest", name="sync-tmpfs-cp-demo") as box:
+
+        # --- The problem: copy_in to /tmp silently fails ---
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write("you won't see me\n")
+            host_file = f.name
+
+        try:
+            # SyncSimpleBox doesn't expose copy_in directly; use the
+            # underlying SyncBox._sync helper to call PyBox.copy_in.
+            box._box._sync(box._box._box.copy_in(host_file, "/tmp/ghost.txt"))
+            result = box.exec("ls", "/tmp/ghost.txt")
+            print(f"copy_in to /tmp:     exit={result.exit_code}  "
+                  f"{'FOUND' if result.exit_code == 0 else 'NOT FOUND (expected)'}")
+        finally:
+            os.unlink(host_file)
+
+        # --- The workaround: pipe tar through container process ---
+        tar_data = make_tar({"hello.txt": b"visible!\n"})
+
+        # Use low-level SyncBox to get stdin access
+        execution = box._box.exec("tar", ["xf", "-", "-C", "/tmp"])
+        stdin = execution.stdin()
+        stdin.send_input(tar_data)
+        stdin.close()
+        result = execution.wait()
+        print(f"tar via stdin:       exit={result.exit_code}")
+
+        result = box.exec("cat", "/tmp/hello.txt")
+        print(f"read /tmp/hello.txt: {result.stdout.strip()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/sdks/node/src/box_handle.rs
+++ b/sdks/node/src/box_handle.rs
@@ -180,6 +180,12 @@ impl JsBox {
     }
 
     /// Copy files from host into the box's container rootfs.
+    ///
+    /// **Note:** Destinations under tmpfs mounts (e.g. `/tmp`, `/dev/shm`) will
+    /// silently fail — files land behind the mount and are invisible to the
+    /// container. Same limitation as `docker cp`. Workaround: pipe tar via
+    /// stdin through the box's command execution API.
+    /// See: <https://github.com/moby/moby/issues/22020>
     #[napi(js_name = "copyIn")]
     pub async fn copy_in(
         &self,

--- a/sdks/node/src/exec.rs
+++ b/sdks/node/src/exec.rs
@@ -121,6 +121,25 @@ impl JsExecStdin {
     pub async fn write_string(&self, text: String) -> Result<()> {
         self.write(text.into_bytes().into()).await
     }
+
+    /// Close stdin stream, signaling EOF to the process.
+    ///
+    /// After closing, the process will receive EOF on its stdin.
+    /// This is necessary for commands like `tar xf -` that read
+    /// until EOF before processing.
+    ///
+    /// # Example
+    /// ```javascript
+    /// const stdin = await execution.stdin();
+    /// await stdin.write(Buffer.from(data));
+    /// await stdin.close();
+    /// ```
+    #[napi]
+    pub async fn close(&self) -> Result<()> {
+        let mut guard = self.stream.lock().await;
+        guard.close();
+        Ok(())
+    }
 }
 
 /// Execution handle for a running command.

--- a/sdks/python/src/box_handle.rs
+++ b/sdks/python/src/box_handle.rs
@@ -98,6 +98,12 @@ impl PyBox {
     }
 
     /// Copy from host into the box container rootfs.
+    ///
+    /// **Note:** Destinations under tmpfs mounts (e.g. `/tmp`, `/dev/shm`) will
+    /// silently fail — files land behind the mount and are invisible to the
+    /// container. Same limitation as `docker cp`. Workaround: pipe tar via
+    /// stdin through the box's command execution API.
+    /// See: <https://github.com/moby/moby/issues/22020>
     #[pyo3(signature = (host_path, container_dest, copy_options=None))]
     fn copy_in<'a>(
         &self,


### PR DESCRIPTION
## Summary

- Document the `copy_in` tmpfs limitation across all SDKs (same as `docker cp`, see [moby/moby#22020](https://github.com/moby/moby/issues/22020))
- Add `exec` + tar stdin workaround examples for async Python, sync Python, and Node.js
- Add missing `SyncExecStdin` class to Python sync API
- Add missing `close()` method to Node SDK `JsExecStdin`

## Context

`copy_in` writes to the rootfs layer, but tmpfs mounts (`/tmp`, `/dev/shm`, `/run`) hide those files inside the running container. The workaround is to pipe a tar archive through `exec("tar", ["xf", "-", "-C", "/tmp"])` via stdin, which runs inside the container's mount namespace and sees tmpfs.

## Test plan

- [x] Async Python example tested: `python examples/python/cp_tmpfs_workaround_example.py`
- [x] Sync Python example tested: `python examples/python/sync_cp_tmpfs_workaround_example.py`
- [x] Node.js example tested: `node examples/node/cp_tmpfs_workaround.js`
- All three produce: `copy_in NOT FOUND (expected)` → `tar via stdin exit=0` → `read visible!`