### PR TITLE
Revert: enable jailer by default + fix macOS library patterns

### DIFF
--- a/boxlite/src/jailer/shim_copy.rs
+++ b/boxlite/src/jailer/shim_copy.rs
@@ -34,7 +34,7 @@ use std::path::{Path, PathBuf};
 const BUNDLED_LIB_PATTERNS: &[&str] = &["libkrun.so", "libkrunfw.so", "libgvproxy.so"];
 
 #[cfg(target_os = "macos")]
-const BUNDLED_LIB_PATTERNS: &[&str] = &["libkrun.", "libkrunfw.", "libgvproxy."];
+const BUNDLED_LIB_PATTERNS: &[&str] = &["libkrun.dylib", "libkrunfw.dylib", "libgvproxy.dylib"];
 
 #[cfg(not(any(target_os = "linux", target_os = "macos")))]
 const BUNDLED_LIB_PATTERNS: &[&str] = &[];
@@ -176,9 +176,9 @@ mod tests {
         }
         #[cfg(target_os = "macos")]
         {
-            assert!(BUNDLED_LIB_PATTERNS.contains(&"libkrun."));
-            assert!(BUNDLED_LIB_PATTERNS.contains(&"libkrunfw."));
-            assert!(BUNDLED_LIB_PATTERNS.contains(&"libgvproxy."));
+            assert!(BUNDLED_LIB_PATTERNS.contains(&"libkrun.dylib"));
+            assert!(BUNDLED_LIB_PATTERNS.contains(&"libkrunfw.dylib"));
+            assert!(BUNDLED_LIB_PATTERNS.contains(&"libgvproxy.dylib"));
         }
     }
 
@@ -204,9 +204,9 @@ mod tests {
 
         #[cfg(target_os = "macos")]
         {
-            // Should match (versioned dylibs)
-            assert!(patterns.iter().any(|p| "libkrun.1.16.0.dylib".starts_with(p)));
-            assert!(patterns.iter().any(|p| "libkrunfw.5.dylib".starts_with(p)));
+            // Should match
+            assert!(patterns.iter().any(|p| "libkrun.dylib".starts_with(p)));
+            assert!(patterns.iter().any(|p| "libkrunfw.dylib".starts_with(p)));
             assert!(patterns.iter().any(|p| "libgvproxy.dylib".starts_with(p)));
 
             // Should not match

--- a/boxlite/src/runtime/advanced_options.rs
+++ b/boxlite/src/runtime/advanced_options.rs
@@ -23,7 +23,7 @@ pub struct SecurityOptions {
     /// - Linux: seccomp, namespaces, chroot, privilege drop
     /// - macOS: sandbox-exec profile
     ///
-    /// Default: true on Linux/macOS, false on other platforms
+    /// Default: false
     #[serde(default = "default_jailer_enabled")]
     pub jailer_enabled: bool,
 
@@ -143,7 +143,7 @@ pub struct ResourceLimits {
 // Default value functions for SecurityOptions
 
 fn default_jailer_enabled() -> bool {
-    cfg!(any(target_os = "linux", target_os = "macos"))
+    false
 }
 
 fn default_seccomp_enabled() -> bool {


### PR DESCRIPTION
## Summary
- Reverts commit ff64289 which enabled jailer by default on Linux/macOS and changed macOS library matching patterns to prefix-based

## Reverted Changes
- `jailer_enabled` default: `true` on Linux/macOS → `false`
- macOS `BUNDLED_LIB_PATTERNS`: prefix patterns (`libkrun.`) → exact names (`libkrun.dylib`)

## Test plan
- [ ] `cargo test -p boxlite` passes
- [ ] `cargo clippy -p boxlite --tests -- -D warnings` clean