### PR TITLE
feat(go-sdk): add Exec interface to Go SDK

### DIFF
--- a/sdks/go/internal/binding/binding.go
+++ b/sdks/go/internal/binding/binding.go
@@ -4,6 +4,7 @@ package binding
 
 /*
 #cgo LDFLAGS: -L${SRCDIR}/../../../../target/debug -lboxlite_go_bridge -Wl,-rpath,${SRCDIR}/../../../../target/debug
+#cgo darwin LDFLAGS: -framework CoreFoundation -framework IOKit -framework DiskArbitration
 
 #include <stdlib.h>
 #include <stdbool.h>

--- a/sdks/go/internal/binding/dep_stubs.c
+++ b/sdks/go/internal/binding/dep_stubs.c
@@ -1,0 +1,49 @@
+// Weak symbol stubs for native dependencies (libkrun, libgvproxy).
+//
+// When building with BOXLITE_DEPS_STUB=1, the Rust static library references
+// these symbols but they are not linked in. These weak definitions satisfy the
+// linker; they are overridden by strong definitions from real libraries in
+// production builds.
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#ifdef __APPLE__
+#define WEAK __attribute__((weak))
+#else
+#define WEAK __attribute__((weak))
+#endif
+
+// libkrun
+WEAK int32_t krun_create_ctx(void) { return -1; }
+WEAK int32_t krun_free_ctx(uint32_t ctx) { return -1; }
+WEAK int32_t krun_set_vm_config(uint32_t ctx, uint8_t cpus, uint32_t mem) { return -1; }
+WEAK int32_t krun_set_root(uint32_t ctx, const char* path) { return -1; }
+WEAK int32_t krun_set_exec(uint32_t ctx, const char* exec, const char** argv, const char** env) { return -1; }
+WEAK int32_t krun_set_env(uint32_t ctx, const char* env) { return -1; }
+WEAK int32_t krun_set_workdir(uint32_t ctx, const char* path) { return -1; }
+WEAK int32_t krun_set_kernel(uint32_t ctx, const char* path) { return -1; }
+WEAK int32_t krun_start_enter(uint32_t ctx) { return -1; }
+WEAK int32_t krun_set_console_output(uint32_t ctx, int fd) { return -1; }
+WEAK int32_t krun_init_log(uint32_t ctx) { return -1; }
+WEAK int32_t krun_add_disk2(uint32_t ctx, const char* path, int ro) { return -1; }
+WEAK int32_t krun_add_net_unixgram(uint32_t ctx, const char* path) { return -1; }
+WEAK int32_t krun_add_net_unixstream(uint32_t ctx, const char* path) { return -1; }
+WEAK int32_t krun_add_virtiofs(uint32_t ctx, const char* tag, const char* path) { return -1; }
+WEAK int32_t krun_add_vsock_port2(uint32_t ctx, uint32_t port, const char* path) { return -1; }
+WEAK int32_t krun_set_gpu_options(uint32_t ctx, uint32_t opts) { return -1; }
+WEAK int32_t krun_set_nested_virt(uint32_t ctx, int nested) { return -1; }
+WEAK int32_t krun_set_port_map(uint32_t ctx, const char* map) { return -1; }
+WEAK int32_t krun_set_rlimits(uint32_t ctx, const char* rlimits) { return -1; }
+WEAK int32_t krun_set_root_disk_remount(uint32_t ctx, int remount) { return -1; }
+WEAK int32_t krun_setgid(uint32_t ctx, uint32_t gid) { return -1; }
+WEAK int32_t krun_setuid(uint32_t ctx, uint32_t uid) { return -1; }
+WEAK int32_t krun_split_irqchip(uint32_t ctx) { return -1; }
+
+// libgvproxy
+WEAK void* gvproxy_create(const char* config) { return NULL; }
+WEAK void gvproxy_destroy(void* handle) {}
+WEAK char* gvproxy_get_stats(void* handle) { return NULL; }
+WEAK char* gvproxy_get_version(void) { return NULL; }
+WEAK void gvproxy_free_string(char* s) {}
+WEAK void gvproxy_set_log_callback(void* cb) {}

--- a/sdks/go/internal/binding/exec.go
+++ b/sdks/go/internal/binding/exec.go
@@ -1,0 +1,100 @@
+package binding
+
+/*
+#include <stdlib.h>
+
+// Defined in exec_bridge.c — wraps boxlite_go_box_exec with the Go callback.
+int call_box_exec_with_go_callback(
+    void* handle,
+    const char* command,
+    const char* opts_json,
+    void* user_data,
+    int* out_exit_code,
+    char** out_err
+);
+*/
+import "C"
+import (
+	"encoding/json"
+	"runtime/cgo"
+	"sync"
+	"unsafe"
+)
+
+// ExecOptions holds the configuration for executing a command.
+type ExecOptions struct {
+	Args       []string          `json:"args,omitempty"`
+	Env        map[string]string `json:"env,omitempty"`
+	TTY        bool              `json:"tty,omitempty"`
+	User       string            `json:"user,omitempty"`
+	TimeoutSec float64           `json:"timeout_secs,omitempty"`
+	WorkingDir string            `json:"working_dir,omitempty"`
+}
+
+// ExecResult holds the result of a command execution.
+type ExecResult struct {
+	ExitCode int
+	Stdout   []string
+	Stderr   []string
+}
+
+// outputCollector gathers stdout/stderr lines from the C callback.
+type outputCollector struct {
+	mu     sync.Mutex
+	stdout []string
+	stderr []string
+}
+
+//export goOutputCallback
+func goOutputCallback(text *C.char, streamType C.int, userData unsafe.Pointer) {
+	h := cgo.Handle(userData)
+	collector := h.Value().(*outputCollector)
+	line := C.GoString(text)
+
+	collector.mu.Lock()
+	defer collector.mu.Unlock()
+
+	if int(streamType) == 0 {
+		collector.stdout = append(collector.stdout, line)
+	} else {
+		collector.stderr = append(collector.stderr, line)
+	}
+}
+
+// Exec executes a command in the box and returns the result.
+func (b *Box) Exec(command string, opts ExecOptions) (ExecResult, error) {
+	cCommand := C.CString(command)
+	defer C.free(unsafe.Pointer(cCommand))
+
+	optsJSON, err := json.Marshal(opts)
+	if err != nil {
+		return ExecResult{}, err
+	}
+	cOptsJSON := C.CString(string(optsJSON))
+	defer C.free(unsafe.Pointer(cOptsJSON))
+
+	collector := &outputCollector{}
+	h := cgo.NewHandle(collector)
+	defer h.Delete()
+
+	var exitCode C.int
+	var outErr *C.char
+
+	res := C.call_box_exec_with_go_callback(
+		b.handle,
+		cCommand,
+		cOptsJSON,
+		unsafe.Pointer(h),
+		&exitCode,
+		&outErr,
+	)
+	if res < 0 {
+		return ExecResult{}, getError(outErr)
+	}
+
+	return ExecResult{
+		ExitCode: int(exitCode),
+		Stdout:   collector.stdout,
+		Stderr:   collector.stderr,
+	}, nil
+}

