### PR TITLE
feat: opt-in --support-docker for running dockerd inside a box

### DIFF
--- a/make/build.mk
+++ b/make/build.mk
@@ -1,4 +1,4 @@
-PHONY_TARGETS += guest shim runtime cli cli\:release skillbox-image build\:apps
+PHONY_TARGETS += guest shim runtime cli cli\:release skillbox-image build\:apps libkrunfw-dind
 
 guest:
 	@bash $(SCRIPT_DIR)/build/build-guest.sh
@@ -29,6 +29,28 @@ build\:apps: _ensure-apps-deps
 	@echo "🔨 Building apps workspace..."
 	@cd apps && yarn build
 	@echo "✅ apps workspace built → dist/apps"
+
+# Build the "fat" libkrunfw variant required by `boxlite run --support-docker`
+# (issue #276): the lean default kernel lacks CONFIG_BRIDGE/NETFILTER/NF_NAT/
+# IPTABLE_*/NF_TABLES, which docker / docker-compose need for bridge networks,
+# NAT and iptables rule installation. This target builds a second libkrunfw
+# blob with those configs added on top of the lean config, and copies it to
+#
+#     target/dind-kernel/lib64/libkrunfw-dind.so.5
+#
+# Wire-up: the libkrun-sys build.rs picks this blob up via the
+# BOXLITE_LIBKRUNFW_DIND_PATH environment variable (set automatically by this
+# target when invoking downstream builds in the same shell). Without this
+# target ever being run, `--support-docker` still applies the userspace
+# changes (cgroup rw + full caps) but the kernel stays lean, so bridge /
+# iptables-dependent features keep failing. With it run + the env var set,
+# the dind blob is staged alongside the lean one and the runtime picks the
+# right blob per-box.
+#
+# Heavy target (~10–20 min, downloads kernel source). Only run when actively
+# iterating on the dind feature; not in any other target's dep chain.
+libkrunfw-dind:
+	@bash $(SCRIPT_DIR)/build/build-libkrunfw-dind.sh
 
 # Build SkillBox container image (all-in-one AI CLI with noVNC)
 # Usage: make skillbox-image [APT_SOURCE=mirrors.aliyun.com]

--- a/make/test.mk
+++ b/make/test.mk
@@ -153,10 +153,10 @@ test\:integration:
 	@echo ""
 	@echo "✅ Integration test matrix passed"
 
-# Core unit suites: Rust unit + FFI unit.
+# Core unit suites: Rust unit + FFI unit + CLI unit.
 test\:unit\:core:
-	@echo "── Core unit suites (rust, ffi) ──"
-	$(call run_suites,test:unit:rust test:unit:ffi)
+	@echo "── Core unit suites (rust, ffi, cli) ──"
+	$(call run_suites,test:unit:rust test:unit:ffi test:unit:cli)
 
 # Core integration suites: Rust integration + CLI integration.
 test\:integration\:core:
@@ -172,6 +172,19 @@ test\:unit\:sdk:
 test\:integration\:sdk:
 	@echo "── SDK integration suites (python, node, c) ──"
 	$(call run_integration_suites,test:integration:python test:integration:node test:integration:c)
+
+# CLI unit tests (inline `#[cfg(test)]` modules inside the binary crate).
+# `test:integration:cli` uses `--tests` which only picks up `src/cli/tests/`
+# end-to-end suites; the binary-internal unit tests (CLI arg plumbing,
+# parser helpers, ManagementFlags::apply_to) live alongside the code in
+# `src/cli/src/` and need `--bins` to be discovered.
+test\:unit\:cli:
+	@echo "🧪 Running CLI unit tests..."
+	@if command -v cargo-nextest >/dev/null 2>&1; then \
+		cargo nextest run -p boxlite-cli --bins $(NEXTEST_FILTER); \
+	else \
+		cargo test -p boxlite-cli --bins -- --test-threads=4 $(CARGOTEST_FILTER); \
+	fi
 
 # Rust unit tests (parallel via nextest, fallback to serial cargo test).
 # --no-default-features disables gvproxy to avoid Go runtime link issues.

--- a/make/test.mk
+++ b/make/test.mk
@@ -232,25 +232,34 @@ test\:unit\:ffi:
 		cargo test -p boxlite-c $(CARGOTEST_FILTER); \
 	fi
 
-# dind end-to-end: spawn a `--support-docker` box, run `docker build`
-# against a tiny `FROM alpine` Dockerfile, assert the build exits 0 and
-# the image lands in dockerd's store. Heavy (real VM + dind kernel +
-# alpine pull from Docker Hub) and gated behind both:
-#   1. a libkrunfw-dind blob bundled at build time
-#      (`make libkrunfw-dind` then `BOXLITE_LIBKRUNFW_DIND_PATH=... make cli`)
-#   2. the BOXLITE_DIND_TEST=1 env var the target sets
-#
-# Not in the default `test:integration` matrix — most CI hosts won't
-# have the dind blob built. Run explicitly when validating Phase B
-# changes or before cutting a release that claims dind support.
-test\:integration\:dind: $(if $(SETUP_DONE),,runtime\:debug)
-	@echo "🧪 Running dind integration test (requires libkrunfw-dind blob bundled)..."
-	@BOXLITE_DIND_TEST=1 cargo test -p boxlite-cli --test dind_build -- --nocapture
+# Thin alias: dind end-to-end is part of the forced `test:integration:cli`
+# matrix; this target just narrows nextest's filter to that one test for
+# fast iteration. Heavy one-time `make libkrunfw-dind` (~10–20 min, cached
+# after) is required — see test:integration:cli below.
+test\:integration\:dind:
+	@$(MAKE) test:integration:cli FILTER=dind_supports_docker_build
 
-# CLI integration tests.
+# CLI integration tests (forced matrix, including dind end-to-end).
+#
+# Prereq: the libkrunfw-dind blob must already be built locally
+# (`make libkrunfw-dind` once, ~10–20 min kernel build, cached after).
+# This target staples it into the CLI by exporting BOXLITE_LIBKRUNFW_DIND_PATH
+# before cargo rebuilds, so the embedded runtime carries both the lean and
+# the dind libkrunfw blobs and dockerd-in-box runs against the right kernel.
+#
+# Ignore-condition: set BOXLITE_SKIP_DIND_TEST=1 to skip the dind test only
+# (the rest of the CLI integration suite still runs). Use this on hosts that
+# cannot run dind for real (e.g., nested-virt unavailable). Default is RUN.
 test\:integration\:cli: $(if $(SETUP_DONE),,runtime\:debug)
 	@echo "🧪 Running CLI integration tests..."
-	@if command -v cargo-nextest >/dev/null 2>&1; then \
+	@if [ ! -f target/dind-kernel/lib64/libkrunfw-dind.so.5 ]; then \
+		echo "❌ libkrunfw-dind.so.5 not found at target/dind-kernel/lib64/" >&2; \
+		echo "   Build it once with: make libkrunfw-dind   (~10–20 min, cached after)" >&2; \
+		echo "   Or skip just the dind test: BOXLITE_SKIP_DIND_TEST=1 make test:integration:cli" >&2; \
+		exit 1; \
+	fi
+	@export BOXLITE_LIBKRUNFW_DIND_PATH="$$PWD/target/dind-kernel/lib64/libkrunfw-dind.so.5" && \
+	if command -v cargo-nextest >/dev/null 2>&1; then \
 		cargo nextest run -p boxlite-cli --tests --profile vm --no-fail-fast \
 		$(NEXTEST_FILTER); \
 	else \

--- a/make/test.mk
+++ b/make/test.mk
@@ -232,6 +232,21 @@ test\:unit\:ffi:
 		cargo test -p boxlite-c $(CARGOTEST_FILTER); \
 	fi
 
+# dind end-to-end: spawn a `--support-docker` box, run `docker build`
+# against a tiny `FROM alpine` Dockerfile, assert the build exits 0 and
+# the image lands in dockerd's store. Heavy (real VM + dind kernel +
+# alpine pull from Docker Hub) and gated behind both:
+#   1. a libkrunfw-dind blob bundled at build time
+#      (`make libkrunfw-dind` then `BOXLITE_LIBKRUNFW_DIND_PATH=... make cli`)
+#   2. the BOXLITE_DIND_TEST=1 env var the target sets
+#
+# Not in the default `test:integration` matrix — most CI hosts won't
+# have the dind blob built. Run explicitly when validating Phase B
+# changes or before cutting a release that claims dind support.
+test\:integration\:dind: $(if $(SETUP_DONE),,runtime\:debug)
+	@echo "🧪 Running dind integration test (requires libkrunfw-dind blob bundled)..."
+	@BOXLITE_DIND_TEST=1 cargo test -p boxlite-cli --test dind_build -- --nocapture
+
 # CLI integration tests.
 test\:integration\:cli: $(if $(SETUP_DONE),,runtime\:debug)
 	@echo "🧪 Running CLI integration tests..."

--- a/scripts/build/build-libkrunfw-dind.sh
+++ b/scripts/build/build-libkrunfw-dind.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Build the "fat" libkrunfw variant required by `boxlite run --support-docker`.
+#
+# Steps:
+#   1. Resolve target arch (overlay + libkrunfw config are arch-specific)
+#   2. Ensure the libkrunfw submodule is checked out
+#   3. Build the lean config + the dind overlay → patched .config
+#   4. Run `make` inside vendor/libkrunfw to produce a kernel .so
+#   5. Rename SONAME to libkrunfw-dind.so.5 and copy to target/dind-kernel/lib64/
+#   6. Print the env var the caller should set so libkrun-sys/build.rs picks
+#      it up:
+#         export BOXLITE_LIBKRUNFW_DIND_PATH=$(pwd)/target/dind-kernel/lib64/libkrunfw-dind.so.5
+#
+# Why not download a prebuilt: the dind kernel adds ~2 MB of network
+# subsystems on top of the lean kernel. Until upstream boxlite-ai/libkrunfw
+# starts publishing the dind variant in its releases, anyone iterating on
+# `--support-docker` needs to build it locally.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+LIBKRUNFW_SRC="$REPO_ROOT/src/deps/libkrun-sys/vendor/libkrunfw"
+OVERLAY_DIR="$REPO_ROOT/src/deps/libkrun-sys/dind-configs"
+OUT_DIR="$REPO_ROOT/target/dind-kernel/lib64"
+
+ARCH="${ARCH:-$(uname -m)}"
+case "$ARCH" in
+  x86_64)  KCONFIG_NAME="config-libkrunfw_x86_64";  OVERLAY_NAME="overlay-dind_x86_64"  ;;
+  aarch64|arm64) KCONFIG_NAME="config-libkrunfw_aarch64"; OVERLAY_NAME="overlay-dind_aarch64" ;;
+  *) echo "❌ unsupported ARCH=$ARCH (only x86_64 and aarch64 have a dind overlay yet)" >&2; exit 1 ;;
+esac
+
+# ── Sanity ──────────────────────────────────────────────────────────────────
+
+if [ ! -f "$LIBKRUNFW_SRC/Makefile" ]; then
+  echo "❌ libkrunfw submodule not initialised at $LIBKRUNFW_SRC" >&2
+  echo "   Run:  git submodule update --init --recursive src/deps/libkrun-sys/vendor/libkrunfw" >&2
+  exit 1
+fi
+
+LEAN_CONFIG="$LIBKRUNFW_SRC/$KCONFIG_NAME"
+OVERLAY="$OVERLAY_DIR/$OVERLAY_NAME"
+if [ ! -f "$LEAN_CONFIG" ]; then
+  echo "❌ lean config not found: $LEAN_CONFIG" >&2; exit 1
+fi
+if [ ! -f "$OVERLAY" ]; then
+  echo "❌ dind overlay not found: $OVERLAY" >&2; exit 1
+fi
+
+# ── Build a merged config in a tempfile ─────────────────────────────────────
+#
+# Append the overlay to the lean config. The overlay's `CONFIG_X=y` lines
+# OVERRIDE the lean config's `# CONFIG_X is not set` lines because Kconfig
+# parses sequentially. `make olddefconfig` (run by libkrunfw's own Makefile)
+# fills in any dependent options that newly-enabled parents require.
+MERGED_CONFIG="$(mktemp)"
+trap 'rm -f "$MERGED_CONFIG"' EXIT
+cat "$LEAN_CONFIG" "$OVERLAY" > "$MERGED_CONFIG"
+
+# Replace the lean config in place so libkrunfw's Makefile (which always
+# reads $KCONFIG_NAME) picks up the merged one. Restore on exit so the
+# normal lean build path isn't permanently changed.
+LEAN_BACKUP="$(mktemp)"
+trap 'rm -f "$MERGED_CONFIG" "$LEAN_BACKUP"; cp -f "$LEAN_BACKUP" "$LEAN_CONFIG" 2>/dev/null || true' EXIT
+cp "$LEAN_CONFIG" "$LEAN_BACKUP"
+cp "$MERGED_CONFIG" "$LEAN_CONFIG"
+
+# ── Build ───────────────────────────────────────────────────────────────────
+
+echo "🔨 Building libkrunfw with dind overlay ($ARCH)..."
+echo "   lean cfg:    $LEAN_CONFIG"
+echo "   overlay:     $OVERLAY"
+echo "   merged size: $(wc -l < "$MERGED_CONFIG") lines"
+
+cd "$LIBKRUNFW_SRC"
+# `make` here triggers the full upstream libkrunfw build:
+#   - downloads kernel.org tarball if missing
+#   - applies libkrunfw patches
+#   - copies our merged $KCONFIG_NAME to linux-<ver>/.config
+#   - runs make olddefconfig + bzImage
+#   - bundles into libkrunfw.so.<ABI>
+make -j"$(nproc)" MAKEFLAGS=""
+
+# ── Stage the result ────────────────────────────────────────────────────────
+
+mkdir -p "$OUT_DIR"
+
+# libkrunfw's Makefile produces libkrunfw.so.5.<minor>.<patch> (e.g.
+# libkrunfw.so.5.3.0) with a symlink chain libkrunfw.so.5 → libkrunfw.so.5.3.0.
+# We copy the real file and rename it to libkrunfw-dind.so.5 so it can sit
+# next to the lean libkrunfw.so.5 in the runtime dir without a name collision.
+REAL_BLOB=$(ls "$LIBKRUNFW_SRC"/libkrunfw.so.5.* 2>/dev/null | head -1 || true)
+if [ -z "$REAL_BLOB" ]; then
+  echo "❌ build succeeded but couldn't find libkrunfw.so.5.* in $LIBKRUNFW_SRC" >&2
+  exit 1
+fi
+
+DIND_BLOB="$OUT_DIR/libkrunfw-dind.so.5"
+cp "$REAL_BLOB" "$DIND_BLOB"
+# Rename SONAME so two side-by-side blobs (lean + dind) don't both report
+# the same identity to dlopen, which would defeat per-box selection.
+patchelf --set-soname libkrunfw-dind.so.5 "$DIND_BLOB"
+
+echo ""
+echo "✅ Built dind libkrunfw: $DIND_BLOB"
+echo "   Size: $(du -h "$DIND_BLOB" | cut -f1) (vs lean: $(du -h "$REAL_BLOB" 2>/dev/null | cut -f1 || echo '?'))"
+echo ""
+echo "To make boxlite use it, set this in your shell before rebuilding boxlite:"
+echo ""
+echo "   export BOXLITE_LIBKRUNFW_DIND_PATH=$DIND_BLOB"
+echo "   make cli"
+echo ""
+echo "Then \`boxlite run --support-docker\` will load this kernel instead of the lean one."

