### PR TITLE
[WIP] fix-stress(guest): cgroup memory.max + pids.max to prevent VM panic under OOM

### DIFF
--- a/src/boxlite/src/litebox/exec.rs
+++ b/src/boxlite/src/litebox/exec.rs
@@ -35,6 +35,7 @@ pub struct BoxCommand {
     pub(crate) working_dir: Option<String>,
     pub(crate) tty: bool,
     pub(crate) user: Option<String>,
+    pub(crate) debug: bool,
 }
 
 impl BoxCommand {
@@ -48,6 +49,7 @@ impl BoxCommand {
             working_dir: None,
             tty: false,
             user: None,
+            debug: false,
         }
     }
 
@@ -102,6 +104,15 @@ impl BoxCommand {
     pub fn user(mut self, spec: impl Into<String>) -> Self {
         let s = spec.into();
         self.user = if s.trim().is_empty() { None } else { Some(s) };
+        self
+    }
+
+    /// Route this exec into the operator cgroup subgroup (`/boxlite/<id>/operator`,
+    /// separate tight budget) instead of the workload subgroup. Lets an operator
+    /// still get into the box when the workload has saturated its own `pids.max`.
+    /// Defaults to off — a plain `boxlite exec` keeps the workload's full budget.
+    pub fn debug(mut self, on: bool) -> Self {
+        self.debug = on;
         self
     }
 }

--- a/src/boxlite/src/portal/interfaces/exec.rs
+++ b/src/boxlite/src/portal/interfaces/exec.rs
@@ -230,6 +230,7 @@ impl ExecProtocol {
                 None
             },
             user: command.user.clone(),
+            debug: command.debug,
         }
     }
 

--- a/src/boxlite/src/rest/types.rs
+++ b/src/boxlite/src/rest/types.rs
@@ -339,6 +339,12 @@ pub(crate) struct ExecRequest {
     pub working_dir: Option<String>,
     #[serde(default)]
     pub tty: bool,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub debug: bool,
+}
+
+fn is_false(b: &bool) -> bool {
+    !*b
 }
 
 impl ExecRequest {
@@ -356,6 +362,7 @@ impl ExecRequest {
             timeout_seconds,
             working_dir: cmd.working_dir.clone(),
             tty: cmd.tty,
+            debug: cmd.debug,
         }
     }
 }
@@ -651,11 +658,16 @@ mod tests {
             timeout_seconds: Some(30.0),
             working_dir: Some("/app".to_string()),
             tty: false,
+            debug: false,
         };
         let json = serde_json::to_string(&req).unwrap();
         assert!(json.contains("\"command\":\"python3\""));
         assert!(json.contains("\"timeout_seconds\":30.0"));
         assert!(json.contains("\"working_dir\":\"/app\""));
+        // debug=false is omitted from the wire to keep payloads compact
+        // and to stay backwards-compatible with REST servers that don't
+        // know about the field.
+        assert!(!json.contains("debug"));
     }
 
     #[test]

--- a/src/cli/src/commands/exec.rs
+++ b/src/cli/src/commands/exec.rs
@@ -13,6 +13,13 @@ pub struct ExecArgs {
     #[arg(short = 'd', long)]
     pub detach: bool,
 
+    /// Route this exec into the box's operator cgroup subgroup so it still
+    /// works when the workload has saturated its own `pids.max`. Use only for
+    /// inspection commands — the operator subgroup has a tight budget
+    /// (~64 PIDs / 32 MiB) and a heavy command may hit ENOSPC/EAGAIN there.
+    #[arg(long)]
+    pub debug: bool,
+
     /// Box ID or name
     #[arg(index = 1, value_name = "BOX")]
     pub target_box: String,
@@ -83,6 +90,7 @@ impl BoxExecutor {
 
     fn prepare_command(&self) -> BoxCommand {
         let cmd = BoxCommand::new(&self.args.command[0]).args(&self.args.command[1..]);
-        self.args.process.configure_command(cmd)
+        let cmd = self.args.process.configure_command(cmd);
+        cmd.debug(self.args.debug)
     }
 }

--- a/src/cli/src/commands/serve/mod.rs
+++ b/src/cli/src/commands/serve/mod.rs
@@ -690,7 +690,7 @@ fn build_box_command(req: &ExecRequest) -> BoxCommand {
     if let Some(secs) = req.timeout_seconds {
         cmd = cmd.timeout(std::time::Duration::from_secs_f64(secs));
     }
-    cmd
+    cmd.debug(req.debug)
 }
 
 // ============================================================================

--- a/src/cli/src/commands/serve/types.rs
+++ b/src/cli/src/commands/serve/types.rs
@@ -87,6 +87,8 @@ pub(super) struct ExecRequest {
     pub working_dir: Option<String>,
     #[serde(default)]
     pub tty: bool,
+    #[serde(default)]
+    pub debug: bool,
 }
 
 #[derive(Serialize)]

--- a/src/cli/tests/stress_oom.rs
+++ b/src/cli/tests/stress_oom.rs
@@ -46,8 +46,10 @@ impl Drop for BoxCleanup {
     }
 }
 
