### PR TITLE
fix(security): paired redaction — stop CA key/secret leaks via trace! + Debug

### DIFF
--- a/src/boxlite/src/net/gvproxy/config.rs
+++ b/src/boxlite/src/net/gvproxy/config.rs
@@ -40,7 +40,11 @@ pub struct PortMapping {
 ///
 /// This structure encapsulates all configuration needed to create a gvproxy
 /// virtual network, replacing the previous approach of hardcoding values in Go.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+///
+/// `Debug` is implemented manually (see below) because the derived form would
+/// print the raw `ca_key_pem` — a PKCS8 CA private key — which must never
+/// land in a log file.
+#[derive(Clone, Serialize, Deserialize)]
 pub struct GvproxyConfig {
     /// Unix socket path for the network tap interface.
     /// Caller-provided to ensure each box gets a unique, collision-free path.
@@ -111,6 +115,39 @@ pub struct GvproxySecretConfig {
     pub hosts: Vec<String>,
     pub placeholder: String,
     pub value: String,
+}
+
+impl std::fmt::Debug for GvproxyConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Treat `ca_key_pem` (PKCS8 private key) and `ca_cert_pem` as
+        // sensitive: render only their presence. `secrets` already redacts
+        // via `GvproxySecretConfig::Debug`.
+        f.debug_struct("GvproxyConfig")
+            .field("socket_path", &self.socket_path)
+            .field("subnet", &self.subnet)
+            .field("gateway_ip", &self.gateway_ip)
+            .field("gateway_mac", &self.gateway_mac)
+            .field("guest_ip", &self.guest_ip)
+            .field("host_ip", &self.host_ip)
+            .field("guest_mac", &self.guest_mac)
+            .field("mtu", &self.mtu)
+            .field("port_mappings", &self.port_mappings)
+            .field("dns_zones", &self.dns_zones)
+            .field("dns_search_domains", &self.dns_search_domains)
+            .field("debug", &self.debug)
+            .field("capture_file", &self.capture_file)
+            .field("allow_net", &self.allow_net)
+            .field("secrets", &self.secrets)
+            .field(
+                "ca_cert_pem",
+                &self.ca_cert_pem.as_ref().map(|_| "[REDACTED]"),
+            )
+            .field(
+                "ca_key_pem",
+                &self.ca_key_pem.as_ref().map(|_| "[REDACTED]"),
+            )
+            .finish()
+    }
 }
 
 impl std::fmt::Debug for GvproxySecretConfig {

--- a/src/boxlite/src/net/mod.rs
+++ b/src/boxlite/src/net/mod.rs
@@ -48,7 +48,12 @@ pub enum NetworkBackendEndpoint {
 ///
 /// This is the only struct that callers need to know about - they don't need
 /// to know which backend will be used.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+///
+/// `Debug` is implemented manually (see below) because `ca_key_pem` is a
+/// PKCS8 CA private key and the derived form would print it in full into
+/// any log line that uses `{:?}`. `secrets` already redacts via
+/// [`Secret`](crate::runtime::options::Secret)'s own `Debug` impl.
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct NetworkBackendConfig {
     /// Port mappings: (host_port, guest_port)
     pub port_mappings: Vec<(u16, u16)>,
@@ -78,6 +83,25 @@ impl NetworkBackendConfig {
             ca_cert_pem: None,
             ca_key_pem: None,
         }
+    }
+}
+
+impl std::fmt::Debug for NetworkBackendConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("NetworkBackendConfig")
+            .field("port_mappings", &self.port_mappings)
+            .field("socket_path", &self.socket_path)
+            .field("allow_net", &self.allow_net)
+            .field("secrets", &self.secrets)
+            .field(
+                "ca_cert_pem",
+                &self.ca_cert_pem.as_ref().map(|_| "[REDACTED]"),
+            )
+            .field(
+                "ca_key_pem",
+                &self.ca_key_pem.as_ref().map(|_| "[REDACTED]"),
+            )
+            .finish()
     }
 }
 
