### PR TITLE
feat(build): prepare crates for crates.io publishing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,7 +484,7 @@ dependencies = [
 
 [[package]]
 name = "bubblewrap-sys"
-version = "0.1.0"
+version = "0.5.11"
 dependencies = [
  "num_cpus",
 ]
@@ -959,7 +959,7 @@ checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
 name = "e2fsprogs-sys"
-version = "0.1.0"
+version = "0.5.11"
 dependencies = [
  "num_cpus",
 ]
@@ -1820,14 +1820,14 @@ dependencies = [
 
 [[package]]
 name = "libgvproxy-sys"
-version = "0.1.0"
+version = "0.5.11"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "libkrun-sys"
-version = "0.1.0"
+version = "0.5.11"
 dependencies = [
  "libc",
  "num_cpus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "boxlite",
     "boxlite-cli",
+    "boxlite/deps/bubblewrap-sys",
     "boxlite/deps/e2fsprogs-sys",
     "boxlite/deps/libgvproxy-sys",
     "boxlite/deps/libkrun-sys",

--- a/boxlite-cli/Cargo.toml
+++ b/boxlite-cli/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.2.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
+publish = false
 description = "Command-line interface for BoxLite container runtime"
 
 [[bin]]

--- a/boxlite-shared/Cargo.toml
+++ b/boxlite-shared/Cargo.toml
@@ -17,3 +17,6 @@ tokio = { version = "1", features = ["io-util"] }
 
 [build-dependencies]
 tonic-build = "0.12"
+
+[package.metadata.docs.rs]
+default-features = true

--- a/boxlite/Cargo.toml
+++ b/boxlite/Cargo.toml
@@ -28,11 +28,11 @@ libslirp-backend = []  # Uses external libslirp-helper binary, no Rust crate nee
 gvproxy-backend = ["dep:libgvproxy-sys"]   # Uses libgvproxy CGO shared library, links via FFI
 
 [dependencies]
-boxlite-shared = { path = "../boxlite-shared" }
+boxlite-shared = { path = "../boxlite-shared", version = "0.5.11" }
 
-e2fsprogs-sys = { path = "deps/e2fsprogs-sys" }
-libgvproxy-sys = { path = "deps/libgvproxy-sys", optional = true }
-libkrun-sys = { path = "deps/libkrun-sys" }
+e2fsprogs-sys = { path = "deps/e2fsprogs-sys", version = "0.5.11" }
+libgvproxy-sys = { path = "deps/libgvproxy-sys", version = "0.5.11", optional = true }
+libkrun-sys = { path = "deps/libkrun-sys", version = "0.5.11" }
 
 thiserror = "1.0"
 async-trait = "0.1"
@@ -80,7 +80,7 @@ signal-hook = "0.3"
 
 # Linux-specific dependencies for bind mount support
 [target.'cfg(target_os = "linux")'.dependencies]
-bubblewrap-sys = { path = "deps/bubblewrap-sys" }  # Bundled bwrap for sandbox isolation
+bubblewrap-sys = { path = "deps/bubblewrap-sys", version = "0.5.11" }  # Bundled bwrap for sandbox isolation
 caps = "0.5"
 fuse-backend-rs = { version = "0.12", features = ["fusedev"] }
 seccompiler = "0.4"  # Generate seccomp BPF filters for jailer

--- a/boxlite/deps/bubblewrap-sys/Cargo.toml
+++ b/boxlite/deps/bubblewrap-sys/Cargo.toml
@@ -1,11 +1,13 @@
 [package]
 name = "bubblewrap-sys"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
-authors = ["BoxLite Contributors"]
+authors.workspace = true
+license.workspace = true
 description = "Builds and bundles bwrap from bubblewrap"
-license = "Apache-2.0"
+repository = "https://github.com/boxlite-ai/boxlite"
 links = "bubblewrap"
+exclude = ["vendor"]
 
 [build-dependencies]
 num_cpus = "1.16"

--- a/boxlite/deps/bubblewrap-sys/build.rs
+++ b/boxlite/deps/bubblewrap-sys/build.rs
@@ -4,16 +4,30 @@
 //! Only builds on Linux (bubblewrap uses Linux-specific features).
 
 use std::env;
+use std::path::PathBuf;
 
 #[cfg(target_os = "linux")]
-use std::path::{Path, PathBuf};
+use std::path::Path;
 #[cfg(target_os = "linux")]
 use std::process::{Command, Stdio};
+
+/// Auto-set BOXLITE_DEPS_STUB=2 when downloaded from a registry (crates.io).
+/// Cargo adds .cargo_vcs_info.json to published packages.
+fn auto_detect_registry() {
+    if env::var("BOXLITE_DEPS_STUB").is_err() {
+        let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+        if manifest_dir.join(".cargo_vcs_info.json").exists() {
+            env::set_var("BOXLITE_DEPS_STUB", "2");
+        }
+    }
+}
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=vendor/bubblewrap");
     println!("cargo:rerun-if-env-changed=BOXLITE_DEPS_STUB");
+
+    auto_detect_registry();
 
     // Check for stub mode (for CI linting without building)
     // Set BOXLITE_DEPS_STUB=1 to skip building and emit stub directives

--- a/boxlite/deps/e2fsprogs-sys/Cargo.toml
+++ b/boxlite/deps/e2fsprogs-sys/Cargo.toml
@@ -1,11 +1,13 @@
 [package]
 name = "e2fsprogs-sys"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
-authors = ["BoxLite Contributors"]
+authors.workspace = true
+license.workspace = true
 description = "Builds and bundles mke2fs from e2fsprogs"
-license = "Apache-2.0"
+repository = "https://github.com/boxlite-ai/boxlite"
 links = "e2fsprogs"
+exclude = ["vendor"]
 
 [build-dependencies]
 num_cpus = "1.16"

--- a/boxlite/deps/e2fsprogs-sys/build.rs
+++ b/boxlite/deps/e2fsprogs-sys/build.rs
@@ -6,10 +6,23 @@ use std::env;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
+/// Auto-set BOXLITE_DEPS_STUB=2 when downloaded from a registry (crates.io).
+/// Cargo adds .cargo_vcs_info.json to published packages.
+fn auto_detect_registry() {
+    if env::var("BOXLITE_DEPS_STUB").is_err() {
+        let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+        if manifest_dir.join(".cargo_vcs_info.json").exists() {
+            env::set_var("BOXLITE_DEPS_STUB", "2");
+        }
+    }
+}
+
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=vendor/e2fsprogs");
     println!("cargo:rerun-if-env-changed=BOXLITE_DEPS_STUB");
+
+    auto_detect_registry();
 
     // Check for stub mode (for CI linting without building)
     // Set BOXLITE_DEPS_STUB=1 to skip building and emit stub directives

--- a/boxlite/deps/libgvproxy-sys/Cargo.toml
+++ b/boxlite/deps/libgvproxy-sys/Cargo.toml
@@ -1,13 +1,15 @@
 [package]
 name = "libgvproxy-sys"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
-authors = ["BoxLite Contributors"]
+authors.workspace = true
+license.workspace = true
 description = "FFI bindings to gvproxy-bridge C library"
-license = "Apache-2.0"
+repository = "https://github.com/boxlite-ai/boxlite"
 
 # This tells Cargo that this crate links with libgvproxy
 links = "gvproxy"
+exclude = ["gvproxy-bridge"]
 
 [build-dependencies]
 # No dependencies needed - we use Make to build

--- a/boxlite/deps/libgvproxy-sys/build.rs
+++ b/boxlite/deps/libgvproxy-sys/build.rs
@@ -1,6 +1,6 @@
 use std::env;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 /// Builds libgvproxy from Go sources using cgo.
@@ -97,12 +97,25 @@ fn get_library_name() -> &'static str {
     }
 }
 
+/// Auto-set BOXLITE_DEPS_STUB=2 when downloaded from a registry (crates.io).
+/// Cargo adds .cargo_vcs_info.json to published packages.
+fn auto_detect_registry() {
+    if env::var("BOXLITE_DEPS_STUB").is_err() {
+        let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+        if manifest_dir.join(".cargo_vcs_info.json").exists() {
+            env::set_var("BOXLITE_DEPS_STUB", "2");
+        }
+    }
+}
+
 fn main() {
     // Rebuild if Go sources change
     println!("cargo:rerun-if-changed=gvproxy-bridge/main.go");
     println!("cargo:rerun-if-changed=gvproxy-bridge/stats.go");
     println!("cargo:rerun-if-changed=gvproxy-bridge/go.mod");
     println!("cargo:rerun-if-env-changed=BOXLITE_DEPS_STUB");
+
+    auto_detect_registry();
 
     // Check for stub mode (for CI linting without building)
     // Set BOXLITE_DEPS_STUB=1 to skip building and emit stub link directives

--- a/boxlite/deps/libkrun-sys/Cargo.toml
+++ b/boxlite/deps/libkrun-sys/Cargo.toml
@@ -1,12 +1,14 @@
 [package]
 name = "libkrun-sys"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
-authors = ["BoxLite Contributors"]
+authors.workspace = true
+license.workspace = true
 description = "FFI bindings to libkrun and libkrunfw"
-license = "Apache-2.0"
+repository = "https://github.com/boxlite-ai/boxlite"
 
 links = "krun"
+exclude = ["vendor"]
 
 [build-dependencies]
 pkg-config = "0.3"

--- a/guest/Cargo.toml
+++ b/guest/Cargo.toml
@@ -3,6 +3,7 @@ name = "boxlite-guest"
 version.workspace = true
 authors.workspace = true
 license.workspace = true
+publish = false
 description = "Boxlite Guest Runtime"
 edition = "2021"
 

--- a/sdks/c/Cargo.toml
+++ b/sdks/c/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
+publish = false
 description = "C SDK for Boxlite runtime"
 
 [lib]

--- a/sdks/node/Cargo.toml
+++ b/sdks/node/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
+publish = false
 description = "Node.js bindings for BoxLite - embeddable VM runtime for secure code execution"
 
 [lib]

--- a/sdks/python/Cargo.toml
+++ b/sdks/python/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
+publish = false
 description = "Python bindings for Boxlite"
 
 [lib]


### PR DESCRIPTION
## Summary

Enable `cargo add boxlite` for Rust developers by preparing all 6 crates for crates.io publishing.

- **Auto-detect crates.io builds**: Each build.rs detects `.cargo_vcs_info.json` (added by Cargo to published packages) and auto-sets `BOXLITE_DEPS_STUB=2`, so crates.io builds download prebuilt runtime instead of compiling from vendored sources
- **Cargo.toml metadata**: Add version specs to path deps, sync -sys crate versions to workspace, add repository URLs, exclude vendor dirs from packages
- **Non-publishable crates**: Set `publish = false` for SDKs, CLI, and guest agent
- **Workspace member**: Add bubblewrap-sys to workspace members

## Publish order (handled by `cargo publish`)

```
boxlite-shared → libkrun-sys, e2fsprogs-sys, libgvproxy-sys, bubblewrap-sys → boxlite
```

## Package sizes (all well under 10MB crates.io limit)

| Crate | Compressed |
|-------|-----------|
| boxlite-shared | 18.5 KB |
| libkrun-sys | 10.0 KB |
| e2fsprogs-sys | 2.4 KB |
| libgvproxy-sys | 4.0 KB |
| bubblewrap-sys | 2.8 KB |
| boxlite | 319.1 KB |

## Test plan

- [x] `cargo package` succeeds for all 6 publishable crates
- [x] Build verification passes (downloads v0.5.11 prebuilt runtime)
- [x] Vendor directories excluded from packages (via `exclude = ["vendor"]`)
- [x] `publish = false` crates skipped
- [ ] `cargo publish -p boxlite-shared -p libkrun-sys -p e2fsprogs-sys -p libgvproxy-sys -p bubblewrap-sys -p boxlite` (after merge)