### PR TITLE
ci(e2e): expand subnet pool to all AZs in the VPC

### DIFF
--- a/scripts/ci/setup-ci-runner.sh
+++ b/scripts/ci/setup-ci-runner.sh
@@ -157,24 +157,31 @@ step_detect_config() {
         print_info "VPC: $VPC_ID"
     fi
 
-    # Subnet
+    # Subnets — gather every subnet in the VPC so the workflow's multi-AZ
+    # loop has the widest possible AZ pool to fall back on when an AZ is
+    # short on capacity (InsufficientInstanceCapacity).
     if [ -z "$SUBNET_ID" ]; then
-        print_step "Public subnet... "
-        SUBNET_ID=$(aws ec2 describe-subnets \
+        print_step "Public subnets... "
+        SUBNET_IDS=$(aws ec2 describe-subnets \
             --filters "Name=vpc-id,Values=${VPC_ID}" "Name=map-public-ip-on-launch,Values=true" \
-            --query "Subnets[0].SubnetId" --output text --region "$REGION" 2>/dev/null || echo "")
-        if [ -z "$SUBNET_ID" ] || [ "$SUBNET_ID" = "None" ]; then
-            SUBNET_ID=$(aws ec2 describe-subnets \
+            --query "Subnets[].SubnetId" --output text --region "$REGION" 2>/dev/null \
+            | tr '[:space:]' ',' | sed 's/,$//; s/^,//')
+        if [ -z "$SUBNET_IDS" ]; then
+            SUBNET_IDS=$(aws ec2 describe-subnets \
                 --filters "Name=vpc-id,Values=${VPC_ID}" \
-                --query "Subnets[0].SubnetId" --output text --region "$REGION" 2>/dev/null || echo "")
+                --query "Subnets[].SubnetId" --output text --region "$REGION" 2>/dev/null \
+                | tr '[:space:]' ',' | sed 's/,$//; s/^,//')
         fi
-        if [ -z "$SUBNET_ID" ] || [ "$SUBNET_ID" = "None" ]; then
-            print_error "No subnet found in VPC $VPC_ID. Provide --subnet-id."
+        if [ -z "$SUBNET_IDS" ]; then
+            print_error "No subnets found in VPC $VPC_ID. Provide --subnet-id."
             exit 1
         fi
-        print_success "$SUBNET_ID"
+        local az_count
+        az_count=$(echo "$SUBNET_IDS" | tr ',' '\n' | wc -l | tr -d ' ')
+        print_success "${SUBNET_IDS} (${az_count} AZs)"
     else
-        print_info "Subnet: $SUBNET_ID"
+        SUBNET_IDS="$SUBNET_ID"
+        print_info "Subnet (override): $SUBNET_ID"
     fi
 
     echo ""
@@ -394,8 +401,12 @@ step_configure_github() {
     gh variable set AWS_ACCOUNT_ID --body "$ACCOUNT_ID" -R "$REPO"
     print_info "AWS_ACCOUNT_ID = $ACCOUNT_ID"
 
-    gh variable set AWS_SUBNET_ID --body "$SUBNET_ID" -R "$REPO"
-    print_info "AWS_SUBNET_ID = $SUBNET_ID"
+    gh variable set AWS_SUBNET_IDS --body "$SUBNET_IDS" -R "$REPO"
+    print_info "AWS_SUBNET_IDS = $SUBNET_IDS"
+    # Drop the legacy single-subnet variable so the workflow's
+    # `vars.AWS_SUBNET_IDS || vars.AWS_SUBNET_ID` fallback can't pick a
+    # narrower (one-AZ) pool by accident.
+    gh variable delete AWS_SUBNET_ID -R "$REPO" 2>/dev/null || true
 
     gh variable set AWS_SECURITY_GROUP_ID --body "$SG_ID" -R "$REPO"
     print_info "AWS_SECURITY_GROUP_ID = $SG_ID"


### PR DESCRIPTION
## Summary
- Multi-AZ fallback in `e2e-test.yml` (#491) iterates over `AWS_SUBNET_IDS`, but the setup script only ever wrote `AWS_SUBNET_ID` (singular). The iteration degenerated to a single AZ, so today's run died on `InsufficientInstanceCapacity` for `c8i.4xlarge` in `us-east-1f` even though five other AZs had spare capacity.
- Setup script now enumerates every public subnet in the VPC, writes the comma-joined list to `AWS_SUBNET_IDS`, and deletes the legacy `AWS_SUBNET_ID` so the workflow's `vars.AWS_SUBNET_IDS || vars.AWS_SUBNET_ID` fallback can't quietly revert to a one-AZ pool.

## Test plan
- [ ] Re-run `./scripts/ci/setup-ci-runner.sh`. Verify it prints `Public subnets... ✓ subnet-...,subnet-... (N AZs)` and saves `AWS_SUBNET_IDS`.
- [ ] `gh variable list -R boxlite-ai/boxlite` shows `AWS_SUBNET_IDS` (plural) populated and `AWS_SUBNET_ID` (singular) absent.
- [ ] Re-trigger the E2E workflow. The `Start E2E Runner` log should iterate subnets and land on one with capacity instead of failing on the first AZ.