### PR TITLE
fix(spawn): set session leader for detached, own pgroup for non-detached

### DIFF
--- a/src/boxlite/src/jailer/builder.rs
+++ b/src/boxlite/src/jailer/builder.rs
@@ -28,6 +28,7 @@ pub struct JailerBuilder {
     box_id: Option<String>,
     layout: Option<BoxFilesystemLayout>,
     preserved_fds: Vec<(RawFd, i32)>,
+    detach: bool,
 }
 
 impl Default for JailerBuilder {
@@ -45,6 +46,7 @@ impl JailerBuilder {
             box_id: None,
             layout: None,
             preserved_fds: Vec::new(),
+            detach: false,
         }
     }
 
@@ -103,6 +105,15 @@ impl JailerBuilder {
         self
     }
 
+    /// Configure detach-mode process isolation applied to the spawned
+    /// child: `detach=true` → `setsid()` in `pre_exec` (daemon, own
+    /// session); `detach=false` → `cmd.process_group(0)` (own pgroup
+    /// for atomic `killpg` cleanup).
+    pub fn with_detach(mut self, detach: bool) -> Self {
+        self.detach = detach;
+        self
+    }
+
     /// Build with the platform-default sandbox.
     ///
     /// On Linux: [`BwrapSandbox`](super::sandbox::BwrapSandbox)
@@ -144,6 +155,7 @@ impl JailerBuilder {
             box_id,
             layout,
             preserved_fds: self.preserved_fds,
+            detach: self.detach,
         })
     }
 }

--- a/src/boxlite/src/jailer/mod.rs
+++ b/src/boxlite/src/jailer/mod.rs
@@ -325,6 +325,10 @@ pub struct Jailer<S: Sandbox> {
     /// FDs to preserve through pre_exec: each (source_fd, target_fd) is dup2'd
     /// before FD cleanup. Used for watchdog pipe inheritance across fork.
     pub(crate) preserved_fds: Vec<(std::os::fd::RawFd, i32)>,
+    /// Detach-mode process isolation: see [`pre_exec::add_pre_exec_hook`]
+    /// — `true` adds `setsid()` to the pre_exec chain, `false` sets the
+    /// child's process group to itself at `Command` build time.
+    pub(crate) detach: bool,
 }
 
 impl<S: Sandbox> Jail for Jailer<S> {
@@ -406,6 +410,7 @@ impl<S: Sandbox> Jail for Jailer<S> {
             resource_limits,
             pid_writer,
             self.preserved_fds.clone(),
+            self.detach,
         );
         cmd
     }

--- a/src/boxlite/src/jailer/pre_exec.rs
+++ b/src/boxlite/src/jailer/pre_exec.rs
@@ -62,8 +62,24 @@ pub fn add_pre_exec_hook(
     resource_limits: ResourceLimits,
     pid_writer: Option<PidFileWriter>,
     preserved_fds: Vec<(RawFd, i32)>,
+    detach: bool,
 ) {
     use std::os::unix::process::CommandExt;
+
+    // Detach=false → child's own process group at Command-build time
+    // so a later `killpg(shim_pid, SIGKILL)` reaps the shim plus its
+    // grandchildren (libkrun threads, gvproxy) atomically.
+    //
+    // Gated on `!detach` because the detached branch below uses
+    // `setsid()`, which creates a new session AND a new pgroup with
+    // the child as leader of both. Calling `process_group(0)` here
+    // would make the child a pgroup leader before `setsid()` runs;
+    // `setsid()` then fails with EPERM (POSIX: setsid is forbidden
+    // for an existing pgroup leader). The branches are exclusive on
+    // purpose — `setsid()` already covers the pgroup case.
+    if !detach {
+        cmd.process_group(0);
+    }
 
     // SAFETY: The hook only uses async-signal-safe syscalls.
     // See module documentation for details.
@@ -97,6 +113,15 @@ pub fn add_pre_exec_hook(
                     .map_err(std::io::Error::from_raw_os_error)?;
             }
 
+            // 4. Detach=true → setsid: child becomes a session leader,
+            // detaching from the parent's controlling terminal. Without
+            // this a SIGHUP on the parent's terminal cascades into the
+            // daemon (the `BoxOptions::detach` contract relies on it).
+            // `setsid` is async-signal-safe.
+            if detach && libc::setsid() == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+
             Ok(())
         });
     }
