### PR TITLE
feat: add health check support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,6 +438,7 @@ name = "boxlite-go-bridge"
 version = "0.1.0"
 dependencies = [
  "boxlite",
+ "boxlite-ffi",
  "boxlite-shared",
  "libc",
  "once_cell",

--- a/boxlite/src/lib.rs
+++ b/boxlite/src/lib.rs
@@ -39,9 +39,12 @@ pub use db::snapshots::SnapshotInfo;
 pub use litebox::SnapshotHandle;
 pub use litebox::{
     BoxCommand, CopyOptions, ExecResult, ExecStderr, ExecStdin, ExecStdout, Execution, ExecutionId,
+    HealthState, HealthStatus,
 };
 pub use metrics::{BoxMetrics, RuntimeMetrics};
-pub use runtime::advanced_options::{AdvancedBoxOptions, ResourceLimits, SecurityOptions};
+pub use runtime::advanced_options::{
+    AdvancedBoxOptions, HealthCheckOptions, ResourceLimits, SecurityOptions,
+};
 use runtime::layout::FilesystemLayout;
 pub use runtime::options::{
     BoxArchive, BoxOptions, BoxliteOptions, CloneOptions, ExportOptions, RootfsSpec,

--- a/boxlite/src/litebox/box_impl.rs
+++ b/boxlite/src/litebox/box_impl.rs
@@ -10,6 +10,8 @@ use std::time::Instant;
 
 use parking_lot::RwLock;
 use tokio::sync::OnceCell;
+use tokio::task::JoinHandle;
+use tokio::time::timeout;
 use tokio_util::sync::CancellationToken;
 
 use boxlite_shared::errors::{BoxliteError, BoxliteResult};
@@ -24,10 +26,11 @@ use crate::litebox::copy::CopyOptions;
 use crate::lock::LockGuard;
 use crate::metrics::{BoxMetrics, BoxMetricsStorage};
 use crate::portal::GuestSession;
+use crate::portal::interfaces::GuestInterface;
 use crate::runtime::rt_impl::SharedRuntimeImpl;
 use crate::runtime::types::BoxStatus;
 use crate::vmm::controller::VmmHandler;
-use crate::{BoxID, BoxInfo};
+use crate::{BoxID, BoxInfo, HealthCheckOptions, HealthState};
 
 // ============================================================================
 // TYPE ALIASES
@@ -95,7 +98,7 @@ impl LiveState {
 pub(crate) struct BoxImpl {
     // --- Always available ---
     pub(crate) config: BoxConfig,
-    pub(crate) state: RwLock<BoxState>,
+    pub(crate) state: Arc<RwLock<BoxState>>,
     pub(crate) runtime: SharedRuntimeImpl,
     /// Cancellation token for this box (child of runtime's token).
     /// When cancelled (via stop() or runtime shutdown), all operations abort gracefully.
@@ -106,6 +109,8 @@ pub(crate) struct BoxImpl {
 
     // --- Lazily initialized ---
     live: OnceCell<LiveState>,
+
+    health_check_task: RwLock<Option<JoinHandle<()>>>,
 }
 
 impl BoxImpl {
@@ -130,11 +135,12 @@ impl BoxImpl {
     ) -> Self {
         Self {
             config,
-            state: RwLock::new(state),
+            state: Arc::new(RwLock::new(state)),
             runtime,
             shutdown_token,
             disk_ops: tokio::sync::Mutex::new(()),
             live: OnceCell::new(),
+            health_check_task: RwLock::new(None),
         }
     }
 
@@ -300,6 +306,22 @@ impl BoxImpl {
         // by runtime.shutdown() before stop() is called on each box.
         if self.state.read().status == BoxStatus::Stopped {
             return Ok(());
+        }
+
+        // Cancel health check task first (if running)
+        // This prevents the task from continuing after stop() completes
+        if let Some(task) = self.health_check_task.write().take() {
+            tracing::debug!(
+                box_id = %self.config.id,
+                "Aborting health check task"
+            );
+            task.abort();
+        }
+
+        // Clear health status (box is no longer running)
+        {
+            let mut state = self.state.write();
+            state.clear_health_status();
         }
 
         // Cancel the token - signals all in-flight operations to abort
@@ -608,6 +630,11 @@ impl BoxImpl {
             state.set_pid(Some(pid));
             state.set_status(BoxStatus::Running);
 
+            // Initialize health status if health check is configured
+            if self.config.options.advanced.health_check.is_some() {
+                state.init_health_status();
+            }
+
             // Save to DB (cache for queries and recovery)
             self.runtime.box_manager.save_box(&self.config.id, &state)?;
 
@@ -621,14 +648,201 @@ impl BoxImpl {
         // All operations succeeded - disarm the cleanup guard
         cleanup_guard.disarm();
 
+        // Start health check task if configured
+        if let Some(ref health_config) = self.config.options.advanced.health_check {
+            // Get guest interface from session
+            let guest = live_state.guest_session.guest().await?;
+
+            // Spawn health check task
+            let health_task = self.spawn_health_check(
+                Arc::clone(&self.state),
+                self.config.id.clone(),
+                health_config.to_owned(),
+                guest,
+                self.shutdown_token.child_token(),
+                Arc::clone(&self.runtime),
+            );
+            *self.health_check_task.write() = Some(health_task);
+        }
+
         tracing::info!(
             box_id = %self.config.id,
             "Box started successfully (first_start={})",
             is_first_start
         );
-
         // Lock is automatically released when _guard drops
         Ok(live_state)
+    }
+
+    pub fn spawn_health_check(
+        &self,
+        state: Arc<RwLock<BoxState>>,
+        box_id: BoxID,
+        health_config: HealthCheckOptions,
+        mut guest: GuestInterface,
+        shutdown_token: CancellationToken,
+        runtime: SharedRuntimeImpl,
+    ) -> JoinHandle<()> {
+        let interval = health_config.interval;
+        let check_timeout = health_config.timeout;
+        let retries = health_config.retries;
+        let start_period = health_config.start_period;
+
+        tokio::spawn(async move {
+            let start_time = Instant::now();
+            let mut last_health_state = state.read().health_status;
+
+            tracing::info!(
+                box_id = %box_id,
+                interval_secs = interval.as_secs(),
+                timeout_secs = check_timeout.as_secs(),
+                retries,
+                start_period_secs = start_period.as_secs(),
+                "Health check task started"
+            );
+
+            loop {
+                tokio::select! {
+                    _ = tokio::time::sleep(interval) => {},
+                    _ = shutdown_token.cancelled() => {
+                        tracing::debug!(
+                            box_id = %box_id,
+                            "Health check task received shutdown signal during sleep"
+                        );
+                        break;
+                    }
+                }
+
+                let elapsed = start_time.elapsed();
+                let result = if elapsed < start_period {
+                    tracing::debug!(
+                        box_id = %box_id,
+                        elapsed_ms = elapsed.as_millis(),
+                        start_period_ms = start_period.as_millis(),
+                        "In start period, skipping health check"
+                    );
+
+                    Ok(())
+                } else {
+                    let ping_result = timeout(check_timeout, guest.ping()).await;
+
+                    match ping_result {
+                        Ok(Ok(_)) => {
+                            // Calculate new state
+                            let new_state = HealthState::Healthy;
+                            let new_failures = 0;
+
+                            // Only update if state actually changed
+                            if last_health_state.state != new_state
+                                || last_health_state.failures != new_failures
+                            {
+                                let mut state_guard = state.write();
+                                state_guard.mark_health_check_success();
+
+                                if let Err(e) = runtime.box_manager.save_box(&box_id, &state_guard)
+                                {
+                                    tracing::error!(
+                                        box_id = %box_id,
+                                        error = %e,
+                                        "Failed to persist health check success to database"
+                                    );
+                                }
+
+                                // Update cache
+                                last_health_state = state_guard.health_status;
+                            }
+
+                            Ok(())
+                        }
+                        Ok(Err(e)) => Err(e),
+                        Err(_) => Err(BoxliteError::Internal(format!(
+                            "Health check timed out after {}s",
+                            check_timeout.as_secs()
+                        ))),
+                    }
+                };
+
+                // Update health status on failure and check if shim died
+                if let Err(e) = result {
+                    tracing::warn!(
+                        box_id = %box_id,
+                        error = %e,
+                        "Health check failed"
+                    );
+
+                    // Step 1: Read pid (brief read lock)
+                    let pid = state.read().pid;
+
+                    // Step 2: Check if shim is alive (without holding lock)
+                    let shim_died = if let Some(pid) = pid
+                        && !crate::util::is_process_alive(pid)
+                    {
+                        tracing::error!(
+                            box_id = %box_id,
+                            pid,
+                            "Shim process died, marking box as Stopped and Unhealthy"
+                        );
+                        true
+                    } else {
+                        false
+                    };
+
+                    // If shim died, mark as Unhealthy and stop health check immediately
+                    if shim_died {
+                        let mut state_guard = state.write();
+                        state_guard.force_status(crate::litebox::BoxStatus::Stopped);
+                        state_guard.set_pid(None);
+                        state_guard.health_status.state = crate::litebox::HealthState::Unhealthy;
+
+                        if let Err(db_err) = runtime.box_manager.save_box(&box_id, &state_guard) {
+                            tracing::error!(
+                                box_id = %box_id,
+                                error = %db_err,
+                                "Failed to persist health check state to database"
+                            );
+                        }
+                        break;
+                    }
+
+                    // Step 3: Calculate new state (shim is still alive)
+                    let new_failures = last_health_state.failures + 1;
+                    let new_state = if new_failures >= retries {
+                        HealthState::Unhealthy
+                    } else {
+                        last_health_state.state
+                    };
+
+                    // Step 4: Only update if state would actually change
+                    if last_health_state.state != new_state
+                        || last_health_state.failures != new_failures
+                    {
+                        let mut state_guard = state.write();
+                        let became_unhealthy = state_guard.mark_health_check_failure(retries);
+
+                        if let Err(db_err) = runtime.box_manager.save_box(&box_id, &state.read()) {
+                            tracing::error!(
+                                box_id = %box_id,
+                                error = %db_err,
+                                "Failed to persist health check state to database"
+                            );
+                        }
+
+                        // Update cache
+                        last_health_state = state_guard.health_status;
+
+                        // Step 5: Stop health check task if became unhealthy
+                        if became_unhealthy {
+                            break;
+                        }
+                    }
+                }
+            }
+
+            tracing::debug!(
+                box_id = %box_id,
+                "Health check task stopped"
+            );
+        })
     }
 }
 

--- a/boxlite/src/litebox/mod.rs
+++ b/boxlite/src/litebox/mod.rs
@@ -19,7 +19,7 @@ pub(crate) use crash_report::CrashReport;
 pub use exec::{BoxCommand, ExecResult, ExecStderr, ExecStdin, ExecStdout, Execution, ExecutionId};
 pub(crate) use manager::BoxManager;
 pub use snapshot::SnapshotHandle;
-pub use state::{BoxState, BoxStatus};
+pub use state::{BoxState, BoxStatus, HealthState, HealthStatus};
 
 pub(crate) use box_impl::SharedBoxImpl;
 pub(crate) use init::BoxBuilder;

--- a/boxlite/src/litebox/state.rs
+++ b/boxlite/src/litebox/state.rs
@@ -189,6 +189,92 @@ pub struct BoxState {
     /// Allocated when the box is first initialized (not at creation time).
     /// Used to retrieve the lock across process restarts.
     pub lock_id: Option<LockId>,
+    /// Health status.
+    pub health_status: HealthStatus,
+}
+
+/// Health status of a box.
+///
+/// Tracks the current health state and consecutive failure count.
+/// Similar to Docker's health check status.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HealthStatus {
+    /// Current health state.
+    pub state: HealthState,
+    /// Consecutive health check failures.
+    pub failures: u32,
+    /// Last health check timestamp.
+    pub last_check: Option<DateTime<Utc>>,
+}
+
+impl HealthStatus {
+    /// Create a new health status with no health check configured.
+    pub fn new() -> Self {
+        Self {
+            state: HealthState::None,
+            failures: 0,
+            last_check: None,
+        }
+    }
+
+    /// Initialize health status (called when box starts with health check configured).
+    pub fn init(&mut self) {
+        self.state = HealthState::Starting;
+        self.failures = 0;
+        self.last_check = Some(Utc::now());
+    }
+
+    /// Update health status after a successful check.
+    pub fn mark_success(&mut self) {
+        self.state = HealthState::Healthy;
+        self.failures = 0;
+        self.last_check = Some(Utc::now());
+    }
+
+    /// Update health status after a failed check.
+    /// Returns true if the box should be marked unhealthy.
+    pub fn mark_failure(&mut self, retries: u32) -> bool {
+        self.failures += 1;
+        self.last_check = Some(Utc::now());
+
+        if self.failures >= retries {
+            self.state = HealthState::Unhealthy;
+            return true;
+        }
+        false
+    }
+
+    /// Clear health status (called when box stops).
+    pub fn clear(&mut self) {
+        self.state = HealthState::None;
+        self.failures = 0;
+        self.last_check = None;
+    }
+}
+
+impl Default for HealthStatus {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Health state of a box.
+///
+/// Docker-compatible health states:
+/// - None: No health check configured
+/// - Starting: Within start_period, not yet checked
+/// - Healthy: Last health check passed
+/// - Unhealthy: Failed `retries` consecutive checks
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum HealthState {
+    /// No health check configured.
+    None,
+    /// Within start_period, not yet checked.
+    Starting,
+    /// Last health check passed.
+    Healthy,
+    /// Failed retries consecutive checks.
+    Unhealthy,
 }
 
 impl BoxState {
@@ -201,6 +287,7 @@ impl BoxState {
             container_id: None,
             last_updated: Utc::now(),
             lock_id: None,
+            health_status: HealthStatus::new(),
         }
     }
 
@@ -263,6 +350,32 @@ impl BoxState {
             self.status = BoxStatus::Stopped;
         }
         self.pid = None;
+        self.last_updated = Utc::now();
+    }
+
+    /// Initialize health status (called when box starts with health check configured).
+    pub fn init_health_status(&mut self) {
+        self.health_status.init();
+        self.last_updated = Utc::now();
+    }
+
+    /// Update health status after a successful check.
+    pub fn mark_health_check_success(&mut self) {
+        self.health_status.mark_success();
+        self.last_updated = Utc::now();
+    }
+
+    /// Update health status after a failed check.
+    /// Returns true if the box should be marked unhealthy.
+    pub fn mark_health_check_failure(&mut self, retries: u32) -> bool {
+        let became_unhealthy = self.health_status.mark_failure(retries);
+        self.last_updated = Utc::now();
+        became_unhealthy
+    }
+
+    /// Clear health status (called when box stops).
+    pub fn clear_health_status(&mut self) {
+        self.health_status.clear();
         self.last_updated = Utc::now();
     }
 }
@@ -458,5 +571,277 @@ mod tests {
         assert_eq!("exporting".parse(), Ok(BoxStatus::Stopped));
         assert_eq!("cloning".parse(), Ok(BoxStatus::Stopped));
         assert!("invalid".parse::<BoxStatus>().is_err());
+    }
+
+    // ========================================================================
+    // HealthStatus Tests
+    // ========================================================================
+
+    #[test]
+    fn test_health_status_new() {
+        let status = HealthStatus::new();
+        assert_eq!(status.state, HealthState::None);
+        assert_eq!(status.failures, 0);
+        assert!(status.last_check.is_none());
+    }
+
+    #[test]
+    fn test_health_status_init() {
+        let mut status = HealthStatus::new();
+        status.init();
+
+        assert_eq!(status.state, HealthState::Starting);
+        assert_eq!(status.failures, 0);
+        assert!(status.last_check.is_some());
+
+        // Verify timestamp is recent (within last second)
+        let elapsed = Utc::now() - status.last_check.unwrap();
+        assert!(elapsed.num_seconds() <= 1);
+    }
+
+    #[test]
+    fn test_health_status_mark_success() {
+        let mut status = HealthStatus::new();
+        status.init();
+
+        // After success, should be Healthy with zero failures
+        status.mark_success();
+
+        assert_eq!(status.state, HealthState::Healthy);
+        assert_eq!(status.failures, 0);
+        assert!(status.last_check.is_some());
+    }
+
+    #[test]
+    fn test_health_status_mark_failure_within_retries() {
+        let mut status = HealthStatus::new();
+        status.init();
+        status.mark_success(); // Transition to Healthy first
+
+        // First failure (retries=3)
+        let became_unhealthy = status.mark_failure(3);
+
+        assert!(!became_unhealthy);
+        assert_eq!(status.state, HealthState::Healthy); // Still healthy
+        assert_eq!(status.failures, 1);
+    }
+
+    #[test]
+    fn test_health_status_mark_failure_at_threshold() {
+        let mut status = HealthStatus::new();
+        status.mark_success(); // Start from Healthy state
+
+        // Failures up to threshold (retries=3)
+        assert!(!status.mark_failure(3)); // failure 1
+        assert_eq!(status.failures, 1);
+
+        assert!(!status.mark_failure(3)); // failure 2
+        assert_eq!(status.failures, 2);
+
+        let became_unhealthy = status.mark_failure(3); // failure 3
+        assert!(became_unhealthy);
+        assert_eq!(status.state, HealthState::Unhealthy);
+        assert_eq!(status.failures, 3);
+    }
+
+    #[test]
+    fn test_health_status_mark_failure_exceeds_threshold() {
+        let mut status = HealthStatus::new();
+        status.mark_success();
+
+        // Exceed threshold (retries=3, but fail 4 times)
+        status.mark_failure(3); // failure 1
+        status.mark_failure(3); // failure 2
+        status.mark_failure(3); // failure 3 → becomes unhealthy
+        status.mark_failure(3); // failure 4 → already unhealthy
+
+        assert_eq!(status.state, HealthState::Unhealthy);
+        assert_eq!(status.failures, 4);
+    }
+
+    #[test]
+    fn test_health_status_zero_retries() {
+        let mut status = HealthStatus::new();
+        status.init();
+
+        // With retries=0, first failure should mark unhealthy immediately
+        let became_unhealthy = status.mark_failure(0);
+        assert!(became_unhealthy);
+        assert_eq!(status.state, HealthState::Unhealthy);
+        assert_eq!(status.failures, 1);
+    }
+
+    #[test]
+    fn test_health_status_one_retry() {
+        let mut status = HealthStatus::new();
+        status.mark_success();
+
+        // With retries=1, first failure marks unhealthy
+        let became_unhealthy = status.mark_failure(1);
+        assert!(became_unhealthy);
+        assert_eq!(status.state, HealthState::Unhealthy);
+        assert_eq!(status.failures, 1);
+    }
+
+    #[test]
+    fn test_health_status_clear() {
+        let mut status = HealthStatus::new();
+        status.init();
+        status.mark_success();
+
+        // Clear should reset to initial state
+        status.clear();
+
+        assert_eq!(status.state, HealthState::None);
+        assert_eq!(status.failures, 0);
+        assert!(status.last_check.is_none());
+    }
+
+    #[test]
+    fn test_health_status_recovery_after_failure() {
+        let mut status = HealthStatus::new();
+        status.mark_success();
+
+        // Fail twice (below threshold of 3)
+        status.mark_failure(3);
+        status.mark_failure(3);
+        assert_eq!(status.failures, 2);
+        assert_eq!(status.state, HealthState::Healthy);
+
+        // Successful check resets failures
+        status.mark_success();
+        assert_eq!(status.failures, 0);
+        assert_eq!(status.state, HealthState::Healthy);
+
+        // New failures start from 0 again
+        status.mark_failure(3);
+        assert_eq!(status.failures, 1);
+        assert_eq!(status.state, HealthState::Healthy);
+    }
+
+    #[test]
+    fn test_health_status_full_lifecycle() {
+        let mut status = HealthStatus::new();
+
+        // 1. Initial state
+        assert_eq!(status.state, HealthState::None);
+
+        // 2. Box starts with health check
+        status.init();
+        assert_eq!(status.state, HealthState::Starting);
+
+        // 3. First successful check
+        status.mark_success();
+        assert_eq!(status.state, HealthState::Healthy);
+
+        // 4. Health check fails (but within retries)
+        status.mark_failure(3);
+        assert_eq!(status.state, HealthState::Healthy);
+        assert_eq!(status.failures, 1);
+
+        // 5. More failures push it over threshold
+        status.mark_failure(3);
+        status.mark_failure(3);
+        assert_eq!(status.state, HealthState::Unhealthy);
+        assert_eq!(status.failures, 3);
+
+        // 6. Box stops
+        status.clear();
+        assert_eq!(status.state, HealthState::None);
+        assert_eq!(status.failures, 0);
+    }
+
+    #[test]
+    fn test_health_status_default() {
+        let status = HealthStatus::default();
+        assert_eq!(status.state, HealthState::None);
+        assert_eq!(status.failures, 0);
+        assert!(status.last_check.is_none());
+    }
+
+    #[test]
+    fn test_health_state_equality() {
+        let status1 = HealthStatus::new();
+        let status2 = HealthStatus::new();
+
+        // Two new instances should be equal
+        assert_eq!(status1, status2);
+
+        // After different state changes, they should not be equal
+        let mut status3 = HealthStatus::new();
+        let mut status4 = HealthStatus::new();
+        status3.init();
+        status4.mark_success();
+
+        assert_ne!(status3, status4);
+        assert_eq!(status3.state, HealthState::Starting);
+        assert_eq!(status4.state, HealthState::Healthy);
+    }
+
+    // ========================================================================
+    // BoxState Health Check Integration Tests
+    // ========================================================================
+
+    #[test]
+    fn test_box_state_init_health_status() {
+        let mut state = BoxState::new();
+
+        state.init_health_status();
+
+        assert_eq!(state.health_status.state, HealthState::Starting);
+        assert_eq!(state.health_status.failures, 0);
+        assert!(state.health_status.last_check.is_some());
+        assert!(state.last_updated > Utc::now() - chrono::Duration::seconds(1));
+    }
+
+    #[test]
+    fn test_box_state_mark_health_check_success() {
+        let mut state = BoxState::new();
+        state.init_health_status();
+
+        state.mark_health_check_success();
+
+        assert_eq!(state.health_status.state, HealthState::Healthy);
+        assert_eq!(state.health_status.failures, 0);
+    }
+
+    #[test]
+    fn test_box_state_mark_health_check_failure() {
+        let mut state = BoxState::new();
+        state.init_health_status();
+        state.mark_health_check_success(); // Start from healthy
+
+        // First failure (within retries)
+        let should_mark_unhealthy = state.mark_health_check_failure(3);
+        assert!(!should_mark_unhealthy);
+        assert_eq!(state.health_status.failures, 1);
+
+        // More failures to cross threshold
+        state.mark_health_check_failure(3);
+        let should_mark_unhealthy = state.mark_health_check_failure(3);
+
+        assert!(should_mark_unhealthy);
+        assert_eq!(state.health_status.state, HealthState::Unhealthy);
+        assert_eq!(state.health_status.failures, 3);
+    }
+
+    #[test]
+    fn test_box_state_clear_health_status() {
+        let mut state = BoxState::new();
+        state.init_health_status();
+        state.mark_health_check_success();
+
+        state.clear_health_status();
+
+        assert_eq!(state.health_status.state, HealthState::None);
+        assert_eq!(state.health_status.failures, 0);
+        assert!(state.health_status.last_check.is_none());
+    }
+
+    #[test]
+    fn test_box_state_new_has_default_health_status() {
+        let state = BoxState::new();
+        assert_eq!(state.health_status.state, HealthState::None);
+        assert_eq!(state.health_status.failures, 0);
     }
 }

--- a/boxlite/src/rest/types.rs
+++ b/boxlite/src/rest/types.rs
@@ -181,6 +181,7 @@ impl BoxResponse {
             cpus: self.cpus,
             memory_mib: self.memory_mib,
             labels: self.labels.clone(),
+            health_status: crate::litebox::HealthStatus::new(), // REST API doesn't provide health status
         }
     }
 }

--- a/boxlite/src/runtime/advanced_options.rs
+++ b/boxlite/src/runtime/advanced_options.rs
@@ -6,6 +6,74 @@
 
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
+use std::time::Duration;
+
+// ============================================================================
+// Health Check Options
+// ============================================================================
+
+/// Health check options for boxes.
+///
+/// Defines how to periodically check if a box's guest agent is responsive.
+/// Similar to Docker's HEALTHCHECK directive.
+///
+/// This is an advanced option - most users should rely on the defaults.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct HealthCheckOptions {
+    /// Time between health checks.
+    ///
+    /// Default: 30 seconds
+    #[serde(default = "default_health_interval")]
+    pub interval: Duration,
+
+    /// Time to wait before considering the check failed.
+    ///
+    /// Default: 10 seconds
+    #[serde(default = "default_health_timeout")]
+    pub timeout: Duration,
+
+    /// Number of consecutive failures before marking as unhealthy.
+    ///
+    /// Default: 3
+    #[serde(default = "default_health_retries")]
+    pub retries: u32,
+
+    /// Startup period before health checks count toward failures.
+    ///
+    /// During this period, failures don't count toward the retry limit.
+    /// This gives the box time to boot up before being marked unhealthy.
+    ///
+    /// Default: 60 seconds
+    #[serde(default = "default_health_start_period")]
+    pub start_period: Duration,
+}
+
+fn default_health_interval() -> Duration {
+    Duration::from_secs(30)
+}
+
+fn default_health_timeout() -> Duration {
+    Duration::from_secs(10)
+}
+
+fn default_health_retries() -> u32 {
+    3
+}
+
+fn default_health_start_period() -> Duration {
+    Duration::from_secs(60)
+}
+
+impl Default for HealthCheckOptions {
+    fn default() -> Self {
+        Self {
+            interval: default_health_interval(),
+            timeout: default_health_timeout(),
+            retries: default_health_retries(),
+            start_period: default_health_start_period(),
+        }
+    }
+}
 
 // ============================================================================
 // Security Options
