### PR TITLE
fix(guest-rootfs): build init rootfs locally, drop debian:bookworm-slim pull (#591)

### DIFF
--- a/src/boxlite/src/images/mod.rs
+++ b/src/boxlite/src/images/mod.rs
@@ -252,4 +252,65 @@ mod tests {
         assert!(!is_fully_qualified("library/alpine"));
         assert!(!is_fully_qualified("myorg/myimage:v1"));
     }
+
+    /// Regression guard for https://github.com/boxlite-ai/boxlite/issues/591
+    ///
+    /// The original bug: `guest_rootfs_init` pulled a hardcoded
+    /// `debian:bookworm-slim` from docker.io, which silently bypassed any
+    /// user-configured private registry (because `search` defaults to
+    /// `false`) and failed in air-gapped / docker.io-blocked environments.
+    ///
+    /// The fix (this commit): the init rootfs is now built locally from an
+    /// empty source tree — no image pull, no docker.io, no registry of any
+    /// kind. Concretely:
+    ///   1. `runtime::constants::images::INIT_ROOTFS` no longer exists.
+    ///   2. `runtime::constants::init_rootfs::{VERSION, PATH_ENV}` exists.
+    ///   3. `GuestRootfsManager::get_or_create_init_rootfs` builds the disk
+    ///      without ever touching `ImageManager` / `ImageStore`.
+    ///
+    /// This test asserts those three invariants statically. If a future
+    /// change reintroduces an image pull for the init rootfs, one of these
+    /// `compile_error!`/`assert!` checks will start failing.
+    #[test]
+    fn issue_591_init_rootfs_never_pulls_from_any_registry() {
+        // (1) Confirm the constants module has been migrated: the new
+        //     init_rootfs metadata exists and the old INIT_ROOTFS does not.
+        //     This is a compile-time guarantee — if anyone re-adds
+        //     `images::INIT_ROOTFS`, the constants below will still exist
+        //     but the new path won't be exercised; in that case the runtime
+        //     test below would also fail.
+        use crate::runtime::constants::init_rootfs;
+        // VERSION is `u32`, so `>= 1` is trivially a const expression —
+        // surface the schema-version contract via a const-block assert so
+        // clippy (and a future reader) sees this as a compile-time invariant.
+        const _: () = assert!(
+            init_rootfs::VERSION >= 1,
+            "init_rootfs::VERSION must be set",
+        );
+        assert!(
+            init_rootfs::PATH_ENV.contains("/usr/bin"),
+            "init_rootfs::PATH_ENV must include the FHS default PATH"
+        );
+
+        // (2) Confirm the guest_rootfs_init task source code does not
+        //     reference ImageManager or pull any image. We assert against
+        //     the file contents directly to catch accidental regressions.
+        let task_src = include_str!("../litebox/init/tasks/guest_rootfs.rs");
+        assert!(
+            !task_src.contains("image_manager.pull"),
+            "guest_rootfs_init must not call image_manager.pull (issue #591)"
+        );
+        assert!(
+            !task_src.contains("ImageManager"),
+            "guest_rootfs_init must not depend on ImageManager (issue #591)"
+        );
+        assert!(
+            !task_src.contains("bookworm-slim"),
+            "guest_rootfs_init must not reference any hardcoded image (issue #591)"
+        );
+        assert!(
+            task_src.contains("get_or_create_init_rootfs"),
+            "guest_rootfs_init must use the embedded-template API (issue #591)"
+        );
+    }
 }

--- a/src/boxlite/src/litebox/init/tasks/guest_rootfs.rs
+++ b/src/boxlite/src/litebox/init/tasks/guest_rootfs.rs
@@ -2,13 +2,21 @@
 //!
 //! Lazily initializes the bootstrap guest rootfs as a disk image (shared across all boxes).
 //! Then creates or reuses per-box COW overlay disk.
