### PR TITLE
fix(api): auto-reconcile v2 boxes stuck in ERROR back toward STARTED

### DIFF
--- a/apps/api/src/box/managers/box.manager.reconcile.spec.ts
+++ b/apps/api/src/box/managers/box.manager.reconcile.spec.ts
@@ -6,6 +6,7 @@
 
 import { BoxManager } from './box.manager'
 import { BoxState } from '../enums/box-state.enum'
+import { BoxDesiredState } from '../enums/box-desired-state.enum'
 
 type Candidate = { id: string; runnerId: string | null }
 
@@ -74,7 +75,12 @@ describe('BoxManager.reconcileErroredBoxes', () => {
     expect(updateWhere).toHaveBeenCalledTimes(1)
     expect(updateWhere).toHaveBeenCalledWith('box-1', {
       updateData: { state: BoxState.STOPPED, errorReason: null },
-      whereCondition: { state: BoxState.ERROR },
+      whereCondition: {
+        state: BoxState.ERROR,
+        pending: false,
+        desiredState: BoxDesiredState.STARTED,
+        runnerId: 'runner-1',
+      },
     })
   })
 
@@ -97,7 +103,30 @@ describe('BoxManager.reconcileErroredBoxes', () => {
     // And such a (non-recoverable) box is still driven back toward STARTED.
     expect(updateWhere).toHaveBeenCalledWith('box-splitbrain', {
       updateData: { state: BoxState.STOPPED, errorReason: null },
-      whereCondition: { state: BoxState.ERROR },
+      whereCondition: {
+        state: BoxState.ERROR,
+        pending: false,
+        desiredState: BoxDesiredState.STARTED,
+        runnerId: 'runner-1',
+      },
+    })
+  })
+
+  it('guards the atomic transition with the same stable fields used for eligibility', async () => {
+    const { manager, updateWhere } = buildHarness({
+      candidates: [{ id: 'box-1', runnerId: 'runner-1' }],
+    })
+
+    await manager.reconcileErroredBoxes()
+
+    expect(updateWhere).toHaveBeenCalledWith('box-1', {
+      updateData: { state: BoxState.STOPPED, errorReason: null },
+      whereCondition: {
+        state: BoxState.ERROR,
+        pending: false,
+        desiredState: BoxDesiredState.STARTED,
+        runnerId: 'runner-1',
+      },
     })
   })
 

--- a/apps/api/src/box/managers/box.manager.reconcile.spec.ts
+++ b/apps/api/src/box/managers/box.manager.reconcile.spec.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { BoxManager } from './box.manager'
+import { BoxState } from '../enums/box-state.enum'
+
+type Candidate = { id: string; runnerId: string | null }
+
+function buildHarness(opts: {
+  candidates: Candidate[]
+  apiVersion?: string
+  failedStartJobs?: number
+  boxLocked?: boolean
+  globalLockAcquired?: boolean
+}) {
+  const updateWhere = jest.fn().mockResolvedValue(undefined)
+
+  const queryBuilder: any = {
+    select: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    getMany: jest.fn().mockResolvedValue(opts.candidates),
+  }
+  const boxRepository: any = {
+    createQueryBuilder: jest.fn().mockReturnValue(queryBuilder),
+    updateWhere,
+  }
+
+  const runnerService: any = {
+    getRunnerApiVersion: jest.fn().mockResolvedValue(opts.apiVersion ?? '2'),
+  }
+
+  const redisLockProvider: any = {
+    lock: jest.fn().mockResolvedValue(opts.globalLockAcquired ?? true),
+    unlock: jest.fn().mockResolvedValue(undefined),
+    isLocked: jest.fn().mockResolvedValue(opts.boxLocked ?? false),
+  }
+
+  const jobRepository: any = {
+    count: jest.fn().mockResolvedValue(opts.failedStartJobs ?? 0),
+  }
+
+  const manager = new BoxManager(
+    boxRepository,
+    runnerService,
+    redisLockProvider,
+    {} as any,
+    {} as any,
+    {} as any,
+    jobRepository,
+  )
+
+  return { manager, updateWhere, runnerService, redisLockProvider, jobRepository }
+}
+
+describe('BoxManager.reconcileErroredBoxes', () => {
+  afterEach(() => jest.clearAllMocks())
+
+  it('flips a recoverable ERROR box to STOPPED so the start flow can re-drive it', async () => {
+    const { manager, updateWhere } = buildHarness({
+      candidates: [{ id: 'box-1', runnerId: 'runner-1' }],
+    })
+
+    await manager.reconcileErroredBoxes()
+
+    expect(updateWhere).toHaveBeenCalledTimes(1)
+    expect(updateWhere).toHaveBeenCalledWith('box-1', {
+      updateData: { state: BoxState.STOPPED, errorReason: null },
+      whereCondition: { state: BoxState.ERROR },
+    })
+  })
+
+  it('does not retry a box that already hit the recovery attempt ceiling', async () => {
+    const { manager, updateWhere, jobRepository } = buildHarness({
+      candidates: [{ id: 'box-1', runnerId: 'runner-1' }],
+      failedStartJobs: 5, // MAX_RECOVER_ATTEMPTS
+    })
+
+    await manager.reconcileErroredBoxes()
+
+    expect(jobRepository.count).toHaveBeenCalledTimes(1)
+    expect(updateWhere).not.toHaveBeenCalled()
+  })
+
+  it('skips boxes on non-v2 runners', async () => {
+    const { manager, updateWhere, jobRepository } = buildHarness({
+      candidates: [{ id: 'box-1', runnerId: 'runner-1' }],
+      apiVersion: '1',
+    })
+
+    await manager.reconcileErroredBoxes()
+
+    expect(jobRepository.count).not.toHaveBeenCalled()
+    expect(updateWhere).not.toHaveBeenCalled()
+  })
+
+  it('skips boxes the sync loop is already holding a lock on', async () => {
+    const { manager, updateWhere } = buildHarness({
+      candidates: [{ id: 'box-1', runnerId: 'runner-1' }],
+      boxLocked: true,
+    })
+
+    await manager.reconcileErroredBoxes()
+
+    expect(updateWhere).not.toHaveBeenCalled()
+  })
+
+  it('bails out without scanning when the global lock is held by another worker', async () => {
+    const { manager, updateWhere, redisLockProvider } = buildHarness({
+      candidates: [{ id: 'box-1', runnerId: 'runner-1' }],
+      globalLockAcquired: false,
+    })
+
+    await manager.reconcileErroredBoxes()
+
+    expect(updateWhere).not.toHaveBeenCalled()
+    expect(redisLockProvider.unlock).not.toHaveBeenCalled()
+  })
+})

