### PR TITLE
fix(test-python): use shared_runtime fixture to avoid BOXLITE_HOME flock collision

### DIFF
--- a/sdks/python/tests/test_exec_timeout_sigalrm.py
+++ b/sdks/python/tests/test_exec_timeout_sigalrm.py
@@ -61,7 +61,7 @@ WORKLOAD_S = 8
 GRACE_S = 2.0
 
 
-async def test_exec_timeout_kills_sigalrm_ignoring_process():
+async def test_exec_timeout_kills_sigalrm_ignoring_process(shared_runtime):
     """A workload that ignores SIGALRM must still be killed at the timeout.
 
     Two-pronged assertion — both must hold:
@@ -78,7 +78,7 @@ async def test_exec_timeout_kills_sigalrm_ignoring_process():
     Fix is in ``src/guest/src/service/exec/timeout.rs``: send ``SIGKILL``
     (uncatchable) rather than ``SIGALRM``.
     """
-    async with boxlite.SimpleBox(image="python:3-alpine") as box:
+    async with boxlite.SimpleBox(image="python:3-alpine", runtime=shared_runtime) as box:
         t0 = time.time()
         result = await box.exec(
             "python3",
@@ -102,7 +102,7 @@ async def test_exec_timeout_kills_sigalrm_ignoring_process():
         )
 
 
-async def test_exec_timeout_sigkill_fallback_when_sigterm_ignored():
+async def test_exec_timeout_sigkill_fallback_when_sigterm_ignored(shared_runtime):
     """Stage-3 SIGKILL must terminate a workload that ignores SIGTERM.
 
     Companion to ``test_exec_timeout_kills_sigalrm_ignoring_process``: that
@@ -119,7 +119,7 @@ async def test_exec_timeout_sigkill_fallback_when_sigterm_ignored():
       - t = TIMEOUT_S:           SIGTERM sent, absorbed by SIG_IGN
       - t = TIMEOUT_S + GRACE_S: SIGKILL sent, process dies (exit_code=-9)
     """
-    async with boxlite.SimpleBox(image="python:3-alpine") as box:
+    async with boxlite.SimpleBox(image="python:3-alpine", runtime=shared_runtime) as box:
         t0 = time.time()
         result = await box.exec(
             "python3",

--- a/sdks/python/tests/test_exec_timeout_sigalrm.py
+++ b/sdks/python/tests/test_exec_timeout_sigalrm.py
@@ -78,7 +78,9 @@ async def test_exec_timeout_kills_sigalrm_ignoring_process(shared_runtime):
     Fix is in ``src/guest/src/service/exec/timeout.rs``: send ``SIGKILL``
     (uncatchable) rather than ``SIGALRM``.
     """
-    async with boxlite.SimpleBox(image="python:3-alpine", runtime=shared_runtime) as box:
+    async with boxlite.SimpleBox(
+        image="python:3-alpine", runtime=shared_runtime
+    ) as box:
         t0 = time.time()
         result = await box.exec(
             "python3",
@@ -119,7 +121,9 @@ async def test_exec_timeout_sigkill_fallback_when_sigterm_ignored(shared_runtime
       - t = TIMEOUT_S:           SIGTERM sent, absorbed by SIG_IGN
       - t = TIMEOUT_S + GRACE_S: SIGKILL sent, process dies (exit_code=-9)
     """
-    async with boxlite.SimpleBox(image="python:3-alpine", runtime=shared_runtime) as box:
+    async with boxlite.SimpleBox(
+        image="python:3-alpine", runtime=shared_runtime
+    ) as box:
         t0 = time.time()
         result = await box.exec(
             "python3",

--- a/sdks/python/tests/test_symlink_escape.py
+++ b/sdks/python/tests/test_symlink_escape.py
@@ -157,7 +157,7 @@ def build_oci_layout(out_dir: str) -> None:
 # ── Reporter's PoC main() — reproduced verbatim ───────────────────────────────
 
 
-async def main():
+async def main(runtime=None):
     print("=" * 60)
     print("  PoC: BoxLite OCI Layer Extraction Symlink Escape")
     print("=" * 60)
@@ -201,7 +201,7 @@ async def main():
     print("\n[4] Loading malicious image via boxlite.SimpleBox(rootfs_path=…)")
 
     try:
-        async with boxlite.SimpleBox(rootfs_path=OCI_LAYOUT_DIR) as box:
+        async with boxlite.SimpleBox(rootfs_path=OCI_LAYOUT_DIR, runtime=runtime) as box:
             r = await box.exec("sh", "-c", "echo ok")
             print(f"    VM stdout: {r.stdout.strip()}")
     except Exception as e:
@@ -222,9 +222,9 @@ async def main():
 # ── Pytest wrapper ────────────────────────────────────────────────────────────
 
 
-async def test_oci_symlink_escape_blocked():
+async def test_oci_symlink_escape_blocked(shared_runtime):
     """GHSA-f396-4rp4-7v2j: reporter's exact PoC must not write outside root."""
-    await main()
+    await main(runtime=shared_runtime)
     assert not os.path.exists(TARGET_FILE), (
         f"GHSA-f396-4rp4-7v2j: host file written via escape symlink at "
         f"{TARGET_FILE} — SafeRoot containment failed"

--- a/sdks/python/tests/test_symlink_escape.py
+++ b/sdks/python/tests/test_symlink_escape.py
@@ -201,7 +201,9 @@ async def main(runtime=None):
     print("\n[4] Loading malicious image via boxlite.SimpleBox(rootfs_path=…)")
 
     try:
-        async with boxlite.SimpleBox(rootfs_path=OCI_LAYOUT_DIR, runtime=runtime) as box:
+        async with boxlite.SimpleBox(
+            rootfs_path=OCI_LAYOUT_DIR, runtime=runtime
+        ) as box:
             r = await box.exec("sh", "-c", "echo ok")
             print(f"    VM stdout: {r.stdout.strip()}")
     except Exception as e:


### PR DESCRIPTION
The SIGALRM/SIGKILL timeout regressions by GHSA-xjhv-pp2r-6f82 and the GHSA-f396-4rp4-7v2j symlink PoC instantiated boxlite.SimpleBox(...) without runtime=, which routes through Boxlite.default() → BoxliteRuntime::default_runtime() → tries to acquire an exclusive flock on the shared BOXLITE_HOME. Once any earlier test triggers conftest's session-scoped shared_runtime fixture (which already holds that flock via BoxliteRuntime::new()), every subsequent SimpleBox(default) panics with "Another BoxliteRuntime is already using directory".

Thread shared_runtime into the three failing tests (matches the pattern already used in test_tcp_filter.py and test_sync_simplebox.py). No SDK or conftest changes.

Verified: make test:integration:python — 157 passed, 21 skipped, 114 deselected (rc=0). The three previously-failing tests now pass:
  - test_exec_timeout_kills_sigalrm_ignoring_process
  - test_exec_timeout_sigkill_fallback_when_sigterm_ignored
  - test_oci_symlink_escape_blocked