### PR TITLE
chore(claude): add PR-review acknowledgment PreToolUse hook

### DIFF
--- a/.claude/hooks/preflight-pr-review.sh
+++ b/.claude/hooks/preflight-pr-review.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# PreToolUse hook: gate `gh pr create` / `gh pr edit` / `gh pr ready` on a
+# user-TYPED acknowledgment that they have reviewed the PR.
+#
+# `gh pr create --draft` (and `-d`) is intentionally excluded — draft PRs are
+# not yet requesting review, so no ack is required.
+#
+# Flow on a denied attempt:
+#   1. Hook denies the gh tool call.
+#   2. Reason text instructs the parent agent to obtain a TYPED confirmation
+#      from the human (not a yes/no click) and persist it verbatim to
+#      .claude/.pr-reviewed.json bound to current branch + HEAD.
+#   3. Parent retries -> hook validates the marker and allows on match.
+#
+# Wired in .claude/settings.json under hooks.PreToolUse with matcher "Bash".
+#
+# Design notes
+# ------------
+# * Matcher scope: same reason as preflight-claude-md.sh — PreToolUse matchers
+#   are tool-name-only. This script does the actual `gh pr <subcmd>` filtering
+#   and exits 0 immediately on unrelated bash calls.
+#
+# * Draft detection caveat: the `--draft` / `-d` check matches anywhere in the
+#   raw command string. A title like `--title "[draft] foo"` would falsely
+#   skip the ack. The user has accepted this — quoting `--draft` inside an
+#   arbitrary string is rare and the failure mode is "let one PR through
+#   without ack," not a destructive action.
+#
+# * One-shot consumption: the marker file is `rm -f`'d on the allow path so
+#   each successive gh pr command forces a fresh ack, even at the same HEAD.
+#   Mirrors the trade-off in preflight-claude-md.sh.
+#
+# Tests: bash .claude/hooks/preflight-pr-review.test.sh
+set -euo pipefail
+
+payload="$(cat)"
+command="$(printf '%s' "$payload" | jq -r '.tool_input.command // ""')"
+
+# Match `gh pr create|edit|ready` at start of command OR at start of any chain
+# segment (after &&, ||, ;, |, &, $(, (, `). Same shape as the git matcher in
+# preflight-claude-md.sh so chained invocations are caught.
+#
+# Scan only the FIRST physical line of the command. Multi-line commands almost
+# always put the gh invocation on the first line; this excludes heredoc bodies
+# (e.g. a `git commit -m "$(cat <<EOF ... gh pr create ... EOF)"` where the
+# trigger phrase legitimately appears in commit-message prose) from matching.
+# Trade-off: a chained `foo \\\n  && gh pr create` would no longer gate, but
+# that form is rare for gh invocations.
+first_line="${command%%$'\n'*}"
+work="${first_line#"${first_line%%[![:space:]]*}"}"
+if [[ "$work" =~ (^|[[:space:]]*(\&\&|\|\||;|\||\&|\$\(|\(|\`)[[:space:]]*)([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]+[[:space:]]+)*gh[[:space:]]+pr[[:space:]]+(create|edit|ready)([[:space:]]|$) ]]; then
+  subcmd="${BASH_REMATCH[4]}"
+else
+  exit 0
+fi
+
+# Exclude draft PRs from the gate (only `gh pr create` has --draft).
+if [[ "$subcmd" == "create" ]] && [[ "$command" =~ (^|[[:space:]])(--draft|-d)([[:space:]]|=|$) ]]; then
+  exit 0
+fi
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+project_dir="${CLAUDE_PROJECT_DIR:-$repo_root}"
+branch="$(git -C "$repo_root" branch --show-current 2>/dev/null || echo '?')"
+head="$(git -C "$repo_root" rev-parse HEAD 2>/dev/null || echo '?')"
+marker_file="$project_dir/.claude/.pr-reviewed.json"
+max_age_seconds=600
+
+deny() {
+  jq -nc --arg r "$1" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: $r
+    }
+  }'
+  exit 0
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TODO(user, learning-mode): author the ack instructions Claude reads on every
+# deny. This is the actual UX of the gate — keep it tight, unambiguous, and
+# anti-cheating.
+#
+# Constraints the message MUST satisfy:
+#   • Direct Claude to obtain a TYPED reply from the human (not AskUserQuestion
+#     click, not Claude inferring "the user already said yes earlier").
+#   • Specify the exact shape the user must type. The hook validates the
+#     marker's `.message` field with the regex defined in REQUIRED_MESSAGE_RE
+#     below — keep the two in sync.
+#   • Tell Claude where to write the marker (path shown via ${marker_file})
+#     and what JSON shape: { branch, head, message }.
+#   • Forbid Claude from fabricating the message or paraphrasing the user.
+#
+# Variables available for interpolation:
+#   ${command}      the exact gh command being gated
+#   ${subcmd}       create | edit | ready
+#   ${branch}       current branch
+#   ${head}         current HEAD sha
+#   ${marker_file}  absolute path Claude must write to
+#
+# Required regex the user's typed message must match (keep in sync with the
+# required phrase shown in ack_instruction below):
+REQUIRED_MESSAGE_RE='^reviewed:[[:space:]]+[^[:space:]]'
+
+ack_instruction="PR-review acknowledgment required before: ${command}
+
+Branch: ${branch}    HEAD: ${head:0:12}
+
+Show the user the gh command above. Then ask them — in plain text, NOT
+AskUserQuestion — to confirm they have reviewed the PR by replying with a
+single line in this exact shape:
+
+    reviewed: <one-line summary, in their own words, of what this PR changes>
+
+Wait for the user's next message. Then:
+  • If their reply matches the shape above, write it verbatim to
+        ${marker_file}
+    as:
+        { \"branch\": \"${branch}\",
+          \"head\": \"${head}\",
+          \"message\": \"<the user's verbatim line>\" }
+    and retry the same gh command.
+  • If their reply is anything else (a 'no'/'abort', a question, silence, the
+    wrong prefix, or text you suspect you suggested rather than they typed),
+    do NOT write the marker and do NOT retry. Abort the PR action and ask
+    what they want to do instead.
+
+You MUST NOT fabricate, paraphrase, or pre-fill the summary on the user's
+behalf. The summary must be the user's own words from their next message."
+# ─────────────────────────────────────────────────────────────────────────────
+
+if [[ ! -r "$marker_file" ]]; then
+  deny "No PR-review acknowledgment on file for: ${command}
+
+${ack_instruction}"
+fi
+
+marker_branch="$(jq -r '.branch // ""' "$marker_file" 2>/dev/null || echo '')"
+marker_head="$(jq -r '.head // ""' "$marker_file" 2>/dev/null || echo '')"
+marker_message="$(jq -r '.message // ""' "$marker_file" 2>/dev/null || echo '')"
+
+marker_mtime="$(stat -f '%m' "$marker_file" 2>/dev/null || stat -c '%Y' "$marker_file" 2>/dev/null || echo 0)"
+now_epoch="$(date +%s)"
+age=$(( now_epoch - marker_mtime ))
+
+if [[ "$marker_branch" != "$branch" ]] || \
+   [[ "$marker_head" != "$head" ]] || \
+   (( age > max_age_seconds )); then
+  deny "Existing PR-review acknowledgment does not match current state:
+  marker.branch=${marker_branch}  current=${branch}
+  marker.head=${marker_head}      current=${head}
+  marker age: ${age}s (max ${max_age_seconds}s)
+
+Re-acknowledgment required.
+${ack_instruction}"
+fi
+
+if [[ ! "$marker_message" =~ $REQUIRED_MESSAGE_RE ]]; then
+  deny "PR-review acknowledgment message is missing or malformed.
+Found: ${marker_message:-<empty>}
+Required to match: ${REQUIRED_MESSAGE_RE}
+
+${ack_instruction}"
+fi
+
+# Marker is valid for this exact branch+HEAD. Consume it so the next
+# gh pr create/edit/ready forces a fresh ack.
+rm -f "$marker_file"
+exit 0

--- a/.claude/hooks/preflight-pr-review.sh
+++ b/.claude/hooks/preflight-pr-review.sh
@@ -107,27 +107,46 @@ ack_instruction="PR-review acknowledgment required before: ${command}
 
 Branch: ${branch}    HEAD: ${head:0:12}
 
-Show the user the gh command above. Then ask them — in plain text, NOT
-AskUserQuestion — to confirm they have reviewed the PR by replying with a
-single line in this exact shape:
+Invoke the AskUserQuestion tool. The user will pick 'Other' and type their
+acknowledgment into the side-panel text field; their typed text comes back
+on the question's 'notes' annotation (not the 'answers' field).
 
-    reviewed: <one-line summary, in their own words, of what this PR changes>
+Use this AskUserQuestion payload:
+  question: 'PR-review acknowledgment for: ${command}
+             Pick \"Other\" and type your acknowledgment in this exact shape:
+                 reviewed: <one-line summary, in your own words, of what
+                            this PR changes>'
+  header:   'PR review'
+  options:
+    - label: 'Abort — do not file this PR'
+      description: 'Cancel the gh command and return to chat.'
+    - label: 'Show me the diff first, then re-ask'
+      description: 'Run git diff main...HEAD --stat + git log main..HEAD,
+                    display output, then re-invoke AskUserQuestion.'
+  multiSelect: false
 
-Wait for the user's next message. Then:
-  • If their reply matches the shape above, write it verbatim to
-        ${marker_file}
-    as:
-        { \"branch\": \"${branch}\",
-          \"head\": \"${head}\",
-          \"message\": \"<the user's verbatim line>\" }
-    and retry the same gh command.
-  • If their reply is anything else (a 'no'/'abort', a question, silence, the
-    wrong prefix, or text you suspect you suggested rather than they typed),
-    do NOT write the marker and do NOT retry. Abort the PR action and ask
-    what they want to do instead.
+After AskUserQuestion returns:
+  • If the user's typed 'notes' text matches ${REQUIRED_MESSAGE_RE}:
+      write it verbatim to:
+          ${marker_file}
+      as:
+          { \"branch\": \"${branch}\",
+            \"head\":   \"${head}\",
+            \"message\": \"<the user's verbatim typed text>\" }
+      then retry the same gh command.
+  • If the user picked 'Abort — do not file this PR':
+      do NOT write marker, do NOT retry; tell the user the PR was aborted
+      and ask what they want to do instead.
+  • If the user picked 'Show me the diff first, then re-ask':
+      run \`git diff main...HEAD --stat && git log main..HEAD --oneline\`,
+      show the output, then re-invoke the SAME AskUserQuestion.
+  • If the user typed text in 'Other' but it does not match the regex:
+      re-invoke the SAME AskUserQuestion with a one-line note explaining
+      the required shape. Do NOT write the marker. Do NOT retry yet.
 
-You MUST NOT fabricate, paraphrase, or pre-fill the summary on the user's
-behalf. The summary must be the user's own words from their next message."
+You MUST NOT fabricate, paraphrase, or pre-fill the summary. Only the user's
+verbatim typed text from the AskUserQuestion 'Other' field is acceptable as
+the ack."
 # ─────────────────────────────────────────────────────────────────────────────
 
 if [[ ! -r "$marker_file" ]]; then

--- a/.claude/hooks/preflight-pr-review.test.sh
+++ b/.claude/hooks/preflight-pr-review.test.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Tests for .claude/hooks/preflight-pr-review.sh
+#
+# Covers:
+#   1. Command matcher: gh pr create / edit / ready vs. unrelated bash,
+#      chained invocations, draft exclusion.
+#   2. Gate logic: missing / mismatched / stale / malformed-message /
+#      consumed marker paths.
+#
+# Run with:  bash .claude/hooks/preflight-pr-review.test.sh
+# Exits non-zero on any failure.
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+HOOK="$REPO_ROOT/.claude/hooks/preflight-pr-review.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+export CLAUDE_PROJECT_DIR="$TMP"
+mkdir -p "$TMP/.claude"
+
+BRANCH="$(git -C "$REPO_ROOT" branch --show-current)"
+HEAD_SHA="$(git -C "$REPO_ROOT" rev-parse HEAD)"
+
+pass=0
+fail=0
+
+run() {
+  local desc="$1" cmd="$2" expect="$3" out decision
+  out=$(printf '%s' "$cmd" | jq -Rs '{tool_input:{command:.}}' | "$HOOK")
+  if [[ -z "$out" ]]; then
+    decision="passthrough"
+  else
+    decision=$(printf '%s' "$out" | jq -r '.hookSpecificOutput.permissionDecision' 2>/dev/null || echo "parse_error")
+  fi
+  if [[ "$decision" == "$expect" ]]; then
+    pass=$((pass + 1))
+    printf '  PASS  %s\n' "$desc"
+  else
+    fail=$((fail + 1))
+    printf '  FAIL  %s  (got=%s expected=%s)\n' "$desc" "$decision" "$expect"
+  fi
+}
+
+write_marker() {
+  local message="$1"
+  jq -nc --arg b "$BRANCH" --arg h "$HEAD_SHA" --arg m "$message" \
+        '{branch:$b, head:$h, message:$m}' \
+        > "$TMP/.claude/.pr-reviewed.json"
+}
+
+echo "## Matcher: should pass through (not a gated gh pr invocation)"
+rm -f "$TMP/.claude/.pr-reviewed.json"
+run "ls"                                "ls"                                "passthrough"
+run "gh pr list (different subcmd)"     "gh pr list"                        "passthrough"
+run "gh pr view (different subcmd)"     "gh pr view 123"                    "passthrough"
+run "gh issue create (different verb)"  "gh issue create -t foo"            "passthrough"
+run "echo literal mention"              "echo 'gh pr create'"               "passthrough"
+run "git push (other hook's domain)"    "git push origin main"              "passthrough"
+run "heredoc body mentions trigger"     $'git commit -m "$(cat <<\'EOF\'\nbody mentions `gh pr create`\nEOF\n)"' "passthrough"
+run "multiline w/ backtick trigger"     $'git commit -m "fix bug"\n# `gh pr create`' "passthrough"
+
+echo
+echo "## Matcher: draft exclusion (only on create)"
+run "gh pr create --draft"              "gh pr create --draft -t wip"       "passthrough"
+run "gh pr create -d short flag"        "gh pr create -d -t wip"            "passthrough"
+
+echo
+echo "## Matcher: should gate"
+run "gh pr create direct"               "gh pr create -t foo"               "deny"
+run "gh pr edit direct"                 "gh pr edit 42 --body foo"          "deny"
+run "gh pr ready direct"                "gh pr ready 42"                    "deny"
+run "chained with &&"                   "cd x && gh pr create -t foo"       "deny"
+run "chained with ;"                    "echo done; gh pr create -t foo"    "deny"
+run "command substitution"              "out=\$(gh pr create -t foo)"       "deny"
+run "env var prefix"                    "FOO=bar gh pr create -t foo"       "deny"
+
+echo
+echo "## Gate logic: marker file states"
+write_marker "reviewed: refactor auth middleware"
+run "valid marker → allow"              "gh pr create -t foo"               "passthrough"
+run "marker consumed on allow"          "gh pr create -t foo"               "deny"
+
+write_marker "reviewed: edit body fix"
+run "valid marker for edit → allow"     "gh pr edit 42"                     "passthrough"
+
+write_marker "yes"
+run "malformed message → deny"          "gh pr create -t foo"               "deny"
+
+write_marker ""
+run "empty message → deny"              "gh pr create -t foo"               "deny"
+
+write_marker "reviewed: stale"
+jq --arg h "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef" '.head=$h' \
+   "$TMP/.claude/.pr-reviewed.json" > "$TMP/.claude/x.json" \
+   && mv "$TMP/.claude/x.json" "$TMP/.claude/.pr-reviewed.json"
+run "HEAD mismatch → deny"              "gh pr create -t foo"               "deny"
+
+write_marker "reviewed: branch test"
+jq --arg b "some-other-branch" '.branch=$b' \
+   "$TMP/.claude/.pr-reviewed.json" > "$TMP/.claude/x.json" \
+   && mv "$TMP/.claude/x.json" "$TMP/.claude/.pr-reviewed.json"
+run "branch mismatch → deny"            "gh pr create -t foo"               "deny"
+
+write_marker "reviewed: old"
+touch -t 202001010000 "$TMP/.claude/.pr-reviewed.json"
+run "stale mtime (>max_age) → deny"     "gh pr create -t foo"               "deny"
+
+echo
+echo "RESULT: $pass passed, $fail failed"
+exit $(( fail > 0 ? 1 : 0 ))

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,6 +7,10 @@
           {
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/preflight-claude-md.sh"
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/preflight-pr-review.sh"
           }
         ]
       }


### PR DESCRIPTION
## Summary

- Adds a new PreToolUse hook (`.claude/hooks/preflight-pr-review.sh`) that gates `gh pr (create | edit | ready)` on a user-typed acknowledgment that they have reviewed the PR. Draft creation is excluded.
- Acknowledgment is routed through the AskUserQuestion side panel: the user picks "Other" and types a one-line summary into the typed-answer field; the hook writes it to `.claude/.pr-reviewed.json` bound to current branch + HEAD with a 10-min freshness window, one-shot consumed.
- Mirrors the shape of the existing `preflight-claude-md.sh` auditor hook and shares the broad `Bash` PreToolUse matcher slot in `.claude/settings.json`.
- Includes `.claude/hooks/preflight-pr-review.test.sh` with 25 cases covering matcher (direct + chained invocations, draft exclusion, sibling subcommands, heredoc-body false-positive regression) and gate logic (missing / mismatched / stale / malformed-message / consumed marker paths).

## Test plan

- [x] `bash .claude/hooks/preflight-pr-review.test.sh` — 25/25 green
- [x] `bash .claude/hooks/preflight-claude-md.test.sh` — 19/19 still green (sibling hook untouched)
- [x] Live exercise on this very PR: hook denied my first `gh pr create` attempt, routed the ack through AskUserQuestion, accepted the typed reply, allowed the retry