### PR TITLE
fix(setup): install cmake for C SDK test harness

### DIFF
--- a/scripts/setup/setup-macos.sh
+++ b/scripts/setup/setup-macos.sh
@@ -196,6 +196,21 @@ install_protobuf() {
     echo ""
 }
 
+# Install cmake (C SDK test harness — sdks/c/tests/CMakeLists.txt)
+install_cmake() {
+    print_step "Checking for cmake... "
+    if command_exists cmake; then
+        print_success "Found ($(cmake --version | head -n1))"
+    elif brew_installed "cmake"; then
+        print_success "Already installed (brew)"
+    else
+        echo -e "${YELLOW}Installing...${NC}"
+        brew install cmake
+        print_success "cmake installed"
+    fi
+    echo ""
+}
+
 # Setup Python
 setup_python() {
     if ! check_python; then
@@ -278,6 +293,8 @@ main() {
     install_gperf
 
     install_protobuf
+
+    install_cmake
 
     setup_python
 

--- a/scripts/setup/setup-manylinux.sh
+++ b/scripts/setup/setup-manylinux.sh
@@ -86,6 +86,9 @@ install_system_deps() {
         # Python
         python3
         python3-pip
+
+        # C SDK test harness (sdks/c/tests/CMakeLists.txt)
+        cmake              # Configure/build/run C SDK unit + integration tests
     )
 
     for pkg in "${packages[@]}"; do

--- a/scripts/setup/setup-musllinux.sh
+++ b/scripts/setup/setup-musllinux.sh
@@ -85,6 +85,9 @@ install_system_deps() {
         python3
         python3-dev
         py3-pip
+
+        # C SDK test harness (sdks/c/tests/CMakeLists.txt)
+        cmake             # Configure/build/run C SDK unit + integration tests
     )
 
     for pkg in "${packages[@]}"; do

--- a/scripts/setup/setup-ubuntu.sh
+++ b/scripts/setup/setup-ubuntu.sh
@@ -99,6 +99,9 @@ install_system_deps() {
 
         # gRPC/protobuf (boxlite-shared)
         protobuf-compiler  # protoc compiler
+
+        # C SDK test harness (sdks/c/tests/CMakeLists.txt)
+        cmake              # Configure/build/run C SDK unit + integration tests
     )
 
     for pkg in "${packages[@]}"; do


### PR DESCRIPTION
## Summary

- C SDK test harness at `sdks/c/tests/CMakeLists.txt` is a CMake project; `make/test.mk:266-281` invokes `cmake ..`, `cmake --build`, and `ctest` for both `test:unit:c` and `test:integration:c`.
- Latest E2E run [26520105049](https://github.com/boxlite-ai/boxlite/actions/runs/26520105049/job/78108508003) failed with `/bin/bash: line 1: cmake: command not found` (Error 127) — the C SDK shared library built fine, then the test target couldn't find cmake.
- Add `cmake` to the system-dep install step in all three Linux platform scripts (`setup-ubuntu.sh`, `setup-manylinux.sh`, `setup-musllinux.sh`) and add an `install_cmake` helper to `setup-macos.sh` mirroring `install_protobuf` / `install_lld` (with a `command_exists cmake` fast-path so an existing non-brew install isn't replaced).
- Placed in `install_system_deps` / `main()`, not `run_dev_extras` — so both local `make setup` (dev mode) and CI provisioning that runs the platform scripts directly pick it up.

## Test plan

- [ ] Local: re-run `make setup` on macOS; verify `install_cmake` step appears and is idempotent (second run reports "Already installed (brew)" or "Found ...").
- [ ] CI: next E2E run on the `boxlite-e2e` self-hosted runner re-executes `bash scripts/setup/setup-ubuntu.sh` (per `.github/workflows/e2e-test.yml:375-381`), which installs cmake via apt, and `test:integration:c` then proceeds past the `cmake ..` step.

## Out of scope

- The same E2E run also surfaced 8 rust + 14 cli test failures unrelated to cmake (shim SIGABRT in jailer tests; zygote IPC `InitReady`/`IntermediateReady` ordering under high concurrency). Those are pre-existing on `main` and need separate investigation.