### PR TITLE
fix(sdks): read stdout and stderr concurrently to prevent deadlock

### DIFF
--- a/sdks/node/lib/simplebox.ts
+++ b/sdks/node/lib/simplebox.ts
@@ -505,31 +505,35 @@ export class SimpleBox {
       stderr = null;
     }
 
-    // Read stdout
-    if (stdout) {
-      try {
-        while (true) {
-          const line = await stdout.next();
-          if (line === null) break;
-          stdoutLines.push(line);
+    // Read stdout and stderr concurrently to avoid deadlock.
+    // Sequential reads can deadlock when a process fills one pipe buffer
+    // while the SDK is blocked reading the other.
+    await Promise.all([
+      (async () => {
+        if (!stdout) return;
+        try {
+          while (true) {
+            const line = await stdout.next();
+            if (line === null) break;
+            stdoutLines.push(line);
+          }
+        } catch {
+          // Stream ended or error occurred
         }
-      } catch (err) {
-        // Stream ended or error occurred
-      }
-    }
-
-    // Read stderr
-    if (stderr) {
-      try {
-        while (true) {
-          const line = await stderr.next();
-          if (line === null) break;
-          stderrLines.push(line);
+      })(),
+      (async () => {
+        if (!stderr) return;
+        try {
+          while (true) {
+            const line = await stderr.next();
+            if (line === null) break;
+            stderrLines.push(line);
+          }
+        } catch {
+          // Stream ended or error occurred
         }
-      } catch (err) {
-        // Stream ended or error occurred
-      }
-    }
+      })(),
+    ]);
 
     // Wait for completion
     const result = await execution.wait();

--- a/sdks/python/boxlite/simplebox.py
+++ b/sdks/python/boxlite/simplebox.py
@@ -4,6 +4,7 @@ SimpleBox - Foundation for specialized container types.
 Provides common functionality for all specialized boxes (CodeBox, BrowserBox, etc.)
 """
 
+import asyncio
 import logging
 from enum import IntEnum
 from typing import Optional, TYPE_CHECKING
@@ -226,12 +227,15 @@ class SimpleBox:
             logger.error(f"take stderr err: {e}")
             stderr = None
 
-        # Collect stdout and stderr separately
+        # Collect stdout and stderr concurrently to avoid deadlock.
+        # Sequential reads can deadlock when a process fills one pipe buffer
+        # while the SDK is blocked reading the other.
         stdout_lines = []
         stderr_lines = []
 
-        # Read stdout
-        if stdout:
+        async def collect_stdout():
+            if not stdout:
+                return
             logger.debug("collecting stdout")
             try:
                 async for line in stdout:
@@ -241,10 +245,10 @@ class SimpleBox:
                         stdout_lines.append(line)
             except Exception as e:
                 logger.error(f"collecting stdout err: {e}")
-                pass
 
-        # Read stderr
-        if stderr:
+        async def collect_stderr():
+            if not stderr:
+                return
             logger.debug("collecting stderr")
             try:
                 async for line in stderr:
@@ -254,9 +258,9 @@ class SimpleBox:
                         stderr_lines.append(line)
             except Exception as e:
                 logger.error(f"collecting stderr err: {e}")
-                pass
 
-        # Combine lines
+        await asyncio.gather(collect_stdout(), collect_stderr())
+
         stdout = "".join(stdout_lines)
         stderr = "".join(stderr_lines)
 

--- a/sdks/python/boxlite/sync_api/_simplebox.py
+++ b/sdks/python/boxlite/sync_api/_simplebox.py
@@ -5,6 +5,8 @@ Provides a synchronous API for box operations.
 API mirrors async SimpleBox exactly.
 """
 
+import asyncio
+import logging
 from typing import TYPE_CHECKING, Dict, Optional
 
 from ..exec import ExecResult
@@ -12,6 +14,8 @@ from ..exec import ExecResult
 if TYPE_CHECKING:
     from ._boxlite import SyncBoxlite
     from ._box import SyncBox
+
+logger = logging.getLogger("boxlite.sync_simplebox")
 
 __all__ = ["SyncSimpleBox"]
 
@@ -170,38 +174,77 @@ class SyncSimpleBox:
             print(f"Exit code: {result.exit_code}")
             print(f"Output: {result.stdout}")
         """
-        # Convert args to list format expected by SyncBox
+        # Run the entire exec+collect as a single async operation through
+        # the greenlet bridge. This avoids the deadlock that occurs with
+        # sequential sync iteration (stdout then stderr), where filling one
+        # pipe buffer blocks the process while we're reading the other.
         arg_list = list(args) if args else None
         env_list = list(env.items()) if env else None
 
-        # SyncBox.exec() returns SyncExecution - already sync!
-        execution = self._box.exec(cmd, arg_list, env_list)
+        # Access the underlying async Box directly
+        async_box = self._box._box
 
-        # Collect stdout (sync iteration)
-        stdout_lines = []
-        for line in execution.stdout():
-            if isinstance(line, bytes):
-                stdout_lines.append(line.decode("utf-8", errors="replace"))
-            else:
-                stdout_lines.append(line)
+        async def _exec_and_collect():
+            execution = await async_box.exec(cmd, arg_list, env_list)
 
-        # Collect stderr (sync iteration)
-        stderr_lines = []
-        for line in execution.stderr():
-            if isinstance(line, bytes):
-                stderr_lines.append(line.decode("utf-8", errors="replace"))
-            else:
-                stderr_lines.append(line)
+            stdout_lines = []
+            stderr_lines = []
 
-        # Wait for completion (sync)
-        result = execution.wait()
+            try:
+                stdout_stream = execution.stdout()
+            except Exception as e:
+                logger.error(f"take stdout err: {e}")
+                stdout_stream = None
 
-        return ExecResult(
-            exit_code=result.exit_code,
-            stdout="".join(stdout_lines),
-            stderr="".join(stderr_lines),
-            error_message=result.error_message,
-        )
+            try:
+                stderr_stream = execution.stderr()
+            except Exception as e:
+                logger.error(f"take stderr err: {e}")
+                stderr_stream = None
+
+            async def collect_stdout():
+                if not stdout_stream:
+                    return
+                try:
+                    async for line in stdout_stream:
+                        if isinstance(line, bytes):
+                            stdout_lines.append(line.decode("utf-8", errors="replace"))
+                        else:
+                            stdout_lines.append(line)
+                except Exception as e:
+                    logger.error(f"collecting stdout err: {e}")
+
+            async def collect_stderr():
+                if not stderr_stream:
+                    return
+                try:
+                    async for line in stderr_stream:
+                        if isinstance(line, bytes):
+                            stderr_lines.append(line.decode("utf-8", errors="replace"))
+                        else:
+                            stderr_lines.append(line)
+                except Exception as e:
+                    logger.error(f"collecting stderr err: {e}")
+
+            await asyncio.gather(collect_stdout(), collect_stderr())
+
+            error_message = None
+            try:
+                exec_result = await execution.wait()
+                exit_code = exec_result.exit_code
+                error_message = exec_result.error_message
+            except Exception as e:
+                logger.error(f"failed to wait execution: {e}")
+                exit_code = -1
+
+            return ExecResult(
+                exit_code=exit_code,
+                stdout="".join(stdout_lines),
+                stderr="".join(stderr_lines),
+                error_message=error_message,
+            )
+
+        return self._runtime._sync(_exec_and_collect())
 
     def stop(self) -> None:
         """Stop the box (preserves state for restart)."""

--- a/sdks/python/tests/test_simplebox.py
+++ b/sdks/python/tests/test_simplebox.py
@@ -299,6 +299,51 @@ class TestSimpleBoxReuseExisting:
                     pass  # Should not reach here
 
 
+class TestSimpleBoxConcurrentStreams:
+    """Test that stdout and stderr are read concurrently, not sequentially.
+
+    Sequential reads deadlock when a process writes enough to both streams:
+    the kernel pipe buffer (~64KB) fills on the unread stream, blocking the
+    process, which prevents the read stream from reaching EOF.
+    """
+
+    @pytest.mark.asyncio
+    async def test_concurrent_stdout_stderr_heavy(self, shared_runtime):
+        """Concurrent reads prevent deadlock with heavy interleaved output.
+
+        Writes ~250KB to each stream by interleaving stdout/stderr lines.
+        With sequential reads, stderr buffer fills → process blocks → deadlock.
+        """
+        import asyncio
+
+        # Write ALL stderr first, then ALL stdout. With sequential reads (stdout
+        # first), the SDK would wait on an empty stdout channel while ~250KB of
+        # stderr accumulates in an unbounded buffer. Concurrent reads consume
+        # stderr as it arrives, avoiding unbounded memory growth.
+        cmd = (
+            "i=0; while [ $i -lt 5000 ]; do "
+            'echo "stderr line $i padding to increase size" >&2; '
+            "i=$((i+1)); done; "
+            "i=0; while [ $i -lt 5000 ]; do "
+            'echo "stdout line $i padding to increase size"; '
+            "i=$((i+1)); done"
+        )
+        async with boxlite.SimpleBox(
+            image="alpine:latest", runtime=shared_runtime
+        ) as box:
+            # Timeout: if concurrent reading works, this finishes in seconds.
+            # A deadlock would hang forever, so 60s is generous but safe.
+            result = await asyncio.wait_for(box.exec("sh", "-c", cmd), timeout=60)
+            assert result.exit_code == 0
+            assert "stdout line 0" in result.stdout
+            assert "stderr line 0" in result.stderr
+            assert "stdout line 4999" in result.stdout
+            assert "stderr line 4999" in result.stderr
+            # Verify we got all lines (stderr may include runtime warnings)
+            assert result.stdout.count("\n") == 5000
+            assert result.stderr.count("\n") >= 5000
+
+
 class TestSimpleBoxExports:
     """Test SimpleBox module exports."""
 

--- a/sdks/python/tests/test_sync_simplebox.py
+++ b/sdks/python/tests/test_sync_simplebox.py
@@ -101,6 +101,59 @@ class TestSyncSimpleBox:
             assert "MY_VAR=my_value" in result.stdout
 
 
+class TestSyncSimpleBoxConcurrentStreams:
+    """Test that stdout and stderr are read concurrently in sync API.
+
+    Sequential reads deadlock when a process writes enough to both streams:
+    the kernel pipe buffer (~64KB) fills on the unread stream, blocking the
+    process, which prevents the read stream from reaching EOF.
+    """
+
+    def test_concurrent_stdout_stderr_heavy(self, shared_sync_runtime):
+        """Concurrent reads prevent deadlock with heavy interleaved output."""
+        import signal
+
+        # Write ALL stderr first, then ALL stdout. With sequential reads (stdout
+        # first), the SDK would wait on an empty stdout channel while ~250KB of
+        # stderr accumulates in an unbounded buffer. Concurrent reads consume
+        # stderr as it arrives, avoiding unbounded memory growth.
+        cmd = (
+            "i=0; while [ $i -lt 5000 ]; do "
+            'echo "stderr line $i padding to increase size" >&2; '
+            "i=$((i+1)); done; "
+            "i=0; while [ $i -lt 5000 ]; do "
+            'echo "stdout line $i padding to increase size"; '
+            "i=$((i+1)); done"
+        )
+
+        # Use SIGALRM as a timeout mechanism for the sync call.
+        # A deadlock would hang forever; 60s is generous but safe.
+        def timeout_handler(signum, frame):
+            raise TimeoutError(
+                "Deadlock detected: concurrent stream reading likely broken"
+            )
+
+        old_handler = signal.signal(signal.SIGALRM, timeout_handler)
+        signal.alarm(60)
+        try:
+            with SyncSimpleBox(
+                image="alpine:latest", runtime=shared_sync_runtime
+            ) as box:
+                result = box.exec("sh", "-c", cmd)
+        finally:
+            signal.alarm(0)
+            signal.signal(signal.SIGALRM, old_handler)
+
+        assert result.exit_code == 0
+        assert "stdout line 0" in result.stdout
+        assert "stderr line 0" in result.stderr
+        assert "stdout line 4999" in result.stdout
+        assert "stderr line 4999" in result.stderr
+        # Verify we got all lines (stderr may include runtime warnings)
+        assert result.stdout.count("\n") == 5000
+        assert result.stderr.count("\n") >= 5000
+
+
 class TestSyncSimpleBoxReuseExisting:
     """Tests for SyncSimpleBox reuse_existing flag."""
 


### PR DESCRIPTION
## Summary

- **Problem**: Sequential reads of stdout then stderr can deadlock when a child process fills one pipe buffer (~64KB) while the reader is blocked on the other pipe
- **Fix**: Read both streams concurrently using `asyncio.gather` (Python) and `Promise.all` (Node.js)
- **Tests**: Added `TestSimpleBoxConcurrentStreams` and `TestSyncSimpleBoxConcurrentStreams` test classes

## Test plan

- [ ] Verify Python async `exec` reads stdout/stderr concurrently via `asyncio.gather`
- [ ] Verify Python sync `exec` uses async internals with concurrent reads
- [ ] Verify Node.js `exec` reads stdout/stderr concurrently via `Promise.all`
- [ ] Run new concurrent stream test cases