### PR TITLE
Add built-in host alias for box-to-host access

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -296,7 +296,9 @@ See [Configuring Networking](./guides/README.md#configuring-networking) for deta
 
 2. **Use host network:**
    - Box A exposes port
-   - Box B connects to `host.docker.internal:port` (or localhost on Linux)
+   - Box B connects to `host.boxlite.internal:port`
+   - This bypasses `allow_net`; if networking is enabled, host loopback
+     services are reachable from inside the box
 
 3. **External service:**
    - Both boxes connect to Redis/database on host or network

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -302,6 +302,28 @@ async with boxlite.SimpleBox(image="alpine:latest") as box:
     print(result.stdout)
 ```
 
+**From Box to Host Loopback:**
+
+```bash
+# On the host, start a service bound to loopback
+python3 -m http.server 8081 --bind 127.0.0.1
+```
+
+```python
+async with boxlite.SimpleBox(image="alpine:latest") as box:
+    result = await box.exec(
+        "wget",
+        "-O-",
+        "http://host.boxlite.internal:8081",
+    )
+    print(result.stdout)
+```
+
+`host.boxlite.internal` is a built-in BoxLite hostname that resolves to the
+host loopback proxy address. It is not a Docker compatibility alias.
+Security note: any service bound to host loopback is reachable from inside the
+box while networking is enabled.
+
 ### Network Metrics
 
 Monitor network usage:

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -135,6 +135,10 @@ Structured network configuration for outbound connectivity.
 - `"enabled"` gives the guest outbound connectivity.
 - `"disabled"` removes the guest network interface entirely.
 - Empty or omitted `allow_net` means full outbound access.
+- `host.boxlite.internal` is always available as a built-in hostname for
+  reaching host loopback services and is not governed by `allow_net`.
+- Security: when networking is enabled, any service bound to host loopback can
+  be reached from inside the box via `host.boxlite.internal` or `192.168.127.254`.
 
 **Supported patterns:**
 - Exact hostname: `"api.openai.com"`
@@ -307,6 +311,8 @@ ports=[
 - Host port must be available (not in use)
 - Multiple boxes can forward to same host port (error if conflict)
 - Supports both TCP and UDP protocols
+- Port mappings are only for host → box traffic. Use
+  `host.boxlite.internal:<port>` for box → host loopback traffic.
 
 #### `auto_remove: bool`
 

--- a/src/boxlite/src/net/constants.rs
+++ b/src/boxlite/src/net/constants.rs
@@ -13,6 +13,23 @@ pub const GATEWAY_IP: &str = "192.168.127.1";
 /// Guest IP address (assigned via DHCP static lease)
 pub const GUEST_IP: &str = "192.168.127.2";
 
+/// Built-in DNS label for reaching host loopback services from inside the box.
+pub const HOST_ALIAS_LABEL: &str = "host";
+
+/// Built-in DNS zone for reaching host loopback services from inside the box.
+pub const HOST_ALIAS_ZONE: &str = "boxlite.internal.";
+
+/// Built-in DNS hostname for reaching host loopback services from inside the box.
+pub const HOST_HOSTNAME: &str = "host.boxlite.internal";
+
+/// Virtual host IP address exposed inside the guest as the host endpoint.
+///
+/// gvproxy NATs traffic sent to this IP to `127.0.0.1` on the host.
+/// The built-in [`HOST_HOSTNAME`] alias resolves to this address.
+/// This destination is always allowed while networking is enabled, even when
+/// `allow_net` would otherwise restrict outbound traffic.
+pub const HOST_IP: &str = "192.168.127.254";
+
 /// Guest IP with subnet prefix (for static IP assignment in guest)
 pub const GUEST_CIDR: &str = "192.168.127.2/24";
 
@@ -74,5 +91,17 @@ mod tests {
         }
         assert_eq!(GUEST_MAC[5], 0xee);
         assert_eq!(GATEWAY_MAC[5], 0xdd);
+    }
+
+    #[test]
+    fn test_host_alias_components_match_hostname() {
+        assert_eq!(
+            HOST_HOSTNAME,
+            format!(
+                "{}.{}",
+                HOST_ALIAS_LABEL,
+                HOST_ALIAS_ZONE.trim_end_matches('.')
+            )
+        );
     }
 }

--- a/src/boxlite/src/net/gvproxy/config.rs
+++ b/src/boxlite/src/net/gvproxy/config.rs
@@ -7,12 +7,24 @@ use std::path::PathBuf;
 ///
 /// Defines local DNS records served by the gateway's embedded DNS server.
 /// Queries not matching any zone are forwarded to the host's system DNS.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DnsZone {
     /// Zone name (e.g., "myapp.local.", "." for root)
     pub name: String,
+    /// Exact A records within this zone.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub records: Vec<DnsRecord>,
     /// Default IP for unmatched queries in this zone
     pub default_ip: String,
+}
+
+/// Exact A record within a local DNS zone.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DnsRecord {
+    /// Record label within the zone (e.g., "host" in "boxlite.internal.")
+    pub name: String,
+    /// IPv4 address returned for this record
+    pub ip: String,
 }
 
 /// Port mapping configuration
@@ -45,6 +57,9 @@ pub struct GvproxyConfig {
 
     /// Guest IP address
     pub guest_ip: String,
+
+    /// Virtual host IP address that routes to host loopback services
+    pub host_ip: String,
 
     /// Guest MAC address
     pub guest_mac: String,
@@ -130,10 +145,11 @@ fn defaults_with_socket_path(socket_path: PathBuf) -> GvproxyConfig {
         gateway_ip: GATEWAY_IP.to_string(),
         gateway_mac: GATEWAY_MAC_STRING.to_string(),
         guest_ip: GUEST_IP.to_string(),
+        host_ip: HOST_IP.to_string(),
         guest_mac: GUEST_MAC_STRING.to_string(),
         mtu: DEFAULT_MTU,
         port_mappings: Vec::new(),
-        dns_zones: Vec::new(),
+        dns_zones: vec![boxlite_internal_dns_zone()],
         dns_search_domains: DNS_SEARCH_DOMAINS.iter().map(|s| s.to_string()).collect(),
         debug: false,
         capture_file: None,
@@ -141,6 +157,20 @@ fn defaults_with_socket_path(socket_path: PathBuf) -> GvproxyConfig {
         secrets: Vec::new(),
         ca_cert_pem: None,
         ca_key_pem: None,
+    }
+}
+
+fn boxlite_internal_dns_zone() -> DnsZone {
+    use crate::net::constants::{HOST_ALIAS_LABEL, HOST_ALIAS_ZONE, HOST_IP};
+
+    DnsZone {
+        name: HOST_ALIAS_ZONE.to_string(),
+        records: vec![DnsRecord {
+            name: HOST_ALIAS_LABEL.to_string(),
+            ip: HOST_IP.to_string(),
+        }],
+        // Empty default_ip means this zone only serves the exact `host` record.
+        default_ip: String::new(),
     }
 }
 
@@ -191,9 +221,11 @@ impl GvproxyConfig {
         self
     }
 
-    /// Set custom DNS zones
+    /// Add custom DNS zones after the built-in BoxLite zones.
+    ///
+    /// This method appends; repeated calls keep earlier zones in place.
     pub fn with_dns_zones(mut self, dns_zones: Vec<DnsZone>) -> Self {
-        self.dns_zones = dns_zones;
+        self.dns_zones.extend(dns_zones);
         self
     }
 
@@ -212,8 +244,9 @@ impl GvproxyConfig {
     ///
     /// ```no_run
     /// use boxlite::net::gvproxy::GvproxyConfig;
+    /// use std::path::PathBuf;
     ///
-    /// let config = GvproxyConfig::new(vec![(8080, 80)])
+    /// let config = GvproxyConfig::new(PathBuf::from("/tmp/network.sock"), vec![(8080, 80)])
     ///     .with_capture_file("/tmp/network.pcap".to_string());
     /// ```
     pub fn with_capture_file(mut self, capture_file: String) -> Self {
@@ -244,6 +277,7 @@ impl GvproxyConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::net::constants::{HOST_ALIAS_LABEL, HOST_ALIAS_ZONE, HOST_HOSTNAME, HOST_IP};
 
     fn test_socket_path() -> PathBuf {
         PathBuf::from("/tmp/test-gvproxy.sock")
@@ -256,9 +290,19 @@ mod tests {
         assert_eq!(config.subnet, "192.168.127.0/24");
         assert_eq!(config.gateway_ip, "192.168.127.1");
         assert_eq!(config.guest_ip, "192.168.127.2");
+        assert_eq!(config.host_ip, HOST_IP);
         assert_eq!(config.mtu, 1500);
         assert!(!config.debug);
-        assert!(config.dns_zones.is_empty());
+        assert_eq!(config.dns_zones.len(), 1);
+        assert_eq!(config.dns_zones[0].name, HOST_ALIAS_ZONE);
+        assert_eq!(
+            config.dns_zones[0].records,
+            vec![DnsRecord {
+                name: HOST_ALIAS_LABEL.to_string(),
+                ip: HOST_IP.to_string(),
+            }]
+        );
+        assert!(config.dns_zones[0].default_ip.is_empty());
     }
 
     #[test]
@@ -286,7 +330,9 @@ mod tests {
         let deserialized: GvproxyConfig = serde_json::from_str(&json).unwrap();
         assert_eq!(config.subnet, deserialized.subnet);
         assert_eq!(config.socket_path, deserialized.socket_path);
+        assert_eq!(config.host_ip, deserialized.host_ip);
         assert_eq!(config.port_mappings.len(), deserialized.port_mappings.len());
+        assert_eq!(config.dns_zones, deserialized.dns_zones);
     }
 
     #[test]
@@ -452,5 +498,66 @@ mod tests {
             "Two configs with different socket paths must produce different JSON"
         );
         assert_ne!(config_a.socket_path, config_b.socket_path);
+    }
+
+    #[test]
+    fn test_with_dns_zones_preserves_builtin_host_alias() {
+        let config = GvproxyConfig::new(test_socket_path(), vec![]).with_dns_zones(vec![DnsZone {
+            name: "example.internal.".to_string(),
+            records: vec![DnsRecord {
+                name: "api".to_string(),
+                ip: "192.168.127.10".to_string(),
+            }],
+            default_ip: String::new(),
+        }]);
+
+        assert_eq!(config.dns_zones.len(), 2);
+        assert_eq!(config.dns_zones[0].name, HOST_ALIAS_ZONE);
+        assert_eq!(config.dns_zones[1].name, "example.internal.");
+    }
+
+    #[test]
+    fn test_with_dns_zones_appends_across_multiple_calls() {
+        let config = GvproxyConfig::new(test_socket_path(), vec![])
+            .with_dns_zones(vec![DnsZone {
+                name: "one.internal.".to_string(),
+                records: vec![],
+                default_ip: "192.168.127.10".to_string(),
+            }])
+            .with_dns_zones(vec![DnsZone {
+                name: "two.internal.".to_string(),
+                records: vec![],
+                default_ip: "192.168.127.11".to_string(),
+            }]);
+
+        assert_eq!(config.dns_zones.len(), 3);
+        assert_eq!(config.dns_zones[0].name, HOST_ALIAS_ZONE);
+        assert_eq!(config.dns_zones[1].name, "one.internal.");
+        assert_eq!(config.dns_zones[2].name, "two.internal.");
+    }
+
+    #[test]
+    fn test_serialization_contains_host_alias_record() {
+        let config = GvproxyConfig::new(test_socket_path(), vec![]);
+        let json = serde_json::to_string(&config).unwrap();
+
+        assert!(json.contains(&format!("\"host_ip\":\"{HOST_IP}\"")));
+        assert!(json.contains(&format!("\"name\":\"{HOST_ALIAS_ZONE}\"")));
+        assert!(json.contains("\"records\""));
+        assert!(json.contains(&format!("\"name\":\"{HOST_ALIAS_LABEL}\"")));
+        assert!(json.contains(&format!("\"ip\":\"{HOST_IP}\"")));
+    }
+
+    #[test]
+    fn test_host_hostname_matches_built_in_zone() {
+        let zone = boxlite_internal_dns_zone();
+        let record = zone.records.first().expect("built-in host alias record");
+
+        assert_eq!(zone.name, HOST_ALIAS_ZONE);
+        assert_eq!(record.name, HOST_ALIAS_LABEL);
+        assert_eq!(
+            HOST_HOSTNAME,
+            format!("{}.{}", record.name, zone.name.trim_end_matches('.'))
+        );
     }
 }

--- a/src/boxlite/src/net/gvproxy/instance.rs
+++ b/src/boxlite/src/net/gvproxy/instance.rs
@@ -38,20 +38,10 @@ use super::stats::NetworkStats;
 ///
 /// ## Example
 ///
-/// ```no_run
-/// use boxlite::net::gvproxy::GvproxyInstance;
-/// use std::path::PathBuf;
-///
-/// // Create instance with caller-provided socket path
-/// let socket_path = PathBuf::from("/tmp/my-box/net.sock");
-/// let instance = GvproxyInstance::new(socket_path, &[(8080, 80), (8443, 443)], vec![], vec![], None, None)?;
-///
-/// // Socket path is known from creation — no FFI call needed
-/// println!("Socket: {:?}", instance.socket_path());
-///
-/// // Instance is automatically cleaned up when dropped
-/// # Ok::<(), boxlite_shared::errors::BoxliteError>(())
-/// ```
+/// `GvproxyInstance` is created internally by BoxLite's gvproxy backend during
+/// box startup. Once initialized, the instance exposes its socket path via
+/// [`GvproxyInstance::socket_path`] and automatically destroys the underlying
+/// gvproxy handle on drop.
 #[derive(Debug)]
 pub struct GvproxyInstance {
     id: i64,
@@ -146,26 +136,8 @@ impl GvproxyInstance {
     /// - VirtualNetwork not initialized yet (too early)
     /// - JSON parsing failed
     ///
-    /// # Example
-    ///
-    /// ```no_run
-    /// use boxlite::net::gvproxy::GvproxyInstance;
-    ///
-    /// let instance = GvproxyInstance::new(path, &[(8080, 80)], vec![], vec![])?;
-    /// let stats = instance.get_stats()?;
-    ///
-    /// // Check for packet drops due to maxInFlight limit
-    /// if stats.tcp.forward_max_inflight_drop > 0 {
-    ///     tracing::warn!(
-    ///         drops = stats.tcp.forward_max_inflight_drop,
-    ///         "Connections dropped - consider increasing maxInFlight"
-    ///     );
-    /// }
-    ///
-    /// println!("Sent: {} bytes, Received: {} bytes",
-    ///     stats.bytes_sent, stats.bytes_received);
-    /// # Ok::<(), boxlite_shared::errors::BoxliteError>(())
-    /// ```
+    /// Call this on an existing gvproxy instance to inspect bandwidth counters
+    /// and debugging metrics such as `forward_max_inflight_drop`.
     pub fn get_stats(&self) -> BoxliteResult<NetworkStats> {
         // Get JSON from FFI layer
         let json_str = ffi::get_stats_json(self.id)?;

--- a/src/boxlite/src/net/gvproxy/mod.rs
+++ b/src/boxlite/src/net/gvproxy/mod.rs
@@ -82,7 +82,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 // Re-export public API
-pub use config::{DnsZone, GvproxyConfig, GvproxySecretConfig, PortMapping};
+pub use config::{DnsRecord, DnsZone, GvproxyConfig, GvproxySecretConfig, PortMapping};
 pub use instance::GvproxyInstance;
 pub use logging::init_logging;
 pub use stats::{NetworkStats, TcpStats};

--- a/src/boxlite/tests/network_spec.rs
+++ b/src/boxlite/tests/network_spec.rs
@@ -2,9 +2,15 @@
 
 mod common;
 
+use boxlite::net::constants::{HOST_HOSTNAME, HOST_IP};
 use boxlite::runtime::options::{BoxOptions, BoxliteOptions, NetworkSpec};
 use boxlite::{BoxCommand, BoxliteRuntime};
 use futures::StreamExt;
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, Instant};
 
 #[test]
 fn default_is_enabled_with_empty_allowlist() {
@@ -137,6 +143,86 @@ async fn run_exit_code(litebox: &boxlite::LiteBox, cmd: &str, args: &[&str]) -> 
         .await
         .unwrap();
     ex.wait().await.unwrap().exit_code
+}
+
+fn wget_url_command(url: &str) -> String {
+    format!("wget -O- --timeout=5 {url} 2>&1; printf '\\nEXIT:%s\\n' $?")
+}
+
+fn start_host_http_server(response_body: &'static str) -> (u16, thread::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind host test server");
+    listener
+        .set_nonblocking(true)
+        .expect("set host test server nonblocking");
+    let port = listener.local_addr().expect("host test server addr").port();
+
+    let handle = thread::spawn(move || {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        let (mut stream, _) = loop {
+            match listener.accept() {
+                Ok(conn) => break conn,
+                Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                    assert!(
+                        Instant::now() < deadline,
+                        "timed out waiting for host test server connection"
+                    );
+                    thread::yield_now();
+                }
+                Err(err) => panic!("accept host test server: {err}"),
+            }
+        };
+        let mut request_buf = [0_u8; 1024];
+        // We only care that wget opened the connection; the request body is irrelevant.
+        let _ = stream.read(&mut request_buf);
+
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            response_body.len(),
+            response_body
+        );
+        stream
+            .write_all(response.as_bytes())
+            .expect("write host test server response");
+    });
+
+    (port, handle)
+}
+
+fn start_host_http_server_expect_no_connection() -> (u16, mpsc::Sender<()>, thread::JoinHandle<()>)
+{
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind host negative test server");
+    listener
+        .set_nonblocking(true)
+        .expect("set host negative test server nonblocking");
+    let port = listener
+        .local_addr()
+        .expect("host negative test server addr")
+        .port();
+    let (stop_tx, stop_rx) = mpsc::channel();
+
+    let handle = thread::spawn(move || {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            match listener.accept() {
+                Ok((_, addr)) => panic!("expected no host test server connection, got {addr}"),
+                Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                    match stop_rx.try_recv() {
+                        Ok(()) | Err(mpsc::TryRecvError::Disconnected) => break,
+                        Err(mpsc::TryRecvError::Empty) => {}
+                    }
+
+                    assert!(
+                        Instant::now() < deadline,
+                        "negative server deadline exceeded before stop signal"
+                    );
+                    thread::yield_now();
+                }
+                Err(err) => panic!("accept host negative test server: {err}"),
+            }
+        }
+    });
+
+    (port, stop_tx, handle)
 }
 
 #[tokio::test]
