### PR TITLE
feat(python-sdk): expose EventListener to Python SDK with typed error mapping

### DIFF
--- a/sdks/python/boxlite/__init__.py
+++ b/sdks/python/boxlite/__init__.py
@@ -75,7 +75,27 @@ except ImportError as e:
 # Import Python convenience wrappers (re-exported via __all__)
 try:
     from .codebox import CodeBox  # noqa: F401
-    from .errors import BoxliteError, ExecError, ParseError, TimeoutError  # noqa: F401
+    from .errors import (  # noqa: F401
+        AlreadyExistsError,
+        BoxliteError,
+        ConfigError,
+        DatabaseError,
+        EngineError,
+        ExecError,
+        ExecutionError,
+        ImageError,
+        InternalError,
+        InvalidArgumentError,
+        InvalidStateError,
+        NetworkError,
+        NotFoundError,
+        ParseError,
+        PortalError,
+        RpcError,
+        StoppedError,
+        StorageError,
+        TimeoutError,
+    )
     from .exec import ExecResult  # noqa: F401
     from .simplebox import SimpleBox  # noqa: F401
 
@@ -85,8 +105,25 @@ try:
             "SimpleBox",
             "CodeBox",
             "ExecResult",
-            # Error types
+            # Error types (base)
             "BoxliteError",
+            # Error types (mapped from Rust)
+            "EngineError",
+            "ConfigError",
+            "StorageError",
+            "ImageError",
+            "PortalError",
+            "NetworkError",
+            "RpcError",
+            "InternalError",
+            "ExecutionError",
+            "NotFoundError",
+            "AlreadyExistsError",
+            "InvalidStateError",
+            "DatabaseError",
+            "InvalidArgumentError",
+            "StoppedError",
+            # Error types (Python convenience)
             "ExecError",
             "TimeoutError",
             "ParseError",

--- a/sdks/python/boxlite/__init__.py
+++ b/sdks/python/boxlite/__init__.py
@@ -72,9 +72,8 @@ except ImportError as e:
     warnings.warn(f"BoxLite native extension not available: {e}", ImportWarning)
     __all__ = []
 
-# Import Python convenience wrappers (re-exported via __all__)
+# Import error types (pure Python, always available independently of native extensions)
 try:
-    from .codebox import CodeBox  # noqa: F401
     from .errors import (  # noqa: F401
         AlreadyExistsError,
         BoxliteError,
@@ -91,20 +90,15 @@ try:
         NotFoundError,
         ParseError,
         PortalError,
+        ResourceExhaustedError,
         RpcError,
         StoppedError,
         StorageError,
         TimeoutError,
     )
-    from .exec import ExecResult  # noqa: F401
-    from .simplebox import SimpleBox  # noqa: F401
 
     __all__.extend(
         [
-            # Python convenience wrappers
-            "SimpleBox",
-            "CodeBox",
-            "ExecResult",
             # Error types (base)
             "BoxliteError",
             # Error types (mapped from Rust)
@@ -123,10 +117,27 @@ try:
             "DatabaseError",
             "InvalidArgumentError",
             "StoppedError",
+            "ResourceExhaustedError",
             # Error types (Python convenience)
             "ExecError",
             "TimeoutError",
             "ParseError",
+        ]
+    )
+except ImportError:
+    pass
+
+# Import Python convenience wrappers (re-exported via __all__)
+try:
+    from .codebox import CodeBox  # noqa: F401
+    from .exec import ExecResult  # noqa: F401
+    from .simplebox import SimpleBox  # noqa: F401
+
+    __all__.extend(
+        [
+            "SimpleBox",
+            "CodeBox",
+            "ExecResult",
         ]
     )
 except ImportError:

--- a/sdks/python/boxlite/errors.py
+++ b/sdks/python/boxlite/errors.py
@@ -21,6 +21,7 @@ __all__ = [
     "DatabaseError",
     "InvalidArgumentError",
     "StoppedError",
+    "ResourceExhaustedError",
     # Convenience aliases
     "ExecError",
     "TimeoutError",
@@ -123,6 +124,12 @@ class InvalidArgumentError(BoxliteError):
 
 class StoppedError(BoxliteError):
     """Raised when operating on a stopped box or shutdown runtime."""
+
+    pass
+
+
+class ResourceExhaustedError(BoxliteError):
+    """Raised when a system resource limit is reached (e.g., VM address spaces exhausted)."""
 
     pass
 

--- a/sdks/python/boxlite/errors.py
+++ b/sdks/python/boxlite/errors.py
@@ -1,16 +1,133 @@
 """
 BoxLite error types.
 
-Provides a hierarchy of exceptions for different failure modes.
+Provides a hierarchy of exceptions matching the Rust BoxliteError variants.
 """
 
-__all__ = ["BoxliteError", "ExecError", "TimeoutError", "ParseError"]
+__all__ = [
+    "BoxliteError",
+    "EngineError",
+    "ConfigError",
+    "StorageError",
+    "ImageError",
+    "PortalError",
+    "NetworkError",
+    "RpcError",
+    "InternalError",
+    "ExecutionError",
+    "NotFoundError",
+    "AlreadyExistsError",
+    "InvalidStateError",
+    "DatabaseError",
+    "InvalidArgumentError",
+    "StoppedError",
+    # Convenience aliases
+    "ExecError",
+    "TimeoutError",
+    "ParseError",
+]
 
 
 class BoxliteError(Exception):
     """Base exception for all boxlite errors."""
 
     pass
+
+
+# ── Mapped from Rust BoxliteError variants ───────────────────────────────
+
+
+class EngineError(BoxliteError):
+    """Raised when the VM engine reports an error."""
+
+    pass
+
+
+class ConfigError(BoxliteError):
+    """Raised for configuration errors (invalid options, incompatible settings)."""
+
+    pass
+
+
+class StorageError(BoxliteError):
+    """Raised when a filesystem or storage operation fails."""
+
+    pass
+
+
+class ImageError(BoxliteError):
+    """Raised when image pull, resolution, or extraction fails."""
+
+    pass
+
+
+class PortalError(BoxliteError):
+    """Raised when host-guest communication (gRPC portal) fails."""
+
+    pass
+
+
+class NetworkError(BoxliteError):
+    """Raised when a networking operation fails."""
+
+    pass
+
+
+class RpcError(BoxliteError):
+    """Raised when a gRPC or transport-level error occurs."""
+
+    pass
+
+
+class InternalError(BoxliteError):
+    """Raised for unexpected internal errors."""
+
+    pass
+
+
+class ExecutionError(BoxliteError):
+    """Raised when command execution fails at the runtime level."""
+
+    pass
+
+
+class NotFoundError(BoxliteError):
+    """Raised when a box or resource is not found."""
+
+    pass
+
+
+class AlreadyExistsError(BoxliteError):
+    """Raised when a box or resource already exists."""
+
+    pass
+
+
+class InvalidStateError(BoxliteError):
+    """Raised when a box is in the wrong state for the requested operation."""
+
+    pass
+
+
+class DatabaseError(BoxliteError):
+    """Raised when a database operation fails."""
+
+    pass
+
+
+class InvalidArgumentError(BoxliteError):
+    """Raised when an invalid argument is provided."""
+
+    pass
+
+
+class StoppedError(BoxliteError):
+    """Raised when operating on a stopped box or shutdown runtime."""
+
+    pass
+
+
+# ── Convenience exceptions (Python-side only) ────────────────────────────
 
 
 class ExecError(BoxliteError):

--- a/sdks/python/src/box_handle.rs
+++ b/sdks/python/src/box_handle.rs
@@ -5,7 +5,7 @@ use crate::info::PyBoxInfo;
 use crate::metrics::PyBoxMetrics;
 use crate::snapshot_options::{PyCloneOptions, PyExportOptions};
 use crate::snapshots::PySnapshotHandle;
-use crate::util::map_err;
+use crate::util::map_boxlite_err;
 use boxlite::{BoxCommand, CloneOptions, ExportOptions, LiteBox};
 use pyo3::prelude::*;
 
@@ -78,7 +78,7 @@ impl PyBox {
                 cmd = cmd.working_dir(cwd);
             }
 
-            let execution = handle.exec(cmd).await.map_err(map_err)?;
+            let execution = handle.exec(cmd).await.map_err(map_boxlite_err)?;
 
             Ok(PyExecution {
                 execution: Arc::new(execution),
@@ -91,7 +91,7 @@ impl PyBox {
         let handle = Arc::clone(&self.handle);
 
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            handle.start().await.map_err(map_err)?;
+            handle.start().await.map_err(map_boxlite_err)?;
             Ok(())
         })
     }
@@ -101,7 +101,7 @@ impl PyBox {
         let handle = Arc::clone(&self.handle);
 
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            handle.stop().await.map_err(map_err)?;
+            handle.stop().await.map_err(map_boxlite_err)?;
             Ok(())
         })
     }
@@ -110,7 +110,7 @@ impl PyBox {
         let handle = Arc::clone(&self.handle);
 
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            let metrics = handle.metrics().await.map_err(map_err)?;
+            let metrics = handle.metrics().await.map_err(map_boxlite_err)?;
             Ok(PyBoxMetrics::from(metrics))
         })
     }
@@ -129,7 +129,7 @@ impl PyBox {
             let archive = handle
                 .export(options, std::path::Path::new(&dest))
                 .await
-                .map_err(map_err)?;
+                .map_err(map_boxlite_err)?;
             Ok(archive.path().to_string_lossy().to_string())
         })
     }
@@ -145,7 +145,10 @@ impl PyBox {
         let handle = Arc::clone(&self.handle);
         let options: CloneOptions = options.map(Into::into).unwrap_or_default();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            let cloned = handle.clone_box(options, name).await.map_err(map_err)?;
+            let cloned = handle
+                .clone_box(options, name)
+                .await
+                .map_err(map_boxlite_err)?;
             Ok(PyBox {
                 handle: Arc::new(cloned),
             })
@@ -169,7 +172,7 @@ impl PyBox {
             handle
                 .copy_into(std::path::Path::new(&host_path), &container_dest, opts)
                 .await
-                .map_err(map_err)?;
+                .map_err(map_boxlite_err)?;
             Ok(())
         })
     }
@@ -191,7 +194,7 @@ impl PyBox {
             handle
                 .copy_out(&container_src, std::path::Path::new(&host_dest), opts)
                 .await
-                .map_err(map_err)?;
+                .map_err(map_boxlite_err)?;
             Ok(())
         })
     }
@@ -202,7 +205,7 @@ impl PyBox {
 
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             // Auto-start on context entry
-            handle.start().await.map_err(map_err)?;
+            handle.start().await.map_err(map_boxlite_err)?;
             Ok(PyBox { handle })
         })
     }
@@ -218,7 +221,7 @@ impl PyBox {
         let handle = Arc::clone(&slf.handle);
 
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            handle.stop().await.map_err(map_err)?;
+            handle.stop().await.map_err(map_boxlite_err)?;
             Ok(())
         })
     }

