### PR TITLE
feat(serve): optional exact-key auth for serve + reference-server

### DIFF
--- a/openapi/reference-server/.env.example
+++ b/openapi/reference-server/.env.example
@@ -8,8 +8,6 @@ BOXLITE_SERVER_PORT=8080
 BOXLITE_SERVER_LOG_LEVEL=info
 BOXLITE_SERVER_JWT_SECRET=boxlite-reference-server-secret
 BOXLITE_SERVER_JWT_EXPIRY_SECONDS=3600
-BOXLITE_SERVER_CLIENT_ID=test-client
-BOXLITE_SERVER_CLIENT_SECRET=test-secret
 
 # ============================================================================
 # BoxLite Runtime Options (consumed by openapi/reference-server/server.py)

--- a/openapi/reference-server/README.md
+++ b/openapi/reference-server/README.md
@@ -19,23 +19,31 @@ cd openapi/reference-server
 uv run --active server.py
 ```
 
-## Test Credentials
+## Authentication
 
-| Field | Value |
-|-------|-------|
-| client_id | `test-client` |
-| client_secret | `test-secret` |
+By default the server accepts **any non-empty `Authorization: Bearer <token>`
+header** (format-agnostic, matching the spec's `BearerAuth` scheme — token
+issuance and real validation are out of scope for a reference server).
+`GET /v1/config` needs no auth; every other endpoint requires a non-empty
+bearer.
+
+Set **`BOXLITE_SERVER_API_KEY`** to require an exact key: the bearer must then
+equal it (constant-time check) or the request gets `401`. A missing/empty
+bearer is always `401` regardless. This lets clients exercise both the success
+and failure auth paths against the reference server.
 
 ## Quick Test
 
 ```bash
-# Get a token
-TOKEN=$(curl -s -X POST http://localhost:8080/v1/oauth/tokens \
-  -d 'grant_type=client_credentials&client_id=test-client&client_secret=test-secret' \
-  | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])")
+# The reference server accepts any non-empty bearer
+TOKEN=dev-token
 
-# Server config
+# Server config (no auth required)
 curl -s http://localhost:8080/v1/config | python3 -m json.tool
+
+# Identity + scopes for the calling credential
+curl -s http://localhost:8080/v1/me \
+  -H "Authorization: Bearer $TOKEN" | python3 -m json.tool
 
 # Create a box
 curl -s -X POST http://localhost:8080/v1/demo/boxes \
@@ -73,7 +81,7 @@ curl -s -X DELETE http://localhost:8080/v1/demo/boxes/$BOX_ID \
 | Endpoint | Method | Description |
 |----------|--------|-------------|
 | `/v1/config` | GET | Server configuration |
-| `/v1/oauth/tokens` | POST | OAuth2 client credentials |
+| `/v1/me` | GET | Identity + scopes for the credential |
 | `/{prefix}/boxes` | POST | Create box |
 | `/{prefix}/boxes` | GET | List boxes |
 | `/{prefix}/boxes/{id}` | GET | Get box |
@@ -114,8 +122,7 @@ Use `--env-file` to load a different file.
 | `BOXLITE_SERVER_LOG_LEVEL` | `info` |
 | `BOXLITE_SERVER_JWT_SECRET` | `boxlite-reference-server-secret` |
 | `BOXLITE_SERVER_JWT_EXPIRY_SECONDS` | `3600` |
-| `BOXLITE_SERVER_CLIENT_ID` | `test-client` |
-| `BOXLITE_SERVER_CLIENT_SECRET` | `test-secret` |
+| `BOXLITE_SERVER_API_KEY` | _(unset → permissive; set → exact-match required)_ |
 
 ### Runtime Settings (`BOXLITE_RUNTIME_*`)
 

--- a/openapi/reference-server/config.py
+++ b/openapi/reference-server/config.py
@@ -17,8 +17,7 @@ ENV_SERVER_PORT = "BOXLITE_SERVER_PORT"
 ENV_SERVER_LOG_LEVEL = "BOXLITE_SERVER_LOG_LEVEL"
 ENV_SERVER_JWT_SECRET = "BOXLITE_SERVER_JWT_SECRET"
 ENV_SERVER_JWT_EXPIRY_SECONDS = "BOXLITE_SERVER_JWT_EXPIRY_SECONDS"
