### PR TITLE
fix: move test cache under workspace target

### DIFF
--- a/src/test-utils/src/cache.rs
+++ b/src/test-utils/src/cache.rs
@@ -262,6 +262,7 @@ impl SharedResources {
 fn cache_dir() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()
+        .and_then(Path::parent)
         .unwrap()
         .join("target")
         .join("boxlite-test")
@@ -293,11 +294,16 @@ mod tests {
     #[test]
     fn cache_dir_is_under_target() {
         let dir = cache_dir();
+        let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(Path::parent)
+            .unwrap();
         assert!(
-            dir.to_str().unwrap().contains("target/boxlite-test"),
-            "cache_dir should be under target/: {:?}",
+            dir.starts_with(repo_root.join("target")),
+            "cache_dir should be under repo target/: {:?}",
             dir
         );
+        assert_eq!(dir, repo_root.join("target").join("boxlite-test"));
     }
 
     #[test]


### PR DESCRIPTION
The test cache was stored under src/target/boxlite-test, outside Cargo's workspace target directory. cargo clean therefore missed it, so large integration-test artifacts could remain after normal cleanup.

Compute the cache path from the repository root and store it under target/boxlite-test. Update the cache_dir unit test to assert the workspace target location explicitly.