### PR TITLE
ci(e2e): fix app verification, use c8i.xlarge for vCPU quota

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -46,7 +46,7 @@ concurrency:
 env:
   AWS_REGION: us-east-1
   AWS_ROLE_ARN: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/boxlite-e2e-github-actions
-  EC2_INSTANCE_TYPE: c8i.2xlarge
+  EC2_INSTANCE_TYPE: c8i.xlarge
   EC2_AMI_ID: ami-0a0e5d9c7acc336f1  # Ubuntu 24.04 LTS x86_64 (us-east-1)
   EC2_SUBNET_ID: ${{ vars.AWS_SUBNET_ID }}
   EC2_SECURITY_GROUP_ID: ${{ vars.AWS_SECURITY_GROUP_ID }}

--- a/scripts/ci/setup-ci-runner.sh
+++ b/scripts/ci/setup-ci-runner.sh
@@ -400,9 +400,26 @@ step_configure_github() {
 
     print_section "GitHub App (runner registration)"
 
+    local owner="${REPO%%/*}"
+
+    # If credentials exist, verify the app is actually installed and working
     if gh secret list -R "$REPO" | grep -q "^GH_APP_PRIVATE_KEY"; then
-        print_info "GH_APP_PRIVATE_KEY already exists, skipping"
-        return 0
+        print_step "Verifying existing app... "
+        local app_id_val
+        app_id_val=$(gh variable get GH_APP_ID -R "$REPO" 2>/dev/null || echo "")
+        if [ -n "$app_id_val" ]; then
+            # Check if the app has an active installation on this repo
+            local install_check
+            install_check=$(gh api "/repos/${REPO}/installation" 2>/dev/null | jq -r '.app_id // empty' 2>/dev/null || echo "")
+            if [ "$install_check" = "$app_id_val" ]; then
+                print_success "App installed and working (ID: $app_id_val)"
+                return 0
+            fi
+        fi
+        print_error "App credentials exist but app is not installed on ${REPO}"
+        print_info "Cleaning up stale credentials and recreating..."
+        gh secret delete GH_APP_PRIVATE_KEY -R "$REPO" 2>/dev/null || true
+        gh variable delete GH_APP_ID -R "$REPO" 2>/dev/null || true
     fi
 
     print_info "Creating GitHub App via manifest flow..."
@@ -411,7 +428,6 @@ step_configure_github() {
 
     local callback_port=9876
     local callback_url="http://localhost:${callback_port}"
-    local owner="${REPO%%/*}"
 
     # Build the manifest JSON
     # hook_attributes.url is required by the API even if unused


### PR DESCRIPTION
## Summary
- Verify GitHub App is actually installed before skipping setup (auto-cleanup stale credentials)
- Downgrade to c8i.xlarge (4 vCPU) to fit within default 16 vCPU quota

## Context
Previous runs failed because:
1. App existed but wasn't installed on the repo → "Integration not found"
2. c8i.2xlarge (8 vCPU) exceeded account vCPU limit

## Test plan
- [ ] Trigger `gh workflow run e2e-test.yml` after merge
- [ ] Verify EC2 launches successfully