### PR TITLE
feat(rest): typed error→HTTP mapping with snake codes + request-id

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5359,12 +5359,14 @@ dependencies = [
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "iri-string",
  "pin-project-lite",
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/openapi/box.openapi.yaml
+++ b/openapi/box.openapi.yaml
@@ -1100,7 +1100,8 @@ components:
             error:
               message: "invalid argument: cpus must be between 1 and 32"
               type: InvalidArgumentError
-              code: 400
+              code: invalid_argument
+              request_id: req_01HZK4TNRPQSXYZ8WM6NCVT9R5
 
     UnauthorizedError:
       description: Missing or invalid authentication credentials
@@ -1110,9 +1111,10 @@ components:
             $ref: "#/components/schemas/ErrorResponse"
           example:
             error:
-              message: "invalid or expired access token"
-              type: UnauthorizedError
-              code: 401
+              message: "invalid or missing API key"
+              type: AuthError
+              code: unauthenticated
+              request_id: req_01HZK4TNRPQSXYZ8WM6NCVT9R5
 
     NotFoundError:
       description: Resource not found
@@ -1124,7 +1126,8 @@ components:
             error:
               message: "box not found: 01HJK4TNRPQSXYZ8WM6NCVT9R5"
               type: NotFoundError
-              code: 404
+              code: not_found
+              request_id: req_01HZK4TNRPQSXYZ8WM6NCVT9R5
 
     ConflictError:
       description: Resource state conflict
@@ -1136,7 +1139,8 @@ components:
             error:
               message: "invalid state: box is already running"
               type: InvalidStateError
-              code: 409
+              code: invalid_state
+              request_id: req_01HZK4TNRPQSXYZ8WM6NCVT9R5
 
     UnprocessableEntityError:
       description: Request understood but cannot be processed
@@ -1146,9 +1150,10 @@ components:
             $ref: "#/components/schemas/ErrorResponse"
           example:
             error:
-              message: "image error: failed to pull python:nonexistent"
+              message: "images error: manifest unknown for python:nonexistent"
               type: ImageError
-              code: 422
+              code: image_pull_failed
+              request_id: req_01HZK4TNRPQSXYZ8WM6NCVT9R5
 
   # -------------------------------------------------------------------------
   # Schemas
@@ -1339,9 +1344,22 @@ components:
     ErrorModel:
       type: object
       description: |
-        Standard error response. Maps directly to BoxliteError variants.
-        `UnauthorizedError` is a server-layer error (auth middleware) and does
-        not correspond to a BoxliteError variant in the core library.
+        Standard error response.
+
+        - `message` is human-readable text (English) for logs and
+          developer display.
+        - `type` is a stable PascalCase identifier (K8s `Status.reason`
+          style). Useful for log filtering. The canonical dispatch
+          field is `code`, not `type`.
+        - `code` is the stable snake_case machine identifier (Stripe
+          `code` style). Clients SHOULD pattern-match on `code` for
+          typed error handling.
+        - `request_id` is propagated from the `X-Request-Id` response
+          header. Include this when reporting issues; it round-trips
+          to server logs verbatim.
+
+        The HTTP numeric status is in the response status line, not in
+        the body — duplicating it added no information.
       required: [message, type, code]
       properties:
         message:
@@ -1350,34 +1368,64 @@ components:
           example: "box not found: 01HJK4TNRPQSXYZ8WM6NCVT9R5"
         type:
           type: string
-          description: Error type identifier (matches BoxliteError variants)
+          description: PascalCase error type identifier (matches BoxliteError variants)
           enum:
+            - InvalidArgumentError
             - UnsupportedError
-            - EngineError
-            - ConfigError
-            - StorageError
-            - ImageError
-            - PortalError
-            - NetworkError
-            - RpcError
-            - RpcTransportError
-            - InternalError
-            - ExecutionError
+            - AuthError
             - NotFoundError
+            - SessionReaped
             - AlreadyExistsError
             - InvalidStateError
+            - StoppedError
+            - ImageError
+            - ExecutionError
+            - ResourceExhaustedError
+            - NetworkError
+            - UpstreamUnavailableError
+            - EngineError
+            - StorageError
             - DatabaseError
             - MetadataError
-            - InvalidArgumentError
-            - StoppedError
-            - UnauthorizedError
+            - ConfigError
+            - InternalError
+            - TimeoutError
           example: NotFoundError
         code:
-          type: integer
-          description: HTTP response status code
-          minimum: 400
-          maximum: 599
-          example: 404
+          type: string
+          description: |
+            Stable snake_case machine identifier. Clients should
+            pattern-match on this field for typed error handling.
+          enum:
+            - invalid_argument
+            - unsupported
+            - unauthenticated
+            - permission_denied
+            - not_found
+            - session_reaped
+            - already_exists
+            - invalid_state
+            - stopped
+            - image_pull_failed
+            - execution_failed
+            - resource_exhausted
+            - network_unavailable
+            - upstream_unavailable
+            - engine_unavailable
+            - storage_error
+            - database_error
+            - metadata_error
+            - config_error
+            - internal
+            - timeout
+          example: not_found
+        request_id:
+          type: string
+          description: |
+            Request id propagated from the `X-Request-Id` response
+            header. Mirrors the server log entry — include when
+            reporting issues.
+          example: req_01HZK4TNRPQSXYZ8WM6NCVT9R5
         stack:
           type: array
           description: Stack trace (only included when server debug mode is enabled)

--- a/sdks/go/errors.go
+++ b/sdks/go/errors.go
@@ -9,6 +9,9 @@ import (
 // ErrorCode represents a BoxLite error category.
 type ErrorCode int
 
+// Error codes mirror the C SDK's BoxliteErrorCode enum
+// (sdks/c/src/error.rs:21-67). Numeric values must stay in sync —
+// the CGO bridge transmits the integer across the FFI boundary.
 const (
 	ErrInternal          ErrorCode = 1
 	ErrNotFound          ErrorCode = 2
@@ -29,6 +32,13 @@ const (
 	ErrRpcTransport      ErrorCode = 17
 	ErrMetadata          ErrorCode = 18
 	ErrUnsupportedEngine ErrorCode = 19
+	// System resource limit reached (disk full, VM slot exhaustion).
+	// Server-side HTTP 429.
+	ErrResourceExhausted ErrorCode = 20
+	// Interactive execution session was reaped server-side after
+	// disconnect; reattach is no longer possible — start a new exec.
+	// Server-side HTTP 410.
+	ErrSessionReaped ErrorCode = 21
 )
 
 // Error is a typed error from the BoxLite runtime.

--- a/src/boxlite/src/rest/client.rs
+++ b/src/boxlite/src/rest/client.rs
@@ -131,10 +131,7 @@ impl ApiClient {
     /// terminal output.
     async fn send_json<T: DeserializeOwned>(&self, builder: RequestBuilder) -> BoxliteResult<T> {
         let builder = self.authorize(builder).await?;
-        let resp = builder
-            .send()
-            .await
-            .map_err(|e| BoxliteError::Internal(format!("HTTP request failed: {}", e)))?;
+        let resp = builder.send().await.map_err(transport_error)?;
 
         let status = resp.status();
         if !status.is_success() {
@@ -170,10 +167,7 @@ impl ApiClient {
     /// Send a request and expect no response body (204).
     async fn send_no_content(&self, builder: RequestBuilder) -> BoxliteResult<()> {
         let builder = self.authorize(builder).await?;
-        let resp = builder
-            .send()
-            .await
-            .map_err(|e| BoxliteError::Internal(format!("HTTP request failed: {}", e)))?;
+        let resp = builder.send().await.map_err(transport_error)?;
 
         let status = resp.status();
         if status.is_success() {
@@ -242,17 +236,11 @@ impl ApiClient {
     ) -> BoxliteResult<Vec<u8>> {
         let builder = self.http.post(self.url(path)).json(body);
         let builder = self.authorize(builder).await?;
-        let resp = builder
-            .send()
-            .await
-            .map_err(|e| BoxliteError::Internal(format!("HTTP request failed: {}", e)))?;
+        let resp = builder.send().await.map_err(transport_error)?;
 
         let status = resp.status();
         if status.is_success() {
-            let bytes = resp
-                .bytes()
-                .await
-                .map_err(|e| BoxliteError::Internal(format!("failed to read response: {}", e)))?;
+            let bytes = resp.bytes().await.map_err(transport_error)?;
             Ok(bytes.to_vec())
         } else {
             self.handle_error::<Vec<u8>>(status, resp).await
@@ -272,10 +260,7 @@ impl ApiClient {
     pub async fn head_exists(&self, path: &str) -> BoxliteResult<bool> {
         let builder = self.http.head(self.url(path));
         let builder = self.authorize(builder).await?;
-        let resp = builder
-            .send()
-            .await
-            .map_err(|e| BoxliteError::Internal(format!("HTTP request failed: {}", e)))?;
+        let resp = builder.send().await.map_err(transport_error)?;
         match resp.status().as_u16() {
             204 | 200 => Ok(true),
             404 => Ok(false),
@@ -419,11 +404,41 @@ impl ApiClient {
     }
 }
 
+/// Convert a `reqwest::Error` into a typed `BoxliteError::Network` with
+/// the underlying cause described in the message. Distinguishes
+/// connect/DNS/TLS failures from request-build failures from timeouts
+/// so the user can act on the diagnosis — a connect refused is "is the
+/// server running?" while a builder error is a client-side bug.
+///
+/// The wrapper preserves the original `reqwest::Error` Display chain
+/// (URL, status, cause) which usually includes the destination host —
+/// invaluable for diagnosing transparent-proxy regressions like the
+/// Clash `:7890` interception that produced bare 502s in
+/// production.
+fn transport_error(err: reqwest::Error) -> BoxliteError {
+    let url_hint = err.url().map(|u| u.as_str().to_string());
+    let kind = if err.is_connect() {
+        "connect failed"
+    } else if err.is_timeout() {
+        "timed out"
+    } else if err.is_request() {
+        "request build failed"
+    } else if err.is_decode() {
+        "response decode failed"
+    } else {
+        "transport error"
+    };
+    let detail = match url_hint {
+        Some(url) => format!("{kind} reaching {url}: {err}"),
+        None => format!("{kind}: {err}"),
+    };
+    BoxliteError::Network(detail)
+}
+
 /// Map a tungstenite connect error to a typed `BoxliteError`. The WS
 /// upgrade returns HTTP status codes for rejections (404 for a missing
-/// session, 409 for an already-attached one); callers want to see those
-/// as `NotFound` / `AlreadyExists` rather than generic `Internal` so
-/// they can map onward to `SessionReaped`.
+/// session, 409 for an already-attached one, 410 once an exec has been
+/// reaped). Symmetric with the REST mapper in [`super::error`].
 fn map_ws_error(err: tokio_tungstenite::tungstenite::Error) -> BoxliteError {
     use tokio_tungstenite::tungstenite::Error as TgErr;
     if let TgErr::Http(resp) = &err {
@@ -444,11 +459,21 @@ fn map_ws_error(err: tokio_tungstenite::tungstenite::Error) -> BoxliteError {
             } else {
                 body
             }),
+            410 => BoxliteError::SessionReaped(if body.is_empty() {
+                "exec session reaped; start a new exec".to_string()
+            } else {
+                body
+            }),
             401 | 403 => BoxliteError::Config(format!("WS auth rejected ({}): {}", status, body)),
+            502..=504 => BoxliteError::Network(format!(
+                "WS upstream returned HTTP {} (proxy or load balancer): {}",
+                status,
+                if body.is_empty() { "<empty>" } else { &body }
+            )),
             _ => BoxliteError::Internal(format!("WS upgrade failed (HTTP {}): {}", status, body)),
         };
     }
-    BoxliteError::Internal(format!("WS connect failed: {}", err))
+    BoxliteError::Network(format!("WS connect failed: {}", err))
 }
 
 fn ensure_capability(name: &str, enabled: Option<bool>) -> BoxliteResult<()> {

--- a/src/boxlite/src/rest/error.rs
+++ b/src/boxlite/src/rest/error.rs
@@ -1,30 +1,73 @@
 //! HTTP error → BoxliteError mapping.
+//!
+//! Symmetric inverse of [`boxlite_shared::errors::BoxliteError::http`].
+//! The server emits `(status, error.type, error.code)` per that table;
+//! we dispatch on `error.code` (stable snake_case) to reconstruct the
+//! `BoxliteError` variant. Falling back to status-only mapping when
+//! the body is missing or doesn't parse.
 
 use boxlite_shared::errors::BoxliteError;
 use reqwest::StatusCode;
 
 use super::types::ErrorModel;
 
-/// Map an HTTP error response to a BoxliteError.
+/// Map a parsed structured error body to a `BoxliteError`.
+///
+/// Dispatch is on `body.code` (the stable snake string), making this
+/// the symmetric inverse of `BoxliteError::http()`. Unknown codes fall
+/// back on the HTTP status — keeps the client forward-compatible with
+/// future server-side variants.
 pub(crate) fn map_http_error(status: StatusCode, body: &ErrorModel) -> BoxliteError {
-    match (status.as_u16(), body.error_type.as_str()) {
-        (404, _) => BoxliteError::NotFound(body.message.clone()),
-        (409, "AlreadyExistsError") => BoxliteError::AlreadyExists(body.message.clone()),
-        (409, "InvalidStateError") => BoxliteError::InvalidState(body.message.clone()),
-        (409, "StoppedError") => BoxliteError::Stopped(body.message.clone()),
-        (400, _) => BoxliteError::InvalidArgument(body.message.clone()),
-        (422, "ImageError") => BoxliteError::Image(body.message.clone()),
-        (422, _) => BoxliteError::InvalidArgument(body.message.clone()),
-        (401 | 403, _) => BoxliteError::Config(format!("auth: {}", body.message)),
-        _ => BoxliteError::Internal(format!("HTTP {}: {}", status, body.message)),
+    let msg = body.message.clone();
+    match body.code.as_str() {
+        "invalid_argument" => BoxliteError::InvalidArgument(msg),
+        "unsupported" => BoxliteError::Unsupported(msg),
+        "unauthenticated" | "permission_denied" => BoxliteError::Config(format!("auth: {}", msg)),
+        "not_found" => BoxliteError::NotFound(msg),
+        "session_reaped" => BoxliteError::SessionReaped(msg),
+        "already_exists" => BoxliteError::AlreadyExists(msg),
+        "invalid_state" => BoxliteError::InvalidState(msg),
+        "stopped" => BoxliteError::Stopped(msg),
+        "image_pull_failed" => BoxliteError::Image(msg),
+        "execution_failed" => BoxliteError::Execution(msg),
+        "resource_exhausted" => BoxliteError::ResourceExhausted(msg),
+        "network_unavailable" => BoxliteError::Network(msg),
+        "upstream_unavailable" => BoxliteError::Portal(msg),
+        "engine_unavailable" => BoxliteError::Engine(msg),
+        "storage_error" => BoxliteError::Storage(msg),
+        "database_error" => BoxliteError::Database(msg),
+        "metadata_error" => BoxliteError::MetadataError(msg),
+        "config_error" => BoxliteError::Config(msg),
+        "timeout" => BoxliteError::Internal(format!("server timed out: {}", msg)),
+        "internal" => BoxliteError::Internal(msg),
+        // Forward-compat: unknown code from a newer server — fall back
+        // to status-driven mapping, preserving the body text.
+        _ => map_http_status(status, &msg),
     }
 }
 
-/// Map an HTTP error when we can't parse the body.
+/// Map a raw HTTP status to a `BoxliteError` when the body is missing
+/// or not the envelope shape.
+///
+/// Distinguishes intermediary 5xx (proxy / unreachable upstream — we
+/// emit the envelope for our own 5xx) by routing **502/503/504 with
+/// no envelope** to `Network`, since the server we deployed never
+/// produces a bare 5xx without our wire envelope.
 pub(crate) fn map_http_status(status: StatusCode, text: &str) -> BoxliteError {
     match status.as_u16() {
         404 => BoxliteError::NotFound(text.to_string()),
         401 | 403 => BoxliteError::Config(format!("auth: {}", text)),
+        // Bare 5xx with no envelope ⇒ an intermediary spoke, not us.
+        // The most common cause is a proxy / load balancer that
+        // couldn't reach the destination (Clash returns 502 with
+        // empty body for unresolvable hosts; ELB returns 504 on
+        // upstream timeout).
+        502..=504 => BoxliteError::Network(format!(
+            "upstream returned HTTP {} (no error envelope; likely a \
+             proxy or load balancer in front of the server). Body: {}",
+            status,
+            if text.is_empty() { "<empty>" } else { text }
+        )),
         _ => BoxliteError::Internal(format!("HTTP {}: {}", status, text)),
     }
 }
@@ -33,95 +76,173 @@ pub(crate) fn map_http_status(status: StatusCode, text: &str) -> BoxliteError {
 mod tests {
     use super::*;
 
-    fn error_model(msg: &str, error_type: &str, code: u16) -> ErrorModel {
+    fn body(msg: &str, etype: &str, code: &str) -> ErrorModel {
         ErrorModel {
             message: msg.to_string(),
-            error_type: error_type.to_string(),
-            code,
+            error_type: etype.to_string(),
+            code: code.to_string(),
+            request_id: None,
         }
     }
 
+    /// One row of the round-trip table: `(http_status, error_type,
+    /// snake_code, variant_predicate)`. Aliased so clippy doesn't
+    /// flag the tuple as overly complex.
+    type RoundTripRow = (u16, &'static str, &'static str, fn(&BoxliteError) -> bool);
+
+    /// Canonical round-trip table — for every `(status, type, code)`
+    /// the server can emit per `BoxliteError::http()`, the client must
+    /// reconstruct a `BoxliteError` of the matching variant.
+    ///
+    /// Pinning the full table here is the second wall: even if the
+    /// server-side mapping changes silently, this test fails — making
+    /// the wire contract bilateral.
     #[test]
-    fn test_404_maps_to_not_found() {
-        let err = map_http_error(
-            StatusCode::NOT_FOUND,
-            &error_model("box xyz not found", "NotFoundError", 404),
-        );
-        assert!(matches!(err, BoxliteError::NotFound(_)));
+    fn round_trip_canonical_table() {
+        let cases: &[RoundTripRow] = &[
+            (400, "InvalidArgumentError", "invalid_argument", |e| {
+                matches!(e, BoxliteError::InvalidArgument(_))
+            }),
+            (400, "UnsupportedError", "unsupported", |e| {
+                matches!(e, BoxliteError::Unsupported(_))
+            }),
+            (401, "AuthError", "unauthenticated", |e| {
+                matches!(e, BoxliteError::Config(_))
+            }),
+            (403, "AuthError", "permission_denied", |e| {
+                matches!(e, BoxliteError::Config(_))
+            }),
+            (404, "NotFoundError", "not_found", |e| {
+                matches!(e, BoxliteError::NotFound(_))
+            }),
+            (410, "SessionReapedError", "session_reaped", |e| {
+                matches!(e, BoxliteError::SessionReaped(_))
+            }),
+            (409, "AlreadyExistsError", "already_exists", |e| {
+                matches!(e, BoxliteError::AlreadyExists(_))
+            }),
+            (409, "InvalidStateError", "invalid_state", |e| {
+                matches!(e, BoxliteError::InvalidState(_))
+            }),
+            (409, "StoppedError", "stopped", |e| {
+                matches!(e, BoxliteError::Stopped(_))
+            }),
+            (422, "ImageError", "image_pull_failed", |e| {
+                matches!(e, BoxliteError::Image(_))
+            }),
+            (422, "ExecutionError", "execution_failed", |e| {
+                matches!(e, BoxliteError::Execution(_))
+            }),
+            (429, "ResourceExhaustedError", "resource_exhausted", |e| {
+                matches!(e, BoxliteError::ResourceExhausted(_))
+            }),
+            (503, "NetworkError", "network_unavailable", |e| {
+                matches!(e, BoxliteError::Network(_))
+            }),
+            (
+                503,
+                "UpstreamUnavailableError",
+                "upstream_unavailable",
+                |e| matches!(e, BoxliteError::Portal(_)),
+            ),
+            (503, "EngineError", "engine_unavailable", |e| {
+                matches!(e, BoxliteError::Engine(_))
+            }),
+            (500, "StorageError", "storage_error", |e| {
+                matches!(e, BoxliteError::Storage(_))
+            }),
+            (500, "DatabaseError", "database_error", |e| {
+                matches!(e, BoxliteError::Database(_))
+            }),
+            (500, "MetadataError", "metadata_error", |e| {
+                matches!(e, BoxliteError::MetadataError(_))
+            }),
+            (500, "ConfigError", "config_error", |e| {
+                matches!(e, BoxliteError::Config(_))
+            }),
+            (500, "InternalError", "internal", |e| {
+                matches!(e, BoxliteError::Internal(_))
+            }),
+            (504, "TimeoutError", "timeout", |e| {
+                matches!(e, BoxliteError::Internal(_))
+            }),
+        ];
+
+        for (status_u16, etype, code, predicate) in cases {
+            let status = StatusCode::from_u16(*status_u16).expect("valid HTTP status");
+            let err = map_http_error(status, &body("msg", etype, code));
+            assert!(
+                predicate(&err),
+                "code {:?} (HTTP {}) mapped to unexpected variant: {:?}",
+                code,
+                status_u16,
+                err
+            );
+        }
     }
 
+    /// Unknown code from a newer server falls back to status-driven
+    /// mapping — forward-compat. The body text must be preserved.
     #[test]
-    fn test_409_already_exists() {
+    fn unknown_code_falls_back_to_status_mapping() {
         let err = map_http_error(
-            StatusCode::CONFLICT,
-            &error_model("box already exists", "AlreadyExistsError", 409),
+            StatusCode::IM_A_TEAPOT,
+            &body("can't brew", "TeapotError", "teapot_brewing_failed"),
         );
-        assert!(matches!(err, BoxliteError::AlreadyExists(_)));
+        match err {
+            BoxliteError::Internal(s) => {
+                assert!(s.contains("418"), "fallback should mention status: {s}");
+                assert!(
+                    s.contains("can't brew"),
+                    "fallback should mention body: {s}"
+                );
+            }
+            other => panic!("expected Internal fallback, got {other:?}"),
+        }
     }
 
+    /// Empty-body 502/503/504 ⇒ `Network`, not `Internal`. Pinned
+    /// because this is precisely the symptom of the user-reported
+    /// Clash proxy regression: the proxy returns 502 with no body
+    /// for unresolvable destinations.
     #[test]
-    fn test_409_invalid_state() {
-        let err = map_http_error(
-            StatusCode::CONFLICT,
-            &error_model("box is stopped", "InvalidStateError", 409),
-        );
-        assert!(matches!(err, BoxliteError::InvalidState(_)));
+    fn bare_5xx_without_envelope_is_network_error() {
+        for status_u16 in [502, 503, 504] {
+            let status = StatusCode::from_u16(status_u16).unwrap();
+            let err = map_http_status(status, "");
+            assert!(
+                matches!(err, BoxliteError::Network(_)),
+                "HTTP {} with empty body should map to Network, got {:?}",
+                status_u16,
+                err
+            );
+        }
     }
 
+    /// Bare 500 with no envelope is `Internal` (server-side bug, not
+    /// proxy). Distinct from 502/503/504 so the CLI can render
+    /// different remediation hints.
     #[test]
-    fn test_409_stopped() {
-        let err = map_http_error(
-            StatusCode::CONFLICT,
-            &error_model("box is stopped", "StoppedError", 409),
-        );
-        assert!(matches!(err, BoxliteError::Stopped(_)));
-    }
-
-    #[test]
-    fn test_400_invalid_argument() {
-        let err = map_http_error(
-            StatusCode::BAD_REQUEST,
-            &error_model("invalid cpus", "ValidationError", 400),
-        );
-        assert!(matches!(err, BoxliteError::InvalidArgument(_)));
-    }
-
-    #[test]
-    fn test_422_image_error() {
-        let err = map_http_error(
-            StatusCode::UNPROCESSABLE_ENTITY,
-            &error_model("image not found", "ImageError", 422),
-        );
-        assert!(matches!(err, BoxliteError::Image(_)));
-    }
-
-    #[test]
-    fn test_401_auth_error() {
-        let err = map_http_error(
-            StatusCode::UNAUTHORIZED,
-            &error_model("invalid token", "AuthError", 401),
-        );
-        assert!(matches!(err, BoxliteError::Config(_)));
-    }
-
-    #[test]
-    fn test_500_internal_error() {
-        let err = map_http_error(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            &error_model("server error", "InternalError", 500),
-        );
+    fn bare_500_without_envelope_is_internal() {
+        let err = map_http_status(StatusCode::INTERNAL_SERVER_ERROR, "");
         assert!(matches!(err, BoxliteError::Internal(_)));
     }
 
+    /// 401/403 status-only still routes to `Config("auth: …")` so the
+    /// CLI's auth-error classifier keeps working when the server
+    /// somehow emits 401 without our envelope.
     #[test]
-    fn test_map_status_fallback() {
-        let err = map_http_status(StatusCode::NOT_FOUND, "not found");
-        assert!(matches!(err, BoxliteError::NotFound(_)));
-
-        let err = map_http_status(StatusCode::FORBIDDEN, "forbidden");
+    fn bare_auth_status_routes_to_config() {
+        let err = map_http_status(StatusCode::UNAUTHORIZED, "no token");
         assert!(matches!(err, BoxliteError::Config(_)));
+        let err = map_http_status(StatusCode::FORBIDDEN, "wrong scope");
+        assert!(matches!(err, BoxliteError::Config(_)));
+    }
 
-        let err = map_http_status(StatusCode::INTERNAL_SERVER_ERROR, "oops");
-        assert!(matches!(err, BoxliteError::Internal(_)));
+    /// 404 status-only is `NotFound` regardless of body shape.
+    #[test]
+    fn bare_404_is_not_found() {
+        let err = map_http_status(StatusCode::NOT_FOUND, "");
+        assert!(matches!(err, BoxliteError::NotFound(_)));
     }
 }

--- a/src/boxlite/src/rest/types.rs
+++ b/src/boxlite/src/rest/types.rs
@@ -20,13 +20,28 @@ pub(crate) struct ErrorResponse {
     pub error: ErrorModel,
 }
 
+/// Wire shape received from the server.
+///
+/// - `message` — human-readable error text.
+/// - `error_type` — stable PascalCase identifier (K8s `Status.reason`
+///   style). Mirrors `BoxliteError::http().1` server-side.
+/// - `code` — stable snake_case machine identifier (Stripe `code` style).
+///   The mapper in [`super::error::map_http_error`] dispatches on this
+///   field; `error_type` is kept for diagnostics / logging.
+/// - `request_id` — propagated from server's `X-Request-Id` middleware
+///   when present; absent on older servers (forward-compat).
 #[derive(Debug, Deserialize)]
 pub(crate) struct ErrorModel {
     pub message: String,
+    /// Preserved for diagnostics / log enrichment; dispatch happens on
+    /// `code` (the snake string).
     #[serde(rename = "type")]
-    pub error_type: String,
     #[allow(dead_code)]
-    pub code: u16,
+    pub error_type: String,
+    pub code: String,
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub request_id: Option<String>,
 }
 
 // ============================================================================
@@ -649,13 +664,15 @@ mod tests {
             "error": {
                 "message": "box not found",
                 "type": "NotFoundError",
-                "code": 404
+                "code": "not_found",
+                "request_id": "req_01HZK"
             }
         }"#;
         let resp: ErrorResponse = serde_json::from_str(json).unwrap();
         assert_eq!(resp.error.message, "box not found");
         assert_eq!(resp.error.error_type, "NotFoundError");
-        assert_eq!(resp.error.code, 404);
+        assert_eq!(resp.error.code, "not_found");
+        assert_eq!(resp.error.request_id.as_deref(), Some("req_01HZK"));
     }
 
     #[test]

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -34,7 +34,12 @@ axum = { version = "0.8", features = ["macros", "ws"] }
 base64 = "0.22"
 tar = "0.4"
 tempfile = "3"
-tower-http = { version = "0.6", features = ["cors", "trace"] }
+tower-http = { version = "0.6", features = [
+    "cors",
+    "trace",
+    "request-id",  # SetRequestIdLayer + PropagateRequestIdLayer for X-Request-Id
+    "catch-panic", # CatchPanicLayer turns handler panics into 500 with our envelope
+] }
 
 # Serialization (aligned with core boxlite)
 serde = { version = "1.0", features = ["derive"] }

--- a/src/cli/src/commands/auth/api_key.rs
+++ b/src/cli/src/commands/auth/api_key.rs
@@ -162,22 +162,31 @@ async fn validate(profile: &Profile) -> Result<Option<Principal>> {
     }
 }
 
-/// Turn a client error into a focused, non-secret message. 401/403 map to
-/// `BoxliteError::Config("auth: …")`; everything else is treated as a
-/// connectivity/server error. Credentials are not saved in either case.
+/// Turn a client error into a focused, non-secret message.
+///
+/// Three buckets: an auth rejection from the server (`Config("auth: …")`
+/// — produced by `map_http_error` for 401/403), a transport-level
+/// failure that never reached the server (`Network(_)` — including the
+/// "bare 5xx → proxy" path in `map_http_status`), and everything else.
+/// We never persist credentials in any of the failure cases.
 fn classify(profile: &Profile, err: BoxliteError) -> anyhow::Error {
-    let msg = err.to_string();
-    if msg.contains("auth:") {
-        anyhow!(
+    match err {
+        BoxliteError::Config(ref msg) if msg.starts_with("auth:") => anyhow!(
             "authentication failed against {}: {} (credentials not saved)",
             profile.url,
             msg
-        )
-    } else {
-        anyhow!(
+        ),
+        ref e @ BoxliteError::Network(_) => anyhow!(
+            "could not reach {}: {} (credentials not saved). \
+             Check that the server is running, the URL is correct, \
+             and any HTTP_PROXY env vars don't shadow this destination.",
+            profile.url,
+            e
+        ),
+        other => anyhow!(
             "could not reach {}: {} (credentials not saved)",
             profile.url,
-            msg
-        )
+            other
+        ),
     }
 }

--- a/src/cli/src/commands/auth/whoami.rs
+++ b/src/cli/src/commands/auth/whoami.rs
@@ -52,14 +52,16 @@ pub async fn run(profile_name: &str) -> Result<()> {
             "server at {} does not implement GET /v1/me — cannot show identity",
             url
         )),
-        Err(err) => {
-            let msg = err.to_string();
-            if msg.contains("auth:") {
-                Err(anyhow!("authentication failed against {}: {}", url, msg))
-            } else {
-                Err(anyhow!("could not reach {}: {}", url, msg))
-            }
+        Err(BoxliteError::Config(msg)) if msg.starts_with("auth:") => {
+            Err(anyhow!("authentication failed against {}: {}", url, msg))
         }
+        Err(err @ BoxliteError::Network(_)) => Err(anyhow!(
+            "could not reach {}: {}. Check the URL, that the server is \
+             running, and any HTTP_PROXY env vars.",
+            url,
+            err
+        )),
+        Err(err) => Err(anyhow!("could not reach {}: {}", url, err)),
     }
 }
 

--- a/src/cli/src/commands/serve/handlers/advanced.rs
+++ b/src/cli/src/commands/serve/handlers/advanced.rs
@@ -12,7 +12,7 @@ use boxlite::{BoxArchive, CloneOptions, ExportOptions};
 
 use super::super::types::{CloneRequest, ImportQuery};
 use super::super::{
-    AppState, box_info_to_response, classify_boxlite_error, error_response, get_or_fetch_box,
+    AppState, box_info_to_response, error_from_boxlite, error_response, get_or_fetch_box,
 };
 
 pub(in crate::commands::serve) async fn clone_box(
@@ -37,10 +37,7 @@ pub(in crate::commands::serve) async fn clone_box(
                 .insert(cloned_id, Arc::new(cloned));
             (StatusCode::CREATED, Json(resp)).into_response()
         }
-        Err(e) => {
-            let (status, etype) = classify_boxlite_error(&e);
-            error_response(status, e.to_string(), etype)
-        }
+        Err(e) => error_from_boxlite(&e),
     }
 }
 
@@ -60,6 +57,7 @@ pub(in crate::commands::serve) async fn export_box(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 format!("failed to create temp dir: {e}"),
                 "InternalError",
+                "internal",
             );
         }
     };
@@ -76,6 +74,7 @@ pub(in crate::commands::serve) async fn export_box(
                         StatusCode::INTERNAL_SERVER_ERROR,
                         format!("failed to read archive: {e}"),
                         "InternalError",
+                        "internal",
                     );
                 }
             };
@@ -86,10 +85,7 @@ pub(in crate::commands::serve) async fn export_box(
                 .body(axum::body::Body::from(bytes))
                 .unwrap()
         }
-        Err(e) => {
-            let (status, etype) = classify_boxlite_error(&e);
-            error_response(status, e.to_string(), etype)
-        }
+        Err(e) => error_from_boxlite(&e),
     }
 }
 
@@ -105,6 +101,7 @@ pub(in crate::commands::serve) async fn import_box(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 format!("failed to create temp dir: {e}"),
                 "InternalError",
+                "internal",
             );
         }
     };
@@ -115,6 +112,7 @@ pub(in crate::commands::serve) async fn import_box(
             StatusCode::INTERNAL_SERVER_ERROR,
             format!("failed to write archive: {e}"),
             "InternalError",
+            "internal",
         );
     }
 
@@ -127,9 +125,6 @@ pub(in crate::commands::serve) async fn import_box(
             state.boxes.write().await.insert(box_id, Arc::new(litebox));
             (StatusCode::CREATED, Json(resp)).into_response()
         }
-        Err(e) => {
-            let (status, etype) = classify_boxlite_error(&e);
-            error_response(status, e.to_string(), etype)
-        }
+        Err(e) => error_from_boxlite(&e),
     }
 }

--- a/src/cli/src/commands/serve/handlers/boxes.rs
+++ b/src/cli/src/commands/serve/handlers/boxes.rs
@@ -9,7 +9,7 @@ use axum::response::{IntoResponse, Response};
 
 use super::super::types::{CreateBoxRequest, ListBoxesResponse, RemoveQuery};
 use super::super::{
-    AppState, box_info_to_response, build_box_options, classify_boxlite_error, error_response,
+    AppState, box_info_to_response, build_box_options, error_from_boxlite, error_response,
     get_or_fetch_box,
 };
 
@@ -20,15 +20,19 @@ pub(in crate::commands::serve) async fn create_box(
     let name = req.name.clone();
     let options = match build_box_options(&req) {
         Ok(options) => options,
-        Err(e) => return error_response(StatusCode::BAD_REQUEST, e.to_string(), "ConfigError"),
+        Err(e) => {
+            return error_response(
+                StatusCode::BAD_REQUEST,
+                e.to_string(),
+                "InvalidArgumentError",
+                "invalid_argument",
+            );
+        }
     };
 
     let litebox = match state.runtime.create(options, name).await {
         Ok(b) => b,
-        Err(e) => {
-            let (status, etype) = classify_boxlite_error(&e);
-            return error_response(status, e.to_string(), etype);
-        }
+        Err(e) => return error_from_boxlite(&e),
     };
 
     let info = litebox.info();
@@ -46,10 +50,7 @@ pub(in crate::commands::serve) async fn list_boxes(State(state): State<Arc<AppSt
             let boxes = infos.iter().map(box_info_to_response).collect();
             Json(ListBoxesResponse { boxes }).into_response()
         }
-        Err(e) => {
-            let (status, etype) = classify_boxlite_error(&e);
-            error_response(status, e.to_string(), etype)
-        }
+        Err(e) => error_from_boxlite(&e),
     }
 }
 
@@ -63,11 +64,9 @@ pub(in crate::commands::serve) async fn get_box(
             StatusCode::NOT_FOUND,
             format!("box not found: {box_id}"),
             "NotFoundError",
+            "not_found",
         ),
-        Err(e) => {
-            let (status, etype) = classify_boxlite_error(&e);
-            error_response(status, e.to_string(), etype)
-        }
+        Err(e) => error_from_boxlite(&e),
     }
 }
 
@@ -78,10 +77,7 @@ pub(in crate::commands::serve) async fn head_box(
     match state.runtime.get_info(&box_id).await {
         Ok(Some(_)) => StatusCode::NO_CONTENT.into_response(),
         Ok(None) => StatusCode::NOT_FOUND.into_response(),
-        Err(e) => {
-            let (status, etype) = classify_boxlite_error(&e);
-            error_response(status, e.to_string(), etype)
-        }
+        Err(e) => error_from_boxlite(&e),
     }
 }
 
@@ -95,8 +91,7 @@ pub(in crate::commands::serve) async fn start_box(
     };
 
     if let Err(e) = litebox.start().await {
-        let (status, etype) = classify_boxlite_error(&e);
-        return error_response(status, e.to_string(), etype);
+        return error_from_boxlite(&e);
     }
 
     let info = litebox.info();
@@ -113,8 +108,7 @@ pub(in crate::commands::serve) async fn stop_box(
     };
 
     if let Err(e) = litebox.stop().await {
-        let (status, etype) = classify_boxlite_error(&e);
-        return error_response(status, e.to_string(), etype);
+        return error_from_boxlite(&e);
     }
 
     let info = litebox.info();
@@ -131,9 +125,6 @@ pub(in crate::commands::serve) async fn remove_box(
 
     match state.runtime.remove(&box_id, force).await {
         Ok(()) => StatusCode::NO_CONTENT.into_response(),
-        Err(e) => {
-            let (status, etype) = classify_boxlite_error(&e);
-            error_response(status, e.to_string(), etype)
-        }
+        Err(e) => error_from_boxlite(&e),
     }
 }

--- a/src/cli/src/commands/serve/handlers/executions.rs
+++ b/src/cli/src/commands/serve/handlers/executions.rs
@@ -13,7 +13,7 @@ use futures::StreamExt;
 
 use super::super::types::{ExecRequest, ExecResponse, ResizeRequest, SignalRequest};
 use super::super::{
-    ActiveExecution, AppState, build_box_command, classify_boxlite_error, error_response,
+    ActiveExecution, AppState, build_box_command, error_from_boxlite, error_response,
     get_or_fetch_box,
 };
 
@@ -32,10 +32,7 @@ pub(in crate::commands::serve) async fn start_execution(
 
     let mut execution = match litebox.exec(cmd).await {
         Ok(e) => e,
-        Err(e) => {
-            let (status, etype) = classify_boxlite_error(&e);
-            return error_response(status, e.to_string(), etype);
-        }
+        Err(e) => return error_from_boxlite(&e),
     };
 
     let mut stdin = execution.stdin();
@@ -82,11 +79,13 @@ fn get_active_for_box(
             StatusCode::NOT_FOUND,
             format!("execution not found: {exec_id}"),
             "NotFoundError",
+            "not_found",
         )),
         None => Err(error_response(
             StatusCode::NOT_FOUND,
             format!("execution not found: {exec_id}"),
             "NotFoundError",
+            "not_found",
         )),
     }
 }