-/// Start a detached 128 MB alpine box running `sleep 600`; returns its id.
-fn start_128mb_box(home: &Path) -> String {
+/// Start a detached alpine box of size `mem_mib` MiB; returns its id.
+/// `start_128mb_box` is just `start_mb_box(home, 128)`.
+fn start_mb_box(home: &Path, mem_mib: u32) -> String {
+    let mem = mem_mib.to_string();
     let out = boxlite(
         home,
         &[
@@ -56,7 +58,7 @@ fn start_128mb_box(home: &Path) -> String {
             "run",
             "-d",
             "--memory",
-            "128",
+            &mem,
             "alpine:latest",
             "sleep",
             "600",
@@ -69,6 +71,23 @@ fn start_128mb_box(home: &Path) -> String {
         String::from_utf8_lossy(&out.stderr)
     );
     String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+/// Read the container's own cgroup path via `/proc/self/cgroup`. Returns the
+/// path stripped of the `0::` prefix (e.g. `/boxlite/<id>`).
+fn read_container_cgroup(home: &Path, box_id: &str) -> String {
+    let out = exec_sh(
+        home,
+        box_id,
+        "sed 's/^0:://' /proc/self/cgroup",
+        Duration::from_secs(15),
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+/// Start a detached 128 MB alpine box running `sleep 600`; returns its id.
+fn start_128mb_box(home: &Path) -> String {
+    start_mb_box(home, 128)
 }
 
 /// Directly verifies the limits are applied to the container's own cgroup: a
@@ -286,5 +305,178 @@ fn cgroup_limits_keep_vm_alive_under_pids_and_memory_bombs() {
         200,
         2,
         "a 200×2 MB fork+alloc bomb",
+    );
+}
+
+// ============================================================================
+// Cleanup, isolation, restart, and limit-enforces-by-killing checks.
+// Added in the design-review pass on this PR — gaps the original two tests
+// didn't cover.
+// ============================================================================
+
+/// `memory.max` must actually OOM-kill a single allocation that overruns the
+/// cap — survival-of-the-VM is necessary but not sufficient; the WHOLE point of
+/// the limit is to kill the offender. A container that allocates well past
+/// `memory.max` in one chunk must exit non-zero (cgroup OOM-killed → SIGKILL =
+/// exit 137), not return success.
+#[test]
+fn memory_limit_actually_oom_kills_overconsumption() {
+    let home = PerTestBoxHome::new();
+    let box_id = start_128mb_box(home.path.as_path());
+    let _cleanup = BoxCleanup {
+        home: home.path.clone(),
+        id: box_id.clone(),
+    };
+
+    // alpine has busybox `dd`, which can be used to allocate a large /dev/zero
+    // buffer in RAM via tmpfs. We allocate WELL beyond memory.max (which is
+    // ~90% of MemAvailable on a 128 MB VM ≈ 90 MB): write 200 MB into /tmp
+    // (tmpfs, RAM-backed inside the cgroup). That MUST be killed.
+    let out = exec_sh(
+        home.path.as_path(),
+        &box_id,
+        "dd if=/dev/zero of=/tmp/hog bs=1M count=200 2>&1; echo exit=$?",
+        Duration::from_secs(45),
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    // The exec returns the dd's exit code through the printed `exit=N`. Either
+    // dd was SIGKILL'd (137), it returned non-zero with an error, or the host
+    // exec channel itself returned non-zero — all are valid "killed by cgroup"
+    // signals. What's NOT acceptable is `exit=0` (write fully succeeded with
+    // no enforcement).
+    assert!(
+        !stdout.contains("exit=0"),
+        "memory.max did not stop a 200 MB allocation in a 128 MB box (memory limit not enforced)\noutput:\n{stdout}"
+    );
+
+    // And the VM itself must still be Running — the cap killed the container
+    // process, not the VM.
+    assert_vm_survives(home.path.as_path(), &box_id, "memory OOM kill");
+}
+
+/// After `rm -f`, the box's `/sys/fs/cgroup/boxlite/<id>` must not linger.
+/// youki removes it on container delete; if a regression bypasses that, the
+/// host cgroup tree grows unbounded across box churn.
+#[test]
+fn cgroup_dir_is_removed_after_box_rm() {
+    let home = PerTestBoxHome::new();
+    let box_id = start_128mb_box(home.path.as_path());
+
+    // Capture the cgroup path the running box uses.
+    let cg = read_container_cgroup(home.path.as_path(), &box_id);
+    assert!(
+        cg.starts_with("/boxlite/"),
+        "expected /boxlite/<id>; got {cg:?}"
+    );
+
+    // The cgroup directory itself lives on the guest. After `rm -f` the VM is
+    // gone, so we verify by starting a SECOND box and checking the first one's
+    // cgroup directory is absent from the guest's view. We must use the same
+    // home to reuse cached images; otherwise the second box takes too long.
+    let rm = boxlite(
+        home.path.as_path(),
+        &["rm", "-f", &box_id],
+        Duration::from_secs(60),
+    );
+    assert!(
+        rm.status.success(),
+        "rm failed: {}",
+        String::from_utf8_lossy(&rm.stderr)
+    );
+
+    // Bring up a fresh box on the same home and ask it whether the prior
+    // box's cgroup directory exists. If it does, youki / boxlite leaked the
+    // cgroup. The fresh box's PID-namespace can read the host cgroup tree
+    // (we didn't add a cgroup namespace).
+    let box2 = start_128mb_box(home.path.as_path());
+    let _c2 = BoxCleanup {
+        home: home.path.clone(),
+        id: box2.clone(),
+    };
+    let check = exec_sh(
+        home.path.as_path(),
+        &box2,
+        &format!("if [ -d /sys/fs/cgroup{cg} ]; then echo LEAKED; else echo CLEAN; fi"),
+        Duration::from_secs(15),
+    );
+    let s = String::from_utf8_lossy(&check.stdout);
+    assert!(
+        s.contains("CLEAN"),
+        "cgroup {cg} not cleaned up after box rm — saw: {s:?}\n(check stderr: {})",
+        String::from_utf8_lossy(&check.stderr)
+    );
+}
+
+/// Two concurrently-running boxes must each land in their own
+/// `/boxlite/<unique-id>` cgroup. A regression that derived the path from
+/// something shared (e.g. a hashed image id) would have both boxes in the
+/// same cgroup and one's fork bomb cap would be split between them.
+#[test]
+fn concurrent_boxes_have_independent_cgroups() {
+    let home = PerTestBoxHome::new();
+    let box_a = start_128mb_box(home.path.as_path());
+    let box_b = start_128mb_box(home.path.as_path());
+    let _a = BoxCleanup {
+        home: home.path.clone(),
+        id: box_a.clone(),
+    };
+    let _b = BoxCleanup {
+        home: home.path.clone(),
+        id: box_b.clone(),
+    };
+    let cg_a = read_container_cgroup(home.path.as_path(), &box_a);
+    let cg_b = read_container_cgroup(home.path.as_path(), &box_b);
+    assert!(
+        cg_a.starts_with("/boxlite/") && cg_b.starts_with("/boxlite/"),
+        "both boxes must run under /boxlite/<id>; got {cg_a:?} and {cg_b:?}"
+    );
+    assert_ne!(
+        cg_a, cg_b,
+        "concurrent boxes must have distinct cgroups; both at {cg_a:?}"
+    );
+}
+
+/// After stop+start the box must re-land in a /boxlite/<id> cgroup with the
+/// same limits (the new container id changes, but the spec-building path is
+/// the same so the path-prefix invariant must hold). A regression that lost
+/// the cgroups_path on restart would land the restarted container in
+/// `/:youki:<id>`.
+#[test]
+fn cgroup_limits_survive_stop_and_start() {
+    let home = PerTestBoxHome::new();
+    let box_id = start_128mb_box(home.path.as_path());
+    let _cleanup = BoxCleanup {
+        home: home.path.clone(),
+        id: box_id.clone(),
+    };
+
+    // stop
+    let stop = boxlite(
+        home.path.as_path(),
+        &["stop", &box_id],
+        Duration::from_secs(60),
+    );
+    assert!(
+        stop.status.success(),
+        "stop failed: {}",
+        String::from_utf8_lossy(&stop.stderr)
+    );
+
+    // start again
+    let start = boxlite(
+        home.path.as_path(),
+        &["start", &box_id],
+        Duration::from_secs(120),
+    );
+    assert!(
+        start.status.success(),
+        "start failed: {}",
+        String::from_utf8_lossy(&start.stderr)
+    );
+
+    let cg = read_container_cgroup(home.path.as_path(), &box_id);
+    assert!(
+        cg.starts_with("/boxlite/"),
+        "after restart, container must still run under /boxlite/<id>; got {cg:?}"
     );
 }

--- a/src/cli/tests/stress_oom.rs
+++ b/src/cli/tests/stress_oom.rs
@@ -177,11 +177,13 @@ fn assert_vm_survives(home: &Path, box_id: &str, ctx: &str) {
 }
 
 /// Run one attack wave, then assert the VM survived and reset the box for the
-/// next wave by killing any lingering flood children.
-fn run_wave(home: &Path, box_id: &str, n: u32, mb: u32, ctx: &str) {
+/// next wave by killing any lingering flood children. Returns the flood's
+/// stdout (`forked <succeeded>/<requested> x <mb>MB`) so a caller can assert on
+/// how many forks the cgroup actually let through.
+fn run_wave(home: &Path, box_id: &str, n: u32, mb: u32, ctx: &str) -> String {
     // The parent exits right after forking; give the cgroup a moment to OOM-kill
     // / block, then assert survival before cleaning up.
-    let _ = exec_sh(
+    let out = exec_sh(
         home,
         box_id,
         &format!("/tmp/flood {n} {mb} || true"),
@@ -197,6 +199,17 @@ fn run_wave(home: &Path, box_id: &str, n: u32, mb: u32, ctx: &str) {
         Duration::from_secs(15),
     );
     std::thread::sleep(Duration::from_secs(2));
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+/// Parse the `forked <succeeded>/<requested>` count the flood prints.
+fn forked_count(wave_stdout: &str) -> u32 {
+    wave_stdout
+        .lines()
+        .find_map(|l| l.strip_prefix("forked "))
+        .and_then(|rest| rest.split('/').next())
+        .and_then(|n| n.trim().parse().ok())
+        .unwrap_or_else(|| panic!("flood did not report a fork count:\n{wave_stdout}"))
 }
 
 /// 128 MB box, gcc-compiled flood, driven through pids → memory → combined
@@ -240,12 +253,23 @@ fn cgroup_limits_keep_vm_alive_under_pids_and_memory_bombs() {
     );
 
     // Wave 1 — pids bomb: 1000 idle forks vs pids.max = 512.
-    run_wave(
+    let wave1 = run_wave(
         home.path.as_path(),
         &box_id,
         1000,
         0,
         "a 1000-fork pids bomb",
+    );
+    // Survival alone can't tell an enforced cap from a kernel that happened to
+    // cope: assert pids.max actually blocked the bomb. The container can hold
+    // at most 512 tasks (CONTAINER_PIDS_MAX) including the ones already running,
+    // so far fewer than the requested 1000 forks can succeed. 700 leaves slack
+    // above the 512 ceiling while still proving hundreds of forks were refused.
+    let forked = forked_count(&wave1);
+    assert!(
+        (1..700).contains(&forked),
+        "pids.max must cap the fork bomb well below the requested 1000 \
+         (ceiling 512 + already-running tasks); got forked={forked}\n{wave1}"
     );
     // Wave 2 — memory bomb: one process grabs 512 MB in a 128 MB VM.
     run_wave(

--- a/src/cli/tests/stress_oom.rs
+++ b/src/cli/tests/stress_oom.rs
@@ -104,11 +104,15 @@ fn cgroup_limits_are_enforced_on_the_container() {
         id: box_id.clone(),
     };
 
-    // Read the container's own cgroup path and its controller files.
+    // Read the container *init* (PID 1)'s cgroup — that's where the workload
+    // limits live. `/proc/self/cgroup` would return the exec'd shell's cgroup
+    // which is now in the operator sibling subgroup (carved out so a workload
+    // bomb doesn't lock the operator out), and that subgroup has a different
+    // smaller budget. The contract this test pins is the WORKLOAD's cap.
     let out = exec_sh(
         home.path.as_path(),
         &box_id,
-        "cg=$(sed 's/^0:://' /proc/self/cgroup); \
+        "cg=$(sed 's/^0:://' /proc/1/cgroup); \
          printf 'CG=%s\\nMEM=%s\\nPIDS=%s\\n' \
            \"$cg\" \
            \"$(cat /sys/fs/cgroup$cg/memory.max 2>&1)\" \
@@ -130,8 +134,9 @@ fn cgroup_limits_are_enforced_on_the_container() {
     let pids = field("PIDS=");
 
     assert!(
-        cg.starts_with("/boxlite/"),
-        "container must run in its own /boxlite/<id> cgroup, not the root; got {cg:?}\n{report}"
+        cg.starts_with("/boxlite/") && cg.ends_with("/workload"),
+        "container init must run in /boxlite/<id>/workload subgroup (workload + \
+         operator carve-out); got {cg:?}\n{report}"
     );
     let mem_max: u64 = mem.parse().unwrap_or_else(|_| {
         panic!("memory.max must be a concrete byte cap, not {mem:?} (cgroup not applied)\n{report}")
@@ -478,5 +483,118 @@ fn cgroup_limits_survive_stop_and_start() {
     assert!(
         cg.starts_with("/boxlite/"),
         "after restart, container must still run under /boxlite/<id>; got {cg:?}"
+    );
+}
+
+/// **The carve-out's load-bearing test**: after a workload bomb saturates the
+/// workload subgroup, `boxlite exec --debug` must land in the sibling
+/// `/operator` subgroup (own `pids.max=64`), not the workload's saturated one.
+///
+/// What the assertions pin:
+///   1. The `--debug` exec succeeds (operator can still get into the box).
+///   2. The exec'd process's `/proc/self/cgroup` ends with `/operator` —
+///      the structural proof of the carve-out. Without the swap-on-debug
+///      logic this would be `/workload` (or `/boxlite/<id>` if the spec
+///      change is also reverted), and the operator would share fate with
+///      a runaway workload.
+///
+/// Honest caveat: the libcontainer-tenant lockout that originally motivated
+/// the carve-out (workload saturating `/boxlite/<id>` → `failed to launch
+/// init process`) does not reproduce deterministically with this bomb size
+/// in CI — libcontainer needs only ~1 PID slot for tenant exec and the
+/// workload bomb usually leaves at least that much. Assertion #2 is the
+/// deterministic guard; #1 is a smoke check that the API works end-to-end.
+#[test]
+fn operator_exec_works_when_workload_saturates_pids_cap() {
+    let home = PerTestBoxHome::new();
+    let box_id = start_128mb_box(home.path.as_path());
+    let _cleanup = BoxCleanup {
+        home: home.path.clone(),
+        id: box_id.clone(),
+    };
+
+    // Bring up gcc + compile the flood binary (same recipe as the other
+    // stress tests).
+    let install = exec_sh(
+        home.path.as_path(),
+        &box_id,
+        "apk add -q --no-cache gcc musl-dev >/dev/null 2>&1 && echo ok",
+        Duration::from_secs(180),
+    );
+    assert!(
+        String::from_utf8_lossy(&install.stdout).contains("ok"),
+        "gcc install failed: {}",
+        String::from_utf8_lossy(&install.stderr)
+    );
+    let compile = format!(
+        "cat > /tmp/flood.c << 'CEOF'\n{FLOOD_C}\nCEOF\ngcc -O0 -o /tmp/flood /tmp/flood.c && echo compiled"
+    );
+    let out = exec_sh(
+        home.path.as_path(),
+        &box_id,
+        &compile,
+        Duration::from_secs(90),
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("compiled"),
+        "flood compile failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // Saturate the workload subgroup: 1000 forks against pids.max=512. The
+    // flood binary's forked children sleep 20 s holding their PIDs, so
+    // they're still alive when we probe `exec` below.
+    let _ = exec_sh(
+        home.path.as_path(),
+        &box_id,
+        "(/tmp/flood 1000 0 &) ; sleep 1 ; echo bomb-launched",
+        Duration::from_secs(30),
+    );
+
+    // Give the bomb a moment to climb to the 512 ceiling. After this the
+    // workload subgroup IS full — any libcontainer cgroup-join into the
+    // same subgroup would EAGAIN.
+    std::thread::sleep(Duration::from_secs(3));
+
+    // Assertion #1 — smoke: `boxlite exec --debug` succeeds against a box
+    // whose workload subgroup is at pids.max. The `--debug` flag is what
+    // routes us out of workload's saturated subgroup.
+    let probe = boxlite(
+        home.path.as_path(),
+        &["exec", "--debug", &box_id, "--", "echo", "operator-alive"],
+        Duration::from_secs(30),
+    );
+    let stdout = String::from_utf8_lossy(&probe.stdout);
+    let stderr = String::from_utf8_lossy(&probe.stderr);
+    assert!(
+        probe.status.success() && stdout.contains("operator-alive"),
+        "boxlite exec --debug must succeed on a workload-saturated box. \
+         exit: {:?}\nstdout: {stdout}\nstderr: {stderr}",
+        probe.status.code()
+    );
+
+    // Assertion #2 (the deterministic one): the `--debug`-exec'd process
+    // landed in the operator subgroup, not workload. This is what catches
+    // a regression where the swap is silently a no-op — the bomb might not
+    // be strong enough to lock workload out, but the cgroup path tells us
+    // definitively whether the carve-out is active.
+    let cg_probe = boxlite(
+        home.path.as_path(),
+        &[
+            "exec",
+            "--debug",
+            &box_id,
+            "--",
+            "sh",
+            "-c",
+            "sed 's/^0:://' /proc/self/cgroup",
+        ],
+        Duration::from_secs(15),
+    );
+    let cg = String::from_utf8_lossy(&cg_probe.stdout).trim().to_string();
+    assert!(
+        cg.ends_with("/operator"),
+        "--debug exec must land in /boxlite/<id>/operator (the carve-out \
+         sibling), not in workload or a single combined cgroup; got {cg:?}"
     );
 }

--- a/src/cli/tests/stress_oom.rs
+++ b/src/cli/tests/stress_oom.rs
@@ -1,0 +1,183 @@
+//! Integration stress test: cgroup memory.max + pids.max prevent VM panic.
+//!
+//! 128MB VM + gcc install + 200×2MB fork+malloc+memset — without cgroup
+//! this kills the VM 2/3 of the time. With cgroup it survives 100%.
+//!
+//! Requires: musl-gcc on the host (apt install musl-tools).
+
+use assert_cmd::Command;
+use boxlite_test_utils::home::PerTestBoxHome;
+use std::time::Duration;
+
+fn compile_flood() -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join("boxlite-stress-bins");
+    std::fs::create_dir_all(&dir).unwrap();
+    let bin = dir.join("flood");
+    if bin.exists() {
+        return bin;
+    }
+    let src = dir.join("flood.c");
+    std::fs::write(
+        &src,
+        r#"
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+int main(int c, char **v) {
+    int n = c > 1 ? atoi(v[1]) : 100;
+    int mb = c > 2 ? atoi(v[2]) : 2;
+    int i;
+    for (i = 0; i < n; i++) {
+        if (fork() == 0) {
+            char *m = malloc(mb << 20);
+            if (m) memset(m, 0x42, mb << 20);
+            pause();
+            _exit(0);
+        }
+    }
+    printf("forked %d x %dMB\n", i, mb);
+    fflush(stdout);
+    pause();
+}
+"#,
+    )
+    .unwrap();
+    let out = std::process::Command::new("musl-gcc")
+        .args(["-static", "-o"])
+        .arg(&bin)
+        .arg(&src)
+        .output()
+        .expect("musl-gcc not found — apt install musl-tools");
+    assert!(
+        out.status.success(),
+        "musl-gcc failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    bin
+}
+
+fn base64_encode(path: &std::path::Path) -> String {
+    use base64::Engine;
+    let data = std::fs::read(path).unwrap();
+    base64::engine::general_purpose::STANDARD.encode(&data)
+}
+
+/// 128MB VM, install gcc (eats cache), fork 200 children each memset 2MB.
+/// Without cgroup this panics the VM ~2/3 of the time.
+/// With cgroup memory.max + pids.max: 100% survival.
+#[test]
+fn stress_128mb_gcc_fork_200x2mb() {
+    let home = PerTestBoxHome::new();
+    let flood = compile_flood();
+    let b64 = base64_encode(&flood);
+
+    // Start 128MB box
+    let out = Command::new(env!("CARGO_BIN_EXE_boxlite"))
+        .args([
+            "--home",
+            home.path.to_str().unwrap(),
+            "--registry",
+            "docker.m.daocloud.io",
+            "run",
+            "-d",
+            "--memory",
+            "128",
+            "alpine:latest",
+            "sleep",
+            "600",
+        ])
+        .timeout(Duration::from_secs(300))
+        .output()
+        .expect("failed to start box");
+    assert!(out.status.success(), "box start failed");
+    let box_id = String::from_utf8_lossy(&out.stdout).trim().to_string();
+
+    // Install gcc (real-world memory pressure source)
+    let out = Command::new(env!("CARGO_BIN_EXE_boxlite"))
+        .args([
+            "--home",
+            home.path.to_str().unwrap(),
+            "exec",
+            &box_id,
+            "--",
+            "sh",
+            "-c",
+            "apk add -q --no-cache gcc musl-dev 2>/dev/null && echo ok",
+        ])
+        .timeout(Duration::from_secs(120))
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("ok"), "gcc install failed");
+
+    // Compile flood inside box
+    let compile_cmd = format!(
+        "cat > /tmp/f.c << 'CEOF'\n\
+         #include <stdlib.h>\n#include <string.h>\n#include <unistd.h>\n#include <stdio.h>\n\
+         int main(int c,char**v){{int n=c>1?atoi(v[1]):100,i;for(i=0;i<n;i++){{if(fork()==0){{char*m=malloc(2<<20);if(m)memset(m,66,2<<20);pause();_exit(0);}}}}\
+         printf(\"forked %d\\n\",i);fflush(stdout);pause();}}\n\
+         CEOF\n\
+         gcc -o /tmp/f /tmp/f.c && echo compiled"
+    );
+    let out = Command::new(env!("CARGO_BIN_EXE_boxlite"))
+        .args([
+            "--home",
+            home.path.to_str().unwrap(),
+            "exec",
+            &box_id,
+            "--",
+            "sh",
+            "-c",
+            &compile_cmd,
+        ])
+        .timeout(Duration::from_secs(60))
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("compiled"), "flood compile failed");
+
+    // Run 200×2MB fork bomb
+    let _ = Command::new(env!("CARGO_BIN_EXE_boxlite"))
+        .args([
+            "--home",
+            home.path.to_str().unwrap(),
+            "exec",
+            &box_id,
+            "--",
+            "/tmp/f",
+            "200",
+        ])
+        .timeout(Duration::from_secs(5))
+        .output();
+
+    std::thread::sleep(Duration::from_secs(15));
+
+    // Assert box survived
+    let out = Command::new(env!("CARGO_BIN_EXE_boxlite"))
+        .args(["--home", home.path.to_str().unwrap(), "list"])
+        .timeout(Duration::from_secs(10))
+        .output()
+        .unwrap();
+    let list = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        list.contains("Running"),
+        "box must survive 128MB + gcc + 200×2MB fork bomb; got: {list}"
+    );
+
+    // Assert exec still works
+    let out = Command::new(env!("CARGO_BIN_EXE_boxlite"))
+        .args([
+            "--home",
+            home.path.to_str().unwrap(),
+            "exec",
+            &box_id,
+            "--",
+            "echo",
+            "alive",
+        ])
+        .timeout(Duration::from_secs(10))
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "exec must work after OOM pressure");
+}

--- a/src/cli/tests/stress_oom.rs
+++ b/src/cli/tests/stress_oom.rs
@@ -1,82 +1,120 @@
-//! Integration stress test: cgroup memory.max + pids.max prevent VM panic.
+//! Integration stress test: container cgroup `memory.max` + `pids.max` keep a
+//! hostile workload from panicking the guest VM kernel.
 //!
-//! 128MB VM + gcc install + 200×2MB fork+malloc+memset — without cgroup
-//! this kills the VM 2/3 of the time. With cgroup it survives 100%.
+//! One 128 MB box is driven through three escalating attack waves, each of
+//! which tends to take down an unprotected tiny VM: a pids bomb (fork 1000 idle
+//! children, which `pids.max` = 512 must cap before PID/kernel-memory
+//! exhaustion), a memory bomb (one child mallocs+touches 512 MB — 4× the VM —
+//! which `memory.max` must OOM-kill on its own), and a combined wave (200
+//! children each touching 2 MB). After every wave the VM must still be
+//! `Running` and accept a fresh exec, proving the cgroup OOM killer hit only
+//! container processes — never the guest kernel or agent.
 //!
-//! Requires: musl-gcc on the host (apt install musl-tools).
+//! Requires a VM-capable host with network to pull `alpine` and `apk add gcc`.
 
 use assert_cmd::Command;
 use boxlite_test_utils::home::PerTestBoxHome;
+use std::path::Path;
 use std::time::Duration;
 
-fn compile_flood() -> std::path::PathBuf {
-    let dir = std::env::temp_dir().join("boxlite-stress-bins");
-    std::fs::create_dir_all(&dir).unwrap();
-    let bin = dir.join("flood");
-    if bin.exists() {
-        return bin;
-    }
-    let src = dir.join("flood.c");
-    std::fs::write(
-        &src,
-        r#"
+/// `boxlite --home <home> <args...>` with a timeout.
+fn boxlite(home: &Path, args: &[&str], timeout: Duration) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_boxlite"))
+        .arg("--home")
+        .arg(home)
+        .args(args)
+        .timeout(timeout)
+        .output()
+        .expect("spawn boxlite")
+}
+
+/// `boxlite exec <box> -- sh -c <script>`.
+fn exec_sh(home: &Path, box_id: &str, script: &str, timeout: Duration) -> std::process::Output {
+    boxlite(home, &["exec", box_id, "--", "sh", "-c", script], timeout)
+}
+
+/// The VM is healthy iff it still lists as `Running` and a fresh exec succeeds.
+/// A guest-kernel panic or dead agent fails one or both.
+fn assert_vm_survives(home: &Path, box_id: &str, ctx: &str) {
+    let list = boxlite(home, &["list"], Duration::from_secs(15));
+    let listing = String::from_utf8_lossy(&list.stdout);
+    assert!(
+        listing.contains("Running"),
+        "VM must survive {ctx}, but it is no longer Running; `list` =\n{listing}"
+    );
+    let echo = boxlite(
+        home,
+        &["exec", box_id, "--", "echo", "alive"],
+        Duration::from_secs(15),
+    );
+    assert!(
+        echo.status.success(),
+        "guest agent must accept exec after {ctx}; stderr = {}",
+        String::from_utf8_lossy(&echo.stderr)
+    );
+}
+
+/// flood <n> <mb>: fork n children; each (if mb>0) malloc+memset mb MiB to fault
+/// it in as RSS, then sleep briefly and exit so waves don't accumulate. The
+/// parent prints how many forks actually succeeded (fewer than n once pids.max
+/// blocks them) and exits immediately.
+const FLOOD_C: &str = r#"
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 #include <stdio.h>
 int main(int c, char **v) {
     int n = c > 1 ? atoi(v[1]) : 100;
-    int mb = c > 2 ? atoi(v[2]) : 2;
-    int i;
+    long mb = c > 2 ? atol(v[2]) : 2;
+    int i, forked = 0;
     for (i = 0; i < n; i++) {
-        if (fork() == 0) {
-            char *m = malloc(mb << 20);
-            if (m) memset(m, 0x42, mb << 20);
-            pause();
+        pid_t p = fork();
+        if (p == 0) {
+            if (mb > 0) { char *m = malloc((size_t)mb << 20); if (m) memset(m, 66, (size_t)mb << 20); }
+            sleep(20);
             _exit(0);
         }
+        if (p > 0) forked++;
     }
-    printf("forked %d x %dMB\n", i, mb);
+    printf("forked %d/%d x %ldMB\n", forked, n, mb);
     fflush(stdout);
-    pause();
+    return 0;
 }
-"#,
-    )
-    .unwrap();
-    let out = std::process::Command::new("musl-gcc")
-        .args(["-static", "-o"])
-        .arg(&bin)
-        .arg(&src)
-        .output()
-        .expect("musl-gcc not found — apt install musl-tools");
-    assert!(
-        out.status.success(),
-        "musl-gcc failed: {}",
-        String::from_utf8_lossy(&out.stderr)
+"#;
+
+/// Run one attack wave, then assert the VM survived and reset the box for the
+/// next wave by killing any lingering flood children.
+fn run_wave(home: &Path, box_id: &str, n: u32, mb: u32, ctx: &str) {
+    // The parent exits right after forking; give the cgroup a moment to OOM-kill
+    // / block, then assert survival before cleaning up.
+    let _ = exec_sh(
+        home,
+        box_id,
+        &format!("/tmp/flood {n} {mb} || true"),
+        Duration::from_secs(30),
     );
-    bin
+    std::thread::sleep(Duration::from_secs(8));
+    assert_vm_survives(home, box_id, ctx);
+    // Reap survivors so the next wave starts from a clean slate.
+    let _ = exec_sh(
+        home,
+        box_id,
+        "pkill -9 -x flood || true",
+        Duration::from_secs(15),
+    );
+    std::thread::sleep(Duration::from_secs(2));
 }
 
-fn base64_encode(path: &std::path::Path) -> String {
-    use base64::Engine;
-    let data = std::fs::read(path).unwrap();
-    base64::engine::general_purpose::STANDARD.encode(&data)
-}
-
-/// 128MB VM, install gcc (eats cache), fork 200 children each memset 2MB.
-/// Without cgroup this panics the VM ~2/3 of the time.
-/// With cgroup memory.max + pids.max: 100% survival.
+/// 128 MB box, gcc-compiled flood, driven through pids → memory → combined
+/// attack waves. Without the cgroup limits a tiny VM panics under these; with
+/// `memory.max` + `pids.max` it survives every wave.
 #[test]
-fn stress_128mb_gcc_fork_200x2mb() {
+fn cgroup_limits_keep_vm_alive_under_pids_and_memory_bombs() {
     let home = PerTestBoxHome::new();
-    let flood = compile_flood();
-    let b64 = base64_encode(&flood);
 
-    // Start 128MB box
-    let out = Command::new(env!("CARGO_BIN_EXE_boxlite"))
-        .args([
-            "--home",
-            home.path.to_str().unwrap(),
+    let out = boxlite(
+        home.path.as_path(),
+        &[
             "--registry",
             "docker.m.daocloud.io",
             "run",
@@ -86,98 +124,66 @@ fn stress_128mb_gcc_fork_200x2mb() {
             "alpine:latest",
             "sleep",
             "600",
-        ])
-        .timeout(Duration::from_secs(300))
-        .output()
-        .expect("failed to start box");
-    assert!(out.status.success(), "box start failed");
+        ],
+        Duration::from_secs(300),
+    );
+    assert!(
+        out.status.success(),
+        "box start failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
     let box_id = String::from_utf8_lossy(&out.stdout).trim().to_string();
 
-    // Install gcc (real-world memory pressure source)
-    let out = Command::new(env!("CARGO_BIN_EXE_boxlite"))
-        .args([
-            "--home",
-            home.path.to_str().unwrap(),
-            "exec",
-            &box_id,
-            "--",
-            "sh",
-            "-c",
-            "apk add -q --no-cache gcc musl-dev 2>/dev/null && echo ok",
-        ])
-        .timeout(Duration::from_secs(120))
-        .output()
-        .unwrap();
-    let stdout = String::from_utf8_lossy(&out.stdout);
-    assert!(stdout.contains("ok"), "gcc install failed");
-
-    // Compile flood inside box
-    let compile_cmd = format!(
-        "cat > /tmp/f.c << 'CEOF'\n\
-         #include <stdlib.h>\n#include <string.h>\n#include <unistd.h>\n#include <stdio.h>\n\
-         int main(int c,char**v){{int n=c>1?atoi(v[1]):100,i;for(i=0;i<n;i++){{if(fork()==0){{char*m=malloc(2<<20);if(m)memset(m,66,2<<20);pause();_exit(0);}}}}\
-         printf(\"forked %d\\n\",i);fflush(stdout);pause();}}\n\
-         CEOF\n\
-         gcc -o /tmp/f /tmp/f.c && echo compiled"
+    // Toolchain to build the flood in-box (a real source of memory pressure too).
+    let install = exec_sh(
+        home.path.as_path(),
+        &box_id,
+        "apk add -q --no-cache gcc musl-dev >/dev/null 2>&1 && echo ok",
+        Duration::from_secs(180),
     );
-    let out = Command::new(env!("CARGO_BIN_EXE_boxlite"))
-        .args([
-            "--home",
-            home.path.to_str().unwrap(),
-            "exec",
-            &box_id,
-            "--",
-            "sh",
-            "-c",
-            &compile_cmd,
-        ])
-        .timeout(Duration::from_secs(60))
-        .output()
-        .unwrap();
-    let stdout = String::from_utf8_lossy(&out.stdout);
-    assert!(stdout.contains("compiled"), "flood compile failed");
-
-    // Run 200×2MB fork bomb
-    let _ = Command::new(env!("CARGO_BIN_EXE_boxlite"))
-        .args([
-            "--home",
-            home.path.to_str().unwrap(),
-            "exec",
-            &box_id,
-            "--",
-            "/tmp/f",
-            "200",
-        ])
-        .timeout(Duration::from_secs(5))
-        .output();
-
-    std::thread::sleep(Duration::from_secs(15));
-
-    // Assert box survived
-    let out = Command::new(env!("CARGO_BIN_EXE_boxlite"))
-        .args(["--home", home.path.to_str().unwrap(), "list"])
-        .timeout(Duration::from_secs(10))
-        .output()
-        .unwrap();
-    let list = String::from_utf8_lossy(&out.stdout);
     assert!(
-        list.contains("Running"),
-        "box must survive 128MB + gcc + 200×2MB fork bomb; got: {list}"
+        String::from_utf8_lossy(&install.stdout).contains("ok"),
+        "gcc install failed: {}",
+        String::from_utf8_lossy(&install.stderr)
     );
 
-    // Assert exec still works
-    let out = Command::new(env!("CARGO_BIN_EXE_boxlite"))
-        .args([
-            "--home",
-            home.path.to_str().unwrap(),
-            "exec",
-            &box_id,
-            "--",
-            "echo",
-            "alive",
-        ])
-        .timeout(Duration::from_secs(10))
-        .output()
-        .unwrap();
-    assert!(out.status.success(), "exec must work after OOM pressure");
+    let compile = format!(
+        "cat > /tmp/flood.c << 'CEOF'\n{FLOOD_C}\nCEOF\ngcc -O0 -o /tmp/flood /tmp/flood.c && echo compiled"
+    );
+    let out = exec_sh(
+        home.path.as_path(),
+        &box_id,
+        &compile,
+        Duration::from_secs(90),
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("compiled"),
+        "flood compile failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // Wave 1 — pids bomb: 1000 idle forks vs pids.max = 512.
+    run_wave(
+        home.path.as_path(),
+        &box_id,
+        1000,
+        0,
+        "a 1000-fork pids bomb",
+    );
+    // Wave 2 — memory bomb: one process grabs 512 MB in a 128 MB VM.
+    run_wave(
+        home.path.as_path(),
+        &box_id,
+        1,
+        512,
+        "a single 512 MB allocation",
+    );
+    // Wave 3 — combined: 200 children each touch 2 MB.
+    run_wave(
+        home.path.as_path(),
+        &box_id,
+        200,
+        2,
+        "a 200×2 MB fork+alloc bomb",
+    );
 }

--- a/src/cli/tests/stress_oom.rs
+++ b/src/cli/tests/stress_oom.rs
@@ -1,14 +1,14 @@
-//! Integration stress test: container cgroup `memory.max` + `pids.max` keep a
-//! hostile workload from panicking the guest VM kernel.
+//! Integration tests for the container cgroup resource guard (`memory.max` +
+//! `pids.max`) that keeps a hostile workload from taking down the guest VM.
 //!
-//! One 128 MB box is driven through three escalating attack waves, each of
-//! which tends to take down an unprotected tiny VM: a pids bomb (fork 1000 idle
-//! children, which `pids.max` = 512 must cap before PID/kernel-memory
-//! exhaustion), a memory bomb (one child mallocs+touches 512 MB — 4× the VM —
-//! which `memory.max` must OOM-kill on its own), and a combined wave (200
-//! children each touching 2 MB). After every wave the VM must still be
-//! `Running` and accept a fresh exec, proving the cgroup OOM killer hit only
-//! container processes — never the guest kernel or agent.
+//! Two angles, both against a real 128 MB box:
+//!   - enforcement — the limits are actually written to the container's own
+//!     cgroup (`/boxlite/<id>/memory.max` bounded, `pids.max` = 512), so a
+//!     regression that drops the resources or re-disables cgroups (leaving the
+//!     container in the root) is caught directly.
+//!   - survival — the VM stays `Running` and keeps serving exec through three
+//!     escalating attack waves (a 1000-fork pids bomb, a single 512 MB malloc
+//!     in a 128 MB VM, and a 200×2 MB fork+alloc bomb).
 //!
 //! Requires a VM-capable host with network to pull `alpine` and `apk add gcc`.
 
@@ -33,24 +33,97 @@ fn exec_sh(home: &Path, box_id: &str, script: &str, timeout: Duration) -> std::p
     boxlite(home, &["exec", box_id, "--", "sh", "-c", script], timeout)
 }
 
-/// The VM is healthy iff it still lists as `Running` and a fresh exec succeeds.
-/// A guest-kernel panic or dead agent fails one or both.
-fn assert_vm_survives(home: &Path, box_id: &str, ctx: &str) {
-    let list = boxlite(home, &["list"], Duration::from_secs(15));
-    let listing = String::from_utf8_lossy(&list.stdout);
-    assert!(
-        listing.contains("Running"),
-        "VM must survive {ctx}, but it is no longer Running; `list` =\n{listing}"
-    );
-    let echo = boxlite(
+/// Force-removes a box on drop so the `PerTestBoxHome` live-shim guard can't
+/// fire and mask the real failure. Declare it *after* the home so it drops
+/// first (reverse declaration order).
+struct BoxCleanup {
+    home: std::path::PathBuf,
+    id: String,
+}
+impl Drop for BoxCleanup {
+    fn drop(&mut self) {
+        let _ = boxlite(&self.home, &["rm", "-f", &self.id], Duration::from_secs(30));
+    }
+}
+
+/// Start a detached 128 MB alpine box running `sleep 600`; returns its id.
+fn start_128mb_box(home: &Path) -> String {
+    let out = boxlite(
         home,
-        &["exec", box_id, "--", "echo", "alive"],
-        Duration::from_secs(15),
+        &[
+            "--registry",
+            "docker.m.daocloud.io",
+            "run",
+            "-d",
+            "--memory",
+            "128",
+            "alpine:latest",
+            "sleep",
+            "600",
+        ],
+        Duration::from_secs(300),
     );
     assert!(
-        echo.status.success(),
-        "guest agent must accept exec after {ctx}; stderr = {}",
-        String::from_utf8_lossy(&echo.stderr)
+        out.status.success(),
+        "box start failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+/// Directly verifies the limits are applied to the container's own cgroup: a
+/// `/boxlite/<id>` path with `memory.max` bounded below the VM and `pids.max`
+/// = 512. Guards both the explicit cgroups_path and that the resources are
+/// written — dropping either (or re-disabling cgroups, which puts the
+/// container back in the root) fails here.
+#[test]
+fn cgroup_limits_are_enforced_on_the_container() {
+    let home = PerTestBoxHome::new();
+    let box_id = start_128mb_box(home.path.as_path());
+    let _cleanup = BoxCleanup {
+        home: home.path.clone(),
+        id: box_id.clone(),
+    };
+
+    // Read the container's own cgroup path and its controller files.
+    let out = exec_sh(
+        home.path.as_path(),
+        &box_id,
+        "cg=$(sed 's/^0:://' /proc/self/cgroup); \
+         printf 'CG=%s\\nMEM=%s\\nPIDS=%s\\n' \
+           \"$cg\" \
+           \"$(cat /sys/fs/cgroup$cg/memory.max 2>&1)\" \
+           \"$(cat /sys/fs/cgroup$cg/pids.max 2>&1)\"",
+        Duration::from_secs(30),
+    );
+    let report = String::from_utf8_lossy(&out.stdout);
+    let field = |key: &str| -> String {
+        report
+            .lines()
+            .find_map(|l| l.strip_prefix(key))
+            .unwrap_or("")
+            .trim()
+            .to_string()
+    };
+
+    let cg = field("CG=");
+    let mem = field("MEM=");
+    let pids = field("PIDS=");
+
+    assert!(
+        cg.starts_with("/boxlite/"),
+        "container must run in its own /boxlite/<id> cgroup, not the root; got {cg:?}\n{report}"
+    );
+    let mem_max: u64 = mem.parse().unwrap_or_else(|_| {
+        panic!("memory.max must be a concrete byte cap, not {mem:?} (cgroup not applied)\n{report}")
+    });
+    assert!(
+        mem_max > 0 && mem_max < 128 * 1024 * 1024,
+        "memory.max ({mem_max}) must be a positive cap below the 128 MB VM\n{report}"
+    );
+    assert_eq!(
+        pids, "512",
+        "pids.max must be the CONTAINER_PIDS_MAX ceiling\n{report}"
     );
 }
 
@@ -82,6 +155,27 @@ int main(int c, char **v) {
 }
 "#;
 
+/// The VM is healthy iff it still lists as `Running` and a fresh exec succeeds.
+/// A guest-kernel panic or dead agent fails one or both.
+fn assert_vm_survives(home: &Path, box_id: &str, ctx: &str) {
+    let list = boxlite(home, &["list"], Duration::from_secs(15));
+    let listing = String::from_utf8_lossy(&list.stdout);
+    assert!(
+        listing.contains("Running"),
+        "VM must survive {ctx}, but it is no longer Running; `list` =\n{listing}"
+    );
+    let echo = boxlite(
+        home,
+        &["exec", box_id, "--", "echo", "alive"],
+        Duration::from_secs(15),
+    );
+    assert!(
+        echo.status.success(),
+        "guest agent must accept exec after {ctx}; stderr = {}",
+        String::from_utf8_lossy(&echo.stderr)
+    );
+}
+
 /// Run one attack wave, then assert the VM survived and reset the box for the
 /// next wave by killing any lingering flood children.
 fn run_wave(home: &Path, box_id: &str, n: u32, mb: u32, ctx: &str) {
@@ -106,33 +200,16 @@ fn run_wave(home: &Path, box_id: &str, n: u32, mb: u32, ctx: &str) {
 }
 
 /// 128 MB box, gcc-compiled flood, driven through pids → memory → combined
-/// attack waves. Without the cgroup limits a tiny VM panics under these; with
-/// `memory.max` + `pids.max` it survives every wave.
+/// attack waves. The container's `memory.max` + `pids.max` keep the OOM kills
+/// scoped to container processes so the guest kernel and agent stay up.
 #[test]
 fn cgroup_limits_keep_vm_alive_under_pids_and_memory_bombs() {
     let home = PerTestBoxHome::new();
-
-    let out = boxlite(
-        home.path.as_path(),
-        &[
-            "--registry",
-            "docker.m.daocloud.io",
-            "run",
-            "-d",
-            "--memory",
-            "128",
-            "alpine:latest",
-            "sleep",
-            "600",
-        ],
-        Duration::from_secs(300),
-    );
-    assert!(
-        out.status.success(),
-        "box start failed: {}",
-        String::from_utf8_lossy(&out.stderr)
-    );
-    let box_id = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    let box_id = start_128mb_box(home.path.as_path());
+    let _cleanup = BoxCleanup {
+        home: home.path.clone(),
+        id: box_id.clone(),
+    };
 
     // Toolchain to build the flood in-box (a real source of memory pressure too).
     let install = exec_sh(

--- a/src/guest/src/container/cgroup_carve.rs
+++ b/src/guest/src/container/cgroup_carve.rs
@@ -1,0 +1,254 @@
+//! Cgroup hierarchy carve-out for the workload / operator split.
+//!
+//! ```text
+//! /sys/fs/cgroup/boxlite/<id>/                  parent (no processes, only delegates)
+//!     ├── workload/                              container init + container processes
+//!     │   pids.max = 512
+//!     │   memory.max = container_memory_limit()
+//!     └── operator/                              `boxlite exec`-spawned processes
+//!         pids.max = OPERATOR_PIDS_MAX (64)
+//!         memory.max = OPERATOR_MEMORY_BYTES
+//! ```
+//!
+//! The split solves a problem the original single-cgroup design has: a
+//! workload that saturates `/boxlite/<id>`'s `pids.max=512` also blocks every
+//! `boxlite exec` attempt (libcontainer's tenant builder spawns the exec'd
+//! process in the same cgroup, and the cgroup is full). By giving operator
+//! processes a separate sibling subgroup with its own small budget, the
+//! workload's cap saturation no longer locks the operator out of the box —
+//! they can always exec in to inspect / kill the runaway.
+//!
+//! This module owns ONLY the cgroup-directory layout (mkdir + write
+//! `pids.max` / `memory.max` / `cgroup.subtree_control`). libcontainer still
+//! mkdirs and writes limits to `<parent>/workload` on container start because
+//! the OCI spec's `cgroupsPath` points there; this module pre-creates the
+//! parent + the operator sibling around it.
+
+use boxlite_shared::errors::{BoxliteError, BoxliteResult};
+use std::fs;
+use std::path::PathBuf;
+
+/// Hard ceiling on the operator subgroup. Enough to cover a few interactive
+/// shells / probes; small enough that an operator script run amok also gets
+/// throttled. Tuned for "the operator's debug session" not "the operator's
+/// workload" — workloads belong in the workload subgroup.
+const OPERATOR_PIDS_MAX: u64 = 64;
+
+/// Memory budget for the operator subgroup. The parent's total budget is
+/// `workload_memory + OPERATOR_MEMORY_BYTES`, so the operator can never
+/// starve the workload by allocating heavily inside the box.
+const OPERATOR_MEMORY_BYTES: u64 = 32 * 1024 * 1024;
+
+const CGROUP_ROOT: &str = "/sys/fs/cgroup";
+
+/// Absolute on-disk path to `/sys/fs/cgroup/boxlite/<id>`.
+fn parent_path(container_id: &str) -> PathBuf {
+    PathBuf::from(CGROUP_ROOT)
+        .join("boxlite")
+        .join(container_id)
+}
+
+/// Pre-create the carve-out hierarchy so libcontainer can spawn container
+/// init into `<parent>/workload` and `boxlite exec` can target
+/// `<parent>/operator`. Idempotent: existing directories are left alone (so
+/// recovery after a crash doesn't error out).
+///
+/// Must run BEFORE `libcontainer::ContainerBuilder::build()` for the
+/// container, otherwise libcontainer's own `mkdir <parent>/workload` succeeds
+/// but the parent has no `subtree_control` delegation and the operator
+/// subgroup never gets its controllers.
+pub(crate) fn ensure_box_cgroup_hierarchy(container_id: &str) -> BoxliteResult<()> {
+    // Called AFTER libcontainer's start_container — libcontainer is the one
+    // that mkdirs `/sys/fs/cgroup/boxlite/<id>/workload` and walks the
+    // `subtree_control` chain (root → boxlite → boxlite/<id>) to delegate
+    // `+pids` `+memory` controllers down. By the time we run here the parent
+    // has both controllers available; mkdir'ing the operator sibling creates
+    // a cgroup that inherits those, so its `pids.max` / `memory.max` files
+    // exist and we can write the caps below.
+    let parent = parent_path(container_id);
+    if !parent.exists() {
+        return Err(BoxliteError::Internal(format!(
+            "cgroup parent {} does not exist — libcontainer didn't run \
+             before ensure_box_cgroup_hierarchy",
+            parent.display()
+        )));
+    }
+
+    let operator = parent.join("operator");
+    create_dir_idempotent(&operator)?;
+
+    // Write operator caps. Best-effort: a controller that isn't delegated
+    // (e.g. memory under a misconfigured rootless host) shouldn't fail box
+    // creation, just log so operators can see the degraded protection.
+    write_cap(&operator.join("pids.max"), &OPERATOR_PIDS_MAX.to_string());
+    write_cap(
+        &operator.join("memory.max"),
+        &OPERATOR_MEMORY_BYTES.to_string(),
+    );
+
+    tracing::info!(
+        container_id,
+        parent = %parent.display(),
+        operator_pids_max = OPERATOR_PIDS_MAX,
+        operator_memory_bytes = OPERATOR_MEMORY_BYTES,
+        "Pre-created /boxlite/<id>/{{workload,operator}} carve-out"
+    );
+    Ok(())
+}
+
+/// Tear down the carve-out on container removal. Recursively rmdir's
+/// `/boxlite/<id>/{workload,operator}` then `/boxlite/<id>`. Best-effort:
+/// rmdir on a non-empty cgroup errors with EBUSY, which is expected if
+/// processes are still attached; the box-lifecycle code calls this AFTER
+/// it has SIGKILL'd everything inside.
+pub(crate) fn remove_box_cgroup_hierarchy(container_id: &str) {
+    let parent = parent_path(container_id);
+    for child in ["workload", "operator"] {
+        let p = parent.join(child);
+        if p.exists() {
+            if let Err(e) = fs::remove_dir(&p) {
+                tracing::debug!(
+                    cgroup = %p.display(),
+                    error = %e,
+                    "Failed to rmdir cgroup subgroup during cleanup (probably already gone or still has processes)"
+                );
+            }
+        }
+    }
+    if parent.exists() {
+        if let Err(e) = fs::remove_dir(&parent) {
+            tracing::debug!(
+                cgroup = %parent.display(),
+                error = %e,
+                "Failed to rmdir cgroup parent during cleanup"
+            );
+        }
+    }
+}
+
+fn create_dir_idempotent(p: &std::path::Path) -> BoxliteResult<()> {
+    match fs::create_dir(p) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Ok(()),
+        Err(e) => Err(BoxliteError::Internal(format!(
+            "Failed to create cgroup directory {}: {e}",
+            p.display()
+        ))),
+    }
+}
+
+fn write_cap(path: &std::path::Path, value: &str) {
+    if let Err(e) = fs::write(path, value) {
+        tracing::warn!(
+            path = %path.display(),
+            value,
+            error = %e,
+            "Failed to write cgroup cap"
+        );
+    }
+}
+
+/// Path to a container's OCI bundle `config.json` — read by libcontainer's
+/// tenant builder at every `boxlite exec`. Kept private here so the swap
+/// helpers below are the only call sites that mutate it.
+fn bundle_config_path(container_id: &str) -> PathBuf {
+    use boxlite_shared::layout::{dirs, GUEST_BASE};
+    PathBuf::from(GUEST_BASE)
+        .join(dirs::CONTAINERS)
+        .join(container_id)
+        .join("config.json")
+}
+
+/// Rewrite the OCI bundle's `cgroupsPath` from `/boxlite/<id>/workload` to
+/// `/boxlite/<id>/operator` so the next `tenant_builder.build()` reads the
+/// operator path. Called immediately before a `boxlite exec` build; paired
+/// with [`restore_workload_cgroup_path`] called on the way out (success or
+/// failure). Caller must hold the container mutex to serialize swaps —
+/// concurrent execs would clobber each other's config.json without it.
+///
+/// Text-replacement rather than parse-modify-serialize: the substring
+/// `/boxlite/<id>/workload` is unique enough that the simpler approach is
+/// safe and avoids the cost of round-tripping the entire 4 KiB spec through
+/// `oci-spec`.
+pub(crate) fn swap_to_operator_cgroup_path(container_id: &str) -> BoxliteResult<()> {
+    let path = bundle_config_path(container_id);
+    let content = fs::read_to_string(&path).map_err(|e| {
+        BoxliteError::Internal(format!(
+            "Failed to read OCI config for cgroup swap {}: {e}",
+            path.display()
+        ))
+    })?;
+    let workload = format!("/boxlite/{container_id}/workload");
+    let operator = format!("/boxlite/{container_id}/operator");
+    let modified = content.replace(&workload, &operator);
+    if modified == content {
+        return Err(BoxliteError::Internal(format!(
+            "cgroupsPath swap found no `{workload}` to replace in {} — \
+             container was created without the workload-subgroup carve-out, \
+             so operator exec cannot be routed to its own subgroup",
+            path.display()
+        )));
+    }
+    fs::write(&path, modified).map_err(|e| {
+        BoxliteError::Internal(format!(
+            "Failed to write OCI config for cgroup swap {}: {e}",
+            path.display()
+        ))
+    })?;
+    Ok(())
+}
+
+/// Reverse of [`swap_to_operator_cgroup_path`]. Best-effort: errors are
+/// logged but not propagated, since the caller is already in the cleanup
+/// path of an exec call. A failure here leaves the bundle pointing at
+/// `/operator` for the NEXT exec — which would still work (operator
+/// processes go to operator subgroup) and self-heals on the subsequent
+/// successful pairing.
+pub(crate) fn restore_workload_cgroup_path(container_id: &str) {
+    let path = bundle_config_path(container_id);
+    let Ok(content) = fs::read_to_string(&path) else {
+        tracing::warn!(
+            container_id,
+            path = %path.display(),
+            "Failed to read OCI config for cgroup restore"
+        );
+        return;
+    };
+    let workload = format!("/boxlite/{container_id}/workload");
+    let operator = format!("/boxlite/{container_id}/operator");
+    let restored = content.replace(&operator, &workload);
+    if restored != content {
+        if let Err(e) = fs::write(&path, restored) {
+            tracing::warn!(
+                container_id,
+                path = %path.display(),
+                error = %e,
+                "Failed to write OCI config restoring workload cgroupsPath — \
+                 next exec will read the wrong path; investigate ASAP"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pure function: confirm the operator path matches what spec.rs's
+    /// `operator_cgroup_path` returns (the two MUST agree — that's the
+    /// contract between this module and the exec swap).
+    #[test]
+    fn operator_path_format_matches_spec() {
+        let id = "test-id";
+        let from_carve = parent_path(id).join("operator");
+        let from_spec = crate::container::spec::operator_cgroup_path(id);
+        assert_eq!(
+            from_carve
+                .to_string_lossy()
+                .trim_start_matches("/sys/fs/cgroup"),
+            from_spec,
+            "the operator cgroup path used by carve-out must equal the one \
+             written into OCI spec for exec — drift breaks the swap"
+        );
+    }
+}

--- a/src/guest/src/container/cgroup_carve.rs
+++ b/src/guest/src/container/cgroup_carve.rs
@@ -178,8 +178,8 @@ pub(crate) fn swap_to_operator_cgroup_path(container_id: &str) -> BoxliteResult<
             path.display()
         ))
     })?;
-    let workload = format!("/boxlite/{container_id}/workload");
-    let operator = format!("/boxlite/{container_id}/operator");
+    let workload = super::spec::workload_cgroup_path(container_id);
+    let operator = super::spec::operator_cgroup_path(container_id);
     let modified = content.replace(&workload, &operator);
     if modified == content {
         return Err(BoxliteError::Internal(format!(
@@ -214,8 +214,8 @@ pub(crate) fn restore_workload_cgroup_path(container_id: &str) {
         );
         return;
     };
-    let workload = format!("/boxlite/{container_id}/workload");
-    let operator = format!("/boxlite/{container_id}/operator");
+    let workload = super::spec::workload_cgroup_path(container_id);
+    let operator = super::spec::operator_cgroup_path(container_id);
     let restored = content.replace(&operator, &workload);
     if restored != content {
         if let Err(e) = fs::write(&path, restored) {

--- a/src/guest/src/container/lifecycle.rs
+++ b/src/guest/src/container/lifecycle.rs
@@ -173,6 +173,21 @@ impl Container {
         start::create_container_with_stdio(container_id, &state_root, &bundle_path, init_fds)?;
         start::start_container(container_id, &state_root)?;
 
+        // Carve out the operator sibling AFTER libcontainer has finished its
+        // own setup — libcontainer is the one that walks `/sys/fs/cgroup/...`
+        // and writes `+pids +memory` into the chain of `subtree_control`
+        // files (root → boxlite → boxlite/<id>) to delegate controllers down.
+        // Running our mkdir before that finishes left `cgroup.controllers`
+        // empty in `/boxlite/<id>`, so the operator subgroup never got
+        // `pids.max` / `memory.max` files at all.
+        if let Err(e) = super::cgroup_carve::ensure_box_cgroup_hierarchy(container_id) {
+            tracing::warn!(
+                container_id,
+                error = %e,
+                "cgroup carve-out failed; container will start but operator-lockout protection is degraded"
+            );
+        }
+
         Ok(Self {
             id: container_id.to_string(),
             state_root,
@@ -465,6 +480,13 @@ impl Drop for Container {
         }
 
         start::cleanup_bundle_directory(&self.bundle_path);
+
+        // Remove the cgroup carve-out. libcontainer's `delete_container`
+        // already rmdirs `<parent>/workload`; this also rmdirs the operator
+        // sibling and the parent so the next box with this id starts clean.
+        // Best-effort: rmdir errors mean processes are still attached
+        // (already logged in cgroup_carve).
+        super::cgroup_carve::remove_box_cgroup_hierarchy(&self.id);
 
         tracing::debug!(container_id = %self.id, "Container cleanup complete");
     }

--- a/src/guest/src/container/mod.rs
+++ b/src/guest/src/container/mod.rs
@@ -60,6 +60,8 @@
 #[cfg(target_os = "linux")]
 mod capabilities;
 #[cfg(target_os = "linux")]
+pub(crate) mod cgroup_carve;
+#[cfg(target_os = "linux")]
 mod command;
 #[cfg(target_os = "linux")]
 mod console_socket;
@@ -68,7 +70,7 @@ mod kill;
 #[cfg(target_os = "linux")]
 mod lifecycle;
 #[cfg(target_os = "linux")]
-mod spec;
+pub(crate) mod spec;
 #[cfg(target_os = "linux")]
 mod start;
 #[cfg(target_os = "linux")]

--- a/src/guest/src/container/spec.rs
+++ b/src/guest/src/container/spec.rs
@@ -485,14 +485,35 @@ fn build_linux_spec_with_memory(
     // changes `/proc/self/cgroup` semantics for every container and the
     // existing enforcement test reads that path; needs a coordinated test
     // update.
+    // Container init lives in the `workload` subgroup of `/boxlite/<id>`. The
+    // sibling `operator` subgroup carries a separate small PID/memory budget
+    // for `boxlite exec` so a workload bomb that saturates `pids.max=512` in
+    // workload doesn't lock the operator out of the box. See
+    // `crate::container::cgroup_carve::ensure_box_cgroup_hierarchy` for the
+    // pre-init setup and `crate::service::exec::executor` for the per-exec
+    // `cgroupsPath` swap that routes operator processes into the operator
+    // subgroup at libcontainer-build time.
     LinuxBuilder::default()
         .namespaces(namespaces)
         .uid_mappings(uid_mappings)
         .gid_mappings(gid_mappings)
-        .cgroups_path(std::path::PathBuf::from(format!("/boxlite/{container_id}")))
+        .cgroups_path(std::path::PathBuf::from(format!(
+            "/boxlite/{container_id}/workload"
+        )))
         .resources(resources)
         .build()
         .map_err(|e| BoxliteError::Internal(format!("Failed to build linux spec: {}", e)))
+}
+
+/// OCI cgroupsPath for operator-injected processes (`boxlite exec`). Lives as
+/// a sibling of `/boxlite/<id>/workload` under the same parent budget so that
+/// a workload bomb saturating the workload subgroup can't lock the operator
+/// out of the box. See [`build_linux_spec_with_memory`] for the workload
+/// counterpart. Used by `cgroup_carve::swap_to_operator_cgroup_path` only —
+/// libcontainer reads it back from the rewritten config.json on disk.
+#[allow(dead_code)] // production callers use the inline format string; this is here for tests + docs
+pub(crate) fn operator_cgroup_path(container_id: &str) -> String {
+    format!("/boxlite/{container_id}/operator")
 }
 
 /// cgroup `pids.max` for a container: a hard ceiling on the process count so a

--- a/src/guest/src/container/spec.rs
+++ b/src/guest/src/container/spec.rs
@@ -429,11 +429,6 @@ fn build_linux_spec(
         "/proc/sysrq-trigger".to_string(),
     ];
 
-    // NOTE: Cgroup path disabled for performance (see cgroup mount comment above)
-    // Re-enable together with cgroup namespace and mount if resource limits are needed.
-    // let cgroups_path = format!("/boxlite/{}", container_id);
-    let _ = container_id; // Suppress unused warning
-
     // Reserve memory for kernel + guest agent; cap container to the rest.
     let mut linux_builder = LinuxBuilder::default()
         .namespaces(namespaces)
@@ -454,7 +449,14 @@ fn build_linux_spec(
             .pids(pids)
             .build()
             .map_err(|e| BoxliteError::Internal(format!("Failed to build resources spec: {e}")))?;
-        linux_builder = linux_builder.resources(resources);
+        // Pin the container to an explicit, predictable cgroup. youki applies
+        // the limits either way, but with no path it invents a default name
+        // (`/:youki:<id>`); a stable `/sys/fs/cgroup/boxlite/<id>` is what
+        // tooling and the enforcement test inspect and matches the
+        // per-container layout the rest of the runtime uses.
+        linux_builder = linux_builder
+            .resources(resources)
+            .cgroups_path(std::path::PathBuf::from(format!("/boxlite/{container_id}")));
     }
 
     linux_builder

--- a/src/guest/src/container/spec.rs
+++ b/src/guest/src/container/spec.rs
@@ -383,10 +383,24 @@ fn build_root_spec(rootfs: &str) -> BoxliteResult<oci_spec::runtime::Root> {
         .map_err(|e| BoxliteError::Internal(format!("Failed to build root spec: {}", e)))
 }
 
-/// Build Linux-specific configuration
+/// Build Linux-specific configuration.
+///
+/// `memory_limit` is passed in (rather than read from `/proc/meminfo` inside
+/// the builder) so the "meminfo unreadable → memory cap absent, pids cap
+/// still enforced" degradation path can be unit-tested without mocking the
+/// filesystem. Production call goes through `build_linux_spec_with_memory`
+/// below which feeds `container_memory_limit()`.
 fn build_linux_spec(
     container_id: &str,
     namespaces: Vec<oci_spec::runtime::LinuxNamespace>,
+) -> BoxliteResult<oci_spec::runtime::Linux> {
+    build_linux_spec_with_memory(container_id, namespaces, container_memory_limit())
+}
+
+fn build_linux_spec_with_memory(
+    container_id: &str,
+    namespaces: Vec<oci_spec::runtime::LinuxNamespace>,
+    memory_limit: Option<i64>,
 ) -> BoxliteResult<oci_spec::runtime::Linux> {
     // UID/GID mappings for user namespace
     // Map full range of UIDs/GIDs to allow non-root users (nginx=33, etc.)
@@ -440,7 +454,7 @@ fn build_linux_spec(
         .map_err(|e| BoxliteError::Internal(format!("Failed to build pids spec: {e}")))?;
     let mut resources_builder = LinuxResourcesBuilder::default().pids(pids);
 
-    if let Some(mem_max) = container_memory_limit() {
+    if let Some(mem_max) = memory_limit {
         let memory = LinuxMemoryBuilder::default()
             .limit(mem_max)
             .build()
@@ -1112,6 +1126,89 @@ mod tests {
         assert!(
             v > 1_000_000_000_000_000,
             "saturated limit must be enormous (>1 PB), not a small overflow remainder (got {v})"
+        );
+    }
+
+    /// Production-path: `memory_limit = Some(N)` lands `memory.max = N` on the
+    /// cgroup spec alongside the constant `pids.max = 512`. Pins that both
+    /// caps are set when meminfo is healthy.
+    #[test]
+    fn linux_spec_with_memory_limit_has_both_memory_and_pids_caps() {
+        let limit: i64 = 256 * 1024 * 1024; // 256 MiB
+        let linux = build_linux_spec_with_memory("container-with-mem", vec![], Some(limit))
+            .expect("must build with Some memory limit");
+
+        let resources = linux
+            .resources()
+            .as_ref()
+            .expect("linux.resources must be set");
+        let memory = resources
+            .memory()
+            .as_ref()
+            .expect("memory.max must be set when memory_limit is Some");
+        assert_eq!(
+            memory.limit(),
+            Some(limit),
+            "memory.max must equal the explicit memory_limit"
+        );
+        let pids = resources.pids().as_ref().expect("pids.max must be set");
+        assert_eq!(
+            pids.limit(),
+            CONTAINER_PIDS_MAX,
+            "pids.max must always be the constant {CONTAINER_PIDS_MAX}"
+        );
+    }
+
+    /// **Load-bearing for the meminfo-degradation contract**: when
+    /// `/proc/meminfo` can't be read (or `MemAvailable` is missing /
+    /// unparseable / zero), `container_memory_limit()` returns `None` and
+    /// `build_linux_spec` must STILL produce a spec whose cgroup has
+    /// `pids.max = 512`. The whole point of pulling pids.max out of the
+    /// `if let Some` block in #605 was to keep fork-bomb protection alive
+    /// even when memory.max can't be derived — silently dropping both
+    /// would be the regression this PR exists to fight.
+    ///
+    /// A regression that, for example, moves the `pids` builder back inside
+    /// the `Some` arm would land here as: `pids().is_none()`.
+    #[test]
+    fn linux_spec_without_memory_limit_still_has_pids_cap() {
+        let linux = build_linux_spec_with_memory("container-no-mem", vec![], None)
+            .expect("must build with None memory limit (degraded path)");
+
+        let resources = linux
+            .resources()
+            .as_ref()
+            .expect("linux.resources must be set even in the degraded path");
+
+        assert!(
+            resources.memory().is_none(),
+            "memory.max must be ABSENT when memory_limit is None — \
+             #605's loud-warn-and-degrade contract means we don't \
+             silently invent a cap"
+        );
+
+        let pids = resources.pids().as_ref().expect(
+            "pids.max must STILL be set when memory_limit is None — \
+             the whole point of decoupling pids from the memory if-let \
+             is to keep fork-bomb protection alive when meminfo fails",
+        );
+        assert_eq!(
+            pids.limit(),
+            CONTAINER_PIDS_MAX,
+            "pids.max must always be the constant {CONTAINER_PIDS_MAX}, \
+             regardless of memory_limit"
+        );
+
+        // The cgroup path must also still be set — youki applies pids.max
+        // there. A regression that moves `cgroups_path` into the Some arm
+        // would silently bury the pids cap in `/:youki:<id>` instead.
+        assert_eq!(
+            linux
+                .cgroups_path()
+                .as_ref()
+                .map(|p| p.to_string_lossy().into_owned()),
+            Some("/boxlite/container-no-mem".to_string()),
+            "cgroups_path must always be /boxlite/<id>"
         );
     }
 }

--- a/src/guest/src/container/spec.rs
+++ b/src/guest/src/container/spec.rs
@@ -446,7 +446,7 @@ fn build_linux_spec(
             .build()
             .map_err(|e| BoxliteError::Internal(format!("Failed to build memory spec: {e}")))?;
         let pids = LinuxPidsBuilder::default()
-            .limit(512)
+            .limit(CONTAINER_PIDS_MAX)
             .build()
             .map_err(|e| BoxliteError::Internal(format!("Failed to build pids spec: {e}")))?;
         let resources = LinuxResourcesBuilder::default()
@@ -462,13 +462,26 @@ fn build_linux_spec(
         .map_err(|e| BoxliteError::Internal(format!("Failed to build linux spec: {}", e)))
 }
 
-/// Container memory hard limit (cgroup `memory.max`) from VM's available memory.
-///
-/// 90% of `MemAvailable` — the remaining 10% is headroom for the guest agent,
-/// zygote, and kernel. Cgroup OOM kills only hit container processes, never
-/// the guest agent.
+/// cgroup `pids.max` for a container: a hard ceiling on the process count so a
+/// fork bomb can't exhaust the VM's PID space and kernel memory. The cgroup
+/// blocks forks past this for container processes only — never the guest agent.
+const CONTAINER_PIDS_MAX: i64 = 512;
+
+/// Container memory hard limit (cgroup `memory.max`) from the VM's available
+/// memory. Thin I/O wrapper over [`memory_limit_from_meminfo`]; `None` (set no
+/// limit) when `/proc/meminfo` can't be read.
 fn container_memory_limit() -> Option<i64> {
-    let meminfo = std::fs::read_to_string("/proc/meminfo").ok()?;
+    memory_limit_from_meminfo(&std::fs::read_to_string("/proc/meminfo").ok()?)
+}
+
+/// Pure: 90% of the `MemAvailable:` line in `/proc/meminfo` contents (the other
+/// 10% is headroom for the guest agent, zygote, and kernel, so a cgroup OOM
+/// kills container processes rather than panicking the guest kernel).
+///
+/// `None` when the field is missing, unparseable, or the result is non-positive
+/// — the caller then sets no memory limit rather than a bogus one. Split from
+/// the file read so the threshold math is unit-testable without `/proc`.
+fn memory_limit_from_meminfo(meminfo: &str) -> Option<i64> {
     let available_kb: i64 = meminfo
         .lines()
         .find(|l| l.starts_with("MemAvailable:"))?
@@ -477,11 +490,7 @@ fn container_memory_limit() -> Option<i64> {
         .parse()
         .ok()?;
     let limit = available_kb * 1024 * 9 / 10;
-    if limit > 0 {
-        Some(limit)
-    } else {
-        None
-    }
+    (limit > 0).then_some(limit)
 }
 
 /// Build standard mounts for container filesystem
@@ -1004,5 +1013,59 @@ mod tests {
         // Malformed entries are silently skipped (not enough fields to match)
         let err = resolve_user(r, "short").unwrap_err().to_string();
         assert!(err.contains("User 'short' not found"), "got: {}", err);
+    }
+
+    #[test]
+    fn memory_limit_is_90_percent_of_available() {
+        let meminfo = "MemTotal:        2048000 kB\n\
+                       MemFree:          100000 kB\n\
+                       MemAvailable:    1000000 kB\n\
+                       Buffers:            5000 kB\n";
+        let limit = memory_limit_from_meminfo(meminfo).expect("parse MemAvailable");
+        assert_eq!(limit, 1_000_000i64 * 1024 * 9 / 10);
+        // The whole point: leave headroom — the cap is strictly below the raw
+        // available bytes so the guest kernel + agent can't be starved.
+        assert!(
+            limit < 1_000_000i64 * 1024,
+            "memory cap must reserve headroom below MemAvailable"
+        );
+    }
+
+    #[test]
+    fn memory_limit_reads_memavailable_not_memfree_or_memtotal() {
+        // MemTotal/MemFree are larger and listed first; a sloppy parser that
+        // grabbed the wrong field would cap the container too high and defeat
+        // the OOM protection.
+        let meminfo = "MemTotal:        9999999 kB\n\
+                       MemFree:         8888888 kB\n\
+                       MemAvailable:     500000 kB\n";
+        assert_eq!(
+            memory_limit_from_meminfo(meminfo).unwrap(),
+            500_000i64 * 1024 * 9 / 10,
+            "must derive the cap from MemAvailable"
+        );
+    }
+
+    #[test]
+    fn memory_limit_none_when_field_missing() {
+        // No MemAvailable → no limit (degrade to unbounded rather than a bogus
+        // cap), so the caller sets no cgroup memory.max.
+        assert_eq!(
+            memory_limit_from_meminfo("MemTotal: 2048000 kB\nMemFree: 100000 kB\n"),
+            None
+        );
+    }
+
+    #[test]
+    fn memory_limit_none_when_unparseable_or_zero() {
+        assert_eq!(
+            memory_limit_from_meminfo("MemAvailable:    notanumber kB\n"),
+            None
+        );
+        // 0 available → 0 cap is meaningless; must be None, never Some(0).
+        assert_eq!(
+            memory_limit_from_meminfo("MemAvailable:          0 kB\n"),
+            None
+        );
     }
 }

--- a/src/guest/src/container/spec.rs
+++ b/src/guest/src/container/spec.rs
@@ -7,9 +7,10 @@ use boxlite_shared::errors::{BoxliteError, BoxliteResult};
 use std::path::Path;
 
 use oci_spec::runtime::{
-    LinuxBuilder, LinuxCapabilitiesBuilder, LinuxIdMappingBuilder, LinuxNamespaceBuilder,
-    LinuxNamespaceType, Mount, MountBuilder, PosixRlimitBuilder, PosixRlimitType, ProcessBuilder,
-    RootBuilder, Spec, SpecBuilder, UserBuilder,
+    LinuxBuilder, LinuxCapabilitiesBuilder, LinuxIdMappingBuilder, LinuxMemoryBuilder,
+    LinuxNamespaceBuilder, LinuxNamespaceType, LinuxPidsBuilder, LinuxResourcesBuilder, Mount,
+    MountBuilder, PosixRlimitBuilder, PosixRlimitType, ProcessBuilder, RootBuilder, Spec,
+    SpecBuilder, UserBuilder,
 };
 
 /// User-specified bind mount for container
@@ -433,15 +434,54 @@ fn build_linux_spec(
     // let cgroups_path = format!("/boxlite/{}", container_id);
     let _ = container_id; // Suppress unused warning
 
-    LinuxBuilder::default()
+    // Reserve memory for kernel + guest agent; cap container to the rest.
+    let mut linux_builder = LinuxBuilder::default()
         .namespaces(namespaces)
         .uid_mappings(uid_mappings)
-        .gid_mappings(gid_mappings)
-        // .masked_paths(masked_paths)
-        // .readonly_paths(readonly_paths)
-        // .cgroups_path(cgroups_path)
+        .gid_mappings(gid_mappings);
+
+    if let Some(mem_max) = container_memory_limit() {
+        let memory = LinuxMemoryBuilder::default()
+            .limit(mem_max)
+            .build()
+            .map_err(|e| BoxliteError::Internal(format!("Failed to build memory spec: {e}")))?;
+        let pids = LinuxPidsBuilder::default()
+            .limit(512)
+            .build()
+            .map_err(|e| BoxliteError::Internal(format!("Failed to build pids spec: {e}")))?;
+        let resources = LinuxResourcesBuilder::default()
+            .memory(memory)
+            .pids(pids)
+            .build()
+            .map_err(|e| BoxliteError::Internal(format!("Failed to build resources spec: {e}")))?;
+        linux_builder = linux_builder.resources(resources);
+    }
+
+    linux_builder
         .build()
         .map_err(|e| BoxliteError::Internal(format!("Failed to build linux spec: {}", e)))
+}
+
+/// Container memory hard limit (cgroup `memory.max`) from VM's available memory.
+///
+/// 90% of `MemAvailable` — the remaining 10% is headroom for the guest agent,
+/// zygote, and kernel. Cgroup OOM kills only hit container processes, never
+/// the guest agent.
+fn container_memory_limit() -> Option<i64> {
+    let meminfo = std::fs::read_to_string("/proc/meminfo").ok()?;
+    let available_kb: i64 = meminfo
+        .lines()
+        .find(|l| l.starts_with("MemAvailable:"))?
+        .split_whitespace()
+        .nth(1)?
+        .parse()
+        .ok()?;
+    let limit = available_kb * 1024 * 9 / 10;
+    if limit > 0 {
+        Some(limit)
+    } else {
+        None
+    }
 }
 
 /// Build standard mounts for container filesystem

--- a/src/guest/src/container/spec.rs
+++ b/src/guest/src/container/spec.rs
@@ -497,21 +497,26 @@ fn build_linux_spec_with_memory(
         .namespaces(namespaces)
         .uid_mappings(uid_mappings)
         .gid_mappings(gid_mappings)
-        .cgroups_path(std::path::PathBuf::from(format!(
-            "/boxlite/{container_id}/workload"
-        )))
+        .cgroups_path(std::path::PathBuf::from(workload_cgroup_path(container_id)))
         .resources(resources)
         .build()
         .map_err(|e| BoxliteError::Internal(format!("Failed to build linux spec: {}", e)))
 }
 
-/// OCI cgroupsPath for operator-injected processes (`boxlite exec`). Lives as
-/// a sibling of `/boxlite/<id>/workload` under the same parent budget so that
-/// a workload bomb saturating the workload subgroup can't lock the operator
-/// out of the box. See [`build_linux_spec_with_memory`] for the workload
-/// counterpart. Used by `cgroup_carve::swap_to_operator_cgroup_path` only —
-/// libcontainer reads it back from the rewritten config.json on disk.
-#[allow(dead_code)] // production callers use the inline format string; this is here for tests + docs
+/// OCI cgroupsPath for the container's init + workload — `pids.max=512`,
+/// `memory.max=container_memory_limit()`. Single source of truth used by both
+/// the OCI spec builder and `cgroup_carve`'s swap (paired with the operator
+/// path below). Keeping them as functions guarantees the two siblings can't
+/// drift in name.
+pub(crate) fn workload_cgroup_path(container_id: &str) -> String {
+    format!("/boxlite/{container_id}/workload")
+}
+
+/// OCI cgroupsPath for operator-injected processes (`boxlite exec --debug`).
+/// Lives as a sibling of `/boxlite/<id>/workload` under the same parent budget
+/// so a workload bomb saturating the workload subgroup can't lock the operator
+/// out of the box. Used by `cgroup_carve` (the swap-on-debug path that rewrites
+/// the OCI config.json on disk so libcontainer reads it back at tenant build).
 pub(crate) fn operator_cgroup_path(container_id: &str) -> String {
     format!("/boxlite/{container_id}/operator")
 }

--- a/src/guest/src/container/spec.rs
+++ b/src/guest/src/container/spec.rs
@@ -429,37 +429,54 @@ fn build_linux_spec(
         "/proc/sysrq-trigger".to_string(),
     ];
 
-    // Reserve memory for kernel + guest agent; cap container to the rest.
-    let mut linux_builder = LinuxBuilder::default()
-        .namespaces(namespaces)
-        .uid_mappings(uid_mappings)
-        .gid_mappings(gid_mappings);
+    // Resource limits. `pids.max` is a constant — applied unconditionally so a
+    // transient `/proc/meminfo` blip doesn't take down the fork-bomb defence
+    // alongside the memory cap. `memory.max` is derived from the VM's current
+    // `MemAvailable`; missing/unparseable falls back to unbounded with a loud
+    // warning (silent degrade-to-unprotected is exactly what this PR fights).
+    let pids = LinuxPidsBuilder::default()
+        .limit(CONTAINER_PIDS_MAX)
+        .build()
+        .map_err(|e| BoxliteError::Internal(format!("Failed to build pids spec: {e}")))?;
+    let mut resources_builder = LinuxResourcesBuilder::default().pids(pids);
 
     if let Some(mem_max) = container_memory_limit() {
         let memory = LinuxMemoryBuilder::default()
             .limit(mem_max)
             .build()
             .map_err(|e| BoxliteError::Internal(format!("Failed to build memory spec: {e}")))?;
-        let pids = LinuxPidsBuilder::default()
-            .limit(CONTAINER_PIDS_MAX)
-            .build()
-            .map_err(|e| BoxliteError::Internal(format!("Failed to build pids spec: {e}")))?;
-        let resources = LinuxResourcesBuilder::default()
-            .memory(memory)
-            .pids(pids)
-            .build()
-            .map_err(|e| BoxliteError::Internal(format!("Failed to build resources spec: {e}")))?;
-        // Pin the container to an explicit, predictable cgroup. youki applies
-        // the limits either way, but with no path it invents a default name
-        // (`/:youki:<id>`); a stable `/sys/fs/cgroup/boxlite/<id>` is what
-        // tooling and the enforcement test inspect and matches the
-        // per-container layout the rest of the runtime uses.
-        linux_builder = linux_builder
-            .resources(resources)
-            .cgroups_path(std::path::PathBuf::from(format!("/boxlite/{container_id}")));
+        resources_builder = resources_builder.memory(memory);
+    } else {
+        // Loud because: zero memory cap is the failure mode this PR exists to
+        // prevent. If you see this in logs, fix the cause; don't ignore.
+        tracing::warn!(
+            container_id,
+            "/proc/meminfo unreadable or MemAvailable missing — container memory.max NOT set (cgroup OOM protection downgraded; pids.max still enforced)"
+        );
     }
 
-    linux_builder
+    let resources = resources_builder
+        .build()
+        .map_err(|e| BoxliteError::Internal(format!("Failed to build resources spec: {e}")))?;
+
+    // Pin the container to an explicit, predictable cgroup. youki applies the
+    // limits either way, but with no path it invents `/:youki:<id>`; a stable
+    // `/sys/fs/cgroup/boxlite/<id>` is what tooling and the enforcement test
+    // inspect and matches the per-container layout the rest of the runtime
+    // uses. Set unconditionally so pids.max enforcement survives a None memory
+    // limit.
+    //
+    // FOLLOW-UP: `LinuxNamespaceType::Cgroup` would hide the host cgroup tree
+    // from the container (peer-box leakage hardening). Deferred — adding it
+    // changes `/proc/self/cgroup` semantics for every container and the
+    // existing enforcement test reads that path; needs a coordinated test
+    // update.
+    LinuxBuilder::default()
+        .namespaces(namespaces)
+        .uid_mappings(uid_mappings)
+        .gid_mappings(gid_mappings)
+        .cgroups_path(std::path::PathBuf::from(format!("/boxlite/{container_id}")))
+        .resources(resources)
         .build()
         .map_err(|e| BoxliteError::Internal(format!("Failed to build linux spec: {}", e)))
 }
@@ -491,8 +508,12 @@ fn memory_limit_from_meminfo(meminfo: &str) -> Option<i64> {
         .nth(1)?
         .parse()
         .ok()?;
-    let limit = available_kb * 1024 * 9 / 10;
-    (limit > 0).then_some(limit)
+    // Saturating: a pathological MemAvailable (~9 PB+) would overflow i64
+    // multiplication and panic under debug arithmetic checks. Saturate to
+    // i64::MAX so the cap stays sane on every realistic and pathological host.
+    let bytes = available_kb.saturating_mul(1024);
+    let nine_tenths = bytes.saturating_mul(9) / 10;
+    (nine_tenths > 0).then_some(nine_tenths)
 }
 
 /// Build standard mounts for container filesystem
@@ -1068,6 +1089,29 @@ mod tests {
         assert_eq!(
             memory_limit_from_meminfo("MemAvailable:          0 kB\n"),
             None
+        );
+    }
+
+    #[test]
+    fn memory_limit_saturates_on_overflow_doesnt_panic() {
+        // i64::MAX kB is ~18 EB; raw `* 1024 * 9` would overflow i64 and
+        // panic under debug arithmetic checks. Saturating math must keep the
+        // guest agent alive at container creation — the value returned is
+        // bounded but the call must NOT panic. The exact saturated value
+        // depends on the multiplication order; assert what we can: it's
+        // `Some(positive)` and large enough to be useless as a cap on
+        // realistic hardware (i.e., effectively "unlimited").
+        let meminfo = format!("MemAvailable: {} kB\n", i64::MAX);
+        let out = memory_limit_from_meminfo(&meminfo);
+        let v = out.expect("must return Some, not panic, on saturated input");
+        assert!(v > 0, "saturated limit must be positive (got {v})");
+        // Saturated bytes ≈ i64::MAX / 10 ≈ 9.2 × 10^17 bytes (~800 PiB) —
+        // way larger than any realistic host. 1 PB (10^15) is a conservative
+        // floor that proves saturation actually happened (a plain overflow
+        // would wrap to a small or negative value).
+        assert!(
+            v > 1_000_000_000_000_000,
+            "saturated limit must be enormous (>1 PB), not a small overflow remainder (got {v})"
         );
     }
 }

--- a/src/guest/src/service/exec/executor.rs
+++ b/src/guest/src/service/exec/executor.rs
@@ -50,6 +50,7 @@ impl Executor for ContainerExecutor {
         // so a stuck console-socket doesn't block other execs or shutdown.
         let spawn_result = {
             let container = self.container.lock().await;
+            let container_id = container.id().to_string();
 
             let mut cmd = container
                 .cmd()
@@ -74,7 +75,41 @@ impl Executor for ContainerExecutor {
                 cmd = cmd.with_user(user.clone());
             }
 
-            cmd.spawn_build().await?
+            // OPT-IN: `boxlite exec --debug` routes this process into the
+            // operator subgroup (`/boxlite/<id>/operator`, separate cap) so
+            // the operator can inspect a box whose workload has saturated
+            // `pids.max=512`. The default `boxlite exec` keeps the original
+            // #605 behaviour — process lands in `/boxlite/<id>/workload` —
+            // so a legitimate long-running command started via exec gets the
+            // full workload budget, not the tight ~64-PID operator cap.
+            //
+            // libcontainer's tenant builder re-reads `cgroupsPath` from the
+            // OCI config.json at build() time, so we flip it on disk under
+            // the container mutex (single-threaded serialization), call
+            // spawn_build, then restore for the next container-level op.
+            let swapped = if req.debug {
+                match crate::container::cgroup_carve::swap_to_operator_cgroup_path(&container_id) {
+                    Ok(()) => true,
+                    Err(e) => {
+                        tracing::warn!(
+                            container_id,
+                            error = %e,
+                            "operator-cgroup swap failed; --debug exec falls back to workload subgroup (lockout protection degraded for this call)"
+                        );
+                        false
+                    }
+                }
+            } else {
+                false
+            };
+
+            let result = cmd.spawn_build().await;
+
+            if swapped {
+                crate::container::cgroup_carve::restore_workload_cgroup_path(&container_id);
+            }
+
+            result?
             // container mutex dropped here
         };
 

--- a/src/shared/proto/boxlite/v1/service.proto
+++ b/src/shared/proto/boxlite/v1/service.proto
@@ -276,6 +276,19 @@ message ExecRequest {
   uint64 timeout_ms = 6;
   optional TtyConfig tty = 7;  // If set, use PTY instead of pipes
   optional string user = 8;    // User override (format: <name|uid>[:<group|gid>])
+
+  // Route this exec into the operator cgroup subgroup
+  // (`/boxlite/<id>/operator`, separate PID + memory budget) so the operator
+  // can debug a box whose workload has saturated its own `pids.max=512`.
+  // Defaults to false: a regular `boxlite exec` shares the workload's
+  // cgroup like before, so a long-running user command launched via exec
+  // gets the full workload budget.
+  //
+  // Set this via `boxlite exec --debug`. The operator subgroup has a tight
+  // cap (~64 PIDs / 64 MiB) intended for inspection only — running a heavy
+  // command under `--debug` may hit ENOSPC/EAGAIN in the operator subgroup
+  // even when the workload subgroup has room.
+  bool debug = 9;
 }
 
 // TTY configuration for interactive sessions

--- a/src/shared/proto/boxlite/v1/service.proto
+++ b/src/shared/proto/boxlite/v1/service.proto
@@ -285,7 +285,7 @@ message ExecRequest {
   // gets the full workload budget.
   //
   // Set this via `boxlite exec --debug`. The operator subgroup has a tight
-  // cap (~64 PIDs / 64 MiB) intended for inspection only — running a heavy
+  // cap (~64 PIDs / 32 MiB) intended for inspection only — running a heavy
   // command under `--debug` may hit ENOSPC/EAGAIN in the operator subgroup
   // even when the workload subgroup has room.
   bool debug = 9;


### PR DESCRIPTION
Cap each container's `memory.max` + `pids.max` via cgroup so a hostile workload inside the box can't exhaust the guest kernel — pinned to an explicit `/boxlite/<id>` path, with a hard enforcement test the survival path alone can't provide and a degradation test that proves pids.max survives a meminfo failure.

## Test plan

### THE load-bearing test (delete it and #605 stops proving its core property)

**`cgroup_limits_keep_vm_alive_under_pids_and_memory_bombs`** (`src/cli/tests/stress_oom.rs`)

Three escalating waves against a 128 MiB box; the assertion the test actually pins is **"the cgroup pids cap was enforced"**, not "the VM would otherwise panic" (see scoping caveat below):

1. **Wave 1 — fork bomb:** 1000 forks vs `pids.max=512`. Asserts `forked in 1..700` (proves the cap blocked **hundreds of forks**, not just that some kernel happened to cope).
2. **Wave 2 — memory bomb:** single 512 MB allocation in a 128 MB VM (4× overcommit). VM still `Running` + exec works after the cgroup OOM-killed the allocator.
3. **Wave 3 — combined:** 200 children each touching 2 MB. Same survival + responsiveness.

**Strict two-side verified** (per CLAUDE.md — full revert of every production file, only the test stays):

| side | spec.rs state | result | timing |
|---|---|---|---|
| **pre-fix** | `git checkout upstream/main -- src/guest/src/container/spec.rs` (zero cgroup setup, zero pids cap, zero memory cap, zero `/boxlite/<id>` path) | **FAIL** at line 288: `pids.max must cap the fork bomb well below the requested 1000; got forked=982 / forked 982/1000 x 0MB` | 68.94 s |
| **post-fix** | full #605 spec.rs restored | **PASS** | 88.88 s |

**Scoping caveat — honest about what this test does and doesn't prove:**
- ✅ **Pins** that `pids.max=512` is *enforced* (a regression that drops `.pids(pids)`, the cgroups_path, the resources_builder, or the entire `build_linux_spec` cgroup logic lands here within seconds).
- ❌ Does **not** itself demonstrate "VM panics without #605". The wave-1 fork-count assertion fires before wave 2/3 + VM-survival assertions get to run. On the dev box used to verify, the guest kernel handled 982 forks fine — `boxlite exec` and `boxlite rm` still worked even with no cap. Whether a runaway *would* take down the VM depends on host hardware / kernel / bomb intensity.

**Why a stronger "no-cap = disaster" demo wasn't added** (we tried, ~150 LOC attempt reverted):

We attempted an `extreme_fork_pressure_starves_guest_agent_without_cap` test: 512 MiB box, 10 000-fork bomb in a detached subshell, then `boxlite exec` to verify guest agent responsiveness. The intent was — with #605, cap clamps bomb at 512 PIDs and the agent has ~31k PIDs free; without #605, bomb consumes thousands and the agent's fork(2) starts failing.

It failed on the **post-fix side too**, with exit 1: `spawn_failed: build failed: failed to create container: intermediate process error failed to launch init process`. The reason: **the cgroup `pids.max=512` ALSO bounds operator `boxlite exec`** — exec spawns a new process in the same container cgroup, which is now full after the bomb's 512 forks. The cap is doing its job, but it bounds the workload AND the operator's debug access symmetrically, so we cannot use exec-after-bomb as a liveness probe.

A clean version of this demo would need:
- a non-exec liveness check that bypasses the container cgroup (e.g. host-side state-DB query routed through the agent), OR
- a smaller `pids.max` so the bomb saturates the guest VM's global `pid_max` (≈ 32 768) without hitting the cgroup cap first — but on a 128–512 MiB VM, the memory pressure from 30k task_structs OOMs the bomb before it reaches the kernel PID ceiling.

Both routes are doable but invasive (new product surface or a much bigger VM). Deferred. The honest framing is that **#605's threat model — "container's runaway exhausts the guest VM" — is structurally hard to reproduce on a small VM**; the cap mechanism is what we can verify, and the catastrophe theory is what kernel-level reasoning provides.

### Supporting coverage (8 tests, brief)

| test | proves | two-side |
|---|---|---|
| `cgroup_limits_are_enforced_on_the_container` | `/proc/self/cgroup` path is `/boxlite/<id>`, `memory.max < VM size`, `pids.max=512` | ✓ drop `cgroups_path` → `/:youki:<id>` → fails |
| `memory_limit_actually_oom_kills_overconsumption` | a single oversized alloc gets killed (exit non-zero) | — (may overlap with guest-kernel OOM; doesn't distinguish cgroup-kill from kernel-kill) |
| `cgroup_dir_is_removed_after_box_rm` | `boxlite rm` cleans up the host-side cgroup dir | — |
| `concurrent_boxes_have_independent_cgroups` | multi-box: each `/boxlite/<idN>` is independent | — |
| `cgroup_limits_survive_stop_and_start` | stop → start re-creates the cgroup with same limits | — |
| `memory_limit_from_meminfo` (5-case unit) | 90% of `MemAvailable`; `None` on missing/unparseable/zero; saturates on overflow | — |
| `linux_spec_with_memory_limit_has_both_memory_and_pids_caps` (`1271dedb`) | healthy path: memory.max == provided limit, pids.max == 512 | — |
| **`linux_spec_without_memory_limit_still_has_pids_cap`** (`1271dedb`) | **load-bearing for the degradation contract** — `memory_limit=None` (meminfo unreadable) must STILL set `pids.max=512` + `/boxlite/<id>` cgroups_path. Memory.max is absent (loud-warn-and-degrade, not silent invent) | **✓** move `pids` builder back inside the `Some` arm → fails with `pids.max must STILL be set when memory_limit is None — the whole point of decoupling pids from the memory if-let is to keep fork-bomb protection alive when meminfo fails` |

### Run

```sh
make test:integration:cli FILTER='stress_oom'                                    # 6 integration
cargo test -p boxlite-guest container::spec::tests                                # 36 unit (incl. memory_limit + new degradation tests)
```

### Known gaps

- **No end-to-end "no-cap = catastrophe" demo** — see "Why a stronger demo wasn't added" above. The cap-enforcement assertion is what's testable; the disaster narrative is by kernel-level reasoning, not by test reproduction.
- **`memory_limit_actually_oom_kills_overconsumption` may be tautological** — assertion is just "alloc exits non-zero". Without #605's `memory.max`, the guest kernel's global OOM killer would *also* kill the offender (exit non-zero). A tighter version would read `memory.events.oom_kill` counter from the cgroup.
- **pids.max boundary precision** — Tier 1 asserts `forked < 700` (slack above the 512 ceiling); a tight `forked in 500..520` test would catch a quiet `CONTAINER_PIDS_MAX` change at the cost of flakiness.
- **User-set `ResourceLimits.max_memory` / `max_processes` override** — current design ignores user-supplied container caps and derives them from `/proc/meminfo` + a constant. Making them overridable is a *new feature*, not a test gap.



---

## Addendum (commits d9fc6813 + f4476d86): operator carve-out + opt-in `--debug` exec

Addresses the "operator-lockout" gap called out above. The `extreme_fork_pressure_starves_guest_agent_without_cap` test attempt failed precisely because workload + operator shared `/boxlite/<id>`. This addendum splits the cgroup:

```
/boxlite/<id>/workload    pids.max=512  memory.max=container_memory_limit()    # init + container PIDs
/boxlite/<id>/operator    pids.max=64   memory.max=32 MiB                       # opt-in via `boxlite exec --debug`
```

The new opt-in `boxlite exec --debug` flag (proto `ExecRequest.debug` field threaded through gRPC + REST + CLI + `BoxCommand`) rewrites the OCI bundle's `cgroupsPath` under the container mutex right before libcontainer's tenant builder runs, so the exec'd process lands in `/operator` instead of `/workload`. Plain `boxlite exec` (no flag) keeps the original `/workload` route — a long-running user command via exec gets the full workload budget, not the tight ~64-PID operator cap.

### Why opt-in (not unconditional)
The original prototype always routed `boxlite exec` into `/operator`. It broke this PR's Tier-1 bomb test — a 1000-fork bomb launched via `exec` needs the full workload budget to reproduce the cap-vs-VM scenario. It also implicitly forced operators who legitimately exec long-running workloads into a 32 MiB memory cap. Opt-in via `--debug` makes the carve-out a deliberate "inspect a wedged box" tool, not a behavioural change to every exec.

### Honest caveat (encoded in test doc-comment)
The libcontainer-tenant lockout that originally motivated the carve-out (workload saturating `/boxlite/<id>` → `failed to launch init process` from libcontainer) **does not reproduce deterministically** with a 1000-fork bomb in CI — libcontainer's tenant build needs only ~1 PID slot and the bomb usually leaves it. The load-bearing assertion in the new test is the **cgroup path** (the `--debug`-exec'd process ends up in `/boxlite/<id>/operator`), not the lockout itself.

### New test + two-side verify

**`operator_exec_works_when_workload_saturates_pids_cap`** (`src/cli/tests/stress_oom.rs`):

1. Boots a 128 MiB box, installs gcc + compiles the same `FLOOD_C` flood binary as Tier-1.
2. Launches a backgrounded `/tmp/flood 1000 0` bomb to saturate `/boxlite/<id>/workload`.
3. Asserts `boxlite exec --debug -- echo operator-alive` succeeds (smoke).
4. **Asserts the `--debug` exec'd process's `/proc/self/cgroup` ends with `/operator`** (the deterministic structural proof).

**Strict two-side verified** (with documented deviation from the literal "revert every non-test file" bullet):

| side | what was reverted | result | timing | failure signal |
|---|---|---|---|---|
| **A (operative fix reverted)** | `cgroup_carve.rs` deleted, `spec.rs` `/workload` change reverted, `lifecycle.rs` hierarchy hooks reverted, `executor.rs` swap block reverted. **API surface kept** (proto / `BoxCommand` / portal / REST / CLI `--debug`) so the test can still issue the `--debug` request. | **FAIL** at line 595 — `--debug exec must land in /boxlite/<id>/operator (the carve-out sibling), not in workload or a single combined cgroup; got "/boxlite/765badac…"` (single combined cgroup, no carve-out). | 37.2 s | cg-path mismatch — exec landed in `/boxlite/<id>`, proving the carve-out is what routes it to `/operator`. |
| **B (full fix)** | nothing reverted | **PASS** | 35.6 s | — |

**Why the deviation from "revert every non-test file"**: a literal full revert would also drop the `--debug` clap flag, and the test would then fail with clap's `unrecognized argument: --debug` — a failure that doesn't point at the bug. Keeping the API plumbing on Side A is the minimum needed for the test to *reach* the swap logic, so the resulting failure cleanly accuses the missing carve-out instead of accusing argv-parsing. Per the CLAUDE.md "if a full revert is genuinely impractical, stop and surface that — do not paper over it" escape clause, surfaced here.

### Pre-existing #605 tests still pass

| test | result | timing |
|---|---|---|
| `cgroup_limits_are_enforced_on_the_container` (now reads `/proc/1/cgroup` and asserts `ends_with("/workload")`) | ✓ | ~26 s |
| `cgroup_limits_keep_vm_alive_under_pids_and_memory_bombs` (Tier-1) | ✓ | 71 s |
| `cgroup_limits_survive_stop_and_start` | ✓ | ~26 s |

### Run

```sh
make test:integration:cli FILTER=operator_exec_works_when_workload_saturates_pids_cap
make test:integration:cli FILTER='cgroup_limits'
```

### Touched files

- `src/shared/proto/boxlite/v1/service.proto` — `+ bool debug = 9` on `ExecRequest`
- `src/boxlite/src/litebox/exec.rs` — `BoxCommand.debug` + `.debug()` builder
- `src/boxlite/src/portal/interfaces/exec.rs` — gRPC propagation
- `src/boxlite/src/rest/types.rs` — REST propagation (omitted from JSON when false)
- `src/cli/src/commands/exec.rs` — `--debug` clap flag
- `src/cli/src/commands/serve/{mod,types}.rs` — serve handler propagation
- `src/guest/src/container/cgroup_carve.rs` — **NEW** carve-out + swap helpers
- `src/guest/src/container/spec.rs` — `workload_cgroup_path` + `operator_cgroup_path` (single source of truth)
- `src/guest/src/container/lifecycle.rs` — `ensure_box_cgroup_hierarchy` after libcontainer start, `remove_box_cgroup_hierarchy` on drop
- `src/guest/src/service/exec/executor.rs` — opt-in swap on `req.debug`
- `src/cli/tests/stress_oom.rs` — new test + enforcement test now asserts workload subgroup directly
