### PR TITLE
fix(ci): respect CARGO_HOME in setup scripts for manylinux builds

### DIFF
--- a/.github/workflows/build-runtime.yml
+++ b/.github/workflows/build-runtime.yml
@@ -90,7 +90,9 @@ jobs:
         if: runner.os == 'Linux'
         uses: actions/cache@v4
         with:
-          path: .cargo-manylinux
+          path: |
+            .cargo-manylinux/registry
+            .cargo-manylinux/git
           key: manylinux-cargo-${{ matrix.target }}-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
             manylinux-cargo-${{ matrix.target }}-

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -62,8 +62,8 @@ command_exists() {
 
 # Ensure cargo is in PATH (sources cargo env if available)
 ensure_cargo() {
-    if [ -f "$HOME/.cargo/env" ]; then
-        source "$HOME/.cargo/env"
+    if [ -f "${CARGO_HOME:-$HOME/.cargo}/env" ]; then
+        source "${CARGO_HOME:-$HOME/.cargo}/env"
     fi
 }
 
@@ -85,8 +85,8 @@ install_rust() {
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
         # Source Rust environment
-        if [ -f "$HOME/.cargo/env" ]; then
-            source "$HOME/.cargo/env"
+        if [ -f "${CARGO_HOME:-$HOME/.cargo}/env" ]; then
+            source "${CARGO_HOME:-$HOME/.cargo}/env"
         else
             echo "❌ ERROR: Rust installation failed"
             exit 1

--- a/scripts/setup/setup-common.sh
+++ b/scripts/setup/setup-common.sh
@@ -23,7 +23,7 @@ check_rust() {
 
     # Source cargo env if not already in PATH
     if ! command_exists rustc; then
-        [ -f "$HOME/.cargo/env" ] && source "$HOME/.cargo/env"
+        [ -f "${CARGO_HOME:-$HOME/.cargo}/env" ] && source "${CARGO_HOME:-$HOME/.cargo}/env"
     fi
 
     if command_exists rustc; then
@@ -41,7 +41,7 @@ install_rust() {
     echo ""
     print_section "Installing Rust..."
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-    source "$HOME/.cargo/env"
+    source "${CARGO_HOME:-$HOME/.cargo}/env"
     print_success "Rust installed"
 }
 


### PR DESCRIPTION
## Summary

Fixes the manylinux runtime build failure from #241.

- Setup scripts hardcoded `$HOME/.cargo/env` but the manylinux container sets `CARGO_HOME=/work/.cargo-manylinux`, so rustup creates the env file at `$CARGO_HOME/env` instead
- Use `${CARGO_HOME:-$HOME/.cargo}` everywhere (backwards-compatible fallback)
- Cache only `registry/` and `git/` subdirs, not `bin/` — avoids stale rustup proxy issue on second CI run

## Test plan

- [ ] CI `build-runtime` workflow passes (manylinux container)
- [ ] macOS build unaffected (`CARGO_HOME` unset, falls back to `$HOME/.cargo`)
- [ ] Node/Python SDK workflows unaffected (don't set `CARGO_HOME`)