### PR TITLE
feat(api): single bearer auth, /v1/me, RFC 8628 device flow endpoints

### DIFF
--- a/openapi/rest-sandbox-open-api.yaml
+++ b/openapi/rest-sandbox-open-api.yaml
@@ -36,9 +36,10 @@ info:
 
     ## Authentication
 
-    All endpoints (except `GET /v1/config` and `POST /v1/oauth/tokens`) require
-    a Bearer token in the `Authorization` header. Obtain tokens via the OAuth2
-    client credentials flow.
+    All endpoints (except `GET /v1/config`) require an opaque API key in the
+    `Authorization: Bearer <key>` header. Keys are issued in the dashboard at
+    `https://app.boxlite.ai/settings/api-keys`. Validate a freshly-pasted key
+    via `GET /v1/me`.
 
     ## Execution Model
 
@@ -74,19 +75,12 @@ servers:
 # ---------------------------------------------------------------------------
 security:
   - BearerAuth: []
-  - OAuth2:
-      - boxes:read
-      - boxes:write
-      - boxes:exec
-      - images:read
-      - images:write
-      - runtime:admin
 
 tags:
   - name: Configuration
     description: Server capability discovery
   - name: Authentication
-    description: OAuth2 token exchange
+    description: Credential validation and identity lookup
   - name: Boxes
     description: Sandbox box lifecycle management
   - name: Execution
@@ -127,28 +121,23 @@ paths:
   # -------------------------------------------------------------------------
   # Authentication
   # -------------------------------------------------------------------------
-  /oauth/tokens:
-    post:
-      operationId: getToken
-      summary: Exchange credentials for an access token
+  /me:
+    get:
+      operationId: getCurrentPrincipal
+      summary: Identity and scopes for the calling credential
       description: |
-        OAuth2 client credentials flow. Returns a Bearer token for
-        authenticating subsequent API requests.
+        Returns the principal (user or service account) and granted scopes for
+        the Bearer credential in the request. Used by `boxlite auth login` to
+        validate freshly-pasted keys and by `boxlite auth status` to render
+        the identity banner.
       tags: [Authentication]
-      security: []
-      requestBody:
-        required: true
-        content:
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: "#/components/schemas/TokenRequest"
       responses:
         "200":
-          description: Token issued successfully
+          description: Authenticated principal
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TokenResponse"
+                $ref: "#/components/schemas/Principal"
         "401":
           $ref: "#/components/responses/UnauthorizedError"
 
@@ -930,21 +919,10 @@ components:
     BearerAuth:
       type: http
       scheme: bearer
-      bearerFormat: JWT
-      description: Bearer token obtained via OAuth2 client credentials flow
-
-    OAuth2:
-      type: oauth2
-      flows:
-        clientCredentials:
-          tokenUrl: /v1/oauth/tokens
-          scopes:
-            boxes:read: Read box information and status
-            boxes:write: Create, modify, and delete boxes
-            boxes:exec: Execute commands and manage executions
-            images:read: List and inspect cached images
-            images:write: Pull images from registries
-            runtime:admin: Runtime administration (metrics, shutdown)
+      description: |
+        Bearer authentication with an opaque API key issued by the dashboard
+        at `https://app.boxlite.ai/settings/api-keys`. Send as
+        `Authorization: Bearer <api-key>`. No token exchange required.
 
   # -------------------------------------------------------------------------
   # Parameters
@@ -1204,40 +1182,58 @@ components:
     # =======================================================================
     # Authentication
     # =======================================================================
-    TokenRequest:
+    Principal:
       type: object
-      required: [grant_type, client_id, client_secret]
+      description: |
+        Identity and scope payload returned by `GET /v1/me`. The CLI uses
+        `email`/`display_name` to render `Logged in as ...` after a successful
+        `boxlite auth login`, and `scopes` to surface under-scoped credentials
+        at login time rather than mid-flow.
+      required: [sub, principal_type, prefix, scopes]
       properties:
