### PR TITLE
fix(test): fix 4 bugs in snapshot integration tests

### DIFF
--- a/boxlite/src/disk/constants.rs
+++ b/boxlite/src/disk/constants.rs
@@ -4,10 +4,10 @@
 
 /// Disk filenames used in box directories.
 pub mod filenames {
-    /// Container rootfs COW disk: `~/.boxlite/boxes/{box_id}/disk.qcow2`
+    /// Container rootfs COW disk: `~/.boxlite/boxes/{box_id}/disks/disk.qcow2`
     pub const CONTAINER_DISK: &str = "disk.qcow2";
 
-    /// Guest bootstrap COW disk: `~/.boxlite/boxes/{box_id}/guest-rootfs.qcow2`
+    /// Guest bootstrap COW disk: `~/.boxlite/boxes/{box_id}/disks/guest-rootfs.qcow2`
     pub const GUEST_ROOTFS_DISK: &str = "guest-rootfs.qcow2";
 }
 

--- a/boxlite/src/rootfs/guest.rs
+++ b/boxlite/src/rootfs/guest.rs
@@ -377,8 +377,9 @@ impl GuestRootfsManager {
             tracing::warn!(
                 version_key = %version_key,
                 base_path = %record.base_path(),
-                "DB record exists but file missing, treating as cache miss"
+                "DB record exists but file missing, removing stale record"
             );
+            let _ = self.base_disk_mgr.store().delete(record.id());
             None
         }
     }
@@ -870,9 +871,17 @@ mod tests {
             dir.path().join("ghost.ext4").to_str().unwrap(),
         );
 
-        let base_disk_mgr = BaseDiskManager::new(dir.path().to_path_buf(), store);
+        let base_disk_mgr = BaseDiskManager::new(dir.path().to_path_buf(), store.clone());
         let mgr = GuestRootfsManager::new(base_disk_mgr, dir.path().to_path_buf());
         assert!(mgr.find("ghost-key").is_none());
