### PR TITLE
feat(release): sh.boxlite.ai Cloudflare Worker for installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,14 +195,19 @@ func main() {
 **Install (Linux & macOS Apple Silicon):**
 
 ```bash
-curl -fsSL https://github.com/boxlite-ai/boxlite/releases/latest/download/install.sh | sh
+curl -fsSL https://sh.boxlite.ai | sh
 ```
 
 Installs to `$HOME/.local/bin/boxlite`. The runtime is embedded in the
-binary — no extra setup. Override the install dir or pin a version:
+binary — no extra setup. `sh.boxlite.ai` is a thin Cloudflare Worker that
+serves the same `install.sh` published on every GitHub Release; the long
+form `https://github.com/boxlite-ai/boxlite/releases/latest/download/install.sh`
+is the verifiable upstream and is what `gh attestation verify` covers.
+
+Override the install dir or pin a version:
 
 ```bash
-curl -fsSL https://github.com/boxlite-ai/boxlite/releases/latest/download/install.sh \
+curl -fsSL https://sh.boxlite.ai \
   | BOXLITE_VERSION=v0.9.4 BOXLITE_INSTALL_DIR=/usr/local/bin sh
 ```
 
@@ -217,7 +222,7 @@ the release page, look up the digest in the release's attested
 `SHA256SUMS` and pass it in explicitly:
 
 ```bash
-curl -fsSL https://github.com/boxlite-ai/boxlite/releases/latest/download/install.sh \
+curl -fsSL https://sh.boxlite.ai \
   | BOXLITE_VERSION=v0.9.4 \
     BOXLITE_EXPECTED_SHA256=<sha256-of-boxlite-cli-vX.Y.Z-target.tar.gz> sh
 ```

--- a/scripts/release/install.sh.template
+++ b/scripts/release/install.sh.template
@@ -2,7 +2,7 @@
 # BoxLite CLI installer.
 #
 # Usage:
-#   curl -fsSL https://github.com/boxlite-ai/boxlite/releases/latest/download/install.sh | sh
+#   curl -fsSL https://sh.boxlite.ai | sh
 #
 # Environment variables:
 #   BOXLITE_VERSION           Pin a specific tag (default: this script's CURRENT_VERSION)

--- a/scripts/release/install.sh.template
+++ b/scripts/release/install.sh.template
@@ -3,6 +3,7 @@
 #
 # Usage:
 #   curl -fsSL https://sh.boxlite.ai | sh
+#   curl -fsSL https://github.com/boxlite-ai/boxlite/releases/latest/download/install.sh | sh
 #
 # Environment variables:
 #   BOXLITE_VERSION           Pin a specific tag (default: this script's CURRENT_VERSION)

--- a/scripts/release/sh-installer/README.md
+++ b/scripts/release/sh-installer/README.md
@@ -1,0 +1,47 @@
+# sh.boxlite.ai installer Worker
+
+A tiny Cloudflare Worker that serves the boxlite-cli installer at
+`https://sh.boxlite.ai`, enabling:
+
+```sh
+curl -fsSL https://sh.boxlite.ai | sh
+```
+
+The Worker is a byte-passthrough proxy for the latest GitHub Release's
+`install.sh`. The install script's trust model (sigstore attestation,
+embedded SHA256 checksums, `.sha256` sidecars) is unchanged — see
+[`../install.sh.template`](../install.sh.template).
+
+## Local dev
+
+```sh
+cd scripts/release/sh-installer
+npx wrangler dev
+# Then in another terminal:
+curl -fsSL http://localhost:8787 | head -20
+```
+
+## Deploy
+
+The Worker source rarely changes, so deploys are manual.
+
+```sh
+cd scripts/release/sh-installer
+npx wrangler login          # first time only — opens a browser
+npx wrangler deploy
+```
+
+On first deploy, Cloudflare auto-provisions the `sh.boxlite.ai` DNS record
+and TLS cert (since `boxlite.ai` is already a Cloudflare-managed zone, and
+`wrangler.toml` has `custom_domain = true`).
+
+## Verify after deploy
+
+```sh
+# Content matches upstream byte-for-byte
+diff <(curl -fsSL https://sh.boxlite.ai) \
+     <(curl -fsSL https://github.com/boxlite-ai/boxlite/releases/latest/download/install.sh)
+
+# Pinning a version still works
+BOXLITE_VERSION=v0.9.4 curl -fsSL https://sh.boxlite.ai | sh
+```