@@ -294,5 +380,130 @@ async fn tcp_filter_sni_allows_https_to_allowed_host() {
         "HTTPS to allowed host should work via SNI match, got empty output"
     );
 
+    litebox.stop().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore = "requires VM runtime (run with make test)"]
+async fn host_alias_resolves_to_dedicated_host_ip() {
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .unwrap();
+
+    let litebox = runtime.create(common::alpine_opts(), None).await.unwrap();
+    litebox.start().await.unwrap();
+
+    let out = run_stdout(&litebox, "nslookup", &[HOST_HOSTNAME]).await;
+    assert!(
+        out.contains(HOST_IP),
+        "host alias should resolve to the dedicated host IP, got: {out}"
+    );
+
+    litebox.stop().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore = "requires VM runtime (run with make test)"]
+async fn host_alias_reaches_host_loopback_service() {
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .unwrap();
+
+    let litebox = runtime.create(common::alpine_opts(), None).await.unwrap();
+    litebox.start().await.unwrap();
+
+    let (port, server) = start_host_http_server("boxlite-host-alias");
+    let command = wget_url_command(&format!("http://{HOST_HOSTNAME}:{port}/"));
+    let out = run_stdout(&litebox, "sh", &["-c", &command]).await;
+
+    assert!(
+        out.contains("boxlite-host-alias"),
+        "host alias should reach host loopback service, got: {out}"
+    );
+
+    server.join().unwrap();
+    litebox.stop().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore = "requires VM runtime (run with make test)"]
+async fn host_alias_reaches_host_loopback_service_with_restrictive_allowlist() {
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .unwrap();
+
+    let opts = BoxOptions {
+        network: NetworkSpec::Enabled {
+            allow_net: vec!["example.com".into()],
+        },
+        ..common::alpine_opts()
+    };
+
+    let litebox = runtime.create(opts, None).await.unwrap();
+    litebox.start().await.unwrap();
+
+    let nslookup = run_stdout(&litebox, "nslookup", &[HOST_HOSTNAME]).await;
+    assert!(
+        nslookup.contains(HOST_IP),
+        "host alias should still resolve under restrictive allowlist, got: {nslookup}"
+    );
+
+    let (port, server) = start_host_http_server("boxlite-host-alias-allowlist");
+    let command = wget_url_command(&format!("http://{HOST_HOSTNAME}:{port}/"));
+    let out = run_stdout(&litebox, "sh", &["-c", &command]).await;
+
+    assert!(
+        out.contains("boxlite-host-alias-allowlist"),
+        "host alias should bypass allowlist filtering for internal host access, got: {out}"
+    );
+
+    server.join().unwrap();
+    litebox.stop().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore = "requires VM runtime (run with make test)"]
+async fn disabled_network_cannot_reach_host_virtual_ip() {
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .unwrap();
+
+    let opts = BoxOptions {
+        network: NetworkSpec::Disabled,
+        ..common::alpine_opts()
+    };
+
+    let litebox = runtime.create(opts, None).await.unwrap();
+    litebox.start().await.unwrap();
+
+    let no_eth0 = run_exit_code(&litebox, "sh", &["-c", "test ! -e /sys/class/net/eth0"]).await;
+    assert_eq!(
+        no_eth0, 0,
+        "disabled network should remove eth0 entirely, got exit code {no_eth0}"
+    );
+
+    let (port, stop_server, server) = start_host_http_server_expect_no_connection();
+    let command = wget_url_command(&format!("http://{HOST_IP}:{port}/"));
+    let out = run_stdout(&litebox, "sh", &["-c", &command]).await;
+
+    assert!(
+        out.contains("EXIT:") && !out.contains("EXIT:0"),
+        "host virtual IP should be unreachable with network disabled, got: {out}"
+    );
+
+    let _ = stop_server.send(());
+    server.join().unwrap();
     litebox.stop().await.unwrap();
 }

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/config_build_test.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/config_build_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"net"
+	"testing"
+
+	"github.com/containers/gvisor-tap-vsock/pkg/types"
+)
+
+func testGvproxyConfig() GvproxyConfig {
+	return GvproxyConfig{
+		SocketPath: "/tmp/test-gvproxy.sock",
+		Subnet:     "192.168.127.0/24",
+		GatewayIP:  "192.168.127.1",
+		GatewayMac: "5a:94:ef:e4:0c:dd",
+		GuestIP:    "192.168.127.2",
+		HostIP:     "192.168.127.254",
+		GuestMac:   "5a:94:ef:e4:0c:ee",
+		MTU:        1500,
+		DNSZones: []DNSZone{
+			{
+				Name: "boxlite.internal.",
+				Records: []DNSRecord{
+					{
+						Name: "host",
+						IP:   "192.168.127.254",
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestBuildTapConfig_UsesHostAliasDNSZone(t *testing.T) {
+	tapConfig := buildTapConfig(testGvproxyConfig(), types.QemuProtocol)
+
+	if len(tapConfig.DNS) == 0 {
+		t.Fatal("expected at least one DNS zone")
+	}
+
+	zone := tapConfig.DNS[0]
+	if zone.Name != "boxlite.internal." {
+		t.Fatalf("expected first DNS zone to be boxlite.internal., got %q", zone.Name)
+	}
+	if len(zone.Records) != 1 {
+		t.Fatalf("expected one DNS record, got %d", len(zone.Records))
+	}
+	if zone.Records[0].Name != "host" {
+		t.Fatalf("expected host record, got %q", zone.Records[0].Name)
+	}
+	if !zone.Records[0].IP.Equal(net.ParseIP("192.168.127.254")) {
+		t.Fatalf("expected host alias to resolve to 192.168.127.254, got %v", zone.Records[0].IP)
+	}
+}
+
+func TestBuildTapConfig_KeepsBuiltinZonesBeforeAllowNet(t *testing.T) {
+	config := testGvproxyConfig()
+	config.AllowNet = []string{"example.com"}
+
+	tapConfig := buildTapConfig(config, types.QemuProtocol)
+
+	if len(tapConfig.DNS) < 2 {
+		t.Fatalf("expected built-in and allowlist DNS zones, got %d", len(tapConfig.DNS))
+	}
+	if tapConfig.DNS[0].Name != "boxlite.internal." {
+		t.Fatalf("expected built-in zone first, got %q", tapConfig.DNS[0].Name)
+	}
+	lastZone := tapConfig.DNS[len(tapConfig.DNS)-1]
+	if lastZone.Name != "" {
+		t.Fatalf("expected allowlist root sinkhole zone last, got %q", lastZone.Name)
+	}
+}
+
+func TestBuildTapConfig_RoutesHostAliasToLoopback(t *testing.T) {
+	tapConfig := buildTapConfig(testGvproxyConfig(), types.QemuProtocol)
+
+	if got := tapConfig.NAT["192.168.127.254"]; got != "127.0.0.1" {
+		t.Fatalf("expected host IP NAT to loopback, got %q", got)
+	}
+
+	foundHostIP := false
+	for _, ip := range tapConfig.GatewayVirtualIPs {
+		if ip == "192.168.127.254" {
+			foundHostIP = true
+			break
+		}
+	}
+	if !foundHostIP {
+		t.Fatal("expected host IP in GatewayVirtualIPs")
+	}
+}

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/forked_tcp.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/forked_tcp.go
@@ -80,6 +80,21 @@ func decideTCPRoute(destIP net.IP, destPort uint16, filter *TCPFilter, secretMat
 	return tcpRouteBlock
 }
 
+func resolveTCPDestination(localAddress tcpip.Address, nat map[tcpip.Address]tcpip.Address,
+	natLock *sync.Mutex) (net.IP, tcpip.Address) {
+	policyAddress := localAddress
+	dialAddress := localAddress
+
+	natLock.Lock()
+	if replaced, ok := nat[localAddress]; ok {
+		dialAddress = replaced
+	}
+	natLock.Unlock()
+
+	addr4 := policyAddress.As4()
+	return net.IP(addr4[:]), dialAddress
+}
+
 func TCPWithFilter(s *stack.Stack, nat map[tcpip.Address]tcpip.Address,
 	natLock *sync.Mutex, ec2MetadataAccess bool, filter *TCPFilter,
 	ca *BoxCA, secretMatcher *SecretHostMatcher) *tcp.Forwarder {
@@ -92,17 +107,11 @@ func TCPWithFilter(s *stack.Stack, nat map[tcpip.Address]tcpip.Address,
 			return
 		}
 
-		// NAT translation
-		natLock.Lock()
-		if replaced, ok := nat[localAddress]; ok {
-			localAddress = replaced
-		}
-		natLock.Unlock()
-
-		addr4 := localAddress.As4()
-		destIP := net.IP(addr4[:])
+		// Policy checks must see the pre-NAT destination (for example the host alias IP),
+		// while the actual outbound dial uses any NAT-translated address (for example 127.0.0.1).
+		destIP, dialAddress := resolveTCPDestination(localAddress, nat, natLock)
 		destPort := r.ID().LocalPort
-		destAddr := fmt.Sprintf("%s:%d", localAddress, destPort)
+		destAddr := fmt.Sprintf("%s:%d", dialAddress, destPort)
 
 		switch decideTCPRoute(destIP, destPort, filter, secretMatcher) {
 		case tcpRouteStandardForward:

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/forked_tcp_test.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/forked_tcp_test.go
@@ -133,7 +133,7 @@ func TestMitmRouting_AllowlistAndSecrets_MitmPriority(t *testing.T) {
 	matcher := NewSecretHostMatcher(secrets)
 
 	// Also create an allowlist filter that includes the same host
-	filter := NewTCPFilter([]string{"api.example.com"}, "192.168.127.1", "192.168.127.2")
+	filter := NewTCPFilter([]string{"api.example.com"}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
 
 	// Both should match
 	if !matcher.Matches("api.example.com") {

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/main.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/main.go
@@ -164,46 +164,108 @@ type PortMapping struct {
 	GuestPort uint16 `json:"guest_port"`
 }
 
+// DNSRecord represents an exact A record within a local DNS zone.
+type DNSRecord struct {
+	Name string `json:"name"`
+	IP   string `json:"ip"`
+}
+
 // DNSZone represents a local DNS zone configuration
 // These are local DNS records served by the gateway's embedded DNS server.
 // Queries not matching any zone are forwarded to the host's system DNS.
 type DNSZone struct {
-	Name      string `json:"name"`       // Zone name (e.g., "myapp.local.", "." for root)
-	DefaultIP string `json:"default_ip"` // Default IP for unmatched queries in this zone
+	Name      string      `json:"name"`              // Zone name (e.g., "myapp.local.", "." for root)
+	Records   []DNSRecord `json:"records,omitempty"` // Exact A records within the zone
+	DefaultIP string      `json:"default_ip"`        // Default IP for unmatched queries in this zone
 }
 
 // GvproxyConfig matches the Rust structure (must stay in sync!)
 type GvproxyConfig struct {
-	SocketPath       string        `json:"socket_path"`
-	Subnet           string        `json:"subnet"`
-	GatewayIP        string        `json:"gateway_ip"`
-	GatewayMac       string        `json:"gateway_mac"`
-	GuestIP          string        `json:"guest_ip"`
-	GuestMac         string        `json:"guest_mac"`
-	MTU              uint16        `json:"mtu"`
-	PortMappings     []PortMapping `json:"port_mappings"`
-	DNSZones         []DNSZone     `json:"dns_zones"`
-	DNSSearchDomains []string      `json:"dns_search_domains"`
-	Debug       bool     `json:"debug"`
-	CaptureFile *string  `json:"capture_file,omitempty"`
-	AllowNet    []string       `json:"allow_net,omitempty"`
-	Secrets     []SecretConfig `json:"secrets,omitempty"`
-	CACertPEM   string         `json:"ca_cert_pem,omitempty"`
-	CAKeyPEM    string         `json:"ca_key_pem,omitempty"`
+	SocketPath       string         `json:"socket_path"`
+	Subnet           string         `json:"subnet"`
+	GatewayIP        string         `json:"gateway_ip"`
+	GatewayMac       string         `json:"gateway_mac"`
+	GuestIP          string         `json:"guest_ip"`
+	HostIP           string         `json:"host_ip"`
+	GuestMac         string         `json:"guest_mac"`
+	MTU              uint16         `json:"mtu"`
+	PortMappings     []PortMapping  `json:"port_mappings"`
+	DNSZones         []DNSZone      `json:"dns_zones"`
+	DNSSearchDomains []string       `json:"dns_search_domains"`
+	Debug            bool           `json:"debug"`
+	CaptureFile      *string        `json:"capture_file,omitempty"`
+	AllowNet         []string       `json:"allow_net,omitempty"`
+	Secrets          []SecretConfig `json:"secrets,omitempty"`
+	CACertPEM        string         `json:"ca_cert_pem,omitempty"`
+	CAKeyPEM         string         `json:"ca_key_pem,omitempty"`
 }
 
 // GvproxyInstance tracks a running gvisor-tap-vsock instance
 type GvproxyInstance struct {
-	ID         int64
-	SocketPath string
-	Config     *types.Configuration
-	Cancel     context.CancelFunc
-	conn       net.Conn                       // For macOS UnixDgram (VFKit)
-	listener   net.Listener                   // For Linux UnixStream (Qemu)
+	ID            int64
+	SocketPath    string
+	Config        *types.Configuration
+	Cancel        context.CancelFunc
+	conn          net.Conn                       // For macOS UnixDgram (VFKit)
+	listener      net.Listener                   // For Linux UnixStream (Qemu)
 	vn            *virtualnetwork.VirtualNetwork // Virtual network for stats collection
 	vnMu          sync.RWMutex                   // Protects vn field
 	ca            *BoxCA                         // Ephemeral MITM CA (nil if no secrets)
-	secretMatcher *SecretHostMatcher              // Hostname→secrets lookup (nil if no secrets)
+	secretMatcher *SecretHostMatcher             // Hostname→secrets lookup (nil if no secrets)
+}
+
+func buildDNSZones(config GvproxyConfig) []types.Zone {
+	dnsZones := make([]types.Zone, 0, len(config.DNSZones)+1)
+	for _, zone := range config.DNSZones {
+		dnsZone := types.Zone{
+			Name:      zone.Name,
+			DefaultIP: net.ParseIP(zone.DefaultIP),
+		}
+		for _, record := range zone.Records {
+			dnsZone.Records = append(dnsZone.Records, types.Record{
+				Name: record.Name,
+				IP:   net.ParseIP(record.IP),
+			})
+		}
+		dnsZones = append(dnsZones, dnsZone)
+	}
+
+	if len(config.AllowNet) > 0 {
+		allowNetZones := buildAllowNetDNSZones(config.AllowNet)
+		dnsZones = append(dnsZones, allowNetZones...)
+		logrus.WithField("rules", len(config.AllowNet)).Info("Network allowlist enabled (DNS sinkhole)")
+	}
+
+	return dnsZones
+}
+
+func buildTapConfig(config GvproxyConfig, protocol types.Protocol) *types.Configuration {
+	nat := make(map[string]string)
+	gatewayVirtualIPs := []string{config.GatewayIP}
+	if config.HostIP != "" {
+		nat[config.HostIP] = "127.0.0.1"
+		if config.HostIP != config.GatewayIP {
+			gatewayVirtualIPs = append(gatewayVirtualIPs, config.HostIP)
+		}
+	}
+
+	return &types.Configuration{
+		Debug:             config.Debug,
+		MTU:               int(config.MTU),
+		Subnet:            config.Subnet,
+		GatewayIP:         config.GatewayIP,
+		GatewayMacAddress: config.GatewayMac,
+		DHCPStaticLeases: map[string]string{
+			config.GuestIP: config.GuestMac,
+		},
+		Forwards:          make(map[string]string),
+		NAT:               nat,
+		GatewayVirtualIPs: gatewayVirtualIPs,
+		Protocol:          protocol,
+		DNS:               buildDNSZones(config),
+		DNSSearchDomains:  config.DNSSearchDomains,
+		CaptureFile:       "",
+	}
 }
 
 var (
@@ -247,42 +309,8 @@ func gvproxy_create(configJSON *C.char) C.longlong {
 		protocol = types.QemuProtocol
 	}
 
-	// Build DNS zones from config
-	// These are local DNS records - queries not matching any zone are forwarded to host DNS
-	dnsZones := make([]types.Zone, len(config.DNSZones))
-	for i, zone := range config.DNSZones {
-		dnsZones[i] = types.Zone{
-			Name:      zone.Name,
-			DefaultIP: net.ParseIP(zone.DefaultIP),
-		}
-	}
-
-	// Build DNS allowlist zones when AllowNet is configured
-	if len(config.AllowNet) > 0 {
-		allowNetZones := buildAllowNetDNSZones(config.AllowNet)
-		dnsZones = append(allowNetZones, dnsZones...)
-		logrus.WithField("rules", len(config.AllowNet)).Info("Network allowlist enabled (DNS sinkhole)")
-	}
-
 	// Create gvisor-tap-vsock configuration from provided config
-	tapConfig := &types.Configuration{
-		Debug:             config.Debug,
-		MTU:               int(config.MTU),
-		Subnet:            config.Subnet,
-		GatewayIP:         config.GatewayIP,
-		GatewayMacAddress: config.GatewayMac,
-		DHCPStaticLeases: map[string]string{
-			config.GuestIP: config.GuestMac,
-		},
-		Forwards: make(map[string]string),
-		NAT: map[string]string{
-			config.GuestIP: "127.0.0.1",
-		},
-		GatewayVirtualIPs: []string{config.GatewayIP},
-		Protocol:          protocol,
-		DNS:               dnsZones,
-		DNSSearchDomains:  config.DNSSearchDomains,
-	}
+	tapConfig := buildTapConfig(config, protocol)
 
 	// Set CaptureFile if provided
 	if config.CaptureFile != nil && *config.CaptureFile != "" {
@@ -393,7 +421,7 @@ func gvproxy_create(configJSON *C.char) C.longlong {
 		if len(config.AllowNet) > 0 || instance.secretMatcher != nil {
 			var tcpFilter *TCPFilter
 			if len(config.AllowNet) > 0 {
-				tcpFilter = NewTCPFilter(config.AllowNet, config.GatewayIP, config.GuestIP)
+				tcpFilter = NewTCPFilter(config.AllowNet, config.GatewayIP, config.GuestIP, config.HostIP)
 			}
 			if err := OverrideTCPHandler(vn, tapConfig, tapConfig.Ec2MetadataAccess, tcpFilter, instance.ca, instance.secretMatcher); err != nil {
 				logrus.WithError(err).Error("TCP: failed to override handler")

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/tcp_filter.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/tcp_filter.go
@@ -18,7 +18,7 @@ import (
 type TCPFilter struct {
 	exactIPs         map[[4]byte]bool
 	cidrs            []*net.IPNet
-	alwaysAllow      map[[4]byte]bool // gateway + guest IPs
+	alwaysAllow      map[[4]byte]bool // internal IPs that should never be filtered
 	exactHosts       map[string]bool  // "api.openai.com" → true
 	wildcardSuffixes []string         // ".example.com"
 	hasHostnameRules bool
@@ -26,7 +26,7 @@ type TCPFilter struct {
 
 // NewTCPFilter parses allow_net rules into IP/CIDR and hostname categories.
 // Returns nil if rules is empty (zero overhead fast path).
-func NewTCPFilter(rules []string, gatewayIP, guestIP string) *TCPFilter {
+func NewTCPFilter(rules []string, internalIPs ...string) *TCPFilter {
 	if len(rules) == 0 {
 		return nil
 	}
@@ -38,7 +38,10 @@ func NewTCPFilter(rules []string, gatewayIP, guestIP string) *TCPFilter {
 	}
 
 	// Internal IPs always allowed
-	for _, ipStr := range []string{gatewayIP, guestIP} {
+	for _, ipStr := range internalIPs {
+		if ipStr == "" {
+			continue
+		}
 		if parsed := net.ParseIP(ipStr); parsed != nil {
 			if ip4 := parsed.To4(); ip4 != nil {
 				f.alwaysAllow[toIPv4Key(ip4)] = true

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/tcp_filter_test.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/tcp_filter_test.go
@@ -2,38 +2,42 @@ package main
 
 import (
 	"net"
+	"sync"
 	"testing"
+
+	"gvisor.dev/gvisor/pkg/tcpip"
 )
 
 func TestTCPFilter_ExactIP(t *testing.T) {
-	f := NewTCPFilter([]string{"1.2.3.4", "5.6.7.8"}, "192.168.127.1", "192.168.127.2")
+	f := NewTCPFilter([]string{"1.2.3.4", "5.6.7.8"}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
 	assertTrue(t, f.MatchesIP(net.ParseIP("1.2.3.4")), "1.2.3.4 allowed")
 	assertTrue(t, f.MatchesIP(net.ParseIP("5.6.7.8")), "5.6.7.8 allowed")
 	assertFalse(t, f.MatchesIP(net.ParseIP("9.9.9.9")), "9.9.9.9 blocked")
 }
 
 func TestTCPFilter_CIDR(t *testing.T) {
-	f := NewTCPFilter([]string{"10.0.0.0/8"}, "192.168.127.1", "192.168.127.2")
+	f := NewTCPFilter([]string{"10.0.0.0/8"}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
 	assertTrue(t, f.MatchesIP(net.ParseIP("10.1.2.3")), "in range")
 	assertTrue(t, f.MatchesIP(net.ParseIP("10.255.255.255")), "end of range")
 	assertFalse(t, f.MatchesIP(net.ParseIP("11.0.0.1")), "out of range")
 }
 
 func TestTCPFilter_InternalIPsAlwaysAllowed(t *testing.T) {
-	f := NewTCPFilter([]string{"1.2.3.4"}, "192.168.127.1", "192.168.127.2")
+	f := NewTCPFilter([]string{"1.2.3.4"}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
 	assertTrue(t, f.MatchesIP(net.ParseIP("192.168.127.1")), "gateway always allowed")
 	assertTrue(t, f.MatchesIP(net.ParseIP("192.168.127.2")), "guest always allowed")
+	assertTrue(t, f.MatchesIP(net.ParseIP("192.168.127.254")), "host alias IP always allowed")
 }
 
 func TestTCPFilter_NilWhenEmpty(t *testing.T) {
-	f := NewTCPFilter([]string{}, "192.168.127.1", "192.168.127.2")
+	f := NewTCPFilter([]string{}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
 	if f != nil {
 		t.Error("empty rules should return nil filter")
 	}
 }
 
 func TestTCPFilter_ExactHostname(t *testing.T) {
-	f := NewTCPFilter([]string{"api.openai.com"}, "192.168.127.1", "192.168.127.2")
+	f := NewTCPFilter([]string{"api.openai.com"}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
 	assertTrue(t, f.MatchesHostname("api.openai.com"), "exact match")
 	assertTrue(t, f.MatchesHostname("API.OPENAI.COM"), "case insensitive")
 	assertFalse(t, f.MatchesHostname("evil.com"), "not in list")
@@ -42,7 +46,7 @@ func TestTCPFilter_ExactHostname(t *testing.T) {
 }
 
 func TestTCPFilter_Wildcard(t *testing.T) {
-	f := NewTCPFilter([]string{"*.example.com"}, "192.168.127.1", "192.168.127.2")
+	f := NewTCPFilter([]string{"*.example.com"}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
 	assertTrue(t, f.MatchesHostname("api.example.com"), "subdomain matched")
 	assertTrue(t, f.MatchesHostname("deep.sub.example.com"), "deep subdomain matched")
 	assertFalse(t, f.MatchesHostname("example.com"), "base domain not matched by wildcard")
@@ -50,7 +54,7 @@ func TestTCPFilter_Wildcard(t *testing.T) {
 }
 
 func TestTCPFilter_IPOnlyNoHostnameRules(t *testing.T) {
-	f := NewTCPFilter([]string{"1.2.3.4", "10.0.0.0/8"}, "192.168.127.1", "192.168.127.2")
+	f := NewTCPFilter([]string{"1.2.3.4", "10.0.0.0/8"}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
 	assertFalse(t, f.HasHostnameRules(), "IP-only rules have no hostname rules")
 }
 
@@ -60,7 +64,7 @@ func TestTCPFilter_MixedRules(t *testing.T) {
 		"10.0.0.0/8",
 		"api.openai.com",
 		"*.anthropic.com",
-	}, "192.168.127.1", "192.168.127.2")
+	}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
 	assertTrue(t, f.MatchesIP(net.ParseIP("1.2.3.4")), "exact IP")
 	assertTrue(t, f.MatchesIP(net.ParseIP("10.50.0.1")), "CIDR")
 	assertTrue(t, f.MatchesHostname("api.openai.com"), "exact hostname")
@@ -69,23 +73,23 @@ func TestTCPFilter_MixedRules(t *testing.T) {
 }
 
 func TestTCPFilter_TrailingDotStripped(t *testing.T) {
-	f := NewTCPFilter([]string{"api.openai.com"}, "192.168.127.1", "192.168.127.2")
+	f := NewTCPFilter([]string{"api.openai.com"}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
 	assertTrue(t, f.MatchesHostname("api.openai.com."), "trailing dot stripped")
 }
 
 func TestTCPFilter_HostWithPort(t *testing.T) {
-	f := NewTCPFilter([]string{"api.openai.com:443"}, "192.168.127.1", "192.168.127.2")
+	f := NewTCPFilter([]string{"api.openai.com:443"}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
 	assertTrue(t, f.MatchesHostname("api.openai.com"), "port stripped from rule")
 	assertTrue(t, f.HasHostnameRules(), "should have hostname rules")
 }
 
 func TestTCPFilter_EmptyHostname(t *testing.T) {
-	f := NewTCPFilter([]string{"api.openai.com"}, "192.168.127.1", "192.168.127.2")
+	f := NewTCPFilter([]string{"api.openai.com"}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
 	assertFalse(t, f.MatchesHostname(""), "empty hostname never matches")
 }
 
 func TestDecideTCPRoute_CIDRUsesStandardForward(t *testing.T) {
-	f := NewTCPFilter([]string{"104.18.26.0/24"}, "192.168.127.1", "192.168.127.2")
+	f := NewTCPFilter([]string{"104.18.26.0/24"}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
 
 	inRange := net.IP([]byte{104, 18, 26, 120})
 	if got := decideTCPRoute(inRange, 80, f, nil); got != tcpRouteStandardForward {
@@ -95,6 +99,30 @@ func TestDecideTCPRoute_CIDRUsesStandardForward(t *testing.T) {
 	outOfRange := net.IP([]byte{104, 18, 3, 24})
 	if got := decideTCPRoute(outOfRange, 80, f, nil); got != tcpRouteBlock {
 		t.Fatalf("expected out-of-range CIDR traffic to block, got %v", got)
+	}
+}
+
+func TestResolveTCPDestination_HostAliasUsesPreNATIPForPolicy(t *testing.T) {
+	filter := NewTCPFilter([]string{"example.com"}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
+	hostAlias := tcpip.AddrFrom4Slice(net.ParseIP("192.168.127.254").To4())
+	loopback := tcpip.AddrFrom4Slice(net.ParseIP("127.0.0.1").To4())
+	nat := map[tcpip.Address]tcpip.Address{
+		hostAlias: loopback,
+	}
+
+	policyIP, dialAddress := resolveTCPDestination(hostAlias, nat, &sync.Mutex{})
+
+	if !policyIP.Equal(net.ParseIP("192.168.127.254")) {
+		t.Fatalf("expected policy IP to remain host alias, got %v", policyIP)
+	}
+	if got := decideTCPRoute(policyIP, 80, filter, nil); got != tcpRouteStandardForward {
+		t.Fatalf("expected host alias policy check to bypass hostname filtering, got %v", got)
+	}
+
+	dialIPBytes := dialAddress.As4()
+	dialIP := net.IP(dialIPBytes[:])
+	if !dialIP.Equal(net.ParseIP("127.0.0.1")) {
+		t.Fatalf("expected dial destination to use NAT loopback, got %v", dialIP)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a built-in `host.boxlite.internal` alias that resolves inside the guest to a dedicated host IP
- route that host IP to host loopback through gvproxy and keep the alias reachable under restrictive `allow_net`
- add Go and Rust coverage for DNS ordering, NAT behavior, TCP filtering, and VM-level host alias behavior
- replace the Docker-specific `host.docker.internal` guidance with BoxLite-specific docs and examples

## Why
The docs previously referenced `host.docker.internal`, but BoxLite did not actually implement or document a BoxLite-native host alias in the runtime. This change makes box-to-host loopback access explicit, test-covered, and documented in the codebase.

## User impact
Boxes can now reach host loopback-backed services through `host.boxlite.internal` or the dedicated virtual host IP `192.168.127.254` when networking is enabled. The docs also now distinguish host-to-box port forwarding from box-to-host connectivity.

## Validation
- `cargo fmt --check`
- `cargo test -p boxlite --features gvproxy --lib net::gvproxy::config`
- `cargo clippy -p boxlite --features gvproxy --tests -- -D warnings`
- `go test ./...` in `src/deps/libgvproxy-sys/gvproxy-bridge`

## Notes
- the tree includes ignored VM integration tests covering host alias resolution and host loopback reachability
- the branch was published from the current local commit contents with a clean `main` base