### PR TITLE
chore(sdk): bump SDK patch version 0.9.4 -> 0.9.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,7 +372,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -446,7 +446,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-c"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "boxlite",
  "cbindgen",
@@ -456,7 +456,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-cli"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -495,7 +495,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-guest"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-node"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "boxlite",
  "boxlite-shared",
@@ -538,7 +538,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-python"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "boxlite",
  "futures",
@@ -551,7 +551,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-shared"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "proptest",
  "prost",
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-shim"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "boxlite",
  "boxlite-shared",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "bubblewrap-sys"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "num_cpus",
 ]
@@ -1066,7 +1066,7 @@ dependencies = [
 
 [[package]]
 name = "e2fsprogs-sys"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "num_cpus",
 ]
@@ -2066,14 +2066,14 @@ dependencies = [
 
 [[package]]
 name = "libgvproxy-sys"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "libkrun-sys"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "libc",
  "num_cpus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,15 +19,15 @@ exclude = ["build/tmp", "target", ".venv", "examples/*/.venv"]
 resolver = "2"
 
 [workspace.dependencies]
-boxlite = { path = "src/boxlite", version = "0.9.4" }
-boxlite-shared = { path = "src/shared", version = "0.9.4" }
-bubblewrap-sys = { path = "src/deps/bubblewrap-sys", version = "0.9.4" }
-e2fsprogs-sys = { path = "src/deps/e2fsprogs-sys", version = "0.9.4" }
-libgvproxy-sys = { path = "src/deps/libgvproxy-sys", version = "0.9.4" }
-libkrun-sys = { path = "src/deps/libkrun-sys", version = "0.9.4" }
+boxlite = { path = "src/boxlite", version = "0.9.5" }
+boxlite-shared = { path = "src/shared", version = "0.9.5" }
+bubblewrap-sys = { path = "src/deps/bubblewrap-sys", version = "0.9.5" }
+e2fsprogs-sys = { path = "src/deps/e2fsprogs-sys", version = "0.9.5" }
+libgvproxy-sys = { path = "src/deps/libgvproxy-sys", version = "0.9.5" }
+libkrun-sys = { path = "src/deps/libkrun-sys", version = "0.9.5" }
 
 [workspace.package]
-version = "0.9.4"
+version = "0.9.5"
 edition = "2024"
 authors = ["Dorian Zheng <https://github.com/dorianzheng>"]
 license = "Apache-2.0"

--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boxlite-ai/boxlite",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "BoxLite - Embeddable micro-VM runtime for secure, isolated code execution",
   "type": "module",
   "main": "dist/index.js",

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "boxlite"
-version = "0.9.4"
+version = "0.9.5"
 description = "Python bindings for Boxlite runtime"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
Patch-bump the SDK version 0.9.4 → 0.9.5 across the published surfaces:
- `Cargo.toml` `[workspace.package]` + the 6 internal path-dep pins (covers the Rust `boxlite`, C, Python-rust, Node-rust crates)
- `Cargo.lock` (12 workspace crate entries; unrelated `rand` 0.9.4 untouched)
- `sdks/python/pyproject.toml`, `sdks/node/package.json`
- Go SDK is git-tag versioned — no in-tree file changes

Rebased on `main` after the Node REST-binding fix (#536) landed.

## Notes
Local pre-push gate skipped (`--no-verify`, explicitly authorized): the gate runs the full Rust integration suite because `Cargo.lock` changed; it passed 224/224 earlier this session, and a subsequent failure was an environmental/flaky VM/image-pull issue. A version-string-only change cannot affect Rust integration behavior. **GitHub CI on this PR is the authoritative gate.**

## Test plan
- [ ] CI green on this PR (Rust/Node/etc. workflows)
- [ ] Lock/version consistency (no drift; `rand` untouched)