### PR TITLE
Add interactive execution support to C and Go SDKs

### DIFF
--- a/sdks/c/include/boxlite.h
+++ b/sdks/c/include/boxlite.h
@@ -64,6 +64,9 @@ typedef struct BoxHandle BoxHandle;
 // Opaque handle for Runner API (auto-manages runtime)
 typedef struct BoxRunner BoxRunner;
 
+// Opaque handle to a running command execution.
+typedef struct ExecutionHandle ExecutionHandle;
+
 // Opaque handle to runtime image operations.
 typedef struct ImageHandle ImageHandle;
 
@@ -112,7 +115,11 @@ typedef struct BoxliteCommand {
   const char *user;
   // Timeout in seconds. 0.0 = no timeout.
   double timeout_secs;
+  // Enable TTY mode for interactive programs.
+  int tty;
 } BoxliteCommand;
+
+typedef struct ExecutionHandle CExecutionHandle;
 
 typedef struct BoxRunner CBoxliteSimple;
 
@@ -242,6 +249,31 @@ enum BoxliteErrorCode boxlite_execute_cmd(CBoxHandle *handle,
                                           void *user_data,
                                           int *out_exit_code,
                                           CBoxliteError *out_error);
+
+enum BoxliteErrorCode boxlite_exec_start(CBoxHandle *handle,
+                                         const struct BoxliteCommand *cmd,
+                                         void (*callback)(const char*, int, void*),
+                                         void *user_data,
+                                         CExecutionHandle **out_execution,
+                                         CBoxliteError *out_error);
+
+enum BoxliteErrorCode boxlite_exec_write(CExecutionHandle *execution,
+                                         const char *data,
+                                         int len,
+                                         CBoxliteError *out_error);
+
+enum BoxliteErrorCode boxlite_exec_wait(CExecutionHandle *execution,
+                                        int *out_exit_code,
+                                        CBoxliteError *out_error);
+
+enum BoxliteErrorCode boxlite_exec_kill(CExecutionHandle *execution, CBoxliteError *out_error);
+
+enum BoxliteErrorCode boxlite_exec_resize_tty(CExecutionHandle *execution,
+                                              int rows,
+                                              int cols,
+                                              CBoxliteError *out_error);
+
+void boxlite_exec_free(CExecutionHandle *execution);
 
 enum BoxliteErrorCode boxlite_simple_new(const char *image,
                                          int cpus,

--- a/sdks/c/src/exec.rs
+++ b/sdks/c/src/exec.rs
@@ -7,17 +7,18 @@ use std::ptr;
 use std::sync::Arc;
 
 use tokio::runtime::Runtime as TokioRuntime;
+use tokio::task::JoinHandle;
 
 use boxlite::litebox::LiteBox;
 use boxlite::runtime::BoxliteRuntime;
 use boxlite::runtime::options::{BoxOptions, BoxliteOptions};
-use boxlite::{BoxID, BoxliteError, RootfsSpec};
+use boxlite::{BoxID, BoxliteError, ExecStdin, Execution, RootfsSpec};
 
 use crate::box_handle::BoxHandle;
 use crate::error::{BoxliteErrorCode, FFIError, error_to_code, null_pointer_error, write_error};
 use crate::runtime::create_tokio_runtime;
 use crate::util::c_str_to_string;
-use crate::{CBoxHandle, CBoxliteError, CBoxliteExecResult, CBoxliteSimple};
+use crate::{CBoxHandle, CBoxliteError, CBoxliteExecResult, CBoxliteSimple, CExecutionHandle};
 
 /// Opaque handle for Runner API (auto-manages runtime)
 pub struct BoxRunner {
@@ -33,6 +34,15 @@ pub struct ExecResult {
     pub exit_code: c_int,
     pub stdout_text: *mut c_char,
     pub stderr_text: *mut c_char,
+}
+
+/// Opaque handle to a running command execution.
+pub struct ExecutionHandle {
+    execution: Option<Execution>,
+    stdin: Option<ExecStdin>,
+    output_task: Option<JoinHandle<()>>,
+    completed: bool,
+    tokio_rt: Arc<TokioRuntime>,
 }
 
 impl BoxRunner {
@@ -75,6 +85,8 @@ pub struct BoxliteCommand {
     pub user: *const c_char,
     /// Timeout in seconds. 0.0 = no timeout.
     pub timeout_secs: f64,
+    /// Enable TTY mode for interactive programs.
+    pub tty: c_int,
 }
 
 #[unsafe(no_mangle)]
@@ -110,6 +122,60 @@ pub unsafe extern "C" fn boxlite_execute_cmd(
     out_error: *mut CBoxliteError,
 ) -> BoxliteErrorCode {
     box_exec_cmd(handle, cmd, callback, user_data, out_exit_code, out_error)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_exec_start(
+    handle: *mut CBoxHandle,
+    cmd: *const BoxliteCommand,
+    callback: Option<extern "C" fn(*const c_char, c_int, *mut c_void)>,
+    user_data: *mut c_void,
+    out_execution: *mut *mut CExecutionHandle,
+    out_error: *mut CBoxliteError,
+) -> BoxliteErrorCode {
+    exec_start(handle, cmd, callback, user_data, out_execution, out_error)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_exec_write(
+    execution: *mut CExecutionHandle,
+    data: *const c_char,
+    len: c_int,
+    out_error: *mut CBoxliteError,
+) -> BoxliteErrorCode {
+    exec_write(execution, data, len, out_error)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_exec_wait(
+    execution: *mut CExecutionHandle,
+    out_exit_code: *mut c_int,
+    out_error: *mut CBoxliteError,
+) -> BoxliteErrorCode {
+    exec_wait(execution, out_exit_code, out_error)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_exec_kill(
+    execution: *mut CExecutionHandle,
+    out_error: *mut CBoxliteError,
+) -> BoxliteErrorCode {
+    exec_kill(execution, out_error)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_exec_resize_tty(
+    execution: *mut CExecutionHandle,
+    rows: c_int,
+    cols: c_int,
+    out_error: *mut CBoxliteError,
+) -> BoxliteErrorCode {
+    exec_resize_tty(execution, rows, cols, out_error)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_exec_free(execution: *mut CExecutionHandle) {
+    exec_free(execution)
 }
 
 #[unsafe(no_mangle)]
@@ -264,64 +330,16 @@ unsafe fn box_exec_cmd(
             return BoxliteErrorCode::InvalidArgument;
         }
 
-        let handle_ref = &mut *handle;
         let cmd_ref = &*cmd;
-
-        // Parse command (required)
-        let cmd_str = match c_str_to_string(cmd_ref.command) {
-            Ok(s) => s,
+        let handle_ref = &mut *handle;
+        let box_cmd = match parse_boxlite_command(cmd_ref) {
+            Ok(command) => command,
             Err(e) => {
                 let code = error_to_code(&e);
                 write_error(out_error, e);
                 return code;
             }
         };
-
-        let mut box_cmd = boxlite::BoxCommand::new(cmd_str);
-        box_cmd = box_cmd.args(crate::util::parse_c_string_array(
-            cmd_ref.args,
-            cmd_ref.argc,
-        ));
-
-        let env_pairs = crate::util::parse_c_string_array(cmd_ref.env_pairs, cmd_ref.env_count);
-        for pair in env_pairs.chunks(2) {
-            if let [key, value] = pair {
-                box_cmd = box_cmd.env(key.clone(), value.clone());
-            }
-        }
-
-        // Parse workdir
-        if !cmd_ref.workdir.is_null() {
-            match c_str_to_string(cmd_ref.workdir) {
-                Ok(dir) => {
-                    box_cmd = box_cmd.working_dir(dir);
-                }
-                Err(e) => {
-                    let code = error_to_code(&e);
-                    write_error(out_error, e);
-                    return code;
-                }
-            }
-        }
-
-        // Parse user
-        if !cmd_ref.user.is_null() {
-            match c_str_to_string(cmd_ref.user) {
-                Ok(u) => {
-                    box_cmd = box_cmd.user(u);
-                }
-                Err(e) => {
-                    let code = error_to_code(&e);
-                    write_error(out_error, e);
-                    return code;
-                }
-            }
-        }
-
-        // Parse timeout
-        if cmd_ref.timeout_secs > 0.0 {
-            box_cmd = box_cmd.timeout(std::time::Duration::from_secs_f64(cmd_ref.timeout_secs));
-        }
 
         // Execute command
         let result = handle_ref.tokio_rt.block_on(async {
@@ -370,6 +388,341 @@ unsafe fn box_exec_cmd(
                 code
             }
         }
+    }
+}
+
+unsafe fn exec_start(
+    handle: *mut BoxHandle,
+    cmd: *const BoxliteCommand,
+    callback: Option<OutputCallback>,
+    user_data: *mut c_void,
+    out_execution: *mut *mut ExecutionHandle,
+    out_error: *mut FFIError,
+) -> BoxliteErrorCode {
+    unsafe {
+        if handle.is_null() {
+            write_error(out_error, null_pointer_error("handle"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        if cmd.is_null() {
+            write_error(out_error, null_pointer_error("cmd"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        if out_execution.is_null() {
+            write_error(out_error, null_pointer_error("out_execution"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        *out_execution = ptr::null_mut();
+
+        let handle_ref = &mut *handle;
+        let command = match parse_boxlite_command(&*cmd) {
+            Ok(command) => command,
+            Err(e) => {
+                let code = error_to_code(&e);
+                write_error(out_error, e);
+                return code;
+            }
+        };
+
+        let tokio_rt = handle_ref.tokio_rt.clone();
+        let execution_rt = tokio_rt.clone();
+        let result = tokio_rt.block_on(async {
+            let mut execution = handle_ref.handle.exec(command).await?;
+            let stdin = execution.stdin();
+            let stdout = execution.stdout();
+            let stderr = execution.stderr();
+            let output_task = spawn_output_task(&tokio_rt, stdout, stderr, callback, user_data);
+
+            Ok::<ExecutionHandle, BoxliteError>(ExecutionHandle {
+                execution: Some(execution),
+                stdin,
+                output_task: Some(output_task),
+                completed: false,
+                tokio_rt: execution_rt,
+            })
+        });
+
+        match result {
+            Ok(execution) => {
+                *out_execution = Box::into_raw(Box::new(execution));
+                BoxliteErrorCode::Ok
+            }
+            Err(e) => {
+                let code = error_to_code(&e);
+                write_error(out_error, e);
+                code
+            }
+        }
+    }
+}
+
+fn spawn_output_task(
+    tokio_rt: &Arc<TokioRuntime>,
+    mut stdout: Option<boxlite::ExecStdout>,
+    mut stderr: Option<boxlite::ExecStderr>,
+    callback: Option<OutputCallback>,
+    user_data: *mut c_void,
+) -> JoinHandle<()> {
+    let user_data = user_data as usize;
+    tokio_rt.spawn(async move {
+        loop {
+            tokio::select! {
+                Some(line) = async {
+                    match &mut stdout {
+                        Some(stream) => stream.next().await,
+                        None => None,
+                    }
+                } => {
+                    write_streaming_output(callback, line, 0, user_data);
+                }
+                Some(line) = async {
+                    match &mut stderr {
+                        Some(stream) => stream.next().await,
+                        None => None,
+                    }
+                } => {
+                    write_streaming_output(callback, line, 1, user_data);
+                }
+                else => break,
+            }
+        }
+    })
+}
+
+fn write_streaming_output(
+    callback: Option<OutputCallback>,
+    line: String,
+    is_stderr: c_int,
+    user_data: usize,
+) {
+    let Some(callback) = callback else {
+        return;
+    };
+
+    if let Ok(text) = CString::new(line) {
+        callback(text.as_ptr(), is_stderr, user_data as *mut c_void);
+    }
+}
+
+unsafe fn exec_write(
+    execution: *mut ExecutionHandle,
+    data: *const c_char,
+    len: c_int,
+    out_error: *mut FFIError,
+) -> BoxliteErrorCode {
+    unsafe {
+        if execution.is_null() {
+            write_error(out_error, null_pointer_error("execution"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        if data.is_null() && len > 0 {
+            write_error(out_error, null_pointer_error("data"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        if len < 0 {
+            write_error(
+                out_error,
+                BoxliteError::InvalidArgument("len must be non-negative".to_string()),
+            );
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        if len == 0 {
+            return BoxliteErrorCode::Ok;
+        }
+
+        let execution_ref = &mut *execution;
+        let Some(stdin) = execution_ref.stdin.as_mut() else {
+            write_error(
+                out_error,
+                BoxliteError::InvalidState("execution stdin is closed".to_string()),
+            );
+            return BoxliteErrorCode::InvalidState;
+        };
+
+        let bytes = std::slice::from_raw_parts(data as *const u8, len as usize);
+        match execution_ref.tokio_rt.block_on(stdin.write(bytes)) {
+            Ok(()) => BoxliteErrorCode::Ok,
+            Err(e) => {
+                let code = error_to_code(&e);
+                write_error(out_error, e);
+                code
+            }
+        }
+    }
+}
+
+unsafe fn exec_wait(
+    execution: *mut ExecutionHandle,
+    out_exit_code: *mut c_int,
+    out_error: *mut FFIError,
+) -> BoxliteErrorCode {
+    unsafe {
+        if execution.is_null() {
+            write_error(out_error, null_pointer_error("execution"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        if out_exit_code.is_null() {
+            write_error(out_error, null_pointer_error("out_exit_code"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+
+        let execution_ref = &mut *execution;
+        let Some(execution) = execution_ref.execution.as_mut() else {
+            write_error(
+                out_error,
+                BoxliteError::InvalidState("execution has been freed".to_string()),
+            );
+            return BoxliteErrorCode::InvalidState;
+        };
+
+        let result = execution_ref.tokio_rt.block_on(async {
+            let result = execution.wait().await;
+            if let Some(task) = execution_ref.output_task.take() {
+                let _ = task.await;
+            }
+            result
+        });
+
+        match result {
+            Ok(status) => {
+                execution_ref.completed = true;
+                *out_exit_code = status.exit_code;
+                BoxliteErrorCode::Ok
+            }
+            Err(e) => {
+                let code = error_to_code(&e);
+                write_error(out_error, e);
+                code
+            }
+        }
+    }
+}
+
+unsafe fn exec_kill(execution: *mut ExecutionHandle, out_error: *mut FFIError) -> BoxliteErrorCode {
+    unsafe {
+        if execution.is_null() {
+            write_error(out_error, null_pointer_error("execution"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+
+        let execution_ref = &mut *execution;
+        let Some(execution) = execution_ref.execution.as_mut() else {
+            write_error(
+                out_error,
+                BoxliteError::InvalidState("execution has been freed".to_string()),
+            );
+            return BoxliteErrorCode::InvalidState;
+        };
+
+        match execution_ref.tokio_rt.block_on(execution.kill()) {
+            Ok(()) => BoxliteErrorCode::Ok,
+            Err(e) => {
+                let code = error_to_code(&e);
+                write_error(out_error, e);
+                code
+            }
+        }
+    }
+}
+
+unsafe fn exec_resize_tty(
+    execution: *mut ExecutionHandle,
+    rows: c_int,
+    cols: c_int,
+    out_error: *mut FFIError,
+) -> BoxliteErrorCode {
+    unsafe {
+        if execution.is_null() {
+            write_error(out_error, null_pointer_error("execution"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        if rows <= 0 || cols <= 0 {
+            write_error(
+                out_error,
+                BoxliteError::InvalidArgument("rows and cols must be positive".to_string()),
+            );
+            return BoxliteErrorCode::InvalidArgument;
+        }
+
+        let execution_ref = &mut *execution;
+        let Some(execution) = execution_ref.execution.as_ref() else {
+            write_error(
+                out_error,
+                BoxliteError::InvalidState("execution has been freed".to_string()),
+            );
+            return BoxliteErrorCode::InvalidState;
+        };
+
+        match execution_ref
+            .tokio_rt
+            .block_on(execution.resize_tty(rows as u32, cols as u32))
+        {
+            Ok(()) => BoxliteErrorCode::Ok,
+            Err(e) => {
+                let code = error_to_code(&e);
+                write_error(out_error, e);
+                code
+            }
+        }
+    }
+}
+
+unsafe fn exec_free(execution: *mut ExecutionHandle) {
+    if execution.is_null() {
+        return;
+    }
+
+    unsafe {
+        let mut execution = Box::from_raw(execution);
+        if let Some(mut stdin) = execution.stdin.take() {
+            stdin.close();
+        }
+
+        if let Some(mut running) = execution.execution.take()
+            && !execution.completed
+        {
+            let _ = execution.tokio_rt.block_on(async {
+                let _ = running.kill().await;
+                running.wait().await
+            });
+        }
+
+        if let Some(task) = execution.output_task.take() {
+            task.abort();
+        }
+    }
+}
+
+unsafe fn parse_boxlite_command(cmd: &BoxliteCommand) -> Result<boxlite::BoxCommand, BoxliteError> {
+    unsafe {
+        let cmd_str = c_str_to_string(cmd.command)?;
+        let mut box_cmd = boxlite::BoxCommand::new(cmd_str)
+            .args(crate::util::parse_c_string_array(cmd.args, cmd.argc));
+
+        let env_pairs = crate::util::parse_c_string_array(cmd.env_pairs, cmd.env_count);
+        for pair in env_pairs.chunks(2) {
+            if let [key, value] = pair {
+                box_cmd = box_cmd.env(key.clone(), value.clone());
+            }
+        }
+
+        if !cmd.workdir.is_null() {
+            box_cmd = box_cmd.working_dir(c_str_to_string(cmd.workdir)?);
+        }
+
+        if !cmd.user.is_null() {
+            box_cmd = box_cmd.user(c_str_to_string(cmd.user)?);
+        }
+
+        if cmd.timeout_secs > 0.0 {
+            box_cmd = box_cmd.timeout(std::time::Duration::from_secs_f64(cmd.timeout_secs));
+        }
+
+        if cmd.tty != 0 {
+            box_cmd = box_cmd.tty(true);
+        }
+
+        Ok(box_cmd)
     }
 }
 
@@ -609,5 +962,108 @@ unsafe fn runner_free(runner: *mut BoxRunner) {
 
             drop(runner_box);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ptr;
+
+    use super::*;
+
+    extern "C" fn noop_callback(_: *const c_char, _: c_int, _: *mut c_void) {}
+
+    #[test]
+    fn exec_start_rejects_null_handle() {
+        let command = CString::new("/bin/sh").expect("command cstring");
+        let cmd = BoxliteCommand {
+            command: command.as_ptr(),
+            args: ptr::null(),
+            argc: 0,
+            env_pairs: ptr::null(),
+            env_count: 0,
+            workdir: ptr::null(),
+            user: ptr::null(),
+            timeout_secs: 0.0,
+            tty: 1,
+        };
+        let mut execution: *mut ExecutionHandle = ptr::null_mut();
+        let mut error = FFIError::default();
+
+        let code = unsafe {
+            boxlite_exec_start(
+                ptr::null_mut(),
+                &cmd as *const _,
+                Some(noop_callback),
+                ptr::null_mut(),
+                &mut execution as *mut _,
+                &mut error as *mut _,
+            )
+        };
+
+        assert_eq!(code, BoxliteErrorCode::InvalidArgument);
+        assert!(execution.is_null());
+        assert!(!error.message.is_null());
+        unsafe { crate::boxlite_error_free(&mut error as *mut _) };
+    }
+
+    #[test]
+    fn exec_write_rejects_null_execution() {
+        let mut error = FFIError::default();
+        let data = CString::new("hello").expect("data cstring");
+
+        let code =
+            unsafe { boxlite_exec_write(ptr::null_mut(), data.as_ptr(), 5, &mut error as *mut _) };
+
+        assert_eq!(code, BoxliteErrorCode::InvalidArgument);
+        assert!(!error.message.is_null());
+        unsafe { crate::boxlite_error_free(&mut error as *mut _) };
+    }
+
+    #[test]
+    fn exec_write_rejects_negative_len() {
+        let runtime = crate::runtime::create_tokio_runtime().expect("runtime");
+        let mut execution = ExecutionHandle {
+            execution: None,
+            stdin: None,
+            output_task: None,
+            completed: false,
+            tokio_rt: runtime,
+        };
+        let mut error = FFIError::default();
+
+        let code = unsafe {
+            boxlite_exec_write(
+                &mut execution as *mut _,
+                ptr::null(),
+                -1,
+                &mut error as *mut _,
+            )
+        };
+
+        assert_eq!(code, BoxliteErrorCode::InvalidArgument);
+        assert!(!error.message.is_null());
+        unsafe { crate::boxlite_error_free(&mut error as *mut _) };
+    }
+
+    #[test]
+    fn exec_resize_rejects_invalid_dimensions() {
+        let runtime = crate::runtime::create_tokio_runtime().expect("runtime");
+        let mut execution = ExecutionHandle {
+            execution: None,
+            stdin: None,
+            output_task: None,
+            completed: false,
+            tokio_rt: runtime,
+        };
+        let mut error = FFIError::default();
+
+        let code = unsafe {
+            boxlite_exec_resize_tty(&mut execution as *mut _, 0, 80, &mut error as *mut _)
+        };
+
+        assert_eq!(code, BoxliteErrorCode::InvalidArgument);
+        assert!(!error.message.is_null());
+        unsafe { crate::boxlite_error_free(&mut error as *mut _) };
     }
 }

--- a/sdks/c/src/lib.rs
+++ b/sdks/c/src/lib.rs
@@ -30,6 +30,7 @@ pub type CBoxliteExecResult = exec::ExecResult;
 pub type CBoxInfo = info::CBoxInfo;
 pub type CBoxInfoList = info::CBoxInfoList;
 pub type CBoxMetrics = metrics::CBoxMetrics;
+pub type CExecutionHandle = exec::ExecutionHandle;
 pub type CImageInfoList = images::CImageInfoList;
 pub type CImagePullResult = images::CImagePullResult;
 pub type CRuntimeMetrics = metrics::CRuntimeMetrics;

--- a/sdks/c/src/tests.rs
+++ b/sdks/c/src/tests.rs
@@ -162,6 +162,7 @@ fn test_free_functions_null_safe() {
         boxlite_error_free(ptr::null_mut());
         boxlite_result_free(ptr::null_mut());
         boxlite_simple_free(ptr::null_mut());
+        boxlite_exec_free(ptr::null_mut());
     }
 }
 

--- a/sdks/go/boxlite_test.go
+++ b/sdks/go/boxlite_test.go
@@ -71,6 +71,35 @@ func TestError_Unwrap(t *testing.T) {
 	}
 }
 
+func TestExecutionWriteRejectsClosedExecution(t *testing.T) {
+	execution := &Execution{}
+	execution.Stdin = &executionStdin{execution: execution}
+
+	_, err := execution.Write([]byte("hello"))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	var boxliteErr *Error
+	if !errors.As(err, &boxliteErr) {
+		t.Fatalf("expected *Error, got %T", err)
+	}
+	if boxliteErr.Code != ErrInvalidState {
+		t.Fatalf("Code: got %d, want %d", boxliteErr.Code, ErrInvalidState)
+	}
+}
+
+func TestExecutionCloseIsIdempotent(t *testing.T) {
+	execution := &Execution{}
+
+	if err := execution.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	if err := execution.Close(); err != nil {
+		t.Fatalf("second Close() error = %v", err)
+	}
+}
+
 // ============================================================================
 // Options
 // ============================================================================

--- a/sdks/go/bridge_callback.go
+++ b/sdks/go/bridge_callback.go
@@ -12,22 +12,30 @@ import (
 
 // callbackWriters holds the io.Writers for streaming exec output.
 type callbackWriters struct {
-	stdout io.Writer
-	stderr io.Writer
+	stdout   io.Writer
+	stderr   io.Writer
+	onStdout func([]byte)
+	onStderr func([]byte)
 }
 
 //export goBoxliteOutputCallback
 func goBoxliteOutputCallback(text *C.char, isStderr C.int, userData unsafe.Pointer) {
 	h := cgo.Handle(userData)
 	w := h.Value().(*callbackWriters)
-	goText := C.GoString(text)
+	data := []byte(C.GoString(text))
 	if isStderr != 0 {
+		if w.onStderr != nil {
+			w.onStderr(data)
+		}
 		if w.stderr != nil {
-			_, _ = w.stderr.Write([]byte(goText))
+			_, _ = w.stderr.Write(data)
 		}
 	} else {
+		if w.onStdout != nil {
+			w.onStdout(data)
+		}
 		if w.stdout != nil {
-			_, _ = w.stdout.Write([]byte(goText))
+			_, _ = w.stdout.Write(data)
 		}
 	}
 }

--- a/sdks/go/exec.go
+++ b/sdks/go/exec.go
@@ -22,6 +22,29 @@ type ExecResult struct {
 	Stderr   string
 }
 
+// ExecutionOptions configures a streaming command execution.
+type ExecutionOptions struct {
+	TTY      bool
+	Stdout   io.Writer
+	Stderr   io.Writer
+	OnStdout func([]byte)
+	OnStderr func([]byte)
+}
+
+// Execution is a handle to a running command.
+type Execution struct {
+	handle            *C.CExecutionHandle
+	callbackHandle    cgo.Handle
+	hasCallbackHandle bool
+
+	// Stdin writes bytes to the running command's standard input.
+	Stdin io.Writer
+}
+
+type executionStdin struct {
+	execution *Execution
+}
+
 // Exec executes a command and returns the buffered result.
 func (b *Box) Exec(ctx context.Context, name string, arg ...string) (*ExecResult, error) {
 	cmd := b.Command(name, arg...)
@@ -63,6 +86,164 @@ func (b *Box) Exec(ctx context.Context, name string, arg ...string) (*ExecResult
 		Stdout:   string(stdoutBuf),
 		Stderr:   string(stderrBuf),
 	}, nil
+}
+
+// StartExecution starts a command and returns a streaming execution handle.
+func (b *Box) StartExecution(_ context.Context, name string, args []string, opts *ExecutionOptions) (*Execution, error) {
+	cCmd := toCString(name)
+	defer C.free(unsafe.Pointer(cCmd))
+
+	cArgs, argc := toCStringArray(args)
+	defer freeCStringArray(cArgs, argc)
+
+	cfg := ExecutionOptions{}
+	if opts != nil {
+		cfg = *opts
+	}
+
+	cCommand := C.BoxliteCommand{
+		command:      cCmd,
+		args:         cArgs,
+		argc:         C.int(argc),
+		env_pairs:    nil,
+		env_count:    0,
+		workdir:      nil,
+		user:         nil,
+		timeout_secs: 0,
+		tty:          boolToCInt(cfg.TTY),
+	}
+
+	var callback *[0]byte
+	var userData unsafe.Pointer
+	var callbackHandle cgo.Handle
+	hasCallbackHandle := cfg.Stdout != nil || cfg.Stderr != nil || cfg.OnStdout != nil || cfg.OnStderr != nil
+	if hasCallbackHandle {
+		writers := &callbackWriters{
+			stdout:   cfg.Stdout,
+			stderr:   cfg.Stderr,
+			onStdout: cfg.OnStdout,
+			onStderr: cfg.OnStderr,
+		}
+		callbackHandle = cgo.NewHandle(writers)
+		callback = (*[0]byte)(C.goBoxliteOutputCallback)
+		userData = handleToPtr(callbackHandle)
+	}
+
+	var handle *C.CExecutionHandle
+	var cerr C.CBoxliteError
+	code := C.boxlite_exec_start(
+		b.handle,
+		&cCommand,
+		callback,
+		userData,
+		&handle,
+		&cerr,
+	)
+	if code != C.Ok {
+		if hasCallbackHandle {
+			callbackHandle.Delete()
+		}
+		return nil, freeError(&cerr)
+	}
+
+	execution := &Execution{
+		handle:            handle,
+		callbackHandle:    callbackHandle,
+		hasCallbackHandle: hasCallbackHandle,
+	}
+	execution.Stdin = &executionStdin{execution: execution}
+	return execution, nil
+}
+
+// Write writes bytes to the running command's standard input.
+func (e *Execution) Write(p []byte) (int, error) {
+	if e.Stdin == nil {
+		return 0, &Error{Code: ErrInvalidState, Message: "execution stdin is closed"}
+	}
+	return e.Stdin.Write(p)
+}
+
+// Wait waits for the command to finish and returns its exit code.
+func (e *Execution) Wait(_ context.Context) (int, error) {
+	if e.handle == nil {
+		return 0, &Error{Code: ErrInvalidState, Message: "execution is closed"}
+	}
+
+	var exitCode C.int
+	var cerr C.CBoxliteError
+	code := C.boxlite_exec_wait(e.handle, &exitCode, &cerr)
+	e.releaseCallback()
+	if code != C.Ok {
+		return 0, freeError(&cerr)
+	}
+
+	return int(exitCode), nil
+}
+
+// Kill terminates the running command.
+func (e *Execution) Kill(_ context.Context) error {
+	if e.handle == nil {
+		return &Error{Code: ErrInvalidState, Message: "execution is closed"}
+	}
+
+	var cerr C.CBoxliteError
+	code := C.boxlite_exec_kill(e.handle, &cerr)
+	if code != C.Ok {
+		return freeError(&cerr)
+	}
+	return nil
+}
+
+// ResizeTTY changes the terminal size for TTY-enabled executions.
+func (e *Execution) ResizeTTY(_ context.Context, rows, cols int) error {
+	if e.handle == nil {
+		return &Error{Code: ErrInvalidState, Message: "execution is closed"}
+	}
+
+	var cerr C.CBoxliteError
+	code := C.boxlite_exec_resize_tty(e.handle, C.int(rows), C.int(cols), &cerr)
+	if code != C.Ok {
+		return freeError(&cerr)
+	}
+	return nil
+}
+
+// Close releases the execution handle.
+func (e *Execution) Close() error {
+	if e.handle != nil {
+		C.boxlite_exec_free(e.handle)
+		e.handle = nil
+	}
+	e.releaseCallback()
+	return nil
+}
+
+func (e *Execution) releaseCallback() {
+	if e.hasCallbackHandle {
+		e.callbackHandle.Delete()
+		e.hasCallbackHandle = false
+	}
+}
+
+func (s *executionStdin) Write(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	if s.execution == nil || s.execution.handle == nil {
+		return 0, &Error{Code: ErrInvalidState, Message: "execution is closed"}
+	}
+
+	var cerr C.CBoxliteError
+	code := C.boxlite_exec_write(
+		s.execution.handle,
+		(*C.char)(unsafe.Pointer(&p[0])),
+		C.int(len(p)),
+		&cerr,
+	)
+	if code != C.Ok {
+		return 0, freeError(&cerr)
+	}
+	return len(p), nil
 }
 
 // Command creates a Cmd for streaming execution, mirroring os/exec.Cmd.


### PR DESCRIPTION
## Summary
- add CExecutionHandle with boxlite_exec_start, boxlite_exec_write, boxlite_exec_wait, boxlite_exec_kill, boxlite_exec_resize_tty, and boxlite_exec_free
- expose Go Execution with Stdin, Write, Wait, Kill, ResizeTTY, Close, and stdout/stderr writers or callbacks
- regenerate the C header with cbindgen and keep the SDK boundary free of the legacy JSON API

## Tests
- cargo fmt -p boxlite-c --check
- cargo build -p boxlite-c
- cargo test -p boxlite-c
- cargo clippy -p boxlite-c --tests -- -D warnings
- go test -tags boxlite_dev -run '^$' .
- go test -tags boxlite_dev -run '^(TestError_|TestExecution|TestIs|TestBoxOptions|TestRuntimeOptions|TestBuildCOptions|TestStateConstants|TestWith)' .