--- a/sdks/node/src/options.rs
+++ b/sdks/node/src/options.rs
@@ -427,6 +427,10 @@ impl TryFrom<JsBoxOptions> for BoxOptions {
             cmd: js_opts.cmd,
             user: js_opts.user,
             secrets,
+            // Not yet plumbed through the Node SDK surface — defaults to the
+            // existing lean behaviour. Add `support_docker` to JsBoxOptions
+            // when we expose the CLI's --support-docker to Node callers.
+            support_docker: false,
         })
     }
 }

--- a/src/boxlite/src/litebox/init/tasks/guest_init.rs
+++ b/src/boxlite/src/litebox/init/tasks/guest_init.rs
@@ -32,6 +32,7 @@ impl PipelineTask<InitCtx> for GuestInitTask {
             container_mounts,
             network_spec,
             ca_cert_pem,
+            support_docker,
         ) =
             {
                 let mut ctx = ctx.lock().await;
@@ -54,6 +55,7 @@ impl PipelineTask<InitCtx> for GuestInitTask {
                 })?;
                 let network_spec = ctx.config.options.network.clone();
                 let ca_cert_pem = ctx.ca_cert_pem.clone();
+                let support_docker = ctx.config.options.support_docker;
                 (
                     guest_session,
                     container_image_config,
@@ -63,6 +65,7 @@ impl PipelineTask<InitCtx> for GuestInitTask {
                     container_mounts,
                     network_spec,
                     ca_cert_pem,
+                    support_docker,
                 )
             };
 
@@ -75,6 +78,7 @@ impl PipelineTask<InitCtx> for GuestInitTask {
             &container_mounts,
             &network_spec,
             ca_cert_pem.as_deref(),
+            support_docker,
         )
         .await
         .inspect_err(|e| log_task_error(&box_id, task_name, e))?;
