### PR TITLE
fix(build): switch shim from musl to glibc static linking

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,18 +1,7 @@
-# libkrun.a (Rust staticlib) bundles its own std, duplicating symbols
-# (rust_eh_personality, etc.) with the outer binary's std.
-# --allow-multiple-definition tells the linker to use the first definition.
-# This applies to all Linux targets because any binary linking libkrun-sys
-# (boxlite-shim, boxlite-cli, tests) hits this issue.
-[target.x86_64-unknown-linux-gnu]
-rustflags = ["-C", "link-arg=-Wl,--allow-multiple-definition"]
-
-[target.aarch64-unknown-linux-gnu]
-rustflags = ["-C", "link-arg=-Wl,--allow-multiple-definition"]
-
 [target.aarch64-unknown-linux-musl]
 linker = "aarch64-linux-musl-gcc"
-rustflags = ["-C", "target-feature=+crt-static", "-C", "link-arg=-Wl,-z,stack-size=2097152", "-C", "link-arg=-Wl,--allow-multiple-definition"]
+rustflags = ["-C", "target-feature=+crt-static", "-C", "link-arg=-Wl,-z,stack-size=2097152"]
 
 [target.x86_64-unknown-linux-musl]
 linker = "x86_64-linux-musl-gcc"
-rustflags = ["-C", "target-feature=+crt-static", "-C", "link-arg=-Wl,-z,stack-size=2097152", "-C", "link-arg=-Wl,--allow-multiple-definition"]
+rustflags = ["-C", "target-feature=+crt-static", "-C", "link-arg=-Wl,-z,stack-size=2097152"]

--- a/.github/workflows/build-node.yml
+++ b/.github/workflows/build-node.yml
@@ -70,25 +70,22 @@ jobs:
           shared-key: "boxlite"
           save-if: false
 
-      # Build guest and shim on host BEFORE manylinux container because:
+      # Build guest on host BEFORE manylinux container because:
       # - manylinux (AlmaLinux/RHEL) doesn't have musl packages in repos
       # - Building musl-cross-make from source takes ~15 minutes
       # - Ubuntu host has musl-tools via apt (~30 seconds)
-      # - Guest and shim are static musl binaries, don't need manylinux glibc compatibility
-      # - Both binaries are embedded via include_bytes! (embedded-runtime feature)
-      - name: Build guest and shim binaries (Linux only)
+      # - Guest is static musl binary, doesn't need manylinux glibc compatibility
+      # - Shim/libkrun must be built IN container (needs glibc 2.28 for manylinux)
+      - name: Build guest binary (Linux only)
         if: runner.os == 'Linux'
         run: |
-          make setup guest shim
+          make setup guest
 
-          # Cache binaries for container (cibuildwheel's tar excludes target/)
+          # Cache only the final binary (11MB), not entire target dir (2.3GB)
+          # Guest is not rebuilt in container (SKIP_GUEST_BUILD=1), so no incremental compilation needed
           GUEST_TARGET=$(scripts/util.sh --target)
           mkdir -p ".cache/$GUEST_TARGET/release"
           cp "target/$GUEST_TARGET/release/boxlite-guest" ".cache/$GUEST_TARGET/release/"
-
-          SHIM_ARCH=$(uname -m)
-          mkdir -p ".cache/${SHIM_ARCH}-unknown-linux-musl/release"
-          cp "target/${SHIM_ARCH}-unknown-linux-musl/release/boxlite-shim" ".cache/${SHIM_ARCH}-unknown-linux-musl/release/"
 
           # Clean up to save disk space (keep target/ dir for rust-cache post-step)
           rm -rf target ~/.rustup ~/.cargo
@@ -122,17 +119,9 @@ jobs:
             cp -a ".cache/$GUEST_TARGET" "target/$GUEST_TARGET"
           fi
 
