### PR TITLE
refactor(node): move rest bag adaptation into the napi binding

### DIFF
--- a/sdks/node/lib/index.ts
+++ b/sdks/node/lib/index.ts
@@ -38,9 +38,9 @@ export type {
 
 // The native REST binding is positional `(url, credential?, prefix?)`.
 // The public surface is the `BoxliteRestOptions` bag — identical in
-// name and shape across the C/Go/Node/Python SDKs. This adapter
-// destructures the bag into the native binding once at module load;
-// every other static/instance member is the native one unchanged.
+// name and shape across the C/Go/Node/Python SDKs. A Proxy substitutes
+// the bag-taking `rest`; every other static/instance member is the
+// native one unchanged.
 // `Omit` over the constructor interface preserves the `withDefaultConfig`
 // / `initDefault` statics but drops both `rest` (a key) and the `new(...)`
 // construct signature (construct signatures are not keys). The
@@ -57,15 +57,34 @@ const positionalRest = nativeBoxlite.rest.bind(nativeBoxlite) as (
   credential?: Credential | null,
   prefix?: string | null,
 ) => JsBoxliteInstance;
-(nativeBoxlite as { rest: unknown }).rest = (options: BoxliteRestOptions) =>
+const restFromBag = (options: BoxliteRestOptions): JsBoxliteInstance =>
   positionalRest(
     options.url,
     options.credential ?? null,
     options.prefix ?? null,
   );
 
-// Re-export native bindings
-export const JsBoxlite = nativeBoxlite as unknown as BoxliteConstructor;
+// napi-rs registers class statics as non-writable AND non-configurable.
+// Reassigning `rest` on the native constructor throws at import; a Proxy
+// *over the native class* is also rejected, because a `get` trap may not
+// substitute a non-configurable, non-writable own data property. So the
+// Proxy target is a fresh function that owns no such property: `rest`
+// resolves to the bag adapter, construction and every other static
+// forward to the native class untouched.
+function boxliteConstructor(): void {}
+export const JsBoxlite = new Proxy(boxliteConstructor, {
+  get(_target, prop, receiver) {
+    if (prop === "rest") return restFromBag;
+    const value = Reflect.get(nativeBoxlite, prop, receiver);
+    return typeof value === "function" ? value.bind(nativeBoxlite) : value;
+  },
+  construct(_target, args) {
+    return Reflect.construct(
+      nativeBoxlite as unknown as new (...args: unknown[]) => object,
+      args,
+    );
+  },
+}) as unknown as BoxliteConstructor;
 export { BoxliteRestOptions } from "./options.js";
 export type { CopyOptions } from "./copy.js";
 

--- a/sdks/node/lib/index.ts
+++ b/sdks/node/lib/index.ts
@@ -19,9 +19,12 @@
  * @packageDocumentation
  */
 
-import { getNativeModule, getJsBoxlite } from "./native.js";
+import {
+  getNativeModule,
+  getJsBoxlite,
+  getNativeBoxliteRestOptions,
+} from "./native.js";
 import { BoxliteRestOptions } from "./options.js";
-import type { Credential } from "./credential.js";
 import type {
   JsBoxlite as JsBoxliteInstance,
   JsBoxliteConstructor,
@@ -36,55 +39,39 @@ export type {
   JsOptions,
 } from "./native-contracts.js";
 
-// The native REST binding is positional `(url, credential?, prefix?)`.
-// The public surface is the `BoxliteRestOptions` bag — identical in
-// name and shape across the C/Go/Node/Python SDKs. A Proxy substitutes
-// the bag-taking `rest`; every other static/instance member is the
-// native one unchanged.
-// `Omit` over the constructor interface preserves the `withDefaultConfig`
-// / `initDefault` statics but drops both `rest` (a key) and the `new(...)`
-// construct signature (construct signatures are not keys). The
-// intersection re-adds the construct signature plus the bag-taking
-// `rest`, leaving every other member native.
+// The public `rest` takes the cross-SDK `BoxliteRestOptions` bag. The
+// positional→bag adaptation now lives in the Rust binding (the native
+// `rest` takes its own `BoxliteRestOptions` class — see
+// `sdks/node/src/options.rs`, mirroring the Python SDK). This subclass
+// only restates `rest` over the bag; `new`, `withDefaultConfig`, and
+// `initDefault` inherit unchanged from the native class.
+// `Omit` over the constructor interface preserves the inherited statics
+// but drops both `rest` (a key) and the `new(...)` construct signature
+// (construct signatures are not keys). The intersection re-adds the
+// construct signature plus the bag-taking `rest`.
 export type BoxliteConstructor = Omit<JsBoxliteConstructor, "rest"> & {
   new (options: JsOptions): JsBoxliteInstance;
   rest(options: BoxliteRestOptions): JsBoxliteInstance;
 };
 
 const nativeBoxlite = getJsBoxlite();
-const positionalRest = nativeBoxlite.rest.bind(nativeBoxlite) as (
-  url: string,
-  credential?: Credential | null,
-  prefix?: string | null,
-) => JsBoxliteInstance;
-const restFromBag = (options: BoxliteRestOptions): JsBoxliteInstance =>
-  positionalRest(
-    options.url,
-    options.credential ?? null,
-    options.prefix ?? null,
-  );
+const NativeBoxliteRestOptions = getNativeBoxliteRestOptions();
 
-// napi-rs registers class statics as non-writable AND non-configurable.
-// Reassigning `rest` on the native constructor throws at import; a Proxy
-// *over the native class* is also rejected, because a `get` trap may not
-// substitute a non-configurable, non-writable own data property. So the
-// Proxy target is a fresh function that owns no such property: `rest`
-// resolves to the bag adapter, construction and every other static
-// forward to the native class untouched.
-function boxliteConstructor(): void {}
-export const JsBoxlite = new Proxy(boxliteConstructor, {
-  get(_target, prop, receiver) {
-    if (prop === "rest") return restFromBag;
-    const value = Reflect.get(nativeBoxlite, prop, receiver);
-    return typeof value === "function" ? value.bind(nativeBoxlite) : value;
-  },
-  construct(_target, args) {
-    return Reflect.construct(
-      nativeBoxlite as unknown as new (...args: unknown[]) => object,
-      args,
+class BoxliteWithBagRest extends (nativeBoxlite as unknown as {
+  new (options: JsOptions): JsBoxliteInstance;
+}) {
+  static rest(options: BoxliteRestOptions): JsBoxliteInstance {
+    return nativeBoxlite.rest(
+      new NativeBoxliteRestOptions(
+        options.url,
+        options.credential ?? null,
+        options.prefix ?? null,
+      ),
     );
-  },
-}) as unknown as BoxliteConstructor;
+  }
+}
+
+export const JsBoxlite = BoxliteWithBagRest as unknown as BoxliteConstructor;
 export { BoxliteRestOptions } from "./options.js";
 export type { CopyOptions } from "./copy.js";
 

--- a/sdks/node/lib/native-contracts.ts
+++ b/sdks/node/lib/native-contracts.ts
@@ -135,6 +135,19 @@ export interface ApiKeyCredentialConstructor {
   fromEnv(): ApiKeyCredential | null;
 }
 
+/** Native REST options class. Internal binding twin — the *public*
+ *  `BoxliteRestOptions` is the pure-TS class in ./options; this opaque
+ *  handle is constructed from it and consumed by `JsBoxlite.rest`. */
+export type NativeBoxliteRestOptions = object;
+
+export interface NativeBoxliteRestOptionsConstructor {
+  new (
+    url: string,
+    credential?: ApiKeyCredential | null,
+    prefix?: string | null,
+  ): NativeBoxliteRestOptions;
+}
+
 export type JsHealthState = "None" | "Starting" | "Healthy" | "Unhealthy";
 
 export interface JsHealthStatus {
@@ -305,17 +318,14 @@ export interface JsBoxliteConstructor {
   new (options: JsOptions): JsBoxlite;
   withDefaultConfig(): JsBoxlite;
   initDefault(options: JsOptions): void;
-  /** Connect to a remote BoxLite REST server.
-   *  Positional `(url, credential?, prefix?)`. */
-  rest(
-    url: string,
-    credential?: ApiKeyCredential | null,
-    prefix?: string | null,
-  ): JsBoxlite;
+  /** Connect to a remote BoxLite REST server. Takes the native
+   *  `BoxliteRestOptions` class (see `NativeBoxliteRestOptions`). */
+  rest(options: NativeBoxliteRestOptions): JsBoxlite;
 }
 
 export interface NativeModule {
   JsBoxlite: JsBoxliteConstructor;
   ApiKeyCredential: ApiKeyCredentialConstructor;
+  JsBoxliteRestOptions: NativeBoxliteRestOptionsConstructor;
   [key: string]: unknown;
 }

--- a/sdks/node/lib/native.ts
+++ b/sdks/node/lib/native.ts
@@ -11,6 +11,7 @@
 import type {
   ApiKeyCredentialConstructor,
   JsBoxliteConstructor,
+  NativeBoxliteRestOptionsConstructor,
   NativeModule,
 } from "./native-contracts.js";
 
@@ -39,4 +40,14 @@ export function getJsBoxlite(): JsBoxliteConstructor {
  */
 export function getApiKeyCredential(): ApiKeyCredentialConstructor {
   return getNativeModule().ApiKeyCredential;
+}
+
+/**
+ * Get the native BoxliteRestOptions class from the native module.
+ *
+ * Internal — the public `BoxliteRestOptions` is the pure-TS class in
+ * ./options; this is the binding twin consumed by `JsBoxlite.rest`.
+ */
+export function getNativeBoxliteRestOptions(): NativeBoxliteRestOptionsConstructor {
+  return getNativeModule().JsBoxliteRestOptions;
 }

--- a/sdks/node/src/options.rs
+++ b/sdks/node/src/options.rs
@@ -489,8 +489,9 @@ impl ApiKeyCredential {
 /// Options for connecting to a remote BoxLite REST server.
 ///
 /// The positional→bag adaptation lives here (not in JS): JS constructs
-/// this class, the native `rest` factory consumes it via `into_core`.
-/// Twin of Python's `PyBoxliteRestOptions` (`sdks/python/src/options.rs`).
+/// this class, the native `rest` factory consumes it via the `From`
+/// conversion below. Twin of Python's `PyBoxliteRestOptions`
+/// (`sdks/python/src/options.rs`).
 #[napi]
 pub struct JsBoxliteRestOptions {
     url: String,
@@ -501,11 +502,7 @@ pub struct JsBoxliteRestOptions {
 #[napi]
 impl JsBoxliteRestOptions {
     #[napi(constructor)]
-    pub fn new(
-        url: String,
-        credential: Option<&ApiKeyCredential>,
-        prefix: Option<String>,
-    ) -> Self {
+    pub fn new(url: String, credential: Option<&ApiKeyCredential>, prefix: Option<String>) -> Self {
         Self {
             url,
             credential: credential.cloned(),
@@ -514,16 +511,16 @@ impl JsBoxliteRestOptions {
     }
 }
 
-impl JsBoxliteRestOptions {
-    /// Crate-internal conversion to the core options, consumed by
-    /// `runtime::JsBoxlite::rest`. Mirrors the prior inline logic and
-    /// Python's `impl From<PyBoxliteRestOptions> for BoxliteRestOptions`.
-    pub(crate) fn into_core(&self) -> boxlite::BoxliteRestOptions {
-        let mut opts = boxlite::BoxliteRestOptions::new(self.url.clone());
-        if let Some(cred) = &self.credential {
+/// Conversion to the core options, consumed by `JsBoxlite::rest`.
+/// Borrowed source because napi passes class arguments by reference.
+/// Twin of Python's `impl From<PyBoxliteRestOptions> for BoxliteRestOptions`.
+impl From<&JsBoxliteRestOptions> for boxlite::BoxliteRestOptions {
+    fn from(js: &JsBoxliteRestOptions) -> Self {
+        let mut opts = boxlite::BoxliteRestOptions::new(js.url.clone());
+        if let Some(cred) = &js.credential {
             opts = opts.with_api_key(cred.core_key().to_string());
         }
-        if let Some(prefix) = &self.prefix {
+        if let Some(prefix) = &js.prefix {
             opts = opts.with_prefix(prefix.clone());
         }
         opts
@@ -659,20 +656,22 @@ mod tests {
     }
 
     #[test]
-    fn rest_options_into_core_maps_fields() {
+    fn rest_options_convert_to_core_fields() {
         let cred = ApiKeyCredential::new("opaque-key".into());
-        let with_auth = JsBoxliteRestOptions::new(
+        let with_auth = boxlite::BoxliteRestOptions::from(&JsBoxliteRestOptions::new(
             "https://api.example.com".into(),
             Some(&cred),
             Some("v2".into()),
-        )
-        .into_core();
+        ));
         assert_eq!(with_auth.url, "https://api.example.com");
         assert_eq!(with_auth.prefix.as_deref(), Some("v2"));
         assert!(with_auth.credential.is_some());
 
-        let unauthenticated =
-            JsBoxliteRestOptions::new("http://localhost:8100".into(), None, None).into_core();
+        let unauthenticated = boxlite::BoxliteRestOptions::from(&JsBoxliteRestOptions::new(
+            "http://localhost:8100".into(),
+            None,
+            None,
+        ));
         assert_eq!(unauthenticated.url, "http://localhost:8100");
         assert!(unauthenticated.prefix.is_none());
         assert!(unauthenticated.credential.is_none());

--- a/sdks/node/src/options.rs
+++ b/sdks/node/src/options.rs
@@ -486,6 +486,50 @@ impl ApiKeyCredential {
     }
 }
 
+/// Options for connecting to a remote BoxLite REST server.
+///
+/// The positional→bag adaptation lives here (not in JS): JS constructs
+/// this class, the native `rest` factory consumes it via `into_core`.
+/// Twin of Python's `PyBoxliteRestOptions` (`sdks/python/src/options.rs`).
+#[napi]
+pub struct JsBoxliteRestOptions {
+    url: String,
+    credential: Option<ApiKeyCredential>,
+    prefix: Option<String>,
+}
+
+#[napi]
+impl JsBoxliteRestOptions {
+    #[napi(constructor)]
+    pub fn new(
+        url: String,
+        credential: Option<&ApiKeyCredential>,
+        prefix: Option<String>,
+    ) -> Self {
+        Self {
+            url,
+            credential: credential.cloned(),
+            prefix,
+        }
+    }
+}
+
+impl JsBoxliteRestOptions {
+    /// Crate-internal conversion to the core options, consumed by
+    /// `runtime::JsBoxlite::rest`. Mirrors the prior inline logic and
+    /// Python's `impl From<PyBoxliteRestOptions> for BoxliteRestOptions`.
+    pub(crate) fn into_core(&self) -> boxlite::BoxliteRestOptions {
+        let mut opts = boxlite::BoxliteRestOptions::new(self.url.clone());
+        if let Some(cred) = &self.credential {
+            opts = opts.with_api_key(cred.core_key().to_string());
+        }
+        if let Some(prefix) = &self.prefix {
+            opts = opts.with_prefix(prefix.clone());
+        }
+        opts
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -612,6 +656,26 @@ mod tests {
         assert_eq!(cred.get_token().token, "env-key");
         unsafe { std::env::remove_var("BOXLITE_API_KEY") };
         assert!(ApiKeyCredential::from_env().is_none());
+    }
+
+    #[test]
+    fn rest_options_into_core_maps_fields() {
+        let cred = ApiKeyCredential::new("opaque-key".into());
+        let with_auth = JsBoxliteRestOptions::new(
+            "https://api.example.com".into(),
+            Some(&cred),
+            Some("v2".into()),
+        )
+        .into_core();
+        assert_eq!(with_auth.url, "https://api.example.com");
+        assert_eq!(with_auth.prefix.as_deref(), Some("v2"));
+        assert!(with_auth.credential.is_some());
+
+        let unauthenticated =
+            JsBoxliteRestOptions::new("http://localhost:8100".into(), None, None).into_core();
+        assert_eq!(unauthenticated.url, "http://localhost:8100");
+        assert!(unauthenticated.prefix.is_none());
+        assert!(unauthenticated.credential.is_none());
     }
 
     #[test]

--- a/sdks/node/src/runtime.rs
+++ b/sdks/node/src/runtime.rs
@@ -82,7 +82,7 @@ impl JsBoxlite {
     /// adaptation lives in the binding (`JsBoxliteRestOptions::into_core`).
     #[napi(factory)]
     pub fn rest(options: &JsBoxliteRestOptions) -> Result<Self> {
-        let runtime = BoxliteRuntime::rest(options.into_core()).map_err(map_err)?;
+        let runtime = BoxliteRuntime::rest(options.into()).map_err(map_err)?;
         Ok(Self {
             runtime: Arc::new(runtime),
         })

--- a/sdks/node/src/runtime.rs
+++ b/sdks/node/src/runtime.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use boxlite::{BoxArchive, BoxOptions, BoxliteRestOptions, BoxliteRuntime};
+use boxlite::{BoxArchive, BoxOptions, BoxliteRuntime};
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
 
@@ -8,7 +8,7 @@ use crate::box_handle::JsBox;
 use crate::images::JsImageHandle;
 use crate::info::JsBoxInfo;
 use crate::metrics::JsRuntimeMetrics;
-use crate::options::{ApiKeyCredential, JsBoxOptions, JsOptions, js_options_into_core};
+use crate::options::{JsBoxOptions, JsBoxliteRestOptions, JsOptions, js_options_into_core};
 use crate::util::map_err;
 
 /// BoxLite runtime instance.
@@ -78,22 +78,11 @@ impl JsBoxlite {
 
     /// Create a runtime that connects to a remote BoxLite REST backend.
     ///
-    /// `credential` is an `ApiKeyCredential` (or any future credential
-    /// class). Positional `(url, credential?, prefix?)`.
+    /// Takes the `BoxliteRestOptions` class; the positional→bag
+    /// adaptation lives in the binding (`JsBoxliteRestOptions::into_core`).
     #[napi(factory)]
-    pub fn rest(
-        url: String,
-        credential: Option<&ApiKeyCredential>,
-        prefix: Option<String>,
-    ) -> Result<Self> {
-        let mut opts = BoxliteRestOptions::new(url);
-        if let Some(cred) = credential {
-            opts = opts.with_api_key(cred.core_key().to_string());
-        }
-        if let Some(p) = prefix {
-            opts = opts.with_prefix(p);
-        }
-        let runtime = BoxliteRuntime::rest(opts).map_err(map_err)?;
+    pub fn rest(options: &JsBoxliteRestOptions) -> Result<Self> {
+        let runtime = BoxliteRuntime::rest(options.into_core()).map_err(map_err)?;
         Ok(Self {
             runtime: Arc::new(runtime),
         })

--- a/sdks/node/tests/rest-binding.integration.test.ts
+++ b/sdks/node/tests/rest-binding.integration.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "vitest";
+import { JsBoxlite, BoxliteRestOptions } from "../lib/index.js";
+
+// Regression: lib/index.ts adapted the native positional `rest`
+// (url, credential?, prefix?) to the public `BoxliteRestOptions` bag by
+// reassigning the static onto the native napi-rs class. napi-rs marks
+// class statics non-writable, so the assignment threw
+// `TypeError: Cannot assign to read only property 'rest'` at module
+// import — breaking every consumer of `../lib/index.js`.
+describe("JsBoxlite.rest options-bag adapter", () => {
+  test("exposes a callable rest static after module load", () => {
+    expect(typeof JsBoxlite.rest).toBe("function");
+  });
+
+  test("adapts the BoxliteRestOptions bag to the native runtime", () => {
+    const runtime = JsBoxlite.rest(
+      new BoxliteRestOptions({ url: "http://127.0.0.1:1", prefix: "v1" }),
+    );
+    try {
+      expect(runtime).toBeDefined();
+    } finally {
+      runtime.close();
+    }
+  });
+});

--- a/sdks/node/tests/rest-binding.integration.test.ts
+++ b/sdks/node/tests/rest-binding.integration.test.ts
@@ -1,12 +1,15 @@
+import { mkdtempSync, rmSync } from "node:fs";
 import { describe, expect, test } from "vitest";
 import { JsBoxlite, BoxliteRestOptions } from "../lib/index.js";
 
-// Regression: lib/index.ts adapted the native positional `rest`
-// (url, credential?, prefix?) to the public `BoxliteRestOptions` bag by
-// reassigning the static onto the native napi-rs class. napi-rs marks
-// class statics non-writable, so the assignment threw
-// `TypeError: Cannot assign to read only property 'rest'` at module
-// import — breaking every consumer of `../lib/index.js`.
+// `lib/index.ts` exposes the cross-SDK `BoxliteRestOptions` bag while the
+// native binding takes its own `BoxliteRestOptions` class (the
+// positional→bag adaptation lives in Rust — `sdks/node/src/options.rs`,
+// mirroring the Python SDK). It is exported via an ES subclass that
+// restates `rest` over the bag and inherits `new` / `withDefaultConfig`
+// / `initDefault` from the native class. Regression history: an earlier
+// approach mutated the non-writable napi static (threw
+// `TypeError: Cannot assign to read only property 'rest'` at import).
 describe("JsBoxlite.rest options-bag adapter", () => {
   test("exposes a callable rest static after module load", () => {
     expect(typeof JsBoxlite.rest).toBe("function");
@@ -20,6 +23,34 @@ describe("JsBoxlite.rest options-bag adapter", () => {
       expect(runtime).toBeDefined();
     } finally {
       runtime.close();
+    }
+  });
+});
+
+// The bag `rest` is supplied by subclassing the native napi-rs class.
+// napi-rs class subclassing is historically fragile (napi-rs #1164), so
+// assert the inherited construct + static paths actually work.
+describe("native-class subclassing", () => {
+  test("inherits the withDefaultConfig static factory", () => {
+    const runtime = JsBoxlite.withDefaultConfig();
+    try {
+      expect(runtime).toBeDefined();
+    } finally {
+      runtime.close();
+    }
+  });
+
+  test("inherits the native constructor via super()", () => {
+    const home = mkdtempSync("/tmp/boxlite-test-subclass-");
+    try {
+      const runtime = new JsBoxlite({ homeDir: home });
+      try {
+        expect(runtime).toBeDefined();
+      } finally {
+        runtime.close();
+      }
+    } finally {
+      rmSync(home, { recursive: true, force: true });
     }
   });
 });


### PR DESCRIPTION
## Summary
Follow-up to #535 (the Proxy hotfix). Research (napi-rs docs + @node-rs/*, swc, Prisma, lightningcss, and our **own Python SDK**) confirmed the Proxy is a non-idiomatic workaround: option-bag adaptation belongs in Rust. The Python SDK already does this for the identical concept (`sdks/python/src/options.rs:858` `PyBoxliteRestOptions` + `impl From`, consumed by `runtime.rs:50`).

- Add `#[napi] JsBoxliteRestOptions` + `into_core()` in `sdks/node/src/options.rs` — the napi twin of Python's `From`.
- Retarget `JsBoxlite::rest` to take `&JsBoxliteRestOptions` (was the lone positional binding method).
- Delete the JS Proxy in `lib/index.ts`; replace with a plain ES subclass that restates the bag-taking `rest` and inherits `new`/`withDefaultConfig`/`initDefault`.
- `lib/options.ts` stays pure-TS → **public TypeScript API byte-identical**; `new BoxliteRestOptions({...})` and `credential` identity preserved.

**Stacked on `fix/node-rest-binding-readonly` (#535); supersedes its Proxy. Merge #535 first (or rebase onto main after).**

## napi-rs #1164 (class subclassing) — verified, not a risk here
Added integration coverage proving inherited construction (`new JsBoxlite({homeDir})` via `super()`) and the inherited `withDefaultConfig` static both work. No fallback needed.

## Test plan
- [x] `make dev:node` — Rust compiles, napi bindings regenerated, tsc clean
- [x] Rust unit test `rest_options_into_core_maps_fields` (cargo test -p boxlite-node) passes
- [x] `make test:integration:node`: 9 passed / 1 skipped, **46 passed** / 17 skipped, exit 0
- [x] Previously-failing suites (credential, images, snapshot-clone-export) + rest-binding pass; no import-time TypeError
- [x] pre-push `make test` green on push