### PR TITLE
fix(jailer): capture SIGSYS in CrashCapture for seccomp diagnostics

### DIFF
--- a/boxlite/src/bin/shim/crash_capture.rs
+++ b/boxlite/src/bin/shim/crash_capture.rs
@@ -76,6 +76,7 @@ fn install_signal_handlers(exit_file: PathBuf) {
         libc::signal(libc::SIGSEGV, crash_signal_handler as *const () as usize);
         libc::signal(libc::SIGBUS, crash_signal_handler as *const () as usize);
         libc::signal(libc::SIGILL, crash_signal_handler as *const () as usize);
+        libc::signal(libc::SIGSYS, crash_signal_handler as *const () as usize);
     }
 }
 
@@ -90,6 +91,7 @@ extern "C" fn crash_signal_handler(sig: libc::c_int) {
         libc::SIGSEGV => "SIGSEGV",
         libc::SIGBUS => "SIGBUS",
         libc::SIGILL => "SIGILL",
+        libc::SIGSYS => "SIGSYS",
         _ => "UNKNOWN",
     };
 


### PR DESCRIPTION
## Summary
- Add SIGSYS to the signal handler list in CrashCapture so seccomp violations produce a meaningful error message instead of generic "VM exited unexpectedly"
- Add seccomp-specific troubleshooting hint in CrashReport when SIGSYS is detected

## Test plan
- [ ] Verify `cargo check -p boxlite` passes
- [ ] Trigger a seccomp violation and confirm the error message mentions seccomp/SIGSYS