### PR TITLE
fix(build): fix workspace root detection in build.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,7 +381,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -453,7 +453,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-c"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "boxlite-ffi",
  "cbindgen",
@@ -461,7 +461,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-cli"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -498,7 +498,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-ffi"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "boxlite",
  "futures",
@@ -508,7 +508,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-guest"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -537,7 +537,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-node"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "boxlite",
  "boxlite-shared",
@@ -551,7 +551,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-python"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "boxlite",
  "futures",
@@ -564,7 +564,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-server"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -603,7 +603,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-shared"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "proptest",
  "prost",
@@ -643,7 +643,7 @@ dependencies = [
 
 [[package]]
 name = "bubblewrap-sys"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "num_cpus",
 ]
@@ -1137,7 +1137,7 @@ checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
 name = "e2fsprogs-sys"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "num_cpus",
 ]
@@ -2112,14 +2112,14 @@ dependencies = [
 
 [[package]]
 name = "libgvproxy-sys"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "libkrun-sys"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "libc",
  "num_cpus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,15 +20,15 @@ exclude = ["build/tmp", "target", ".venv", "examples/*/.venv"]
 resolver = "2"
 
 [workspace.dependencies]
-boxlite = { path = "src/boxlite", version = "0.8.1" }
-boxlite-shared = { path = "src/shared", version = "0.8.1" }
-bubblewrap-sys = { path = "src/deps/bubblewrap-sys", version = "0.8.1" }
-e2fsprogs-sys = { path = "src/deps/e2fsprogs-sys", version = "0.8.1" }
-libgvproxy-sys = { path = "src/deps/libgvproxy-sys", version = "0.8.1" }
-libkrun-sys = { path = "src/deps/libkrun-sys", version = "0.8.1" }
+boxlite = { path = "src/boxlite", version = "0.8.2" }
+boxlite-shared = { path = "src/shared", version = "0.8.2" }
+bubblewrap-sys = { path = "src/deps/bubblewrap-sys", version = "0.8.2" }
+e2fsprogs-sys = { path = "src/deps/e2fsprogs-sys", version = "0.8.2" }
+libgvproxy-sys = { path = "src/deps/libgvproxy-sys", version = "0.8.2" }
+libkrun-sys = { path = "src/deps/libkrun-sys", version = "0.8.2" }
 
 [workspace.package]
-version = "0.8.1"
+version = "0.8.2"
 edition = "2024"
 authors = ["Dorian Zheng <https://github.com/dorianzheng>"]
 license = "Apache-2.0"

--- a/sdks/go/cmd/setup/main.go
+++ b/sdks/go/cmd/setup/main.go
@@ -109,7 +109,7 @@ func detectVersion() string {
 		}
 	}
 
-	fatalf("cannot detect SDK version. Specify explicitly:\n  go run %s/cmd/setup@v0.8.1", modulePath)
+	fatalf("cannot detect SDK version. Specify explicitly:\n  go run %s/cmd/setup@v0.8.2", modulePath)
 	return ""
 }
 

--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -76,10 +76,5 @@
   "engines": {
     "node": ">=18.0.0"
   },
-  "author": "Dorian Zheng <xingzhengde72@gmail.com>",
-  "optionalDependencies": {
-    "@boxlite-ai/boxlite-darwin-arm64": "0.8.1",
-    "@boxlite-ai/boxlite-linux-x64-gnu": "0.8.1",
-    "@boxlite-ai/boxlite-linux-arm64-gnu": "0.8.1"
-  }
+  "author": "Dorian Zheng <xingzhengde72@gmail.com>"
 }

--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boxlite-ai/boxlite",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "BoxLite - Embeddable micro-VM runtime for secure, isolated code execution",
   "type": "module",
   "main": "dist/index.js",
@@ -76,5 +76,10 @@
   "engines": {
     "node": ">=18.0.0"
   },
-  "author": "Dorian Zheng <xingzhengde72@gmail.com>"
+  "author": "Dorian Zheng <xingzhengde72@gmail.com>",
+  "optionalDependencies": {
+    "@boxlite-ai/boxlite-darwin-arm64": "0.8.1",
+    "@boxlite-ai/boxlite-linux-x64-gnu": "0.8.1",
+    "@boxlite-ai/boxlite-linux-arm64-gnu": "0.8.1"
+  }
 }

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "boxlite"
-version = "0.8.1"
+version = "0.8.2"
 description = "Python bindings for Boxlite runtime"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/boxlite/build.rs
+++ b/src/boxlite/build.rs
@@ -7,6 +7,29 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+/// Find the cargo workspace root by walking up from CARGO_MANIFEST_DIR.
+/// Looks for a Cargo.toml containing `[workspace]`.
+fn find_workspace_root() -> PathBuf {
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+    let mut dir = manifest_dir.as_path();
+    loop {
+        let cargo_toml = dir.join("Cargo.toml");
+        if cargo_toml.is_file()
+            && fs::read_to_string(&cargo_toml)
+                .is_ok_and(|contents| contents.contains("[workspace]"))
+        {
+            return dir.to_path_buf();
+        }
+        dir = match dir.parent() {
+            Some(parent) => parent,
+            None => panic!(
+                "Could not find workspace root from {}",
+                manifest_dir.display()
+            ),
+        };
+    }
+}
+
 /// Copies all dynamic library files from source directory to destination.
 /// Only copies files with library extensions (.dylib, .so, .so.*, .dll).
 /// Preserves symlinks to avoid duplicating the same library multiple times.
@@ -635,10 +658,7 @@ impl EmbeddedManifest {
 
         // Feature enabled: collect pre-built binaries into runtime_dir,
         // then generate include_bytes! for all files.
-        let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
-        let workspace_root = manifest_dir
-            .parent()
-            .expect("CARGO_MANIFEST_DIR has no parent");
+        let workspace_root = find_workspace_root();
 
         fs::create_dir_all(&self.runtime_dir)
             .unwrap_or_else(|e| panic!("Failed to create runtime directory: {}", e));
@@ -646,13 +666,13 @@ impl EmbeddedManifest {
         let profile = env::var("PROFILE").unwrap();
 
         self.copy_prebuilt_binary(
-            workspace_root,
+            &workspace_root,
             "boxlite-shim",
             &profile,
             Self::find_prebuilt_shim,
         );
         self.copy_prebuilt_binary(
-            workspace_root,
+            &workspace_root,
             "boxlite-guest",
             &profile,
             Self::find_prebuilt_guest,
@@ -865,13 +885,12 @@ fn main() {
 ///
 /// If the binary isn't found, silently skips — runtime will compute the hash as fallback.
 fn compute_guest_hash(runtime_dir: &Path) {
-    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
     let profile = env::var("PROFILE").unwrap_or_else(|_| "debug".to_string());
 
     // Check source binary first (direct build output) to avoid stale OUT_DIR copies.
-    let workspace_root = manifest_dir.parent().unwrap_or(&manifest_dir);
+    let workspace_root = find_workspace_root();
     let guest_path =
-        EmbeddedManifest::find_prebuilt_guest(workspace_root, &profile).or_else(|| {
+        EmbeddedManifest::find_prebuilt_guest(&workspace_root, &profile).or_else(|| {
             // Fallback: OUT_DIR copy (for prebuilt/CI mode where source isn't available)
             let p = runtime_dir.join("boxlite-guest");
             p.is_file().then_some(p)


### PR DESCRIPTION
## Summary
- Fix `build.rs` incorrectly computing workspace root as `CARGO_MANIFEST_DIR.parent()` (`src/`) instead of the actual repo root after PR #419 (src/ layout reorganization)
- This caused `find_prebuilt_shim/guest` to search `src/target/` (doesn't exist), resulting in v0.8.1 runtime tarballs missing `boxlite-guest` and `boxlite-shim`
- Replace `.parent()` heuristic with `find_workspace_root()` that walks up looking for `Cargo.toml` containing `[workspace]`
- Bump all SDK versions to 0.8.2

## Test plan
- [x] `make runtime` produces complete runtime with guest + shim
- [x] `cargo build -p boxlite-cli --release` after `make runtime` now correctly embeds guest + shim (was "not found, skipping")
- [x] `ls -dt target/release/build/boxlite-*/out/runtime | head -1 | xargs ls` shows all 5 files in newest dir
- [x] `cargo clippy -p boxlite --tests -- -D warnings` passes clean
- [ ] CI runtime build produces complete tarballs