### PR TITLE
fix(ci): replace abandoned docker-run-action and fix meson PATH

### DIFF
--- a/.github/workflows/build-node.yml
+++ b/.github/workflows/build-node.yml
@@ -93,38 +93,40 @@ jobs:
 
       - name: Build Node.js package (Linux)
         if: runner.os == 'Linux'
-        uses: addnab/docker-run-action@v3
-        with:
-          image: quay.io/pypa/manylinux_2_28_${{ contains(matrix.target, 'arm64') && 'aarch64' || 'x86_64' }}
-          options: -v ${{ github.workspace }}:/work -w /work
-          run: |
-            set -ex
+        run: |
+          docker run --rm \
+            -v ${{ github.workspace }}:/work \
+            -w /work \
+            quay.io/pypa/manylinux_2_28_${{ contains(matrix.target, 'arm64') && 'aarch64' || 'x86_64' }} \
+            bash -c '
+              set -ex
 
-            # Mark directory as safe for git (ownership differs in container)
-            git config --global --add safe.directory /work
+              # Mark directory as safe for git (ownership differs in container)
+              git config --global --add safe.directory /work
 
-            # Restore pre-built guest target directory
-            GUEST_TARGET=$(scripts/util.sh --target)
-            if [ -d ".cache/$GUEST_TARGET" ]; then
-              echo "Restoring guest from .cache/$GUEST_TARGET"
-              mkdir -p target
-              cp -a ".cache/$GUEST_TARGET" "target/$GUEST_TARGET"
-            fi
+              # Restore pre-built guest target directory
+              GUEST_TARGET=$(scripts/util.sh --target)
+              if [ -d ".cache/$GUEST_TARGET" ]; then
+                echo "Restoring guest from .cache/$GUEST_TARGET"
+                mkdir -p target
+                cp -a ".cache/$GUEST_TARGET" "target/$GUEST_TARGET"
+              fi
 
-            # Build with SKIP_GUEST_BUILD=1 to use pre-built guest
-            export SKIP_GUEST_BUILD=1
-            make setup runtime
+              # Build with SKIP_GUEST_BUILD=1 to use pre-built guest
+              export SKIP_GUEST_BUILD=1
+              make setup runtime
 
-            # Add cargo to PATH for npm commands (matches Makefile pattern)
-            # (make installs cargo to ~/.cargo/bin but npm subprocesses don't inherit PATH)
-            export PATH="$HOME/.cargo/bin:$PATH"
+              # Add cargo to PATH for npm commands (matches Makefile pattern)
+              # (make installs cargo to ~/.cargo/bin but npm subprocesses don't inherit PATH)
+              export PATH="$HOME/.cargo/bin:$PATH"
 
-            # Build Node.js artifacts (no pack - CI uploads raw artifacts)
-            cd sdks/node
-            npm install --silent
-            npm run build:native -- --release
-            npm run artifacts
-            npm run bundle:runtime
+              # Build Node.js artifacts (no pack - CI uploads raw artifacts)
+              cd sdks/node
+              npm install --silent
+              npm run build:native -- --release
+              npm run artifacts
+              npm run bundle:runtime
+            '
 
       - name: Build Node.js package (macOS)
         if: runner.os == 'macOS'

--- a/.github/workflows/build-runtime.yml
+++ b/.github/workflows/build-runtime.yml
@@ -99,28 +99,31 @@ jobs:
 
       - name: Build runtime (Linux)
         if: runner.os == 'Linux'
-        uses: addnab/docker-run-action@v3
-        with:
-          image: quay.io/pypa/manylinux_2_28_${{ contains(matrix.target, 'arm64') && 'aarch64' || 'x86_64' }}
-          options: -v ${{ github.workspace }}:/work -w /work -e CARGO_HOME=/work/.cargo-manylinux
-          run: |
-            set -ex
+        run: |
+          docker run --rm \
+            -v ${{ github.workspace }}:/work \
+            -w /work \
+            -e CARGO_HOME=/work/.cargo-manylinux \
+            quay.io/pypa/manylinux_2_28_${{ contains(matrix.target, 'arm64') && 'aarch64' || 'x86_64' }} \
+            bash -c '
+              set -ex
 
-            # Mark directory as safe for git (ownership differs in container)
-            git config --global --add safe.directory /work
+              # Mark directory as safe for git (ownership differs in container)
+              git config --global --add safe.directory /work
 
-            # Restore pre-built guest target directory
-            GUEST_TARGET=$(scripts/util.sh --target)
-            if [ -d ".cache/$GUEST_TARGET" ]; then
-              echo "Restoring guest from .cache/$GUEST_TARGET"
-              mkdir -p target
-              cp -a ".cache/$GUEST_TARGET" "target/$GUEST_TARGET"
-            fi
+              # Restore pre-built guest target directory
+              GUEST_TARGET=$(scripts/util.sh --target)
+              if [ -d ".cache/$GUEST_TARGET" ]; then
+                echo "Restoring guest from .cache/$GUEST_TARGET"
+                mkdir -p target
+                cp -a ".cache/$GUEST_TARGET" "target/$GUEST_TARGET"
+              fi
 
-            # Build with SKIP_GUEST_BUILD=1 to use pre-built guest
-            export SKIP_GUEST_BUILD=1
-            export PATH="$CARGO_HOME/bin:$PATH"
-            make setup runtime
+              # Build with SKIP_GUEST_BUILD=1 to use pre-built guest
+              export SKIP_GUEST_BUILD=1
+              export PATH="$CARGO_HOME/bin:$PATH"
+              make setup runtime
+            '
 
       - name: Build runtime (macOS)
         if: runner.os == 'macOS'

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+        with:
+          submodules: recursive
 
       - name: Set up Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -109,7 +109,7 @@ repair-wheel-command = ""  # Skip auditwheel repair
 
 # Set Rust and library paths
 # SKIP_GUEST_BUILD=1: Use pre-built guest from Ubuntu host (manylinux lacks musl packages)
-environment = { SKIP_GUEST_BUILD = "1", PATH = "$CARGO_HOME:$PATH", PKG_CONFIG_PATH = "/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig", LD_LIBRARY_PATH = "/usr/local/lib64:/usr/local/lib" }
+environment = { SKIP_GUEST_BUILD = "1", PATH = "$HOME/.cargo/bin:/usr/local/bin:$PATH", PKG_CONFIG_PATH = "/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig", LD_LIBRARY_PATH = "/usr/local/lib64:/usr/local/lib" }
 
 # Retag wheel for PyPI compliance without bundling libs (we handle runtime deps ourselves)
 # Uses 'wheel tags' to change linux_x86_64 -> manylinux_2_28_x86_64


### PR DESCRIPTION
## Summary

- Replace `addnab/docker-run-action@v3` with direct `docker run` in build-runtime.yml and build-node.yml — the action is abandoned (2021) and bundles Docker 20.10 (API 1.41), incompatible with Docker Engine v29+ on GitHub runners (requires API 1.44+)
- Fix cibuildwheel linux PATH from `$CARGO_HOME:$PATH` to `$HOME/.cargo/bin:/usr/local/bin:$PATH` so per-Python builds can find `meson` (needed by `bubblewrap-sys` added in v0.5.11)
- Add `submodules: recursive` to build-wheels.yml checkout step

## Test plan

- [ ] Trigger `workflow_dispatch` for build-runtime workflow
- [ ] Trigger `workflow_dispatch` for build-wheels workflow
- [ ] Trigger `workflow_dispatch` for build-node workflow (optional, runs on release)