### PR TITLE
refactor(vmm): improve crash diagnostics and kernel cmdline handling

### DIFF
--- a/boxlite/Cargo.toml
+++ b/boxlite/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["rlib"]
 
 [[bin]]
 name = "boxlite-shim"
-path = "src/bin/shim.rs"
+path = "src/bin/shim/main.rs"
 
 [features]
 default = ["gvproxy-backend"]

--- a/boxlite/src/bin/shim/crash_capture.rs
+++ b/boxlite/src/bin/shim/crash_capture.rs
@@ -1,0 +1,116 @@
+//! Crash capture for shim process.
+//!
+//! Captures crash information (panics, signals) to an exit file for diagnostics.
+//! Signal handlers can't capture closures, so we use global statics for paths.
+//!
+//! Uses [`boxlite::vmm::ExitInfo`] for the JSON format.
+
+use boxlite::vmm::ExitInfo;
+use std::path::PathBuf;
+use std::sync::OnceLock;
+
+/// Unix convention: exit code for signal-terminated process = 128 + signal number.
+const SIGNAL_EXIT_CODE_BASE: i32 = 128;
+
+/// Exit code for Rust panics.
+const PANIC_EXIT_CODE: i32 = 101;
+
+/// Global exit file path for signal handlers.
+static EXIT_FILE_PATH: OnceLock<PathBuf> = OnceLock::new();
+
+/// Global stderr file path for signal handlers to read crash messages.
+static STDERR_FILE_PATH: OnceLock<PathBuf> = OnceLock::new();
+
+/// Crash capture installer.
+///
+/// Installs panic hook and signal handlers to capture crash info.
+/// The stderr_file is used for reading crash messages (not redirecting).
+pub struct CrashCapture;
+
+impl CrashCapture {
+    /// Install crash capture mechanisms (panic hook + signal handlers).
+    ///
+    /// - `exit_file`: Where to write crash info (JSON format)
+    /// - `stderr_file`: Where to read stderr content from (for crash diagnostics)
+    pub fn install(exit_file: PathBuf, stderr_file: PathBuf) {
+        let _ = STDERR_FILE_PATH.set(stderr_file);
+        install_panic_hook(exit_file.clone());
+        install_signal_handlers(exit_file);
+    }
+}
+
+/// Install panic hook that writes JSON to exit file AND log.
+fn install_panic_hook(exit_file: PathBuf) {
+    let default_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |panic_info| {
+        let message = panic_info
+            .payload()
+            .downcast_ref::<&str>()
+            .map(|s| s.to_string())
+            .or_else(|| panic_info.payload().downcast_ref::<String>().cloned())
+            .unwrap_or_else(|| "Unknown panic".into());
+
+        let location = panic_info
+            .location()
+            .map(|l| format!("{}:{}:{}", l.file(), l.line(), l.column()))
+            .unwrap_or_else(|| "unknown".into());
+
+        tracing::error!(message = %message, location = %location, "PANIC");
+
+        let info = ExitInfo::Panic {
+            exit_code: PANIC_EXIT_CODE,
+            message,
+            location,
+        };
+        if let Ok(json) = serde_json::to_string(&info) {
+            let _ = std::fs::write(&exit_file, json);
+        }
+
+        default_hook(panic_info);
+    }));
+}
+
+/// Install Unix signal handlers to catch C library crashes.
+fn install_signal_handlers(exit_file: PathBuf) {
+    let _ = EXIT_FILE_PATH.set(exit_file);
+
+    unsafe {
+        libc::signal(libc::SIGABRT, crash_signal_handler as *const () as usize);
+        libc::signal(libc::SIGSEGV, crash_signal_handler as *const () as usize);
+        libc::signal(libc::SIGBUS, crash_signal_handler as *const () as usize);
+        libc::signal(libc::SIGILL, crash_signal_handler as *const () as usize);
+    }
+}
+
+/// Signal handler that writes JSON crash info to exit file.
+extern "C" fn crash_signal_handler(sig: libc::c_int) {
+    let signal = match sig {
+        libc::SIGABRT => "SIGABRT",
+        libc::SIGSEGV => "SIGSEGV",
+        libc::SIGBUS => "SIGBUS",
+        libc::SIGILL => "SIGILL",
+        _ => "UNKNOWN",
+    };
+
+    if let Some(exit_file) = EXIT_FILE_PATH.get() {
+        let stderr = STDERR_FILE_PATH
+            .get()
+            .and_then(|p| std::fs::read_to_string(p).ok())
+            .map(|s| s.trim().to_string())
+            .unwrap_or_default();
+
+        let info = ExitInfo::Signal {
+            exit_code: SIGNAL_EXIT_CODE_BASE + sig,
+            signal: signal.to_string(),
+            stderr,
+        };
+        if let Ok(json) = serde_json::to_string(&info) {
+            let _ = std::fs::write(exit_file, json);
+        }
+    }
+
+    unsafe {
+        libc::signal(sig, libc::SIG_DFL);
+        libc::raise(sig);
+    }
+}