--- a/sdks/python/src/event_listener.rs
+++ b/sdks/python/src/event_listener.rs
@@ -1,0 +1,161 @@
+//! Python bindings for the EventListener trait.
+//!
+//! Bridges Python callback objects to the Rust `EventListener` trait.
+//! Python users pass an object with optional `on_*` methods; only implemented
+//! methods are called.
+
+use std::time::Duration;
+
+use boxlite::BoxID;
+use boxlite::event_listener::EventListener;
+use pyo3::prelude::*;
+
+/// Python-side event listener that delegates to a Python object.
+///
+/// The Python object can implement any subset of the callback methods:
+///
+/// ```python
+/// class MyListener:
+///     def on_box_created(self, box_id: str) -> None: ...
+///     def on_box_started(self, box_id: str) -> None: ...
+///     def on_box_stopped(self, box_id: str, exit_code: int | None) -> None: ...
+///     def on_box_removed(self, box_id: str) -> None: ...
+///     def on_exec_started(self, box_id: str, command: str, args: list[str]) -> None: ...
+///     def on_exec_completed(self, box_id: str, command: str, exit_code: int, duration_secs: float) -> None: ...
+///     def on_file_copied_in(self, box_id: str, host_src: str, container_dst: str) -> None: ...
+///     def on_file_copied_out(self, box_id: str, container_src: str, host_dst: str) -> None: ...
+/// ```
+///
+/// Missing methods are silently skipped (no-op).
+pub(crate) struct PyEventListener {
+    callback: Py<PyAny>,
+}
+
+// SAFETY: `Py<PyAny>` is `Send` in PyO3 0.27 but not `Sync`. We need `Sync`
+// because `EventListener: Send + Sync` (listeners are shared across async tasks
+// via `Arc`). This `impl Sync` is sound because:
+//
+// 1. The only field (`callback: Py<PyAny>`) is never accessed outside
+//    `Python::attach` blocks, which acquire the GIL before any interaction.
+// 2. `Py::call_method1` with a valid `Python<'_>` token is safe to invoke
+//    from multiple threads — the GIL serializes all Python execution.
+// 3. The `Py<PyAny>` is never cloned or dropped outside GIL-protected contexts
+//    (only `Arc<PyEventListener>` is cloned, which is an atomic refcount op).
+//
+// INVARIANT: Do NOT access `self.callback` outside a `Python::attach` closure.
+// Violating this invariant would be undefined behavior.
+//
+// NOTE: This assumes CPython's GIL. Free-threaded Python (PEP 703) would
+// require revisiting this safety argument.
+unsafe impl Sync for PyEventListener {}
+
+impl PyEventListener {
+    pub(crate) fn new(callback: Py<PyAny>) -> Self {
+        Self { callback }
+    }
+}
+
+/// Log non-AttributeError callback failures. AttributeError means the Python
+/// object didn't implement that particular method, which is expected.
+fn log_callback_err(py: Python<'_>, method: &str, err: &PyErr) {
+    if !err.is_instance_of::<pyo3::exceptions::PyAttributeError>(py) {
+        tracing::warn!("EventListener.{} callback error: {}", method, err);
+    }
+}
+
+impl EventListener for PyEventListener {
+    fn on_box_created(&self, box_id: &BoxID) {
+        let id = box_id.to_string();
+        Python::attach(|py| {
+            if let Err(ref e) = self.callback.call_method1(py, "on_box_created", (id,)) {
+                log_callback_err(py, "on_box_created", e);
+            }
+        });
+    }
+
+    fn on_box_started(&self, box_id: &BoxID) {
+        let id = box_id.to_string();
+        Python::attach(|py| {
+            if let Err(ref e) = self.callback.call_method1(py, "on_box_started", (id,)) {
+                log_callback_err(py, "on_box_started", e);
+            }
+        });
+    }
+
+    fn on_box_stopped(&self, box_id: &BoxID, exit_code: Option<i32>) {
+        let id = box_id.to_string();
+        Python::attach(|py| {
+            if let Err(ref e) = self
+                .callback
+                .call_method1(py, "on_box_stopped", (id, exit_code))
+            {
+                log_callback_err(py, "on_box_stopped", e);
+            }
+        });
+    }
+
+    fn on_box_removed(&self, box_id: &BoxID) {
+        let id = box_id.to_string();
+        Python::attach(|py| {
+            if let Err(ref e) = self.callback.call_method1(py, "on_box_removed", (id,)) {
+                log_callback_err(py, "on_box_removed", e);
+            }
+        });
+    }
+
+    fn on_exec_started(&self, box_id: &BoxID, command: &str, args: &[String]) {
+        let id = box_id.to_string();
+        let cmd = command.to_string();
+        let a = args.to_vec();
+        Python::attach(|py| {
+            if let Err(ref e) = self
+                .callback
+                .call_method1(py, "on_exec_started", (id, cmd, a))
+            {
+                log_callback_err(py, "on_exec_started", e);
+            }
+        });
+    }
+
+    fn on_exec_completed(&self, box_id: &BoxID, command: &str, exit_code: i32, duration: Duration) {
+        let id = box_id.to_string();
+        let cmd = command.to_string();
+        let secs = duration.as_secs_f64();
+        Python::attach(|py| {
+            if let Err(ref e) =
+                self.callback
+                    .call_method1(py, "on_exec_completed", (id, cmd, exit_code, secs))
+            {
+                log_callback_err(py, "on_exec_completed", e);
+            }
+        });
+    }
+
+    fn on_file_copied_in(&self, box_id: &BoxID, host_src: &str, container_dst: &str) {
+        let id = box_id.to_string();
+        let src = host_src.to_string();
+        let dst = container_dst.to_string();
+        Python::attach(|py| {
+            if let Err(ref e) = self
+                .callback
+                .call_method1(py, "on_file_copied_in", (id, src, dst))
+            {
+                log_callback_err(py, "on_file_copied_in", e);
+            }
+        });
+    }
+
+    fn on_file_copied_out(&self, box_id: &BoxID, container_src: &str, host_dst: &str) {
+        let id = box_id.to_string();
+        let src = container_src.to_string();
+        let dst = host_dst.to_string();
+        Python::attach(|py| {
+            if let Err(ref e) = self
+                .callback
+                .call_method1(py, "on_file_copied_out", (id, src, dst))
+            {
+                log_callback_err(py, "on_file_copied_out", e);
+            }
+        });
+    }
+}

--- a/sdks/python/src/event_listener.rs
+++ b/sdks/python/src/event_listener.rs
@@ -12,6 +12,11 @@ use pyo3::prelude::*;
 
 /// Python-side event listener that delegates to a Python object.
 ///
+/// **Threading:** Callbacks run synchronously on the Rust caller thread (the
+/// async task performing the operation). Slow Python handlers will stall
+/// runtime operations — keep callbacks fast or offload heavy work to a
+/// background thread/task.
+///
 /// The Python object can implement any subset of the callback methods:
 ///
 /// ```python
@@ -39,8 +44,9 @@ pub(crate) struct PyEventListener {
 //    `Python::attach` blocks, which acquire the GIL before any interaction.
 // 2. `Py::call_method1` with a valid `Python<'_>` token is safe to invoke
 //    from multiple threads — the GIL serializes all Python execution.
-// 3. The `Py<PyAny>` is never cloned or dropped outside GIL-protected contexts
-//    (only `Arc<PyEventListener>` is cloned, which is an atomic refcount op).
+// 3. When the last `Arc<PyEventListener>` is dropped, PyO3's `Py<T>` drop
+//    implementation acquires the GIL internally to release the Python object,
+//    so this is safe even if the drop occurs on a non-Python thread.
 //
 // INVARIANT: Do NOT access `self.callback` outside a `Python::attach` closure.
 // Violating this invariant would be undefined behavior.
@@ -55,51 +61,48 @@ impl PyEventListener {
     }
 }
 
-/// Log non-AttributeError callback failures. AttributeError means the Python
-/// object didn't implement that particular method, which is expected.
-fn log_callback_err(py: Python<'_>, method: &str, err: &PyErr) {
-    if !err.is_instance_of::<pyo3::exceptions::PyAttributeError>(py) {
-        tracing::warn!("EventListener.{} callback error: {}", method, err);
-    }
+/// Call a Python callback method if it exists on the listener object.
+///
+/// Uses `hasattr` to check for the method first, then calls it. This avoids
+/// suppressing real `AttributeError` exceptions raised *inside* a user callback
+/// (which would be silently swallowed if we relied on catching `AttributeError`
+/// from `call_method1`).
+macro_rules! call_if_exists {
+    ($py:expr, $obj:expr, $method:expr, $args:expr) => {
+        if $obj.bind($py).hasattr($method).unwrap_or(false) {
+            if let Err(ref e) = $obj.call_method1($py, $method, $args) {
+                tracing::warn!("EventListener.{} callback error: {}", $method, e);
+            }
+        }
+    };
 }
 
 impl EventListener for PyEventListener {
     fn on_box_created(&self, box_id: &BoxID) {
         let id = box_id.to_string();
         Python::attach(|py| {
-            if let Err(ref e) = self.callback.call_method1(py, "on_box_created", (id,)) {
-                log_callback_err(py, "on_box_created", e);
-            }
+            call_if_exists!(py, &self.callback, "on_box_created", (id,));
         });
     }
 
     fn on_box_started(&self, box_id: &BoxID) {
         let id = box_id.to_string();
         Python::attach(|py| {
-            if let Err(ref e) = self.callback.call_method1(py, "on_box_started", (id,)) {
-                log_callback_err(py, "on_box_started", e);
-            }
+            call_if_exists!(py, &self.callback, "on_box_started", (id,));
         });
     }
 
     fn on_box_stopped(&self, box_id: &BoxID, exit_code: Option<i32>) {
         let id = box_id.to_string();
         Python::attach(|py| {
-            if let Err(ref e) = self
-                .callback
-                .call_method1(py, "on_box_stopped", (id, exit_code))
-            {
-                log_callback_err(py, "on_box_stopped", e);
-            }
+            call_if_exists!(py, &self.callback, "on_box_stopped", (id, exit_code));
         });
     }
 
     fn on_box_removed(&self, box_id: &BoxID) {
         let id = box_id.to_string();
         Python::attach(|py| {
-            if let Err(ref e) = self.callback.call_method1(py, "on_box_removed", (id,)) {
-                log_callback_err(py, "on_box_removed", e);
-            }
+            call_if_exists!(py, &self.callback, "on_box_removed", (id,));
         });
     }
 
@@ -108,12 +111,7 @@ impl EventListener for PyEventListener {
         let cmd = command.to_string();
         let a = args.to_vec();
         Python::attach(|py| {
-            if let Err(ref e) = self
-                .callback
-                .call_method1(py, "on_exec_started", (id, cmd, a))
-            {
-                log_callback_err(py, "on_exec_started", e);
-            }
+            call_if_exists!(py, &self.callback, "on_exec_started", (id, cmd, a));
         });
     }
 
@@ -122,12 +120,12 @@ impl EventListener for PyEventListener {
         let cmd = command.to_string();
         let secs = duration.as_secs_f64();
         Python::attach(|py| {
-            if let Err(ref e) =
-                self.callback
-                    .call_method1(py, "on_exec_completed", (id, cmd, exit_code, secs))
-            {
-                log_callback_err(py, "on_exec_completed", e);
-            }
+            call_if_exists!(
+                py,
+                &self.callback,
+                "on_exec_completed",
+                (id, cmd, exit_code, secs)
+            );
         });
     }
 
@@ -136,12 +134,7 @@ impl EventListener for PyEventListener {
         let src = host_src.to_string();
         let dst = container_dst.to_string();
         Python::attach(|py| {
-            if let Err(ref e) = self
-                .callback
-                .call_method1(py, "on_file_copied_in", (id, src, dst))
-            {
-                log_callback_err(py, "on_file_copied_in", e);
-            }
+            call_if_exists!(py, &self.callback, "on_file_copied_in", (id, src, dst));
         });
     }
 
@@ -150,12 +143,7 @@ impl EventListener for PyEventListener {
         let src = container_src.to_string();
         let dst = host_dst.to_string();
         Python::attach(|py| {
-            if let Err(ref e) = self
-                .callback
-                .call_method1(py, "on_file_copied_out", (id, src, dst))
-            {
-                log_callback_err(py, "on_file_copied_out", e);
-            }
+            call_if_exists!(py, &self.callback, "on_file_copied_out", (id, src, dst));
         });
     }
 }

--- a/sdks/python/src/exec.rs
+++ b/sdks/python/src/exec.rs
@@ -1,4 +1,4 @@
-use crate::util::map_err;
+use crate::util::{map_boxlite_err, map_err};
 use boxlite::Execution;
 use pyo3::{Bound, PyAny, PyRef, PyResult, Python, pyclass, pymethods};
 use std::sync::Arc;
@@ -170,7 +170,7 @@ impl PyExecution {
 
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let execution_mut = unsafe { &mut *(Arc::as_ptr(&execution) as *mut Execution) };
-            let exec_result = execution_mut.wait().await.map_err(map_err)?;
+            let exec_result = execution_mut.wait().await.map_err(map_boxlite_err)?;
             Ok(PyExecResult {
                 exit_code: exec_result.exit_code,
                 error_message: exec_result.error_message,
@@ -183,7 +183,7 @@ impl PyExecution {
 
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let execution_mut = unsafe { &mut *(Arc::as_ptr(&execution) as *mut Execution) };
-            execution_mut.kill().await.map_err(map_err)?;
+            execution_mut.kill().await.map_err(map_boxlite_err)?;
             Ok(())
         })
     }
@@ -195,7 +195,10 @@ impl PyExecution {
         let execution = Arc::clone(&self.execution);
 
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            execution.resize_tty(rows, cols).await.map_err(map_err)?;
+            execution
+                .resize_tty(rows, cols)
+                .await
+                .map_err(map_boxlite_err)?;
             Ok(())
         })
     }

--- a/sdks/python/src/lib.rs
+++ b/sdks/python/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod advanced_options;
 mod box_handle;
+mod event_listener;
 mod exec;
 mod images;
 mod info;

--- a/sdks/python/src/options.rs
+++ b/sdks/python/src/options.rs
@@ -1,6 +1,8 @@
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use boxlite::BoxliteRestOptions;
+use boxlite::event_listener::EventListener;
 use boxlite::litebox::copy::CopyOptions;
 use boxlite::runtime::advanced_options::{HealthCheckOptions, SecurityOptions};
 use boxlite::runtime::constants::images;
@@ -13,33 +15,55 @@ use pyo3::prelude::*;
 use pyo3::types::{PyAnyMethods, PyDict, PyTuple};
 
 use crate::advanced_options::PyAdvancedBoxOptions;
+use crate::event_listener::PyEventListener;
 
+/// Runtime configuration options.
+///
+/// Args:
+///     home_dir: Override the default BoxLite home directory (~/.boxlite).
+///     image_registries: Registries to search for unqualified image references.
+///         Tried in order; first successful pull wins.
+///     event_listeners: List of event listener objects for lifecycle callbacks.
+///         Each object can implement any subset of: on_box_created, on_box_started,
+///         on_box_stopped, on_box_removed, on_exec_started, on_exec_completed,
+///         on_file_copied_in, on_file_copied_out.
 #[pyclass(name = "Options")]
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub(crate) struct PyOptions {
     #[pyo3(get, set)]
     pub(crate) home_dir: Option<String>,
-    /// Registries to search for unqualified image references.
-    /// Tried in order; first successful pull wins.
     #[pyo3(get, set)]
     pub(crate) image_registries: Vec<String>,
+    /// Converted from Python objects to Arc<dyn EventListener> at construction time.
+    pub(crate) event_listeners: Vec<Arc<dyn EventListener>>,
 }
 
 #[pymethods]
 impl PyOptions {
     #[new]
-    #[pyo3(signature = (home_dir=None, image_registries=vec![]))]
-    fn new(home_dir: Option<String>, image_registries: Vec<String>) -> Self {
+    #[pyo3(signature = (home_dir=None, image_registries=vec![], event_listeners=vec![]))]
+    fn new(
+        home_dir: Option<String>,
+        image_registries: Vec<String>,
+        event_listeners: Vec<Py<PyAny>>,
+    ) -> Self {
+        let listeners: Vec<Arc<dyn EventListener>> = event_listeners
+            .into_iter()
+            .map(|obj| Arc::new(PyEventListener::new(obj)) as Arc<dyn EventListener>)
+            .collect();
         Self {
             home_dir,
             image_registries,
+            event_listeners: listeners,
         }
     }
 
     fn __repr__(&self) -> String {
         format!(
-            "Options(home_dir={:?}, image_registries={:?})",
-            self.home_dir, self.image_registries
+            "Options(home_dir={:?}, image_registries={:?}, event_listeners=[{} listeners])",
+            self.home_dir,
+            self.image_registries,
+            self.event_listeners.len()
         )
     }
 }
@@ -53,6 +77,7 @@ impl From<PyOptions> for BoxliteOptions {
         }
 
         config.image_registries = py_opts.image_registries;
+        config.event_listeners = py_opts.event_listeners;
 
         config
     }

