### PR TITLE
fix(api): pull image instead of stub build for single-FROM sandboxes

### DIFF
--- a/apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts
+++ b/apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts
@@ -175,6 +175,12 @@ export class SandboxStartAction extends SandboxAction {
     } else {
       const snapshot = await this.snapshotService.getSnapshotByName(sandbox.snapshot, sandbox.organizationId)
       snapshotRef = snapshot.ref
+      // Auto-snapshots (image-ref sandboxes) start out as PENDING with no ref —
+      // snapshot.manager populates ref once it inspects the registry. Park the
+      // sandbox until then; the 10s sync-states cron will retry.
+      if (!snapshotRef) {
+        return DONT_SYNC_AGAIN
+      }
     }
 
     const declarativeBuildScoreThreshold = this.configService.get('runnerScore.thresholds.declarativeBuild')

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -72,6 +72,7 @@ import { PortPreviewUrlDto, SignedPortPreviewUrlDto } from '../dto/port-preview-
 import { RegionService } from '../../region/services/region.service'
 import { DefaultRegionRequiredException } from '../../organization/exceptions/DefaultRegionRequiredException'
 import { SnapshotService } from './snapshot.service'
+import { parseDockerfileForSingleFromRef } from '../utils/dockerfile.util'
 import { RegionType } from '../../region/enums/region-type.enum'
 import { SandboxCreatedEvent } from '../events/sandbox-create.event'
 import { InjectRedis } from '@nestjs-modules/ioredis'
@@ -617,12 +618,130 @@ export class SandboxService {
     return this.toSandboxDto(updatedSandbox)
   }
 
