### PR TITLE
Refactor: Extract FFI code to dedicated crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,11 +365,8 @@ dependencies = [
 name = "boxlite-c"
 version = "0.5.10"
 dependencies = [
- "boxlite",
+ "boxlite-ffi",
  "cbindgen",
- "futures",
- "serde_json",
- "tokio",
 ]
 
 [[package]]
@@ -400,6 +397,17 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "ulid",
+]
+
+[[package]]
+name = "boxlite-ffi"
+version = "0.5.10"
+dependencies = [
+ "boxlite",
+ "futures",
+ "serde_json",
+ "tempfile",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "boxlite/deps/libkrun-sys",
     "boxlite-shared",
     "guest",
+    "sdks/boxlite-ffi",
     "sdks/c",
     "sdks/python",
     "sdks/node",

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ help:
 	@echo "  Testing:"
 	@echo "    make test           - Run all unit tests (Rust + Python + Node.js)"
 	@echo "    make test:rust      - Run Rust unit tests"
+	@echo "    make test:ffi       - Run BoxLite FFI unit tests"
 	@echo "    make test:python    - Run Python SDK unit tests"
 	@echo "    make test:node      - Run Node.js SDK unit tests"
 	@echo "    make test:cli       - Run CLI integration tests (prepares runtime first)"
@@ -177,8 +178,10 @@ dev\:node: runtime-debug
 # Run all unit tests (excludes integration tests that require VMs)
 test:
 	@$(MAKE) test:rust
+	@$(MAKE) test:ffi
 	@$(MAKE) test:python
 	@$(MAKE) test:node
+	@$(MAKE) test:c
 	@echo "✅ All tests passed"
 
 # Run Rust unit tests (single-threaded, without gvproxy to avoid Go runtime issues)
@@ -186,6 +189,12 @@ test\:rust:
 	@echo "🧪 Running Rust unit tests..."
 	@cargo test -p boxlite --no-default-features --lib -- --test-threads=1
 	@cargo test -p boxlite-shared --lib -- --test-threads=1
+
+# Run BoxLite FFI unit tests
+test\:ffi:
+	@echo "🧪 Running BoxLite FFI unit tests..."
+	@cargo test -p boxlite-ffi
+
 
 # Run Python SDK unit tests (excludes integration tests)
 test\:python:

--- a/boxlite/src/litebox/box_impl.rs
+++ b/boxlite/src/litebox/box_impl.rs
@@ -329,8 +329,13 @@ impl BoxImpl {
         // Update state
         {
             let mut state = self.state.write();
-            state.set_status(BoxStatus::Stopped);
-            state.set_pid(None);
+
+            // Only transition to Stopped if we were Running (or other active state).
+            // If we were Configured (never started), stay Configured so next start()
+            // triggers full initialization (creating disks).
+            if !state.status.is_configured() {
+                state.mark_stop();
+            }
 
             if was_persisted {
                 // Box was persisted - sync to DB

--- a/boxlite/src/runtime/options.rs
+++ b/boxlite/src/runtime/options.rs
@@ -550,6 +550,7 @@ impl Default for BoxliteOptions {
 
 /// Options used when constructing a box.
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(default)]
 pub struct BoxOptions {
     pub cpus: Option<u8>,
     pub memory_mib: Option<u32>,

--- a/sdks/boxlite-ffi/Cargo.toml
+++ b/sdks/boxlite-ffi/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "boxlite-ffi"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "Shared FFI layer for BoxLite SDKs"
+
+[lib]
+crate-type = ["rlib"]
+
+[features]
+default = []
+gvproxy-backend = ["boxlite/gvproxy-backend"]
+libslirp-backend = ["boxlite/libslirp-backend"]
+
+[dependencies]
+boxlite = { path = "../../boxlite" }
+
+tokio = { version = "1.37", features = ["rt", "rt-multi-thread"] }
+serde_json = "1.0"
+futures = "0.3"
+
+[dev-dependencies]
+tempfile = "3.10"
+

--- a/sdks/boxlite-ffi/src/error.rs
+++ b/sdks/boxlite-ffi/src/error.rs
@@ -1,0 +1,144 @@
+//! Error handling utilities for BoxLite FFI
+//!
+//! Provides error codes and conversion functions for C API error handling.
+
+use std::ffi::CString;
+use std::os::raw::c_char;
+use std::ptr;
+
+use boxlite::BoxliteError;
+
+// ============================================================================
+// Error Code Enum - Maps to BoxliteError variants
+// ============================================================================
+
+/// Error codes returned by BoxLite C API functions.
+///
+/// These codes map directly to Rust's BoxliteError variants,
+/// allowing programmatic error handling in C.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BoxliteErrorCode {
+    /// Operation succeeded
+    Ok = 0,
+    /// Internal error
+    Internal = 1,
+    /// Resource not found
+    NotFound = 2,
+    /// Resource already exists
+    AlreadyExists = 3,
+    /// Invalid state for operation
+    InvalidState = 4,
+    /// Invalid argument provided
+    InvalidArgument = 5,
+    /// Configuration error
+    Config = 6,
+    /// Storage error
+    Storage = 7,
+    /// Image error
+    Image = 8,
+    /// Network error
+    Network = 9,
+    /// Execution error
+    Execution = 10,
+    /// Resource stopped
+    Stopped = 11,
+    /// Engine error
+    Engine = 12,
+    /// Unsupported operation
+    Unsupported = 13,
+    /// Database error
+    Database = 14,
+    /// Portal/communication error
+    Portal = 15,
+    /// RPC error
+    Rpc = 16,
+    /// RPC transport error
+    RpcTransport = 17,
+    /// Metadata error
+    Metadata = 18,
+    /// Unsupported engine error
+    UnsupportedEngine = 19,
+}
+
+/// Extended error information for C API.
+///
+/// Contains both an error code (for programmatic handling)
+/// and an optional detailed message (for debugging).
+#[repr(C)]
+pub struct FFIError {
+    /// Error code
+    pub code: BoxliteErrorCode,
+    /// Detailed error message (NULL if none, caller must free with boxlite_error_free)
+    pub message: *mut c_char,
+}
+
+impl Default for FFIError {
+    fn default() -> Self {
+        FFIError {
+            code: BoxliteErrorCode::Ok,
+            message: ptr::null_mut(),
+        }
+    }
+}
+
+/// Map BoxliteError to BoxliteErrorCode
+pub fn error_to_code(err: &BoxliteError) -> BoxliteErrorCode {
+    match err {
+        BoxliteError::Internal(_) => BoxliteErrorCode::Internal,
+        BoxliteError::NotFound(_) => BoxliteErrorCode::NotFound,
+        BoxliteError::AlreadyExists(_) => BoxliteErrorCode::AlreadyExists,
+        BoxliteError::InvalidState(_) => BoxliteErrorCode::InvalidState,
+        BoxliteError::InvalidArgument(_) => BoxliteErrorCode::InvalidArgument,
+        BoxliteError::Config(_) => BoxliteErrorCode::Config,
+        BoxliteError::Storage(_) => BoxliteErrorCode::Storage,
+        BoxliteError::Image(_) => BoxliteErrorCode::Image,
+        BoxliteError::Network(_) => BoxliteErrorCode::Network,
+        BoxliteError::Execution(_) => BoxliteErrorCode::Execution,
+        BoxliteError::Stopped(_) => BoxliteErrorCode::Stopped,
+        BoxliteError::Engine(_) => BoxliteErrorCode::Engine,
+        BoxliteError::Unsupported(_) => BoxliteErrorCode::Unsupported,
+        BoxliteError::UnsupportedEngine => BoxliteErrorCode::UnsupportedEngine,
+        BoxliteError::Database(_) => BoxliteErrorCode::Database,
+        BoxliteError::Portal(_) => BoxliteErrorCode::Portal,
+        BoxliteError::Rpc(_) => BoxliteErrorCode::Rpc,
+        BoxliteError::RpcTransport(_) => BoxliteErrorCode::RpcTransport,
+        BoxliteError::MetadataError(_) => BoxliteErrorCode::Metadata,
+    }
+}
+
+/// Convert Rust error to C string (caller must free)
+pub fn error_to_c_string(err: &BoxliteError) -> *mut c_char {
+    let msg = format!("{}", err);
+    match CString::new(msg) {
+        Ok(s) => s.into_raw(),
+        Err(_) => {
+            let fallback = CString::new("Failed to format error message").unwrap();
+            fallback.into_raw()
+        }
+    }
+}
+
+/// Convert Rust error to C error struct
+pub fn error_to_c_error(err: BoxliteError) -> FFIError {
+    let code = error_to_code(&err);
+    let message = error_to_c_string(&err);
+    FFIError { code, message }
+}
+
+/// Write error to output parameter (if not NULL)
+///
+/// # Safety
+/// out_error must be null or a valid pointer to FFIError
+pub unsafe fn write_error(out_error: *mut FFIError, err: BoxliteError) {
+    unsafe {
+        if !out_error.is_null() {
+            *out_error = error_to_c_error(err);
+        }
+    }
+}
+
+/// Helper to create InvalidArgument error for NULL pointers
+pub fn null_pointer_error(param_name: &str) -> BoxliteError {
+    BoxliteError::InvalidArgument(format!("{} is null", param_name))
+}

--- a/sdks/boxlite-ffi/src/json.rs
+++ b/sdks/boxlite-ffi/src/json.rs
@@ -1,0 +1,33 @@
+//! JSON serialization utilities for BoxLite FFI
+//!
+//! Provides functions for converting BoxLite types to JSON.
+
+use boxlite::runtime::types::{BoxInfo, BoxStatus};
+
+/// Convert BoxStatus to string representation
+pub fn status_to_string(status: BoxStatus) -> &'static str {
+    match status {
+        BoxStatus::Unknown => "unknown",
+        BoxStatus::Configured => "configured",
+        BoxStatus::Running => "running",
+        BoxStatus::Stopping => "stopping",
+        BoxStatus::Stopped => "stopped",
+    }
+}
+
+/// Convert BoxInfo to JSON with nested state structure
+pub fn box_info_to_json(info: &BoxInfo) -> serde_json::Value {
+    serde_json::json!({
+        "id": info.id.to_string(),
+        "name": info.name,
+        "state": {
+            "status": status_to_string(info.status),
+            "running": info.status.is_running(),
+            "pid": info.pid
+        },
+        "created_at": info.created_at.to_rfc3339(),
+        "image": info.image,
+        "cpus": info.cpus,
+        "memory_mib": info.memory_mib
+    })
+}

--- a/sdks/boxlite-ffi/src/lib.rs
+++ b/sdks/boxlite-ffi/src/lib.rs
@@ -1,0 +1,20 @@
+//! Shared FFI layer for BoxLite SDKs
+//!
+//! This crate provides common utilities for C FFI bindings across all BoxLite SDKs:
+//! - Error handling and error codes
+//! - C string allocation and parsing
+//! - JSON serialization helpers
+//! - Runtime management (Tokio + BoxliteRuntime)
+//! - Core FFI operations implementation
+
+pub mod error;
+pub mod json;
+pub mod ops;
+pub mod runner;
+pub mod runtime;
+pub mod string;
+
+pub use error::*;
+pub use json::*;
+pub use runtime::*;
+pub use string::*;

--- a/sdks/boxlite-ffi/src/ops.rs
+++ b/sdks/boxlite-ffi/src/ops.rs
@@ -1,0 +1,1386 @@
+//! Core FFI operations for BoxLite
+//!
+//! This module contains the internal implementation of FFI operations.
+//! These functions are called by the SDK-specific FFI exports.
+
+use futures::StreamExt;
+use std::ffi::{CString, c_void};
+use std::os::raw::{c_char, c_int};
+use std::ptr;
+
+use boxlite::litebox::LiteBox;
+use boxlite::runtime::BoxliteRuntime;
+use boxlite::runtime::options::{BoxOptions, BoxliteOptions};
+use boxlite::runtime::types::BoxID;
+use boxlite::{BoxliteError, RootfsSpec};
+
+use crate::error::{BoxliteErrorCode, FFIError, error_to_code, null_pointer_error, write_error};
+use crate::json::box_info_to_json;
+use crate::runtime::{BoxHandle, RuntimeHandle, create_tokio_runtime};
+use crate::string::c_str_to_string;
+
+/// Create a new BoxliteRuntime
+///
+/// # Parameters
+/// * `home_dir`: Optional path to home directory (or null for default `~/.boxlite`)
+/// * `registries_json`: Optional JSON array of registry URLs (or null)
+/// * `out_runtime`: Output pointer for the created `RuntimeHandle`
+/// * `out_error`: Output pointer for error details
+///
+/// # Implementation Note
+/// This function initializes both the Tokio runtime and the BoxLite runtime.
+/// It parses the optional `home_dir` and `registries_json` arguments.
+/// If `registries_json` is provided, it attempts to parse it as a JSON array of strings.
+///
+/// # Safety
+/// All pointer parameters must be valid or null. `out_runtime` must be a valid pointer to a pointer.
+pub unsafe fn runtime_new(
+    home_dir: *const c_char,
+    registries_json: *const c_char,
+    out_runtime: *mut *mut RuntimeHandle,
+    out_error: *mut FFIError,
+) -> BoxliteErrorCode {
+    unsafe {
+        if out_runtime.is_null() {
+            write_error(out_error, null_pointer_error("out_runtime"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+
+        // Create tokio runtime
+        let tokio_rt = match create_tokio_runtime() {
+            Ok(rt) => rt,
+            Err(e) => {
+                let err = BoxliteError::Internal(e);
+                write_error(out_error, err);
+                return BoxliteErrorCode::Internal;
+            }
+        };
+
+        // Parse options
+        let mut options = BoxliteOptions::default();
+        if !home_dir.is_null() {
+            match c_str_to_string(home_dir) {
+                Ok(path) => options.home_dir = path.into(),
+                Err(e) => {
+                    write_error(out_error, e);
+                    return BoxliteErrorCode::InvalidArgument;
+                }
+            }
+        }
+
+        // Parse image registries (JSON array)
+        if !registries_json.is_null() {
+            match c_str_to_string(registries_json) {
+                Ok(json_str) => match serde_json::from_str::<Vec<String>>(&json_str) {
+                    Ok(registries) => options.image_registries = registries,
+                    Err(e) => {
+                        let err = BoxliteError::Internal(format!("Invalid registries JSON: {}", e));
+                        write_error(out_error, err);
+                        return BoxliteErrorCode::Internal;
+                    }
+                },
+                Err(e) => {
+                    write_error(out_error, e);
+                    return BoxliteErrorCode::InvalidArgument;
+                }
+            }
+        }
+
+        // Create runtime
+        let runtime = match BoxliteRuntime::new(options) {
+            Ok(rt) => rt,
+            Err(e) => {
+                let code = error_to_code(&e);
+                write_error(out_error, e);
+                return code;
+            }
+        };
+
+        *out_runtime = Box::into_raw(Box::new(RuntimeHandle { runtime, tokio_rt }));
+        BoxliteErrorCode::Ok
+    }
+}
+
+/// Create a new box
+///
+/// # Parameters
+/// * `runtime`: Pointer to the `RuntimeHandle`
+/// * `options_json`: JSON string defining the box configuration
+/// * `name`: Optional name for the box (or null)
+/// * `out_box`: Output pointer for the created `BoxHandle`
+/// * `out_error`: Output pointer for error details
+///
+/// # Implementation Note
+/// This function creates a new box within the given runtime.
+/// It parses the `options_json` string into `BoxOptions`.
+/// The operation is asynchronous, so it blocks on the runtime's Tokio executor.
+///
+/// # Safety
+/// All pointer parameters must be valid or null.
+pub unsafe fn box_create(
+    runtime: *mut RuntimeHandle,
+    options_json: *const c_char,
+    name: *const c_char,
+    out_box: *mut *mut BoxHandle,
+    out_error: *mut FFIError,
+) -> BoxliteErrorCode {
+    unsafe {
+        if runtime.is_null() {
+            write_error(out_error, null_pointer_error("runtime"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        if out_box.is_null() {
+            write_error(out_error, null_pointer_error("out_box"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+
+        let runtime_ref = &mut *runtime;
+
+        // Parse JSON options
+        let options_str = match c_str_to_string(options_json) {
+            Ok(s) => s,
+            Err(e) => {
+                write_error(out_error, e);
+                return BoxliteErrorCode::InvalidArgument;
+            }
+        };
+
+        // Parse optional name
+        let name_opt = if name.is_null() {
+            None
+        } else {
+            match c_str_to_string(name) {
+                Ok(s) => Some(s),
+                Err(e) => {
+                    write_error(out_error, e);
+                    return BoxliteErrorCode::InvalidArgument;
+                }
+            }
+        };
+
+        let options: BoxOptions = match serde_json::from_str(&options_str) {
+            Ok(opts) => opts,
+            Err(e) => {
+                let err = BoxliteError::Internal(format!("Invalid JSON options: {}", e));
+                write_error(out_error, err);
+                return BoxliteErrorCode::InvalidArgument;
+            }
+        };
+
+        // Create box
+        // create() is async, so we block on the tokio runtime
+        let result = runtime_ref
+            .tokio_rt
+            .block_on(runtime_ref.runtime.create(options, name_opt));
+
+        match result {
+            Ok(handle) => {
+                let box_id = handle.id().clone();
+                *out_box = Box::into_raw(Box::new(BoxHandle {
+                    handle,
+                    box_id,
+                    tokio_rt: runtime_ref.tokio_rt.clone(),
+                }));
+                BoxliteErrorCode::Ok
+            }
+            Err(e) => {
+                let code = error_to_code(&e);
+                write_error(out_error, e);
+                code
+            }
+        }
+    }
+}
+
+/// List all boxes as JSON
+///
+/// # Parameters
+/// * `runtime`: Pointer to the `RuntimeHandle`
+/// * `out_json`: Output pointer for the JSON string (must be freed)
+/// * `out_error`: Output pointer for error details
+///
+/// # Implementation Note
+/// Retrieves the list of all boxes from the runtime and serializes them to a JSON string.
+/// The JSON string is allocated as a CString and must be freed by the caller using `string_free`.
+///
+/// # Safety
+/// All pointer parameters must be valid or null.
+pub unsafe fn box_list(
+    runtime: *mut RuntimeHandle,
+    out_json: *mut *mut c_char,
+    out_error: *mut FFIError,
+) -> BoxliteErrorCode {
+    unsafe {
+        if runtime.is_null() {
+            write_error(out_error, null_pointer_error("runtime"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        if out_json.is_null() {
+            write_error(out_error, null_pointer_error("out_json"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+
+        let runtime_ref = &*runtime;
+
+        let result = runtime_ref
+            .tokio_rt
+            .block_on(runtime_ref.runtime.list_info());
+
+        match result {
+            Ok(boxes) => {
+                let json_array: Vec<serde_json::Value> =
+                    boxes.iter().map(box_info_to_json).collect();
+                let json_str = match serde_json::to_string(&json_array) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        let err =
+                            BoxliteError::Internal(format!("JSON serialization failed: {}", e));
+                        write_error(out_error, err);
+                        return BoxliteErrorCode::Internal;
+                    }
+                };
+
+                match CString::new(json_str) {
+                    Ok(s) => {
+                        *out_json = s.into_raw();
+                        BoxliteErrorCode::Ok
+                    }
+                    Err(e) => {
+                        let err =
+                            BoxliteError::Internal(format!("CString conversion failed: {}", e));
+                        write_error(out_error, err);
+                        BoxliteErrorCode::Internal
+                    }
+                }
+            }
+            Err(e) => {
+                let code = error_to_code(&e);
+                write_error(out_error, e);
+                code
+            }
+        }
+    }
+}
+
+/// Stop a box
+///
+/// # Parameters
+/// * `handle`: Pointer to the `BoxHandle`
+/// * `out_error`: Output pointer for error details
+///
+/// # Implementation Note
+/// Stops the execution of a box. This is an async operation that is blocked on.
+///
+/// # Safety
+/// handle must be a valid pointer to `BoxHandle`.
+pub unsafe fn box_stop(handle: *mut BoxHandle, out_error: *mut FFIError) -> BoxliteErrorCode {
+    unsafe {
+        if handle.is_null() {
+            write_error(out_error, null_pointer_error("handle"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+
+        let handle_ref = Box::from_raw(handle);
+
+        // Block on async stop using the stored tokio runtime
+        let result = handle_ref.tokio_rt.block_on(handle_ref.handle.stop());
+        match result {
+            Ok(_) => BoxliteErrorCode::Ok,
+            Err(e) => {
+                let code = error_to_code(&e);
+                write_error(out_error, e);
+                code
+            }
+        }
+    }
+}
+
+/// Inspect single box info as JSON
+///
+/// # Parameters
+/// * `runtime`: Pointer to the `RuntimeHandle`
+/// * `id_or_name`: ID or name of the box to inspect
+/// * `out_json`: Output pointer for the JSON string
+/// * `out_error`: Output pointer for error details
+///
+/// # Implementation Note
+/// Retrieves detailed information about a specific box identified by ID or name.
+/// The result is serialized to JSON.
+///
+/// # Safety
+/// All pointer parameters must be valid or null.
+pub unsafe fn box_inspect(
+    runtime: *mut RuntimeHandle,
+    id_or_name: *const c_char,
+    out_json: *mut *mut c_char,
+    out_error: *mut FFIError,
+) -> BoxliteErrorCode {
+    unsafe {
+        if runtime.is_null() {
+            write_error(out_error, null_pointer_error("runtime"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        if out_json.is_null() {
+            write_error(out_error, null_pointer_error("out_json"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+
+        let runtime_ref = &*runtime;
+
+        let id_str = match c_str_to_string(id_or_name) {
+            Ok(s) => s,
+            Err(e) => {
+                write_error(out_error, e);
+                return BoxliteErrorCode::InvalidArgument;
+            }
+        };
+
+        let result = runtime_ref
+            .tokio_rt
+            .block_on(runtime_ref.runtime.get_info(&id_str));
+
+        match result {
+            Ok(Some(info)) => {
+                let json_str = match serde_json::to_string(&box_info_to_json(&info)) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        let err =
+                            BoxliteError::Internal(format!("JSON serialization failed: {}", e));
+                        write_error(out_error, err);
+                        return BoxliteErrorCode::Internal;
+                    }
+                };
+
+                match CString::new(json_str) {
+                    Ok(s) => {
+                        *out_json = s.into_raw();
+                        BoxliteErrorCode::Ok
+                    }
+                    Err(e) => {
+                        let err =
+                            BoxliteError::Internal(format!("CString conversion failed: {}", e));
+                        write_error(out_error, err);
+                        BoxliteErrorCode::Internal
+                    }
+                }
+            }
+            Ok(None) => {
+                let err = BoxliteError::NotFound(format!("Box not found: {}", id_str));
+                write_error(out_error, err);
+                BoxliteErrorCode::NotFound
+            }
+            Err(e) => {
+                let code = error_to_code(&e);
+                write_error(out_error, e);
+                code
+            }
+        }
+    }
+}
+
+/// Attach to an existing box
+///
+/// # Parameters
+/// * `runtime`: Pointer to the `RuntimeHandle`
+/// * `id_or_name`: ID or name of the box to attach to
+/// * `out_handle`: Output pointer for the attached `BoxHandle`
+/// * `out_error`: Output pointer for error details
+///
+/// # Implementation Note
+/// Gets a handle to an existing box. This allows performing operations on a box
+/// that was created previously or listed.
+///
+/// # Safety
+/// All pointer parameters must be valid or null.
+pub unsafe fn box_attach(
+    runtime: *mut RuntimeHandle,
+    id_or_name: *const c_char,
+    out_handle: *mut *mut BoxHandle,
+    out_error: *mut FFIError,
+) -> BoxliteErrorCode {
+    unsafe {
+        if runtime.is_null() {
+            write_error(out_error, null_pointer_error("runtime"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        if out_handle.is_null() {
+            write_error(out_error, null_pointer_error("out_handle"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+
+        let runtime_ref = &*runtime;
+
+        let id_str = match c_str_to_string(id_or_name) {
+            Ok(s) => s,
+            Err(e) => {
+                write_error(out_error, e);
+                return BoxliteErrorCode::InvalidArgument;
+            }
+        };
+
+        let result = runtime_ref
+            .tokio_rt
+            .block_on(runtime_ref.runtime.get(&id_str));
+
+        match result {
+            Ok(Some(handle)) => {
+                let box_id = handle.id().clone();
+                *out_handle = Box::into_raw(Box::new(BoxHandle {
+                    handle,
+                    box_id,
+                    tokio_rt: runtime_ref.tokio_rt.clone(),
+                }));
+                BoxliteErrorCode::Ok
+            }
+            Ok(None) => {
+                let err = BoxliteError::NotFound(format!("Box not found: {}", id_str));
+                write_error(out_error, err);
+                BoxliteErrorCode::NotFound
+            }
+            Err(e) => {
+                let code = error_to_code(&e);
+                write_error(out_error, e);
+                code
+            }
+        }
+    }
+}
+
+/// Remove a box
+///
+/// # Parameters
+/// * `runtime`: Pointer to the `RuntimeHandle`
+/// * `id_or_name`: ID or name of the box to remove
+/// * `force`: If true, force remove even if running
+/// * `out_error`: Output pointer for error details
+///
+/// # Implementation Note
+/// Removes a box from the runtime. If `force` is true, it attempts to stop the box if running.
+///
+/// # Safety
+/// All pointer parameters must be valid or null.
+pub unsafe fn box_remove(
+    runtime: *mut RuntimeHandle,
+    id_or_name: *const c_char,
+    force: bool,
+    out_error: *mut FFIError,
+) -> BoxliteErrorCode {
+    unsafe {
+        if runtime.is_null() {
+            write_error(out_error, null_pointer_error("runtime"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+
+        let runtime_ref = &*runtime;
+
+        let id_str = match c_str_to_string(id_or_name) {
+            Ok(s) => s,
+            Err(e) => {
+                write_error(out_error, e);
+                return BoxliteErrorCode::InvalidArgument;
+            }
+        };
+
+        let result = runtime_ref
+            .tokio_rt
+            .block_on(runtime_ref.runtime.remove(&id_str, force));
+
+        match result {
+            Ok(_) => BoxliteErrorCode::Ok,
+            Err(e) => {
+                let code = error_to_code(&e);
+                write_error(out_error, e);
+                code
+            }
+        }
+    }
+}
+
+/// Get runtime metrics as JSON
+///
+/// # Parameters
+/// * `runtime`: Pointer to the `RuntimeHandle`
+/// * `out_json`: Output pointer for the JSON string
+/// * `out_error`: Output pointer for error details
+///
+/// # Implementation Note
+/// Aggregates metrics for the entire runtime and serializes them to JSON.
+///
+/// # Safety
+/// All pointer parameters must be valid or null.
+pub unsafe fn runtime_metrics(
+    runtime: *mut RuntimeHandle,
+    out_json: *mut *mut c_char,
+    out_error: *mut FFIError,
+) -> BoxliteErrorCode {
+    unsafe {
+        if runtime.is_null() {
+            write_error(out_error, null_pointer_error("runtime"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        if out_json.is_null() {
+            write_error(out_error, null_pointer_error("out_json"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+
+        let runtime_ref = &*runtime;
+        let metrics = runtime_ref.tokio_rt.block_on(runtime_ref.runtime.metrics());
+
+        let json = serde_json::json!({
+            "boxes_created_total": metrics.boxes_created_total(),
+            "boxes_failed_total": metrics.boxes_failed_total(),
+            "num_running_boxes": metrics.num_running_boxes(),
+            "total_commands_executed": metrics.total_commands_executed(),
+            "total_exec_errors": metrics.total_exec_errors()
+        });
+
+        let json_str = match serde_json::to_string(&json) {
+            Ok(s) => s,
+            Err(e) => {
+                let err = BoxliteError::Internal(format!("JSON serialization failed: {}", e));
+                write_error(out_error, err);
+                return BoxliteErrorCode::Internal;
+            }
+        };
+
+        match CString::new(json_str) {
+            Ok(s) => {
+                *out_json = s.into_raw();
+                BoxliteErrorCode::Ok
+            }
+            Err(e) => {
+                let err = BoxliteError::Internal(format!("CString conversion failed: {}", e));
+                write_error(out_error, err);
+                BoxliteErrorCode::Internal
+            }
+        }
+    }
+}
+
+/// Gracefully shutdown all boxes in this runtime
+///
+/// # Parameters
+/// * `runtime`: Pointer to the `RuntimeHandle`
+/// * `timeout`: Optional timeout in seconds
+/// * `out_error`: Output pointer for error details
+///
+/// # Implementation Note
+/// Attempts to stop all running boxes. Accepts an optional timeout via `Option<i32>`.
+///
+/// # Safety
+/// All pointer parameters must be valid or null.
+pub unsafe fn runtime_shutdown(
+    runtime: *mut RuntimeHandle,
+    timeout: Option<i32>,
+    out_error: *mut FFIError,
+) -> BoxliteErrorCode {
+    unsafe {
+        if runtime.is_null() {
+            write_error(out_error, null_pointer_error("runtime"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+
+        let runtime_ref = &*runtime;
+
+        let result = runtime_ref
+            .tokio_rt
+            .block_on(runtime_ref.runtime.shutdown(timeout));
+
+        match result {
+            Ok(()) => BoxliteErrorCode::Ok,
+            Err(e) => {
+                let code = error_to_code(&e);
+                write_error(out_error, e);
+                code
+            }
+        }
+    }
+}
+
+pub type OutputCallback = extern "C" fn(*const c_char, c_int, *mut c_void);
+
+/// Execute a command in a box
+///
+/// # Parameters
+/// * `handle`: Pointer to the `BoxHandle`
+/// * `command`: Command to execute (e.g., "/bin/sh")
+/// * `args_json`: JSON string of arguments (e.g., `["-c", "echo hello"]`)
+/// * `callback`: Optional callback function for streaming output
+/// * `user_data`: User data pointer to be passed to the callback
+/// * `out_exit_code`: Output pointer for the exit code
+/// * `out_error`: Output pointer for error details
+///
+/// # Implementation Note
+/// Executes a command inside the container. Supports streaming output via a callback function.
+/// Takes arguments as a JSON string.
+///
+/// # Safety
+/// All pointer parameters must be valid or null.
+///
+pub unsafe fn box_exec(
+    handle: *mut BoxHandle,
+    command: *const c_char,
+    args_json: *const c_char,
+    callback: Option<OutputCallback>,
+    user_data: *mut c_void,
+    out_exit_code: *mut c_int,
+    out_error: *mut FFIError,
+) -> BoxliteErrorCode {
+    unsafe {
+        if handle.is_null() {
+            write_error(out_error, null_pointer_error("handle"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+
+        if out_exit_code.is_null() {
+            write_error(out_error, null_pointer_error("out_exit_code"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+
+        let handle_ref = &mut *handle;
+
+        // Parse command
+        let cmd_str = match c_str_to_string(command) {
+            Ok(s) => s,
+            Err(e) => {
+                let code = error_to_code(&e);
+                write_error(out_error, e);
+                return code;
+            }
+        };
+
+        // Parse args
+        let args: Vec<String> = if !args_json.is_null() {
+            match c_str_to_string(args_json) {
+                Ok(json_str) => match serde_json::from_str(&json_str) {
+                    Ok(a) => a,
+                    Err(e) => {
+                        let err = BoxliteError::Internal(format!("Invalid args JSON: {}", e));
+                        write_error(out_error, err);
+                        return BoxliteErrorCode::InvalidArgument;
+                    }
+                },
+                Err(e) => {
+                    let code = error_to_code(&e);
+                    write_error(out_error, e);
+                    return code;
+                }
+            }
+        } else {
+            vec![]
+        };
+
+        let mut cmd = boxlite::BoxCommand::new(cmd_str);
+        cmd = cmd.args(args);
+
+        // Execute command using new API
+        let result = handle_ref.tokio_rt.block_on(async {
+            let mut execution = handle_ref.handle.exec(cmd).await?;
+
+            // Stream output to callback if provided
+            if let Some(cb) = callback {
+                use futures::StreamExt;
+
+                // Take stdout and stderr
+                let mut stdout = execution.stdout();
+                let mut stderr = execution.stderr();
+
+                // Read both streams
+                loop {
+                    tokio::select! {
+                        Some(line) = async {
+                            match &mut stdout {
+                                Some(s) => s.next().await,
+                                None => None,
+                            }
+                        } => {
+                            let c_text = CString::new(line).unwrap_or_default();
+                            cb(c_text.as_ptr(), 0, user_data); // 0 = stdout
+                        }
+                        Some(line) = async {
+                            match &mut stderr {
+                                Some(s) => s.next().await,
+                                None => None,
+                            }
+                        } => {
+                            let c_text = CString::new(line).unwrap_or_default();
+                            cb(c_text.as_ptr(), 1, user_data); // 1 = stderr
+                        }
+                        else => break,
+                    }
+                }
+            }
+            // Now wait for completion (should not deadlock due to output backpressure)
+            let status = execution.wait().await?;
+            Ok::<i32, BoxliteError>(status.exit_code)
+        });
+
+        match result {
+            Ok(exit_code) => {
+                *out_exit_code = exit_code;
+                BoxliteErrorCode::Ok
+            }
+            Err(e) => {
+                let code = error_to_code(&e);
+                write_error(out_error, e);
+                code
+            }
+        }
+    }
+}
+
+/// Get box info from handle as JSON
+///
+/// # Parameters
+/// * `handle`: Pointer to the `BoxHandle`
+/// * `out_json`: Output pointer for the JSON string
+/// * `out_error`: Output pointer for error details
+///
+/// # Implementation Note
+/// Retrieves info for a box handle. Useful for getting the status of an attached box.
+///
+/// # Safety
+/// All pointer parameters must be valid or null.
+pub unsafe fn box_inspect_handle(
+    handle: *mut BoxHandle,
+    out_json: *mut *mut c_char,
+    out_error: *mut FFIError,
+) -> BoxliteErrorCode {
+    unsafe {
+        if handle.is_null() {
+            write_error(out_error, null_pointer_error("handle"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        if out_json.is_null() {
+            write_error(out_error, null_pointer_error("out_json"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+
+        let handle_ref = &*handle;
+        let info = handle_ref.handle.info();
+
+        let json_str = match serde_json::to_string(&box_info_to_json(&info)) {
+            Ok(s) => s,
+            Err(e) => {
+                let err = BoxliteError::Internal(format!("JSON serialization failed: {}", e));
+                write_error(out_error, err);
+                return BoxliteErrorCode::Internal;
+            }
+        };
+
+        match CString::new(json_str) {
+            Ok(s) => {
+                *out_json = s.into_raw();
+                BoxliteErrorCode::Ok
+            }
+            Err(e) => {
+                let err = BoxliteError::Internal(format!("CString conversion failed: {}", e));
+                write_error(out_error, err);
+                BoxliteErrorCode::Internal
+            }
+        }
+    }
+}
+
+/// Get box metrics from handle as JSON
+///
+/// # Implementation Note
+/// Retrieves real-time metrics for a specific box.
+///
+/// # Safety
+/// All pointer parameters must be valid or null.
+pub unsafe fn box_metrics(
+    handle: *mut BoxHandle,
+    out_json: *mut *mut c_char,
+    out_error: *mut FFIError,
+) -> BoxliteErrorCode {
+    unsafe {
+        if handle.is_null() {
+            write_error(out_error, null_pointer_error("handle"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        if out_json.is_null() {
+            write_error(out_error, null_pointer_error("out_json"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+
+        let handle_ref = &*handle;
+
+        let result = handle_ref.tokio_rt.block_on(handle_ref.handle.metrics());
+
+        match result {
+            Ok(metrics) => {
+                let json = serde_json::json!({
+                    "cpu_percent": metrics.cpu_percent,
+                    "memory_bytes": metrics.memory_bytes,
+                    "commands_executed_total": metrics.commands_executed_total,
+                    "exec_errors_total": metrics.exec_errors_total,
+                    "bytes_sent_total": metrics.bytes_sent_total,
+                    "bytes_received_total": metrics.bytes_received_total,
+                    "total_create_duration_ms": metrics.total_create_duration_ms,
+                    "guest_boot_duration_ms": metrics.guest_boot_duration_ms,
+                    "network_bytes_sent": metrics.network_bytes_sent,
+                    "network_bytes_received": metrics.network_bytes_received,
+                    "network_tcp_connections": metrics.network_tcp_connections,
+                    "network_tcp_errors": metrics.network_tcp_errors
+                });
+
+                let json_str = match serde_json::to_string(&json) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        let err =
+                            BoxliteError::Internal(format!("JSON serialization failed: {}", e));
+                        write_error(out_error, err);
+                        return BoxliteErrorCode::Internal;
+                    }
+                };
+
+                match CString::new(json_str) {
+                    Ok(s) => {
+                        *out_json = s.into_raw();
+                        BoxliteErrorCode::Ok
+                    }
+                    Err(e) => {
+                        let err =
+                            BoxliteError::Internal(format!("CString conversion failed: {}", e));
+                        write_error(out_error, err);
+                        BoxliteErrorCode::Internal
+                    }
+                }
+            }
+            Err(e) => {
+                let code = error_to_code(&e);
+                write_error(out_error, e);
+                code
+            }
+        }
+    }
+}
+
+/// Free a runtime instance
+///
+/// # Parameters
+/// * `runtime`: Pointer to `RuntimeHandle`
+///
+/// # Implementation Note
+/// Releases the `RuntimeHandle` and drops the Tokio runtime.
+///
+/// # Safety
+/// runtime must be null or a valid pointer to RuntimeHandle
+pub unsafe fn runtime_free(runtime: *mut RuntimeHandle) {
+    if !runtime.is_null() {
+        unsafe {
+            drop(Box::from_raw(runtime));
+        }
+    }
+}
+
+/// Free a string allocated by BoxLite
+///
+/// # Parameters
+/// * `str`: Pointer to the string
+///
+/// # Implementation Note
+/// Frees a `CString` that was allocated by Rust and passed to C.
+///
+/// # Safety
+/// str must be null or a valid pointer to c_char allocated by CString
+pub unsafe fn string_free(str: *mut c_char) {
+    if !str.is_null() {
+        unsafe {
+            drop(CString::from_raw(str));
+        }
+    }
+}
+
+/// Free error struct
+///
+/// # Implementation Note
+/// Frees the `message` string within the `FFIError` struct and resets the code.
+///
+/// # Safety
+/// error must be null or a valid pointer to FFIError
+pub unsafe fn error_free(error: *mut FFIError) {
+    if !error.is_null() {
+        unsafe {
+            let err = &mut *error;
+            if !err.message.is_null() {
+                drop(CString::from_raw(err.message));
+                err.message = ptr::null_mut();
+            }
+            err.code = BoxliteErrorCode::Ok;
+        }
+    }
+}
+
+/// Get BoxLite version string
+///
+/// # Implementation Note
+/// Returns a static C string containing the package version.
+/// This string is statically allocated and should NOT be freed.
+///
+/// # Returns
+/// Static string containing the version (e.g., "0.1.0")
+pub extern "C" fn version() -> *const c_char {
+    // Static string, safe to return pointer
+    concat!(env!("CARGO_PKG_VERSION"), "\0").as_ptr() as *const c_char
+}
+
+/// Create and start a box runner
+///
+/// # Implementation Note
+/// Creates a `BoxRunner` which encapsulates a runtime and a single box.
+/// Simplified API for quick execution.
+///
+/// # Safety
+/// All pointers must be valid
+pub unsafe fn runner_new(
+    image: *const c_char,
+    cpus: c_int,
+    memory_mib: c_int,
+    out_runner: *mut *mut crate::runner::BoxRunner,
+    out_error: *mut FFIError,
+) -> BoxliteErrorCode {
+    unsafe {
+        if image.is_null() {
+            write_error(out_error, null_pointer_error("image"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        if out_runner.is_null() {
+            write_error(out_error, null_pointer_error("out_runner"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+
+        let image_str = match c_str_to_string(image) {
+            Ok(s) => s,
+            Err(e) => {
+                write_error(out_error, e);
+                return BoxliteErrorCode::InvalidArgument;
+            }
+        };
+
+        let tokio_rt = match create_tokio_runtime() {
+            Ok(rt) => rt,
+            Err(e) => {
+                let err = BoxliteError::Internal(format!("Failed to create async runtime: {}", e));
+                write_error(out_error, err);
+                return BoxliteErrorCode::Internal;
+            }
+        };
+
+        let runtime = match BoxliteRuntime::new(BoxliteOptions::default()) {
+            Ok(rt) => rt,
+            Err(e) => {
+                write_error(out_error, e);
+                return BoxliteErrorCode::Internal;
+            }
+        };
+
+        let options = BoxOptions {
+            rootfs: RootfsSpec::Image(image_str),
+            cpus: if cpus > 0 { Some(cpus as u8) } else { None },
+            memory_mib: if memory_mib > 0 {
+                Some(memory_mib as u32)
+            } else {
+                None
+            },
+            ..Default::default()
+        };
+
+        let result = tokio_rt.block_on(async {
+            let handle = runtime.create(options, None).await?;
+            let box_id = handle.id().clone();
+            Ok::<(LiteBox, BoxID), BoxliteError>((handle, box_id))
+        });
+
+        match result {
+            Ok((handle, box_id)) => {
+                let runner = Box::new(crate::runner::BoxRunner::new(
+                    runtime, handle, box_id, tokio_rt,
+                ));
+                *out_runner = Box::into_raw(runner);
+                BoxliteErrorCode::Ok
+            }
+            Err(e) => {
+                let code = error_to_code(&e);
+                write_error(out_error, e);
+                code
+            }
+        }
+    }
+}
+
+/// Run a command using the runner
+///
+/// # Implementation Note
+/// Executes a command on the runner's box. Returns buffered stdout/stderr.
+///
+/// # Safety
+/// All pointers must be valid
+pub unsafe fn runner_exec(
+    runner: *mut crate::runner::BoxRunner,
+    command: *const c_char,
+    args: *const *const c_char,
+    argc: c_int,
+    out_result: *mut *mut crate::runner::ExecResult,
+    out_error: *mut FFIError,
+) -> BoxliteErrorCode {
+    unsafe {
+        if runner.is_null() {
+            write_error(out_error, null_pointer_error("runner"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        if command.is_null() {
+            write_error(out_error, null_pointer_error("command"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        if out_result.is_null() {
+            write_error(out_error, null_pointer_error("out_result"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+
+        let runner_ref = &mut *runner;
+
+        let cmd_str = match c_str_to_string(command) {
+            Ok(s) => s,
+            Err(e) => {
+                write_error(out_error, e);
+                return BoxliteErrorCode::InvalidArgument;
+            }
+        };
+
+        let mut arg_vec = Vec::new();
+        if !args.is_null() {
+            for i in 0..argc {
+                let arg_ptr = *args.offset(i as isize);
+                if arg_ptr.is_null() {
+                    break;
+                }
+                match c_str_to_string(arg_ptr) {
+                    Ok(s) => arg_vec.push(s),
+                    Err(e) => {
+                        write_error(out_error, e);
+                        return BoxliteErrorCode::InvalidArgument;
+                    }
+                }
+            }
+        }
+
+        let handle = match &runner_ref.handle {
+            Some(h) => h,
+            None => {
+                write_error(
+                    out_error,
+                    BoxliteError::InvalidState("Box not initialized".to_string()),
+                );
+                return BoxliteErrorCode::InvalidState;
+            }
+        };
+
+        let result = runner_ref.tokio_rt.block_on(async {
+            let mut cmd = boxlite::BoxCommand::new(cmd_str);
+            cmd = cmd.args(arg_vec);
+
+            let mut execution = handle.exec(cmd).await?;
+
+            let mut stdout_lines = Vec::new();
+            let mut stderr_lines = Vec::new();
+
+            let mut stdout_stream = execution.stdout();
+            let mut stderr_stream = execution.stderr();
+
+            loop {
+                tokio::select! {
+                    Some(line) = async {
+                        match &mut stdout_stream {
+                            Some(s) => s.next().await,
+                            None => None,
+                        }
+                    } => {
+                        stdout_lines.push(line);
+                    }
+                    Some(line) = async {
+                        match &mut stderr_stream {
+                            Some(s) => s.next().await,
+                            None => None,
+                        }
+                    } => {
+                        stderr_lines.push(line);
+                    }
+                    else => break,
+                }
+            }
+
+            let status = execution.wait().await?;
+
+            Ok::<(i32, String, String), BoxliteError>((
+                status.exit_code,
+                stdout_lines.join("\n"),
+                stderr_lines.join("\n"),
+            ))
+        });
+
+        match result {
+            Ok((exit_code, stdout, stderr)) => {
+                let stdout_c = match CString::new(stdout) {
+                    Ok(s) => s.into_raw(),
+                    Err(_) => ptr::null_mut(),
+                };
+                let stderr_c = match CString::new(stderr) {
+                    Ok(s) => s.into_raw(),
+                    Err(_) => ptr::null_mut(),
+                };
+
+                let exec_result = Box::new(crate::runner::ExecResult {
+                    exit_code,
+                    stdout_text: stdout_c,
+                    stderr_text: stderr_c,
+                });
+                *out_result = Box::into_raw(exec_result);
+                BoxliteErrorCode::Ok
+            }
+            Err(e) => {
+                let code = error_to_code(&e);
+                write_error(out_error, e);
+                code
+            }
+        }
+    }
+}
+
+/// Free execution result
+///
+/// # Implementation Note
+/// Frees the `ExecResult` struct and its contained strings.
+///
+/// # Safety
+/// result must be null or valid pointer
+pub unsafe fn result_free(result: *mut crate::runner::ExecResult) {
+    if !result.is_null() {
+        unsafe {
+            let result_box = Box::from_raw(result);
+            if !result_box.stdout_text.is_null() {
+                drop(CString::from_raw(result_box.stdout_text));
+            }
+            if !result_box.stderr_text.is_null() {
+                drop(CString::from_raw(result_box.stderr_text));
+            }
+        }
+    }
+}
+
+/// Free runner (auto-cleanup)
+///
+/// # Implementation Note
+/// Frees the `BoxRunner`. This triggers cleanup of the box (stopping and removing it).
+///
+/// # Safety
+/// runner must be null or valid pointer
+pub unsafe fn runner_free(runner: *mut crate::runner::BoxRunner) {
+    if !runner.is_null() {
+        unsafe {
+            let mut runner_box = Box::from_raw(runner);
+
+            if let Some(handle) = runner_box.handle.take() {
+                let _ = runner_box.tokio_rt.block_on(handle.stop());
+            }
+
+            if let Some(box_id) = runner_box.box_id.take() {
+                let _ = runner_box
+                    .tokio_rt
+                    .block_on(runner_box.runtime.remove(box_id.as_ref(), true));
+            }
+
+            drop(runner_box);
+        }
+    }
+}
+
+/// Start or restart a stopped box
+///
+/// # Implementation Note
+/// Starts the box execution.
+///
+/// # Safety
+/// handle must be valid or null
+pub unsafe fn box_start(handle: *mut BoxHandle, out_error: *mut FFIError) -> BoxliteErrorCode {
+    unsafe {
+        if handle.is_null() {
+            write_error(out_error, null_pointer_error("handle"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+
+        let handle_ref = &*handle;
+
+        match handle_ref.tokio_rt.block_on(handle_ref.handle.start()) {
+            Ok(_) => BoxliteErrorCode::Ok,
+            Err(e) => {
+                let code = error_to_code(&e);
+                write_error(out_error, e);
+                code
+            }
+        }
+    }
+}
+
+/// Get box ID string from handle
+///
+/// # Implementation Note
+/// Returns the Box ID as a newly allocated C string. Caller must free.
+///
+/// # Safety
+/// handle must be valid or null
+pub unsafe fn box_id(handle: *mut BoxHandle) -> *mut c_char {
+    unsafe {
+        if handle.is_null() {
+            return ptr::null_mut();
+        }
+
+        let handle_ref = &*handle;
+        let id_str = handle_ref.handle.id().to_string();
+
+        match CString::new(id_str) {
+            Ok(s) => s.into_raw(),
+            Err(_) => ptr::null_mut(),
+        }
+    }
+}
+
+/// Free a box handle
+///
+/// # Implementation Note
+/// Frees the `BoxHandle`. Note that this does NOT destroy the box itself, only the handle.
+/// To destroy the box, use `box_remove`.
+///
+/// # Safety
+/// handle must be null or a valid pointer to BoxHandle
+pub unsafe fn box_free(handle: *mut BoxHandle) {
+    if !handle.is_null() {
+        unsafe {
+            drop(Box::from_raw(handle));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::error_to_c_error;
+    use crate::json::status_to_string;
+    use boxlite::runtime::types::BoxStatus;
+    use std::ffi::CStr;
+
+    #[test]
+    fn test_version_string() {
+        let ver = version();
+        assert!(!ver.is_null());
+        let ver_str = unsafe { CStr::from_ptr(ver) }.to_str().unwrap();
+        assert!(!ver_str.is_empty());
+        assert!(ver_str.contains('.'));
+    }
+
+    #[test]
+    fn test_error_code_mapping() {
+        assert_eq!(
+            error_to_code(&BoxliteError::NotFound("test".into())),
+            BoxliteErrorCode::NotFound
+        );
+        assert_eq!(
+            error_to_code(&BoxliteError::AlreadyExists("test".into())),
+            BoxliteErrorCode::AlreadyExists
+        );
+        assert_eq!(
+            error_to_code(&BoxliteError::InvalidState("test".into())),
+            BoxliteErrorCode::InvalidState
+        );
+        assert_eq!(
+            error_to_code(&BoxliteError::InvalidArgument("test".into())),
+            BoxliteErrorCode::InvalidArgument
+        );
+        assert_eq!(
+            error_to_code(&BoxliteError::Internal("test".into())),
+            BoxliteErrorCode::Internal
+        );
+        assert_eq!(
+            error_to_code(&BoxliteError::Config("test".into())),
+            BoxliteErrorCode::Config
+        );
+        assert_eq!(
+            error_to_code(&BoxliteError::Storage("test".into())),
+            BoxliteErrorCode::Storage
+        );
+        assert_eq!(
+            error_to_code(&BoxliteError::Image("test".into())),
+            BoxliteErrorCode::Image
+        );
+        assert_eq!(
+            error_to_code(&BoxliteError::Network("test".into())),
+            BoxliteErrorCode::Network
+        );
+        assert_eq!(
+            error_to_code(&BoxliteError::Execution("test".into())),
+            BoxliteErrorCode::Execution
+        );
+    }
+
+    #[test]
+    fn test_error_struct_creation() {
+        let err = BoxliteError::NotFound("box123".into());
+        let mut c_err = error_to_c_error(err);
+        assert_eq!(c_err.code, BoxliteErrorCode::NotFound);
+        assert!(!c_err.message.is_null());
+        unsafe {
+            error_free(&mut c_err as *mut _);
+        }
+        assert!(c_err.message.is_null());
+        assert_eq!(c_err.code, BoxliteErrorCode::Ok);
+    }
+
+    #[test]
+    fn test_null_pointer_validation() {
+        unsafe {
+            let mut error = FFIError::default();
+            // runtime_new with null out_runtime should return InvalidArgument
+            let code = runtime_new(
+                ptr::null(),
+                ptr::null(),
+                ptr::null_mut(),
+                &mut error as *mut _,
+            );
+            assert_eq!(code, BoxliteErrorCode::InvalidArgument);
+            assert!(!error.message.is_null());
+            error_free(&mut error as *mut _);
+        }
+    }
+
+    #[test]
+    fn test_c_string_conversion_logic() {
+        let test_str = CString::new("hello").unwrap();
+        unsafe {
+            let result = c_str_to_string(test_str.as_ptr());
+            assert!(result.is_ok());
+            assert_eq!(result.unwrap(), "hello");
+        }
+    }
+
+    #[test]
+    fn test_status_to_string_mapping() {
+        assert_eq!(status_to_string(BoxStatus::Unknown), "unknown");
+        assert_eq!(status_to_string(BoxStatus::Configured), "configured");
+        assert_eq!(status_to_string(BoxStatus::Running), "running");
+        assert_eq!(status_to_string(BoxStatus::Stopping), "stopping");
+        assert_eq!(status_to_string(BoxStatus::Stopped), "stopped");
+    }
+
+    #[test]
+    fn test_free_functions_null_safe() {
+        unsafe {
+            runtime_free(ptr::null_mut());
+            box_free(ptr::null_mut());
+            string_free(ptr::null_mut());
+            error_free(ptr::null_mut());
+            result_free(ptr::null_mut());
+            runner_free(ptr::null_mut());
+        }
+    }
+}

--- a/sdks/boxlite-ffi/src/runner.rs
+++ b/sdks/boxlite-ffi/src/runner.rs
@@ -1,0 +1,45 @@
+//! High-level "Runner" API for quick box execution
+//!
+//! Provides a simplified API for creating a box, running a command, and cleaning up.
+//! Useful for scripting and simple integrations.
+
+use std::os::raw::{c_char, c_int};
+use std::sync::Arc;
+
+use tokio::runtime::Runtime as TokioRuntime;
+
+use boxlite::BoxID;
+use boxlite::litebox::LiteBox;
+use boxlite::runtime::BoxliteRuntime;
+
+/// Opaque handle for Runner API (auto-manages runtime)
+pub struct BoxRunner {
+    pub runtime: BoxliteRuntime,
+    pub handle: Option<LiteBox>,
+    pub box_id: Option<BoxID>,
+    pub tokio_rt: Arc<TokioRuntime>,
+}
+
+/// Result structure for runner command execution
+#[repr(C)]
+pub struct ExecResult {
+    pub exit_code: c_int,
+    pub stdout_text: *mut c_char,
+    pub stderr_text: *mut c_char,
+}
+
+impl BoxRunner {
+    pub fn new(
+        runtime: BoxliteRuntime,
+        handle: LiteBox,
+        box_id: BoxID,
+        tokio_rt: Arc<TokioRuntime>,
+    ) -> Self {
+        Self {
+            runtime,
+            handle: Some(handle),
+            box_id: Some(box_id),
+            tokio_rt,
+        }
+    }
+}

--- a/sdks/boxlite-ffi/src/runtime.rs
+++ b/sdks/boxlite-ffi/src/runtime.rs
@@ -1,0 +1,37 @@
+//! Runtime management for BoxLite FFI
+//!
+//! Provides Tokio runtime and BoxliteRuntime handle management.
+
+use std::sync::Arc;
+
+use tokio::runtime::Runtime as TokioRuntime;
+
+use boxlite::BoxID;
+use boxlite::litebox::LiteBox;
+use boxlite::runtime::BoxliteRuntime;
+
+/// Opaque handle to a BoxliteRuntime instance with associated Tokio runtime
+pub struct RuntimeHandle {
+    pub runtime: BoxliteRuntime,
+    pub tokio_rt: Arc<TokioRuntime>,
+}
+
+/// Opaque handle to a running box
+pub struct BoxHandle {
+    pub handle: LiteBox,
+    #[allow(dead_code)]
+    pub box_id: BoxID,
+    pub tokio_rt: Arc<TokioRuntime>,
+}
+
+/// Create a new Tokio runtime
+pub fn create_tokio_runtime() -> Result<Arc<TokioRuntime>, String> {
+    TokioRuntime::new()
+        .map(Arc::new)
+        .map_err(|e| format!("Failed to create async runtime: {}", e))
+}
+
+/// Block on a future using the provided Tokio runtime
+pub fn block_on<F: std::future::Future>(tokio_rt: &TokioRuntime, future: F) -> F::Output {
+    tokio_rt.block_on(future)
+}

--- a/sdks/boxlite-ffi/src/string.rs
+++ b/sdks/boxlite-ffi/src/string.rs
@@ -1,0 +1,65 @@
+//! C string utilities for BoxLite FFI
+//!
+//! Provides functions for converting between Rust strings and C strings.
+
+use std::ffi::{CStr, CString};
+use std::os::raw::c_char;
+use std::ptr;
+
+use boxlite::BoxliteError;
+
+/// Allocate a C string from a Rust string.
+///
+/// Caller must free with the corresponding free function.
+/// Returns NULL if the string contains null bytes.
+pub fn alloc_c_string(s: &str) -> *mut c_char {
+    match CString::new(s) {
+        Ok(cs) => cs.into_raw(),
+        Err(_) => ptr::null_mut(),
+    }
+}
+
+/// Parse a C string to Rust &str (borrowed).
+///
+/// Returns None if the pointer is null or contains invalid UTF-8.
+///
+/// # Safety
+/// ptr must be null or a valid pointer to a null-terminated C string
+pub unsafe fn parse_c_str<'a>(ptr: *const c_char) -> Option<&'a str> {
+    unsafe {
+        if ptr.is_null() {
+            return None;
+        }
+        CStr::from_ptr(ptr).to_str().ok()
+    }
+}
+
+/// Convert C string to Rust String (owned).
+///
+/// Returns an error if the pointer is null or contains invalid UTF-8.
+///
+/// # Safety
+/// s must be null or a valid pointer to a null-terminated C string
+pub unsafe fn c_str_to_string(s: *const c_char) -> Result<String, BoxliteError> {
+    unsafe {
+        if s.is_null() {
+            return Err(BoxliteError::Internal("null pointer".to_string()));
+        }
+        CStr::from_ptr(s)
+            .to_str()
+            .map(|s| s.to_string())
+            .map_err(|e| BoxliteError::Internal(format!("invalid UTF-8: {}", e)))
+    }
+}
+
+/// Free a C string allocated by alloc_c_string.
+///
+/// # Safety
+/// s must be null or a valid pointer to a C string allocated by alloc_c_string
+pub unsafe fn free_c_string(s: *mut c_char) {
+    unsafe {
+        if !s.is_null() {
+            drop(CString::from_raw(s));
+        }
+    }
+}

--- a/sdks/c/Cargo.toml
+++ b/sdks/c/Cargo.toml
@@ -12,15 +12,11 @@ crate-type = ["cdylib", "staticlib"]
 
 [features]
 default = []
-gvproxy-backend = ["boxlite/gvproxy-backend"]
-libslirp-backend = ["boxlite/libslirp-backend"]
+gvproxy-backend = ["boxlite-ffi/gvproxy-backend"]
+libslirp-backend = ["boxlite-ffi/libslirp-backend"]
 
 [dependencies]
-boxlite = { path = "../../boxlite" }
-
-tokio = { version = "1.37", features = ["rt", "rt-multi-thread"] }
-serde_json = "1.0"
-futures = "0.3"
+boxlite-ffi = { path = "../boxlite-ffi" }
 
 [build-dependencies]
 cbindgen = "0.29"

--- a/sdks/c/build.rs
+++ b/sdks/c/build.rs
@@ -9,17 +9,18 @@ fn main() {
     std::fs::create_dir_all(output_file.parent().unwrap())
         .expect("Failed to create include directory");
 
-    // Generate C header from Rust code
+    // Load cbindgen configuration from cbindgen.toml
+    let config_path = PathBuf::from(&crate_dir).join("cbindgen.toml");
+    let config = cbindgen::Config::from_file(&config_path).expect("Failed to load cbindgen.toml");
+
+    // Generate C header from Rust code (including boxlite-ffi types via parse_deps)
     cbindgen::Builder::new()
         .with_crate(&crate_dir)
-        .with_language(cbindgen::Language::C)
-        .with_pragma_once(true)
-        .with_include_guard("BOXLITE_H")
-        .with_documentation(true)
-        .with_cpp_compat(true)
+        .with_config(config)
         .generate()
         .expect("Unable to generate C bindings")
         .write_to_file(&output_file);
 
     println!("cargo:rerun-if-changed=src/");
+    println!("cargo:rerun-if-changed=cbindgen.toml");
 }

--- a/sdks/c/cbindgen.toml
+++ b/sdks/c/cbindgen.toml
@@ -1,0 +1,19 @@
+# cbindgen configuration for boxlite-c
+# See: https://github.com/mozilla/cbindgen/blob/master/docs.md
+
+language = "C"
+include_guard = "BOXLITE_H"
+pragma_once = true
+cpp_compat = true
+documentation = true
+documentation_style = "c99"
+
+# Style settings
+style = "both"
+usize_is_size_t = true
+
+[parse]
+# Enable parsing dependency crates to resolve types defined in boxlite-ffi
+parse_deps = true
+# Only parse boxlite-ffi (avoid scanning the entire boxlite core crate)
+include = ["boxlite-ffi"]

--- a/sdks/c/include/boxlite.h
+++ b/sdks/c/include/boxlite.h
@@ -5,455 +5,450 @@
 
 #include <stdarg.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <stdlib.h>
 
-/**
- * Error codes returned by BoxLite C API functions.
- *
- * These codes map directly to Rust's BoxliteError variants,
- * allowing programmatic error handling in C.
- */
+// Error codes returned by BoxLite C API functions.
+//
+// These codes map directly to Rust's BoxliteError variants,
+// allowing programmatic error handling in C.
 typedef enum BoxliteErrorCode {
-  /**
-   * Operation succeeded
-   */
+  // Operation succeeded
   Ok = 0,
-  /**
-   * Internal error
-   */
+  // Internal error
   Internal = 1,
-  /**
-   * Resource not found
-   */
+  // Resource not found
   NotFound = 2,
-  /**
-   * Resource already exists
-   */
+  // Resource already exists
   AlreadyExists = 3,
-  /**
-   * Invalid state for operation
-   */
+  // Invalid state for operation
   InvalidState = 4,
-  /**
-   * Invalid argument provided
-   */
+  // Invalid argument provided
   InvalidArgument = 5,
-  /**
-   * Configuration error
-   */
+  // Configuration error
   Config = 6,
-  /**
-   * Storage error
-   */
+  // Storage error
   Storage = 7,
-  /**
-   * Image error
-   */
+  // Image error
   Image = 8,
-  /**
-   * Network error
-   */
+  // Network error
   Network = 9,
-  /**
-   * Execution error
-   */
+  // Execution error
   Execution = 10,
-  /**
-   * Resource stopped
-   */
+  // Resource stopped
   Stopped = 11,
-  /**
-   * Engine error
-   */
+  // Engine error
   Engine = 12,
-  /**
-   * Unsupported operation
-   */
+  // Unsupported operation
   Unsupported = 13,
-  /**
-   * Database error
-   */
+  // Database error
   Database = 14,
-  /**
-   * Portal/communication error
-   */
+  // Portal/communication error
   Portal = 15,
-  /**
-   * RPC error
-   */
+  // RPC error
   Rpc = 16,
+  // RPC transport error
+  RpcTransport = 17,
+  // Metadata error
+  Metadata = 18,
+  // Unsupported engine error
+  UnsupportedEngine = 19,
 } BoxliteErrorCode;
 
-/**
- * Opaque handle to a running box
- */
-typedef struct CBoxHandle CBoxHandle;
+// Opaque handle to a running box
+typedef struct BoxHandle BoxHandle;
 
-/**
- * Opaque handle to a BoxliteRuntime instance
- */
-typedef struct CBoxliteRuntime CBoxliteRuntime;
+// Opaque handle for Runner API (auto-manages runtime)
+typedef struct BoxRunner BoxRunner;
 
-/**
- * Opaque handle for simple API (auto-manages runtime)
- */
-typedef struct CBoxliteSimple CBoxliteSimple;
+// Opaque handle to a BoxliteRuntime instance with associated Tokio runtime
+typedef struct RuntimeHandle RuntimeHandle;
 
-/**
- * Extended error information for C API.
- *
- * Contains both an error code (for programmatic handling)
- * and an optional detailed message (for debugging).
- */
-typedef struct CBoxliteError {
-  /**
-   * Error code
-   */
+typedef struct RuntimeHandle CBoxliteRuntime;
+
+// Extended error information for C API.
+//
+// Contains both an error code (for programmatic handling)
+// and an optional detailed message (for debugging).
+typedef struct FFIError {
+  // Error code
   enum BoxliteErrorCode code;
-  /**
-   * Detailed error message (NULL if none, caller must free with boxlite_error_free)
-   */
+  // Detailed error message (NULL if none, caller must free with boxlite_error_free)
   char *message;
-} CBoxliteError;
+} FFIError;
 
-/**
- * Result structure for simple API command execution
- */
-typedef struct CBoxliteExecResult {
+typedef struct FFIError CBoxliteError;
+
+typedef struct BoxHandle CBoxHandle;
+
+typedef struct BoxRunner CBoxliteSimple;
+
+// Result structure for runner command execution
+typedef struct ExecResult {
   int exit_code;
   char *stdout_text;
   char *stderr_text;
-} CBoxliteExecResult;
+} ExecResult;
+
+typedef struct ExecResult CBoxliteExecResult;
 
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
-/**
- * Get BoxLite version string
- *
- * # Returns
- * Static string containing the version (e.g., "0.1.0")
- */
+// Get BoxLite version string
+//
+// # Returns
+// A pointer to a static C string containing the version. Do not free this string.
+//
+// # Example
+// ```c
+// printf("BoxLite Version: %s\n", boxlite_version());
+// ```
 const char *boxlite_version(void);
 
-/**
- * Create a new BoxLite runtime
- *
- * # Arguments
- * * `home_dir` - Path to BoxLite home directory (stores images, rootfs, etc.)
- *                If NULL, uses default: ~/.boxlite
- * * `registries_json` - JSON array of registries to search for unqualified images,
- *                       e.g. `["ghcr.io", "quay.io"]`. If NULL, uses default (docker.io).
- *                       Registries are tried in order; first successful pull wins.
- * * `out_error` - Output parameter for error message (caller must free with boxlite_free_string)
- *
- * # Returns
- * Pointer to CBoxliteRuntime on success, NULL on failure
- *
- * # Example
- * ```c
- * char *error = NULL;
- * const char *registries = "[\"ghcr.io\", \"docker.io\"]";
- * BoxliteRuntime *runtime = boxlite_runtime_new("/tmp/boxlite", registries, &error);
- * if (!runtime) {
- *     fprintf(stderr, "Error: %s\n", error);
- *     boxlite_free_string(error);
- *     return 1;
- * }
- * ```
- */
+// Create a new BoxLite runtime configuration.
+//
+// # Arguments
+// * `home_dir` - Optional path to the home directory. If NULL, defaults to `~/.boxlite`.
+// * `registries_json` - Optional JSON array of registry configurations.
+// * `out_runtime` - Output parameter to store the created `CBoxliteRuntime` pointer.
+// * `out_error` - Output parameter for error information.
+//
+// # Returns
+// `BoxliteErrorCode::Ok` on success, or an error code on failure.
+//
+// # Example
+// ```c
+// CBoxliteRuntime *runtime;
+// CBoxliteError *error = malloc(sizeof(CBoxliteError));
+// if (boxlite_runtime_new(NULL, NULL, &runtime, error) != BOXLITE_OK) {
+//     fprintf(stderr, "Failed to create runtime\n");
+// }
+// ```
 enum BoxliteErrorCode boxlite_runtime_new(const char *home_dir,
                                           const char *registries_json,
-                                          struct CBoxliteRuntime **out_runtime,
-                                          struct CBoxliteError *out_error);
+                                          CBoxliteRuntime **out_runtime,
+                                          CBoxliteError *out_error);
 
-/**
- * Create a new box with the given options (JSON)
- *
- * # Arguments
- * * `runtime` - BoxLite runtime instance
- * * `options_json` - JSON-encoded BoxOptions, e.g.:
- *                    `{"rootfs": {"Image": "alpine:3.19"}, "working_dir": "/workspace"}`
- * * `out_error` - Output parameter for error message
- *
- * # Returns
- * Pointer to CBoxHandle on success, NULL on failure
- *
- * # Example
- * ```c
- * const char *opts = "{\"rootfs\":{\"Image\":\"alpine:3.19\"}}";
- * BoxHandle *box = boxlite_create_box(runtime, opts, &error);
- * ```
- */
-enum BoxliteErrorCode boxlite_create_box(struct CBoxliteRuntime *runtime,
+// Create a new box with the given options (JSON).
+//
+// # Arguments
+// * `runtime` - Pointer to the active `CBoxliteRuntime`.
+// * `options_json` - JSON string defining the box (e.g., image, resources).
+// * `out_box` - Output parameter to store the created `CBoxHandle`.
+// * `out_error` - Output parameter for error information.
+//
+// # Returns
+// `BoxliteErrorCode::Ok` on success.
+//
+// # Example
+// ```c
+// const char *options = "{\"rootfs\": {\"Image\": \"alpine:latest\"}}";
+// CBoxHandle *box;
+// if (boxlite_create_box(runtime, options, &box, error) == BOXLITE_OK) {
+//     // Use box...
+// }
+// ```
+enum BoxliteErrorCode boxlite_create_box(CBoxliteRuntime *runtime,
                                          const char *options_json,
-                                         struct CBoxHandle **out_box,
-                                         struct CBoxliteError *out_error);
+                                         CBoxHandle **out_box,
+                                         CBoxliteError *out_error);
 
-/**
- * Execute a command in a box
- *
- * # Arguments
- * * `handle` - Box handle
- * * `command` - Command to execute
- * * `args_json` - JSON array of arguments, e.g.: `["arg1", "arg2"]`
- * * `callback` - Optional callback for streaming output (chunk_text, is_stderr, user_data)
- * * `user_data` - User data passed to callback
- * * `out_exit_code` - Output parameter for command exit code
- * * `out_error` - Output parameter for error information
- *
- * # Returns
- * BoxliteErrorCode::Ok on success, error code on failure
- *
- * # Example
- * ```c
- * int exit_code;
- * CBoxliteError error = {0};
- * const char *args = "[\"hello\"]";
- * BoxliteErrorCode code = boxlite_execute(box, "echo", args, NULL, NULL, &exit_code, &error);
- * if (code == BOXLITE_OK) {
- *     printf("Command exited with code: %d\n", exit_code);
- * }
- * ```
- */
-enum BoxliteErrorCode boxlite_execute(struct CBoxHandle *handle,
+// Execute a command in a box.
+//
+// # Arguments
+// * `handle` - Box handle.
+// * `command` - Command to execute (e.g., "/bin/sh").
+// * `args_json` - JSON array of arguments, e.g.: `["-c", "echo hello"]`.
+// * `callback` - Optional callback for streaming output.
+// * `user_data` - User data passed to callback.
+// * `out_exit_code` - Output parameter for command exit code.
+// * `out_error` - Output parameter for error information.
+//
+// # Returns
+// `BoxliteErrorCode::Ok` on success.
+//
+// # Example
+// ```c
+// int exit_code;
+// const char *args = "[\"hello\"]";
+// if (boxlite_execute(box, "echo", args, NULL, NULL, &exit_code, error) == BOXLITE_OK) {
+//     printf("Exit code: %d\n", exit_code);
+// }
+// ```
+enum BoxliteErrorCode boxlite_execute(CBoxHandle *handle,
                                       const char *command,
                                       const char *args_json,
                                       void (*callback)(const char*, int, void*),
                                       void *user_data,
                                       int *out_exit_code,
-                                      struct CBoxliteError *out_error);
+                                      CBoxliteError *out_error);
 
-/**
- * Stop a box
- *
- * # Arguments
- * * `handle` - Box handle (will be consumed/freed)
- * * `out_error` - Output parameter for error information
- *
- * # Returns
- * BoxliteErrorCode::Ok on success, error code on failure
- */
-enum BoxliteErrorCode boxlite_stop_box(struct CBoxHandle *handle, struct CBoxliteError *out_error);
+// Stop a box.
+//
+// # Arguments
+// * `handle` - Box handle.
+// * `out_error` - output error.
+//
+// # Example
+// ```c
+// boxlite_stop_box(box, error);
+// ```
+enum BoxliteErrorCode boxlite_stop_box(CBoxHandle *handle, CBoxliteError *out_error);
 
-/**
- * List all boxes as JSON
- *
- * # Arguments
- * * `runtime` - BoxLite runtime instance
- * * `out_json` - Output parameter for JSON array of box info
- * * `out_error` - Output parameter for error information
- *
- * # Returns
- * BoxliteErrorCode::Ok on success, error code on failure
- *
- * # JSON Format
- * ```json
- * [
- *   {
- *     "id": "01HJK4TNRPQSXYZ8WM6NCVT9R5",
- *     "name": "my-box",
- *     "state": { "status": "running", "running": true, "pid": 12345 },
- *     "created_at": "2024-01-15T10:30:00Z",
- *     "image": "alpine:3.19",
- *     "cpus": 2,
- *     "memory_mib": 512
- *   }
- * ]
- * ```
- */
-enum BoxliteErrorCode boxlite_list_info(struct CBoxliteRuntime *runtime,
+// List all boxes as JSON.
+//
+// # Arguments
+// * `runtime` - Runtime handle.
+// * `out_json` - Output pointer for JSON string. Caller must free this with `boxlite_free_string`.
+// * `out_error` - Output error.
+//
+// # Example
+// ```c
+// char *json;
+// if (boxlite_list_info(runtime, &json, error) == BOXLITE_OK) {
+//     printf("Boxes: %s\n", json);
+//     boxlite_free_string(json);
+// }
+// ```
+enum BoxliteErrorCode boxlite_list_info(CBoxliteRuntime *runtime,
                                         char **out_json,
-                                        struct CBoxliteError *out_error);
+                                        CBoxliteError *out_error);
 
-/**
- * Get single box info as JSON
- *
- * # Arguments
- * * `runtime` - BoxLite runtime instance
- * * `id_or_name` - Box ID (full or prefix) or name
- * * `out_json` - Output parameter for JSON object
- * * `out_error` - Output parameter for error information
- *
- * # Returns
- * BoxliteErrorCode::Ok on success, error code on failure (including box not found)
- */
-enum BoxliteErrorCode boxlite_get_info(struct CBoxliteRuntime *runtime,
+// Get single box info as JSON.
+//
+// # Arguments
+// * `runtime` - Runtime handle.
+// * `id_or_name` - ID or name of the box.
+// * `out_json` - Output pointer for JSON string.
+// * `out_error` - Output error.
+//
+// # Example
+// ```c
+// char *json;
+// boxlite_get_info(runtime, "my-box", &json, error);
+// ```
+enum BoxliteErrorCode boxlite_get_info(CBoxliteRuntime *runtime,
                                        const char *id_or_name,
                                        char **out_json,
-                                       struct CBoxliteError *out_error);
+                                       CBoxliteError *out_error);
 
-/**
- * Get box handle for reattaching to an existing box
- *
- * # Arguments
- * * `runtime` - BoxLite runtime instance
- * * `id_or_name` - Box ID (full or prefix) or name
- * * `out_handle` - Output parameter for box handle
- * * `out_error` - Output parameter for error information
- *
- * # Returns
- * BoxliteErrorCode::Ok on success, error code on failure (including box not found)
- */
-enum BoxliteErrorCode boxlite_get(struct CBoxliteRuntime *runtime,
+// Attach to an existing box.
+//
+// # Arguments
+// * `runtime` - Runtime handle.
+// * `id_or_name` - ID or name of the box.
+// * `out_handle` - Output pointer for box handle.
+// * `out_error` - Output error.
+//
+// # Example
+// ```c
+// CBoxHandle *handle;
+// if (boxlite_get(runtime, "my-box", &handle, error) == BOXLITE_OK) {
+//     // Use handle...
+// }
+// ```
+enum BoxliteErrorCode boxlite_get(CBoxliteRuntime *runtime,
                                   const char *id_or_name,
-                                  struct CBoxHandle **out_handle,
-                                  struct CBoxliteError *out_error);
+                                  CBoxHandle **out_handle,
+                                  CBoxliteError *out_error);
 
-/**
- * Remove a box
- *
- * # Arguments
- * * `runtime` - BoxLite runtime instance
- * * `id_or_name` - Box ID (full or prefix) or name
- * * `force` - If non-zero, force remove even if running
- * * `out_error` - Output parameter for error information
- *
- * # Returns
- * BoxliteErrorCode::Ok on success, error code on failure
- */
-enum BoxliteErrorCode boxlite_remove(struct CBoxliteRuntime *runtime,
+// Remove a box.
+//
+// # Arguments
+// * `runtime` - Runtime handle.
+// * `id_or_name` - ID or name of the box.
+// * `force` - 1 to force remove (stop if running), 0 otherwise.
+// * `out_error` - Output error.
+//
+// # Example
+// ```c
+// boxlite_remove(runtime, "my-box", 1, error);
+// ```
+enum BoxliteErrorCode boxlite_remove(CBoxliteRuntime *runtime,
                                      const char *id_or_name,
                                      int force,
-                                     struct CBoxliteError *out_error);
+                                     CBoxliteError *out_error);
 
-/**
- * Get runtime metrics as JSON
- *
- * # Arguments
- * * `runtime` - BoxLite runtime instance
- * * `out_json` - Output parameter for JSON object
- * * `out_error` - Output parameter for error information
- *
- * # Returns
- * BoxliteErrorCode::Ok on success, error code on failure
- */
-enum BoxliteErrorCode boxlite_runtime_metrics(struct CBoxliteRuntime *runtime,
+// Get runtime metrics as JSON.
+//
+// # Arguments
+// * `runtime` - Runtime handle.
+// * `out_json` - Output pointer for JSON string.
+// * `out_error` - Output error.
+//
+// # Example
+// ```c
+// char *json;
+// boxlite_runtime_metrics(runtime, &json, error);
+// ```
+enum BoxliteErrorCode boxlite_runtime_metrics(CBoxliteRuntime *runtime,
                                               char **out_json,
-                                              struct CBoxliteError *out_error);
+                                              CBoxliteError *out_error);
 
-/**
- * Gracefully shutdown all boxes in this runtime.
- *
- * This method stops all running boxes, waiting up to `timeout` seconds
- * for each box to stop gracefully before force-killing it.
- *
- * After calling this method, the runtime is permanently shut down and
- * will return errors for any new operations (like `create()`).
- *
- * # Arguments
- * * `runtime` - BoxLite runtime instance
- * * `timeout` - Seconds to wait before force-killing each box:
- *   - 0 - Use default timeout (10 seconds)
- *   - Positive integer - Wait that many seconds
- *   - -1 - Wait indefinitely (no timeout)
- * * `out_error` - Output parameter for error information
- *
- * # Returns
- * BoxliteErrorCode::Ok on success, error code on failure
- */
-enum BoxliteErrorCode boxlite_runtime_shutdown(struct CBoxliteRuntime *runtime,
+// Gracefully shutdown all boxes in this runtime.
+//
+// # Arguments
+// * `runtime` - Runtime handle.
+// * `timeout` - Seconds to wait before force-killing each box:
+//   - 0 - Use default timeout (10 seconds)
+//   - Positive integer - Wait that many seconds
+//   - -1 - Wait indefinitely (no timeout)
+// * `out_error` - Output parameter for error information
+//
+// # Example
+// ```c
+// boxlite_runtime_shutdown(runtime, 5, error);
+// ```
+enum BoxliteErrorCode boxlite_runtime_shutdown(CBoxliteRuntime *runtime,
                                                int timeout,
-                                               struct CBoxliteError *out_error);
+                                               CBoxliteError *out_error);
 
-/**
- * Get box info from handle as JSON
- *
- * # Arguments
- * * `handle` - Box handle
- * * `out_json` - Output parameter for JSON object
- * * `out_error` - Output parameter for error information
- *
- * # Returns
- * BoxliteErrorCode::Ok on success, error code on failure
- */
-enum BoxliteErrorCode boxlite_box_info(struct CBoxHandle *handle,
+// Get info for a box handle as JSON.
+//
+// # Arguments
+// * `handle` - Box handle.
+// * `out_json` - Output pointer for JSON string.
+// * `out_error` - Output error.
+//
+// # Example
+// ```c
+// char *json;
+// boxlite_box_info(handle, &json, error);
+// ```
+enum BoxliteErrorCode boxlite_box_info(CBoxHandle *handle,
                                        char **out_json,
-                                       struct CBoxliteError *out_error);
+                                       CBoxliteError *out_error);
 
-/**
- * Get box metrics from handle as JSON
- *
- * # Arguments
- * * `handle` - Box handle
- * * `out_json` - Output parameter for JSON object
- * * `out_error` - Output parameter for error information
- *
- * # Returns
- * BoxliteErrorCode::Ok on success, error code on failure
- */
-enum BoxliteErrorCode boxlite_box_metrics(struct CBoxHandle *handle,
+// Get metrics for a box handle as JSON.
+//
+// # Arguments
+// * `handle` - Box handle.
+// * `out_json` - Output pointer for JSON string.
+// * `out_error` - Output error.
+//
+// # Example
+// ```c
+// char *json;
+// boxlite_box_metrics(handle, &json, error);
+// ```
+enum BoxliteErrorCode boxlite_box_metrics(CBoxHandle *handle,
                                           char **out_json,
-                                          struct CBoxliteError *out_error);
+                                          CBoxliteError *out_error);
 
-/**
- * Start or restart a stopped box
- *
- * # Arguments
- * * `handle` - Box handle
- * * `out_error` - Output parameter for error information
- *
- * # Returns
- * BoxliteErrorCode::Ok on success, error code on failure
- */
-enum BoxliteErrorCode boxlite_start_box(struct CBoxHandle *handle, struct CBoxliteError *out_error);
+// Start a stopped box.
+//
+// # Arguments
+// * `handle` - Box handle.
+// * `out_error` - output error.
+//
+// # Example
+// ```c
+// boxlite_start_box(handle, error);
+// ```
+enum BoxliteErrorCode boxlite_start_box(CBoxHandle *handle, CBoxliteError *out_error);
 
-/**
- * Get box ID string from handle
- *
- * # Arguments
- * * `handle` - Box handle
- *
- * # Returns
- * Pointer to C string (caller must free with boxlite_free_string), NULL on failure
- */
-char *boxlite_box_id(struct CBoxHandle *handle);
+// Get box ID.
+//
+// # Arguments
+// * `handle` - Box handle.
+//
+// # Returns
+// Pointer to a C string containing the ID. Must be freed with `boxlite_free_string`.
+//
+// # Example
+// ```c
+// char *id = boxlite_box_id(handle);
+// printf("Box ID: %s\n", id);
+// boxlite_free_string(id);
+// ```
+char *boxlite_box_id(CBoxHandle *handle);
 
-/**
- * Create and start a box using simple API
- */
+// Create a simplified box runner.
+//
+// # Arguments
+// * `image` - Container image.
+// * `cpus` - Number of CPUs.
+// * `memory_mib` - Memory in MiB.
+// * `out_box` - Output pointer for `CBoxliteSimple,`.
+// * `out_error` - Output error.
+//
+// # Returns
+// `BoxliteErrorCode::Ok` on success.
+//
+// # Example
+// ```c
+// CBoxliteSimple, *runner;
+// if (boxlite_simple_new("alpine", 1, 128, &runner, error) == BOXLITE_OK) {
+//     // Use runner...
+// }
+// ```
 enum BoxliteErrorCode boxlite_simple_new(const char *image,
                                          int cpus,
                                          int memory_mib,
-                                         struct CBoxliteSimple **out_box,
-                                         struct CBoxliteError *out_error);
+                                         CBoxliteSimple **out_box,
+                                         CBoxliteError *out_error);
 
-/**
- * Run a command and get buffered result
- */
-enum BoxliteErrorCode boxlite_simple_run(struct CBoxliteSimple *simple_box,
+// Run a command using the simplified runner.
+//
+// # Arguments
+// * `box_runner` - Runner handle.
+// * `command` - Command to execute.
+// * `args` - Array of argument strings.
+// * `argc` - Count of arguments.
+// * `out_result` - Output pointer for `CBoxliteExecResult`.
+// * `out_error` - Output error.
+//
+// # Example
+// ```c
+// CBoxliteExecResult *result;
+// const char *args[] = {"hello"};
+// boxlite_simple_run(runner, "echo", args, 1, &result, error);
+// ```
+enum BoxliteErrorCode boxlite_simple_run(CBoxliteSimple *box_runner,
                                          const char *command,
                                          const char *const *args,
                                          int argc,
-                                         struct CBoxliteExecResult **out_result,
-                                         struct CBoxliteError *out_error);
+                                         CBoxliteExecResult **out_result,
+                                         CBoxliteError *out_error);
 
-/**
- * Free execution result
- */
-void boxlite_result_free(struct CBoxliteExecResult *result);
+// Free an execution result.
+//
+// # Arguments
+// * `result` - Pointer to `CBoxliteExecResult` to free.
+void boxlite_result_free(CBoxliteExecResult *result);
 
-/**
- * Free simple box (auto-cleanup)
- */
-void boxlite_simple_free(struct CBoxliteSimple *simple_box);
+// Free a simple runner.
+//
+// # Arguments
+// * `box_runner` - Pointer to `CBoxliteSimple,` to free.
+void boxlite_simple_free(CBoxliteSimple *box_runner);
 
-/**
- * Free a runtime instance
- */
-void boxlite_runtime_free(struct CBoxliteRuntime *runtime);
+// Free a box handle.
+//
+// # Arguments
+// * `handle` - Pointer to `CBoxHandle` to free.
+void boxlite_box_free(CBoxHandle *handle);
 
-/**
- * Free a string allocated by BoxLite
- */
-void boxlite_free_string(char *str);
+// Free a runtime handle.
+//
+// # Arguments
+// * `runtime` - Pointer to `CBoxliteRuntime` to free.
+void boxlite_runtime_free(CBoxliteRuntime *runtime);
 
-/**
- * Free error struct
- */
-void boxlite_error_free(struct CBoxliteError *error);
+// Free a string allocated by the library.
+//
+// # Arguments
+// * `s` - Pointer to string to free.
+void boxlite_free_string(char *s);
+
+// Free an error object.
+//
+// # Arguments
+// * `error` - Pointer to `CBoxliteError` to free.
+void boxlite_error_free(CBoxliteError *error);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sdks/c/src/ffi.rs
+++ b/sdks/c/src/ffi.rs
@@ -14,244 +14,55 @@
 #![allow(clippy::missing_safety_doc)]
 #![allow(clippy::doc_overindented_list_items)]
 
-use std::ffi::{CStr, CString};
 use std::os::raw::{c_char, c_int, c_void};
-use std::ptr;
-use std::sync::Arc;
 
-use tokio::runtime::Runtime as TokioRuntime;
+// Import internal FFI types from shared layer
+use boxlite_ffi::error::{BoxliteErrorCode, FFIError};
+use boxlite_ffi::runner::{BoxRunner, ExecResult};
+use boxlite_ffi::runtime::{BoxHandle, RuntimeHandle};
 
-use boxlite::BoxID;
-use boxlite::BoxliteError;
-use boxlite::litebox::LiteBox;
-use boxlite::runtime::BoxliteRuntime;
-use boxlite::runtime::options::{BoxOptions, BoxliteOptions, RootfsSpec};
-use boxlite::runtime::types::{BoxInfo, BoxStatus};
-
-// ============================================================================
-// Error Code Enum - Maps to BoxliteError variants
-// ============================================================================
-
-/// Error codes returned by BoxLite C API functions.
-///
-/// These codes map directly to Rust's BoxliteError variants,
-/// allowing programmatic error handling in C.
-#[repr(C)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum BoxliteErrorCode {
-    /// Operation succeeded
-    Ok = 0,
-    /// Internal error
-    Internal = 1,
-    /// Resource not found
-    NotFound = 2,
-    /// Resource already exists
-    AlreadyExists = 3,
-    /// Invalid state for operation
-    InvalidState = 4,
-    /// Invalid argument provided
-    InvalidArgument = 5,
-    /// Configuration error
-    Config = 6,
-    /// Storage error
-    Storage = 7,
-    /// Image error
-    Image = 8,
-    /// Network error
-    Network = 9,
-    /// Execution error
-    Execution = 10,
-    /// Resource stopped
-    Stopped = 11,
-    /// Engine error
-    Engine = 12,
-    /// Unsupported operation
-    Unsupported = 13,
-    /// Database error
-    Database = 14,
-    /// Portal/communication error
-    Portal = 15,
-    /// RPC error
-    Rpc = 16,
-}
-
-/// Extended error information for C API.
-///
-/// Contains both an error code (for programmatic handling)
-/// and an optional detailed message (for debugging).
-#[repr(C)]
-pub struct CBoxliteError {
-    /// Error code
-    pub code: BoxliteErrorCode,
-    /// Detailed error message (NULL if none, caller must free with boxlite_error_free)
-    pub message: *mut c_char,
-}
-
-impl Default for CBoxliteError {
-    fn default() -> Self {
-        CBoxliteError {
-            code: BoxliteErrorCode::Ok,
-            message: ptr::null_mut(),
-        }
-    }
-}
-
-/// Opaque handle to a BoxliteRuntime instance
-pub struct CBoxliteRuntime {
-    runtime: BoxliteRuntime,
-    tokio_rt: Arc<TokioRuntime>,
-}
-
-/// Opaque handle to a running box
-pub struct CBoxHandle {
-    handle: LiteBox,
-    #[allow(dead_code)]
-    box_id: BoxID,
-    tokio_rt: Arc<TokioRuntime>,
-}
-
-/// Opaque handle for simple API (auto-manages runtime)
-pub struct CBoxliteSimple {
-    runtime: BoxliteRuntime,
-    handle: Option<LiteBox>,
-    box_id: Option<BoxID>,
-    tokio_rt: Arc<TokioRuntime>,
-}
+// Define C-compatible type aliases for the C header
+pub type CBoxliteRuntime = RuntimeHandle;
+pub type CBoxHandle = BoxHandle;
+pub type CBoxliteSimple = BoxRunner;
+pub type CBoxliteError = FFIError;
+pub type CBoxliteExecResult = ExecResult;
 
 // ============================================================================
-// Error Conversion Helpers
+// Public API Functions
 // ============================================================================
-
-/// Map BoxliteError to BoxliteErrorCode
-fn error_to_code(err: &BoxliteError) -> BoxliteErrorCode {
-    match err {
-        BoxliteError::Internal(_) => BoxliteErrorCode::Internal,
-        BoxliteError::NotFound(_) => BoxliteErrorCode::NotFound,
-        BoxliteError::AlreadyExists(_) => BoxliteErrorCode::AlreadyExists,
-        BoxliteError::InvalidState(_) => BoxliteErrorCode::InvalidState,
-        BoxliteError::InvalidArgument(_) => BoxliteErrorCode::InvalidArgument,
-        BoxliteError::Config(_) => BoxliteErrorCode::Config,
-        BoxliteError::Storage(_) => BoxliteErrorCode::Storage,
-        BoxliteError::Image(_) => BoxliteErrorCode::Image,
-        BoxliteError::Network(_) => BoxliteErrorCode::Network,
-        BoxliteError::Execution(_) => BoxliteErrorCode::Execution,
-        BoxliteError::Stopped(_) => BoxliteErrorCode::Stopped,
-        BoxliteError::Engine(_) => BoxliteErrorCode::Engine,
-        BoxliteError::Unsupported(_) => BoxliteErrorCode::Unsupported,
-        BoxliteError::UnsupportedEngine => BoxliteErrorCode::Unsupported,
-        BoxliteError::Database(_) => BoxliteErrorCode::Database,
-        BoxliteError::Portal(_) => BoxliteErrorCode::Portal,
-        BoxliteError::Rpc(_) | BoxliteError::RpcTransport(_) => BoxliteErrorCode::Rpc,
-        BoxliteError::MetadataError(_) => BoxliteErrorCode::Internal,
-    }
-}
-
-/// Convert Rust error to C error struct
-fn error_to_c_error(err: BoxliteError) -> CBoxliteError {
-    let code = error_to_code(&err);
-    let message = error_to_c_string(err);
-    CBoxliteError { code, message }
-}
-
-/// Write error to output parameter (if not NULL)
-fn write_error(out_error: *mut CBoxliteError, err: BoxliteError) {
-    if !out_error.is_null() {
-        unsafe {
-            *out_error = error_to_c_error(err);
-        }
-    }
-}
-
-/// Helper to create InvalidArgument error for NULL pointers
-fn null_pointer_error(param_name: &str) -> BoxliteError {
-    BoxliteError::InvalidArgument(format!("{} is null", param_name))
-}
-
-/// Helper to convert Rust error to C string
-fn error_to_c_string(err: BoxliteError) -> *mut c_char {
-    let msg = format!("{}", err);
-    match CString::new(msg) {
-        Ok(s) => s.into_raw(),
-        Err(_) => {
-            let fallback = CString::new("Failed to format error message").unwrap();
-            fallback.into_raw()
-        }
-    }
-}
-
-/// Helper to convert C string to Rust string
-unsafe fn c_str_to_string(s: *const c_char) -> Result<String, BoxliteError> {
-    if s.is_null() {
-        return Err(BoxliteError::Internal("null pointer".to_string()));
-    }
-    unsafe {
-        CStr::from_ptr(s)
-            .to_str()
-            .map(|s| s.to_string())
-            .map_err(|e| BoxliteError::Internal(format!("invalid UTF-8: {}", e)))
-    }
-}
-
-/// Convert BoxStatus to string
-fn status_to_string(status: BoxStatus) -> &'static str {
-    match status {
-        BoxStatus::Unknown => "unknown",
-        BoxStatus::Configured => "configured",
-        BoxStatus::Running => "running",
-        BoxStatus::Stopping => "stopping",
-        BoxStatus::Stopped => "stopped",
-    }
-}
-
-/// Convert BoxInfo to JSON with nested state structure
-fn box_info_to_json(info: &BoxInfo) -> serde_json::Value {
-    serde_json::json!({
-        "id": info.id.to_string(),
-        "name": info.name,
-        "state": {
-            "status": status_to_string(info.status),
-            "running": info.status.is_running(),
-            "pid": info.pid
-        },
-        "created_at": info.created_at.to_rfc3339(),
-        "image": info.image,
-        "cpus": info.cpus,
-        "memory_mib": info.memory_mib
-    })
-}
 
 /// Get BoxLite version string
 ///
 /// # Returns
-/// Static string containing the version (e.g., "0.1.0")
-#[unsafe(no_mangle)]
-pub extern "C" fn boxlite_version() -> *const c_char {
-    // Static string, safe to return pointer
-    concat!(env!("CARGO_PKG_VERSION"), "\0").as_ptr() as *const c_char
-}
-
-/// Create a new BoxLite runtime
-///
-/// # Arguments
-/// * `home_dir` - Path to BoxLite home directory (stores images, rootfs, etc.)
-///                If NULL, uses default: ~/.boxlite
-/// * `registries_json` - JSON array of registries to search for unqualified images,
-///                       e.g. `["ghcr.io", "quay.io"]`. If NULL, uses default (docker.io).
-///                       Registries are tried in order; first successful pull wins.
-/// * `out_error` - Output parameter for error message (caller must free with boxlite_free_string)
-///
-/// # Returns
-/// Pointer to CBoxliteRuntime on success, NULL on failure
+/// A pointer to a static C string containing the version. Do not free this string.
 ///
 /// # Example
 /// ```c
-/// char *error = NULL;
-/// const char *registries = "[\"ghcr.io\", \"docker.io\"]";
-/// BoxliteRuntime *runtime = boxlite_runtime_new("/tmp/boxlite", registries, &error);
-/// if (!runtime) {
-///     fprintf(stderr, "Error: %s\n", error);
-///     boxlite_free_string(error);
-///     return 1;
+/// printf("BoxLite Version: %s\n", boxlite_version());
+/// ```
+#[unsafe(no_mangle)]
+pub extern "C" fn boxlite_version() -> *const c_char {
+    boxlite_ffi::ops::version()
+}
+
+/// Create a new BoxLite runtime configuration.
+///
+/// # Arguments
+/// * `home_dir` - Optional path to the home directory. If NULL, defaults to `~/.boxlite`.
+/// * `registries_json` - Optional JSON array of registry configurations.
+/// * `out_runtime` - Output parameter to store the created `CBoxliteRuntime` pointer.
+/// * `out_error` - Output parameter for error information.
+///
+/// # Returns
+/// `BoxliteErrorCode::Ok` on success, or an error code on failure.
+///
+/// # Example
+/// ```c
+/// CBoxliteRuntime *runtime;
+/// CBoxliteError *error = malloc(sizeof(CBoxliteError));
+/// if (boxlite_runtime_new(NULL, NULL, &runtime, error) != BOXLITE_OK) {
+///     fprintf(stderr, "Failed to create runtime\n");
 /// }
 /// ```
 #[unsafe(no_mangle)]
@@ -261,80 +72,27 @@ pub unsafe extern "C" fn boxlite_runtime_new(
     out_runtime: *mut *mut CBoxliteRuntime,
     out_error: *mut CBoxliteError,
 ) -> BoxliteErrorCode {
-    if out_runtime.is_null() {
-        write_error(out_error, null_pointer_error("out_runtime"));
-        return BoxliteErrorCode::InvalidArgument;
-    }
-
-    // Create tokio runtime
-    let tokio_rt = match TokioRuntime::new() {
-        Ok(rt) => Arc::new(rt),
-        Err(e) => {
-            let err = BoxliteError::Internal(format!("Failed to create async runtime: {}", e));
-            write_error(out_error, err);
-            return BoxliteErrorCode::Internal;
-        }
-    };
-
-    // Parse options
-    let mut options = BoxliteOptions::default();
-    if !home_dir.is_null() {
-        match c_str_to_string(home_dir) {
-            Ok(path) => options.home_dir = path.into(),
-            Err(e) => {
-                write_error(out_error, e);
-                return BoxliteErrorCode::InvalidArgument;
-            }
-        }
-    }
-
-    // Parse image registries (JSON array)
-    if !registries_json.is_null() {
-        match c_str_to_string(registries_json) {
-            Ok(json_str) => match serde_json::from_str::<Vec<String>>(&json_str) {
-                Ok(registries) => options.image_registries = registries,
-                Err(e) => {
-                    let err = BoxliteError::Internal(format!("Invalid registries JSON: {}", e));
-                    write_error(out_error, err);
-                    return BoxliteErrorCode::Internal;
-                }
-            },
-            Err(e) => {
-                write_error(out_error, e);
-                return BoxliteErrorCode::InvalidArgument;
-            }
-        }
-    }
-
-    // Create runtime
-    let runtime = match BoxliteRuntime::new(options) {
-        Ok(rt) => rt,
-        Err(e) => {
-            let code = error_to_code(&e);
-            write_error(out_error, e);
-            return code;
-        }
-    };
-
-    *out_runtime = Box::into_raw(Box::new(CBoxliteRuntime { runtime, tokio_rt }));
-    BoxliteErrorCode::Ok
+    boxlite_ffi::ops::runtime_new(home_dir, registries_json, out_runtime, out_error)
 }
 
-/// Create a new box with the given options (JSON)
+/// Create a new box with the given options (JSON).
 ///
 /// # Arguments
-/// * `runtime` - BoxLite runtime instance
-/// * `options_json` - JSON-encoded BoxOptions, e.g.:
-///                    `{"rootfs": {"Image": "alpine:3.19"}, "working_dir": "/workspace"}`
-/// * `out_error` - Output parameter for error message
+/// * `runtime` - Pointer to the active `CBoxliteRuntime`.
+/// * `options_json` - JSON string defining the box (e.g., image, resources).
+/// * `out_box` - Output parameter to store the created `CBoxHandle`.
+/// * `out_error` - Output parameter for error information.
 ///
 /// # Returns
-/// Pointer to CBoxHandle on success, NULL on failure
+/// `BoxliteErrorCode::Ok` on success.
 ///
 /// # Example
 /// ```c
-/// const char *opts = "{\"rootfs\":{\"Image\":\"alpine:3.19\"}}";
-/// BoxHandle *box = boxlite_create_box(runtime, opts, &error);
+/// const char *options = "{\"rootfs\": {\"Image\": \"alpine:latest\"}}";
+/// CBoxHandle *box;
+/// if (boxlite_create_box(runtime, options, &box, error) == BOXLITE_OK) {
+///     // Use box...
+/// }
 /// ```
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn boxlite_create_box(
@@ -343,81 +101,29 @@ pub unsafe extern "C" fn boxlite_create_box(
     out_box: *mut *mut CBoxHandle,
     out_error: *mut CBoxliteError,
 ) -> BoxliteErrorCode {
-    if runtime.is_null() {
-        write_error(out_error, null_pointer_error("runtime"));
-        return BoxliteErrorCode::InvalidArgument;
-    }
-    if out_box.is_null() {
-        write_error(out_error, null_pointer_error("out_box"));
-        return BoxliteErrorCode::InvalidArgument;
-    }
-
-    let runtime_ref = &mut *runtime;
-
-    // Parse JSON options
-    let options_str = match c_str_to_string(options_json) {
-        Ok(s) => s,
-        Err(e) => {
-            write_error(out_error, e);
-            return BoxliteErrorCode::InvalidArgument;
-        }
-    };
-
-    let options: BoxOptions = match serde_json::from_str(&options_str) {
-        Ok(opts) => opts,
-        Err(e) => {
-            let err = BoxliteError::Internal(format!("Invalid JSON options: {}", e));
-            write_error(out_error, err);
-            return BoxliteErrorCode::Internal;
-        }
-    };
-
-    // Create box (no name support in C API yet)
-    // create() is async, so we block on the tokio runtime
-    let result = runtime_ref
-        .tokio_rt
-        .block_on(runtime_ref.runtime.create(options, None));
-
-    match result {
-        Ok(handle) => {
-            let box_id = handle.id().clone();
-            *out_box = Box::into_raw(Box::new(CBoxHandle {
-                handle,
-                box_id,
-                tokio_rt: runtime_ref.tokio_rt.clone(),
-            }));
-            BoxliteErrorCode::Ok
-        }
-        Err(e) => {
-            let code = error_to_code(&e);
-            write_error(out_error, e);
-            code
-        }
-    }
+    boxlite_ffi::ops::box_create(runtime, options_json, std::ptr::null(), out_box, out_error)
 }
 
-/// Execute a command in a box
+/// Execute a command in a box.
 ///
 /// # Arguments
-/// * `handle` - Box handle
-/// * `command` - Command to execute
-/// * `args_json` - JSON array of arguments, e.g.: `["arg1", "arg2"]`
-/// * `callback` - Optional callback for streaming output (chunk_text, is_stderr, user_data)
-/// * `user_data` - User data passed to callback
-/// * `out_exit_code` - Output parameter for command exit code
-/// * `out_error` - Output parameter for error information
+/// * `handle` - Box handle.
+/// * `command` - Command to execute (e.g., "/bin/sh").
+/// * `args_json` - JSON array of arguments, e.g.: `["-c", "echo hello"]`.
+/// * `callback` - Optional callback for streaming output.
+/// * `user_data` - User data passed to callback.
+/// * `out_exit_code` - Output parameter for command exit code.
+/// * `out_error` - Output parameter for error information.
 ///
 /// # Returns
-/// BoxliteErrorCode::Ok on success, error code on failure
+/// `BoxliteErrorCode::Ok` on success.
 ///
 /// # Example
 /// ```c
 /// int exit_code;
-/// CBoxliteError error = {0};
 /// const char *args = "[\"hello\"]";
-/// BoxliteErrorCode code = boxlite_execute(box, "echo", args, NULL, NULL, &exit_code, &error);
-/// if (code == BOXLITE_OK) {
-///     printf("Command exited with code: %d\n", exit_code);
+/// if (boxlite_execute(box, "echo", args, NULL, NULL, &exit_code, error) == BOXLITE_OK) {
+///     printf("Exit code: %d\n", exit_code);
 /// }
 /// ```
 #[unsafe(no_mangle)]
@@ -430,168 +136,49 @@ pub unsafe extern "C" fn boxlite_execute(
     out_exit_code: *mut c_int,
     out_error: *mut CBoxliteError,
 ) -> BoxliteErrorCode {
-    if handle.is_null() {
-        write_error(out_error, null_pointer_error("handle"));
-        return BoxliteErrorCode::InvalidArgument;
-    }
-
-    if out_exit_code.is_null() {
-        write_error(out_error, null_pointer_error("out_exit_code"));
-        return BoxliteErrorCode::InvalidArgument;
-    }
-
-    let handle_ref = &mut *handle;
-
-    // Parse command
-    let cmd_str = match c_str_to_string(command) {
-        Ok(s) => s,
-        Err(e) => {
-            let code = error_to_code(&e);
-            write_error(out_error, e);
-            return code;
-        }
-    };
-
-    // Parse args
-    let args: Vec<String> = if !args_json.is_null() {
-        match c_str_to_string(args_json) {
-            Ok(json_str) => match serde_json::from_str(&json_str) {
-                Ok(a) => a,
-                Err(e) => {
-                    let err = BoxliteError::Internal(format!("Invalid args JSON: {}", e));
-                    write_error(out_error, err);
-                    return BoxliteErrorCode::InvalidArgument;
-                }
-            },
-            Err(e) => {
-                let code = error_to_code(&e);
-                write_error(out_error, e);
-                return code;
-            }
-        }
-    } else {
-        vec![]
-    };
-
-    let mut cmd = boxlite::BoxCommand::new(cmd_str);
-    cmd = cmd.args(args);
-
-    // Execute command using new API
-    let result = handle_ref.tokio_rt.block_on(async {
-        let mut execution = handle_ref.handle.exec(cmd).await?;
-
-        // Stream output to callback if provided
-        if let Some(cb) = callback {
-            use futures::StreamExt;
-
-            // Take stdout and stderr
-            let mut stdout = execution.stdout();
-            let mut stderr = execution.stderr();
-
-            // Read both streams
-            loop {
-                tokio::select! {
-                    Some(line) = async {
-                        match &mut stdout {
-                            Some(s) => s.next().await,
-                            None => None,
-                        }
-                    } => {
-                        let c_text = CString::new(line).unwrap_or_default();
-                        cb(c_text.as_ptr(), 0, user_data); // 0 = stdout
-                    }
-                    Some(line) = async {
-                        match &mut stderr {
-                            Some(s) => s.next().await,
-                            None => None,
-                        }
-                    } => {
-                        let c_text = CString::new(line).unwrap_or_default();
-                        cb(c_text.as_ptr(), 1, user_data); // 1 = stderr
-                    }
-                    else => break,
-                }
-            }
-        }
-
-        // Wait for execution to complete
-        let status = execution.wait().await?;
-        Ok::<i32, BoxliteError>(status.exit_code)
-    });
-
-    match result {
-        Ok(exit_code) => {
-            *out_exit_code = exit_code;
-            BoxliteErrorCode::Ok
-        }
-        Err(e) => {
-            let code = error_to_code(&e);
-            write_error(out_error, e);
-            code
-        }
-    }
+    boxlite_ffi::ops::box_exec(
+        handle,
+        command,
+        args_json,
+        callback,
+        user_data,
+        out_exit_code,
+        out_error,
+    )
 }
 
-/// Stop a box
+/// Stop a box.
 ///
 /// # Arguments
-/// * `handle` - Box handle (will be consumed/freed)
-/// * `out_error` - Output parameter for error information
+/// * `handle` - Box handle.
+/// * `out_error` - output error.
 ///
-/// # Returns
-/// BoxliteErrorCode::Ok on success, error code on failure
+/// # Example
+/// ```c
+/// boxlite_stop_box(box, error);
+/// ```
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn boxlite_stop_box(
     handle: *mut CBoxHandle,
     out_error: *mut CBoxliteError,
 ) -> BoxliteErrorCode {
-    if handle.is_null() {
-        write_error(out_error, null_pointer_error("handle"));
-        return BoxliteErrorCode::InvalidArgument;
-    }
-
-    let handle_box = Box::from_raw(handle);
-
-    // Block on async stop using the stored tokio runtime
-    let result = handle_box.tokio_rt.block_on(handle_box.handle.stop());
-
-    match result {
-        Ok(_) => BoxliteErrorCode::Ok,
-        Err(e) => {
-            let code = error_to_code(&e);
-            write_error(out_error, e);
-            code
-        }
-    }
+    boxlite_ffi::ops::box_stop(handle, out_error)
 }
 
-// ============================================================================
-// NEW API FUNCTIONS - Python SDK Parity
-// ============================================================================
-
-/// List all boxes as JSON
+/// List all boxes as JSON.
 ///
 /// # Arguments
-/// * `runtime` - BoxLite runtime instance
-/// * `out_json` - Output parameter for JSON array of box info
-/// * `out_error` - Output parameter for error information
+/// * `runtime` - Runtime handle.
+/// * `out_json` - Output pointer for JSON string. Caller must free this with `boxlite_free_string`.
+/// * `out_error` - Output error.
 ///
-/// # Returns
-/// BoxliteErrorCode::Ok on success, error code on failure
-///
-/// # JSON Format
-/// ```json
-/// [
-///   {
-///     "id": "01HJK4TNRPQSXYZ8WM6NCVT9R5",
-///     "name": "my-box",
-///     "state": { "status": "running", "running": true, "pid": 12345 },
-///     "created_at": "2024-01-15T10:30:00Z",
-///     "image": "alpine:3.19",
-///     "cpus": 2,
-///     "memory_mib": 512
-///   }
-/// ]
+/// # Example
+/// ```c
+/// char *json;
+/// if (boxlite_list_info(runtime, &json, error) == BOXLITE_OK) {
+///     printf("Boxes: %s\n", json);
+///     boxlite_free_string(json);
+/// }
 /// ```
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn boxlite_list_info(
@@ -599,63 +186,22 @@ pub unsafe extern "C" fn boxlite_list_info(
     out_json: *mut *mut c_char,
     out_error: *mut CBoxliteError,
 ) -> BoxliteErrorCode {
-    if runtime.is_null() {
-        write_error(out_error, null_pointer_error("runtime"));
-        return BoxliteErrorCode::InvalidArgument;
-    }
-    if out_json.is_null() {
-        write_error(out_error, null_pointer_error("out_json"));
-        return BoxliteErrorCode::InvalidArgument;
-    }
-
-    let runtime_ref = &*runtime;
-
-    let result = runtime_ref
-        .tokio_rt
-        .block_on(runtime_ref.runtime.list_info());
-
-    match result {
-        Ok(boxes) => {
-            let json_array: Vec<serde_json::Value> = boxes.iter().map(box_info_to_json).collect();
-            let json_str = match serde_json::to_string(&json_array) {
-                Ok(s) => s,
-                Err(e) => {
-                    let err = BoxliteError::Internal(format!("JSON serialization failed: {}", e));
-                    write_error(out_error, err);
-                    return BoxliteErrorCode::Internal;
-                }
-            };
-
-            match CString::new(json_str) {
-                Ok(s) => {
-                    *out_json = s.into_raw();
-                    BoxliteErrorCode::Ok
-                }
-                Err(e) => {
-                    let err = BoxliteError::Internal(format!("CString conversion failed: {}", e));
-                    write_error(out_error, err);
-                    BoxliteErrorCode::Internal
-                }
-            }
-        }
-        Err(e) => {
-            let code = error_to_code(&e);
-            write_error(out_error, e);
-            code
-        }
-    }
+    boxlite_ffi::ops::box_list(runtime, out_json, out_error)
 }
 
-/// Get single box info as JSON
+/// Get single box info as JSON.
 ///
 /// # Arguments
-/// * `runtime` - BoxLite runtime instance
-/// * `id_or_name` - Box ID (full or prefix) or name
-/// * `out_json` - Output parameter for JSON object
-/// * `out_error` - Output parameter for error information
+/// * `runtime` - Runtime handle.
+/// * `id_or_name` - ID or name of the box.
+/// * `out_json` - Output pointer for JSON string.
+/// * `out_error` - Output error.
 ///
-/// # Returns
-/// BoxliteErrorCode::Ok on success, error code on failure (including box not found)
+/// # Example
+/// ```c
+/// char *json;
+/// boxlite_get_info(runtime, "my-box", &json, error);
+/// ```
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn boxlite_get_info(
     runtime: *mut CBoxliteRuntime,
@@ -663,75 +209,24 @@ pub unsafe extern "C" fn boxlite_get_info(
     out_json: *mut *mut c_char,
     out_error: *mut CBoxliteError,
 ) -> BoxliteErrorCode {
-    if runtime.is_null() {
-        write_error(out_error, null_pointer_error("runtime"));
-        return BoxliteErrorCode::InvalidArgument;
-    }
-    if out_json.is_null() {
-        write_error(out_error, null_pointer_error("out_json"));
-        return BoxliteErrorCode::InvalidArgument;
-    }
-
-    let runtime_ref = &*runtime;
-
-    let id_str = match c_str_to_string(id_or_name) {
-        Ok(s) => s,
-        Err(e) => {
-            write_error(out_error, e);
-            return BoxliteErrorCode::InvalidArgument;
-        }
-    };
-
-    let result = runtime_ref
-        .tokio_rt
-        .block_on(runtime_ref.runtime.get_info(&id_str));
-
-    match result {
-        Ok(Some(info)) => {
-            let json_str = match serde_json::to_string(&box_info_to_json(&info)) {
-                Ok(s) => s,
-                Err(e) => {
-                    let err = BoxliteError::Internal(format!("JSON serialization failed: {}", e));
-                    write_error(out_error, err);
-                    return BoxliteErrorCode::Internal;
-                }
-            };
-
-            match CString::new(json_str) {
-                Ok(s) => {
-                    *out_json = s.into_raw();
-                    BoxliteErrorCode::Ok
-                }
-                Err(e) => {
-                    let err = BoxliteError::Internal(format!("CString conversion failed: {}", e));
-                    write_error(out_error, err);
-                    BoxliteErrorCode::Internal
-                }
-            }
-        }
-        Ok(None) => {
-            let err = BoxliteError::NotFound(id_str.clone());
-            write_error(out_error, err);
-            BoxliteErrorCode::NotFound
-        }
-        Err(e) => {
-            let code = error_to_code(&e);
-            write_error(out_error, e);
-            code
-        }
-    }
+    boxlite_ffi::ops::box_inspect(runtime, id_or_name, out_json, out_error)
 }
 
-/// Get box handle for reattaching to an existing box
+/// Attach to an existing box.
 ///
 /// # Arguments
-/// * `runtime` - BoxLite runtime instance
-/// * `id_or_name` - Box ID (full or prefix) or name
-/// * `out_handle` - Output parameter for box handle
-/// * `out_error` - Output parameter for error information
+/// * `runtime` - Runtime handle.
+/// * `id_or_name` - ID or name of the box.
+/// * `out_handle` - Output pointer for box handle.
+/// * `out_error` - Output error.
 ///
-/// # Returns
-/// BoxliteErrorCode::Ok on success, error code on failure (including box not found)
+/// # Example
+/// ```c
+/// CBoxHandle *handle;
+/// if (boxlite_get(runtime, "my-box", &handle, error) == BOXLITE_OK) {
+///     // Use handle...
+/// }
+/// ```
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn boxlite_get(
     runtime: *mut CBoxliteRuntime,
@@ -739,62 +234,21 @@ pub unsafe extern "C" fn boxlite_get(
     out_handle: *mut *mut CBoxHandle,
     out_error: *mut CBoxliteError,
 ) -> BoxliteErrorCode {
-    if runtime.is_null() {
-        write_error(out_error, null_pointer_error("runtime"));
-        return BoxliteErrorCode::InvalidArgument;
-    }
-    if out_handle.is_null() {
-        write_error(out_error, null_pointer_error("out_handle"));
-        return BoxliteErrorCode::InvalidArgument;
-    }
-
-    let runtime_ref = &*runtime;
-
-    let id_str = match c_str_to_string(id_or_name) {
-        Ok(s) => s,
-        Err(e) => {
-            write_error(out_error, e);
-            return BoxliteErrorCode::InvalidArgument;
-        }
-    };
-
-    let result = runtime_ref
-        .tokio_rt
-        .block_on(runtime_ref.runtime.get(&id_str));
-
-    match result {
-        Ok(Some(handle)) => {
-            let box_id = handle.id().clone();
-            *out_handle = Box::into_raw(Box::new(CBoxHandle {
-                handle,
-                box_id,
-                tokio_rt: runtime_ref.tokio_rt.clone(),
-            }));
-            BoxliteErrorCode::Ok
-        }
-        Ok(None) => {
-            let err = BoxliteError::NotFound(id_str.clone());
-            write_error(out_error, err);
-            BoxliteErrorCode::NotFound
-        }
-        Err(e) => {
-            let code = error_to_code(&e);
-            write_error(out_error, e);
-            code
-        }
-    }
+    boxlite_ffi::ops::box_attach(runtime, id_or_name, out_handle, out_error)
 }
 
-/// Remove a box
+/// Remove a box.
 ///
 /// # Arguments
-/// * `runtime` - BoxLite runtime instance
-/// * `id_or_name` - Box ID (full or prefix) or name
-/// * `force` - If non-zero, force remove even if running
-/// * `out_error` - Output parameter for error information
+/// * `runtime` - Runtime handle.
+/// * `id_or_name` - ID or name of the box.
+/// * `force` - 1 to force remove (stop if running), 0 otherwise.
+/// * `out_error` - Output error.
 ///
-/// # Returns
-/// BoxliteErrorCode::Ok on success, error code on failure
+/// # Example
+/// ```c
+/// boxlite_remove(runtime, "my-box", 1, error);
+/// ```
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn boxlite_remove(
     runtime: *mut CBoxliteRuntime,
@@ -802,331 +256,156 @@ pub unsafe extern "C" fn boxlite_remove(
     force: c_int,
     out_error: *mut CBoxliteError,
 ) -> BoxliteErrorCode {
-    if runtime.is_null() {
-        write_error(out_error, null_pointer_error("runtime"));
-        return BoxliteErrorCode::InvalidArgument;
-    }
-
-    let runtime_ref = &*runtime;
-
-    let id_str = match c_str_to_string(id_or_name) {
-        Ok(s) => s,
-        Err(e) => {
-            write_error(out_error, e);
-            return BoxliteErrorCode::InvalidArgument;
-        }
-    };
-
-    let result = runtime_ref
-        .tokio_rt
-        .block_on(runtime_ref.runtime.remove(&id_str, force != 0));
-
-    match result {
-        Ok(_) => BoxliteErrorCode::Ok,
-        Err(e) => {
-            let code = error_to_code(&e);
-            write_error(out_error, e);
-            code
-        }
-    }
+    boxlite_ffi::ops::box_remove(runtime, id_or_name, force != 0, out_error)
 }
 
-/// Get runtime metrics as JSON
+/// Get runtime metrics as JSON.
 ///
 /// # Arguments
-/// * `runtime` - BoxLite runtime instance
-/// * `out_json` - Output parameter for JSON object
-/// * `out_error` - Output parameter for error information
+/// * `runtime` - Runtime handle.
+/// * `out_json` - Output pointer for JSON string.
+/// * `out_error` - Output error.
 ///
-/// # Returns
-/// BoxliteErrorCode::Ok on success, error code on failure
+/// # Example
+/// ```c
+/// char *json;
+/// boxlite_runtime_metrics(runtime, &json, error);
+/// ```
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn boxlite_runtime_metrics(
     runtime: *mut CBoxliteRuntime,
     out_json: *mut *mut c_char,
     out_error: *mut CBoxliteError,
 ) -> BoxliteErrorCode {
-    if runtime.is_null() {
-        write_error(out_error, null_pointer_error("runtime"));
-        return BoxliteErrorCode::InvalidArgument;
-    }
-    if out_json.is_null() {
-        write_error(out_error, null_pointer_error("out_json"));
-        return BoxliteErrorCode::InvalidArgument;
-    }
-
-    let runtime_ref = &*runtime;
-
-    let metrics = runtime_ref.tokio_rt.block_on(runtime_ref.runtime.metrics());
-
-    let json = serde_json::json!({
-        "boxes_created_total": metrics.boxes_created_total(),
-        "boxes_failed_total": metrics.boxes_failed_total(),
-        "num_running_boxes": metrics.num_running_boxes(),
-        "total_commands_executed": metrics.total_commands_executed(),
-        "total_exec_errors": metrics.total_exec_errors()
-    });
-
-    let json_str = match serde_json::to_string(&json) {
-        Ok(s) => s,
-        Err(e) => {
-            let err = BoxliteError::Internal(format!("JSON serialization failed: {}", e));
-            write_error(out_error, err);
-            return BoxliteErrorCode::Internal;
-        }
-    };
-
-    match CString::new(json_str) {
-        Ok(s) => {
-            *out_json = s.into_raw();
-            BoxliteErrorCode::Ok
-        }
-        Err(e) => {
-            let err = BoxliteError::Internal(format!("CString conversion failed: {}", e));
-            write_error(out_error, err);
-            BoxliteErrorCode::Internal
-        }
-    }
+    boxlite_ffi::ops::runtime_metrics(runtime, out_json, out_error)
 }
 
 /// Gracefully shutdown all boxes in this runtime.
 ///
-/// This method stops all running boxes, waiting up to `timeout` seconds
-/// for each box to stop gracefully before force-killing it.
-///
-/// After calling this method, the runtime is permanently shut down and
-/// will return errors for any new operations (like `create()`).
-///
 /// # Arguments
-/// * `runtime` - BoxLite runtime instance
+/// * `runtime` - Runtime handle.
 /// * `timeout` - Seconds to wait before force-killing each box:
 ///   - 0 - Use default timeout (10 seconds)
 ///   - Positive integer - Wait that many seconds
 ///   - -1 - Wait indefinitely (no timeout)
 /// * `out_error` - Output parameter for error information
 ///
-/// # Returns
-/// BoxliteErrorCode::Ok on success, error code on failure
+/// # Example
+/// ```c
+/// boxlite_runtime_shutdown(runtime, 5, error);
+/// ```
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn boxlite_runtime_shutdown(
     runtime: *mut CBoxliteRuntime,
     timeout: c_int,
     out_error: *mut CBoxliteError,
 ) -> BoxliteErrorCode {
-    if runtime.is_null() {
-        write_error(out_error, null_pointer_error("runtime"));
-        return BoxliteErrorCode::InvalidArgument;
-    }
-
-    let runtime_ref = &*runtime;
-
-    // C API: 0 = default (maps to Rust None), positive = timeout, -1 = infinite
     let timeout_opt = if timeout == 0 { None } else { Some(timeout) };
-
-    let result = runtime_ref
-        .tokio_rt
-        .block_on(runtime_ref.runtime.shutdown(timeout_opt));
-
-    match result {
-        Ok(()) => BoxliteErrorCode::Ok,
-        Err(e) => {
-            let code = error_to_code(&e);
-            write_error(out_error, e);
-            code
-        }
-    }
+    boxlite_ffi::ops::runtime_shutdown(runtime, timeout_opt, out_error)
 }
 
-/// Get box info from handle as JSON
+/// Get info for a box handle as JSON.
 ///
 /// # Arguments
-/// * `handle` - Box handle
-/// * `out_json` - Output parameter for JSON object
-/// * `out_error` - Output parameter for error information
+/// * `handle` - Box handle.
+/// * `out_json` - Output pointer for JSON string.
+/// * `out_error` - Output error.
 ///
-/// # Returns
-/// BoxliteErrorCode::Ok on success, error code on failure
+/// # Example
+/// ```c
+/// char *json;
+/// boxlite_box_info(handle, &json, error);
+/// ```
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn boxlite_box_info(
     handle: *mut CBoxHandle,
     out_json: *mut *mut c_char,
     out_error: *mut CBoxliteError,
 ) -> BoxliteErrorCode {
-    if handle.is_null() {
-        write_error(out_error, null_pointer_error("handle"));
-        return BoxliteErrorCode::InvalidArgument;
-    }
-    if out_json.is_null() {
-        write_error(out_error, null_pointer_error("out_json"));
-        return BoxliteErrorCode::InvalidArgument;
-    }
-
-    let handle_ref = &*handle;
-    let info = handle_ref.handle.info();
-
-    let json_str = match serde_json::to_string(&box_info_to_json(&info)) {
-        Ok(s) => s,
-        Err(e) => {
-            let err = BoxliteError::Internal(format!("JSON serialization failed: {}", e));
-            write_error(out_error, err);
-            return BoxliteErrorCode::Internal;
-        }
-    };
-
-    match CString::new(json_str) {
-        Ok(s) => {
-            *out_json = s.into_raw();
-            BoxliteErrorCode::Ok
-        }
-        Err(e) => {
-            let err = BoxliteError::Internal(format!("CString conversion failed: {}", e));
-            write_error(out_error, err);
-            BoxliteErrorCode::Internal
-        }
-    }
+    boxlite_ffi::ops::box_inspect_handle(handle, out_json, out_error)
 }
 
-/// Get box metrics from handle as JSON
+/// Get metrics for a box handle as JSON.
 ///
 /// # Arguments
-/// * `handle` - Box handle
-/// * `out_json` - Output parameter for JSON object
-/// * `out_error` - Output parameter for error information
+/// * `handle` - Box handle.
+/// * `out_json` - Output pointer for JSON string.
+/// * `out_error` - Output error.
 ///
-/// # Returns
-/// BoxliteErrorCode::Ok on success, error code on failure
+/// # Example
+/// ```c
+/// char *json;
+/// boxlite_box_metrics(handle, &json, error);
+/// ```
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn boxlite_box_metrics(
     handle: *mut CBoxHandle,
     out_json: *mut *mut c_char,
     out_error: *mut CBoxliteError,
 ) -> BoxliteErrorCode {
-    if handle.is_null() {
-        write_error(out_error, null_pointer_error("handle"));
-        return BoxliteErrorCode::InvalidArgument;
-    }
-    if out_json.is_null() {
-        write_error(out_error, null_pointer_error("out_json"));
-        return BoxliteErrorCode::InvalidArgument;
-    }
-
-    let handle_ref = &*handle;
-
-    let result = handle_ref.tokio_rt.block_on(handle_ref.handle.metrics());
-
-    match result {
-        Ok(metrics) => {
-            let json = serde_json::json!({
-                "cpu_percent": metrics.cpu_percent,
-                "memory_bytes": metrics.memory_bytes,
-                "commands_executed_total": metrics.commands_executed_total,
-                "exec_errors_total": metrics.exec_errors_total,
-                "bytes_sent_total": metrics.bytes_sent_total,
-                "bytes_received_total": metrics.bytes_received_total,
-                "total_create_duration_ms": metrics.total_create_duration_ms,
-                "guest_boot_duration_ms": metrics.guest_boot_duration_ms,
-                "network_bytes_sent": metrics.network_bytes_sent,
-                "network_bytes_received": metrics.network_bytes_received,
-                "network_tcp_connections": metrics.network_tcp_connections,
-                "network_tcp_errors": metrics.network_tcp_errors
-            });
-
-            let json_str = match serde_json::to_string(&json) {
-                Ok(s) => s,
-                Err(e) => {
-                    let err = BoxliteError::Internal(format!("JSON serialization failed: {}", e));
-                    write_error(out_error, err);
-                    return BoxliteErrorCode::Internal;
-                }
-            };
-
-            match CString::new(json_str) {
-                Ok(s) => {
-                    *out_json = s.into_raw();
-                    BoxliteErrorCode::Ok
-                }
-                Err(e) => {
-                    let err = BoxliteError::Internal(format!("CString conversion failed: {}", e));
-                    write_error(out_error, err);
-                    BoxliteErrorCode::Internal
-                }
-            }
-        }
-        Err(e) => {
-            let code = error_to_code(&e);
-            write_error(out_error, e);
-            code
-        }
-    }
+    boxlite_ffi::ops::box_metrics(handle, out_json, out_error)
 }
 
-/// Start or restart a stopped box
+/// Start a stopped box.
 ///
 /// # Arguments
-/// * `handle` - Box handle
-/// * `out_error` - Output parameter for error information
+/// * `handle` - Box handle.
+/// * `out_error` - output error.
 ///
-/// # Returns
-/// BoxliteErrorCode::Ok on success, error code on failure
+/// # Example
+/// ```c
+/// boxlite_start_box(handle, error);
+/// ```
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn boxlite_start_box(
     handle: *mut CBoxHandle,
     out_error: *mut CBoxliteError,
 ) -> BoxliteErrorCode {
-    if handle.is_null() {
-        write_error(out_error, null_pointer_error("handle"));
-        return BoxliteErrorCode::InvalidArgument;
-    }
-
-    let handle_ref = &*handle;
-
-    let result = handle_ref.tokio_rt.block_on(handle_ref.handle.start());
-
-    match result {
-        Ok(_) => BoxliteErrorCode::Ok,
-        Err(e) => {
-            let code = error_to_code(&e);
-            write_error(out_error, e);
-            code
-        }
-    }
+    boxlite_ffi::ops::box_start(handle, out_error)
 }
 
-/// Get box ID string from handle
+/// Get box ID.
 ///
 /// # Arguments
-/// * `handle` - Box handle
+/// * `handle` - Box handle.
 ///
 /// # Returns
-/// Pointer to C string (caller must free with boxlite_free_string), NULL on failure
+/// Pointer to a C string containing the ID. Must be freed with `boxlite_free_string`.
+///
+/// # Example
+/// ```c
+/// char *id = boxlite_box_id(handle);
+/// printf("Box ID: %s\n", id);
+/// boxlite_free_string(id);
+/// ```
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn boxlite_box_id(handle: *mut CBoxHandle) -> *mut c_char {
-    if handle.is_null() {
-        return ptr::null_mut();
-    }
-
-    let handle_ref = &*handle;
-    let id_str = handle_ref.handle.id().to_string();
-
-    match CString::new(id_str) {
-        Ok(s) => s.into_raw(),
-        Err(_) => ptr::null_mut(),
-    }
+    boxlite_ffi::ops::box_id(handle)
 }
 
 // ============================================================================
-// Simple Convenience API
+// Runner API (formerly Simple API)
 // ============================================================================
 
-/// Result structure for simple API command execution
-#[repr(C)]
-pub struct CBoxliteExecResult {
-    pub exit_code: c_int,
-    pub stdout_text: *mut c_char,
-    pub stderr_text: *mut c_char,
-}
-
-/// Create and start a box using simple API
+/// Create a simplified box runner.
+///
+/// # Arguments
+/// * `image` - Container image.
+/// * `cpus` - Number of CPUs.
+/// * `memory_mib` - Memory in MiB.
+/// * `out_box` - Output pointer for `CBoxliteSimple,`.
+/// * `out_error` - Output error.
+///
+/// # Returns
+/// `BoxliteErrorCode::Ok` on success.
+///
+/// # Example
+/// ```c
+/// CBoxliteSimple, *runner;
+/// if (boxlite_simple_new("alpine", 1, 128, &runner, error) == BOXLITE_OK) {
+///     // Use runner...
+/// }
+/// ```
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn boxlite_simple_new(
     image: *const c_char,
@@ -1135,420 +414,91 @@ pub unsafe extern "C" fn boxlite_simple_new(
     out_box: *mut *mut CBoxliteSimple,
     out_error: *mut CBoxliteError,
 ) -> BoxliteErrorCode {
-    if image.is_null() {
-        write_error(out_error, null_pointer_error("image"));
-        return BoxliteErrorCode::InvalidArgument;
-    }
-    if out_box.is_null() {
-        write_error(out_error, null_pointer_error("out_box"));
-        return BoxliteErrorCode::InvalidArgument;
-    }
-
-    let image_str = match c_str_to_string(image) {
-        Ok(s) => s,
-        Err(e) => {
-            write_error(out_error, e);
-            return BoxliteErrorCode::InvalidArgument;
-        }
-    };
-
-    let tokio_rt = match TokioRuntime::new() {
-        Ok(rt) => Arc::new(rt),
-        Err(e) => {
-            let err = BoxliteError::Internal(format!("Failed to create async runtime: {}", e));
-            write_error(out_error, err);
-            return BoxliteErrorCode::Internal;
-        }
-    };
-
-    let runtime = match BoxliteRuntime::new(BoxliteOptions::default()) {
-        Ok(rt) => rt,
-        Err(e) => {
-            write_error(out_error, e);
-            return BoxliteErrorCode::Internal;
-        }
-    };
-
-    let options = BoxOptions {
-        rootfs: RootfsSpec::Image(image_str),
-        cpus: if cpus > 0 { Some(cpus as u8) } else { None },
-        memory_mib: if memory_mib > 0 {
-            Some(memory_mib as u32)
-        } else {
-            None
-        },
-        ..Default::default()
-    };
-
-    let result = tokio_rt.block_on(async {
-        let handle = runtime.create(options, None).await?;
-        let box_id = handle.id().clone();
-        Ok::<(LiteBox, BoxID), BoxliteError>((handle, box_id))
-    });
-
-    match result {
-        Ok((handle, box_id)) => {
-            let simple_box = Box::new(CBoxliteSimple {
-                runtime,
-                handle: Some(handle),
-                box_id: Some(box_id),
-                tokio_rt,
-            });
-            *out_box = Box::into_raw(simple_box);
-            BoxliteErrorCode::Ok
-        }
-        Err(e) => {
-            let code = error_to_code(&e);
-            write_error(out_error, e);
-            code
-        }
-    }
+    boxlite_ffi::ops::runner_new(image, cpus, memory_mib, out_box, out_error)
 }
 
-/// Run a command and get buffered result
+/// Run a command using the simplified runner.
+///
+/// # Arguments
+/// * `box_runner` - Runner handle.
+/// * `command` - Command to execute.
+/// * `args` - Array of argument strings.
+/// * `argc` - Count of arguments.
+/// * `out_result` - Output pointer for `CBoxliteExecResult`.
+/// * `out_error` - Output error.
+///
+/// # Example
+/// ```c
+/// CBoxliteExecResult *result;
+/// const char *args[] = {"hello"};
+/// boxlite_simple_run(runner, "echo", args, 1, &result, error);
+/// ```
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn boxlite_simple_run(
-    simple_box: *mut CBoxliteSimple,
+    box_runner: *mut CBoxliteSimple,
     command: *const c_char,
     args: *const *const c_char,
     argc: c_int,
     out_result: *mut *mut CBoxliteExecResult,
     out_error: *mut CBoxliteError,
 ) -> BoxliteErrorCode {
-    if simple_box.is_null() {
-        write_error(out_error, null_pointer_error("simple_box"));
-        return BoxliteErrorCode::InvalidArgument;
-    }
-    if command.is_null() {
-        write_error(out_error, null_pointer_error("command"));
-        return BoxliteErrorCode::InvalidArgument;
-    }
-    if out_result.is_null() {
-        write_error(out_error, null_pointer_error("out_result"));
-        return BoxliteErrorCode::InvalidArgument;
-    }
-
-    let simple_ref = &mut *simple_box;
-
-    let cmd_str = match c_str_to_string(command) {
-        Ok(s) => s,
-        Err(e) => {
-            write_error(out_error, e);
-            return BoxliteErrorCode::InvalidArgument;
-        }
-    };
-
-    let mut arg_vec = Vec::new();
-    if !args.is_null() {
-        for i in 0..argc {
-            let arg_ptr = *args.offset(i as isize);
-            if arg_ptr.is_null() {
-                break;
-            }
-            match c_str_to_string(arg_ptr) {
-                Ok(s) => arg_vec.push(s),
-                Err(e) => {
-                    write_error(out_error, e);
-                    return BoxliteErrorCode::InvalidArgument;
-                }
-            }
-        }
-    }
-
-    let handle = match &simple_ref.handle {
-        Some(h) => h,
-        None => {
-            write_error(
-                out_error,
-                BoxliteError::InvalidState("Box not initialized".to_string()),
-            );
-            return BoxliteErrorCode::InvalidState;
-        }
-    };
-
-    let result = simple_ref.tokio_rt.block_on(async {
-        let mut cmd = boxlite::BoxCommand::new(cmd_str);
-        cmd = cmd.args(arg_vec);
-
-        let mut execution = handle.exec(cmd).await?;
-
-        use futures::StreamExt;
-        let mut stdout_lines = Vec::new();
-        let mut stderr_lines = Vec::new();
-
-        let mut stdout_stream = execution.stdout();
-        let mut stderr_stream = execution.stderr();
-
-        loop {
-            tokio::select! {
-                Some(line) = async {
-                    match &mut stdout_stream {
-                        Some(s) => s.next().await,
-                        None => None,
-                    }
-                } => {
-                    stdout_lines.push(line);
-                }
-                Some(line) = async {
-                    match &mut stderr_stream {
-                        Some(s) => s.next().await,
-                        None => None,
-                    }
-                } => {
-                    stderr_lines.push(line);
-                }
-                else => break,
-            }
-        }
-
-        let status = execution.wait().await?;
-
-        Ok::<(i32, String, String), BoxliteError>((
-            status.exit_code,
-            stdout_lines.join("\n"),
-            stderr_lines.join("\n"),
-        ))
-    });
-
-    match result {
-        Ok((exit_code, stdout, stderr)) => {
-            let stdout_c = match CString::new(stdout) {
-                Ok(s) => s.into_raw(),
-                Err(_) => ptr::null_mut(),
-            };
-            let stderr_c = match CString::new(stderr) {
-                Ok(s) => s.into_raw(),
-                Err(_) => ptr::null_mut(),
-            };
-
-            let exec_result = Box::new(CBoxliteExecResult {
-                exit_code,
-                stdout_text: stdout_c,
-                stderr_text: stderr_c,
-            });
-            *out_result = Box::into_raw(exec_result);
-            BoxliteErrorCode::Ok
-        }
-        Err(e) => {
-            let code = error_to_code(&e);
-            write_error(out_error, e);
-            code
-        }
-    }
-}
-
-/// Free execution result
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn boxlite_result_free(result: *mut CBoxliteExecResult) {
-    if !result.is_null() {
-        let result_box = Box::from_raw(result);
-        if !result_box.stdout_text.is_null() {
-            drop(CString::from_raw(result_box.stdout_text));
-        }
-        if !result_box.stderr_text.is_null() {
-            drop(CString::from_raw(result_box.stderr_text));
-        }
-    }
-}
-
-/// Free simple box (auto-cleanup)
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn boxlite_simple_free(simple_box: *mut CBoxliteSimple) {
-    if !simple_box.is_null() {
-        let mut simple = Box::from_raw(simple_box);
-
-        if let Some(handle) = simple.handle.take() {
-            let _ = simple.tokio_rt.block_on(handle.stop());
-        }
-
-        if let Some(box_id) = simple.box_id.take() {
-            let _ = simple
-                .tokio_rt
-                .block_on(simple.runtime.remove(box_id.as_ref(), true));
-        }
-
-        drop(simple);
-    }
+    boxlite_ffi::ops::runner_exec(box_runner, command, args, argc, out_result, out_error)
 }
 
 // ============================================================================
 // Memory Management
 // ============================================================================
 
-/// Free a runtime instance
+/// Free an execution result.
+///
+/// # Arguments
+/// * `result` - Pointer to `CBoxliteExecResult` to free.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_result_free(result: *mut CBoxliteExecResult) {
+    boxlite_ffi::ops::result_free(result)
+}
+
+/// Free a simple runner.
+///
+/// # Arguments
+/// * `box_runner` - Pointer to `CBoxliteSimple,` to free.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_simple_free(box_runner: *mut CBoxliteSimple) {
+    boxlite_ffi::ops::runner_free(box_runner)
+}
+
+/// Free a box handle.
+///
+/// # Arguments
+/// * `handle` - Pointer to `CBoxHandle` to free.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_box_free(handle: *mut CBoxHandle) {
+    boxlite_ffi::ops::box_free(handle)
+}
+
+/// Free a runtime handle.
+///
+/// # Arguments
+/// * `runtime` - Pointer to `CBoxliteRuntime` to free.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn boxlite_runtime_free(runtime: *mut CBoxliteRuntime) {
-    if !runtime.is_null() {
-        unsafe {
-            drop(Box::from_raw(runtime));
-        }
-    }
+    boxlite_ffi::ops::runtime_free(runtime)
 }
 
-/// Free a string allocated by BoxLite
+/// Free a string allocated by the library.
+///
+/// # Arguments
+/// * `s` - Pointer to string to free.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn boxlite_free_string(str: *mut c_char) {
-    if !str.is_null() {
-        unsafe {
-            drop(CString::from_raw(str));
-        }
-    }
+pub unsafe extern "C" fn boxlite_free_string(s: *mut c_char) {
+    boxlite_ffi::ops::string_free(s)
 }
 
-/// Free error struct
+/// Free an error object.
+///
+/// # Arguments
+/// * `error` - Pointer to `CBoxliteError` to free.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn boxlite_error_free(error: *mut CBoxliteError) {
-    if !error.is_null() {
-        let err = &mut *error;
-        if !err.message.is_null() {
-            drop(CString::from_raw(err.message));
-            err.message = ptr::null_mut();
-        }
-        err.code = BoxliteErrorCode::Ok;
-    }
-}
-
-// ============================================================================
-// Unit Tests
-// ============================================================================
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_version() {
-        unsafe {
-            let version = CStr::from_ptr(boxlite_version()).to_str().unwrap();
-            assert!(!version.is_empty());
-            assert!(version.contains('.'));
-        }
-    }
-
-    #[test]
-    fn test_error_code_mapping() {
-        assert_eq!(
-            error_to_code(&BoxliteError::NotFound("test".into())),
-            BoxliteErrorCode::NotFound
-        );
-        assert_eq!(
-            error_to_code(&BoxliteError::AlreadyExists("test".into())),
-            BoxliteErrorCode::AlreadyExists
-        );
-        assert_eq!(
-            error_to_code(&BoxliteError::InvalidState("test".into())),
-            BoxliteErrorCode::InvalidState
-        );
-        assert_eq!(
-            error_to_code(&BoxliteError::InvalidArgument("test".into())),
-            BoxliteErrorCode::InvalidArgument
-        );
-        assert_eq!(
-            error_to_code(&BoxliteError::Internal("test".into())),
-            BoxliteErrorCode::Internal
-        );
-        assert_eq!(
-            error_to_code(&BoxliteError::Config("test".into())),
-            BoxliteErrorCode::Config
-        );
-        assert_eq!(
-            error_to_code(&BoxliteError::Storage("test".into())),
-            BoxliteErrorCode::Storage
-        );
-        assert_eq!(
-            error_to_code(&BoxliteError::Image("test".into())),
-            BoxliteErrorCode::Image
-        );
-        assert_eq!(
-            error_to_code(&BoxliteError::Network("test".into())),
-            BoxliteErrorCode::Network
-        );
-        assert_eq!(
-            error_to_code(&BoxliteError::Execution("test".into())),
-            BoxliteErrorCode::Execution
-        );
-    }
-
-    #[test]
-    fn test_error_struct_creation() {
-        let err = BoxliteError::NotFound("box123".into());
-        let c_err = error_to_c_error(err);
-        assert_eq!(c_err.code, BoxliteErrorCode::NotFound);
-        assert!(!c_err.message.is_null());
-        unsafe {
-            boxlite_error_free(&mut CBoxliteError {
-                code: c_err.code,
-                message: c_err.message,
-            } as *mut _);
-        }
-    }
-
-    #[test]
-    fn test_null_pointer_validation() {
-        unsafe {
-            let mut error = CBoxliteError::default();
-            let code = boxlite_simple_new(ptr::null(), 0, 0, ptr::null_mut(), &mut error as *mut _);
-            assert_eq!(code, BoxliteErrorCode::InvalidArgument);
-            assert!(!error.message.is_null());
-            boxlite_error_free(&mut error as *mut _);
-        }
-    }
-
-    #[test]
-    fn test_c_string_conversion() {
-        let test_str = CString::new("hello").unwrap();
-        unsafe {
-            let result = c_str_to_string(test_str.as_ptr());
-            assert!(result.is_ok());
-            assert_eq!(result.unwrap(), "hello");
-        }
-    }
-
-    #[test]
-    fn test_c_string_null_handling() {
-        unsafe {
-            let result = c_str_to_string(ptr::null());
-            assert!(result.is_err());
-        }
-    }
-
-    #[test]
-    fn test_status_to_string() {
-        assert_eq!(status_to_string(BoxStatus::Unknown), "unknown");
-        assert_eq!(status_to_string(BoxStatus::Configured), "configured");
-        assert_eq!(status_to_string(BoxStatus::Running), "running");
-        assert_eq!(status_to_string(BoxStatus::Stopping), "stopping");
-        assert_eq!(status_to_string(BoxStatus::Stopped), "stopped");
-    }
-
-    #[test]
-    fn test_default_error_struct() {
-        let err = CBoxliteError::default();
-        assert_eq!(err.code, BoxliteErrorCode::Ok);
-        assert!(err.message.is_null());
-    }
-
-    #[test]
-    fn test_error_free_null_safe() {
-        unsafe {
-            boxlite_error_free(ptr::null_mut());
-            // Should not panic
-        }
-    }
-
-    #[test]
-    fn test_result_free_null_safe() {
-        unsafe {
-            boxlite_result_free(ptr::null_mut());
-            // Should not panic
-        }
-    }
-
-    #[test]
-    fn test_simple_free_null_safe() {
-        unsafe {
-            boxlite_simple_free(ptr::null_mut());
-            // Should not panic
-        }
-    }
+    boxlite_ffi::ops::error_free(error)
 }

--- a/sdks/c/tests/CMakeLists.txt
+++ b/sdks/c/tests/CMakeLists.txt
@@ -63,21 +63,50 @@ endforeach()
 # Enable testing
 enable_testing()
 
-# Add tests
-add_test(NAME basic COMMAND test_basic)
-add_test(NAME lifecycle COMMAND test_lifecycle)
-add_test(NAME execute COMMAND test_execute)
-add_test(NAME errors COMMAND test_errors)
-add_test(NAME simple_api COMMAND test_simple_api)
-add_test(NAME streaming COMMAND test_streaming)
-add_test(NAME memory COMMAND test_memory)
-add_test(NAME integration COMMAND test_integration)
+# Auto-discover runtime directory
+# Priority: BOXLITE_RUNTIME_DIR env > target/boxlite-runtime (from `make runtime`)
+# The runtime directory contains: boxlite-guest, mke2fs, debugfs, libkrun, libgvproxy, etc.
+if(DEFINED ENV{BOXLITE_RUNTIME_DIR})
+    set(BOXLITE_RUNTIME_DIR "$ENV{BOXLITE_RUNTIME_DIR}")
+elseif(EXISTS "${BOXLITE_ROOT}/target/boxlite-runtime")
+    set(BOXLITE_RUNTIME_DIR "${BOXLITE_ROOT}/target/boxlite-runtime")
+else()
+    # Fallback: try to find the build output from boxlite crate
+    file(GLOB _RUNTIME_CANDIDATES "${BOXLITE_ROOT}/target/release/build/boxlite-*/out/runtime")
+    list(LENGTH _RUNTIME_CANDIDATES _NUM_CANDIDATES)
+    if(_NUM_CANDIDATES GREATER 0)
+        list(GET _RUNTIME_CANDIDATES 0 BOXLITE_RUNTIME_DIR)
+    else()
+        set(BOXLITE_RUNTIME_DIR "")
+    endif()
+endif()
+
+# Add tests with runtime environment
+foreach(TARGET ${TEST_TARGETS})
+    add_test(NAME ${TARGET} COMMAND ${TARGET})
+    if(BOXLITE_RUNTIME_DIR)
+        set_tests_properties(${TARGET} PROPERTIES
+            ENVIRONMENT "BOXLITE_RUNTIME_DIR=${BOXLITE_RUNTIME_DIR};DYLD_LIBRARY_PATH=${BOXLITE_RUNTIME_DIR}:${BOXLITE_LIB_DIR}"
+        )
+    endif()
+endforeach()
 
 # Print instructions
+if(BOXLITE_RUNTIME_DIR)
+    message(STATUS "  Runtime dir: ${BOXLITE_RUNTIME_DIR}")
+else()
+    message(WARNING "Runtime directory not found. Tests requiring VM (execute, streaming, etc.) will fail.")
+    message(WARNING "Run 'make runtime' from the project root first, or set BOXLITE_RUNTIME_DIR.")
+endif()
+
 message(STATUS "BoxLite C Tests Configuration:")
 message(STATUS "  Include dir: ${BOXLITE_INCLUDE_DIR}")
 message(STATUS "  Library: ${BOXLITE_LIB}")
 message(STATUS "  Test targets: ${TEST_TARGETS}")
+message(STATUS "")
+message(STATUS "Prerequisites:")
+message(STATUS "  1. cargo build --release -p boxlite-c   (build libboxlite)")
+message(STATUS "  2. make runtime                         (build runtime binaries)")
 message(STATUS "")
 message(STATUS "To build and run tests:")
 message(STATUS "  mkdir -p build && cd build")


### PR DESCRIPTION
Close #225 
This PR extracts the FFI logic from the C SDK into a dedicated `boxlite-ffi` crate.

### Changes
- Moved core FFI operations from `sdks/c/src/ffi.rs` to `sdks/boxlite-ffi/src/ops.rs`.
- Created shared utility modules `error.rs`, `json.rs`, and `string.rs` in `boxlite-ffi`.
- Updated `sdks/c` to depend on the new shared crate.

### Motivation
This refactoring allows reusing the core FFI implementation across multiple language bindings (C, Go, Node.js, Python), significantly reducing code duplication and simplifying maintenance. It is a necessary step for cleaner SDK architecture.

This work also prepares the codebase for the Go SDK implementation. As noted in #202, the Go SDK development will be completed after this PR is merged.