### PR TITLE
chore(setup): install Node 22 LTS via unified setup_nodejs

### DIFF
--- a/scripts/setup/setup-common.sh
+++ b/scripts/setup/setup-common.sh
@@ -295,17 +295,164 @@ setup_go() {
     echo ""
 }
 
-# Check Node.js installation
+# Minimum Node.js version. The Node SDK's transitive devDeps
+# (@napi-rs/cli@3 -> @inquirer/core@11) need Node >= 20.12, and Node 20 hit
+# EOL on 2026-04-30, so we standardize on the active LTS line.
+NODE_MIN_MAJOR=22
+NODE_MIN_MINOR=0
+
+# Pinned Node.js version used for fresh installs. Should track the active LTS.
+NODE_INSTALL_VERSION="22.18.0"
+
+# Check Node.js installation and version.
+# Returns: 0 = OK, 1 = missing, 2 = too old
 check_nodejs() {
-    print_step "Checking for Node.js... "
-    if command_exists node; then
-        local node_version=$(node --version)
-        print_success "Found ($node_version)"
-        return 0
-    else
+    print_step "Checking for Node.js >= ${NODE_MIN_MAJOR}.${NODE_MIN_MINOR}... "
+
+    if ! command_exists node; then
         print_error "Not found"
         return 1
     fi
+
+    local node_version
+    node_version=$(node --version | sed 's/^v//')
+
+    local major minor
+    major=$(echo "$node_version" | cut -d. -f1)
+    minor=$(echo "$node_version" | cut -d. -f2)
+
+    if [ "$major" -gt "$NODE_MIN_MAJOR" ] 2>/dev/null ||
+       { [ "$major" -eq "$NODE_MIN_MAJOR" ] 2>/dev/null && [ "$minor" -ge "$NODE_MIN_MINOR" ] 2>/dev/null; }; then
+        print_success "Found (version $node_version)"
+        return 0
+    else
+        echo -e "${YELLOW}Found Node.js $node_version (too old, need >= ${NODE_MIN_MAJOR}.${NODE_MIN_MINOR})${NC}"
+        return 2
+    fi
+}
+
+# Install Node.js from official nodejs.org tarball (Linux).
+# Used as a fallback when no package manager path is available.
+install_nodejs_from_tarball() {
+    local arch
+    arch=$(uname -m)
+    case "$arch" in
+        x86_64)  arch="x64" ;;
+        aarch64) arch="arm64" ;;
+        *)
+            print_error "Unsupported architecture for Node.js: $arch"
+            return 1
+            ;;
+    esac
+
+    local tarball="node-v${NODE_INSTALL_VERSION}-linux-${arch}.tar.xz"
+    local url="https://nodejs.org/dist/v${NODE_INSTALL_VERSION}/${tarball}"
+
+    print_step "Downloading ${tarball}... "
+    local tmpfile="/tmp/${tarball}"
+    if ! curl -fsSL "$url" -o "$tmpfile"; then
+        print_error "Failed to download Node.js from $url"
+        return 1
+    fi
+    print_success "Done"
+
+    print_step "Installing to /usr/local... "
+    run_with_sudo tar -xJ -C /usr/local --strip-components=1 -f "$tmpfile"
+    rm -f "$tmpfile"
+    print_success "Installed"
+
+    local installed_version
+    installed_version=$(node --version | sed 's/^v//')
+    print_success "Node.js $installed_version installed"
+}
+
+# Install Node.js via NodeSource on Debian/Ubuntu.
+# Distro packages on Ubuntu 24.04 ship Node 18, which is EOL.
+install_nodejs_from_nodesource() {
+    print_step "Configuring NodeSource repository for Node.js ${NODE_MIN_MAJOR}.x... "
+    local nodesource_url="https://deb.nodesource.com/setup_${NODE_MIN_MAJOR}.x"
+    # NodeSource's setup script writes to /etc/apt/sources.list.d and runs
+    # apt-get update; pipe through sudo so it has the right privileges, but
+    # keep the body in a here-string to avoid shell quoting pitfalls.
+    local nodesource_script
+    if ! nodesource_script=$(curl -fsSL "$nodesource_url"); then
+        print_error "Failed to download NodeSource setup script"
+        return 1
+    fi
+    if ! echo "$nodesource_script" | run_with_sudo bash -; then
+        print_error "NodeSource setup script failed"
+        return 1
+    fi
+    print_success "Configured"
+
+    print_step "Installing nodejs... "
+    run_with_sudo apt-get install -y -qq nodejs
+    print_success "Installed"
+
+    local installed_version
+    installed_version=$(node --version | sed 's/^v//')
+    print_success "Node.js $installed_version installed"
+}
+
+# Install Node.js via Homebrew (macOS).
+install_nodejs_from_brew() {
+    if ! command_exists brew; then
+        print_error "Homebrew not found"
+        return 1
+    fi
+
+    local formula="node@${NODE_MIN_MAJOR}"
+    print_step "Installing ${formula} via Homebrew... "
+    brew install "$formula"
+    # node@N is keg-only; expose it on PATH (idempotent — --force overwrites symlinks).
+    brew link --overwrite --force "$formula" >/dev/null 2>&1 || true
+    print_success "Installed"
+
+    local installed_version
+    installed_version=$(node --version | sed 's/^v//')
+    print_success "Node.js $installed_version installed"
+}
+
+# Setup Node.js with version validation. Picks an installer based on platform.
+# Respects SKIP_INSTALL_NODEJS=1 to skip entirely.
+setup_nodejs() {
+    if [ "${SKIP_INSTALL_NODEJS:-}" = "1" ]; then
+        print_step "Skipping Node.js (SKIP_INSTALL_NODEJS=1)"
+        echo ""
+        return 0
+    fi
+
+    print_section "📦 Checking Node.js..."
+
+    local status=0
+    check_nodejs || status=$?
+
+    if [ "$status" -eq 0 ]; then
+        echo ""
+        return 0
+    fi
+
+    # Pick installer for the current platform
+    local os
+    os=$(detect_os)
+
+    case "$os" in
+        macos)
+            install_nodejs_from_brew
+            ;;
+        linux)
+            if command_exists apt-get && [ -f /etc/debian_version ]; then
+                install_nodejs_from_nodesource
+            else
+                install_nodejs_from_tarball
+            fi
+            ;;
+        *)
+            print_error "Unsupported platform for Node.js install: $os"
+            return 1
+            ;;
+    esac
+    echo ""
 }
 
 # Check if musl toolchain is available (fail fast)

