### PR TITLE
fix(python): fix CodeBox(memory_mib=...) crash due to positional arg mismatch

### DIFF
--- a/sdks/python/boxlite/codebox.py
+++ b/sdks/python/boxlite/codebox.py
@@ -42,7 +42,9 @@ class CodeBox(SimpleBox):
             runtime: Optional runtime instance (uses global default if None)
             **kwargs: Additional configuration options
         """
-        super().__init__(image, memory_mib, cpus, runtime, **kwargs)
+        super().__init__(
+            image=image, memory_mib=memory_mib, cpus=cpus, runtime=runtime, **kwargs
+        )
 
     async def run(self, code: str, timeout: Optional[int] = None) -> str:
         """


### PR DESCRIPTION
## Summary
- Fix `CodeBox.__init__` passing positional args to `SimpleBox.__init__`, which has `rootfs_path` as the 2nd parameter — causing `memory_mib` to map to `rootfs_path`

## Test plan
- [ ] `CodeBox(memory_mib=1024)` no longer crashes with `TypeError`
- [ ] `CodeBox(cpus=2)` correctly sets CPU count instead of silently misassigning

Closes #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)