### PR TITLE
fix(runtime): rebuild invalid guest rootfs overlay

### DIFF
--- a/src/boxlite/src/disk/qcow2.rs
+++ b/src/boxlite/src/disk/qcow2.rs
@@ -838,31 +838,62 @@ impl Qcow2Helper {
     }
 }
 
-/// Read the backing file path from a qcow2 disk image header.
+/// Why reading a qcow2 header failed.
 ///
-/// Returns `None` if the qcow2 has no backing file (offset or size is 0).
-/// Returns `Err` if the file is not a valid qcow2 image.
-pub fn read_backing_file_path(path: &Path) -> BoxliteResult<Option<String>> {
-    use std::io::{Read, Seek, SeekFrom};
+/// The split matters for callers that decide whether to *discard* a disk: a
+/// structurally [`Corrupt`](Qcow2HeaderError::Corrupt) overlay is unreadable and
+/// safe to rebuild, whereas an [`Io`](Qcow2HeaderError::Io) fault is transient or
+/// environmental and proves nothing about the file's contents — discarding on it
+/// could destroy an intact overlay.
+#[derive(Debug)]
+pub enum Qcow2HeaderError {
+    /// The file could not be read — open/seek/read failed for a reason other than
+    /// hitting end-of-file. A transient or system I/O fault, not evidence of
+    /// corruption.
+    Io(std::io::Error),
+    /// The bytes are not a valid qcow2 header: bad magic, truncated, or a
+    /// non-UTF-8 backing path. The image is structurally corrupt.
+    Corrupt(String),
+}
 
-    let mut file = std::fs::File::open(path).map_err(|e| {
-        BoxliteError::Storage(format!("Failed to open qcow2 {}: {}", path.display(), e))
-    })?;
+impl std::fmt::Display for Qcow2HeaderError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Qcow2HeaderError::Io(e) => write!(f, "I/O error: {e}"),
+            Qcow2HeaderError::Corrupt(msg) => f.write_str(msg),
+        }
+    }
+}
+
+/// Read the backing file path from a qcow2 header, classifying failures as a
+/// transient [`Io`](Qcow2HeaderError::Io) fault vs structural
+/// [`Corrupt`](Qcow2HeaderError::Corrupt)ion.
+///
+/// Returns `Ok(None)` for a valid qcow2 with no backing file.
+pub fn read_backing_file_path_checked(path: &Path) -> Result<Option<String>, Qcow2HeaderError> {
+    use std::io::{ErrorKind, Read, Seek, SeekFrom};
+
+    // A short read (UnexpectedEof) means the file is truncated — structural
+    // corruption; any other io::Error is a genuine I/O fault.
+    fn on_read(path: &Path, e: std::io::Error, what: &str) -> Qcow2HeaderError {
+        if e.kind() == ErrorKind::UnexpectedEof {
+            Qcow2HeaderError::Corrupt(format!("qcow2 {} is truncated ({what})", path.display()))
+        } else {
+            Qcow2HeaderError::Io(e)
+        }
+    }
+
+    let mut file = std::fs::File::open(path).map_err(Qcow2HeaderError::Io)?;
 
     // Read the first 20 bytes of the header
     let mut header = [0u8; 20];
-    file.read_exact(&mut header).map_err(|e| {
-        BoxliteError::Storage(format!(
-            "Failed to read qcow2 header from {}: {}",
-            path.display(),
-            e
-        ))
-    })?;
+    file.read_exact(&mut header)
+        .map_err(|e| on_read(path, e, "header"))?;
 
     // Verify magic
     let magic = u32::from_be_bytes([header[0], header[1], header[2], header[3]]);
     if magic != 0x514649fb {
-        return Err(BoxliteError::Storage(format!(
+        return Err(Qcow2HeaderError::Corrupt(format!(
             "Invalid qcow2 magic in {}: 0x{:08x}",
             path.display(),
             magic
@@ -881,25 +912,15 @@ pub fn read_backing_file_path(path: &Path) -> BoxliteResult<Option<String>> {
     }
 
     // Read backing file path
-    file.seek(SeekFrom::Start(backing_offset)).map_err(|e| {
-        BoxliteError::Storage(format!(
-            "Failed to seek to backing file path in {}: {}",
-            path.display(),
-            e
-        ))
-    })?;
+    file.seek(SeekFrom::Start(backing_offset))
+        .map_err(Qcow2HeaderError::Io)?;
 
     let mut backing_buf = vec![0u8; backing_size as usize];
-    file.read_exact(&mut backing_buf).map_err(|e| {
-        BoxliteError::Storage(format!(
-            "Failed to read backing file path from {}: {}",
-            path.display(),
-            e
-        ))
-    })?;
+    file.read_exact(&mut backing_buf)
+        .map_err(|e| on_read(path, e, "backing path"))?;
 
     let backing_path = String::from_utf8(backing_buf).map_err(|e| {
-        BoxliteError::Storage(format!(
+        Qcow2HeaderError::Corrupt(format!(
             "Invalid UTF-8 in backing file path of {}: {}",
             path.display(),
             e
@@ -907,6 +928,21 @@ pub fn read_backing_file_path(path: &Path) -> BoxliteResult<Option<String>> {
     })?;
 
     Ok(Some(backing_path))
+}
+
+/// Read the backing file path from a qcow2 disk image header.
+///
+/// Returns `None` if the qcow2 has no backing file (offset or size is 0).
+/// Returns `Err` if the file is not a valid qcow2 image or cannot be read. Use
+/// [`read_backing_file_path_checked`] when the caller needs to distinguish a
+/// transient I/O fault from structural corruption.
+pub fn read_backing_file_path(path: &Path) -> BoxliteResult<Option<String>> {
+    read_backing_file_path_checked(path).map_err(|e| match e {
+        Qcow2HeaderError::Io(io) => {
+            BoxliteError::Storage(format!("Failed to read qcow2 {}: {io}", path.display()))
+        }
+        Qcow2HeaderError::Corrupt(msg) => BoxliteError::Storage(msg),
+    })
 }
 
 /// Overwrite the backing file path in a qcow2 header.
@@ -1441,6 +1477,30 @@ mod tests {
     fn test_read_backing_file_path_nonexistent_file() {
         let result = read_backing_file_path(Path::new("/nonexistent/file.qcow2"));
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_read_backing_file_path_checked_classifies_corrupt_vs_io() {
+        let dir = TempDir::new().unwrap();
+
+        // Bad magic => the bytes are not a valid qcow2 header => structural corruption.
+        let corrupt = dir.path().join("corrupt.qcow2");
+        let mut buf = vec![0u8; 64];
+        buf[0..4].copy_from_slice(&0xDEADBEEFu32.to_be_bytes());
+        std::fs::write(&corrupt, &buf).unwrap();
+        assert!(matches!(
+            read_backing_file_path_checked(&corrupt),
+            Err(Qcow2HeaderError::Corrupt(_))
+        ));
+
+        // A directory opens fine but read() fails with EISDIR (not EOF) => I/O fault,
+        // which must NOT be mistaken for corruption.
+        let as_dir = dir.path().join("dir.qcow2");
+        std::fs::create_dir(&as_dir).unwrap();
+        assert!(matches!(
+            read_backing_file_path_checked(&as_dir),
+            Err(Qcow2HeaderError::Io(_))
+        ));
     }
 
     #[test]

--- a/src/boxlite/src/litebox/init/tasks/guest_rootfs.rs
+++ b/src/boxlite/src/litebox/init/tasks/guest_rootfs.rs
@@ -255,7 +255,27 @@ mod tests {
     use super::*;
     use crate::runtime::layout::FsLayoutConfig;
     use std::fs::File;
+    use std::io::Write;
     use tempfile::TempDir;
+
+    fn test_layout(dir: &TempDir) -> BoxFilesystemLayout {
+        let layout = BoxFilesystemLayout::new(
+            dir.path().join("boxes").join("box-1"),
+            FsLayoutConfig::without_bind_mount(),
+            false,
+        );
+        std::fs::create_dir_all(layout.disks_dir()).unwrap();
+        layout
+    }
+
+    fn create_base_disk(dir: &TempDir) -> std::path::PathBuf {
+        let base_disk_path = dir.path().join("guest-rootfs-base.ext4");
+        File::create(&base_disk_path)
+            .unwrap()
+            .set_len(1024 * 1024)
+            .unwrap();
+        base_disk_path
+    }
 
     fn test_guest_rootfs(base_disk_path: std::path::PathBuf) -> GuestRootfs {
         GuestRootfs {
@@ -273,21 +293,68 @@ mod tests {
         }
     }
 
+    fn create_guest_overlay(
+        base_disk_path: &std::path::Path,
+        guest_rootfs_disk_path: &std::path::Path,
+    ) {
+        Qcow2Helper::create_cow_child_disk(
+            base_disk_path,
+            BackingFormat::Raw,
+            guest_rootfs_disk_path,
+            1024 * 1024,
+        )
+        .unwrap()
+        .leak();
+    }
+
+    fn read_guest_overlay_backing(guest_rootfs_disk_path: &std::path::Path) -> String {
+        crate::disk::qcow2::read_backing_file_path(guest_rootfs_disk_path)
+            .unwrap()
+            .unwrap()
+    }
+
+    fn write_qcow2_with_backing_bytes(
+        guest_rootfs_disk_path: &std::path::Path,
+        backing_bytes: &[u8],
+    ) {
+        let mut buf = vec![0u8; 1024];
+        buf[0..4].copy_from_slice(&0x514649fbu32.to_be_bytes());
+        buf[4..8].copy_from_slice(&3u32.to_be_bytes());
+        buf[8..16].copy_from_slice(&512u64.to_be_bytes());
+        buf[16..20].copy_from_slice(&(backing_bytes.len() as u32).to_be_bytes());
+        buf[512..512 + backing_bytes.len()].copy_from_slice(backing_bytes);
+
+        let mut file = File::create(guest_rootfs_disk_path).unwrap();
+        file.write_all(&buf).unwrap();
+    }
+
+    #[test]
+    fn test_reuse_keeps_valid_guest_rootfs_overlay() {
+        let dir = TempDir::new().unwrap();
+        let base_disk_path = create_base_disk(&dir);
+        let layout = test_layout(&dir);
+        let guest_rootfs_disk_path = layout.guest_rootfs_disk_path();
+        create_guest_overlay(&base_disk_path, &guest_rootfs_disk_path);
+        let before = std::fs::metadata(&guest_rootfs_disk_path).unwrap();
+
+        let guest_rootfs = test_guest_rootfs(base_disk_path.clone());
+        let (_updated, disk) = create_or_reuse_cow_disk(&guest_rootfs, &layout, true).unwrap();
+
+        assert_eq!(disk.unwrap().path(), guest_rootfs_disk_path);
+        let after = std::fs::metadata(&guest_rootfs_disk_path).unwrap();
+        assert_eq!(after.len(), before.len());
+        assert_eq!(after.modified().unwrap(), before.modified().unwrap());
+        assert_eq!(
+            read_guest_overlay_backing(&guest_rootfs_disk_path),
+            base_disk_path.canonicalize().unwrap().display().to_string()
+        );
+    }
+
     #[test]
     fn test_reuse_recreates_invalid_guest_rootfs_overlay() {
         let dir = TempDir::new().unwrap();
-        let base_disk_path = dir.path().join("guest-rootfs-base.ext4");
-        File::create(&base_disk_path)
-            .unwrap()
-            .set_len(1024 * 1024)
-            .unwrap();
-
-        let layout = BoxFilesystemLayout::new(
-            dir.path().join("boxes").join("box-1"),
-            FsLayoutConfig::without_bind_mount(),
-            false,
-        );
-        std::fs::create_dir_all(layout.disks_dir()).unwrap();
+        let base_disk_path = create_base_disk(&dir);
+        let layout = test_layout(&dir);
         let guest_rootfs_disk_path = layout.guest_rootfs_disk_path();
         std::fs::write(&guest_rootfs_disk_path, vec![0u8; 256 * 1024]).unwrap();
 
@@ -295,38 +362,68 @@ mod tests {
         let (_updated, disk) = create_or_reuse_cow_disk(&guest_rootfs, &layout, true).unwrap();
 
         assert_eq!(disk.unwrap().path(), guest_rootfs_disk_path);
-        let backing = crate::disk::qcow2::read_backing_file_path(&guest_rootfs_disk_path)
-            .unwrap()
-            .unwrap();
         assert_eq!(
-            backing,
+            read_guest_overlay_backing(&guest_rootfs_disk_path),
             base_disk_path.canonicalize().unwrap().display().to_string()
         );
     }
 
     #[test]
+    fn test_reuse_recreates_too_short_guest_rootfs_overlay() {
+        let dir = TempDir::new().unwrap();
+        let base_disk_path = create_base_disk(&dir);
+        let layout = test_layout(&dir);
+        let guest_rootfs_disk_path = layout.guest_rootfs_disk_path();
+        std::fs::write(&guest_rootfs_disk_path, [0u8; 10]).unwrap();
+
+        let guest_rootfs = test_guest_rootfs(base_disk_path.clone());
+        create_or_reuse_cow_disk(&guest_rootfs, &layout, true).unwrap();
+
+        assert_eq!(
+            read_guest_overlay_backing(&guest_rootfs_disk_path),
+            base_disk_path.canonicalize().unwrap().display().to_string()
+        );
+    }
+
+    #[test]
+    fn test_reuse_recreates_guest_rootfs_overlay_with_invalid_utf8_backing_path() {
+        let dir = TempDir::new().unwrap();
+        let base_disk_path = create_base_disk(&dir);
+        let layout = test_layout(&dir);
+        let guest_rootfs_disk_path = layout.guest_rootfs_disk_path();
+        write_qcow2_with_backing_bytes(&guest_rootfs_disk_path, &[0xff, 0xfe, 0xfd]);
+
+        let guest_rootfs = test_guest_rootfs(base_disk_path.clone());
+        create_or_reuse_cow_disk(&guest_rootfs, &layout, true).unwrap();
+
+        assert_eq!(
+            read_guest_overlay_backing(&guest_rootfs_disk_path),
+            base_disk_path.canonicalize().unwrap().display().to_string()
+        );
+    }
+
+    #[test]
+    fn test_reuse_reports_remove_failure_for_invalid_guest_rootfs_overlay() {
+        let dir = TempDir::new().unwrap();
+        let guest_rootfs_disk_path = dir.path().join("guest-rootfs.qcow2");
+        std::fs::create_dir(&guest_rootfs_disk_path).unwrap();
+
+        let err = match validate_reusable_guest_rootfs_disk(&guest_rootfs_disk_path) {
+            Ok(_) => panic!("expected remove failure"),
+            Err(err) => err,
+        };
+
+        assert!(format!("{err}").contains("Failed to remove invalid guest rootfs"));
+        assert!(guest_rootfs_disk_path.exists());
+    }
+
+    #[test]
     fn test_reuse_reports_missing_guest_rootfs_backing() {
         let dir = TempDir::new().unwrap();
-        let base_disk_path = dir.path().join("guest-rootfs-base.ext4");
-        File::create(&base_disk_path)
-            .unwrap()
-            .set_len(1024 * 1024)
-            .unwrap();
-        let layout = BoxFilesystemLayout::new(
-            dir.path().join("boxes").join("box-1"),
-            FsLayoutConfig::without_bind_mount(),
-            false,
-        );
-        std::fs::create_dir_all(layout.disks_dir()).unwrap();
+        let base_disk_path = create_base_disk(&dir);
+        let layout = test_layout(&dir);
         let guest_rootfs_disk_path = layout.guest_rootfs_disk_path();
-        Qcow2Helper::create_cow_child_disk(
-            &base_disk_path,
-            BackingFormat::Raw,
-            &guest_rootfs_disk_path,
-            1024 * 1024,
-        )
-        .unwrap()
-        .leak();
+        create_guest_overlay(&base_disk_path, &guest_rootfs_disk_path);
         std::fs::remove_file(&base_disk_path).unwrap();
 
         let guest_rootfs = test_guest_rootfs(base_disk_path);

--- a/src/boxlite/src/litebox/init/tasks/guest_rootfs.rs
+++ b/src/boxlite/src/litebox/init/tasks/guest_rootfs.rs
@@ -172,7 +172,8 @@ fn validate_reusable_guest_rootfs_disk(guest_rootfs_disk_path: &Path) -> Boxlite
     // Validate backing chain is intact before reusing.
     // A broken chain (e.g. from a failed migration or deleted cache) would cause
     // a cryptic hypervisor failure — catch it early with a clear error.
-    match crate::disk::qcow2::read_backing_file_path(guest_rootfs_disk_path) {
+    use crate::disk::qcow2::Qcow2HeaderError;
+    match crate::disk::qcow2::read_backing_file_path_checked(guest_rootfs_disk_path) {
         Ok(Some(backing)) if !Path::new(&backing).exists() => Err(BoxliteError::Storage(format!(
             "Guest rootfs {} has missing backing file: {}. \
                  This may indicate a broken migration or deleted cache file. \
@@ -181,22 +182,31 @@ fn validate_reusable_guest_rootfs_disk(guest_rootfs_disk_path: &Path) -> Boxlite
             backing
         ))),
         Ok(_) => Ok(true),
-        Err(err) => {
+        // Structurally corrupt overlay: its data is already unreadable, so discard
+        // it and recreate a fresh COW from the shared cache.
+        Err(Qcow2HeaderError::Corrupt(reason)) => {
             tracing::warn!(
                 disk_path = %guest_rootfs_disk_path.display(),
-                error = %err,
-                "Discarding invalid guest rootfs COW overlay and recreating from cache"
+                reason = %reason,
+                "Discarding corrupt guest rootfs COW overlay and recreating from cache"
             );
             std::fs::remove_file(guest_rootfs_disk_path).map_err(|remove_err| {
                 BoxliteError::Storage(format!(
-                    "Failed to remove invalid guest rootfs {} after qcow2 validation failed ({}): {}",
+                    "Failed to remove corrupt guest rootfs {} ({}): {}",
                     guest_rootfs_disk_path.display(),
-                    err,
+                    reason,
                     remove_err
                 ))
             })?;
             Ok(false)
         }
+        // Transient/system I/O fault: we cannot tell whether the overlay is intact,
+        // so do NOT delete it — surface the error and let the start be retried.
+        Err(Qcow2HeaderError::Io(io)) => Err(BoxliteError::Storage(format!(
+            "Cannot read guest rootfs {} to validate its backing chain (I/O error: {io}); \
+             refusing to discard a possibly-intact overlay",
+            guest_rootfs_disk_path.display()
+        ))),
     }
 }
 
@@ -403,18 +413,28 @@ mod tests {
     }
 
     #[test]
-    fn test_reuse_reports_remove_failure_for_invalid_guest_rootfs_overlay() {
+    fn test_io_error_does_not_discard_guest_rootfs_overlay() {
+        // A directory at the overlay path makes the header read fail with an I/O
+        // error (EISDIR) — not EOF — i.e. a transient/system fault, NOT proof of
+        // corruption. validate must surface the error WITHOUT deleting the path,
+        // so a momentary I/O blip never destroys a possibly-intact overlay.
         let dir = TempDir::new().unwrap();
         let guest_rootfs_disk_path = dir.path().join("guest-rootfs.qcow2");
         std::fs::create_dir(&guest_rootfs_disk_path).unwrap();
 
         let err = match validate_reusable_guest_rootfs_disk(&guest_rootfs_disk_path) {
-            Ok(_) => panic!("expected remove failure"),
+            Ok(_) => panic!("expected an I/O error, not a reuse/discard decision"),
             Err(err) => err,
         };
 
-        assert!(format!("{err}").contains("Failed to remove invalid guest rootfs"));
-        assert!(guest_rootfs_disk_path.exists());
+        assert!(
+            format!("{err}").contains("refusing to discard"),
+            "I/O failures must not be treated as corruption: {err}"
+        );
+        assert!(
+            guest_rootfs_disk_path.exists(),
+            "overlay must not be deleted on an I/O error"
+        );
     }
 
     #[test]

--- a/src/boxlite/src/litebox/init/tasks/guest_rootfs.rs
+++ b/src/boxlite/src/litebox/init/tasks/guest_rootfs.rs
@@ -13,6 +13,7 @@ use crate::runtime::layout::BoxFilesystemLayout;
 use crate::runtime::rt_impl::SharedRuntimeImpl;
 use async_trait::async_trait;
 use boxlite_shared::errors::{BoxliteError, BoxliteResult};
+use std::path::Path;
 
 pub struct GuestRootfsTask;
 
@@ -94,41 +95,27 @@ fn create_or_reuse_cow_disk(
     let guest_rootfs_disk_path = layout.guest_rootfs_disk_path();
 
     if reuse_rootfs && guest_rootfs_disk_path.exists() {
-        // Validate backing chain is intact before reusing.
-        // A broken chain (e.g. from a failed migration or deleted cache) would cause
-        // a cryptic hypervisor failure — catch it early with a clear error.
-        if let Ok(Some(backing)) =
-            crate::disk::qcow2::read_backing_file_path(&guest_rootfs_disk_path)
-            && !std::path::Path::new(&backing).exists()
-        {
-            return Err(BoxliteError::Storage(format!(
-                "Guest rootfs {} has missing backing file: {}. \
-                 This may indicate a broken migration or deleted cache file. \
-                 The box cannot start until the backing file is restored.",
-                guest_rootfs_disk_path.display(),
-                backing
-            )));
+        if validate_reusable_guest_rootfs_disk(&guest_rootfs_disk_path)? {
+            // Restart: reuse existing COW disk
+            tracing::info!(
+                disk_path = %guest_rootfs_disk_path.display(),
+                "Restart mode: reusing existing guest rootfs disk"
+            );
+
+            // Open existing disk as persistent
+            let disk = Disk::new(guest_rootfs_disk_path.clone(), DiskFormat::Qcow2, true);
+
+            // Update guest_rootfs with the COW disk path
+            let mut updated = guest_rootfs.clone();
+            if let Strategy::Disk { ref disk_path, .. } = guest_rootfs.strategy {
+                updated.strategy = Strategy::Disk {
+                    disk_path: disk_path.clone(), // Keep base path reference
+                    device_path: None,            // Will be set by VmmSpawnTask
+                };
+            }
+
+            return Ok((updated, Some(disk)));
         }
-
-        // Restart: reuse existing COW disk
-        tracing::info!(
-            disk_path = %guest_rootfs_disk_path.display(),
-            "Restart mode: reusing existing guest rootfs disk"
-        );
-
-        // Open existing disk as persistent
-        let disk = Disk::new(guest_rootfs_disk_path.clone(), DiskFormat::Qcow2, true);
-
-        // Update guest_rootfs with the COW disk path
-        let mut updated = guest_rootfs.clone();
-        if let Strategy::Disk { ref disk_path, .. } = guest_rootfs.strategy {
-            updated.strategy = Strategy::Disk {
-                disk_path: disk_path.clone(), // Keep base path reference
-                device_path: None,            // Will be set by VmmSpawnTask
-            };
-        }
-
-        return Ok((updated, Some(disk)));
     } else if reuse_rootfs {
         // Guest rootfs disk missing (e.g., clone or snapshot-restore).
         // Fall through to create a fresh COW overlay from the shared cache.
@@ -181,6 +168,38 @@ fn create_or_reuse_cow_disk(
     }
 }
 
+fn validate_reusable_guest_rootfs_disk(guest_rootfs_disk_path: &Path) -> BoxliteResult<bool> {
+    // Validate backing chain is intact before reusing.
+    // A broken chain (e.g. from a failed migration or deleted cache) would cause
+    // a cryptic hypervisor failure — catch it early with a clear error.
+    match crate::disk::qcow2::read_backing_file_path(guest_rootfs_disk_path) {
+        Ok(Some(backing)) if !Path::new(&backing).exists() => Err(BoxliteError::Storage(format!(
+            "Guest rootfs {} has missing backing file: {}. \
+                 This may indicate a broken migration or deleted cache file. \
+                 The box cannot start until the backing file is restored.",
+            guest_rootfs_disk_path.display(),
+            backing
+        ))),
+        Ok(_) => Ok(true),
+        Err(err) => {
+            tracing::warn!(
+                disk_path = %guest_rootfs_disk_path.display(),
+                error = %err,
+                "Discarding invalid guest rootfs COW overlay and recreating from cache"
+            );
+            std::fs::remove_file(guest_rootfs_disk_path).map_err(|remove_err| {
+                BoxliteError::Storage(format!(
+                    "Failed to remove invalid guest rootfs {} after qcow2 validation failed ({}): {}",
+                    guest_rootfs_disk_path.display(),
+                    err,
+                    remove_err
+                ))
+            })?;
+            Ok(false)
+        }
+    }
+}
+
 /// Prepare guest rootfs as a versioned disk image.
 ///
 /// Uses the two-stage pipeline:
@@ -229,4 +248,94 @@ async fn extract_env_from_image(
     };
 
     Ok(env)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::layout::FsLayoutConfig;
+    use std::fs::File;
+    use tempfile::TempDir;
+
+    fn test_guest_rootfs(base_disk_path: std::path::PathBuf) -> GuestRootfs {
+        GuestRootfs {
+            path: base_disk_path
+                .parent()
+                .expect("base disk has parent")
+                .to_path_buf(),
+            strategy: Strategy::Disk {
+                disk_path: base_disk_path,
+                device_path: None,
+            },
+            kernel: None,
+            initrd: None,
+            env: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn test_reuse_recreates_invalid_guest_rootfs_overlay() {
+        let dir = TempDir::new().unwrap();
+        let base_disk_path = dir.path().join("guest-rootfs-base.ext4");
+        File::create(&base_disk_path)
+            .unwrap()
+            .set_len(1024 * 1024)
+            .unwrap();
+
+        let layout = BoxFilesystemLayout::new(
+            dir.path().join("boxes").join("box-1"),
+            FsLayoutConfig::without_bind_mount(),
+            false,
+        );
+        std::fs::create_dir_all(layout.disks_dir()).unwrap();
+        let guest_rootfs_disk_path = layout.guest_rootfs_disk_path();
+        std::fs::write(&guest_rootfs_disk_path, vec![0u8; 256 * 1024]).unwrap();
+
+        let guest_rootfs = test_guest_rootfs(base_disk_path.clone());
+        let (_updated, disk) = create_or_reuse_cow_disk(&guest_rootfs, &layout, true).unwrap();
+
+        assert_eq!(disk.unwrap().path(), guest_rootfs_disk_path);
+        let backing = crate::disk::qcow2::read_backing_file_path(&guest_rootfs_disk_path)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            backing,
+            base_disk_path.canonicalize().unwrap().display().to_string()
+        );
+    }
+
+    #[test]
+    fn test_reuse_reports_missing_guest_rootfs_backing() {
+        let dir = TempDir::new().unwrap();
+        let base_disk_path = dir.path().join("guest-rootfs-base.ext4");
+        File::create(&base_disk_path)
+            .unwrap()
+            .set_len(1024 * 1024)
+            .unwrap();
+        let layout = BoxFilesystemLayout::new(
+            dir.path().join("boxes").join("box-1"),
+            FsLayoutConfig::without_bind_mount(),
+            false,
+        );
+        std::fs::create_dir_all(layout.disks_dir()).unwrap();
+        let guest_rootfs_disk_path = layout.guest_rootfs_disk_path();
+        Qcow2Helper::create_cow_child_disk(
+            &base_disk_path,
+            BackingFormat::Raw,
+            &guest_rootfs_disk_path,
+            1024 * 1024,
+        )
+        .unwrap()
+        .leak();
+        std::fs::remove_file(&base_disk_path).unwrap();
+
+        let guest_rootfs = test_guest_rootfs(base_disk_path);
+        let err = match create_or_reuse_cow_disk(&guest_rootfs, &layout, true) {
+            Ok(_) => panic!("expected missing backing file error"),
+            Err(err) => err,
+        };
+
+        assert!(format!("{err}").contains("has missing backing file"));
+        assert!(guest_rootfs_disk_path.exists());
+    }
 }


### PR DESCRIPTION
## Summary

- Detect an invalid per-box `guest-rootfs.qcow2` during restart/reuse before it reaches libkrun.
- Discard the bad overlay and recreate it from the shared guest rootfs cache.
- Keep missing backing-file failures as explicit storage errors instead of masking deleted cache data.

## Test plan

- [x] `cargo fmt --check -p boxlite`
- [x] `git diff --check`
- [x] `BOXLITE_DEPS_STUB=1 cargo test -p boxlite litebox::init::tasks::guest_rootfs::tests -- --nocapture`

Covered cases:

- valid guest rootfs overlay is reused unchanged
- zero-filled invalid overlay is rebuilt
- too-short overlay is rebuilt
- invalid UTF-8 backing path overlay is rebuilt
- remove failure while discarding invalid overlay returns a clear error
- missing backing file remains an explicit storage error and does not delete the overlay