### PR TITLE
fix(make): exclude cbindgen-generated boxlite.h from clang-format

### DIFF
--- a/make/quality.mk
+++ b/make/quality.mk
@@ -74,7 +74,7 @@ fmt\:c:
 		echo "❌ clang-format not found. Install LLVM/clang-format to format C SDK files."; \
 		exit 1; \
 	fi; \
-	"$$CLANG_FORMAT" -i sdks/c/include/boxlite.h sdks/c/tests/*.c
+	"$$CLANG_FORMAT" -i sdks/c/tests/*.c
 
 fmt\:check\:c:
 	@echo "🔍 Checking C SDK formatting..."
@@ -86,7 +86,7 @@ fmt\:check\:c:
 		echo "❌ clang-format not found. Install LLVM/clang-format to check C SDK formatting."; \
 		exit 1; \
 	fi; \
-	"$$CLANG_FORMAT" --dry-run --Werror sdks/c/include/boxlite.h sdks/c/tests/*.c
+	"$$CLANG_FORMAT" --dry-run --Werror sdks/c/tests/*.c
 
 # Smart lint: only lint changed components.
 lint:


### PR DESCRIPTION
## Summary
- Removed `sdks/c/include/boxlite.h` from `fmt:c` and `fmt:check:c` Makefile targets
- The header is generated by cbindgen and should not be reformatted by clang-format, as it creates noise diffs on every pre-commit hook run
- `.clang-format` is retained for formatting hand-written test files in `sdks/c/tests/`

## Test plan
- [ ] Run `make fmt:c` — only formats test files, does not touch `boxlite.h`
- [ ] Run `make fmt:check:c` — only checks test files
- [ ] Pre-commit hook no longer creates spurious diffs on `boxlite.h`