### PR TITLE
refactor(sdk): extract security types into advanced_options module

### DIFF
--- a/sdks/node/src/advanced_options.rs
+++ b/sdks/node/src/advanced_options.rs
@@ -1,0 +1,126 @@
+use boxlite::runtime::advanced_options::{ResourceLimits, SecurityOptions};
+use napi_derive::napi;
+
+// ============================================================================
+// Security Options
+// ============================================================================
+
+/// Security isolation options for a box.
+///
+/// Controls how the boxlite-shim process is isolated from the host.
+#[napi(object)]
+#[derive(Clone, Debug)]
+pub struct JsSecurityOptions {
+    /// Enable jailer isolation (Linux/macOS).
+    pub jailer_enabled: Option<bool>,
+
+    /// Enable seccomp syscall filtering (Linux only).
+    pub seccomp_enabled: Option<bool>,
+
+    /// Maximum number of open file descriptors.
+    pub max_open_files: Option<f64>,
+
+    /// Maximum file size in bytes.
+    pub max_file_size: Option<f64>,
+
+    /// Maximum number of processes.
+    pub max_processes: Option<f64>,
+
+    /// Maximum virtual memory in bytes.
+    pub max_memory: Option<f64>,
+
+    /// Maximum CPU time in seconds.
+    pub max_cpu_time: Option<f64>,
+
+    /// Enable network access in sandbox (macOS only).
+    pub network_enabled: Option<bool>,
+
+    /// Close inherited file descriptors.
+    pub close_fds: Option<bool>,
+}
+
+const JS_MAX_SAFE_INTEGER: u64 = 9_007_199_254_740_991;
+
+pub(crate) fn coerce_u64_limit(number: f64) -> Option<u64> {
+    if !number.is_finite() || number < 0.0 || number.fract() != 0.0 {
+        return None;
+    }
+
+    if number > JS_MAX_SAFE_INTEGER as f64 {
+        return None;
+    }
+
+    Some(number as u64)
+}
+
+fn coerce_optional_u64_limit(value: Option<f64>) -> Option<u64> {
+    value.and_then(coerce_u64_limit)
+}
+
+impl From<JsSecurityOptions> for SecurityOptions {
+    fn from(js_opts: JsSecurityOptions) -> Self {
+        let mut opts = SecurityOptions::default();
+
+        if let Some(jailer_enabled) = js_opts.jailer_enabled {
+            opts.jailer_enabled = jailer_enabled;
+        }
+
+        if let Some(seccomp_enabled) = js_opts.seccomp_enabled {
+            opts.seccomp_enabled = seccomp_enabled;
+        }
+
+        if let Some(network_enabled) = js_opts.network_enabled {
+            opts.network_enabled = network_enabled;
+        }
+
+        if let Some(close_fds) = js_opts.close_fds {
+            opts.close_fds = close_fds;
+        }
+
+        opts.resource_limits = ResourceLimits {
+            max_open_files: coerce_optional_u64_limit(js_opts.max_open_files),
+            max_file_size: coerce_optional_u64_limit(js_opts.max_file_size),
+            max_processes: coerce_optional_u64_limit(js_opts.max_processes),
+            max_memory: coerce_optional_u64_limit(js_opts.max_memory),
+            max_cpu_time: coerce_optional_u64_limit(js_opts.max_cpu_time),
+        };
+
+        opts
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn coerces_safe_integer_number_limit() {
+        let parsed = coerce_u64_limit(1024.0);
+        assert_eq!(parsed, Some(1024));
+    }
+
+    #[test]
+    fn drops_fractional_number_limit() {
+        let parsed = coerce_u64_limit(12.5);
+        assert_eq!(parsed, None);
+    }
+
+    #[test]
+    fn drops_negative_number_limit() {
+        let parsed = coerce_u64_limit(-1.0);
+        assert_eq!(parsed, None);
+    }
+
+    #[test]
+    fn drops_unsafe_integer_number_limit() {
+        let too_large_for_number = JS_MAX_SAFE_INTEGER as f64 + 1.0;
+        let parsed = coerce_u64_limit(too_large_for_number);
+        assert_eq!(parsed, None);
+    }
+
+    #[test]
+    fn drops_non_finite_number_limit() {
+        let parsed = coerce_u64_limit(f64::INFINITY);
+        assert_eq!(parsed, None);
+    }
+}

--- a/sdks/node/src/lib.rs
+++ b/sdks/node/src/lib.rs
@@ -5,6 +5,7 @@
 //! This crate provides napi-rs bindings for BoxLite, allowing JavaScript/TypeScript
 //! applications to create and manage isolated VM-based containers.
 
+mod advanced_options;
 mod box_handle;
 mod copy;
 mod exec;
@@ -15,10 +16,11 @@ mod runtime;
 mod util;
 
 // Re-export all public types
+pub use advanced_options::JsSecurityOptions;
 pub use box_handle::JsBox;
 pub use copy::JsCopyOptions;
 pub use exec::{JsExecResult, JsExecStderr, JsExecStdin, JsExecStdout, JsExecution};
 pub use info::JsBoxInfo;
 pub use metrics::{JsBoxMetrics, JsRuntimeMetrics};
-pub use options::{JsBoxOptions, JsEnvVar, JsOptions, JsPortSpec, JsSecurityOptions, JsVolumeSpec};
+pub use options::{JsBoxOptions, JsEnvVar, JsOptions, JsPortSpec, JsVolumeSpec};
 pub use runtime::JsBoxlite; // re-export for dist bundling

--- a/sdks/node/src/options.rs
+++ b/sdks/node/src/options.rs
@@ -1,11 +1,13 @@
 use std::path::PathBuf;
 
-use boxlite::runtime::advanced_options::{AdvancedBoxOptions, ResourceLimits, SecurityOptions};
+use boxlite::runtime::advanced_options::{AdvancedBoxOptions, SecurityOptions};
 use boxlite::runtime::constants::images;
 use boxlite::runtime::options::{
     BoxOptions, BoxliteOptions, NetworkSpec, PortProtocol, PortSpec, RootfsSpec, VolumeSpec,
 };
 use napi_derive::napi;
+
+use crate::advanced_options::JsSecurityOptions;
 
 /// Runtime configuration options.
 ///
@@ -34,94 +36,6 @@ impl From<JsOptions> for BoxliteOptions {
         }
 
         config
-    }
-}
-
-// ============================================================================
-// Security Options
-// ============================================================================
-
-/// Security isolation options for a box.
-///
-/// Controls how the boxlite-shim process is isolated from the host.
-#[napi(object)]
-#[derive(Clone, Debug)]
-pub struct JsSecurityOptions {
-    /// Enable jailer isolation (Linux/macOS).
-    pub jailer_enabled: Option<bool>,
-
-    /// Enable seccomp syscall filtering (Linux only).
-    pub seccomp_enabled: Option<bool>,
-
-    /// Maximum number of open file descriptors.
-    pub max_open_files: Option<f64>,
-
-    /// Maximum file size in bytes.
-    pub max_file_size: Option<f64>,
-
-    /// Maximum number of processes.
-    pub max_processes: Option<f64>,
-
-    /// Maximum virtual memory in bytes.
-    pub max_memory: Option<f64>,
-
-    /// Maximum CPU time in seconds.
-    pub max_cpu_time: Option<f64>,
-
-    /// Enable network access in sandbox (macOS only).
-    pub network_enabled: Option<bool>,
-
-    /// Close inherited file descriptors.
-    pub close_fds: Option<bool>,
-}
-
-const JS_MAX_SAFE_INTEGER: u64 = 9_007_199_254_740_991;
-
-fn coerce_u64_limit(number: f64) -> Option<u64> {
-    if !number.is_finite() || number < 0.0 || number.fract() != 0.0 {
-        return None;
-    }
-
-    if number > JS_MAX_SAFE_INTEGER as f64 {
-        return None;
-    }
-
-    Some(number as u64)
-}
-
-fn coerce_optional_u64_limit(value: Option<f64>) -> Option<u64> {
-    value.and_then(coerce_u64_limit)
-}
-
-impl From<JsSecurityOptions> for SecurityOptions {
-    fn from(js_opts: JsSecurityOptions) -> Self {
-        let mut opts = SecurityOptions::default();
-
-        if let Some(jailer_enabled) = js_opts.jailer_enabled {
-            opts.jailer_enabled = jailer_enabled;
-        }
-
-        if let Some(seccomp_enabled) = js_opts.seccomp_enabled {
-            opts.seccomp_enabled = seccomp_enabled;
-        }
-
-        if let Some(network_enabled) = js_opts.network_enabled {
-            opts.network_enabled = network_enabled;
-        }
-
-        if let Some(close_fds) = js_opts.close_fds {
-            opts.close_fds = close_fds;
-        }
-
-        opts.resource_limits = ResourceLimits {
-            max_open_files: coerce_optional_u64_limit(js_opts.max_open_files),
-            max_file_size: coerce_optional_u64_limit(js_opts.max_file_size),
-            max_processes: coerce_optional_u64_limit(js_opts.max_processes),
-            max_memory: coerce_optional_u64_limit(js_opts.max_memory),
-            max_cpu_time: coerce_optional_u64_limit(js_opts.max_cpu_time),
-        };
-
-        opts
     }
 }
 