@@ -171,5 +195,40 @@ impl NetworkBackendFactory {
             tracing::info!("No network backend - engine will use default net");
             Ok(None)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Defense-in-depth: `Debug` must not print the CA private key or cert
+    /// PEM. The derived `Debug` previously did; a manual impl now redacts.
+    #[test]
+    fn debug_redacts_ca_pem_fields() {
+        let key_sentinel = "----BEGIN PRIVATE KEY----TOPSECRETPKCS8";
+        let cert_sentinel = "----BEGIN CERTIFICATE----TOPSECRETCERT";
+        let mut config =
+            NetworkBackendConfig::new(vec![(8080, 80)], PathBuf::from("/tmp/test-net.sock"));
+        config.ca_key_pem = Some(key_sentinel.to_string());
+        config.ca_cert_pem = Some(cert_sentinel.to_string());
+
+        let rendered = format!("{:?}", config);
+
+        assert!(
+            !rendered.contains(key_sentinel),
+            "Debug leaked ca_key_pem: {}",
+            rendered
+        );
+        assert!(
+            !rendered.contains(cert_sentinel),
+            "Debug leaked ca_cert_pem: {}",
+            rendered
+        );
+        assert!(
+            rendered.contains("[REDACTED]"),
+            "expected redaction marker, got: {}",
+            rendered
+        );
     }
 }

--- a/src/boxlite/src/vmm/controller/shim.rs
+++ b/src/boxlite/src/vmm/controller/shim.rs
@@ -198,6 +198,29 @@ impl VmmHandlerTrait for ShimHandler {
     }
 }
 
+/// Emit the post-spawn TRACE event with the serialized `InstanceSpec`'s
+/// secrets stripped out.
+///
+/// The serialized `InstanceSpec` (`config_json`) carries
+/// `NetworkBackendConfig.secrets` (user-provided secret values) and, when a
+/// MITM proxy is configured, `ca_key_pem` — the PKCS8 CA private key. The
+/// config is deliberately piped via stdin rather than CLI args so those bytes
+/// stay out of `/proc/<pid>/cmdline` (see `spawn.rs:97-99`); serializing them
+/// into a TRACE log would defeat that mitigation.
+///
+/// This helper is the single audited site for that trace event so that
+/// `redacted_box_config_trace_does_not_emit_config_json` can pin the
+/// behavior with a real subscriber capture rather than relying on
+/// source-grep heuristics.
+fn emit_redacted_box_config_trace(engine: VmmKind, box_id: &str, config_json: &str) {
+    tracing::trace!(
+        engine = ?engine,
+        box_id = %box_id,
+        json_bytes = config_json.len(),
+        "Box configuration prepared (raw config not logged; contains secrets)"
+    );
+}
+
 // ============================================================================
 // SHIM CONTROLLER - Spawning operations
 // ============================================================================
@@ -319,7 +342,7 @@ impl VmmController for ShimController {
             "Starting Box subprocess"
         );
         tracing::debug!(binary = %self.binary_path.display(), "Box runner binary");
-        tracing::trace!(config = %config_json, "Box configuration");
+        emit_redacted_box_config_trace(self.engine_type, self.box_id.as_str(), &config_json);
 
         // Measure subprocess spawn time
         let shim_spawn_start = Instant::now();
