### PR TITLE
fix(build): prevent RUSTFLAGS leaking into vendored libkrun build

### DIFF
--- a/boxlite/deps/libkrun-sys/build.rs
+++ b/boxlite/deps/libkrun-sys/build.rs
@@ -362,6 +362,12 @@ impl LibBuilder {
         cmd.stdout(Stdio::inherit());
         cmd.stderr(Stdio::inherit());
 
+        // Prevent outer RUSTFLAGS from leaking into vendored libkrun build.
+        // CI tools (e.g., actions-rust-lang/setup-rust-toolchain) set RUSTFLAGS=-D warnings,
+        // which would promote warnings in vendored code to errors.
+        cmd.env_remove("RUSTFLAGS");
+        cmd.env_remove("CARGO_ENCODED_RUSTFLAGS");
+
         run_command(&mut cmd, "cargo rustc (libkrun staticlib)");
 
         // Determine output path (differs when --target is specified)


### PR DESCRIPTION
CI tools (e.g., actions-rust-lang/setup-rust-toolchain) set RUSTFLAGS=-D warnings, which leaks into the nested cargo subprocess that builds vendored libkrun. This promotes warnings in vendored code (like unused_unsafe in cpuid crate) to errors, breaking the build.

Strip RUSTFLAGS and CARGO_ENCODED_RUSTFLAGS from the subprocess environment to isolate the vendored build from outer compiler flags.