### PR TITLE
fix(runner): use Done as single canonical "exec finished" signal

### DIFF
--- a/apps/runner/pkg/api/controllers/boxlite_exec_test.go
+++ b/apps/runner/pkg/api/controllers/boxlite_exec_test.go
@@ -308,3 +308,20 @@ func TestBoxliteExecSignalClosedReturns409(t *testing.T) {
 		t.Fatalf("signal on closed exec: expected 409, got %d body=%s", w.Code, w.Body.String())
 	}
 }
+
+// Same Done-vs-closed race as the signal endpoint: resizing a finished exec
+// must return 409, not silently no-op against a dead handle.
+func TestBoxliteExecResizeClosedReturns409(t *testing.T) {
+	mgr := withFreshExecManager(t)
+	stub := &signalCapturingExec{}
+	exec := seedManagedExec(mgr, "exec-closed-resize", stub)
+	close(exec.Done)
+
+	w := runHandler(http.MethodPost,
+		"/v1/boxes/:boxId/executions/:execId/resize",
+		"/v1/boxes/box/executions/exec-closed-resize/resize",
+		strings.NewReader(`{"rows":40,"cols":120}`), BoxliteExecResize)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("resize on closed exec: expected 409, got %d body=%s", w.Code, w.Body.String())
+	}
+}

