### PR TITLE
fix(runner): SSH gateway uses BoxLite exec (ssh -p 2222 back online)

### DIFF
--- a/apps/runner/pkg/api/controllers/proxy.go
+++ b/apps/runner/pkg/api/controllers/proxy.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/boxlite-ai/runner/pkg/runner"
+	"github.com/boxlite-ai/runner/pkg/shellutil"
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
 )
@@ -111,7 +112,8 @@ func handleWebSocketTerminal(ctx *gin.Context, r *runner.Runner, sandboxId strin
 	defer cancelKeepalive()
 	go runTerminalKeepalive(keepaliveCtx, ws, &writeMu, logger)
 
-	execution, err := r.Boxlite.StartExecution(ctx.Request.Context(), sandboxId, "/bin/sh", nil, wsWriter, wsWriter, true)
+	shellCmd, shellArgs := shellutil.DefaultInteractiveShell()
+	execution, err := r.Boxlite.StartExecution(ctx.Request.Context(), sandboxId, shellCmd, shellArgs, wsWriter, wsWriter, true)
 	if err != nil {
 		logger.Warn("failed to start terminal execution", "sandbox", sandboxId, "error", err)
 		writeMu.Lock()

--- a/apps/runner/pkg/shellutil/launcher.go
+++ b/apps/runner/pkg/shellutil/launcher.go
@@ -1,0 +1,47 @@
+// Copyright 2025 BoxLite AI (originally Daytona Platforms Inc.
+// Modified by BoxLite AI, 2025-2026
+// SPDX-License-Identifier: AGPL-3.0
+
+// Package shellutil contains shared decisions about how to spawn an
+// interactive shell inside a sandbox VM. All three entry points that drop
+// the user into a shell — the SSH gateway (sshgateway.Service), the
+// dashboard's WebSocket terminal handler (controllers.handleWebSocketTerminal),
+// and the proxy's iframe-terminal endpoint — should use the same selection
+// logic so users see the same prompt regardless of how they arrived.
+package shellutil
+
+// DefaultInteractiveShell returns the command + args to pass to
+// boxlite.Client.StartExecution when the caller wants an interactive shell
+// session and the user has NOT supplied a specific command.
+//
+// Strategy: a POSIX `/bin/sh -c` launcher picks the best available shell
+// inside the VM at exec time and execs it as a login shell:
+//
+//	exec $(command -v bash || command -v ash || command -v sh) -l
+//
+// Why this shape:
+//
+//   - `/bin/sh` is required by POSIX, so the launcher process itself always
+//     starts. We don't have to guess what the VM ships before we connect.
+//   - `command -v` is POSIX and works on busybox/alpine (the default
+//     BoxLite snapshot), bash-only distros, and everything in between.
+//     Trying bash first, then ash, then sh matches user preference for
+//     bash where it exists while falling through cleanly on minimal images.
+//   - `exec` replaces the launcher sh in-place — no extra PID hangs around
+//     and the chosen shell becomes pid 1 of the SSH/terminal session.
+//   - `-l` makes it a *login* shell: ~/.profile or ~/.bash_profile is
+//     sourced, PWD is set to HOME, PATH is populated. That matches what
+//     `ssh user@host` users expect when they land at a prompt.
+//
+// This follows the kubectl exec convention for unknown container images
+// (see https://kubernetes.io/docs/reference/kubectl/generated/kubectl_exec/),
+// which is the closest established pattern for "spawn a shell inside a
+// container/VM I don't fully control."
+//
+// If you need a specific shell (e.g. running a one-shot command from a
+// `ssh user@host "ls -la"` invocation), skip this helper and pass
+// `/bin/sh` with `-c <command>` directly — there is no ambiguity to
+// resolve in that case.
+func DefaultInteractiveShell() (command string, args []string) {
+	return "/bin/sh", []string{"-c", "exec $(command -v bash || command -v ash || command -v sh) -l"}
+}

--- a/apps/runner/pkg/shellutil/launcher.go
+++ b/apps/runner/pkg/shellutil/launcher.go
@@ -14,23 +14,30 @@ package shellutil
 // boxlite.Client.StartExecution when the caller wants an interactive shell
 // session and the user has NOT supplied a specific command.
 //
-// Strategy: a POSIX `/bin/sh -c` launcher picks the best available shell
-// inside the VM at exec time and execs it as a login shell:
+// Strategy: a POSIX `/bin/sh -c` launcher cd's to the user's home and
+// execs the best available shell as a login shell:
 //
+//	cd "${HOME:-/root}" 2>/dev/null || cd /;
 //	exec $(command -v bash || command -v ash || command -v sh) -l
 //
 // Why this shape:
 //
 //   - `/bin/sh` is required by POSIX, so the launcher process itself always
 //     starts. We don't have to guess what the VM ships before we connect.
+//   - The `cd "$HOME"` step mirrors OpenSSH `sshd`'s chdir(pw_dir) before
+//     exec'ing the user's shell. Without it the session lands at `/`,
+//     which is jarring and breaks `~/.something` references in shell
+//     startup files. `${HOME:-/root}` falls back to /root because the
+//     default BoxLite snapshot runs as root with HOME=/root; `|| cd /`
+//     keeps the launcher running even on minimal images that lack /root.
 //   - `command -v` is POSIX and works on busybox/alpine (the default
 //     BoxLite snapshot), bash-only distros, and everything in between.
 //     Trying bash first, then ash, then sh matches user preference for
 //     bash where it exists while falling through cleanly on minimal images.
 //   - `exec` replaces the launcher sh in-place — no extra PID hangs around
 //     and the chosen shell becomes pid 1 of the SSH/terminal session.
-//   - `-l` makes it a *login* shell: ~/.profile or ~/.bash_profile is
-//     sourced, PWD is set to HOME, PATH is populated. That matches what
+//   - `-l` makes it a *login* shell: /etc/profile and ~/.profile are
+//     sourced, PATH is populated. Pairs with the cd above to match what
 //     `ssh user@host` users expect when they land at a prompt.
 //
 // This follows the kubectl exec convention for unknown container images
@@ -43,5 +50,30 @@ package shellutil
 // `/bin/sh` with `-c <command>` directly — there is no ambiguity to
 // resolve in that case.
 func DefaultInteractiveShell() (command string, args []string) {
-	return "/bin/sh", []string{"-c", "exec $(command -v bash || command -v ash || command -v sh) -l"}
+	return "/bin/sh", []string{"-c",
+		`cd "${HOME:-/root}" 2>/dev/null || cd /; ` +
+			`exec $(command -v bash || command -v ash || command -v sh) -l`,
+	}
+}
+
+// SftpSubsystem returns the command + args to spawn an SFTP server inside
+// the VM in response to an SSH `subsystem sftp` request (RFC 4254 §6.5;
+// modern OpenSSH scp defaults to this protocol).
+//
+// Probes the common install paths in order (alpine, debian-ish, RHEL-ish,
+// PATH) and refuses to exec an empty binary path — without the guard, a
+// missing sftp-server would land at `exec ` (no-op, exit 0) and the
+// client would see "Connection closed" with no explanation. The explicit
+// "not found" message lets users see the gap and fall back to
+// `scp -O -P 2222 ...` (legacy protocol over `exec`).
+func SftpSubsystem() (command string, args []string) {
+	return "/bin/sh", []string{"-c",
+		`bin=$(command -v sftp-server 2>/dev/null || ` +
+			`ls /usr/lib/openssh/sftp-server /usr/lib/ssh/sftp-server /usr/libexec/sftp-server /usr/libexec/openssh/sftp-server 2>/dev/null | head -n1); ` +
+			`if [ -z "$bin" ]; then ` +
+			`echo "boxlite: sftp-server not found in sandbox VM; install openssh-sftp-server (or 'apk add openssh-sftp-server'), or fall back to 'scp -O'" >&2; ` +
+			`exit 127; ` +
+			`fi; ` +
+			`exec "$bin"`,
+	}
 }

--- a/apps/runner/pkg/sshgateway/service.go
+++ b/apps/runner/pkg/sshgateway/service.go
@@ -16,6 +16,7 @@ import (
 
 	boxlitesdk "github.com/boxlite-ai/boxlite/sdks/go"
 	blclient "github.com/boxlite-ai/runner/pkg/boxlite"
+	"github.com/boxlite-ai/runner/pkg/shellutil"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -147,16 +148,20 @@ func (s *Service) handleChannel(ctx context.Context, newChannel ssh.NewChannel, 
 		return
 	}
 
+	// When a client opens a session without an explicit `exec` request
+	// (typical interactive ssh), pick the best available shell at exec
+	// time via the shared launcher used by the dashboard terminal too.
+	defaultCmd, defaultArgs := shellutil.DefaultInteractiveShell()
+
 	state := &sessionState{
 		log:           s.log,
 		boxlite:       s.boxlite,
 		sandboxId:     sandboxId,
 		clientChannel: clientChannel,
-		// Default command if the client opens a session without `exec` —
-		// most ssh clients send `pty-req` then `shell`, which lands here.
-		cmd:  "/bin/bash",
-		rows: 24,
-		cols: 80,
+		cmd:           defaultCmd,
+		args:          defaultArgs,
+		rows:          24,
+		cols:          80,
 	}
 
 	execCtx, cancelExec := context.WithCancel(ctx)

--- a/apps/runner/pkg/sshgateway/service.go
+++ b/apps/runner/pkg/sshgateway/service.go
@@ -7,12 +7,14 @@ package sshgateway
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"fmt"
 	"io"
 	"log/slog"
 	"net"
-	"time"
+	"sync"
 
+	boxlitesdk "github.com/boxlite-ai/boxlite/sdks/go"
 	blclient "github.com/boxlite-ai/runner/pkg/boxlite"
 	"golang.org/x/crypto/ssh"
 )
@@ -101,16 +103,15 @@ func (s *Service) Start(ctx context.Context) error {
 				continue
 			}
 
-			go s.handleConnection(conn, serverConfig)
+			go s.handleConnection(ctx, conn, serverConfig)
 		}
 	}
 }
 
 // handleConnection handles an individual SSH connection
