### PR TITLE
allow the node sdk to support persistent disks

### DIFF
--- a/sdks/node/lib/simplebox.ts
+++ b/sdks/node/lib/simplebox.ts
@@ -33,6 +33,9 @@ export interface SimpleBoxOptions {
   /** Number of CPU cores */
   cpus?: number;
 
+  /** Disk size in GB for container rootfs (sparse, grows as needed) */
+  diskSizeGb?: number;
+
   /** Optional runtime instance (uses global default if not provided) */
   runtime?: Boxlite;
 
@@ -181,6 +184,7 @@ export class SimpleBox {
       rootfsPath: options.rootfsPath,
       cpus: options.cpus,
       memoryMib: options.memoryMib,
+      diskSizeGb: options.diskSizeGb,
       autoRemove: options.autoRemove ?? true,
       detach: options.detach ?? false,
       workingDir: options.workingDir,

--- a/sdks/node/tests/options.test.ts
+++ b/sdks/node/tests/options.test.ts
@@ -82,4 +82,39 @@ describe('SimpleBoxOptions', () => {
     expect(opts.memoryMib).toBe(1024);
     expect(opts.cpus).toBe(2);
   });
+
+  test('diskSizeGb defaults to undefined', () => {
+    const opts: SimpleBoxOptions = {};
+    expect(opts.diskSizeGb).toBeUndefined();
+  });
+
+  test('accepts diskSizeGb number', () => {
+    const opts: SimpleBoxOptions = {
+      image: 'python:slim',
+      diskSizeGb: 10,
+    };
+    expect(opts.diskSizeGb).toBe(10);
+  });
+
+  test('accepts fractional diskSizeGb', () => {
+    const opts: SimpleBoxOptions = {
+      image: 'alpine:latest',
+      diskSizeGb: 5.5,
+    };
+    expect(opts.diskSizeGb).toBe(5.5);
+  });
+
+  test('diskSizeGb can be combined with other options', () => {
+    const opts: SimpleBoxOptions = {
+      image: 'python:slim',
+      memoryMib: 1024,
+      cpus: 2,
+      diskSizeGb: 20,
+      env: { FOO: 'bar' },
+    };
+
+    expect(opts.diskSizeGb).toBe(20);
+    expect(opts.memoryMib).toBe(1024);
+    expect(opts.cpus).toBe(2);
+  });
 });


### PR DESCRIPTION
It looks like the rust FFI already supports the persistent disk option disk_size_gb but the node SDK didn't expose the option. It was difficult to actually manually test this so I'm not 100% sure I didn't miss something.