### PR TITLE
Bump SDK patch versions to 0.9.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,7 +369,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -442,7 +442,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-c"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "boxlite",
  "cbindgen",
@@ -452,7 +452,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-cli"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -489,7 +489,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-guest"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-node"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "boxlite",
  "boxlite-shared",
@@ -532,7 +532,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-python"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "boxlite",
  "futures",
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-shared"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "proptest",
  "prost",
@@ -585,7 +585,7 @@ dependencies = [
 
 [[package]]
 name = "bubblewrap-sys"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "num_cpus",
 ]
@@ -1062,7 +1062,7 @@ checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
 name = "e2fsprogs-sys"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "num_cpus",
 ]
@@ -2019,14 +2019,14 @@ dependencies = [
 
 [[package]]
 name = "libgvproxy-sys"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "libkrun-sys"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "libc",
  "num_cpus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,11 +19,11 @@ resolver = "2"
 
 [workspace.dependencies]
 boxlite = { path = "src/boxlite", version = "0.9.2" }
-boxlite-shared = { path = "src/shared", version = "0.9.0" }
-bubblewrap-sys = { path = "src/deps/bubblewrap-sys", version = "0.9.0" }
-e2fsprogs-sys = { path = "src/deps/e2fsprogs-sys", version = "0.9.0" }
-libgvproxy-sys = { path = "src/deps/libgvproxy-sys", version = "0.9.0" }
-libkrun-sys = { path = "src/deps/libkrun-sys", version = "0.9.0" }
+boxlite-shared = { path = "src/shared", version = "0.9.2" }
+bubblewrap-sys = { path = "src/deps/bubblewrap-sys", version = "0.9.2" }
+e2fsprogs-sys = { path = "src/deps/e2fsprogs-sys", version = "0.9.2" }
+libgvproxy-sys = { path = "src/deps/libgvproxy-sys", version = "0.9.2" }
+libkrun-sys = { path = "src/deps/libkrun-sys", version = "0.9.2" }
 
 [workspace.package]
 version = "0.9.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = ["build/tmp", "target", ".venv", "examples/*/.venv"]
 resolver = "2"
 
 [workspace.dependencies]
-boxlite = { path = "src/boxlite", version = "0.9.1" }
+boxlite = { path = "src/boxlite", version = "0.9.2" }
 boxlite-shared = { path = "src/shared", version = "0.9.0" }
 bubblewrap-sys = { path = "src/deps/bubblewrap-sys", version = "0.9.0" }
 e2fsprogs-sys = { path = "src/deps/e2fsprogs-sys", version = "0.9.0" }
@@ -26,7 +26,7 @@ libgvproxy-sys = { path = "src/deps/libgvproxy-sys", version = "0.9.0" }
 libkrun-sys = { path = "src/deps/libkrun-sys", version = "0.9.0" }
 
 [workspace.package]
-version = "0.9.1"
+version = "0.9.2"
 edition = "2024"
 authors = ["Dorian Zheng <https://github.com/dorianzheng>"]
 license = "Apache-2.0"

--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boxlite-ai/boxlite",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "BoxLite - Embeddable micro-VM runtime for secure, isolated code execution",
   "type": "module",
   "main": "dist/index.js",

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "boxlite"
-version = "0.9.1"
+version = "0.9.2"
 description = "Python bindings for Boxlite runtime"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Bump workspace package version 0.9.1 → 0.9.2 (covers Rust core `boxlite` crate, plus the `boxlite-c`, `boxlite-python`, `boxlite-node` crates that inherit `version.workspace = true`)
- Bump `sdks/python/pyproject.toml` and `sdks/node/package.json` to 0.9.2
- Refresh `Cargo.lock` for all workspace members

The Go SDK has no source-level version file (consumers resolve via `go.mod` and the `sdks/go/vX.Y.Z` git tag), so it isn't touched here — push the matching `sdks/go/v0.9.2` tag separately after merge.

## Test plan
- [ ] CI build passes
- [ ] CI test matrix passes