### PR TITLE
fix(ci): enforce least-privilege permissions across all GHA workflows

### DIFF
--- a/.github/workflows/build-c.yml
+++ b/.github/workflows/build-c.yml
@@ -26,6 +26,9 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: '0'
 
+permissions:
+  contents: read
+
 jobs:
   config:
     uses: ./.github/workflows/config.yml

--- a/.github/workflows/build-go.yml
+++ b/.github/workflows/build-go.yml
@@ -19,6 +19,9 @@ on:
     types: [completed]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   config:
     uses: ./.github/workflows/config.yml

--- a/.github/workflows/build-node.yml
+++ b/.github/workflows/build-node.yml
@@ -22,6 +22,9 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: '0'
 
+permissions:
+  contents: read
+
 jobs:
   config:
     uses: ./.github/workflows/config.yml

--- a/.github/workflows/build-runtime.yml
+++ b/.github/workflows/build-runtime.yml
@@ -43,6 +43,9 @@ env:
   CARGO_INCREMENTAL: '0'
   SKIP_INSTALL_NODEJS: '1'
 
+permissions:
+  contents: read
+
 jobs:
   config:
     uses: ./.github/workflows/config.yml
@@ -312,6 +315,8 @@ jobs:
     needs: upload_to_release
     runs-on: ubuntu-latest
     if: github.event_name == 'release'
+    permissions:
+      contents: read
     env:
       BOXLITE_DEPS_STUB: "1"
 

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -9,6 +9,9 @@ env:
   SKIP_INSTALL_NODEJS: '1'
   CARGO_INCREMENTAL: '0'
 
+permissions:
+  contents: read
+
 jobs:
   # Load shared configuration
   config:

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -36,6 +36,8 @@ on:
         description: 'Number of days to retain artifacts'
         value: ${{ jobs.config.outputs.artifact-retention-days }}
 
+permissions: {}
+
 jobs:
   config:
     name: Load configuration

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -58,6 +58,9 @@ concurrency:
   group: e2e-runner
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   AWS_REGION: us-east-1
   AWS_ROLE_ARN: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/boxlite-e2e-github-actions
@@ -102,7 +105,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
-      contents: read
     outputs:
       instance-id: ${{ steps.ensure-instance.outputs.instance-id }}
     steps:
@@ -480,7 +482,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
-      contents: read
     if: always() && needs.start-runner.outputs.instance-id != ''
     steps:
       - name: Configure AWS credentials (OIDC)

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,6 +46,9 @@ on:
       - '.github/workflows/build-runtime.yml'
       - 'scripts/release/**'
 
+permissions:
+  contents: read
+
 jobs:
   config:
     uses: ./.github/workflows/config.yml
@@ -53,6 +56,7 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: read
     outputs:
       rust: ${{ steps.filter.outputs.rust }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,9 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: '0'
 
+permissions:
+  contents: read
+
 jobs:
   # Load shared configuration
   config:
@@ -49,6 +52,7 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: read
     outputs:
       rust: ${{ steps.filter.outputs.rust }}
@@ -90,6 +94,7 @@ jobs:
 
     permissions:
       id-token: write
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v5

--- a/.github/workflows/warm-caches.yml
+++ b/.github/workflows/warm-caches.yml
@@ -37,6 +37,9 @@ env:
   SCCACHE_GHA_ENABLED: 'true'
   RUSTC_WRAPPER: 'sccache'
 
+permissions:
+  contents: read
+
 jobs:
   config:
     uses: ./.github/workflows/config.yml


### PR DESCRIPTION
 ---
  **Problem**
  
GitHub Actions uses the repository's default token permissions when no permissions block is declared. If the repo default is contents: write, every build and test job silently gets write access to the repository. Additionally, when a job declares any explicit permission, all others drop to none, which can silently break steps like actions/checkout.

 ---
 **Changes**

Three classes of bug fixed across 10 workflow files:

  1. **Missing workflow-level permissions block:** Added `permissions: contents: read` as a safe default to build-c, build-go, build-node, build-runtime, build-wheels, warm-caches, e2e-test, lint, and test. Set `permissions: {}` on config.yml whose only job runs echo.
  2. **Partial explicit job-level block:** lint.yml and test.yml changes jobs declared only `pull-requests: read`, silently dropping contents to none and breaking actions/checkout and dorny/paths-filter on push events. The test.yml rust job had only id-token: write, also dropping contents to none. Added `contents: read` to all three.
  3. **Unused `contents: read`:** e2e-test.yml start-runner and stop-runner declared `contents: read` but neither job checks out code. Removed, leaving only `id-token: write` for AWS OIDC.
 
--- 
**Note:**  Analysed using LLM model (Claude/DeepSeek) and static analysis tools [zizmor](https://github.com/zizmorcore/zizmor). All findings are reviewed manually and applied fix.