### PR TITLE
fix(error): prevent cleanup error from masking original error

### DIFF
--- a/boxlite/src/db/boxes.rs
+++ b/boxlite/src/db/boxes.rs
@@ -112,7 +112,7 @@ impl BoxStore {
 
         // Podman pattern: verify rows were actually updated
         if rows_affected == 0 {
-            return Err(BoxliteError::NotFound(format!("Box not found: {}", box_id)));
+            return Err(BoxliteError::NotFound(box_id.to_string()));
         }
 
         Ok(())

--- a/boxlite/src/litebox/manager.rs
+++ b/boxlite/src/litebox/manager.rs
@@ -165,7 +165,7 @@ impl BoxManager {
     pub fn update_box(&self, id: &BoxID) -> BoxliteResult<BoxState> {
         self.store
             .load_state(id.as_str())?
-            .ok_or_else(|| BoxliteError::NotFound(format!("box {} state not found", id)))
+            .ok_or_else(|| BoxliteError::NotFound(id.to_string()))
     }
 
     // ========================================================================

--- a/boxlite/src/runtime/rt_impl.rs
+++ b/boxlite/src/runtime/rt_impl.rs
@@ -771,7 +771,7 @@ impl RuntimeImpl {
         }
 
         // Box not found anywhere
-        Err(BoxliteError::NotFound(format!("Box not found: {}", id)))
+        Err(BoxliteError::NotFound(id.to_string()))
     }
 
     // ========================================================================

--- a/sdks/c/src/ffi.rs
+++ b/sdks/c/src/ffi.rs
@@ -710,7 +710,7 @@ pub unsafe extern "C" fn boxlite_get_info(
             }
         }
         Ok(None) => {
-            let err = BoxliteError::NotFound(format!("Box not found: {}", id_str));
+            let err = BoxliteError::NotFound(id_str.clone());
             write_error(out_error, err);
             BoxliteErrorCode::NotFound
         }
@@ -773,7 +773,7 @@ pub unsafe extern "C" fn boxlite_get(
             BoxliteErrorCode::Ok
         }
         Ok(None) => {
-            let err = BoxliteError::NotFound(format!("Box not found: {}", id_str));
+            let err = BoxliteError::NotFound(id_str.clone());
             write_error(out_error, err);
             BoxliteErrorCode::NotFound
         }


### PR DESCRIPTION
## Summary

- Fix error masking when box initialization fails (e.g., image pull failure)
- Remove redundant "Box not found:" prefix from NotFound error messages

## Problem

When using a non-existent image, users saw:
```
box not found: Box not found: 01KGSJN01NWS16RJATH7C2N2Q7
```

Instead of the actual error:
```
storage error: Failed to pull image 'xxx' after trying 1 registry
```

**Root cause:** When `start()` fails during image pull, `CleanupGuard::drop()` removes the box from DB. Then `stop()` in the finally block tries to save to a deleted box, and that `NotFound` error overwrites the original error.

## Changes

| File | Change |
|------|--------|
| `box_impl.rs` | Handle `NotFound` in `stop()` gracefully - if box already removed, return `Ok(())` |
| `boxes.rs`, `rt_impl.rs`, `manager.rs`, `ffi.rs` | Remove redundant "Box not found:" prefix |

## Test plan

- [x] `cargo check` passes
- [x] Tested with non-existent image - now shows proper error message