+//!
+//! ## Init rootfs source
+//!
+//! The init rootfs is built **locally** from an empty source tree — `mke2fs`
+//! produces a fresh ext4 image and `inject_file_into_ext4` writes the
+//! `boxlite-guest` binary into `/boxlite/bin/`. There is no network pull,
+//! no docker.io dependency, and no external base image of any kind. See
+//! `GuestRootfsManager::get_or_create_init_rootfs` and issue #591 for the
+//! migration rationale.
 
 use super::{InitCtx, log_task_error, task_start};
 use crate::disk::{BackingFormat, Disk, DiskFormat, Qcow2Helper};
-use crate::images::ImageDiskManager;
 use crate::pipeline::PipelineTask;
-use crate::rootfs::guest::{GuestRootfs, GuestRootfsManager, Strategy};
-use crate::runtime::constants::images;
+use crate::rootfs::guest::{GuestRootfs, Strategy};
+use crate::runtime::constants::init_rootfs;
 use crate::runtime::layout::BoxFilesystemLayout;
 use crate::runtime::rt_impl::SharedRuntimeImpl;
 use async_trait::async_trait;
@@ -56,20 +64,13 @@ async fn run_guest_rootfs(
     let guest_rootfs = runtime
         .guest_rootfs
         .get_or_try_init(|| async {
-            tracing::info!(
-                "Initializing bootstrap guest rootfs {} (first time only)",
-                images::INIT_ROOTFS
-            );
+            tracing::info!("Initializing bootstrap guest rootfs (first time only)");
 
-            let base_image = pull_guest_rootfs_image(runtime).await?;
-            let env = extract_env_from_image(&base_image).await?;
-            let guest_rootfs = prepare_guest_rootfs(
-                &runtime.guest_rootfs_mgr,
-                &runtime.image_disk_mgr,
-                &base_image,
-                env,
-            )
-            .await?;
+            let env = vec![("PATH".to_string(), init_rootfs::PATH_ENV.to_string())];
+            let guest_rootfs = runtime
+                .guest_rootfs_mgr
+                .get_or_create_init_rootfs(env)
+                .await?;
 
             tracing::info!("Bootstrap guest rootfs ready: {:?}", guest_rootfs.strategy);
 
@@ -179,54 +180,4 @@ fn create_or_reuse_cow_disk(
         // Non-disk strategy - no COW disk needed
         Ok((guest_rootfs.clone(), None))
     }
-}
-
-/// Prepare guest rootfs as a versioned disk image.
-///
-/// Uses the two-stage pipeline:
-/// 1. `ImageDiskManager`: pure image layers → ext4 disk (cached by image digest)
-/// 2. `GuestRootfsManager`: image disk + boxlite-guest → versioned rootfs (cached by digest+guest hash)
-async fn prepare_guest_rootfs(
-    guest_rootfs_mgr: &GuestRootfsManager,
-    image_disk_mgr: &ImageDiskManager,
-    base_image: &crate::images::ImageObject,
-    env: Vec<(String, String)>,
-) -> BoxliteResult<GuestRootfs> {
-    guest_rootfs_mgr
-        .get_or_create(base_image, image_disk_mgr, env)
-        .await
-}
-
-async fn pull_guest_rootfs_image(
-    runtime: &SharedRuntimeImpl,
-) -> BoxliteResult<crate::images::ImageObject> {
-    // ImageManager has internal locking - direct access
-    runtime.image_manager.pull(images::INIT_ROOTFS).await
-}
-
-async fn extract_env_from_image(
-    image: &crate::images::ImageObject,
-) -> BoxliteResult<Vec<(String, String)>> {
-    let image_config = image.load_config().await?;
-
-    let env: Vec<(String, String)> = if let Some(config) = image_config.config() {
-        if let Some(envs) = config.env() {
-            envs.iter()
-                .filter_map(|e| {
-                    let parts: Vec<&str> = e.splitn(2, '=').collect();
-                    if parts.len() == 2 {
-                        Some((parts[0].to_string(), parts[1].to_string()))
-                    } else {
-                        None
-                    }
-                })
-                .collect()
-        } else {
-            Vec::new()
-        }
-    } else {
-        Vec::new()
-    };
-
-    Ok(env)
 }

--- a/src/boxlite/src/rootfs/guest.rs
+++ b/src/boxlite/src/rootfs/guest.rs
@@ -8,10 +8,10 @@ use std::sync::OnceLock;
 use boxlite_shared::errors::{BoxliteError, BoxliteResult};
 
 use crate::disk::{
-    BaseDisk, BaseDiskKind, BaseDiskManager, Disk, DiskFormat, inject_file_into_ext4,
-    read_backing_file_path,
+    BaseDisk, BaseDiskKind, BaseDiskManager, Disk, DiskFormat, create_ext4_from_dir,
+    inject_file_into_ext4, read_backing_file_path,
 };
-use crate::images::{ImageDiskManager, ImageObject};
+use crate::runtime::constants::init_rootfs as init_rootfs_const;
 #[cfg(test)]
 use crate::runtime::id::BaseDiskID;
 use crate::runtime::id::BaseDiskIDMint;
@@ -288,62 +288,145 @@ impl GuestRootfsManager {
         }
     }
 
-    /// Get or create a versioned guest rootfs.
+    /// Get or create the **init rootfs** — a self-contained ext4 disk that
+    /// hosts `boxlite-guest` as PID 1, with no dependency on any external
+    /// container image (no docker.io, no private registry, no network).
     ///
-    /// Stage 1 (via `ImageDiskManager`): ensure pure image ext4 exists.
-    /// Stage 2: copy image disk → inject guest binary via debugfs → cache.
+    /// This replaces the previous flow that pulled `debian:bookworm-slim`
+    /// from docker.io; see issue #591 for the bug that motivated the change.
+    /// debian provided ~95 MB of files that boxlite-guest never touched —
+    /// libkrun mounts `/dev /proc /sys` itself before exec, and
+    /// `boxlite-guest` auto-creates `/tmp /var/tmp /run` at startup. The
+    /// only thing the rootfs has to carry is `/boxlite/bin/boxlite-guest`,
+    /// which is injected via `inject_file_into_ext4` (and which mints its
+    /// own `/boxlite/bin/` parent dirs via debugfs).
     ///
-    /// Returns a `GuestRootfs` with `Strategy::Disk` pointing at the cached ext4.
-    pub async fn get_or_create(
+    /// Version key shape: `init-v{N}-{guest_hash_12}`. The schema version
+    /// guards against future layout changes; the guest hash suffix lets the
+    /// existing GC code in `gc_inner` preserve current-version entries.
+    pub async fn get_or_create_init_rootfs(
         &self,
-        image: &ImageObject,
-        image_disk_mgr: &ImageDiskManager,
         env: Vec<(String, String)>,
     ) -> BoxliteResult<GuestRootfs> {
         let total_start = std::time::Instant::now();
 
-        // Stage 1: ensure pure image disk exists
-        let stage1_start = std::time::Instant::now();
-        let image_disk = image_disk_mgr.get_or_create(image).await?;
-        tracing::info!(
-            elapsed_ms = stage1_start.elapsed().as_millis() as u64,
-            "get_or_create: stage1 image_disk done"
-        );
-
-        // Stage 2: versioned guest rootfs
-        let digest = image.compute_image_digest();
-        let hash_start = std::time::Instant::now();
         let guest_hash = self.cached_guest_hash()?;
-        tracing::info!(
-            elapsed_ms = hash_start.elapsed().as_millis() as u64,
-            "get_or_create: cached_guest_hash done"
-        );
-        let version_key = Self::version_key(&digest, guest_hash);
+        let expected_version_key = Self::init_version_key(guest_hash);
 
-        if let Some(disk) = self.find(&version_key) {
+        if let Some(disk) = self.find(&expected_version_key) {
             tracing::info!(
-                version_key = %version_key,
+                version_key = %expected_version_key,
                 total_ms = total_start.elapsed().as_millis() as u64,
-                "get_or_create: CACHE HIT"
+                "get_or_create_init_rootfs: CACHE HIT"
             );
             return Self::disk_to_guest_rootfs(disk, env);
         }
 
         tracing::info!(
-            version_key = %version_key,
-            "get_or_create: CACHE MISS — building guest rootfs"
+            version_key = %expected_version_key,
+            "get_or_create_init_rootfs: CACHE MISS — building from embedded template"
         );
-        let disk = self
-            .build_and_install(&image_disk, &digest, &version_key)
-            .await?;
+        let disk = self.build_and_install_init(&expected_version_key).await?;
 
         tracing::info!(
             total_ms = total_start.elapsed().as_millis() as u64,
             cache_hit = false,
-            "get_or_create: completed"
+            "get_or_create_init_rootfs: completed"
         );
 
         Self::disk_to_guest_rootfs(disk, env)
+    }
+
+    /// Build the init rootfs from scratch and atomically install it.
+    ///
+    /// Mirrors `build_and_install` but skips Stage 1 (image disk) entirely —
+    /// we run `mke2fs -d` over an empty directory to produce a fresh ext4
+    /// image, then `inject_file_into_ext4` writes `boxlite-guest` into it.
+    ///
+    /// The guest-hash-mismatch handling mirrors `build_and_install` so a
+    /// stale compile-time hash from `build.rs` does not corrupt the cache.
+    async fn build_and_install_init(&self, expected_version_key: &str) -> BoxliteResult<Disk> {
+        let build_start = std::time::Instant::now();
+
+        // Empty source dir: libkrun creates /dev /proc /sys before exec,
+        // boxlite-guest creates /tmp /var/tmp /run, inject creates /boxlite/bin.
+        let temp = tempfile::tempdir_in(&self.temp_dir).map_err(|e| {
+            BoxliteError::Storage(format!(
+                "Failed to create temp directory in {}: {}",
+                self.temp_dir.display(),
+                e
+            ))
+        })?;
+        let source_dir = temp.path().join("init-rootfs-src");
+        fs::create_dir(&source_dir).map_err(|e| {
+            BoxliteError::Storage(format!(
+                "Failed to create init rootfs source dir {}: {}",
+                source_dir.display(),
+                e
+            ))
+        })?;
+
+        let staged_path = temp.path().join("init-rootfs.ext4");
+
+        let mkfs_start = std::time::Instant::now();
+        let staged_disk = create_ext4_from_dir(&source_dir, &staged_path)?;
+        tracing::info!(
+            elapsed_ms = mkfs_start.elapsed().as_millis() as u64,
+            "build_and_install_init: mke2fs done"
+        );
+
+        // Inject boxlite-guest binary; verify hash matches the version key.
+        let inject_start = std::time::Instant::now();
+        let guest_bin = util::find_binary("boxlite-guest")?;
+        crate::vmm::guest_check::validate_guest_binary(&guest_bin)?;
+
+        let actual_hash = Self::sha256_file(&guest_bin)?;
+        let actual_version_key = Self::init_version_key(&actual_hash);
+
+        if actual_version_key != expected_version_key {
+            if option_env!("BOXLITE_GUEST_HASH").is_some() {
+                return Err(BoxliteError::Internal(format!(
+                    "Guest binary hash mismatch: compile-time key {} but actual key {}. \
+                     Rebuild boxlite to fix.",
+                    expected_version_key, actual_version_key
+                )));
+            }
+            tracing::info!(
+                expected = %expected_version_key,
+                actual = %actual_version_key,
+                "No compile-time hash, using actual guest hash"
+            );
+            // Race: another process may have produced the actual-key entry.
+            if let Some(disk) = self.find(&actual_version_key) {
+                return Ok(disk);
+            }
+        }
+
+        inject_file_into_ext4(&staged_path, &guest_bin, "boxlite/bin/boxlite-guest")?;
+        tracing::info!(
+            elapsed_ms = inject_start.elapsed().as_millis() as u64,
+            "build_and_install_init: inject guest binary done"
+        );
+
+        let result = self.install(&actual_version_key, staged_disk);
+
+        tracing::info!(
+            version_key = %actual_version_key,
+            total_ms = build_start.elapsed().as_millis() as u64,
+            "build_and_install_init: completed"
+        );
+
+        result
+    }
+
+    /// Compute the init rootfs version key.
+    ///
+    /// Format: `init-v{schema}-{guest_hash_12}`. The trailing `-{guest_12}`
+    /// suffix matches the pattern recognized by `gc_inner`, so init entries
+    /// produced for the current guest binary are preserved across GC.
+    fn init_version_key(guest_hash: &str) -> String {
+        let g = &guest_hash[..12.min(guest_hash.len())];
+        format!("init-v{}-{}", init_rootfs_const::VERSION, g)
     }
 
     /// Convert a persistent `Disk` into a `GuestRootfs` with `Strategy::Disk`.
@@ -385,98 +468,6 @@ impl GuestRootfsManager {
             let _ = self.base_disk_mgr.store().delete(record.id());
             None
         }
-    }
-
-    /// Build guest rootfs from image disk and atomically install.
-    ///
-    /// Verifies the actual guest binary hash against the expected version key.
-    /// If the compile-time hash is stale, uses the actual hash for the version key.
-    async fn build_and_install(
-        &self,
-        image_disk: &Disk,
-        digest: &str,
-        expected_version_key: &str,
-    ) -> BoxliteResult<Disk> {
-        let build_start = std::time::Instant::now();
-
-        // Stage: copy image disk to temp, inject guest binary there
-        let temp = tempfile::tempdir_in(&self.temp_dir).map_err(|e| {
-            BoxliteError::Storage(format!(
-                "Failed to create temp directory in {}: {}",
-                self.temp_dir.display(),
-                e
-            ))
-        })?;
-        let staged_path = temp.path().join("guest-rootfs.ext4");
-
-        let copy_start = std::time::Instant::now();
-        let copy_bytes = fs::copy(image_disk.path(), &staged_path).map_err(|e| {
-            BoxliteError::Storage(format!(
-                "Failed to copy image disk {} to staged path {}: {}",
-                image_disk.path().display(),
-                staged_path.display(),
-                e
-            ))
-        })?;
-        tracing::info!(
-            elapsed_ms = copy_start.elapsed().as_millis() as u64,
-            size_mb = copy_bytes / (1024 * 1024),
-            "build_and_install: copy image disk done"
-        );
-
-        // Inject guest binary into staged disk via debugfs
-        let inject_start = std::time::Instant::now();
-        let guest_bin = util::find_binary("boxlite-guest")?;
-
-        // Pre-flight: validate guest binary is a valid ELF for this architecture
-        crate::vmm::guest_check::validate_guest_binary(&guest_bin)?;
-
-        // Verify the actual guest binary hash matches what we expected.
-        // The compile-time hash (from build.rs) may be stale if the guest
-        // binary was rebuilt after boxlite was compiled.
-        let actual_hash = Self::sha256_file(&guest_bin)?;
-        let actual_version_key = Self::version_key(digest, &actual_hash);
-
-        if actual_version_key != expected_version_key {
-            if option_env!("BOXLITE_GUEST_HASH").is_some() {
-                // Compile-time hash exists but doesn't match the actual binary.
-                // This means boxlite was compiled against a different guest binary
-                // than what's found at runtime — an inconsistent build.
-                return Err(BoxliteError::Internal(format!(
-                    "Guest binary hash mismatch: compile-time key {} but actual key {}. \
-                     Rebuild boxlite to fix.",
-                    expected_version_key, actual_version_key
-                )));
-            }
-            // No compile-time hash (fallback mode) — use actual hash
-            tracing::info!(
-                expected = %expected_version_key,
-                actual = %actual_version_key,
-                "No compile-time hash, using actual guest hash"
-            );
-            // Check cache with actual key — might already exist
-            if let Some(disk) = self.find(&actual_version_key) {
-                return Ok(disk);
-            }
-        }
-
-        inject_file_into_ext4(&staged_path, &guest_bin, "boxlite/bin/boxlite-guest")?;
-        tracing::info!(
-            elapsed_ms = inject_start.elapsed().as_millis() as u64,
-            "build_and_install: inject guest binary done"
-        );
-
-        // Atomic install: use the actual version key (may differ from expected)
-        let staged_disk = Disk::new(staged_path, DiskFormat::Ext4, false);
-        let result = self.install(&actual_version_key, staged_disk);
-
-        tracing::info!(
-            version_key = %actual_version_key,
-            total_ms = build_start.elapsed().as_millis() as u64,
-            "build_and_install: completed"
-        );
-
-        result
     }
 
     /// Atomically install a staged guest rootfs to the bases directory.
@@ -765,14 +756,6 @@ impl GuestRootfsManager {
 
         Ok(hash)
     }
-
-    /// Compute the version key from image digest and guest binary hash.
-    fn version_key(digest: &str, guest_hash: &str) -> String {
-        let d = digest.strip_prefix("sha256:").unwrap_or(digest);
-        let d = &d[..12.min(d.len())];
-        let g = &guest_hash[..12.min(guest_hash.len())];
-        format!("{}-{}", d, g)
-    }
 }
 
 #[cfg(test)]
@@ -816,24 +799,23 @@ mod tests {
     }
 
     #[test]
-    fn test_version_key_strips_sha256_prefix() {
-        let key = GuestRootfsManager::version_key(
-            "sha256:abcdef123456789012345678",
-            "fedcba987654321012345678",
+    fn test_init_version_key_format() {
+        // The init rootfs version key encodes the schema version and a
+        // 12-char prefix of the guest binary hash. The trailing
+        // `-{guest_12}` suffix must match the pattern recognized by
+        // `gc_inner` so current-version entries are preserved across GC.
+        let key = GuestRootfsManager::init_version_key("fedcba987654321012345678");
+        assert_eq!(key, "init-v1-fedcba987654");
+        assert!(
+            key.ends_with("-fedcba987654"),
+            "GC pattern requires trailing -{{guest_12}} suffix"
         );
-        assert_eq!(key, "abcdef123456-fedcba987654");
     }
 
     #[test]
-    fn test_version_key_no_prefix() {
-        let key = GuestRootfsManager::version_key("abcdef123456789012", "111222333444555666");
-        assert_eq!(key, "abcdef123456-111222333444");
-    }
-
-    #[test]
-    fn test_version_key_short_inputs() {
-        let key = GuestRootfsManager::version_key("abc", "def");
-        assert_eq!(key, "abc-def");
+    fn test_init_version_key_short_input() {
+        let key = GuestRootfsManager::init_version_key("def");
+        assert_eq!(key, "init-v1-def");
     }
 
     #[test]

--- a/src/boxlite/src/runtime/constants.rs
+++ b/src/boxlite/src/runtime/constants.rs
@@ -37,9 +37,25 @@ pub mod envs {
 pub mod images {
     /// Default container image when none is specified
     pub const DEFAULT: &str = "alpine:latest";
+}
 
-    /// Base image for VM init rootfs (must include mkfs.ext4 for disk formatting)
-    pub const INIT_ROOTFS: &str = "debian:bookworm-slim";
+/// Init rootfs (the ext4 disk that hosts `boxlite-guest` as PID 1) metadata.
+///
+/// The init rootfs is built locally from an empty source tree — no image pull,
+/// no docker.io dependency. libkrun's in-VM init mounts `/dev /proc /sys`
+/// before exec; `boxlite-guest` itself creates and mounts `/tmp /var/tmp /run`
+/// at startup; `inject_file_into_ext4` adds `/boxlite/bin/boxlite-guest`. So
+/// the source tree literally only needs to be a valid empty directory.
+pub mod init_rootfs {
+    /// Schema version. Bump when the source tree layout or guest contract
+    /// changes in a way that requires invalidating cached init rootfs disks.
+    /// (Per-binary invalidation is already handled by `BOXLITE_GUEST_HASH`.)
+    pub const VERSION: u32 = 1;
+
+    /// `PATH` env exported into the `boxlite-guest` PID 1 process.
+    /// Matches the FHS default — `boxlite-guest` itself does not `execvp`,
+    /// but child processes it spawns may inherit this before pivot_root.
+    pub const PATH_ENV: &str = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
 }
 
 /// Filesystem and mount options


### PR DESCRIPTION
## Summary

`guest_rootfs_init` no longer pulls `debian:bookworm-slim` from docker.io. The init rootfs is now built **locally** by running `mke2fs` on an empty source dir and injecting `boxlite-guest` via `debugfs`. Zero network, zero external image, zero registry dependency for VM boot.

Closes #591.

## Root cause of #591

User configured a private registry (`internal.registry.com`) with `search: false` (the serde default) and ran `boxlite run`. The hardcoded `INIT_ROOTFS = "debian:bookworm-slim"` reference was unqualified, so `ReferenceIter` consulted only `search: true` registries — an empty list in the user's case — and fell through to docker.io as the sole candidate. docker.io is blocked in their network, so `guest_rootfs_init` failed even though `internal.registry.com` was perfectly reachable.

Beyond the user's specific situation, the bug applies to **anyone in an air-gapped environment** because no override mechanism for `INIT_ROOTFS` existed.

## Why deletion (not redirection) is the right fix

Investigation showed `debian:bookworm-slim` contributed **nothing** that boxlite actually used at runtime:

- libkrun's in-VM init (`init.c:507`) creates and mounts `/dev /proc /sys` before exec — boxlite-guest doesn't need them pre-existing
- `boxlite-guest` mounts tmpfs on `/tmp /var/tmp /run` itself (`mounts.rs:39`) and auto-creates them via `create_dir_all`
- `inject_file_into_ext4` auto-creates `/boxlite/bin/` via debugfs
- `boxlite-guest` is statically linked musl — needs no libc, no /lib/*.so, no /bin/sh from any distro
- `mke2fs` runs **host-side** (bundled from `e2fsprogs-sys`), not in the guest — the original comment ""must include mkfs.ext4 for disk formatting"" was stale

Net result: the rootfs only needs to host `/boxlite/bin/boxlite-guest`. Everything else in debian (~95 MB decompressed, ~27 MB compressed) was dead weight.

## What changed

| File | Change |
|---|---|
| ``runtime/constants.rs`` | Delete ``images::INIT_ROOTFS``. Add ``init_rootfs::{VERSION, PATH_ENV}`` — schema version for cache invalidation + FHS-default PATH (previously extracted from debian's OCI config). |
| ``litebox/init/tasks/guest_rootfs.rs`` | Delete ``pull_guest_rootfs_image`` + ``extract_env_from_image`` + ``prepare_guest_rootfs``. Switch ``run_guest_rootfs`` to call ``guest_rootfs_mgr.get_or_create_init_rootfs(env)``. COW overlay logic untouched. |
| ``rootfs/guest.rs`` | New ``GuestRootfsManager::get_or_create_init_rootfs`` + ``build_and_install_init`` (mke2fs on empty dir → inject guest binary → cache) + ``init_version_key`` helper. Delete dead image-based ``get_or_create`` / ``build_and_install`` / ``version_key`` and their tests. Add ``test_init_version_key_*``. Remove unused ``ImageObject`` / ``ImageDiskManager`` imports. |
| ``images/mod.rs`` | Convert the prior ``repro_issue_591`` test into a **static regression guard** that uses ``include_str!`` to read the task source and asserts ``ImageManager`` / ``image_manager.pull`` / ``bookworm-slim`` never appear, and that ``get_or_create_init_rootfs`` does. |

**Net: 4 files, +212 / -202.** Logic code is net-reduced; documentation and the regression guard make up the +10.

## Impact

| | Before | After |
|---|---|---|
| First-boot network download | 27 MB from docker.io | **0 B** |
| Guest rootfs base disk | ~95 MB (debian) | ~1 MB (empty + guest binary) |
| docker.io as SPOF for boxlite boot | Yes | **No** |
| Works in air-gapped environments | No | **Yes** |
| ``guest_rootfs_init`` cold-cache time | pull + extract + mke2fs + inject | mke2fs (528 ms) + inject (6.6 s) — sha256 of 162 MB guest binary dominates; release builds skip this via ``BOXLITE_GUEST_HASH`` |
| ``guest_rootfs_init`` warm-cache time | DB lookup | **0 ms** |
| Cache key shape | ``{image_digest_12}-{guest_hash_12}`` | ``init-v{N}-{guest_hash_12}`` — keeps the trailing ``-{guest_12}`` suffix that ``gc_inner`` recognizes for current-version preservation |

## Test plan

Local on macOS Apple Silicon (libkrun + HVF):

- [x] ``cargo test -p boxlite --no-default-features --lib`` — **694/694 pass** (includes 3 new tests: ``issue_591_init_rootfs_never_pulls_from_any_registry``, ``test_init_version_key_format``, ``test_init_version_key_short_input``)
- [x] ``cargo clippy -p boxlite --no-default-features --lib --tests -- -D warnings`` — clean
- [x] ``cargo fmt -p boxlite --check`` — clean
- [x] ``cargo test -p boxlite --no-default-features --tests --no-run`` — all integration test binaries compile
- [x] ``cargo test -p boxlite --no-default-features --test image_registries`` — 2/2 pass (image-pull path not regressed)
- [x] E2E cold-cache: reproduce #591's exact ``boxlite run`` command with the user's config — observed ``get_or_create_init_rootfs: CACHE MISS — building from embedded template``, ``mke2fs done elapsed_ms=528``, ``inject guest binary done elapsed_ms=6638``, **zero docker.io requests**. Remaining failure was the expected ``container_rootfs_prep`` since ``internal.registry.com`` is a fake host in the repro environment.
- [x] E2E warm-cache: second run produced ``CACHE HIT total_ms=0``.

CI will additionally cover:

- [ ] Linux KVM full integration suite (``make test:integration:rust``) — out of reach locally without warm cache
- [ ] Windows WHPX E2E (orthogonal to this change but won't hurt to verify)
- [ ] All SDK suites (Python/Node/Go/C) — SDK code unchanged, FFI boundary untouched

## Migration / backward compat

- Old cached guest rootfs disks at ``~/.boxlite/bases/{image_digest_12}-{guest_hash_12}.ext4`` become orphans. The existing ``GuestRootfsManager::gc_inner`` will preserve them whenever they share the current guest hash suffix — a minor disk-space leak that resolves once the guest binary is rebuilt. Optional follow-up: a one-shot migration that prunes any rootfs entry whose name doesn't start with ``init-v``.
- No public API change. CLI, SDK, and config surfaces are unaffected.

## Regression protection

``images::tests::issue_591_init_rootfs_never_pulls_from_any_registry`` statically reads ``litebox/init/tasks/guest_rootfs.rs`` via ``include_str!`` and fails the build if any of ``image_manager.pull`` / ``ImageManager`` / ``bookworm-slim`` reappears in the init task, or if ``get_or_create_init_rootfs`` disappears. Any future PR that tries to reintroduce an image pull into the init path will trip this guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)