--- a/scripts/release/sh-installer/src/index.ts
+++ b/scripts/release/sh-installer/src/index.ts
@@ -1,0 +1,52 @@
+// Cloudflare Worker that serves the boxlite-cli installer at sh.boxlite.ai.
+//
+// It proxies the latest install.sh published by the release pipeline:
+//   https://github.com/boxlite-ai/boxlite/releases/latest/download/install.sh
+//
+// The Worker is a passthrough — the install.sh content (including its embedded
+// sigstore attestation and SHA256 checksums) is untouched. Trust still flows
+// from the GitHub Release, not from this Worker.
+
+const UPSTREAM =
+  "https://github.com/boxlite-ai/boxlite/releases/latest/download/install.sh";
+
+// Edge cache TTL. Longer = fewer GitHub fetches but slower propagation of a
+// newly-published release. 300s (5 min) is the same order as rustup's CDN.
+const CACHE_TTL_SECONDS = 300;
+
+export default {
+  async fetch(request: Request): Promise<Response> {
+    if (request.method !== "GET" && request.method !== "HEAD") {
+      return new Response("Method not allowed\n", {
+        status: 405,
+        headers: { Allow: "GET, HEAD" },
+      });
+    }
+
+    const upstream = await fetch(UPSTREAM, {
+      // Tell Cloudflare's edge cache to store the response for CACHE_TTL_SECONDS
+      // regardless of upstream cache-control. cacheEverything overrides GitHub's
+      // defaults so we don't refetch on every request.
+      cf: { cacheTtl: CACHE_TTL_SECONDS, cacheEverything: true },
+      headers: { "User-Agent": "sh.boxlite.ai (Cloudflare Worker)" },
+    });
+
+    if (!upstream.ok) {
+      return new Response(
+        `sh.boxlite.ai upstream returned ${upstream.status}. ` +
+          `Try the verifiable URL directly: ${UPSTREAM}\n`,
+        { status: 502, headers: { "content-type": "text/plain; charset=utf-8" } },
+      );
+    }
+
+    // Override GitHub's Content-Type (application/octet-stream) so curl/browsers
+    // recognise it as a shell script. Body is forwarded byte-for-byte.
+    return new Response(upstream.body, {
+      status: 200,
+      headers: {
+        "content-type": "text/x-shellscript; charset=utf-8",
+        "cache-control": `public, max-age=${CACHE_TTL_SECONDS}, s-maxage=${CACHE_TTL_SECONDS}`,
+      },
+    });
+  },
+};

--- a/scripts/release/sh-installer/wrangler.toml
+++ b/scripts/release/sh-installer/wrangler.toml
@@ -1,0 +1,15 @@
+# Cloudflare Worker that serves the boxlite-cli installer at sh.boxlite.ai.
+# See README.md in this directory for setup and deploy.
+
+name = "sh-boxlite-ai"
+main = "src/index.ts"
+compatibility_date = "2026-01-01"
+
+# Cloudflare manages boxlite.ai DNS; custom_domain=true makes it auto-create
+# the sh.boxlite.ai DNS record and TLS cert on first deploy.
+routes = [
+  { pattern = "sh.boxlite.ai", custom_domain = true }
+]
+
+[observability]
+enabled = true


### PR DESCRIPTION
## Summary
- Add Cloudflare Worker at `sh.boxlite.ai` that proxies the latest GitHub Release's `install.sh`, enabling `curl -fsSL https://sh.boxlite.ai | sh` as a memorable entry point alongside the existing long URL.
- Worker is a byte-passthrough with 5-min edge cache and `Content-Type: text/x-shellscript` override; the install.sh trust model (sigstore attestation + embedded checksums + `.sha256` sidecars) stays anchored to the GitHub Release, not to the Worker.
- Update README + install.sh Usage comment to surface `sh.boxlite.ai` as the primary URL; verify-before-pipe section deliberately keeps the GitHub Releases URL since that's where the attestation lives.
- Versioning UX unchanged: `BOXLITE_VERSION=v0.9.4 curl -fsSL https://sh.boxlite.ai | sh` works (matches rustup/pnpm/mise env-var pattern).
- No CI workflow: Worker code rarely changes, deploy is manual via `npx wrangler deploy`.

## Test plan
- [ ] `cd scripts/release/sh-installer && npx wrangler login && npx wrangler deploy` (one-time setup; auto-provisions DNS + TLS for `sh.boxlite.ai`)
- [ ] `curl -I https://sh.boxlite.ai` returns `200`, `content-type: text/x-shellscript`, `server: cloudflare`
- [ ] `diff <(curl -fsSL https://sh.boxlite.ai) <(curl -fsSL https://github.com/boxlite-ai/boxlite/releases/latest/download/install.sh)` shows no diff
- [ ] `curl -fsSL https://sh.boxlite.ai | sh` installs `boxlite` to `~/.local/bin/`
- [ ] `BOXLITE_VERSION=v0.9.4 curl -fsSL https://sh.boxlite.ai | sh` pins to v0.9.4
- [ ] `curl -X POST https://sh.boxlite.ai` returns `405 Method not allowed`