@@ -329,41 +243,5 @@ impl From<JsBoxOptions> for BoxOptions {
             cmd: js_opts.cmd,
             user: js_opts.user,
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn coerces_safe_integer_number_limit() {
-        let parsed = coerce_u64_limit(1024.0);
-        assert_eq!(parsed, Some(1024));
-    }
-
-    #[test]
-    fn drops_fractional_number_limit() {
-        let parsed = coerce_u64_limit(12.5);
-        assert_eq!(parsed, None);
-    }
-
-    #[test]
-    fn drops_negative_number_limit() {
-        let parsed = coerce_u64_limit(-1.0);
-        assert_eq!(parsed, None);
-    }
-
-    #[test]
-    fn drops_unsafe_integer_number_limit() {
-        let too_large_for_number = JS_MAX_SAFE_INTEGER as f64 + 1.0;
-        let parsed = coerce_u64_limit(too_large_for_number);
-        assert_eq!(parsed, None);
-    }
-
-    #[test]
-    fn drops_non_finite_number_limit() {
-        let parsed = coerce_u64_limit(f64::INFINITY);
-        assert_eq!(parsed, None);
     }
 }

--- a/sdks/python/src/advanced_options.rs
+++ b/sdks/python/src/advanced_options.rs
@@ -1,0 +1,213 @@
+use boxlite::runtime::advanced_options::{ResourceLimits, SecurityOptions};
+use pyo3::prelude::*;
+
+// ============================================================================
+// Security Options
+// ============================================================================
+
+/// Security isolation options for a box.
+///
+/// Controls how the boxlite-shim process is isolated from the host.
+/// Different presets are available: `development()`, `standard()`, `maximum()`.
+///
+/// Example:
+///     ```python
+///     from boxlite import SecurityOptions
+///
+///     # Use preset with customizations
+///     security = SecurityOptions.standard()
+///     security.max_open_files = 2048
+///     security.max_memory = 1024 * 1024 * 1024  # 1 GiB
+///
+///     # Or create from scratch
+///     security = SecurityOptions(
+///         jailer_enabled=True,
+///         seccomp_enabled=True,
+///         max_open_files=1024,
+///     )
+///     ```
+#[pyclass(name = "SecurityOptions")]
+#[derive(Clone, Debug)]
+pub struct PySecurityOptions {
+    /// Enable jailer isolation (Linux/macOS).
+    #[pyo3(get, set)]
+    pub jailer_enabled: bool,
+
+    /// Enable seccomp syscall filtering (Linux only).
+    #[pyo3(get, set)]
+    pub seccomp_enabled: bool,
+
+    /// Maximum number of open file descriptors.
+    #[pyo3(get, set)]
+    pub max_open_files: Option<u64>,
+
+    /// Maximum file size in bytes.
+    #[pyo3(get, set)]
+    pub max_file_size: Option<u64>,
+
+    /// Maximum number of processes.
+    #[pyo3(get, set)]
+    pub max_processes: Option<u64>,
+
+    /// Maximum virtual memory in bytes.
+    #[pyo3(get, set)]
+    pub max_memory: Option<u64>,
+
+    /// Maximum CPU time in seconds.
+    #[pyo3(get, set)]
+    pub max_cpu_time: Option<u64>,
+
+    /// Enable network access in sandbox (macOS only).
+    #[pyo3(get, set)]
+    pub network_enabled: bool,
+
+    /// Close inherited file descriptors.
+    #[pyo3(get, set)]
+    pub close_fds: bool,
+}
+
+#[pymethods]
+impl PySecurityOptions {
+    /// Create a new SecurityOptions with custom settings.
+    #[new]
+    #[pyo3(signature = (
+        jailer_enabled=true,
+        seccomp_enabled=false,
+        max_open_files=None,
+        max_file_size=None,
+        max_processes=None,
+        max_memory=None,
+        max_cpu_time=None,
+        network_enabled=true,
+        close_fds=true,
+    ))]
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        jailer_enabled: bool,
+        seccomp_enabled: bool,
+        max_open_files: Option<u64>,
+        max_file_size: Option<u64>,
+        max_processes: Option<u64>,
+        max_memory: Option<u64>,
+        max_cpu_time: Option<u64>,
+        network_enabled: bool,
+        close_fds: bool,
+    ) -> Self {
+        Self {
+            jailer_enabled,
+            seccomp_enabled,
+            max_open_files,
+            max_file_size,
+            max_processes,
+            max_memory,
+            max_cpu_time,
+            network_enabled,
+            close_fds,
+        }
+    }
+
+    /// Development mode: minimal isolation for debugging.
+    ///
+    /// Use this when debugging issues where isolation interferes.
+    #[staticmethod]
+    fn development() -> Self {
+        Self {
+            jailer_enabled: false,
+            seccomp_enabled: false,
+            max_open_files: None,
+            max_file_size: None,
+            max_processes: None,
+            max_memory: None,
+            max_cpu_time: None,
+            network_enabled: true,
+            close_fds: false,
+        }
+    }
+
+    /// Standard mode: recommended for most use cases.
+    ///
+    /// Equivalent to `SecurityOptions()` with no arguments.
+    /// Provides good security without being overly restrictive.
+    #[staticmethod]
+    fn standard() -> Self {
+        Self {
+            jailer_enabled: cfg!(any(target_os = "linux", target_os = "macos")),
+            seccomp_enabled: cfg!(target_os = "linux"),
+            max_open_files: None,
+            max_file_size: None,
+            max_processes: None,
+            max_memory: None,
+            max_cpu_time: None,
+            network_enabled: true,
+            close_fds: true,
+        }
+    }
+
+    /// Maximum mode: all isolation features enabled.
+    ///
+    /// Use this for untrusted workloads (AI sandbox, multi-tenant).
+    #[staticmethod]
+    fn maximum() -> Self {
+        Self {
+            jailer_enabled: true,
+            seccomp_enabled: cfg!(target_os = "linux"),
+            max_open_files: Some(1024),
+            max_file_size: Some(1024 * 1024 * 1024), // 1 GiB
+            max_processes: Some(100),
+            max_memory: None,   // Let VM config handle this
+            max_cpu_time: None, // Let VM config handle this
+            network_enabled: true,
+            close_fds: true,
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "SecurityOptions(jailer_enabled={}, seccomp_enabled={}, max_open_files={:?})",
+            self.jailer_enabled, self.seccomp_enabled, self.max_open_files
+        )
+    }
+}
+
+impl From<PySecurityOptions> for SecurityOptions {
+    fn from(py_opts: PySecurityOptions) -> Self {
+        SecurityOptions {
+            jailer_enabled: py_opts.jailer_enabled,
+            seccomp_enabled: py_opts.seccomp_enabled,
+            network_enabled: py_opts.network_enabled,
+            close_fds: py_opts.close_fds,
+            resource_limits: ResourceLimits {
+                max_open_files: py_opts.max_open_files,
+                max_file_size: py_opts.max_file_size,
+                max_processes: py_opts.max_processes,
+                max_memory: py_opts.max_memory,
+                max_cpu_time: py_opts.max_cpu_time,
+            },
+            ..Default::default()
+        }
+    }
+}
+
+// ============================================================================
+// Advanced Options
+// ============================================================================
+
+/// Advanced options for expert users.
+///
+/// Entry-level users can ignore this — defaults are secure and reasonable.
+#[pyclass(name = "AdvancedBoxOptions")]
+#[derive(Clone, Debug)]
+pub struct PyAdvancedBoxOptions {
+    /// Security isolation options.
+    #[pyo3(get, set)]
+    pub security: Option<PySecurityOptions>,
+}
+
+#[pymethods]
+impl PyAdvancedBoxOptions {
+    #[new]
+    #[pyo3(signature = (security=None))]
+    fn new(security: Option<PySecurityOptions>) -> Self {
+        Self { security }
+    }
+}

