### PR TITLE
feat(api): single-bearer auth, drop OAuth2 facade, add GET /v1/me

### DIFF
--- a/openapi/rest-sandbox-open-api.yaml
+++ b/openapi/rest-sandbox-open-api.yaml
@@ -36,9 +36,10 @@ info:
 
     ## Authentication
 
-    All endpoints (except `GET /v1/config` and `POST /v1/oauth/tokens`) require
-    a Bearer token in the `Authorization` header. Obtain tokens via the OAuth2
-    client credentials flow.
+    All endpoints (except `GET /v1/config`) require an opaque API key in the
+    `Authorization: Bearer <key>` header. Keys are issued in the dashboard at
+    `https://app.boxlite.ai/settings/api-keys`. Validate a freshly-pasted key
+    via `GET /v1/me`.
 
     ## Execution Model
 
@@ -74,19 +75,12 @@ servers:
 # ---------------------------------------------------------------------------
 security:
   - BearerAuth: []
-  - OAuth2:
-      - boxes:read
-      - boxes:write
-      - boxes:exec
-      - images:read
-      - images:write
-      - runtime:admin
 
 tags:
   - name: Configuration
     description: Server capability discovery
   - name: Authentication
-    description: OAuth2 token exchange
+    description: Credential validation and identity lookup
   - name: Boxes
     description: Sandbox box lifecycle management
   - name: Execution
@@ -127,28 +121,23 @@ paths:
   # -------------------------------------------------------------------------
   # Authentication
   # -------------------------------------------------------------------------
-  /oauth/tokens:
-    post:
-      operationId: getToken
-      summary: Exchange credentials for an access token
+  /me:
+    get:
+      operationId: getCurrentPrincipal
+      summary: Identity and scopes for the calling credential
       description: |
-        OAuth2 client credentials flow. Returns a Bearer token for
-        authenticating subsequent API requests.
+        Returns the principal (user or service account) and granted scopes for
+        the Bearer credential in the request. Used by `boxlite auth login` to
+        validate freshly-pasted keys and by `boxlite auth status` to render
+        the identity banner.
       tags: [Authentication]
-      security: []
-      requestBody:
-        required: true
-        content:
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: "#/components/schemas/TokenRequest"
       responses:
         "200":
-          description: Token issued successfully
+          description: Authenticated principal
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TokenResponse"
+                $ref: "#/components/schemas/Principal"
         "401":
           $ref: "#/components/responses/UnauthorizedError"
 
@@ -930,21 +919,10 @@ components:
     BearerAuth:
       type: http
       scheme: bearer
-      bearerFormat: JWT
-      description: Bearer token obtained via OAuth2 client credentials flow
-
-    OAuth2:
-      type: oauth2
-      flows:
-        clientCredentials:
-          tokenUrl: /v1/oauth/tokens
-          scopes:
-            boxes:read: Read box information and status
-            boxes:write: Create, modify, and delete boxes
-            boxes:exec: Execute commands and manage executions
-            images:read: List and inspect cached images
-            images:write: Pull images from registries
-            runtime:admin: Runtime administration (metrics, shutdown)
+      description: |
+        Bearer authentication with an opaque API key issued by the dashboard
+        at `https://app.boxlite.ai/settings/api-keys`. Send as
+        `Authorization: Bearer <api-key>`. No token exchange required.
 
   # -------------------------------------------------------------------------
   # Parameters
@@ -1204,40 +1182,58 @@ components:
     # =======================================================================
     # Authentication
     # =======================================================================
-    TokenRequest:
+    Principal:
       type: object
-      required: [grant_type, client_id, client_secret]
+      description: |
+        Identity and scope payload returned by `GET /v1/me`. The CLI uses
+        `email`/`display_name` to render `Logged in as ...` after a successful
+        `boxlite auth login`, and `scopes` to surface under-scoped credentials
+        at login time rather than mid-flow.
+      required: [sub, principal_type, prefix, scopes]
       properties:
-        grant_type:
+        sub:
           type: string
-          enum: [client_credentials]
-        client_id:
+          description: |
+            Stable opaque principal identifier. Clients MUST treat the value
+            as opaque — the server may change format (UUID, ULID, Base62, or
+            prefixed) without notice. Survives email and display-name renames.
+        principal_type:
           type: string
-        client_secret:
+          enum: [user, service_account]
+          description: |
+            `user` for interactive dashboard-issued keys; `service_account`
+            for automation keys. Modeled as a sum type rather than a nullable
+            `user_id` field so the SDK can dispatch by variant.
+        email:
           type: string
-        scope:
+          format: email
+          description: |
+            Email of the user behind the key. Absent for `service_account`
+            principals.
+        display_name:
           type: string