-          SHIM_ARCH=$(uname -m)
-          if [ -d ".cache/${SHIM_ARCH}-unknown-linux-musl" ]; then
-            echo "Restoring shim from .cache/${SHIM_ARCH}-unknown-linux-musl"
-            mkdir -p target
-            cp -a ".cache/${SHIM_ARCH}-unknown-linux-musl" "target/${SHIM_ARCH}-unknown-linux-musl"
-          fi
-
           export SKIP_GUEST_BUILD=1
-          export SKIP_SHIM_BUILD=1
           export PATH="$CARGO_HOME/bin:$PATH"
-          make setup shim guest
+          make setup runtime
 
           export PATH="$HOME/.cargo/bin:$PATH"
           cd sdks/node
@@ -152,7 +141,7 @@ jobs:
       - name: Build Node.js package (macOS)
         if: runner.os == 'macOS'
         run: |
-          make setup shim guest
+          make setup runtime
 
           # Build Node.js artifacts (no pack - CI uploads raw artifacts)
           cd sdks/node

--- a/.github/workflows/build-runtime.yml
+++ b/.github/workflows/build-runtime.yml
@@ -64,24 +64,22 @@ jobs:
           shared-key: "boxlite"
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
-      # Build guest and shim on host BEFORE manylinux container because:
+      # Build guest on host BEFORE manylinux container because:
       # - manylinux (AlmaLinux/RHEL) doesn't have musl packages in repos
       # - Building musl-cross-make from source takes ~15 minutes
       # - Ubuntu host has musl-tools via apt (~30 seconds)
-      # - Guest and shim are static musl binaries, don't need manylinux glibc compatibility
-      - name: Build guest and shim binaries (Linux only)
+      # - Guest is static musl binary, doesn't need manylinux glibc compatibility
+      # - Shim/libkrun must be built IN container (needs glibc 2.28 for manylinux)
+      - name: Build guest binary (Linux only)
         if: runner.os == 'Linux'
         run: |
-          make setup guest shim
+          make setup guest
 
-          # Cache binaries for container (cibuildwheel's tar excludes target/)
+          # Cache only the final binary (11MB), not entire target dir (2.3GB)
+          # Guest is not rebuilt in container (SKIP_GUEST_BUILD=1), so no incremental compilation needed
           GUEST_TARGET=$(scripts/util.sh --target)
           mkdir -p ".cache/$GUEST_TARGET/release"
           cp "target/$GUEST_TARGET/release/boxlite-guest" ".cache/$GUEST_TARGET/release/"
-
-          SHIM_ARCH=$(uname -m)
-          mkdir -p ".cache/${SHIM_ARCH}-unknown-linux-musl/release"
-          cp "target/${SHIM_ARCH}-unknown-linux-musl/release/boxlite-shim" ".cache/${SHIM_ARCH}-unknown-linux-musl/release/"
 
           # Clean up to save disk space (keep target/ dir for rust-cache post-step)
           rm -rf target ~/.rustup ~/.cargo
@@ -115,15 +113,7 @@ jobs:
             cp -a ".cache/$GUEST_TARGET" "target/$GUEST_TARGET"
           fi
 
-          SHIM_ARCH=$(uname -m)
-          if [ -d ".cache/${SHIM_ARCH}-unknown-linux-musl" ]; then
-            echo "Restoring shim from .cache/${SHIM_ARCH}-unknown-linux-musl"
-            mkdir -p target
-            cp -a ".cache/${SHIM_ARCH}-unknown-linux-musl" "target/${SHIM_ARCH}-unknown-linux-musl"
-          fi
-
           export SKIP_GUEST_BUILD=1
-          export SKIP_SHIM_BUILD=1
           export PATH="$CARGO_HOME/bin:$PATH"
           make setup runtime
           CONTAINER_SCRIPT

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -39,25 +39,22 @@ jobs:
           shared-key: "boxlite"
           save-if: false  # Workflow deletes cache after guest build
 
-      # Build guest and shim on host BEFORE cibuildwheel container because:
+      # Build guest on host BEFORE cibuildwheel container because:
       # - manylinux (AlmaLinux/RHEL) doesn't have musl packages in repos
       # - Building musl-cross-make from source takes ~15 minutes
       # - Ubuntu host has musl-tools via apt (~30 seconds)
