### PR TITLE
feat(build): statically link libkrun and libgvproxy into boxlite-shim

### DIFF
--- a/boxlite/deps/libgvproxy-sys/build.rs
+++ b/boxlite/deps/libgvproxy-sys/build.rs
@@ -3,12 +3,11 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-/// Builds libgvproxy from Go sources using cgo.
+/// Builds libgvproxy from Go sources as a C static archive.
 ///
 /// Steps:
 /// 1. Downloads Go module dependencies
-/// 2. Compiles Go code as a C shared library
-/// 3. Fixes the install_name for proper loading
+/// 2. Compiles Go code as a C archive (static library)
 fn build_gvproxy(source_dir: &Path, output_path: &Path) {
     println!("cargo:warning=Building libgvproxy from Go sources...");
 
@@ -23,13 +22,9 @@ fn build_gvproxy(source_dir: &Path, output_path: &Path) {
         panic!("Failed to download Go module dependencies");
     }
 
-    // Build as C shared library
+    // Build as C archive (static library)
     let mut build_cmd = Command::new("go");
-    build_cmd.args(["build", "-buildmode=c-shared"]);
-
-    // macOS: Reserve space for install_name_tool to modify paths later
-    #[cfg(target_os = "macos")]
-    build_cmd.arg("-ldflags=-extldflags=-headerpad_max_install_names");
+    build_cmd.args(["build", "-buildmode=c-archive"]);
 
     build_cmd.args([
         "-o",
@@ -48,53 +43,6 @@ fn build_gvproxy(source_dir: &Path, output_path: &Path) {
     }
 
     println!("cargo:warning=Successfully built libgvproxy");
-}
-
-/// Fixes the install_name on macOS to use an absolute path.
-/// This allows install_name_tool to modify the library path during wheel repair.
-#[cfg(target_os = "macos")]
-fn fix_install_name(lib_name: &str, lib_path: &Path) {
-    let lib_path_str = lib_path.to_str().expect("Invalid library path");
-
-    let status = Command::new("install_name_tool")
-        .args(["-id", &format!("@rpath/{}", lib_name), lib_path_str])
-        .status()
-        .expect("Failed to execute install_name_tool");
-
-    if !status.success() {
-        panic!("Failed to set install_name for libgvproxy");
-    }
-}
-
-#[cfg(target_os = "linux")]
-fn fix_install_name(lib_name: &str, lib_path: &Path) {
-    let lib_path_str = lib_path.to_str().expect("Invalid library path");
-
-    let status = Command::new("patchelf")
-        .args([
-            "--set-soname",
-            lib_name, // On Linux, SONAME is just the library name, not @rpath/name
-            lib_path_str,
-        ])
-        .status()
-        .expect("Failed to execute patchelf");
-
-    if !status.success() {
-        panic!("Failed to set install_name for libgvproxy");
-    }
-}
-
-/// Determines the library filename based on the target platform.
-fn get_library_name() -> &'static str {
-    if cfg!(target_os = "macos") {
-        "libgvproxy.dylib"
-    } else if cfg!(target_os = "linux") {
-        "libgvproxy.so"
-    } else if cfg!(target_os = "windows") {
-        "libgvproxy.dll"
-    } else {
-        panic!("Unsupported platform for libgvproxy");
-    }
 }
 
 /// Auto-set BOXLITE_DEPS_STUB=2 when downloaded from a registry (crates.io).
@@ -121,7 +69,7 @@ fn main() {
     // Set BOXLITE_DEPS_STUB=1 to skip building and emit stub link directives
     if env::var("BOXLITE_DEPS_STUB").is_ok() {
         println!("cargo:warning=BOXLITE_DEPS_STUB mode: skipping libgvproxy build");
-        println!("cargo:rustc-link-lib=dylib=gvproxy");
+        println!("cargo:rustc-link-lib=static=gvproxy");
         println!("cargo:LIBGVPROXY_BOXLITE_DEP=/nonexistent");
         return;
     }
@@ -130,14 +78,12 @@ fn main() {
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
 
     let source_dir = Path::new(&manifest_dir).join("gvproxy-bridge");
-    let lib_name = get_library_name();
-    let lib_output = Path::new(&out_dir).join(lib_name);
+    let lib_output = Path::new(&out_dir).join("libgvproxy.a");
 
     // Build libgvproxy from Go sources
     // Note: cargo only re-runs this script when rerun-if-changed files change,
     // so no extra caching is needed here.
     build_gvproxy(&source_dir, &lib_output);
-    fix_install_name(lib_name, &lib_output);
 
     // Copy header file for downstream C/C++ usage (optional)
     let header_src = source_dir.join("libgvproxy.h");
@@ -148,7 +94,15 @@ fn main() {
 
     // Tell Cargo where to find the library
     println!("cargo:rustc-link-search=native={}", out_dir);
-    println!("cargo:rustc-link-lib=dylib=gvproxy");
+    println!("cargo:rustc-link-lib=static=gvproxy");
+
+    // Transitive dependencies from the Go runtime (embedded in the c-archive)
+    #[cfg(target_os = "macos")]
+    {
+        println!("cargo:rustc-link-lib=framework=CoreFoundation");
+        println!("cargo:rustc-link-lib=framework=Security");
+        println!("cargo:rustc-link-lib=resolv");
+    }
 
     // Expose library directory to downstream crates (used by boxlite/build.rs)
     // Convention: {LIBNAME}_BOXLITE_DEP=<path> for auto-discovery

--- a/boxlite/deps/libkrun-sys/build.rs
+++ b/boxlite/deps/libkrun-sys/build.rs
@@ -5,6 +5,8 @@ use std::io;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
+// ── Constants ────────────────────────────────────────────────────────────────
+
 // libkrunfw release configuration (v5.1.0)
 // Source: https://github.com/boxlite-ai/libkrunfw (fork with prebuilt releases)
 
@@ -28,26 +30,23 @@ const LIBKRUNFW_SO_URL: &str =
 #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
 const LIBKRUNFW_SHA256: &str = "e254bc3fb07b32e26a258d9958967b2f22eb6c3136cfedf358c332308b6d35ea";
 
-// libkrun build features (NET=1 BLK=1 enables network and block device support)
-const LIBKRUN_BUILD_FEATURES: &[(&str, &str)] = &[("NET", "1"), ("BLK", "1")];
-
 // Library directory name differs by platform
 #[cfg(target_os = "macos")]
 const LIB_DIR: &str = "lib";
 #[cfg(target_os = "linux")]
 const LIB_DIR: &str = "lib64";
 
-/// Returns libkrun build environment with features enabled.
-fn libkrun_build_env(libkrunfw_install: &Path) -> HashMap<String, String> {
-    let mut env = HashMap::new();
-    env.insert(
-        "PKG_CONFIG_PATH".to_string(),
-        format!("{}/{}/pkgconfig", libkrunfw_install.display(), LIB_DIR),
-    );
-    for (key, value) in LIBKRUN_BUILD_FEATURES {
-        env.insert(key.to_string(), value.to_string());
+// ── Core utilities ───────────────────────────────────────────────────────────
+
+/// Runs a command and panics with a helpful message if it fails.
+fn run_command(cmd: &mut Command, description: &str) {
+    let status = cmd
+        .status()
+        .unwrap_or_else(|e| panic!("Failed to execute {}: {}", description, e));
+
+    if !status.success() {
+        panic!("{} failed with exit code: {:?}", description, status.code());
     }
-    env
 }
 
 /// Verifies vendored sources exist.
@@ -68,6 +67,828 @@ fn verify_vendored_sources(manifest_dir: &Path, require_libkrunfw: bool) {
         std::process::exit(1);
     }
 }
+
+// ── Fetcher: download, verify, extract ───────────────────────────────────────
+
+struct Fetcher;
+
+impl Fetcher {
+    /// Downloads, verifies, and extracts a tarball.
+    /// Skips download if tarball already exists at `tarball_path`.
+    pub fn fetch(
+        url: &str,
+        sha256: &str,
+        tarball_path: &Path,
+        extract_dir: &Path,
+    ) -> io::Result<()> {
+        if !tarball_path.exists() {
+            Self::download(url, tarball_path)?;
+            Self::verify_sha256(tarball_path, sha256)?;
+        }
+        Self::extract_tarball(tarball_path, extract_dir)
+    }
+
+    /// Downloads a file from URL to the specified path.
+    fn download(url: &str, dest: &Path) -> io::Result<()> {
+        println!("cargo:warning=Downloading {}...", url);
+
+        let output = Command::new("curl")
+            .args(["-fsSL", "-o", dest.to_str().unwrap(), url])
+            .output()?;
+
+        if !output.status.success() {
+            return Err(io::Error::other(format!(
+                "curl failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            )));
+        }
+
+        Ok(())
+    }
+
+    /// Verifies SHA256 checksum of a file.
+    fn verify_sha256(file: &Path, expected: &str) -> io::Result<()> {
+        let (cmd, args): (&str, Vec<&str>) = if cfg!(target_os = "linux") {
+            ("sha256sum", vec![file.to_str().unwrap()])
+        } else {
+            ("shasum", vec!["-a", "256", file.to_str().unwrap()])
+        };
+
+        let output = Command::new(cmd).args(&args).output()?;
+
+        if !output.status.success() {
+            return Err(io::Error::other(format!("{} failed", cmd)));
+        }
+
+        let actual = String::from_utf8_lossy(&output.stdout)
+            .split_whitespace()
+            .next()
+            .unwrap_or("")
+            .to_string();
+
+        if actual != expected {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("SHA256 mismatch: expected {}, got {}", expected, actual),
+            ));
+        }
+
+        println!("cargo:warning=SHA256 verified: {}", expected);
+        Ok(())
+    }
+
+    /// Extracts a tarball to the specified directory.
+    fn extract_tarball(tarball: &Path, dest: &Path) -> io::Result<()> {
+        fs::create_dir_all(dest)?;
+
+        let status = Command::new("tar")
+            .args([
+                "-xzf",
+                tarball.to_str().unwrap(),
+                "-C",
+                dest.to_str().unwrap(),
+            ])
+            .status()?;
+
+        if !status.success() {
+            return Err(io::Error::other("tar extraction failed"));
+        }
+
+        Ok(())
+    }
+}
+
+/// Downloads and extracts the prebuilt libkrunfw tarball (macOS).
+/// Returns the path to the extracted source directory containing kernel.c.
+#[cfg(target_os = "macos")]
+fn download_libkrunfw_prebuilt(out_dir: &Path) -> PathBuf {
+    let tarball_path = out_dir.join("libkrunfw-prebuilt.tar.gz");
+    let extract_dir = out_dir.join("libkrunfw-src");
+    // boxlite-ai/libkrunfw prebuilt tarball extracts to "libkrunfw/" directory
+    let src_dir = extract_dir.join("libkrunfw");
+
+    // Check if already extracted
+    if src_dir.join("kernel.c").exists() {
+        println!("cargo:warning=Using cached libkrunfw source");
+        return src_dir;
+    }
+
+    // Clean stale extraction before re-extracting
+    if extract_dir.exists() {
+        fs::remove_dir_all(&extract_dir).ok();
+    }
+
+    Fetcher::fetch(
+        LIBKRUNFW_PREBUILT_URL,
+        LIBKRUNFW_SHA256,
+        &tarball_path,
+        &extract_dir,
+    )
+    .unwrap_or_else(|e| panic!("Failed to fetch libkrunfw: {}", e));
+
+    println!("cargo:warning=Extracted libkrunfw to {}", src_dir.display());
+    src_dir
+}
+
+/// Downloads pre-compiled libkrunfw .so files (Linux).
+/// Extracts directly to the install directory - no build step needed.
+#[cfg(target_os = "linux")]
+fn download_libkrunfw_so(install_dir: &Path) {
+    let lib_dir = install_dir.join(LIB_DIR);
+
+    // Check if already extracted
+    let already_cached = lib_dir
+        .read_dir()
+        .ok()
+        .map(|entries| {
+            entries
+                .filter_map(Result::ok)
+                .any(|e| e.file_name().to_string_lossy().starts_with("libkrunfw.so"))
+        })
+        .unwrap_or(false);
+
+    if already_cached {
+        println!("cargo:warning=Using cached libkrunfw.so");
+        return;
+    }
+
+    // Create install directory first (required before download)
+    fs::create_dir_all(install_dir)
+        .unwrap_or_else(|e| panic!("Failed to create install dir: {}", e));
+
+    let tarball_path = install_dir.join("libkrunfw.tgz");
+
+    Fetcher::fetch(
+        LIBKRUNFW_SO_URL,
+        LIBKRUNFW_SHA256,
+        &tarball_path,
+        install_dir,
+    )
+    .unwrap_or_else(|e| panic!("Failed to fetch libkrunfw: {}", e));
+
+    println!(
+        "cargo:warning=Extracted libkrunfw.so to {}",
+        lib_dir.display()
+    );
+}
+
+// ── Make utilities ───────────────────────────────────────────────────────────
+
+/// Creates a make command with common configuration.
+fn make_command(source_dir: &Path, extra_env: &HashMap<String, String>) -> Command {
+    let mut cmd = Command::new("make");
+    cmd.stdout(Stdio::inherit());
+    cmd.stderr(Stdio::inherit());
+    cmd.args(["-j", &num_cpus::get().to_string()])
+        .arg("MAKEFLAGS=") // Clear MAKEFLAGS to prevent -w flag issues in submakes
+        .current_dir(source_dir);
+
+    // Apply extra environment variables
+    for (key, value) in extra_env {
+        cmd.env(key, value);
+    }
+
+    cmd
+}
+
+/// Builds a library using Make with the specified parameters.
+fn build_with_make(
+    source_dir: &Path,
+    install_dir: &Path,
+    lib_name: &str,
+    extra_env: &HashMap<String, String>,
+    extra_make_args: &[String],
+) {
+    println!("cargo:warning=Building {} from source...", lib_name);
+
+    fs::create_dir_all(install_dir)
+        .unwrap_or_else(|e| panic!("Failed to create install directory: {}", e));
+
+    // Build
+    let mut make_cmd = make_command(source_dir, extra_env);
+    make_cmd.env("PREFIX", install_dir);
+    make_cmd.args(extra_make_args);
+    run_command(&mut make_cmd, &format!("make {}", lib_name));
+
+    // Install
+    let mut install_cmd = make_command(source_dir, extra_env);
+    install_cmd.env("PREFIX", install_dir);
+    install_cmd.args(extra_make_args);
+    install_cmd.arg("install");
+    run_command(&mut install_cmd, &format!("make install {}", lib_name));
+}
+
+// ── LibBuilder: libkrun build operations ─────────────────────────────────────
+
+struct LibBuilder;
+
+impl LibBuilder {
+    /// Builds libkrun end-to-end: init binary → static library → linking configuration.
+    pub fn build(
+        libkrun_src: &Path,
+        libkrun_install: &Path,
+        libkrunfw_install: &Path,
+        init_env: &HashMap<String, String>,
+        init_make_args: &[String],
+    ) {
+        Self::build_init_binary(libkrun_src, init_env, init_make_args);
+        Self::build_libkrun_static(libkrun_src, libkrun_install, libkrunfw_install);
+        let libkrun_lib = libkrun_install.join(LIB_DIR);
+        let libkrunfw_lib = libkrunfw_install.join(LIB_DIR);
+        Self::configure_linking(&libkrun_lib, &libkrunfw_lib);
+    }
+
+    /// Builds only the init binary from the libkrun Makefile.
+    ///
+    /// The init binary (init/init) is a static C program that runs inside the VM.
+    /// It is embedded into libkrun via include_bytes! and must be built before
+    /// the Rust library.
+    fn build_init_binary(
+        libkrun_src: &Path,
+        extra_env: &HashMap<String, String>,
+        extra_make_args: &[String],
+    ) {
+        println!("cargo:warning=Building init binary...");
+
+        let mut cmd = make_command(libkrun_src, extra_env);
+        cmd.args(extra_make_args);
+        cmd.arg("init/init");
+
+        run_command(&mut cmd, "make init/init");
+    }
+
+    /// Builds libkrun as a static library using `cargo rustc --crate-type staticlib`.
+    ///
+    /// This overrides libkrun's Cargo.toml crate-type (cdylib) at the command line,
+    /// producing libkrun.a without modifying the vendored source code.
+    fn build_libkrun_static(libkrun_src: &Path, install_dir: &Path, libkrunfw_install: &Path) {
+        println!("cargo:warning=Building libkrun as static library...");
+
+        let lib_dir = install_dir.join(LIB_DIR);
+        fs::create_dir_all(&lib_dir)
+            .unwrap_or_else(|e| panic!("Failed to create lib directory: {}", e));
+
+        // Read the outer build's TARGET to propagate cross-compilation (e.g., musl)
+        let target = env::var("TARGET").ok();
+
+        let mut cmd = Command::new("cargo");
+        cmd.args([
+            "rustc",
+            "-p",
+            "libkrun",
+            "--release",
+            "--crate-type",
+            "staticlib",
+        ]);
+        // Features must be forwarded to internal dependency crates explicitly when
+        // using -p, since libkrun's Cargo.toml doesn't propagate them (net = [], blk = []).
+        // Without -p, workspace-level feature unification handles this automatically,
+        // but cargo rustc -p requires explicit dep/feature syntax.
+        cmd.args([
+            "--features",
+            "net,blk,vmm/net,vmm/blk,devices/net,devices/blk",
+        ]);
+
+        // Propagate target for cross-compilation (e.g., x86_64-unknown-linux-musl)
+        if let Some(ref target) = target {
+            cmd.args(["--target", target]);
+        }
+
+        cmd.current_dir(libkrun_src);
+        cmd.env(
+            "PKG_CONFIG_PATH",
+            format!("{}/{}/pkgconfig", libkrunfw_install.display(), LIB_DIR),
+        );
+        cmd.stdout(Stdio::inherit());
+        cmd.stderr(Stdio::inherit());
+
+        run_command(&mut cmd, "cargo rustc (libkrun staticlib)");
+
+        // Determine output path (differs when --target is specified)
+        let output_dir = if let Some(ref target) = target {
+            libkrun_src.join(format!("target/{}/release", target))
+        } else {
+            libkrun_src.join("target/release")
+        };
+
+        let src = output_dir.join("libkrun.a");
+        let dst = lib_dir.join("libkrun.a");
+        fs::copy(&src, &dst).unwrap_or_else(|e| {
+            panic!(
+                "Failed to copy libkrun.a from {} to {}: {}",
+                src.display(),
+                dst.display(),
+                e
+            )
+        });
+
+        println!("cargo:warning=Built static libkrun at {}", dst.display());
+    }
+
+    /// Configure linking for libkrun (static) and expose library paths.
+    ///
+    /// Note: libkrunfw is NOT linked here — it's dlopened by libkrun at runtime.
+    /// We only expose the library directory so downstream crates can bundle it.
+    fn configure_linking(libkrun_dir: &Path, libkrunfw_dir: &Path) {
+        println!("cargo:rustc-link-search=native={}", libkrun_dir.display());
+        println!("cargo:rustc-link-lib=static=krun");
+
+        // Transitive dependencies from libkrun (now statically linked, these were
+        // previously resolved by the dynamic linker inside libkrun.so/dylib)
+        #[cfg(target_os = "macos")]
+        {
+            println!("cargo:rustc-link-lib=framework=Hypervisor");
+        }
+
+        // Expose library directories to downstream crates (used by boxlite/build.rs)
+        // Convention: {LIBNAME}_BOXLITE_DEP=<path> for auto-discovery
+        // Note: LIBKRUN dir now contains .a (not bundled at runtime), but the path
+        // is still exposed for consistency. Only LIBKRUNFW .so/.dylib gets bundled.
+        println!("cargo:LIBKRUN_BOXLITE_DEP={}", libkrun_dir.display());
+        println!("cargo:LIBKRUNFW_BOXLITE_DEP={}", libkrunfw_dir.display());
+    }
+}
+
+// ── LibFixup: post-build library fixup ───────────────────────────────────────
+
+struct LibFixup;
+
+impl LibFixup {
+    /// Fixes the shared library name (install_name on macOS, SONAME on Linux).
+    fn fix_install_name(lib_name: &str, lib_path: &Path) {
+        let lib_path_str = lib_path.to_str().expect("Invalid library path");
+
+        #[cfg(target_os = "macos")]
+        let mut cmd = {
+            let mut c = Command::new("install_name_tool");
+            c.args(["-id", &format!("@rpath/{}", lib_name), lib_path_str]);
+            c
+        };
+
+        #[cfg(target_os = "linux")]
+        let mut cmd = {
+            println!("cargo:warning=Fixing {} in {}", lib_name, lib_path_str);
+            let mut c = Command::new("patchelf");
+            c.args(["--set-soname", lib_name, lib_path_str]);
+            c
+        };
+
+        run_command(&mut cmd, &format!("fix install name for {}", lib_name));
+    }
+
+    /// Extract SONAME from versioned library filename.
+    /// e.g., libkrunfw.so.4.9.0 -> Some("libkrunfw.so.4")
+    #[cfg(target_os = "linux")]
+    fn extract_major_soname(filename: &str) -> Option<String> {
+        if let Some(so_pos) = filename.find(".so.") {
+            let base = &filename[..so_pos + 3];
+            let versions = &filename[so_pos + 4..];
+
+            if let Some(major) = versions.split('.').next() {
+                return Some(format!("{}.{}", base, major));
+            }
+        }
+        None
+    }
+
+    /// Fixes install names and re-signs libraries in a directory.
+    pub fn fix(lib_dir: &Path, lib_prefix: &str) -> Result<(), String> {
+        let ext = if cfg!(target_os = "macos") {
+            ".dylib"
+        } else {
+            ".so"
+        };
+
+        for entry in
+            fs::read_dir(lib_dir).map_err(|e| format!("Failed to read directory: {}", e))?
+        {
+            let entry = entry.map_err(|e| format!("Failed to read entry: {}", e))?;
+            let path = entry.path();
+            let filename = path.file_name().unwrap().to_string_lossy().to_string();
+
+            if filename.starts_with(lib_prefix) && filename.contains(ext) {
+                let metadata = fs::symlink_metadata(&path)
+                    .map_err(|e| format!("Failed to get metadata: {}", e))?;
+
+                if metadata.file_type().is_symlink() {
+                    continue;
+                }
+
+                // Linux: rename libkrunfw to major-version soname
+                #[cfg(target_os = "linux")]
+                if lib_prefix == "libkrunfw" {
+                    if let Some(soname) = Self::extract_major_soname(&filename) {
+                        if soname != filename {
+                            let new_path = lib_dir.join(&soname);
+                            fs::rename(&path, &new_path)
+                                .map_err(|e| format!("Failed to rename file: {}", e))?;
+                            println!("cargo:warning=Renamed {} to {}", filename, soname);
+                            Self::fix_install_name(&soname, &new_path);
+                            continue;
+                        }
+                    }
+                }
+
+                Self::fix_install_name(&filename, &path);
+
+                // macOS: re-sign after modifying
+                #[cfg(target_os = "macos")]
+                {
+                    let sign_status = Command::new("codesign")
+                        .args(["-s", "-", "--force"])
+                        .arg(&path)
+                        .status()
+                        .map_err(|e| format!("Failed to run codesign: {}", e))?;
+
+                    if !sign_status.success() {
+                        return Err(format!("codesign failed for {}", filename));
+                    }
+
+                    println!("cargo:warning=Fixed and signed {}", filename);
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+// ── MacToolchain: macOS toolchain discovery ──────────────────────────────────
+
+#[cfg(target_os = "macos")]
+struct MacToolchain {
+    clang: PathBuf,
+    path_dirs: Vec<PathBuf>,
+}
+
+#[cfg(target_os = "macos")]
+impl MacToolchain {
+    /// Sets LIBCLANG_PATH for bindgen if not already set.
+    /// This is needed when llvm is installed via brew but not linked (keg-only).
+    fn setup_libclang_path() {
+        // Skip if LIBCLANG_PATH already set or llvm-config is in PATH
+        if env::var("LIBCLANG_PATH").is_ok() {
+            return;
+        }
+        if Command::new("llvm-config")
+            .arg("--version")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .is_ok_and(|s| s.success())
+        {
+            return;
+        }
+
+        // Try common Homebrew locations (useful when `brew` itself can't be executed).
+        for prefix in ["/opt/homebrew/opt/llvm", "/usr/local/opt/llvm"] {
+            let lib_path = Path::new(prefix).join("lib");
+            if lib_path.join("libclang.dylib").exists() {
+                env::set_var("LIBCLANG_PATH", &lib_path);
+                return;
+            }
+        }
+
+        // Try to find brew's llvm
+        if let Ok(output) = Command::new("brew").args(["--prefix", "llvm"]).output() {
+            if output.status.success() {
+                let prefix = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                let lib_path = format!("{}/lib", prefix);
+                if Path::new(&lib_path).join("libclang.dylib").exists() {
+                    env::set_var("LIBCLANG_PATH", &lib_path);
+                }
+            }
+        }
+    }
+
+    fn brew_prefix(formula: &str) -> Option<PathBuf> {
+        let output = Command::new("brew")
+            .args(["--prefix", formula])
+            .output()
+            .ok()?;
+        if !output.status.success() {
+            return None;
+        }
+
+        let prefix = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if prefix.is_empty() {
+            return None;
+        }
+
+        Some(PathBuf::from(prefix))
+    }
+
+    fn find_non_apple_clang_in_path() -> Option<PathBuf> {
+        let version = Command::new("clang").arg("--version").output().ok()?;
+        if !version.status.success() {
+            return None;
+        }
+
+        let version_stdout = String::from_utf8_lossy(&version.stdout);
+        if version_stdout.starts_with("Apple clang") {
+            return None;
+        }
+
+        let output = Command::new("which").arg("clang").output().ok()?;
+        if !output.status.success() {
+            return None;
+        }
+
+        let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if path.is_empty() {
+            return None;
+        }
+
+        let path = PathBuf::from(path);
+        path.exists().then_some(path)
+    }
+
+    fn find_llvm_clang() -> Option<PathBuf> {
+        // If the user has already put a non-Apple clang first in PATH, prefer that.
+        if let Some(clang) = Self::find_non_apple_clang_in_path() {
+            return Some(clang);
+        }
+
+        // If llvm-config is available, use it.
+        if let Ok(output) = Command::new("llvm-config").arg("--bindir").output() {
+            if output.status.success() {
+                let bindir = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                if !bindir.is_empty() {
+                    let clang = PathBuf::from(bindir).join("clang");
+                    if clang.exists() {
+                        return Some(clang);
+                    }
+                }
+            }
+        }
+
+        // Common Homebrew locations (useful when `brew` itself can't be executed).
+        for prefix in ["/opt/homebrew/opt/llvm", "/usr/local/opt/llvm"] {
+            let clang = Path::new(prefix).join("bin/clang");
+            if clang.exists() {
+                return Some(clang);
+            }
+        }
+
+        // Homebrew llvm is keg-only; locate it via brew.
+        Self::brew_prefix("llvm")
+            .map(|prefix| prefix.join("bin/clang"))
+            .filter(|clang| clang.exists())
+    }
+
+    fn find_lld_bin_dir() -> Option<PathBuf> {
+        // If ld.lld is already in PATH, we're good.
+        if Command::new("ld.lld")
+            .arg("--version")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .is_ok_and(|s| s.success())
+        {
+            return None;
+        }
+
+        // Common Homebrew locations (useful when `brew` itself can't be executed).
+        for prefix in ["/opt/homebrew/opt/lld", "/usr/local/opt/lld"] {
+            let ld_lld = Path::new(prefix).join("bin/ld.lld");
+            if ld_lld.exists() {
+                return ld_lld.parent().map(Path::to_path_buf);
+            }
+        }
+
+        // Otherwise, try locating via Homebrew.
+        let ld_lld = Self::brew_prefix("lld")
+            .map(|prefix| prefix.join("bin/ld.lld"))
+            .filter(|path| path.exists())?;
+
+        ld_lld.parent().map(Path::to_path_buf)
+    }
+
+    fn prepend_path_dirs(path_dirs: &[PathBuf]) -> Option<String> {
+        if path_dirs.is_empty() {
+            return None;
+        }
+
+        let existing = env::var("PATH").unwrap_or_default();
+        let mut merged = String::new();
+        for dir in path_dirs {
+            if merged.is_empty() {
+                merged.push_str(&dir.to_string_lossy());
+            } else {
+                merged.push(':');
+                merged.push_str(&dir.to_string_lossy());
+            }
+        }
+
+        if existing.is_empty() {
+            return Some(merged);
+        }
+
+        merged.push(':');
+        merged.push_str(&existing);
+        Some(merged)
+    }
+
+    /// Discovers the LLVM clang and lld paths, storing them as intermediate state.
+    fn discover() -> Result<Self, String> {
+        if let Ok(cc_linux) = env::var("BOXLITE_LIBKRUN_CC_LINUX") {
+            let cc_linux = cc_linux.trim().to_string();
+            if cc_linux.is_empty() {
+                return Err("BOXLITE_LIBKRUN_CC_LINUX is set but empty".to_string());
+            }
+            // User-provided override — no clang discovery needed, but we still
+            // need a valid PathBuf. Store the raw string as the clang path.
+            return Ok(Self {
+                clang: PathBuf::from(cc_linux),
+                path_dirs: Vec::new(),
+            });
+        }
+
+        let clang = Self::find_llvm_clang().ok_or_else(|| {
+            "libkrun cross-compilation on macOS requires LLVM clang + lld. Run `make setup` (or `brew install llvm lld`) and retry."
+                .to_string()
+        })?;
+
+        let mut path_dirs = Vec::new();
+        if let Some(dir) = clang.parent() {
+            path_dirs.push(dir.to_path_buf());
+        }
+        if let Some(lld_dir) = Self::find_lld_bin_dir() {
+            path_dirs.push(lld_dir);
+        }
+
+        Ok(Self { clang, path_dirs })
+    }
+
+    /// Converts the discovered toolchain into make arguments and env overrides.
+    fn into_make_args(self) -> Result<(String, HashMap<String, String>), String> {
+        // If the user provided BOXLITE_LIBKRUN_CC_LINUX, return it directly
+        if env::var("BOXLITE_LIBKRUN_CC_LINUX").is_ok() {
+            let cc_linux = self.clang.to_string_lossy().to_string();
+            return Ok((format!("CC_LINUX={}", cc_linux), HashMap::new()));
+        }
+
+        let path_override = Self::prepend_path_dirs(&self.path_dirs);
+
+        // Ensure ld.lld is available (either already in PATH or via brew lld).
+        let mut ld_lld_cmd = Command::new("ld.lld");
+        ld_lld_cmd
+            .arg("--version")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        if let Some(ref path) = path_override {
+            ld_lld_cmd.env("PATH", path);
+        }
+
+        if !ld_lld_cmd.status().is_ok_and(|s| s.success()) {
+            return Err(
+                "Missing `ld.lld` (LLVM linker). Install it with `make setup` (or `brew install lld`)."
+                    .to_string(),
+            );
+        }
+
+        println!(
+            "cargo:warning=Using LLVM clang for libkrun init cross-compile: {}",
+            self.clang.display()
+        );
+
+        let linux_target_triple = match env::var("CARGO_CFG_TARGET_ARCH")
+            .unwrap_or_else(|_| "$(ARCH)".to_string())
+            .as_str()
+        {
+            // libkrun's sysroot is extracted from Debian arm64 packages, which use the GNU triplet
+            // `aarch64-linux-gnu` for libgcc/crt objects. Using `arm64-linux-gnu` can prevent clang
+            // from finding those files inside the sysroot.
+            "arm64" | "aarch64" => "aarch64-linux-gnu".to_string(),
+            "x86_64" => "x86_64-linux-gnu".to_string(),
+            arch => format!("{arch}-linux-gnu"),
+        };
+
+        // vendor/libkrun hardcodes `/usr/bin/clang` for CC_LINUX on macOS; override it.
+        let clang_escaped = {
+            let s = self.clang.to_string_lossy();
+            format!("'{}'", s.replace('\'', "'\\''"))
+        };
+        let cc_linux = format!(
+            "{} -target {} -fuse-ld=lld -Wl,-strip-debug --sysroot $(SYSROOT_LINUX) -Wno-c23-extensions",
+            clang_escaped,
+            linux_target_triple
+        );
+
+        let mut env_overrides = HashMap::new();
+        if let Some(path) = path_override {
+            env_overrides.insert("PATH".to_string(), path);
+        }
+
+        Ok((format!("CC_LINUX={}", cc_linux), env_overrides))
+    }
+
+    /// Entry point: discovers the toolchain and produces make arguments.
+    pub fn resolve() -> Result<(String, HashMap<String, String>), String> {
+        Self::setup_libclang_path();
+        Self::discover()?.into_make_args()
+    }
+}
+
+// ── Platform build orchestration ─────────────────────────────────────────────
+
+/// macOS: Build libkrunfw (dylib, dlopen'd at runtime) and libkrun (static archive)
+#[cfg(target_os = "macos")]
+fn build() {
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+
+    let libkrunfw_install = out_dir.join("libkrunfw");
+    let libkrun_install = out_dir.join("libkrun");
+    let libkrunfw_lib = libkrunfw_install.join(LIB_DIR);
+
+    println!("cargo:warning=Building libkrun-sys for macOS (static libkrun)");
+
+    // Verify vendored libkrun source exists (libkrunfw is downloaded as prebuilt)
+    verify_vendored_sources(&manifest_dir, false);
+
+    let libkrun_src = manifest_dir.join("vendor/libkrun");
+
+    // 1. Download and extract prebuilt libkrunfw
+    let libkrunfw_src = download_libkrunfw_prebuilt(&out_dir);
+
+    // 2. Build libkrunfw (dylib — dlopen'd by libkrun at runtime)
+    build_with_make(
+        &libkrunfw_src,
+        &libkrunfw_install,
+        "libkrunfw",
+        &HashMap::new(),
+        &[],
+    );
+
+    // 3. Build libkrun (init binary → static library → linking)
+    let (cc_linux_make_arg, env_overrides) =
+        MacToolchain::resolve().unwrap_or_else(|e| panic!("{}", e));
+    LibBuilder::build(
+        &libkrun_src,
+        &libkrun_install,
+        &libkrunfw_install,
+        &env_overrides,
+        &[cc_linux_make_arg],
+    );
+
+    // 4. Fix install names for libkrunfw only (it's still a .dylib)
+    LibFixup::fix(&libkrunfw_lib, "libkrunfw")
+        .unwrap_or_else(|e| panic!("Failed to fix libkrunfw: {}", e));
+}
+
+/// Linux: Build libkrun (static archive) with pre-compiled libkrunfw (.so, dlopen'd)
+#[cfg(target_os = "linux")]
+fn build() {
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+
+    let libkrunfw_install = out_dir.join("libkrunfw");
+    let libkrun_install = out_dir.join("libkrun");
+    let libkrunfw_lib_dir = libkrunfw_install.join(LIB_DIR);
+
+    // Check if user wants to build libkrunfw from source (slow, ~20 min)
+    let build_from_source = env::var("BOXLITE_BUILD_LIBKRUNFW").is_ok();
+
+    if build_from_source {
+        println!(
+            "cargo:warning=Building libkrun-sys for Linux (static, BOXLITE_BUILD_LIBKRUNFW=1)"
+        );
+        verify_vendored_sources(&manifest_dir, true);
+
+        let libkrunfw_src = manifest_dir.join("vendor/libkrunfw");
+
+        build_with_make(
+            &libkrunfw_src,
+            &libkrunfw_install,
+            "libkrunfw",
+            &HashMap::new(),
+            &[],
+        );
+    } else {
+        println!("cargo:warning=Building libkrun-sys for Linux (static, pre-compiled libkrunfw)");
+        verify_vendored_sources(&manifest_dir, false);
+
+        download_libkrunfw_so(&libkrunfw_install);
+    }
+
+    let libkrun_src = manifest_dir.join("vendor/libkrun");
+
+    // Build libkrun (init binary → static library → linking)
+    LibBuilder::build(
+        &libkrun_src,
+        &libkrun_install,
+        &libkrunfw_install,
+        &HashMap::new(),
+        &[],
+    );
+
+    // Fix library names for libkrunfw (still a .so)
+    LibFixup::fix(&libkrunfw_lib_dir, "libkrunfw")
+        .unwrap_or_else(|e| panic!("Failed to fix libkrunfw: {}", e));
+}
+
+// ── Entry point ──────────────────────────────────────────────────────────────
 
 /// Auto-set BOXLITE_DEPS_STUB=2 when downloaded from a registry (crates.io).
 /// Cargo adds .cargo_vcs_info.json to published packages.
@@ -94,784 +915,11 @@ fn main() {
     // Set BOXLITE_DEPS_STUB=1 to skip building and emit stub link directives
     if env::var("BOXLITE_DEPS_STUB").is_ok() {
         println!("cargo:warning=BOXLITE_DEPS_STUB mode: skipping libkrun build");
-        // Emit minimal link directives that won't actually link anything
-        // This allows cargo check/clippy to pass without building libkrun
-        println!("cargo:rustc-link-lib=dylib=krun");
-        // Use a non-existent path - linking will fail but check/clippy won't try to link
+        println!("cargo:rustc-link-lib=static=krun");
         println!("cargo:LIBKRUN_BOXLITE_DEP=/nonexistent");
         println!("cargo:LIBKRUNFW_BOXLITE_DEP=/nonexistent");
         return;
     }
 
     build();
-}
-
-/// Runs a command and panics with a helpful message if it fails.
-#[allow(unused)]
-fn run_command(cmd: &mut Command, description: &str) {
-    let status = cmd
-        .status()
-        .unwrap_or_else(|e| panic!("Failed to execute {}: {}", description, e));
-
-    if !status.success() {
-        panic!("{} failed with exit code: {:?}", description, status.code());
-    }
-}
-
-/// Checks if a directory contains any library file matching the given prefix.
-/// Returns true if a file like "prefix.*.{dylib,so}" exists.
-#[allow(unused)]
-fn has_library(dir: &Path, prefix: &str) -> bool {
-    let extensions = if cfg!(target_os = "macos") {
-        vec!["dylib"]
-    } else if cfg!(target_os = "linux") {
-        vec!["so"]
-    } else {
-        vec!["dll"]
-    };
-
-    dir.read_dir()
-        .ok()
-        .map(|entries| {
-            entries.filter_map(Result::ok).any(|entry| {
-                let filename = entry.file_name().to_string_lossy().to_string();
-                filename.starts_with(prefix)
-                    && extensions
-                        .iter()
-                        .any(|ext| entry.path().extension().is_some_and(|e| e == *ext))
-            })
-        })
-        .unwrap_or(false)
-}
-
-/// Creates a make command with common configuration.
-#[allow(unused)]
-fn make_command(
-    source_dir: &Path,
-    install_dir: &Path,
-    extra_env: &HashMap<String, String>,
-) -> Command {
-    let mut cmd = Command::new("make");
-    cmd.stdout(Stdio::inherit());
-    cmd.stderr(Stdio::inherit());
-    cmd.args(["-j", &num_cpus::get().to_string()])
-        .arg("MAKEFLAGS=") // Clear MAKEFLAGS to prevent -w flag issues in submakes
-        .env("PREFIX", install_dir)
-        .current_dir(source_dir);
-
-    // Apply extra environment variables
-    for (key, value) in extra_env {
-        cmd.env(key, value);
-    }
-
-    cmd
-}
-
-/// Builds a library using Make with the specified parameters.
-#[allow(unused)]
-fn build_with_make(
-    source_dir: &Path,
-    install_dir: &Path,
-    lib_name: &str,
-    extra_env: HashMap<String, String>,
-) {
-    build_with_make_args(source_dir, install_dir, lib_name, extra_env, &[]);
-}
-
-/// Builds a library using Make with additional Make arguments.
-#[allow(unused)]
-fn build_with_make_args(
-    source_dir: &Path,
-    install_dir: &Path,
-    lib_name: &str,
-    extra_env: HashMap<String, String>,
-    extra_make_args: &[String],
-) {
-    println!("cargo:warning=Building {} from source...", lib_name);
-
-    std::fs::create_dir_all(install_dir)
-        .unwrap_or_else(|e| panic!("Failed to create install directory: {}", e));
-
-    // Build
-    let mut make_cmd = make_command(source_dir, install_dir, &extra_env);
-    make_cmd.args(extra_make_args);
-    run_command(&mut make_cmd, &format!("make {}", lib_name));
-
-    // Install
-    let mut install_cmd = make_command(source_dir, install_dir, &extra_env);
-    install_cmd.args(extra_make_args);
-    install_cmd.arg("install");
-    run_command(&mut install_cmd, &format!("make install {}", lib_name));
-}
-
-/// Configure linking for libkrun.
-///
-/// Note: libkrunfw is NOT linked here - it's dlopened by libkrun at runtime.
-/// We only expose the library directory so downstream crates can bundle it.
-fn configure_linking(libkrun_dir: &Path, libkrunfw_dir: &Path) {
-    println!("cargo:rustc-link-search=native={}", libkrun_dir.display());
-    println!("cargo:rustc-link-lib=dylib=krun");
-
-    // Expose library directories to downstream crates (used by boxlite/build.rs)
-    // Convention: {LIBNAME}_BOXLITE_DEP=<path> for auto-discovery
-    println!("cargo:LIBKRUN_BOXLITE_DEP={}", libkrun_dir.display());
-    println!("cargo:LIBKRUNFW_BOXLITE_DEP={}", libkrunfw_dir.display());
-}
-
-/// Fixes the install_name on macOS to use an absolute path.
-/// This allows install_name_tool to modify the library path during wheel repair.
-#[cfg(target_os = "macos")]
-fn fix_install_name(lib_name: &str, lib_path: &Path) {
-    let status = Command::new("install_name_tool")
-        .args([
-            "-id",
-            &format!("@rpath/{}", lib_name),
-            lib_path.to_str().unwrap(),
-        ])
-        .status()
-        .expect("Failed to execute install_name_tool");
-
-    if !status.success() {
-        panic!("Failed to set install_name for {}", lib_name);
-    }
-}
-
-#[cfg(target_os = "linux")]
-fn fix_install_name(lib_name: &str, lib_path: &Path) {
-    let lib_path_str = lib_path.to_str().expect("Invalid library path");
-
-    println!("cargo:warning=Fixing {} in {}", lib_name, lib_path_str);
-
-    let status = Command::new("patchelf")
-        .args([
-            "--set-soname",
-            lib_name, // On Linux, SONAME is just the library name, not @rpath/name
-            lib_path_str,
-        ])
-        .status()
-        .expect("Failed to execute patchelf");
-
-    if !status.success() {
-        panic!("Failed to set install_name for {}", lib_name);
-    }
-}
-
-/// Extract SONAME from versioned library filename
-/// e.g., libkrunfw.so.4.9.0 -> Some("libkrunfw.so.4")
-///       libkrun.so.1.15.1 -> Some("libkrun.so.1")
-#[allow(dead_code)]
-fn extract_major_soname(filename: &str) -> Option<String> {
-    // Find ".so." pattern
-    if let Some(so_pos) = filename.find(".so.") {
-        let base = &filename[..so_pos + 3]; // "libkrunfw.so"
-        let versions = &filename[so_pos + 4..]; // "4.9.0"
-
-        // Get first number (major version)
-        if let Some(major) = versions.split('.').next() {
-            return Some(format!("{}.{}", base, major)); // "libkrunfw.so.4"
-        }
-    }
-    None
-}
-
-#[cfg(target_os = "linux")]
-fn fix_linux_libs(src_dir: &Path, lib_prefix: &str) -> Result<(), String> {
-    use std::fs;
-
-    // First pass: copy regular files and record symlinks
-    for entry in
-        fs::read_dir(src_dir).map_err(|e| format!("Failed to read source directory: {}", e))?
-    {
-        let entry = entry.map_err(|e| format!("Failed to read entry: {}", e))?;
-        let path = entry.path();
-        let filename = path.file_name().unwrap().to_string_lossy().to_string();
-
-        if filename.starts_with(lib_prefix) && filename.contains(".so") {
-            // Check if it's a symlink
-            let metadata = fs::symlink_metadata(&path)
-                .map_err(|e| format!("Failed to get metadata: {}", e))?;
-
-            if metadata.file_type().is_symlink() {
-                continue;
-            } else {
-                // For libkrunfw only: rename to major version
-                if lib_prefix == "libkrunfw" {
-                    if let Some(soname) = extract_major_soname(&filename) {
-                        if soname != filename {
-                            let new_path = src_dir.join(&soname);
-                            fs::rename(&path, &new_path)
-                                .map_err(|e| format!("Failed to rename file: {}", e))?;
-                            println!("cargo:warning=Renamed {} to {}", filename, soname);
-
-                            // Fix install_name on renamed file
-                            fix_install_name(&soname, &new_path);
-                            continue;
-                        }
-                    }
-                }
-
-                // Fix install_name (only for non-symlinks)
-                fix_install_name(&filename, &path);
-            }
-        }
-    }
-
-    Ok(())
-}
-
-/// Downloads a file from URL to the specified path.
-fn download_file(url: &str, dest: &Path) -> io::Result<()> {
-    println!("cargo:warning=Downloading {}...", url);
-
-    let output = Command::new("curl")
-        .args(["-fsSL", "-o", dest.to_str().unwrap(), url])
-        .output()?;
-
-    if !output.status.success() {
-        return Err(io::Error::other(format!(
-            "curl failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        )));
-    }
-
-    Ok(())
-}
-
-/// Verifies SHA256 checksum of a file.
-fn verify_sha256(file: &Path, expected: &str) -> io::Result<()> {
-    // Use sha256sum on Linux, shasum on macOS
-    let (cmd, args): (&str, Vec<&str>) = if cfg!(target_os = "linux") {
-        ("sha256sum", vec![file.to_str().unwrap()])
-    } else {
-        ("shasum", vec!["-a", "256", file.to_str().unwrap()])
-    };
-
-    let output = Command::new(cmd).args(&args).output()?;
-
-    if !output.status.success() {
-        return Err(io::Error::other(format!("{} failed", cmd)));
-    }
-
-    let actual = String::from_utf8_lossy(&output.stdout)
-        .split_whitespace()
-        .next()
-        .unwrap_or("")
-        .to_string();
-
-    if actual != expected {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!("SHA256 mismatch: expected {}, got {}", expected, actual),
-        ));
-    }
-
-    println!("cargo:warning=SHA256 verified: {}", expected);
-    Ok(())
-}
-
-/// Extracts a tarball to the specified directory.
-fn extract_tarball(tarball: &Path, dest: &Path) -> io::Result<()> {
-    fs::create_dir_all(dest)?;
-
-    let status = Command::new("tar")
-        .args([
-            "-xzf",
-            tarball.to_str().unwrap(),
-            "-C",
-            dest.to_str().unwrap(),
-        ])
-        .status()?;
-
-    if !status.success() {
-        return Err(io::Error::other("tar extraction failed"));
-    }
-
-    Ok(())
-}
-
-/// Downloads and extracts the prebuilt libkrunfw tarball (macOS).
-/// Returns the path to the extracted source directory containing kernel.c.
-#[cfg(target_os = "macos")]
-fn download_libkrunfw_prebuilt(out_dir: &Path) -> PathBuf {
-    let tarball_path = out_dir.join("libkrunfw-prebuilt.tar.gz");
-    let extract_dir = out_dir.join("libkrunfw-src");
-    // boxlite-ai/libkrunfw prebuilt tarball extracts to "libkrunfw/" directory
-    let src_dir = extract_dir.join("libkrunfw");
-
-    // Check if already extracted
-    if src_dir.join("kernel.c").exists() {
-        println!("cargo:warning=Using cached libkrunfw source");
-        return src_dir;
-    }
-
-    // Download if not cached
-    if !tarball_path.exists() {
-        download_file(LIBKRUNFW_PREBUILT_URL, &tarball_path)
-            .unwrap_or_else(|e| panic!("Failed to download libkrunfw: {}", e));
-
-        verify_sha256(&tarball_path, LIBKRUNFW_SHA256)
-            .unwrap_or_else(|e| panic!("Failed to verify libkrunfw checksum: {}", e));
-    }
-
-    // Extract
-    if extract_dir.exists() {
-        fs::remove_dir_all(&extract_dir).ok();
-    }
-    extract_tarball(&tarball_path, &extract_dir)
-        .unwrap_or_else(|e| panic!("Failed to extract libkrunfw: {}", e));
-
-    println!("cargo:warning=Extracted libkrunfw to {}", src_dir.display());
-    src_dir
-}
-
-/// Downloads pre-compiled libkrunfw .so files (Linux).
-/// Extracts directly to the install directory - no build step needed.
-#[cfg(target_os = "linux")]
-fn download_libkrunfw_so(install_dir: &Path) {
-    let lib_dir = install_dir.join(LIB_DIR);
-
-    // Check if already extracted
-    if has_library(&lib_dir, "libkrunfw") {
-        println!("cargo:warning=Using cached libkrunfw.so");
-        return;
-    }
-
-    // Create install directory first (required before download)
-    fs::create_dir_all(install_dir)
-        .unwrap_or_else(|e| panic!("Failed to create install dir: {}", e));
-
-    let tarball_path = install_dir.join("libkrunfw.tgz");
-
-    // Download if not cached
-    if !tarball_path.exists() {
-        download_file(LIBKRUNFW_SO_URL, &tarball_path)
-            .unwrap_or_else(|e| panic!("Failed to download libkrunfw: {}", e));
-
-        verify_sha256(&tarball_path, LIBKRUNFW_SHA256)
-            .unwrap_or_else(|e| panic!("Failed to verify libkrunfw checksum: {}", e));
-    }
-
-    // Extract (tarball contains lib64/ directory)
-    extract_tarball(&tarball_path, install_dir)
-        .unwrap_or_else(|e| panic!("Failed to extract libkrunfw: {}", e));
-
-    println!(
-        "cargo:warning=Extracted libkrunfw.so to {}",
-        lib_dir.display()
-    );
-}
-
-/// Builds libkrunfw from the prebuilt source.
-#[cfg(target_os = "macos")]
-fn build_libkrunfw_macos(src_dir: &Path, install_dir: &Path) {
-    build_with_make(src_dir, install_dir, "libkrunfw", HashMap::new());
-}
-
-/// Sets LIBCLANG_PATH for bindgen if not already set.
-/// This is needed when llvm is installed via brew but not linked (keg-only).
-#[cfg(target_os = "macos")]
-fn setup_libclang_path() {
-    // Skip if LIBCLANG_PATH already set or llvm-config is in PATH
-    if env::var("LIBCLANG_PATH").is_ok() {
-        return;
-    }
-    if Command::new("llvm-config")
-        .arg("--version")
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .is_ok_and(|s| s.success())
-    {
-        return;
-    }
-
-    // Try common Homebrew locations (useful when `brew` itself can't be executed).
-    for prefix in ["/opt/homebrew/opt/llvm", "/usr/local/opt/llvm"] {
-        let lib_path = Path::new(prefix).join("lib");
-        if lib_path.join("libclang.dylib").exists() {
-            env::set_var("LIBCLANG_PATH", &lib_path);
-            return;
-        }
-    }
-
-    // Try to find brew's llvm
-    if let Ok(output) = Command::new("brew").args(["--prefix", "llvm"]).output() {
-        if output.status.success() {
-            let prefix = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            let lib_path = format!("{}/lib", prefix);
-            if Path::new(&lib_path).join("libclang.dylib").exists() {
-                env::set_var("LIBCLANG_PATH", &lib_path);
-            }
-        }
-    }
-}
-
-#[cfg(target_os = "macos")]
-fn brew_prefix(formula: &str) -> Option<PathBuf> {
-    let output = Command::new("brew")
-        .args(["--prefix", formula])
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-
-    let prefix = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if prefix.is_empty() {
-        return None;
-    }
-
-    Some(PathBuf::from(prefix))
-}
-
-#[cfg(target_os = "macos")]
-fn find_non_apple_clang_in_path() -> Option<PathBuf> {
-    let version = Command::new("clang").arg("--version").output().ok()?;
-    if !version.status.success() {
-        return None;
-    }
-
-    let version_stdout = String::from_utf8_lossy(&version.stdout);
-    if version_stdout.starts_with("Apple clang") {
-        return None;
-    }
-
-    let output = Command::new("which").arg("clang").output().ok()?;
-    if !output.status.success() {
-        return None;
-    }
-
-    let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if path.is_empty() {
-        return None;
-    }
-
-    let path = PathBuf::from(path);
-    path.exists().then_some(path)
-}
-
-#[cfg(target_os = "macos")]
-fn find_llvm_clang() -> Option<PathBuf> {
-    // If the user has already put a non-Apple clang first in PATH, prefer that.
-    if let Some(clang) = find_non_apple_clang_in_path() {
-        return Some(clang);
-    }
-
-    // If llvm-config is available, use it.
-    if let Ok(output) = Command::new("llvm-config").arg("--bindir").output() {
-        if output.status.success() {
-            let bindir = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            if !bindir.is_empty() {
-                let clang = PathBuf::from(bindir).join("clang");
-                if clang.exists() {
-                    return Some(clang);
-                }
-            }
-        }
-    }
-
-    // Common Homebrew locations (useful when `brew` itself can't be executed).
-    for prefix in ["/opt/homebrew/opt/llvm", "/usr/local/opt/llvm"] {
-        let clang = Path::new(prefix).join("bin/clang");
-        if clang.exists() {
-            return Some(clang);
-        }
-    }
-
-    // Homebrew llvm is keg-only; locate it via brew.
-    brew_prefix("llvm")
-        .map(|prefix| prefix.join("bin/clang"))
-        .filter(|clang| clang.exists())
-}
-
-#[cfg(target_os = "macos")]
-fn lld_bin_dir() -> Option<PathBuf> {
-    // If ld.lld is already in PATH, we're good.
-    if Command::new("ld.lld")
-        .arg("--version")
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .is_ok_and(|s| s.success())
-    {
-        return None;
-    }
-
-    // Common Homebrew locations (useful when `brew` itself can't be executed).
-    for prefix in ["/opt/homebrew/opt/lld", "/usr/local/opt/lld"] {
-        let ld_lld = Path::new(prefix).join("bin/ld.lld");
-        if ld_lld.exists() {
-            return ld_lld.parent().map(Path::to_path_buf);
-        }
-    }
-
-    // Otherwise, try locating via Homebrew.
-    let ld_lld = brew_prefix("lld")
-        .map(|prefix| prefix.join("bin/ld.lld"))
-        .filter(|path| path.exists())?;
-
-    ld_lld.parent().map(Path::to_path_buf)
-}
-
-#[cfg(target_os = "macos")]
-fn prepend_path_dirs(path_dirs: &[PathBuf]) -> Option<String> {
-    if path_dirs.is_empty() {
-        return None;
-    }
-
-    let existing = env::var("PATH").unwrap_or_default();
-    let mut merged = String::new();
-    for dir in path_dirs {
-        if merged.is_empty() {
-            merged.push_str(&dir.to_string_lossy());
-        } else {
-            merged.push(':');
-            merged.push_str(&dir.to_string_lossy());
-        }
-    }
-
-    if existing.is_empty() {
-        return Some(merged);
-    }
-
-    merged.push(':');
-    merged.push_str(&existing);
-    Some(merged)
-}
-
-#[cfg(target_os = "macos")]
-fn resolve_cc_linux_make_arg() -> Result<(String, HashMap<String, String>), String> {
-    if let Ok(cc_linux) = env::var("BOXLITE_LIBKRUN_CC_LINUX") {
-        let cc_linux = cc_linux.trim().to_string();
-        if cc_linux.is_empty() {
-            return Err("BOXLITE_LIBKRUN_CC_LINUX is set but empty".to_string());
-        }
-        return Ok((format!("CC_LINUX={}", cc_linux), HashMap::new()));
-    }
-
-    let clang = find_llvm_clang().ok_or_else(|| {
-        "libkrun cross-compilation on macOS requires LLVM clang + lld. Run `make setup` (or `brew install llvm lld`) and retry."
-            .to_string()
-    })?;
-
-    let mut path_dirs = Vec::new();
-    if let Some(dir) = clang.parent() {
-        path_dirs.push(dir.to_path_buf());
-    }
-    if let Some(lld_dir) = lld_bin_dir() {
-        path_dirs.push(lld_dir);
-    }
-
-    let path_override = prepend_path_dirs(&path_dirs);
-
-    // Ensure ld.lld is available (either already in PATH or via brew lld).
-    let mut ld_lld_cmd = Command::new("ld.lld");
-    ld_lld_cmd
-        .arg("--version")
-        .stdout(Stdio::null())
-        .stderr(Stdio::null());
-    if let Some(ref path) = path_override {
-        ld_lld_cmd.env("PATH", path);
-    }
-
-    if !ld_lld_cmd.status().is_ok_and(|s| s.success()) {
-        return Err(
-            "Missing `ld.lld` (LLVM linker). Install it with `make setup` (or `brew install lld`)."
-                .to_string(),
-        );
-    }
-
-    println!(
-        "cargo:warning=Using LLVM clang for libkrun init cross-compile: {}",
-        clang.display()
-    );
-
-    let linux_target_triple = match env::var("CARGO_CFG_TARGET_ARCH")
-        .unwrap_or_else(|_| "$(ARCH)".to_string())
-        .as_str()
-    {
-        // libkrun's sysroot is extracted from Debian arm64 packages, which use the GNU triplet
-        // `aarch64-linux-gnu` for libgcc/crt objects. Using `arm64-linux-gnu` can prevent clang
-        // from finding those files inside the sysroot.
-        "arm64" | "aarch64" => "aarch64-linux-gnu".to_string(),
-        "x86_64" => "x86_64-linux-gnu".to_string(),
-        arch => format!("{arch}-linux-gnu"),
-    };
-
-    // vendor/libkrun hardcodes `/usr/bin/clang` for CC_LINUX on macOS; override it.
-    // Shell-escape the clang path so that spaces or special characters do not break the Make command.
-    let clang_escaped = {
-        let s = clang.to_string_lossy();
-        // Use single-quote shell escaping: each ' becomes '\'' and the whole string is wrapped in single quotes.
-        format!("'{}'", s.replace('\'', "'\\''"))
-    };
-    let cc_linux = format!(
-        "{} -target {} -fuse-ld=lld -Wl,-strip-debug --sysroot $(SYSROOT_LINUX) -Wno-c23-extensions",
-        clang_escaped,
-        linux_target_triple
-    );
-
-    let mut env_overrides = HashMap::new();
-    if let Some(path) = path_override {
-        env_overrides.insert("PATH".to_string(), path);
-    }
-
-    Ok((format!("CC_LINUX={}", cc_linux), env_overrides))
-}
-
-/// Builds libkrun from vendored source with cross-compilation support.
-#[cfg(target_os = "macos")]
-fn build_libkrun_macos(src_dir: &Path, install_dir: &Path, libkrunfw_install: &Path) {
-    // Setup LIBCLANG_PATH for bindgen if needed
-    setup_libclang_path();
-
-    let (cc_linux_make_arg, env_overrides) =
-        resolve_cc_linux_make_arg().unwrap_or_else(|e| panic!("{}", e));
-
-    let mut extra_env = libkrun_build_env(libkrunfw_install);
-    extra_env.extend(env_overrides);
-
-    build_with_make_args(
-        src_dir,
-        install_dir,
-        "libkrun",
-        extra_env,
-        &[cc_linux_make_arg],
-    );
-}
-
-/// Fixes install names and re-signs libraries in a directory.
-#[cfg(target_os = "macos")]
-fn fix_macos_libs(lib_dir: &Path, lib_prefix: &str) -> Result<(), String> {
-    for entry in fs::read_dir(lib_dir).map_err(|e| format!("Failed to read lib dir: {}", e))? {
-        let entry = entry.map_err(|e| format!("Failed to read entry: {}", e))?;
-        let path = entry.path();
-        let filename = path.file_name().unwrap().to_string_lossy().to_string();
-
-        if filename.starts_with(lib_prefix) && filename.contains(".dylib") {
-            let metadata = fs::symlink_metadata(&path)
-                .map_err(|e| format!("Failed to get metadata: {}", e))?;
-
-            // Skip symlinks
-            if metadata.file_type().is_symlink() {
-                continue;
-            }
-
-            // Fix install_name to use @rpath
-            fix_install_name(&filename, &path);
-
-            // Re-sign after modifying
-            let sign_status = Command::new("codesign")
-                .args(["-s", "-", "--force"])
-                .arg(&path)
-                .status()
-                .map_err(|e| format!("Failed to run codesign: {}", e))?;
-
-            if !sign_status.success() {
-                return Err(format!("codesign failed for {}", filename));
-            }
-
-            println!("cargo:warning=Fixed and signed {}", filename);
-        }
-    }
-
-    Ok(())
-}
-
-/// macOS: Build libkrun and libkrunfw from source
-#[cfg(target_os = "macos")]
-fn build() {
-    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
-    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
-
-    let libkrunfw_install = out_dir.join("libkrunfw");
-    let libkrun_install = out_dir.join("libkrun");
-    let libkrunfw_lib = libkrunfw_install.join(LIB_DIR);
-    let libkrun_lib = libkrun_install.join(LIB_DIR);
-
-    println!("cargo:warning=Building libkrun-sys for macOS (from source)");
-
-    // Verify vendored libkrun source exists (libkrunfw is downloaded as prebuilt)
-    verify_vendored_sources(&manifest_dir, false);
-
-    let libkrun_src = manifest_dir.join("vendor/libkrun");
-
-    // 1. Download and extract prebuilt libkrunfw
-    let libkrunfw_src = download_libkrunfw_prebuilt(&out_dir);
-
-    // 2. Build libkrunfw
-    build_libkrunfw_macos(&libkrunfw_src, &libkrunfw_install);
-
-    // 3. Build libkrun from vendored source
-    build_libkrun_macos(&libkrun_src, &libkrun_install, &libkrunfw_install);
-
-    // 4. Fix install names for @rpath
-    fix_macos_libs(&libkrunfw_lib, "libkrunfw")
-        .unwrap_or_else(|e| panic!("Failed to fix libkrunfw: {}", e));
-
-    fix_macos_libs(&libkrun_lib, "libkrun")
-        .unwrap_or_else(|e| panic!("Failed to fix libkrun: {}", e));
-
-    // 5. Configure linking
-    configure_linking(&libkrun_lib, &libkrunfw_lib);
-}
-
-/// Linux: Build libkrun (libkrunfw is downloaded pre-compiled)
-/// By default, downloads pre-compiled libkrunfw.so to avoid ~20min kernel build.
-/// Set BOXLITE_BUILD_LIBKRUNFW=1 to build libkrunfw from source.
-#[cfg(target_os = "linux")]
-fn build() {
-    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
-    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
-
-    let libkrunfw_install = out_dir.join("libkrunfw");
-    let libkrun_install = out_dir.join("libkrun");
-    let libkrunfw_lib_dir = libkrunfw_install.join(LIB_DIR);
-    let libkrun_lib_dir = libkrun_install.join(LIB_DIR);
-
-    // Check if user wants to build libkrunfw from source (slow, ~20 min)
-    let build_from_source = env::var("BOXLITE_BUILD_LIBKRUNFW").is_ok();
-
-    if build_from_source {
-        println!(
-            "cargo:warning=Building libkrun-sys for Linux (from source, BOXLITE_BUILD_LIBKRUNFW=1)"
-        );
-        // Verify vendored sources exist
-        verify_vendored_sources(&manifest_dir, true);
-
-        let libkrunfw_src = manifest_dir.join("vendor/libkrunfw");
-
-        // Build libkrunfw from source (~20 min kernel build)
-        build_with_make(
-            &libkrunfw_src,
-            &libkrunfw_install,
-            "libkrunfw",
-            HashMap::new(),
-        );
-    } else {
-        println!("cargo:warning=Building libkrun-sys for Linux (using pre-compiled .so)");
-        // Verify only libkrun vendored source exists (libkrunfw is downloaded)
-        verify_vendored_sources(&manifest_dir, false);
-
-        // Download pre-compiled libkrunfw.so directly (no build needed)
-        download_libkrunfw_so(&libkrunfw_install);
-    }
-
-    // Build libkrun from vendored source (always)
-    let libkrun_src = manifest_dir.join("vendor/libkrun");
-    build_with_make(
-        &libkrun_src,
-        &libkrun_install,
-        "libkrun",
-        libkrun_build_env(&libkrunfw_install),
-    );
-
-    // Fix library names
-    fix_linux_libs(&libkrun_lib_dir, "libkrun")
-        .unwrap_or_else(|e| panic!("Failed to fix libkrun: {}", e));
-
-    fix_linux_libs(&libkrunfw_lib_dir, "libkrunfw")
-        .unwrap_or_else(|e| panic!("Failed to fix libkrunfw: {}", e));
-
-    configure_linking(&libkrun_lib_dir, &libkrunfw_lib_dir);
 }

--- a/boxlite/src/litebox/state.rs
+++ b/boxlite/src/litebox/state.rs
@@ -190,6 +190,7 @@ pub struct BoxState {
     /// Used to retrieve the lock across process restarts.
     pub lock_id: Option<LockId>,
     /// Health status.
+    #[serde(default)]
     pub health_status: HealthStatus,
 }
 
@@ -843,5 +844,23 @@ mod tests {
         let state = BoxState::new();
         assert_eq!(state.health_status.state, HealthState::None);
         assert_eq!(state.health_status.failures, 0);
+    }
+
+    #[test]
+    fn deserialize_box_state_without_health_status() {
+        // JSON from before PR #266 (no health_status field).
+        // Old database rows lack this field; serde(default) must fill it in.
+        let old_json = r#"{
+            "status": "configured",
+            "pid": null,
+            "container_id": null,
+            "last_updated": "2026-02-26T00:00:00Z",
+            "lock_id": null
+        }"#;
+        let state: BoxState = serde_json::from_str(old_json).unwrap();
+        assert_eq!(state.status, BoxStatus::Configured);
+        assert_eq!(state.health_status.state, HealthState::None);
+        assert_eq!(state.health_status.failures, 0);
+        assert!(state.health_status.last_check.is_none());
     }
 }

--- a/scripts/build/build-runtime.sh
+++ b/scripts/build/build-runtime.sh
@@ -12,11 +12,9 @@
 #   --profile PROFILE   Build profile: release or debug (default: release)
 #
 # The runtime directory will contain:
-#   - boxlite-shim      VM subprocess runner
+#   - boxlite-shim      VM subprocess runner (statically links libkrun + libgvproxy)
 #   - boxlite-guest     Guest agent (Linux binary)
-#   - libkrun.*         libkrun library
-#   - libkrunfw.*       libkrunfw library
-#   - libgvproxy.*      gvproxy library (if gvproxy-backend feature enabled)
+#   - libkrunfw.*       libkrunfw library (dlopen'd at runtime)
 
 set -e
 
@@ -43,11 +41,9 @@ Options:
   --help, -h          Show this help message
 
 The runtime directory will contain:
-  - boxlite-shim      VM subprocess runner
+  - boxlite-shim      VM subprocess runner (statically links libkrun + libgvproxy)
   - boxlite-guest     Guest agent (Linux binary)
-  - libkrun.*         libkrun library
-  - libkrunfw.*       libkrunfw library
-  - libgvproxy.*      gvproxy library (if available)
+  - libkrunfw.*       libkrunfw library (dlopen'd at runtime)
 
 Examples:
   # Build release runtime in default location
@@ -147,7 +143,16 @@ build_shim() {
     # Always build to ensure freshness (Cargo handles incremental compilation)
     bash "$SCRIPT_BUILD_DIR/build-shim.sh" --profile "$PROFILE"
 
-    local shim_path="$PROJECT_ROOT/target/$PROFILE/boxlite-shim"
+    # Compute shim binary path (matches build-shim.sh's compute_shim_target logic)
+    local shim_path
+    if [ "$OS" = "linux" ]; then
+        local arch
+        arch=$(uname -m)
+        shim_path="$PROJECT_ROOT/target/${arch}-unknown-linux-musl/$PROFILE/boxlite-shim"
+    else
+        shim_path="$PROJECT_ROOT/target/$PROFILE/boxlite-shim"
+    fi
+
     if [ -f "$shim_path" ]; then
         SHIM_BINARY="$shim_path"
         print_success "Built: $shim_path"

--- a/scripts/build/build-shim.sh
+++ b/scripts/build/build-shim.sh
@@ -9,6 +9,7 @@
 #   --profile PROFILE   Build profile: release or debug (default: release)
 #
 # Note: On macOS, the binary is automatically signed with hypervisor entitlements
+# Note: On Linux, the binary is built with musl for a fully static executable
 
 set -e
 
@@ -70,6 +71,21 @@ parse_args "$@"
 OS=$(detect_os)
 print_header "🚀 Building boxlite-shim on $OS..."
 
+# Compute the Rust target triple and binary path for the current platform
+compute_shim_target() {
+    if [ "$OS" = "linux" ]; then
+        local arch
+        arch=$(uname -m)
+        SHIM_TARGET="${arch}-unknown-linux-musl"
+        SHIM_BINARY_PATH="$PROJECT_ROOT/target/$SHIM_TARGET/$PROFILE/boxlite-shim"
+    else
+        SHIM_TARGET=""
+        SHIM_BINARY_PATH="$PROJECT_ROOT/target/$PROFILE/boxlite-shim"
+    fi
+}
+
+compute_shim_target
+
 # Build the shim binary
 build_shim_binary() {
     cd "$PROJECT_ROOT"
@@ -78,7 +94,13 @@ build_shim_binary() {
     if [ "$PROFILE" = "release" ]; then
         build_flag="--release"
     fi
-    cargo build $build_flag --bin boxlite-shim
+
+    if [ -n "$SHIM_TARGET" ]; then
+        echo "🎯 Target: $SHIM_TARGET (static musl binary)"
+        cargo build $build_flag --bin boxlite-shim --target "$SHIM_TARGET"
+    else
+        cargo build $build_flag --bin boxlite-shim
+    fi
 }
 
 # Sign the binary (macOS only, automatic)
@@ -107,7 +129,7 @@ sign_binary() {
 copy_to_destination() {
     if [ -z "$DEST_DIR" ]; then
         echo "✅ Shim binary built successfully (no destination specified)"
-        echo "Binary location: $PROJECT_ROOT/target/$PROFILE/boxlite-shim"
+        echo "Binary location: $SHIM_BINARY_PATH"
         return 0
     fi
 
@@ -115,7 +137,7 @@ copy_to_destination() {
     # Absolute paths are used as-is
     echo "📦 Copying to destination: $DEST_DIR"
     mkdir -p "$DEST_DIR"
-    cp "$PROJECT_ROOT/target/$PROFILE/boxlite-shim" "$DEST_DIR/"
+    cp "$SHIM_BINARY_PATH" "$DEST_DIR/"
 
     echo "✅ Shim binary built and copied to $DEST_DIR"
     echo "Binary info:"

--- a/sdks/c/include/boxlite.h
+++ b/sdks/c/include/boxlite.h
@@ -74,8 +74,7 @@ typedef struct RuntimeHandle CBoxliteRuntime;
 typedef struct FFIError {
   // Error code
   enum BoxliteErrorCode code;
-  // Detailed error message (NULL if none, caller must free with
-  // boxlite_error_free)
+  // Detailed error message (NULL if none, caller must free with boxlite_error_free)
   char *message;
 } FFIError;
 
@@ -101,8 +100,7 @@ extern "C" {
 // Get BoxLite version string
 //
 // # Returns
-// A pointer to a static C string containing the version. Do not free this
-// string.
+// A pointer to a static C string containing the version. Do not free this string.
 //
 // # Example
 // ```c
@@ -113,11 +111,9 @@ const char *boxlite_version(void);
 // Create a new BoxLite runtime configuration.
 //
 // # Arguments
-// * `home_dir` - Optional path to the home directory. If NULL, defaults to
-// `~/.boxlite`.
+// * `home_dir` - Optional path to the home directory. If NULL, defaults to `~/.boxlite`.
 // * `registries_json` - Optional JSON array of registry configurations.
-// * `out_runtime` - Output parameter to store the created `CBoxliteRuntime`
-// pointer.
+// * `out_runtime` - Output parameter to store the created `CBoxliteRuntime` pointer.
 // * `out_error` - Output parameter for error information.
 //
 // # Returns
@@ -178,15 +174,17 @@ enum BoxliteErrorCode boxlite_create_box(CBoxliteRuntime *runtime,
 // ```c
 // int exit_code;
 // const char *args = "[\"hello\"]";
-// if (boxlite_execute(box, "echo", args, NULL, NULL, &exit_code, error) ==
-// BOXLITE_OK) {
+// if (boxlite_execute(box, "echo", args, NULL, NULL, &exit_code, error) == BOXLITE_OK) {
 //     printf("Exit code: %d\n", exit_code);
 // }
 // ```
-enum BoxliteErrorCode
-boxlite_execute(CBoxHandle *handle, const char *command, const char *args_json,
-                void (*callback)(const char *, int, void *), void *user_data,
-                int *out_exit_code, CBoxliteError *out_error);
+enum BoxliteErrorCode boxlite_execute(CBoxHandle *handle,
+                                      const char *command,
+                                      const char *args_json,
+                                      void (*callback)(const char*, int, void*),
+                                      void *user_data,
+                                      int *out_exit_code,
+                                      CBoxliteError *out_error);
 
 // Stop a box.
 //
@@ -198,15 +196,13 @@ boxlite_execute(CBoxHandle *handle, const char *command, const char *args_json,
 // ```c
 // boxlite_stop_box(box, error);
 // ```
-enum BoxliteErrorCode boxlite_stop_box(CBoxHandle *handle,
-                                       CBoxliteError *out_error);
+enum BoxliteErrorCode boxlite_stop_box(CBoxHandle *handle, CBoxliteError *out_error);
 
 // List all boxes as JSON.
 //
 // # Arguments
 // * `runtime` - Runtime handle.
-// * `out_json` - Output pointer for JSON string. Caller must free this with
-// `boxlite_free_string`.
+// * `out_json` - Output pointer for JSON string. Caller must free this with `boxlite_free_string`.
 // * `out_error` - Output error.
 //
 // # Example
@@ -235,7 +231,8 @@ enum BoxliteErrorCode boxlite_list_info(CBoxliteRuntime *runtime,
 // boxlite_get_info(runtime, "my-box", &json, error);
 // ```
 enum BoxliteErrorCode boxlite_get_info(CBoxliteRuntime *runtime,
-                                       const char *id_or_name, char **out_json,
+                                       const char *id_or_name,
+                                       char **out_json,
                                        CBoxliteError *out_error);
 
 // Attach to an existing box.
@@ -271,7 +268,8 @@ enum BoxliteErrorCode boxlite_get(CBoxliteRuntime *runtime,
 // boxlite_remove(runtime, "my-box", 1, error);
 // ```
 enum BoxliteErrorCode boxlite_remove(CBoxliteRuntime *runtime,
-                                     const char *id_or_name, int force,
+                                     const char *id_or_name,
+                                     int force,
                                      CBoxliteError *out_error);
 
 // Get runtime metrics as JSON.
@@ -320,7 +318,8 @@ enum BoxliteErrorCode boxlite_runtime_shutdown(CBoxliteRuntime *runtime,
 // char *json;
 // boxlite_box_info(handle, &json, error);
 // ```
-enum BoxliteErrorCode boxlite_box_info(CBoxHandle *handle, char **out_json,
+enum BoxliteErrorCode boxlite_box_info(CBoxHandle *handle,
+                                       char **out_json,
                                        CBoxliteError *out_error);
 
 // Get metrics for a box handle as JSON.
@@ -335,7 +334,8 @@ enum BoxliteErrorCode boxlite_box_info(CBoxHandle *handle, char **out_json,
 // char *json;
 // boxlite_box_metrics(handle, &json, error);
 // ```
-enum BoxliteErrorCode boxlite_box_metrics(CBoxHandle *handle, char **out_json,
+enum BoxliteErrorCode boxlite_box_metrics(CBoxHandle *handle,
+                                          char **out_json,
                                           CBoxliteError *out_error);
 
 // Start a stopped box.
@@ -348,8 +348,7 @@ enum BoxliteErrorCode boxlite_box_metrics(CBoxHandle *handle, char **out_json,
 // ```c
 // boxlite_start_box(handle, error);
 // ```
-enum BoxliteErrorCode boxlite_start_box(CBoxHandle *handle,
-                                        CBoxliteError *out_error);
+enum BoxliteErrorCode boxlite_start_box(CBoxHandle *handle, CBoxliteError *out_error);
 
 // Get box ID.
 //
@@ -357,8 +356,7 @@ enum BoxliteErrorCode boxlite_start_box(CBoxHandle *handle,
 // * `handle` - Box handle.
 //
 // # Returns
-// Pointer to a C string containing the ID. Must be freed with
-// `boxlite_free_string`.
+// Pointer to a C string containing the ID. Must be freed with `boxlite_free_string`.
 //
 // # Example
 // ```c
@@ -387,7 +385,8 @@ char *boxlite_box_id(CBoxHandle *handle);
 //     // Use runner...
 // }
 // ```
-enum BoxliteErrorCode boxlite_simple_new(const char *image, int cpus,
+enum BoxliteErrorCode boxlite_simple_new(const char *image,
+                                         int cpus,
                                          int memory_mib,
                                          CBoxliteSimple **out_box,
                                          CBoxliteError *out_error);
@@ -410,7 +409,8 @@ enum BoxliteErrorCode boxlite_simple_new(const char *image, int cpus,
 // ```
 enum BoxliteErrorCode boxlite_simple_run(CBoxliteSimple *box_runner,
                                          const char *command,
-                                         const char *const *args, int argc,
+                                         const char *const *args,
+                                         int argc,
                                          CBoxliteExecResult **out_result,
                                          CBoxliteError *out_error);
 
@@ -451,7 +451,7 @@ void boxlite_free_string(char *s);
 void boxlite_error_free(CBoxliteError *error);
 
 #ifdef __cplusplus
-} // extern "C"
-#endif // __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
 
-#endif /* BOXLITE_H */
+#endif  /* BOXLITE_H */


### PR DESCRIPTION
- Build libgvproxy as c-archive instead of c-shared (static .a)
- Build libkrun as staticlib via `cargo rustc --crate-type staticlib`
- Build shim with musl target on Linux for fully static binary
- Refactor libkrun-sys build.rs into Fetcher/LibBuilder/LibFixup/MacToolchain
- Add serde(default) to BoxState.health_status for backward compat
- Reformat C SDK header (one parameter per line, re-wrapped comments)