### PR TITLE
Fix rust-cache post-step path validation error

### DIFF
--- a/.github/workflows/build-node.yml
+++ b/.github/workflows/build-node.yml
@@ -88,8 +88,9 @@ jobs:
           mkdir -p ".cache/$GUEST_TARGET/release"
           cp "target/$GUEST_TARGET/release/boxlite-guest" ".cache/$GUEST_TARGET/release/"
 
-          # Clean up to save disk space
+          # Clean up to save disk space (keep target/ dir for rust-cache post-step)
           rm -rf target ~/.rustup ~/.cargo
+          mkdir -p target
 
       # Cache cargo registry for manylinux container.
       # Swatinem/rust-cache can't run inside Docker, so we use actions/cache

--- a/.github/workflows/build-runtime.yml
+++ b/.github/workflows/build-runtime.yml
@@ -81,8 +81,9 @@ jobs:
           mkdir -p ".cache/$GUEST_TARGET/release"
           cp "target/$GUEST_TARGET/release/boxlite-guest" ".cache/$GUEST_TARGET/release/"
 
-          # Clean up to save disk space
+          # Clean up to save disk space (keep target/ dir for rust-cache post-step)
           rm -rf target ~/.rustup ~/.cargo
+          mkdir -p target
 
       # Cache cargo registry for manylinux container.
       # Swatinem/rust-cache can't run inside Docker, so we use actions/cache

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -56,8 +56,9 @@ jobs:
           mkdir -p ".cache/$GUEST_TARGET/release"
           cp "target/$GUEST_TARGET/release/boxlite-guest" ".cache/$GUEST_TARGET/release/"
 
-          # Clean up to save disk space
+          # Clean up to save disk space (keep target/ dir for rust-cache post-step)
           rm -rf target ~/.rustup ~/.cargo
+          mkdir -p target
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.2.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,6 +438,7 @@ name = "boxlite-go-bridge"
 version = "0.1.0"
 dependencies = [
  "boxlite",
+ "boxlite-ffi",
  "boxlite-shared",
  "libc",
  "once_cell",


### PR DESCRIPTION
## Summary
- The build workflows (`build-wheels`, `build-runtime`, `build-node`) delete `target/` to save disk space after building the guest binary
- `Swatinem/rust-cache@v2`'s post-step validates paths even with `save-if: false`, erroring when `target/` is missing
- Fix: recreate an empty `target/` directory after cleanup with `mkdir -p target`

## Test plan
- [ ] Trigger `Build Wheels` workflow via `workflow_dispatch` and verify rust-cache post-step no longer errors
- [ ] Verify `Build Runtime` and `Build Node` workflows similarly pass