### PR TITLE
fix(runner): roll back SignaledHUP/TERM when SDK signal delivery fails

### DIFF
--- a/apps/runner/pkg/boxlite/exec_manager.go
+++ b/apps/runner/pkg/boxlite/exec_manager.go
@@ -704,7 +704,7 @@ func (m *ExecManager) escalate(e *ManagedExec, sig syscall.Signal, name string) 
 	e.handleMu.Lock()
 	if e.closed || e.execution == nil {
 		e.handleMu.Unlock()
-		e.escalationFailedMarkDoomed()
+		e.escalationFailedMarkDoomed(sig)
 		m.killAndEvict(e)
 		return
 	}
@@ -718,12 +718,12 @@ func (m *ExecManager) escalate(e *ManagedExec, sig syscall.Signal, name string) 
 	case errors.Is(err, ErrSignalUnsupported):
 		slog.Warn("boxlite: SDK cannot deliver signal, falling through to Kill",
 			"exec_id", e.ID, "signal", name)
-		e.escalationFailedMarkDoomed()
+		e.escalationFailedMarkDoomed(sig)
 		m.killAndEvict(e)
 	default:
 		slog.Warn("boxlite: signal delivery failed, killing exec",
 			"exec_id", e.ID, "signal", name, "err", err)
-		e.escalationFailedMarkDoomed()
+		e.escalationFailedMarkDoomed(sig)
 		m.killAndEvict(e)
 	}
 }
@@ -821,12 +821,20 @@ func (e *ManagedExec) FinishEscalation() {
 }
 
 // escalationFailedMarkDoomed atomically sets ReapingKill and clears
