### PR TITLE
docs: reposition README to emphasize stateful, local-first sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,23 +5,24 @@
 [![Lint](https://github.com/boxlite-ai/boxlite/actions/workflows/lint.yml/badge.svg)](https://github.com/boxlite-ai/boxlite/actions/workflows/lint.yml)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-**Embedded, lightweight** micro-VM runtime for **AI agents** running OCI containers with
-hardware-level isolation — built for **high concurrency**, **no daemon required**.
+Local-first micro-VM sandbox for **AI agents** — stateful, lightweight,
+hardware-level isolation, **no daemon required**.
 
 
 ## What is BoxLite?
 
-BoxLite lets you spin up **lightweight VMs** ("Boxes") and run **OCI containers inside them**. It's
-designed for use cases like **AI agent sandboxes** and **multi-tenant code execution**, where Docker
-alone isn't enough and full VM infrastructure is too heavy.
+BoxLite lets you spin up **lightweight VMs** ("Boxes") and run **OCI containers inside them**. Unlike
+ephemeral sandboxes that destroy state after each execution, BoxLite Boxes are **persistent workspaces** —
+install packages, create files, build up environment state, then come back later and pick up where you left off.
 
 **Why BoxLite**
 
-- **Lightweight**: small footprint, fast-starting Boxes, minimal operational overhead.
-- **High concurrency**: async-first API designed to run many Boxes in parallel; stream stdout/stderr.
-- **Hardware isolation**: each Box has its own kernel (not just namespaces).
-- **Embeddable**: link a library; no root; no background service to manage.
-- **OCI compatible**: use Docker/OCI images (`python:slim`, `node:alpine`, `alpine:latest`).
+- **Stateful**: Boxes retain packages, files, and environment across stop/restart. No rebuilding on every interaction.
+- **Lightweight**: small footprint, fast boot, async-first API for high concurrency.
+- **Hardware isolation**: each Box runs its own kernel — not just namespaces or containers.
+- **No daemon**: embed as a library, no root, no background service.
+- **OCI compatible**: use standard Docker images (`python:slim`, `node:alpine`, `alpine:latest`).
+- **Local-first**: runs entirely on your machine — no cloud account needed. Scale out when ready.
 
 ## Python Quick Start
 


### PR DESCRIPTION
## Summary
- Update tagline to "Local-first micro-VM sandbox for AI agents — stateful, lightweight, hardware-level isolation, no daemon required"
- Rewrite "What is BoxLite?" to contrast with ephemeral sandboxes — BoxLite Boxes are persistent workspaces
- Restructure "Why BoxLite" bullets around 6 key differentiators: stateful, lightweight, hardware isolation, no daemon, OCI compatible, local-first

## Test plan
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)