-          description: Space-separated list of requested scopes
-          example: "boxes:read boxes:write boxes:exec"
-
-    TokenResponse:
-      type: object
-      required: [access_token, token_type, expires_in]
-      properties:
-        access_token:
+          description: Human-readable label. Optional.
+        prefix:
           type: string
-          description: Bearer token for authenticating API requests
-        token_type:
+          description: |
+            Tenant/workspace prefix the credential is bound to. The CLI uses
+            this to populate `--prefix` defaults on subsequent calls.
+        scopes:
+          type: array
+          items:
+            type: string
+            example: "boxes:read"
+          description: |
+            Granted scope strings (`boxes:read`, `boxes:write`, etc.). The
+            CLI checks these at login so under-scoped credentials surface
+            immediately rather than at first use.
+        expires_at:
           type: string
-          enum: [bearer]
-        expires_in:
-          type: integer
-          description: Token lifetime in seconds
-          example: 3600
-        scope:
-          type: string
-          description: Granted scopes (may differ from requested)
-          example: "boxes:read boxes:write boxes:exec"
+          format: date-time
+          nullable: true
+          description: |
+            Optional expiry. `null` for long-lived dashboard-issued keys;
+            ISO 8601 timestamp for rotating credentials.
 
     # =======================================================================
     # Error Model


### PR DESCRIPTION
## Summary

- Replace the dual auth scheme (`BearerAuth: JWT` + `OAuth2 clientCredentials`) with a single `BearerAuth` over opaque dashboard-issued keys — matches Stripe / Resend / OpenAI / GitHub PAT for single-host SaaS REST APIs.
- Delete `POST /v1/oauth/tokens` and its `TokenRequest` / `TokenResponse` schemas; the dashboard already issues a single secret, so the OAuth2 wrapper carried zero information.
- Add `GET /v1/me` returning a `Principal` schema (`sub`, `principal_type` ∈ {user, service_account}, `email`, `display_name`, `prefix`, `scopes`, `expires_at`) so the CLI can validate freshly-pasted keys and render `Logged in as <email>`.

## Why now

`bearerFormat: JWT` misdescribed the long-lived opaque key the SDK actually sends, and the live server at `dev.boxlite.ai` had already collapsed to a "client_secret IS the API key" shape that violates RFC 6749 §2.3.1. Aligning the spec with what comparable services actually publish lets the SDK, CLI, and backend stop diverging.

## Research grounding

Three parallel research agents + two follow-up validation agents (full reports in `~/.claude/plans/can-i-kind-pixel-agent-*.md`):

- **15-spec dual-auth survey** — every API that offers both opaque-bearer and OAuth2 bearer uses two distinct securitySchemes (Linode, Datadog, Cloudflare). `bearerFormat: JWT` paired with opaque keys has zero precedents.
- **9-impl OAuth2 `client_id` survey** — RFC 6749 §2.3.1 + Auth0 / Okta / Keycloak / Cognito / Azure AD / Ory / HubSpot all require `client_id`. No major service collapses API key → client_secret inside `/oauth/token`. Stripe / GitHub PAT / Postmark put the opaque key directly in `Authorization: Bearer`.
- **22-API identity-endpoint survey** — `/v1/me` is principal-agnostic (matches Auth0 My Account, Spotify) and lives at the API root above the `{prefix}` tenant segment. `/v1/account` would collide with boxlite billing terminology.
- **15-repo OpenAPI organization survey** — monolithic dominates below ~5k LOC; closest peer (e2b sandbox API, 3344 LOC) is monolithic. The 1907-line spec stays single-file.

## Follow-ups (gated on backend, not in this PR)

Tracked in project memory under `project-dev-boxlite-auth-blockers`:

- Backend implements `GET /v1/me` per the `Principal` schema.
- Backend accepts the opaque dashboard key as `Authorization: Bearer` on resource routes (current `/v1/sandboxes` etc. return 404).
- Backend decides whether to keep `POST /v1/oauth/tokens` as a deprecated compat shim or delete it.

SDK + CLI cleanup (also follow-up): remove `Credentials::ClientCredentials` variant, drop `--client-id` / `--client-secret-stdin` CLI flags, switch validation call from `list_info()` to `get_principal()` (calling `/v1/me`).

## Test plan

- [x] `grep -nE "TokenRequest|TokenResponse|OAuth2|/oauth/tokens" openapi/rest-sandbox-open-api.yaml` returns zero hits.
- [x] `grep -nE "Principal" openapi/rest-sandbox-open-api.yaml` shows exactly the schema definition + the one `$ref` from `GET /me`.
- [x] Single `BearerAuth` entry in `securitySchemes`; `bearerFormat: JWT` removed.
- [ ] `npx @redocly/cli lint openapi/rest-sandbox-open-api.yaml` returns no new warnings (run in CI / pre-merge).
- [ ] Backend issue filed with the `Principal` schema for implementation alignment.