### PR TITLE
feat(ci): add sccache compilation caching with graceful fallback

### DIFF
--- a/.github/workflows/build-node.yml
+++ b/.github/workflows/build-node.yml
@@ -70,6 +70,22 @@ jobs:
           shared-key: "boxlite"
           save-if: false
 
+      # sccache caches individual compilation units via GHA cache API.
+      # Works inside Docker containers (unlike Swatinem/rust-cache).
+      # Cache is pre-warmed by the Warm Caches workflow on push to main.
+      - name: Setup sccache
+        if: runner.os == 'Linux'
+        uses: mozilla-actions/sccache-action@v0.0.9
+        continue-on-error: true
+
+      - name: Export GHA cache env vars
+        if: runner.os == 'Linux'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+
       # Build guest on host BEFORE manylinux container because:
       # - manylinux (AlmaLinux/RHEL) doesn't have musl packages in repos
       # - Building musl-cross-make from source takes ~15 minutes
@@ -91,26 +107,18 @@ jobs:
           rm -rf target ~/.rustup ~/.cargo
           mkdir -p target
 
-      # Cache cargo registry for manylinux container.
-      # Swatinem/rust-cache can't run inside Docker, so we use actions/cache
-      # with CARGO_HOME redirected to a host-mounted path.
-      - name: Cache manylinux cargo registry
-        if: runner.os == 'Linux'
-        uses: actions/cache@v4
-        with:
-          path: |
-            .cargo-manylinux/registry
-            .cargo-manylinux/git
-          key: manylinux-cargo-${{ matrix.target }}-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            manylinux-cargo-${{ matrix.target }}-
-
       - name: Build Node.js package (Linux)
         if: runner.os == 'Linux'
         run: |
           cat > "$RUNNER_TEMP/build.sh" << 'CONTAINER_SCRIPT'
           set -ex
           git config --global --add safe.directory /work
+
+          # sccache fallback: if not available, disable wrapper for normal compilation
+          if [ -n "${RUSTC_WRAPPER:-}" ] && ! command -v "$RUSTC_WRAPPER" &>/dev/null; then
+            echo "::warning::sccache not available in container, falling back to normal compilation"
+            unset RUSTC_WRAPPER
+          fi
 
           GUEST_TARGET=$(scripts/util.sh --target)
           if [ -d ".cache/$GUEST_TARGET" ]; then
@@ -128,11 +136,21 @@ jobs:
           npm install --silent
           npm run build:native -- --release
           npm run artifacts
+
+          command -v sccache &>/dev/null && sccache --show-stats || true
           CONTAINER_SCRIPT
+
+          # Conditionally mount sccache binary and pass env vars into Docker.
+          # If sccache-action failed or binary is missing, build proceeds without caching.
+          SCCACHE_DOCKER_ARGS=""
+          if command -v sccache &>/dev/null; then
+            SCCACHE_DOCKER_ARGS="-v $(which sccache):/usr/local/bin/sccache:ro -e SCCACHE_GHA_ENABLED=true -e RUSTC_WRAPPER=sccache -e ACTIONS_RESULTS_URL -e ACTIONS_RUNTIME_TOKEN"
+          fi
 
           docker run --rm \
             -v ${{ github.workspace }}:/work \
             -v "$RUNNER_TEMP/build.sh:/tmp/build.sh:ro" \
+            $SCCACHE_DOCKER_ARGS \
             -w /work \
             -e CARGO_HOME=/work/.cargo-manylinux \
             quay.io/pypa/manylinux_2_28_${{ contains(matrix.target, 'arm64') && 'aarch64' || 'x86_64' }} \

--- a/.github/workflows/build-runtime.yml
+++ b/.github/workflows/build-runtime.yml
@@ -64,6 +64,22 @@ jobs:
           shared-key: "boxlite"
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
+      # sccache caches individual compilation units via GHA cache API.
+      # Works inside Docker containers (unlike Swatinem/rust-cache).
+      # Cache is pre-warmed by the Warm Caches workflow on push to main.
+      - name: Setup sccache
+        if: runner.os == 'Linux'
+        uses: mozilla-actions/sccache-action@v0.0.9
+        continue-on-error: true
+
+      - name: Export GHA cache env vars
+        if: runner.os == 'Linux'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+
       # Build guest on host BEFORE manylinux container because:
       # - manylinux (AlmaLinux/RHEL) doesn't have musl packages in repos
       # - Building musl-cross-make from source takes ~15 minutes
