### PR TITLE
feat(guest): enable libseccomp in guest runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2000,6 +2000,7 @@ dependencies = [
  "fastrand",
  "libc",
  "libcgroups",
+ "libseccomp",
  "nc",
  "nix 0.29.0",
  "oci-spec 0.8.4",
@@ -2053,6 +2054,24 @@ dependencies = [
  "libc",
  "redox_syscall 0.7.0",
 ]
+
+[[package]]
+name = "libseccomp"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e5310a2c5b6ffbc094b5f70a2ca7b79ed36ad90e6f90994b166489a1bce3fcc"
+dependencies = [
+ "bitflags 2.10.0",
+ "libc",
+ "libseccomp-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "libseccomp-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60276e2d41bbb68b323e566047a1bfbf952050b157d8b5cdc74c07c1bf4ca3b6"
 
 [[package]]
 name = "libsqlite3-sys"

--- a/scripts/build/build-guest.sh
+++ b/scripts/build/build-guest.sh
@@ -118,6 +118,14 @@ build_guest_binary() {
         fi
     fi
 
+    # libseccomp is enabled in src/guest/Cargo.toml ("libseccomp" feature on
+    # libcontainer). The Rust libseccomp-sys crate needs libseccomp.a built for
+    # the *target* triple. Build/cache it and export the env vars libseccomp-sys
+    # reads in its build.rs.
+    # shellcheck source=./build-libseccomp.sh
+    source "$SCRIPT_BUILD_DIR/build-libseccomp.sh"
+    ensure_libseccomp_for_target "$GUEST_TARGET"
+
     cargo build $build_flag --target "$GUEST_TARGET" -p boxlite-guest
 
     # Verify guest binary is statically linked

--- a/scripts/build/build-libseccomp.sh
+++ b/scripts/build/build-libseccomp.sh
@@ -7,10 +7,17 @@
 # source using the musl cross-compiler that build-guest.sh already requires.
 #
 # Output layout (cache):
-#   $LIBSECCOMP_PREFIX/lib/libseccomp.a
-#   $LIBSECCOMP_PREFIX/include/seccomp.h
+#   $BOXLITE_CACHE/libseccomp/<target>/<version>/{lib,include}
+#   $BOXLITE_CACHE/linux-headers/<version>/<arch>/include
 #
-# where $LIBSECCOMP_PREFIX = $HOME/.cache/boxlite/libseccomp/<target>/<version>
+# Default: $BOXLITE_CACHE = <project-root>/target/native
+# Override: set BOXLITE_CACHE env var (e.g. CI may want a shared cache).
+#
+# Living under target/native/ means:
+#   - per-checkout (each worktree has its own)
+#   - gitignored (target/ is in .gitignore already)
+#   - cleaned by `cargo clean`
+#   - sibling-friendly for future vendored C deps (target/native/libcap/, etc.)
 #
 # On success, exports:
 #   LIBSECCOMP_LIB_PATH      (consumed by libseccomp-sys build.rs)
@@ -22,6 +29,12 @@
 #   ensure_libseccomp_for_target aarch64-unknown-linux-musl
 
 set -e
+
+# Default cache lives under the project's target/native/ dir (per-checkout,
+# gitignored, cleaned by `cargo clean`). Resolved from this script's own
+# location so it works whether sourced or run directly.
+_BUILD_LIBSECCOMP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEFAULT_BOXLITE_CACHE="$(cd "$_BUILD_LIBSECCOMP_DIR/../.." && pwd)/target/native"
 
 LIBSECCOMP_VERSION="${LIBSECCOMP_VERSION:-2.5.5}"
 LIBSECCOMP_TARBALL_SHA256="${LIBSECCOMP_TARBALL_SHA256:-248a2c8a4d9b9858aa6baf52712c34afefcf9c9e94b76dce02c1c9aa25fb3375}"
@@ -42,7 +55,7 @@ ensure_linux_headers_for_arch() {
         return 1
     fi
 
-    local cache_root="${BOXLITE_CACHE:-$HOME/.cache/boxlite}/linux-headers/$LINUX_HEADERS_VERSION/$arch"
+    local cache_root="${BOXLITE_CACHE:-$DEFAULT_BOXLITE_CACHE}/linux-headers/$LINUX_HEADERS_VERSION/$arch"
     local include_dir="$cache_root/include"
 
     if [ -f "$include_dir/asm/unistd.h" ] && [ -f "$include_dir/linux/audit.h" ]; then
@@ -112,7 +125,7 @@ ensure_libseccomp_for_target() {
         return 1
     fi
 
-    local cache_root="${BOXLITE_CACHE:-$HOME/.cache/boxlite}/libseccomp/$target/$LIBSECCOMP_VERSION"
+    local cache_root="${BOXLITE_CACHE:-$DEFAULT_BOXLITE_CACHE}/libseccomp/$target/$LIBSECCOMP_VERSION"
     local lib_path="$cache_root/lib/libseccomp.a"
 
     if [ -f "$lib_path" ]; then

--- a/scripts/build/build-libseccomp.sh
+++ b/scripts/build/build-libseccomp.sh
@@ -1,0 +1,222 @@
+#!/bin/bash
+# Build libseccomp.a statically for the guest musl target.
+#
+# The guest binary is statically linked with musl. The Rust `libseccomp` crate
+# (pulled by libcontainer's "libseccomp" feature) needs libseccomp.a for the
+# *target* triple, not the host. This script builds that .a from upstream
+# source using the musl cross-compiler that build-guest.sh already requires.
+#
+# Output layout (cache):
+#   $LIBSECCOMP_PREFIX/lib/libseccomp.a
+#   $LIBSECCOMP_PREFIX/include/seccomp.h
+#
+# where $LIBSECCOMP_PREFIX = $HOME/.cache/boxlite/libseccomp/<target>/<version>
+#
+# On success, exports:
+#   LIBSECCOMP_LIB_PATH      (consumed by libseccomp-sys build.rs)
+#   LIBSECCOMP_LINK_TYPE=static
+#   LIBSECCOMP_INCLUDE_PATH
+#
+# Usage:
+#   source scripts/build/build-libseccomp.sh
+#   ensure_libseccomp_for_target aarch64-unknown-linux-musl
+
+set -e
+
+LIBSECCOMP_VERSION="${LIBSECCOMP_VERSION:-2.5.5}"
+LIBSECCOMP_TARBALL_SHA256="${LIBSECCOMP_TARBALL_SHA256:-248a2c8a4d9b9858aa6baf52712c34afefcf9c9e94b76dce02c1c9aa25fb3375}"
+
+# sabotage-linux/kernel-headers: small portable export of Linux user-space
+# headers (asm/, linux/, etc.). Needed because brew's musl-cross ships
+# musl libc headers but no Linux kernel headers, and libseccomp #includes
+# <asm/unistd.h> and <linux/audit.h>.
+LINUX_HEADERS_VERSION="${LINUX_HEADERS_VERSION:-4.19.88-2}"
+LINUX_HEADERS_SHA256="${LINUX_HEADERS_SHA256:-16161844e56944d39794ad74c2dfd6faad12bda79b5dc00595f4178d28a92e2d}"
+
+# Install Linux user-space headers for ARCH into a cache dir, return path
+# to the include/ root via stdout. Idempotent.
+ensure_linux_headers_for_arch() {
+    local arch="$1"
+    if [ -z "$arch" ]; then
+        echo "ERROR: ensure_linux_headers_for_arch requires an arch (e.g. aarch64, x86_64)" >&2
+        return 1
+    fi
+
+    local cache_root="${BOXLITE_CACHE:-$HOME/.cache/boxlite}/linux-headers/$LINUX_HEADERS_VERSION/$arch"
+    local include_dir="$cache_root/include"
+
+    if [ -f "$include_dir/asm/unistd.h" ] && [ -f "$include_dir/linux/audit.h" ]; then
+        echo "$include_dir"
+        return 0
+    fi
+
+    local build_root
+    build_root=$(mktemp -d -t boxlite-kheaders-XXXXXX)
+    # local trap so caller's trap (libseccomp build_root) isn't clobbered
+    local _kheaders_cleanup="rm -rf '$build_root'"
+
+    local tarball="$build_root/kernel-headers.tar.gz"
+    local url="https://github.com/sabotage-linux/kernel-headers/archive/refs/tags/v$LINUX_HEADERS_VERSION.tar.gz"
+
+    echo "  → downloading $url" >&2
+    if command -v curl >/dev/null 2>&1; then
+        curl -fsSL "$url" -o "$tarball" || { eval "$_kheaders_cleanup"; return 1; }
+    else
+        wget -q "$url" -O "$tarball" || { eval "$_kheaders_cleanup"; return 1; }
+    fi
+
+    local actual_sha256
+    if command -v shasum >/dev/null 2>&1; then
+        actual_sha256=$(shasum -a 256 "$tarball" | awk '{print $1}')
+    else
+        actual_sha256=$(sha256sum "$tarball" | awk '{print $1}')
+    fi
+    if [ "$actual_sha256" != "$LINUX_HEADERS_SHA256" ]; then
+        echo "ERROR: kernel-headers tarball SHA256 mismatch" >&2
+        echo "  expected: $LINUX_HEADERS_SHA256" >&2
+        echo "  actual:   $actual_sha256" >&2
+        eval "$_kheaders_cleanup"
+        return 1
+    fi
+
+    tar -xzf "$tarball" -C "$build_root"
+    mkdir -p "$cache_root"
+    (
+        cd "$build_root/kernel-headers-$LINUX_HEADERS_VERSION"
+        make ARCH="$arch" prefix="$cache_root" install >/dev/null
+    )
+
+    eval "$_kheaders_cleanup"
+
+    if [ ! -f "$include_dir/asm/unistd.h" ] || [ ! -f "$include_dir/linux/audit.h" ]; then
+        echo "ERROR: kernel-headers install did not produce expected headers" >&2
+        return 1
+    fi
+
+    echo "$include_dir"
+}
+
+ensure_libseccomp_for_target() {
+    local target="$1"
+    if [ -z "$target" ]; then
+        echo "ERROR: ensure_libseccomp_for_target requires a target triple" >&2
+        return 1
+    fi
+
+    local arch_prefix
+    arch_prefix=$(echo "$target" | cut -d'-' -f1)
+    local cc="${arch_prefix}-linux-musl-gcc"
+    if ! command -v "$cc" >/dev/null 2>&1; then
+        echo "ERROR: musl cross-compiler $cc not found in PATH" >&2
+        echo "  Run scripts/setup/setup-macos.sh (or setup-ubuntu.sh / setup-musllinux.sh)" >&2
+        return 1
+    fi
+
+    local cache_root="${BOXLITE_CACHE:-$HOME/.cache/boxlite}/libseccomp/$target/$LIBSECCOMP_VERSION"
+    local lib_path="$cache_root/lib/libseccomp.a"
+
+    if [ -f "$lib_path" ]; then
+        export LIBSECCOMP_LIB_PATH="$cache_root/lib"
+        export LIBSECCOMP_INCLUDE_PATH="$cache_root/include"
+        export LIBSECCOMP_LINK_TYPE="static"
+        return 0
+    fi
+
+    echo "🔨 Building libseccomp $LIBSECCOMP_VERSION for $target..."
+
+    if ! command -v gperf >/dev/null 2>&1; then
+        echo "ERROR: gperf not found (libseccomp build dep)" >&2
+        echo "  macOS:    brew install gperf" >&2
+        echo "  Ubuntu:   sudo apt-get install gperf" >&2
+        echo "  Alpine:   apk add gperf" >&2
+        return 1
+    fi
+
+    local build_root
+    build_root=$(mktemp -d -t boxlite-libseccomp-XXXXXX)
+    trap 'rm -rf "$build_root"' EXIT
+
+    local tarball="$build_root/libseccomp-$LIBSECCOMP_VERSION.tar.gz"
+    local url="https://github.com/seccomp/libseccomp/releases/download/v$LIBSECCOMP_VERSION/libseccomp-$LIBSECCOMP_VERSION.tar.gz"
+
+    echo "  → downloading $url"
+    if command -v curl >/dev/null 2>&1; then
+        curl -fsSL "$url" -o "$tarball"
+    else
+        wget -q "$url" -O "$tarball"
+    fi
+
+    # Verify integrity
+    local actual_sha256
+    if command -v shasum >/dev/null 2>&1; then
+        actual_sha256=$(shasum -a 256 "$tarball" | awk '{print $1}')
+    else
+        actual_sha256=$(sha256sum "$tarball" | awk '{print $1}')
+    fi
+    if [ "$actual_sha256" != "$LIBSECCOMP_TARBALL_SHA256" ]; then
+        echo "ERROR: libseccomp tarball SHA256 mismatch" >&2
+        echo "  expected: $LIBSECCOMP_TARBALL_SHA256" >&2
+        echo "  actual:   $actual_sha256" >&2
+        return 1
+    fi
+
+    # libseccomp #includes <asm/unistd.h> and <linux/audit.h> which musl-cross
+    # doesn't ship. Vendor portable Linux user-space headers for the target arch.
+    local headers_include
+    headers_include=$(ensure_linux_headers_for_arch "$arch_prefix")
+    if [ -z "$headers_include" ]; then
+        echo "ERROR: failed to provision Linux kernel headers for $arch_prefix" >&2
+        return 1
+    fi
+
+    tar -xzf "$tarball" -C "$build_root"
+    local src_dir="$build_root/libseccomp-$LIBSECCOMP_VERSION"
+
+    mkdir -p "$cache_root"
+
+    (
+        cd "$src_dir"
+        # --host tells autotools we're cross-compiling.
+        # CC overrides default gcc; CFLAGS hardens; --enable-static + --disable-shared
+        # gives us libseccomp.a only. CPPFLAGS points at vendored kernel headers.
+        ./configure \
+            --host="${arch_prefix}-linux-musl" \
+            --prefix="$cache_root" \
+            --enable-static \
+            --disable-shared \
+            --disable-python \
+            CC="$cc" \
+            CFLAGS="-Os -fPIC" \
+            CPPFLAGS="-I$headers_include" \
+            >/dev/null
+
+        make -j"$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)" >/dev/null
+        make install >/dev/null
+    )
+
+    if [ ! -f "$lib_path" ]; then
+        echo "ERROR: libseccomp build did not produce $lib_path" >&2
+        return 1
+    fi
+
+    echo "✓ libseccomp.a → $lib_path"
+
+    export LIBSECCOMP_LIB_PATH="$cache_root/lib"
+    export LIBSECCOMP_INCLUDE_PATH="$cache_root/include"
+    export LIBSECCOMP_LINK_TYPE="static"
+}
+
+# When executed directly, build for $1 or auto-detected target.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    target="${1:-}"
+    if [ -z "$target" ]; then
+        SCRIPT_DIR_LSC="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+        # shellcheck source=../util.sh
+        source "$SCRIPT_DIR_LSC/util.sh"
+        target="$GUEST_TARGET"
+    fi
+    ensure_libseccomp_for_target "$target"
+    echo "LIBSECCOMP_LIB_PATH=$LIBSECCOMP_LIB_PATH"
+    echo "LIBSECCOMP_INCLUDE_PATH=$LIBSECCOMP_INCLUDE_PATH"
+    echo "LIBSECCOMP_LINK_TYPE=$LIBSECCOMP_LINK_TYPE"
+fi

--- a/scripts/setup/setup-macos.sh
+++ b/scripts/setup/setup-macos.sh
@@ -170,6 +170,19 @@ install_dylibbundler() {
     echo ""
 }
 
+# Install gperf (libseccomp build dep — required by build-libseccomp.sh)
+install_gperf() {
+    print_step "Checking for gperf... "
+    if brew_installed "gperf"; then
+        print_success "Already installed"
+    else
+        echo -e "${YELLOW}Installing...${NC}"
+        brew install gperf
+        print_success "gperf installed"
+    fi
+    echo ""
+}
+
 # Install protobuf (for boxlite-shared gRPC/protobuf compilation)
 install_protobuf() {
     print_step "Checking for protobuf... "
@@ -261,6 +274,8 @@ main() {
     install_llvm
 
     install_dylibbundler
+
+    install_gperf
 
     install_protobuf
 

--- a/scripts/setup/setup-manylinux.sh
+++ b/scripts/setup/setup-manylinux.sh
@@ -80,6 +80,9 @@ install_system_deps() {
         ninja-build        # Ninja build backend
         libcap-devel       # Linux capabilities library
 
+        # libseccomp build dep (used by build-libseccomp.sh)
+        gperf
+
         # Python
         python3
         python3-pip

--- a/scripts/setup/setup-musllinux.sh
+++ b/scripts/setup/setup-musllinux.sh
@@ -56,6 +56,7 @@ install_system_deps() {
 
         # musl development
         musl-dev
+        gperf             # libseccomp build dep (used by build-libseccomp.sh)
 
         # libkrun build dependencies
         clang

--- a/scripts/setup/setup-ubuntu.sh
+++ b/scripts/setup/setup-ubuntu.sh
@@ -72,6 +72,7 @@ install_system_deps() {
 
         # Guest binary (static musl build)
         musl-tools         # musl-gcc for static linking
+        gperf              # libseccomp build dep (used by build-libseccomp.sh)
 
         # Python SDK
         python3

--- a/src/guest/Cargo.toml
+++ b/src/guest/Cargo.toml
@@ -33,7 +33,7 @@ tar = "0.4"
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = "0.18.0"
 tokio-vsock = { version = "0.7", features = ["tonic012"] }
-libcontainer = { version = "0.5.6", default-features = false, features = ["v2"] }
+libcontainer = { version = "0.5.6", default-features = false, features = ["v2", "libseccomp"] }
 oci-spec = "0.6"
 rtnetlink = "0.14"
 futures = "0.3"


### PR DESCRIPTION
## Summary
- Enable libcontainer's `libseccomp` feature so OCI seccomp profiles are actually applied. Today the guest prints `WARN libcontainer::process::init::process: seccomp not available, unable to set seccomp privileges!` and runs workloads with no filter.
- Add `scripts/build/build-libseccomp.sh` that vendors libseccomp 2.5.5 + sabotage-linux/kernel-headers, builds `libseccomp.a` statically per target arch, cached under `~/.cache/boxlite/`.
- Wire it into `build-guest.sh`; add `gperf` (libseccomp's build dep) to all four platform setup scripts (`setup-macos.sh`, `setup-ubuntu.sh`, `setup-musllinux.sh`, `setup-manylinux.sh`).

## Why
Without seccomp, BoxLite's "secure isolated execution environment" is missing a defense-in-depth layer the OCI spec already specifies. The fix is mechanical (one feature flag) but the cross-compile plumbing isn't — `brew install FiloSottile/musl-cross` ships musl libc headers but no Linux UAPI headers, so libseccomp's `#include <asm/unistd.h>` and `<linux/audit.h>` fail. Vendoring the [sabotage-linux/kernel-headers](https://github.com/sabotage-linux/kernel-headers) tarball (~1.4 MB) gives a deterministic, portable header set across all platforms.

Cache layout under `~/.cache/boxlite/`:
- `libseccomp/<target>/<version>/{lib,include}` — built `.a` and headers
- `linux-headers/<version>/<arch>/include` — sabotage UAPI export

Idempotent — re-runs hit cache in ~10 ms.

## Test plan
- [x] \`bash scripts/build/build-libseccomp.sh aarch64-unknown-linux-musl\` on macOS Apple Silicon → 207 KB \`.a\`
- [x] \`bash scripts/build/build-libseccomp.sh x86_64-unknown-linux-musl\` on Ubuntu EC2 → 222 KB \`.a\`
- [x] Re-run hits cache (~10 ms)
- [x] \`bash scripts/build/build-guest.sh --profile debug\` succeeds on both arches
- [x] \`nm\` shows \`seccomp_init\`, \`seccomp_load\`, \`seccomp_rule_add\` linked into guest binary
- [x] Guest binary remains statically linked (\`file\` reports \`statically linked\` / \`static-pie\`)
- [x] \`cargo clippy -p boxlite-guest -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [ ] End-to-end: \`make runtime-debug\` + run a box with a seccomp profile, confirm \`Seccomp: 2\` in \`/proc/self/status\` and the WARN line is gone
- [ ] CI passes for both target arches and all four setup scripts