### PR TITLE
ci(e2e): move make setup from user-data to a job step

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -187,13 +187,12 @@ jobs:
           modprobe kvm_intel 2>/dev/null || modprobe kvm_amd 2>/dev/null || true
           chmod 666 /dev/kvm 2>/dev/null || true
           usermod -aG kvm root 2>/dev/null || true
-          apt-get update -qq && apt-get install -y -qq make sudo git curl jq
-          if [ ! -d /opt/boxlite ]; then
-            git clone --recursive https://github.com/__REPO__.git /opt/boxlite
-          fi
-          cd /opt/boxlite && git pull --recurse-submodules || true
-          make setup
-          source "$HOME/.cargo/env"
+          # User-data only installs the actions-runner. Build deps
+          # (apt + rustup + cargo-nextest) are installed by the
+          # e2e-tests job's "Install build dependencies" step so they
+          # stream to the GitHub Actions log and don't race the
+          # runner-online poll.
+          apt-get update -qq && apt-get install -y -qq curl jq tar
           RUNNER_VERSION="__RUNNER_VERSION__"
           mkdir -p /opt/actions-runner && cd /opt/actions-runner
           if [ ! -f ./config.sh ]; then
@@ -296,7 +295,7 @@ jobs:
     runs-on:
       - self-hosted
       - boxlite-e2e
-    timeout-minutes: 35
+    timeout-minutes: 50
     env:
       CARGO_TERM_COLOR: always
       CARGO_INCREMENTAL: '0'
@@ -322,6 +321,14 @@ jobs:
           test -c /dev/kvm && test -r /dev/kvm -a -w /dev/kvm && echo "/dev/kvm is accessible" || {
             echo "::error::/dev/kvm not accessible"; exit 1
           }
+
+      - name: Install build dependencies (make setup)
+        run: |
+          # First run on a fresh instance: ~5–10 min (apt + rustup +
+          # cargo-nextest; CI=true so prek install is skipped).
+          # Subsequent runs reuse the persistent EBS volume and are
+          # idempotent fast-paths (~10–30 s).
+          bash scripts/setup/setup-ubuntu.sh
 
       - name: Run integration tests
         run: |


### PR DESCRIPTION
## Summary
Move the heavy build-dependency install (`make setup`) out of EC2 user-data and into the `e2e-tests` job as a normal step. User-data shrinks to "install + start the actions-runner" (~30s) and no longer races the 180s `Wait for runner to come online` poll.

Root cause from [run 25629760929](https://github.com/boxlite-ai/boxlite/actions/runs/25629760929/job/75231224533): user-data hit the 180s wait timeout mid-`cargo install prek`, the always-on `Stop E2E Runner` job sent SIGTERM via `aws ec2 stop-instances`, cloud-init's run-once semaphore was consumed, instance was permanently broken (no runner systemd unit ever installed). Recovered evidence in `/var/log/cloud-init-output.log` from `i-07e41b4444e0103dc` showed compilation killed at `Compiling reqwest v0.12.28`.

## Changes
- `.github/workflows/e2e-test.yml`:
  - User-data: drop `git clone`, `git pull`, `make setup`, `source ~/.cargo/env`. Keep KVM module load + actions-runner download/configure/start. Apt installs trimmed to `curl jq tar`.
  - e2e-tests: add new step `Install build dependencies (make setup)` running `scripts/setup/setup-ubuntu.sh` before `Run integration tests`.
  - e2e-tests: bump `timeout-minutes` 35 → 50 to cover first-run setup on top of test runtime.

## Test plan
- [ ] PR labelled `e2e-test` so the workflow runs.
- [ ] First run (fresh instance):
  - [ ] `Wait for runner to come online` succeeds well under 180s.
  - [ ] `Install build dependencies` step runs `make setup` with output streamed live; **does NOT** install `prek` (CI=true skip path).
  - [ ] `Run integration tests` runs.
  - [ ] `Stop E2E Runner` stops the instance.
- [ ] Second run (instance reused via `STATE=stopped` fast path):
  - [ ] Runner re-registers in ~30s after `aws ec2 start-instances`.
  - [ ] `Install build dependencies` runs in seconds (idempotent fast-paths).
  - [ ] Tests run; instance stops.
- [ ] At rest: exactly one EC2 instance tagged `Name=boxlite-e2e` exists, in `stopped` state.

## Cleanup performed
- Terminated `i-07e41b4444e0103dc` (the broken instance from the failing run); next workflow run will create a fresh instance with the new user-data.