### PR TITLE
feat: resolve non-numeric USER directives and fix OCI layer extraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,6 +412,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tar",
+ "tempfile",
  "tokio",
  "tokio-stream",
  "tokio-vsock",

--- a/boxlite-shared/proto/boxlite/v1/service.proto
+++ b/boxlite-shared/proto/boxlite/v1/service.proto
@@ -221,7 +221,7 @@ message ContainerConfig {
   // Working directory (e.g., "/app")
   string workdir = 3;
 
-  // User/group to run as (e.g., "0:0", "1000", "1000:1000", "nginx")
+  // Username or UID (format: <name|uid>[:<group|gid>]).
   string user = 4;
 }
 

--- a/boxlite/src/images/archive/tar.rs
+++ b/boxlite/src/images/archive/tar.rs
@@ -256,7 +256,9 @@ pub fn apply_oci_layer<R: Read>(reader: R, dest: &Path) -> BoxliteResult<u64> {
                 fs::set_permissions(&full_path, Permissions::from_mode(mode)).map_err(|e| {
                     BoxliteError::Storage(format!(
                         "Failed to set permissions {:o} on {}: {}",
-                        mode, full_path.display(), e
+                        mode,
+                        full_path.display(),
+                        e
                     ))
                 })?;
             }
@@ -274,7 +276,9 @@ pub fn apply_oci_layer<R: Read>(reader: R, dest: &Path) -> BoxliteResult<u64> {
         fs::set_permissions(&dir.path, Permissions::from_mode(dir.mode)).map_err(|e| {
             BoxliteError::Storage(format!(
                 "Failed to set deferred dir permissions {:o} on {}: {}",
-                dir.mode, dir.path.display(), e
+                dir.mode,
+                dir.path.display(),
+                e
             ))
         })?;
         apply_times(&dir.path, EntryType::Directory, dir.atime, dir.mtime)?;

--- a/boxlite/src/runtime/options.rs
+++ b/boxlite/src/runtime/options.rs
@@ -624,10 +624,8 @@ pub struct BoxOptions {
     #[serde(default)]
     pub cmd: Option<Vec<String>>,
 
-    /// Override container user (UID/GID).
-    ///
-    /// Format: `"uid"`, `"uid:gid"`, or `"username"`.
-    /// If None, uses the image's USER directive (defaults to root "0:0").
+    /// Username or UID (format: <name|uid>[:<group|gid>]).
+    /// If None, uses the image's USER directive (defaults to root).
     #[serde(default)]
     pub user: Option<String>,
 }

--- a/guest/Cargo.toml
+++ b/guest/Cargo.toml
@@ -36,3 +36,6 @@ libcontainer = { version = "0.5.6", default-features = false, features = ["v2"] 
 oci-spec = "0.6"
 rtnetlink = "0.14"
 futures = "0.3"
+
+[dev-dependencies]
+tempfile = "3"

--- a/guest/src/container/start.rs
+++ b/guest/src/container/start.rs
@@ -94,7 +94,8 @@ pub(crate) fn create_oci_bundle(
     entrypoint: &[String],
     env: &[String],
     workdir: &Path,
-    user: &str,
+    uid: u32,
+    gid: u32,
     bundle_root: &Path,
     user_mounts: &[spec::UserMount],
 ) -> BoxliteResult<PathBuf> {
@@ -122,7 +123,8 @@ pub(crate) fn create_oci_bundle(
         workdir
             .to_str()
             .ok_or_else(|| BoxliteError::Internal("Invalid workdir path".to_string()))?,
-        user,
+        uid,
+        gid,
         &bundle_path,
         user_mounts,
     )?;

--- a/sdks/node/src/options.rs
+++ b/sdks/node/src/options.rs
@@ -91,9 +91,7 @@ pub struct JsBoxOptions {
     /// Final execution = image_entrypoint + cmd.
     pub cmd: Option<Vec<String>>,
 
-    /// Override container user (UID/GID).
-    ///
-    /// Format: "uid", "uid:gid", or "username".
+    /// Username or UID (format: <name|uid>[:<group|gid>]).
     /// If None, uses the image's USER directive (defaults to root).
     pub user: Option<String>,
 }

--- a/sdks/python/src/options.rs
+++ b/sdks/python/src/options.rs
@@ -327,7 +327,7 @@ pub(crate) struct PyBoxOptions {
     /// Example: `cmd=["--iptables=false"]` with `docker:dind`
     #[pyo3(get, set)]
     pub(crate) cmd: Option<Vec<String>>,
-    /// Override container user (e.g., "1000", "1000:1000").
+    /// Username or UID (format: <name|uid>[:<group|gid>]).
     /// If None, uses the image's USER directive (defaults to root).
     #[pyo3(get, set)]
     pub(crate) user: Option<String>,


### PR DESCRIPTION
## Summary

- **OCI layer extraction fix**: Directories with restrictive permissions (e.g., `0o700`) blocked extraction of children. Now defers directory permission/timestamp restoration until after all entries are extracted.
- **Non-numeric USER resolution**: Support all Docker/Podman USER formats (`name`, `uid`, `name:group`, `uid:gid`, `name:gid`, `uid:group`) by resolving from container rootfs `/etc/passwd` and `/etc/group`.
- **Resolve-once design**: User string resolved to `(uid, gid)` once at `Container::start()`, passed as numeric tuple to OCI spec and exec commands. Removes redundant `parse_user_for_exec`.
- **Trailing colon fix**: `"1000:"` now correctly treated as "no explicit group" (uses passwd GID or default 0).
- **27 unit tests** covering all valid Docker USER input formats including boundary UIDs, special characters, duplicate entries, malformed passwd, and error cases.

## Test plan

- [x] `cargo build -p boxlite-guest --target aarch64-unknown-linux-musl` compiles clean
- [x] `make dev:python && python examples/python/cmd_user_example.py` passes all 5 examples
- [x] Verified no regression: stashed changes, ran example on original code, confirmed identical behavior
- [ ] CI: `cargo test` for unit tests
- [ ] E2E: verify `user="nobody"` and `user="nobody:nobody"` with alpine image