@@ -356,5 +379,161 @@ impl VmmController for ShimController {
         // Note: Child is dropped here, but process continues running
         // Handler manages it by PID
         Ok(Box::new(handler))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    /// Captures `tracing` output into a shared byte buffer so a test can
+    /// assert what was (and wasn't) written by an event emitted within
+    /// `tracing::subscriber::with_default`.
+    #[derive(Clone)]
+    struct BufWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl std::io::Write for BufWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for BufWriter {
+        type Writer = BufWriter;
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    /// Behavioral regression for the leak fixed in this commit: feed a
+    /// `config_json` whose body contains sentinel CA-key / secret bytes
+    /// into the helper that is the *only* site allowed to emit the
+    /// post-spawn TRACE event, capture every byte the subscriber writes,
+    /// and assert the sentinels never appear — while the redacted fields
+    /// (`box_id`, `json_bytes`) do. If any future change reintroduces
+    /// `config = %config_json` (or any other form that lets the raw bytes
+    /// reach the subscriber), the sentinel assertion fires.
+    #[test]
+    fn redacted_box_config_trace_does_not_emit_config_json() {
+        let buf = Arc::new(Mutex::new(Vec::<u8>::new()));
+        let subscriber = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::TRACE)
+            .with_writer(BufWriter(buf.clone()))
+            .with_ansi(false)
+            .finish();
+
+        let key_sentinel = "PKCS8_PRIVATE_KEY_SENTINEL_DO_NOT_LEAK";
+        let secret_sentinel = "USER_SECRET_VALUE_SENTINEL_DO_NOT_LEAK";
+        let config_json = format!(
+            r#"{{"secrets":[{{"name":"db","value":"{}"}}],"ca_key_pem":"-----BEGIN PRIVATE KEY-----\n{}\n-----END PRIVATE KEY-----"}}"#,
+            secret_sentinel, key_sentinel
+        );
+        let expected_len = config_json.len();
+
+        tracing::subscriber::with_default(subscriber, || {
+            emit_redacted_box_config_trace(VmmKind::Libkrun, "test-box-id", &config_json);
+        });
+
+        let output = String::from_utf8(buf.lock().unwrap().clone()).expect("utf8 trace output");
+
+        assert!(
+            !output.contains(key_sentinel),
+            "CA private key sentinel leaked into trace output: {output}"
+        );
+        assert!(
+            !output.contains(secret_sentinel),
+            "user secret sentinel leaked into trace output: {output}"
+        );
+        assert!(
+            output.contains("test-box-id"),
+            "box_id (non-sensitive) should appear in trace output: {output}"
+        );
+        assert!(
+            output.contains(&format!("json_bytes={expected_len}")),
+            "json_bytes redacted summary should appear: {output}"
+        );
+    }
+
+    /// Workspace-wide regression: the behavioral test above pins the helper
+    /// itself. It does **not** pin the invariant that the helper is the
+    /// *only* site emitting `config_json` to a `tracing::*` macro — a new
+    /// `tracing::trace!(config = %config_json, ...)` added anywhere else in
+    /// the workspace (this crate, the shim binary which reads the same
+    /// JSON from stdin, etc.) would slip past it.
+    ///
+    /// `tracing`'s `%` (Display) and `?` (Debug) field-value sigils are
+    /// unambiguous markers for "this expression's formatted output goes
+    /// into the event". Forbid both `%config_json` and `?config_json`
+    /// anywhere in production source under the workspace's `src/`. Test
+    /// code (anything past the first `#[cfg(test)]` in each file) is
+    /// exempt so this patrol can talk about the patterns it catches
+    /// without tripping over itself.
+    #[test]
+    fn no_config_json_in_tracing_sigil_workspace_wide() {
+        fn walk_rs(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
+            let entries = match std::fs::read_dir(dir) {
+                Ok(e) => e,
+                Err(_) => return,
+            };
+            for entry in entries.flatten() {
+                let p = entry.path();
+                if p.is_dir() {
+                    walk_rs(&p, out);
+                } else if p.extension().is_some_and(|e| e == "rs") {
+                    out.push(p);
+                }
+            }
+        }
+
+        // CARGO_MANIFEST_DIR points at this crate (src/boxlite); the
+        // workspace root is two levels up, and the workspace-level source
+        // tree (which also includes src/shim, src/cli, …) lives at
+        // <workspace-root>/src.
+        let workspace_src = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../..")
+            .join("src");
+        let mut files = Vec::new();
+        walk_rs(&workspace_src, &mut files);
+        assert!(
+            !files.is_empty(),
+            "patrol found zero .rs files under {}",
+            workspace_src.display()
+        );
+
+        let forbidden = ["%config_json", "?config_json"];
+        let mut offenders = Vec::new();
+        for path in &files {
+            let src = match std::fs::read_to_string(path) {
+                Ok(s) => s,
+                Err(_) => continue,
+            };
+            // Strip every `#[cfg(test)]` block (only the first one is
+            // sufficient because tests sit at the bottom of a file by
+            // convention; if a project ever puts a `#[cfg(test)]` in the
+            // middle, the patrol still gates everything above the first
+            // such marker).
+            let production = match src.find("#[cfg(test)]") {
+                Some(idx) => &src[..idx],
+                None => &src,
+            };
+            for needle in &forbidden {
+                if production.contains(needle) {
+                    offenders.push(format!("{}: contains {needle:?}", path.display()));
+                }
+            }
+        }
+
+        assert!(
+            offenders.is_empty(),
+            "`config_json` reached a `tracing::*` field sigil in production code — \
+             that string carries secrets and a PKCS8 CA private key. Route the \
+             log through `emit_redacted_box_config_trace` instead.\n  {}",
+            offenders.join("\n  ")
+        );
     }
 }

