### PR TITLE
build: copy runtime libraries to target directory for test compatibility

### DIFF
--- a/scripts/build/build-runtime.sh
+++ b/scripts/build/build-runtime.sh
@@ -288,6 +288,22 @@ assemble_runtime() {
         echo "✓"
     fi
 
+    # Copy libraries to target/debug or target/release for test compatibility
+    # This is needed because cargo test uses the shim in target/debug,
+    # which has RUNPATH=$ORIGIN and expects libraries in the same directory
+    if [ -n "$PROFILE" ]; then
+        local target_dir="$PROJECT_ROOT/target/$PROFILE"
+        print_step "Copying libraries to $target_dir for test compatibility... "
+
+        # Copy each library if it exists
+        for lib in "$DEST_DIR"/libkrun* "$DEST_DIR"/libgvproxy* "$DEST_DIR"/libkrunfw*; do
+            if [ -f "$lib" ]; then
+                cp -P "$lib" "$target_dir/" 2>/dev/null || true
+            fi
+        done
+        echo "✓"
+    fi
+
     print_success "Runtime directory assembled"
 }
 


### PR DESCRIPTION
Fix dynamic library loading errors when running `cargo test`.

The shim binary in target/debug has RUNPATH=$ORIGIN and expects libraries (libkrun, libgvproxy, libkrunfw) in the same directory. This change copies libraries from target/boxlite-runtime to target/debug during `make runtime-debug`.

Usage:
  make runtime-debug
  cargo test -p boxlite