### PR TITLE
Reference server: BOXLITE_SERVER/BOXLITE_RUNTIME env config + non-detached handle retention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,7 @@ yarn-error.log*
 *.mobileprovision
 .env
 .env.*
+!/openapi/reference-server/.env.example
 
 # ============================================================================
 # Project Specific

--- a/examples/python/08_rest_api/README.md
+++ b/examples/python/08_rest_api/README.md
@@ -21,12 +21,26 @@ Start the reference server before running any example:
 
 ```bash
 make dev:python
+
+# Optional: copy server defaults for local development
+cp openapi/reference-server/.env.example openapi/reference-server/.env
+
 cd openapi/reference-server
-uv run --active server.py --port 8080
+uv run --active server.py
 ```
 
 Then run examples from this directory:
 
 ```bash
 python connect_and_list.py
+```
+
+For env-based client configuration (`use_env_config.py`), set:
+
+```bash
+BOXLITE_REST_URL=http://localhost:8080
+BOXLITE_REST_CLIENT_ID=test-client
+BOXLITE_REST_CLIENT_SECRET=test-secret
+# Optional (default in SDK is v1):
+BOXLITE_REST_PREFIX=v1
 ```

--- a/examples/python/08_rest_api/use_env_config.py
+++ b/examples/python/08_rest_api/use_env_config.py
@@ -10,7 +10,7 @@ Environment variables:
     BOXLITE_REST_URL          Server URL (required)
     BOXLITE_REST_CLIENT_ID    OAuth2 client ID
     BOXLITE_REST_CLIENT_SECRET OAuth2 client secret
-    BOXLITE_REST_PREFIX       API path prefix (default: /v1/demo)
+    BOXLITE_REST_PREFIX       API version prefix (default: v1)
 
 Usage:
     BOXLITE_REST_URL=http://localhost:8080 \

--- a/openapi/reference-server/.env.example
+++ b/openapi/reference-server/.env.example
@@ -1,0 +1,25 @@
+# ============================================================================
+# BoxLite REST Reference Server
+# ============================================================================
+# Development defaults only. Do not use these credentials or secrets in production.
+
+BOXLITE_SERVER_HOST=0.0.0.0
+BOXLITE_SERVER_PORT=8080
+BOXLITE_SERVER_LOG_LEVEL=info
+BOXLITE_SERVER_JWT_SECRET=boxlite-reference-server-secret
+BOXLITE_SERVER_JWT_EXPIRY_SECONDS=3600
+BOXLITE_SERVER_CLIENT_ID=test-client
+BOXLITE_SERVER_CLIENT_SECRET=test-secret
+
+# ============================================================================
+# BoxLite Runtime Options (consumed by openapi/reference-server/server.py)
+# ============================================================================
+# Use an absolute path.
+BOXLITE_RUNTIME_HOME_DIR=/tmp/boxlite-reference-server
+# Comma-separated list, first successful pull wins.
+BOXLITE_RUNTIME_IMAGE_REGISTRIES=mirror.gcr.io,docker.io
+
+# ============================================================================
+# Optional debugging
+# ============================================================================
+# RUST_LOG=debug

--- a/openapi/reference-server/README.md
+++ b/openapi/reference-server/README.md
@@ -3,7 +3,7 @@
 Reference implementation of the [BoxLite Cloud Sandbox REST API](../rest-sandbox-open-api.yaml).
 Use this to validate client implementations against the spec.
 
-**Not production-ready** — no persistence, hardcoded auth, single-tenant.
+**Not production-ready** — no persistence, single-tenant.
 
 ## Setup
 
@@ -11,9 +11,12 @@ Use this to validate client implementations against the spec.
 # 1. Build the BoxLite Python SDK (installs into project .venv)
 make dev:python
 
-# 2. Start the server (uv installs server deps, --active uses the project .venv)
+# 2. (Optional) Copy server defaults for local development
+cp openapi/reference-server/.env.example openapi/reference-server/.env
+
+# 3. Start the server (uv installs server deps, --active uses the project .venv)
 cd openapi/reference-server
-uv run --active server.py --port 8080
+uv run --active server.py
 ```
 
 ## Test Credentials
@@ -98,5 +101,37 @@ curl -s -X DELETE http://localhost:8080/v1/demo/boxes/$BOX_ID \
 ## CLI Options
 
 ```
