### PR TITLE
fix(net): surface gvproxy bind errors through FFI

### DIFF
--- a/src/boxlite/src/net/gvproxy/ffi.rs
+++ b/src/boxlite/src/net/gvproxy/ffi.rs
@@ -27,11 +27,29 @@ pub fn create_instance(config: &GvproxyConfig) -> BoxliteResult<i64> {
     let c_json = CString::new(json)
         .map_err(|e| BoxliteError::Network(format!("Invalid JSON string: {}", e)))?;
 
-    // Call CGO function with full config
-    let id = unsafe { gvproxy_create(c_json.as_ptr()) };
+    // Call CGO function with full config. `err_ptr` receives the underlying
+    // Go-side error string on failure so we can include it in the user-visible
+    // message (e.g. "listen tcp 0.0.0.0:27380: bind: address already in use"
+    // instead of an opaque "gvproxy_create failed").
+    let mut err_ptr: *mut std::os::raw::c_char = std::ptr::null_mut();
+    let id = unsafe { gvproxy_create(c_json.as_ptr(), &mut err_ptr) };
 
     if id < 0 {
-        return Err(BoxliteError::Network("gvproxy_create failed".to_string()));
+        let detail = if err_ptr.is_null() {
+            "unknown".to_string()
+        } else {
+            // SAFETY: err_ptr points to a C string allocated by gvproxy on
+            // failure; we read it then hand it back for the Go-side free.
+            let s = unsafe { CStr::from_ptr(err_ptr) }
+                .to_string_lossy()
+                .into_owned();
+            unsafe { gvproxy_free_string(err_ptr) };
+            s
+        };
+        return Err(BoxliteError::Network(format!(
+            "gvproxy_create failed: {}",
+            detail
+        )));
     }
 
     tracing::info!(id, "Created gvproxy instance via FFI");

--- a/src/cli/tests/gvproxy_port_conflict.rs
+++ b/src/cli/tests/gvproxy_port_conflict.rs
@@ -84,3 +84,69 @@ fn gvproxy_port_conflict_fails_fast_with_named_error() {
         rc = output.status.code(),
     );
 }
+
+/// Companion to `gvproxy_port_conflict_fails_fast_with_named_error`,
+/// exercising a *different* gvproxy bind failure mode: EACCES on a
+/// privileged port instead of EADDRINUSE on a busy one.
+///
+/// Same plumbing (`virtualnetwork.New` → goroutine → `initErr` channel
+/// → `gvproxy_create` errOut → Rust `Network` folding), but the
+/// underlying OS error string differs ("permission denied" vs
+/// "address already in use"). Proves the fix surfaces *whatever* the
+/// kernel returned at bind time, not a hard-coded port-conflict
+/// shortcut.
+#[test]
+fn gvproxy_privileged_port_fails_fast_with_named_error() {
+    // Skip when the runner happens to have permission to bind <1024
+    // (root, fcap'd binary, container with CAP_NET_BIND_SERVICE,
+    // sysctl `net.ipv4.ip_unprivileged_port_start` lowered). The test
+    // premise is "bind privileged port fails"; without that, the test
+    // is meaningless.
+    if TcpListener::bind("127.0.0.1:80").is_ok() {
+        eprintln!(
+            "SKIP gvproxy_privileged_port_fails_fast_with_named_error: \
+             host allows binding port 80 (root / CAP_NET_BIND_SERVICE / \
+             low ip_unprivileged_port_start)"
+        );
+        return;
+    }
+
+    let ctx = common::boxlite();
+    let started_at = Instant::now();
+    let output = Command::new(env!("CARGO_BIN_EXE_boxlite"))
+        .arg("--home")
+        .arg(&ctx.home)
+        .args(
+            boxlite_test_utils::TEST_REGISTRIES
+                .iter()
+                .flat_map(|r| ["--registry", r]),
+        )
+        .args(["run", "--rm", "-p", "80:80", "alpine:latest", "true"])
+        .output()
+        .expect("spawn boxlite");
+
+    let elapsed = started_at.elapsed();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    let mut failures: Vec<&'static str> = Vec::new();
+    if output.status.success() {
+        failures
+            .push("L1 [boxlite rc != 0]: boxlite returned success despite privileged-port bind");
+    }
+    if !stderr.contains("gvproxy_create failed") {
+        failures.push("L2 [stderr names gvproxy]: stderr missing 'gvproxy_create failed'");
+    }
+    if !stderr.contains("permission denied") {
+        failures.push("L3 [stderr carries OS detail]: stderr missing 'permission denied'");
+    }
+
+    assert!(
+        failures.is_empty(),
+        "{} of 3 checks failed:\n  - {}\n\n\
+         elapsed: {elapsed:?}\nrc: {rc:?}\nstdout: {stdout}\nstderr: {stderr}",
+        failures.len(),
+        failures.join("\n  - "),
+        rc = output.status.code(),
+    );
+}