@@ -136,7 +135,8 @@ pub(in crate::commands::serve) async fn send_signal(
                  cooperative signals are {:?}",
                 req.signal, ALLOWED_SIGNALS
             ),
-            "ValidationError",
+            "InvalidArgumentError",
+            "invalid_argument",
         );
     }
 
@@ -154,14 +154,12 @@ pub(in crate::commands::serve) async fn send_signal(
     .await;
     match sig_result {
         Ok(Ok(())) => StatusCode::NO_CONTENT.into_response(),
-        Ok(Err(e)) => {
-            let (status, etype) = classify_boxlite_error(&e);
-            error_response(status, e.to_string(), etype)
-        }
+        Ok(Err(e)) => error_from_boxlite(&e),
         Err(_) => error_response(
             StatusCode::GATEWAY_TIMEOUT,
             "signal delivery timed out",
             "TimeoutError",
+            "timeout",
         ),
     }
 }
@@ -190,14 +188,12 @@ pub(in crate::commands::serve) async fn kill_execution(
             state.executions.write().await.remove(&exec_id);
             StatusCode::NO_CONTENT.into_response()
         }
-        Ok(Err(e)) => {
-            let (status, etype) = classify_boxlite_error(&e);
-            error_response(status, e.to_string(), etype)
-        }
+        Ok(Err(e)) => error_from_boxlite(&e),
         Err(_) => error_response(
             StatusCode::GATEWAY_TIMEOUT,
             "kill timed out; the reaper will retry",
             "TimeoutError",
+            "timeout",
         ),
     }
 }