--- a/scripts/setup/setup-macos.sh
+++ b/scripts/setup/setup-macos.sh
@@ -224,19 +224,10 @@ setup_go() {
     echo ""
 }
 
-# Setup Node.js
+# Node.js install delegates to setup_nodejs in setup-common.sh.
+# Local alias kept so the main flow reads the same on every platform.
 install_nodejs() {
-    if [ "${SKIP_INSTALL_NODEJS:-}" = "1" ]; then
-        print_step "Skipping Node.js (SKIP_INSTALL_NODEJS=1)"
-        echo ""
-        return 0
-    fi
-    if ! check_nodejs; then
-        echo -e "${YELLOW}Installing...${NC}"
-        brew install node
-        print_success "Node.js installed"
-    fi
-    echo ""
+    setup_nodejs
 }
 
 # Main installation flow

--- a/scripts/setup/setup-manylinux.sh
+++ b/scripts/setup/setup-manylinux.sh
@@ -183,42 +183,11 @@ install_protoc() {
     echo ""
 }
 
-# Install Node.js from nodejs.org (not available in manylinux repos)
+# Node.js install delegates to setup_nodejs in setup-common.sh.
+# manylinux has no Node packages, so the shared installer falls back to the
+# nodejs.org tarball.
 install_nodejs() {
-    if [ "${SKIP_INSTALL_NODEJS:-}" = "1" ]; then
-        print_step "Skipping Node.js (SKIP_INSTALL_NODEJS=1)"
-        echo ""
-        return 0
-    fi
-
-    print_section "📦 Installing Node.js..."
-
-    local NODE_VERSION="20.18.0"
-    local ARCH=$(uname -m)
-
-    # Map architecture names to Node.js naming convention
-    case "$ARCH" in
-        x86_64)  NODE_ARCH="x64" ;;
-        aarch64) NODE_ARCH="arm64" ;;
-        *)
-            print_error "Unsupported architecture: $ARCH"
-            return 1
-            ;;
-    esac
-
-    print_step "Checking for Node.js... "
-    if command -v node &>/dev/null; then
-        local version=$(node --version)
-        print_success "Found ($version)"
-        echo ""
-        return 0
-    fi
-
-    echo -e "${YELLOW}Downloading Node.js $NODE_VERSION...${NC}"
-    curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" \
-        | run_with_sudo tar -xJ -C /usr/local --strip-components=1
-    print_success "Node.js $NODE_VERSION installed"
-    echo ""
+    setup_nodejs
 }
 
 # Main installation flow

