### PR TITLE
fix(node): remove unpublished NAPI targets from package manifest

### DIFF
--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -16,9 +16,7 @@
     "binaryName": "boxlite",
     "targets": [
       "aarch64-apple-darwin",
-      "x86_64-apple-darwin",
-      "x86_64-unknown-linux-gnu",
-      "aarch64-unknown-linux-gnu"
+      "x86_64-unknown-linux-gnu"
     ],
     "package": {
       "name": "@boxlite-ai/boxlite"


### PR DESCRIPTION
## Problem

(fixes #347)

`@boxlite-ai/boxlite@0.3.0` on npm declares four `optionalDependencies` (generated by `napi prepublish` from `napi.targets`):

- `@boxlite-ai/boxlite-darwin-arm64` — **published** ✅
- `@boxlite-ai/boxlite-darwin-x64` — **404** ❌
- `@boxlite-ai/boxlite-linux-x64-gnu` — **published** ✅
- `@boxlite-ai/boxlite-linux-arm64-gnu` — **404** ❌

```
$ npm view @boxlite-ai/boxlite-linux-arm64-gnu@0.3.0
npm error 404 Not Found - GET https://registry.npmjs.org/@boxlite-ai%2fboxlite-linux-arm64-gnu - Not found
```

## Root cause

`sdks/node/package.json` declares 4 NAPI targets, but `.github/workflows/config.yml` only builds 2 platforms (`darwin-arm64` and `linux-x64-gnu`). The `napi prepublish` step in `prepack` injects `optionalDependencies` for all 4 targets regardless of which platform packages are actually built and published.

## Fix

Remove `x86_64-apple-darwin` and `aarch64-unknown-linux-gnu` from `napi.targets` since they aren't built by CI. They can be re-added when the corresponding platforms are supported and built:

- `x86_64-apple-darwin` (macOS Intel) — listed as "Coming soon" in the README
- `aarch64-unknown-linux-gnu` (Linux ARM64) — listed as "Supported" but not built in CI yet

This ensures the published package only declares optional dependencies that actually exist on npm.

I also suppose another solution could to build it in the CI tho.