### PR TITLE
chore: bump SDK versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,7 +302,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -363,7 +363,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-c"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "boxlite",
  "cbindgen",
@@ -404,7 +404,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-guest"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -433,7 +433,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-node"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "boxlite",
  "boxlite-shared",
@@ -447,7 +447,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-python"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "boxlite",
  "futures",
@@ -460,7 +460,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-shared"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "prost",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = ["build/tmp", "target", ".venv", "examples/*/.venv"]
 resolver = "2"
 
 [workspace.package]
-version = "0.5.9"
+version = "0.5.10"
 edition = "2024"
 authors = ["Dorian Zheng <https://github.com/dorianzheng>"]
 license = "Apache-2.0"

--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boxlite-ai/boxlite",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "BoxLite - Embeddable micro-VM runtime for secure, isolated code execution",
   "type": "module",
   "main": "dist/index.js",

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "boxlite"
-version = "0.5.9"
+version = "0.5.10"
 description = "Python bindings for Boxlite runtime"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Bump workspace/Rust/C/Python SDK versions: 0.5.9 → 0.5.10
- Bump Node.js SDK version: 0.2.6 → 0.2.7

## Files Changed
- `Cargo.toml` - workspace version
- `Cargo.lock` - updated lockfile
- `sdks/python/pyproject.toml` - Python package version
- `sdks/node/package.json` - Node.js package version