### PR TITLE
docs: add SECURITY.md with private vulnerability reporting process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,7 @@ Key test entry points:
 - Use [GitHub Issues](https://github.com/boxlite-labs/boxlite/issues)
 - Include OS, architecture, and BoxLite version
 - Provide minimal reproduction steps
+- **Security vulnerabilities:** do not open a public issue. See [SECURITY.md](./SECURITY.md) for the private reporting process.
 
 ### Pull Requests
 

--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ For details, see [Architecture](./docs/architecture/).
 
 - [GitHub Issues](https://github.com/boxlite-ai/boxlite/issues) — Bug reports and feature requests
 - [Discord](https://go.boxlite.ai/discord) — Questions and community support
+- [Security Policy](./SECURITY.md) — How to privately report a vulnerability
 
 ## Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,110 @@
+# Security Policy
+
+BoxLite is a sandboxing runtime, so the security of the project matters
+to everyone running it. We take vulnerability reports seriously and
+appreciate the time researchers spend finding and responsibly disclosing
+issues.
+
+## Reporting a Vulnerability
+
+**Please do not open a public GitHub issue for security reports.** Public
+issues are indexed immediately and give potential attackers a head start
+before a fix is available.
+
+Use one of the following private channels instead:
+
+1. **Preferred — GitHub Private Vulnerability Reporting.** Submit a
+   report via
+   [github.com/boxlite-ai/boxlite/security/advisories/new](https://github.com/boxlite-ai/boxlite/security/advisories/new).
+   This opens a private advisory visible only to the maintainers and to
+   collaborators you invite. It is the fastest path, and it lets us
+   coordinate a fix, request a CVE, and credit you — all from the same
+   thread.
+2. **Fallback — Discord.** If GitHub's advisory form is unavailable to
+   you, send a direct message to a maintainer on our
+   [Discord server](https://go.boxlite.ai/discord) and ask for a private
+   channel. Do not post details in public channels.
+
+When reporting, please include (as much as you can share):
+
+- A description of the vulnerability and its impact.
+- Step-by-step reproduction instructions or a proof-of-concept.
+- Affected version(s), platform (macOS / Linux / WSL2), and
+  architecture (x86_64 / aarch64).
+- Any suggested mitigation or patch, if you have one.
+
+## What to Expect
+
+- **Acknowledgement:** we aim to acknowledge a report within 3 business
+  days.
+- **Triage:** we will work with you to confirm the issue, assess impact,
+  and agree on a disclosure timeline — typically within 90 days of the
+  initial report, shorter for actively exploited issues.
+- **Fix and release:** we will prepare a patch, coordinate the release,
+  and publish a GitHub Security Advisory (with a CVE where applicable).
+- **Credit:** with your permission, we will credit you in the advisory
+  and the release notes. Anonymous reports are also welcome.
+
+We will keep you updated at each step. If you have not heard back after
+an acknowledgement window, feel free to ping us on the same channel.
+
+## Supported Versions
+
+BoxLite is pre-1.0 and moves quickly. Security fixes land on `main` and
+the latest published minor release. We do not back-patch older releases.
+
+| Version | Supported          |
+|---------|--------------------|
+| 0.8.x   | :white_check_mark: |
+| < 0.8   | :x:                |
+
+## Scope
+
+In-scope examples (highest priority):
+
+- VM escape — guest code that escapes the libkrun / Hypervisor.framework
+  / KVM boundary and reaches the host.
+- Guest-to-host privilege escalation via the portal / gRPC / vsock
+  surface or the shared filesystem.
+- Jailer bypass — guest or shim processes escaping the seccomp /
+  sandbox-exec / namespace jail.
+- Image handling vulnerabilities that can corrupt the host (e.g. unsafe
+  tar extraction, path traversal on rootfs prepare).
+- Host-side memory safety bugs in the Rust core or FFI shims that are
+  reachable from untrusted input.
+
+Out of scope:
+
+- Issues in dependencies that already have a public advisory and a
+  scheduled upgrade in this repository — please link the advisory in a
+  regular issue instead.
+- Vulnerabilities requiring physical access to the host, a pre-existing
+  root shell on the host, or a modified local build.
+- Denial-of-service caused by running workloads that legitimately
+  consume the resources the caller configured (e.g. setting a high
+  memory limit and then allocating it).
+- Typos, style issues, and non-security bugs — use a normal GitHub
+  issue.
+
+If you are not sure whether something is in scope, report it anyway and
+we will triage.
+
+## Safe Harbor
+
+We support good-faith security research. If you follow this policy, we
+will:
+
+- Consider your research authorized under the relevant anti-hacking
+  laws, and we will not pursue legal action for your report.
+- Work with you to understand and resolve the issue before any public
+  disclosure.
+- Not ask for payment or waiving of credit as a condition of the fix.
+
+Please make a good-faith effort to avoid privacy violations, data
+destruction, and service disruption while researching. Only interact
+with accounts and systems you own or for which you have explicit
+permission.
+
+---
+
+Thanks for helping keep BoxLite and its users safe.


### PR DESCRIPTION
## Summary

- Adds `SECURITY.md` documenting how to privately report vulnerabilities (GitHub Private Vulnerability Reporting as primary channel, Discord DM as fallback).
- Covers acknowledgement SLA (3 business days), supported versions (`0.8.x`), scope (VM escape, jailer bypass, guest-to-host escalation, image handling, host-side memory safety), and safe-harbor language for good-faith research.
- Cross-links from `README.md` "Getting Help" and `CONTRIBUTING.md` "Reporting Issues" so researchers can find the policy.

Addresses #440 item 1 (SECURITY.md).

## Remaining follow-ups for the maintainers (not code)

- Item 2 of #440: flip **Settings → Code security → Private vulnerability reporting** on for this repo. `SECURITY.md` already points at `/security/advisories/new`, but that form only works once the setting is enabled.
- Item 3 of #440 (GitHub Security Advisories) is unlocked by the same setting.

## Test plan

- [x] `SECURITY.md` renders on GitHub (standard Markdown, checked table/list syntax).
- [x] Links in `SECURITY.md` resolve: `/security/advisories/new`, Discord invite, no dangling references.
- [x] `README.md` and `CONTRIBUTING.md` pointers render as expected.
- [ ] Maintainer sanity-checks contact defaults: Discord-DM fallback, 3-business-day ack SLA, `0.8.x`-only support window.