@@ -216,10 +212,7 @@ pub(in crate::commands::serve) async fn resize_tty(
 
     match active.execution().resize_tty(req.rows, req.cols).await {
         Ok(()) => StatusCode::NO_CONTENT.into_response(),
-        Err(e) => {
-            let (status, etype) = classify_boxlite_error(&e);
-            error_response(status, e.to_string(), etype)
-        }
+        Err(e) => error_from_boxlite(&e),
     }
 }
 
@@ -254,7 +247,8 @@ pub(in crate::commands::serve) async fn attach_execution(
         return error_response(
             StatusCode::CONFLICT,
             format!("execution {} already has an attached client", exec_id),
-            "ConflictError",
+            "InvalidStateError",
+            "invalid_state",
         );
     }
 

--- a/src/cli/src/commands/serve/handlers/files.rs
+++ b/src/cli/src/commands/serve/handlers/files.rs
@@ -10,7 +10,7 @@ use axum::response::{IntoResponse, Response};
 use boxlite::CopyOptions;
 
 use super::super::types::FileQuery;
-use super::super::{AppState, classify_boxlite_error, error_response, get_or_fetch_box};
+use super::super::{AppState, error_from_boxlite, error_response, get_or_fetch_box};
 
 pub(in crate::commands::serve) async fn upload_files(
     State(state): State<Arc<AppState>>,
@@ -31,6 +31,7 @@ pub(in crate::commands::serve) async fn upload_files(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 format!("failed to create temp dir: {e}"),
                 "InternalError",
+                "internal",
             );
         }
     };