--- a/src/boxlite/tests/gvproxy_debug_redaction.rs
+++ b/src/boxlite/tests/gvproxy_debug_redaction.rs
@@ -1,0 +1,42 @@
+//! Integration test: `GvproxyConfig::Debug` must redact PEM fields.
+//!
+//! The unit-test counterpart of this assertion lives in `src/net/mod.rs`
+//! for `NetworkBackendConfig`, which is reachable from `--no-default-features`
+//! and therefore runs under `make test:unit:rust`. `GvproxyConfig`, in
+//! contrast, lives behind `#[cfg(feature = "gvproxy")]` — so an in-crate
+//! `#[test]` would never compile under the standard unit-test target
+//! (see the comment at `make/test.mk:177`).
+//!
+//! Putting the assertion here, gated on the `gvproxy` feature, lets the
+//! existing `make test:integration:rust` target (which already passes
+//! `--features krun,gvproxy --test '*'`) pick it up.
+
+#![cfg(feature = "gvproxy")]
+
+use boxlite::net::gvproxy::GvproxyConfig;
+use std::path::PathBuf;
+
+#[test]
+fn gvproxy_config_debug_redacts_ca_pem_fields() {
+    let key_sentinel = "----BEGIN PRIVATE KEY----TOPSECRETPKCS8";
+    let cert_sentinel = "----BEGIN CERTIFICATE----TOPSECRETCERT";
+
+    let mut config = GvproxyConfig::new(PathBuf::from("/tmp/test-gvproxy.sock"), vec![]);
+    config.ca_key_pem = Some(key_sentinel.to_string());
+    config.ca_cert_pem = Some(cert_sentinel.to_string());
+
+    let rendered = format!("{:?}", config);
+
+    assert!(
+        !rendered.contains(key_sentinel),
+        "Debug leaked ca_key_pem: {rendered}"
+    );
+    assert!(
+        !rendered.contains(cert_sentinel),
+        "Debug leaked ca_cert_pem: {rendered}"
+    );
+    assert!(
+        rendered.contains("[REDACTED]"),
+        "expected redaction marker, got: {rendered}"
+    );
+}


### PR DESCRIPTION
## Summary