-uv run --active server.py [--host 0.0.0.0] [--port 8080] [--log-level info]
+uv run --active server.py [--env-file /path/to/.env] [--host 0.0.0.0] [--port 8080] [--log-level info]
 ```
+
+## Environment Configuration
+
+The server supports `openapi/reference-server/.env` by default.
+Use `--env-file` to load a different file.
+
+### Server Settings (`BOXLITE_SERVER_*`)
+
+| Variable | Default |
+|----------|---------|
+| `BOXLITE_SERVER_HOST` | `0.0.0.0` |
+| `BOXLITE_SERVER_PORT` | `8080` |
+| `BOXLITE_SERVER_LOG_LEVEL` | `info` |
+| `BOXLITE_SERVER_JWT_SECRET` | `boxlite-reference-server-secret` |
+| `BOXLITE_SERVER_JWT_EXPIRY_SECONDS` | `3600` |
+| `BOXLITE_SERVER_CLIENT_ID` | `test-client` |
+| `BOXLITE_SERVER_CLIENT_SECRET` | `test-secret` |
+
+### Runtime Settings (`BOXLITE_RUNTIME_*`)
+
+| Variable | Default |
+|----------|---------|
+| `BOXLITE_RUNTIME_HOME_DIR` | `~/.boxlite` |
+| `BOXLITE_RUNTIME_IMAGE_REGISTRIES` | `mirror.gcr.io,docker.io` |
+
+### Precedence
+
+For `host`, `port`, and `log-level`:
+
+1. CLI args (`--host`, `--port`, `--log-level`)
+2. Environment (`BOXLITE_SERVER_*`)
+3. Built-in defaults

--- a/openapi/reference-server/config.py
+++ b/openapi/reference-server/config.py
@@ -1,0 +1,251 @@
+"""Configuration parsing helpers for the BoxLite reference server."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+from dotenv import load_dotenv
+
+# Server env vars
+ENV_SERVER_HOST = "BOXLITE_SERVER_HOST"
+ENV_SERVER_PORT = "BOXLITE_SERVER_PORT"
+ENV_SERVER_LOG_LEVEL = "BOXLITE_SERVER_LOG_LEVEL"
+ENV_SERVER_JWT_SECRET = "BOXLITE_SERVER_JWT_SECRET"
+ENV_SERVER_JWT_EXPIRY_SECONDS = "BOXLITE_SERVER_JWT_EXPIRY_SECONDS"
+ENV_SERVER_CLIENT_ID = "BOXLITE_SERVER_CLIENT_ID"
+ENV_SERVER_CLIENT_SECRET = "BOXLITE_SERVER_CLIENT_SECRET"
+
+# Runtime env vars (reference-server local contract)
+ENV_RUNTIME_HOME_DIR = "BOXLITE_RUNTIME_HOME_DIR"
+ENV_RUNTIME_IMAGE_REGISTRIES = "BOXLITE_RUNTIME_IMAGE_REGISTRIES"
+
+DEFAULT_SERVER_HOST = "0.0.0.0"
+DEFAULT_SERVER_PORT = 8080
+DEFAULT_SERVER_LOG_LEVEL = "info"
+DEFAULT_SERVER_JWT_SECRET = "boxlite-reference-server-secret"
+DEFAULT_SERVER_JWT_EXPIRY_SECONDS = 3600
+DEFAULT_SERVER_CLIENT_ID = "test-client"
+DEFAULT_SERVER_CLIENT_SECRET = "test-secret"
+DEFAULT_RUNTIME_IMAGE_REGISTRIES = ["mirror.gcr.io", "docker.io"]
+DEFAULT_ENV_FILE_PATH = Path(__file__).resolve().parent / ".env"
+
+_ALLOWED_LOG_LEVELS = {
+    "critical",
+    "error",
+    "warning",
+    "warn",
+    "info",
+    "debug",
+    "trace",
+}
+
+
+@dataclass(frozen=True)
+class ServerConfig:
+    host: str
+    port: int
+    log_level: str
+    jwt_secret: str
+    jwt_expiry_seconds: int
+    client_id: str
+    client_secret: str
+
+
+@dataclass(frozen=True)
+class RuntimeConfig:
+    home_dir: str
+    image_registries: list[str]
+
+
+def default_runtime_home_dir() -> str:
+    try:
+        home_dir = Path.home()
+    except RuntimeError:
+        home_dir = Path(".").resolve()
+    return str(home_dir / ".boxlite")
+
+
+def parse_bootstrap_env_file(argv: Sequence[str] | None = None) -> str | None:
+    """Parse only --env-file before loading environment defaults."""
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--env-file", default=None)
+    args, _ = parser.parse_known_args(argv)
+    return args.env_file
+
+
+def load_env_file(env_file: str | None) -> Path | None:
+    """Load .env without overriding existing process env vars."""
+    if env_file:
+        path = Path(env_file).expanduser()
+    else:
+        path = DEFAULT_ENV_FILE_PATH
+
+    if not path.exists():
+        if env_file:
+            raise ValueError(f"--env-file path does not exist: {path}")
+        return None
+
+    load_dotenv(path, override=False)
+    return path
+
+
+def parse_int_env(
+    name: str,
+    default: int,
+    *,
+    minimum: int | None = None,
+    maximum: int | None = None,
+) -> int:
+    raw_value = os.getenv(name)
+    if raw_value is None:
+        value = default
+    else:
+        text = raw_value.strip()
+        if not text:
+            raise ValueError(f"{name} cannot be empty")
+        try:
+            value = int(text)
+        except ValueError as err:
+            raise ValueError(f"{name} must be an integer, got: {raw_value!r}") from err
+
+    if minimum is not None and value < minimum:
+        raise ValueError(f"{name} must be >= {minimum}, got: {value}")
+    if maximum is not None and value > maximum:
+        raise ValueError(f"{name} must be <= {maximum}, got: {value}")
+    return value
+
+
+def parse_csv_env(name: str, default: Sequence[str]) -> list[str]:
+    raw_value = os.getenv(name)
+    if raw_value is None:
+        return list(default)
+
+    values = [part.strip() for part in raw_value.split(",")]
+    if not values or any(not item for item in values):
+        raise ValueError(
+            f"{name} must be a comma-separated list with non-empty values, got: {raw_value!r}"
+        )
+    return values
+
+
+def normalize_log_level(value: str) -> str:
+    if value is None:
+        raise ValueError("log level cannot be None")
+    level = value.strip().lower()
+    if not level:
+        raise ValueError("log level cannot be empty")
+    if level not in _ALLOWED_LOG_LEVELS:
+        allowed = ", ".join(sorted(_ALLOWED_LOG_LEVELS))
+        raise ValueError(f"log level must be one of: {allowed}; got: {value!r}")
+    if level == "warn":
+        return "warning"
+    return level
+
+
+def parse_log_level_env(name: str, default: str) -> str:
+    raw_value = os.getenv(name)
+    return normalize_log_level(raw_value if raw_value is not None else default)
+
+
+def logging_level_from_name(level: str) -> int:
+    if level == "trace":
+        return logging.DEBUG
+    return getattr(logging, level.upper())
+
+
+def _parse_cli_port(value: str) -> int:
+    try:
+        port = int(value)
+    except ValueError as err:
+        raise argparse.ArgumentTypeError(f"invalid port {value!r}: must be an integer") from err
+    if port < 1 or port > 65535:
+        raise argparse.ArgumentTypeError(
+            f"invalid port {value!r}: must be between 1 and 65535"
+        )
+    return port
+
+
+def _parse_cli_log_level(value: str) -> str:
+    try:
+        return normalize_log_level(value)
+    except ValueError as err:
+        raise argparse.ArgumentTypeError(str(err)) from err
+
+
+def build_main_parser(defaults: ServerConfig) -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="BoxLite REST API Reference Server")
+    parser.add_argument(
+        "--env-file",
+        default=None,
+        help=(
+            "Path to .env file (loaded before parsing other args). "
+            "If omitted, uses openapi/reference-server/.env when present."
+        ),
+    )
+    parser.add_argument("--host", default=defaults.host, help="Bind address")
+    parser.add_argument("--port", type=_parse_cli_port, default=defaults.port, help="Bind port")
+    parser.add_argument(
+        "--log-level",
+        type=_parse_cli_log_level,
+        default=defaults.log_level,
+        help="Log level (critical,error,warning,info,debug,trace)",
+    )
+    return parser
+
+
+def load_server_config_from_env() -> ServerConfig:
+    host = os.getenv(ENV_SERVER_HOST, DEFAULT_SERVER_HOST).strip()
+    if not host:
+        raise ValueError(f"{ENV_SERVER_HOST} cannot be empty")
+
+    jwt_secret = os.getenv(ENV_SERVER_JWT_SECRET, DEFAULT_SERVER_JWT_SECRET).strip()
+    if not jwt_secret:
+        raise ValueError(f"{ENV_SERVER_JWT_SECRET} cannot be empty")
+
+    client_id = os.getenv(ENV_SERVER_CLIENT_ID, DEFAULT_SERVER_CLIENT_ID).strip()
+    if not client_id:
+        raise ValueError(f"{ENV_SERVER_CLIENT_ID} cannot be empty")
+
+    client_secret = os.getenv(
+        ENV_SERVER_CLIENT_SECRET, DEFAULT_SERVER_CLIENT_SECRET
+    ).strip()
+    if not client_secret:
+        raise ValueError(f"{ENV_SERVER_CLIENT_SECRET} cannot be empty")
+
+    return ServerConfig(
+        host=host,
+        port=parse_int_env(ENV_SERVER_PORT, DEFAULT_SERVER_PORT, minimum=1, maximum=65535),
+        log_level=parse_log_level_env(ENV_SERVER_LOG_LEVEL, DEFAULT_SERVER_LOG_LEVEL),
+        jwt_secret=jwt_secret,
+        jwt_expiry_seconds=parse_int_env(
+            ENV_SERVER_JWT_EXPIRY_SECONDS,
+            DEFAULT_SERVER_JWT_EXPIRY_SECONDS,
+            minimum=1,
+        ),
+        client_id=client_id,
+        client_secret=client_secret,
+    )
+
+
+def load_runtime_config_from_env() -> RuntimeConfig:
+    raw_home_dir = os.getenv(ENV_RUNTIME_HOME_DIR, default_runtime_home_dir()).strip()
+    if not raw_home_dir:
+        raise ValueError(f"{ENV_RUNTIME_HOME_DIR} cannot be empty")
+
+    home_dir = Path(raw_home_dir).expanduser()
+    if not home_dir.is_absolute():
+        raise ValueError(
+            f"{ENV_RUNTIME_HOME_DIR} must be an absolute path, got: {raw_home_dir!r}"
+        )
+
+    return RuntimeConfig(
+        home_dir=str(home_dir),
+        image_registries=parse_csv_env(
+            ENV_RUNTIME_IMAGE_REGISTRIES, DEFAULT_RUNTIME_IMAGE_REGISTRIES
+        ),
+    )

--- a/openapi/reference-server/server.py
+++ b/openapi/reference-server/server.py
@@ -7,6 +7,7 @@
 #     "sse-starlette>=2.0",
 #     "PyJWT>=2.8",
 #     "python-multipart>=0.0.9",
+#     "python-dotenv>=1.0",
 # ]
 # ///
 """
@@ -20,18 +21,18 @@ NOT production-ready — no persistence, no real auth, single-tenant.
 
 Usage:
     make dev:python  # build boxlite SDK
-    uv run --active server.py --port 8080
+    uv run --active server.py
 """
 
 from __future__ import annotations
 
-import argparse
 import asyncio
 import base64
 import io
 import json
 import logging
 import os
+import sys
 import tarfile
 import tempfile
 import time
@@ -59,18 +60,24 @@ from pydantic import BaseModel, Field
 from sse_starlette.sse import EventSourceResponse, ServerSentEvent
 
 import boxlite
+from config import (
+    DEFAULT_ENV_FILE_PATH,
+    ServerConfig,
+    RuntimeConfig,
+    build_main_parser,
+    load_env_file,
+    load_runtime_config_from_env,
+    load_server_config_from_env,
+    logging_level_from_name,
+    normalize_log_level,
+    parse_bootstrap_env_file,
+)
 
 # ============================================================================
 # Configuration
 # ============================================================================
 
-JWT_SECRET = "boxlite-reference-server-secret"  # NOT for production
 JWT_ALGORITHM = "HS256"
-JWT_EXPIRY_SECONDS = 3600
-
-# Hardcoded test credentials
-TEST_CLIENT_ID = "test-client"
-TEST_CLIENT_SECRET = "test-secret"
 
 logger = logging.getLogger("boxlite-server")
 
@@ -165,10 +172,20 @@ class ActiveExecution:
 class AppState:
     def __init__(self):
         self.runtime: Optional[boxlite.Boxlite] = None
+        self.server_config: Optional[ServerConfig] = None
+        self.runtime_config: Optional[RuntimeConfig] = None
         self.active_executions: dict[str, ActiveExecution] = {}
+        self.active_boxes_by_id: dict[str, Any] = {}
+        self.active_boxes_lock = asyncio.Lock()
 
 
 state = AppState()
+
+
+def get_server_config() -> ServerConfig:
+    if state.server_config is None:
+        raise RuntimeError("server configuration not initialized")
+    return state.server_config
 
 # ============================================================================
 # Error Mapping
@@ -220,19 +237,20 @@ bearer_scheme = HTTPBearer(auto_error=False)
 
 
 def create_token(client_id: str, scopes: str = "") -> dict:
+    config = get_server_config()
     now = time.time()
     payload = {
         "sub": client_id,
         "iat": now,
-        "exp": now + JWT_EXPIRY_SECONDS,
+        "exp": now + config.jwt_expiry_seconds,
         "scope": scopes
         or "boxes:read boxes:write boxes:exec images:read images:write runtime:admin",
     }
-    token = jwt.encode(payload, JWT_SECRET, algorithm=JWT_ALGORITHM)
+    token = jwt.encode(payload, config.jwt_secret, algorithm=JWT_ALGORITHM)
     return {
         "access_token": token,
         "token_type": "bearer",
-        "expires_in": JWT_EXPIRY_SECONDS,
+        "expires_in": config.jwt_expiry_seconds,
         "scope": payload["scope"],
     }
 
@@ -252,8 +270,9 @@ async def require_auth(
             },
         )
     try:
+        config = get_server_config()
         payload = jwt.decode(
-            credentials.credentials, JWT_SECRET, algorithms=[JWT_ALGORITHM]
+            credentials.credentials, config.jwt_secret, algorithms=[JWT_ALGORITHM]
         )
         return payload
     except jwt.ExpiredSignatureError:
@@ -360,7 +379,33 @@ def snapshot_info_to_dict(info) -> dict:
     }
 
 
+async def cache_box_handle(box_handle: Any) -> str:
+    box_id = box_handle.info().id
+    async with state.active_boxes_lock:
+        state.active_boxes_by_id[box_id] = box_handle
+    return box_id
+
+
+async def get_cached_box_handle(box_id: str) -> Optional[Any]:
+    async with state.active_boxes_lock:
+        return state.active_boxes_by_id.get(box_id)
+
+
+async def evict_cached_box_by_id(box_id: str) -> None:
+    async with state.active_boxes_lock:
+        state.active_boxes_by_id.pop(box_id, None)
+
+
+async def clear_cached_box_handles() -> None:
+    async with state.active_boxes_lock:
+        state.active_boxes_by_id.clear()
+
+
 async def get_box_or_404(box_id: str):
+    cached = await get_cached_box_handle(box_id)
+    if cached is not None:
+        return cached
+
     box_handle = await state.runtime.get(box_id)
     if box_handle is None:
         raise HTTPException(
@@ -373,6 +418,7 @@ async def get_box_or_404(box_id: str):
                 }
             },
         )
+    await cache_box_handle(box_handle)
     return box_handle
 
 
@@ -399,15 +445,28 @@ def get_active_execution_or_404(exec_id: str) -> ActiveExecution:
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    # Prefer a public mirror first to avoid Docker Hub unauthenticated pull limits.
-    options = boxlite.Options(image_registries=["mirror.gcr.io", "docker.io"])
+    runtime_config = state.runtime_config
+    if runtime_config is None:
+        raise RuntimeError("runtime configuration not initialized")
+
+    options = boxlite.Options(
+        home_dir=runtime_config.home_dir,
+        image_registries=runtime_config.image_registries,
+    )
     state.runtime = boxlite.Boxlite(options)
-    logger.info("BoxLite runtime initialized")
+    logger.info(
+        "BoxLite runtime initialized (home_dir=%s, image_registries=%s)",
+        runtime_config.home_dir,
+        ",".join(runtime_config.image_registries),
+    )
     yield
+    await clear_cached_box_handles()
     try:
         await state.runtime.shutdown(timeout=10)
     except Exception as e:
         logger.warning("Shutdown error: %s", e)
+    finally:
+        await clear_cached_box_handles()
 
 
 app = FastAPI(
@@ -462,6 +521,7 @@ async def get_config():
 
 @app.post("/v1/oauth/tokens")
 async def get_token(request: Request):
+    config = get_server_config()
     body = await request.form()
     grant_type = body.get("grant_type")
     client_id = body.get("client_id")
@@ -471,7 +531,7 @@ async def get_token(request: Request):
     if grant_type != "client_credentials":
         return error_response(400, "unsupported grant_type", "InvalidArgumentError")
 
-    if client_id != TEST_CLIENT_ID or client_secret != TEST_CLIENT_SECRET:
+    if client_id != config.client_id or client_secret != config.client_secret:
         return error_response(401, "invalid client credentials", "UnauthorizedError")
 
     return create_token(client_id, scope)
@@ -490,6 +550,7 @@ async def create_box(
 ):
     options = build_box_options(req)
     box_handle = await state.runtime.create(options, req.name)
+    await cache_box_handle(box_handle)
     info = box_handle.info()
     data = box_info_to_dict(info)
     return JSONResponse(
@@ -545,7 +606,10 @@ async def remove_box(
     force: bool = Query(False),
     _auth: dict = Depends(require_auth),
 ):
+    info = await state.runtime.get_info(box_id)
     await state.runtime.remove(box_id, force=force)
+    if info is not None:
+        await evict_cached_box_by_id(info.id)
     return Response(status_code=204)
 
 
@@ -557,6 +621,7 @@ async def start_box(
 ):
     box_handle = await get_box_or_404(box_id)
     await box_handle.start()
+    await cache_box_handle(box_handle)
     info = box_handle.info()
     return box_info_to_dict(info)
 
@@ -571,6 +636,7 @@ async def stop_box(
     box_handle = await get_box_or_404(box_id)
     await box_handle.stop()
     info = box_handle.info()
+    await evict_cached_box_by_id(info.id)
     return box_info_to_dict(info)
 
 
@@ -651,6 +717,7 @@ async def clone_box(
     box_handle = await get_box_or_404(box_id)
     opts = boxlite.CloneOptions()
     cloned = await box_handle.clone(req.name, opts)
+    await cache_box_handle(cloned)
     info = cloned.info()
     return JSONResponse(
         status_code=201,
@@ -695,6 +762,7 @@ async def import_box(
 
         imported = await state.runtime.import_box(archive_path, name=name)
 
+    await cache_box_handle(imported)
     info = imported.info()
     return JSONResponse(
         status_code=201,
@@ -1065,20 +1133,46 @@ async def get_box_metrics(
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        description="BoxLite REST API Reference Server"
-    )
-    parser.add_argument("--host", default="0.0.0.0", help="Bind address")
-    parser.add_argument("--port", type=int, default=8080, help="Bind port")
-    parser.add_argument("--log-level", default="info", help="Log level")
+    env_file_arg = parse_bootstrap_env_file(sys.argv[1:])
+    try:
+        loaded_env_path = load_env_file(env_file_arg)
+        env_server_config = load_server_config_from_env()
+        runtime_config = load_runtime_config_from_env()
+    except ValueError as err:
+        raise SystemExit(f"configuration error: {err}")
+
+    parser = build_main_parser(env_server_config)
     args = parser.parse_args()
 
+    server_config = ServerConfig(
+        host=args.host,
+        port=args.port,
+        log_level=normalize_log_level(args.log_level),
+        jwt_secret=env_server_config.jwt_secret,
+        jwt_expiry_seconds=env_server_config.jwt_expiry_seconds,
+        client_id=env_server_config.client_id,
+        client_secret=env_server_config.client_secret,
+    )
+
+    state.server_config = server_config
+    state.runtime_config = runtime_config
+
     logging.basicConfig(
-        level=getattr(logging, args.log_level.upper()),
+        level=logging_level_from_name(server_config.log_level),
         format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
     )
 
-    uvicorn.run(app, host=args.host, port=args.port, log_level=args.log_level)
+    if loaded_env_path is not None:
+        logger.info("Loaded environment from %s", loaded_env_path)
+    elif env_file_arg is None:
+        logger.info("No .env file found at %s", DEFAULT_ENV_FILE_PATH)
+
+    uvicorn.run(
+        app,
+        host=server_config.host,
+        port=server_config.port,
+        log_level=server_config.log_level,
+    )
 
 
 if __name__ == "__main__":

--- a/openapi/reference-server/tests/test_env_config.py
+++ b/openapi/reference-server/tests/test_env_config.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+CONFIG_PATH = Path(__file__).resolve().parents[1] / "config.py"
+SPEC = importlib.util.spec_from_file_location("reference_server_config", CONFIG_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"Failed to load config module spec from {CONFIG_PATH}")
+CONFIG = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = CONFIG
+SPEC.loader.exec_module(CONFIG)
+
+
+class ReferenceServerConfigTests(unittest.TestCase):
+    def test_defaults_when_env_is_empty(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            server = CONFIG.load_server_config_from_env()
+            runtime = CONFIG.load_runtime_config_from_env()
+
+        self.assertEqual(server.host, CONFIG.DEFAULT_SERVER_HOST)
+        self.assertEqual(server.port, CONFIG.DEFAULT_SERVER_PORT)
+        self.assertEqual(server.log_level, CONFIG.DEFAULT_SERVER_LOG_LEVEL)
+        self.assertEqual(server.jwt_secret, CONFIG.DEFAULT_SERVER_JWT_SECRET)
+        self.assertEqual(
+            server.jwt_expiry_seconds, CONFIG.DEFAULT_SERVER_JWT_EXPIRY_SECONDS
+        )
+        self.assertEqual(server.client_id, CONFIG.DEFAULT_SERVER_CLIENT_ID)
+        self.assertEqual(server.client_secret, CONFIG.DEFAULT_SERVER_CLIENT_SECRET)
+        self.assertEqual(runtime.home_dir, CONFIG.default_runtime_home_dir())
+        self.assertEqual(
+            runtime.image_registries, CONFIG.DEFAULT_RUNTIME_IMAGE_REGISTRIES
+        )
+
+    def test_env_overrides_for_all_server_and_runtime_options(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_home:
+            with patch.dict(
+                os.environ,
+                {
+                    "BOXLITE_SERVER_HOST": "127.0.0.1",
+                    "BOXLITE_SERVER_PORT": "9090",
+                    "BOXLITE_SERVER_LOG_LEVEL": "debug",
+                    "BOXLITE_SERVER_JWT_SECRET": "secret-123",
+                    "BOXLITE_SERVER_JWT_EXPIRY_SECONDS": "7200",
+                    "BOXLITE_SERVER_CLIENT_ID": "client-123",
+                    "BOXLITE_SERVER_CLIENT_SECRET": "secret-456",
+                    "BOXLITE_RUNTIME_HOME_DIR": temp_home,
+                    "BOXLITE_RUNTIME_IMAGE_REGISTRIES": "ghcr.io,docker.io",
+                },
+                clear=True,
+            ):
+                server = CONFIG.load_server_config_from_env()
+                runtime = CONFIG.load_runtime_config_from_env()
+
+        self.assertEqual(server.host, "127.0.0.1")
+        self.assertEqual(server.port, 9090)
+        self.assertEqual(server.log_level, "debug")
+        self.assertEqual(server.jwt_secret, "secret-123")
+        self.assertEqual(server.jwt_expiry_seconds, 7200)
+        self.assertEqual(server.client_id, "client-123")
+        self.assertEqual(server.client_secret, "secret-456")
+        self.assertEqual(runtime.home_dir, temp_home)
+        self.assertEqual(runtime.image_registries, ["ghcr.io", "docker.io"])
+
+    def test_invalid_int_env_fails_fast(self) -> None:
+        with patch.dict(os.environ, {"BOXLITE_SERVER_PORT": "oops"}, clear=True):
+            with self.assertRaisesRegex(
+                ValueError, "BOXLITE_SERVER_PORT must be an integer"
+            ):
+                CONFIG.load_server_config_from_env()
+
+        with patch.dict(
+            os.environ, {"BOXLITE_SERVER_JWT_EXPIRY_SECONDS": "0"}, clear=True
+        ):
+            with self.assertRaisesRegex(
+                ValueError, "BOXLITE_SERVER_JWT_EXPIRY_SECONDS must be >= 1"
+            ):
+                CONFIG.load_server_config_from_env()
+
+    def test_invalid_csv_env_fails_fast(self) -> None:
+        with patch.dict(
+            os.environ, {"BOXLITE_RUNTIME_IMAGE_REGISTRIES": "ghcr.io,,docker.io"}, clear=True
+        ):
+            with self.assertRaisesRegex(
+                ValueError,
+                "BOXLITE_RUNTIME_IMAGE_REGISTRIES must be a comma-separated list",
+            ):
+                CONFIG.load_runtime_config_from_env()
+
+    def test_invalid_log_level_fails_fast(self) -> None:
+        with patch.dict(os.environ, {"BOXLITE_SERVER_LOG_LEVEL": "verbose"}, clear=True):
+            with self.assertRaisesRegex(ValueError, "log level must be one of"):
+                CONFIG.load_server_config_from_env()
+
+    def test_cli_overrides_env_for_host_port_and_log_level(self) -> None:
+        with patch.dict(
+            os.environ,
+            {
+                "BOXLITE_SERVER_HOST": "10.0.0.10",
+                "BOXLITE_SERVER_PORT": "9000",
+                "BOXLITE_SERVER_LOG_LEVEL": "debug",
+            },
+            clear=True,
+        ):
+            defaults = CONFIG.load_server_config_from_env()
+            parser = CONFIG.build_main_parser(defaults)
+            args = parser.parse_args(
+                ["--host", "127.0.0.1", "--port", "8081", "--log-level", "warning"]
+            )
+
+        self.assertEqual(args.host, "127.0.0.1")
+        self.assertEqual(args.port, 8081)
+        self.assertEqual(args.log_level, "warning")
+
+    def test_runtime_home_ignores_boxlite_home_env(self) -> None:
+        with patch.dict(os.environ, {"BOXLITE_HOME": "/tmp/legacy-home"}, clear=True):
+            runtime = CONFIG.load_runtime_config_from_env()
+
+        self.assertEqual(runtime.home_dir, CONFIG.default_runtime_home_dir())
+        self.assertNotEqual(runtime.home_dir, "/tmp/legacy-home")
+
+    def test_default_env_file_path_is_reference_server_local(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            default_env_path = Path(tempdir) / ".env"
+            default_env_path.write_text("BOXLITE_SERVER_PORT=6060\n", encoding="utf-8")
+
+            with patch.object(CONFIG, "DEFAULT_ENV_FILE_PATH", default_env_path):
+                with patch.dict(os.environ, {}, clear=True):
+                    loaded = CONFIG.load_env_file(None)
+                    server = CONFIG.load_server_config_from_env()
+
+        self.assertEqual(loaded, default_env_path)
+        self.assertEqual(server.port, 6060)
+
+    def test_load_env_file_respects_existing_process_env(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            env_path = Path(tempdir) / "test.env"
+            env_path.write_text(
+                "\n".join(
+                    [
+                        "BOXLITE_SERVER_HOST=1.2.3.4",
+                        "BOXLITE_SERVER_PORT=7777",
+                    ]
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            with patch.dict(os.environ, {"BOXLITE_SERVER_HOST": "9.9.9.9"}, clear=True):
+                loaded = CONFIG.load_env_file(str(env_path))
+                server = CONFIG.load_server_config_from_env()
+
+        self.assertEqual(loaded, env_path)
+        self.assertEqual(server.host, "9.9.9.9")
+        self.assertEqual(server.port, 7777)
+
+    def test_explicit_env_file_must_exist(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            with self.assertRaisesRegex(ValueError, "--env-file path does not exist"):
+                CONFIG.load_env_file("/definitely/not/here/.env")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/openapi/reference-server/tests/test_handle_cache.py
+++ b/openapi/reference-server/tests/test_handle_cache.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import sys
+import types
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+
+SERVER_PATH = Path(__file__).resolve().parents[1] / "server.py"
+SERVER_DIR = SERVER_PATH.parent
+if str(SERVER_DIR) not in sys.path:
+    sys.path.insert(0, str(SERVER_DIR))
+
+
+def _install_boxlite_stub() -> None:
+    if "boxlite" in sys.modules:
+        return
+
+    module = types.ModuleType("boxlite")
+
+    class _Noop:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    class _SecurityOptions:
+        @staticmethod
+        def development():
+            return object()
+
+        @staticmethod
+        def standard():
+            return object()
+
+        @staticmethod
+        def maximum():
+            return object()
+
+    module.Boxlite = _Noop
+    module.Options = _Noop
+    module.BoxOptions = _Noop
+    module.CloneOptions = _Noop
+    module.ExportOptions = _Noop
+    module.SnapshotOptions = _Noop
+    module.CopyOptions = _Noop
+    module.SecurityOptions = _SecurityOptions
+    sys.modules["boxlite"] = module
+
+
+_install_boxlite_stub()
+
+SPEC = importlib.util.spec_from_file_location("reference_server_app", SERVER_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"Failed to load server module spec from {SERVER_PATH}")
+SERVER = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = SERVER
+SPEC.loader.exec_module(SERVER)
+
+
+def _make_box_info(box_id: str, *, name: str = "test-box", status: str = "created"):
+    return SimpleNamespace(
+        id=box_id,
+        name=name,
+        state=SimpleNamespace(status=status, pid=12345),
+        created_at="2026-02-22T00:00:00+00:00",
+        image="alpine:latest",
+        cpus=2,
+        memory_mib=512,
+    )
+
+
+def _make_box_handle(box_id: str, *, name: str = "test-box"):
+    info = _make_box_info(box_id, name=name)
+    handle = SimpleNamespace(info=lambda: info)
+    handle.start = AsyncMock()
+    handle.stop = AsyncMock()
+    handle.clone = AsyncMock()
+    return handle
+
+
+class _DummyRequest:
+    def __init__(self, payload: bytes):
+        self._payload = payload
+
+    async def body(self) -> bytes:
+        return self._payload
+
+
+class HandleCacheTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:
+        SERVER.state.runtime = None
+        SERVER.state.server_config = None
+        SERVER.state.runtime_config = None
+        SERVER.state.active_executions = {}
+        SERVER.state.active_boxes_by_id = {}
+        SERVER.state.active_boxes_lock = asyncio.Lock()
+
+    async def test_cache_is_keyed_by_id_only(self) -> None:
+        handle = _make_box_handle("box-123", name="friendly-name")
+
+        cached_id = await SERVER.cache_box_handle(handle)
+
+        self.assertEqual(cached_id, "box-123")
+        self.assertIn("box-123", SERVER.state.active_boxes_by_id)
+        self.assertNotIn("friendly-name", SERVER.state.active_boxes_by_id)
+
+    async def test_get_box_or_404_uses_cache_hit_before_runtime_get(self) -> None:
+        handle = _make_box_handle("box-123")
+        SERVER.state.active_boxes_by_id["box-123"] = handle
+        runtime = SimpleNamespace(get=AsyncMock(side_effect=AssertionError("unexpected call")))
+        SERVER.state.runtime = runtime
+
+        resolved = await SERVER.get_box_or_404("box-123")
+
+        self.assertIs(resolved, handle)
+        runtime.get.assert_not_called()
+
+    async def test_get_box_or_404_caches_runtime_lookup_result(self) -> None:
+        handle = _make_box_handle("box-canonical")
+        runtime = SimpleNamespace(get=AsyncMock(return_value=handle))
+        SERVER.state.runtime = runtime
+
+        resolved = await SERVER.get_box_or_404("friendly-name")
+
+        self.assertIs(resolved, handle)
+        runtime.get.assert_awaited_once_with("friendly-name")
+        self.assertIs(SERVER.state.active_boxes_by_id["box-canonical"], handle)
+
+    async def test_get_box_or_404_missing_returns_404(self) -> None:
+        runtime = SimpleNamespace(get=AsyncMock(return_value=None))
+        SERVER.state.runtime = runtime
+
+        with self.assertRaises(SERVER.HTTPException) as ctx:
+            await SERVER.get_box_or_404("missing-box")
+
+        self.assertEqual(ctx.exception.status_code, 404)
+        self.assertIn("box not found", ctx.exception.detail["error"]["message"])
+
+    async def test_create_box_caches_handle(self) -> None:
+        handle = _make_box_handle("box-create")
+        runtime = SimpleNamespace(create=AsyncMock(return_value=handle))
+        SERVER.state.runtime = runtime
+
+        with patch.object(SERVER, "build_box_options", return_value=object()):
+            response = await SERVER.create_box(
+                "demo", SERVER.CreateBoxRequest(), _auth={}
+            )
+
+        payload = json.loads(response.body)
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(payload["box_id"], "box-create")
+        self.assertIn("box-create", SERVER.state.active_boxes_by_id)
+
+    async def test_clone_box_caches_cloned_handle(self) -> None:
+        source = _make_box_handle("box-source")
+        cloned = _make_box_handle("box-cloned")
+        source.clone = AsyncMock(return_value=cloned)
+        runtime = SimpleNamespace(get=AsyncMock(return_value=source))
+        SERVER.state.runtime = runtime
+
+        response = await SERVER.clone_box(
+            "demo", "box-source", SERVER.CloneBoxRequest(name="copy"), _auth={}
+        )
+
+        payload = json.loads(response.body)
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(payload["box_id"], "box-cloned")
+        self.assertIn("box-cloned", SERVER.state.active_boxes_by_id)
+
+    async def test_import_box_caches_imported_handle(self) -> None:
+        imported = _make_box_handle("box-imported")
+        runtime = SimpleNamespace(import_box=AsyncMock(return_value=imported))
+        SERVER.state.runtime = runtime
+        request = _DummyRequest(b"fake archive")
+
+        response = await SERVER.import_box("demo", request, name=None, _auth={})
+
+        payload = json.loads(response.body)
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(payload["box_id"], "box-imported")
+        self.assertIn("box-imported", SERVER.state.active_boxes_by_id)
+
+    async def test_stop_box_evicts_cached_handle_by_canonical_id(self) -> None:
+        handle = _make_box_handle("box-stop")
+        SERVER.state.active_boxes_by_id["box-stop"] = handle
+        runtime = SimpleNamespace(get=AsyncMock(return_value=handle))
+        SERVER.state.runtime = runtime
+
+        response = await SERVER.stop_box("demo", "box-stop", req=None, _auth={})
+
+        self.assertEqual(response["box_id"], "box-stop")
+        self.assertNotIn("box-stop", SERVER.state.active_boxes_by_id)
+        runtime.get.assert_not_called()
+
+    async def test_remove_box_evicts_cached_handle_using_canonical_id(self) -> None:
+        cached = _make_box_handle("box-canonical")
+        SERVER.state.active_boxes_by_id["box-canonical"] = cached
+        runtime = SimpleNamespace(
+            get_info=AsyncMock(return_value=_make_box_info("box-canonical")),
+            remove=AsyncMock(return_value=None),
+        )
+        SERVER.state.runtime = runtime
+
+        response = await SERVER.remove_box(
+            "demo", "friendly-name", force=False, _auth={}
+        )
+
+        self.assertEqual(response.status_code, 204)
+        runtime.get_info.assert_awaited_once_with("friendly-name")
+        runtime.remove.assert_awaited_once_with("friendly-name", force=False)
+        self.assertNotIn("box-canonical", SERVER.state.active_boxes_by_id)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
This PR updates the reference server config surface and lifecycle handling:

- Adds server-local env config module (`openapi/reference-server/config.py`)
- Standardizes env prefixes:
  - `BOXLITE_SERVER_*` for server settings
  - `BOXLITE_RUNTIME_*` for runtime options used by reference server
- Loads `.env` from `openapi/reference-server/.env` by default (or `--env-file`)
- Adds `openapi/reference-server/.env.example` (server/runtime only)
- Updates docs for setup, env behavior, and precedence
- Adds strict config parsing tests
- Fixes non-detached lifecycle issue by retaining strong box handles in server memory (ID-keyed cache)

## Why
- Clarifies and stabilizes reference-server env contract
- Avoids dependence on legacy env aliases
- Prevents watchdog-triggered shutdown from dropped request-scoped handles

## Validation
- `python3 -m py_compile` on server/config/tests
- `python3 -m unittest discover -s openapi/reference-server/tests -p "test_*.py" -v`
- Manual create/start/get smoke test confirms start -> running and stable process behavior
