### PR TITLE
ci(e2e): make runner instance persistence non-fatal

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -248,11 +248,11 @@ jobs:
             aws ec2 wait instance-running --instance-ids "$INSTANCE_ID"
             echo "instance-id=$INSTANCE_ID" >> "$GITHUB_OUTPUT"
 
-            # Save instance ID for future runs (must succeed or we'll orphan the instance)
+            # Try to save instance ID for faster lookup on the next run.
+            # Best-effort: tag-based fallback (Name=boxlite-e2e) handles rediscovery
+            # if this fails (e.g., the auth token lacks variables:write).
             if ! gh variable set EC2_E2E_INSTANCE_ID --body "$INSTANCE_ID" -R "${{ github.repository }}"; then
-              echo "::error::Failed to save instance ID. Terminating orphaned instance."
-              aws ec2 terminate-instances --instance-ids "$INSTANCE_ID"
-              exit 1
+              echo "::warning::Could not persist EC2_E2E_INSTANCE_ID. Future runs will rediscover by tag."
             fi
           fi
         env:

--- a/scripts/ci/setup-ci-runner.sh
+++ b/scripts/ci/setup-ci-runner.sh
@@ -424,6 +424,35 @@ step_configure_github() {
         gh variable delete GH_APP_ID -R "$REPO" 2>/dev/null || true
     fi
 
+    # Pre-check: GitHub rejects manifest creation with "Name is already taken"
+    # if the slug exists anywhere (any owner, including private Apps). The
+    # rejection happens on the form page, so the OAuth callback never fires
+    # and we'd time out 120s later with no useful message. Detect it now.
+    local app_slug="boxlite-e2e-runner"
+    if [ "$(curl -sI -o /dev/null -w '%{http_code}' "https://github.com/apps/${app_slug}")" = "200" ]; then
+        print_error "An App named '${app_slug}' already exists on GitHub."
+        print_info "Local credentials are missing, so we can't reuse it from this script."
+        print_info "Delete the App, then continue:"
+        local app_settings_url
+        if gh api "/orgs/${owner}" &>/dev/null; then
+            app_settings_url="https://github.com/organizations/${owner}/settings/apps/${app_slug}/advanced"
+        else
+            app_settings_url="https://github.com/settings/apps/${app_slug}/advanced"
+        fi
+        print_info "  ${app_settings_url}"
+        if command_exists open; then
+            open "$app_settings_url"
+        elif command_exists xdg-open; then
+            xdg-open "$app_settings_url"
+        fi
+        read -rp "  Press Enter once the App has been deleted (or Ctrl+C to abort)... "
+        if [ "$(curl -sI -o /dev/null -w '%{http_code}' "https://github.com/apps/${app_slug}")" = "200" ]; then
+            print_error "App still exists. Aborting."
+            exit 1
+        fi
+        print_success "App deleted. Continuing with creation."
+    fi
+
     print_info "Creating GitHub App via manifest flow..."
     print_info "A browser window will open. Click 'Create GitHub App' to proceed."
     echo ""
@@ -434,6 +463,9 @@ step_configure_github() {
     # Build the manifest JSON
     # hook_attributes.url is required by the API even if unused
     local manifest
+    # default_permissions:
+    #   administration:     write — mint runner registration tokens (used by e2e-test.yml)
+    #   actions_variables:  write — persist EC2_E2E_INSTANCE_ID across runs
     manifest=$(jq -n \
         --arg name "boxlite-e2e-runner" \
         --arg url "https://github.com/${REPO}" \
@@ -444,7 +476,10 @@ step_configure_github() {
             public: false,
             redirect_url: $redirect_url,
             hook_attributes: { url: $url, active: false },
-            default_permissions: { administration: "write" },
+            default_permissions: {
+                administration: "write",
+                actions_variables: "write"
+            },
             default_events: []
         }')
 
@@ -514,10 +549,14 @@ server.serve_forever()
         print_warning "Cannot open browser. Open this file manually: $html_file"
     fi
 
-    # Wait for callback (up to 2 minutes)
-    print_info "Waiting for GitHub callback..."
+    # Wait for callback (up to 5 minutes — clicking through GitHub's
+    # "Create GitHub App" confirmation page can be slow if the user is
+    # signed-out or has 2FA prompts).
+    print_info "Waiting for GitHub callback (up to 5 min)..."
+    print_info "  In the browser: click the green 'Create GitHub App' button to confirm."
+    print_info "  If the page shows 'Invalid GitHub App configuration', stop and report the error."
     local elapsed=0
-    while [ ! -s "$code_file" ] && [ $elapsed -lt 120 ]; do
+    while [ ! -s "$code_file" ] && [ $elapsed -lt 300 ]; do
         sleep 2
         elapsed=$((elapsed + 2))
     done
@@ -527,9 +566,14 @@ server.serve_forever()
     wait "$server_pid" 2>/dev/null || true
 
     if [ ! -s "$code_file" ]; then
-        print_error "Timed out waiting for GitHub callback"
+        print_error "Timed out waiting for GitHub callback after ${elapsed}s."
+        print_info "Common causes:"
+        print_info "  - Didn't click 'Create GitHub App' on the GitHub confirmation page"
+        print_info "  - GitHub rejected the manifest (page shows 'Invalid GitHub App configuration')"
+        print_info "  - Browser blocked the redirect to http://localhost:9876"
         exit 1
     fi
+    print_success "Callback received."
 
     local code
     code=$(cat "$code_file")


### PR DESCRIPTION
## Summary
- Workflow: persistence of `EC2_E2E_INSTANCE_ID` is now best-effort. Tag fallback (`Name=boxlite-e2e`) handles rediscovery, so a 403 from `gh variable set` no longer terminates a healthy runner. Fixes the self-destruct loop in [run 25603658679](https://github.com/boxlite-ai/boxlite/actions/runs/25603658679/job/75161756964).
- Setup script: requests `actions_variables: write` in the App manifest so newly-created Apps can write Actions Variables, pre-checks that the App slug is free before triggering manifest creation (avoids a silent 120s timeout when the slug is taken), and bumps the OAuth callback wait from 2 min to 5 min with clearer instructions.

## Test plan
- [ ] PR labelled `e2e-test` so the workflow runs.
- [ ] `Start E2E Runner` job reaches `Wait for runner to come online` instead of dying at `gh variable set`.
- [ ] EC2 instance is left in `running` (not `terminated`) after `start-runner`: `aws ec2 describe-instances --filters Name=tag:Name,Values=boxlite-e2e --query 'Reservations[*].Instances[*].[InstanceId,State.Name]'`.
- [ ] Re-run the workflow without changes — subsequent runs should hit the `STATE=running`/`STATE=stopped` fast path and skip the create-new branch.
- [ ] Once the App owner grants `Variables: write` on the existing App, confirm `EC2_E2E_INSTANCE_ID` appears in `gh variable list -R boxlite-ai/boxlite` after a successful run (until then, expect a `::warning::` instead).