### PR TITLE
fix(build): link libresolv for static glibc builds on Linux

### DIFF
--- a/boxlite/deps/libgvproxy-sys/build.rs
+++ b/boxlite/deps/libgvproxy-sys/build.rs
@@ -83,13 +83,15 @@ fn main() {
     println!("cargo:rustc-link-search=native={}", out_dir);
     println!("cargo:rustc-link-lib=static=gvproxy");
 
-    // Transitive dependencies from the Go runtime (embedded in the c-archive)
+    // Transitive dependencies from the Go runtime (embedded in the c-archive).
+    // Go's net package uses the CGO resolver by default, which calls res_search
+    // from libresolv for DNS lookups on both macOS and Linux.
     #[cfg(target_os = "macos")]
     {
         println!("cargo:rustc-link-lib=framework=CoreFoundation");
         println!("cargo:rustc-link-lib=framework=Security");
-        println!("cargo:rustc-link-lib=resolv");
     }
+    println!("cargo:rustc-link-lib=resolv");
 
     // Expose library directory to downstream crates (used by boxlite/build.rs)
     // Convention: {LIBNAME}_BOXLITE_DEP=<path> for auto-discovery

--- a/scripts/setup/setup-manylinux.sh
+++ b/scripts/setup/setup-manylinux.sh
@@ -97,12 +97,15 @@ install_system_deps() {
         fi
     done
 
-    # Try to install glibc-static if available (not critical, not available on all arches)
-    print_step "Checking for glibc-static (optional)... "
-    if yum install -y -q glibc-static 2>/dev/null; then
-        print_success "Installed"
+    # glibc-static is required for boxlite-shim (built with +crt-static).
+    # Provides libc.a and libresolv.a needed for static glibc linking.
+    print_step "Checking for glibc-static... "
+    if yum_installed glibc-static; then
+        print_success "Already installed"
     else
-        echo -e "${YELLOW}Not available (not required)${NC}"
+        echo -e "${YELLOW}Installing...${NC}"
+        yum install -y -q glibc-static
+        print_success "glibc-static installed"
     fi
 
     echo ""


### PR DESCRIPTION
Go's CGO net package calls res_search from libresolv for DNS lookups. With dynamic linking, libresolv.so is resolved transitively. After switching to glibc static linking (#319), libresolv.a must be linked explicitly since glibc separates it from libc.a.

Also make glibc-static a required dependency in manylinux setup since it provides both libc.a and libresolv.a needed for +crt-static builds.