### PR TITLE
docs: refresh outdated architecture and path references

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -72,10 +72,10 @@ can be embedded directly into applications without requiring a daemon or externa
 
 ### BoxliteRuntime
 
-The main entry point for creating and managing Boxes. Holds all runtime state protected by a single
-`RwLock`.
+The main entry point for creating and managing Boxes. Uses a coordination
+`RwLock` (`sync_state`) plus manager-internal locks and atomic counters.
 
-**Source:** `boxlite/src/runtime/`
+**Source:** `src/boxlite/src/runtime/`
 
 **Key responsibilities:**
 
@@ -86,16 +86,22 @@ The main entry point for creating and managing Boxes. Holds all runtime state pr
 
 **State architecture:**
 
-```
-RuntimeInnerImpl
-├── sync_state (RwLock)
-│   ├── BoxManager      # Tracks all Boxes and their states (Source: boxlite/src/management/box_manager.rs)
-│   └── ImageManager    # OCI image cache and management (Source: boxlite/src/management/image_manager.rs)
-└── non_sync_state (immutable)
-    ├── FilesystemLayout  # Directory structure (~/.boxlite)
-
-    ├── InitRootfs        # Shared init rootfs for guests
-    └── RuntimeMetrics    # Atomic counters (lock-free)
+```text
+RuntimeImpl
+├── sync_state (RwLock<SynchronizedState>)
+│   ├── active_boxes_by_id   # Weak cache of BoxImpl handles
+│   └── active_boxes_by_name # Weak cache of named BoxImpl handles
+├── box_manager        # DB-backed Box metadata/state management
+├── image_manager      # OCI image pull/cache management
+├── layout             # FilesystemLayout (~/.boxlite)
+├── image_disk_mgr     # Cached image layer -> ext4 conversion
+├── guest_rootfs_mgr   # Versioned guest rootfs cache manager
+├── guest_rootfs       # Arc<OnceCell<GuestRootfs>> lazy singleton
+├── base_disk_mgr      # Clone base/rootfs backing lifecycle
+├── snapshot_mgr       # Snapshot metadata + disk lifecycle
+├── lock_manager       # Per-entity multiprocess file locks
+├── _runtime_lock      # BOXLITE_HOME process-wide lock
+└── runtime_metrics    # Atomic counters (lock-free)
 ```
 
 ### LiteBox
@@ -103,7 +109,7 @@ RuntimeInnerImpl
 Individual Box handle providing execution capabilities. Supports lazy initialization - heavy work (
 image pulling, Box startup) is deferred until first use.
 
-**Source:** `boxlite/src/litebox/`
+**Source:** `src/boxlite/src/litebox/`
 
 **Key responsibilities:**
 
@@ -122,7 +128,7 @@ image pulling, Box startup) is deferred until first use.
 Universal subprocess-based Box controller. Spawns `boxlite-shim` binary in a subprocess to isolate
 Box process takeover from the host application.
 
-**Source:** `boxlite/src/vmm/controller/shim.rs`, `boxlite/src/bin/shim.rs`
+**Source:** `src/boxlite/src/vmm/controller/shim.rs`, `src/boxlite/src/bin/shim/main.rs`
 
 **Why subprocess isolation:**
 
@@ -136,7 +142,7 @@ Box process takeover from the host application.
 Defense-in-depth security layer that sandboxes the shim process, inspired by Firecracker's jailer.
 Provides OS-level isolation on top of hardware virtualization.
 
-**Source:** `boxlite/src/jailer/`
+**Source:** `src/boxlite/src/jailer/`
 
 **Key responsibilities:**
 
@@ -194,7 +200,7 @@ let opts = BoxOptions {
 };
 ```
 
-**For complete threat model and security design, see:** `boxlite/src/jailer/THREAT_MODEL.md`
+**For complete threat model and security design, see:** `src/boxlite/src/jailer/THREAT_MODEL.md`
 
 ### Portal (Host-Guest Communication)
 
@@ -204,19 +210,20 @@ gRPC-based communication layer between host and guest.
 
 - `GuestSession`: High-level facade for service interfaces
 - `Connection`: Lazy gRPC channel management
-- Service interfaces: `GuestInterface`, `ContainerInterface`, `ExecutionInterface`
+- Service interfaces: `GuestInterface`, `ContainerInterface`, `ExecutionInterface`, `FilesInterface`
 
 ### Guest Agent
 
 Runs inside the Box, receives commands from host via gRPC.
 
