### PR TITLE
fix(python): clarify run_script() reads from host, add run_guest_script()

### DIFF
--- a/sdks/python/boxlite/codebox.py
+++ b/sdks/python/boxlite/codebox.py
@@ -72,17 +72,34 @@ class CodeBox(SimpleBox):
 
     async def run_script(self, script_path: str) -> str:
         """
-        Execute a Python script file in the container.
+        Read a Python script from the **host** filesystem and execute it in the container.
+
+        The script file is read on the host side and its contents are sent to
+        the container for execution via ``python -c``. To run a script that
+        already exists inside the VM, use :meth:`run_guest_script` instead.
 
         Args:
-            script_path: Path to the Python script on the host
+            script_path: Path to the Python script on the **host** filesystem
 
         Returns:
-            Execution output as a string
+            Execution output as a string (stdout + stderr)
         """
         with open(script_path, "r") as f:
             code = f.read()
         return await self.run(code)
+
+    async def run_guest_script(self, guest_script_path: str) -> str:
+        """
+        Execute a Python script that exists inside the container.
+
+        Args:
+            guest_script_path: Path to the script inside the container
+
+        Returns:
+            Execution output as a string (stdout + stderr)
+        """
+        result = await self.exec("/usr/local/bin/python", guest_script_path)
+        return result.stdout + result.stderr
 
     async def install_package(self, package: str) -> str:
         """

--- a/sdks/python/boxlite/sync_api/_codebox.py
+++ b/sdks/python/boxlite/sync_api/_codebox.py
@@ -127,15 +127,17 @@ class SyncCodeBox(SyncSimpleBox):
 
     def run_script(self, script_path: str) -> str:
         """
-        Execute a Python script file.
+        Read a Python script from the **host** filesystem and execute it in the box.
 
-        Reads the script from the host filesystem and executes it in the box.
+        The script file is read on the host side and its contents are sent to
+        the container for execution via ``python -c``. To run a script that
+        already exists inside the VM, use :meth:`run_guest_script` instead.
 
         Args:
-            script_path: Path to the Python script on the host
+            script_path: Path to the Python script on the **host** filesystem
 
         Returns:
-            Script output (stdout + stderr)
+            Execution output as a string (stdout + stderr)
 
         Example:
             result = box.run_script("./my_script.py")
@@ -143,3 +145,16 @@ class SyncCodeBox(SyncSimpleBox):
         with open(script_path, "r") as f:
             code = f.read()
         return self.run(code)
+
+    def run_guest_script(self, guest_script_path: str) -> str:
+        """
+        Execute a Python script that exists inside the container.
+
+        Args:
+            guest_script_path: Path to the script inside the container
+
+        Returns:
+            Execution output as a string (stdout + stderr)
+        """
+        result = self.exec("/usr/local/bin/python", guest_script_path)
+        return result.stdout + result.stderr


### PR DESCRIPTION
## Summary
- Clarify `run_script()` docstring: it reads from the **host** filesystem, not from inside the container
- Add `run_guest_script()` method for executing scripts that exist inside the VM
- Mirror both changes in `SyncCodeBox` to maintain API parity

Closes #235

## Dependency
**After PR #248 is merged** (which changes `run()` to return stdout only), `run_guest_script()` and `SyncCodeBox.run_guest_script()` should be updated to also return stdout only for consistency. Currently they return `stdout + stderr` to match the current `run()` behavior.

## Test plan
- [ ] Verify `run_script()` still works with host-side scripts
- [ ] Verify `run_guest_script()` works with container-side scripts
- [ ] Verify SyncCodeBox mirrors the same methods

🤖 Generated with [Claude Code](https://claude.com/claude-code)