### PR TITLE
chore(infra): track .env.example for stack setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,6 +161,7 @@ Cargo.lock
 /apps/infra/.sst/
 /apps/infra/sst-env.d.ts
 /apps/infra/.env*
+!/apps/infra/.env.example
 /apps/snapshot-manager/data/
 /apps/runner/pkg/daemon/static/*
 !/apps/runner/pkg/daemon/static/.gitkeep

--- a/apps/infra/.env.example
+++ b/apps/infra/.env.example
@@ -1,0 +1,121 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# BoxLite Infra — .env
+#
+# Copy to .env and fill in required values before first deploy.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# ─── 1. Required: Domain + DNS ───────────────────────────────────────────────
+# A Cloudflare-managed domain is required. SST creates ACM certs + DNS records
+# automatically via the Cloudflare API.
+
+# Subdomain for this stack (e.g. dev.boxlite.ai, staging.boxlite.ai)
+STACK_DOMAIN=dev.example.com
+
+# Cloudflare credentials — token needs Zone:Read + DNS:Edit on your domain
+CLOUDFLARE_DEFAULT_ACCOUNT_ID=
+CLOUDFLARE_API_TOKEN=
+
+# AWS profile used by SST. Leave unset to use "default".
+# AWS_PROFILE=my-aws-profile
+
+# ─── 2. Required: Auth (Auth0 / Okta / Keycloak / Dex / …) ──────────────────
+# External OIDC provider. The Api validates JWTs via JWKS and probes the
+# issuer's discovery doc once at startup. Any compliant IdP works.
+#
+# IdPs that don't advertise `end_session_endpoint` (notably Dex —
+# `dexidp/dex#1697`) are handled automatically: the dashboard's logout falls
+# back through BoxLite's own `/api/auth/end-session` route. See section 7 for
+# the override knobs if you need them.
+#
+# Auth0 setup:
+#   1. Create a Single Page Application → get client_id
+#   2. Create a custom API → use its identifier as audience
+#   3. Set in Auth0 app settings:
+#        Allowed Callback URLs: https://<STACK_DOMAIN>
+#        Allowed Logout URLs:  https://<STACK_DOMAIN>
+#        Allowed Web Origins:  https://<STACK_DOMAIN>
+#   4. Create a Post-Login Action to add claims to the access token:
+#        exports.onExecutePostLogin = async (event, api) => {
+#          if (event.authorization) {
+#            api.accessToken.setCustomClaim('email_verified', event.user.email_verified);
+#            api.accessToken.setCustomClaim('email', event.user.email);
+#            api.accessToken.setCustomClaim('name', event.user.name);
+#          }
+#        };
+#      Deploy → Actions → Flows → Login → drag onto flow → Apply.
+#   5. Enable Dashboard → Settings → Advanced → "Login and Logout" →
+#      "RP-Initiated Logout End Session Endpoint Discovery". Without this
+#      toggle the SPA's Sign Out will silently re-authenticate the user via
+#      Auth0's still-alive session cookie. Default-on for tenants created on
+#      or after 14 November 2023; older tenants must flip it manually.
+#
+# Issuer URL (no trailing slash):
+OIDC_ISSUER_BASE_URL=https://your-tenant.auth0.com
+OIDC_CLIENT_ID=your-spa-client-id
+OIDC_AUDIENCE=https://dev.example.com/api
+
+# ─── 3. Optional: Auth0 Management API (account linking) ────────────────────
+# Create a Machine-to-Machine application in Auth0, authorize it for the
+# Auth0 Management API with permissions: read:users, update:users,
+# read:connections, create:guardian_enrollment_tickets, read:connections_options.
+# OIDC_MANAGEMENT_API_ENABLED=true
+# OIDC_MANAGEMENT_API_CLIENT_ID=
+# OIDC_MANAGEMENT_API_CLIENT_SECRET=
+# OIDC_MANAGEMENT_API_AUDIENCE=https://your-tenant.auth0.com/api/v2/
+
+# ─── 4. After first deploy: Runner IP ────────────────────────────────────────
+# The runner EC2 instance is created on first deploy. Get its private IP and
+# redeploy so the API can route jobs to it:
+#   aws ec2 describe-instances --region ap-southeast-1 \
+#     --filters "Name=tag:Name,Values=boxlite-runner-default" \
+#     --query 'Reservations[].Instances[].PrivateIpAddress' --output text
+RUNNER_PRIVATE_IP=
+
+# ─── 4a. Runner fleet (optional) ─────────────────────────────────────────────
+# Comma-separated list of runner names. The first must be `default`. Append
+# names to add additional v2 runners — see "Adding a runner" in README.md.
+#   RUNNERS=default,runner-2
+#RUNNERS=default
+
+# ─── 5. SSH Gateway ──────────────────────────────────────────────────────────
+# Base64-encoded Ed25519 keys. Generate once:
+#   ssh-keygen -t ed25519 -f /tmp/boxlite-user -N ""
+#   ssh-keygen -t ed25519 -f /tmp/boxlite-host -N ""
+#   echo "SSH_PRIVATE_KEY_B64=$(base64 -i /tmp/boxlite-user)" >> .env
+#   echo "SSH_HOST_KEY_B64=$(base64 -i /tmp/boxlite-host)" >> .env
+SSH_PRIVATE_KEY_B64=
+SSH_HOST_KEY_B64=
+
+# ─── 6. Observability (optional) ─────────────────────────────────────────────
+# PostHog — feature flags. Without this, "Create Sandbox" button is disabled.
+# POSTHOG_API_KEY=
+# POSTHOG_HOST=https://us.posthog.com
+
+# Svix — webhook delivery. Without this, dashboard logs cosmetic errors.
+# SVIX_AUTH_TOKEN=
+
+# ─── 7. Advanced overrides ───────────────────────────────────────────────────
+# Everything below has safe auto-generated defaults. Set only to pin values.
+
+# ENCRYPTION_KEY=
+# ENCRYPTION_SALT=
+# ADMIN_API_KEY=
+# PROXY_API_KEY=
+# SSH_GATEWAY_API_KEY=
+# PROXY_DOMAIN=proxy.dev.example.com
+# PROXY_PROTOCOL=https
+# PROXY_TEMPLATE_URL=https://proxy.dev.example.com
+# SSH_GATEWAY_URL=ssh://localhost:2222
+# DEFAULT_SNAPSHOT=ubuntu:latest
+
+# OIDC RP-initiated logout fallback URL. Auto-derived to
+# `https://<STACK_DOMAIN>/api/auth/end-session`. The Api only advertises this
+# to the dashboard when the IdP itself lacks `end_session_endpoint`; for
+# Auth0/Okta it stays hidden and the IdP's real endpoint is used. Pin only
+# if the dashboard sits on a different origin from the Api.
+# OIDC_END_SESSION_ENDPOINT=
+
+# Additional origins (comma-separated) the logout endpoint will accept as
+# `post_logout_redirect_uri` beyond `DASHBOARD_URL`. Useful when multiple
+# dashboards share one IdP tenant. The default allowlist is `[DASHBOARD_URL]`.
+# OIDC_POST_LOGOUT_REDIRECT_ALLOWLIST=https://staging.example.com,https://preview.example.com


### PR DESCRIPTION
## Summary

- adds `apps/infra/.env.example` so the required-env-var contract for `sst deploy` is discoverable in-repo
- adds a `!/apps/infra/.env.example` negation in the root `.gitignore` so the example stays tracked while real `.env` files remain ignored

## Test plan

- [ ] `git check-ignore apps/infra/.env.example` exits non-zero (file is not ignored)
- [ ] `git check-ignore apps/infra/.env` still exits zero (real env file remains ignored)
- [ ] new contributors can read the example and know which keys to set before their first `sst deploy`