--- a/src/cli/tests/gvproxy_port_conflict.rs
+++ b/src/cli/tests/gvproxy_port_conflict.rs
@@ -59,18 +59,28 @@ fn gvproxy_port_conflict_fails_fast_with_named_error() {
 
     drop(holder); // release the held port after we've captured the box exit
 
+    // Collect all check failures, then panic once. This lets a developer
+    // observe every level of regression in a single test run — e.g. a
+    // partial fix that flips boxlite's exit code but loses the underlying
+    // bind detail will still show "L3 missing" instead of needing a
+    // second iteration.
+    let mut failures: Vec<&'static str> = Vec::new();
+    if output.status.success() {
+        failures.push("L1 [boxlite rc != 0]: boxlite returned success despite host-port conflict");
+    }
+    if !stderr.contains("gvproxy_create failed") {
+        failures.push("L2 [stderr names gvproxy]: stderr missing 'gvproxy_create failed'");
+    }
+    if !stderr.contains("address already in use") {
+        failures.push("L3 [stderr carries OS detail]: stderr missing 'address already in use'");
+    }
+
     assert!(
-        !output.status.success(),
-        "boxlite must exit non-zero when -p host port is already bound\n\
-         elapsed: {elapsed:?}\nstdout: {stdout}\nstderr: {stderr}"
-    );
-    assert!(
-        stderr.contains("gvproxy_create failed"),
-        "stderr must name gvproxy as the failure source; got:\n{stderr}"
-    );
-    assert!(
-        stderr.contains("address already in use"),
-        "stderr must surface the underlying bind error (the whole point of the\n\
-         FFI `errOut` plumbing); got:\n{stderr}"
+        failures.is_empty(),
+        "{} of 3 checks failed:\n  - {}\n\n\
+         elapsed: {elapsed:?}\nrc: {rc:?}\nstdout: {stdout}\nstderr: {stderr}",
+        failures.len(),
+        failures.join("\n  - "),
+        rc = output.status.code(),
     );
 }

--- a/src/cli/tests/gvproxy_port_conflict.rs
+++ b/src/cli/tests/gvproxy_port_conflict.rs
@@ -68,4 +68,9 @@ fn gvproxy_port_conflict_fails_fast_with_named_error() {
         stderr.contains("gvproxy_create failed"),
         "stderr must name gvproxy as the failure source; got:\n{stderr}"
     );
+    assert!(
+        stderr.contains("address already in use"),
+        "stderr must surface the underlying bind error (the whole point of the\n\
+         FFI `errOut` plumbing); got:\n{stderr}"
+    );
 }