--- a/scripts/setup/setup-ubuntu.sh
+++ b/scripts/setup/setup-ubuntu.sh
@@ -120,29 +120,11 @@ setup_python() {
     echo ""
 }
 
-# Install Node.js
+# Node.js install delegates to setup_nodejs in setup-common.sh.
+# Distro packages on Ubuntu 24.04 ship Node 18 (EOL), so the shared installer
+# uses NodeSource to pull the active LTS line instead.
 install_nodejs() {
-    if [ "${SKIP_INSTALL_NODEJS:-}" = "1" ]; then
-        print_step "Skipping Node.js (SKIP_INSTALL_NODEJS=1)"
-        echo ""
-        return 0
-    fi
-
-    print_section "📦 Installing Node.js..."
-
-    local packages=(nodejs npm)
-
-    for pkg in "${packages[@]}"; do
-        print_step "Checking for $pkg... "
-        if apt_installed "$pkg"; then
-            print_success "Already installed"
-        else
-            echo -e "${YELLOW}Installing...${NC}"
-            apt_get install -y -qq "$pkg"
-            print_success "$pkg installed"
-        fi
-    done
-    echo ""
+    setup_nodejs
 }
 
 


### PR DESCRIPTION
## Summary

- \`make setup\` now installs Node 22 LTS instead of whatever the distro ships
- Replaces three bespoke \`install_nodejs\` flows (macOS / Ubuntu / manylinux) with a shared \`setup_nodejs\` that mirrors the existing \`setup_go\` pattern
- \`check_nodejs\` is now version-aware (returns 0/1/2 like \`check_go\`)

## Why

The Node SDK's \`@napi-rs/cli@3\` transitively requires \`@inquirer/core@11\` (engines \`>=20.12\`). On Ubuntu 24.04, \`apt-get install nodejs\` lands Node 18 (EOL since 2025-04-30), so \`make test\` fails at the \`napi build\` step. The manylinux path was hardcoded to Node 20.18, which hit EOL on 2026-04-30.

## What's installed where

| Platform | Path |
|---|---|
| macOS | \`brew install node@22 && brew link --force\` |
| Ubuntu/Debian | NodeSource \`setup_22.x\` + \`apt-get install nodejs\` |
| Other Linux (manylinux / RHEL-ish) | \`nodejs.org\` tarball, pinned to v22.18.0 |
| musllinux | Unchanged (no Node install; for Python wheel builds only) |

\`SKIP_INSTALL_NODEJS=1\` still works as an opt-out.

## Known gaps (deferred)

- \`sdks/node/package.json\` still declares \`engines.node >= 18\` and \`.github/workflows/config.yml\` still tests \`[18, 20, 22]\`. This change only fixes \`make setup\`; aligning the published support matrix is a separate conversation.
- Per-installer hardening (checksums, signed-by keyrings, post-install version re-check) would need to be done consistently across Go / Rust / protoc / Node — out of scope here.

## Test plan

- [x] \`bash -n\` syntax-check all four modified scripts
- [ ] \`make setup\` on Ubuntu 24.04: Node 18 → Node 22 (boxlite-prod EC2)
- [ ] Second \`make setup\` is a no-op (idempotent)
- [ ] \`SKIP_INSTALL_NODEJS=1 make setup\` skips installation
- [ ] \`make test\` succeeds on the upgraded box