-**Source:** `guest/` (crate: `boxlite-guest`)
+**Source:** `src/guest/` (crate: `boxlite-guest`)
 
 **Services:**
 
 - `Guest`: Environment initialization (mounts, rootfs, network)
 - `Container`: OCI container lifecycle management (via libcontainer)
 - `Execution`: Command execution with streaming I/O
+- `Files`: Tar-based upload/download between host and container rootfs
 
 **Guest-side modules:**
 
@@ -228,7 +235,7 @@ Runs inside the Box, receives commands from host via gRPC.
 
 BoxLite uses OCI-compatible container images with intelligent caching.
 
-**Location:** `boxlite/src/images/`
+**Location:** `src/boxlite/src/images/`
 
 ### Components
 
@@ -251,7 +258,7 @@ Registry (Docker Hub, GHCR, ECR, etc.)
            │
            ▼
 ┌─────────────────────┐
-│   ImageStore        │  Store blobs in ~/.boxlite/images/blobs/
+│   ImageStore        │  Store manifests/configs/layers in ~/.boxlite/images/
 └─────────────────────┘
            │
            ▼
@@ -261,7 +268,7 @@ Registry (Docker Hub, GHCR, ECR, etc.)
            │
            ▼
 ┌─────────────────────┐
-│   Rootfs Assembly   │  Combine layers for Box rootfs
+│   Disk Cache Build  │  Build/reuse ext4 base images for fast COW startup
 └─────────────────────┘
 ```
 
@@ -275,30 +282,36 @@ Registry (Docker Hub, GHCR, ECR, etc.)
 
 ### Rootfs Preparation
 
-**Location:** `boxlite/src/rootfs/`
+**Location:** `src/boxlite/src/rootfs/` and `src/boxlite/src/litebox/init/tasks/`
 
-The rootfs builder assembles a container filesystem from OCI image layers:
+Current startup path is disk-first (faster restart/clone), orchestrated by init tasks:
 
 ```
-Image Layers          Rootfs Builder              Box Rootfs
-┌─────────┐          ┌─────────────┐          ┌─────────────┐
-│ Layer 1 │────┐     │             │          │ /bin        │
-├─────────┤    │     │  Extract &  │          │ /etc        │
-│ Layer 2 │────┼────▶│   Overlay   │─────────▶│ /usr        │
-├─────────┤    │     │             │          │ /var        │
-│ Layer N │────┘     └─────────────┘          │ ...         │
-└─────────┘                                   └─────────────┘
+OCI Image
+   │
+   ▼
+ImageDiskManager (cached ext4 base image)
+   │
+   ▼
+ContainerRootfsTask (create/reuse per-box qcow2 COW disk)
+   │
+   ▼
+GuestInitTask (mount + initialize container in guest)
 ```
+
+Guest bootstrap rootfs follows a separate cache path:
+- `GuestRootfsManager`: versioned guest rootfs cache keyed by image digest + guest binary hash
+- `GuestRootfsTask`: create/reuse per-box guest-rootfs COW overlay
 
 **Key operations:**
 
-- Layer extraction and overlay mounting
-- DNS configuration injection
-- Copy-on-write snapshot creation
+- Layer extraction and cached ext4 image preparation
+- Guest rootfs bootstrap and versioned caching
+- Per-box COW disk creation/reuse for fast restart
 
 ### Volume Management
 
-**Location:** `boxlite/src/volumes/`
+**Location:** `src/boxlite/src/volumes/`
 
 **Supported volume types:**
 
@@ -317,32 +330,31 @@ Image Layers          Rootfs Builder              Box Rootfs
 
 BoxLite supports pluggable network backends for Box connectivity.
 
-**Location:** `boxlite/src/net/`
+**Location:** `src/boxlite/src/net/`
 
 ### Architecture
 
 ```rust
 pub trait NetworkBackend: Send + Sync {
-    fn start(&mut self) -> BoxliteResult<NetworkConfig>;
-    fn stop(&mut self) -> BoxliteResult<()>;
-    fn metrics(&self) -> NetworkMetrics;
+    fn endpoint(&self) -> BoxliteResult<NetworkBackendEndpoint>;
+    fn name(&self) -> &'static str;
+    fn metrics(&self) -> BoxliteResult<Option<NetworkMetrics>>;
 }
 ```
 
 ### Available Backends
 
-#### gvproxy (Default)
+#### gvproxy (recommended when `gvproxy` feature is enabled)
 
 User-mode networking based on gVisor's network stack.
 
 ```