-        grant_type:
+        sub:
           type: string
-          enum: [client_credentials]
-        client_id:
+          description: |
+            Stable opaque principal identifier. Clients MUST treat the value
+            as opaque — the server may change format (UUID, ULID, Base62, or
+            prefixed) without notice. Survives email and display-name renames.
+        principal_type:
           type: string
-        client_secret:
+          enum: [user, service_account]
+          description: |
+            `user` for interactive dashboard-issued keys; `service_account`
+            for automation keys. Modeled as a sum type rather than a nullable
+            `user_id` field so the SDK can dispatch by variant.
+        email:
           type: string
-        scope:
+          format: email
+          description: |
+            Email of the user behind the key. Absent for `service_account`
+            principals.
+        display_name:
           type: string
-          description: Space-separated list of requested scopes
-          example: "boxes:read boxes:write boxes:exec"
-
-    TokenResponse:
-      type: object
-      required: [access_token, token_type, expires_in]
-      properties:
-        access_token:
+          description: Human-readable label. Optional.
+        prefix:
           type: string
-          description: Bearer token for authenticating API requests
-        token_type:
+          description: |
+            Tenant/workspace prefix the credential is bound to. The CLI uses
+            this to populate `--prefix` defaults on subsequent calls.
+        scopes:
+          type: array
+          items:
+            type: string
+            example: "boxes:read"
+          description: |
+            Granted scope strings (`boxes:read`, `boxes:write`, etc.). The
+            CLI checks these at login so under-scoped credentials surface
+            immediately rather than at first use.
+        expires_at:
           type: string
-          enum: [bearer]
-        expires_in:
-          type: integer
-          description: Token lifetime in seconds
-          example: 3600
-        scope:
-          type: string
-          description: Granted scopes (may differ from requested)
-          example: "boxes:read boxes:write boxes:exec"
+          format: date-time
+          nullable: true
+          description: |
+            Optional expiry. `null` for long-lived dashboard-issued keys;
+            ISO 8601 timestamp for rotating credentials.
 
     # =======================================================================
     # Error Model

--- a/openapi/rest-sandbox-open-api.yaml
+++ b/openapi/rest-sandbox-open-api.yaml
@@ -36,10 +36,19 @@ info:
 
     ## Authentication
 
-    All endpoints (except `GET /v1/config`) require an opaque API key in the
-    `Authorization: Bearer <key>` header. Keys are issued in the dashboard at
-    `https://app.boxlite.ai/settings/api-keys`. Validate a freshly-pasted key
-    via `GET /v1/me`.
+    All endpoints (except `GET /v1/config` and the `/v1/oauth/*` endpoints)
+    require an opaque token in the `Authorization: Bearer` header (RFC 6750).
+    The server is **bearer-format-agnostic** — any token its validation
+    pipeline can verify is accepted. See the `BearerAuth` security scheme
+    for the supported token sources, which include BoxLite-issued API keys
+    and OAuth tokens, plus (configurable per deployment) federated SSO JWTs,
+    third-party OIDC tokens, and customer-issued gateway tokens.
+
+    The CLI's `boxlite auth login` provides the two BoxLite-issued paths
+    (`--api-key-stdin` for API keys, `--web` for OAuth device flow). Other
+    sources are configured at the customer's gateway or IdP layer.
+
+    Validate a freshly-acquired token via `GET /v1/me`.
 
     ## Execution Model
 
@@ -140,6 +149,101 @@ paths:
                 $ref: "#/components/schemas/Principal"
         "401":
           $ref: "#/components/responses/UnauthorizedError"