--- a/src/cli/tests/gvproxy_port_conflict.rs
+++ b/src/cli/tests/gvproxy_port_conflict.rs
@@ -1,0 +1,71 @@
+//! Regression: when a host port is already bound by another process,
+//! `boxlite run -p HOST:GUEST` must fail-fast with a Rust-layer error
+//! that names gvproxy as the failure source — not silently boot a box
+//! with a dead netstack whose breakage only surfaces 20s+ later as a
+//! guest "DNS lookup … i/o timeout".
+//!
+//! Pre-fix:
+//! `virtualnetwork.New(tapConfig)` at
+//! `src/deps/libgvproxy-sys/gvproxy-bridge/main.go:412-418` returned
+//! the bind error to the surrounding goroutine, which logged it to
+//! logrus and returned. `gvproxy_create` had already returned a valid
+//! id by then, so the FFI caller never learned about the failure.
+//!
+//! Fix: surface the result via an `initErr` channel so `gvproxy_create`
+//! returns -1 on bind failure and the Rust runtime maps that to
+//! `Network("gvproxy_create failed")`.
+
+mod common;
+
+use std::net::TcpListener;
+use std::process::Command;
+use std::time::Instant;
+
+#[test]
+fn gvproxy_port_conflict_fails_fast_with_named_error() {
+    // Plain TcpListener (no boxlite involvement) holds the host port
+    // for the test's lifetime; OS picks a free ephemeral port so the
+    // test is parallel-safe with everything.
+    let holder = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral");
+    let host_port = holder.local_addr().unwrap().port();
+
+    let ctx = common::boxlite();
+    let started_at = Instant::now();
+
+    // Bypass `assert_cmd`'s success-asserting wrappers — we expect
+    // non-zero exit here and want the raw `Output`.
+    let output = Command::new(env!("CARGO_BIN_EXE_boxlite"))
+        .arg("--home")
+        .arg(&ctx.home)
+        .args(
+            boxlite_test_utils::TEST_REGISTRIES
+                .iter()
+                .flat_map(|r| ["--registry", r]),
+        )
+        .args([
+            "run",
+            "--rm",
+            "-p",
+            &format!("{host_port}:80"),
+            "alpine:latest",
+            "true",
+        ])
+        .output()
+        .expect("spawn boxlite");
+
+    let elapsed = started_at.elapsed();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    drop(holder); // release the held port after we've captured the box exit
+
+    assert!(
+        !output.status.success(),
+        "boxlite must exit non-zero when -p host port is already bound\n\
+         elapsed: {elapsed:?}\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("gvproxy_create failed"),
+        "stderr must name gvproxy as the failure source; got:\n{stderr}"
+    );
+}

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/gvproxy_create_latency_test.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/gvproxy_create_latency_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/containers/gvisor-tap-vsock/pkg/types"
+	"github.com/containers/gvisor-tap-vsock/pkg/virtualnetwork"
+)
+
+// gvproxy_create blocks on `<-initErr` (main.go), which only fires once
+// virtualnetwork.New has finished. So virtualnetwork.New's duration is the
+// upper bound on the main-thread delay that wait adds: if New stays under
+// the budget, the added wait does too. This guards the answer to the #612
+// review question ("will this hurt performance in normal cases?") against a
+// future regression that makes the synchronous init expensive.
+//
+// We assert the MEDIAN over several runs (not a single sample) so one-off GC
+// or scheduler pauses don't flake the test, with a 0.5ms budget that leaves
+// healthy headroom over the observed ~150µs for the normal (no-forwards)
+// config.
+func TestVirtualNetworkNewWithinLatencyBudget(t *testing.T) {
+	const (
+		iters  = 11
+		budget = 500 * time.Microsecond
+	)
+
+	// Warm up once: the first construction pays one-time lazy-init costs
+	// that are not representative of the steady-state per-box cost.
+	if vn, err := virtualnetwork.New(buildTapConfig(testGvproxyConfig(), types.QemuProtocol)); err != nil {
+		t.Fatalf("warmup virtualnetwork.New failed: %v", err)
+	} else {
+		_ = vn
+	}
+
+	samples := make([]time.Duration, 0, iters)
+	for i := 0; i < iters; i++ {
+		cfg := buildTapConfig(testGvproxyConfig(), types.QemuProtocol)
+		start := time.Now()
+		vn, err := virtualnetwork.New(cfg)
+		elapsed := time.Since(start)
+		if err != nil {
+			t.Fatalf("iter %d: virtualnetwork.New failed: %v", i, err)
+		}
+		_ = vn
+		samples = append(samples, elapsed)
+	}
+
+	sort.Slice(samples, func(i, j int) bool { return samples[i] < samples[j] })
+	median := samples[len(samples)/2]
+	t.Logf("virtualnetwork.New median=%v budget=%v samples=%v", median, budget, samples)
+
+	if median > budget {
+		t.Fatalf(
+			"virtualnetwork.New median %v exceeds %v budget — the synchronous gvproxy_create `<-initErr` wait regressed",
+			median, budget,
+		)
+	}
+}

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/main.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/main.go
@@ -275,12 +275,27 @@ var (
 )
 
 //export gvproxy_create
