### PR TITLE
fix: plumb sandbox disk size and correct CPU/memory unit conversions

### DIFF
--- a/apps/infra/sst.config.ts
+++ b/apps/infra/sst.config.ts
@@ -5,10 +5,6 @@
 
 /// <reference path="./.sst/platform/config.d.ts" />
 
-import { readFileSync } from "fs";
-import { dirname, resolve } from "path";
-import { fileURLToPath } from "url";
-
 // ─────────────────────────────────────────────────────────────────────────────
 // BoxLite control plane on AWS (ap-southeast-1).
 //
@@ -516,15 +512,18 @@ export default $config({
 // ── runner bootstrap ─────────────────────────────────────────────────────────
 // EC2 user-data: downloads prebuilt runner binary from GitHub Releases
 // and runs it directly with BoxLite VM isolation.
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const RUNNER_VERSION = readFileSync(resolve(__dirname, "../../Cargo.toml"), "utf-8")
-  .match(/^version\s*=\s*"(.+?)"/m)![1];
-
-function buildRunnerUserData(input: {
+async function buildRunnerUserData(input: {
   apiUrl: string;
   token: string;
   registryUrl: string;
-}): string {
+}): Promise<string> {
+  const { readFileSync } = await import("fs");
+  const { resolve } = await import("path");
+
+  // SST invokes from apps/infra/ as cwd; Cargo.toml lives at repo root.
+  const RUNNER_VERSION = readFileSync(resolve(process.cwd(), "../../Cargo.toml"), "utf-8")
+    .match(/^version\s*=\s*"(.+?)"/m)![1];
+
   const registryHost = input.registryUrl.replace(/^https?:\/\//, "").replace(/\/$/, "");
 
   const script = `#!/bin/bash

--- a/apps/runner/pkg/boxlite/client.go
+++ b/apps/runner/pkg/boxlite/client.go
@@ -135,11 +135,12 @@ func (c *Client) Close() error {
 // Create creates a new sandbox (VM) from the given image and configuration.
 // Returns the box ID and daemon version.
 func (c *Client) Create(ctx context.Context, sandboxDto dto.CreateSandboxDTO) (string, string, error) {
-	cpus := int(sandboxDto.CpuQuota / 100_000)
+	// API sends cores / GB / GB as small integers (see apps/api Sandbox entity).
+	cpus := int(sandboxDto.CpuQuota)
 	if cpus < 1 {
 		cpus = 1
 	}
-	memoryMiB := int(sandboxDto.MemoryQuota / (1024 * 1024))
+	memoryMiB := int(sandboxDto.MemoryQuota * 1024)
 	if memoryMiB < 128 {
 		memoryMiB = 128
 	}
@@ -151,7 +152,7 @@ func (c *Client) Create(ctx context.Context, sandboxDto dto.CreateSandboxDTO) (s
 		boxlite.WithDetach(true),
 	}
 	if sandboxDto.StorageQuota > 0 {
-		c.logger.DebugContext(ctx, "storage quota ignored because the Go SDK does not expose disk sizing", "sandbox", sandboxDto.Id)
+		opts = append(opts, boxlite.WithDiskSize(int(sandboxDto.StorageQuota)))
 	}
 
 	for k, v := range sandboxDto.Env {

--- a/apps/runner/pkg/boxlite/stubs.go
+++ b/apps/runner/pkg/boxlite/stubs.go
@@ -36,13 +36,14 @@ func (c *Client) Resize(ctx context.Context, sandboxId string, resizeDto dto.Res
 		return fmt.Errorf("failed to destroy box during resize: %w", err)
 	}
 
+	// API sends cores / GB / GB as small integers (see apps/api ResizeSandboxDto).
 	cpus := info.CPUs
 	if resizeDto.Cpu > 0 {
 		cpus = int(resizeDto.Cpu)
 	}
 	memoryMiB := info.MemoryMiB
 	if resizeDto.Memory > 0 {
-		memoryMiB = int(resizeDto.Memory / (1024 * 1024))
+		memoryMiB = int(resizeDto.Memory * 1024)
 	}
 
 	opts := []boxlite.BoxOption{
@@ -55,7 +56,7 @@ func (c *Client) Resize(ctx context.Context, sandboxId string, resizeDto dto.Res
 	}
 
 	if resizeDto.Disk > 0 {
-		c.logger.DebugContext(ctx, "disk resize ignored because the Go SDK does not expose disk sizing", "sandbox", sandboxId)
+		opts = append(opts, boxlite.WithDiskSize(int(resizeDto.Disk)))
 	}
 
 	newBox, err := c.runtime.Create(ctx, info.Image, opts...)

--- a/sdks/c/include/boxlite.h
+++ b/sdks/c/include/boxlite.h
@@ -343,6 +343,8 @@ void boxlite_options_set_cpus(CBoxliteOptions *opts, int cpus);
 
 void boxlite_options_set_memory(CBoxliteOptions *opts, int memory_mib);
 
+void boxlite_options_set_disk_size_gb(CBoxliteOptions *opts, int disk_size_gb);
+
 void boxlite_options_set_workdir(CBoxliteOptions *opts, const char *workdir);
 
 void boxlite_options_add_env(CBoxliteOptions *opts, const char *key, const char *val);

--- a/sdks/c/src/options.rs
+++ b/sdks/c/src/options.rs
@@ -46,6 +46,14 @@ pub unsafe extern "C" fn boxlite_options_set_memory(opts: *mut CBoxliteOptions, 
 }
 
 #[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_options_set_disk_size_gb(
+    opts: *mut CBoxliteOptions,
+    disk_size_gb: c_int,
+) {
+    options_set_disk_size_gb(opts, disk_size_gb)
+}
+
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn boxlite_options_set_workdir(
     opts: *mut CBoxliteOptions,
     workdir: *const c_char,
@@ -210,6 +218,14 @@ pub unsafe fn options_set_memory(handle: *mut OptionsHandle, memory_mib: c_int) 
     unsafe {
         if !handle.is_null() && memory_mib > 0 {
             (*handle).options.memory_mib = Some(memory_mib as u32);
+        }
+    }
+}
+
+pub unsafe fn options_set_disk_size_gb(handle: *mut OptionsHandle, disk_size_gb: c_int) {
+    unsafe {
+        if !handle.is_null() && disk_size_gb > 0 {
+            (*handle).options.disk_size_gb = Some(disk_size_gb as u64);
         }
     }
 }

--- a/sdks/go/options.go
+++ b/sdks/go/options.go
@@ -86,6 +86,7 @@ type boxConfig struct {
 	name       string
 	cpus       int
 	memoryMiB  int
+	diskSizeGB int
 	rootfsPath string
 	env        [][2]string
 	volumes    []volumeEntry
@@ -117,6 +118,15 @@ func WithCPUs(n int) BoxOption {
 // WithMemory sets the memory limit in MiB.
 func WithMemory(mib int) BoxOption {
 	return func(c *boxConfig) { c.memoryMiB = mib }
+}
+
+// WithDiskSize sets the per-box COW disk virtual size in GB.
+// When unset, the COW disk inherits the base ext4 image size, which is
+// content-fitted (~256 MB minimum). Set this to give the sandbox runtime
+// write headroom; the guest's ext4 is automatically resized via resize2fs
+// on first boot.
+func WithDiskSize(gb int) BoxOption {
+	return func(c *boxConfig) { c.diskSizeGB = gb }
 }
 
 // WithRootfsPath prefers a local OCI image layout directory over pulling from a registry.
@@ -233,6 +243,9 @@ func buildCOptions(image string, cfg *boxConfig) (*C.CBoxliteOptions, error) {
 	}
 	if cfg.memoryMiB > 0 {
 		C.boxlite_options_set_memory(cOpts, C.int(cfg.memoryMiB))
+	}
+	if cfg.diskSizeGB > 0 {
+		C.boxlite_options_set_disk_size_gb(cOpts, C.int(cfg.diskSizeGB))
 	}
 	if cfg.workDir != "" {
 		cDir := toCString(cfg.workDir)


### PR DESCRIPTION
## Summary
- Runner was treating `CpuQuota` as cgroup µs and `MemoryQuota` as bytes; the API actually sends cores / GB. Fixed in both create (`client.go`) and resize (`stubs.go`) paths.
- Added `WithDiskSize(gb int)` to the Go SDK plus matching FFI (`boxlite_options_set_disk_size_gb`); previously `StorageQuota` was logged-and-dropped, leaving every sandbox on the content-fitted 256 MB ext4 image disk.
- Moved `fs` / `path` / `url` imports inside `buildRunnerUserData` (dynamic import) so SST 4.6.11 will accept the config and deploys can resume.

## Test plan
- [ ] Rebuild C SDK / `libboxlite.a` to ensure the new symbol is exported.
- [ ] `go build ./...` in `apps/runner/` after C SDK rebuild.
- [ ] Create a sandbox; confirm `df -h` shows ~10 GB at `/`, `nproc` matches snapshot `cpu`, and `free -m` matches `mem * 1024`.
- [ ] Resize a stopped sandbox with `disk: 20`; confirm new size reflected inside the guest.
- [ ] `npx sst deploy --stage dev` completes past the prior yarn/Docker steps and reconciles the runner instance.