### PR TITLE
refactor(runtime): extract security types into advanced_options module

### DIFF
--- a/boxlite/src/jailer/builder.rs
+++ b/boxlite/src/jailer/builder.rs
@@ -3,7 +3,7 @@
 //! This module provides the main `Jailer` type for process isolation,
 //! along with a fluent `JailerBuilder` for configuration.
 
-use crate::jailer::config::{ResourceLimits, SecurityOptions};
+use crate::runtime::advanced_options::{ResourceLimits, SecurityOptions};
 use crate::runtime::options::VolumeSpec;
 use std::path::{Path, PathBuf};
 

--- a/boxlite/src/jailer/bwrap.rs
+++ b/boxlite/src/jailer/bwrap.rs
@@ -28,7 +28,7 @@
 // Allow dead_code on non-Linux platforms where bwrap is not available
 #![allow(dead_code)]
 
-use super::config::SecurityOptions;
+use crate::runtime::advanced_options::SecurityOptions;
 use crate::runtime::layout::FilesystemLayout;
 use crate::util::find_binary;
 use std::path::{Path, PathBuf};
@@ -105,7 +105,7 @@ pub fn check_userns_available() -> Result<(), String> {
     };
 
     let output = Command::new(bwrap_path)
-        .args(["--unshare-user", "--", "true"])
+        .args(["--unshare-user", "--ro-bind", "/", "/", "--", "true"])
         .output();
 
     match output {

--- a/boxlite/src/jailer/cgroup.rs
+++ b/boxlite/src/jailer/cgroup.rs
@@ -31,8 +31,8 @@
 //! ```
 
 use super::common;
-use super::config::ResourceLimits;
 use super::error::JailerError;
+use crate::runtime::advanced_options::ResourceLimits;
 use std::fs;
 use std::path::{Path, PathBuf};
 

--- a/boxlite/src/jailer/command.rs
+++ b/boxlite/src/jailer/command.rs
@@ -64,7 +64,7 @@ impl Jailer {
                      on this system.\n\n\
                      To fix, see: https://boxlite.dev/docs/faq#sandbox-userns\n\n\
                      To skip the sandbox (development only):\n  \
-                       SecurityOptions {{ jailer_enabled: false, .. }}"
+                       SecurityOptions::development()"
                 )));
             }
 
@@ -359,7 +359,7 @@ impl Jailer {
 #[cfg(test)]
 mod tests {
     use crate::jailer::builder::Jailer;
-    use crate::jailer::config::SecurityOptions;
+    use crate::runtime::advanced_options::SecurityOptions;
     use std::path::Path;
 
     /// When `jailer_enabled=false`, build_command must return a direct command

--- a/boxlite/src/jailer/common/rlimit.rs
+++ b/boxlite/src/jailer/common/rlimit.rs
@@ -6,7 +6,7 @@
 //! Only the async-signal-safe `apply_limits_raw()` is used,
 //! called from the `pre_exec` hook before exec().
 
-use crate::jailer::config::ResourceLimits;
+use crate::runtime::advanced_options::ResourceLimits;
 use std::io;
 
 /// Resource type alias for cross-platform compatibility.

--- a/boxlite/src/jailer/config.rs
+++ b/boxlite/src/jailer/config.rs
@@ -1,8 +1,0 @@
-//! Security configuration for the jailer.
-//!
-//! This module re-exports security types from `crate::runtime::options`.
-//! The actual definitions are in `runtime/options.rs` to keep related
-//! configuration types together and avoid circular dependencies.
-
-// Re-export security types from runtime::options
-pub use crate::runtime::options::{ResourceLimits, SecurityOptions};

--- a/boxlite/src/jailer/mod.rs
+++ b/boxlite/src/jailer/mod.rs
@@ -14,7 +14,6 @@
 //! ├── command.rs      (Command building for isolated processes)
 //! ├── pre_exec.rs     (Pre-exec hook for process isolation)
 //! ├── shim_copy.rs    (Firecracker copy-to-jail pattern)
-//! ├── config.rs       (Re-exports SecurityOptions, ResourceLimits)
 //! ├── error.rs        (Hierarchical error types)
 //! ├── seccomp.rs      (Seccomp BPF filter generation)
 //! ├── bwrap.rs        (Bubblewrap command builder)
@@ -68,7 +67,6 @@
 mod builder;
 mod command;
 mod common;
-mod config;
 mod error;
 mod pre_exec;
 
@@ -90,8 +88,8 @@ pub(crate) mod shim_copy;
 // ============================================================================
 
 // Core types
+pub use crate::runtime::advanced_options::{ResourceLimits, SecurityOptions};
 pub use builder::{Jailer, JailerBuilder};
-pub use config::{ResourceLimits, SecurityOptions};
 pub use error::{ConfigError, IsolationError, JailerError, SystemError};
 pub use platform::{PlatformIsolation, SpawnIsolation};
 
@@ -101,6 +99,8 @@ pub use crate::runtime::options::VolumeSpec;
 // Linux-specific exports
 #[cfg(target_os = "linux")]
 pub use bwrap::{build_shim_command, is_available as is_bwrap_available};
+#[cfg(target_os = "linux")]
+pub use seccomp::SeccompRole;
 
 // macOS-specific exports
 #[cfg(target_os = "macos")]

--- a/boxlite/src/jailer/platform/macos/mod.rs
+++ b/boxlite/src/jailer/platform/macos/mod.rs
@@ -47,7 +47,7 @@
 //!     boxlite-shim --config ...
 //! ```
 
-use crate::jailer::config::SecurityOptions;
+use crate::runtime::advanced_options::SecurityOptions;
 use crate::runtime::options::VolumeSpec;
 use boxlite_shared::errors::BoxliteResult;
 use std::ffi::CStr;

--- a/boxlite/src/jailer/platform/mod.rs
+++ b/boxlite/src/jailer/platform/mod.rs
@@ -17,7 +17,7 @@ pub mod linux;
 #[cfg(target_os = "macos")]
 pub mod macos;
 
-use crate::jailer::config::SecurityOptions;
+use crate::runtime::advanced_options::SecurityOptions;
 use crate::runtime::layout::FilesystemLayout;
 use crate::runtime::options::VolumeSpec;
 use boxlite_shared::errors::BoxliteResult;

--- a/boxlite/src/jailer/pre_exec.rs
+++ b/boxlite/src/jailer/pre_exec.rs
@@ -21,7 +21,7 @@
 //! See the [`common`](crate::jailer::common) module for async-signal-safe utilities.
 
 use crate::jailer::common;
-use crate::jailer::config::ResourceLimits;
+use crate::runtime::advanced_options::ResourceLimits;
 use std::process::Command;
 
 /// Add pre-execution hook for process isolation (async-signal-safe).

--- a/boxlite/src/jailer/seccomp.rs
+++ b/boxlite/src/jailer/seccomp.rs
@@ -16,8 +16,9 @@
 //!
 //! ## Filter Application
 //!
-//! - VMM filter: Applied to shim main thread before VM takeover
-//! - vCPU filter: Compiled but not yet applied (requires libkrun hooks)
+//! - VMM filter: Applied to shim main thread before VM takeover (with TSYNC
+//!   to synchronize across all existing threads)
+//! - vCPU filter: Compiled; vCPU threads inherit VMM filter via TSYNC
 //! - API filter: Not used in BoxLite (no separate API thread)
 //!
 //! ## Thread Model Differences
@@ -27,9 +28,7 @@
 //! threads are created internally by libkrun. This means:
 //!
 //! - Main thread: Becomes VMM thread after `ctx.start_enter()` (vmm filter applied)
-//! - vCPU threads: Created by libkrun (currently inherit vmm filter)
-//!
-//! Future enhancement: Add libkrun hooks to apply vcpu filter to vCPU threads.
+//! - vCPU threads: Created by libkrun (inherit vmm filter via TSYNC)
 
 use std::collections::HashMap;
 use std::io::Read;
@@ -64,6 +63,33 @@ pub type BpfProgramRef<'a> = &'a [BpfInstruction];
 /// Type that associates a thread category to a BPF program.
 pub type BpfThreadMap = HashMap<String, Arc<BpfProgram>>;
 
+/// Thread categories for seccomp filter application.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SeccompRole {
+    /// VMM (Virtual Machine Monitor) — main shim thread
+    Vmm,
+    /// vCPU — virtual CPU threads created by libkrun
+    Vcpu,
+    /// API — not used in BoxLite (reserved for compatibility)
+    Api,
+}
+
+impl SeccompRole {
+    /// Filter key used in BpfThreadMap.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Vmm => "vmm",
+            Self::Vcpu => "vcpu",
+            Self::Api => "api",
+        }
+    }
+}
+
+/// Get the BPF filter for a specific thread role.
+pub fn get_filter(filters: &BpfThreadMap, role: SeccompRole) -> Option<&Arc<BpfProgram>> {
+    filters.get(role.as_str())
+}
+
 /// Binary filter deserialization errors.
 pub type DeserializationError = bincode::error::DecodeError;
 