-Box                    gvproxy                  Internet
-┌──────┐              ┌───────┐              ┌──────────┐
-│ eth0 │◄────vsock───▶│       │◄────TCP/UDP─▶│          │
-└──────┘              │ NAT   │              │ External │
-                      │ DHCP  │              │ Services │
-                      │ DNS   │              └──────────┘
-                      └───────┘
+Box (virtio-net)        gvproxy                 Internet
+┌──────────────┐       ┌───────┐              ┌──────────┐
+│ guest eth0   │◄─────▶│ NAT   │◄────TCP/UDP─▶│ External │
+└──────────────┘       │ DHCP  │              │ Services │
+                       │ DNS   │              └──────────┘
+                       └───────┘
 ```
 
 **Features:**
@@ -370,7 +382,7 @@ Boxes receive network configuration via DHCP:
 
 BoxLite uses a pluggable Vmm (Virtual Machine Monitor) architecture for Box execution.
 
-**Location:** `boxlite/src/vmm/`
+**Location:** `src/boxlite/src/vmm/`
 
 ### Vmm Trait
 
@@ -424,7 +436,7 @@ To add a new Vmm implementation:
 
 1. Implement `Vmm` trait
 2. Implement `VmmInstanceImpl` for the instance type
-3. Register in `VmmFactory`
+3. Register engine factory via inventory (`EngineFactoryRegistration`)
 4. Add `VmmKind` variant
 
 ## Host-Guest Communication
@@ -436,7 +448,7 @@ Communication uses gRPC over transport channels, bridged via libkrun's vsock sup
 ```
 Host Application
       │
-      │ Unix Socket (/tmp/boxlite-{id}.sock)
+      │ Unix Socket (~/.boxlite/boxes/{id}/sockets/box.sock)
       ▼
 ┌─────────────────┐
 │  libkrun vsock  │  (Unix socket ↔ vsock bridge)
@@ -450,13 +462,15 @@ Guest Agent (gRPC Server)
 
 ### Protocol Definition
 
-Defined in `boxlite-shared/proto/boxlite/v1/service.proto`:
+Defined in `src/shared/proto/boxlite/v1/service.proto`:
 
 ```protobuf
 service Guest {
   rpc Init(GuestInitRequest) returns (GuestInitResponse);
   rpc Ping(PingRequest) returns (PingResponse);
   rpc Shutdown(ShutdownRequest) returns (ShutdownResponse);
+  rpc Quiesce(QuiesceRequest) returns (QuiesceResponse);
+  rpc Thaw(ThawRequest) returns (ThawResponse);
 }
 
 service Container {
@@ -471,6 +485,11 @@ service Execution {
   rpc Kill(KillRequest) returns (KillResponse);
   rpc ResizeTty(ResizeTtyRequest) returns (ResizeTtyResponse);
 }
+
+service Files {
+  rpc Upload(stream UploadChunk) returns (UploadResponse);
+  rpc Download(DownloadRequest) returns (stream DownloadChunk);
+}
 ```
 
 ### Initialization Sequence
@@ -480,7 +499,7 @@ Host                              Guest (Box)
   │                                 │
   │──── spawn Box subprocess ──────▶│
   │                                 │
-  │◀─── ready notification ─────────│ (vsock connect to port 2696)
+  │◀─── ready notification ─────────│ (host-ready socket signaled)
   │                                 │
   │──── Guest.Init ────────────────▶│ (mounts, rootfs, network)
   │◀─── GuestInitResponse ──────────│
@@ -497,7 +516,7 @@ Host                              Guest (Box)
 
 BoxLite provides comprehensive metrics at runtime and per-Box levels.
 
-**Location:** `boxlite/src/metrics/`
+**Location:** `src/boxlite/src/metrics/`
 
 ### Architecture
 
@@ -507,20 +526,22 @@ BoxLite provides comprehensive metrics at runtime and per-Box levels.
 │  ┌─────────────────────────────────┐   │
 │  │  AtomicU64 counters (lock-free) │   │
 │  │  - boxes_created                │   │
