### PR TITLE
feat(vmm): replace ProcessMonitor polling with pidfd/kqueue event-driven detection

### DIFF
--- a/src/boxlite/src/jailer/common/fd.rs
+++ b/src/boxlite/src/jailer/common/fd.rs
@@ -12,35 +12,76 @@
 //! 1. **Linux 5.9+**: `close_range(first_fd, ~0U, 0)` — O(1), kernel closes all.
 //! 2. **Linux < 5.9**: Enumerate `/proc/self/fd` via raw `getdents64` syscall
 //!    (no memory allocation) and close only open FDs. Falls back to brute-force
-//!    with a dynamic upper bound from `getrlimit(RLIMIT_NOFILE)`.
+//!    with a dynamic upper bound queried via raw `prlimit64` syscall.
 //! 3. **macOS**: Brute-force close with dynamic upper bound from
-//!    `getrlimit(RLIMIT_NOFILE)` instead of a hardcoded limit.
+//!    `getrlimit(RLIMIT_NOFILE)`.
 
-/// Query the soft limit for `RLIMIT_NOFILE`. Async-signal-safe.
+/// Safe cap for brute-force FD closure (2^20), matches Linux /proc/sys/fs/nr_open.
+/// Used when the rlimit query fails or returns an excessively large value.
+const MAX_FD_CAP: i32 = 1_048_576;
+
+/// Convert rlimit soft/hard values to a capped i32 upper bound for FD iteration.
 ///
-/// Returns the soft limit (current max open files), or a safe default
-/// if the query fails. `getrlimit` is async-signal-safe per POSIX.
-///
-/// Note: Cannot reuse `rlimit::get_rlimit()` because it returns `io::Error`
-/// which heap-allocates (not async-signal-safe for pre_exec context).
-fn get_max_fd() -> i32 {
-    let mut rlim = libc::rlimit {
-        rlim_cur: 0,
-        rlim_max: 0,
-    };
-    // SAFETY: getrlimit is async-signal-safe per POSIX. rlim is a valid stack-allocated struct.
-    let result = unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &mut rlim) };
-    if result == 0 && rlim.rlim_cur > 0 {
-        if rlim.rlim_cur < i32::MAX as u64 {
-            rlim.rlim_cur as i32
-        } else {
-            // rlim_cur is RLIM_INFINITY or very large; cap to a safe maximum.
-            // 1048576 (2^20) matches Linux's default /proc/sys/fs/nr_open.
-            1_048_576
-        }
+/// Uses `max(soft, hard)` to cover FDs opened before a soft limit decrease.
+/// Caps excessively large values (including RLIM_INFINITY) to [`MAX_FD_CAP`].
+/// Async-signal-safe: pure arithmetic, no allocation.
+fn rlimit_to_max_fd(soft: u64, hard: u64) -> i32 {
+    let limit = soft.max(hard);
+    if limit > 0 && limit <= i32::MAX as u64 {
+        limit as i32
     } else {
-        // getrlimit failed or returned 0; safe default per POSIX OPEN_MAX
-        1024
+        // limit is 0, RLIM_INFINITY, or exceeds i32::MAX
+        MAX_FD_CAP
+    }
+}
+
+/// Query the upper bound for open FDs. Async-signal-safe.
+///
+/// On Linux, uses a raw `prlimit64` syscall to avoid libc wrappers that may
+/// not be async-signal-safe in all implementations. On other platforms, uses
+/// `getrlimit` which is async-signal-safe per POSIX.
+///
+/// Returns `max(soft, hard)` from `RLIMIT_NOFILE`, capped to [`MAX_FD_CAP`].
+/// Using the max of both limits covers the case where a process opens
+/// high-numbered FDs then lowers its soft limit before fork.
+fn get_max_fd() -> i32 {
+    #[cfg(target_os = "linux")]
+    {
+        let mut rlim = libc::rlimit64 {
+            rlim_cur: 0,
+            rlim_max: 0,
+        };
+        // SAFETY: Raw syscall — bypasses libc wrappers for async-signal-safety.
+        // pid=0 means current process, new_limit=NULL means read-only query.
+        let result = unsafe {
+            libc::syscall(
+                libc::SYS_prlimit64,
+                0 as libc::pid_t,
+                libc::RLIMIT_NOFILE,
+                core::ptr::null::<libc::rlimit64>(),
+                &mut rlim as *mut libc::rlimit64,
+            )
+        };
+        if result == 0 {
+            rlimit_to_max_fd(rlim.rlim_cur, rlim.rlim_max)
+        } else {
+            MAX_FD_CAP
+        }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        let mut rlim = libc::rlimit {
+            rlim_cur: 0,
+            rlim_max: 0,
+        };
+        // SAFETY: getrlimit is async-signal-safe per POSIX. rlim is a valid stack-allocated struct.
+        let result = unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &mut rlim) };
+        if result == 0 {
+            rlimit_to_max_fd(rlim.rlim_cur, rlim.rlim_max)
+        } else {
+            MAX_FD_CAP
+        }
     }
 }
 
