### PR TITLE
fix(dashboard): RP-initiated logout fallback for non-compliant IdPs

### DIFF
--- a/apps/api/src/auth/auth.module.ts
+++ b/apps/api/src/auth/auth.module.ts
@@ -12,14 +12,12 @@ import { UserModule } from '../user/user.module'
 import { ApiKeyModule } from '../api-key/api-key.module'
 import { SandboxModule } from '../sandbox/sandbox.module'
 import { TypedConfigService } from '../config/typed-config.service'
-import { HttpModule, HttpService } from '@nestjs/axios'
-import { OidcMetadata } from 'oidc-client-ts'
-import { firstValueFrom } from 'rxjs'
 import { UserService } from '../user/user.service'
 import { TypedConfigModule } from '../config/typed-config.module'
-import { catchError, map } from 'rxjs/operators'
+import { OidcMetadataService } from '../config/oidc-metadata.service'
 import { FailedAuthTrackerService } from './failed-auth-tracker.service'
 import { RegionModule } from '../region/region.module'
+import { LogoutController } from './logout.controller'
 @Module({
   imports: [
     PassportModule.register({
@@ -32,27 +30,22 @@ import { RegionModule } from '../region/region.module'
     ApiKeyModule,
     SandboxModule,
     RegionModule,
-    HttpModule,
   ],
+  controllers: [LogoutController],
   providers: [
     ApiKeyStrategy,
     {
       provide: JwtStrategy,
-      useFactory: async (userService: UserService, httpService: HttpService, configService: TypedConfigService) => {
+      useFactory: async (
+        userService: UserService,
+        oidcMetadataService: OidcMetadataService,
+        configService: TypedConfigService,
+      ) => {
         if (configService.get('skipConnections')) {
           return
         }
 
-        // Get the OpenID configuration from the issuer
-        const discoveryUrl = `${configService.get('oidc.issuer')}/.well-known/openid-configuration`
-        const metadata = await firstValueFrom(
-          httpService.get(discoveryUrl).pipe(
-            map((response) => response.data as OidcMetadata),
-            catchError((error) => {
-              throw new Error(`Failed to fetch OpenID configuration: ${error.message}`)
-            }),
-          ),
-        )
+        const metadata = await oidcMetadataService.getMetadata()
 
         let jwksUri = metadata.jwks_uri
 
@@ -72,7 +65,7 @@ import { RegionModule } from '../region/region.module'
           configService,
         )
       },
-      inject: [UserService, HttpService, TypedConfigService],
+      inject: [UserService, OidcMetadataService, TypedConfigService],
     },
     FailedAuthTrackerService,
   ],

--- a/apps/api/src/auth/logout.controller.ts
+++ b/apps/api/src/auth/logout.controller.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Controller, Get, Logger, Query, Res, UseGuards } from '@nestjs/common'
+import { ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger'
+import { Response } from 'express'
+import { AnonymousRateLimitGuard } from '../common/guards/anonymous-rate-limit.guard'
+import { parseHttpUrl } from '../config/oidc-metadata.service'
+import { TypedConfigService } from '../config/typed-config.service'
+
+@ApiTags('auth')
+@Controller('auth')
+export class LogoutController {
+  private readonly logger = new Logger(LogoutController.name)
+
+  constructor(private readonly configService: TypedConfigService) {}
+
+  @Get('end-session')
+  @UseGuards(AnonymousRateLimitGuard)
+  @ApiOperation({
+    summary: 'OIDC RP-initiated logout endpoint',
+    description:
+      'Implements OpenID Connect RP-Initiated Logout 1.0 for IdPs (e.g. Dex) that do not natively advertise end_session_endpoint. Validates the post-logout redirect target, then 302-redirects the browser back to the SPA.',
+  })
+  @ApiQuery({ name: 'post_logout_redirect_uri', required: false })
+  @ApiQuery({ name: 'id_token_hint', required: false })
+  @ApiQuery({ name: 'state', required: false })
+  @ApiResponse({ status: 302, description: 'Redirect to post_logout_redirect_uri' })
+  @ApiResponse({ status: 400, description: 'post_logout_redirect_uri not allowed' })
+  endSession(
+    @Query('post_logout_redirect_uri') postLogoutRedirectUri: string | undefined,
+    @Query('id_token_hint') _idTokenHint: string | undefined,
+    @Query('state') state: string | undefined,
+    @Res() res: Response,
+  ) {
+    const dashboardUrl = this.configService.getOrThrow('dashboardUrl')
+    const allowlist = this.getAllowlist(dashboardUrl)
+
+    const target = postLogoutRedirectUri || dashboardUrl
+    if (!validatePostLogoutRedirect(target, allowlist)) {
+      this.logger.warn(`Rejected post_logout_redirect_uri: ${target}`)
+      res.status(400).send('post_logout_redirect_uri not in allowlist')
+      return
+    }
+
+    const finalUrl = state ? appendStateParam(target, state) : target
+    res.redirect(302, finalUrl)
+  }
+
+  private getAllowlist(dashboardUrl: string): string[] {
+    const extra = this.configService.get('oidc.postLogoutRedirectAllowlist')
+    const extras = extra ? extra.split(',').map((s) => s.trim()).filter(Boolean) : []
+    return [dashboardUrl, ...extras].filter(Boolean)
+  }
+}
+
+/**
+ * Open-redirect prevention for RP-initiated logout. Returns true iff `uri`
+ * passes the shared `parseHttpUrl` policy AND its origin matches the origin
+ * of some allowlist entry. Origin-match (not exact-equality) lets the SPA
+ * redirect to deep paths under the same origin without registering each one.
+ */
+function validatePostLogoutRedirect(uri: string, allowlist: string[]): boolean {
+  const target = parseHttpUrl(uri)
+  if (!target) return false
+  for (const allowed of allowlist) {
+    const parsed = parseHttpUrl(allowed)
+    if (parsed && parsed.origin === target.origin) return true
+  }
+  return false
+}
+
+function appendStateParam(url: string, state: string): string {
+  const u = new URL(url)
+  u.searchParams.set('state', state)
+  return u.toString()
+}

--- a/apps/api/src/config/config.controller.ts
+++ b/apps/api/src/config/config.controller.ts
@@ -8,11 +8,15 @@ import { Controller, Get } from '@nestjs/common'
 import { TypedConfigService } from './typed-config.service'
 import { ApiOperation, ApiTags, ApiResponse } from '@nestjs/swagger'
 import { ConfigurationDto } from './dto/configuration.dto'
+import { OidcMetadataService } from './oidc-metadata.service'
 
 @ApiTags('config')
 @Controller('config')
 export class ConfigController {
-  constructor(private readonly configService: TypedConfigService) {}
+  constructor(
+    private readonly configService: TypedConfigService,
+    private readonly oidcMetadataService: OidcMetadataService,
+  ) {}
 
   @Get()
   @ApiOperation({ summary: 'Get config' })
@@ -21,7 +25,8 @@ export class ConfigController {
     description: 'BoxLite configuration',
     type: ConfigurationDto,
   })
-  getConfig() {
-    return new ConfigurationDto(this.configService)
+  async getConfig() {
+    const endSessionState = await this.oidcMetadataService.getEndSessionState()
+    return new ConfigurationDto(this.configService, { endSessionState })
   }
 }

--- a/apps/api/src/config/configuration.ts
+++ b/apps/api/src/config/configuration.ts
@@ -46,6 +46,8 @@ const configuration = {
     issuer: process.env.OIDC_ISSUER_BASE_URL || process.env.OID_ISSUER_BASE_URL,
     publicIssuer: process.env.PUBLIC_OIDC_DOMAIN,
     audience: process.env.OIDC_AUDIENCE || process.env.OID_AUDIENCE,
+    endSessionEndpoint: process.env.OIDC_END_SESSION_ENDPOINT,
+    postLogoutRedirectAllowlist: process.env.OIDC_POST_LOGOUT_REDIRECT_ALLOWLIST,
     managementApi: {
       enabled: process.env.OIDC_MANAGEMENT_API_ENABLED === 'true',
       clientId: process.env.OIDC_MANAGEMENT_API_CLIENT_ID,

--- a/apps/api/src/config/dto/configuration.dto.ts
+++ b/apps/api/src/config/dto/configuration.dto.ts
@@ -7,6 +7,7 @@
 import { ApiExtraModels, ApiProperty, ApiPropertyOptional, ApiSchema, getSchemaPath } from '@nestjs/swagger'
 import { IsBoolean, IsNumber, IsOptional, IsString } from 'class-validator'
 import { TypedConfigService } from '../typed-config.service'
+import { EndSessionState, isValidHttpUrl } from '../oidc-metadata.service'
 
 @ApiSchema({ name: 'Announcement' })
 export class Announcement {
@@ -115,6 +116,15 @@ export class OidcConfig {
   })
   @IsString()
   audience: string
+
+  @ApiPropertyOptional({
+    description:
+      'OIDC end-session endpoint. Set when the IdP does not advertise one via discovery (e.g. Dex) and BoxLite hosts a compatible logout endpoint.',
+    example: 'https://api.example.com/api/auth/end-session',
+  })
+  @IsString()
+  @IsOptional()
+  endSessionEndpoint?: string
 }
 
 @ApiExtraModels(Announcement)
@@ -250,13 +260,23 @@ export class ConfigurationDto {
   @IsOptional()
   rateLimit?: RateLimitConfig
 
-  constructor(configService: TypedConfigService) {
+  constructor(configService: TypedConfigService, options: { endSessionState: EndSessionState }) {
     this.version = configService.getOrThrow('version')
 
     this.oidc = {
       issuer: configService.get('oidc.publicIssuer') || configService.getOrThrow('oidc.issuer'),
       clientId: configService.getOrThrow('oidc.clientId'),
       audience: configService.getOrThrow('oidc.audience'),
+      // Only expose the BoxLite-hosted fallback when discovery proved the IdP
+      // lacks end_session_endpoint. 'present' → trust the IdP; 'unknown' →
+      // fail closed (don't override Auth0/Okta's real endpoint on a probe
+      // blip). Only 'absent' is a definitive answer that justifies the seed.
+      // Even then we validate the operator-set env: a typo'd OIDC_END_SESSION_ENDPOINT
+      // must not silently propagate as a metadataSeed value.
+      endSessionEndpoint:
+        options.endSessionState === 'absent'
+          ? validatedEndSessionEndpoint(configService.get('oidc.endSessionEndpoint'))
+          : undefined,
     }
     this.linkedAccountsEnabled = configService.get('oidc.managementApi.enabled')
     this.proxyTemplateUrl = configService.getOrThrow('proxy.templateUrl')
@@ -305,4 +325,9 @@ export class ConfigurationDto {
       },
     }
   }
+}
+
+function validatedEndSessionEndpoint(value: string | undefined): string | undefined {
+  if (!value) return undefined
+  return isValidHttpUrl(value) ? value : undefined
 }

--- a/apps/api/src/config/oidc-metadata.service.ts
+++ b/apps/api/src/config/oidc-metadata.service.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { HttpService } from '@nestjs/axios'
+import { Injectable, Logger } from '@nestjs/common'
+import { OidcMetadata } from 'oidc-client-ts'
+import { catchError, firstValueFrom, map } from 'rxjs'
+import { TypedConfigService } from './typed-config.service'
+
+export type EndSessionState = 'present' | 'absent' | 'unknown'
+
+/**
+ * Parse a value as an http(s) URL with sanity-tight rules. Returns the parsed
+ * `URL` or `undefined` if any check fails. Shared by every boundary that
+ * receives a URL from a source we don't fully trust (IdP discovery response,
+ * operator env, SPA query param).
+ *
+ * Rejects: non-strings, non-http(s) schemes (blocks javascript:, data:, file:),
+ * empty hostnames, and URLs with userinfo (`user:pass@host`) because those
+ * leak credentials into logs and the address bar.
+ */
+export function parseHttpUrl(value: unknown): URL | undefined {
+  if (typeof value !== 'string' || value.trim() === '') return undefined
+  let u: URL
+  try {
+    u = new URL(value)
+  } catch {
+    return undefined
+  }
+  if (u.protocol !== 'https:' && u.protocol !== 'http:') return undefined
+  if (!u.hostname) return undefined
+  if (u.username || u.password) return undefined
+  return u
+}
+
+export function isValidHttpUrl(value: unknown): value is string {
+  return parseHttpUrl(value) !== undefined
+}
+
+@Injectable()
+export class OidcMetadataService {
+  private readonly logger = new Logger(OidcMetadataService.name)
+  private cached?: Promise<OidcMetadata>
+
+  constructor(
+    private readonly httpService: HttpService,
+    private readonly configService: TypedConfigService,
+  ) {
+    const configured = this.configService.get('oidc.endSessionEndpoint')
+    if (configured && !isValidHttpUrl(configured)) {
+      this.logger.warn(
+        `OIDC_END_SESSION_ENDPOINT is set but not a valid http(s) URL; it will be ignored: ${configured}`,
+      )
+    }
+  }
+
+  getMetadata(): Promise<OidcMetadata> {
+    if (!this.cached) {
+      const inflight = this.fetchOnce()
+      this.cached = inflight
+      inflight.catch(() => {
+        if (this.cached === inflight) {
+          this.cached = undefined
+        }
+      })
+    }
+    return this.cached
+  }
+
+  async getEndSessionState(): Promise<EndSessionState> {
+    let metadata: OidcMetadata
+    try {
+      metadata = await this.getMetadata()
+    } catch (err) {
+      this.logger.warn(
+        `OIDC discovery probe failed; treating as 'unknown' (fail-closed): ${err instanceof Error ? err.message : String(err)}`,
+      )
+      return 'unknown'
+    }
+    if (typeof metadata !== 'object' || metadata === null) {
+      // Server returned non-JSON or empty body; the type cast at fetch time lied.
+      return 'unknown'
+    }
+    const endpoint = metadata.end_session_endpoint
+    if (endpoint === undefined) {
+      // Canonically missing — the IdP intentionally doesn't advertise it.
+      return 'absent'
+    }
+    // Field is present in the doc; only call it "valid" if it's a real URL.
+    return isValidHttpUrl(endpoint) ? 'present' : 'unknown'
+  }
+
+  private async fetchOnce(): Promise<OidcMetadata> {
+    // Strip trailing slash so the composed URL doesn't get a `//` segment some
+    // IdPs reject (Keycloak in strict mode, certain Auth0 tenants).
+    const issuer = this.configService.getOrThrow('oidc.issuer').replace(/\/+$/, '')
+    const discoveryUrl = `${issuer}/.well-known/openid-configuration`
+    return firstValueFrom(
+      this.httpService.get(discoveryUrl).pipe(
+        map((response) => response.data as OidcMetadata),
+        catchError((error) => {
+          throw new Error(`Failed to fetch OpenID configuration from ${discoveryUrl}: ${error.message}`)
+        }),
+      ),
+    )
+  }
+}

--- a/apps/api/src/config/typed-config.module.ts
+++ b/apps/api/src/config/typed-config.module.ts
@@ -4,11 +4,13 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
+import { HttpModule } from '@nestjs/axios'
 import { Global, Module, DynamicModule } from '@nestjs/common'
 import { ConfigModule as NestConfigModule, ConfigModuleOptions } from '@nestjs/config'
 import { TypedConfigService } from './typed-config.service'
 import { configuration } from './configuration'
 import { ConfigController } from './config.controller'
+import { OidcMetadataService } from './oidc-metadata.service'
 
 @Global()
 @Module({
@@ -17,10 +19,11 @@ import { ConfigController } from './config.controller'
       isGlobal: true,
       load: [() => configuration],
     }),
+    HttpModule,
   ],
   controllers: [ConfigController],
-  providers: [TypedConfigService],
-  exports: [TypedConfigService],
+  providers: [TypedConfigService, OidcMetadataService],
+  exports: [TypedConfigService, OidcMetadataService],
 })
 export class TypedConfigModule {
   static forRoot(options: Partial<ConfigModuleOptions> = {}): DynamicModule {
@@ -30,9 +33,10 @@ export class TypedConfigModule {
         NestConfigModule.forRoot({
           ...options,
         }),
+        HttpModule,
       ],
-      providers: [TypedConfigService],
-      exports: [TypedConfigService],
+      providers: [TypedConfigService, OidcMetadataService],
+      exports: [TypedConfigService, OidcMetadataService],
     }
   }
 }

--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -87,7 +87,7 @@ function App() {
   const config = useConfig()
   const location = useLocation()
   const posthog = usePostHog()
-  const { error: authError, isAuthenticated, user, signoutRedirect } = useAuth()
+  const { error: authError, isAuthenticated, user, removeUser } = useAuth()
 
   useEffect(() => {
     if (isAuthenticated && user && posthog?.get_distinct_id() !== user.profile.sub) {
@@ -127,7 +127,14 @@ function App() {
             <DialogDescription>{authError.message}</DialogDescription>
           </DialogHeader>
           <DialogFooter>
-            <Button onClick={() => signoutRedirect()}>Go Back</Button>
+            <Button
+              onClick={async () => {
+                await removeUser()
+                window.location.assign(RoutePath.LANDING)
+              }}
+            >
+              Go Back
+            </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/apps/dashboard/src/providers/ConfigProvider.tsx
+++ b/apps/dashboard/src/providers/ConfigProvider.tsx
@@ -53,6 +53,11 @@ export function ConfigProvider(props: Props) {
         window.dispatchEvent(new PopStateEvent('popstate'))
       },
       post_logout_redirect_uri: window.location.origin,
+      // For IdPs (e.g. Dex) that don't advertise end_session_endpoint via discovery,
+      // the API exposes a compatible endpoint and reports it here.
+      ...(config.oidc.endSessionEndpoint && {
+        metadataSeed: { end_session_endpoint: config.oidc.endSessionEndpoint },
+      }),
     }
   }, [config])
 

--- a/apps/infra/README.md
+++ b/apps/infra/README.md
@@ -118,9 +118,20 @@ layers per AWS's "WebSocket through ALB" guidance:
 If you raise or lower the ALB idle, keep the Node `keepAliveTimeout`
 strictly greater than it.
 
-## Auth0 setup
+## OIDC provider setup (Auth0 example)
 
-The stack delegates all authentication to an external OIDC provider. For Auth0:
+The stack delegates all authentication to an external OIDC provider. The API
+validates JWTs via JWKS and probes the issuer's `/.well-known/openid-configuration`
+once at startup. Any standards-compliant IdP works (Auth0, Okta, Keycloak, Dex,
+Cognito, etc.) — the only hard requirement is that the JWKS URL be reachable
+from the API container.
+
+For IdPs that don't advertise `end_session_endpoint` in their discovery doc
+(Dex is the common case — see `dexidp/dex#1697`), the dashboard's logout flow
+transparently falls back through BoxLite's own `/api/auth/end-session` route.
+No operator action needed; the API auto-detects and the dashboard auto-uses it.
+
+For Auth0 specifically:
 
 1. **SPA Application** — create in Auth0, set callback/logout URLs to `https://<STACK_DOMAIN>`
 2. **Custom API** — identifier becomes `OIDC_AUDIENCE` (e.g. `https://dev.boxlite.ai/api`)
@@ -129,7 +140,15 @@ The stack delegates all authentication to an external OIDC provider. For Auth0:
    `functions/auth0/setCustomClaims.onExecutePostLogin.js`, copied from upstream BoxLite
    with its AGPL-3.0 SPDX header preserved.
    Deploy → Actions → Flows → Login → drag onto flow → Apply.
-4. **Machine-to-Machine app** (optional, for account linking) — authorize for Auth0 Management API
+4. **RP-Initiated Logout End Session Endpoint Discovery** — required so the SPA's
+   logout fully terminates the Auth0 session (otherwise the browser silently
+   re-authenticates via the still-alive Auth0 cookie and "Sign out" looks like a
+   page refresh). Dashboard → Settings → Advanced → "Login and Logout" → enable
+   the toggle. For tenants created on or after 14 November 2023 this is the
+   default; older tenants need the manual flip. After enabling, restart the API
+   service so its cached discovery probe re-fetches and stops emitting the
+   BoxLite fallback. ([Auth0 docs](https://auth0.com/docs/authenticate/login/logout/log-users-out-of-auth0))
+5. **Machine-to-Machine app** (optional, for account linking) — authorize for Auth0 Management API
    with permissions: `read:users`, `update:users`, `read:connections`,
    `create:guardian_enrollment_tickets`, `read:connections_options`.
 
@@ -252,7 +271,9 @@ follows that. Not yet implemented.
                           │  (nested KVM, privileged)     │
                           └───────────────────────────────┘
 
-Auth: Auth0 (external) ← OIDC tokens validated by Api via JWKS
+Auth: OIDC provider (Auth0/Okta/Keycloak/Dex/…) ← Api validates JWT via JWKS;
+      /api/auth/end-session provides RP-initiated-logout fallback for IdPs
+      that don't advertise end_session_endpoint in discovery
 ```
 
 ## Troubleshooting
@@ -263,8 +284,17 @@ Auth: Auth0 (external) ← OIDC tokens validated by Api via JWKS
 from an earlier failed deploy. If `runningCount == desiredCount` the service
 is fine; ignore it.
 
-**Api crashes with `Failed to fetch OpenID configuration`** — `OIDC_ISSUER_BASE_URL`
-has a trailing slash causing `//` in the discovery URL. Remove the trailing slash.
+**Api crashes with `Failed to fetch OpenID configuration`** — the API can't
+reach `<OIDC_ISSUER_BASE_URL>/.well-known/openid-configuration`. Check network
+egress from the API container to the IdP, and confirm `OIDC_ISSUER_BASE_URL`
+points at a working host. Trailing slashes are normalized automatically.
+
+**Dashboard shows `Authentication Error: No end session endpoint` on logout** —
+the API's IdP-discovery probe failed at startup, so the dashboard never
+received the `end_session_endpoint` fallback. Check API logs for the
+`OIDC discovery probe failed; treating as 'unknown' (fail-closed)` warning;
+fix the underlying connectivity to the IdP and the next `/api/config` request
+self-heals.
 
 **"Organization is suspended: Please verify your email address"** — Auth0 access_token
 missing `email_verified` claim. Deploy the Post-Login Action described above.

--- a/apps/infra/sst.config.ts
+++ b/apps/infra/sst.config.ts
@@ -289,6 +289,18 @@ export default $config({
           OIDC_MANAGEMENT_API_CLIENT_SECRET: process.env.OIDC_MANAGEMENT_API_CLIENT_SECRET!,
           OIDC_MANAGEMENT_API_AUDIENCE: process.env.OIDC_MANAGEMENT_API_AUDIENCE!,
         }),
+        // RP-initiated logout fallback. Safe to set unconditionally: the API
+        // probes the IdP's discovery doc at startup and only exposes this URL
+        // to the dashboard when the IdP itself lacks end_session_endpoint
+        // (e.g. Dex). For Auth0/Okta the API hides this and the SPA uses the
+        // IdP's real endpoint advertised in /.well-known/openid-configuration.
+        OIDC_END_SESSION_ENDPOINT: envOr(
+          "OIDC_END_SESSION_ENDPOINT",
+          `https://${stackDomain}/api/auth/end-session`,
+        ),
+        ...(process.env.OIDC_POST_LOGOUT_REDIRECT_ALLOWLIST && {
+          OIDC_POST_LOGOUT_REDIRECT_ALLOWLIST: process.env.OIDC_POST_LOGOUT_REDIRECT_ALLOWLIST,
+        }),
 
         // S3 (API signs STS creds for per-sandbox buckets)
         S3_ENDPOINT: $interpolate`https://s3.${aws.getRegionOutput().name}.amazonaws.com`,
@@ -321,7 +333,7 @@ export default $config({
         // (index.html + /assets/*) still serve through the CF Router at the
         // root domain. CORS on the API is already `origin: true` so the
         // cross-origin dashboard→API path works without further changes.
-        DASHBOARD_URL: envOr("DASHBOARD_URL", ""),
+        DASHBOARD_URL: envOr("DASHBOARD_URL", `https://${stackDomain}`),
         APP_URL: envOr("APP_URL", ""),
         DASHBOARD_BASE_API_URL: envOr("DASHBOARD_BASE_API_URL", `https://api.${stackDomain}`),
 

--- a/apps/libs/api-client/src/models/oidc-config.ts
+++ b/apps/libs/api-client/src/models/oidc-config.ts
@@ -38,4 +38,10 @@ export interface OidcConfig {
      * @memberof OidcConfig
      */
     'audience': string;
+    /**
+     * OIDC end-session endpoint. Set when the IdP does not advertise one via discovery (e.g. Dex) and BoxLite hosts a compatible logout endpoint.
+     * @type {string}
+     * @memberof OidcConfig
+     */
+    'endSessionEndpoint'?: string;
 }


### PR DESCRIPTION
## Summary

The dashboard's logout flow inherits Daytona upstream's `signoutRedirect()` call (react-oidc-context / oidc-client-ts), which navigates the browser to the IdP's `end_session_endpoint` from OIDC discovery. Auth0 advertises that endpoint, so upstream Just Works.

BoxLite's default IdP is **Dex**, which does not advertise `end_session_endpoint` (`dexidp/dex#1697`, open since 2019). `oidc-client-ts` throws `Error("No end session endpoint")` and the dashboard gets stuck on its `Authentication Error / Go Back` dialog at `https://<stack>/?code=…&state=…`. The "Go Back" button re-calls the same failing `signoutRedirect()` — the dialog is sticky.

## Root cause

Two distinct bugs, one tenant-config issue:

1. Dex's discovery doc is non-compliant with OIDC RP-Initiated Logout 1.0.
2. The dashboard's error-recovery handler re-triggered the same failing call.
3. Auth0 tenants created before 14 Nov 2023 default the "RP-Initiated Logout End Session Endpoint Discovery" toggle to OFF — same symptom, different cause.

## Fix

Three-layer fix that's zero-config for compliant IdPs and self-healing for the rest.

**API**
- New `LogoutController` at `/api/auth/end-session` — implements OIDC RP-Initiated Logout 1.0. Open-redirect prevention is strict origin-match against `DASHBOARD_URL` + an operator-set `OIDC_POST_LOGOUT_REDIRECT_ALLOWLIST`. State param preserved across the redirect.
- New `OidcMetadataService` — singleton that probes the IdP's discovery doc once at startup, caches the result, and exposes `getEndSessionState(): 'present' | 'absent' | 'unknown'`. Replaces the inline fetch previously embedded in `auth.module.ts`. Fails closed on probe error so a transient blip doesn't override Auth0's real endpoint.
- `ConfigurationDto.oidc.endSessionEndpoint` is only emitted when the probe returns `'absent'`. Validates the env-set URL before exposing it (typos don't propagate as `metadataSeed` values).

**Dashboard**
- `ConfigProvider.tsx` conditionally passes `metadataSeed: { end_session_endpoint }` to `AuthProvider`. `oidc-client-ts.js:827` merges this LAST, after discovery — so the fallback wins iff the field is set.
- `App.tsx` auth-error dialog's "Go Back" handler now calls `removeUser()` and navigates to `/` instead of re-calling `signoutRedirect()`. Breaks the sticky-error loop.

**Infra**
- `sst.config.ts` wires `OIDC_END_SESSION_ENDPOINT=https://<stackDomain>/api/auth/end-session` unconditionally. Safe because the API gates exposure on the discovery probe — Auth0/Okta stacks see no behaviour change.
- `apps/infra/README.md` documents the Auth0 toggle for pre-Nov-2023 tenants + a troubleshooting entry for the failure mode.

## Test plan

- [x] Dex/self-hosted: clicking "Sign out" routes through `/api/auth/end-session` → 302 to dashboard, session cleared.
- [x] Auth0 (tenant `dev-j60pjpmu6neaeaga.us.auth0.com`, toggle enabled): `curl /api/config | jq .oidc.endSessionEndpoint` returns `null`. Sign out navigates to `/oidc/logout` on Auth0 directly, terminates the session cookie, no silent re-auth.
- [x] Auth0 (toggle disabled, pre-fix): reproduces the original "page-refresh loops" symptom. Confirms the toggle is the root cause for Auth0 stacks.
- [x] Sticky-error dialog: simulating an auth error with stale state, "Go Back" now lands on `/` cleanly instead of re-triggering the same error.
- [x] Negative test: `curl -i '/api/auth/end-session?post_logout_redirect_uri=https://evil.example.com'` → 400.

## Known limitations / follow-ups

- `apps/libs/api-client/src/models/oidc-config.ts` is hand-patched to add the optional `endSessionEndpoint` field. The next OpenAPI codegen pass will regenerate it from the API schema; the hand edit keeps types and runtime in sync until then. Follow-up: run `nx run api-client:generate:api-client`.
- Stricter security posture would also POST to the IdP's `/token/revoke` to invalidate the refresh token. Skipped in this PR — the security delta is small once `removeUser()` clears local storage and the IdP terminates its own session. Tracked for a follow-up.
