### PR TITLE
feat(sdk/go): local OCI bundle via WithRootfsPath

### DIFF
--- a/sdks/go/boxlite.go
+++ b/sdks/go/boxlite.go
@@ -96,6 +96,10 @@ func (r *Runtime) Shutdown(_ context.Context, timeout time.Duration) error {
 }
 
 // Create creates and returns a new box.
+//
+// The image argument is the registry reference to pull when no usable local path is
+// selected. With [WithRootfsPath], if that path exists as a directory it takes
+// precedence and image is ignored; if the path is missing, Create uses image instead.
 func (r *Runtime) Create(_ context.Context, image string, opts ...BoxOption) (*Box, error) {
 	cfg := &boxConfig{}
 	for _, o := range opts {

--- a/sdks/go/boxlite_test.go
+++ b/sdks/go/boxlite_test.go
@@ -2,6 +2,8 @@ package boxlite
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -150,6 +152,93 @@ func TestRuntimeOptions(t *testing.T) {
 // ============================================================================
 // Wire types
 // ============================================================================
+
+func TestBuildOptionsJSON_WithRootfsPath(t *testing.T) {
+	bundle := t.TempDir()
+	cfg := &boxConfig{}
+	WithRootfsPath(bundle)(cfg)
+	wire, err := buildOptionsJSON("", cfg)
+	if err != nil {
+		t.Fatalf("buildOptionsJSON: %v", err)
+	}
+	path, ok := wire.Rootfs.(wireRootfsPath)
+	if !ok {
+		t.Fatalf("Rootfs type: got %T", wire.Rootfs)
+	}
+	if path.RootfsPath != bundle {
+		t.Errorf("RootfsPath: got %q", path.RootfsPath)
+	}
+}
+
+func TestBuildOptionsJSON_RootfsPathWinsOverImage(t *testing.T) {
+	bundle := t.TempDir()
+	cfg := &boxConfig{}
+	WithRootfsPath(bundle)(cfg)
+	wire, err := buildOptionsJSON("alpine:latest", cfg)
+	if err != nil {
+		t.Fatalf("buildOptionsJSON: %v", err)
+	}
+	path, ok := wire.Rootfs.(wireRootfsPath)
+	if !ok {
+		t.Fatalf("Rootfs type: got %T", wire.Rootfs)
+	}
+	if path.RootfsPath != bundle {
+		t.Errorf("RootfsPath: got %q", path.RootfsPath)
+	}
+}
+
+func TestBuildOptionsJSON_RootfsPathMissingFallsBackToImage(t *testing.T) {
+	cfg := &boxConfig{}
+	WithRootfsPath("/no/such/oci-bundle-xyz")(cfg)
+	wire, err := buildOptionsJSON("alpine:latest", cfg)
+	if err != nil {
+		t.Fatalf("buildOptionsJSON: %v", err)
+	}
+	img, ok := wire.Rootfs.(wireRootfsImage)
+	if !ok {
+		t.Fatalf("Rootfs type: got %T", wire.Rootfs)
+	}
+	if img.Image != "alpine:latest" {
+		t.Errorf("Image: got %q", img.Image)
+	}
+}
+
+func TestBuildOptionsJSON_RootfsPathNotDirFallsBackToImage(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(f, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &boxConfig{}
+	WithRootfsPath(f)(cfg)
+	wire, err := buildOptionsJSON("ubuntu:22.04", cfg)
+	if err != nil {
+		t.Fatalf("buildOptionsJSON: %v", err)
+	}
+	out, ok := wire.Rootfs.(wireRootfsImage)
+	if !ok {
+		t.Fatalf("Rootfs type: got %T", wire.Rootfs)
+	}
+	if out.Image != "ubuntu:22.04" {
+		t.Errorf("Image: got %q", out.Image)
+	}
+}
+
+func TestBuildOptionsJSON_RootfsPathMissingAndNoImage(t *testing.T) {
+	cfg := &boxConfig{}
+	WithRootfsPath("/no/such/bundle")(cfg)
+	_, err := buildOptionsJSON("", cfg)
+	if err == nil {
+		t.Fatal("expected error when local path is missing and image is empty")
+	}
+}
+
+func TestBuildOptionsJSON_MissingImageAndPath(t *testing.T) {
+	cfg := &boxConfig{}
+	_, err := buildOptionsJSON("", cfg)
+	if err == nil {
+		t.Fatal("expected error when image is empty and WithRootfsPath is not set")
+	}
+}
 
 func TestBuildOptionsJSON(t *testing.T) {
 	cfg := &boxConfig{}

--- a/sdks/go/options.go
+++ b/sdks/go/options.go
@@ -45,6 +45,7 @@ type boxConfig struct {
 	name       string
 	cpus       int
 	memoryMiB  int
+	rootfsPath string
 	env        [][2]string
 	volumes    []volumeEntry
 	workDir    string
@@ -75,6 +76,17 @@ func WithCPUs(n int) BoxOption {
 // WithMemory sets the memory limit in MiB.
 func WithMemory(mib int) BoxOption {
 	return func(c *boxConfig) { c.memoryMiB = mib }
+}
+
+// WithRootfsPath prefers a local OCI image layout directory over pulling from a registry.
+//
+// If the path exists and is a directory, it is used and the image argument to
+// [Runtime.Create] is ignored. Otherwise BoxLite falls back to the image reference
+// (for example when the directory has not been exported yet).
+//
+// The directory should contain a valid OCI bundle (oci-layout, index.json, blobs/sha256/, …).
+func WithRootfsPath(path string) BoxOption {
+	return func(c *boxConfig) { c.rootfsPath = path }
 }
 
 // WithEnv adds an environment variable.

--- a/sdks/go/wire.go
+++ b/sdks/go/wire.go
@@ -2,6 +2,8 @@ package boxlite
 
 import (
 	"fmt"
+	"os"
+	"strings"
 	"time"
 )
 
@@ -52,6 +54,11 @@ type wireSecret struct {
 // wireRootfsImage matches Rust RootfsSpec::Image serialization.
 type wireRootfsImage struct {
 	Image string `json:"Image"`
+}
+
+// wireRootfsPath matches Rust RootfsSpec::RootfsPath serialization.
+type wireRootfsPath struct {
+	RootfsPath string `json:"RootfsPath"`
 }
 
 // boxInfoWire matches the JSON from box_info_to_json() in ffi/src/json.rs.
@@ -125,8 +132,32 @@ func (w *imagePullResultWire) toImagePullResult() ImagePullResult {
 
 // buildOptionsJSON creates the JSON wire representation from boxConfig.
 func buildOptionsJSON(image string, cfg *boxConfig) (boxOptionsWire, error) {
+	image = strings.TrimSpace(image)
+	rootfsPath := strings.TrimSpace(cfg.rootfsPath)
+
+	useLocalOCI := false
+	if rootfsPath != "" {
+		if fi, err := os.Stat(rootfsPath); err == nil && fi.IsDir() {
+			useLocalOCI = true
+		}
+	}
+
+	var rootfs any
+	switch {
+	case useLocalOCI:
+		// Local OCI bundle: image is ignored when the path exists and is a directory.
+		rootfs = wireRootfsPath{RootfsPath: rootfsPath}
+	case image != "":
+		// Registry image, or fallback when WithRootfsPath points to a missing path.
+		rootfs = wireRootfsImage{Image: image}
+	default:
+		return boxOptionsWire{}, fmt.Errorf(
+			"boxlite: image reference is required when WithRootfsPath is unset, the path does not exist, or it is not a directory",
+		)
+	}
+
 	w := boxOptionsWire{
-		Rootfs: wireRootfsImage{Image: image},
+		Rootfs: rootfs,
 		Env:    cfg.env,
 	}
 


### PR DESCRIPTION
## Summary
- Add `WithRootfsPath` so Go callers can pass a local OCI image layout directory, wiring the same JSON shape as Rust `RootfsSpec::RootfsPath`.
- If the path exists and is a directory, that path is used and the `Create` image argument is ignored; if the path is missing or not a directory, fall back to the registry `image` string.

## Test plan
- [x] `go build` in `sdks/go` (with `CGO_CFLAGS` pointing at `sdks/c/include`)
- Unit tests in `boxlite_test.go` for local path, precedence over image, fallback, and errors


Made with [Cursor](https://cursor.com)