### PR TITLE
fix: prevent snapshot COW child disks from being deleted by Disk::Drop

### DIFF
--- a/boxlite/src/litebox/local_snapshot.rs
+++ b/boxlite/src/litebox/local_snapshot.rs
@@ -245,56 +245,19 @@ impl LocalSnapshotBackend {
             BoxliteError::Storage(format!("Failed to move container disk to snapshot: {}", e))
         })?;
 
-        if let Err(e) = Qcow2Helper::create_cow_child_disk(
+        match Qcow2Helper::create_cow_child_disk(
             &snap_container,
             BackingFormat::Qcow2,
             container_disk,
             container_virtual_size,
         ) {
-            let mut rollback_errors = Vec::new();
-            if let Err(re) = std::fs::rename(&snap_container, container_disk) {
-                rollback_errors.push(format!("restore container disk: {}", re));
+            Ok(disk) => {
+                disk.leak();
             }
-            if let Err(re) = std::fs::remove_dir_all(&snapshot_dir) {
-                rollback_errors.push(format!("remove snapshot dir: {}", re));
-            }
-            if !rollback_errors.is_empty() {
-                tracing::error!(
-                    box_id = %self.inner.id(),
-                    rollback_errors = ?rollback_errors,
-                    "Snapshot rollback partially failed"
-                );
-                return Err(BoxliteError::Storage(format!(
-                    "Snapshot failed AND rollback partially failed: {}. Original error: {}. Box may need manual recovery.",
-                    rollback_errors.join("; "),
-                    e
-                )));
-            }
-            let _ = std::fs::remove_file(&pending_marker);
-            return Err(e);
-        }
-
-        if guest_disk.exists() {
-            let snap_guest = snapshot_dir.join(disk_filenames::GUEST_ROOTFS_DISK);
-            std::fs::rename(guest_disk, &snap_guest).map_err(|e| {
-                BoxliteError::Storage(format!("Failed to move guest disk to snapshot: {}", e))
-            })?;
-
-            if let Err(e) = Qcow2Helper::create_cow_child_disk(
-                &snap_guest,
-                BackingFormat::Qcow2,
-                guest_disk,
-                guest_virtual_size,
-            ) {
+            Err(e) => {
                 let mut rollback_errors = Vec::new();
-                if let Err(re) = std::fs::remove_file(container_disk) {
-                    rollback_errors.push(format!("remove container COW child: {}", re));
-                }
                 if let Err(re) = std::fs::rename(&snap_container, container_disk) {
                     rollback_errors.push(format!("restore container disk: {}", re));
-                }
-                if let Err(re) = std::fs::rename(&snap_guest, guest_disk) {
-                    rollback_errors.push(format!("restore guest disk: {}", re));
                 }
                 if let Err(re) = std::fs::remove_dir_all(&snapshot_dir) {
                     rollback_errors.push(format!("remove snapshot dir: {}", re));
@@ -313,6 +276,53 @@ impl LocalSnapshotBackend {
                 }
                 let _ = std::fs::remove_file(&pending_marker);
                 return Err(e);
+            }
+        }
+
+        if guest_disk.exists() {
+            let snap_guest = snapshot_dir.join(disk_filenames::GUEST_ROOTFS_DISK);
+            std::fs::rename(guest_disk, &snap_guest).map_err(|e| {
+                BoxliteError::Storage(format!("Failed to move guest disk to snapshot: {}", e))
+            })?;
+
+            match Qcow2Helper::create_cow_child_disk(
+                &snap_guest,
+                BackingFormat::Qcow2,
+                guest_disk,
+                guest_virtual_size,
+            ) {
+                Ok(disk) => {
+                    disk.leak();
+                }
+                Err(e) => {
+                    let mut rollback_errors = Vec::new();
+                    if let Err(re) = std::fs::remove_file(container_disk) {
+                        rollback_errors.push(format!("remove container COW child: {}", re));
+                    }
+                    if let Err(re) = std::fs::rename(&snap_container, container_disk) {
+                        rollback_errors.push(format!("restore container disk: {}", re));
+                    }
+                    if let Err(re) = std::fs::rename(&snap_guest, guest_disk) {
+                        rollback_errors.push(format!("restore guest disk: {}", re));
+                    }
+                    if let Err(re) = std::fs::remove_dir_all(&snapshot_dir) {
+                        rollback_errors.push(format!("remove snapshot dir: {}", re));
+                    }
+                    if !rollback_errors.is_empty() {
+                        tracing::error!(
+                            box_id = %self.inner.id(),
+                            rollback_errors = ?rollback_errors,
+                            "Snapshot rollback partially failed"
+                        );
+                        return Err(BoxliteError::Storage(format!(
+                            "Snapshot failed AND rollback partially failed: {}. Original error: {}. Box may need manual recovery.",
+                            rollback_errors.join("; "),
+                            e
+                        )));
+                    }
+                    let _ = std::fs::remove_file(&pending_marker);
+                    return Err(e);
+                }
             }
         }
 
@@ -367,7 +377,8 @@ impl LocalSnapshotBackend {
             BackingFormat::Qcow2,
             &container_disk,
             info.container_disk_bytes,
-        )?;
+        )?
+        .leak();
 
         let guest_disk = box_home.join(disk_filenames::GUEST_ROOTFS_DISK);
         let snap_guest = snapshot_dir.join(disk_filenames::GUEST_ROOTFS_DISK);
@@ -384,7 +395,8 @@ impl LocalSnapshotBackend {
                 BackingFormat::Qcow2,
                 &guest_disk,
                 info.guest_disk_bytes,
-            )?;
+            )?
+            .leak();
         }
 
         tracing::info!(

--- a/boxlite/tests/snapshot.rs
+++ b/boxlite/tests/snapshot.rs
@@ -1,0 +1,290 @@
+//! Integration tests for snapshot create and restore operations.
+//!
+//! These tests verify that snapshot operations preserve bootable box state,
+//! specifically that COW child disks are not deleted by `Disk::Drop` after
+//! `create_cow_child_disk()` (which returns `Disk { persistent: false }`).
+//!
+//! Requires a real VM runtime (alpine:latest image).
+//! Run with:
+//!
+//! ```sh
+//! cargo test -p boxlite --test snapshot
+//! ```
+
+mod common;
+
+use std::path::{Path, PathBuf};
+
+use boxlite::runtime::options::BoxliteOptions;
+use boxlite::{BoxCommand, BoxliteRuntime, LiteBox, SnapshotOptions};
+use tokio_stream::StreamExt;
+
+// ============================================================================
+// LOCAL HELPERS
+// ============================================================================
+
+/// Disk filenames matching `boxlite::disk::constants::filenames`.
+const CONTAINER_DISK: &str = "disk.qcow2";
+const GUEST_ROOTFS_DISK: &str = "guest-rootfs.qcow2";
+const SNAPSHOTS_DIR: &str = "snapshots";
+
+/// Return the box directory path: `{home}/boxes/{box_id}`.
+fn box_dir(home: &Path, box_id: &str) -> PathBuf {
+    home.join("boxes").join(box_id)
+}
+
+/// Return the snapshot directory path: `{home}/boxes/{box_id}/snapshots/{name}`.
+fn snapshot_dir(home: &Path, box_id: &str, name: &str) -> PathBuf {
+    box_dir(home, box_id).join(SNAPSHOTS_DIR).join(name)
+}
+
+/// Exec a command, collect stdout, assert exit code 0.
+async fn exec_stdout(handle: &LiteBox, cmd: BoxCommand) -> String {
+    let mut execution = handle.exec(cmd).await.expect("exec failed");
+
+    let mut stdout = String::new();
+    if let Some(mut stream) = execution.stdout() {
+        while let Some(chunk) = stream.next().await {
+            stdout.push_str(&chunk);
+        }
+    }
+
+    let result = execution.wait().await.expect("wait failed");
+    assert_eq!(result.exit_code, 0, "command should exit 0");
+    stdout
+}
+
+/// Create a box from alpine:latest, start it, stop it, return it ready for snapshot operations.
+async fn create_stopped_box(runtime: &BoxliteRuntime) -> LiteBox {
+    let litebox = runtime
+        .create(common::alpine_opts(), Some("test-box".to_string()))
+        .await
+        .expect("Failed to create box");
+
+    // Start and stop to ensure disk state is populated.
+    litebox.start().await.expect("Failed to start box");
+    litebox.stop().await.expect("Failed to stop box");
+
+    litebox
+}
+
+// ============================================================================
+// SNAPSHOT CREATE — disk integrity
+// ============================================================================
+
+#[tokio::test]
+async fn test_cow_child_disks_exist_after_snapshot_create() {
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+    let litebox = create_stopped_box(&runtime).await;
+    let box_id = litebox.id().to_string();
+
+    // Precondition: disks exist before snapshot.
+    let bdir = box_dir(&home.path, &box_id);
+    assert!(
+        bdir.join(CONTAINER_DISK).exists(),
+        "container disk missing before snapshot"
+    );
+    assert!(
+        bdir.join(GUEST_ROOTFS_DISK).exists(),
+        "guest disk missing before snapshot"
+    );
+
+    let info = litebox
+        .snapshots()
+        .create(SnapshotOptions::default(), "ckpt1")
+        .await
+        .expect("snapshot create failed");
+    assert_eq!(info.name, "ckpt1");
+
+    // Snapshot copies must exist in the snapshot directory.
+    let sdir = snapshot_dir(&home.path, &box_id, "ckpt1");
+    assert!(
+        sdir.join(CONTAINER_DISK).exists(),
+        "snapshot container disk missing"
+    );
+    assert!(
+        sdir.join(GUEST_ROOTFS_DISK).exists(),
+        "snapshot guest disk missing"
+    );
+
+    // COW child disks in the box directory must still exist.
+    // Bug: create_cow_child_disk() returns Disk(persistent=false); if the caller
+    // does not call .leak(), Disk::Drop deletes the newly created file.
+    assert!(
+        bdir.join(CONTAINER_DISK).exists(),
+        "COW child disk.qcow2 deleted by Disk::Drop (missing .leak() in local_snapshot.rs)"
+    );
+    assert!(
+        bdir.join(GUEST_ROOTFS_DISK).exists(),
+        "COW child guest-rootfs.qcow2 deleted by Disk::Drop (missing .leak() in local_snapshot.rs)"
+    );
+
+    let _ = runtime.shutdown(Some(common::TEST_SHUTDOWN_TIMEOUT)).await;
+}
+
+// ============================================================================
+// SNAPSHOT CREATE — box restartable
+// ============================================================================
+
+#[tokio::test]
+async fn test_box_restartable_after_snapshot_create() {
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+    let litebox = create_stopped_box(&runtime).await;
+
+    litebox
+        .snapshots()
+        .create(SnapshotOptions::default(), "restart_test")
+        .await
+        .expect("snapshot create failed");
+
+    // Box must be restartable after snapshot create.
+    litebox
+        .start()
+        .await
+        .expect("start after snapshot create failed");
+
+    let cmd = BoxCommand::new("echo").args(["alive"]);
+    let mut exec = litebox.exec(cmd).await.expect("exec failed");
+    let result = exec.wait().await.expect("wait failed");
+    assert_eq!(
+        result.exit_code, 0,
+        "box should be functional after snapshot create"
+    );
+
+    litebox.stop().await.expect("stop failed");
+
+    let _ = runtime.shutdown(Some(common::TEST_SHUTDOWN_TIMEOUT)).await;
+}
+
+// ============================================================================
+// SNAPSHOT RESTORE — disk integrity
+// ============================================================================
+
+#[tokio::test]
+async fn test_cow_child_disks_exist_after_snapshot_restore() {
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+    let litebox = create_stopped_box(&runtime).await;
+    let box_id = litebox.id().to_string();
+
+    litebox
+        .snapshots()
+        .create(SnapshotOptions::default(), "v1")
+        .await
+        .expect("snapshot create failed");
+
+    litebox
+        .snapshots()
+        .restore("v1")
+        .await
+        .expect("snapshot restore failed");
+
+    // COW child disks in the box directory must exist after restore.
+    let bdir = box_dir(&home.path, &box_id);
+    assert!(
+        bdir.join(CONTAINER_DISK).exists(),
+        "COW child disk.qcow2 deleted by Disk::Drop after restore (missing .leak())"
+    );
+    assert!(
+        bdir.join(GUEST_ROOTFS_DISK).exists(),
+        "COW child guest-rootfs.qcow2 deleted by Disk::Drop after restore (missing .leak())"
+    );
+
+    let _ = runtime.shutdown(Some(common::TEST_SHUTDOWN_TIMEOUT)).await;
+}
+
+// ============================================================================
+// SNAPSHOT RESTORE — box startable
+// ============================================================================
+
+#[tokio::test]
+async fn test_box_startable_after_snapshot_restore() {
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+    let litebox = create_stopped_box(&runtime).await;
+
+    // Write marker, snapshot, then restore.
+    litebox.start().await.expect("start failed");
+    let cmd = BoxCommand::new("sh").args(["-c", "echo RESTORE_V1 > /root/ver.txt"]);
+    let mut exec = litebox.exec(cmd).await.expect("exec failed");
+    exec.wait().await.expect("wait failed");
+    litebox.stop().await.expect("stop failed");
+
+    litebox
+        .snapshots()
+        .create(SnapshotOptions::default(), "restore_boot_test")
+        .await
+        .expect("snapshot create failed");
+
+    litebox
+        .snapshots()
+        .restore("restore_boot_test")
+        .await
+        .expect("snapshot restore failed");
+
+    // Box must be startable after restore, with snapshot state intact.
+    litebox.start().await.expect("start after restore failed");
+
+    let out = exec_stdout(&litebox, BoxCommand::new("cat").args(["/root/ver.txt"])).await;
+    assert_eq!(
+        out.trim(),
+        "RESTORE_V1",
+        "snapshot restore should preserve filesystem state"
+    );
+
+    litebox.stop().await.expect("stop failed");
+
+    let _ = runtime.shutdown(Some(common::TEST_SHUTDOWN_TIMEOUT)).await;
+}
+
+// ============================================================================
+// SNAPSHOT METADATA — persistence
+// ============================================================================
+
+#[tokio::test]
+async fn test_snapshot_list_returns_created_snapshot() {
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+    let litebox = create_stopped_box(&runtime).await;
+
+    litebox
+        .snapshots()
+        .create(SnapshotOptions::default(), "persist_test")
+        .await
+        .expect("snapshot create failed");
+
+    let snapshots = litebox
+        .snapshots()
+        .list()
+        .await
+        .expect("snapshot list failed");
+
+    assert!(
+        snapshots.iter().any(|s| s.name == "persist_test"),
+        "created snapshot not found in list"
+    );
+
+    let _ = runtime.shutdown(Some(common::TEST_SHUTDOWN_TIMEOUT)).await;
+}


### PR DESCRIPTION
## Impact

**All snapshot operations are broken.** After `snapshot.create()` or `snapshot.restore()`, the box becomes un-startable — the operation returns success, but the box's disk files (`disk.qcow2`, `guest-rootfs.qcow2`) are silently deleted within the same function call. The next `box.start()` fails because the required disk files no longer exist.

- **Affected**: `LiteBox::snapshots().create()`, `LiteBox::snapshots().restore()`
- **Not affected**: clone, export (they already call `.leak()` correctly)
- **Reproducibility**: 100% — every snapshot operation triggers the bug

## Root cause

`Disk` is an RAII type (`boxlite/src/disk/image.rs`) that deletes its file on drop when `persistent=false`. `create_cow_child_disk()` always returns `Disk { persistent: false }`. Callers must call `.leak()` to prevent the destructor from deleting the file.

In `local_snapshot.rs`, all 4 calls to `create_cow_child_disk()` neglect to call `.leak()`:

- `do_snapshot_create()` uses `if let Err(e) = create_cow_child_disk(...)` — the `Ok(Disk)` is never bound, so it drops immediately
- `do_snapshot_restore()` uses `create_cow_child_disk(...)?;` — the `Disk` is unwrapped by `?` then dropped at the semicolon

Every other call site in the codebase handles this correctly:
- `container_rootfs.rs:233` — `temp_disk.leak()`
- `guest_rootfs.rs:150` — `temp_disk.leak()`
- `qcow2.rs:827,833` (`clone_disk_pair`) — `create_cow_child_disk(...)?.leak()`

## Fix

Add `.leak()` to all 4 `create_cow_child_disk()` return values in `local_snapshot.rs`:

| Location | Change |
|----------|--------|
| `do_snapshot_create()` container disk (L248) | `if let Err` → `match` with `Ok(disk) => { disk.leak(); }`, error branch keeps rollback |
| `do_snapshot_create()` guest disk (L288) | Same `match` pattern, error branch keeps full rollback including container cleanup |
| `do_snapshot_restore()` container disk (L375) | `)?;` → `)?.leak();` |
| `do_snapshot_restore()` guest disk (L393) | `)?;` → `)?.leak();` |

## Tests

Added `boxlite/tests/snapshot.rs` — 5 integration tests following `clone_export_import.rs` conventions:

| Test | Assertion type | Verifies |
|------|---------------|----------|
| `test_cow_child_disks_exist_after_snapshot_create` | Filesystem | `disk.qcow2` and `guest-rootfs.qcow2` exist in box dir after create |
| `test_box_restartable_after_snapshot_create` | Functional | Box starts and runs `echo alive` after create |
| `test_cow_child_disks_exist_after_snapshot_restore` | Filesystem | Both disks exist after restore |
| `test_box_startable_after_snapshot_restore` | Functional | Box starts after restore, `cat /root/ver.txt` returns snapshot content |
| `test_snapshot_list_returns_created_snapshot` | Metadata | Snapshot appears in `list()` after create |

Uses `PerTestBoxHome::new()` for isolation, public `LiteBox::snapshots()` API. VM integration tests require `make runtime-debug`.

## CI results (same commit `ac6f182`, run on fork)

| Check | Platform | Result |
|-------|----------|--------|
| Rust formatting (`cargo fmt --check`) | ubuntu | pass |
| Clippy (`cargo clippy -- -D warnings`) | ubuntu | pass |
| Clippy | macos-15 (ARM64) | pass |
| Rust Tests (`boxlite-shared` unit) | linux-x64-gnu | pass |
| Rust Tests (`boxlite-shared` unit) | darwin-arm64 | pass |

Full CI run: https://github.com/acmerfight/boxlite/actions/runs/22585287612

## Local verification

- `cargo fmt --check` — pass
- `cargo clippy -p boxlite --tests -- -D warnings` — 0 warnings
- `cargo test -p boxlite --lib -- litebox::local_snapshot` — 12/12 unit tests pass
- `cargo test -p boxlite --test snapshot` — requires VM runtime (`make runtime-debug`)