### PR TITLE
fix(test): add missing .clone() in image_registries test after #604

### DIFF
--- a/src/boxlite/tests/image_registries.rs
+++ b/src/boxlite/tests/image_registries.rs
@@ -37,7 +37,7 @@ async fn structured_image_registries_pull_unqualified_image() {
 fn structured_image_registries_validate_at_runtime_start() {
     let home = PerTestBoxHome::isolated_in("/tmp");
     let result = BoxliteRuntime::new(BoxliteOptions {
-        home_dir: home.path,
+        home_dir: home.path.clone(),
         image_registries: vec![ImageRegistry::https("https://registry.local")],
     });
 


### PR DESCRIPTION
#604 added \`impl Drop for PerTestBoxHome\` but missed one site. Line 40 still moves \`home.path\` directly, triggering E0509 on every \`cargo build --tests -p boxlite\` on current main.

Reproduce on origin/main (2b9b545):

\`\`\`
$ cargo build --tests -p boxlite
error[E0509]: cannot move out of type \`PerTestBoxHome\`, which implements the \`Drop\` trait
  --> src/boxlite/tests/image_registries.rs:40:19
\`\`\`

Same file's line 14 and every other test file (e.g. \`shutdown.rs\`, 10+ sites) was already updated to \`home.path.clone()\`; this is the one site sed/find-replace skipped.

After this change \`cargo build --tests -p boxlite\` compiles clean.