### PR TITLE
fix(go-sdk): fold stream drain into Execution.Wait (os/exec io.Writer case)

### DIFF
--- a/sdks/go/exec.go
+++ b/sdks/go/exec.go
@@ -92,6 +92,16 @@ type executionStreamState struct {
 	onStderr func([]byte)
 
 	released atomic.Bool
+
+	// drained is the os/exec `goroutineErr` analog: closed by
+	// deliverExit when the C-side on_exit callback fires. C's exit_pump
+	// gates Exit on every stream pump's done_tx, so by the time on_exit
+	// runs, the drain goroutine has already dispatched every
+	// Stdout/Stderr callback for this execution. Execution.Wait blocks
+	// on this after the reap so a caller using buffered Stdout/Stderr
+	// sinks never sees a truncated buffer. The fold happens at the SDK
+	// boundary; the C-side Wait task stays decoupled from streams.
+	drained chan struct{}
 }
 
 func newExecutionStreamState(opts ExecutionOptions) *executionStreamState {
@@ -100,6 +110,7 @@ func newExecutionStreamState(opts ExecutionOptions) *executionStreamState {
 		stderr:   opts.Stderr,
 		onStdout: opts.OnStdout,
 		onStderr: opts.OnStderr,
+		drained:  make(chan struct{}),
 	}
 }
 