-      # - Guest and shim are static musl binaries, don't need manylinux glibc compatibility
-      # - Both binaries are embedded via include_bytes! (embedded-runtime feature)
-      - name: Build guest and shim binaries (Linux only)
+      # - Guest is static musl binary, doesn't need manylinux glibc compatibility
+      # - Shim must be built IN container (needs glibc 2.28 for manylinux)
+      - name: Build guest binary (Linux only)
         if: runner.os == 'Linux'
         run: |
-          make setup guest shim
+          make setup guest
 
-          # Cache binaries for container (cibuildwheel's tar excludes target/)
+          # Cache only the final binary (11MB), not entire target dir (2.3GB)
+          # Guest is not rebuilt in container (SKIP_GUEST_BUILD=1), so no incremental compilation needed
           GUEST_TARGET=$(scripts/util.sh --target)
           mkdir -p ".cache/$GUEST_TARGET/release"
           cp "target/$GUEST_TARGET/release/boxlite-guest" ".cache/$GUEST_TARGET/release/"
-
-          SHIM_ARCH=$(uname -m)
-          mkdir -p ".cache/${SHIM_ARCH}-unknown-linux-musl/release"
-          cp "target/${SHIM_ARCH}-unknown-linux-musl/release/boxlite-shim" ".cache/${SHIM_ARCH}-unknown-linux-musl/release/"
 
           # Clean up to save disk space (keep target/ dir for rust-cache post-step)
           rm -rf target ~/.rustup ~/.cargo

--- a/boxlite/Cargo.toml
+++ b/boxlite/Cargo.toml
@@ -26,6 +26,7 @@ path = "src/bin/shim/main.rs"
 default = ["gvproxy-backend", "embedded-runtime"]
 libslirp-backend = []  # Uses external libslirp-helper binary, no Rust crate needed
 gvproxy-backend = ["dep:libgvproxy-sys"]   # Uses libgvproxy CGO shared library, links via FFI
+link-krun = ["libkrun-sys/link-static"]    # Statically link libkrun.a (only for boxlite-shim)
 rest = ["dep:reqwest", "dep:urlencoding"]  # REST API client backend
 embedded-runtime = []  # Embed runtime binaries via include_bytes! for self-contained SDKs
 