--- a/apps/api/src/box/managers/box.manager.reconcile.spec.ts
+++ b/apps/api/src/box/managers/box.manager.reconcile.spec.ts
@@ -31,6 +31,9 @@ function buildHarness(opts: {
     updateWhere,
   }
 
+  const collectQueryClauses = () =>
+    [...queryBuilder.where.mock.calls, ...queryBuilder.andWhere.mock.calls].map((call: any[]) => String(call[0]))
+
   const runnerService: any = {
     getRunnerApiVersion: jest.fn().mockResolvedValue(opts.apiVersion ?? '2'),
   }
@@ -55,7 +58,7 @@ function buildHarness(opts: {
     jobRepository,
   )
 
-  return { manager, updateWhere, runnerService, redisLockProvider, jobRepository }
+  return { manager, updateWhere, runnerService, redisLockProvider, jobRepository, collectQueryClauses }
 }
 
 describe('BoxManager.reconcileErroredBoxes', () => {
@@ -70,6 +73,29 @@ describe('BoxManager.reconcileErroredBoxes', () => {
 
     expect(updateWhere).toHaveBeenCalledTimes(1)
     expect(updateWhere).toHaveBeenCalledWith('box-1', {
+      updateData: { state: BoxState.STOPPED, errorReason: null },
+      whereCondition: { state: BoxState.ERROR },
+    })
+  })
+
+  it('does not gate eligibility on the storage-only recoverable flag, so split-brain ERROR boxes qualify', async () => {
+    const { manager, updateWhere, collectQueryClauses } = buildHarness({
+      // A split-brain box (CREATE failed late while the box exists on the runner)
+      // is reported with recoverable=false; it must still be eligible for reconcile.
+      candidates: [{ id: 'box-splitbrain', runnerId: 'runner-1' }],
+    })
+
+    await manager.reconcileErroredBoxes()
+
+    const clauses = collectQueryClauses()
+    // The errors #578 targets (split-brain, timeout) are recoverable=false. Pre-filtering on
+    // box.recoverable (set true only for storage-full) would make the loop recover nothing.
+    expect(clauses.some((clause) => clause.includes('recoverable'))).toBe(false)
+    // Eligibility is still scoped to ERROR boxes that want to be STARTED.
+    expect(clauses.some((clause) => clause.includes('box.state'))).toBe(true)
+    expect(clauses.some((clause) => clause.includes('desiredState'))).toBe(true)
+    // And such a (non-recoverable) box is still driven back toward STARTED.
+    expect(updateWhere).toHaveBeenCalledWith('box-splitbrain', {
       updateData: { state: BoxState.STOPPED, errorReason: null },
       whereCondition: { state: BoxState.ERROR },
     })

--- a/apps/api/src/box/managers/box.manager.reconcile.spec.ts
+++ b/apps/api/src/box/managers/box.manager.reconcile.spec.ts
@@ -7,6 +7,7 @@
 import { BoxManager } from './box.manager'
 import { BoxState } from '../enums/box-state.enum'
 import { BoxDesiredState } from '../enums/box-desired-state.enum'
+import { Box } from '../entities/box.entity'
 
 type Candidate = { id: string; runnerId: string | null }
 
@@ -82,6 +83,21 @@ describe('BoxManager.reconcileErroredBoxes', () => {
         runnerId: 'runner-1',
       },
     })
+  })
+
+  it('keeps reconciled boxes pending because STOPPED is only a recovery waypoint toward STARTED', () => {
+    const box = new Box('us-east-1', 'box-1')
+    box.state = BoxState.ERROR
+    box.desiredState = BoxDesiredState.STARTED
+    box.pending = false
+
+    Object.assign(box, { state: BoxState.STOPPED, errorReason: null, recoverable: false })
+    const invariantChanges = box.enforceInvariants()
+
+    expect(invariantChanges.pending).toBe(true)
+    expect(box.pending).toBe(true)
+    expect(box.state).toBe(BoxState.STOPPED)
+    expect(box.desiredState).toBe(BoxDesiredState.STARTED)
   })
 
   it('does not gate eligibility on the storage-only recoverable flag, so split-brain ERROR boxes qualify', async () => {

--- a/apps/api/src/box/managers/box.manager.reconcile.spec.ts
+++ b/apps/api/src/box/managers/box.manager.reconcile.spec.ts
@@ -74,7 +74,7 @@ describe('BoxManager.reconcileErroredBoxes', () => {
 
     expect(updateWhere).toHaveBeenCalledTimes(1)
     expect(updateWhere).toHaveBeenCalledWith('box-1', {
-      updateData: { state: BoxState.STOPPED, errorReason: null },
+      updateData: { state: BoxState.STOPPED, errorReason: null, recoverable: false },
       whereCondition: {
         state: BoxState.ERROR,
         pending: false,
@@ -102,7 +102,7 @@ describe('BoxManager.reconcileErroredBoxes', () => {
     expect(clauses.some((clause) => clause.includes('desiredState'))).toBe(true)
     // And such a (non-recoverable) box is still driven back toward STARTED.
     expect(updateWhere).toHaveBeenCalledWith('box-splitbrain', {
-      updateData: { state: BoxState.STOPPED, errorReason: null },
+      updateData: { state: BoxState.STOPPED, errorReason: null, recoverable: false },
       whereCondition: {
         state: BoxState.ERROR,
         pending: false,
@@ -120,7 +120,7 @@ describe('BoxManager.reconcileErroredBoxes', () => {
     await manager.reconcileErroredBoxes()
 
     expect(updateWhere).toHaveBeenCalledWith('box-1', {
-      updateData: { state: BoxState.STOPPED, errorReason: null },
+      updateData: { state: BoxState.STOPPED, errorReason: null, recoverable: false },
       whereCondition: {
         state: BoxState.ERROR,
         pending: false,

--- a/apps/api/src/box/managers/box.manager.sync-error-job.spec.ts
+++ b/apps/api/src/box/managers/box.manager.sync-error-job.spec.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { BoxManager } from './box.manager'
+import { BoxState } from '../enums/box-state.enum'
+import { BoxDesiredState } from '../enums/box-desired-state.enum'
+import { JobType } from '../enums/job-type.enum'
+import { JobStatus } from '../enums/job-status.enum'
+
+// Job's constructor calls uuid's v4(), which needs a global WebCrypto the node-18
+// jest env doesn't expose. Mock it like the other box specs (e.g.
+// box-start.action.spec) so constructing a Job in the code under test stays
+// deterministic and crypto-free.
+jest.mock('uuid', () => ({ v4: jest.fn(() => 'mock-uuid') }))
+
+// Guards the reconcile retry ceiling: when a START_BOX sync throws *before* a
+// START_BOX job is ever persisted (synchronous runner lookup / adapter failure),
+// syncInstanceState must record a terminal FAILED START_BOX job so the ceiling —
+// which counts FAILED START_BOX jobs — can see the attempt. Otherwise the box is
+// flipped out of ERROR forever.
+function buildHarness(opts: {
+  box: { state: BoxState; desiredState: BoxDesiredState; runnerId: string | null }
+  failingAction: 'start' | 'stop'
+}) {
+  const box = { id: 'box-1', ...opts.box } as any
+
+  const insert = jest.fn().mockResolvedValue(undefined)
+  const updateWhere = jest.fn().mockResolvedValue(undefined)
+
+  const boxRepository: any = {
+    findOneOrFail: jest.fn().mockResolvedValue(box),
+    updateWhere,
+  }
+  const runnerService: any = {
+    getRunnerApiVersion: jest.fn().mockResolvedValue('2'),
+  }
+  const redisLockProvider: any = {
+    lock: jest.fn().mockResolvedValue(true),
+    unlock: jest.fn().mockResolvedValue(undefined),
+    isLocked: jest.fn().mockResolvedValue(false),
+  }
+  const thrower = jest.fn().mockRejectedValue(new Error('runner unreachable'))
+  const boxStartAction: any = { run: opts.failingAction === 'start' ? thrower : jest.fn() }
+  const boxStopAction: any = { run: opts.failingAction === 'stop' ? thrower : jest.fn() }
+  const boxDestroyAction: any = { run: jest.fn() }
+  const jobRepository: any = { insert, count: jest.fn().mockResolvedValue(0) }
+
+  const manager = new BoxManager(
+    boxRepository,
+    runnerService,
+    redisLockProvider,
+    boxStartAction,
+    boxStopAction,
+    boxDestroyAction,
+    jobRepository,
+  )
+  return { manager, insert, updateWhere }
+}
+
+describe('BoxManager.syncInstanceState — failed START_BOX accounting', () => {
+  afterEach(() => jest.clearAllMocks())
+
+  it('records a terminal FAILED START_BOX job when a STARTED sync throws before a job is persisted', async () => {
+    const { manager, insert, updateWhere } = buildHarness({
+      box: { state: BoxState.STOPPED, desiredState: BoxDesiredState.STARTED, runnerId: 'runner-1' },
+      failingAction: 'start',
+    })
+
+    await manager.syncInstanceState('box-1')
+
+    // The box is still transitioned to ERROR ...
+    expect(updateWhere).toHaveBeenCalledTimes(1)
+    // ... and a FAILED START_BOX job is recorded so the reconcile ceiling counts it.
+    expect(insert).toHaveBeenCalledTimes(1)
+    const job = insert.mock.calls[0][0]
+    expect(job).toMatchObject({
+      type: JobType.START_BOX,
+      status: JobStatus.FAILED,
+      resourceId: 'box-1',
+      runnerId: 'runner-1',
+    })
+    // completedAt set => row stays outside the "one incomplete job per box" partial-unique index.
+    expect(job.completedAt).toBeInstanceOf(Date)
+  })
+
+  it('does not record a START_BOX job when the failing sync is not a START (e.g. STOPPED)', async () => {
+    const { manager, insert, updateWhere } = buildHarness({
+      box: { state: BoxState.STARTED, desiredState: BoxDesiredState.STOPPED, runnerId: 'runner-1' },
+      failingAction: 'stop',
+    })
+
+    await manager.syncInstanceState('box-1')
+
+    expect(updateWhere).toHaveBeenCalledTimes(1) // still transitions to ERROR
+    expect(insert).not.toHaveBeenCalled() // but no synthetic START_BOX job
+  })
+
+  it('skips the synthetic job when the box has no runner', async () => {
+    const { manager, insert } = buildHarness({
+      box: { state: BoxState.STOPPED, desiredState: BoxDesiredState.STARTED, runnerId: null },
+      failingAction: 'start',
+    })
+
+    await manager.syncInstanceState('box-1')
+
+    expect(insert).not.toHaveBeenCalled()
+  })
+})

--- a/apps/api/src/box/managers/box.manager.ts
+++ b/apps/api/src/box/managers/box.manager.ts
@@ -327,7 +327,7 @@ export class BoxManager implements TrackableJobExecutions, OnApplicationShutdown
    * Recovery is bounded by counting recent failed START_BOX jobs for the box so a genuinely
    * dead box is not retried forever; the count is derived from the job table, not stored state.
    */
-  @Cron(CronExpression.EVERY_30_SECONDS, { name: 'reconcile-errored' })
+  @Cron(CronExpression.EVERY_MINUTE, { name: 'reconcile-errored' })
   @TrackJobExecution()
   @WithInstrumentation()
   @LogExecution('reconcile-errored')

--- a/apps/api/src/box/managers/box.manager.ts
+++ b/apps/api/src/box/managers/box.manager.ts
@@ -491,6 +491,35 @@ export class BoxManager implements TrackableJobExecutions, OnApplicationShutdown
 
           const { recoverable, errorReason } = sanitizeBoxError(error)
 
+          // A START_BOX attempt can throw before runnerAdapter.startBox() ever
+          // persists its START_BOX job (e.g. a synchronous runner lookup or
+          // adapter-creation failure). The reconcile retry ceiling counts FAILED
+          // START_BOX jobs, so without a record here it would keep flipping this
+          // box out of ERROR indefinitely. Record a terminal FAILED START_BOX job
+          // so the ceiling counts this attempt — best-effort, never blocking the
+          // ERROR transition. completedAt is set so the row stays outside the
+          // "one incomplete job per box" partial-unique index.
+          if (box.desiredState === BoxDesiredState.STARTED && box.runnerId) {
+            try {
+              await this.jobRepository.insert(
+                new Job({
+                  type: JobType.START_BOX,
+                  runnerId: box.runnerId,
+                  resourceType: ResourceType.BOX,
+                  resourceId: boxId,
+                  status: JobStatus.FAILED,
+                  errorMessage: errorReason ?? null,
+                  completedAt: new Date(),
+                }),
+              )
+            } catch (jobError) {
+              this.logger.error(
+                `Failed to record FAILED START_BOX job for box ${boxId}; retry ceiling may undercount`,
+                jobError,
+              )
+            }
+          }
+
           const updateData: Partial<Box> = {
             state: BoxState.ERROR,
             errorReason,

--- a/apps/api/src/box/managers/box.manager.ts
+++ b/apps/api/src/box/managers/box.manager.ts
@@ -316,6 +316,14 @@ export class BoxManager implements TrackableJobExecutions, OnApplicationShutdown
    * desired state by transitioning ERROR -> STOPPED, which lets the normal start flow
    * issue an idempotent START_BOX (not a non-idempotent CREATE_BOX) on the existing box.
    *
+   * Eligibility is deliberately NOT gated on the box.recoverable flag: that flag is set true
+   * only for storage-expansion errors (the runner's sole recoverable pattern), whereas the
+   * split-brain errors this loop targets — "box already exists" from a late-failing CREATE,
+   * job timeouts — are reported recoverable=false. The safety net is not that pre-filter but
+   * the idempotent START_BOX plus the bounded retry below: a box that truly cannot start fails
+   * START_BOX up to MAX_RECOVER_ATTEMPTS times and is then left alone, while a box that is
+   * actually alive on the runner is recovered on the first retry.
+   *
    * Recovery is bounded by counting recent failed START_BOX jobs for the box so a genuinely
    * dead box is not retried forever; the count is derived from the job table, not stored state.
    */
@@ -339,7 +347,6 @@ export class BoxManager implements TrackableJobExecutions, OnApplicationShutdown
         .createQueryBuilder('box')
         .select(['box.id', 'box.runnerId'])
         .where('box.state = :state', { state: BoxState.ERROR })
-        .andWhere('box.recoverable = true')
         .andWhere('box.pending = false')
         .andWhere('box."desiredState"::text = :desired', { desired: BoxDesiredState.STARTED })
         .andWhere('box."updatedAt" < :settledBefore', { settledBefore })

--- a/apps/api/src/box/managers/box.manager.ts
+++ b/apps/api/src/box/managers/box.manager.ts
@@ -6,6 +6,8 @@
 
 import { Injectable, Logger, OnApplicationShutdown } from '@nestjs/common'
 import { Cron, CronExpression } from '@nestjs/schedule'
+import { InjectRepository } from '@nestjs/typeorm'
+import { MoreThan, Repository } from 'typeorm'
 import { randomUUID } from 'crypto'
 
 import { BoxConflictError } from '../errors/box-conflict.error'
@@ -40,6 +42,19 @@ import { getStateChangeLockKey } from '../utils/lock-key.util'
 import { OnAsyncEvent } from '../../common/decorators/on-async-event.decorator'
 import { sanitizeBoxError } from '../utils/sanitize-error.util'
 import { Box } from '../entities/box.entity'
+import { Job } from '../entities/job.entity'
+import { JobType } from '../enums/job-type.enum'
+import { JobStatus } from '../enums/job-status.enum'
+import { ResourceType } from '../enums/resource-type.enum'
+
+//  Auto-recovery bounds for the reconcile-errored loop.
+const MAX_RECOVER_ATTEMPTS = 5
+const MAX_RECONCILE_PER_RUN = 200
+//  Only reconcile boxes whose last change has settled for this long.
+const RECONCILE_MIN_AGE_MS = 60_000
+//  Window over which prior failed recovery attempts are counted against a box.
+//  Bounds auto-recovery within a burst while letting a long-quiet box be retried again later.
+const RECONCILE_FAILURE_WINDOW_MS = 60 * 60 * 1000
 
 @Injectable()
 export class BoxManager implements TrackableJobExecutions, OnApplicationShutdown {
@@ -54,6 +69,8 @@ export class BoxManager implements TrackableJobExecutions, OnApplicationShutdown
     private readonly boxStartAction: BoxStartAction,
     private readonly boxStopAction: BoxStopAction,
     private readonly boxDestroyAction: BoxDestroyAction,
+    @InjectRepository(Job)
+    private readonly jobRepository: Repository<Job>,
   ) {}
 
   async onApplicationShutdown() {
@@ -282,6 +299,107 @@ export class BoxManager implements TrackableJobExecutions, OnApplicationShutdown
       } finally {
         if (!stream.destroyed) {
           stream.destroy()
+        }
+      }
+    } finally {
+      await this.redisLockProvider.unlock(globalLockKey)
+    }
+  }
+
+  /**
+   * Reconcile boxes that are stuck in ERROR but want to be STARTED.
+   *
+   * v2 runners report state only through job outcomes; a transient runner failure
+   * (saturation, timeout, a CREATE job that failed late while the box actually exists)
+   * sediments into a terminal ERROR that the regular sync loop deliberately skips, even
+   * though the box is healthy on the runner. This drives such boxes back toward their
+   * desired state by transitioning ERROR -> STOPPED, which lets the normal start flow
+   * issue an idempotent START_BOX (not a non-idempotent CREATE_BOX) on the existing box.
+   *
+   * Recovery is bounded by counting recent failed START_BOX jobs for the box so a genuinely
+   * dead box is not retried forever; the count is derived from the job table, not stored state.
+   */
+  @Cron(CronExpression.EVERY_30_SECONDS, { name: 'reconcile-errored' })
+  @TrackJobExecution()
+  @WithInstrumentation()
+  @LogExecution('reconcile-errored')
+  async reconcileErroredBoxes(): Promise<void> {
+    const globalLockKey = 'reconcile-errored'
+    const lockTtl = 5 * 60 // seconds
+    if (!(await this.redisLockProvider.lock(globalLockKey, lockTtl))) {
+      return
+    }
+
+    try {
+      // Only retry boxes whose last change has settled, to avoid racing an in-flight
+      // failure and to space out successive recovery attempts.
+      const settledBefore = new Date(Date.now() - RECONCILE_MIN_AGE_MS)
+
+      const candidates = await this.boxRepository
+        .createQueryBuilder('box')
+        .select(['box.id', 'box.runnerId'])
+        .where('box.state = :state', { state: BoxState.ERROR })
+        .andWhere('box.recoverable = true')
+        .andWhere('box.pending = false')
+        .andWhere('box."desiredState"::text = :desired', { desired: BoxDesiredState.STARTED })
+        .andWhere('box."updatedAt" < :settledBefore', { settledBefore })
+        .orderBy('box."updatedAt"', 'ASC')
+        .limit(MAX_RECONCILE_PER_RUN)
+        .getMany()
+
+      const failureWindowStart = new Date(Date.now() - RECONCILE_FAILURE_WINDOW_MS)
+
+      for (const candidate of candidates) {
+        if (!candidate.runnerId) {
+          continue
+        }
+
+        // Scope to v2 runners: this is where the job-driven model produces the
+        // ERROR/runner split-brain. v1 runners are reconciled by their own paths.
+        if ((await this.runnerService.getRunnerApiVersion(candidate.runnerId)) !== '2') {
+          continue
+        }
+
+        // Bound auto-recovery: each reconcile drives a START_BOX, so the number of recent
+        // failed START_BOX jobs for this box equals how many times we have already retried.
+        const recentFailures = await this.jobRepository.count({
+          where: {
+            resourceType: ResourceType.BOX,
+            resourceId: candidate.id,
+            type: JobType.START_BOX,
+            status: JobStatus.FAILED,
+            createdAt: MoreThan(failureWindowStart),
+          },
+        })
+        if (recentFailures >= MAX_RECOVER_ATTEMPTS) {
+          continue
+        }
+
+        // Skip boxes the sync loop is already touching.
+        const lockKey = getStateChangeLockKey(candidate.id)
+        if (await this.redisLockProvider.isLocked(lockKey)) {
+          continue
+        }
+
+        try {
+          // Atomic ERROR -> STOPPED transition; the conditional whereCondition ensures
+          // only one transition wins and we never clobber a concurrent state change.
+          await this.boxRepository.updateWhere(candidate.id, {
+            updateData: {
+              state: BoxState.STOPPED,
+              errorReason: null,
+            },
+            whereCondition: { state: BoxState.ERROR },
+          })
+          this.logger.warn(
+            `Reconcile: box ${candidate.id} ERROR -> STOPPED (attempt ${recentFailures + 1}/${MAX_RECOVER_ATTEMPTS}), letting start flow re-drive it`,
+          )
+        } catch (error) {
+          if (error instanceof BoxConflictError) {
+            // Box changed under us (e.g. recovered or destroyed); nothing to do.
+            continue
+          }
+          this.logger.error(`Reconcile: failed to transition box ${candidate.id} out of ERROR`, error)
         }
       }
     } finally {

--- a/apps/api/src/box/managers/box.manager.ts
+++ b/apps/api/src/box/managers/box.manager.ts
@@ -396,7 +396,12 @@ export class BoxManager implements TrackableJobExecutions, OnApplicationShutdown
               state: BoxState.STOPPED,
               errorReason: null,
             },
-            whereCondition: { state: BoxState.ERROR },
+            whereCondition: {
+              state: BoxState.ERROR,
+              pending: false,
+              desiredState: BoxDesiredState.STARTED,
+              runnerId: candidate.runnerId,
+            },
           })
           this.logger.warn(
             `Reconcile: box ${candidate.id} ERROR -> STOPPED (attempt ${recentFailures + 1}/${MAX_RECOVER_ATTEMPTS}), letting start flow re-drive it`,

--- a/apps/api/src/box/managers/box.manager.ts
+++ b/apps/api/src/box/managers/box.manager.ts
@@ -395,6 +395,7 @@ export class BoxManager implements TrackableJobExecutions, OnApplicationShutdown
             updateData: {
               state: BoxState.STOPPED,
               errorReason: null,
+              recoverable: false,
             },
             whereCondition: {
               state: BoxState.ERROR,

--- a/apps/api/src/box/services/job-state-handler.service.spec.ts
+++ b/apps/api/src/box/services/job-state-handler.service.spec.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { JobStateHandlerService } from './job-state-handler.service'
+import { BoxState } from '../enums/box-state.enum'
+import { BoxDesiredState } from '../enums/box-desired-state.enum'
+import { JobStatus } from '../enums/job-status.enum'
+import { JobType } from '../enums/job-type.enum'
+
+function buildHarness(box: { id: string; state: BoxState; desiredState: BoxDesiredState }) {
+  const updates: Array<{ id: string; updateData: any }> = []
+  const boxRepository: any = {
+    findOne: jest.fn().mockResolvedValue(box),
+    update: jest.fn(async (id: string, opts: { updateData: any }) => {
+      updates.push({ id, updateData: opts.updateData })
+    }),
+  }
+  const service = new JobStateHandlerService(boxRepository, {} as any)
+  return { service, boxRepository, updates }
+}
+
+function failedCreateJob(errorMessage: string) {
+  return {
+    id: 'job-1',
+    type: JobType.CREATE_BOX,
+    status: JobStatus.FAILED,
+    resourceId: 'box-1',
+    errorMessage,
+  } as any
+}
+
+describe('JobStateHandlerService CREATE_BOX failure handling', () => {
+  afterEach(() => jest.clearAllMocks())
+
+  it('converges a split-brain "already exists" CREATE failure to STOPPED, not ERROR', async () => {
+    // A prior CREATE_BOX already built this box on the runner; the API never recorded
+    // success, so the retry collides on the name and the runner reports "already exists".
+    // The box is present, not failed — it must not be stranded in ERROR.
+    const { service, updates } = buildHarness({
+      id: 'box-1',
+      state: BoxState.CREATING,
+      desiredState: BoxDesiredState.STARTED,
+    })
+
+    await service.handleJobCompletion(failedCreateJob("failed to create box: box with name 'box-1' already exists"))
+
+    expect(updates).toHaveLength(1)
+    expect(updates[0].updateData.state).toBe(BoxState.STOPPED)
+    expect(updates[0].updateData.errorReason).toBeNull()
+  })
+
+  it('still marks a genuine CREATE failure as ERROR', async () => {
+    const { service, updates } = buildHarness({
+      id: 'box-1',
+      state: BoxState.CREATING,
+      desiredState: BoxDesiredState.STARTED,
+    })
+
+    await service.handleJobCompletion(failedCreateJob('engine exited unexpectedly: signal SIGABRT'))
+
+    expect(updates).toHaveLength(1)
+    expect(updates[0].updateData.state).toBe(BoxState.ERROR)
+  })
+})

--- a/apps/api/src/box/services/job-state-handler.service.spec.ts
+++ b/apps/api/src/box/services/job-state-handler.service.spec.ts
@@ -52,6 +52,34 @@ describe('JobStateHandlerService CREATE_BOX failure handling', () => {
     expect(updates[0].updateData.errorReason).toBeNull()
   })
 
+  it('also treats runner box ID collisions as split-brain create success', async () => {
+    const { service, updates } = buildHarness({
+      id: 'box-1',
+      state: BoxState.CREATING,
+      desiredState: BoxDesiredState.STARTED,
+    })
+
+    await service.handleJobCompletion(failedCreateJob('failed to create box: box box-1 already exists'))
+
+    expect(updates).toHaveLength(1)
+    expect(updates[0].updateData.state).toBe(BoxState.STOPPED)
+    expect(updates[0].updateData.errorReason).toBeNull()
+  })
+
+  it('does not treat unrelated already-exists CREATE errors as box split-brain', async () => {
+    const { service, updates } = buildHarness({
+      id: 'box-1',
+      state: BoxState.CREATING,
+      desiredState: BoxDesiredState.STARTED,
+    })
+
+    await service.handleJobCompletion(failedCreateJob("failed to create box: volume with name 'box-1' already exists"))
+
+    expect(updates).toHaveLength(1)
+    expect(updates[0].updateData.state).toBe(BoxState.ERROR)
+    expect(updates[0].updateData.errorReason).toContain('volume with name')
+  })
+
   it('still marks a genuine CREATE failure as ERROR', async () => {
     const { service, updates } = buildHarness({
       id: 'box-1',

--- a/apps/api/src/box/services/job-state-handler.service.ts
+++ b/apps/api/src/box/services/job-state-handler.service.ts
@@ -17,10 +17,12 @@ import { RedisLockProvider } from '../common/redis-lock.provider'
 import { ResourceType } from '../enums/resource-type.enum'
 import { getStateChangeLockKey } from '../utils/lock-key.util'
 
-// The runner reports a name collision as "box with name '<id>' already exists" /
-// "box with this name already exists" (src/boxlite runtime). Both contain this substring,
-// which survives the runner's error wrapping and sanitizeBoxError unchanged.
-const BOX_ALREADY_EXISTS_PATTERN = /already exists/i
+// The runner reports box name/ID collisions as:
+// - "box with name '<id>' already exists"
+// - "box <id> already exists"
+// - "box with this name already exists"
+// The pattern intentionally avoids matching unrelated resource collisions.
+const BOX_ALREADY_EXISTS_PATTERN = /\bbox (?:with name ['"][^'"]+['"]|with this name|\S+) already exists\b/i
 
 function isBoxAlreadyExistsError(errorReason: string | undefined | null): boolean {
   return !!errorReason && BOX_ALREADY_EXISTS_PATTERN.test(errorReason)

--- a/apps/api/src/box/services/job-state-handler.service.ts
+++ b/apps/api/src/box/services/job-state-handler.service.ts
@@ -17,6 +17,15 @@ import { RedisLockProvider } from '../common/redis-lock.provider'
 import { ResourceType } from '../enums/resource-type.enum'
 import { getStateChangeLockKey } from '../utils/lock-key.util'
 
+// The runner reports a name collision as "box with name '<id>' already exists" /
+// "box with this name already exists" (src/boxlite runtime). Both contain this substring,
+// which survives the runner's error wrapping and sanitizeBoxError unchanged.
+const BOX_ALREADY_EXISTS_PATTERN = /already exists/i
+
+function isBoxAlreadyExistsError(errorReason: string | undefined | null): boolean {
+  return !!errorReason && BOX_ALREADY_EXISTS_PATTERN.test(errorReason)
+}
+
 /**
  * Service for handling entity state updates based on job completion (v2 runners only).
  * This service listens to job status changes and updates entity states accordingly.
@@ -110,11 +119,24 @@ export class JobStateHandlerService {
           updateData.daemonVersion = metadata.daemonVersion
         }
       } else if (job.status === JobStatus.FAILED) {
-        this.logger.error(`CREATE_BOX job ${job.id} failed for box ${boxId}: ${job.errorMessage}`)
-        updateData.state = BoxState.ERROR
         const { recoverable, errorReason } = sanitizeBoxError(job.errorMessage)
-        updateData.errorReason = errorReason || 'Failed to create box'
-        updateData.recoverable = recoverable
+        if (isBoxAlreadyExistsError(errorReason)) {
+          // Split-brain: a previous CREATE_BOX already built this box on the runner, but the
+          // API never recorded success (lost/stale job ack). Re-running CREATE collides on the
+          // box name and the runner reports "already exists". The box is present, not failed —
+          // so converge to STOPPED and let the start flow re-drive it with an idempotent
+          // START_BOX rather than stranding it in ERROR (and re-emitting the same collision).
+          this.logger.warn(
+            `CREATE_BOX job ${job.id} hit split-brain (box ${boxId} already exists on runner); converging to STOPPED for restart`,
+          )
+          updateData.state = BoxState.STOPPED
+          updateData.errorReason = null
+        } else {
+          this.logger.error(`CREATE_BOX job ${job.id} failed for box ${boxId}: ${job.errorMessage}`)
+          updateData.state = BoxState.ERROR
+          updateData.errorReason = errorReason || 'Failed to create box'
+          updateData.recoverable = recoverable
+        }
       }
 
       await this.boxRepository.update(boxId, { updateData, entity: box })

--- a/apps/api/src/box/services/job-state-handler.service.ts
+++ b/apps/api/src/box/services/job-state-handler.service.ts
@@ -134,9 +134,10 @@ export class JobStateHandlerService {
           updateData.state = BoxState.STOPPED
           updateData.errorReason = null
         } else {
-          this.logger.error(`CREATE_BOX job ${job.id} failed for box ${boxId}: ${job.errorMessage}`)
+          const sanitizedErrorReason = errorReason || 'Failed to create box'
+          this.logger.error(`CREATE_BOX job ${job.id} failed for box ${boxId}: ${sanitizedErrorReason}`)
           updateData.state = BoxState.ERROR
-          updateData.errorReason = errorReason || 'Failed to create box'
+          updateData.errorReason = sanitizedErrorReason
           updateData.recoverable = recoverable
         }
       }


### PR DESCRIPTION
while v2 box running inside runner but marked as "Error" by mistake by API, scan reconcile them each minute

## Test plan

- [x] `yarn nx test api --testPathPatterns=box.manager.reconcile --skip-nx-cache`
- [x] `yarn nx test api --testPathPatterns=job-state-handler.service --skip-nx-cache`
- [x] `yarn tsc -p api/tsconfig.json --noEmit`
- [x] `yarn eslint api/src/box/managers/box.manager.ts api/src/box/managers/box.manager.reconcile.spec.ts api/src/box/services/job-state-handler.service.ts api/src/box/services/job-state-handler.service.spec.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit — Release Notes

* **New Features**
  * Added automatic reconciliation for boxes stuck in error states, including a scheduled, lock-protected workflow with retry-attempt ceilings.
  * Added logic to better handle split-brain “box already exists” collisions by converging boxes to a recovered state instead of leaving them in error.
  * Added job-backed failure accounting so retry limits work even when expected job records aren’t created.

* **Bug Fixes**
  * Prevented retries for boxes that hit the configured recovery-attempt cap; skipped incompatible runner versions and already-locked boxes.

* **Tests**
  * Added Jest coverage for reconciliation and job failure handling edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->