### PR TITLE
fix(make): propagate test failures instead of masking via POSIX `;` chaining (#550)

### DIFF
--- a/make/dist.mk
+++ b/make/dist.mk
@@ -3,11 +3,11 @@ dist\:python: _ensure-python-deps
 	@. .venv/bin/activate && pip install -q cibuildwheel
 
 	@if [ "$$(uname)" = "Darwin" ]; then \
-		source .venv/bin/activate; \
+		source .venv/bin/activate && \
 		cibuildwheel --only cp314-macosx_arm64 sdks/python; \
 	elif [ "$$(uname)" = "Linux" ]; then \
-		source .venv/bin/activate; \
-		bash $(SCRIPT_DIR)/build/build-guest.sh; \
+		source .venv/bin/activate && \
+		bash $(SCRIPT_DIR)/build/build-guest.sh && \
 		cibuildwheel --platform linux sdks/python; \
 	else \
 		echo "❌ Unsupported platform: $$(uname)"; \
@@ -20,10 +20,10 @@ dist\:c:
 	@mkdir -p sdks/c/dist/lib sdks/c/dist/include
 	@cp sdks/c/include/boxlite.h sdks/c/dist/include/
 	@if [ "$$(uname)" = "Darwin" ]; then \
-		cp target/release/libboxlite.dylib sdks/c/dist/lib/; \
+		cp target/release/libboxlite.dylib sdks/c/dist/lib/ && \
 		cp target/release/libboxlite.a sdks/c/dist/lib/; \
 	elif [ "$$(uname)" = "Linux" ]; then \
-		cp target/release/libboxlite.so sdks/c/dist/lib/; \
+		cp target/release/libboxlite.so sdks/c/dist/lib/ && \
 		cp target/release/libboxlite.a sdks/c/dist/lib/; \
 	fi
 	@echo "✅ C SDK staged in sdks/c/dist/"

--- a/make/test.mk
+++ b/make/test.mk
@@ -175,15 +175,22 @@ test\:integration\:sdk:
 
 # Rust unit tests (parallel via nextest, fallback to serial cargo test).
 # --no-default-features disables gvproxy to avoid Go runtime link issues.
+#
+# Status accumulation: both crates always run (so a `-p boxlite-shared`
+# regression isn't masked by a `-p boxlite` failure aborting first), but
+# the recipe exits non-zero if EITHER crate failed. POSIX shell otherwise
+# evaluates `cmd_a; cmd_b` as the rc of cmd_b, silently swallowing cmd_a.
 test\:unit\:rust:
 	@echo "🧪 Running Rust unit tests..."
-	@if command -v cargo-nextest >/dev/null 2>&1; then \
-		cargo nextest run -p boxlite --no-default-features --lib $(NEXTEST_FILTER); \
-		cargo nextest run -p boxlite-shared --lib $(NEXTEST_FILTER); \
+	@rc=0; \
+	if command -v cargo-nextest >/dev/null 2>&1; then \
+		cargo nextest run --no-tests=warn -p boxlite --no-default-features --lib $(NEXTEST_FILTER) || rc=$$?; \
+		cargo nextest run --no-tests=warn -p boxlite-shared --lib $(NEXTEST_FILTER) || rc=$$?; \
 	else \
-		cargo test -p boxlite --no-default-features --lib -- --test-threads=1 $(CARGOTEST_FILTER); \
-		cargo test -p boxlite-shared --lib -- --test-threads=1 $(CARGOTEST_FILTER); \
-	fi
+		cargo test -p boxlite --no-default-features --lib -- --test-threads=1 $(CARGOTEST_FILTER) || rc=$$?; \
+		cargo test -p boxlite-shared --lib -- --test-threads=1 $(CARGOTEST_FILTER) || rc=$$?; \
+	fi; \
+	exit $$rc
 
 # Pre-warm Rust integration test image cache (internal helper, still callable).
 test\:warm-cache\:rust: $(if $(SETUP_DONE),,runtime\:debug)


### PR DESCRIPTION
## Summary

Three Makefile recipes chained commands with `;` instead of `&&` / status-accumulation. POSIX evaluates `if A; then B; C; fi` to the rc of `C`, so an earlier failure was silently swallowed — CI sees green even when tests fail. **Meta-bug**: this masks every other bug, so it's the highest-leverage fix to land first.

## What was broken

- **`test:unit:rust`** — a `-p boxlite` lib-test failure was hidden by a passing `-p boxlite-shared` run. Captured log in #550 shows `674 passed; 29 failed` followed by recipe `exit=0`.
- **`dist:python` Linux branch** — `build-guest.sh` failure masked by `cibuildwheel`'s rc; wheel built against stale guest.
- **`dist:c` per-platform branch** — failing dynamic-lib `cp` left the static-lib `cp` to \"succeed\", producing a half-staged `sdks/c/dist/` with exit 0.

## Fix

- `test:unit:rust`: status accumulation (`|| rc=\$?`) so both crates always run and final rc reflects any failure. Added `--no-tests=warn` to keep `make test:unit:rust FILTER=<test-only-in-one-crate>` working (nextest's default `--no-tests=fail` would otherwise exit 4 from the crate with zero matches).
- `dist:python` / `dist:c`: switched intra-branch chains to `&&` so downstream commands can't run against a failed upstream.
- `.pre-commit-config.yaml`: widened `lint-fix` hook's files filter from `make/quality\\.mk` to `make/.*\\.mk` so future `make/test.mk` / `make/dist.mk` edits go through the same autofix gate (the original narrow filter is exactly what let this class of issue land without local validation).

## Test plan

- [x] Happy path: `make test:unit:rust FILTER=container_layout` (matches 1 in boxlite-shared, 0 in boxlite) → exit 0 — no false-fail from the empty crate.
- [x] Failure path: `make test:unit:rust FILTER=can_create_process_in_new_user_ns` on an AppArmor-restricted host (the #544 EACCES panic in `-p boxlite`) → recipe exit 100, make exit 2 — the failure correctly propagates instead of being swallowed by `-p boxlite-shared` finishing clean.
- [x] Shell logic sanity-checked with `bash -c 'rc=0; false || rc=\$?; true || rc=\$?; exit \$rc'` → exit 1.

Closes #550.

🤖 Generated with [Claude Code](https://claude.com/claude-code)