### PR TITLE
[codex] Auto-use sudo in Linux setup scripts

### DIFF
--- a/scripts/setup/setup-common.sh
+++ b/scripts/setup/setup-common.sh
@@ -17,6 +17,39 @@ if [[ -z "$SCRIPT_DIR" ]]; then
     source "$SCRIPT_DIR/common.sh"
 fi
 
+# Configure sudo helper for scripts that write system locations.
+setup_sudo() {
+    if [ "$EUID" -eq 0 ]; then
+        SUDO=""
+    elif command_exists sudo; then
+        SUDO="sudo"
+    else
+        SUDO=""
+    fi
+
+    export SUDO
+}
+
+# Fail early when a setup flow needs system-level package installation.
+require_root_or_sudo() {
+    setup_sudo
+
+    if [ "$EUID" -ne 0 ] && [ -z "$SUDO" ]; then
+        print_error "This setup requires root privileges or sudo"
+        echo "   Re-run as root or install sudo and retry"
+        exit 1
+    fi
+}
+
+# Run a command through sudo when the current shell is not root.
+run_with_sudo() {
+    if [ -n "${SUDO:-}" ]; then
+        "$SUDO" "$@"
+    else
+        "$@"
+    fi
+}
+
 # Check Rust installation
 check_rust() {
     print_step "Checking for Rust... "
@@ -178,8 +211,8 @@ install_go_from_official() {
     print_success "Done"
 
     print_step "Installing to /usr/local/go... "
-    ${SUDO:-} rm -rf /usr/local/go
-    ${SUDO:-} tar -C /usr/local -xzf "$tmpfile"
+    run_with_sudo rm -rf /usr/local/go
+    run_with_sudo tar -C /usr/local -xzf "$tmpfile"
     rm -f "$tmpfile"
     print_success "Installed"
 

--- a/scripts/setup/setup-manylinux.sh
+++ b/scripts/setup/setup-manylinux.sh
@@ -34,7 +34,7 @@ yum_installed() {
 # Update package lists
 update_yum() {
     print_section "🔄 Updating package lists..."
-    yum update -y -q
+    run_with_sudo yum update -y -q
     echo ""
 }
 
@@ -91,7 +91,7 @@ install_system_deps() {
             print_success "Already installed"
         else
             echo -e "${YELLOW}Installing...${NC}"
-            yum install -y -q "$pkg"
+            run_with_sudo yum install -y -q "$pkg"
             print_success "$pkg installed"
         fi
     done
@@ -103,7 +103,7 @@ install_system_deps() {
         print_success "Already installed"
     else
         echo -e "${YELLOW}Installing...${NC}"
-        yum install -y -q glibc-static
+        run_with_sudo yum install -y -q glibc-static
         print_success "glibc-static installed"
     fi
 
@@ -119,7 +119,7 @@ install_python_deps() {
         print_success "Already installed"
     else
         echo -e "${YELLOW}Installing...${NC}"
-        pip3 install -q pyelftools
+        run_with_sudo pip3 install -q pyelftools
         print_success "pyelftools installed"
     fi
 
@@ -129,7 +129,7 @@ install_python_deps() {
         print_success "Already installed"
     else
         echo -e "${YELLOW}Installing via pip...${NC}"
-        pip3 install -q meson
+        run_with_sudo pip3 install -q meson
         print_success "meson installed"
     fi
 
@@ -176,7 +176,7 @@ install_protoc() {
     local PROTOC_ZIP="/tmp/protoc.zip"
 
     curl -sSL "$PROTOC_URL" -o "$PROTOC_ZIP"
-    unzip -q -o "$PROTOC_ZIP" -d /usr/local
+    run_with_sudo unzip -q -o "$PROTOC_ZIP" -d /usr/local
     rm -f "$PROTOC_ZIP"
 
     print_success "Installed protoc $PROTOC_VERSION"
@@ -216,7 +216,7 @@ install_nodejs() {
 
     echo -e "${YELLOW}Downloading Node.js $NODE_VERSION...${NC}"
     curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" \
-        | tar -xJ -C /usr/local --strip-components=1
+        | run_with_sudo tar -xJ -C /usr/local --strip-components=1
     print_success "Node.js $NODE_VERSION installed"
     echo ""
 }
@@ -226,6 +226,7 @@ main() {
     print_header "BoxLite Development Setup for manylinux"
 
     check_platform
+    require_root_or_sudo
 
     print_section "📋 Checking prerequisites..."
     echo ""

--- a/scripts/setup/setup-musllinux.sh
+++ b/scripts/setup/setup-musllinux.sh
@@ -34,7 +34,7 @@ apk_installed() {
 # Update package lists
 update_apk() {
     print_section "🔄 Updating package lists..."
-    apk update
+    run_with_sudo apk update
     echo ""
 }
 
@@ -92,7 +92,7 @@ install_system_deps() {
             print_success "Already installed"
         else
             echo -e "${YELLOW}Installing...${NC}"
-            apk add --quiet "$pkg"
+            run_with_sudo apk add --quiet "$pkg"
             print_success "$pkg installed"
         fi
     done
@@ -109,7 +109,7 @@ install_python_deps() {
         print_success "Already installed"
     else
         echo -e "${YELLOW}Installing...${NC}"
-        pip3 install --quiet pyelftools
+        run_with_sudo pip3 install --quiet pyelftools
         print_success "pyelftools installed"
     fi
 
@@ -156,7 +156,7 @@ install_protoc() {
     local PROTOC_ZIP="/tmp/protoc.zip"
 
     curl -sSL "$PROTOC_URL" -o "$PROTOC_ZIP"
-    unzip -q -o "$PROTOC_ZIP" -d /usr/local
+    run_with_sudo unzip -q -o "$PROTOC_ZIP" -d /usr/local
     rm -f "$PROTOC_ZIP"
 
     print_success "Installed protoc $PROTOC_VERSION"
@@ -168,6 +168,7 @@ main() {
     print_header "BoxLite Development Setup for musllinux"
 
     check_platform
+    require_root_or_sudo
 
     print_section "📋 Checking prerequisites..."
     echo ""

--- a/scripts/setup/setup-ubuntu.sh
+++ b/scripts/setup/setup-ubuntu.sh
@@ -31,13 +31,6 @@ check_platform() {
     fi
 }
 
-# Check if we need $SUDO (not root and $SUDO exists)
-if [ "$EUID" -ne 0 ] && command -v sudo &> /dev/null; then
-    SUDO="sudo"
-else
-    SUDO=""
-fi
-
 # Check if a package is installed
 apt_installed() {
     dpkg -l "$1" 2>/dev/null | grep -q "^ii"
@@ -46,7 +39,7 @@ apt_installed() {
 # Update package lists
 update_apt() {
     print_section "🔄 Updating package lists..."
-    $SUDO apt-get update -qq
+    run_with_sudo apt-get update -qq
     echo ""
 }
 
@@ -103,7 +96,7 @@ install_system_deps() {
             print_success "Already installed"
         else
             echo -e "${YELLOW}Installing...${NC}"
-            $SUDO apt-get install -y -qq "$pkg"
+            run_with_sudo apt-get install -y -qq "$pkg"
             print_success "$pkg installed"
         fi
     done
@@ -135,7 +128,7 @@ install_nodejs() {
             print_success "Already installed"
         else
             echo -e "${YELLOW}Installing...${NC}"
-            $SUDO apt-get install -y -qq "$pkg"
+            run_with_sudo apt-get install -y -qq "$pkg"
             print_success "$pkg installed"
         fi
     done
@@ -150,6 +143,7 @@ main() {
     print_header "BoxLite Development Setup for Ubuntu/Debian"
 
     check_platform
+    require_root_or_sudo
 
     print_section "📋 Checking prerequisites..."
     echo ""


### PR DESCRIPTION
## Summary
This changes the Linux setup scripts to auto-use `sudo` when the current shell is not already running as root.

## What Changed
- added shared `setup_sudo`, `require_root_or_sudo`, and `run_with_sudo` helpers in `scripts/setup/setup-common.sh`
- switched the Ubuntu, manylinux, and musllinux setup flows to route package-manager and `/usr/local` writes through the shared sudo helper
- removed the duplicated Ubuntu-only sudo detection now that the behavior lives in shared setup code

## Why
`make setup` on manylinux failed immediately for non-root users because the manylinux setup script invoked `yum`, `pip3`, `unzip`, and `tar` directly, unlike the Ubuntu setup flow which already auto-used `sudo`. This makes the Linux setup behavior consistent across supported distributions.

## User Impact
Non-root users can run `make setup` on manylinux and musllinux the same way they do on Ubuntu, with `sudo` applied automatically when system package installation or writes to `/usr/local` are required.

## Validation
- `bash -n scripts/setup/setup-common.sh`
- `bash -n scripts/setup/setup-manylinux.sh`
- `bash -n scripts/setup/setup-musllinux.sh`
- `bash -n scripts/setup/setup-ubuntu.sh`
- `git diff --check`
