### PR TITLE
docs: install requests in Python CodeBox quickstart

### DIFF
--- a/docs/getting-started/quickstart-python.md
+++ b/docs/getting-started/quickstart-python.md
@@ -69,6 +69,7 @@ print(response.text)
 """
 
     async with boxlite.CodeBox() as codebox:
+        await codebox.install_package("requests")
         result = await codebox.run(code)
         print(result)
 
@@ -83,10 +84,13 @@ python codebox.py
 ```
 
 **What's happening:**
-1. CodeBox automatically installs required packages (requests)
+1. The example installs the `requests` dependency inside the CodeBox
 2. Executes the code in complete isolation
 3. Returns the output
 4. Your host system remains completely safe
+
+When running code that imports third-party packages, install them inside the
+CodeBox first so the example behaves the same in clean images and reused boxes.
 
 ## Running Examples
 


### PR DESCRIPTION
## Summary
- Install equests explicitly in the Python CodeBox quickstart before running code that imports it
- Replace the misleading note that CodeBox automatically installs required packages
- Add a short note that third-party imports should be installed inside the CodeBox first

## Why
This fixes the first-run confusion described in #439: in a clean environment, the quickstart code imports equests without installing it, while CodeBox.run() only prints stdout. New users can see an empty result and assume the SDK is broken.

## Checks
- git diff --check

Docs-only change; no runtime tests were needed.

Fixes #439