### PR TITLE
feat(node-sdk): add security options passthrough in Node SDK

### DIFF
--- a/sdks/node/lib/index.ts
+++ b/sdks/node/lib/index.ts
@@ -31,7 +31,7 @@ export type CopyOptions = InstanceType<typeof nativeModule.JsCopyOptions>;
 export { getNativeModule, getJsBoxlite };
 
 // Re-export TypeScript wrappers
-export { SimpleBox, type SimpleBoxOptions } from './simplebox.js';
+export { SimpleBox, type SimpleBoxOptions, type SecurityOptions } from './simplebox.js';
 export { type ExecResult } from './exec.js';
 export { BoxliteError, ExecError, TimeoutError, ParseError } from './errors.js';
 export * from './constants.js';

--- a/sdks/node/src/lib.rs
+++ b/sdks/node/src/lib.rs
@@ -20,5 +20,5 @@ pub use copy::JsCopyOptions;
 pub use exec::{JsExecResult, JsExecStderr, JsExecStdin, JsExecStdout, JsExecution};
 pub use info::JsBoxInfo;
 pub use metrics::{JsBoxMetrics, JsRuntimeMetrics};
-pub use options::{JsBoxOptions, JsEnvVar, JsOptions, JsPortSpec, JsVolumeSpec};
+pub use options::{JsBoxOptions, JsEnvVar, JsOptions, JsPortSpec, JsSecurityOptions, JsVolumeSpec};
 pub use runtime::JsBoxlite; // re-export for dist bundling

--- a/sdks/node/src/options.rs
+++ b/sdks/node/src/options.rs
@@ -2,7 +2,8 @@ use std::path::PathBuf;
 
 use boxlite::runtime::constants::images;
 use boxlite::runtime::options::{
-    BoxOptions, BoxliteOptions, NetworkSpec, PortProtocol, PortSpec, RootfsSpec, VolumeSpec,
+    BoxOptions, BoxliteOptions, NetworkSpec, PortProtocol, PortSpec, ResourceLimits, RootfsSpec,
+    SecurityOptions, VolumeSpec,
 };
 use napi_derive::napi;
 
@@ -33,6 +34,94 @@ impl From<JsOptions> for BoxliteOptions {
         }
 
         config
+    }
+}
+
+// ============================================================================
+// Security Options
+// ============================================================================
+
+/// Security isolation options for a box.
+///
+/// Controls how the boxlite-shim process is isolated from the host.
+#[napi(object)]
+#[derive(Clone, Debug)]
+pub struct JsSecurityOptions {
+    /// Enable jailer isolation (Linux/macOS).
+    pub jailer_enabled: Option<bool>,
+
+    /// Enable seccomp syscall filtering (Linux only).
+    pub seccomp_enabled: Option<bool>,
+
+    /// Maximum number of open file descriptors.
+    pub max_open_files: Option<f64>,
+
+    /// Maximum file size in bytes.
+    pub max_file_size: Option<f64>,
+
+    /// Maximum number of processes.
+    pub max_processes: Option<f64>,
+
+    /// Maximum virtual memory in bytes.
+    pub max_memory: Option<f64>,
+
+    /// Maximum CPU time in seconds.
+    pub max_cpu_time: Option<f64>,
+
+    /// Enable network access in sandbox (macOS only).
+    pub network_enabled: Option<bool>,
+
+    /// Close inherited file descriptors.
+    pub close_fds: Option<bool>,
+}
+
+const JS_MAX_SAFE_INTEGER: u64 = 9_007_199_254_740_991;
+
+fn coerce_u64_limit(number: f64) -> Option<u64> {
+    if !number.is_finite() || number < 0.0 || number.fract() != 0.0 {
+        return None;
+    }
+
+    if number > JS_MAX_SAFE_INTEGER as f64 {
+        return None;
+    }
+
+    Some(number as u64)
+}
+
+fn coerce_optional_u64_limit(value: Option<f64>) -> Option<u64> {
+    value.and_then(coerce_u64_limit)
+}
+
+impl From<JsSecurityOptions> for SecurityOptions {
+    fn from(js_opts: JsSecurityOptions) -> Self {
+        let mut opts = SecurityOptions::default();
+
+        if let Some(jailer_enabled) = js_opts.jailer_enabled {
+            opts.jailer_enabled = jailer_enabled;
+        }
+
+        if let Some(seccomp_enabled) = js_opts.seccomp_enabled {
+            opts.seccomp_enabled = seccomp_enabled;
+        }
+
+        if let Some(network_enabled) = js_opts.network_enabled {
+            opts.network_enabled = network_enabled;
+        }
+
+        if let Some(close_fds) = js_opts.close_fds {
+            opts.close_fds = close_fds;
+        }
+
+        opts.resource_limits = ResourceLimits {
+            max_open_files: coerce_optional_u64_limit(js_opts.max_open_files),
+            max_file_size: coerce_optional_u64_limit(js_opts.max_file_size),
+            max_processes: coerce_optional_u64_limit(js_opts.max_processes),
+            max_memory: coerce_optional_u64_limit(js_opts.max_memory),
+            max_cpu_time: coerce_optional_u64_limit(js_opts.max_cpu_time),
+        };
+
+        opts
     }
 }
 
