### PR TITLE
fix(runtime): prune embedded cache by each dir's own build profile

### DIFF
--- a/make/dev.mk
+++ b/make/dev.mk
@@ -16,11 +16,11 @@ _ensure-node-deps:
 	fi
 
 # Build wheel locally with maturin + embedded runtime
-dev\:python: runtime\:debug _ensure-python-deps
+dev\:python: $(if $(SETUP_DONE),,runtime\:debug) _ensure-python-deps
 	@echo "🔨 Building wheel with maturin (embedded-runtime)..."
 	@. .venv/bin/activate && pip install -q maturin && cd sdks/python && maturin develop --uv
 
-dev\:c: runtime\:debug
+dev\:c: $(if $(SETUP_DONE),,runtime\:debug)
 	@echo "🔨 Building C SDK (debug)..."
 	@cargo build -p boxlite-c
 	@echo "✅ C SDK built:"
@@ -28,14 +28,14 @@ dev\:c: runtime\:debug
 	@echo "   Header:  sdks/c/include/boxlite.h"
 
 # Build Node.js SDK locally with napi-rs (debug mode)
-dev\:node: runtime\:debug
+dev\:node: $(if $(SETUP_DONE),,runtime\:debug)
 	@cd sdks/node && npm install --silent && npm run build:native && npm run build
 	@echo "📦 Linking SDK to examples..."
 	@cd examples/node && npm install --silent
 	@echo "✅ Node.js SDK built and linked to examples"
 
 # Build Go SDK locally (debug mode, static linking)
-dev\:go: runtime\:debug
+dev\:go: $(if $(SETUP_DONE),,runtime\:debug)
 	@echo "🔨 Building Go SDK (debug)..."
 	@cargo build -p boxlite-c
 	@bash $(SCRIPT_DIR)/build/fix-go-symbols.sh target/debug/libboxlite.a

--- a/make/test.mk
+++ b/make/test.mk
@@ -40,6 +40,39 @@ define run_suites
 	fi
 endef
 
+# Heavy shared setup (runtime build + Rust image cache) is built ONCE by the
+# integration aggregators before they fan out; SETUP_DONE=1 tells the per-suite
+# recursive sub-makes (and the dev:* prereqs) to skip rebuilding it. Running a
+# leaf directly (SETUP_DONE unset) still builds its own prerequisites.
+export SETUP_DONE
+
+# $(call run_integration_suites,<space-separated make targets>)
+# Like run_suites, but builds the shared runtime once up front (unless a parent
+# already did, signalled by SETUP_DONE) and runs every suite with SETUP_DONE=1
+# so no sub-make re-derives the phony runtime:debug / warm-cache prereqs.
+define run_integration_suites
+	@if [ -z "$(SETUP_DONE)" ]; then \
+		echo "🔧 Preparing shared test runtime (once)..."; \
+		$(MAKE) runtime:debug || exit 1; \
+		if echo "$(1)" | grep -qE 'test:integration:(rust|core)'; then \
+			$(MAKE) test:warm-cache:rust SETUP_DONE=1 || exit 1; \
+		fi; \
+	fi
+	@rc=0; failed=""; \
+	for t in $(1); do \
+		echo ""; \
+		if ! $(MAKE) $$t SETUP_DONE=1; then \
+			rc=1; failed="$$failed $$t"; \
+			if [ "$(FAIL_FAST)" = "true" ]; then break; fi; \
+		fi; \
+	done; \
+	echo ""; \
+	if [ $$rc -ne 0 ]; then \
+		echo "❌ Failed suites:$$failed"; \
+		exit 1; \
+	fi
+endef
+
 # Default test target runs only changed components.
 test:
 	@$(MAKE) test:changed
@@ -86,7 +119,7 @@ ifeq ($(CHANGED_COMPONENTS),)
 	@echo "📋 No changed components detected — skipping integration tests."
 else
 	@echo "📋 Running integration tests for changed components: $(CHANGED_COMPONENTS)"
