### PR TITLE
refactor(ci): consolidate all compilation caching to sccache

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -13,34 +13,38 @@ This directory contains GitHub Actions workflows for building and publishing Box
         ┌───────────────────────┼───────────────────────┐
         ↓                       ↓                       ↓
 ┌───────────────┐     ┌─────────────────┐     ┌─────────────────┐
-│build-runtime  │     │build-wheels     │     │build-node       │
+│warm-caches    │     │build-wheels     │     │build-node       │
 │               │     │                 │     │                 │
 │ Triggers:     │     │ Triggers:       │     │ Triggers:       │
-│ - boxlite/*   │────→│ - release       │     │ - release       │
-│ - Cargo.*     │     │ - manual        │     │ - manual        │
+│ - push main   │     │ - release       │     │ - release       │
+│ - weekly      │     │ - manual        │     │ - manual        │
 │               │     │                 │     │                 │
-│ Saves to:     │     │ Restores from:  │     │ Restores from:  │
-│ actions/cache │     │ actions/cache   │     │ actions/cache   │
-└───────────────┘     └─────────────────┘     └─────────────────┘
+│ Warms sccache │     │ Uses sccache    │     │ Uses sccache    │
+└───────┬───────┘     └─────────────────┘     └─────────────────┘
+        │ [completed]
+        ↓
+┌───────────────┐
+│build-runtime  │
+│               │
+│ Triggers:     │
+│ - warm-caches │
+│ - release     │
+│ - manual      │
+│               │
+│ Uses sccache  │
+└───────────────┘
 ```
 
-## Key Design: Cache-Based Separation
+## Key Design: sccache Compilation Caching
 
-Instead of artifacts (which only work within a single workflow), we use **`actions/cache`** to share build caches across workflows:
+All Rust compilation is cached via **sccache** using the GHA cache API:
 
-```yaml
-# build-runtime.yml saves:
-key: boxlite-build-{platform}-{hash of core files}
-
-# build-wheels.yml / build-node.yml restore:
-key: boxlite-build-{platform}-{hash of core files}
-restore-keys: boxlite-build-{platform}-  # fallback to latest
-```
-
-**Benefits:**
-- SDK workflows only rebuild runtime on cache miss
-- Same core code = same cache key = instant restore
-- Core changes = different hash = new build
+- Caches individual compilation units (object files) by content hash
+- Works on host runners and inside Docker/manylinux containers
+- Pre-warmed by `warm-caches.yml` on push to main
+- `build-runtime.yml` chains after warm-caches via `workflow_run` for cache hits
+- Requires `CARGO_INCREMENTAL=0` (sccache and incremental compilation are incompatible)
+- Graceful fallback: if sccache fails to set up, builds proceed without caching
 
 ## Workflows
 
@@ -61,7 +65,7 @@ Shared configuration loaded by all workflows.
 Builds BoxLite runtime, uploads to GitHub Release, and publishes Rust crates to crates.io.
 
 **Triggers:**
-- Push to `main` with changes in `boxlite/**`, `Cargo.*`, etc.
+- After `Warm Caches` workflow completes on `main` (via `workflow_run`)
 - Release published
 - Manual dispatch
 
@@ -127,33 +131,24 @@ Runs code quality checks.
 
 ## Trigger Behavior
 
-| Change | build-runtime | build-wheels | build-node |
-|--------|---------------|--------------|------------|
-| `boxlite/**` | ✅ Runs | ❌ Skips | ❌ Skips |
-| `sdks/python/**` | ❌ Skips | ❌ Skips | ❌ Skips |
-| `sdks/node/**` | ❌ Skips | ❌ Skips | ❌ Skips |
-| Release published | ✅ Runs (build + upload + publish crates) | ✅ Runs | ✅ Runs |
+| Change | warm-caches | build-runtime | build-wheels | build-node |
+|--------|-------------|---------------|--------------|------------|
+| `boxlite/**` | ✅ Runs | ✅ Chains after warm-caches | ❌ Skips | ❌ Skips |
+| `sdks/python/**` | ❌ Skips | ❌ Skips | ❌ Skips | ❌ Skips |
+| `sdks/node/**` | ❌ Skips | ❌ Skips | ❌ Skips | ❌ Skips |
+| Release published | ❌ Skips | ✅ Runs directly | ✅ Runs | ✅ Runs |
 
 ## Cache Strategy
 
-### Runtime Cache
+### Compilation Cache (sccache)
 
-```yaml
-key: boxlite-build-{platform}-{hashFiles('boxlite/**', 'Cargo.lock', ...)}
-```
+All Rust compilation is cached via sccache using the GHA cache API:
 
-- **Same core code** → Cache hit → Skip rebuild (~8 min saved)
-- **Core changed** → Cache miss → Rebuild runtime
-
-### Rust Dependencies Cache (Swatinem/rust-cache)
-
-```yaml
-shared-key: "boxlite"  # Shared across all workflows
-```
-
-- Caches `~/.cargo` and `./target` directories
-- Shared across workflow runs
-- Invalidates on Cargo.lock changes
+- Caches individual compilation units (object files)
+- Works on host runners and inside Docker containers
+- Pre-warmed by the `warm-caches.yml` workflow on push to main
+- Requires `CARGO_INCREMENTAL=0` (sccache and incremental compilation are incompatible)
+- Graceful fallback: if sccache fails to set up, builds proceed without caching
 
 ## Platform Matrix
 
@@ -203,14 +198,14 @@ make dev:node
 ## Troubleshooting
 
 **Cache miss when expected hit:**
-- Check if core files changed (hash is different)
-- Caches expire after 7 days of non-use
+- sccache caches expire after 7 days of non-use (weekly warm-caches schedule prevents this)
 - Branch-based cache isolation may apply
+- Check sccache stats in build logs for hit/miss rates
 
-**Runtime binaries missing:**
-- Fallback build runs automatically on cache miss
-- Check logs for "Runtime cache miss - building runtime"
-- Verify submodules initialized
+**Build taking too long:**
+- Check sccache stats — low hit rate means cache is cold
+- Verify warm-caches workflow completed successfully before build-runtime
+- Check GHA cache usage (Settings > Actions > Caches) for eviction
 
 **Node.js package install fails:**
 - Platform package must be installed before main package
@@ -218,7 +213,6 @@ make dev:node
 
 ## References
 
-- [GitHub Actions Cache](https://github.com/actions/cache)
-- [Swatinem/rust-cache](https://github.com/Swatinem/rust-cache)
+- [mozilla-actions/sccache-action](https://github.com/mozilla-actions/sccache-action)
 - [cibuildwheel](https://cibuildwheel.readthedocs.io/)
 - [napi-rs](https://napi.rs/)

--- a/.github/workflows/build-node.yml
+++ b/.github/workflows/build-node.yml
@@ -20,6 +20,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: '0'
 
 jobs:
   config:
@@ -64,22 +65,14 @@ jobs:
         with:
           toolchain: ${{ needs.config.outputs.rust-toolchain }}
 
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: "boxlite"
-          save-if: false
-
       # sccache caches individual compilation units via GHA cache API.
-      # Works inside Docker containers (unlike Swatinem/rust-cache).
+      # Works on host and inside Docker containers.
       # Cache is pre-warmed by the Warm Caches workflow on push to main.
       - name: Setup sccache
-        if: runner.os == 'Linux'
         uses: mozilla-actions/sccache-action@v0.0.9
         continue-on-error: true
 
       - name: Export GHA cache env vars
-        if: runner.os == 'Linux'
         uses: actions/github-script@v7
         with:
           script: |
@@ -104,7 +97,7 @@ jobs:
           mkdir -p ".cache/$GUEST_TARGET/release"
           cp "target/$GUEST_TARGET/release/boxlite-guest" ".cache/$GUEST_TARGET/release/"
 
-          # Clean up to save disk space (keep target/ dir for rust-cache post-step)
+          # Clean up to save disk space (sccache stores compilation cache separately)
           rm -rf target ~/.rustup ~/.cargo
           mkdir -p target
 
@@ -167,6 +160,8 @@ jobs:
           npm install --silent
           npm run build:native -- --release
           npm run artifacts
+
+          command -v sccache &>/dev/null && sccache --show-stats || true
 
       # Create tar archive to preserve Unix file permissions (especially execute bits).
       # GitHub Actions upload-artifact uses ZIP which doesn't preserve permissions.

--- a/.github/workflows/build-runtime.yml
+++ b/.github/workflows/build-runtime.yml
@@ -1,7 +1,7 @@
 # Build BoxLite core runtime, upload artifacts, and publish to crates.io.
 #
 # This workflow builds the Rust runtime and populates the shared cache.
-# On push to main: builds and caches (existing behavior).
+# On push to main: chains after Warm Caches workflow for sccache hits.
 # On release: builds, uploads runtime tarballs to GitHub Release, and publishes
 #   Rust crates to crates.io (requires CARGO_REGISTRY_TOKEN secret).
 #
@@ -16,22 +16,17 @@
 name: Build Runtime
 
 on:
-  push:
+  workflow_run:
+    workflows: ["Warm Caches"]
+    types: [completed]
     branches: [main]
-    paths:
-      - 'boxlite/**'
-      - 'boxlite-shared/**'
-      - 'guest/**'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - '.github/workflows/build-runtime.yml'
-      - '.github/workflows/config.yml'
   release:
     types: [published]
   workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: '0'
   SKIP_INSTALL_NODEJS: '1'
 
 jobs:
@@ -41,6 +36,9 @@ jobs:
   build:
     name: Build Runtime (${{ matrix.target }})
     needs: config
+    if: >-
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.conclusion == 'success'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -57,23 +55,14 @@ jobs:
         with:
           toolchain: ${{ needs.config.outputs.rust-toolchain }}
 
-      # Cache Rust dependencies (used by guest build on Linux, full build on macOS)
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: "boxlite"
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-
       # sccache caches individual compilation units via GHA cache API.
-      # Works inside Docker containers (unlike Swatinem/rust-cache).
+      # Works on host and inside Docker containers.
       # Cache is pre-warmed by the Warm Caches workflow on push to main.
       - name: Setup sccache
-        if: runner.os == 'Linux'
         uses: mozilla-actions/sccache-action@v0.0.9
         continue-on-error: true
 
       - name: Export GHA cache env vars
-        if: runner.os == 'Linux'
         uses: actions/github-script@v7
         with:
           script: |
@@ -98,7 +87,7 @@ jobs:
           mkdir -p ".cache/$GUEST_TARGET/release"
           cp "target/$GUEST_TARGET/release/boxlite-guest" ".cache/$GUEST_TARGET/release/"
 
-          # Clean up to save disk space (keep target/ dir for rust-cache post-step)
+          # Clean up to save disk space (sccache stores compilation cache separately)
           rm -rf target ~/.rustup ~/.cargo
           mkdir -p target
 

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   SKIP_INSTALL_NODEJS: '1'
+  CARGO_INCREMENTAL: '0'
 
 jobs:
   # Load shared configuration
@@ -33,30 +34,20 @@ jobs:
         with:
           toolchain: ${{ needs.config.outputs.rust-toolchain }}
 
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: "boxlite"
-          save-if: false  # Workflow deletes cache after guest build
-
       # sccache caches individual compilation units via GHA cache API.
-      # Works inside cibuildwheel's manylinux containers via environment-pass.
+      # Works on host and inside cibuildwheel's manylinux containers.
       # Cache is pre-warmed by the Warm Caches workflow on push to main.
       - name: Setup sccache
-        if: runner.os == 'Linux'
         uses: mozilla-actions/sccache-action@v0.0.9
         continue-on-error: true
 
       - name: Export GHA cache env vars
-        if: runner.os == 'Linux'
         uses: actions/github-script@v7
         with:
           script: |
             core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
             core.exportVariable('ACTIONS_CACHE_SERVICE_V2', process.env.ACTIONS_CACHE_SERVICE_V2 || '');
-            core.exportVariable('SCCACHE_GHA_ENABLED', 'true');
-            core.exportVariable('RUSTC_WRAPPER', 'sccache');
 
       # Build guest on host BEFORE cibuildwheel container because:
       # - manylinux (AlmaLinux/RHEL) doesn't have musl packages in repos
@@ -75,7 +66,7 @@ jobs:
           mkdir -p ".cache/$GUEST_TARGET/release"
           cp "target/$GUEST_TARGET/release/boxlite-guest" ".cache/$GUEST_TARGET/release/"
 
-          # Clean up to save disk space (keep target/ dir for rust-cache post-step)
+          # Clean up to save disk space (sccache stores compilation cache separately)
           rm -rf target ~/.rustup ~/.cargo
           mkdir -p target
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -135,6 +135,19 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install protobuf
 
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+        continue-on-error: true
+
+      - name: Export GHA cache env vars
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+            core.exportVariable('ACTIONS_CACHE_SERVICE_V2', process.env.ACTIONS_CACHE_SERVICE_V2 || '');
+            core.exportVariable('CARGO_INCREMENTAL', '0');
+
       - name: Run clippy checks
         run: make clippy
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: '0'
 
 jobs:
   # Load shared configuration
@@ -112,11 +113,6 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
 
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: boxlite-test
-
       - name: Run Rust unit tests with coverage
         # Only test boxlite-shared - boxlite requires libkrun/libgvproxy not available in CI
         run: cargo llvm-cov nextest -p boxlite-shared --lib --profile ci --lcov --output-path lcov.info
@@ -160,10 +156,17 @@ jobs:
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
 
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+        continue-on-error: true
+
+      - name: Export GHA cache env vars
+        uses: actions/github-script@v7
         with:
-          shared-key: boxlite-test
+          script: |
+            core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+            core.exportVariable('ACTIONS_CACHE_SERVICE_V2', process.env.ACTIONS_CACHE_SERVICE_V2 || '');
 
       - name: Run boxlite-cli unit tests
         # Only run tests in src/ (name contains "::tests::"); skip integration tests in tests/ (require VM)
@@ -263,10 +266,17 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install protobuf
 
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+        continue-on-error: true
+
+      - name: Export GHA cache env vars
+        uses: actions/github-script@v7
         with:
-          shared-key: boxlite-test
+          script: |
+            core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+            core.exportVariable('ACTIONS_CACHE_SERVICE_V2', process.env.ACTIONS_CACHE_SERVICE_V2 || '');
 
       - name: Run Go unit tests (stub mode)
         working-directory: sdks/go

--- a/.github/workflows/warm-caches.yml
+++ b/.github/workflows/warm-caches.yml
@@ -1,12 +1,11 @@
-# Pre-warm sccache for all workflows that build Rust inside manylinux Docker containers.
+# Pre-warm sccache for all workflows that build Rust code.
 #
 # Problem: Three workflows (build-runtime, build-node, build-wheels) independently
-# compile the same Rust code inside Docker, where Swatinem/rust-cache can't reach.
-# This results in ~20 min cold compiles per workflow on every run.
+# compile the same Rust code. Without a warm cache, each faces ~20 min cold compiles.
 #
 # Solution: sccache caches individual compilation units via the GHA cache API,
-# which works inside Docker containers. This workflow warms the cache on push to
-# main so that subsequent workflow runs get cache hits.
+# which works on host runners and inside Docker containers. This workflow warms
+# the cache on push to main so that subsequent workflow runs get cache hits.
 #
 # Pattern inspired by Bevy's cache warmup workflow.
 name: Warm Caches
@@ -21,6 +20,8 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - '.github/workflows/warm-caches.yml'
+      - '.github/workflows/build-runtime.yml'
+      - '.github/workflows/config.yml'
   schedule:
     - cron: '0 1 * * 1'  # Weekly Monday 1 AM UTC (prevents 7-day GHA cache eviction)
   workflow_dispatch:

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -108,7 +108,7 @@ test-command = "python -c 'import boxlite; print(boxlite.__version__)'"
 
 [tool.cibuildwheel.macos]
 # Fix "libkrunfw.4.dylib has a minimum target of 14.0" error
-environment = { MACOSX_DEPLOYMENT_TARGET = "14.0", _PYTHON_HOST_PLATFORM = "macosx_14_0_arm64", PATH = "$HOME/.cargo/bin:$PATH" }
+environment = { MACOSX_DEPLOYMENT_TARGET = "14.0", _PYTHON_HOST_PLATFORM = "macosx_14_0_arm64", PATH = "$HOME/.cargo/bin:$PATH", CARGO_INCREMENTAL = "0" }
 
 repair-wheel-command = ""  # Skip auditwheel repair
 


### PR DESCRIPTION
## Summary

- **Remove Swatinem/rust-cache** from all workflows (build-runtime, build-wheels, build-node, test) and standardize on **sccache** as the sole compilation cache
- **Extend sccache to macOS** (previously Linux-only) by removing platform conditions from sccache setup and GHA env export steps
- **Add sccache to lint and test workflows**: clippy job (lint.yml), cli and go jobs (test.yml)
- **Chain build-runtime after warm-caches** via `workflow_run` trigger so builds benefit from warm cache
- **Fix build-wheels.yml**: remove explicit `SCCACHE_GHA_ENABLED`/`RUSTC_WRAPPER` from Export step to prevent macOS failures when sccache-action fails with `continue-on-error`

## Why

Two caching systems (Swatinem + sccache) created redundancy:
- sccache already caches all compilation work (the expensive part)
- Swatinem doesn't work inside Docker/manylinux containers (the main bottleneck)
- Both compete for the 10GB GHA cache limit

Trade-off: Cargo dependencies are re-downloaded each run (~30-60s) since Swatinem cached `~/.cargo`, but compilation (5-20 min) is the real bottleneck that sccache addresses.

## Test plan

- [ ] YAML validation passes for all 6 workflow files
- [ ] Open PR touching Rust code triggers `test.yml` and `lint.yml` — verify sccache stats in cli, go, and clippy jobs
- [ ] Manual `workflow_dispatch` on `build-runtime.yml` — verify macOS sccache stats appear
- [ ] After merge: verify Warm Caches → Build Runtime chain works via `workflow_run`
- [ ] Verify `rust` test job (llvm-cov) works without sccache (no RUSTC_WRAPPER conflict)
- [ ] Check GHA cache (Settings > Actions > Caches) — Swatinem `rust-cache-*` entries should stop being created