### PR TITLE
fix(python): export SecurityOptions from top-level boxlite module

### DIFF
--- a/sdks/python/boxlite/__init__.py
+++ b/sdks/python/boxlite/__init__.py
@@ -22,6 +22,7 @@ try:
         BoxMetrics,
         CopyOptions,
         RootfsSpec,
+        SecurityOptions,
     )
 
     __all__ = [
@@ -39,6 +40,7 @@ try:
         "BoxMetrics",
         "CopyOptions",
         "RootfsSpec",
+        "SecurityOptions",
     ]
 except ImportError as e:
     warnings.warn(f"BoxLite native extension not available: {e}", ImportWarning)


### PR DESCRIPTION
## Summary
- Add `SecurityOptions` to the import list and `__all__` in `__init__.py` so `from boxlite import SecurityOptions` works as documented

## Test plan
- [ ] `from boxlite import SecurityOptions` succeeds
- [ ] `SecurityOptions.development()`, `.standard()`, `.maximum()` all work

Closes #230
Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)