### PR TITLE
feat(rest): switch file upload to WebDAV (PUT/MKCOL)

### DIFF
--- a/openapi/box.openapi.yaml
+++ b/openapi/box.openapi.yaml
@@ -716,47 +716,13 @@ paths:
   # -------------------------------------------------------------------------
   # Files
   # -------------------------------------------------------------------------
+  # Bulk download still returns a tar archive for the requested directory:
+  # callers receive an archive and don't need to issue N requests. Upload uses
+  # per-resource WebDAV verbs below so callers no longer have to tar locally.
   /{prefix}/boxes/{box_id}/files:
     parameters:
       - $ref: "#/components/parameters/prefix"
       - $ref: "#/components/parameters/boxId"
-
-    put:
-      operationId: uploadFiles
-      summary: Upload files into the box
-      description: |
-        Uploads a tar archive and extracts it at the specified path
-        inside the container. The box must be running.
-      tags: [Files]
-      parameters:
-        - name: path
-          in: query
-          required: true
-          description: Destination path inside the container
-          schema:
-            type: string
-          example: /app
-        - name: overwrite
-          in: query
-          description: Overwrite existing files at destination
-          schema:
-            type: boolean
-            default: true
-      requestBody:
-        required: true
-        content:
-          application/x-tar:
-            schema:
-              type: string
-              format: binary
-              description: Tar archive to extract at destination
-      responses:
-        "204":
-          description: Upload successful
-        "404":
-          $ref: "#/components/responses/NotFoundError"
-        "409":
-          $ref: "#/components/responses/ConflictError"
 
     get:
       operationId: downloadFiles
@@ -791,6 +757,78 @@ paths:
           $ref: "#/components/responses/NotFoundError"
         "409":
           $ref: "#/components/responses/ConflictError"
+
+  # Upload uses WebDAV verbs scoped to a concrete container path. Callers do not
+  # tar locally; the SDK walks the host tree and issues MKCOL for each directory
+  # and PUT for each file (see [[Rust client copy_into]] in
+  # src/boxlite/src/rest/litebox.rs).
+  /{prefix}/boxes/{box_id}/files/{path}:
+    parameters:
+      - $ref: "#/components/parameters/prefix"
+      - $ref: "#/components/parameters/boxId"
+      - name: path
+        in: path
+        required: true
+        description: |
+          Absolute path inside the container, percent-encoded. The leading
+          slash is implicit; e.g. `app/config.json` targets `/app/config.json`.
+        schema:
+          type: string
+        example: app/config.json
+
+    put:
+      operationId: uploadFile
+      summary: Upload a single file into the box (WebDAV PUT)
+      description: |
+        Writes the request body to the given container path, creating or
+        overwriting the file. Parent directories must already exist — create
+        them with MKCOL first. The box must be running.
+      tags: [Files]
+      parameters:
+        - name: overwrite
+          in: query
+          description: Overwrite an existing file at the destination
+          schema:
+            type: boolean
+            default: true
+      requestBody:
+        required: true
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+              description: Raw file bytes
+      responses:
+        "201":
+          description: File created
+        "204":
+          description: Existing file overwritten
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+        "409":
+          description: |
+            Parent directory does not exist, or overwrite=false and file exists.
+          $ref: "#/components/responses/ConflictError"
+
+    # WebDAV's MKCOL verb is not a standard HTTP method, so OpenAPI 3.1 can't
+    # express it directly. We document it here as a vendor extension on the
+    # same path-item — clients should issue `MKCOL` against this URL.
+    x-webdav-mkcol:
+      operationId: makeCollection
+      method: MKCOL
+      summary: Create a directory inside the box (WebDAV MKCOL)
+      description: |
+        Creates an empty directory at the given container path. Parent
+        directories must already exist. The box must be running.
+      tags: [Files]
+      responses:
+        "201":
+          description: Directory created
+        "405":
+          description: A non-collection resource already exists at this path
+        "409":
+          description: Parent directory does not exist
 
   # -------------------------------------------------------------------------
   # Metrics

