### PR TITLE
fix: make Start() idempotent when box is already running

### DIFF
--- a/apps/runner/pkg/boxlite/client.go
+++ b/apps/runner/pkg/boxlite/client.go
@@ -205,7 +205,33 @@ func (c *Client) Create(ctx context.Context, sandboxDto dto.CreateSandboxDTO) (s
 	return bx.ID(), "boxlite", nil
 }
 
+// boxStarter is the subset of *boxlite.Box needed by startIdempotent.
+type boxStarter interface {
+	Start(context.Context) error
+	Info(context.Context) (*boxlite.BoxInfo, error)
+}
+
+// startIdempotent calls bx.Start and suppresses the error only when the box is
+// confirmed to be already running. ErrInvalidState from any other state
+// (Stopping/Paused/Unknown) is propagated unchanged.
+func startIdempotent(ctx context.Context, bx boxStarter, sandboxId string, log *slog.Logger) error {
+	if err := bx.Start(ctx); err != nil {
+		if boxlite.IsInvalidState(err) {
+			// Rust start() returns Ok(()) for Running state, so ErrInvalidState means
+			// the box is in a non-startable state. Verify before suppressing.
+			info, infoErr := bx.Info(ctx)
+			if infoErr == nil && info.State == boxlite.StateRunning {
+				log.DebugContext(ctx, "start called on already running box, treating as no-op", "sandbox_id", sandboxId)
+				return nil
+			}
+		}
+		return err
+	}
+	return nil
+}
+
 // Start starts a stopped sandbox and returns the daemon version.
