### PR TITLE
feat(api): add OpenAPI 3.1.1 spec for cloud sandbox REST API

### DIFF
--- a/boxlite/openapi/rest-sandbox-open-api.yaml
+++ b/boxlite/openapi/rest-sandbox-open-api.yaml
@@ -1095,6 +1095,8 @@ components:
       type: object
       description: |
         Standard error response. Maps directly to BoxliteError variants.
+        `UnauthorizedError` is a server-layer error (auth middleware) and does
+        not correspond to a BoxliteError variant in the core library.
       required: [message, type, code]
       properties:
         message:
@@ -1113,6 +1115,7 @@ components:
             - PortalError
             - NetworkError
             - RpcError
+            - RpcTransportError
             - InternalError
             - ExecutionError
             - NotFoundError
@@ -1276,8 +1279,9 @@ components:
             $ref: "#/components/schemas/PortSpec"
         network:
           type: string
-          description: Network isolation mode
-          enum: [isolated]
+          description: |
+            Network isolation mode. Currently supported: `isolated`.
+            Additional modes may be added in future versions.
           default: isolated
         auto_remove:
           type: boolean
@@ -1289,11 +1293,6 @@ components:
           default: false
         security:
           $ref: "#/components/schemas/SecurityPreset"
-        labels:
-          type: object
-          additionalProperties:
-            type: string
-          description: User-defined key-value labels
 
     VolumeSpec:
       type: object


### PR DESCRIPTION
## Summary

- Add OpenAPI 3.1.1 specification for the BoxLite cloud sandbox REST API at `boxlite/openapi/rest-sandbox-open-api.yaml`
- API design follows industry-standard REST patterns (versioned prefix, multi-tenancy, capability discovery, idempotency keys, standard error model, pagination)
- 24 endpoints across 7 resource groups, all schemas mapping 1:1 to existing Rust types

## API Design

| Group | Endpoints | Description |
|-------|-----------|-------------|
| Configuration | `GET /v1/config` | Server capability discovery |
| Auth | `POST /v1/oauth/tokens` | OAuth2 client credentials |
| Boxes | 7 endpoints | CRUD + start/stop lifecycle |
| Execution | 6 endpoints | Async exec, SSE streaming, stdin, signals, TTY (WebSocket) |
| Files | 2 endpoints | Upload/download via tar streams |
| Metrics | 2 endpoints | Runtime-wide + per-box metrics |
| Images | 4 endpoints | Pull, list, get, exists check |

### Key Design Decisions

- **Multi-tenancy**: `{prefix}` path segment = organization/workspace ID
- **Execution**: Async only — `POST /exec` returns `execution_id`, stream via SSE
- **TTY**: WebSocket at `/exec/tty` for interactive terminal sessions
- **Files**: Binary tar stream (matches existing `FilesInterface`)
- **Errors**: Standard `{message, type, code}` model mapping all `BoxliteError` variants

## Test plan

- [x] YAML syntax validated (Python yaml.safe_load)
- [x] All `$ref` references resolve correctly (24 schemas, 7 parameters)
- [x] All `BoxliteError` variants mapped to error types
- [x] All `BoxOptions` fields represented in `CreateBoxRequest`
- [x] All `BoxInfo` fields represented in `Box` response schema
- [ ] Lint with `npx @redocly/cli lint` (optional, CI)
- [ ] Generate preview docs with `npx @redocly/cli preview-docs` (optional)