@@ -94,6 +183,9 @@ pub struct JsBoxOptions {
     /// Username or UID (format: <name|uid>[:<group|gid>]).
     /// If None, uses the image's USER directive (defaults to root).
     pub user: Option<String>,
+
+    /// Security isolation options for the box.
+    pub security: Option<JsSecurityOptions>,
 }
 
 /// Environment variable specification.
@@ -212,6 +304,11 @@ impl From<JsBoxOptions> for BoxOptions {
             .map(|e| (e.key, e.value))
             .collect();
 
+        let security = js_opts
+            .security
+            .map(SecurityOptions::from)
+            .unwrap_or_default();
+
         BoxOptions {
             cpus: js_opts.cpus,
             memory_mib: js_opts.memory_mib,
@@ -225,10 +322,46 @@ impl From<JsBoxOptions> for BoxOptions {
             isolate_mounts: false, // Not exposed in JS API yet
             auto_remove: js_opts.auto_remove.unwrap_or(false),
             detach: js_opts.detach.unwrap_or(false),
-            security: Default::default(), // Use default security options
+            security,
             entrypoint: js_opts.entrypoint,
             cmd: js_opts.cmd,
             user: js_opts.user,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn coerces_safe_integer_number_limit() {
+        let parsed = coerce_u64_limit(1024.0);
+        assert_eq!(parsed, Some(1024));
+    }
+
+    #[test]
+    fn drops_fractional_number_limit() {
+        let parsed = coerce_u64_limit(12.5);
+        assert_eq!(parsed, None);
+    }
+
+    #[test]
+    fn drops_negative_number_limit() {
+        let parsed = coerce_u64_limit(-1.0);
+        assert_eq!(parsed, None);
+    }
+
+    #[test]
+    fn drops_unsafe_integer_number_limit() {
+        let too_large_for_number = JS_MAX_SAFE_INTEGER as f64 + 1.0;
+        let parsed = coerce_u64_limit(too_large_for_number);
+        assert_eq!(parsed, None);
+    }
+
+    #[test]
+    fn drops_non_finite_number_limit() {
+        let parsed = coerce_u64_limit(f64::INFINITY);
+        assert_eq!(parsed, None);
     }
 }

--- a/sdks/node/tests/options.test.ts
+++ b/sdks/node/tests/options.test.ts
@@ -66,6 +66,20 @@ describe('SimpleBoxOptions', () => {
     expect(opts.user).toBe('nginx');
   });
 
+  test('accepts security options', () => {
+    const opts: SimpleBoxOptions = {
+      security: {
+        jailerEnabled: true,
+        seccompEnabled: true,
+        maxOpenFiles: 1024,
+      },
+    };
+
+    expect(opts.security?.jailerEnabled).toBe(true);
+    expect(opts.security?.seccompEnabled).toBe(true);
+    expect(opts.security?.maxOpenFiles).toBe(1024);
+  });
+
   test('cmd and user can be combined with other options', () => {
     const opts: SimpleBoxOptions = {
       image: 'python:slim',


### PR DESCRIPTION
> I'm using the Node SDK. The security options aren't exposed in the same way they are in the other SDKs yet:

fix https://github.com/boxlite-ai/boxlite/issues/222#issuecomment-3881969315 and align [implementation](https://github.com/boxlite-ai/boxlite/blob/main/sdks/python/src/options.rs#L133) in  Python SDK  


## Testing

- [x] make test:node
