### PR TITLE
docs(auth): drop legacy /oauth/tokens references after #532

### DIFF
--- a/apps/api/src/boxlite-rest/boxlite-ws-proxy.service.ts
+++ b/apps/api/src/boxlite-rest/boxlite-ws-proxy.service.ts
@@ -128,9 +128,9 @@ export class BoxliteWsProxyService {
    * sandboxes in that org.
    *
    * JWT (the second strategy in CombinedAuthGuard) is unused here because the
-   * BoxLite SDK's `/oauth/tokens` handler echoes the client_secret straight
-   * back as the access_token, so the Bearer is always the raw API key. If a
-   * real JWT issuer is ever wired in, extend this method to fall through to
+   * gateway has no OAuth token issuer — API keys are the only credential
+   * source today, and the Bearer is always the raw API key. If a real JWT
+   * issuer is ever wired in, extend this method to fall through to
    * `jwtVerify`.
    *
    * Unlike the HTTP path, this does not consult the Redis cache used by

--- a/openapi/reference-server/README.md
+++ b/openapi/reference-server/README.md
@@ -19,23 +19,28 @@ cd openapi/reference-server
 uv run --active server.py
 ```
 
-## Test Credentials
+## Authentication
 
-| Field | Value |
-|-------|-------|
-| client_id | `test-client` |
-| client_secret | `test-secret` |
+The reference server accepts **any non-empty Bearer token** — token format and
+validation are out of scope for the contract (see `BearerAuth` in
+`box.openapi.yaml`). Production gateways plug in real validators. Use any
+placeholder locally:
+
+```bash
+TOKEN=demo
+```
 
 ## Quick Test
 
 ```bash
-# Get a token
-TOKEN=$(curl -s -X POST http://localhost:8080/v1/oauth/tokens \
-  -d 'grant_type=client_credentials&client_id=test-client&client_secret=test-secret' \
-  | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])")
+TOKEN=demo
 
-# Server config
+# Server config (no auth required)
 curl -s http://localhost:8080/v1/config | python3 -m json.tool
+
+# Identity for the calling credential
+curl -s http://localhost:8080/v1/me \
+  -H "Authorization: Bearer $TOKEN" | python3 -m json.tool
 
 # Create a box
 curl -s -X POST http://localhost:8080/v1/demo/boxes \
@@ -68,12 +73,12 @@ curl -s -X DELETE http://localhost:8080/v1/demo/boxes/$BOX_ID \
   -H "Authorization: Bearer $TOKEN" -w "%{http_code}\n"
 ```
 
-## Implemented Endpoints (20 of 22)
+## Implemented Endpoints
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
 | `/v1/config` | GET | Server configuration |
-| `/v1/oauth/tokens` | POST | OAuth2 client credentials |
+| `/v1/me` | GET | Identity for the calling credential |
 | `/{prefix}/boxes` | POST | Create box |
 | `/{prefix}/boxes` | GET | List boxes |
 | `/{prefix}/boxes/{id}` | GET | Get box |
@@ -112,10 +117,6 @@ Use `--env-file` to load a different file.
 | `BOXLITE_SERVER_HOST` | `0.0.0.0` |
 | `BOXLITE_SERVER_PORT` | `8080` |
 | `BOXLITE_SERVER_LOG_LEVEL` | `info` |
-| `BOXLITE_SERVER_JWT_SECRET` | `boxlite-reference-server-secret` |
-| `BOXLITE_SERVER_JWT_EXPIRY_SECONDS` | `3600` |
-| `BOXLITE_SERVER_CLIENT_ID` | `test-client` |
-| `BOXLITE_SERVER_CLIENT_SECRET` | `test-secret` |
 
 ### Runtime Settings (`BOXLITE_RUNTIME_*`)
 

--- a/src/cli/src/commands/serve/README.md
+++ b/src/cli/src/commands/serve/README.md
@@ -68,7 +68,7 @@ execute(ServeArgs, GlobalFlags)
 │  │  └──────────────────────────────────────────────┘ │  │
 │  └──────────────────────────────────────────────────┘  │
 │                                                        │
-│  Handlers:  auth · config · boxes · executions         │
+│  Handlers:  me · config · boxes · executions           │
 │             files · metrics · snapshots · advanced     │
 │                                                        │
 │  Background:  reaper_loop  (orphan cleanup)            │
@@ -89,7 +89,7 @@ registry.
 
 | Module       | File                     | Purpose                                                       |
 |--------------|--------------------------|---------------------------------------------------------------|
-| `auth`       | `handlers/auth.rs`       | OAuth2 token endpoint (local passthrough, always succeeds)    |
+| `me`         | `handlers/me.rs`         | `GET /v1/me` — identity for the calling credential            |
 | `config`     | `handlers/config.rs`     | Capability discovery (snapshots, clone, export, import)       |
 | `boxes`      | `handlers/boxes.rs`      | Box CRUD: create, list, get, head, start, stop, remove        |
 | `executions` | `handlers/executions.rs` | Lifecycle: start, status, signal, kill, resize, attach        |
@@ -102,11 +102,11 @@ registry.
 
 All paths are relative to the server root (e.g. `http://localhost:8100`).
 
-### Auth & Config
+### Identity & Config
 
 | Method | Path                 | Handler               | Description                        |
 |--------|----------------------|-----------------------|------------------------------------|
-| POST   | `/v1/oauth/tokens`   | `auth::oauth_token`   | Get bearer token (always succeeds) |
+| GET    | `/v1/me`             | `me::get_me`          | Identity for the calling credential |
 | GET    | `/v1/config`         | `config::get_config`  | Capability discovery               |
 
 ### Box CRUD & Lifecycle


### PR DESCRIPTION
The final commit in #532 (refactor(auth): API-key-only; drop device flow scaffolding) deleted the /v1/oauth/* handlers from the Axum reference server (boxlite serve) and the Python reference server, and the device-flow CLI/SDK code.

Current auth model:

Single Bearer auth via API

OpenAPI spec (openapi/box.openapi.yaml) — BearerAuth only; 

So we need to change this documents:

src/cli/src/commands/serve/README.md:109 — route table lists POST /v1/oauth/tokens (handler doesn't exist).

openapi/reference-server/README.md:22-35, 76 — "Test Credentials" table + Quick Test fetches token from removed
