### PR TITLE
fix(python): return only stdout from CodeBox.run()

### DIFF
--- a/sdks/python/boxlite/codebox.py
+++ b/sdks/python/boxlite/codebox.py
@@ -53,7 +53,8 @@ class CodeBox(SimpleBox):
             timeout: Execution timeout in seconds (not yet implemented)
 
         Returns:
-            Execution output as a string (stdout + stderr)
+            Execution stdout as a string. Use exec() directly if you need
+            both stdout and stderr.
 
         Example:
             >>> async with CodeBox() as cb:
@@ -68,7 +69,7 @@ class CodeBox(SimpleBox):
         """
         # Execute Python code using python3 -c
         result = await self.exec("/usr/local/bin/python", "-c", code)
-        return result.stdout + result.stderr
+        return result.stdout
 
     async def run_script(self, script_path: str) -> str:
         """
@@ -78,7 +79,7 @@ class CodeBox(SimpleBox):
             script_path: Path to the Python script on the host
 
         Returns:
-            Execution output as a string
+            Execution stdout as a string
         """
         with open(script_path, "r") as f:
             code = f.read()

--- a/sdks/python/boxlite/sync_api/_codebox.py
+++ b/sdks/python/boxlite/sync_api/_codebox.py
@@ -76,7 +76,8 @@ class SyncCodeBox(SyncSimpleBox):
             timeout: Execution timeout in seconds (not yet implemented)
 
         Returns:
-            Combined stdout and stderr output
+            Execution stdout as a string. Use exec() directly if you need
+            both stdout and stderr.
 
         Example:
             with SyncCodeBox() as box:
@@ -90,7 +91,7 @@ class SyncCodeBox(SyncSimpleBox):
                 ''')
         """
         result = self.exec("/usr/local/bin/python", "-c", code)
-        return result.stdout + result.stderr
+        return result.stdout
 
     def install_package(self, package: str) -> str:
         """
@@ -135,7 +136,7 @@ class SyncCodeBox(SyncSimpleBox):
             script_path: Path to the Python script on the host
 
         Returns:
-            Script output (stdout + stderr)
+            Script stdout as a string
 
         Example:
             result = box.run_script("./my_script.py")

--- a/sdks/python/tests/test_sync_codebox.py
+++ b/sdks/python/tests/test_sync_codebox.py
@@ -72,10 +72,12 @@ print(round(math.pi, 2))
             assert "3.14" in result
 
     def test_run_exception(self, shared_sync_runtime):
-        """Captures exceptions in output."""
+        """Exceptions go to stderr, not run() output."""
         with SyncCodeBox(runtime=shared_sync_runtime) as box:
-            result = box.run("raise ValueError('test error')")
-            assert "ValueError" in result or "test error" in result
+            result = box.exec(
+                "/usr/local/bin/python", "-c", "raise ValueError('test error')"
+            )
+            assert "ValueError" in result.stderr or "test error" in result.stderr
 
     @pytest.mark.slow
     def test_install_package(self, shared_sync_runtime):


### PR DESCRIPTION
## Summary
- Change `CodeBox.run()` to return only stdout (previously returned stdout + stderr)
- Update `SyncCodeBox.run()` to match (same change)
- Update `run_script()` docstrings in both async and sync APIs
- Update tests that asserted errors in `run()` output to use `exec()` instead

Closes #237

## Note
If PR #249 is also merged, `run_guest_script()` should be updated to return stdout only for consistency.

## Test plan
- [ ] Verify `run()` returns only stdout for successful code
- [ ] Verify errors (exceptions, syntax errors) are NOT in `run()` output
- [ ] Verify `exec()` still returns both stdout and stderr
- [ ] Verify SyncCodeBox.run() behavior matches async CodeBox.run()
- [ ] Verify updated tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)