+  // Auto-snapshot path for sandboxes created from a plain image ref. The
+  // dashboard / SDK wrap a string `image` field into a single-FROM Dockerfile;
+  // we recognize that shape and pull instead of build. The sandbox is parked
+  // in PULLING_SNAPSHOT with `runnerId=null`; the state-sync cron picks it up
+  // once the auto-snapshot's ref is populated by snapshot.manager.
+  private async createFromImageRef(
+    createSandboxDto: CreateSandboxDto,
+    organization: Organization,
+    region: Region,
+    imageRef: string,
+  ): Promise<SandboxDto> {
+    let pendingCpuIncrement: number | undefined
+    let pendingMemoryIncrement: number | undefined
+    let pendingDiskIncrement: number | undefined
+
+    try {
+      const sandboxClass = this.getValidatedOrDefaultClass(createSandboxDto.class)
+
+      const cpu = createSandboxDto.cpu || DEFAULT_CPU
+      const mem = createSandboxDto.memory || DEFAULT_MEMORY
+      const disk = createSandboxDto.disk || DEFAULT_DISK
+      const gpu = createSandboxDto.gpu || DEFAULT_GPU
+
+      this.organizationService.assertOrganizationIsNotSuspended(organization)
+
+      const { pendingCpuIncremented, pendingMemoryIncremented, pendingDiskIncremented } =
+        await this.validateOrganizationQuotas(organization, region, cpu, mem, disk)
+
+      if (pendingCpuIncremented) {
+        pendingCpuIncrement = cpu
+      }
+      if (pendingMemoryIncremented) {
+        pendingMemoryIncrement = mem
+      }
+      if (pendingDiskIncremented) {
+        pendingDiskIncrement = disk
+      }
+
+      if (createSandboxDto.volumes && createSandboxDto.volumes.length > 0) {
+        const volumeIdOrNames = createSandboxDto.volumes.map((v) => v.volumeId)
+        await this.volumeService.validateVolumes(organization.id, volumeIdOrNames)
+      }
+
+      const autoSnapshot = await this.snapshotService.ensureAutoSnapshotForImage(organization, region.id, imageRef)
+
+      const sandbox = new Sandbox(region.id, createSandboxDto.name)
+      sandbox.organizationId = organization.id
+      sandbox.class = sandboxClass
+      sandbox.snapshot = autoSnapshot.name
+      sandbox.osUser = createSandboxDto.user || 'boxlite'
+      sandbox.env = createSandboxDto.env || {}
+      sandbox.labels = createSandboxDto.labels || {}
+      sandbox.cpu = cpu
+      sandbox.gpu = gpu
+      sandbox.mem = mem
+      sandbox.disk = disk
+      sandbox.public = createSandboxDto.public || false
+
+      // Park in PULLING_SNAPSHOT with no runner. handleUnassignedRunnerSandbox
+      // will retry while the auto-snapshot's ref is still being computed.
+      sandbox.state = SandboxState.PULLING_SNAPSHOT
+      sandbox.desiredState = SandboxDesiredState.STARTED
+
+      if (createSandboxDto.networkBlockAll !== undefined) {
+        sandbox.networkBlockAll = createSandboxDto.networkBlockAll
+      }
+      if (createSandboxDto.networkAllowList !== undefined) {
+        sandbox.networkAllowList = this.resolveNetworkAllowList(createSandboxDto.networkAllowList)
+      }
+      if (createSandboxDto.autoStopInterval !== undefined) {
+        sandbox.autoStopInterval = this.resolveAutoStopInterval(createSandboxDto.autoStopInterval)
+      }
+      if (createSandboxDto.autoArchiveInterval !== undefined) {
+        sandbox.autoArchiveInterval = this.resolveAutoArchiveInterval(createSandboxDto.autoArchiveInterval)
+      }
+      if (createSandboxDto.autoDeleteInterval !== undefined) {
+        sandbox.autoDeleteInterval = createSandboxDto.autoDeleteInterval
+      }
+      if (createSandboxDto.volumes !== undefined) {
+        sandbox.volumes = this.resolveVolumes(createSandboxDto.volumes)
+      }
+
+      sandbox.pending = true
+
+      const insertedSandbox = await this.sandboxRepository.insert(sandbox)
+
+      this.eventEmitter
+        .emitAsync(SandboxEvents.CREATED, new SandboxCreatedEvent(insertedSandbox))
+        .catch((err) => this.logger.error('Failed to emit SandboxCreatedEvent', err))
+
+      return this.toSandboxDto(insertedSandbox)
+    } catch (error) {
+      await this.rollbackPendingUsage(
+        organization.id,
+        region.id,
+        pendingCpuIncrement,
+        pendingMemoryIncrement,
+        pendingDiskIncrement,
+      )
+
+      if (error.code === '23505') {
+        throw new ConflictException(`Sandbox with name ${createSandboxDto.name} already exists`)
+      }
+
+      throw error
+    }
+  }
+
   async createFromBuildInfo(createSandboxDto: CreateSandboxDto, organization: Organization): Promise<SandboxDto> {
     let pendingCpuIncrement: number | undefined
     let pendingMemoryIncrement: number | undefined
     let pendingDiskIncrement: number | undefined
 
     const region = await this.getValidatedOrDefaultRegion(organization, createSandboxDto.target)
+
+    // Single-FROM dockerfiles (e.g. SDK's `Image.base('alpine:3.22.4')`) don't
+    // need a real build — they translate 1:1 to an image pull, which the runner
+    // supports today. The build path (apps/runner/pkg/boxlite/stubs.go::Build-
+    // Snapshot) is currently a stub. Auto-create a hidden snapshot for the image
+    // and route through the snapshot-pull lifecycle.
+    const singleFromRef = parseDockerfileForSingleFromRef(createSandboxDto.buildInfo?.dockerfileContent)
+    if (singleFromRef) {
+      return this.createFromImageRef(createSandboxDto, organization, region, singleFromRef)
+    }
 
     try {
       const sandboxClass = this.getValidatedOrDefaultClass(createSandboxDto.class)

--- a/apps/api/src/sandbox/services/snapshot.service.ts
+++ b/apps/api/src/sandbox/services/snapshot.service.ts
@@ -56,6 +56,16 @@ import { LogExecution } from '../../common/decorators/log-execution.decorator'
 import { WithInstrumentation } from '../../common/decorators/otel.decorator'
 
 const IMAGE_NAME_REGEX = /^[a-zA-Z0-9_.\-:]+(\/[a-zA-Z0-9_.\-:]+)*(@sha256:[a-f0-9]{64})?$/
+
+// Snapshot name prefix for auto-created snapshots backing single-FROM Dockerfile
+// builds. Hidden from end users; reused across sandbox creates for the same
+// (org, region, image) tuple.
+const AUTO_IMAGE_SNAPSHOT_PREFIX = '_auto-image'
+
+export function buildAutoImageSnapshotName(regionId: string, imageRef: string): string {
+  return `${AUTO_IMAGE_SNAPSHOT_PREFIX}/${regionId}/${imageRef}`
+}
+
 @Injectable()
 export class SnapshotService {
   private readonly logger = new Logger(SnapshotService.name)
@@ -214,6 +224,65 @@ export class SnapshotService {
       }
     } catch (error) {
       await this.rollbackPendingUsage(organization.id, pendingSnapshotCountIncrement)
+      throw error
+    }
+  }
+
+  // Find or create an auto-snapshot backing a single-FROM Dockerfile (i.e. a
+  // sandbox-create request whose `buildInfo.dockerfileContent` is just
+  // `FROM <imageRef>`). Auto-snapshots are hidden from users and identified by
+  // the `_auto-image/` name prefix; the existing snapshot.manager state machine
+  // transitions them PENDING → PULLING → ACTIVE.
+  //
+  // Concurrent callers for the same (org, region, image) tuple converge on the
+  // same snapshot via the (organizationId, name) UNIQUE constraint.
+  async ensureAutoSnapshotForImage(
+    organization: Organization,
+    regionId: string,
+    imageRef: string,
+  ): Promise<Snapshot> {
+    const imageValidationError = this.validateImageName(imageRef)
+    if (imageValidationError) {
+      throw new BadRequestException(imageValidationError)
+    }
+
+    const snapshotName = buildAutoImageSnapshotName(regionId, imageRef)
+
+    const existing = await this.snapshotRepository.findOne({
+      where: { organizationId: organization.id, name: snapshotName },
+    })
+    if (existing) {
+      return existing
+    }
+
+    this.organizationService.assertOrganizationIsNotSuspended(organization)
+
+    const snapshotId = uuidv4()
+    const snapshot = this.snapshotRepository.create({
+      id: snapshotId,
+      organizationId: organization.id,
+      name: snapshotName,
+      imageName: imageRef,
+      state: SnapshotState.PENDING,
+      hideFromUsers: true,
+      general: false,
+      snapshotRegions: [{ snapshotId, regionId }],
+    })
+
+    try {
+      const saved = await this.snapshotRepository.save(snapshot)
+      this.eventEmitter.emit(SnapshotEvents.CREATED, new SnapshotCreatedEvent(saved))
+      return saved
+    } catch (error) {
+      if (error.code === '23505') {
+        // Lost the race against a concurrent create — re-read the winner.
+        const concurrent = await this.snapshotRepository.findOne({
+          where: { organizationId: organization.id, name: snapshotName },
+        })
+        if (concurrent) {
+          return concurrent
+        }
+      }
       throw error
     }
   }

--- a/apps/api/src/sandbox/utils/dockerfile.util.spec.ts
+++ b/apps/api/src/sandbox/utils/dockerfile.util.spec.ts
@@ -5,6 +5,10 @@
 
 import { parseDockerfileForSingleFromRef } from './dockerfile.util'
 
+// 64-hex sha256 used in place of the toy `abcd` in earlier fixtures so the
+// test ref matches the shape `validateImageName` enforces in snapshot.service.
+const SAMPLE_DIGEST = 'a'.repeat(64)
+
 describe('parseDockerfileForSingleFromRef', () => {
   describe('matches single-FROM dockerfiles', () => {
     it('extracts a simple image ref', () => {
@@ -24,8 +28,8 @@ describe('parseDockerfileForSingleFromRef', () => {
     })
 
     it('accepts registry-qualified refs with digest', () => {
-      expect(parseDockerfileForSingleFromRef('FROM ghcr.io/example/app@sha256:abcd\n')).toBe(
-        'ghcr.io/example/app@sha256:abcd',
+      expect(parseDockerfileForSingleFromRef(`FROM ghcr.io/example/app@sha256:${SAMPLE_DIGEST}\n`)).toBe(
+        `ghcr.io/example/app@sha256:${SAMPLE_DIGEST}`,
       )
     })
 
@@ -43,6 +47,14 @@ describe('parseDockerfileForSingleFromRef', () => {
 
     it('strips blank lines around FROM', () => {
       expect(parseDockerfileForSingleFromRef('\n\nFROM alpine:3.22.4\n\n')).toBe('alpine:3.22.4')
+    })
+
+    it('handles leading whitespace before FROM', () => {
+      expect(parseDockerfileForSingleFromRef('  FROM alpine:3.22.4\n')).toBe('alpine:3.22.4')
+    })
+
+    it('handles mixed leading + trailing whitespace and tabs', () => {
+      expect(parseDockerfileForSingleFromRef('\t FROM alpine:3.22.4 \n')).toBe('alpine:3.22.4')
     })
   })
 

--- a/apps/api/src/sandbox/utils/dockerfile.util.spec.ts
+++ b/apps/api/src/sandbox/utils/dockerfile.util.spec.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { parseDockerfileForSingleFromRef } from './dockerfile.util'
+
+describe('parseDockerfileForSingleFromRef', () => {
+  describe('matches single-FROM dockerfiles', () => {
+    it('extracts a simple image ref', () => {
+      expect(parseDockerfileForSingleFromRef('FROM alpine:3.22.4\n')).toBe('alpine:3.22.4')
+    })
+
+    it('handles missing trailing newline', () => {
+      expect(parseDockerfileForSingleFromRef('FROM alpine:3.22.4')).toBe('alpine:3.22.4')
+    })
+
+    it('handles CRLF line endings', () => {
+      expect(parseDockerfileForSingleFromRef('FROM alpine:3.22.4\r\n')).toBe('alpine:3.22.4')
+    })
+
+    it('is case-insensitive on FROM', () => {
+      expect(parseDockerfileForSingleFromRef('from alpine:3.22.4\n')).toBe('alpine:3.22.4')
+    })
+
+    it('accepts registry-qualified refs with digest', () => {
+      expect(parseDockerfileForSingleFromRef('FROM ghcr.io/example/app@sha256:abcd\n')).toBe(
+        'ghcr.io/example/app@sha256:abcd',
+      )
+    })
+
+    it('accepts --platform flag', () => {
+      expect(parseDockerfileForSingleFromRef('FROM --platform=linux/amd64 alpine:3.22.4\n')).toBe('alpine:3.22.4')
+    })
+
+    it('accepts AS <stage> suffix on a single stage', () => {
+      expect(parseDockerfileForSingleFromRef('FROM alpine:3.22.4 AS base\n')).toBe('alpine:3.22.4')
+    })
+
+    it('strips Docker-style comments', () => {
+      expect(parseDockerfileForSingleFromRef('# user-supplied image\nFROM alpine:3.22.4\n')).toBe('alpine:3.22.4')
+    })
+
+    it('strips blank lines around FROM', () => {
+      expect(parseDockerfileForSingleFromRef('\n\nFROM alpine:3.22.4\n\n')).toBe('alpine:3.22.4')
+    })
+  })
+
+  describe('rejects multi-instruction dockerfiles', () => {
+    it('rejects FROM + RUN', () => {
+      expect(parseDockerfileForSingleFromRef('FROM alpine:3.22.4\nRUN apk add curl\n')).toBeNull()
+    })
+
+    it('rejects FROM + COPY', () => {
+      expect(parseDockerfileForSingleFromRef('FROM alpine:3.22.4\nCOPY . /app\n')).toBeNull()
+    })
+
+    it('rejects ARG before FROM', () => {
+      expect(parseDockerfileForSingleFromRef('ARG VERSION=3.22.4\nFROM alpine:${VERSION}\n')).toBeNull()
+    })
+
+    it('rejects multi-stage builds', () => {
+      expect(
+        parseDockerfileForSingleFromRef('FROM alpine:3.22.4 AS base\nFROM base\nRUN echo hi\n'),
+      ).toBeNull()
+    })
+  })
+
+  describe('rejects edge cases', () => {
+    it('returns null on empty input', () => {
+      expect(parseDockerfileForSingleFromRef('')).toBeNull()
+      expect(parseDockerfileForSingleFromRef(undefined)).toBeNull()
+      expect(parseDockerfileForSingleFromRef(null)).toBeNull()
+    })
+
+    it('returns null when FROM is missing', () => {
+      expect(parseDockerfileForSingleFromRef('RUN echo hi\n')).toBeNull()
+    })
+
+    it('rejects build-arg interpolation in ref', () => {
+      expect(parseDockerfileForSingleFromRef('FROM alpine:${VERSION}\n')).toBeNull()
+    })
+
+    it('rejects malformed FROM', () => {
+      expect(parseDockerfileForSingleFromRef('FROM\n')).toBeNull()
+      expect(parseDockerfileForSingleFromRef('FROM   \n')).toBeNull()
+    })
+  })
+})

--- a/apps/api/src/sandbox/utils/dockerfile.util.ts
+++ b/apps/api/src/sandbox/utils/dockerfile.util.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+// Detects "no-op" dockerfiles that consist of a single `FROM <ref>` and nothing
+// else. These can be served by the snapshot-pull path (which is implemented end
+// to end) instead of the snapshot-build path (which is currently a stub in the
+// BoxLite Go runner — see apps/runner/pkg/boxlite/stubs.go::BuildSnapshot).
+
+// Strips Docker-style comments and trailing whitespace; preserves quoted text.
+function stripComments(line: string): string {
+  return line.replace(/^\s*#.*$/, '').replace(/\s+$/, '')
+}
+
+// Returns the ref if `dockerfile` contains exactly one non-empty instruction
+// `FROM <ref>` (case-insensitive, optional platform/stage). Returns null
+// otherwise — any RUN/COPY/ADD/ARG/ENV/etc. instruction or multi-stage build
+// disqualifies the dockerfile from the pull short-circuit.
+export function parseDockerfileForSingleFromRef(dockerfile: string | undefined | null): string | null {
+  if (!dockerfile) {
+    return null
+  }
+
+  const lines = dockerfile.split(/\r?\n/).map(stripComments).filter((l) => l.length > 0)
+
+  if (lines.length !== 1) {
+    return null
+  }
+
+  const match = lines[0].match(/^FROM\s+(?:--platform=\S+\s+)?(\S+)(?:\s+AS\s+\S+)?\s*$/i)
+  if (!match) {
+    return null
+  }
+
+  const ref = match[1]
+  // Reject build-arg interpolation in the ref — caller would need the build env.
+  if (ref.includes('$')) {
+    return null
+  }
+
+  return ref
+}

--- a/apps/api/src/sandbox/utils/dockerfile.util.ts
+++ b/apps/api/src/sandbox/utils/dockerfile.util.ts
@@ -8,9 +8,12 @@
 // to end) instead of the snapshot-build path (which is currently a stub in the
 // BoxLite Go runner — see apps/runner/pkg/boxlite/stubs.go::BuildSnapshot).
 
-// Strips Docker-style comments and trailing whitespace; preserves quoted text.
+// Strips Docker-style whole-line comments and surrounding whitespace.
+// Trimming both sides matters because Dockerfile syntax permits indented
+// instructions (e.g. `  FROM alpine`) and a line-start FROM anchor below
+// would otherwise drop them.
 function stripComments(line: string): string {
-  return line.replace(/^\s*#.*$/, '').replace(/\s+$/, '')
+  return line.replace(/^\s*#.*$/, '').trim()
 }
 
 // Returns the ref if `dockerfile` contains exactly one non-empty instruction

--- a/apps/libs/sdk-typescript/src/Sandbox.ts
+++ b/apps/libs/sdk-typescript/src/Sandbox.ts
@@ -370,7 +370,7 @@ export class Sandbox implements SandboxDto {
         return
       }
 
-      if (this.state === 'error') {
+      if (this.state === 'error' || this.state === 'build_failed') {
         const errMsg = `Sandbox ${this.id} failed to start with status: ${this.state}, error reason: ${this.errorReason}`
         throw new BoxliteError(errMsg)
       }


### PR DESCRIPTION
## Summary

Creating a sandbox from a plain image ref like `alpine:3.22.4` is currently broken on `dev.boxlite.ai`: the dashboard hangs for 60s, then surfaces a generic "Sandbox failed to become ready" error. The underlying sandbox row is in `state=build_failed` with `errorReason="snapshot build is not supported by the BoxLite Go SDK"` — `apps/runner/pkg/boxlite/stubs.go::BuildSnapshot` is a stub.

This PR recognizes that a Dockerfile consisting of only `FROM <ref>` is operationally a **pull**, not a build, and routes it through the existing (fully implemented) snapshot-pull lifecycle. Real multi-instruction Dockerfiles are untouched and still hit the stub — that path's product story is unchanged.

## Root cause flow (before)

```
Dashboard image="alpine:3.22.4"
  → SDK Image.base() wraps as `FROM alpine:3.22.4\n`
  → POST /sandbox  { buildInfo: { dockerfileContent: ... } }
  → API createFromBuildInfo → runnerAdapter.buildSnapshot
  → runner BuildSnapshot stub → ErrNotImplemented
  → sandbox.state = build_failed
  → SDK waitUntilStarted only treats `error` as terminal, so loops 60s
  → Generic timeout reported, real reason hidden
```

## Fix flow (after)

```
Dashboard image="alpine:3.22.4"   (no client change)
  → SDK wraps as `FROM alpine:3.22.4\n`   (no SDK contract change)
  → POST /sandbox  { buildInfo: { ... } }
  → API parseDockerfileForSingleFromRef → "alpine:3.22.4"
  → createFromImageRef
     • ensureAutoSnapshotForImage(org, region, "alpine:3.22.4")
         snapshot row: name=_auto-image/<region>/<ref>, state=PENDING, hideFromUsers=true
     • sandbox row: state=PULLING_SNAPSHOT, runnerId=null
  → snapshot.manager (existing) handles PENDING → PULLING → ACTIVE
  → sandbox-start sync (existing) picks PULLING_SNAPSHOT, picks runner, pulls, → STARTED
```

Even when the underlying registry pull genuinely fails (image typo, registry 404, network), the SDK fix makes the failure visible **immediately** (0s, with real `errorReason`) instead of after 60s.

## Changes

| File | Change |
|---|---|
| `apps/api/src/sandbox/utils/dockerfile.util.ts` *(new)* | Pure parser `parseDockerfileForSingleFromRef`. Returns the ref for a single-`FROM` Dockerfile (allows `--platform`, `AS stage`, comments, blank lines), null otherwise. |
| `apps/api/src/sandbox/utils/dockerfile.util.spec.ts` *(new)* | 17 unit tests: positive cases (simple, CRLF, comments, `AS`, `--platform`), negative (multi-instruction, multi-stage, ARG interpolation, malformed). |
| `apps/api/src/sandbox/services/snapshot.service.ts` | New `ensureAutoSnapshotForImage(org, regionId, imageRef)`. Find-or-create idempotent on the existing `(organizationId, name)` UNIQUE constraint; concurrent callers converge via 23505 catch-and-reread. Hidden from user-visible lists via `hideFromUsers=true`. |
| `apps/api/src/sandbox/services/sandbox.service.ts` | `createFromBuildInfo` short-circuits to a new private `createFromImageRef` when the Dockerfile is single-`FROM`. The new helper mirrors the existing create lifecycle (quota/volumes/event paths) but parks the sandbox in `PULLING_SNAPSHOT` with `runnerId=null`. `createFromSnapshot` is not modified. |
| `apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts` | `handleUnassignedRunnerSandbox` returns `DONT_SYNC_AGAIN` when `snapshot.ref` is null. Lets the 10s `sync-states` cron retry while `snapshot.manager` is computing the ref — instead of pinning a runner without a ref and erroring out in `pullSnapshotToRunner`. |
| `apps/libs/sdk-typescript/src/Sandbox.ts` | `waitUntilStarted` recognizes `build_failed` as terminal (one-line change next to existing `error` check). Independently valuable: any `build_failed` from any path now surfaces in 0s with the real reason. |

Two commits:
1. `fix(api): pull image instead of stub build for single-FROM sandboxes` — core fix.
2. `chore(local-dev): docker-compose + mock-runner for local verification` — adds `apps/local-dev/` so contributors can smoke the routing locally without deploying to dev.

## Backwards compatibility

- **Single-`FROM` Dockerfiles** (typed-image path) — newly works. Previously stuck at `build_failed`.
- **Multi-instruction Dockerfiles** — unchanged. Still routes to `runnerAdapter.buildSnapshot`. Will continue to fail with the same `build_failed` error until the runner stub is implemented; this PR makes that failure visible 0s instead of 60s.
- **Named-snapshot sandboxes** (`snapshot: <name>`) — unchanged; `createFromSnapshot` not touched.
- **Old SDK / dashboard clients** — automatically benefit; the routing decision is server-side.

No DB schema changes. No new dependencies. The auto-snapshot name format `_auto-image/<region>/<image-ref>` is greppable for ops cleanup.

## Test plan

- [x] Parser unit tests pass (17/17, standalone Node test harness).
- [x] SDK `waitUntilStarted` standalone harness (4/4): immediate throw on `build_failed`, immediate throw on `error`, success on `started`, correct timeout on stuck states.
- [x] `tsc --noEmit` clean on touched files (`api/tsconfig.app.json`, `libs/sdk-typescript/tsconfig.lib.json`). Pre-existing unrelated errors in other files (e.g. `req.headers` typing, missing `node-forge` types) are unchanged.
- [x] Local docker-compose smoke (`apps/local-dev/smoke.sh`): pg/redis/mock-runner all healthy; mock-runner returns 501 on `/snapshots/build` (the path our fix avoids) and 202 on `/snapshots/pull` (the path our fix routes to).
- [ ] **Deploy to `dev.boxlite.ai` and create a sandbox from `alpine:3.22.4` in the dashboard.** Expect: sandbox row appears with `state=pulling_snapshot`; an auto-snapshot row appears with `imageName=alpine:3.22.4` and `hideFromUsers=true`; sandbox transitions to `started` within ~30–90s.
- [ ] Verify a known-bad image (e.g. `alpine:does-not-exist-9.9.9`) now fails fast with the real registry error, not a 60s timeout.

## Notes for reviewers

- The "auto-snapshot" approach was chosen over reusing `createFromSnapshot` directly because that path's invariants (snapshot must be `ACTIVE`, cpu/mem inherited from snapshot, warm-pool lookup) don't fit a freshly-created `PENDING` snapshot. Adding a parallel `createFromImageRef` keeps both paths internally consistent.
- The runner `BuildSnapshot` stub is intentionally left in place. Implementing real Dockerfile builds (containerd/buildkit/buildah integration in `src/boxlite/`) is a separate epic.
- I added `apps/local-dev/` because there's no existing local-stack scaffolding I could find. Happy to relocate or rename if the project has a preferred convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