--- a/sdks/go/internal/binding/exec_bridge.c
+++ b/sdks/go/internal/binding/exec_bridge.c
@@ -1,0 +1,28 @@
+#include <stdlib.h>
+#include "_cgo_export.h"
+
+typedef void (*boxlite_output_callback)(const char* text, int stream_type, void* user_data);
+
+int boxlite_go_box_exec(
+    void* handle,
+    const char* command,
+    const char* opts_json,
+    boxlite_output_callback callback,
+    void* user_data,
+    int* out_exit_code,
+    char** out_err
+);
+
+// Wrapper: passes the Go-exported goOutputCallback to the Rust FFI function.
+int call_box_exec_with_go_callback(
+    void* handle,
+    const char* command,
+    const char* opts_json,
+    void* user_data,
+    int* out_exit_code,
+    char** out_err
+) {
+    return boxlite_go_box_exec(handle, command, opts_json,
+        (boxlite_output_callback)goOutputCallback, user_data,
+        out_exit_code, out_err);
+}

--- a/sdks/go/pkg/client/binding_mock_test.go
+++ b/sdks/go/pkg/client/binding_mock_test.go
@@ -12,9 +12,11 @@ import (
 // ===========================================================================
 
 type mockBoxProvider struct {
-	startErr error
-	stopErr  error
-	info     binding.BoxInfo
+	startErr   error
+	stopErr    error
+	execResult binding.ExecResult
+	execErr    error
+	info       binding.BoxInfo
 }
 
 func newMockBoxProvider(id, image string) *mockBoxProvider {
@@ -46,6 +48,13 @@ func (b *mockBoxProvider) Stop() error {
 
 func (b *mockBoxProvider) Info() (binding.BoxInfo, error) {
 	return b.info, nil
+}
+
+func (b *mockBoxProvider) Exec(_ string, _ binding.ExecOptions) (binding.ExecResult, error) {
+	if b.execErr != nil {
+		return binding.ExecResult{}, b.execErr
+	}
+	return b.execResult, nil
 }
 
 func (b *mockBoxProvider) Free() {}

--- a/sdks/go/pkg/client/box.go
+++ b/sdks/go/pkg/client/box.go
@@ -1,6 +1,8 @@
 package client
 
-import "github.com/boxlite-ai/boxlite/sdks/go/internal/binding"
+import (
+	"github.com/boxlite-ai/boxlite/sdks/go/internal/binding"
+)
 
 // Box is a handle to a running or stopped BoxLite box.
 // Closing the handle does not remove the box; the box continues to exist in the runtime.
@@ -35,6 +37,33 @@ func (b *Box) Info() (binding.BoxInfo, error) {
 		Image:     info.Image,
 		State:     info.State,
 		CreatedAt: info.CreatedAt,
+	}, nil
+}
+
+// Exec executes a command inside the box and returns the result.
+// If opts is nil, the command is executed with default options.
+func (b *Box) Exec(command string, opts *ExecOptions) (*ExecResult, error) {
+	bindOpts := binding.ExecOptions{}
+	if opts != nil {
+		bindOpts.Args = opts.Args
+		bindOpts.Env = opts.Env
+		bindOpts.TTY = opts.TTY
+		bindOpts.User = opts.User
+		bindOpts.WorkingDir = opts.WorkingDir
+		if opts.Timeout > 0 {
+			bindOpts.TimeoutSec = opts.Timeout.Seconds()
+		}
+	}
+
+	result, err := b.handle.Exec(command, bindOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ExecResult{
+		ExitCode: result.ExitCode,
+		Stdout:   result.Stdout,
+		Stderr:   result.Stderr,
 	}, nil
 }
 

--- a/sdks/go/pkg/client/box_test.go
+++ b/sdks/go/pkg/client/box_test.go
@@ -1,0 +1,140 @@
+package client
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/boxlite-ai/boxlite/sdks/go/internal/binding"
+)
+
+func TestBoxExecDelegatesToProvider(t *testing.T) {
+	mock := newMockRuntimeProvider()
+	mock.AddBox("box-1", "alpine:latest")
+	mock.boxes["box-1"].execResult = binding.ExecResult{
+		ExitCode: 0,
+		Stdout:   []string{"hello from boxlite"},
+		Stderr:   nil,
+	}
+
+	rt := newRuntimeWith(mock)
+	box, err := rt.GetBox(t.Context(), "box-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if box == nil {
+		t.Fatal("expected box, got nil")
+	}
+
+	result, err := box.Exec("echo", &ExecOptions{
+		Args: []string{"hello", "from", "boxlite"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", result.ExitCode)
+	}
+	if len(result.Stdout) != 1 || result.Stdout[0] != "hello from boxlite" {
+		t.Fatalf("unexpected stdout: %v", result.Stdout)
+	}
+}
+
+func TestBoxExecNilOpts(t *testing.T) {
+	mock := newMockRuntimeProvider()
+	mock.AddBox("box-1", "alpine:latest")
+	mock.boxes["box-1"].execResult = binding.ExecResult{ExitCode: 42}
+
+	rt := newRuntimeWith(mock)
+	box, err := rt.GetBox(t.Context(), "box-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := box.Exec("exit", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.ExitCode != 42 {
+		t.Fatalf("expected exit code 42, got %d", result.ExitCode)
+	}
+}
+
+func TestBoxExecError(t *testing.T) {
+	mock := newMockRuntimeProvider()
+	mock.AddBox("box-1", "alpine:latest")
+	mock.boxes["box-1"].execErr = errors.New("command not found")
+
+	rt := newRuntimeWith(mock)
+	box, err := rt.GetBox(t.Context(), "box-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = box.Exec("nonexistent", nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if err.Error() != "command not found" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestBoxExecTimeoutConversion(t *testing.T) {
+	mock := newMockRuntimeProvider()
+	bp := mock.AddBox("box-1", "alpine:latest")
+
+	// Capture the binding opts to verify timeout conversion
+	var capturedOpts binding.ExecOptions
+	origExec := bp.Exec
+	_ = origExec
+	// Override with a capturing mock
+	capturingProvider := &capturingMockBoxProvider{
+		mockBoxProvider: bp,
+		capturedOpts:    &capturedOpts,
+	}
+
+	rt := &Runtime{runtime: &capturingRuntimeProvider{
+		mockRuntimeProvider: mock,
+		overrides:           map[string]boxProvider{"box-1": capturingProvider},
+	}}
+
+	box, err := rt.GetBox(t.Context(), "box-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = box.Exec("sleep", &ExecOptions{
+		Timeout: 30 * time.Second,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if capturedOpts.TimeoutSec != 30.0 {
+		t.Fatalf("expected timeout_secs 30.0, got %f", capturedOpts.TimeoutSec)
+	}
+}
+
+// capturingMockBoxProvider wraps mockBoxProvider to capture Exec call arguments.
+type capturingMockBoxProvider struct {
+	*mockBoxProvider
+	capturedOpts *binding.ExecOptions
+}
+
+func (c *capturingMockBoxProvider) Exec(command string, opts binding.ExecOptions) (binding.ExecResult, error) {
+	*c.capturedOpts = opts
+	return c.mockBoxProvider.Exec(command, opts)
+}
+
+// capturingRuntimeProvider wraps mockRuntimeProvider to return overridden box providers.
+type capturingRuntimeProvider struct {
+	*mockRuntimeProvider
+	overrides map[string]boxProvider
+}
+
+func (c *capturingRuntimeProvider) GetBox(idOrName string) (boxProvider, string, error) {
+	if bp, ok := c.overrides[idOrName]; ok {
+		return bp, idOrName, nil
+	}
+	return c.mockRuntimeProvider.GetBox(idOrName)
+}

--- a/sdks/go/pkg/client/client.go
+++ b/sdks/go/pkg/client/client.go
@@ -11,6 +11,7 @@ type boxProvider interface {
 	Start() error
 	Stop() error
 	Info() (binding.BoxInfo, error)
+	Exec(command string, opts binding.ExecOptions) (binding.ExecResult, error)
 	Free()
 }
 

--- a/sdks/go/pkg/client/exec_integration_test.go
+++ b/sdks/go/pkg/client/exec_integration_test.go
@@ -1,0 +1,43 @@
+//go:build integration
+
+package client_test
+
+import (
+	"testing"
+
+	"github.com/boxlite-ai/boxlite/sdks/go/pkg/client"
+)
+
+func TestBoxExec(t *testing.T) {
+	rt, err := client.NewRuntime(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rt.Close()
+
+	box, err := rt.CreateBox(t.Context(), "test-exec", client.BoxOptions{Image: "alpine:latest"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer box.Close()
+
+	if err := box.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer box.Stop()
+
+	result, err := box.Exec("echo", &client.ExecOptions{
+		Args: []string{"hello", "from", "boxlite"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result.ExitCode != 0 {
+		t.Fatalf("expected exit 0, got %d", result.ExitCode)
+	}
+	if len(result.Stdout) == 0 {
+		t.Fatal("expected stdout output")
+	}
+	t.Logf("stdout: %v", result.Stdout)
+}

--- a/sdks/go/pkg/client/types.go
+++ b/sdks/go/pkg/client/types.go
@@ -58,6 +58,39 @@ type BoxInfo struct {
 	CreatedAt time.Time `json:"created_at"`
 }
 
+// ExecOptions holds options for executing a command in a box.
+type ExecOptions struct {
+	// Args is the argument list for the command.
+	Args []string
+
+	// Env is a map of environment variables to set.
+	Env map[string]string
+
+	// TTY enables pseudo-terminal allocation.
+	TTY bool
+
+	// User specifies the user to run the command as (e.g., "root", "1000:1000").
+	User string
+
+	// Timeout is the maximum duration for the command. Zero means no timeout.
+	Timeout time.Duration
+
+	// WorkingDir overrides the working directory for the command.
+	WorkingDir string
+}
+
+// ExecResult holds the result of a command execution.
+type ExecResult struct {
+	// ExitCode is the process exit code.
+	ExitCode int
+
+	// Stdout contains the lines captured from standard output.
+	Stdout []string
+
+	// Stderr contains the lines captured from standard error.
+	Stderr []string
+}
+
 // BoxState represents the state of a box.
 type BoxState string
 

--- a/sdks/go/rust/Cargo.toml
+++ b/sdks/go/rust/Cargo.toml
@@ -27,6 +27,9 @@ tracing-subscriber = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
+# Async stream utilities
+futures = "0.3"
+
 # FFI helpers
 libc = "0.2"
 once_cell = "1"

--- a/sdks/go/rust/src/lib.rs
+++ b/sdks/go/rust/src/lib.rs
@@ -2,22 +2,26 @@
 //
 // 将 boxlite-ffi 的内部实现暴露为 Go CGo 可调用的 C ABI 函数。
 
-use std::ffi::CString;
+use std::collections::HashMap;
+use std::ffi::{CString, c_void};
 use std::os::raw::{c_char, c_int};
 use std::ptr;
+use std::time::Duration;
 
 use boxlite_ffi::error::{BoxliteErrorCode, FFIError};
 use boxlite_ffi::ops::{
     box_attach, box_create, box_free, box_id, box_inspect_handle, box_list, box_remove, box_start,
-    box_stop, error_free,
+    box_stop, error_free, OutputCallback,
 };
 use boxlite_ffi::runtime::RuntimeHandle;
 
 // Import from boxlite core
+use boxlite::BoxCommand;
 use boxlite::BoxliteOptions;
 use boxlite::BoxliteRuntime;
 use boxlite_ffi::runtime::create_tokio_runtime;
 use boxlite_ffi::runtime::BoxHandle;
+use futures::StreamExt;
 use std::path::PathBuf;
 
 // ============================================================================
@@ -374,5 +378,162 @@ pub unsafe extern "C" fn boxlite_go_box_id(handle: *mut BoxHandle) -> *mut c_cha
 pub unsafe extern "C" fn boxlite_go_box_free(handle: *mut BoxHandle) {
     if !handle.is_null() {
         unsafe { box_free(handle) };
+    }
+}
+
+// ============================================================================
+// BOX EXEC
+// ============================================================================
+
+/// JSON schema for exec options passed from Go.
+#[derive(serde::Deserialize, Default)]
+struct ExecOptsJson {
+    #[serde(default)]
+    args: Vec<String>,
+    #[serde(default)]
+    env: Option<HashMap<String, String>>,
+    #[serde(default)]
+    tty: bool,
+    #[serde(default)]
+    user: Option<String>,
+    #[serde(default)]
+    timeout_secs: Option<f64>,
+    #[serde(default)]
+    working_dir: Option<String>,
+}
+
+/// Execute a command in a box.
+///
+/// Blocks until the command completes. stdout/stderr are streamed
+/// via the callback function during execution.
+///
+/// # Parameters
+/// * `handle` — BoxHandle pointer
+/// * `command` — C string, command to execute
+/// * `opts_json` — JSON string with optional fields:
+///   `{"args":[], "env":{}, "tty":false, "user":"", "timeout_secs":0, "working_dir":""}`
+/// * `callback` — optional output callback: fn(text, stream_type, user_data)
+///   stream_type: 0 = stdout, 1 = stderr
+/// * `user_data` — passed to callback
+/// * `out_exit_code` — output exit code
+/// * `out_err` — output error string (caller must free with boxlite_go_free_string)
+///
+/// Returns 0 on success, -1 on failure.
+///
+/// # Safety
+/// All pointer parameters must be valid or null as described.
+#[no_mangle]
+pub unsafe extern "C" fn boxlite_go_box_exec(
+    handle: *mut BoxHandle,
+    command: *const c_char,
+    opts_json: *const c_char,
+    callback: Option<OutputCallback>,
+    user_data: *mut c_void,
+    out_exit_code: *mut c_int,
+    out_err: *mut *mut c_char,
+) -> c_int {
+    if handle.is_null() {
+        set_error(out_err, "handle is null");
+        return -1;
+    }
+    if out_exit_code.is_null() {
+        set_error(out_err, "out_exit_code is null");
+        return -1;
+    }
+
+    let handle_ref = unsafe { &mut *handle };
+
+    // Parse command
+    let cmd_str = match unsafe { c_str_to_string(command) } {
+        Ok(s) => s,
+        Err(e) => {
+            set_error(out_err, &format!("invalid command: {}", e));
+            return -1;
+        }
+    };
+
+    // Parse opts_json
+    let opts: ExecOptsJson = if !opts_json.is_null() {
+        match unsafe { c_str_to_string(opts_json) } {
+            Ok(json_str) => match serde_json::from_str(&json_str) {
+                Ok(o) => o,
+                Err(e) => {
+                    set_error(out_err, &format!("invalid opts_json: {}", e));
+                    return -1;
+                }
+            },
+            Err(e) => {
+                set_error(out_err, &format!("invalid opts_json string: {}", e));
+                return -1;
+            }
+        }
+    } else {
+        ExecOptsJson::default()
+    };
+
+    // Build BoxCommand
+    let mut cmd = BoxCommand::new(&cmd_str).args(opts.args).tty(opts.tty);
+
+    if let Some(env_map) = opts.env {
+        for (k, v) in env_map {
+            cmd = cmd.env(k, v);
+        }
+    }
+    if let Some(user) = opts.user {
+        cmd = cmd.user(user);
+    }
+    if let Some(secs) = opts.timeout_secs {
+        cmd = cmd.timeout(Duration::from_secs_f64(secs));
+    }
+    if let Some(dir) = opts.working_dir {
+        cmd = cmd.working_dir(dir);
+    }
+
+    // Execute
+    let result = handle_ref.tokio_rt.block_on(async {
+        let mut execution = handle_ref.handle.exec(cmd).await?;
+
+        if let Some(cb) = callback {
+            let mut stdout = execution.stdout();
+            let mut stderr = execution.stderr();
+
+            loop {
+                tokio::select! {
+                    Some(line) = async {
+                        match &mut stdout {
+                            Some(s) => s.next().await,
+                            None => None,
+                        }
+                    } => {
+                        let c_text = CString::new(line).unwrap_or_default();
+                        cb(c_text.as_ptr(), 0, user_data);
+                    }
+                    Some(line) = async {
+                        match &mut stderr {
+                            Some(s) => s.next().await,
+                            None => None,
+                        }
+                    } => {
+                        let c_text = CString::new(line).unwrap_or_default();
+                        cb(c_text.as_ptr(), 1, user_data);
+                    }
+                    else => break,
+                }
+            }
+        }
+
+        let status = execution.wait().await?;
+        Ok::<i32, boxlite::BoxliteError>(status.exit_code)
+    });
+
+    match result {
+        Ok(exit_code) => {
+            unsafe { *out_exit_code = exit_code };
+            0
+        }
+        Err(e) => {
+            set_error(out_err, &format!("{}", e));
+            -1
+        }
     }
 }


### PR DESCRIPTION
## Summary

Add `box.Exec()` method to the Go SDK, enabling command execution inside running boxes with full parameter support.

Closes #198

## Changes

**Three-layer implementation:**

| Layer | Files | What |
|-------|-------|------|
| Rust C Bridge | `rust/src/lib.rs` | `boxlite_go_box_exec` with JSON opts parsing |
| Go CGo Binding | `binding/exec.go`, `exec_bridge.c` | `ExecOptions`/`ExecResult` + `goOutputCallback` |
| Go Client | `client/box.go`, `types.go` | `Box.Exec()` with `time.Duration` timeout conversion |

**`Box.Exec()` supports:**
- `command`, `args`, `env`, `tty`, `user`, `timeout`, `working_dir`
- stdout/stderr streaming via CGo callback
- Returns `ExecResult{ExitCode, Stdout, Stderr}`

**Also includes:**
- `dep_stubs.c` for `BOXLITE_DEPS_STUB=1` test builds
- darwin framework LDFLAGS (`IOKit`, `DiskArbitration`)
- Unit tests + integration test

## Test

```bash
# Unit tests (stub mode)
cd sdks/go && BOXLITE_DEPS_STUB=1 go test ./pkg/client/ -v

# Integration test (requires boxlite runtime)
cd sdks/go && go test ./pkg/client/ -run TestExecIntegration -v
```
