### PR TITLE
feat(vmm): add HypervisorProbe for post-failure VM diagnostics

### DIFF
--- a/sdks/c/include/boxlite.h
+++ b/sdks/c/include/boxlite.h
@@ -54,6 +54,8 @@ typedef enum BoxliteErrorCode {
   Metadata = 18,
   // Unsupported engine error
   UnsupportedEngine = 19,
+  // System resource limit reached
+  ResourceExhausted = 20,
 } BoxliteErrorCode;
 
 // Opaque handle to a running box

--- a/src/boxlite/src/system_check.rs
+++ b/src/boxlite/src/system_check.rs
@@ -3,8 +3,33 @@
 //! `SystemCheck::run()` verifies all host requirements before BoxLite does
 //! expensive work (filesystem setup, database, networking). The returned
 //! struct is proof that checks passed and holds validated resources.
+//!
+//! The `HypervisorProbe` trait provides platform-abstracted hypervisor
+//! diagnostics for both startup validation and post-failure error refinement.
 
 use boxlite_shared::{BoxliteError, BoxliteResult};
+
+// ── HypervisorProbe trait ──────────────────────────────────────────────────
+
+/// Platform-abstracted hypervisor validation.
+///
+/// Provides two levels of checking:
+/// - `startup_check()`: one-time validation at runtime init
+/// - `diagnose_create_failure()`: post-failure diagnostic when VM creation
+///   fails, refining a generic error into a specific one (zero-cost on the
+///   happy path since it only runs after a failure)
+pub(crate) trait HypervisorProbe: Send + Sync {
+    /// One-time startup validation. Called from `SystemCheck::run()`.
+    fn startup_check(&self) -> BoxliteResult<()>;
+
+    /// Post-failure diagnostic. Called when engine create/enter fails.
+    ///
+    /// Inspects hypervisor state to refine the generic error into a
+    /// specific one. Returns the original error unchanged if no better
+    /// diagnosis is available.
+    #[allow(dead_code)] // Called by krun engine (feature-gated)
+    fn diagnose_create_failure(&self, error: BoxliteError) -> BoxliteError;
+}
 
 /// Validated host system. Existence means all checks passed.
 pub struct SystemCheck {
@@ -17,14 +42,17 @@ impl SystemCheck {
     pub fn run() -> BoxliteResult<Self> {
         #[cfg(target_os = "linux")]
         {
-            let kvm = open_kvm()?;
-            smoke_test_kvm(&kvm)?;
-            Ok(Self { _kvm: kvm })
+            let probe = KvmProbe;
+            probe.startup_check()?;
+            Ok(Self {
+                _kvm: probe.into_kvm_file(),
+            })
         }
 
         #[cfg(target_os = "macos")]
         {
-            check_hypervisor_framework()?;
+            let probe = HvfProbe;
+            probe.startup_check()?;
             Ok(Self {})
         }
 
@@ -37,7 +65,56 @@ impl SystemCheck {
     }
 }
 
+/// Create the platform-appropriate hypervisor probe.
+///
+/// Used by the shim to get a probe for `diagnose_create_failure()` without
+/// needing a full `SystemCheck` (startup checks already passed).
+#[cfg(feature = "krun")]
+pub(crate) fn hypervisor_probe() -> Box<dyn HypervisorProbe> {
+    #[cfg(target_os = "macos")]
+    {
+        Box::new(HvfProbe)
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        Box::new(KvmProbe)
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        Box::new(NoopProbe)
+    }
+}
+
 // ── Linux: KVM ──────────────────────────────────────────────────────────────
+
+#[cfg(target_os = "linux")]
+struct KvmProbe;
+
+#[cfg(target_os = "linux")]
+impl KvmProbe {
+    /// Open /dev/kvm and return the file handle.
+    fn into_kvm_file(self) -> std::fs::File {
+        // Re-open for the SystemCheck to hold. If startup_check passed,
+        // this will succeed too.
+        open_kvm().expect("KVM was validated in startup_check but re-open failed")
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl HypervisorProbe for KvmProbe {
+    fn startup_check(&self) -> BoxliteResult<()> {
+        let kvm = open_kvm()?;
+        smoke_test_kvm(&kvm)?;
+        Ok(())
+    }
+
+    fn diagnose_create_failure(&self, error: BoxliteError) -> BoxliteError {
+        // KVM errors from libkrun are already specific enough.
+        error
+    }
+}
 
 #[cfg(target_os = "linux")]
 fn open_kvm() -> BoxliteResult<std::fs::File> {
@@ -126,6 +203,107 @@ fn smoke_test_kvm(kvm: &std::fs::File) -> BoxliteResult<()> {
 // ── macOS: Hypervisor.framework ─────────────────────────────────────────────
 
 #[cfg(target_os = "macos")]
+#[allow(dead_code)] // FFI interface — not all constants/functions used in every code path
+mod hvf_ffi {
+    //! Direct FFI to Hypervisor.framework for diagnostic probing.
+    //!
+    //! The shim links Hypervisor.framework via libkrun-sys (build.rs),
+    //! so these symbols are available at runtime.
+
+    // hv_return_t = i32 (mach_error_t)
+    pub const HV_SUCCESS: i32 = 0;
+    pub const HV_BUSY: i32 = -85377022;
+    pub const HV_NO_RESOURCES: i32 = -85377019;
+    pub const HV_DENIED: i32 = -85377017;
+
+    unsafe extern "C" {
+        /// Create a VM for the current process. One VM per process on ARM64.
+        /// `config` is nullable — NULL uses default configuration.
+        pub fn hv_vm_create(config: *mut std::ffi::c_void) -> i32;
+
+        /// Destroy the VM for the current process.
+        pub fn hv_vm_destroy() -> i32;
+    }
+}
+
+#[cfg(target_os = "macos")]
+struct HvfProbe;
+
+#[cfg(target_os = "macos")]
+impl HypervisorProbe for HvfProbe {
+    fn startup_check(&self) -> BoxliteResult<()> {
+        check_hypervisor_framework()
+    }
+
+    fn diagnose_create_failure(&self, error: BoxliteError) -> BoxliteError {
+        // Probe HVF directly to get the exact error code that libkrun discards.
+        //
+        // After libkrun's krun_start_enter() fails:
+        // - If hv_vm_create() failed inside libkrun (e.g., HV_NO_RESOURCES):
+        //   no VM exists, our probe can call hv_vm_create() to reproduce the error.
+        // - If hv_vm_create() succeeded but a later step failed:
+        //   a VM exists, our probe returns HV_BUSY (one VM per process on ARM64).
+        //
+        // SAFETY: hv_vm_create/hv_vm_destroy are C functions from Hypervisor.framework.
+        // The shim process links the framework via libkrun-sys.
+        let ret = unsafe { hvf_ffi::hv_vm_create(std::ptr::null_mut()) };
+
+        match ret {
+            hvf_ffi::HV_NO_RESOURCES => {
+                tracing::error!(
+                    hvf_code = ret,
+                    "HVF diagnostic: HV_NO_RESOURCES — VM address spaces exhausted"
+                );
+                BoxliteError::ResourceExhausted(
+                    "macOS Hypervisor.framework VM address spaces exhausted \
+                     (kern.hv.max_address_spaces limit reached). \
+                     Stop some boxes with `boxlite stop` and retry. \
+                     See: sysctl kern.hv.max_address_spaces"
+                        .into(),
+                )
+            }
+            hvf_ffi::HV_SUCCESS => {
+                // HVF works fine — failure was elsewhere (rootfs, config, etc.)
+                unsafe {
+                    hvf_ffi::hv_vm_destroy();
+                }
+                tracing::debug!(
+                    "HVF diagnostic: hv_vm_create succeeded — failure is not HVF-related"
+                );
+                error
+            }
+            hvf_ffi::HV_BUSY => {
+                // libkrun created a VM but failed after (vCPU setup, memory mapping, etc.)
+                tracing::debug!("HVF diagnostic: HV_BUSY — VM exists, failure was post-creation");
+                error
+            }
+            hvf_ffi::HV_DENIED => {
+                tracing::error!(
+                    hvf_code = ret,
+                    "HVF diagnostic: HV_DENIED — missing entitlement"
+                );
+                BoxliteError::Unsupported(
+                    "Hypervisor.framework access denied. \
+                     The boxlite-shim binary needs the \
+                     com.apple.security.hypervisor entitlement."
+                        .into(),
+                )
+            }
+            _ => {
+                tracing::error!(
+                    hvf_code = format!("{ret:#x}"),
+                    "HVF diagnostic: unexpected error code"
+                );
+                BoxliteError::Engine(format!(
+                    "{}. HVF diagnostic probe returned error code {ret:#x}",
+                    error
+                ))
+            }
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
 fn check_hypervisor_framework() -> BoxliteResult<()> {
     #[cfg(not(target_arch = "aarch64"))]
     return Err(BoxliteError::Unsupported(format!(
@@ -170,6 +348,24 @@ fn check_hypervisor_framework() -> BoxliteResult<()> {
     }
 }
 
+// ── Unsupported platforms ──────────────────────────────────────────────────
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+struct NoopProbe;
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+impl HypervisorProbe for NoopProbe {
+    fn startup_check(&self) -> BoxliteResult<()> {
+        Err(BoxliteError::Unsupported(
+            "BoxLite only supports Linux and macOS".into(),
+        ))
+    }
+
+    fn diagnose_create_failure(&self, error: BoxliteError) -> BoxliteError {
+        error
+    }
+}
+
 // ── Tests ───────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -188,6 +384,49 @@ mod tests {
                     "Error should mention the hypervisor: {msg}"
                 );
             }
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "krun")]
+    fn hypervisor_probe_returns_original_on_passthrough() {
+        // On any platform, diagnose_create_failure should at least return
+        // the original error (or a refined version) — never panic.
+        let probe = hypervisor_probe();
+        let original = BoxliteError::Engine("test error".into());
+        let result = probe.diagnose_create_failure(original);
+        // Should be some form of error (original or refined)
+        let msg = result.to_string();
+        assert!(!msg.is_empty());
+    }
+
+    #[cfg(target_os = "macos")]
+    mod hvf_tests {
+        use super::super::*;
+
+        #[test]
+        fn hvf_probe_startup_check() {
+            let probe = HvfProbe;
+            // Should succeed on Apple Silicon Mac with HVF support
+            match probe.startup_check() {
+                Ok(()) => {}
+                Err(e) => {
+                    let msg = e.to_string();
+                    assert!(
+                        msg.contains("Hypervisor") || msg.contains("architecture"),
+                        "Error should mention HVF: {msg}"
+                    );
+                }
+            }
+        }
+
+        #[test]
+        fn hvf_ffi_constants() {
+            // Verify constants match Apple's Hypervisor.framework definitions
+            assert_eq!(hvf_ffi::HV_SUCCESS, 0);
+            assert_eq!(hvf_ffi::HV_NO_RESOURCES, -85377019_i32);
+            assert_eq!(hvf_ffi::HV_BUSY, -85377022_i32);
+            assert_eq!(hvf_ffi::HV_DENIED, -85377017_i32);
         }
     }
 }

--- a/src/boxlite/src/vmm/krun/engine.rs
+++ b/src/boxlite/src/vmm/krun/engine.rs
@@ -8,6 +8,7 @@ use boxlite_shared::errors::{BoxliteError, BoxliteResult};
 /// Libkrun-specific VMM instance implementation.
 struct KrunVmmInstance {
     context: KrunContext,
+    probe: Box<dyn crate::system_check::HypervisorProbe>,
 }
 
 impl VmmInstanceImpl for KrunVmmInstance {
@@ -29,13 +30,11 @@ impl VmmInstanceImpl for KrunVmmInstance {
         // 1. VM failed to start (negative status)
         // 2. VM started and guest exited (non-negative status) - this is success
         if status < 0 {
-            // VM failed to start
-            if status == -22 {
-                return Err(BoxliteError::Engine("libkrun returned EINVAL.".into()));
-            }
-            Err(BoxliteError::Engine(format!(
-                "VM failed to start with status {status}"
-            )))
+            // VM failed to start — use hypervisor probe to diagnose the cause.
+            // libkrun collapses all errors to -EINVAL, so the probe inspects
+            // the hypervisor directly to get the specific error code.
+            let err = BoxliteError::Engine(format!("VM failed to start (libkrun status={status})"));
+            Err(self.probe.diagnose_create_failure(err))
         } else {
             // VM started and guest exited successfully (status is guest exit code)
             Ok(())
@@ -473,7 +472,10 @@ impl Vmm for Krun {
 
         // Return a VmmInstance that wraps the configured context
         // The actual VM start will happen when enter() is called
-        let instance = KrunVmmInstance { context: ctx };
+        let instance = KrunVmmInstance {
+            context: ctx,
+            probe: crate::system_check::hypervisor_probe(),
+        };
         Ok(VmmInstance::new(Box::new(instance)))
     }
 }

--- a/src/boxlite/src/vmm/krun/mod.rs
+++ b/src/boxlite/src/vmm/krun/mod.rs
@@ -14,7 +14,10 @@ pub(crate) fn check_status(label: &str, status: i32) -> BoxliteResult<()> {
         tracing::error!(function = label, status, "libkrun FFI call failed");
         if status == -22 {
             return Err(BoxliteError::Engine(format!(
-                "libkrun function '{}' returned EINVAL (-22). Check that rootfs contains valid kernel and rootfs structure.",
+                "libkrun function '{}' returned EINVAL (-22). Possible causes:\n\
+                 - macOS: VM address space limit reached (kern.hv.max_address_spaces)\n\
+                 - Invalid rootfs structure (missing kernel or initrd)\n\
+                 Run `boxlite list` to check active boxes.",
                 label
             )));
         }

--- a/src/ffi/src/error.rs
+++ b/src/ffi/src/error.rs
@@ -59,6 +59,8 @@ pub enum BoxliteErrorCode {
     Metadata = 18,
     /// Unsupported engine error
     UnsupportedEngine = 19,
+    /// System resource limit reached
+    ResourceExhausted = 20,
 }
 
 /// Extended error information for C API.
@@ -104,6 +106,7 @@ pub fn error_to_code(err: &BoxliteError) -> BoxliteErrorCode {
         BoxliteError::Rpc(_) => BoxliteErrorCode::Rpc,
         BoxliteError::RpcTransport(_) => BoxliteErrorCode::RpcTransport,
         BoxliteError::MetadataError(_) => BoxliteErrorCode::Metadata,
+        BoxliteError::ResourceExhausted(_) => BoxliteErrorCode::ResourceExhausted,
     }
 }
 

--- a/src/shared/src/errors.rs
+++ b/src/shared/src/errors.rs
@@ -70,6 +70,10 @@ pub enum BoxliteError {
     /// Resource (box or runtime) has been stopped/shutdown.
     #[error("stopped: {0}")]
     Stopped(String),
+
+    /// System resource limit reached (e.g., VM address spaces exhausted).
+    #[error("resource exhausted: {0}")]
+    ResourceExhausted(String),
 }
 
 // Implement From for common error types to enable `?` operator


### PR DESCRIPTION
## Summary

- Add `HypervisorProbe` trait for platform-abstracted hypervisor validation with `startup_check()` and `diagnose_create_failure()` methods
- On macOS, when `krun_start_enter()` fails, `HvfProbe` calls `hv_vm_create()` directly to get the exact HVF error code that libkrun discards (collapses all to EINVAL)
- Maps `HV_NO_RESOURCES` → `ResourceExhausted` with actionable message (address space limit), `HV_DENIED` → entitlement error, `HV_BUSY` → post-creation failure
- Zero-cost on happy path — probe only runs after a failure

## Context

macOS Hypervisor.framework has a hard limit of 128 VM address spaces (`kern.hv.max_address_spaces`). When exhausted, `hv_vm_create()` returns `HV_NO_RESOURCES` (0xfae94005), but libkrun discards the code at `hvf/src/lib.rs:260` and returns generic `-EINVAL` (-22). Users see a misleading "rootfs" error.

## Changes

| File | Change |
|------|--------|
| `src/shared/src/errors.rs` | Add `ResourceExhausted(String)` variant |
| `src/boxlite/src/system_check.rs` | `HypervisorProbe` trait, `HvfProbe` (macOS), `KvmProbe` (Linux), HVF FFI |
| `src/boxlite/src/vmm/krun/engine.rs` | Wire probe into `enter()` failure path |
| `src/boxlite/src/vmm/krun/mod.rs` | Improve EINVAL message in `check_status()` |
| `src/ffi/src/error.rs` | Add `ResourceExhausted = 20` to FFI error codes |
| `sdks/c/include/boxlite.h` | Auto-regenerated C header |

## Test plan

- [x] `cargo clippy -p boxlite -p boxlite-shared --tests -- -D warnings` (clean)
- [x] `cargo test -p boxlite --lib` (614 passed, 0 failed)
- [x] `cargo test -p boxlite-shared` (1 passed)
- [x] HVF constant verification test (`hvf_ffi_constants`)
- [x] HVF startup check test (`hvf_probe_startup_check`)
- [x] System check test (`system_check_runs`)
- [x] Pre-push hook: 220 Rust integration tests passed, C unit tests passed