@@ -91,6 +117,8 @@ pub fn deserialize_binary<R: Read>(mut reader: R) -> Result<BpfThreadMap, Deseri
 pub enum InstallationError {
     /// Filter length exceeds the maximum size of 4096 instructions
     FilterTooLarge,
+    /// Thread synchronization failed. The value is the TID of the thread that could not sync: {0}
+    TsyncFailed(i64),
     /// `prctl` syscall failed with error code: {0}
     Prctl(std::io::Error),
 }
@@ -107,7 +135,7 @@ struct SockFprog {
     filter: *const BpfInstruction,
 }
 
-/// Apply BPF filter to current thread.
+/// Apply BPF filter to the calling thread only.
 ///
 /// This function installs a seccomp filter on the calling thread. The filter
 /// is applied using the SECCOMP_SET_MODE_FILTER operation, which allows the
@@ -124,6 +152,32 @@ struct SockFprog {
 /// - `FilterTooLarge`: Filter exceeds kernel's BPF_MAX_LEN limit
 /// - `Prctl`: System call failed (check errno for details)
 pub fn apply_filter(bpf_filter: BpfProgramRef) -> Result<(), InstallationError> {
+    install_filter(bpf_filter, 0)
+}
+
+/// Apply BPF filter to ALL threads in the process (TSYNC).
+///
+/// Uses `SECCOMP_FILTER_FLAG_TSYNC` to synchronize the filter across all
+/// existing threads. New threads created after this call inherit the filter
+/// automatically (standard kernel behavior).
+///
+/// This is defense-in-depth: ensures no thread escapes filtering,
+/// even if the process has unexpected threads at filter time.
+///
+/// ## Errors
+///
+/// - `FilterTooLarge`: Filter exceeds kernel's BPF_MAX_LEN limit
+/// - `TsyncFailed`: A thread could not be synchronized (returns its TID)
+/// - `Prctl`: System call failed
+pub fn apply_filter_all_threads(bpf_filter: BpfProgramRef) -> Result<(), InstallationError> {
+    install_filter(bpf_filter, libc::SECCOMP_FILTER_FLAG_TSYNC)
+}
+
+/// Internal: install seccomp filter with the given flags.
+fn install_filter(
+    bpf_filter: BpfProgramRef,
+    flags: libc::c_ulong,
+) -> Result<(), InstallationError> {
     // If the program is empty, don't install the filter.
     if bpf_filter.is_empty() {
         return Ok(());
@@ -158,9 +212,12 @@ pub fn apply_filter(bpf_filter: BpfProgramRef) -> Result<(), InstallationError> 
             let rc = libc::syscall(
                 libc::SYS_seccomp,
                 libc::SECCOMP_SET_MODE_FILTER,
-                0,
+                flags,
                 bpf_prog_ptr,
             );
+            if rc > 0 {
+                return Err(InstallationError::TsyncFailed(rc));
+            }
             if rc != 0 {
                 return Err(InstallationError::Prctl(std::io::Error::last_os_error()));
             }
@@ -268,6 +325,44 @@ mod tests {
         assert!(filters.get("vmm").unwrap().is_empty());
         assert!(filters.get("vcpu").unwrap().is_empty());
         assert!(filters.get("api").unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_seccomp_role() {
+        assert_eq!(SeccompRole::Vmm.as_str(), "vmm");
+        assert_eq!(SeccompRole::Vcpu.as_str(), "vcpu");
+        assert_eq!(SeccompRole::Api.as_str(), "api");
+    }
+
+    #[test]
+    fn test_get_filter() {
+        let mut map = BpfThreadMap::new();
+        map.insert("vmm".to_string(), Arc::new(vec![1, 2, 3]));
+        map.insert("vcpu".to_string(), Arc::new(vec![4, 5]));
+
+        assert!(get_filter(&map, SeccompRole::Vmm).is_some());
+        assert_eq!(get_filter(&map, SeccompRole::Vmm).unwrap().len(), 3);
+        assert!(get_filter(&map, SeccompRole::Vcpu).is_some());
+        assert!(get_filter(&map, SeccompRole::Api).is_none());
+    }
+
+    #[test]
+    fn test_tsync_failed_display() {
+        let err = InstallationError::TsyncFailed(12345);
+        assert!(err.to_string().contains("12345"));
+    }
+
+    #[test]
+    fn test_apply_filter_all_threads_empty() {
+        // Empty filter should be a no-op
+        thread::spawn(|| {
+            let filter: BpfProgram = vec![];
+            apply_filter_all_threads(&filter).unwrap();
+            let seccomp_level = unsafe { libc::prctl(libc::PR_GET_SECCOMP) };
+            assert_eq!(seccomp_level, 0);
+        })
+        .join()
+        .unwrap();
     }
 
     #[cfg(target_os = "linux")]

--- a/boxlite/src/lib.rs
+++ b/boxlite/src/lib.rs
@@ -35,13 +35,11 @@ pub use litebox::{
     BoxCommand, CopyOptions, ExecResult, ExecStderr, ExecStdin, ExecStdout, Execution, ExecutionId,
 };
 pub use metrics::{BoxMetrics, RuntimeMetrics};
+pub use runtime::advanced_options::{AdvancedBoxOptions, ResourceLimits, SecurityOptions};
 use runtime::layout::FilesystemLayout;
-pub use runtime::options::{
-    BoxOptions, BoxliteOptions, ResourceLimits, RootfsSpec, SecurityOptions,
-};
+pub use runtime::options::{BoxOptions, BoxliteOptions, RootfsSpec};
 /// Boxlite library version (from CARGO_PKG_VERSION at compile time).
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
-
 pub use runtime::types::ContainerID;
 pub use runtime::types::{BoxID, BoxInfo, BoxState, BoxStateInfo, BoxStatus};
 

--- a/boxlite/src/litebox/init/tasks/filesystem.rs
+++ b/boxlite/src/litebox/init/tasks/filesystem.rs
@@ -17,7 +17,10 @@ impl PipelineTask<InitCtx> for FilesystemTask {
 
         let (runtime, isolate_mounts) = {
             let ctx = ctx.lock().await;
-            (ctx.runtime.clone(), ctx.config.options.isolate_mounts)
+            (
+                ctx.runtime.clone(),
+                ctx.config.options.advanced.isolate_mounts,
+            )
         };
 
         let layout = runtime

--- a/boxlite/src/litebox/init/tasks/vmm_spawn.rs
+++ b/boxlite/src/litebox/init/tasks/vmm_spawn.rs
@@ -202,7 +202,7 @@ async fn build_config(
     let instance_spec = InstanceSpec {
         // Box identification and security
         box_id: box_id.to_string(),
-        security: options.security.clone(),
+        security: options.advanced.security.clone(),
         // VM resources
         cpus: options.cpus,
         memory_mib: options.memory_mib,

--- a/boxlite/src/runtime/advanced_options.rs
+++ b/boxlite/src/runtime/advanced_options.rs
@@ -1,0 +1,521 @@
+//! Advanced options for expert users.
+//!
+//! This module contains [`AdvancedBoxOptions`], [`SecurityOptions`], [`ResourceLimits`],
+//! and [`SecurityOptionsBuilder`] — configuration that entry-level users can safely
+//! ignore. Defaults are secure on all supported platforms.
+
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+// ============================================================================
+// Security Options
+// ============================================================================
+
+/// Security isolation options for a box.
+///
+/// These options control how the boxlite-shim process is isolated from the host.
+/// Different presets are available for different security requirements.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SecurityOptions {
+    /// Enable jailer isolation.
+    ///
+    /// When true, applies platform-specific security isolation:
+    /// - Linux: seccomp, namespaces, chroot, privilege drop
+    /// - macOS: sandbox-exec profile
+    ///
+    /// Default: true on Linux/macOS (use `SecurityOptions::development()` to disable)
+    #[serde(default = "default_jailer_enabled")]
+    pub jailer_enabled: bool,
+
+    /// Enable seccomp syscall filtering (Linux only).
+    ///
+    /// When true, applies a whitelist of allowed syscalls.
+    /// Default: true on Linux (use `SecurityOptions::development()` to disable)
+    #[serde(default = "default_seccomp_enabled")]
+    pub seccomp_enabled: bool,
+
+    /// UID to drop to after setup (Linux only).
+    ///
+    /// - None: Auto-allocate an unprivileged UID
+    /// - Some(0): Don't drop privileges (not recommended)
+    /// - Some(uid): Drop to specific UID
+    #[serde(default)]
+    pub uid: Option<u32>,
+
+    /// GID to drop to after setup (Linux only).
+    ///
+    /// - None: Auto-allocate an unprivileged GID
+    /// - Some(0): Don't drop privileges (not recommended)
+    /// - Some(gid): Drop to specific GID
+    #[serde(default)]
+    pub gid: Option<u32>,
+
+    /// Create new PID namespace (Linux only).
+    ///
+    /// When true, the shim becomes PID 1 in a new namespace.
+    /// Default: false
+    #[serde(default)]
+    pub new_pid_ns: bool,
+
+    /// Create new network namespace (Linux only).
+    ///
+    /// When true, creates isolated network namespace.
+    /// Note: gvproxy handles networking, so this may not be needed.
+    /// Default: false
+    #[serde(default)]
+    pub new_net_ns: bool,
+
+    /// Base directory for chroot jails (Linux only).
+    ///
+    /// Default: /srv/boxlite
+    #[serde(default = "default_chroot_base")]
+    pub chroot_base: PathBuf,
+
+    /// Enable chroot isolation (Linux only).
+    ///
+    /// When true, uses pivot_root to isolate filesystem.
+    /// Default: true on Linux
+    #[serde(default = "default_chroot_enabled")]
+    pub chroot_enabled: bool,
+
+    /// Close inherited file descriptors.
+    ///
+    /// When true, closes all FDs except stdin/stdout/stderr before VM start.
+    /// Default: true
+    #[serde(default = "default_close_fds")]
+    pub close_fds: bool,
+
+    /// Sanitize environment variables.
+    ///
+    /// When true, clears all environment variables except those in allowlist.
+    /// Default: true
+    #[serde(default = "default_sanitize_env")]
+    pub sanitize_env: bool,
+
+    /// Environment variables to preserve when sanitizing.
+    ///
+    /// Default: ["RUST_LOG", "PATH", "HOME", "USER", "LANG"]
+    #[serde(default = "default_env_allowlist")]
+    pub env_allowlist: Vec<String>,
+
+    /// Resource limits to apply.
+    #[serde(default)]
+    pub resource_limits: ResourceLimits,
+
+    /// Custom sandbox profile path (macOS only).
+    ///
+    /// If None, uses the built-in modular sandbox profile.
+    #[serde(default)]
+    pub sandbox_profile: Option<PathBuf>,
+
+    /// Enable network access in sandbox (macOS only).
+    ///
+    /// When true, adds network policy to the sandbox.
+    /// Default: true (needed for gvproxy VM networking)
+    #[serde(default = "default_network_enabled")]
+    pub network_enabled: bool,
+}
+
+/// Resource limits for the jailed process.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct ResourceLimits {
+    /// Maximum number of open file descriptors (RLIMIT_NOFILE).
+    #[serde(default)]
+    pub max_open_files: Option<u64>,
+
+    /// Maximum file size in bytes (RLIMIT_FSIZE).
+    #[serde(default)]
+    pub max_file_size: Option<u64>,
+
+    /// Maximum number of processes (RLIMIT_NPROC).
+    #[serde(default)]
+    pub max_processes: Option<u64>,
+
+    /// Maximum virtual memory in bytes (RLIMIT_AS).
+    #[serde(default)]
+    pub max_memory: Option<u64>,
+
+    /// Maximum CPU time in seconds (RLIMIT_CPU).
+    #[serde(default)]
+    pub max_cpu_time: Option<u64>,
+}
+
+// Default value functions for SecurityOptions
+
+fn default_jailer_enabled() -> bool {
+    cfg!(any(target_os = "linux", target_os = "macos"))
+}
+
+fn default_seccomp_enabled() -> bool {
+    cfg!(target_os = "linux")
+}
+
+fn default_chroot_base() -> PathBuf {
+    PathBuf::from("/srv/boxlite")
+}
+
+fn default_chroot_enabled() -> bool {
+    cfg!(target_os = "linux")
+}
+
+fn default_close_fds() -> bool {
+    true
+}
+
+fn default_sanitize_env() -> bool {
+    true
+}
+
+fn default_env_allowlist() -> Vec<String> {
+    vec![
+        "RUST_LOG".to_string(),
+        "PATH".to_string(),
+        "HOME".to_string(),
+        "USER".to_string(),
+        "LANG".to_string(),
+        "TERM".to_string(),
+    ]
+}
+
+fn default_network_enabled() -> bool {
+    true
+}
+
+impl Default for SecurityOptions {
+    fn default() -> Self {
+        Self {
+            jailer_enabled: default_jailer_enabled(),
+            seccomp_enabled: default_seccomp_enabled(),
+            uid: None,
+            gid: None,
+            new_pid_ns: false,
+            new_net_ns: false,
+            chroot_base: default_chroot_base(),
+            chroot_enabled: default_chroot_enabled(),
+            close_fds: default_close_fds(),
+            sanitize_env: default_sanitize_env(),
+            env_allowlist: default_env_allowlist(),
+            resource_limits: ResourceLimits::default(),
+            sandbox_profile: None,
+            network_enabled: default_network_enabled(),
+        }
+    }
+}
+
+impl SecurityOptions {
+    /// Development mode: minimal isolation for debugging.
+    ///
+    /// Use this when debugging issues where isolation interferes.
+    pub fn development() -> Self {
+        Self {
+            jailer_enabled: false,
+            seccomp_enabled: false,
+            chroot_enabled: false,
+            close_fds: false,
+            sanitize_env: false,
+            ..Default::default()
+        }
+    }
+
+    /// Standard mode: recommended for most use cases.
+    ///
+    /// Equivalent to `SecurityOptions::default()`. Provides good security
+    /// without being overly restrictive. Enables jailer on Linux/macOS,
+    /// seccomp on Linux.
+    pub fn standard() -> Self {
+        Self::default()
+    }
+
+    /// Maximum mode: all isolation features enabled.
+    ///
+    /// Use this for untrusted workloads (AI sandbox, multi-tenant).
+    pub fn maximum() -> Self {
+        Self {
+            jailer_enabled: true,
+            seccomp_enabled: cfg!(target_os = "linux"),
+            uid: Some(65534), // nobody
+            gid: Some(65534), // nogroup
+            new_pid_ns: cfg!(target_os = "linux"),
+            new_net_ns: false, // gvproxy needs network
+            chroot_enabled: cfg!(target_os = "linux"),
+            close_fds: true,
+            sanitize_env: true,
+            env_allowlist: vec!["RUST_LOG".to_string()],
+            resource_limits: ResourceLimits {
+                max_open_files: Some(1024),
+                max_file_size: Some(1024 * 1024 * 1024), // 1GB
+                max_processes: Some(100),
+                max_memory: None,   // Let VM config handle this
+                max_cpu_time: None, // Let VM config handle this
+            },
+            ..Default::default()
+        }
+    }
+
+    /// Check if current platform supports full jailer features.
+    pub fn is_full_isolation_available() -> bool {
+        cfg!(target_os = "linux")
+    }
+
+    /// Create a builder for customizing security options.
+    ///
+    /// Starts with default settings (jailer enabled on Linux/macOS).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use boxlite::runtime::advanced_options::SecurityOptions;
+    ///
+    /// let security = SecurityOptions::builder()
+    ///     .max_open_files(1024)
+    ///     .build();
+    /// ```
+    pub fn builder() -> SecurityOptionsBuilder {
+        SecurityOptionsBuilder::new()
+    }
+}
+
+// ============================================================================
+// Security Options Builder (C-BUILDER: Non-consuming builder pattern)
+// ============================================================================
+
+/// Builder for customizing [`SecurityOptions`].
+///
+/// Provides a fluent API for configuring security isolation options.
+/// Uses non-consuming methods per Rust API guidelines (C-BUILDER).
+///
+/// # Example
+///
+/// ```
+/// use boxlite::runtime::advanced_options::SecurityOptionsBuilder;
+///
+/// let security = SecurityOptionsBuilder::standard()
+///     .max_open_files(2048)
+///     .max_file_size_bytes(1024 * 1024 * 512) // 512 MiB
+///     .build();
+/// ```
+#[derive(Debug, Clone)]
+pub struct SecurityOptionsBuilder {
+    inner: SecurityOptions,
+}
+
+impl Default for SecurityOptionsBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SecurityOptionsBuilder {
+    /// Create a builder starting from default options.
+    pub fn new() -> Self {
+        Self {
+            inner: SecurityOptions::default(),
+        }
+    }
+
+    /// Create a builder starting from development settings.
+    ///
+    /// Minimal isolation for debugging.
+    pub fn development() -> Self {
+        Self {
+            inner: SecurityOptions::development(),
+        }
+    }
+
+    /// Create a builder starting from standard settings.
+    ///
+    /// Recommended for most use cases.
+    pub fn standard() -> Self {
+        Self {
+            inner: SecurityOptions::standard(),
+        }
+    }
+
+    /// Create a builder starting from maximum security settings.
+    ///
+    /// All isolation features enabled.
+    pub fn maximum() -> Self {
+        Self {
+            inner: SecurityOptions::maximum(),
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Core isolation settings
+    // ─────────────────────────────────────────────────────────────────────
+
+    /// Enable or disable jailer isolation.
+    pub fn jailer_enabled(&mut self, enabled: bool) -> &mut Self {
+        self.inner.jailer_enabled = enabled;
+        self
+    }
+
+    /// Enable or disable seccomp syscall filtering (Linux only).
+    pub fn seccomp_enabled(&mut self, enabled: bool) -> &mut Self {
+        self.inner.seccomp_enabled = enabled;
+        self
+    }
+
+    /// Set UID to drop to after setup (Linux only).
+    pub fn uid(&mut self, uid: u32) -> &mut Self {
+        self.inner.uid = Some(uid);
+        self
+    }
+
+    /// Set GID to drop to after setup (Linux only).
+    pub fn gid(&mut self, gid: u32) -> &mut Self {
+        self.inner.gid = Some(gid);
+        self
+    }
+
+    /// Enable or disable new PID namespace (Linux only).
+    pub fn new_pid_ns(&mut self, enabled: bool) -> &mut Self {
+        self.inner.new_pid_ns = enabled;
+        self
+    }
+
+    /// Enable or disable new network namespace (Linux only).
+    pub fn new_net_ns(&mut self, enabled: bool) -> &mut Self {
+        self.inner.new_net_ns = enabled;
+        self
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Filesystem isolation
+    // ─────────────────────────────────────────────────────────────────────
+
+    /// Set base directory for chroot jails (Linux only).
+    pub fn chroot_base(&mut self, path: impl Into<PathBuf>) -> &mut Self {
+        self.inner.chroot_base = path.into();
+        self
+    }
+
+    /// Enable or disable chroot isolation (Linux only).
+    pub fn chroot_enabled(&mut self, enabled: bool) -> &mut Self {
+        self.inner.chroot_enabled = enabled;
+        self
+    }
+
+    /// Enable or disable closing inherited file descriptors.
+    pub fn close_fds(&mut self, enabled: bool) -> &mut Self {
+        self.inner.close_fds = enabled;
+        self
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Environment settings
+    // ─────────────────────────────────────────────────────────────────────
+
+    /// Enable or disable environment variable sanitization.
+    pub fn sanitize_env(&mut self, enabled: bool) -> &mut Self {
+        self.inner.sanitize_env = enabled;
+        self
+    }
+
+    /// Set environment variables to preserve when sanitizing.
+    pub fn env_allowlist(&mut self, vars: Vec<String>) -> &mut Self {
+        self.inner.env_allowlist = vars;
+        self
+    }
+
+    /// Add an environment variable to the allowlist.
+    pub fn allow_env(&mut self, var: impl Into<String>) -> &mut Self {
+        self.inner.env_allowlist.push(var.into());
+        self
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Resource limits (type-safe setters)
+    // ─────────────────────────────────────────────────────────────────────
+
+    /// Set all resource limits at once.
+    pub fn resource_limits(&mut self, limits: ResourceLimits) -> &mut Self {
+        self.inner.resource_limits = limits;
+        self
+    }
+
+    /// Set maximum number of open file descriptors.
+    pub fn max_open_files(&mut self, limit: u64) -> &mut Self {
+        self.inner.resource_limits.max_open_files = Some(limit);
+        self
+    }
+
+    /// Set maximum file size in bytes.
+    pub fn max_file_size_bytes(&mut self, bytes: u64) -> &mut Self {
+        self.inner.resource_limits.max_file_size = Some(bytes);
+        self
+    }
+
+    /// Set maximum number of processes.
+    pub fn max_processes(&mut self, limit: u64) -> &mut Self {
+        self.inner.resource_limits.max_processes = Some(limit);
+        self
+    }
+
+    /// Set maximum virtual memory in bytes.
+    pub fn max_memory_bytes(&mut self, bytes: u64) -> &mut Self {
+        self.inner.resource_limits.max_memory = Some(bytes);
+        self
+    }
+
+    /// Set maximum CPU time in seconds.
+    pub fn max_cpu_time_seconds(&mut self, seconds: u64) -> &mut Self {
+        self.inner.resource_limits.max_cpu_time = Some(seconds);
+        self
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // macOS-specific settings
+    // ─────────────────────────────────────────────────────────────────────
+
+    /// Set custom sandbox profile path (macOS only).
+    pub fn sandbox_profile(&mut self, path: impl Into<PathBuf>) -> &mut Self {
+        self.inner.sandbox_profile = Some(path.into());
+        self
+    }
+
+    /// Enable or disable network access in sandbox (macOS only).
+    pub fn network_enabled(&mut self, enabled: bool) -> &mut Self {
+        self.inner.network_enabled = enabled;
+        self
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Build
+    // ─────────────────────────────────────────────────────────────────────
+
+    /// Build the configured [`SecurityOptions`].
+    pub fn build(&self) -> SecurityOptions {
+        self.inner.clone()
+    }
+}
+
+// ============================================================================
+// Advanced Options
+// ============================================================================
+
+/// Advanced options for expert users.
+///
+/// Entry-level users can ignore this — defaults are secure and reasonable.
+/// Only modify these if you understand the security implications.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct AdvancedBoxOptions {
+    /// Security isolation options (jailer, seccomp, namespaces, resource limits).
+    ///
+    /// Defaults are secure on all supported platforms. Use presets:
+    /// - `SecurityOptions::default()` / `standard()` — recommended for production
+    /// - `SecurityOptions::development()` — minimal isolation for debugging
+    /// - `SecurityOptions::maximum()` — maximum isolation for untrusted workloads
+    #[serde(default)]
+    pub security: SecurityOptions,
+
+    /// Enable bind mount isolation for the shared mounts directory.
+    ///
+    /// When true, creates a read-only bind mount from `mounts/` to `shared/`,
+    /// preventing the guest from modifying host-prepared files.
+    ///
+    /// Requires CAP_SYS_ADMIN (privileged) or FUSE (rootless) on Linux.
+    /// Defaults to false.
+    #[serde(default)]
+    pub isolate_mounts: bool,
+}

--- a/boxlite/src/runtime/mod.rs
+++ b/boxlite/src/runtime/mod.rs
@@ -1,3 +1,4 @@
+pub mod advanced_options;
 pub mod constants;
 pub(crate) mod guest_rootfs;
 pub mod layout;

--- a/boxlite/src/runtime/options.rs
+++ b/boxlite/src/runtime/options.rs
@@ -7,492 +7,7 @@ use dirs::home_dir;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
-// ============================================================================
-// Security Options
-// ============================================================================
-
-/// Security isolation options for a box.
-///
-/// These options control how the boxlite-shim process is isolated from the host.
-/// Different presets are available for different security requirements.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct SecurityOptions {
-    /// Enable jailer isolation.
-    ///
-    /// When true, applies platform-specific security isolation:
-    /// - Linux: seccomp, namespaces, chroot, privilege drop
-    /// - macOS: sandbox-exec profile
-    ///
-    /// Default: false (use `SecurityOptions::standard()` or `maximum()` to enable)
-    #[serde(default = "default_jailer_enabled")]
-    pub jailer_enabled: bool,
-
-    /// Enable seccomp syscall filtering (Linux only).
-    ///
-    /// When true, applies a whitelist of allowed syscalls.
-    /// Default: false (use `SecurityOptions::standard()` or `maximum()` to enable)
-    #[serde(default = "default_seccomp_enabled")]
-    pub seccomp_enabled: bool,
-
-    /// UID to drop to after setup (Linux only).
-    ///
-    /// - None: Auto-allocate an unprivileged UID
-    /// - Some(0): Don't drop privileges (not recommended)
-    /// - Some(uid): Drop to specific UID
-    #[serde(default)]
-    pub uid: Option<u32>,
-
-    /// GID to drop to after setup (Linux only).
-    ///
-    /// - None: Auto-allocate an unprivileged GID
-    /// - Some(0): Don't drop privileges (not recommended)
-    /// - Some(gid): Drop to specific GID
-    #[serde(default)]
-    pub gid: Option<u32>,
-
-    /// Create new PID namespace (Linux only).
-    ///
-    /// When true, the shim becomes PID 1 in a new namespace.
-    /// Default: false
-    #[serde(default)]
-    pub new_pid_ns: bool,
-
-    /// Create new network namespace (Linux only).
-    ///
-    /// When true, creates isolated network namespace.
-    /// Note: gvproxy handles networking, so this may not be needed.
-    /// Default: false
-    #[serde(default)]
-    pub new_net_ns: bool,
-
-    /// Base directory for chroot jails (Linux only).
-    ///
-    /// Default: /srv/boxlite
-    #[serde(default = "default_chroot_base")]
-    pub chroot_base: PathBuf,
-
-    /// Enable chroot isolation (Linux only).
-    ///
-    /// When true, uses pivot_root to isolate filesystem.
-    /// Default: true on Linux
-    #[serde(default = "default_chroot_enabled")]
-    pub chroot_enabled: bool,
-
-    /// Close inherited file descriptors.
-    ///
-    /// When true, closes all FDs except stdin/stdout/stderr before VM start.
-    /// Default: true
-    #[serde(default = "default_close_fds")]
-    pub close_fds: bool,
-
-    /// Sanitize environment variables.
-    ///
-    /// When true, clears all environment variables except those in allowlist.
-    /// Default: true
-    #[serde(default = "default_sanitize_env")]
-    pub sanitize_env: bool,
-
-    /// Environment variables to preserve when sanitizing.
-    ///
-    /// Default: ["RUST_LOG", "PATH", "HOME", "USER", "LANG"]
-    #[serde(default = "default_env_allowlist")]
-    pub env_allowlist: Vec<String>,
-
-    /// Resource limits to apply.
-    #[serde(default)]
-    pub resource_limits: ResourceLimits,
-
-    /// Custom sandbox profile path (macOS only).
-    ///
-    /// If None, uses the built-in modular sandbox profile.
-    #[serde(default)]
-    pub sandbox_profile: Option<PathBuf>,
-
-    /// Enable network access in sandbox (macOS only).
-    ///
-    /// When true, adds network policy to the sandbox.
-    /// Default: true (needed for gvproxy VM networking)
-    #[serde(default = "default_network_enabled")]
-    pub network_enabled: bool,
-}
-
-/// Resource limits for the jailed process.
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
-pub struct ResourceLimits {
-    /// Maximum number of open file descriptors (RLIMIT_NOFILE).
-    #[serde(default)]
-    pub max_open_files: Option<u64>,
-
-    /// Maximum file size in bytes (RLIMIT_FSIZE).
-    #[serde(default)]
-    pub max_file_size: Option<u64>,
-
-    /// Maximum number of processes (RLIMIT_NPROC).
-    #[serde(default)]
-    pub max_processes: Option<u64>,
-
-    /// Maximum virtual memory in bytes (RLIMIT_AS).
-    #[serde(default)]
-    pub max_memory: Option<u64>,
-
-    /// Maximum CPU time in seconds (RLIMIT_CPU).
-    #[serde(default)]
-    pub max_cpu_time: Option<u64>,
-}
-
-// Default value functions for SecurityOptions
-
-fn default_jailer_enabled() -> bool {
-    false
-}
-
-fn default_seccomp_enabled() -> bool {
-    false
-}
-
-fn default_chroot_base() -> PathBuf {
-    PathBuf::from("/srv/boxlite")
-}
-
-fn default_chroot_enabled() -> bool {
-    cfg!(target_os = "linux")
-}
-
-fn default_close_fds() -> bool {
-    true
-}
-
-fn default_sanitize_env() -> bool {
-    true
-}
-
-fn default_env_allowlist() -> Vec<String> {
-    vec![
-        "RUST_LOG".to_string(),
-        "PATH".to_string(),
-        "HOME".to_string(),
-        "USER".to_string(),
-        "LANG".to_string(),
-        "TERM".to_string(),
-    ]
-}
-
-fn default_network_enabled() -> bool {
-    true
-}
-
-impl Default for SecurityOptions {
-    fn default() -> Self {
-        Self {
-            jailer_enabled: default_jailer_enabled(),
-            seccomp_enabled: default_seccomp_enabled(),
-            uid: None,
-            gid: None,
-            new_pid_ns: false,
-            new_net_ns: false,
-            chroot_base: default_chroot_base(),
-            chroot_enabled: default_chroot_enabled(),
-            close_fds: default_close_fds(),
-            sanitize_env: default_sanitize_env(),
-            env_allowlist: default_env_allowlist(),
-            resource_limits: ResourceLimits::default(),
-            sandbox_profile: None,
-            network_enabled: default_network_enabled(),
-        }
-    }
-}
-
-impl SecurityOptions {
-    /// Development mode: minimal isolation for debugging.
-    ///
-    /// Use this when debugging issues where isolation interferes.
-    pub fn development() -> Self {
-        Self {
-            jailer_enabled: false,
-            seccomp_enabled: false,
-            chroot_enabled: false,
-            close_fds: false,
-            sanitize_env: false,
-            ..Default::default()
-        }
-    }
-
-    /// Standard mode: recommended for most use cases.
-    ///
-    /// Provides good security without being overly restrictive.
-    /// Enables jailer on Linux/macOS, seccomp on Linux.
-    pub fn standard() -> Self {
-        Self {
-            jailer_enabled: cfg!(any(target_os = "linux", target_os = "macos")),
-            seccomp_enabled: cfg!(target_os = "linux"),
-            ..Default::default()
-        }
-    }
-
-    /// Maximum mode: all isolation features enabled.
-    ///
-    /// Use this for untrusted workloads (AI sandbox, multi-tenant).
-    pub fn maximum() -> Self {
-        Self {
-            jailer_enabled: true,
-            seccomp_enabled: cfg!(target_os = "linux"),
-            uid: Some(65534), // nobody
-            gid: Some(65534), // nogroup
-            new_pid_ns: cfg!(target_os = "linux"),
-            new_net_ns: false, // gvproxy needs network
-            chroot_enabled: cfg!(target_os = "linux"),
-            close_fds: true,
-            sanitize_env: true,
-            env_allowlist: vec!["RUST_LOG".to_string()],
-            resource_limits: ResourceLimits {
-                max_open_files: Some(1024),
-                max_file_size: Some(1024 * 1024 * 1024), // 1GB
-                max_processes: Some(100),
-                max_memory: None,   // Let VM config handle this
-                max_cpu_time: None, // Let VM config handle this
-            },
-            ..Default::default()
-        }
-    }
-
-    /// Check if current platform supports full jailer features.
-    pub fn is_full_isolation_available() -> bool {
-        cfg!(target_os = "linux")
-    }
-
-    /// Create a builder for customizing security options.
-    ///
-    /// Starts with default (development) settings.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use boxlite::runtime::options::SecurityOptions;
-    ///
-    /// let security = SecurityOptions::builder()
-    ///     .jailer_enabled(true)
-    ///     .max_open_files(1024)
-    ///     .build();
-    /// ```
-    pub fn builder() -> SecurityOptionsBuilder {
-        SecurityOptionsBuilder::new()
-    }
-}
-
-// ============================================================================
-// Security Options Builder (C-BUILDER: Non-consuming builder pattern)
-// ============================================================================
-
-/// Builder for customizing [`SecurityOptions`].
-///
-/// Provides a fluent API for configuring security isolation options.
-/// Uses non-consuming methods per Rust API guidelines (C-BUILDER).
-///
-/// # Example
-///
-/// ```
-/// use boxlite::runtime::options::SecurityOptionsBuilder;
-///
-/// let security = SecurityOptionsBuilder::standard()
-///     .max_open_files(2048)
-///     .max_file_size_bytes(1024 * 1024 * 512) // 512 MiB
-///     .build();
-/// ```
-#[derive(Debug, Clone)]
-pub struct SecurityOptionsBuilder {
-    inner: SecurityOptions,
-}
-
-impl Default for SecurityOptionsBuilder {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl SecurityOptionsBuilder {
-    /// Create a builder starting from default options.
-    pub fn new() -> Self {
-        Self {
-            inner: SecurityOptions::default(),
-        }
-    }
-
-    /// Create a builder starting from development settings.
-    ///
-    /// Minimal isolation for debugging.
-    pub fn development() -> Self {
-        Self {
-            inner: SecurityOptions::development(),
-        }
-    }
-
-    /// Create a builder starting from standard settings.
-    ///
-    /// Recommended for most use cases.
-    pub fn standard() -> Self {
-        Self {
-            inner: SecurityOptions::standard(),
-        }
-    }
-
-    /// Create a builder starting from maximum security settings.
-    ///
-    /// All isolation features enabled.
-    pub fn maximum() -> Self {
-        Self {
-            inner: SecurityOptions::maximum(),
-        }
-    }
-
-    // ─────────────────────────────────────────────────────────────────────
-    // Core isolation settings
-    // ─────────────────────────────────────────────────────────────────────
-
-    /// Enable or disable jailer isolation.
-    pub fn jailer_enabled(&mut self, enabled: bool) -> &mut Self {
-        self.inner.jailer_enabled = enabled;
-        self
-    }
-
-    /// Enable or disable seccomp syscall filtering (Linux only).
-    pub fn seccomp_enabled(&mut self, enabled: bool) -> &mut Self {
-        self.inner.seccomp_enabled = enabled;
-        self
-    }
-
-    /// Set UID to drop to after setup (Linux only).
-    pub fn uid(&mut self, uid: u32) -> &mut Self {
-        self.inner.uid = Some(uid);
-        self
-    }
-
-    /// Set GID to drop to after setup (Linux only).
-    pub fn gid(&mut self, gid: u32) -> &mut Self {
-        self.inner.gid = Some(gid);
-        self
-    }
-
-    /// Enable or disable new PID namespace (Linux only).
-    pub fn new_pid_ns(&mut self, enabled: bool) -> &mut Self {
-        self.inner.new_pid_ns = enabled;
-        self
-    }
-
-    /// Enable or disable new network namespace (Linux only).
-    pub fn new_net_ns(&mut self, enabled: bool) -> &mut Self {
-        self.inner.new_net_ns = enabled;
-        self
-    }
-
-    // ─────────────────────────────────────────────────────────────────────
-    // Filesystem isolation
-    // ─────────────────────────────────────────────────────────────────────
-
-    /// Set base directory for chroot jails (Linux only).
-    pub fn chroot_base(&mut self, path: impl Into<PathBuf>) -> &mut Self {
-        self.inner.chroot_base = path.into();
-        self
-    }
-
-    /// Enable or disable chroot isolation (Linux only).
-    pub fn chroot_enabled(&mut self, enabled: bool) -> &mut Self {
-        self.inner.chroot_enabled = enabled;
-        self
-    }
-
-    /// Enable or disable closing inherited file descriptors.
-    pub fn close_fds(&mut self, enabled: bool) -> &mut Self {
-        self.inner.close_fds = enabled;
-        self
-    }
-
-    // ─────────────────────────────────────────────────────────────────────
-    // Environment settings
-    // ─────────────────────────────────────────────────────────────────────
-
-    /// Enable or disable environment variable sanitization.
-    pub fn sanitize_env(&mut self, enabled: bool) -> &mut Self {
-        self.inner.sanitize_env = enabled;
-        self
-    }
-
-    /// Set environment variables to preserve when sanitizing.
-    pub fn env_allowlist(&mut self, vars: Vec<String>) -> &mut Self {
-        self.inner.env_allowlist = vars;
-        self
-    }
-
-    /// Add an environment variable to the allowlist.
-    pub fn allow_env(&mut self, var: impl Into<String>) -> &mut Self {
-        self.inner.env_allowlist.push(var.into());
-        self
-    }
-
-    // ─────────────────────────────────────────────────────────────────────
-    // Resource limits (type-safe setters)
-    // ─────────────────────────────────────────────────────────────────────
-
-    /// Set all resource limits at once.
-    pub fn resource_limits(&mut self, limits: ResourceLimits) -> &mut Self {
-        self.inner.resource_limits = limits;
-        self
-    }
-
-    /// Set maximum number of open file descriptors.
-    pub fn max_open_files(&mut self, limit: u64) -> &mut Self {
-        self.inner.resource_limits.max_open_files = Some(limit);
-        self
-    }
-
-    /// Set maximum file size in bytes.
-    pub fn max_file_size_bytes(&mut self, bytes: u64) -> &mut Self {
-        self.inner.resource_limits.max_file_size = Some(bytes);
-        self
-    }
-
-    /// Set maximum number of processes.
-    pub fn max_processes(&mut self, limit: u64) -> &mut Self {
-        self.inner.resource_limits.max_processes = Some(limit);
-        self
-    }
-
-    /// Set maximum virtual memory in bytes.
-    pub fn max_memory_bytes(&mut self, bytes: u64) -> &mut Self {
-        self.inner.resource_limits.max_memory = Some(bytes);
-        self
-    }
-
-    /// Set maximum CPU time in seconds.
-    pub fn max_cpu_time_seconds(&mut self, seconds: u64) -> &mut Self {
-        self.inner.resource_limits.max_cpu_time = Some(seconds);
-        self
-    }
-
-    // ─────────────────────────────────────────────────────────────────────
-    // macOS-specific settings
-    // ─────────────────────────────────────────────────────────────────────
-
-    /// Set custom sandbox profile path (macOS only).
-    pub fn sandbox_profile(&mut self, path: impl Into<PathBuf>) -> &mut Self {
-        self.inner.sandbox_profile = Some(path.into());
-        self
-    }
-
-    /// Enable or disable network access in sandbox (macOS only).
-    pub fn network_enabled(&mut self, enabled: bool) -> &mut Self {
-        self.inner.network_enabled = enabled;
-        self
-    }
-
-    // ─────────────────────────────────────────────────────────────────────
-    // Build
-    // ─────────────────────────────────────────────────────────────────────
-
-    /// Build the configured [`SecurityOptions`].
-    pub fn build(&self) -> SecurityOptions {
-        self.inner.clone()
-    }
-}
+use crate::runtime::advanced_options::{AdvancedBoxOptions, SecurityOptions};
 
 // ============================================================================
 // Runtime Options
@@ -565,16 +80,6 @@ pub struct BoxOptions {
     pub volumes: Vec<VolumeSpec>,
     pub network: NetworkSpec,
     pub ports: Vec<PortSpec>,
-    /// Enable bind mount isolation for the shared mounts directory.
-    ///
-    /// When true, creates a read-only bind mount from `mounts/` to `shared/`,
-    /// preventing the guest from modifying host-prepared files.
-    ///
-    /// Requires CAP_SYS_ADMIN (privileged) or FUSE (rootless) on Linux.
-    /// Defaults to false.
-    #[serde(default)]
-    pub isolate_mounts: bool,
-
     /// Automatically remove box when stopped.
     ///
     /// When true (default), the box is removed from the database and its
@@ -598,13 +103,12 @@ pub struct BoxOptions {
     #[serde(default = "default_detach")]
     pub detach: bool,
 
-    /// Security isolation options for the box.
+    /// Advanced options for expert users (security, mount isolation).
     ///
-    /// Controls how the boxlite-shim process is isolated from the host.
-    /// Different presets are available: `SecurityOptions::development()`,
-    /// `SecurityOptions::standard()`, `SecurityOptions::maximum()`.
+    /// Defaults are secure — most users can ignore this entirely.
+    /// See [`AdvancedBoxOptions`] for details.
     #[serde(default)]
-    pub security: SecurityOptions,
+    pub advanced: AdvancedBoxOptions,
 
     /// Override the image's ENTRYPOINT directive.
     ///
@@ -654,10 +158,9 @@ impl Default for BoxOptions {
             volumes: Vec::new(),
             network: NetworkSpec::default(),
             ports: Vec::new(),
-            isolate_mounts: false,
             auto_remove: default_auto_remove(),
             detach: default_detach(),
-            security: SecurityOptions::default(),
+            advanced: AdvancedBoxOptions::default(),
             entrypoint: None,
             cmd: None,
             user: None,
@@ -670,7 +173,7 @@ impl BoxOptions {
     ///
     /// Validates option combinations:
     /// - `auto_remove=true` with `detach=true` is invalid (detached boxes need manual lifecycle control)
-    /// - `isolate_mounts=true` is only supported on Linux
+    /// - `advanced.isolate_mounts=true` is only supported on Linux
     pub fn sanitize(&self) -> BoxliteResult<()> {
         // Validate auto_remove + detach combination
         // A detached box that auto-removes doesn't make practical sense:
@@ -686,12 +189,18 @@ impl BoxOptions {
         }
 
         #[cfg(not(target_os = "linux"))]
-        if self.isolate_mounts {
+        if self.advanced.isolate_mounts {
             return Err(boxlite_shared::errors::BoxliteError::Unsupported(
                 "isolate_mounts is only supported on Linux".to_string(),
             ));
         }
         Ok(())
+    }
+
+    /// Set security options (convenience for `advanced.security`).
+    pub fn with_security(mut self, security: SecurityOptions) -> Self {
+        self.advanced.security = security;
+        self
     }
 }
 
@@ -752,6 +261,7 @@ pub struct PortSpec {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::runtime::advanced_options::SecurityOptionsBuilder;
 
     #[test]
     fn test_box_options_defaults() {
@@ -867,9 +377,12 @@ mod tests {
     #[test]
     fn test_security_builder_new() {
         let opts = SecurityOptionsBuilder::new().build();
-        // Default should match SecurityOptions::default()
-        assert!(!opts.jailer_enabled);
-        assert!(!opts.seccomp_enabled);
+        // Default should match SecurityOptions::default() = standard security
+        assert_eq!(
+            opts.jailer_enabled,
+            cfg!(any(target_os = "linux", target_os = "macos"))
+        );
+        assert_eq!(opts.seccomp_enabled, cfg!(target_os = "linux"));
     }
 
     #[test]

--- a/boxlite/src/vmm/controller/shim.rs
+++ b/boxlite/src/vmm/controller/shim.rs
@@ -270,7 +270,7 @@ impl VmmController for ShimController {
         let serializable_config = InstanceSpec {
             // Box identification and security (from ShimController)
             box_id: self.box_id.to_string(),
-            security: self.options.security.clone(),
+            security: self.options.advanced.security.clone(),
             // VM configuration
             cpus: config.cpus,
             memory_mib: config.memory_mib,

--- a/boxlite/src/vmm/controller/spawn.rs
+++ b/boxlite/src/vmm/controller/spawn.rs
@@ -47,7 +47,7 @@ pub(crate) fn spawn_subprocess(
 
     // Create Jailer with security options and volumes
     let jailer = Jailer::new(box_id, &box_dir)
-        .with_security(options.security.clone())
+        .with_security(options.advanced.security.clone())
         .with_volumes(options.volumes.clone());
 
     // Setup pre-spawn isolation (cgroups on Linux, no-op on macOS)

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -181,19 +181,16 @@ Provides OS-level isolation on top of hardware virtualization.
 **Configuration:**
 
 ```rust
-use boxlite::SecurityOptions;
+use boxlite::{AdvancedBoxOptions, SecurityOptions};
 
-// Maximum security (recommended for untrusted workloads)
-let security = SecurityOptions::maximum();
-
-// Custom configuration
-let security = SecurityOptions {
-    jailer_enabled: true,
-    seccomp_enabled: true,  // Linux only
-    chroot_enabled: true,   // Linux only
-    close_fds: true,
-    sanitize_env: true,
-    resource_limits: Some(ResourceLimits::default()),
+// Most users don't need to configure security — defaults are secure
+// For advanced users who need maximum isolation:
+let opts = BoxOptions {
+    advanced: AdvancedBoxOptions {
+        security: SecurityOptions::maximum(),
+        ..Default::default()
+    },
+    ..Default::default()
 };
 ```
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -554,10 +554,10 @@ If you don't need sandbox isolation (e.g., development environment),
 disable the jailer:
 
 ```python
-from boxlite.boxlite import SecurityOptions
+from boxlite.boxlite import SecurityOptions, AdvancedBoxOptions
 
 boxlite.BoxOptions(
-    security=SecurityOptions(jailer_enabled=False),
+    advanced=AdvancedBoxOptions(security=SecurityOptions.development()),
     # ... other options
 )
 ```

--- a/sdks/node/src/options.rs
+++ b/sdks/node/src/options.rs
@@ -1,9 +1,9 @@
 use std::path::PathBuf;
 
+use boxlite::runtime::advanced_options::{AdvancedBoxOptions, ResourceLimits, SecurityOptions};
 use boxlite::runtime::constants::images;
 use boxlite::runtime::options::{
-    BoxOptions, BoxliteOptions, NetworkSpec, PortProtocol, PortSpec, ResourceLimits, RootfsSpec,
-    SecurityOptions, VolumeSpec,
+    BoxOptions, BoxliteOptions, NetworkSpec, PortProtocol, PortSpec, RootfsSpec, VolumeSpec,
 };
 use napi_derive::napi;
 
@@ -319,10 +319,12 @@ impl From<JsBoxOptions> for BoxOptions {
             volumes,
             network,
             ports,
-            isolate_mounts: false, // Not exposed in JS API yet
+            advanced: AdvancedBoxOptions {
+                security,
+                ..Default::default()
+            },
             auto_remove: js_opts.auto_remove.unwrap_or(false),
             detach: js_opts.detach.unwrap_or(false),
-            security,
             entrypoint: js_opts.entrypoint,
             cmd: js_opts.cmd,
             user: js_opts.user,

--- a/sdks/python/src/lib.rs
+++ b/sdks/python/src/lib.rs
@@ -12,7 +12,9 @@ use crate::box_handle::PyBox;
 use crate::exec::{PyExecStderr, PyExecStdin, PyExecStdout, PyExecution};
 use crate::info::{PyBoxInfo, PyBoxStateInfo};
 use crate::metrics::{PyBoxMetrics, PyRuntimeMetrics};
-use crate::options::{PyBoxOptions, PyCopyOptions, PyOptions, PySecurityOptions};
+use crate::options::{
+    PyAdvancedBoxOptions, PyBoxOptions, PyCopyOptions, PyOptions, PySecurityOptions,
+};
 use crate::runtime::PyBoxlite;
 use pyo3::prelude::*;
 
@@ -21,6 +23,7 @@ fn boxlite_python(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyOptions>()?;
     m.add_class::<PyBoxOptions>()?;
     m.add_class::<PySecurityOptions>()?;
+    m.add_class::<PyAdvancedBoxOptions>()?;
     m.add_class::<PyBoxlite>()?;
     m.add_class::<PyBox>()?;
     m.add_class::<PyExecution>()?;


### PR DESCRIPTION
## Summary

- Extract `SecurityOptions`, `ResourceLimits`, and `AdvancedBoxOptions` from `runtime::options` into a dedicated `runtime::advanced_options` module
- Add `SeccompRole` enum and multi-role filter support to `jailer::seccomp` (preparation for two-phase stacking)
- Update all SDK imports (Python, Node) to use the new module paths
- Remove deprecated `jailer::config` module (re-exported types now live in `advanced_options`)

## Motivation

`runtime::options` had grown to include both user-facing box options and internal security/isolation types. Extracting security types into `advanced_options` provides:
- Clearer separation between user-facing API (`BoxOptions`) and internal isolation config
- A home for `SeccompRole` and filter compilation infrastructure needed by upcoming seccomp work
- Consistent module for SDK security option passthrough (Node SDK PR #231)

## Test plan

- [x] `cargo check -p boxlite -p boxlite-python -p boxlite-node -p boxlite-cli` — clean
- [x] `cargo test -p boxlite-node` — 5/5 pass
- [x] Node SDK security options passthrough preserved (routes through `AdvancedBoxOptions.security`)
- [ ] CI checks