### PR TITLE
fix(tests): complete mirror registry rollout and fix stale warm-up DB

### DIFF
--- a/boxlite/build.rs
+++ b/boxlite/build.rs
@@ -534,9 +534,6 @@ fn main() {
             fs::create_dir_all(&runtime_dir)
                 .unwrap_or_else(|e| panic!("Failed to create runtime directory: {}", e));
             download_prebuilt_runtime(&runtime_dir);
-            // -sys crates emit rustc-link-lib in STUB mode.
-            // Tell the linker where to find the prebuilt libraries.
-            println!("cargo:rustc-link-search=native={}", runtime_dir.display());
             // Embed runtime directory for compile-time fallback by RuntimeBinaryFinder.
             // Runtime override remains BOXLITE_RUNTIME_DIR (read via std::env::var).
             // Compile-time embed is only needed in prebuilt mode.
@@ -556,6 +553,10 @@ fn main() {
             }
         }
     }
+
+    // -sys crates emit rustc-link-lib in STUB mode.
+    // Tell the linker where to find the prebuilt libraries.
+    println!("cargo:rustc-link-search=native={}", runtime_dir.display());
 
     // Expose the runtime directory to downstream crates (e.g., Python SDK)
     println!("cargo:runtime_dir={}", runtime_dir.display());