@@ -41,6 +42,7 @@ pub(in crate::commands::serve) async fn upload_files(
             StatusCode::INTERNAL_SERVER_ERROR,
             format!("failed to create extract dir: {e}"),
             "InternalError",
+            "internal",
         );
     }
 
@@ -50,6 +52,7 @@ pub(in crate::commands::serve) async fn upload_files(
             StatusCode::BAD_REQUEST,
             format!("failed to extract tar: {e}"),
             "InvalidArgumentError",
+            "invalid_argument",
         );
     }
 
@@ -57,8 +60,7 @@ pub(in crate::commands::serve) async fn upload_files(
         .copy_into(&extract_dir, &query.path, CopyOptions::default())
         .await
     {
-        let (status, etype) = classify_boxlite_error(&e);
-        return error_response(status, e.to_string(), etype);
+        return error_from_boxlite(&e);
     }
 
     StatusCode::NO_CONTENT.into_response()
@@ -81,6 +83,7 @@ pub(in crate::commands::serve) async fn download_files(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 format!("failed to create temp dir: {e}"),
                 "InternalError",
+                "internal",
             );
         }
     };
@@ -89,8 +92,7 @@ pub(in crate::commands::serve) async fn download_files(
         .copy_out(&query.path, temp_dir.path(), CopyOptions::default())
         .await
     {
-        let (status, etype) = classify_boxlite_error(&e);
-        return error_response(status, e.to_string(), etype);
+        return error_from_boxlite(&e);
     }
 
     // Create tar from extracted files
@@ -100,6 +102,7 @@ pub(in crate::commands::serve) async fn download_files(
             StatusCode::INTERNAL_SERVER_ERROR,
             format!("failed to create tar: {e}"),
             "InternalError",
+            "internal",
         );
     }
 