@@ -523,4 +591,14 @@ pub struct AdvancedBoxOptions {
     /// Defaults to false.
     #[serde(default)]
     pub isolate_mounts: bool,
+
+    /// Health check options.
+    ///
+    /// When set, a background task will periodically ping the guest agent
+    /// to verify the box is healthy. Unhealthy boxes are marked and can
+    /// trigger automatic recovery.
+    ///
+    /// Most users should rely on the defaults.
+    #[serde(default)]
+    pub health_check: Option<HealthCheckOptions>,
 }

--- a/boxlite/src/runtime/types.rs
+++ b/boxlite/src/runtime/types.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use std::fmt;
 use std::hash::Hash;
 
-pub use crate::litebox::{BoxState, BoxStatus};
+pub use crate::litebox::{BoxState, BoxStatus, HealthStatus};
 use crate::runtime::id::BoxID;
 
 // ============================================================================
@@ -312,6 +312,9 @@ pub struct BoxInfo {
 
     /// User-defined labels for filtering and organization.
     pub labels: HashMap<String, String>,
+
+    /// Health status.
+    pub health_status: HealthStatus,
 }
 
 impl BoxInfo {
@@ -333,6 +336,7 @@ impl BoxInfo {
             cpus: config.options.cpus.unwrap_or(2),
             memory_mib: config.options.memory_mib.unwrap_or(512),
             labels: HashMap::new(),
+            health_status: state.health_status,
         }
     }
 }
