### PR TITLE
feat(cli): implement  info command for `boxlite-cli`

### DIFF
--- a/boxlite-cli/src/cli.rs
+++ b/boxlite-cli/src/cli.rs
@@ -144,20 +144,18 @@ pub struct GlobalFlags {
 }
 
 impl GlobalFlags {
-    pub fn create_runtime(&self) -> anyhow::Result<BoxliteRuntime> {
-        // Load config file if provided, otherwise use default options
+    /// Resolve runtime options from config file and CLI overrides (--home, --registry).
+    pub fn resolve_runtime_options(&self) -> anyhow::Result<BoxliteOptions> {
         let mut options = if let Some(config_path) = &self.config {
             crate::config::load_config(Path::new(config_path))?
         } else {
             BoxliteOptions::default()
         };
 
-        // CLI --home override home_dir
         if let Some(cli_home) = &self.home {
             options.home_dir = cli_home.clone();
         }
 
-        // CLI --registry prepends to image_registries (highest priority)
         if !self.registry.is_empty() {
             options.image_registries = self
                 .registry
@@ -167,7 +165,20 @@ impl GlobalFlags {
                 .collect();
         }
 
+        Ok(options)
+    }
+
+    /// Create a runtime from pre-resolved options (avoids resolving twice when caller already has options).
+    pub fn create_runtime_with_options(
+        &self,
+        options: BoxliteOptions,
+    ) -> anyhow::Result<BoxliteRuntime> {
         BoxliteRuntime::new(options).map_err(Into::into)
+    }
+
+    pub fn create_runtime(&self) -> anyhow::Result<BoxliteRuntime> {
+        let options = self.resolve_runtime_options()?;
+        self.create_runtime_with_options(options)
     }
 }
 

--- a/boxlite-cli/src/commands/info.rs
+++ b/boxlite-cli/src/commands/info.rs
@@ -1,7 +1,25 @@
 use crate::cli::GlobalFlags;
 use crate::formatter;
+use boxlite::BoxStatus;
 use clap::Args;
 use clap::ValueEnum;
+use serde::Serialize;
+
+/// System-wide runtime information (CLI output shape).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SystemInfo {
+    version: String,
+    home_dir: String,
+    virtualization: String,
+    os: String,
+    arch: String,
+    boxes_total: u32,
+    boxes_running: u32,
+    boxes_stopped: u32,
+    boxes_configured: u32,
+    images_count: u32,
+}
 
 /// Display system-wide runtime information (default: YAML).
 #[derive(Args, Debug)]
@@ -19,8 +37,43 @@ pub enum InfoFormat {
 }
 
 pub async fn execute(args: InfoArgs, global: &GlobalFlags) -> anyhow::Result<()> {
-    let rt = global.create_runtime()?;
-    let info = rt.system_info().await?;
+    let options = global.resolve_runtime_options()?;
+    let home_dir = options.home_dir.to_string_lossy().to_string();
+
+    let rt = global.create_runtime_with_options(options)?;
+    let version = boxlite::VERSION.to_string();
+    let virtualization = boxlite::vmm::host_check::check_virtualization_support()
+        .map(|s| s.reason)
+        .unwrap_or_else(|e| format!("unavailable: {}", e));
+    let os = std::env::consts::OS.to_string();
+    let arch = std::env::consts::ARCH.to_string();
+
+    let boxes_list = rt.list_info().await?;
+    let boxes_total = boxes_list.len() as u32;
+    let boxes_running = boxes_list.iter().filter(|b| b.status.is_active()).count() as u32;
+    let boxes_stopped = boxes_list
+        .iter()
+        .filter(|b| b.status == BoxStatus::Stopped)
+        .count() as u32;
+    let boxes_configured = boxes_list
+        .iter()
+        .filter(|b| b.status == BoxStatus::Configured)
+        .count() as u32;
+
+    let images_count = rt.list_images().await?.len() as u32;
+
+    let info = SystemInfo {
+        version,
+        home_dir,
+        virtualization,
+        os,
+        arch,
+        boxes_total,
+        boxes_running,
+        boxes_stopped,
+        boxes_configured,
+        images_count,
+    };
 
     let out = match args.format {
         InfoFormat::Yaml => formatter::format_yaml(&info)?,

--- a/boxlite-cli/tests/info.rs
+++ b/boxlite-cli/tests/info.rs
@@ -1,31 +1,24 @@
 //! Info command tests.
 //! Default output is YAML (Podman-style). Only json/yaml formats supported.
+//! Assertions use serde_json::Value (sqlx-cli / inspect.rs style), no duplicate structs.
 
-use boxlite::SystemInfo;
 use predicates::prelude::*;
 
 mod common;
 
-fn system_info_json_keys() -> Vec<String> {
-    let sample = SystemInfo {
-        version: String::new(),
-        home_dir: String::new(),
-        virtualization: String::new(),
-        os: String::new(),
-        arch: String::new(),
-        boxes_total: 0,
-        boxes_running: 0,
-        boxes_stopped: 0,
-        boxes_configured: 0,
-        images_count: 0,
-    };
-    let v = serde_json::to_value(&sample).expect("serialize SystemInfo");
-    v.as_object()
-        .expect("object")
-        .keys()
-        .map(String::from)
-        .collect()
-}
+/// Expected top-level keys for `boxlite info --format json` (camelCase, must match info command).
+const INFO_JSON_KEYS: &[&str] = &[
+    "version",
+    "homeDir",
+    "virtualization",
+    "os",
+    "arch",
+    "boxesTotal",
+    "boxesRunning",
+    "boxesStopped",
+    "boxesConfigured",
+    "imagesCount",
+];
 
 #[test]
 fn test_info_default_is_yaml() {
@@ -45,38 +38,23 @@ fn test_info_default_is_yaml() {
 #[test]
 fn test_info_json_format() {
     let mut ctx = common::boxlite();
-    let assert = ctx
-        .cmd
-        .args(["info", "--format", "json"])
-        .assert()
-        .success();
-    let output = assert.get_output();
-    let stdout = std::str::from_utf8(&output.stdout).unwrap();
-
-    assert!(stdout.trim().starts_with('{'));
-    assert!(stdout.trim().ends_with('}'));
-
-    for key in system_info_json_keys() {
-        assert!(
-            stdout.contains(&format!("\"{}\"", key)),
-            "JSON must contain key {:?}",
-            key
-        );
+    let output = ctx.cmd.args(["info", "--format", "json"]).output().unwrap();
+    assert!(output.status.success());
+    let v: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("info --format json should be valid JSON");
+    let obj = v.as_object().expect("root should be object");
+    for key in INFO_JSON_KEYS {
+        assert!(obj.contains_key(*key), "JSON must contain key {:?}", key);
     }
 }
 
 #[test]
 fn test_info_yaml_format() {
     let mut ctx = common::boxlite();
-    let assert = ctx
-        .cmd
-        .args(["info", "--format", "yaml"])
-        .assert()
-        .success();
-    let output = assert.get_output();
+    let output = ctx.cmd.args(["info", "--format", "yaml"]).output().unwrap();
+    assert!(output.status.success());
     let stdout = std::str::from_utf8(&output.stdout).unwrap();
-
-    for key in system_info_json_keys() {
+    for key in INFO_JSON_KEYS {
         let needle = format!("{}:", key);
         assert!(stdout.contains(&needle), "YAML must contain {:?}:", key);
     }
@@ -99,17 +77,29 @@ fn test_info_box_counts() {
         .unwrap();
     assert!(output.status.success());
 
-    let stdout = String::from_utf8(output.stdout).unwrap();
-    let info: SystemInfo =
-        serde_json::from_str(stdout.trim()).expect("valid JSON roundtrip to SystemInfo");
-    assert!(
-        info.boxes_total >= 1,
-        "expected at least one box after create"
-    );
-    // Breakdown must sum to total (only created box: configured or stopped)
+    let v: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("info --format json should be valid JSON");
+    let obj = v.as_object().expect("root should be object");
+    let boxes_total = obj
+        .get("boxesTotal")
+        .and_then(|n| n.as_u64())
+        .expect("boxesTotal");
+    let boxes_running = obj
+        .get("boxesRunning")
+        .and_then(|n| n.as_u64())
+        .unwrap_or(0);
+    let boxes_stopped = obj
+        .get("boxesStopped")
+        .and_then(|n| n.as_u64())
+        .unwrap_or(0);
+    let boxes_configured = obj
+        .get("boxesConfigured")
+        .and_then(|n| n.as_u64())
+        .unwrap_or(0);
+    assert!(boxes_total >= 1, "expected at least one box after create");
     assert_eq!(
-        info.boxes_configured + info.boxes_stopped + info.boxes_running,
-        info.boxes_total,
+        boxes_configured + boxes_stopped + boxes_running,
+        boxes_total,
         "box count breakdown must sum to total"
     );
 
@@ -132,11 +122,15 @@ fn test_info_version_present() {
     let mut ctx = common::boxlite();
     let output = ctx.cmd.args(["info", "--format", "json"]).output().unwrap();
     assert!(output.status.success());
-    let info: SystemInfo =
-        serde_json::from_slice(&output.stdout).expect("valid JSON roundtrip to SystemInfo");
-    assert!(!info.version.is_empty(), "version must not be empty");
+    let v: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("info --format json should be valid JSON");
+    let version = v
+        .get("version")
+        .and_then(|s| s.as_str())
+        .expect("version key present");
+    assert!(!version.is_empty(), "version must not be empty");
     assert!(
-        info.version.chars().any(|c| c.is_ascii_digit()),
+        version.chars().any(|c| c.is_ascii_digit()),
         "version should contain a digit"
     );
 }
@@ -161,16 +155,14 @@ fn test_info_format_table_rejected() {
 }
 
 #[test]
-fn test_info_json_roundtrip() {
+fn test_info_json_has_expected_keys() {
     let mut ctx = common::boxlite();
     let output = ctx.cmd.args(["info", "--format", "json"]).output().unwrap();
     assert!(output.status.success());
-    let info: SystemInfo =
-        serde_json::from_slice(&output.stdout).expect("valid JSON roundtrip to SystemInfo");
-    let expected_keys = system_info_json_keys();
-    let actual: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
-    for key in &expected_keys {
-        assert!(actual.get(key).is_some(), "JSON must contain key {:?}", key);
+    let v: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("info --format json should be valid JSON");
+    let obj = v.as_object().expect("root should be object");
+    for key in INFO_JSON_KEYS {
+        assert!(obj.contains_key(*key), "JSON must contain key {:?}", key);
     }
-    let _ = info;
 }

--- a/boxlite/src/lib.rs
+++ b/boxlite/src/lib.rs
@@ -39,8 +39,11 @@ use runtime::layout::FilesystemLayout;
 pub use runtime::options::{
     BoxOptions, BoxliteOptions, ResourceLimits, RootfsSpec, SecurityOptions,
 };
+/// Boxlite library version (from CARGO_PKG_VERSION at compile time).
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
 pub use runtime::types::ContainerID;
-pub use runtime::types::{BoxID, BoxInfo, BoxState, BoxStateInfo, BoxStatus, SystemInfo};
+pub use runtime::types::{BoxID, BoxInfo, BoxState, BoxStateInfo, BoxStatus};
 
 /// Initialize tracing for Boxlite using the provided filesystem layout.
 ///

--- a/boxlite/src/runtime/core.rs
+++ b/boxlite/src/runtime/core.rs
@@ -7,7 +7,7 @@ use crate::metrics::RuntimeMetrics;
 use crate::runtime::options::{BoxOptions, BoxliteOptions};
 use crate::runtime::rt_impl::{RuntimeImpl, SharedRuntimeImpl};
 use crate::runtime::signal_handler::install_signal_handler;
-use crate::runtime::types::{BoxInfo, SystemInfo};
+use crate::runtime::types::BoxInfo;
 use boxlite_shared::errors::{BoxliteError, BoxliteResult};
 // ============================================================================
 // GLOBAL DEFAULT RUNTIME
@@ -238,11 +238,6 @@ impl BoxliteRuntime {
     /// Get runtime-wide metrics.
     pub async fn metrics(&self) -> RuntimeMetrics {
         self.rt_impl.metrics().await
-    }
-
-    /// Get system-wide runtime information.
-    pub async fn system_info(&self) -> BoxliteResult<SystemInfo> {
-        self.rt_impl.system_info().await
     }
 
     /// Remove a box completely by ID or name.

--- a/boxlite/src/runtime/rt_impl.rs
+++ b/boxlite/src/runtime/rt_impl.rs
@@ -11,7 +11,7 @@ use crate::runtime::layout::{FilesystemLayout, FsLayoutConfig};
 use crate::runtime::lock::RuntimeLock;
 use crate::runtime::options::{BoxOptions, BoxliteOptions};
 use crate::runtime::signal_handler::timeout_to_duration;
-use crate::runtime::types::{BoxID, BoxInfo, BoxState, BoxStatus, ContainerID, SystemInfo};
+use crate::runtime::types::{BoxID, BoxInfo, BoxState, BoxStatus, ContainerID};
 use crate::vmm::VmmKind;
 use boxlite_shared::{BoxliteError, BoxliteResult, Transport};
 use chrono::Utc;
@@ -521,45 +521,6 @@ impl RuntimeImpl {
     /// Get runtime-wide metrics.
     pub async fn metrics(&self) -> RuntimeMetrics {
         RuntimeMetrics::new(self.runtime_metrics.clone())
-    }
-
-    /// Get system-wide runtime information.
-    pub async fn system_info(self: &Arc<Self>) -> BoxliteResult<SystemInfo> {
-        let version = env!("CARGO_PKG_VERSION").to_string();
-        let home_dir = self.layout.home_dir().to_string_lossy().to_string();
-        let virtualization = crate::vmm::host_check::check_virtualization_support()
-            .map(|s| s.reason)
-            .unwrap_or_else(|e| format!("unavailable: {}", e));
-        let os = std::env::consts::OS.to_string();
-        let arch = std::env::consts::ARCH.to_string();
-
-        let boxes_list = self.list_info().await?;
-        let boxes_total = boxes_list.len() as u32;
-        let boxes_running = boxes_list.iter().filter(|b| b.status.is_active()).count() as u32;
-        let boxes_stopped = boxes_list
-            .iter()
-            .filter(|b| b.status == BoxStatus::Stopped)
-            .count() as u32;
-        let boxes_configured = boxes_list
-            .iter()
-            .filter(|b| b.status == BoxStatus::Configured)
-            .count() as u32;
-
-        let images = self.image_manager.list().await?;
-        let images_count = images.len() as u32;
-
-        Ok(SystemInfo {
-            version,
-            home_dir,
-            virtualization,
-            os,
-            arch,
-            boxes_total,
-            boxes_running,
-            boxes_stopped,
-            boxes_configured,
-            images_count,
-        })
     }
 
     // ========================================================================

--- a/boxlite/src/runtime/types.rs
+++ b/boxlite/src/runtime/types.rs
@@ -528,38 +528,6 @@ pub struct ImageInfo {
 }
 
 // ============================================================================
-// SYSTEM INFO (runtime-wide)
-// ============================================================================
-
-/// System-wide runtime information.
-///
-/// Contains version, paths, host/virtualization info, and box/image counts.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct SystemInfo {
-    /// Runtime/workspace version (e.g. from CARGO_PKG_VERSION).
-    pub version: String,
-    /// BOXLITE_HOME directory (absolute path).
-    pub home_dir: String,
-    /// Virtualization support status (human-readable).
-    pub virtualization: String,
-    /// Operating system (e.g. "macos", "linux").
-    pub os: String,
-    /// Architecture (e.g. "aarch64", "x86_64").
-    pub arch: String,
-    /// Total number of boxes.
-    pub boxes_total: u32,
-    /// Number of running boxes.
-    pub boxes_running: u32,
-    /// Number of stopped boxes.
-    pub boxes_stopped: u32,
-    /// Number of configured (created but never started) boxes.
-    pub boxes_configured: u32,
-    /// Number of cached images.
-    pub images_count: u32,
-}
-
-// ============================================================================
 // BOX CONFIG (Podman-style separation)
 // ============================================================================
 


### PR DESCRIPTION
## Info

https://github.com/boxlite-ai/boxlite/issues/35


## Key Changes
-  Add `boxlite info` for system-wide runtime info
- Add Runtime `**VERSION**` in boxlite.
- Add `info` subcommand with --format yaml|json (default: yaml).
- Add integration tests for info JSON/YAML output and roundtrip.
- docs about how to use `inspect`,`info` and `-p -v `in README

## Testing

- [x] make test:cli
- [x] make test:rust
- [x] manually test `./target/debug/boxlite info`


```
./target/debug/boxlite info
version: 0.5.8
homeDir: /Users/goranka/.boxlite
virtualization: Hypervisor.framework is available (Apple Silicon)
os: macos
arch: aarch64
boxesTotal: 3
boxesRunning: 0
boxesStopped: 2
boxesConfigured: 1
imagesCount: 4
```


```
./target/debug/boxlite info --format json
{
  "version": "0.5.8",
  "homeDir": "/Users/goranka/.boxlite",
  "virtualization": "Hypervisor.framework is available (Apple Silicon)",
  "os": "macos",
  "arch": "aarch64",
  "boxesTotal": 3,
  "boxesRunning": 0,
  "boxesStopped": 2,
  "boxesConfigured": 1,
  "imagesCount": 4
}
```