### PR TITLE
chore: update Cargo.lock for version 0.5.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,7 +302,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -363,7 +363,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-c"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "boxlite",
  "cbindgen",
@@ -399,7 +399,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-guest"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -428,7 +428,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-node"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "boxlite",
  "boxlite-shared",
@@ -442,7 +442,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-python"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "boxlite",
  "futures",
@@ -455,7 +455,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-shared"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "prost",
  "serde",


### PR DESCRIPTION
## Summary
- Update Cargo.lock to reflect version 0.5.9 changes from #203

## Test plan
- [ ] CI passes