+// Idempotent: if the box is already running, treats the call as a no-op.
 func (c *Client) Start(ctx context.Context, sandboxId string, authToken *string, metadata map[string]string) (string, error) {
 	if err := c.ensureVolumeMountsFromMetadata(ctx, sandboxId, metadata); err != nil {
 		c.logger.ErrorContext(ctx, "failed to ensure volume FUSE mounts", "error", err)
@@ -215,7 +241,8 @@ func (c *Client) Start(ctx context.Context, sandboxId string, authToken *string,
 	if err != nil {
 		return "", err
 	}
-	if err := bx.Start(ctx); err != nil {
+
+	if err := startIdempotent(ctx, bx, sandboxId, c.logger); err != nil {
 		return "", err
 	}
 	return "boxlite", nil

--- a/apps/runner/pkg/boxlite/client_start_test.go
+++ b/apps/runner/pkg/boxlite/client_start_test.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+package boxlite
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	boxlite "github.com/boxlite-ai/boxlite/sdks/go"
+)
+
+// fakeBox is a test double for boxStarter that does not require a real VM.
+type fakeBox struct {
+	startErr error
+	info     *boxlite.BoxInfo
+	infoErr  error
+}
+
+func (f *fakeBox) Start(_ context.Context) error                    { return f.startErr }
+func (f *fakeBox) Info(_ context.Context) (*boxlite.BoxInfo, error) { return f.info, f.infoErr }
+
+func invalidStateErr(msg string) error {
+	return &boxlite.Error{Code: boxlite.ErrInvalidState, Message: msg}
+}
+
+// TestStartIdempotent_AlreadyRunning is the core regression test:
+// Create() auto-starts the box; the subsequent explicit Start() call from the
+// Python SDK returns ErrInvalidState, and we must treat it as a no-op when
+// the box is confirmed Running.
+func TestStartIdempotent_AlreadyRunning(t *testing.T) {
+	bx := &fakeBox{
+		startErr: invalidStateErr("box is not in a startable state"),
+		info:     &boxlite.BoxInfo{State: boxlite.StateRunning},
+	}
+	if err := startIdempotent(context.Background(), bx, "test-id", slog.Default()); err != nil {
+		t.Fatalf("expected no error when box is already running, got: %v", err)
+	}
+}
+
+// TestStartIdempotent_StoppingIsError ensures ErrInvalidState is not silently
+// swallowed when the box is in a genuinely non-startable state (e.g. Stopping).
+func TestStartIdempotent_StoppingIsError(t *testing.T) {
+	bx := &fakeBox{
+		startErr: invalidStateErr("box is stopping"),
+		info:     &boxlite.BoxInfo{State: boxlite.StateStopping},
+	}
+	err := startIdempotent(context.Background(), bx, "test-id", slog.Default())
+	if err == nil {
+		t.Fatal("expected error when box is stopping, got nil")
+	}
+	if !boxlite.IsInvalidState(err) {
+		t.Fatalf("expected ErrInvalidState, got: %v", err)
+	}
+}
+
+// TestStartIdempotent_InfoFailsIsError ensures that when Info() itself errors
+// after receiving ErrInvalidState, the original Start error is propagated.
+func TestStartIdempotent_InfoFailsIsError(t *testing.T) {
+	bx := &fakeBox{
+		startErr: invalidStateErr("box is not in a startable state"),
+		infoErr:  &boxlite.Error{Code: boxlite.ErrInternal, Message: "info call failed"},
+	}
+	if err := startIdempotent(context.Background(), bx, "test-id", slog.Default()); err == nil {
+		t.Fatal("expected error when Info() fails, got nil")
+	}
+}
+
+// TestStartIdempotent_NormalStart covers the happy path where Start() succeeds.
+func TestStartIdempotent_NormalStart(t *testing.T) {
+	bx := &fakeBox{startErr: nil}
+	if err := startIdempotent(context.Background(), bx, "test-id", slog.Default()); err != nil {
+		t.Fatalf("expected no error on successful start, got: %v", err)
+	}
+}

--- a/sdks/python/src/box_handle.rs
+++ b/sdks/python/src/box_handle.rs
@@ -18,7 +18,7 @@ pub(crate) struct PyBox {
 impl PyBox {
     #[getter]
     fn id(&self) -> PyResult<String> {
-        Ok(self.handle.id().to_string())
+        Ok(self.handle.api_id())
     }
 
     #[getter]

--- a/src/boxlite/src/litebox/mod.rs
+++ b/src/boxlite/src/litebox/mod.rs
@@ -74,6 +74,15 @@ impl LiteBox {
         &self.id
     }
 
+    /// Returns the identifier to use when calling external APIs.
+    ///
+    /// For local boxes this equals `id().to_string()`. For REST-backed boxes
+    /// this returns the raw server-issued ID (e.g. a UUID), which may not
+    /// satisfy `BoxID`'s length/charset constraints.
+    pub fn api_id(&self) -> String {
+        self.box_backend.api_id()
+    }
+
     pub fn name(&self) -> Option<&str> {
         self.name.as_deref()
     }

--- a/src/boxlite/src/rest/litebox.rs
+++ b/src/boxlite/src/rest/litebox.rs
@@ -32,19 +32,25 @@ use super::types::{
 /// all operations to the remote REST API.
 pub(crate) struct RestBox {
     client: ApiClient,
+    /// The raw box_id string returned by the REST API (may be a UUID).
+    /// Used for URL path construction. Kept separate from `cached_info.id`
+    /// because `BoxID` only accepts 12- or 26-char alphanumeric strings,
+    /// while the REST API returns UUIDs.
+    raw_id: String,
     cached_info: RwLock<BoxInfo>,
 }
 
 impl RestBox {
-    pub fn new(client: ApiClient, info: BoxInfo) -> Self {
+    pub fn new(client: ApiClient, raw_id: String, info: BoxInfo) -> Self {
         Self {
             client,
+            raw_id,
             cached_info: RwLock::new(info),
         }
     }
 
     fn box_id_str(&self) -> String {
-        self.cached_info.read().id.to_string()
+        self.raw_id.clone()
     }
 }
 
@@ -58,6 +64,10 @@ impl BoxBackend for RestBox {
             let info = self.cached_info.data_ptr();
             &(*info).id
         }
+    }
+
+    fn api_id(&self) -> String {
+        self.raw_id.clone()
     }
 
     fn name(&self) -> Option<&str> {
@@ -243,8 +253,9 @@ impl BoxBackend for RestBox {
         let req = CloneBoxRequest::from_options(&options, name.as_deref());
         let resp: BoxResponse = self.client.post(&path, &req).await?;
 
+        let raw_id = resp.box_id.clone();
         let info = resp.to_box_info()?;
-        let rest_box = Arc::new(RestBox::new(self.client.clone(), info));
+        let rest_box = Arc::new(RestBox::new(self.client.clone(), raw_id, info));
         let box_backend: Arc<dyn BoxBackend> = rest_box.clone();
         let snapshot_backend: Arc<dyn SnapshotBackend> = rest_box;
         Ok(crate::LiteBox::new(box_backend, snapshot_backend))

--- a/src/boxlite/src/rest/runtime.rs
+++ b/src/boxlite/src/rest/runtime.rs
@@ -36,8 +36,9 @@ impl RuntimeBackend for RestRuntime {
     async fn create(&self, options: BoxOptions, name: Option<String>) -> BoxliteResult<LiteBox> {
         let req = CreateBoxRequest::from_options(&options, name);
         let resp: BoxResponse = self.client.post("/boxes", &req).await?;
+        let raw_id = resp.box_id.clone();
         let info = resp.to_box_info()?;
-        let rest_box = Arc::new(RestBox::new(self.client.clone(), info));
+        let rest_box = Arc::new(RestBox::new(self.client.clone(), raw_id, info));
         Ok(litebox_from_rest(rest_box))
     }
 
@@ -61,8 +62,9 @@ impl RuntimeBackend for RestRuntime {
         let path = format!("/boxes/{}", id_or_name);
         match self.client.get::<BoxResponse>(&path).await {
             Ok(resp) => {
+                let raw_id = resp.box_id.clone();
                 let info = resp.to_box_info()?;
-                let rest_box = Arc::new(RestBox::new(self.client.clone(), info));
+                let rest_box = Arc::new(RestBox::new(self.client.clone(), raw_id, info));
                 Ok(Some(litebox_from_rest(rest_box)))
             }
             Err(BoxliteError::NotFound(_)) => Ok(None),
@@ -136,8 +138,9 @@ impl RuntimeBackend for RestRuntime {
             .post_bytes_for_json("/boxes/import", archive_bytes, &query)
             .await?;
 
+        let raw_id = resp.box_id.clone();
         let info = resp.to_box_info()?;
-        let rest_box = Arc::new(RestBox::new(self.client.clone(), info));
+        let rest_box = Arc::new(RestBox::new(self.client.clone(), raw_id, info));
         Ok(litebox_from_rest(rest_box))
     }
 }

--- a/src/boxlite/src/runtime/backend.rs
+++ b/src/boxlite/src/runtime/backend.rs
@@ -70,6 +70,15 @@ pub(crate) trait RuntimeBackend: Send + Sync {
 pub(crate) trait BoxBackend: Send + Sync {
     fn id(&self) -> &BoxID;
 
+    /// Returns the identifier string to use in API/URL calls.
+    ///
+    /// For local boxes this is identical to `id().to_string()`.
+    /// For REST-backed boxes this preserves the raw server-returned ID
+    /// (e.g., a UUID), which may not be a valid `BoxID`.
+    fn api_id(&self) -> String {
+        self.id().to_string()
+    }
+
     fn name(&self) -> Option<&str>;
 
     fn info(&self) -> BoxInfo;

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -1,1 +1,7 @@
-fn main() {}
+fn main() {
+    // libkrun is a Rust staticlib that embeds its own copy of std.
+    // When linked into a binary on Linux, std symbols conflict with the
+    // binary's own std copy. --allow-multiple-definition suppresses the error.
+    #[cfg(target_os = "linux")]
+    println!("cargo:rustc-link-arg-bins=-Wl,--allow-multiple-definition");
+}


### PR DESCRIPTION
## Problem

Start() returns ErrInvalidState when the box was already started by Create(), even though the box is actually running. Affects all users following the standard pattern of calling create() then start().

## Root Cause

Create() was updated to auto-start the box, but Start() was not made idempotent. When the box is already Running, Start() returns ErrInvalidState, which propagates as an error.

## Change

Extract startIdempotent() in the runner client: when ErrInvalidState is received, call Info() to confirm the box is actually Running before suppressing the error. All other states (Stopping, etc.) propagate the error unchanged.

Unconditionally suppressing ErrInvalidState would be wrong — the error code also covers Stopping/Paused states that are genuine failures.

Also adds api_id() to BoxBackend for REST API ID handling and fixes CLI linker issue on Linux.

## Verification

```bash
cd apps/runner
go test -tags boxlite_dev ./pkg/boxlite/ -run TestStartIdempotent -v
```

All 4 tests pass.