### PR TITLE
feat(vmm): use event-driven exit detection during guest startup

### DIFF
--- a/src/boxlite/src/litebox/init/tasks/guest_connect.rs
+++ b/src/boxlite/src/litebox/init/tasks/guest_connect.rs
@@ -11,7 +11,8 @@ use crate::litebox::CrashReport;
 use crate::pipeline::PipelineTask;
 use crate::portal::GuestSession;
 use crate::runtime::layout::{BoxFilesystemLayout, FsLayoutConfig};
-use crate::util::{ProcessExit, ProcessMonitor};
+use crate::util::ProcessExit;
+use crate::vmm::controller::VmmHandler;
 use async_trait::async_trait;
 use boxlite_shared::Transport;
 use boxlite_shared::errors::{BoxliteError, BoxliteResult};
@@ -26,15 +27,7 @@ impl PipelineTask<InitCtx> for GuestConnectTask {
         let task_name = self.name();
         let box_id = task_start(&ctx, task_name).await;
 
-        let (
-            transport,
-            ready_transport,
-            skip_guest_wait,
-            shim_pid,
-            exit_file,
-            console_log,
-            stderr_file,
-        ) = {
+        let (transport, ready_transport, skip_guest_wait, exit_file, console_log, stderr_file) = {
             let ctx = ctx.lock().await;
             // Use pipeline layout if available, otherwise construct from box_home
             // (reattach scenario: layout not set because FilesystemTask didn't run)
@@ -57,7 +50,6 @@ impl PipelineTask<InitCtx> for GuestConnectTask {
                 ctx.config.transport.clone(),
                 Transport::unix(ctx.config.ready_socket_path.clone()),
                 ctx.skip_guest_wait,
-                ctx.guard.handler_pid(),
                 exit_file,
                 console_log,
                 stderr_file,
@@ -70,9 +62,11 @@ impl PipelineTask<InitCtx> for GuestConnectTask {
             tracing::debug!(box_id = %box_id, "Skipping guest ready wait (reattach)");
         } else {
             tracing::debug!(box_id = %box_id, "Waiting for guest to be ready");
+            let ctx_guard = ctx.lock().await;
+            let handler = ctx_guard.guard.handler_ref();
             wait_for_guest_ready(
                 &ready_transport,
-                shim_pid,
+                handler,
                 &exit_file,
                 &console_log,
                 &stderr_file,
@@ -104,7 +98,7 @@ impl PipelineTask<InitCtx> for GuestConnectTask {
 /// 3. 30s timeout expires (slow failure fallback)
 async fn wait_for_guest_ready(
     ready_transport: &Transport,
-    shim_pid: Option<u32>,
+    handler: Option<&dyn VmmHandler>,
     exit_file: &Path,
     console_log: &Path,
     stderr_file: &Path,
@@ -166,7 +160,7 @@ async fn wait_for_guest_ready(
                 ))),
             }
         }
-        exit_code = wait_for_process_exit(shim_pid) => {
+        exit_code = wait_for_process_exit(handler) => {
             // Parse exit file and present user-friendly message
             let report = CrashReport::from_exit_file(
                 exit_file,
@@ -191,29 +185,24 @@ async fn wait_for_guest_ready(
 
 /// Async poll until a process exits. Returns exit code when process terminates.
 /// If pid is None, never resolves (lets other select! branches win).
-async fn wait_for_process_exit(pid: Option<u32>) -> Option<i32> {
-    let Some(pid) = pid else {
-        // No PID to monitor — pend forever, let timeout branch handle it
-        return std::future::pending().await;
+async fn wait_for_process_exit(handler: Option<&dyn VmmHandler>) -> Option<i32> {
+    let h = match handler {
+        Some(h) => h,
+        None => return std::future::pending().await,
     };
-
-    let monitor = ProcessMonitor::new(pid);
-    match monitor.wait_for_exit().await {
-        ProcessExit::Code(code) => {
+    match h.wait_for_exit().await {
+        Ok(ProcessExit::Code(code)) => {
             tracing::warn!(
-                pid = pid,
                 exit_code = code,
                 "VM subprocess exited unexpectedly during startup"
             );
             Some(code)
         }
-        ProcessExit::Unknown => {
-            tracing::warn!(
-                pid = pid,
-                "VM subprocess exited (not our child, exit code unknown)"
-            );
+        Ok(ProcessExit::Unknown) => {
+            tracing::warn!("VM subprocess exited (exit code unknown)");
             None
         }
+        Err(e) => panic!("wait_for_exit failed: {}", e),
     }
 }
 
@@ -242,7 +231,7 @@ mod tests {
             let _ = tokio::net::UnixStream::connect(&connect_path).await;
         });
 
-        // No shim PID to monitor (None = never triggers death branch)
+        // No handler to monitor (None = never triggers death branch)
         let result = wait_for_guest_ready(
             &transport,
             None,
@@ -320,10 +309,10 @@ mod tests {
         );
     }
 
-    /// When the shim process dies (invalid PID), the death branch fires
-    /// before the 30s timeout, producing a diagnostic error.
+    /// When the handler reports exit (event-driven), death branch fires
+    /// immediately without polling.
     #[tokio::test]
-    async fn test_guest_ready_detects_shim_death() {
+    async fn test_guest_ready_detects_shim_death_via_handler() {
         let dir = tempfile::tempdir().unwrap();
         let socket_path = dir.path().join("ready.sock");
         let exit_file = dir.path().join("exit");
@@ -331,14 +320,12 @@ mod tests {
         let stderr_file = dir.path().join("shim.stderr");
         let transport = Transport::unix(socket_path);
 
-        // Use a PID that doesn't exist — wait_for_process_exit will
-        // detect it as dead on the first poll interval.
-        let dead_pid = Some(999_999_999u32);
+        let handler = MockHandler::with_code(1);
 
         let start = std::time::Instant::now();
         let result = wait_for_guest_ready(
             &transport,
-            dead_pid,
+            Some(&handler),
             &exit_file,
             &console_log,
             &stderr_file,
@@ -351,97 +338,118 @@ mod tests {
         let err = result.unwrap_err().to_string();
         assert!(
             err.contains("test-box failed to start"),
-            "Expected user-friendly error with box_id, got: {}",
+            "Expected user-friendly error, got: {}",
             err
         );
 
-        // Should complete in ~500ms (one poll interval), not 30s
+        // Event-driven: should complete in <50ms, not ~500ms poll interval
         assert!(
-            elapsed < Duration::from_secs(5),
-            "Should detect dead process quickly, took {:?}",
+            elapsed < Duration::from_millis(200),
+            "Event-driven path should be instant, took {:?}",
             elapsed
         );
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Mock handler for event-driven path testing
+    // ─────────────────────────────────────────────────────────────────────
+
+    use crate::vmm::controller::VmmMetrics;
+
+    struct MockHandler {
+        exit_code: Option<i32>, // Some = Code, None = Unknown
+        should_error: bool,
+    }
+
+    impl MockHandler {
+        fn with_code(code: i32) -> Self {
+            Self {
+                exit_code: Some(code),
+                should_error: false,
+            }
+        }
+        fn with_unknown() -> Self {
+            Self {
+                exit_code: None,
+                should_error: false,
+            }
+        }
+        fn with_error() -> Self {
+            Self {
+                exit_code: None,
+                should_error: true,
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl VmmHandler for MockHandler {
+        fn stop(&mut self) -> BoxliteResult<()> {
+            Ok(())
+        }
+        fn metrics(&self) -> BoxliteResult<VmmMetrics> {
+            Ok(VmmMetrics::default())
+        }
+        fn is_running(&self) -> bool {
+            true
+        }
+        fn pid(&self) -> u32 {
+            12345
+        }
+        async fn wait_for_exit(&self) -> BoxliteResult<ProcessExit> {
+            if self.should_error {
+                return Err(BoxliteError::Engine("mock error".into()));
+            }
+            Ok(match self.exit_code {
+                Some(code) => ProcessExit::Code(code),
+                None => ProcessExit::Unknown,
+            })
+        }
     }
 
     // ─────────────────────────────────────────────────────────────────────
     // wait_for_process_exit tests
     // ─────────────────────────────────────────────────────────────────────
 
-    /// None PID → future never resolves (pends forever).
-    /// Verify by racing against a short timeout.
+    /// Handler returns exit code → event-driven path resolves immediately.
     #[tokio::test]
-    async fn test_wait_for_process_exit_none_pid_pends() {
-        let result =
-            tokio::time::timeout(Duration::from_millis(200), wait_for_process_exit(None)).await;
+    async fn test_wait_for_process_exit_handler_code() {
+        let handler = MockHandler::with_code(42);
 
-        // Should timeout because None pid pends forever
-        assert!(
-            result.is_err(),
-            "None pid should pend forever, but it resolved"
-        );
-    }
-
-    /// Dead PID resolves within one poll interval (~500ms).
-    #[tokio::test]
-    async fn test_wait_for_process_exit_dead_pid_resolves() {
         let start = std::time::Instant::now();
-        wait_for_process_exit(Some(999_999_999)).await;
+        let code = wait_for_process_exit(Some(&handler)).await;
         let elapsed = start.elapsed();
 
-        // Should complete within ~600ms (500ms poll + small overhead)
+        assert_eq!(code, Some(42));
         assert!(
-            elapsed < Duration::from_secs(2),
-            "Dead PID should resolve quickly, took {:?}",
+            elapsed < Duration::from_millis(50),
+            "Event-driven path should resolve immediately, took {:?}",
             elapsed
         );
     }
 
-    /// Live PID (current process) should NOT resolve within a short window.
+    /// Handler returns Unknown → event-driven path resolves immediately with None.
     #[tokio::test]
-    async fn test_wait_for_process_exit_live_pid_pends() {
-        let current_pid = std::process::id();
+    async fn test_wait_for_process_exit_handler_unknown() {
+        let handler = MockHandler::with_unknown();
 
-        let result = tokio::time::timeout(
-            Duration::from_millis(700),
-            wait_for_process_exit(Some(current_pid)),
-        )
-        .await;
+        let start = std::time::Instant::now();
+        let code = wait_for_process_exit(Some(&handler)).await;
+        let elapsed = start.elapsed();
 
-        // Current process is alive, so this should timeout
-        assert!(result.is_err(), "Live PID should not resolve");
+        assert_eq!(code, None);
+        assert!(
+            elapsed < Duration::from_millis(50),
+            "Event-driven path should resolve immediately, took {:?}",
+            elapsed
+        );
     }
 
-    /// Zombie PID should resolve quickly (treated as not alive).
-    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    /// Handler errors → panics to expose the bug.
     #[tokio::test]
-    async fn test_wait_for_process_exit_zombie_pid_resolves() {
-        struct PidReaper {
-            pid: libc::pid_t,
-        }
-
-        impl Drop for PidReaper {
-            fn drop(&mut self) {
-                let mut status = 0;
-                let _ = unsafe { libc::waitpid(self.pid, &mut status, 0) };
-            }
-        }
-
-        let child_pid = unsafe { libc::fork() };
-        assert!(child_pid >= 0, "fork() failed");
-        if child_pid == 0 {
-            unsafe { libc::_exit(0) };
-        }
-        let _reaper = PidReaper { pid: child_pid };
-
-        let result = tokio::time::timeout(
-            Duration::from_secs(2),
-            wait_for_process_exit(Some(child_pid as u32)),
-        )
-        .await;
-
-        assert!(
-            result.is_ok(),
-            "Zombie PID should resolve quickly, got timeout"
-        );
+    #[should_panic(expected = "wait_for_exit failed")]
+    async fn test_wait_for_process_exit_handler_error_panics() {
+        let handler = MockHandler::with_error();
+        wait_for_process_exit(Some(&handler)).await;
     }
 }

--- a/src/boxlite/src/litebox/init/types.rs
+++ b/src/boxlite/src/litebox/init/types.rs
@@ -170,9 +170,9 @@ impl CleanupGuard {
         self.handler.take()
     }
 
-    /// Get the PID of the VM subprocess, if a handler is registered.
-    pub fn handler_pid(&self) -> Option<u32> {
-        self.handler.as_ref().map(|h| h.pid())
+    /// Get a reference to the VM handler, if registered.
+    pub fn handler_ref(&self) -> Option<&dyn VmmHandler> {
+        self.handler.as_deref()
     }
 
     /// Disarm the guard (call on success).

--- a/src/boxlite/src/vmm/controller/handler.rs
+++ b/src/boxlite/src/vmm/controller/handler.rs
@@ -1,9 +1,11 @@
 //! VmmHandler - Runtime operations on a running VM.
 
 use super::VmmMetrics;
+use crate::util::ProcessExit;
 use boxlite_shared::BoxliteResult;
 
 /// Trait for runtime operations on a running VM.
+#[async_trait::async_trait]
 ///
 /// Separates runtime operations (stop, metrics) from spawning operations (VmmController).
 /// This allows reconnection to existing VMs by creating a handler directly from PID.
@@ -15,7 +17,7 @@ use boxlite_shared::BoxliteResult;
 /// - Get process ID
 ///
 /// Other metadata (transport, boot duration) is stored in BoxConfig/BoxMetrics.
-pub trait VmmHandler: Send {
+pub trait VmmHandler: Send + Sync {
     /// Stop the VM.
     fn stop(&mut self) -> BoxliteResult<()>;
 
@@ -27,4 +29,16 @@ pub trait VmmHandler: Send {
 
     /// Get the process ID of the running VM.
     fn pid(&self) -> u32;
+
+    /// Wait for the VM process to exit.
+    ///
+    /// Spawn path uses `tokio::process::Child::wait()` (event-driven).
+    /// Attach path falls back to PID-based polling.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if the child handle has already been consumed
+    /// (e.g., `wait_for_exit()` or `stop()` was called previously),
+    /// or in the attach path where no child handle exists.
+    async fn wait_for_exit(&self) -> BoxliteResult<ProcessExit>;
 }

--- a/src/boxlite/src/vmm/controller/shim.rs
+++ b/src/boxlite/src/vmm/controller/shim.rs
@@ -1,7 +1,9 @@
 //! ShimController and ShimHandler - Universal process management for all Box engines.
 
-use std::{path::PathBuf, process::Child, sync::Mutex, time::Instant};
+use std::{path::PathBuf, sync::Mutex, time::Instant};
+use tokio::process::Child;
 
+use crate::util::ProcessExit;
 use crate::{
     BoxID,
     runtime::layout::BoxFilesystemLayout,
@@ -30,7 +32,7 @@ pub struct ShimHandler {
     /// Child process handle for proper lifecycle management.
     /// When we spawn the process, we keep the Child to properly wait() on stop.
     /// When we attach to an existing process, this is None.
-    process: Option<Child>,
+    process: Mutex<Option<Child>>,
     /// Watchdog keepalive. Dropping closes the pipe write end, delivering
     /// POLLHUP to the shim and triggering graceful shutdown.
     /// Defense-in-depth: even if `stop()` is never called, dropping the
@@ -49,11 +51,11 @@ impl ShimHandler {
     /// proper lifecycle management. The keepalive keeps the watchdog pipe
     /// alive; dropping it triggers shim shutdown.
     pub fn from_spawned(spawned: SpawnedShim, box_id: BoxID) -> Self {
-        let pid = spawned.child.id();
+        let pid = spawned.child.id().expect("valid pid");
         Self {
             pid,
             box_id,
-            process: Some(spawned.child),
+            process: Mutex::new(Some(spawned.child)),
             keepalive: spawned.keepalive,
             metrics_sys: Mutex::new(sysinfo::System::new()),
         }
@@ -71,13 +73,14 @@ impl ShimHandler {
         Self {
             pid,
             box_id,
-            process: None,
+            process: Mutex::new(None),
             keepalive: None,
             metrics_sys: Mutex::new(sysinfo::System::new()),
         }
     }
 }
 
+#[async_trait::async_trait]
 impl VmmHandlerTrait for ShimHandler {
     fn pid(&self) -> u32 {
         self.pid
@@ -89,9 +92,16 @@ impl VmmHandlerTrait for ShimHandler {
         // preventing qcow2 corruption.
         const GRACEFUL_SHUTDOWN_TIMEOUT_MS: u64 = 2000;
 
-        if let Some(mut process) = self.process.take() {
+        let process = self
+            .process
+            .lock()
+            .map_err(|e| BoxliteError::Internal(format!("process lock poisoned: {}", e)))?
+            .take();
+        if let Some(mut process) = process {
             // Step 1: Send SIGTERM for graceful shutdown
-            let pid = process.id();
+            let pid = process
+                .id()
+                .ok_or_else(|| BoxliteError::Engine("child pid unavailable".into()))?;
             unsafe {
                 libc::kill(pid as i32, libc::SIGTERM);
             }
@@ -108,8 +118,7 @@ impl VmmHandlerTrait for ShimHandler {
                         // Still running, check timeout
                         if start.elapsed().as_millis() > GRACEFUL_SHUTDOWN_TIMEOUT_MS as u128 {
                             // Timeout - force kill
-                            let _ = process.kill();
-                            let _ = process.wait();
+                            process.start_kill()?;
                             return Ok(());
                         }
                         // Brief sleep before checking again
@@ -117,8 +126,7 @@ impl VmmHandlerTrait for ShimHandler {
                     }
                     Err(_) => {
                         // Error checking status - try to kill anyway
-                        let _ = process.kill();
-                        let _ = process.wait();
+                        process.start_kill()?;
                         return Ok(());
                     }
                 }
@@ -195,6 +203,24 @@ impl VmmHandlerTrait for ShimHandler {
 
     fn is_running(&self) -> bool {
         crate::util::is_process_alive(self.pid)
+    }
+
+    async fn wait_for_exit(&self) -> BoxliteResult<ProcessExit> {
+        let mut child = self
+            .process
+            .lock()
+            .map_err(|e| BoxliteError::Internal(format!("process lock poisoned: {}", e)))?
+            .take();
+        let status = child
+            .as_mut()
+            .ok_or_else(|| BoxliteError::Engine("child handle already consumed".into()))?
+            .wait()
+            .await
+            .map_err(|e| BoxliteError::Engine(format!("wait failed: {}", e)))?;
+        Ok(match status.code() {
+            Some(code) => ProcessExit::Code(code),
+            None => ProcessExit::Unknown,
+        })
     }
 }
 
@@ -329,7 +355,7 @@ impl VmmController for ShimController {
             self.box_id.as_str(),
             &self.options,
         );
-        let spawned = spawner.spawn(&config_json, config.detach)?;
+        let spawned = spawner.spawn(&config_json, config.detach).await?;
         // spawn_duration: time to create Box subprocess
         let shim_spawn_duration = shim_spawn_start.elapsed();
 

--- a/src/boxlite/src/vmm/controller/spawn.rs
+++ b/src/boxlite/src/vmm/controller/spawn.rs
@@ -1,9 +1,7 @@
 //! Subprocess spawning for boxlite-shim binary.
 
-use std::{
-    path::Path,
-    process::{Child, Stdio},
-};
+use std::{path::Path, process::Stdio};
+use tokio::process::Child;
 
 use crate::jailer::{Jail, JailerBuilder};
 use crate::runtime::layout::BoxFilesystemLayout;
@@ -62,7 +60,7 @@ impl<'a> ShimSpawner<'a> {
     ///
     /// # Returns
     /// * `SpawnedShim` containing the child process and optional keepalive
-    pub fn spawn(&self, config_json: &str, detach: bool) -> BoxliteResult<SpawnedShim> {
+    pub async fn spawn(&self, config_json: &str, detach: bool) -> BoxliteResult<SpawnedShim> {
         // 1. Create watchdog pipe (non-detached only)
         let (keepalive, child_setup) = if !detach {
             let (k, s) = watchdog::create()?;
@@ -89,10 +87,10 @@ impl<'a> ShimSpawner<'a> {
 
         // 4. Build isolated command — no CLI args, config sent via stdin pipe
         let no_args: &[String] = &[];
-        let mut cmd = jail.command(self.binary_path, no_args);
+        let mut cmd = tokio::process::Command::from(jail.command(self.binary_path, no_args));
 
         // 5. Configure environment
-        self.configure_env(&mut cmd);
+        self.configure_env(cmd.as_std_mut());
 
         // 6. Configure stdio
         // stdin=piped: config JSON is sent via stdin to avoid /proc/cmdline exposure
@@ -120,8 +118,8 @@ impl<'a> ShimSpawner<'a> {
         // (>16KB on macOS, >64KB on Linux), write_all blocks until the child
         // drains the buffer — which it does as its first action in main().
         if let Some(mut stdin) = child.stdin.take() {
-            use std::io::Write;
-            stdin.write_all(config_json.as_bytes()).map_err(|e| {
+            use tokio::io::AsyncWriteExt;
+            stdin.write_all(config_json.as_bytes()).await.map_err(|e| {
                 BoxliteError::Engine(format!("Failed to write config to shim stdin: {e}"))
             })?;
             drop(stdin); // close write end — shim sees EOF


### PR DESCRIPTION
Replace PID-based polling with tokio::process::Child::wait() for immediate crash detection when the VM exits during startup. Migrate from std::process::Child to tokio::process::Child in ShimSpawner and ShimHandler, add async wait_for_exit() to VmmHandler trait. The attach path retains PID-based polling as fallback. Add MockHandler tests with timing assertions for the event-driven path.