@@ -347,6 +351,7 @@ impl PartialEq for BoxInfo {
             && self.cpus == other.cpus
             && self.memory_mib == other.memory_mib
             && self.labels == other.labels
+            && self.health_status == other.health_status
     }
 }
 

--- a/boxlite/tests/health_check.rs
+++ b/boxlite/tests/health_check.rs
@@ -1,0 +1,201 @@
+//! Integration tests for health check functionality.
+//!
+//! # Prerequisites
+//!
+//! These tests require a real VM environment:
+//! 1. Build the runtime: `make runtime-debug`
+//! 2. Run with: `cargo test -p boxlite --test health_check -- --test-threads=1`
+
+use boxlite::BoxliteRuntime;
+use boxlite::litebox::HealthState;
+use boxlite::runtime::advanced_options::{AdvancedBoxOptions, HealthCheckOptions};
+use boxlite::runtime::options::{BoxOptions, BoxliteOptions, RootfsSpec};
+use boxlite::runtime::types::BoxStatus;
+use std::process::Command;
+use std::time::Duration;
+use tempfile::TempDir;
+use tokio::time::sleep;
+
+// ============================================================================
+// TEST FIXTURES
+// ============================================================================
+
+/// Test context with isolated runtime and automatic cleanup.
+struct TestContext {
+    runtime: BoxliteRuntime,
+    _temp_dir: TempDir,
+}
+
+impl TestContext {
+    fn new() -> Self {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let options = BoxliteOptions {
+            home_dir: temp_dir.path().to_path_buf(),
+            image_registries: vec!["docker.m.daocloud.io".into()],
+        };
+        let runtime = BoxliteRuntime::new(options).expect("Failed to create runtime");
+        Self {
+            runtime,
+            _temp_dir: temp_dir,
+        }
+    }
+
+    /// Create a box with health check enabled
+    async fn create_box_with_health_check(
+        &self,
+        interval: Duration,
+        timeout: Duration,
+        retries: u32,
+        start_period: Duration,
+    ) -> boxlite::LiteBox {
+        let options = BoxOptions {
+            rootfs: RootfsSpec::Image("alpine:latest".into()),
+            advanced: AdvancedBoxOptions {
+                health_check: Some(HealthCheckOptions {
+                    interval,
+                    timeout,
+                    retries,
+                    start_period,
+                }),
+                ..Default::default()
+            },
+            auto_remove: false,
+            ..Default::default()
+        };
+        self.runtime
+            .create(options, None)
+            .await
+            .expect("Failed to create box with health check")
+    }
+}
+
+// ============================================================================
+// CORE INTEGRATION TESTS
+// ============================================================================
+
+#[tokio::test]
+async fn health_check_transitions_to_healthy_after_startup() {
+    let ctx = TestContext::new();
+
+    let handle = ctx
+        .create_box_with_health_check(
+            Duration::from_secs(2),
+            Duration::from_secs(1),
+            2,
+            Duration::from_secs(1),
+        )
+        .await;
+
+    // Start the box
+    handle.start().await.expect("Failed to start box");
+
+    // Initially in Starting state during start_period
+    let info = ctx
+        .runtime
+        .get_info(handle.id().as_str())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(info.health_status.state, HealthState::Starting);
+
+    // Wait for start period to pass and first health check to complete
+    sleep(Duration::from_secs(4)).await;
+
+    // Should transition to Healthy after successful ping
+    let info = ctx
+        .runtime
+        .get_info(handle.id().as_str())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        info.health_status.state,
+        HealthState::Healthy,
+        "Expected health state to be Healthy, got {:?}",
+        info.health_status.state
+    );
+    assert_eq!(info.health_status.failures, 0);
+
+    // Cleanup
+    handle.stop().await.unwrap();
+    ctx.runtime
+        .remove(handle.id().as_str(), false)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn health_check_becomes_unhealthy_when_shim_killed() {
+    let ctx = TestContext::new();
+
+    let handle = ctx
+        .create_box_with_health_check(
+            Duration::from_secs(2),
+            Duration::from_secs(1),
+            2,
+            Duration::from_secs(1),
+        )
+        .await;
+
+    let box_id = handle.id().clone();
+
+    // Start the box
+    handle.start().await.expect("Failed to start box");
+
+    // Wait for health check to become healthy
+    sleep(Duration::from_secs(4)).await;
+
+    // Verify initial healthy state
+    let info = ctx
+        .runtime
+        .get_info(box_id.as_str())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(info.health_status.state, HealthState::Healthy);
+
+    // Find and kill the shim process using BoxInfo
+    let shim_pid = info.pid.expect("No shim PID found");
+    println!("Killing shim process with PID: {}", shim_pid);
+
+    Command::new("kill")
+        .arg("-9")
+        .arg(shim_pid.to_string())
+        .output()
+        .expect("Failed to kill shim process");
+
+    // Wait for health check to detect the failure
+    sleep(Duration::from_secs(5)).await;
+
+    // Box should be stopped
+    let info = ctx
+        .runtime
+        .get_info(box_id.as_str())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        info.status,
+        BoxStatus::Stopped,
+        "Expected box status to be Stopped, got {:?}",
+        info.status
+    );
+
+    // Health status should be cleared or show unhealthy state
+    // (depending on implementation - health check task stops when box stops)
+    let health_status = info.health_status;
+    println!(
+        "Health status after shim killed: state={:?}, failures={}",
+        health_status.state, health_status.failures
+    );
+    // Health status should indicate failures or unhealthy state
+    assert!(
+        health_status.state == HealthState::Unhealthy || health_status.failures > 0,
+        "Expected unhealthy state or failures, got state={:?}, failures={}",
+        health_status.state,
+        health_status.failures
+    );
+
+    // Cleanup
+    ctx.runtime.remove(box_id.as_str(), false).await.unwrap();
+}

