### PR TITLE
fix(net): redact ca_key_pem / ca_cert_pem in Debug impls (defense-in-depth)

### DIFF
--- a/src/boxlite/src/net/gvproxy/config.rs
+++ b/src/boxlite/src/net/gvproxy/config.rs
@@ -40,7 +40,11 @@ pub struct PortMapping {
 ///
 /// This structure encapsulates all configuration needed to create a gvproxy
 /// virtual network, replacing the previous approach of hardcoding values in Go.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+///
+/// `Debug` is implemented manually (see below) because the derived form would
+/// print the raw `ca_key_pem` — a PKCS8 CA private key — which must never
+/// land in a log file.
+#[derive(Clone, Serialize, Deserialize)]
 pub struct GvproxyConfig {
     /// Unix socket path for the network tap interface.
     /// Caller-provided to ensure each box gets a unique, collision-free path.
@@ -111,6 +115,39 @@ pub struct GvproxySecretConfig {
     pub hosts: Vec<String>,
     pub placeholder: String,
     pub value: String,
+}
+
+impl std::fmt::Debug for GvproxyConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Treat `ca_key_pem` (PKCS8 private key) and `ca_cert_pem` as
+        // sensitive: render only their presence. `secrets` already redacts
+        // via `GvproxySecretConfig::Debug`.
+        f.debug_struct("GvproxyConfig")
+            .field("socket_path", &self.socket_path)
+            .field("subnet", &self.subnet)
+            .field("gateway_ip", &self.gateway_ip)
+            .field("gateway_mac", &self.gateway_mac)
+            .field("guest_ip", &self.guest_ip)
+            .field("host_ip", &self.host_ip)
+            .field("guest_mac", &self.guest_mac)
+            .field("mtu", &self.mtu)
+            .field("port_mappings", &self.port_mappings)
+            .field("dns_zones", &self.dns_zones)
+            .field("dns_search_domains", &self.dns_search_domains)
+            .field("debug", &self.debug)
+            .field("capture_file", &self.capture_file)
+            .field("allow_net", &self.allow_net)
+            .field("secrets", &self.secrets)
+            .field(
+                "ca_cert_pem",
+                &self.ca_cert_pem.as_ref().map(|_| "[REDACTED]"),
+            )
+            .field(
+                "ca_key_pem",
+                &self.ca_key_pem.as_ref().map(|_| "[REDACTED]"),
+            )
+            .finish()
+    }
 }
 
 impl std::fmt::Debug for GvproxySecretConfig {

--- a/src/boxlite/src/net/mod.rs
+++ b/src/boxlite/src/net/mod.rs
@@ -48,7 +48,12 @@ pub enum NetworkBackendEndpoint {
 ///
 /// This is the only struct that callers need to know about - they don't need
 /// to know which backend will be used.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+///
+/// `Debug` is implemented manually (see below) because `ca_key_pem` is a
+/// PKCS8 CA private key and the derived form would print it in full into
+/// any log line that uses `{:?}`. `secrets` already redacts via
+/// [`Secret`](crate::runtime::options::Secret)'s own `Debug` impl.
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct NetworkBackendConfig {
     /// Port mappings: (host_port, guest_port)
     pub port_mappings: Vec<(u16, u16)>,
@@ -78,6 +83,25 @@ impl NetworkBackendConfig {
             ca_cert_pem: None,
             ca_key_pem: None,
         }
+    }
+}
+
+impl std::fmt::Debug for NetworkBackendConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("NetworkBackendConfig")
+            .field("port_mappings", &self.port_mappings)
+            .field("socket_path", &self.socket_path)
+            .field("allow_net", &self.allow_net)
+            .field("secrets", &self.secrets)
+            .field(
+                "ca_cert_pem",
+                &self.ca_cert_pem.as_ref().map(|_| "[REDACTED]"),
+            )
+            .field(
+                "ca_key_pem",
+                &self.ca_key_pem.as_ref().map(|_| "[REDACTED]"),
+            )
+            .finish()
     }
 }
 
@@ -171,5 +195,40 @@ impl NetworkBackendFactory {
             tracing::info!("No network backend - engine will use default net");
             Ok(None)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Defense-in-depth: `Debug` must not print the CA private key or cert
+    /// PEM. The derived `Debug` previously did; a manual impl now redacts.
+    #[test]
+    fn debug_redacts_ca_pem_fields() {
+        let key_sentinel = "----BEGIN PRIVATE KEY----TOPSECRETPKCS8";
+        let cert_sentinel = "----BEGIN CERTIFICATE----TOPSECRETCERT";
+        let mut config =
+            NetworkBackendConfig::new(vec![(8080, 80)], PathBuf::from("/tmp/test-net.sock"));
+        config.ca_key_pem = Some(key_sentinel.to_string());
+        config.ca_cert_pem = Some(cert_sentinel.to_string());
+
+        let rendered = format!("{:?}", config);
+
+        assert!(
+            !rendered.contains(key_sentinel),
+            "Debug leaked ca_key_pem: {}",
+            rendered
+        );
+        assert!(
+            !rendered.contains(cert_sentinel),
+            "Debug leaked ca_cert_pem: {}",
+            rendered
+        );
+        assert!(
+            rendered.contains("[REDACTED]"),
+            "expected redaction marker, got: {}",
+            rendered
+        );
     }
 }