@@ -110,6 +113,7 @@ pub(in crate::commands::serve) async fn download_files(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 format!("failed to finalize tar: {e}"),
                 "InternalError",
+                "internal",
             );
         }
     };

--- a/src/cli/src/commands/serve/handlers/metrics.rs
+++ b/src/cli/src/commands/serve/handlers/metrics.rs
@@ -7,7 +7,7 @@ use axum::extract::{Path, State};
 use axum::response::{IntoResponse, Response};
 
 use super::super::types::{BootTimingResponse, BoxMetricsResponse, RuntimeMetricsResponse};
-use super::super::{AppState, classify_boxlite_error, error_response, get_or_fetch_box};
+use super::super::{AppState, error_from_boxlite, get_or_fetch_box};
 
 pub(in crate::commands::serve) async fn runtime_metrics(
     State(state): State<Arc<AppState>>,
@@ -23,10 +23,7 @@ pub(in crate::commands::serve) async fn runtime_metrics(
             total_exec_errors: metrics.total_exec_errors(),
         })
         .into_response(),
-        Err(e) => {
-            let (status, etype) = classify_boxlite_error(&e);
-            error_response(status, e.to_string(), etype)
-        }
+        Err(e) => error_from_boxlite(&e),
     }
 }
 
@@ -72,9 +69,6 @@ pub(in crate::commands::serve) async fn box_metrics(
             })
             .into_response()
         }
