### PR TITLE
fix(dashboard): constrain dialog grid/flex children so long values stay inside on mobile

### DIFF
--- a/apps/dashboard/src/components/ui/alert-dialog.tsx
+++ b/apps/dashboard/src/components/ui/alert-dialog.tsx
@@ -45,7 +45,7 @@ function AlertDialogContent({ className, ...props }: React.ComponentProps<typeof
       <AlertDialogPrimitive.Content
         data-slot="alert-dialog-content"
         className={cn(
-          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-2xl',
+          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] grid-cols-[minmax(0,1fr)] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-2xl',
           className,
         )}
         {...props}

--- a/apps/dashboard/src/components/ui/dialog.tsx
+++ b/apps/dashboard/src/components/ui/dialog.tsx
@@ -57,7 +57,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] fixed top-[50%] left-[50%] z-50 flex max-h-[80vh] w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] flex-col gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
+          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] fixed top-[50%] left-[50%] z-50 flex max-h-[80vh] w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] flex-col gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg [&>*]:min-w-0',
           className,
         )}
         {...props}


### PR DESCRIPTION
## Summary

PR #513 added `CopyableValue` (`min-w-0 flex-1 overflow-x-auto` on the value span) so long SSH commands / API keys would scroll inside the row instead of pushing siblings. The fix works in isolation but on narrow viewports the row itself still **escapes its dialog** — reproducer: Sandboxes → Create SSH Access on mobile, the `ssh -p 2222 …` command renders past the right edge of `AlertDialogContent`.

## Root cause

`AlertDialogContent` is `display: grid` with no explicit `grid-template-columns`, so it gets a single implicit auto column whose items default to `min-width: auto` (= min-content). With `whitespace-nowrap` on the value span, that min-content is the full unbreakable SSH command — the grid item grows past `max-w-[calc(100%-2rem)]` and clips at the viewport. `DialogContent` has the same latent shape with `flex flex-col` items.

## Fix

- `AlertDialogContent`: add `grid-cols-[minmax(0,1fr)]` so the implicit auto column becomes `minmax(0,1fr)`. Children can now shrink below content-width, and CopyableValue's internal `overflow-x-auto` engages.
- `DialogContent`: add `[&>*]:min-w-0` so every direct flex-col child gets `min-width: 0` (Tailwind arbitrary child-selector).

One-line each. Fixes every CopyableValue site + any future long-content dialog without patching call sites.

## Test plan

- [ ] Open https://dev.boxlite.ai on a 375px-wide viewport (or DevTools device mode).
- [ ] Sandboxes → … → Create SSH Access → verify the SSH command stays inside the dialog, scrolls horizontally within the row, copy button remains visible.
- [ ] Create-Region / Create-Runner / Onboarding dialogs that show API keys: same check.
- [ ] Existing desktop dialogs render unchanged (no regressions on `sm:max-w-lg` / `sm:max-w-2xl` widths).