-func (s *Service) handleConnection(conn net.Conn, serverConfig *ssh.ServerConfig) {
+func (s *Service) handleConnection(ctx context.Context, conn net.Conn, serverConfig *ssh.ServerConfig) {
 	defer conn.Close()
 
-	// Perform SSH handshake
 	serverConn, chans, reqs, err := ssh.NewServerConn(conn, serverConfig)
 	if err != nil {
 		s.log.Warn("Failed to handshake", "error", err)
@@ -120,161 +121,330 @@ func (s *Service) handleConnection(conn net.Conn, serverConfig *ssh.ServerConfig
 
 	sandboxId := serverConn.Permissions.Extensions["sandbox-id"]
 
-	// Handle global requests
-	go func() {
-		for req := range reqs {
-			if req == nil {
-				continue
-			}
-			s.log.Debug("Global request", "requestType", req.Type)
-			// For now, just discard requests, but in a full implementation
-			// these would be forwarded to the sandbox
-			if req.WantReply {
-				if err := req.Reply(false, []byte("not implemented")); err != nil {
-					s.log.Warn("Failed to reply to global request", "error", err)
-				}
-			}
-		}
-	}()
+	// Discard global requests; we don't currently forward any.
+	go ssh.DiscardRequests(reqs)
 
-	// Handle channels
 	for newChannel := range chans {
-		go s.handleChannel(newChannel, sandboxId)
+		go s.handleChannel(ctx, newChannel, sandboxId)
 	}
 }
 
-// handleChannel handles an individual SSH channel
-func (s *Service) handleChannel(newChannel ssh.NewChannel, sandboxId string) {
-	s.log.Debug("New channel", "channelType", newChannel.ChannelType(), "sandboxID", sandboxId)
+// handleChannel bridges an SSH session channel to an in-VM exec via the
+// BoxLite SDK (libkrun vsock), the same primitive the dashboard's WebSocket
+// terminal uses at apps/runner/pkg/api/controllers/proxy.go:114. There is no
+// host-side hostname lookup, no `ssh.Dial` to a sandbox-internal address —
+// the kernel routes the spawn through libkrun and pipes stdio over the
+// connection's file descriptors.
+func (s *Service) handleChannel(ctx context.Context, newChannel ssh.NewChannel, sandboxId string) {
+	if newChannel.ChannelType() != "session" {
+		_ = newChannel.Reject(ssh.UnknownChannelType, "only session channels are supported")
+		return
+	}
 
-	// Accept the channel from the client
 	clientChannel, clientRequests, err := newChannel.Accept()
 	if err != nil {
 		s.log.Warn("Could not accept client channel", "error", err)
 		return
 	}
-	defer clientChannel.Close()
 
-	// Connect to the sandbox container via toolbox
-	sandboxChannel, sandboxRequests, err := s.connectToSandbox(sandboxId, newChannel.ChannelType(), newChannel.ExtraData())
-	if err != nil {
-		s.log.Warn("Could not connect to sandbox", "sandboxID", sandboxId, "error", err)
-		clientChannel.Close()
+	state := &sessionState{
+		log:           s.log,
+		boxlite:       s.boxlite,
+		sandboxId:     sandboxId,
+		clientChannel: clientChannel,
+		// Default command if the client opens a session without `exec` —
+		// most ssh clients send `pty-req` then `shell`, which lands here.
+		cmd:  "/bin/bash",
+		rows: 24,
+		cols: 80,
+	}
+
+	execCtx, cancelExec := context.WithCancel(ctx)
+	defer cancelExec()
+
+	for req := range clientRequests {
+		if req == nil {
+			break
+		}
+		s.handleRequest(execCtx, state, req)
+		// Once the exec has started, channel teardown is driven by the
+		// exec's exit (see runExec); we just keep forwarding signal/env/
+		// window-change requests until the SSH channel is closed.
+	}
+
+	state.waitForExitAndClose()
+}
+
+// sessionState carries the per-channel mutable state across the request stream
+// and the spawned exec. Methods on it are not safe for concurrent use except
+// where explicitly noted (window-change runs on the request goroutine; the
+// stdin pump and exit waiter run on goroutines started by runExec).
+type sessionState struct {
+	log           *slog.Logger
+	boxlite       *blclient.Client
+	sandboxId     string
+	clientChannel ssh.Channel
+
+	// Negotiated before exec start.
+	withTTY bool
+	cmd     string
+	args    []string
+	rows    int
+	cols    int
+
+	// Set when runExec succeeds.
+	mu       sync.Mutex
+	exec     *boxlitesdk.Execution
+	started  bool
+	exitDone chan int // exit code (or -1 on error); closed by exit waiter
+}
+
+func (s *Service) handleRequest(ctx context.Context, st *sessionState, req *ssh.Request) {
+	switch req.Type {
+	case "pty-req":
+		dims := parsePtyReq(req.Payload)
+		st.withTTY = true
+		if dims.rows > 0 && dims.cols > 0 {
+			st.rows, st.cols = dims.rows, dims.cols
+		}
+		// Resize if already started (rare — clients usually send pty-req first).
+		if st.startedExec() {
+			st.resize(ctx)
+		}
+		_ = req.Reply(true, nil)
+
+	case "env":
+		// Accept env requests without forwarding; the in-VM exec runs in
+		// its own environment. This matches OpenSSH default behaviour
+		// for unknown env vars (silently ignored).
+		_ = req.Reply(true, nil)
+
+	case "shell":
+		_ = req.Reply(true, nil)
+		st.runExec(ctx, "shell")
+
+	case "exec":
+		cmd, ok := parseStringPayload(req.Payload)
+		if !ok {
+			_ = req.Reply(false, nil)
+			return
+		}
+		// SSH "exec" payload is a single command string; run via shell -c
+		// so the user can include pipes / redirects without us parsing.
+		st.cmd = "/bin/sh"
+		st.args = []string{"-c", cmd}
+		_ = req.Reply(true, nil)
+		st.runExec(ctx, "exec")
+
+	case "window-change":
+		dims := parseWindowChange(req.Payload)
+		if dims.rows > 0 && dims.cols > 0 {
+			st.rows, st.cols = dims.rows, dims.cols
+			if st.startedExec() {
+				st.resize(ctx)
+			}
+		}
+		// window-change has want_reply=false per RFC 4254.
+
+	case "signal":
+		// Best-effort: the SDK does not currently expose a kill primitive
+		// for in-flight executions other than Close(). Ignore for now.
+		// (Closing the channel triggers exec cleanup; that is enough for
+		// interactive sessions to terminate via Ctrl-C → SIGINT in pty.)
+
+	default:
+		s.log.Debug("Ignoring unsupported channel request", "type", req.Type, "sandboxID", st.sandboxId)
+		if req.WantReply {
+			_ = req.Reply(false, nil)
+		}
+	}
+}
+
+// runExec starts the in-VM exec and wires SSH-channel stdio to it. Idempotent:
+// a second `shell`/`exec` request after one has already started is a no-op.
+func (st *sessionState) runExec(ctx context.Context, kind string) {
+	st.mu.Lock()
+	if st.started {
+		st.mu.Unlock()
 		return
 	}
-	defer sandboxChannel.Close()
+	st.started = true
+	st.exitDone = make(chan int, 1)
+	st.mu.Unlock()
 
-	// Forward requests from client to sandbox
+	// In TTY mode, the in-VM kernel merges stdout/stderr onto the pty
+	// master, so both writers point at the SSH channel. Without a TTY,
+	// stderr goes to the SSH channel's extended (stderr) stream so the
+	// client can distinguish 1/2.
+	var stdout, stderr io.Writer = st.clientChannel, st.clientChannel.Stderr()
+	if st.withTTY {
+		stderr = st.clientChannel
+	}
+
+	st.log.Info("Starting exec in sandbox",
+		"sandboxID", st.sandboxId,
+		"cmd", st.cmd,
+		"tty", st.withTTY,
+		"kind", kind,
+	)
+
+	exec, err := st.boxlite.StartExecution(ctx, st.sandboxId, st.cmd, st.args, stdout, stderr, st.withTTY)
+	if err != nil {
+		st.log.Warn("Failed to start execution in sandbox", "sandboxID", st.sandboxId, "error", err)
+		_, _ = st.clientChannel.SendRequest("exit-status", false, exitStatusPayload(127))
+		_ = st.clientChannel.Close()
+		st.exitDone <- 127
+		close(st.exitDone)
+		return
+	}
+
+	st.mu.Lock()
+	st.exec = exec
+	st.mu.Unlock()
+
+	// Apply initial window size if pty-req sent dims.
+	if st.withTTY {
+		st.resize(ctx)
+	}
+
+	// Pump SSH channel stdin → exec stdin until either side closes.
 	go func() {
-		for req := range clientRequests {
-			if req == nil {
-				return
+		defer func() {
+			// Close stdin so the in-VM process sees EOF (some commands
+			// need this to exit). Errors are ignored — channel may already
+			// be torn down.
+			if exec.Stdin != nil {
+				_ = exec.Stdin.Close()
 			}
-			s.log.Debug("Client request", "requestType", req.Type, "sandboxID", sandboxId)
-
-			ok, err := sandboxChannel.SendRequest(req.Type, req.WantReply, req.Payload)
-			if req.WantReply {
-				if err != nil {
-					s.log.Warn("Failed to send request to sandbox", "requestType", req.Type, "sandboxID", sandboxId, "error", err)
-					if replyErr := req.Reply(false, []byte(err.Error())); replyErr != nil {
-						s.log.Warn("Failed to reply to client request", "error", replyErr)
-					}
-				} else {
-					if replyErr := req.Reply(ok, nil); replyErr != nil {
-						s.log.Warn("Failed to reply to client request", "error", replyErr)
-					}
-				}
-			}
+		}()
+		if _, err := io.Copy(exec.Stdin, st.clientChannel); err != nil && err != io.EOF {
+			st.log.Debug("stdin pump ended", "sandboxID", st.sandboxId, "error", err)
 		}
 	}()
 
-	// Forward requests from sandbox to client
+	// Wait for the in-VM process to exit, then send SSH exit-status and
+	// close the channel. This goroutine is the channel's owner-of-record
+	// for shutdown; the request loop returns naturally once the channel
+	// closes.
 	go func() {
-		for req := range sandboxRequests {
-			if req == nil {
-				return
-			}
-			s.log.Debug("Sandbox request", "requestType", req.Type, "sandboxID", sandboxId)
-
-			ok, err := clientChannel.SendRequest(req.Type, req.WantReply, req.Payload)
-			if req.WantReply {
-				if err != nil {
-					s.log.Warn("Failed to send request to client", "requestType", req.Type, "sandboxID", sandboxId, "error", err)
-					if replyErr := req.Reply(false, []byte(err.Error())); replyErr != nil {
-						s.log.Warn("Failed to reply to sandbox request", "error", replyErr)
-					}
-				} else {
-					if replyErr := req.Reply(ok, nil); replyErr != nil {
-						s.log.Warn("Failed to reply to sandbox request", "error", replyErr)
-					}
-				}
-			}
+		exitCode, werr := exec.Wait(ctx)
+		if werr != nil && exitCode == 0 {
+			// Surface plumbing errors as a non-zero exit; openssh maps
+			// 255 to "session closed by remote". Keep this distinct from
+			// a genuine 0 exit.
+			exitCode = 255
+			st.log.Warn("exec.Wait returned error",
+				"sandboxID", st.sandboxId, "error", werr)
 		}
+		st.log.Info("Exec completed",
+			"sandboxID", st.sandboxId, "exitCode", exitCode)
+		_, _ = st.clientChannel.SendRequest("exit-status", false, exitStatusPayload(exitCode))
+		_ = exec.Close()
+		_ = st.clientChannel.Close()
+		st.exitDone <- exitCode
+		close(st.exitDone)
 	}()
-
-	// Bidirectional data forwarding
-	go func() {
-		_, err := io.Copy(sandboxChannel, clientChannel)
-		if err != nil {
-			s.log.Debug("Client to sandbox copy error", "error", err)
-		}
-	}()
-
-	_, err = io.Copy(clientChannel, sandboxChannel)
-	if err != nil {
-		s.log.Debug("Sandbox to client copy error", "error", err)
-	}
-
-	s.log.Debug("Channel closed for sandbox", "sandboxID", sandboxId)
 }
 
-// connectToSandbox connects to the sandbox container via the toolbox
-func (s *Service) connectToSandbox(sandboxId, channelType string, extraData []byte) (ssh.Channel, <-chan *ssh.Request, error) {
-	// Get sandbox details via toolbox API
-	sandboxDetails, err := s.getSandboxDetails(sandboxId)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get sandbox details: %w", err)
-	}
-
-	// Create SSH client config to connect to the sandbox
-	clientConfig := &ssh.ClientConfig{
-		User:            sandboxDetails.User,
-		Auth:            []ssh.AuthMethod{ssh.Password("sandbox-ssh")}, // Use hardcoded password for sandbox auth
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
-		Timeout:         30 * time.Second,
-	}
-
-	// Connect to the sandbox container via toolbox
-	sandboxClient, err := ssh.Dial("tcp", fmt.Sprintf("%s:22220", sandboxDetails.Hostname), clientConfig)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to connect to sandbox: %w", err)
-	}
-
-	// Open channel to the sandbox
-	sandboxChannel, sandboxRequests, err := sandboxClient.OpenChannel(channelType, extraData)
-	if err != nil {
-		sandboxClient.Close()
-		return nil, nil, fmt.Errorf("failed to open channel to sandbox: %w", err)
-	}
-
-	// Return the real sandbox channel and requests
-	return sandboxChannel, sandboxRequests, nil
+// startedExec reports whether runExec has been called. Holds mu only briefly.
+func (st *sessionState) startedExec() bool {
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	return st.exec != nil
 }
 
-func (s *Service) getSandboxDetails(sandboxId string) (*SandboxDetails, error) {
-	_, err := s.boxlite.GetSandboxState(context.Background(), sandboxId)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get sandbox %s: %w", sandboxId, err)
+// resize forwards the current rows/cols to the in-VM TTY. No-op if exec
+// isn't running yet or isn't a TTY.
+func (st *sessionState) resize(ctx context.Context) {
+	st.mu.Lock()
+	exec, rows, cols := st.exec, st.rows, st.cols
+	st.mu.Unlock()
+	if exec == nil || !st.withTTY {
+		return
 	}
-
-	return &SandboxDetails{
-		User:     "boxlite",
-		Hostname: sandboxId,
-	}, nil
+	if err := exec.ResizeTTY(ctx, rows, cols); err != nil {
+		st.log.Debug("ResizeTTY failed", "sandboxID", st.sandboxId, "error", err)
+	}
 }
 
-// SandboxDetails contains information about a sandbox
-type SandboxDetails struct {
-	User     string `json:"user"`
-	Hostname string `json:"hostname"`
+// waitForExitAndClose blocks until the exit-waiter has reported a code,
+// so the connection-level defers (which include logging completion) don't
+// race ahead of the channel's actual teardown. Safe to call when runExec
+// never started; in that case there's nothing to wait for.
+func (st *sessionState) waitForExitAndClose() {
+	st.mu.Lock()
+	done := st.exitDone
+	st.mu.Unlock()
+	if done == nil {
+		_ = st.clientChannel.Close()
+		return
+	}
+	<-done
+}
+
+// ── payload helpers ─────────────────────────────────────────────────────────
+
+type ptyDims struct{ rows, cols int }
+
+// parsePtyReq pulls (rows, cols) out of an SSH "pty-req" payload per RFC 4254 §6.2:
+//
+//	string  TERM
+//	uint32  cols
+//	uint32  rows
+//	uint32  width-px
+//	uint32  height-px
+//	string  encoded-terminal-modes
+func parsePtyReq(p []byte) ptyDims {
+	rest, _, ok := readSSHString(p)
+	if !ok || len(rest) < 8 {
+		return ptyDims{}
+	}
+	cols := binary.BigEndian.Uint32(rest[0:4])
+	rows := binary.BigEndian.Uint32(rest[4:8])
+	return ptyDims{rows: int(rows), cols: int(cols)}
+}
+
+// parseWindowChange pulls (rows, cols) from an SSH "window-change" payload
+// per RFC 4254 §6.7:
+//
+//	uint32 cols ; uint32 rows ; uint32 wpx ; uint32 hpx
+func parseWindowChange(p []byte) ptyDims {
+	if len(p) < 8 {
+		return ptyDims{}
+	}
+	cols := binary.BigEndian.Uint32(p[0:4])
+	rows := binary.BigEndian.Uint32(p[4:8])
+	return ptyDims{rows: int(rows), cols: int(cols)}
+}
+
+// parseStringPayload reads a single SSH string from `p`. Used for "exec"
+// requests where the entire payload is a single command string.
+func parseStringPayload(p []byte) (string, bool) {
+	_, s, ok := readSSHString(p)
+	return s, ok
+}
+
+// readSSHString reads a length-prefixed string off the front of p and returns
+// (remaining, value, ok).
+func readSSHString(p []byte) ([]byte, string, bool) {
+	if len(p) < 4 {
+		return nil, "", false
+	}
+	n := binary.BigEndian.Uint32(p[0:4])
+	if uint64(len(p)) < 4+uint64(n) {
+		return nil, "", false
+	}
+	return p[4+n:], string(p[4 : 4+n]), true
+}
+
+// exitStatusPayload encodes an SSH "exit-status" channel request payload:
+//
+//	uint32 exit-status
+func exitStatusPayload(code int) []byte {
+	if code < 0 {
+		code = 255
+	}
+	buf := make([]byte, 4)
+	binary.BigEndian.PutUint32(buf, uint32(code))
+	return buf
 }

--- a/apps/runner/pkg/sshgateway/service.go
+++ b/apps/runner/pkg/sshgateway/service.go
@@ -241,6 +241,29 @@ func (s *Service) handleRequest(ctx context.Context, st *sessionState, req *ssh.
 		_ = req.Reply(true, nil)
 		st.runExec(ctx, "exec")
 
+	case "subsystem":
+		// Modern OpenSSH scp defaults to the SFTP subsystem (RFC 4254 §6.5).
+		// Spawn an sftp-server binary inside the VM; its stdio gets wired
+		// to the SSH channel just like a regular exec. We probe common
+		// install paths in order (alpine: /usr/lib/ssh; debian-ish:
+		// /usr/lib/openssh; RHEL-ish: /usr/libexec) and fall through to
+		// PATH lookup so unusual layouts still work. If the VM ships
+		// neither, runExec surfaces "executable not found" and the client
+		// can retry with `scp -O` (legacy protocol over `exec`).
+		name, ok := parseStringPayload(req.Payload)
+		if !ok || name != "sftp" {
+			_ = req.Reply(false, nil)
+			return
+		}
+		st.cmd = "/bin/sh"
+		st.args = []string{"-c",
+			"exec $(command -v sftp-server 2>/dev/null || " +
+				"ls /usr/lib/openssh/sftp-server /usr/lib/ssh/sftp-server /usr/libexec/sftp-server /usr/libexec/openssh/sftp-server 2>/dev/null | head -n1)"}
+		// No TTY for binary-protocol subsystems.
+		st.withTTY = false
+		_ = req.Reply(true, nil)
+		st.runExec(ctx, "subsystem:sftp")
+
 	case "window-change":
 		dims := parseWindowChange(req.Payload)
 		if dims.rows > 0 && dims.cols > 0 {

--- a/apps/runner/pkg/sshgateway/service.go
+++ b/apps/runner/pkg/sshgateway/service.go
@@ -244,21 +244,16 @@ func (s *Service) handleRequest(ctx context.Context, st *sessionState, req *ssh.
 	case "subsystem":
 		// Modern OpenSSH scp defaults to the SFTP subsystem (RFC 4254 §6.5).
 		// Spawn an sftp-server binary inside the VM; its stdio gets wired
-		// to the SSH channel just like a regular exec. We probe common
-		// install paths in order (alpine: /usr/lib/ssh; debian-ish:
-		// /usr/lib/openssh; RHEL-ish: /usr/libexec) and fall through to
-		// PATH lookup so unusual layouts still work. If the VM ships
-		// neither, runExec surfaces "executable not found" and the client
-		// can retry with `scp -O` (legacy protocol over `exec`).
+		// to the SSH channel just like a regular exec. The launcher in
+		// shellutil.SftpSubsystem probes common install paths and refuses
+		// to exec an empty path so the client sees a real error instead
+		// of a silent "Connection closed".
 		name, ok := parseStringPayload(req.Payload)
 		if !ok || name != "sftp" {
 			_ = req.Reply(false, nil)
 			return
 		}
-		st.cmd = "/bin/sh"
-		st.args = []string{"-c",
-			"exec $(command -v sftp-server 2>/dev/null || " +
-				"ls /usr/lib/openssh/sftp-server /usr/lib/ssh/sftp-server /usr/libexec/sftp-server /usr/libexec/openssh/sftp-server 2>/dev/null | head -n1)"}
+		st.cmd, st.args = shellutil.SftpSubsystem()
 		// No TTY for binary-protocol subsystems.
 		st.withTTY = false
 		_ = req.Reply(true, nil)


### PR DESCRIPTION
## Summary

Commit `d7717290` ("replace Docker with BoxLite VM backend") removed Docker without replacing the userland DNS the SSH gateway depended on. `apps/runner/pkg/sshgateway/service.go::connectToSandbox` was still doing `ssh.Dial("tcp", "<sandbox-uuid>:22220")`, relying on Docker-era container-name DNS. Post-upgrade every `ssh -p 2222 <token>@ssh.dev.boxlite.ai` failed with `lookup <uuid> on 127.0.0.53:53: server misbehaving`; the user saw `Connection closed`.

## Root cause

The original SSH-to-SSH bridge assumed a daemon SSH server listening inside each sandbox at port 22220, reachable by container-name DNS. With Docker gone there's no DNS, no per-container IP, and no in-VM SSH daemon — only libkrun's vsock. The dashboard WebSocket terminal at `controllers/proxy.go:114` already routes through libkrun via `boxlite.Client.StartExecution`; the SSH gateway was the only caller still on the dead path.

## Fix

Four commits, smallest unit each:

- **`baca7b62`** — replace dial-by-UUID with `StartExecution` bridge. SSH channel requests (`pty-req`/`env`/`shell`/`exec`/`window-change`/`signal`) map onto SDK calls. Drops `connectToSandbox`, `getSandboxDetails`, `ssh.Password("sandbox-ssh")`, `InsecureIgnoreHostKey`.
- **`c42f2e7d`** — new `apps/runner/pkg/shellutil/launcher.go` with `DefaultInteractiveShell()` returning `/bin/sh -c 'exec $(command -v bash || command -v ash || command -v sh) -l'`. Shared by both `sshgateway/service.go` and `controllers/proxy.go::handleWebSocketTerminal` so dashboard terminal + iframe terminal + SSH all land on the same shell. Follows kubectl exec convention.
- **`b2e722be`** — accept `subsystem sftp` requests (RFC 4254 §6.5; OpenSSH 9.0+ scp defaults to SFTP).
- **`bada4280`** — `cd "${HOME:-/root}"` before exec (matches OpenSSH `chdir(pw_dir)` so users land at `~`, not `/`); explicit error when `sftp-server` binary is missing in the sandbox image.

## Test plan

- [x] `ssh -p 2222 <token>@ssh.dev.boxlite.ai` lands at `boxlite:~#` prompt (verified post-deploy).
- [x] Dashboard sandbox-detail Terminal tab still works (unified launcher).
- [x] `ssh user@host "ls /"` one-shot exec returns content and exits cleanly.
- [ ] `scp -P 2222 file <token>@ssh.dev.boxlite.ai:/root/` — **known limitation**, see below.

## Known limitations / follow-ups

- **scp against snapshots without `sftp-server`**: shows `scp: Connection closed`. OpenSSH scp discards SSH channel stderr (extended-data type 1) in SFTP subsystem mode, so the fail-loud stderr from `bada4280` does run but the user never sees it. Two workarounds: (a) install `openssh-sftp-server` in the sandbox image (`apk add openssh-sftp-server` on alpine), (b) `scp -O -P 2222 …` falls back to legacy SCP protocol over `exec`. Cleaner server-side fix is a pre-flight probe + `Reply(false, nil)` so scp prints `subsystem request failed` — deferred to a follow-up PR.
- **No port forwarding** (`-L`/`-R`/Unix sockets). Daytona supports this via gliderlabs/ssh callbacks; we deliberately ship a minimal subset here.
