### PR TITLE
feat(restart): add automatic restart policies for crash recovery

### DIFF
--- a/docs/development/restart.md
+++ b/docs/development/restart.md
@@ -1,0 +1,849 @@
+# Box Restart Policies
+
+BoxLite supports multiple restart policies for automatic recovery when a Box (VM) crashes. This document details the architecture, inner workings, and configuration of the restart mechanism.
+
+---
+
+## Part 1: Architecture Overview
+
+### 1.1 Three Layers of Restart Mechanisms
+
+BoxLite's restart system operates at **three layers**, triggered in different scenarios:
+
+| Layer | Trigger | Handler | Characteristics |
+|-------|---------|---------|-----------------|
+| **Runtime-time** | VM crashes while user process is running | Health Check + Crash Handler | Real-time detection, millisecond response |
+| **Startup-time** | User restarts process, calls `Runtime::new()` | `recover_boxes()` | Recovery detection, state evaluation is synchronous; auto-restarts are async |
+| **Manual** | User calls `start()` on stopped box | `start()` → `restart()` (internal) | Immediate execution, bypasses policy |
+
+**Key Insight**:
+- BoxLite is an **embedded library** without a background daemon
+- Health Check runs **in-process** and stops when the process exits
+- Startup recovery handles crashes that occurred while the process was down
+
+### 1.2 Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────────────────────────────┐
+│                           BoxLite Runtime (Host Process)                        │
+│                                                                                 │
+│  ┌─────────────────────────────────────────────────────────────────────────┐    │
+│  │                      Crash Handler Task (per Runtime)                   │    │
+│  │                                                                         │    │
+│  │   ┌─────────────┐     ┌──────────────┐     ┌──────────────────────┐     │    │
+│  │   │ mpsc::      │────▶│ Process      │────▶│ Evaluate Restart     │     │    │
+│  │   │ Receiver    │     │ Crash Event  │     │ Policy               │     │    │
+│  │   └─────────────┘     └──────────────┘     └──────────────────────┘     │    │
+│  │        │                                            │                   │    │
+│  │        │                                    ┌───────┴──────┐            │    │
+│  │        │                                    ▼              ▼            │    │
+│  │        │                              ┌─────────┐   ┌──────────┐        │    │
+│  │        │                              │ No      │   │ Yes      │        │    │
+│  │        │                              │ Restart │   │ Restart  │        │    │
+│  │        │                              └────┬────┘   └────┬─────┘        │    │
+│  │        │                                   │             │              │    │
+│  │        │                                   ▼             ▼              │    │
+│  │        │                             ┌──────────┐   ┌──────────────┐    │    │
+│  │        │                             │ Mark     │   │ Backoff +    │    │    │
+│  │        │                             │ Stopped  │   │ Call restart │    │    │
+│  │        │                             └──────────┘   └──────────────┘    │    │
+│  │        │                                                                │    │
+│  │   ┌────┴────┐  ┌────────────────────────────────────────────────────┐   │    │
+│  │   │Shutdown │◀─┤ Listens to:                                        │   │    │
+│  │   │ Token   │  │  - crash_rx.recv()                                 │   │    │
+│  │   └─────────┘  │  - shutdown_token.cancelled()                      │   │    │
+│  │                └────────────────────────────────────────────────────┘   │    │
+│  └─────────────────────────────────────────────────────────────────────────┘    │
+│                                    │                                            │
+│                                    │ mpsc::channel<BoxID>                       │
+│                                    ▼                                            │
+│  ┌─────────────────────────────────────────────────────────────────────────┐    │
+│  │                           BoxImpl (per Box)                             │    │
+│  │                                                                         │    │
+│  │   ┌────────────────────────────────────────────────────────────────┐    │    │
+│  │   │                    Health Check Task                           │    │    │
+│  │   │                                                                │    │    │
+│  │   │   loop {                                                       │    │    │
+│  │   │       tokio::select! {                                         │    │    │
+│  │   │           _ = sleep(interval) => {                             │    │    │
+│  │   │               match guest.ping().await {                       │    │    │
+│  │   │                   Ok(_) => mark_healthy(),                     │    │    │
+│  │   │                   Err(_) => {                                  │    │    │
+│  │   │                       if !is_shim_alive() {                    │    │    │
+│  │   │                           crash_tx.send(box_id); ─────────┐    │    │    │
+│  │   │                           break; // Task exits ───────────┤    │    │    │
+│  │   │                       }                                   │    │    │    │
+│  │   │                       if retries_exceeded() {             │    │    │    │
+│  │   │                           mark_unhealthy();               │    │    │    │
+│  │   │                           break;                          │    │    │    │
+│  │   │                       }                                   │    │    │    │
+│  │   │                   }                                       │    │    │    │
+│  │   │               }                                           │    │    │    │
+│  │   │           }                                               │    │    │    │
+│  │   │           _ = shutdown_token.cancelled() => break; ◀──────┘    │    │    │
+│  │   │       }                                                        │    │    │
+│  │   │   }                                                            │    │    │
+│  │   └────────────────────────────────────────────────────────────────┘    │    │
+│  │                                                                         │    │
+│  │   ┌────────────────────────────────────────────────────────────────┐    │    │
+│  │   │                        LiveState                               │    │    │
+│  │   │  ┌──────────────┐  ┌──────────────────┐  ┌──────────────────┐  │    │    │
+│  │   │  │ VmmHandler   │  │ GuestSession     │  │ Metrics          │  │    │    │
+│  │   │  │ (Shim PID)   │  │ (gRPC to Guest)  │  │ (CPU/Mem)        │  │    │    │
+│  │   │  └──────────────┘  └──────────────────┘  └──────────────────┘  │    │    │
+│  │   └────────────────────────────────────────────────────────────────┘    │    │
+│  │                                                                         │    │
+│  └─────────────────────────────────────────────────────────────────────────┘    │
+│                                                                                 │
+│  ┌─────────────────────────────────────────────────────────────────────────┐    │
+│  │                      RuntimeImpl State Management                       │    │
+│  │                                                                         │    │
+│  │   ┌──────────────────┐  ┌───────────────────────────────────────────┐   │    │
+│  │   │ pending_crashes  │  │ HashSet<BoxID>                            │   │    │
+│  │   │ (RwLock)         │  │ Prevents duplicate crash handling         │   │    │
+│  │   └──────────────────┘  └───────────────────────────────────────────┘   │    │
+│  │                                                                         │    │
+│  │   ┌──────────────────┐  ┌───────────────────────────────────────────┐   │    │
+│  │   │ crash_tx         │  │ mpsc::Sender<BoxID>                       │   │    │
+│  │   │ (cloned per box) │  │ Fire-and-forget crash notifications       │   │    │
+│  │   └──────────────────┘  └───────────────────────────────────────────┘   │    │
+│  │                                                                         │    │
+│  │   ┌──────────────────┐  ┌───────────────────────────────────────────┐   │    │
+│  │   │ shutdown_token   │  │ CancellationToken                         │   │    │
+│  │   │ (per Runtime)    │  │ Signals shutdown to all components        │   │    │
+│  │   └──────────────────┘  └───────────────────────────────────────────┘   │    │
+│  │                                                                         │    │
+│  │   ┌──────────────────┐  ┌───────────────────────────────────────────┐   │    │
+│  │   │ crash_task_      │  │ RwLock<Vec<JoinHandle<()>>>               │   │    │
+│  │   │ handles          │  │ Tracks spawned per-crash tasks            │   │    │
+│  │   └──────────────────┘  └───────────────────────────────────────────┘   │    │
+│  └─────────────────────────────────────────────────────────────────────────┘    │
+└─────────────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────────────┐
+│                              Persistence Layer (SQLite)                         │
+│                                                                                 │
+│   BoxState {                                                                    │
+│       status: BoxStatus,          // Configured | Running | Crashed | etc       │
+│       stop_info: StopInfo {       // Valid when stopped/crashed/restarting      │
+│           cause: StopCause,       // Normal | CrashedNoPolicy | MaxRetries      │
+│           exit_code: Option<i32>, // From shim exit file                        │
+│           exit_time: DateTime,    // When crash detected                        │
+│           restart_count: u32,     // Attempts in current sequence               │
+│           restarted_at: Option,   // Last successful restart                    │
+│       },                                                                        │
+│       last_restart_error: Option<String>,  // Error from last failed restart    │
+│       health_status: HealthStatus,          // Health state + failure count     │
+│       // ... other fields                                                       │
+│   }                                                                             │
+└─────────────────────────────────────────────────────────────────────────────────┘
+```
+
+### 1.3 Core Design Principles
+
+| Principle | Implementation |
+|-----------|---------------|
+| **Separation of Concerns** | Health Check detects only; Crash Handler decides and executes |
+| **Non-blocking Notification** | Health Check sends via `crash_tx.send()` with 100ms timeout; drops notification on timeout |
+| **Duplicate Prevention** | `pending_crashes` HashSet prevents concurrent handling of the same box |
+| **Graceful Shutdown** | All components listen to `shutdown_token` |
+| **Cleanup Guarantee** | Spawned task removes `pending_crashes` entry after completion |
+
+### 1.4 Component Boundaries
+
+| Component | Responsibility | Lifecycle |
+|-----------|---------------|-----------|
+| **Health Check Task** | Detect shim death, report via channel | Per Box; exits on crash, stop, or unhealthy |
+| **Crash Handler Task** | Receive notifications, evaluate policy, execute restart | Per Runtime; runs until shutdown |
+| **Per-Crash Handler** | Handle single crash: read exit info, backoff, restart | Per crash; exits when done or shutdown |
+| **Pending Crashes Set** | Track in-flight crash handling, prevent duplicates | Runtime-scoped; guarded by RwLock |
+| **Crash Task Handles** | Track spawned per-crash task JoinHandles | Runtime-scoped; periodically pruned |
+
+### 1.5 State Machine Overview
+
+```
+[Configured] --start()--> [Running] --stop()--> [Stopped]
+      |                        |                 ^
+      |                        | crash           |
+      |                        v                 |
+      |                    [Crashed]--no policy--+
+      |                        |
+      |         +--------------+ restart policy
+      |         v
+      +----[Restarting]--success--> [Running]
+                           |
+                           | max attempts / cancelled
+                           v
+                        [Stopped]
+```
+
+**Key State Transitions**:
+- `Running` → `Crashed`: Health Check detects shim process death
+- `Crashed` → `Restarting`: Restart policy conditions met
+- `Crashed` → `Stopped`: No policy or policy conditions not met
+- `Restarting` → `Running`: Restart succeeds
+- `Restarting` → `Stopped`: Cancelled or max retries exceeded
+
+---
+
+## Part 2: Runtime-time Mechanism
+
+When the user process is running, the Health Check Task and Crash Handler Task work together to enable real-time crash detection and automatic recovery.
+
+### 2.1 Crash Detection
+
+#### 2.1.1 Health Check Task Workflow
+
+The Health Check Task is created when a Box starts and continuously monitors the Guest's health:
+
+```
+loop:
+    ├─ sleep(interval)
+    ├─ In start_period? → skip ping (treat as OK)
+    ├─ guest.ping() with timeout
+    │   ├─ OK → mark Healthy (persist if changed)
+    │   └─ Fail → check process alive
+    │       ├─ Alive → count failure
+    │       │   └─ retries exceeded → Unhealthy, exit
+    │       └─ Dead → **CRASHED**
+    │           → crash_tx.send(box_id)  (notify Crash Handler, 100ms timeout)
+    │           → exit (Task ends)
+    └─ shutdown_token.cancelled() → exit
+```
+
+#### 2.1.2 Two Unhealthy Scenarios
+
+When the Health Check detects a failure, it responds differently based on shim process state:
+
+| Scenario | Detection | Health State | Box Status | Action |
+|----------|-----------|--------------|------------|--------|
+| Guest unresponsive | `ping()` fails, retries exhausted | `Unhealthy` | `Running` | Mark unhealthy, stop Health Check |
+| Shim process died | `is_process_alive(pid)` returns false | `Unhealthy` | `Crashed` | Send crash notification to Crash Handler |
+
+**Key Distinction**: Only **shim process death** triggers crash handling and restart policy evaluation. Guest unresponsiveness alone does not cause a restart.
+
+#### 2.1.3 Health Check Responsibilities
+
+The Health Check **only does three things**:
+1. Periodically ping Guest to check health
+2. Detect if shim process has died
+3. Send crash notification (`crash_tx.send(box_id)` with 100ms timeout)
+
+The Health Check **does NOT**:
+- Read exit info files
+- Evaluate restart policies
+- Handle backoff logic
+- Call `restart()`
+
+After sending the notification, the Health Check Task exits immediately (`break from loop`).
+
+### 2.2 Crash Handling
+
+#### 2.2.1 Crash Handler Task Architecture
+
+The Crash Handler Task is created during `ensure_services_started()` (lazily on first async call) and is a long-running, per-Runtime task:
+
+```rust
+fn spawn_crash_handler(runtime, crash_rx) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                Some(box_id) = crash_rx.recv() => {
+                    if runtime.shutdown_token.is_cancelled() { continue; }
+                    if runtime.pending_crashes.read().unwrap().contains(&box_id) { continue; }
+                    runtime.pending_crashes.write().unwrap().insert(box_id.clone());
+                    let rt = Arc::clone(&runtime);
+                    let handle = tokio::spawn(async move {
+                        Self::handle_box_crash(rt, box_id).await;
+                        rt.pending_crashes.write().unwrap().remove(&box_id);
+                    });
+                    // Track spawned task handle
+                    runtime.crash_task_handles.write().unwrap().push(handle);
+                }
+                _ = runtime.shutdown_token.cancelled() => { break; }
+            }
+        }
+    })
+}
+```
+
+#### 2.2.2 Single Crash Handling Flow
+
+`handle_box_crash()` processes a single crash through the complete flow:
+
+```
+Crash Handler receives box_id
+    ↓
+1. Register in pending_crashes (HashSet insert)
+   └─ Spawned task removes entry on completion (no CleanupGuard)
+    ↓
+2. Acquire per-box lock (spinloop with shutdown check)
+   └─ Ensures mutual exclusion with manual restart() and other crash handlers
+    ↓
+3. Verify Box state (crashable: Running/Crashed)
+   └─ Re-read state from DB to minimize races
+    ↓
+4. Read exit info
+   └─ Read from shim exit file; no file defaults to exit_code = 0 (clean exit)
+    ↓
+5. Update state (persist before evaluation for crash metadata recovery)
+   └─ status = Crashed
+   └─ stop_info.exit_code = exit_code
+   └─ stop_info.exit_time = now
+   └─ stop_info.restart_count += 1
+   └─ Persist to DB
+    ↓
+6. Evaluate restart policy (lock still held; uses pre-increment count)
+   └─ Calls policy.should_restart(exit_code, current_restart_count)
+   └─ No → Stopped, cause = stop_cause_when_restart_denied(), return
+   └─ Should restart → continue
+    ↓
+7. Release per-box lock (end of Phase 1)
+    ↓
+8. Execute backoff + restart loop (lock acquired per attempt)
+   Calculate backoff (exponential: 100ms, 200ms, 400ms... cap 30s)
+   ↓
+   tokio::select! {
+       _ = sleep(delay) => {
+           // Per attempt: acquire lock → restart → release lock
+           acquire per-box lock
+           re-read status (if Running → skip, manual restart already succeeded)
+           runtime.restart(box_id).await
+           release per-box lock
+       }
+
+       _ = shutdown_token.cancelled() => {
+           // Runtime shutting down
+           status = Stopped, cause = Normal
+           return
+       }
+   }
+   ↓
+   On success: restart() resets stop_info (count=0, restarted_at=now); break loop
+   On failure: persist RestartFailed, check if should_retry
+       ├─ should_retry → continue loop (next backoff + attempt)
+       └─ !should_retry → Stopped, cause = MaxRetriesExceeded; break
+    ↓
+Spawned task removes entry from pending_crashes
+```
+
+#### 2.2.3 Producer-Consumer Pattern
+
+Health Check and Crash Handler form a **producer-consumer** relationship:
+
+```
+┌─────────────────────┐         ┌──────────────────────┐
+│   Producer          │         │   Consumer           │
+│   (Health Check)    │         │   (Crash Handler)    │
+│                     │         │                      │
+│  Detect crash       │────┐    │  Receive notification│
+│  Send notification  │    │    │  Evaluate policy     │
+│  Exit immediately   │    │    │  Execute restart     │
+└─────────────────────┘    │    └──────────────────────┘
+                           │
+                    ┌──────┴──────┐
+                    │ mpsc::      │
+                    │ channel     │
+                    └─────────────┘
+```
+
+**Design Benefits**:
+1. **Decoupling**: Health Check doesn't block waiting for restart
+2. **Parallelism**: Multiple crashes can be processed concurrently
+3. **Mutual Exclusion**: Per-box file lock prevents conflicting restart attempts
+
+### 2.3 Concurrency Safety
+
+#### 2.3.1 Shutdown Ordering
+
+The Crash Handler must listen to both `crash_rx.recv()` and `shutdown_token.cancelled()`:
+
+```rust
+loop {
+    tokio::select! {
+        Some(box_id) = crash_rx.recv() => { /* handle crash */ }
+        _ = shutdown_token.cancelled() => { break; }
+    }
+}
+```
+
+If only listening to the channel, when Runtime shuts down:
+- The channel won't close (producers still hold senders)
+- Crash Handler never exits
+- Causes shutdown to hang
+
+#### 2.3.2 Duplicate Handling Protection
+
+`pending_crashes: RwLock<HashSet<BoxID>>` prevents duplicate processing:
+
+```rust
+// When receiving crash notification
+if pending_crashes.read().unwrap().contains(&box_id) {
+    // Already being handled, skip
+    continue;
+}
+
+// Before starting handling
+pending_crashes.write().unwrap().insert(box_id.clone());
+
+// The spawned task removes the entry directly after completion:
+//   pending_crashes.write().unwrap().remove(&box_id);
+```
+
+#### 2.3.3 Manual Restart vs Auto-Restart Mutual Exclusion
+
+`restart()` does **NOT** cancel pending crash handling. Mutual exclusion is ensured by the per-box file lock:
+
+- Callers must hold the per-box lock before calling `restart()`
+- Both `handle_box_crash` and recovery auto-restart tasks acquire the lock before calling `restart()`
+
+**Race Handling**: If the crash handler's backoff sleep finishes and `restart()` was called manually while the handler was sleeping, the crash handler re-acquires the per-box lock, re-reads the box status, sees `Running`, and skips the auto-restart. This avoids conflicting restart attempts without requiring explicit cancellation.
+
+---
+
+## Part 3: Startup-time Mechanism
+
+### 3.1 Why Startup Recovery is Needed
+
+BoxLite has no daemon; Health Check runs in the user process. When the user process exits:
+- VM may continue running (detach mode)
+- VM may crash
+- No monitoring, no automatic recovery
+
+When the user **restarts the process** and calls `Runtime::new()`, we need to check the status of these "orphan" Boxes.
+
+### 3.2 recover_boxes() Flow
+
+```
+Runtime::new()
+    ↓
+recover_boxes() ──► Iterate all persisted boxes
+    │
+    ├─ Phase 0: Cleanup orphaned directories (no DB record)
+    ├─ Phase 1: Remove auto_remove=true boxes and orphaned active boxes
+    ├─ Phase 1.5: Recover interrupted snapshots
+    │
+    ├─ Phase 2: For each remaining box:
+    │   ├─ Read PID file
+    │   │   ├─ Process alive + same process ──► Reattach, set Running
+    │   │   └─ Process dead / no PID file ──► Not running, evaluate restart policy
+    │   │       ├─ None / No ──► Mark Stopped, cause = CrashedNoPolicy
+    │   │       ├─ OnFailure + exit_code == 0 ──► Mark Stopped, cause = Normal
+    │   │       ├─ OnFailure + max_retries exceeded ──► Mark Stopped, cause = MaxRetriesExceeded
+    │   │       ├─ OnFailure + non-zero exit + under max_retries ──► Queue for auto-restart
+    │   │       ├─ Always ──► Queue for auto-restart
+    │   │       ├─ UnlessStopped + cause=Normal ──► Mark Stopped (user explicitly stopped)
+    │   │       └─ UnlessStopped + cause!=Normal ──► Queue for auto-restart
+    │   └─ Persist updated state
+    ↓
+Return list of boxes to auto-restart (stored in recovery_queue)
+    ↓
+ensure_services_started() (lazily on first async call)
+    ├─ Spawn crash handler task
+    └─ Spawn async task for auto-restart (sequential, with per-box lock)
+    ↓
+Runtime ready to accept requests
+```
+
+### 3.3 Runtime-time vs Startup-time Comparison
+
+| Characteristic | Runtime-time | Startup-time |
+|----------------|-------------|--------------|
+| **Trigger** | Health Check detects crash | `Runtime::new()` called |
+| **Handler** | Crash Handler Task | `recover_boxes()` + `ensure_services_started()` |
+| **Execution** | Async (spawn task) | State evaluation synchronous; auto-restart async |
+| **Response Latency** | Milliseconds | Seconds (startup overhead) |
+| **Communication** | `mpsc::channel` | Direct function call |
+| **Concurrency** | Multiple crashes in parallel | Sequential processing |
+| **Mutual Exclusion** | Per-box file lock | Per-box file lock |
+
+### 3.4 Why Two Mechanisms are Needed
+
+**Runtime-time**:
+- User process is running
+- Real-time crash response needed
+- Supports complex concurrency control
+
+**Startup-time**:
+- User process just started
+- Crash Handler Task not yet created
+- Must recover existing Boxes before serving requests
+
+**Complementary Relationship**:
+- Runtime-time handles "real-time monitoring while running"
+- Startup-time handles "state recovery after process restart"
+- Together they cover the complete Box lifecycle
+
+---
+
+## Part 4: Configuration Guide
+
+### 4.1 Restart Policy Types
+
+```rust
+pub enum RestartPolicy {
+    No,                             // Never restart (default)
+    Always,                         // Always restart
+    OnFailure { max_retries: u32 }, // Restart on non-zero exit, limited retries
+    UnlessStopped,                  // Always restart unless explicitly stopped
+}
+```
+
+**Policy Semantics**:
+
+| Policy | Restart Condition | Retry Limit | Use Case |
+|--------|-------------------|-------------|----------|
+| `No` | Never | N/A | Development, one-off tasks |
+| `Always` | Always (any exit code) | Unlimited | Services that must stay running |
+| `OnFailure { max_retries }` | Exit code != 0 only (`None` = clean exit) | `max_retries` | Fault-tolerant with ceiling |
+| `UnlessStopped` | Always at runtime; only `cause != Normal` at recovery | Unlimited | Long-running services |
+
+### 4.2 Auto-Enable Health Check
+
+Restart policies require a monitoring mechanism to work. When `restart_policy` is set but `health_check` is not, the system **auto-enables** a default Health Check:
+
+```rust
+// effective_health_check() logic
+if user_configured_health_check {
+    Some(user_config)  // Use user config
+} else if restart_policy.is_some() {
+    Some(default_config)  // Auto-enable default
+} else {
+    None  // No monitoring
+}
+```
+
+**Default Configuration**:
+- `interval`: 5s (user default is 30s, policy needs faster detection)
+- `timeout`: 10s
+- `retries`: 3
+- `start_period`: 60s
+
+### 4.3 Configuration Matrix
+
+| Health Check | Restart Policy | Behavior |
+|-------------|----------------|----------|
+| Configured | Configured | Use user Health Check, trigger policy on crash |
+| Not configured | Configured | Auto-enable default Health Check |
+| Configured | Not configured | Health Check marks unhealthy, no auto-restart |
+| Not configured | Not configured | No monitoring, no restart |
+
+### 4.4 Configuration Examples
+
+**Basic Configuration**:
+
+```python
+import boxlite
+
+runtime = await boxlite.Runtime.new()
+
+# Always policy - always restart
+box1 = await runtime.create_box(
+    image="python:3.11",
+    advanced=boxlite.AdvancedBoxOptions(
+        restart_policy=boxlite.RestartPolicy.ALWAYS
+    )
+)
+
+# OnFailure policy - max 3 retries
+box2 = await runtime.create_box(
+    image="worker:latest",
+    advanced=boxlite.AdvancedBoxOptions(
+        restart_policy=boxlite.RestartPolicy.ON_FAILURE(max_retries=3)
+    )
+)
+
+# UnlessStopped policy - restart unless explicitly stopped
+box3 = await runtime.create_box(
+    image="server:latest",
+    advanced=boxlite.AdvancedBoxOptions(
+        restart_policy=boxlite.RestartPolicy.UNLESS_STOPPED
+    )
+)
+```
+
+**Custom Health Check + Policy**:
+
+```python
+box = await runtime.create_box(
+    image="api:latest",
+    health_check=boxlite.HealthCheckOptions(
+        interval=10,      # Check every 10 seconds
+        timeout=5,        # 5 second timeout
+        retries=5,        # Mark unhealthy after 5 failures
+        start_period=120  # Don't count failures for 120s after start
+    ),
+    advanced=boxlite.AdvancedBoxOptions(
+        restart_policy=boxlite.RestartPolicy.ON_FAILURE(max_retries=5)
+    )
+)
+```
+
+**Detach Mode + Policy**:
+
+```python
+box = await runtime.create_box(
+    image="daemon:latest",
+    detach=True,  # VM continues after process exits
+    advanced=boxlite.AdvancedBoxOptions(
+        restart_policy=boxlite.RestartPolicy.UNLESS_STOPPED
+    )
+)
+
+# After process exits, if VM crashes, detection happens on next get()
+box_ref = await runtime.get_box(box.id)
+await box_ref.start()  # Restart if needed
+```
+
+### 4.5 Restart Policy vs Detach Mode
+
+**Key Distinction**: Auto-restart only works while user process is running.
+
+```
+Normal Mode (detach=false):
+    User process running ──► BoxImpl in memory ──► Health Check active
+                                │
+                                ▼ Shim death detected
+                        Immediate auto-restart ✅
+
+Detach Mode (detach=true):
+    User process running ──► BoxImpl in memory ──► Health Check active
+            │                  │
+            ▼                  ▼ User exits
+    Process exits      BoxImpl dropped, Health Check stopped
+            │                  │
+            │                  ▼ VM crashes
+            │             No Health Check, no auto-restart ❌
+            │                  │
+            ▼                  ▼
+    User restarts process  Crash detected on next get()/start()
+            │                  │
+            └──────────────────┘
+                        │
+                        ▼
+                Manual restart() to recover
+```
+
+**Detach Mode Implication**: "Decouple VM lifecycle from process lifecycle". User accepts responsibility for managing the Box after process exit.
+
+---
+
+## Part 5: Implementation Details
+
+### 5.1 Restart Method Implementation
+
+`restart()` follows the same pattern as `stop()`: invalidate old `BoxImpl`, create new one, call `start()`.
+
+**Important**: Callers must hold the per-box lock before calling `restart()` -- `restart()` does NOT acquire it internally. Both `handle_box_crash` and recovery auto-restart tasks acquire the lock before calling `restart()`.
+
+```
+SharedRuntimeImpl::restart(box_id)
+    │
+    ├─ 1. Read existing config and state from DB
+    │
+    ├─ 2. If active BoxImpl in cache:
+    │      Abort its Health Check Task
+    │      Cancel shutdown_token (makes old BoxImpl unusable)
+    │
+    ├─ 3. Invalidate old BoxImpl from cache
+    │      invalidate_box_impl(box_id, box_name)
+    │
+    ├─ 4. Update state: status=Restarting, clear health, persist
+    │
+    ├─ 5. Create new BoxImpl
+    │      Empty OnceCell, new shutdown_token
+    │
+    ├─ 6. Call start() on new BoxImpl
+    │      → OnceCell empty → init_live_state()
+    │      → BoxBuilder sees status=Restarting → restart pipeline
+    │      → New VM starts, new Health Check Task
+    │
+    └─ 7. Reset stop_info
+           stop_info = StopInfo::default()
+           stop_info.restarted_at = now()
+           Persist
+```
+
+### 5.2 BoxBuilder Restart Pipeline
+
+`BoxBuilder` treats `Restarting` the same as `Stopped`: reuse existing COW disks, spawn new VM:
+
+```rust
+fn get_execution_plan(status: BoxStatus) -> ExecutionPlan<InitCtx> {
+    match status {
+        BoxStatus::Configured => { /* Full pipeline */ }
+        BoxStatus::Stopped | BoxStatus::Restarting => {
+            // Restart pipeline: reuse COW disks, spawn new VM, connect, init
+        }
+        BoxStatus::Running => { /* Reattach pipeline */ }
+        _ => panic!("Invalid status for initialization"),
+    }
+}
+```
+
+The distinction between `Restarting` and `Stopped` exists only at the state machine level for observability—the Builder executes the same pipeline.
+
+### 5.3 Backoff Calculation
+
+```rust
+pub fn calculate_backoff(restart_count: u32) -> Duration {
+    let base_ms: u64 = 100;
+    let max_ms: u64 = 30_000;
+    let exp = 1u64.checked_shl(restart_count.min(18)).unwrap_or(u64::MAX);
+    Duration::from_millis(base_ms.saturating_mul(exp).min(max_ms))
+}
+```
+
+**Backoff Sequence**: 100ms → 200ms → 400ms → 800ms → ... → 30s (cap)
+
+### 5.4 StopCause Tracking
+
+`StopCause` is set by different code paths to record why a Box stopped:
+
+| Method | Cause | Scenario |
+|--------|-------|----------|
+| `mark_stop()` | `Normal` | User called `stop()` or normal exit |
+| `reset_for_reboot()` | `SystemReboot` | System reboot detected during recovery |
+| Crash handler (no policy) | `CrashedNoPolicy` | Shim crashed, no restart policy (`No` or `None`) |
+| Crash handler (OnFailure, clean exit) | `Normal` | `exit_code == 0` or `None`, not a failure |
+| Crash handler (OnFailure, max retries) | `MaxRetriesExceeded` | Policy exhausted retry budget |
+| Crash handler (restart attempt failed) | `RestartFailed` | A restart attempt failed but retries may continue |
+| Crash handler (backoff loop, max retries) | `MaxRetriesExceeded` | Restart attempt failed and no retries left |
+| Recovery (`UnlessStopped`, user stopped) | `Normal` | `stop_info.cause == Normal` during startup recovery |
+| `restart()` success | `Normal` (default) | Reset stop_info on successful restart |
+| Defensive code | `Unknown` | Unreachable branch (should not happen) |
+
+**UnlessStopped policy** uses `StopCause::Normal` to distinguish user-initiated stops from crashes. During recovery, if `stop_info.cause == Normal`, auto-restart should not occur.
+
+### 5.5 Restart Counter
+
+The counter exists both in-memory (for backoff) and persisted (for recovery).
+
+**In-memory counter** (inside Crash Handler Task):
+```rust
+let current_restart_count = state.stop_info.restart_count;
+let new_restart_count = current_restart_count + 1;
+let backoff = calculate_backoff(current_restart_count);
+```
+
+**Persisted counter** (`state.stop_info.restart_count`):
+- Written to DB on each crash: `restart_count += 1`
+- Reset on successful restart: `restart()` sets `stop_info` to default (`count=0`)
+- `OnFailure` policy: `should_restart()` checks `restart_count < max_retries` (strict less-than)
+
+**Design Rationale**:
+- Resetting on success ensures each "crash sequence" has independent retry budget
+- Persisted counter enables cross-process recovery
+
+### 5.6 State Definitions
+
+```rust
+pub enum BoxStatus {
+    Unknown,
+    Configured,
+    Running,
+    Stopping,
+    Stopped,
+    Crashed,
+    Restarting,
+    Paused,
+}
+
+impl BoxStatus {
+    /// Only Running boxes have an active VM process that needs monitoring
+    /// Restarting is transient—monitoring starts after transition to Running
+    pub fn requires_monitoring(&self) -> bool {
+        matches!(self, BoxStatus::Running)
+    }
+}
+
+/// Why the box stopped
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StopCause {
+    #[default]
+    Normal,           // User called stop() or normal exit
+    CrashedNoPolicy,  // Crashed but no restart policy
+    MaxRetriesExceeded,  // Policy exhausted retries
+    SystemReboot,     // System reboot detected
+    RestartFailed,    // Restart attempt failed (e.g., VM failed to start)
+    Unknown,          // Unexpected state (should not happen in normal operation)
+}
+
+/// Stop info (valid when status is Stopped/Crashed)
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct StopInfo {
+    pub cause: StopCause,
+    pub exit_code: Option<i32>,
+    pub exit_time: Option<DateTime<Utc>>,
+    pub restart_count: u32,
+    pub restarted_at: Option<DateTime<Utc>>,
+}
+
+pub struct BoxState {
+    pub status: BoxStatus,
+    pub stop_info: StopInfo,
+}
+```
+
+### 5.7 API Reference
+
+```rust
+pub enum RestartPolicy {
+    No,
+    Always,
+    OnFailure { max_retries: u32 },
+    UnlessStopped,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct AdvancedBoxOptions {
+    #[serde(default)]
+    restart_policy: Option<RestartPolicy>,
+}
+```
+
+---
+
+## Appendix: FAQ
+
+### Q: Why doesn't BoxLite have a Daemon?
+
+BoxLite is designed as "SQLite for sandboxing"—a lightweight embedded library without a background service. This brings:
+- Simple deployment: No daemon to manage
+- Resource efficiency: No resident memory overhead
+- Security boundary: No shared privileged process
+
+The trade-off: No monitoring after process exit, requiring Startup Recovery.
+
+### Q: Why are Health Check and Crash Handler separated?
+
+**Separation of Concerns**:
+- Health Check is bound to BoxImpl lifecycle
+- Crash Handler needs to manage Box lifecycle (including creating new BoxImpl)
+- If Health Check directly handled restart, it would create circular dependency
+
+After separation:
+- Health Check only detects and reports
+- Crash Handler decides and orchestrates
+- Clear data flow: `channel` decouples them
+
+### Q: Does manually calling `start()` on a stopped box trigger the policy?
+
+No. Calling `start()` on a stopped box invokes the internal `restart()` method, which is a **forced restart** that:
+1. Acquires the per-box lock (caller holds it)
+2. Immediately restarts the Box
+3. Resets `stop_info`
+
+If a crash handler's backoff sleep finishes after the manual restart, it re-acquires the lock, re-reads the status, sees `Running`, and skips the auto-restart.
+
+The policy is only evaluated when a **crash is detected**.
+
+### Q: Does the policy work in Detach mode?
+
+**Only while the user process is running**. In Detach mode:
+- User process running: Health Check active, crashes detectable, policy effective
+- User process exited: Health Check stopped, crashes undetectable
+- Next startup: Startup Recovery detects crashes but policy evaluation differs
+
+If you need monitoring after process exit, BoxLite is not the right solution (consider container runtimes with a daemon).

--- a/sdks/node/src/info.rs
+++ b/sdks/node/src/info.rs
@@ -75,6 +75,8 @@ fn status_to_string(status: BoxStatus) -> String {
         BoxStatus::Running => "running",
         BoxStatus::Stopping => "stopping",
         BoxStatus::Stopped => "stopped",
+        BoxStatus::Crashed => "crashed",
+        BoxStatus::Restarting => "restarting",
         BoxStatus::Paused => "paused",
     }
     .to_string()

--- a/sdks/node/src/lib.rs
+++ b/sdks/node/src/lib.rs
@@ -26,7 +26,7 @@ pub use info::{JsBoxInfo, JsBoxStateInfo, JsHealthState, JsHealthStatus};
 pub use metrics::{JsBoxMetrics, JsRuntimeMetrics};
 pub use options::{
     JsBoxOptions, JsBoxliteRestOptions, JsEnvVar, JsHealthCheckOptions, JsNetworkSpec, JsOptions,
-    JsPortSpec, JsSecret, JsVolumeSpec,
+    JsPortSpec, JsRestartPolicy, JsSecret, JsVolumeSpec,
 };
 pub use runtime::JsBoxlite; // re-export for dist bundling
 pub use snapshot_options::{JsCloneOptions, JsExportOptions, JsSnapshotOptions};

--- a/sdks/node/src/options.rs
+++ b/sdks/node/src/options.rs
@@ -2,7 +2,9 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use boxlite::BoxliteRestOptions;
-use boxlite::runtime::advanced_options::{AdvancedBoxOptions, HealthCheckOptions, SecurityOptions};
+use boxlite::runtime::advanced_options::{
+    AdvancedBoxOptions, HealthCheckOptions, RestartPolicy, SecurityOptions,
+};
 use boxlite::runtime::constants::images;
 use boxlite::runtime::options::{
     BoxOptions, BoxliteOptions, NetworkConfig, NetworkMode, NetworkSpec, PortProtocol, PortSpec,
@@ -11,6 +13,46 @@ use boxlite::runtime::options::{
 use napi_derive::napi;
 
 use crate::advanced_options::JsSecurityOptions;
+
+/// Restart policy for automatic restart on crash.
+///
+/// Similar to Docker's restart policy. Controls what happens when a box's
+/// shim process crashes.
+#[napi(object)]
+#[derive(Clone, Debug)]
+pub struct JsRestartPolicy {
+    /// Policy type: "no", "always", "on_failure", or "unless_stopped"
+    #[napi(js_name = "type")]
+    pub type_: String,
+
+    /// Maximum retries for "on_failure" policy.
+    #[napi(js_name = "maxRetries")]
+    pub max_retries: Option<u32>,
+}
+
+impl TryFrom<JsRestartPolicy> for RestartPolicy {
+    type Error = boxlite_shared::errors::BoxliteError;
+
+    fn try_from(js_policy: JsRestartPolicy) -> Result<Self, Self::Error> {
+        match js_policy.type_.as_str() {
+            "no" => Ok(RestartPolicy::No),
+            "always" => Ok(RestartPolicy::Always),
+            "on_failure" => {
+                let max_retries = js_policy.max_retries.ok_or_else(|| {
+                    boxlite_shared::errors::BoxliteError::Config(
+                        "on_failure restart policy requires maxRetries".into(),
+                    )
+                })?;
+                Ok(RestartPolicy::OnFailure { max_retries })
+            }
+            "unless_stopped" => Ok(RestartPolicy::UnlessStopped),
+            _ => Err(boxlite_shared::errors::BoxliteError::Config(format!(
+                "invalid restart policy type: {}",
+                js_policy.type_
+            ))),
+        }
+    }
+}
 
 /// Health check options for boxes.
 ///
@@ -143,6 +185,10 @@ pub struct JsBoxOptions {
     /// Health check options for the box.
     #[napi(js_name = "healthCheck")]
     pub health_check: Option<JsHealthCheckOptions>,
+
+    /// Restart policy for automatic restart on crash.
+    #[napi(js_name = "restartPolicy")]
+    pub restart_policy: Option<JsRestartPolicy>,
 
     /// Secrets to inject into outbound HTTPS requests via MITM proxy.
     pub secrets: Option<Vec<JsSecret>>,
@@ -313,6 +359,10 @@ impl TryFrom<JsBoxOptions> for BoxOptions {
             .unwrap_or_default();
 
         let health_check = js_opts.health_check.map(HealthCheckOptions::from);
+        let restart_policy = js_opts
+            .restart_policy
+            .map(RestartPolicy::try_from)
+            .transpose()?;
         let secrets = js_opts
             .secrets
             .unwrap_or_default()
@@ -340,6 +390,7 @@ impl TryFrom<JsBoxOptions> for BoxOptions {
             advanced: AdvancedBoxOptions {
                 security,
                 health_check,
+                restart_policy,
                 ..Default::default()
             },
             auto_remove: js_opts.auto_remove.unwrap_or(false),
@@ -435,6 +486,7 @@ mod tests {
             user: None,
             security: None,
             health_check: None,
+            restart_policy: None,
             secrets: None,
         };
 
@@ -467,6 +519,7 @@ mod tests {
             user: None,
             security: None,
             health_check: None,
+            restart_policy: None,
             secrets: Some(vec![JsSecret {
                 name: "openai".into(),
                 value: "sk-test".into(),
@@ -480,6 +533,97 @@ mod tests {
         assert_eq!(opts.secrets[0].name, "openai");
         assert_eq!(opts.secrets[0].hosts, vec!["api.openai.com"]);
         assert_eq!(opts.secrets[0].placeholder, "<BOXLITE_SECRET:openai>");
+    }
+
+    #[test]
+    fn restart_policy_no() {
+        let js = JsRestartPolicy {
+            type_: "no".into(),
+            max_retries: None,
+        };
+        let policy = RestartPolicy::try_from(js).unwrap();
+        assert_eq!(policy, RestartPolicy::No);
+    }
+
+    #[test]
+    fn restart_policy_always() {
+        let js = JsRestartPolicy {
+            type_: "always".into(),
+            max_retries: None,
+        };
+        let policy = RestartPolicy::try_from(js).unwrap();
+        assert_eq!(policy, RestartPolicy::Always);
+    }
+
+    #[test]
+    fn restart_policy_on_failure() {
+        let js = JsRestartPolicy {
+            type_: "on_failure".into(),
+            max_retries: Some(3),
+        };
+        let policy = RestartPolicy::try_from(js).unwrap();
+        assert_eq!(policy, RestartPolicy::OnFailure { max_retries: 3 });
+    }
+
+    #[test]
+    fn restart_policy_on_failure_missing_max_retries() {
+        let js = JsRestartPolicy {
+            type_: "on_failure".into(),
+            max_retries: None,
+        };
+        let err = RestartPolicy::try_from(js).unwrap_err();
+        assert!(err.to_string().contains("maxRetries"));
+    }
+
+    #[test]
+    fn restart_policy_unless_stopped() {
+        let js = JsRestartPolicy {
+            type_: "unless_stopped".into(),
+            max_retries: None,
+        };
+        let policy = RestartPolicy::try_from(js).unwrap();
+        assert_eq!(policy, RestartPolicy::UnlessStopped);
+    }
+
+    #[test]
+    fn restart_policy_invalid_type() {
+        let js = JsRestartPolicy {
+            type_: "invalid".into(),
+            max_retries: None,
+        };
+        let err = RestartPolicy::try_from(js).unwrap_err();
+        assert!(err.to_string().contains("invalid"));
+    }
+
+    #[test]
+    fn box_options_from_js_restart_policy() {
+        let js = JsBoxOptions {
+            image: Some("alpine:latest".into()),
+            rootfs_path: None,
+            cpus: None,
+            memory_mib: None,
+            disk_size_gb: None,
+            working_dir: None,
+            env: None,
+            volumes: None,
+            network: None,
+            ports: None,
+            auto_remove: None,
+            detach: None,
+            entrypoint: None,
+            cmd: None,
+            user: None,
+            security: None,
+            health_check: None,
+            restart_policy: Some(JsRestartPolicy {
+                type_: "always".into(),
+                max_retries: None,
+            }),
+            secrets: None,
+        };
+
+        let opts = BoxOptions::try_from(js).unwrap();
+        assert_eq!(opts.advanced.restart_policy, Some(RestartPolicy::Always));
     }
 
     #[test]

--- a/sdks/python/boxlite/__init__.py
+++ b/sdks/python/boxlite/__init__.py
@@ -9,6 +9,7 @@ import warnings
 # Import core Rust API
 try:
     from .boxlite import (
+        AdvancedBoxOptions,
         Box,
         BoxInfo,
         Boxlite,
@@ -27,6 +28,7 @@ try:
         HealthStatus,
         NetworkSpec,
         Options,
+        RestartPolicy,
         RuntimeMetrics,
         Secret,
         SecurityOptions,
@@ -39,6 +41,7 @@ try:
         # Core Rust API
         "Options",
         "BoxOptions",
+        "AdvancedBoxOptions",
         "BoxliteRestOptions",
         "Boxlite",
         "NetworkSpec",
@@ -54,6 +57,7 @@ try:
         "BoxMetrics",
         "CopyOptions",
         "HealthCheckOptions",
+        "RestartPolicy",
         "SecurityOptions",
         "Secret",
         "SnapshotHandle",

--- a/sdks/python/src/advanced_options.rs
+++ b/sdks/python/src/advanced_options.rs
@@ -1,4 +1,6 @@
-use boxlite::runtime::advanced_options::{HealthCheckOptions, ResourceLimits, SecurityOptions};
+use boxlite::runtime::advanced_options::{
+    HealthCheckOptions, ResourceLimits, RestartPolicy, SecurityOptions,
+};
 use pyo3::prelude::*;
 
 // ============================================================================
@@ -250,6 +252,97 @@ impl From<PySecurityOptions> for SecurityOptions {
 }
 
 // ============================================================================
+// Restart Policy
+// ============================================================================
+
+/// Restart policy for automatic restart on crash.
+///
+/// Similar to Docker's restart policy. Controls what happens when a box's
+/// shim process crashes.
+///
+/// # Variants
+/// - `RestartPolicy.no()` - Never restart (default)
+/// - `RestartPolicy.always()` - Always restart regardless of exit status
+/// - `RestartPolicy.on_failure(max_retries)` - Restart only on non-zero exit code
+/// - `RestartPolicy.unless_stopped()` - Always restart unless user explicitly called stop()
+///
+/// # Example
+///     ```python
+///     from boxlite import RestartPolicy, AdvancedBoxOptions
+///
+///     # Always restart
+///     policy = RestartPolicy.always()
+///
+///     # Restart on failure, max 3 retries
+///     policy = RestartPolicy.on_failure(max_retries=3)
+///
+///     opts = AdvancedBoxOptions(restart_policy=policy)
+///     ```
+#[pyclass(name = "RestartPolicy")]
+#[derive(Clone, Debug)]
+pub struct PyRestartPolicy {
+    inner: RestartPolicy,
+}
+
+#[pymethods]
+impl PyRestartPolicy {
+    /// Never restart (default).
+    #[staticmethod]
+    fn no() -> Self {
+        Self {
+            inner: RestartPolicy::No,
+        }
+    }
+
+    /// Always restart regardless of exit status.
+    /// Unlimited retries with exponential backoff.
+    #[staticmethod]
+    fn always() -> Self {
+        Self {
+            inner: RestartPolicy::Always,
+        }
+    }
+
+    /// Restart only on non-zero exit code.
+    ///
+    /// Args:
+    ///     max_retries: Maximum consecutive restart attempts before giving up
+    #[staticmethod]
+    #[pyo3(signature = (max_retries))]
+    fn on_failure(max_retries: u32) -> Self {
+        Self {
+            inner: RestartPolicy::OnFailure { max_retries },
+        }
+    }
+
+    /// Always restart unless user explicitly called stop().
+    /// Unlimited retries.
+    #[staticmethod]
+    fn unless_stopped() -> Self {
+        Self {
+            inner: RestartPolicy::UnlessStopped,
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        match &self.inner {
+            RestartPolicy::No => "RestartPolicy.no()".to_string(),
+            RestartPolicy::Always => "RestartPolicy.always()".to_string(),
+            RestartPolicy::OnFailure { max_retries } => {
+                format!("RestartPolicy.on_failure(max_retries={})", max_retries)
+            }
+            RestartPolicy::UnlessStopped => "RestartPolicy.unless_stopped()".to_string(),
+        }
+    }
+}
+
+impl From<PyRestartPolicy> for RestartPolicy {
+    fn from(py_policy: PyRestartPolicy) -> Self {
+        py_policy.inner
+    }
+}
+
+// ============================================================================
 // Advanced Options
 // ============================================================================
 
@@ -266,19 +359,25 @@ pub struct PyAdvancedBoxOptions {
     /// Health check options.
     #[pyo3(get, set)]
     pub health_check: Option<PyHealthCheckOptions>,
+
+    /// Restart policy for automatic restart on crash.
+    #[pyo3(get, set)]
+    pub restart_policy: Option<PyRestartPolicy>,
 }
 
 #[pymethods]
 impl PyAdvancedBoxOptions {
     #[new]
-    #[pyo3(signature = (security=None, health_check=None))]
+    #[pyo3(signature = (security=None, health_check=None, restart_policy=None))]
     fn new(
         security: Option<PySecurityOptions>,
         health_check: Option<PyHealthCheckOptions>,
+        restart_policy: Option<PyRestartPolicy>,
     ) -> Self {
         Self {
             security,
             health_check,
+            restart_policy,
         }
     }
 }

--- a/sdks/python/src/info.rs
+++ b/sdks/python/src/info.rs
@@ -128,6 +128,8 @@ fn status_to_string(status: BoxStatus) -> String {
         BoxStatus::Running => "running",
         BoxStatus::Stopping => "stopping",
         BoxStatus::Stopped => "stopped",
+        BoxStatus::Crashed => "crashed",
+        BoxStatus::Restarting => "restarting",
         BoxStatus::Paused => "paused",
     }
     .to_string()

--- a/sdks/python/src/lib.rs
+++ b/sdks/python/src/lib.rs
@@ -11,7 +11,9 @@ mod snapshot_options;
 mod snapshots;
 mod util;
 
-use crate::advanced_options::{PyAdvancedBoxOptions, PyHealthCheckOptions, PySecurityOptions};
+use crate::advanced_options::{
+    PyAdvancedBoxOptions, PyHealthCheckOptions, PyRestartPolicy, PySecurityOptions,
+};
 use crate::box_handle::PyBox;
 use crate::exec::{PyExecStderr, PyExecStdin, PyExecStdout, PyExecution};
 use crate::info::{PyBoxInfo, PyBoxStateInfo, PyHealthState, PyHealthStatus};
@@ -31,6 +33,7 @@ fn boxlite_python(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyNetworkSpec>()?;
     m.add_class::<PySecurityOptions>()?;
     m.add_class::<PyHealthCheckOptions>()?;
+    m.add_class::<PyRestartPolicy>()?;
     m.add_class::<PyAdvancedBoxOptions>()?;
     m.add_class::<PyBoxlite>()?;
     m.add_class::<PyBox>()?;

--- a/sdks/python/src/options.rs
+++ b/sdks/python/src/options.rs
@@ -408,6 +408,9 @@ impl TryFrom<PyBoxOptions> for BoxOptions {
             if let Some(health_check) = advanced.health_check {
                 opts.advanced.health_check = Some(HealthCheckOptions::from(health_check));
             }
+            if let Some(restart_policy) = advanced.restart_policy {
+                opts.advanced.restart_policy = Some(restart_policy.into());
+            }
         }
 
         // Convert Python secrets to Rust secrets

--- a/sdks/python/src/runtime.rs
+++ b/sdks/python/src/runtime.rs
@@ -19,7 +19,6 @@ impl PyBoxlite {
     #[new]
     fn new(options: PyOptions) -> PyResult<Self> {
         let runtime = BoxliteRuntime::new(options.into()).map_err(map_err)?;
-
         Ok(Self {
             runtime: Arc::new(runtime),
         })

--- a/src/boxlite/Cargo.toml
+++ b/src/boxlite/Cargo.toml
@@ -118,3 +118,4 @@ bincode = "2.0"  # Serialize compiled BPF filters
 [dev-dependencies]
 boxlite-test-utils = { path = "../test-utils" }
 proptest = "1.4"
+rusqlite = { version = "0.37", features = ["bundled"] }

--- a/src/boxlite/src/lib.rs
+++ b/src/boxlite/src/lib.rs
@@ -46,7 +46,7 @@ pub use litebox::{
 };
 pub use metrics::{BoxMetrics, RuntimeMetrics};
 pub use runtime::advanced_options::{
-    AdvancedBoxOptions, HealthCheckOptions, ResourceLimits, SecurityOptions,
+    AdvancedBoxOptions, HealthCheckOptions, ResourceLimits, RestartPolicy, SecurityOptions,
 };
 use runtime::layout::FilesystemLayout;
 pub use runtime::options::{
@@ -55,6 +55,7 @@ pub use runtime::options::{
 };
 /// Boxlite library version (from CARGO_PKG_VERSION at compile time).
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+pub use litebox::{StopCause, StopInfo};
 pub use runtime::id::{BaseDiskID, BaseDiskIDMint, BoxID, BoxIDMint};
 pub use runtime::types::ContainerID;
 pub use runtime::types::{BoxInfo, BoxState, BoxStateInfo, BoxStatus};

--- a/src/boxlite/src/litebox/box_impl.rs
+++ b/src/boxlite/src/litebox/box_impl.rs
@@ -166,6 +166,19 @@ impl BoxImpl {
         BoxInfo::new(&self.config, &state)
     }
 
+    /// Abort the health check task (if running).
+    ///
+    /// Used by restart() to stop monitoring before creating a fresh BoxImpl.
+    pub(crate) fn abort_health_check(&self) {
+        if let Some(task) = self.health_check_task.write().take() {
+            tracing::debug!(
+                box_id = %self.config.id,
+                "Aborting health check task"
+            );
+            task.abort();
+        }
+    }
+
     // ========================================================================
     // OPERATIONS (require LiveState)
     // ========================================================================
@@ -689,8 +702,8 @@ impl BoxImpl {
         // All operations succeeded - disarm the cleanup guard
         cleanup_guard.disarm();
 
-        // Start health check task if configured
-        if let Some(ref health_config) = self.config.options.advanced.health_check {
+        // Start health check task if configured (auto-enabled when restart_policy is set)
+        if let Some(health_config) = self.config.options.advanced.effective_health_check() {
             // Get guest interface from session
             let guest = live_state.guest_session.guest().await?;
 
@@ -698,7 +711,7 @@ impl BoxImpl {
             let health_task = self.spawn_health_check(
                 Arc::clone(&self.state),
                 self.config.id.clone(),
-                health_config.to_owned(),
+                health_config,
                 guest,
                 self.shutdown_token.child_token(),
                 Arc::clone(&self.runtime),
@@ -724,6 +737,7 @@ impl BoxImpl {
         shutdown_token: CancellationToken,
         runtime: SharedRuntimeImpl,
     ) -> JoinHandle<()> {
+        let crash_tx = runtime.crash_sender();
         let interval = health_config.interval;
         let check_timeout = health_config.timeout;
         let retries = health_config.retries;
@@ -828,20 +842,44 @@ impl BoxImpl {
                         false
                     };
 
-                    // If shim died, mark as Unhealthy and stop health check immediately
+                    // If shim died, notify Crash Handler and exit.
+                    // State mutation (exit info, Crashed status, persistence) is the
+                    // Crash Handler's responsibility — Health Check only detects and reports.
                     if shim_died {
-                        let mut state_guard = state.write();
-                        state_guard.force_status(crate::litebox::BoxStatus::Stopped);
-                        state_guard.set_pid(None);
-                        state_guard.health_status.state = crate::litebox::HealthState::Unhealthy;
+                        tracing::info!(
+                            box_id = %box_id,
+                            "Shim process died, notifying crash handler"
+                        );
 
-                        if let Err(db_err) = runtime.box_manager.save_box(&box_id, &state_guard) {
-                            tracing::error!(
-                                box_id = %box_id,
-                                error = %db_err,
-                                "Failed to persist health check state to database"
-                            );
+                        // Send crash notification to Crash Handler with timeout
+                        // Channel has capacity 100; if full, wait briefly then give up
+                        match tokio::time::timeout(
+                            Duration::from_millis(100),
+                            crash_tx.send(box_id.clone()),
+                        )
+                        .await
+                        {
+                            Ok(Ok(())) => {
+                                tracing::debug!(box_id = %box_id, "Crash notification sent to handler");
+                            }
+                            Ok(Err(e)) => {
+                                // Channel closed (receiver dropped)
+                                tracing::error!(
+                                    box_id = %box_id,
+                                    error = %e,
+                                    "Crash handler channel closed, notification dropped"
+                                );
+                            }
+                            Err(_) => {
+                                // Timeout - channel full for too long
+                                tracing::error!(
+                                    box_id = %box_id,
+                                    "Timeout sending crash notification (channel full), notification dropped"
+                                );
+                            }
                         }
+
+                        // Exit immediately after attempting notification
                         break;
                     }
 
@@ -860,7 +898,7 @@ impl BoxImpl {
                         let mut state_guard = state.write();
                         let became_unhealthy = state_guard.mark_health_check_failure(retries);
 
-                        if let Err(db_err) = runtime.box_manager.save_box(&box_id, &state.read()) {
+                        if let Err(db_err) = runtime.box_manager.save_box(&box_id, &state_guard) {
                             tracing::error!(
                                 box_id = %box_id,
                                 error = %db_err,

--- a/src/boxlite/src/litebox/init/mod.rs
+++ b/src/boxlite/src/litebox/init/mod.rs
@@ -73,7 +73,7 @@ fn get_execution_plan(status: BoxStatus) -> ExecutionPlan<InitCtx> {
             Stage::sequential(vec![Box::new(GuestConnectTask)]),
             Stage::sequential(vec![Box::new(GuestInitTask)]),
         ],
-        BoxStatus::Stopped => vec![
+        BoxStatus::Stopped | BoxStatus::Restarting => vec![
             // Restart: Same flow but rootfs tasks reuse existing COW disks
             // (preserves user modifications from previous run)
             Stage::sequential(vec![Box::new(FilesystemTask)]),
@@ -186,7 +186,7 @@ impl BoxBuilder {
         } = self;
 
         let status = state.status;
-        let reuse_rootfs = status == BoxStatus::Stopped;
+        let reuse_rootfs = matches!(status, BoxStatus::Stopped | BoxStatus::Restarting);
         let skip_guest_wait = status == BoxStatus::Running;
 
         let ctx = InitPipelineContext::new(config, runtime.clone(), reuse_rootfs, skip_guest_wait);

--- a/src/boxlite/src/litebox/mod.rs
+++ b/src/boxlite/src/litebox/mod.rs
@@ -21,7 +21,7 @@ pub(crate) use crash_report::CrashReport;
 pub use exec::{BoxCommand, ExecResult, ExecStderr, ExecStdin, ExecStdout, Execution, ExecutionId};
 pub(crate) use manager::BoxManager;
 pub use snapshot::SnapshotHandle;
-pub use state::{BoxState, BoxStatus, HealthState, HealthStatus};
+pub use state::{BoxState, BoxStatus, HealthState, HealthStatus, StopCause, StopInfo};
 
 pub(crate) use box_impl::SharedBoxImpl;
 pub(crate) use init::BoxBuilder;

--- a/src/boxlite/src/litebox/state.rs
+++ b/src/boxlite/src/litebox/state.rs
@@ -20,6 +20,7 @@ use serde::{Deserialize, Serialize};
 /// SIGSTOP   → Paused (VM frozen, used during export/snapshot)
 /// SIGCONT   → Running (VM resumed)
 /// stop()    → Stopped (VM terminated, can restart)
+/// crash     → Crashed (health check detected shim death)
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -40,6 +41,14 @@ pub enum BoxStatus {
     /// Box is not running. VM process terminated.
     /// Rootfs is preserved, box can be restarted.
     Stopped,
+
+    /// Box crashed (health check detected shim process death).
+    /// Evaluates restart policy to decide next action.
+    Crashed,
+
+    /// Box is in the process of being restarted after a crash.
+    /// Transient state during backoff wait before new VM start.
+    Restarting,
 
     /// Box VM is frozen via SIGSTOP (all vCPUs and virtio backends paused).
     /// Used during export/snapshot for point-in-time consistency.
@@ -71,27 +80,41 @@ impl BoxStatus {
 
     /// Check if this status represents a transient state.
     pub fn is_transient(&self) -> bool {
-        matches!(self, BoxStatus::Stopping)
+        matches!(self, BoxStatus::Stopping | BoxStatus::Restarting)
+    }
+
+    /// Check if this status requires health check monitoring.
+    /// Only Running boxes have an active VM process that needs monitoring.
+    /// Restarting is a transient state with no VM yet - monitoring starts after transition to Running.
+    pub fn requires_monitoring(&self) -> bool {
+        matches!(self, BoxStatus::Running)
     }
 
     /// Check if start() can be called from this state.
-    /// Configured boxes need first start, Stopped boxes can restart.
+    /// Configured boxes need first start, Stopped boxes can restart,
+    /// and Restarting resumes the crash-recovery restart pipeline.
     pub fn can_start(&self) -> bool {
-        matches!(self, BoxStatus::Configured | BoxStatus::Stopped)
+        matches!(
+            self,
+            BoxStatus::Configured | BoxStatus::Stopped | BoxStatus::Restarting
+        )
     }
 
     /// Check if stop() can be called from this state.
-    /// Running and Paused boxes can be stopped.
+    /// Running, Restarting, and Paused boxes can be stopped.
     pub fn can_stop(&self) -> bool {
-        matches!(self, BoxStatus::Running | BoxStatus::Paused)
+        matches!(
+            self,
+            BoxStatus::Running | BoxStatus::Restarting | BoxStatus::Paused
+        )
     }
 
     /// Check if remove() can be called from this state.
-    /// Configured, Stopped, and Unknown boxes can be removed.
+    /// Configured, Stopped, Crashed, and Unknown boxes can be removed.
     pub fn can_remove(&self) -> bool {
         matches!(
             self,
-            BoxStatus::Configured | BoxStatus::Stopped | BoxStatus::Unknown
+            BoxStatus::Configured | BoxStatus::Stopped | BoxStatus::Crashed | BoxStatus::Unknown
         )
     }
 
@@ -115,9 +138,10 @@ impl BoxStatus {
             (Configured, Running) |
             (Configured, Stopped) |
             (Configured, Unknown) |
-            // Running → Stopping (graceful), Stopped (crash), or Paused (SIGSTOP)
+            // Running → Stopping (graceful), Crashed (shim died), Paused (SIGSTOP), or Stopped
             (Running, Stopping) |
             (Running, Stopped) |
+            (Running, Crashed) |
             (Running, Paused) |
             (Running, Unknown) |
             // Stopping → Stopped (complete) or Unknown (error)
@@ -126,6 +150,14 @@ impl BoxStatus {
             // Stopped → Running (restart)
             (Stopped, Running) |
             (Stopped, Unknown) |
+            // Crashed → Stopped (no policy) or Restarting (has policy)
+            (Crashed, Stopped) |
+            (Crashed, Restarting) |
+            (Crashed, Unknown) |
+            // Restarting → Running (success), Stopped (cancelled/max retries)
+            (Restarting, Running) |
+            (Restarting, Stopped) |
+            (Restarting, Unknown) |
             // Paused → Running (SIGCONT resume) or Stopped (killed while paused)
             (Paused, Running) |
             (Paused, Stopped) |
@@ -141,6 +173,8 @@ impl BoxStatus {
             BoxStatus::Running => "running",
             BoxStatus::Stopping => "stopping",
             BoxStatus::Stopped => "stopped",
+            BoxStatus::Crashed => "crashed",
+            BoxStatus::Restarting => "restarting",
             BoxStatus::Paused => "paused",
         }
     }
@@ -158,6 +192,8 @@ impl std::str::FromStr for BoxStatus {
             "running" => Ok(BoxStatus::Running),
             "stopping" => Ok(BoxStatus::Stopping),
             "stopped" => Ok(BoxStatus::Stopped),
+            "crashed" => Ok(BoxStatus::Crashed),
+            "restarting" => Ok(BoxStatus::Restarting),
             "paused" => Ok(BoxStatus::Paused),
             // Legacy: old transient statuses map to Stopped (DB backward compat)
             "snapshotting" | "restoring" | "exporting" | "cloning" => Ok(BoxStatus::Stopped),
@@ -192,6 +228,48 @@ pub struct BoxState {
     /// Health status.
     #[serde(default)]
     pub health_status: HealthStatus,
+    /// Stop info (valid when status is Stopped/Crashed/Restarting).
+    #[serde(default)]
+    pub stop_info: StopInfo,
+    /// Error message from the last failed auto-restart attempt (cleared on success).
+    #[serde(default)]
+    pub last_restart_error: Option<String>,
+}
+
+/// Why the box stopped.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StopCause {
+    /// User called stop() or normal exit.
+    #[default]
+    Normal,
+    /// Crashed but no restart policy configured.
+    CrashedNoPolicy,
+    /// Restart policy exhausted max attempts.
+    MaxRetriesExceeded,
+    /// System reboot detected.
+    SystemReboot,
+    /// Restart attempt failed (e.g., VM failed to start).
+    RestartFailed,
+    /// Unknown/unexpected stop cause (should not happen in normal operation).
+    Unknown,
+}
+
+/// Stop info for a stopped box (valid when status is Stopped/Crashed).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct StopInfo {
+    /// Why the box stopped.
+    #[serde(default)]
+    pub cause: StopCause,
+    /// Exit code from the shim process (if available).
+    pub exit_code: Option<i32>,
+    /// When the box stopped/crashed (UTC).
+    pub exit_time: Option<DateTime<Utc>>,
+    /// How many restart attempts in the last sequence.
+    #[serde(default)]
+    pub restart_count: u32,
+    /// When the last successful restart happened (UTC).
+    pub restarted_at: Option<DateTime<Utc>>,
 }
 
 /// Health status of a box.
@@ -289,6 +367,8 @@ impl BoxState {
             last_updated: Utc::now(),
             lock_id: None,
             health_status: HealthStatus::new(),
+            stop_info: StopInfo::default(),
+            last_restart_error: None,
         }
     }
 
@@ -339,6 +419,8 @@ impl BoxState {
     pub fn mark_stop(&mut self) {
         self.status = BoxStatus::Stopped;
         self.pid = None;
+        self.stop_info.cause = StopCause::Normal;
+        self.stop_info.exit_time = Some(Utc::now());
         self.last_updated = Utc::now();
     }
 
@@ -349,6 +431,8 @@ impl BoxState {
     pub fn reset_for_reboot(&mut self) {
         if self.status.is_active() {
             self.status = BoxStatus::Stopped;
+            self.stop_info.cause = StopCause::SystemReboot;
+            self.stop_info.exit_time = Some(Utc::now());
         }
         self.pid = None;
         self.last_updated = Utc::now();
@@ -421,6 +505,7 @@ mod tests {
         assert!(!BoxStatus::Running.can_start());
         assert!(!BoxStatus::Stopping.can_start());
         assert!(BoxStatus::Stopped.can_start());
+        assert!(BoxStatus::Restarting.can_start());
         assert!(!BoxStatus::Paused.can_start());
         assert!(!BoxStatus::Unknown.can_start());
     }
@@ -862,5 +947,38 @@ mod tests {
         assert_eq!(state.health_status.state, HealthState::None);
         assert_eq!(state.health_status.failures, 0);
         assert!(state.health_status.last_check.is_none());
+    }
+
+    // ====================================================================
+    // requires_monitoring tests
+    // ====================================================================
+
+    #[test]
+    fn test_requires_monitoring_only_running() {
+        // Only Running status requires monitoring
+        assert!(!BoxStatus::Unknown.requires_monitoring());
+        assert!(!BoxStatus::Configured.requires_monitoring());
+        assert!(BoxStatus::Running.requires_monitoring());
+        assert!(!BoxStatus::Stopping.requires_monitoring());
+        assert!(!BoxStatus::Stopped.requires_monitoring());
+        assert!(!BoxStatus::Crashed.requires_monitoring());
+        assert!(!BoxStatus::Restarting.requires_monitoring()); // Transient, no VM yet
+        assert!(!BoxStatus::Paused.requires_monitoring());
+    }
+
+    // ====================================================================
+    // can_start tests (includes restart from Stopped/Restarting)
+    // ====================================================================
+
+    #[test]
+    fn test_can_start_from_stopped_or_crashed() {
+        assert!(!BoxStatus::Unknown.can_start());
+        assert!(BoxStatus::Configured.can_start()); // First start
+        assert!(!BoxStatus::Running.can_start());
+        assert!(!BoxStatus::Stopping.can_start());
+        assert!(BoxStatus::Stopped.can_start()); // Restart
+        assert!(!BoxStatus::Crashed.can_start()); // Must transition to Stopped first
+        assert!(BoxStatus::Restarting.can_start()); // Crash recovery restart
+        assert!(!BoxStatus::Paused.can_start());
     }
 }

--- a/src/boxlite/src/rest/types.rs
+++ b/src/boxlite/src/rest/types.rs
@@ -235,6 +235,8 @@ impl BoxResponse {
             memory_mib: self.memory_mib,
             labels: self.labels.clone(),
             health_status: crate::litebox::HealthStatus::new(), // REST API doesn't provide health status
+            stop_info: crate::litebox::StopInfo::default(), // REST API doesn't provide stop info
+            last_restart_error: None, // REST API doesn't provide restart error
         }
     }
 }

--- a/src/boxlite/src/runtime/advanced_options.rs
+++ b/src/boxlite/src/runtime/advanced_options.rs
@@ -601,4 +601,281 @@ pub struct AdvancedBoxOptions {
     /// Most users should rely on the defaults.
     #[serde(default)]
     pub health_check: Option<HealthCheckOptions>,
+
+    /// Restart policy for automatic restart on crash.
+    ///
+    /// When set, the health check task will evaluate the policy when the
+    /// shim process dies and automatically restart the box if the policy allows it.
+    ///
+    /// If `health_check` is not configured but `restart_policy` is, a default
+    /// health check is auto-enabled (interval=5s, timeout=10s, retries=3, start_period=60s).
+    #[serde(default)]
+    pub restart_policy: Option<RestartPolicy>,
+}
+
+/// Restart policy for automatic restart on crash.
+///
+/// Similar to Docker's restart policy. Controls what happens when a box's
+/// shim process crashes.
+///
+/// # Example
+///
+/// ```
+/// use boxlite::runtime::advanced_options::{AdvancedBoxOptions, RestartPolicy};
+///
+/// let opts = AdvancedBoxOptions {
+///     restart_policy: Some(RestartPolicy::Always),
+///     ..Default::default()
+/// };
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum RestartPolicy {
+    /// Never restart (default).
+    No,
+    /// Always restart regardless of exit status. Unlimited retries with exponential backoff.
+    Always,
+    /// Restart only on non-zero exit code, limited to max_retries consecutive failures.
+    OnFailure {
+        /// Maximum consecutive restart attempts before giving up.
+        max_retries: u32,
+    },
+    /// Always restart unless user explicitly called stop(). Unlimited retries.
+    UnlessStopped,
+}
+
+impl RestartPolicy {
+    /// Evaluate whether a restart should happen based on exit code and restart count.
+    ///
+    /// # Arguments
+    /// * `exit_code` - Exit code from the shim process (None = signal/unknown)
+    /// * `restart_count` - Current consecutive restart attempt count
+    ///
+    /// # Returns
+    /// `true` if the box should be restarted
+    ///
+    /// # Warning
+    /// `Always` and `UnlessStopped` restart regardless of exit code. If the shim
+    /// exits cleanly (exit_code == 0) repeatedly, this results in an infinite
+    /// restart loop. Use `UnlessStopped` when you want a user-initiated `stop()`
+    /// to break the loop (the only way to stop an `Always` loop is to remove the box).
+    pub fn should_restart(&self, exit_code: Option<i32>, restart_count: u32) -> bool {
+        match self {
+            RestartPolicy::No => false,
+            RestartPolicy::Always => true,
+            RestartPolicy::OnFailure { max_retries } => {
+                // Only restart on non-zero exit code (explicit failure)
+                // None (no exit file) means normal/clean exit - no restart
+                let is_failure = exit_code.is_some_and(|code| code != 0);
+                is_failure && restart_count < *max_retries
+            }
+            RestartPolicy::UnlessStopped => true,
+        }
+    }
+
+    /// Check if this policy has unlimited retries.
+    pub fn is_unlimited_retries(&self) -> bool {
+        matches!(self, RestartPolicy::Always | RestartPolicy::UnlessStopped)
+    }
+
+    /// Default health check config to use when restart_policy is set but health_check is not.
+    pub fn default_health_check() -> HealthCheckOptions {
+        HealthCheckOptions {
+            interval: Duration::from_secs(5),
+            timeout: Duration::from_secs(10),
+            retries: 3,
+            start_period: Duration::from_secs(60),
+        }
+    }
+}
+
+impl AdvancedBoxOptions {
+    /// Get the effective health check config.
+    ///
+    /// Returns user-configured health check if set, or auto-enables default
+    /// health check when restart_policy is configured without one.
+    pub fn effective_health_check(&self) -> Option<HealthCheckOptions> {
+        if let Some(ref hc) = self.health_check {
+            Some(hc.clone())
+        } else if self.restart_policy.is_some() {
+            Some(RestartPolicy::default_health_check())
+        } else {
+            None
+        }
+    }
+}
+
+/// Calculate exponential backoff delay for restart attempts.
+///
+/// Base: 100ms, doubles each attempt, capped at 30s.
+/// Sequence: 100ms, 200ms, 400ms, 800ms, 1.6s, 3.2s, 6.4s, 12.8s, 25.6s, 30s (capped)
+pub fn calculate_backoff(restart_count: u32) -> Duration {
+    let base_ms: u64 = 100;
+    let max_ms: u64 = 30_000;
+    let exp = 1u64.checked_shl(restart_count.min(18)).unwrap_or(u64::MAX); // Cap shift to avoid overflow
+    Duration::from_millis(base_ms.saturating_mul(exp).min(max_ms))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ====================================================================
+    // RestartPolicy::should_restart tests
+    // ====================================================================
+
+    #[test]
+    fn test_restart_policy_no_never_restarts() {
+        let policy = RestartPolicy::No;
+        assert!(!policy.should_restart(Some(0), 0));
+        assert!(!policy.should_restart(Some(1), 0));
+        assert!(!policy.should_restart(None, 0));
+        assert!(!policy.should_restart(Some(0), 100));
+    }
+
+    #[test]
+    fn test_restart_policy_always_always_restarts() {
+        let policy = RestartPolicy::Always;
+        assert!(policy.should_restart(Some(0), 0));
+        assert!(policy.should_restart(Some(1), 0));
+        assert!(policy.should_restart(None, 0));
+        assert!(policy.should_restart(Some(0), 100)); // Unlimited retries
+    }
+
+    #[test]
+    fn test_restart_policy_unless_stopped_always_restarts() {
+        let policy = RestartPolicy::UnlessStopped;
+        assert!(policy.should_restart(Some(0), 0));
+        assert!(policy.should_restart(Some(1), 0));
+        assert!(policy.should_restart(None, 0));
+        assert!(policy.should_restart(Some(0), 100)); // Unlimited retries
+    }
+
+    #[test]
+    fn test_restart_policy_on_failure_restarts_on_non_zero_exit() {
+        let policy = RestartPolicy::OnFailure { max_retries: 3 };
+        // Non-zero exit code should restart
+        assert!(policy.should_restart(Some(1), 0));
+        assert!(policy.should_restart(Some(127), 1));
+        assert!(policy.should_restart(Some(-1), 2));
+    }
+
+    #[test]
+    fn test_restart_policy_on_failure_no_restart_on_zero_exit() {
+        let policy = RestartPolicy::OnFailure { max_retries: 3 };
+        // Zero exit code should NOT restart
+        assert!(!policy.should_restart(Some(0), 0));
+        assert!(!policy.should_restart(Some(0), 2));
+    }
+
+    #[test]
+    fn test_restart_policy_on_failure_no_restart_on_no_exit_file() {
+        let policy = RestartPolicy::OnFailure { max_retries: 3 };
+        // No exit file (None) means clean/normal exit - no restart
+        assert!(!policy.should_restart(None, 0));
+        assert!(!policy.should_restart(None, 1));
+    }
+
+    #[test]
+    fn test_restart_policy_on_failure_respects_max_retries() {
+        let policy = RestartPolicy::OnFailure { max_retries: 3 };
+        // Should restart when under max_retries
+        assert!(policy.should_restart(Some(1), 0));
+        assert!(policy.should_restart(Some(1), 1));
+        assert!(policy.should_restart(Some(1), 2));
+        // Should NOT restart when at max_retries
+        assert!(!policy.should_restart(Some(1), 3));
+        assert!(!policy.should_restart(Some(1), 4));
+    }
+
+    #[test]
+    fn test_restart_policy_on_failure_zero_max_retries() {
+        let policy = RestartPolicy::OnFailure { max_retries: 0 };
+        // With max_retries=0, should never restart
+        assert!(!policy.should_restart(Some(1), 0));
+        assert!(!policy.should_restart(None, 0));
+    }
+
+    // ====================================================================
+    // RestartPolicy::is_unlimited_retries tests
+    // ====================================================================
+
+    #[test]
+    fn test_is_unlimited_retries() {
+        assert!(!RestartPolicy::No.is_unlimited_retries());
+        assert!(RestartPolicy::Always.is_unlimited_retries());
+        assert!(RestartPolicy::UnlessStopped.is_unlimited_retries());
+        assert!(!RestartPolicy::OnFailure { max_retries: 3 }.is_unlimited_retries());
+    }
+
+    // ====================================================================
+    // calculate_backoff tests
+    // ====================================================================
+
+    #[test]
+    fn test_calculate_backoff_sequence() {
+        assert_eq!(calculate_backoff(0), Duration::from_millis(100));
+        assert_eq!(calculate_backoff(1), Duration::from_millis(200));
+        assert_eq!(calculate_backoff(2), Duration::from_millis(400));
+        assert_eq!(calculate_backoff(3), Duration::from_millis(800));
+        assert_eq!(calculate_backoff(4), Duration::from_millis(1600));
+        assert_eq!(calculate_backoff(5), Duration::from_millis(3200));
+        assert_eq!(calculate_backoff(6), Duration::from_millis(6400));
+        assert_eq!(calculate_backoff(7), Duration::from_millis(12800));
+        assert_eq!(calculate_backoff(8), Duration::from_millis(25600));
+    }
+
+    #[test]
+    fn test_calculate_backoff_capped_at_30s() {
+        // After 30s cap is reached
+        assert_eq!(calculate_backoff(9), Duration::from_millis(30000));
+        assert_eq!(calculate_backoff(10), Duration::from_millis(30000));
+        assert_eq!(calculate_backoff(100), Duration::from_millis(30000));
+    }
+
+    // ====================================================================
+    // AdvancedBoxOptions::effective_health_check tests
+    // ====================================================================
+
+    #[test]
+    fn test_effective_health_check_user_config() {
+        let user_config = HealthCheckOptions {
+            interval: Duration::from_secs(10),
+            timeout: Duration::from_secs(5),
+            retries: 5,
+            start_period: Duration::from_secs(30),
+        };
+        let opts = AdvancedBoxOptions {
+            health_check: Some(user_config.clone()),
+            restart_policy: Some(RestartPolicy::Always),
+            ..Default::default()
+        };
+        let effective = opts.effective_health_check().unwrap();
+        assert_eq!(effective.interval, Duration::from_secs(10));
+        assert_eq!(effective.retries, 5);
+    }
+
+    #[test]
+    fn test_effective_health_check_auto_enabled_for_restart_policy() {
+        let opts = AdvancedBoxOptions {
+            health_check: None,
+            restart_policy: Some(RestartPolicy::Always),
+            ..Default::default()
+        };
+        let effective = opts.effective_health_check().unwrap();
+        assert_eq!(effective.interval, Duration::from_secs(5));
+        assert_eq!(effective.timeout, Duration::from_secs(10));
+        assert_eq!(effective.retries, 3);
+        assert_eq!(effective.start_period, Duration::from_secs(60));
+    }
+
+    #[test]
+    fn test_effective_health_check_none_when_no_policy() {
+        let opts = AdvancedBoxOptions {
+            health_check: None,
+            restart_policy: None,
+            ..Default::default()
+        };
+        assert!(opts.effective_health_check().is_none());
+    }
 }

--- a/src/boxlite/src/runtime/layout.rs
+++ b/src/boxlite/src/runtime/layout.rs
@@ -41,6 +41,9 @@ pub mod dirs {
 
     /// Subdirectory for per-entity locks
     pub const LOCKS_DIR: &str = "locks";
+
+    /// Exit info file written by shim on crash (contains exit code, signal, etc.)
+    pub const EXIT_FILE: &str = "exit";
 }
 
 /// Configuration for filesystem layout behavior.
@@ -504,10 +507,9 @@ impl BoxFilesystemLayout {
     /// Exit file path: ~/.boxlite/boxes/{box_id}/exit
     ///
     /// Written by the shim process on exit (normal or panic).
-    /// Format: First line is exit code, subsequent lines contain error details.
-    /// Follows Podman's conmon pattern for capturing exit information.
+    /// Format: JSON with exit_code, type, and optional message/signal.
     pub fn exit_file_path(&self) -> PathBuf {
-        self.box_dir.join("exit")
+        self.box_dir.join(dirs::EXIT_FILE)
     }
 
     /// Stderr file path: ~/.boxlite/boxes/{box_id}/shim.stderr

--- a/src/boxlite/src/runtime/rt_impl.rs
+++ b/src/boxlite/src/runtime/rt_impl.rs
@@ -2,23 +2,27 @@ use crate::db::{BoxStore, Database};
 use crate::images::{ImageDiskManager, ImageManager};
 use crate::init_logging_for;
 use crate::litebox::config::BoxConfig;
-use crate::litebox::{BoxManager, LiteBox, LocalSnapshotBackend, SharedBoxImpl};
+use crate::litebox::{BoxManager, LiteBox, LocalSnapshotBackend, SharedBoxImpl, StopCause};
 use crate::lock::{FileLockManager, LockManager};
 use crate::metrics::{RuntimeMetrics, RuntimeMetricsStorage};
 use crate::rootfs::guest::{GuestRootfs, GuestRootfsManager};
+use crate::runtime::advanced_options::{RestartPolicy, calculate_backoff};
 use crate::runtime::constants::filenames;
 use crate::runtime::id::{BoxID, BoxIDMint};
+use crate::runtime::layout::dirs::EXIT_FILE;
 use crate::runtime::layout::{FilesystemLayout, FsLayoutConfig};
 use crate::runtime::lock::RuntimeLock;
 use crate::runtime::options::{BoxArchive, BoxOptions, BoxliteOptions};
 use crate::runtime::signal_handler::timeout_to_duration;
 use crate::runtime::types::{BoxInfo, BoxState, BoxStatus, ContainerID};
-use crate::vmm::VmmKind;
+use crate::vmm::{ExitInfo, VmmKind};
 use boxlite_shared::{BoxliteError, BoxliteResult, Transport};
 use chrono::Utc;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
 use std::sync::{Arc, RwLock, Weak};
-use tokio::sync::OnceCell;
+use tokio::sync::{OnceCell, mpsc};
+use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
 fn litebox_from_impl(box_impl: SharedBoxImpl) -> LiteBox {
@@ -26,6 +30,49 @@ fn litebox_from_impl(box_impl: SharedBoxImpl) -> LiteBox {
     let snapshot_backend: Arc<dyn crate::runtime::backend::SnapshotBackend> =
         Arc::new(LocalSnapshotBackend::new(box_impl));
     LiteBox::new(box_backend, snapshot_backend)
+}
+
+fn read_box_exit_code(box_home: &Path) -> Option<i32> {
+    let exit_file = box_home.join(EXIT_FILE);
+    ExitInfo::from_file(&exit_file).map(|info| info.exit_code())
+}
+
+fn stop_cause_when_restart_denied(
+    restart_policy: Option<&RestartPolicy>,
+    exit_code: Option<i32>,
+    max_retries_exhausted: bool,
+) -> StopCause {
+    match restart_policy {
+        None | Some(RestartPolicy::No) => StopCause::CrashedNoPolicy,
+        Some(RestartPolicy::OnFailure { .. }) if exit_code == Some(0) => StopCause::Normal,
+        Some(RestartPolicy::OnFailure { .. }) if max_retries_exhausted => {
+            StopCause::MaxRetriesExceeded
+        }
+        Some(RestartPolicy::OnFailure { .. }) => {
+            // This branch should be unreachable:
+            // - exit_code != 0 (caught by guard above)
+            // - !max_retries_exhausted (caught by guard above)
+            // For OnFailure, non-zero exit + under max_retries should restart, not deny.
+            tracing::error!(
+                exit_code = ?exit_code,
+                max_retries_exhausted,
+                "BUG: Unreachable branch reached in stop_cause_when_restart_denied"
+            );
+            debug_assert!(false, "Unreachable branch reached");
+            StopCause::Unknown
+        }
+        Some(RestartPolicy::Always) => {
+            // Always policy should never deny restart - this is a bug
+            tracing::error!("BUG: Always policy should not reach stop_cause_when_restart_denied");
+            debug_assert!(false, "Always policy should never deny restart");
+            StopCause::Unknown
+        }
+        Some(RestartPolicy::UnlessStopped) => {
+            // UnlessStopped only denies restart when user explicitly stopped (cause == Normal)
+            // At this point, exit_code == 0 indicates a clean exit from user stop
+            StopCause::Normal
+        }
+    }
 }
 
 /// Internal runtime state protected by single lock.
@@ -93,6 +140,38 @@ pub struct RuntimeImpl {
     /// Use `.is_cancelled()` for sync checks, `.cancelled()` for async select!.
     /// Child tokens are passed to each box via `.child_token()`.
     pub(crate) shutdown_token: CancellationToken,
+
+    // ========================================================================
+    // CRASH HANDLER
+    // ========================================================================
+    /// Channel sender for box crash notifications.
+    /// Used by health check tasks to notify runtime of crashes.
+    crash_tx: mpsc::Sender<BoxID>,
+
+    /// Handle to the crash handler task (for graceful shutdown).
+    crash_handler_handle: RwLock<Option<JoinHandle<()>>>,
+
+    /// Tracks in-flight crash handling per box.
+    /// Prevents duplicate concurrent handling of the same box crash.
+    /// Entry is inserted before spawning a per-crash task and removed
+    /// when the task completes (via RAII guard).
+    pending_crashes: RwLock<HashSet<BoxID>>,
+
+    /// JoinHandles for in-flight per-crash tasks spawned by the crash handler.
+    /// Tracked so shutdown can await them instead of leaving fire-and-forget tasks
+    /// that hold Arc<RuntimeImpl> and delay drop.
+    crash_task_handles: RwLock<Vec<JoinHandle<()>>>,
+
+    /// Pending crash notification receiver, consumed once by `ensure_services_started`.
+    pending_crash_rx: std::sync::Mutex<Option<mpsc::Receiver<BoxID>>>,
+
+    /// Boxes queued for auto-restart during recovery, consumed once by
+    /// `ensure_services_started`.
+    recovery_queue: std::sync::Mutex<Vec<(BoxID, BoxState)>>,
+
+    /// One-time gate for background services initialization (crash handler,
+    /// recovery auto-restarts). Spawned lazily on first async method call.
+    services_started: tokio::sync::OnceCell<()>,
 }
 
 /// Synchronized state protected by RwLock.
@@ -209,6 +288,9 @@ impl RuntimeImpl {
             ImageDiskManager::new(layout.image_layout().disk_images_dir(), layout.temp_dir());
         let guest_rootfs_mgr = GuestRootfsManager::new(base_disk_mgr.clone(), layout.temp_dir());
 
+        // Create crash notification channel
+        let (crash_tx, crash_rx) = mpsc::channel::<BoxID>(100);
+
         let inner = Arc::new(Self {
             sync_state: RwLock::new(SynchronizedState {
                 active_boxes_by_id: HashMap::new(),
@@ -226,14 +308,483 @@ impl RuntimeImpl {
             lock_manager,
             _runtime_lock: runtime_lock,
             shutdown_token: CancellationToken::new(),
+            crash_tx,
+            crash_handler_handle: RwLock::new(None),
+            pending_crashes: RwLock::new(HashSet::new()),
+            crash_task_handles: RwLock::new(Vec::new()),
+            pending_crash_rx: std::sync::Mutex::new(Some(crash_rx)),
+            recovery_queue: std::sync::Mutex::new(Vec::new()),
+            services_started: tokio::sync::OnceCell::new(),
         });
 
         tracing::debug!("initialized runtime");
 
         // Recover boxes from database
-        inner.recover_boxes()?;
+        let boxes_to_restart = inner.recover_boxes()?;
+
+        // Store recovery queue for lazy initialization by ensure_services_started.
+        // The crash handler and recovery tasks will be spawned on the first async call.
+        if !boxes_to_restart.is_empty() {
+            tracing::info!(
+                count = boxes_to_restart.len(),
+                "Queued boxes for auto-restart (will start on first async operation)"
+            );
+            *inner.recovery_queue.lock().unwrap() = boxes_to_restart;
+        }
 
         Ok(inner)
+    }
+
+    // ========================================================================
+    // CRASH HANDLER
+    // ========================================================================
+
+    /// Spawn the central crash handler task.
+    fn spawn_crash_handler(
+        runtime: SharedRuntimeImpl,
+        mut crash_rx: mpsc::Receiver<BoxID>,
+    ) -> JoinHandle<()> {
+        tokio::spawn(async move {
+            tracing::info!("Crash handler task started");
+
+            loop {
+                tokio::select! {
+                    Some(box_id) = crash_rx.recv() => {
+                        // Check runtime is not shutting down
+                        if runtime.shutdown_token.is_cancelled() {
+                            tracing::debug!("Runtime shutting down, ignoring crash notification");
+                            continue;
+                        }
+
+                        // Deduplication: skip if already handling a crash for this box
+                        if runtime.pending_crashes.read().unwrap().contains(&box_id) {
+                            tracing::debug!(
+                                box_id = %box_id,
+                                "Crash already being handled, skipping duplicate notification"
+                            );
+                            continue;
+                        }
+
+                        tracing::info!(box_id = %box_id, "Received crash notification");
+
+                        // Register in pending_crashes before spawning
+                        runtime.pending_crashes.write().unwrap().insert(box_id.clone());
+
+                        // Spawn task to handle this crash
+                        let rt = Arc::clone(&runtime);
+                        let rt_for_cleanup = Arc::clone(&runtime);
+                        let box_id_for_cleanup = box_id.clone();
+                        let handle = tokio::spawn(async move {
+                            Self::handle_box_crash(rt, box_id).await;
+                            // Always remove from pending_crashes when done
+                            rt_for_cleanup
+                                .pending_crashes
+                                .write()
+                                .unwrap()
+                                .remove(&box_id_for_cleanup);
+                        });
+                        let mut handles = runtime.crash_task_handles.write().unwrap();
+                        handles.retain(|h| !h.is_finished());
+                        handles.push(handle);
+                    }
+                    _ = runtime.shutdown_token.cancelled() => {
+                        tracing::debug!("Crash handler received shutdown signal");
+                        break;
+                    }
+                }
+            }
+
+            tracing::info!("Crash handler task stopped");
+        })
+    }
+
+    /// Handle a single box crash (runs in spawned task).
+    async fn handle_box_crash(this: SharedRuntimeImpl, box_id: BoxID) {
+        use crate::litebox::BoxStatus;
+
+        // ── Phase 1: State mutation (under box lock) ──
+
+        let (config, mut state) = match this.box_manager.box_by_id(&box_id) {
+            Ok(Some((c, s))) => (c, s),
+            Ok(None) => {
+                tracing::debug!(box_id = %box_id, "Box not found, ignoring crash");
+                return;
+            }
+            Err(e) => {
+                tracing::error!(box_id = %box_id, error = %e, "Failed to read box state");
+                return;
+            }
+        };
+
+        // Acquire box lock for state mutation
+        let lock_id = match state.lock_id {
+            Some(id) => id,
+            None => {
+                tracing::warn!(box_id = %box_id, "Box has no lock_id");
+                return;
+            }
+        };
+
+        let locker = match this.lock_manager.retrieve(lock_id) {
+            Ok(l) => l,
+            Err(e) => {
+                tracing::error!(box_id = %box_id, error = %e, "Failed to retrieve lock");
+                return;
+            }
+        };
+
+        let _lock_guard = loop {
+            if let Some(guard) = crate::lock::LockGuard::try_new(&*locker) {
+                break guard;
+            }
+
+            if this.shutdown_token.is_cancelled() {
+                tracing::debug!(box_id = %box_id, "Shutdown while waiting for lock");
+                return;
+            }
+
+            tokio::task::yield_now().await;
+        };
+
+        // State check: only handle crashes for boxes that were running
+        match state.status {
+            BoxStatus::Running | BoxStatus::Crashed => {}
+            BoxStatus::Restarting => {
+                tracing::debug!(box_id = %box_id, "Box already restarting, ignoring");
+                return;
+            }
+            _ => {
+                tracing::debug!(
+                    box_id = %box_id,
+                    status = ?state.status,
+                    "Box not running, ignoring crash"
+                );
+                return;
+            }
+        }
+
+        // Read exit info. No file means normal exit (shim wrote nothing on success).
+        let exit_code = read_box_exit_code(&config.box_home).or(Some(0));
+        let restart_policy = &config.options.advanced.restart_policy;
+        let current_restart_count = state.stop_info.restart_count;
+        let exit_time = Utc::now();
+        let new_restart_count = state.stop_info.restart_count.saturating_add(1);
+        let max_retries_exhausted = matches!(
+            restart_policy.as_ref(),
+            Some(RestartPolicy::OnFailure { max_retries }) if current_restart_count >= *max_retries
+        );
+
+        // Persist the crash before evaluating restart policy so recovery sees
+        // the updated exit metadata and retry count even if this task is interrupted.
+        state.force_status(BoxStatus::Crashed);
+        state.set_pid(None);
+        state.health_status.state = crate::litebox::HealthState::Unhealthy;
+        state.stop_info = crate::litebox::StopInfo {
+            cause: StopCause::CrashedNoPolicy,
+            exit_code,
+            exit_time: Some(exit_time),
+            restart_count: new_restart_count,
+            restarted_at: None,
+        };
+
+        if let Err(e) = this.box_manager.save_box(&box_id, &state) {
+            tracing::error!(box_id = %box_id, error = %e, "Failed to save crashed state");
+        }
+
+        // Evaluate restart policy
+        let should_restart = restart_policy
+            .as_ref()
+            .map(|policy| policy.should_restart(exit_code, current_restart_count))
+            .unwrap_or(false);
+
+        if !should_restart {
+            tracing::info!(
+                box_id = %box_id,
+                policy = ?restart_policy,
+                "No restart policy or max retries exceeded, marking as stopped"
+            );
+
+            state.force_status(BoxStatus::Stopped);
+            state.stop_info.cause = stop_cause_when_restart_denied(
+                restart_policy.as_ref(),
+                exit_code,
+                max_retries_exhausted,
+            );
+
+            if let Err(e) = this.box_manager.save_box(&box_id, &state) {
+                tracing::error!(box_id = %box_id, error = %e, "Failed to save stopped state");
+            }
+            return;
+        }
+
+        // Lock released here (end of _lock_guard scope).
+        // The restart_policy is cloned out so we don't need the lock for the backoff loop.
+
+        // ── Phase 2: Backoff + restart loop (lock acquired per attempt) ──
+
+        let restart_policy = restart_policy.clone();
+
+        tracing::info!(
+            box_id = %box_id,
+            restart_count = new_restart_count,
+            exit_code = ?exit_code,
+            "Box crashed, scheduling restart with backoff"
+        );
+
+        let mut attempt = current_restart_count;
+        loop {
+            let backoff = calculate_backoff(attempt);
+            attempt += 1;
+
+            tracing::info!(
+                box_id = %box_id,
+                attempt,
+                backoff_ms = backoff.as_millis() as u64,
+                "Scheduling restart attempt"
+            );
+
+            tokio::select! {
+                _ = tokio::time::sleep(backoff) => {
+                    // Re-acquire box lock for this restart attempt
+                    let (_, state) = match this.box_manager.box_by_id(&box_id) {
+                        Ok(Some(pair)) => pair,
+                        Ok(None) => {
+                            tracing::debug!(box_id = %box_id, "Box removed during backoff");
+                            return;
+                        }
+                        Err(e) => {
+                            tracing::error!(box_id = %box_id, error = %e, "Failed to read state");
+                            return;
+                        }
+                    };
+
+                    let lock_id = match state.lock_id {
+                        Some(id) => id,
+                        None => {
+                            tracing::warn!(box_id = %box_id, "Box has no lock_id");
+                            return;
+                        }
+                    };
+
+                    let locker = match this.lock_manager.retrieve(lock_id) {
+                        Ok(l) => l,
+                        Err(e) => {
+                            tracing::error!(box_id = %box_id, error = %e, "Failed to retrieve lock");
+                            return;
+                        }
+                    };
+
+                    let _lock_guard = loop {
+                        if let Some(guard) = crate::lock::LockGuard::try_new(locker.as_ref()) {
+                            break guard;
+                        }
+
+                        if this.shutdown_token.is_cancelled() {
+                            tracing::debug!(
+                                box_id = %box_id,
+                                "Shutdown while waiting for lock (restart attempt)"
+                            );
+                            return;
+                        }
+
+                        tokio::task::yield_now().await;
+                    };
+
+                    // Re-read state after acquiring lock: manual restart() may have succeeded
+                    let current_status = match this.box_manager.box_by_id(&box_id) {
+                        Ok(Some((_, s))) => s.status,
+                        Ok(None) => {
+                            tracing::debug!(box_id = %box_id, "Box removed during backoff");
+                            return;
+                        }
+                        Err(e) => {
+                            tracing::error!(box_id = %box_id, error = %e, "Failed to read state");
+                            return;
+                        }
+                    };
+
+                    if current_status == BoxStatus::Running {
+                        tracing::debug!(
+                            box_id = %box_id,
+                            "Box already running (manual restart), skipping auto-restart"
+                        );
+                        return;
+                    }
+
+                    tracing::info!(box_id = %box_id, attempt, "Executing restart");
+
+                    match this.restart(&box_id).await {
+                        Ok(()) => {
+                            tracing::info!(
+                                box_id = %box_id,
+                                attempt,
+                                "Box restarted successfully"
+                            );
+                            break;  // Success
+                        }
+                        Err(e) => {
+                            tracing::error!(
+                                box_id = %box_id,
+                                attempt,
+                                error = %e,
+                                "Restart attempt failed"
+                            );
+
+                            // Update state with new attempt count and failure cause
+                            if let Ok(Some((_, mut state))) = this.box_manager.box_by_id(&box_id) {
+                                state.stop_info.restart_count = attempt;
+                                state.stop_info.cause = StopCause::RestartFailed;
+                                let _ = this.box_manager.save_box(&box_id, &state);
+                            }
+
+                            // Check if should retry
+                            let should_retry = restart_policy
+                                .as_ref()
+                                .map(|p| p.should_restart(exit_code, attempt))
+                                .unwrap_or(false);
+
+                            if !should_retry {
+                                tracing::info!(box_id = %box_id, attempt, "Max retries exceeded");
+
+                                if let Ok(Some((_, mut state))) = this.box_manager.box_by_id(&box_id) {
+                                    state.force_status(BoxStatus::Stopped);
+                                    state.stop_info.cause = StopCause::MaxRetriesExceeded;
+                                    let _ = this.box_manager.save_box(&box_id, &state);
+                                }
+                                break;  // Give up
+                            }
+                            // Continue loop for retry (_lock_guard dropped here)
+                        }
+                    }
+                    // _lock_guard dropped here
+                }
+                _ = this.shutdown_token.cancelled() => {
+                    tracing::debug!(box_id = %box_id, "Restart cancelled (shutdown)");
+                    if let Ok(Some((_, mut state))) = this.box_manager.box_by_id(&box_id) {
+                        state.force_status(BoxStatus::Stopped);
+                        state.stop_info.restart_count = attempt;
+                        state.stop_info.cause = StopCause::Normal;
+                        let _ = this.box_manager.save_box(&box_id, &state);
+                    }
+                    break;
+                }
+            }
+        }
+    }
+
+    /// Get crash sender for health check tasks.
+    pub(crate) fn crash_sender(&self) -> mpsc::Sender<BoxID> {
+        self.crash_tx.clone()
+    }
+
+    // ========================================================================
+    // LAZY SERVICES INITIALIZATION
+    // ========================================================================
+
+    /// Ensure background services are started (crash handler, recovery tasks).
+    ///
+    /// This is called lazily on the first async method, guaranteeing a tokio
+    /// runtime exists. Uses `OnceCell` to ensure exactly-once execution.
+    async fn ensure_services_started(self: &Arc<Self>) {
+        self.services_started
+            .get_or_init(|| {
+                let rt = Arc::clone(self);
+                async move {
+                    // 1. Spawn crash handler
+                    let crash_rx = rt
+                        .pending_crash_rx
+                        .lock()
+                        .unwrap()
+                        .take()
+                        .expect("pending_crash_rx consumed twice");
+                    let handle = Self::spawn_crash_handler(Arc::clone(&rt), crash_rx);
+                    *rt.crash_handler_handle.write().unwrap() = Some(handle);
+
+                    // 2. Spawn recovery auto-restart tasks
+                    let queue: Vec<_> = rt.recovery_queue.lock().unwrap().drain(..).collect();
+                    if !queue.is_empty() {
+                        tracing::info!(
+                            count = queue.len(),
+                            "Starting auto-restart for boxes with Always/UnlessStopped policy"
+                        );
+                        let rt_for_restart = Arc::clone(&rt);
+                        tokio::spawn(async move {
+                            for (box_id, mut state) in queue {
+                                tracing::info!(
+                                    box_id = %box_id,
+                                    "Auto-restarting box after runtime recovery"
+                                );
+
+                                // Acquire per-box lock before calling restart()
+                                let lock_id = match state.lock_id {
+                                    Some(id) => id,
+                                    None => {
+                                        tracing::warn!(
+                                            box_id = %box_id,
+                                            "Box has no lock_id, skipping auto-restart"
+                                        );
+                                        continue;
+                                    }
+                                };
+                                let locker = match rt_for_restart.lock_manager.retrieve(lock_id) {
+                                    Ok(l) => l,
+                                    Err(e) => {
+                                        tracing::error!(
+                                            box_id = %box_id,
+                                            error = %e,
+                                            "Failed to retrieve lock"
+                                        );
+                                        continue;
+                                    }
+                                };
+
+                                let mut acquired = false;
+                                let _lock_guard = loop {
+                                    if let Some(guard) =
+                                        crate::lock::LockGuard::try_new(locker.as_ref())
+                                    {
+                                        acquired = true;
+                                        break guard;
+                                    }
+                                    if rt_for_restart.shutdown_token.is_cancelled() {
+                                        tracing::debug!(
+                                            box_id = %box_id,
+                                            "Shutdown while waiting for lock (recovery)"
+                                        );
+                                        break crate::lock::LockGuard::new(locker.as_ref());
+                                    }
+                                    tokio::task::yield_now().await;
+                                };
+
+                                if !acquired {
+                                    continue;
+                                }
+
+                                match rt_for_restart.restart(&box_id).await {
+                                    Ok(()) => {
+                                        tracing::info!(
+                                            box_id = %box_id,
+                                            "Auto-restart succeeded during recovery"
+                                        );
+                                    }
+                                    Err(e) => {
+                                        let error_msg = format!("{}", e);
+                                        tracing::error!(
+                                            box_id = %box_id,
+                                            error = %error_msg,
+                                            "Auto-restart failed during recovery"
+                                        );
+                                        state.last_restart_error = Some(error_msg);
+                                        let _ =
+                                            rt_for_restart.box_manager.save_box(&box_id, &state);
+                                    }
+                                }
+                            }
+                        });
+                    }
+                }
+            })
+            .await;
     }
 
     // ========================================================================
@@ -251,6 +802,7 @@ impl RuntimeImpl {
         options: BoxOptions,
         name: Option<String>,
     ) -> BoxliteResult<LiteBox> {
+        self.ensure_services_started().await;
         let (litebox, _created) = self.create_inner(options, name, false).await?;
         Ok(litebox)
     }
@@ -265,6 +817,7 @@ impl RuntimeImpl {
         options: BoxOptions,
         name: Option<String>,
     ) -> BoxliteResult<(LiteBox, bool)> {
+        self.ensure_services_started().await;
         self.create_inner(options, name, true).await
     }
 
@@ -277,6 +830,7 @@ impl RuntimeImpl {
         archive: BoxArchive,
         name: Option<String>,
     ) -> BoxliteResult<LiteBox> {
+        self.ensure_services_started().await;
         super::import::import_box(self, archive, name).await
     }
 
@@ -382,6 +936,7 @@ impl RuntimeImpl {
     /// If another handle to the same box exists, they share the same BoxImpl
     /// (and thus the same LiveState if initialized).
     pub async fn get(self: &Arc<Self>, id_or_name: &str) -> BoxliteResult<Option<LiteBox>> {
+        self.ensure_services_started().await;
         tracing::trace!(id_or_name = %id_or_name, "RuntimeInnerImpl::get called");
 
         // Check in-memory cache first (for boxes created but not yet persisted)
@@ -444,6 +999,7 @@ impl RuntimeImpl {
     ///
     /// Checks in-memory cache first (for boxes not yet persisted), then database.
     pub async fn get_info(self: &Arc<Self>, id_or_name: &str) -> BoxliteResult<Option<BoxInfo>> {
+        self.ensure_services_started().await;
         // Check in-memory cache first (for boxes created but not yet persisted)
         {
             let sync = self.sync_state.read().unwrap();
@@ -483,6 +1039,7 @@ impl RuntimeImpl {
     /// Includes both persisted boxes (from database) and in-memory boxes
     /// (created but not yet persisted).
     pub async fn list_info(self: &Arc<Self>) -> BoxliteResult<Vec<BoxInfo>> {
+        self.ensure_services_started().await;
         use std::collections::HashSet;
 
         // Get boxes from database - run on blocking thread pool
@@ -519,6 +1076,7 @@ impl RuntimeImpl {
     ///
     /// Checks in-memory cache first (for boxes not yet persisted), then database.
     pub async fn exists(self: &Arc<Self>, id_or_name: &str) -> BoxliteResult<bool> {
+        self.ensure_services_started().await;
         // Check in-memory cache first
         {
             let sync = self.sync_state.read().unwrap();
@@ -645,6 +1203,40 @@ impl RuntimeImpl {
 
         if errors.is_empty() {
             tracing::info!("Runtime shutdown complete");
+        } else {
+            tracing::warn!("Shutdown completed with errors: {}", errors.join(", "));
+        }
+
+        // Stop crash handler
+        drop(self.crash_tx.clone()); // Drop all senders to close channel
+        let crash_handle = self.crash_handler_handle.write().unwrap().take();
+        if let Some(handle) = crash_handle {
+            match tokio::time::timeout(std::time::Duration::from_secs(5), handle).await {
+                Ok(Ok(())) => tracing::debug!("Crash handler stopped gracefully"),
+                Ok(Err(e)) => tracing::warn!("Crash handler panicked: {:?}", e),
+                Err(_) => tracing::warn!("Crash handler stop timeout"),
+            }
+        }
+
+        // Await in-flight per-crash tasks. The shutdown_token is already
+        // cancelled so these tasks will exit their backoff loops promptly.
+        let crash_tasks: Vec<JoinHandle<()>> =
+            self.crash_task_handles.write().unwrap().drain(..).collect();
+        if !crash_tasks.is_empty() {
+            tracing::debug!(
+                count = crash_tasks.len(),
+                "Waiting for in-flight crash tasks to finish"
+            );
+            for handle in crash_tasks {
+                match tokio::time::timeout(std::time::Duration::from_secs(5), handle).await {
+                    Ok(Ok(())) => {}
+                    Ok(Err(e)) => tracing::warn!("Crash task panicked: {:?}", e),
+                    Err(_) => tracing::warn!("Crash task stop timeout"),
+                }
+            }
+        }
+
+        if errors.is_empty() {
             Ok(())
         } else {
             Err(BoxliteError::Internal(format!(
@@ -1004,6 +1596,7 @@ impl RuntimeImpl {
         options: BoxOptions,
         initial_status: BoxStatus,
     ) -> BoxliteResult<LiteBox> {
+        self.ensure_services_started().await;
         use crate::litebox::config::ContainerRuntimeConfig;
 
         let box_id = BoxIDMint::mint();
@@ -1054,7 +1647,8 @@ impl RuntimeImpl {
     }
 
     /// Recover boxes from persistent storage on runtime startup.
-    fn recover_boxes(&self) -> BoxliteResult<()> {
+    /// Returns list of (box_id, state) tuples that need auto-restart (Always/UnlessStopped policy).
+    fn recover_boxes(&self) -> BoxliteResult<Vec<(BoxID, BoxState)>> {
         use crate::util::{is_process_alive, is_same_process};
 
         // Check for system reboot and reset active boxes
@@ -1161,6 +1755,9 @@ impl RuntimeImpl {
 
         tracing::info!("Recovering {} boxes from database", persisted.len());
 
+        // Collect boxes that need auto-restart (Crashed/Restarting with Always/UnlessStopped policy)
+        let mut boxes_to_auto_restart: Vec<(BoxID, BoxState)> = Vec::new();
+
         for (config, mut state) in persisted {
             let box_id = &config.id;
             let original_status = state.status;
@@ -1186,18 +1783,18 @@ impl RuntimeImpl {
                 }
             }
 
-            // Check PID file (single source of truth for running processes)
+            // Check if box is actually running (single source of truth: PID file + process check)
             let pid_file = self
                 .layout
                 .boxes_dir()
                 .join(box_id.as_str())
                 .join("shim.pid");
 
-            if pid_file.exists() {
+            let is_running = if pid_file.exists() {
                 match crate::util::read_pid_file(&pid_file) {
                     Ok(pid) => {
                         if is_process_alive(pid) && is_same_process(pid, box_id.as_str()) {
-                            // Process is alive and it's our boxlite-shim - box stays Running
+                            // Process is alive and it's our boxlite-shim
                             state.set_pid(Some(pid));
                             state.set_status(BoxStatus::Running);
                             tracing::info!(
@@ -1205,37 +1802,95 @@ impl RuntimeImpl {
                                 pid = pid,
                                 "Recovered running box from PID file"
                             );
+                            true
                         } else {
-                            // Process died or PID was reused - clean up and mark as Stopped
+                            // Process died or PID was reused
                             let _ = std::fs::remove_file(&pid_file);
-                            state.mark_stop();
                             tracing::warn!(
                                 box_id = %box_id,
                                 pid = pid,
                                 "Box process dead, cleaned up stale PID file"
                             );
+                            false
                         }
                     }
                     Err(e) => {
-                        // Can't read PID file - clean up and mark as Stopped
+                        // Can't read PID file
                         let _ = std::fs::remove_file(&pid_file);
-                        state.mark_stop();
                         tracing::warn!(
                             box_id = %box_id,
                             error = %e,
-                            "Failed to read PID file, marking as Stopped"
+                            "Failed to read PID file"
                         );
+                        false
                     }
                 }
             } else {
                 // No PID file - box was stopped gracefully or never started
-                // Note: Configured boxes won't have a PID file (this is expected)
                 if state.status == BoxStatus::Running {
-                    state.set_status(BoxStatus::Stopped);
                     tracing::warn!(
                         box_id = %box_id,
-                        "Box was Running but no PID file found, marked as Stopped"
+                        "Box was Running but no PID file found"
                     );
+                }
+                false
+            };
+
+            // If box is not running, decide whether recovery should auto-restart it.
+            if !is_running {
+                let should_evaluate_restart = matches!(
+                    original_status,
+                    BoxStatus::Running | BoxStatus::Crashed | BoxStatus::Restarting
+                );
+
+                if should_evaluate_restart {
+                    let restart_policy = config.options.advanced.restart_policy.as_ref();
+                    // Read exit code from file. If no file (clean exit), default to 0.
+                    let exit_code = read_box_exit_code(&config.box_home).or(Some(0));
+                    let max_retries_exhausted = matches!(
+                        restart_policy,
+                        Some(RestartPolicy::OnFailure { max_retries })
+                            if state.stop_info.restart_count >= *max_retries
+                    );
+
+                    // Evaluate whether to auto-restart during recovery
+                    let should_auto_restart = match restart_policy {
+                        None => false,
+                        Some(RestartPolicy::UnlessStopped) => {
+                            state.stop_info.cause != StopCause::Normal
+                        }
+                        Some(policy) => {
+                            policy.should_restart(exit_code, state.stop_info.restart_count)
+                        }
+                    };
+
+                    if should_auto_restart {
+                        // Queue for auto-restart
+                        boxes_to_auto_restart.push((box_id.clone(), state.clone()));
+                        tracing::info!(
+                            box_id = %box_id,
+                            previous_status = ?original_status,
+                            restart_count = state.stop_info.restart_count,
+                            exit_code = ?exit_code,
+                            "Box queued for auto-restart during recovery"
+                        );
+                    } else {
+                        state.force_status(BoxStatus::Stopped);
+                        state.set_pid(None);
+                        state.stop_info.cause = stop_cause_when_restart_denied(
+                            restart_policy,
+                            exit_code,
+                            max_retries_exhausted,
+                        );
+                        state.stop_info.exit_code = exit_code;
+                        state.stop_info.exit_time.get_or_insert(Utc::now());
+                        tracing::warn!(
+                            box_id = %box_id,
+                            previous_status = ?original_status,
+                            exit_code = ?exit_code,
+                            "Box not running at recovery, marked as Stopped for manual recovery"
+                        );
+                    }
                 }
             }
 
@@ -1250,8 +1905,11 @@ impl RuntimeImpl {
             tracing::warn!("Guest rootfs GC failed: {}", e);
         }
 
-        tracing::info!("Box recovery complete");
-        Ok(())
+        tracing::info!(
+            "Box recovery complete, {} boxes queued for auto-restart",
+            boxes_to_auto_restart.len()
+        );
+        Ok(boxes_to_auto_restart)
     }
 
     /// Scan filesystem for orphaned box directories and remove them.
@@ -1328,6 +1986,77 @@ impl RuntimeImpl {
             }
         }
 
+        Ok(())
+    }
+
+    // ========================================================================
+    // RESTART
+    // ========================================================================
+
+    /// Restart a box by ID.
+    ///
+    /// Follows the same pattern as stop(): invalidate old BoxImpl from cache,
+    /// create a fresh BoxImpl, and call start() on it. The fresh BoxImpl has
+    /// an empty OnceCell, so start() triggers init_live_state() which runs
+    /// the Restarting execution plan (same as Stopped - reuse COW disks, spawn new VM).
+    ///
+    /// **Callers must hold the per-box lock** to ensure mutual exclusion with
+    /// crash handling. This function does NOT acquire the lock internally.
+    pub(crate) async fn restart(self: &Arc<Self>, box_id: &BoxID) -> BoxliteResult<()> {
+        use crate::litebox::BoxStatus;
+
+        tracing::info!(box_id = %box_id, "Restarting box");
+
+        // 1. Look up existing box config and state from DB
+        let (config, mut state) = self
+            .box_manager
+            .box_by_id(box_id)?
+            .ok_or_else(|| BoxliteError::NotFound(box_id.to_string()))?;
+
+        // 2. If there's an active BoxImpl in cache, abort its health check and cancel it
+        {
+            let sync = self.sync_state.read().unwrap();
+            if let Some(weak) = sync.active_boxes_by_id.get(box_id)
+                && let Some(strong) = weak.upgrade()
+            {
+                // Abort health check task
+                strong.abort_health_check();
+                // Cancel shutdown token (makes old BoxImpl unusable)
+                strong.shutdown_token.cancel();
+            }
+        }
+
+        // 3. Invalidate old BoxImpl from cache
+        self.invalidate_box_impl(box_id, config.name.as_deref());
+
+        // 4. Update state to Restarting and persist
+        state.force_status(BoxStatus::Restarting);
+        state.set_pid(None);
+        state.clear_health_status();
+        self.box_manager.save_box(box_id, &state)?;
+
+        // 5. Create fresh BoxImpl with updated state
+        let (box_impl, _) = self.get_or_create_box_impl(config, state);
+
+        // 6. Call start() on fresh BoxImpl → empty OnceCell → init_live_state()
+        //    BoxBuilder sees status=Restarting → same pipeline as Stopped
+        box_impl.start().await?;
+
+        // 7. Reset stop info — previous crash/restart history is no longer relevant
+        {
+            let mut state = box_impl.state.write();
+            state.stop_info = crate::litebox::StopInfo::default();
+            state.stop_info.restarted_at = Some(chrono::Utc::now());
+            if let Err(e) = self.box_manager.save_box(box_id, &state) {
+                tracing::warn!(
+                    box_id = %box_id,
+                    error = %e,
+                    "Failed to persist restart success state"
+                );
+            }
+        }
+
+        tracing::info!(box_id = %box_id, "Box restarted successfully");
         Ok(())
     }
 
@@ -1558,6 +2287,7 @@ impl Drop for RuntimeImpl {
 mod tests {
     use super::*;
     use crate::litebox::config::{BoxConfig, ContainerRuntimeConfig};
+    use crate::runtime::advanced_options::RestartPolicy;
     use crate::runtime::backend::RuntimeBackend;
     use crate::runtime::options::RootfsSpec;
     use tempfile::TempDir;
@@ -1658,6 +2388,77 @@ mod tests {
     // ====================================================================
     // shutdown() tests
     // ====================================================================
+
+    #[test]
+    fn test_new_does_not_start_background_tasks() {
+        let (runtime, _dir) = create_test_runtime();
+
+        // new() is sync — no crash handler or recovery tasks should be spawned
+        assert!(runtime.crash_handler_handle.read().unwrap().is_none());
+        assert!(runtime.services_started.get().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_async_call_starts_background_services() {
+        let (runtime, _dir) = create_test_runtime();
+
+        // Before any async call, services are not started
+        assert!(runtime.services_started.get().is_none());
+
+        // Calling an async method triggers lazy initialization
+        runtime.list_info().await.unwrap();
+
+        // Services should now be started
+        assert!(runtime.services_started.get().is_some());
+        assert!(runtime.crash_handler_handle.read().unwrap().is_some());
+    }
+
+    #[test]
+    fn test_new_without_tokio_with_recovery_candidate_does_not_panic() {
+        let temp_dir = TempDir::new_in("/tmp").expect("Failed to create temp dir");
+        let options = BoxliteOptions {
+            home_dir: temp_dir.path().to_path_buf(),
+            image_registries: vec![],
+        };
+
+        let box_id = {
+            let runtime = RuntimeImpl::new(options.clone()).expect("Failed to create seed runtime");
+
+            let mut config = test_box_config_in_layout(false, &runtime);
+            config.options.advanced.restart_policy = Some(RestartPolicy::Always);
+            std::fs::create_dir_all(&config.box_home).expect("Failed to create box home");
+
+            let mut state = BoxState::new();
+            state.status = BoxStatus::Crashed;
+            state.set_lock_id(
+                runtime
+                    .lock_manager
+                    .allocate()
+                    .expect("Failed to allocate lock"),
+            );
+
+            let box_id = config.id.clone();
+            runtime
+                .box_manager
+                .add_box(&config, &state)
+                .expect("Failed to add box");
+            drop(runtime);
+            box_id
+        };
+
+        let runtime = RuntimeImpl::new(options).expect("Failed to recover runtime");
+
+        // Recovery queue should be populated but not yet processed (no tokio runtime)
+        assert_eq!(runtime.recovery_queue.lock().unwrap().len(), 1);
+
+        let (_, recovered_state) = runtime
+            .box_manager
+            .box_by_id(&box_id)
+            .expect("Failed to read recovered box")
+            .expect("Recovered box should exist");
+        assert_eq!(recovered_state.status, BoxStatus::Crashed);
+        assert!(recovered_state.last_restart_error.is_none());
+    }
 
     #[tokio::test]
     async fn test_shutdown_is_idempotent() {

--- a/src/boxlite/src/runtime/types.rs
+++ b/src/boxlite/src/runtime/types.rs
@@ -315,6 +315,14 @@ pub struct BoxInfo {
 
     /// Health status.
     pub health_status: HealthStatus,
+
+    /// Stop info (valid when status is Stopped/Crashed/Restarting).
+    #[serde(default)]
+    pub stop_info: crate::litebox::StopInfo,
+
+    /// Last restart error message (if any).
+    #[serde(default)]
+    pub last_restart_error: Option<String>,
 }
 
 impl BoxInfo {
@@ -337,6 +345,8 @@ impl BoxInfo {
             memory_mib: config.options.memory_mib.unwrap_or(512),
             labels: HashMap::new(),
             health_status: state.health_status,
+            stop_info: state.stop_info.clone(),
+            last_restart_error: None,
         }
     }
 }

--- a/src/boxlite/tests/recovery.rs
+++ b/src/boxlite/tests/recovery.rs
@@ -7,13 +7,16 @@
 mod common;
 
 use boxlite::BoxliteRuntime;
+use boxlite::StopCause;
 use boxlite::litebox::BoxCommand;
+use boxlite::runtime::advanced_options::{AdvancedBoxOptions, RestartPolicy};
 use boxlite::runtime::id::BoxID;
-use boxlite::runtime::options::BoxliteOptions;
+use boxlite::runtime::options::{BoxOptions, BoxliteOptions};
 use boxlite::runtime::types::BoxStatus;
 use boxlite::util::read_pid_file;
 use std::path::{Path, PathBuf};
 use tempfile::TempDir;
+use tokio::time::{Duration, sleep};
 
 // ============================================================================
 // LOCAL HELPERS
@@ -22,6 +25,98 @@ use tempfile::TempDir;
 /// Get the PID file path for a box under the given home directory.
 fn pid_file_path(home_dir: &Path, box_id: &str) -> PathBuf {
     home_dir.join("boxes").join(box_id).join("shim.pid")
+}
+
+/// Get the exit file path for a box under the given home directory.
+fn exit_file_path(home_dir: &Path, box_id: &str) -> PathBuf {
+    home_dir.join("boxes").join(box_id).join("exit")
+}
+
+/// Write exit file with given exit code and message.
+fn write_exit_file(path: &Path, exit_code: i32, message: &str) {
+    let json = format!(
+        r#"{{"type":"error","exit_code":{},"message":"{}"}}"#,
+        exit_code, message
+    );
+    std::fs::write(path, json).expect("Failed to write exit file");
+}
+
+/// Helper to create OnFailure policy options.
+fn on_failure_opts(max_retries: u32) -> BoxOptions {
+    BoxOptions {
+        advanced: AdvancedBoxOptions {
+            restart_policy: Some(RestartPolicy::OnFailure { max_retries }),
+            ..Default::default()
+        },
+        ..common::alpine_opts()
+    }
+}
+
+/// Helper to create UnlessStopped policy options.
+fn unless_stopped_opts() -> BoxOptions {
+    BoxOptions {
+        advanced: AdvancedBoxOptions {
+            restart_policy: Some(RestartPolicy::UnlessStopped),
+            ..Default::default()
+        },
+        ..common::alpine_opts()
+    }
+}
+
+/// Helper to create Always policy options.
+fn always_opts() -> BoxOptions {
+    BoxOptions {
+        advanced: AdvancedBoxOptions {
+            restart_policy: Some(RestartPolicy::Always),
+            ..Default::default()
+        },
+        ..common::alpine_opts()
+    }
+}
+
+/// Wait for shim.pid to appear.
+async fn wait_for_shim_pid(home_dir: &Path, box_id: &str) -> u32 {
+    let pid_path = pid_file_path(home_dir, box_id);
+
+    for _ in 0..20 {
+        if let Ok(pid) = read_pid_file(&pid_path) {
+            return pid;
+        }
+        sleep(Duration::from_millis(500)).await;
+    }
+
+    panic!("shim.pid did not appear for box {}", box_id);
+}
+
+/// Manually update box state in database to simulate a crashed box.
+fn set_box_state_crashed(home_dir: &Path, box_id: &str, restart_count: u32, stop_cause: &str) {
+    let db_path = home_dir.join("db").join("boxes.db");
+    let conn = rusqlite::Connection::open(&db_path).expect("Failed to open database");
+
+    // Get current state JSON
+    let mut stmt = conn
+        .prepare("SELECT json FROM box_state WHERE id = ?1")
+        .expect("Failed to prepare select");
+    let json: String = stmt
+        .query_row([box_id], |row| row.get(0))
+        .expect("Failed to get state JSON");
+    drop(stmt);
+
+    // Parse and modify state
+    let mut state: serde_json::Value = serde_json::from_str(&json).expect("Failed to parse state");
+    state["status"] = serde_json::json!(BoxStatus::Crashed.as_str());
+    state["pid"] = serde_json::json!(null);
+    state["stop_info"]["restart_count"] = serde_json::json!(restart_count);
+    state["stop_info"]["cause"] = serde_json::json!(stop_cause);
+
+    let new_json = serde_json::to_string(&state).expect("Failed to serialize state");
+
+    // Update database
+    conn.execute(
+        "UPDATE box_state SET status = ?1, pid = ?2, json = ?3 WHERE id = ?4",
+        rusqlite::params![BoxStatus::Crashed.as_str(), None::<i32>, new_json, box_id],
+    )
+    .expect("Failed to update state");
 }
 
 // ============================================================================
@@ -459,5 +554,278 @@ async fn recovery_removes_orphaned_stopped_boxes_without_directory() {
 
         // Cleanup
         runtime.remove(box_id.as_str(), false).await.unwrap();
+    }
+}
+
+// ============================================================================
+// RECOVERY WITH RESTART POLICY EVALUATION
+// ============================================================================
+
+#[tokio::test]
+async fn recovery_on_failure_respects_max_retries() {
+    // Test: When restart_count >= max_retries, box should NOT auto-restart during recovery
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let box_id: String;
+    let shim_pid: u32;
+
+    // Create box with OnFailure policy and max_retries=2
+    {
+        let runtime = BoxliteRuntime::new(BoxliteOptions {
+            home_dir: home.path.clone(),
+            image_registries: common::test_registries(),
+        })
+        .unwrap();
+
+        let handle = runtime.create(on_failure_opts(2), None).await.unwrap();
+
+        handle.start().await.unwrap();
+        box_id = handle.id().to_string();
+        shim_pid = wait_for_shim_pid(&home.path, &box_id).await;
+    }
+
+    // Kill shim and write exit file (non-zero exit to indicate failure)
+    unsafe {
+        libc::kill(shim_pid as i32, libc::SIGKILL);
+    }
+    sleep(Duration::from_millis(200)).await;
+    write_exit_file(&exit_file_path(&home.path, &box_id), 1, "error");
+
+    // Manually set restart_count to max_retries (2) to simulate exhausted retries
+    set_box_state_crashed(&home.path, &box_id, 2, "MaxRetriesExceeded");
+
+    // Recovery should NOT auto-restart because restart_count >= max_retries
+    {
+        let runtime = BoxliteRuntime::new(BoxliteOptions {
+            home_dir: home.path.clone(),
+            image_registries: common::test_registries(),
+        })
+        .unwrap();
+
+        // Wait a bit for recovery to complete
+        sleep(Duration::from_secs(2)).await;
+
+        let info = runtime
+            .get_info(&box_id)
+            .await
+            .unwrap()
+            .expect("Box should exist");
+
+        assert_eq!(
+            info.status,
+            BoxStatus::Stopped,
+            "Box with exhausted max_retries should be Stopped, not restarted"
+        );
+        assert!(info.pid.is_none(), "Stopped box should have no PID");
+
+        // Verify stop cause indicates max retries exceeded
+        assert_eq!(
+            info.stop_info.cause,
+            StopCause::MaxRetriesExceeded,
+            "Stop cause should be MaxRetriesExceeded"
+        );
+
+        runtime.remove(&box_id, false).await.unwrap();
+    }
+}
+
+#[tokio::test]
+async fn recovery_unless_stopped_does_not_restart_normal_stop() {
+    // Test: UnlessStopped policy should NOT restart if stop cause is Normal
+    // (i.e., box was manually stopped, not crashed)
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let box_id: String;
+    let shim_pid: u32;
+
+    // Create box with UnlessStopped policy
+    {
+        let runtime = BoxliteRuntime::new(BoxliteOptions {
+            home_dir: home.path.clone(),
+            image_registries: common::test_registries(),
+        })
+        .unwrap();
+
+        let handle = runtime.create(unless_stopped_opts(), None).await.unwrap();
+
+        handle.start().await.unwrap();
+        box_id = handle.id().to_string();
+        shim_pid = wait_for_shim_pid(&home.path, &box_id).await;
+    }
+
+    // Kill shim (simulates a crash, but we will set Normal stop cause)
+    unsafe {
+        libc::kill(shim_pid as i32, libc::SIGKILL);
+    }
+    sleep(Duration::from_millis(200)).await;
+    write_exit_file(&exit_file_path(&home.path, &box_id), 0, "clean exit");
+
+    // Manually set state to Crashed with Normal stop cause (simulates manual stop)
+    set_box_state_crashed(&home.path, &box_id, 0, "Normal");
+
+    // Recovery should NOT auto-restart because stop cause is Normal
+    {
+        let runtime = BoxliteRuntime::new(BoxliteOptions {
+            home_dir: home.path.clone(),
+            image_registries: common::test_registries(),
+        })
+        .unwrap();
+
+        // Wait a bit for recovery to complete
+        sleep(Duration::from_secs(2)).await;
+
+        let info = runtime
+            .get_info(&box_id)
+            .await
+            .unwrap()
+            .expect("Box should exist");
+
+        assert_eq!(
+            info.status,
+            BoxStatus::Stopped,
+            "UnlessStopped box with Normal stop cause should not be restarted"
+        );
+        assert!(info.pid.is_none(), "Stopped box should have no PID");
+
+        runtime.remove(&box_id, false).await.unwrap();
+    }
+}
+
+#[tokio::test]
+async fn recovery_unless_stopped_restarts_on_crash() {
+    // Test: UnlessStopped policy SHOULD restart if stop cause is NOT Normal
+    // (i.e., box crashed unexpectedly)
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let box_id: String;
+    let shim_pid: u32;
+
+    // Create box with UnlessStopped policy
+    {
+        let runtime = BoxliteRuntime::new(BoxliteOptions {
+            home_dir: home.path.clone(),
+            image_registries: common::test_registries(),
+        })
+        .unwrap();
+
+        let handle = runtime.create(unless_stopped_opts(), None).await.unwrap();
+
+        handle.start().await.unwrap();
+        box_id = handle.id().to_string();
+        shim_pid = wait_for_shim_pid(&home.path, &box_id).await;
+    }
+
+    // Kill shim (simulates a crash)
+    unsafe {
+        libc::kill(shim_pid as i32, libc::SIGKILL);
+    }
+    sleep(Duration::from_millis(200)).await;
+    write_exit_file(&exit_file_path(&home.path, &box_id), 1, "crashed");
+
+    // Manually set state to Crashed with non-Normal stop cause
+    set_box_state_crashed(&home.path, &box_id, 0, "CrashedNoPolicy");
+
+    // Recovery SHOULD auto-restart because stop cause is not Normal
+    {
+        let runtime = BoxliteRuntime::new(BoxliteOptions {
+            home_dir: home.path.clone(),
+            image_registries: common::test_registries(),
+        })
+        .unwrap();
+
+        // Wait for auto-restart
+        let mut restarted = false;
+        for _ in 0..20 {
+            let info = runtime
+                .get_info(&box_id)
+                .await
+                .unwrap()
+                .expect("Box should exist");
+
+            if info.status == BoxStatus::Running && info.pid.is_some() {
+                restarted = true;
+                break;
+            }
+
+            sleep(Duration::from_secs(1)).await;
+        }
+
+        assert!(
+            restarted,
+            "UnlessStopped box with crash stop cause should be restarted during recovery"
+        );
+
+        runtime.remove(&box_id, true).await.unwrap();
+    }
+}
+
+#[tokio::test]
+async fn recovery_crashed_state_is_evaluated_for_restart() {
+    // Test: Box with Crashed status (not just Running) is properly evaluated during recovery
+    // This verifies the recover_boxes() handles Crashed/Restarting states correctly
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let box_id: String;
+    let shim_pid: u32;
+
+    // Create box with Always policy
+    {
+        let runtime = BoxliteRuntime::new(BoxliteOptions {
+            home_dir: home.path.clone(),
+            image_registries: common::test_registries(),
+        })
+        .unwrap();
+
+        let handle = runtime.create(always_opts(), None).await.unwrap();
+
+        handle.start().await.unwrap();
+        box_id = handle.id().to_string();
+        shim_pid = wait_for_shim_pid(&home.path, &box_id).await;
+    }
+
+    // Kill shim
+    unsafe {
+        libc::kill(shim_pid as i32, libc::SIGKILL);
+    }
+    sleep(Duration::from_millis(200)).await;
+    write_exit_file(&exit_file_path(&home.path, &box_id), 1, "crashed");
+
+    // Manually set state to Crashed (simulating the crash handling persisted this state)
+    set_box_state_crashed(&home.path, &box_id, 1, "CrashedNoPolicy");
+
+    // Recovery should evaluate the Crashed state and auto-restart (Always policy)
+    {
+        let runtime = BoxliteRuntime::new(BoxliteOptions {
+            home_dir: home.path.clone(),
+            image_registries: common::test_registries(),
+        })
+        .unwrap();
+
+        // Wait for auto-restart
+        let mut restarted = false;
+        for _ in 0..20 {
+            let info = runtime
+                .get_info(&box_id)
+                .await
+                .unwrap()
+                .expect("Box should exist");
+
+            if info.status == BoxStatus::Running && info.pid.is_some() {
+                restarted = true;
+                break;
+            }
+
+            sleep(Duration::from_secs(1)).await;
+        }
+
+        assert!(
+            restarted,
+            "Crashed box with Always policy should be restarted during recovery"
+        );
+
+        // Verify restart_count was preserved
+        let info = runtime.get_info(&box_id).await.unwrap().unwrap();
+        assert_eq!(
+            info.stop_info.restart_count, 1,
+            "restart_count should be preserved from Crashed state"
+        );
+
+        runtime.remove(&box_id, true).await.unwrap();
     }
 }

--- a/src/boxlite/tests/restart_policy.rs
+++ b/src/boxlite/tests/restart_policy.rs
@@ -1,0 +1,356 @@
+//! Integration tests for restart policy functionality.
+//!
+//! # Prerequisites
+//!
+//! These tests require a real VM environment:
+//! 1. Build the runtime: `make runtime:debug`
+//! 2. Run with: `cargo test -p boxlite --test restart_policy -- --test-threads=1`
+
+mod common;
+
+use boxlite::StopCause;
+use boxlite::runtime::advanced_options::{AdvancedBoxOptions, HealthCheckOptions, RestartPolicy};
+use boxlite::runtime::options::{BoxOptions, RootfsSpec};
+use boxlite::runtime::types::BoxStatus;
+use common::box_test::BoxTestBase;
+use std::process::Command;
+use std::time::Duration;
+use tokio::time::sleep;
+
+/// Build `BoxOptions` with restart policy enabled.
+fn restart_policy_opts(policy: RestartPolicy) -> BoxOptions {
+    BoxOptions {
+        rootfs: RootfsSpec::Image("alpine:latest".into()),
+        advanced: AdvancedBoxOptions {
+            restart_policy: Some(policy),
+            // Auto-enable health check for restart policy
+            ..Default::default()
+        },
+        auto_remove: false,
+        ..Default::default()
+    }
+}
+
+/// Build `BoxOptions` with both restart policy and custom health check.
+fn restart_and_health_opts(policy: RestartPolicy, interval: Duration) -> BoxOptions {
+    BoxOptions {
+        rootfs: RootfsSpec::Image("alpine:latest".into()),
+        advanced: AdvancedBoxOptions {
+            restart_policy: Some(policy),
+            health_check: Some(HealthCheckOptions {
+                interval,
+                timeout: Duration::from_secs(5),
+                retries: 3,
+                start_period: Duration::from_secs(5),
+            }),
+            ..Default::default()
+        },
+        auto_remove: false,
+        ..Default::default()
+    }
+}
+
+// ============================================================================
+// RESTART POLICY: No
+// ============================================================================
+
+#[tokio::test]
+async fn restart_policy_no_does_not_restart() {
+    let t = BoxTestBase::with_options(restart_policy_opts(RestartPolicy::No)).await;
+
+    // Start the box
+    t.bx.start().await.expect("Failed to start box");
+    let box_id = t.bx.id().clone();
+
+    // Wait for health check to become healthy
+    sleep(Duration::from_secs(5)).await;
+
+    // Verify box is running
+    let info = t.runtime.get_info(box_id.as_str()).await.unwrap().unwrap();
+    assert_eq!(info.status, BoxStatus::Running);
+    let shim_pid = info.pid.expect("No shim PID found");
+
+    // Kill the shim process
+    Command::new("kill")
+        .arg("-9")
+        .arg(shim_pid.to_string())
+        .output()
+        .expect("Failed to kill shim process");
+
+    // Wait for health check to detect failure
+    sleep(Duration::from_secs(8)).await;
+
+    // Box should be stopped, not restarted (No policy)
+    let info = t.runtime.get_info(box_id.as_str()).await.unwrap().unwrap();
+    assert_eq!(
+        info.status,
+        BoxStatus::Stopped,
+        "Expected box to be Stopped with No restart policy"
+    );
+
+    // Verify stop cause
+    assert_eq!(info.stop_info.cause, StopCause::CrashedNoPolicy);
+    assert_eq!(info.stop_info.restart_count, 1);
+}
+
+// ============================================================================
+// RESTART POLICY: Always
+// ============================================================================
+
+#[tokio::test]
+async fn restart_policy_always_restarts_on_crash() {
+    let t = BoxTestBase::with_options(restart_and_health_opts(
+        RestartPolicy::Always,
+        Duration::from_secs(2),
+    ))
+    .await;
+
+    // Start the box
+    t.bx.start().await.expect("Failed to start box");
+    let box_id = t.bx.id().clone();
+
+    // Wait for health check to become healthy
+    sleep(Duration::from_secs(5)).await;
+
+    // Verify box is running
+    let info = t.runtime.get_info(box_id.as_str()).await.unwrap().unwrap();
+    assert_eq!(info.status, BoxStatus::Running);
+    let original_pid = info.pid.expect("No shim PID found");
+
+    // Kill the shim process
+    Command::new("kill")
+        .arg("-9")
+        .arg(original_pid.to_string())
+        .output()
+        .expect("Failed to kill shim process");
+
+    // Wait for restart to complete (health check interval + restart time)
+    sleep(Duration::from_secs(10)).await;
+
+    // Box should be running again with a new PID
+    let info = t.runtime.get_info(box_id.as_str()).await.unwrap().unwrap();
+    assert_eq!(
+        info.status,
+        BoxStatus::Running,
+        "Expected box to be Running after auto-restart"
+    );
+
+    let new_pid = info.pid.expect("No shim PID found after restart");
+    assert_ne!(
+        original_pid, new_pid,
+        "Expected new PID after restart, got same PID"
+    );
+
+    // After successful restart, stop_info is reset (restart_count=0, restarted_at set)
+    assert_eq!(info.stop_info.restart_count, 0);
+    assert!(info.stop_info.restarted_at.is_some());
+}
+
+// ============================================================================
+// RESTART POLICY: OnFailure
+// ============================================================================
+
+#[tokio::test]
+async fn restart_policy_on_failure_restarts_within_max_retries() {
+    let t = BoxTestBase::with_options(restart_and_health_opts(
+        RestartPolicy::OnFailure { max_retries: 2 },
+        Duration::from_secs(2),
+    ))
+    .await;
+
+    // Start the box
+    t.bx.start().await.expect("Failed to start box");
+    let box_id = t.bx.id().clone();
+
+    // Wait for health check
+    sleep(Duration::from_secs(5)).await;
+
+    // Verify box is running
+    let info = t.runtime.get_info(box_id.as_str()).await.unwrap().unwrap();
+    assert_eq!(info.status, BoxStatus::Running);
+
+    // First crash
+    let shim_pid = info.pid.expect("No shim PID found");
+    Command::new("kill")
+        .arg("-9")
+        .arg(shim_pid.to_string())
+        .output()
+        .expect("Failed to kill shim process");
+
+    sleep(Duration::from_secs(10)).await;
+
+    // Should restart (restart_count=1 < max_retries=2)
+    let info = t.runtime.get_info(box_id.as_str()).await.unwrap().unwrap();
+    assert_eq!(info.status, BoxStatus::Running);
+    assert_eq!(info.stop_info.restart_count, 1);
+}
+
+#[tokio::test]
+async fn restart_policy_on_failure_stops_after_max_retries() {
+    let t = BoxTestBase::with_options(restart_and_health_opts(
+        RestartPolicy::OnFailure { max_retries: 1 },
+        Duration::from_secs(2),
+    ))
+    .await;
+
+    // Start the box
+    t.bx.start().await.expect("Failed to start box");
+    let box_id = t.bx.id().clone();
+
+    // Wait for health check
+    sleep(Duration::from_secs(5)).await;
+
+    // First crash
+    let info = t.runtime.get_info(box_id.as_str()).await.unwrap().unwrap();
+    let shim_pid = info.pid.expect("No shim PID found");
+    Command::new("kill")
+        .arg("-9")
+        .arg(shim_pid.to_string())
+        .output()
+        .expect("Failed to kill shim process");
+
+    // Wait for first restart
+    sleep(Duration::from_secs(10)).await;
+
+    // Second crash
+    let info = t.runtime.get_info(box_id.as_str()).await.unwrap().unwrap();
+    if info.status == BoxStatus::Running {
+        let shim_pid = info.pid.expect("No shim PID found");
+        Command::new("kill")
+            .arg("-9")
+            .arg(shim_pid.to_string())
+            .output()
+            .expect("Failed to kill shim process");
+
+        // Wait for health check to detect and stop
+        sleep(Duration::from_secs(10)).await;
+    }
+
+    // Should be stopped (max_retries exceeded)
+    let info = t.runtime.get_info(box_id.as_str()).await.unwrap().unwrap();
+    assert_eq!(
+        info.status,
+        BoxStatus::Stopped,
+        "Expected box to be Stopped after max_retries exceeded"
+    );
+    assert_eq!(info.stop_info.cause, StopCause::MaxRetriesExceeded);
+}
+
+// ============================================================================
+// RESTART POLICY: UnlessStopped
+// ============================================================================
+
+#[tokio::test]
+async fn restart_policy_unless_stopped_restarts_on_crash() {
+    let t = BoxTestBase::with_options(restart_and_health_opts(
+        RestartPolicy::UnlessStopped,
+        Duration::from_secs(2),
+    ))
+    .await;
+
+    // Start the box
+    t.bx.start().await.expect("Failed to start box");
+    let box_id = t.bx.id().clone();
+
+    // Wait for health check
+    sleep(Duration::from_secs(5)).await;
+
+    // Verify running
+    let info = t.runtime.get_info(box_id.as_str()).await.unwrap().unwrap();
+    assert_eq!(info.status, BoxStatus::Running);
+    let shim_pid = info.pid.expect("No shim PID found");
+
+    // Kill the shim
+    Command::new("kill")
+        .arg("-9")
+        .arg(shim_pid.to_string())
+        .output()
+        .expect("Failed to kill shim process");
+
+    // Wait for restart
+    sleep(Duration::from_secs(10)).await;
+
+    // Should be running again
+    let info = t.runtime.get_info(box_id.as_str()).await.unwrap().unwrap();
+    assert_eq!(
+        info.status,
+        BoxStatus::Running,
+        "Expected box to be Running after auto-restart (UnlessStopped)"
+    );
+}
+
+#[tokio::test]
+async fn restart_policy_unless_stopped_stays_stopped_after_user_stop() {
+    let t = BoxTestBase::with_options(restart_and_health_opts(
+        RestartPolicy::UnlessStopped,
+        Duration::from_secs(2),
+    ))
+    .await;
+
+    // Start the box
+    t.bx.start().await.expect("Failed to start box");
+    let box_id = t.bx.id().clone();
+
+    // Wait for health check
+    sleep(Duration::from_secs(5)).await;
+
+    // Verify running
+    let info = t.runtime.get_info(box_id.as_str()).await.unwrap().unwrap();
+    assert_eq!(info.status, BoxStatus::Running);
+
+    // User explicitly stops the box
+    t.bx.stop().await.expect("Failed to stop box");
+
+    let info = t.runtime.get_info(box_id.as_str()).await.unwrap().unwrap();
+    assert_eq!(info.status, BoxStatus::Stopped);
+    assert_eq!(info.stop_info.cause, StopCause::Normal);
+
+    // Wait and verify it stays stopped (UnlessStopped should NOT restart after user stop)
+    sleep(Duration::from_secs(5)).await;
+
+    let info = t.runtime.get_info(box_id.as_str()).await.unwrap().unwrap();
+    assert_eq!(
+        info.status,
+        BoxStatus::Stopped,
+        "UnlessStopped should not restart a user-stopped box"
+    );
+}
+
+// ============================================================================
+// RESTART ERROR TRACKING
+// ============================================================================
+
+#[tokio::test]
+async fn restart_error_cleared_on_success() {
+    let t = BoxTestBase::with_options(restart_and_health_opts(
+        RestartPolicy::Always,
+        Duration::from_secs(2),
+    ))
+    .await;
+
+    // Start the box
+    t.bx.start().await.expect("Failed to start box");
+    let box_id = t.bx.id().clone();
+
+    // Wait for healthy
+    sleep(Duration::from_secs(5)).await;
+
+    // Crash and restart
+    let info = t.runtime.get_info(box_id.as_str()).await.unwrap().unwrap();
+    let shim_pid = info.pid.expect("No shim PID found");
+    Command::new("kill")
+        .arg("-9")
+        .arg(shim_pid.to_string())
+        .output()
+        .expect("Failed to kill shim process");
+
+    sleep(Duration::from_secs(10)).await;
+
+    // Verify running and no error
+    let info = t.runtime.get_info(box_id.as_str()).await.unwrap().unwrap();
+    assert_eq!(info.status, BoxStatus::Running);
+    assert!(
+        info.last_restart_error.is_none(),
+        "Expected no restart error after successful restart"
+    );
+}

--- a/src/ffi/src/json.rs
+++ b/src/ffi/src/json.rs
@@ -12,6 +12,8 @@ pub fn status_to_string(status: BoxStatus) -> &'static str {
         BoxStatus::Running => "running",
         BoxStatus::Stopping => "stopping",
         BoxStatus::Stopped => "stopped",
+        BoxStatus::Crashed => "crashed",
+        BoxStatus::Restarting => "restarting",
         BoxStatus::Paused => "paused",
     }
 }


### PR DESCRIPTION
Implement restart policies (No, Always, OnFailure, UnlessStopped) with exponential backoff and crash detection via health check.

Key changes:
- Add RestartPolicy enum, StopCause, StopInfo to state model
- Crash handler task (per-Runtime) evaluates policy on shim death
- Startup recovery evaluates persisted crash state on Runtime::new()
- pending_crashes HashSet prevents duplicate concurrent crash handling
- Health check only detects and notifies (no state mutation)
- Per-box file lock ensures mutual exclusion (callers hold before restart())
- Auto-enable health check when restart_policy is set without health_check
- SDK changes (Python, Node, C) for new status strings and tokio runtime context

issue: #32 