### PR TITLE
chore(deps): bump rusqlite 0.37 -> 0.39

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1464,6 +1464,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1740,7 +1746,16 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -1751,11 +1766,11 @@ checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "hashlink"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -2470,9 +2485,9 @@ checksum = "60276e2d41bbb68b323e566047a1bfbf952050b157d8b5cdc74c07c1bf4ca3b6"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.35.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
+checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
 dependencies = [
  "cc",
  "pkg-config",
@@ -4124,6 +4139,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsqlite-vfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
+dependencies = [
+ "hashbrown 0.16.1",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "rstest"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4183,9 +4208,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.37.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
+checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
 dependencies = [
  "bitflags 2.11.1",
  "fallible-iterator",
@@ -4193,6 +4218,7 @@ dependencies = [
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
+ "sqlite-wasm-rs",
 ]
 
 [[package]]
@@ -4701,6 +4727,18 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
+]
+
+[[package]]
+name = "sqlite-wasm-rs"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd578e94101503d97e2b286bbf8db2135035ca24b2ce4cbf3f9e2fb2bbf1eee"
+dependencies = [
+ "cc",
+ "js-sys",
+ "rsqlite-vfs",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/src/boxlite/Cargo.toml
+++ b/src/boxlite/Cargo.toml
@@ -61,7 +61,7 @@ tracing-appender = "0.2"
 sysinfo = "0.30"
 libc = "0.2"
 rayon = "1.10"
-rusqlite = { version = "0.37", features = ["bundled"] }
+rusqlite = { version = "0.39", features = ["bundled"] }
 parking_lot = "0.12"
 inventory = "0.3"
 clap = { version = "4.5", features = ["derive"] }


### PR DESCRIPTION
## Summary

- Bumps `rusqlite` from 0.37 → 0.39 in `src/boxlite/Cargo.toml`; refreshes `Cargo.lock` (libsqlite3-sys 0.35 → 0.37, bundled SQLite 3.50.2 → 3.51.3).
- Unblocks downstream consumers that depend on `toasty-driver-sqlite 0.6`, which requires `rusqlite ^0.39`. Before this bump, users of both crates had to vendor boxlite and patch the dep.
- Closes #572.

## Why this is safe

Audited every 0.38/0.39 breaking change against every rusqlite call site in `src/boxlite/src/db/` + `src/boxlite/src/runtime/id.rs`:

| Breaking change | Affects us? | Reason |
| --- | --- | --- |
| 0.38: `u64`/`usize` `ToSql`/`FromSql` impls off by default | No | No call site binds `u64`/`usize`. `ImageIndexStore::len` already reads `count: i64`. |
| 0.38: statement cache optional | No | We use plain `Connection::prepare`, never `prepare_cached`. |
| 0.38: min system SQLite 3.34.1 | No | `bundled` feature ships SQLite 3.51.3. |
| 0.38: owned-connection check for closure hooks | No | We register no update/commit/rollback/wal hooks. |
| 0.39: `TryFrom<ValueRef>` for `Value` | No | We build `ValueRef::Text` directly in `ToSql` impls; never construct `Value`. |
| 0.39: pass-your-own-pointers API | No | Opt-in, not used. |

`cargo tree --workspace -i rusqlite` confirms `boxlite` is the only consumer — no transitive conflicts.

## Test plan

- [x] `cargo build -p boxlite --tests` — green
- [x] `cargo test -p boxlite --lib db::` — 52/52 pass (includes v4→v7, v5→v7, v7→v8 migrations and the reject-newer-version guard)
- [x] `cargo test -p boxlite --lib runtime::id::` — 40/40 pass (covers `ToSql`/`FromSql` for `BoxID`/`BaseDiskID` + proptest round-trips)
- [x] Pre-push integration suite (nextest, 225 tests) — green in 5m48s
- [ ] CI green