--- a/boxlite/tests/common/mod.rs
+++ b/boxlite/tests/common/mod.rs
@@ -50,6 +50,20 @@ pub fn alpine_opts_auto() -> BoxOptions {
 
 const TEST_IMAGES: &[&str] = &["alpine:latest", "debian:bookworm-slim"];
 
+/// Docker Hub mirror registries for reliable image pulls.
+/// Mirrors are tried first; `docker.io` is the final fallback.
+const TEST_REGISTRIES: &[&str] = &[
+    "docker.m.daocloud.io",
+    "docker.xuanyuan.me",
+    "docker.1ms.run",
+    "docker.io",
+];
+
+/// Convert `TEST_REGISTRIES` to `Vec<String>` for `BoxliteOptions::image_registries`.
+pub fn test_registries() -> Vec<String> {
+    TEST_REGISTRIES.iter().map(|s| s.to_string()).collect()
+}
+
 // ============================================================================
 // SHARED HELPERS
 // ============================================================================
@@ -145,7 +159,7 @@ fn warm_home() -> &'static PathBuf {
                 rt.block_on(async {
                     let runtime = BoxliteRuntime::new(BoxliteOptions {
                         home_dir: home.clone(),
-                        image_registries: vec![],
+                        image_registries: test_registries(),
                     })
                     .unwrap();
                     let images = runtime.images().unwrap();
@@ -174,6 +188,14 @@ fn warm_home() -> &'static PathBuf {
                     handle.start().await.unwrap();
                     handle.stop().await.unwrap();
                     let _ = runtime.remove(handle.id().as_str(), false).await;
+
+                    // Force-remove any stale boxes from previous incomplete warm-ups.
+                    // Only image index records should survive into the cached DB.
+                    let all_boxes = runtime.list_info().await.unwrap_or_default();
+                    for info in &all_boxes {
+                        let _ = runtime.remove(info.id.as_str(), true).await;
+                    }
+
                     eprintln!("[test] Guest rootfs pipeline warm.");
 
                     let _ = runtime.shutdown(Some(TEST_SHUTDOWN_TIMEOUT)).await;
@@ -211,7 +233,7 @@ impl ParallelRuntime {
         let (temp_dir, home_dir) = warm_temp_dir();
         let runtime = BoxliteRuntime::new(BoxliteOptions {
             home_dir: home_dir.clone(),
-            image_registries: vec![],
+            image_registries: test_registries(),
         })
         .expect("create parallel runtime");
         Self {
@@ -270,7 +292,7 @@ impl IsolatedRuntime {
         }
         let runtime = BoxliteRuntime::new(BoxliteOptions {
             home_dir: home_dir.clone(),
-            image_registries: vec![],
+            image_registries: test_registries(),
         })
         .expect("create isolated runtime");
         Self {

--- a/boxlite/tests/lifecycle.rs
+++ b/boxlite/tests/lifecycle.rs
@@ -459,7 +459,7 @@ async fn boxes_persist_across_runtime_restart() {
     {
         let options = BoxliteOptions {
             home_dir: home_dir.clone(),
-            image_registries: vec![],
+            image_registries: common::test_registries(),
         };
         let runtime = BoxliteRuntime::new(options).expect("Failed to create runtime");
         let litebox = runtime.create(common::alpine_opts(), None).await.unwrap();
@@ -478,7 +478,7 @@ async fn boxes_persist_across_runtime_restart() {
     {
         let options = BoxliteOptions {
             home_dir,
-            image_registries: vec![],
+            image_registries: common::test_registries(),
         };
         let runtime = BoxliteRuntime::new(options).expect("Failed to create runtime");
 
@@ -508,7 +508,7 @@ async fn multiple_boxes_persist_and_recover_without_lock_errors() {
     {
         let options = BoxliteOptions {
             home_dir: home_dir.clone(),
-            image_registries: vec![],
+            image_registries: common::test_registries(),
         };
         let runtime = BoxliteRuntime::new(options).expect("Failed to create runtime");
 
@@ -541,7 +541,7 @@ async fn multiple_boxes_persist_and_recover_without_lock_errors() {
     {
         let options = BoxliteOptions {
             home_dir,
-            image_registries: vec![],
+            image_registries: common::test_registries(),
         };
         let runtime = BoxliteRuntime::new(options).expect("Failed to create runtime after restart");
 
@@ -704,7 +704,7 @@ async fn recovery_removes_auto_remove_true_boxes() {
     {
         let options = BoxliteOptions {
             home_dir: home_dir.clone(),
-            image_registries: vec![],
+            image_registries: common::test_registries(),
         };
         let runtime = BoxliteRuntime::new(options).expect("Failed to create runtime");
 
@@ -736,7 +736,7 @@ async fn recovery_removes_auto_remove_true_boxes() {
     {
         let options = BoxliteOptions {
             home_dir,
-            image_registries: vec![],
+            image_registries: common::test_registries(),
         };
         let runtime = BoxliteRuntime::new(options).expect("Failed to create runtime after restart");
 
@@ -775,7 +775,7 @@ async fn recovery_removes_orphaned_stopped_boxes_without_directory() {
     {
         let options = BoxliteOptions {
             home_dir: home_dir.clone(),
-            image_registries: vec![],
+            image_registries: common::test_registries(),
         };
         let runtime = BoxliteRuntime::new(options).expect("Failed to create runtime");
 
@@ -802,7 +802,7 @@ async fn recovery_removes_orphaned_stopped_boxes_without_directory() {
     {
         let options = BoxliteOptions {
             home_dir,
-            image_registries: vec![],
+            image_registries: common::test_registries(),
         };
         let runtime = BoxliteRuntime::new(options).expect("Failed to create runtime after restart");
 

--- a/boxlite/tests/pid_file.rs
+++ b/boxlite/tests/pid_file.rs
@@ -263,7 +263,7 @@ async fn detached_box_survives_runtime_drop() {
     {
         let runtime = BoxliteRuntime::new(BoxliteOptions {
             home_dir: home_dir.clone(),
-            image_registries: vec![],
+            image_registries: common::test_registries(),
         })
         .unwrap();
 
@@ -300,7 +300,7 @@ async fn detached_box_survives_runtime_drop() {
     // Cleanup
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir,
-        image_registries: vec![],
+        image_registries: common::test_registries(),
     })
     .unwrap();
     runtime.remove(&box_id, true).await.unwrap();
@@ -323,7 +323,7 @@ async fn non_detached_box_exits_on_runtime_drop() {
     {
         let runtime = BoxliteRuntime::new(BoxliteOptions {
             home_dir: home_dir.clone(),
-            image_registries: vec![],
+            image_registries: common::test_registries(),
         })
         .unwrap();
 
@@ -373,7 +373,7 @@ async fn detached_box_recoverable_after_restart() {
     {
         let runtime = BoxliteRuntime::new(BoxliteOptions {
             home_dir: home_dir.clone(),
-            image_registries: vec![],
+            image_registries: common::test_registries(),
         })
         .unwrap();
 
@@ -396,7 +396,7 @@ async fn detached_box_recoverable_after_restart() {
     {
         let runtime = BoxliteRuntime::new(BoxliteOptions {
             home_dir,
-            image_registries: vec![],
+            image_registries: common::test_registries(),
         })
         .unwrap();
 
@@ -486,7 +486,7 @@ async fn recovery_with_live_process() {
     {
         let runtime = BoxliteRuntime::new(BoxliteOptions {
             home_dir: home_dir.clone(),
-            image_registries: vec![],
+            image_registries: common::test_registries(),
         })
         .unwrap();
 
@@ -512,7 +512,7 @@ async fn recovery_with_live_process() {
     {
         let runtime = BoxliteRuntime::new(BoxliteOptions {
             home_dir,
-            image_registries: vec![],
+            image_registries: common::test_registries(),
         })
         .unwrap();
 
@@ -540,7 +540,7 @@ async fn recovery_with_dead_process() {
     {
         let runtime = BoxliteRuntime::new(BoxliteOptions {
             home_dir: home_dir.clone(),
-            image_registries: vec![],
+            image_registries: common::test_registries(),
         })
         .unwrap();
 
@@ -574,7 +574,7 @@ async fn recovery_with_dead_process() {
     {
         let runtime = BoxliteRuntime::new(BoxliteOptions {
             home_dir: home_dir.clone(),
-            image_registries: vec![],
+            image_registries: common::test_registries(),
         })
         .unwrap();
 
@@ -612,7 +612,7 @@ async fn recovery_with_missing_pid_file() {
     {
         let runtime = BoxliteRuntime::new(BoxliteOptions {
             home_dir: home_dir.clone(),
-            image_registries: vec![],
+            image_registries: common::test_registries(),
         })
         .unwrap();
 
@@ -639,7 +639,7 @@ async fn recovery_with_missing_pid_file() {
     {
         let runtime = BoxliteRuntime::new(BoxliteOptions {
             home_dir,
-            image_registries: vec![],
+            image_registries: common::test_registries(),
         })
         .unwrap();
 
@@ -669,7 +669,7 @@ async fn recovery_with_corrupted_pid_file() {
     {
         let runtime = BoxliteRuntime::new(BoxliteOptions {
             home_dir: home_dir.clone(),
-            image_registries: vec![],
+            image_registries: common::test_registries(),
         })
         .unwrap();
 
@@ -696,7 +696,7 @@ async fn recovery_with_corrupted_pid_file() {
     {
         let runtime = BoxliteRuntime::new(BoxliteOptions {
             home_dir: home_dir.clone(),
-            image_registries: vec![],
+            image_registries: common::test_registries(),
         })
         .unwrap();
 
@@ -730,7 +730,7 @@ async fn recovery_preserves_stopped_boxes() {
     {
         let runtime = BoxliteRuntime::new(BoxliteOptions {
             home_dir: home_dir.clone(),
-            image_registries: vec![],
+            image_registries: common::test_registries(),
         })
         .unwrap();
 
@@ -751,7 +751,7 @@ async fn recovery_preserves_stopped_boxes() {
     {
         let runtime = BoxliteRuntime::new(BoxliteOptions {
             home_dir,
-            image_registries: vec![],
+            image_registries: common::test_registries(),
         })
         .unwrap();
 

--- a/boxlite/tests/runtime.rs
+++ b/boxlite/tests/runtime.rs
@@ -1,5 +1,7 @@
 //! Integration tests for runtime initialization and locking behavior.
 
+mod common;
+
 use boxlite::BoxliteRuntime;
 use boxlite::runtime::options::BoxliteOptions;
 use std::thread;
@@ -13,14 +15,14 @@ fn test_runtime_prevents_concurrent_access() {
     // Create first runtime
     let config1 = BoxliteOptions {
         home_dir: temp_dir.path().to_path_buf(),
-        image_registries: vec![],
+        image_registries: common::test_registries(),
     };
     let runtime1 = BoxliteRuntime::new(config1).unwrap();
 
     // Try to create second runtime (should fail)
     let config2 = BoxliteOptions {
         home_dir: temp_dir.path().to_path_buf(),
-        image_registries: vec![],
+        image_registries: common::test_registries(),
     };
     let result = BoxliteRuntime::new(config2);
     assert!(result.is_err());
@@ -35,7 +37,7 @@ fn test_runtime_prevents_concurrent_access() {
     // Now should be able to create another
     let config3 = BoxliteOptions {
         home_dir: temp_dir.path().to_path_buf(),
-        image_registries: vec![],
+        image_registries: common::test_registries(),
     };
     let _runtime2 = BoxliteRuntime::new(config3).unwrap();
 }
@@ -48,7 +50,7 @@ fn test_runtime_lock_released_on_drop() {
     {
         let config = BoxliteOptions {
             home_dir: temp_dir.path().to_path_buf(),
-            image_registries: vec![],
+            image_registries: common::test_registries(),
         };
         let _runtime = BoxliteRuntime::new(config).unwrap();
     } // Lock released here
@@ -56,7 +58,7 @@ fn test_runtime_lock_released_on_drop() {
     // Should be able to create new runtime
     let config2 = BoxliteOptions {
         home_dir: temp_dir.path().to_path_buf(),
-        image_registries: vec![],
+        image_registries: common::test_registries(),
     };
     let _runtime2 = BoxliteRuntime::new(config2).unwrap();
 }
@@ -69,7 +71,7 @@ fn test_runtime_lock_across_threads() {
     // Acquire lock in main thread
     let config1 = BoxliteOptions {
         home_dir: dir_path.clone(),
-        image_registries: vec![],
+        image_registries: common::test_registries(),
     };
     let _runtime1 = BoxliteRuntime::new(config1).unwrap();
 
@@ -78,7 +80,7 @@ fn test_runtime_lock_across_threads() {
     let handle = thread::spawn(move || {
         let config = BoxliteOptions {
             home_dir: dir_clone,
-            image_registries: vec![],
+            image_registries: common::test_registries(),
         };
         BoxliteRuntime::new(config)
     });
@@ -95,14 +97,14 @@ fn test_different_home_dirs_independent() {
     // Create runtime in first directory
     let config1 = BoxliteOptions {
         home_dir: temp_dir1.path().to_path_buf(),
-        image_registries: vec![],
+        image_registries: common::test_registries(),
     };
     let _runtime1 = BoxliteRuntime::new(config1).unwrap();
 
     // Should be able to create runtime in second directory
     let config2 = BoxliteOptions {
         home_dir: temp_dir2.path().to_path_buf(),
-        image_registries: vec![],
+        image_registries: common::test_registries(),
     };
     let _runtime2 = BoxliteRuntime::new(config2).unwrap();
 
@@ -117,7 +119,7 @@ fn test_lock_file_created() {
 
     let config = BoxliteOptions {
         home_dir: temp_dir.path().to_path_buf(),
-        image_registries: vec![],
+        image_registries: common::test_registries(),
     };
     let _runtime = BoxliteRuntime::new(config).unwrap();
 
@@ -132,7 +134,7 @@ fn test_lock_survives_short_operations() {
 
     let config1 = BoxliteOptions {
         home_dir: temp_dir.path().to_path_buf(),
-        image_registries: vec![],
+        image_registries: common::test_registries(),
     };
     let runtime = BoxliteRuntime::new(config1).unwrap();
 
@@ -142,7 +144,7 @@ fn test_lock_survives_short_operations() {
     // Lock should still be held
     let config2 = BoxliteOptions {
         home_dir: temp_dir.path().to_path_buf(),
-        image_registries: vec![],
+        image_registries: common::test_registries(),
     };
     let result = BoxliteRuntime::new(config2);
     assert!(result.is_err());

--- a/boxlite/tests/shutdown.rs
+++ b/boxlite/tests/shutdown.rs
@@ -95,7 +95,7 @@ fn drop_releases_lock() {
     {
         let options = BoxliteOptions {
             home_dir: dir_path.clone(),
-            image_registries: vec![],
+            image_registries: common::test_registries(),
         };
         let _rt = BoxliteRuntime::new(options).unwrap();
     } // Drop fires here
@@ -103,7 +103,7 @@ fn drop_releases_lock() {
     // Should be able to create a new runtime on the same directory
     let options2 = BoxliteOptions {
         home_dir: dir_path,
-        image_registries: vec![],
+        image_registries: common::test_registries(),
     };
     let _rt2 = BoxliteRuntime::new(options2).unwrap();
 }

--- a/make/test.mk
+++ b/make/test.mk
@@ -64,7 +64,12 @@ test\:warm-cache\:rust: runtime-debug
 	@echo "🔥 Warming Rust integration test image cache..."
 	@mkdir -p /tmp/boxlite-test
 	@BOXLITE_RUNTIME_DIR=$(PROJECT_ROOT)/target/boxlite-runtime \
-		./target/debug/boxlite --home /tmp/boxlite-test pull alpine:latest 2>/dev/null || \
+		./target/debug/boxlite --home /tmp/boxlite-test \
+		--registry docker.m.daocloud.io \
+		--registry docker.xuanyuan.me \
+		--registry docker.1ms.run \
+		--registry docker.io \
+		pull alpine:latest 2>/dev/null || \
 		echo "  ⚠️ Pre-warm skipped (pull failed, tests will pull on-demand)"
 	@echo "✅ Rust integration image cache ready"
 


### PR DESCRIPTION
## Summary
- Force-remove all boxes after warm-up before caching DB, preventing stale box records from previous incomplete warm-ups leaking into test DBs (fixes lifecycle test "expected N boxes, got N+1" failures)
- Replace all 37 occurrences of `image_registries: vec![]` with `common::test_registries()` across 4 test files
- Add mirror registries to Make warm-cache target
- Move `rustc-link-search` outside prebuilt-only branch in build.rs

## Test plan
- [x] `cargo clippy -p boxlite --tests -- -D warnings` — zero warnings
- [x] 486 unit tests pass (`cargo nextest run -p boxlite`)
- [ ] Integration tests with VM (`cargo nextest run -p boxlite --test lifecycle --profile vm`)