--- a/boxlite/build.rs
+++ b/boxlite/build.rs
@@ -708,25 +708,25 @@ impl EmbeddedManifest {
     /// Find pre-built boxlite-shim binary for the given build profile.
     ///
     /// Search order:
-    /// 1. macOS: `target/{profile}/boxlite-shim`
-    /// 2. Linux: `target/{arch}-unknown-linux-musl/{profile}/boxlite-shim`
+    /// 1. Native: `target/{profile}/boxlite-shim` (macOS)
+    /// 2. Linux gnu: `target/{arch}-unknown-linux-gnu/{profile}/boxlite-shim` (static glibc)
     fn find_prebuilt_shim(workspace_root: &Path, profile: &str) -> Option<PathBuf> {
         let target_dir = workspace_root.join("target");
 
-        // macOS: target/{profile}/boxlite-shim
+        // Native path (macOS)
         let native = target_dir.join(profile).join("boxlite-shim");
         if native.is_file() {
             return Some(native);
         }
 
-        // Linux musl: target/{arch}-unknown-linux-musl/{profile}/boxlite-shim
+        // Linux gnu (static glibc — Go c-archive is incompatible with musl TLS)
         for arch in ["x86_64", "aarch64"] {
-            let musl = target_dir
-                .join(format!("{}-unknown-linux-musl", arch))
+            let gnu = target_dir
+                .join(format!("{}-unknown-linux-gnu", arch))
                 .join(profile)
                 .join("boxlite-shim");
-            if musl.is_file() {
-                return Some(musl);
+            if gnu.is_file() {
+                return Some(gnu);
             }
         }
 

--- a/boxlite/deps/libgvproxy-sys/build.rs
+++ b/boxlite/deps/libgvproxy-sys/build.rs
@@ -26,17 +26,6 @@ fn build_gvproxy(source_dir: &Path, output_path: &Path) {
     let mut build_cmd = Command::new("go");
     build_cmd.args(["build", "-buildmode=c-archive"]);
 
-    // When cross-compiling for musl, tell CGO to use the musl C compiler.
-    // Without this, Go uses the system's gcc (glibc), producing objects that
-    // reference glibc-specific symbols (__fprintf_chk, etc.) which musl lacks.
-    let target = env::var("TARGET").unwrap_or_default();
-    if target.contains("musl") {
-        let arch = target.split('-').next().unwrap_or("x86_64");
-        let musl_cc = format!("{}-linux-musl-gcc", arch);
-        build_cmd.env("CC", &musl_cc);
-        build_cmd.env("CGO_ENABLED", "1");
-    }
-
     build_cmd.args([
         "-o",
         output_path.to_str().expect("Invalid output path"),

--- a/boxlite/deps/libkrun-sys/Cargo.toml
+++ b/boxlite/deps/libkrun-sys/Cargo.toml
@@ -19,3 +19,4 @@ libc = "0.2"
 
 [features]
 default = []
+link-static = []  # Emit rustc-link-lib to statically link libkrun.a into the binary

--- a/boxlite/deps/libkrun-sys/build.rs
+++ b/boxlite/deps/libkrun-sys/build.rs
@@ -389,24 +389,30 @@ impl LibBuilder {
     ///
     /// Note: libkrunfw is NOT linked here — it's dlopened by libkrun at runtime.
     /// We only expose the library directory so downstream crates can bundle it.
+    ///
+    /// Link directives (`rustc-link-lib`, `rustc-link-search`) are only emitted
+    /// when the `link-static` feature is enabled. This prevents downstream crates
+    /// that only need metadata (e.g., boxlite library for bundling) from linking
+    /// libkrun.a and hitting duplicate std symbol errors. Only boxlite-shim
+    /// (which actually calls libkrun functions) enables `link-static`.
     fn configure_linking(libkrun_dir: &Path, libkrunfw_dir: &Path) {
-        println!("cargo:rustc-link-search=native={}", libkrun_dir.display());
-        println!("cargo:rustc-link-lib=static=krun");
-
-        // Transitive dependencies from libkrun (now statically linked, these were
-        // previously resolved by the dynamic linker inside libkrun.so/dylib)
-        #[cfg(target_os = "macos")]
+        // Only emit link directives when the binary actually needs to link libkrun.a.
+        // libkrun.a is a Rust staticlib that bundles its own std — linking it into
+        // another Rust binary causes duplicate symbol errors without --allow-multiple-definition.
+        #[cfg(feature = "link-static")]
         {
-            println!("cargo:rustc-link-lib=framework=Hypervisor");
+            println!("cargo:rustc-link-search=native={}", libkrun_dir.display());
+            println!("cargo:rustc-link-lib=static=krun");
+
+            // Transitive dependencies from libkrun (now statically linked, these were
+            // previously resolved by the dynamic linker inside libkrun.so/dylib)
+            #[cfg(target_os = "macos")]
+            {
+                println!("cargo:rustc-link-lib=framework=Hypervisor");
+            }
         }
 
-        // libkrun.a is a Rust staticlib that bundles its own std. When linked into
-        // another Rust binary, std symbols (rust_eh_personality, etc.) are duplicated.
-        // Tell the linker to use the first definition.
-        #[cfg(target_os = "linux")]
-        println!("cargo:rustc-link-arg=-Wl,--allow-multiple-definition");
-
-        // Expose library directories to downstream crates (used by boxlite/build.rs)
+        // Always expose library directories to downstream crates (used by boxlite/build.rs)
         // Convention: {LIBNAME}_BOXLITE_DEP=<path> for auto-discovery
         // Note: LIBKRUN dir now contains .a (not bundled at runtime), but the path
         // is still exposed for consistency. Only LIBKRUNFW .so/.dylib gets bundled.
@@ -796,73 +802,6 @@ impl MacToolchain {
     }
 }
 
-// ── Musl libc fixup ──────────────────────────────────────────────────────
-
-/// Enables musl `statx` support in the libc crate when building for musl targets.
-///
-/// Two things are needed for `libc::statx` on musl:
-///
-/// 1. **libc >= 0.2.175** — older versions (e.g., 0.2.172 pinned in the submodule)
-///    only define `statx` for `target_env = "gnu"`. Newer versions add a
-///    `musl_v1_2_3` cfg gate that also enables it for musl.
-///
-/// 2. **`RUST_LIBC_UNSTABLE_MUSL_V1_2_3=1`** — the libc crate's build.rs reads
-///    this env var to activate the `musl_v1_2_3` cfg flag, which in turn exposes
-///    `statx`, `STATX_BASIC_STATS`, and `STATX_MNT_ID` for musl targets.
-///
-/// We update the submodule's Cargo.lock at build time (not committed) and set the
-/// env var process-wide so the nested `cargo rustc` inherits it.
-#[cfg(target_os = "linux")]
-fn enable_musl_statx_support(libkrun_src: &Path) {
-    let target = env::var("TARGET").unwrap_or_default();
-    if !target.contains("musl") {
-        return;
-    }
-
-    // Step 1: Ensure libc is recent enough to have the musl_v1_2_3 cfg gate
-    let cargo_lock = libkrun_src.join("Cargo.lock");
-    let content = fs::read_to_string(&cargo_lock).unwrap_or_default();
-
-    if !is_libc_version_sufficient(&content, 175) {
-        println!("cargo:warning=Updating libc in vendored libkrun for musl statx support...");
-        run_command(
-            Command::new("cargo")
-                .args(["update", "-p", "libc"])
-                .current_dir(libkrun_src)
-                .stdout(Stdio::inherit())
-                .stderr(Stdio::inherit()),
-            "cargo update -p libc (musl statx fix)",
-        );
-    }
-
-    // Step 2: Enable the musl_v1_2_3 cfg flag via env var
-    println!("cargo:warning=Enabling musl statx support (RUST_LIBC_UNSTABLE_MUSL_V1_2_3=1)");
-    env::set_var("RUST_LIBC_UNSTABLE_MUSL_V1_2_3", "1");
-}
-
-/// Checks if libc version in Cargo.lock content has patch version >= min_patch.
-/// Expects format: name = "libc"\nversion = "0.2.XXX"
-#[cfg(target_os = "linux")]
-fn is_libc_version_sufficient(lock_content: &str, min_patch: u32) -> bool {
-    let Some(pos) = lock_content.find("name = \"libc\"") else {
-        return false;
-    };
-    let rest = &lock_content[pos..];
-    for line in rest.lines().skip(1).take(1) {
-        if let Some(ver) = line
-            .strip_prefix("version = \"")
-            .and_then(|s| s.strip_suffix('"'))
-        {
-            if let Some(patch_str) = ver.strip_prefix("0.2.") {
-                if let Ok(patch) = patch_str.parse::<u32>() {
-                    return patch >= min_patch;
-                }
-            }
-        }
-    }
-    false
-}
-
 // ── Platform build orchestration ─────────────────────────────────────────────
 
 /// macOS: Build libkrunfw (dylib, dlopen'd at runtime) and libkrun (static archive)
@@ -947,9 +886,6 @@ fn build() {
 
     let libkrun_src = manifest_dir.join("vendor/libkrun");
 
-    // Enable statx support in the libc crate for musl targets
-    enable_musl_statx_support(&libkrun_src);
-
     // Build libkrun (init binary → static library → linking)
     LibBuilder::build(
         &libkrun_src,
@@ -978,6 +914,7 @@ fn main() {
     // Set BOXLITE_DEPS_STUB=1 to skip building and emit stub link directives
     if env::var("BOXLITE_DEPS_STUB").is_ok() {
         println!("cargo:warning=BOXLITE_DEPS_STUB mode: skipping libkrun build");
+        #[cfg(feature = "link-static")]
         println!("cargo:rustc-link-lib=static=krun");
         println!("cargo:LIBKRUN_BOXLITE_DEP=/nonexistent");
         println!("cargo:LIBKRUNFW_BOXLITE_DEP=/nonexistent");

--- a/boxlite/src/jailer/common/rlimit.rs
+++ b/boxlite/src/jailer/common/rlimit.rs
@@ -10,11 +10,10 @@ use crate::runtime::advanced_options::ResourceLimits;
 use std::io;
 
 /// Resource type alias for cross-platform compatibility.
-/// On Linux glibc, RLIMIT_* use `__rlimit_resource_t` (c_uint).
-/// On Linux musl and macOS, they use c_int.
-#[cfg(all(target_os = "linux", target_env = "gnu"))]
+/// On Linux glibc, RLIMIT_* are u32; on macOS they're i32.
+#[cfg(target_os = "linux")]
 type RlimitResource = libc::__rlimit_resource_t;
-#[cfg(not(all(target_os = "linux", target_env = "gnu")))]
+#[cfg(not(target_os = "linux"))]
 type RlimitResource = libc::c_int;
 
 /// Get current value of a resource limit.

--- a/boxlite/src/vmm/controller/spawn.rs
+++ b/boxlite/src/vmm/controller/spawn.rs
@@ -11,7 +11,6 @@ use crate::runtime::options::BoxOptions;
 use crate::util::configure_library_env;
 use crate::vmm::VmmKind;
 use boxlite_shared::errors::{BoxliteError, BoxliteResult};
-use libkrun_sys::krun_create_ctx;
 
 use super::watchdog;
 
@@ -154,8 +153,8 @@ impl<'a> ShimSpawner<'a> {
             cmd.env("TEMP", &tmp_dir);
         }
 
-        // Set library search paths for bundled dependencies
-        configure_library_env(cmd, krun_create_ctx as *const libc::c_void);
+        // Set library search paths for bundled dependencies (e.g., libkrunfw.so)
+        configure_library_env(cmd, std::ptr::null());
     }
 
     fn create_stderr_file(&self) -> BoxliteResult<std::fs::File> {

--- a/boxlite/src/vmm/engine.rs
+++ b/boxlite/src/vmm/engine.rs
@@ -64,6 +64,7 @@ pub struct VmmInstance {
 
 impl VmmInstance {
     /// Create a new VmmInstance from an engine-specific implementation.
+    #[allow(dead_code)] // Used by engine implementations (e.g., krun) behind feature gates
     pub(crate) fn new(inner: Box<dyn VmmInstanceImpl>) -> Self {
         Self { inner }
     }

--- a/boxlite/src/vmm/mod.rs
+++ b/boxlite/src/vmm/mod.rs
@@ -10,6 +10,7 @@ pub mod engine;
 pub mod exit_info;
 pub mod factory;
 pub mod host_check;
+#[cfg(feature = "link-krun")]
 pub mod krun;
 pub mod registry;
 

--- a/boxlite/src/vmm/registry.rs
+++ b/boxlite/src/vmm/registry.rs
@@ -79,6 +79,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[cfg(feature = "link-krun")]
     fn test_libkrun_registered() {
         // At minimum, libkrun should be registered
         assert!(is_registered(VmmKind::Libkrun));
@@ -100,6 +101,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "link-krun")]
     fn test_create_libkrun_engine() {
         let options = VmmConfig::default();
         let result = create_engine(VmmKind::Libkrun, options);

--- a/scripts/build/build-runtime.sh
+++ b/scripts/build/build-runtime.sh
@@ -145,26 +145,10 @@ build_shim() {
     if [ "$OS" = "linux" ]; then
         local arch
         arch=$(uname -m)
-        shim_path="$PROJECT_ROOT/target/${arch}-unknown-linux-musl/$PROFILE/boxlite-shim"
+        shim_path="$PROJECT_ROOT/target/${arch}-unknown-linux-gnu/$PROFILE/boxlite-shim"
     else
         shim_path="$PROJECT_ROOT/target/$PROFILE/boxlite-shim"
     fi
-
-    # Skip build if SKIP_SHIM_BUILD=1 and binary exists
-    # Used in CI when shim is pre-built on Ubuntu host
-    if [ "${SKIP_SHIM_BUILD:-0}" = "1" ]; then
-        if [ -f "$shim_path" ] && [ -x "$shim_path" ]; then
-            SHIM_BINARY="$shim_path"
-            print_success "Using pre-built: $shim_path (SKIP_SHIM_BUILD=1)"
-            return 0
-        else
-            print_error "SKIP_SHIM_BUILD=1 but shim binary not found at $shim_path"
-            exit 1
-        fi
-    fi
-
-    # Always build to ensure freshness (Cargo handles incremental compilation)
-    bash "$SCRIPT_BUILD_DIR/build-shim.sh" --profile "$PROFILE"
 
     if [ -f "$shim_path" ]; then
         SHIM_BINARY="$shim_path"

--- a/scripts/build/build-shim.sh
+++ b/scripts/build/build-shim.sh
@@ -9,7 +9,9 @@
 #   --profile PROFILE   Build profile: release or debug (default: release)
 #
 # Note: On macOS, the binary is automatically signed with hypervisor entitlements
-# Note: On Linux, the binary is built with musl for a fully static executable
+# Note: On Linux, the binary is statically linked using glibc (gnu target + crt-static).
+#       Go c-archive is incompatible with musl TLS, so we use glibc static linking instead.
+#       --target is required so RUSTFLAGS don't affect proc-macro compilation.
 
 set -e
 
@@ -71,12 +73,13 @@ parse_args "$@"
 OS=$(detect_os)
 print_header "🚀 Building boxlite-shim on $OS..."
 
-# Compute the Rust target triple and binary path for the current platform
+# Compute shim target and binary path
+# Linux needs --target to isolate RUSTFLAGS from proc-macro compilation
 compute_shim_target() {
     if [ "$OS" = "linux" ]; then
         local arch
         arch=$(uname -m)
-        SHIM_TARGET="${arch}-unknown-linux-musl"
+        SHIM_TARGET="${arch}-unknown-linux-gnu"
         SHIM_BINARY_PATH="$PROJECT_ROOT/target/$SHIM_TARGET/$PROFILE/boxlite-shim"
     else
         SHIM_TARGET=""
@@ -97,10 +100,15 @@ build_shim_binary() {
 
     # Shim doesn't use embedded-runtime (it IS the binary that gets embedded).
     # Disable it to avoid the chicken-and-egg: can't embed shim while building shim.
-    local features="--no-default-features --features gvproxy-backend"
+    # link-krun: statically link libkrun.a (only shim needs this, not boxlite-cli)
+    local features="--no-default-features --features gvproxy-backend,link-krun"
 
     if [ -n "$SHIM_TARGET" ]; then
-        echo "🎯 Target: $SHIM_TARGET (static musl binary)"
+        echo "🎯 Target: $SHIM_TARGET (static glibc binary)"
+        # Go c-archive crashes with musl TLS; use glibc + crt-static instead.
+        # relocation-model=static avoids static-pie which is incompatible with Go c-archive relocations.
+        # --target is required so these flags don't affect proc-macro compilation.
+        export RUSTFLAGS="-C target-feature=+crt-static -C relocation-model=static -C link-arg=-Wl,-z,stack-size=2097152 -C link-arg=-Wl,--allow-multiple-definition"
         cargo build $build_flag --bin boxlite-shim --target "$SHIM_TARGET" $features
     else
         cargo build $build_flag --bin boxlite-shim $features

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -61,20 +61,20 @@ skip = [
 ]
 
 
-# Build shim and guest binaries before building wheels (runs once per platform).
-# Runtime binaries are embedded via include_bytes! (embedded-runtime feature),
-# so no runtime directory assembly or copy is needed.
-#
+# Build BoxLite runtime before building wheels (runs once per platform)
 # Linux build strategy:
 # - Guest binary: Built on Ubuntu host BEFORE container (manylinux lacks musl packages)
-# - Shim binary: Built IN container (static musl, needs musl-tools)
-# - Libraries: Built IN container from source (libkrun, libkrunfw, etc.)
+# - Shim binary: Built IN container (needs glibc 2.28 for manylinux compatibility)
+# - Libraries: Built IN container (libkrun, libkrunfw from source)
 before-all = ["""
-    set -ex
+    set -ex  # Exit on error, print commands
 
+    # cibuildwheel runs from repository root
     BOXLITE_ROOT=$(pwd)
 
-    # Restore pre-built binaries if available (from Ubuntu host)
+    # Restore pre-built guest target directory if available (from Ubuntu host)
+    # This is needed because cibuildwheel's tar excludes target/ (.gitignore)
+    # We restore the full cache (not just binary) for cargo incremental compilation
     GUEST_TARGET=$(scripts/util.sh --target)
     if [ -d ".cache/$GUEST_TARGET" ]; then
         echo "Restoring guest cargo cache from .cache/$GUEST_TARGET"
@@ -82,20 +82,13 @@ before-all = ["""
         cp -a ".cache/$GUEST_TARGET" "target/$GUEST_TARGET"
     fi
 
-    SHIM_ARCH=$(uname -m)
-    if [ -d ".cache/${SHIM_ARCH}-unknown-linux-musl" ]; then
-        echo "Restoring shim cargo cache from .cache/${SHIM_ARCH}-unknown-linux-musl"
-        mkdir -p target
-        cp -a ".cache/${SHIM_ARCH}-unknown-linux-musl" "target/${SHIM_ARCH}-unknown-linux-musl"
-    fi
-
+    # Run setup script (installs dependencies, such as Rust, Make, etc.)
     make setup
 
+    # Source cargo env (Rust may have just been installed)
     [ -f "$HOME/.cargo/env" ] && source "$HOME/.cargo/env"
 
-    # Build shim and guest (skip if pre-built via SKIP_*_BUILD)
-    # No 'make runtime' needed — embedded-runtime feature handles everything
-    make shim guest
+    make runtime
     """]
 
 # Test the built wheel (optional, add tests later)
@@ -115,8 +108,7 @@ repair-wheel-command = ""  # Skip auditwheel repair
 
 # Set Rust and library paths
 # SKIP_GUEST_BUILD=1: Use pre-built guest from Ubuntu host (manylinux lacks musl packages)
-# SKIP_SHIM_BUILD=1: Use pre-built shim from Ubuntu host
-environment = { SKIP_GUEST_BUILD = "1", SKIP_SHIM_BUILD = "1", PATH = "$HOME/.cargo/bin:/usr/local/bin:$PATH", PKG_CONFIG_PATH = "/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig", LD_LIBRARY_PATH = "/usr/local/lib64:/usr/local/lib" }
+environment = { SKIP_GUEST_BUILD = "1", PATH = "$HOME/.cargo/bin:/usr/local/bin:$PATH", PKG_CONFIG_PATH = "/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig", LD_LIBRARY_PATH = "/usr/local/lib64:/usr/local/lib" }
 
 # Retag wheel for PyPI compliance without bundling libs (we handle runtime deps ourselves)
 # Uses 'wheel tags' to change linux_x86_64 -> manylinux_2_28_x86_64


### PR DESCRIPTION
Go c-archive (libgvproxy) is fundamentally incompatible with musl TLS, causing SIGSEGV at runtime. Replace musl target with gnu + crt-static for a fully static binary using glibc's static libraries.

Key changes:
- Revert musl compat commits (#317, #318) that are no longer needed
- Use x86_64-unknown-linux-gnu with +crt-static and relocation-model=static
- Add link-krun feature to gate libkrun.a linking (shim-only)
- Feature-gate krun VMM module so boxlite-cli doesn't link libkrun.a
- Remove shim pre-build from CI (builds natively in manylinux container)
- Remove configure_library_env dependency on krun_create_ctx symbol

--target is required on Linux so RUSTFLAGS don't affect proc-macro compilation. relocation-model=static avoids static-pie which crashes with Go c-archive relocations.