### PR TITLE
ci: add Codecov integration with OIDC auth

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,6 +84,8 @@ jobs:
       matrix:
         platform: ${{ fromJson(needs.config.outputs.platforms) }}
 
+    permissions:
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -117,10 +119,11 @@ jobs:
         run: cargo llvm-cov nextest -p boxlite-shared --lib --profile ci --lcov --output-path lcov.info
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           file: lcov.info
           flags: rust-shared
+          use_oidc: true
           fail_ci_if_error: false
 
   # cli unit tests (integration tests in tests/ are ignored - require VM)

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![GitHub stars](https://img.shields.io/github/stars/boxlite-ai/boxlite?style=social)](https://github.com/boxlite-ai/boxlite)
 [![Build](https://github.com/boxlite-ai/boxlite/actions/workflows/build-wheels.yml/badge.svg)](https://github.com/boxlite-ai/boxlite/actions/workflows/build-wheels.yml)
 [![Lint](https://github.com/boxlite-ai/boxlite/actions/workflows/lint.yml/badge.svg)](https://github.com/boxlite-ai/boxlite/actions/workflows/lint.yml)
+[![codecov](https://codecov.io/gh/boxlite-ai/boxlite/branch/main/graph/badge.svg)](https://codecov.io/gh/boxlite-ai/boxlite)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 Local-first micro-VM sandbox for **AI agents** — stateful, lightweight,

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,23 @@
+# Codecov configuration for BoxLite
+# Docs: https://docs.codecov.io/docs/codecov-yaml
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto    # Track against historical baseline
+        threshold: 2%   # Allow 2% drop before failing
+    patch:
+      default:
+        target: 70%     # New code in PRs must be 70% covered
+
+comment:
+  layout: "condensed_header, diff, flags, components"
+  behavior: default
+  require_changes: true   # Only comment if coverage changed
+
+ignore:
+  - "boxlite/deps/**"     # Vendored dependencies
+  - "**/tests/**"         # Test files themselves
+  - "guest/**"            # Guest agent (tested separately)
+  - "sdks/**"             # SDKs (have their own test suites)


### PR DESCRIPTION
## Summary
- Adds `codecov.yml` with PR comment config, patch/project coverage targets, and path exclusions for non-source directories
- Bumps `codecov-action` to v5 with OIDC authentication (eliminates need for `CODECOV_TOKEN` secret)
- Adds `id-token: write` permission to the `rust` CI job for GitHub OIDC token issuance
- Adds coverage badge to README

## Test plan
- [ ] CI "Upload coverage to Codecov" step succeeds without token errors
- [ ] Codecov bot posts a coverage comment on this PR
- [ ] Coverage badge renders in README
- [ ] codecov.io dashboard shows the repo