### PR TITLE
fix(box_impl): offload blocking handler.stop() and metrics() to spawn_blocking

### DIFF
--- a/src/boxlite/src/litebox/box_impl.rs
+++ b/src/boxlite/src/litebox/box_impl.rs
@@ -659,7 +659,12 @@ impl BoxImpl {
             h.metrics()
         })
         .await
-        .map_err(|e| BoxliteError::Internal(format!("spawn_blocking join: {}", e)))??;
+        .map_err(|e| {
+            BoxliteError::Internal(format!(
+                "metrics spawn_blocking join (box_id={}): {}",
+                self.config.id, e
+            ))
+        })??;
 
         Ok(BoxMetrics::from_storage(
             &live.metrics,
@@ -726,15 +731,24 @@ impl BoxImpl {
 
             // Stop handler (on blocking thread — ShimHandler::stop() polls with sleep)
             let handler = Arc::clone(&live.handler);
-            tokio::task::spawn_blocking(move || {
-                if let Ok(mut h) = handler.lock() {
+            let box_id_for_join = self.config.id.clone();
+            tokio::task::spawn_blocking(move || match handler.lock() {
+                Ok(mut h) => h.stop(),
+                Err(poisoned) => {
+                    tracing::warn!(
+                        "Handler mutex poisoned during shutdown; recovering guard to stop handler"
+                    );
+                    let mut h = poisoned.into_inner();
                     h.stop()
-                } else {
-                    Ok(())
                 }
             })
             .await
-            .map_err(|e| BoxliteError::Internal(format!("spawn_blocking join: {}", e)))??;
+            .map_err(|e| {
+                BoxliteError::Internal(format!(
+                    "stop spawn_blocking join (box_id={}): {}",
+                    box_id_for_join, e
+                ))
+            })??;
         }
         // If live_state() failed (vmm_attach said Absent — shim is gone),
         // or status wasn't Running, fall through to cleanup.

--- a/src/boxlite/src/litebox/box_impl.rs
+++ b/src/boxlite/src/litebox/box_impl.rs
@@ -1751,6 +1751,13 @@ mod tests {
     }
 
     async fn running_box_for_start_test(gate: Arc<StartGate>) -> StartFixture {
+        running_box_with_handler(gate, Box::new(InfoTestHandler(0))).await
+    }
+
+    async fn running_box_with_handler(
+        gate: Arc<StartGate>,
+        handler: Box<dyn VmmHandler>,
+    ) -> StartFixture {
         let temp_dir = TempDir::new_in("/tmp").expect("create temp dir");
         let runtime = RuntimeImpl::new_for_test(BoxliteOptions {
             home_dir: temp_dir.path().to_path_buf(),
@@ -1797,7 +1804,7 @@ mod tests {
             .push(listener.clone() as Arc<dyn EventListener>);
 
         let live = LiveState::new(
-            Box::new(InfoTestHandler(0)),
+            handler,
             guest_session,
             None,
             None,
@@ -1980,6 +1987,150 @@ mod tests {
 
         assert_eq!(gate.calls.load(Ordering::SeqCst), 0);
         assert_eq!(fixture.listener.count.load(Ordering::SeqCst), 0);
+    }
+
+    /// Stands in for the real handlers' blocking work: `ShimHandler::stop()`
+    /// polls `waitpid` with `std::thread::sleep(50ms)` for up to 2s, and
+    /// `ShimHandler::metrics()` refreshes sysinfo through syscalls. Both block
+    /// whatever thread runs them.
+    struct BlockingHandler {
+        stop_block: Duration,
+        metrics_block: Duration,
+        entered: std::sync::mpsc::SyncSender<()>,
+    }
+
+    impl VmmHandler for BlockingHandler {
+        fn stop(&mut self) -> BoxliteResult<()> {
+            let _ = self.entered.try_send(());
+            std::thread::sleep(self.stop_block);
+            Ok(())
+        }
+
+        fn metrics(&self) -> BoxliteResult<VmmMetrics> {
+            let _ = self.entered.try_send(());
+            std::thread::sleep(self.metrics_block);
+            Ok(VmmMetrics::default())
+        }
+
+        fn is_running(&self) -> bool {
+            true
+        }
+
+        fn pid(&self) -> u32 {
+            0
+        }
+    }
+
+    const REPRO_BLOCK: Duration = Duration::from_millis(600);
+    const REPRO_OBSERVE: Duration = Duration::from_millis(300);
+    const REPRO_TICK: Duration = Duration::from_millis(10);
+    const REPRO_MIN_TICKS: usize = 5;
+
+    /// Counts timer ticks landing on the runtime worker while the handler is
+    /// inside its blocking call. The sampler runs on a plain OS thread so it
+    /// can observe even when every worker is wedged.
+    fn spawn_tick_observer(
+        ticks: Arc<AtomicUsize>,
+        entered_rx: std::sync::mpsc::Receiver<()>,
+    ) -> std::thread::JoinHandle<usize> {
+        std::thread::spawn(move || {
+            entered_rx
+                .recv()
+                .expect("handler never entered blocking call");
+            let before = ticks.load(Ordering::SeqCst);
+            std::thread::sleep(REPRO_OBSERVE);
+            ticks.load(Ordering::SeqCst) - before
+        })
+    }
+
+    fn spawn_heartbeat(ticks: Arc<AtomicUsize>) -> JoinHandle<()> {
+        tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(REPRO_TICK).await;
+                ticks.fetch_add(1, Ordering::SeqCst);
+            }
+        })
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn stop_keeps_runtime_worker_free_while_handler_blocks() {
+        let (entered_tx, entered_rx) = std::sync::mpsc::sync_channel(1);
+        let fixture = running_box_with_handler(
+            {
+                // live_state() drives an implicit Container.Start; hand it a
+                // permit so the call under test reaches the handler instead of
+                // parking on the stub guest's gate.
+                let gate = Arc::new(StartGate::default());
+                gate.release.add_permits(1);
+                gate
+            },
+            Box::new(BlockingHandler {
+                stop_block: REPRO_BLOCK,
+                metrics_block: Duration::ZERO,
+                entered: entered_tx,
+            }),
+        )
+        .await;
+
+        let ticks = Arc::new(AtomicUsize::new(0));
+        let heartbeat = spawn_heartbeat(Arc::clone(&ticks));
+        let observer = spawn_tick_observer(Arc::clone(&ticks), entered_rx);
+
+        // The call under test must run ON the single worker: #[tokio::test]'s
+        // block_on drives the test body from the calling thread, which is not
+        // part of the worker pool, so blocking there would starve nothing.
+        let target = Arc::clone(&fixture.box_impl);
+        tokio::spawn(async move { target.stop().await })
+            .await
+            .expect("stop task panicked")
+            .expect("stop running box");
+        heartbeat.abort();
+
+        let ticks_during_stop = observer.join().expect("observer thread panicked");
+        assert!(
+            ticks_during_stop >= REPRO_MIN_TICKS,
+            "runtime worker starved while handler.stop() blocked: {ticks_during_stop} \
+             timer ticks in {REPRO_OBSERVE:?} (expected >= {REPRO_MIN_TICKS})"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn metrics_keeps_runtime_worker_free_while_handler_blocks() {
+        let (entered_tx, entered_rx) = std::sync::mpsc::sync_channel(1);
+        let fixture = running_box_with_handler(
+            {
+                // live_state() drives an implicit Container.Start; hand it a
+                // permit so the call under test reaches the handler instead of
+                // parking on the stub guest's gate.
+                let gate = Arc::new(StartGate::default());
+                gate.release.add_permits(1);
+                gate
+            },
+            Box::new(BlockingHandler {
+                stop_block: Duration::ZERO,
+                metrics_block: REPRO_BLOCK,
+                entered: entered_tx,
+            }),
+        )
+        .await;
+
+        let ticks = Arc::new(AtomicUsize::new(0));
+        let heartbeat = spawn_heartbeat(Arc::clone(&ticks));
+        let observer = spawn_tick_observer(Arc::clone(&ticks), entered_rx);
+
+        let target = Arc::clone(&fixture.box_impl);
+        tokio::spawn(async move { target.metrics().await })
+            .await
+            .expect("metrics task panicked")
+            .expect("collect metrics");
+        heartbeat.abort();
+
+        let ticks_during_metrics = observer.join().expect("observer thread panicked");
+        assert!(
+            ticks_during_metrics >= REPRO_MIN_TICKS,
+            "runtime worker starved while handler.metrics() blocked: {ticks_during_metrics} \
+             timer ticks in {REPRO_OBSERVE:?} (expected >= {REPRO_MIN_TICKS})"
+        );
     }
 
     // Regression test for the silent-orphan bug in stop().

--- a/src/boxlite/src/litebox/box_impl.rs
+++ b/src/boxlite/src/litebox/box_impl.rs
@@ -52,7 +52,7 @@ pub type SharedBoxImpl = Arc<BoxImpl>;
 /// Separated from BoxImpl to allow operations like `info()` without initializing LiveState.
 pub(crate) struct LiveState {
     // VM process control
-    handler: std::sync::Mutex<Box<dyn VmmHandler>>,
+    handler: Arc<std::sync::Mutex<Box<dyn VmmHandler>>>,
     guest_session: GuestSession,
 
     /// Host-side network control backend (gvproxy ServicesMux client), owned
@@ -93,7 +93,7 @@ impl LiveState {
         #[cfg(target_os = "linux")] bind_mount: Option<BindMountHandle>,
     ) -> Self {
         Self {
-            handler: std::sync::Mutex::new(handler),
+            handler: Arc::new(std::sync::Mutex::new(handler)),
             guest_session,
             network: network.map(Arc::from),
             published_ports,
@@ -651,11 +651,15 @@ impl BoxImpl {
         self.ensure_usable_without_rerunning_main("metrics")?;
 
         let live = self.live_state().await?;
-        let handler = live
-            .handler
-            .lock()
-            .map_err(|e| BoxliteError::Internal(format!("handler lock poisoned: {}", e)))?;
-        let raw = handler.metrics()?;
+        let handler = Arc::clone(&live.handler);
+        let raw = tokio::task::spawn_blocking(move || {
+            let h = handler
+                .lock()
+                .map_err(|e| BoxliteError::Internal(format!("handler lock poisoned: {}", e)))?;
+            h.metrics()
+        })
+        .await
+        .map_err(|e| BoxliteError::Internal(format!("spawn_blocking join: {}", e)))??;
 
         Ok(BoxMetrics::from_storage(
             &live.metrics,
@@ -720,10 +724,17 @@ impl BoxImpl {
                 tracing::warn!(box_id = %self.config.id, "Guest shutdown timed out after 10s");
             }
 
-            // Stop handler
-            if let Ok(mut handler) = live.handler.lock() {
-                handler.stop()?;
-            }
+            // Stop handler (on blocking thread — ShimHandler::stop() polls with sleep)
+            let handler = Arc::clone(&live.handler);
+            tokio::task::spawn_blocking(move || {
+                if let Ok(mut h) = handler.lock() {
+                    h.stop()
+                } else {
+                    Ok(())
+                }
+            })
+            .await
+            .map_err(|e| BoxliteError::Internal(format!("spawn_blocking join: {}", e)))??;
         }
         // If live_state() failed (vmm_attach said Absent — shim is gone),
         // or status wasn't Running, fall through to cleanup.


### PR DESCRIPTION
## Summary

- `ShimHandler::stop()` uses a `std::thread::sleep(50ms)` polling loop (up to 2 seconds).
  Called directly from async `BoxImpl::stop()`, this blocks a Tokio worker thread.
  Similarly, `handler.metrics()` performs sysinfo syscalls (~5ms), also a blocking operation.
- Wrap `LiveState.handler` from `std::sync::Mutex<...>` to `Arc<std::sync::Mutex<...>>`
  so it can be cloned and moved into `spawn_blocking` closures.
- Both `handler.stop()` and `handler.metrics()` now run on Tokio's dedicated blocking
  thread pool via `tokio::task::spawn_blocking`, keeping worker threads free.
- Lock poisoning uses asymmetric handling: `stop()` swallows it (shutdown must not be
  blocked by a poisoned lock), `metrics()` propagates it (monitoring should surface
  anomalies).

## Files changed

| File | Change |
|------|--------|
| `boxlite/src/litebox/box_impl.rs` | Arc-wrap handler field; `spawn_blocking` for `stop()` and `metrics()` |

## Test plan

- [x] `cargo test -p boxlite --no-default-features --lib` — 593 passed (main branch)
- [x] `cargo clippy -p boxlite --no-default-features --lib -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved responsiveness when collecting metrics or stopping a running box.
  * Added more reliable handling for internal locking and background task errors.
  * Ensured boxes can still be stopped safely when a lock encounters an error.
  * Improved cleanup of temporary files used during copy operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->