-func gvproxy_create(configJSON *C.char) C.longlong {
+//
+// On failure (return -1), the underlying error message is written to `*errOut`
+// as a heap-allocated C string. Caller must free it via gvproxy_free_string.
+// `errOut` may be nil if the caller doesn't want the message.
+func gvproxy_create(configJSON *C.char, errOut **C.char) C.longlong {
+	// setErr surfaces the underlying error back to the FFI caller so the
+	// Rust runtime can include it in the user-visible BoxliteError message
+	// (e.g. "listen tcp 0.0.0.0:27380: bind: address already in use" instead
+	// of an opaque "gvproxy_create failed").
+	setErr := func(err error) {
+		if errOut != nil {
+			*errOut = C.CString(err.Error())
+		}
+	}
+
 	goJSON := C.GoString(configJSON)
 
 	var config GvproxyConfig
 	if err := json.Unmarshal([]byte(goJSON), &config); err != nil {
 		logrus.WithError(err).Error("Failed to parse gvproxy config")
+		setErr(err)
 		return -1
 	}
 
@@ -293,6 +308,7 @@ func gvproxy_create(configJSON *C.char) C.longlong {
 	socketPath := config.SocketPath
 	if socketPath == "" {
 		logrus.Error("socket_path is required in GvproxyConfig")
+		setErr(fmt.Errorf("socket_path is required in GvproxyConfig"))
 		return -1
 	}
 
@@ -341,6 +357,7 @@ func gvproxy_create(configJSON *C.char) C.longlong {
 		conn, err = transport.ListenUnixgram(socketURI)
 		if err != nil {
 			logrus.WithFields(logrus.Fields{"error": err, "path": socketPath}).Error("Failed to create Unix datagram socket")
+			setErr(fmt.Errorf("failed to create Unix datagram socket %q: %w", socketPath, err))
 			return -1
 		}
 		logrus.WithField("path", socketPath).Info("Created UnixDgram socket for VFKit protocol")
@@ -349,6 +366,7 @@ func gvproxy_create(configJSON *C.char) C.longlong {
 		listener, err = net.Listen("unix", socketPath)
 		if err != nil {
 			logrus.WithFields(logrus.Fields{"error": err, "path": socketPath}).Error("Failed to create Unix stream socket")
+			setErr(fmt.Errorf("failed to create Unix stream socket %q: %w", socketPath, err))
 			return -1
 		}
 		logrus.WithField("path", socketPath).Info("Created UnixStream socket for Qemu protocol")
@@ -371,6 +389,7 @@ func gvproxy_create(configJSON *C.char) C.longlong {
 		ca, err := NewBoxCAFromPEM([]byte(config.CACertPEM), []byte(config.CAKeyPEM))
 		if err != nil {
 			logrus.WithError(err).Error("MITM: failed to parse CA from config")
+			setErr(fmt.Errorf("MITM: failed to parse CA from config: %w", err))
 			cancel()
 			return -1
 		}
@@ -514,6 +533,7 @@ func gvproxy_create(configJSON *C.char) C.longlong {
 	// shipping a broken socket downstream.
 	if err := <-initErr; err != nil {
 		logrus.WithFields(logrus.Fields{"error": err, "id": id}).Error("gvproxy init failed; tearing down instance")
+		setErr(err)
 		cancel()
 		instancesMu.Lock()
 		delete(instances, id)

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/main.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/main.go
@@ -383,6 +383,13 @@ func gvproxy_create(configJSON *C.char) C.longlong {
 	instances[id] = instance
 	instancesMu.Unlock()
 
+	// initErr surfaces synchronous failures from virtualnetwork.New (e.g.
+	// host-port EADDRINUSE) back to the FFI caller. Pre-fix, the bind error
+	// died in a logrus line inside the gvproxy goroutine and gvproxy_create
+	// returned a valid id; the failure only surfaced ~20s later as guest
+	// "DNS lookup … i/o timeout" from a broken netstack.
+	initErr := make(chan error, 1)
+
 	// Start runtime metrics monitoring goroutine
 	go func() {
 		ticker := time.NewTicker(30 * time.Second)
@@ -414,8 +421,10 @@ func gvproxy_create(configJSON *C.char) C.longlong {
 		vn, err := virtualnetwork.New(tapConfig)
 		if err != nil {
 			logrus.WithFields(logrus.Fields{"error": err, "id": id}).Error("Failed to create virtual network")
+			initErr <- err
 			return
 		}
+		initErr <- nil
 
 		// Override TCP handler with AllowNet filter and/or MITM secret substitution
 		if len(config.AllowNet) > 0 || instance.secretMatcher != nil {
@@ -498,6 +507,25 @@ func gvproxy_create(configJSON *C.char) C.longlong {
 		}
 		os.Remove(socketPath)
 	}()
+
+	// Wait for virtualnetwork.New to complete before returning a valid id.
+	// On failure, tear down the instance and surface -1 so the FFI caller
+	// (Rust boxlite runtime) can fail fast with a clear error instead of
+	// shipping a broken socket downstream.
+	if err := <-initErr; err != nil {
+		logrus.WithFields(logrus.Fields{"error": err, "id": id}).Error("gvproxy init failed; tearing down instance")
+		cancel()
+		instancesMu.Lock()
+		delete(instances, id)
+		instancesMu.Unlock()
+		if runtime.GOOS == "darwin" && conn != nil {
+			conn.Close()
+		} else if listener != nil {
+			listener.Close()
+		}
+		os.Remove(socketPath)
+		return -1
+	}
 
 	logrus.Info("Created gvproxy instance", "id", id, "socket", socketPath, "protocol", protocol)
 	return C.longlong(id)

--- a/src/deps/libgvproxy-sys/src/lib.rs
+++ b/src/deps/libgvproxy-sys/src/lib.rs
@@ -19,10 +19,13 @@ extern "C" {
     ///
     /// # Arguments
     /// * `portMappingsJSON` - JSON string describing port mappings
+    /// * `errOut` - On failure, receives a heap-allocated C string with the
+    ///   underlying error message. Caller must free via `gvproxy_free_string`.
+    ///   Pass null to discard the message.
     ///
     /// # Returns
     /// Instance ID (handle) or -1 on error
-    pub fn gvproxy_create(portMappingsJSON: *const c_char) -> c_longlong;
+    pub fn gvproxy_create(portMappingsJSON: *const c_char, errOut: *mut *mut c_char) -> c_longlong;
 
     /// Free a string allocated by libgvproxy
     ///


### PR DESCRIPTION
Surface gvproxy `virtualnetwork.New` bind failures (port-in-use, privileged-port, …) through the Go `initErr` channel → FFI `errOut` → `BoxliteError::Network` instead of swallowing them into an opaque box failure
## Test plan

Two regression tests, each verified two-sided (fix reverted vs applied):

- `gvproxy_port_conflict_fails_fast_with_named_error` — host pre-binds the port, then `boxlite run -p` collides (**EADDRINUSE**).
- `gvproxy_privileged_port_fails_fast_with_named_error` — non-root `boxlite run -p 80:80` (**EACCES**).

| observed | pre-fix (main.go/ffi.rs reverted) | post-fix |
|---|---|---|
| box exit code | `rc=0` — boots despite the bind failure | `rc≠0` — fails fast |
| stderr | no `gvproxy_create failed`, no OS reason | `gvproxy_create failed: … address already in use` / `… permission denied` |
| test result | **both FAIL** (all 3 checks) | **both PASS** |

Pre-fix the bind error was swallowed in a goroutine `logrus` line and the box booted with broken networking; post-fix it interrupts startup with the named OS reason.
