### PR TITLE
refactor(logging): executable-owned subscriber + layered CLI sink

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,6 +489,7 @@ dependencies = [
  "toml 0.8.23",
  "tower-http",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "ulid",
 ]
@@ -4663,6 +4664,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4672,12 +4683,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/docs/reference/cli/README.md
+++ b/docs/reference/cli/README.md
@@ -120,7 +120,7 @@ These flags can appear before *or* after the subcommand and apply to every comma
 
 | Flag | Type | Default | Env Var | Description |
 |------|------|---------|---------|-------------|
-| `--debug` | bool | `false` | — | Enable debug output |
+| `--debug` | bool | `false` | `RUST_LOG` (lower precedence than the flag) | Enable debug output. Precedence: `--debug` > `RUST_LOG` env > default (`warn` on stderr, `info` in file when enabled). |
 | `--home PATH` | path | `~/.boxlite` | `BOXLITE_HOME` | BoxLite runtime data directory |
 | `--registry REGISTRY` | string (repeatable) | `[]` | — | Image registry hostname; prepended to the registries from `--config` |
 | `--config PATH` | path | none | — | JSON config file (see [Configuration File](#configuration-file)) |

--- a/sdks/c/src/exec/simple.rs
+++ b/sdks/c/src/exec/simple.rs
@@ -115,7 +115,10 @@ unsafe fn runner_new(
             }
         };
 
-        let runtime = match BoxliteRuntime::new(BoxliteOptions::default()) {
+        let options = BoxliteOptions::default();
+        // Executable-owned logging init (the library no longer auto-installs a subscriber).
+        let _ = boxlite::init_logging_for(&options.home_dir);
+        let runtime = match BoxliteRuntime::new(options) {
             Ok(rt) => rt,
             Err(e) => {
                 write_error(out_error, e);

--- a/sdks/c/src/runtime.rs
+++ b/sdks/c/src/runtime.rs
@@ -206,6 +206,9 @@ unsafe fn runtime_new(
                 }
             };
 
+        // Executable-owned logging init (the library no longer auto-installs a subscriber).
+        let _ = boxlite::init_logging_for(&options.home_dir);
+
         let runtime = match BoxliteRuntime::new(options) {
             Ok(rt) => rt,
             Err(e) => {

--- a/sdks/node/src/runtime.rs
+++ b/sdks/node/src/runtime.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use boxlite::{BoxArchive, BoxOptions, BoxliteRuntime};
+use boxlite::{BoxArchive, BoxOptions, BoxliteOptions, BoxliteRuntime};
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
 
@@ -34,7 +34,10 @@ impl JsBoxlite {
     /// ```
     #[napi(constructor)]
     pub fn new(options: JsOptions) -> Result<Self> {
-        let runtime = BoxliteRuntime::new(js_options_into_core(options)?).map_err(map_err)?;
+        let core_opts = js_options_into_core(options)?;
+        // Executable-owned logging init (the library no longer auto-installs a subscriber).
+        let _ = boxlite::init_logging_for(&core_opts.home_dir);
+        let runtime = BoxliteRuntime::new(core_opts).map_err(map_err)?;
 
         Ok(Self {
             runtime: Arc::new(runtime),
@@ -52,6 +55,10 @@ impl JsBoxlite {
     /// ```
     #[napi(factory)]
     pub fn with_default_config() -> Result<Self> {
+        // Executable-owned logging init (the library no longer auto-installs a
+        // subscriber). The default runtime uses `BoxliteOptions::default()`, so
+        // we mirror its home_dir for the log location.
+        let _ = boxlite::init_logging_for(&BoxliteOptions::default().home_dir);
         let runtime = BoxliteRuntime::default_runtime();
         Ok(Self {
             runtime: Arc::new(runtime.clone()),
@@ -73,7 +80,9 @@ impl JsBoxlite {
     /// ```
     #[napi]
     pub fn init_default(options: JsOptions) -> Result<()> {
-        BoxliteRuntime::init_default_runtime(js_options_into_core(options)?).map_err(map_err)
+        let core_opts = js_options_into_core(options)?;
+        let _ = boxlite::init_logging_for(&core_opts.home_dir);
+        BoxliteRuntime::init_default_runtime(core_opts).map_err(map_err)
     }
 
     /// Create a runtime that connects to a remote BoxLite REST backend.

--- a/sdks/python/src/runtime.rs
+++ b/sdks/python/src/runtime.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use boxlite::{BoxArchive, BoxOptions, BoxliteRuntime};
+use boxlite::{BoxArchive, BoxOptions, BoxliteOptions, BoxliteRuntime};
 use pyo3::prelude::*;
 
 use crate::box_handle::PyBox;
@@ -19,7 +19,10 @@ pub(crate) struct PyBoxlite {
 impl PyBoxlite {
     #[new]
     fn new(options: PyOptions) -> PyResult<Self> {
-        let runtime = BoxliteRuntime::new(options.into_core()?).map_err(map_err)?;
+        let core_opts = options.into_core()?;
+        // Executable-owned logging init (the library no longer auto-installs a subscriber).
+        let _ = boxlite::init_logging_for(&core_opts.home_dir);
+        let runtime = BoxliteRuntime::new(core_opts).map_err(map_err)?;
 
         Ok(Self {
             runtime: Arc::new(runtime),
@@ -28,6 +31,10 @@ impl PyBoxlite {
 
     #[staticmethod]
     fn default() -> PyResult<Self> {
+        // Executable-owned logging init (the library no longer auto-installs a
+        // subscriber). The default runtime uses `BoxliteOptions::default()`, so
+        // we mirror its home_dir for the log location.
+        let _ = boxlite::init_logging_for(&BoxliteOptions::default().home_dir);
         let runtime = BoxliteRuntime::default_runtime();
         Ok(Self {
             runtime: Arc::new(runtime.clone()),
@@ -56,7 +63,9 @@ impl PyBoxlite {
 
     #[staticmethod]
     fn init_default(options: PyOptions) -> PyResult<()> {
-        BoxliteRuntime::init_default_runtime(options.into_core()?).map_err(map_err)
+        let core_opts = options.into_core()?;
+        let _ = boxlite::init_logging_for(&core_opts.home_dir);
+        BoxliteRuntime::init_default_runtime(core_opts).map_err(map_err)
     }
 
     #[pyo3(signature = (options, name=None))]

--- a/src/boxlite/src/lib.rs
+++ b/src/boxlite/src/lib.rs
@@ -2,10 +2,12 @@
 //!
 //! This crate provides the host-side API for managing Boxlite sandboxes.
 
+use std::path::Path;
 use std::sync::OnceLock;
 use tracing_subscriber::EnvFilter;
 
-// Global guard for tracing-appender to keep the writer thread alive
+// Global guard for tracing-appender to keep the writer thread alive.
+// Only set when an executable explicitly calls `init_logging_for`.
 static LOG_GUARD: OnceLock<tracing_appender::non_blocking::WorkerGuard> = OnceLock::new();
 
 pub mod event_listener;
@@ -48,7 +50,6 @@ pub use metrics::{BoxMetrics, RuntimeMetrics};
 pub use runtime::advanced_options::{
     AdvancedBoxOptions, HealthCheckOptions, ResourceLimits, SecurityOptions,
 };
-use runtime::layout::FilesystemLayout;
 pub use runtime::options::{
     BoxArchive, BoxOptions, BoxliteOptions, CloneOptions, ExportOptions, ImageRegistry,
     ImageRegistryAuth, NetworkSpec, RegistryTransport, RootfsSpec, Secret, SnapshotOptions,
@@ -64,13 +65,22 @@ pub use rest::credential::{AccessToken, ApiKeyCredential, Credential};
 #[cfg(feature = "rest")]
 pub use rest::options::BoxliteRestOptions;
 
-/// Initialize tracing for Boxlite using the provided filesystem layout.
+/// Opt-in helper for executables (SDK bindings, daemons, embedders) that want
+/// the default Boxlite file logger at `<home_dir>/logs/boxlite.log` with daily
+/// rotation. Honors `RUST_LOG` (defaults to `info` when unset). Idempotent.
 ///
-/// Logs are written to `<layout.home_dir()>/logs/boxlite.log` with daily rotation.
-/// Uses the `RUST_LOG` environment variable for filtering (defaults to `info`).
-/// Idempotent: subsequent calls return immediately once initialized.
-pub fn init_logging_for(layout: &FilesystemLayout) -> BoxliteResult<()> {
-    let logs_dir = layout.logs_dir();
+/// **Libraries must not call this.** The `tracing` crate is explicit that
+/// installing a global default subscriber is the executable's responsibility;
+/// doing it from a library "will cause conflicts when executables that depend
+/// on the library try to set the default later." Boxlite's own CLI installs
+/// its own layered subscriber in `boxlite-cli/src/main.rs` and does not call
+/// this function.
+///
+/// Errors creating the log directory are returned; errors installing the
+/// global default (because one is already set by the host) are swallowed
+/// silently — the host's subscriber wins.
+pub fn init_logging_for(home_dir: &Path) -> BoxliteResult<()> {
+    let logs_dir = crate::runtime::layout::FilesystemLayout::logs_dir_for(home_dir);
     std::fs::create_dir_all(&logs_dir).map_err(|e| {
         BoxliteError::Storage(format!(
             "Failed to create logs directory {}: {}",
@@ -87,8 +97,8 @@ pub fn init_logging_for(layout: &FilesystemLayout) -> BoxliteResult<()> {
             .or_else(|_| EnvFilter::try_new("info"))
             .unwrap_or_else(|_| EnvFilter::new("info"));
 
-        // If global default subscriber is already set, this will return an error.
-        // We ignore it to avoid interfering with host-configured tracing.
+        // If a global default subscriber is already set, `try_init` is a no-op —
+        // the host's subscriber wins, which is the idiomatic outcome.
         util::register_to_tracing(non_blocking, env_filter);
 
         guard

--- a/src/boxlite/src/runtime/layout.rs
+++ b/src/boxlite/src/runtime/layout.rs
@@ -135,7 +135,14 @@ impl FilesystemLayout {
     }
 
     pub fn logs_dir(&self) -> PathBuf {
-        self.home_dir.join(dirs::LOGS_DIR)
+        Self::logs_dir_for(&self.home_dir)
+    }
+
+    /// Compute the logs dir for a given home directory without constructing
+    /// a full `FilesystemLayout`. Used by logging init paths that run before
+    /// the runtime (and thus before the layout) is built.
+    pub fn logs_dir_for(home_dir: &Path) -> PathBuf {
+        home_dir.join(dirs::LOGS_DIR)
     }
 
     /// OCI images layers storage: ~/.boxlite/images/layers

--- a/src/boxlite/src/runtime/rt_impl.rs
+++ b/src/boxlite/src/runtime/rt_impl.rs
@@ -1,6 +1,5 @@
 use crate::db::{BoxStore, Database};
 use crate::images::{ImageDiskManager, ImageManager};
-use crate::init_logging_for;
 use crate::litebox::config::BoxConfig;
 use crate::litebox::{BoxManager, LiteBox, LocalSnapshotBackend, SharedBoxImpl};
 use crate::lock::{FileLockManager, LockManager};
@@ -141,8 +140,6 @@ impl RuntimeImpl {
                 e
             ))
         })?;
-
-        init_logging_for(&layout)?;
 
         let runtime_lock = RuntimeLock::acquire(layout.home_dir()).map_err(|e| {
             BoxliteError::Internal(format!(

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -25,7 +25,8 @@ term_size = "0.3"
 nix = { version = "0.30.1", features = ["term", "signal"] }
 anyhow = "1.0"
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter", "json"] }
+tracing-appender = "0.2"
 
 # HTTP server (serve subcommand)
 async-stream = "0.3"

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -149,7 +149,7 @@ Available for all commands:
 
 | Flag | Description |
 |------|-------------|
-| `--debug` | Enable debug output |
+| `--debug` | Enable debug output. Precedence: `--debug` > `RUST_LOG` env > default (`warn`). |
 | `--home PATH` | BoxLite home directory (default: `~/.boxlite`). Overridden by `BOXLITE_HOME` |
 | `--registry REGISTRY` | Image registry (repeatable; prepended to config) |
 | `--config PATH` | JSON config file path (e.g. for `image_registries`) |

--- a/src/cli/src/main.rs
+++ b/src/cli/src/main.rs
@@ -7,12 +7,17 @@ mod formatter;
 pub mod terminal;
 pub mod util;
 
+use std::path::{Path, PathBuf};
 use std::process;
+use std::sync::OnceLock;
 
 use clap::CommandFactory;
 use clap::Parser;
 use cli::Cli;
-use tracing_subscriber::{EnvFilter, fmt, layer::SubscriberExt, util::SubscriberInitExt};
+use tracing_appender::non_blocking::WorkerGuard;
+use tracing_subscriber::{EnvFilter, Layer, fmt, layer::SubscriberExt, util::SubscriberInitExt};
+
+static FILE_LOG_GUARD: OnceLock<WorkerGuard> = OnceLock::new();
 
 fn main() {
     let cli = Cli::parse();
@@ -34,15 +39,52 @@ fn main() {
 }
 
 async fn run_cli(cli: Cli) -> anyhow::Result<()> {
-    // Initialize tracing based on --debug flag
-    let level = if cli.global.debug { "debug" } else { "info" };
-    let env_filter = EnvFilter::try_from_default_env()
-        .or_else(|_| EnvFilter::try_new(level))
-        .unwrap_or_else(|_| EnvFilter::new(level));
+    // Per-layer filters: stderr stays peer-CLI quiet (warn), the optional file
+    // layer carries richer info-level data for triage. Precedence (docker
+    // convention): `--debug` flag > `RUST_LOG` env > per-layer default.
+    let debug = cli.global.debug;
+    // Read RUST_LOG once at startup so `build_filter` stays pure and
+    // testable; tests can pass values directly without racing on the
+    // global env. Read here (not inside `build_filter`) because the
+    // function is called twice and the second call would otherwise race
+    // any subsequent env mutation in the same process.
+    let rust_log_env = std::env::var("RUST_LOG").ok();
+
+    let stderr_layer = fmt::layer()
+        .with_writer(std::io::stderr)
+        .with_filter(build_filter(debug, "warn", rust_log_env.as_deref()));
+
+    // For `boxlite serve`, the daemon's logs must land under the *resolved*
+    // home_dir (config file + --home + BOXLITE_HOME), not just the --home flag.
+    // Other subcommands resolve options later inside their handlers.
+    //
+    // The `.ok()` here is intentionally best-effort: this resolution is only
+    // consulted for the log directory. In local mode the serve handler calls
+    // `create_runtime()` which re-runs `resolve_runtime_options()` and
+    // surfaces config errors to the user. In REST mode (`--url` /
+    // `BOXLITE_API_KEY` set) the resolver is *not* re-invoked, so a malformed
+    // config file is silently ignored here; `boxlite serve` is overwhelmingly
+    // a local-daemon operation, so we accept that narrow gap rather than
+    // duplicating the resolver call here.
+    let serve_mode = matches!(cli.command, cli::Commands::Serve(_));
+    let serve_home_dir = if serve_mode {
+        cli.global
+            .resolve_runtime_options()
+            .ok()
+            .map(|o| o.home_dir)
+    } else {
+        None
+    };
+    let file_layer = build_file_layer(
+        serve_home_dir.as_deref(),
+        serve_mode,
+        debug,
+        rust_log_env.as_deref(),
+    );
 
     tracing_subscriber::registry()
-        .with(env_filter)
-        .with(fmt::layer().with_writer(std::io::stderr))
+        .with(stderr_layer)
+        .with(file_layer)
         .init();
 
     let global = cli.global;
@@ -76,4 +118,208 @@ async fn run_cli(cli: Cli) -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+/// Build a tracing filter with docker-style precedence:
+/// `--debug` flag > `RUST_LOG` env > `default_level`.
+///
+/// When `--debug` is set, `RUST_LOG` is intentionally bypassed — the flag is a
+/// per-invocation override and should not be silently nullified by ambient env.
+///
+/// `rust_log` is the snapshot of `RUST_LOG` taken once at the call site so
+/// this function stays pure (no env reads) and the precedence tests can
+/// pass values directly without racing on the process-global env.
+fn build_filter(debug: bool, default_level: &str, rust_log: Option<&str>) -> EnvFilter {
+    if debug {
+        return EnvFilter::new("debug");
+    }
+    if let Some(value) = rust_log.filter(|v| !v.is_empty())
+        && let Ok(filter) = EnvFilter::try_new(value)
+    {
+        return filter;
+    }
+    EnvFilter::try_new(default_level).unwrap_or_else(|_| EnvFilter::new(default_level))
+}
+
+/// Resolve the explicit `BOXLITE_LOG_FILE` value into `(dir, filename)`.
+///
+/// A bare filename (`BOXLITE_LOG_FILE=boxlite.log`) is treated as
+/// CWD-relative: `Path::parent` returns `Some("")` for those, which we map to
+/// `"."` so the file lands in the working directory rather than being silently
+/// dropped. Returns `None` only when the value has no usable filename.
+fn resolve_explicit_log_path(value: &str) -> Option<(PathBuf, String)> {
+    let path = PathBuf::from(value);
+    let filename = path.file_name()?.to_string_lossy().into_owned();
+    let dir = match path.parent() {
+        Some(p) if !p.as_os_str().is_empty() => p.to_path_buf(),
+        // None (root) or empty (bare filename) → CWD.
+        _ => PathBuf::from("."),
+    };
+    Some((dir, filename))
+}
+
+/// Prepare the serve-mode log directory, returning the resolved path on
+/// success or the underlying `io::Error` on failure.
+///
+/// Extracted so the caller can `eprintln!` a visible warning when the
+/// daemon's log directory cannot be created — a silent fallback would
+/// leave operators wondering why `<home>/logs/serve.log` never appears.
+fn prepare_serve_log_dir(serve_home: &Path) -> std::io::Result<PathBuf> {
+    let logs_dir = boxlite::runtime::layout::FilesystemLayout::logs_dir_for(serve_home);
+    std::fs::create_dir_all(&logs_dir)?;
+    Ok(logs_dir)
+}
+
+/// Build an optional JSON file-logging layer with its own filter.
+///
+/// Two paths to enabling a file sink:
+///   1. Explicit: `BOXLITE_LOG_FILE=/path/to/log` (any subcommand, no rotation).
+///      Bare filenames are CWD-relative.
+///   2. Implicit: `boxlite serve` — defaults to `<home>/logs/serve.log` with
+///      daily rotation since the daemon mode is the canonical file-logging case.
+///
+/// The file layer defaults to `info` (richer than stderr's `warn` floor);
+/// `--debug` and `RUST_LOG` override per `build_filter` precedence.
+fn build_file_layer<S>(
+    serve_home: Option<&Path>,
+    serve_mode: bool,
+    debug: bool,
+    rust_log: Option<&str>,
+) -> Option<Box<dyn Layer<S> + Send + Sync + 'static>>
+where
+    S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+{
+    let writer = if let Some(path_str) = std::env::var("BOXLITE_LOG_FILE")
+        .ok()
+        .filter(|p| !p.is_empty())
+    {
+        let (dir, filename) = resolve_explicit_log_path(&path_str)?;
+        // Explicit user-set path: silent fallback is defensible (the user
+        // chose this path; if it's unwritable, that's their immediate
+        // problem and stderr logging continues).
+        std::fs::create_dir_all(&dir).ok()?;
+        let appender = tracing_appender::rolling::never(dir, filename);
+        let (non_blocking, guard) = tracing_appender::non_blocking(appender);
+        let _ = FILE_LOG_GUARD.set(guard);
+        non_blocking
+    } else if serve_mode {
+        let home_dir = serve_home?;
+        // Serve-mode daemon: fail loudly. A silent skip here is the exact
+        // operational footgun that motivates file logging in the first
+        // place (long-lived daemon, no terminal scrollback to recover).
+        let logs_dir = match prepare_serve_log_dir(home_dir) {
+            Ok(p) => p,
+            Err(err) => {
+                eprintln!(
+                    "warning: could not create log dir {}: {}; serve logs will be stderr only",
+                    boxlite::runtime::layout::FilesystemLayout::logs_dir_for(home_dir).display(),
+                    err,
+                );
+                return None;
+            }
+        };
+        let appender = tracing_appender::rolling::daily(&logs_dir, "serve.log");
+        let (non_blocking, guard) = tracing_appender::non_blocking(appender);
+        let _ = FILE_LOG_GUARD.set(guard);
+        non_blocking
+    } else {
+        return None;
+    };
+
+    Some(
+        fmt::layer()
+            .json()
+            .with_writer(writer)
+            .with_ansi(false)
+            .with_filter(build_filter(debug, "info", rust_log))
+            .boxed(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `--debug` overrides `RUST_LOG` (docker-style precedence). A stale
+    /// ambient `RUST_LOG=warn` must not nullify an explicit `--debug` flag.
+    ///
+    /// Pure: `build_filter` takes the env snapshot as a parameter, so this
+    /// test is order-independent under parallel execution (no global env
+    /// mutation, no cross-test races).
+    #[test]
+    fn build_filter_debug_flag_overrides_rust_log_env() {
+        let filter = build_filter(true, "warn", Some("warn"));
+        // EnvFilter's Display renders the directive set; "debug" indicates
+        // the flag won over the ambient env.
+        assert_eq!(filter.to_string(), "debug");
+    }
+
+    /// `RUST_LOG` wins over the per-layer default when `--debug` is unset.
+    #[test]
+    fn build_filter_rust_log_overrides_default_when_no_debug() {
+        let filter = build_filter(false, "warn", Some("error"));
+        assert_eq!(filter.to_string(), "error");
+    }
+
+    /// No `RUST_LOG` value falls through to the per-layer default.
+    #[test]
+    fn build_filter_falls_back_to_default_when_no_rust_log() {
+        let filter = build_filter(false, "warn", None);
+        assert_eq!(filter.to_string(), "warn");
+        let filter_empty = build_filter(false, "warn", Some(""));
+        assert_eq!(filter_empty.to_string(), "warn");
+    }
+
+    /// `BOXLITE_LOG_FILE=boxlite.log` (no directory component) must resolve
+    /// to `(., boxlite.log)` so the file lands in the working directory
+    /// rather than being silently dropped.
+    #[test]
+    fn resolve_explicit_log_path_bare_filename_is_cwd_relative() {
+        let (dir, filename) = resolve_explicit_log_path("boxlite.log")
+            .expect("bare filename should resolve, not be dropped");
+        assert_eq!(dir, PathBuf::from("."));
+        assert_eq!(filename, "boxlite.log");
+    }
+
+    #[test]
+    fn resolve_explicit_log_path_absolute_path_splits_correctly() {
+        let (dir, filename) = resolve_explicit_log_path("/tmp/boxlite/app.log").unwrap();
+        assert_eq!(dir, PathBuf::from("/tmp/boxlite"));
+        assert_eq!(filename, "app.log");
+    }
+
+    #[test]
+    fn resolve_explicit_log_path_relative_path_splits_correctly() {
+        let (dir, filename) = resolve_explicit_log_path("logs/app.log").unwrap();
+        assert_eq!(dir, PathBuf::from("logs"));
+        assert_eq!(filename, "app.log");
+    }
+
+    /// `prepare_serve_log_dir` must surface an `io::Error` when the home
+    /// directory cannot host a `logs/` subdir. Caller uses the error to
+    /// emit a visible warning instead of silently dropping file logs.
+    #[test]
+    fn prepare_serve_log_dir_surfaces_mkdir_error() {
+        // `/dev/null` is a character device on Linux/macOS — creating a
+        // subdir under it must fail at the OS level, giving us an Err to
+        // assert on without needing chmod / mock filesystems.
+        let home = PathBuf::from("/dev/null");
+        let result = prepare_serve_log_dir(&home);
+        assert!(
+            result.is_err(),
+            "creating logs/ under /dev/null must fail, got Ok({:?})",
+            result.ok(),
+        );
+    }
+
+    /// Happy path: `prepare_serve_log_dir` creates `<home>/logs` and
+    /// returns its absolute path.
+    #[test]
+    fn prepare_serve_log_dir_creates_and_returns_logs_subdir() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let logs_dir =
+            prepare_serve_log_dir(tmp.path()).expect("mkdir on writable tempdir should succeed");
+        assert_eq!(logs_dir, tmp.path().join("logs"));
+        assert!(logs_dir.is_dir(), "logs dir should exist after mkdir");
+    }
 }


### PR DESCRIPTION
## Summary

- Library no longer auto-installs a tracing subscriber. `boxlite::init_logging_for(home_dir)` is an opt-in helper that the SDK FFI shims (Python / Node / C) call explicitly, matching the wasmtime C-API / swc NAPI pattern (FFI boundary auto-installs via `try_init` so a host-installed subscriber short-circuits).
- CLI installs its own layered subscriber: stderr `warn` (peer-CLI quiet — was `info`, which pinned an ENA NIC under nextest stderr capture on the shared CI runner) + optional JSON file layer at `info`. File sink enabled by `BOXLITE_LOG_FILE` (any subcommand) or implicitly by `boxlite serve` (daily-rolling `<home>/logs/serve.log`).
- Docker-style precedence: `--debug` > `RUST_LOG` > per-layer default. Previously `RUST_LOG=warn boxlite --debug list` silently suppressed debug events because the env filter won over the explicit flag.
- `FilesystemLayout::logs_dir_for(home_dir)` collapses the logs dir name back to one place (it was hardcoded `"logs"` in two paths after the helper's signature changed from `&FilesystemLayout` to `&Path`).

## Test plan

- [x] `cargo test -p boxlite-cli --bin boxlite -- tests::` — 86 unit tests pass including 8 new (precedence x3, path resolution x3, prepare_serve_log_dir x2). Tests are pure (filter values passed as parameters) so they're order-independent under parallel execution.
- [x] `cargo check -p boxlite -p boxlite-cli` clean
- [ ] `RUST_LOG=warn boxlite --debug list` emits DEBUG events to stderr (regression case D)
- [ ] `BOXLITE_LOG_FILE=/tmp/test.log boxlite list` writes JSON to `/tmp/test.log`
- [ ] `BOXLITE_LOG_FILE=foo.log boxlite list` writes to `./foo.log` (bare filename resolution)
- [ ] `boxlite serve` creates `<home>/logs/serve.log` with daily rotation
- [ ] SDK smoke: Python / Node / C bindings still write `<home>/logs/boxlite.log` via the explicit `init_logging_for` calls