### PR TITLE
fix(copy): file-to-file extraction for copy_in/copy_out

### DIFF
--- a/examples/python/02_features/copy_files.py
+++ b/examples/python/02_features/copy_files.py
@@ -2,10 +2,11 @@
 """
 Copy files into and out of a box (docker-like cp).
 
-Demonstrates three approaches:
+Demonstrates four approaches:
   1. copy_in / copy_out via the native API (works for persistent filesystem paths)
   2. Tar-pipe workaround for tmpfs destinations (e.g. /tmp) — async
   3. Tar-pipe workaround — sync variant (requires boxlite[sync])
+  4. File-to-file copy — copy a single file to a specific file path (with rename)
 
 Background on tmpfs:
   copy_in() writes to the rootfs layer, so files destined for tmpfs mounts are
@@ -149,9 +150,83 @@ def example_tmpfs_workaround_sync():
         print(f"read /tmp/hello_sync.txt: {result.stdout.strip()}")
 
 
+# ---------------------------------------------------------------------------
+# Example 4: file-to-file copy (single file to a specific path)
+# ---------------------------------------------------------------------------
+
+async def example_file_to_file_copy():
+    """Copy a single file to a specific file path, including rename.
+
+    Docker-cp semantics:
+      - copy_in("foo.py", "/app/bar.py")   → /app/bar.py  (file, renamed)
+      - copy_in("foo.py", "/app/")          → /app/foo.py  (into directory)
+      - copy_in("foo.py", "/app/existing/") → /app/existing/foo.py  (into dir)
+    """
+    print("\n=== Example 4: file-to-file copy (single file to path) ===\n")
+
+    async with SimpleBox("alpine:latest", name="file-copy-demo") as box:
+        # Prepare a host file
+        host_dir = Path("/tmp/boxlite_file_copy")
+        host_dir.mkdir(parents=True, exist_ok=True)
+        (host_dir / "original.py").write_text('print("hello from original.py")\n')
+
+        # --- 4a: Copy file to a specific file path (not a directory) ---
+        # This creates /workspace/script.py as a FILE, not a directory.
+        print("4a: Copy to specific file path ...")
+        await box.copy_in(
+            str(host_dir / "original.py"),
+            "/workspace/script.py",
+        )
+        result = await box.exec("ls", "-la", "/workspace/script.py")
+        print(f"  /workspace/script.py: {result.stdout.strip()}")
+        result = await box.exec("test", "-f", "/workspace/script.py")
+        print(f"  is regular file: {'yes' if result.exit_code == 0 else 'no'}")
+        result = await box.exec("cat", "/workspace/script.py")
+        print(f"  content: {result.stdout.strip()}")
+
+        # --- 4b: Copy file with rename ---
+        # Source is original.py, destination is renamed.py
+        print("\n4b: Copy with rename ...")
+        await box.copy_in(
+            str(host_dir / "original.py"),
+            "/workspace/renamed.py",
+        )
+        result = await box.exec("cat", "/workspace/renamed.py")
+        print(f"  /workspace/renamed.py: {result.stdout.strip()}")
+
+        # --- 4c: Copy file into a directory (trailing slash) ---
+        # Trailing slash means "extract into this directory"
+        print("\n4c: Copy into directory (trailing slash) ...")
+        await box.exec("mkdir", "-p", "/workspace/scripts")
+        await box.copy_in(
+            str(host_dir / "original.py"),
+            "/workspace/scripts/",
+        )
+        result = await box.exec("ls", "/workspace/scripts/")
+        print(f"  /workspace/scripts/ contains: {result.stdout.strip()}")
+
+        # --- 4d: Copy file into existing directory (no trailing slash) ---
+        # When dest is an existing directory, file is placed inside it
+        print("\n4d: Copy into existing directory (no trailing slash) ...")
+        await box.exec("mkdir", "-p", "/workspace/libs")
+        await box.copy_in(
+            str(host_dir / "original.py"),
+            "/workspace/libs",
+        )
+        result = await box.exec("ls", "/workspace/libs/")
+        print(f"  /workspace/libs/ contains: {result.stdout.strip()}")
+
+        # Summary
+        print("\n  Summary of /workspace:")
+        result = await box.exec("find", "/workspace", "-type", "f")
+        for line in result.stdout.strip().split("\n"):
+            print(f"    {line}")
+
+
 async def main():
     await example_copy_in_out()
     await example_tmpfs_workaround()
+    await example_file_to_file_copy()
 
 
 if __name__ == "__main__":
@@ -167,3 +242,6 @@ if __name__ == "__main__":
     print("  - copy_in/copy_out work for persistent filesystem paths")
     print("  - For tmpfs destinations, pipe a tar archive via stdin")
     print("  - Sync API uses the same tar-pipe pattern (requires boxlite[sync])")
+    print("  - File-to-file: copy_in('f.py', '/app/script.py') creates a file (not dir)")
+    print("  - Trailing slash: copy_in('f.py', '/app/') copies into the directory")
+    print("  - Existing dir: copy_in('f.py', '/app/existing_dir') copies into it")


### PR DESCRIPTION
## Summary

Fixes #238 — `copy_in("file.py", "/workspace/script.py")` created a **directory** named `script.py` instead of copying the file.

- Add mode-aware tar extraction (FileToFile vs IntoDirectory) to both guest upload and host download paths
- Inspect tar contents and destination state to choose extraction mode, following Docker `cp` semantics
- Add 14 unit tests covering all extraction mode combinations and edge cases
- Add Python example (Example 4) demonstrating file-to-file copy, rename, and directory semantics

### Behavior matrix

| Source | Destination | Dest state | Result |
|--------|------------|------------|--------|
| file `foo.py` | `/workspace/script.py` | doesn't exist | `/workspace/script.py` (file) |
| file `foo.py` | `/workspace/bar.py` | doesn't exist | `/workspace/bar.py` (renamed) |
| file `foo.py` | `/workspace/script.py` | exists as file | overwrites file |
| file `foo.py` | `/workspace/scripts` | exists as dir | `/workspace/scripts/foo.py` |
| file `foo.py` | `/workspace/` | any | `/workspace/foo.py` |
| dir `mydir/` | `/workspace/mydir` | any | unchanged (dir copy) |

### Key insight

`tar::Entry::unpack(dest)` writes directly to `dest` (ignoring the tar entry name), while `tar::Archive::unpack(dest)` treats `dest` as a parent directory. The fix uses the former for single-file-to-file-path cases.

## Test plan

- [x] `cargo test -p boxlite --no-default-features --lib` — 14 tests pass (including regression test for #238)
- [x] `cargo clippy -p boxlite --no-default-features --lib -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] Manual integration test: `copy_in("script.py", "/workspace/script.py")` creates a file
- [ ] Manual test: `copy_in("foo.py", "/workspace/bar.py")` renames correctly
- [ ] Manual test: `copy_in("foo.py", "/workspace/")` copies into directory