-│  │  - boxes_destroyed              │   │
-│  │  - total_exec_calls             │   │
-│  │  - total_bytes_transferred      │   │
+│  │  - boxes_failed                 │   │
+│  │  - boxes_stopped                │   │
+│  │  - total_commands               │   │
+│  │  - total_exec_errors            │   │
 │  └─────────────────────────────────┘   │
 └─────────────────────────────────────────┘
            │
            ▼
 ┌─────────────────────────────────────────┐
 │            BoxMetrics (per-Box)         │
-│  - cpu_time_ms                          │
-│  - memory_usage_bytes                   │
-│  - exec_count                           │
+│  - commands_executed                    │
+│  - exec_errors                          │
+│  - cpu_percent / memory_bytes           │
 │  - network_bytes_sent                   │
 │  - network_bytes_received               │
+│  - stage_*_duration_ms                  │
 └─────────────────────────────────────────┘
 ```
 
@@ -554,7 +575,7 @@ BoxLite provides language-specific SDKs built on the core Rust library.
 | SDK         | Technology     | Status      | Location       |
 |-------------|----------------|-------------|----------------|
 | **Python**  | PyO3 + maturin | Available   | `sdks/python/` |
-| **Node.js** | napi-rs        | In Progress | `sdks/node/`   |
+| **Node.js** | napi-rs        | Available   | `sdks/node/`   |
 | **C**       | FFI + cbindgen | Available   | `sdks/c/`      |
 
 ## Shared Library
@@ -562,7 +583,7 @@ BoxLite provides language-specific SDKs built on the core Rust library.
 The `boxlite-shared` crate contains data types, error definitions, and constants shared between the
 host runtime, the shim, and the guest agent.
 
-**Location:** `boxlite-shared/`
+**Location:** `src/shared/`
 
 **Key Components:**
 
@@ -576,18 +597,31 @@ Default home directory: `~/.boxlite`
 
 ```
 ~/.boxlite/
+├── .lock               # Runtime lock file (single process per BOXLITE_HOME)
+├── db/
+│   └── boxlite.db      # SQLite metadata (boxes/images/snapshots/base refs)
 ├── boxes/              # Per-Box runtime data
 │   └── {box-id}/
-│       ├── rootfs/     # Container rootfs
-│       └── config.json
+│       ├── sockets/    # box.sock / ready.sock / net.sock
+│       ├── mounts/     # Host preparation area
+│       ├── shared/     # Guest-visible share root
+│       ├── disks/
+│       │   ├── disk.qcow2
+│       │   └── guest-rootfs.qcow2
+│       ├── logs/       # boxlite-shim.log / console.log
+│       └── tmp/
 ├── images/             # OCI image cache
-│   ├── blobs/          # Image layer blobs (by digest)
-│   └── index.json      # Image index
-├── init/               # Shared init rootfs
-│   └── rootfs/
-├── logs/               # Runtime logs
-│   └── boxlite.log     # Daily rotating log
-└── boxlite.lock        # Runtime lock file (prevents multiple instances)
+│   ├── layers/
+│   ├── extracted/
+│   ├── disk-images/
+│   ├── manifests/
+│   ├── configs/
+│   └── local/
+├── bases/              # Shared base/backing files
+├── locks/              # Per-entity lock files
+├── tmp/                # Runtime temp files
+└── logs/
+    └── boxlite.log     # Runtime log
 ```
 
 ## Concurrency Model
@@ -596,16 +630,17 @@ Default home directory: `~/.boxlite`
 
 - `BoxliteRuntime`: `Send + Sync`, safely shareable across threads
 - `LiteBox`: `Send + Sync`, handles can be passed between threads
-- Single `RwLock` protects all mutable runtime state
+- Runtime coordination uses `sync_state: RwLock<...>` plus manager-internal locks
 - Metrics use `AtomicU64` for lock-free updates
 
-### Single Lock Design
+### Locking Design
 
-BoxLite uses one `RwLock` for all mutable state:
+BoxLite uses layered synchronization:
 
-- Eliminates nested locking complexity
-- Simplifies reasoning about concurrency
+- Runtime-level coordination lock (`sync_state`) for multi-step atomic flows
+- Manager-level internal locks (`BoxManager`, `ImageStore`, etc.)
 - Filesystem lock prevents multiple runtimes using same `BOXLITE_HOME`
+- Per-entity file locks provide cross-process safety for box operations
 
 ### Async Design
 
@@ -621,6 +656,7 @@ Centralized error type: `BoxliteError`
 pub enum BoxliteError {
     UnsupportedEngine,
     Engine(String),
+    Config(String),
     Storage(String),
     Image(String),
     Portal(String),
@@ -629,6 +665,15 @@ pub enum BoxliteError {
     RpcTransport(String),
     Internal(String),
     Execution(String),
+    Unsupported(String),
+    NotFound(String),
+    AlreadyExists(String),
+    InvalidState(String),
+    Database(String),
+    MetadataError(String),
+    InvalidArgument(String),
+    Stopped(String),
+    ResourceExhausted(String),
 }
 ```
 