+
+  /oauth/device_code:
+    post:
+      operationId: initiateDeviceAuthorization
+      summary: Begin the OAuth 2.0 device authorization flow (RFC 8628)
+      description: |
+        CLI calls this without credentials to start a device-flow login. The
+        response contains a short `user_code` the human pastes into the
+        verification URL (or opens the `verification_uri_complete` directly),
+        plus a `device_code` the CLI polls `/v1/oauth/token` with.
+
+        Device flow is preferred over loopback PKCE because BoxLite users
+        often run the CLI inside containers / SSH sessions / remote dev pods
+        where binding `127.0.0.1` for a callback fails.
+      tags: [Authentication]
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: "#/components/schemas/DeviceAuthorizationRequest"
+      responses:
+        "200":
+          description: Device flow initiated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeviceAuthorizationResponse"
+
+  /oauth/token:
+    post:
+      operationId: exchangeOAuthToken
+      summary: Exchange a device_code (or refresh_token) for an access token
+      description: |
+        Handles two grant types:
+          - `urn:ietf:params:oauth:grant-type:device_code` (RFC 8628 §3.4):
+            CLI polls this after `/v1/oauth/device_code` until the user
+            authorizes in their browser. Returns
+            `authorization_pending` / `slow_down` (HTTP 400) until ready.
+          - `refresh_token` (RFC 6749 §6): rotates the refresh token and
+            returns a fresh access token. The previous refresh_token is
+            invalidated; reusing it triggers family invalidation (Auth0
+            pattern) — all tokens in the chain are revoked.
+
+        No `client_secret` is accepted; the CLI is a public OAuth client.
+      tags: [Authentication]
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: "#/components/schemas/OAuthTokenRequest"
+      responses:
+        "200":
+          description: Token issued successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OAuthTokenResponse"
+        "400":
+          description: |
+            Standard OAuth 2.0 error responses (RFC 6749 §5.2 + RFC 8628 §3.5):
+              - `authorization_pending` — user has not yet authorized; CLI
+                should continue polling.
+              - `slow_down` — polling too frequently; increase interval by 5s.
+              - `expired_token` — device_code expired; restart the flow.
+              - `access_denied` — user explicitly denied.
+              - `invalid_grant` — refresh_token rejected (reused, revoked, or
+                family invalidated).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OAuthError"
+
+  /oauth/revoke:
+    post:
+      operationId: revokeOAuthToken
+      summary: Revoke an OAuth token (RFC 7009)
+      description: |
+        Logout. Revokes the supplied token (and its family, if it is a
+        refresh token). Always returns 200 per RFC 7009 §2.2 — never leaks
+        whether the token existed.
+      tags: [Authentication]
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: "#/components/schemas/OAuthRevokeRequest"
+      responses:
+        "200":
+          description: Revoked (always returned, idempotent)
 
   # -------------------------------------------------------------------------
   # Boxes
@@ -920,9 +1024,48 @@ components:
       type: http
       scheme: bearer
       description: |
-        Bearer authentication with an opaque API key issued by the dashboard
-        at `https://app.boxlite.ai/settings/api-keys`. Send as
-        `Authorization: Bearer <api-key>`. No token exchange required.
+        Bearer authentication. The wire format is RFC 6750 — an opaque token
+        passed as `Authorization: Bearer <token>`. The server is **format-
+        agnostic**: any token its validation pipeline can verify is accepted.
+
+        ## Token sources the server validates
+
+        Which sources are enabled depends on deployment configuration. The
+        validation pipeline is pluggable; new sources can be added without
+        client changes.
+
+          1. **BoxLite-issued** (always enabled). Tokens minted by this
+             server come in three kinds:
+               - `blk_live_…` / `blk_test_…` — dashboard-issued API keys.
+                 Long-lived, org-scoped, survives teammate offboarding.
+                 Use for CI, server-side automation, SDK integrations.
+                 Issued at `https://app.boxlite.ai/settings/api-keys`.
+               - `blo_…` — OAuth access tokens from `POST /v1/oauth/token`
+                 (device-flow grant). 15-minute lifetime. Acts as the
+                 specific user who authorized via `boxlite auth login --web`.
+               - `blr_…` — OAuth refresh tokens. Only sent to
+                 `POST /v1/oauth/token` (`grant_type=refresh_token`), never
+                 as `Authorization: Bearer` for resource calls.
+          2. **Federated SSO / enterprise JWTs** (optional, per-deployment).
+             JWTs issued by a configured enterprise IdP (Okta, Auth0,
+             Azure AD, Google Workspace). Validated against the IdP's JWKS;
+             `iss`, `aud`, `sub`, `exp` claims checked. Principal is
+             projected from claims into the BoxLite identity model.
+          3. **Third-party OIDC tokens** (optional, per-deployment). Access
+             tokens from public IdPs (GitHub, Google, Anthropic). Validated
+             by introspection against the IdP's userinfo endpoint. Used by
+             "Sign in with X" integrations.
+          4. **Customer-issued passthrough tokens** (optional, when a
+             customer fronts the BoxLite gateway with their own auth layer).
+             The customer's gateway authenticates the request, attaches a
+             token in a configured format, and BoxLite trusts the upstream
+             chain.
+
+        Clients (SDKs, CLI) treat all of these identically — opaque strings
+        carried in `Authorization: Bearer`. The CLI's `boxlite auth login`
+        provides the two BoxLite-issued paths (API key paste, OAuth device
+        flow); other sources are configured at the customer's gateway or
+        IdP layer.
 
   # -------------------------------------------------------------------------
   # Parameters
