### PR TITLE
refactor(crash): extract ProcessMonitor and improve crash diagnostics

### DIFF
--- a/boxlite/src/bin/shim/main.rs
+++ b/boxlite/src/bin/shim/main.rs
@@ -14,7 +14,6 @@
 
 mod crash_capture;
 
-use std::os::unix::io::AsRawFd;
 use std::path::Path;
 use std::thread;
 use std::time::Duration;
@@ -82,20 +81,6 @@ fn init_logging(home_dir: &Path) -> tracing_appender::non_blocking::WorkerGuard 
     guard
 }
 
-/// Redirect stderr to a file to capture vmm crash messages.
-///
-/// vmm prints error messages to stderr before calling abort().
-/// Since shim's stderr is /dev/null, we redirect it to the configured stderr_file.
-/// The crash handler reads this file and includes content in exit file.
-fn redirect_stderr_to_file(stderr_file: &Path) {
-    if let Ok(file) = std::fs::File::create(stderr_file) {
-        let fd = file.as_raw_fd();
-        unsafe {
-            libc::dup2(fd, libc::STDERR_FILENO);
-        }
-    }
-}
-
 fn main() -> BoxliteResult<()> {
     // Parse command line arguments with clap
     // VmmKind parsed via FromStr trait automatically
@@ -109,11 +94,10 @@ fn main() -> BoxliteResult<()> {
     // Keep guard alive until end of main to ensure logs are written
     let _log_guard = init_logging(&config.home_dir);
 
-    // Redirect stderr to capture libkrun crash messages
-    redirect_stderr_to_file(&config.stderr_file);
-
-    // Install crash capture (panic hook, signal handlers)
-    CrashCapture::install(config.exit_file.clone(), config.stderr_file.clone());
+    // Install crash capture (panic hook, signal handlers).
+    // Note: stderr is already redirected to file by parent process (spawn.rs).
+    // CrashReport reads stderr content directly from shim.stderr when needed.
+    CrashCapture::install(config.exit_file.clone());
 
     tracing::info!(
         engine = ?args.engine,

--- a/boxlite/src/litebox/crash_report.rs
+++ b/boxlite/src/litebox/crash_report.rs
@@ -29,36 +29,37 @@ impl CrashReport {
     /// * `console_log` - Path to console log (for error message)
     /// * `stderr_file` - Path to stderr file (for error message)
     /// * `box_id` - Box identifier (for error message)
+    /// * `exit_code` - Exit code from waitpid (if available)
     pub fn from_exit_file(
         exit_file: &Path,
         console_log: &Path,
         stderr_file: &Path,
         box_id: &str,
+        exit_code: Option<i32>,
     ) -> Self {
         let console_display = console_log.display();
         let stderr_display = stderr_file.display();
 
+        // Always read stderr file (contains pre-main dyld errors too)
+        let stderr_content = std::fs::read_to_string(stderr_file)
+            .unwrap_or_default()
+            .trim()
+            .to_string();
+
         // Try to parse JSON exit file
         let Some(info) = ExitInfo::from_file(exit_file) else {
-            // No exit file or invalid JSON - generic message
-            return Self {
-                user_message: format!(
-                    "Box {box_id} failed to start\n\n\
-                     The VM exited unexpectedly.\n\n\
-                     Common causes:\n\
-                     • AppArmor or SELinux blocking execution\n\
-                     • /dev/kvm permissions (Linux)\n\
-                     • Missing Hypervisor entitlement (macOS)\n\n\
-                     Debug files:\n\
-                     • Console: {console_display}\n\n\
-                     Tip: Check system logs (dmesg, Console.app)"
-                ),
-                debug_info: String::new(),
-            };
+            // No exit file - use exit code and raw stderr content
+            return Self::from_raw_exit(
+                box_id,
+                exit_code,
+                &stderr_content,
+                console_log,
+                stderr_file,
+            );
         };
 
-        // Extract debug info (stderr for signals, empty for panics)
-        let debug_info = info.stderr().unwrap_or("").to_string();
+        // Use stderr_content we already read from file (single source of truth)
+        let debug_info = stderr_content;
 
         // Build user-friendly message based on crash type
         let mut user_message = match &info {
@@ -139,6 +140,76 @@ impl CrashReport {
             debug_info,
         }
     }
+
+    /// Create crash report when no exit file exists (pre-main crash).
+    ///
+    /// Uses exit code and raw stderr content to provide diagnostic info.
+    fn from_raw_exit(
+        box_id: &str,
+        exit_code: Option<i32>,
+        stderr_content: &str,
+        console_log: &Path,
+        stderr_file: &Path,
+    ) -> Self {
+        let mut msg = format!("Box {box_id} failed to start\n\n");
+
+        // Add exit code with signal interpretation
+        match exit_code {
+            Some(code) => {
+                msg.push_str(&format!("Exit code: {code}"));
+                if code > 128 {
+                    let signal = code - 128;
+                    let signal_name = match signal {
+                        6 => "SIGABRT",
+                        9 => "SIGKILL",
+                        11 => "SIGSEGV",
+                        15 => "SIGTERM",
+                        _ => "unknown signal",
+                    };
+                    msg.push_str(&format!(" ({signal_name})\n"));
+                } else {
+                    msg.push('\n');
+                }
+            }
+            None => {
+                msg.push_str("Exit code: unknown\n");
+            }
+        }
+        msg.push('\n');
+
+        // Add stderr content if available (includes dyld errors)
+        if !stderr_content.is_empty() {
+            msg.push_str("Shim stderr:\n");
+            msg.push_str(&truncate_lines(stderr_content, 15));
+            msg.push_str("\n\n");
+        }
+
+        msg.push_str(&format!(
+            "Debug files:\n\
+             • Console: {}\n\
+             • Stderr: {}\n\n\
+             System logs: dmesg (Linux), Console.app (macOS)",
+            console_log.display(),
+            stderr_file.display()
+        ));
+
+        Self {
+            user_message: msg,
+            debug_info: stderr_content.to_string(),
+        }
+    }
+}
+
+/// Truncate content to max_lines, showing count of remaining lines.
+fn truncate_lines(content: &str, max_lines: usize) -> String {
+    let lines: Vec<&str> = content.lines().take(max_lines).collect();
+    let truncated = lines.join("\n");
+    let total_lines = content.lines().count();
+    if total_lines > max_lines {
+        format!("{truncated}\n... ({} more lines)", total_lines - max_lines)
+    } else {
+        truncated
+    }
 }
 
 #[cfg(test)]
@@ -146,18 +217,45 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_no_exit_file() {
+    fn test_no_exit_file_with_exit_code() {
         let dir = tempfile::tempdir().unwrap();
         let exit_file = dir.path().join("nonexistent");
         let console_log = dir.path().join("console.log");
         let stderr_file = dir.path().join("stderr");
 
-        let report =
-            CrashReport::from_exit_file(&exit_file, &console_log, &stderr_file, "test-box");
+        // Create stderr file with content
+        std::fs::write(&stderr_file, "dyld: Library not loaded").unwrap();
+
+        let report = CrashReport::from_exit_file(
+            &exit_file,
+            &console_log,
+            &stderr_file,
+            "test-box",
+            Some(1),
+        );
 
         assert!(report.user_message.contains("test-box failed to start"));
-        assert!(report.user_message.contains("VM exited unexpectedly"));
-        assert!(report.debug_info.is_empty());
+        assert!(report.user_message.contains("Exit code: 1"));
+        assert!(report.user_message.contains("dyld: Library not loaded"));
+        assert!(report.user_message.contains("System logs: dmesg"));
+    }
+
+    #[test]
+    fn test_no_exit_file_with_signal_exit_code() {
+        let dir = tempfile::tempdir().unwrap();
+        let exit_file = dir.path().join("nonexistent");
+        let console_log = dir.path().join("console.log");
+        let stderr_file = dir.path().join("stderr");
+
+        let report = CrashReport::from_exit_file(
+            &exit_file,
+            &console_log,
+            &stderr_file,
+            "test-box",
+            Some(134), // 128 + 6 (SIGABRT)
+        );
+
+        assert!(report.user_message.contains("Exit code: 134 (SIGABRT)"));
     }
 
     #[test]
@@ -167,14 +265,21 @@ mod tests {
         let console_log = dir.path().join("console.log");
         let stderr_file = dir.path().join("stderr");
 
+        // Exit file no longer contains stderr - it's read from stderr_file
         std::fs::write(
             &exit_file,
-            r#"{"type":"signal","exit_code":134,"signal":"SIGABRT","stderr":"error details"}"#,
+            r#"{"type":"signal","exit_code":134,"signal":"SIGABRT"}"#,
         )
         .unwrap();
+        std::fs::write(&stderr_file, "error details").unwrap();
 
-        let report =
-            CrashReport::from_exit_file(&exit_file, &console_log, &stderr_file, "test-box");
+        let report = CrashReport::from_exit_file(
+            &exit_file,
+            &console_log,
+            &stderr_file,
+            "test-box",
+            Some(134),
+        );
 
         assert!(report.user_message.contains("SIGABRT"));
         assert!(report.user_message.contains("internal error"));
@@ -194,8 +299,13 @@ mod tests {
         )
         .unwrap();
 
-        let report =
-            CrashReport::from_exit_file(&exit_file, &console_log, &stderr_file, "test-box");
+        let report = CrashReport::from_exit_file(
+            &exit_file,
+            &console_log,
+            &stderr_file,
+            "test-box",
+            Some(101),
+        );
 
         assert!(report.user_message.contains("panic"));
         assert!(report.user_message.contains("assertion failed"));
@@ -215,12 +325,16 @@ mod tests {
         )
         .unwrap();
 
-        let report =
-            CrashReport::from_exit_file(&exit_file, &console_log, &stderr_file, "test-box");
+        let report = CrashReport::from_exit_file(
+            &exit_file,
+            &console_log,
+            &stderr_file,
+            "test-box",
+            Some(1),
+        );
 
         assert!(report.user_message.contains("error"));
         assert!(report.user_message.contains("Failed to create VM instance"));
-        assert!(report.debug_info.is_empty());
     }
 
     #[test]
@@ -230,7 +344,7 @@ mod tests {
         let console_log = dir.path().join("console.log");
         let stderr_file = dir.path().join("stderr");
 
-        // Create stderr with more than 5 lines
+        // Create stderr file with more than 5 lines (stderr is read from file, not exit file)
         let long_stderr = (1..=10)
             .map(|i| format!("line {i}"))
             .collect::<Vec<_>>()
@@ -238,15 +352,18 @@ mod tests {
 
         std::fs::write(
             &exit_file,
-            format!(
-                r#"{{"type":"signal","exit_code":134,"signal":"SIGABRT","stderr":"{}"}}"#,
-                long_stderr.replace('\n', "\\n")
-            ),
+            r#"{"type":"signal","exit_code":134,"signal":"SIGABRT"}"#,
         )
         .unwrap();
+        std::fs::write(&stderr_file, &long_stderr).unwrap();
 
-        let report =
-            CrashReport::from_exit_file(&exit_file, &console_log, &stderr_file, "test-box");
+        let report = CrashReport::from_exit_file(
+            &exit_file,
+            &console_log,
+            &stderr_file,
+            "test-box",
+            Some(134),
+        );
 
         assert!(report.user_message.contains("line 1"));
         assert!(report.user_message.contains("line 5"));
@@ -256,5 +373,15 @@ mod tests {
                 .contains("... (see stderr file for full output)")
         );
         assert!(!report.user_message.contains("line 6")); // Truncated
+    }
+
+    #[test]
+    fn test_truncate_lines() {
+        let content = "line1\nline2\nline3\nline4\nline5";
+        assert_eq!(
+            truncate_lines(content, 3),
+            "line1\nline2\nline3\n... (2 more lines)"
+        );
+        assert_eq!(truncate_lines(content, 10), content);
     }
 }

--- a/boxlite/src/util/mod.rs
+++ b/boxlite/src/util/mod.rs
@@ -12,7 +12,9 @@ use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{EnvFilter, fmt};
 
-pub use process::{is_process_alive, is_same_process, kill_process, read_pid_file};
+pub use process::{
+    ProcessExit, ProcessMonitor, is_process_alive, is_same_process, kill_process, read_pid_file,
+};
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 unsafe extern "C" {

--- a/boxlite/src/vmm/mod.rs
+++ b/boxlite/src/vmm/mod.rs
@@ -178,8 +178,6 @@ pub struct InstanceSpec {
     pub console_output: Option<PathBuf>,
     /// Exit file for shim to write on panic (Podman pattern).
     pub exit_file: PathBuf,
-    /// Stderr file to capture libkrun crash messages.
-    pub stderr_file: PathBuf,
     /// Whether the box should continue running when the parent process exits.
     /// When false, a watchdog thread monitors parent PID and triggers shutdown.
     pub detach: bool,


### PR DESCRIPTION
## Summary

- Add `ProcessMonitor` abstraction for waitpid-based process liveness detection
- Capture stderr to file BEFORE subprocess spawn (catches pre-main dyld errors)
- Pass `BoxFilesystemLayout` through spawn chain (DRY - no redundant recreation)
- Remove `stderr` from `ExitInfo::Signal` (CrashReport reads directly from file)
- Simplify `CrashCapture::install()` to only take `exit_file` parameter

## Details

### ProcessMonitor Abstraction

Extracts duplicated waitpid polling logic into a minimal struct:

```rust
pub enum ProcessExit {
    Code(i32),   // Process exited, we captured the code
    Unknown,     // Process dead, but we're not parent (ECHILD)
}

pub struct ProcessMonitor { pid: u32 }

impl ProcessMonitor {
    pub fn try_wait(&self) -> Option<ProcessExit>
    pub async fn wait_for_exit(&self) -> ProcessExit
}
```

This encapsulates the Unix parent/child constraint for `waitpid()`:
- Owned processes (spawned): can call `waitpid()` to get exit code
- Attached processes (reconnected): get `ECHILD`, fall back to `kill(pid, 0)`

### Stderr Capture Before Spawn

Previously, stderr was redirected inside the shim's `main()`, losing pre-main errors (dyld library loading failures). Now the parent creates the stderr file BEFORE spawn:

```rust
// spawn.rs
let stderr_file = std::fs::File::create(&layout.stderr_file_path())?;
cmd.stderr(Stdio::from(stderr_file));  // Captures ALL stderr
```

### Layout Pass-Through

Eliminates redundant `FilesystemLayout` recreation in `spawn_subprocess()` by passing `BoxFilesystemLayout` through the call chain.

## Test plan

- [x] `cargo build --package boxlite`
- [x] `cargo test --package boxlite process` (12 tests pass)
- [x] `cargo test --package boxlite guest_connect` (8 tests pass)
- [x] `cargo test --package boxlite crash_report` (7 tests pass)