### PR TITLE
Reorganize integration test suite and refactor test utilities

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -30,6 +30,7 @@ fail-fast = false
 # VM PROFILE (integration/E2E tests that boot real VMs)
 # =============================================================================
 [profile.vm]
+test-threads = 4
 slow-timeout = { period = "120s", terminate-after = 5 }
 retries = 0
 fail-fast = false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,7 +527,10 @@ name = "boxlite-test-utils"
 version = "0.1.0"
 dependencies = [
  "boxlite",
+ "futures",
  "libc",
+ "parking_lot",
+ "paste",
  "tempfile",
  "tokio",
 ]

--- a/boxlite-cli/tests/common/mod.rs
+++ b/boxlite-cli/tests/common/mod.rs
@@ -1,10 +1,10 @@
 #![allow(dead_code)]
 
 use assert_cmd::Command;
-use boxlite_test_utils::{TEST_REGISTRIES, warm_temp_dir};
+use boxlite_test_utils::TEST_REGISTRIES;
+use boxlite_test_utils::home::PerTestBoxHome;
 use std::path::PathBuf;
 use std::time::Duration;
-use tempfile::TempDir;
 
 fn apply_registries(cmd: &mut Command) {
     for reg in TEST_REGISTRIES {
@@ -15,7 +15,7 @@ fn apply_registries(cmd: &mut Command) {
 pub struct TestContext {
     pub cmd: Command,
     pub home: PathBuf,
-    _tmp_dir: TempDir,
+    _home: PerTestBoxHome,
 }
 
 impl TestContext {
@@ -45,7 +45,8 @@ impl TestContext {
 /// Create a TestContext without default registries.
 /// Use this when the test needs full control over which registries are used.
 pub fn boxlite_bare() -> TestContext {
-    let (tmp_dir, home) = warm_temp_dir();
+    let home_dir = PerTestBoxHome::new();
+    let home = home_dir.path.clone();
     let bin_path = env!("CARGO_BIN_EXE_boxlite");
     let mut cmd = Command::new(bin_path);
     cmd.timeout(Duration::from_secs(60));
@@ -54,12 +55,13 @@ pub fn boxlite_bare() -> TestContext {
     TestContext {
         cmd,
         home,
-        _tmp_dir: tmp_dir,
+        _home: home_dir,
     }
 }
 
 pub fn boxlite() -> TestContext {
-    let (tmp_dir, home) = warm_temp_dir();
+    let home_dir = PerTestBoxHome::new();
+    let home = home_dir.path.clone();
     let bin_path = env!("CARGO_BIN_EXE_boxlite");
     let mut cmd = Command::new(bin_path);
     cmd.timeout(Duration::from_secs(60));
@@ -69,6 +71,6 @@ pub fn boxlite() -> TestContext {
     TestContext {
         cmd,
         home,
-        _tmp_dir: tmp_dir,
+        _home: home_dir,
     }
 }

--- a/boxlite-test-utils/Cargo.toml
+++ b/boxlite-test-utils/Cargo.toml
@@ -7,5 +7,8 @@ publish = false
 [dependencies]
 boxlite = { path = "../boxlite" }
 tempfile = "3"
-tokio = { version = "1", features = ["rt", "rt-multi-thread"] }
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "time"] }
 libc = "0.2"
+parking_lot = "0.12"
+paste = "1"
+futures = "0.3"

--- a/boxlite-test-utils/src/assertions.rs
+++ b/boxlite-test-utils/src/assertions.rs
@@ -1,0 +1,335 @@
+//! Test assertion macros for boxlite.
+//!
+//! Provides expressive assertions that produce clear failure messages with
+//! the failed expression, actual error, and source location.
+//!
+//! # Macros
+//!
+//! - [`assert_ok!`] — unwrap `Result::Ok`, show actual error on failure
+//! - [`assert_err!`] — assert `Result::Err`, return the error
+//! - [`assert_err_kind!`] — assert a specific `BoxliteError` variant
+//! - [`assert_exec_ok!`] — assert `Result::Ok` AND `exit_code == 0`
+//! - [`assert_err_contains!`] — assert error message contains substring
+
+/// Unwrap a `Result::Ok`, panicking with a clear message on `Err`.
+///
+/// Returns the inner `Ok` value. On failure, shows the expression text,
+/// the actual error, and the source location.
+///
+/// # Examples
+///
+/// ```ignore
+/// let handle = assert_ok!(runtime.create(opts, None).await);
+/// let handle = assert_ok!(runtime.create(opts, None).await, "creating box {}", name);
+/// ```
+#[macro_export]
+macro_rules! assert_ok {
+    ($expr:expr) => {
+        match $expr {
+            Ok(val) => val,
+            Err(e) => {
+                panic!(
+                    "assert_ok! failed\n  expression: {}\n  error: {:?}\n  at: {}:{}",
+                    stringify!($expr),
+                    e,
+                    file!(),
+                    line!(),
+                )
+            }
+        }
+    };
+    ($expr:expr, $($msg:tt)+) => {
+        match $expr {
+            Ok(val) => val,
+            Err(e) => {
+                panic!(
+                    "assert_ok! failed: {}\n  expression: {}\n  error: {:?}\n  at: {}:{}",
+                    format_args!($($msg)+),
+                    stringify!($expr),
+                    e,
+                    file!(),
+                    line!(),
+                )
+            }
+        }
+    };
+}
+
+/// Assert that a `Result` is `Err`, returning the error value.
+///
+/// Panics if the result is `Ok`, showing the unexpected success value.
+///
+/// # Examples
+///
+/// ```ignore
+/// let err = assert_err!(runtime.remove("nonexistent", false).await);
+/// assert!(err.to_string().contains("not found"));
+/// ```
+#[macro_export]
+macro_rules! assert_err {
+    ($expr:expr) => {
+        match $expr {
+            Err(e) => e,
+            Ok(val) => {
+                panic!(
+                    "assert_err! failed — expected Err, got Ok\n  expression: {}\n  ok value: {:?}\n  at: {}:{}",
+                    stringify!($expr),
+                    val,
+                    file!(),
+                    line!(),
+                )
+            }
+        }
+    };
+    ($expr:expr, $($msg:tt)+) => {
+        match $expr {
+            Err(e) => e,
+            Ok(val) => {
+                panic!(
+                    "assert_err! failed: {} — expected Err, got Ok\n  expression: {}\n  ok value: {:?}\n  at: {}:{}",
+                    format_args!($($msg)+),
+                    stringify!($expr),
+                    val,
+                    file!(),
+                    line!(),
+                )
+            }
+        }
+    };
+}
+
+/// Assert that a `Result` is `Err` matching a specific `BoxliteError` variant.
+///
+/// Panics with a clear message if the result is `Ok` or the wrong error variant.
+///
+/// # Examples
+///
+/// ```ignore
+/// assert_err_kind!(
+///     handle.exec(BoxCommand::new("echo").arg("world")).await,
+///     BoxliteError::Stopped(_)
+/// );
+/// ```
+#[macro_export]
+macro_rules! assert_err_kind {
+    ($expr:expr, $pattern:pat) => {
+        match $expr {
+            Err(ref e) if matches!(e, $pattern) => {}
+            Err(e) => {
+                panic!(
+                    "assert_err_kind! failed — wrong error variant\n  expression: {}\n  expected: {}\n  actual: {:?}\n  at: {}:{}",
+                    stringify!($expr),
+                    stringify!($pattern),
+                    e,
+                    file!(),
+                    line!(),
+                )
+            }
+            Ok(val) => {
+                panic!(
+                    "assert_err_kind! failed — expected Err({}), got Ok\n  expression: {}\n  ok value: {:?}\n  at: {}:{}",
+                    stringify!($pattern),
+                    stringify!($expr),
+                    val,
+                    file!(),
+                    line!(),
+                )
+            }
+        }
+    };
+}
+
+/// Assert that a `Result<ExecResult, _>` is `Ok` with `exit_code == 0`.
+///
+/// Returns the `ExecResult`. Panics if the result is `Err` or if the exit code
+/// is non-zero.
+///
+/// # Examples
+///
+/// ```ignore
+/// let result = assert_exec_ok!(execution.wait().await);
+/// ```
+#[macro_export]
+macro_rules! assert_exec_ok {
+    ($expr:expr) => {
+        match $expr {
+            Ok(result) => {
+                if result.exit_code != 0 {
+                    panic!(
+                        "assert_exec_ok! failed — non-zero exit code\n  expression: {}\n  exit_code: {}\n  error_message: {:?}\n  at: {}:{}",
+                        stringify!($expr),
+                        result.exit_code,
+                        result.error_message,
+                        file!(),
+                        line!(),
+                    )
+                }
+                result
+            }
+            Err(e) => {
+                panic!(
+                    "assert_exec_ok! failed\n  expression: {}\n  error: {:?}\n  at: {}:{}",
+                    stringify!($expr),
+                    e,
+                    file!(),
+                    line!(),
+                )
+            }
+        }
+    };
+}
+
+/// Assert that an error's display message contains a substring.
+///
+/// Works with any type implementing `std::fmt::Display`.
+///
+/// # Examples
+///
+/// ```ignore
+/// let err = assert_err!(result);
+/// assert_err_contains!(err, "not found");
+/// ```
+#[macro_export]
+macro_rules! assert_err_contains {
+    ($err:expr, $substr:expr) => {
+        {
+            let err_msg = $err.to_string();
+            let substr = $substr;
+            if !err_msg.contains(substr) {
+                panic!(
+                    "assert_err_contains! failed\n  error: {}\n  expected to contain: {:?}\n  at: {}:{}",
+                    err_msg,
+                    substr,
+                    file!(),
+                    line!(),
+                )
+            }
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fmt;
+
+    // Simple error type for testing macros without depending on BoxliteError.
+    #[derive(Debug)]
+    #[allow(dead_code)]
+    enum TestError {
+        NotFound(String),
+        InvalidState(String),
+        Config(String),
+    }
+
+    impl fmt::Display for TestError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            match self {
+                TestError::NotFound(msg) => write!(f, "not found: {msg}"),
+                TestError::InvalidState(msg) => write!(f, "invalid state: {msg}"),
+                TestError::Config(msg) => write!(f, "config: {msg}"),
+            }
+        }
+    }
+
+    // Simple result type for exec assertions.
+    #[derive(Debug)]
+    struct MockExecResult {
+        exit_code: i32,
+        error_message: Option<String>,
+    }
+
+    #[test]
+    fn assert_ok_returns_value_on_success() {
+        let result: Result<i32, TestError> = Ok(42);
+        let val = assert_ok!(result);
+        assert_eq!(val, 42);
+    }
+
+    #[test]
+    #[should_panic(expected = "assert_ok! failed")]
+    fn assert_ok_panics_on_error() {
+        let result: Result<i32, TestError> = Err(TestError::Config("bad".into()));
+        let _ = assert_ok!(result);
+    }
+
+    #[test]
+    #[should_panic(expected = "creating box")]
+    fn assert_ok_with_context_message() {
+        let result: Result<i32, TestError> = Err(TestError::Config("bad".into()));
+        let _ = assert_ok!(result, "creating box {}", "test-box");
+    }
+
+    #[test]
+    fn assert_err_returns_error_on_failure() {
+        let result: Result<i32, TestError> = Err(TestError::NotFound("box-1".into()));
+        let err = assert_err!(result);
+        assert!(matches!(err, TestError::NotFound(_)));
+    }
+
+    #[test]
+    #[should_panic(expected = "expected Err, got Ok")]
+    fn assert_err_panics_on_success() {
+        let result: Result<i32, TestError> = Ok(42);
+        let _ = assert_err!(result);
+    }
+
+    #[test]
+    fn assert_err_kind_matches_variant() {
+        let result: Result<i32, TestError> = Err(TestError::NotFound("x".into()));
+        assert_err_kind!(result, TestError::NotFound(_));
+    }
+
+    #[test]
+    #[should_panic(expected = "wrong error variant")]
+    fn assert_err_kind_panics_on_wrong_variant() {
+        let result: Result<i32, TestError> = Err(TestError::Config("x".into()));
+        assert_err_kind!(result, TestError::NotFound(_));
+    }
+
+    #[test]
+    #[should_panic(expected = "expected Err")]
+    fn assert_err_kind_panics_on_ok() {
+        let result: Result<i32, TestError> = Ok(42);
+        assert_err_kind!(result, TestError::NotFound(_));
+    }
+
+    #[test]
+    fn assert_exec_ok_returns_result_on_zero_exit() {
+        let result: Result<MockExecResult, TestError> = Ok(MockExecResult {
+            exit_code: 0,
+            error_message: None,
+        });
+        let r = assert_exec_ok!(result);
+        assert_eq!(r.exit_code, 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "non-zero exit code")]
+    fn assert_exec_ok_panics_on_nonzero_exit() {
+        let result: Result<MockExecResult, TestError> = Ok(MockExecResult {
+            exit_code: 1,
+            error_message: Some("command failed".into()),
+        });
+        let _ = assert_exec_ok!(result);
+    }
+
+    #[test]
+    #[should_panic(expected = "assert_exec_ok! failed")]
+    fn assert_exec_ok_panics_on_error() {
+        let result: Result<MockExecResult, TestError> = Err(TestError::Config("bad".into()));
+        let _ = assert_exec_ok!(result);
+    }
+
+    #[test]
+    fn assert_err_contains_matches_substring() {
+        let err = TestError::NotFound("box-123".into());
+        assert_err_contains!(err, "box-123");
+    }
+
+    #[test]
+    #[should_panic(expected = "expected to contain")]
+    fn assert_err_contains_panics_on_missing_substring() {
+        let err = TestError::NotFound("box-123".into());
+        assert_err_contains!(err, "nonexistent");
+    }
+}

--- a/boxlite-test-utils/src/box_test.rs
+++ b/boxlite-test-utils/src/box_test.rs
@@ -1,0 +1,235 @@
+//! Per-test fixture: runtime + running box + one-word helpers.
+//!
+//! Like RocksDB's `DBTestBase` — constructor does all setup, Drop does cleanup.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use boxlite_test_utils::box_test::BoxTestBase;
+//!
+//! #[tokio::test]
+//! async fn exec_echo() {
+//!     let t = BoxTestBase::new().await;
+//!     let out = t.exec_stdout("echo", &["hello"]).await;
+//!     assert_eq!(out.trim(), "hello");
+//! }
+//! ```
+
+use boxlite::runtime::options::{BoxOptions, BoxliteOptions, RootfsSpec};
+use boxlite::{BoxCommand, BoxliteRuntime, ExecResult, LiteBox};
+use futures::StreamExt as _;
+
+use crate::home::PerTestBoxHome;
+use crate::test_registries;
+
+/// Per-test fixture with runtime, running box, and one-word helpers.
+///
+/// Constructor creates a runtime, creates a box, and starts it.
+/// Drop stops the box, removes it, and shuts down the runtime.
+///
+/// Drop order: `bx` → `runtime` → `_home` (ensures cleanup before dir removal).
+pub struct BoxTestBase {
+    /// The boxlite runtime for this test.
+    pub runtime: BoxliteRuntime,
+    /// The running box handle.
+    pub bx: LiteBox,
+    _home: PerTestBoxHome,
+}
+
+impl BoxTestBase {
+    /// Create a new test fixture with `alpine:latest` and default options.
+    ///
+    /// Triggers shared cache initialization on first call (image pull, rootfs build).
+    pub async fn new() -> Self {
+        Self::with_options(BoxOptions {
+            rootfs: RootfsSpec::Image("alpine:latest".into()),
+            auto_remove: false,
+            ..Default::default()
+        })
+        .await
+    }
+
+    /// Create a new test fixture with custom `BoxOptions`.
+    pub async fn with_options(options: BoxOptions) -> Self {
+        let home = PerTestBoxHome::new();
+        let runtime = BoxliteRuntime::new(BoxliteOptions {
+            home_dir: home.path.clone(),
+            image_registries: test_registries(),
+        })
+        .expect("create BoxTestBase runtime");
+
+        let bx = runtime
+            .create(options, None)
+            .await
+            .expect("create BoxTestBase box");
+        bx.start().await.expect("start BoxTestBase box");
+
+        Self {
+            runtime,
+            bx,
+            _home: home,
+        }
+    }
+
+    /// Create a fixture without warm cache (for non-VM tests that still need the struct shape).
+    pub async fn isolated() -> Self {
+        let home = PerTestBoxHome::isolated();
+        let runtime = BoxliteRuntime::new(BoxliteOptions {
+            home_dir: home.path.clone(),
+            image_registries: test_registries(),
+        })
+        .expect("create isolated BoxTestBase runtime");
+
+        let bx = runtime
+            .create(
+                BoxOptions {
+                    rootfs: RootfsSpec::Image("alpine:latest".into()),
+                    auto_remove: false,
+                    ..Default::default()
+                },
+                None,
+            )
+            .await
+            .expect("create isolated BoxTestBase box");
+
+        Self {
+            runtime,
+            bx,
+            _home: home,
+        }
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // One-word helpers
+    // ────────────────────────────────────────────────────────────────────────
+
+    /// Run a command and return stdout as a string.
+    ///
+    /// Asserts exit code is 0. Panics on error.
+    pub async fn exec_stdout(&self, cmd: &str, args: &[&str]) -> String {
+        let command = BoxCommand::new(cmd).args(args.iter().copied());
+        let mut run = self
+            .bx
+            .exec(command)
+            .await
+            .unwrap_or_else(|e| panic!("exec_stdout({cmd}): failed: {e}"));
+
+        let mut stdout = String::new();
+        if let Some(mut stream) = run.stdout() {
+            while let Some(chunk) = stream.next().await {
+                stdout.push_str(&chunk);
+            }
+        }
+
+        let result = run
+            .wait()
+            .await
+            .unwrap_or_else(|e| panic!("exec_stdout({cmd}): wait failed: {e}"));
+        assert_eq!(
+            result.exit_code, 0,
+            "exec_stdout({cmd}): non-zero exit code {}",
+            result.exit_code
+        );
+        stdout
+    }
+
+    /// Run a command and return the exit code.
+    ///
+    /// Does not assert on exit code — returns it for the caller to check.
+    pub async fn exec_exit_code(&self, cmd: &str, args: &[&str]) -> i32 {
+        let command = BoxCommand::new(cmd).args(args.iter().copied());
+        let mut run = self
+            .bx
+            .exec(command)
+            .await
+            .unwrap_or_else(|e| panic!("exec_exit_code({cmd}): failed: {e}"));
+
+        let result = run
+            .wait()
+            .await
+            .unwrap_or_else(|e| panic!("exec_exit_code({cmd}): wait failed: {e}"));
+        result.exit_code
+    }
+
+    /// Run a command and return the full `ExecResult`.
+    ///
+    /// Does not assert on exit code.
+    pub async fn exec_result(&self, cmd: &str, args: &[&str]) -> ExecResult {
+        let command = BoxCommand::new(cmd).args(args.iter().copied());
+        let mut run = self
+            .bx
+            .exec(command)
+            .await
+            .unwrap_or_else(|e| panic!("exec_result({cmd}): failed: {e}"));
+
+        run.wait()
+            .await
+            .unwrap_or_else(|e| panic!("exec_result({cmd}): wait failed: {e}"))
+    }
+
+    /// Write a file inside the box.
+    pub async fn write_file(&self, path: &str, content: &str) {
+        let escaped = content.replace('\'', "'\\''");
+        let shell_cmd = format!("printf '%s' '{escaped}' > {path}");
+        let command = BoxCommand::new("sh").args(["-c", &shell_cmd]);
+        let mut run = self
+            .bx
+            .exec(command)
+            .await
+            .unwrap_or_else(|e| panic!("write_file({path}): failed: {e}"));
+        let result = run
+            .wait()
+            .await
+            .unwrap_or_else(|e| panic!("write_file({path}): wait failed: {e}"));
+        assert_eq!(
+            result.exit_code, 0,
+            "write_file({path}): non-zero exit code"
+        );
+    }
+
+    /// Read a file from inside the box.
+    pub async fn read_file(&self, path: &str) -> String {
+        self.exec_stdout("cat", &[path]).await
+    }
+
+    /// Stop and restart the box with new options.
+    ///
+    /// Like RocksDB's `Reopen()`. Stops the current box, removes it,
+    /// creates a new one with the given options, and starts it.
+    pub async fn restart(&mut self, options: BoxOptions) {
+        let _ = self.bx.stop().await;
+        let _ = self.runtime.remove(self.bx.id().as_str(), true).await;
+
+        let bx = self
+            .runtime
+            .create(options, None)
+            .await
+            .expect("restart: create box");
+        bx.start().await.expect("restart: start box");
+        self.bx = bx;
+    }
+
+    /// Assert that the box is in a running/active state.
+    pub fn assert_running(&self) {
+        let info = self.bx.info();
+        assert!(
+            info.status.is_active(),
+            "expected box to be running, got: {:?}",
+            info.status
+        );
+    }
+
+    /// Assert that the box is stopped.
+    pub fn assert_stopped(&self) {
+        let info = self.bx.info();
+        assert!(
+            !info.status.is_active(),
+            "expected box to be stopped, got: {:?}",
+            info.status
+        );
+    }
+}
+
+// Drop: RuntimeImpl::Drop calls shutdown_sync() automatically when the
+// last Arc reference is released. No explicit cleanup needed — the runtime's
+// safety net handles stopping non-detached boxes.

--- a/boxlite-test-utils/src/cache.rs
+++ b/boxlite-test-utils/src/cache.rs
@@ -1,0 +1,291 @@
+//! Shared test cache: images, rootfs, DB snapshot.
+//!
+//! Created once per process ([`OnceLock`]), cross-process safe ([`flock`]).
+//! Replaces the monolithic `warm_home()` function.
+//!
+//! # Layout
+//!
+//! ```text
+//! target/boxlite-test/
+//! ├── images/         ← pulled OCI images (shared read-only)
+//! ├── rootfs/         ← built guest rootfs (shared read-only)
+//! ├── tmp/            ← transient files (per-test subdirs)
+//! └── db/boxlite.db   ← DB snapshot (copied per-test)
+//! ```
+
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+use boxlite::BoxliteRuntime;
+use boxlite::runtime::options::{BoxOptions, BoxliteOptions, RootfsSpec};
+
+use crate::{TEST_IMAGES, TEST_SHUTDOWN_TIMEOUT, test_registries};
+
+static SHARED_RESOURCES: OnceLock<SharedResources> = OnceLock::new();
+
+/// Shared test cache containing pre-pulled images, built rootfs, and DB snapshot.
+///
+/// Created once per process via [`SharedResources::global()`]. Cross-process safe
+/// via `flock` (nextest runs each test in a separate process).
+pub struct SharedResources {
+    /// Root of the persistent cache: `target/boxlite-test/`.
+    dir: PathBuf,
+    /// Warm home directory in `/tmp/` (short paths for Unix sockets).
+    warm_home: PathBuf,
+}
+
+impl SharedResources {
+    /// Get or create the global shared cache.
+    ///
+    /// On first call: creates cache directories, pulls images (with cross-process lock),
+    /// warms rootfs, and snapshots the DB. Subsequent calls return the cached instance.
+    pub fn global() -> &'static Self {
+        SHARED_RESOURCES.get_or_init(Self::init)
+    }
+
+    /// Path to the shared images directory.
+    pub fn images_dir(&self) -> PathBuf {
+        self.dir.join("images")
+    }
+
+    /// Path to the shared rootfs directory.
+    pub fn rootfs_dir(&self) -> PathBuf {
+        self.dir.join("rootfs")
+    }
+
+    /// Path to the shared tmp directory.
+    pub fn tmp_dir(&self) -> PathBuf {
+        self.dir.join("tmp")
+    }
+
+    /// Path to the DB snapshot.
+    pub fn db_snapshot(&self) -> PathBuf {
+        self.dir.join("db/boxlite.db")
+    }
+
+    /// Symlink shared caches into a per-test home directory and copy the DB.
+    ///
+    /// Creates:
+    /// - `home/images → target/boxlite-test/images/` (symlink, read-only)
+    /// - `home/rootfs → target/boxlite-test/rootfs/` (symlink, read-only)
+    /// - `home/tmp → target/boxlite-test/tmp/<unique>/` (symlink, per-test)
+    /// - `home/db/boxlite.db` (copy, per-test writable)
+    pub fn link_into(&self, home_dir: &Path) {
+        // Symlink images, rootfs → cache (shared, read-only)
+        for name in ["images", "rootfs"] {
+            let link = home_dir.join(name);
+            if !link.exists() {
+                let target = self.warm_home.join(name);
+                if target.exists() {
+                    let real_dir =
+                        std::fs::canonicalize(&target).unwrap_or_else(|_| target.clone());
+                    symlink_or_exists(&real_dir, &link, name);
+                }
+            }
+        }
+
+        // Per-test tmp: unique subdir on same device as rootfs.
+        // Avoids cross-test cleanup race when BoxliteRuntime::new() wipes temp_dir.
+        let cache_tmp = self.tmp_dir();
+        std::fs::create_dir_all(&cache_tmp).unwrap_or_default();
+        let per_test_tmp = tempfile::tempdir_in(&cache_tmp).expect("create per-test tmp dir");
+        let per_test_tmp_path = per_test_tmp.keep();
+        symlink_or_exists(&per_test_tmp_path, &home_dir.join("tmp"), "tmp");
+
+        // Copy DB from cache — each test gets its own writable copy.
+        let cached_db = self.db_snapshot();
+        if cached_db.exists() {
+            let db_dir = home_dir.join("db");
+            std::fs::create_dir_all(&db_dir).expect("create db dir");
+            if let Err(e) = std::fs::copy(&cached_db, db_dir.join("boxlite.db")) {
+                eprintln!("[test] warn: failed to copy cached DB: {e}");
+            }
+        }
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // Private initialization
+    // ────────────────────────────────────────────────────────────────────────
+
+    fn init() -> Self {
+        let dir = cache_dir();
+        let warm_home = PathBuf::from("/tmp/boxlite-test");
+
+        let resources = Self {
+            dir: dir.clone(),
+            warm_home: warm_home.clone(),
+        };
+
+        // Create directories
+        resources.ensure_dirs(&warm_home);
+
+        // Symlink warm_home/{images,rootfs,tmp} → cache
+        for name in ["images", "rootfs", "tmp"] {
+            let target = dir.join(name);
+            symlink_or_exists(&target, &warm_home.join(name), name);
+        }
+
+        // Fast path: cache already warm
+        if resources.is_warm() {
+            return resources;
+        }
+
+        // Cold path: cross-process lock serializes initial image pull.
+        // nextest runs each test in a separate process, so OnceLock alone doesn't help.
+        let lock_path = dir.join(".warmup.lock");
+        let _lock_file = flock_exclusive(&lock_path);
+
+        // Re-check after acquiring lock
+        if resources.is_warm() {
+            return resources;
+        }
+
+        // Pull images and warm rootfs on a dedicated thread.
+        // #[tokio::test] already has a Tokio runtime; creating another inside
+        // the same thread panics ("Cannot start a runtime from within a runtime").
+        resources.warm_on_thread(&warm_home);
+        resources.snapshot_db(&warm_home);
+
+        resources
+    }
+
+    fn ensure_dirs(&self, warm_home: &Path) {
+        std::fs::create_dir_all(warm_home).expect("create /tmp/boxlite-test");
+        for subdir in ["images", "rootfs", "tmp"] {
+            std::fs::create_dir_all(self.dir.join(subdir))
+                .unwrap_or_else(|e| panic!("create cache/{subdir}: {e}"));
+        }
+    }
+
+    fn is_warm(&self) -> bool {
+        let manifests_dir = self.images_dir().join("manifests");
+        manifests_dir.exists()
+            && std::fs::read_dir(&manifests_dir)
+                .map(|d| d.count() > 0)
+                .unwrap_or(false)
+    }
+
+    fn warm_on_thread(&self, warm_home: &Path) {
+        eprintln!("[test] Warming image cache...");
+        let home = warm_home.to_path_buf();
+        std::thread::spawn(move || {
+            let rt = tokio::runtime::Runtime::new().unwrap();
+            rt.block_on(async {
+                let runtime = BoxliteRuntime::new(BoxliteOptions {
+                    home_dir: home.clone(),
+                    image_registries: test_registries(),
+                })
+                .unwrap();
+
+                // Pull test images
+                let images = runtime.images().unwrap();
+                for image in TEST_IMAGES {
+                    match images.pull(image).await {
+                        Ok(_) => eprintln!("[test]   pulled {image}"),
+                        Err(e) => eprintln!("[test]   skip {image} ({e})"),
+                    }
+                }
+
+                // Warm rootfs by starting a box
+                eprintln!("[test] Warming guest rootfs pipeline...");
+                let handle = runtime
+                    .create(
+                        BoxOptions {
+                            rootfs: RootfsSpec::Image("alpine:latest".into()),
+                            auto_remove: false,
+                            ..Default::default()
+                        },
+                        None,
+                    )
+                    .await
+                    .unwrap();
+                handle.start().await.unwrap();
+                handle.stop().await.unwrap();
+                let _ = runtime.remove(handle.id().as_str(), false).await;
+
+                // Clean up stale boxes from previous incomplete warm-ups
+                let all_boxes = runtime.list_info().await.unwrap_or_default();
+                for info in &all_boxes {
+                    let _ = runtime.remove(info.id.as_str(), true).await;
+                }
+
+                eprintln!("[test] Guest rootfs pipeline warm.");
+                let _ = runtime.shutdown(Some(TEST_SHUTDOWN_TIMEOUT)).await;
+            });
+        })
+        .join()
+        .expect("warm-cache thread panicked");
+    }
+
+    fn snapshot_db(&self, warm_home: &Path) {
+        let cache_db = self.dir.join("db");
+        std::fs::create_dir_all(&cache_db).expect("create target/boxlite-test/db");
+        if let Err(e) = std::fs::copy(warm_home.join("db/boxlite.db"), cache_db.join("boxlite.db"))
+        {
+            eprintln!("[test] warn: failed to copy cached DB: {e}");
+        }
+    }
+}
+
+// ============================================================================
+// INTERNAL HELPERS
+// ============================================================================
+
+/// Persistent cache directory in `target/boxlite-test/`.
+fn cache_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .join("target")
+        .join("boxlite-test")
+}
+
+/// Create a symlink, ignoring `AlreadyExists` errors (race-safe).
+fn symlink_or_exists(target: &Path, link: &Path, label: &str) {
+    match std::os::unix::fs::symlink(target, link) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
+        Err(e) => panic!("symlink {label}: {e}"),
+    }
+}
+
+/// Acquire an exclusive `flock` on `path`, blocking until available.
+fn flock_exclusive(path: &Path) -> std::fs::File {
+    use std::os::unix::io::AsRawFd;
+
+    let file = std::fs::File::create(path).expect("create lock file");
+    let ret = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) };
+    assert_eq!(ret, 0, "acquire flock on {}", path.display());
+    file
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cache_dir_is_under_target() {
+        let dir = cache_dir();
+        assert!(
+            dir.to_str().unwrap().contains("target/boxlite-test"),
+            "cache_dir should be under target/: {:?}",
+            dir
+        );
+    }
+
+    #[test]
+    fn shared_resources_paths_are_consistent() {
+        // Test path construction without triggering full init
+        let resources = SharedResources {
+            dir: PathBuf::from("/test/cache"),
+            warm_home: PathBuf::from("/tmp/boxlite-test"),
+        };
+        assert_eq!(resources.images_dir(), PathBuf::from("/test/cache/images"));
+        assert_eq!(resources.rootfs_dir(), PathBuf::from("/test/cache/rootfs"));
+        assert_eq!(resources.tmp_dir(), PathBuf::from("/test/cache/tmp"));
+        assert_eq!(
+            resources.db_snapshot(),
+            PathBuf::from("/test/cache/db/boxlite.db")
+        );
+    }
+}

--- a/boxlite-test-utils/src/config_matrix.rs
+++ b/boxlite-test-utils/src/config_matrix.rs
@@ -1,0 +1,410 @@
+//! Multi-configuration test runner for boxlite.
+//!
+//! Adapts RocksDB's `do/while(ChangeOptions())` pattern. Runs one test body
+//! across multiple [`BoxOptions`] configurations.
+//!
+//! # Key types
+//!
+//! - [`BoxConfig`] — named configuration with skip conditions
+//! - [`SkipCondition`] — platform/CI skip conditions
+//! - [`default_configs()`] — standard config matrix (~8 configs)
+//!
+//! # Key functions
+//!
+//! - [`run_config_matrix()`] — sequential runner
+//! - [`config_matrix_tests!`] — generates individual `#[tokio::test]` per config
+
+use boxlite::runtime::advanced_options::{AdvancedBoxOptions, SecurityOptions};
+use boxlite::runtime::options::{BoxOptions, RootfsSpec};
+
+// ============================================================================
+// SKIP CONDITIONS
+// ============================================================================
+
+/// Conditions under which a config should be skipped.
+#[derive(Clone, Debug, Default)]
+pub struct SkipCondition {
+    /// Skip on macOS.
+    pub macos: bool,
+    /// Skip on Linux.
+    pub linux: bool,
+    /// Skip in CI environments (`CI` env var is set).
+    pub ci: bool,
+    /// Skip when jailer is not available on the platform.
+    pub no_jailer: bool,
+}
+
+impl SkipCondition {
+    /// Check whether this config should be skipped on the current platform.
+    pub fn should_skip(&self) -> Option<&'static str> {
+        if self.macos && cfg!(target_os = "macos") {
+            return Some("skipped on macOS");
+        }
+        if self.linux && cfg!(target_os = "linux") {
+            return Some("skipped on Linux");
+        }
+        if self.ci && std::env::var("CI").is_ok() {
+            return Some("skipped in CI");
+        }
+        if self.no_jailer && !SecurityOptions::is_full_isolation_available() {
+            return Some("skipped: no jailer support");
+        }
+        None
+    }
+}
+
+// ============================================================================
+// BOX CONFIG
+// ============================================================================
+
+/// A named `BoxOptions` configuration for multi-config testing.
+#[derive(Clone, Debug)]
+pub struct BoxConfig {
+    /// Human-readable name (e.g., "default", "jailer_enabled").
+    pub name: &'static str,
+    /// The `BoxOptions` to use.
+    pub options: BoxOptions,
+    /// When to skip this config.
+    pub skip_on: SkipCondition,
+}
+
+// ============================================================================
+// DEFAULT CONFIGS
+// ============================================================================
+
+/// Standard configuration matrix (~8 configs).
+///
+/// Covers common option combinations:
+/// - `default` — all defaults
+/// - `jailer_enabled` — explicit jailer on
+/// - `jailer_disabled` — jailer off (development mode)
+/// - `small_memory` — 256 MiB memory
+/// - `large_disk` — 4 GB disk
+/// - `auto_remove_false` — keep box after stop
+/// - `detach_mode` — detached box
+/// - `max_security` — maximum security preset
+pub fn default_configs() -> Vec<BoxConfig> {
+    vec![
+        BoxConfig {
+            name: "default",
+            options: BoxOptions {
+                rootfs: RootfsSpec::Image("alpine:latest".into()),
+                auto_remove: false,
+                ..Default::default()
+            },
+            skip_on: SkipCondition::default(),
+        },
+        BoxConfig {
+            name: "jailer_enabled",
+            options: BoxOptions {
+                rootfs: RootfsSpec::Image("alpine:latest".into()),
+                auto_remove: false,
+                advanced: AdvancedBoxOptions {
+                    security: SecurityOptions::standard(),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            skip_on: SkipCondition::default(),
+        },
+        BoxConfig {
+            name: "jailer_disabled",
+            options: BoxOptions {
+                rootfs: RootfsSpec::Image("alpine:latest".into()),
+                auto_remove: false,
+                advanced: AdvancedBoxOptions {
+                    security: SecurityOptions::development(),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            skip_on: SkipCondition::default(),
+        },
+        BoxConfig {
+            name: "small_memory",
+            options: BoxOptions {
+                rootfs: RootfsSpec::Image("alpine:latest".into()),
+                memory_mib: Some(256),
+                auto_remove: false,
+                ..Default::default()
+            },
+            skip_on: SkipCondition::default(),
+        },
+        BoxConfig {
+            name: "large_disk",
+            options: BoxOptions {
+                rootfs: RootfsSpec::Image("alpine:latest".into()),
+                disk_size_gb: Some(4),
+                auto_remove: false,
+                ..Default::default()
+            },
+            skip_on: SkipCondition::default(),
+        },
+        BoxConfig {
+            name: "auto_remove_false",
+            options: BoxOptions {
+                rootfs: RootfsSpec::Image("alpine:latest".into()),
+                auto_remove: false,
+                ..Default::default()
+            },
+            skip_on: SkipCondition::default(),
+        },
+        BoxConfig {
+            name: "detach_mode",
+            options: BoxOptions {
+                rootfs: RootfsSpec::Image("alpine:latest".into()),
+                auto_remove: false,
+                detach: true,
+                ..Default::default()
+            },
+            skip_on: SkipCondition::default(),
+        },
+        BoxConfig {
+            name: "max_security",
+            options: BoxOptions {
+                rootfs: RootfsSpec::Image("alpine:latest".into()),
+                auto_remove: false,
+                advanced: AdvancedBoxOptions {
+                    security: SecurityOptions::maximum(),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            skip_on: SkipCondition::default(),
+        },
+    ]
+}
+
+/// Get a config by name from `default_configs()`.
+pub fn config_by_name(name: &str) -> Option<BoxConfig> {
+    default_configs().into_iter().find(|c| c.name == name)
+}
+
+// ============================================================================
+// SKIP MASKS
+// ============================================================================
+
+/// Skip mask constants for `run_config_matrix`.
+pub mod skip {
+    /// No configs skipped.
+    pub const NONE: u32 = 0;
+    /// Skip the `jailer_enabled` config.
+    pub const JAILER_ENABLED: u32 = 1 << 0;
+    /// Skip the `jailer_disabled` config.
+    pub const JAILER_DISABLED: u32 = 1 << 1;
+    /// Skip the `max_security` config.
+    pub const MAX_SECURITY: u32 = 1 << 2;
+    /// Skip the `detach_mode` config.
+    pub const DETACH_MODE: u32 = 1 << 3;
+    /// Skip the `small_memory` config.
+    pub const SMALL_MEMORY: u32 = 1 << 4;
+    /// Skip the `large_disk` config.
+    pub const LARGE_DISK: u32 = 1 << 5;
+
+    /// Map config name to skip mask bit.
+    pub fn mask_for(name: &str) -> u32 {
+        match name {
+            "jailer_enabled" => JAILER_ENABLED,
+            "jailer_disabled" => JAILER_DISABLED,
+            "max_security" => MAX_SECURITY,
+            "detach_mode" => DETACH_MODE,
+            "small_memory" => SMALL_MEMORY,
+            "large_disk" => LARGE_DISK,
+            _ => 0,
+        }
+    }
+}
+
+// ============================================================================
+// SEQUENTIAL RUNNER
+// ============================================================================
+
+/// Run a test body across all default configs, skipping those masked out.
+///
+/// The test body receives a reference to `BoxliteRuntime` and the current `BoxConfig`.
+/// Each config is run sequentially. On skip, a message is printed to stderr.
+///
+/// # Example
+///
+/// ```ignore
+/// use boxlite_test_utils::config_matrix::{run_config_matrix, skip};
+///
+/// #[tokio::test]
+/// async fn exec_echo_across_configs() {
+///     run_config_matrix(skip::NONE, |runtime, config| async move {
+///         let handle = runtime.create(config.options.clone(), None).await.unwrap();
+///         handle.start().await.unwrap();
+///         // ... test body ...
+///         handle.stop().await.unwrap();
+///     }).await;
+/// }
+/// ```
+pub async fn run_config_matrix<F, Fut>(skip_mask: u32, test_body: F)
+where
+    F: Fn(boxlite::BoxliteRuntime, BoxConfig) -> Fut,
+    Fut: std::future::Future<Output = ()>,
+{
+    use boxlite::runtime::options::BoxliteOptions;
+
+    let configs = default_configs();
+
+    for config in configs {
+        // Check skip mask
+        if skip_mask & skip::mask_for(config.name) != 0 {
+            eprintln!("[config_matrix] skipping {} (skip mask)", config.name);
+            continue;
+        }
+
+        // Check platform skip conditions
+        if let Some(reason) = config.skip_on.should_skip() {
+            eprintln!("[config_matrix] skipping {} ({reason})", config.name);
+            continue;
+        }
+
+        eprintln!("[config_matrix] running config: {}", config.name);
+
+        let home = crate::home::PerTestBoxHome::new();
+        let runtime = boxlite::BoxliteRuntime::new(BoxliteOptions {
+            home_dir: home.path.clone(),
+            image_registries: crate::test_registries(),
+        })
+        .expect("create runtime for config matrix");
+
+        test_body(runtime, config).await;
+
+        // home dropped here → cleanup
+        drop(home);
+    }
+}
+
+// ============================================================================
+// PER-CONFIG TEST MACRO
+// ============================================================================
+
+/// Generate individual `#[tokio::test]` functions per config.
+///
+/// Each generated test has its own name (`{name}__{config}`), enabling
+/// parallel execution with `cargo nextest`.
+///
+/// # Example
+///
+/// ```ignore
+/// use boxlite_test_utils::config_matrix_tests;
+///
+/// config_matrix_tests! {
+///     name: exec_echo,
+///     configs: [default, jailer_disabled],
+///     body: |runtime, config| async move {
+///         let handle = runtime.create(config.options.clone(), None).await.unwrap();
+///         handle.start().await.unwrap();
+///         handle.stop().await.unwrap();
+///     }
+/// }
+/// // Generates:
+/// //   #[tokio::test] async fn exec_echo__default() { ... }
+/// //   #[tokio::test] async fn exec_echo__jailer_disabled() { ... }
+/// ```
+#[macro_export]
+macro_rules! config_matrix_tests {
+    (
+        name: $test_name:ident,
+        configs: [$($config_name:ident),+ $(,)?],
+        body: $body:expr
+    ) => {
+        $(
+            ::paste::paste! {
+                #[tokio::test]
+                async fn [<$test_name __ $config_name>]() {
+                    let config = $crate::config_matrix::config_by_name(
+                        stringify!($config_name)
+                    ).unwrap_or_else(|| panic!(
+                        "unknown config: {}",
+                        stringify!($config_name)
+                    ));
+
+                    if let Some(reason) = config.skip_on.should_skip() {
+                        eprintln!(
+                            "[config_matrix] skipping {} ({})",
+                            stringify!([<$test_name __ $config_name>]),
+                            reason,
+                        );
+                        return;
+                    }
+
+                    let home = $crate::home::PerTestBoxHome::new();
+                    let runtime = ::boxlite::BoxliteRuntime::new(
+                        ::boxlite::runtime::options::BoxliteOptions {
+                            home_dir: home.path.clone(),
+                            image_registries: $crate::test_registries(),
+                        }
+                    ).expect("create runtime for config matrix test");
+
+                    let test_fn = $body;
+                    test_fn(runtime, config).await;
+
+                    drop(home);
+                }
+            }
+        )+
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_configs_has_expected_count() {
+        let configs = default_configs();
+        assert_eq!(configs.len(), 8);
+    }
+
+    #[test]
+    fn default_configs_have_unique_names() {
+        let configs = default_configs();
+        let mut names: Vec<_> = configs.iter().map(|c| c.name).collect();
+        names.sort();
+        names.dedup();
+        assert_eq!(names.len(), configs.len(), "duplicate config names found");
+    }
+
+    #[test]
+    fn config_by_name_finds_existing() {
+        assert!(config_by_name("default").is_some());
+        assert!(config_by_name("jailer_enabled").is_some());
+        assert!(config_by_name("max_security").is_some());
+    }
+
+    #[test]
+    fn config_by_name_returns_none_for_unknown() {
+        assert!(config_by_name("nonexistent").is_none());
+    }
+
+    #[test]
+    fn skip_mask_filters_configs() {
+        let mask = skip::JAILER_ENABLED | skip::MAX_SECURITY;
+        assert_ne!(mask & skip::mask_for("jailer_enabled"), 0);
+        assert_ne!(mask & skip::mask_for("max_security"), 0);
+        assert_eq!(mask & skip::mask_for("default"), 0);
+        assert_eq!(mask & skip::mask_for("jailer_disabled"), 0);
+    }
+
+    #[test]
+    fn skip_condition_none_by_default() {
+        let cond = SkipCondition::default();
+        assert!(cond.should_skip().is_none());
+    }
+
+    #[test]
+    fn skip_condition_platform() {
+        let cond = SkipCondition {
+            #[cfg(target_os = "macos")]
+            macos: true,
+            #[cfg(target_os = "linux")]
+            linux: true,
+            ..Default::default()
+        };
+        // On either platform this should skip
+        assert!(cond.should_skip().is_some());
+    }
+}

--- a/boxlite-test-utils/src/fault_injection.rs
+++ b/boxlite-test-utils/src/fault_injection.rs
@@ -1,0 +1,208 @@
+//! Fault injection framework for testing error paths.
+//!
+//! `FaultInjector` uses atomic flags for thread-safe control of simulated failures.
+//! Requires `#[cfg(feature = "fault-injection")]` hooks in production code.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use boxlite_test_utils::fault_injection::FaultInjector;
+//!
+//! let injector = FaultInjector::new();
+//! injector.enable_portal_failure();
+//! // ... test that gRPC calls fail gracefully ...
+//! injector.reset();
+//! ```
+
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
+
+/// Thread-safe fault injection controller.
+///
+/// Uses atomic operations for lock-free, thread-safe flag checking.
+/// Production code checks these flags at injection points.
+pub struct FaultInjector {
+    /// Fail all portal (gRPC) calls.
+    portal_failure: AtomicBool,
+    /// Fail portal calls after N successful ones.
+    portal_fail_after: AtomicU32,
+    /// Counter for successful portal calls (compared against `portal_fail_after`).
+    portal_call_count: AtomicU32,
+    /// Simulate disk full errors.
+    disk_full: AtomicBool,
+    /// Artificial portal latency in milliseconds (0 = none).
+    portal_latency_ms: AtomicU64,
+}
+
+static GLOBAL_INJECTOR: std::sync::OnceLock<FaultInjector> = std::sync::OnceLock::new();
+
+impl FaultInjector {
+    /// Create a new fault injector with all faults disabled.
+    pub fn new() -> Self {
+        Self {
+            portal_failure: AtomicBool::new(false),
+            portal_fail_after: AtomicU32::new(u32::MAX),
+            portal_call_count: AtomicU32::new(0),
+            disk_full: AtomicBool::new(false),
+            portal_latency_ms: AtomicU64::new(0),
+        }
+    }
+
+    /// Get the global fault injector.
+    pub fn global() -> &'static Self {
+        GLOBAL_INJECTOR.get_or_init(Self::new)
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // Portal (gRPC) faults
+    // ────────────────────────────────────────────────────────────────────────
+
+    /// Enable unconditional portal failure.
+    pub fn enable_portal_failure(&self) {
+        self.portal_failure.store(true, Ordering::SeqCst);
+    }
+
+    /// Disable portal failure.
+    pub fn disable_portal_failure(&self) {
+        self.portal_failure.store(false, Ordering::SeqCst);
+    }
+
+    /// Fail portal calls after `n` successful ones.
+    pub fn fail_portal_after(&self, n: u32) {
+        self.portal_call_count.store(0, Ordering::SeqCst);
+        self.portal_fail_after.store(n, Ordering::SeqCst);
+    }
+
+    /// Check if a portal call should fail.
+    ///
+    /// Called at injection points in production code.
+    /// Returns `true` if the call should be failed.
+    pub fn should_fail_portal(&self) -> bool {
+        if self.portal_failure.load(Ordering::SeqCst) {
+            return true;
+        }
+
+        let count = self.portal_call_count.fetch_add(1, Ordering::SeqCst);
+        let threshold = self.portal_fail_after.load(Ordering::SeqCst);
+        count >= threshold
+    }
+
+    /// Set artificial portal latency in milliseconds.
+    pub fn set_portal_latency(&self, ms: u64) {
+        self.portal_latency_ms.store(ms, Ordering::SeqCst);
+    }
+
+    /// Get current portal latency setting.
+    pub fn portal_latency(&self) -> u64 {
+        self.portal_latency_ms.load(Ordering::SeqCst)
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // Disk faults
+    // ────────────────────────────────────────────────────────────────────────
+
+    /// Enable disk full simulation.
+    pub fn enable_disk_full(&self) {
+        self.disk_full.store(true, Ordering::SeqCst);
+    }
+
+    /// Disable disk full simulation.
+    pub fn disable_disk_full(&self) {
+        self.disk_full.store(false, Ordering::SeqCst);
+    }
+
+    /// Check if disk operations should fail with "disk full".
+    pub fn should_fail_disk(&self) -> bool {
+        self.disk_full.load(Ordering::SeqCst)
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // Reset
+    // ────────────────────────────────────────────────────────────────────────
+
+    /// Reset all fault injection state to defaults.
+    pub fn reset(&self) {
+        self.portal_failure.store(false, Ordering::SeqCst);
+        self.portal_fail_after.store(u32::MAX, Ordering::SeqCst);
+        self.portal_call_count.store(0, Ordering::SeqCst);
+        self.disk_full.store(false, Ordering::SeqCst);
+        self.portal_latency_ms.store(0, Ordering::SeqCst);
+    }
+}
+
+impl Default for FaultInjector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn starts_with_no_faults() {
+        let fi = FaultInjector::new();
+        assert!(!fi.should_fail_portal());
+        assert!(!fi.should_fail_disk());
+        assert_eq!(fi.portal_latency(), 0);
+    }
+
+    #[test]
+    fn portal_failure_toggle() {
+        let fi = FaultInjector::new();
+        fi.enable_portal_failure();
+        assert!(fi.should_fail_portal());
+        fi.disable_portal_failure();
+        // Reset counter since should_fail_portal increments it
+        fi.reset();
+        assert!(!fi.should_fail_portal());
+    }
+
+    #[test]
+    fn fail_portal_after_n() {
+        let fi = FaultInjector::new();
+        fi.fail_portal_after(3);
+
+        // First 3 calls succeed
+        assert!(!fi.should_fail_portal()); // count 0 < 3
+        assert!(!fi.should_fail_portal()); // count 1 < 3
+        assert!(!fi.should_fail_portal()); // count 2 < 3
+
+        // 4th call fails
+        assert!(fi.should_fail_portal()); // count 3 >= 3
+        assert!(fi.should_fail_portal()); // count 4 >= 3
+    }
+
+    #[test]
+    fn disk_full_toggle() {
+        let fi = FaultInjector::new();
+        fi.enable_disk_full();
+        assert!(fi.should_fail_disk());
+        fi.disable_disk_full();
+        assert!(!fi.should_fail_disk());
+    }
+
+    #[test]
+    fn portal_latency() {
+        let fi = FaultInjector::new();
+        fi.set_portal_latency(100);
+        assert_eq!(fi.portal_latency(), 100);
+        fi.set_portal_latency(0);
+        assert_eq!(fi.portal_latency(), 0);
+    }
+
+    #[test]
+    fn reset_clears_all() {
+        let fi = FaultInjector::new();
+        fi.enable_portal_failure();
+        fi.enable_disk_full();
+        fi.set_portal_latency(500);
+        fi.fail_portal_after(5);
+
+        fi.reset();
+
+        assert!(!fi.should_fail_portal());
+        assert!(!fi.should_fail_disk());
+        assert_eq!(fi.portal_latency(), 0);
+    }
+}

--- a/boxlite-test-utils/src/home.rs
+++ b/boxlite-test-utils/src/home.rs
@@ -1,0 +1,108 @@
+//! Per-test isolated home directory with shared cache linked in.
+//!
+//! Like RocksDB's `PerThreadDBPath` + `DestroyDB`. Each test gets a unique
+//! directory under `/tmp/`. Drop cleans up.
+//!
+//! # Layout
+//!
+//! ```text
+//! /tmp/boxlite-XXXXXX/
+//! ├── images → target/boxlite-test/images/  (symlink, read-only)
+//! ├── rootfs → target/boxlite-test/rootfs/  (symlink, read-only)
+//! ├── tmp    → target/boxlite-test/tmp/XXXX (symlink, per-test subdir)
+//! ├── db/boxlite.db                          (copy, per-test writable)
+//! ├── boxes/                                  (per-test writable)
+//! └── locks/                                  (per-test writable)
+//! ```
+
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+use crate::cache::SharedResources;
+
+/// Per-test home directory with shared cache linked in.
+///
+/// Each test gets a unique directory. Drop cleans up automatically.
+/// The image cache is symlinked (shared read-only), the DB is copied
+/// (independent writes per test).
+pub struct PerTestBoxHome {
+    /// Path to this test's home directory.
+    pub path: PathBuf,
+    _temp: TempDir,
+}
+
+impl Default for PerTestBoxHome {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PerTestBoxHome {
+    /// Create a new per-test home with shared cache.
+    ///
+    /// Triggers `SharedResources::global()` initialization if needed
+    /// (image pull, rootfs warm-up). This is the primary constructor.
+    pub fn new() -> Self {
+        let cache = SharedResources::global();
+        let temp = TempDir::new_in("/tmp").expect("create temp dir");
+        let path = temp.path().to_path_buf();
+        cache.link_into(&path);
+        Self { path, _temp: temp }
+    }
+
+    /// Create a per-test home without warm cache.
+    ///
+    /// For non-VM tests (locking behavior, config validation, shutdown tests).
+    /// Does not trigger image pulls or rootfs builds.
+    pub fn isolated() -> Self {
+        let temp = TempDir::new_in("/tmp").expect("create temp dir");
+        let path = temp.path().to_path_buf();
+        Self { path, _temp: temp }
+    }
+
+    /// Create a per-test home under a specific base directory.
+    ///
+    /// Useful for tests that need short Unix socket paths (macOS 104-char limit).
+    pub fn new_in(base: &str) -> Self {
+        let cache = SharedResources::global();
+        let temp = TempDir::new_in(base).expect("create temp dir");
+        let path = temp.path().to_path_buf();
+        cache.link_into(&path);
+        Self { path, _temp: temp }
+    }
+
+    /// Create an isolated home under a specific base directory.
+    pub fn isolated_in(base: &str) -> Self {
+        let temp = TempDir::new_in(base).expect("create temp dir");
+        let path = temp.path().to_path_buf();
+        Self { path, _temp: temp }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn isolated_creates_temp_dir() {
+        let home = PerTestBoxHome::isolated();
+        assert!(home.path.exists(), "home dir should exist");
+        assert!(
+            home.path.starts_with("/tmp"),
+            "should be under /tmp: {:?}",
+            home.path
+        );
+    }
+
+    #[test]
+    fn isolated_cleanup_on_drop() {
+        let path;
+        {
+            let home = PerTestBoxHome::isolated();
+            path = home.path.clone();
+            assert!(path.exists());
+        }
+        // After drop, temp dir should be cleaned up
+        assert!(!path.exists(), "temp dir should be cleaned up after drop");
+    }
+}

--- a/boxlite-test-utils/src/lib.rs
+++ b/boxlite-test-utils/src/lib.rs
@@ -1,18 +1,28 @@
 //! Shared test infrastructure for boxlite integration tests.
 //!
-//! Provides a warm image cache in `target/boxlite-test/` and per-test `TempDir`
-//! helpers that symlink the cache for parallel-safe test execution.
+//! # Modules
 //!
-//! # Key functions
-//! - [`warm_temp_dir()`]: Per-test `TempDir` with symlinked image cache + copied DB.
-//! - [`warm_dir()`]: Add warm caches to any existing directory.
+//! - [`assertions`] — Assertion macros (`assert_ok!`, `assert_err!`, etc.)
+//! - [`config_matrix`] — Multi-configuration test runner
+//! - [`cache`] — Shared image/rootfs cache (`SharedResources`)
+//! - [`home`] — Per-test isolated home directory (`PerTestBoxHome`)
+//! - [`box_test`] — Per-test fixture with helpers (`BoxTestBase`)
+//! - [`sync_point`] — Async sync points for concurrency testing
+//! - [`fault_injection`] — Fault injection framework
+//!
+//! # Quick Start
+//!
+//! - [`home::PerTestBoxHome::new()`]: Per-test home with shared image cache (for VM tests).
+//! - [`home::PerTestBoxHome::isolated()`]: Per-test home without cache (for non-VM tests).
 //! - [`test_registries()`]: Docker Hub mirror registries for reliable pulls.
 
-use boxlite::BoxliteRuntime;
-use boxlite::runtime::options::{BoxOptions, BoxliteOptions, RootfsSpec};
-use std::path::{Path, PathBuf};
-use std::sync::OnceLock;
-use tempfile::TempDir;
+pub mod assertions;
+pub mod box_test;
+pub mod cache;
+pub mod config_matrix;
+pub mod fault_injection;
+pub mod home;
+pub mod sync_point;
 
 /// Shutdown timeout for test runtimes (seconds).
 pub const TEST_SHUTDOWN_TIMEOUT: i32 = 10;
@@ -32,216 +42,4 @@ pub const TEST_REGISTRIES: &[&str] = &[
 /// Convert `TEST_REGISTRIES` to `Vec<String>` for `BoxliteOptions::image_registries`.
 pub fn test_registries() -> Vec<String> {
     TEST_REGISTRIES.iter().map(|s| s.to_string()).collect()
-}
-
-// ============================================================================
-// INTERNAL HELPERS
-// ============================================================================
-
-/// Create a symlink, ignoring `AlreadyExists` errors (race-safe).
-fn symlink_or_exists(target: &Path, link: &Path, label: &str) {
-    match std::os::unix::fs::symlink(target, link) {
-        Ok(_) => {}
-        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
-        Err(e) => panic!("symlink {label}: {e}"),
-    }
-}
-
-/// Acquire an exclusive `flock` on `path`, blocking until the lock is available.
-fn flock_exclusive(path: &Path) -> std::fs::File {
-    use std::os::unix::io::AsRawFd;
-
-    let file = std::fs::File::create(path).expect("create lock file");
-    let ret = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) };
-    assert_eq!(ret, 0, "acquire flock on {}", path.display());
-    file
-}
-
-static WARM_HOME: OnceLock<PathBuf> = OnceLock::new();
-
-/// Persistent cache directory in `target/boxlite-test/`.
-/// Survives reboots; cleaned by `cargo clean`.
-fn cache_dir() -> PathBuf {
-    // Walk up from this crate's manifest dir to the workspace root.
-    std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .unwrap()
-        .join("target")
-        .join("boxlite-test")
-}
-
-/// Check whether image cache in `target/` is populated.
-fn cache_is_warm() -> bool {
-    let manifests_dir = cache_dir().join("images").join("manifests");
-    manifests_dir.exists()
-        && std::fs::read_dir(&manifests_dir)
-            .map(|d| d.count() > 0)
-            .unwrap_or(false)
-}
-
-fn warm_home() -> &'static PathBuf {
-    WARM_HOME.get_or_init(|| {
-        let home = PathBuf::from("/tmp/boxlite-test");
-        std::fs::create_dir_all(&home).expect("create /tmp/boxlite-test");
-
-        // Image + rootfs caches live in target/ (persist across reboots, cleaned by cargo clean).
-        // Runtime home stays in /tmp/ for short Unix socket paths (macOS 104-char limit).
-        let cache_images = cache_dir().join("images");
-        std::fs::create_dir_all(&cache_images).expect("create target/boxlite-test/images");
-        let cache_rootfs = cache_dir().join("rootfs");
-        std::fs::create_dir_all(&cache_rootfs).expect("create target/boxlite-test/rootfs");
-        let cache_tmp = cache_dir().join("tmp");
-        std::fs::create_dir_all(&cache_tmp).expect("create target/boxlite-test/tmp");
-
-        // Symlink /tmp/boxlite-test/{images,rootfs,tmp} → target/boxlite-test/{images,rootfs,tmp}.
-        // Multiple processes may race here; symlink_or_exists handles AlreadyExists.
-        for (target, name) in [
-            (&cache_images, "images"),
-            (&cache_rootfs, "rootfs"),
-            (&cache_tmp, "tmp"),
-        ] {
-            symlink_or_exists(target, &home.join(name), name);
-        }
-
-        // Fast path: cache already warm (survives reboots)
-        if cache_is_warm() {
-            return home;
-        }
-
-        // Cold path: cross-process lock serializes the initial image pull.
-        // nextest runs each test in a separate process, so OnceLock doesn't help.
-        // Use a blocking flock — the winner pulls, losers wait then re-check.
-        let lock_path = cache_dir().join(".warmup.lock");
-        let _lock_file = flock_exclusive(&lock_path);
-
-        // Re-check after acquiring lock (another process may have finished pulling)
-        if cache_is_warm() {
-            return home;
-        }
-
-        // We won the race — pull images on a dedicated thread.
-        // #[tokio::test] already has a Tokio runtime; creating another inside
-        // the same thread panics ("Cannot start a runtime from within a runtime").
-        eprintln!("[test] Warming image cache...");
-        std::thread::spawn({
-            let home = home.clone();
-            move || {
-                let rt = tokio::runtime::Runtime::new().unwrap();
-                rt.block_on(async {
-                    let runtime = BoxliteRuntime::new(BoxliteOptions {
-                        home_dir: home.clone(),
-                        image_registries: test_registries(),
-                    })
-                    .unwrap();
-                    let images = runtime.images().unwrap();
-                    for image in TEST_IMAGES {
-                        match images.pull(image).await {
-                            Ok(_) => eprintln!("[test]   pulled {image}"),
-                            Err(e) => eprintln!("[test]   skip {image} ({e})"),
-                        }
-                    }
-
-                    // Warm the guest rootfs pipeline by starting a box.
-                    // This triggers: pull debian:bookworm-slim → build image disk → build rootfs disk → boot VM.
-                    // Pre-building these artifacts prevents concurrent builds during parallel tests.
-                    eprintln!("[test] Warming guest rootfs pipeline...");
-                    let handle = runtime
-                        .create(
-                            BoxOptions {
-                                rootfs: RootfsSpec::Image("alpine:latest".into()),
-                                auto_remove: false,
-                                ..Default::default()
-                            },
-                            None,
-                        )
-                        .await
-                        .unwrap();
-                    handle.start().await.unwrap();
-                    handle.stop().await.unwrap();
-                    let _ = runtime.remove(handle.id().as_str(), false).await;
-
-                    // Force-remove any stale boxes from previous incomplete warm-ups.
-                    // Only image index records should survive into the cached DB.
-                    let all_boxes = runtime.list_info().await.unwrap_or_default();
-                    for info in &all_boxes {
-                        let _ = runtime.remove(info.id.as_str(), true).await;
-                    }
-
-                    eprintln!("[test] Guest rootfs pipeline warm.");
-
-                    let _ = runtime.shutdown(Some(TEST_SHUTDOWN_TIMEOUT)).await;
-                });
-            }
-        })
-        .join()
-        .expect("warm-cache thread panicked");
-
-        // Cache the DB in target/ so warm_temp_dir() can copy it.
-        // The DB contains image pull records that the runtime needs to find cached images.
-        let cache_db = cache_dir().join("db");
-        std::fs::create_dir_all(&cache_db).expect("create target/boxlite-test/db");
-        if let Err(e) = std::fs::copy(home.join("db/boxlite.db"), cache_db.join("boxlite.db")) {
-            eprintln!("[test] warn: failed to copy cached DB: {e}");
-        }
-
-        // lock_file dropped here → releases flock → waiting processes proceed
-        home
-    })
-}
-
-// ============================================================================
-// PUBLIC API
-// ============================================================================
-
-/// Add warm caches (symlinked images/rootfs + copied DB) to any home directory.
-///
-/// Ensures `warm_home()` has run (images pulled and cached in `target/`), then:
-/// - Symlinks `images/` → `target/boxlite-test/images/` (shared, read-only)
-/// - Symlinks `rootfs/` → `target/boxlite-test/rootfs/` (shared, built on first box start)
-/// - Copies `db/boxlite.db` from `target/` (independent writes per test)
-pub fn warm_dir(home_dir: &Path) {
-    let warm = warm_home();
-
-    // Symlink images, rootfs → target/ cache (shared across tests, read-only).
-    for name in ["images", "rootfs"] {
-        let link = home_dir.join(name);
-        if !link.exists() {
-            let warm_target = warm.join(name);
-            if warm_target.exists() {
-                let real_dir =
-                    std::fs::canonicalize(&warm_target).unwrap_or_else(|_| warm_target.clone());
-                symlink_or_exists(&real_dir, &link, name);
-            }
-        }
-    }
-
-    // Per-test tmp: unique subdir on same device as rootfs, avoids cross-test cleanup race
-    // when BoxliteRuntime::new() wipes temp_dir contents on startup.
-    let cache_tmp = cache_dir().join("tmp");
-    std::fs::create_dir_all(&cache_tmp).unwrap_or_default();
-    let per_test_tmp = tempfile::tempdir_in(&cache_tmp).expect("create per-test tmp dir");
-    let per_test_tmp_path = per_test_tmp.keep();
-    symlink_or_exists(&per_test_tmp_path, &home_dir.join("tmp"), "tmp");
-
-    // Copy DB from target/ cache so the runtime finds cached image records.
-    // Each test gets its own DB copy — no SQLite locking conflicts.
-    let cached_db = cache_dir().join("db").join("boxlite.db");
-    if cached_db.exists() {
-        let db_dir = home_dir.join("db");
-        std::fs::create_dir_all(&db_dir).expect("create db dir");
-        if let Err(e) = std::fs::copy(&cached_db, db_dir.join("boxlite.db")) {
-            eprintln!("[test] warn: failed to copy cached DB: {e}");
-        }
-    }
-}
-
-/// Create a `TempDir` with symlinked image cache and copied DB from `target/`.
-///
-/// Each test gets its own home dir (parallel-safe). The image cache is symlinked
-/// (shared read-only) and the DB is copied (independent writes per test).
-pub fn warm_temp_dir() -> (TempDir, PathBuf) {
-    let temp_dir = TempDir::new_in("/tmp").expect("create temp dir");
-    let home_dir = temp_dir.path().to_path_buf();
-    warm_dir(&home_dir);
-    (temp_dir, home_dir)
 }

--- a/boxlite-test-utils/src/sync_point.rs
+++ b/boxlite-test-utils/src/sync_point.rs
@@ -1,0 +1,340 @@
+//! Async sync points for concurrency testing.
+//!
+//! Adapted from RocksDB's `TEST_SYNC_POINT` for async Rust. Uses
+//! `tokio::sync::Notify` + `parking_lot::Mutex` for async-safe coordination.
+//!
+//! Compiled to no-op in release builds via `#[cfg(debug_assertions)]`.
+//!
+//! # Production code usage
+//!
+//! ```ignore
+//! // boxlite/src/vmm/shim_controller.rs
+//! pub async fn stop(&self) {
+//!     test_sync_point!("ShimController::stop::before_signal");
+//!     self.signal_shutdown().await;
+//! }
+//! ```
+//!
+//! # Test usage
+//!
+//! ```ignore
+//! use boxlite_test_utils::sync_point::{SyncPointRegistry, SyncPointPair};
+//!
+//! SyncPointRegistry::global().load_dependency(&[
+//!     SyncPointPair {
+//!         predecessor: "ShimController::stop::before_signal",
+//!         successor: "Portal::exec::before_send",
+//!     },
+//! ]);
+//! SyncPointRegistry::global().enable();
+//! // ... spawn concurrent tasks ...
+//! SyncPointRegistry::global().disable();
+//! ```
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use parking_lot::Mutex;
+use tokio::sync::Notify;
+
+// ============================================================================
+// SYNC POINT PAIR
+// ============================================================================
+
+/// A dependency relationship between two sync points.
+///
+/// When `predecessor` is reached, it waits until `successor` is also reached,
+/// creating a happens-before relationship.
+#[derive(Debug, Clone)]
+pub struct SyncPointPair {
+    /// The sync point that must wait.
+    pub predecessor: &'static str,
+    /// The sync point that unblocks the predecessor.
+    pub successor: &'static str,
+}
+
+// ============================================================================
+// SYNC POINT REGISTRY
+// ============================================================================
+
+/// Global registry of sync points and their dependencies.
+///
+/// Thread-safe via `parking_lot::Mutex`. Async-safe via `tokio::sync::Notify`.
+pub struct SyncPointRegistry {
+    enabled: AtomicBool,
+    inner: Mutex<RegistryInner>,
+}
+
+struct RegistryInner {
+    /// Map from sync point name → list of notifiers it should wait on.
+    wait_on: HashMap<&'static str, Vec<std::sync::Arc<Notify>>>,
+    /// Map from sync point name → list of notifiers it should trigger.
+    triggers: HashMap<&'static str, Vec<std::sync::Arc<Notify>>>,
+    /// Custom callbacks triggered at sync points (for advanced use).
+    callbacks: HashMap<&'static str, Vec<std::sync::Arc<dyn Fn() + Send + Sync>>>,
+}
+
+static GLOBAL_REGISTRY: std::sync::OnceLock<SyncPointRegistry> = std::sync::OnceLock::new();
+
+impl SyncPointRegistry {
+    /// Get the global sync point registry.
+    pub fn global() -> &'static Self {
+        GLOBAL_REGISTRY.get_or_init(Self::new)
+    }
+
+    /// Create a new empty registry.
+    pub fn new() -> Self {
+        Self {
+            enabled: AtomicBool::new(false),
+            inner: Mutex::new(RegistryInner {
+                wait_on: HashMap::new(),
+                triggers: HashMap::new(),
+                callbacks: HashMap::new(),
+            }),
+        }
+    }
+
+    /// Enable sync point processing.
+    pub fn enable(&self) {
+        self.enabled.store(true, Ordering::SeqCst);
+    }
+
+    /// Disable sync point processing and clear all dependencies.
+    pub fn disable(&self) {
+        self.enabled.store(false, Ordering::SeqCst);
+        self.clear();
+    }
+
+    /// Check if sync points are enabled.
+    pub fn is_enabled(&self) -> bool {
+        self.enabled.load(Ordering::SeqCst)
+    }
+
+    /// Load dependency pairs.
+    ///
+    /// For each pair: when `predecessor` is reached, it waits until
+    /// `successor` notifies it.
+    pub fn load_dependency(&self, pairs: &[SyncPointPair]) {
+        let mut inner = self.inner.lock();
+        for pair in pairs {
+            let notify = std::sync::Arc::new(Notify::new());
+
+            // predecessor waits on this notify
+            inner
+                .wait_on
+                .entry(pair.predecessor)
+                .or_default()
+                .push(notify.clone());
+
+            // successor triggers this notify
+            inner
+                .triggers
+                .entry(pair.successor)
+                .or_default()
+                .push(notify);
+        }
+    }
+
+    /// Register a callback to fire when a sync point is reached.
+    pub fn set_callback<F>(&self, name: &'static str, callback: F)
+    where
+        F: Fn() + Send + Sync + 'static,
+    {
+        let mut inner = self.inner.lock();
+        inner
+            .callbacks
+            .entry(name)
+            .or_default()
+            .push(std::sync::Arc::new(callback));
+    }
+
+    /// Process a sync point hit. Called by the `test_sync_point!` macro.
+    ///
+    /// 1. Fire any registered callbacks
+    /// 2. Notify any successors waiting on this point
+    /// 3. Wait for all predecessors to complete
+    pub async fn process(&self, name: &str) {
+        if !self.is_enabled() {
+            return;
+        }
+
+        let (callbacks, triggers, waiters) = {
+            let inner = self.inner.lock();
+            let callbacks: Vec<std::sync::Arc<dyn Fn() + Send + Sync>> =
+                inner.callbacks.get(name).cloned().unwrap_or_default();
+            let triggers: Vec<std::sync::Arc<Notify>> =
+                inner.triggers.get(name).cloned().unwrap_or_default();
+            let waiters: Vec<std::sync::Arc<Notify>> =
+                inner.wait_on.get(name).cloned().unwrap_or_default();
+            (callbacks, triggers, waiters)
+        };
+
+        // Fire callbacks
+        for cb in &callbacks {
+            cb();
+        }
+
+        // Notify successors
+        for notify in &triggers {
+            notify.notify_one();
+        }
+
+        // Wait for predecessors
+        for notify in &waiters {
+            notify.notified().await;
+        }
+    }
+
+    /// Clear all dependencies and callbacks.
+    pub fn clear(&self) {
+        let mut inner = self.inner.lock();
+        inner.wait_on.clear();
+        inner.triggers.clear();
+        inner.callbacks.clear();
+    }
+}
+
+impl Default for SyncPointRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ============================================================================
+// SYNC POINT MACRO
+// ============================================================================
+
+/// Hit a sync point in production code.
+///
+/// In debug builds: calls `SyncPointRegistry::global().process(name).await`.
+/// In release builds: compiles to nothing.
+///
+/// # Usage
+///
+/// ```ignore
+/// use boxlite_test_utils::test_sync_point;
+///
+/// async fn stop(&self) {
+///     test_sync_point!("ShimController::stop::before_signal");
+///     self.signal_shutdown().await;
+/// }
+/// ```
+#[macro_export]
+macro_rules! test_sync_point {
+    ($name:expr) => {
+        #[cfg(debug_assertions)]
+        {
+            $crate::sync_point::SyncPointRegistry::global()
+                .process($name)
+                .await;
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registry_starts_disabled() {
+        let reg = SyncPointRegistry::new();
+        assert!(!reg.is_enabled());
+    }
+
+    #[test]
+    fn enable_disable_toggle() {
+        let reg = SyncPointRegistry::new();
+        reg.enable();
+        assert!(reg.is_enabled());
+        reg.disable();
+        assert!(!reg.is_enabled());
+    }
+
+    #[tokio::test]
+    async fn process_noop_when_disabled() {
+        let reg = SyncPointRegistry::new();
+        // Should return immediately without blocking
+        reg.process("nonexistent::point").await;
+    }
+
+    #[tokio::test]
+    async fn callback_fires_on_process() {
+        let reg = SyncPointRegistry::new();
+        let fired = std::sync::Arc::new(AtomicBool::new(false));
+        let fired_clone = fired.clone();
+
+        reg.set_callback("test::callback", move || {
+            fired_clone.store(true, Ordering::SeqCst);
+        });
+
+        reg.enable();
+        reg.process("test::callback").await;
+        assert!(fired.load(Ordering::SeqCst));
+        reg.disable();
+    }
+
+    #[tokio::test]
+    async fn dependency_pair_blocks_predecessor() {
+        let reg = std::sync::Arc::new(SyncPointRegistry::new());
+
+        reg.load_dependency(&[SyncPointPair {
+            predecessor: "first",
+            successor: "second",
+        }]);
+        reg.enable();
+
+        let order = std::sync::Arc::new(Mutex::new(Vec::<&str>::new()));
+
+        // Predecessor task — should block until successor runs
+        let predecessor = tokio::spawn({
+            let reg = reg.clone();
+            let order = order.clone();
+            async move {
+                reg.process("first").await;
+                order.lock().push("first_done");
+            }
+        });
+
+        // Give predecessor a moment to start
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        // Successor task — unblocks predecessor
+        order.lock().push("second_start");
+        reg.process("second").await;
+        order.lock().push("second_done");
+
+        predecessor.await.unwrap();
+
+        let final_order = order.lock().clone();
+        // second_start should come before first_done (predecessor waited)
+        let second_idx = final_order
+            .iter()
+            .position(|s| *s == "second_start")
+            .unwrap();
+        let first_idx = final_order.iter().position(|s| *s == "first_done").unwrap();
+        assert!(
+            second_idx < first_idx,
+            "predecessor should wait for successor: {:?}",
+            final_order
+        );
+
+        reg.disable();
+    }
+
+    #[test]
+    fn clear_removes_all_state() {
+        let reg = SyncPointRegistry::new();
+        reg.load_dependency(&[SyncPointPair {
+            predecessor: "a",
+            successor: "b",
+        }]);
+        reg.set_callback("c", || {});
+
+        reg.clear();
+
+        let inner = reg.inner.lock();
+        assert!(inner.wait_on.is_empty());
+        assert!(inner.triggers.is_empty());
+        assert!(inner.callbacks.is_empty());
+    }
+}

--- a/boxlite/src/litebox/box_impl.rs
+++ b/boxlite/src/litebox/box_impl.rs
@@ -6,7 +6,7 @@
 
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use parking_lot::RwLock;
 use tokio::sync::OnceCell;
@@ -307,9 +307,17 @@ impl BoxImpl {
 
         // Only try to stop VM if LiveState exists
         if let Some(live) = self.live.get() {
-            // Gracefully shut down guest
-            if let Ok(mut guest) = live.guest_session.guest().await {
-                let _ = guest.shutdown().await;
+            // Gracefully shut down guest (with timeout to avoid hanging on unresponsive guests)
+            let guest_shutdown = async {
+                if let Ok(mut guest) = live.guest_session.guest().await {
+                    let _ = guest.shutdown().await;
+                }
+            };
+            if tokio::time::timeout(Duration::from_secs(10), guest_shutdown)
+                .await
+                .is_err()
+            {
+                tracing::warn!(box_id = %self.config.id, "Guest shutdown timed out after 10s");
             }
 
             // Stop handler

--- a/boxlite/src/portal/connection.rs
+++ b/boxlite/src/portal/connection.rs
@@ -2,9 +2,11 @@
 //!
 //! Converts Transport to tonic Channel with lazy initialization.
 
+use std::sync::Arc;
+use std::time::Duration;
+
 use boxlite_shared::{BoxliteError, BoxliteResult, Transport};
 use hyper_util::rt::TokioIo;
-use std::sync::Arc;
 use tokio::sync::OnceCell;
 use tonic::transport::{Channel, Endpoint, Uri};
 use tower::service_fn;
@@ -60,6 +62,7 @@ async fn connect_unix(socket_path: &std::path::Path) -> BoxliteResult<Channel> {
     let socket_path = socket_path.to_path_buf();
 
     let channel = Endpoint::try_from("http://[::]:50051")?
+        .connect_timeout(Duration::from_secs(30))
         .connect_with_connector(service_fn(move |_: Uri| {
             let socket_path = socket_path.clone();
             async move {
@@ -75,7 +78,10 @@ async fn connect_unix(socket_path: &std::path::Path) -> BoxliteResult<Channel> {
 
 async fn connect_tcp(port: u16) -> BoxliteResult<Channel> {
     let addr = format!("http://127.0.0.1:{}", port);
-    let channel = Endpoint::try_from(addr)?.connect().await?;
+    let channel = Endpoint::try_from(addr)?
+        .connect_timeout(Duration::from_secs(30))
+        .connect()
+        .await?;
 
     tracing::debug!("Connected via TCP");
     Ok(channel)

--- a/boxlite/src/util/process.rs
+++ b/boxlite/src/util/process.rs
@@ -524,6 +524,68 @@ mod tests {
         }
     }
 
+    // ========================================================================
+    // read_pid_file edge cases
+    // ========================================================================
+
+    #[test]
+    fn test_read_pid_file_with_whitespace() {
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        let mut file = NamedTempFile::new().unwrap();
+        write!(file, "  12345\n\n").unwrap();
+
+        let pid = read_pid_file(file.path()).expect("Should parse PID with whitespace");
+        assert_eq!(pid, 12345);
+    }
+
+    #[test]
+    fn test_read_pid_file_empty_rejected() {
+        use tempfile::NamedTempFile;
+
+        // NamedTempFile::new() creates an empty file
+        let file = NamedTempFile::new().unwrap();
+        let result = read_pid_file(file.path());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_read_pid_file_large_pid() {
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        let mut file = NamedTempFile::new().unwrap();
+        write!(file, "4194304").unwrap(); // Max PID on Linux
+
+        let pid = read_pid_file(file.path()).expect("Should parse max Linux PID");
+        assert_eq!(pid, 4194304);
+    }
+
+    #[test]
+    fn test_read_pid_file_negative_rejected() {
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        let mut file = NamedTempFile::new().unwrap();
+        write!(file, "-1").unwrap();
+
+        let result = read_pid_file(file.path());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_read_pid_file_overflow_rejected() {
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        let mut file = NamedTempFile::new().unwrap();
+        write!(file, "99999999999").unwrap();
+
+        let result = read_pid_file(file.path());
+        assert!(result.is_err());
+    }
+
     #[test]
     fn test_process_exit_equality() {
         assert_eq!(ProcessExit::Code(0), ProcessExit::Code(0));

--- a/boxlite/tests/README.md
+++ b/boxlite/tests/README.md
@@ -28,7 +28,7 @@ This directory contains integration tests for the BoxLite runtime. Tests run con
 | `timing_profile.rs` | Yes | Boot latency profiling |
 | `network.rs` | No | Network configuration tests |
 | `runtime.rs` | No | Runtime initialization and configuration tests |
-| `shutdown.rs` | No | Shutdown behavior (`IsolatedRuntime`, no VM) |
+| `shutdown.rs` | No | Shutdown behavior (isolated home, no VM) |
 
 ### macOS Seatbelt deny lifecycle tests
 
@@ -67,54 +67,52 @@ make test:integration
 
 ## Test Infrastructure
 
-All test files use shared infrastructure from `common/mod.rs`. Three runtime flavors provide per-test isolation for concurrent execution:
+All test files use shared infrastructure from `boxlite-test-utils` and `common/mod.rs`. Per-test isolation is achieved via `PerTestBoxHome` which creates a temporary directory with optional symlinked image cache.
 
-### `ParallelRuntime` — VM integration tests
+### `PerTestBoxHome::new()` — VM integration tests
 
 Per-test `TempDir` with symlinked image cache from `target/boxlite-test/`. On first use, a cross-process `flock` serializes the initial image pull and guest rootfs warmup. Subsequent tests reuse the cached artifacts.
 
 ```rust
-use crate::common::ParallelRuntime;
+use boxlite_test_utils::home::PerTestBoxHome;
 
 #[tokio::test]
 async fn test_box_lifecycle() {
-    let ctx = ParallelRuntime::new();
-    let handle = ctx.runtime.create(alpine_opts(), None).await.unwrap();
+    let home = PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    }).expect("create runtime");
+    let handle = runtime.create(alpine_opts(), None).await.unwrap();
     handle.start().await.unwrap();
     // ... test logic ...
     handle.stop().await.unwrap();
-    ctx.shutdown().await;
+    let _ = runtime.shutdown(Some(common::TEST_SHUTDOWN_TIMEOUT)).await;
 }
 ```
 
-### `IsolatedRuntime` — non-VM tests
+### `PerTestBoxHome::isolated()` — non-VM tests
 
 Per-test `TempDir` with no image cache. For tests that don't boot VMs: locking behavior, shutdown idempotency, config validation.
 
 ```rust
-use crate::common::IsolatedRuntime;
+use boxlite_test_utils::home::PerTestBoxHome;
 
 #[tokio::test]
 async fn test_shutdown_idempotent() {
-    let ctx = IsolatedRuntime::new();
-    // ... test logic using ctx.runtime ...
+    let home = PerTestBoxHome::isolated();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    }).expect("create runtime");
+    // ... test logic using runtime ...
 }
 ```
 
-### `warm_temp_dir()` — recovery tests
+### Other `PerTestBoxHome` constructors
 
-Raw `TempDir` + symlinked image cache. For tests that create and drop multiple runtimes manually (e.g., crash recovery, state persistence across restarts).
-
-```rust
-use crate::common::warm_temp_dir;
-
-#[tokio::test]
-async fn test_recovery_after_crash() {
-    let (temp_dir, home_dir) = warm_temp_dir();
-    // Create first runtime, do work, drop it
-    // Create second runtime with same home_dir, verify recovery
-}
-```
+- `PerTestBoxHome::new_in(base)` — warm cache under a custom base directory (e.g., `~/.boxlite-it` for short socket paths)
+- `PerTestBoxHome::isolated_in(base)` — no cache under a custom base directory
 
 ### macOS Socket Path Limits
 
@@ -150,7 +148,7 @@ If you see errors about socket paths, ensure the test home base path is short:
 
 ```rust
 let base = dirs::home_dir().unwrap().join(".boxlite-it");
-let temp_dir = TempDir::new_in(base).expect("Failed to create temp dir");
+let home = PerTestBoxHome::new_in(base.to_str().unwrap());
 ```
 
 ### Tests Hang

--- a/boxlite/tests/clone_export_import.rs
+++ b/boxlite/tests/clone_export_import.rs
@@ -9,7 +9,7 @@
 
 mod common;
 
-use boxlite::runtime::options::{CloneOptions, ExportOptions};
+use boxlite::runtime::options::{BoxliteOptions, CloneOptions, ExportOptions};
 use boxlite::runtime::types::BoxStatus;
 use boxlite::{BoxCommand, BoxliteRuntime, LiteBox};
 use tempfile::TempDir;
@@ -51,8 +51,13 @@ async fn create_running_box(runtime: &BoxliteRuntime, name: &str) -> LiteBox {
 
 #[tokio::test]
 async fn test_clone_produces_independent_box() {
-    let ctx = common::ParallelRuntime::new();
-    let source = create_stopped_box(&ctx.runtime).await;
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+    let source = create_stopped_box(&runtime).await;
 
     let cloned = source
         .clone_box(CloneOptions::default(), Some("cloned-box".to_string()))
@@ -70,13 +75,18 @@ async fn test_clone_produces_independent_box() {
     cloned.start().await.expect("Failed to start cloned box");
     cloned.stop().await.expect("Failed to stop cloned box");
 
-    ctx.shutdown().await;
+    let _ = runtime.shutdown(Some(common::TEST_SHUTDOWN_TIMEOUT)).await;
 }
 
 #[tokio::test]
 async fn test_export_import_roundtrip() {
-    let ctx = common::ParallelRuntime::new();
-    let source = create_stopped_box(&ctx.runtime).await;
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+    let source = create_stopped_box(&runtime).await;
 
     let export_dir = TempDir::new_in("/tmp").unwrap();
     let export_path = export_dir.path();
@@ -89,8 +99,7 @@ async fn test_export_import_roundtrip() {
     assert!(archive.path().exists());
     assert!(archive.path().extension().is_some_and(|e| e == "boxlite"));
 
-    let imported = ctx
-        .runtime
+    let imported = runtime
         .import_box(archive, Some("imported-box".to_string()))
         .await
         .expect("Failed to import box");
@@ -106,15 +115,19 @@ async fn test_export_import_roundtrip() {
         .expect("Failed to start imported box");
     imported.stop().await.expect("Failed to stop imported box");
 
-    ctx.shutdown().await;
+    let _ = runtime.shutdown(Some(common::TEST_SHUTDOWN_TIMEOUT)).await;
 }
 
 #[tokio::test]
 async fn test_export_import_preserves_box_options() {
-    let ctx = common::ParallelRuntime::new();
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
 
-    let source = ctx
-        .runtime
+    let source = runtime
         .create(common::alpine_opts(), Some("options-test".to_string()))
         .await
         .expect("Failed to create box");
@@ -130,12 +143,12 @@ async fn test_export_import_preserves_box_options() {
         .await
         .expect("export");
 
-    let imported = ctx.runtime.import_box(archive, None).await.expect("import");
+    let imported = runtime.import_box(archive, None).await.expect("import");
 
     let imported_info = imported.info();
     assert_eq!(imported_info.status, BoxStatus::Stopped);
 
-    ctx.shutdown().await;
+    let _ = runtime.shutdown(Some(common::TEST_SHUTDOWN_TIMEOUT)).await;
 }
 
 // ============================================================================
@@ -144,8 +157,13 @@ async fn test_export_import_preserves_box_options() {
 
 #[tokio::test]
 async fn test_clone_running_box() {
-    let ctx = common::ParallelRuntime::new();
-    let source = create_running_box(&ctx.runtime, "clone-src").await;
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+    let source = create_running_box(&runtime, "clone-src").await;
 
     // Clone while source is running — should succeed without stopping
     let cloned = source
@@ -178,13 +196,18 @@ async fn test_clone_running_box() {
 
     source.stop().await.expect("Stop source box");
 
-    ctx.shutdown().await;
+    let _ = runtime.shutdown(Some(common::TEST_SHUTDOWN_TIMEOUT)).await;
 }
 
 #[tokio::test]
 async fn test_export_running_box() {
-    let ctx = common::ParallelRuntime::new();
-    let source = create_running_box(&ctx.runtime, "export-running").await;
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+    let source = create_running_box(&runtime, "export-running").await;
 
     let export_dir = TempDir::new_in("/tmp").unwrap();
     let export_path = export_dir.path();
@@ -209,8 +232,7 @@ async fn test_export_running_box() {
     assert_eq!(result.exit_code, 0);
 
     // Archived box can be imported and started
-    let imported = ctx
-        .runtime
+    let imported = runtime
         .import_box(archive, Some("imported-running".to_string()))
         .await
         .expect("Import should succeed");
@@ -220,13 +242,18 @@ async fn test_export_running_box() {
 
     source.stop().await.expect("Stop source box");
 
-    ctx.shutdown().await;
+    let _ = runtime.shutdown(Some(common::TEST_SHUTDOWN_TIMEOUT)).await;
 }
 
 #[tokio::test]
 async fn test_export_import_running_box_roundtrip() {
-    let ctx = common::ParallelRuntime::new();
-    let source = create_running_box(&ctx.runtime, "roundtrip-running").await;
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+    let source = create_running_box(&runtime, "roundtrip-running").await;
 
     // Write a marker file inside the running VM
     let cmd = BoxCommand::new("sh").args(["-c", "echo boxlite-test-data > /root/marker.txt"]);
@@ -247,8 +274,7 @@ async fn test_export_import_running_box_roundtrip() {
     assert_eq!(source.info().status, BoxStatus::Running);
 
     // Import and verify the marker file is preserved
-    let imported = ctx
-        .runtime
+    let imported = runtime
         .import_box(archive, Some("imported-roundtrip".to_string()))
         .await
         .expect("Import should succeed");
@@ -266,7 +292,7 @@ async fn test_export_import_running_box_roundtrip() {
     imported.stop().await.expect("Stop imported box");
     source.stop().await.expect("Stop source box");
 
-    ctx.shutdown().await;
+    let _ = runtime.shutdown(Some(common::TEST_SHUTDOWN_TIMEOUT)).await;
 }
 
 // ============================================================================
@@ -275,8 +301,13 @@ async fn test_export_import_running_box_roundtrip() {
 
 #[tokio::test]
 async fn test_export_under_write_pressure() {
-    let ctx = common::ParallelRuntime::new();
-    let source = create_running_box(&ctx.runtime, "write-stress").await;
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+    let source = create_running_box(&runtime, "write-stress").await;
 
     // Start a background process that continuously writes random 4KB blocks
     // to a file at random offsets. This simulates active I/O during export.
@@ -305,8 +336,7 @@ async fn test_export_under_write_pressure() {
     assert_eq!(source.info().status, BoxStatus::Running);
 
     // Import the archive and verify the filesystem is intact (bootable)
-    let imported = ctx
-        .runtime
+    let imported = runtime
         .import_box(archive, Some("imported-stress".to_string()))
         .await
         .expect("Import should succeed");
@@ -328,5 +358,5 @@ async fn test_export_under_write_pressure() {
     imported.stop().await.expect("Stop imported box");
     source.stop().await.expect("Stop source box");
 
-    ctx.shutdown().await;
+    let _ = runtime.shutdown(Some(common::TEST_SHUTDOWN_TIMEOUT)).await;
 }

--- a/boxlite/tests/common/mod.rs
+++ b/boxlite/tests/common/mod.rs
@@ -1,11 +1,8 @@
 //! Shared test infrastructure for boxlite integration tests.
 //!
-//! Runtime flavors:
-//! - [`ParallelRuntime`]: Per-test `TempDir` + symlinked image cache.
-//!   Each test gets its own home dir → parallel-safe even for VM tests.
-//! - [`IsolatedRuntime`]: Per-test `TempDir`, no image cache. For non-VM tests.
-//! - [`warm_temp_dir()`]: Raw `TempDir` + image symlink. For recovery tests
-//!   that create/drop multiple runtimes manually.
+//! Runtime setup:
+//! - [`PerTestBoxHome::new()`]: Per-test home with image cache (for VM tests).
+//! - [`PerTestBoxHome::isolated()`]: Per-test home without cache (for non-VM tests).
 //!
 //! Helper functions:
 //! - [`alpine_opts()`]: Default `BoxOptions` with `alpine:latest`, `auto_remove=false`
@@ -13,13 +10,10 @@
 
 #![allow(dead_code)]
 
-// Re-export shared warm-cache infrastructure from boxlite-test-utils.
+// Re-export shared infrastructure from boxlite-test-utils.
 pub use boxlite_test_utils::*;
 
-use boxlite::BoxliteRuntime;
-use boxlite::runtime::options::{BoxOptions, BoxliteOptions, RootfsSpec};
-use std::path::PathBuf;
-use tempfile::TempDir;
+use boxlite::runtime::options::{BoxOptions, RootfsSpec};
 
 // ============================================================================
 // BOX OPTIONS HELPERS
@@ -40,94 +34,5 @@ pub fn alpine_opts_auto() -> BoxOptions {
         rootfs: RootfsSpec::Image("alpine:latest".into()),
         auto_remove: true,
         ..Default::default()
-    }
-}
-
-// ============================================================================
-// PARALLEL RUNTIME (per-test TempDir, symlinked images)
-// ============================================================================
-
-/// Per-test runtime with isolated TempDir and symlinked image cache.
-///
-/// Parallel-safe: each test gets its own home dir (unique flock).
-/// Drop order: `runtime` drops first (shutdown_sync), `_temp_dir` drops last (cleanup).
-pub struct ParallelRuntime {
-    pub runtime: BoxliteRuntime,
-    pub home_dir: PathBuf,
-    _temp_dir: TempDir,
-}
-
-impl ParallelRuntime {
-    pub fn new() -> Self {
-        let (temp_dir, home_dir) = warm_temp_dir();
-        let runtime = BoxliteRuntime::new(BoxliteOptions {
-            home_dir: home_dir.clone(),
-            image_registries: test_registries(),
-        })
-        .expect("create parallel runtime");
-        Self {
-            runtime,
-            home_dir,
-            _temp_dir: temp_dir,
-        }
-    }
-
-    /// Shut down the runtime with the standard test timeout.
-    pub async fn shutdown(&self) {
-        let _ = self.runtime.shutdown(Some(TEST_SHUTDOWN_TIMEOUT)).await;
-    }
-}
-
-// ============================================================================
-// ISOLATED RUNTIME (per-test TempDir, for non-VM tests)
-// ============================================================================
-
-/// Isolated runtime with per-test temp directory.
-///
-/// Safe for parallel execution. Use for tests that don't boot VMs:
-/// locking behavior, shutdown idempotency, config validation.
-pub struct IsolatedRuntime {
-    pub runtime: BoxliteRuntime,
-    pub home_dir: PathBuf,
-    _temp_dir: TempDir,
-}
-
-impl IsolatedRuntime {
-    /// Create isolated runtime with `TempDir` in system default location.
-    pub fn new() -> Self {
-        Self::new_in_base(None, false)
-    }
-
-    /// Create isolated runtime with `TempDir` under a specific base.
-    /// Use `new_in("/tmp")` to keep Unix socket paths short on macOS.
-    pub fn new_in(base: &str) -> Self {
-        Self::new_in_base(Some(base), false)
-    }
-
-    /// Create isolated runtime with pre-warmed image cache.
-    /// Use for tests that boot VMs but can't use `ParallelRuntime`.
-    pub fn new_warm(base: &str) -> Self {
-        Self::new_in_base(Some(base), true)
-    }
-
-    fn new_in_base(base: Option<&str>, warm: bool) -> Self {
-        let temp_dir = match base {
-            Some(b) => TempDir::new_in(b).expect("create temp dir"),
-            None => TempDir::new().expect("create temp dir"),
-        };
-        let home_dir = temp_dir.path().to_path_buf();
-        if warm {
-            warm_dir(&home_dir);
-        }
-        let runtime = BoxliteRuntime::new(BoxliteOptions {
-            home_dir: home_dir.clone(),
-            image_registries: test_registries(),
-        })
-        .expect("create isolated runtime");
-        Self {
-            runtime,
-            home_dir,
-            _temp_dir: temp_dir,
-        }
     }
 }

--- a/boxlite/tests/copy.rs
+++ b/boxlite/tests/copy.rs
@@ -9,6 +9,8 @@
 
 mod common;
 
+use boxlite::BoxliteRuntime;
+use boxlite::runtime::options::BoxliteOptions;
 use boxlite::{BoxCommand, CopyOptions, LiteBox};
 use std::path::Path;
 use tempfile::TempDir;
@@ -48,9 +50,13 @@ async fn exec_exit_code(bx: &LiteBox, cmd: BoxCommand) -> i32 {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn copy_integration() {
-    let ctx = common::ParallelRuntime::new();
-    let bx = ctx
-        .runtime
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+    let bx = runtime
         .create(common::alpine_opts(), None)
         .await
         .expect("create box");
@@ -80,7 +86,7 @@ async fn copy_integration() {
     copy_out_nonexistent_errors(&bx, tmp.path()).await;
     concurrent_copy_roundtrip(&bx, tmp.path()).await;
 
-    ctx.shutdown().await;
+    let _ = runtime.shutdown(Some(common::TEST_SHUTDOWN_TIMEOUT)).await;
 }
 
 // ============================================================================

--- a/boxlite/tests/detach.rs
+++ b/boxlite/tests/detach.rs
@@ -1,0 +1,282 @@
+//! Integration tests for detach mode behavior.
+//!
+//! Verifies detached boxes survive runtime drop, non-detached boxes exit
+//! via watchdog POLLHUP, and detached boxes can be recovered after restart.
+
+mod common;
+
+use boxlite::BoxliteRuntime;
+use boxlite::litebox::BoxCommand;
+use boxlite::runtime::options::BoxliteOptions;
+use boxlite::runtime::types::BoxStatus;
+use boxlite::util::{is_process_alive, read_pid_file};
+use std::path::{Path, PathBuf};
+
+// ============================================================================
+// LOCAL HELPERS
+// ============================================================================
+
+/// Get the PID file path for a box under the given home directory.
+fn pid_file_path(home_dir: &Path, box_id: &str) -> PathBuf {
+    home_dir.join("boxes").join(box_id).join("shim.pid")
+}
+
+// ============================================================================
+// DETACH MODE TESTS
+// ============================================================================
+
+#[tokio::test]
+async fn detached_box_creates_pid_file() {
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+
+    let handle = runtime
+        .create(
+            boxlite::runtime::options::BoxOptions {
+                detach: true,
+                ..common::alpine_opts()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    let _ = handle.exec(BoxCommand::new("sleep").args(["300"])).await;
+
+    let pf = pid_file_path(&home.path, handle.id().as_str());
+    assert!(pf.exists(), "Detached box should have PID file");
+
+    // Cleanup
+    runtime.remove(handle.id().as_str(), true).await.unwrap();
+}
+
+#[tokio::test]
+async fn detached_box_survives_runtime_drop() {
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let box_id: String;
+    let original_pid: u32;
+
+    // Create detached box
+    {
+        let runtime = BoxliteRuntime::new(BoxliteOptions {
+            home_dir: home.path.clone(),
+            image_registries: common::test_registries(),
+        })
+        .unwrap();
+
+        let handle = runtime
+            .create(
+                boxlite::runtime::options::BoxOptions {
+                    detach: true,
+                    ..common::alpine_opts()
+                },
+                None,
+            )
+            .await
+            .unwrap();
+
+        let _ = handle.exec(BoxCommand::new("sleep").args(["300"])).await;
+        box_id = handle.id().to_string();
+
+        let pf = pid_file_path(&home.path, &box_id);
+        original_pid = read_pid_file(&pf).unwrap();
+
+        // Runtime drops here - box should survive
+    }
+
+    // Wait a moment
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    // Verify process still alive
+    assert!(
+        is_process_alive(original_pid),
+        "Detached box process {} should survive runtime drop",
+        original_pid
+    );
+
+    // Cleanup
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .unwrap();
+    runtime.remove(&box_id, true).await.unwrap();
+}
+
+/// Non-detached box should exit when runtime drops (watchdog POLLHUP).
+///
+/// Symmetric counterpart to `detached_box_survives_runtime_drop`.
+/// Verifies the full watchdog chain:
+///   Keepalive drop -> pipe close -> shim POLLHUP -> SIGTERM -> process exit
+#[tokio::test]
+async fn non_detached_box_exits_on_runtime_drop() {
+    // Use /tmp for shorter paths -- macOS default TempDir paths exceed SUN_LEN for Unix sockets.
+    let home = boxlite_test_utils::home::PerTestBoxHome::new_in("/tmp");
+    let home_dir = home.path.clone();
+    let original_pid: u32;
+
+    // Create non-detached box
+    {
+        let runtime = BoxliteRuntime::new(BoxliteOptions {
+            home_dir: home_dir.clone(),
+            image_registries: common::test_registries(),
+        })
+        .unwrap();
+
+        let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
+
+        handle
+            .exec(BoxCommand::new("sleep").args(["300"]))
+            .await
+            .unwrap();
+
+        let pf = pid_file_path(&home_dir, handle.id().as_str());
+        original_pid = read_pid_file(&pf).unwrap();
+
+        // Verify process is running before drop
+        assert!(
+            is_process_alive(original_pid),
+            "Process {} should be alive before runtime drop",
+            original_pid
+        );
+
+        // Runtime + handler + Keepalive drop here -> POLLHUP -> shim exit
+    }
+
+    // Wait for shim to detect POLLHUP and exit gracefully.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    while std::time::Instant::now() < deadline {
+        if !is_process_alive(original_pid) {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+
+    // Verify process exited
+    assert!(
+        !is_process_alive(original_pid),
+        "Non-detached box process {} should exit after runtime drop (watchdog POLLHUP)",
+        original_pid
+    );
+}
+
+#[tokio::test]
+async fn multiple_detached_boxes_each_have_pid_file() {
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+
+    let mut box_ids = Vec::new();
+
+    // Create 3 detached boxes
+    for _ in 0..3 {
+        let handle = runtime
+            .create(
+                boxlite::runtime::options::BoxOptions {
+                    detach: true,
+                    ..common::alpine_opts()
+                },
+                None,
+            )
+            .await
+            .unwrap();
+
+        let _ = handle.exec(BoxCommand::new("sleep").args(["300"])).await;
+        box_ids.push(handle.id().to_string());
+    }
+
+    // Verify each has unique PID file with different PID
+    let mut pids = std::collections::HashSet::new();
+    for box_id in &box_ids {
+        let pf = pid_file_path(&home.path, box_id);
+        assert!(pf.exists(), "Box {} should have PID file", box_id);
+        let pid = read_pid_file(&pf).unwrap();
+        assert!(
+            pids.insert(pid),
+            "Each box should have unique PID, but {} is duplicate",
+            pid
+        );
+    }
+
+    // Cleanup
+    for box_id in box_ids {
+        runtime.remove(&box_id, true).await.unwrap();
+    }
+}
+
+// ============================================================================
+// DETACH + RECOVERY TEST
+// ============================================================================
+
+#[tokio::test]
+async fn detached_box_recoverable_after_restart() {
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let box_id: String;
+
+    // Create and run detached box
+    {
+        let runtime = BoxliteRuntime::new(BoxliteOptions {
+            home_dir: home.path.clone(),
+            image_registries: common::test_registries(),
+        })
+        .unwrap();
+
+        let handle = runtime
+            .create(
+                boxlite::runtime::options::BoxOptions {
+                    detach: true,
+                    ..common::alpine_opts()
+                },
+                None,
+            )
+            .await
+            .unwrap();
+
+        let _ = handle.exec(BoxCommand::new("sleep").args(["300"])).await;
+        box_id = handle.id().to_string();
+    }
+
+    // Create NEW runtime - should recover the box
+    {
+        let runtime = BoxliteRuntime::new(BoxliteOptions {
+            home_dir: home.path.clone(),
+            image_registries: common::test_registries(),
+        })
+        .unwrap();
+
+        // Should recover the box
+        let info = runtime
+            .get_info(&box_id)
+            .await
+            .unwrap()
+            .expect("Box should be recovered");
+
+        assert_eq!(
+            info.status,
+            BoxStatus::Running,
+            "Box should be recovered as Running"
+        );
+        assert!(info.pid.is_some(), "Recovered box should have PID");
+
+        // Should be able to stop it
+        let handle = runtime.get(&box_id).await.unwrap().unwrap();
+        handle.stop().await.unwrap();
+
+        let info = runtime
+            .get_info(&box_id)
+            .await
+            .unwrap()
+            .expect("Box should exist");
+        assert_eq!(info.status, BoxStatus::Stopped);
+
+        // Cleanup
+        runtime.remove(&box_id, false).await.unwrap();
+    }
+}

--- a/boxlite/tests/exec_user.rs
+++ b/boxlite/tests/exec_user.rs
@@ -27,29 +27,34 @@ async fn exec_stdout(handle: &boxlite::LiteBox, cmd: BoxCommand) -> String {
 /// RAII wrapper that creates/starts a box and cleans up on drop.
 struct TestBox {
     handle: boxlite::LiteBox,
-    ctx: common::ParallelRuntime,
+    runtime: boxlite::BoxliteRuntime,
+    _home: boxlite_test_utils::home::PerTestBoxHome,
 }
 
 impl TestBox {
     async fn new() -> Self {
-        let ctx = common::ParallelRuntime::new();
-        let handle = ctx
-            .runtime
-            .create(common::alpine_opts(), None)
-            .await
-            .unwrap();
+        let home = boxlite_test_utils::home::PerTestBoxHome::new();
+        let runtime = boxlite::BoxliteRuntime::new(boxlite::runtime::options::BoxliteOptions {
+            home_dir: home.path.clone(),
+            image_registries: common::test_registries(),
+        })
+        .expect("create runtime");
+        let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
         handle.start().await.unwrap();
-        Self { handle, ctx }
+        Self {
+            handle,
+            runtime,
+            _home: home,
+        }
     }
 
     async fn teardown(self) {
         self.handle.stop().await.unwrap();
+        let _ = self.runtime.remove(self.handle.id().as_str(), true).await;
         let _ = self
-            .ctx
             .runtime
-            .remove(self.handle.id().as_str(), true)
+            .shutdown(Some(common::TEST_SHUTDOWN_TIMEOUT))
             .await;
-        self.ctx.shutdown().await;
     }
 }
 

--- a/boxlite/tests/execution_shutdown.rs
+++ b/boxlite/tests/execution_shutdown.rs
@@ -6,6 +6,8 @@
 mod common;
 
 use boxlite::BoxCommand;
+use boxlite::BoxliteRuntime;
+use boxlite::runtime::options::BoxliteOptions;
 use boxlite_shared::BoxliteError;
 use std::time::Duration;
 
@@ -19,12 +21,13 @@ use std::time::Duration;
 /// because the guest process exits when box stops.
 #[tokio::test]
 async fn test_wait_behavior_on_box_stop() {
-    let ctx = common::ParallelRuntime::new();
-    let handle = ctx
-        .runtime
-        .create(common::alpine_opts(), None)
-        .await
-        .unwrap();
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+    let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
     handle.start().await.unwrap();
 
     // Start a long-running command
@@ -83,8 +86,8 @@ async fn test_wait_behavior_on_box_stop() {
     }
 
     // Cleanup
-    let _ = ctx.runtime.remove(handle.id().as_str(), true).await;
-    ctx.shutdown().await;
+    let _ = runtime.remove(handle.id().as_str(), true).await;
+    let _ = runtime.shutdown(Some(common::TEST_SHUTDOWN_TIMEOUT)).await;
 }
 
 /// Test 2: What happens to wait() when runtime.shutdown() is called?
@@ -93,12 +96,13 @@ async fn test_wait_behavior_on_box_stop() {
 /// because shutdown stops all boxes concurrently.
 #[tokio::test]
 async fn test_wait_behavior_on_runtime_shutdown() {
-    let ctx = common::ParallelRuntime::new();
-    let handle = ctx
-        .runtime
-        .create(common::alpine_opts(), None)
-        .await
-        .unwrap();
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+    let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
     handle.start().await.unwrap();
 
     // Start a long-running command
@@ -120,10 +124,7 @@ async fn test_wait_behavior_on_runtime_shutdown() {
 
     // Shutdown runtime
     let shutdown_start = std::time::Instant::now();
-    let shutdown_result = ctx
-        .runtime
-        .shutdown(Some(common::TEST_SHUTDOWN_TIMEOUT))
-        .await;
+    let shutdown_result = runtime.shutdown(Some(common::TEST_SHUTDOWN_TIMEOUT)).await;
     let shutdown_elapsed = shutdown_start.elapsed();
 
     // Wait for wait() to return (with timeout)
@@ -168,12 +169,13 @@ async fn test_wait_behavior_on_runtime_shutdown() {
 async fn test_stdout_stream_on_box_stop() {
     use futures::StreamExt;
 
-    let ctx = common::ParallelRuntime::new();
-    let handle = ctx
-        .runtime
-        .create(common::alpine_opts(), None)
-        .await
-        .unwrap();
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+    let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
     handle.start().await.unwrap();
 
     // Start a command that produces continuous output
@@ -217,8 +219,8 @@ async fn test_stdout_stream_on_box_stop() {
     // None = EOF, Some(...) = got more data, Timeout = stream hung
 
     // Cleanup
-    let _ = ctx.runtime.remove(handle.id().as_str(), true).await;
-    ctx.shutdown().await;
+    let _ = runtime.remove(handle.id().as_str(), true).await;
+    let _ = runtime.shutdown(Some(common::TEST_SHUTDOWN_TIMEOUT)).await;
 }
 
 /// Test 4: Can we call exec() on a stopped box?
@@ -226,12 +228,13 @@ async fn test_stdout_stream_on_box_stop() {
 /// Assumption: Should return an error (InvalidState or Stopped).
 #[tokio::test]
 async fn test_exec_on_stopped_box() {
-    let ctx = common::ParallelRuntime::new();
-    let handle = ctx
-        .runtime
-        .create(common::alpine_opts(), None)
-        .await
-        .unwrap();
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+    let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
     handle.start().await.unwrap();
 
     // Run a quick command first to ensure box is working
@@ -272,8 +275,8 @@ async fn test_exec_on_stopped_box() {
     assert!(result.is_err());
 
     // Cleanup
-    let _ = ctx.runtime.remove(handle.id().as_str(), true).await;
-    ctx.shutdown().await;
+    let _ = runtime.remove(handle.id().as_str(), true).await;
+    let _ = runtime.shutdown(Some(common::TEST_SHUTDOWN_TIMEOUT)).await;
 }
 
 /// Test 5: What happens to existing Execution when box is stopped?
@@ -282,12 +285,13 @@ async fn test_exec_on_stopped_box() {
 /// then box.stop() is called from elsewhere.
 #[tokio::test]
 async fn test_existing_execution_after_box_stop() {
-    let ctx = common::ParallelRuntime::new();
-    let handle = ctx
-        .runtime
-        .create(common::alpine_opts(), None)
-        .await
-        .unwrap();
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+    let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
     handle.start().await.unwrap();
 
     // Start a quick command and get execution
@@ -315,19 +319,20 @@ async fn test_existing_execution_after_box_stop() {
     assert_eq!(result1.unwrap().exit_code, result2.unwrap().exit_code);
 
     // Cleanup
-    let _ = ctx.runtime.remove(handle.id().as_str(), true).await;
-    ctx.shutdown().await;
+    let _ = runtime.remove(handle.id().as_str(), true).await;
+    let _ = runtime.shutdown(Some(common::TEST_SHUTDOWN_TIMEOUT)).await;
 }
 
 /// Test 6: Measure actual timing - how long does wait() block after stop?
 #[tokio::test]
 async fn test_wait_timing_after_stop() {
-    let ctx = common::ParallelRuntime::new();
-    let handle = ctx
-        .runtime
-        .create(common::alpine_opts(), None)
-        .await
-        .unwrap();
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+    let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
     handle.start().await.unwrap();
 
     // Start command that ignores SIGTERM (to test worst case)
@@ -371,8 +376,8 @@ async fn test_wait_timing_after_stop() {
     }
 
     // Cleanup
-    let _ = ctx.runtime.remove(handle.id().as_str(), true).await;
-    ctx.shutdown().await;
+    let _ = runtime.remove(handle.id().as_str(), true).await;
+    let _ = runtime.shutdown(Some(common::TEST_SHUTDOWN_TIMEOUT)).await;
 }
 
 /// Test 7: Multiple concurrent executions when box stops
@@ -380,12 +385,13 @@ async fn test_wait_timing_after_stop() {
 /// Tests that all pending wait() calls return when box stops.
 #[tokio::test]
 async fn test_multiple_executions_on_box_stop() {
-    let ctx = common::ParallelRuntime::new();
-    let handle = ctx
-        .runtime
-        .create(common::alpine_opts(), None)
-        .await
-        .unwrap();
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+    let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
     handle.start().await.unwrap();
 
     // Start multiple long-running commands
@@ -458,8 +464,8 @@ async fn test_multiple_executions_on_box_stop() {
     }
 
     // Cleanup
-    let _ = ctx.runtime.remove(handle.id().as_str(), true).await;
-    ctx.shutdown().await;
+    let _ = runtime.remove(handle.id().as_str(), true).await;
+    let _ = runtime.shutdown(Some(common::TEST_SHUTDOWN_TIMEOUT)).await;
 }
 
 // ============================================================================
@@ -469,12 +475,13 @@ async fn test_multiple_executions_on_box_stop() {
 /// Test that running a command returns Stopped error after box.stop().
 #[tokio::test]
 async fn test_run_command_returns_stopped_error() {
-    let ctx = common::ParallelRuntime::new();
-    let handle = ctx
-        .runtime
-        .create(common::alpine_opts(), None)
-        .await
-        .unwrap();
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+    let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
     handle.start().await.unwrap();
 
     // Run a quick command to verify box works
@@ -507,19 +514,20 @@ async fn test_run_command_returns_stopped_error() {
     assert!(matches!(result, Err(BoxliteError::Stopped(_))));
 
     // Cleanup
-    let _ = ctx.runtime.remove(handle.id().as_str(), true).await;
-    ctx.shutdown().await;
+    let _ = runtime.remove(handle.id().as_str(), true).await;
+    let _ = runtime.shutdown(Some(common::TEST_SHUTDOWN_TIMEOUT)).await;
 }
 
 /// Test that start() returns Stopped error after box.stop().
 #[tokio::test]
 async fn test_start_returns_stopped_error() {
-    let ctx = common::ParallelRuntime::new();
-    let handle = ctx
-        .runtime
-        .create(common::alpine_opts(), None)
-        .await
-        .unwrap();
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+    let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
     handle.start().await.unwrap();
 
     // Stop the box
@@ -544,19 +552,20 @@ async fn test_start_returns_stopped_error() {
     assert!(matches!(result, Err(BoxliteError::Stopped(_))));
 
     // Cleanup
-    let _ = ctx.runtime.remove(handle.id().as_str(), true).await;
-    ctx.shutdown().await;
+    let _ = runtime.remove(handle.id().as_str(), true).await;
+    let _ = runtime.shutdown(Some(common::TEST_SHUTDOWN_TIMEOUT)).await;
 }
 
 /// Test that metrics() returns Stopped error after box.stop().
 #[tokio::test]
 async fn test_metrics_returns_stopped_error() {
-    let ctx = common::ParallelRuntime::new();
-    let handle = ctx
-        .runtime
-        .create(common::alpine_opts(), None)
-        .await
-        .unwrap();
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+    let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
     handle.start().await.unwrap();
 
     // Stop the box
@@ -581,23 +590,28 @@ async fn test_metrics_returns_stopped_error() {
     assert!(matches!(result, Err(BoxliteError::Stopped(_))));
 
     // Cleanup
-    let _ = ctx.runtime.remove(handle.id().as_str(), true).await;
-    ctx.shutdown().await;
+    let _ = runtime.remove(handle.id().as_str(), true).await;
+    let _ = runtime.shutdown(Some(common::TEST_SHUTDOWN_TIMEOUT)).await;
 }
 
 /// Test that create() returns Stopped error after runtime.shutdown().
 #[tokio::test]
 async fn test_create_after_shutdown_returns_stopped() {
-    let ctx = common::ParallelRuntime::new();
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
 
     // Shutdown runtime
-    ctx.runtime
+    runtime
         .shutdown(Some(common::TEST_SHUTDOWN_TIMEOUT))
         .await
         .unwrap();
 
     // Attempt to create box after shutdown
-    let result = ctx.runtime.create(common::alpine_opts(), None).await;
+    let result = runtime.create(common::alpine_opts(), None).await;
 
     println!("=== test_create_after_shutdown_returns_stopped ===");
     match &result {
@@ -618,12 +632,13 @@ async fn test_create_after_shutdown_returns_stopped() {
 /// Test that wait() returns promptly when box is stopped.
 #[tokio::test]
 async fn test_wait_returns_promptly_on_stop() {
-    let ctx = common::ParallelRuntime::new();
-    let handle = ctx
-        .runtime
-        .create(common::alpine_opts(), None)
-        .await
-        .unwrap();
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+    let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
     handle.start().await.unwrap();
 
     // Start a long-running command
@@ -674,19 +689,20 @@ async fn test_wait_returns_promptly_on_stop() {
     }
 
     // Cleanup
-    let _ = ctx.runtime.remove(handle.id().as_str(), true).await;
-    ctx.shutdown().await;
+    let _ = runtime.remove(handle.id().as_str(), true).await;
+    let _ = runtime.shutdown(Some(common::TEST_SHUTDOWN_TIMEOUT)).await;
 }
 
 /// Test that all concurrent wait() calls return when box is stopped.
 #[tokio::test]
 async fn test_all_waits_return_on_stop() {
-    let ctx = common::ParallelRuntime::new();
-    let handle = ctx
-        .runtime
-        .create(common::alpine_opts(), None)
-        .await
-        .unwrap();
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+    let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
     handle.start().await.unwrap();
 
     // Start multiple long-running commands
@@ -755,23 +771,26 @@ async fn test_all_waits_return_on_stop() {
     }
 
     // Cleanup
-    let _ = ctx.runtime.remove(handle.id().as_str(), true).await;
-    ctx.shutdown().await;
+    let _ = runtime.remove(handle.id().as_str(), true).await;
+    let _ = runtime.shutdown(Some(common::TEST_SHUTDOWN_TIMEOUT)).await;
 }
 
 /// Test that runtime shutdown stops all boxes and their commands.
 #[tokio::test]
 async fn test_runtime_shutdown_stops_all_boxes() {
-    let ctx = common::ParallelRuntime::new();
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
 
     // Create multiple boxes
-    let handle1 = ctx
-        .runtime
+    let handle1 = runtime
         .create(common::alpine_opts(), Some("box1".into()))
         .await
         .unwrap();
-    let handle2 = ctx
-        .runtime
+    let handle2 = runtime
         .create(common::alpine_opts(), Some("box2".into()))
         .await
         .unwrap();
@@ -805,10 +824,7 @@ async fn test_runtime_shutdown_stops_all_boxes() {
     tokio::time::sleep(Duration::from_millis(50)).await;
 
     // Shutdown runtime (should cancel all boxes)
-    let shutdown_result = ctx
-        .runtime
-        .shutdown(Some(common::TEST_SHUTDOWN_TIMEOUT))
-        .await;
+    let shutdown_result = runtime.shutdown(Some(common::TEST_SHUTDOWN_TIMEOUT)).await;
     let shutdown_elapsed = start_time.elapsed();
 
     // Wait for all with timeout
@@ -854,12 +870,13 @@ async fn test_runtime_shutdown_stops_all_boxes() {
 /// Exec completes normally, then runtime shutdown — should be clean.
 #[tokio::test]
 async fn test_exec_completes_then_shutdown_is_clean() {
-    let ctx = common::ParallelRuntime::new();
-    let handle = ctx
-        .runtime
-        .create(common::alpine_opts(), None)
-        .await
-        .unwrap();
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+    let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
     handle.start().await.unwrap();
 
     let mut execution = handle
@@ -870,22 +887,20 @@ async fn test_exec_completes_then_shutdown_is_clean() {
     assert_eq!(result.exit_code, 0);
 
     // Shutdown after exec completes — should not produce transport errors
-    let shutdown_result = ctx
-        .runtime
-        .shutdown(Some(common::TEST_SHUTDOWN_TIMEOUT))
-        .await;
+    let shutdown_result = runtime.shutdown(Some(common::TEST_SHUTDOWN_TIMEOUT)).await;
     assert!(shutdown_result.is_ok());
 }
 
 /// Sequential exec on same box should both succeed.
 #[tokio::test]
 async fn test_sequential_exec_same_box() {
-    let ctx = common::ParallelRuntime::new();
-    let handle = ctx
-        .runtime
-        .create(common::alpine_opts(), None)
-        .await
-        .unwrap();
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+    let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
     handle.start().await.unwrap();
 
     // First exec
@@ -905,19 +920,20 @@ async fn test_sequential_exec_same_box() {
     assert_eq!(result2.exit_code, 0);
 
     // Cleanup
-    let _ = ctx.runtime.remove(handle.id().as_str(), true).await;
-    ctx.shutdown().await;
+    let _ = runtime.remove(handle.id().as_str(), true).await;
+    let _ = runtime.shutdown(Some(common::TEST_SHUTDOWN_TIMEOUT)).await;
 }
 
 /// Exit codes should be correctly preserved.
 #[tokio::test]
 async fn test_exec_exit_code_preserved() {
-    let ctx = common::ParallelRuntime::new();
-    let handle = ctx
-        .runtime
-        .create(common::alpine_opts(), None)
-        .await
-        .unwrap();
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+    let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
     handle.start().await.unwrap();
 
     // Success (exit 0)
@@ -936,19 +952,20 @@ async fn test_exec_exit_code_preserved() {
     assert_eq!(exec42.wait().await.unwrap().exit_code, 42);
 
     // Cleanup
-    let _ = ctx.runtime.remove(handle.id().as_str(), true).await;
-    ctx.shutdown().await;
+    let _ = runtime.remove(handle.id().as_str(), true).await;
+    let _ = runtime.shutdown(Some(common::TEST_SHUTDOWN_TIMEOUT)).await;
 }
 
 /// Multiple sequential execs followed by shutdown — the full CLI workflow.
 #[tokio::test]
 async fn test_exec_then_shutdown_sequential() {
-    let ctx = common::ParallelRuntime::new();
-    let handle = ctx
-        .runtime
-        .create(common::alpine_opts(), None)
-        .await
-        .unwrap();
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+    let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
     handle.start().await.unwrap();
 
     // Run 3 commands sequentially
@@ -962,9 +979,6 @@ async fn test_exec_then_shutdown_sequential() {
     }
 
     // Shutdown after all commands complete
-    let shutdown_result = ctx
-        .runtime
-        .shutdown(Some(common::TEST_SHUTDOWN_TIMEOUT))
-        .await;
+    let shutdown_result = runtime.shutdown(Some(common::TEST_SHUTDOWN_TIMEOUT)).await;
     assert!(shutdown_result.is_ok());
 }

--- a/boxlite/tests/jailer.rs
+++ b/boxlite/tests/jailer.rs
@@ -9,8 +9,9 @@
 mod common;
 
 use boxlite::BoxCommand;
+use boxlite::BoxliteRuntime;
 use boxlite::runtime::advanced_options::{AdvancedBoxOptions, SecurityOptions};
-use boxlite::runtime::options::BoxOptions;
+use boxlite::runtime::options::{BoxOptions, BoxliteOptions};
 use std::path::PathBuf;
 
 // ============================================================================
@@ -46,21 +47,29 @@ fn assert_macos_socket_path_budget(home_dir: &std::path::Path) {
     );
 }
 
-/// Create an IsolatedRuntime under `~/.boxlite-it` with macOS socket path validation.
-fn jailer_runtime() -> common::IsolatedRuntime {
+/// Per-test runtime context for jailer tests.
+struct JailerTestCtx {
+    runtime: BoxliteRuntime,
+    home_dir: PathBuf,
+    _home: boxlite_test_utils::home::PerTestBoxHome,
+}
+
+/// Create a runtime under `~/.boxlite-it` with macOS socket path validation.
+fn jailer_runtime() -> JailerTestCtx {
     let base = jailer_test_home_base_dir();
     std::fs::create_dir_all(&base).expect("Failed to create jailer test home base");
 
-    let ctx = common::IsolatedRuntime::new_warm(base.to_str().expect("base path should be UTF-8"));
+    let home =
+        boxlite_test_utils::home::PerTestBoxHome::new_in(base.to_str().expect("base path UTF-8"));
 
     #[cfg(target_os = "macos")]
-    assert_macos_socket_path_budget(&ctx.home_dir);
+    assert_macos_socket_path_budget(&home.path);
     #[cfg(target_os = "macos")]
     {
-        let canonical_home = ctx
-            .home_dir
+        let canonical_home = home
+            .path
             .canonicalize()
-            .unwrap_or_else(|_| ctx.home_dir.clone());
+            .unwrap_or_else(|_| home.path.clone());
         assert!(
             !canonical_home.starts_with("/private/tmp"),
             "jailer integration tests must not use /private/tmp as home_dir: {}",
@@ -68,7 +77,18 @@ fn jailer_runtime() -> common::IsolatedRuntime {
         );
     }
 
-    ctx
+    let home_dir = home.path.clone();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create jailer runtime");
+
+    JailerTestCtx {
+        runtime,
+        home_dir,
+        _home: home,
+    }
 }
 
 fn jailer_enabled_options() -> BoxOptions {

--- a/boxlite/tests/lifecycle.rs
+++ b/boxlite/tests/lifecycle.rs
@@ -6,7 +6,6 @@ use boxlite::BoxliteRuntime;
 use boxlite::runtime::id::BoxID;
 use boxlite::runtime::options::{BoxOptions, BoxliteOptions};
 use boxlite::runtime::types::BoxStatus;
-use tempfile::TempDir;
 
 // ============================================================================
 // RUNTIME INITIALIZATION TESTS
@@ -14,8 +13,13 @@ use tempfile::TempDir;
 
 #[tokio::test]
 async fn runtime_initialization_creates_empty_list() {
-    let ctx = common::IsolatedRuntime::new();
-    assert!(ctx.runtime.list_info().await.unwrap().is_empty());
+    let home = boxlite_test_utils::home::PerTestBoxHome::isolated();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+    assert!(runtime.list_info().await.unwrap().is_empty());
 }
 
 // ============================================================================
@@ -24,17 +28,14 @@ async fn runtime_initialization_creates_empty_list() {
 
 #[tokio::test]
 async fn create_generates_unique_ids() {
-    let ctx = common::IsolatedRuntime::new();
-    let box1 = ctx
-        .runtime
-        .create(common::alpine_opts(), None)
-        .await
-        .unwrap();
-    let box2 = ctx
-        .runtime
-        .create(common::alpine_opts(), None)
-        .await
-        .unwrap();
+    let home = boxlite_test_utils::home::PerTestBoxHome::isolated();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+    let box1 = runtime.create(common::alpine_opts(), None).await.unwrap();
+    let box2 = runtime.create(common::alpine_opts(), None).await.unwrap();
 
     // IDs should be unique
     assert_ne!(box1.id(), box2.id());
@@ -46,8 +47,8 @@ async fn create_generates_unique_ids() {
     // Cleanup
     box1.stop().await.unwrap();
     box2.stop().await.unwrap();
-    ctx.runtime.remove(box1.id().as_str(), false).await.unwrap();
-    ctx.runtime.remove(box2.id().as_str(), false).await.unwrap();
+    runtime.remove(box1.id().as_str(), false).await.unwrap();
+    runtime.remove(box2.id().as_str(), false).await.unwrap();
 }
 
 #[tokio::test]
@@ -58,16 +59,16 @@ async fn create_stores_custom_options() {
         ..common::alpine_opts()
     };
 
-    let ctx = common::IsolatedRuntime::new();
-    let handle = ctx.runtime.create(options, None).await.unwrap();
+    let home = boxlite_test_utils::home::PerTestBoxHome::isolated();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+    let handle = runtime.create(options, None).await.unwrap();
     let box_id = handle.id().clone();
 
-    let info = ctx
-        .runtime
-        .get_info(box_id.as_str())
-        .await
-        .unwrap()
-        .unwrap();
+    let info = runtime.get_info(box_id.as_str()).await.unwrap().unwrap();
 
     // Verify metadata was stored correctly
     assert_eq!(info.cpus, 4);
@@ -76,7 +77,7 @@ async fn create_stores_custom_options() {
 
     // Cleanup
     handle.stop().await.unwrap();
-    ctx.runtime.remove(box_id.as_str(), false).await.unwrap();
+    runtime.remove(box_id.as_str(), false).await.unwrap();
 }
 
 // ============================================================================
@@ -85,25 +86,22 @@ async fn create_stores_custom_options() {
 
 #[tokio::test]
 async fn list_info_returns_all_boxes() {
-    let ctx = common::IsolatedRuntime::new();
+    let home = boxlite_test_utils::home::PerTestBoxHome::isolated();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
 
     // Initially empty
-    assert_eq!(ctx.runtime.list_info().await.unwrap().len(), 0);
+    assert_eq!(runtime.list_info().await.unwrap().len(), 0);
 
     // Create two boxes
-    let box1 = ctx
-        .runtime
-        .create(common::alpine_opts(), None)
-        .await
-        .unwrap();
-    let box2 = ctx
-        .runtime
-        .create(common::alpine_opts(), None)
-        .await
-        .unwrap();
+    let box1 = runtime.create(common::alpine_opts(), None).await.unwrap();
+    let box2 = runtime.create(common::alpine_opts(), None).await.unwrap();
 
     // List should show both boxes
-    let boxes = ctx.runtime.list_info().await.unwrap();
+    let boxes = runtime.list_info().await.unwrap();
     assert_eq!(boxes.len(), 2);
 
     let ids: Vec<&str> = boxes.iter().map(|b| b.id.as_str()).collect();
@@ -113,33 +111,26 @@ async fn list_info_returns_all_boxes() {
     // Cleanup
     box1.stop().await.unwrap();
     box2.stop().await.unwrap();
-    ctx.runtime.remove(box1.id().as_str(), false).await.unwrap();
-    ctx.runtime.remove(box2.id().as_str(), false).await.unwrap();
+    runtime.remove(box1.id().as_str(), false).await.unwrap();
+    runtime.remove(box2.id().as_str(), false).await.unwrap();
 }
 
 #[tokio::test]
 async fn list_info_sorted_by_creation_time_newest_first() {
-    let ctx = common::IsolatedRuntime::new();
+    let home = boxlite_test_utils::home::PerTestBoxHome::isolated();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
 
     // Create boxes (chrono has microsecond resolution — timestamps differ naturally)
-    let box1 = ctx
-        .runtime
-        .create(common::alpine_opts(), None)
-        .await
-        .unwrap();
-    let box2 = ctx
-        .runtime
-        .create(common::alpine_opts(), None)
-        .await
-        .unwrap();
-    let box3 = ctx
-        .runtime
-        .create(common::alpine_opts(), None)
-        .await
-        .unwrap();
+    let box1 = runtime.create(common::alpine_opts(), None).await.unwrap();
+    let box2 = runtime.create(common::alpine_opts(), None).await.unwrap();
+    let box3 = runtime.create(common::alpine_opts(), None).await.unwrap();
 
     // List should be sorted newest first
-    let boxes = ctx.runtime.list_info().await.unwrap();
+    let boxes = runtime.list_info().await.unwrap();
     assert_eq!(boxes.len(), 3);
     assert_eq!(boxes[0].id, *box3.id()); // Newest
     assert_eq!(boxes[1].id, *box2.id());
@@ -152,9 +143,9 @@ async fn list_info_sorted_by_creation_time_newest_first() {
     box1.stop().await.unwrap();
     box2.stop().await.unwrap();
     box3.stop().await.unwrap();
-    ctx.runtime.remove(box1_id.as_str(), false).await.unwrap();
-    ctx.runtime.remove(box2_id.as_str(), false).await.unwrap();
-    ctx.runtime.remove(box3_id.as_str(), false).await.unwrap();
+    runtime.remove(box1_id.as_str(), false).await.unwrap();
+    runtime.remove(box2_id.as_str(), false).await.unwrap();
+    runtime.remove(box3_id.as_str(), false).await.unwrap();
 }
 
 // ============================================================================
@@ -163,21 +154,20 @@ async fn list_info_sorted_by_creation_time_newest_first() {
 
 #[tokio::test]
 async fn get_info_returns_box_metadata() {
-    let ctx = common::IsolatedRuntime::new();
-    let handle = ctx
-        .runtime
+    let home = boxlite_test_utils::home::PerTestBoxHome::isolated();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+    let handle = runtime
         .create(common::alpine_opts_auto(), None)
         .await
         .unwrap();
     let box_id = handle.id().clone();
 
     // Get info from runtime - box is Configured after create() but not yet started
-    let info = ctx
-        .runtime
-        .get_info(box_id.as_str())
-        .await
-        .unwrap()
-        .unwrap();
+    let info = runtime.get_info(box_id.as_str()).await.unwrap().unwrap();
     assert_eq!(info.id, box_id);
     assert_eq!(
         info.status,
@@ -187,36 +177,50 @@ async fn get_info_returns_box_metadata() {
     );
 
     // Cleanup
-    ctx.runtime.remove(box_id.as_str(), true).await.unwrap();
+    runtime.remove(box_id.as_str(), true).await.unwrap();
 }
 
 #[tokio::test]
 async fn get_info_returns_none_for_nonexistent() {
-    let ctx = common::IsolatedRuntime::new();
-    let missing = ctx.runtime.get_info("nonexistent-id").await.unwrap();
+    let home = boxlite_test_utils::home::PerTestBoxHome::isolated();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+    let missing = runtime.get_info("nonexistent-id").await.unwrap();
     assert!(missing.is_none());
 }
 
 #[tokio::test]
 async fn exists_returns_true_for_existing_box() {
-    let ctx = common::IsolatedRuntime::new();
-    let handle = ctx
-        .runtime
+    let home = boxlite_test_utils::home::PerTestBoxHome::isolated();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+    let handle = runtime
         .create(common::alpine_opts_auto(), None)
         .await
         .unwrap();
     let box_id = handle.id().clone();
 
-    assert!(ctx.runtime.exists(box_id.as_str()).await.unwrap());
+    assert!(runtime.exists(box_id.as_str()).await.unwrap());
 
     // Cleanup
-    ctx.runtime.remove(box_id.as_str(), true).await.unwrap();
+    runtime.remove(box_id.as_str(), true).await.unwrap();
 }
 
 #[tokio::test]
 async fn exists_returns_false_for_nonexistent() {
-    let ctx = common::IsolatedRuntime::new();
-    assert!(!ctx.runtime.exists("nonexistent-id").await.unwrap());
+    let home = boxlite_test_utils::home::PerTestBoxHome::isolated();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+    assert!(!runtime.exists("nonexistent-id").await.unwrap());
 }
 
 // ============================================================================
@@ -225,8 +229,13 @@ async fn exists_returns_false_for_nonexistent() {
 
 #[tokio::test]
 async fn remove_nonexistent_returns_not_found() {
-    let ctx = common::IsolatedRuntime::new();
-    let result = ctx.runtime.remove("nonexistent-id", false).await;
+    let home = boxlite_test_utils::home::PerTestBoxHome::isolated();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+    let result = runtime.remove("nonexistent-id", false).await;
 
     assert!(result.is_err());
     let err = result.unwrap_err();
@@ -239,29 +248,34 @@ async fn remove_nonexistent_returns_not_found() {
 
 #[tokio::test]
 async fn remove_stopped_box_succeeds() {
-    let ctx = common::IsolatedRuntime::new();
-    let handle = ctx
-        .runtime
-        .create(common::alpine_opts(), None)
-        .await
-        .unwrap();
+    let home = boxlite_test_utils::home::PerTestBoxHome::isolated();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+    let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
     let box_id = handle.id().clone();
 
     // Stop the box first
     handle.stop().await.unwrap();
 
     // Remove without force should succeed on stopped box
-    ctx.runtime.remove(box_id.as_str(), false).await.unwrap();
+    runtime.remove(box_id.as_str(), false).await.unwrap();
 
     // Box should no longer exist
-    assert!(!ctx.runtime.exists(box_id.as_str()).await.unwrap());
+    assert!(!runtime.exists(box_id.as_str()).await.unwrap());
 }
 
 #[tokio::test]
 async fn remove_active_without_force_fails() {
-    let ctx = common::ParallelRuntime::new();
-    let handle = ctx
-        .runtime
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+    let handle = runtime
         .create(common::alpine_opts_auto(), None)
         .await
         .unwrap();
@@ -271,16 +285,11 @@ async fn remove_active_without_force_fails() {
     handle.start().await.unwrap();
 
     // Box should now be active.
-    let info = ctx
-        .runtime
-        .get_info(box_id.as_str())
-        .await
-        .unwrap()
-        .unwrap();
+    let info = runtime.get_info(box_id.as_str()).await.unwrap().unwrap();
     assert!(info.status.is_active());
 
     // Remove without force should fail
-    let result = ctx.runtime.remove(box_id.as_str(), false).await;
+    let result = runtime.remove(box_id.as_str(), false).await;
     assert!(result.is_err());
     let err = result.unwrap_err();
     assert!(
@@ -290,18 +299,22 @@ async fn remove_active_without_force_fails() {
     );
 
     // Box should still exist
-    assert!(ctx.runtime.exists(box_id.as_str()).await.unwrap());
+    assert!(runtime.exists(box_id.as_str()).await.unwrap());
 
     // Cleanup with force
-    ctx.runtime.remove(box_id.as_str(), true).await.unwrap();
-    ctx.shutdown().await;
+    runtime.remove(box_id.as_str(), true).await.unwrap();
+    let _ = runtime.shutdown(Some(common::TEST_SHUTDOWN_TIMEOUT)).await;
 }
 
 #[tokio::test]
 async fn remove_active_with_force_stops_and_removes() {
-    let ctx = common::ParallelRuntime::new();
-    let handle = ctx
-        .runtime
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+    let handle = runtime
         .create(common::alpine_opts_auto(), None)
         .await
         .unwrap();
@@ -311,40 +324,39 @@ async fn remove_active_with_force_stops_and_removes() {
     handle.start().await.unwrap();
 
     // Box should now be active.
-    let info = ctx
-        .runtime
-        .get_info(box_id.as_str())
-        .await
-        .unwrap()
-        .unwrap();
+    let info = runtime.get_info(box_id.as_str()).await.unwrap().unwrap();
     assert!(info.status.is_active());
 
     // Force remove should succeed
-    ctx.runtime.remove(box_id.as_str(), true).await.unwrap();
+    runtime.remove(box_id.as_str(), true).await.unwrap();
 
     // Box should no longer exist
-    assert!(!ctx.runtime.exists(box_id.as_str()).await.unwrap());
-    ctx.shutdown().await;
+    assert!(!runtime.exists(box_id.as_str()).await.unwrap());
+    let _ = runtime.shutdown(Some(common::TEST_SHUTDOWN_TIMEOUT)).await;
 }
 
 #[tokio::test]
 async fn remove_deletes_box_from_database() {
-    let ctx = common::IsolatedRuntime::new();
-    let handle = ctx
-        .runtime
+    let home = boxlite_test_utils::home::PerTestBoxHome::isolated();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+    let handle = runtime
         .create(common::alpine_opts_auto(), None)
         .await
         .unwrap();
     let box_id = handle.id().clone();
 
     // Verify box exists before removal
-    assert!(ctx.runtime.exists(box_id.as_str()).await.unwrap());
+    assert!(runtime.exists(box_id.as_str()).await.unwrap());
 
     // Force remove
-    ctx.runtime.remove(box_id.as_str(), true).await.unwrap();
+    runtime.remove(box_id.as_str(), true).await.unwrap();
 
     // Box should no longer exist in database
-    assert!(!ctx.runtime.exists(box_id.as_str()).await.unwrap());
+    assert!(!runtime.exists(box_id.as_str()).await.unwrap());
 }
 
 // ============================================================================
@@ -353,12 +365,13 @@ async fn remove_deletes_box_from_database() {
 
 #[tokio::test]
 async fn stop_marks_box_as_stopped() {
-    let ctx = common::ParallelRuntime::new();
-    let handle = ctx
-        .runtime
-        .create(common::alpine_opts(), None)
-        .await
-        .unwrap();
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+    let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
     let box_id = handle.id().clone();
 
     // Start first so stop() transitions to Stopped.
@@ -368,17 +381,12 @@ async fn stop_marks_box_as_stopped() {
     handle.stop().await.unwrap();
 
     // Status should be Stopped
-    let info = ctx
-        .runtime
-        .get_info(box_id.as_str())
-        .await
-        .unwrap()
-        .unwrap();
+    let info = runtime.get_info(box_id.as_str()).await.unwrap().unwrap();
     assert_eq!(info.status, BoxStatus::Stopped);
 
     // Cleanup
-    ctx.runtime.remove(box_id.as_str(), false).await.unwrap();
-    ctx.shutdown().await;
+    runtime.remove(box_id.as_str(), false).await.unwrap();
+    let _ = runtime.shutdown(Some(common::TEST_SHUTDOWN_TIMEOUT)).await;
 }
 
 // ============================================================================
@@ -387,17 +395,20 @@ async fn stop_marks_box_as_stopped() {
 
 #[tokio::test]
 async fn litebox_info_returns_correct_metadata() {
-    let ctx = common::IsolatedRuntime::new();
-    let handle = ctx
-        .runtime
+    let home = boxlite_test_utils::home::PerTestBoxHome::isolated();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+    let handle = runtime
         .create(common::alpine_opts_auto(), None)
         .await
         .unwrap();
     let box_id = handle.id().clone();
 
     // Get info from runtime - box is Configured after create() but not yet started
-    let info = ctx
-        .runtime
+    let info = runtime
         .get_info(box_id.as_str())
         .await
         .unwrap()
@@ -408,7 +419,7 @@ async fn litebox_info_returns_correct_metadata() {
     assert_eq!(info.memory_mib, 512); // Default value
 
     // Cleanup
-    ctx.runtime.remove(box_id.as_str(), true).await.unwrap();
+    runtime.remove(box_id.as_str(), true).await.unwrap();
 }
 
 // ============================================================================
@@ -417,30 +428,38 @@ async fn litebox_info_returns_correct_metadata() {
 
 #[tokio::test]
 async fn multiple_runtimes_are_isolated() {
-    let ctx1 = common::IsolatedRuntime::new();
-    let ctx2 = common::IsolatedRuntime::new();
+    let home1 = boxlite_test_utils::home::PerTestBoxHome::isolated();
+    let runtime1 = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home1.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+    let home2 = boxlite_test_utils::home::PerTestBoxHome::isolated();
+    let runtime2 = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home2.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
 
-    let box1 = ctx1
-        .runtime
+    let box1 = runtime1
         .create(common::alpine_opts_auto(), None)
         .await
         .unwrap();
-    let box2 = ctx2
-        .runtime
+    let box2 = runtime2
         .create(common::alpine_opts_auto(), None)
         .await
         .unwrap();
 
     // Each runtime should only see its own box
-    assert_eq!(ctx1.runtime.list_info().await.unwrap().len(), 1);
-    assert_eq!(ctx2.runtime.list_info().await.unwrap().len(), 1);
+    assert_eq!(runtime1.list_info().await.unwrap().len(), 1);
+    assert_eq!(runtime2.list_info().await.unwrap().len(), 1);
 
-    assert_eq!(ctx1.runtime.list_info().await.unwrap()[0].id, *box1.id());
-    assert_eq!(ctx2.runtime.list_info().await.unwrap()[0].id, *box2.id());
+    assert_eq!(runtime1.list_info().await.unwrap()[0].id, *box1.id());
+    assert_eq!(runtime2.list_info().await.unwrap()[0].id, *box2.id());
 
     // Cleanup
-    ctx1.runtime.remove(box1.id().as_str(), true).await.unwrap();
-    ctx2.runtime.remove(box2.id().as_str(), true).await.unwrap();
+    runtime1.remove(box1.id().as_str(), true).await.unwrap();
+    runtime2.remove(box2.id().as_str(), true).await.unwrap();
 }
 
 // ============================================================================
@@ -450,15 +469,15 @@ async fn multiple_runtimes_are_isolated() {
 #[tokio::test]
 async fn boxes_persist_across_runtime_restart() {
     // Persistence tests need their own home_dir to test restart behavior.
-    // Use warm_temp_dir() so the image cache is available for start().
-    let (_temp_dir, home_dir) = common::warm_temp_dir();
+    // Use PerTestBoxHome::new() so the image cache is available for start().
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
 
     let box_id: BoxID;
 
     // Create runtime and a box
     {
         let options = BoxliteOptions {
-            home_dir: home_dir.clone(),
+            home_dir: home.path.clone(),
             image_registries: common::test_registries(),
         };
         let runtime = BoxliteRuntime::new(options).expect("Failed to create runtime");
@@ -477,7 +496,7 @@ async fn boxes_persist_across_runtime_restart() {
     // Create new runtime with same home directory (simulates restart)
     {
         let options = BoxliteOptions {
-            home_dir,
+            home_dir: home.path.clone(),
             image_registries: common::test_registries(),
         };
         let runtime = BoxliteRuntime::new(options).expect("Failed to create runtime");
@@ -499,15 +518,15 @@ async fn boxes_persist_across_runtime_restart() {
 async fn multiple_boxes_persist_and_recover_without_lock_errors() {
     // Test that multiple boxes can be created, persisted, and recovered
     // without lock allocation errors during recovery.
-    // Use warm_temp_dir() so the image cache is available for start().
-    let (_temp_dir, home_dir) = common::warm_temp_dir();
+    // Use PerTestBoxHome::new() so the image cache is available for start().
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
 
     let box_ids: Vec<BoxID>;
 
     // Create multiple boxes (allocates locks)
     {
         let options = BoxliteOptions {
-            home_dir: home_dir.clone(),
+            home_dir: home.path.clone(),
             image_registries: common::test_registries(),
         };
         let runtime = BoxliteRuntime::new(options).expect("Failed to create runtime");
@@ -540,7 +559,7 @@ async fn multiple_boxes_persist_and_recover_without_lock_errors() {
     // This should successfully recover all boxes without lock allocation errors
     {
         let options = BoxliteOptions {
-            home_dir,
+            home_dir: home.path.clone(),
             image_registries: common::test_registries(),
         };
         let runtime = BoxliteRuntime::new(options).expect("Failed to create runtime after restart");
@@ -590,35 +609,40 @@ async fn auto_remove_default_is_true() {
 
 #[tokio::test]
 async fn auto_remove_true_removes_box_on_stop() {
-    let ctx = common::IsolatedRuntime::new();
-    let handle = ctx
-        .runtime
+    let home = boxlite_test_utils::home::PerTestBoxHome::isolated();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+    let handle = runtime
         .create(common::alpine_opts_auto(), None)
         .await
         .unwrap();
     let box_id = handle.id().clone();
 
     // Box should exist before stop
-    assert!(ctx.runtime.exists(box_id.as_str()).await.unwrap());
+    assert!(runtime.exists(box_id.as_str()).await.unwrap());
 
     // Stop should auto-remove
     handle.stop().await.unwrap();
 
     // Box should no longer exist
     assert!(
-        !ctx.runtime.exists(box_id.as_str()).await.unwrap(),
+        !runtime.exists(box_id.as_str()).await.unwrap(),
         "Box should be auto-removed when auto_remove=true"
     );
 }
 
 #[tokio::test]
 async fn auto_remove_false_preserves_box_on_stop() {
-    let ctx = common::ParallelRuntime::new();
-    let handle = ctx
-        .runtime
-        .create(common::alpine_opts(), None)
-        .await
-        .unwrap();
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+    let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
     let box_id = handle.id().clone();
 
     // Start first so stop() transitions to Stopped.
@@ -629,22 +653,17 @@ async fn auto_remove_false_preserves_box_on_stop() {
 
     // Box should still exist
     assert!(
-        ctx.runtime.exists(box_id.as_str()).await.unwrap(),
+        runtime.exists(box_id.as_str()).await.unwrap(),
         "Box should be preserved when auto_remove=false"
     );
 
     // Status should be Stopped
-    let info = ctx
-        .runtime
-        .get_info(box_id.as_str())
-        .await
-        .unwrap()
-        .unwrap();
+    let info = runtime.get_info(box_id.as_str()).await.unwrap().unwrap();
     assert_eq!(info.status, BoxStatus::Stopped);
 
     // Cleanup manually
-    ctx.runtime.remove(box_id.as_str(), false).await.unwrap();
-    ctx.shutdown().await;
+    runtime.remove(box_id.as_str(), false).await.unwrap();
+    let _ = runtime.shutdown(Some(common::TEST_SHUTDOWN_TIMEOUT)).await;
 }
 
 // ============================================================================
@@ -662,11 +681,15 @@ async fn detach_default_is_false() {
 
 #[tokio::test]
 async fn detach_option_is_stored_in_box_config() {
-    let ctx = common::IsolatedRuntime::new();
+    let home = boxlite_test_utils::home::PerTestBoxHome::isolated();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
 
     // Create box with detach=true
-    let handle = ctx
-        .runtime
+    let handle = runtime
         .create(
             BoxOptions {
                 detach: true,
@@ -681,150 +704,8 @@ async fn detach_option_is_stored_in_box_config() {
     // Note: detach is not exposed in BoxInfo, it's an internal option
     // that affects the shim subprocess behavior. We just verify the box
     // was created successfully with the option.
-    assert!(ctx.runtime.exists(box_id.as_str()).await.unwrap());
+    assert!(runtime.exists(box_id.as_str()).await.unwrap());
 
     // Cleanup
-    ctx.runtime.remove(box_id.as_str(), true).await.unwrap();
-}
-
-// ============================================================================
-// RECOVERY CLEANUP TESTS
-// ============================================================================
-
-#[tokio::test]
-async fn recovery_removes_auto_remove_true_boxes() {
-    // Test that boxes with auto_remove=true are removed during recovery
-    // This simulates a crash scenario where boxes weren't properly cleaned up
-    let temp_dir = TempDir::new().expect("Failed to create temp dir");
-    let home_dir = temp_dir.path().to_path_buf();
-
-    let persistent_box_id: BoxID;
-
-    // Create two boxes: one with auto_remove=true, one with auto_remove=false
-    {
-        let options = BoxliteOptions {
-            home_dir: home_dir.clone(),
-            image_registries: common::test_registries(),
-        };
-        let runtime = BoxliteRuntime::new(options).expect("Failed to create runtime");
-
-        // Create auto_remove=true box (should be cleaned up on recovery)
-        let auto_remove_box = runtime
-            .create(common::alpine_opts_auto(), None)
-            .await
-            .unwrap();
-
-        // Create auto_remove=false box (should persist)
-        let persistent_box = runtime.create(common::alpine_opts(), None).await.unwrap();
-        persistent_box_id = persistent_box.id().clone();
-
-        // Both boxes should exist before shutdown
-        assert!(runtime.exists(auto_remove_box.id().as_str()).await.unwrap());
-        assert!(runtime.exists(persistent_box_id.as_str()).await.unwrap());
-
-        // Stop the persistent box normally (it stays in DB)
-        persistent_box.stop().await.unwrap();
-
-        // Verify both exist in DB (auto_remove box is still Starting)
-        assert_eq!(runtime.list_info().await.unwrap().len(), 2);
-
-        // Drop runtime without stopping auto_remove_box - simulates crash
-        // The box will remain in database but should be cleaned on recovery
-    }
-
-    // Create new runtime with same home directory (simulates restart)
-    {
-        let options = BoxliteOptions {
-            home_dir,
-            image_registries: common::test_registries(),
-        };
-        let runtime = BoxliteRuntime::new(options).expect("Failed to create runtime after restart");
-
-        // auto_remove=true box should be removed during recovery
-        // auto_remove=false box should be recovered
-        let boxes = runtime.list_info().await.unwrap();
-        assert_eq!(
-            boxes.len(),
-            1,
-            "Only persistent box should survive recovery"
-        );
-        assert_eq!(
-            boxes[0].id, persistent_box_id,
-            "Recovered box should be the persistent one"
-        );
-
-        // Cleanup
-        runtime
-            .remove(persistent_box_id.as_str(), false)
-            .await
-            .unwrap();
-    }
-}
-
-#[tokio::test]
-async fn recovery_removes_orphaned_stopped_boxes_without_directory() {
-    // Test that stopped boxes without directories are KEPT during recovery
-    // (They might have been created but never started, which is valid).
-    // Use warm_temp_dir() so the image cache is available for start().
-    let (_temp_dir, home_dir) = common::warm_temp_dir();
-
-    let box_id: BoxID;
-    let box_home: std::path::PathBuf;
-
-    // Create a box, stop it (persists), then delete directory
-    {
-        let options = BoxliteOptions {
-            home_dir: home_dir.clone(),
-            image_registries: common::test_registries(),
-        };
-        let runtime = BoxliteRuntime::new(options).expect("Failed to create runtime");
-
-        let litebox = runtime.create(common::alpine_opts(), None).await.unwrap();
-        box_id = litebox.id().clone();
-        box_home = home_dir.join("boxes").join(box_id.as_str());
-
-        // Start first so stop() persists Stopped status.
-        litebox.start().await.unwrap();
-
-        // Stop the box (persists to DB with status=Stopped)
-        litebox.stop().await.unwrap();
-
-        // Box should be persisted
-        assert!(runtime.exists(box_id.as_str()).await.unwrap());
-    }
-
-    // Delete the box's directory (simulating it was never created or manually deleted)
-    if box_home.exists() {
-        std::fs::remove_dir_all(&box_home).expect("Failed to delete box directory");
-    }
-
-    // Create new runtime with same home directory (simulates restart)
-    {
-        let options = BoxliteOptions {
-            home_dir,
-            image_registries: common::test_registries(),
-        };
-        let runtime = BoxliteRuntime::new(options).expect("Failed to create runtime after restart");
-
-        // Stopped box without directory should be KEPT (it might never have been started)
-        // Recovery only removes active (Starting/Running) boxes that are missing directories
-        let boxes = runtime.list_info().await.unwrap();
-        assert_eq!(
-            boxes.len(),
-            1,
-            "Stopped box without directory should be kept"
-        );
-        assert_eq!(
-            boxes[0].id, box_id,
-            "Box should be recovered even without directory"
-        );
-        assert_eq!(
-            boxes[0].status,
-            BoxStatus::Stopped,
-            "Box should remain in Stopped status"
-        );
-
-        // Cleanup
-        runtime.remove(box_id.as_str(), false).await.unwrap();
-    }
+    runtime.remove(box_id.as_str(), true).await.unwrap();
 }

--- a/boxlite/tests/pid_file.rs
+++ b/boxlite/tests/pid_file.rs
@@ -1,13 +1,9 @@
-//! Integration tests for PID file functionality.
+//! Integration tests for PID file lifecycle.
 //!
 //! Tests the PID file as single source of truth for process tracking:
-//! - PID file created in pre_exec (after fork, before exec)
-//! - Recovery uses PID file instead of DB
-//! - Detached boxes survive parent exit and can be recovered
-//!
-//! Test categories:
-//! - P0 (Critical): Basic functionality, Detach mode, Recovery scenarios
-//! - P1 (Important): Edge cases, Cleanup, Process validation
+//! - PID file creation, correctness, and deletion
+//! - Cleanup on stop, force remove, and box directory removal
+//! - Process validation via is_same_process
 
 mod common;
 
@@ -17,7 +13,6 @@ use boxlite::runtime::options::BoxliteOptions;
 use boxlite::runtime::types::BoxStatus;
 use boxlite::util::{is_process_alive, is_same_process, read_pid_file};
 use std::path::{Path, PathBuf};
-use tempfile::TempDir;
 
 // ============================================================================
 // LOCAL HELPERS
@@ -29,46 +24,47 @@ fn pid_file_path(home_dir: &Path, box_id: &str) -> PathBuf {
 }
 
 // ============================================================================
-// CATEGORY 1: BASIC FUNCTIONALITY (P0)
+// BASIC FUNCTIONALITY (P0)
 // ============================================================================
 
 #[tokio::test]
 async fn pid_file_created_on_box_start() {
-    let ctx = common::ParallelRuntime::new();
-    let handle = ctx
-        .runtime
-        .create(common::alpine_opts(), None)
-        .await
-        .unwrap();
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+
+    let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
 
     // Run command to start the box
     let _ = handle.exec(BoxCommand::new("true")).await;
 
     // Verify PID file exists
-    let pf = pid_file_path(&ctx.home_dir, handle.id().as_str());
+    let pf = pid_file_path(&home.path, handle.id().as_str());
     assert!(pf.exists(), "PID file should exist after run");
 
     // Cleanup
     handle.stop().await.unwrap();
-    ctx.runtime
-        .remove(handle.id().as_str(), false)
-        .await
-        .unwrap();
+    runtime.remove(handle.id().as_str(), false).await.unwrap();
 }
 
 #[tokio::test]
 async fn pid_file_contains_correct_pid() {
-    let ctx = common::ParallelRuntime::new();
-    let handle = ctx
-        .runtime
-        .create(common::alpine_opts(), None)
-        .await
-        .unwrap();
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+
+    let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
 
     // Start a long-running command
     let _ = handle.exec(BoxCommand::new("sleep").args(["30"])).await;
 
-    let pf = pid_file_path(&ctx.home_dir, handle.id().as_str());
+    let pf = pid_file_path(&home.path, handle.id().as_str());
     let pid_from_file = read_pid_file(&pf).expect("Should read PID file");
 
     // Verify process is actually running
@@ -88,24 +84,23 @@ async fn pid_file_contains_correct_pid() {
 
     // Cleanup
     handle.stop().await.unwrap();
-    ctx.runtime
-        .remove(handle.id().as_str(), false)
-        .await
-        .unwrap();
+    runtime.remove(handle.id().as_str(), false).await.unwrap();
 }
 
 #[tokio::test]
 async fn pid_file_deleted_on_normal_stop() {
-    let ctx = common::ParallelRuntime::new();
-    let handle = ctx
-        .runtime
-        .create(common::alpine_opts(), None)
-        .await
-        .unwrap();
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+
+    let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
 
     let _ = handle.exec(BoxCommand::new("sleep").args(["30"])).await;
 
-    let pf = pid_file_path(&ctx.home_dir, handle.id().as_str());
+    let pf = pid_file_path(&home.path, handle.id().as_str());
     assert!(pf.exists(), "PID file should exist before stop");
 
     handle.stop().await.unwrap();
@@ -113,28 +108,26 @@ async fn pid_file_deleted_on_normal_stop() {
     assert!(!pf.exists(), "PID file should be deleted after stop");
 
     // Cleanup
-    ctx.runtime
-        .remove(handle.id().as_str(), false)
-        .await
-        .unwrap();
+    runtime.remove(handle.id().as_str(), false).await.unwrap();
 }
 
 #[tokio::test]
 async fn pid_matches_box_info() {
-    let ctx = common::ParallelRuntime::new();
-    let handle = ctx
-        .runtime
-        .create(common::alpine_opts(), None)
-        .await
-        .unwrap();
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+
+    let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
 
     let _ = handle.exec(BoxCommand::new("sleep").args(["30"])).await;
 
-    let pf = pid_file_path(&ctx.home_dir, handle.id().as_str());
+    let pf = pid_file_path(&home.path, handle.id().as_str());
     let pid_from_file = read_pid_file(&pf).expect("Should read PID file");
 
-    let info = ctx
-        .runtime
+    let info = runtime
         .get_info(handle.id().as_str())
         .await
         .unwrap()
@@ -148,28 +141,25 @@ async fn pid_matches_box_info() {
 
     // Cleanup
     handle.stop().await.unwrap();
-    ctx.runtime
-        .remove(handle.id().as_str(), false)
-        .await
-        .unwrap();
+    runtime.remove(handle.id().as_str(), false).await.unwrap();
 }
 
 #[tokio::test]
 async fn pid_available_immediately_after_run() {
-    let ctx = common::ParallelRuntime::new();
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
 
     // Create and start box
-    let handle = ctx
-        .runtime
-        .create(common::alpine_opts(), None)
-        .await
-        .unwrap();
+    let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
 
     let _ = handle.exec(BoxCommand::new("sleep").args(["30"])).await;
 
     // IMMEDIATELY check - no delay (this is the race condition fix)
-    let info = ctx
-        .runtime
+    let info = runtime
         .get_info(handle.id().as_str())
         .await
         .unwrap()
@@ -182,718 +172,109 @@ async fn pid_available_immediately_after_run() {
     assert_eq!(info.status, BoxStatus::Running, "Status should be Running");
 
     // PID file should also exist immediately
-    let pf = pid_file_path(&ctx.home_dir, handle.id().as_str());
+    let pf = pid_file_path(&home.path, handle.id().as_str());
     assert!(pf.exists(), "PID file should exist immediately");
 
     // Cleanup
     handle.stop().await.unwrap();
-    ctx.runtime
-        .remove(handle.id().as_str(), false)
-        .await
-        .unwrap();
+    runtime.remove(handle.id().as_str(), false).await.unwrap();
 }
 
 #[tokio::test]
 async fn pid_file_path_is_correct() {
-    let ctx = common::ParallelRuntime::new();
-    let handle = ctx
-        .runtime
-        .create(common::alpine_opts(), None)
-        .await
-        .unwrap();
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+
+    let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
 
     let _ = handle.exec(BoxCommand::new("true")).await;
 
     // Expected path: {home}/boxes/{box_id}/shim.pid
-    let expected = pid_file_path(&ctx.home_dir, handle.id().as_str());
+    let expected = pid_file_path(&home.path, handle.id().as_str());
     assert!(expected.exists(), "PID file should be at expected path");
 
     // Verify no PID file in wrong locations
-    let wrong1 = ctx.home_dir.join("shim.pid");
-    let wrong2 = ctx.home_dir.join("boxes").join("shim.pid");
+    let wrong1 = home.path.join("shim.pid");
+    let wrong2 = home.path.join("boxes").join("shim.pid");
     assert!(!wrong1.exists(), "No PID file at home root");
     assert!(!wrong2.exists(), "No PID file at boxes root");
 
     // Cleanup
     handle.stop().await.unwrap();
-    ctx.runtime
-        .remove(handle.id().as_str(), false)
-        .await
-        .unwrap();
+    runtime.remove(handle.id().as_str(), false).await.unwrap();
 }
 
 // ============================================================================
-// CATEGORY 2: DETACH MODE (P0 - Original Issue)
-// ============================================================================
-
-#[tokio::test]
-async fn detached_box_creates_pid_file() {
-    let ctx = common::ParallelRuntime::new();
-    let handle = ctx
-        .runtime
-        .create(
-            boxlite::runtime::options::BoxOptions {
-                detach: true,
-                ..common::alpine_opts()
-            },
-            None,
-        )
-        .await
-        .unwrap();
-
-    let _ = handle.exec(BoxCommand::new("sleep").args(["300"])).await;
-
-    let pf = pid_file_path(&ctx.home_dir, handle.id().as_str());
-    assert!(pf.exists(), "Detached box should have PID file");
-
-    // Cleanup
-    ctx.runtime
-        .remove(handle.id().as_str(), true)
-        .await
-        .unwrap();
-}
-
-#[tokio::test]
-async fn detached_box_survives_runtime_drop() {
-    let (_temp_dir, home_dir) = common::warm_temp_dir();
-    let box_id: String;
-    let original_pid: u32;
-
-    // Create detached box
-    {
-        let runtime = BoxliteRuntime::new(BoxliteOptions {
-            home_dir: home_dir.clone(),
-            image_registries: common::test_registries(),
-        })
-        .unwrap();
-
-        let handle = runtime
-            .create(
-                boxlite::runtime::options::BoxOptions {
-                    detach: true,
-                    ..common::alpine_opts()
-                },
-                None,
-            )
-            .await
-            .unwrap();
-
-        let _ = handle.exec(BoxCommand::new("sleep").args(["300"])).await;
-        box_id = handle.id().to_string();
-
-        let pf = pid_file_path(&home_dir, &box_id);
-        original_pid = read_pid_file(&pf).unwrap();
-
-        // Runtime drops here - box should survive
-    }
-
-    // Wait a moment
-    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
-
-    // Verify process still alive
-    assert!(
-        is_process_alive(original_pid),
-        "Detached box process {} should survive runtime drop",
-        original_pid
-    );
-
-    // Cleanup
-    let runtime = BoxliteRuntime::new(BoxliteOptions {
-        home_dir,
-        image_registries: common::test_registries(),
-    })
-    .unwrap();
-    runtime.remove(&box_id, true).await.unwrap();
-}
-
-/// Non-detached box should exit when runtime drops (watchdog POLLHUP).
-///
-/// Symmetric counterpart to `detached_box_survives_runtime_drop`.
-/// Verifies the full watchdog chain:
-///   Keepalive drop → pipe close → shim POLLHUP → SIGTERM → process exit
-#[tokio::test]
-async fn non_detached_box_exits_on_runtime_drop() {
-    // Use /tmp for shorter paths — macOS default TempDir paths exceed SUN_LEN for Unix sockets.
-    let temp_dir = TempDir::new_in("/tmp").unwrap();
-    let home_dir = temp_dir.path().to_path_buf();
-    common::warm_dir(&home_dir);
-    let original_pid: u32;
-
-    // Create non-detached box
-    {
-        let runtime = BoxliteRuntime::new(BoxliteOptions {
-            home_dir: home_dir.clone(),
-            image_registries: common::test_registries(),
-        })
-        .unwrap();
-
-        let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
-
-        handle
-            .exec(BoxCommand::new("sleep").args(["300"]))
-            .await
-            .unwrap();
-
-        let pf = pid_file_path(&home_dir, handle.id().as_str());
-        original_pid = read_pid_file(&pf).unwrap();
-
-        // Verify process is running before drop
-        assert!(
-            is_process_alive(original_pid),
-            "Process {} should be alive before runtime drop",
-            original_pid
-        );
-
-        // Runtime + handler + Keepalive drop here → POLLHUP → shim exit
-    }
-
-    // Wait for shim to detect POLLHUP and exit gracefully.
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
-    while std::time::Instant::now() < deadline {
-        if !is_process_alive(original_pid) {
-            break;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-    }
-
-    // Verify process exited
-    assert!(
-        !is_process_alive(original_pid),
-        "Non-detached box process {} should exit after runtime drop (watchdog POLLHUP)",
-        original_pid
-    );
-}
-
-#[tokio::test]
-async fn detached_box_recoverable_after_restart() {
-    let (_temp_dir, home_dir) = common::warm_temp_dir();
-    let box_id: String;
-
-    // Create and run detached box
-    {
-        let runtime = BoxliteRuntime::new(BoxliteOptions {
-            home_dir: home_dir.clone(),
-            image_registries: common::test_registries(),
-        })
-        .unwrap();
-
-        let handle = runtime
-            .create(
-                boxlite::runtime::options::BoxOptions {
-                    detach: true,
-                    ..common::alpine_opts()
-                },
-                None,
-            )
-            .await
-            .unwrap();
-
-        let _ = handle.exec(BoxCommand::new("sleep").args(["300"])).await;
-        box_id = handle.id().to_string();
-    }
-
-    // Create NEW runtime - should recover the box
-    {
-        let runtime = BoxliteRuntime::new(BoxliteOptions {
-            home_dir,
-            image_registries: common::test_registries(),
-        })
-        .unwrap();
-
-        // Should recover the box
-        let info = runtime
-            .get_info(&box_id)
-            .await
-            .unwrap()
-            .expect("Box should be recovered");
-
-        assert_eq!(
-            info.status,
-            BoxStatus::Running,
-            "Box should be recovered as Running"
-        );
-        assert!(info.pid.is_some(), "Recovered box should have PID");
-
-        // Should be able to stop it
-        let handle = runtime.get(&box_id).await.unwrap().unwrap();
-        handle.stop().await.unwrap();
-
-        let info = runtime
-            .get_info(&box_id)
-            .await
-            .unwrap()
-            .expect("Box should exist");
-        assert_eq!(info.status, BoxStatus::Stopped);
-
-        // Cleanup
-        runtime.remove(&box_id, false).await.unwrap();
-    }
-}
-
-#[tokio::test]
-async fn multiple_detached_boxes_each_have_pid_file() {
-    let ctx = common::ParallelRuntime::new();
-    let mut box_ids = Vec::new();
-
-    // Create 3 detached boxes
-    for _ in 0..3 {
-        let handle = ctx
-            .runtime
-            .create(
-                boxlite::runtime::options::BoxOptions {
-                    detach: true,
-                    ..common::alpine_opts()
-                },
-                None,
-            )
-            .await
-            .unwrap();
-
-        let _ = handle.exec(BoxCommand::new("sleep").args(["300"])).await;
-        box_ids.push(handle.id().to_string());
-    }
-
-    // Verify each has unique PID file with different PID
-    let mut pids = std::collections::HashSet::new();
-    for box_id in &box_ids {
-        let pf = pid_file_path(&ctx.home_dir, box_id);
-        assert!(pf.exists(), "Box {} should have PID file", box_id);
-        let pid = read_pid_file(&pf).unwrap();
-        assert!(
-            pids.insert(pid),
-            "Each box should have unique PID, but {} is duplicate",
-            pid
-        );
-    }
-
-    // Cleanup
-    for box_id in box_ids {
-        ctx.runtime.remove(&box_id, true).await.unwrap();
-    }
-}
-
-// ============================================================================
-// CATEGORY 3: RECOVERY SCENARIOS (P0)
-// ============================================================================
-
-#[tokio::test]
-async fn recovery_with_live_process() {
-    let (_temp_dir, home_dir) = common::warm_temp_dir();
-    let box_id: String;
-    let original_pid: u32;
-
-    // Create box with detach=true
-    {
-        let runtime = BoxliteRuntime::new(BoxliteOptions {
-            home_dir: home_dir.clone(),
-            image_registries: common::test_registries(),
-        })
-        .unwrap();
-
-        let handle = runtime
-            .create(
-                boxlite::runtime::options::BoxOptions {
-                    detach: true,
-                    ..common::alpine_opts()
-                },
-                None,
-            )
-            .await
-            .unwrap();
-
-        let _ = handle.exec(BoxCommand::new("sleep").args(["300"])).await;
-        box_id = handle.id().to_string();
-
-        let pf = pid_file_path(&home_dir, &box_id);
-        original_pid = read_pid_file(&pf).unwrap();
-    }
-
-    // New runtime should recover
-    {
-        let runtime = BoxliteRuntime::new(BoxliteOptions {
-            home_dir,
-            image_registries: common::test_registries(),
-        })
-        .unwrap();
-
-        let info = runtime
-            .get_info(&box_id)
-            .await
-            .unwrap()
-            .expect("Box should exist");
-
-        assert_eq!(info.status, BoxStatus::Running);
-        assert_eq!(info.pid, Some(original_pid), "PID should match original");
-
-        // Cleanup
-        runtime.remove(&box_id, true).await.unwrap();
-    }
-}
-
-#[tokio::test]
-async fn recovery_with_dead_process() {
-    let (_temp_dir, home_dir) = common::warm_temp_dir();
-    let box_id: String;
-    let original_pid: u32;
-
-    // Create box
-    {
-        let runtime = BoxliteRuntime::new(BoxliteOptions {
-            home_dir: home_dir.clone(),
-            image_registries: common::test_registries(),
-        })
-        .unwrap();
-
-        let handle = runtime
-            .create(
-                boxlite::runtime::options::BoxOptions {
-                    detach: true,
-                    ..common::alpine_opts()
-                },
-                None,
-            )
-            .await
-            .unwrap();
-
-        let _ = handle.exec(BoxCommand::new("sleep").args(["300"])).await;
-        box_id = handle.id().to_string();
-
-        let pf = pid_file_path(&home_dir, &box_id);
-        original_pid = read_pid_file(&pf).unwrap();
-
-        // Kill process directly (simulate crash)
-        unsafe {
-            libc::kill(original_pid as i32, libc::SIGKILL);
-        }
-
-        // Wait for process to die
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-    }
-
-    // New runtime should detect dead process
-    {
-        let runtime = BoxliteRuntime::new(BoxliteOptions {
-            home_dir: home_dir.clone(),
-            image_registries: common::test_registries(),
-        })
-        .unwrap();
-
-        let info = runtime
-            .get_info(&box_id)
-            .await
-            .unwrap()
-            .expect("Box should exist");
-
-        assert_eq!(
-            info.status,
-            BoxStatus::Stopped,
-            "Dead process should be marked Stopped"
-        );
-        assert!(info.pid.is_none(), "Stopped box should have no PID");
-
-        // PID file should be deleted
-        let pf = pid_file_path(&home_dir, &box_id);
-        assert!(
-            !pf.exists(),
-            "Stale PID file should be deleted during recovery"
-        );
-
-        // Cleanup
-        runtime.remove(&box_id, false).await.unwrap();
-    }
-}
-
-#[tokio::test]
-async fn recovery_with_missing_pid_file() {
-    let (_temp_dir, home_dir) = common::warm_temp_dir();
-    let box_id: String;
-
-    // Create box and delete PID file
-    {
-        let runtime = BoxliteRuntime::new(BoxliteOptions {
-            home_dir: home_dir.clone(),
-            image_registries: common::test_registries(),
-        })
-        .unwrap();
-
-        let handle = runtime
-            .create(
-                boxlite::runtime::options::BoxOptions {
-                    detach: true,
-                    ..common::alpine_opts()
-                },
-                None,
-            )
-            .await
-            .unwrap();
-
-        let _ = handle.exec(BoxCommand::new("sleep").args(["300"])).await;
-        box_id = handle.id().to_string();
-
-        // Manually delete PID file
-        let pf = pid_file_path(&home_dir, &box_id);
-        std::fs::remove_file(&pf).unwrap();
-    }
-
-    // New runtime should handle missing PID file gracefully
-    {
-        let runtime = BoxliteRuntime::new(BoxliteOptions {
-            home_dir,
-            image_registries: common::test_registries(),
-        })
-        .unwrap();
-
-        let info = runtime
-            .get_info(&box_id)
-            .await
-            .unwrap()
-            .expect("Box should exist");
-
-        assert_eq!(
-            info.status,
-            BoxStatus::Stopped,
-            "Missing PID file should result in Stopped status"
-        );
-
-        // Cleanup
-        runtime.remove(&box_id, true).await.unwrap();
-    }
-}
-
-#[tokio::test]
-async fn recovery_with_corrupted_pid_file() {
-    let (_temp_dir, home_dir) = common::warm_temp_dir();
-    let box_id: String;
-
-    // Create box and corrupt PID file
-    {
-        let runtime = BoxliteRuntime::new(BoxliteOptions {
-            home_dir: home_dir.clone(),
-            image_registries: common::test_registries(),
-        })
-        .unwrap();
-
-        let handle = runtime
-            .create(
-                boxlite::runtime::options::BoxOptions {
-                    detach: true,
-                    ..common::alpine_opts()
-                },
-                None,
-            )
-            .await
-            .unwrap();
-
-        let _ = handle.exec(BoxCommand::new("sleep").args(["300"])).await;
-        box_id = handle.id().to_string();
-
-        // Corrupt PID file
-        let pf = pid_file_path(&home_dir, &box_id);
-        std::fs::write(&pf, "not-a-valid-pid").unwrap();
-    }
-
-    // New runtime should handle corrupted PID file gracefully
-    {
-        let runtime = BoxliteRuntime::new(BoxliteOptions {
-            home_dir: home_dir.clone(),
-            image_registries: common::test_registries(),
-        })
-        .unwrap();
-
-        let info = runtime
-            .get_info(&box_id)
-            .await
-            .unwrap()
-            .expect("Box should exist");
-
-        assert_eq!(
-            info.status,
-            BoxStatus::Stopped,
-            "Corrupted PID file should result in Stopped status"
-        );
-
-        // Corrupted PID file should be deleted
-        let pf = pid_file_path(&home_dir, &box_id);
-        assert!(!pf.exists(), "Corrupted PID file should be deleted");
-
-        // Cleanup
-        runtime.remove(&box_id, true).await.unwrap();
-    }
-}
-
-#[tokio::test]
-async fn recovery_preserves_stopped_boxes() {
-    let (_temp_dir, home_dir) = common::warm_temp_dir();
-    let box_id: String;
-
-    // Create and stop box normally
-    {
-        let runtime = BoxliteRuntime::new(BoxliteOptions {
-            home_dir: home_dir.clone(),
-            image_registries: common::test_registries(),
-        })
-        .unwrap();
-
-        let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
-
-        let _ = handle.exec(BoxCommand::new("true")).await;
-        box_id = handle.id().to_string();
-
-        // Stop normally
-        handle.stop().await.unwrap();
-
-        // Verify PID file is gone
-        let pf = pid_file_path(&home_dir, &box_id);
-        assert!(!pf.exists());
-    }
-
-    // New runtime should see stopped box
-    {
-        let runtime = BoxliteRuntime::new(BoxliteOptions {
-            home_dir,
-            image_registries: common::test_registries(),
-        })
-        .unwrap();
-
-        let info = runtime
-            .get_info(&box_id)
-            .await
-            .unwrap()
-            .expect("Box should exist");
-
-        assert_eq!(info.status, BoxStatus::Stopped);
-        assert!(info.pid.is_none());
-
-        // Cleanup
-        runtime.remove(&box_id, false).await.unwrap();
-    }
-}
-
-// ============================================================================
-// CATEGORY 4: EDGE CASES (P1)
-// ============================================================================
-
-#[test]
-fn read_pid_file_with_whitespace() {
-    let temp = tempfile::NamedTempFile::new().unwrap();
-    std::fs::write(temp.path(), "  12345\n\n").unwrap();
-
-    let pid = read_pid_file(temp.path()).unwrap();
-    assert_eq!(pid, 12345);
-}
-
-#[test]
-fn read_pid_file_invalid_content_rejected() {
-    let temp = tempfile::NamedTempFile::new().unwrap();
-    std::fs::write(temp.path(), "not-a-pid").unwrap();
-
-    let result = read_pid_file(temp.path());
-    assert!(result.is_err());
-}
-
-#[test]
-fn read_pid_file_empty_rejected() {
-    let temp = tempfile::NamedTempFile::new().unwrap();
-    std::fs::write(temp.path(), "").unwrap();
-
-    let result = read_pid_file(temp.path());
-    assert!(result.is_err());
-}
-
-#[test]
-fn read_pid_file_missing_returns_error() {
-    let result = read_pid_file(std::path::Path::new("/nonexistent/shim.pid"));
-    assert!(result.is_err());
-}
-
-#[test]
-fn read_pid_file_large_pid() {
-    let temp = tempfile::NamedTempFile::new().unwrap();
-    std::fs::write(temp.path(), "4194304").unwrap(); // Max PID on Linux
-
-    let pid = read_pid_file(temp.path()).unwrap();
-    assert_eq!(pid, 4194304);
-}
-
-#[test]
-fn read_pid_file_negative_rejected() {
-    let temp = tempfile::NamedTempFile::new().unwrap();
-    std::fs::write(temp.path(), "-1").unwrap();
-
-    let result = read_pid_file(temp.path());
-    assert!(result.is_err());
-}
-
-#[test]
-fn read_pid_file_overflow_rejected() {
-    let temp = tempfile::NamedTempFile::new().unwrap();
-    std::fs::write(temp.path(), "99999999999").unwrap();
-
-    let result = read_pid_file(temp.path());
-    assert!(result.is_err());
-}
-
-// ============================================================================
-// CATEGORY 5: CLEANUP (P1)
+// CLEANUP (P1)
 // ============================================================================
 
 #[tokio::test]
 async fn force_remove_deletes_pid_file() {
-    let ctx = common::ParallelRuntime::new();
-    let handle = ctx
-        .runtime
-        .create(common::alpine_opts(), None)
-        .await
-        .unwrap();
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+
+    let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
 
     let _ = handle.exec(BoxCommand::new("sleep").args(["300"])).await;
     let box_id = handle.id().to_string();
 
-    let pf = pid_file_path(&ctx.home_dir, &box_id);
+    let pf = pid_file_path(&home.path, &box_id);
     assert!(pf.exists());
 
     // Force remove while running
-    ctx.runtime.remove(&box_id, true).await.unwrap();
+    runtime.remove(&box_id, true).await.unwrap();
 
     assert!(!pf.exists(), "PID file should be deleted on force remove");
 }
 
 #[tokio::test]
 async fn box_directory_cleanup_includes_pid_file() {
-    let ctx = common::ParallelRuntime::new();
-    let handle = ctx
-        .runtime
-        .create(common::alpine_opts(), None)
-        .await
-        .unwrap();
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+
+    let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
 
     let box_id = handle.id().to_string();
     let _ = handle.exec(BoxCommand::new("true")).await;
     handle.stop().await.unwrap();
 
-    ctx.runtime.remove(&box_id, false).await.unwrap();
+    runtime.remove(&box_id, false).await.unwrap();
 
     // Entire box directory should be gone
-    let box_dir = ctx.home_dir.join("boxes").join(&box_id);
+    let box_dir = home.path.join("boxes").join(&box_id);
     assert!(!box_dir.exists(), "Box directory should be removed");
 }
 
 // ============================================================================
-// CATEGORY 7: PROCESS VALIDATION (P1)
+// PROCESS VALIDATION (P1)
 // ============================================================================
 
 #[tokio::test]
 async fn is_same_process_validates_boxlite_shim() {
-    let ctx = common::ParallelRuntime::new();
-    let handle = ctx
-        .runtime
-        .create(common::alpine_opts(), None)
-        .await
-        .unwrap();
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+
+    let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
 
     let _ = handle.exec(BoxCommand::new("sleep").args(["30"])).await;
 
-    let pf = pid_file_path(&ctx.home_dir, handle.id().as_str());
+    let pf = pid_file_path(&home.path, handle.id().as_str());
     let pid = read_pid_file(&pf).unwrap();
 
     // Should be true for actual shim
@@ -910,23 +291,5 @@ async fn is_same_process_validates_boxlite_shim() {
 
     // Cleanup
     handle.stop().await.unwrap();
-    ctx.runtime
-        .remove(handle.id().as_str(), false)
-        .await
-        .unwrap();
-}
-
-#[test]
-fn is_process_alive_true_for_current() {
-    assert!(
-        is_process_alive(std::process::id()),
-        "Current process should be alive"
-    );
-}
-
-#[test]
-fn is_process_alive_false_for_invalid() {
-    // Very high PIDs unlikely to exist
-    assert!(!is_process_alive(999999999));
-    assert!(!is_process_alive(888888888));
+    runtime.remove(handle.id().as_str(), false).await.unwrap();
 }

--- a/boxlite/tests/recovery.rs
+++ b/boxlite/tests/recovery.rs
@@ -1,0 +1,463 @@
+//! Integration tests for runtime recovery scenarios.
+//!
+//! Verifies that BoxliteRuntime correctly recovers box state on restart:
+//! live/dead/missing/corrupt processes, stopped boxes, auto-remove cleanup,
+//! and orphaned entries.
+
+mod common;
+
+use boxlite::BoxliteRuntime;
+use boxlite::litebox::BoxCommand;
+use boxlite::runtime::id::BoxID;
+use boxlite::runtime::options::BoxliteOptions;
+use boxlite::runtime::types::BoxStatus;
+use boxlite::util::read_pid_file;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+// ============================================================================
+// LOCAL HELPERS
+// ============================================================================
+
+/// Get the PID file path for a box under the given home directory.
+fn pid_file_path(home_dir: &Path, box_id: &str) -> PathBuf {
+    home_dir.join("boxes").join(box_id).join("shim.pid")
+}
+
+// ============================================================================
+// RECOVERY WITH PROCESS STATE (P0)
+// ============================================================================
+
+#[tokio::test]
+async fn recovery_with_live_process() {
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let box_id: String;
+    let original_pid: u32;
+
+    // Create box with detach=true
+    {
+        let runtime = BoxliteRuntime::new(BoxliteOptions {
+            home_dir: home.path.clone(),
+            image_registries: common::test_registries(),
+        })
+        .unwrap();
+
+        let handle = runtime
+            .create(
+                boxlite::runtime::options::BoxOptions {
+                    detach: true,
+                    ..common::alpine_opts()
+                },
+                None,
+            )
+            .await
+            .unwrap();
+
+        let _ = handle.exec(BoxCommand::new("sleep").args(["300"])).await;
+        box_id = handle.id().to_string();
+
+        let pf = pid_file_path(&home.path, &box_id);
+        original_pid = read_pid_file(&pf).unwrap();
+    }
+
+    // New runtime should recover
+    {
+        let runtime = BoxliteRuntime::new(BoxliteOptions {
+            home_dir: home.path.clone(),
+            image_registries: common::test_registries(),
+        })
+        .unwrap();
+
+        let info = runtime
+            .get_info(&box_id)
+            .await
+            .unwrap()
+            .expect("Box should exist");
+
+        assert_eq!(info.status, BoxStatus::Running);
+        assert_eq!(info.pid, Some(original_pid), "PID should match original");
+
+        // Cleanup
+        runtime.remove(&box_id, true).await.unwrap();
+    }
+}
+
+#[tokio::test]
+async fn recovery_with_dead_process() {
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let box_id: String;
+
+    // Create box
+    {
+        let runtime = BoxliteRuntime::new(BoxliteOptions {
+            home_dir: home.path.clone(),
+            image_registries: common::test_registries(),
+        })
+        .unwrap();
+
+        let handle = runtime
+            .create(
+                boxlite::runtime::options::BoxOptions {
+                    detach: true,
+                    ..common::alpine_opts()
+                },
+                None,
+            )
+            .await
+            .unwrap();
+
+        let _ = handle.exec(BoxCommand::new("sleep").args(["300"])).await;
+        box_id = handle.id().to_string();
+
+        let pf = pid_file_path(&home.path, &box_id);
+        let original_pid = read_pid_file(&pf).unwrap();
+
+        // Kill process directly (simulate crash)
+        unsafe {
+            libc::kill(original_pid as i32, libc::SIGKILL);
+        }
+
+        // Wait for process to die
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+
+    // New runtime should detect dead process
+    {
+        let runtime = BoxliteRuntime::new(BoxliteOptions {
+            home_dir: home.path.clone(),
+            image_registries: common::test_registries(),
+        })
+        .unwrap();
+
+        let info = runtime
+            .get_info(&box_id)
+            .await
+            .unwrap()
+            .expect("Box should exist");
+
+        assert_eq!(
+            info.status,
+            BoxStatus::Stopped,
+            "Dead process should be marked Stopped"
+        );
+        assert!(info.pid.is_none(), "Stopped box should have no PID");
+
+        // PID file should be deleted
+        let pf = pid_file_path(&home.path, &box_id);
+        assert!(
+            !pf.exists(),
+            "Stale PID file should be deleted during recovery"
+        );
+
+        // Cleanup
+        runtime.remove(&box_id, false).await.unwrap();
+    }
+}
+
+#[tokio::test]
+async fn recovery_with_missing_pid_file() {
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let box_id: String;
+
+    // Create box and delete PID file
+    {
+        let runtime = BoxliteRuntime::new(BoxliteOptions {
+            home_dir: home.path.clone(),
+            image_registries: common::test_registries(),
+        })
+        .unwrap();
+
+        let handle = runtime
+            .create(
+                boxlite::runtime::options::BoxOptions {
+                    detach: true,
+                    ..common::alpine_opts()
+                },
+                None,
+            )
+            .await
+            .unwrap();
+
+        let _ = handle.exec(BoxCommand::new("sleep").args(["300"])).await;
+        box_id = handle.id().to_string();
+
+        // Manually delete PID file
+        let pf = pid_file_path(&home.path, &box_id);
+        std::fs::remove_file(&pf).unwrap();
+    }
+
+    // New runtime should handle missing PID file gracefully
+    {
+        let runtime = BoxliteRuntime::new(BoxliteOptions {
+            home_dir: home.path.clone(),
+            image_registries: common::test_registries(),
+        })
+        .unwrap();
+
+        let info = runtime
+            .get_info(&box_id)
+            .await
+            .unwrap()
+            .expect("Box should exist");
+
+        assert_eq!(
+            info.status,
+            BoxStatus::Stopped,
+            "Missing PID file should result in Stopped status"
+        );
+
+        // Cleanup
+        runtime.remove(&box_id, true).await.unwrap();
+    }
+}
+
+#[tokio::test]
+async fn recovery_with_corrupted_pid_file() {
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let box_id: String;
+
+    // Create box and corrupt PID file
+    {
+        let runtime = BoxliteRuntime::new(BoxliteOptions {
+            home_dir: home.path.clone(),
+            image_registries: common::test_registries(),
+        })
+        .unwrap();
+
+        let handle = runtime
+            .create(
+                boxlite::runtime::options::BoxOptions {
+                    detach: true,
+                    ..common::alpine_opts()
+                },
+                None,
+            )
+            .await
+            .unwrap();
+
+        let _ = handle.exec(BoxCommand::new("sleep").args(["300"])).await;
+        box_id = handle.id().to_string();
+
+        // Corrupt PID file
+        let pf = pid_file_path(&home.path, &box_id);
+        std::fs::write(&pf, "not-a-valid-pid").unwrap();
+    }
+
+    // New runtime should handle corrupted PID file gracefully
+    {
+        let runtime = BoxliteRuntime::new(BoxliteOptions {
+            home_dir: home.path.clone(),
+            image_registries: common::test_registries(),
+        })
+        .unwrap();
+
+        let info = runtime
+            .get_info(&box_id)
+            .await
+            .unwrap()
+            .expect("Box should exist");
+
+        assert_eq!(
+            info.status,
+            BoxStatus::Stopped,
+            "Corrupted PID file should result in Stopped status"
+        );
+
+        // Corrupted PID file should be deleted
+        let pf = pid_file_path(&home.path, &box_id);
+        assert!(!pf.exists(), "Corrupted PID file should be deleted");
+
+        // Cleanup
+        runtime.remove(&box_id, true).await.unwrap();
+    }
+}
+
+#[tokio::test]
+async fn recovery_preserves_stopped_boxes() {
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let box_id: String;
+
+    // Create and stop box normally
+    {
+        let runtime = BoxliteRuntime::new(BoxliteOptions {
+            home_dir: home.path.clone(),
+            image_registries: common::test_registries(),
+        })
+        .unwrap();
+
+        let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
+
+        let _ = handle.exec(BoxCommand::new("true")).await;
+        box_id = handle.id().to_string();
+
+        // Stop normally
+        handle.stop().await.unwrap();
+
+        // Verify PID file is gone
+        let pf = pid_file_path(&home.path, &box_id);
+        assert!(!pf.exists());
+    }
+
+    // New runtime should see stopped box
+    {
+        let runtime = BoxliteRuntime::new(BoxliteOptions {
+            home_dir: home.path.clone(),
+            image_registries: common::test_registries(),
+        })
+        .unwrap();
+
+        let info = runtime
+            .get_info(&box_id)
+            .await
+            .unwrap()
+            .expect("Box should exist");
+
+        assert_eq!(info.status, BoxStatus::Stopped);
+        assert!(info.pid.is_none());
+
+        // Cleanup
+        runtime.remove(&box_id, false).await.unwrap();
+    }
+}
+
+// ============================================================================
+// RECOVERY CLEANUP (P1)
+// ============================================================================
+
+#[tokio::test]
+async fn recovery_removes_auto_remove_true_boxes() {
+    // Test that boxes with auto_remove=true are removed during recovery
+    // This simulates a crash scenario where boxes weren't properly cleaned up
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let home_dir = temp_dir.path().to_path_buf();
+
+    let persistent_box_id: BoxID;
+
+    // Create two boxes: one with auto_remove=true, one with auto_remove=false
+    {
+        let options = BoxliteOptions {
+            home_dir: home_dir.clone(),
+            image_registries: common::test_registries(),
+        };
+        let runtime = BoxliteRuntime::new(options).expect("Failed to create runtime");
+
+        // Create auto_remove=true box (should be cleaned up on recovery)
+        let auto_remove_box = runtime
+            .create(common::alpine_opts_auto(), None)
+            .await
+            .unwrap();
+
+        // Create auto_remove=false box (should persist)
+        let persistent_box = runtime.create(common::alpine_opts(), None).await.unwrap();
+        persistent_box_id = persistent_box.id().clone();
+
+        // Both boxes should exist before shutdown
+        assert!(runtime.exists(auto_remove_box.id().as_str()).await.unwrap());
+        assert!(runtime.exists(persistent_box_id.as_str()).await.unwrap());
+
+        // Stop the persistent box normally (it stays in DB)
+        persistent_box.stop().await.unwrap();
+
+        // Verify both exist in DB (auto_remove box is still Starting)
+        assert_eq!(runtime.list_info().await.unwrap().len(), 2);
+
+        // Drop runtime without stopping auto_remove_box - simulates crash
+        // The box will remain in database but should be cleaned on recovery
+    }
+
+    // Create new runtime with same home directory (simulates restart)
+    {
+        let options = BoxliteOptions {
+            home_dir,
+            image_registries: common::test_registries(),
+        };
+        let runtime = BoxliteRuntime::new(options).expect("Failed to create runtime after restart");
+
+        // auto_remove=true box should be removed during recovery
+        // auto_remove=false box should be recovered
+        let boxes = runtime.list_info().await.unwrap();
+        assert_eq!(
+            boxes.len(),
+            1,
+            "Only persistent box should survive recovery"
+        );
+        assert_eq!(
+            boxes[0].id, persistent_box_id,
+            "Recovered box should be the persistent one"
+        );
+
+        // Cleanup
+        runtime
+            .remove(persistent_box_id.as_str(), false)
+            .await
+            .unwrap();
+    }
+}
+
+#[tokio::test]
+async fn recovery_removes_orphaned_stopped_boxes_without_directory() {
+    // Test that stopped boxes without directories are KEPT during recovery
+    // (They might have been created but never started, which is valid).
+    // Use PerTestBoxHome::new() so the image cache is available for start().
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+
+    let box_id: BoxID;
+    let box_home: PathBuf;
+
+    // Create a box, stop it (persists), then delete directory
+    {
+        let options = BoxliteOptions {
+            home_dir: home.path.clone(),
+            image_registries: common::test_registries(),
+        };
+        let runtime = BoxliteRuntime::new(options).expect("Failed to create runtime");
+
+        let litebox = runtime.create(common::alpine_opts(), None).await.unwrap();
+        box_id = litebox.id().clone();
+        box_home = home.path.join("boxes").join(box_id.as_str());
+
+        // Start first so stop() persists Stopped status.
+        litebox.start().await.unwrap();
+
+        // Stop the box (persists to DB with status=Stopped)
+        litebox.stop().await.unwrap();
+
+        // Box should be persisted
+        assert!(runtime.exists(box_id.as_str()).await.unwrap());
+    }
+
+    // Delete the box's directory (simulating it was never created or manually deleted)
+    if box_home.exists() {
+        std::fs::remove_dir_all(&box_home).expect("Failed to delete box directory");
+    }
+
+    // Create new runtime with same home directory (simulates restart)
+    {
+        let options = BoxliteOptions {
+            home_dir: home.path.clone(),
+            image_registries: common::test_registries(),
+        };
+        let runtime = BoxliteRuntime::new(options).expect("Failed to create runtime after restart");
+
+        // Stopped box without directory should be KEPT (it might never have been started)
+        // Recovery only removes active (Starting/Running) boxes that are missing directories
+        let boxes = runtime.list_info().await.unwrap();
+        assert_eq!(
+            boxes.len(),
+            1,
+            "Stopped box without directory should be kept"
+        );
+        assert_eq!(
+            boxes[0].id, box_id,
+            "Box should be recovered even without directory"
+        );
+        assert_eq!(
+            boxes[0].status,
+            BoxStatus::Stopped,
+            "Box should remain in Stopped status"
+        );
+
+        // Cleanup
+        runtime.remove(box_id.as_str(), false).await.unwrap();
+    }
+}

--- a/boxlite/tests/shutdown.rs
+++ b/boxlite/tests/shutdown.rs
@@ -12,7 +12,6 @@ mod common;
 
 use boxlite::BoxliteRuntime;
 use boxlite::runtime::options::{BoxOptions, BoxliteOptions, RootfsSpec};
-use tempfile::TempDir;
 
 // ============================================================================
 // SHUTDOWN IDEMPOTENCY
@@ -21,30 +20,45 @@ use tempfile::TempDir;
 /// Calling shutdown() twice should succeed (second call is no-op).
 #[tokio::test]
 async fn shutdown_is_idempotent() {
-    let ctx = common::IsolatedRuntime::new_in("/tmp");
+    let home = boxlite_test_utils::home::PerTestBoxHome::isolated_in("/tmp");
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
 
-    let result1 = ctx.runtime.shutdown(None).await;
+    let result1 = runtime.shutdown(None).await;
     assert!(result1.is_ok());
 
-    let result2 = ctx.runtime.shutdown(None).await;
+    let result2 = runtime.shutdown(None).await;
     assert!(result2.is_ok());
 }
 
 /// Shutdown with explicit timeout should succeed.
 #[tokio::test]
 async fn shutdown_with_timeout() {
-    let ctx = common::IsolatedRuntime::new_in("/tmp");
+    let home = boxlite_test_utils::home::PerTestBoxHome::isolated_in("/tmp");
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
 
-    let result = ctx.runtime.shutdown(Some(5)).await;
+    let result = runtime.shutdown(Some(5)).await;
     assert!(result.is_ok());
 }
 
 /// Shutdown with no boxes should complete immediately.
 #[tokio::test]
 async fn shutdown_empty_runtime() {
-    let ctx = common::IsolatedRuntime::new_in("/tmp");
+    let home = boxlite_test_utils::home::PerTestBoxHome::isolated_in("/tmp");
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
 
-    let result = ctx.runtime.shutdown(None).await;
+    let result = runtime.shutdown(None).await;
     assert!(result.is_ok());
 }
 
@@ -55,14 +69,25 @@ async fn shutdown_empty_runtime() {
 /// Shutting down one runtime should not affect another.
 #[tokio::test]
 async fn shutdown_does_not_affect_other_runtimes() {
-    let ctx1 = common::IsolatedRuntime::new_in("/tmp");
-    let ctx2 = common::IsolatedRuntime::new_in("/tmp");
+    let home1 = boxlite_test_utils::home::PerTestBoxHome::isolated_in("/tmp");
+    let runtime1 = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home1.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+
+    let home2 = boxlite_test_utils::home::PerTestBoxHome::isolated_in("/tmp");
+    let runtime2 = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home2.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
 
     // Shutdown runtime 1
-    ctx1.runtime.shutdown(None).await.unwrap();
+    runtime1.shutdown(None).await.unwrap();
 
     // Runtime 2 should still be operational (list_info works)
-    let result = ctx2.runtime.list_info().await;
+    let result = runtime2.list_info().await;
     assert!(result.is_ok());
     assert!(result.unwrap().is_empty());
 }
@@ -71,12 +96,17 @@ async fn shutdown_does_not_affect_other_runtimes() {
 /// Only box creation/start should fail.
 #[tokio::test]
 async fn read_operations_work_after_shutdown() {
-    let ctx = common::IsolatedRuntime::new_in("/tmp");
+    let home = boxlite_test_utils::home::PerTestBoxHome::isolated_in("/tmp");
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
 
-    ctx.runtime.shutdown(None).await.unwrap();
+    runtime.shutdown(None).await.unwrap();
 
     // list_info is a read-only query — should still work
-    let result = ctx.runtime.list_info().await;
+    let result = runtime.list_info().await;
     assert!(result.is_ok());
     assert!(result.unwrap().is_empty());
 }
@@ -88,13 +118,12 @@ async fn read_operations_work_after_shutdown() {
 /// Runtime drop releases the lock, allowing a new runtime on the same directory.
 #[test]
 fn drop_releases_lock() {
-    let temp_dir = TempDir::new_in("/tmp").expect("Failed to create temp dir");
-    let dir_path = temp_dir.path().to_path_buf();
+    let home = boxlite_test_utils::home::PerTestBoxHome::isolated_in("/tmp");
 
     // Create and drop a runtime
     {
         let options = BoxliteOptions {
-            home_dir: dir_path.clone(),
+            home_dir: home.path.clone(),
             image_registries: common::test_registries(),
         };
         let _rt = BoxliteRuntime::new(options).unwrap();
@@ -102,7 +131,7 @@ fn drop_releases_lock() {
 
     // Should be able to create a new runtime on the same directory
     let options2 = BoxliteOptions {
-        home_dir: dir_path,
+        home_dir: home.path.clone(),
         image_registries: common::test_registries(),
     };
     let _rt2 = BoxliteRuntime::new(options2).unwrap();
@@ -112,14 +141,19 @@ fn drop_releases_lock() {
 /// Both see the same shutdown token, so double-shutdown via clone is safe.
 #[tokio::test]
 async fn cloned_runtime_shares_shutdown_state() {
-    let ctx = common::IsolatedRuntime::new_in("/tmp");
-    let clone = ctx.runtime.clone();
+    let home = boxlite_test_utils::home::PerTestBoxHome::isolated_in("/tmp");
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+    let clone = runtime.clone();
 
     // Shutdown via clone
     clone.shutdown(None).await.unwrap();
 
     // Second shutdown via original should be a no-op
-    let result = ctx.runtime.shutdown(None).await;
+    let result = runtime.shutdown(None).await;
     assert!(
         result.is_ok(),
         "Second shutdown via original should succeed as no-op"
@@ -134,20 +168,40 @@ async fn cloned_runtime_shares_shutdown_state() {
 #[tokio::test]
 async fn shutdown_timeout_edge_values() {
     // Some(0) — zero timeout
-    let ctx = common::IsolatedRuntime::new_in("/tmp");
-    assert!(ctx.runtime.shutdown(Some(0)).await.is_ok());
+    let home = boxlite_test_utils::home::PerTestBoxHome::isolated_in("/tmp");
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+    assert!(runtime.shutdown(Some(0)).await.is_ok());
 
     // Some(-1) — infinite timeout
-    let ctx = common::IsolatedRuntime::new_in("/tmp");
-    assert!(ctx.runtime.shutdown(Some(-1)).await.is_ok());
+    let home = boxlite_test_utils::home::PerTestBoxHome::isolated_in("/tmp");
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+    assert!(runtime.shutdown(Some(-1)).await.is_ok());
 
     // Some(30) — explicit 30s
-    let ctx = common::IsolatedRuntime::new_in("/tmp");
-    assert!(ctx.runtime.shutdown(Some(30)).await.is_ok());
+    let home = boxlite_test_utils::home::PerTestBoxHome::isolated_in("/tmp");
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+    assert!(runtime.shutdown(Some(30)).await.is_ok());
 
     // Some(-5) — negative value
-    let ctx = common::IsolatedRuntime::new_in("/tmp");
-    assert!(ctx.runtime.shutdown(Some(-5)).await.is_ok());
+    let home = boxlite_test_utils::home::PerTestBoxHome::isolated_in("/tmp");
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+    assert!(runtime.shutdown(Some(-5)).await.is_ok());
 }
 
 // ============================================================================
@@ -157,12 +211,17 @@ async fn shutdown_timeout_edge_values() {
 /// Multiple concurrent shutdown() calls should all succeed without panic or deadlock.
 #[tokio::test]
 async fn concurrent_shutdown_is_safe() {
-    let ctx = common::IsolatedRuntime::new_in("/tmp");
+    let home = boxlite_test_utils::home::PerTestBoxHome::isolated_in("/tmp");
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
 
     // Clone runtime 4 times and call shutdown concurrently
     let handles: Vec<_> = (0..4)
         .map(|_| {
-            let rt = ctx.runtime.clone();
+            let rt = runtime.clone();
             tokio::spawn(async move { rt.shutdown(None).await })
         })
         .collect();
@@ -183,12 +242,16 @@ async fn concurrent_shutdown_is_safe() {
 /// Creating a box after shutdown should fail with a clear error.
 #[tokio::test]
 async fn create_after_shutdown_is_rejected() {
-    let ctx = common::IsolatedRuntime::new_in("/tmp");
+    let home = boxlite_test_utils::home::PerTestBoxHome::isolated_in("/tmp");
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
 
-    ctx.runtime.shutdown(None).await.unwrap();
+    runtime.shutdown(None).await.unwrap();
 
-    let result = ctx
-        .runtime
+    let result = runtime
         .create(
             BoxOptions {
                 rootfs: RootfsSpec::Image("test:latest".into()),

--- a/boxlite/tests/sigstop_quiesce.rs
+++ b/boxlite/tests/sigstop_quiesce.rs
@@ -15,13 +15,19 @@ mod common;
 use std::time::Duration;
 
 use boxlite::BoxCommand;
+use boxlite::BoxliteRuntime;
+use boxlite::runtime::options::BoxliteOptions;
 
 #[tokio::test]
 async fn test_sigstop_sigcont_preserves_vm() {
-    let ctx = common::ParallelRuntime::new();
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
 
-    let litebox = ctx
-        .runtime
+    let litebox = runtime
         .create(common::alpine_opts(), Some("sigstop-test".to_string()))
         .await
         .expect("Failed to create box");
@@ -73,7 +79,7 @@ async fn test_sigstop_sigcont_preserves_vm() {
     // Clean shutdown
     litebox.stop().await.expect("Failed to stop box");
 
-    ctx.shutdown().await;
+    let _ = runtime.shutdown(Some(common::TEST_SHUTDOWN_TIMEOUT)).await;
 }
 
 /// Check if a process is in stopped (T) state.

--- a/boxlite/tests/timing_profile.rs
+++ b/boxlite/tests/timing_profile.rs
@@ -13,7 +13,8 @@
 
 mod common;
 
-use boxlite::runtime::options::BoxOptions;
+use boxlite::BoxliteRuntime;
+use boxlite::runtime::options::{BoxOptions, BoxliteOptions};
 use std::time::Instant;
 
 /// Print timing lines from shim.stderr, returning counts per prefix.
@@ -40,13 +41,14 @@ fn print_timing_lines(content: &str) -> (usize, usize, usize) {
 
 #[tokio::test]
 async fn boot_timing_profile() {
-    let ctx = common::ParallelRuntime::new();
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
 
-    let handle = ctx
-        .runtime
-        .create(common::alpine_opts(), None)
-        .await
-        .unwrap();
+    let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
     let box_id = handle.id().clone();
 
     // Measure handle.start() — this includes the full guest_connect wait
@@ -54,8 +56,8 @@ async fn boot_timing_profile() {
     handle.start().await.unwrap();
     let start_elapsed = start.elapsed();
 
-    let stderr_path = ctx
-        .home_dir
+    let stderr_path = home
+        .path
         .join("boxes")
         .join(box_id.as_str())
         .join("shim.stderr");
@@ -65,8 +67,8 @@ async fn boot_timing_profile() {
     println!("============================================================");
     println!("handle.start() total: {:?}\n", start_elapsed);
 
-    let console_log_path = ctx
-        .home_dir
+    let console_log_path = home
+        .path
         .join("boxes")
         .join(box_id.as_str())
         .join("logs")
@@ -166,14 +168,19 @@ async fn boot_timing_profile() {
     println!("============================================================\n");
 
     // Cleanup
-    ctx.runtime.remove(box_id.as_str(), false).await.unwrap();
-    ctx.shutdown().await;
+    runtime.remove(box_id.as_str(), false).await.unwrap();
+    let _ = runtime.shutdown(Some(common::TEST_SHUTDOWN_TIMEOUT)).await;
 }
 
 /// Same profile but with jailer disabled — isolates sandbox-exec overhead.
 #[tokio::test]
 async fn boot_timing_profile_no_jailer() {
-    let ctx = common::ParallelRuntime::new();
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
 
     let opts = BoxOptions {
         rootfs: boxlite::runtime::options::RootfsSpec::Image("alpine:latest".into()),
@@ -188,15 +195,15 @@ async fn boot_timing_profile_no_jailer() {
         ..Default::default()
     };
 
-    let handle = ctx.runtime.create(opts, None).await.unwrap();
+    let handle = runtime.create(opts, None).await.unwrap();
     let box_id = handle.id().clone();
 
     let start = Instant::now();
     handle.start().await.unwrap();
     let start_elapsed = start.elapsed();
 
-    let stderr_path = ctx
-        .home_dir
+    let stderr_path = home
+        .path
         .join("boxes")
         .join(box_id.as_str())
         .join("shim.stderr");
@@ -229,6 +236,6 @@ async fn boot_timing_profile_no_jailer() {
     println!("============================================================\n");
 
     handle.stop().await.unwrap();
-    ctx.runtime.remove(box_id.as_str(), false).await.unwrap();
-    ctx.shutdown().await;
+    runtime.remove(box_id.as_str(), false).await.unwrap();
+    let _ = runtime.shutdown(Some(common::TEST_SHUTDOWN_TIMEOUT)).await;
 }


### PR DESCRIPTION
Split pid_file.rs (21 tests, 4 concerns) into focused test files:
- pid_file.rs: trimmed to 9 tests (PID file lifecycle only)
- detach.rs: 5 tests for detach mode behavior (new)
- recovery.rs: 7 tests for runtime recovery scenarios (new)
- lifecycle.rs: removed 2 recovery tests (moved to recovery.rs)

Consolidate 5 edge-case unit tests into boxlite/src/util/process.rs and delete 4 duplicate integration tests that duplicated existing unit tests.

Refactor boxlite-test-utils into focused modules (home, cache, assertions, box_test, config_matrix, fault_injection, sync_point) and update all integration tests to use the shared infrastructure.