### PR TITLE
fix(macos): re-sign boxlite-shim with hypervisor entitlement after extraction

### DIFF
--- a/boxlite/src/runtime/embedded.rs
+++ b/boxlite/src/runtime/embedded.rs
@@ -106,6 +106,12 @@ impl EmbeddedRuntime {
             Self::set_permissions(&path, name)?;
         }
 
+        // macOS: re-sign boxlite-shim with hypervisor entitlement.
+        // The shim may have lost its codesign during cargo rebuild (build.rs
+        // rerun triggers re-link, which strips the ad-hoc signature).
+        #[cfg(target_os = "macos")]
+        Self::sign_shim_if_needed(&tmp)?;
+
         // Stamp marks extraction as complete — checked by the fast path above.
         std::fs::write(tmp.join(".complete"), crate::VERSION)
             .map_err(|e| BoxliteError::Storage(format!("write stamp: {}", e)))?;
@@ -168,6 +174,53 @@ impl EmbeddedRuntime {
     }
 
     // ── Helpers ─────────────────────────────────────────────────────
+
+    /// Sign `boxlite-shim` with macOS Hypervisor.framework entitlement.
+    ///
+    /// The shim calls into Hypervisor.framework which requires the
+    /// `com.apple.security.hypervisor` entitlement.  Build-system re-links
+    /// can strip the ad-hoc signature added by `make runtime-debug`, so we
+    /// re-sign unconditionally after extraction.
+    #[cfg(target_os = "macos")]
+    fn sign_shim_if_needed(dir: &Path) -> BoxliteResult<()> {
+        let shim = dir.join("boxlite-shim");
+        if !shim.exists() {
+            return Ok(());
+        }
+
+        let entitlements = "\
+            <?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+            <!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \
+            \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n\
+            <plist version=\"1.0\">\n\
+            <dict>\n\
+            \t<key>com.apple.security.hypervisor</key>\n\
+            \t<true/>\n\
+            \t<key>com.apple.security.cs.disable-library-validation</key>\n\
+            \t<true/>\n\
+            </dict>\n\
+            </plist>";
+
+        let tmp_plist = dir.join(".entitlements.plist");
+        std::fs::write(&tmp_plist, entitlements)
+            .map_err(|e| BoxliteError::Storage(format!("write entitlements: {}", e)))?;
+
+        let output = std::process::Command::new("codesign")
+            .args(["-s", "-", "--force", "--entitlements"])
+            .arg(&tmp_plist)
+            .arg(&shim)
+            .output()
+            .map_err(|e| BoxliteError::Storage(format!("codesign exec: {}", e)))?;
+
+        let _ = std::fs::remove_file(&tmp_plist);
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            tracing::warn!("codesign failed (non-fatal): {}", stderr);
+        }
+
+        Ok(())
+    }
 
     fn versioned_dir() -> BoxliteResult<PathBuf> {
         let data_dir = dirs::data_local_dir()
@@ -249,6 +302,39 @@ mod tests {
                 "Debug build dir should include hash suffix"
             );
         }
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn sign_shim_if_needed_signs_binary() {
+        let tmp = tempfile::tempdir().unwrap();
+        let shim = tmp.path().join("boxlite-shim");
+
+        // Create a minimal Mach-O executable (copy /usr/bin/true as a stand-in)
+        std::fs::copy("/usr/bin/true", &shim).unwrap();
+
+        EmbeddedRuntime::sign_shim_if_needed(tmp.path()).unwrap();
+
+        // Verify codesign added the hypervisor entitlement
+        let output = std::process::Command::new("codesign")
+            .args(["-d", "--entitlements", "-", "--xml"])
+            .arg(&shim)
+            .output()
+            .unwrap();
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            stdout.contains("com.apple.security.hypervisor"),
+            "Expected hypervisor entitlement in codesign output, got: {}",
+            stdout
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn sign_shim_if_needed_skips_missing_shim() {
+        let tmp = tempfile::tempdir().unwrap();
+        // No boxlite-shim file — should return Ok(()) without error
+        EmbeddedRuntime::sign_shim_if_needed(tmp.path()).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- macOS 上 `make runtime-debug` 对 `boxlite-shim` 签名添加 `com.apple.security.hypervisor` entitlement，但随后 `cargo test` 重新编译时 shim 被 re-link，签名丢失，导致所有 Rust VM 集成测试失败（shim 无法调用 Hypervisor.framework）
- 在 `EmbeddedRuntime::extract()` 提取文件后、写 `.complete` stamp 之前，对 `boxlite-shim` 重新 codesign，确保提取出的 shim 始终带有正确的 entitlement
- 添加两个 macOS-only 单元测试验证签名行为

## Problem

两个 build.rs 的 `cargo:rerun-if-changed` 设置形成自毒循环，导致 `boxlite-shim` 每次 `cargo build/test` 都被重新 link：

1. **`libkrun-sys/build.rs`**：`rerun-if-changed=vendor/libkrun` 指向目录，而 build.rs 在该目录内运行 `make`/`cargo build`，修改了 mtime → 每次都重新触发
2. **`boxlite/build.rs`**：对 `target/debug/boxlite-shim`（本 crate 的 `[[bin]]` 输出）设了 `rerun-if-changed`，每次 link 更新 mtime → 永远 dirty

重新 link 覆盖了 `make runtime-debug` 中 `sign.sh` 添加的 ad-hoc signature → entitlement 丢失 → shim 调用 Hypervisor.framework 失败 → VM 测试全挂。

## Solution

在 `EmbeddedRuntime::extract()` 中，所有文件写入完成后调用 `codesign` 重签 `boxlite-shim`，使用与 `scripts/build/sign.sh` 完全相同的 entitlement（`com.apple.security.hypervisor` + `com.apple.security.cs.disable-library-validation`）。

### 为什么选这个方案

| 方案 | 评估 |
|------|------|
| **A. 修 libkrun-sys build.rs** | 根治根因 1，但涉及 vendor 子模块和 Makefile 改造，影响面大 |
| **B. 修 boxlite build.rs** | 只解决根因 2，根因 1 仍触发重编译 |
| **C. extract() 后重签** (本 PR) | 最小侵入，只改 1 个文件，不管重编译多少次都能恢复签名 |
| **D. Makefile post-sign** | 需要用户记住特殊步骤 |

选 C 因为：
- **只改 1 个文件**（`embedded.rs`），约 40 行新代码含测试
- **完全解决问题**：不依赖 build chain 不重编译这个前提
- **无副作用**：`#[cfg(target_os = "macos")]` 编译期跳过 Linux；codesign 失败只 warn 不阻塞
- **与已有实践一致**：entitlement 内容与 `scripts/build/sign.sh` 完全相同

## Test plan

- [x] `cargo clippy -p boxlite --tests -- -D warnings` — zero warnings
- [x] `cargo test -p boxlite --lib runtime::embedded` — all 5 tests pass (3 existing + 2 new)
- [ ] `make runtime-debug && cargo test -p boxlite --test snapshot` — VM integration tests pass with signed shim
- [ ] `codesign -d --entitlements - ~/.local/share/boxlite/runtimes/v*/boxlite-shim` — verify entitlement present after extraction

