### PR TITLE
feat(images): add reference resolution cache to avoid expensive parsing

### DIFF
--- a/boxlite/src/db/images.rs
+++ b/boxlite/src/db/images.rs
@@ -117,6 +117,41 @@ impl ImageIndexStore {
         Ok(rows_affected > 0)
     }
 
+    /// Get resolved reference for a short reference.
+    ///
+    /// Returns None if no resolution exists.
+    pub fn get_resolution(&self, short_ref: &str) -> BoxliteResult<Option<String>> {
+        let conn = self.db.conn();
+
+        let row: Option<String> = db_err!(
+            conn.query_row(
+                "SELECT resolved_ref FROM reference_resolution WHERE short_ref = ?1",
+                params![short_ref],
+                |row| row.get(0),
+            )
+            .optional()
+        )?;
+
+        Ok(row)
+    }
+
+    /// Update or insert resolution mapping.
+    pub fn upsert_resolution(&self, short_ref: &str, resolved_ref: &str) -> BoxliteResult<()> {
+        let conn = self.db.conn();
+
+        db_err!(conn.execute(
+            r#"
+            INSERT INTO reference_resolution (short_ref, resolved_ref)
+            VALUES (?1, ?2)
+            ON CONFLICT(short_ref) DO UPDATE SET
+                resolved_ref = excluded.resolved_ref
+            "#,
+            params![short_ref, resolved_ref],
+        ))?;
+
+        Ok(())
+    }
+
     /// Get number of cached images in index.
     pub fn len(&self) -> BoxliteResult<usize> {
         let conn = self.db.conn();
@@ -136,8 +171,8 @@ impl ImageIndexStore {
         let conn = self.db.conn();
         let mut stmt = db_err!(conn.prepare(
             r#"
-            SELECT reference, manifest_digest, config_digest, layers, cached_at, complete 
-            FROM image_index 
+            SELECT reference, manifest_digest, config_digest, layers, cached_at, complete
+            FROM image_index
             ORDER BY cached_at DESC
             "#
         ))?;

--- a/boxlite/src/db/schema.rs
+++ b/boxlite/src/db/schema.rs
@@ -7,7 +7,7 @@
 //! Each table has queryable columns for efficient filtering + JSON blob for full data.
 
 /// Current schema version.
-pub const SCHEMA_VERSION: i32 = 6;
+pub const SCHEMA_VERSION: i32 = 7;
 
 /// Schema version tracking table.
 pub const SCHEMA_VERSION_TABLE: &str = r#"
@@ -80,6 +80,18 @@ CREATE TABLE IF NOT EXISTS image_index (
 CREATE INDEX IF NOT EXISTS idx_image_index_manifest_digest ON image_index(manifest_digest);
 "#;
 
+/// Reference resolution mapping table schema.
+///
+/// Maps short references (e.g., "alpine:latest") to their resolved full references
+/// (e.g., "docker.m.daocloud.io/library/alpine:latest"). Enables fast cache lookup
+/// without expensive ReferenceIter::new() parsing.
+pub const REFERENCE_RESOLUTION_TABLE: &str = r#"
+CREATE TABLE IF NOT EXISTS reference_resolution (
+    short_ref TEXT PRIMARY KEY NOT NULL,
+    resolved_ref TEXT NOT NULL
+);
+"#;
+
 /// Box snapshot table schema (added in v6, replaces v5 `snapshots`).
 ///
 /// Stores snapshot metadata for box state persistence.
@@ -108,6 +120,7 @@ pub fn all_schemas() -> Vec<&'static str> {
         BOX_STATE_TABLE,
         ALIVE_TABLE,
         IMAGE_INDEX_TABLE,
+        REFERENCE_RESOLUTION_TABLE,
         BOX_SNAPSHOT_TABLE,
     ]
 }

--- a/boxlite/src/images/store.rs
+++ b/boxlite/src/images/store.rs
@@ -145,13 +145,38 @@ impl ImageStore {
     /// Thread-safe: Multiple concurrent pulls of the same image will only
     /// download once; others will get the cached result.
     pub async fn pull(&self, image_ref: &str) -> BoxliteResult<ImageManifest> {
-        use super::ReferenceIter;
+        use super::{ReferenceIter, is_fully_qualified};
 
         tracing::debug!(
             image_ref = %image_ref,
             registries = ?self.registries,
             "Starting image pull with registry fallback"
         );
+
+        // Ultra-fast path: Check cache before expensive ReferenceIter::new() (364ms cold start)
+        //
+        // Two cases:
+        // 1. Long reference (e.g., "docker.m.daocloud.io/library/alpine:latest"): Direct cache lookup
+        // 2. Short reference (e.g., "alpine:latest"): Check resolution mapping first
+        if is_fully_qualified(image_ref) {
+            let inner = self.inner.read().await;
+            if let Some(manifest) = self.try_load_cached(&inner, image_ref)? {
+                return Ok(manifest);
+            }
+        } else {
+            let resolved_ref = {
+                let inner = self.inner.read().await;
+                inner.index.get_resolution(image_ref)?
+            };
+
+            if let Some(resolved) = resolved_ref {
+                // Use the resolved long reference to check cache
+                let inner = self.inner.read().await;
+                if let Some(manifest) = self.try_load_cached(&inner, &resolved)? {
+                    return Ok(manifest);
+                }
+            }
+        }
 
         // Parse image reference and create iterator over registry candidates
         let candidates = ReferenceIter::new(image_ref, &self.registries)
@@ -173,7 +198,7 @@ impl ImageStore {
 
             // Slow path: pull from registry
             tracing::info!("Pulling image from registry: {}", ref_str);
-            match self.pull_from_registry(&reference).await {
+            match self.pull_from_registry(&reference, image_ref).await {
                 Ok(manifest) => {
                     if !errors.is_empty() {
                         tracing::info!(
@@ -499,7 +524,15 @@ impl ImageStore {
     ///
     /// This method handles the actual network I/O - manifest pull, layer download, etc.
     /// Lock is released during network I/O to allow other operations.
-    async fn pull_from_registry(&self, reference: &Reference) -> BoxliteResult<ImageManifest> {
+    ///
+    /// # Arguments
+    /// * `reference` - The parsed Reference object (full registry path)
+    /// * `original_ref` - The original image reference string provided by user (e.g., "alpine:latest")
+    async fn pull_from_registry(
+        &self,
+        reference: &Reference,
+        original_ref: &str,
+    ) -> BoxliteResult<ImageManifest> {
         // Step 1: Pull manifest (no lock needed - uses self.client)
         let (manifest, manifest_digest_str) = self
             .client
@@ -528,15 +561,25 @@ impl ImageStore {
         self.download_config(reference, &image_manifest.config_digest)
             .await?;
 
-        // Step 6: Update index using reference.whole() as the cache key
-        self.update_index(&reference.whole(), &image_manifest)
+        // Step 6: Update index and resolution mapping
+        self.update_index(original_ref, &reference.whole(), &image_manifest)
             .await?;
 
         Ok(image_manifest)
     }
 
     /// Update index with newly pulled image.
-    async fn update_index(&self, image_ref: &str, manifest: &ImageManifest) -> BoxliteResult<()> {
+    ///
+    /// # Arguments
+    /// * `original_ref` - Original user input (e.g., "alpine:latest")
+    /// * `resolved_ref` - Resolved full reference (e.g., "docker.m.daocloud.io/library/alpine:latest")
+    /// * `manifest` - Image manifest to cache
+    async fn update_index(
+        &self,
+        original_ref: &str,
+        resolved_ref: &str,
+        manifest: &ImageManifest,
+    ) -> BoxliteResult<()> {
         let inner = self.inner.read().await;
 
         let cached_image = CachedImage {
@@ -547,9 +590,20 @@ impl ImageStore {
             complete: true,
         };
 
-        inner.index.upsert(image_ref, &cached_image)?;
+        // Update image index with resolved reference
+        inner.index.upsert(resolved_ref, &cached_image)?;
 
-        tracing::debug!("Updated index for image: {}", image_ref);
+        // Update resolution mapping if original_ref is different from resolved_ref
+        if original_ref != resolved_ref {
+            inner.index.upsert_resolution(original_ref, resolved_ref)?;
+            tracing::debug!(
+                "Updated resolution mapping: {} → {}",
+                original_ref,
+                resolved_ref
+            );
+        }
+
+        tracing::debug!("Updated index for image: {}", resolved_ref);
         Ok(())
     }
 


### PR DESCRIPTION
Add fast-path cache for image references to avoid costly `ReferenceIter::new()` parsing (364ms cold start).

**Changes:**
- New `reference_resolution` table mapping short refs (e.g., "alpine:latest") to resolved full refs
- Fast-path lookup before parsing: check cache first, only parse on miss
- Store resolution mapping after successful pull for future reuse

**Performance:**
- Cache hit: ~µs (DB lookup) vs 364ms (parsing)
- Cache miss: No regression (same as before)