### PR TITLE
fix(ci): use hardcoded target/ path in Package runtime step

### DIFF
--- a/.github/workflows/build-runtime.yml
+++ b/.github/workflows/build-runtime.yml
@@ -132,10 +132,8 @@ jobs:
 
       - name: Package runtime
         run: |
-          TARGET_DIR=$(cargo metadata --format-version 1 --no-deps 2>/dev/null | \
-            grep -o '"target_directory":"[^"]*"' | cut -d'"' -f4)
-          RUNTIME_DIR=$(ls -dt "$TARGET_DIR"/release/build/boxlite-*/out/runtime 2>/dev/null | head -1)
-          [ -n "$RUNTIME_DIR" ] || { echo "ERROR: Runtime directory not found under $TARGET_DIR"; exit 1; }
+          RUNTIME_DIR=$(ls -dt target/release/build/boxlite-*/out/runtime 2>/dev/null | head -1)
+          [ -n "$RUNTIME_DIR" ] || { echo "ERROR: Runtime directory not found under target/"; exit 1; }
           cp -a "$RUNTIME_DIR" boxlite-runtime
           tar czf boxlite-runtime-${{ matrix.target }}.tar.gz boxlite-runtime/
           rm -rf boxlite-runtime


### PR DESCRIPTION
## Summary

- Fix CI "Package runtime" step failing on Linux because `cargo` was deleted earlier in the build flow
- The Linux build deletes `~/.rustup` and `~/.cargo` after building the guest binary (to save disk space), so `cargo metadata` fails silently, leaving `TARGET_DIR` empty
- Replace `cargo metadata` lookup with direct `target/` reference — no custom target-dir is configured in this project

## Test plan

- [ ] Verify CI `build-runtime` workflow passes on Linux targets
- [ ] Verify CI `build-runtime` workflow still passes on macOS targets