--- a/apps/runner/pkg/boxlite/exec_manager.go
+++ b/apps/runner/pkg/boxlite/exec_manager.go
@@ -103,7 +103,6 @@ type ManagedExec struct {
 	// against the deferred Close in the wait goroutine. Without this,
 	// Signal/ResizeTTY/stdin Write can race handle.Close().
 	handleMu sync.Mutex
-	closed   bool
 
 	// Per-stream capture + fan-out sinks. Passed directly to the Go SDK as
 	// ExecutionOptions.Stdout/.Stderr — no io.Pipe involved. Every byte the
@@ -385,14 +384,21 @@ func (m *ExecManager) Start(ctx context.Context, bx *boxlite.Box, boxID string, 
 	exec.stdinW = execution.Stdin
 
 	go func() {
-		defer close(exec.Done)
-		defer exec.stdoutBus.close()
-		defer exec.stderrBus.close()
+		// Single cleanup defer with close(Done) FIRST so the canonical
+		// "exec finished, do not use" signal is broadcast even if Wait
+		// or any cleanup step below panics. Subsequent handle.Close /
+		// bus closures are serialized via handleMu against in-flight
+		// control ops — anyone holding handleMu finishes their op,
+		// anyone arriving after sees Done closed and bails.
 		defer func() {
+			close(exec.Done)
+
 			exec.handleMu.Lock()
 			handle.Close()
-			exec.closed = true
 			exec.handleMu.Unlock()
+
+			exec.stdoutBus.close()
+			exec.stderrBus.close()
 		}()
 
 		exitCode, err := handle.Wait(context.Background())
@@ -441,20 +447,21 @@ func (m *ExecManager) GetForBox(id, boxID string) (*ManagedExec, error) {
 	return e, nil
 }
 
-// finishedLocked reports whether the exec is over. Done is the canonical
-// "exec finished" signal — closed by the wait-task's outermost defer, so it
-// fires on any goroutine exit including a panic — while the `closed` flag is
-// set later in a nested defer an abnormal exit can skip. Checking Done first
-// closes the race window where Done is closed but `closed` is still false.
-// Callers must hold handleMu. The per-resource nil check (execution/stdinW)
+// finishedLocked reports whether the exec is over. Done is the single
+// canonical "exec finished, do not touch handle/stdin" signal — the
+// wait-goroutine's cleanup defer closes Done FIRST (before handle.Close
+// and bus closures), so the close is panic-safe and any subsequent
+// control op observing Done==closed knows the C handle is being or has
+// already been released. handleMu serializes us against the cleanup's
+// own handle.Close call. The per-resource nil check (execution / stdinW)
 // stays at the call site since it differs per operation.
 func (e *ManagedExec) finishedLocked() bool {
 	select {
 	case <-e.Done:
 		return true
 	default:
+		return false
 	}
-	return e.closed
 }
 
 func (m *ExecManager) Signal(id string, sig int) error {
@@ -496,7 +503,7 @@ func (m *ExecManager) Kill(id string) error {
 	e.attachMu.Unlock()
 
 	e.handleMu.Lock()
-	if !e.closed && e.execution != nil {
+	if !e.finishedLocked() && e.execution != nil {
 		killCtx, killCancel := context.WithTimeout(context.Background(), 10*time.Second)
 		err := e.execution.Kill(killCtx)
 		killCancel()
@@ -718,7 +725,7 @@ func (m *ExecManager) escalate(e *ManagedExec, sig syscall.Signal, name string) 
 		"exec_id", e.ID, "signal", name)
 
 	e.handleMu.Lock()
-	if e.closed || e.execution == nil {
+	if e.finishedLocked() || e.execution == nil {
 		e.handleMu.Unlock()
 		e.escalationFailedMarkDoomed(sig)
 		m.killAndEvict(e)
@@ -756,7 +763,7 @@ func (m *ExecManager) killAndEvict(e *ManagedExec) {
 	}
 
 	e.handleMu.Lock()
-	if !e.closed && e.execution != nil {
+	if !e.finishedLocked() && e.execution != nil {
 		killCtx, killCancel := context.WithTimeout(context.Background(), 10*time.Second)
 		err := e.execution.Kill(killCtx)
 		killCancel()

--- a/apps/runner/pkg/boxlite/exec_manager.go
+++ b/apps/runner/pkg/boxlite/exec_manager.go
@@ -441,6 +441,22 @@ func (m *ExecManager) GetForBox(id, boxID string) (*ManagedExec, error) {
 	return e, nil
 }
 
+// finishedLocked reports whether the exec is over. Done is the canonical
+// "exec finished" signal — closed by the wait-task's outermost defer, so it
+// fires on any goroutine exit including a panic — while the `closed` flag is
+// set later in a nested defer an abnormal exit can skip. Checking Done first
+// closes the race window where Done is closed but `closed` is still false.
+// Callers must hold handleMu. The per-resource nil check (execution/stdinW)
+// stays at the call site since it differs per operation.
+func (e *ManagedExec) finishedLocked() bool {
+	select {
+	case <-e.Done:
+		return true
+	default:
+	}
+	return e.closed
+}
+
 func (m *ExecManager) Signal(id string, sig int) error {
 	m.mu.RLock()
 	e, ok := m.execs[id]
@@ -456,7 +472,7 @@ func (m *ExecManager) Signal(id string, sig int) error {
 	}
 	e.handleMu.Lock()
 	defer e.handleMu.Unlock()
-	if e.closed || e.execution == nil {
+	if e.finishedLocked() || e.execution == nil {
 		return fmt.Errorf("%w: %s", ErrExecClosed, id)
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -548,7 +564,7 @@ func (m *ExecManager) ResizeTTY(id string, rows, cols int) error {
 	}
 	e.handleMu.Lock()
 	defer e.handleMu.Unlock()
-	if e.closed || e.execution == nil {
+	if e.finishedLocked() || e.execution == nil {
 		return fmt.Errorf("%w: %s", ErrExecClosed, id)
 	}
 	if !e.TTY {
@@ -851,7 +867,7 @@ func (e *ManagedExec) MarkDisconnected() {
 func (e *ManagedExec) AttachWriteStdin(data []byte) (int, error) {
 	e.handleMu.Lock()
 	defer e.handleMu.Unlock()
-	if e.closed || e.stdinW == nil {
+	if e.finishedLocked() || e.stdinW == nil {
 		return 0, fmt.Errorf("execution %s stdin is closed", e.ID)
 	}
 	return e.stdinW.Write(data)
@@ -883,7 +899,7 @@ func (e *ManagedExec) AttachCloseStdin() error {
 func (e *ManagedExec) AttachResize(rows, cols int) error {
 	e.handleMu.Lock()
 	defer e.handleMu.Unlock()
-	if e.closed || e.execution == nil {
+	if e.finishedLocked() || e.execution == nil {
 		return fmt.Errorf("execution %s is closed", e.ID)
 	}
 	if !e.TTY {
@@ -901,7 +917,7 @@ func (e *ManagedExec) AttachResize(rows, cols int) error {
 func (e *ManagedExec) AttachSignal(sig int) error {
 	e.handleMu.Lock()
 	defer e.handleMu.Unlock()
-	if e.closed || e.execution == nil {
+	if e.finishedLocked() || e.execution == nil {
 		return fmt.Errorf("execution %s is closed", e.ID)
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/apps/runner/pkg/boxlite/exec_manager_test.go
+++ b/apps/runner/pkg/boxlite/exec_manager_test.go
@@ -764,18 +764,3 @@ func TestAttachWriteStdinClosedExecErrors(t *testing.T) {
 		t.Fatal("AttachWriteStdin on a Done exec must error, got nil")
 	}
 }
-
-// The complementary window: the inner defer has run (handle.Close + closed=true)
-// but the outer defer that closes Done hasn't, so closed is set while Done is
-// still open. finishedLocked must reject here via the `closed` branch — this
-// pins that the Done-first refactor did not turn `closed` into dead code.
-// Done left open; execution is non-nil, so closed is the sole error source.
-func TestAttachSignalClosedFlagNoDoneErrors(t *testing.T) {
-	m := newQuietManager(t)
-	exec := registerStub(t, m, "attach-sig-closedflag", &stubExecHandle{})
-	exec.closed = true // Done intentionally left open
-
-	if err := exec.AttachSignal(int(syscall.SIGTERM)); err == nil {
-		t.Fatal("AttachSignal with closed=true and Done open must error, got nil")
-	}
-}

--- a/apps/runner/pkg/boxlite/exec_manager_test.go
+++ b/apps/runner/pkg/boxlite/exec_manager_test.go
@@ -764,3 +764,18 @@ func TestAttachWriteStdinClosedExecErrors(t *testing.T) {
 		t.Fatal("AttachWriteStdin on a Done exec must error, got nil")
 	}
 }
+
+// The complementary window: the inner defer has run (handle.Close + closed=true)
+// but the outer defer that closes Done hasn't, so closed is set while Done is
+// still open. finishedLocked must reject here via the `closed` branch — this
+// pins that the Done-first refactor did not turn `closed` into dead code.
+// Done left open; execution is non-nil, so closed is the sole error source.
+func TestAttachSignalClosedFlagNoDoneErrors(t *testing.T) {
+	m := newQuietManager(t)
+	exec := registerStub(t, m, "attach-sig-closedflag", &stubExecHandle{})
+	exec.closed = true // Done intentionally left open
+
+	if err := exec.AttachSignal(int(syscall.SIGTERM)); err == nil {
+		t.Fatal("AttachSignal with closed=true and Done open must error, got nil")
+	}
+}

--- a/apps/runner/pkg/boxlite/exec_manager_test.go
+++ b/apps/runner/pkg/boxlite/exec_manager_test.go
@@ -727,3 +727,40 @@ func TestSdkExecSignalReturnsUnsupported(t *testing.T) {
 		t.Fatalf("expected ErrSignalUnsupported, got %v", err)
 	}
 }
+
+// Done-vs-closed race for the attach (WebSocket) control ops. Done (process
+// finished) is set before the closed flag in abnormal exits; these ops must
+// reject a finished exec rather than act on a dead handle. Two-side: without
+// the Done check the stub ops succeed (return nil); with it they error.
+
+func TestAttachSignalClosedExecErrors(t *testing.T) {
+	m := newQuietManager(t)
+	exec := registerStub(t, m, "attach-sig", &stubExecHandle{})
+	close(exec.Done)
+
+	if err := exec.AttachSignal(int(syscall.SIGTERM)); err == nil {
+		t.Fatal("AttachSignal on a Done exec must error, got nil")
+	}
+}
+
+func TestAttachResizeClosedExecErrors(t *testing.T) {
+	m := newQuietManager(t)
+	exec := registerStub(t, m, "attach-resize", &stubExecHandle{})
+	exec.TTY = true // ensure the only error source is the Done check, not !TTY
+	close(exec.Done)
+
+	if err := exec.AttachResize(40, 120); err == nil {
+		t.Fatal("AttachResize on a Done exec must error, got nil")
+	}
+}
+
+func TestAttachWriteStdinClosedExecErrors(t *testing.T) {
+	m := newQuietManager(t)
+	exec := registerStub(t, m, "attach-stdin", &stubExecHandle{})
+	exec.stdinW = writerOnly{} // a live writer, so only Done causes the error
+	close(exec.Done)
+
+	if _, err := exec.AttachWriteStdin([]byte("data")); err == nil {
+		t.Fatal("AttachWriteStdin on a Done exec must error, got nil")
+	}
+}


### PR DESCRIPTION
## Bug

Inside `ManagedExec`, after the box process has exited, exec-control ops (signal / resize / write-stdin / attach-*) must consult the canonical "exec finished" signal and refuse to act on a released C handle.

Previously two flags answered the same question and could desynchronize: `Done chan struct{}` (broadcast by the wait goroutine's outermost defer, panic-safe) and `closed bool` (set by a nested defer that an abnormal exit can skip). The original review feedback called this out — the dual-flag pattern was papering over a lifecycle ordering issue rather than fixing it.

## Fix

Make `Done` the single canonical "exec finished, do not touch handle/stdin" signal across the whole lifecycle:

- **Wait goroutine cleanup is one defer with `close(Done)` first** — panic-safe and ordered strictly before `handle.Close()` and bus closures. Any control op observing `Done == closed` knows the C handle is being or has been released.
- **`closed bool` field deleted.** There is no longer any window where one flag is set and the other isn't.
- **`finishedLocked()` is a pure non-blocking `<-Done` check.** Used by every control / cleanup site (8 in total): the 5 attach-control ops (`Signal`, `ResizeTTY`, `AttachWriteStdin`, `AttachResize`, `AttachSignal`) plus the 3 reaper paths (`escalate`, `killAndEvict`, `ReapingKill` cleanup) that were left raw in earlier rounds — now consistent.
- **Lock ordering unchanged.** `handleMu` still serializes `handle.Close` against in-flight ops. A control op arriving after `close(Done)` but before the defer's `handle.Close` sees Done closed and bails via `finishedLocked`.

The per-resource nil check (`e.execution == nil` / `e.stdinW == nil`) stays at the call site because the resource being checked differs per operation.

## Test plan

Run with `-tags boxlite_dev`. After collapsing to a single signal, the only reachable "finished" state is `<-Done` returning. The PR-D-era matrix of "closed-caught vs Done-caught" rows collapses to one row.

Done-caught row (`close(exec.Done)`):

- `TestAttachSignalClosedExecErrors` (pkg/boxlite)
- `TestAttachResizeClosedExecErrors` (pkg/boxlite)
- `TestAttachWriteStdinClosedExecErrors` (pkg/boxlite)
- `TestBoxliteExecResizeClosedReturns409` (pkg/api/controllers)
- `TestBoxliteExecSignalClosedReturns409` (pkg/api/controllers)

`TestAttachSignalClosedFlagNoDoneErrors` (which pinned the dual-flag desync) is removed — that state is now unreachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed resize operation behavior on closed executions—now correctly returns HTTP 409 Conflict instead of potentially returning 404 or silently failing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->