### PR TITLE
refactor(test): migrate health_check.rs to BoxTestBase

### DIFF
--- a/boxlite-test-utils/src/box_test.rs
+++ b/boxlite-test-utils/src/box_test.rs
@@ -39,17 +39,21 @@ pub struct BoxTestBase {
 impl BoxTestBase {
     /// Create a new test fixture with `alpine:latest` and default options.
     ///
-    /// Triggers shared cache initialization on first call (image pull, rootfs build).
+    /// Returns a **running** box. Triggers shared cache initialization on first call.
     pub async fn new() -> Self {
-        Self::with_options(BoxOptions {
+        let t = Self::with_options(BoxOptions {
             rootfs: RootfsSpec::Image("alpine:latest".into()),
             auto_remove: false,
             ..Default::default()
         })
-        .await
+        .await;
+        t.bx.start().await.expect("start BoxTestBase box");
+        t
     }
 
     /// Create a new test fixture with custom `BoxOptions`.
+    ///
+    /// Returns a **created-but-not-started** box. Call `bx.start().await` when ready.
     pub async fn with_options(options: BoxOptions) -> Self {
         let home = PerTestBoxHome::new();
         let runtime = BoxliteRuntime::new(BoxliteOptions {
@@ -62,7 +66,6 @@ impl BoxTestBase {
             .create(options, None)
             .await
             .expect("create BoxTestBase box");
-        bx.start().await.expect("start BoxTestBase box");
 
         Self {
             runtime,

--- a/boxlite-test-utils/src/cache.rs
+++ b/boxlite-test-utils/src/cache.rs
@@ -19,7 +19,17 @@ use std::sync::OnceLock;
 use boxlite::BoxliteRuntime;
 use boxlite::runtime::options::{BoxOptions, BoxliteOptions, RootfsSpec};
 
+use tempfile::TempDir;
+
 use crate::{TEST_IMAGES, TEST_SHUTDOWN_TIMEOUT, test_registries};
+
+/// Cleanup handle for per-test resources linked into a home directory.
+///
+/// Owns the per-test tmp directory under `target/boxlite-test/tmp/`.
+/// Dropping this removes it automatically via [`TempDir`]'s RAII cleanup.
+pub struct LinkedCache {
+    _per_test_tmp: TempDir,
+}
 
 static SHARED_RESOURCES: OnceLock<SharedResources> = OnceLock::new();
 
@@ -30,8 +40,6 @@ static SHARED_RESOURCES: OnceLock<SharedResources> = OnceLock::new();
 pub struct SharedResources {
     /// Root of the persistent cache: `target/boxlite-test/`.
     dir: PathBuf,
-    /// Warm home directory in `/tmp/` (short paths for Unix sockets).
-    warm_home: PathBuf,
 }
 
 impl SharedResources {
@@ -70,16 +78,14 @@ impl SharedResources {
     /// - `home/rootfs → target/boxlite-test/rootfs/` (symlink, read-only)
     /// - `home/tmp → target/boxlite-test/tmp/<unique>/` (symlink, per-test)
     /// - `home/db/boxlite.db` (copy, per-test writable)
-    pub fn link_into(&self, home_dir: &Path) {
-        // Symlink images, rootfs → cache (shared, read-only)
+    pub fn link_into(&self, home_dir: &Path) -> LinkedCache {
+        // Symlink images, rootfs → cache dir (shared, read-only)
         for name in ["images", "rootfs"] {
             let link = home_dir.join(name);
             if !link.exists() {
-                let target = self.warm_home.join(name);
+                let target = self.dir.join(name);
                 if target.exists() {
-                    let real_dir =
-                        std::fs::canonicalize(&target).unwrap_or_else(|_| target.clone());
-                    symlink_or_exists(&real_dir, &link, name);
+                    symlink_or_exists(&target, &link, name);
                 }
             }
         }
@@ -89,8 +95,7 @@ impl SharedResources {
         let cache_tmp = self.tmp_dir();
         std::fs::create_dir_all(&cache_tmp).unwrap_or_default();
         let per_test_tmp = tempfile::tempdir_in(&cache_tmp).expect("create per-test tmp dir");
-        let per_test_tmp_path = per_test_tmp.keep();
-        symlink_or_exists(&per_test_tmp_path, &home_dir.join("tmp"), "tmp");
+        symlink_or_exists(per_test_tmp.path(), &home_dir.join("tmp"), "tmp");
 
         // Copy DB from cache — each test gets its own writable copy.
         let cached_db = self.db_snapshot();
@@ -101,6 +106,10 @@ impl SharedResources {
                 eprintln!("[test] warn: failed to copy cached DB: {e}");
             }
         }
+
+        LinkedCache {
+            _per_test_tmp: per_test_tmp,
+        }
     }
 
     // ────────────────────────────────────────────────────────────────────────
@@ -109,21 +118,14 @@ impl SharedResources {
 
     fn init() -> Self {
         let dir = cache_dir();
-        let warm_home = PathBuf::from("/tmp/boxlite-test");
 
-        let resources = Self {
-            dir: dir.clone(),
-            warm_home: warm_home.clone(),
-        };
-
-        // Create directories
-        resources.ensure_dirs(&warm_home);
-
-        // Symlink warm_home/{images,rootfs,tmp} → cache
-        for name in ["images", "rootfs", "tmp"] {
-            let target = dir.join(name);
-            symlink_or_exists(&target, &warm_home.join(name), name);
+        // Create persistent cache directories
+        for subdir in ["images", "rootfs", "tmp"] {
+            std::fs::create_dir_all(dir.join(subdir))
+                .unwrap_or_else(|e| panic!("create cache/{subdir}: {e}"));
         }
+
+        let resources = Self { dir: dir.clone() };
 
         // Fast path: cache already warm
         if resources.is_warm() {
@@ -140,21 +142,21 @@ impl SharedResources {
             return resources;
         }
 
+        // Ephemeral short-path home for warm-up runtime (macOS 104-char socket limit).
+        // Symlinks {images,rootfs,tmp} → target/boxlite-test/ so data persists.
+        let warm_home = TempDir::new_in("/tmp").expect("create warm home");
+        for name in ["images", "rootfs", "tmp"] {
+            symlink_or_exists(&dir.join(name), &warm_home.path().join(name), name);
+        }
+
         // Pull images and warm rootfs on a dedicated thread.
         // #[tokio::test] already has a Tokio runtime; creating another inside
         // the same thread panics ("Cannot start a runtime from within a runtime").
-        resources.warm_on_thread(&warm_home);
-        resources.snapshot_db(&warm_home);
+        resources.warm_on_thread(warm_home.path());
+        resources.snapshot_db(warm_home.path());
+        // warm_home dropped here — cleaned up automatically
 
         resources
-    }
-
-    fn ensure_dirs(&self, warm_home: &Path) {
-        std::fs::create_dir_all(warm_home).expect("create /tmp/boxlite-test");
-        for subdir in ["images", "rootfs", "tmp"] {
-            std::fs::create_dir_all(self.dir.join(subdir))
-                .unwrap_or_else(|e| panic!("create cache/{subdir}: {e}"));
-        }
     }
 
     fn is_warm(&self) -> bool {
@@ -278,7 +280,6 @@ mod tests {
         // Test path construction without triggering full init
         let resources = SharedResources {
             dir: PathBuf::from("/test/cache"),
-            warm_home: PathBuf::from("/tmp/boxlite-test"),
         };
         assert_eq!(resources.images_dir(), PathBuf::from("/test/cache/images"));
         assert_eq!(resources.rootfs_dir(), PathBuf::from("/test/cache/rootfs"));
@@ -286,6 +287,67 @@ mod tests {
         assert_eq!(
             resources.db_snapshot(),
             PathBuf::from("/test/cache/db/boxlite.db")
+        );
+    }
+
+    #[test]
+    fn linked_cache_cleans_per_test_tmp_on_drop() {
+        let base = tempfile::tempdir().expect("create base temp dir");
+        let cache_dir = base.path().join("cache");
+        for sub in ["images", "rootfs", "tmp"] {
+            std::fs::create_dir_all(cache_dir.join(sub)).unwrap();
+        }
+
+        let resources = SharedResources {
+            dir: cache_dir.clone(),
+        };
+
+        // Create a per-test home and link into it
+        let home = tempfile::tempdir().expect("create home temp dir");
+        let linked = resources.link_into(home.path());
+
+        // The per-test tmp dir should exist under cache/tmp/
+        let tmp_entries: Vec<_> = std::fs::read_dir(cache_dir.join("tmp"))
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .collect();
+        assert_eq!(tmp_entries.len(), 1, "should have one per-test tmp dir");
+        let per_test_tmp_path = tmp_entries[0].path();
+        assert!(per_test_tmp_path.exists());
+
+        // Drop the LinkedCache — per-test tmp should be cleaned up
+        drop(linked);
+        assert!(
+            !per_test_tmp_path.exists(),
+            "per-test tmp dir should be removed after LinkedCache drop"
+        );
+    }
+
+    #[test]
+    fn link_into_creates_tmp_symlink() {
+        let base = tempfile::tempdir().expect("create base temp dir");
+        let cache_dir = base.path().join("cache");
+        for sub in ["images", "rootfs", "tmp"] {
+            std::fs::create_dir_all(cache_dir.join(sub)).unwrap();
+        }
+
+        let resources = SharedResources { dir: cache_dir };
+
+        let home = tempfile::tempdir().expect("create home temp dir");
+        let _linked = resources.link_into(home.path());
+
+        let tmp_link = home.path().join("tmp");
+        assert!(
+            tmp_link
+                .symlink_metadata()
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "home/tmp should be a symlink"
+        );
+        assert!(
+            tmp_link.exists(),
+            "symlink target should exist while LinkedCache is alive"
         );
     }
 }

--- a/boxlite-test-utils/src/home.rs
+++ b/boxlite-test-utils/src/home.rs
@@ -18,7 +18,7 @@
 use std::path::PathBuf;
 use tempfile::TempDir;
 
-use crate::cache::SharedResources;
+use crate::cache::{LinkedCache, SharedResources};
 
 /// Per-test home directory with shared cache linked in.
 ///
@@ -29,6 +29,9 @@ pub struct PerTestBoxHome {
     /// Path to this test's home directory.
     pub path: PathBuf,
     _temp: TempDir,
+    /// Cleanup handle for per-test cache resources (tmp dir under `target/boxlite-test/tmp/`).
+    /// `None` for isolated homes that don't use shared cache.
+    _cache: Option<LinkedCache>,
 }
 
 impl Default for PerTestBoxHome {
@@ -46,8 +49,12 @@ impl PerTestBoxHome {
         let cache = SharedResources::global();
         let temp = TempDir::new_in("/tmp").expect("create temp dir");
         let path = temp.path().to_path_buf();
-        cache.link_into(&path);
-        Self { path, _temp: temp }
+        let linked = cache.link_into(&path);
+        Self {
+            path,
+            _temp: temp,
+            _cache: Some(linked),
+        }
     }
 
     /// Create a per-test home without warm cache.
@@ -57,7 +64,11 @@ impl PerTestBoxHome {
     pub fn isolated() -> Self {
         let temp = TempDir::new_in("/tmp").expect("create temp dir");
         let path = temp.path().to_path_buf();
-        Self { path, _temp: temp }
+        Self {
+            path,
+            _temp: temp,
+            _cache: None,
+        }
     }
 
     /// Create a per-test home under a specific base directory.
@@ -67,15 +78,23 @@ impl PerTestBoxHome {
         let cache = SharedResources::global();
         let temp = TempDir::new_in(base).expect("create temp dir");
         let path = temp.path().to_path_buf();
-        cache.link_into(&path);
-        Self { path, _temp: temp }
+        let linked = cache.link_into(&path);
+        Self {
+            path,
+            _temp: temp,
+            _cache: Some(linked),
+        }
     }
 
     /// Create an isolated home under a specific base directory.
     pub fn isolated_in(base: &str) -> Self {
         let temp = TempDir::new_in(base).expect("create temp dir");
         let path = temp.path().to_path_buf();
-        Self { path, _temp: temp }
+        Self {
+            path,
+            _temp: temp,
+            _cache: None,
+        }
     }
 }
 
@@ -104,5 +123,15 @@ mod tests {
         }
         // After drop, temp dir should be cleaned up
         assert!(!path.exists(), "temp dir should be cleaned up after drop");
+    }
+
+    #[test]
+    fn isolated_home_has_no_tmp_symlink() {
+        let home = PerTestBoxHome::isolated();
+        let tmp_link = home.path.join("tmp");
+        assert!(
+            !tmp_link.exists(),
+            "isolated home should not have a tmp symlink"
+        );
     }
 }

--- a/boxlite/tests/health_check.rs
+++ b/boxlite/tests/health_check.rs
@@ -6,66 +6,37 @@
 //! 1. Build the runtime: `make runtime-debug`
 //! 2. Run with: `cargo test -p boxlite --test health_check -- --test-threads=1`
 
-use boxlite::BoxliteRuntime;
+mod common;
+
 use boxlite::litebox::HealthState;
 use boxlite::runtime::advanced_options::{AdvancedBoxOptions, HealthCheckOptions};
-use boxlite::runtime::options::{BoxOptions, BoxliteOptions, RootfsSpec};
+use boxlite::runtime::options::{BoxOptions, RootfsSpec};
 use boxlite::runtime::types::BoxStatus;
+use common::box_test::BoxTestBase;
 use std::process::Command;
 use std::time::Duration;
-use tempfile::TempDir;
 use tokio::time::sleep;
 
-// ============================================================================
-// TEST FIXTURES
-// ============================================================================
-
-/// Test context with isolated runtime and automatic cleanup.
-struct TestContext {
-    runtime: BoxliteRuntime,
-    _temp_dir: TempDir,
-}
-
-impl TestContext {
-    fn new() -> Self {
-        let temp_dir = TempDir::new().expect("Failed to create temp dir");
-        let options = BoxliteOptions {
-            home_dir: temp_dir.path().to_path_buf(),
-            image_registries: vec!["docker.m.daocloud.io".into()],
-        };
-        let runtime = BoxliteRuntime::new(options).expect("Failed to create runtime");
-        Self {
-            runtime,
-            _temp_dir: temp_dir,
-        }
-    }
-
-    /// Create a box with health check enabled
-    async fn create_box_with_health_check(
-        &self,
-        interval: Duration,
-        timeout: Duration,
-        retries: u32,
-        start_period: Duration,
-    ) -> boxlite::LiteBox {
-        let options = BoxOptions {
-            rootfs: RootfsSpec::Image("alpine:latest".into()),
-            advanced: AdvancedBoxOptions {
-                health_check: Some(HealthCheckOptions {
-                    interval,
-                    timeout,
-                    retries,
-                    start_period,
-                }),
-                ..Default::default()
-            },
-            auto_remove: false,
+/// Build `BoxOptions` with health check enabled.
+fn health_check_opts(
+    interval: Duration,
+    timeout: Duration,
+    retries: u32,
+    start_period: Duration,
+) -> BoxOptions {
+    BoxOptions {
+        rootfs: RootfsSpec::Image("alpine:latest".into()),
+        advanced: AdvancedBoxOptions {
+            health_check: Some(HealthCheckOptions {
+                interval,
+                timeout,
+                retries,
+                start_period,
+            }),
             ..Default::default()
-        };
-        self.runtime
-            .create(options, None)
-            .await
-            .expect("Failed to create box with health check")
+        },
+        auto_remove: false,
+        ..Default::default()
     }
 }
 
@@ -75,24 +46,21 @@ impl TestContext {
 
 #[tokio::test]
 async fn health_check_transitions_to_healthy_after_startup() {
-    let ctx = TestContext::new();
-
-    let handle = ctx
-        .create_box_with_health_check(
-            Duration::from_secs(2),
-            Duration::from_secs(1),
-            2,
-            Duration::from_secs(1),
-        )
-        .await;
+    let t = BoxTestBase::with_options(health_check_opts(
+        Duration::from_secs(2),
+        Duration::from_secs(1),
+        2,
+        Duration::from_secs(1),
+    ))
+    .await;
 
     // Start the box
-    handle.start().await.expect("Failed to start box");
+    t.bx.start().await.expect("Failed to start box");
 
     // Initially in Starting state during start_period
-    let info = ctx
+    let info = t
         .runtime
-        .get_info(handle.id().as_str())
+        .get_info(t.bx.id().as_str())
         .await
         .unwrap()
         .unwrap();
@@ -102,9 +70,9 @@ async fn health_check_transitions_to_healthy_after_startup() {
     sleep(Duration::from_secs(4)).await;
 
     // Should transition to Healthy after successful ping
-    let info = ctx
+    let info = t
         .runtime
-        .get_info(handle.id().as_str())
+        .get_info(t.bx.id().as_str())
         .await
         .unwrap()
         .unwrap();
@@ -115,43 +83,28 @@ async fn health_check_transitions_to_healthy_after_startup() {
         info.health_status.state
     );
     assert_eq!(info.health_status.failures, 0);
-
-    // Cleanup
-    handle.stop().await.unwrap();
-    ctx.runtime
-        .remove(handle.id().as_str(), false)
-        .await
-        .unwrap();
 }
 
 #[tokio::test]
 async fn health_check_becomes_unhealthy_when_shim_killed() {
-    let ctx = TestContext::new();
+    let t = BoxTestBase::with_options(health_check_opts(
+        Duration::from_secs(2),
+        Duration::from_secs(1),
+        2,
+        Duration::from_secs(1),
+    ))
+    .await;
 
-    let handle = ctx
-        .create_box_with_health_check(
-            Duration::from_secs(2),
-            Duration::from_secs(1),
-            2,
-            Duration::from_secs(1),
-        )
-        .await;
-
-    let box_id = handle.id().clone();
+    let box_id = t.bx.id().clone();
 
     // Start the box
-    handle.start().await.expect("Failed to start box");
+    t.bx.start().await.expect("Failed to start box");
 
     // Wait for health check to become healthy
     sleep(Duration::from_secs(4)).await;
 
     // Verify initial healthy state
-    let info = ctx
-        .runtime
-        .get_info(box_id.as_str())
-        .await
-        .unwrap()
-        .unwrap();
+    let info = t.runtime.get_info(box_id.as_str()).await.unwrap().unwrap();
     assert_eq!(info.health_status.state, HealthState::Healthy);
 
     // Find and kill the shim process using BoxInfo
@@ -168,12 +121,7 @@ async fn health_check_becomes_unhealthy_when_shim_killed() {
     sleep(Duration::from_secs(5)).await;
 
     // Box should be stopped
-    let info = ctx
-        .runtime
-        .get_info(box_id.as_str())
-        .await
-        .unwrap()
-        .unwrap();
+    let info = t.runtime.get_info(box_id.as_str()).await.unwrap().unwrap();
     assert_eq!(
         info.status,
         BoxStatus::Stopped,
@@ -181,21 +129,16 @@ async fn health_check_becomes_unhealthy_when_shim_killed() {
         info.status
     );
 
-    // Health status should be cleared or show unhealthy state
-    // (depending on implementation - health check task stops when box stops)
+    // Health status should indicate failures or unhealthy state
     let health_status = info.health_status;
     println!(
         "Health status after shim killed: state={:?}, failures={}",
         health_status.state, health_status.failures
     );
-    // Health status should indicate failures or unhealthy state
     assert!(
         health_status.state == HealthState::Unhealthy || health_status.failures > 0,
         "Expected unhealthy state or failures, got state={:?}, failures={}",
         health_status.state,
         health_status.failures
     );
-
-    // Cleanup
-    ctx.runtime.remove(box_id.as_str(), false).await.unwrap();
 }


### PR DESCRIPTION
## Summary

- Split `BoxTestBase::with_options()` to return a created-but-not-started box, so tests can observe pre-start state (e.g. `HealthState::Starting`). `new()` still returns a running box.
- Rewrites `health_check.rs` to use `BoxTestBase` instead of a hand-rolled `TestContext`, eliminating manual setup and explicit cleanup.
- Fixes per-test tmp directory leaks: replaces persistent `/tmp/boxlite-test` warm home with ephemeral `TempDir`, introduces `LinkedCache` RAII handle for automatic cleanup.

## Test plan

- [x] `cargo clippy -p boxlite-test-utils --tests -- -D warnings` — clean
- [x] `cargo clippy -p boxlite --tests -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo test -p boxlite-test-utils` — 39/39 passed
- [x] Integration tests via pre-push hook — both health_check tests passed