### PR TITLE
Bump SDK patch versions to 0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,7 +369,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -442,7 +442,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-c"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "boxlite",
  "cbindgen",
@@ -452,7 +452,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-cli"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -489,7 +489,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-guest"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-node"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "boxlite",
  "boxlite-shared",
@@ -532,7 +532,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-python"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "boxlite",
  "futures",
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-shared"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "proptest",
  "prost",
@@ -585,7 +585,7 @@ dependencies = [
 
 [[package]]
 name = "bubblewrap-sys"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "num_cpus",
 ]
@@ -1062,7 +1062,7 @@ checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
 name = "e2fsprogs-sys"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "num_cpus",
 ]
@@ -2019,14 +2019,14 @@ dependencies = [
 
 [[package]]
 name = "libgvproxy-sys"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "libkrun-sys"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "libc",
  "num_cpus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = ["build/tmp", "target", ".venv", "examples/*/.venv"]
 resolver = "2"
 
 [workspace.dependencies]
-boxlite = { path = "src/boxlite", version = "0.9.0" }
+boxlite = { path = "src/boxlite", version = "0.9.1" }
 boxlite-shared = { path = "src/shared", version = "0.9.0" }
 bubblewrap-sys = { path = "src/deps/bubblewrap-sys", version = "0.9.0" }
 e2fsprogs-sys = { path = "src/deps/e2fsprogs-sys", version = "0.9.0" }
@@ -26,7 +26,7 @@ libgvproxy-sys = { path = "src/deps/libgvproxy-sys", version = "0.9.0" }
 libkrun-sys = { path = "src/deps/libkrun-sys", version = "0.9.0" }
 
 [workspace.package]
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 authors = ["Dorian Zheng <https://github.com/dorianzheng>"]
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ main();
 ### Install
 
 ```bash
-cargo add boxlite
+cargo add boxlite tokio futures --features tokio/macros,tokio/rt-multi-thread
 ```
 
 ### Run

--- a/docs/getting-started/quickstart-rust.md
+++ b/docs/getting-started/quickstart-rust.md
@@ -9,8 +9,7 @@ Get up and running with BoxLite Rust crate in 5 minutes.
 Add BoxLite to your project:
 
 ```bash
-cargo add boxlite tokio --features tokio/full
-cargo add futures
+cargo add boxlite tokio futures --features tokio/macros,tokio/rt-multi-thread
 ```
 
 ## Basic Execution
@@ -31,7 +30,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         rootfs: RootfsSpec::Image("alpine:latest".into()),
         ..Default::default()
     };
-    let (_, litebox) = runtime.create(options)?;
+    let litebox = runtime.create(options, None).await?;
 
     // Execute command
     let mut execution = litebox

--- a/sdks/node/README.md
+++ b/sdks/node/README.md
@@ -24,7 +24,7 @@ Embeddable VM runtime for secure, isolated code execution environments.
 ## Installation
 
 ```bash
-npm install boxlite
+npm install @boxlite-ai/boxlite
 ```
 
 **Requirements:**
@@ -337,7 +337,7 @@ See [../../examples/node/](../../examples/node/) directory for complete examples
 
 ```bash
 # If installed via npm
-npm install boxlite
+npm install @boxlite-ai/boxlite
 node simplebox.js
 
 # If working from source
@@ -345,7 +345,7 @@ cd ../../sdks/node
 npm install && npm run build
 npm link
 cd ../../examples/node
-npm link boxlite
+npm link @boxlite-ai/boxlite
 node simplebox.js
 ```
 
@@ -385,7 +385,7 @@ npm run build
 # Link to examples
 npm link
 cd ../../examples/node
-npm link boxlite
+npm link @boxlite-ai/boxlite
 
 # Run examples
 node simplebox.js

--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boxlite-ai/boxlite",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "BoxLite - Embeddable micro-VM runtime for secure, isolated code execution",
   "type": "module",
   "main": "dist/index.js",

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "boxlite"
-version = "0.9.0"
+version = "0.9.1"
 description = "Python bindings for Boxlite runtime"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/boxlite/build.rs
+++ b/src/boxlite/build.rs
@@ -1,5 +1,6 @@
 use regex::Regex;
 use sha2::{Digest, Sha256};
+use std::cell::OnceCell;
 use std::env;
 use std::fs;
 use std::io;
@@ -7,26 +8,94 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-/// Find the cargo workspace root by walking up from CARGO_MANIFEST_DIR.
-/// Looks for a Cargo.toml containing `[workspace]`.
-fn find_workspace_root() -> PathBuf {
-    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
-    let mut dir = manifest_dir.as_path();
-    loop {
-        let cargo_toml = dir.join("Cargo.toml");
-        if cargo_toml.is_file()
-            && fs::read_to_string(&cargo_toml)
-                .is_ok_and(|contents| contents.contains("[workspace]"))
-        {
-            return dir.to_path_buf();
+/// Cargo build-script facts shared across runtime preparation steps.
+struct CargoBuildContext {
+    manifest_dir: PathBuf,
+    out_dir: PathBuf,
+    // Resolve lazily so registry/prebuilt builds do not require a source workspace.
+    workspace_root: OnceCell<Option<PathBuf>>,
+    primary_package: bool,
+}
+
+impl CargoBuildContext {
+    /// Capture the Cargo environment values this build script needs.
+    fn new() -> Self {
+        let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+        let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+        let primary_package = env::var_os("CARGO_PRIMARY_PACKAGE").is_some();
+
+        Self {
+            manifest_dir,
+            out_dir,
+            workspace_root: OnceCell::new(),
+            primary_package,
         }
-        dir = match dir.parent() {
-            Some(parent) => parent,
-            None => panic!(
-                "Could not find workspace root from {}",
-                manifest_dir.display()
-            ),
-        };
+    }
+
+    /// Return Cargo's build output directory.
+    fn out_dir(&self) -> &Path {
+        &self.out_dir
+    }
+
+    /// Return the source workspace root when this build is inside one.
+    fn workspace_root(&self) -> Option<&Path> {
+        self.workspace_root
+            .get_or_init(|| Self::find_workspace_root(&self.manifest_dir))
+            .as_deref()
+    }
+
+    /// Return true when BoxLite is being built by a downstream consumer.
+    fn is_dependency_build(&self) -> bool {
+        if self.primary_package {
+            return false;
+        }
+
+        match Self::target_dir_for_workspace(self.workspace_root()) {
+            Some(target_dir) => !self.out_dir.starts_with(target_dir),
+            None => true,
+        }
+    }
+
+    /// Resolve Cargo's target directory for the source workspace.
+    fn target_dir_for_workspace(workspace_root: Option<&Path>) -> Option<PathBuf> {
+        let workspace_root = workspace_root?;
+        Some(
+            env::var_os("CARGO_TARGET_DIR")
+                .map(PathBuf::from)
+                .map(|target_dir| {
+                    if target_dir.is_absolute() {
+                        target_dir
+                    } else {
+                        workspace_root.join(target_dir)
+                    }
+                })
+                .unwrap_or_else(|| workspace_root.join("target")),
+        )
+    }
+
+    /// Find the cargo workspace root by walking up from CARGO_MANIFEST_DIR.
+    /// Looks for a Cargo.toml containing `[workspace]`.
+    fn find_workspace_root(manifest_dir: &Path) -> Option<PathBuf> {
+        let mut dir = manifest_dir;
+        loop {
+            let cargo_toml = dir.join("Cargo.toml");
+            if cargo_toml.is_file()
+                && fs::read_to_string(&cargo_toml)
+                    .is_ok_and(|contents| contents.contains("[workspace]"))
+            {
+                return Some(dir.to_path_buf());
+            }
+            dir = match dir.parent() {
+                Some(parent) => parent,
+                None => {
+                    println!(
+                        "cargo:warning=BoxLite workspace root was not found from {}; source runtime embedding will be skipped unless a prebuilt runtime is available",
+                        manifest_dir.display()
+                    );
+                    return None;
+                }
+            };
+        }
     }
 }
 
@@ -305,189 +374,294 @@ fn compile_seccomp_filters() {
 }
 
 #[cfg(not(target_os = "linux"))]
+/// Skip seccomp filter generation on non-Linux targets.
 fn compile_seccomp_filters() {
     // No-op on non-Linux platforms
     println!("cargo:warning=Seccomp compilation skipped (not Linux)");
 }
 
-/// Downloads a file from URL using curl.
-fn download_file(url: &str, dest: &Path) -> io::Result<()> {
-    println!("cargo:warning=Downloading {}...", url);
-
-    let output = Command::new("curl")
-        .args(["-fsSL", "-o", dest.to_str().unwrap(), url])
-        .output()?;
-
-    if !output.status.success() {
-        return Err(io::Error::other(format!(
-            "curl failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        )));
-    }
-
-    Ok(())
+/// Prebuilt runtime artifact state under OUT_DIR/runtime.
+struct PrebuiltRuntime {
+    runtime_dir: PathBuf,
 }
 
-/// Maps the host platform to the runtime artifact target name.
-/// Matches the naming convention from config.yml and build-runtime.yml.
-fn runtime_target() -> Option<&'static str> {
-    let os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
-    let arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+impl PrebuiltRuntime {
+    const FILE_MANIFEST: &'static str = ".boxlite-runtime-files";
+    const TARBALL_NAME: &'static str = "boxlite-runtime.tar.gz";
 
-    match (os.as_str(), arch.as_str()) {
-        ("macos", "aarch64") => Some("darwin-arm64"),
-        ("linux", "x86_64") => Some("linux-x64-gnu"),
-        ("linux", "aarch64") => Some("linux-arm64-gnu"),
-        _ => None,
-    }
-}
-
-/// Extracts an entire tarball to the destination directory.
-fn extract_runtime_tarball(tarball: &Path, dest: &Path) -> io::Result<()> {
-    let status = Command::new("tar")
-        .args([
-            "-xzf",
-            tarball.to_str().unwrap(),
-            "-C",
-            dest.to_str().unwrap(),
-            "--strip-components=1",
-        ])
-        .status()?;
-
-    if !status.success() {
-        return Err(io::Error::other("tar extraction failed"));
+    /// Create a handle for an extracted prebuilt runtime directory.
+    fn new(runtime_dir: &Path) -> Self {
+        Self {
+            runtime_dir: runtime_dir.to_path_buf(),
+        }
     }
 
-    Ok(())
-}
+    /// Return the generated file manifest path.
+    fn manifest_path(&self) -> PathBuf {
+        self.runtime_dir.join(Self::FILE_MANIFEST)
+    }
 
-/// Creates unversioned symlinks for versioned library files.
-///
-/// Build-time linking (`-lkrun`) requires `libkrun.dylib` (unversioned),
-/// but the prebuilt tarball only contains versioned files like `libkrun.1.16.0.dylib`.
-/// This creates the symlinks that `make install` would normally create.
-///
-/// Patterns:
-/// - macOS: `libfoo.1.2.3.dylib` → `libfoo.dylib`
-/// - Linux: `libfoo.so.1.2.3` → `libfoo.so`
-fn create_library_symlinks(dir: &Path) {
-    // macOS: lib<name>.<version>.dylib → lib<name>.dylib
-    // Linux: lib<name>.so.<version>    → lib<name>.so
-    let re = Regex::new(r"^(lib\w+)\.(\d+\.)*\d+\.dylib$|^(lib\w+\.so)\.\d+(\.\d+)*$").unwrap();
+    /// List runtime files and symlinks that came from the release artifact.
+    fn scan_file_names(&self) -> io::Result<Vec<String>> {
+        let mut files = Vec::new();
+        for entry in fs::read_dir(&self.runtime_dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            let name = entry.file_name().to_string_lossy().to_string();
+            if name == Self::FILE_MANIFEST || name == Self::TARBALL_NAME {
+                continue;
+            }
 
-    let entries: Vec<_> = fs::read_dir(dir)
-        .into_iter()
-        .flatten()
-        .filter_map(|e| e.ok())
-        .collect();
+            let metadata = fs::symlink_metadata(&path)?;
+            if metadata.is_file() || metadata.file_type().is_symlink() {
+                files.push(name);
+            }
+        }
+        files.sort();
+        Ok(files)
+    }
 
-    for entry in &entries {
-        let filename = entry.file_name();
-        let filename = filename.to_string_lossy();
+    /// Write the artifact-defined runtime file manifest.
+    fn write_file_manifest(&self) -> io::Result<Vec<String>> {
+        let files = self.scan_file_names()?;
+        if files.is_empty() {
+            return Err(io::Error::other(
+                "prebuilt runtime did not contain any files",
+            ));
+        }
 
-        if let Some(caps) = re.captures(&filename) {
-            // Group 1 = macOS base (e.g., "libkrun"), Group 3 = Linux base (e.g., "libkrun.so")
-            let base = caps.get(1).or(caps.get(3)).map(|m| m.as_str());
-            if let Some(base) = base {
-                let symlink_name = if caps.get(1).is_some() {
-                    format!("{}.dylib", base)
-                } else {
-                    base.to_string()
-                };
+        let mut contents = String::new();
+        for file in &files {
+            contents.push_str(file);
+            contents.push('\n');
+        }
+        // The release artifact defines the required runtime set; avoid OS-specific lists here.
+        fs::write(self.manifest_path(), contents)?;
+        Ok(files)
+    }
 
-                let symlink_path = dir.join(&symlink_name);
-                if !symlink_path.exists() {
-                    #[cfg(unix)]
-                    {
-                        // Relative symlink: libkrun.dylib → libkrun.1.16.0.dylib
-                        std::os::unix::fs::symlink(filename.as_ref(), &symlink_path).ok();
-                        println!(
-                            "cargo:warning=Created symlink: {} -> {}",
-                            symlink_name, filename
-                        );
+    /// Read the artifact-defined runtime file manifest.
+    fn read_file_manifest(&self) -> io::Result<Vec<String>> {
+        let contents = fs::read_to_string(self.manifest_path())?;
+        Ok(contents
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty())
+            .map(ToOwned::to_owned)
+            .collect())
+    }
+
+    /// Return user-facing reasons why the runtime cannot be embedded.
+    fn incomplete_reasons(&self) -> Vec<String> {
+        if !self.runtime_dir.exists() {
+            return vec!["runtime directory missing".to_string()];
+        }
+
+        let files = match self.read_file_manifest() {
+            Ok(files) => files,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => {
+                return vec!["prebuilt runtime manifest missing".to_string()];
+            }
+            Err(e) => return vec![format!("failed to read prebuilt runtime manifest: {e}")],
+        };
+
+        if files.is_empty() {
+            return vec!["prebuilt runtime manifest is empty".to_string()];
+        }
+
+        files
+            .into_iter()
+            .filter(|name| !self.runtime_dir.join(name).exists())
+            .map(|name| format!("missing manifest entry {name}"))
+            .collect()
+    }
+
+    /// Return true when every manifest-listed runtime file exists.
+    fn is_complete(&self) -> bool {
+        self.incomplete_reasons().is_empty()
+    }
+
+    /// Maps the host platform to the runtime artifact target name.
+    /// Matches the naming convention from config.yml and build-runtime.yml.
+    fn runtime_target() -> Option<&'static str> {
+        let os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+        let arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+
+        match (os.as_str(), arch.as_str()) {
+            ("macos", "aarch64") => Some("darwin-arm64"),
+            ("linux", "x86_64") => Some("linux-x64-gnu"),
+            ("linux", "aarch64") => Some("linux-arm64-gnu"),
+            _ => None,
+        }
+    }
+
+    /// Downloads a file from URL using curl.
+    fn download_file(url: &str, dest: &Path) -> io::Result<()> {
+        println!("cargo:warning=Downloading {}...", url);
+
+        let output = Command::new("curl")
+            .args(["-fsSL", "-o", dest.to_str().unwrap(), url])
+            .output()?;
+
+        if !output.status.success() {
+            return Err(io::Error::other(format!(
+                "curl failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            )));
+        }
+
+        Ok(())
+    }
+
+    /// Extracts an entire tarball to the runtime directory.
+    fn extract_tarball(&self, tarball: &Path) -> io::Result<()> {
+        let status = Command::new("tar")
+            .args([
+                "-xzf",
+                tarball.to_str().unwrap(),
+                "-C",
+                self.runtime_dir.to_str().unwrap(),
+                "--strip-components=1",
+            ])
+            .status()?;
+
+        if !status.success() {
+            return Err(io::Error::other("tar extraction failed"));
+        }
+
+        Ok(())
+    }
+
+    /// Creates unversioned symlinks for versioned library files.
+    ///
+    /// Build-time linking (`-lkrun`) requires `libkrun.dylib` (unversioned),
+    /// but the prebuilt tarball only contains versioned files like `libkrun.1.16.0.dylib`.
+    /// This creates the symlinks that `make install` would normally create.
+    ///
+    /// Patterns:
+    /// - macOS: `libfoo.1.2.3.dylib` → `libfoo.dylib`
+    /// - Linux: `libfoo.so.1.2.3` → `libfoo.so`
+    fn create_library_symlinks(&self) {
+        // macOS: lib<name>.<version>.dylib → lib<name>.dylib
+        // Linux: lib<name>.so.<version>    → lib<name>.so
+        let re = Regex::new(r"^(lib\w+)\.(\d+\.)*\d+\.dylib$|^(lib\w+\.so)\.\d+(\.\d+)*$").unwrap();
+
+        let entries: Vec<_> = fs::read_dir(&self.runtime_dir)
+            .into_iter()
+            .flatten()
+            .filter_map(|e| e.ok())
+            .collect();
+
+        for entry in &entries {
+            let filename = entry.file_name();
+            let filename = filename.to_string_lossy();
+
+            if let Some(caps) = re.captures(&filename) {
+                // Group 1 = macOS base (e.g., "libkrun"), Group 3 = Linux base (e.g., "libkrun.so")
+                let base = caps.get(1).or(caps.get(3)).map(|m| m.as_str());
+                if let Some(base) = base {
+                    let symlink_name = if caps.get(1).is_some() {
+                        format!("{}.dylib", base)
+                    } else {
+                        base.to_string()
+                    };
+
+                    let symlink_path = self.runtime_dir.join(&symlink_name);
+                    if !symlink_path.exists() {
+                        #[cfg(unix)]
+                        {
+                            // Relative symlink: libkrun.dylib → libkrun.1.16.0.dylib
+                            std::os::unix::fs::symlink(filename.as_ref(), &symlink_path).ok();
+                            println!(
+                                "cargo:warning=Created symlink: {} -> {}",
+                                symlink_name, filename
+                            );
+                        }
                     }
                 }
             }
         }
     }
-}
 
-/// Downloads prebuilt runtime binaries from GitHub Releases.
-///
-/// Called when BOXLITE_DEPS_STUB is set (i.e., -sys crates skipped their builds).
-/// Downloads the full `boxlite-runtime-v{version}-{target}.tar.gz` tarball which contains
-/// all native libraries (libkrun, libgvproxy, etc.) and tool binaries.
-fn download_prebuilt_runtime(runtime_dir: &Path) {
-    // Skip if already downloaded (check for any library file)
-    if runtime_dir.exists()
-        && fs::read_dir(runtime_dir)
-            .map(|entries| {
-                entries
-                    .filter_map(|e| e.ok())
-                    .any(|e| is_library_file(&e.path()))
-            })
-            .unwrap_or(false)
-    {
-        println!("cargo:warning=Prebuilt runtime already present, skipping download");
-        return;
-    }
-
-    let target = match runtime_target() {
-        Some(t) => t,
-        None => {
-            println!("cargo:warning=Unsupported platform for prebuilt download, skipping");
-            return;
+    /// Downloads prebuilt runtime binaries from GitHub Releases.
+    ///
+    /// Called when BOXLITE_DEPS_STUB is set (i.e., -sys crates skipped their builds).
+    /// Downloads the full `boxlite-runtime-v{version}-{target}.tar.gz` tarball which contains
+    /// all native libraries (libkrun, libgvproxy, etc.) and tool binaries.
+    fn download(&self) -> bool {
+        if self.is_complete() {
+            println!("cargo:warning=Prebuilt runtime already present, skipping download");
+            return true;
         }
-    };
 
-    let version = env::var("CARGO_PKG_VERSION").unwrap();
-    let default_url = format!(
-        "https://github.com/boxlite-ai/boxlite/releases/download/v{version}/boxlite-runtime-v{version}-{target}.tar.gz"
-    );
+        let target = match Self::runtime_target() {
+            Some(t) => t,
+            None => {
+                println!("cargo:warning=Unsupported platform for prebuilt download, skipping");
+                return false;
+            }
+        };
 
-    println!("cargo:rerun-if-env-changed=BOXLITE_RUNTIME_URL");
-    let url = env::var("BOXLITE_RUNTIME_URL").unwrap_or(default_url);
+        let version = env::var("CARGO_PKG_VERSION").unwrap();
+        let default_url = format!(
+            "https://github.com/boxlite-ai/boxlite/releases/download/v{version}/boxlite-runtime-v{version}-{target}.tar.gz"
+        );
 
-    fs::create_dir_all(runtime_dir)
-        .unwrap_or_else(|e| panic!("Failed to create runtime directory: {}", e));
+        println!("cargo:rerun-if-env-changed=BOXLITE_RUNTIME_URL");
+        let url = env::var("BOXLITE_RUNTIME_URL").unwrap_or(default_url);
 
-    let tarball_path = runtime_dir.join("boxlite-runtime.tar.gz");
+        fs::create_dir_all(&self.runtime_dir)
+            .unwrap_or_else(|e| panic!("Failed to create runtime directory: {}", e));
 
-    match download_file(&url, &tarball_path) {
-        Ok(()) => {}
-        Err(e) => {
-            println!(
-                "cargo:warning=Failed to download prebuilt runtime from {}: {}",
-                url, e
-            );
-            println!("cargo:warning=Native libraries will not be available.");
-            return;
+        let tarball_path = self.runtime_dir.join(Self::TARBALL_NAME);
+
+        match Self::download_file(&url, &tarball_path) {
+            Ok(()) => {}
+            Err(e) => {
+                println!(
+                    "cargo:warning=Failed to download prebuilt runtime from {}: {}",
+                    url, e
+                );
+                println!("cargo:warning=Native libraries will not be available.");
+                return false;
+            }
         }
-    }
 
-    match extract_runtime_tarball(&tarball_path, runtime_dir) {
-        Ok(()) => {
-            // Clean up tarball before listing
-            fs::remove_file(&tarball_path).ok();
+        match self.extract_tarball(&tarball_path) {
+            Ok(()) => {
+                // Clean up tarball before listing
+                fs::remove_file(&tarball_path).ok();
 
-            // Create unversioned symlinks for build-time linking
-            create_library_symlinks(runtime_dir);
+                // Create unversioned symlinks for build-time linking
+                self.create_library_symlinks();
 
-            let files: Vec<_> = fs::read_dir(runtime_dir)
-                .into_iter()
-                .flatten()
-                .filter_map(|e| e.ok())
-                .map(|e| e.file_name().to_string_lossy().to_string())
-                .collect();
-            println!(
-                "cargo:warning=Downloaded prebuilt runtime v{}: [{}]",
-                version,
-                files.join(", ")
-            );
-        }
-        Err(e) => {
-            fs::remove_file(&tarball_path).ok();
-            println!("cargo:warning=Failed to extract runtime tarball: {}", e);
+                let files = match self.write_file_manifest() {
+                    Ok(files) => files,
+                    Err(e) => {
+                        println!("cargo:warning=Failed to write runtime manifest: {}", e);
+                        return false;
+                    }
+                };
+                println!(
+                    "cargo:warning=Downloaded prebuilt runtime v{}: [{}]",
+                    version,
+                    files.join(", ")
+                );
+                let incomplete = self.incomplete_reasons();
+                if !incomplete.is_empty() {
+                    println!(
+                        "cargo:warning=Prebuilt runtime is incomplete: {}",
+                        incomplete.join(", ")
+                    );
+                    return false;
+                }
+                true
+            }
+            Err(e) => {
+                fs::remove_file(&tarball_path).ok();
+                println!("cargo:warning=Failed to extract runtime tarball: {}", e);
+                false
+            }
         }
     }
 }
@@ -505,6 +679,7 @@ enum DepsMode {
 }
 
 impl DepsMode {
+    /// Convert BOXLITE_DEPS_STUB into the native dependency resolution mode.
     fn from_env() -> Self {
         match env::var("BOXLITE_DEPS_STUB").ok().as_deref() {
             Some("2") => Self::Prebuilt,
@@ -546,7 +721,7 @@ impl EmbeddedManifest {
     }
 
     /// Scan `runtime_dir` for regular files (skipping symlinks/directories).
-    fn scan_entries(&self) -> Vec<(String, PathBuf)> {
+    fn scan_entries(&self) -> Vec<(String, PathBuf, u32)> {
         let mut entries = Vec::new();
         if self.runtime_dir.exists() {
             for entry in fs::read_dir(&self.runtime_dir)
@@ -554,14 +729,18 @@ impl EmbeddedManifest {
             {
                 let entry = entry.unwrap();
                 let path = entry.path();
+                let name = entry.file_name().to_string_lossy().to_string();
+                if name == PrebuiltRuntime::FILE_MANIFEST {
+                    continue;
+                }
 
                 let meta = fs::symlink_metadata(&path).unwrap();
                 if !meta.is_file() {
                     continue;
                 }
 
-                let name = entry.file_name().to_string_lossy().to_string();
-                entries.push((name, path));
+                let mode = Self::file_mode(&path);
+                entries.push((name, path, mode));
             }
         }
         // Sort for deterministic code generation and hashing
@@ -571,7 +750,8 @@ impl EmbeddedManifest {
 
     // ── Private helpers ─────────────────────────────────────────────
 
-    fn emit_manifest(manifest_path: &Path, entries: &[(String, PathBuf)]) {
+    /// Write the generated manifest and emit its build metadata.
+    fn emit_manifest(manifest_path: &Path, entries: &[(String, PathBuf, u32)]) {
         Self::write_manifest_rs(manifest_path, entries);
         Self::emit_content_hash(entries);
         if !entries.is_empty() {
@@ -579,24 +759,25 @@ impl EmbeddedManifest {
         }
     }
 
-    fn write_manifest_rs(manifest_path: &Path, entries: &[(String, PathBuf)]) {
+    /// Generate the Rust source included by runtime::embedded.
+    fn write_manifest_rs(manifest_path: &Path, entries: &[(String, PathBuf, u32)]) {
         if entries.is_empty() {
             fs::write(
                 manifest_path,
                 "// Auto-generated by build.rs — no embedded files\n\
-                 pub const MANIFEST: &[(&str, &[u8])] = &[];\n",
+                 pub const MANIFEST: &[(&str, u32, &[u8])] = &[];\n",
             )
             .unwrap_or_else(|e| panic!("Failed to write empty manifest: {}", e));
             return;
         }
 
         let mut code = String::from("// Auto-generated by build.rs — do not edit\n");
-        code.push_str("pub const MANIFEST: &[(&str, &[u8])] = &[\n");
-        for (name, path) in entries {
+        code.push_str("pub const MANIFEST: &[(&str, u32, &[u8])] = &[\n");
+        for (name, path, mode) in entries {
             let abs = path.to_string_lossy().replace('\\', "/");
             code.push_str(&format!(
-                "    (\"{}\", include_bytes!(\"{}\")),\n",
-                name, abs
+                "    (\"{}\", 0o{:o}, include_bytes!(\"{}\")),\n",
+                name, mode, abs
             ));
             println!("cargo:rerun-if-changed={}", path.display());
         }
@@ -606,10 +787,12 @@ impl EmbeddedManifest {
             .unwrap_or_else(|e| panic!("Failed to write embedded manifest: {}", e));
     }
 
-    fn emit_content_hash(entries: &[(String, PathBuf)]) {
+    /// Hash manifest names, modes, and bytes for cache invalidation.
+    fn emit_content_hash(entries: &[(String, PathBuf, u32)]) {
         let mut hasher = Sha256::new();
-        for (name, path) in entries {
+        for (name, path, mode) in entries {
             hasher.update(name.as_bytes());
+            hasher.update(mode.to_le_bytes());
             let content = fs::read(path)
                 .unwrap_or_else(|e| panic!("Failed to read {} for hashing: {}", path.display(), e));
             hasher.update(&content);
@@ -624,16 +807,34 @@ impl EmbeddedManifest {
         println!("cargo:warning=Embedded manifest hash: {}", prefix);
     }
 
-    fn log_summary(entries: &[(String, PathBuf)]) {
+    /// Log the generated embedded runtime size summary.
+    fn log_summary(entries: &[(String, PathBuf, u32)]) {
         let total_size: u64 = entries
             .iter()
-            .map(|(_, p)| fs::metadata(p).map(|m| m.len()).unwrap_or(0))
+            .map(|(_, p, _)| fs::metadata(p).map(|m| m.len()).unwrap_or(0))
             .sum();
         println!(
             "cargo:warning=Embedded runtime: {} files, {:.1} MB total",
             entries.len(),
             total_size as f64 / (1024.0 * 1024.0)
         );
+    }
+
+    /// Return the Unix permission bits to preserve in the generated manifest.
+    fn file_mode(path: &Path) -> u32 {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::metadata(path)
+                .map(|metadata| metadata.permissions().mode() & 0o777)
+                .unwrap_or(0o644)
+        }
+
+        #[cfg(not(unix))]
+        {
+            let _ = path;
+            0o644
+        }
     }
 
     // ── Embedded manifest generation ────────────────────────────────
@@ -645,9 +846,8 @@ impl EmbeddedManifest {
     /// an `include_bytes!` manifest for all files in the runtime dir.
     ///
     /// When the feature is off or in Stub mode, generates an empty manifest.
-    fn generate(&self, mode: &DepsMode) {
-        let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
-        let manifest_path = out_dir.join("embedded_manifest.rs");
+    fn generate(&self, mode: &DepsMode, cargo: &CargoBuildContext) {
+        let manifest_path = cargo.out_dir().join("embedded_manifest.rs");
 
         let enabled = env::var("CARGO_FEATURE_EMBEDDED_RUNTIME").is_ok();
 
@@ -656,9 +856,26 @@ impl EmbeddedManifest {
             return;
         }
 
+        if matches!(mode, DepsMode::Prebuilt) {
+            let entries = self.scan_entries();
+            Self::emit_manifest(&manifest_path, &entries);
+            return;
+        }
+
+        let prebuilt_runtime = PrebuiltRuntime::new(&self.runtime_dir);
+        if cargo.is_dependency_build() && prebuilt_runtime.is_complete() {
+            let entries = self.scan_entries();
+            Self::emit_manifest(&manifest_path, &entries);
+            return;
+        }
+
         // Feature enabled: collect pre-built binaries into runtime_dir,
         // then generate include_bytes! for all files.
-        let workspace_root = find_workspace_root();
+        let Some(workspace_root) = cargo.workspace_root() else {
+            let entries = self.scan_entries();
+            Self::emit_manifest(&manifest_path, &entries);
+            return;
+        };
 
         fs::create_dir_all(&self.runtime_dir)
             .unwrap_or_else(|e| panic!("Failed to create runtime directory: {}", e));
@@ -666,13 +883,13 @@ impl EmbeddedManifest {
         let profile = env::var("PROFILE").unwrap();
 
         self.copy_prebuilt_binary(
-            &workspace_root,
+            workspace_root,
             "boxlite-shim",
             &profile,
             Self::find_prebuilt_shim,
         );
         self.copy_prebuilt_binary(
-            &workspace_root,
+            workspace_root,
             "boxlite-guest",
             &profile,
             Self::find_prebuilt_guest,
@@ -876,6 +1093,98 @@ fn sign_shim_with_entitlements(binary: &Path) {
         }
     }
 }
+/// Computes and embeds the `boxlite-guest` binary hash.
+///
+/// Search order:
+/// 1. Direct build output: `target/{target-triple}/{profile}/boxlite-guest`
+/// 2. `runtime_dir` (OUT_DIR/runtime/ — for prebuilt mode)
+///
+/// IMPORTANT: The source binary (direct build output) must be checked FIRST because
+/// this runs before embedded manifest generation in main(). The OUT_DIR/runtime/ copy
+/// may be from a previous build and stale when the guest binary was rebuilt.
+///
+/// If the binary isn't found, silently skips — runtime will compute the hash as fallback.
+struct GuestBinaryHash<'a> {
+    runtime_dir: &'a Path,
+    mode: &'a DepsMode,
+    cargo: &'a CargoBuildContext,
+}
+
+impl<'a> GuestBinaryHash<'a> {
+    /// Create a guest binary hash emitter.
+    fn new(runtime_dir: &'a Path, mode: &'a DepsMode, cargo: &'a CargoBuildContext) -> Self {
+        Self {
+            runtime_dir,
+            mode,
+            cargo,
+        }
+    }
+
+    /// Emit BOXLITE_GUEST_HASH when a guest binary is available.
+    fn emit(&self) {
+        let Some(guest_path) = self.guest_path() else {
+            println!("cargo:warning=boxlite-guest not found, skipping compile-time hash");
+            return;
+        };
+
+        match Self::sha256_file(&guest_path) {
+            Ok(hash) => {
+                println!("cargo:rustc-env=BOXLITE_GUEST_HASH={}", hash);
+                println!("cargo:rerun-if-changed={}", guest_path.display());
+                println!(
+                    "cargo:warning=Embedded guest hash: {}... (from {})",
+                    &hash[..12],
+                    guest_path.display()
+                );
+            }
+            Err(e) => {
+                println!(
+                    "cargo:warning=Failed to hash boxlite-guest at {}: {}",
+                    guest_path.display(),
+                    e
+                );
+            }
+        }
+    }
+
+    /// Pick the best available guest binary for hashing.
+    fn guest_path(&self) -> Option<PathBuf> {
+        let profile = env::var("PROFILE").unwrap_or_else(|_| "debug".to_string());
+        self.source_guest_path(&profile)
+            .or_else(|| self.runtime_guest_path())
+    }
+
+    /// Find the workspace-built guest binary in source builds.
+    fn source_guest_path(&self, profile: &str) -> Option<PathBuf> {
+        if !matches!(self.mode, DepsMode::Source) {
+            return None;
+        }
+
+        let workspace_root = self.cargo.workspace_root()?;
+        EmbeddedManifest::find_prebuilt_guest(workspace_root, profile)
+    }
+
+    /// Find the guest binary already copied into OUT_DIR/runtime.
+    fn runtime_guest_path(&self) -> Option<PathBuf> {
+        let path = self.runtime_dir.join("boxlite-guest");
+        path.is_file().then_some(path)
+    }
+
+    /// Compute SHA256 hex digest of a file.
+    fn sha256_file(path: &Path) -> io::Result<String> {
+        let mut file = fs::File::open(path)?;
+        let mut hasher = Sha256::new();
+        let mut buffer = vec![0u8; 64 * 1024];
+        loop {
+            let n = file.read(&mut buffer)?;
+            if n == 0 {
+                break;
+            }
+            hasher.update(&buffer[..n]);
+        }
+        Ok(format!("{:x}", hasher.finalize()))
+    }
+}
 
 /// Collects all FFI dependencies into a single runtime directory.
 /// This directory can be used by downstream crates (e.g., Python SDK) to
@@ -900,10 +1209,11 @@ fn main() {
     // Compile seccomp filters at build time (fast, required for include_bytes!())
     compile_seccomp_filters();
 
+    let cargo = CargoBuildContext::new();
     let mode = DepsMode::from_env();
 
-    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
-    let runtime_dir = out_dir.join("runtime");
+    let runtime_dir = cargo.out_dir().join("runtime");
+    let prebuilt_runtime = PrebuiltRuntime::new(&runtime_dir);
 
     match &mode {
         DepsMode::Stub => {
@@ -911,7 +1221,7 @@ fn main() {
             // the embedded manifest (needed for env!() macros in embedded.rs)
             println!("cargo:warning=BOXLITE_DEPS_STUB=1: skipping dependency bundling");
             println!("cargo:runtime_dir=/nonexistent");
-            EmbeddedManifest::new(&runtime_dir).generate(&mode);
+            EmbeddedManifest::new(&runtime_dir).generate(&mode, &cargo);
             return;
         }
         DepsMode::Prebuilt => {
@@ -919,7 +1229,12 @@ fn main() {
             println!("cargo:warning=BOXLITE_DEPS_STUB=2: downloading prebuilt runtime");
             fs::create_dir_all(&runtime_dir)
                 .unwrap_or_else(|e| panic!("Failed to create runtime directory: {}", e));
-            download_prebuilt_runtime(&runtime_dir);
+            if !prebuilt_runtime.download() {
+                panic!(
+                    "Failed to prepare complete prebuilt BoxLite runtime in {}",
+                    runtime_dir.display()
+                );
+            }
             // Embed runtime directory for compile-time fallback by RuntimeBinaryFinder.
             // Runtime override remains BOXLITE_RUNTIME_DIR (read via std::env::var).
             // Compile-time embed is only needed in prebuilt mode.
@@ -936,6 +1251,22 @@ fn main() {
             if !collected.is_empty() {
                 let names: Vec<_> = collected.iter().map(|(name, _)| name.as_str()).collect();
                 println!("cargo:warning=Bundled: {}", names.join(", "));
+            }
+            if env::var("CARGO_FEATURE_EMBEDDED_RUNTIME").is_ok()
+                && cargo.is_dependency_build()
+                && !prebuilt_runtime.is_complete()
+            {
+                let incomplete = prebuilt_runtime.incomplete_reasons();
+                println!(
+                    "cargo:warning=Dependency build has incomplete runtime [{}]; downloading prebuilt runtime",
+                    incomplete.join(", ")
+                );
+                if !prebuilt_runtime.download() {
+                    panic!(
+                        "Failed to prepare complete prebuilt BoxLite runtime in {}",
+                        runtime_dir.display()
+                    );
+                }
             }
         }
     };
@@ -956,78 +1287,14 @@ fn main() {
 
     // Compute and embed guest binary hash at compile time (best-effort).
     // Falls back to runtime computation if the binary isn't available yet.
-    compute_guest_hash(&runtime_dir);
+    GuestBinaryHash::new(&runtime_dir, &mode, &cargo).emit();
 
     // Generate embedded runtime manifest (include_bytes! for self-contained SDKs)
-    EmbeddedManifest::new(&runtime_dir).generate(&mode);
+    EmbeddedManifest::new(&runtime_dir).generate(&mode, &cargo);
 
     // Set rpath for boxlite-shim
     #[cfg(target_os = "macos")]
     println!("cargo:rustc-link-arg=-Wl,-rpath,@loader_path");
     #[cfg(target_os = "linux")]
     println!("cargo:rustc-link-arg=-Wl,-rpath,$ORIGIN");
-}
-
-/// Compute SHA256 hash of the `boxlite-guest` binary and embed it via `cargo:rustc-env`.
-///
-/// Search order:
-/// 1. Direct build output: `target/{target-triple}/{profile}/boxlite-guest`
-/// 2. `runtime_dir` (OUT_DIR/runtime/ — for prebuilt mode)
-///
-/// IMPORTANT: The source binary (direct build output) must be checked FIRST because
-/// `compute_guest_hash` runs before `generate()` in main(). The OUT_DIR/runtime/ copy
-/// is placed there by a previous build's `generate()` and may be stale when the guest
-/// binary has been rebuilt since then.
-///
-/// If the binary isn't found, silently skips — runtime will compute the hash as fallback.
-fn compute_guest_hash(runtime_dir: &Path) {
-    let profile = env::var("PROFILE").unwrap_or_else(|_| "debug".to_string());
-
-    // Check source binary first (direct build output) to avoid stale OUT_DIR copies.
-    let workspace_root = find_workspace_root();
-    let guest_path =
-        EmbeddedManifest::find_prebuilt_guest(&workspace_root, &profile).or_else(|| {
-            // Fallback: OUT_DIR copy (for prebuilt/CI mode where source isn't available)
-            let p = runtime_dir.join("boxlite-guest");
-            p.is_file().then_some(p)
-        });
-
-    let Some(guest_path) = guest_path else {
-        println!("cargo:warning=boxlite-guest not found, skipping compile-time hash");
-        return;
-    };
-
-    match sha256_file(&guest_path) {
-        Ok(hash) => {
-            println!("cargo:rustc-env=BOXLITE_GUEST_HASH={}", hash);
-            println!("cargo:rerun-if-changed={}", guest_path.display());
-            println!(
-                "cargo:warning=Embedded guest hash: {}... (from {})",
-                &hash[..12],
-                guest_path.display()
-            );
-        }
-        Err(e) => {
-            println!(
-                "cargo:warning=Failed to hash boxlite-guest at {}: {}",
-                guest_path.display(),
-                e
-            );
-        }
-    }
-}
-
-/// Compute SHA256 hex digest of a file.
-fn sha256_file(path: &Path) -> io::Result<String> {
-    let mut file = fs::File::open(path)?;
-    let mut hasher = Sha256::new();
-    let mut buffer = vec![0u8; 64 * 1024];
-    loop {
-        let n = file.read(&mut buffer)?;
-        if n == 0 {
-            break;
-        }
-        hasher.update(&buffer[..n]);
-    }
-    Ok(format!("{:x}", hasher.finalize()))
 }

--- a/src/boxlite/src/runtime/embedded.rs
+++ b/src/boxlite/src/runtime/embedded.rs
@@ -1,6 +1,6 @@
 //! Embedded runtime: binaries compiled into the library, extracted on first use.
 //!
-//! The build.rs generates a manifest of (filename, bytes) pairs via `include_bytes!`.
+//! The build.rs generates a manifest of (filename, mode, bytes) entries via `include_bytes!`.
 //! On first access, [`EmbeddedRuntime`] extracts them to a version-stamped directory
 //! under the platform's local data dir, then serves that directory to
 //! [`RuntimeBinaryFinder`](crate::util::RuntimeBinaryFinder) for binary discovery.
@@ -18,7 +18,7 @@ use std::time::{Duration, SystemTime};
 
 use boxlite_shared::errors::{BoxliteError, BoxliteResult};
 
-// Build.rs generates: pub const MANIFEST: &[(&str, &[u8])] = &[...];
+// Build.rs generates: pub const MANIFEST: &[(&str, u32, &[u8])] = &[...];
 include!(concat!(env!("OUT_DIR"), "/embedded_manifest.rs"));
 
 /// Embedded runtime binary cache.
@@ -98,12 +98,12 @@ impl EmbeddedRuntime {
         std::fs::create_dir_all(&tmp)
             .map_err(|e| BoxliteError::Storage(format!("mkdir {}: {}", tmp.display(), e)))?;
 
-        for (name, data) in MANIFEST {
+        for (name, mode, data) in MANIFEST {
             let path = tmp.join(name);
             std::fs::write(&path, data)
                 .map_err(|e| BoxliteError::Storage(format!("write {}: {}", path.display(), e)))?;
             #[cfg(unix)]
-            Self::set_permissions(&path, name)?;
+            Self::set_permissions(&path, *mode)?;
         }
 
         // Stamp marks extraction as complete — checked by the fast path above.
@@ -194,17 +194,12 @@ impl EmbeddedRuntime {
         Ok(dir)
     }
 
-    /// Known executable binary names that should get 0o755.
-    /// Everything else (shared libraries) gets 0o644.
-    const EXECUTABLES: &[&str] = &["boxlite-shim", "boxlite-guest", "mke2fs", "debugfs"];
-
     #[cfg(unix)]
-    fn set_permissions(path: &Path, name: &str) -> BoxliteResult<()> {
+    fn set_permissions(path: &Path, mode: u32) -> BoxliteResult<()> {
         use std::os::unix::fs::PermissionsExt;
-        let mode = if Self::EXECUTABLES.contains(&name) {
-            0o755
-        } else {
-            0o644
+        let mode = match mode & 0o777 {
+            0 => 0o644,
+            mode => mode,
         };
         std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode)).map_err(|e| {
             BoxliteError::Storage(format!("chmod {:o} {}: {}", mode, path.display(), e))
@@ -261,7 +256,7 @@ mod tests {
         if let Some(runtime) = EmbeddedRuntime::get() {
             assert!(runtime.dir().join(".complete").exists());
             // Verify all manifest entries were extracted
-            for (name, _) in MANIFEST {
+            for (name, _, _) in MANIFEST {
                 assert!(
                     runtime.dir().join(name).exists(),
                     "Expected {} to exist in cache",


### PR DESCRIPTION
## Summary

This bumps the BoxLite SDK patch release metadata to `0.9.1` and includes the Rust consumer packaging fix needed after the `v0.9.0` README validation pass.

The SDK-facing version updates are:

- Rust workspace package version and `boxlite` workspace dependency requirement: `0.9.1`
- Cargo lockfile package entries: `0.9.1`
- Python SDK package metadata: `0.9.1`
- Node SDK package metadata: `0.9.1`
- Go SDK patch version is driven by the release workflow tag `sdks/go/v${VERSION}`, so the workspace release version now drives `sdks/go/v0.9.1`

Language/runtime constraints are intentionally unchanged: Rust `rust-version`, Python `requires-python`, Node `engines`, and Go `go` directives were not bumped.

## Rust Packaging Fix

The Rust build script now handles consumer builds without relying on source-workspace discovery. Prebuilt-runtime mode embeds the already downloaded runtime directly, and non-primary source dependency builds can fall back to the GitHub release runtime instead of producing an empty embedded runtime or panicking while looking for a workspace root.

The embedded runtime manifest also now carries file modes from the packaged runtime, so extracted binaries and libraries preserve the artifact-defined permissions instead of relying on hard-coded executable-name lists.

## Docs

- Simplified the Rust quick-start install command to one `cargo add` command.
- Updated the Rust getting-started snippet to match the current async API.
- Fixed Node SDK README install/link examples to use `@boxlite-ai/boxlite`.

## Validation

On `ssh dev` in `/tmp/boxlite-sdk-bump-worktree`:

- `cargo fmt --check`
- `git diff --check`
- `cargo pkgid -p boxlite`, `boxlite-c`, `boxlite-python`, `boxlite-node` all resolve to `0.9.1`
- docs grep confirms the one-line Rust install command and scoped Node package name
- `cargo package -p boxlite --allow-dirty --no-verify`
- `cargo clippy -p boxlite --no-default-features --lib -- -D warnings`
- `cargo test -p boxlite --no-default-features --lib runtime::embedded::tests::manifest_is_available -- --test-threads=1`

Local repository hooks also passed before push:

- pre-commit quality autofix/checks
- pre-push changed-component matrix for Node, Python, and Rust, including VM integration tests

Note: public `cargo add boxlite@0.9.1` validation requires the `0.9.1` release artifacts and crates.io package to exist first. This PR prepares the patch release; the release workflow publishes the runtime artifact before publishing the Rust crate.