@@ -85,26 +101,18 @@ jobs:
           rm -rf target ~/.rustup ~/.cargo
           mkdir -p target
 
-      # Cache cargo registry for manylinux container.
-      # Swatinem/rust-cache can't run inside Docker, so we use actions/cache
-      # with CARGO_HOME redirected to a host-mounted path.
-      - name: Cache manylinux cargo registry
-        if: runner.os == 'Linux'
-        uses: actions/cache@v4
-        with:
-          path: |
-            .cargo-manylinux/registry
-            .cargo-manylinux/git
-          key: manylinux-cargo-${{ matrix.target }}-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            manylinux-cargo-${{ matrix.target }}-
-
       - name: Build runtime (Linux)
         if: runner.os == 'Linux'
         run: |
           cat > "$RUNNER_TEMP/build.sh" << 'CONTAINER_SCRIPT'
           set -ex
           git config --global --add safe.directory /work
+
+          # sccache fallback: if not available, disable wrapper for normal compilation
+          if [ -n "${RUSTC_WRAPPER:-}" ] && ! command -v "$RUSTC_WRAPPER" &>/dev/null; then
+            echo "::warning::sccache not available in container, falling back to normal compilation"
+            unset RUSTC_WRAPPER
+          fi
 
           GUEST_TARGET=$(scripts/util.sh --target)
           if [ -d ".cache/$GUEST_TARGET" ]; then
@@ -116,11 +124,21 @@ jobs:
           export SKIP_GUEST_BUILD=1
           export PATH="$CARGO_HOME/bin:$PATH"
           make setup runtime
+
+          command -v sccache &>/dev/null && sccache --show-stats || true
           CONTAINER_SCRIPT
+
+          # Conditionally mount sccache binary and pass env vars into Docker.
+          # If sccache-action failed or binary is missing, build proceeds without caching.
+          SCCACHE_DOCKER_ARGS=""
+          if command -v sccache &>/dev/null; then
+            SCCACHE_DOCKER_ARGS="-v $(which sccache):/usr/local/bin/sccache:ro -e SCCACHE_GHA_ENABLED=true -e RUSTC_WRAPPER=sccache -e ACTIONS_RESULTS_URL -e ACTIONS_RUNTIME_TOKEN"
+          fi
 
           docker run --rm \
             -v ${{ github.workspace }}:/work \
             -v "$RUNNER_TEMP/build.sh:/tmp/build.sh:ro" \
+            $SCCACHE_DOCKER_ARGS \
             -w /work \
             -e CARGO_HOME=/work/.cargo-manylinux \
             quay.io/pypa/manylinux_2_28_${{ contains(matrix.target, 'arm64') && 'aarch64' || 'x86_64' }} \

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -39,6 +39,24 @@ jobs:
           shared-key: "boxlite"
           save-if: false  # Workflow deletes cache after guest build
 
+      # sccache caches individual compilation units via GHA cache API.
+      # Works inside cibuildwheel's manylinux containers via environment-pass.
+      # Cache is pre-warmed by the Warm Caches workflow on push to main.
+      - name: Setup sccache
+        if: runner.os == 'Linux'
+        uses: mozilla-actions/sccache-action@v0.0.9
+        continue-on-error: true
+
+      - name: Export GHA cache env vars
+        if: runner.os == 'Linux'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+            core.exportVariable('SCCACHE_GHA_ENABLED', 'true');
+            core.exportVariable('RUSTC_WRAPPER', 'sccache');
+
       # Build guest on host BEFORE cibuildwheel container because:
       # - manylinux (AlmaLinux/RHEL) doesn't have musl packages in repos
       # - Building musl-cross-make from source takes ~15 minutes

