### PR TITLE
fix(quality): lint:python tomllib check works on Python 3.10

### DIFF
--- a/make/quality.mk
+++ b/make/quality.mk
@@ -146,7 +146,7 @@ lint\:python: _ensure-python-deps
 	@echo "🔍 Linting Python SDK..."
 	@. .venv/bin/activate && cd sdks/python && ruff check .
 	@echo "🔍 Checking Python SDK dependency policy..."
-	@. .venv/bin/activate && cd sdks/python && python -c "import tomllib; config=tomllib.load(open('pyproject.toml','rb')); deps=config.get('project',{}).get('dependencies',[]); import sys; (print(f'ERROR: pyproject.toml has required dependencies: {deps}') or print('Move dependencies to [project.optional-dependencies] instead.') or sys.exit(1)) if deps else print('✓ No required dependencies')"
+	@. .venv/bin/activate && cd sdks/python && python -c "import sys; tomllib = __import__('tomllib') if sys.version_info >= (3, 11) else __import__('tomli'); config=tomllib.load(open('pyproject.toml','rb')); deps=config.get('project',{}).get('dependencies',[]); (print(f'ERROR: pyproject.toml has required dependencies: {deps}') or print('Move dependencies to [project.optional-dependencies] instead.') or sys.exit(1)) if deps else print('✓ No required dependencies')"
 
 lint\:node: _ensure-node-deps
 	@echo "🔍 Checking Node SDK native import boundary..."

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -31,12 +31,26 @@ Repository = "https://github.com/boxlite-ai/boxlite"
 Issues = "https://github.com/boxlite-ai/boxlite/issues"
 
 [project.optional-dependencies]
-dev = ["pytest>=7.0", "pytest-asyncio>=0.21", "ruff>=0.4"]
+# `tomli` is needed by `make lint:python` (and other dev tooling) to parse
+# this file. It's stdlib as `tomllib` on Python 3.11+, but the project
+# supports Python 3.10+ — declare the backport explicitly so we don't
+# silently rely on `maturin`/`pytest` pulling it in transitively.
+dev = [
+    "pytest>=7.0",
+    "pytest-asyncio>=0.21",
+    "ruff>=0.4",
+    "tomli>=2.0; python_version < '3.11'",
+]
 sync = ["greenlet>=3.0.0"]
 orchestration = ["cloudpickle>=3.0"]
 
 [dependency-groups]
-dev = ["pytest>=7.0", "pytest-asyncio>=0.21", "ruff>=0.4"]
+dev = [
+    "pytest>=7.0",
+    "pytest-asyncio>=0.21",
+    "ruff>=0.4",
+    "tomli>=2.0; python_version < '3.11'",
+]
 sync = ["greenlet>=3.0.0"]
 
 [build-system]


### PR DESCRIPTION
## Summary
- `make lint:python` imported `tomllib` unconditionally, but that module is 3.11+ stdlib — the SDK declares `requires-python = ">=3.10"`, so the lint step blew up on 3.10 envs.
- Fall back to the `tomli` backport when running on 3.10, and declare `tomli>=2.0; python_version < '3.11'` as a dev dep so it's actually present instead of relying on transitive pulls from `maturin`/`pytest`.

## Test plan
- [ ] `make lint:python` passes on Python 3.10
- [ ] `make lint:python` passes on Python 3.11+

🤖 Generated with [Claude Code](https://claude.com/claude-code)