### PR TITLE
docs: correct BoxOptions::detach contract + restore two-side test rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,8 +78,11 @@ Every change goes: understand → research → design → implement → test →
 
 **Test**
 
+- Two-side verification for reproducer tests. When you add a test alongside a fix, demonstrate it in this order, both manually run:
+    1. You must revert **every** production change — every non-test file back to its pre-fix state, only the test remains. Run the test. It must fail, with the failure pointing at the bug — log the observed failure signal (assertion text, hang, panic). **Partial reverts, mental simulation, or "it would obviously fail without the fix" are treated as cheating.** If a full revert is genuinely impractical, stop and surface that — do not paper over it.
+    2. Restore the production change in full. Run the test. It must pass.
+       Without a complete step 1 you've only proved your code works, not that the fix was necessary or that this test would have caught the bug. Don't accept "it passes now" as evidence the test guards the right thing.
 - A test is only meaningful when there's something that could go wrong between the data being produced and the assertion being made. If the test builds the value it then asserts on (e.g., `format!`-ing a string and then asserting that the same string contains a substring it just put in), the assertion is tautological — nothing crossed a boundary, so nothing is being tested. The data must come from production code under test, not from the test body itself.
-- Every test must reference a project symbol — no framework- or standard-library-only filler. Self-check: "name the project symbol this test calls." Filler tests would stay green if the production fix were ripped out.
 - Add or update tests when behavior changes around branching, parsing, retries, security checks, or boundaries.
 - Prefer focused tests that prove the *right* reason for the change.
 - Do not create tests that don't actually test project code. A test that only exercises stdlib or framework code is not a real test.

--- a/src/boxlite/src/runtime/options.rs
+++ b/src/boxlite/src/runtime/options.rs
@@ -339,15 +339,16 @@ pub struct BoxOptions {
     #[serde(default = "default_auto_remove")]
     pub auto_remove: bool,
 
-    /// Whether the box should continue running when the parent process exits.
+    /// Whether the box should outlive the process that created it.
     ///
-    /// When false (default), the box will automatically stop when the process
-    /// that created it exits. This ensures orphan boxes don't accumulate.
-    /// Similar to running a process in the foreground.
+    /// When false (default), the box stops when the runtime that created
+    /// it is dropped. Similar to running a process in the foreground.
     ///
-    /// When true, the box runs independently and survives parent process exit.
-    /// The box can be reattached using `runtime.get(box_id)`. Similar to
-    /// Docker's `-d` (detach) flag.
+    /// When true, the box runs independently and survives the host
+    /// process exiting — clean exit, panic, or SIGKILL. A new runtime in
+    /// any process can reattach via `runtime.get(box_id)`. The only ways
+    /// to stop a detached box are `runtime.get(box_id).stop()` and
+    /// `boxlite stop <id>`. Similar to Docker's `-d` (detach) flag.
     #[serde(default = "default_detach")]
     pub detach: bool,
 


### PR DESCRIPTION
## Summary
- Rewrite `BoxOptions::detach` docstring to describe the actual contract: a detached box outlives the host process (clean exit, panic, SIGKILL), is reattachable via `runtime.get(box_id)`, and is stopped only by `runtime.get(box_id).stop()` or `boxlite stop <id>`. Drops the implementation specifics (setsid, recovery pipeline, PID 1) from public docs.
- Restore CLAUDE.md's two-side verification protocol for reproducer tests. Reverts the test-section swap in #599: the "every test must reference a project symbol" rule captured the same intent but lost the explicit revert/restore loop that catches green-on-broken tests.

## Test plan
- [ ] `cargo doc -p boxlite --no-deps` renders the new `BoxOptions::detach` docstring without warnings.
- [ ] Visual check: no `setsid` / `pre_exec` / `PID 1` / "recovery pipeline" / "control socket" in the rendered doc.