--- a/sdks/node/src/info.rs
+++ b/sdks/node/src/info.rs
@@ -1,5 +1,51 @@
-use boxlite::runtime::types::{BoxInfo, BoxStatus};
+use boxlite::litebox::HealthState as CoreHealthState;
+use boxlite::runtime::types::{BoxInfo, BoxStateInfo, BoxStatus};
 use napi_derive::napi;
+
+// ============================================================================
+// HealthState - Health check state enumeration
+// ============================================================================
+
+/// Health state of a box.
+#[napi(string_enum)]
+#[derive(Clone, Debug)]
+pub enum JsHealthState {
+    /// No health check configured
+    None,
+    /// Within start_period, not yet checked
+    Starting,
+    /// Last health check passed
+    Healthy,
+    /// Failed retries consecutive checks
+    Unhealthy,
+}
+
+fn health_state_to_js(state: &CoreHealthState) -> JsHealthState {
+    match state {
+        CoreHealthState::None => JsHealthState::None,
+        CoreHealthState::Starting => JsHealthState::Starting,
+        CoreHealthState::Healthy => JsHealthState::Healthy,
+        CoreHealthState::Unhealthy => JsHealthState::Unhealthy,
+    }
+}
+
+// ============================================================================
+// HealthStatus - Health check status
+// ============================================================================
+
+/// Health status of a box with health check enabled.
+///
+/// Tracks the current health state and consecutive failure count.
+#[napi(object)]
+#[derive(Clone, Debug)]
+pub struct JsHealthStatus {
+    /// Current health state
+    pub state: JsHealthState,
+    /// Consecutive health check failures
+    pub failures: u32,
+    /// Last health check timestamp (ISO 8601 format)
+    pub last_check: Option<String>,
+}
 
 // ============================================================================
 // BoxStateInfo - Runtime state (Docker-like State object)