@@ -137,6 +148,7 @@ func (s *executionStreamState) deliverStderr(data []byte) {
 
 func (s *executionStreamState) deliverExit(_ int) {
 	s.released.Store(true)
+	close(s.drained)
 }
 
 func (s *executionStreamState) markReleased() {
@@ -181,6 +193,15 @@ func (b *Box) Exec(ctx context.Context, name string, arg ...string) (*ExecResult
 	exitCode, err := execution.Wait(ctx)
 	if err != nil {
 		return nil, err
+	}
+	// Wait reaps only; the Stdout/Stderr bytesCollectors we read below
+	// are not guaranteed complete until on_exit fires (which the C
+	// exit_pump gates on every stream pump's done_tx). Wrappers that
+	// own buffered sinks compose the drain at this boundary.
+	select {
+	case <-execution.streamState.drained:
+	case <-execution.closing:
+		return nil, ErrRuntimeClosed
 	}
 
 	return &ExecResult{
@@ -286,12 +307,28 @@ func (e *Execution) Write(p []byte) (int, error) {
 	return e.Stdin.Write(p)
 }
 
-// Wait waits for the command to finish and returns its exit code.
+// Wait reaps the process and returns its exit code. This is the bare
+// "process exited" terminal — it does NOT block on stream pump
+// completion, so a caller using a buffered Stdout/Stderr io.Writer
+// sink may observe a truncated buffer right after Wait returns.
 //
-// boxlite_execution_wait runs as its own async task on the C side and
-// pushes a wait completion event into the runtime queue, dispatched here
-// by the drain goroutine.
+// The callback ordering contract holds: the C side's exit_pump gates
+// the on_exit callback on every stream pump's done_tx, so a caller
+// using OnStdout/OnStderr callbacks naturally sees every chunk before
+// the executionStreamState.drained signal closes.
+//
+// For "whole exec done including output buffers", use Cmd.Run /
+// box.Exec — they compose reap + stream drain at the wrapper
+// boundary where the buffered sinks are owned.
 func (e *Execution) Wait(ctx context.Context) (int, error) {
+	return e.reap(ctx)
+}
+
+// reap is os/exec's Process.Wait analog: it kicks the C
+// boxlite_execution_wait task and blocks on its result, with ctx and
+// runtime-shutdown escapes. Decoupled from stream drain — caller (Wait)
+// composes the drain step.
+func (e *Execution) reap(ctx context.Context) (int, error) {
 	if e.handle == nil {
 		return 0, &Error{Code: ErrInvalidState, Message: "execution is closed"}
 	}
@@ -300,8 +337,7 @@ func (e *Execution) Wait(ctx context.Context) (int, error) {
 	h := registerHandleForDispatch(cgo.NewHandle(ch))
 
 	var cerr C.CBoxliteError
-	code := C.boxlite_execution_wait(e.handle, C.cbExecutionWait(), handleToPtr(h), &cerr)
-	if code != C.Ok {
+	if rc := C.boxlite_execution_wait(e.handle, C.cbExecutionWait(), handleToPtr(h), &cerr); rc != C.Ok {
 		deleteHandleForDispatch(h)
 		return 0, freeError(&cerr)
 	}
@@ -526,6 +562,16 @@ func (c *Cmd) Run(ctx context.Context) error {
 	exitCode, err := execution.Wait(ctx)
 	if err != nil {
 		return err
+	}
+	// Wait reaps only; c.Stdout / c.Stderr (caller-supplied io.Writer
+	// sinks) are not guaranteed complete until on_exit fires (which
+	// the C exit_pump gates on every stream pump's done_tx). Cmd.Run
+	// composes the drain at the wrapper boundary so the caller can
+	// read their sink immediately after Run returns.
+	select {
+	case <-execution.streamState.drained:
+	case <-execution.closing:
+		return ErrRuntimeClosed
 	}
 
 	c.exitCode = exitCode

--- a/sdks/go/exec.go
+++ b/sdks/go/exec.go
@@ -98,9 +98,10 @@ type executionStreamState struct {
 	// gates Exit on every stream pump's done_tx, so by the time on_exit
 	// runs, the drain goroutine has already dispatched every
 	// Stdout/Stderr callback for this execution. Execution.Wait blocks
-	// on this after the reap so a caller using buffered Stdout/Stderr
-	// sinks never sees a truncated buffer. The fold happens at the SDK
-	// boundary; the C-side Wait task stays decoupled from streams.
+	// on this after the process's exit code has been collected, so a
+	// caller using buffered Stdout/Stderr sinks never sees a truncated
+	// buffer. The fold happens at the SDK boundary; the C-side Wait
+	// task stays decoupled from streams.
 	drained chan struct{}
 }
 
@@ -298,7 +299,7 @@ func (e *Execution) Write(p []byte) (int, error) {
 	return e.Stdin.Write(p)
 }
 
-// Wait reaps the process and blocks until every stdout/stderr
+// Wait blocks until the process has exited AND every stdout/stderr
 // callback for this execution has been dispatched, then returns the
 // exit code. Mirrors os/exec.Cmd's Wait for the io.Writer case —
 // every BoxLite execution IS the io.Writer case (streams are pushed
@@ -306,27 +307,11 @@ func (e *Execution) Write(p []byte) (int, error) {
 // user-read pipe), so Wait is the single terminal and must guarantee
 // output completeness on return.
 //
-// The post-reap drain is non-cancelable by ctx (parity with os/exec's
-// awaitGoroutines); only runtime shutdown breaks it, in which case
-// the reap's exit code is preserved and err is overwritten only if
-// the reap had none.
+// The post-exit-code drain is non-cancelable by ctx (parity with
+// os/exec's awaitGoroutines); only runtime shutdown breaks it, in
+// which case the process's exit code is preserved and err is
+// overwritten only if the wait had none.
 func (e *Execution) Wait(ctx context.Context) (int, error) {
-	code, err := e.reap(ctx)
-	select {
-	case <-e.streamState.drained:
-	case <-e.closing:
-		if err == nil {
-			err = ErrRuntimeClosed
-		}
-	}
-	return code, err
-}
-
-// reap is os/exec's Process.Wait analog: it kicks the C
-// boxlite_execution_wait task and blocks on its result, with ctx and
-// runtime-shutdown escapes. Decoupled from stream drain — caller (Wait)
-// composes the drain step.
-func (e *Execution) reap(ctx context.Context) (int, error) {
 	if e.handle == nil {
 		return 0, &Error{Code: ErrInvalidState, Message: "execution is closed"}
 	}
@@ -340,16 +325,35 @@ func (e *Execution) reap(ctx context.Context) (int, error) {
 		return 0, freeError(&cerr)
 	}
 
+	var code int
+	var err error
 	select {
 	case res := <-ch:
-		return res.exitCode, res.err
+		code, err = res.exitCode, res.err
 	case <-ctx.Done():
+		// ctx cancel before the process reports exit: skip the
+		// drain barrier (consistent with os/exec's behavior on
+		// Process.Wait cancellation).
 		drainAndDelete(ch, h, e.closing)
 		return 0, ctx.Err()
 	case <-e.closing:
 		drainAndDelete(ch, h, e.closing)
 		return 0, ErrRuntimeClosed
 	}
+
+	// Drain barrier: wait for stream pumps to flush before returning,
+	// so the caller's stdout/stderr Writers see every chunk the exec
+	// produced. Non-cancelable by ctx — only runtime shutdown breaks
+	// it. Preserves the exit code from the wait result; overwrites
+	// err only if the wait itself had none.
+	select {
+	case <-e.streamState.drained:
+	case <-e.closing:
+		if err == nil {
+			err = ErrRuntimeClosed
+		}
+	}
+	return code, err
 }
 
 // Kill terminates the running command.

--- a/sdks/go/exec.go
+++ b/sdks/go/exec.go
@@ -194,15 +194,6 @@ func (b *Box) Exec(ctx context.Context, name string, arg ...string) (*ExecResult
 	if err != nil {
 		return nil, err
 	}
-	// Wait reaps only; the Stdout/Stderr bytesCollectors we read below
-	// are not guaranteed complete until on_exit fires (which the C
-	// exit_pump gates on every stream pump's done_tx). Wrappers that
-	// own buffered sinks compose the drain at this boundary.
-	select {
-	case <-execution.streamState.drained:
-	case <-execution.closing:
-		return nil, ErrRuntimeClosed
-	}
 
 	return &ExecResult{
 		ExitCode: exitCode,
@@ -307,21 +298,28 @@ func (e *Execution) Write(p []byte) (int, error) {
 	return e.Stdin.Write(p)
 }
 
-// Wait reaps the process and returns its exit code. This is the bare
-// "process exited" terminal — it does NOT block on stream pump
-// completion, so a caller using a buffered Stdout/Stderr io.Writer
-// sink may observe a truncated buffer right after Wait returns.
+// Wait reaps the process and blocks until every stdout/stderr
+// callback for this execution has been dispatched, then returns the
+// exit code. Mirrors os/exec.Cmd's Wait for the io.Writer case —
+// every BoxLite execution IS the io.Writer case (streams are pushed
+// to a user-supplied Writer / callback; there is no StdoutPipe-style
+// user-read pipe), so Wait is the single terminal and must guarantee
+// output completeness on return.
 //
-// The callback ordering contract holds: the C side's exit_pump gates
-// the on_exit callback on every stream pump's done_tx, so a caller
-// using OnStdout/OnStderr callbacks naturally sees every chunk before
-// the executionStreamState.drained signal closes.
-//
-// For "whole exec done including output buffers", use Cmd.Run /
-// box.Exec — they compose reap + stream drain at the wrapper
-// boundary where the buffered sinks are owned.
+// The post-reap drain is non-cancelable by ctx (parity with os/exec's
+// awaitGoroutines); only runtime shutdown breaks it, in which case
+// the reap's exit code is preserved and err is overwritten only if
+// the reap had none.
 func (e *Execution) Wait(ctx context.Context) (int, error) {
-	return e.reap(ctx)
+	code, err := e.reap(ctx)
+	select {
+	case <-e.streamState.drained:
+	case <-e.closing:
+		if err == nil {
+			err = ErrRuntimeClosed
+		}
+	}
+	return code, err
 }
 
 // reap is os/exec's Process.Wait analog: it kicks the C
@@ -562,16 +560,6 @@ func (c *Cmd) Run(ctx context.Context) error {
 	exitCode, err := execution.Wait(ctx)
 	if err != nil {
 		return err
-	}
-	// Wait reaps only; c.Stdout / c.Stderr (caller-supplied io.Writer
-	// sinks) are not guaranteed complete until on_exit fires (which
-	// the C exit_pump gates on every stream pump's done_tx). Cmd.Run
-	// composes the drain at the wrapper boundary so the caller can
-	// read their sink immediately after Run returns.
-	select {
-	case <-execution.streamState.drained:
-	case <-execution.closing:
-		return ErrRuntimeClosed
 	}
 
 	c.exitCode = exitCode

--- a/sdks/go/exec_integration_test.go
+++ b/sdks/go/exec_integration_test.go
@@ -114,3 +114,47 @@ func TestIntegrationExecEnvWorkingDirTimeout(t *testing.T) {
 		}
 	})
 }
+
+// TestIntegrationExecStdoutRace asserts that Execution.Wait does not
+// return until every stdout chunk has been delivered to the user's sink
+// — i.e. the drain barrier introduced for #563 holds. Pre-fix, the C
+// Wait task was decoupled from the stream pumps, so a short command
+// could push its Wait queue event before the late Stdout chunks landed,
+// and Cmd.Run would return with a truncated buffer. The pre-existing
+// `TestIntegrationExecEnvWorkingDirTimeout` papers over this with a
+// `&& sleep 0.1` pad on every command (see drainPad). This test
+// deliberately does NOT pad the command — that's the whole point.
+//
+// Repeated rounds because the race is timing-sensitive: a single
+// fast/lucky run can mask it. ROUNDS=20 has caught the regression
+// reliably on this machine.
+func TestIntegrationExecStdoutRace(t *testing.T) {
+	rt := newTestRuntime(t)
+	box := createStartedBoxOrSkip(t, rt, "alpine:latest", WithAutoRemove(false))
+
+	const rounds = 20
+	const want = "marker-line\n"
+	var truncated int
+	for i := 0; i < rounds; i++ {
+		cmd := box.Command("sh", "-c", "echo marker-line")
+		var buf bytes.Buffer
+		cmd.Stdout = &buf
+		if err := cmd.Run(context.Background()); err != nil {
+			t.Fatalf("round %d: Cmd.Run: %v", i, err)
+		}
+		if buf.String() != want {
+			truncated++
+			t.Logf("round %d: stdout=%q (want %q)", i, buf.String(), want)
+		}
+	}
+	if truncated > 0 {
+		t.Fatalf(
+			"Cmd.Run returned before %d/%d stdout deliveries — the "+
+				"#563 race regressed. Either Cmd.Run's post-Wait drain "+
+				"select (<-streamState.drained) was removed, or the "+
+				"C-side exit_pump no longer awaits the stream_done_rx "+
+				"oneshots that close that channel.",
+			truncated, rounds,
+		)
+	}
+}

--- a/sdks/go/exec_integration_test.go
+++ b/sdks/go/exec_integration_test.go
@@ -149,9 +149,10 @@ func TestIntegrationExecStdoutRace(t *testing.T) {
 	}
 	if truncated > 0 {
 		t.Fatalf(
-			"Cmd.Run returned before %d/%d stdout deliveries — the "+
-				"#563 race regressed. Either Cmd.Run's post-Wait drain "+
-				"select (<-streamState.drained) was removed, or the "+
+			"Execution.Wait returned before %d/%d stdout deliveries — "+
+				"the #563 race regressed. Either Execution.Wait's "+
+				"post-reap drain step (<-streamState.drained, the "+
+				"os/exec awaitGoroutines analog) was removed, or the "+
 				"C-side exit_pump no longer awaits the stream_done_rx "+
 				"oneshots that close that channel.",
 			truncated, rounds,


### PR DESCRIPTION
## Bug

Go SDK's `box.Exec` / `Cmd.Run` / `Execution.Wait` returns with stdout chunks still in flight — the caller reads a buffered Stdout sink before the trailing stream callbacks have delivered them.

- Stock pre-fix: 18-26 / 50 truncated (also `test_p0_6_exec_stdout_race.py`).
- This commit: 50/50 complete.

## Fix (Go-only, no new API, no C FFI changes)

Mirror `os/exec.Cmd.Wait`'s `Process.Wait` → `awaitGoroutines` sequence inside `Execution.Wait`. BoxLite's streams are always pushed into a user-supplied `Writer` / callback — there is no `StdoutPipe`-style user-read pipe — so every `Execution` IS `os/exec`'s **io.Writer case**, and `Wait` is the single terminal that must guarantee output completeness on return.

| Layer | Behavior |
|---|---|
| `Execution.Wait` | Reap (`e.reap(ctx)`) → block on `<-streamState.drained` (the `awaitGoroutines` analog) → return. Non-cancelable by ctx during drain (os/exec parity); only runtime shutdown breaks it. |
| Callback ordering | C-side `exit_pump` gates `on_exit` on every stream pump's `done_tx`. Go-side `deliverExit` closes the private `executionStreamState.drained` channel. So by the time `Wait` unblocks, every `OnStdout` / `OnStderr` callback (and every `io.Writer.Write`) has fired. |
| `Cmd.Run` / `box.Exec` | Just call `Execution.Wait` — no extra drain. The strong contract lives in one place. |

C FFI untouched.

## Two-side verification

`sdks/go/exec_integration_test.go::TestIntegrationExecStdoutRace` runs `echo marker-line` 20× via `Cmd.Run` without the `&& sleep 0.1` drainPad workaround that the existing `TestIntegrationExecEnvWorkingDirTimeout` uses.

| Side | `Execution.Wait` drain | Result |
|---|---|---|
| A | removed (Wait = pure reap) | 4/20 truncated to `""`, **FAIL** |
| B (this PR) | present | 20/20 complete, **PASS** |

§5 no-regression suite green: `HandleDeletedOnExit`, `NoDoubleDeleteRaceDuringClose`, `AbandonAsync*` (×6), `DrainAndDelete*` (×3), `ClaimOrFreePayload_*` (×2).

E2E (`test_p0_6_exec_stdout_race.py`) passes both sides — the Python path goes through the runner's `streamBus`, which buffers stdout in backlog regardless of close ordering, so it doesn't surface the race. The Go SDK direct test path does.

## Supersedes

#685 — same bug, C FFI `streams_pending` approach (couples Wait with streams at FFI). Closed in favor of this Go-only fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)