--- a/sdks/python/src/runtime.rs
+++ b/sdks/python/src/runtime.rs
@@ -8,7 +8,7 @@ use crate::images::PyImageHandle;
 use crate::info::PyBoxInfo;
 use crate::metrics::PyRuntimeMetrics;
 use crate::options::{PyBoxOptions, PyBoxliteRestOptions, PyOptions};
-use crate::util::map_err;
+use crate::util::map_boxlite_err;
 
 #[pyclass(name = "Boxlite")]
 pub(crate) struct PyBoxlite {
@@ -19,7 +19,7 @@ pub(crate) struct PyBoxlite {
 impl PyBoxlite {
     #[new]
     fn new(options: PyOptions) -> PyResult<Self> {
-        let runtime = BoxliteRuntime::new(options.into()).map_err(map_err)?;
+        let runtime = BoxliteRuntime::new(options.into()).map_err(map_boxlite_err)?;
 
         Ok(Self {
             runtime: Arc::new(runtime),
@@ -48,7 +48,7 @@ impl PyBoxlite {
     ///     runtime = boxlite.Boxlite.rest(opts)
     #[staticmethod]
     fn rest(options: PyBoxliteRestOptions) -> PyResult<Self> {
-        let runtime = BoxliteRuntime::rest(options.into()).map_err(map_err)?;
+        let runtime = BoxliteRuntime::rest(options.into()).map_err(map_boxlite_err)?;
         Ok(Self {
             runtime: Arc::new(runtime),
         })
@@ -56,7 +56,7 @@ impl PyBoxlite {
 
     #[staticmethod]
     fn init_default(options: PyOptions) -> PyResult<()> {
-        BoxliteRuntime::init_default_runtime(options.into()).map_err(map_err)
+        BoxliteRuntime::init_default_runtime(options.into()).map_err(map_boxlite_err)
     }
 
     #[pyo3(signature = (options, name=None))]
@@ -69,7 +69,7 @@ impl PyBoxlite {
         let runtime = Arc::clone(&self.runtime);
         let opts = BoxOptions::try_from(options).map_err(map_err)?;
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            let handle = runtime.create(opts, name).await.map_err(map_err)?;
+            let handle = runtime.create(opts, name).await.map_err(map_boxlite_err)?;
             Ok(PyBox {
                 handle: Arc::new(handle),
             })
@@ -84,7 +84,7 @@ impl PyBoxlite {
     ) -> PyResult<Bound<'py, PyAny>> {
         let runtime = Arc::clone(&self.runtime);
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            let infos = runtime.list_info().await.map_err(map_err)?;
+            let infos = runtime.list_info().await.map_err(map_boxlite_err)?;
             Ok(infos.into_iter().map(PyBoxInfo::from).collect::<Vec<_>>())
         })
     }
@@ -96,7 +96,7 @@ impl PyBoxlite {
             Ok(runtime
                 .get_info(&id_or_name)
                 .await
-                .map_err(map_err)?
+                .map_err(map_boxlite_err)?
                 .map(PyBoxInfo::from))
         })
     }
@@ -107,7 +107,7 @@ impl PyBoxlite {
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             tracing::trace!("Python get() called with id_or_name={}", id_or_name);
 
-            let result = runtime.get(&id_or_name).await.map_err(map_err)?;
+            let result = runtime.get(&id_or_name).await.map_err(map_boxlite_err)?;
 
             tracing::trace!("Rust get() returned: is_some={}", result.is_some());
 
@@ -134,7 +134,10 @@ impl PyBoxlite {
         let runtime = Arc::clone(&self.runtime);
         let opts = BoxOptions::try_from(options).map_err(map_err)?;
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            let (handle, created) = runtime.get_or_create(opts, name).await.map_err(map_err)?;
+            let (handle, created) = runtime
+                .get_or_create(opts, name)
+                .await
+                .map_err(map_boxlite_err)?;
             Ok((
                 PyBox {
                     handle: Arc::new(handle),
@@ -147,7 +150,7 @@ impl PyBoxlite {
     fn metrics<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let runtime = Arc::clone(&self.runtime);
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            let metrics = runtime.metrics().await.map_err(map_err)?;
+            let metrics = runtime.metrics().await.map_err(map_boxlite_err)?;
             Ok(PyRuntimeMetrics::from(metrics))
         })
     }
@@ -170,7 +173,10 @@ impl PyBoxlite {
     ) -> PyResult<Bound<'py, PyAny>> {
         let runtime = Arc::clone(&self.runtime);
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            runtime.remove(&id_or_name, force).await.map_err(map_err)?;
+            runtime
+                .remove(&id_or_name, force)
+                .await
+                .map_err(map_boxlite_err)?;
             Ok(())
         })
     }
@@ -184,7 +190,7 @@ impl PyBoxlite {
     fn shutdown<'py>(&self, py: Python<'py>, timeout: Option<i32>) -> PyResult<Bound<'py, PyAny>> {
         let runtime = Arc::clone(&self.runtime);
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            runtime.shutdown(timeout).await.map_err(map_err)?;
+            runtime.shutdown(timeout).await.map_err(map_boxlite_err)?;
             Ok(())
         })
     }
@@ -207,7 +213,10 @@ impl PyBoxlite {
         let runtime = Arc::clone(&self.runtime);
         let archive = BoxArchive::new(archive_path);
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            let handle = runtime.import_box(archive, name).await.map_err(map_err)?;
+            let handle = runtime
+                .import_box(archive, name)
+                .await
+                .map_err(map_boxlite_err)?;
             Ok(PyBox {
                 handle: Arc::new(handle),
             })

--- a/sdks/python/src/runtime.rs
+++ b/sdks/python/src/runtime.rs
@@ -8,7 +8,7 @@ use crate::images::PyImageHandle;
 use crate::info::PyBoxInfo;
 use crate::metrics::PyRuntimeMetrics;
 use crate::options::{PyBoxOptions, PyBoxliteRestOptions, PyOptions};
-use crate::util::map_boxlite_err;
+use crate::util::{map_boxlite_err, map_err};
 
 #[pyclass(name = "Boxlite")]
 pub(crate) struct PyBoxlite {

--- a/sdks/python/src/snapshots.rs
+++ b/sdks/python/src/snapshots.rs
@@ -6,7 +6,7 @@ use boxlite::{LiteBox, SnapshotInfo, SnapshotOptions};
 use pyo3::prelude::*;
 
 use crate::snapshot_options::PySnapshotOptions;
-use crate::util::map_err;
+use crate::util::map_boxlite_err;
 
 /// Snapshot metadata.
 #[pyclass(name = "SnapshotInfo")]
@@ -73,7 +73,7 @@ impl PySnapshotHandle {
                 .snapshots()
                 .create(options, &name)
                 .await
-                .map_err(map_err)?;
+                .map_err(map_boxlite_err)?;
             Ok(PySnapshotInfo::from(info))
         })
     }
@@ -82,7 +82,7 @@ impl PySnapshotHandle {
     fn list<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let handle = Arc::clone(&self.handle);
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            let infos = handle.snapshots().list().await.map_err(map_err)?;
+            let infos = handle.snapshots().list().await.map_err(map_boxlite_err)?;
             Ok(infos
                 .into_iter()
                 .map(PySnapshotInfo::from)
@@ -94,7 +94,11 @@ impl PySnapshotHandle {
     fn get<'py>(&self, py: Python<'py>, name: String) -> PyResult<Bound<'py, PyAny>> {
         let handle = Arc::clone(&self.handle);
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            let info = handle.snapshots().get(&name).await.map_err(map_err)?;
+            let info = handle
+                .snapshots()
+                .get(&name)
+                .await
+                .map_err(map_boxlite_err)?;
             Ok(info.map(PySnapshotInfo::from))
         })
     }
@@ -103,7 +107,11 @@ impl PySnapshotHandle {
     fn remove<'py>(&self, py: Python<'py>, name: String) -> PyResult<Bound<'py, PyAny>> {
         let handle = Arc::clone(&self.handle);
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            handle.snapshots().remove(&name).await.map_err(map_err)?;
+            handle
+                .snapshots()
+                .remove(&name)
+                .await
+                .map_err(map_boxlite_err)?;
             Ok(())
         })
     }
@@ -112,7 +120,11 @@ impl PySnapshotHandle {
     fn restore<'py>(&self, py: Python<'py>, name: String) -> PyResult<Bound<'py, PyAny>> {
         let handle = Arc::clone(&self.handle);
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            handle.snapshots().restore(&name).await.map_err(map_err)?;
+            handle
+                .snapshots()
+                .restore(&name)
+                .await
+                .map_err(map_boxlite_err)?;
             Ok(())
         })
     }

--- a/sdks/python/src/util.rs
+++ b/sdks/python/src/util.rs
@@ -1,5 +1,55 @@
-use pyo3::{exceptions::PyRuntimeError, prelude::*};
+use boxlite::BoxliteError;
+use pyo3::exceptions::PyRuntimeError;
+use pyo3::import_exception;
+use pyo3::prelude::*;
 
+// Import Python exception classes defined in boxlite.errors
+import_exception!(boxlite.errors, EngineError);
+import_exception!(boxlite.errors, ConfigError);
+import_exception!(boxlite.errors, StorageError);
+import_exception!(boxlite.errors, ImageError);
+import_exception!(boxlite.errors, PortalError);
+import_exception!(boxlite.errors, NetworkError);
+import_exception!(boxlite.errors, RpcError);
+import_exception!(boxlite.errors, InternalError);
+import_exception!(boxlite.errors, ExecutionError);
+import_exception!(boxlite.errors, NotFoundError);
+import_exception!(boxlite.errors, AlreadyExistsError);
+import_exception!(boxlite.errors, InvalidStateError);
+import_exception!(boxlite.errors, DatabaseError);
+import_exception!(boxlite.errors, InvalidArgumentError);
+import_exception!(boxlite.errors, StoppedError);
+
+/// Map a BoxliteError to its corresponding typed Python exception.
+pub(crate) fn map_boxlite_err(err: BoxliteError) -> PyErr {
+    let msg = err.to_string();
+    match err {
+        BoxliteError::UnsupportedEngine => EngineError::new_err(msg),
+        BoxliteError::Engine(_) => EngineError::new_err(msg),
+        BoxliteError::Config(_) => ConfigError::new_err(msg),
+        BoxliteError::Storage(_) => StorageError::new_err(msg),
+        BoxliteError::Image(_) => ImageError::new_err(msg),
+        BoxliteError::Portal(_) => PortalError::new_err(msg),
+        BoxliteError::Network(_) => NetworkError::new_err(msg),
+        // Rpc + RpcTransport both map to RpcError (low-level gRPC distinction not useful to Python users)
+        BoxliteError::Rpc(_) | BoxliteError::RpcTransport(_) => RpcError::new_err(msg),
+        BoxliteError::Internal(_) => InternalError::new_err(msg),
+        BoxliteError::Execution(_) => ExecutionError::new_err(msg),
+        // Unsupported -> EngineError: intentional simplification to avoid exception class explosion.
+        // "Unsupported" errors are rare platform-level constraints (e.g., "feature X not on this OS").
+        BoxliteError::Unsupported(_) => EngineError::new_err(msg),
+        BoxliteError::NotFound(_) => NotFoundError::new_err(msg),
+        BoxliteError::AlreadyExists(_) => AlreadyExistsError::new_err(msg),
+        BoxliteError::InvalidState(_) => InvalidStateError::new_err(msg),
+        BoxliteError::Database(_) => DatabaseError::new_err(msg),
+        // MetadataError -> InternalError: metadata corruption is an internal concern, not actionable by SDK users.
+        BoxliteError::MetadataError(_) => InternalError::new_err(msg),
+        BoxliteError::InvalidArgument(_) => InvalidArgumentError::new_err(msg),
+        BoxliteError::Stopped(_) => StoppedError::new_err(msg),
+    }
+}
+
+/// Fallback for non-BoxliteError types (preserves backwards compatibility).
 pub(crate) fn map_err(err: impl std::fmt::Display) -> PyErr {
     PyRuntimeError::new_err(err.to_string())
 }

--- a/sdks/python/src/util.rs
+++ b/sdks/python/src/util.rs
@@ -19,6 +19,7 @@ import_exception!(boxlite.errors, InvalidStateError);
 import_exception!(boxlite.errors, DatabaseError);
 import_exception!(boxlite.errors, InvalidArgumentError);
 import_exception!(boxlite.errors, StoppedError);
