### PR TITLE
fix(python): make cloudpickle an optional dependency

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -98,7 +98,7 @@ jobs:
 
       - name: Install wheel
         run: |
-          # Use --find-links to let pip select the compatible wheel
+          # --no-index ensures wheel has no external dependencies (acts as lint)
           pip install --find-links=wheelhouse --no-index boxlite
 
       - name: Test import

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -139,6 +139,22 @@ jobs:
         working-directory: sdks/python
         run: ruff format --check .
 
+      - name: Check no required dependencies
+        working-directory: sdks/python
+        run: |
+          # Ensure core package has no required dependencies (optional deps OK)
+          python -c "
+          import tomllib
+          with open('pyproject.toml', 'rb') as f:
+              config = tomllib.load(f)
+          deps = config.get('project', {}).get('dependencies', [])
+          if deps:
+              print(f'ERROR: pyproject.toml has required dependencies: {deps}')
+              print('Move dependencies to [project.optional-dependencies] instead.')
+              exit(1)
+          print('✓ No required dependencies')
+          "
+
   node:
     name: Node.js Lint
     needs: changes

--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boxlite-ai/boxlite",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "BoxLite - Embeddable micro-VM runtime for secure, isolated code execution",
   "type": "module",
   "main": "dist/index.js",

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.10"
 authors = [{ name = "Dorian Zheng" }]
 license = "Apache-2.0"
 keywords = ["sandbox", "virtual machine", "vm", "ai agents", "code execution", "isolation", "container", "security", "kvm", "hypervisor"]
-dependencies = ["cloudpickle>=3.0"]
+dependencies = []
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
@@ -33,6 +33,7 @@ Issues = "https://github.com/boxlite-ai/boxlite/issues"
 [project.optional-dependencies]
 dev = ["pytest>=7.0", "pytest-asyncio>=0.21"]
 sync = ["greenlet>=3.0.0"]
+orchestration = ["cloudpickle>=3.0"]
 
 [build-system]
 requires = ["maturin>=1.4,<2.0"]


### PR DESCRIPTION
## Summary

- Move cloudpickle from required dependencies to optional `[orchestration]` extra
- Add lint check in CI to enforce no required dependencies in Python SDK
- Update `--no-index` comment in build-wheels.yml to document its lint purpose
- Bump Node SDK version to 0.2.7

## Problem

The wheel test job was failing with:
```
ERROR: Could not find a version that satisfies the requirement cloudpickle>=3.0
```

The `--no-index` flag prevents PyPI access, but cloudpickle wasn't in the wheelhouse.

## Solution

cloudpickle is only used by `BoxRuntime` (multi-box orchestration), which is already wrapped in `try/except ImportError`. Making it optional aligns the dependency declaration with the existing code pattern.

**Before:**
```bash
pip install boxlite  # Requires cloudpickle
```

**After:**
```bash
pip install boxlite              # Zero dependencies
pip install boxlite[orchestration]  # With BoxRuntime support
```

## Test plan

- [ ] lint.yml job passes (includes new "Check no required dependencies" step)
- [ ] build-wheels.yml workflow passes when triggered manually
- [ ] `python -c "import boxlite"` works without cloudpickle installed
- [ ] `pip install boxlite[orchestration]` + `from boxlite import BoxRuntime` works