### PR TITLE
feat(dashboard): mobile-first sandbox terminal and VNC

### DIFF
--- a/apps/daemon/pkg/terminal/static/index.html
+++ b/apps/daemon/pkg/terminal/static/index.html
@@ -2,6 +2,10 @@
 <html>
   <head>
     <title>Web Terminal</title>
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, viewport-fit=cover, interactive-widget=resizes-content"
+    />
     <link rel="stylesheet" href="/xterm.css" />
     <script src="/xterm.js"></script>
     <script src="/xterm-addon-fit.js"></script>
@@ -10,26 +14,166 @@
       body {
         margin: 0;
         padding: 0;
-        height: 100vh;
         background: #000;
+        color: #fff;
+        overscroll-behavior: none;
+      }
+      html,
+      body {
+        height: 100svh;
+        height: 100dvh;
+      }
+      body {
+        display: flex;
+        flex-direction: column;
       }
       #terminal {
-        height: 100%;
+        flex: 1 1 auto;
+        min-height: 0;
         width: 100%;
+      }
+      .xterm-viewport {
+        overflow-y: auto !important;
+      }
+      /* Mirrors dashboard dark tokens; iframe boundaries prevent cascade. */
+      :root {
+        --foreground: 40 18% 92%;
+        --secondary: 220 11% 14%;
+        --secondary-foreground: 40 18% 92%;
+        --accent: 220 11% 16%;
+        --accent-foreground: 40 18% 92%;
+        --border: 220 10% 20%;
+        --primary: 40 18% 92%;
+        --primary-foreground: 220 16% 8%;
+        --ring: 40 18% 92%;
+        --radius: 0.375rem;
+      }
+      #softkeys {
+        display: none;
+        flex-wrap: nowrap;
+        align-items: center;
+        gap: 6px;
+        background: rgba(0, 0, 0, 0.92);
+        border-top: 1px solid hsl(var(--border));
+        overflow-x: auto;
+        overscroll-behavior: contain;
+        -webkit-user-select: none;
+        user-select: none;
+        padding: 6px 6px calc(6px + env(safe-area-inset-bottom, 0px));
+      }
+      #softkeys button {
+        flex: 0 0 auto;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-width: 36px;
+        height: 32px;
+        padding: 0 12px;
+        font-size: 13px;
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        font-weight: 500;
+        color: hsl(var(--secondary-foreground));
+        background: hsl(var(--secondary));
+        border: 1px solid hsl(var(--border));
+        border-radius: calc(var(--radius) - 1px);
+        transition:
+          background-color 120ms ease,
+          color 120ms ease,
+          border-color 120ms ease,
+          box-shadow 120ms ease;
+        touch-action: manipulation;
+        cursor: pointer;
+        white-space: nowrap;
+      }
+      @media (hover: hover) {
+        #softkeys button:hover {
+          background: hsl(var(--accent));
+          color: hsl(var(--accent-foreground));
+        }
+      }
+      #softkeys button:active {
+        background: hsl(var(--accent));
+      }
+      #softkeys button:focus-visible {
+        outline: none;
+        border-color: hsl(var(--ring));
+        box-shadow: 0 0 0 2px hsl(var(--ring) / 0.25);
+      }
+      #softkeys button.armed,
+      #softkeys button.locked,
+      #softkeys button.trackpad-active {
+        background: hsl(var(--primary));
+        color: hsl(var(--primary-foreground));
+        border-color: hsl(var(--primary));
+      }
+      #softkeys button.locked {
+        box-shadow: 0 0 0 2px hsl(var(--ring) / 0.35);
+      }
+      @media (max-width: 768px), (pointer: coarse) {
+        #softkeys {
+          display: flex;
+        }
       }
     </style>
   </head>
   <body>
     <div id="terminal"></div>
+    <div id="softkeys" role="toolbar" aria-label="Terminal keys"></div>
     <script>
+      const params = new URLSearchParams(window.location.search)
+      const imeOff = params.get('ime') === 'off'
+      const isNarrow = window.matchMedia('(max-width: 768px)').matches
+
+      // Font size is the only parent-persisted terminal preference. User
+      // snippets or custom key sequences are not transferred into the iframe.
+      function loadFontSize() {
+        const fromParam = parseInt(params.get('fs') || '', 10)
+        if (Number.isFinite(fromParam) && fromParam >= 8 && fromParam <= 32) return fromParam
+        // localStorage access can throw under privacy-hardened browsers or
+        // when the iframe is denied storage. Don't let that halt boot.
+        try {
+          const saved = parseInt(localStorage.getItem('terminal-font-size') || '', 10)
+          if (Number.isFinite(saved) && saved >= 8 && saved <= 32) return saved
+        } catch (_) {
+          /* storage blocked */
+        }
+        return isNarrow ? 16 : 14
+      }
+
+      const DEFAULT_SOFTKEYS = [
+        { id: 'Esc', label: 'Esc', seq: '\x1b' },
+        { id: 'Tab', label: 'Tab', seq: '\t' },
+        { id: 'Ctrl', label: 'Ctrl', modifier: true },
+        { id: 'Alt', label: 'Alt', modifier: true },
+        { id: 'Up', label: '↑', seq: '\x1b[A' },
+        { id: 'Down', label: '↓', seq: '\x1b[B' },
+        { id: 'Left', label: '←', seq: '\x1b[D' },
+        { id: 'Right', label: '→', seq: '\x1b[C' },
+        { id: 'Pipe', label: '|', seq: '|' },
+        { id: 'Slash', label: '/', seq: '/' },
+        { id: 'Tilde', label: '~', seq: '~' },
+        {
+          id: 'Trackpad',
+          label: '↕',
+          action: 'trackpad',
+          title: 'Drag to move cursor',
+        },
+        {
+          id: 'Kbd',
+          label: '⌨',
+          action: 'toggle-keyboard',
+          title: 'Show/hide keyboard',
+        },
+      ]
+
+      // ---------------- Terminal init ----------------
+      let currentFontSize = loadFontSize()
       const term = new Terminal({
         cursorBlink: true,
-        fontSize: 14,
-        fontFamily: 'monospace',
-        theme: {
-          background: '#000000',
-          foreground: '#ffffff',
-        },
+        fontSize: currentFontSize,
+        fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+        scrollback: 5000,
+        theme: { background: '#000000', foreground: '#ffffff' },
       })
 
       const fitAddon = new FitAddon.FitAddon()
@@ -37,56 +181,434 @@
       term.open(document.getElementById('terminal'))
       fitAddon.fit()
 
