### PR TITLE
chore: bump SDK versions (Rust/C/Python 0.5.14, Node 0.2.11)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,7 +302,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite"
-version = "0.5.13"
+version = "0.5.14"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -365,7 +365,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-c"
-version = "0.5.13"
+version = "0.5.14"
 dependencies = [
  "boxlite-ffi",
  "cbindgen",
@@ -404,7 +404,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-ffi"
-version = "0.5.13"
+version = "0.5.14"
 dependencies = [
  "boxlite",
  "futures",
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-guest"
-version = "0.5.13"
+version = "0.5.14"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -444,7 +444,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-node"
-version = "0.5.13"
+version = "0.5.14"
 dependencies = [
  "boxlite",
  "boxlite-shared",
@@ -458,7 +458,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-python"
-version = "0.5.13"
+version = "0.5.14"
 dependencies = [
  "boxlite",
  "futures",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-shared"
-version = "0.5.13"
+version = "0.5.14"
 dependencies = [
  "prost",
  "serde",
@@ -495,7 +495,7 @@ dependencies = [
 
 [[package]]
 name = "bubblewrap-sys"
-version = "0.5.13"
+version = "0.5.14"
 dependencies = [
  "num_cpus",
 ]
@@ -970,7 +970,7 @@ checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
 name = "e2fsprogs-sys"
-version = "0.5.13"
+version = "0.5.14"
 dependencies = [
  "num_cpus",
 ]
@@ -1880,14 +1880,14 @@ dependencies = [
 
 [[package]]
 name = "libgvproxy-sys"
-version = "0.5.13"
+version = "0.5.14"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "libkrun-sys"
-version = "0.5.13"
+version = "0.5.14"
 dependencies = [
  "libc",
  "num_cpus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = ["build/tmp", "target", ".venv", "examples/*/.venv"]
 resolver = "2"
 
 [workspace.package]
-version = "0.5.13"
+version = "0.5.14"
 edition = "2024"
 authors = ["Dorian Zheng <https://github.com/dorianzheng>"]
 license = "Apache-2.0"

--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boxlite-ai/boxlite",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "BoxLite - Embeddable micro-VM runtime for secure, isolated code execution",
   "type": "module",
   "main": "dist/index.js",

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "boxlite"
-version = "0.5.13"
+version = "0.5.14"
 description = "Python bindings for Boxlite runtime"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Rust/C/Python SDK: 0.5.13 → 0.5.14
- Node.js SDK: 0.2.10 → 0.2.11

Patch version bump following #270.