### PR TITLE
chore(release): bump SDK patch versions to 0.9.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,7 +372,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -446,7 +446,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-c"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "boxlite",
  "cbindgen",
@@ -456,7 +456,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-cli"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -493,7 +493,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-guest"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -522,7 +522,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-node"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "boxlite",
  "boxlite-shared",
@@ -536,7 +536,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-python"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "boxlite",
  "futures",
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-shared"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "proptest",
  "prost",
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-shim"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "boxlite",
  "boxlite-shared",
@@ -605,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "bubblewrap-sys"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "num_cpus",
 ]
@@ -1064,7 +1064,7 @@ dependencies = [
 
 [[package]]
 name = "e2fsprogs-sys"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "num_cpus",
 ]
@@ -2064,14 +2064,14 @@ dependencies = [
 
 [[package]]
 name = "libgvproxy-sys"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "libkrun-sys"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "libc",
  "num_cpus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,15 +19,15 @@ exclude = ["build/tmp", "target", ".venv", "examples/*/.venv"]
 resolver = "2"
 
 [workspace.dependencies]
-boxlite = { path = "src/boxlite", version = "0.9.3" }
-boxlite-shared = { path = "src/shared", version = "0.9.3" }
-bubblewrap-sys = { path = "src/deps/bubblewrap-sys", version = "0.9.3" }
-e2fsprogs-sys = { path = "src/deps/e2fsprogs-sys", version = "0.9.3" }
-libgvproxy-sys = { path = "src/deps/libgvproxy-sys", version = "0.9.3" }
-libkrun-sys = { path = "src/deps/libkrun-sys", version = "0.9.3" }
+boxlite = { path = "src/boxlite", version = "0.9.4" }
+boxlite-shared = { path = "src/shared", version = "0.9.4" }
+bubblewrap-sys = { path = "src/deps/bubblewrap-sys", version = "0.9.4" }
+e2fsprogs-sys = { path = "src/deps/e2fsprogs-sys", version = "0.9.4" }
+libgvproxy-sys = { path = "src/deps/libgvproxy-sys", version = "0.9.4" }
+libkrun-sys = { path = "src/deps/libkrun-sys", version = "0.9.4" }
 
 [workspace.package]
-version = "0.9.3"
+version = "0.9.4"
 edition = "2024"
 authors = ["Dorian Zheng <https://github.com/dorianzheng>"]
 license = "Apache-2.0"

--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boxlite-ai/boxlite",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "BoxLite - Embeddable micro-VM runtime for secure, isolated code execution",
   "type": "module",
   "main": "dist/index.js",

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "boxlite"
-version = "0.9.3"
+version = "0.9.4"
 description = "Python bindings for Boxlite runtime"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Bumps Rust, C, Node, Python, and Go SDKs by one patch level (0.9.3 → 0.9.4).
- Source-of-truth edits: workspace `Cargo.toml` (`workspace.package.version` + all 6 `workspace.dependencies` path-version pins), `sdks/node/package.json`, `sdks/python/pyproject.toml`. Root `Cargo.lock` regenerated via `cargo update --workspace`.
- Go SDK has no source-level version pin (`sdks/go/cmd/setup/main.go:88` reads it from `runtime/debug.BuildInfo`) — it tags along with the release tag and needs no file change here.

## Notes
- `boxlite-test-utils` retains its own `0.1.0` (internal-only test helper, not on the workspace version).
- The orphaned `sdks/python/Cargo.lock` (still pins `boxlite` at `0.1.0`) is untouched — maturin builds use the root workspace lock; cleaning it up is out of scope for a patch bump.

## Test plan
- [x] `cargo metadata --no-deps` reports `0.9.4` for every workspace member (except internal `boxlite-test-utils`).
- [ ] CI runs (build + tests) on this PR.