-      // Connect to WebSocket
+      // Android IME desync workaround - xtermjs/xterm.js#2403
+      const helperTextarea = document.querySelector('.xterm-helper-textarea')
+      if (helperTextarea) {
+        helperTextarea.setAttribute('autocorrect', 'off')
+        helperTextarea.setAttribute('autocapitalize', 'off')
+        helperTextarea.setAttribute('spellcheck', 'false')
+        helperTextarea.setAttribute('autocomplete', 'off')
+        helperTextarea.setAttribute('enterkeyhint', 'send')
+        if (imeOff) helperTextarea.setAttribute('type', 'password')
+      }
+
+      // Chromium-only: precise keyboard insets via env(keyboard-inset-height)
+      if ('virtualKeyboard' in navigator) {
+        try {
+          navigator.virtualKeyboard.overlaysContent = true
+        } catch (_) {}
+      }
+
+      // ---------------- Outbound send (buffered until WS opens) ----------------
+      // Defined here so soft-keys / trackpad click handlers can call it
+      // synchronously. Swapped in-place by socket.onopen below.
+      const pendingSend = []
+      let send = (s) => pendingSend.push(s)
+
+      // ---------------- Soft-keys toolbar ----------------
+      const softkeysEl = document.getElementById('softkeys')
+      const armed = new Set()
+      const locked = new Set()
+      const modifierButtons = new Map()
+
+      function refreshModifierVisuals() {
+        for (const [id, btn] of modifierButtons) {
+          btn.classList.toggle('armed', armed.has(id))
+          btn.classList.toggle('locked', locked.has(id))
+        }
+      }
+
+      function handleModifierTap(id) {
+        if (locked.has(id)) {
+          locked.delete(id)
+          armed.delete(id)
+        } else if (armed.has(id)) {
+          armed.delete(id)
+          locked.add(id)
+        } else {
+          armed.add(id)
+        }
+        refreshModifierVisuals()
+      }
+
+      // Consume one-shot armed modifiers (locked stays). Called from both
+      // applyModifiers (after a real transformation) AND after a paste
+      // path that bypassed applyModifiers - otherwise armed Ctrl would
+      // survive across the paste and corrupt the next typed key.
+      function consumeArmedModifiers() {
+        let changed = false
+        if (armed.has('Ctrl') && !locked.has('Ctrl')) {
+          armed.delete('Ctrl')
+          changed = true
+        }
+        if (armed.has('Alt') && !locked.has('Alt')) {
+          armed.delete('Alt')
+          changed = true
+        }
+        if (changed) refreshModifierVisuals()
+      }
+
+      function applyModifiers(seq) {
+        let out = seq
+        if (armed.has('Ctrl') || locked.has('Ctrl')) {
+          if (out.length === 1) {
+            const upper = out.toUpperCase()
+            const code = upper.charCodeAt(0)
+            if (code >= 0x40 && code <= 0x5f) out = String.fromCharCode(code & 0x1f)
+            else if (code >= 0x61 && code <= 0x7a) out = String.fromCharCode(code - 0x60)
+          }
+        }
+        if (armed.has('Alt') || locked.has('Alt')) out = '\x1b' + out
+        consumeArmedModifiers()
+        return out
+      }
+
+      // ---------------- D1: Hold-to-move-cursor trackpad button ----------------
+      function wireTrackpad(btn) {
+        let st = null
+        const onPointerDown = (e) => {
+          e.preventDefault()
+          try {
+            btn.setPointerCapture(e.pointerId)
+          } catch (_) {}
+          st = { x: e.clientX, y: e.clientY, ax: 0, ay: 0, id: e.pointerId }
+          btn.classList.add('trackpad-active')
+        }
+        const onPointerMove = (e) => {
+          if (!st || st.id !== e.pointerId) return
+          const dx = e.clientX - st.x
+          const dy = e.clientY - st.y
+          // Empirical sensitivity: ~12 px per cell horizontally, ~16 px vertically
+          const tx = Math.trunc(dx / 12)
+          const ty = Math.trunc(dy / 16)
+          while (st.ax < tx) {
+            send(applyModifiers('\x1b[C'))
+            st.ax++
+          }
+          while (st.ax > tx) {
+            send(applyModifiers('\x1b[D'))
+            st.ax--
+          }
+          while (st.ay < ty) {
+            send(applyModifiers('\x1b[B'))
+            st.ay++
+          }
+          while (st.ay > ty) {
+            send(applyModifiers('\x1b[A'))
+            st.ay--
+          }
+        }
+        const onPointerUp = (e) => {
+          if (!st || st.id !== e.pointerId) return
+          try {
+            btn.releasePointerCapture(e.pointerId)
+          } catch (_) {}
+          st = null
+          btn.classList.remove('trackpad-active')
+        }
+        btn.addEventListener('pointerdown', onPointerDown)
+        btn.addEventListener('pointermove', onPointerMove)
+        btn.addEventListener('pointerup', onPointerUp)
+        btn.addEventListener('pointercancel', onPointerUp)
+      }
+
+      // ---------------- Tap activation (touch-safe) ----------------
+      // We preventDefault touchstart on every soft-key so tapping the toolbar
+      // doesn't steal focus from the xterm helper textarea and dismiss the
+      // on-screen keyboard. iOS Safari / Android Chrome treat that cancelled
+      // touchstart as a cancelled tap and suppress the synthesised click -
+      // which would silently kill every modifier/arrow/Esc/Paste button on
+      // the exact devices this UI targets. We dispatch on pointerup-within-
+      // bounds instead, and route through a mouse-click fallback for desktop
+      // users who never trigger pointer events.
+      function attachTap(btn, onActivate) {
+        let handled = false
+        let active = false
+        btn.addEventListener('pointerdown', (e) => {
+          if (e.pointerType === 'mouse' && e.button !== 0) return
+          active = true
+          handled = false
+        })
+        btn.addEventListener('pointerup', (e) => {
+          if (!active) return
+          active = false
+          const r = btn.getBoundingClientRect()
+          if (e.clientX < r.left || e.clientX > r.right || e.clientY < r.top || e.clientY > r.bottom) return
+          handled = true
+          e.preventDefault()
+          onActivate(e)
+        })
+        btn.addEventListener('pointercancel', () => {
+          active = false
+        })
+        btn.addEventListener('click', (e) => {
+          e.preventDefault()
+          if (handled) {
+            handled = false
+            return
+          }
+          onActivate(e)
+        })
+      }
+
+      // ---------------- Build soft-keys row ----------------
+      function rebuildSoftkeys() {
+        softkeysEl.replaceChildren()
+        modifierButtons.clear()
+        armed.clear()
+        locked.clear()
+        for (const key of DEFAULT_SOFTKEYS) {
+          if (!key || typeof key !== 'object' || !key.id) continue
+          const btn = document.createElement('button')
+          btn.type = 'button'
+          btn.textContent = key.label || key.id
+          btn.dataset.id = key.id
+          if (key.title) btn.title = key.title
+          if (key.modifier) modifierButtons.set(key.id, btn)
+          // Prevent stealing focus and dismissing the keyboard
+          btn.addEventListener('mousedown', (e) => e.preventDefault())
+          btn.addEventListener('touchstart', (e) => e.preventDefault(), {
+            passive: false,
+          })
+
+          if (key.action === 'trackpad') {
+            wireTrackpad(btn)
+            softkeysEl.appendChild(btn)
+            continue
+          }
+
+          attachTap(btn, () => {
+            if (key.modifier) return handleModifierTap(key.id)
+            if (key.action === 'toggle-keyboard') {
+              if (helperTextarea) {
+                if (document.activeElement === helperTextarea) helperTextarea.blur()
+                else helperTextarea.focus()
+              }
+              return
+            }
+            if (key.seq) send(applyModifiers(key.seq))
+          })
+          softkeysEl.appendChild(btn)
+        }
+      }
+
+      rebuildSoftkeys()
+
+      // ---------------- Paste-in-flight tracking ----------------
+      // Modifier transformation rules (see term.onData below):
+      //   * OS-keyboard typing -> applyModifiers, so softkey-armed Ctrl + a
+      //     typed 'c' becomes \x03.
+      //   * Paste from ANY source (dashboard-button postMessage, native
+      //     Cmd+V on the helper textarea, right-click paste) -> bytes go
+      //     out raw. xterm.paste wraps the payload in bracketed-paste
+      //     sequences (`\e[200~ ... \e[201~`) when the remote shell enabled
+      //     `\e[?2004h`; re-mapping the first byte with Ctrl or prefixing
+      //     ESC for locked Alt would corrupt the wrapper and let embedded
+      //     newlines run as shell commands.
+      //
+      // Track via a refcount. Set by (a) the inbound message handler
+      // before it calls term.paste, (b) a capture-phase document `paste`
+      // listener so we increment BEFORE xterm's own bubble-phase handler
+      // synchronously invokes term.paste -> onData.
+      let pasteInFlight = 0
+      document.addEventListener(
+        'paste',
+        () => {
+          pasteInFlight++
+          // The native paste event triggers xterm's textarea handler
+          // synchronously in the bubble phase; onData fires inside the
+          // same task. A macrotask `setTimeout(_, 0)` clears the flag
+          // after the synchronous chain settles. We also consume any
+          // armed (one-shot) Ctrl/Alt so a user who armed a modifier
+          // and then pasted doesn't have the modifier silently apply
+          // to the next typed key.
+          setTimeout(() => {
+            pasteInFlight = Math.max(0, pasteInFlight - 1)
+            if (pasteInFlight === 0) consumeArmedModifiers()
+          }, 0)
+        },
+        true,
+      )
+
+      // ---------------- Inbound parent bridge ----------------
+      // Paste text is read by a dashboard-rendered button under dashboard
+      // user activation, then posted here. The iframe never asks the parent
+      // to read clipboard and receives no user-supplied layout/snippet data.
+      window.addEventListener('message', (event) => {
+        if (event.source !== window.parent) return
+        const data = event.data
+        if (!data || typeof data !== 'object') return
+
+        if (data.source === 'boxlite-terminal' && data.type === 'paste') {
+          if (typeof data.text !== 'string' || data.text.length === 0) return
+          // Route through xterm's paste() so bracketed-paste mode wraps
+          // the payload with `\e[200~ ... \e[201~` when the remote shell
+          // enabled it. Increment pasteInFlight so the onData handler
+          // above sends the bytes raw (no Ctrl/Alt transformation).
+          pasteInFlight++
+          try {
+            term.paste(data.text)
+          } finally {
+            pasteInFlight = Math.max(0, pasteInFlight - 1)
+            if (pasteInFlight === 0) consumeArmedModifiers()
+          }
+          return
+        }
+      })
+
+      // Empty liveness ping; no secrets are sent.
+      function announceReady() {
+        try {
+          if (window.parent && window.parent !== window) {
+            window.parent.postMessage({ source: 'boxlite-terminal', type: 'ready' }, '*')
+          }
+        } catch (_) {}
+      }
+      announceReady()
+      window.addEventListener('load', announceReady)
+
+      // ---------------- WebSocket ----------------
       const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
       const socket = new WebSocket(`${protocol}//${window.location.host}/ws`)
+      socket.binaryType = 'arraybuffer'
+
+      // Register input handlers immediately. `send` was hoisted earlier so
+      // soft-key / trackpad handlers share the same buffering path.
+      // Paste-in-flight gating is documented above the pasteInFlight decl.
+      term.onData((data) => send(pasteInFlight > 0 ? data : applyModifiers(data)))
+      term.onResize((size) => send(JSON.stringify({ rows: size.rows, cols: size.cols })))
+
+      socket.onmessage = (event) => {
+        if (event.data instanceof ArrayBuffer) term.write(new Uint8Array(event.data))
+        else term.write(event.data)
+      }
 
       socket.onopen = () => {
         console.log('WebSocket connected')
-
-        // WebSocket -> Terminal
-        socket.onmessage = (event) => {
-          // Remove the Uint8Array conversion
-          term.write(event.data)
-        }
-
-        // Handle xterm data
-        term.onData((data) => {
-          socket.send(data)
-        })
-
-        // Handle resize
-        term.onResize((size) => {
-          socket.send(
-            JSON.stringify({
-              rows: size.rows,
-              cols: size.cols,
-            }),
-          )
-        })
-
-        // Initial size
-        socket.send(
-          JSON.stringify({
-            rows: term.rows,
-            cols: term.cols,
-          }),
-        )
-      }
-
-      // WebSocket -> Terminal
-      socket.onmessage = (event) => {
-        term.write(new Uint8Array(event.data))
+        send = (s) => socket.send(s)
+        // Initial size + flush anything buffered before open
+        send(JSON.stringify({ rows: term.rows, cols: term.cols }))
+        for (const s of pendingSend) socket.send(s)
+        pendingSend.length = 0
       }
 
       socket.onclose = () => {
+        // Re-buffer further keystrokes rather than throwing.
+        send = (s) => pendingSend.push(s)
         term.write('\r\nConnection closed\r\n')
       }
 
