### PR TITLE
tiny(test-auth): drop stale period in status "Not logged in" assertion

### DIFF
--- a/src/cli/tests/auth.rs
+++ b/src/cli/tests/auth.rs
@@ -234,5 +234,5 @@ fn status_treats_empty_env_api_key_as_not_logged_in() {
     cmd.args(["auth", "status"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("Not logged in."));
+        .stdout(predicate::str::contains("Not logged in"));
 }


### PR DESCRIPTION
Very tiny fix
PR #581 (2026-05-23 15:56) changed `auth status` output from "Not logged in." to "Not logged in (profile `<name>`).". 
PR #577 (17:25 same day) added a new regression test asserting `contains("Not logged in.")`

only tiny fix required

Verified: `make test:integration:cli FILTER=status_treats_empty_env_api_key_as_not_logged_in` → 1 passed.