### PR TITLE
ci(e2e): fix runner version (deprecated) and update to Ubuntu 24.04

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -184,7 +184,7 @@ jobs:
           sed -i "s|__SELF_DESTRUCT__|${{ env.SELF_DESTRUCT_SECONDS }}|g" /tmp/user-data.sh
           sed -i "s|__REGION__|${{ env.AWS_REGION }}|g" /tmp/user-data.sh
 
-          # Launch instance
+          # Launch instance (NestedVirtualization=enabled required for /dev/kvm on c8i)
           RESPONSE=$(aws ec2 run-instances \
             --instance-type "${{ env.EC2_INSTANCE_TYPE }}" \
             --image-id "${{ env.EC2_AMI_ID }}" \
@@ -192,6 +192,7 @@ jobs:
             --security-group-ids "${{ env.EC2_SECURITY_GROUP_ID }}" \
             --iam-instance-profile Name=boxlite-e2e-runner \
             --user-data file:///tmp/user-data.sh \
+            --cpu-options "NestedVirtualization=enabled" \
             --block-device-mappings '[{"DeviceName":"/dev/sda1","Ebs":{"VolumeSize":50,"VolumeType":"gp3","DeleteOnTermination":true}}]' \
             --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=${LABEL}},{Key=Purpose,Value=boxlite-e2e},{Key=GitHubRunId,Value=${{ github.run_id }}}]" \
             --instance-initiated-shutdown-behavior terminate \

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -135,11 +135,11 @@ jobs:
           LABEL="boxlite-e2e-${{ github.run_id }}-${{ github.run_attempt }}"
 
           # Build user-data script
-          cat > /tmp/user-data.sh << 'USERDATA'
+          # Use sed to strip 10 leading spaces (heredoc inside YAML must be indented)
+          sed 's/^          //' > /tmp/user-data.sh << 'USERDATA'
           #!/bin/bash
           set -euo pipefail
 
-          # === Configuration ===
           GITHUB_REPOSITORY="__REPO__"
           RUNNER_TOKEN="__TOKEN__"
           RUNNER_NAME="__LABEL__"
@@ -148,7 +148,7 @@ jobs:
           SELF_DESTRUCT_SECONDS="__SELF_DESTRUCT__"
           AWS_REGION="__REGION__"
 
-          # === Self-Destruct Timer ===
+          # Self-destruct timer
           (
             sleep ${SELF_DESTRUCT_SECONDS}
             TOKEN=$(curl -sf -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 60")
@@ -156,15 +156,16 @@ jobs:
             aws ec2 terminate-instances --instance-ids "$INSTANCE_ID" --region "${AWS_REGION}" || true
           ) &
 
-          # === Enable KVM ===
+          # Enable KVM
           modprobe kvm_intel 2>/dev/null || modprobe kvm_amd 2>/dev/null || true
           if [ ! -c /dev/kvm ]; then
             echo "FATAL: /dev/kvm not found after modprobe"
             exit 1
           fi
           chmod 666 /dev/kvm
+          usermod -aG kvm root 2>/dev/null || true
 
-          # === Install GitHub Actions Runner ===
+          # Install GitHub Actions Runner
           mkdir -p /opt/actions-runner && cd /opt/actions-runner
           curl -fsSL "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz" | tar xz
           RUNNER_ALLOW_RUNASROOT=1 ./config.sh \

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -46,7 +46,7 @@ concurrency:
 env:
   AWS_REGION: us-east-1
   AWS_ROLE_ARN: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/boxlite-e2e-github-actions
-  EC2_INSTANCE_TYPE: c8i.2xlarge
+  EC2_INSTANCE_TYPE: c8i.xlarge
   EC2_AMI_ID: ami-0a0e5d9c7acc336f1  # Ubuntu 24.04 LTS x86_64 (us-east-1)
   EC2_SUBNET_ID: ${{ vars.AWS_SUBNET_ID }}
   EC2_SECURITY_GROUP_ID: ${{ vars.AWS_SECURITY_GROUP_ID }}

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -47,10 +47,10 @@ env:
   AWS_REGION: us-east-1
   AWS_ROLE_ARN: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/boxlite-e2e-github-actions
   EC2_INSTANCE_TYPE: c8i.xlarge
-  EC2_AMI_ID: ami-0a0e5d9c7acc336f1  # Ubuntu 24.04 LTS x86_64 (us-east-1)
+  EC2_AMI_ID: ami-05cf1e9f73fbad2e2  # Ubuntu 24.04 LTS x86_64 (us-east-1, 2026-04-24)
   EC2_SUBNET_ID: ${{ vars.AWS_SUBNET_ID }}
   EC2_SECURITY_GROUP_ID: ${{ vars.AWS_SECURITY_GROUP_ID }}
-  RUNNER_VERSION: '2.322.0'
+  RUNNER_VERSION: '2.334.0'
   MAX_RUNNER_WAIT_SECONDS: '300'
   SELF_DESTRUCT_SECONDS: '2700'
 

--- a/scripts/ci/setup-ci-runner.sh
+++ b/scripts/ci/setup-ci-runner.sh
@@ -400,9 +400,26 @@ step_configure_github() {
 
     print_section "GitHub App (runner registration)"
 
+    local owner="${REPO%%/*}"
+
+    # If credentials exist, verify the app is actually installed and working
     if gh secret list -R "$REPO" | grep -q "^GH_APP_PRIVATE_KEY"; then
-        print_info "GH_APP_PRIVATE_KEY already exists, skipping"
-        return 0
+        print_step "Verifying existing app... "
+        local app_id_val
+        app_id_val=$(gh variable get GH_APP_ID -R "$REPO" 2>/dev/null || echo "")
+        if [ -n "$app_id_val" ]; then
+            # Check if the app has an active installation on this repo
+            local install_check
+            install_check=$(gh api "/repos/${REPO}/installation" 2>/dev/null | jq -r '.app_id // empty' 2>/dev/null || echo "")
+            if [ "$install_check" = "$app_id_val" ]; then
+                print_success "App installed and working (ID: $app_id_val)"
+                return 0
+            fi
+        fi
+        print_error "App credentials exist but app is not installed on ${REPO}"
+        print_info "Cleaning up stale credentials and recreating..."
+        gh secret delete GH_APP_PRIVATE_KEY -R "$REPO" 2>/dev/null || true
+        gh variable delete GH_APP_ID -R "$REPO" 2>/dev/null || true
     fi
 
     print_info "Creating GitHub App via manifest flow..."
@@ -411,7 +428,6 @@ step_configure_github() {
 
     local callback_port=9876
     local callback_url="http://localhost:${callback_port}"
-    local owner="${REPO%%/*}"
 
     # Build the manifest JSON
     # hook_attributes.url is required by the API even if unused


### PR DESCRIPTION
Root cause found from console output: runner v2.322.0 registered successfully but GitHub rejected it as deprecated. Updated to v2.334.0. Also switched AMI to Ubuntu 24.04 (noble).