@@ -111,7 +136,7 @@ mod tests {
         let mut cmd = Command::new("/bin/echo");
         let limits = ResourceLimits::default();
 
-        add_pre_exec_hook(&mut cmd, limits, None, vec![]);
+        add_pre_exec_hook(&mut cmd, limits, None, vec![], false);
     }
 
     #[test]
@@ -119,7 +144,7 @@ mod tests {
         let mut cmd = Command::new("/bin/echo");
         let limits = ResourceLimits::default();
         let writer = PidFileWriter::at(std::path::Path::new("/tmp/test.pid")).ok();
-        add_pre_exec_hook(&mut cmd, limits, writer, vec![]);
+        add_pre_exec_hook(&mut cmd, limits, writer, vec![], false);
     }
 
     #[test]
@@ -128,6 +153,6 @@ mod tests {
         let limits = ResourceLimits::default();
 
         // Simulate preserving fd 5 → target fd 3
-        add_pre_exec_hook(&mut cmd, limits, None, vec![(5, 3)]);
+        add_pre_exec_hook(&mut cmd, limits, None, vec![(5, 3)], false);
     }
 }

--- a/src/boxlite/src/vmm/controller/spawn.rs
+++ b/src/boxlite/src/vmm/controller/spawn.rs
@@ -71,12 +71,15 @@ impl<'a> ShimSpawner<'a> {
             (None, None)
         };
 
-        // 2. Build jailer with optional FD preservation for watchdog pipe
+        // 2. Build jailer with optional FD preservation for watchdog pipe.
+        // `with_detach(detach)` threads the lifecycle choice into the
+        // jailer's pre_exec chain (setsid vs. process_group).
         let mut builder = JailerBuilder::new()
             .with_box_id(self.box_id)
             .with_layout(self.layout.clone())
             .with_security(self.options.advanced.security.clone())
