### PR TITLE
fix(node): wrap native rest static via Proxy instead of mutating it

### DIFF
--- a/sdks/node/lib/index.ts
+++ b/sdks/node/lib/index.ts
@@ -38,9 +38,9 @@ export type {
 
 // The native REST binding is positional `(url, credential?, prefix?)`.
 // The public surface is the `BoxliteRestOptions` bag — identical in
-// name and shape across the C/Go/Node/Python SDKs. This adapter
-// destructures the bag into the native binding once at module load;
-// every other static/instance member is the native one unchanged.
+// name and shape across the C/Go/Node/Python SDKs. A Proxy substitutes
+// the bag-taking `rest`; every other static/instance member is the
+// native one unchanged.
 // `Omit` over the constructor interface preserves the `withDefaultConfig`
 // / `initDefault` statics but drops both `rest` (a key) and the `new(...)`
 // construct signature (construct signatures are not keys). The
@@ -57,15 +57,34 @@ const positionalRest = nativeBoxlite.rest.bind(nativeBoxlite) as (
   credential?: Credential | null,
   prefix?: string | null,
 ) => JsBoxliteInstance;
-(nativeBoxlite as { rest: unknown }).rest = (options: BoxliteRestOptions) =>
+const restFromBag = (options: BoxliteRestOptions): JsBoxliteInstance =>
   positionalRest(
     options.url,
     options.credential ?? null,
     options.prefix ?? null,
   );
 
-// Re-export native bindings
-export const JsBoxlite = nativeBoxlite as unknown as BoxliteConstructor;
+// napi-rs registers class statics as non-writable AND non-configurable.
+// Reassigning `rest` on the native constructor throws at import; a Proxy
+// *over the native class* is also rejected, because a `get` trap may not
+// substitute a non-configurable, non-writable own data property. So the
+// Proxy target is a fresh function that owns no such property: `rest`
+// resolves to the bag adapter, construction and every other static
+// forward to the native class untouched.
+function boxliteConstructor(): void {}
+export const JsBoxlite = new Proxy(boxliteConstructor, {
+  get(_target, prop, receiver) {
+    if (prop === "rest") return restFromBag;
+    const value = Reflect.get(nativeBoxlite, prop, receiver);
+    return typeof value === "function" ? value.bind(nativeBoxlite) : value;
+  },
+  construct(_target, args) {
+    return Reflect.construct(
+      nativeBoxlite as unknown as new (...args: unknown[]) => object,
+      args,
+    );
+  },
+}) as unknown as BoxliteConstructor;
 export { BoxliteRestOptions } from "./options.js";
 export type { CopyOptions } from "./copy.js";
 

--- a/sdks/node/tests/rest-binding.integration.test.ts
+++ b/sdks/node/tests/rest-binding.integration.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "vitest";
+import { JsBoxlite, BoxliteRestOptions } from "../lib/index.js";
+
+// Regression: lib/index.ts adapted the native positional `rest`
+// (url, credential?, prefix?) to the public `BoxliteRestOptions` bag by
+// reassigning the static onto the native napi-rs class. napi-rs marks
+// class statics non-writable, so the assignment threw
+// `TypeError: Cannot assign to read only property 'rest'` at module
+// import — breaking every consumer of `../lib/index.js`.
+describe("JsBoxlite.rest options-bag adapter", () => {
+  test("exposes a callable rest static after module load", () => {
+    expect(typeof JsBoxlite.rest).toBe("function");
+  });
+
+  test("adapts the BoxliteRestOptions bag to the native runtime", () => {
+    const runtime = JsBoxlite.rest(
+      new BoxliteRestOptions({ url: "http://127.0.0.1:1", prefix: "v1" }),
+    );
+    try {
+      expect(runtime).toBeDefined();
+    } finally {
+      runtime.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- `sdks/node/lib/index.ts` adapted the native positional `rest(url, credential?, prefix?)` to the public `BoxliteRestOptions` bag by **reassigning** the `rest` static on the native napi-rs class. napi-rs registers class statics as non-writable **and** non-configurable, so the assignment threw `TypeError: Cannot assign to read only property 'rest'` **at module import** — breaking every consumer of `../lib/index.js`. Three integration suites (`credential`, `images`, `snapshot-clone-export`) failed on import; `main` was red on Node integration.
- A Proxy *over the native class* is also rejected by the JS spec: a `get` trap may not substitute a non-configurable, non-writable own data property. The fix proxies a **fresh function** that owns no such property — `rest` resolves to the bag adapter, while construction (`new`) and every other static forward to the native class untouched.
- Adds `tests/rest-binding.integration.test.ts` (reproducer: import + bag adaptation).

Regression introduced by #532 (bearer auth). Surfaced while bumping SDK patch versions, whose pre-push `make test` runs the Node integration suite.

## Test plan
- [x] New reproducer fails before fix (exact `TypeError` at `lib/index.ts:60`), passes after
- [x] Previously-failing suites pass: `credential`, `images`, `snapshot-clone-export`
- [x] Full `make test:integration:node`: 9 passed / 1 skipped, 44 tests, exit 0
- [x] `npm run build` (tsc) clean; unit project 69/69
- [x] pre-push `make test` green on push