### PR TITLE
feat(cli): add --rootfs flag to run/create command [WIP]

### DIFF
--- a/docs/reference/cli/README.md
+++ b/docs/reference/cli/README.md
@@ -231,11 +231,11 @@ Credential:      API key (from BOXLITE_API_KEY env var)
 
 ### `boxlite run`
 
-**Synopsis:** `boxlite run [OPTIONS] IMAGE [COMMAND...]`
+**Synopsis:** `boxlite run [OPTIONS] (IMAGE | --rootfs PATH) [COMMAND...]`
 
 Create a box from an image and run a command. If `COMMAND` is omitted, the box runs `sh` (`src/cli/src/commands/run.rs:138`).
 
-**Options:** Uses [`ProcessFlags`](#processflags) + [`ResourceFlags`](#resourceflags) + [`PublishFlags`](#publishflags) + [`VolumeFlags`](#volumeflags) + [`ManagementFlags`](#managementflags).
+**Options:** Uses [`RootfsFlags`](#rootfsflags) + [`ProcessFlags`](#processflags) + [`ResourceFlags`](#resourceflags) + [`PublishFlags`](#publishflags) + [`VolumeFlags`](#volumeflags) + [`ManagementFlags`](#managementflags).
 
 **Exit behavior:**
 
@@ -251,6 +251,7 @@ boxlite run -it --rm alpine:latest /bin/sh
 boxlite run -d --name web -p 8080:80 nginx:alpine
 boxlite run -v $(pwd):/work -w /work alpine:latest ls -la
 boxlite run --cpus 4 --memory 4096 python:slim python -c "print(2+2)"
+boxlite run --rootfs /var/lib/bundles/myapp -- /app/server
 ```
 
 ---
@@ -281,7 +282,7 @@ boxlite exec -e DEBUG=1 -w /app mybox -- pytest tests/
 
 ### `boxlite create`
 
-**Synopsis:** `boxlite create [OPTIONS] IMAGE`
+**Synopsis:** `boxlite create [OPTIONS] (IMAGE | --rootfs PATH)`
 
 Create a box without running a command. Prints the new box's ID to stdout.
 
@@ -292,7 +293,7 @@ Create a box without running a command. Prints the new box's ID to stdout.
 | `--env KEY=VALUE` | `-e` | Set environment variables (repeatable) |
 | `--workdir PATH` | `-w` | Working directory inside the box |
 
-Also uses [`ResourceFlags`](#resourceflags) + [`PublishFlags`](#publishflags) + [`VolumeFlags`](#volumeflags) + [`ManagementFlags`](#managementflags).
+Also uses [`RootfsFlags`](#rootfsflags) + [`ResourceFlags`](#resourceflags) + [`PublishFlags`](#publishflags) + [`VolumeFlags`](#volumeflags) + [`ManagementFlags`](#managementflags).
 
 > Note: `create` accepts `--env` and `--workdir` directly rather than via `ProcessFlags` (no `-i`/`-t`/`-u` here, since no command is being executed).
 
@@ -301,6 +302,7 @@ Also uses [`ResourceFlags`](#resourceflags) + [`PublishFlags`](#publishflags) + 
 ```bash
 boxlite create --name mybox alpine:latest
 boxlite create -p 8080:80 -v /data:/app/data --name web nginx:alpine
+boxlite create --rootfs /var/lib/bundles/myapp --name offline-box
 ```
 
 ---
@@ -559,6 +561,19 @@ boxlite completion fish > ~/.config/fish/completions/boxlite.fish
 ## Shared Flag Groups
 
 Several commands flatten shared `clap` `Args` structs. Each is documented here once.
+
+### `RootfsFlags`
+
+Used by `run` and `create` (defined at `src/cli/src/cli.rs`).
+
+Selects the source for the box rootfs. Exactly one of `IMAGE` or `--rootfs` is required; clap enforces mutual exclusion at parse time.
+
+| Flag | Description |
+|------|-------------|
+| `IMAGE` (positional) | Registry image reference (e.g. `alpine:latest`). Conflicts with `--rootfs`. |
+| `--rootfs PATH` | Path to a pre-exported OCI bundle directory (contains `oci-layout`, `index.json`, `blobs/`). The CLI verifies the path exists, is a directory, and contains an `oci-layout` file; deeper validation happens in the runtime. Conflicts with `IMAGE`. |
+
+> When combining `--rootfs` with a `COMMAND` on `boxlite run`, use `--` before the command (`boxlite run --rootfs /b -- echo hi`), otherwise the first command word is parsed as `IMAGE` and clap rejects the conflict.
 
 ### `ProcessFlags`
 

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -206,7 +206,7 @@ Credential:      API key (from ~/.boxlite/credentials.toml)
 
 Create a box from an image and run a command.
 
-**Usage:** `boxlite run [OPTIONS] IMAGE [COMMAND]...`
+**Usage:** `boxlite run [OPTIONS] (IMAGE | --rootfs PATH) [COMMAND]...`
 
 | Option | Short | Description |
 |--------|-------|-------------|
@@ -218,6 +218,7 @@ Create a box from an image and run a command.
 | `--volume VOLUME` | `-v` | Mount a volume (e.g. `hostPath:boxPath`, `boxPath` for anonymous) |
 | `--cpus N` | | CPU limit |
 | `--memory MiB` | | Memory limit (MiB) |
+| `--rootfs PATH` | | Use a pre-exported OCI bundle directory instead of pulling an image. Mutually exclusive with `IMAGE`. When combined with a `COMMAND`, use `--` before the command. |
 | `--name NAME` | | Name the box |
 | `--detach` | `-d` | Run in background, print box ID |
 | `--rm` | | Remove the box when it exits |
@@ -229,13 +230,16 @@ boxlite run alpine:latest echo "Hello"
 boxlite run -it --rm alpine:latest /bin/sh
 boxlite run -d --name openclaw -p 18789:18789 ghcr.io/openclaw/openclaw:main
 boxlite run -v /host/data:/app/data alpine:latest cat /app/data/hello.txt
+
+# Run from a pre-exported OCI bundle (no registry pull)
+boxlite run --rootfs /path/to/oci-bundle -- echo "Hello from local rootfs"
 ```
 
 ### `boxlite create`
 
 Create a new box without running a command.
 
-**Usage:** `boxlite create [OPTIONS] IMAGE`
+**Usage:** `boxlite create [OPTIONS] (IMAGE | --rootfs PATH)`
 
 | Option | Short | Description |
 |--------|-------|-------------|
@@ -246,6 +250,7 @@ Create a new box without running a command.
 | `--volume VOLUME` | `-v` | Mount a volume (e.g. `hostPath:boxPath`, or box path for anonymous) |
 | `--cpus N` | | CPU limit |
 | `--memory MiB` | | Memory limit (MiB) |
+| `--rootfs PATH` | | Use a pre-exported OCI bundle directory instead of pulling an image. Mutually exclusive with `IMAGE`. |
 | `--detach` | `-d` | (create always “detaches”) |
 | `--rm` | | Auto-remove when stopped |
 
@@ -256,6 +261,9 @@ boxlite create --name mybox alpine:latest
 boxlite create -p 18789:18789 -v /data:/app/data --name openclaw ghcr.io/openclaw/openclaw:main
 boxlite start mybox
 boxlite start openclaw
+
+# Create a box from a pre-exported OCI bundle
+boxlite create --rootfs /path/to/oci-bundle --name offline-box
 ```
 
 ### `boxlite exec`

--- a/src/cli/src/cli.rs
+++ b/src/cli/src/cli.rs
@@ -665,9 +665,7 @@ impl RootfsFlags {
     pub fn resolve(&self) -> anyhow::Result<RootfsSpec> {
         if let Some(path) = &self.rootfs {
             validate_oci_bundle(path)?;
-            Ok(RootfsSpec::RootfsPath(
-                path.to_string_lossy().into_owned(),
-            ))
+            Ok(RootfsSpec::RootfsPath(path.to_string_lossy().into_owned()))
         } else if let Some(image) = &self.image {
             Ok(RootfsSpec::Image(image.clone()))
         } else {
@@ -1116,13 +1114,8 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("oci-layout"), "{}").unwrap();
         let path_str = dir.path().to_str().unwrap();
-        let result = Cli::try_parse_from([
-            "boxlite",
-            "create",
-            "--rootfs",
-            path_str,
-            "alpine:latest",
-        ]);
+        let result =
+            Cli::try_parse_from(["boxlite", "create", "--rootfs", path_str, "alpine:latest"]);
         assert!(result.is_err(), "expected mutex error when both set");
     }
 

--- a/src/cli/src/cli.rs
+++ b/src/cli/src/cli.rs
@@ -5,6 +5,7 @@
 use boxlite::runtime::options::{PortProtocol, PortSpec, VolumeSpec};
 use boxlite::{
     BoxCommand, BoxOptions, BoxliteOptions, BoxliteRestOptions, BoxliteRuntime, ImageRegistry,
+    RootfsSpec,
 };
 use clap::{Args, Command, Parser, Subcommand, ValueEnum};
 use clap_complete::shells::{Bash, Fish, Zsh};
@@ -632,6 +633,68 @@ impl ManagementFlags {
     }
 }
 
+// ============================================================================
+// ROOTFS FLAGS
+// ============================================================================
+
+/// Source for the box rootfs: either a registry image reference (positional
+/// `IMAGE`) or a pre-exported OCI bundle directory (`--rootfs PATH`).
+///
+/// Exactly one must be provided; clap's `ArgGroup` enforces this at parse time.
+/// When `--rootfs` is used together with `boxlite run`, place `--` before
+/// `COMMAND` to avoid the first command word being parsed as `IMAGE`.
+#[derive(Args, Debug, Clone)]
+#[group(required = true, multiple = false)]
+pub struct RootfsFlags {
+    /// Image to create the box from (e.g. `alpine:latest`)
+    #[arg(index = 1)]
+    pub image: Option<String>,
+
+    /// Use a pre-exported OCI bundle directory instead of pulling an image.
+    ///
+    /// The directory must contain an `oci-layout` file (i.e. it must be a
+    /// valid OCI image layout, as produced by `skopeo copy oci:` or similar).
+    #[arg(long, value_name = "PATH")]
+    pub rootfs: Option<std::path::PathBuf>,
+}
+
+impl RootfsFlags {
+    /// Convert the parsed flags into a `RootfsSpec`. Validates the bundle
+    /// path when `--rootfs` is set. Returns an error if neither field is
+    /// populated (clap's group should prevent this, but be defensive).
+    pub fn resolve(&self) -> anyhow::Result<RootfsSpec> {
+        if let Some(path) = &self.rootfs {
+            validate_oci_bundle(path)?;
+            Ok(RootfsSpec::RootfsPath(
+                path.to_string_lossy().into_owned(),
+            ))
+        } else if let Some(image) = &self.image {
+            Ok(RootfsSpec::Image(image.clone()))
+        } else {
+            anyhow::bail!("either IMAGE or --rootfs must be provided")
+        }
+    }
+}
+
+/// Verify `path` looks like an OCI image layout: directory containing an
+/// `oci-layout` file. Deeper validation (parsing `index.json`, checking
+/// blobs) is left to the runtime's `image_manager.load_from_local()`.
+fn validate_oci_bundle(path: &std::path::Path) -> anyhow::Result<()> {
+    if !path.exists() {
+        anyhow::bail!("rootfs path does not exist: {}", path.display());
+    }
+    if !path.is_dir() {
+        anyhow::bail!("rootfs path is not a directory: {}", path.display());
+    }
+    if !path.join("oci-layout").exists() {
+        anyhow::bail!(
+            "rootfs path {} is not an OCI bundle (missing oci-layout file)",
+            path.display()
+        );
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -984,5 +1047,88 @@ mod tests {
             panic!("expected AuthCommand::Login");
         };
         assert!(login.api_key_stdin);
+    }
+
+    // ─── RootfsFlags tests ───────────────────────────────────────────────
+    // (these live inside the existing `mod tests`, which already does
+    // `use super::*;`, so `RootfsSpec`, `RootfsFlags`, and
+    // `validate_oci_bundle` are all in scope.)
+
+    #[test]
+    fn rootfs_flags_image_only_resolves_to_image() {
+        let flags = RootfsFlags {
+            image: Some("alpine:latest".into()),
+            rootfs: None,
+        };
+        match flags.resolve().unwrap() {
+            RootfsSpec::Image(r) => assert_eq!(r, "alpine:latest"),
+            other => panic!("expected Image, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn rootfs_flags_rootfs_only_resolves_to_path() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("oci-layout"), "{}").unwrap();
+        let flags = RootfsFlags {
+            image: None,
+            rootfs: Some(dir.path().to_path_buf()),
+        };
+        match flags.resolve().unwrap() {
+            RootfsSpec::RootfsPath(p) => assert_eq!(p, dir.path().to_string_lossy()),
+            other => panic!("expected RootfsPath, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn validate_oci_bundle_missing_path_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("does-not-exist");
+        let err = validate_oci_bundle(&missing).unwrap_err();
+        assert!(err.to_string().contains("does not exist"), "got: {}", err);
+    }
+
+    #[test]
+    fn validate_oci_bundle_not_a_dir_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("regular-file");
+        std::fs::write(&file, b"not a bundle").unwrap();
+        let err = validate_oci_bundle(&file).unwrap_err();
+        assert!(err.to_string().contains("not a directory"), "got: {}", err);
+    }
+
+    #[test]
+    fn validate_oci_bundle_missing_oci_layout_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let err = validate_oci_bundle(dir.path()).unwrap_err();
+        assert!(err.to_string().contains("oci-layout"), "got: {}", err);
+    }
+
+    #[test]
+    fn validate_oci_bundle_minimal_bundle_passes() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("oci-layout"), "{}").unwrap();
+        validate_oci_bundle(dir.path()).expect("minimal bundle should pass");
+    }
+
+    #[test]
+    fn cli_rejects_image_and_rootfs_together() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("oci-layout"), "{}").unwrap();
+        let path_str = dir.path().to_str().unwrap();
+        let result = Cli::try_parse_from([
+            "boxlite",
+            "create",
+            "--rootfs",
+            path_str,
+            "alpine:latest",
+        ]);
+        assert!(result.is_err(), "expected mutex error when both set");
+    }
+
+    #[test]
+    fn cli_rejects_neither_image_nor_rootfs_on_create() {
+        let result = Cli::try_parse_from(["boxlite", "create"]);
+        assert!(result.is_err(), "expected required-group error");
     }
 }

--- a/src/cli/src/commands/create.rs
+++ b/src/cli/src/commands/create.rs
@@ -1,13 +1,12 @@
-use crate::cli::{GlobalFlags, PublishFlags, ResourceFlags, VolumeFlags};
-use boxlite::{BoxOptions, RootfsSpec};
+use crate::cli::{GlobalFlags, PublishFlags, ResourceFlags, RootfsFlags, VolumeFlags};
+use boxlite::BoxOptions;
 use clap::Args;
 
 /// Create a new box
 #[derive(Args, Debug)]
 pub struct CreateArgs {
-    /// Image to create from
-    #[arg(index = 1)]
-    pub image: String,
+    #[command(flatten)]
+    pub rootfs: RootfsFlags,
 
     #[command(flatten)]
     pub management: crate::cli::ManagementFlags,
@@ -49,7 +48,7 @@ impl CreateArgs {
         self.volume.apply_to(&mut options, global.home.as_deref())?;
         options.working_dir = self.workdir.clone();
         crate::cli::apply_env_vars(&self.env, &mut options);
-        options.rootfs = RootfsSpec::Image(self.image.clone());
+        options.rootfs = self.rootfs.resolve()?;
         Ok(options)
     }
 }

--- a/src/cli/src/commands/run.rs
+++ b/src/cli/src/commands/run.rs
@@ -1,10 +1,11 @@
 use crate::cli::{
-    GlobalFlags, ManagementFlags, ProcessFlags, PublishFlags, ResourceFlags, VolumeFlags,
+    GlobalFlags, ManagementFlags, ProcessFlags, PublishFlags, ResourceFlags, RootfsFlags,
+    VolumeFlags,
 };
 use crate::terminal::StreamManager;
 use crate::util::to_shell_exit_code;
 use boxlite::BoxCommand;
-use boxlite::{BoxOptions, BoxliteRuntime, LiteBox, RootfsSpec};
+use boxlite::{BoxOptions, BoxliteRuntime, LiteBox};
 use clap::Args;
 use std::io::{self, IsTerminal};
 
@@ -25,10 +26,10 @@ pub struct RunArgs {
     #[command(flatten)]
     pub management: ManagementFlags,
 
-    #[arg(index = 1)]
-    pub image: String,
+    #[command(flatten)]
+    pub rootfs: RootfsFlags,
 
-    /// Command to run inside the image
+    /// Command to run inside the box (use `--` before COMMAND when using --rootfs)
     #[arg(index = 2, trailing_var_arg = true)]
     pub command: Vec<String>,
 }
@@ -106,7 +107,7 @@ impl BoxRunner {
             options.auto_remove = false;
         }
 
-        options.rootfs = RootfsSpec::Image(self.args.image.clone());
+        options.rootfs = self.args.rootfs.resolve()?;
 
         let litebox = self
             .rt

--- a/src/cli/tests/create.rs
+++ b/src/cli/tests/create.rs
@@ -134,3 +134,74 @@ fn test_create_with_volume_invalid_format() {
         .failure()
         .stderr(predicate::str::contains("absolute"));
 }
+
+// ============================================================================
+// --rootfs Argument Tests
+// ============================================================================
+
+#[test]
+fn test_create_rootfs_and_image_mutually_exclusive() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("oci-layout"), "{}").unwrap();
+
+    let mut ctx = common::boxlite();
+    ctx.cmd.args([
+        "create",
+        "--rootfs",
+        dir.path().to_str().unwrap(),
+        "alpine:latest",
+    ]);
+    ctx.cmd.assert().failure().stderr(
+        predicate::str::contains("cannot be used with")
+            .or(predicate::str::contains("conflict"))
+            .or(predicate::str::contains("the argument")),
+    );
+}
+
+#[test]
+fn test_create_requires_image_or_rootfs() {
+    let mut ctx = common::boxlite();
+    ctx.cmd.args(["create"]);
+    ctx.cmd.assert().failure().stderr(
+        predicate::str::contains("required")
+            .or(predicate::str::contains("the following required")),
+    );
+}
+
+#[test]
+fn test_create_rootfs_path_missing() {
+    let mut ctx = common::boxlite();
+    ctx.cmd
+        .args(["create", "--rootfs", "/path/that/does/not/exist/boxlite-rootfs"]);
+    ctx.cmd
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("does not exist"));
+}
+
+#[test]
+fn test_create_rootfs_path_not_a_directory() {
+    let dir = tempfile::tempdir().unwrap();
+    let file = dir.path().join("regular-file");
+    std::fs::write(&file, b"x").unwrap();
+
+    let mut ctx = common::boxlite();
+    ctx.cmd.args(["create", "--rootfs", file.to_str().unwrap()]);
+    ctx.cmd
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("not a directory"));
+}
+
+#[test]
+fn test_create_rootfs_path_missing_oci_layout() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let mut ctx = common::boxlite();
+    ctx.cmd
+        .args(["create", "--rootfs", dir.path().to_str().unwrap()]);
+    ctx.cmd
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("oci-layout"));
+}

--- a/src/cli/tests/create.rs
+++ b/src/cli/tests/create.rs
@@ -163,16 +163,18 @@ fn test_create_requires_image_or_rootfs() {
     let mut ctx = common::boxlite();
     ctx.cmd.args(["create"]);
     ctx.cmd.assert().failure().stderr(
-        predicate::str::contains("required")
-            .or(predicate::str::contains("the following required")),
+        predicate::str::contains("required").or(predicate::str::contains("the following required")),
     );
 }
 
 #[test]
 fn test_create_rootfs_path_missing() {
     let mut ctx = common::boxlite();
-    ctx.cmd
-        .args(["create", "--rootfs", "/path/that/does/not/exist/boxlite-rootfs"]);
+    ctx.cmd.args([
+        "create",
+        "--rootfs",
+        "/path/that/does/not/exist/boxlite-rootfs",
+    ]);
     ctx.cmd
         .assert()
         .failure()

--- a/src/cli/tests/run.rs
+++ b/src/cli/tests/run.rs
@@ -773,3 +773,75 @@ fn test_run_tty_error_in_pipe() {
         .failure()
         .stderr(predicate::str::contains("input device is not a TTY"));
 }
+
+// ============================================================================
+// --rootfs Argument Tests
+// ============================================================================
+
+#[test]
+fn test_run_rootfs_and_image_mutually_exclusive() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("oci-layout"), "{}").unwrap();
+
+    let mut ctx = common::boxlite();
+    ctx.cmd.args([
+        "run",
+        "--rootfs",
+        dir.path().to_str().unwrap(),
+        "alpine:latest",
+        "echo",
+        "hi",
+    ]);
+    ctx.cmd.assert().failure().stderr(
+        predicate::str::contains("cannot be used with")
+            .or(predicate::str::contains("conflict"))
+            .or(predicate::str::contains("the argument")),
+    );
+}
+
+#[test]
+fn test_run_requires_image_or_rootfs() {
+    let mut ctx = common::boxlite();
+    ctx.cmd.args(["run"]);
+    ctx.cmd.assert().failure().stderr(
+        predicate::str::contains("required")
+            .or(predicate::str::contains("the following required")),
+    );
+}
+
+#[test]
+fn test_run_rootfs_path_missing() {
+    let mut ctx = common::boxlite();
+    ctx.cmd
+        .args(["run", "--rootfs", "/path/that/does/not/exist/boxlite-rootfs"]);
+    ctx.cmd
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("does not exist"));
+}
+
+#[test]
+fn test_run_rootfs_path_not_a_directory() {
+    let dir = tempfile::tempdir().unwrap();
+    let file = dir.path().join("regular-file");
+    std::fs::write(&file, b"x").unwrap();
+
+    let mut ctx = common::boxlite();
+    ctx.cmd.args(["run", "--rootfs", file.to_str().unwrap()]);
+    ctx.cmd
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("not a directory"));
+}
+
+#[test]
+fn test_run_rootfs_path_missing_oci_layout() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let mut ctx = common::boxlite();
+    ctx.cmd.args(["run", "--rootfs", dir.path().to_str().unwrap()]);
+    ctx.cmd
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("oci-layout"));
+}

--- a/src/cli/tests/run.rs
+++ b/src/cli/tests/run.rs
@@ -804,16 +804,18 @@ fn test_run_requires_image_or_rootfs() {
     let mut ctx = common::boxlite();
     ctx.cmd.args(["run"]);
     ctx.cmd.assert().failure().stderr(
-        predicate::str::contains("required")
-            .or(predicate::str::contains("the following required")),
+        predicate::str::contains("required").or(predicate::str::contains("the following required")),
     );
 }
 
 #[test]
 fn test_run_rootfs_path_missing() {
     let mut ctx = common::boxlite();
-    ctx.cmd
-        .args(["run", "--rootfs", "/path/that/does/not/exist/boxlite-rootfs"]);
+    ctx.cmd.args([
+        "run",
+        "--rootfs",
+        "/path/that/does/not/exist/boxlite-rootfs",
+    ]);
     ctx.cmd
         .assert()
         .failure()
@@ -839,7 +841,8 @@ fn test_run_rootfs_path_missing_oci_layout() {
     let dir = tempfile::tempdir().unwrap();
 
     let mut ctx = common::boxlite();
-    ctx.cmd.args(["run", "--rootfs", dir.path().to_str().unwrap()]);
+    ctx.cmd
+        .args(["run", "--rootfs", dir.path().to_str().unwrap()]);
     ctx.cmd
         .assert()
         .failure()


### PR DESCRIPTION
Close #449

Added `--rootfs` flag to the CLI `run/create` command to allow users 
to specify a custom root filesystem path.