### PR TITLE
fix(build): remove stale guest dir reference in clean script

### DIFF
--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -46,7 +46,6 @@ parse_args "$@"
 clean_cargo() {
     print_section "Cleaning Rust artifacts..."
     cargo clean
-    [ -d "guest" ] && (cd guest && cargo clean)
 }
 
 clean_python() {


### PR DESCRIPTION
## Summary
- Removed stale `[ -d "guest" ] && (cd guest && cargo clean)` from `scripts/clean.sh`
- The `guest` crate is now a workspace member at `src/guest/`, so root `cargo clean` already handles it
- The old reference caused `make clean` to fail with exit 1 due to `set -e` + `&&` pitfall when the top-level `guest` directory doesn't exist

## Test plan
- [x] `make clean` completes successfully (exit 0)
- [x] All clean stages run to completion (runtime, venv, cargo, python, c, node, cache, wheels, temp, dist)