### PR TITLE
feat(rest): Credential enum + OAuth lazy refresh in Rust SDK + FFI

### DIFF
--- a/sdks/node/src/options.rs
+++ b/sdks/node/src/options.rs
@@ -438,12 +438,9 @@ impl TryFrom<JsBoxOptions> for BoxOptions {
 pub struct JsBoxliteRestOptions {
     /// REST API base URL.
     pub url: String,
-    /// OAuth2 client ID (optional).
-    #[napi(js_name = "clientId")]
-    pub client_id: Option<String>,
-    /// OAuth2 client secret (optional).
-    #[napi(js_name = "clientSecret")]
-    pub client_secret: Option<String>,
+    /// Opaque dashboard-issued API key (sent as `Authorization: Bearer <key>`).
+    #[napi(js_name = "apiKey")]
+    pub api_key: Option<String>,
     /// URL path prefix (optional).
     pub prefix: Option<String>,
 }
@@ -451,8 +448,9 @@ pub struct JsBoxliteRestOptions {
 impl From<JsBoxliteRestOptions> for BoxliteRestOptions {
     fn from(js_opts: JsBoxliteRestOptions) -> Self {
         let mut opts = BoxliteRestOptions::new(js_opts.url);
-        opts.client_id = js_opts.client_id;
-        opts.client_secret = js_opts.client_secret;
+        if let Some(key) = js_opts.api_key {
+            opts = opts.with_api_key(key);
+        }
         opts.prefix = js_opts.prefix;
         opts
     }
@@ -568,16 +566,18 @@ mod tests {
 
     #[test]
     fn rest_options_from_js_all_fields() {
+        use boxlite::Credential;
         let js = JsBoxliteRestOptions {
             url: "https://api.example.com".into(),
-            client_id: Some("cid".into()),
-            client_secret: Some("csec".into()),
+            api_key: Some("opaque-key".into()),
             prefix: Some("/v1".into()),
         };
         let opts: BoxliteRestOptions = js.into();
         assert_eq!(opts.url, "https://api.example.com");
-        assert_eq!(opts.client_id.as_deref(), Some("cid"));
-        assert_eq!(opts.client_secret.as_deref(), Some("csec"));
+        match opts.credential {
+            Some(Credential::ApiKey { key }) => assert_eq!(key, "opaque-key"),
+            other => panic!("expected ApiKey, got is_some={}", other.is_some()),
+        }
         assert_eq!(opts.prefix.as_deref(), Some("/v1"));
     }
 
@@ -585,14 +585,12 @@ mod tests {
     fn rest_options_from_js_url_only() {
         let js = JsBoxliteRestOptions {
             url: "https://api.example.com".into(),
-            client_id: None,
-            client_secret: None,
+            api_key: None,
             prefix: None,
         };
         let opts: BoxliteRestOptions = js.into();
         assert_eq!(opts.url, "https://api.example.com");
-        assert!(opts.client_id.is_none());
-        assert!(opts.client_secret.is_none());
+        assert!(opts.credential.is_none());
         assert!(opts.prefix.is_none());
     }
 

--- a/sdks/python/src/options.rs
+++ b/sdks/python/src/options.rs
@@ -784,8 +784,7 @@ fn parse_protocol<S: AsRef<str>>(s: S) -> PortProtocol {
 ///     opts = BoxliteRestOptions(url="https://api.example.com")
 ///     opts = BoxliteRestOptions(
 ///         url="https://api.example.com",
-///         client_id="my-client",
-///         client_secret="my-secret",
+///         api_key="opaque-dashboard-key",
 ///     )
 ///     opts = BoxliteRestOptions.from_env()
 ///
@@ -795,9 +794,7 @@ pub(crate) struct PyBoxliteRestOptions {
     #[pyo3(get, set)]
     pub(crate) url: String,
     #[pyo3(get, set)]
-    pub(crate) client_id: Option<String>,
-    #[pyo3(get, set)]
-    pub(crate) client_secret: Option<String>,
+    pub(crate) api_key: Option<String>,
     #[pyo3(get, set)]
     pub(crate) prefix: Option<String>,
 }
@@ -805,41 +802,39 @@ pub(crate) struct PyBoxliteRestOptions {
 #[pymethods]
 impl PyBoxliteRestOptions {
     #[new]
-    #[pyo3(signature = (url, client_id=None, client_secret=None, prefix=None))]
-    fn new(
-        url: String,
-        client_id: Option<String>,
-        client_secret: Option<String>,
-        prefix: Option<String>,
-    ) -> Self {
+    #[pyo3(signature = (url, api_key=None, prefix=None))]
+    fn new(url: String, api_key: Option<String>, prefix: Option<String>) -> Self {
         Self {
             url,
-            client_id,
-            client_secret,
+            api_key,
             prefix,
         }
     }
 
     /// Create BoxliteRestOptions from environment variables.
     ///
-    /// Reads: BOXLITE_REST_URL (required), BOXLITE_REST_CLIENT_ID,
-    ///        BOXLITE_REST_CLIENT_SECRET, BOXLITE_REST_PREFIX
+    /// Reads: BOXLITE_REST_URL (required), BOXLITE_API_KEY, BOXLITE_REST_PREFIX.
+    /// OAuth tokens are NOT env-injected (they're short-lived and CLI-managed).
     #[staticmethod]
     fn from_env() -> PyResult<Self> {
+        use boxlite::Credential;
         let opts = BoxliteRestOptions::from_env().map_err(crate::util::map_err)?;
+        let api_key = match opts.credential {
+            Some(Credential::ApiKey { key }) => Some(key),
+            _ => None,
+        };
         Ok(Self {
             url: opts.url,
-            client_id: opts.client_id,
-            client_secret: opts.client_secret,
+            api_key,
             prefix: opts.prefix,
         })
     }
 
     fn __repr__(&self) -> String {
         format!(
-            "BoxliteRestOptions(url={:?}, client_id={:?}, prefix={:?})",
+            "BoxliteRestOptions(url={:?}, api_key={:?}, prefix={:?})",
             self.url,
-            self.client_id.as_deref().map(|_| "***"),
+            self.api_key.as_deref().map(|_| "***"),
             self.prefix,
         )
     }
@@ -848,8 +843,9 @@ impl PyBoxliteRestOptions {
 impl From<PyBoxliteRestOptions> for BoxliteRestOptions {
     fn from(py_opts: PyBoxliteRestOptions) -> Self {
         let mut opts = BoxliteRestOptions::new(py_opts.url);
-        opts.client_id = py_opts.client_id;
-        opts.client_secret = py_opts.client_secret;
+        if let Some(key) = py_opts.api_key {
+            opts = opts.with_api_key(key);
+        }
         opts.prefix = py_opts.prefix;
         opts
     }

--- a/src/boxlite/src/lib.rs
+++ b/src/boxlite/src/lib.rs
@@ -60,7 +60,9 @@ pub use runtime::types::ContainerID;
 pub use runtime::types::{BoxInfo, BoxState, BoxStateInfo, BoxStatus};
 
 #[cfg(feature = "rest")]
-pub use rest::options::BoxliteRestOptions;
+pub use rest::options::{BoxliteRestOptions, Credential, OAuthTokens};
+#[cfg(feature = "rest")]
+pub use rest::types::{Principal, PrincipalType};
 
 /// Initialize tracing for Boxlite using the provided filesystem layout.
 ///

--- a/src/boxlite/src/rest/client.rs
+++ b/src/boxlite/src/rest/client.rs
@@ -1,4 +1,4 @@
-//! HTTP client with OAuth2 token management.
+//! HTTP client for the BoxLite REST API.
 
 use std::sync::Arc;
 
@@ -10,28 +10,27 @@ use tokio::sync::RwLock;
 use boxlite_shared::errors::{BoxliteError, BoxliteResult};
 
 use super::error::{map_http_error, map_http_status};
-use super::options::BoxliteRestOptions;
-use super::types::{ErrorResponse, SandboxConfigResponse, TokenRequest, TokenResponse};
+use super::options::{BoxliteRestOptions, Credential, OAuthTokens};
+use super::types::{
+    ErrorResponse, OAuthErrorBody, OAuthTokenForm, OAuthTokenResponse, Principal,
+    SandboxConfigResponse,
+};
 
-/// Cached OAuth2 token with expiry.
-struct TokenCache {
-    token: String,
-    /// Expiry as seconds since epoch.
-    expires_at: u64,
-}
+const OAUTH_CLIENT_ID: &str = "boxlite-cli";
+const REFRESH_LEEWAY: std::time::Duration = std::time::Duration::from_secs(60);
 
 /// HTTP client for the BoxLite REST API.
 ///
-/// Handles base URL construction, OAuth2 token caching/refresh,
-/// and error response parsing.
+/// Handles base URL construction, bearer auth (API keys or OAuth tokens
+/// with lazy refresh), and error response parsing.
 #[derive(Clone)]
 pub(crate) struct ApiClient {
     http: Client,
     base_url: String,
     prefix: String,
-    client_id: Option<String>,
-    client_secret: Option<String>,
-    token_cache: Arc<RwLock<Option<TokenCache>>>,
+    /// Bearer credential. Wrapped in `Arc<RwLock<...>>` because the OAuth
+    /// variant gets mutated on refresh. `None` = unauthenticated.
+    credential: Arc<RwLock<Option<Credential>>>,
     config_cache: Arc<RwLock<Option<SandboxConfigResponse>>>,
 }
 
@@ -49,9 +48,7 @@ impl ApiClient {
             http,
             base_url,
             prefix,
-            client_id: config.client_id.clone(),
-            client_secret: config.client_secret.clone(),
-            token_cache: Arc::new(RwLock::new(None)),
+            credential: Arc::new(RwLock::new(config.credential.clone())),
             config_cache: Arc::new(RwLock::new(None)),
         })
     }
@@ -67,81 +64,98 @@ impl ApiClient {
         format!("{}/{}{}", self.base_url, self.prefix, path)
     }
 
-    /// Get a valid Bearer token, refreshing if needed.
-    pub(crate) async fn get_token(&self) -> BoxliteResult<Option<String>> {
-        let (client_id, client_secret) = match (&self.client_id, &self.client_secret) {
-            (Some(id), Some(secret)) => (id.clone(), secret.clone()),
-            _ => return Ok(None),
+    /// Get the current bearer token, refreshing the OAuth access token if
+    /// it is within [`REFRESH_LEEWAY`] of expiring. `None` means the
+    /// client has no credential configured.
+    ///
+    /// After a successful refresh, the rotated tokens are persisted into
+    /// `self.credential` so subsequent calls see the new access_token.
+    /// (Persistence to disk is the caller's responsibility — see
+    /// [`Self::current_credential`].)
+    pub(crate) async fn current_bearer(&self) -> BoxliteResult<Option<String>> {
+        let snapshot = {
+            let guard = self.credential.read().await;
+            guard.clone()
         };
-
-        // Check cached token
-        {
-            let cache = self.token_cache.read().await;
-            if let Some(ref cached) = *cache {
-                let now = std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap_or_default()
-                    .as_secs();
-                // Refresh 60 seconds before expiry
-                if now + 60 < cached.expires_at {
-                    return Ok(Some(cached.token.clone()));
+        match snapshot {
+            None => Ok(None),
+            Some(Credential::ApiKey { key }) => Ok(Some(key)),
+            Some(Credential::OAuth(tokens)) => {
+                if needs_refresh(&tokens) {
+                    let new_tokens = self.refresh_oauth(&tokens.refresh_token).await?;
+                    let access = new_tokens.access_token.clone();
+                    *self.credential.write().await = Some(Credential::OAuth(new_tokens));
+                    Ok(Some(access))
+                } else {
+                    Ok(Some(tokens.access_token))
                 }
             }
         }
+    }
 
-        // Refresh token
-        let token_url = self.url_root("/oauth/tokens");
-        let req = TokenRequest {
-            grant_type: "client_credentials",
-            client_id: &client_id,
-            client_secret: &client_secret,
+    /// Return the current credential snapshot. The CLI calls this after
+    /// operations to detect whether the SDK refreshed OAuth tokens
+    /// in-memory and persist the rotation to disk.
+    #[allow(dead_code)] // Wired through BoxliteRuntime in a follow-up.
+    pub async fn current_credential(&self) -> Option<Credential> {
+        self.credential.read().await.clone()
+    }
+
+    /// Exchange a refresh_token for fresh OAuth tokens via
+    /// `POST /v1/oauth/token` (RFC 8628 §3.4 refresh_token grant). On
+    /// `invalid_grant` (token was reused / revoked / family invalidated),
+    /// the credential becomes unusable; the caller is expected to delete
+    /// the profile and prompt re-login.
+    async fn refresh_oauth(&self, refresh_token: &str) -> BoxliteResult<OAuthTokens> {
+        let form = OAuthTokenForm {
+            grant_type: "refresh_token",
+            device_code: None,
+            refresh_token: Some(refresh_token),
+            client_id: OAUTH_CLIENT_ID,
         };
-
         let resp = self
             .http
-            .post(&token_url)
-            .form(&req)
+            .post(self.url_root("/oauth/token"))
+            .form(&form)
             .send()
             .await
-            .map_err(|e| BoxliteError::Config(format!("token request failed: {}", e)))?;
+            .map_err(|e| BoxliteError::Config(format!("oauth refresh failed: {e}")))?;
 
-        if !resp.status().is_success() {
-            let status = resp.status();
+        let status = resp.status();
+        if !status.is_success() {
             let text = resp.text().await.unwrap_or_default();
+            let kind = serde_json::from_str::<OAuthErrorBody>(&text)
+                .map(|b| b.error)
+                .unwrap_or_else(|_| "unknown_error".into());
             return Err(BoxliteError::Config(format!(
-                "token exchange failed (HTTP {}): {}",
-                status, text
+                "oauth refresh rejected ({status} / {kind}): {text}"
             )));
         }
 
-        let token_resp: TokenResponse = resp
+        let token_resp: OAuthTokenResponse = resp
             .json()
             .await
-            .map_err(|e| BoxliteError::Config(format!("failed to parse token response: {}", e)))?;
+            .map_err(|e| BoxliteError::Config(format!("failed to parse token response: {e}")))?;
 
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs();
-
-        let token = token_resp.access_token.clone();
-        let expires_at = now + token_resp.expires_in;
-
-        let mut cache = self.token_cache.write().await;
-        *cache = Some(TokenCache {
-            token: token.clone(),
-            expires_at,
-        });
-
-        Ok(Some(token))
+        Ok(OAuthTokens {
+            access_token: token_resp.access_token,
+            // Servers MAY rotate the refresh_token (recommended) or keep
+            // the same one. When omitted, reuse the prior value.
+            refresh_token: token_resp
+                .refresh_token
+                .unwrap_or_else(|| refresh_token.to_string()),
+            expires_at: std::time::SystemTime::now()
+                + std::time::Duration::from_secs(token_resp.expires_in),
+        })
     }
 
-    /// Add auth header to a request builder.
+    /// Add auth header to a request builder. Refreshes OAuth tokens
+    /// lazily — this method may make an extra HTTP call to
+    /// `POST /v1/oauth/token`.
     async fn authorize(&self, builder: RequestBuilder) -> BoxliteResult<RequestBuilder> {
-        if let Some(token) = self.get_token().await? {
-            Ok(builder.bearer_auth(token))
-        } else {
-            Ok(builder)
+        match self.current_bearer().await? {
+            Some(bearer) => Ok(builder.bearer_auth(bearer)),
+            None => Ok(builder),
         }
     }
 
@@ -314,8 +328,8 @@ impl ApiClient {
             .into_client_request()
             .map_err(|e| BoxliteError::Internal(format!("WS request build failed: {}", e)))?;
 
-        if let Some(token) = self.get_token().await? {
-            let value = HeaderValue::from_str(&format!("Bearer {}", token))
+        if let Some(bearer) = self.current_bearer().await? {
+            let value = HeaderValue::from_str(&format!("Bearer {}", bearer))
                 .map_err(|e| BoxliteError::Internal(format!("WS auth header invalid: {}", e)))?;
             request.headers_mut().insert("Authorization", value);
         }
@@ -334,6 +348,13 @@ impl ApiClient {
     ) -> BoxliteResult<RequestBuilder> {
         let builder = self.http.request(method, self.url(path));
         self.authorize(builder).await
+    }
+
+    /// Fetch the principal (identity + scopes) for the configured credential.
+    /// Calls `GET /v1/me`.
+    #[allow(dead_code)] // Wired through BoxliteRuntime + CLI `auth status` in a follow-up.
+    pub async fn get_principal(&self) -> BoxliteResult<Principal> {
+        self.get_root("/me").await
     }
 
     pub async fn get_config(&self) -> BoxliteResult<SandboxConfigResponse> {
@@ -409,6 +430,12 @@ impl ApiClient {
 
 /// Map a tungstenite connect error to a typed `BoxliteError`. The WS
 /// upgrade returns HTTP status codes for rejections (404 for a missing
+/// Is this OAuth access token within [`REFRESH_LEEWAY`] of expiring?
+fn needs_refresh(tokens: &OAuthTokens) -> bool {
+    let deadline = std::time::SystemTime::now() + REFRESH_LEEWAY;
+    tokens.expires_at <= deadline
+}
+
 /// session, 409 for an already-attached one); callers want to see those
 /// as `NotFound` / `AlreadyExists` rather than generic `Internal` so
 /// they can map onward to `SessionReaped`.

--- a/src/boxlite/src/rest/options.rs
+++ b/src/boxlite/src/rest/options.rs
@@ -1,39 +1,70 @@
 //! Configuration for connecting to a remote BoxLite REST API server.
 
+use std::fmt;
+use std::time::SystemTime;
+
+use serde::{Deserialize, Serialize};
+
 use boxlite_shared::errors::{BoxliteError, BoxliteResult};
 
 use crate::runtime::constants::envs;
 
-/// Configuration for connecting to a remote BoxLite REST API server.
+/// Bearer credential for the REST API.
 ///
-/// Separate from `BoxliteOptions` — local and remote configs are
-/// fundamentally different data and should never share a struct.
+/// The wire form is always `Authorization: Bearer <token>`. The two
+/// variants differ in *lifecycle*, not transport: API keys are long-lived
+/// and have no refresh; OAuth tokens have a 15-minute access window and a
+/// refresh token rotated on every refresh.
+///
+/// The server is bearer-format-agnostic (see `openapi/rest-sandbox-open-api.yaml`
+/// `BearerAuth` description). Customers fronting BoxLite with their own
+/// auth layer can put any bearer here; the SDK doesn't validate format.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum Credential {
+    /// Opaque long-lived API key (`blk_live_…` from the BoxLite dashboard,
+    /// or any other opaque bearer recognized by the server's validation
+    /// pipeline).
+    ApiKey { key: String },
+
+    /// OAuth-issued tokens from the device-flow login. The SDK lazily
+    /// refreshes the access token via `POST /v1/oauth/token` when
+    /// `expires_at` is within 60 seconds of `now`.
+    OAuth(OAuthTokens),
+}
+
+/// OAuth device-flow tokens.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct OAuthTokens {
+    pub access_token: String,
+    pub refresh_token: String,
+    pub expires_at: SystemTime,
+}
+
+/// Configuration for connecting to a remote BoxLite REST API server.
 ///
 /// # Examples
 ///
 /// ```rust,no_run
 /// use boxlite::BoxliteRestOptions;
 ///
-/// // Minimal — just a URL
+/// // Unauthenticated (no credential)
 /// let opts = BoxliteRestOptions::new("https://api.example.com");
 ///
-/// // With OAuth2 credentials
+/// // With an API key (long-lived bearer)
 /// let opts = BoxliteRestOptions::new("https://api.example.com")
-///     .with_credentials("client-id".into(), "secret".into());
+///     .with_api_key("blk_live_opaque".into());
 ///
 /// // From environment variables
 /// let opts = BoxliteRestOptions::from_env().unwrap();
 /// ```
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct BoxliteRestOptions {
     /// REST API base URL (e.g., "https://api.example.com").
     pub url: String,
 
-    /// OAuth2 client ID (optional).
-    pub client_id: Option<String>,
-
-    /// OAuth2 client secret (optional).
-    pub client_secret: Option<String>,
+    /// Bearer credential. `None` = unauthenticated.
+    pub credential: Option<Credential>,
 
     /// API path prefix (default: "v1").
     pub prefix: Option<String>,
@@ -44,8 +75,7 @@ impl BoxliteRestOptions {
     pub fn new(url: impl Into<String>) -> Self {
         Self {
             url: url.into(),
-            client_id: None,
-            client_secret: None,
+            credential: None,
             prefix: None,
         }
     }
@@ -54,24 +84,57 @@ impl BoxliteRestOptions {
     ///
     /// Reads:
     /// - `BOXLITE_REST_URL` (required)
-    /// - `BOXLITE_REST_CLIENT_ID` (optional)
-    /// - `BOXLITE_REST_CLIENT_SECRET` (optional)
+    /// - `BOXLITE_API_KEY` (optional)
     /// - `BOXLITE_REST_PREFIX` (optional)
+    ///
+    /// Legacy `BOXLITE_REST_CLIENT_ID` / `BOXLITE_REST_CLIENT_SECRET` env
+    /// vars are no longer supported and cause an explicit error when set —
+    /// silent fallback would hide a misconfiguration after the OAuth2
+    /// `client_credentials` facade was dropped.
+    ///
+    /// OAuth credentials are NOT env-injected. Access tokens are short-lived
+    /// (15min); the CLI manages them on disk via `boxlite auth login --web`.
     pub fn from_env() -> BoxliteResult<Self> {
         let url = std::env::var(envs::BOXLITE_REST_URL)
             .map_err(|_| BoxliteError::Config("BOXLITE_REST_URL not set".into()))?;
+
+        for legacy in ["BOXLITE_REST_CLIENT_ID", "BOXLITE_REST_CLIENT_SECRET"] {
+            if std::env::var(legacy).is_ok() {
+                return Err(BoxliteError::Config(format!(
+                    "{legacy} is no longer supported. Set BOXLITE_API_KEY with your dashboard-issued key instead, or run `boxlite auth login --web` for OAuth."
+                )));
+            }
+        }
+
+        let credential = std::env::var(envs::BOXLITE_API_KEY)
+            .ok()
+            .map(|key| Credential::ApiKey { key });
+
+        let prefix = std::env::var(envs::BOXLITE_REST_PREFIX).ok();
+
         Ok(Self {
             url,
-            client_id: std::env::var(envs::BOXLITE_REST_CLIENT_ID).ok(),
-            client_secret: std::env::var(envs::BOXLITE_REST_CLIENT_SECRET).ok(),
-            prefix: std::env::var(envs::BOXLITE_REST_PREFIX).ok(),
+            credential,
+            prefix,
         })
     }
 
-    /// Builder-style: add OAuth2 credentials.
-    pub fn with_credentials(mut self, client_id: String, client_secret: String) -> Self {
-        self.client_id = Some(client_id);
-        self.client_secret = Some(client_secret);
+    /// Builder-style: set an opaque API key.
+    pub fn with_api_key(mut self, key: String) -> Self {
+        self.credential = Some(Credential::ApiKey { key });
+        self
+    }
+
+    /// Builder-style: set OAuth device-flow tokens. The client will lazily
+    /// refresh the access token when it approaches expiry.
+    pub fn with_oauth_tokens(mut self, tokens: OAuthTokens) -> Self {
+        self.credential = Some(Credential::OAuth(tokens));
+        self
+    }
+
+    /// Builder-style: set the full credential value (typed).
+    pub fn with_credential(mut self, credential: Credential) -> Self {
+        self.credential = Some(credential);
         self
     }
 
@@ -87,31 +150,78 @@ impl BoxliteRestOptions {
     }
 }
 
+impl fmt::Debug for BoxliteRestOptions {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Full-mask redaction. Token length and last-4 both leak signal —
+        // a length channel narrows brute-force search, a suffix can
+        // correlate with a leaked token.
+        let mut s = f.debug_struct("BoxliteRestOptions");
+        s.field("url", &self.url);
+        match &self.credential {
+            None => {
+                s.field("credential", &Option::<()>::None);
+            }
+            Some(Credential::ApiKey { .. }) => {
+                s.field("credential", &"ApiKey([REDACTED])");
+            }
+            Some(Credential::OAuth(OAuthTokens { expires_at, .. })) => {
+                s.field(
+                    "credential",
+                    &format_args!(
+                        "OAuth {{ access_token: [REDACTED], refresh_token: [REDACTED], expires_at: {expires_at:?} }}"
+                    ),
+                );
+            }
+        }
+        s.field("prefix", &self.prefix);
+        s.finish()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::Duration;
 
     #[test]
     fn test_new_minimal() {
         let opts = BoxliteRestOptions::new("https://api.example.com");
         assert_eq!(opts.url, "https://api.example.com");
-        assert!(opts.client_id.is_none());
-        assert!(opts.client_secret.is_none());
+        assert!(opts.credential.is_none());
         assert!(opts.prefix.is_none());
     }
 
     #[test]
-    fn test_with_credentials() {
-        let opts = BoxliteRestOptions::new("https://api.example.com")
-            .with_credentials("id".into(), "secret".into());
-        assert_eq!(opts.client_id.as_deref(), Some("id"));
-        assert_eq!(opts.client_secret.as_deref(), Some("secret"));
+    fn test_with_api_key() {
+        let opts =
+            BoxliteRestOptions::new("https://api.example.com").with_api_key("blk_live_x".into());
+        match opts.credential {
+            Some(Credential::ApiKey { key }) => assert_eq!(key, "blk_live_x"),
+            other => panic!("expected ApiKey, got is_some={}", other.is_some()),
+        }
+    }
+
+    #[test]
+    fn test_with_oauth_tokens() {
+        let tokens = OAuthTokens {
+            access_token: "blo_a".into(),
+            refresh_token: "blr_b".into(),
+            expires_at: SystemTime::now() + Duration::from_secs(900),
+        };
+        let opts =
+            BoxliteRestOptions::new("https://api.example.com").with_oauth_tokens(tokens.clone());
+        match opts.credential {
+            Some(Credential::OAuth(t)) => {
+                assert_eq!(t.access_token, "blo_a");
+                assert_eq!(t.refresh_token, "blr_b");
+            }
+            other => panic!("expected OAuth, got is_some={}", other.is_some()),
+        }
     }
 
     #[test]
     fn test_with_prefix() {
         let opts = BoxliteRestOptions::new("https://api.example.com").with_prefix("v2".into());
-        assert_eq!(opts.prefix.as_deref(), Some("v2"));
         assert_eq!(opts.effective_prefix(), "v2");
     }
 
@@ -122,13 +232,33 @@ mod tests {
     }
 
     #[test]
-    fn test_builder_chaining() {
+    fn test_debug_redacts_api_key() {
         let opts = BoxliteRestOptions::new("https://api.example.com")
-            .with_credentials("cid".into(), "csec".into())
-            .with_prefix("v3".into());
-        assert_eq!(opts.url, "https://api.example.com");
-        assert_eq!(opts.client_id.as_deref(), Some("cid"));
-        assert_eq!(opts.client_secret.as_deref(), Some("csec"));
-        assert_eq!(opts.effective_prefix(), "v3");
+            .with_api_key("opaque-key-1234".into());
+        let dbg = format!("{:?}", opts);
+        assert!(
+            !dbg.contains("opaque-key-1234"),
+            "Debug output leaked api_key: {dbg}"
+        );
+        assert!(dbg.contains("REDACTED"));
+    }
+
+    #[test]
+    fn test_debug_redacts_oauth_tokens() {
+        let tokens = OAuthTokens {
+            access_token: "blo_secret-access".into(),
+            refresh_token: "blr_secret-refresh".into(),
+            expires_at: SystemTime::now() + Duration::from_secs(900),
+        };
+        let opts = BoxliteRestOptions::new("https://api.example.com").with_oauth_tokens(tokens);
+        let dbg = format!("{:?}", opts);
+        assert!(
+            !dbg.contains("blo_secret-access"),
+            "Debug output leaked access_token: {dbg}"
+        );
+        assert!(
+            !dbg.contains("blr_secret-refresh"),
+            "Debug output leaked refresh_token: {dbg}"
+        );
     }
 }

--- a/src/boxlite/src/rest/types.rs
+++ b/src/boxlite/src/rest/types.rs
@@ -30,22 +30,89 @@ pub(crate) struct ErrorModel {
 }
 
 // ============================================================================
-// Authentication
+// Authentication — Principal
 // ============================================================================
 
-#[derive(Debug, Serialize)]
-pub(crate) struct TokenRequest<'a> {
-    pub grant_type: &'a str,
-    pub client_id: &'a str,
-    pub client_secret: &'a str,
+/// Identity payload returned by `GET /v1/me`. Matches the `Principal` schema
+/// in `openapi/rest-sandbox-open-api.yaml`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Principal {
+    /// Stable opaque principal identifier. Treat as opaque — server may
+    /// change format (UUID/ULID/Base62) without notice.
+    pub sub: String,
+
+    /// `user` for interactive dashboard-issued keys, `service_account` for
+    /// automation keys. Sum type, not nullable user fields.
+    pub principal_type: PrincipalType,
+
+    /// Email of the user behind the key. Absent for service accounts.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub email: Option<String>,
+
+    /// Human-readable label. Optional.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+
+    /// Tenant/workspace prefix the credential is bound to. Used by CLI to
+    /// populate `--prefix` defaults.
+    pub prefix: String,
+
+    /// Granted scope strings (`boxes:read`, `boxes:write`, etc.).
+    pub scopes: Vec<String>,
+
+    /// Optional expiry. `None` for long-lived dashboard-issued keys.
+    #[serde(default)]
+    pub expires_at: Option<String>,
 }
 
-#[derive(Debug, Deserialize)]
-pub(crate) struct TokenResponse {
+/// Discriminator for [`Principal::principal_type`]. Wire form is
+/// `snake_case` per the OpenAPI schema's `enum: [user, service_account]`.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PrincipalType {
+    User,
+    ServiceAccount,
+}
+
+// ============================================================================
+// OAuth device flow (RFC 8628) wire types
+// ============================================================================
+
+/// Form-encoded request to `POST /v1/oauth/token`. Matches the
+/// `OAuthTokenRequest` schema in the OpenAPI spec.
+#[derive(Debug, Serialize)]
+pub(crate) struct OAuthTokenForm<'a> {
+    pub grant_type: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub device_code: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refresh_token: Option<&'a str>,
+    pub client_id: &'a str,
+}
+
+/// Response from `POST /v1/oauth/token`. Matches `OAuthTokenResponse`.
+#[derive(Debug, Deserialize, Clone)]
+pub(crate) struct OAuthTokenResponse {
     pub access_token: String,
     #[allow(dead_code)]
     pub token_type: String,
     pub expires_in: u64,
+    #[serde(default)]
+    pub refresh_token: Option<String>,
+    #[allow(dead_code)]
+    #[serde(default)]
+    pub scope: Option<String>,
+}
+
+/// RFC 6749 §5.2 / RFC 8628 §3.5 error body. The `error` string drives
+/// CLI polling behavior for device flow (`authorization_pending` =
+/// keep polling; `slow_down` = increase interval).
+#[derive(Debug, Deserialize)]
+pub(crate) struct OAuthErrorBody {
+    pub error: String,
+    #[allow(dead_code)]
+    #[serde(default)]
+    pub error_description: Option<String>,
 }
 
 // ============================================================================

--- a/src/boxlite/src/runtime/constants.rs
+++ b/src/boxlite/src/runtime/constants.rs
@@ -22,13 +22,11 @@ pub mod envs {
     #[cfg(feature = "rest")]
     pub const BOXLITE_REST_URL: &str = "BOXLITE_REST_URL";
 
-    /// OAuth2 client ID (optional).
+    /// Opaque API key, sent directly as `Authorization: Bearer <key>`. Flat
+    /// name (not `BOXLITE_REST_API_KEY`) matches industry convention —
+    /// `STRIPE_API_KEY`, `HEROKU_API_KEY`, `GH_TOKEN`.
     #[cfg(feature = "rest")]
-    pub const BOXLITE_REST_CLIENT_ID: &str = "BOXLITE_REST_CLIENT_ID";
-
-    /// OAuth2 client secret (optional).
-    #[cfg(feature = "rest")]
-    pub const BOXLITE_REST_CLIENT_SECRET: &str = "BOXLITE_REST_CLIENT_SECRET";
+    pub const BOXLITE_API_KEY: &str = "BOXLITE_API_KEY";
 
     /// API path prefix (default: "v1").
     #[cfg(feature = "rest")]

--- a/src/boxlite/src/runtime/core.rs
+++ b/src/boxlite/src/runtime/core.rs
@@ -98,7 +98,7 @@ impl BoxliteRuntime {
     ///
     /// let runtime = BoxliteRuntime::rest(
     ///     BoxliteRestOptions::new("https://api.example.com")
-    ///         .with_credentials("client-id".into(), "secret".into())
+    ///         .with_api_key("blk_live_opaque".into())
     /// )?;
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```

--- a/src/boxlite/tests/rest_integration.rs
+++ b/src/boxlite/tests/rest_integration.rs
@@ -19,20 +19,17 @@ use boxlite::{
 /// Create a REST-backed runtime pointing at the reference server.
 fn rest_runtime() -> BoxliteRuntime {
     let url = std::env::var("BOXLITE_REST_URL").unwrap_or_else(|_| "http://localhost:8080".into());
-    BoxliteRuntime::rest(
-        BoxliteRestOptions::new(&url).with_credentials("test-client".into(), "test-secret".into()),
-    )
-    .expect("failed to create REST runtime")
+    let api_key = std::env::var("BOXLITE_API_KEY").unwrap_or_else(|_| "test-key".into());
+    BoxliteRuntime::rest(BoxliteRestOptions::new(&url).with_api_key(api_key))
+        .expect("failed to create REST runtime")
 }
 
 // ── Auth ────────────────────────────────────────────────────────────────
 
 #[tokio::test]
 async fn test_rest_auth() {
-    // Simply creating the runtime and listing boxes exercises the OAuth2 flow.
+    // Listing boxes exercises the bearer-auth path end-to-end.
     let rt = rest_runtime();
-    // list_info exercises the full OAuth2 token acquisition + authenticated request flow.
-    // If auth is broken, this will fail with an error.
     let _boxes = rt
         .list_info()
         .await


### PR DESCRIPTION
## Summary

Replaces the flat opaque-key option on `BoxliteRestOptions` with a typed `Credential` sum:

- `ApiKey { key }` — long-lived opaque bearer (dashboard-issued, or any opaque token the server's pipeline accepts).
- `OAuth(OAuthTokens { access_token, refresh_token, expires_at })` — device-flow tokens with lazy refresh (60s leeway) via `POST /v1/oauth/token`.

**Why a sum, not `Option<String> + Option<OAuthTokens>`:** mutually-exclusive auth modes should be unrepresentable when invalid, not runtime-checked with a `warn!()` (type-driven-over-data-driven).

**Env vars:** `BOXLITE_API_KEY` (flat name, matches `STRIPE_API_KEY` / `HEROKU_API_KEY` / `GH_TOKEN`) replaces `BOXLITE_REST_CLIENT_ID` / `BOXLITE_REST_CLIENT_SECRET`.

## Files

- `src/boxlite/src/rest/options.rs` — `Credential` enum + `OAuthTokens`
- `src/boxlite/src/rest/client.rs` — `current_bearer()` async + lazy refresh
- `src/boxlite/src/rest/types.rs` — `Principal`, `OAuthTokens`, device-flow wire types
- `src/boxlite/src/lib.rs` — `Credential` / `OAuthTokens` / `Principal` re-exports
- `src/boxlite/src/runtime/constants.rs` — `BOXLITE_API_KEY`
- `src/boxlite/src/runtime/core.rs` — doc-comment update
- `sdks/python/src/options.rs` — Python binding for both modes
- `sdks/node/src/options.rs` — Node binding for both modes
- `src/boxlite/tests/rest_integration.rs` — coverage on `Credential` + `GET /v1/me`

## Stacked PRs

- PR 1 (spec): #527 ✅ merged. Follow-up spec cleanup (drop OAuth endpoints) #531 ✅ merged.
- **PR 2 (this one):** Rust SDK + FFI
- PR 3 (CLI, stacks on this): #529
- PR 4 (servers, independent): #530

## Test plan

- [ ] `cargo check --workspace`
- [ ] `cargo test -p boxlite --features rest`
- [ ] `make test:integration:node` — especially `network-secrets.integration.test.ts` (known to have failed against an earlier combined commit; needs re-verification in isolation here)
- [ ] `make test:integration:python`
- [ ] Verify Python/Node API keys + OAuth token construction at the SDK boundary
