### PR TITLE
fix(examples): skip reuse_existing when unsupported

### DIFF
--- a/examples/python/simplebox_example.py
+++ b/examples/python/simplebox_example.py
@@ -12,6 +12,7 @@ Demonstrates core BoxLite features using SimpleBox directly:
 """
 
 import asyncio
+import inspect
 import logging
 import sys
 
@@ -27,6 +28,15 @@ def setup_logging():
         format="%(asctime)s [%(levelname)s] %(message)s",
         handlers=[logging.StreamHandler(sys.stdout)],
     )
+
+
+def supports_reuse_existing() -> bool:
+    """Detect whether the installed SimpleBox supports reuse_existing."""
+    try:
+        params = inspect.signature(boxlite.SimpleBox.__init__).parameters
+    except (TypeError, ValueError):
+        return False
+    return "reuse_existing" in params
 
 
 async def example_basic():
@@ -135,6 +145,11 @@ async def example_reuse_existing():
     print("\n\n=== Example 6: Reuse Existing Box ===")
 
     name = "reuse-demo"
+
+    if not supports_reuse_existing():
+        print("Skipping: installed boxlite does not support reuse_existing.")
+        print("Upgrade boxlite or install from source to enable this example.")
+        return
 
     # First call creates a new box
     async with boxlite.SimpleBox(

--- a/examples/python/sync_simplebox_example.py
+++ b/examples/python/sync_simplebox_example.py
@@ -13,6 +13,7 @@ Demonstrates core BoxLite features using SyncSimpleBox directly:
 Requires: pip install boxlite[sync]
 """
 
+import inspect
 import logging
 import sys
 
@@ -28,6 +29,15 @@ def setup_logging():
         format="%(asctime)s [%(levelname)s] %(message)s",
         handlers=[logging.StreamHandler(sys.stdout)],
     )
+
+
+def supports_reuse_existing() -> bool:
+    """Detect whether the installed SyncSimpleBox supports reuse_existing."""
+    try:
+        params = inspect.signature(boxlite.SyncSimpleBox.__init__).parameters
+    except (TypeError, ValueError):
+        return False
+    return "reuse_existing" in params
 
 
 def example_basic():
@@ -138,6 +148,11 @@ def example_reuse_existing():
     from boxlite.sync_api import SyncBoxlite
 
     name = "sync-reuse-demo"
+
+    if not supports_reuse_existing():
+        print("Skipping: installed boxlite does not support reuse_existing.")
+        print("Upgrade boxlite or install from source to enable this example.")
+        return
 
     # Nested SyncSimpleBox instances must share a single runtime,
     # because the sync API runs one greenlet event loop that cannot


### PR DESCRIPTION
## Summary
- guard the reuse_existing example with a runtime capability check
- skip the example on older SDK installs instead of raising BoxOptions errors

## Test plan
- not run (examples only)

Made with [Cursor](https://cursor.com)