### PR TITLE
fix(build): enable musl target compatibility for boxlite-shim

### DIFF
--- a/boxlite/deps/libgvproxy-sys/build.rs
+++ b/boxlite/deps/libgvproxy-sys/build.rs
@@ -26,6 +26,17 @@ fn build_gvproxy(source_dir: &Path, output_path: &Path) {
     let mut build_cmd = Command::new("go");
     build_cmd.args(["build", "-buildmode=c-archive"]);
 
+    // When cross-compiling for musl, tell CGO to use the musl C compiler.
+    // Without this, Go uses the system's gcc (glibc), producing objects that
+    // reference glibc-specific symbols (__fprintf_chk, etc.) which musl lacks.
+    let target = env::var("TARGET").unwrap_or_default();
+    if target.contains("musl") {
+        let arch = target.split('-').next().unwrap_or("x86_64");
+        let musl_cc = format!("{}-linux-musl-gcc", arch);
+        build_cmd.env("CC", &musl_cc);
+        build_cmd.env("CGO_ENABLED", "1");
+    }
+
     build_cmd.args([
         "-o",
         output_path.to_str().expect("Invalid output path"),

--- a/boxlite/deps/libkrun-sys/build.rs
+++ b/boxlite/deps/libkrun-sys/build.rs
@@ -400,6 +400,12 @@ impl LibBuilder {
             println!("cargo:rustc-link-lib=framework=Hypervisor");
         }
 
+        // libkrun.a is a Rust staticlib that bundles its own std. When linked into
+        // another Rust binary, std symbols (rust_eh_personality, etc.) are duplicated.
+        // Tell the linker to use the first definition.
+        #[cfg(target_os = "linux")]
+        println!("cargo:rustc-link-arg=-Wl,--allow-multiple-definition");
+
         // Expose library directories to downstream crates (used by boxlite/build.rs)
         // Convention: {LIBNAME}_BOXLITE_DEP=<path> for auto-discovery
         // Note: LIBKRUN dir now contains .a (not bundled at runtime), but the path
@@ -790,6 +796,73 @@ impl MacToolchain {
     }
 }
 
+// ── Musl libc fixup ──────────────────────────────────────────────────────
+
+/// Enables musl `statx` support in the libc crate when building for musl targets.
+///
+/// Two things are needed for `libc::statx` on musl:
+///
+/// 1. **libc >= 0.2.175** — older versions (e.g., 0.2.172 pinned in the submodule)
+///    only define `statx` for `target_env = "gnu"`. Newer versions add a
+///    `musl_v1_2_3` cfg gate that also enables it for musl.
+///
+/// 2. **`RUST_LIBC_UNSTABLE_MUSL_V1_2_3=1`** — the libc crate's build.rs reads
+///    this env var to activate the `musl_v1_2_3` cfg flag, which in turn exposes
+///    `statx`, `STATX_BASIC_STATS`, and `STATX_MNT_ID` for musl targets.
+///
+/// We update the submodule's Cargo.lock at build time (not committed) and set the
+/// env var process-wide so the nested `cargo rustc` inherits it.
+#[cfg(target_os = "linux")]
+fn enable_musl_statx_support(libkrun_src: &Path) {
+    let target = env::var("TARGET").unwrap_or_default();
+    if !target.contains("musl") {
+        return;
+    }
+
+    // Step 1: Ensure libc is recent enough to have the musl_v1_2_3 cfg gate
+    let cargo_lock = libkrun_src.join("Cargo.lock");
+    let content = fs::read_to_string(&cargo_lock).unwrap_or_default();
+
+    if !is_libc_version_sufficient(&content, 175) {
+        println!("cargo:warning=Updating libc in vendored libkrun for musl statx support...");
+        run_command(
+            Command::new("cargo")
+                .args(["update", "-p", "libc"])
+                .current_dir(libkrun_src)
+                .stdout(Stdio::inherit())
+                .stderr(Stdio::inherit()),
+            "cargo update -p libc (musl statx fix)",
+        );
+    }
+
+    // Step 2: Enable the musl_v1_2_3 cfg flag via env var
+    println!("cargo:warning=Enabling musl statx support (RUST_LIBC_UNSTABLE_MUSL_V1_2_3=1)");
+    env::set_var("RUST_LIBC_UNSTABLE_MUSL_V1_2_3", "1");
+}
+
+/// Checks if libc version in Cargo.lock content has patch version >= min_patch.
+/// Expects format: name = "libc"\nversion = "0.2.XXX"
+#[cfg(target_os = "linux")]
+fn is_libc_version_sufficient(lock_content: &str, min_patch: u32) -> bool {
+    let Some(pos) = lock_content.find("name = \"libc\"") else {
+        return false;
+    };
+    let rest = &lock_content[pos..];
+    for line in rest.lines().skip(1).take(1) {
+        if let Some(ver) = line
+            .strip_prefix("version = \"")
+            .and_then(|s| s.strip_suffix('"'))
+        {
+            if let Some(patch_str) = ver.strip_prefix("0.2.") {
+                if let Ok(patch) = patch_str.parse::<u32>() {
+                    return patch >= min_patch;
+                }
+            }
+        }
+    }
+    false
+}
+
 // ── Platform build orchestration ─────────────────────────────────────────────
 
 /// macOS: Build libkrunfw (dylib, dlopen'd at runtime) and libkrun (static archive)
@@ -873,6 +946,9 @@ fn build() {
     }
 
     let libkrun_src = manifest_dir.join("vendor/libkrun");
+
+    // Enable statx support in the libc crate for musl targets
+    enable_musl_statx_support(&libkrun_src);
 
     // Build libkrun (init binary → static library → linking)
     LibBuilder::build(

--- a/boxlite/src/jailer/common/rlimit.rs
+++ b/boxlite/src/jailer/common/rlimit.rs
@@ -10,10 +10,11 @@ use crate::runtime::advanced_options::ResourceLimits;
 use std::io;
 
 /// Resource type alias for cross-platform compatibility.
-/// On Linux glibc, RLIMIT_* are u32; on macOS they're i32.
-#[cfg(target_os = "linux")]
+/// On Linux glibc, RLIMIT_* use `__rlimit_resource_t` (c_uint).
+/// On Linux musl and macOS, they use c_int.
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
 type RlimitResource = libc::__rlimit_resource_t;
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(all(target_os = "linux", target_env = "gnu")))]
 type RlimitResource = libc::c_int;
 
 /// Get current value of a resource limit.


### PR DESCRIPTION
## Summary

- Fix `make shim` build failures on Linux musl (`x86_64-unknown-linux-musl`) by addressing four compatibility issues:
  - **libc::statx** — update libc at build time and set `RUST_LIBC_UNSTABLE_MUSL_V1_2_3=1` to enable musl statx support
  - **libc::__rlimit_resource_t** — use `c_int` for musl (glibc-specific type)
  - **Go CGO** — set `CC` to musl-gcc to avoid glibc-specific `__fprintf_chk` references
  - **rust_eh_personality duplicate** — add `--allow-multiple-definition` linker flag for all Linux targets (libkrun.a staticlib bundles its own std)

## Test plan

- [x] `make shim` succeeds on Linux musl (tested on boxlite-dev GCE instance)
- [x] Binary verified: static-pie ELF x86-64, 24MB
- [ ] CI passes on glibc targets