### PR TITLE
fix(ci): pass ACTIONS_CACHE_SERVICE_V2 into Docker for sccache v2 cache API

### DIFF
--- a/.github/workflows/build-node.yml
+++ b/.github/workflows/build-node.yml
@@ -85,6 +85,7 @@ jobs:
           script: |
             core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+            core.exportVariable('ACTIONS_CACHE_SERVICE_V2', process.env.ACTIONS_CACHE_SERVICE_V2 || '');
 
       # Build guest on host BEFORE manylinux container because:
       # - manylinux (AlmaLinux/RHEL) doesn't have musl packages in repos
@@ -144,7 +145,7 @@ jobs:
           # If sccache-action failed or binary is missing, build proceeds without caching.
           SCCACHE_DOCKER_ARGS=""
           if command -v sccache &>/dev/null; then
-            SCCACHE_DOCKER_ARGS="-v $(which sccache):/usr/local/bin/sccache:ro -e SCCACHE_GHA_ENABLED=true -e RUSTC_WRAPPER=sccache -e ACTIONS_RESULTS_URL -e ACTIONS_RUNTIME_TOKEN"
+            SCCACHE_DOCKER_ARGS="-v $(which sccache):/usr/local/bin/sccache:ro -e SCCACHE_GHA_ENABLED=true -e RUSTC_WRAPPER=sccache -e ACTIONS_CACHE_SERVICE_V2 -e ACTIONS_RESULTS_URL -e ACTIONS_RUNTIME_TOKEN"
           fi
 
           docker run --rm \

--- a/.github/workflows/build-runtime.yml
+++ b/.github/workflows/build-runtime.yml
@@ -79,6 +79,7 @@ jobs:
           script: |
             core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+            core.exportVariable('ACTIONS_CACHE_SERVICE_V2', process.env.ACTIONS_CACHE_SERVICE_V2 || '');
 
       # Build guest on host BEFORE manylinux container because:
       # - manylinux (AlmaLinux/RHEL) doesn't have musl packages in repos
@@ -132,7 +133,7 @@ jobs:
           # If sccache-action failed or binary is missing, build proceeds without caching.
           SCCACHE_DOCKER_ARGS=""
           if command -v sccache &>/dev/null; then
-            SCCACHE_DOCKER_ARGS="-v $(which sccache):/usr/local/bin/sccache:ro -e SCCACHE_GHA_ENABLED=true -e RUSTC_WRAPPER=sccache -e ACTIONS_RESULTS_URL -e ACTIONS_RUNTIME_TOKEN"
+            SCCACHE_DOCKER_ARGS="-v $(which sccache):/usr/local/bin/sccache:ro -e SCCACHE_GHA_ENABLED=true -e RUSTC_WRAPPER=sccache -e ACTIONS_CACHE_SERVICE_V2 -e ACTIONS_RESULTS_URL -e ACTIONS_RUNTIME_TOKEN"
           fi
 
           docker run --rm \

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -54,6 +54,7 @@ jobs:
           script: |
             core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+            core.exportVariable('ACTIONS_CACHE_SERVICE_V2', process.env.ACTIONS_CACHE_SERVICE_V2 || '');
             core.exportVariable('SCCACHE_GHA_ENABLED', 'true');
             core.exportVariable('RUSTC_WRAPPER', 'sccache');
 

--- a/.github/workflows/warm-caches.yml
+++ b/.github/workflows/warm-caches.yml
@@ -59,6 +59,7 @@ jobs:
           script: |
             core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+            core.exportVariable('ACTIONS_CACHE_SERVICE_V2', process.env.ACTIONS_CACHE_SERVICE_V2 || '');
 
       # Guest build on host WITH sccache — warms cache for all workflows' guest builds
       - name: Build guest binary
@@ -102,7 +103,7 @@ jobs:
           # If sccache-action failed or binary is missing, build proceeds without caching.
           SCCACHE_DOCKER_ARGS=""
           if command -v sccache &>/dev/null; then
-            SCCACHE_DOCKER_ARGS="-v $(which sccache):/usr/local/bin/sccache:ro -e SCCACHE_GHA_ENABLED=true -e RUSTC_WRAPPER=sccache -e ACTIONS_RESULTS_URL -e ACTIONS_RUNTIME_TOKEN"
+            SCCACHE_DOCKER_ARGS="-v $(which sccache):/usr/local/bin/sccache:ro -e SCCACHE_GHA_ENABLED=true -e RUSTC_WRAPPER=sccache -e ACTIONS_CACHE_SERVICE_V2 -e ACTIONS_RESULTS_URL -e ACTIONS_RUNTIME_TOKEN"
           fi
 
           docker run --rm \

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -124,7 +124,7 @@ environment = { SKIP_GUEST_BUILD = "1", PATH = "$HOME/.cargo/bin:/usr/local/bin:
 
 # Pass sccache env vars from host into cibuildwheel's manylinux container
 # These enable sccache to use the GHA cache API for compilation caching
-environment-pass = ["ACTIONS_RESULTS_URL", "ACTIONS_RUNTIME_TOKEN", "SCCACHE_GHA_ENABLED", "RUSTC_WRAPPER"]
+environment-pass = ["ACTIONS_RESULTS_URL", "ACTIONS_RUNTIME_TOKEN", "ACTIONS_CACHE_SERVICE_V2", "SCCACHE_GHA_ENABLED", "RUSTC_WRAPPER"]
 
 # Retag wheel for PyPI compliance without bundling libs (we handle runtime deps ourselves)
 # Uses 'wheel tags' to change linux_x86_64 -> manylinux_2_28_x86_64


### PR DESCRIPTION
## Summary

- Fix sccache cache write errors (1790/1790 failures) inside Docker containers by passing `ACTIONS_CACHE_SERVICE_V2` env var
- Without this var, sccache defaults to the legacy v1 GHA cache API (sunset April 2025), causing 100% write failures
- Host-side sccache worked fine because `sccache-action` sets this var, but it wasn't forwarded into Docker

## Root cause

`mozilla-actions/sccache-action@v0.0.9` sets `ACTIONS_CACHE_SERVICE_V2=on` on the host. OpenDAL (sccache's storage backend) checks this env var to choose between v1/v2 cache API. Without it, Docker containers fell back to the dead v1 API — confirmed by the cache name difference: host used a SHA256 hash (v2), Docker used `sccache-v0.14.0` (v1).

## Changes

Added `ACTIONS_CACHE_SERVICE_V2` to:
- Docker `-e` flags in `build-runtime.yml`, `build-node.yml`, `warm-caches.yml`
- `environment-pass` in `pyproject.toml` for cibuildwheel
- `github-script` exports in all four workflows

## Test plan

- [ ] Merge and verify `Warm Caches` workflow shows cache writes succeeding (0 write errors)
- [ ] Verify `Build Runtime` workflow gets cache hits from warm cache