### PR TITLE
refactor: per-exec user override structural cleanup

### DIFF
--- a/boxlite/src/litebox/exec.rs
+++ b/boxlite/src/litebox/exec.rs
@@ -34,6 +34,7 @@ pub struct BoxCommand {
     pub(crate) timeout: Option<Duration>,
     pub(crate) working_dir: Option<String>,
     pub(crate) tty: bool,
+    pub(crate) user: Option<String>,
 }
 
 impl BoxCommand {
@@ -46,6 +47,7 @@ impl BoxCommand {
             timeout: None,
             working_dir: None,
             tty: false,
+            user: None,
         }
     }
 
@@ -90,6 +92,16 @@ impl BoxCommand {
     /// Terminal size is auto-detected from the current terminal.
     pub fn tty(mut self, enable: bool) -> Self {
         self.tty = enable;
+        self
+    }
+
+    /// Set the user to run the command as.
+    ///
+    /// Format: `<name|uid>[:<group|gid>]` (same as `docker exec --user`).
+    /// If not set, uses the container's default user from image config.
+    pub fn user(mut self, spec: impl Into<String>) -> Self {
+        let s = spec.into();
+        self.user = if s.trim().is_empty() { None } else { Some(s) };
         self
     }
 }
@@ -341,5 +353,40 @@ impl Stream for ExecStderr {
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         self.receiver.poll_recv(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_box_command_user_builder() {
+        let cmd = BoxCommand::new("whoami").user("abc:staff");
+        assert_eq!(cmd.user, Some("abc:staff".to_string()));
+    }
+
+    #[test]
+    fn test_box_command_default_no_user() {
+        let cmd = BoxCommand::new("ls");
+        assert_eq!(cmd.user, None);
+    }
+
+    #[test]
+    fn test_box_command_user_numeric() {
+        let cmd = BoxCommand::new("id").user("1000:1000");
+        assert_eq!(cmd.user, Some("1000:1000".to_string()));
+    }
+
+    #[test]
+    fn test_box_command_user_empty_string_becomes_none() {
+        let cmd = BoxCommand::new("id").user("");
+        assert_eq!(cmd.user, None);
+    }
+
+    #[test]
+    fn test_box_command_user_whitespace_only_becomes_none() {
+        let cmd = BoxCommand::new("id").user("  ");
+        assert_eq!(cmd.user, None);
     }
 }

--- a/boxlite/tests/exec_user.rs
+++ b/boxlite/tests/exec_user.rs
@@ -1,0 +1,113 @@
+//! Integration tests for per-exec user override.
+//!
+//! Verifies that `BoxCommand::user()` correctly overrides the execution user
+//! inside the VM guest.
+
+mod common;
+
+use boxlite::BoxCommand;
+use tokio_stream::StreamExt;
+
+/// Helper: exec a command, collect stdout, assert exit code 0.
+async fn exec_stdout(handle: &boxlite::LiteBox, cmd: BoxCommand) -> String {
+    let mut execution = handle.exec(cmd).await.expect("exec failed");
+
+    let mut stdout = String::new();
+    if let Some(mut stream) = execution.stdout() {
+        while let Some(chunk) = stream.next().await {
+            stdout.push_str(&chunk);
+        }
+    }
+
+    let result = execution.wait().await.expect("wait failed");
+    assert_eq!(result.exit_code, 0, "command should exit 0");
+    stdout
+}
+
+/// RAII wrapper that creates/starts a box and cleans up on drop.
+struct TestBox {
+    handle: boxlite::LiteBox,
+    ctx: common::ParallelRuntime,
+}
+
+impl TestBox {
+    async fn new() -> Self {
+        let ctx = common::ParallelRuntime::new();
+        let handle = ctx
+            .runtime
+            .create(common::alpine_opts(), None)
+            .await
+            .unwrap();
+        handle.start().await.unwrap();
+        Self { handle, ctx }
+    }
+
+    async fn teardown(self) {
+        self.handle.stop().await.unwrap();
+        let _ = self
+            .ctx
+            .runtime
+            .remove(self.handle.id().as_str(), true)
+            .await;
+        self.ctx.shutdown().await;
+    }
+}
+
+/// Default user in alpine is root (uid 0).
+#[tokio::test]
+async fn test_exec_default_user_is_root() {
+    let tb = TestBox::new().await;
+    let stdout = exec_stdout(&tb.handle, BoxCommand::new("id").arg("-u")).await;
+    assert_eq!(stdout.trim(), "0", "default user should be root (uid 0)");
+    tb.teardown().await;
+}
+
+/// Table-driven test for user override variants.
+#[tokio::test]
+async fn test_exec_user_overrides() {
+    let tb = TestBox::new().await;
+
+    // (description, command, expected substring in stdout)
+    let cases: Vec<(&str, BoxCommand, &str)> = vec![
+        (
+            "numeric uid:gid",
+            BoxCommand::new("id").arg("-u").user("65534:65534"),
+            "65534",
+        ),
+        (
+            "user by name",
+            BoxCommand::new("id").arg("-un").user("nobody"),
+            "nobody",
+        ),
+        (
+            "uid:gid both set",
+            BoxCommand::new("sh")
+                .args(["-c", "echo uid=$(id -u) gid=$(id -g)"])
+                .user("1000:2000"),
+            "uid=1000",
+        ),
+    ];
+
+    for (desc, cmd, expected) in cases {
+        let stdout = exec_stdout(&tb.handle, cmd).await;
+        assert!(
+            stdout.contains(expected),
+            "{desc}: expected stdout to contain {expected:?}, got: {stdout:?}"
+        );
+    }
+
+    // Extra assertion for uid:gid case — verify gid separately
+    let stdout = exec_stdout(
+        &tb.handle,
+        BoxCommand::new("sh")
+            .args(["-c", "echo gid=$(id -g)"])
+            .user("1000:2000"),
+    )
+    .await;
+    assert!(
+        stdout.contains("gid=2000"),
+        "stdout should contain gid=2000, got: {stdout:?}"
+    );
+
+    tb.teardown().await;
+}

--- a/guest/src/container/command.rs
+++ b/guest/src/container/command.rs
@@ -52,6 +52,13 @@ pub struct ContainerCommand {
     /// Resolved (uid, gid) from container init, propagated to exec processes.
     user: (u32, u32),
 
+    /// User override string (format: <name|uid>[:<group|gid>]).
+    /// When set, resolved at spawn time via resolve_user().
+    user_override: Option<String>,
+
+    /// Rootfs path for resolving user overrides from /etc/passwd.
+    rootfs: Option<PathBuf>,
+
     /// Working directory (None = use default "/")
     cwd: Option<String>,
 
@@ -72,12 +79,15 @@ impl ContainerCommand {
         state_root: PathBuf,
         env: HashMap<String, String>,
         user: (u32, u32),
+        rootfs: PathBuf,
     ) -> Self {
         Self {
             program: None,
             args: Vec::new(),
             env,
             user,
+            user_override: None,
+            rootfs: Some(rootfs),
             cwd: None,
             console_socket: None,
             pty_config: None,
@@ -93,6 +103,15 @@ impl ContainerCommand {
     pub fn with_pty(mut self, config: PtyConfig) -> Self {
         // Store config for spawn() to use
         self.pty_config = Some(config);
+        self
+    }
+
+    /// Set user override for this exec.
+    ///
+    /// Format: `<name|uid>[:<group|gid>]` (same as `docker exec --user`).
+    /// Resolved at spawn time from the container's /etc/passwd.
+    pub fn with_user(mut self, user: String) -> Self {
+        self.user_override = Some(user);
         self
     }
 
@@ -297,6 +316,28 @@ impl ContainerCommand {
         create_pty_child(pid, pty_master, config)
     }
 
+    /// Resolve the effective (uid, gid) for this exec.
+    ///
+    /// If `user_override` is set, resolves it against the container's /etc/passwd.
+    /// Otherwise, returns the init default `self.user`.
+    fn resolve_exec_user(&self) -> BoxliteResult<(u32, u32)> {
+        match self.user_override {
+            Some(ref spec) => {
+                let rootfs_str =
+                    self.rootfs
+                        .as_ref()
+                        .and_then(|p| p.to_str())
+                        .ok_or_else(|| {
+                            BoxliteError::Internal(
+                                "Missing rootfs path for user resolution".to_string(),
+                            )
+                        })?;
+                super::spec::resolve_user(rootfs_str, spec)
+            }
+            None => Ok(self.user),
+        }
+    }
+
     /// Build and spawn process using libcontainer.
     async fn build_and_spawn(
         &self,
@@ -353,7 +394,7 @@ impl ContainerCommand {
             );
         }
 
-        let (uid, gid) = self.user;
+        let (uid, gid) = self.resolve_exec_user()?;
 
         let pid = builder
             .as_tenant()
@@ -480,4 +521,38 @@ fn pty_master_to_file(pty_master: OwnedFd) -> std::fs::File {
     let fd = pty_master.as_raw_fd();
     std::mem::forget(pty_master); // Transfer ownership, don't close
     unsafe { std::fs::File::from_raw_fd(fd) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_cmd() -> ContainerCommand {
+        ContainerCommand::new(
+            "test-container".to_string(),
+            PathBuf::from("/tmp/state"),
+            HashMap::new(),
+            (0, 0),
+            PathBuf::from("/tmp/rootfs"),
+        )
+    }
+
+    #[test]
+    fn test_with_user_override_sets_field() {
+        let cmd = make_cmd().with_user("abc:staff".to_string());
+        assert_eq!(cmd.user_override, Some("abc:staff".to_string()));
+    }
+
+    #[test]
+    fn test_without_user_uses_default() {
+        let cmd = make_cmd();
+        assert_eq!(cmd.user_override, None);
+        assert_eq!(cmd.user, (0, 0));
+    }
+
+    #[test]
+    fn test_with_user_numeric() {
+        let cmd = make_cmd().with_user("1000:1000".to_string());
+        assert_eq!(cmd.user_override, Some("1000:1000".to_string()));
+    }
 }

--- a/guest/src/service/exec/executor.rs
+++ b/guest/src/service/exec/executor.rs
@@ -61,6 +61,10 @@ impl Executor for ContainerExecutor {
                 });
             }
 
+            if let Some(ref user) = req.user {
+                cmd = cmd.with_user(user.clone());
+            }
+
             cmd
         }; // Release container lock before spawn
 


### PR DESCRIPTION
## Summary

- **Validate early**: `BoxCommand::user()` now filters empty/whitespace strings to `None` at the builder layer, instead of guarding in the guest executor
- **Extract method**: Inline user resolution logic in `build_and_spawn()` moved to `ContainerCommand::resolve_exec_user()`
- **DRY integration tests**: `TestBox` helper eliminates copy-pasted setup/teardown; 3 override variants consolidated into a table-driven test

## Test plan

- [x] `cargo test -p boxlite --lib -- exec::tests` — 17 passed (2 new: empty string, whitespace)
- [x] `cargo clippy -p boxlite --lib -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `make test:integration` — 100 passed, 0 leaky