### PR TITLE
chore(deps): add lint:yarn-lock make target + pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,3 +49,15 @@ repos:
             .*/Cargo\.toml$|
             Cargo\.lock$
           )
+
+      - id: yarn-lock-sync
+        name: apps/yarn.lock in sync with apps/package.json
+        entry: make lint:yarn-lock
+        language: system
+        pass_filenames: false
+        stages: [pre-commit]
+        # apps/yarn.lock is gitignored, so this only fires on package.json
+        # changes. Catches the case where a dep is added/changed locally
+        # without running `yarn install` to refresh the working-tree lockfile
+        # that `sst deploy` then Docker-COPYs into the image.
+        files: ^apps/package\.json$

--- a/make/quality.mk
+++ b/make/quality.mk
@@ -1,4 +1,4 @@
-PHONY_TARGETS += fmt lint clippy
+PHONY_TARGETS += fmt lint clippy lint\:yarn-lock
 
 # Smart format: only format changed components.
 fmt:
@@ -116,6 +116,16 @@ lint\:fix:
 		. .venv/bin/activate && cd sdks/python && ruff check --fix .; \
 	fi
 	@$(MAKE) lint
+
+# Verify apps/yarn.lock is in sync with apps/package.json. apps/yarn.lock is
+# gitignored, so this guards the developer's local working tree — which is
+# what `sst deploy` Docker-COPYs at build time. Mirrors the --immutable flag
+# the Dockerfile itself uses, so a local pass means the Docker yarn install
+# will also pass.
+lint\:yarn-lock:
+	@echo "📋 Checking apps/yarn.lock is in sync with apps/package.json..."
+	@cd apps && yarn install --immutable
+	@echo "✅ apps/yarn.lock is in sync"
 
 lint\:rust:
 	@$(MAKE) clippy


### PR DESCRIPTION
## Summary

Adds a local-side gate that catches the failure mode from PR #516 (Api deploy died at Docker `yarn install --immutable` because `apps/package.json` had a new `@opentelemetry/sdk-node` constraint that the developer's local — gitignored — `apps/yarn.lock` hadn't been re-resolved against).

- `make lint:yarn-lock` runs `cd apps && yarn install --immutable`. Mirrors what `apps/api/Dockerfile` already does, so a local pass means the Docker build will also pass.
- `yarn-lock-sync` pre-commit hook (gated on `apps/package.json`) calls the make target. Same shape as the existing `lint-fix` / `full-test-matrix` hooks: thin prek wrapper around a make entry.

Catches the symptom at commit time instead of at deploy time.

## Why a gate even though yarn.lock isn't tracked

`apps/yarn.lock` is in `.gitignore`, so each developer maintains their own copy. `sst deploy` reads from the working tree (no `.dockerignore` exclusion). The failure isn't lockfile-in-commit drift; it's working-tree-lockfile-vs-working-tree-package.json drift — and that's exactly what `yarn install --immutable` detects.

## Test plan

- [x] `make lint:yarn-lock` passes on this branch's working tree.
- [x] Local commit on this branch triggered `lint-fix` (passed) and `yarn-lock-sync` (correctly skipped — no `apps/package.json` change in this PR).
- [ ] Verify by inducing drift in a follow-up: stage a no-op edit to `apps/package.json` and confirm the hook rejects the commit.