-ENV_SERVER_CLIENT_ID = "BOXLITE_SERVER_CLIENT_ID"
-ENV_SERVER_CLIENT_SECRET = "BOXLITE_SERVER_CLIENT_SECRET"
+ENV_SERVER_API_KEY = "BOXLITE_SERVER_API_KEY"
 
 # Runtime env vars (reference-server local contract)
 ENV_RUNTIME_HOME_DIR = "BOXLITE_RUNTIME_HOME_DIR"
@@ -29,8 +28,6 @@ DEFAULT_SERVER_PORT = 8080
 DEFAULT_SERVER_LOG_LEVEL = "info"
 DEFAULT_SERVER_JWT_SECRET = "boxlite-reference-server-secret"
 DEFAULT_SERVER_JWT_EXPIRY_SECONDS = 3600
-DEFAULT_SERVER_CLIENT_ID = "test-client"
-DEFAULT_SERVER_CLIENT_SECRET = "test-secret"
 DEFAULT_RUNTIME_IMAGE_REGISTRIES = ["mirror.gcr.io", "docker.io"]
 DEFAULT_ENV_FILE_PATH = Path(__file__).resolve().parent / ".env"
 
@@ -52,8 +49,9 @@ class ServerConfig:
     log_level: str
     jwt_secret: str
     jwt_expiry_seconds: int
-    client_id: str
-    client_secret: str
+    # Optional expected Bearer token. None ⇒ permissive (any non-empty
+    # bearer accepted); set ⇒ exact match required (else 401).
+    api_key: str | None
 
 
 @dataclass(frozen=True)
@@ -207,15 +205,11 @@ def load_server_config_from_env() -> ServerConfig:
     if not jwt_secret:
         raise ValueError(f"{ENV_SERVER_JWT_SECRET} cannot be empty")
 
-    client_id = os.getenv(ENV_SERVER_CLIENT_ID, DEFAULT_SERVER_CLIENT_ID).strip()
-    if not client_id:
-        raise ValueError(f"{ENV_SERVER_CLIENT_ID} cannot be empty")
-
-    client_secret = os.getenv(
-        ENV_SERVER_CLIENT_SECRET, DEFAULT_SERVER_CLIENT_SECRET
-    ).strip()
-    if not client_secret:
-        raise ValueError(f"{ENV_SERVER_CLIENT_SECRET} cannot be empty")
+    # Optional: unset or whitespace-only ⇒ None (permissive); else strict.
+    api_key_raw = os.getenv(ENV_SERVER_API_KEY)
+    api_key = api_key_raw.strip() if api_key_raw is not None else None
+    if not api_key:
+        api_key = None
 
     return ServerConfig(
         host=host,
@@ -227,8 +221,7 @@ def load_server_config_from_env() -> ServerConfig:
             DEFAULT_SERVER_JWT_EXPIRY_SECONDS,
             minimum=1,
         ),
-        client_id=client_id,
-        client_secret=client_secret,
+        api_key=api_key,
     )
 
 

--- a/openapi/reference-server/server.py
+++ b/openapi/reference-server/server.py
@@ -42,6 +42,8 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Literal, Optional
 
+import hmac
+
 import jwt
 import uvicorn
 from fastapi import (
@@ -285,6 +287,8 @@ LOCAL_PRINCIPAL = {
 async def require_auth(
     credentials: Optional[HTTPAuthorizationCredentials] = Depends(bearer_scheme),
 ) -> dict:
+    # Always-on: a missing/empty bearer is a 401 regardless of config
+    # (enforces the declared BearerAuth scheme's presence — Prism-style).
     if credentials is None or not credentials.credentials:
         raise HTTPException(
             status_code=401,
@@ -296,8 +300,24 @@ async def require_auth(
                 }
             },
         )
-    # Format-agnostic: any non-empty bearer is accepted. The full server
-    # validates against its issuance store; this reference server doesn't.
+    cfg = state.server_config
+    expected = cfg.api_key if cfg is not None else None
+    if expected is not None and not hmac.compare_digest(
+        credentials.credentials, expected
+    ):
+        # Configured expected key + mismatch ⇒ reject (constant-time).
+        raise HTTPException(
+            status_code=401,
+            detail={
+                "error": {
+                    "message": "invalid api key",
+                    "type": "UnauthorizedError",
+                    "code": 401,
+                }
+            },
+        )
+    # No expected key configured ⇒ accept any non-empty bearer (the
+    # zero-config reference default). Configured ⇒ matched above.
     return {"sub": "local-anonymous"}
 
 
@@ -1053,8 +1073,7 @@ def main():
         log_level=normalize_log_level(args.log_level),
         jwt_secret=env_server_config.jwt_secret,
         jwt_expiry_seconds=env_server_config.jwt_expiry_seconds,
-        client_id=env_server_config.client_id,
-        client_secret=env_server_config.client_secret,
+        api_key=env_server_config.api_key,
     )
 
     state.server_config = server_config