@@ -34,6 +80,16 @@ fn status_to_string(status: BoxStatus) -> String {
     .to_string()
 }
 
+impl From<BoxStateInfo> for JsBoxStateInfo {
+    fn from(state_info: BoxStateInfo) -> Self {
+        Self {
+            status: status_to_string(state_info.status),
+            running: state_info.running,
+            pid: state_info.pid,
+        }
+    }
+}
+
 // ============================================================================
 // BoxInfo - Container info with nested state
 // ============================================================================
@@ -65,14 +121,19 @@ pub struct JsBoxInfo {
 
     /// Allocated memory in MiB
     pub memory_mib: u32,
+
+    /// Health status
+    pub health_status: JsHealthStatus,
 }
 
 impl From<BoxInfo> for JsBoxInfo {
     fn from(info: BoxInfo) -> Self {
-        let state = JsBoxStateInfo {
-            status: status_to_string(info.status),
-            running: info.status.is_running(),
-            pid: info.pid,
+        let state_info = BoxStateInfo::from(&info);
+        let state = JsBoxStateInfo::from(state_info);
+        let health_status = JsHealthStatus {
+            state: health_state_to_js(&info.health_status.state),
+            failures: info.health_status.failures,
+            last_check: info.health_status.last_check.map(|dt| dt.to_rfc3339()),
         };
 
         Self {
@@ -83,6 +144,7 @@ impl From<BoxInfo> for JsBoxInfo {
             image: info.image,
             cpus: info.cpus,
             memory_mib: info.memory_mib,
+            health_status,
         }
     }
 }

--- a/sdks/node/src/lib.rs
+++ b/sdks/node/src/lib.rs
@@ -22,10 +22,11 @@ pub use advanced_options::JsSecurityOptions;
 pub use box_handle::JsBox;
 pub use copy::JsCopyOptions;
 pub use exec::{JsExecResult, JsExecStderr, JsExecStdin, JsExecStdout, JsExecution};
-pub use info::JsBoxInfo;
+pub use info::{JsBoxInfo, JsBoxStateInfo, JsHealthState, JsHealthStatus};
 pub use metrics::{JsBoxMetrics, JsRuntimeMetrics};
 pub use options::{
-    JsBoxOptions, JsBoxliteRestOptions, JsEnvVar, JsOptions, JsPortSpec, JsVolumeSpec,
+    JsBoxOptions, JsBoxliteRestOptions, JsEnvVar, JsHealthCheckOptions, JsOptions, JsPortSpec,
+    JsVolumeSpec,
 };
 pub use runtime::JsBoxlite; // re-export for dist bundling
 pub use snapshot_options::{JsCloneOptions, JsExportOptions, JsSnapshotOptions};

--- a/sdks/node/src/options.rs
+++ b/sdks/node/src/options.rs
@@ -1,7 +1,8 @@
 use std::path::PathBuf;
+use std::time::Duration;
 
 use boxlite::BoxliteRestOptions;
-use boxlite::runtime::advanced_options::{AdvancedBoxOptions, SecurityOptions};
+use boxlite::runtime::advanced_options::{AdvancedBoxOptions, HealthCheckOptions, SecurityOptions};
 use boxlite::runtime::constants::images;
 use boxlite::runtime::options::{
     BoxOptions, BoxliteOptions, NetworkSpec, PortProtocol, PortSpec, RootfsSpec, VolumeSpec,
@@ -9,6 +10,42 @@ use boxlite::runtime::options::{
 use napi_derive::napi;
 
 use crate::advanced_options::JsSecurityOptions;
+
+/// Health check options for boxes.
+///
+/// Defines how to periodically check if a box's guest agent is responsive.
+/// Similar to Docker's HEALTHCHECK directive.
+///
+/// This is an advanced option - most users should rely on the defaults.
+#[napi(object)]
+#[derive(Clone, Debug)]
+pub struct JsHealthCheckOptions {
+    /// Time between health checks (seconds)
+    #[napi(js_name = "interval")]
+    pub interval_seconds: f64,
+
+    /// Time to wait before considering the check failed (seconds)
+    #[napi(js_name = "timeout")]
+    pub timeout_seconds: f64,
+
+    /// Number of consecutive failures before marking as unhealthy
+    pub retries: u32,
+
+    /// Startup period before health checks count toward failures (seconds)
+    #[napi(js_name = "startPeriod")]
+    pub start_period_seconds: f64,
+}
+
+impl From<JsHealthCheckOptions> for HealthCheckOptions {
+    fn from(js_config: JsHealthCheckOptions) -> Self {
+        Self {
+            interval: Duration::from_secs(js_config.interval_seconds as u64),
+            timeout: Duration::from_secs(js_config.timeout_seconds as u64),
+            retries: js_config.retries,
+            start_period: Duration::from_secs(js_config.start_period_seconds as u64),
+        }
+    }
+}
 
 /// Runtime configuration options.
 ///
@@ -101,6 +138,10 @@ pub struct JsBoxOptions {
 
     /// Security isolation options for the box.
     pub security: Option<JsSecurityOptions>,
+
+    /// Health check options for the box.
+    #[napi(js_name = "healthCheck")]
+    pub health_check: Option<JsHealthCheckOptions>,
 }
 
 /// Environment variable specification.
@@ -224,6 +265,8 @@ impl From<JsBoxOptions> for BoxOptions {
             .map(SecurityOptions::from)
             .unwrap_or_default();
 
+        let health_check = js_opts.health_check.map(HealthCheckOptions::from);
+
         BoxOptions {
             cpus: js_opts.cpus,
             memory_mib: js_opts.memory_mib,
@@ -236,6 +279,7 @@ impl From<JsBoxOptions> for BoxOptions {
             ports,
             advanced: AdvancedBoxOptions {
                 security,
+                health_check,
                 ..Default::default()
             },
             auto_remove: js_opts.auto_remove.unwrap_or(false),

--- a/sdks/python/boxlite/__init__.py
+++ b/sdks/python/boxlite/__init__.py
@@ -9,25 +9,29 @@ import warnings
 # Import core Rust API
 try:
     from .boxlite import (
-        Options,
-        BoxOptions,
-        BoxliteRestOptions,
-        Boxlite,
         Box,
-        Execution,
-        ExecStdout,
-        ExecStderr,
         BoxInfo,
-        BoxStateInfo,
-        RuntimeMetrics,
+        Boxlite,
+        BoxliteRestOptions,
         BoxMetrics,
+        BoxOptions,
+        BoxStateInfo,
+        CloneOptions,
         CopyOptions,
+        ExecStderr,
+        ExecStdout,
+        Execution,
+        ExportOptions,
+        HealthCheckOptions,
+        HealthState,
+        HealthStatus,
+        Options,
+        RootfsSpec,
+        RuntimeMetrics,
         SecurityOptions,
         SnapshotHandle,
         SnapshotInfo,
         SnapshotOptions,
-        CloneOptions,
-        ExportOptions,
     )
 
     __all__ = [
@@ -42,9 +46,13 @@ try:
         "ExecStderr",
         "BoxInfo",
         "BoxStateInfo",
+        "HealthState",
+        "HealthStatus",
         "RuntimeMetrics",
         "BoxMetrics",
         "CopyOptions",
+        "HealthCheckOptions",
+        "RootfsSpec",
         "SecurityOptions",
         "SnapshotHandle",
         "SnapshotInfo",
@@ -58,10 +66,10 @@ except ImportError as e:
 
 # Import Python convenience wrappers (re-exported via __all__)
 try:
-    from .simplebox import SimpleBox  # noqa: F401
-    from .exec import ExecResult  # noqa: F401
     from .codebox import CodeBox  # noqa: F401
-    from .errors import BoxliteError, ExecError, TimeoutError, ParseError  # noqa: F401
+    from .errors import BoxliteError, ExecError, ParseError, TimeoutError  # noqa: F401
+    from .exec import ExecResult  # noqa: F401
+    from .simplebox import SimpleBox  # noqa: F401
 
     __all__.extend(
         [
@@ -110,7 +118,7 @@ except ImportError:
 
 # Multi-box orchestration (guest-initiated messaging)
 try:
-    from .orchestration import BoxRuntime, ManagedBox, BoxGroup  # noqa: F401
+    from .orchestration import BoxGroup, BoxRuntime, ManagedBox  # noqa: F401
 
     __all__.extend(["BoxRuntime", "ManagedBox", "BoxGroup"])
 except ImportError:
@@ -120,13 +128,13 @@ except ImportError:
 # Requires greenlet: pip install boxlite[sync]
 try:
     from .sync_api import (  # noqa: F401
-        SyncBoxlite,
         SyncBox,
-        SyncExecution,
-        SyncExecStdout,
-        SyncExecStderr,
-        SyncSimpleBox,
+        SyncBoxlite,
         SyncCodeBox,
+        SyncExecStderr,
+        SyncExecStdout,
+        SyncExecution,
+        SyncSimpleBox,
         SyncSkillBox,
     )
 
@@ -148,7 +156,7 @@ except ImportError:
 
 # Get version from package metadata
 try:
-    from importlib.metadata import version, PackageNotFoundError
+    from importlib.metadata import PackageNotFoundError, version
 
     __version__ = version("boxlite")
 except PackageNotFoundError:

--- a/sdks/python/src/advanced_options.rs
+++ b/sdks/python/src/advanced_options.rs
@@ -1,5 +1,67 @@
-use boxlite::runtime::advanced_options::{ResourceLimits, SecurityOptions};
+use boxlite::runtime::advanced_options::{HealthCheckOptions, ResourceLimits, SecurityOptions};
 use pyo3::prelude::*;
+
+// ============================================================================
+// Health Check Options
+// ============================================================================
+
+/// Health check options for boxes.
+///
+/// Defines how to periodically check if a box's guest agent is responsive.
+/// Similar to Docker's HEALTHCHECK directive.
+///
+/// This is an advanced option - most users should rely on the defaults.
+#[pyclass(name = "HealthCheckOptions")]
+#[derive(Clone, Debug)]
+pub struct PyHealthCheckOptions {
+    /// Time between health checks (seconds).
+    #[pyo3(get, set)]
+    pub interval: u64,
+
+    /// Time to wait before considering the check failed (seconds).
+    #[pyo3(get, set)]
+    pub timeout: u64,
+
+    /// Number of consecutive failures before marking as unhealthy.
+    #[pyo3(get, set)]
+    pub retries: u32,
+
+    /// Startup period before health checks count toward failures (seconds).
+    #[pyo3(get, set)]
+    pub start_period: u64,
+}
+
+#[pymethods]
+impl PyHealthCheckOptions {
+    #[new]
+    #[pyo3(signature = (interval=30, timeout=10, retries=3, start_period=60))]
+    fn new(interval: u64, timeout: u64, retries: u32, start_period: u64) -> Self {
+        Self {
+            interval,
+            timeout,
+            retries,
+            start_period,
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "HealthCheckOptions(interval={}s, timeout={}s, retries={}, start_period={}s)",
+            self.interval, self.timeout, self.retries, self.start_period
+        )
+    }
+}
+
+impl From<PyHealthCheckOptions> for HealthCheckOptions {
+    fn from(py_opts: PyHealthCheckOptions) -> Self {
+        Self {
+            interval: std::time::Duration::from_secs(py_opts.interval),
+            timeout: std::time::Duration::from_secs(py_opts.timeout),
+            retries: py_opts.retries,
+            start_period: std::time::Duration::from_secs(py_opts.start_period),
+        }
+    }
+}
 
 // ============================================================================
 // Security Options
@@ -200,13 +262,23 @@ pub struct PyAdvancedBoxOptions {
     /// Security isolation options.
     #[pyo3(get, set)]
     pub security: Option<PySecurityOptions>,
+
+    /// Health check options.
+    #[pyo3(get, set)]
+    pub health_check: Option<PyHealthCheckOptions>,
 }
 
 #[pymethods]
 impl PyAdvancedBoxOptions {
     #[new]
-    #[pyo3(signature = (security=None))]
-    fn new(security: Option<PySecurityOptions>) -> Self {
-        Self { security }
+    #[pyo3(signature = (security=None, health_check=None))]
+    fn new(
+        security: Option<PySecurityOptions>,
+        health_check: Option<PyHealthCheckOptions>,
+    ) -> Self {
+        Self {
+            security,
+            health_check,
+        }
     }
 }

--- a/sdks/python/src/info.rs
+++ b/sdks/python/src/info.rs
@@ -1,5 +1,98 @@
-use boxlite::{BoxInfo, BoxStateInfo, BoxStatus};
+use boxlite::{BoxInfo, BoxStateInfo, BoxStatus, HealthState as CoreHealthState};
 use pyo3::prelude::*;
+
+// ============================================================================
+// HealthState - Health check state enumeration
+// ============================================================================
+
+#[pyclass(name = "HealthState")]
+#[derive(Clone, Debug)]
+pub struct PyHealthState {
+    #[pyo3(get)]
+    pub(crate) value: String,
+}
+
+#[pymethods]
+impl PyHealthState {
+    fn __repr__(&self) -> String {
+        format!("<HealthState: {}>", self.value)
+    }
+
+    fn __str__(&self) -> String {
+        self.value.clone()
+    }
+
+    #[staticmethod]
+    fn none() -> Self {
+        Self {
+            value: "none".to_string(),
+        }
+    }
+
+    #[staticmethod]
+    fn starting() -> Self {
+        Self {
+            value: "starting".to_string(),
+        }
+    }
+
+    #[staticmethod]
+    fn healthy() -> Self {
+        Self {
+            value: "healthy".to_string(),
+        }
+    }
+
+    #[staticmethod]
+    fn unhealthy() -> Self {
+        Self {
+            value: "unhealthy".to_string(),
+        }
+    }
+
+    fn is_none(&self) -> bool {
+        self.value == "none"
+    }
+
+    fn is_starting(&self) -> bool {
+        self.value == "starting"
+    }
+
+    fn is_healthy(&self) -> bool {
+        self.value == "healthy"
+    }
+
+    fn is_unhealthy(&self) -> bool {
+        self.value == "unhealthy"
+    }
+}
+
+// ============================================================================
+// HealthStatus - Health check status
+// ============================================================================
+
+#[pyclass(name = "HealthStatus")]
+#[derive(Clone)]
+pub struct PyHealthStatus {
+    #[pyo3(get)]
+    pub(crate) state: PyHealthState,
+    #[pyo3(get)]
+    pub(crate) failures: u32,
+    #[pyo3(get)]
+    pub(crate) last_check: Option<String>,
+}
+
+#[pymethods]
+impl PyHealthStatus {
+    fn __repr__(&self) -> String {
+        serde_json::to_string_pretty(&serde_json::json!({
+            "state": self.state.value,
+            "failures": self.failures,
+            "last_check": self.last_check
+        }))
+        .unwrap_or_default()
+    }
+}
 
 // ============================================================================
 // BoxStateInfo - Runtime state (Docker-like State object)
@@ -22,7 +115,7 @@ impl PyBoxStateInfo {
         serde_json::to_string_pretty(&serde_json::json!({
             "status": self.status,
             "running": self.running,
-            "pid": self.pid
+            "pid": self.pid,
         }))
         .unwrap_or_default()
     }
@@ -40,12 +133,23 @@ fn status_to_string(status: BoxStatus) -> String {
     .to_string()
 }
 
+fn health_state_to_py(state: &CoreHealthState) -> PyHealthState {
+    let value = match state {
+        CoreHealthState::None => "none",
+        CoreHealthState::Starting => "starting",
+        CoreHealthState::Healthy => "healthy",
+        CoreHealthState::Unhealthy => "unhealthy",
+    }
+    .to_string();
+    PyHealthState { value }
+}
+
 impl From<BoxStateInfo> for PyBoxStateInfo {
-    fn from(info: BoxStateInfo) -> Self {
+    fn from(state_info: BoxStateInfo) -> Self {
         PyBoxStateInfo {
-            status: status_to_string(info.status),
-            running: info.running,
-            pid: info.pid,
+            status: status_to_string(state_info.status),
+            running: state_info.running,
+            pid: state_info.pid,
         }
     }
 }
@@ -71,6 +175,8 @@ pub(crate) struct PyBoxInfo {
     pub(crate) cpus: u8,
     #[pyo3(get)]
     pub(crate) memory_mib: u32,
+    #[pyo3(get)]
+    pub(crate) health_status: PyHealthStatus,
 }
 
 #[pymethods]
@@ -82,12 +188,17 @@ impl PyBoxInfo {
             "state": {
                 "status": self.state.status,
                 "running": self.state.running,
-                "pid": self.state.pid
+                "pid": self.state.pid,
             },
             "image": self.image,
             "cpus": self.cpus,
             "memory_mib": self.memory_mib,
-            "created_at": self.created_at
+            "created_at": self.created_at,
+            "health_status": {
+                "state": self.health_status.state.value,
+                "failures": self.health_status.failures,
+                "last_check": self.health_status.last_check
+            }
         }))
         .unwrap_or_default()
     }
@@ -95,10 +206,12 @@ impl PyBoxInfo {
 
 impl From<BoxInfo> for PyBoxInfo {
     fn from(info: BoxInfo) -> Self {
-        let state = PyBoxStateInfo {
-            status: status_to_string(info.status),
-            running: info.status.is_running(),
-            pid: info.pid,
+        let state_info = BoxStateInfo::from(&info);
+        let state = PyBoxStateInfo::from(state_info);
+        let health_status = PyHealthStatus {
+            state: health_state_to_py(&info.health_status.state),
+            failures: info.health_status.failures,
+            last_check: info.health_status.last_check.map(|dt| dt.to_rfc3339()),
         };
 
         PyBoxInfo {
@@ -109,6 +222,7 @@ impl From<BoxInfo> for PyBoxInfo {
             image: info.image,
             cpus: info.cpus,
             memory_mib: info.memory_mib,
+            health_status,
         }
     }
 }

--- a/sdks/python/src/lib.rs
+++ b/sdks/python/src/lib.rs
@@ -11,10 +11,10 @@ mod snapshot_options;
 mod snapshots;
 mod util;
 
-use crate::advanced_options::{PyAdvancedBoxOptions, PySecurityOptions};
+use crate::advanced_options::{PyAdvancedBoxOptions, PyHealthCheckOptions, PySecurityOptions};
 use crate::box_handle::PyBox;
 use crate::exec::{PyExecStderr, PyExecStdin, PyExecStdout, PyExecution};
-use crate::info::{PyBoxInfo, PyBoxStateInfo};
+use crate::info::{PyBoxInfo, PyBoxStateInfo, PyHealthState, PyHealthStatus};
 use crate::metrics::{PyBoxMetrics, PyRuntimeMetrics};
 use crate::options::{PyBoxOptions, PyBoxliteRestOptions, PyCopyOptions, PyOptions};
 use crate::runtime::PyBoxlite;
@@ -27,6 +27,7 @@ fn boxlite_python(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyOptions>()?;
     m.add_class::<PyBoxOptions>()?;
     m.add_class::<PySecurityOptions>()?;
+    m.add_class::<PyHealthCheckOptions>()?;
     m.add_class::<PyAdvancedBoxOptions>()?;
     m.add_class::<PyBoxlite>()?;
     m.add_class::<PyBox>()?;
@@ -36,6 +37,8 @@ fn boxlite_python(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyExecStderr>()?;
     m.add_class::<PyBoxInfo>()?;
     m.add_class::<PyBoxStateInfo>()?;
+    m.add_class::<PyHealthState>()?;
+    m.add_class::<PyHealthStatus>()?;
     m.add_class::<PyRuntimeMetrics>()?;
     m.add_class::<PyBoxMetrics>()?;
     m.add_class::<PyCopyOptions>()?;
@@ -44,6 +47,7 @@ fn boxlite_python(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PySnapshotOptions>()?;
     m.add_class::<PyExportOptions>()?;
     m.add_class::<PyCloneOptions>()?;
+    m.add_class::<PyHealthCheckOptions>()?;
     m.add_class::<PyBoxliteRestOptions>()?;
 
     Ok(())

--- a/sdks/python/src/options.rs
+++ b/sdks/python/src/options.rs
@@ -1,8 +1,8 @@
 use std::path::PathBuf;
 
 use boxlite::BoxliteRestOptions;
-use boxlite::CopyOptions;
-use boxlite::runtime::advanced_options::SecurityOptions;
+use boxlite::litebox::copy::CopyOptions;
+use boxlite::runtime::advanced_options::{HealthCheckOptions, SecurityOptions};
 use boxlite::runtime::constants::images;
 use boxlite::runtime::options::{
     BoxOptions, BoxliteOptions, NetworkSpec, PortProtocol, PortSpec, RootfsSpec, VolumeSpec,
@@ -148,7 +148,8 @@ pub(crate) struct PyBoxOptions {
     /// If None, uses the image's USER directive (defaults to root).
     #[pyo3(get, set)]
     pub(crate) user: Option<String>,
-    /// Advanced options for expert users (security, mount isolation).
+
+    /// Advanced options for expert users (security, mount isolation, health check).
     #[pyo3(get, set)]
     pub(crate) advanced: Option<PyAdvancedBoxOptions>,
 }
@@ -276,10 +277,13 @@ impl From<PyBoxOptions> for BoxOptions {
             opts.detach = detach;
         }
 
-        if let Some(advanced) = py_opts.advanced
-            && let Some(security) = advanced.security
-        {
-            opts.advanced.security = SecurityOptions::from(security);
+        if let Some(advanced) = py_opts.advanced {
+            if let Some(security) = advanced.security {
+                opts.advanced.security = SecurityOptions::from(security);
+            }
+            if let Some(health_check) = advanced.health_check {
+                opts.advanced.health_check = Some(HealthCheckOptions::from(health_check));
+            }
         }
 
         opts


### PR DESCRIPTION
- Add HealthCheckConfig to BoxOptions for configuring health checks
- Add HealthState and HealthStatus types to track box health
- Implement health check task with start_period grace period
- Skip health checks during start_period to avoid false failures
- Expose health status through BoxInfo.health_status field
- Add health status state management (starting/healthy/unhealthy)
- Track consecutive failures and mark box as unhealthy after retries

This is an initial framework with basic functionality:
- Health check configuration and execution
- Start period grace period logic
- Health state tracking and status reporting

issue: #33 