### PR TITLE
chore: bump Rust/C/Python/Node SDK minimum versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,7 +302,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -363,7 +363,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-c"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "boxlite",
  "cbindgen",
@@ -404,7 +404,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-guest"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -433,7 +433,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-node"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "boxlite",
  "boxlite-shared",
@@ -447,7 +447,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-python"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "boxlite",
  "futures",
@@ -460,7 +460,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-shared"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "prost",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = ["build/tmp", "target", ".venv", "examples/*/.venv"]
 resolver = "2"
 
 [workspace.package]
-version = "0.5.10"
+version = "0.5.11"
 edition = "2024"
 authors = ["Dorian Zheng <https://github.com/dorianzheng>"]
 license = "Apache-2.0"

--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
   },
   "homepage": "https://github.com/boxlite-labs/boxlite#readme",
   "dependencies": {
-    "@boxlite-ai/boxlite": "^0.1.6"
+    "@boxlite-ai/boxlite": "^0.2.8"
   },
   "optionalDependencies": {
-    "@boxlite-ai/boxlite-darwin-arm64": "^0.1.6",
-    "@boxlite-ai/boxlite-linux-x64-gnu": "^0.1.6"
+    "@boxlite-ai/boxlite-darwin-arm64": "^0.2.8",
+    "@boxlite-ai/boxlite-linux-x64-gnu": "^0.2.8"
   }
 }

--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boxlite-ai/boxlite",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "BoxLite - Embeddable micro-VM runtime for secure, isolated code execution",
   "type": "module",
   "main": "dist/index.js",

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "boxlite"
-version = "0.5.10"
+version = "0.5.11"
 description = "Python bindings for Boxlite runtime"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary\n- bump workspace SDK version from `0.5.10` to `0.5.11` (covers Rust/C/Python crates)\n- bump Node.js SDK package version from `0.2.7` to `0.2.8`\n- bump top-level Node package minimum dependency ranges to `^0.2.8`\n- update `Cargo.lock` for workspace package version updates\n\n## Validation\n- `cargo metadata --no-deps --format-version 1`\n- TOML/JSON parse checks for updated manifests