### PR TITLE
feat(watchdog): pipe-based POLLHUP parent death detection

### DIFF
--- a/boxlite/src/jailer/common/fd.rs
+++ b/boxlite/src/jailer/common/fd.rs
@@ -7,7 +7,7 @@
 //! Only the async-signal-safe `close_inherited_fds_raw()` is used,
 //! called from the `pre_exec` hook before exec().
 
-/// Close inherited FDs - async-signal-safe version for pre_exec.
+/// Close all FDs from `first_fd` onwards. Async-signal-safe.
 ///
 /// This function is designed to be called from a `pre_exec` hook, which runs
 /// after `fork()` but before `exec()`. Only async-signal-safe operations are
@@ -26,16 +26,14 @@
 ///
 /// * `Ok(())` - FDs closed successfully
 /// * `Err(errno)` - Failed (returns raw errno for io::Error conversion)
-pub fn close_inherited_fds_raw() -> Result<(), i32> {
-    const FIRST_FD: i32 = 3; // Keep stdin(0), stdout(1), stderr(2)
-
+pub fn close_fds_from(first_fd: i32) -> Result<(), i32> {
     #[cfg(target_os = "linux")]
     {
         // Try close_range syscall (Linux 5.9+, most efficient)
         let result = unsafe {
             libc::syscall(
                 libc::SYS_close_range,
-                FIRST_FD as libc::c_uint,
+                first_fd as libc::c_uint,
                 libc::c_uint::MAX,
                 0 as libc::c_uint,
             )
@@ -48,7 +46,7 @@ pub fn close_inherited_fds_raw() -> Result<(), i32> {
         // Note: We can't use /proc/self/fd here because:
         // 1. read_dir allocates memory (not async-signal-safe)
         // 2. We might be in a mount namespace where /proc isn't mounted
-        for fd in FIRST_FD..1024 {
+        for fd in first_fd..1024 {
             // Ignore errors - FD might not be open
             unsafe { libc::close(fd) };
         }
@@ -59,7 +57,7 @@ pub fn close_inherited_fds_raw() -> Result<(), i32> {
     {
         // macOS: brute force close (no close_range syscall)
         // 4096 is a reasonable upper bound for most processes
-        for fd in FIRST_FD..4096 {
+        for fd in first_fd..4096 {
             // Ignore errors - FD might not be open
             unsafe { libc::close(fd) };
         }
@@ -69,8 +67,16 @@ pub fn close_inherited_fds_raw() -> Result<(), i32> {
     #[cfg(not(any(target_os = "linux", target_os = "macos")))]
     {
         // Unsupported platform - return ENOSYS
+        let _ = first_fd;
         Err(libc::ENOSYS)
     }
+}
+
+/// Close inherited FDs (3+). Delegates to [`close_fds_from`].
+///
+/// Keeps stdin(0), stdout(1), stderr(2) open. Closes everything from FD 3 onwards.
+pub fn close_inherited_fds_raw() -> Result<(), i32> {
+    close_fds_from(3)
 }
 
 #[cfg(test)]
@@ -108,5 +114,40 @@ mod tests {
 
         let result = unsafe { libc::fcntl(2, libc::F_GETFD) };
         assert!(result >= 0 || result == -1, "stderr should be accessible");
+    }
+
+    #[test]
+    fn test_close_fds_from_preserves_below() {
+        // Create two test FDs (will get 3 and 4, or similar)
+        let fd_a = unsafe { libc::dup(STDOUT_FD) };
+        let fd_b = unsafe { libc::dup(STDOUT_FD) };
+        assert!(fd_a >= 3);
+        assert!(fd_b > fd_a);
+
+        // Close from fd_b onwards — fd_a should survive
+        close_fds_from(fd_b).expect("Should succeed");
+
+        // fd_a should still be valid
+        let result = unsafe { libc::fcntl(fd_a, libc::F_GETFD) };
+        assert!(result >= 0, "fd_a should still be open");
+
+        // fd_b should be closed
+        let result = unsafe { libc::fcntl(fd_b, libc::F_GETFD) };
+        assert_eq!(result, -1, "fd_b should be closed");
+
+        // Cleanup fd_a
+        unsafe { libc::close(fd_a) };
+    }
+
+    #[test]
+    fn test_close_fds_from_closes_target_and_above() {
+        let fd = unsafe { libc::dup(STDOUT_FD) };
+        assert!(fd >= 3);
+
+        // Close from fd onwards — fd itself should be closed
+        close_fds_from(fd).expect("Should succeed");
+
+        let result = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+        assert_eq!(result, -1, "target fd should be closed");
     }
 }

--- a/boxlite/src/jailer/pre_exec.rs
+++ b/boxlite/src/jailer/pre_exec.rs
@@ -22,12 +22,14 @@
 
 use crate::jailer::common;
 use crate::runtime::advanced_options::ResourceLimits;
+use std::os::fd::RawFd;
 use std::process::Command;
 
 /// Add pre-execution hook for process isolation (async-signal-safe).
 ///
 /// Runs after fork() but before the new program starts in the child process.
-/// Applies: FD cleanup, rlimits, cgroup membership (Linux), PID file writing.
+/// Applies: FD preservation (dup2), FD cleanup, rlimits, cgroup membership (Linux),
+/// PID file writing.
 ///
 /// # Arguments
 ///
@@ -35,12 +37,15 @@ use std::process::Command;
 /// * `resource_limits` - Resource limits to apply
 /// * `cgroup_procs_path` - Path to cgroup.procs file (Linux only, pre-computed)
 /// * `pid_file_path` - Path to PID file (pre-computed CString for async-signal-safety)
+/// * `preserved_fds` - FDs to preserve: each `(source, target)` is dup2'd before cleanup.
+///   After dup2, all FDs above the highest target are closed.
+///   Pass empty vec for default behavior (close all FDs >= 3).
 ///
 /// # Safety
 ///
 /// This function uses `unsafe` to set the hook. The hook itself
 /// only uses async-signal-safe operations:
-/// - `close()` / `close_range()` syscalls
+/// - `dup2()` / `close()` / `close_range()` syscalls
 /// - `setrlimit()` syscall
 /// - `open()` / `write()` / `close()` syscalls (for cgroup and PID file)
 /// - `getpid()` syscall
@@ -50,25 +55,12 @@ use std::process::Command;
 /// - Memory allocation (Box, Vec, String creation)
 /// - Mutex operations
 /// - Most Rust standard library functions
-///
-/// # Example
-///
-/// ```ignore
-/// use std::process::Command;
-/// use boxlite::jailer::pre_execution::add_hook;
-///
-/// let mut cmd = Command::new("/path/to/binary");
-/// let limits = ResourceLimits::default();
-///
-/// add_hook(&mut cmd, limits, None, None);
-///
-/// cmd.spawn()?;
-/// ```
 pub fn add_pre_exec_hook(
     cmd: &mut Command,
     resource_limits: ResourceLimits,
     #[allow(unused_variables)] cgroup_procs_path: Option<std::ffi::CString>,
     pid_file_path: Option<std::ffi::CString>,
+    preserved_fds: Vec<(RawFd, i32)>,
 ) {
     use std::os::unix::process::CommandExt;
 
@@ -76,25 +68,34 @@ pub fn add_pre_exec_hook(
     // See module documentation for details.
     unsafe {
         cmd.pre_exec(move || {
-            // 1. Close inherited file descriptors
-            // This prevents information leakage through inherited FDs
-            common::fd::close_inherited_fds_raw().map_err(std::io::Error::from_raw_os_error)?;
+            // 1. FD preservation + cleanup
+            // If preserved_fds is non-empty, dup2 each (source -> target),
+            // then close everything above the highest target.
+            // Otherwise, close all FDs >= 3 (default behavior).
+            if !preserved_fds.is_empty() {
+                for &(source, target) in &preserved_fds {
+                    if source != target {
+                        libc::dup2(source, target);
+                    }
+                }
+                let first_close = preserved_fds.iter().map(|(_, t)| *t).max().unwrap() + 1;
+                common::fd::close_fds_from(first_close)
+                    .map_err(std::io::Error::from_raw_os_error)?;
+            } else {
+                common::fd::close_inherited_fds_raw().map_err(std::io::Error::from_raw_os_error)?;
+            }
 
             // 2. Apply resource limits (rlimits)
-            // This is enforced by the kernel
             common::rlimit::apply_limits_raw(&resource_limits)
                 .map_err(std::io::Error::from_raw_os_error)?;
 
             // 3. Add self to cgroup (Linux only)
-            // This ensures the process is subject to cgroup resource limits
             #[cfg(target_os = "linux")]
             if let Some(ref path) = cgroup_procs_path {
-                // Ignore cgroup errors - the box can still run without cgroup limits
                 let _ = crate::jailer::cgroup::add_self_to_cgroup_raw(path);
             }
 
-            // 4. Write PID file (single source of truth for process tracking)
-            // This must happen after fork() - child has its own PID now
+            // 4. Write PID file
             if let Some(ref path) = pid_file_path {
                 common::pid::write_pid_file_raw(path).map_err(std::io::Error::from_raw_os_error)?;
             }
@@ -110,14 +111,10 @@ mod tests {
 
     #[test]
     fn test_add_hook_compiles() {
-        // Just verify the function compiles with various argument types
         let mut cmd = Command::new("/bin/echo");
         let limits = ResourceLimits::default();
 
-        add_pre_exec_hook(&mut cmd, limits, None, None);
-
-        // We can't actually test the hook without forking
-        // Integration tests should verify the actual behavior
+        add_pre_exec_hook(&mut cmd, limits, None, None, vec![]);
     }
 
     #[cfg(target_os = "linux")]
@@ -129,7 +126,7 @@ mod tests {
         let limits = ResourceLimits::default();
         let cgroup_path = CString::new("/sys/fs/cgroup/boxlite/test/cgroup.procs").ok();
 
-        add_pre_exec_hook(&mut cmd, limits, cgroup_path, None);
+        add_pre_exec_hook(&mut cmd, limits, cgroup_path, None, vec![]);
     }
 
     #[test]
@@ -140,6 +137,15 @@ mod tests {
         let limits = ResourceLimits::default();
         let pid_file = CString::new("/tmp/test.pid").ok();
 
-        add_pre_exec_hook(&mut cmd, limits, None, pid_file);
+        add_pre_exec_hook(&mut cmd, limits, None, pid_file, vec![]);
+    }
+
+    #[test]
+    fn test_add_hook_with_preserved_fds() {
+        let mut cmd = Command::new("/bin/echo");
+        let limits = ResourceLimits::default();
+
+        // Simulate preserving fd 5 → target fd 3
+        add_pre_exec_hook(&mut cmd, limits, None, None, vec![(5, 3)]);
     }
 }

--- a/boxlite/src/litebox/init/tasks/vmm_spawn.rs
+++ b/boxlite/src/litebox/init/tasks/vmm_spawn.rs
@@ -220,7 +220,6 @@ async fn build_config(
         console_output: Some(layout.console_output_path()),
         exit_file: layout.exit_file_path(),
         detach: options.detach,
-        parent_pid: std::process::id(),
     };
 
     Ok((instance_spec, volume_mgr, rootfs_init, container_mounts))

--- a/boxlite/src/vmm/controller/mod.rs
+++ b/boxlite/src/vmm/controller/mod.rs
@@ -17,6 +17,7 @@
 mod handler;
 mod shim;
 mod spawn;
+pub mod watchdog;
 
 use crate::vmm::InstanceSpec;
 use boxlite_shared::BoxliteResult;

--- a/boxlite/src/vmm/controller/shim.rs
+++ b/boxlite/src/vmm/controller/shim.rs
@@ -9,7 +9,11 @@ use crate::{
 };
 use boxlite_shared::errors::{BoxliteError, BoxliteResult};
 
-use super::{VmmController, VmmHandler as VmmHandlerTrait, VmmMetrics, spawn::spawn_subprocess};
+use super::watchdog;
+use super::{
+    VmmController, VmmHandler as VmmHandlerTrait, VmmMetrics,
+    spawn::{ShimSpawner, SpawnedShim},
+};
 
 // ============================================================================
 // SHIM HANDLER - Runtime operations on running VM
@@ -27,34 +31,38 @@ pub struct ShimHandler {
     /// When we spawn the process, we keep the Child to properly wait() on stop.
     /// When we attach to an existing process, this is None.
     process: Option<Child>,
+    /// Watchdog keepalive. Dropping closes the pipe write end, delivering
+    /// POLLHUP to the shim and triggering graceful shutdown.
+    /// Defense-in-depth: even if `stop()` is never called, dropping the
+    /// handler closes this, triggering shim cleanup automatically.
+    #[allow(dead_code)]
+    keepalive: Option<watchdog::Keepalive>,
     /// Shared System instance for CPU metrics calculation across calls.
     /// CPU usage requires comparing snapshots over time, so we must reuse the same System.
     metrics_sys: Mutex<sysinfo::System>,
 }
 
 impl ShimHandler {
-    /// Create a handler for a spawned VM with process ownership.
+    /// Create a handler from a spawned shim.
     ///
-    /// This constructor takes ownership of the Child process handle for proper
-    /// lifecycle management (clean shutdown with wait()).
-    ///
-    /// # Arguments
-    /// * `process` - The spawned subprocess (Child handle)
-    /// * `box_id` - Box identifier (for logging)
-    pub fn from_child(process: Child, box_id: BoxID) -> Self {
-        let pid = process.id();
+    /// Takes ownership of the `SpawnedShim` (child process + keepalive) for
+    /// proper lifecycle management. The keepalive keeps the watchdog pipe
+    /// alive; dropping it triggers shim shutdown.
+    pub fn from_spawned(spawned: SpawnedShim, box_id: BoxID) -> Self {
+        let pid = spawned.child.id();
         Self {
             pid,
             box_id,
-            process: Some(process),
+            process: Some(spawned.child),
+            keepalive: spawned.keepalive,
             metrics_sys: Mutex::new(sysinfo::System::new()),
         }
     }
 
     /// Create a handler for an existing VM (attach mode).
     ///
-    /// Used when reconnecting to a running box. We don't have a Child handle,
-    /// so we manage the process by PID only.
+    /// Used when reconnecting to a running box. We don't have a Child handle
+    /// or keepalive, so we manage the process by PID only.
     ///
     /// # Arguments
     /// * `pid` - Process ID of the running VM
@@ -64,6 +72,7 @@ impl ShimHandler {
             pid,
             box_id,
             process: None,
+            keepalive: None,
             metrics_sys: Mutex::new(sysinfo::System::new()),
         }
     }
@@ -286,7 +295,6 @@ impl VmmController for ShimController {
             console_output: config.console_output.clone(),
             exit_file: config.exit_file.clone(),
             detach: config.detach,
-            parent_pid: config.parent_pid,
         };
 
         // Serialize the config for passing to subprocess
@@ -313,18 +321,18 @@ impl VmmController for ShimController {
 
         // Measure subprocess spawn time
         let shim_spawn_start = Instant::now();
-        let child = spawn_subprocess(
+        let spawner = ShimSpawner::new(
             &self.binary_path,
             self.engine_type,
-            &config_json,
             &self.layout,
             self.box_id.as_str(),
             &self.options,
-        )?;
+        );
+        let spawned = spawner.spawn(&config_json, config.detach)?;
         // spawn_duration: time to create Box subprocess
         let shim_spawn_duration = shim_spawn_start.elapsed();
 
-        let pid = child.id();
+        let pid = spawned.child.id();
         tracing::info!(
             box_id = %self.box_id,
             pid = pid,
@@ -336,9 +344,8 @@ impl VmmController for ShimController {
         // GuestConnectTask handles waiting for guest readiness,
         // which allows reusing that task across spawn/restart/reconnect.
 
-        // Create handler for the running VM
-        // Note: stdio is null (no pipes), so no LogStreamHandler needed
-        let handler = ShimHandler::from_child(child, self.box_id.clone());
+        // Create handler from spawned shim (takes ownership of child + keepalive)
+        let handler = ShimHandler::from_spawned(spawned, self.box_id.clone());
 
         tracing::info!(
             box_id = %self.box_id,

--- a/boxlite/src/vmm/controller/spawn.rs
+++ b/boxlite/src/vmm/controller/spawn.rs
@@ -13,86 +13,180 @@ use crate::vmm::VmmKind;
 use boxlite_shared::errors::{BoxliteError, BoxliteResult};
 use libkrun_sys::krun_create_ctx;
 
-/// Spawns a subprocess with jailer isolation.
+use super::watchdog;
+
+/// A shim that was spawned, with its child process handle and optional keepalive.
 ///
-/// # Arguments
-/// * `binary_path` - Path to the boxlite-shim binary
-/// * `engine_type` - Type of VM engine to use
-/// * `config_json` - Serialized BoxConfig
-/// * `layout` - Box filesystem layout (provides paths for box directory, stderr, etc.)
-/// * `box_id` - Unique box identifier
-/// * `options` - Box options (includes security and volumes)
+/// The `keepalive` holds the parent side of the watchdog pipe. While it exists,
+/// the shim's watchdog thread blocks on `poll()`. Dropping it closes the pipe
+/// write end, delivering POLLHUP to the shim and triggering graceful shutdown.
+pub struct SpawnedShim {
+    pub child: Child,
+    /// Parent-side watchdog keepalive. Dropping triggers shim shutdown.
+    /// `None` for detached boxes (no watchdog).
+    pub keepalive: Option<watchdog::Keepalive>,
+}
+
+/// Spawns `boxlite-shim` with full isolation, environment, and watchdog.
 ///
-/// # Returns
-/// * `Ok(Child)` - Successfully spawned subprocess
-/// * `Err(...)` - Failed to spawn subprocess
-pub(crate) fn spawn_subprocess(
-    binary_path: &Path,
+/// Composes: Jailer (isolation) + watchdog (lifecycle) + env/stdio setup.
+///
+/// # Fields
+///
+/// Stable inputs grouped into the struct; variable inputs (`config_json`, `detach`)
+/// are passed to [`spawn()`](Self::spawn).
+pub struct ShimSpawner<'a> {
+    binary_path: &'a Path,
     engine_type: VmmKind,
-    config_json: &str,
-    layout: &BoxFilesystemLayout,
-    box_id: &str,
-    options: &BoxOptions,
-) -> BoxliteResult<Child> {
-    // Build shim arguments
-    let shim_args = vec![
-        "--engine".to_string(),
-        format!("{:?}", engine_type),
-        "--config".to_string(),
-        config_json.to_string(),
-    ];
+    layout: &'a BoxFilesystemLayout,
+    box_id: &'a str,
+    options: &'a BoxOptions,
+}
 
-    // Create Jailer with security options and volumes
-    let jail = JailerBuilder::new()
-        .with_box_id(box_id)
-        .with_layout(layout.clone())
-        .with_security(options.advanced.security.clone())
-        .with_volumes(options.volumes.clone())
-        .build()?;
-
-    // Setup pre-spawn isolation (cgroups on Linux, no-op on macOS)
-    jail.prepare()?;
-
-    // Build isolated command (includes pre_exec FD cleanup hook)
-    let mut cmd = jail.command(binary_path, &shim_args);
-
-    // Pass debugging environment variables to subprocess
-    if let Ok(rust_log) = std::env::var("RUST_LOG") {
-        cmd.env("RUST_LOG", rust_log);
-    }
-    if let Ok(rust_backtrace) = std::env::var("RUST_BACKTRACE") {
-        cmd.env("RUST_BACKTRACE", rust_backtrace);
+impl<'a> ShimSpawner<'a> {
+    pub fn new(
+        binary_path: &'a Path,
+        engine_type: VmmKind,
+        layout: &'a BoxFilesystemLayout,
+        box_id: &'a str,
+        options: &'a BoxOptions,
+    ) -> Self {
+        Self {
+            binary_path,
+            engine_type,
+            layout,
+            box_id,
+            options,
+        }
     }
 
-    // Set library search paths for bundled dependencies
-    configure_library_env(&mut cmd, krun_create_ctx as *const libc::c_void);
+    /// Spawn the shim subprocess with jailer isolation and optional watchdog.
+    ///
+    /// When `detach` is false, creates a watchdog pipe so the shim detects
+    /// parent death via POLLHUP. When `detach` is true, no watchdog is created.
+    ///
+    /// # Returns
+    /// * `SpawnedShim` containing the child process and optional keepalive
+    pub fn spawn(&self, config_json: &str, detach: bool) -> BoxliteResult<SpawnedShim> {
+        // 1. Create watchdog pipe (non-detached only)
+        let (keepalive, child_setup) = if !detach {
+            let (k, s) = watchdog::create()?;
+            (Some(k), Some(s))
+        } else {
+            (None, None)
+        };
 
-    // Create stderr file BEFORE spawn to capture ALL errors including pre-main dyld errors.
-    // This is critical: dyld errors happen before main() and would go to /dev/null otherwise.
-    let stderr_file_path = layout.stderr_file_path();
-    let stderr_file = std::fs::File::create(&stderr_file_path).map_err(|e| {
-        BoxliteError::Storage(format!(
-            "Failed to create stderr file {}: {}",
-            stderr_file_path.display(),
-            e
-        ))
-    })?;
+        // 2. Build jailer with optional FD preservation for watchdog pipe
+        let mut builder = JailerBuilder::new()
+            .with_box_id(self.box_id)
+            .with_layout(self.layout.clone())
+            .with_security(self.options.advanced.security.clone())
+            .with_volumes(self.options.volumes.clone());
 
-    // Use null for stdin/stdout to support detach/reattach without pipe issues.
-    // - stdin: prevents libkrun from affecting parent's stdin
-    // - stdout: prevents SIGPIPE when LogStreamHandler is dropped on detach
-    // - stderr: captured to file for crash diagnostics
-    cmd.stdin(Stdio::null());
-    cmd.stdout(Stdio::null());
-    cmd.stderr(Stdio::from(stderr_file));
+        if let Some(ref setup) = child_setup {
+            builder = builder.with_preserved_fd(setup.raw_fd(), watchdog::PIPE_FD);
+        }
 
-    cmd.spawn().map_err(|e| {
-        let err_msg = format!(
-            "Failed to spawn VM subprocess at {}: {}",
-            binary_path.display(),
-            e
+        let jail = builder.build()?;
+
+        // 3. Setup pre-spawn isolation (cgroups on Linux, no-op on macOS)
+        jail.prepare()?;
+
+        // 4. Build isolated command (includes pre_exec hook)
+        let shim_args = self.build_shim_args(config_json);
+        let mut cmd = jail.command(self.binary_path, &shim_args);
+
+        // 5. Configure environment
+        self.configure_env(&mut cmd);
+
+        // 6. Configure stdio (stdin/stdout=null, stderr=file)
+        let stderr_file = self.create_stderr_file()?;
+        cmd.stdin(Stdio::null());
+        cmd.stdout(Stdio::null());
+        cmd.stderr(Stdio::from(stderr_file));
+
+        // 7. Spawn
+        let child = cmd.spawn().map_err(|e| {
+            let err_msg = format!(
+                "Failed to spawn VM subprocess at {}: {}",
+                self.binary_path.display(),
+                e
+            );
+            tracing::error!("{}", err_msg);
+            BoxliteError::Engine(err_msg)
+        })?;
+
+        // 8. Close read end in parent (child inherited it via fork)
+        drop(child_setup);
+
+        Ok(SpawnedShim { child, keepalive })
+    }
+
+    fn build_shim_args(&self, config_json: &str) -> Vec<String> {
+        vec![
+            "--engine".to_string(),
+            format!("{:?}", self.engine_type),
+            "--config".to_string(),
+            config_json.to_string(),
+        ]
+    }
+
+    fn configure_env(&self, cmd: &mut std::process::Command) {
+        // Pass debugging environment variables to subprocess
+        if let Ok(rust_log) = std::env::var("RUST_LOG") {
+            cmd.env("RUST_LOG", rust_log);
+        }
+        if let Ok(rust_backtrace) = std::env::var("RUST_BACKTRACE") {
+            cmd.env("RUST_BACKTRACE", rust_backtrace);
+        }
+
+        // Set library search paths for bundled dependencies
+        configure_library_env(cmd, krun_create_ctx as *const libc::c_void);
+    }
+
+    fn create_stderr_file(&self) -> BoxliteResult<std::fs::File> {
+        // Create stderr file BEFORE spawn to capture ALL errors including pre-main dyld errors.
+        // This is critical: dyld errors happen before main() and would go to /dev/null otherwise.
+        let stderr_file_path = self.layout.stderr_file_path();
+        std::fs::File::create(&stderr_file_path).map_err(|e| {
+            BoxliteError::Storage(format!(
+                "Failed to create stderr file {}: {}",
+                stderr_file_path.display(),
+                e
+            ))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_shim_args() {
+        use crate::runtime::layout::{BoxFilesystemLayout, FsLayoutConfig};
+        use std::path::PathBuf;
+
+        let layout = BoxFilesystemLayout::new(
+            PathBuf::from("/tmp/box"),
+            FsLayoutConfig::without_bind_mount(),
+            false,
         );
-        tracing::error!("{}", err_msg);
-        BoxliteError::Engine(err_msg)
-    })
+        let options = BoxOptions::default();
+
+        let spawner = ShimSpawner::new(
+            Path::new("/usr/bin/boxlite-shim"),
+            VmmKind::Libkrun,
+            &layout,
+            "test-box",
+            &options,
+        );
+
+        let args = spawner.build_shim_args("{\"test\":true}");
+        assert_eq!(args.len(), 4);
+        assert_eq!(args[0], "--engine");
+        assert_eq!(args[1], "Libkrun");
+        assert_eq!(args[2], "--config");
+        assert_eq!(args[3], "{\"test\":true}");
+    }
 }

--- a/boxlite/src/vmm/controller/watchdog.rs
+++ b/boxlite/src/vmm/controller/watchdog.rs
@@ -1,0 +1,147 @@
+//! Watchdog pipe for parent death detection.
+//!
+//! Implements the "pipe trick" — the parent holds the write end of a pipe,
+//! the child polls the read end. When the parent dies (or drops the keepalive),
+//! the kernel closes the write end, delivering POLLHUP to the child.
+//!
+//! This is zero-latency, tamper-proof (kernel FDs), and works across
+//! PID/mount namespaces — the gold standard used by s6, containerd-shim,
+//! runc, crun, and conmon.
+
+use boxlite_shared::errors::{BoxliteError, BoxliteResult};
+use std::os::fd::{FromRawFd, OwnedFd, RawFd};
+
+/// Well-known FD for the watchdog pipe in the shim process.
+/// Pre-exec dup2s the inherited pipe read end to this position.
+pub const PIPE_FD: i32 = 3;
+
+/// Parent-side keepalive handle.
+///
+/// While this exists, the shim's watchdog thread blocks on poll().
+/// Dropping this closes the pipe write end, delivering POLLHUP to the shim,
+/// which triggers graceful shutdown.
+///
+/// Defense-in-depth: even if `stop()` is never called, dropping the
+/// `ShimHandler` closes this, triggering shim cleanup automatically.
+pub struct Keepalive {
+    _pipe_write: OwnedFd,
+}
+
+/// Child-side setup data, consumed during subprocess spawn.
+///
+/// Carries the raw FD that must be preserved through pre_exec.
+/// Dropped in the parent after spawn to close the read end
+/// (child already inherited it via fork).
+pub struct ChildSetup {
+    pipe_read: RawFd,
+}
+
+impl ChildSetup {
+    /// Raw FD to preserve through pre_exec FD cleanup.
+    /// Will be dup2'd to [`PIPE_FD`] by the pre_exec hook.
+    pub fn raw_fd(&self) -> RawFd {
+        self.pipe_read
+    }
+}
+
+impl Drop for ChildSetup {
+    fn drop(&mut self) {
+        // SAFETY: closing a valid pipe read-end FD.
+        unsafe {
+            libc::close(self.pipe_read);
+        }
+    }
+}
+
+/// Create a watchdog pipe pair.
+///
+/// Returns `(keepalive, child_setup)`. The parent holds the keepalive;
+/// the child setup is consumed during spawn to configure FD inheritance.
+pub fn create() -> BoxliteResult<(Keepalive, ChildSetup)> {
+    let mut fds = [0i32; 2];
+    // SAFETY: pipe() writes two valid FDs into the array.
+    if unsafe { libc::pipe(fds.as_mut_ptr()) } != 0 {
+        return Err(BoxliteError::Engine(format!(
+            "Failed to create watchdog pipe: {}",
+            std::io::Error::last_os_error()
+        )));
+    }
+    Ok((
+        Keepalive {
+            // SAFETY: fds[1] is a valid write-end FD from pipe().
+            _pipe_write: unsafe { OwnedFd::from_raw_fd(fds[1]) },
+        },
+        ChildSetup { pipe_read: fds[0] },
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_returns_valid_fds() {
+        let (keepalive, child_setup) = create().expect("pipe creation should succeed");
+        let read_fd = child_setup.raw_fd();
+
+        // Both FDs should be valid (>= 0)
+        assert!(read_fd >= 0, "read fd should be valid");
+
+        // Verify read_fd is open via fcntl
+        let result = unsafe { libc::fcntl(read_fd, libc::F_GETFD) };
+        assert!(result >= 0, "read fd should be open");
+
+        drop(child_setup);
+        drop(keepalive);
+    }
+
+    #[test]
+    fn test_child_setup_raw_fd() {
+        let (_keepalive, child_setup) = create().expect("pipe creation should succeed");
+        let fd = child_setup.raw_fd();
+        assert!(fd >= 3, "pipe fd should be >= 3 (not stdin/stdout/stderr)");
+        drop(child_setup);
+    }
+
+    #[test]
+    fn test_child_setup_drop_closes_read_end() {
+        let (_keepalive, child_setup) = create().expect("pipe creation should succeed");
+        let read_fd = child_setup.raw_fd();
+
+        // FD should be open
+        assert!(unsafe { libc::fcntl(read_fd, libc::F_GETFD) } >= 0);
+
+        // Drop closes the read end
+        drop(child_setup);
+
+        // FD should be closed (fcntl returns -1 with EBADF)
+        assert_eq!(unsafe { libc::fcntl(read_fd, libc::F_GETFD) }, -1);
+    }
+
+    #[test]
+    fn test_keepalive_drop_closes_write_end_triggers_pollhup() {
+        let (keepalive, child_setup) = create().expect("pipe creation should succeed");
+        let read_fd = child_setup.raw_fd();
+
+        // Drop keepalive — closes write end
+        drop(keepalive);
+
+        // Poll read_fd — should get POLLHUP immediately.
+        // Use POLLIN in events for macOS compatibility (macOS poll() may not
+        // wake on POLLHUP alone when events mask is empty).
+        let mut pollfd = libc::pollfd {
+            fd: read_fd,
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        let ret = unsafe { libc::poll(&mut pollfd, 1, 100) }; // 100ms timeout
+        assert_eq!(ret, 1, "poll should return 1 (one fd ready)");
+        assert_ne!(
+            pollfd.revents & libc::POLLHUP,
+            0,
+            "should get POLLHUP when write end is closed"
+        );
+
+        drop(child_setup);
+    }
+}

--- a/boxlite/src/vmm/mod.rs
+++ b/boxlite/src/vmm/mod.rs
@@ -179,11 +179,8 @@ pub struct InstanceSpec {
     /// Exit file for shim to write on panic (Podman pattern).
     pub exit_file: PathBuf,
     /// Whether the box should continue running when the parent process exits.
-    /// When false, a watchdog thread monitors parent PID and triggers shutdown.
+    /// When false, the shim detects parent death via watchdog pipe POLLHUP.
     pub detach: bool,
-    /// PID of the parent process that spawned this box.
-    /// Used by watchdog to detect when parent exits (if detach=false).
-    pub parent_pid: u32,
 }
 
 /// Entrypoint configuration that the guest should run.


### PR DESCRIPTION
## Summary

- Replace `kill(parent_pid, 0)` polling with the **pipe trick** for parent death detection — zero latency, kernel-mediated, works across PID/mount namespaces
- New `watchdog` module with `Keepalive`/`ChildSetup` types; parent holds write end, shim polls read end for POLLHUP
- `JailerBuilder` gains `preserved_fd` support to inherit the watchdog pipe through pre_exec FD cleanup
- `ShimSpawner` struct replaces `spawn_subprocess()` free function, returning `SpawnedShim` with child + keepalive
- `ShimHandler` stores `Keepalive` for defense-in-depth (dropping handler triggers shim shutdown even if `stop()` is never called)
- Remove `parent_pid` from `InstanceSpec` (no longer needed)

## Test plan

- [x] Unit tests: watchdog pipe creation, FD validity, close behavior, POLLHUP delivery (4 tests)
- [x] Unit tests: JailerBuilder preserved_fd, pre_exec FD handling, ShimSpawner args (12 tests)
- [x] Integration test: `non_detached_box_exits_on_runtime_drop` — verifies full chain: Keepalive drop → pipe close → POLLHUP → SIGTERM → shim exit
- [x] Symmetric pair with existing `detached_box_survives_runtime_drop` (detached boxes survive, non-detached boxes exit)
- [x] `cargo clippy --tests` clean, `cargo fmt` clean