### PR TITLE
ci(e2e): add VM integration tests on ephemeral AWS EC2 runner

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -129,6 +129,54 @@ Runs code quality checks.
 4. `node` - Run Node lint and format checks via `make lint:node` and `make fmt:check:node`
 5. `c` - Run C SDK lint and format checks via `make lint:c` and `make fmt:check:c`
 
+### `e2e-test.yml`
+
+Runs VM-based E2E integration tests on an ephemeral AWS EC2 self-hosted runner.
+
+**Why:** GitHub-hosted runners (including larger paid runners) do not support `/dev/kvm`. BoxLite integration tests need real VMs via libkrun.
+
+**Architecture:** Three-job ephemeral pattern:
+1. `start-runner` (ubuntu-latest) — launches an AWS EC2 c8i.2xlarge instance, registers an ephemeral GitHub Actions runner
+2. `e2e-tests` (self-hosted) — builds runtime, runs all integration test suites
+3. `stop-runner` (ubuntu-latest, `if: always()`) — terminates instance, deregisters runner
+
+**Triggers:**
+- Push to `main` (path-filtered to `src/`, `sdks/`, `Cargo.*`)
+- Pull request with `e2e` label (cost-gated)
+- Manual dispatch (`workflow_dispatch`)
+
+**Cost:** ~$0.34/hr (c8i.2xlarge). Typical run: 15-25 min → ~$0.09-0.14 per run.
+
+**Safety mechanisms:**
+- `--ephemeral` runner auto-deregisters after one job
+- `if: always()` ensures cleanup on failure/cancellation
+- 45-minute self-destruct timer on the instance (EC2 self-termination)
+- Runner deregistration API call (belt-and-suspenders)
+- 35-minute job timeout prevents runaway tests
+- `instance-initiated-shutdown-behavior: terminate` auto-cleans on shutdown
+
+**Authentication:** GitHub OIDC → AWS STS (no stored AWS credentials).
+
+**Required secret:**
+- `GH_PAT` - GitHub PAT with `repo` scope (for runner registration API)
+
+**Required variables** (Settings → Variables → Actions):
+- `AWS_ACCOUNT_ID` - AWS account ID
+- `AWS_SUBNET_ID` - Subnet with auto-assign public IP
+- `AWS_SECURITY_GROUP_ID` - Security group allowing outbound HTTPS
+
+**Required AWS resources** (provisioned by `scripts/ci/setup-aws-oidc.sh`):
+- OIDC identity provider (`token.actions.githubusercontent.com`)
+- IAM role `boxlite-e2e-github-actions` with trust policy for this repo
+- IAM instance profile `boxlite-e2e-runner` with `ec2:TerminateInstances` on self
+- Subnet with internet access + security group (outbound 443)
+
+**Jobs:**
+1. `should-run` - Gate check (label present on PR?)
+2. `start-runner` - Launch EC2 c8i.2xlarge, register runner, wait for online
+3. `e2e-tests` - Build runtime, run Rust/CLI/Python/Node/C integration tests
+4. `stop-runner` - Terminate instance, deregister runner
+
 ## Trigger Behavior
 
 | Change | warm-caches | build-runtime | build-wheels | build-node |
@@ -179,6 +227,7 @@ Additional platforms (darwin-x64, linux-arm64-gnu) can be added to `config.yml` 
 - `CARGO_REGISTRY_TOKEN` - crates.io API token for publishing Rust crates
 - `PYPI_API_TOKEN` - PyPI API token for publishing Python wheels
 - `NPM_TOKEN` - npm access token for publishing Node.js packages