-      // Handle window resize
-      window.addEventListener('resize', () => {
-        fitAddon.fit()
-      })
+      // ---------------- Refit chain ----------------
+      let fitScheduled = false
+      function scheduleFit() {
+        if (fitScheduled) return
+        fitScheduled = true
+        requestAnimationFrame(() => {
+          fitScheduled = false
+          try {
+            fitAddon.fit()
+            // Coder workaround: first call can overflow; second normalizes.
+            fitAddon.fit()
+            term.scrollToBottom()
+          } catch (_) {}
+        })
+      }
+
+      window.addEventListener('resize', scheduleFit)
+      window.addEventListener('orientationchange', scheduleFit)
+
+      const mount = document.getElementById('terminal')
+      if (typeof ResizeObserver !== 'undefined') {
+        new ResizeObserver(scheduleFit).observe(mount)
+      }
+
+      if (window.visualViewport) {
+        const applyVV = () => {
+          window.scrollTo(0, 0)
+          if (window.visualViewport) document.body.style.height = `${window.visualViewport.height}px`
+          scheduleFit()
+        }
+        window.visualViewport.addEventListener('resize', applyVV)
+        window.visualViewport.addEventListener('scroll', applyVV)
+        applyVV()
+      }
+
+      // ---------------- D2: Pinch-to-zoom font size ----------------
+      // Touch events on the terminal mount. xterm.js handles single-touch
+      // scrolling natively, so we only act when 2+ fingers are down.
+      ;(function () {
+        let pinchStart = 0
+        let pinchStartSize = currentFontSize
+        let saveTimer = 0
+
+        const persist = () => {
+          if (saveTimer) clearTimeout(saveTimer)
+          saveTimer = setTimeout(() => {
+            try {
+              localStorage.setItem('terminal-font-size', String(currentFontSize))
+            } catch (_) {}
+            // The iframe origin is throwaway (per-session token subdomain);
+            // notify the parent dashboard so it can persist on its stable
+            // origin and replay via the ?fs= query param on next session.
+            try {
+              if (window.parent && window.parent !== window) {
+                window.parent.postMessage(
+                  {
+                    source: 'boxlite-terminal',
+                    type: 'pref',
+                    key: 'fontSize',
+                    value: currentFontSize,
+                  },
+                  '*',
+                )
+              }
+            } catch (_) {}
+          }, 250)
+        }
+
+        mount.addEventListener(
+          'touchstart',
+          (e) => {
+            if (e.touches.length === 2) {
+              const [a, b] = e.touches
+              pinchStart = Math.hypot(a.clientX - b.clientX, a.clientY - b.clientY)
+              pinchStartSize = currentFontSize
+            }
+          },
+          { passive: true },
+        )
+
+        mount.addEventListener(
+          'touchmove',
+          (e) => {
+            if (e.touches.length === 2 && pinchStart > 0) {
+              e.preventDefault()
+              const [a, b] = e.touches
+              const dist = Math.hypot(a.clientX - b.clientX, a.clientY - b.clientY)
+              const next = Math.max(8, Math.min(32, Math.round(pinchStartSize * (dist / pinchStart))))
+              if (next !== currentFontSize) {
+                currentFontSize = next
+                term.options.fontSize = next
+                scheduleFit()
+              }
+            }
+          },
+          { passive: false },
+        )
+
+        const release = () => {
+          if (pinchStart > 0) persist()
+          pinchStart = 0
+        }
+        mount.addEventListener('touchend', release)
+        mount.addEventListener('touchcancel', release)
+
+        // iOS Safari fires non-standard gesture events alongside touch events;
+        // suppress them so the page itself doesn't pinch-zoom underneath us.
+        ;['gesturestart', 'gesturechange', 'gestureend'].forEach((evt) => {
+          mount.addEventListener(evt, (e) => e.preventDefault())
+        })
+      })()
     </script>
   </body>
 </html>

--- a/apps/daemon/tools/xterm.go
+++ b/apps/daemon/tools/xterm.go
@@ -14,6 +14,11 @@ import (
 	"runtime"
 )
 