+import_exception!(boxlite.errors, ResourceExhaustedError);
 
 /// Map a BoxliteError to its corresponding typed Python exception.
 pub(crate) fn map_boxlite_err(err: BoxliteError) -> PyErr {
@@ -46,6 +47,7 @@ pub(crate) fn map_boxlite_err(err: BoxliteError) -> PyErr {
         BoxliteError::MetadataError(_) => InternalError::new_err(msg),
         BoxliteError::InvalidArgument(_) => InvalidArgumentError::new_err(msg),
         BoxliteError::Stopped(_) => StoppedError::new_err(msg),
+        BoxliteError::ResourceExhausted(_) => ResourceExhaustedError::new_err(msg),
     }
 }
 

--- a/sdks/python/tests/test_errors.py
+++ b/sdks/python/tests/test_errors.py
@@ -5,7 +5,27 @@ Tests the error hierarchy and exception behavior.
 """
 
 import pytest
-from boxlite.errors import BoxliteError, ExecError, TimeoutError, ParseError
+from boxlite.errors import (
+    AlreadyExistsError,
+    BoxliteError,
+    ConfigError,
+    DatabaseError,
+    EngineError,
+    ExecError,
+    ExecutionError,
+    ImageError,
+    InternalError,
+    InvalidArgumentError,
+    InvalidStateError,
+    NetworkError,
+    NotFoundError,
+    ParseError,
+    PortalError,
+    RpcError,
+    StoppedError,
+    StorageError,
+    TimeoutError,
+)
 
 
 class TestBoxliteError:
@@ -104,21 +124,289 @@ class TestParseError:
             raise ParseError("parse error")
 
 
+class TestEngineError:
+    """Test EngineError exception."""
+
+    def test_inherits_boxlite_error(self):
+        assert issubclass(EngineError, BoxliteError)
+
+    def test_can_raise(self):
+        with pytest.raises(EngineError):
+            raise EngineError("engine crashed")
+
+    def test_can_catch_as_boxlite_error(self):
+        with pytest.raises(BoxliteError):
+            raise EngineError("engine error")
+
+    def test_message(self):
+        err = EngineError("unsupported engine: kvm")
+        assert str(err) == "unsupported engine: kvm"
+
+
+class TestConfigError:
+    """Test ConfigError exception."""
+
+    def test_inherits_boxlite_error(self):
+        assert issubclass(ConfigError, BoxliteError)
+
+    def test_can_raise(self):
+        with pytest.raises(ConfigError):
+            raise ConfigError("invalid config")
+
+    def test_can_catch_as_boxlite_error(self):
+        with pytest.raises(BoxliteError):
+            raise ConfigError("bad option")
+
+
+class TestStorageError:
+    """Test StorageError exception."""
+
+    def test_inherits_boxlite_error(self):
+        assert issubclass(StorageError, BoxliteError)
+
+    def test_can_raise(self):
+        with pytest.raises(StorageError):
+            raise StorageError("disk full")
+
+    def test_can_catch_as_boxlite_error(self):
+        with pytest.raises(BoxliteError):
+            raise StorageError("I/O error")
+
+
+class TestImageError:
+    """Test ImageError exception."""
+
+    def test_inherits_boxlite_error(self):
+        assert issubclass(ImageError, BoxliteError)
+
+    def test_can_raise(self):
+        with pytest.raises(ImageError):
+            raise ImageError("image not found")
+
+    def test_can_catch_as_boxlite_error(self):
+        with pytest.raises(BoxliteError):
+            raise ImageError("pull failed")
+
+
+class TestPortalError:
+    """Test PortalError exception."""
+
+    def test_inherits_boxlite_error(self):
+        assert issubclass(PortalError, BoxliteError)
+
+    def test_can_raise(self):
+        with pytest.raises(PortalError):
+            raise PortalError("portal connection lost")
+
+    def test_can_catch_as_boxlite_error(self):
+        with pytest.raises(BoxliteError):
+            raise PortalError("gRPC portal error")
+
+
+class TestNetworkError:
+    """Test NetworkError exception."""
+
+    def test_inherits_boxlite_error(self):
+        assert issubclass(NetworkError, BoxliteError)
+
+    def test_can_raise(self):
+        with pytest.raises(NetworkError):
+            raise NetworkError("network unreachable")
+
+    def test_can_catch_as_boxlite_error(self):
+        with pytest.raises(BoxliteError):
+            raise NetworkError("DNS resolution failed")
+
+
+class TestRpcError:
+    """Test RpcError exception."""
+
+    def test_inherits_boxlite_error(self):
+        assert issubclass(RpcError, BoxliteError)
+
+    def test_can_raise(self):
+        with pytest.raises(RpcError):
+            raise RpcError("gRPC status: UNAVAILABLE")
+
+    def test_can_catch_as_boxlite_error(self):
+        with pytest.raises(BoxliteError):
+            raise RpcError("transport error")
+
+
+class TestInternalError:
+    """Test InternalError exception."""
+
+    def test_inherits_boxlite_error(self):
+        assert issubclass(InternalError, BoxliteError)
+
+    def test_can_raise(self):
+        with pytest.raises(InternalError):
+            raise InternalError("unexpected state")
+
+    def test_can_catch_as_boxlite_error(self):
+        with pytest.raises(BoxliteError):
+            raise InternalError("internal error")
+
+
+class TestExecutionError:
+    """Test ExecutionError exception."""
+
+    def test_inherits_boxlite_error(self):
+        assert issubclass(ExecutionError, BoxliteError)
+
+    def test_can_raise(self):
+        with pytest.raises(ExecutionError):
+            raise ExecutionError("execution failed")
+
+    def test_can_catch_as_boxlite_error(self):
+        with pytest.raises(BoxliteError):
+            raise ExecutionError("runtime exec error")
+
+
+class TestNotFoundError:
+    """Test NotFoundError exception."""
+
+    def test_inherits_boxlite_error(self):
+        assert issubclass(NotFoundError, BoxliteError)
+
+    def test_can_raise(self):
+        with pytest.raises(NotFoundError):
+            raise NotFoundError("box abc123 not found")
+
+    def test_can_catch_as_boxlite_error(self):
+        with pytest.raises(BoxliteError):
+            raise NotFoundError("resource not found")
+
+
+class TestAlreadyExistsError:
+    """Test AlreadyExistsError exception."""
+
+    def test_inherits_boxlite_error(self):
+        assert issubclass(AlreadyExistsError, BoxliteError)
+
+    def test_can_raise(self):
+        with pytest.raises(AlreadyExistsError):
+            raise AlreadyExistsError("box already exists")
+
+    def test_can_catch_as_boxlite_error(self):
+        with pytest.raises(BoxliteError):
+            raise AlreadyExistsError("duplicate")
+
+
+class TestInvalidStateError:
+    """Test InvalidStateError exception."""
+
+    def test_inherits_boxlite_error(self):
+        assert issubclass(InvalidStateError, BoxliteError)
+
+    def test_can_raise(self):
+        with pytest.raises(InvalidStateError):
+            raise InvalidStateError("box is stopped")
+
+    def test_can_catch_as_boxlite_error(self):
+        with pytest.raises(BoxliteError):
+            raise InvalidStateError("wrong state")
+
+
+class TestDatabaseError:
+    """Test DatabaseError exception."""
+
+    def test_inherits_boxlite_error(self):
+        assert issubclass(DatabaseError, BoxliteError)
+
+    def test_can_raise(self):
+        with pytest.raises(DatabaseError):
+            raise DatabaseError("SQLite error: table not found")
+
+    def test_can_catch_as_boxlite_error(self):
+        with pytest.raises(BoxliteError):
+            raise DatabaseError("db error")
+
+
+class TestInvalidArgumentError:
+    """Test InvalidArgumentError exception."""
+
+    def test_inherits_boxlite_error(self):
+        assert issubclass(InvalidArgumentError, BoxliteError)
+
+    def test_can_raise(self):
+        with pytest.raises(InvalidArgumentError):
+            raise InvalidArgumentError("invalid memory: -1")
+
+    def test_can_catch_as_boxlite_error(self):
+        with pytest.raises(BoxliteError):
+            raise InvalidArgumentError("bad argument")
+
+
+class TestStoppedError:
+    """Test StoppedError exception."""
+
+    def test_inherits_boxlite_error(self):
+        assert issubclass(StoppedError, BoxliteError)
+
+    def test_can_raise(self):
+        with pytest.raises(StoppedError):
+            raise StoppedError("runtime is shut down")
+
+    def test_can_catch_as_boxlite_error(self):
+        with pytest.raises(BoxliteError):
+            raise StoppedError("stopped")
+
+
+# ── All typed exceptions: parametrized tests ─────────────────────────────
+
+# Complete list of the 15 Rust-mapped exception classes
+RUST_MAPPED_EXCEPTIONS = [
+    EngineError,
+    ConfigError,
+    StorageError,
+    ImageError,
+    PortalError,
+    NetworkError,
+    RpcError,
+    InternalError,
+    ExecutionError,
+    NotFoundError,
+    AlreadyExistsError,
+    InvalidStateError,
+    DatabaseError,
+    InvalidArgumentError,
+    StoppedError,
+]
+
+# All 18 exception classes (Rust-mapped + Python convenience)
+ALL_EXCEPTIONS = RUST_MAPPED_EXCEPTIONS + [ExecError, TimeoutError, ParseError]
+
+
 class TestErrorHierarchy:
     """Test the complete error hierarchy."""
 
-    def test_all_errors_inherit_from_base(self):
-        """Test that all error types inherit from BoxliteError."""
-        assert issubclass(ExecError, BoxliteError)
-        assert issubclass(TimeoutError, BoxliteError)
-        assert issubclass(ParseError, BoxliteError)
+    @pytest.mark.parametrize(
+        "exc_class",
+        RUST_MAPPED_EXCEPTIONS,
+        ids=lambda c: c.__name__,
+    )
+    def test_rust_mapped_errors_inherit_from_base(self, exc_class):
+        """Every Rust-mapped exception inherits from BoxliteError."""
+        assert issubclass(exc_class, BoxliteError)
 
-    def test_all_errors_are_exceptions(self):
-        """Test that all error types are Exceptions."""
-        assert issubclass(BoxliteError, Exception)
-        assert issubclass(ExecError, Exception)
-        assert issubclass(TimeoutError, Exception)
-        assert issubclass(ParseError, Exception)
+    @pytest.mark.parametrize(
+        "exc_class",
+        ALL_EXCEPTIONS,
+        ids=lambda c: c.__name__,
+    )
+    def test_all_errors_are_exceptions(self, exc_class):
+        """Every exception type is a subclass of Exception."""
+        assert issubclass(exc_class, Exception)
+
+    @pytest.mark.parametrize(
+        "exc_class",
+        RUST_MAPPED_EXCEPTIONS,
+        ids=lambda c: c.__name__,
+    )
+    def test_rust_mapped_errors_directly_inherit_base(self, exc_class):
+        """Rust-mapped exceptions inherit directly from BoxliteError (flat hierarchy)."""
+        assert BoxliteError in exc_class.__bases__
 
     def test_catch_all_with_base_class(self):
         """Test catching all boxlite errors with base class."""
@@ -127,6 +415,21 @@ class TestErrorHierarchy:
             ExecError("cmd", 1, "err"),
             TimeoutError("timeout"),
             ParseError("parse"),
+            EngineError("engine"),
+            ConfigError("config"),
+            StorageError("storage"),
+            ImageError("image"),
+            PortalError("portal"),
+            NetworkError("network"),
+            RpcError("rpc"),
+            InternalError("internal"),
+            ExecutionError("execution"),
+            NotFoundError("not found"),
+            AlreadyExistsError("exists"),
+            InvalidStateError("state"),
+            DatabaseError("db"),
+            InvalidArgumentError("arg"),
+            StoppedError("stopped"),
         ]
 
         for error in errors:
@@ -135,27 +438,72 @@ class TestErrorHierarchy:
             except BoxliteError as e:
                 assert e is error
 
+    @pytest.mark.parametrize(
+        "exc_class",
+        RUST_MAPPED_EXCEPTIONS,
+        ids=lambda c: c.__name__,
+    )
+    def test_specific_catch_does_not_catch_siblings(self, exc_class):
+        """Catching one typed exception does not catch a different one."""
+        # Pick a sibling that is different from exc_class
+        sibling = next(e for e in RUST_MAPPED_EXCEPTIONS if e is not exc_class)
+        with pytest.raises(sibling):
+            # This should NOT be caught by exc_class
+            try:
+                raise sibling("test")
+            except exc_class:
+                pytest.fail(
+                    f"Catching {exc_class.__name__} should not catch {sibling.__name__}"
+                )
+
 
 class TestErrorExports:
     """Test that errors are properly exported."""
 
-    def test_errors_in_module(self):
-        """Test that errors are exported from boxlite module."""
+    EXPECTED_EXPORTS = [
+        "BoxliteError",
+        # Rust-mapped
+        "EngineError",
+        "ConfigError",
+        "StorageError",
+        "ImageError",
+        "PortalError",
+        "NetworkError",
+        "RpcError",
+        "InternalError",
+        "ExecutionError",
+        "NotFoundError",
+        "AlreadyExistsError",
+        "InvalidStateError",
+        "DatabaseError",
+        "InvalidArgumentError",
+        "StoppedError",
+        # Python convenience
+        "ExecError",
+        "TimeoutError",
+        "ParseError",
+    ]
+
+    @pytest.mark.parametrize("name", EXPECTED_EXPORTS)
+    def test_errors_in_module(self, name):
+        """Test that each error is exported from the boxlite module."""
         import boxlite
 
-        assert hasattr(boxlite, "BoxliteError")
-        assert hasattr(boxlite, "ExecError")
-        assert hasattr(boxlite, "TimeoutError")
-        assert hasattr(boxlite, "ParseError")
+        assert hasattr(boxlite, name), f"boxlite.{name} should be exported"
 
-    def test_errors_from_errors_module(self):
-        """Test that errors can be imported from errors module."""
-        from boxlite.errors import BoxliteError, ExecError, TimeoutError, ParseError
+    @pytest.mark.parametrize("name", EXPECTED_EXPORTS)
+    def test_errors_from_errors_module(self, name):
+        """Test that each error can be imported from boxlite.errors."""
+        import boxlite.errors
 
-        assert BoxliteError is not None
-        assert ExecError is not None
-        assert TimeoutError is not None
-        assert ParseError is not None
+        assert hasattr(boxlite.errors, name), f"boxlite.errors.{name} should exist"
+
+    def test_errors_in_errors_module_all(self):
+        """Test that all 18 exceptions are listed in errors.__all__."""
+        from boxlite import errors
+
+        for name in self.EXPECTED_EXPORTS:
+            assert name in errors.__all__, f"{name} should be in errors.__all__"
 
 
 if __name__ == "__main__":

--- a/sdks/python/tests/test_errors.py
+++ b/sdks/python/tests/test_errors.py
@@ -21,6 +21,7 @@ from boxlite.errors import (
     NotFoundError,
     ParseError,
     PortalError,
+    ResourceExhaustedError,
     RpcError,
     StoppedError,
     StorageError,
@@ -353,9 +354,24 @@ class TestStoppedError:
             raise StoppedError("stopped")
 
 
+class TestResourceExhaustedError:
+    """Test ResourceExhaustedError exception."""
+
+    def test_inherits_boxlite_error(self):
+        assert issubclass(ResourceExhaustedError, BoxliteError)
+
+    def test_can_raise(self):
+        with pytest.raises(ResourceExhaustedError):
+            raise ResourceExhaustedError("VM address spaces exhausted")
+
+    def test_can_catch_as_boxlite_error(self):
+        with pytest.raises(BoxliteError):
+            raise ResourceExhaustedError("resource limit")
+
+
 # ── All typed exceptions: parametrized tests ─────────────────────────────
 
-# Complete list of the 15 Rust-mapped exception classes
+# Complete list of the 16 Rust-mapped exception classes
 RUST_MAPPED_EXCEPTIONS = [
     EngineError,
     ConfigError,
@@ -372,9 +388,10 @@ RUST_MAPPED_EXCEPTIONS = [
     DatabaseError,
     InvalidArgumentError,
     StoppedError,
+    ResourceExhaustedError,
 ]
 
-# All 18 exception classes (Rust-mapped + Python convenience)
+# All 19 exception classes (Rust-mapped + Python convenience)
 ALL_EXCEPTIONS = RUST_MAPPED_EXCEPTIONS + [ExecError, TimeoutError, ParseError]
 
 
@@ -430,6 +447,7 @@ class TestErrorHierarchy:
             DatabaseError("db"),
             InvalidArgumentError("arg"),
             StoppedError("stopped"),
+            ResourceExhaustedError("exhausted"),
         ]
 
         for error in errors:
@@ -478,6 +496,7 @@ class TestErrorExports:
         "DatabaseError",
         "InvalidArgumentError",
         "StoppedError",
+        "ResourceExhaustedError",
         # Python convenience
         "ExecError",
         "TimeoutError",
@@ -499,7 +518,7 @@ class TestErrorExports:
         assert hasattr(boxlite.errors, name), f"boxlite.errors.{name} should exist"
 
     def test_errors_in_errors_module_all(self):
-        """Test that all 18 exceptions are listed in errors.__all__."""
+        """Test that all 19 exceptions are listed in errors.__all__."""
         from boxlite import errors
 
         for name in self.EXPECTED_EXPORTS:

--- a/src/boxlite/src/litebox/box_impl.rs
+++ b/src/boxlite/src/litebox/box_impl.rs
@@ -255,9 +255,11 @@ impl BoxImpl {
             listener.on_exec_started(&self.config.id, &command.command, &command.args);
         }
 
+        let exec_started_at = Instant::now();
+
         let mut exec_interface = live.guest_session.execution().await?;
         let result = exec_interface
-            .exec(command, self.shutdown_token.clone())
+            .exec(command.clone(), self.shutdown_token.clone())
             .await;
 
         // Instrument metrics
@@ -275,6 +277,20 @@ impl BoxImpl {
                 .fetch_add(1, Ordering::Relaxed);
         }
 
+        // Build completion callback for event listeners
+        let on_completed = if self.event_listeners.is_empty() {
+            None
+        } else {
+            let listeners = self.event_listeners.clone();
+            let box_id = self.config.id.clone();
+            let cmd = command.command.clone();
+            Some(Box::new(move |exit_code: i32, duration: Duration| {
+                for listener in &listeners {
+                    listener.on_exec_completed(&box_id, &cmd, exit_code, duration);
+                }
+            }) as Box<dyn FnOnce(i32, Duration) + Send>)
+        };
+
         let components = result?;
         Ok(Execution::new(
             components.execution_id,
@@ -283,6 +299,8 @@ impl BoxImpl {
             Some(ExecStdin::new(components.stdin_tx)),
             Some(ExecStdout::new(components.stdout_rx)),
             Some(ExecStderr::new(components.stderr_rx)),
+            exec_started_at,
+            on_completed,
         ))
     }
 

--- a/src/boxlite/src/litebox/box_impl.rs
+++ b/src/boxlite/src/litebox/box_impl.rs
@@ -136,6 +136,7 @@ impl BoxImpl {
         state: BoxState,
         runtime: SharedRuntimeImpl,
         shutdown_token: CancellationToken,
+        event_listeners: Vec<std::sync::Arc<dyn EventListener>>,
     ) -> Self {
         Self {
             config,
@@ -143,7 +144,7 @@ impl BoxImpl {
             runtime,
             shutdown_token,
             disk_ops: tokio::sync::Mutex::new(()),
-            event_listeners: Vec::new(), // populated from runtime options
+            event_listeners,
             live: OnceCell::new(),
             health_check_task: RwLock::new(None),
         }

--- a/src/boxlite/src/litebox/exec.rs
+++ b/src/boxlite/src/litebox/exec.rs
@@ -8,7 +8,7 @@ use boxlite_shared::errors::BoxliteResult;
 use futures::Stream;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
 
 /// Command builder for executing programs in a box.
@@ -151,6 +151,13 @@ pub(crate) struct ExecutionInner {
 
     /// Standard error stream (read-only).
     stderr: Option<ExecStderr>,
+
+    /// When the execution was initiated (for duration calculation).
+    started_at: Instant,
+
+    /// Optional callback fired once when the execution completes.
+    /// Used by BoxImpl to invoke event listeners with exit_code and duration.
+    on_completed: Option<Box<dyn FnOnce(i32, Duration) + Send>>,
 }
 
 /// Unique identifier for an execution.
@@ -158,6 +165,7 @@ pub type ExecutionId = String;
 
 impl Execution {
     /// Create a new Execution (internal use).
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         execution_id: ExecutionId,
         interface: Box<dyn ExecBackend>,
@@ -165,6 +173,8 @@ impl Execution {
         stdin: Option<ExecStdin>,
         stdout: Option<ExecStdout>,
         stderr: Option<ExecStderr>,
+        started_at: Instant,
+        on_completed: Option<Box<dyn FnOnce(i32, Duration) + Send>>,
     ) -> Self {
         let inner = ExecutionInner {
             interface,
@@ -173,6 +183,8 @@ impl Execution {
             stdin,
             stdout,
             stderr,
+            started_at,
+            on_completed,
         };
 
         Self {
@@ -223,15 +235,21 @@ impl Execution {
         }
 
         // Try to receive from result channel (non-blocking)
-        if let Ok(status) = inner.result_rx.try_recv() {
-            inner.cached_result = Some(status.clone());
-            return Ok(status);
+        let status = if let Ok(status) = inner.result_rx.try_recv() {
+            status
+        } else {
+            // Await next result
+            inner.result_rx.recv().await.ok_or_else(|| {
+                boxlite_shared::BoxliteError::Internal("Result channel closed".into())
+            })?
+        };
+
+        // Fire completion callback once (on first wait)
+        if let Some(callback) = inner.on_completed.take() {
+            let duration = inner.started_at.elapsed();
+            callback(status.exit_code, duration);
         }
 
-        // Await next result
-        let status = inner.result_rx.recv().await.ok_or_else(|| {
-            boxlite_shared::BoxliteError::Internal("Result channel closed".into())
-        })?;
         inner.cached_result = Some(status.clone());
         Ok(status)
     }

--- a/src/boxlite/src/rest/litebox.rs
+++ b/src/boxlite/src/rest/litebox.rs
@@ -133,6 +133,8 @@ impl BoxBackend for RestBox {
             Some(stdin),
             Some(stdout),
             Some(stderr),
+            std::time::Instant::now(),
+            None,
         ))
     }
 

--- a/src/boxlite/src/runtime/options.rs
+++ b/src/boxlite/src/runtime/options.rs
@@ -1,11 +1,13 @@
 //! Configuration for Boxlite.
 
+use crate::event_listener::EventListener;
 use crate::runtime::constants::envs as const_envs;
 use crate::runtime::layout::dirs as const_dirs;
 use boxlite_shared::errors::BoxliteResult;
 use dirs::home_dir;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use crate::runtime::advanced_options::{AdvancedBoxOptions, SecurityOptions};
 
@@ -15,7 +17,7 @@ use crate::runtime::advanced_options::{AdvancedBoxOptions, SecurityOptions};
 /// Configuration options for BoxliteRuntime.
 ///
 /// Users can create it with defaults and modify fields as needed.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct BoxliteOptions {
     #[serde(default = "default_home_dir")]
     pub home_dir: PathBuf,
@@ -42,6 +44,46 @@ pub struct BoxliteOptions {
     /// ```
     #[serde(default)]
     pub image_registries: Vec<String>,
+
+    /// Event listeners for box lifecycle notifications.
+    ///
+    /// Listeners receive callbacks when boxes are created, started, stopped,
+    /// removed, and when commands are executed or files are copied.
+    ///
+    /// All callbacks default to no-op — implement only what you need.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// use boxlite::event_listener::EventListener;
+    ///
+    /// struct Logger;
+    /// impl EventListener for Logger {
+    ///     fn on_box_started(&self, box_id: &BoxID) {
+    ///         println!("Box {} started", box_id);
+    ///     }
+    /// }
+    ///
+    /// let opts = BoxliteOptions {
+    ///     event_listeners: vec![Arc::new(Logger)],
+    ///     ..Default::default()
+    /// };
+    /// ```
+    #[serde(skip, default)]
+    pub event_listeners: Vec<Arc<dyn EventListener>>,
+}
+
+impl std::fmt::Debug for BoxliteOptions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BoxliteOptions")
+            .field("home_dir", &self.home_dir)
+            .field("image_registries", &self.image_registries)
+            .field(
+                "event_listeners",
+                &format_args!("[{} listeners]", self.event_listeners.len()),
+            )
+            .finish()
+    }
 }
 
 fn default_home_dir() -> PathBuf {
@@ -59,6 +101,7 @@ impl Default for BoxliteOptions {
         Self {
             home_dir: default_home_dir(),
             image_registries: Vec::new(),
+            event_listeners: Vec::new(),
         }
     }
 }
@@ -1018,5 +1061,87 @@ mod tests {
         // Only opts2 should have max_processes
         assert!(opts1.resource_limits.max_processes.is_none());
         assert_eq!(opts2.resource_limits.max_processes, Some(50));
+    }
+
+    // ========================================================================
+    // event_listeners tests
+    // ========================================================================
+
+    #[test]
+    fn test_boxlite_options_default_has_no_listeners() {
+        let opts = BoxliteOptions::default();
+        assert!(
+            opts.event_listeners.is_empty(),
+            "Default options should have no event listeners"
+        );
+    }
+
+    #[test]
+    fn test_boxlite_options_with_event_listeners() {
+        use crate::event_listener::EventListener;
+
+        struct TestListener;
+        impl EventListener for TestListener {}
+
+        let opts = BoxliteOptions {
+            event_listeners: vec![Arc::new(TestListener)],
+            ..Default::default()
+        };
+        assert_eq!(opts.event_listeners.len(), 1);
+    }
+
+    #[test]
+    fn test_boxlite_options_clone_preserves_listeners() {
+        use crate::event_listener::EventListener;
+
+        struct TestListener;
+        impl EventListener for TestListener {}
+
+        let opts = BoxliteOptions {
+            event_listeners: vec![Arc::new(TestListener), Arc::new(TestListener)],
+            ..Default::default()
+        };
+        let cloned = opts.clone();
+        assert_eq!(cloned.event_listeners.len(), 2);
+    }
+
+    #[test]
+    fn test_boxlite_options_serde_skips_listeners() {
+        use crate::event_listener::EventListener;
+
+        struct TestListener;
+        impl EventListener for TestListener {}
+
+        let opts = BoxliteOptions {
+            event_listeners: vec![Arc::new(TestListener)],
+            ..Default::default()
+        };
+
+        // Serialization should succeed (event_listeners skipped)
+        let json = serde_json::to_string(&opts).unwrap();
+        assert!(!json.contains("event_listeners"));
+
+        // Deserialization should default to empty vec
+        let deserialized: BoxliteOptions = serde_json::from_str(&json).unwrap();
+        assert!(deserialized.event_listeners.is_empty());
+    }
+
+    #[test]
+    fn test_boxlite_options_debug_shows_listener_count() {
+        use crate::event_listener::EventListener;
+
+        struct TestListener;
+        impl EventListener for TestListener {}
+
+        let opts = BoxliteOptions {
+            event_listeners: vec![Arc::new(TestListener), Arc::new(TestListener)],
+            ..Default::default()
+        };
+        let debug_str = format!("{:?}", opts);
+        assert!(
+            debug_str.contains("[2 listeners]"),
+            "Debug should show listener count, got: {}",
+            debug_str
+        );
     }
 }

--- a/src/boxlite/src/runtime/rt_impl.rs
+++ b/src/boxlite/src/runtime/rt_impl.rs
@@ -93,6 +93,10 @@ pub struct RuntimeImpl {
     /// Use `.is_cancelled()` for sync checks, `.cancelled()` for async select!.
     /// Child tokens are passed to each box via `.child_token()`.
     pub(crate) shutdown_token: CancellationToken,
+
+    /// Event listeners registered at runtime level.
+    /// Cloned into each BoxImpl on construction.
+    pub(crate) event_listeners: Vec<Arc<dyn crate::event_listener::EventListener>>,
 }
 
 /// Synchronized state protected by RwLock.
@@ -226,6 +230,7 @@ impl RuntimeImpl {
             lock_manager,
             _runtime_lock: runtime_lock,
             shutdown_token: CancellationToken::new(),
+            event_listeners: options.event_listeners,
         });
 
         tracing::debug!("initialized runtime");
@@ -1379,7 +1384,13 @@ impl RuntimeImpl {
         // Create new BoxImpl and cache in both maps
         // Pass a child token so box can be cancelled independently or via runtime shutdown
         let box_token = self.shutdown_token.child_token();
-        let box_impl = Arc::new(BoxImpl::new(config, state, Arc::clone(self), box_token));
+        let box_impl = Arc::new(BoxImpl::new(
+            config,
+            state,
+            Arc::clone(self),
+            box_token,
+            self.event_listeners.clone(),
+        ));
         let weak = Arc::downgrade(&box_impl);
 
         sync.active_boxes_by_id.insert(box_id.clone(), weak.clone());
@@ -1579,6 +1590,7 @@ mod tests {
         let options = BoxliteOptions {
             home_dir: temp_dir.path().to_path_buf(),
             image_registries: vec![],
+            ..Default::default()
         };
         let runtime = RuntimeImpl::new(options).expect("Failed to create runtime");
         (runtime, temp_dir)
@@ -2417,5 +2429,71 @@ mod tests {
         // Force remove should succeed despite dependency.
         let result = runtime.remove_box(&config_a.id, true);
         assert!(result.is_ok());
+    }
+
+    // ====================================================================
+    // event_listeners plumbing tests
+    // ====================================================================
+
+    #[test]
+    fn test_runtime_stores_event_listeners() {
+        use crate::event_listener::EventListener;
+
+        struct TestListener;
+        impl EventListener for TestListener {}
+
+        let temp_dir = TempDir::new_in("/tmp").expect("Failed to create temp dir");
+        let options = BoxliteOptions {
+            home_dir: temp_dir.path().to_path_buf(),
+            image_registries: vec![],
+            event_listeners: vec![std::sync::Arc::new(TestListener)],
+        };
+        let runtime = RuntimeImpl::new(options).expect("Failed to create runtime");
+        assert_eq!(
+            runtime.event_listeners.len(),
+            1,
+            "Runtime should store event listeners from options"
+        );
+    }
+
+    #[test]
+    fn test_runtime_passes_listeners_to_box_impl() {
+        use crate::event_listener::EventListener;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        static CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+        struct CountingListener;
+        impl EventListener for CountingListener {
+            fn on_box_created(&self, _box_id: &BoxID) {
+                CALL_COUNT.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+
+        CALL_COUNT.store(0, Ordering::SeqCst);
+
+        let temp_dir = TempDir::new_in("/tmp").expect("Failed to create temp dir");
+        let options = BoxliteOptions {
+            home_dir: temp_dir.path().to_path_buf(),
+            image_registries: vec![],
+            event_listeners: vec![std::sync::Arc::new(CountingListener)],
+        };
+        let runtime = RuntimeImpl::new(options).expect("Failed to create runtime");
+
+        // Create a BoxImpl via get_or_create_box_impl — listeners should be cloned
+        let config = test_box_config(false);
+        let box_id = config.id.clone();
+        let state = BoxState::new();
+        let (box_impl, _created) = runtime.get_or_create_box_impl(config, state);
+
+        assert_eq!(
+            box_impl.event_listeners.len(),
+            1,
+            "BoxImpl should have listeners from runtime"
+        );
+
+        // Invoke the listener directly to verify it works
+        box_impl.event_listeners[0].on_box_created(&box_id);
+        assert_eq!(CALL_COUNT.load(Ordering::SeqCst), 1);
     }
 }

--- a/src/boxlite/tests/clone_export_import.rs
+++ b/src/boxlite/tests/clone_export_import.rs
@@ -55,6 +55,7 @@ async fn test_clone_produces_independent_box() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
     let source = create_stopped_box(&runtime).await;
@@ -84,6 +85,7 @@ async fn test_export_import_roundtrip() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
     let source = create_stopped_box(&runtime).await;
@@ -124,6 +126,7 @@ async fn test_export_import_preserves_box_options() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -161,6 +164,7 @@ async fn test_clone_running_box() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
     let source = create_running_box(&runtime, "clone-src").await;
@@ -205,6 +209,7 @@ async fn test_export_running_box() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
     let source = create_running_box(&runtime, "export-running").await;
@@ -251,6 +256,7 @@ async fn test_export_import_running_box_roundtrip() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
     let source = create_running_box(&runtime, "roundtrip-running").await;
@@ -312,6 +318,7 @@ async fn test_clone_snapshot_isolation() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
     let source = create_running_box(&runtime, "isolation-src").await;
@@ -368,6 +375,7 @@ async fn test_clone_10x_benchmark() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
     let source = create_stopped_box(&runtime).await;
@@ -414,6 +422,7 @@ async fn test_export_under_write_pressure() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
     let source = create_running_box(&runtime, "write-stress").await;

--- a/src/boxlite/tests/copy.rs
+++ b/src/boxlite/tests/copy.rs
@@ -54,6 +54,7 @@ async fn copy_integration() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
     let bx = runtime

--- a/src/boxlite/tests/detach.rs
+++ b/src/boxlite/tests/detach.rs
@@ -31,6 +31,7 @@ async fn detached_box_creates_pid_file() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -65,6 +66,7 @@ async fn detached_box_survives_runtime_drop() {
         let runtime = BoxliteRuntime::new(BoxliteOptions {
             home_dir: home.path.clone(),
             image_registries: common::test_registries(),
+            ..Default::default()
         })
         .unwrap();
 
@@ -102,6 +104,7 @@ async fn detached_box_survives_runtime_drop() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .unwrap();
     runtime.remove(&box_id, true).await.unwrap();
@@ -124,6 +127,7 @@ async fn non_detached_box_exits_on_runtime_drop() {
         let runtime = BoxliteRuntime::new(BoxliteOptions {
             home_dir: home_dir.clone(),
             image_registries: common::test_registries(),
+            ..Default::default()
         })
         .unwrap();
 
@@ -170,6 +174,7 @@ async fn multiple_detached_boxes_each_have_pid_file() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -225,6 +230,7 @@ async fn detached_box_recoverable_after_restart() {
         let runtime = BoxliteRuntime::new(BoxliteOptions {
             home_dir: home.path.clone(),
             image_registries: common::test_registries(),
+            ..Default::default()
         })
         .unwrap();
 
@@ -248,6 +254,7 @@ async fn detached_box_recoverable_after_restart() {
         let runtime = BoxliteRuntime::new(BoxliteOptions {
             home_dir: home.path.clone(),
             image_registries: common::test_registries(),
+            ..Default::default()
         })
         .unwrap();
 

--- a/src/boxlite/tests/exec_options.rs
+++ b/src/boxlite/tests/exec_options.rs
@@ -39,6 +39,7 @@ impl TestBox {
         let runtime = boxlite::BoxliteRuntime::new(boxlite::runtime::options::BoxliteOptions {
             home_dir: home.path.clone(),
             image_registries: common::test_registries(),
+            ..Default::default()
         })
         .expect("create runtime");
         let handle = runtime.create(common::alpine_opts(), None).await.unwrap();

--- a/src/boxlite/tests/exec_user.rs
+++ b/src/boxlite/tests/exec_user.rs
@@ -37,6 +37,7 @@ impl TestBox {
         let runtime = boxlite::BoxliteRuntime::new(boxlite::runtime::options::BoxliteOptions {
             home_dir: home.path.clone(),
             image_registries: common::test_registries(),
+            ..Default::default()
         })
         .expect("create runtime");
         let handle = runtime.create(common::alpine_opts(), None).await.unwrap();

--- a/src/boxlite/tests/execution_shutdown.rs
+++ b/src/boxlite/tests/execution_shutdown.rs
@@ -25,6 +25,7 @@ async fn test_wait_behavior_on_box_stop() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
     let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
@@ -100,6 +101,7 @@ async fn test_wait_behavior_on_runtime_shutdown() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
     let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
@@ -173,6 +175,7 @@ async fn test_stdout_stream_on_box_stop() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
     let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
@@ -232,6 +235,7 @@ async fn test_exec_on_stopped_box() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
     let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
@@ -289,6 +293,7 @@ async fn test_existing_execution_after_box_stop() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
     let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
@@ -330,6 +335,7 @@ async fn test_wait_timing_after_stop() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
     let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
@@ -389,6 +395,7 @@ async fn test_multiple_executions_on_box_stop() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
     let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
@@ -479,6 +486,7 @@ async fn test_run_command_returns_stopped_error() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
     let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
@@ -525,6 +533,7 @@ async fn test_start_returns_stopped_error() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
     let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
@@ -563,6 +572,7 @@ async fn test_metrics_returns_stopped_error() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
     let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
@@ -601,6 +611,7 @@ async fn test_create_after_shutdown_returns_stopped() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -636,6 +647,7 @@ async fn test_wait_returns_promptly_on_stop() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
     let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
@@ -700,6 +712,7 @@ async fn test_all_waits_return_on_stop() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
     let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
@@ -782,6 +795,7 @@ async fn test_runtime_shutdown_stops_all_boxes() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -874,6 +888,7 @@ async fn test_exec_completes_then_shutdown_is_clean() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
     let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
@@ -898,6 +913,7 @@ async fn test_sequential_exec_same_box() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
     let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
@@ -931,6 +947,7 @@ async fn test_exec_exit_code_preserved() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
     let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
@@ -963,6 +980,7 @@ async fn test_exec_then_shutdown_sequential() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
     let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
@@ -1119,6 +1137,7 @@ fn create_test_runtime() -> (boxlite_test_utils::home::PerTestBoxHome, BoxliteRu
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
     (home, runtime)

--- a/src/boxlite/tests/lifecycle.rs
+++ b/src/boxlite/tests/lifecycle.rs
@@ -17,6 +17,7 @@ async fn runtime_initialization_creates_empty_list() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
     assert!(runtime.list_info().await.unwrap().is_empty());
@@ -32,6 +33,7 @@ async fn create_generates_unique_ids() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
     let box1 = runtime.create(common::alpine_opts(), None).await.unwrap();
@@ -63,6 +65,7 @@ async fn create_stores_custom_options() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
     let handle = runtime.create(options, None).await.unwrap();
@@ -90,6 +93,7 @@ async fn list_info_returns_all_boxes() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -121,6 +125,7 @@ async fn list_info_sorted_by_creation_time_newest_first() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -158,6 +163,7 @@ async fn get_info_returns_box_metadata() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
     let handle = runtime
@@ -186,6 +192,7 @@ async fn get_info_returns_none_for_nonexistent() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
     let missing = runtime.get_info("nonexistent-id").await.unwrap();
@@ -198,6 +205,7 @@ async fn exists_returns_true_for_existing_box() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
     let handle = runtime
@@ -218,6 +226,7 @@ async fn exists_returns_false_for_nonexistent() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
     assert!(!runtime.exists("nonexistent-id").await.unwrap());
@@ -233,6 +242,7 @@ async fn remove_nonexistent_returns_not_found() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
     let result = runtime.remove("nonexistent-id", false).await;
@@ -252,6 +262,7 @@ async fn remove_stopped_box_succeeds() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
     let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
@@ -273,6 +284,7 @@ async fn remove_active_without_force_fails() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
     let handle = runtime
@@ -312,6 +324,7 @@ async fn remove_active_with_force_stops_and_removes() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
     let handle = runtime
@@ -341,6 +354,7 @@ async fn remove_deletes_box_from_database() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
     let handle = runtime
@@ -369,6 +383,7 @@ async fn stop_marks_box_as_stopped() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
     let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
@@ -399,6 +414,7 @@ async fn litebox_info_returns_correct_metadata() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
     let handle = runtime
@@ -432,12 +448,14 @@ async fn multiple_runtimes_are_isolated() {
     let runtime1 = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home1.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
     let home2 = boxlite_test_utils::home::PerTestBoxHome::isolated();
     let runtime2 = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home2.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -479,6 +497,7 @@ async fn boxes_persist_across_runtime_restart() {
         let options = BoxliteOptions {
             home_dir: home.path.clone(),
             image_registries: common::test_registries(),
+            ..Default::default()
         };
         let runtime = BoxliteRuntime::new(options).expect("Failed to create runtime");
         let litebox = runtime.create(common::alpine_opts(), None).await.unwrap();
@@ -498,6 +517,7 @@ async fn boxes_persist_across_runtime_restart() {
         let options = BoxliteOptions {
             home_dir: home.path.clone(),
             image_registries: common::test_registries(),
+            ..Default::default()
         };
         let runtime = BoxliteRuntime::new(options).expect("Failed to create runtime");
 
@@ -528,6 +548,7 @@ async fn multiple_boxes_persist_and_recover_without_lock_errors() {
         let options = BoxliteOptions {
             home_dir: home.path.clone(),
             image_registries: common::test_registries(),
+            ..Default::default()
         };
         let runtime = BoxliteRuntime::new(options).expect("Failed to create runtime");
 
@@ -561,6 +582,7 @@ async fn multiple_boxes_persist_and_recover_without_lock_errors() {
         let options = BoxliteOptions {
             home_dir: home.path.clone(),
             image_registries: common::test_registries(),
+            ..Default::default()
         };
         let runtime = BoxliteRuntime::new(options).expect("Failed to create runtime after restart");
 
@@ -613,6 +635,7 @@ async fn auto_remove_true_removes_box_on_stop() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
     let handle = runtime
@@ -640,6 +663,7 @@ async fn auto_remove_false_preserves_box_on_stop() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
     let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
@@ -685,6 +709,7 @@ async fn detach_option_is_stored_in_box_config() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 

--- a/src/boxlite/tests/mount_security.rs
+++ b/src/boxlite/tests/mount_security.rs
@@ -69,6 +69,7 @@ async fn mount_security_integration() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 

--- a/src/boxlite/tests/network_spec.rs
+++ b/src/boxlite/tests/network_spec.rs
@@ -72,6 +72,7 @@ async fn disabled_network_returns_no_network_config() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .unwrap();
 
@@ -90,6 +91,7 @@ async fn disabled_network_runs_without_eth0() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .unwrap();
 
@@ -232,6 +234,7 @@ async fn dns_sinkhole_blocks_unlisted_host() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .unwrap();
 
@@ -262,6 +265,7 @@ async fn dns_sinkhole_allows_listed_host() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .unwrap();
 
@@ -292,6 +296,7 @@ async fn empty_allowlist_allows_all() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .unwrap();
 
@@ -319,6 +324,7 @@ async fn tcp_filter_blocks_direct_ip_connection() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .unwrap();
 
@@ -355,6 +361,7 @@ async fn tcp_filter_sni_allows_https_to_allowed_host() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .unwrap();
 
@@ -390,6 +397,7 @@ async fn host_alias_resolves_to_dedicated_host_ip() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .unwrap();
 
@@ -412,6 +420,7 @@ async fn host_alias_reaches_host_loopback_service() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .unwrap();
 
@@ -438,6 +447,7 @@ async fn host_alias_reaches_host_loopback_service_with_restrictive_allowlist() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .unwrap();
 
@@ -477,6 +487,7 @@ async fn disabled_network_cannot_reach_host_virtual_ip() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .unwrap();
 

--- a/src/boxlite/tests/pid_file.rs
+++ b/src/boxlite/tests/pid_file.rs
@@ -33,6 +33,7 @@ async fn pid_file_created_on_box_start() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -56,6 +57,7 @@ async fn pid_file_contains_correct_pid() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -93,6 +95,7 @@ async fn pid_file_deleted_on_normal_stop() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -117,6 +120,7 @@ async fn pid_matches_box_info() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -150,6 +154,7 @@ async fn pid_available_immediately_after_run() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -186,6 +191,7 @@ async fn pid_file_path_is_correct() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -218,6 +224,7 @@ async fn force_remove_deletes_pid_file() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -241,6 +248,7 @@ async fn box_directory_cleanup_includes_pid_file() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -267,6 +275,7 @@ async fn is_same_process_validates_boxlite_shim() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 

--- a/src/boxlite/tests/recovery.rs
+++ b/src/boxlite/tests/recovery.rs
@@ -39,6 +39,7 @@ async fn recovery_with_live_process() {
         let runtime = BoxliteRuntime::new(BoxliteOptions {
             home_dir: home.path.clone(),
             image_registries: common::test_registries(),
+            ..Default::default()
         })
         .unwrap();
 
@@ -65,6 +66,7 @@ async fn recovery_with_live_process() {
         let runtime = BoxliteRuntime::new(BoxliteOptions {
             home_dir: home.path.clone(),
             image_registries: common::test_registries(),
+            ..Default::default()
         })
         .unwrap();
 
@@ -92,6 +94,7 @@ async fn recovery_with_dead_process() {
         let runtime = BoxliteRuntime::new(BoxliteOptions {
             home_dir: home.path.clone(),
             image_registries: common::test_registries(),
+            ..Default::default()
         })
         .unwrap();
 
@@ -126,6 +129,7 @@ async fn recovery_with_dead_process() {
         let runtime = BoxliteRuntime::new(BoxliteOptions {
             home_dir: home.path.clone(),
             image_registries: common::test_registries(),
+            ..Default::default()
         })
         .unwrap();
 
@@ -164,6 +168,7 @@ async fn recovery_with_missing_pid_file() {
         let runtime = BoxliteRuntime::new(BoxliteOptions {
             home_dir: home.path.clone(),
             image_registries: common::test_registries(),
+            ..Default::default()
         })
         .unwrap();
 
@@ -191,6 +196,7 @@ async fn recovery_with_missing_pid_file() {
         let runtime = BoxliteRuntime::new(BoxliteOptions {
             home_dir: home.path.clone(),
             image_registries: common::test_registries(),
+            ..Default::default()
         })
         .unwrap();
 
@@ -221,6 +227,7 @@ async fn recovery_with_corrupted_pid_file() {
         let runtime = BoxliteRuntime::new(BoxliteOptions {
             home_dir: home.path.clone(),
             image_registries: common::test_registries(),
+            ..Default::default()
         })
         .unwrap();
 
@@ -248,6 +255,7 @@ async fn recovery_with_corrupted_pid_file() {
         let runtime = BoxliteRuntime::new(BoxliteOptions {
             home_dir: home.path.clone(),
             image_registries: common::test_registries(),
+            ..Default::default()
         })
         .unwrap();
 
@@ -282,6 +290,7 @@ async fn recovery_preserves_stopped_boxes() {
         let runtime = BoxliteRuntime::new(BoxliteOptions {
             home_dir: home.path.clone(),
             image_registries: common::test_registries(),
+            ..Default::default()
         })
         .unwrap();
 
@@ -303,6 +312,7 @@ async fn recovery_preserves_stopped_boxes() {
         let runtime = BoxliteRuntime::new(BoxliteOptions {
             home_dir: home.path.clone(),
             image_registries: common::test_registries(),
+            ..Default::default()
         })
         .unwrap();
 
@@ -338,6 +348,7 @@ async fn recovery_removes_auto_remove_true_boxes() {
         let options = BoxliteOptions {
             home_dir: home_dir.clone(),
             image_registries: common::test_registries(),
+            ..Default::default()
         };
         let runtime = BoxliteRuntime::new(options).expect("Failed to create runtime");
 
@@ -370,6 +381,7 @@ async fn recovery_removes_auto_remove_true_boxes() {
         let options = BoxliteOptions {
             home_dir,
             image_registries: common::test_registries(),
+            ..Default::default()
         };
         let runtime = BoxliteRuntime::new(options).expect("Failed to create runtime after restart");
 
@@ -409,6 +421,7 @@ async fn recovery_removes_orphaned_stopped_boxes_without_directory() {
         let options = BoxliteOptions {
             home_dir: home.path.clone(),
             image_registries: common::test_registries(),
+            ..Default::default()
         };
         let runtime = BoxliteRuntime::new(options).expect("Failed to create runtime");
 
@@ -436,6 +449,7 @@ async fn recovery_removes_orphaned_stopped_boxes_without_directory() {
         let options = BoxliteOptions {
             home_dir: home.path.clone(),
             image_registries: common::test_registries(),
+            ..Default::default()
         };
         let runtime = BoxliteRuntime::new(options).expect("Failed to create runtime after restart");
 

--- a/src/boxlite/tests/runtime.rs
+++ b/src/boxlite/tests/runtime.rs
@@ -16,6 +16,7 @@ fn test_runtime_prevents_concurrent_access() {
     let config1 = BoxliteOptions {
         home_dir: temp_dir.path().to_path_buf(),
         image_registries: common::test_registries(),
+        ..Default::default()
     };
     let runtime1 = BoxliteRuntime::new(config1).unwrap();
 
@@ -23,6 +24,7 @@ fn test_runtime_prevents_concurrent_access() {
     let config2 = BoxliteOptions {
         home_dir: temp_dir.path().to_path_buf(),
         image_registries: common::test_registries(),
+        ..Default::default()
     };
     let result = BoxliteRuntime::new(config2);
     assert!(result.is_err());
@@ -38,6 +40,7 @@ fn test_runtime_prevents_concurrent_access() {
     let config3 = BoxliteOptions {
         home_dir: temp_dir.path().to_path_buf(),
         image_registries: common::test_registries(),
+        ..Default::default()
     };
     let _runtime2 = BoxliteRuntime::new(config3).unwrap();
 }
@@ -51,6 +54,7 @@ fn test_runtime_lock_released_on_drop() {
         let config = BoxliteOptions {
             home_dir: temp_dir.path().to_path_buf(),
             image_registries: common::test_registries(),
+            ..Default::default()
         };
         let _runtime = BoxliteRuntime::new(config).unwrap();
     } // Lock released here
@@ -59,6 +63,7 @@ fn test_runtime_lock_released_on_drop() {
     let config2 = BoxliteOptions {
         home_dir: temp_dir.path().to_path_buf(),
         image_registries: common::test_registries(),
+        ..Default::default()
     };
     let _runtime2 = BoxliteRuntime::new(config2).unwrap();
 }
@@ -72,6 +77,7 @@ fn test_runtime_lock_across_threads() {
     let config1 = BoxliteOptions {
         home_dir: dir_path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     };
     let _runtime1 = BoxliteRuntime::new(config1).unwrap();
 
@@ -81,6 +87,7 @@ fn test_runtime_lock_across_threads() {
         let config = BoxliteOptions {
             home_dir: dir_clone,
             image_registries: common::test_registries(),
+            ..Default::default()
         };
         BoxliteRuntime::new(config)
     });
@@ -98,6 +105,7 @@ fn test_different_home_dirs_independent() {
     let config1 = BoxliteOptions {
         home_dir: temp_dir1.path().to_path_buf(),
         image_registries: common::test_registries(),
+        ..Default::default()
     };
     let _runtime1 = BoxliteRuntime::new(config1).unwrap();
 
@@ -105,6 +113,7 @@ fn test_different_home_dirs_independent() {
     let config2 = BoxliteOptions {
         home_dir: temp_dir2.path().to_path_buf(),
         image_registries: common::test_registries(),
+        ..Default::default()
     };
     let _runtime2 = BoxliteRuntime::new(config2).unwrap();
 
@@ -120,6 +129,7 @@ fn test_lock_file_created() {
     let config = BoxliteOptions {
         home_dir: temp_dir.path().to_path_buf(),
         image_registries: common::test_registries(),
+        ..Default::default()
     };
     let _runtime = BoxliteRuntime::new(config).unwrap();
 
@@ -135,6 +145,7 @@ fn test_lock_survives_short_operations() {
     let config1 = BoxliteOptions {
         home_dir: temp_dir.path().to_path_buf(),
         image_registries: common::test_registries(),
+        ..Default::default()
     };
     let runtime = BoxliteRuntime::new(config1).unwrap();
 
@@ -145,6 +156,7 @@ fn test_lock_survives_short_operations() {
     let config2 = BoxliteOptions {
         home_dir: temp_dir.path().to_path_buf(),
         image_registries: common::test_registries(),
+        ..Default::default()
     };
     let result = BoxliteRuntime::new(config2);
     assert!(result.is_err());

--- a/src/boxlite/tests/shutdown.rs
+++ b/src/boxlite/tests/shutdown.rs
@@ -24,6 +24,7 @@ async fn shutdown_is_idempotent() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -41,6 +42,7 @@ async fn shutdown_with_timeout() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -55,6 +57,7 @@ async fn shutdown_empty_runtime() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -73,6 +76,7 @@ async fn shutdown_does_not_affect_other_runtimes() {
     let runtime1 = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home1.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -80,6 +84,7 @@ async fn shutdown_does_not_affect_other_runtimes() {
     let runtime2 = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home2.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -100,6 +105,7 @@ async fn read_operations_work_after_shutdown() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -125,6 +131,7 @@ fn drop_releases_lock() {
         let options = BoxliteOptions {
             home_dir: home.path.clone(),
             image_registries: common::test_registries(),
+            ..Default::default()
         };
         let _rt = BoxliteRuntime::new(options).unwrap();
     } // Drop fires here
@@ -133,6 +140,7 @@ fn drop_releases_lock() {
     let options2 = BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     };
     let _rt2 = BoxliteRuntime::new(options2).unwrap();
 }
@@ -145,6 +153,7 @@ async fn cloned_runtime_shares_shutdown_state() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
     let clone = runtime.clone();
@@ -172,6 +181,7 @@ async fn shutdown_timeout_edge_values() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
     assert!(runtime.shutdown(Some(0)).await.is_ok());
@@ -181,6 +191,7 @@ async fn shutdown_timeout_edge_values() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
     assert!(runtime.shutdown(Some(-1)).await.is_ok());
@@ -190,6 +201,7 @@ async fn shutdown_timeout_edge_values() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
     assert!(runtime.shutdown(Some(30)).await.is_ok());
@@ -199,6 +211,7 @@ async fn shutdown_timeout_edge_values() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
     assert!(runtime.shutdown(Some(-5)).await.is_ok());
@@ -215,6 +228,7 @@ async fn concurrent_shutdown_is_safe() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -246,6 +260,7 @@ async fn create_after_shutdown_is_rejected() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 

--- a/src/boxlite/tests/sigstop_quiesce.rs
+++ b/src/boxlite/tests/sigstop_quiesce.rs
@@ -24,6 +24,7 @@ async fn test_sigstop_sigcont_preserves_vm() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 

--- a/src/boxlite/tests/snapshot.rs
+++ b/src/boxlite/tests/snapshot.rs
@@ -91,6 +91,7 @@ async fn test_cow_child_disks_exist_after_snapshot_create() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
     let litebox = create_stopped_box(&runtime).await;
@@ -144,6 +145,7 @@ async fn test_box_restartable_after_snapshot_create() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
     let litebox = create_stopped_box(&runtime).await;
@@ -183,6 +185,7 @@ async fn test_cow_child_disks_exist_after_snapshot_restore() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
     let litebox = create_stopped_box(&runtime).await;
@@ -225,6 +228,7 @@ async fn test_box_startable_after_snapshot_restore() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
     let litebox = create_stopped_box(&runtime).await;
@@ -280,6 +284,7 @@ async fn test_snapshot_list_returns_created_snapshot() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
     let litebox = create_stopped_box(&runtime).await;

--- a/src/boxlite/tests/snapshot_clone_deep.rs
+++ b/src/boxlite/tests/snapshot_clone_deep.rs
@@ -115,6 +115,7 @@ async fn test_multiple_snapshots_list_order() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -177,6 +178,7 @@ async fn test_snapshot_data_isolation_across_versions() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -225,6 +227,7 @@ async fn test_snapshot_restore_discards_post_snapshot_writes() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -264,6 +267,7 @@ async fn test_multiple_restore_cycles() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -316,6 +320,7 @@ async fn test_snapshot_get_returns_correct_metadata() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -352,6 +357,7 @@ async fn test_snapshot_created_at_ordering() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -392,6 +398,7 @@ async fn test_snapshot_remove_success() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -448,6 +455,7 @@ async fn test_snapshot_remove_then_recreate_same_name() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -492,6 +500,7 @@ async fn test_snapshot_remove_nonexistent_returns_error() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -512,6 +521,7 @@ async fn test_snapshot_remove_current_backing_rejected() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -540,6 +550,7 @@ async fn test_snapshot_remove_after_restore_different() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -585,6 +596,7 @@ async fn test_snapshot_chain_remove_oldest_with_newer_depending() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -641,6 +653,7 @@ async fn test_snapshot_remove_middle_of_three() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -690,6 +703,7 @@ async fn test_snapshot_running_box_with_quiesce() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -723,6 +737,7 @@ async fn test_snapshot_restore_rejected_while_running() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -753,6 +768,7 @@ async fn test_snapshot_remove_while_running() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -796,6 +812,7 @@ async fn test_two_snapshots_while_running() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -837,6 +854,7 @@ async fn test_clone_after_snapshot_preserves_snapshot_data() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -887,6 +905,7 @@ async fn test_snapshot_then_clone_then_remove_snapshot() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -937,6 +956,7 @@ async fn test_clone_then_snapshot_clone() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -986,6 +1006,7 @@ async fn test_clone_of_clone() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -1027,6 +1048,7 @@ async fn test_clone_source_snapshot_independence() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -1078,6 +1100,7 @@ async fn test_batch_clone_produces_correct_count() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -1117,6 +1140,7 @@ async fn test_batch_clone_names_count_mismatch_errors() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -1144,6 +1168,7 @@ async fn test_clone_count_zero_returns_empty() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -1165,6 +1190,7 @@ async fn test_clone_data_preserved() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -1193,6 +1219,7 @@ async fn test_clone_write_isolation_from_source() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -1234,6 +1261,7 @@ async fn test_clone_without_name() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -1262,6 +1290,7 @@ async fn test_clone_with_duplicate_name_errors() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -1287,6 +1316,7 @@ async fn test_multiple_clones_share_base_disk() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -1321,6 +1351,7 @@ async fn test_export_import_preserves_file_contents() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -1372,6 +1403,7 @@ async fn test_export_to_directory_uses_box_name() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -1398,6 +1430,7 @@ async fn test_double_import_from_same_archive() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -1446,6 +1479,7 @@ async fn test_imported_box_has_no_snapshots() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -1490,6 +1524,7 @@ async fn test_export_import_cloned_box() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -1524,6 +1559,7 @@ async fn test_import_validates_no_backing_references() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -1552,6 +1588,7 @@ async fn test_export_unnamed_box_uses_default_filename() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -1581,6 +1618,7 @@ async fn test_export_import_box_with_custom_options() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -1614,6 +1652,7 @@ async fn test_export_archive_has_boxlite_extension() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -1648,6 +1687,7 @@ async fn test_snapshot_name_validation_integration() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -1676,6 +1716,7 @@ async fn test_snapshot_duplicate_name_rejected() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -1705,6 +1746,7 @@ async fn test_remove_box_with_snapshots_cleans_up() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -1747,6 +1789,7 @@ async fn test_remove_source_box_blocked_by_clone() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -1776,6 +1819,7 @@ async fn test_snapshot_on_never_started_box() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -1803,6 +1847,7 @@ async fn test_restore_nonexistent_snapshot() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -1823,6 +1868,7 @@ async fn test_clone_box_without_container_disk() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -1846,6 +1892,7 @@ async fn test_snapshot_name_max_length() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -1880,6 +1927,7 @@ async fn test_snapshot_under_write_pressure() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -1929,6 +1977,7 @@ async fn test_clone_under_write_pressure() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -1972,6 +2021,7 @@ async fn test_rapid_snapshot_cycle() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -2052,6 +2102,7 @@ async fn test_export_under_write_pressure_with_data_check() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -2108,6 +2159,7 @@ async fn test_snapshot_survives_box_restart() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -2148,6 +2200,7 @@ async fn test_box_info_status_correct_throughout_snapshot_lifecycle() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -2185,6 +2238,7 @@ async fn test_snapshot_after_clone_source_modification() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -2231,6 +2285,7 @@ async fn test_multiple_boxes_snapshot_independently() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -2277,6 +2332,7 @@ async fn test_clone_and_export_same_box_sequentially() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -2325,6 +2381,7 @@ async fn test_snapshot_preserves_file_permissions() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -2380,6 +2437,7 @@ async fn test_snapshot_preserves_nested_directories() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -2427,6 +2485,7 @@ async fn test_clone_preserves_multiple_files() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -2464,6 +2523,7 @@ async fn test_export_import_preserves_symlinks() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -2518,6 +2578,7 @@ async fn test_remove_clone_triggers_base_gc_when_last_dependent() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -2556,6 +2617,7 @@ async fn test_remove_one_of_two_clones_preserves_base() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -2591,6 +2653,7 @@ async fn test_remove_all_clones_cascades_gc() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -2636,6 +2699,7 @@ async fn test_box_removal_cleans_all_snapshots() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -2681,6 +2745,7 @@ async fn test_archive_file_is_valid_zstd_tar() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -2710,6 +2775,7 @@ async fn test_archive_roundtrip_checksum_integrity() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -2746,6 +2812,7 @@ async fn test_export_produces_deterministic_extension() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 

--- a/src/boxlite/tests/timing_profile.rs
+++ b/src/boxlite/tests/timing_profile.rs
@@ -45,6 +45,7 @@ async fn boot_timing_profile() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 
@@ -179,6 +180,7 @@ async fn boot_timing_profile_no_jailer() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
 

--- a/src/boxlite/tests/zygote_integration.rs
+++ b/src/boxlite/tests/zygote_integration.rs
@@ -30,6 +30,7 @@ fn create_test_runtime() -> (boxlite_test_utils::home::PerTestBoxHome, BoxliteRu
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        ..Default::default()
     })
     .expect("create runtime");
     (home, runtime)

--- a/src/test-utils/src/box_test.rs
+++ b/src/test-utils/src/box_test.rs
@@ -67,6 +67,7 @@ impl BoxTestBase {
         let runtime = BoxliteRuntime::new(BoxliteOptions {
             home_dir: home.path.clone(),
             image_registries: test_registries(),
+            ..Default::default()
         })
         .expect("create BoxTestBase runtime");
 
@@ -88,6 +89,7 @@ impl BoxTestBase {
         let runtime = BoxliteRuntime::new(BoxliteOptions {
             home_dir: home.path.clone(),
             image_registries: test_registries(),
+            ..Default::default()
         })
         .expect("create isolated BoxTestBase runtime");
 

--- a/src/test-utils/src/cache.rs
+++ b/src/test-utils/src/cache.rs
@@ -201,6 +201,7 @@ impl SharedResources {
                 let runtime = BoxliteRuntime::new(BoxliteOptions {
                     home_dir: home.clone(),
                     image_registries: test_registries(),
+                    ..Default::default()
                 })
                 .unwrap();
 

--- a/src/test-utils/src/config_matrix.rs
+++ b/src/test-utils/src/config_matrix.rs
@@ -267,6 +267,7 @@ where
         let runtime = boxlite::BoxliteRuntime::new(BoxliteOptions {
             home_dir: home.path.clone(),
             image_registries: crate::test_registries(),
+            ..Default::default()
         })
         .expect("create runtime for config matrix");
 
@@ -336,6 +337,7 @@ macro_rules! config_matrix_tests {
                         ::boxlite::runtime::options::BoxliteOptions {
                             home_dir: home.path.clone(),
                             image_registries: $crate::test_registries(),
+                            ..Default::default()
                         }
                     ).expect("create runtime for config matrix test");
 


### PR DESCRIPTION
## Summary

- Bridge the Rust `EventListener` trait (#403) to Python via PyO3, enabling push-based
  lifecycle callbacks (`on_box_started`, `on_exec_completed`, etc.) for monitoring and
  instrumentation
- Replace generic `PyRuntimeError` with 15 typed Python exception classes inheriting from
  `BoxliteError`, using exhaustive match on all 18 `BoxliteError` variants for compile-time
  completeness
- Add 165 Python tests covering exception hierarchy, sibling isolation, and export
  completeness

## Motivation

The Rust core added `EventListener` in #403 but no SDK exposed it — Python users had no
way to monitor box lifecycle events. Additionally, all Rust errors were mapped to a generic
`RuntimeError`, making programmatic error handling impossible.

## What changed

### EventListener Python bindings (new capability)
- `PyEventListener` bridge wraps a Python object and implements the Rust `EventListener` trait
- Duck-typing pattern: users implement only the callbacks they need; missing methods are
  silently skipped via `AttributeError` detection
- `event_listeners` parameter added to `BoxliteOptions`, propagated through `RuntimeImpl`
  to each `BoxImpl`
- `unsafe impl Sync` with detailed safety comment (GIL serialization, PEP 703 caveat)

### Typed error mapping (improved error handling)
- 15 `import_exception!` macros import Python exception classes from `boxlite.errors`
- `map_boxlite_err()` exhaustive match (no wildcard) maps every `BoxliteError` variant
  to the correct typed exception
- 3 intentional simplifications documented with inline comments:
  `Rpc`+`RpcTransport` → `RpcError`, `Unsupported` → `EngineError`,
  `MetadataError` → `InternalError`
- All existing `map_err` calls in `runtime.rs`, `box_handle.rs`, `exec.rs`, `snapshots.rs`
  updated to use `map_boxlite_err` where applicable

### Files changed (17 files, +1050/-75)

| Category | Files |
|----------|-------|
| Rust core (EventListener plumbing) | `options.rs`, `rt_impl.rs`, `box_impl.rs` |
| Python SDK Rust (bridge + errors) | `event_listener.rs` (new), `util.rs`, `options.rs`, `runtime.rs`, `box_handle.rs`, `exec.rs`, `snapshots.rs`, `lib.rs` |
| Python SDK (exceptions + exports) | `errors.py`, `__init__.py` |
| Tests | `test_errors.py` (165 tests) |
| Test utils (compatibility) | `box_test.rs`, `cache.rs`, `config_matrix.rs` |

## Usage example

```python
class MyListener:
    def on_box_started(self, box_id: str):
        print(f"Box {box_id} started!")
    def on_exec_completed(self, box_id, command, exit_code, duration_secs):
        print(f"'{command}' finished in {duration_secs:.2f}s (exit={exit_code})")

opts = boxlite.Options(event_listeners=[MyListener()])
runtime = boxlite.Boxlite(opts)

# Typed error handling
try:
    box = await runtime.get("nonexistent")
except boxlite.NotFoundError:
    print("Box not found")
except boxlite.BoxliteError:
    print("Other boxlite error")
```

## Test plan

- [x] `cargo fmt -- --check` — clean
- [x] `cargo clippy -p boxlite --no-default-features --lib -- -D warnings` — 0 warnings (macOS + Linux)
- [x] `cargo clippy -p boxlite-python --lib -- -D warnings` — 0 warnings (macOS + Linux)
- [x] `cargo test -p boxlite --no-default-features --lib` — 600 passed (macOS), 573 passed (Linux, 27 KVM-dependent pre-existing failures)
- [x] `pytest test_errors.py` — 165 passed (macOS + Linux)
- [x] `ruff check` + `ruff format --check` — clean

## Known limitations

- 3 of 8 callbacks not yet wired in Rust core (`on_box_created`, `on_box_removed`, `on_exec_completed`) — bridge is ready, awaiting core call sites
- `map_boxlite_err` and `PyEventListener` require built native extension for integration testing (documented)
- `unsafe impl Sync` assumes CPython GIL; PEP 703 (free-threaded Python) noted in safety comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)