-        Err(e) => {
-            let (status, etype) = classify_boxlite_error(&e);
-            error_response(status, e.to_string(), etype)
-        }
+        Err(e) => error_from_boxlite(&e),
     }
 }

--- a/src/cli/src/commands/serve/handlers/snapshots.rs
+++ b/src/cli/src/commands/serve/handlers/snapshots.rs
@@ -10,7 +10,7 @@ use axum::response::{IntoResponse, Response};
 use boxlite::SnapshotOptions;
 
 use super::super::types::{CreateSnapshotRequest, ListSnapshotsResponse, SnapshotResponse};
-use super::super::{AppState, classify_boxlite_error, error_response, get_or_fetch_box};
+use super::super::{AppState, error_from_boxlite, error_response, get_or_fetch_box};
 
 fn snapshot_to_response(info: &boxlite::SnapshotInfo) -> SnapshotResponse {
     SnapshotResponse {
@@ -39,10 +39,7 @@ pub(in crate::commands::serve) async fn create_snapshot(
         .await
     {
         Ok(info) => (StatusCode::CREATED, Json(snapshot_to_response(&info))).into_response(),
-        Err(e) => {
-            let (status, etype) = classify_boxlite_error(&e);
-            error_response(status, e.to_string(), etype)
-        }
+        Err(e) => error_from_boxlite(&e),
     }
 }
 
@@ -60,10 +57,7 @@ pub(in crate::commands::serve) async fn list_snapshots(
             let snapshots = snaps.iter().map(snapshot_to_response).collect();
             Json(ListSnapshotsResponse { snapshots }).into_response()
         }
-        Err(e) => {
-            let (status, etype) = classify_boxlite_error(&e);
-            error_response(status, e.to_string(), etype)
-        }
+        Err(e) => error_from_boxlite(&e),
     }
 }
 
@@ -82,11 +76,9 @@ pub(in crate::commands::serve) async fn get_snapshot(
             StatusCode::NOT_FOUND,
             format!("snapshot not found: {name}"),
             "NotFoundError",
+            "not_found",
         ),
-        Err(e) => {
-            let (status, etype) = classify_boxlite_error(&e);
-            error_response(status, e.to_string(), etype)
-        }
+        Err(e) => error_from_boxlite(&e),
     }
 }
 
@@ -101,10 +93,7 @@ pub(in crate::commands::serve) async fn delete_snapshot(
 
     match litebox.snapshots().remove(&name).await {
         Ok(()) => StatusCode::NO_CONTENT.into_response(),
-        Err(e) => {
-            let (status, etype) = classify_boxlite_error(&e);
-            error_response(status, e.to_string(), etype)
-        }
+        Err(e) => error_from_boxlite(&e),
     }
 }
 
@@ -119,9 +108,6 @@ pub(in crate::commands::serve) async fn restore_snapshot(
 
     match litebox.snapshots().restore(&name).await {
         Ok(()) => StatusCode::NO_CONTENT.into_response(),
-        Err(e) => {
-            let (status, etype) = classify_boxlite_error(&e);
-            error_response(status, e.to_string(), etype)
-        }
+        Err(e) => error_from_boxlite(&e),
     }
 }

--- a/src/cli/src/commands/serve/mod.rs
+++ b/src/cli/src/commands/serve/mod.rs
@@ -20,6 +20,8 @@ use axum::{Json, Router};
 use clap::Args;
 use futures::StreamExt;
 use tokio::sync::RwLock;
+use tower_http::catch_panic::CatchPanicLayer;
+use tower_http::request_id::{MakeRequestUuid, PropagateRequestIdLayer, SetRequestIdLayer};
 
 use boxlite::runtime::options::{NetworkConfig, NetworkMode};
 use boxlite::{
@@ -695,28 +697,59 @@ fn build_box_command(req: &ExecRequest) -> BoxCommand {
 // Error Helpers
 // ============================================================================
 
-fn error_response(status: StatusCode, message: impl Into<String>, error_type: &str) -> Response {
+/// Build a JSON error response with the canonical wire envelope.
+///
+/// `error_type` and `code` are caller-supplied because some sites
+/// (auth middleware, handler timeout, schema-validation rejection) emit
+/// errors that don't correspond to a `BoxliteError` variant. For
+/// `BoxliteError` paths use [`error_from_boxlite`] instead — it dispatches
+/// to the single source of truth in `BoxliteError::http()`.
+fn error_response(
+    status: StatusCode,
+    message: impl Into<String>,
+    error_type: &str,
+    code: &str,
+) -> Response {
     let body = ErrorBody {
         error: ErrorDetail {
             message: message.into(),
             error_type: error_type.to_string(),
-            code: status.as_u16(),
+            code: code.to_string(),
+            request_id: None,
         },
     };
     (status, Json(body)).into_response()
 }
 
-fn classify_boxlite_error(err: &boxlite::BoxliteError) -> (StatusCode, &'static str) {
-    let msg = err.to_string().to_lowercase();
-    if msg.contains("not found") {
-        (StatusCode::NOT_FOUND, "NotFoundError")
-    } else if msg.contains("already") || msg.contains("conflict") {
-        (StatusCode::CONFLICT, "ConflictError")
-    } else if msg.contains("unsupported") {
-        (StatusCode::BAD_REQUEST, "UnsupportedError")
-    } else {
-        (StatusCode::INTERNAL_SERVER_ERROR, "InternalError")
-    }
+/// Map a `BoxliteError` to its canonical HTTP response. Delegates the
+/// (status, type, code) decision to `BoxliteError::http()` so the mapping
+/// is exhaustive at compile time — adding a new variant becomes a build
+/// error in `errors.rs`, never a silent 500.
+fn error_from_boxlite(err: &boxlite::BoxliteError) -> Response {
+    let (code, etype, ecode) = err.http();
+    let status = StatusCode::from_u16(code)
+        .expect("BoxliteError::http() must return a valid HTTP status code");
+    error_response(status, err.to_string(), etype, ecode)
+}
+
+/// Panic handler for [`CatchPanicLayer`]. Turns a handler panic into a
+/// `500 InternalError internal` response with our wire envelope —
+/// otherwise axum's default returns an empty `500 Internal Server Error`
+/// with no body, breaking the client's `map_http_status` 500-vs-Network
+/// distinction.
+fn handle_panic(err: Box<dyn std::any::Any + Send + 'static>) -> Response {
+    let detail = err
+        .downcast_ref::<&'static str>()
+        .map(|s| s.to_string())
+        .or_else(|| err.downcast_ref::<String>().cloned())
+        .unwrap_or_else(|| "panic in handler".to_string());
+    tracing::error!(panic = %detail, "handler panicked");
+    error_response(
+        StatusCode::INTERNAL_SERVER_ERROR,
+        format!("internal error: {}", detail),
+        "InternalError",
+        "internal",
+    )
 }
 
 /// Pure auth decision (unit-tested). `true` = allow. `expected == None` ⇒
@@ -754,6 +787,7 @@ async fn require_api_key(State(state): State<Arc<AppState>>, req: Request, next:
             StatusCode::UNAUTHORIZED,
             "invalid or missing API key",
             "AuthError",
+            "unauthenticated",
         )
     }
 }
@@ -793,11 +827,9 @@ async fn get_or_fetch_box(state: &AppState, box_id: &str) -> Result<Arc<LiteBox>
             StatusCode::NOT_FOUND,
             format!("box not found: {box_id}"),
             "NotFoundError",
+            "not_found",
         )),
