### PR TITLE
Fix mobile credential row overflow

### DIFF
--- a/apps/dashboard/src/components/CreateRegionDialog.tsx
+++ b/apps/dashboard/src/components/CreateRegionDialog.tsx
@@ -7,6 +7,7 @@
 import React, { useState } from 'react'
 import { CreateRegion, CreateRegionResponse } from '@boxlite-ai/api-client'
 import { Button } from '@/components/ui/button'
+import { CopyableValue } from '@/components/ui/copyable-value'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import {
@@ -20,7 +21,7 @@ import {
   DialogTrigger,
 } from '@/components/ui/dialog'
 import { toast } from 'sonner'
-import { Plus, Copy } from 'lucide-react'
+import { Plus } from 'lucide-react'
 import { getMaskedToken } from '@/lib/utils'
 
 const DEFAULT_FORM_DATA = {
@@ -140,76 +141,70 @@ export const CreateRegionDialog: React.FC<CreateRegionDialogProps> = ({
             {createdRegion.proxyApiKey && (
               <div className="space-y-3">
                 <Label htmlFor="proxy-api-key">Proxy API Key</Label>
-                <div className="p-3 flex justify-between items-center rounded-md bg-green-100 text-green-600 dark:bg-green-900/50 dark:text-green-400">
-                  <span
-                    className="overflow-x-auto pr-2 cursor-text select-all"
-                    onMouseEnter={() => setIsProxyApiKeyRevealed(true)}
-                    onMouseLeave={() => setIsProxyApiKeyRevealed(false)}
-                  >
-                    {isProxyApiKeyRevealed ? createdRegion.proxyApiKey : getMaskedToken(createdRegion.proxyApiKey)}
-                  </span>
-                  <Copy
-                    className="w-4 h-4 cursor-pointer text-muted-foreground hover:text-foreground transition-colors"
-                    onClick={() => copyToClipboard(createdRegion.proxyApiKey!)}
-                  />
-                </div>
+                <CopyableValue
+                  displayValue={
+                    isProxyApiKeyRevealed ? createdRegion.proxyApiKey : getMaskedToken(createdRegion.proxyApiKey)
+                  }
+                  copyValue={createdRegion.proxyApiKey}
+                  copyLabel="proxy API key"
+                  onCopy={copyToClipboard}
+                  valueProps={{
+                    onMouseEnter: () => setIsProxyApiKeyRevealed(true),
+                    onMouseLeave: () => setIsProxyApiKeyRevealed(false),
+                  }}
+                />
               </div>
             )}
 
             {createdRegion.sshGatewayApiKey && (
               <div className="space-y-3">
                 <Label htmlFor="ssh-gateway-api-key">SSH Gateway API Key</Label>
-                <div className="p-3 flex justify-between items-center rounded-md bg-green-100 text-green-600 dark:bg-green-900/50 dark:text-green-400">
-                  <span
-                    className="overflow-x-auto pr-2 cursor-text select-all"
-                    onMouseEnter={() => setIsSshGatewayApiKeyRevealed(true)}
-                    onMouseLeave={() => setIsSshGatewayApiKeyRevealed(false)}
-                  >
-                    {isSshGatewayApiKeyRevealed
+                <CopyableValue
+                  displayValue={
+                    isSshGatewayApiKeyRevealed
                       ? createdRegion.sshGatewayApiKey
-                      : getMaskedToken(createdRegion.sshGatewayApiKey)}
-                  </span>
-                  <Copy
-                    className="w-4 h-4 cursor-pointer text-muted-foreground hover:text-foreground transition-colors"
-                    onClick={() => copyToClipboard(createdRegion.sshGatewayApiKey!)}
-                  />
-                </div>
+                      : getMaskedToken(createdRegion.sshGatewayApiKey)
+                  }
+                  copyValue={createdRegion.sshGatewayApiKey}
+                  copyLabel="SSH gateway API key"
+                  onCopy={copyToClipboard}
+                  valueProps={{
+                    onMouseEnter: () => setIsSshGatewayApiKeyRevealed(true),
+                    onMouseLeave: () => setIsSshGatewayApiKeyRevealed(false),
+                  }}
+                />
               </div>
             )}
 
             {createdRegion.snapshotManagerUsername && (
               <div className="space-y-3">
                 <Label htmlFor="snapshot-manager-username">Snapshot manager username</Label>
-                <div className="p-3 flex justify-between items-center rounded-md bg-green-100 text-green-600 dark:bg-green-900/50 dark:text-green-400">
-                  <span className="overflow-x-auto pr-2 cursor-text select-all">
-                    {createdRegion.snapshotManagerUsername}
-                  </span>
-                  <Copy
-                    className="w-4 h-4 cursor-pointer text-muted-foreground hover:text-foreground transition-colors"
-                    onClick={() => copyToClipboard(createdRegion.snapshotManagerUsername!)}
-                  />
-                </div>
+                <CopyableValue
+                  displayValue={createdRegion.snapshotManagerUsername}
+                  copyValue={createdRegion.snapshotManagerUsername}
+                  copyLabel="snapshot manager username"
+                  onCopy={copyToClipboard}
+                />
               </div>
             )}
 
             {createdRegion.snapshotManagerPassword && (
               <div className="space-y-3">
                 <Label htmlFor="snapshot-manager-password">Snapshot manager password</Label>
-                <div className="p-3 flex justify-between items-center rounded-md bg-green-100 text-green-600 dark:bg-green-900/50 dark:text-green-400">
-                  <span
-                    className="overflow-x-auto pr-2 cursor-text select-all"
-                    onMouseEnter={() => setIsSnapshotManagerPasswordRevealed(true)}
-                    onMouseLeave={() => setIsSnapshotManagerPasswordRevealed(false)}
-                  >
-                    {isSnapshotManagerPasswordRevealed
+                <CopyableValue
+                  displayValue={
+                    isSnapshotManagerPasswordRevealed
                       ? createdRegion.snapshotManagerPassword
-                      : getMaskedToken(createdRegion.snapshotManagerPassword)}
-                  </span>
-                  <Copy
-                    className="w-4 h-4 cursor-pointer text-muted-foreground hover:text-foreground transition-colors"
-                    onClick={() => copyToClipboard(createdRegion.snapshotManagerPassword!)}
-                  />
-                </div>
+                      : getMaskedToken(createdRegion.snapshotManagerPassword)
+                  }
+                  copyValue={createdRegion.snapshotManagerPassword}
+                  copyLabel="snapshot manager password"
+                  onCopy={copyToClipboard}
+                  valueProps={{
+                    onMouseEnter: () => setIsSnapshotManagerPasswordRevealed(true),
+                    onMouseLeave: () => setIsSnapshotManagerPasswordRevealed(false),
+                  }}
+                />
               </div>
             )}
           </div>

--- a/apps/dashboard/src/components/CreateRunnerDialog.tsx
+++ b/apps/dashboard/src/components/CreateRunnerDialog.tsx
@@ -7,6 +7,7 @@
 import React, { useState, useEffect } from 'react'
 import { Region, CreateRunner, CreateRunnerResponse } from '@boxlite-ai/api-client'
 import { Button } from '@/components/ui/button'
+import { CopyableValue } from '@/components/ui/copyable-value'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import {
@@ -21,7 +22,7 @@ import {
 } from '@/components/ui/dialog'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { toast } from 'sonner'
-import { Plus, Copy } from 'lucide-react'
+import { Plus } from 'lucide-react'
 import { getMaskedToken } from '@/lib/utils'
 
 const DEFAULT_FORM_DATA = {
@@ -135,19 +136,16 @@ export const CreateRunnerDialog: React.FC<CreateRunnerDialogProps> = ({ regions,
           <div className="space-y-6">
             <div className="space-y-3">
               <Label htmlFor="token">Token</Label>
-              <div className="p-3 flex justify-between items-center rounded-md bg-green-100 text-green-600 dark:bg-green-900/50 dark:text-green-400">
-                <span
-                  className="overflow-x-auto pr-2 cursor-text select-all"
-                  onMouseEnter={() => setIsTokenRevealed(true)}
-                  onMouseLeave={() => setIsTokenRevealed(false)}
-                >
-                  {isTokenRevealed ? createdRunner.apiKey : getMaskedToken(createdRunner.apiKey)}
-                </span>
-                <Copy
-                  className="w-4 h-4 cursor-pointer text-muted-foreground hover:text-foreground transition-colors"
-                  onClick={() => copyToClipboard(createdRunner.apiKey)}
-                />
-              </div>
+              <CopyableValue
+                displayValue={isTokenRevealed ? createdRunner.apiKey : getMaskedToken(createdRunner.apiKey)}
+                copyValue={createdRunner.apiKey}
+                copyLabel="runner token"
+                onCopy={copyToClipboard}
+                valueProps={{
+                  onMouseEnter: () => setIsTokenRevealed(true),
+                  onMouseLeave: () => setIsTokenRevealed(false),
+                }}
+              />
               <p className="text-sm text-muted-foreground">
                 Save this token securely. You won't be able to see it again.
               </p>

--- a/apps/dashboard/src/components/Organizations/CreateOrganizationDialog.tsx
+++ b/apps/dashboard/src/components/Organizations/CreateOrganizationDialog.tsx
@@ -5,9 +5,9 @@
  */
 
 import { useState } from 'react'
-import { Check, Copy } from 'lucide-react'
 import { Organization, Region } from '@boxlite-ai/api-client'
 import { Button } from '@/components/ui/button'
+import { CopyableValue } from '@/components/ui/copyable-value'
 import {
   Dialog,
   DialogClose,
@@ -102,15 +102,13 @@ export const CreateOrganizationDialog: React.FC<CreateOrganizationDialogProps> =
           <div className="space-y-6">
             <div className="space-y-3">
               <Label htmlFor="organization-id">Organization ID</Label>
-              <div className="p-3 flex justify-between items-center rounded-md bg-green-100 text-green-600 dark:bg-green-900/50 dark:text-green-400">
-                <span className="overflow-x-auto pr-2 cursor-text select-all">{createdOrg.id}</span>
-                {(copied === 'Organization ID' && <Check className="w-4 h-4" />) || (
-                  <Copy
-                    className="w-4 h-4 cursor-pointer"
-                    onClick={() => copyToClipboard(createdOrg.id, 'Organization ID')}
-                  />
-                )}
-              </div>
+              <CopyableValue
+                displayValue={createdOrg.id}
+                copyValue={createdOrg.id}
+                copyLabel="organization ID"
+                copied={copied === 'Organization ID'}
+                onCopy={(value) => copyToClipboard(value, 'Organization ID')}
+              />
             </div>
 
             {createdOrg.defaultRegionId && (

--- a/apps/dashboard/src/components/ui/copyable-value.tsx
+++ b/apps/dashboard/src/components/ui/copyable-value.tsx
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+'use client'
+
+import { CheckIcon, CopyIcon } from 'lucide-react'
+import * as React from 'react'
+
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+interface CopyableValueProps extends Omit<React.ComponentProps<'div'>, 'children' | 'onCopy'> {
+  displayValue: React.ReactNode
+  copyValue?: string
+  copyLabel?: string
+  copied?: boolean
+  onCopy?: (value: string) => void
+  valueClassName?: string
+  valueProps?: Omit<React.ComponentProps<'span'>, 'children' | 'className'> & {
+    className?: string
+  }
+  actions?: React.ReactNode
+  actionsClassName?: string
+}
+
+function CopyableValue({
+  className,
+  displayValue,
+  copyValue,
+  copyLabel = 'value',
+  copied,
+  onCopy,
+  valueClassName,
+  valueProps,
+  actions,
+  actionsClassName,
+  ...props
+}: CopyableValueProps) {
+  const { className: valuePropsClassName, ...restValueProps } = valueProps ?? {}
+  let copyAction: React.ReactNode = null
+
+  if (copyValue !== undefined && onCopy) {
+    const valueToCopy = copyValue
+    copyAction = copied ? (
+      <CheckIcon className="h-4 w-4 shrink-0" />
+    ) : (
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-xs"
+        aria-label={`Copy ${copyLabel}`}
+        className="-mr-1 h-6 w-6 shrink-0 text-current hover:bg-green-200/70 hover:text-current dark:hover:bg-green-800/70"
+        onClick={() => onCopy(valueToCopy)}
+      >
+        <CopyIcon className="h-4 w-4" />
+      </Button>
+    )
+  }
+
+  return (
+    <div
+      data-slot="copyable-value"
+      className={cn(
+        'flex min-w-0 items-center gap-2 overflow-hidden rounded-md bg-green-100 p-3 text-green-600 dark:bg-green-900/50 dark:text-green-400',
+        className,
+      )}
+      {...props}
+    >
+      <span
+        data-slot="copyable-value-text"
+        className={cn(
+          'min-w-0 flex-1 overflow-x-auto whitespace-nowrap pr-2 cursor-text select-all',
+          valueClassName,
+          valuePropsClassName,
+        )}
+        {...restValueProps}
+      >
+        {displayValue}
+      </span>
+      {actions ? (
+        <div className={cn('flex shrink-0 items-center gap-2', actionsClassName)}>{actions}</div>
+      ) : copyAction ? (
+        copyAction
+      ) : null}
+    </div>
+  )
+}
+
+export { CopyableValue }

--- a/apps/dashboard/src/components/ui/stories/copyable-value.stories.tsx
+++ b/apps/dashboard/src/components/ui/stories/copyable-value.stories.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import type { Meta, StoryObj } from '@storybook/react'
+import { CheckIcon, EyeIcon } from 'lucide-react'
+import { CopyableValue } from '../copyable-value'
+import { Button } from '../button'
+
+const meta: Meta<typeof CopyableValue> = {
+  title: 'UI/CopyableValue',
+  component: CopyableValue,
+  decorators: [
+    (Story) => (
+      <div className="w-[320px] max-w-full">
+        <Story />
+      </div>
+    ),
+  ],
+}
+
+export default meta
+type Story = StoryObj<typeof CopyableValue>
+
+const sshCommand = 'ssh -p 2222 drbDvBTdVD8g38GJ2bdTw66ys94CAXaZ@ssh.dev.boxlite.ai'
+const apiKey = 'bxl_live_1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
+
+export const LongCommand: Story = {
+  args: {
+    displayValue: sshCommand,
+    copyValue: sshCommand,
+    copyLabel: 'SSH command',
+    onCopy: () => {},
+  },
+}
+
+export const Copied: Story = {
+  args: {
+    displayValue: apiKey,
+    copyValue: apiKey,
+    copyLabel: 'API key',
+    copied: true,
+    onCopy: () => {},
+  },
+}
+
+export const WithMultipleActions: Story = {
+  render: () => (
+    <CopyableValue
+      displayValue={apiKey}
+      actionsClassName="gap-3"
+      actions={
+        <>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            aria-label="Reveal API key"
+            className="h-6 w-6 text-current hover:bg-green-200/70 hover:text-current dark:hover:bg-green-800/70"
+          >
+            <EyeIcon className="h-4 w-4" />
+          </Button>
+          <CheckIcon className="h-4 w-4 shrink-0" />
+        </>
+      }
+    />
+  ),
+}

--- a/apps/dashboard/src/pages/Onboarding.tsx
+++ b/apps/dashboard/src/pages/Onboarding.tsx
@@ -8,6 +8,7 @@ import pythonIcon from '@/assets/python.svg'
 import typescriptIcon from '@/assets/typescript.svg'
 import CodeBlock from '@/components/CodeBlock'
 import { Button } from '@/components/ui/button'
+import { CopyableValue } from '@/components/ui/copyable-value'
 import { Input } from '@/components/ui/input'
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { BOXLITE_DOCS_URL } from '@/constants/ExternalLinks'
@@ -185,32 +186,39 @@ const Onboarding: React.FC = () => {
                     page.
                   </p>
                   {createdApiKey ? (
-                    <div className="p-4 flex justify-between items-center rounded-md bg-green-100 text-green-600 dark:bg-green-900/50 dark:text-green-400">
-                      <span className="overflow-x-auto pr-2 cursor-text select-all">
-                        {isApiKeyRevealed ? createdApiKey.value : getMaskedToken(createdApiKey.value)}
-                      </span>
-                      <div className="flex items-center space-x-3 pl-3">
-                        {isApiKeyRevealed ? (
-                          <EyeOff
-                            className="w-4 h-4 cursor-pointer hover:text-green-400 dark:hover:text-green-200 transition-colors"
-                            onClick={() => setIsApiKeyRevealed(false)}
-                          />
-                        ) : (
-                          <Eye
-                            className="w-4 h-4 cursor-pointer hover:text-green-400 dark:hover:text-green-200 transition-colors"
-                            onClick={() => setIsApiKeyRevealed(true)}
-                          />
-                        )}
-                        {isApiKeyCopied ? (
-                          <Check className="w-4 h-4" />
-                        ) : (
-                          <ClipboardIcon
-                            className="w-4 h-4 cursor-pointer hover:text-green-400 dark:hover:text-green-200 transition-colors"
-                            onClick={() => copyToClipboard(createdApiKey.value)}
-                          />
-                        )}
-                      </div>
-                    </div>
+                    <CopyableValue
+                      className="p-4"
+                      displayValue={isApiKeyRevealed ? createdApiKey.value : getMaskedToken(createdApiKey.value)}
+                      actionsClassName="gap-3"
+                      actions={
+                        <>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon-xs"
+                            aria-label={isApiKeyRevealed ? 'Hide API key' : 'Reveal API key'}
+                            className="h-6 w-6 text-current hover:bg-green-200/70 hover:text-current dark:hover:bg-green-800/70"
+                            onClick={() => setIsApiKeyRevealed(!isApiKeyRevealed)}
+                          >
+                            {isApiKeyRevealed ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                          </Button>
+                          {isApiKeyCopied ? (
+                            <Check className="h-4 w-4 shrink-0" />
+                          ) : (
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="icon-xs"
+                              aria-label="Copy API key"
+                              className="h-6 w-6 text-current hover:bg-green-200/70 hover:text-current dark:hover:bg-green-800/70"
+                              onClick={() => copyToClipboard(createdApiKey.value)}
+                            >
+                              <ClipboardIcon className="h-4 w-4" />
+                            </Button>
+                          )}
+                        </>
+                      }
+                    />
                   ) : (
                     <form
                       onSubmit={async (e) => {

--- a/apps/dashboard/src/pages/Regions.tsx
+++ b/apps/dashboard/src/pages/Regions.tsx
@@ -38,12 +38,12 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
 import { Button } from '@/components/ui/button'
+import { CopyableValue } from '@/components/ui/copyable-value'
 import { toast } from 'sonner'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
 import { handleApiError } from '@/lib/error-handling'
 import { useRegions } from '@/hooks/useRegions'
 import { getMaskedToken } from '@/lib/utils'
-import { Copy } from 'lucide-react'
 import { PageContent, PageHeader, PageLayout, PageTitle } from '@/components/PageLayout'
 
 const Regions: React.FC = () => {
@@ -68,7 +68,6 @@ const Regions: React.FC = () => {
   const [regeneratedSnapshotManagerCreds, setRegeneratedSnapshotManagerCreds] =
     useState<SnapshotManagerCredentials | null>(null)
   const [regionForRegenerate, setRegionForRegenerate] = useState<Region | null>(null)
-  const [copied, setCopied] = useState(false)
   const [isApiKeyRevealed, setIsApiKeyRevealed] = useState(false)
   const [isSnapshotManagerPasswordRevealed, setIsSnapshotManagerPasswordRevealed] = useState(false)
 
@@ -244,8 +243,6 @@ const Regions: React.FC = () => {
   const copyToClipboard = async (text: string) => {
     try {
       await navigator.clipboard.writeText(text)
-      setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
       toast.success('Copied to clipboard')
     } catch (err) {
       console.error('Failed to copy text:', err)
@@ -358,7 +355,6 @@ const Regions: React.FC = () => {
           if (!isOpen) {
             setRegionForRegenerate(null)
             setRegeneratedApiKey(null)
-            setCopied(false)
             setIsApiKeyRevealed(false)
           }
         }}
@@ -379,19 +375,16 @@ const Regions: React.FC = () => {
               )}
               {regeneratedApiKey && (
                 <div className="space-y-4 mt-4">
-                  <div className="p-3 flex justify-between items-center rounded-md bg-green-100 text-green-600 dark:bg-green-900/50 dark:text-green-400">
-                    <span
-                      className="overflow-x-auto pr-2 cursor-text select-all"
-                      onMouseEnter={() => setIsApiKeyRevealed(true)}
-                      onMouseLeave={() => setIsApiKeyRevealed(false)}
-                    >
-                      {isApiKeyRevealed ? regeneratedApiKey : getMaskedToken(regeneratedApiKey)}
-                    </span>
-                    <Copy
-                      className="w-4 h-4 cursor-pointer flex-shrink-0 text-muted-foreground hover:text-foreground transition-colors"
-                      onClick={() => copyToClipboard(regeneratedApiKey)}
-                    />
-                  </div>
+                  <CopyableValue
+                    displayValue={isApiKeyRevealed ? regeneratedApiKey : getMaskedToken(regeneratedApiKey)}
+                    copyValue={regeneratedApiKey}
+                    copyLabel="proxy API key"
+                    onCopy={copyToClipboard}
+                    valueProps={{
+                      onMouseEnter: () => setIsApiKeyRevealed(true),
+                      onMouseLeave: () => setIsApiKeyRevealed(false),
+                    }}
+                  />
                 </div>
               )}
             </AlertDialogDescription>
@@ -415,7 +408,6 @@ const Regions: React.FC = () => {
                   setShowRegenerateProxyApiKeyDialog(false)
                   setRegionForRegenerate(null)
                   setRegeneratedApiKey(null)
-                  setCopied(false)
                   setIsApiKeyRevealed(false)
                 }}
                 className="bg-secondary text-secondary-foreground hover:bg-secondary/80"
@@ -435,7 +427,6 @@ const Regions: React.FC = () => {
           if (!isOpen) {
             setRegionForRegenerate(null)
             setRegeneratedApiKey(null)
-            setCopied(false)
             setIsApiKeyRevealed(false)
           }
         }}
@@ -456,19 +447,16 @@ const Regions: React.FC = () => {
               )}
               {regeneratedApiKey && (
                 <div className="space-y-4 mt-4">
-                  <div className="p-3 flex justify-between items-center rounded-md bg-green-100 text-green-600 dark:bg-green-900/50 dark:text-green-400">
-                    <span
-                      className="overflow-x-auto pr-2 cursor-text select-all"
-                      onMouseEnter={() => setIsApiKeyRevealed(true)}
-                      onMouseLeave={() => setIsApiKeyRevealed(false)}
-                    >
-                      {isApiKeyRevealed ? regeneratedApiKey : getMaskedToken(regeneratedApiKey)}
-                    </span>
-                    <Copy
-                      className="w-4 h-4 cursor-pointer flex-shrink-0 text-muted-foreground hover:text-foreground transition-colors"
-                      onClick={() => copyToClipboard(regeneratedApiKey)}
-                    />
-                  </div>
+                  <CopyableValue
+                    displayValue={isApiKeyRevealed ? regeneratedApiKey : getMaskedToken(regeneratedApiKey)}
+                    copyValue={regeneratedApiKey}
+                    copyLabel="SSH gateway API key"
+                    onCopy={copyToClipboard}
+                    valueProps={{
+                      onMouseEnter: () => setIsApiKeyRevealed(true),
+                      onMouseLeave: () => setIsApiKeyRevealed(false),
+                    }}
+                  />
                 </div>
               )}
             </AlertDialogDescription>
@@ -492,7 +480,6 @@ const Regions: React.FC = () => {
                   setShowRegenerateSshGatewayApiKeyDialog(false)
                   setRegionForRegenerate(null)
                   setRegeneratedApiKey(null)
-                  setCopied(false)
                   setIsApiKeyRevealed(false)
                 }}
                 className="bg-secondary text-secondary-foreground hover:bg-secondary/80"
@@ -512,7 +499,6 @@ const Regions: React.FC = () => {
           if (!isOpen) {
             setRegionForRegenerate(null)
             setRegeneratedSnapshotManagerCreds(null)
-            setCopied(false)
             setIsSnapshotManagerPasswordRevealed(false)
           }
         }}
@@ -537,33 +523,29 @@ const Regions: React.FC = () => {
                 <div className="space-y-4 mt-4">
                   <div>
                     <span className="text-xs text-muted-foreground">Username</span>
-                    <div className="p-3 flex justify-between items-center rounded-md bg-green-100 text-green-600 dark:bg-green-900/50 dark:text-green-400">
-                      <span className="overflow-x-auto pr-2 cursor-text select-all">
-                        {regeneratedSnapshotManagerCreds.username}
-                      </span>
-                      <Copy
-                        className="w-4 h-4 cursor-pointer flex-shrink-0 text-muted-foreground hover:text-foreground transition-colors"
-                        onClick={() => copyToClipboard(regeneratedSnapshotManagerCreds.username)}
-                      />
-                    </div>
+                    <CopyableValue
+                      displayValue={regeneratedSnapshotManagerCreds.username}
+                      copyValue={regeneratedSnapshotManagerCreds.username}
+                      copyLabel="snapshot manager username"
+                      onCopy={copyToClipboard}
+                    />
                   </div>
                   <div>
                     <span className="text-xs text-muted-foreground">Password</span>
-                    <div className="p-3 flex justify-between items-center rounded-md bg-green-100 text-green-600 dark:bg-green-900/50 dark:text-green-400">
-                      <span
-                        className="overflow-x-auto pr-2 cursor-text select-all"
-                        onMouseEnter={() => setIsSnapshotManagerPasswordRevealed(true)}
-                        onMouseLeave={() => setIsSnapshotManagerPasswordRevealed(false)}
-                      >
-                        {isSnapshotManagerPasswordRevealed
+                    <CopyableValue
+                      displayValue={
+                        isSnapshotManagerPasswordRevealed
                           ? regeneratedSnapshotManagerCreds.password
-                          : getMaskedToken(regeneratedSnapshotManagerCreds.password)}
-                      </span>
-                      <Copy
-                        className="w-4 h-4 cursor-pointer flex-shrink-0 text-muted-foreground hover:text-foreground transition-colors"
-                        onClick={() => copyToClipboard(regeneratedSnapshotManagerCreds.password)}
-                      />
-                    </div>
+                          : getMaskedToken(regeneratedSnapshotManagerCreds.password)
+                      }
+                      copyValue={regeneratedSnapshotManagerCreds.password}
+                      copyLabel="snapshot manager password"
+                      onCopy={copyToClipboard}
+                      valueProps={{
+                        onMouseEnter: () => setIsSnapshotManagerPasswordRevealed(true),
+                        onMouseLeave: () => setIsSnapshotManagerPasswordRevealed(false),
+                      }}
+                    />
                   </div>
                 </div>
               )}
@@ -588,7 +570,6 @@ const Regions: React.FC = () => {
                   setShowRegenerateSnapshotManagerCredsDialog(false)
                   setRegionForRegenerate(null)
                   setRegeneratedSnapshotManagerCreds(null)
-                  setCopied(false)
                   setIsSnapshotManagerPasswordRevealed(false)
                 }}
                 className="bg-secondary text-secondary-foreground hover:bg-secondary/80"

--- a/apps/dashboard/src/pages/Sandboxes.tsx
+++ b/apps/dashboard/src/pages/Sandboxes.tsx
@@ -27,6 +27,7 @@ import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
 import { LocalStorageKey } from '@/enums/LocalStorageKey'
 import { RoutePath } from '@/enums/RoutePath'
 import { SnapshotFilters, SnapshotQueryParams, useSnapshotsQuery } from '@/hooks/queries/useSnapshotsQuery'
+import { CopyableValue } from '@/components/ui/copyable-value'
 import { useApi } from '@/hooks/useApi'
 import { useConfig } from '@/hooks/useConfig'
 import { useNotificationSocket } from '@/hooks/useNotificationSocket'
@@ -52,7 +53,6 @@ import {
   SshAccessDto,
 } from '@boxlite-ai/api-client'
 import { QueryKey, useQueryClient } from '@tanstack/react-query'
-import { Check, Copy } from 'lucide-react'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { useAuth } from 'react-oidc-context'
 import { useNavigate } from 'react-router-dom'
@@ -1056,15 +1056,13 @@ const Sandboxes: React.FC = () => {
                   />
                 </div>
               ) : (
-                <div className="p-3 flex justify-between items-center rounded-md bg-green-100 text-green-600 dark:bg-green-900/50 dark:text-green-400">
-                  <span className="overflow-x-auto pr-2 cursor-text select-all">{sshAccess.sshCommand}</span>
-                  {(copied === 'SSH Command' && <Check className="w-4 h-4" />) || (
-                    <Copy
-                      className="w-4 h-4 cursor-pointer"
-                      onClick={() => copyToClipboard(sshAccess.sshCommand, 'SSH Command')}
-                    />
-                  )}
-                </div>
+                <CopyableValue
+                  displayValue={sshAccess.sshCommand}
+                  copyValue={sshAccess.sshCommand}
+                  copyLabel="SSH command"
+                  copied={copied === 'SSH Command'}
+                  onCopy={(value) => copyToClipboard(value, 'SSH Command')}
+                />
               )}
             </div>
             <AlertDialogFooter>


### PR DESCRIPTION
## Summary
- Add a shared `CopyableValue` component for dashboard credential/token rows.
- Replace legacy green credential rows in sandbox, region, runner, onboarding, and organization dialogs.
- Keep long commands and tokens constrained on mobile by scrolling the value internally while action buttons stay visible.

## Root Cause
Long unbroken SSH commands/API keys were rendered inside flex rows without a `min-w-0`/`flex-1` contract on the value child. On narrow screens, the value kept its min-content width and pushed or shrank neighboring action controls instead of scrolling inside the row.

## Validation
- `git diff --cached --check` passed before commit.
- Targeted 320px/375px layout probe passed: no document-level horizontal overflow; values scroll internally; action controls remain visible.
- `make fmt:check` passed but skipped dashboard changes.
- `make lint` passed but skipped dashboard changes.
- Installed app dependencies locally with `npm install --package-lock=false --ignore-scripts --legacy-peer-deps` after the initial build found missing Nx modules.
- `npm exec -- nx run dashboard:build` still fails in existing Vite/tsconfig resolution before transforming dashboard modules: `failed to resolve "extends":"../../tsconfig.base.json" in apps/dashboard/tsconfig.json`.