--- a/boxlite/src/litebox/crash_report.rs
+++ b/boxlite/src/litebox/crash_report.rs
@@ -1,0 +1,231 @@
+//! Crash report formatting for user-friendly error messages.
+//!
+//! Transforms raw [`ExitInfo`] into human-readable crash reports
+//! with context-aware troubleshooting suggestions.
+
+use crate::vmm::ExitInfo;
+use std::path::Path;
+
+/// Formatted crash report for user-friendly error messages.
+///
+/// Combines parsed exit information with formatted messages suitable
+/// for displaying to users.
+#[derive(Debug)]
+pub struct CrashReport {
+    /// User-friendly error message with troubleshooting hints.
+    pub user_message: String,
+    /// Raw debug info (stderr content for signals).
+    pub debug_info: String,
+}
+
+impl CrashReport {
+    /// Create a crash report from exit file and context.
+    ///
+    /// Parses the JSON exit file and formats a user-friendly message
+    /// with context-specific troubleshooting suggestions.
+    ///
+    /// # Arguments
+    /// * `exit_file` - Path to the JSON exit file written by shim
+    /// * `console_log` - Path to console log (for error message)
+    /// * `stderr_file` - Path to stderr file (for error message)
+    /// * `box_id` - Box identifier (for error message)
+    pub fn from_exit_file(
+        exit_file: &Path,
+        console_log: &Path,
+        stderr_file: &Path,
+        box_id: &str,
+    ) -> Self {
+        let console_display = console_log.display();
+        let stderr_display = stderr_file.display();
+
+        // Try to parse JSON exit file
+        let Some(info) = ExitInfo::from_file(exit_file) else {
+            // No exit file or invalid JSON - generic message
+            return Self {
+                user_message: format!(
+                    "Box {box_id} failed to start\n\n\
+                     The VM exited unexpectedly.\n\n\
+                     Common causes:\n\
+                     • AppArmor or SELinux blocking execution\n\
+                     • /dev/kvm permissions (Linux)\n\
+                     • Missing Hypervisor entitlement (macOS)\n\n\
+                     Debug files:\n\
+                     • Console: {console_display}\n\n\
+                     Tip: Check system logs (dmesg, Console.app)"
+                ),
+                debug_info: String::new(),
+            };
+        };
+
+        // Extract debug info (stderr for signals, empty for panics)
+        let debug_info = info.stderr().unwrap_or("").to_string();
+
+        // Build user-friendly message based on crash type
+        let mut user_message = match &info {
+            ExitInfo::Signal { signal, .. } => match signal.as_str() {
+                "SIGABRT" => format!(
+                    "Box {box_id} failed to start: internal error (SIGABRT)\n\n\
+                     The VM crashed during initialization.\n\n\
+                     Common causes:\n\
+                     • Missing or incompatible native libraries\n\
+                     • Invalid VM configuration (memory, CPU)\n\
+                     • Resource limits exceeded\n\n\
+                     Debug files:\n\
+                     • Console: {console_display}\n\
+                     • Stderr:  {stderr_display}"
+                ),
+                "SIGSEGV" | "SIGBUS" => format!(
+                    "Box {box_id} failed to start: memory error ({signal})\n\n\
+                     The VM encountered a memory access error.\n\n\
+                     Common causes:\n\
+                     • Insufficient memory available\n\
+                     • Library version mismatch\n\
+                     • Corrupted binary or library\n\n\
+                     Debug files:\n\
+                     • Console: {console_display}\n\
+                     • Stderr:  {stderr_display}"
+                ),
+                "SIGILL" => format!(
+                    "Box {box_id} failed to start: invalid instruction (SIGILL)\n\n\
+                     The VM encountered an unsupported CPU instruction.\n\n\
+                     Common causes:\n\
+                     • CPU compatibility issue\n\
+                     • Binary compiled for different architecture\n\n\
+                     Debug files:\n\
+                     • Console: {console_display}\n\
+                     • Stderr:  {stderr_display}"
+                ),
+                _ => format!(
+                    "Box {box_id} failed to start\n\n\
+                     The VM exited unexpectedly during startup.\n\n\
+                     Debug files:\n\
+                     • Console: {console_display}\n\
+                     • Stderr:  {stderr_display}"
+                ),
+            },
+            ExitInfo::Panic {
+                message, location, ..
+            } => format!(
+                "Box {box_id} failed to start: panic\n\n\
+                 The shim process panicked during initialization.\n\n\
+                 Panic: {message}\n\
+                 Location: {location}\n\n\
+                 Debug files:\n\
+                 • Console: {console_display}\n\
+                 • Stderr:  {stderr_display}"
+            ),
+        };
+
+        // Include brief debug info if available (first 5 lines)
+        if !debug_info.is_empty() {
+            let brief_debug: Vec<&str> = debug_info.lines().take(5).collect();
+            user_message.push_str("\n\nError output:\n");
+            user_message.push_str(&brief_debug.join("\n"));
+            if debug_info.lines().count() > 5 {
+                user_message.push_str("\n... (see stderr file for full output)");
+            }
+        }
+
+        Self {
+            user_message,
+            debug_info,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_no_exit_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let exit_file = dir.path().join("nonexistent");
+        let console_log = dir.path().join("console.log");
+        let stderr_file = dir.path().join("stderr");
+
+        let report =
+            CrashReport::from_exit_file(&exit_file, &console_log, &stderr_file, "test-box");
+
+        assert!(report.user_message.contains("test-box failed to start"));
+        assert!(report.user_message.contains("VM exited unexpectedly"));
+        assert!(report.debug_info.is_empty());
+    }
+
+    #[test]
+    fn test_signal_crash() {
+        let dir = tempfile::tempdir().unwrap();
+        let exit_file = dir.path().join("exit");
+        let console_log = dir.path().join("console.log");
+        let stderr_file = dir.path().join("stderr");
+
+        std::fs::write(
+            &exit_file,
+            r#"{"type":"signal","exit_code":134,"signal":"SIGABRT","stderr":"error details"}"#,
+        )
+        .unwrap();
+
+        let report =
+            CrashReport::from_exit_file(&exit_file, &console_log, &stderr_file, "test-box");
+
+        assert!(report.user_message.contains("SIGABRT"));
+        assert!(report.user_message.contains("internal error"));
+        assert_eq!(report.debug_info, "error details");
+    }
+
+    #[test]
+    fn test_panic_crash() {
+        let dir = tempfile::tempdir().unwrap();
+        let exit_file = dir.path().join("exit");
+        let console_log = dir.path().join("console.log");
+        let stderr_file = dir.path().join("stderr");
+
+        std::fs::write(
+            &exit_file,
+            r#"{"type":"panic","exit_code":101,"message":"assertion failed","location":"main.rs:42:5"}"#,
+        )
+        .unwrap();
+
+        let report =
+            CrashReport::from_exit_file(&exit_file, &console_log, &stderr_file, "test-box");
+
+        assert!(report.user_message.contains("panic"));
+        assert!(report.user_message.contains("assertion failed"));
+        assert!(report.user_message.contains("main.rs:42:5"));
+    }
+
+    #[test]
+    fn test_debug_info_truncation() {
+        let dir = tempfile::tempdir().unwrap();
+        let exit_file = dir.path().join("exit");
+        let console_log = dir.path().join("console.log");
+        let stderr_file = dir.path().join("stderr");
+
+        // Create stderr with more than 5 lines
+        let long_stderr = (1..=10)
+            .map(|i| format!("line {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        std::fs::write(
+            &exit_file,
+            format!(
+                r#"{{"type":"signal","exit_code":134,"signal":"SIGABRT","stderr":"{}"}}"#,
+                long_stderr.replace('\n', "\\n")
+            ),
+        )
+        .unwrap();
+
+        let report =
+            CrashReport::from_exit_file(&exit_file, &console_log, &stderr_file, "test-box");
+
+        assert!(report.user_message.contains("line 1"));
+        assert!(report.user_message.contains("line 5"));
+        assert!(
+            report
+                .user_message
+                .contains("... (see stderr file for full output)")
+        );
+        assert!(!report.user_message.contains("line 6")); // Truncated
+    }
+}

--- a/boxlite/src/litebox/init/tasks/guest_entrypoint.rs
+++ b/boxlite/src/litebox/init/tasks/guest_entrypoint.rs
@@ -1,0 +1,186 @@
+//! Guest entrypoint builder for managing env vars within kernel cmdline size limits.
+//!
+//! The kernel cmdline has architecture-specific size limits (2KB on ARM64, 64KB on x86_64).
+//! This builder manages env var accumulation while respecting these limits using FILO
+//! (First In, Last Out) semantics - later additions override earlier ones with the same key.
+
+use crate::util::is_printable_ascii;
+use crate::vmm::Entrypoint;
+
+/// Builds guest entrypoint with env vars constrained by kernel cmdline size limits.
+///
+/// Uses FILO (First In, Last Out) semantics: later `with_env` calls override earlier
+/// ones with the same key, automatically reclaiming the space.
+///
+/// # Usage
+///
+/// ```ignore
+/// let mut builder = GuestEntrypointBuilder::new(executable, args);
+/// builder.with_env("PATH", "/usr/bin");       // From image
+/// builder.with_env("PATH", "/custom/bin");    // Override - automatically wins
+/// builder.with_env("RUST_LOG", &std::env::var("RUST_LOG").unwrap()); // Pass through from host
+/// let entrypoint = builder.build();
+/// ```
+pub(crate) struct GuestEntrypointBuilder {
+    executable: String,
+    args: Vec<String>,
+    env: Vec<(String, String)>,
+    total_size: usize,
+    limit: usize,
+}
+
+impl GuestEntrypointBuilder {
+    /// Kernel cmdline size limit for ARM64 (Apple Silicon).
+    ///
+    /// ARM64 Macs using Hypervisor.framework have a much smaller command line
+    /// buffer (2KB) compared to x86_64 (64KB). With ~20-30 env vars from a
+    /// typical shell, this limit is easily exceeded.
+    ///
+    /// Source: `libkrun/src/arch/src/aarch64/layout.rs`
+    #[cfg(target_arch = "aarch64")]
+    const KERNEL_CMDLINE_MAX_SIZE: usize = 2048;
+
+    /// Kernel cmdline size limit for x86_64.
+    ///
+    /// x86_64 has a generous 64KB buffer, enough for most use cases.
+    ///
+    /// Source: `libkrun/src/arch/src/x86_64/layout.rs`
+    #[cfg(target_arch = "x86_64")]
+    const KERNEL_CMDLINE_MAX_SIZE: usize = 65536;
+
+    /// Per env var overhead in kernel cmdline: `"KEY=VALUE" ` (quote + equals + quote + space).
+    /// libkrun wraps each env var in quotes when building the cmdline.
+    const ENV_VAR_OVERHEAD: usize = 4;
+
+    /// Fixed overhead in libkrun's kernel cmdline.
+    ///
+    /// The kernel cmdline structure is:
+    /// `{DEFAULT_KERNEL_CMDLINE} init=/init.krun KRUN_INIT={exec} KRUN_WORKDIR={wd} {env} -- {args}`
+    ///
+    /// Fixed components (from libkrun source):
+    /// - DEFAULT_KERNEL_CMDLINE: ~91 bytes (macOS: "reboot=k panic=-1 ... no-kvmapf")
+    /// - ` init=/init.krun`: ~15 bytes
+    /// - `KRUN_INIT=` prefix: ~10 bytes (exec path counted separately)
+    /// - ` KRUN_WORKDIR=/`: ~15 bytes
+    /// - ` -- ` separator: ~4 bytes
+    /// - Formatting/spaces: ~15 bytes
+    /// - Safety margin: ~150 bytes (for platform variations)
+    ///
+    /// Total calculated: ~140 bytes, but testing showed 200 was insufficient.
+    /// Using 300 bytes to prevent TooLarge while not over-trimming env vars.
+    const LIBKRUN_CMDLINE_FIXED_OVERHEAD: usize = 300;
+
+    /// Create a new builder with the given executable.
+    ///
+    /// The available env space is calculated based on the arch limit minus
+    /// the space used by executable and fixed overhead.
+    pub fn new(executable: String) -> Self {
+        let limit = Self::calculate_limit(&executable);
+        tracing::debug!(
+            arch_limit = Self::KERNEL_CMDLINE_MAX_SIZE,
+            env_space_limit = limit,
+            "Calculated env space limit for kernel cmdline"
+        );
+        Self {
+            executable,
+            args: Vec::new(),
+            env: Vec::new(),
+            total_size: 0,
+            limit,
+        }
+    }
+
+    /// Add an env var, using FILO semantics (later calls override earlier ones).
+    ///
+    /// If a var with the same key exists, it's removed and its space is reclaimed
+    /// before adding the new value.
+    ///
+    /// Returns `true` if added, `false` if skipped (logged as warning).
+    pub fn with_env(&mut self, key: &str, value: &str) -> bool {
+        // FILO: Remove existing key if present, reclaim space
+        if let Some(pos) = self.env.iter().position(|(k, _)| k == key) {
+            let (old_key, old_value) = &self.env[pos];
+            let old_size = old_key.len() + old_value.len() + Self::ENV_VAR_OVERHEAD;
+            self.total_size = self.total_size.saturating_sub(old_size);
+            self.env.remove(pos);
+            tracing::trace!(env_key = %key, "Overriding existing env var");
+        }
+
+        // Check ASCII
+        if !is_printable_ascii(key) || !is_printable_ascii(value) {
+            tracing::warn!(
+                env_key = %key,
+                env_value = %Self::redact_for_log(value),
+                "Skipping env var: contains non-ASCII characters"
+            );
+            return false;
+        }
+
+        // Check size limit
+        let var_size = key.len() + value.len() + Self::ENV_VAR_OVERHEAD;
+        if self.total_size + var_size > self.limit {
+            tracing::warn!(
+                env_key = %key,
+                env_value = %Self::redact_for_log(value),
+                total_size = self.total_size,
+                var_size,
+                limit = self.limit,
+                "Skipping env var: kernel cmdline size limit reached"
+            );
+            return false;
+        }
+
+        self.total_size += var_size;
+        self.env.push((key.to_string(), value.to_string()));
+        tracing::trace!(env_key = %key, var_size, "Added env var");
+        true
+    }
+
+    /// Add an argument to the entrypoint.
+    ///
+    /// Arguments are appended after the initial args passed to `new()`.
+    /// The limit is reduced to account for the new arg's size.
+    pub fn with_arg(&mut self, arg: &str) {
+        let arg_size = arg.len() + 1; // arg + space
+        self.limit = self.limit.saturating_sub(arg_size);
+        self.args.push(arg.to_string());
+        tracing::trace!(arg, arg_size, new_limit = self.limit, "Added arg");
+    }
+
+    /// Build the final Entrypoint, consuming the builder.
+    pub fn build(self) -> Entrypoint {
+        tracing::debug!(
+            env_count = self.env.len(),
+            total_size = self.total_size,
+            limit = self.limit,
+            "Final env vars for guest entrypoint"
+        );
+        Entrypoint {
+            executable: self.executable,
+            args: self.args,
+            env: self.env,
+        }
+    }
+
+    /// Calculate available space for env vars.
+    fn calculate_limit(executable: &str) -> usize {
+        let exec_size = executable.len() + 1; // executable + space
+        Self::KERNEL_CMDLINE_MAX_SIZE
+            .saturating_sub(exec_size)
+            .saturating_sub(Self::LIBKRUN_CMDLINE_FIXED_OVERHEAD)
+    }
+
+    /// Redact a value for safe logging, preventing secret leakage.
+    fn redact_for_log(value: &str) -> String {
+        if value.len() <= 8 {
+            "***".to_string()
+        } else {
+            format!(
+                "{}...{} ({} chars)",
+                &value[..4],
+                &value[value.len() - 4..],
+                value.len()
+            )
+        }
+    }
+}

--- a/boxlite/src/litebox/init/tasks/mod.rs
+++ b/boxlite/src/litebox/init/tasks/mod.rs
@@ -26,6 +26,7 @@
 mod container_rootfs;
 mod filesystem;
 mod guest_connect;
+mod guest_entrypoint;
 mod guest_init;
 mod guest_rootfs;
 mod vmm_attach;

--- a/boxlite/src/litebox/init/tasks/vmm_spawn.rs
+++ b/boxlite/src/litebox/init/tasks/vmm_spawn.rs
@@ -3,6 +3,7 @@
 //! Builds VMM InstanceSpec from prepared components, then spawns a new VM
 //! subprocess and returns a handler for runtime operations.
 
+use super::guest_entrypoint::GuestEntrypointBuilder;
 use super::{InitCtx, log_task_error, task_start};
 use crate::disk::DiskFormat;
 use crate::images::ContainerImageConfig;
@@ -197,10 +198,6 @@ async fn build_config(
     // Network configuration
     let network_config = build_network_config(container_image_config, options, layout);
 
-    // Use runtime home for logs (not box_home)
-    let runtime_home = runtime.layout.home_dir();
-    let logs_dir = runtime.layout.logs_dir();
-
     // Assemble VMM instance spec
     let instance_spec = InstanceSpec {
         // Box identification and security
@@ -218,8 +215,11 @@ async fn build_config(
         guest_rootfs,
         network_config,
         network_backend_endpoint: None,
-        home_dir: runtime_home.to_path_buf(),
-        console_output: Some(logs_dir.join(format!("{}-console.log", box_id))),
+        home_dir: runtime.layout.home_dir().to_path_buf(),
+        // Diagnostic files in box_dir (preserved on crash)
+        console_output: Some(layout.console_output_path()),
+        exit_file: layout.exit_file_path(),
+        stderr_file: layout.stderr_file_path(),
         detach: options.detach,
         parent_pid: std::process::id(),
     };
@@ -265,41 +265,30 @@ fn build_guest_entrypoint(
     let listen_uri = transport.to_uri();
     let ready_notify_uri = ready_transport.to_uri();
 
-    // Start with guest rootfs env
-    let mut env: Vec<(String, String)> = guest_rootfs.env.clone();
+    let executable = format!("{}/boxlite-guest", guest_paths::BIN_DIR);
+    let mut builder = GuestEntrypointBuilder::new(executable);
+    builder.with_arg("--listen");
+    builder.with_arg(&listen_uri);
+    builder.with_arg("--notify");
+    builder.with_arg(&ready_notify_uri);
 
-    // Override with user env vars
+    // Debug vars first (prioritized - guaranteed space)
+    if let Ok(v) = std::env::var("RUST_LOG") {
+        builder.with_env("RUST_LOG", &v);
+    }
+    if let Ok(v) = std::env::var("RUST_BACKTRACE") {
+        builder.with_env("RUST_BACKTRACE", &v);
+    }
+
+    // FILO order: image → user (later overrides earlier)
+    for (key, value) in &guest_rootfs.env {
+        builder.with_env(key, value);
+    }
     for (key, value) in &options.env {
-        env.retain(|(k, _)| k != key);
-        env.push((key.clone(), value.clone()));
+        builder.with_env(key, value);
     }
 
-    // Inject RUST_LOG from host for debugging
-    if !env.iter().any(|(k, _)| k == "RUST_LOG")
-        && let Ok(rust_log) = std::env::var("RUST_LOG")
-        && !rust_log.is_empty()
-    {
-        env.push(("RUST_LOG".to_string(), rust_log));
-    }
-
-    // Inject RUST_BACKTRACE from host for debugging
-    if !env.iter().any(|(k, _)| k == "RUST_BACKTRACE")
-        && let Ok(rust_backtrace) = std::env::var("RUST_BACKTRACE")
-        && !rust_backtrace.is_empty()
-    {
-        env.push(("RUST_BACKTRACE".to_string(), rust_backtrace));
-    }
-
-    Ok(Entrypoint {
-        executable: format!("{}/boxlite-guest", guest_paths::BIN_DIR),
-        args: vec![
-            "--listen".to_string(),
-            listen_uri,
-            "--notify".to_string(),
-            ready_notify_uri,
-        ],
-        env,
-    })
+    Ok(builder.build())
 }
 
 /// Build network configuration from container image config and options.

--- a/boxlite/src/litebox/init/types.rs
+++ b/boxlite/src/litebox/init/types.rs
@@ -177,11 +177,14 @@ impl Drop for CleanupGuard {
             tracing::warn!("Failed to stop handler during cleanup: {}", e);
         }
 
-        // Cleanup filesystem
-        if let Some(ref layout) = self.layout
-            && let Err(e) = layout.cleanup()
-        {
-            tracing::warn!("Failed to cleanup box directory: {}", e);
+        // DON'T cleanup filesystem - preserve diagnostic files for debugging
+        // Log message to user about preserved files
+        if let Some(ref layout) = self.layout {
+            tracing::error!(
+                "Box crashed. Diagnostic files preserved at:\n  {}\n\nTo clean up: rm -rf {}",
+                layout.root().display(),
+                layout.root().display()
+            );
         }
 
         // Remove from BoxManager (which handles DB delete via database-first pattern)

--- a/boxlite/src/litebox/mod.rs
+++ b/boxlite/src/litebox/mod.rs
@@ -5,12 +5,14 @@
 pub(crate) mod box_impl;
 pub(crate) mod config;
 pub mod copy;
+mod crash_report;
 mod exec;
 mod init;
 mod manager;
 mod state;
 
 pub use copy::CopyOptions;
+pub(crate) use crash_report::CrashReport;
 pub use exec::{BoxCommand, ExecResult, ExecStderr, ExecStdin, ExecStdout, Execution, ExecutionId};
 pub(crate) use manager::BoxManager;
 pub use state::{BoxState, BoxStatus};

--- a/boxlite/src/runtime/layout.rs
+++ b/boxlite/src/runtime/layout.rs
@@ -350,6 +350,23 @@ impl BoxFilesystemLayout {
         self.box_dir.join("shim.pid")
     }
 
+    /// Exit file path: ~/.boxlite/boxes/{box_id}/exit
+    ///
+    /// Written by the shim process on exit (normal or panic).
+    /// Format: First line is exit code, subsequent lines contain error details.
+    /// Follows Podman's conmon pattern for capturing exit information.
+    pub fn exit_file_path(&self) -> PathBuf {
+        self.box_dir.join("exit")
+    }
+
+    /// Stderr file path: ~/.boxlite/boxes/{box_id}/shim.stderr
+    ///
+    /// Captures libkrun stderr output for crash diagnostics.
+    /// The signal handler reads this and includes content in exit file.
+    pub fn stderr_file_path(&self) -> PathBuf {
+        self.box_dir.join("shim.stderr")
+    }
+
     // ========================================================================
     // PREPARATION AND CLEANUP
     // ========================================================================

--- a/boxlite/src/vmm/controller/shim.rs
+++ b/boxlite/src/vmm/controller/shim.rs
@@ -133,7 +133,7 @@ impl VmmHandlerTrait for ShimHandler {
                 if result < 0 {
                     // Error - process may not be our child (common in attached mode)
                     // Fall back to checking if process still exists
-                    let exists = unsafe { libc::kill(self.pid as i32, 0) } == 0;
+                    let exists = crate::util::is_process_alive(self.pid);
                     if !exists {
                         return Ok(()); // Already dead
                     }
@@ -278,6 +278,8 @@ impl VmmController for ShimController {
             network_backend_endpoint: None, // Will be populated by shim (not serialized)
             home_dir: config.home_dir.clone(),
             console_output: config.console_output.clone(),
+            exit_file: config.exit_file.clone(),
+            stderr_file: config.stderr_file.clone(),
             detach: config.detach,
             parent_pid: config.parent_pid,
         };

--- a/boxlite/src/vmm/mod.rs
+++ b/boxlite/src/vmm/mod.rs
@@ -7,6 +7,7 @@ use std::str::FromStr;
 
 pub mod controller;
 pub mod engine;
+pub mod exit_info;
 pub mod factory;
 pub mod host_check;
 pub mod krun;
@@ -15,6 +16,7 @@ pub mod registry;
 use crate::jailer::SecurityOptions;
 use crate::runtime::guest_rootfs::GuestRootfs;
 pub use engine::{Vmm, VmmConfig, VmmInstance};
+pub use exit_info::ExitInfo;
 pub use factory::VmmFactory;
 pub use registry::create_engine;
 
@@ -174,6 +176,10 @@ pub struct InstanceSpec {
     pub home_dir: PathBuf,
     /// Optional file path to redirect console output (kernel/init messages)
     pub console_output: Option<PathBuf>,
+    /// Exit file for shim to write on panic (Podman pattern).
+    pub exit_file: PathBuf,
+    /// Stderr file to capture libkrun crash messages.
+    pub stderr_file: PathBuf,
     /// Whether the box should continue running when the parent process exits.
     /// When false, a watchdog thread monitors parent PID and triggers shutdown.
     pub detach: bool,


### PR DESCRIPTION
## Summary

- Fix https://github.com/boxlite-ai/boxlite/issues/222
- Add `ExitInfo` enum for JSON crash data transfer between shim and library
- Add `CrashReport` struct for user-friendly error message formatting
- Add `GuestEntrypointBuilder` for managing env vars within kernel cmdline limits
- Refactor `shim.rs` to `shim/main.rs` + `crash_capture.rs` directory structure
- Fix `LIBKRUN_CMDLINE_FIXED_OVERHEAD` constant (300 bytes)
- Preserve diagnostic files on crash (don't cleanup box directory)
- Improve build script with deterministic OUT_DIR detection

## Architecture

**Crash Diagnostics:**
- `ExitInfo` (vmm layer): Pure data structure for JSON serialization - shim writes, library reads
- `CrashReport` (litebox layer): Presentation/formatting for user-friendly error messages

**Kernel Cmdline:**
- `GuestEntrypointBuilder`: Manages env vars with FILO semantics within arch-specific limits (2KB ARM64, 64KB x86_64)

## Files Changed

| New Files | Purpose |
|-----------|---------|
| `vmm/exit_info.rs` | ExitInfo enum for JSON crash data |
| `litebox/crash_report.rs` | CrashReport for user-friendly errors |
| `bin/shim/crash_capture.rs` | Panic/signal handlers |
| `init/tasks/guest_entrypoint.rs` | GuestEntrypointBuilder |

## Test plan

- [x] `cargo test -p boxlite --lib -- vmm::exit_info` (5 tests)
- [x] `cargo test -p boxlite --lib -- litebox::crash_report` (4 tests)
- [x] `cargo clippy -p boxlite --lib` (no warnings)
- [x] `cargo fmt --check` (clean)