@@ -1234,6 +1377,156 @@ components:
           description: |
             Optional expiry. `null` for long-lived dashboard-issued keys;
             ISO 8601 timestamp for rotating credentials.
+
+    DeviceAuthorizationRequest:
+      type: object
+      required: [client_id]
+      properties:
+        client_id:
+          type: string
+          description: |
+            Public client identifier. The BoxLite CLI uses the literal
+            value `boxlite-cli`. No `client_secret` — public client.
+          example: boxlite-cli
+        scope:
+          type: string
+          description: |
+            Space-delimited scope list (RFC 6749 §3.3). Defaults to the
+            full set the CLI needs.
+          example: "box:read box:write box:exec image:read image:write me:read"
+
+    DeviceAuthorizationResponse:
+      type: object
+      required: [device_code, user_code, verification_uri, expires_in, interval]
+      description: |
+        RFC 8628 §3.2 device authorization response.
+      properties:
+        device_code:
+          type: string
+          description: Opaque code the CLI polls `/oauth/token` with.
+        user_code:
+          type: string
+          description: |
+            Short human-typeable code (8 chars, dash-separated). The user
+            enters this at `verification_uri`.
+          example: "WDJB-MJHT"
+        verification_uri:
+          type: string
+          format: uri
+          description: URL the user opens to authorize.
+          example: "https://app.boxlite.ai/activate"
+        verification_uri_complete:
+          type: string
+          format: uri
+          description: |
+            Optional URL that embeds `user_code` for one-click activation.
+            The CLI displays this as a clickable link when available.
+          example: "https://app.boxlite.ai/activate?user_code=WDJB-MJHT"
+        expires_in:
+          type: integer
+          description: Lifetime of `device_code` in seconds.
+          example: 600
+        interval:
+          type: integer
+          description: Minimum seconds between polls of `/oauth/token`.
+          example: 5
+
+    OAuthTokenRequest:
+      type: object
+      required: [grant_type]
+      description: |
+        Form-encoded request to `POST /oauth/token`. The `grant_type`
+        determines which other fields are required.
+      properties:
+        grant_type:
+          type: string
+          enum:
+            - "urn:ietf:params:oauth:grant-type:device_code"
+            - "refresh_token"
+          description: |
+            `device_code` grant requires `device_code` + `client_id`.
+            `refresh_token` grant requires `refresh_token` + `client_id`.
+        device_code:
+          type: string
+          description: Required when grant_type is `device_code`.
+        refresh_token:
+          type: string
+          description: Required when grant_type is `refresh_token`.
+        client_id:
+          type: string
+          description: Public client identifier (e.g., `boxlite-cli`).
+
+    OAuthTokenResponse:
+      type: object
+      required: [access_token, token_type, expires_in]
+      description: RFC 6749 §5.1 token response.
+      properties:
+        access_token:
+          type: string
+          description: |
+            Opaque bearer token starting with `blo_`. Send as
+            `Authorization: Bearer <access_token>` to resource endpoints.
+          example: "blo_AbCdEfGhIjKlMnOpQrStUvWxYz012345"
+        token_type:
+          type: string
+          enum: [Bearer]
+        expires_in:
+          type: integer
+          description: Access token lifetime in seconds.
+          example: 900
+        refresh_token:
+          type: string
+          description: |
+            Opaque token starting with `blr_`. Stored by the CLI and used
+            to obtain a fresh `access_token`. Rotated on every refresh.
+          example: "blr_ZyXwVuTsRqPoNmLkJiHgFeDcBa543210"
+        scope:
+          type: string
+          description: Granted scopes (space-delimited).
+
+    OAuthRevokeRequest:
+      type: object
+      required: [token]
+      description: RFC 7009 §2.1 token revocation request.
+      properties:
+        token:
+          type: string
+          description: |
+            The access_token or refresh_token to revoke. If a refresh_token
+            is provided, the entire token family is invalidated.
+        token_type_hint:
+          type: string
+          enum: [access_token, refresh_token]
+          description: |
+            Optional hint to speed up server-side lookup. Servers MUST
+            still extend the search to the other type if the hinted lookup
+            fails (§4.1.2).
+
+    OAuthError:
+      type: object
+      required: [error]
+      description: RFC 6749 §5.2 / RFC 8628 §3.5 error response.
+      properties:
+        error:
+          type: string
+          enum:
+            - authorization_pending
+            - slow_down
+            - expired_token
+            - access_denied
+            - invalid_grant
+            - invalid_request
+            - invalid_client
+            - unauthorized_client
+            - unsupported_grant_type
+            - invalid_scope
+        error_description:
+          type: string
+          description: Human-readable explanation, optional per §5.2.
+        error_uri:
+          type: string
+          format: uri
+          description: Optional URL to a page explaining the error.
 
     # =======================================================================
     # Error Model