+- `GH_PAT` - GitHub PAT with `repo` scope (for self-hosted runner registration)
 
 Set these in repository Settings → Secrets and variables → Actions.
 

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1,0 +1,358 @@
+# Run VM-based E2E integration tests on an ephemeral AWS EC2 runner.
+#
+# GitHub-hosted runners do not support nested virtualization / KVM.
+# This workflow provisions an AWS EC2 instance (Intel Nitro with KVM support),
+# runs all integration tests that require real VMs, then terminates the instance.
+#
+# Architecture:
+#   start-runner (ubuntu-latest)  →  e2e-tests (self-hosted)  →  stop-runner (ubuntu-latest)
+#     Create EC2 instance              Build + run tests             Terminate instance
+#     Register ephemeral runner        35-min timeout                Deregister runner
+#     Poll until online                                              if: always()
+#
+# Cost: ~$0.34/hr (c8i.2xlarge). Typical run: 15-25 min → ~$0.09-0.14 per run.
+#
+# Authentication: GitHub OIDC → AWS STS (no stored AWS credentials).
+#
+# Setup (one command, auto-detects default VPC):
+#   ./scripts/ci/setup-ci-runner.sh
+#
+# This provisions all AWS resources and configures GitHub variables/secrets.
+name: E2E Tests
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/boxlite/**'
+      - 'src/shared/**'
+      - 'src/cli/**'
+      - 'src/guest/**'
+      - 'sdks/**'
+      - '**/Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/e2e-test.yml'
+  pull_request:
+    types: [labeled, synchronize]
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: e2e-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  AWS_REGION: us-east-1
+  AWS_ROLE_ARN: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/boxlite-e2e-github-actions
+  EC2_INSTANCE_TYPE: c8i.2xlarge
+  EC2_AMI_ID: ami-0a0e5d9c7acc336f1  # Ubuntu 24.04 LTS x86_64 (us-east-1)
+  EC2_SUBNET_ID: ${{ vars.AWS_SUBNET_ID }}
+  EC2_SECURITY_GROUP_ID: ${{ vars.AWS_SECURITY_GROUP_ID }}
+  RUNNER_VERSION: '2.322.0'
+  MAX_RUNNER_WAIT_SECONDS: '300'
+  SELF_DESTRUCT_SECONDS: '2700'
+
+jobs:
+  # =========================================================================
+  # Gate: only run for push-to-main, manual dispatch, or PRs with 'e2e' label
+  # =========================================================================
+  should-run:
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.check.outputs.run }}
+    steps:
+      - name: Check trigger conditions
+        id: check
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event_name }}" = "push" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            LABELS='${{ toJson(github.event.pull_request.labels.*.name) }}'
+            if echo "$LABELS" | jq -e 'index("e2e")' > /dev/null 2>&1; then
+              echo "run=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "run=false" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  # =========================================================================
+  # Job 1: Provision EC2 instance and register ephemeral runner
+  # =========================================================================
+  start-runner:
+    name: Start E2E Runner
+    needs: should-run
+    if: needs.should-run.outputs.run == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    outputs:
+      label: ${{ steps.launch-instance.outputs.label }}
+      instance-id: ${{ steps.launch-instance.outputs.instance-id }}
+      runner-id: ${{ steps.wait-for-runner.outputs.runner-id }}
+    steps:
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+          role-session-name: e2e-start-${{ github.run_id }}
+
+      - name: Generate runner registration token
+        id: reg-token
+        run: |
+          RESPONSE=$(curl -sf -X POST \
+            -H "Authorization: token ${{ secrets.GH_PAT }}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ github.repository }}/actions/runners/registration-token")
+          TOKEN=$(echo "$RESPONSE" | jq -r .token)
+          if [ "$TOKEN" = "null" ] || [ -z "$TOKEN" ]; then
+            echo "::error::Failed to get runner registration token"
+            echo "$RESPONSE" >&2
+            exit 1
+          fi
+          echo "::add-mask::$TOKEN"
+          echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
+
+      - name: Launch EC2 instance
+        id: launch-instance
+        run: |
+          LABEL="boxlite-e2e-${{ github.run_id }}-${{ github.run_attempt }}"
+
+          # Build user-data script
+          cat > /tmp/user-data.sh << 'USERDATA'
+          #!/bin/bash
+          set -euo pipefail
+
+          # === Configuration ===
+          GITHUB_REPOSITORY="__REPO__"
+          RUNNER_TOKEN="__TOKEN__"
+          RUNNER_NAME="__LABEL__"
+          RUNNER_LABELS="__LABEL__,self-hosted,linux,x64,kvm"
+          RUNNER_VERSION="__RUNNER_VERSION__"
+          SELF_DESTRUCT_SECONDS="__SELF_DESTRUCT__"
+          AWS_REGION="__REGION__"
+
+          # === Self-Destruct Timer ===
+          (
+            sleep ${SELF_DESTRUCT_SECONDS}
+            TOKEN=$(curl -sf -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 60")
+            INSTANCE_ID=$(curl -sf -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/instance-id)
+            aws ec2 terminate-instances --instance-ids "$INSTANCE_ID" --region "${AWS_REGION}" || true
+          ) &
+
+          # === Enable KVM ===
+          modprobe kvm_intel 2>/dev/null || modprobe kvm_amd 2>/dev/null || true
+          if [ ! -c /dev/kvm ]; then
+            echo "FATAL: /dev/kvm not found after modprobe"
+            exit 1
+          fi
+          chmod 666 /dev/kvm
+
+          # === Install GitHub Actions Runner ===
+          mkdir -p /opt/actions-runner && cd /opt/actions-runner
+          curl -fsSL "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz" | tar xz
+          RUNNER_ALLOW_RUNASROOT=1 ./config.sh \
+            --url "https://github.com/${GITHUB_REPOSITORY}" \
+            --token "${RUNNER_TOKEN}" \
+            --name "${RUNNER_NAME}" \
+            --labels "${RUNNER_LABELS}" \
+            --ephemeral --unattended --disableupdate
+          RUNNER_ALLOW_RUNASROOT=1 ./run.sh
+          USERDATA
+
+          # Substitute placeholders
+          sed -i "s|__REPO__|${{ github.repository }}|g" /tmp/user-data.sh
+          sed -i "s|__TOKEN__|${{ steps.reg-token.outputs.token }}|g" /tmp/user-data.sh
+          sed -i "s|__LABEL__|${LABEL}|g" /tmp/user-data.sh
+          sed -i "s|__RUNNER_VERSION__|${{ env.RUNNER_VERSION }}|g" /tmp/user-data.sh
+          sed -i "s|__SELF_DESTRUCT__|${{ env.SELF_DESTRUCT_SECONDS }}|g" /tmp/user-data.sh
+          sed -i "s|__REGION__|${{ env.AWS_REGION }}|g" /tmp/user-data.sh
+
+          # Launch instance
+          RESPONSE=$(aws ec2 run-instances \
+            --instance-type "${{ env.EC2_INSTANCE_TYPE }}" \
+            --image-id "${{ env.EC2_AMI_ID }}" \
+            --subnet-id "${{ env.EC2_SUBNET_ID }}" \
+            --security-group-ids "${{ env.EC2_SECURITY_GROUP_ID }}" \
+            --iam-instance-profile Name=boxlite-e2e-runner \
+            --user-data file:///tmp/user-data.sh \
+            --block-device-mappings '[{"DeviceName":"/dev/sda1","Ebs":{"VolumeSize":50,"VolumeType":"gp3","DeleteOnTermination":true}}]' \
+            --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=${LABEL}},{Key=Purpose,Value=boxlite-e2e},{Key=GitHubRunId,Value=${{ github.run_id }}}]" \
+            --instance-initiated-shutdown-behavior terminate \
+            --metadata-options "HttpTokens=required,HttpEndpoint=enabled" \
+            --output json)
+
+          INSTANCE_ID=$(echo "$RESPONSE" | jq -r '.Instances[0].InstanceId')
+          if [ -z "$INSTANCE_ID" ] || [ "$INSTANCE_ID" = "null" ]; then
+            echo "::error::Failed to launch EC2 instance"
+            echo "$RESPONSE" >&2
+            exit 1
+          fi
+
+          echo "Instance launched: $INSTANCE_ID (name: $LABEL)"
+          echo "instance-id=${INSTANCE_ID}" >> "$GITHUB_OUTPUT"
+          echo "label=${LABEL}" >> "$GITHUB_OUTPUT"
+
+          # Wait for instance to be running
+          aws ec2 wait instance-running --instance-ids "$INSTANCE_ID"
+          echo "Instance is running"
+
+      - name: Wait for runner to come online
+        id: wait-for-runner
+        run: |
+          LABEL="${{ steps.launch-instance.outputs.label }}"
+          TIMEOUT=${{ env.MAX_RUNNER_WAIT_SECONDS }}
+          ELAPSED=0
+          INTERVAL=15
+
+          echo "Waiting for runner '${LABEL}' to come online (timeout: ${TIMEOUT}s)..."
+
+          while [ $ELAPSED -lt $TIMEOUT ]; do
+            RUNNERS=$(curl -sf \
+              -H "Authorization: token ${{ secrets.GH_PAT }}" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${{ github.repository }}/actions/runners" 2>/dev/null || echo '{"runners":[]}')
+
+            RUNNER_ID=$(echo "$RUNNERS" | jq -r ".runners[] | select(.name == \"$LABEL\") | .id // empty")
+            STATUS=$(echo "$RUNNERS" | jq -r ".runners[] | select(.name == \"$LABEL\") | .status // empty")
+
+            if [ "$STATUS" = "online" ]; then
+              echo "Runner is online (id: $RUNNER_ID)"
+              echo "runner-id=$RUNNER_ID" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+
+            echo "  Waiting... (${ELAPSED}s / ${TIMEOUT}s)"
+            sleep $INTERVAL
+            ELAPSED=$((ELAPSED + INTERVAL))
+          done
+
+          echo "::error::Runner did not come online within ${TIMEOUT}s"
+          exit 1
+
+  # =========================================================================
+  # Job 2: Run all integration tests on the self-hosted runner
+  # =========================================================================
+  e2e-tests:
+    name: E2E Integration Tests
+    needs: start-runner
+    runs-on:
+      - self-hosted
+      - ${{ needs.start-runner.outputs.label }}
+    timeout-minutes: 35
+    env:
+      CARGO_TERM_COLOR: always
+      CARGO_INCREMENTAL: '0'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      - name: Verify KVM access
+        run: |
+          if [ ! -c /dev/kvm ]; then
+            echo "::error::/dev/kvm not found"
+            exit 1
+          fi
+          test -r /dev/kvm -a -w /dev/kvm || {
+            echo "::error::Cannot read/write /dev/kvm"
+            ls -la /dev/kvm
+            exit 1
+          }
+          echo "/dev/kvm is accessible"
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq \
+            build-essential git curl wget file pkg-config patchelf \
+            libssl-dev musl-tools python3 python3-pip python3-venv \
+            llvm libclang-dev flex bison bc libelf-dev python3-pyelftools \
+            meson ninja-build libcap-dev protobuf-compiler \
+            jq
+
+      - name: Install Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Install guest musl target
+        run: |
+          GUEST_TARGET=$(bash scripts/util.sh --target)
+          echo "Guest target: $GUEST_TARGET"
+          rustup target add "$GUEST_TARGET"
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+
+      - name: Build runtime (debug)
+        run: make runtime:debug
+
+      - name: Warm integration test image cache
+        run: make test:warm-cache:rust
+
+      - name: Run Rust integration tests
+        run: make test:integration:rust
+
+      - name: Run CLI integration tests
+        run: make test:integration:cli
+
+      - name: Run Python integration tests
+        run: make test:integration:python
+        continue-on-error: true
+
+      - name: Run Node.js integration tests
+        run: make test:integration:node
+        continue-on-error: true
+
+      - name: Run C SDK integration tests
+        run: make test:integration:c
+        continue-on-error: true
+
+  # =========================================================================
+  # Job 3: Terminate instance and deregister runner (always runs)
+  # =========================================================================
+  stop-runner:
+    name: Stop E2E Runner
+    needs: [start-runner, e2e-tests]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    if: always() && needs.start-runner.outputs.instance-id != ''
+    steps:
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+          role-session-name: e2e-stop-${{ github.run_id }}
+
+      - name: Terminate EC2 instance
+        run: |
+          echo "Terminating instance ${{ needs.start-runner.outputs.instance-id }}..."
+          aws ec2 terminate-instances \
+            --instance-ids "${{ needs.start-runner.outputs.instance-id }}" \
+            && echo "Instance terminated successfully" \
+            || echo "::warning::Failed to terminate instance (may have been self-destructed)"
+
+      - name: Deregister GitHub runner
+        if: needs.start-runner.outputs.runner-id != ''
+        run: |
+          curl -sf -X DELETE \
+            -H "Authorization: token ${{ secrets.GH_PAT }}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ github.repository }}/actions/runners/${{ needs.start-runner.outputs.runner-id }}" \
+            && echo "Runner deregistered" \
+            || echo "::warning::Runner already deregistered (ephemeral auto-cleanup)"

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -241,6 +241,8 @@ jobs:
   # =========================================================================
   e2e-tests:
     name: E2E Integration Tests
+    permissions:
+      contents: read
     needs: start-runner
     runs-on:
       - self-hosted

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -58,6 +58,7 @@ jobs:
   # =========================================================================
   should-run:
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
       run: ${{ steps.check.outputs.run }}
     steps:

--- a/scripts/ci/setup-ci-runner.sh
+++ b/scripts/ci/setup-ci-runner.sh
@@ -1,0 +1,435 @@
+#!/bin/bash
+# Set up AWS infrastructure for E2E integration test runner.
+#
+# This provisions everything needed to run the e2e-test.yml workflow:
+#   AWS: OIDC provider, IAM roles, instance profile, security group
+#   GitHub: Repository variables and secrets
+#
+# Auto-detects AWS account ID, GitHub repo, default VPC, and public subnet.
+#
+# Usage:
+#   ./scripts/ci/setup-ci-runner.sh
+#   ./scripts/ci/setup-ci-runner.sh --vpc-id vpc-xxx --subnet-id subnet-xxx
+#   ./scripts/ci/setup-ci-runner.sh --skip-github
+
+set -euo pipefail
+
+CI_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$CI_SCRIPT_DIR/../common.sh"
+
+# ============================================================================
+# Configuration
+# ============================================================================
+
+DEFAULT_REGION="us-east-1"
+
+VPC_ID=""
+SUBNET_ID=""
+REGION="$DEFAULT_REGION"
+SKIP_GITHUB=false
+
+OIDC_PROVIDER_URL="token.actions.githubusercontent.com"
+GH_ACTIONS_ROLE_NAME="boxlite-e2e-github-actions"
+INSTANCE_PROFILE_ROLE_NAME="boxlite-e2e-runner"
+INSTANCE_PROFILE_NAME="boxlite-e2e-runner"
+SECURITY_GROUP_NAME="boxlite-e2e-runner"
+
+# ============================================================================
+# Functions
+# ============================================================================
+
+usage() {
+    cat << EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Set up AWS + GitHub infrastructure for BoxLite E2E integration tests.
+
+OPTIONS:
+    --vpc-id VPC_ID         VPC ID for security group (auto-detects default VPC)
+    --subnet-id SUBNET_ID   Subnet ID for EC2 instances (auto-detects public subnet)
+    --region REGION         AWS region (default: $DEFAULT_REGION)
+    --skip-github           Skip GitHub variables/secrets setup
+    --help                  Show this help message
+
+EXAMPLES:
+    $(basename "$0")                                                    # auto-detect everything
+    $(basename "$0") --vpc-id vpc-abc123 --subnet-id subnet-abc123      # explicit VPC/subnet
+    $(basename "$0") --skip-github                                      # AWS only
+
+EOF
+    exit 0
+}
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --vpc-id)
+                VPC_ID="$2"
+                shift 2
+                ;;
+            --subnet-id)
+                SUBNET_ID="$2"
+                shift 2
+                ;;
+            --region)
+                REGION="$2"
+                shift 2
+                ;;
+            --skip-github)
+                SKIP_GITHUB=true
+                shift
+                ;;
+            --help|-h)
+                usage
+                ;;
+            *)
+                print_error "Unknown option: $1"
+                usage
+                ;;
+        esac
+    done
+}
+
+step_detect_config() {
+    print_section "Detecting configuration"
+
+    # AWS account ID
+    print_step "AWS account... "
+    ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+    print_success "$ACCOUNT_ID"
+
+    # GitHub repository (derive from origin remote to avoid multi-remote ambiguity)
+    print_step "GitHub repository... "
+    REPO=$(git remote get-url origin | sed 's|.*github.com[:/]||;s|\.git$||')
+    if [ -z "$REPO" ]; then
+        print_error "Cannot detect repo from 'origin' remote"
+        exit 1
+    fi
+    print_success "$REPO"
+
+    # VPC
+    if [ -z "$VPC_ID" ]; then
+        print_step "Default VPC... "
+        VPC_ID=$(aws ec2 describe-vpcs \
+            --filters "Name=is-default,Values=true" \
+            --query "Vpcs[0].VpcId" --output text --region "$REGION" 2>/dev/null || echo "")
+        if [ -z "$VPC_ID" ] || [ "$VPC_ID" = "None" ]; then
+            print_error "No default VPC found in $REGION. Provide --vpc-id."
+            exit 1
+        fi
+        print_success "$VPC_ID"
+    else
+        print_info "VPC: $VPC_ID"
+    fi
+
+    # Subnet
+    if [ -z "$SUBNET_ID" ]; then
+        print_step "Public subnet... "
+        SUBNET_ID=$(aws ec2 describe-subnets \
+            --filters "Name=vpc-id,Values=${VPC_ID}" "Name=map-public-ip-on-launch,Values=true" \
+            --query "Subnets[0].SubnetId" --output text --region "$REGION" 2>/dev/null || echo "")
+        if [ -z "$SUBNET_ID" ] || [ "$SUBNET_ID" = "None" ]; then
+            SUBNET_ID=$(aws ec2 describe-subnets \
+                --filters "Name=vpc-id,Values=${VPC_ID}" \
+                --query "Subnets[0].SubnetId" --output text --region "$REGION" 2>/dev/null || echo "")
+        fi
+        if [ -z "$SUBNET_ID" ] || [ "$SUBNET_ID" = "None" ]; then
+            print_error "No subnet found in VPC $VPC_ID. Provide --subnet-id."
+            exit 1
+        fi
+        print_success "$SUBNET_ID"
+    else
+        print_info "Subnet: $SUBNET_ID"
+    fi
+
+    echo ""
+}
+
+step_create_oidc_provider() {
+    print_section "OIDC identity provider"
+
+    OIDC_ARN="arn:aws:iam::${ACCOUNT_ID}:oidc-provider/${OIDC_PROVIDER_URL}"
+
+    print_step "Checking provider... "
+    if aws iam get-open-id-connect-provider --open-id-connect-provider-arn "$OIDC_ARN" &>/dev/null; then
+        print_success "Already exists"
+    else
+        aws iam create-open-id-connect-provider \
+            --url "https://${OIDC_PROVIDER_URL}" \
+            --client-id-list sts.amazonaws.com \
+            --thumbprint-list 6938fd4d98bab03faadb97b34396831e3780aea1 \
+            > /dev/null
+        print_success "Created"
+    fi
+}
+
+step_create_actions_role() {
+    print_section "GitHub Actions IAM role"
+
+    local trust_policy
+    trust_policy=$(cat << EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "${OIDC_ARN}"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+        },
+        "StringLike": {
+          "token.actions.githubusercontent.com:sub": "repo:${REPO}:*"
+        }
+      }
+    }
+  ]
+}
+EOF
+    )
+
+    local permissions_policy
+    permissions_policy=$(cat << EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "EC2Management",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:RunInstances",
+        "ec2:TerminateInstances",
+        "ec2:DescribeInstances",
+        "ec2:DescribeInstanceStatus",
+        "ec2:CreateTags"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestedRegion": "${REGION}"
+        }
+      }
+    },
+    {
+      "Sid": "PassRoleToEC2",
+      "Effect": "Allow",
+      "Action": "iam:PassRole",
+      "Resource": "arn:aws:iam::${ACCOUNT_ID}:role/${INSTANCE_PROFILE_ROLE_NAME}",
+      "Condition": {
+        "StringEquals": {
+          "iam:PassedToService": "ec2.amazonaws.com"
+        }
+      }
+    }
+  ]
+}
+EOF
+    )
+
+    print_step "Checking role... "
+    if aws iam get-role --role-name "$GH_ACTIONS_ROLE_NAME" &>/dev/null; then
+        print_success "Exists, updating trust policy"
+        aws iam update-assume-role-policy \
+            --role-name "$GH_ACTIONS_ROLE_NAME" \
+            --policy-document "$trust_policy"
+    else
+        aws iam create-role \
+            --role-name "$GH_ACTIONS_ROLE_NAME" \
+            --assume-role-policy-document "$trust_policy" \
+            > /dev/null
+        print_success "Created"
+    fi
+
+    aws iam put-role-policy \
+        --role-name "$GH_ACTIONS_ROLE_NAME" \
+        --policy-name "EC2Management" \
+        --policy-document "$permissions_policy"
+    print_info "Permissions attached"
+}
+
+step_create_instance_profile() {
+    print_section "EC2 instance profile"
+
+    local instance_role_policy
+    instance_role_policy=$(cat << EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "SelfTerminate",
+      "Effect": "Allow",
+      "Action": "ec2:TerminateInstances",
+      "Resource": "arn:aws:ec2:${REGION}:${ACCOUNT_ID}:instance/*",
+      "Condition": {
+        "StringEquals": {
+          "aws:ResourceTag/Purpose": "boxlite-e2e"
+        }
+      }
+    }
+  ]
+}
+EOF
+    )
+
+    local instance_trust_policy
+    instance_trust_policy=$(cat << EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": { "Service": "ec2.amazonaws.com" },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+    )
+
+    print_step "Checking instance role... "
+    if aws iam get-role --role-name "$INSTANCE_PROFILE_ROLE_NAME" &>/dev/null; then
+        print_success "Exists"
+    else
+        aws iam create-role \
+            --role-name "$INSTANCE_PROFILE_ROLE_NAME" \
+            --assume-role-policy-document "$instance_trust_policy" \
+            > /dev/null
+        print_success "Created"
+    fi
+
+    aws iam put-role-policy \
+        --role-name "$INSTANCE_PROFILE_ROLE_NAME" \
+        --policy-name "SelfTerminate" \
+        --policy-document "$instance_role_policy"
+
+    print_step "Checking instance profile... "
+    if aws iam get-instance-profile --instance-profile-name "$INSTANCE_PROFILE_NAME" &>/dev/null; then
+        print_success "Exists"
+    else
+        aws iam create-instance-profile --instance-profile-name "$INSTANCE_PROFILE_NAME" > /dev/null
+        aws iam add-role-to-instance-profile \
+            --instance-profile-name "$INSTANCE_PROFILE_NAME" \
+            --role-name "$INSTANCE_PROFILE_ROLE_NAME"
+        print_success "Created"
+    fi
+}
+
+step_create_security_group() {
+    print_section "Security group"
+
+    print_step "Checking security group... "
+    SG_ID=$(aws ec2 describe-security-groups \
+        --filters "Name=group-name,Values=${SECURITY_GROUP_NAME}" "Name=vpc-id,Values=${VPC_ID}" \
+        --query "SecurityGroups[0].GroupId" --output text --region "$REGION" 2>/dev/null || echo "None")
+
+    if [ "$SG_ID" != "None" ] && [ -n "$SG_ID" ]; then
+        print_success "Exists ($SG_ID)"
+    else
+        SG_ID=$(aws ec2 create-security-group \
+            --group-name "$SECURITY_GROUP_NAME" \
+            --description "BoxLite E2E runner - outbound HTTPS only" \
+            --vpc-id "$VPC_ID" \
+            --region "$REGION" \
+            --query "GroupId" --output text)
+
+        aws ec2 authorize-security-group-egress \
+            --group-id "$SG_ID" --region "$REGION" \
+            --protocol tcp --port 443 --cidr 0.0.0.0/0 2>/dev/null || true
+        aws ec2 authorize-security-group-egress \
+            --group-id "$SG_ID" --region "$REGION" \
+            --protocol tcp --port 80 --cidr 0.0.0.0/0 2>/dev/null || true
+
+        print_success "Created ($SG_ID)"
+    fi
+}
+
+step_configure_github() {
+    if [ "$SKIP_GITHUB" = true ]; then
+        print_info "GitHub configuration skipped (--skip-github)"
+        return 0
+    fi
+
+    print_section "GitHub repository variables"
+
+    gh variable set AWS_ACCOUNT_ID --body "$ACCOUNT_ID" -R "$REPO"
+    print_info "AWS_ACCOUNT_ID = $ACCOUNT_ID"
+
+    gh variable set AWS_SUBNET_ID --body "$SUBNET_ID" -R "$REPO"
+    print_info "AWS_SUBNET_ID = $SUBNET_ID"
+
+    gh variable set AWS_SECURITY_GROUP_ID --body "$SG_ID" -R "$REPO"
+    print_info "AWS_SECURITY_GROUP_ID = $SG_ID"
+
+    print_section "GitHub repository secret (GH_PAT)"
+
+    if gh secret list -R "$REPO" | grep -q "^GH_PAT"; then
+        print_info "GH_PAT already exists, skipping"
+    else
+        # Get repo ID for pre-filled token creation URL
+        local repo_id
+        repo_id=$(gh repo view "$REPO" --json databaseId -q .databaseId 2>/dev/null || echo "")
+
+        print_info "A fine-grained PAT is needed for runner registration."
+        print_info "Required permission: Administration → Read and write"
+        print_info "Scope: this repository only"
+        echo ""
+
+        if [ -n "$repo_id" ]; then
+            local token_url="https://github.com/settings/personal-access-tokens/new?scoped_to=${repo_id}"
+            print_info "Create one here (permission pre-filled is not supported, select manually):"
+            echo "  ${token_url}"
+        else
+            print_info "Create one at: https://github.com/settings/personal-access-tokens/new"
+        fi
+
+        echo ""
+        print_info "Steps: 1) Open link above"
+        print_info "       2) Set token name: boxlite-e2e-runner"
+        print_info "       3) Repository access → Only select repositories → ${REPO}"
+        print_info "       4) Permissions → Repository → Administration → Read and write"
+        print_info "       5) Generate token, copy it"
+        echo ""
+        read -rsp "  Paste your GitHub PAT (input hidden): " GH_PAT_VALUE
+        echo ""
+        if [ -n "$GH_PAT_VALUE" ]; then
+            echo "$GH_PAT_VALUE" | gh secret set GH_PAT -R "$REPO"
+            print_success "GH_PAT set"
+        else
+            print_warning "Skipped (empty input). Set manually: gh secret set GH_PAT"
+        fi
+    fi
+}
+
+# ============================================================================
+# Entry point
+# ============================================================================
+
+main() {
+    require_command aws "Install: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html"
+    require_command gh "Install: https://cli.github.com"
+    require_command jq "Install: https://jqlang.github.io/jq/download"
+
+    parse_args "$@"
+
+    print_header "E2E CI Runner Setup"
+
+    step_detect_config
+    step_create_oidc_provider
+    step_create_actions_role
+    step_create_instance_profile
+    step_create_security_group
+    step_configure_github
+
+    print_header "Setup Complete"
+    print_info "OIDC Provider: $OIDC_ARN"
+    print_info "Actions Role:  arn:aws:iam::${ACCOUNT_ID}:role/${GH_ACTIONS_ROLE_NAME}"
+    print_info "Instance Profile: $INSTANCE_PROFILE_NAME"
+    print_info "Security Group: $SG_ID"
+    echo ""
+    print_success "Run: gh workflow run e2e-test.yml"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- Adds `e2e-test.yml` workflow that provisions an ephemeral AWS EC2 c8i.2xlarge instance per job to run VM-requiring integration tests
- Uses GitHub OIDC → AWS STS authentication (no stored AWS credentials)
- Includes `scripts/ci/setup-ci-runner.sh` for one-command infrastructure provisioning (AWS + GitHub)

## Architecture
```
start-runner (ubuntu-latest) → e2e-tests (self-hosted EC2) → stop-runner (ubuntu-latest)
```

## Safety
- `--ephemeral` runner auto-deregisters after one job
- `if: always()` ensures cleanup on failure/cancellation
- 45-min self-destruct timer on instance (IAM-based)
- `instance-initiated-shutdown-behavior: terminate`
- 35-min job timeout

## Cost
~$0.09-0.14 per run (~$0.34/hr for c8i.2xlarge, 15-25 min typical)

## Test plan
- [ ] Run `./scripts/ci/setup-ci-runner.sh` to provision AWS infra
- [ ] Trigger workflow manually via Actions tab
- [ ] Verify EC2 instance creates, tests run, instance terminates
- [ ] Verify no orphaned instances: `aws ec2 describe-instances --filters "Name=tag:Purpose,Values=boxlite-e2e"`