### PR TITLE
fix(jailer): propagate child errno from userns probe

### DIFF
--- a/src/boxlite/src/jailer/bwrap.rs
+++ b/src/boxlite/src/jailer/bwrap.rs
@@ -95,7 +95,9 @@ pub fn is_available() -> bool {
 ///
 /// Performs two checks:
 /// 1. **Chrome-style raw probe** — `clone(CLONE_NEWUSER)` for kernel-level
-///    diagnosis (captures errno: EPERM, EUSERS, EINVAL, ENOSPC)
+///    diagnosis (captures errno: EPERM, EUSERS, EINVAL, ENOSPC, EACCES
+///    — last is AppArmor `userns_create` denial on Linux 6.7+, see
+///    [`credentials::check_clone_new_user_errno`](super::credentials::check_clone_new_user_errno))
 /// 2. **bwrap probe** — `bwrap --unshare-user` to test actual bwrap capability
 ///    (handles AppArmor per-binary profiles where bwrap may work even if
 ///    our process's clone fails)

--- a/src/boxlite/src/jailer/bwrap.rs
+++ b/src/boxlite/src/jailer/bwrap.rs
@@ -113,14 +113,14 @@ pub fn can_create_user_namespace() -> Result<(), String> {
     // Chrome-style raw probe for kernel-level diagnosis.
     // This may fail on AppArmor systems even when system bwrap works
     // (bwrap has its own AppArmor profile with userns permission).
-    let clone_errno = match super::credentials::can_create_process_in_new_user_ns() {
+    let clone_failure = match super::credentials::can_create_process_in_new_user_ns() {
         Ok(()) => None,
-        Err(errno) => {
+        Err(failure) => {
             tracing::debug!(
-                errno = errno,
+                failure = %failure,
                 "clone(CLONE_NEWUSER) failed — will still try bwrap (may have AppArmor profile)"
             );
-            Some(errno)
+            Some(failure)
         }
     };
 
@@ -139,7 +139,7 @@ pub fn can_create_user_namespace() -> Result<(), String> {
                 "bundled"
             };
             Err(build_diagnostic(
-                clone_errno,
+                clone_failure,
                 bwrap_source,
                 bwrap_path,
                 &stderr,
@@ -159,7 +159,7 @@ fn is_system_bwrap(path: &Path) -> bool {
 /// Reads sysctl files to detect the specific restriction and provides
 /// targeted fix commands for each scenario.
 fn build_diagnostic(
-    clone_errno: Option<i32>,
+    clone_failure: Option<super::credentials::ProbeFailure>,
     bwrap_source: &str,
     bwrap_path: &Path,
     bwrap_stderr: &str,
@@ -174,13 +174,9 @@ fn build_diagnostic(
         msg.push_str(&format!("\nbwrap stderr: {}", bwrap_stderr));
     }
 
-    // Chrome errno diagnosis
-    if let Some(errno) = clone_errno {
-        msg.push_str(&format!(
-            "\nclone(CLONE_NEWUSER) errno: {} ({})",
-            errno,
-            std::io::Error::from_raw_os_error(errno)
-        ));
+    // Chrome probe diagnosis (errno or non-errno failure mode)
+    if let Some(failure) = clone_failure {
+        msg.push_str(&format!("\nclone(CLONE_NEWUSER) {failure}"));
     }
 
     // Sysctl detection for targeted fix

--- a/src/boxlite/src/jailer/credentials.rs
+++ b/src/boxlite/src/jailer/credentials.rs
@@ -16,11 +16,18 @@
 /// support the feature. ENOSPC can occur when the system has reached its
 /// maximum configured number of user namespaces."
 ///
+/// `EACCES` was added on top of Chrome's set: Linux 6.7+ ships an
+/// AppArmor `userns_create` LSM hook (default-on in Ubuntu 23.10+) that
+/// denies unprivileged user-namespace creation with `EACCES` rather than
+/// `EPERM`. Without it, every probe on those hosts logs at `error` level
+/// even though the case is well-understood.
+///
 /// Returns the errno for diagnosis. Logs unexpected errors.
 pub(crate) fn check_clone_new_user_errno(error: i32) -> i32 {
     match error {
-        libc::EPERM | libc::EUSERS | libc::EINVAL | libc::ENOSPC => {
-            // Expected errors — same set Chrome checks
+        libc::EPERM | libc::EUSERS | libc::EINVAL | libc::ENOSPC | libc::EACCES => {
+            // Expected errors — Chrome's original set plus EACCES for the
+            // AppArmor userns_create denial path.
             tracing::debug!(
                 errno = error,
                 message = %std::io::Error::from_raw_os_error(error),
@@ -280,12 +287,15 @@ mod tests {
         assert_eq!(check_clone_new_user_errno(libc::EUSERS), libc::EUSERS);
         assert_eq!(check_clone_new_user_errno(libc::EINVAL), libc::EINVAL);
         assert_eq!(check_clone_new_user_errno(libc::ENOSPC), libc::ENOSPC);
+        // EACCES is expected on Ubuntu 23.10+ where AppArmor's
+        // userns_create hook denies unprivileged user namespaces.
+        assert_eq!(check_clone_new_user_errno(libc::EACCES), libc::EACCES);
     }
 
     #[test]
     fn test_check_clone_new_user_errno_unexpected() {
         // Unexpected errnos should also be returned (just logged differently)
-        assert_eq!(check_clone_new_user_errno(libc::EACCES), libc::EACCES);
+        assert_eq!(check_clone_new_user_errno(libc::EIO), libc::EIO);
     }
 
     #[test]

--- a/src/boxlite/src/jailer/credentials.rs
+++ b/src/boxlite/src/jailer/credentials.rs
@@ -47,7 +47,10 @@ pub(crate) fn check_clone_new_user_errno(error: i32) -> i32 {
 /// 2. Calls `unshare(CLONE_NEWUSER)` again (tests nested userns)
 ///
 /// Returns `Ok(())` if user namespaces work, `Err(errno)` with the
-/// specific failure code for diagnosis.
+/// specific failure code for diagnosis. The child encodes its failing
+/// syscall's errno into its exit code so the parent can surface the real
+/// cause (e.g., `EACCES` from AppArmor's `userns_create` denial, not just
+/// a generic `EPERM`).
 ///
 /// # Safety
 ///
@@ -85,26 +88,26 @@ pub(crate) fn can_create_process_in_new_user_ns() -> Result<(), i32> {
 
             // Write /proc/self/setgroups -> "deny" (required before gid_map)
             if write_proc_file("/proc/self/setgroups\0", b"deny").is_err() {
-                libc::_exit(1);
+                child_exit_with_errno();
             }
 
             // Write /proc/self/gid_map
             let mut gid_buf = [0u8; 32];
             let gid_len = format_id_map(&mut gid_buf, gid, gid);
             if write_proc_file("/proc/self/gid_map\0", &gid_buf[..gid_len]).is_err() {
-                libc::_exit(1);
+                child_exit_with_errno();
             }
 
             // Write /proc/self/uid_map
             let mut uid_buf = [0u8; 32];
             let uid_len = format_id_map(&mut uid_buf, uid, uid);
             if write_proc_file("/proc/self/uid_map\0", &uid_buf[..uid_len]).is_err() {
-                libc::_exit(1);
+                child_exit_with_errno();
             }
 
             // Chrome: sys_unshare(CLONE_NEWUSER) — test nested user namespace
             if libc::unshare(libc::CLONE_NEWUSER) != 0 {
-                libc::_exit(1);
+                child_exit_with_errno();
             }
 
             libc::_exit(0);
@@ -122,12 +125,51 @@ pub(crate) fn can_create_process_in_new_user_ns() -> Result<(), i32> {
             }
         }
 
-        if libc::WIFEXITED(status) && libc::WEXITSTATUS(status) == 0 {
-            Ok(())
-        } else {
-            // Child failed — treat as permission error
-            Err(libc::EPERM)
-        }
+        decode_probe_status(status).map_err(check_clone_new_user_errno)
+    }
+}
+
+/// Read errno and `_exit` with it as the exit code, conveying the failing
+/// syscall's cause to the parent via `WEXITSTATUS`.
+///
+/// Standard Linux errnos all fit in `[1, 255]`. Anything outside that range
+/// (including the POSIX-violating errno == 0) is reported as 255 so the
+/// parent still sees a nonzero exit code (= failure) rather than a false
+/// success.
+///
+/// # Safety
+///
+/// Must be called from the child after fork. Reads thread-local errno.
+/// Both `*__errno_location()` and `_exit` are async-signal-safe.
+#[inline]
+unsafe fn child_exit_with_errno() -> ! {
+    let errno = unsafe { *libc::__errno_location() };
+    let code = if (1..=255).contains(&errno) {
+        errno
+    } else {
+        255
+    };
+    unsafe { libc::_exit(code) }
+}
+
+/// Decode the child's `waitpid` status into a `Result<(), i32>`.
+///
+/// The child uses [`child_exit_with_errno`] to encode its failing syscall's
+/// errno into the exit code. A clean exit (`_exit(0)`) means the probe
+/// succeeded. A signal-terminated child surfaces as `EINTR` — the probe
+/// child shouldn't normally be signaled, so this is a sentinel indicating
+/// the kernel did something unexpected.
+fn decode_probe_status(status: libc::c_int) -> Result<(), i32> {
+    if libc::WIFEXITED(status) {
+        let code = libc::WEXITSTATUS(status);
+        if code == 0 { Ok(()) } else { Err(code) }
+    } else if libc::WIFSIGNALED(status) {
+        // Child died from a signal — shouldn't happen in normal operation.
+        Err(libc::EINTR)
+    } else {
+        // waitpid(.., .., 0) doesn't report stopped/continued; if we got
+        // here the kernel did something we don't recognize.
+        Err(libc::EINVAL)
     }
 }
 
@@ -248,24 +290,79 @@ mod tests {
 
     #[test]
     fn test_can_create_process_in_new_user_ns() {
-        // This is a real probe — result depends on the system
+        // This is a real probe — result depends on the system. On failure
+        // the errno must be one of the documented cases. The test acts as
+        // a canary: a novel errno should panic so a maintainer reviews it
+        // and adds the new case explicitly (don't broaden silently).
+        //
+        // EACCES was added on top of Chrome's 2014 set after AppArmor's
+        // userns_create LSM hook (Linux 6.7+, Ubuntu 23.10+) became the
+        // default mechanism for blocking unprivileged userns creation.
         let result = can_create_process_in_new_user_ns();
         match result {
             Ok(()) => {
                 // User namespaces are available
             }
             Err(errno) => {
-                // Should be one of Chrome's expected errnos
                 assert!(
                     errno == libc::EPERM
                         || errno == libc::EUSERS
                         || errno == libc::EINVAL
-                        || errno == libc::ENOSPC,
+                        || errno == libc::ENOSPC
+                        || errno == libc::EACCES,
                     "Unexpected errno: {} ({})",
                     errno,
                     std::io::Error::from_raw_os_error(errno)
                 );
             }
         }
+    }
+
+    /// Construct a synthetic `wait` status that satisfies `WIFEXITED` with
+    /// the given exit code. Matches the encoding `WEXITSTATUS` decodes:
+    /// `((status >> 8) & 0xff)`.
+    fn make_exited_status(code: libc::c_int) -> libc::c_int {
+        (code & 0xff) << 8
+    }
+
+    #[test]
+    fn test_decode_probe_status_success() {
+        // _exit(0) → status low byte = 0, high byte = 0 → WEXITSTATUS == 0
+        assert_eq!(decode_probe_status(make_exited_status(0)), Ok(()));
+    }
+
+    #[test]
+    fn test_decode_probe_status_propagates_eperm() {
+        // Child encoded EPERM via _exit(EPERM); parent must surface EPERM.
+        assert_eq!(
+            decode_probe_status(make_exited_status(libc::EPERM)),
+            Err(libc::EPERM)
+        );
+    }
+
+    #[test]
+    fn test_decode_probe_status_propagates_eacces() {
+        // Regression: before this fix, the parent threw the child's errno
+        // away and always returned EPERM. On hosts with AppArmor's
+        // userns_create restriction active (Ubuntu 23.10+ with kernel
+        // 6.7+), the child fails with EACCES in nested userns / capability
+        // checks — that EACCES must now propagate through to the caller
+        // instead of being silently rewritten to EPERM.
+        assert_eq!(
+            decode_probe_status(make_exited_status(libc::EACCES)),
+            Err(libc::EACCES)
+        );
+    }
+
+    #[test]
+    fn test_decode_probe_status_signaled_returns_sentinel() {
+        // WIFSIGNALED: low 7 bits hold the signal, e.g., SIGKILL = 9.
+        // The probe child shouldn't be signaled in normal operation; we
+        // surface a sentinel (EINTR) so the caller sees a failure rather
+        // than a misleading "child succeeded".
+        let status: libc::c_int = libc::SIGKILL;
+        assert!(libc::WIFSIGNALED(status));
+        assert!(!libc::WIFEXITED(status));
+        assert_eq!(decode_probe_status(status), Err(libc::EINTR));
     }
 }

--- a/src/boxlite/src/jailer/credentials.rs
+++ b/src/boxlite/src/jailer/credentials.rs
@@ -7,6 +7,40 @@
 //! and checking if the child can set up uid/gid maps. This is more reliable
 //! than checking sysctl files because it tests the actual kernel code path.
 
+use std::fmt;
+
+/// How a `clone(CLONE_NEWUSER)` probe failed.
+///
+/// The probe either rolls up the child's failing-syscall errno via
+/// `WEXITSTATUS`, or it never got that far (signal-killed or kernel
+/// returned a status `waitpid` doesn't describe). We model the latter
+/// two as their own variants so they don't get smuggled inside a real
+/// errno value — earlier versions used `EINTR` as a "child was killed"
+/// sentinel, which collides with `EINTR`'s established "retry-the-syscall"
+/// semantics and produced misleading log lines downstream.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum ProbeFailure {
+    /// Child exited with a non-zero errno encoded in its exit code.
+    Errno(i32),
+    /// Child was terminated by a signal (SIGKILL, SIGSEGV, ...). Not
+    /// expected in normal operation; surface so the caller can choose
+    /// to retry or report.
+    ChildKilled,
+    /// `waitpid` returned a status that is neither `WIFEXITED` nor
+    /// `WIFSIGNALED` (e.g. stopped/continued from a misuse of flags).
+    BadStatus,
+}
+
+impl fmt::Display for ProbeFailure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Errno(e) => write!(f, "errno {} ({})", e, std::io::Error::from_raw_os_error(*e)),
+            Self::ChildKilled => f.write_str("probe child terminated by signal"),
+            Self::BadStatus => f.write_str("unrecognized waitpid status"),
+        }
+    }
+}
+
 /// Port of Chrome's `CheckCloneNewUserErrno()`.
 ///
 /// Validates that `clone(CLONE_NEWUSER)` failed with an expected errno.
@@ -46,6 +80,33 @@ pub(crate) fn check_clone_new_user_errno(error: i32) -> i32 {
     error
 }
 
+/// Log a [`ProbeFailure`] at the appropriate level and return it unchanged.
+///
+/// Mirrors [`check_clone_new_user_errno`]'s expected/unexpected split for the
+/// `Errno` variant, and routes the non-errno variants to their own log
+/// messages so a future reader of the logs can tell `clone(...)` failed
+/// outright from the probe child dying mid-flight.
+pub(crate) fn log_probe_failure(failure: ProbeFailure) -> ProbeFailure {
+    match &failure {
+        ProbeFailure::Errno(error) => {
+            check_clone_new_user_errno(*error);
+        }
+        ProbeFailure::ChildKilled => {
+            tracing::warn!(
+                "clone(CLONE_NEWUSER) probe child terminated by signal; \
+                 treating as probe failure (no retry)"
+            );
+        }
+        ProbeFailure::BadStatus => {
+            tracing::error!(
+                "clone(CLONE_NEWUSER) probe returned an unrecognized waitpid \
+                 status; this should not happen with waitpid(.., .., 0)"
+            );
+        }
+    }
+    failure
+}
+
 /// Port of Chrome's `Credentials::CanCreateProcessInNewUserNS()`.
 ///
 /// Probes whether the current process can create a child in a new user
@@ -53,17 +114,19 @@ pub(crate) fn check_clone_new_user_errno(error: i32) -> i32 {
 /// 1. Writes uid/gid maps (Chrome's `SetGidAndUidMaps`)
 /// 2. Calls `unshare(CLONE_NEWUSER)` again (tests nested userns)
 ///
-/// Returns `Ok(())` if user namespaces work, `Err(errno)` with the
-/// specific failure code for diagnosis. The child encodes its failing
+/// Returns `Ok(())` if user namespaces work, `Err(ProbeFailure)` describing
+/// the specific failure for diagnosis. The child encodes its failing
 /// syscall's errno into its exit code so the parent can surface the real
 /// cause (e.g., `EACCES` from AppArmor's `userns_create` denial, not just
-/// a generic `EPERM`).
+/// a generic `EPERM`). Non-errno failure modes (child killed by signal,
+/// kernel returned an unrecognized status) get their own variants so
+/// they're not smuggled inside a misleading errno value.
 ///
 /// # Safety
 ///
 /// Uses raw `clone` syscall and `waitpid`. The child process only uses
 /// async-signal-safe operations (open/write/close/unshare/_exit).
-pub(crate) fn can_create_process_in_new_user_ns() -> Result<(), i32> {
+pub(crate) fn can_create_process_in_new_user_ns() -> Result<(), ProbeFailure> {
     // SAFETY: Uses clone(CLONE_NEWUSER | SIGCHLD) to fork a child process.
     // Child only performs async-signal-safe operations before _exit().
     // Parent waits for child with EINTR retry loop.
@@ -84,7 +147,7 @@ pub(crate) fn can_create_process_in_new_user_ns() -> Result<(), i32> {
 
         if pid == -1 {
             let errno = *libc::__errno_location();
-            return Err(check_clone_new_user_errno(errno));
+            return Err(log_probe_failure(ProbeFailure::Errno(errno)));
         }
 
         if pid == 0 {
@@ -128,11 +191,13 @@ pub(crate) fn can_create_process_in_new_user_ns() -> Result<(), i32> {
                 break;
             }
             if r == -1 && *libc::__errno_location() != libc::EINTR {
-                return Err(*libc::__errno_location());
+                return Err(log_probe_failure(ProbeFailure::Errno(
+                    *libc::__errno_location(),
+                )));
             }
         }
 
-        decode_probe_status(status).map_err(check_clone_new_user_errno)
+        decode_probe_status(status).map_err(log_probe_failure)
     }
 }
 
@@ -159,24 +224,28 @@ unsafe fn child_exit_with_errno() -> ! {
     unsafe { libc::_exit(code) }
 }
 
-/// Decode the child's `waitpid` status into a `Result<(), i32>`.
+/// Decode the child's `waitpid` status into a `Result<(), ProbeFailure>`.
 ///
 /// The child uses [`child_exit_with_errno`] to encode its failing syscall's
 /// errno into the exit code. A clean exit (`_exit(0)`) means the probe
-/// succeeded. A signal-terminated child surfaces as `EINTR` — the probe
-/// child shouldn't normally be signaled, so this is a sentinel indicating
-/// the kernel did something unexpected.
-fn decode_probe_status(status: libc::c_int) -> Result<(), i32> {
+/// succeeded; a non-zero exit becomes [`ProbeFailure::Errno`]. A signal-
+/// terminated child surfaces as [`ProbeFailure::ChildKilled`] (not an
+/// errno), and a status `waitpid` doesn't classify becomes
+/// [`ProbeFailure::BadStatus`]. Using dedicated variants here avoids
+/// reusing a real errno (previously `EINTR`) as a sentinel, which
+/// collides with `EINTR`'s established retry semantics.
+fn decode_probe_status(status: libc::c_int) -> Result<(), ProbeFailure> {
     if libc::WIFEXITED(status) {
         let code = libc::WEXITSTATUS(status);
-        if code == 0 { Ok(()) } else { Err(code) }
+        if code == 0 {
+            Ok(())
+        } else {
+            Err(ProbeFailure::Errno(code))
+        }
     } else if libc::WIFSIGNALED(status) {
-        // Child died from a signal — shouldn't happen in normal operation.
-        Err(libc::EINTR)
+        Err(ProbeFailure::ChildKilled)
     } else {
-        // waitpid(.., .., 0) doesn't report stopped/continued; if we got
-        // here the kernel did something we don't recognize.
-        Err(libc::EINVAL)
+        Err(ProbeFailure::BadStatus)
     }
 }
 
@@ -301,7 +370,7 @@ mod tests {
     #[test]
     fn test_can_create_process_in_new_user_ns() {
         // This is a real probe — result depends on the system. On failure
-        // the errno must be one of the documented cases. The test acts as
+        // the variant must be one of the documented cases. The test acts as
         // a canary: a novel errno should panic so a maintainer reviews it
         // and adds the new case explicitly (don't broaden silently).
         //
@@ -313,7 +382,7 @@ mod tests {
             Ok(()) => {
                 // User namespaces are available
             }
-            Err(errno) => {
+            Err(ProbeFailure::Errno(errno)) => {
                 assert!(
                     errno == libc::EPERM
                         || errno == libc::EUSERS
@@ -324,6 +393,9 @@ mod tests {
                     errno,
                     std::io::Error::from_raw_os_error(errno)
                 );
+            }
+            Err(other) => {
+                panic!("Unexpected probe failure: {other:?}");
             }
         }
     }
@@ -346,7 +418,7 @@ mod tests {
         // Child encoded EPERM via _exit(EPERM); parent must surface EPERM.
         assert_eq!(
             decode_probe_status(make_exited_status(libc::EPERM)),
-            Err(libc::EPERM)
+            Err(ProbeFailure::Errno(libc::EPERM))
         );
     }
 
@@ -360,19 +432,20 @@ mod tests {
         // instead of being silently rewritten to EPERM.
         assert_eq!(
             decode_probe_status(make_exited_status(libc::EACCES)),
-            Err(libc::EACCES)
+            Err(ProbeFailure::Errno(libc::EACCES))
         );
     }
 
     #[test]
-    fn test_decode_probe_status_signaled_returns_sentinel() {
+    fn test_decode_probe_status_signaled_returns_child_killed() {
         // WIFSIGNALED: low 7 bits hold the signal, e.g., SIGKILL = 9.
         // The probe child shouldn't be signaled in normal operation; we
-        // surface a sentinel (EINTR) so the caller sees a failure rather
-        // than a misleading "child succeeded".
+        // surface ChildKilled (a dedicated variant, not a borrowed errno)
+        // so callers can tell "child died" apart from "syscall returned X"
+        // without colliding with EINTR's retry semantics.
         let status: libc::c_int = libc::SIGKILL;
         assert!(libc::WIFSIGNALED(status));
         assert!(!libc::WIFEXITED(status));
-        assert_eq!(decode_probe_status(status), Err(libc::EINTR));
+        assert_eq!(decode_probe_status(status), Err(ProbeFailure::ChildKilled));
     }
 }

--- a/src/boxlite/src/jailer/credentials.rs
+++ b/src/boxlite/src/jailer/credentials.rs
@@ -295,25 +295,51 @@ fn write_u32_to_buf(buf: &mut [u8], mut n: u32) -> usize {
 ///
 /// Chrome uses `NamespaceUtils::WriteToIdMapFile()` for this.
 ///
+/// Returns `Err(())` without exposing the errno through the return value
+/// — the caller reads it from thread-local `errno` (via
+/// [`child_exit_with_errno`]). To make that path robust, we save the
+/// `write` errno across the `close(fd)` cleanup and restore it before
+/// returning: POSIX promises `close` leaves errno untouched on success,
+/// but the "save errno across cleanup" idiom keeps this correct if a
+/// future change inserts another syscall between the failing `write`
+/// and the caller's errno read, or if `close` itself ever returns an
+/// error on this fd.
+///
 /// # Safety
 ///
-/// Only uses async-signal-safe syscalls: open, write, close.
-/// The `path` must be a null-terminated string (e.g., "/proc/self/uid_map\0").
+/// Only uses async-signal-safe syscalls: open, write, close, and the
+/// `__errno_location` read/store. The `path` must be a null-terminated
+/// string (e.g., "/proc/self/uid_map\0").
 unsafe fn write_proc_file(path: &str, content: &[u8]) -> Result<(), ()> {
     // Path must be null-terminated for libc::open
     // SAFETY: path is a null-terminated string literal, content is a valid slice.
-    // All three syscalls (open, write, close) are async-signal-safe.
+    // All four syscalls (open, write, close, __errno_location) are
+    // async-signal-safe.
     unsafe {
         let fd = libc::open(
             path.as_ptr() as *const libc::c_char,
             libc::O_WRONLY | libc::O_CLOEXEC,
         );
         if fd < 0 {
+            // errno already set by open(); leave it for the caller.
             return Err(());
         }
         let written = libc::write(fd, content.as_ptr() as *const libc::c_void, content.len());
+        // Snapshot the write errno before close() so a future change
+        // that lets close clobber it (or any inserted syscall) can't
+        // hide the real failure from the caller.
+        let saved_errno = if written < 0 {
+            *libc::__errno_location()
+        } else {
+            0
+        };
         libc::close(fd);
-        if written < 0 { Err(()) } else { Ok(()) }
+        if written < 0 {
+            *libc::__errno_location() = saved_errno;
+            Err(())
+        } else {
+            Ok(())
+        }
     }
 }
 


### PR DESCRIPTION
in Ubuntu 26.04, /etc/appaarmor.d/disable/unprivileged_userns closed so that the Child clone returns pid=-1 with EACCES, so EACCES should be added to the exit-code assert range