### PR DESCRIPTION
## Summary

OpenAPI spec change only. Three logical edits ship together because the wire contract is one coherent story:

1. **Replace dual securitySchemes with single `BearerAuth`** (drops the OAuth2 `client_credentials` facade that collapsed to "client_secret IS the API key" — RFC 6749 §2.3.1 non-compliant). Description documents the four token sources the validation pipeline accepts: BoxLite-issued API keys, BoxLite-issued OAuth tokens, federated SSO JWTs, customer-issued gateway tokens.
2. **Add `GET /v1/me`** + `Principal` schema (`sub`, `principal_type`, `email`, `display_name`, `prefix`, `scopes`, `expires_at`).
3. **Add `/v1/oauth/device_code` / `/v1/oauth/token` / `/v1/oauth/revoke`** for RFC 8628 device flow + RFC 7009 revocation.

Device flow over loopback PKCE: BoxLite users run the CLI inside containers / SSH / remote dev pods where binding 127.0.0.1 fails. Vercel switched for the same reason in Sept 2025.

## Stacked PRs

This is one of four PRs that together replace the original combined branch:

- **PR 1 (this one):** spec only — `feat/auth-single-bearer-impl`
- **PR 2:** Rust SDK + FFI bindings — `feat/auth-rest-credential`
- **PR 3:** CLI `auth login --web` — `feat/auth-cli-device-flow` (stacks on PR 2)
- **PR 4:** Axum / Python reference servers + NestJS controllers — `feat/auth-server-stubs`

Each PR is independently reviewable; only PR 3 has a hard merge dependency (on PR 2).

## Test plan

- [ ] Spec lints (`spectral`, `openapi-cli validate`)
- [ ] Rendered docs preview shows the four token sources description
- [ ] SDK / server PRs reference these endpoints by path + operationId