--- a/sdks/python/src/lib.rs
+++ b/sdks/python/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(unsafe_op_in_unsafe_fn, non_local_definitions)]
 
+mod advanced_options;
 mod box_handle;
 mod exec;
 mod info;
@@ -8,13 +9,12 @@ mod options;
 mod runtime;
 mod util;
 
+use crate::advanced_options::{PyAdvancedBoxOptions, PySecurityOptions};
 use crate::box_handle::PyBox;
 use crate::exec::{PyExecStderr, PyExecStdin, PyExecStdout, PyExecution};
 use crate::info::{PyBoxInfo, PyBoxStateInfo};
 use crate::metrics::{PyBoxMetrics, PyRuntimeMetrics};
-use crate::options::{
-    PyAdvancedBoxOptions, PyBoxOptions, PyCopyOptions, PyOptions, PySecurityOptions,
-};
+use crate::options::{PyBoxOptions, PyCopyOptions, PyOptions};
 use crate::runtime::PyBoxlite;
 use pyo3::prelude::*;
 

--- a/sdks/python/src/options.rs
+++ b/sdks/python/src/options.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use boxlite::CopyOptions;
-use boxlite::runtime::advanced_options::{ResourceLimits, SecurityOptions};
+use boxlite::runtime::advanced_options::SecurityOptions;
 use boxlite::runtime::constants::images;
 use boxlite::runtime::options::{
     BoxOptions, BoxliteOptions, NetworkSpec, PortProtocol, PortSpec, RootfsSpec, VolumeSpec,
@@ -9,6 +9,8 @@ use boxlite::runtime::options::{
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 use pyo3::types::{PyAnyMethods, PyDict, PyTuple};
+
+use crate::advanced_options::PyAdvancedBoxOptions;
 
 #[pyclass(name = "Options")]
 #[derive(Clone, Debug)]
@@ -100,217 +102,6 @@ impl From<PyCopyOptions> for CopyOptions {
             follow_symlinks: opt.follow_symlinks,
             include_parent: opt.include_parent,
         }
-    }
-}
-
-// ============================================================================
-// Security Options
-// ============================================================================
-
-/// Security isolation options for a box.
-///
-/// Controls how the boxlite-shim process is isolated from the host.
-/// Different presets are available: `development()`, `standard()`, `maximum()`.
-///
-/// Example:
-///     ```python
-///     from boxlite import SecurityOptions
-///
-///     # Use preset with customizations
-///     security = SecurityOptions.standard()
-///     security.max_open_files = 2048
-///     security.max_memory = 1024 * 1024 * 1024  # 1 GiB
-///
-///     # Or create from scratch
-///     security = SecurityOptions(
-///         jailer_enabled=True,
-///         seccomp_enabled=True,
-///         max_open_files=1024,
-///     )
-///     ```
-#[pyclass(name = "SecurityOptions")]
-#[derive(Clone, Debug)]
-pub(crate) struct PySecurityOptions {
-    /// Enable jailer isolation (Linux/macOS).
-    #[pyo3(get, set)]
-    pub(crate) jailer_enabled: bool,
-
-    /// Enable seccomp syscall filtering (Linux only).
-    #[pyo3(get, set)]
-    pub(crate) seccomp_enabled: bool,
-
-    /// Maximum number of open file descriptors.
-    #[pyo3(get, set)]
-    pub(crate) max_open_files: Option<u64>,
-
-    /// Maximum file size in bytes.
-    #[pyo3(get, set)]
-    pub(crate) max_file_size: Option<u64>,
-
-    /// Maximum number of processes.
-    #[pyo3(get, set)]
-    pub(crate) max_processes: Option<u64>,
-
-    /// Maximum virtual memory in bytes.
-    #[pyo3(get, set)]
-    pub(crate) max_memory: Option<u64>,
-
-    /// Maximum CPU time in seconds.
-    #[pyo3(get, set)]
-    pub(crate) max_cpu_time: Option<u64>,
-
-    /// Enable network access in sandbox (macOS only).
-    #[pyo3(get, set)]
-    pub(crate) network_enabled: bool,
-
-    /// Close inherited file descriptors.
-    #[pyo3(get, set)]
-    pub(crate) close_fds: bool,
-}
-
-#[pymethods]
-impl PySecurityOptions {
-    /// Create a new SecurityOptions with custom settings.
-    #[new]
-    #[pyo3(signature = (
-        jailer_enabled=true,
-        seccomp_enabled=false,
-        max_open_files=None,
-        max_file_size=None,
-        max_processes=None,
-        max_memory=None,
-        max_cpu_time=None,
-        network_enabled=true,
-        close_fds=true,
-    ))]
-    #[allow(clippy::too_many_arguments)]
-    fn new(
-        jailer_enabled: bool,
-        seccomp_enabled: bool,
-        max_open_files: Option<u64>,
-        max_file_size: Option<u64>,
-        max_processes: Option<u64>,
-        max_memory: Option<u64>,
-        max_cpu_time: Option<u64>,
-        network_enabled: bool,
-        close_fds: bool,
-    ) -> Self {
-        Self {
-            jailer_enabled,
-            seccomp_enabled,
-            max_open_files,
-            max_file_size,
-            max_processes,
-            max_memory,
-            max_cpu_time,
-            network_enabled,
-            close_fds,
-        }
-    }
-
-    /// Development mode: minimal isolation for debugging.
-    ///
-    /// Use this when debugging issues where isolation interferes.
-    #[staticmethod]
-    fn development() -> Self {
-        Self {
-            jailer_enabled: false,
-            seccomp_enabled: false,
-            max_open_files: None,
-            max_file_size: None,
-            max_processes: None,
-            max_memory: None,
-            max_cpu_time: None,
-            network_enabled: true,
-            close_fds: false,
-        }
-    }
-
-    /// Standard mode: recommended for most use cases.
-    ///
-    /// Equivalent to `SecurityOptions()` with no arguments.
-    /// Provides good security without being overly restrictive.
-    #[staticmethod]
-    fn standard() -> Self {
-        Self {
-            jailer_enabled: cfg!(any(target_os = "linux", target_os = "macos")),
-            seccomp_enabled: cfg!(target_os = "linux"),
-            max_open_files: None,
-            max_file_size: None,
-            max_processes: None,
-            max_memory: None,
-            max_cpu_time: None,
-            network_enabled: true,
-            close_fds: true,
-        }
-    }
-
-    /// Maximum mode: all isolation features enabled.
-    ///
-    /// Use this for untrusted workloads (AI sandbox, multi-tenant).
-    #[staticmethod]
-    fn maximum() -> Self {
-        Self {
-            jailer_enabled: true,
-            seccomp_enabled: cfg!(target_os = "linux"),
-            max_open_files: Some(1024),
-            max_file_size: Some(1024 * 1024 * 1024), // 1 GiB
-            max_processes: Some(100),
-            max_memory: None,   // Let VM config handle this
-            max_cpu_time: None, // Let VM config handle this
-            network_enabled: true,
-            close_fds: true,
-        }
-    }
-
-    fn __repr__(&self) -> String {
-        format!(
-            "SecurityOptions(jailer_enabled={}, seccomp_enabled={}, max_open_files={:?})",
-            self.jailer_enabled, self.seccomp_enabled, self.max_open_files
-        )
-    }
-}
-
-impl From<PySecurityOptions> for SecurityOptions {
-    fn from(py_opts: PySecurityOptions) -> Self {
-        SecurityOptions {
-            jailer_enabled: py_opts.jailer_enabled,
-            seccomp_enabled: py_opts.seccomp_enabled,
-            network_enabled: py_opts.network_enabled,
-            close_fds: py_opts.close_fds,
-            resource_limits: ResourceLimits {
-                max_open_files: py_opts.max_open_files,
-                max_file_size: py_opts.max_file_size,
-                max_processes: py_opts.max_processes,
-                max_memory: py_opts.max_memory,
-                max_cpu_time: py_opts.max_cpu_time,
-            },
-            ..Default::default()
-        }
-    }
-}
-
-// ============================================================================
-// Advanced Options
-// ============================================================================
-
-/// Advanced options for expert users.
-///
-/// Entry-level users can ignore this — defaults are secure and reasonable.
-#[pyclass(name = "AdvancedBoxOptions")]
-#[derive(Clone, Debug)]
-pub struct PyAdvancedBoxOptions {
-    /// Security isolation options.
-    #[pyo3(get, set)]
-    pub(crate) security: Option<PySecurityOptions>,
-}
-
-#[pymethods]
-impl PyAdvancedBoxOptions {
-    #[new]
-    #[pyo3(signature = (security=None))]
-    fn new(security: Option<PySecurityOptions>) -> Self {
-        Self { security }
     }
 }
 


### PR DESCRIPTION
## Summary

- Extract `PySecurityOptions` and `PyAdvancedBoxOptions` from Python SDK `options.rs` into `advanced_options.rs`
- Extract `JsSecurityOptions`, coercion helpers, and tests from Node SDK `options.rs` into `advanced_options.rs`

Mirrors the core crate's structure from PR #253.

## Test plan

- [x] `cargo clippy -p boxlite-python -p boxlite-node -- -D warnings` — clean
- [x] `cargo test -p boxlite-node` — 5/5 pass
- [x] `cargo fmt --check` — clean
- [ ] CI checks