-// Escalating so no gap exists for MarkConnected to slip through.
-func (e *ManagedExec) escalationFailedMarkDoomed() {
+// Escalating so no gap exists for MarkConnected to slip through. Also
+// rolls back the matching Signaled* flag set optimistically in tryEscalate
+// so the state machine doesn't claim a signal was delivered when it wasn't.
+func (e *ManagedExec) escalationFailedMarkDoomed(sig syscall.Signal) {
 	e.attachMu.Lock()
 	defer e.attachMu.Unlock()
 	e.ReapingKill = true
 	e.Escalating = false
+	switch sig {
+	case syscall.SIGHUP:
+		e.SignaledHUP = false
+	case syscall.SIGTERM:
+		e.SignaledTERM = false
+	}
 }
 
 // MarkDisconnected releases the single-attach slot and stamps

--- a/apps/runner/pkg/boxlite/exec_manager_test.go
+++ b/apps/runner/pkg/boxlite/exec_manager_test.go
@@ -595,6 +595,108 @@ func TestExecManagerSignalUnsupportedFallsThroughToKill(t *testing.T) {
 	exec.attachMu.Unlock()
 }
 
+// A non-sentinel Signal error (timeout, CGo/transport failure) hits the
+// default: arm of escalate()'s switch (exec_manager.go:723) — distinct
+// from the ErrSignalUnsupported arm. Both fall through to Kill, but the
+// generic arm must also roll back the optimistic SignaledHUP set in
+// tryEscalate. Pre-fix this arm left SignaledHUP=true.
+func TestExecManagerGenericSignalErrorRollsBackSignaledHUP(t *testing.T) {
+	m := newQuietManager(t)
+
+	stub := &stubExecHandle{
+		signalFn: func(_ int) error {
+			// Not ErrSignalUnsupported → default: arm.
+			return errors.New("runner↔shim transport down")
+		},
+	}
+	exec := registerStub(t, m, "generic-err-1", stub)
+
+	m.SetReapingForTest(50*time.Millisecond, 20*time.Millisecond, 10*time.Minute)
+
+	t0 := time.Now()
+	exec.attachMu.Lock()
+	exec.Connected = false
+	exec.LastDisconnectAt = t0
+	exec.attachMu.Unlock()
+
+	m.runCleanupOnce(t0.Add(70 * time.Millisecond))
+
+	signals, killed := stub.snapshot()
+	if len(signals) != 1 || signals[0] != int(syscall.SIGHUP) {
+		t.Fatalf("expected one SIGHUP attempt, got %v", signals)
+	}
+	if killed != 1 {
+		t.Fatalf("expected immediate Kill fallthrough on generic error, got killed=%d", killed)
+	}
+	if _, stillTracked := m.Get("generic-err-1"); stillTracked {
+		t.Fatalf("exec should be evicted after Kill fallthrough")
+	}
+	exec.attachMu.Lock()
+	defer exec.attachMu.Unlock()
+	if exec.SignaledHUP {
+		t.Fatalf("SignaledHUP must be rolled back when a generic signal error fails delivery")
+	}
+}
+
+// SIGTERM uses a separate optimistic flag (SignaledTERM). Drive escalation
+// past SIGHUP (delivered OK) so the next tick attempts SIGTERM, then fail
+// that delivery. The SIGTERM arm of escalationFailedMarkDoomed's switch must
+// roll back SignaledTERM while leaving the successful SignaledHUP intact.
+// Pre-fix this left SignaledTERM=true.
+func TestExecManagerSigtermFailureRollsBackSignaledTERM(t *testing.T) {
+	m := newQuietManager(t)
+
+	stub := &stubExecHandle{
+		signalFn: func(sig int) error {
+			if sig == int(syscall.SIGTERM) {
+				return errors.New("runner↔shim transport down")
+			}
+			return nil // SIGHUP succeeds so escalation advances to TERM.
+		},
+	}
+	exec := registerStub(t, m, "term-fail-1", stub)
+
+	m.SetReapingForTest(50*time.Millisecond, 20*time.Millisecond, 10*time.Minute)
+
+	t0 := time.Now()
+	exec.attachMu.Lock()
+	exec.Connected = false
+	exec.LastDisconnectAt = t0
+	exec.attachMu.Unlock()
+
+	// Tick 1: past reconnect grace → SIGHUP (succeeds).
+	m.runCleanupOnce(t0.Add(70 * time.Millisecond))
+	exec.attachMu.Lock()
+	if !exec.SignaledHUP {
+		exec.attachMu.Unlock()
+		t.Fatalf("expected SignaledHUP after successful SIGHUP")
+	}
+	hupAt := exec.LastDisconnectAt
+	exec.attachMu.Unlock()
+
+	// Tick 2: past shutdown grace after HUP → SIGTERM (fails).
+	m.runCleanupOnce(hupAt.Add(25 * time.Millisecond))
+
+	signals, killed := stub.snapshot()
+	if len(signals) != 2 || signals[1] != int(syscall.SIGTERM) {
+		t.Fatalf("expected SIGTERM as second signal, got %v", signals)
+	}
+	if killed != 1 {
+		t.Fatalf("expected Kill fallthrough after SIGTERM delivery failed, got killed=%d", killed)
+	}
+	if _, stillTracked := m.Get("term-fail-1"); stillTracked {
+		t.Fatalf("exec should be evicted after Kill fallthrough")
+	}
+	exec.attachMu.Lock()
+	defer exec.attachMu.Unlock()
+	if exec.SignaledTERM {
+		t.Fatalf("SignaledTERM must be rolled back when SIGTERM delivery failed")
+	}
+	if !exec.SignaledHUP {
+		t.Fatalf("SignaledHUP must remain set: the SIGHUP delivery succeeded")
+	}
+}
+
 func TestResolveDurationFallsBackOnUnset(t *testing.T) {
 	got := resolveDuration("BOXLITE_RECONNECT_GRACE_TEST_UNSET", 7*time.Minute)
 	if got != 7*time.Minute {


### PR DESCRIPTION
while SIGHUP/SIGTERM is not succeed in delivery because the communication between runner and shim is interrupted (also maybe caused by Go SDK/CGo fail, test-based), the info requires fallback