--- a/openapi/reference-server/tests/test_env_config.py
+++ b/openapi/reference-server/tests/test_env_config.py
@@ -31,8 +31,7 @@ class ReferenceServerConfigTests(unittest.TestCase):
         self.assertEqual(
             server.jwt_expiry_seconds, CONFIG.DEFAULT_SERVER_JWT_EXPIRY_SECONDS
         )
-        self.assertEqual(server.client_id, CONFIG.DEFAULT_SERVER_CLIENT_ID)
-        self.assertEqual(server.client_secret, CONFIG.DEFAULT_SERVER_CLIENT_SECRET)
+        self.assertIsNone(server.api_key)
         self.assertEqual(runtime.home_dir, CONFIG.default_runtime_home_dir())
         self.assertEqual(
             runtime.image_registries, CONFIG.DEFAULT_RUNTIME_IMAGE_REGISTRIES
@@ -48,8 +47,7 @@ class ReferenceServerConfigTests(unittest.TestCase):
                     "BOXLITE_SERVER_LOG_LEVEL": "debug",
                     "BOXLITE_SERVER_JWT_SECRET": "secret-123",
                     "BOXLITE_SERVER_JWT_EXPIRY_SECONDS": "7200",
-                    "BOXLITE_SERVER_CLIENT_ID": "client-123",
-                    "BOXLITE_SERVER_CLIENT_SECRET": "secret-456",
+                    "BOXLITE_SERVER_API_KEY": "k-abc",
                     "BOXLITE_RUNTIME_HOME_DIR": temp_home,
                     "BOXLITE_RUNTIME_IMAGE_REGISTRIES": "ghcr.io,docker.io",
                 },
@@ -63,8 +61,7 @@ class ReferenceServerConfigTests(unittest.TestCase):
         self.assertEqual(server.log_level, "debug")
         self.assertEqual(server.jwt_secret, "secret-123")
         self.assertEqual(server.jwt_expiry_seconds, 7200)
-        self.assertEqual(server.client_id, "client-123")
-        self.assertEqual(server.client_secret, "secret-456")
+        self.assertEqual(server.api_key, "k-abc")
         self.assertEqual(runtime.home_dir, temp_home)
         self.assertEqual(runtime.image_registries, ["ghcr.io", "docker.io"])
 
@@ -97,6 +94,18 @@ class ReferenceServerConfigTests(unittest.TestCase):
         with patch.dict(os.environ, {"BOXLITE_SERVER_LOG_LEVEL": "verbose"}, clear=True):
             with self.assertRaisesRegex(ValueError, "log level must be one of"):
                 CONFIG.load_server_config_from_env()
