### PR TITLE
test(security): Node + Go regression parity for GHSA-g6ww + GHSA-f396

### DIFF
--- a/sdks/go/security_readonly_volume_remount_integration_test.go
+++ b/sdks/go/security_readonly_volume_remount_integration_test.go
@@ -1,0 +1,114 @@
+//go:build boxlite_dev
+
+// Regression test for GHSA-g6ww-w5j2-r7x3 (read-only volume remount bypass).
+//
+// A host directory mounted via WithVolumeReadOnly must stay read-only even
+// against a malicious guest that runs `mount -o remount,rw`. Before v0.9.0
+// the guest could remount the virtiofs share read-write (it had
+// CAP_SYS_ADMIN) and write through to the host.
+//
+// Go-SDK counterpart of:
+//   - sdks/python/tests/test_readonly_volume_remount.py
+//   - sdks/node/tests/security-readonly-volume-remount.integration.test.ts
+//   - src/boxlite/tests/security_enforcement.rs::readonly_volume_blocks_remount
+package boxlite
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const (
+	roGuestMount    = "/mnt/sensitive"
+	roOriginal      = "original content\n"
+	roAttackPayload = "modified content"
+)
+
+func TestSecurityReadonlyVolumeRemountBypass(t *testing.T) {
+	hostDir, err := os.MkdirTemp("/tmp", "virtiofs-ro-poc-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(hostDir) })
+
+	roFile := filepath.Join(hostDir, "read_only.txt")
+	if err := os.WriteFile(roFile, []byte(roOriginal), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	rt := newTestRuntime(t)
+	box := createStartedBoxOrSkip(t, rt, "alpine:latest",
+		WithAutoRemove(false),
+		WithVolumeReadOnly(hostDir, roGuestMount),
+	)
+
+	ctx := context.Background()
+
+	// The share must be exposed read-only to the guest.
+	mounts, err := box.Exec(ctx, "sh", "-c", "cat /proc/mounts | grep sensitive")
+	if err != nil {
+		t.Fatalf("Exec(mounts): %v", err)
+	}
+	if !strings.Contains(mounts.Stdout, " ro,") {
+		t.Fatalf("volume not mounted read-only: %q", mounts.Stdout)
+	}
+
+	// Direct write is rejected (client-side MS_RDONLY active).
+	write1, err := box.Exec(ctx, "sh", "-c",
+		"echo '"+roAttackPayload+"' > "+roGuestMount+"/read_only.txt 2>&1")
+	if err != nil {
+		t.Fatalf("Exec(write1): %v", err)
+	}
+	if write1.ExitCode == 0 {
+		t.Fatalf("initial write to read-only volume should fail; got exit=0 stdout=%q", write1.Stdout)
+	}
+
+	// ATTACK: try to remount the share read-write.
+	if _, err := box.Exec(ctx, "sh", "-c",
+		"mount -o remount,rw "+roGuestMount+" 2>&1"); err != nil {
+		// Exec itself may report the underlying mount failure as an
+		// error or a non-zero exit; either way we proceed to verify
+		// the mount state and the host file.
+		t.Logf("remount Exec returned err (expected/ok): %v", err)
+	}
+
+	// The mount must still be read-only after the remount attempt.
+	after, err := box.Exec(ctx, "sh", "-c", "cat /proc/mounts | grep sensitive")
+	if err != nil {
+		t.Fatalf("Exec(mounts after): %v", err)
+	}
+	if !strings.Contains(after.Stdout, " ro,") || strings.Contains(after.Stdout, " rw,") {
+		t.Fatalf("volume became writable after remount: %q", after.Stdout)
+	}
+
+	// A post-attack write must still fail.
+	write2, err := box.Exec(ctx, "sh", "-c",
+		"echo '"+roAttackPayload+"' > "+roGuestMount+"/read_only.txt 2>&1")
+	if err != nil {
+		t.Fatalf("Exec(write2): %v", err)
+	}
+	if write2.ExitCode == 0 {
+		t.Fatalf("write after remount bypass should still fail; got exit=0")
+	}
+
+	// Guest-visible content unchanged.
+	guestView, err := box.Exec(ctx, "cat", roGuestMount+"/read_only.txt")
+	if err != nil {
+		t.Fatalf("Exec(cat): %v", err)
+	}
+	if guestView.Stdout != roOriginal {
+		t.Fatalf("guest modified the file: %q", guestView.Stdout)
+	}
+
+	// HOST VERIFICATION — the advisory's exploit oracle.
+	hostBytes, err := os.ReadFile(roFile)
+	if err != nil {
+		t.Fatalf("ReadFile(host): %v", err)
+	}
+	if string(hostBytes) != roOriginal {
+		t.Fatalf("GHSA-g6ww-w5j2-r7x3 regression: host file modified from inside the sandbox: got %q", string(hostBytes))
+	}
+}

--- a/sdks/go/security_symlink_escape_integration_test.go
+++ b/sdks/go/security_symlink_escape_integration_test.go
@@ -1,0 +1,216 @@
+//go:build boxlite_dev
+
+// Regression test for GHSA-f396-4rp4-7v2j (OCI layer symlink escape).
+//
+// A crafted OCI layer with a symlink pointing outside the extraction root
+// followed by a file entry that resolves through that symlink must NOT
+// write to the host. The v0.9.0 fix enforces this via SafeRoot containment
+// in the Rust extractor; this test exercises the same defense through the
+// Go SDK by loading a malicious local OCI layout via WithRootfsPath.
+//
+// Go-SDK counterpart of:
+//   - sdks/python/tests/test_symlink_escape.py
+//   - sdks/node/tests/security-symlink-escape.integration.test.ts
+//   - src/boxlite/src/images/archive/extractor.rs::test_cve_symlink_escape_blocked
+package boxlite
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+const symlinkEscapeTarget = "/tmp/boxlite_host_escape_go/pwned.txt"
+
+func writeBlob(t *testing.T, blobsDir string, data []byte) (string, int) {
+	t.Helper()
+	sum := sha256.Sum256(data)
+	digest := hex.EncodeToString(sum[:])
+	if err := os.WriteFile(filepath.Join(blobsDir, digest), data, 0o644); err != nil {
+		t.Fatalf("write blob: %v", err)
+	}
+	return digest, len(data)
+}
+
+func buildMaliciousLayerTar(t *testing.T) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	mtime := time.Now()
+
+	writeHeader := func(hdr *tar.Header, body []byte) {
+		hdr.ModTime = mtime
+		if body != nil {
+			hdr.Size = int64(len(body))
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatalf("tar header: %v", err)
+		}
+		if body != nil {
+			if _, err := tw.Write(body); err != nil {
+				t.Fatalf("tar body: %v", err)
+			}
+		}
+	}
+
+	// (1) Symlink: escape -> /tmp
+	writeHeader(&tar.Header{
+		Name:     "escape",
+		Mode:     0o777,
+		Typeflag: tar.TypeSymlink,
+		Linkname: "/tmp",
+	}, nil)
+
+	// (2) Dir under the symlink — resolves to /tmp/boxlite_host_escape_go/
+	writeHeader(&tar.Header{
+		Name:     "escape/boxlite_host_escape_go",
+		Mode:     0o755,
+		Typeflag: tar.TypeDir,
+	}, nil)
+
+	// (3) Payload file at the escape target.
+	payload := []byte(fmt.Sprintf("===== BOXLITE GO SDK SYMLINK ESCAPE PoC =====\nTarget: %s\n", symlinkEscapeTarget))
+	writeHeader(&tar.Header{
+		Name:     "escape/boxlite_host_escape_go/pwned.txt",
+		Mode:     0o644,
+		Typeflag: tar.TypeReg,
+	}, payload)
+
+	// (4) Decoy legit entry.
+	writeHeader(&tar.Header{
+		Name:     "etc/os-release",
+		Mode:     0o644,
+		Typeflag: tar.TypeReg,
+	}, []byte("ID=alpine\nVERSION_ID=3.19.0\n"))
+
+	if err := tw.Close(); err != nil {
+		t.Fatalf("tar close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func buildMaliciousOciLayout(t *testing.T, dir string) {
+	t.Helper()
+	blobsDir := filepath.Join(dir, "blobs", "sha256")
+	if err := os.MkdirAll(blobsDir, 0o755); err != nil {
+		t.Fatalf("mkdir blobs: %v", err)
+	}
+
+	layer := buildMaliciousLayerTar(t)
+	layerDigest, layerSize := writeBlob(t, blobsDir, layer)
+
+	cfg, err := json.Marshal(map[string]any{
+		"architecture": "amd64",
+		"os":           "linux",
+		"config":       map[string]any{"Cmd": []string{"/bin/sh"}},
+		"rootfs": map[string]any{
+			"type":     "layers",
+			"diff_ids": []string{"sha256:" + layerDigest},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal config: %v", err)
+	}
+	cfgDigest, cfgSize := writeBlob(t, blobsDir, cfg)
+
+	mf, err := json.Marshal(map[string]any{
+		"schemaVersion": 2,
+		"mediaType":     "application/vnd.oci.image.manifest.v1+json",
+		"config": map[string]any{
+			"mediaType": "application/vnd.oci.image.config.v1+json",
+			"digest":    "sha256:" + cfgDigest,
+			"size":      cfgSize,
+		},
+		"layers": []map[string]any{{
+			"mediaType": "application/vnd.oci.image.layer.v1.tar",
+			"digest":    "sha256:" + layerDigest,
+			"size":      layerSize,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	mfDigest, mfSize := writeBlob(t, blobsDir, mf)
+
+	idx, err := json.Marshal(map[string]any{
+		"schemaVersion": 2,
+		"manifests": []map[string]any{{
+			"mediaType":   "application/vnd.oci.image.manifest.v1+json",
+			"digest":      "sha256:" + mfDigest,
+			"size":        mfSize,
+			"annotations": map[string]string{"org.opencontainers.image.ref.name": "latest"},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("marshal index: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "index.json"), idx, 0o644); err != nil {
+		t.Fatalf("write index.json: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "oci-layout"), []byte(`{"imageLayoutVersion":"1.0.0"}`), 0o644); err != nil {
+		t.Fatalf("write oci-layout: %v", err)
+	}
+}
+
+func TestSecuritySymlinkEscapeBlocked(t *testing.T) {
+	// Pre-clean any state from a previous run.
+	_ = os.RemoveAll("/tmp/boxlite_host_escape_go")
+
+	layoutDir, err := os.MkdirTemp("/tmp", "malicious-oci-go-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(layoutDir) })
+
+	buildMaliciousOciLayout(t, layoutDir)
+
+	if _, err := os.Stat(symlinkEscapeTarget); err == nil {
+		t.Fatalf("host file must not exist before exploit attempt: %s", symlinkEscapeTarget)
+	}
+
+	rt := newTestRuntime(t)
+	ctx := context.Background()
+
+	// The image arg is required by Create signature, but WithRootfsPath
+	// takes precedence per options.go:132.
+	box, err := rt.Create(ctx, "alpine:latest",
+		WithAutoRemove(false),
+		WithRootfsPath(layoutDir),
+	)
+	if err != nil {
+		// Create may legitimately fail on incomplete rootfs after the
+		// extractor refuses the escape — that's fine; the vulnerability
+		// would fire during extraction, before VM launch.
+		var e *Error
+		if errors.As(err, &e) {
+			t.Logf("Create returned error (acceptable): %v", err)
+		}
+	} else {
+		t.Cleanup(func() {
+			_ = box.Stop(ctx)
+			_ = rt.ForceRemove(ctx, box.ID())
+			_ = box.Close()
+		})
+		// Best-effort start; failures are also acceptable since the
+		// extraction has already completed (or been refused).
+		if err := box.Start(ctx); err == nil {
+			_, _ = box.Exec(ctx, "sh", "-c", "echo ok")
+		} else {
+			t.Logf("Start returned error (acceptable): %v", err)
+		}
+	}
+
+	// The advisory's own exploit oracle.
+	if _, err := os.Stat(symlinkEscapeTarget); err == nil {
+		t.Fatalf("GHSA-f396-4rp4-7v2j: host file written via escape symlink at %s — SafeRoot containment failed", symlinkEscapeTarget)
+	}
+}

--- a/sdks/node/tests/security-readonly-volume-remount.integration.test.ts
+++ b/sdks/node/tests/security-readonly-volume-remount.integration.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Regression test for GHSA-g6ww-w5j2-r7x3 (read-only volume remount bypass).
+ *
+ * A host directory mounted with `readOnly: true` must stay read-only even
+ * against a malicious guest that runs `mount -o remount,rw`. Before the
+ * v0.9.0 fix the guest could remount the virtiofs share read-write (it had
+ * CAP_SYS_ADMIN) and write through to the host.
+ *
+ * Node-SDK counterpart of:
+ *  - sdks/python/tests/test_readonly_volume_remount.py
+ *  - src/boxlite/tests/security_enforcement.rs::readonly_volume_blocks_remount
+ *
+ * Requires:
+ *  - make dev:node (build Node SDK)
+ *  - VM runtime for integration tests (libkrun / Hypervisor.framework)
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { SimpleBox } from "../lib/simplebox.js";
+
+const GUEST_MOUNT = "/mnt/sensitive";
+const ORIGINAL = "original content\n";
+const ATTACK_PAYLOAD = "modified content";
+
+describe(
+  "GHSA-g6ww-w5j2-r7x3: read-only volume remount bypass",
+  { timeout: 180_000 },
+  () => {
+    let hostDir: string;
+    let roFile: string;
+    let box: SimpleBox;
+
+    beforeAll(async () => {
+      hostDir = mkdtempSync(join(tmpdir(), "virtiofs-ro-poc-"));
+      roFile = join(hostDir, "read_only.txt");
+      writeFileSync(roFile, ORIGINAL);
+
+      box = new SimpleBox({
+        image: "alpine:latest",
+        volumes: [
+          { hostPath: hostDir, guestPath: GUEST_MOUNT, readOnly: true },
+        ],
+        memoryMib: 512,
+        cpus: 1,
+        autoRemove: false,
+      });
+      // Force creation now so the volume is mounted before the test body runs.
+      await box.exec("true");
+    });
+
+    afterAll(async () => {
+      try {
+        await box.stop();
+      } finally {
+        rmSync(hostDir, { recursive: true, force: true });
+      }
+    });
+
+    test("mount -o remount,rw cannot reach host file", async () => {
+      // The share must be exposed read-only to the guest.
+      const mounts = await box.exec("sh", [
+        "-c",
+        "cat /proc/mounts | grep sensitive",
+      ]);
+      expect(mounts.stdout, `mounts: ${mounts.stdout}`).toContain(" ro,");
+
+      // Direct write is rejected (client-side MS_RDONLY active).
+      const write1 = await box.exec("sh", [
+        "-c",
+        `echo '${ATTACK_PAYLOAD}' > ${GUEST_MOUNT}/read_only.txt 2>&1`,
+      ]);
+      expect(
+        write1.exitCode,
+        "initial write to read-only volume should fail",
+      ).not.toBe(0);
+
+      // ATTACK: try to remount the share read-write.
+      await box.exec("sh", ["-c", `mount -o remount,rw ${GUEST_MOUNT} 2>&1`]);
+
+      // The mount must still be read-only after the remount attempt.
+      const after = await box.exec("sh", [
+        "-c",
+        "cat /proc/mounts | grep sensitive",
+      ]);
+      expect(after.stdout, `mounts after remount: ${after.stdout}`).toContain(
+        " ro,",
+      );
+      expect(
+        after.stdout,
+        `mounts after remount: ${after.stdout}`,
+      ).not.toContain(" rw,");
+
+      // A post-attack write must still fail.
+      const write2 = await box.exec("sh", [
+        "-c",
+        `echo '${ATTACK_PAYLOAD}' > ${GUEST_MOUNT}/read_only.txt 2>&1`,
+      ]);
+      expect(
+        write2.exitCode,
+        "write after remount bypass should still fail",
+      ).not.toBe(0);
+
+      // Guest-visible content unchanged.
+      const guestView = await box.exec("cat", `${GUEST_MOUNT}/read_only.txt`);
+      expect(guestView.stdout).toBe(ORIGINAL);
+
+      // HOST VERIFICATION — the advisory's own exploit oracle: if the host
+      // file now reads ATTACK_PAYLOAD the sandbox was escaped.
+      const hostContent = readFileSync(roFile, "utf8");
+      expect(
+        hostContent,
+        `read-only volume bypass: host file was modified from inside the sandbox (got ${JSON.stringify(hostContent)})`,
+      ).toBe(ORIGINAL);
+    });
+  },
+);

--- a/sdks/node/tests/security-symlink-escape.integration.test.ts
+++ b/sdks/node/tests/security-symlink-escape.integration.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Regression test for GHSA-f396-4rp4-7v2j (OCI layer symlink escape).
+ *
+ * A crafted OCI layer with a symlink pointing outside the extraction root
+ * (e.g. `escape -> /tmp`) followed by a file entry at `escape/<path>` must
+ * NOT be allowed to write through to the host filesystem. The v0.9.0 fix
+ * enforces this via SafeRoot containment in the Rust extractor; this Node
+ * test exercises the same defense through the napi-rs binding by loading
+ * a malicious local OCI layout via `SimpleBox({ rootfsPath })`.
+ *
+ * Node-SDK counterpart of sdks/python/tests/test_symlink_escape.py and the
+ * unit test src/boxlite/src/images/archive/extractor.rs::test_cve_symlink_escape_blocked.
+ *
+ * Requires:
+ *  - make dev:node (build Node SDK)
+ *  - VM runtime for integration tests (libkrun / Hypervisor.framework)
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { SimpleBox } from "../lib/simplebox.js";
+
+const TARGET_FILE = "/tmp/boxlite_host_escape_node/pwned.txt";
+
+// ── Minimal USTAR tar builder ─────────────────────────────────────────────────
+// Hand-rolled to avoid adding a tar dependency for a single security regression
+// test. Matches the GNU/USTAR header format the Rust extractor parses.
+
+type EntryType = "file" | "dir" | "symlink";
+
+interface TarEntry {
+  name: string;
+  type: EntryType;
+  linkname?: string;
+  data?: Buffer;
+  mode?: number;
+}
+
+function tarHeader(entry: TarEntry, mtime: number): Buffer {
+  const buf = Buffer.alloc(512);
+  buf.write(entry.name.slice(0, 100), 0, "utf8");
+  const mode =
+    entry.mode ??
+    (entry.type === "symlink" ? 0o777 : entry.type === "dir" ? 0o755 : 0o644);
+  buf.write(mode.toString(8).padStart(7, "0") + "\0", 100);
+  buf.write("0000000\0", 108); // uid
+  buf.write("0000000\0", 116); // gid
+  const size = entry.type === "file" ? entry.data!.length : 0;
+  buf.write(size.toString(8).padStart(11, "0") + "\0", 124);
+  buf.write(mtime.toString(8).padStart(11, "0") + "\0", 136);
+  // chksum: placeholder spaces while computing
+  buf.fill(0x20, 148, 156);
+  const typeflag =
+    entry.type === "file" ? "0" : entry.type === "symlink" ? "2" : "5";
+  buf.write(typeflag, 156);
+  if (entry.linkname) buf.write(entry.linkname.slice(0, 100), 157, "utf8");
+  buf.write("ustar\0", 257);
+  buf.write("00", 263);
+
+  let sum = 0;
+  for (let i = 0; i < 512; i++) sum += buf[i];
+  buf.write(sum.toString(8).padStart(6, "0") + "\0 ", 148);
+  return buf;
+}
+
+function buildTar(entries: TarEntry[]): Buffer {
+  const mtime = Math.floor(Date.now() / 1000);
+  const chunks: Buffer[] = [];
+  for (const e of entries) {
+    chunks.push(tarHeader(e, mtime));
+    if (e.type === "file" && e.data && e.data.length > 0) {
+      chunks.push(e.data);
+      const pad = (512 - (e.data.length % 512)) % 512;
+      if (pad > 0) chunks.push(Buffer.alloc(pad));
+    }
+  }
+  chunks.push(Buffer.alloc(1024)); // two zero blocks = end of archive
+  return Buffer.concat(chunks);
+}
+
+// ── Malicious OCI layout: tar entries [symlink "escape" -> /tmp/...] +
+//    file "escape/<...>/pwned.txt"; the second entry resolves through the
+//    symlink and would land on the host without containment. ────────────────
+
+function buildMaliciousOciLayout(layoutDir: string): void {
+  mkdirSync(join(layoutDir, "blobs", "sha256"), { recursive: true });
+
+  // The exact PoC shape: symlink pointing to /tmp + a file path that
+  // dereferences through it. We aim the escape at /tmp/boxlite_host_escape_node
+  // (distinct from the Python test's /tmp/boxlite_host_escape so the two
+  // tests don't share state).
+  const payload = Buffer.from(
+    `===== BOXLITE NODE SDK SYMLINK ESCAPE PoC =====\nTarget: ${TARGET_FILE}\n`,
+  );
+
+  const layer = buildTar([
+    { name: "escape", type: "symlink", linkname: "/tmp" },
+    { name: "escape/boxlite_host_escape_node", type: "dir" },
+    {
+      name: "escape/boxlite_host_escape_node/pwned.txt",
+      type: "file",
+      data: payload,
+    },
+    {
+      name: "etc/os-release",
+      type: "file",
+      data: Buffer.from("ID=alpine\nVERSION_ID=3.19.0\n"),
+    },
+  ]);
+
+  const writeBlob = (data: Buffer): { digest: string; size: number } => {
+    const digest = createHash("sha256").update(data).digest("hex");
+    writeFileSync(join(layoutDir, "blobs", "sha256", digest), data);
+    return { digest, size: data.length };
+  };
+
+  const layerBlob = writeBlob(layer);
+  const config = Buffer.from(
+    JSON.stringify({
+      architecture: "amd64",
+      os: "linux",
+      config: { Cmd: ["/bin/sh"] },
+      rootfs: { type: "layers", diff_ids: [`sha256:${layerBlob.digest}`] },
+    }),
+  );
+  const cfgBlob = writeBlob(config);
+
+  const manifest = Buffer.from(
+    JSON.stringify({
+      schemaVersion: 2,
+      mediaType: "application/vnd.oci.image.manifest.v1+json",
+      config: {
+        mediaType: "application/vnd.oci.image.config.v1+json",
+        digest: `sha256:${cfgBlob.digest}`,
+        size: cfgBlob.size,
+      },
+      layers: [
+        {
+          mediaType: "application/vnd.oci.image.layer.v1.tar",
+          digest: `sha256:${layerBlob.digest}`,
+          size: layerBlob.size,
+        },
+      ],
+    }),
+  );
+  const mfBlob = writeBlob(manifest);
+
+  writeFileSync(
+    join(layoutDir, "index.json"),
+    JSON.stringify({
+      schemaVersion: 2,
+      manifests: [
+        {
+          mediaType: "application/vnd.oci.image.manifest.v1+json",
+          digest: `sha256:${mfBlob.digest}`,
+          size: mfBlob.size,
+          annotations: { "org.opencontainers.image.ref.name": "latest" },
+        },
+      ],
+    }),
+  );
+  writeFileSync(
+    join(layoutDir, "oci-layout"),
+    JSON.stringify({ imageLayoutVersion: "1.0.0" }),
+  );
+}
+
+describe(
+  "GHSA-f396-4rp4-7v2j: OCI layer symlink escape",
+  { timeout: 180_000 },
+  () => {
+    let layoutDir: string;
+
+    beforeAll(() => {
+      // Pre-clean any state from a previous run.
+      rmSync(TARGET_FILE, { force: true });
+      rmSync("/tmp/boxlite_host_escape_node", { recursive: true, force: true });
+      layoutDir = mkdtempSync(join(tmpdir(), "malicious-oci-node-"));
+      buildMaliciousOciLayout(layoutDir);
+    });
+
+    afterAll(() => {
+      rmSync(layoutDir, { recursive: true, force: true });
+      // Best-effort: if the test failed and the host file exists, leave it for
+      // post-mortem; the assertion message points at it.
+    });
+
+    test("rootfsPath of malicious OCI layout cannot write through escape symlink", async () => {
+      expect(
+        existsSync(TARGET_FILE),
+        "host file must not exist before exploit attempt",
+      ).toBe(false);
+
+      const box = new SimpleBox({ rootfsPath: layoutDir });
+      try {
+        // Box may fail to start (incomplete rootfs) — that's fine; the
+        // vulnerability fires during layer extraction, before VM launch.
+        await box.exec("sh", "-c", "echo ok").catch(() => {});
+      } finally {
+        await box.stop().catch(() => {});
+      }
+
+      // The advisory's exploit oracle: if this host file now exists, the
+      // sandbox was escaped during OCI extraction.
+      expect(
+        existsSync(TARGET_FILE),
+        `GHSA-f396-4rp4-7v2j: host file written via escape symlink at ${TARGET_FILE} — SafeRoot containment failed`,
+      ).toBe(false);
+    });
+  },
+);


### PR DESCRIPTION
Brings SDK regression coverage in line with the existing Python tests (#539 / #540) and the Rust core test at `src/boxlite/src/images/archive/extractor.rs::test_cve_symlink_escape_blocked`. Companion to the 2026-05-20 GHSA-f396 mapping correction (5-row "Affected products" matching GHSA-g6ww) and the v0.9.0 / v0.9.5 release-note Security sections that surface both advisories to the non-Dependabot cohort.

## Coverage matrix after this PR

| | Rust | Python | Node | Go | C |
|---|---|---|---|---|---|
| GHSA-g6ww (remount) | ✅ `security_enforcement.rs` | ✅ `test_readonly_volume_remount.py` | ✅ **new** | ✅ **new** | delegated to Go |
| GHSA-f396 (symlink) | ✅ `extractor.rs::test_cve_symlink_escape_blocked` (unit) | ✅ `test_symlink_escape.py` | ✅ **new** | ✅ **new** | delegated to Go |

## Files added

- `sdks/node/tests/security-readonly-volume-remount.integration.test.ts` — mounts a host volume `readOnly: true`, runs `mount -o remount,rw` from inside the box, asserts the host file is unchanged.
- `sdks/node/tests/security-symlink-escape.integration.test.ts` — builds a minimal malicious OCI layout inline (hand-rolled USTAR + sha256 + manifest/config/index, no new devDeps), loads it via `SimpleBox({ rootfsPath })`, asserts no host file written outside the extraction root.
- `sdks/go/security_readonly_volume_remount_integration_test.go` — same shape as the Node test, using `WithVolumeReadOnly` + `box.Exec`.
- `sdks/go/security_symlink_escape_integration_test.go` — uses stdlib `archive/tar` to build the malicious layer + `encoding/json` for the OCI layout, then `rt.Create(..., WithRootfsPath(layoutDir))`.

## Why no C SDK tests

`sdks/c/tests/CMakeLists.txt` documents the upstream decision: *"lifecycle/execute/streaming/etc. tests were removed when the C SDK moved to the post-and-drain callback API; coverage of those code paths now lives in the Go SDK + runner integration suite."* Both PoCs need the callback-based full options API (`boxlite_options_add_volume`, `boxlite_options_set_rootfs_path`) — the simple API doesn't expose them. Re-introducing 150+ lines of callback/condvar plumbing per test contradicts the documented delegation; the new Go tests cover the same C-FFI machinery one layer up.

## How verification was done

- Go: `go vet -tags boxlite_dev ./...` passes from the `sdks/go` module root.
- Node: precommit-hook lint passed (TypeScript type check via the SDK's own configuration).
- Integration runs require `make dev:node` / `make dev:go` + a VM runtime — not run here.

## Companion work (outside this PR)

- `gh api PATCH` corrected `GHSA-f396-4rp4-7v2j` "Affected products" from a single `pip boxlite <= 0.8.2` row to the 5-row shape that mirrors GHSA-g6ww (pip / npm / go / rust `boxlite` / rust `boxlite-cli`, each `< 0.9.0` patched `0.9.0`).
- v0.9.0 + v0.9.5 release notes prepended with a `## Security` section linking both GHSAs + CVEs.
- RustSec PR rustsec/advisory-db#2899 opened to cover `cargo audit` users (GitHub advisories don't auto-populate RustSec).