Paired secret-redaction fixes against the same threat model — CA private keys and user-provided secrets must not bleed into log files or Debug output. Originally opened as two PRs (#575 + the now-superseded #576); merged here because each is incomplete without the other.

- **Commit a4c4172** (this PR's original commit): stop `tracing::trace!(config = %config_json, ...)` in `vmm::controller::shim::ShimController::start`. That line dumped the serialized `InstanceSpec` to the box log, leaking `NetworkBackendConfig.secrets` and (when MITM proxy is configured) the PKCS8 CA private key whenever `RUST_LOG=trace` is set and any operator reads the box log. Replaces the dump with a redacted summary (`engine` / `box_id` / `json_bytes=<len>`) emitted from a single audited helper `emit_redacted_box_config_trace`, so the trace site has exactly one auditable callsite. The whole reason the config travels via stdin rather than CLI args was to keep these bytes out of `/proc/<pid>/cmdline` (see `spawn.rs:97-99`) — trace-logging the same blob defeated that mitigation.

- **Commit ada6b59** (was the standalone PR #576): implement `Debug` manually on `GvproxyConfig` and `NetworkBackendConfig` so `ca_key_pem` / `ca_cert_pem` render as `Some("[REDACTED]")` instead of the full PEM. Defense-in-depth: a grep of the codebase finds **zero** production `{:?}` callers on either type today, but a future `tracing::debug!(?config, ...)` or `format!("{:?}", config)` would silently regress the trace-leak class fixed by the first commit. `Serialize` / `Deserialize` are unchanged (wire format byte-identical). The companion test for `NetworkBackendConfig::Debug` lives in `src/net/mod.rs` as a unit test (visible to `make test:unit:rust`). `GvproxyConfig` lives behind `#[cfg(feature = "gvproxy")]` and `make test:unit:rust` uses `--no-default-features`, so the assertion for it is placed in `tests/gvproxy_debug_redaction.rs` (picked up by the existing `make test:integration:rust` target with `--features krun,gvproxy --test '*'`).

## Why neither half is complete alone

- Only the trace! fix → any future `Debug`-format call on these structs still leaks
- Only the `Debug` redaction → the current `trace!(config = %config_json)` site still leaks today

Together they form a closed loop: current leak source fixed, future regression class blocked.

Closes boxlite-ai/boxlite#576.

## Test plan

- [x] **PR-introduced tests pass** — `cargo nextest run -p boxlite --lib -E 'test(/redacted_box_config|debug.*redact|network_backend_config_debug|gvproxy.*debug/)'` → **4/4 PASS**.
- [x] **Gvproxy-gated integration test** — `cargo nextest run -p boxlite --features krun,gvproxy --test gvproxy_debug_redaction` → **1/1 PASS** (the `GvproxyConfig` Debug redact case, compiles + runs only under the gvproxy feature).
- [x] **Broader regression sweep** — `cargo nextest run -p boxlite --lib --no-fail-fast` → 707 tests run, **705 PASS** + 2 pre-existing failures (`jailer::credentials::test_can_create_process_in_new_user_ns`, `jailer::tests::test_jailer_full_flow_with_real_tempdir`) — both are AppArmor host-environment issues unrelated to this change, tracked upstream as #468 / #544 (verified via `git stash` against `main`).
- [x] `cargo nextest run -p boxlite-shared --lib` → **36/36 PASS**.
- [x] `cargo clippy -p boxlite --features krun,gvproxy --no-deps` and `cargo clippy -p boxlite-shared --no-deps` → both exit 0, no warnings.
- [x] **Reverse verification** per the original PRs:
  - Re-introducing `config = %config_json` inside `emit_redacted_box_config_trace` → the trace test fails with CA-key / secret sentinel bytes echoed in captured subscriber output.
  - Re-deriving `Debug` on `GvproxyConfig` (regression injection) → the integration test fails with the CA-key sentinel echoed.
  - Both restore green on revert. The assertions actually catch the bug they claim to.

## Out of scope (flagged for follow-up — not addressed here)

The `net::gvproxy` submodule has ~28 in-crate `#[test]` items that are likewise invisible to `make test:unit:rust` (it uses `--no-default-features`). Fixing that broader gap — e.g. by adding a `test:unit:rust:gvproxy` make target — is wider than this PR and deserves its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)