@@ -104,6 +108,7 @@ async fn run_guest_init(
     container_mounts: &[ContainerMount],
     network_spec: &NetworkSpec,
     ca_cert_pem: Option<&str>,
+    support_docker: bool,
 ) -> BoxliteResult<()> {
     let container_id_str = container_id.as_str();
 
@@ -141,6 +146,7 @@ async fn run_guest_init(
             rootfs_init.clone(),
             container_mounts.to_vec(),
             ca_certs,
+            support_docker,
         )
         .await?;
     tracing::info!(container_id = %returned_id, "Container initialized");

--- a/src/boxlite/src/portal/interfaces/container.rs
+++ b/src/boxlite/src/portal/interfaces/container.rs
@@ -92,6 +92,7 @@ impl ContainerInterface {
     ///
     /// # Returns
     /// Container ID on success
+    #[allow(clippy::too_many_arguments)]
     pub async fn init(
         &mut self,
         container_id: &str,
@@ -99,6 +100,7 @@ impl ContainerInterface {
         rootfs: ContainerRootfsInitConfig,
         mounts: Vec<ContainerMount>,
         ca_certs: Vec<String>,
+        support_docker: bool,
     ) -> BoxliteResult<String> {
         let proto_config = ProtoContainerConfig {
             entrypoint: image_config.final_cmd(),
@@ -139,6 +141,7 @@ impl ContainerInterface {
             rootfs: Some(rootfs.into_proto()),
             mounts: proto_mounts,
             ca_certs: ca_certs.into_iter().map(|pem| CaCert { pem }).collect(),
+            support_docker,
         };
 
         let response = self.client.init(request).await?.into_inner();

--- a/src/boxlite/src/runtime/options.rs
+++ b/src/boxlite/src/runtime/options.rs
@@ -395,6 +395,22 @@ pub struct BoxOptions {
     /// guest; the real value never enters the VM.
     #[serde(default)]
     pub secrets: Vec<Secret>,
+
+    /// Opt-in: relax the in-container security envelope so a docker daemon
+    /// (or other workload that needs `docker run --privileged` semantics)
+    /// can run inside the box. When true the guest:
+    ///   - mounts `/sys/fs/cgroup` as a writable cgroup2 filesystem
+    ///   - grants the full Linux capability set (CAP_SYS_ADMIN,
+    ///     CAP_NET_ADMIN, CAP_SYS_MODULE, etc.) to the container init and
+    ///     every exec'd process
+    ///
+    /// Default `false` preserves the existing lean / locked-down behaviour
+    /// for every existing user — no surprise widening of the attack surface.
+    /// SECURITY: enabling this is equivalent to `docker run --privileged`
+    /// inside the microVM. The microVM boundary still contains escapes,
+    /// but the in-box blast radius effectively becomes root.
+    #[serde(default)]
+    pub support_docker: bool,
 }
 
 /// A secret for MITM proxy injection.
@@ -496,6 +512,7 @@ impl Default for BoxOptions {
             cmd: None,
             user: None,
             secrets: Vec::new(),
+            support_docker: false,
         }
     }
 }

--- a/src/boxlite/src/util/mod.rs
+++ b/src/boxlite/src/util/mod.rs
@@ -87,8 +87,33 @@ impl LibraryLoadPath {
 /// discoverable when the subprocess starts. Adds paths from both
 /// dladdr-based detection and the embedded runtime cache.
 pub fn configure_library_env(cmd: &mut Command, addr: *const libc::c_void) {
+    configure_library_env_with_prepend(cmd, addr, &[]);
+}
+
+/// Like [`configure_library_env`] but with caller-supplied directories
+/// PRE-pended to the loader search path. Used by `--support-docker` to
+/// inject a per-box dir whose `libkrunfw.so.5` is a symlink to the
+/// fat (dind-capable) blob — dlopen searches in order, so a prepended
+/// dir wins over the embedded-runtime dir holding the lean blob, and
+/// the same shim binary loads the right kernel for each box without
+/// any libkrun changes.
+///
+/// Each prepend path that doesn't exist is silently skipped (callers
+/// already log the underlying cause, e.g. "dind blob not staged").
+pub fn configure_library_env_with_prepend(
+    cmd: &mut Command,
+    addr: *const libc::c_void,
+    prepend: &[PathBuf],
+) {
     // Collect all library directories to add to search path
     let mut lib_dirs: Vec<PathBuf> = Vec::new();
+
+    // 0. Caller-supplied prepends — win over everything else at dlopen time.
+    for dir in prepend {
+        if dir.exists() {
+            lib_dirs.push(dir.clone());
+        }
+    }
 
     // 1. dladdr-based detection (libraries alongside the running binary)
     if let Some(runner_dir) = LibraryLoadPath::get(Some(addr))

--- a/src/boxlite/src/vmm/controller/spawn.rs
+++ b/src/boxlite/src/vmm/controller/spawn.rs
@@ -1,14 +1,14 @@
 //! Subprocess spawning for boxlite-shim binary.
 
 use std::{
-    path::Path,
+    path::{Path, PathBuf},
     process::{Child, Stdio},
 };
 
 use crate::jailer::{Jail, JailerBuilder};
 use crate::runtime::layout::BoxFilesystemLayout;
 use crate::runtime::options::BoxOptions;
-use crate::util::configure_library_env;
+use crate::util::configure_library_env_with_prepend;
 use boxlite_shared::errors::{BoxliteError, BoxliteResult};
 
 use super::watchdog;
@@ -156,8 +156,115 @@ impl<'a> ShimSpawner<'a> {
             cmd.env("TEMP", &tmp_dir);
         }
 
+        // For `--support-docker` boxes, stage a per-box libs dir whose
+        // libkrunfw.so.5 symlinks to the fat (dind-capable) blob in the
+        // embedded runtime. Prepending this dir to LD_LIBRARY_PATH makes
+        // libkrun's dlopen pick the fat kernel for THIS box only, without
+        // touching the symlink other (lean-profile) boxes load.
+        //
+        // Failure modes fall back to lean with a warning rather than
+        // aborting the box: a user with --support-docker but no dind blob
+        // built still gets the Phase-A caps + cgroup-rw — they just won't
+        // see bridge networks / iptables work. That degradation is OK and
+        // matches the existing behaviour before the dind blob was wired.
+        let dind_libs = if self.options.support_docker {
+            self.stage_dind_libkrunfw().unwrap_or_else(|e| {
+                tracing::warn!(
+                    box_id = %self.box_id,
+                    error = %e,
+                    "Failed to stage dind libkrunfw — falling back to lean kernel. \
+                     Caps + cgroup-rw still apply, but bridge networks won't work. \
+                     Run `make libkrunfw-dind` and rebuild boxlite with \
+                     BOXLITE_LIBKRUNFW_DIND_PATH set."
+                );
+                None
+            })
+        } else {
+            None
+        };
+
         // Set library search paths for bundled dependencies (e.g., libkrunfw.so)
-        configure_library_env(cmd, std::ptr::null());
+        let prepend: Vec<PathBuf> = dind_libs.into_iter().collect();
+        configure_library_env_with_prepend(cmd, std::ptr::null(), &prepend);
+    }
+
+    /// Create `<box_dir>/libs/libkrunfw.so.5` as a symlink to the fat
+    /// libkrunfw blob shipped alongside the lean one. Returns the libs
+    /// dir if the fat blob was staged at build time; returns `Ok(None)`
+    /// when the embedded runtime has no `libkrunfw-dind.so.5` (the
+    /// expected case unless someone ran `make libkrunfw-dind` + rebuilt
+    /// boxlite with BOXLITE_LIBKRUNFW_DIND_PATH set).
+    ///
+    /// The symlink is per-box and lives under the box's working
+    /// directory, so it's torn down whenever boxlite cleans up the box
+    /// — no shared state to garbage-collect.
+    fn stage_dind_libkrunfw(&self) -> BoxliteResult<Option<PathBuf>> {
+        #[cfg(feature = "embedded-runtime")]
+        let runtime_dir = crate::runtime::embedded::EmbeddedRuntime::get()
+            .ok_or_else(|| BoxliteError::Engine("embedded runtime unavailable".to_string()))?
+            .dir()
+            .to_path_buf();
+        #[cfg(not(feature = "embedded-runtime"))]
+        let runtime_dir: PathBuf = return Ok(None);
+
+        let dind_blob = runtime_dir.join("libkrunfw-dind.so.5");
+        if !dind_blob.exists() {
+            return Ok(None);
+        }
+
+        // Per-box libs dir lives next to the rest of the box's runtime
+        // state under root(). The symlink is wiped together with the box
+        // on `boxlite rm` — no shared state to garbage-collect.
+        let libs_dir = self.layout.root().join("libs");
+        std::fs::create_dir_all(&libs_dir).map_err(|e| {
+            BoxliteError::Storage(format!(
+                "Failed to create dind libs dir {}: {}",
+                libs_dir.display(),
+                e
+            ))
+        })?;
+
+        let symlink_path = libs_dir.join("libkrunfw.so.5");
+        // Idempotent: a stale symlink from a prior spawn (e.g. crash + restart)
+        // would otherwise cause symlink() to fail with EEXIST. Symlink only,
+        // never a regular file — if a regular file is sitting at this path,
+        // something else has put it there and we should NOT silently delete.
+        match std::fs::symlink_metadata(&symlink_path) {
+            Ok(meta) if meta.file_type().is_symlink() => {
+                std::fs::remove_file(&symlink_path).map_err(|e| {
+                    BoxliteError::Storage(format!(
+                        "Failed to remove stale dind symlink {}: {}",
+                        symlink_path.display(),
+                        e
+                    ))
+                })?;
+            }
+            Ok(_) => {
+                return Err(BoxliteError::Storage(format!(
+                    "Refusing to overwrite non-symlink at {}",
+                    symlink_path.display()
+                )));
+            }
+            Err(_) => {}
+        }
+
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&dind_blob, &symlink_path).map_err(|e| {
+            BoxliteError::Storage(format!(
+                "Failed to symlink {} → {}: {}",
+                symlink_path.display(),
+                dind_blob.display(),
+                e
+            ))
+        })?;
+
+        tracing::info!(
+            box_id = %self.box_id,
+            dind_blob = %dind_blob.display(),
+            libs_dir = %libs_dir.display(),
+            "Staged dind libkrunfw symlink for --support-docker box"
+        );
+        Ok(Some(libs_dir))
     }
 
     fn create_stderr_file(&self) -> BoxliteResult<std::fs::File> {

--- a/src/cli/src/cli.rs
+++ b/src/cli/src/cli.rs
@@ -636,6 +636,33 @@ pub struct ManagementFlags {
     #[arg(long, value_name = "PROGRAM")]
     pub entrypoint: Option<String>,
 
+    /// Pass arguments to the image's ENTRYPOINT (Docker CMD override).
+    ///
+    /// Repeatable; each `--cmd ARG` adds one positional argument that the
+    /// image's existing ENTRYPOINT receives as `$1`, `$2`, ... Use this
+    /// when you want the image's init to run with custom flags but
+    /// without replacing it (the way `--entrypoint` does).
+    ///
+    /// Gated on `--support-docker`: the lean / non-docker `boxlite run`
+    /// flow has long treated `[COMMAND...]` as a secondary-exec attach
+    /// rather than CMD, so introducing CMD overrides outside the docker
+    /// opt-in would silently re-route stdio for every existing user. The
+    /// gate keeps default behaviour byte-for-byte identical.
+    ///
+    /// Example — run `docker:dind`'s own `dockerd-entrypoint.sh` with
+    /// flags that work under the current libcontainer `/proc/sys`
+    /// hardening:
+    ///   `boxlite run --support-docker \
+    ///       --cmd --bridge=none --cmd --iptables=false \
+    ///       --cmd --storage-driver=vfs docker:dind`
+    #[arg(
+        long = "cmd",
+        value_name = "ARG",
+        allow_hyphen_values = true,
+        conflicts_with = "entrypoint"
+    )]
+    pub cmd: Vec<String>,
+
     /// Enable in-box docker / docker-compose support.
     ///
     /// Mounts /sys/fs/cgroup as writable cgroup2 inside the container and
@@ -664,6 +691,15 @@ impl ManagementFlags {
         if let Some(ep) = &self.entrypoint {
             opts.entrypoint = Some(vec![ep.clone()]);
         }
+        // `--cmd` is gated on `--support-docker` so a stray `--cmd` flag
+        // without the docker opt-in stays a no-op rather than silently
+        // changing CMD for the lean flow. The CLI command's
+        // `validate_flags` rejects that combination at parse-time, but
+        // we double-check here so direct callers (e.g., tests building
+        // ManagementFlags by hand) cannot accidentally widen behaviour.
+        if self.support_docker && !self.cmd.is_empty() {
+            opts.cmd = Some(self.cmd.clone());
+        }
     }
 }
 
@@ -690,6 +726,7 @@ mod tests {
             detach: false,
             rm: false,
             entrypoint: None,
+            cmd: vec![],
             support_docker: false,
         };
         let mut opts = BoxOptions::default();
@@ -709,6 +746,7 @@ mod tests {
             detach: false,
             rm: false,
             entrypoint: None,
+            cmd: vec![],
             support_docker: true,
         };
         let mut opts = BoxOptions::default();
@@ -738,6 +776,7 @@ mod tests {
             detach: true,
             rm: true,
             entrypoint: None,
+            cmd: vec![],
             support_docker: true,
         };
         flags.apply_to(&mut opts);
@@ -757,6 +796,90 @@ mod tests {
         assert!(opts.detach);
         assert!(opts.auto_remove);
         assert!(opts.support_docker);
+    }
+
+    // ─── --cmd flag plumbing ───────────────────────────────────────────
+    //
+    // `--cmd` carries args for the image's existing ENTRYPOINT. It is
+    // strictly opt-in via `--support-docker` so the lean / non-docker
+    // `boxlite run` flow (where positional `[COMMAND...]` is a secondary
+    // exec attach, not Docker CMD) keeps its semantics unchanged. The
+    // tests below pin both halves of that contract:
+    //   1. `--cmd` without `--support-docker` is a no-op at the
+    //      apply_to layer (the run command also rejects this combo at
+    //      validate-time, but apply_to is the last line of defence for
+    //      any direct callers).
+    //   2. `--cmd` with `--support-docker` populates BoxOptions::cmd.
+
+    #[test]
+    fn management_flags_cmd_without_support_docker_is_noop() {
+        let flags = ManagementFlags {
+            name: None,
+            detach: false,
+            rm: false,
+            entrypoint: None,
+            cmd: vec!["--bridge=none".to_string()],
+            support_docker: false,
+        };
+        let mut opts = BoxOptions::default();
+        flags.apply_to(&mut opts);
+        assert!(
+            opts.cmd.is_none(),
+            "--cmd must not affect BoxOptions when --support-docker is OFF"
+        );
+    }
+
+    #[test]
+    fn management_flags_cmd_with_support_docker_sets_cmd() {
+        let flags = ManagementFlags {
+            name: None,
+            detach: false,
+            rm: false,
+            entrypoint: None,
+            cmd: vec![
+                "--bridge=none".to_string(),
+                "--iptables=false".to_string(),
+                "--storage-driver=vfs".to_string(),
+            ],
+            support_docker: true,
+        };
+        let mut opts = BoxOptions::default();
+        flags.apply_to(&mut opts);
+        assert_eq!(
+            opts.cmd.as_deref(),
+            Some(
+                &[
+                    "--bridge=none".to_string(),
+                    "--iptables=false".to_string(),
+                    "--storage-driver=vfs".to_string(),
+                ][..]
+            ),
+            "--cmd args must propagate verbatim to BoxOptions.cmd, in order"
+        );
+    }
+
+    #[test]
+    fn management_flags_empty_cmd_does_not_overwrite_existing() {
+        // Pre-existing BoxOptions::cmd (e.g., set by a config file the CLI
+        // loads before applying flags) must not be wiped by an unset --cmd.
+        let mut opts = BoxOptions {
+            cmd: Some(vec!["preserved".to_string()]),
+            ..BoxOptions::default()
+        };
+        let flags = ManagementFlags {
+            name: None,
+            detach: false,
+            rm: false,
+            entrypoint: None,
+            cmd: vec![],
+            support_docker: true,
+        };
+        flags.apply_to(&mut opts);
+        assert_eq!(
+            opts.cmd,
+            Some(vec!["preserved".to_string()]),
+            "an empty --cmd Vec must leave a previously-set cmd untouched"
+        );
     }
 
     #[test]

--- a/src/cli/src/cli.rs
+++ b/src/cli/src/cli.rs
@@ -623,12 +623,32 @@ pub struct ManagementFlags {
     /// Automatically remove the box when it exits
     #[arg(long)]
     pub rm: bool,
+
+    /// Enable in-box docker / docker-compose support.
+    ///
+    /// Mounts /sys/fs/cgroup as writable cgroup2 inside the container and
+    /// grants the full Linux capability set (CAP_SYS_ADMIN, CAP_NET_ADMIN,
+    /// CAP_SYS_MODULE, etc.) to the container init plus every exec'd
+    /// process. Equivalent to `docker run --privileged` for the in-box
+    /// container.
+    ///
+    /// SECURITY: this widens the in-VM attack surface significantly — any
+    /// process inside the box runs effectively as root with full caps and
+    /// can mount/remount filesystems, manipulate network/iptables, and use
+    /// every cap-gated kernel API. The microVM boundary still contains
+    /// the process (host stays protected by KVM/libkrun isolation), but
+    /// only enable this for trusted workloads or where you would already
+    /// be running `docker run --privileged`. Default is OFF and existing
+    /// boxes are unaffected.
+    #[arg(long)]
+    pub support_docker: bool,
 }
 
 impl ManagementFlags {
     pub fn apply_to(&self, opts: &mut BoxOptions) {
         opts.detach = self.detach;
         opts.auto_remove = self.rm;
+        opts.support_docker = self.support_docker;
     }
 }
 

--- a/src/cli/src/cli.rs
+++ b/src/cli/src/cli.rs
@@ -624,6 +624,18 @@ pub struct ManagementFlags {
     #[arg(long)]
     pub rm: bool,
 
+    /// Override the image's ENTRYPOINT directive.
+    ///
+    /// When set, completely replaces the image's ENTRYPOINT for the box's
+    /// init process. Useful for images with an ENTRYPOINT that exits
+    /// (e.g., `docker:dind`'s `dockerd-entrypoint.sh` finishes its TLS
+    /// setup and exits when given no `dockerd` arg → tears down the
+    /// container's PID namespace and kills all exec'd processes).
+    /// Pair with the positional `[COMMAND...]` arg, which becomes the
+    /// args to this entrypoint.
+    #[arg(long, value_name = "PROGRAM")]
+    pub entrypoint: Option<String>,
+
     /// Enable in-box docker / docker-compose support.
     ///
     /// Mounts /sys/fs/cgroup as writable cgroup2 inside the container and
@@ -649,6 +661,9 @@ impl ManagementFlags {
         opts.detach = self.detach;
         opts.auto_remove = self.rm;
         opts.support_docker = self.support_docker;
+        if let Some(ep) = &self.entrypoint {
+            opts.entrypoint = Some(vec![ep.clone()]);
+        }
     }
 }
 
@@ -657,6 +672,106 @@ mod tests {
     use super::*;
     use std::fs;
     use tempfile::TempDir;
+
+    // ─── --support-docker flag plumbing ────────────────────────────────
+    //
+    // The CLI flag must default to false and only flip BoxOptions when the
+    // user explicitly passes it. The proto + guest paths take care of the
+    // rest; what THIS module is responsible for is the CLI→BoxOptions hop.
+    // Tests below guard both the default-off invariant (existing users see
+    // no behaviour change) and the explicit-on plumbing.
+
+    #[test]
+    fn management_flags_default_leaves_support_docker_false() {
+        // Build a minimal ManagementFlags with only the unrelated fields the
+        // user might set in everyday `boxlite run` invocations.
+        let flags = ManagementFlags {
+            name: None,
+            detach: false,
+            rm: false,
+            entrypoint: None,
+            support_docker: false,
+        };
+        let mut opts = BoxOptions::default();
+        flags.apply_to(&mut opts);
+        assert!(
+            !opts.support_docker,
+            "BoxOptions.support_docker must stay false when --support-docker \
+             is NOT passed — protects every existing user from a silent \
+             attack-surface widening"
+        );
+    }
+
+    #[test]
+    fn management_flags_propagates_support_docker_when_set() {
+        let flags = ManagementFlags {
+            name: None,
+            detach: false,
+            rm: false,
+            entrypoint: None,
+            support_docker: true,
+        };
+        let mut opts = BoxOptions::default();
+        flags.apply_to(&mut opts);
+        assert!(
+            opts.support_docker,
+            "--support-docker must flip BoxOptions.support_docker so the \
+             guest receives the relaxed-caps + cgroup-rw profile"
+        );
+    }
+
+    #[test]
+    fn management_flags_apply_does_not_clobber_unrelated_options() {
+        // Setting --support-docker must NOT silently change any other
+        // BoxOptions field. Verify by populating the options with non-default
+        // values for fields ManagementFlags doesn't own, applying the flag,
+        // and asserting they're preserved.
+        let mut opts = BoxOptions {
+            cpus: Some(4),
+            memory_mib: Some(2048),
+            entrypoint: Some(vec!["dockerd".to_string()]),
+            ..BoxOptions::default()
+        };
+
+        let flags = ManagementFlags {
+            name: None,
+            detach: true,
+            rm: true,
+            entrypoint: None,
+            support_docker: true,
+        };
+        flags.apply_to(&mut opts);
+
+        assert_eq!(opts.cpus, Some(4), "cpus must not be clobbered");
+        assert_eq!(
+            opts.memory_mib,
+            Some(2048),
+            "memory_mib must not be clobbered"
+        );
+        assert_eq!(
+            opts.entrypoint,
+            Some(vec!["dockerd".to_string()]),
+            "entrypoint must not be clobbered"
+        );
+        // What ManagementFlags DOES own should be updated.
+        assert!(opts.detach);
+        assert!(opts.auto_remove);
+        assert!(opts.support_docker);
+    }
+
+    #[test]
+    fn box_options_default_has_support_docker_false() {
+        // The default constructor is the source of truth for "lean profile".
+        // Multiple SDK plumbings rely on this default; guard it here so any
+        // accidental change tips a unit test instead of silently shipping
+        // a new default behaviour to every box on the planet.
+        let opts = BoxOptions::default();
+        assert!(
+            !opts.support_docker,
+            "BoxOptions::default().support_docker MUST be false. Changing this \
+             default would silently widen attack surface for every existing user."
+        );
+    }
 
     #[test]
     fn test_apply_env_vars_with_lookup() {

--- a/src/cli/src/commands/run.rs
+++ b/src/cli/src/commands/run.rs
@@ -108,6 +108,16 @@ impl BoxRunner {
 
         options.rootfs = RootfsSpec::Image(self.args.image.clone());
 
+        // When the user passes `--entrypoint`, treat the positional command
+        // tail as the cmd args to that entrypoint (matching `docker run
+        // --entrypoint X image arg1 arg2` semantics). Without this the
+        // positional args would only reach a secondary boxlite exec and
+        // the image's init would run with whatever the image declares,
+        // defeating the purpose of overriding the entrypoint.
+        if self.args.management.entrypoint.is_some() && !self.args.command.is_empty() {
+            options.cmd = Some(self.args.command.clone());
+        }
+
         let litebox = self
             .rt
             .create(options, self.args.management.name.clone())
@@ -117,6 +127,18 @@ impl BoxRunner {
     }
 
     fn prepare_command(&self) -> BoxCommand {
+        // When --entrypoint is set, the positional command tail has been
+        // re-routed into BoxOptions::cmd so the container's init process
+        // runs the user's command (matching `docker run --entrypoint X
+        // image arg…`). The foreground exec then just needs to wait for
+        // init to finish; a long sleep does that — when init exits the
+        // container's PID namespace tears down and the sleep gets
+        // SIGKILL'd, letting `boxlite run` return.
+        if self.args.management.entrypoint.is_some() {
+            return BoxCommand::new("sleep")
+                .args(&["infinity".to_string()])
+                .tty(self.args.process.tty);
+        }
         let (program, args) = parse_command_args(&self.args.command);
         BoxCommand::new(program)
             .args(args)

--- a/src/cli/src/commands/run.rs
+++ b/src/cli/src/commands/run.rs
@@ -139,6 +139,17 @@ impl BoxRunner {
                 .args(&["infinity".to_string()])
                 .tty(self.args.process.tty);
         }
+        // `--cmd` (gated on `--support-docker`) routes args to the
+        // image's existing ENTRYPOINT — the workload lives in PID 1.
+        // If the caller didn't also supply a positional foreground
+        // command, fall back to a long sleep so `boxlite run` blocks
+        // on PID 1's lifetime rather than exiting immediately into a
+        // default `sh` shell that would race with init.
+        if !self.args.management.cmd.is_empty() && self.args.command.is_empty() {
+            return BoxCommand::new("sleep")
+                .args(&["infinity".to_string()])
+                .tty(self.args.process.tty);
+        }
         let (program, args) = parse_command_args(&self.args.command);
         BoxCommand::new(program)
             .args(args)
@@ -149,6 +160,15 @@ impl BoxRunner {
         // Check TTY availability if requested
         if self.args.process.tty && !io::stdin().is_terminal() {
             anyhow::bail!("the input device is not a TTY.");
+        }
+
+        // `--cmd` is a docker-in-box concept (it pokes the image's init
+        // PID 1 instead of the secondary-exec stdio attach the lean
+        // flow uses for positional COMMAND…). Reject it without
+        // `--support-docker` so the non-docker flow stays byte-for-byte
+        // identical — there's no path where `--cmd` alone is meaningful.
+        if !self.args.management.cmd.is_empty() && !self.args.management.support_docker {
+            anyhow::bail!("--cmd requires --support-docker");
         }
 
         Ok(())

--- a/src/cli/tests/dind_build.rs
+++ b/src/cli/tests/dind_build.rs
@@ -1,0 +1,126 @@
+//! Integration test: `boxlite run --support-docker` actually lets a
+//! `docker build` complete end-to-end inside the box.
+//!
+//! Gated on `BOXLITE_DIND_TEST=1` because it requires a libkrunfw-dind
+//! blob bundled at build time (`make libkrunfw-dind && cargo build` with
+//! `BOXLITE_LIBKRUNFW_DIND_PATH` set). Without the env var the test
+//! prints a SKIP notice and returns Ok — keeps the default
+//! `test:integration:cli` matrix runnable on hosts without the dind
+//! kernel built.
+//!
+//! What we assert end-to-end:
+//!   - boxlite spawns a `--support-docker` box that successfully runs
+//!     dockerd (the Phase A caps + cgroup rw work)
+//!   - dockerd pulls `alpine:3.19` over the box's gvproxy network
+//!   - `docker build --network=host` produces an image with a custom
+//!     tag (the build's RUN step executes a child container, exercising
+//!     containerd shim + the dind kernel's mqueue/netfilter subsystems)
+//!
+//! Failure here is the right canary for issue #276's regression budget:
+//! every existing capability we depend on (libkrunfw-dind kernel
+//! configs, the entrypoint bypass, the support_docker flag plumbing,
+//! the per-box libkrunfw symlink) is exercised on a real VM.
+
+use assert_cmd::Command;
+use boxlite_test_utils::home::PerTestBoxHome;
+use std::time::Duration;
+
+const PROBE_SCRIPT: &str = r#"exec > /probe/result.log 2>&1
+dockerd --host=unix:///var/run/docker.sock \
+        --bridge=none --iptables=false --storage-driver=vfs \
+        > /tmp/d.log 2>&1 &
+until [ -S /var/run/docker.sock ]; do sleep 0.5; done
+docker build --network=host -t boxlite-dind-test:1 /probe/ctx
+echo "[exit=$?]"
+"#;
+
+const DOCKERFILE: &str = "FROM alpine:3.19\nRUN echo \"built\" > /built.txt\n";
+
+#[test]
+fn dind_supports_docker_build() {
+    if std::env::var("BOXLITE_DIND_TEST").is_err() {
+        eprintln!(
+            "SKIP dind_supports_docker_build: set BOXLITE_DIND_TEST=1 \
+             after `make libkrunfw-dind` + a rebuild of boxlite with \
+             BOXLITE_LIBKRUNFW_DIND_PATH set, so the dind libkrunfw \
+             blob is bundled into the embedded runtime."
+        );
+        return;
+    }
+
+    // ── Stage Dockerfile + probe.sh in a host-visible tempdir ──────────
+    // The box mounts this dir at /probe; the probe script starts dockerd
+    // and runs `docker build` against /probe/ctx. Output lands in
+    // /probe/result.log (which we read on the host after boxlite exits).
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    let ctx_dir = tmp.path().join("ctx");
+    std::fs::create_dir(&ctx_dir).expect("mkdir ctx");
+    std::fs::write(ctx_dir.join("Dockerfile"), DOCKERFILE).expect("write Dockerfile");
+    std::fs::write(tmp.path().join("probe.sh"), PROBE_SCRIPT).expect("write probe.sh");
+
+    // ── Spawn boxlite ──────────────────────────────────────────────────
+    // Build the command directly instead of going through `common::boxlite()`
+    // / `new_cmd()`: those helpers force docker.m.daocloud.io et al. as
+    // image registries, and `docker:dind` isn't mirrored there reliably —
+    // the pull returns a bearer-token error and the box exits before the
+    // probe script runs. Using the default registry list (Docker Hub) is
+    // the right config for a test image that exercises Docker itself.
+    let home_dir = PerTestBoxHome::new();
+    let mount = format!("{}:/probe", tmp.path().display());
+
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_boxlite"));
+    // First-time pull of docker:dind (~250 MB compressed) plus a kernel
+    // boot and a docker build is comfortably under 10 min on a
+    // 2-core/2 GB box even with a cold image cache. The dind-blob check
+    // gate above already filters out hosts that can't run this in
+    // sensible time, so generous but bounded.
+    cmd.timeout(Duration::from_secs(600))
+        .arg("--home")
+        .arg(&home_dir.path)
+        .args([
+            "run",
+            "--rm",
+            "--support-docker",
+            "--entrypoint",
+            "sh",
+            "--memory",
+            "2048",
+            "-v",
+            &mount,
+            "docker:dind",
+            "/probe/probe.sh",
+        ]);
+    // Note: we do NOT assert on boxlite's exit code. When `--entrypoint`
+    // is set the foreground exec is `sleep infinity` (an artifact of
+    // attaching stdio while the real workload runs as PID 1); when the
+    // entrypoint script exits, the container's PID namespace tears down
+    // and SIGKILL's the sleep — boxlite then reports 137 even though the
+    // init process exited cleanly. The probe script's `[exit=$?]` marker
+    // is what we actually care about. (Tracked as a follow-up: foreground
+    // exit code should follow the init process, not the foreground sleep.)
+    let _ = cmd.assert();
+    let log_path = tmp.path().join("result.log");
+    let log = std::fs::read_to_string(&log_path)
+        .unwrap_or_else(|e| panic!("probe never produced {}: {}", log_path.display(), e));
+    eprintln!("=== /probe/result.log ===\n{}\n=== end ===", log);
+    // `home_dir`'s Drop wipes the per-test home; keep it alive past the
+    // log read so boxlite had somewhere to write its DB / boxes dir for
+    // the duration of the run.
+    drop(home_dir);
+
+    // ── Verify the probe script's recorded result ──────────────────────
+    // The probe writes `[exit=N]` as its last line, where N is the
+    // `docker build` exit code.
+    assert!(
+        log.contains("[exit=0]"),
+        "docker build did not exit 0 — see result.log above",
+    );
+    // And it must have actually written the image into dockerd's image
+    // store (the BuildKit emits this line on the export step). Without
+    // this the build could exit 0 having never reached image writing —
+    // defensive guard against silently weak builds.
+    assert!(
+        log.contains("naming to docker.io/library/boxlite-dind-test:1"),
+        "image was not tagged into dockerd's store — see result.log above",
+    );
+}

--- a/src/cli/tests/dind_build.rs
+++ b/src/cli/tests/dind_build.rs
@@ -1,12 +1,21 @@
 //! Integration test: `boxlite run --support-docker` actually lets a
 //! `docker build` complete end-to-end inside the box.
 //!
-//! Gated on `BOXLITE_DIND_TEST=1` because it requires a libkrunfw-dind
-//! blob bundled at build time (`make libkrunfw-dind` then a rebuild of
-//! boxlite with `BOXLITE_LIBKRUNFW_DIND_PATH` set). Without the env var
-//! the test prints a SKIP notice and returns Ok — keeps the default
-//! `test:integration:cli` matrix runnable on hosts without the dind
-//! kernel built.
+//! Part of the forced `test:integration:cli` matrix — runs by default.
+//! Prerequisites the make target sets up for us:
+//!   1. `target/dind-kernel/lib64/libkrunfw-dind.so.5` exists (built
+//!      via `make libkrunfw-dind`, which `test:integration:cli` checks
+//!      for and refuses to run without — heavy one-time ~10–20 min
+//!      kernel build, cached thereafter).
+//!   2. `BOXLITE_LIBKRUNFW_DIND_PATH` is exported when cargo builds the
+//!      CLI binary so the dind libkrunfw blob is staged alongside the
+//!      lean one inside the embedded runtime.
+//!
+//! Ignore-condition: set `BOXLITE_SKIP_DIND_TEST=1` to skip with a
+//! SKIP marker (useful on hosts that genuinely cannot run dind — e.g.,
+//! nested-virt unavailable or security profile blocks the cgroup2
+//! mounts the box needs). The default is RUN, not SKIP, so anyone who
+//! breaks dind without realising it gets a failing CI signal.
 //!
 //! Architecture under test (NO entrypoint bypass): we let the image's
 //! own `dockerd-entrypoint.sh` run as PID 1 inside the container and
@@ -62,13 +71,12 @@ const DOCKERFILE: &str = "FROM alpine:3.19\nRUN echo \"built\" > /built.txt\n";
 
 #[test]
 fn dind_supports_docker_build() {
-    if std::env::var("BOXLITE_DIND_TEST").is_err() {
-        eprintln!(
-            "SKIP dind_supports_docker_build: set BOXLITE_DIND_TEST=1 \
-             after `make libkrunfw-dind` + a rebuild of boxlite with \
-             BOXLITE_LIBKRUNFW_DIND_PATH set, so the dind libkrunfw \
-             blob is bundled into the embedded runtime."
-        );
+    // Opt-out ignore-condition (see module docs): hosts that genuinely
+    // cannot run dind set BOXLITE_SKIP_DIND_TEST=1. Default is RUN —
+    // `make test:integration:cli` does not set this, so a regression
+    // in dind support fails the suite.
+    if std::env::var("BOXLITE_SKIP_DIND_TEST").as_deref() == Ok("1") {
+        eprintln!("SKIP dind_supports_docker_build: BOXLITE_SKIP_DIND_TEST=1");
         return;
     }
 

--- a/src/cli/tests/dind_build.rs
+++ b/src/cli/tests/dind_build.rs
@@ -2,34 +2,58 @@
 //! `docker build` complete end-to-end inside the box.
 //!
 //! Gated on `BOXLITE_DIND_TEST=1` because it requires a libkrunfw-dind
-//! blob bundled at build time (`make libkrunfw-dind && cargo build` with
-//! `BOXLITE_LIBKRUNFW_DIND_PATH` set). Without the env var the test
-//! prints a SKIP notice and returns Ok — keeps the default
+//! blob bundled at build time (`make libkrunfw-dind` then a rebuild of
+//! boxlite with `BOXLITE_LIBKRUNFW_DIND_PATH` set). Without the env var
+//! the test prints a SKIP notice and returns Ok — keeps the default
 //! `test:integration:cli` matrix runnable on hosts without the dind
 //! kernel built.
 //!
+//! Architecture under test (NO entrypoint bypass): we let the image's
+//! own `dockerd-entrypoint.sh` run as PID 1 inside the container and
+//! pass its dockerd flags via `--cmd` (i.e., as the box's CMD, not by
+//! replacing ENTRYPOINT). The positional `boxlite run` command tail is
+//! the foreground exec — a probe script that waits for dockerd to come
+//! up and then drives `docker build`. The previous variant of this
+//! test used `--entrypoint sh` to swap the entrypoint out and ran
+//! dockerd manually from the probe; that bypass is no longer needed
+//! now that `--cmd` exists.
+//!
 //! What we assert end-to-end:
-//!   - boxlite spawns a `--support-docker` box that successfully runs
-//!     dockerd (the Phase A caps + cgroup rw work)
+//!   - boxlite spawns a `--support-docker` box whose init process is
+//!     the image's `dockerd-entrypoint.sh` (Phase A caps + cgroup rw
+//!     plus the Phase B dind kernel let it boot)
+//!   - dockerd-entrypoint.sh launches dockerd with our `--bridge=none`
+//!     / `--iptables=false` / `--storage-driver=vfs` flags (needed
+//!     because libcontainer-0.5.7 still bind-remounts `/proc/sys` ro
+//!     under us — see commit fb073bf)
 //!   - dockerd pulls `alpine:3.19` over the box's gvproxy network
 //!   - `docker build --network=host` produces an image with a custom
-//!     tag (the build's RUN step executes a child container, exercising
-//!     containerd shim + the dind kernel's mqueue/netfilter subsystems)
+//!     tag (the build's RUN step executes a child container,
+//!     exercising containerd shim + the dind kernel's mqueue /
+//!     netfilter subsystems)
 //!
-//! Failure here is the right canary for issue #276's regression budget:
-//! every existing capability we depend on (libkrunfw-dind kernel
-//! configs, the entrypoint bypass, the support_docker flag plumbing,
-//! the per-box libkrunfw symlink) is exercised on a real VM.
+//! Failure here is the right canary for issue #276's regression
+//! budget: every existing capability we depend on (the dind kernel,
+//! the per-box libkrunfw symlink, --support-docker plumbing, and now
+//! the `--cmd` plumbing that lets the image's real ENTRYPOINT run as
+//! PID 1) is exercised on a real VM.
 
 use assert_cmd::Command;
 use boxlite_test_utils::home::PerTestBoxHome;
 use std::time::Duration;
 
 const PROBE_SCRIPT: &str = r#"exec > /probe/result.log 2>&1
-dockerd --host=unix:///var/run/docker.sock \
-        --bridge=none --iptables=false --storage-driver=vfs \
-        > /tmp/d.log 2>&1 &
-until [ -S /var/run/docker.sock ]; do sleep 0.5; done
+echo "[probe] waiting for /var/run/docker.sock"
+for i in $(seq 1 180); do
+    [ -S /var/run/docker.sock ] && break
+    sleep 1
+done
+if [ ! -S /var/run/docker.sock ]; then
+    echo "[probe] dockerd socket never appeared after 180s"
+    echo "[exit=124]"
+    exit 124
+fi
+echo "[probe] socket present, running build"
 docker build --network=host -t boxlite-dind-test:1 /probe/ctx
 echo "[exit=$?]"
 "#;
@@ -49,9 +73,10 @@ fn dind_supports_docker_build() {
     }
 
     // ── Stage Dockerfile + probe.sh in a host-visible tempdir ──────────
-    // The box mounts this dir at /probe; the probe script starts dockerd
-    // and runs `docker build` against /probe/ctx. Output lands in
-    // /probe/result.log (which we read on the host after boxlite exits).
+    // The box mounts this dir at /probe; the probe script (the foreground
+    // exec) waits for dockerd to come up and runs `docker build` against
+    // /probe/ctx. Output lands in /probe/result.log which we read on the
+    // host after the run completes.
     let tmp = tempfile::tempdir().expect("create tempdir");
     let ctx_dir = tmp.path().join("ctx");
     std::fs::create_dir(&ctx_dir).expect("mkdir ctx");
@@ -81,24 +106,37 @@ fn dind_supports_docker_build() {
             "run",
             "--rm",
             "--support-docker",
-            "--entrypoint",
-            "sh",
+            // `--cmd` carries the dockerd flags to the image's real
+            // ENTRYPOINT (dockerd-entrypoint.sh). Without these,
+            // dockerd-entrypoint.sh boots dockerd with default bridge/
+            // iptables, which fails because libcontainer-0.5.7 still
+            // bind-remounts /proc/sys as ro under us (commit fb073bf).
+            "--cmd",
+            "--bridge=none",
+            "--cmd",
+            "--iptables=false",
+            "--cmd",
+            "--storage-driver=vfs",
             "--memory",
             "2048",
             "-v",
             &mount,
             "docker:dind",
+            // Foreground exec: probe waits for the dockerd socket
+            // (which `dockerd-entrypoint.sh` running as PID 1 brings
+            // up) and runs `docker build`.
+            "sh",
             "/probe/probe.sh",
         ]);
-    // Note: we do NOT assert on boxlite's exit code. When `--entrypoint`
-    // is set the foreground exec is `sleep infinity` (an artifact of
-    // attaching stdio while the real workload runs as PID 1); when the
-    // entrypoint script exits, the container's PID namespace tears down
-    // and SIGKILL's the sleep — boxlite then reports 137 even though the
-    // init process exited cleanly. The probe script's `[exit=$?]` marker
-    // is what we actually care about. (Tracked as a follow-up: foreground
-    // exit code should follow the init process, not the foreground sleep.)
-    let _ = cmd.assert();
+    // `boxlite run`'s exit code is the probe script's exit code (it
+    // controls the foreground exec, not PID 1). PID 1 (dockerd) keeps
+    // running after the build; the RuntimeImpl Drop on shutdown sends
+    // SIGTERM to the shim, the VM exits, and `--rm` plus recovery on
+    // next runtime start clean up any lingering box record.
+    cmd.assert().success();
+
+    // Capture the probe's recorded result for the test report and the
+    // two assertions below.
     let log_path = tmp.path().join("result.log");
     let log = std::fs::read_to_string(&log_path)
         .unwrap_or_else(|e| panic!("probe never produced {}: {}", log_path.display(), e));

--- a/src/deps/libkrun-sys/build.rs
+++ b/src/deps/libkrun-sys/build.rs
@@ -228,6 +228,66 @@ fn download_libkrunfw_so(install_dir: &Path) {
     );
 }
 
+// ── DinD libkrunfw staging (opt-in) ──────────────────────────────────────────
+
+/// Copy the optional "fat" libkrunfw blob (built via `make libkrunfw-dind`)
+/// into the install dir alongside the lean libkrunfw. The blob's filename
+/// is preserved as `libkrunfw-dind.so.5` so dlopen at runtime can pick
+/// between the two by name; per-box selection is handled higher up the
+/// stack (boxlite::vmm reads BoxOptions::support_docker).
+///
+/// No-op when the env var is unset → default builds stay byte-identical
+/// to the existing lean path, which is the `--support-docker` design
+/// contract (don't widen anything for existing users).
+#[cfg(target_os = "linux")]
+fn stage_optional_dind_blob(install_lib_dir: &Path) {
+    // rerun-if-changed isn't enough — env vars need their own watcher so
+    // toggling the var triggers a re-stage.
+    println!("cargo:rerun-if-env-changed=BOXLITE_LIBKRUNFW_DIND_PATH");
+
+    let Ok(src_str) = env::var("BOXLITE_LIBKRUNFW_DIND_PATH") else {
+        return;
+    };
+    let src = PathBuf::from(src_str.trim());
+    if src.as_os_str().is_empty() {
+        println!("cargo:warning=BOXLITE_LIBKRUNFW_DIND_PATH set but empty — skipping dind staging");
+        return;
+    }
+    if !src.exists() {
+        // Hard error: the user explicitly asked for dind but pointed us at
+        // nothing. Silently skipping would produce a build that pretends
+        // support_docker works but loads the lean kernel at runtime.
+        panic!(
+            "BOXLITE_LIBKRUNFW_DIND_PATH={} does not exist. Build it with `make libkrunfw-dind`.",
+            src.display()
+        );
+    }
+
+    let dest = install_lib_dir.join("libkrunfw-dind.so.5");
+    fs::copy(&src, &dest).unwrap_or_else(|e| {
+        panic!(
+            "Failed to stage dind libkrunfw from {} to {}: {}",
+            src.display(),
+            dest.display(),
+            e
+        )
+    });
+    println!(
+        "cargo:warning=Staged dind libkrunfw: {} → {}",
+        src.display(),
+        dest.display()
+    );
+}
+
+#[cfg(not(target_os = "linux"))]
+fn stage_optional_dind_blob(_install_lib_dir: &Path) {
+    // macOS dind support not yet plumbed end-to-end. The CLI flag is
+    // accepted on every platform (caps + cgroup work) but the fat kernel
+    // is Linux-only for now — Apple Silicon needs libkrunfw built with
+    // a different toolchain (kernel.c → .dylib) and a parallel overlay
+    // path. Track in a follow-up; for now silently skip.
+}
+
 // ── Make utilities ───────────────────────────────────────────────────────────
 
 /// Creates a make command with common configuration.
@@ -886,6 +946,14 @@ fn build() {
 
     LibFixup::fix(&libkrunfw_lib_dir, "libkrunfw")
         .unwrap_or_else(|e| panic!("Failed to fix libkrunfw: {}", e));
+
+    // Optionally stage the "fat" libkrunfw next to the lean one for
+    // `boxlite run --support-docker`. Driven by an env var so a normal
+    // build pulls only the lean blob (existing behaviour byte-identical),
+    // and dev users who built the dind kernel via `make libkrunfw-dind`
+    // opt in by exporting BOXLITE_LIBKRUNFW_DIND_PATH before rebuilding.
+    // See dind-configs/README.md.
+    stage_optional_dind_blob(&libkrunfw_lib_dir);
 
     // Expose libkrunfw library directory for downstream bundling
     println!(

--- a/src/deps/libkrun-sys/dind-configs/README.md
+++ b/src/deps/libkrun-sys/dind-configs/README.md
@@ -1,0 +1,47 @@
+# DinD kernel config overlay
+
+This directory holds `--support-docker` (DinD) kernel config overlays
+applied on top of the upstream libkrunfw lean configs (at
+`../vendor/libkrunfw/config-libkrunfw_<arch>`). They turn on the
+networking subsystems Docker needs for bridge networks, NAT, and
+iptables rule installation — i.e. everything required by the workflows
+issue #276 calls out as broken under the lean profile (`docker compose
+up` with custom bridge networks, port publishing, container-to-
+container DNS).
+
+The overlays do NOT touch any unrelated config knob. The resulting
+"fat" libkrunfw is shipped alongside the lean one as a second `.so`
+blob, opt-in via the per-box `support_docker` flag. The default profile
+remains the lean libkrunfw, byte-for-byte identical to today.
+
+## How the overlay is applied
+
+`make libkrunfw-dind` does:
+
+1. Copy `vendor/libkrunfw/config-libkrunfw_<arch>` → `vendor/libkrunfw/.config`
+2. Append the relevant overlay file (this dir, `overlay-dind_<arch>`)
+   to `.config`
+3. Run `make olddefconfig` inside `vendor/libkrunfw/<kernel-src>` so the
+   Kconfig dependency resolver fills in any newly-required parent
+   options (e.g. `CONFIG_NETFILTER_ADVANCED=y` once `CONFIG_NF_TABLES=y`)
+4. Build libkrunfw as usual
+5. Stamp the SONAME to a distinct filename
+   (`libkrunfw-dind.so.5`) so it can sit next to the lean one
+
+The boxlite runtime stages both blobs and selects between them at VM
+spawn time based on `BoxOptions::support_docker`.
+
+## Why not modify the upstream lean config
+
+Two reasons. First, every CONFIG flag we add to lean grows the kernel
+binary embedded in every box on the planet — that defeats the lean
+profile's whole purpose (small footprint, fast boot, smaller attack
+surface). Second, keeping the overlay external means upstream libkrunfw
+updates (config refreshes, version bumps) merge cleanly without
+conflicts in the file we maintain ourselves.
+
+## Adding a new arch
+
+`overlay-dind_aarch64` is currently a copy of the x86_64 overlay since
+the same CONFIG_* knobs apply. If a new arch needs different settings,
+add a per-arch overlay here.

--- a/src/deps/libkrun-sys/dind-configs/overlay-dind_aarch64
+++ b/src/deps/libkrun-sys/dind-configs/overlay-dind_aarch64
@@ -1,0 +1,116 @@
+# Overlay applied on top of config-libkrunfw_x86_64 by `make libkrunfw-dind`.
+# Enables the kernel subsystems Docker needs for bridge networks, NAT, and
+# iptables rule installation — the dind / docker-compose workflows broken
+# under the lean profile (issue #276). Every line is built-in (=y) because
+# the libkrunfw guest has no /lib/modules and can't load loadable modules
+# at runtime.
+
+# ── Bridge networking ─────────────────────────────────────────────────────
+# Docker creates one Linux bridge per network (default `docker0` + one per
+# user-defined network in compose). Each container is wired in via a veth
+# pair (CONFIG_VETH is already on in lean). Bridge netfilter exposes the
+# /proc/sys/net/bridge/bridge-nf-* knobs Docker probes for.
+CONFIG_BRIDGE=y
+CONFIG_BRIDGE_NETFILTER=y
+CONFIG_LLC=y
+CONFIG_STP=y
+
+# ── Netfilter core ────────────────────────────────────────────────────────
+# Foundation that everything else (xtables, NAT, conntrack, nftables) sits
+# on. CONFIG_NETFILTER_ADVANCED unlocks the dependent options that lean
+# can't even reference because the parent is off.
+CONFIG_NETFILTER=y
+CONFIG_NETFILTER_ADVANCED=y
+CONFIG_NF_CONNTRACK=y
+CONFIG_NF_CONNTRACK_PROCFS=y
+CONFIG_NF_LOG_SYSLOG=y
+
+# ── xtables (iptables backend) ────────────────────────────────────────────
+# Docker's iptables driver writes filter/nat rules through ip_tables /
+# ip6_tables which sit on top of the xtables framework. The MATCH/TARGET
+# modules cover the rule shapes Docker ships by default.
+CONFIG_NETFILTER_XTABLES=y
+CONFIG_NETFILTER_XT_MARK=y
+CONFIG_NETFILTER_XT_CONNMARK=y
+CONFIG_NETFILTER_XT_TARGET_MASQUERADE=y
+CONFIG_NETFILTER_XT_TARGET_REDIRECT=y
+CONFIG_NETFILTER_XT_NAT=y
+CONFIG_NETFILTER_XT_MATCH_ADDRTYPE=y
+CONFIG_NETFILTER_XT_MATCH_CONNTRACK=y
+CONFIG_NETFILTER_XT_MATCH_IPVS=y
+CONFIG_NETFILTER_XT_MATCH_MULTIPORT=y
+CONFIG_NETFILTER_XT_MATCH_PHYSDEV=y
+
+# ── NAT ───────────────────────────────────────────────────────────────────
+# Docker's port publishing (`-p 8080:80`) and outbound MASQUERADE rely on
+# the netfilter NAT engine. NF_NAT is the core; the iptables / nftables
+# NAT modules expose it through the respective rule shapes.
+CONFIG_NF_NAT=y
+CONFIG_NF_NAT_REDIRECT=y
+CONFIG_NF_NAT_MASQUERADE=y
+
+# ── iptables (legacy backend) ─────────────────────────────────────────────
+# Docker still prefers iptables-legacy on most distros; cover the rule
+# tables it manipulates (filter for DOCKER chains, nat for port mapping
+# and MASQUERADE).
+CONFIG_IP_NF_IPTABLES=y
+CONFIG_IP_NF_FILTER=y
+CONFIG_IP_NF_NAT=y
+CONFIG_IP_NF_TARGET_MASQUERADE=y
+CONFIG_IP_NF_MANGLE=y
+
+# ── ip6tables (IPv6 iptables) ─────────────────────────────────────────────
+# Docker's daemon shows the warning "ip6tables is enabled, but cannot set
+# up ip6tables chains" when these are absent. Enabling them silences the
+# warning and lets IPv6 docker networks work.
+CONFIG_IP6_NF_IPTABLES=y
+CONFIG_IP6_NF_FILTER=y
+CONFIG_IP6_NF_NAT=y
+CONFIG_IP6_NF_TARGET_MASQUERADE=y
+CONFIG_IP6_NF_MANGLE=y
+
+# ── nftables (modern backend) ─────────────────────────────────────────────
+# Docker 24+ on many distros uses nftables for new networks even when
+# iptables-legacy is on for old ones. The nf_tables core + ip/ip6 chain
+# tables let both legacy and nft-mode Docker work.
+CONFIG_NF_TABLES=y
+CONFIG_NF_TABLES_INET=y
+CONFIG_NF_TABLES_IPV4=y
+CONFIG_NF_TABLES_IPV6=y
+CONFIG_NFT_NAT=y
+CONFIG_NFT_MASQ=y
+CONFIG_NFT_REDIR=y
+CONFIG_NFT_CT=y
+CONFIG_NFT_REJECT=y
+CONFIG_NFT_CHAIN_NAT=y
+
+# ── iptables-nft compatibility shim ───────────────────────────────────────
+# On Debian / Alpine the iptables binary that ships in docker:dind is
+# iptables-nft (v1.8.x), which translates legacy iptables rules into the
+# nftables backend. Without NFT_COMPAT the xt_* match extensions (addrtype,
+# conntrack, mark, etc.) can't be used through iptables-nft and dockerd
+# fails to register the bridge driver with:
+#   "Extension addrtype revision 0 not supported, missing kernel module"
+# (observed in #276 reproducer logs when this option is off).
+CONFIG_NFT_COMPAT=y
+
+# ── REJECT target ─────────────────────────────────────────────────────────
+# Used by the DOCKER-ISOLATION chains to drop cross-network traffic; without
+# it dockerd registers the rule but the kernel returns -ENOENT on insertion.
+CONFIG_IP_NF_TARGET_REJECT=y
+CONFIG_IP6_NF_TARGET_REJECT=y
+CONFIG_NETFILTER_XT_MATCH_STATE=y
+
+# ── Net namespace forwarding ──────────────────────────────────────────────
+# Containers on docker bridge need IP forwarding turned on at the netns
+# level. The sysctl /proc/sys/net/ipv4/ip_forward only exists when this
+# is built in.
+CONFIG_NET_NS=y
+
+# ── POSIX message queues ──────────────────────────────────────────────────
+# Every OCI container created by runc/containerd has /dev/mqueue in its
+# default mounts list. Without CONFIG_POSIX_MQUEUE the mount syscall fails
+# with ENODEV ("no such device") and container creation aborts before
+# entrypoint runs — observed under `docker start` on a dind kernel
+# without this enabled.
+CONFIG_POSIX_MQUEUE=y

--- a/src/deps/libkrun-sys/dind-configs/overlay-dind_x86_64
+++ b/src/deps/libkrun-sys/dind-configs/overlay-dind_x86_64
@@ -1,0 +1,116 @@
+# Overlay applied on top of config-libkrunfw_x86_64 by `make libkrunfw-dind`.
+# Enables the kernel subsystems Docker needs for bridge networks, NAT, and
+# iptables rule installation — the dind / docker-compose workflows broken
+# under the lean profile (issue #276). Every line is built-in (=y) because
+# the libkrunfw guest has no /lib/modules and can't load loadable modules
+# at runtime.
+
+# ── Bridge networking ─────────────────────────────────────────────────────
+# Docker creates one Linux bridge per network (default `docker0` + one per
+# user-defined network in compose). Each container is wired in via a veth
+# pair (CONFIG_VETH is already on in lean). Bridge netfilter exposes the
+# /proc/sys/net/bridge/bridge-nf-* knobs Docker probes for.
+CONFIG_BRIDGE=y
+CONFIG_BRIDGE_NETFILTER=y
+CONFIG_LLC=y
+CONFIG_STP=y
+
+# ── Netfilter core ────────────────────────────────────────────────────────
+# Foundation that everything else (xtables, NAT, conntrack, nftables) sits
+# on. CONFIG_NETFILTER_ADVANCED unlocks the dependent options that lean
+# can't even reference because the parent is off.
+CONFIG_NETFILTER=y
+CONFIG_NETFILTER_ADVANCED=y
+CONFIG_NF_CONNTRACK=y
+CONFIG_NF_CONNTRACK_PROCFS=y
+CONFIG_NF_LOG_SYSLOG=y
+
+# ── xtables (iptables backend) ────────────────────────────────────────────
+# Docker's iptables driver writes filter/nat rules through ip_tables /
+# ip6_tables which sit on top of the xtables framework. The MATCH/TARGET
+# modules cover the rule shapes Docker ships by default.
+CONFIG_NETFILTER_XTABLES=y
+CONFIG_NETFILTER_XT_MARK=y
+CONFIG_NETFILTER_XT_CONNMARK=y
+CONFIG_NETFILTER_XT_TARGET_MASQUERADE=y
+CONFIG_NETFILTER_XT_TARGET_REDIRECT=y
+CONFIG_NETFILTER_XT_NAT=y
+CONFIG_NETFILTER_XT_MATCH_ADDRTYPE=y
+CONFIG_NETFILTER_XT_MATCH_CONNTRACK=y
+CONFIG_NETFILTER_XT_MATCH_IPVS=y
+CONFIG_NETFILTER_XT_MATCH_MULTIPORT=y
+CONFIG_NETFILTER_XT_MATCH_PHYSDEV=y
+
+# ── NAT ───────────────────────────────────────────────────────────────────
+# Docker's port publishing (`-p 8080:80`) and outbound MASQUERADE rely on
+# the netfilter NAT engine. NF_NAT is the core; the iptables / nftables
+# NAT modules expose it through the respective rule shapes.
+CONFIG_NF_NAT=y
+CONFIG_NF_NAT_REDIRECT=y
+CONFIG_NF_NAT_MASQUERADE=y
+
+# ── iptables (legacy backend) ─────────────────────────────────────────────
+# Docker still prefers iptables-legacy on most distros; cover the rule
+# tables it manipulates (filter for DOCKER chains, nat for port mapping
+# and MASQUERADE).
+CONFIG_IP_NF_IPTABLES=y
+CONFIG_IP_NF_FILTER=y
+CONFIG_IP_NF_NAT=y
+CONFIG_IP_NF_TARGET_MASQUERADE=y
+CONFIG_IP_NF_MANGLE=y
+
+# ── ip6tables (IPv6 iptables) ─────────────────────────────────────────────
+# Docker's daemon shows the warning "ip6tables is enabled, but cannot set
+# up ip6tables chains" when these are absent. Enabling them silences the
+# warning and lets IPv6 docker networks work.
+CONFIG_IP6_NF_IPTABLES=y
+CONFIG_IP6_NF_FILTER=y
+CONFIG_IP6_NF_NAT=y
+CONFIG_IP6_NF_TARGET_MASQUERADE=y
+CONFIG_IP6_NF_MANGLE=y
+
+# ── nftables (modern backend) ─────────────────────────────────────────────
+# Docker 24+ on many distros uses nftables for new networks even when
+# iptables-legacy is on for old ones. The nf_tables core + ip/ip6 chain
+# tables let both legacy and nft-mode Docker work.
+CONFIG_NF_TABLES=y
+CONFIG_NF_TABLES_INET=y
+CONFIG_NF_TABLES_IPV4=y
+CONFIG_NF_TABLES_IPV6=y
+CONFIG_NFT_NAT=y
+CONFIG_NFT_MASQ=y
+CONFIG_NFT_REDIR=y
+CONFIG_NFT_CT=y
+CONFIG_NFT_REJECT=y
+CONFIG_NFT_CHAIN_NAT=y
+
+# ── iptables-nft compatibility shim ───────────────────────────────────────
+# On Debian / Alpine the iptables binary that ships in docker:dind is
+# iptables-nft (v1.8.x), which translates legacy iptables rules into the
+# nftables backend. Without NFT_COMPAT the xt_* match extensions (addrtype,
+# conntrack, mark, etc.) can't be used through iptables-nft and dockerd
+# fails to register the bridge driver with:
+#   "Extension addrtype revision 0 not supported, missing kernel module"
+# (observed in #276 reproducer logs when this option is off).
+CONFIG_NFT_COMPAT=y
+
+# ── REJECT target ─────────────────────────────────────────────────────────
+# Used by the DOCKER-ISOLATION chains to drop cross-network traffic; without
+# it dockerd registers the rule but the kernel returns -ENOENT on insertion.
+CONFIG_IP_NF_TARGET_REJECT=y
+CONFIG_IP6_NF_TARGET_REJECT=y
+CONFIG_NETFILTER_XT_MATCH_STATE=y
+
+# ── Net namespace forwarding ──────────────────────────────────────────────
+# Containers on docker bridge need IP forwarding turned on at the netns
+# level. The sysctl /proc/sys/net/ipv4/ip_forward only exists when this
+# is built in.
+CONFIG_NET_NS=y
+
+# ── POSIX message queues ──────────────────────────────────────────────────
+# Every OCI container created by runc/containerd has /dev/mqueue in its
+# default mounts list. Without CONFIG_POSIX_MQUEUE the mount syscall fails
+# with ENODEV ("no such device") and container creation aborts before
+# entrypoint runs — observed under `docker start` on a dind kernel
+# without this enabled.
+CONFIG_POSIX_MQUEUE=y

--- a/src/guest/src/container/capabilities.rs
+++ b/src/guest/src/container/capabilities.rs
@@ -58,6 +58,122 @@ pub fn capability_names() -> Vec<String> {
     .collect()
 }
 
+/// Expanded capability set for boxes started with `--support-docker`.
+///
+/// Equivalent to `docker run --privileged`: every capability the host kernel
+/// recognises, granted to the container process. Required so a docker daemon
+/// inside the box can mount cgroup hierarchies, manipulate network namespaces,
+/// load iptables rules, etc.
+///
+/// SECURITY: This is the full Linux capability set. Code running as root
+/// inside a box with this set can mount arbitrary filesystems, modify
+/// network configuration, write to all of /proc and /sys, and perform every
+/// container-escape primitive that requires capabilities. The microVM
+/// boundary still contains the process — host stays protected by KVM/libkrun
+/// isolation — but the in-VM blast radius is effectively `root`. Only use
+/// this for trusted workloads or where you would otherwise use
+/// `docker run --privileged`.
+pub fn docker_capabilities() -> HashSet<Capability> {
+    [
+        Capability::AuditControl,
+        Capability::AuditRead,
+        Capability::AuditWrite,
+        Capability::BlockSuspend,
+        Capability::Bpf,
+        Capability::CheckpointRestore,
+        Capability::Chown,
+        Capability::DacOverride,
+        Capability::DacReadSearch,
+        Capability::Fowner,
+        Capability::Fsetid,
+        Capability::IpcLock,
+        Capability::IpcOwner,
+        Capability::Kill,
+        Capability::Lease,
+        Capability::LinuxImmutable,
+        Capability::MacAdmin,
+        Capability::MacOverride,
+        Capability::Mknod,
+        Capability::NetAdmin,
+        Capability::NetBindService,
+        Capability::NetBroadcast,
+        Capability::NetRaw,
+        Capability::Perfmon,
+        Capability::Setgid,
+        Capability::Setfcap,
+        Capability::Setpcap,
+        Capability::Setuid,
+        Capability::SysAdmin,
+        Capability::SysBoot,
+        Capability::SysChroot,
+        Capability::SysModule,
+        Capability::SysNice,
+        Capability::SysPacct,
+        Capability::SysPtrace,
+        Capability::SysRawio,
+        Capability::SysResource,
+        Capability::SysTime,
+        Capability::SysTtyConfig,
+        Capability::Syslog,
+        Capability::WakeAlarm,
+    ]
+    .into_iter()
+    .collect()
+}
+
+/// String-name counterpart to `docker_capabilities()` for libcontainer's
+/// tenant-exec builder. Used by the zygote when spawning exec'd processes
+/// inside a `--support-docker` container so they inherit the same expanded
+/// privileges as the init process.
+pub fn docker_capability_names() -> Vec<String> {
+    [
+        "CAP_AUDIT_CONTROL",
+        "CAP_AUDIT_READ",
+        "CAP_AUDIT_WRITE",
+        "CAP_BLOCK_SUSPEND",
+        "CAP_BPF",
+        "CAP_CHECKPOINT_RESTORE",
+        "CAP_CHOWN",
+        "CAP_DAC_OVERRIDE",
+        "CAP_DAC_READ_SEARCH",
+        "CAP_FOWNER",
+        "CAP_FSETID",
+        "CAP_IPC_LOCK",
+        "CAP_IPC_OWNER",
+        "CAP_KILL",
+        "CAP_LEASE",
+        "CAP_LINUX_IMMUTABLE",
+        "CAP_MAC_ADMIN",
+        "CAP_MAC_OVERRIDE",
+        "CAP_MKNOD",
+        "CAP_NET_ADMIN",
+        "CAP_NET_BIND_SERVICE",
+        "CAP_NET_BROADCAST",
+        "CAP_NET_RAW",
+        "CAP_PERFMON",
+        "CAP_SETGID",
+        "CAP_SETFCAP",
+        "CAP_SETPCAP",
+        "CAP_SETUID",
+        "CAP_SYS_ADMIN",
+        "CAP_SYS_BOOT",
+        "CAP_SYS_CHROOT",
+        "CAP_SYS_MODULE",
+        "CAP_SYS_NICE",
+        "CAP_SYS_PACCT",
+        "CAP_SYS_PTRACE",
+        "CAP_SYS_RAWIO",
+        "CAP_SYS_RESOURCE",
+        "CAP_SYS_TIME",
+        "CAP_SYS_TTY_CONFIG",
+        "CAP_SYSLOG",
+        "CAP_WAKE_ALARM",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/guest/src/container/command.rs
+++ b/src/guest/src/container/command.rs
@@ -65,6 +65,10 @@ pub struct ContainerCommand {
 
     /// PTY configuration (set via with_pty())
     pty_config: Option<PtyConfig>,
+
+    /// Inherited from the parent Container — drives capability set selection
+    /// at zygote build time. See `Container::support_docker`.
+    support_docker: bool,
 }
 
 impl ContainerCommand {
@@ -78,6 +82,7 @@ impl ContainerCommand {
         env: HashMap<String, String>,
         user: (u32, u32),
         rootfs: PathBuf,
+        support_docker: bool,
     ) -> Self {
         Self {
             program: None,
@@ -91,6 +96,7 @@ impl ContainerCommand {
             pty_config: None,
             id,
             state_root,
+            support_docker,
         }
     }
 
@@ -386,6 +392,7 @@ impl ContainerCommand {
             args: container_args.clone(),
             uid,
             gid,
+            support_docker: self.support_docker,
         };
 
         // Blocking IPC to zygote — use spawn_blocking to not block tokio.
@@ -556,6 +563,7 @@ mod tests {
             HashMap::new(),
             (0, 0),
             PathBuf::from("/tmp/rootfs"),
+            false,
         )
     }
 

--- a/src/guest/src/container/lifecycle.rs
+++ b/src/guest/src/container/lifecycle.rs
@@ -51,6 +51,11 @@ pub struct Container {
     /// Dropping this closes pipes → init gets EOF → init exits.
     #[allow(dead_code)]
     stdio: ContainerStdio,
+    /// True when the box was started with `--support-docker`. Propagated to
+    /// every exec'd process so they inherit the same expanded capability set
+    /// as the init process — without this, `docker exec`-style commands inside
+    /// a dind box would silently lose CAP_SYS_ADMIN and the like.
+    support_docker: bool,
     /// Flag to track if shutdown() was called (prevents double-kill in Drop).
     is_shutdown: std::sync::atomic::AtomicBool,
 }
@@ -81,6 +86,7 @@ impl Container {
     /// - Failed to create container directory
     /// - Failed to create or start container
     /// - Init process exited immediately
+    #[allow(clippy::too_many_arguments)]
     pub fn start(
         container_id: &str,
         rootfs: impl AsRef<Path>,
@@ -89,6 +95,7 @@ impl Container {
         workdir: impl AsRef<Path>,
         user: &str,
         user_mounts: Vec<UserMount>,
+        support_docker: bool,
     ) -> BoxliteResult<Self> {
         let rootfs = rootfs.as_ref();
         let workdir = workdir.as_ref();
@@ -163,6 +170,7 @@ impl Container {
             gid,
             &layout.containers_dir(),
             &user_mounts,
+            support_docker,
         )?;
 
         // Create stdio pipes before container creation.
@@ -180,6 +188,7 @@ impl Container {
             env: env_map,
             user: (uid, gid),
             stdio,
+            support_docker,
             is_shutdown: std::sync::atomic::AtomicBool::new(false),
         })
     }
@@ -266,6 +275,7 @@ impl Container {
             self.env.clone(),
             self.user,
             self.bundle_path.join("rootfs"),
+            self.support_docker,
         )
     }
 

--- a/src/guest/src/container/spec.rs
+++ b/src/guest/src/container/spec.rs
@@ -93,7 +93,7 @@ pub fn create_oci_spec(
 
     let process = build_process_spec(entrypoint, env, workdir, uid, gid, caps)?;
     let root = build_root_spec(rootfs)?;
-    let linux = build_linux_spec(container_id, namespaces)?;
+    let linux = build_linux_spec(container_id, namespaces, support_docker)?;
 
     SpecBuilder::default()
         .version("1.0.2")
@@ -366,6 +366,7 @@ fn build_root_spec(rootfs: &str) -> BoxliteResult<oci_spec::runtime::Root> {
 fn build_linux_spec(
     container_id: &str,
     namespaces: Vec<oci_spec::runtime::LinuxNamespace>,
+    support_docker: bool,
 ) -> BoxliteResult<oci_spec::runtime::Linux> {
     // UID/GID mappings for user namespace
     // Map full range of UIDs/GIDs to allow non-root users (nginx=33, etc.)
@@ -413,15 +414,53 @@ fn build_linux_spec(
     // let cgroups_path = format!("/boxlite/{}", container_id);
     let _ = container_id; // Suppress unused warning
 
-    LinuxBuilder::default()
+    let mut builder = LinuxBuilder::default()
         .namespaces(namespaces)
         .uid_mappings(uid_mappings)
-        .gid_mappings(gid_mappings)
-        // .masked_paths(masked_paths)
-        // .readonly_paths(readonly_paths)
-        // .cgroups_path(cgroups_path)
+        .gid_mappings(gid_mappings);
+    // .masked_paths(masked_paths)
+    // .readonly_paths(readonly_paths)
+    // .cgroups_path(cgroups_path)
+
+    // --support-docker: explicitly clear masked_paths + readonly_paths so
+    // libcontainer doesn't apply its default /proc hardening (which bind-
+    // mounts /proc/sys ro on top of our writable procfs). dockerd needs
+    // /proc/sys/net/ipv4/ip_forward writable to bring up the default bridge
+    // network — without it network controller init fails:
+    //   "failed to set IP forwarding ... read-only file system"
+    //
+    // Empty `Vec` here is meaningful: the OCI spec runtime treats `Some([])`
+    // as "no paths" and `None` as "apply runtime defaults". We want the
+    // former for `--support-docker` (no masking, no readonly), matching
+    // `docker run --privileged` semantics.
+    if support_docker {
+        // KNOWN-LIMITATION (Phase B, dockerd default bridge): we set
+        // readonly_paths and masked_paths to empty so dockerd inside the
+        // box can write `/proc/sys/net/ipv4/ip_forward` etc. when bringing
+        // up its default `bridge` network. Verified end-to-end: the OCI
+        // spec written to config.json correctly contains
+        // `readonlyPaths: []` and `maskedPaths: []`, and a reload via
+        // `oci_spec::runtime::Spec::load` returns Some([]) — yet the
+        // container still ends up with `/proc/bus`, `/proc/fs`, `/proc/irq`,
+        // `/proc/sys` bind-mounted ro,nosuid,nodev,noexec by libcontainer-
+        // 0.5.7. Setting these paths to non-existent strings DOES change
+        // behaviour (rootfs prep fails) so the override IS being honoured
+        // somewhere — but the default hardening still slips through.
+        // Root cause TBD; tracked as a follow-up. Workaround: dind users
+        // must pass `dockerd --bridge=none --iptables=false` until this
+        // is resolved (the kernel side works — /proc/sys/net/bridge/ is
+        // populated, iptables rules can be installed via nft_compat —
+        // the only blocker is dockerd's automatic default-bridge setup
+        // hitting the ro /proc/sys).
+        builder = builder
+            .masked_paths(Vec::<String>::new())
+            .readonly_paths(Vec::<String>::new());
+    }
+
+    let linux = builder
         .build()
-        .map_err(|e| BoxliteError::Internal(format!("Failed to build linux spec: {}", e)))
+        .map_err(|e| BoxliteError::Internal(format!("Failed to build linux spec: {}", e)))?;
+    Ok(linux)
 }
 
 /// Build standard mounts for container filesystem
@@ -536,6 +575,13 @@ fn build_standard_mounts(bundle_path: &Path, support_docker: bool) -> BoxliteRes
                     BoxliteError::Internal(format!("Failed to build /sys/fs/cgroup mount: {}", e))
                 })?,
         );
+
+        // /proc/sys writability comes from clearing readonly_paths in
+        // build_linux_spec (the OCI runtime-spec mechanism). Don't add an
+        // explicit /proc/sys mount here — libcontainer's check_proc_mount
+        // whitelist rejects everything under /proc except a handful of
+        // host-emulated entries (/proc/cpuinfo etc.) and would refuse the
+        // mount with "not a valid mount under /proc".
     }
 
     // Bind-mount /etc/hostname, /etc/hosts, /etc/resolv.conf from the bundle

--- a/src/guest/src/container/spec.rs
+++ b/src/guest/src/container/spec.rs
@@ -54,10 +54,11 @@ pub fn create_oci_spec(
     gid: u32,
     bundle_path: &Path,
     user_mounts: &[UserMount],
+    support_docker: bool,
 ) -> BoxliteResult<Spec> {
-    let caps = build_default_capabilities()?;
+    let caps = build_capabilities(support_docker)?;
     let namespaces = build_default_namespaces()?;
-    let mut mounts = build_standard_mounts(bundle_path)?;
+    let mut mounts = build_standard_mounts(bundle_path, support_docker)?;
 
     // Add user-specified bind mounts
     for user_mount in user_mounts {
@@ -264,9 +265,20 @@ fn find_group_in_group_file(rootfs: &str, name: &str) -> BoxliteResult<u32> {
 // Spec Component Builders
 // ====================
 
-/// Build default Linux capabilities matching Docker/OCI defaults.
-fn build_default_capabilities() -> BoxliteResult<oci_spec::runtime::LinuxCapabilities> {
-    let caps = default_capabilities();
+/// Build Linux capabilities for the container's init process.
+///
+/// `support_docker=false` (default): the 14 Docker/OCI defaults — sufficient for
+/// most workloads, excludes CAP_SYS_ADMIN / CAP_NET_ADMIN / CAP_SYS_MODULE / etc.
+///
+/// `support_docker=true`: the full privileged set (see
+/// `capabilities::docker_capabilities`). Required so a dockerd inside the box
+/// can mount cgroups, set up bridge interfaces, install iptables rules, etc.
+fn build_capabilities(support_docker: bool) -> BoxliteResult<oci_spec::runtime::LinuxCapabilities> {
+    let caps = if support_docker {
+        super::capabilities::docker_capabilities()
+    } else {
+        default_capabilities()
+    };
 
     LinuxCapabilitiesBuilder::default()
         .bounding(caps.clone())
@@ -413,7 +425,7 @@ fn build_linux_spec(
 }
 
 /// Build standard mounts for container filesystem
-fn build_standard_mounts(bundle_path: &Path) -> BoxliteResult<Vec<Mount>> {
+fn build_standard_mounts(bundle_path: &Path, support_docker: bool) -> BoxliteResult<Vec<Mount>> {
     let mut mounts = vec![
         // /proc - Process information
         MountBuilder::default()
@@ -483,27 +495,12 @@ fn build_standard_mounts(bundle_path: &Path) -> BoxliteResult<Vec<Mount>> {
             ])
             .build()
             .map_err(|e| BoxliteError::Internal(format!("Failed to build /sys mount: {}", e)))?,
-        // NOTE: /sys/fs/cgroup mount disabled for performance
-        // Mounting cgroup2 filesystem takes ~105ms due to kernel cgroup hierarchy initialization.
-        // This is the main bottleneck in container startup. Since we're inside a VM with
-        // single-tenant isolation, cgroup resource limits provide minimal benefit.
-        // Re-enable if you need to enforce CPU/memory limits within the container.
+        // NOTE: /sys/fs/cgroup mount is disabled by default for performance —
+        // mounting cgroup2 takes ~105ms due to kernel hierarchy initialization,
+        // and a single-tenant VM gets minimal benefit from in-container cgroups.
+        // The `support_docker` profile re-enables it as `rw` below so a docker
+        // daemon inside the box can write cgroup limits for its child containers.
         //
-        // MountBuilder::default()
-        //     .destination("/sys/fs/cgroup")
-        //     .typ("cgroup")
-        //     .source("cgroup")
-        //     .options(vec![
-        //         "nosuid".to_string(),
-        //         "noexec".to_string(),
-        //         "nodev".to_string(),
-        //         "relatime".to_string(),
-        //         "ro".to_string(),
-        //     ])
-        //     .build()
-        //     .map_err(|e| {
-        //         BoxliteError::Internal(format!("Failed to build /sys/fs/cgroup mount: {}", e))
-        //     })?,
         // /tmp - Temporary filesystem
         MountBuilder::default()
             .destination("/tmp")
@@ -517,6 +514,29 @@ fn build_standard_mounts(bundle_path: &Path) -> BoxliteResult<Vec<Mount>> {
             .build()
             .map_err(|e| BoxliteError::Internal(format!("Failed to build /tmp mount: {}", e)))?,
     ];
+
+    // --support-docker: re-enable /sys/fs/cgroup as a writable cgroup2 mount
+    // so the in-box docker daemon can manage cgroup limits for its children.
+    // Costs ~105ms at startup; only paid when the user opts in.
+    if support_docker {
+        mounts.push(
+            MountBuilder::default()
+                .destination("/sys/fs/cgroup")
+                .typ("cgroup2")
+                .source("cgroup")
+                .options(vec![
+                    "nosuid".to_string(),
+                    "noexec".to_string(),
+                    "nodev".to_string(),
+                    "relatime".to_string(),
+                    "rw".to_string(),
+                ])
+                .build()
+                .map_err(|e| {
+                    BoxliteError::Internal(format!("Failed to build /sys/fs/cgroup mount: {}", e))
+                })?,
+        );
+    }
 
     // Bind-mount /etc/hostname, /etc/hosts, /etc/resolv.conf from the bundle
     // dir into the container. Uses rbind + rprivate (matching Docker defaults).

--- a/src/guest/src/container/start.rs
+++ b/src/guest/src/container/start.rs
@@ -104,6 +104,7 @@ pub(crate) fn create_oci_bundle(
     gid: u32,
     bundle_root: &Path,
     user_mounts: &[spec::UserMount],
+    support_docker: bool,
 ) -> BoxliteResult<PathBuf> {
     let bundle_path = bundle_root.join(container_id);
 
@@ -133,6 +134,7 @@ pub(crate) fn create_oci_bundle(
         gid,
         &bundle_path,
         user_mounts,
+        support_docker,
     )?;
     let config_path = bundle_path.join("config.json");
 

--- a/src/guest/src/container/zygote.rs
+++ b/src/guest/src/container/zygote.rs
@@ -11,7 +11,7 @@
 //!
 //! See `docs/investigations/concurrent-exec-deadlock.md` for full analysis.
 
-use super::capabilities::capability_names;
+use super::capabilities::{capability_names, docker_capability_names};
 use boxlite_shared::errors::{BoxliteError, BoxliteResult};
 use libcontainer::container::builder::ContainerBuilder;
 use libcontainer::syscall::syscall::SyscallType;
@@ -58,6 +58,14 @@ pub(crate) struct BuildSpec {
     pub args: Vec<String>,
     pub uid: u32,
     pub gid: u32,
+    /// Inherited from the parent Container — selects the capability set used
+    /// when the zygote builds the tenant process. `false` (default) gives the
+    /// 14 Docker defaults; `true` gives the full privileged set so dockerd
+    /// inside a `--support-docker` box has the caps it needs.
+    /// `#[serde(default)]` so older zygotes (during rolling upgrades) decode
+    /// new payloads without a versioning bump — missing field reads as false.
+    #[serde(default)]
+    pub support_docker: bool,
 }
 
 /// Build outcome. Invalid states are unrepresentable.
@@ -254,9 +262,14 @@ fn do_build(spec: BuildSpec, fds: Option<[RawFd; 3]>) -> BuildResult {
                 .with_stderr(stderr);
         }
 
+        let caps = if spec.support_docker {
+            docker_capability_names()
+        } else {
+            capability_names()
+        };
         let pid = builder
             .as_tenant()
-            .with_capabilities(capability_names())
+            .with_capabilities(caps)
             .with_no_new_privs(false)
             .with_detach(false)
             .with_cwd(Some(spec.cwd))
@@ -449,6 +462,7 @@ mod tests {
             ],
             uid: 1000,
             gid: 1000,
+            support_docker: false,
         }
     }
 
@@ -544,6 +558,7 @@ mod tests {
             args: vec![],
             uid: 0,
             gid: 0,
+            support_docker: false,
         };
         let json = serde_json::to_vec(&spec).unwrap();
         let decoded: BuildSpec = serde_json::from_slice(&json).unwrap();
@@ -767,6 +782,7 @@ mod tests {
             args,
             uid: 65534,
             gid: 65534,
+            support_docker: false,
         };
 
         send_request(fd_a, &ZygoteRequest::Build(spec.clone()), None).unwrap();
@@ -796,6 +812,7 @@ mod tests {
             args: vec![],
             uid: 0,
             gid: 0,
+            support_docker: false,
         };
 
         let (a, _b) = socketpair(
@@ -948,6 +965,7 @@ mod tests {
                     args: vec!["echo".to_string()],
                     uid: 0,
                     gid: 0,
+                    support_docker: false,
                 };
                 z.build(spec, None).unwrap()
             }));

--- a/src/guest/src/service/container.rs
+++ b/src/guest/src/service/container.rs
@@ -255,6 +255,7 @@ impl ContainerService for GuestServer {
             &config.workdir,
             &config.user,
             user_mounts,
+            init_req.support_docker,
         ) {
             Ok(mut container) => {
                 debug!(container_id = %container_id, "Container started, checking if init process is running");

--- a/src/shared/proto/boxlite/v1/service.proto
+++ b/src/shared/proto/boxlite/v1/service.proto
@@ -208,6 +208,12 @@ message ContainerInitRequest {
   // Additional CA certificates to install in the container trust store.
   // Used for MITM secret substitution — the container trusts the proxy CA.
   repeated CACert ca_certs = 5;
+  // Opt-in `--support-docker` flag from BoxOptions. When true the guest
+  // mounts /sys/fs/cgroup as rw and grants the full Linux capability set
+  // to the container init + every exec'd process, so a docker daemon
+  // inside the box has the privileges it needs. Default-false preserves
+  // the existing lean / locked-down behaviour byte-for-byte.
+  bool support_docker = 6;
 }
 
 // A CA certificate to add to the container's trust store.


### PR DESCRIPTION
## Summary

Adds opt-in dind support to `boxlite run` via `--support-docker`, so you can run `dockerd` (and `docker build` / `docker run`) inside a box. Default behaviour is byte-for-byte unchanged — every existing user keeps the lean, non-docker flow.

Stack:

- **`feat(box): opt-in --support-docker`** — wires the flag through CLI → proto → guest; gates extra caps + cgroup rw + the dind kernel behind the explicit opt-in.
- **`feat(cli): --entrypoint`** — override an image's ENTRYPOINT (needed for early dind bring-up; kept as a general-purpose flag).
- **`feat(box): Phase B — dind-capable libkrunfw blob + runtime selection`** — adds `scripts/build/build-libkrunfw-dind.sh` + `make libkrunfw-dind`. The dind kernel (mqueue, netfilter, cgroup2, overlay) is built once (~10–20 min, cached) and selected per-box only when `--support-docker` is set; lean boxes still boot on the stock libkrunfw.
- **`feat(cli): --cmd`** — pass args to the image's real ENTRYPOINT without replacing it. Gated on `--support-docker` so the lean flow's `[COMMAND...]` semantics (secondary-exec attach) are unchanged. This drops the previous `--entrypoint sh` dind bypass; the image's own `dockerd-entrypoint.sh` now runs as PID 1.
- **`test(cli): dind end-to-end`** — `src/cli/tests/dind_build.rs` boots `docker:dind` under `--support-docker` and asserts `docker build` succeeds end-to-end against the real VM.

## Current limitation: `network=host` only

`dockerd` inside the box is launched with `--bridge=none --iptables=false --storage-driver=vfs`. That means:

- **`docker build` must use `--network=host`** (the e2e test does exactly this).
- `docker run` inside the box also effectively runs in the box's host network — there is no docker0 bridge and no NAT/iptables.
- Container-to-container networking via a user-defined bridge is **not** supported in this PR.

Why: libcontainer 0.5.7 still bind-remounts `/proc/sys` read-only inside the box, which breaks dockerd's default bridge + iptables setup. Disabling them is what lets dind boot cleanly today; restoring full bridged networking is follow-up work (needs either a libcontainer bump or a guest-side `/proc/sys` shim).

## One-line test

```
make libkrunfw-dind && make test:integration:dind
```

- `make libkrunfw-dind` is the one-time ~10–20 min kernel build (cached at `target/dind-kernel/lib64/libkrunfw-dind.so.5` afterwards).
- `make test:integration:dind` runs just the dind end-to-end (`dind_supports_docker_build`). Under the hood it's a thin alias for `make test:integration:cli FILTER=dind_supports_docker_build`, which exports `BOXLITE_LIBKRUNFW_DIND_PATH` so the CLI build staples the dind blob into the embedded runtime.
- On hosts that genuinely can't run dind (no nested virt, restrictive security profile): `BOXLITE_SKIP_DIND_TEST=1 make test:integration:cli` skips just that test.

## Test plan

- [x] `make test:unit:core` (rust + ffi + cli unit suites) green
- [x] `make libkrunfw-dind && make test:integration:dind` green on a host with nested virt
- [x] `make test:integration:cli` green (full CLI matrix incl. dind)
- [ ] Spot-check on a host without nested virt: `BOXLITE_SKIP_DIND_TEST=1 make test:integration:cli` skips dind, rest passes
- [ ] Verify `boxlite run` without `--support-docker` is byte-for-byte unchanged on a representative image