+// Pinned to the last release of the legacy `xterm` npm package.
+// xterm moved to `@xterm/xterm` from v6.x onwards; v6.0.0 also shipped a
+// touch-scroll regression (xtermjs/xterm.js#5489, fixed only in v7.0.0
+// via #5563). Do not bump to 6.x. If we ever migrate to @xterm/xterm,
+// target >=7.0.0 and re-verify touch scrolling on mobile.
 const (
 	XTERM_VERSION     = "5.3.0"
 	XTERM_FIT_VERSION = "0.8.0"

--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -18,7 +18,7 @@ import { OrganizationRolePermissionsEnum, OrganizationUserRoleEnum } from '@boxl
 import { useFeatureFlagEnabled, usePostHog } from 'posthog-js/react'
 import React, { Suspense, useEffect } from 'react'
 import { useAuth } from 'react-oidc-context'
-import { Navigate, Route, Routes, useLocation } from 'react-router-dom'
+import { Navigate, Outlet, Route, Routes, useLocation } from 'react-router-dom'
 import { BannerProvider } from './components/Banner'
 import { CommandPaletteProvider } from './components/CommandPalette'
 import LoadingFallback from './components/LoadingFallback'
@@ -56,9 +56,10 @@ import Volumes from './pages/Volumes'
 import Wallet from './pages/Wallet'
 import WebhookEndpointDetails from './pages/WebhookEndpointDetails'
 import Webhooks from './pages/Webhooks'
-import { SandboxDetails } from './components/sandboxes'
+import { SandboxDetails, SandboxTerminalFullscreen, SandboxVncFullscreen } from './components/sandboxes'
 import { ApiProvider } from './providers/ApiProvider'
 import { RegionsProvider } from './providers/RegionsProvider'
+import { SandboxSessionProvider } from './providers/SandboxSessionProvider'
 import { SvixProvider } from './providers/SvixProvider'
 
 // Simple redirection components for external URLs
@@ -78,11 +79,14 @@ const SlackRedirect = () => {
   return null
 }
 
+// Same-origin OIDC silent-renew iframes are legitimate, so frame refusal
+// belongs in deployment headers. The terminal Paste action also refuses to
+// read clipboard when the dashboard itself is framed.
+
 function App() {
   const config = useConfig()
   const location = useLocation()
   const posthog = usePostHog()
-
   const { error: authError, isAuthenticated, user, signoutRedirect } = useAuth()
 
   useEffect(() => {
@@ -163,7 +167,22 @@ function App() {
         <Route index element={<Navigate to={`${getRouteSubPath(RoutePath.SANDBOXES)}${location.search}`} replace />} />
         <Route path={getRouteSubPath(RoutePath.KEYS)} element={<Keys />} />
         <Route path={getRouteSubPath(RoutePath.SANDBOXES)} element={<Sandboxes />} />
-        <Route path={getRouteSubPath(RoutePath.SANDBOX_DETAILS)} element={<SandboxDetails />} />
+        {/* Pathless layout route: a single SandboxSessionProvider fiber
+            persists across the three sandbox routes, so activation state
+            (e.g. "terminal connected") survives navigation between the
+            details view and its fullscreen siblings. Per-route providers
+            held state in a useRef that died with each unmount. */}
+        <Route
+          element={
+            <SandboxSessionProvider>
+              <Outlet />
+            </SandboxSessionProvider>
+          }
+        >
+          <Route path={getRouteSubPath(RoutePath.SANDBOX_TERMINAL)} element={<SandboxTerminalFullscreen />} />
+          <Route path={getRouteSubPath(RoutePath.SANDBOX_VNC)} element={<SandboxVncFullscreen />} />
+          <Route path={getRouteSubPath(RoutePath.SANDBOX_DETAILS)} element={<SandboxDetails />} />
+        </Route>
         <Route path={getRouteSubPath(RoutePath.SNAPSHOTS)} element={<Snapshots />} />
         <Route path={getRouteSubPath(RoutePath.REGISTRIES)} element={<Registries />} />
         <Route

--- a/apps/dashboard/src/components/sandboxes/SandboxDetails.tsx
+++ b/apps/dashboard/src/components/sandboxes/SandboxDetails.tsx
@@ -34,7 +34,6 @@ import { useSandboxWsSync } from '@/hooks/useSandboxWsSync'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
 import { handleApiError } from '@/lib/error-handling'
 import { isStoppable, isTransitioning } from '@/lib/utils/sandbox'
-import { SandboxSessionProvider } from '@/providers/SandboxSessionProvider'
 import { OrganizationRolePermissionsEnum, OrganizationUserRoleEnum } from '@boxlite-ai/api-client'
 import { isAxiosError } from 'axios'
 import { Container, GripVertical, RefreshCw } from 'lucide-react'
@@ -180,130 +179,128 @@ export default function SandboxDetails() {
   }
 
   return (
-    <SandboxSessionProvider>
-      <PageLayout className="max-h-screen overflow-hidden">
-        <PageHeader>
-          <PageTitle>Sandboxes</PageTitle>
-        </PageHeader>
+    <PageLayout className="h-[var(--app-content-height,calc(100svh_-_3.5rem))] overflow-hidden">
+      <PageHeader className="hidden sm:flex">
+        <PageTitle>Sandboxes</PageTitle>
+      </PageHeader>
 
-        <SandboxHeader
-          sandbox={sandbox}
-          isLoading={isLoading}
-          writePermitted={writePermitted}
-          deletePermitted={deletePermitted}
-          actionsDisabled={actionsDisabled}
-          isFetching={isFetching}
-          onStart={handleStart}
-          onStop={handleStop}
-          onArchive={handleArchive}
-          onRecover={handleRecover}
-          onDelete={() => setDeleteDialogOpen(true)}
-          onRefresh={() => refetch()}
-          onBack={() => navigate(RoutePath.SANDBOXES)}
-          onCreateSshAccess={() => setCreateSshDialogOpen(true)}
-          onRevokeSshAccess={() => setRevokeSshDialogOpen(true)}
-          onScreenRecordings={handleScreenRecordings}
-          mutations={{
-            start: startMutation.isPending,
-            stop: stopMutation.isPending,
-            archive: archiveMutation.isPending,
-            recover: recoverMutation.isPending,
-          }}
-        />
+      <SandboxHeader
+        sandbox={sandbox}
+        isLoading={isLoading}
+        writePermitted={writePermitted}
+        deletePermitted={deletePermitted}
+        actionsDisabled={actionsDisabled}
+        isFetching={isFetching}
+        onStart={handleStart}
+        onStop={handleStop}
+        onArchive={handleArchive}
+        onRecover={handleRecover}
+        onDelete={() => setDeleteDialogOpen(true)}
+        onRefresh={() => refetch()}
+        onBack={() => navigate(RoutePath.SANDBOXES)}
+        onCreateSshAccess={() => setCreateSshDialogOpen(true)}
+        onRevokeSshAccess={() => setRevokeSshDialogOpen(true)}
+        onScreenRecordings={handleScreenRecordings}
+        mutations={{
+          start: startMutation.isPending,
+          stop: stopMutation.isPending,
+          archive: archiveMutation.isPending,
+          recover: recoverMutation.isPending,
+        }}
+      />
 
-        {isNotFound ? (
-          <div className="flex flex-1 min-h-0 items-center justify-center">
-            <Empty>
-              <EmptyHeader>
-                <EmptyMedia variant="icon">
-                  <Container className="size-4" />
-                </EmptyMedia>
-                <EmptyTitle>Sandbox not found</EmptyTitle>
-                <EmptyDescription>Are you sure you're in the right organization?</EmptyDescription>
-              </EmptyHeader>
-              <Button variant="outline" size="sm" onClick={() => navigate(RoutePath.SANDBOXES)}>
-                Back to Sandboxes
-              </Button>
-            </Empty>
-          </div>
-        ) : (
-          <Group orientation="horizontal" className="flex flex-1 min-h-0 overflow-hidden">
-            {isDesktop && (
-              <>
-                <Panel
-                  id="overview"
-                  minSize={250}
-                  maxSize={550}
-                  defaultSize={320}
-                  className="flex flex-col overflow-hidden"
-                >
-                  <div className="flex items-center px-5 border-b border-border shrink-0 h-[41px]">
-                    <span className="text-sm font-medium">Overview</span>
-                  </div>
-                  <ScrollArea fade="mask" className="flex-1 min-h-0">
-                    {isLoading ? (
-                      <InfoPanelSkeleton />
-                    ) : isError || !sandbox ? (
-                      <div className="flex flex-col items-center justify-center gap-3 p-8 text-center text-muted-foreground">
-                        <p className="text-sm">Failed to load sandbox details.</p>
-                        <Button variant="outline" size="sm" onClick={() => refetch()}>
-                          <RefreshCw className="size-4" />
-                          Retry
-                        </Button>
-                      </div>
-                    ) : (
-                      <SandboxInfoPanel sandbox={sandbox} getRegionName={getRegionName} />
-                    )}
-                  </ScrollArea>
-                </Panel>
-                <ResizableSeparator />
-              </>
-            )}
-            <Panel id="content" className="flex-1 min-w-0 flex flex-col overflow-hidden">
-              <SandboxContentTabs
-                sandbox={sandbox}
-                isLoading={isLoading}
-                experimentsEnabled={experimentsEnabled}
-                tab={tab}
-                onTabChange={setTab}
-              />
-            </Panel>
-          </Group>
-        )}
-
-        <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
-          <AlertDialogContent>
-            <AlertDialogHeader>
-              <AlertDialogTitle>Delete Sandbox</AlertDialogTitle>
-              <AlertDialogDescription>
-                Are you sure you want to delete this sandbox? This action cannot be undone.
-              </AlertDialogDescription>
-            </AlertDialogHeader>
-            <AlertDialogFooter>
-              <AlertDialogCancel disabled={deleteMutation.isPending}>Cancel</AlertDialogCancel>
-              <AlertDialogAction variant="destructive" onClick={handleDelete} disabled={deleteMutation.isPending}>
-                {deleteMutation.isPending ? 'Deleting...' : 'Delete'}
-              </AlertDialogAction>
-            </AlertDialogFooter>
-          </AlertDialogContent>
-        </AlertDialog>
-
-        {sandboxId && (
-          <>
-            <CreateSshAccessDialog
-              sandboxId={sandboxId}
-              open={createSshDialogOpen}
-              onOpenChange={setCreateSshDialogOpen}
+      {isNotFound ? (
+        <div className="flex flex-1 min-h-0 items-center justify-center">
+          <Empty>
+            <EmptyHeader>
+              <EmptyMedia variant="icon">
+                <Container className="size-4" />
+              </EmptyMedia>
+              <EmptyTitle>Sandbox not found</EmptyTitle>
+              <EmptyDescription>Are you sure you're in the right organization?</EmptyDescription>
+            </EmptyHeader>
+            <Button variant="outline" size="sm" onClick={() => navigate(RoutePath.SANDBOXES)}>
+              Back to Sandboxes
+            </Button>
+          </Empty>
+        </div>
+      ) : (
+        <Group orientation="horizontal" className="flex flex-1 min-h-0 overflow-hidden">
+          {isDesktop && (
+            <>
+              <Panel
+                id="overview"
+                minSize={250}
+                maxSize={550}
+                defaultSize={320}
+                className="flex flex-col overflow-hidden"
+              >
+                <div className="flex items-center px-5 border-b border-border shrink-0 h-[41px]">
+                  <span className="text-sm font-medium">Overview</span>
+                </div>
+                <ScrollArea fade="mask" className="flex-1 min-h-0">
+                  {isLoading ? (
+                    <InfoPanelSkeleton />
+                  ) : isError || !sandbox ? (
+                    <div className="flex flex-col items-center justify-center gap-3 p-8 text-center text-muted-foreground">
+                      <p className="text-sm">Failed to load sandbox details.</p>
+                      <Button variant="outline" size="sm" onClick={() => refetch()}>
+                        <RefreshCw className="size-4" />
+                        Retry
+                      </Button>
+                    </div>
+                  ) : (
+                    <SandboxInfoPanel sandbox={sandbox} getRegionName={getRegionName} />
+                  )}
+                </ScrollArea>
+              </Panel>
+              <ResizableSeparator />
+            </>
+          )}
+          <Panel id="content" className="flex-1 min-w-0 flex flex-col overflow-hidden">
+            <SandboxContentTabs
+              sandbox={sandbox}
+              isLoading={isLoading}
+              experimentsEnabled={experimentsEnabled}
+              tab={tab}
+              onTabChange={setTab}
             />
-            <RevokeSshAccessDialog
-              sandboxId={sandboxId}
-              open={revokeSshDialogOpen}
-              onOpenChange={setRevokeSshDialogOpen}
-            />
-          </>
-        )}
-      </PageLayout>
-    </SandboxSessionProvider>
+          </Panel>
+        </Group>
+      )}
+
+      <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete Sandbox</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to delete this sandbox? This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deleteMutation.isPending}>Cancel</AlertDialogCancel>
+            <AlertDialogAction variant="destructive" onClick={handleDelete} disabled={deleteMutation.isPending}>
+              {deleteMutation.isPending ? 'Deleting...' : 'Delete'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {sandboxId && (
+        <>
+          <CreateSshAccessDialog
+            sandboxId={sandboxId}
+            open={createSshDialogOpen}
+            onOpenChange={setCreateSshDialogOpen}
+          />
+          <RevokeSshAccessDialog
+            sandboxId={sandboxId}
+            open={revokeSshDialogOpen}
+            onOpenChange={setRevokeSshDialogOpen}
+          />
+        </>
+      )}
+    </PageLayout>
   )
 }
 

--- a/apps/dashboard/src/components/sandboxes/SandboxFullscreenShell.tsx
+++ b/apps/dashboard/src/components/sandboxes/SandboxFullscreenShell.tsx
@@ -1,0 +1,39 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { CopyButton } from '@/components/CopyButton'
+import { Button } from '@/components/ui/button'
+import { RoutePath } from '@/enums/RoutePath'
+import { ArrowLeft } from 'lucide-react'
+import { type ReactNode } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+interface SandboxFullscreenShellProps {
+  sandboxId?: string
+  title?: string
+  copyValue?: string
+  children: ReactNode
+}
+
+export function SandboxFullscreenShell({ sandboxId, title, copyValue, children }: SandboxFullscreenShellProps) {
+  const navigate = useNavigate()
+
+  const handleBack = () => {
+    navigate(sandboxId ? RoutePath.SANDBOX_DETAILS.replace(':sandboxId', sandboxId) : RoutePath.SANDBOXES)
+  }
+
+  return (
+    <div className="flex h-[var(--app-content-height,calc(100svh_-_3.5rem))] flex-col bg-background">
+      <div className="flex min-w-0 shrink-0 items-center gap-2 border-b border-border px-3 py-1.5">
+        <Button variant="ghost" size="icon-sm" className="shrink-0" onClick={handleBack} aria-label="Back">
+          <ArrowLeft className="size-4" />
+        </Button>
+        <h1 className="min-w-0 truncate text-sm font-medium">{title || sandboxId || 'Sandbox'}</h1>
+        {copyValue && <CopyButton value={copyValue} tooltipText="Copy" size="icon-xs" />}
+      </div>
+      <div className="flex min-h-0 flex-1 flex-col">{children}</div>
+    </div>
+  )
+}

--- a/apps/dashboard/src/components/sandboxes/SandboxHeader.tsx
+++ b/apps/dashboard/src/components/sandboxes/SandboxHeader.tsx
@@ -38,7 +38,12 @@ interface SandboxHeaderProps {
   onCreateSshAccess: () => void
   onRevokeSshAccess: () => void
   onScreenRecordings: () => void
-  mutations: { start: boolean; stop: boolean; archive: boolean; recover: boolean }
+  mutations: {
+    start: boolean
+    stop: boolean
+    archive: boolean
+    recover: boolean
+  }
 }
 
 export function SandboxHeader({
@@ -61,7 +66,7 @@ export function SandboxHeader({
   mutations,
 }: SandboxHeaderProps) {
   return (
-    <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2 min-w-0 px-4 sm:px-5 py-2 border-b border-border shrink-0">
+    <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2 min-w-0 px-4 sm:px-5 py-1.5 sm:py-2 border-b border-border shrink-0">
       <div className="flex items-center gap-2 min-w-0">
         <Button variant="ghost" size="icon-sm" className="shrink-0" onClick={onBack}>
           <ArrowLeft className="size-4" />
@@ -74,7 +79,7 @@ export function SandboxHeader({
               <h2 className="text-base font-medium truncate">{sandbox.name || sandbox.id}</h2>
               <CopyButton value={sandbox.name || sandbox.id} tooltipText="Copy name" size="icon-xs" />
             </div>
-            <div className="flex items-center gap-1 min-w-0">
+            <div className="hidden sm:flex items-center gap-1 min-w-0">
               <span className="text-xs text-muted-foreground shrink-0">UUID</span>
               <span className="text-sm text-muted-foreground font-mono truncate">{sandbox.id}</span>
               <CopyButton value={sandbox.id} tooltipText="Copy ID" size="icon-xs" />
@@ -122,6 +127,12 @@ export function SandboxHeader({
                       </Button>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="end" className="w-48">
+                      <DropdownMenuGroup className="sm:hidden">
+                        <DropdownMenuItem onClick={onRefresh} disabled={isFetching}>
+                          Refresh
+                        </DropdownMenuItem>
+                        <DropdownMenuSeparator />
+                      </DropdownMenuGroup>
                       <DropdownMenuGroup>
                         <DropdownMenuItem onClick={onCreateSshAccess} disabled={actionsDisabled}>
                           Create SSH Access
@@ -158,7 +169,14 @@ export function SandboxHeader({
                   </DropdownMenu>
                 </ButtonGroup>
               )}
-              <Button variant="ghost" size="icon-sm" onClick={onRefresh} disabled={isFetching} title="Refresh">
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                onClick={onRefresh}
+                disabled={isFetching}
+                title="Refresh"
+                className="hidden sm:inline-flex"
+              >
                 {isFetching ? <Spinner className="size-4" /> : <RefreshCw className="size-4" />}
               </Button>
             </div>

--- a/apps/dashboard/src/components/sandboxes/SandboxTerminalFrame.tsx
+++ b/apps/dashboard/src/components/sandboxes/SandboxTerminalFrame.tsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import { ClipboardPaste, Maximize2 } from 'lucide-react'
+import { useEffect, useRef, type SyntheticEvent } from 'react'
+import { Link } from 'react-router-dom'
+import { buildTerminalIframeSrc, pasteIntoTerminalIframe, registerActiveTerminalFrame } from './terminalIframeSrc'
+
+interface SandboxTerminalFrameProps {
+  sessionUrl: string
+  fullscreenHref?: string
+  className?: string
+}
+
+export function SandboxTerminalFrame({ sessionUrl, fullscreenHref, className }: SandboxTerminalFrameProps) {
+  const frameRef = useRef<HTMLIFrameElement | null>(null)
+  const deregisterRef = useRef<(() => void) | null>(null)
+  const iframeSrc = buildTerminalIframeSrc(sessionUrl)
+
+  const handlePaste = async () => {
+    const frame = frameRef.current?.contentWindow
+    if (!frame) return
+    await pasteIntoTerminalIframe(frame, sessionUrl)
+  }
+
+  const handleLoad = (event: SyntheticEvent<HTMLIFrameElement>) => {
+    const frame = event.currentTarget.contentWindow
+    if (!frame) return
+    deregisterRef.current?.()
+    deregisterRef.current = registerActiveTerminalFrame(frame, sessionUrl)
+  }
+
+  useEffect(() => {
+    return () => {
+      deregisterRef.current?.()
+      deregisterRef.current = null
+    }
+  }, [])
+
+  return (
+    <div className={cn('relative min-h-0 bg-black', className)}>
+      <iframe
+        ref={frameRef}
+        title="Sandbox terminal"
+        src={iframeSrc}
+        onLoad={handleLoad}
+        className="absolute inset-0 h-full w-full border-0 bg-black"
+      />
+      <Button
+        type="button"
+        variant="secondary"
+        size="icon-sm"
+        className={cn('absolute top-2 opacity-60 hover:opacity-100', fullscreenHref ? 'right-12' : 'right-2')}
+        title="Paste from clipboard"
+        aria-label="Paste from clipboard"
+        onClick={handlePaste}
+      >
+        <ClipboardPaste className="size-4" />
+      </Button>
+      {fullscreenHref && (
+        <Button
+          asChild
+          variant="secondary"
+          size="icon-sm"
+          className="absolute right-2 top-2 opacity-60 hover:opacity-100"
+          title="Fullscreen"
+        >
+          <Link to={fullscreenHref} aria-label="Open terminal fullscreen">
+            <Maximize2 className="size-4" />
+          </Link>
+        </Button>
+      )}
+    </div>
+  )
+}

--- a/apps/dashboard/src/components/sandboxes/SandboxTerminalFullscreen.tsx
+++ b/apps/dashboard/src/components/sandboxes/SandboxTerminalFullscreen.tsx
@@ -1,0 +1,140 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { useEffect, useState, type ReactNode } from 'react'
+import { Link, useParams } from 'react-router-dom'
+import { Button } from '@/components/ui/button'
+import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from '@/components/ui/empty'
+import { Spinner } from '@/components/ui/spinner'
+import { RoutePath } from '@/enums/RoutePath'
+import { useSandboxQuery } from '@/hooks/queries/useSandboxQuery'
+import { useTerminalSessionQuery } from '@/hooks/queries/useTerminalSessionQuery'
+import { useSandboxSessionContext } from '@/hooks/useSandboxSessionContext'
+import { useSandboxWsSync } from '@/hooks/useSandboxWsSync'
+import { isStoppable } from '@/lib/utils/sandbox'
+import { Container, Play, RefreshCw, TerminalSquare } from 'lucide-react'
+import { SandboxFullscreenShell } from './SandboxFullscreenShell'
+import { SandboxTerminalFrame } from './SandboxTerminalFrame'
+
+export default function SandboxTerminalFullscreen() {
+  const { sandboxId } = useParams<{ sandboxId: string }>()
+  const { data: sandbox, isLoading: sandboxLoading, isError: sandboxIsError } = useSandboxQuery(sandboxId ?? '')
+  useSandboxWsSync({ sandboxId })
+
+  const running = sandbox ? isStoppable(sandbox) : false
+  const { isTerminalActivated, activateTerminal } = useSandboxSessionContext()
+  const [activated, setActivated] = useState(() => (sandboxId ? isTerminalActivated(sandboxId) : false))
+
+  // Carry session activation across remounts
+  useEffect(() => {
+    if (sandboxId && isTerminalActivated(sandboxId)) setActivated(true)
+  }, [sandboxId, isTerminalActivated])
+
+  const {
+    data: session,
+    isLoading: sessionLoading,
+    isError: sessionError,
+    isFetching,
+    reset,
+  } = useTerminalSessionQuery(sandboxId ?? '', running && activated)
+
+  const handleConnect = () => {
+    if (!sandboxId) return
+    activateTerminal(sandboxId)
+    setActivated(true)
+  }
+
+  const backPath = sandboxId ? RoutePath.SANDBOX_DETAILS.replace(':sandboxId', sandboxId) : RoutePath.SANDBOXES
+
+  let body: ReactNode
+  if (sandboxLoading) {
+    body = (
+      <div className="flex-1 flex items-center justify-center gap-2 text-muted-foreground">
+        <Spinner className="size-4" />
+        <span className="text-sm">Loading sandbox...</span>
+      </div>
+    )
+  } else if (sandboxIsError || !sandbox) {
+    body = (
+      <Empty>
+        <EmptyHeader>
+          <EmptyMedia variant="icon">
+            <Container className="size-4" />
+          </EmptyMedia>
+          <EmptyTitle>Sandbox not found</EmptyTitle>
+          <EmptyDescription>Are you sure you're in the right organization?</EmptyDescription>
+        </EmptyHeader>
+        <Button variant="outline" size="sm" asChild>
+          <Link to={backPath}>Back</Link>
+        </Button>
+      </Empty>
+    )
+  } else if (!running) {
+    body = (
+      <Empty>
+        <EmptyHeader>
+          <EmptyMedia variant="icon">
+            <TerminalSquare className="size-4" />
+          </EmptyMedia>
+          <EmptyTitle>Sandbox is not running</EmptyTitle>
+          <EmptyDescription>Start the sandbox to access the terminal.</EmptyDescription>
+        </EmptyHeader>
+        <Button variant="outline" size="sm" asChild>
+          <Link to={backPath}>Back</Link>
+        </Button>
+      </Empty>
+    )
+  } else if (!activated) {
+    body = (
+      <Empty>
+        <EmptyHeader>
+          <EmptyMedia variant="icon">
+            <TerminalSquare className="size-4" />
+          </EmptyMedia>
+          <EmptyTitle>Terminal</EmptyTitle>
+          <EmptyDescription>Connect to an interactive terminal session in your sandbox.</EmptyDescription>
+        </EmptyHeader>
+        <Button onClick={handleConnect}>
+          <Play className="size-4" />
+          Connect
+        </Button>
+      </Empty>
+    )
+  } else if (sessionLoading || isFetching) {
+    body = (
+      <div className="flex-1 flex items-center justify-center gap-2 text-muted-foreground">
+        <Spinner className="size-4" />
+        <span className="text-sm">Connecting...</span>
+      </div>
+    )
+  } else if (sessionError || !session) {
+    body = (
+      <Empty>
+        <EmptyHeader>
+          <EmptyTitle>Failed to connect</EmptyTitle>
+          <EmptyDescription>Something went wrong while connecting to the terminal.</EmptyDescription>
+        </EmptyHeader>
+        <Button variant="outline" size="sm" onClick={() => reset()}>
+          <RefreshCw className="size-4" />
+          Retry
+        </Button>
+      </Empty>
+    )
+  } else {
+    body = <SandboxTerminalFrame sessionUrl={session.url} className="flex-1" />
+  }
+
+  const label = sandbox?.name || sandbox?.id || sandboxId
+
+  return (
+    <SandboxFullscreenShell
+      sandboxId={sandboxId}
+      title={label}
+      copyValue={sandbox ? sandbox.name || sandbox.id : undefined}
+    >
+      {body}
+    </SandboxFullscreenShell>
+  )
+}

--- a/apps/dashboard/src/components/sandboxes/SandboxTerminalTab.tsx
+++ b/apps/dashboard/src/components/sandboxes/SandboxTerminalTab.tsx
@@ -7,12 +7,14 @@ import { useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from '@/components/ui/empty'
 import { BOXLITE_DOCS_URL } from '@/constants/ExternalLinks'
+import { RoutePath } from '@/enums/RoutePath'
 import { useTerminalSessionQuery } from '@/hooks/queries/useTerminalSessionQuery'
 import { useSandboxSessionContext } from '@/hooks/useSandboxSessionContext'
 import { isStoppable } from '@/lib/utils/sandbox'
 import { Sandbox } from '@boxlite-ai/api-client'
 import { Spinner } from '@/components/ui/spinner'
 import { Play, RefreshCw, TerminalSquare } from 'lucide-react'
+import { SandboxTerminalFrame } from './SandboxTerminalFrame'
 
 export function SandboxTerminalTab({ sandbox }: { sandbox: Sandbox }) {
   const running = isStoppable(sandbox)
@@ -35,7 +37,7 @@ export function SandboxTerminalTab({ sandbox }: { sandbox: Sandbox }) {
 
   if (!running) {
     return (
-      <div className="flex-1 flex flex-col p-4">
+      <div className="flex-1 flex flex-col p-2 sm:p-4">
         <div className="flex-1 min-h-0 rounded-md border border-border flex">
           <Empty className="border-0">
             <EmptyHeader>
@@ -57,10 +59,10 @@ export function SandboxTerminalTab({ sandbox }: { sandbox: Sandbox }) {
     )
   }
 
-  // Not yet activated — show connect button
+  // Not yet activated - show connect button
   if (!activated) {
     return (
-      <div className="flex-1 flex flex-col p-4">
+      <div className="flex-1 flex flex-col p-2 sm:p-4">
         <div className="flex-1 min-h-0 rounded-md border border-border flex">
           <Empty className="border-0">
             <EmptyHeader>
@@ -89,7 +91,7 @@ export function SandboxTerminalTab({ sandbox }: { sandbox: Sandbox }) {
   // Loading / fetching
   if (isLoading || isFetching) {
     return (
-      <div className="flex-1 flex flex-col p-4">
+      <div className="flex-1 flex flex-col p-2 sm:p-4">
         <div className="flex-1 min-h-0 rounded-md border border-border flex items-center justify-center gap-2 text-muted-foreground">
           <Spinner className="size-4" />
           <span className="text-sm">Connecting...</span>
@@ -101,7 +103,7 @@ export function SandboxTerminalTab({ sandbox }: { sandbox: Sandbox }) {
   // Error
   if (isError || !session) {
     return (
-      <div className="flex-1 flex flex-col p-4">
+      <div className="flex-1 flex flex-col p-2 sm:p-4">
         <div className="flex-1 min-h-0 rounded-md border border-border flex">
           <Empty className="border-0">
             <EmptyHeader>
@@ -119,10 +121,11 @@ export function SandboxTerminalTab({ sandbox }: { sandbox: Sandbox }) {
   }
 
   // Active session
+  const fullscreenHref = RoutePath.SANDBOX_TERMINAL.replace(':sandboxId', sandbox.id)
   return (
-    <div className="flex-1 flex flex-col p-4">
-      <div className="flex-1 min-h-0 rounded-md border border-border bg-black overflow-hidden p-1">
-        <iframe title="Sandbox terminal" src={session.url} className="w-full h-full border-0" />
+    <div className="flex-1 flex flex-col p-2 sm:p-4">
+      <div className="relative flex-1 min-h-0 rounded-md border border-border bg-black overflow-hidden p-1">
+        <SandboxTerminalFrame sessionUrl={session.url} fullscreenHref={fullscreenHref} className="h-full" />
       </div>
     </div>
   )

--- a/apps/dashboard/src/components/sandboxes/SandboxVncFullscreen.tsx
+++ b/apps/dashboard/src/components/sandboxes/SandboxVncFullscreen.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Link, useParams } from 'react-router-dom'
+import { Button } from '@/components/ui/button'
+import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from '@/components/ui/empty'
+import { Spinner } from '@/components/ui/spinner'
+import { RoutePath } from '@/enums/RoutePath'
+import { useSandboxQuery } from '@/hooks/queries/useSandboxQuery'
+import { useSandboxWsSync } from '@/hooks/useSandboxWsSync'
+import { Container } from 'lucide-react'
+import { SandboxFullscreenShell } from './SandboxFullscreenShell'
+import { SandboxVncTab } from './SandboxVncTab'
+
+export default function SandboxVncFullscreen() {
+  const { sandboxId } = useParams<{ sandboxId: string }>()
+  const { data: sandbox, isLoading, isError } = useSandboxQuery(sandboxId ?? '')
+  useSandboxWsSync({ sandboxId })
+
+  const label = sandbox?.name || sandbox?.id || sandboxId
+  const backPath = sandboxId ? RoutePath.SANDBOX_DETAILS.replace(':sandboxId', sandboxId) : RoutePath.SANDBOXES
+
+  return (
+    <SandboxFullscreenShell
+      sandboxId={sandboxId}
+      title={label}
+      copyValue={sandbox ? sandbox.name || sandbox.id : undefined}
+    >
+      {isLoading ? (
+        <div className="flex flex-1 items-center justify-center gap-2 text-muted-foreground">
+          <Spinner className="size-4" />
+          <span className="text-sm">Loading sandbox...</span>
+        </div>
+      ) : isError || !sandbox ? (
+        <Empty>
+          <EmptyHeader>
+            <EmptyMedia variant="icon">
+              <Container className="size-4" />
+            </EmptyMedia>
+            <EmptyTitle>Sandbox not found</EmptyTitle>
+            <EmptyDescription>Are you sure you're in the right organization?</EmptyDescription>
+          </EmptyHeader>
+          <Button variant="outline" size="sm" asChild>
+            <Link to={backPath}>Back</Link>
+          </Button>
+        </Empty>
+      ) : (
+        <SandboxVncTab sandbox={sandbox} variant="fullscreen" />
+      )}
+    </SandboxFullscreenShell>
+  )
+}

--- a/apps/dashboard/src/components/sandboxes/SandboxVncTab.tsx
+++ b/apps/dashboard/src/components/sandboxes/SandboxVncTab.tsx
@@ -3,21 +3,34 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
+import { Link } from 'react-router-dom'
 import { Button } from '@/components/ui/button'
 import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from '@/components/ui/empty'
 import { BOXLITE_DOCS_URL } from '@/constants/ExternalLinks'
+import { RoutePath } from '@/enums/RoutePath'
 import { useStartVncMutation } from '@/hooks/mutations/useStartVncMutation'
 import { useVncInitialStatusQuery, useVncPollStatusQuery } from '@/hooks/queries/useVncStatusQuery'
 import { useVncSessionQuery } from '@/hooks/queries/useVncSessionQuery'
+import { cn } from '@/lib/utils'
 import { isStoppable } from '@/lib/utils/sandbox'
 import { Sandbox } from '@boxlite-ai/api-client'
 import { Spinner } from '@/components/ui/spinner'
-import { Monitor, Play, RefreshCw } from 'lucide-react'
+import { Maximize2, Monitor, Play, RefreshCw } from 'lucide-react'
+import { type ReactNode } from 'react'
 
 const VNC_MISSING_DEPS_MSG = 'Computer-use functionality is not available'
 
-export function SandboxVncTab({ sandbox }: { sandbox: Sandbox }) {
+export function SandboxVncTab({ sandbox, variant = 'tab' }: { sandbox: Sandbox; variant?: 'tab' | 'fullscreen' }) {
   const running = isStoppable(sandbox)
+  const fullscreen = variant === 'fullscreen'
+
+  const renderPanel = (children: ReactNode, className?: string) => (
+    <div className={cn('flex flex-1 flex-col', !fullscreen && 'p-2 sm:p-4')}>
+      <div className={cn('flex min-h-0 flex-1', !fullscreen && 'rounded-md border border-border', className)}>
+        {children}
+      </div>
+    </div>
+  )
 
   // 1. Check initial VNC availability & status
   const initialStatusQuery = useVncInitialStatusQuery(sandbox.id, running)
@@ -54,143 +67,138 @@ export function SandboxVncTab({ sandbox }: { sandbox: Sandbox }) {
   const anyError = startError && !startMissingDeps ? startError : pollError
 
   if (!running) {
-    return (
-      <div className="flex-1 flex flex-col p-4">
-        <div className="flex-1 min-h-0 rounded-md border border-border flex">
-          <Empty className="border-0">
-            <EmptyHeader>
-              <EmptyMedia variant="icon">
-                <Monitor className="size-4" />
-              </EmptyMedia>
-              <EmptyTitle>Sandbox is not running</EmptyTitle>
-              <EmptyDescription>
-                Start the sandbox to access the VNC desktop.{' '}
-                <a href={`${BOXLITE_DOCS_URL}/en/vnc-access`} target="_blank" rel="noopener noreferrer">
-                  Learn more
-                </a>
-                .
-              </EmptyDescription>
-            </EmptyHeader>
-          </Empty>
-        </div>
-      </div>
+    return renderPanel(
+      <Empty className="border-0">
+        <EmptyHeader>
+          <EmptyMedia variant="icon">
+            <Monitor className="size-4" />
+          </EmptyMedia>
+          <EmptyTitle>Sandbox is not running</EmptyTitle>
+          <EmptyDescription>
+            Start the sandbox to access the VNC desktop.{' '}
+            <a href={`${BOXLITE_DOCS_URL}/en/vnc-access`} target="_blank" rel="noopener noreferrer">
+              Learn more
+            </a>
+            .
+          </EmptyDescription>
+        </EmptyHeader>
+      </Empty>,
     )
   }
 
   if (initialStatusQuery.isLoading) {
-    return (
-      <div className="flex-1 flex flex-col p-4">
-        <div className="flex-1 min-h-0 rounded-md border border-border flex items-center justify-center gap-2 text-muted-foreground">
-          <Spinner className="size-4" />
-          <span className="text-sm">Checking VNC status...</span>
-        </div>
-      </div>
+    return renderPanel(
+      <>
+        <Spinner className="size-4" />
+        <span className="text-sm">Checking VNC status...</span>
+      </>,
+      'items-center justify-center gap-2 text-muted-foreground',
     )
   }
 
   if (unavailable) {
-    return (
-      <div className="flex-1 flex flex-col p-4">
-        <div className="flex-1 min-h-0 rounded-md border border-border flex">
-          <Empty className="border-0">
-            <EmptyHeader>
-              <EmptyMedia variant="icon">
-                <Monitor className="size-4" />
-              </EmptyMedia>
-              <EmptyTitle>VNC not available</EmptyTitle>
-              <EmptyDescription>
-                Computer-use dependencies are not installed in this sandbox.{' '}
-                <a href={`${BOXLITE_DOCS_URL}/en/vnc-access`} target="_blank" rel="noopener noreferrer">
-                  Read the setup guide
-                </a>
-                .
-              </EmptyDescription>
-            </EmptyHeader>
-          </Empty>
-        </div>
-      </div>
+    return renderPanel(
+      <Empty className="border-0">
+        <EmptyHeader>
+          <EmptyMedia variant="icon">
+            <Monitor className="size-4" />
+          </EmptyMedia>
+          <EmptyTitle>VNC not available</EmptyTitle>
+          <EmptyDescription>
+            Computer-use dependencies are not installed in this sandbox.{' '}
+            <a href={`${BOXLITE_DOCS_URL}/en/vnc-access`} target="_blank" rel="noopener noreferrer">
+              Read the setup guide
+            </a>
+            .
+          </EmptyDescription>
+        </EmptyHeader>
+      </Empty>,
     )
   }
 
-  // Not yet started — show start button
+  // Not yet started - show start button
   if (!vncReady && !isStarting) {
-    return (
-      <div className="flex-1 flex flex-col p-4">
-        <div className="flex-1 min-h-0 rounded-md border border-border flex">
-          <Empty className="border-0">
-            <EmptyHeader>
-              <EmptyMedia variant="icon">
-                <Monitor className="size-4" />
-              </EmptyMedia>
-              <EmptyTitle>VNC Desktop</EmptyTitle>
-              <EmptyDescription>
-                Start the VNC server to access a graphical desktop.{' '}
-                <a href={`${BOXLITE_DOCS_URL}/en/vnc-access`} target="_blank" rel="noopener noreferrer">
-                  Learn more
-                </a>
-                .
-              </EmptyDescription>
-            </EmptyHeader>
-            <Button onClick={() => startMutation.mutate()}>
-              <Play className="size-4" />
-              Start VNC
-            </Button>
-          </Empty>
-        </div>
-      </div>
+    return renderPanel(
+      <Empty className="border-0">
+        <EmptyHeader>
+          <EmptyMedia variant="icon">
+            <Monitor className="size-4" />
+          </EmptyMedia>
+          <EmptyTitle>VNC Desktop</EmptyTitle>
+          <EmptyDescription>
+            Start the VNC server to access a graphical desktop.{' '}
+            <a href={`${BOXLITE_DOCS_URL}/en/vnc-access`} target="_blank" rel="noopener noreferrer">
+              Learn more
+            </a>
+            .
+          </EmptyDescription>
+        </EmptyHeader>
+        <Button onClick={() => startMutation.mutate()}>
+          <Play className="size-4" />
+          Start VNC
+        </Button>
+      </Empty>,
     )
   }
 
   // Starting / polling / getting URL
   if (isStarting) {
-    return (
-      <div className="flex-1 flex flex-col p-4">
-        <div className="flex-1 min-h-0 rounded-md border border-border bg-neutral-950 flex items-center justify-center gap-2 text-muted-foreground">
-          <Spinner className="size-4" />
-          <span className="text-sm">
-            {startMutation.isPending
-              ? 'Starting VNC desktop...'
-              : vncReady && sessionLoading
-                ? 'Getting preview URL...'
-                : 'Waiting for VNC to become ready...'}
-          </span>
-        </div>
-      </div>
+    return renderPanel(
+      <>
+        <Spinner className="size-4" />
+        <span className="text-sm">
+          {startMutation.isPending
+            ? 'Starting VNC desktop...'
+            : vncReady && sessionLoading
+              ? 'Getting preview URL...'
+              : 'Waiting for VNC to become ready...'}
+        </span>
+      </>,
+      'items-center justify-center gap-2 bg-neutral-950 text-muted-foreground',
     )
   }
 
   // Error
   if (anyError || sessionError) {
-    return (
-      <div className="flex-1 flex flex-col p-4">
-        <div className="flex-1 min-h-0 rounded-md border border-border flex">
-          <Empty className="border-0">
-            <EmptyHeader>
-              <EmptyTitle>Failed to connect</EmptyTitle>
-              <EmptyDescription>{anyError || 'Something went wrong while connecting to VNC.'}</EmptyDescription>
-            </EmptyHeader>
-            <Button variant="outline" size="sm" onClick={reset}>
-              <RefreshCw className="size-4" />
-              Retry
-            </Button>
-          </Empty>
-        </div>
-      </div>
+    return renderPanel(
+      <Empty className="border-0">
+        <EmptyHeader>
+          <EmptyTitle>Failed to connect</EmptyTitle>
+          <EmptyDescription>{anyError || 'Something went wrong while connecting to VNC.'}</EmptyDescription>
+        </EmptyHeader>
+        <Button variant="outline" size="sm" onClick={reset}>
+          <RefreshCw className="size-4" />
+          Retry
+        </Button>
+      </Empty>,
     )
   }
 
   // Active session
   if (session) {
-    return (
-      <div className="flex-1 flex flex-col p-4">
-        <div className="flex-1 min-h-0 rounded-md border border-border bg-neutral-950 overflow-hidden">
-          <iframe
-            title="VNC desktop"
-            src={`${session.url}/vnc.html?autoconnect=true&resize=scale`}
-            className="w-full h-full border-0"
-          />
-        </div>
-      </div>
+    const fullscreenHref = RoutePath.SANDBOX_VNC.replace(':sandboxId', sandbox.id)
+    return renderPanel(
+      <>
+        <iframe
+          title="VNC desktop"
+          src={`${session.url}/vnc.html?autoconnect=true&resize=scale`}
+          className="h-full w-full border-0"
+        />
+        {!fullscreen && (
+          <Button
+            asChild
+            variant="secondary"
+            size="icon-sm"
+            className="absolute right-2 top-2 opacity-60 hover:opacity-100"
+            title="Fullscreen"
+          >
+            <Link to={fullscreenHref} aria-label="Open VNC fullscreen">
+              <Maximize2 className="size-4" />
+            </Link>
+          </Button>
+        )}
+      </>,
+      'relative overflow-hidden bg-neutral-950',
     )
   }
 

--- a/apps/dashboard/src/components/sandboxes/index.ts
+++ b/apps/dashboard/src/components/sandboxes/index.ts
@@ -4,6 +4,8 @@
  */
 
 export { default as SandboxDetails } from './SandboxDetails'
+export { default as SandboxTerminalFullscreen } from './SandboxTerminalFullscreen'
+export { default as SandboxVncFullscreen } from './SandboxVncFullscreen'
 export { SandboxLogsTab } from './SandboxLogsTab'
 export { SandboxTracesTab } from './SandboxTracesTab'
 export { SandboxMetricsTab } from './SandboxMetricsTab'

--- a/apps/dashboard/src/components/sandboxes/terminalIframeSrc.ts
+++ b/apps/dashboard/src/components/sandboxes/terminalIframeSrc.ts
@@ -1,0 +1,144 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+/**
+ * Bridge for the sandbox-controlled terminal iframe.
+ *
+ * Only the bounded font-size scalar is forwarded on the iframe URL. User
+ * snippets or custom key sequences stay out of URL/query/postMessage paths.
+ */
+
+const FONT_SIZE_KEY = 'boxlite.terminal.fontSize'
+
+function readNumber(key: string, min: number, max: number): number | null {
+  try {
+    const raw = window.localStorage.getItem(key)
+    if (!raw) return null
+    const n = parseInt(raw, 10)
+    if (!Number.isFinite(n) || n < min || n > max) return null
+    return n
+  } catch {
+    return null
+  }
+}
+
+export function buildTerminalIframeSrc(baseUrl: string): string {
+  if (typeof window === 'undefined') return baseUrl
+  ensureTerminalPrefListener()
+  let url: URL
+  try {
+    url = new URL(baseUrl)
+  } catch {
+    return baseUrl
+  }
+
+  // Only the non-sensitive font-size scalar is allowed on the URL.
+  // See module docstring for the sensitivity classification.
+  const fs = readNumber(FONT_SIZE_KEY, 8, 32)
+  if (fs !== null) url.searchParams.set('fs', String(fs))
+
+  return url.toString()
+}
+
+let listenerInstalled = false
+
+// Registered iframe windows are allowed to persist non-sensitive prefs and
+// receive paste replies with a precise targetOrigin. Registration is not a
+// user gesture, so iframe-originated messages never trigger clipboard reads.
+const activeTerminalFrames = new Map<Window, string>()
+
+export function registerActiveTerminalFrame(frame: Window, sessionUrl: string): () => void {
+  if (typeof window === 'undefined') return () => {}
+  let origin: string
+  try {
+    origin = new URL(sessionUrl).origin
+  } catch {
+    return () => {}
+  }
+  activeTerminalFrames.set(frame, origin)
+  return () => {
+    if (activeTerminalFrames.get(frame) === origin) activeTerminalFrames.delete(frame)
+  }
+}
+
+function ensureTerminalPrefListener() {
+  if (listenerInstalled || typeof window === 'undefined') return
+  listenerInstalled = true
+  window.addEventListener('message', (event) => {
+    const data = event.data as unknown
+    if (!data || typeof data !== 'object') return
+    const msg = data as {
+      source?: unknown
+      type?: unknown
+      key?: unknown
+      value?: unknown
+    }
+    if (msg.source !== 'boxlite-terminal') return
+
+    const senderFrame = event.source as Window | null
+    if (!senderFrame) return
+    const registeredOrigin = activeTerminalFrames.get(senderFrame)
+    if (!registeredOrigin) return
+    if (event.origin !== registeredOrigin) return
+
+    if (msg.type === 'pref') {
+      if (msg.key === 'fontSize' && typeof msg.value === 'number' && msg.value >= 8 && msg.value <= 32) {
+        try {
+          window.localStorage.setItem(FONT_SIZE_KEY, String(Math.round(msg.value)))
+        } catch {
+          /* localStorage may be blocked; persistence is best effort. */
+        }
+      }
+      return
+    }
+
+    if (msg.type === 'ready') {
+      // Handshake ping only; no user-supplied terminal data is sent back.
+      return
+    }
+
+    // In particular, iframe-originated paste requests are ignored.
+  })
+}
+
+/**
+ * Triggered by a dashboard-rendered Paste button. Because the click handler
+ * runs in the dashboard document, `navigator.clipboard.readText()` carries
+ * the dashboard's user activation. The text is posted to the registered
+ * iframe origin, never `'*'`.
+ *
+ * Clickjacking defence: if the dashboard itself is framed by a third party,
+ * a malicious parent could overlay this button and trick the user into
+ * leaking their host clipboard. Refuse to read clipboard from a framed
+ * dashboard. Deployments should also enforce CSP `frame-ancestors 'none'`
+ * (or `X-Frame-Options: DENY`) on the dashboard HTML response; this
+ * runtime check is defence in depth, not a substitute.
+ */
+export async function pasteIntoTerminalIframe(frame: Window, sessionUrl: string): Promise<void> {
+  if (typeof navigator === 'undefined' || !navigator.clipboard?.readText) return
+  if (typeof window !== 'undefined' && window.top !== window.self) return
+  // Prefer the origin recorded at iframe load; sessionUrl is only a pre-load fallback.
+  let targetOrigin = activeTerminalFrames.get(frame)
+  if (!targetOrigin) {
+    try {
+      targetOrigin = new URL(sessionUrl).origin
+    } catch {
+      return
+    }
+  }
+  let text: string
+  try {
+    text = await navigator.clipboard.readText()
+  } catch {
+    // User denied, no user gesture propagated, or the API is unavailable.
+    return
+  }
+  if (!text) return
+  try {
+    frame.postMessage({ source: 'boxlite-terminal', type: 'paste', text }, targetOrigin)
+  } catch {
+    /* Frame may have been closed between gesture and reply. */
+  }
+}

--- a/apps/dashboard/src/enums/RoutePath.ts
+++ b/apps/dashboard/src/enums/RoutePath.ts
@@ -44,6 +44,8 @@ export enum RoutePath {
   WEBHOOK_ENDPOINT_DETAILS = '/dashboard/webhooks/:endpointId',
   // Sandboxes
   SANDBOX_DETAILS = '/dashboard/sandboxes/:sandboxId',
+  SANDBOX_TERMINAL = '/dashboard/sandboxes/:sandboxId/terminal',
+  SANDBOX_VNC = '/dashboard/sandboxes/:sandboxId/vnc',
 
   // Email verification
   EMAIL_VERIFY = '/dashboard/organization/:organizationId/verify-email/:email/:token',

--- a/apps/dashboard/src/pages/Dashboard.tsx
+++ b/apps/dashboard/src/pages/Dashboard.tsx
@@ -53,7 +53,11 @@ function useDashboardCommands() {
     ],
     [],
   )
-  useRegisterCommands(helpCommands, { groupId: 'help', groupLabel: 'Help', groupOrder: 2 })
+  useRegisterCommands(helpCommands, {
+    groupId: 'help',
+    groupLabel: 'Help',
+    groupOrder: 2,
+  })
 
   const globalCommands: CommandConfig[] = useMemo(
     () => [
@@ -66,7 +70,11 @@ function useDashboardCommands() {
     ],
     [theme, setTheme],
   )
-  useRegisterCommands(globalCommands, { groupId: 'global', groupLabel: 'Global', groupOrder: 5 })
+  useRegisterCommands(globalCommands, {
+    groupId: 'global',
+    groupLabel: 'Global',
+    groupOrder: 5,
+  })
 }
 
 const Dashboard: React.FC = () => {
@@ -137,14 +145,20 @@ const Dashboard: React.FC = () => {
   }
 
   return (
-    <div className={cn('relative w-full', isBannerVisible ? 'pt-16 md:pt-12' : '')}>
+    <div
+      className={cn(
+        'relative w-full [--app-content-height:calc(100svh_-_3.5rem)]',
+        isBannerVisible &&
+          'pt-16 [--app-banner-height:4rem] [--app-content-height:calc(100svh_-_3.5rem_-_var(--app-banner-height))] md:pt-12 md:[--app-banner-height:3rem]',
+      )}
+    >
       {isBannerVisible && bannerText && (
         <AnnouncementBanner text={bannerText} onDismiss={handleDismissBanner} learnMoreUrl={bannerLearnMoreUrl} />
       )}
       <SidebarProvider isBannerVisible={false} defaultOpen={true} className="flex-col">
         <Sidebar isBannerVisible={isBannerVisible} billingEnabled={!!config.billingApiUrl} version={config.version} />
         <SidebarInset className="min-h-0 overflow-visible">
-          <div className="w-full min-h-[calc(100svh-3.5rem)] overscroll-none">
+          <div className="w-full min-h-[var(--app-content-height,calc(100svh_-_3.5rem))] overscroll-none">
             <Outlet />
             <CommandPalette />
           </div>


### PR DESCRIPTION
## Summary
- New `/sandboxes/:id/terminal` and `/sandboxes/:id/vnc` fullscreen routes share a single `SandboxSessionProvider` so activation survives navigation; details/header collapse on mobile and a `--app-content-height` CSS var carries the banner-aware viewport budget to every page.
- Daemon terminal HTML gains a viewport-meta + `svh`/`dvh` body, a `ResizeObserver`+`visualViewport`+`orientationchange` refit chain, IME-hardened helper textarea, and a soft-keys toolbar (Esc/Tab/Ctrl/Alt/arrows/|//~/Trackpad/Keyboard) using shadcn dark tokens, with sticky modifiers and pinch-to-zoom.
- Clipboard paste is parent-mediated: a dashboard-rendered Paste button reads under the dashboard's user activation and `postMessage`s to the iframe's registered origin; iframe-originated paste requests are dropped. xterm pinned to 5.3.0 (avoids 6.x touch-scroll regression).

## Test plan
- [ ] Open a running sandbox on a phone (or DevTools iPhone 12 Pro emulation): Terminal tab is edge-to-edge; the `⛶` opens `/sandboxes/:id/terminal` fullscreen.
- [ ] Focus the terminal, raise the soft keyboard: viewport shrinks, cursor stays in view; soft-keys row is visible above the OS keyboard.
- [ ] Tap `Ctrl` then `c` on the OS keyboard: SIGINT fires. Double-tap `Ctrl` to lock; verify next two keys are also Ctrl-modified.
- [ ] Drag the `↕` trackpad button: cursor moves; lifting releases without emitting stray arrows.
- [ ] Pinch two fingers on the terminal: font size scales between 8 and 32 and persists across reloads.
- [ ] Click the Paste button: dashboard prompts for clipboard, text appears in the shell (with bracketed-paste wrapper when the remote shell enabled it).
- [ ] Read-only viewer on mobile can still see the sandbox (note: refresh is currently gated behind the writePermitted dropdown — separate fix incoming).
- [ ] Desktop ≥1024px: no soft-keys, no fullscreen affordance change, full sidebar/tabs unchanged.
- [ ] VNC tab: `⛶` opens fullscreen VNC; fullscreen variant has no extra chrome.