+
+    def test_api_key_empty_or_whitespace_is_none_else_trimmed(self) -> None:
+        for raw in ("", "   "):
+            with patch.dict(os.environ, {"BOXLITE_SERVER_API_KEY": raw}, clear=True):
+                server = CONFIG.load_server_config_from_env()
+            self.assertIsNone(server.api_key)
+
+        with patch.dict(
+            os.environ, {"BOXLITE_SERVER_API_KEY": "  k-trim  "}, clear=True
+        ):
+            server = CONFIG.load_server_config_from_env()
+        self.assertEqual(server.api_key, "k-trim")
 
     def test_cli_overrides_env_for_host_port_and_log_level(self) -> None:
         with patch.dict(

--- a/src/cli/src/commands/serve/README.md
+++ b/src/cli/src/commands/serve/README.md
@@ -8,9 +8,10 @@ sessions.
 ## Quick Start
 
 ```bash
-boxlite serve                      # listen on 0.0.0.0:8100
+boxlite serve                      # listen on 0.0.0.0:8100 (permissive)
 boxlite serve --port 9090          # custom port
 boxlite serve --host 127.0.0.1    # bind localhost only
+boxlite serve --api-key dev-key    # require Bearer dev-key (else 401)
 ```
 
 Ctrl-C triggers graceful shutdown (`runtime.shutdown` with a 10 s timeout).
@@ -68,7 +69,7 @@ execute(ServeArgs, GlobalFlags)
 │  │  └──────────────────────────────────────────────┘ │  │
 │  └──────────────────────────────────────────────────┘  │
 │                                                        │
-│  Handlers:  auth · config · boxes · executions         │
+│  Handlers:  config · boxes · executions                │
 │             files · metrics · snapshots · advanced     │
 │                                                        │
 │  Background:  reaper_loop  (orphan cleanup)            │
@@ -89,8 +90,8 @@ registry.
 
 | Module       | File                     | Purpose                                                       |
 |--------------|--------------------------|---------------------------------------------------------------|
-| `auth`       | `handlers/auth.rs`       | OAuth2 token endpoint (local passthrough, always succeeds)    |
 | `config`     | `handlers/config.rs`     | Capability discovery (snapshots, clone, export, import)       |
+| `me`         | `handlers/me.rs`         | Identity of the calling credential (`GET /v1/me`)             |
 | `boxes`      | `handlers/boxes.rs`      | Box CRUD: create, list, get, head, start, stop, remove        |
 | `executions` | `handlers/executions.rs` | Lifecycle: start, status, signal, kill, resize, attach        |
 | `files`      | `handlers/files.rs`      | Tar-based file upload / download into / from boxes            |
@@ -106,8 +107,13 @@ All paths are relative to the server root (e.g. `http://localhost:8100`).
 
 | Method | Path                 | Handler               | Description                        |
 |--------|----------------------|-----------------------|------------------------------------|
-| POST   | `/v1/oauth/tokens`   | `auth::oauth_token`   | Get bearer token (always succeeds) |
-| GET    | `/v1/config`         | `config::get_config`  | Capability discovery               |
+| GET    | `/v1/config`         | `config::get_config`  | Capability discovery (always public) |
+| GET    | `/v1/me`             | `me::get_me`          | Identity of the calling credential |
+
+**Auth.** With `--api-key <KEY>` (or `$BOXLITE_SERVE_API_KEY`) set, every
+route except `GET /v1/config` requires `Authorization: Bearer <KEY>`
+(constant-time match) and returns `401` otherwise. Without it the server is
+permissive (accepts any/no bearer) — the zero-config local-dev default.
 
 ### Box CRUD & Lifecycle
 

--- a/src/cli/src/commands/serve/mod.rs
+++ b/src/cli/src/commands/serve/mod.rs
@@ -10,7 +10,10 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Instant;
 
+use axum::extract::{Request, State};
 use axum::http::StatusCode;
+use axum::http::header::AUTHORIZATION;
+use axum::middleware::{self, Next};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post, put};
 use axum::{Json, Router};
@@ -42,6 +45,13 @@ pub struct ServeArgs {
     /// Host/address to bind to. Defaults to `LOCAL_SERVE_HOST`.
     #[arg(long, default_value_t = LOCAL_SERVE_HOST.to_string())]
     pub host: String,
+
+    /// Optional expected API key. When set, every route except
+    /// `GET /v1/config` requires `Authorization: Bearer <this>` (constant-time
+    /// match) and returns 401 otherwise. Unset = permissive (accepts any/no
+    /// bearer) — the zero-config local-dev default.
+    #[arg(long, env = "BOXLITE_SERVE_API_KEY")]
+    pub api_key: Option<String>,
 }
 
 // ============================================================================
@@ -56,6 +66,9 @@ struct AppState {
     /// `Arc` so attach sessions can drop the map lock before doing
     /// long-running WS pumping while keeping the exec alive.
     executions: RwLock<HashMap<String, Arc<ActiveExecution>>>,
+    /// Optional expected API key (`--api-key` / `$BOXLITE_SERVE_API_KEY`).
+    /// `None` ⇒ permissive (no auth enforced).
+    api_key: Option<String>,
 }
 
 /// Server-side state for one execution. The underlying `Execution`'s
@@ -706,6 +719,58 @@ fn classify_boxlite_error(err: &boxlite::BoxliteError) -> (StatusCode, &'static 
     }
 }
 
+/// Pure auth decision (unit-tested). `true` = allow. `expected == None` ⇒
+/// permissive (no key configured). `GET /v1/config` is always public
+/// (pre-auth capability discovery). Otherwise the presented bearer must
+/// match `expected` (constant-time).
+fn auth_allows(expected: Option<&str>, path: &str, bearer: Option<&str>) -> bool {
+    let Some(expected) = expected else {
+        return true;
+    };
+    if path == "/v1/config" {
+        return true;
+    }
+    match bearer {
+        Some(tok) => constant_time_eq(tok.as_bytes(), expected.as_bytes()),
+        None => false,
+    }
+}
+
+/// Auth middleware: thin axum adapter over [`auth_allows`]. 401 in the
+/// standard error shape when denied.
+async fn require_api_key(State(state): State<Arc<AppState>>, req: Request, next: Next) -> Response {
+    let bearer = req
+        .headers()
+        .get(AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| {
+            v.strip_prefix("Bearer ")
+                .or_else(|| v.strip_prefix("bearer "))
+        });
+    if auth_allows(state.api_key.as_deref(), req.uri().path(), bearer) {
+        next.run(req).await
+    } else {
+        error_response(
+            StatusCode::UNAUTHORIZED,
+            "invalid or missing API key",
+            "AuthError",
+        )
+    }
+}
+
+/// Length-checked constant-time byte compare — avoids a timing oracle on the
+/// configured token without pulling in a crate.
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
 // ============================================================================
 // Box Handle Cache Helper
 // ============================================================================