-	$(call run_suites,$(strip \
+	$(call run_integration_suites,$(strip \
 		$(if $(filter rust,$(CHANGED_COMPONENTS)),test:integration:rust) \
 		$(if $(filter cli,$(CHANGED_COMPONENTS)),test:integration:cli) \
 		$(if $(filter python,$(CHANGED_COMPONENTS)),test:integration:python) \
@@ -113,7 +146,7 @@ test\:unit:
 # Integration matrix.
 test\:integration:
 	@echo "── Integration tests (core, sdk) ──"
-	$(call run_suites,test:integration:core test:integration:sdk)
+	$(call run_integration_suites,test:integration:core test:integration:sdk)
 	@echo ""
 	@echo "✅ Integration test matrix passed"
 
@@ -125,7 +158,7 @@ test\:unit\:core:
 # Core integration suites: Rust integration + CLI integration.
 test\:integration\:core:
 	@echo "── Core integration suites (rust, cli) ──"
-	$(call run_suites,test:integration:rust test:integration:cli)
+	$(call run_integration_suites,test:integration:rust test:integration:cli)
 
 # SDK unit suites: Python unit + Node unit + C unit + Go unit.
 test\:unit\:sdk:
@@ -135,7 +168,7 @@ test\:unit\:sdk:
 # SDK integration suites: Python integration + Node integration + C SDK test suite.
 test\:integration\:sdk:
 	@echo "── SDK integration suites (python, node, c) ──"
-	$(call run_suites,test:integration:python test:integration:node test:integration:c)
+	$(call run_integration_suites,test:integration:python test:integration:node test:integration:c)
 
 # Rust unit tests (parallel via nextest, fallback to serial cargo test).
 # --no-default-features disables gvproxy to avoid Go runtime link issues.
@@ -150,7 +183,7 @@ test\:unit\:rust:
 	fi
 
 # Pre-warm Rust integration test image cache (internal helper, still callable).
-test\:warm-cache\:rust: runtime\:debug
+test\:warm-cache\:rust: $(if $(SETUP_DONE),,runtime\:debug)
 	@echo "🔥 Warming Rust integration test image cache..."
 	@mkdir -p /tmp/boxlite-test
 	@./target/debug/boxlite --home /tmp/boxlite-test \
@@ -164,7 +197,7 @@ test\:warm-cache\:rust: runtime\:debug
 
 # Rust integration tests (requires VM environment).
 # FILTER works here and on every test target, e.g. make test:integration:rust FILTER=copy
-test\:integration\:rust: runtime\:debug test\:warm-cache\:rust
+test\:integration\:rust: $(if $(SETUP_DONE),,runtime\:debug test\:warm-cache\:rust)
 	@echo "🧪 Running Rust integration tests (requires VM)..."
 	@if command -v cargo-nextest >/dev/null 2>&1; then \
 		cargo nextest run -p boxlite --features krun,gvproxy --test '*' --no-fail-fast --profile vm \
@@ -184,7 +217,7 @@ test\:unit\:ffi:
 	fi
 
 # CLI integration tests.
-test\:integration\:cli: runtime\:debug
+test\:integration\:cli: $(if $(SETUP_DONE),,runtime\:debug)
 	@echo "🧪 Running CLI integration tests..."
 	@if command -v cargo-nextest >/dev/null 2>&1; then \
 		cargo nextest run -p boxlite-cli --tests --profile vm --no-fail-fast \

--- a/src/boxlite/src/runtime/embedded.rs
+++ b/src/boxlite/src/runtime/embedded.rs
@@ -43,8 +43,25 @@ pub struct EmbeddedRuntime {
 }
 
 impl EmbeddedRuntime {
-    /// Stale cache directories older than this are deleted after extraction.
-    const STALE_TTL: Duration = Duration::from_secs(7 * 24 * 3600);
+    /// Stale-cache TTL for release builds: cache reclaimed after this much disuse.
+    const STALE_TTL_RELEASE: Duration = Duration::from_secs(7 * 24 * 3600);
+    /// Stale-cache TTL for non-release (debug) builds.
+    const STALE_TTL_DEBUG: Duration = Duration::from_secs(3600);
+
+    /// TTL for a cache dir, classified from *its own* `.complete` stamp.
+    ///
+    /// The stamp's 2nd line records the build profile that created the dir, so
+    /// retention follows the dir's origin — not the profile of whatever process
+    /// happens to run cleanup (both profiles share one parent dir). An
+    /// unreadable / legacy (version-only) / unrecognized stamp falls back to the
+    /// longest TTL: never over-delete a cache we cannot positively classify.
+    fn ttl_for_stamp(stamp: &Path) -> Duration {
+        let profile = std::fs::read_to_string(stamp);
+        match profile.as_deref().map(|s| s.lines().nth(1)) {
+            Ok(Some("debug")) => Self::STALE_TTL_DEBUG,
+            _ => Self::STALE_TTL_RELEASE,
+        }
+    }
 
     /// Get the embedded runtime, extracting on first call.
     ///
@@ -107,7 +124,11 @@ impl EmbeddedRuntime {
         }
 
         // Stamp marks extraction as complete — checked by the fast path above.
-        std::fs::write(tmp.join(".complete"), crate::VERSION)
+        // Line 1: version (human-readable). Line 2: build profile, read back by
+        // `ttl_for_stamp` so each dir is pruned by the TTL of the profile that
+        // created it. `\n` separated; readers use `str::lines` (CRLF-tolerant).
+        let stamp_body = format!("{}\n{}\n", crate::VERSION, env!("BOXLITE_BUILD_PROFILE"));
+        std::fs::write(tmp.join(".complete"), stamp_body)
             .map_err(|e| BoxliteError::Storage(format!("write stamp: {}", e)))?;
 
         // Atomic rename: loser detects winner's dir and cleans up.
@@ -149,7 +170,7 @@ impl EmbeddedRuntime {
         let Ok(entries) = std::fs::read_dir(parent) else {
             return;
         };
-        let cutoff = SystemTime::now() - Self::STALE_TTL;
+        let now = SystemTime::now();
 
         for entry in entries.filter_map(Result::ok) {
             let path = entry.path();
@@ -157,9 +178,12 @@ impl EmbeddedRuntime {
                 continue;
             }
             let stamp = path.join(".complete");
-            let is_stale = std::fs::metadata(&stamp)
-                .and_then(|m| m.modified())
-                .is_ok_and(|mtime| mtime < cutoff);
+            let Ok(mtime) = std::fs::metadata(&stamp).and_then(|m| m.modified()) else {
+                continue;
+            };
+            // Each dir is judged by the TTL of the profile that created it.
+            let ttl = Self::ttl_for_stamp(&stamp);
+            let is_stale = now.duration_since(mtime).is_ok_and(|age| age > ttl);
             if is_stale {
                 tracing::info!(dir = %path.display(), "Removing stale embedded cache");
                 let _ = std::fs::remove_dir_all(&path);
@@ -244,6 +268,41 @@ mod tests {
                 "Debug build dir should include hash suffix"
             );
         }
+    }
+
+    #[test]
+    fn ttl_for_stamp_classifies_by_recorded_profile() {
+        let tmp = tempfile::tempdir().unwrap();
+        let stamp = tmp.path().join(".complete");
+
+        std::fs::write(&stamp, format!("{}\ndebug\n", crate::VERSION)).unwrap();
+        assert_eq!(
+            EmbeddedRuntime::ttl_for_stamp(&stamp),
+            EmbeddedRuntime::STALE_TTL_DEBUG,
+            "debug-stamped dir must use the short TTL"
+        );
+
+        std::fs::write(&stamp, format!("{}\nrelease\n", crate::VERSION)).unwrap();
+        assert_eq!(
+            EmbeddedRuntime::ttl_for_stamp(&stamp),
+            EmbeddedRuntime::STALE_TTL_RELEASE,
+            "release-stamped dir must use the long TTL"
+        );
+
+        // Legacy (pre-change) stamp: version only, no profile line.
+        std::fs::write(&stamp, crate::VERSION).unwrap();
+        assert_eq!(
+            EmbeddedRuntime::ttl_for_stamp(&stamp),
+            EmbeddedRuntime::STALE_TTL_RELEASE,
+            "legacy version-only stamp must fall back to the long TTL"
+        );
+
+        // Missing stamp: unclassifiable, must not be over-deleted.
+        assert_eq!(
+            EmbeddedRuntime::ttl_for_stamp(&tmp.path().join("absent")),
+            EmbeddedRuntime::STALE_TTL_RELEASE,
+            "unreadable stamp must fall back to the long TTL"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Embedded-runtime cache TTL bug fix.** `cleanup_stale()` selected the stale TTL from the *running process's* `BOXLITE_BUILD_PROFILE` and applied it to every sibling dir in the shared `runtimes/` parent. Release (`v{VERSION}`) and debug (`v{VERSION}-{HASH}`) caches share that parent, so a debug binary (1h TTL) would prematurely delete the release cache (intended 7d), and a release binary would let debug caches linger 7d.
- **Fix:** the `.complete` stamp now records the build profile on line 2; `ttl_for_stamp()` classifies each dir from its *own* stamp during cleanup. This follows Cargo's global-cache GC model — retention is decided from the entry's own recorded metadata, not the identity of whoever runs cleanup. Unreadable / legacy version-only / unrecognized stamps conservatively fall back to the long (release) TTL, so a cache that can't be positively classified is never over-deleted. Staleness timing semantics are otherwise byte-for-byte unchanged (verified branch-by-branch).
- **Cross-platform:** plain file I/O + the already-used cross-platform `filetime`; `str::lines` is CRLF-tolerant for Windows; no `atime` reliance.
- **Unrelated, bundled at maintainer request:** `make/dev.mk` + `make/test.mk` add a `SETUP_DONE` guard and a `run_integration_suites` helper so the shared runtime is built once before the integration aggregators fan out, instead of each per-suite sub-make re-deriving `runtime:debug` / warm-cache.

## Test plan

- [x] `make clippy` (`--workspace --all-targets --all-features -- -D warnings`) — clean; confirms the changed module compiles with `embedded-runtime` and no dead code (validates removal of the old `stale_ttl()` and that both TTL consts are still used).
- [x] New unit test `ttl_for_stamp_classifies_by_recorded_profile` — passes all four cases: `debug`→1h, `release`→7d, legacy version-only→7d, missing stamp→7d.
- [x] `runtime::embedded` module — 4/4 tests pass, no regression.
- [ ] **Residual (coverage, not correctness):** the new two-line stamp *write* is not exercised end-to-end in stub mode (`extraction_creates_complete_stamp` early-returns with an empty manifest). The read/classify side is fully tested and the write is a plain `format!` + `fs::write`. Full extraction-path coverage requires `make test:integration:rust` (VM).