@@ -48,17 +89,22 @@ fn get_max_fd() -> i32 {
 /// Async-signal-safe: uses only stack buffers and raw syscalls.
 ///
 /// Returns `true` if `/proc/self/fd` was successfully enumerated,
-/// `false` if it's unavailable (e.g., mount namespace without /proc).
+/// `false` if it's unavailable or an error occurred (e.g., mount namespace
+/// without /proc, or `getdents64` failure).
 #[cfg(target_os = "linux")]
 fn close_fds_via_proc(first_fd: i32) -> bool {
-    // Open /proc/self/fd with raw syscall (no allocation)
+    // Open /proc/self/fd with a raw syscall (no libc wrapper)
     let proc_path = b"/proc/self/fd\0";
-    // SAFETY: proc_path is a valid null-terminated string literal. open() is async-signal-safe.
+    // SAFETY: syscall(SYS_openat, ...) invokes the kernel directly,
+    // appropriate for pre_exec async-signal-safe use.
     let dir_fd = unsafe {
-        libc::open(
+        libc::syscall(
+            libc::SYS_openat,
+            libc::AT_FDCWD,
             proc_path.as_ptr().cast::<libc::c_char>(),
             libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC,
-        )
+            0,
+        ) as i32
     };
     if dir_fd < 0 {
         return false;
@@ -67,6 +113,8 @@ fn close_fds_via_proc(first_fd: i32) -> bool {
     // Stack buffer for getdents64 — 1024 bytes handles ~40 entries per call,
     // sufficient for typical processes without heap allocation.
     let mut buf = [0u8; 1024];
+
+    let mut success = true;
 
     loop {
         let nread = unsafe {
@@ -78,7 +126,20 @@ fn close_fds_via_proc(first_fd: i32) -> bool {
             )
         };
 
-        if nread <= 0 {
+        if nread == 0 {
+            // End of directory — all entries have been read successfully.
+            break;
+        }
+
+        if nread < 0 {
+            // SAFETY: errno is thread-local and may be read immediately after
+            // the failing syscall to determine whether to retry or fall back.
+            let errno = unsafe { *libc::__errno_location() };
+            if errno == libc::EINTR {
+                continue;
+            }
+            // Non-retriable error: signal failure so the brute-force fallback runs.
+            success = false;
             break;
         }
 
@@ -115,7 +176,7 @@ fn close_fds_via_proc(first_fd: i32) -> bool {
 
     // SAFETY: close() is async-signal-safe. dir_fd was opened by us above.
     unsafe { libc::close(dir_fd) };
-    true
+    success
 }
 
 /// Parse a decimal FD number from a null-terminated C string pointer.
@@ -170,7 +231,7 @@ fn brute_force_close_fds(first_fd: i32) {
 /// # Safety
 ///
 /// This function only uses async-signal-safe syscalls (close, syscall,
-/// getrlimit, open, getdents64).
+/// prlimit64/getrlimit, openat, getdents64).
 /// Do NOT add:
 /// - Logging (tracing, println)
 /// - Memory allocation (Box, Vec, String)
@@ -203,7 +264,7 @@ pub fn close_fds_from(first_fd: i32) -> Result<(), i32> {
             return Ok(());
         }
 
-        // Strategy 3: Brute-force close with dynamic limit from getrlimit.
+        // Strategy 3: Brute-force close with dynamic limit from prlimit64.
         // Used when both close_range and /proc are unavailable (e.g., old kernel
         // in a mount namespace without /proc).
         brute_force_close_fds(first_fd);
@@ -443,6 +504,63 @@ mod tests {
             max >= 256,
             "get_max_fd should return at least 256, got {}",
             max
+        );
+    }
+
+    #[test]
+    fn test_rlimit_to_max_fd() {
+        // Normal soft limit
+        assert_eq!(rlimit_to_max_fd(1024, 4096), 4096);
+
+        // Soft > hard (unusual but handled)
+        assert_eq!(rlimit_to_max_fd(8192, 1024), 8192);
+
+        // Exact i32::MAX
+        assert_eq!(rlimit_to_max_fd(i32::MAX as u64, 0), i32::MAX);
+
+        // Exceeds i32::MAX — capped
+        assert_eq!(rlimit_to_max_fd(i32::MAX as u64 + 1, 0), MAX_FD_CAP);
+
+        // RLIM_INFINITY (u64::MAX) — capped
+        assert_eq!(rlimit_to_max_fd(u64::MAX, u64::MAX), MAX_FD_CAP);
+
+        // Both zero — capped
+        assert_eq!(rlimit_to_max_fd(0, 0), MAX_FD_CAP);
+
+        // Soft zero, hard nonzero — uses hard
+        assert_eq!(rlimit_to_max_fd(0, 2048), 2048);
+    }
+
+    /// Verify brute-force fallback closes FDs correctly.
+    /// This exercises the code path used when `close_fds_via_proc` returns `false`
+    /// (e.g., when `getdents64` fails or `/proc` is unavailable).
+    fn child_brute_force_fallback_closes_fds() -> i32 {
+        // Create test FDs
+        let fd_a = unsafe { libc::dup(STDOUT_FD) };
+        let fd_b = unsafe { libc::dup(STDOUT_FD) };
+        if fd_a < 3 || fd_b <= fd_a {
+            return 1;
+        }
+
+        // Call brute_force_close_fds directly — this is the fallback path
+        // exercised when getdents64 fails (nread < 0).
+        brute_force_close_fds(fd_a);
+
+        // Both FDs should be closed
+        if unsafe { libc::fcntl(fd_a, libc::F_GETFD) } != -1 {
+            return 2;
+        }
+        if unsafe { libc::fcntl(fd_b, libc::F_GETFD) } != -1 {
+            return 3;
+        }
+        0
+    }
+
+    #[test]
+    fn test_brute_force_fallback_closes_fds() {
+        run_in_child(
+            "test_brute_force_fallback_closes_fds",
+            child_brute_force_fallback_closes_fds,
         );
     }
 

--- a/src/boxlite/src/jailer/common/fd.rs
+++ b/src/boxlite/src/jailer/common/fd.rs
@@ -6,6 +6,160 @@
 //!
 //! Only the async-signal-safe `close_inherited_fds_raw()` is used,
 //! called from the `pre_exec` hook before exec().
+//!
+//! ## Strategy (in order of preference)
+//!
+//! 1. **Linux 5.9+**: `close_range(first_fd, ~0U, 0)` — O(1), kernel closes all.
+//! 2. **Linux < 5.9**: Enumerate `/proc/self/fd` via raw `getdents64` syscall
+//!    (no memory allocation) and close only open FDs. Falls back to brute-force
+//!    with a dynamic upper bound from `getrlimit(RLIMIT_NOFILE)`.
+//! 3. **macOS**: Brute-force close with dynamic upper bound from
+//!    `getrlimit(RLIMIT_NOFILE)` instead of a hardcoded limit.
+
+/// Query the soft limit for `RLIMIT_NOFILE`. Async-signal-safe.
+///
+/// Returns the soft limit (current max open files), or a safe default
+/// if the query fails. `getrlimit` is async-signal-safe per POSIX.
+///
+/// Note: Cannot reuse `rlimit::get_rlimit()` because it returns `io::Error`
+/// which heap-allocates (not async-signal-safe for pre_exec context).
+fn get_max_fd() -> i32 {
+    let mut rlim = libc::rlimit {
+        rlim_cur: 0,
+        rlim_max: 0,
+    };
+    // SAFETY: getrlimit is async-signal-safe per POSIX. rlim is a valid stack-allocated struct.
+    let result = unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &mut rlim) };
+    if result == 0 && rlim.rlim_cur > 0 {
+        if rlim.rlim_cur < i32::MAX as u64 {
+            rlim.rlim_cur as i32
+        } else {
+            // rlim_cur is RLIM_INFINITY or very large; cap to a safe maximum.
+            // 1048576 (2^20) matches Linux's default /proc/sys/fs/nr_open.
+            1_048_576
+        }
+    } else {
+        // getrlimit failed or returned 0; safe default per POSIX OPEN_MAX
+        1024
+    }
+}
+
+/// Close open FDs by enumerating `/proc/self/fd` with raw `getdents64`.
+/// Async-signal-safe: uses only stack buffers and raw syscalls.
+///
+/// Returns `true` if `/proc/self/fd` was successfully enumerated,
+/// `false` if it's unavailable (e.g., mount namespace without /proc).
+#[cfg(target_os = "linux")]
+fn close_fds_via_proc(first_fd: i32) -> bool {
+    // Open /proc/self/fd with raw syscall (no allocation)
+    let proc_path = b"/proc/self/fd\0";
+    // SAFETY: proc_path is a valid null-terminated string literal. open() is async-signal-safe.
+    let dir_fd = unsafe {
+        libc::open(
+            proc_path.as_ptr().cast::<libc::c_char>(),
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC,
+        )
+    };
+    if dir_fd < 0 {
+        return false;
+    }
+
+    // Stack buffer for getdents64 — 1024 bytes handles ~40 entries per call,
+    // sufficient for typical processes without heap allocation.
+    let mut buf = [0u8; 1024];
+
+    loop {
+        let nread = unsafe {
+            libc::syscall(
+                libc::SYS_getdents64,
+                dir_fd,
+                buf.as_mut_ptr(),
+                buf.len() as libc::c_uint,
+            )
+        };
+
+        if nread <= 0 {
+            break;
+        }
+
+        let mut offset = 0usize;
+        while offset < nread as usize {
+            // SAFETY: getdents64 returns packed linux_dirent64 structs.
+            // d_reclen is at byte offset 16. Use read_unaligned because the
+            // buffer is a byte array and the u16 field may not be 2-byte aligned.
+            let d_reclen =
+                unsafe { buf.as_ptr().add(offset + 16).cast::<u16>().read_unaligned() } as usize;
+
+            if d_reclen == 0 || offset + d_reclen > nread as usize {
+                break;
+            }
+
+            // d_name starts at offset 19 in linux_dirent64
+            let name_ptr = unsafe { buf.as_ptr().add(offset + 19) };
+
+            // Parse FD number from d_name (decimal string, null-terminated).
+            // Async-signal-safe: no allocation, just pointer arithmetic.
+            let fd = parse_fd_from_name(name_ptr);
+
+            if let Some(fd) = fd
+                && fd >= first_fd
+                && fd != dir_fd
+            {
+                // SAFETY: close() is async-signal-safe. Closing an already-closed FD is harmless.
+                unsafe { libc::close(fd) };
+            }
+
+            offset += d_reclen;
+        }
+    }
+
+    // SAFETY: close() is async-signal-safe. dir_fd was opened by us above.
+    unsafe { libc::close(dir_fd) };
+    true
+}
+
+/// Parse a decimal FD number from a null-terminated C string pointer.
+/// Returns `None` for non-numeric entries (e.g., "." and "..").
+/// Async-signal-safe: no allocation, pure arithmetic.
+///
+/// # Safety
+///
+/// `ptr` must point to a valid, null-terminated byte string in readable memory.
+/// Called only from `close_fds_via_proc` with pointers into the `getdents64` buffer,
+/// which the kernel guarantees to contain null-terminated `d_name` fields.
+#[cfg(target_os = "linux")]
+fn parse_fd_from_name(ptr: *const u8) -> Option<i32> {
+    let mut fd: i32 = 0;
+    let mut i = 0usize;
+    loop {
+        // SAFETY: ptr is guaranteed by the caller to point to a null-terminated string.
+        // We stop reading at the null terminator (byte == 0).
+        let byte = unsafe { *ptr.add(i) };
+        if byte == 0 {
+            break;
+        }
+        if !byte.is_ascii_digit() {
+            return None;
+        }
+        fd = fd.checked_mul(10)?.checked_add((byte - b'0') as i32)?;
+        i += 1;
+    }
+    if i == 0 {
+        return None;
+    }
+    Some(fd)
+}
+
+/// Brute-force close all FDs from `first_fd` to `get_max_fd()`. Async-signal-safe.
+///
+/// Last-resort fallback when `close_range` and `/proc/self/fd` are unavailable.
+fn brute_force_close_fds(first_fd: i32) {
+    let max_fd = get_max_fd();
+    for fd in first_fd..max_fd {
+        // SAFETY: close() is async-signal-safe. Closing a non-open FD returns EBADF (ignored).
+        unsafe { libc::close(fd) };
+    }
+}
 
 /// Close all FDs from `first_fd` onwards. Async-signal-safe.
 ///
@@ -15,7 +169,8 @@
 ///
 /// # Safety
 ///
-/// This function only uses async-signal-safe syscalls (close, syscall).
+/// This function only uses async-signal-safe syscalls (close, syscall,
+/// getrlimit, open, getdents64).
 /// Do NOT add:
 /// - Logging (tracing, println)
 /// - Memory allocation (Box, Vec, String)
@@ -29,7 +184,7 @@
 pub fn close_fds_from(first_fd: i32) -> Result<(), i32> {
     #[cfg(target_os = "linux")]
     {
-        // Try close_range syscall (Linux 5.9+, most efficient)
+        // Strategy 1: close_range syscall (Linux 5.9+, most efficient — O(1))
         let result = unsafe {
             libc::syscall(
                 libc::SYS_close_range,
@@ -42,25 +197,24 @@ pub fn close_fds_from(first_fd: i32) -> Result<(), i32> {
             return Ok(());
         }
 
-        // Fallback: brute force close
-        // Note: We can't use /proc/self/fd here because:
-        // 1. read_dir allocates memory (not async-signal-safe)
-        // 2. We might be in a mount namespace where /proc isn't mounted
-        for fd in first_fd..1024 {
-            // Ignore errors - FD might not be open
-            unsafe { libc::close(fd) };
+        // Strategy 2: Enumerate /proc/self/fd via raw getdents64 (no allocation).
+        // Closes only open FDs — efficient even with high ulimit -n.
+        if close_fds_via_proc(first_fd) {
+            return Ok(());
         }
+
+        // Strategy 3: Brute-force close with dynamic limit from getrlimit.
+        // Used when both close_range and /proc are unavailable (e.g., old kernel
+        // in a mount namespace without /proc).
+        brute_force_close_fds(first_fd);
         Ok(())
     }
 
     #[cfg(target_os = "macos")]
     {
-        // macOS: brute force close (no close_range syscall)
-        // 4096 is a reasonable upper bound for most processes
-        for fd in first_fd..4096 {
-            // Ignore errors - FD might not be open
-            unsafe { libc::close(fd) };
-        }
+        // macOS: brute-force close with dynamic limit from getrlimit.
+        // Handles systems where ulimit -n exceeds the previous hardcoded 4096.
+        brute_force_close_fds(first_fd);
         Ok(())
     }
 
@@ -229,5 +383,93 @@ mod tests {
             "test_close_fds_from_closes_target_and_above",
             child_close_fds_from_closes_target_and_above,
         );
+    }
+
+    /// Create a high-numbered FD (above the old hardcoded 1024/4096 limits)
+    /// and verify that `close_inherited_fds_raw` closes it.
+    fn child_close_high_numbered_fd() -> i32 {
+        // Raise the soft FD limit so we can dup2 to a high FD number.
+        // Some systems default to ulimit -n 1024, which would prevent dup2 to FD 2000.
+        let new_limit = libc::rlimit {
+            rlim_cur: 4096,
+            rlim_max: 4096,
+        };
+        // SAFETY: setrlimit is async-signal-safe. Raising soft limit within hard limit is allowed.
+        if unsafe { libc::setrlimit(libc::RLIMIT_NOFILE, &new_limit) } != 0 {
+            // Can't raise limit (hard limit too low) — skip test gracefully
+            return 0;
+        }
+
+        // dup2 stdout to a high FD number that exceeds the old hardcoded limits.
+        // Use 2000 on all platforms — above old Linux limit (1024) and reasonable.
+        let high_fd: i32 = 2000;
+        let result = unsafe { libc::dup2(STDOUT_FD, high_fd) };
+        if result != high_fd {
+            // dup2 failed — unexpected after raising ulimit
+            return 1;
+        }
+
+        // Verify the high FD is open
+        if unsafe { libc::fcntl(high_fd, libc::F_GETFD) } < 0 {
+            return 2;
+        }
+
+        // Close all inherited FDs
+        if close_inherited_fds_raw().is_err() {
+            return 3;
+        }
+
+        // The high FD should now be closed
+        if unsafe { libc::fcntl(high_fd, libc::F_GETFD) } != -1 {
+            return 4;
+        }
+        0
+    }
+
+    #[test]
+    fn test_close_high_numbered_fd() {
+        run_in_child("test_close_high_numbered_fd", child_close_high_numbered_fd);
+    }
+
+    #[test]
+    fn test_get_max_fd_returns_positive() {
+        let max = get_max_fd();
+        assert!(
+            max > 0,
+            "get_max_fd should return positive value, got {}",
+            max
+        );
+        assert!(
+            max >= 256,
+            "get_max_fd should return at least 256, got {}",
+            max
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_parse_fd_from_name() {
+        // Valid numeric names
+        assert_eq!(parse_fd_from_name(b"0\0".as_ptr()), Some(0));
+        assert_eq!(parse_fd_from_name(b"3\0".as_ptr()), Some(3));
+        assert_eq!(parse_fd_from_name(b"42\0".as_ptr()), Some(42));
+        assert_eq!(parse_fd_from_name(b"1024\0".as_ptr()), Some(1024));
+        assert_eq!(parse_fd_from_name(b"65535\0".as_ptr()), Some(65535));
+
+        // Non-numeric names (. and ..)
+        assert_eq!(parse_fd_from_name(b".\0".as_ptr()), None);
+        assert_eq!(parse_fd_from_name(b"..\0".as_ptr()), None);
+
+        // Empty name
+        assert_eq!(parse_fd_from_name(b"\0".as_ptr()), None);
+
+        // Overflow: i32::MAX (2147483647) should succeed
+        assert_eq!(parse_fd_from_name(b"2147483647\0".as_ptr()), Some(i32::MAX));
+
+        // Overflow: i32::MAX + 1 (2147483648) should return None (checked_add overflow)
+        assert_eq!(parse_fd_from_name(b"2147483648\0".as_ptr()), None);
+
+        // Overflow: very large number should return None
+        assert_eq!(parse_fd_from_name(b"99999999999\0".as_ptr()), None);
     }
 }

--- a/src/boxlite/src/util/process.rs
+++ b/src/boxlite/src/util/process.rs
@@ -159,8 +159,14 @@ impl ProcessMonitor {
         // SAFETY: owned.as_raw_fd() is a valid open FD. fcntl(F_SETFD) and
         // fcntl(F_SETFL) do not take ownership.
         unsafe {
-            libc::fcntl(owned.as_raw_fd(), libc::F_SETFD, libc::FD_CLOEXEC);
-            if libc::fcntl(owned.as_raw_fd(), libc::F_SETFL, libc::O_NONBLOCK) < 0 {
+            if libc::fcntl(owned.as_raw_fd(), libc::F_SETFD, libc::FD_CLOEXEC) < 0 {
+                return None; // OwnedFd closes the FD on drop
+            }
+            let flags = libc::fcntl(owned.as_raw_fd(), libc::F_GETFL);
+            if flags < 0 {
+                return None; // OwnedFd closes the FD on drop
+            }
+            if libc::fcntl(owned.as_raw_fd(), libc::F_SETFL, flags | libc::O_NONBLOCK) < 0 {
                 return None; // OwnedFd closes the FD on drop
             }
         }
@@ -233,8 +239,14 @@ impl ProcessMonitor {
         // SAFETY: owned.as_raw_fd() is a valid open FD. fcntl(F_SETFD) and
         // fcntl(F_SETFL) do not take ownership.
         unsafe {
-            libc::fcntl(owned.as_raw_fd(), libc::F_SETFD, libc::FD_CLOEXEC);
-            if libc::fcntl(owned.as_raw_fd(), libc::F_SETFL, libc::O_NONBLOCK) < 0 {
+            if libc::fcntl(owned.as_raw_fd(), libc::F_SETFD, libc::FD_CLOEXEC) < 0 {
+                return None; // OwnedFd closes the kqueue FD on drop
+            }
+            let flags = libc::fcntl(owned.as_raw_fd(), libc::F_GETFL);
+            if flags < 0 {
+                return None; // OwnedFd closes the kqueue FD on drop
+            }
+            if libc::fcntl(owned.as_raw_fd(), libc::F_SETFL, flags | libc::O_NONBLOCK) < 0 {
                 return None; // OwnedFd closes the kqueue FD on drop
             }
         }
@@ -812,7 +824,11 @@ mod tests {
 
         // Give the child a moment to start, then kill it.
         tokio::time::sleep(Duration::from_millis(50)).await;
-        unsafe { libc::kill(pid as i32, libc::SIGKILL) };
+        assert_eq!(
+            unsafe { libc::kill(pid as i32, libc::SIGKILL) },
+            0,
+            "Failed to send SIGKILL to child process"
+        );
 
         let exit = monitor.wait_for_exit().await;
         assert_eq!(exit, ProcessExit::Code(128 + libc::SIGKILL));

--- a/src/boxlite/src/util/process.rs
+++ b/src/boxlite/src/util/process.rs
@@ -95,16 +95,163 @@ impl ProcessMonitor {
         }
     }
 
-    /// Async poll until the process exits.
+    /// Async wait until the process exits.
     ///
-    /// Polls every 500ms until the process terminates.
+    /// Uses platform-native event-driven mechanisms for near-zero latency:
+    /// - **Linux**: `pidfd_open()` (kernel 5.3+) with Tokio `AsyncFd`
+    /// - **macOS**: `kqueue` + `EVFILT_PROC` + `NOTE_EXIT` with Tokio `AsyncFd`
+    /// - **Fallback**: 100ms polling via `try_wait()` if event-driven setup fails
     pub async fn wait_for_exit(&self) -> ProcessExit {
-        let poll_interval = Duration::from_millis(500);
+        // Fast path: already dead.
+        if let Some(exit) = self.try_wait() {
+            return exit;
+        }
+
+        // Try event-driven detection (platform-specific).
+        #[cfg(target_os = "linux")]
+        if let Some(exit) = self.wait_pidfd().await {
+            return exit;
+        }
+
+        #[cfg(target_os = "macos")]
+        if let Some(exit) = self.wait_kqueue().await {
+            return exit;
+        }
+
+        // Fallback for older kernels or when event-driven setup fails.
+        self.wait_polling().await
+    }
+
+    /// Fallback: poll `try_wait()` at a fixed interval.
+    ///
+    /// Only used when `pidfd_open()` (Linux < 5.3) or `kqueue` setup fails.
+    async fn wait_polling(&self) -> ProcessExit {
+        let poll_interval = Duration::from_millis(100);
         loop {
             if let Some(exit) = self.try_wait() {
                 return exit;
             }
             tokio::time::sleep(poll_interval).await;
+        }
+    }
+
+    /// Linux: event-driven process exit detection via `pidfd_open()`.
+    ///
+    /// Returns a pollable FD that becomes readable when the process exits.
+    /// Available on kernel 5.3+. Returns `None` if unavailable, allowing
+    /// the caller to fall back to polling.
+    #[cfg(target_os = "linux")]
+    async fn wait_pidfd(&self) -> Option<ProcessExit> {
+        use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+        use tokio::io::unix::AsyncFd;
+
+        // SAFETY: pidfd_open() returns a pollable FD for the target process.
+        // Returns -1 with ESRCH (process dead) or ENOSYS (kernel < 5.3).
+        let raw_fd = unsafe { libc::syscall(libc::SYS_pidfd_open, self.pid as i32, 0u32) } as i32;
+        if raw_fd < 0 {
+            return None;
+        }
+
+        // SAFETY: raw_fd is a valid, open FD from pidfd_open(). OwnedFd takes
+        // ownership immediately so all error paths are leak-free.
+        let owned = unsafe { OwnedFd::from_raw_fd(raw_fd) };
+
+        // SAFETY: owned.as_raw_fd() is a valid open FD. fcntl(F_SETFD) and
+        // fcntl(F_SETFL) do not take ownership.
+        unsafe {
+            libc::fcntl(owned.as_raw_fd(), libc::F_SETFD, libc::FD_CLOEXEC);
+            if libc::fcntl(owned.as_raw_fd(), libc::F_SETFL, libc::O_NONBLOCK) < 0 {
+                return None; // OwnedFd closes the FD on drop
+            }
+        }
+
+        let async_fd = AsyncFd::new(owned).ok()?;
+
+        // Best-effort fast return: if process died between the initial
+        // try_wait() and pidfd_open(), skip waiting. Not a correctness gate —
+        // the pidfd/readable path also handles this correctly.
+        if !self.is_alive() {
+            return Some(self.try_wait().unwrap_or(ProcessExit::Unknown));
+        }
+
+        // Wait for the pidfd to become readable (process exit).
+        match async_fd.readable().await {
+            Ok(_guard) => Some(self.try_wait().unwrap_or(ProcessExit::Unknown)),
+            Err(_) => None,
+        }
+    }
+
+    /// macOS: event-driven process exit detection via `kqueue` + `EVFILT_PROC`.
+    ///
+    /// Registers a `NOTE_EXIT` event on a kqueue for the target PID. The kqueue
+    /// FD becomes readable when the process exits. Returns `None` if setup fails,
+    /// allowing the caller to fall back to polling.
+    #[cfg(target_os = "macos")]
+    async fn wait_kqueue(&self) -> Option<ProcessExit> {
+        use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+        use tokio::io::unix::AsyncFd;
+
+        // SAFETY: kqueue() creates a new kernel event queue FD.
+        let kq = unsafe { libc::kqueue() };
+        if kq < 0 {
+            return None;
+        }
+
+        // SAFETY: kq is a valid, open FD from kqueue(). OwnedFd takes
+        // ownership immediately so all error paths are leak-free.
+        let owned = unsafe { OwnedFd::from_raw_fd(kq) };
+
+        // Block scope: kevent struct contains *mut c_void (udata field) which
+        // is not Send. Must be dropped before any .await points.
+        {
+            let change = libc::kevent {
+                ident: self.pid as usize,
+                filter: libc::EVFILT_PROC,
+                flags: libc::EV_ADD | libc::EV_ONESHOT,
+                fflags: libc::NOTE_EXIT,
+                data: 0,
+                udata: std::ptr::null_mut(),
+            };
+
+            // SAFETY: kevent() with changelist registers the event filter.
+            // owned.as_raw_fd() is valid. Returns -1 with ESRCH if process dead.
+            let ret = unsafe {
+                libc::kevent(
+                    owned.as_raw_fd(),
+                    &change,
+                    1,
+                    std::ptr::null_mut(),
+                    0,
+                    std::ptr::null(),
+                )
+            };
+            if ret < 0 {
+                return None; // OwnedFd closes the kqueue FD on drop
+            }
+        }
+
+        // SAFETY: owned.as_raw_fd() is a valid open FD. fcntl(F_SETFD) and
+        // fcntl(F_SETFL) do not take ownership.
+        unsafe {
+            libc::fcntl(owned.as_raw_fd(), libc::F_SETFD, libc::FD_CLOEXEC);
+            if libc::fcntl(owned.as_raw_fd(), libc::F_SETFL, libc::O_NONBLOCK) < 0 {
+                return None; // OwnedFd closes the kqueue FD on drop
+            }
+        }
+
+        let async_fd = AsyncFd::new(owned).ok()?;
+
+        // Best-effort fast return: if process died between the initial
+        // try_wait() and kevent registration, skip waiting. Not a correctness
+        // gate — the kqueue/readable path also handles this correctly.
+        if !self.is_alive() {
+            return Some(self.try_wait().unwrap_or(ProcessExit::Unknown));
+        }
+
+        // Wait for the kqueue FD to become readable (process exit).
+        match async_fd.readable().await {
+            Ok(_guard) => Some(self.try_wait().unwrap_or(ProcessExit::Unknown)),
+            Err(_) => None,
         }
     }
 }
@@ -584,6 +731,66 @@ mod tests {
 
         let result = read_pid_file(file.path());
         assert!(result.is_err());
+    }
+
+    // ========================================================================
+    // Event-driven wait_for_exit tests
+    // ========================================================================
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[tokio::test]
+    #[allow(clippy::zombie_processes)] // wait_for_exit() calls waitpid() internally
+    async fn test_wait_for_exit_captures_exit_code() {
+        use std::process::Command;
+
+        // Spawn a child that exits with code 7
+        let child = Command::new("sh")
+            .arg("-c")
+            .arg("exit 7")
+            .spawn()
+            .expect("Failed to spawn child");
+
+        let monitor = ProcessMonitor::new(child.id());
+        let exit = monitor.wait_for_exit().await;
+        assert_eq!(exit, ProcessExit::Code(7));
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[tokio::test]
+    #[allow(clippy::zombie_processes)]
+    async fn test_wait_for_exit_detects_delayed_exit() {
+        use std::process::Command;
+        use std::time::Instant;
+
+        // Spawn a child that sleeps 200ms then exits
+        let child = Command::new("sh")
+            .arg("-c")
+            .arg("sleep 0.2; exit 3")
+            .spawn()
+            .expect("Failed to spawn child");
+
+        let monitor = ProcessMonitor::new(child.id());
+        let start = Instant::now();
+        let exit = monitor.wait_for_exit().await;
+        let elapsed = start.elapsed();
+
+        assert_eq!(exit, ProcessExit::Code(3));
+        // Event-driven detection should return shortly after the 200ms sleep,
+        // well within 2 seconds (old 500ms polling could take up to 700ms).
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "wait_for_exit took {:?}, expected prompt detection",
+            elapsed
+        );
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[tokio::test]
+    async fn test_wait_for_exit_already_dead_pid() {
+        // Non-existent PID should return Unknown immediately
+        let monitor = ProcessMonitor::new(999999999);
+        let exit = monitor.wait_for_exit().await;
+        assert_eq!(exit, ProcessExit::Unknown);
     }
 
     #[test]

--- a/src/boxlite/src/util/process.rs
+++ b/src/boxlite/src/util/process.rs
@@ -793,6 +793,80 @@ mod tests {
         assert_eq!(exit, ProcessExit::Unknown);
     }
 
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[tokio::test]
+    #[allow(clippy::zombie_processes)]
+    async fn test_wait_for_exit_signal_kill() {
+        use std::process::Command;
+
+        // Spawn a long-lived child, then SIGKILL it.
+        // Exercises the WIFSIGNALED decode path through event-driven detection.
+        let child = Command::new("sh")
+            .arg("-c")
+            .arg("sleep 60")
+            .spawn()
+            .expect("Failed to spawn child");
+
+        let pid = child.id();
+        let monitor = ProcessMonitor::new(pid);
+
+        // Give the child a moment to start, then kill it.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        unsafe { libc::kill(pid as i32, libc::SIGKILL) };
+
+        let exit = monitor.wait_for_exit().await;
+        assert_eq!(exit, ProcessExit::Code(128 + libc::SIGKILL));
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[tokio::test]
+    #[allow(clippy::zombie_processes)]
+    async fn test_wait_for_exit_concurrent_monitors() {
+        use std::process::Command;
+
+        // Spawn 3 children with different exit codes.
+        // Verify concurrent pidfd/kqueue FD registrations all resolve correctly.
+        let codes = [1, 2, 3];
+        let mut monitors = Vec::new();
+
+        for &code in &codes {
+            let child = Command::new("sh")
+                .arg("-c")
+                .arg(format!("exit {code}"))
+                .spawn()
+                .expect("Failed to spawn child");
+            monitors.push(ProcessMonitor::new(child.id()));
+        }
+
+        let (r0, r1, r2) = tokio::join!(
+            monitors[0].wait_for_exit(),
+            monitors[1].wait_for_exit(),
+            monitors[2].wait_for_exit(),
+        );
+
+        assert_eq!(r0, ProcessExit::Code(1));
+        assert_eq!(r1, ProcessExit::Code(2));
+        assert_eq!(r2, ProcessExit::Code(3));
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[tokio::test]
+    #[allow(clippy::zombie_processes)]
+    async fn test_wait_polling_captures_exit_code() {
+        use std::process::Command;
+
+        // Test the polling fallback path directly.
+        let child = Command::new("sh")
+            .arg("-c")
+            .arg("exit 5")
+            .spawn()
+            .expect("Failed to spawn child");
+
+        let monitor = ProcessMonitor::new(child.id());
+        let exit = monitor.wait_polling().await;
+        assert_eq!(exit, ProcessExit::Code(5));
+    }
+
     #[test]
     fn test_process_exit_equality() {
         assert_eq!(ProcessExit::Code(0), ProcessExit::Code(0));


### PR DESCRIPTION
## Summary

- Replace `ProcessMonitor::wait_for_exit()` 500ms sleep-based polling loop with platform-native event-driven process exit detection
- **Linux**: `pidfd_open()` (kernel 5.3+) wrapped in `tokio::io::unix::AsyncFd` for near-zero latency
- **macOS**: `kqueue` + `EVFILT_PROC` + `NOTE_EXIT` wrapped in `AsyncFd`
- **Fallback**: 100ms polling for older kernels (Linux < 5.3) when event-driven setup fails
- Fixes violation of project Rule #15: "No Sleep for Events"

## Motivation

`ProcessMonitor::wait_for_exit()` is used in production at `guest_connect.rs` inside a `tokio::select!` race to detect VM subprocess death during startup. The 500ms polling loop added up to 500ms latency to crash detection. With `pidfd`/`kqueue`, detection is near-instantaneous.

## Design

```
wait_for_exit()
  ├── Fast path: try_wait() → already dead? return immediately
  ├── Linux: pidfd_open() + AsyncFd::readable().await
  ├── macOS: kqueue(EVFILT_PROC, NOTE_EXIT) + AsyncFd::readable().await
  └── Fallback: 100ms polling loop (for kernel < 5.3)
```

Key safety decisions:
- `OwnedFd` wraps raw FDs immediately after creation — all error paths are leak-free by construction
- `fcntl(O_NONBLOCK)` return checked; falls back to polling on failure (required by `AsyncFd`)
- Block scope for `kevent` struct (contains `*mut c_void`, not `Send`) — dropped before `.await`
- Best-effort race guard via `is_alive()` after FD setup, before `.await`
- No new crate dependencies — uses existing `libc` + `tokio` (already in `Cargo.toml`)

## Test plan

- [x] New async test: `test_wait_for_exit_captures_exit_code` — verifies exit code through event-driven path
- [x] New async test: `test_wait_for_exit_detects_delayed_exit` — spawns child with 200ms delay, verifies prompt detection
- [x] New async test: `test_wait_for_exit_already_dead_pid` — non-existent PID returns `Unknown` immediately
- [x] All 598 existing tests pass on macOS ARM64
- [x] All process tests (31/31) pass on Linux ARM64 (via Lima VM)
- [x] Clippy clean (zero warnings) on both platforms
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process exit detection for faster and more reliable status updates.
  * Added resilient fallback handling when native exit notifications are unavailable.
  * Improved cleanup of inherited file descriptors, including high-numbered descriptors, reducing resource leaks during process startup.
  * Enhanced handling of processes that have already exited or were terminated by signals.
  * Improved reliability when monitoring multiple processes concurrently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->