### PR TITLE
fix(python): fix 5 Python SDK bugs

### DIFF
--- a/sdks/python/boxlite/__init__.py
+++ b/sdks/python/boxlite/__init__.py
@@ -22,6 +22,7 @@ try:
         BoxMetrics,
         CopyOptions,
         RootfsSpec,
+        SecurityOptions,
     )
 
     __all__ = [
@@ -39,6 +40,7 @@ try:
         "BoxMetrics",
         "CopyOptions",
         "RootfsSpec",
+        "SecurityOptions",
     ]
 except ImportError as e:
     warnings.warn(f"BoxLite native extension not available: {e}", ImportWarning)

--- a/sdks/python/boxlite/codebox.py
+++ b/sdks/python/boxlite/codebox.py
@@ -42,7 +42,7 @@ class CodeBox(SimpleBox):
             runtime: Optional runtime instance (uses global default if None)
             **kwargs: Additional configuration options
         """
-        super().__init__(image, memory_mib, cpus, runtime, **kwargs)
+        super().__init__(image=image, memory_mib=memory_mib, cpus=cpus, runtime=runtime, **kwargs)
 
     async def run(self, code: str, timeout: Optional[int] = None) -> str:
         """
@@ -53,7 +53,8 @@ class CodeBox(SimpleBox):
             timeout: Execution timeout in seconds (not yet implemented)
 
         Returns:
-            Execution output as a string (stdout + stderr)
+            Execution stdout as a string. Use exec() directly if you need
+            both stdout and stderr.
 
         Example:
             >>> async with CodeBox() as cb:
@@ -68,21 +69,38 @@ class CodeBox(SimpleBox):
         """
         # Execute Python code using python3 -c
         result = await self.exec("/usr/local/bin/python", "-c", code)
-        return result.stdout + result.stderr
+        return result.stdout
 
     async def run_script(self, script_path: str) -> str:
         """
-        Execute a Python script file in the container.
+        Read a Python script from the **host** filesystem and execute it in the container.
+
+        The script file is read on the host side and its contents are sent to
+        the container for execution via ``python -c``. To run a script that
+        already exists inside the VM, use :meth:`run_guest_script` instead.
 
         Args:
-            script_path: Path to the Python script on the host
+            script_path: Path to the Python script on the **host** filesystem
 
         Returns:
-            Execution output as a string
+            Execution stdout as a string
         """
         with open(script_path, "r") as f:
             code = f.read()
         return await self.run(code)
+
+    async def run_guest_script(self, guest_script_path: str) -> str:
+        """
+        Execute a Python script that exists inside the container.
+
+        Args:
+            guest_script_path: Path to the script inside the container
+
+        Returns:
+            Execution stdout as a string
+        """
+        result = await self.exec("/usr/local/bin/python", guest_script_path)
+        return result.stdout
 
     async def install_package(self, package: str) -> str:
         """

--- a/sdks/python/boxlite/simplebox.py
+++ b/sdks/python/boxlite/simplebox.py
@@ -279,9 +279,9 @@ class SimpleBox:
             error_message=error_message,
         )
 
-    def shutdown(self):
+    async def stop(self):
         """
-        Shutdown the box and release resources.
+        Stop the box and release resources.
 
         Note: Usually not needed as context manager handles cleanup.
         """
@@ -290,7 +290,15 @@ class SimpleBox:
                 "Box not started. Use 'async with SimpleBox(...) as box:' "
                 "or call 'await box.start()' first."
             )
-        self._box.shutdown()
+        await self._box.stop()
+
+    async def shutdown(self):
+        """
+        Shutdown the box and release resources.
+
+        Alias for stop(). Usually not needed as context manager handles cleanup.
+        """
+        await self.stop()
 
     async def copy_in(
         self,


### PR DESCRIPTION
## Summary

Fixes 5 confirmed bugs in the Python SDK, all low-hanging fruit identified during a comprehensive issue triage.

- **Fix CodeBox positional arg mismatch (#228):** `CodeBox(memory_mib=1024)` was crashing with `TypeError` because `super().__init__()` passed args positionally, but `SimpleBox.__init__` has `rootfs_path` as 2nd param — so `memory_mib` mapped to `rootfs_path`. Fix: use keyword arguments.

- **Fix SimpleBox.shutdown() crash (#229):** `shutdown()` called `self._box.shutdown()` but the Rust `Box` only exposes `stop()`. Fix: make `shutdown()` async and delegate to `stop()`. Also expose `stop()` directly on `SimpleBox`.

- **Export SecurityOptions from top-level module (#230, #236):** `from boxlite import SecurityOptions` failed because `__init__.py` didn't import it, despite the Rust side exporting it. Fix: add to import and `__all__`.

- **Fix CodeBox.run() returning stderr noise (#237):** `run()` returned `stdout + stderr`, so seccomp/libcontainer warnings polluted the output — especially bad for AI agent use cases. Fix: return only `stdout`.

- **Clarify run_script() reads from host (#235):** Docstring now clearly states it reads from the **host** filesystem. Added `run_guest_script()` for running scripts already inside the VM.

Closes #228
Closes #229
Closes #230
Closes #235
Closes #236
Closes #237

## Test plan

- [ ] `CodeBox(memory_mib=1024)` no longer crashes
- [ ] `await box.shutdown()` works (calls stop under the hood)
- [ ] `await box.stop()` works directly
- [ ] `from boxlite import SecurityOptions` succeeds
- [ ] `SecurityOptions.development()`, `.standard()`, `.maximum()` work
- [ ] `await codebox.run("print('hello')")` returns `'hello\n'` without stderr noise
- [ ] `await codebox.run_guest_script("/tmp/script.py")` runs a script inside the VM

🤖 Generated with [Claude Code](https://claude.com/claude-code)