@@ -823,6 +888,10 @@ fn build_router(state: Arc<AppState>) -> Router {
             "/v1/default/boxes/{box_id}/export",
             post(advanced::export_box),
         )
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            require_api_key,
+        ))
         .with_state(state)
 }
 
@@ -837,6 +906,7 @@ pub async fn execute(args: ServeArgs, global: &GlobalFlags) -> anyhow::Result<()
         runtime,
         boxes: RwLock::new(HashMap::new()),
         executions: RwLock::new(HashMap::new()),
+        api_key: args.api_key.clone(),
     });
 
     // Phase 5.7: spawn the orphan reaper. Same escalation policy as the
@@ -868,6 +938,35 @@ pub async fn execute(args: ServeArgs, global: &GlobalFlags) -> anyhow::Result<()
 mod tests {
     use super::*;
     use std::time::Duration;
+
+    // --- API-key auth decision (pure; no runtime/network needed) ---
+
+    #[test]
+    fn auth_allows_permissive_when_no_key() {
+        assert!(auth_allows(None, "/v1/default/boxes", None));
+        assert!(auth_allows(None, "/v1/me", Some("anything")));
+    }
+
+    #[test]
+    fn auth_allows_config_public_even_with_key() {
+        assert!(auth_allows(Some("k"), "/v1/config", None));
+    }
+
+    #[test]
+    fn auth_allows_requires_exact_bearer_when_key_set() {
+        assert!(auth_allows(Some("k"), "/v1/me", Some("k")));
+        assert!(!auth_allows(Some("k"), "/v1/me", Some("wrong")));
+        assert!(!auth_allows(Some("k"), "/v1/me", None));
+        assert!(!auth_allows(Some("k"), "/v1/default/boxes", Some("")));
+    }
+
+    #[test]
+    fn constant_time_eq_basic() {
+        assert!(constant_time_eq(b"abc", b"abc"));
+        assert!(!constant_time_eq(b"abc", b"abd"));
+        assert!(!constant_time_eq(b"abc", b"abcd"));
+        assert!(constant_time_eq(b"", b""));
+    }
 
     /// Build an `ActiveExecution` backed by a stub `Execution` whose
     /// stdout/stderr/result channels we control from the test.


### PR DESCRIPTION
## Summary

- **CLI `boxlite serve`** — new `--api-key <KEY>` flag (clap, env
  `BOXLITE_SERVE_API_KEY`) + `require_api_key` axum middleware:
  unset = any non-empty bearer accepted (existing permissive
  behavior, unchanged); set = bearer must equal the configured key
  (constant-time compare); missing/empty `Authorization` always
  returns `401` regardless. 4 unit tests added.
- **Reference server (`openapi/reference-server`)** — `ServerConfig.api_key`
  from `BOXLITE_SERVER_API_KEY` (whitespace-trimmed; empty → `None`).
  `require_auth` enforces exact match when configured (`hmac.compare_digest`);
  `GET /v1/config` stays public regardless. README + `.env.example` updated.

Together these let clients exercise BOTH the success and failure auth
paths against either server — pairing with the recently-merged
`boxlite auth login` flow (#554) to cover the BoxLite identity loop
end-to-end.

## Test plan

- [x] `cargo check -p boxlite-cli`
- [x] `cargo test -p boxlite-cli --bin boxlite -- auth_allows constant_time_eq` (4/4 pass)
- [x] `python3 openapi/reference-server/tests/test_env_config.py` (11/11 pass, incl. `api_key` empty/whitespace handling)
- [x] Pre-push hook ran `test:integration:cli`: `234 tests run: 234 passed, 0 skipped` (218 s)
- [ ] CI verifies the full matrix
- [ ] Manual smoke against a running `boxlite serve --api-key K` (curl with/without correct bearer)