--- a/openapi/reference-server/server.py
+++ b/openapi/reference-server/server.py
@@ -917,34 +917,66 @@ async def resize_execution_tty(
 # ============================================================================
 
 
-@app.put("/v1/{prefix}/boxes/{box_id}/files", status_code=204)
-async def upload_files(
+def _split_parent_basename(container_path: str) -> tuple[str, str] | None:
+    """Split `/a/b/c` into (`/a/b`, `c`). Returns None when no basename."""
+    trimmed = container_path.strip("/")
+    if not trimmed:
+        return None
+    head, _, tail = trimmed.rpartition("/")
+    if not tail:
+        return None
+    parent = "/" + head if head else "/"
+    return parent, tail
+
+
+@app.api_route(
+    "/v1/{prefix}/boxes/{box_id}/files/{path:path}",
+    methods=["PUT", "MKCOL"],
+)
+async def webdav_upload(
     prefix: str,
     box_id: str,
-    path: str = Query(..., description="Destination path inside the container"),
+    path: str,
+    request: Request,
     overwrite: bool = Query(True),
-    request: Request = None,
     _auth: dict = Depends(require_auth),
 ):
+    """WebDAV PUT (single file) / MKCOL (single directory).
+
+    Bulk upload is no longer a tar PUT to /files; callers issue per-resource
+    PUT and MKCOL requests under /files/{path}.
+    """
     box_handle = await get_box_or_404(box_id)
-    body = await request.body()
+    container_path = "/" + path.strip("/")
+    split = _split_parent_basename(container_path)
+    if split is None:
+        return error_response(400, "container path requires a name", "InvalidArgumentError")
+    parent, basename = split
 
-    with tempfile.TemporaryDirectory() as tmpdir:
-        tar_path = os.path.join(tmpdir, "upload.tar")
-        with open(tar_path, "wb") as f:
-            f.write(body)
+    method = request.method.upper()
+    if method == "PUT":
+        body = await request.body()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            host_file = os.path.join(tmpdir, basename)
+            with open(host_file, "wb") as f:
+                f.write(body)
+            await box_handle.copy_in(
+                host_file, parent,
+                boxlite.CopyOptions(overwrite=overwrite, include_parent=False),
+            )
+        return Response(status_code=204)
 
-        extract_dir = os.path.join(tmpdir, "extracted")
-        os.makedirs(extract_dir)
-        with tarfile.open(tar_path, "r:*") as tar:
-            tar.extractall(extract_dir)
+    if method == "MKCOL":
+        with tempfile.TemporaryDirectory() as tmpdir:
+            host_dir = os.path.join(tmpdir, basename)
+            os.makedirs(host_dir)
+            await box_handle.copy_in(
+                host_dir, parent,
+                boxlite.CopyOptions(include_parent=True),
+            )
+        return Response(status_code=201)
 
-        await box_handle.copy_in(
-            extract_dir, path,
-            boxlite.CopyOptions(overwrite=overwrite, include_parent=False),
-        )
-
-    return Response(status_code=204)
+    return Response(status_code=405)
 
 
 @app.get("/v1/{prefix}/boxes/{box_id}/files")

--- a/src/boxlite/src/rest/litebox.rs
+++ b/src/boxlite/src/rest/litebox.rs
@@ -47,6 +47,94 @@ impl RestBox {
     fn box_id_str(&self) -> String {
         self.cached_info.read().id.to_string()
     }
+
+    /// Issue `PUT /boxes/{box_id}/files/{remote}` with the file's bytes as the
+    /// body. `remote` is an absolute container path with a leading `/`.
+    async fn put_file(
+        &self,
+        box_id: &str,
+        host_path: &Path,
+        remote: &str,
+        overwrite: bool,
+    ) -> BoxliteResult<()> {
+        let bytes = tokio::fs::read(host_path).await.map_err(|e| {
+            BoxliteError::Internal(format!("failed to read {}: {}", host_path.display(), e))
+        })?;
+        let url_path = build_webdav_url(box_id, remote);
+        let mut builder = self
+            .client
+            .authorized_request(Method::PUT, &url_path)
+            .await?
+            .header("Content-Type", "application/octet-stream")
+            .body(bytes);
+        if !overwrite {
+            builder = builder.query(&[("overwrite", "false")]);
+        }
+        let resp = builder
+            .send()
+            .await
+            .map_err(|e| BoxliteError::Internal(format!("PUT {} failed: {}", remote, e)))?;
+        let status = resp.status();
+        if status.is_success() {
+            return Ok(());
+        }
+        let text = resp.text().await.unwrap_or_default();
+        Err(BoxliteError::Internal(format!(
+            "PUT {} failed (HTTP {}): {}",
+            remote, status, text
+        )))
+    }
+
+    /// Issue `MKCOL /boxes/{box_id}/files/{remote}`. Treats "already exists"
+    /// (HTTP 405) as success since `copy_into` may target a path whose root
+    /// directory has been created by a previous call.
+    async fn mkcol_idempotent(&self, box_id: &str, remote: &str) -> BoxliteResult<()> {
+        let url_path = build_webdav_url(box_id, remote);
+        let method = Method::from_bytes(b"MKCOL")
+            .expect("MKCOL is a valid HTTP method token");
+        let resp = self
+            .client
+            .authorized_request(method, &url_path)
+            .await?
+            .send()
+            .await
+            .map_err(|e| BoxliteError::Internal(format!("MKCOL {} failed: {}", remote, e)))?;
+        let status = resp.status();
+        if status.is_success() || status.as_u16() == 405 {
+            return Ok(());
+        }
+        let text = resp.text().await.unwrap_or_default();
+        Err(BoxliteError::Internal(format!(
+            "MKCOL {} failed (HTTP {}): {}",
+            remote, status, text
+        )))
+    }
+}
+
+/// Join a base container path with a relative segment, normalizing slashes.
+fn join_container_path(base: &str, rel: &str) -> String {
+    let base = base.trim_end_matches('/');
+    let rel = rel.trim_start_matches('/').replace('\\', "/");
+    if rel.is_empty() {
+        base.to_string()
+    } else {
+        format!("{}/{}", base, rel)
+    }
+}
+
+/// Build the WebDAV URL path for a given container resource.
+///
+/// The resource path is split on `/` and each segment is percent-encoded
+/// separately so that the slashes between segments stay literal.
+fn build_webdav_url(box_id: &str, container_path: &str) -> String {
+    let encoded: String = container_path
+        .trim_start_matches('/')
+        .split('/')
+        .filter(|s| !s.is_empty())
+        .map(|s| urlencoding::encode(s).into_owned())
+        .collect::<Vec<_>>()
+        .join("/");
+    format!("/boxes/{}/files/{}", box_id, encoded)
 }
 
 #[async_trait]
@@ -209,35 +297,52 @@ impl BoxBackend for RestBox {
         &self,
         host_src: &Path,
         container_dst: &str,
-        _opts: CopyOptions,
+        opts: CopyOptions,
     ) -> BoxliteResult<()> {
         let box_id = self.box_id_str();
+        // Preserve the wire semantics of the previous tar-based PUT, where
+        // the reference server extracted the archive at `container_dst` with
+        // include_parent=False regardless of `opts`:
+        //   - file source: result is `container_dst/<host_basename>`
+        //   - directory source: result is `container_dst/<contents...>`
+        let dst_root = container_dst.trim_end_matches('/').to_string();
 
-        // Create tar archive from host path
-        let tar_bytes = create_tar_from_path(host_src)?;
+        if host_src.is_file() {
+            let basename = host_src
+                .file_name()
+                .ok_or_else(|| BoxliteError::Config("source path has no file name".into()))?
+                .to_string_lossy()
+                .into_owned();
+            let dest = join_container_path(&dst_root, &basename);
+            return self.put_file(&box_id, host_src, &dest, opts.overwrite).await;
+        }
 
-        // Upload tar to server
-        let encoded_dst = urlencoding::encode(container_dst);
-        let path = format!("/boxes/{}/files?path={}", box_id, encoded_dst);
-        let builder = self
-            .client
-            .authorized_request(Method::PUT, &path)
-            .await?
-            .header("Content-Type", "application/x-tar")
-            .body(tar_bytes);
+        // Directory: ensure the destination root exists, then walk and emit
+        // MKCOL per dir, PUT per file.
+        self.mkcol_idempotent(&box_id, &dst_root).await?;
 
-        let resp = builder
-            .send()
-            .await
-            .map_err(|e| BoxliteError::Internal(format!("copy_into upload failed: {}", e)))?;
+        let walker = walkdir::WalkDir::new(host_src)
+            .follow_links(opts.follow_symlinks)
+            .sort_by_file_name();
 
-        if !resp.status().is_success() {
-            let status = resp.status();
-            let text = resp.text().await.unwrap_or_default();
-            return Err(BoxliteError::Internal(format!(
-                "copy_into failed (HTTP {}): {}",
-                status, text
-            )));
+        for entry in walker {
+            let entry = entry
+                .map_err(|e| BoxliteError::Internal(format!("walkdir failed: {}", e)))?;
+            let rel = entry
+                .path()
+                .strip_prefix(host_src)
+                .map_err(|e| BoxliteError::Internal(format!("strip_prefix failed: {}", e)))?;
+            if rel.as_os_str().is_empty() {
+                continue; // skip the root, already created via dst_root
+            }
+            let rel_str = rel.to_string_lossy();
+            let remote = join_container_path(&dst_root, &rel_str);
+            if entry.file_type().is_dir() {
+                self.mkcol_idempotent(&box_id, &remote).await?;
+            } else if entry.file_type().is_file() {
+                self.put_file(&box_id, entry.path(), &remote, opts.overwrite)
+                    .await?;
+            }
         }
         Ok(())
     }
@@ -855,40 +960,6 @@ async fn emit_or_fallback(
 // ============================================================================
 // Tar Helpers
 // ============================================================================
-
-/// Create a tar archive from a host file or directory.
-fn create_tar_from_path(host_src: &Path) -> BoxliteResult<Vec<u8>> {
-    let mut archive = tar::Builder::new(Vec::new());
-
-    if host_src.is_dir() {
-        archive.append_dir_all(".", host_src).map_err(|e| {
-            BoxliteError::Internal(format!(
-                "failed to create tar from {}: {}",
-                host_src.display(),
-                e
-            ))
-        })?;
-    } else {
-        let file_name = host_src
-            .file_name()
-            .map(|n| n.to_string_lossy().to_string())
-            .unwrap_or_else(|| "file".to_string());
-        let mut file = std::fs::File::open(host_src).map_err(|e| {
-            BoxliteError::Internal(format!("failed to open {}: {}", host_src.display(), e))
-        })?;
-        archive.append_file(&file_name, &mut file).map_err(|e| {
-            BoxliteError::Internal(format!(
-                "failed to add {} to tar: {}",
-                host_src.display(),
-                e
-            ))
-        })?;
-    }
-
-    archive
-        .into_inner()
-        .map_err(|e| BoxliteError::Internal(format!("failed to finalize tar archive: {}", e)))
-}
 
 /// Extract a tar archive to a host directory.
 fn extract_tar_to_path(tar_bytes: &[u8], host_dst: &Path) -> BoxliteResult<()> {

--- a/src/cli/src/commands/serve/handlers/files.rs
+++ b/src/cli/src/commands/serve/handlers/files.rs
@@ -1,29 +1,79 @@
-//! File upload/download handlers (tar-based).
+//! File upload/download handlers.
+//!
+//! Upload uses WebDAV verbs scoped under `/files/{*path}`:
+//!   - `PUT`   — write request body as a single file
+//!   - `MKCOL` — create an empty directory
+//! Bulk download stays at `GET /files?path=...` returning a tar archive so
+//! callers can pull a whole tree in one round-trip.
 
 use std::sync::Arc;
 
 use axum::body::Bytes;
 use axum::extract::{Path, Query, State};
-use axum::http::StatusCode;
+use axum::http::{Method, StatusCode};
 use axum::response::{IntoResponse, Response};
 
 use boxlite::CopyOptions;
 
-use super::super::types::FileQuery;
+use super::super::types::{FileQuery, WebdavQuery};
 use super::super::{AppState, classify_boxlite_error, error_response, get_or_fetch_box};
 
-pub(in crate::commands::serve) async fn upload_files(
+/// Dispatch WebDAV verbs (PUT, MKCOL) on `/files/{*path}`.
+///
+/// Axum's `MethodFilter` only covers standard methods, so this single handler
+/// matches `any()` and branches on the request method.
+pub(in crate::commands::serve) async fn webdav_dispatch(
     State(state): State<Arc<AppState>>,
-    Path(box_id): Path<String>,
-    Query(query): Query<FileQuery>,
+    Path((box_id, path)): Path<(String, String)>,
+    Query(query): Query<WebdavQuery>,
+    method: Method,
     body: Bytes,
+) -> Response {
+    let container_path = normalize_container_path(&path);
+    if container_path.is_empty() {
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            "container path cannot be empty".into(),
+            "InvalidArgumentError",
+        );
+    }
+
+    match method.as_str() {
+        "PUT" => upload_file(state, box_id, container_path, body, query.overwrite).await,
+        "MKCOL" => make_collection(state, box_id, container_path).await,
+        _ => error_response(
+            StatusCode::METHOD_NOT_ALLOWED,
+            format!("method {} not supported on /files/{{path}}", method),
+            "MethodNotAllowed",
+        ),
+    }
+}
+
+async fn upload_file(
+    state: Arc<AppState>,
+    box_id: String,
+    container_path: String,
+    body: Bytes,
+    overwrite: bool,
 ) -> Response {
     let litebox = match get_or_fetch_box(&state, &box_id).await {
         Ok(b) => b,
         Err(resp) => return resp,
     };
 
-    // Extract tar to temp dir, then copy into container
+    // Split into parent dir + basename; tar-pack extracts a single-file
+    // archive at the parent and re-creates the file with the basename.
+    let (parent, basename) = match split_parent_basename(&container_path) {
+        Some(pair) => pair,
+        None => {
+            return error_response(
+                StatusCode::BAD_REQUEST,
+                "PUT requires a non-empty file name".into(),
+                "InvalidArgumentError",
+            );
+        }
+    };
+
     let temp_dir = match tempfile::tempdir() {
         Ok(d) => d,
         Err(e) => {
@@ -34,34 +84,83 @@ pub(in crate::commands::serve) async fn upload_files(
             );
         }
     };
-
-    let extract_dir = temp_dir.path().join("extracted");
-    if let Err(e) = std::fs::create_dir_all(&extract_dir) {
+    let host_file = temp_dir.path().join(&basename);
+    if let Err(e) = tokio::fs::write(&host_file, &body).await {
         return error_response(
             StatusCode::INTERNAL_SERVER_ERROR,
-            format!("failed to create extract dir: {e}"),
+            format!("failed to stage upload: {e}"),
             "InternalError",
         );
     }
 
-    let mut archive = tar::Archive::new(&body[..]);
-    if let Err(e) = archive.unpack(&extract_dir) {
-        return error_response(
-            StatusCode::BAD_REQUEST,
-            format!("failed to extract tar: {e}"),
-            "InvalidArgumentError",
-        );
-    }
-
-    if let Err(e) = litebox
-        .copy_into(&extract_dir, &query.path, CopyOptions::default())
-        .await
-    {
+    let opts = CopyOptions {
+        overwrite,
+        // The host file's basename IS the destination basename; the parent
+        // directory is the extract root, so we must NOT include the parent.
+        include_parent: false,
+        ..CopyOptions::default()
+    };
+    if let Err(e) = litebox.copy_into(&host_file, &parent, opts).await {
         let (status, etype) = classify_boxlite_error(&e);
         return error_response(status, e.to_string(), etype);
     }
 
     StatusCode::NO_CONTENT.into_response()
+}
+
+async fn make_collection(
+    state: Arc<AppState>,
+    box_id: String,
+    container_path: String,
+) -> Response {
+    let litebox = match get_or_fetch_box(&state, &box_id).await {
+        Ok(b) => b,
+        Err(resp) => return resp,
+    };
+
+    let (parent, basename) = match split_parent_basename(&container_path) {
+        Some(pair) => pair,
+        None => {
+            return error_response(
+                StatusCode::BAD_REQUEST,
+                "MKCOL requires a non-empty directory name".into(),
+                "InvalidArgumentError",
+            );
+        }
+    };
+
+    // Build an empty host directory with the target basename and copy it in
+    // with include_parent=true so the directory itself (not just its empty
+    // contents) materializes under `parent`.
+    let temp_dir = match tempfile::tempdir() {
+        Ok(d) => d,
+        Err(e) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("failed to create temp dir: {e}"),
+                "InternalError",
+            );
+        }
+    };
+    let host_dir = temp_dir.path().join(&basename);
+    if let Err(e) = std::fs::create_dir(&host_dir) {
+        return error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("failed to stage directory: {e}"),
+            "InternalError",
+        );
+    }
+
+    let opts = CopyOptions {
+        include_parent: true,
+        ..CopyOptions::default()
+    };
+    if let Err(e) = litebox.copy_into(&host_dir, &parent, opts).await {
+        let (status, etype) = classify_boxlite_error(&e);
+        return error_response(status, e.to_string(), etype);
+    }
+
+    StatusCode::CREATED.into_response()
 }
 
 pub(in crate::commands::serve) async fn download_files(
@@ -93,7 +192,6 @@ pub(in crate::commands::serve) async fn download_files(
         return error_response(status, e.to_string(), etype);
     }
 
-    // Create tar from extracted files
     let mut builder = tar::Builder::new(Vec::new());
     if let Err(e) = builder.append_dir_all(".", temp_dir.path()) {
         return error_response(
@@ -119,4 +217,25 @@ pub(in crate::commands::serve) async fn download_files(
         .header("Content-Type", "application/x-tar")
         .body(axum::body::Body::from(tar_bytes))
         .unwrap()
+}
+
+/// Normalize a URL path segment captured by the router into an absolute
+/// container path with a single leading `/` and no trailing slash.
+fn normalize_container_path(raw: &str) -> String {
+    let trimmed = raw.trim_matches('/');
+    if trimmed.is_empty() {
+        String::new()
+    } else {
+        format!("/{}", trimmed)
+    }
+}
+
+/// Split `/a/b/c` into ("/a/b", "c"). Returns None if there is no basename.
+fn split_parent_basename(path: &str) -> Option<(String, String)> {
+    let (head, tail) = path.rsplit_once('/')?;
+    if tail.is_empty() {
+        return None;
+    }
+    let parent = if head.is_empty() { "/" } else { head };
+    Some((parent.to_string(), tail.to_string()))
 }

--- a/src/cli/src/commands/serve/mod.rs
+++ b/src/cli/src/commands/serve/mod.rs
@@ -12,7 +12,7 @@ use std::time::Instant;
 
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use axum::routing::{get, post, put};
+use axum::routing::{get, post};
 use axum::{Json, Router};
 use clap::Args;
 use futures::StreamExt;
@@ -797,9 +797,15 @@ fn build_router(state: Arc<AppState>) -> Router {
             post(executions::resize_tty),
         )
         // Files
+        // Bulk download stays at `/files?path=...` and returns a tar; upload
+        // moved to per-resource WebDAV verbs scoped under `/files/{*path}`.
         .route(
             "/v1/default/boxes/{box_id}/files",
-            put(files::upload_files).get(files::download_files),
+            get(files::download_files),
+        )
+        .route(
+            "/v1/default/boxes/{box_id}/files/{*path}",
+            axum::routing::any(files::webdav_dispatch),
         )
         // Snapshots
         .route(

--- a/src/cli/src/commands/serve/types.rs
+++ b/src/cli/src/commands/serve/types.rs
@@ -235,3 +235,14 @@ pub(super) struct RemoveQuery {
 pub(super) struct FileQuery {
     pub path: String,
 }
+
+#[derive(Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub(super) struct WebdavQuery {
+    #[serde(default = "default_true")]
+    pub overwrite: bool,
+}
+
+fn default_true() -> bool {
+    true
+}


### PR DESCRIPTION
Customers calling the REST API directly previously had to tar a folder themselves before issuing the upload — the SDK did the tarring transparently, so the two transports had divergent ergonomics. Replace the single `PUT /boxes/{id}/files` (tar body) with per-resource WebDAV verbs scoped under `/boxes/{id}/files/{path}`: `PUT` writes one file, `MKCOL` creates one directory. Bulk download stays at the existing `GET /boxes/{id}/files?path=...` tar endpoint.

The Rust REST client (`RestBox::copy_into`) now walks the host tree and issues MKCOL + PUT per entry, preserving the previous wire semantics (file source -> `<dst>/<host_basename>`, directory source -> contents land at `<dst>`). The SDK surface (`SimpleBox.copy_in`) is unchanged.