--- a/src/boxlite/tests/gvproxy_debug_redaction.rs
+++ b/src/boxlite/tests/gvproxy_debug_redaction.rs
@@ -1,0 +1,42 @@
+//! Integration test: `GvproxyConfig::Debug` must redact PEM fields.
+//!
+//! The unit-test counterpart of this assertion lives in `src/net/mod.rs`
+//! for `NetworkBackendConfig`, which is reachable from `--no-default-features`
+//! and therefore runs under `make test:unit:rust`. `GvproxyConfig`, in
+//! contrast, lives behind `#[cfg(feature = "gvproxy")]` — so an in-crate
+//! `#[test]` would never compile under the standard unit-test target
+//! (see the comment at `make/test.mk:177`).
+//!
+//! Putting the assertion here, gated on the `gvproxy` feature, lets the
+//! existing `make test:integration:rust` target (which already passes
+//! `--features krun,gvproxy --test '*'`) pick it up.
+
+#![cfg(feature = "gvproxy")]
+
+use boxlite::net::gvproxy::GvproxyConfig;
+use std::path::PathBuf;
+
+#[test]
+fn gvproxy_config_debug_redacts_ca_pem_fields() {
+    let key_sentinel = "----BEGIN PRIVATE KEY----TOPSECRETPKCS8";
+    let cert_sentinel = "----BEGIN CERTIFICATE----TOPSECRETCERT";
+
+    let mut config = GvproxyConfig::new(PathBuf::from("/tmp/test-gvproxy.sock"), vec![]);
+    config.ca_key_pem = Some(key_sentinel.to_string());
+    config.ca_cert_pem = Some(cert_sentinel.to_string());
+
+    let rendered = format!("{:?}", config);
+
+    assert!(
+        !rendered.contains(key_sentinel),
+        "Debug leaked ca_key_pem: {rendered}"
+    );
+    assert!(
+        !rendered.contains(cert_sentinel),
+        "Debug leaked ca_cert_pem: {rendered}"
+    );
+    assert!(
+        rendered.contains("[REDACTED]"),
+        "expected redaction marker, got: {rendered}"
+    );
+}


### PR DESCRIPTION
## Summary

- `GvproxyConfig` and `NetworkBackendConfig` both held the MITM proxy's PKCS8 CA private key in `ca_key_pem: Option<String>` (and the matching cert PEM in `ca_cert_pem`) and **derived** `Debug`. Any log line that used `{:?}` on one of these — or on a struct that transitively held one, e.g. `InstanceSpec.network_config` — would have printed the full PEM.
- Defense-in-depth: PR #575 (companion) already cuts off the JSON-serialization path that was the one known leak site, but a future `tracing::debug!(?config, ...)` or `format!(\"{:?}\", config)` would silently regress.
- Implement `Debug` manually on both types so `ca_key_pem` / `ca_cert_pem` render as `Some(\"[REDACTED]\")` while every other field renders identically to the previous derived form. `secrets: Vec<…>` is unchanged because the inner `Secret` / `GvproxySecretConfig` already redact their `value` field via their own custom `Debug` impl.

## Why no current behavior changes

I grep'd the codebase: there are **zero** production `{:?}` callers on either type today (one match in `tests/secret_substitution.rs` is on `GvproxySecretConfig`, a different type that is untouched here). `Serialize` / `Deserialize` derives are unchanged, so the wire format is byte-identical. The only observable change is the rendered form of `format!(\"{:?}\", config)` for these two structs, and nothing in production code reads that today.

## Test placement note

The companion assertion for `NetworkBackendConfig::Debug` lives in `src/net/mod.rs` as a `#[test]`, reachable from the standard `make test:unit:rust` target. `GvproxyConfig` lives behind `#[cfg(feature = \"gvproxy\")]`, and `make test:unit:rust` uses `--no-default-features` to avoid the Go runtime link (see `make/test.mk:177`), so an in-crate `#[test]` for it would never compile under that target. Put that assertion in `tests/gvproxy_debug_redaction.rs` gated on `#[cfg(feature = \"gvproxy\")]` — `make test:integration:rust` already passes `--features krun,gvproxy --test '*'`, so it's picked up by the existing target with no make changes.

## Out of scope (flagged for follow-up)

The whole `net::gvproxy` submodule has ~28 in-crate `#[test]` items that are likewise invisible to `make test:unit:rust`. Fixing that gap (e.g. adding a `test:unit:rust:gvproxy` make target that runs `--features gvproxy --lib`) is broader than this PR and deserves its own change.

## Test plan

- [x] `make test:unit:rust` → 705/705 boxlite lib + 36/36 boxlite-shared, no regressions; `NetworkBackendConfig` redaction test passes here.
- [x] `cargo nextest run -p boxlite --features krun,gvproxy --test gvproxy_debug_redaction` → 1 passed; the relocated `GvproxyConfig` test compiles + runs under the gvproxy feature.
- [x] `make clippy` → clean.
- [x] Reverse verification: re-deriving `Debug` on `GvproxyConfig` (regression injection) made the integration test fail with the sentinel CA-key bytes echoed in the captured output. Restoring the manual impl returned it to green. Confirms the assertion catches the leak it claims to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)