### PR TITLE
chore(setup): add cargo-nextest to setup scripts

### DIFF
--- a/scripts/setup/setup-common.sh
+++ b/scripts/setup/setup-common.sh
@@ -65,6 +65,19 @@ init_submodules() {
     fi
 }
 
+# Install cargo-nextest
+install_cargo_nextest() {
+    print_step "Checking for cargo-nextest... "
+    if cargo nextest --version &>/dev/null; then
+        print_success "Already installed"
+    else
+        echo -e "${YELLOW}Installing...${NC}"
+        cargo install cargo-nextest --locked
+        print_success "cargo-nextest installed"
+    fi
+    echo ""
+}
+
 # Detect guest target architecture
 detect_guest_target() {
     source "$SCRIPT_DIR/util.sh"

--- a/scripts/setup/setup-macos.sh
+++ b/scripts/setup/setup-macos.sh
@@ -211,6 +211,8 @@ main() {
 
     setup_rust_target
 
+    install_cargo_nextest
+
     install_musl_cross
 
     install_dtc

--- a/scripts/setup/setup-manylinux.sh
+++ b/scripts/setup/setup-manylinux.sh
@@ -249,6 +249,8 @@ main() {
     detect_guest_target
     check_rust_target "$GUEST_TARGET"
 
+    install_cargo_nextest
+
     print_header "Setup Complete"
 }
 

--- a/scripts/setup/setup-musllinux.sh
+++ b/scripts/setup/setup-musllinux.sh
@@ -192,6 +192,8 @@ main() {
     detect_guest_target
     check_rust_target "$GUEST_TARGET"
 
+    install_cargo_nextest
+
     print_header "Setup Complete"
 }
 

--- a/scripts/setup/setup-ubuntu.sh
+++ b/scripts/setup/setup-ubuntu.sh
@@ -187,6 +187,8 @@ main() {
     detect_guest_target
     check_rust_target "$GUEST_TARGET"
 
+    install_cargo_nextest
+
     print_header "Setup Complete"
 }
 


### PR DESCRIPTION
## Summary
- Add `install_cargo_nextest` function to `setup-common.sh` (shared across all platforms)
- Call it from all 4 platform setup scripts (macOS, Ubuntu, manylinux, musllinux)
- Checks if already installed before attempting install; uses `--locked` for reproducibility

## Test plan
- [ ] Run `make setup` on macOS and verify nextest is checked/installed
- [ ] Verify `cargo nextest --version` works after setup