-        Err(e) => {
-            let (status, etype) = classify_boxlite_error(&e);
-            Err(error_response(status, e.to_string(), etype))
-        }
+        Err(e) => Err(error_from_boxlite(&e)),
     }
 }
 
@@ -892,6 +924,23 @@ fn build_router(state: Arc<AppState>) -> Router {
             state.clone(),
             require_api_key,
         ))
+        // Middleware stack (outermost first, applied in reverse):
+        // 1. SetRequestIdLayer — read X-Request-Id from request, or mint
+        //    a UUID. Stored in request extensions for downstream handlers
+        //    and tracing spans.
+        // 2. PropagateRequestIdLayer — copy the request-id onto the
+        //    response headers so clients can correlate to server logs.
+        // 3. CatchPanicLayer — handler panic ⇒ 500 with our envelope.
+        //    Without this, axum returns an empty 500 which the client
+        //    mis-classifies as a proxy/Network error.
+        //
+        // Skipped (intentionally): TimeoutLayer. boxlite handlers have
+        // operation-specific timeouts (signal/kill use 10s, image pulls
+        // can legitimately take minutes). A global request timeout would
+        // break long-running ops.
+        .layer(CatchPanicLayer::custom(handle_panic))
+        .layer(PropagateRequestIdLayer::x_request_id())
+        .layer(SetRequestIdLayer::x_request_id(MakeRequestUuid))
         .with_state(state)
 }
 

--- a/src/cli/src/commands/serve/types.rs
+++ b/src/cli/src/commands/serve/types.rs
@@ -216,12 +216,29 @@ pub(super) struct ErrorBody {
     pub error: ErrorDetail,
 }
 
+/// Wire shape for HTTP error responses.
+///
+/// - `message` — human-readable description with context (for logs and
+///   end-user display).
+/// - `type` — stable PascalCase identifier (K8s `Status.reason` style).
+///   `BoxliteError::http()` is the source of truth in
+///   `boxlite_shared::errors`.
+/// - `code` — stable snake_case machine identifier (Stripe `code` style).
+///   Clients pattern-match on this for typed error handling.
+/// - `request_id` — populated from `X-Request-Id` if propagated by the
+///   middleware; omitted when absent.
+///
+/// The HTTP numeric status lives in the response status line, not in the
+/// body — including it twice (header + body) was the legacy shape and
+/// added no information.
 #[derive(Serialize)]
 pub(super) struct ErrorDetail {
     pub message: String,
     #[serde(rename = "type")]
     pub error_type: String,
-    pub code: u16,
+    pub code: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
 }
 
 // ============================================================================

--- a/src/shared/src/errors.rs
+++ b/src/shared/src/errors.rs
@@ -120,3 +120,273 @@ impl From<tonic::transport::Error> for BoxliteError {
         BoxliteError::RpcTransport(err.to_string())
     }
 }