-            .with_volumes(self.options.volumes.clone());
+            .with_volumes(self.options.volumes.clone())
+            .with_detach(detach);
 
         if let Some(ref setup) = child_setup {
             builder = builder.with_preserved_fd(setup.raw_fd(), watchdog::PIPE_FD);
@@ -297,5 +300,116 @@ mod tests {
         assert!(!envs.contains_key(OsStr::new("TMPDIR")));
         assert!(!envs.contains_key(OsStr::new("TMP")));
         assert!(!envs.contains_key(OsStr::new("TEMP")));
+    }
+
+    /// Detached spawn must produce a child that is its own session
+    /// leader. Without `setsid`, a SIGHUP to the parent's controlling
+    /// terminal cascades into the daemon — breaking detach.
+    ///
+    /// Revert procedure: comment out the
+    /// `.with_detach(detach)` builder call in `spawn()`.
+    /// This test must then fail with `child_sid == parent_sid`.
+    #[cfg(unix)]
+    #[test]
+    fn shim_spawner_detached_creates_new_session() {
+        use crate::runtime::advanced_options::SecurityOptions;
+        use crate::runtime::layout::{BoxFilesystemLayout, FsLayoutConfig};
+        use std::time::Duration;
+        use tempfile::TempDir;
+
+        let parent_sid = unsafe { libc::getsid(0) };
+
+        let tmp = TempDir::new_in("/tmp").expect("tempdir");
+        let box_dir = tmp.path().join("box");
+        std::fs::create_dir_all(&box_dir).expect("mkdir box");
+        let layout = BoxFilesystemLayout::new(box_dir, FsLayoutConfig::without_bind_mount(), false);
+        // Disable jailer: on macOS the default wraps the child in
+        // sandbox-exec, which would block the `/usr/bin/yes` stand-in.
+        // The setsid pre_exec hook is unaffected by sandbox state.
+        let mut options = BoxOptions::default();
+        options.advanced.security = SecurityOptions::development();
+        let spawner = ShimSpawner::new(
+            std::path::Path::new("/usr/bin/yes"),
+            &layout,
+            "shimspawnertest",
+            &options,
+        );
+
+        let spawned = spawner.spawn("", true).expect("spawn detached");
+        let pid = spawned.child.id();
+
+        std::thread::sleep(Duration::from_millis(100));
+        let child_sid = unsafe { libc::getsid(pid as i32) };
+
+        unsafe {
+            libc::kill(pid as i32, libc::SIGKILL);
+            libc::waitpid(pid as i32, std::ptr::null_mut(), 0);
+        }
+
+        assert_eq!(
+            child_sid, pid as i32,
+            "detached ShimSpawner::spawn must produce a session-leader child. \
+             Got sid={child_sid}, expected {pid}. parent_sid={parent_sid}. \
+             Without setsid, a SIGHUP to the parent's controlling terminal \
+             would cascade into the detached shim."
+        );
+        assert_ne!(
+            child_sid, parent_sid,
+            "shim's session id must differ from parent's"
+        );
+    }
+
+    /// Non-detached spawn must produce a child that is its own
+    /// process-group leader so `killpg(shim_pid, SIGKILL)` reaps the
+    /// shim + grandchildren (libkrun threads, gvproxy) atomically.
+    ///
+    /// Revert procedure: comment out the
+    /// `.with_detach(detach)` builder call in `spawn()`.
+    /// This test must then fail with `child_pgid == parent_pgid`.
+    #[cfg(unix)]
+    #[test]
+    fn shim_spawner_non_detached_creates_new_pgroup() {
+        use crate::runtime::advanced_options::SecurityOptions;
+        use crate::runtime::layout::{BoxFilesystemLayout, FsLayoutConfig};
+        use std::time::Duration;
+        use tempfile::TempDir;
+
+        let parent_pgid = unsafe { libc::getpgid(0) };
+
+        let tmp = TempDir::new_in("/tmp").expect("tempdir");
+        let box_dir = tmp.path().join("box");
+        std::fs::create_dir_all(&box_dir).expect("mkdir box");
+        let layout = BoxFilesystemLayout::new(box_dir, FsLayoutConfig::without_bind_mount(), false);
+        let mut options = BoxOptions::default();
+        options.advanced.security = SecurityOptions::development();
+        let spawner = ShimSpawner::new(
+            std::path::Path::new("/usr/bin/yes"),
+            &layout,
+            "shimspawnertest",
+            &options,
+        );
+
+        let spawned = spawner.spawn("", false).expect("spawn non-detached");
+        let pid = spawned.child.id();
+
+        std::thread::sleep(Duration::from_millis(100));
+        let child_pgid = unsafe { libc::getpgid(pid as i32) };
+
+        unsafe {
+            libc::kill(pid as i32, libc::SIGKILL);
+            libc::waitpid(pid as i32, std::ptr::null_mut(), 0);
+        }
+
+        assert_eq!(
+            child_pgid, pid as i32,
+            "non-detached ShimSpawner::spawn must produce a pgroup-leader child. \
+             Got pgid={child_pgid}, expected {pid}. parent_pgid={parent_pgid}. \
+             Without process_group(0), killpg(shim_pid) would target the \
+             parent's pgroup."
+        );
+        assert_ne!(
+            child_pgid, parent_pgid,
+            "shim's pgid must differ from parent's"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Detached shims (`detach=true`) become true Unix daemons via `setsid()` in the jailer's `pre_exec` chain — own session, no controlling terminal, immune to terminal-SIGHUP cascade. Required by the `BoxOptions::detach` contract documented in #601.
- Non-detached shims (`detach=false`) get their own process group via `cmd.process_group(0)` so a future `killpg(shim_pid, SIGKILL)` reaps shim + libkrun/gvproxy grandchildren atomically.
- Branches are mutually exclusive: `process_group(0)` before `setsid()` would cause `setsid()` to fail with `EPERM` (POSIX: forbidden on an existing pgroup leader). `pre_exec.rs` documents the gate.
- Plumbed via `JailerBuilder::with_detach(detach)`. The lifecycle decision lives next to the other pre_exec primitives instead of as a separate call at the spawn site.

## Test plan
- [x] `shim_spawner_detached_creates_new_session` — asserts `getsid(child) == child_pid` after `ShimSpawner::spawn("", true)`. Two-side verified: reverted production makes it fail with `sid == parent_sid`; restored, passes.
- [x] `shim_spawner_non_detached_creates_new_pgroup` — asserts `getpgid(child) == child_pid` after `ShimSpawner::spawn("", false)`. Two-side verified analogously.
- [x] Existing `jailer::pre_exec::tests` (3 tests) still pass after adding the `detach` parameter.