### PR TITLE
test(test-utils): PerTestBoxHome::Drop fails loudly if a shim is still alive

### DIFF
--- a/src/test-utils/src/home.rs
+++ b/src/test-utils/src/home.rs
@@ -20,6 +20,8 @@ use std::path::PathBuf;
 use tempfile::TempDir;
 
 use crate::cache::{LinkedCache, SharedResources};
+use boxlite::BoxID;
+use boxlite::util::PidFileReader;
 
 /// Per-test home directory with shared cache linked in.
 ///
@@ -99,6 +101,75 @@ impl PerTestBoxHome {
     }
 }
 
+/// Fail the test if a shim is still alive when this home drops.
+///
+/// Detached shims are `setsid()`'d daemons (see `vmm/controller/spawn.rs`)
+/// that intentionally outlive the parent process. The production
+/// stop paths — `box.stop()`, `auto_remove`, `runtime.remove()` —
+/// are what should kill them; if the shim is still alive at drop
+/// time, something on the production side did not run.
+///
+/// We do NOT silently reap here. Reaping would mask the bug: the
+/// orphan accumulation that motivated this would just move from
+/// `/tmp/` (visible) into the implicit Drop cleanup (invisible).
+/// Failing loudly forces the test author to find the missing stop
+/// call (or the production cleanup gap).
+///
+/// `panic` during another panic would mask the real failure, so
+/// the check is skipped when `std::thread::panicking()` is true —
+/// the original test failure is the primary signal in that case.
+impl Drop for PerTestBoxHome {
+    fn drop(&mut self) {
+        if std::thread::panicking() {
+            return;
+        }
+        let leaks = live_shim_pids(&self.path.join("boxes"));
+        assert!(
+            leaks.is_empty(),
+            "PerTestBoxHome dropped with {n} live shim(s): {leaks:?}. \
+             Tests must stop boxes (e.g. `box.stop()`, `runtime.remove()`, \
+             or `auto_remove=true`) before the home goes out of scope. A \
+             live shim here means a production cleanup path did not run.",
+            n = leaks.len(),
+        );
+    }
+}
+
+/// Return PIDs from `<boxes_dir>/<box_id>/shim.pid` that point at
+/// processes still alive right now. Missing dirs, malformed PID
+/// files, and dead PIDs are all skipped silently.
+fn live_shim_pids(boxes_dir: &std::path::Path) -> Vec<u32> {
+    let mut alive = Vec::new();
+    let Ok(entries) = std::fs::read_dir(boxes_dir) else {
+        return alive;
+    };
+    for entry in entries.flatten() {
+        let box_home = entry.path();
+        let Some(name) = box_home.file_name().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        if BoxID::parse(name).is_none() {
+            continue;
+        }
+        let pid_file = box_home.join("shim.pid");
+        if !pid_file.exists() {
+            continue;
+        }
+        let Ok(record) = PidFileReader::at(&pid_file).read() else {
+            continue;
+        };
+        // `kill(pid, 0)` returns 0 if the process exists (alive or
+        // zombie). Zombies are dead from a leak-accounting view, but
+        // for a brand-new test stand-in they shouldn't appear — and
+        // the cost of being conservative is one extra reported leak,
+        // not a missed one.
+        if unsafe { libc::kill(record.pid as i32, 0) } == 0 {
+            alive.push(record.pid);
+        }
+    }
+    alive
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -133,6 +204,70 @@ mod tests {
         assert!(
             !tmp_link.exists(),
             "isolated home should not have a tmp symlink"
+        );
+    }
+
+    /// `PerTestBoxHome::drop` must fail the test if a referenced
+    /// shim is still alive — the production stop path (box.stop,
+    /// auto_remove, runtime.remove) is what should have killed it.
+    /// Silently reaping would mask that gap.
+    ///
+    /// Revert procedure: replace the `impl Drop` body with an empty
+    /// `fn drop(&mut self) {}`. The `catch_unwind` below must then
+    /// report `Ok(())` instead of `Err(_)` — i.e., the drop didn't
+    /// panic, and the leak would have gone unnoticed.
+    #[test]
+    fn drop_panics_if_shim_still_alive() {
+        use std::os::unix::process::CommandExt;
+        use std::process::Command;
+
+        let home = PerTestBoxHome::isolated();
+        let home_path = home.path.clone();
+
+        // Stand-in for a detached shim. argv[0] override + own
+        // pgroup match what a real shim spawn looks like.
+        let argv0 = "boxlite-shim testbox123abc".to_string();
+        let child = Command::new("sleep")
+            .arg("30")
+            .arg0(&argv0)
+            .process_group(0)
+            .spawn()
+            .expect("spawn stand-in shim");
+        let shim_pid = child.id();
+
+        // Forget Child so its own Drop doesn't kill the stand-in
+        // before PerTestBoxHome::drop runs.
+        std::mem::forget(child);
+
+        // Write a fake shim.pid into a BoxID-shaped dir.
+        let box_dir = home_path.join("boxes").join("boxtestabc12");
+        std::fs::create_dir_all(&box_dir).expect("mkdir box dir");
+        std::fs::write(box_dir.join("shim.pid"), format!("{shim_pid}\n"))
+            .expect("write fake shim.pid");
+
+        assert_eq!(
+            unsafe { libc::kill(shim_pid as i32, 0) },
+            0,
+            "test precondition: stand-in PID {shim_pid} must be alive before drop"
+        );
+
+        // Drop must panic — the leak is real and unhandled.
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+            drop(home);
+        }));
+
+        // Test-only cleanup (the production code under test stays
+        // hands-off the kill, but this test created the stand-in so
+        // we reap it ourselves to avoid leaking into the next test).
+        unsafe {
+            libc::kill(shim_pid as i32, libc::SIGKILL);
+            libc::waitpid(shim_pid as i32, std::ptr::null_mut(), 0);
+        }
+
+        assert!(
+            result.is_err(),
+            "PerTestBoxHome::drop should have panicked on a live shim. \
+             Stand-in PID {shim_pid} was never reported."
         );
     }
 }


### PR DESCRIPTION
## Summary
The original "8 orphan shims in /tmp" report came from tests that created detached boxes and let `PerTestBoxHome` go out of scope without explicitly stopping them. The detached shim survived (per the `BoxOptions::detach` contract from #601), `TempDir` cleaned up the directory, and the process kept running forever.

A reaper-on-drop would have masked the bug: the leak just moves from `/tmp/` (visible) into the implicit `Drop` cleanup (invisible). Instead, `Drop` now **asserts** that no shim referenced by `<home>/boxes/*/shim.pid` is still alive. If one is, the test fails with the PID list and a hint pointing at the missing stop call.

A test panic is the right signal because the production stop paths (`box.stop()`, `runtime.remove()`, `auto_remove=true`) are what should reap the shim. A live shim at drop time means one of those paths did not run — either the test forgot the call or production has a gap. Either way the test author needs to look.

The `std::thread::panicking()` guard skips the check when another panic is already in progress so the original test failure stays the primary signal.

## Test plan
- [x] Two-side verified by `drop_panics_if_shim_still_alive`:
  - With an empty `Drop` body: `catch_unwind` returns `Ok(_)` → test fails with "PerTestBoxHome::drop should have panicked on a live shim."
  - With the full `Drop` body: `catch_unwind` returns `Err(_)` → test passes.
- [x] Existing 42 test-utils tests still pass.