+
+/// Canonical mapping from a `BoxliteError` variant to its HTTP response
+/// shape: `(status, error_type, code)` where:
+///
+/// - `status` is the HTTP status code as a `u16`. Callers convert to
+///   their concrete `StatusCode` type (axum, reqwest, http) at the
+///   boundary.
+/// - `error_type` is the stable PascalCase identifier matching the
+///   `error.type` field on the wire (K8s `Status.reason` style).
+/// - `code` is the stable snake_case machine identifier matching the
+///   `error.code` field on the wire (Stripe `code` style).
+///
+/// Both `error_type` and `code` are part of the public API contract;
+/// changing them is a breaking change to SDK clients that pattern-match
+/// on them. The single source of truth lives here so adding a
+/// `BoxliteError` variant becomes a compile error elsewhere.
+///
+/// Mapping rationale per row:
+/// - Status semantics follow RFC 9110 (§15.5 — 422 specifically) and
+///   Google's `google.rpc.Code` ↔ HTTP translation, except
+///   `FAILED_PRECONDITION` (Google → 400, boxlite → 409 per
+///   Docker / K8s / Stripe public-API consensus).
+/// - `Image` and `Execution` are 422 because the *shape* of the
+///   request was valid; the semantic content (`alpine:lastest`,
+///   `/nonexistent/binary`) was wrong — RFC 9110 §15.5.21.
+/// - `Network`, `Portal`, `Rpc`, `RpcTransport`, `Engine` are 503
+///   because they signal an internal dep is unavailable, not that the
+///   server itself failed (gRPC `UNAVAILABLE`).
+/// - `Storage`, `Database`, `MetadataError`, `Config`, `Internal` are
+///   500 because they indicate a server-side bug or data-plane
+///   corruption — not a recoverable condition.
+impl BoxliteError {
+    pub fn http(&self) -> (u16, &'static str, &'static str) {
+        match self {
+            BoxliteError::InvalidArgument(_) => (400, "InvalidArgumentError", "invalid_argument"),
+            BoxliteError::Unsupported(_) | BoxliteError::UnsupportedEngine => {
+                (400, "UnsupportedError", "unsupported")
+            }
+            BoxliteError::NotFound(_) => (404, "NotFoundError", "not_found"),
+            BoxliteError::SessionReaped(_) => (410, "SessionReapedError", "session_reaped"),
+            BoxliteError::AlreadyExists(_) => (409, "AlreadyExistsError", "already_exists"),
+            BoxliteError::InvalidState(_) => (409, "InvalidStateError", "invalid_state"),
+            BoxliteError::Stopped(_) => (409, "StoppedError", "stopped"),
+            BoxliteError::Image(_) => (422, "ImageError", "image_pull_failed"),
+            BoxliteError::Execution(_) => (422, "ExecutionError", "execution_failed"),
+            BoxliteError::ResourceExhausted(_) => {
+                (429, "ResourceExhaustedError", "resource_exhausted")
+            }
+            BoxliteError::Network(_) => (503, "NetworkError", "network_unavailable"),
+            BoxliteError::Portal(_) | BoxliteError::Rpc(_) | BoxliteError::RpcTransport(_) => {
+                (503, "UpstreamUnavailableError", "upstream_unavailable")
+            }
+            BoxliteError::Engine(_) => (503, "EngineError", "engine_unavailable"),
+            BoxliteError::Storage(_) => (500, "StorageError", "storage_error"),
+            BoxliteError::Database(_) => (500, "DatabaseError", "database_error"),
+            BoxliteError::MetadataError(_) => (500, "MetadataError", "metadata_error"),
+            BoxliteError::Config(_) => (500, "ConfigError", "config_error"),
+            BoxliteError::Internal(_) => (500, "InternalError", "internal"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Canonical `BoxliteError → (status, error_type, code)` table.
+    ///
+    /// Each row is asserted via [`BoxliteError::http`]. Adding a
+    /// `BoxliteError` variant without extending this table OR the
+    /// `http()` match will produce a compile error in the impl
+    /// (exhaustive match) — the assertion here is the second wall:
+    /// it pins the *exact* status / type / code so a silent re-map
+    /// later (e.g. changing 422 → 400) trips the test.
+    #[test]
+    fn http_mapping_matches_canonical_table() {
+        let cases: &[(BoxliteError, u16, &str, &str)] = &[
+            (
+                BoxliteError::InvalidArgument("cpus must be 1..32".into()),
+                400,
+                "InvalidArgumentError",
+                "invalid_argument",
+            ),
+            (
+                BoxliteError::Unsupported("feature x not built".into()),
+                400,
+                "UnsupportedError",
+                "unsupported",
+            ),
+            (
+                BoxliteError::UnsupportedEngine,
+                400,
+                "UnsupportedError",
+                "unsupported",
+            ),
+            (
+                BoxliteError::NotFound("box abc".into()),
+                404,
+                "NotFoundError",
+                "not_found",
+            ),
+            (
+                BoxliteError::SessionReaped("exec 123".into()),
+                410,
+                "SessionReapedError",
+                "session_reaped",
+            ),
+            (
+                BoxliteError::AlreadyExists("box abc".into()),
+                409,
+                "AlreadyExistsError",
+                "already_exists",
+            ),
+            (
+                BoxliteError::InvalidState("box not running".into()),
+                409,
+                "InvalidStateError",
+                "invalid_state",
+            ),
+            (
+                BoxliteError::Stopped("runtime shut down".into()),
+                409,
+                "StoppedError",
+                "stopped",
+            ),
+            (
+                BoxliteError::Image("manifest unknown for alpine:lastest".into()),
+                422,
+                "ImageError",
+                "image_pull_failed",
+            ),
+            (
+                BoxliteError::Execution("/nonexistent: no such file".into()),
+                422,
+                "ExecutionError",
+                "execution_failed",
+            ),
+            (
+                BoxliteError::ResourceExhausted("disk full".into()),
+                429,
+                "ResourceExhaustedError",
+                "resource_exhausted",
+            ),
+            (
+                BoxliteError::Network("tap setup failed".into()),
+                503,
+                "NetworkError",
+                "network_unavailable",
+            ),
+            (
+                BoxliteError::Portal("portal not ready".into()),
+                503,
+                "UpstreamUnavailableError",
+                "upstream_unavailable",
+            ),
+            (
+                BoxliteError::Rpc("tonic status: …".into()),
+                503,
+                "UpstreamUnavailableError",
+                "upstream_unavailable",
+            ),
+            (
+                BoxliteError::RpcTransport("connection refused".into()),
+                503,
+                "UpstreamUnavailableError",
+                "upstream_unavailable",
+            ),
+            (
+                BoxliteError::Engine("krun init failed".into()),
+                503,
+                "EngineError",
+                "engine_unavailable",
+            ),
+            (
+                BoxliteError::Storage("qcow2 corrupt".into()),
+                500,
+                "StorageError",
+                "storage_error",
+            ),
+            (
+                BoxliteError::Database("sqlite locked".into()),
+                500,
+                "DatabaseError",
+                "database_error",
+            ),
+            (
+                BoxliteError::MetadataError("box.toml parse failed".into()),
+                500,
+                "MetadataError",
+                "metadata_error",
+            ),
+            (
+                BoxliteError::Config("startup misconfig".into()),
+                500,
+                "ConfigError",
+                "config_error",
+            ),
+            (
+                BoxliteError::Internal("unreachable".into()),
+                500,
+                "InternalError",
+                "internal",
+            ),
+        ];
+
+        for (err, want_status, want_type, want_code) in cases {
+            let (status, etype, ecode) = err.http();
+            assert_eq!(
+                (status, etype, ecode),
+                (*want_status, *want_type, *want_code),
+                "variant {:?} mapped incorrectly",
+                err
+            );
+        }
+    }
+
+    /// Spot-check: the snake_code identifier set is unique. Two
+    /// variants sharing a code would break round-tripping on the
+    /// client (which dispatches on `error.code`).
+    #[test]
+    fn http_code_strings_are_unique_per_logical_status() {
+        // Variants that intentionally share a code (multi-variant
+        // rows in the canonical table).
+        let shared_ok: &[&str] = &["unsupported", "upstream_unavailable"];
+
+        let all: Vec<&'static str> = [
+            BoxliteError::InvalidArgument(String::new()),
+            BoxliteError::Unsupported(String::new()),
+            BoxliteError::UnsupportedEngine,
+            BoxliteError::NotFound(String::new()),
+            BoxliteError::SessionReaped(String::new()),
+            BoxliteError::AlreadyExists(String::new()),
+            BoxliteError::InvalidState(String::new()),
+            BoxliteError::Stopped(String::new()),
+            BoxliteError::Image(String::new()),
+            BoxliteError::Execution(String::new()),
+            BoxliteError::ResourceExhausted(String::new()),
+            BoxliteError::Network(String::new()),
+            BoxliteError::Portal(String::new()),
+            BoxliteError::Rpc(String::new()),
+            BoxliteError::RpcTransport(String::new()),
+            BoxliteError::Engine(String::new()),
+            BoxliteError::Storage(String::new()),
+            BoxliteError::Database(String::new()),
+            BoxliteError::MetadataError(String::new()),
+            BoxliteError::Config(String::new()),
+            BoxliteError::Internal(String::new()),
+        ]
+        .iter()
+        .map(|e| e.http().2)
+        .collect();
+
+        // Build a histogram; codes seen >1 time must be in shared_ok.
+        let mut counts: std::collections::HashMap<&'static str, usize> =
+            std::collections::HashMap::new();
+        for c in &all {
+            *counts.entry(c).or_default() += 1;
+        }
+        for (code, n) in counts {
+            if n > 1 {
+                assert!(
+                    shared_ok.contains(&code),
+                    "code {:?} mapped by {} variants but not in shared_ok",
+                    code,
+                    n
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Replaces the substring-match error classifier in `boxlite serve` with a compile-exhaustive `BoxliteError::http() -> (status, type, code_snake)` in `src/shared/src/errors.rs` — single source of truth for the error → HTTP mapping. Old classifier covered 5 of 21 variants; the rest collapsed to 500.
- Wire envelope is now `{error: {message, type, code, request_id}}`; `code` flipped from numeric (duplicate of HTTP status line) to a stable snake_case identifier (Stripe shape). OpenAPI spec updated to match with full enum + `request_id` field.
- Adds `tower-http` middleware stack: `SetRequestIdLayer` + `PropagateRequestIdLayer` (X-Request-Id round-trip, UUIDv4 mint) and `CatchPanicLayer` (handler panics emit the envelope rather than empty 500s).
- Client mapper now dispatches on `error.code` (symmetric inverse). Empty-body 502/503/504 → `BoxliteError::Network` — catches the transparent-proxy regression (Clash returning bare 502 for unreachable destinations) we hit live in this session. Transport failures preserve cause via `Network` with connect/timeout/decode-kind tagging.
- Go SDK gains `ErrResourceExhausted` (20) and `ErrSessionReaped` (21) to mirror the C SDK enum. Python/Node/C audited — none read the wire `code` field directly, so the breaking rename is contained to the Rust client.

In-session bugs fixed:
- `boxlite run alpine:lastest …` (typo) now returns **422 `ImageError image_pull_failed`** instead of 500.
- Proxy-502 against `boxlite serve` is now an actionable `Network` error with hostname + proxy guidance.

Research underpinning the mapping table: RFC 9110 §15.5.21 (422 promoted out of WebDAV), Google `google.rpc.Code` ↔ HTTP canonical translation (except `FAILED_PRECONDITION` — we follow Docker/K8s/Stripe and use 409 for state conflicts). Peer Rust precedent: Meilisearch's `make_error_codes!` DSL, crates.io middleware composition, Materialize 401 redaction discipline.

## Test plan

- [x] `cargo test -p boxlite-shared` — 2 tests pass (canonical mapping table + code-uniqueness invariant)
- [x] `cargo test -p boxlite --features rest -- rest::error rest::types` — 19 tests pass (6 new round-trip mapper tests + 13 existing)
- [x] `cargo test -p boxlite-cli` — 7 tests pass (auth allows + reaper)
- [x] End-to-end live curl against `boxlite serve --port 8101`:
  - 401 → body `{error:{type:"AuthError", code:"unauthenticated"}}` ✓
  - 404 → body `{error:{type:"NotFoundError", code:"not_found"}}` ✓
  - `X-Request-Id: <uuid>` response header round-trip ✓

## Out of scope (deliberate)

- `apps/api` and `apps/runner` error envelopes — they emit a different shape today; verdict was to defer alignment until a concrete consumer needs typed dispatch from those servers. The Rust client's status-only fallback already handles every user-visible case correctly against the legacy shape. No client-side compatibility shim added (see new memory `feedback_no_client_side_legacy_shim.md`).