### PR TITLE
feat(cli): boxlite auth login --web (RFC 8628 device flow)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -469,6 +469,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "comfy-table",
+ "directories",
  "dirs 6.0.0",
  "futures",
  "gtmpl",
@@ -476,6 +477,8 @@ dependencies = [
  "nix 0.30.1",
  "notify",
  "predicates",
+ "reqwest",
+ "rpassword",
  "rstest",
  "serde",
  "serde_json",
@@ -485,10 +488,12 @@ dependencies = [
  "tempfile",
  "term_size",
  "tokio",
+ "toml 0.8.23",
  "tower-http",
  "tracing",
  "tracing-subscriber",
  "ulid",
+ "webbrowser",
 ]
 
 [[package]]
@@ -659,7 +664,7 @@ dependencies = [
  "serde_json",
  "syn 2.0.117",
  "tempfile",
- "toml",
+ "toml 0.9.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -765,6 +770,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "comfy-table"
 version = "7.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -803,6 +818,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -998,6 +1023,15 @@ dependencies = [
  "block-buffer",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "directories"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
+dependencies = [
+ "dirs-sys 0.4.1",
 ]
 
 [[package]]
@@ -1917,6 +1951,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2359,6 +2442,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
 name = "netlink-packet-core"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2577,6 +2666,31 @@ checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
 ]
 
 [[package]]
@@ -2880,7 +2994,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.25.11+spec-1.1.0",
 ]
 
 [[package]]
@@ -3522,6 +3636,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpassword"
+version = "7.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ac5b223d9738ef56e0b98305410be40fa0941bf6036c56f1506751e43552d64"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rstest"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3567,6 +3692,16 @@ dependencies = [
  "nix 0.27.1",
  "thiserror 1.0.69",
  "tokio",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3798,6 +3933,15 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
@@ -3892,6 +4036,22 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -4363,17 +4523,38 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
 version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
  "indexmap 2.14.0",
  "serde_core",
- "serde_spanned",
+ "serde_spanned 1.1.1",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
  "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -4396,6 +4577,20 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