+
+        // Stale DB record should have been deleted
+        assert!(
+            store
+                .find_by_name(GLOBAL_SOURCE, "ghost-key")
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[test]

--- a/boxlite/tests/snapshot.rs
+++ b/boxlite/tests/snapshot.rs
@@ -27,10 +27,16 @@ use tokio_stream::StreamExt;
 const CONTAINER_DISK: &str = "disk.qcow2";
 const GUEST_ROOTFS_DISK: &str = "guest-rootfs.qcow2";
 const SNAPSHOTS_DIR: &str = "snapshots";
+const DISKS_DIR: &str = "disks";
 
 /// Return the box directory path: `{home}/boxes/{box_id}`.
 fn box_dir(home: &Path, box_id: &str) -> PathBuf {
     home.join("boxes").join(box_id)
+}
+
+/// Return the disks directory path: `{home}/boxes/{box_id}/disks`.
+fn disks_dir(home: &Path, box_id: &str) -> PathBuf {
+    box_dir(home, box_id).join(DISKS_DIR)
 }
 
 /// Return the snapshot directory path: `{home}/boxes/{box_id}/snapshots/{name}`.
@@ -54,7 +60,9 @@ async fn exec_stdout(handle: &LiteBox, cmd: BoxCommand) -> String {
     stdout
 }
 
-/// Create a box from alpine:latest, start it, stop it, return it ready for snapshot operations.
+/// Create a box from alpine:latest, start it, stop it, return a fresh handle ready for snapshot
+/// operations. After `stop()` the original handle's shutdown token is cancelled, so we must
+/// obtain a new handle via `runtime.get()` to allow subsequent `start()` calls.
 async fn create_stopped_box(runtime: &BoxliteRuntime) -> LiteBox {
     let litebox = runtime
         .create(common::alpine_opts(), Some("test-box".to_string()))
@@ -65,7 +73,12 @@ async fn create_stopped_box(runtime: &BoxliteRuntime) -> LiteBox {
     litebox.start().await.expect("Failed to start box");
     litebox.stop().await.expect("Failed to stop box");
 
-    litebox
+    // stop() invalidates the handle (cancels shutdown_token); get a fresh one.
+    runtime
+        .get("test-box")
+        .await
+        .expect("get failed")
+        .expect("box not found")
 }
 
 // ============================================================================
@@ -84,13 +97,13 @@ async fn test_cow_child_disks_exist_after_snapshot_create() {
     let box_id = litebox.id().to_string();
 
     // Precondition: disks exist before snapshot.
-    let bdir = box_dir(&home.path, &box_id);
+    let ddir = disks_dir(&home.path, &box_id);
     assert!(
-        bdir.join(CONTAINER_DISK).exists(),
+        ddir.join(CONTAINER_DISK).exists(),
         "container disk missing before snapshot"
     );
     assert!(
-        bdir.join(GUEST_ROOTFS_DISK).exists(),
+        ddir.join(GUEST_ROOTFS_DISK).exists(),
         "guest disk missing before snapshot"
     );
 
@@ -102,26 +115,20 @@ async fn test_cow_child_disks_exist_after_snapshot_create() {
     assert_eq!(info.name, "ckpt1");
 
     // Snapshot copies must exist in the snapshot directory.
+    // Note: only the container disk is forked into the snapshot; guest rootfs is
+    // recreated from cache on start, so it is not part of the snapshot.
     let sdir = snapshot_dir(&home.path, &box_id, "ckpt1");
     assert!(
         sdir.join(CONTAINER_DISK).exists(),
         "snapshot container disk missing"
-    );
-    assert!(
-        sdir.join(GUEST_ROOTFS_DISK).exists(),
-        "snapshot guest disk missing"
     );
 
     // COW child disks in the box directory must still exist.
     // Bug: create_cow_child_disk() returns Disk(persistent=false); if the caller
     // does not call .leak(), Disk::Drop deletes the newly created file.
     assert!(
-        bdir.join(CONTAINER_DISK).exists(),
+        ddir.join(CONTAINER_DISK).exists(),
         "COW child disk.qcow2 deleted by Disk::Drop (missing .leak() in local_snapshot.rs)"
-    );
-    assert!(
-        bdir.join(GUEST_ROOTFS_DISK).exists(),
-        "COW child guest-rootfs.qcow2 deleted by Disk::Drop (missing .leak() in local_snapshot.rs)"
     );
 
     let _ = runtime.shutdown(Some(common::TEST_SHUTDOWN_TIMEOUT)).await;
@@ -193,15 +200,16 @@ async fn test_cow_child_disks_exist_after_snapshot_restore() {
         .await
         .expect("snapshot restore failed");
 
-    // COW child disks in the box directory must exist after restore.
-    let bdir = box_dir(&home.path, &box_id);
+    // COW child container disk must exist after restore.
+    let ddir = disks_dir(&home.path, &box_id);
     assert!(
-        bdir.join(CONTAINER_DISK).exists(),
+        ddir.join(CONTAINER_DISK).exists(),
         "COW child disk.qcow2 deleted by Disk::Drop after restore (missing .leak())"
     );
+    // Guest rootfs is intentionally deleted by restore so the next start recreates it fresh.
     assert!(
-        bdir.join(GUEST_ROOTFS_DISK).exists(),
-        "COW child guest-rootfs.qcow2 deleted by Disk::Drop after restore (missing .leak())"
+        !ddir.join(GUEST_ROOTFS_DISK).exists(),
+        "guest-rootfs.qcow2 should be deleted after restore (recreated on next start)"
     );
 
     let _ = runtime.shutdown(Some(common::TEST_SHUTDOWN_TIMEOUT)).await;
@@ -227,6 +235,13 @@ async fn test_box_startable_after_snapshot_restore() {
     let mut exec = litebox.exec(cmd).await.expect("exec failed");
     exec.wait().await.expect("wait failed");
     litebox.stop().await.expect("stop failed");
+
+    // stop() invalidates the handle; get a fresh one for snapshot + restart.
+    let litebox = runtime
+        .get("test-box")
+        .await
+        .expect("get failed")
+        .expect("box not found");
 
     litebox
         .snapshots()

--- a/make/test.mk
+++ b/make/test.mk
@@ -147,10 +147,10 @@ test\:warm-cache\:rust: runtime-debug
 test\:integration\:rust: runtime-debug test\:warm-cache\:rust
 	@echo "🧪 Running Rust integration tests (requires VM)..."
 	@if command -v cargo-nextest >/dev/null 2>&1; then \
-		cargo nextest run -p boxlite --test '*' --no-fail-fast --profile vm \
+		cargo nextest run -p boxlite --features link-krun --test '*' --no-fail-fast --profile vm \
 			$(if $(FILTER),-E 'test(~$(FILTER))',); \
 	else \
-		cargo test -p boxlite --test '*' --no-fail-fast -- --test-threads=1 --nocapture \
+		cargo test -p boxlite --features link-krun --test '*' --no-fail-fast -- --test-threads=1 --nocapture \
 			$(if $(FILTER),$(FILTER),); \
 	fi
 


### PR DESCRIPTION
## Summary

- Fixed in https://github.com/boxlite-ai/boxlite/issues/343
- **Wrong disk paths**: Tests asserted files at `boxes/{id}/disk.qcow2` but actual path is `boxes/{id}/disks/disk.qcow2`. Added `disks_dir()` helper.
- **Handle invalidation after stop()**: `stop()` cancels the shutdown token, making the handle unusable for `start()`. Fixed by calling `runtime.get("test-box")` to get a fresh handle after each `stop()`.
- **False guest-rootfs assertion in snapshot dir**: Snapshot only forks the container disk; removed incorrect assertion.
- **False guest-rootfs assertion after restore**: `restore_disks()` intentionally deletes guest-rootfs so next start recreates it fresh. Flipped assertion to `!exists()`.
- **Stale DB record cleanup**: `GuestRootfsManager::find()` now deletes stale DB records when the backing file is missing.
- **Missing `--features link-krun`**: Integration test make target was missing the feature flag.
- **Doc comment fix**: Updated `disk/constants.rs` paths to include `disks/` subdirectory.

## Test plan

- [x] `cargo clippy -p boxlite --tests -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `make test:integration:rust` — all 111 integration tests pass (including 5 snapshot tests)