--- a/.github/workflows/warm-caches.yml
+++ b/.github/workflows/warm-caches.yml
@@ -1,0 +1,115 @@
+# Pre-warm sccache for all workflows that build Rust inside manylinux Docker containers.
+#
+# Problem: Three workflows (build-runtime, build-node, build-wheels) independently
+# compile the same Rust code inside Docker, where Swatinem/rust-cache can't reach.
+# This results in ~20 min cold compiles per workflow on every run.
+#
+# Solution: sccache caches individual compilation units via the GHA cache API,
+# which works inside Docker containers. This workflow warms the cache on push to
+# main so that subsequent workflow runs get cache hits.
+#
+# Pattern inspired by Bevy's cache warmup workflow.
+name: Warm Caches
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'boxlite/**'
+      - 'boxlite-shared/**'
+      - 'guest/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/warm-caches.yml'
+  schedule:
+    - cron: '0 1 * * 1'  # Weekly Monday 1 AM UTC (prevents 7-day GHA cache eviction)
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: '0'  # sccache and incremental compilation are incompatible
+  SKIP_INSTALL_NODEJS: '1'
+  SCCACHE_GHA_ENABLED: 'true'
+  RUSTC_WRAPPER: 'sccache'
+
+jobs:
+  config:
+    uses: ./.github/workflows/config.yml
+
+  warm:
+    name: Warm sccache
+    needs: config
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: ${{ needs.config.outputs.rust-toolchain }}
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Export GHA cache env vars
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+
+      # Guest build on host WITH sccache — warms cache for all workflows' guest builds
+      - name: Build guest binary
+        run: |
+          make setup guest
+          sccache --show-stats
+          GUEST_TARGET=$(scripts/util.sh --target)
+          mkdir -p ".cache/$GUEST_TARGET/release"
+          cp "target/$GUEST_TARGET/release/boxlite-guest" ".cache/$GUEST_TARGET/release/"
+          rm -rf target ~/.rustup ~/.cargo
+          mkdir -p target
+
+      # Docker build WITH sccache — warms cache for all workflows' manylinux builds
+      - name: Build runtime in manylinux (warm sccache)
+        run: |
+          cat > "$RUNNER_TEMP/build.sh" << 'CONTAINER_SCRIPT'
+          set -ex
+          git config --global --add safe.directory /work
+
+          # sccache fallback: if not available, disable wrapper for normal compilation
+          if [ -n "${RUSTC_WRAPPER:-}" ] && ! command -v "$RUSTC_WRAPPER" &>/dev/null; then
+            echo "::warning::sccache not available in container, falling back to normal compilation"
+            unset RUSTC_WRAPPER
+          fi
+
+          GUEST_TARGET=$(scripts/util.sh --target)
+          if [ -d ".cache/$GUEST_TARGET" ]; then
+            echo "Restoring guest from .cache/$GUEST_TARGET"
+            mkdir -p target
+            cp -a ".cache/$GUEST_TARGET" "target/$GUEST_TARGET"
+          fi
+
+          export SKIP_GUEST_BUILD=1
+          export PATH="$CARGO_HOME/bin:$PATH"
+          make setup runtime
+
+          command -v sccache &>/dev/null && sccache --show-stats || true
+          CONTAINER_SCRIPT
+
+          # Conditionally mount sccache binary and pass env vars into Docker.
+          # If sccache-action failed or binary is missing, build proceeds without caching.
+          SCCACHE_DOCKER_ARGS=""
+          if command -v sccache &>/dev/null; then
+            SCCACHE_DOCKER_ARGS="-v $(which sccache):/usr/local/bin/sccache:ro -e SCCACHE_GHA_ENABLED=true -e RUSTC_WRAPPER=sccache -e ACTIONS_RESULTS_URL -e ACTIONS_RUNTIME_TOKEN"
+          fi
+
+          docker run --rm \
+            -v ${{ github.workspace }}:/work \
+            -v "$RUNNER_TEMP/build.sh:/tmp/build.sh:ro" \
+            $SCCACHE_DOCKER_ARGS \
+            -w /work \
+            -e CARGO_HOME=/work/.cargo-manylinux \
+            quay.io/pypa/manylinux_2_28_x86_64 \
+            bash /tmp/build.sh

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -69,6 +69,18 @@ skip = [
 before-all = ["""
     set -ex  # Exit on error, print commands
 
+    # Install sccache for compilation caching (CI uses GHA cache backend)
+    pip install sccache 2>/dev/null || true
+    # Verify sccache works; create pass-through shim if not to prevent build failures.
+    # When RUSTC_WRAPPER=sccache is set (via environment-pass), cargo calls
+    # `sccache /path/to/rustc <args>`. The shim just runs `exec "$@"` which
+    # executes `/path/to/rustc <args>` directly — a no-op wrapper.
+    if ! command -v sccache &>/dev/null; then
+        echo "WARNING: sccache not available, creating pass-through shim"
+        printf '#!/bin/sh\nexec "$@"\n' > /usr/local/bin/sccache
+        chmod +x /usr/local/bin/sccache
+    fi
+
     # cibuildwheel runs from repository root
     BOXLITE_ROOT=$(pwd)
 
@@ -109,6 +121,10 @@ repair-wheel-command = ""  # Skip auditwheel repair
 # Set Rust and library paths
 # SKIP_GUEST_BUILD=1: Use pre-built guest from Ubuntu host (manylinux lacks musl packages)
 environment = { SKIP_GUEST_BUILD = "1", PATH = "$HOME/.cargo/bin:/usr/local/bin:$PATH", PKG_CONFIG_PATH = "/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig", LD_LIBRARY_PATH = "/usr/local/lib64:/usr/local/lib" }
+
+# Pass sccache env vars from host into cibuildwheel's manylinux container
+# These enable sccache to use the GHA cache API for compilation caching
+environment-pass = ["ACTIONS_RESULTS_URL", "ACTIONS_RUNTIME_TOKEN", "SCCACHE_GHA_ENABLED", "RUSTC_WRAPPER"]
 
 # Retag wheel for PyPI compliance without bundling libs (we handle runtime deps ourselves)
 # Uses 'wheel tags' to change linux_x86_64 -> manylinux_2_28_x86_64


### PR DESCRIPTION
## Summary

- Add **sccache** (per-compilation-unit caching via GHA cache API) to all Linux Docker builds across build-runtime, build-node, and build-wheels workflows
- Create **warm-caches.yml** workflow (Bevy pattern) to pre-warm sccache on push to main and weekly cron, so subsequent builds get cache hits
- Replace `actions/cache` for manylinux cargo registry with sccache (which caches compilation units, not just the registry)
- Add **three-layer graceful fallback** so sccache failure never breaks builds:
  1. `continue-on-error` on sccache setup steps
  2. Conditional Docker mount (only if sccache binary exists on host)
  3. Container-level `RUSTC_WRAPPER` check + pass-through shim for cibuildwheel

## Motivation

Three workflows independently compile the same Rust code inside manylinux Docker containers (~17-25 min each). Current caching (Swatinem + actions/cache) only caches the cargo registry — zero compilation caching inside Docker. sccache works inside containers via the GHA cache API and shares cache across all workflows.

## Files Changed

| File | Change |
|------|--------|
| `.github/workflows/warm-caches.yml` | **NEW** — dedicated cache warmup workflow |
| `.github/workflows/build-runtime.yml` | Remove actions/cache, add sccache with fallback |
| `.github/workflows/build-node.yml` | Remove actions/cache, add sccache with fallback |
| `.github/workflows/build-wheels.yml` | Add sccache via cibuildwheel environment-pass |
| `sdks/python/pyproject.toml` | Add environment-pass + sccache install with shim fallback |

## Test plan

- [ ] Trigger `Warm Caches` via workflow_dispatch — verify cold cache (all misses in `sccache --show-stats`)
- [ ] Trigger `Warm Caches` again — verify warm cache (90%+ hits)
- [ ] Trigger `Build Runtime` — verify sccache hits in Docker build, macOS unaffected
- [ ] Trigger `Build Node.js` — verify sccache hits in Docker build
- [ ] Trigger `Build Wheels` — verify sccache hits in cibuildwheel container
- [ ] Verify fallback: if sccache setup step were to fail, builds should still succeed without caching