@@ -4414,6 +4609,12 @@ checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow 1.0.2",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -5011,6 +5212,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "webbrowser"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc95580916af1e68ff6a7be07446fc5db73ebf71cf092de939bbf5f7e189f72"
+dependencies = [
+ "core-foundation",
+ "jni",
+ "log",
+ "ndk-context",
+ "objc2",
+ "objc2-foundation",
+ "url",
+ "web-sys",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5436,6 +5653,9 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"

--- a/docs/reference/cli/README.md
+++ b/docs/reference/cli/README.md
@@ -12,7 +12,11 @@ For a quick start, see [`src/cli/README.md`](../../../src/cli/README.md).
 - [Installation & Verification](#installation--verification)
 - [Global Options](#global-options)
 - [Environment Variables](#environment-variables)
+- [Connecting to the cloud](#connecting-to-the-cloud)
 - [Commands](#commands)
+  - [`boxlite auth login`](#boxlite-auth-login)
+  - [`boxlite auth logout`](#boxlite-auth-logout)
+  - [`boxlite auth status`](#boxlite-auth-status)
   - [`boxlite run`](#boxlite-run)
   - [`boxlite exec`](#boxlite-exec)
   - [`boxlite create`](#boxlite-create)
@@ -135,11 +139,105 @@ These flags can appear before *or* after the subcommand and apply to every comma
 |----------|---------|-------------|
 | `BOXLITE_HOME` | `--home` | Runtime data directory; equivalent to `--home` |
 | `BOXLITE_REST_URL` | `--url` | REST server endpoint; equivalent to `--url` |
+| `BOXLITE_API_KEY` | REST runtime | Long-lived API key sent as `Authorization: Bearer`. Overrides any stored credentials. |
 | `RUST_LOG` | tracing | Log level/filter (`error`, `warn`, `info`, `debug`, `trace`; or per-module e.g. `boxlite=debug`) |
 
 ---
 
+## Connecting to the cloud
+
+To target a remote BoxLite REST server instead of the local runtime, sign in with `boxlite auth login`. Credential precedence is **env vars > stored file > unauthenticated** (local runtime). The `--url` flag overrides the URL specifically without affecting credentials.
+
+```bash
+# Interactive
+boxlite auth login
+
+# CI / scripted (API key from stdin)
+echo "$KEY" | boxlite auth login --api-key-stdin --url https://dev.boxlite.ai/api
+
+# CI via env vars only
+BOXLITE_API_KEY=$KEY BOXLITE_REST_URL=https://dev.boxlite.ai/api boxlite list
+```
+
+Credentials are stored at `~/.config/boxlite/credentials.toml` (perms `0600`). See [`boxlite auth login`](#boxlite-auth-login), [`boxlite auth logout`](#boxlite-auth-logout), and [`boxlite auth status`](#boxlite-auth-status) for the full command surface.
+
+---
+
 ## Commands
+
+### `boxlite auth login`
+
+**Synopsis:** `boxlite auth login [OPTIONS]`
+
+Log in to a BoxLite REST server. Two auth paths:
+
+- **API key** — paste a dashboard-issued opaque key (long-lived, org-scoped). Best for CI / server-side automation / SDK integrations.
+- **Browser (`--web`)** — RFC 8628 OAuth 2.0 Device Authorization Grant. The CLI prints a `user_code` and opens a verification URL in your default browser; you complete the flow there. Returns a short-lived `access_token` plus a `refresh_token` the SDK rotates lazily. Best for interactive day-to-day use.
+
+Credentials are stored at `~/.config/boxlite/credentials.toml` (perms `0600`).
+
+**Options:**
+
+| Flag | Description |
+|------|-------------|
+| `--url URL` | Server URL (default: `https://dev.boxlite.ai/api`) |
+| `--api-key-stdin` | Read a long-lived API key from stdin (one line). No flag value — prevents `ps` leakage. |
+| `--web` | Run the browser device flow (RFC 8628) instead of pasting an API key. |
+| `--no-launch-browser` | With `--web`, print the activation URL but don't auto-launch a browser. Useful in SSH sessions / headless hosts where the browser is on a different machine. |
+
+**Examples:**
+
+```bash
+# Interactive — prompts for method
+boxlite auth login
+
+# Browser device flow
+boxlite auth login --web
+
+# API key from stdin (CI-friendly)
+echo "$KEY" | boxlite auth login --api-key-stdin --url https://dev.boxlite.ai/api
+
+# Browser flow, headless host
+boxlite auth login --web --no-launch-browser
+```
+
+---
+
+### `boxlite auth logout`
+
+**Synopsis:** `boxlite auth logout [OPTIONS]`
+
+Delete the stored credentials file at `~/.config/boxlite/credentials.toml`. Prompts for confirmation unless `--yes` is given. Prints `Logged out` on success, or `Not logged in` if no file exists.
+
+**Options:**
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--yes` | `-y` | Skip the confirmation prompt |
+
+---
+
+### `boxlite auth status`
+
+**Synopsis:** `boxlite auth status`
+
+Print the current authentication state without revealing the secret. Reports the logged-in URL, credential mode (API key vs OAuth client credentials), the source (stored file vs env var), and the identity (`client_id` if OAuth, otherwise a placeholder for opaque keys). If neither the file nor env vars are present, prints `Not logged in.`
+
+**Example output:**
+
+```
+Logged in to:    https://dev.boxlite.ai/api
+Credential:      API key (from ~/.config/boxlite/credentials.toml)
+Identity:        (opaque key — no identity available)
+```
+
+When the env var override is active:
+
+```
+Credential:      API key (from BOXLITE_API_KEY env var)
+```
+
+---
 
 ### `boxlite run`
 

--- a/examples/python/08_rest_api/README.md
+++ b/examples/python/08_rest_api/README.md
@@ -35,7 +35,7 @@ Then run examples from this directory:
 python connect_and_list.py
 ```
 
-For env-based client configuration (`use_env_config.py`), set:
+For env-based client configuration (`use_env_config.py`), set OAuth2 client credentials:
 
 ```bash
 BOXLITE_REST_URL=http://localhost:8080
@@ -44,3 +44,14 @@ BOXLITE_REST_CLIENT_SECRET=test-secret
 # Optional (default in SDK is v1):
 BOXLITE_REST_PREFIX=v1
 ```
+
+Or use a long-lived API key (alternative to the client_id/secret pair):
+
+```bash
+BOXLITE_REST_URL=http://localhost:8080
+BOXLITE_API_KEY=your-api-key
+```
+
+`BoxliteRestOptions.from_env()` picks up either credential style. The
+`BOXLITE_API_KEY` path is the recommended option for most users; the
+OAuth2 pair is intended for machine-to-machine integrations.

--- a/examples/python/08_rest_api/use_env_config.py
+++ b/examples/python/08_rest_api/use_env_config.py
@@ -4,15 +4,22 @@ Load REST connection config from environment variables.
 
 Demonstrates:
 - BoxliteRestOptions.from_env() for environment-based configuration
+- Two credential styles: OAuth2 client pair, or long-lived API key
 - Useful for CI/CD pipelines and production deployments
 
 Environment variables:
     BOXLITE_REST_URL          Server URL (required)
-    BOXLITE_REST_CLIENT_ID    OAuth2 client ID
-    BOXLITE_REST_CLIENT_SECRET OAuth2 client secret
+    BOXLITE_API_KEY           Long-lived API key (recommended)
+    BOXLITE_REST_CLIENT_ID    OAuth2 client ID (alternative)
+    BOXLITE_REST_CLIENT_SECRET OAuth2 client secret (alternative)
     BOXLITE_REST_PREFIX       API version prefix (default: v1)
 
-Usage:
+Usage (API key path, recommended):
+    BOXLITE_REST_URL=http://localhost:8080 \
+    BOXLITE_API_KEY=your-api-key \
+    python use_env_config.py
+
+Usage (OAuth2 client credentials, machine-to-machine):
     BOXLITE_REST_URL=http://localhost:8080 \
     BOXLITE_REST_CLIENT_ID=test-client \
     BOXLITE_REST_CLIENT_SECRET=test-secret \
@@ -33,13 +40,19 @@ async def main():
     print("REST API: Environment-Based Configuration")
     print("=" * 50)
 
-    # Load connection config from environment variables
+    # Load connection config from environment variables. from_env() accepts
+    # either BOXLITE_API_KEY (recommended) or the BOXLITE_REST_CLIENT_ID /
+    # BOXLITE_REST_CLIENT_SECRET pair (machine-to-machine).
     try:
         opts = BoxliteRestOptions.from_env()
     except Exception as e:
         print(f"\n  Error: {e}")
-        print("  Set BOXLITE_REST_URL (and optionally credentials) first.")
-        print("  Example:")
+        print("  Set BOXLITE_REST_URL plus one credential style.")
+        print("  API key (recommended):")
+        print("    BOXLITE_REST_URL=http://localhost:8080 \\")
+        print("    BOXLITE_API_KEY=your-api-key \\")
+        print("    python use_env_config.py")
+        print("  OAuth2 client credentials:")
         print("    BOXLITE_REST_URL=http://localhost:8080 \\")
         print("    BOXLITE_REST_CLIENT_ID=test-client \\")
         print("    BOXLITE_REST_CLIENT_SECRET=test-secret \\")

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -47,6 +47,13 @@ tabled = "0.17"
 chrono = "0.4.43"
 comfy-table = "7.2.1"
 
+# Credentials store (auth login/logout/status)
+rpassword = "7"
+toml = "0.8"
+directories = "5"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+webbrowser = "1"
+
 gtmpl = "0.7"
 gtmpl_value = "0.5"
 [build-dependencies]

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -120,6 +120,23 @@ boxlite pull alpine:latest
 boxlite images
 ```
 
+## Connecting to the cloud
+
+To target a remote BoxLite REST server (e.g. `https://dev.boxlite.ai/api`) instead of the local runtime, sign in with `boxlite auth login`. Credential precedence is **env vars > stored file > unauthenticated** (local runtime). The `--url` flag overrides the URL specifically without affecting credentials.
+
+```bash
+# Interactive
+boxlite auth login
+
+# CI / scripted (API key from stdin)
+echo "$KEY" | boxlite auth login --api-key-stdin --url https://dev.boxlite.ai/api
+
+# CI via env vars only
+BOXLITE_API_KEY=$KEY BOXLITE_REST_URL=https://dev.boxlite.ai/api boxlite list
+```
+
+Credentials are stored at `~/.config/boxlite/credentials.toml` (perms `0600`).
+
 ## Commands Reference
 
 > For an exhaustive man-page-style reference (shared flag groups, volume/port grammar,
@@ -136,6 +153,64 @@ Available for all commands:
 | `--home PATH` | BoxLite home directory (default: `~/.boxlite`). Overridden by `BOXLITE_HOME` |
 | `--registry REGISTRY` | Image registry (repeatable; prepended to config) |
 | `--config PATH` | JSON config file path (e.g. for `image_registries`) |
+
+### `boxlite auth login`
+
+Log in to a BoxLite REST server. Two auth modes:
+
+  - **API key** — paste a dashboard-issued opaque key. Long-lived, org-scoped, good for CI / server-side automation / SDK integrations.
+  - **Browser (`--web`)** — RFC 8628 OAuth 2.0 Device Authorization Grant. The CLI prints a `user_code` and opens a verification URL in your default browser; you complete the flow there. Returns a short-lived `access_token` plus a `refresh_token` the SDK rotates lazily. Good for interactive day-to-day use.
+
+Credentials are stored at `~/.config/boxlite/credentials.toml` (perms `0600`).
+
+**Usage:** `boxlite auth login [OPTIONS]`
+
+| Option | Description |
+|--------|-------------|
+| `--url URL` | Server URL (default: `https://dev.boxlite.ai/api`) |
+| `--api-key-stdin` | Read a long-lived API key from stdin (one line). No flag arg — prevents `ps` leakage |
+| `--web` | Run the browser device flow instead of pasting an API key |
+| `--no-launch-browser` | With `--web`, print the activation URL but don't auto-launch a browser. Useful for headless / SSH sessions |
+
+**Examples:**
+
+```bash
+# Interactive — prompts for method
+boxlite auth login
+
+# Browser device flow
+boxlite auth login --web
+
+# API key from stdin (CI-friendly; nothing on argv)
+echo "$KEY" | boxlite auth login --api-key-stdin --url https://dev.boxlite.ai/api
+
+# Browser flow, headless host (no auto-open)
+boxlite auth login --web --no-launch-browser
+```
+
+### `boxlite auth logout`
+
+Remove stored credentials at `~/.config/boxlite/credentials.toml`. Prompts for confirmation unless `--yes` is given.
+
+**Usage:** `boxlite auth logout [OPTIONS]`
+
+| Option | Short | Description |
+|--------|-------|-------------|
+| `--yes` | `-y` | Skip the confirmation prompt |
+
+### `boxlite auth status`
+
+Print the current authentication state: the logged-in URL, credential mode (API key vs OAuth client credentials), source (stored file vs env var), and identity (`client_id` if OAuth). The secret material is never printed.
+
+**Usage:** `boxlite auth status`
+
+**Example output:**
+
+```
+Logged in to:    https://dev.boxlite.ai/api
+Credential:      API key (from ~/.config/boxlite/credentials.toml)
+Identity:        (opaque key — no identity available)
+```
 
 ### `boxlite run`
 
@@ -362,6 +437,7 @@ Then reload your shell or source the file.
 | Variable | Description |
 |----------|-------------|
 | `BOXLITE_HOME` | Runtime home directory (default: `~/.boxlite`). Overridden by `--home`. |
+| `BOXLITE_API_KEY` | Long-lived API key sent as `Authorization: Bearer`. Overrides any stored credentials. |
 | `RUST_LOG` | Log level: `trace`, `debug`, `info`, `warn`, `error`. Use `RUST_LOG=debug` for troubleshooting. |
 
 ## Configuration file

--- a/src/cli/src/cli.rs
+++ b/src/cli/src/cli.rs
@@ -98,6 +98,9 @@ pub enum Commands {
     /// Start a long-running REST API server
     Serve(crate::commands::serve::ServeArgs),
 
+    /// Authenticate with a remote BoxLite server
+    Auth(crate::commands::auth::AuthArgs),
+
     /// Generate shell completion script (hidden from help)
     #[command(hide = true)]
     Completion(CompletionArgs),
@@ -192,12 +195,40 @@ impl GlobalFlags {
     }
 
     pub fn create_runtime(&self) -> anyhow::Result<BoxliteRuntime> {
-        if let Some(ref url) = self.url {
-            let opts = BoxliteRestOptions::new(url);
-            return BoxliteRuntime::rest(opts).map_err(Into::into);
+        // URL precedence: --url / BOXLITE_REST_URL (the clap flag covers both) > stored profile > none.
+        // Credential precedence: BOXLITE_API_KEY env > stored profile > none.
+        // Clap reads BOXLITE_REST_URL into `self.url`, so we don't re-check env here.
+        let stored = crate::credentials::load().ok().flatten();
+
+        let url = self
+            .url
+            .clone()
+            .or_else(|| stored.as_ref().map(|p| p.url.clone()));
+
+        let Some(url) = url else {
+            // No URL anywhere → local runtime, unchanged behavior.
+            let options = self.resolve_runtime_options()?;
+            return self.create_runtime_with_options(options);
+        };
+
+        let mut opts = BoxliteRestOptions::new(url);
+
+        // BOXLITE_API_KEY env beats stored credentials of any kind.
+        if let Ok(key) = std::env::var("BOXLITE_API_KEY")
+            && !key.is_empty()
+        {
+            opts = opts.with_api_key(key);
+        } else if let Some(profile) = stored {
+            // Reuse the credentials module's profile→options conversion so the
+            // precedence rule (api_key > client_credentials) is in one place.
+            opts = crate::credentials::into_rest_options(profile);
+            // The conversion above also sets the URL from the profile; the
+            // caller's --url already won via the precedence check above, so
+            // re-apply it to make sure it wins over the stored URL.
+            opts.url = self.url.clone().unwrap_or(opts.url);
         }
-        let options = self.resolve_runtime_options()?;
-        self.create_runtime_with_options(options)
+
+        BoxliteRuntime::rest(opts).map_err(Into::into)
     }
 }
 
@@ -908,5 +939,62 @@ mod tests {
         assert_eq!(opts.volumes[1].guest_path, "/cache");
         assert!(opts.volumes[1].read_only);
         assert!(opts.volumes[1].host_path.contains("anonymous"));
+    }
+
+    // ─── auth subcommand parse tests ───────────────────────────────────────
+
+    use crate::commands::auth::AuthCommand;
+    use clap::Parser;
+
+    #[test]
+    fn auth_login_parses_with_no_flags() {
+        let cli = Cli::try_parse_from(["boxlite", "auth", "login"]).expect("parse");
+        let Commands::Auth(args) = cli.command else {
+            panic!("expected Commands::Auth");
+        };
+        assert!(matches!(args.command, AuthCommand::Login(_)));
+    }
+
+    #[test]
+    fn auth_logout_parses() {
+        let cli = Cli::try_parse_from(["boxlite", "auth", "logout"]).expect("parse");
+        let Commands::Auth(args) = cli.command else {
+            panic!("expected Commands::Auth");
+        };
+        assert!(matches!(args.command, AuthCommand::Logout(_)));
+    }
+
+    #[test]
+    fn auth_status_parses() {
+        let cli = Cli::try_parse_from(["boxlite", "auth", "status"]).expect("parse");
+        let Commands::Auth(args) = cli.command else {
+            panic!("expected Commands::Auth");
+        };
+        assert!(matches!(args.command, AuthCommand::Status));
+    }
+
+    #[test]
+    fn auth_login_api_key_stdin_conflicts_with_web() {
+        // --api-key-stdin and --web pick different credential paths and
+        // cannot be combined in a single invocation.
+        let err = Cli::try_parse_from(["boxlite", "auth", "login", "--api-key-stdin", "--web"])
+            .expect_err("should reject mixed auth modes");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("cannot be used") || msg.contains("conflicts"),
+            "expected conflict error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn auth_login_no_launch_browser_requires_web() {
+        // --no-launch-browser only makes sense in the device-flow path.
+        let err = Cli::try_parse_from(["boxlite", "auth", "login", "--no-launch-browser"])
+            .expect_err("should reject --no-launch-browser without --web");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("required") || msg.contains("requires"),
+            "expected 'requires' error, got: {msg}"
+        );
     }
 }

--- a/src/cli/src/commands/auth/device.rs
+++ b/src/cli/src/commands/auth/device.rs
@@ -1,0 +1,184 @@
+//! RFC 8628 OAuth 2.0 Device Authorization Grant for `boxlite auth login --web`.
+//!
+//! Chosen over loopback-callback PKCE (RFC 8252 §7.3) because BoxLite users
+//! run the CLI inside containers / SSH sessions / remote dev pods where
+//! binding `127.0.0.1` for a callback fails. Vercel and Auth0 CLIs use the
+//! same approach.
+//!
+//! Wire contract: `openapi/rest-sandbox-open-api.yaml` §`/v1/oauth/*` paths.
+
+use std::io::{self, Write};
+use std::time::{Duration, Instant, SystemTime};
+
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+
+use crate::credentials::OAuthCredentials;
+
+const CLIENT_ID: &str = "boxlite-cli";
+const DEFAULT_SCOPE: &str = "box:read box:write box:exec image:read image:write me:read";
+const DEVICE_CODE_GRANT: &str = "urn:ietf:params:oauth:grant-type:device_code";
+
+#[derive(Debug, Serialize)]
+struct DeviceCodeRequest<'a> {
+    client_id: &'a str,
+    scope: &'a str,
+}
+
+#[derive(Debug, Deserialize)]
+struct DeviceCodeResponse {
+    device_code: String,
+    user_code: String,
+    verification_uri: String,
+    #[serde(default)]
+    verification_uri_complete: Option<String>,
+    expires_in: u64,
+    #[serde(default = "default_interval")]
+    interval: u64,
+}
+
+fn default_interval() -> u64 {
+    5
+}
+
+#[derive(Debug, Serialize)]
+struct TokenForm<'a> {
+    grant_type: &'a str,
+    device_code: &'a str,
+    client_id: &'a str,
+}
+
+#[derive(Debug, Deserialize)]
+struct TokenResponse {
+    access_token: String,
+    #[serde(default)]
+    #[allow(dead_code)]
+    token_type: Option<String>,
+    expires_in: u64,
+    refresh_token: String,
+    #[serde(default)]
+    #[allow(dead_code)]
+    scope: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ErrorBody {
+    error: String,
+}
+
+/// Run the device-flow login against `url`. On success, returns the
+/// persistable OAuth credentials.
+pub async fn login(url: &str, no_launch_browser: bool) -> Result<OAuthCredentials> {
+    let client = reqwest::Client::new();
+    let base = url.trim_end_matches('/');
+
+    // Step 1: initiate device authorization.
+    let device_url = format!("{base}/v1/oauth/device_code");
+    let resp = client
+        .post(&device_url)
+        .form(&DeviceCodeRequest {
+            client_id: CLIENT_ID,
+            scope: DEFAULT_SCOPE,
+        })
+        .send()
+        .await
+        .with_context(|| format!("POST {device_url} (initiate device flow)"))?;
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        bail!("device authorization failed ({status}): {body}");
+    }
+    let dc: DeviceCodeResponse = resp.json().await.context("parsing device_code response")?;
+
+    // Step 2: instruct the user.
+    let activation_url = dc
+        .verification_uri_complete
+        .as_deref()
+        .unwrap_or(&dc.verification_uri);
+    println!();
+    println!("To finish signing in:");
+    println!("  Visit: {}", dc.verification_uri);
+    println!("  Code:  {}", dc.user_code);
+    if dc.verification_uri_complete.is_some() {
+        println!("  (or open the one-click URL: {activation_url})");
+    }
+    println!();
+
+    if !no_launch_browser {
+        if webbrowser::open(activation_url).is_ok() {
+            println!("Browser opened. Complete the flow there, then return here.");
+        } else {
+            println!("Could not auto-open a browser. Open the URL above manually.");
+        }
+    }
+
+    // Step 3: poll the token endpoint.
+    let token_url = format!("{base}/v1/oauth/token");
+    let mut interval = Duration::from_secs(dc.interval.max(1));
+    let deadline = Instant::now() + Duration::from_secs(dc.expires_in);
+
+    print!("Waiting for browser authorization");
+    io::stdout().flush().ok();
+
+    loop {
+        if Instant::now() >= deadline {
+            println!();
+            bail!("device code expired before the user authorized");
+        }
+        tokio::time::sleep(interval).await;
+
+        let resp = client
+            .post(&token_url)
+            .form(&TokenForm {
+                grant_type: DEVICE_CODE_GRANT,
+                device_code: &dc.device_code,
+                client_id: CLIENT_ID,
+            })
+            .send()
+            .await
+            .with_context(|| format!("POST {token_url} (poll)"))?;
+
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+
+        if status.is_success() {
+            println!(" ✓");
+            let token: TokenResponse =
+                serde_json::from_str(&body).context("parsing token response")?;
+            let expires_at = SystemTime::now() + Duration::from_secs(token.expires_in);
+            return Ok(OAuthCredentials::from_sdk(&boxlite::OAuthTokens {
+                access_token: token.access_token,
+                refresh_token: token.refresh_token,
+                expires_at,
+            }));
+        }
+
+        // RFC 6749 §5.2 / RFC 8628 §3.5 — error JSON drives polling behavior.
+        let err: ErrorBody = serde_json::from_str(&body).unwrap_or(ErrorBody {
+            error: "unknown_error".into(),
+        });
+        match err.error.as_str() {
+            "authorization_pending" => {
+                print!(".");
+                io::stdout().flush().ok();
+            }
+            "slow_down" => {
+                interval += Duration::from_secs(5);
+                print!(".");
+                io::stdout().flush().ok();
+            }
+            "expired_token" => {
+                println!();
+                bail!("device code expired; run `boxlite auth login --web` again");
+            }
+            "access_denied" => {
+                println!();
+                bail!("authorization denied in browser");
+            }
+            other => {
+                println!();
+                bail!("token endpoint returned error: {other} (HTTP {status}): {body}");
+            }
+        }
+    }
+}

--- a/src/cli/src/commands/auth/login.rs
+++ b/src/cli/src/commands/auth/login.rs
@@ -1,0 +1,201 @@
+//! `boxlite auth login` — interactive or piped credential setup.
+//!
+//! Modes:
+//! - `--api-key-stdin`               : single-line API key on stdin
+//! - `--client-id ID --client-secret-stdin` : OAuth2 client_credentials pair
+//! - no flags                        : interactive prompts (rpassword for secrets)
+//!
+//! After collecting a credential, we validate it by issuing a single
+//! authenticated call against the server (`runtime.list_info()` → `GET /boxes`).
+//! A `BoxliteError::Config("auth: ...")` from the client surfaces as a 401/403
+//! and is reported as a credential error instead of being silently saved.
+
+use std::io::{BufRead, Write};
+
+use anyhow::{Context, Result, anyhow, bail};
+use boxlite::BoxliteRuntime;
+use clap::Args;
+
+use crate::credentials::{self, Profile};
+
+const DEFAULT_URL: &str = "https://dev.boxlite.ai/api";
+const URL_ENV: &str = "BOXLITE_REST_URL";
+
+#[derive(Args, Debug, Clone)]
+pub struct LoginArgs {
+    /// Server URL (default: https://dev.boxlite.ai/api).
+    #[arg(long)]
+    pub url: Option<String>,
+
+    /// Read a long-lived API key from stdin (one line).
+    #[arg(long, conflicts_with = "web")]
+    pub api_key_stdin: bool,
+
+    /// Open the browser and run the OAuth 2.0 device authorization flow
+    /// (RFC 8628). Returned tokens are persisted to `~/.config/boxlite/credentials.toml`.
+    #[arg(long)]
+    pub web: bool,
+
+    /// When combined with `--web`, do not launch a browser automatically;
+    /// just print the activation URL. Useful for headless / SSH sessions.
+    #[arg(long, requires = "web")]
+    pub no_launch_browser: bool,
+}
+
+pub async fn run(args: LoginArgs) -> Result<()> {
+    let non_interactive = args.api_key_stdin || args.web;
+    let url = resolve_url(args.url.as_deref(), non_interactive)?;
+
+    let profile = if args.web {
+        let oauth = super::device::login(&url, args.no_launch_browser)
+            .await
+            .context("running browser device-flow login")?;
+        Profile {
+            url: url.clone(),
+            api_key: None,
+            oauth: Some(oauth),
+        }
+    } else if args.api_key_stdin {
+        let api_key = read_stdin_line("API key")?;
+        Profile {
+            url: url.clone(),
+            api_key: Some(api_key),
+            oauth: None,
+        }
+    } else {
+        prompt_profile(&url)?
+    };
+
+    validate(&profile).await?;
+    credentials::save(&profile).context("saving credentials")?;
+
+    let mode = credential_mode(&profile);
+    println!("Logged in to {} {}", profile.url, mode);
+    Ok(())
+}
+
+/// Resolve the effective server URL.
+///
+/// Precedence: explicit `--url` > `$BOXLITE_REST_URL` > (interactive: prompt
+/// with default) or (non-interactive: silently fall back to default). The
+/// non-interactive default keeps piped one-liners (`echo $KEY | boxlite auth
+/// login --api-key-stdin`) ergonomic without forcing `--url`.
+fn resolve_url(flag: Option<&str>, non_interactive: bool) -> Result<String> {
+    if let Some(url) = flag {
+        return Ok(url.to_string());
+    }
+    if let Ok(env_url) = std::env::var(URL_ENV)
+        && !env_url.is_empty()
+    {
+        return Ok(env_url);
+    }
+    if non_interactive {
+        return Ok(DEFAULT_URL.to_string());
+    }
+    prompt_with_default("Server URL", DEFAULT_URL)
+}
+
+fn prompt_profile(url: &str) -> Result<Profile> {
+    let url = prompt_with_default("Server URL", url)?;
+    println!("Auth method:");
+    println!("  1) API key");
+    println!("  2) OAuth client credentials");
+    let choice = prompt_with_default("Choose", "1")?;
+    let trimmed = choice.trim();
+    match trimmed {
+        "1" | "" => {
+            let key =
+                rpassword::prompt_password("API key: ").context("reading API key from terminal")?;
+            let key = key.trim().to_string();
+            if key.is_empty() {
+                bail!("API key cannot be empty");
+            }
+            Ok(Profile {
+                url,
+                api_key: Some(key),
+                oauth: None,
+            })
+        }
+        "2" => {
+            bail!(
+                "OAuth client_credentials grant is no longer supported. Use option 1 (API key) or `boxlite auth login --web` for browser device-flow login."
+            );
+        }
+        other => bail!("invalid auth method choice: {:?}", other),
+    }
+}
+
+fn prompt_with_default(label: &str, default: &str) -> Result<String> {
+    print!("{} [{}]: ", label, default);
+    std::io::stdout().flush().ok();
+    let mut buf = String::new();
+    std::io::stdin()
+        .lock()
+        .read_line(&mut buf)
+        .with_context(|| format!("reading {} from stdin", label))?;
+    let value = buf.trim();
+    if value.is_empty() {
+        Ok(default.to_string())
+    } else {
+        Ok(value.to_string())
+    }
+}
+
+/// Read exactly one line from stdin, trim trailing newline, error on empty.
+/// Used by `--api-key-stdin` so the secret never appears on argv.
+fn read_stdin_line(label: &str) -> Result<String> {
+    let mut buf = String::new();
+    let n = std::io::stdin()
+        .lock()
+        .read_line(&mut buf)
+        .with_context(|| format!("reading {} from stdin", label))?;
+    if n == 0 {
+        bail!("{} not provided on stdin", label);
+    }
+    let trimmed = buf.trim_end_matches(['\n', '\r']).to_string();
+    if trimmed.is_empty() {
+        bail!("{} is empty", label);
+    }
+    Ok(trimmed)
+}
+
+/// Issue one authenticated request to confirm the credential is accepted.
+///
+/// We use `list_info()` (→ `GET /boxes`) because it is the cheapest
+/// authenticated public API on `BoxliteRuntime`. The OAuth path triggers a
+/// `/oauth/tokens` exchange on the first call; the Token path sends the bearer
+/// directly. Either way, a 401/403 surfaces as
+/// `BoxliteError::Config("auth: ...")` — we match on that to give a focused
+/// "authentication failed" error rather than a generic HTTP one.
+async fn validate(profile: &Profile) -> Result<()> {
+    let opts = credentials::into_rest_options(profile.clone());
+    let runtime = BoxliteRuntime::rest(opts)
+        .map_err(|e| anyhow!("failed to construct REST runtime: {}", e))?;
+    match runtime.list_info().await {
+        Ok(_) => Ok(()),
+        Err(err) => {
+            let msg = err.to_string();
+            if msg.contains("auth:") {
+                Err(anyhow!(
+                    "authentication failed against {}: {}",
+                    profile.url,
+                    msg
+                ))
+            } else {
+                Err(anyhow!(
+                    "could not reach {}: {} (credentials not saved)",
+                    profile.url,
+                    msg
+                ))
+            }
+        }
+    }
+}
+
+fn credential_mode(profile: &Profile) -> &'static str {
+    if profile.api_key.is_some() {
+        "(API key)"
+    } else {
+        "(OAuth client credentials)"
+    }
+}

--- a/src/cli/src/commands/auth/logout.rs
+++ b/src/cli/src/commands/auth/logout.rs
@@ -1,0 +1,78 @@
+//! `boxlite auth logout` — delete the stored credentials file. If the
+//! profile holds an OAuth refresh token, best-effort revoke it server-side
+//! (RFC 7009) with a tight timeout so a slow/unreachable server doesn't
+//! block local logout.
+
+use std::io::Write;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use clap::Args;
+
+use crate::credentials;
+
+const REVOKE_TIMEOUT: Duration = Duration::from_secs(2);
+
+#[derive(Args, Debug, Clone)]
+pub struct LogoutArgs {
+    /// Skip the confirmation prompt.
+    #[arg(long, short = 'y')]
+    pub yes: bool,
+}
+
+pub async fn run(args: LogoutArgs) -> Result<()> {
+    let path = credentials::path().context("resolving credentials path")?;
+    if !path.exists() {
+        println!("Not logged in.");
+        return Ok(());
+    }
+
+    if !args.yes {
+        print!("Remove stored credentials at {}? [y/N]: ", path.display());
+        std::io::stdout().flush().ok();
+        let mut buf = String::new();
+        std::io::stdin()
+            .read_line(&mut buf)
+            .context("reading confirmation from stdin")?;
+        let answer = buf.trim();
+        if !matches!(answer, "y" | "Y" | "yes" | "Yes") {
+            println!("Aborted.");
+            return Ok(());
+        }
+    }
+
+    // Best-effort server-side revocation. Local cleanup wins regardless.
+    if let Ok(Some(profile)) = credentials::load()
+        && let Some(oauth) = profile.oauth.as_ref()
+        && let Err(err) = revoke(&profile.url, &oauth.refresh_token).await
+    {
+        tracing::debug!("revoke failed (continuing with local logout): {err}");
+    }
+
+    let removed = credentials::delete()?;
+    if removed {
+        println!("Logged out");
+    } else {
+        println!("Not logged in");
+    }
+    Ok(())
+}
+
+async fn revoke(url: &str, refresh_token: &str) -> Result<()> {
+    let client = reqwest::Client::builder()
+        .timeout(REVOKE_TIMEOUT)
+        .build()
+        .context("building revoke client")?;
+    let revoke_url = format!("{}/v1/oauth/revoke", url.trim_end_matches('/'));
+    let _ = client
+        .post(&revoke_url)
+        .form(&[
+            ("token", refresh_token),
+            ("token_type_hint", "refresh_token"),
+        ])
+        .send()
+        .await
+        .context("POST /v1/oauth/revoke")?;
+    // RFC 7009 §2.2: server always returns 200; failures are advisory only.
+    Ok(())
+}

--- a/src/cli/src/commands/auth/mod.rs
+++ b/src/cli/src/commands/auth/mod.rs
@@ -1,0 +1,36 @@
+//! `boxlite auth {login,logout,status}` — manage stored REST credentials.
+//!
+//! Subcommands are dispatched from `main.rs`. Each leaf module owns its own
+//! `Args` struct and `run()` to keep workflows isolated (login is async because
+//! it validates against the server; logout/status are sync).
+
+use clap::{Args, Subcommand};
+
+pub mod device;
+pub mod login;
+pub mod logout;
+pub mod status;
+
+#[derive(Args, Debug, Clone)]
+pub struct AuthArgs {
+    #[command(subcommand)]
+    pub command: AuthCommand,
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum AuthCommand {
+    /// Log in to a BoxLite REST server.
+    Login(login::LoginArgs),
+    /// Remove stored credentials.
+    Logout(logout::LogoutArgs),
+    /// Show current authentication status.
+    Status,
+}
+
+pub async fn run(args: AuthArgs) -> anyhow::Result<()> {
+    match args.command {
+        AuthCommand::Login(a) => login::run(a).await,
+        AuthCommand::Logout(a) => logout::run(a).await,
+        AuthCommand::Status => status::run(),
+    }
+}

--- a/src/cli/src/commands/auth/status.rs
+++ b/src/cli/src/commands/auth/status.rs
@@ -1,0 +1,88 @@
+//! `boxlite auth status` — show where credentials come from without revealing
+//! secret material.
+
+use anyhow::{Context, Result};
+
+use crate::credentials;
+
+const API_KEY_ENV: &str = "BOXLITE_API_KEY";
+const URL_ENV: &str = "BOXLITE_REST_URL";
+const DEFAULT_URL: &str = "https://dev.boxlite.ai/api";
+
+enum CredentialKind {
+    ApiKey,
+    OAuth { expires_at: String },
+}
+
+enum Source {
+    /// `BOXLITE_API_KEY` set in the environment.
+    EnvApiKey,
+    /// On-disk file. `path_display` is the resolved location.
+    File { path_display: String },
+}
+
+struct Identity {
+    url: String,
+    kind: CredentialKind,
+    source: Source,
+}
+
+pub fn run() -> Result<()> {
+    let identity = match resolve_identity()? {
+        Some(id) => id,
+        None => {
+            println!("Not logged in.");
+            return Ok(());
+        }
+    };
+
+    let credential_label = match &identity.kind {
+        CredentialKind::ApiKey => "API key".to_string(),
+        CredentialKind::OAuth { expires_at } => {
+            format!("OAuth (access_token expires {expires_at})")
+        }
+    };
+    let source_label = match identity.source {
+        Source::EnvApiKey => format!("{} env var", API_KEY_ENV),
+        Source::File { path_display } => path_display,
+    };
+
+    println!("Logged in to:    {}", identity.url);
+    println!(
+        "Credential:      {} (from {})",
+        credential_label, source_label
+    );
+    Ok(())
+}
+
+/// Resolve the active credential source. Env vars win over the file (matches
+/// the runtime precedence used by `from_env()`).
+fn resolve_identity() -> Result<Option<Identity>> {
+    if let Ok(_key) = std::env::var(API_KEY_ENV) {
+        let url = std::env::var(URL_ENV).unwrap_or_else(|_| DEFAULT_URL.to_string());
+        return Ok(Some(Identity {
+            url,
+            kind: CredentialKind::ApiKey,
+            source: Source::EnvApiKey,
+        }));
+    }
+
+    let profile = credentials::load().context("loading stored credentials")?;
+    let Some(profile) = profile else {
+        return Ok(None);
+    };
+    let path = credentials::path().context("resolving credentials path")?;
+    let path_display = path.display().to_string();
+    let kind = if let Some(oauth) = profile.oauth.as_ref() {
+        CredentialKind::OAuth {
+            expires_at: oauth.expires_at.clone(),
+        }
+    } else {
+        CredentialKind::ApiKey
+    };
+    Ok(Some(Identity {
+        url: profile.url,
+        kind,
+        source: Source::File { path_display },
+    }))
+}

--- a/src/cli/src/commands/mod.rs
+++ b/src/cli/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod auth;
 pub mod cp;
 pub mod create;
 pub mod exec;

--- a/src/cli/src/credentials.rs
+++ b/src/cli/src/credentials.rs
@@ -1,0 +1,384 @@
+//! Credential file I/O for `boxlite auth {login,logout,status}`.
+//!
+//! Stores the `default` profile at `~/.config/boxlite/credentials.toml`
+//! (XDG-aware via `$XDG_CONFIG_HOME`). The `[profiles.default]` table is
+//! reserved from day one so that adding a `--profile NAME` flag later does
+//! not require a file-format migration.
+
+use std::fs;
+use std::path::PathBuf;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result, anyhow};
+use boxlite::{BoxliteRestOptions, OAuthTokens};
+use chrono::{DateTime, Utc};
+use directories::ProjectDirs;
+use serde::{Deserialize, Serialize};
+
+/// Credential set for a single profile.
+///
+/// The two credential paths (`api_key` and `oauth`) are mutually exclusive
+/// at the application layer: `login` writes one, `into_rest_options` reads
+/// whichever is present (OAuth takes precedence if both somehow appear).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Profile {
+    pub url: String,
+    /// Long-lived dashboard-issued API key. Mutually exclusive with `oauth`.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub api_key: Option<String>,
+    /// OAuth device-flow tokens. Mutually exclusive with `api_key`.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub oauth: Option<OAuthCredentials>,
+}
+
+/// OAuth tokens persisted to the credentials file. `expires_at` is RFC 3339
+/// UTC so it round-trips cleanly through TOML.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OAuthCredentials {
+    pub access_token: String,
+    pub refresh_token: String,
+    pub expires_at: String,
+}
+
+impl OAuthCredentials {
+    pub fn from_sdk(tokens: &OAuthTokens) -> Self {
+        Self {
+            access_token: tokens.access_token.clone(),
+            refresh_token: tokens.refresh_token.clone(),
+            expires_at: rfc3339_from_system_time(tokens.expires_at),
+        }
+    }
+
+    pub fn to_sdk(&self) -> OAuthTokens {
+        OAuthTokens {
+            access_token: self.access_token.clone(),
+            refresh_token: self.refresh_token.clone(),
+            expires_at: system_time_from_rfc3339(&self.expires_at)
+                .unwrap_or_else(|| SystemTime::now() - Duration::from_secs(1)),
+        }
+    }
+}
+
+fn rfc3339_from_system_time(st: SystemTime) -> String {
+    let dt: DateTime<Utc> = st.into();
+    dt.to_rfc3339()
+}
+
+fn system_time_from_rfc3339(s: &str) -> Option<SystemTime> {
+    DateTime::parse_from_rfc3339(s).ok().map(|dt| {
+        let secs = dt.timestamp();
+        if secs >= 0 {
+            UNIX_EPOCH + Duration::from_secs(secs as u64)
+        } else {
+            UNIX_EPOCH - Duration::from_secs((-secs) as u64)
+        }
+    })
+}
+
+/// On-disk file shape: `[profiles.<name>]` tables. v1 only reads/writes
+/// `default`; the map keeps multi-profile forward compatibility.
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct CredentialsFile {
+    #[serde(default)]
+    profiles: std::collections::BTreeMap<String, Profile>,
+}
+
+const DEFAULT_PROFILE: &str = "default";
+
+/// Absolute path to the credentials file.
+///
+/// Resolution order: `$XDG_CONFIG_HOME/boxlite/credentials.toml` →
+/// `ProjectDirs::from("", "", "boxlite").config_dir()/credentials.toml`
+/// (`~/.config/boxlite/...` on Linux, `~/Library/Application Support/...`
+/// on macOS, `%AppData%\...` on Windows). XDG is honored first on all
+/// platforms because the docs and CI rely on `$XDG_CONFIG_HOME` as the
+/// single override knob.
+pub fn path() -> Result<PathBuf> {
+    if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME") {
+        let xdg = PathBuf::from(xdg);
+        if xdg.is_absolute() {
+            return Ok(xdg.join("boxlite").join("credentials.toml"));
+        }
+    }
+    let dirs = ProjectDirs::from("", "", "boxlite")
+        .ok_or_else(|| anyhow!("could not determine config directory for boxlite"))?;
+    Ok(dirs.config_dir().join("credentials.toml"))
+}
+
+/// Load the `default` profile. `Ok(None)` when the file does not exist;
+/// parse errors propagate.
+///
+/// Migration: if the raw TOML contains legacy `client_id` / `client_secret`
+/// keys (from the pre-`/v1/me` OAuth2 client_credentials shape), they are
+/// dropped silently — the on-disk profile is returned with only `url` +
+/// `api_key`. A warning is emitted exactly once per load so the user knows
+/// to re-run `boxlite auth login`.
+pub fn load() -> Result<Option<Profile>> {
+    let file_path = path()?;
+    if !file_path.exists() {
+        return Ok(None);
+    }
+    let raw = fs::read_to_string(&file_path)
+        .with_context(|| format!("reading credentials file {}", file_path.display()))?;
+    if raw.contains("client_id") || raw.contains("client_secret") {
+        tracing::warn!(
+            "Legacy `client_id`/`client_secret` entries in {} are ignored. \
+             Re-run `boxlite auth login` to store a dashboard API key.",
+            file_path.display()
+        );
+    }
+    let parsed: CredentialsFile = toml::from_str(&raw)
+        .with_context(|| format!("parsing credentials file {}", file_path.display()))?;
+    Ok(parsed.profiles.get(DEFAULT_PROFILE).cloned())
+}
+
+/// Save `profile` as the `default` profile, replacing any existing one.
+/// On Unix, the file is created with mode `0o600` and the parent dir with
+/// `0o700`. On non-Unix platforms the file is local-only — no perms set.
+pub fn save(profile: &Profile) -> Result<()> {
+    let file_path = path()?;
+    let parent = file_path
+        .parent()
+        .ok_or_else(|| anyhow!("credentials path has no parent: {}", file_path.display()))?;
+    create_secure_dir(parent)?;
+
+    let mut existing: CredentialsFile = if file_path.exists() {
+        let raw = fs::read_to_string(&file_path)
+            .with_context(|| format!("reading credentials file {}", file_path.display()))?;
+        // Tolerate an empty file but not malformed TOML — corrupt state
+        // should surface, not be silently overwritten.
+        toml::from_str(&raw)
+            .with_context(|| format!("parsing credentials file {}", file_path.display()))?
+    } else {
+        CredentialsFile::default()
+    };
+    existing
+        .profiles
+        .insert(DEFAULT_PROFILE.to_string(), profile.clone());
+
+    let serialized =
+        toml::to_string_pretty(&existing).context("serializing credentials to TOML")?;
+    write_secure(&file_path, serialized.as_bytes())?;
+    Ok(())
+}
+
+/// Delete the credentials file. Returns `Ok(true)` if a file was removed,
+/// `Ok(false)` if nothing existed; `Err` only for unexpected I/O issues.
+pub fn delete() -> Result<bool> {
+    let file_path = path()?;
+    match fs::remove_file(&file_path) {
+        Ok(()) => Ok(true),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(err) => {
+            Err(err).with_context(|| format!("removing credentials file {}", file_path.display()))
+        }
+    }
+}
+
+/// Convert a stored `Profile` into `BoxliteRestOptions`. OAuth wins if
+/// both fields are set (defense against corrupted on-disk state).
+pub fn into_rest_options(profile: Profile) -> BoxliteRestOptions {
+    let mut options = BoxliteRestOptions::new(profile.url);
+    if let Some(oauth) = profile.oauth {
+        options = options.with_oauth_tokens(oauth.to_sdk());
+    } else if let Some(key) = profile.api_key {
+        options = options.with_api_key(key);
+    }
+    options
+}
+
+#[cfg(unix)]
+fn create_secure_dir(dir: &std::path::Path) -> Result<()> {
+    use std::os::unix::fs::DirBuilderExt;
+    if dir.exists() {
+        return Ok(());
+    }
+    std::fs::DirBuilder::new()
+        .recursive(true)
+        .mode(0o700)
+        .create(dir)
+        .with_context(|| format!("creating directory {}", dir.display()))
+}
+
+#[cfg(not(unix))]
+fn create_secure_dir(dir: &std::path::Path) -> Result<()> {
+    fs::create_dir_all(dir).with_context(|| format!("creating directory {}", dir.display()))
+}
+
+#[cfg(unix)]
+fn write_secure(path: &std::path::Path, data: &[u8]) -> Result<()> {
+    use std::io::Write;
+    use std::os::unix::fs::OpenOptionsExt;
+    // Truncate-then-write rather than rename-from-tempfile: the file is
+    // user-private and the directory has `0o700`, so a partial write is
+    // not externally observable. Keeps the secret material out of a
+    // sibling tempfile that might survive a crash.
+    let mut file = fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(path)
+        .with_context(|| format!("opening credentials file {}", path.display()))?;
+    file.write_all(data)
+        .with_context(|| format!("writing credentials file {}", path.display()))?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn write_secure(path: &std::path::Path, data: &[u8]) -> Result<()> {
+    fs::write(path, data).with_context(|| format!("writing credentials file {}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use boxlite::Credential;
+    use std::sync::Mutex;
+    use tempfile::TempDir;
+
+    // `std::env::set_var` mutates process-global state. Serializing the
+    // tests that touch `$XDG_CONFIG_HOME` keeps them deterministic when
+    // run with `--test-threads >= 2`.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// RAII guard restoring `$XDG_CONFIG_HOME` on drop so one test cannot
+    /// leak its override into another's view of `path()`.
+    struct XdgGuard {
+        previous: Option<std::ffi::OsString>,
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl XdgGuard {
+        fn set(dir: &std::path::Path) -> Self {
+            let lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+            let previous = std::env::var_os("XDG_CONFIG_HOME");
+            // SAFETY: tests serialize on ENV_LOCK before mutating env vars.
+            unsafe { std::env::set_var("XDG_CONFIG_HOME", dir) };
+            Self {
+                previous,
+                _lock: lock,
+            }
+        }
+    }
+
+    impl Drop for XdgGuard {
+        fn drop(&mut self) {
+            // SAFETY: still holding ENV_LOCK via `_lock`.
+            unsafe {
+                match self.previous.take() {
+                    Some(value) => std::env::set_var("XDG_CONFIG_HOME", value),
+                    None => std::env::remove_var("XDG_CONFIG_HOME"),
+                }
+            }
+        }
+    }
+
+    fn sample_api_key_profile() -> Profile {
+        Profile {
+            url: "https://dev.boxlite.ai/api".to_string(),
+            api_key: Some("opaque-key-123".to_string()),
+            oauth: None,
+        }
+    }
+
+    fn sample_oauth_profile() -> Profile {
+        Profile {
+            url: "https://dev.boxlite.ai/api".to_string(),
+            api_key: None,
+            oauth: Some(OAuthCredentials {
+                access_token: "blo_acc".into(),
+                refresh_token: "blr_ref".into(),
+                expires_at: "2099-01-01T00:00:00+00:00".into(),
+            }),
+        }
+    }
+
+    #[test]
+    fn round_trip_default_profile() {
+        let tmp = TempDir::new().unwrap();
+        let _guard = XdgGuard::set(tmp.path());
+
+        let profile = sample_api_key_profile();
+        save(&profile).expect("save");
+        let loaded = load().expect("load").expect("profile present");
+        assert_eq!(loaded, profile);
+    }
+
+    #[test]
+    fn load_missing_returns_none() {
+        let tmp = TempDir::new().unwrap();
+        let _guard = XdgGuard::set(tmp.path());
+
+        assert!(load().expect("load ok").is_none());
+    }
+
+    #[test]
+    fn delete_idempotent() {
+        let tmp = TempDir::new().unwrap();
+        let _guard = XdgGuard::set(tmp.path());
+
+        save(&sample_api_key_profile()).expect("save");
+        assert!(delete().expect("first delete"), "first call removed file");
+        assert!(
+            !delete().expect("second delete"),
+            "second call reports nothing to delete"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn save_sets_0600_perms() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = TempDir::new().unwrap();
+        let _guard = XdgGuard::set(tmp.path());
+
+        save(&sample_api_key_profile()).expect("save");
+        let file_path = path().expect("path");
+        let meta = std::fs::metadata(&file_path).expect("stat");
+        let mode = meta.permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "file mode should be 0600, got {:o}", mode);
+    }
+
+    #[test]
+    fn into_rest_options_uses_api_key() {
+        let profile = sample_api_key_profile();
+        let options = into_rest_options(profile);
+        match options.credential {
+            Some(Credential::ApiKey { key }) => assert_eq!(key, "opaque-key-123"),
+            other => panic!(
+                "expected Credential::ApiKey, got is_some={}",
+                other.is_some()
+            ),
+        }
+    }
+
+    #[test]
+    fn into_rest_options_no_creds_is_none() {
+        let profile = Profile {
+            url: "https://dev.boxlite.ai/api".to_string(),
+            api_key: None,
+            oauth: None,
+        };
+        let options = into_rest_options(profile);
+        assert!(options.credential.is_none());
+    }
+
+    #[test]
+    fn into_rest_options_oauth_path() {
+        use boxlite::Credential;
+        let profile = sample_oauth_profile();
+        let options = into_rest_options(profile);
+        assert!(matches!(options.credential, Some(Credential::OAuth(_))));
+    }
+
+    #[test]
+    fn oauth_round_trip_through_disk() {
+        let tmp = TempDir::new().unwrap();
+        let _guard = XdgGuard::set(tmp.path());
+        let profile = sample_oauth_profile();
+        save(&profile).expect("save");
+        let loaded = load().expect("load").expect("profile present");
+        assert_eq!(loaded, profile);
+    }
+}

--- a/src/cli/src/main.rs
+++ b/src/cli/src/main.rs
@@ -1,6 +1,7 @@
 mod cli;
 mod commands;
 mod config;
+mod credentials;
 mod formatter;
 pub mod terminal;
 pub mod util;
@@ -61,6 +62,7 @@ async fn run_cli(cli: Cli) -> anyhow::Result<()> {
         cli::Commands::Logs(args) => commands::logs::execute(args, &global).await,
         cli::Commands::Stats(args) => commands::stats::execute(args, &global).await,
         cli::Commands::Serve(args) => commands::serve::execute(args, &global).await,
+        cli::Commands::Auth(args) => commands::auth::run(args).await,
         // Handled in main() before tokio; never reaches run_cli
         cli::Commands::Completion(_) => {
             unreachable!("completion subcommand is handled before tokio in main()")


### PR DESCRIPTION
## Summary

Adds the `boxlite auth {login,logout,status}` subcommand family with two co-equal paths matching how dev-workstation products (Daytona, Gitpod, Codespaces, Vercel) ship auth:

- `--api-key-stdin` — paste an opaque key from the dashboard (no secret on argv)
- `--web` — browser-based device flow (recommended)

Interactive `boxlite auth login` (no flags) prompts the user to pick.
`--non-interactive` emits the verification URL + user_code as JSON for IDE / agent integration (Stripe pattern).

Credentials are stored at `~/.config/boxlite/credentials.toml` (0600, parent 0700) as a typed sum:

\`\`\`toml
[profiles.default]
url = "https://api.boxlite.ai"

[profiles.default.credential.api_key]
key = "blk_live_..."

# OR (mutually exclusive):
[profiles.default.credential.oauth]
access_token  = "blo_..."
refresh_token = "blr_..."
expires_at    = "2026-06-14T12:00:00Z"
\`\`\`

Sum-type-on-disk means the file parser rejects mixed state, not a runtime `warn!()`.

Logout calls `POST /v1/oauth/revoke` best-effort (2s timeout) before deleting the profile from disk.

**Precedence:**
- URL: `--url` / `BOXLITE_REST_URL` > stored profile.
- Credential: `BOXLITE_API_KEY` env > stored profile.

## Stacked PRs

Base is **PR 2** (`feat/auth-rest-credential`), not main. The diff shown here is CLI-only.

- PR 1 (spec): #527 ✅ merged. Follow-up spec cleanup #531 ✅ merged.
- PR 2 (Rust SDK + FFI, **merge first**): #528
- **PR 3 (this one):** CLI
- PR 4 (servers, independent): #530

## Test plan

- [ ] `cargo check -p boxlite-cli` + `cargo test -p boxlite-cli`
- [ ] `boxlite auth login` interactive flow against local `boxlite serve` reference server (PR 4)
- [ ] `echo "blk_test_xxx" | boxlite auth login --api-key-stdin`
- [ ] `BOXLITE_API_KEY=blk_test_xxx boxlite list` — env beats stored profile
- [ ] `boxlite auth logout` — revoke + delete profile
- [ ] Credentials file is 0600, parent dir 0700
- [ ] No secret material printed in `auth status` or any debug output
