### PR TITLE
fix: recover detached boxes after stdin shim config

### DIFF
--- a/src/boxlite/src/litebox/box_impl.rs
+++ b/src/boxlite/src/litebox/box_impl.rs
@@ -359,6 +359,28 @@ impl BoxImpl {
             if let Ok(mut handler) = live.handler.lock() {
                 handler.stop()?;
             }
+        } else {
+            let (status, pid) = {
+                let state = self.state.read();
+                (state.status, state.pid)
+            };
+
+            if let Some(pid) = pid
+                && !matches!(status, BoxStatus::Configured | BoxStatus::Stopped)
+            {
+                tracing::warn!(
+                    box_id = %self.config.id,
+                    pid = pid,
+                    status = ?status,
+                    "Stopping recovered box process without live state"
+                );
+                if !crate::util::kill_process(pid) {
+                    return Err(BoxliteError::InvalidState(format!(
+                        "failed to kill box process {}",
+                        pid
+                    )));
+                }
+            }
         }
 
         // Clean up PID file (single source of truth)
@@ -622,6 +644,16 @@ impl BoxImpl {
 
         let state = self.state.read().clone();
         let is_first_start = state.status == BoxStatus::Configured;
+
+        if !matches!(
+            state.status,
+            BoxStatus::Configured | BoxStatus::Stopped | BoxStatus::Running
+        ) {
+            return Err(BoxliteError::InvalidState(format!(
+                "Cannot initialize box {} in {} state",
+                self.config.id, state.status
+            )));
+        }
 
         // Retrieve the lock (allocated in create())
         let lock_id = state.lock_id.ok_or_else(|| {

--- a/src/boxlite/src/runtime/rt_impl.rs
+++ b/src/boxlite/src/runtime/rt_impl.rs
@@ -780,11 +780,11 @@ impl RuntimeImpl {
         if let Some((config, state)) = self.box_manager.box_by_id(id)? {
             // Box exists in database - handle as before
             let mut state = state;
-            if state.status.is_active() {
+            if state.status.is_active() || state.pid.is_some() {
                 if force {
                     // Force mode: kill the process directly
                     if let Some(pid) = state.pid {
-                        tracing::info!(box_id = %id, pid = pid, "Force killing active box");
+                        tracing::info!(box_id = %id, pid = pid, "Force killing box process");
                         crate::util::kill_process(pid);
                     }
                     // Update status to stopped and save
@@ -794,8 +794,8 @@ impl RuntimeImpl {
                 } else {
                     // Non-force mode: error on active box
                     return Err(BoxliteError::InvalidState(format!(
-                        "cannot remove active box {} (status: {:?}). Use force=true to stop first",
-                        id, state.status
+                        "cannot remove box {} with live pid {:?} (status: {:?}). Use force=true to stop first",
+                        id, state.pid, state.status
                     )));
                 }
             }
@@ -1164,6 +1164,7 @@ impl RuntimeImpl {
         for (config, mut state) in persisted {
             let box_id = &config.id;
             let original_status = state.status;
+            let original_pid = state.pid;
 
             // Reclaim the lock for this box if one was allocated
             if let Some(lock_id) = state.lock_id {
@@ -1211,13 +1212,14 @@ impl RuntimeImpl {
                         }
                         (true, ProcessIdentity::Unverified) => {
                             // Older detached shims may predate BOXLITE_BOX_ID. Preserve
-                            // the PID file and avoid deleting a live VM we cannot prove.
+                            // the PID file and recover them as Running so lifecycle ops
+                            // keep treating the live VM as active.
                             state.set_pid(Some(pid));
-                            state.set_status(BoxStatus::Unknown);
+                            state.set_status(BoxStatus::Running);
                             tracing::warn!(
                                 box_id = %box_id,
                                 pid = pid,
-                                "Box shim is live but unverified, marking as Unknown"
+                                "Recovered legacy running box from unmarked shim PID file"
                             );
                         }
                         _ => {
@@ -1255,7 +1257,7 @@ impl RuntimeImpl {
             }
 
             // Save updated state to database if changed
-            if state.status != original_status {
+            if state.status != original_status || state.pid != original_pid {
                 self.box_manager.save_box(box_id, &state)?;
             }
         }
@@ -2098,7 +2100,7 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     #[test]
-    fn test_recovery_marks_unverified_live_shim_unknown() {
+    fn test_recovery_marks_unverified_live_shim_running() {
         use std::os::unix::process::CommandExt;
 
         let (runtime, _dir) = create_test_runtime();
@@ -2126,7 +2128,7 @@ mod tests {
         runtime.recover_boxes().expect("Failed to recover boxes");
 
         let (_, db_state) = runtime.box_manager.box_by_id(&config.id).unwrap().unwrap();
-        assert_eq!(db_state.status, BoxStatus::Unknown);
+        assert_eq!(db_state.status, BoxStatus::Running);
         assert_eq!(db_state.pid, Some(pid));
         assert!(
             pid_file.exists(),
@@ -2135,6 +2137,125 @@ mod tests {
 
         child.kill().ok();
         child.wait().ok();
+    }
+
+    #[test]
+    fn test_remove_box_refuses_live_pid_without_force_even_unknown() {
+        let (runtime, _dir) = create_test_runtime();
+
+        let (pid, mut child) = spawn_dummy_process();
+        let config = test_box_config_in_layout(false, &runtime);
+        let mut state = BoxState::new();
+        state.set_status(BoxStatus::Unknown);
+        state.set_pid(Some(pid));
+        let lock_id = runtime.lock_manager.allocate().expect("Failed to allocate lock");
+        state.set_lock_id(lock_id);
+
+        runtime
+            .box_manager
+            .add_box(&config, &state)
+            .expect("Failed to add box");
+
+        let result = runtime.remove_box(&config.id, false);
+        assert!(result.is_err());
+        assert!(
+            crate::util::is_process_alive(pid),
+            "Non-force remove must not orphan or kill the live process"
+        );
+        assert!(
+            runtime.box_manager.box_by_id(&config.id).unwrap().is_some(),
+            "Box should remain in DB after rejected remove"
+        );
+
+        runtime
+            .remove_box(&config.id, true)
+            .expect("Force remove should kill process and remove box");
+        std::thread::sleep(std::time::Duration::from_millis(200));
+        assert!(
+            !crate::util::is_process_alive(pid),
+            "Force remove should kill the live process"
+        );
+        assert!(runtime.box_manager.box_by_id(&config.id).unwrap().is_none());
+
+        child.wait().ok();
+    }
+
+    #[tokio::test]
+    async fn test_stop_kills_recovered_pid_without_live_state() {
+        let (runtime, _dir) = create_test_runtime();
+
+        let (pid, mut child) = spawn_dummy_process();
+        let config = test_box_config_in_layout(false, &runtime);
+        let mut state = running_state(pid);
+        let lock_id = runtime.lock_manager.allocate().expect("Failed to allocate lock");
+        state.set_lock_id(lock_id);
+
+        let box_dir = runtime.layout.boxes_dir().join(config.id.as_str());
+        std::fs::create_dir_all(&box_dir).expect("Failed to create box directory");
+        let pid_file = box_dir.join("shim.pid");
+        std::fs::write(&pid_file, pid.to_string()).expect("Failed to write PID file");
+
+        runtime
+            .box_manager
+            .add_box(&config, &state)
+            .expect("Failed to add box");
+
+        let litebox = runtime
+            .get(config.id.as_str())
+            .await
+            .expect("Failed to get box")
+            .expect("Box should exist");
+
+        litebox.stop().await.expect("Stop should succeed");
+
+        std::thread::sleep(std::time::Duration::from_millis(200));
+        assert!(
+            !crate::util::is_process_alive(pid),
+            "Stop should kill recovered process when no LiveState is cached"
+        );
+        assert!(!pid_file.exists(), "PID file should be removed on stop");
+
+        let (_, db_state) = runtime.box_manager.box_by_id(&config.id).unwrap().unwrap();
+        assert_eq!(db_state.status, BoxStatus::Stopped);
+        assert!(db_state.pid.is_none());
+
+        child.wait().ok();
+    }
+
+    #[tokio::test]
+    async fn test_exec_unknown_state_returns_error_without_panic() {
+        use crate::litebox::BoxCommand;
+
+        let (runtime, _dir) = create_test_runtime();
+
+        let config = test_box_config_in_layout(false, &runtime);
+        let mut state = BoxState::new();
+        state.set_status(BoxStatus::Unknown);
+        let lock_id = runtime.lock_manager.allocate().expect("Failed to allocate lock");
+        state.set_lock_id(lock_id);
+
+        runtime
+            .box_manager
+            .add_box(&config, &state)
+            .expect("Failed to add box");
+
+        let litebox = runtime
+            .get(config.id.as_str())
+            .await
+            .expect("Failed to get box")
+            .expect("Box should exist");
+
+        let result = litebox.exec(BoxCommand::new("true")).await;
+        match result {
+            Err(BoxliteError::InvalidState(msg)) => {
+                assert!(
+                    msg.contains("Cannot initialize box"),
+                    "Expected initialization state error, got: {msg}"
+                );
+            }
+            Err(other) => panic!("Expected InvalidState error, got: {other}"),
+            Ok(_) => panic!("Expected InvalidState error, got success"),
+        }
     }
 
     // ====================================================================

--- a/src/boxlite/src/runtime/rt_impl.rs
+++ b/src/boxlite/src/runtime/rt_impl.rs
@@ -2148,7 +2148,10 @@ mod tests {
         let mut state = BoxState::new();
         state.set_status(BoxStatus::Unknown);
         state.set_pid(Some(pid));
-        let lock_id = runtime.lock_manager.allocate().expect("Failed to allocate lock");
+        let lock_id = runtime
+            .lock_manager
+            .allocate()
+            .expect("Failed to allocate lock");
         state.set_lock_id(lock_id);
 
         runtime
@@ -2187,7 +2190,10 @@ mod tests {
         let (pid, mut child) = spawn_dummy_process();
         let config = test_box_config_in_layout(false, &runtime);
         let mut state = running_state(pid);
-        let lock_id = runtime.lock_manager.allocate().expect("Failed to allocate lock");
+        let lock_id = runtime
+            .lock_manager
+            .allocate()
+            .expect("Failed to allocate lock");
         state.set_lock_id(lock_id);
 
         let box_dir = runtime.layout.boxes_dir().join(config.id.as_str());
@@ -2231,7 +2237,10 @@ mod tests {
         let config = test_box_config_in_layout(false, &runtime);
         let mut state = BoxState::new();
         state.set_status(BoxStatus::Unknown);
-        let lock_id = runtime.lock_manager.allocate().expect("Failed to allocate lock");
+        let lock_id = runtime
+            .lock_manager
+            .allocate()
+            .expect("Failed to allocate lock");
         state.set_lock_id(lock_id);
 
         runtime

--- a/src/boxlite/src/runtime/rt_impl.rs
+++ b/src/boxlite/src/runtime/rt_impl.rs
@@ -1055,7 +1055,7 @@ impl RuntimeImpl {
 
     /// Recover boxes from persistent storage on runtime startup.
     fn recover_boxes(&self) -> BoxliteResult<()> {
-        use crate::util::{is_process_alive, is_same_process};
+        use crate::util::{is_process_alive, process_identity, ProcessIdentity};
 
         // Check for system reboot and reset active boxes
         self.box_manager.check_and_handle_reboot()?;
@@ -1195,8 +1195,11 @@ impl RuntimeImpl {
 
             if pid_file.exists() {
                 match crate::util::read_pid_file(&pid_file) {
-                    Ok(pid) => {
-                        if is_process_alive(pid) && is_same_process(pid, box_id.as_str()) {
+                    Ok(pid) => match (
+                        is_process_alive(pid),
+                        process_identity(pid, box_id.as_str()),
+                    ) {
+                        (true, ProcessIdentity::Matches) => {
                             // Process is alive and it's our boxlite-shim - box stays Running
                             state.set_pid(Some(pid));
                             state.set_status(BoxStatus::Running);
@@ -1205,7 +1208,19 @@ impl RuntimeImpl {
                                 pid = pid,
                                 "Recovered running box from PID file"
                             );
-                        } else {
+                        }
+                        (true, ProcessIdentity::Unverified) => {
+                            // Older detached shims may predate BOXLITE_BOX_ID. Preserve
+                            // the PID file and avoid deleting a live VM we cannot prove.
+                            state.set_pid(Some(pid));
+                            state.set_status(BoxStatus::Unknown);
+                            tracing::warn!(
+                                box_id = %box_id,
+                                pid = pid,
+                                "Box shim is live but unverified, marking as Unknown"
+                            );
+                        }
+                        _ => {
                             // Process died or PID was reused - clean up and mark as Stopped
                             let _ = std::fs::remove_file(&pid_file);
                             state.mark_stop();
@@ -1215,7 +1230,7 @@ impl RuntimeImpl {
                                 "Box process dead, cleaned up stale PID file"
                             );
                         }
-                    }
+                    },
                     Err(e) => {
                         // Can't read PID file - clean up and mark as Stopped
                         let _ = std::fs::remove_file(&pid_file);
@@ -2076,6 +2091,47 @@ mod tests {
         let (_, db_state) = runtime.box_manager.box_by_id(&config.id).unwrap().unwrap();
         assert_eq!(db_state.status, BoxStatus::Stopped);
         assert!(db_state.pid.is_none());
+
+        child.kill().ok();
+        child.wait().ok();
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_recovery_marks_unverified_live_shim_unknown() {
+        use std::os::unix::process::CommandExt;
+
+        let (runtime, _dir) = create_test_runtime();
+
+        let mut child = std::process::Command::new("sleep")
+            .arg0("boxlite-shim")
+            .arg("300")
+            .spawn()
+            .expect("Failed to spawn legacy shim process");
+        let pid = child.id();
+
+        let config = test_box_config_in_layout(false, &runtime);
+        let state = running_state(pid);
+
+        let box_dir = runtime.layout.boxes_dir().join(config.id.as_str());
+        std::fs::create_dir_all(&box_dir).expect("Failed to create box directory");
+        let pid_file = box_dir.join("shim.pid");
+        std::fs::write(&pid_file, pid.to_string()).expect("Failed to write PID file");
+
+        runtime
+            .box_manager
+            .add_box(&config, &state)
+            .expect("Failed to add box");
+
+        runtime.recover_boxes().expect("Failed to recover boxes");
+
+        let (_, db_state) = runtime.box_manager.box_by_id(&config.id).unwrap().unwrap();
+        assert_eq!(db_state.status, BoxStatus::Unknown);
+        assert_eq!(db_state.pid, Some(pid));
+        assert!(
+            pid_file.exists(),
+            "Unverified live shim PID file should be preserved"
+        );
 
         child.kill().ok();
         child.wait().ok();

--- a/src/boxlite/src/runtime/rt_impl.rs
+++ b/src/boxlite/src/runtime/rt_impl.rs
@@ -1055,7 +1055,7 @@ impl RuntimeImpl {
 
     /// Recover boxes from persistent storage on runtime startup.
     fn recover_boxes(&self) -> BoxliteResult<()> {
-        use crate::util::{is_process_alive, process_identity, ProcessIdentity};
+        use crate::util::{ProcessIdentity, is_process_alive, process_identity};
 
         // Check for system reboot and reset active boxes
         self.box_manager.check_and_handle_reboot()?;

--- a/src/boxlite/src/util/mod.rs
+++ b/src/boxlite/src/util/mod.rs
@@ -13,7 +13,8 @@ use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{EnvFilter, fmt};
 
 pub use process::{
-    ProcessExit, ProcessMonitor, is_process_alive, is_same_process, kill_process, read_pid_file,
+    ProcessExit, ProcessIdentity, ProcessMonitor, is_process_alive, is_same_process, kill_process,
+    process_identity, read_pid_file,
 };
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]

--- a/src/boxlite/src/util/process.rs
+++ b/src/boxlite/src/util/process.rs
@@ -27,6 +27,17 @@ pub enum ProcessExit {
     Unknown,
 }
 
+/// Result of validating whether a live PID belongs to a specific box.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProcessIdentity {
+    /// The process is a boxlite shim for the requested box.
+    Matches,
+    /// The PID is missing, reused, or belongs to another box/process.
+    Mismatch,
+    /// The process looks like a live shim, but lacks a box marker.
+    Unverified,
+}
+
 /// Monitors a process for exit, handling both owned and attached cases.
 ///
 /// # Unix Parent/Child Constraint
@@ -261,50 +272,88 @@ fn is_process_zombie_macos(pid: u32) -> bool {
 /// * `true` - PID is our boxlite-shim process
 /// * `false` - PID is different process or doesn't exist
 pub fn is_same_process(pid: u32, box_id: &str) -> bool {
+    process_identity(pid, box_id) == ProcessIdentity::Matches
+}
+
+/// Verify whether a PID belongs to a boxlite-shim process for the given box.
+pub fn process_identity(pid: u32, box_id: &str) -> ProcessIdentity {
     #[cfg(target_os = "linux")]
     {
-        is_same_process_linux(pid, box_id)
+        process_identity_linux(pid, box_id)
     }
 
     #[cfg(target_os = "macos")]
     {
         let _ = box_id; // Unused on macOS
-        is_same_process_macos(pid)
+        if is_same_process_macos(pid) {
+            ProcessIdentity::Matches
+        } else {
+            ProcessIdentity::Mismatch
+        }
     }
 
     #[cfg(not(any(target_os = "linux", target_os = "macos")))]
     {
         // Fallback: just check if process exists
         // Not ideal but better than nothing
-        is_process_alive(pid)
+        if is_process_alive(pid) {
+            ProcessIdentity::Matches
+        } else {
+            ProcessIdentity::Mismatch
+        }
     }
 }
 
 #[cfg(target_os = "linux")]
-fn is_same_process_linux(pid: u32, box_id: &str) -> bool {
+fn process_identity_linux(pid: u32, box_id: &str) -> ProcessIdentity {
     use std::fs;
 
     let cmdline_path = format!("/proc/{}/cmdline", pid);
     let environ_path = format!("/proc/{}/environ", pid);
 
-    let Ok(cmdline) = fs::read_to_string(&cmdline_path) else {
-        return false;
+    let Ok(cmdline) = fs::read(&cmdline_path) else {
+        return ProcessIdentity::Mismatch;
     };
 
     // cmdline is null-separated, split by \0 for proper parsing.
     // The box id is intentionally not passed as an argument anymore because
     // the full InstanceSpec is sent over stdin to keep secrets out of procfs.
-    let is_shim = cmdline.split('\0').any(|arg| arg.contains("boxlite-shim"));
+    let is_shim = cmdline
+        .split(|byte| *byte == 0)
+        .any(|arg| contains_bytes(arg, b"boxlite-shim"));
 
     if !is_shim {
-        return false;
+        return ProcessIdentity::Mismatch;
     }
 
-    let expected_env = format!("BOXLITE_BOX_ID={box_id}");
-    match fs::read_to_string(&environ_path) {
-        Ok(environ) => environ.split('\0').any(|entry| entry == expected_env),
-        Err(_) => false,
+    let Ok(environ) = fs::read(&environ_path) else {
+        return ProcessIdentity::Unverified;
+    };
+
+    let mut saw_box_marker = false;
+    for entry in environ.split(|byte| *byte == 0) {
+        let Some(value) = entry.strip_prefix(b"BOXLITE_BOX_ID=") else {
+            continue;
+        };
+
+        saw_box_marker = true;
+        if value == box_id.as_bytes() {
+            return ProcessIdentity::Matches;
+        }
     }
+
+    if saw_box_marker {
+        ProcessIdentity::Mismatch
+    } else {
+        ProcessIdentity::Unverified
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn contains_bytes(haystack: &[u8], needle: &[u8]) -> bool {
+    haystack
+        .windows(needle.len())
+        .any(|window| window == needle)
 }
 
 #[cfg(target_os = "macos")]
@@ -427,8 +476,74 @@ mod tests {
 
         let pid = child.id();
 
+        assert_eq!(
+            process_identity(pid, "box-env-test"),
+            ProcessIdentity::Matches
+        );
         assert!(is_same_process(pid, "box-env-test"));
+        assert_eq!(
+            process_identity(pid, "other-box"),
+            ProcessIdentity::Mismatch
+        );
         assert!(!is_same_process(pid, "other-box"));
+
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_process_identity_linux_reads_non_utf8_environ_bytes() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+        use std::os::unix::process::CommandExt;
+        use std::process::{Command, Stdio};
+
+        let mut child = Command::new("sleep")
+            .arg0("boxlite-shim")
+            .arg("5")
+            .env("BAD_UTF8", OsString::from_vec(vec![0x66, 0x80, 0x6f]))
+            .env("BOXLITE_BOX_ID", "box-env-test")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn test shim process");
+
+        let pid = child.id();
+
+        assert_eq!(
+            process_identity(pid, "box-env-test"),
+            ProcessIdentity::Matches
+        );
+        assert!(is_same_process(pid, "box-env-test"));
+
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_process_identity_linux_unverified_without_box_marker() {
+        use std::os::unix::process::CommandExt;
+        use std::process::{Command, Stdio};
+
+        let mut child = Command::new("sleep")
+            .arg0("boxlite-shim")
+            .arg("5")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn legacy shim process");
+
+        let pid = child.id();
+
+        assert_eq!(
+            process_identity(pid, "box-env-test"),
+            ProcessIdentity::Unverified
+        );
+        assert!(!is_same_process(pid, "box-env-test"));
 
         let _ = child.kill();
         let _ = child.wait();

--- a/src/boxlite/src/util/process.rs
+++ b/src/boxlite/src/util/process.rs
@@ -249,7 +249,8 @@ fn is_process_zombie_macos(pid: u32) -> bool {
 /// This prevents PID reuse attacks where a PID is recycled for a different process.
 ///
 /// # Implementation
-/// * **Linux**: Read `/proc/{pid}/cmdline` and check for "boxlite-shim" + box_id
+/// * **Linux**: Read `/proc/{pid}/cmdline` and `/proc/{pid}/environ`,
+///   then check for a boxlite-shim process tagged with BOXLITE_BOX_ID.
 /// * **macOS**: Use `sysinfo` crate to get process name and check for "boxlite-shim"
 ///
 /// # Arguments
@@ -284,16 +285,25 @@ fn is_same_process_linux(pid: u32, box_id: &str) -> bool {
     use std::fs;
 
     let cmdline_path = format!("/proc/{}/cmdline", pid);
+    let environ_path = format!("/proc/{}/environ", pid);
 
-    match fs::read_to_string(&cmdline_path) {
-        Ok(cmdline) => {
-            // cmdline is null-separated, split by \0 for proper parsing
-            let args: Vec<&str> = cmdline.split('\0').collect();
+    let Ok(cmdline) = fs::read_to_string(&cmdline_path) else {
+        return false;
+    };
 
-            // Check if any arg contains "boxlite-shim" and cmdline contains box_id
-            args.iter().any(|arg| arg.contains("boxlite-shim")) && cmdline.contains(box_id)
-        }
-        Err(_) => false, // Process doesn't exist or no permission
+    // cmdline is null-separated, split by \0 for proper parsing.
+    // The box id is intentionally not passed as an argument anymore because
+    // the full InstanceSpec is sent over stdin to keep secrets out of procfs.
+    let is_shim = cmdline.split('\0').any(|arg| arg.contains("boxlite-shim"));
+
+    if !is_shim {
+        return false;
+    }
+
+    let expected_env = format!("BOXLITE_BOX_ID={box_id}");
+    match fs::read_to_string(&environ_path) {
+        Ok(environ) => environ.split('\0').any(|entry| entry == expected_env),
+        Err(_) => false,
     }
 }
 
@@ -397,6 +407,31 @@ mod tests {
         // Invalid PID should return false
         assert!(!is_same_process(0, "test123"));
         assert!(!is_same_process(u32::MAX, "test123"));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_is_same_process_linux_validates_box_id_env() {
+        use std::os::unix::process::CommandExt;
+        use std::process::{Command, Stdio};
+
+        let mut child = Command::new("sleep")
+            .arg0("boxlite-shim")
+            .arg("5")
+            .env("BOXLITE_BOX_ID", "box-env-test")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn test shim process");
+
+        let pid = child.id();
+
+        assert!(is_same_process(pid, "box-env-test"));
+        assert!(!is_same_process(pid, "other-box"));
+
+        let _ = child.kill();
+        let _ = child.wait();
     }
 
     #[test]

--- a/src/boxlite/src/util/process.rs
+++ b/src/boxlite/src/util/process.rs
@@ -327,7 +327,7 @@ fn process_identity_linux(pid: u32, box_id: &str) -> ProcessIdentity {
     }
 
     let Ok(environ) = fs::read(&environ_path) else {
-        return ProcessIdentity::Unverified;
+        return ProcessIdentity::Mismatch;
     };
 
     let mut saw_box_marker = false;

--- a/src/boxlite/src/vmm/controller/spawn.rs
+++ b/src/boxlite/src/vmm/controller/spawn.rs
@@ -87,7 +87,7 @@ impl<'a> ShimSpawner<'a> {
         // 3. Setup pre-spawn isolation (cgroups on Linux, no-op on macOS)
         jail.prepare()?;
 
-        // 4. Build isolated command — no CLI args, config sent via stdin pipe
+        // 4. Build isolated command - no CLI args, config sent via stdin pipe
         let no_args: &[String] = &[];
         let mut cmd = jail.command(self.binary_path, no_args);
 
@@ -118,13 +118,13 @@ impl<'a> ShimSpawner<'a> {
         // producer-consumer pattern via the kernel pipe buffer. For typical
         // configs (~2-5KB), write_all completes immediately. For large configs
         // (>16KB on macOS, >64KB on Linux), write_all blocks until the child
-        // drains the buffer — which it does as its first action in main().
+        // drains the buffer - which it does as its first action in main().
         if let Some(mut stdin) = child.stdin.take() {
             use std::io::Write;
             stdin.write_all(config_json.as_bytes()).map_err(|e| {
                 BoxliteError::Engine(format!("Failed to write config to shim stdin: {e}"))
             })?;
-            drop(stdin); // close write end — shim sees EOF
+            drop(stdin); // close write end - shim sees EOF
         }
 
         // 9. Close read end in parent (child inherited it via fork)
@@ -134,6 +134,10 @@ impl<'a> ShimSpawner<'a> {
     }
 
     fn configure_env(&self, cmd: &mut std::process::Command) {
+        // Non-sensitive process marker used by recovery to validate shim PIDs
+        // without putting the full InstanceSpec back into /proc/<pid>/cmdline.
+        cmd.env("BOXLITE_BOX_ID", self.box_id);
+
         // Pass debugging environment variables to subprocess
         if let Ok(rust_log) = std::env::var("RUST_LOG") {
             cmd.env("RUST_LOG", rust_log);
@@ -198,7 +202,7 @@ mod tests {
             &options,
         );
 
-        // No CLI args — config is sent via stdin pipe
+        // No CLI args - config is sent via stdin pipe
         // Just verify the spawner was created without error
         assert_eq!(spawner.box_id, "test-box");
     }
@@ -238,6 +242,10 @@ mod tests {
         let envs: std::collections::HashMap<_, _> = cmd.get_envs().collect();
         let expected = layout.tmp_dir();
 
+        assert_eq!(
+            envs.get(OsStr::new("BOXLITE_BOX_ID")).and_then(|v| *v),
+            Some(OsStr::new("test-box"))
+        );
         assert_eq!(
             envs.get(OsStr::new("TMPDIR")).and_then(|v| *v),
             Some(expected.as_os_str())


### PR DESCRIPTION
## Summary
- tag spawned shim processes with `BOXLITE_BOX_ID` so recovery can validate the owning box without putting the InstanceSpec back in argv
- update Linux PID validation to require a `boxlite-shim` process with the matching env marker instead of checking for the box id in `/proc/<pid>/cmdline`
- add regression coverage for the Linux env-based process check

Fixes #434.

## Testing
- `git diff --check`
- Not run: `cargo fmt --check` / `cargo test -p boxlite util::process` because `cargo` is not installed in this Windows environment and WSL commands timed out before reaching the repo.