### PR TITLE
feat(sdk): add rootfs_path support to SimpleBox (Python + Node.js)

### DIFF
--- a/sdks/node/lib/simplebox.ts
+++ b/sdks/node/lib/simplebox.ts
@@ -24,6 +24,9 @@ export interface SimpleBoxOptions {
   /** Container image to use (e.g., 'python:slim', 'alpine:latest') */
   image?: string;
 
+  /** Path to local OCI layout directory (overrides image if provided) */
+  rootfsPath?: string;
+
   /** Memory limit in MiB */
   memoryMib?: number;
 
@@ -175,6 +178,7 @@ export class SimpleBox {
     // Convert options to BoxOptions format (stored for lazy creation)
     this._boxOpts = {
       image: options.image,
+      rootfsPath: options.rootfsPath,
       cpus: options.cpus,
       memoryMib: options.memoryMib,
       autoRemove: options.autoRemove ?? true,

--- a/sdks/python/boxlite/simplebox.py
+++ b/sdks/python/boxlite/simplebox.py
@@ -41,7 +41,8 @@ class SimpleBox:
 
     def __init__(
         self,
-        image: str,
+        image: Optional[str] = None,
+        rootfs_path: Optional[str] = None,
         memory_mib: Optional[int] = None,
         cpus: Optional[int] = None,
         runtime: Optional["Boxlite"] = None,
@@ -54,7 +55,8 @@ class SimpleBox:
         Create a specialized box.
 
         Args:
-            image: Container images to use
+            image: Container image to use (e.g., "python:3.12-slim")
+            rootfs_path: Path to local OCI layout directory (overrides image if provided)
             memory_mib: Memory limit in MiB
             cpus: Number of CPU cores
             runtime: Optional runtime instance (uses global default if None)
@@ -66,7 +68,12 @@ class SimpleBox:
 
         Note: The box is not actually created until entering the async context manager.
         Use `async with SimpleBox(...) as box:` to create and start the box.
+
+        Either `image` or `rootfs_path` must be provided.
         """
+        if not image and not rootfs_path:
+            raise ValueError("Either 'image' or 'rootfs_path' must be provided")
+
         try:
             from .boxlite import Boxlite, BoxOptions
         except ImportError as e:
@@ -84,6 +91,7 @@ class SimpleBox:
         # Store box options for deferred creation in __aenter__
         self._box_options = BoxOptions(
             image=image,
+            rootfs_path=rootfs_path,
             cpus=cpus,
             memory_mib=memory_mib,
             auto_remove=auto_remove,

--- a/sdks/python/boxlite/sync_api/_simplebox.py
+++ b/sdks/python/boxlite/sync_api/_simplebox.py
@@ -38,7 +38,8 @@ class SyncSimpleBox:
 
     def __init__(
         self,
-        image: str,
+        image: Optional[str] = None,
+        rootfs_path: Optional[str] = None,
         memory_mib: Optional[int] = None,
         cpus: Optional[int] = None,
         runtime: Optional["SyncBoxlite"] = None,
@@ -52,6 +53,7 @@ class SyncSimpleBox:
 
         Args:
             image: Container image to use (e.g., "python:slim", "ubuntu:latest")
+            rootfs_path: Path to local OCI layout directory (overrides image if provided)
             memory_mib: Memory limit in MiB (default: system default)
             cpus: Number of CPU cores (default: system default)
             runtime: Optional SyncBoxlite runtime. If None, creates default runtime.
@@ -60,7 +62,12 @@ class SyncSimpleBox:
             reuse_existing: If True and a box with the given name already exists,
                 reuse it instead of raising an error (default: False)
             **kwargs: Additional BoxOptions parameters
+
+        Either `image` or `rootfs_path` must be provided.
         """
+        if not image and not rootfs_path:
+            raise ValueError("Either 'image' or 'rootfs_path' must be provided")
+
         from ._boxlite import SyncBoxlite
         from ..boxlite import BoxOptions
 
@@ -76,6 +83,7 @@ class SyncSimpleBox:
         # Create box options
         self._box_opts = BoxOptions(
             image=image,
+            rootfs_path=rootfs_path,
             cpus=cpus,
             memory_mib=memory_mib,
             auto_remove=auto_remove,


### PR DESCRIPTION
## Summary
- Expose `rootfs_path` / `rootfsPath` option in high-level SimpleBox APIs for Python and Node.js SDKs
- Allows using local OCI layout directories instead of pulling images from a registry
- Validates that either `image` or `rootfs_path` is provided

## Changes
- **Python**: `SimpleBox(rootfs_path="/path/to/oci-layout")` and `SyncSimpleBox(rootfs_path=...)`
- **Node.js**: `new SimpleBox({ rootfsPath: "/path/to/oci-layout" })`
- Rust napi/PyO3 bindings already support `rootfs_path` in `BoxOptions`; this PR exposes it in the high-level wrappers

## Test plan
- [ ] `make test:python` passes
- [ ] `make test:node` passes
- [ ] Manual test: create a SimpleBox with `rootfs_path` pointing to a local OCI layout