--- a/docs/development/boot-latency-analysis.md
+++ b/docs/development/boot-latency-analysis.md
@@ -2,7 +2,7 @@
 
 **Date:** 2025-02-22
 **Scope:** `handle.start()` latency on macOS ARM64 (Apple Silicon)
-**Test:** `boxlite/tests/timing_profile.rs` with `alpine:latest` image
+**Test:** `src/boxlite/tests/timing_profile.rs` with `alpine:latest` image
 
 ## Executive Summary
 

--- a/docs/development/rust-style.md
+++ b/docs/development/rust-style.md
@@ -54,7 +54,7 @@ async fn read_config(path: &Path) -> Result<Config> {
 
 ### Centralized Error Handling
 
-Use the `BoxliteError` enum for all errors (see `boxlite-shared/src/errors.rs`):
+Use the `BoxliteError` enum for all errors (see `src/shared/src/errors.rs`):
 
 ```rust
 // ✅ Correct: use BoxliteError with context

--- a/docs/guides/macos-sandbox-debugging.md
+++ b/docs/guides/macos-sandbox-debugging.md
@@ -205,10 +205,10 @@ BoxLite's sandbox policy is split into multiple files:
 
 ### Viewing Generated Policy
 
-The full runtime policy is assembled in `boxlite/src/jailer/sandbox/seatbelt.rs` by `build_sandbox_policy()` and passed directly via `sandbox-exec -p`.
+The full runtime policy is assembled in `src/boxlite/src/jailer/sandbox/seatbelt.rs` by `build_sandbox_policy()` and passed directly via `sandbox-exec -p`.
 
 When debugging, inspect:
-- Static fragments in `boxlite/resources/seatbelt/*.sbpl`
+- Static fragments in `src/boxlite/resources/seatbelt/*.sbpl`
 - Dynamic path grants from `build_dynamic_read_paths()` and `build_dynamic_write_paths()`
 - Sandbox denials from `log show`/`log stream` to identify missing allowlist clauses
 

--- a/docs/investigations/concurrent-exec-deadlock.md
+++ b/docs/investigations/concurrent-exec-deadlock.md
@@ -207,8 +207,8 @@ only one build() runs at a time, yet it still stalls intermittently.
 Traced the call path through these files:
 
 ```
-guest/src/service/exec/executor.rs    → ContainerExecutor::spawn()
-guest/src/container/command.rs        → build_and_spawn()
+src/guest/src/service/exec/executor.rs    → ContainerExecutor::spawn()
+src/guest/src/container/command.rs        → build_and_spawn()
 libcontainer/tenant_builder.rs        → TenantContainerBuilder::build()
 libcontainer/builder_impl.rs          → ContainerBuilderImpl::create()
                                       → run_container()
@@ -238,7 +238,7 @@ waiting for the intermediate process to send `intermediate_ready`.
 
 ### Step 3: Add Watchdog Diagnostic Thread
 
-**Tool:** Custom diagnostic code in `guest/src/container/command.rs`
+**Tool:** Custom diagnostic code in `src/guest/src/container/command.rs`
 
 Added a watchdog thread that fires after 3 seconds if `build()` hasn't completed:
 
@@ -630,9 +630,9 @@ When intermediate deadlocks at step 5:
 ## Files Read During Investigation
 
 ```
-guest/src/container/command.rs                                    (MODIFIED — watchdog)
-guest/src/service/exec/executor.rs                                (ContainerExecutor::spawn)
-guest/src/service/exec/mod.rs
+src/guest/src/container/command.rs                                    (MODIFIED — watchdog)
+src/guest/src/service/exec/executor.rs                                (ContainerExecutor::spawn)
+src/guest/src/service/exec/mod.rs
 libcontainer/src/channel.rs                                       (base channel, socketpair)
 libcontainer/src/process/channel.rs                               (Main/Inter/Init channels)
 libcontainer/src/process/container_main_process.rs                (fork + channel lifecycle)

--- a/sdks/go/boxlite.go
+++ b/sdks/go/boxlite.go
@@ -96,6 +96,10 @@ func (r *Runtime) Shutdown(_ context.Context, timeout time.Duration) error {
 }
 
 // Create creates and returns a new box.
+//
+// The image argument is the registry reference to pull when no usable local path is
+// selected. With [WithRootfsPath], if that path exists as a directory it takes
+// precedence and image is ignored; if the path is missing, Create uses image instead.
 func (r *Runtime) Create(_ context.Context, image string, opts ...BoxOption) (*Box, error) {
 	cfg := &boxConfig{}
 	for _, o := range opts {

--- a/sdks/go/boxlite_test.go
+++ b/sdks/go/boxlite_test.go
@@ -2,6 +2,8 @@ package boxlite
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -150,6 +152,93 @@ func TestRuntimeOptions(t *testing.T) {
 // ============================================================================
 // Wire types
 // ============================================================================
+
+func TestBuildOptionsJSON_WithRootfsPath(t *testing.T) {
+	bundle := t.TempDir()
+	cfg := &boxConfig{}
+	WithRootfsPath(bundle)(cfg)
+	wire, err := buildOptionsJSON("", cfg)
+	if err != nil {
+		t.Fatalf("buildOptionsJSON: %v", err)
+	}
+	path, ok := wire.Rootfs.(wireRootfsPath)
+	if !ok {
+		t.Fatalf("Rootfs type: got %T", wire.Rootfs)
+	}
+	if path.RootfsPath != bundle {
+		t.Errorf("RootfsPath: got %q", path.RootfsPath)
+	}
+}
+
+func TestBuildOptionsJSON_RootfsPathWinsOverImage(t *testing.T) {
+	bundle := t.TempDir()
+	cfg := &boxConfig{}
+	WithRootfsPath(bundle)(cfg)
+	wire, err := buildOptionsJSON("alpine:latest", cfg)
+	if err != nil {
+		t.Fatalf("buildOptionsJSON: %v", err)
+	}
+	path, ok := wire.Rootfs.(wireRootfsPath)
+	if !ok {
+		t.Fatalf("Rootfs type: got %T", wire.Rootfs)
+	}
+	if path.RootfsPath != bundle {
+		t.Errorf("RootfsPath: got %q", path.RootfsPath)
+	}
+}
+
+func TestBuildOptionsJSON_RootfsPathMissingFallsBackToImage(t *testing.T) {
+	cfg := &boxConfig{}
+	WithRootfsPath("/no/such/oci-bundle-xyz")(cfg)
+	wire, err := buildOptionsJSON("alpine:latest", cfg)
+	if err != nil {
+		t.Fatalf("buildOptionsJSON: %v", err)
+	}
+	img, ok := wire.Rootfs.(wireRootfsImage)
+	if !ok {
+		t.Fatalf("Rootfs type: got %T", wire.Rootfs)
+	}
+	if img.Image != "alpine:latest" {
+		t.Errorf("Image: got %q", img.Image)
+	}
+}
+
+func TestBuildOptionsJSON_RootfsPathNotDirFallsBackToImage(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(f, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &boxConfig{}
+	WithRootfsPath(f)(cfg)
+	wire, err := buildOptionsJSON("ubuntu:22.04", cfg)
+	if err != nil {
+		t.Fatalf("buildOptionsJSON: %v", err)
+	}
+	out, ok := wire.Rootfs.(wireRootfsImage)
+	if !ok {
+		t.Fatalf("Rootfs type: got %T", wire.Rootfs)
+	}
+	if out.Image != "ubuntu:22.04" {
+		t.Errorf("Image: got %q", out.Image)
+	}
+}
+
+func TestBuildOptionsJSON_RootfsPathMissingAndNoImage(t *testing.T) {
+	cfg := &boxConfig{}
+	WithRootfsPath("/no/such/bundle")(cfg)
+	_, err := buildOptionsJSON("", cfg)
+	if err == nil {
+		t.Fatal("expected error when local path is missing and image is empty")
+	}
+}
+
+func TestBuildOptionsJSON_MissingImageAndPath(t *testing.T) {
+	cfg := &boxConfig{}
+	_, err := buildOptionsJSON("", cfg)
+	if err == nil {
+		t.Fatal("expected error when image is empty and WithRootfsPath is not set")
+	}
+}
 
 func TestBuildOptionsJSON(t *testing.T) {
 	cfg := &boxConfig{}

--- a/sdks/go/options.go
+++ b/sdks/go/options.go
@@ -45,6 +45,7 @@ type boxConfig struct {
 	name       string
 	cpus       int
 	memoryMiB  int
+	rootfsPath string
 	env        [][2]string
 	volumes    []volumeEntry
 	workDir    string
@@ -75,6 +76,17 @@ func WithCPUs(n int) BoxOption {
 // WithMemory sets the memory limit in MiB.
 func WithMemory(mib int) BoxOption {
 	return func(c *boxConfig) { c.memoryMiB = mib }
+}
+
+// WithRootfsPath prefers a local OCI image layout directory over pulling from a registry.
+//
+// If the path exists and is a directory, it is used and the image argument to
+// [Runtime.Create] is ignored. Otherwise BoxLite falls back to the image reference
+// (for example when the directory has not been exported yet).
+//
+// The directory should contain a valid OCI bundle (oci-layout, index.json, blobs/sha256/, …).
+func WithRootfsPath(path string) BoxOption {
+	return func(c *boxConfig) { c.rootfsPath = path }
 }
 
 // WithEnv adds an environment variable.

--- a/sdks/go/wire.go
+++ b/sdks/go/wire.go
@@ -2,6 +2,8 @@ package boxlite
 
 import (
 	"fmt"
+	"os"
+	"strings"
 	"time"
 )
 
@@ -52,6 +54,11 @@ type wireSecret struct {
 // wireRootfsImage matches Rust RootfsSpec::Image serialization.
 type wireRootfsImage struct {
 	Image string `json:"Image"`
+}
+
+// wireRootfsPath matches Rust RootfsSpec::RootfsPath serialization.
+type wireRootfsPath struct {
+	RootfsPath string `json:"RootfsPath"`
 }
 
 // boxInfoWire matches the JSON from box_info_to_json() in ffi/src/json.rs.
@@ -125,8 +132,32 @@ func (w *imagePullResultWire) toImagePullResult() ImagePullResult {
 
 // buildOptionsJSON creates the JSON wire representation from boxConfig.
 func buildOptionsJSON(image string, cfg *boxConfig) (boxOptionsWire, error) {
+	image = strings.TrimSpace(image)
+	rootfsPath := strings.TrimSpace(cfg.rootfsPath)
+
+	useLocalOCI := false
+	if rootfsPath != "" {
+		if fi, err := os.Stat(rootfsPath); err == nil && fi.IsDir() {
+			useLocalOCI = true
+		}
+	}
+
+	var rootfs any
+	switch {
+	case useLocalOCI:
+		// Local OCI bundle: image is ignored when the path exists and is a directory.
+		rootfs = wireRootfsPath{RootfsPath: rootfsPath}
+	case image != "":
+		// Registry image, or fallback when WithRootfsPath points to a missing path.
+		rootfs = wireRootfsImage{Image: image}
+	default:
+		return boxOptionsWire{}, fmt.Errorf(
+			"boxlite: image reference is required when WithRootfsPath is unset, the path does not exist, or it is not a directory",
+		)
+	}
+
 	w := boxOptionsWire{
-		Rootfs: wireRootfsImage{Image: image},
+		Rootfs: rootfs,
 		Env:    cfg.env,
 	}
 


### PR DESCRIPTION
## Summary
- refresh outdated architecture docs to match current source tree and runtime model
- fix stale source paths in development/investigation guides (`src/boxlite/...`, `src/guest/...`, `src/shared/...`)
- update protocol, metrics, filesystem layout, and service descriptions in architecture docs

## Changed files
- docs/architecture/README.md
- docs/development/boot-latency-analysis.md
- docs/development/rust-style.md
- docs/guides/macos-sandbox-debugging.md
- docs/investigations/concurrent-exec-deadlock.md

## Notes
- documentation-only change
