### PR TITLE
[high] fix(vmm): reap shim after kill in rm-force + async-death paths (Issue #523)

### DIFF
--- a/src/boxlite/src/litebox/box_impl.rs
+++ b/src/boxlite/src/litebox/box_impl.rs
@@ -844,6 +844,63 @@ impl BoxImpl {
 
                     // If shim died, mark as Unhealthy and stop health check immediately
                     if shim_died {
+                        // Reap the zombie so the PID slot is freed. `is_process_alive`
+                        // returns false for `State: Z`, so the detector caught a dead
+                        // *or* a zombie — but if it's a zombie, the kernel keeps the
+                        // PID slot occupied until somebody `waitpid`s. Health check
+                        // is the natural reaper here: only background task observing
+                        // shim liveness, parent (this process) still owns the SIGCHLD
+                        // relationship, and nobody else does it — the synchronous
+                        // `stop()` / non-force `rm` paths reap via their own
+                        // `Child::wait()`; this branch covers everything else: OOM
+                        // kill, external SIGKILL/SIGTERM, internal panic.
+                        if let Some(pid) = pid {
+                            // Reap with a short retry loop. SIGKILL→zombie
+                            // transition is fast but not always synchronous
+                            // with the wait queue: WNOHANG can briefly return
+                            // 0 before the kernel posts the SIGCHLD/wait
+                            // status, even when /proc already shows State: Z.
+                            // Bounded by `REAP_DEADLINE_MS` to avoid stalling
+                            // the health check loop on a wedged shim.
+                            const REAP_DEADLINE_MS: u64 = 500;
+                            let deadline = std::time::Instant::now()
+                                + std::time::Duration::from_millis(REAP_DEADLINE_MS);
+                            loop {
+                                let mut status: i32 = 0;
+                                // SAFETY: documented C ABI; pid fits libc::pid_t.
+                                let r = unsafe {
+                                    libc::waitpid(pid as libc::pid_t, &mut status, libc::WNOHANG)
+                                };
+                                if r > 0 {
+                                    tracing::debug!(
+                                        box_id = %box_id, pid, raw_status = status,
+                                        "Reaped dead shim from health check"
+                                    );
+                                    break;
+                                }
+                                if r < 0 {
+                                    // ECHILD: not our child or already reaped.
+                                    tracing::debug!(
+                                        box_id = %box_id, pid,
+                                        error = %std::io::Error::last_os_error(),
+                                        "waitpid for dead shim returned error \
+                                         (likely ECHILD)"
+                                    );
+                                    break;
+                                }
+                                if std::time::Instant::now() >= deadline {
+                                    tracing::warn!(
+                                        box_id = %box_id, pid,
+                                        "Dead shim not reapable within {}ms; \
+                                         leaving for runtime drop / OS",
+                                        REAP_DEADLINE_MS
+                                    );
+                                    break;
+                                }
+                                std::thread::sleep(std::time::Duration::from_millis(10));
+                            }
+                        }
+
                         let mut state_guard = state.write();
                         state_guard.force_status(BoxStatus::Stopped);
                         state_guard.set_pid(None);

--- a/src/boxlite/src/litebox/box_impl.rs
+++ b/src/boxlite/src/litebox/box_impl.rs
@@ -321,6 +321,24 @@ impl BoxImpl {
     }
 
     pub(crate) async fn stop(&self) -> BoxliteResult<()> {
+        self.stop_impl(false).await
+    }
+
+    /// Force-stop variant for `rm --force`: skips the SIGTERM grace
+    /// phase + the 10 s guest-agent shutdown wait, and goes straight to
+    /// SIGKILL via `ShimHandler::stop_force()`. Shares the rest of the
+    /// teardown pipeline with `stop()` (health-check cancel, PID-file
+    /// cleanup, state transition, DB sync, listener notification) so
+    /// the only behavioural delta is "no graceful steps". This aligns
+    /// `rm --force` with the canonical 持-Child kill path; the inline
+    /// `kill_process + libc::waitpid` block in `rt_impl::remove_box`'s
+    /// force branch is now a fallback for direct sync callers
+    /// (Drop / tests) that bypass the async surface.
+    pub(crate) async fn stop_force(&self) -> BoxliteResult<()> {
+        self.stop_impl(true).await
+    }
+
+    async fn stop_impl(&self, force: bool) -> BoxliteResult<()> {
         let t0 = Instant::now();
 
         // Early exit if already stopped (idempotent, prevents double-counting)
@@ -357,22 +375,33 @@ impl BoxImpl {
         if should_attach && let Ok(live) = self.live_state().await {
             // Recovered boxes lazy-attach here via vmm_attach (now
             // ProcessIdentity-gated). Live boxes hit the cached LiveState.
-            // Either way the teardown is identical:
-            let guest_shutdown = async {
-                if let Ok(mut guest) = live.guest_session.guest().await {
-                    let _ = guest.shutdown().await;
+            // Force path skips the graceful guest-agent shutdown
+            // (operator asked for `rm --force` precisely to not wait).
+            if !force {
+                let guest_shutdown = async {
+                    if let Ok(mut guest) = live.guest_session.guest().await {
+                        let _ = guest.shutdown().await;
+                    }
+                };
+                if tokio::time::timeout(Duration::from_secs(10), guest_shutdown)
+                    .await
+                    .is_err()
+                {
+                    tracing::warn!(box_id = %self.config.id, "Guest shutdown timed out after 10s");
                 }
-            };
-            if tokio::time::timeout(Duration::from_secs(10), guest_shutdown)
-                .await
-                .is_err()
-            {
-                tracing::warn!(box_id = %self.config.id, "Guest shutdown timed out after 10s");
             }
 
-            // Stop handler
+            // Stop handler — SIGTERM-then-SIGKILL for `stop`, immediate
+            // SIGKILL for `stop_force`. Both paths block on
+            // `Child::wait()` (the 持-Child canonical reap) when the
+            // handler owns a Child, or fall back to `libc::waitpid`
+            // in attached mode.
             if let Ok(mut handler) = live.handler.lock() {
-                handler.stop()?;
+                if force {
+                    handler.stop_force()?;
+                } else {
+                    handler.stop()?;
+                }
             }
         }
         // If live_state() failed (vmm_attach said Absent — shim is gone),
@@ -446,7 +475,11 @@ impl BoxImpl {
             .boxes_stopped
             .fetch_add(1, Ordering::Relaxed);
 
-        if self.config.options.auto_remove {
+        // Skip auto_remove when force-stopping — `rm --force` is the
+        // caller, and it'll run `runtime.remove_box` itself once
+        // stop_force returns. Triggering remove_box from here would
+        // race with the caller's own removal.
+        if !force && self.config.options.auto_remove {
             self.runtime.remove_box(self.id(), false)?;
         }
 
@@ -1165,6 +1198,10 @@ impl crate::runtime::backend::BoxBackend for BoxImpl {
 
     async fn stop(&self) -> BoxliteResult<()> {
         self.stop().await
+    }
+
+    async fn stop_force(&self) -> BoxliteResult<()> {
+        self.stop_force().await
     }
 
     async fn copy_into(

--- a/src/boxlite/src/litebox/box_impl.rs
+++ b/src/boxlite/src/litebox/box_impl.rs
@@ -888,58 +888,17 @@ impl BoxImpl {
                         // `Child::wait()`; this branch covers everything else: OOM
                         // kill, external SIGKILL/SIGTERM, internal panic.
                         if let Some(pid) = pid {
-                            // Reap with a short retry loop. SIGKILL→zombie
-                            // transition is fast but not always synchronous
-                            // with the wait queue: WNOHANG can briefly return
-                            // 0 before the kernel posts the SIGCHLD/wait
-                            // status, even when /proc already shows State: Z.
-                            // Bounded by `REAP_DEADLINE_MS` to avoid stalling
-                            // the health check loop on a wedged shim.
-                            //
-                            // `tokio::time::sleep().await` (not `std::thread
-                            // ::sleep`) — this runs inside a `tokio::spawn`
-                            // task, and `std::thread::sleep` would block the
-                            // worker thread, starving other tasks on the
-                            // runtime (matters during host-wide shim death
-                            // events where many `shim_died` arms fire at
-                            // once).
+                            // Bounded reap via pidfd (no sleep loop). See
+                            // `util::process::reap_pid_async` — pidfd wakes
+                            // the moment the kernel posts SIGCHLD; tokio
+                            // timeout caps the wait at REAP_DEADLINE_MS on
+                            // a wedged shim. No spawn_blocking thread leak.
                             const REAP_DEADLINE_MS: u64 = 500;
-                            let deadline = std::time::Instant::now()
-                                + std::time::Duration::from_millis(REAP_DEADLINE_MS);
-                            loop {
-                                let mut status: i32 = 0;
-                                // SAFETY: documented C ABI; pid fits libc::pid_t.
-                                let r = unsafe {
-                                    libc::waitpid(pid as libc::pid_t, &mut status, libc::WNOHANG)
-                                };
-                                if r > 0 {
-                                    tracing::debug!(
-                                        box_id = %box_id, pid, raw_status = status,
-                                        "Reaped dead shim from health check"
-                                    );
-                                    break;
-                                }
-                                if r < 0 {
-                                    // ECHILD: not our child or already reaped.
-                                    tracing::debug!(
-                                        box_id = %box_id, pid,
-                                        error = %std::io::Error::last_os_error(),
-                                        "waitpid for dead shim returned error \
-                                         (likely ECHILD)"
-                                    );
-                                    break;
-                                }
-                                if std::time::Instant::now() >= deadline {
-                                    tracing::warn!(
-                                        box_id = %box_id, pid,
-                                        "Dead shim not reapable within {}ms; \
-                                         leaving for runtime drop / OS",
-                                        REAP_DEADLINE_MS
-                                    );
-                                    break;
-                                }
-                                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-                            }
+                            let outcome = crate::util::reap_pid_async(pid, REAP_DEADLINE_MS).await;
+                            tracing::debug!(
+                                box_id = %box_id, pid, ?outcome,
+                                "health check reaped dead shim"
+                            );
                         }
 
                         let mut state_guard = state.write();

--- a/src/boxlite/src/litebox/box_impl.rs
+++ b/src/boxlite/src/litebox/box_impl.rs
@@ -911,32 +911,13 @@ impl BoxImpl {
                         false
                     };
 
-                    // If shim died, mark as Unhealthy and stop health check immediately
+                    // If shim died, mark as Unhealthy and stop health check immediately.
+                    // Zombie cleanup is not health-check's job — the runtime-wide
+                    // SIGCHLD reaper (`util::child_reaper::spawn_child_reaper`,
+                    // wired in `RuntimeImpl::new`) drains every zombie via
+                    // `waitpid(-1, ..., WNOHANG)` the moment the kernel posts
+                    // SIGCHLD, regardless of whether health-check has noticed.
                     if shim_died {
-                        // Reap the zombie so the PID slot is freed. `is_process_alive`
-                        // returns false for `State: Z`, so the detector caught a dead
-                        // *or* a zombie — but if it's a zombie, the kernel keeps the
-                        // PID slot occupied until somebody `waitpid`s. Health check
-                        // is the natural reaper here: only background task observing
-                        // shim liveness, parent (this process) still owns the SIGCHLD
-                        // relationship, and nobody else does it — the synchronous
-                        // `stop()` / non-force `rm` paths reap via their own
-                        // `Child::wait()`; this branch covers everything else: OOM
-                        // kill, external SIGKILL/SIGTERM, internal panic.
-                        if let Some(pid) = pid {
-                            // Bounded reap via pidfd (no sleep loop). See
-                            // `util::process::reap_pid_async` — pidfd wakes
-                            // the moment the kernel posts SIGCHLD; tokio
-                            // timeout caps the wait at REAP_DEADLINE_MS on
-                            // a wedged shim. No spawn_blocking thread leak.
-                            const REAP_DEADLINE_MS: u64 = 500;
-                            let outcome = crate::util::reap_pid_async(pid, REAP_DEADLINE_MS).await;
-                            tracing::debug!(
-                                box_id = %box_id, pid, ?outcome,
-                                "health check reaped dead shim"
-                            );
-                        }
-
                         let mut state_guard = state.write();
                         state_guard.force_status(BoxStatus::Stopped);
                         state_guard.set_pid(None);

--- a/src/boxlite/src/litebox/box_impl.rs
+++ b/src/boxlite/src/litebox/box_impl.rs
@@ -862,6 +862,14 @@ impl BoxImpl {
                             // status, even when /proc already shows State: Z.
                             // Bounded by `REAP_DEADLINE_MS` to avoid stalling
                             // the health check loop on a wedged shim.
+                            //
+                            // `tokio::time::sleep().await` (not `std::thread
+                            // ::sleep`) — this runs inside a `tokio::spawn`
+                            // task, and `std::thread::sleep` would block the
+                            // worker thread, starving other tasks on the
+                            // runtime (matters during host-wide shim death
+                            // events where many `shim_died` arms fire at
+                            // once).
                             const REAP_DEADLINE_MS: u64 = 500;
                             let deadline = std::time::Instant::now()
                                 + std::time::Duration::from_millis(REAP_DEADLINE_MS);
@@ -897,7 +905,7 @@ impl BoxImpl {
                                     );
                                     break;
                                 }
-                                std::thread::sleep(std::time::Duration::from_millis(10));
+                                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
                             }
                         }
 

--- a/src/boxlite/src/litebox/box_impl.rs
+++ b/src/boxlite/src/litebox/box_impl.rs
@@ -5,6 +5,7 @@
 // ============================================================================
 
 use std::sync::Arc;
+use std::sync::Weak;
 use std::sync::atomic::Ordering;
 use std::time::{Duration, Instant};
 
@@ -29,7 +30,7 @@ use crate::metrics::{BoxMetrics, BoxMetricsStorage};
 use crate::portal::GuestSession;
 use crate::portal::interfaces::GuestInterface;
 use crate::runtime::layout::BoxFilesystemLayout;
-use crate::runtime::rt_impl::SharedRuntimeImpl;
+use crate::runtime::rt_impl::{RuntimeImpl, SharedRuntimeImpl};
 use crate::runtime::types::BoxStatus;
 use crate::vmm::controller::VmmHandler;
 use crate::{BoxID, BoxInfo, HealthCheckOptions, HealthState};
@@ -736,21 +737,33 @@ impl BoxImpl {
         // Stash (rename → exit.previous) preserves forensic data.
         crate::runtime::rt_impl::stash_exit_file(&self.layout);
 
-        // Start health check task if configured
+        // Start health check task if configured. Failing to obtain the
+        // guest interface here is non-fatal: health check is best-effort
+        // (liveness ping + zombie reap on async shim death), and
+        // propagating the error would break recovered/attached boxes
+        // whose guest session can't be re-established — `stop_impl`'s
+        // kill branch depends on `live_state()` succeeding.
         if let Some(ref health_config) = self.config.options.advanced.health_check {
-            // Get guest interface from session
-            let guest = live_state.guest_session.guest().await?;
-
-            // Spawn health check task
-            let health_task = self.spawn_health_check(
-                Arc::clone(&self.state),
-                self.config.id.clone(),
-                health_config.to_owned(),
-                guest,
-                self.shutdown_token.child_token(),
-                Arc::clone(&self.runtime),
-            );
-            *self.health_check_task.write() = Some(health_task);
+            match live_state.guest_session.guest().await {
+                Ok(guest) => {
+                    let health_task = self.spawn_health_check(
+                        Arc::clone(&self.state),
+                        self.config.id.clone(),
+                        health_config.to_owned(),
+                        guest,
+                        self.shutdown_token.child_token(),
+                        Arc::downgrade(&self.runtime),
+                    );
+                    *self.health_check_task.write() = Some(health_task);
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        box_id = %self.config.id,
+                        error = %e,
+                        "Skipping health check task: guest session unavailable"
+                    );
+                }
+            }
         }
 
         tracing::info!(
@@ -762,6 +775,16 @@ impl BoxImpl {
         Ok(live_state)
     }
 
+    /// Spawns the periodic health check task.
+    ///
+    /// The task holds a `Weak<RuntimeImpl>` (not Arc) so that an
+    /// out-of-band runtime drop — e.g. the user drops their
+    /// `BoxliteRuntime` handle while a box is detached and the
+    /// box-scoped `shutdown_token` was never cancelled — does not pin
+    /// the runtime alive forever. On each persistence write the task
+    /// `upgrade()`s the Weak; if the runtime is already gone, the
+    /// write is skipped (state would have nowhere to land anyway) and
+    /// the task exits on the next iteration.
     pub fn spawn_health_check(
         &self,
         state: Arc<RwLock<BoxState>>,
@@ -769,7 +792,7 @@ impl BoxImpl {
         health_config: HealthCheckOptions,
         mut guest: GuestInterface,
         shutdown_token: CancellationToken,
-        runtime: SharedRuntimeImpl,
+        runtime: Weak<RuntimeImpl>,
     ) -> JoinHandle<()> {
         let interval = health_config.interval;
         let check_timeout = health_config.timeout;
@@ -800,6 +823,19 @@ impl BoxImpl {
                         break;
                     }
                 }
+
+                // Bail out if the runtime has been dropped. Without
+                // this check the task would keep pinging the guest
+                // forever (no Arc on the runtime to extend its life
+                // and no shutdown_token to cancel us, e.g. detached
+                // box + runtime drop without explicit stop).
+                let Some(runtime) = runtime.upgrade() else {
+                    tracing::debug!(
+                        box_id = %box_id,
+                        "Health check task exiting: runtime dropped"
+                    );
+                    break;
+                };
 
                 let elapsed = start_time.elapsed();
                 let result = if elapsed < start_period {

--- a/src/boxlite/src/litebox/mod.rs
+++ b/src/boxlite/src/litebox/mod.rs
@@ -116,6 +116,17 @@ impl LiteBox {
         self.box_backend.stop().await
     }
 
+    /// Force-stop variant for `rm --force`. Skips the SIGTERM-then-
+    /// SIGKILL graceful phase + the 10 s guest-agent shutdown wait
+    /// that `stop()` does, and sends SIGKILL immediately via the
+    /// canonical 持-Child path (`ShimHandler::stop_force`). Used by
+    /// `LocalRuntime::remove(force=true)` so the kill+reap shares
+    /// the same lifecycle teardown as `stop()` instead of the older
+    /// PID-only `kill_process + libc::waitpid` shortcut.
+    pub async fn stop_force(&self) -> BoxliteResult<()> {
+        self.box_backend.stop_force().await
+    }
+
     /// Copy files/directories from host into the container rootfs.
     pub async fn copy_into(
         &self,

--- a/src/boxlite/src/rest/litebox.rs
+++ b/src/boxlite/src/rest/litebox.rs
@@ -205,6 +205,16 @@ impl BoxBackend for RestBox {
         Ok(())
     }
 
+    async fn stop_force(&self) -> BoxliteResult<()> {
+        // The REST surface doesn't expose a force-stop verb today;
+        // the server side reaches the same outcome through
+        // `DELETE /v1/boxes/<id>?force=true` (which calls
+        // `RuntimeBackend::remove(force=true)` server-side). A
+        // client-driven stop_force currently falls back to graceful
+        // stop — best the wire protocol can do without a new endpoint.
+        self.stop().await
+    }
+
     async fn copy_into(
         &self,
         host_src: &Path,

--- a/src/boxlite/src/rest/litebox.rs
+++ b/src/boxlite/src/rest/litebox.rs
@@ -206,13 +206,25 @@ impl BoxBackend for RestBox {
     }
 
     async fn stop_force(&self) -> BoxliteResult<()> {
-        // The REST surface doesn't expose a force-stop verb today;
-        // the server side reaches the same outcome through
-        // `DELETE /v1/boxes/<id>?force=true` (which calls
-        // `RuntimeBackend::remove(force=true)` server-side). A
-        // client-driven stop_force currently falls back to graceful
-        // stop — best the wire protocol can do without a new endpoint.
-        self.stop().await
+        // Coderabbitai review on #613: previously this silently fell
+        // back to graceful `stop()` — making the public
+        // `LiteBox::stop_force()` contract backend-dependent in a
+        // dangerous way. A caller asking for SIGKILL semantics would
+        // get SIGTERM + wait + auto-fallback instead, with no signal
+        // of the downgrade.
+        //
+        // Until the REST surface gains a real force-stop verb,
+        // return `Unsupported` so the caller can route via
+        // `runtime.remove(.., force=true)` (which maps to
+        // `DELETE /v1/boxes/<id>?force=true`) or fall back to the
+        // local CLI.
+        Err(BoxliteError::Unsupported(
+            "stop_force is not exposed by the REST API; \
+             use `runtime.remove(id, force=true)` which maps to \
+             `DELETE /v1/boxes/<id>?force=true`, or run the local \
+             CLI directly. See PR #613 review for context."
+                .to_string(),
+        ))
     }
 
     async fn copy_into(

--- a/src/boxlite/src/rest/types.rs
+++ b/src/boxlite/src/rest/types.rs
@@ -108,6 +108,17 @@ pub(crate) struct CreateBoxRequest {
     /// behaviour without changing their POST body shape.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub health_check_disabled: Option<bool>,
+    /// Non-default health-check settings (interval / timeout /
+    /// retries / start_period). Omitted when absent OR when the
+    /// settings equal `HealthCheckOptions::default()`, so old clients
+    /// and unmodified BoxOptions keep producing the same POST body.
+    /// Coderabbitai review on #613: prior to this field, the wire
+    /// carried only the disabled bit, so any custom `HealthCheckOptions`
+    /// on the caller side was silently rewritten to defaults on the
+    /// server. Carries the full settings now so local and REST runtimes
+    /// behave identically for the same `BoxOptions`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub health_check_settings: Option<crate::HealthCheckOptions>,
 }
 
 impl CreateBoxRequest {
@@ -134,13 +145,19 @@ impl CreateBoxRequest {
             Some(options.secrets.iter().map(CreateBoxSecret::from).collect())
         };
 
-        // Only set the wire field when the operator explicitly disabled
-        // health check. `None` on the wire = "use server default" (which
-        // is currently `Some(HealthCheckOptions::default())`).
-        let health_check_disabled = if options.advanced.health_check.is_none() {
-            Some(true)
-        } else {
-            None
+        // Health-check policy on the wire:
+        //   - `health_check_disabled = Some(true)` → operator opted out
+        //   - `health_check_settings = Some(opts)` → non-default custom
+        //     settings (carries interval / timeout / retries /
+        //     start_period so the server doesn't silently rewrite them
+        //     to defaults — coderabbitai review on #613).
+        //   - both omitted → caller is using `HealthCheckOptions::default()`,
+        //     server-side default takes over (same shape as before this
+        //     PR, so old clients keep their POST body unchanged).
+        let (health_check_disabled, health_check_settings) = match &options.advanced.health_check {
+            None => (Some(true), None),
+            Some(opts) if opts == &crate::HealthCheckOptions::default() => (None, None),
+            Some(opts) => (None, Some(opts.clone())),
         };
 
         Self {
@@ -161,6 +178,7 @@ impl CreateBoxRequest {
             detach: Some(options.detach),
             security: None, // TODO: map security preset
             health_check_disabled,
+            health_check_settings,
         }
     }
 }
@@ -498,6 +516,7 @@ mod tests {
             detach: None,
             security: None,
             health_check_disabled: None,
+            health_check_settings: None,
         };
         let json = serde_json::to_string(&req).unwrap();
         assert!(json.contains("\"name\":\"mybox\""));
@@ -574,6 +593,61 @@ mod tests {
         assert!(
             json.contains("\"health_check_disabled\":true"),
             "explicit disable must appear on the wire; got: {json}"
+        );
+    }
+
+    /// Coderabbitai review #613: when the caller provides custom
+    /// `HealthCheckOptions` (non-default `interval`, etc.),
+    /// `from_options` MUST carry those on the wire via
+    /// `health_check_settings` — otherwise the server silently
+    /// rewrites them to defaults. Reverting either the field on the
+    /// struct or the match arm in `from_options` flips this red.
+    #[test]
+    fn test_create_box_request_carries_custom_health_check_settings_on_the_wire() {
+        use crate::HealthCheckOptions;
+        use crate::runtime::advanced_options::AdvancedBoxOptions;
+        use crate::runtime::options::{BoxOptions, RootfsSpec};
+        let custom = HealthCheckOptions {
+            interval: std::time::Duration::from_secs(5),
+            timeout: std::time::Duration::from_secs(2),
+            retries: 1,
+            start_period: std::time::Duration::from_secs(0),
+        };
+        let opts = BoxOptions {
+            rootfs: RootfsSpec::Image("alpine:latest".into()),
+            advanced: AdvancedBoxOptions {
+                health_check: Some(custom.clone()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let req = CreateBoxRequest::from_options(&opts, None);
+        assert_eq!(req.health_check_disabled, None);
+        assert_eq!(req.health_check_settings.as_ref(), Some(&custom));
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(
+            json.contains("health_check_settings"),
+            "custom settings must surface on the wire; got: {json}"
+        );
+    }
+
+    /// Default settings: `from_options` must NOT emit
+    /// `health_check_settings` when the caller's options equal
+    /// `HealthCheckOptions::default()` — keeps the wire body
+    /// byte-identical with pre-PR clients.
+    #[test]
+    fn test_create_box_request_omits_health_check_settings_when_default() {
+        use crate::runtime::options::{BoxOptions, RootfsSpec};
+        let opts = BoxOptions {
+            rootfs: RootfsSpec::Image("alpine:latest".into()),
+            ..Default::default()
+        };
+        let req = CreateBoxRequest::from_options(&opts, None);
+        assert_eq!(req.health_check_settings, None);
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(
+            !json.contains("health_check_settings"),
+            "wire form must omit settings on default health check; got: {json}"
         );
     }
 

--- a/src/boxlite/src/rest/types.rs
+++ b/src/boxlite/src/rest/types.rs
@@ -102,6 +102,12 @@ pub(crate) struct CreateBoxRequest {
     pub detach: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub security: Option<String>,
+    /// Disable the per-box health check (Issue #523: also disables
+    /// the async-death zombie reaper that piggybacks on health check).
+    /// Omitted when absent so existing clients keep the default-on
+    /// behaviour without changing their POST body shape.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub health_check_disabled: Option<bool>,
 }
 
 impl CreateBoxRequest {
@@ -128,6 +134,15 @@ impl CreateBoxRequest {
             Some(options.secrets.iter().map(CreateBoxSecret::from).collect())
         };
 
+        // Only set the wire field when the operator explicitly disabled
+        // health check. `None` on the wire = "use server default" (which
+        // is currently `Some(HealthCheckOptions::default())`).
+        let health_check_disabled = if options.advanced.health_check.is_none() {
+            Some(true)
+        } else {
+            None
+        };
+
         Self {
             name,
             image,
@@ -145,6 +160,7 @@ impl CreateBoxRequest {
             auto_remove: Some(options.auto_remove),
             detach: Some(options.detach),
             security: None, // TODO: map security preset
+            health_check_disabled,
         }
     }
 }
@@ -481,6 +497,7 @@ mod tests {
             auto_remove: Some(true),
             detach: None,
             security: None,
+            health_check_disabled: None,
         };
         let json = serde_json::to_string(&req).unwrap();
         assert!(json.contains("\"name\":\"mybox\""));
@@ -532,6 +549,52 @@ mod tests {
         assert_eq!(
             req.secrets.as_ref().unwrap()[0].placeholder,
             "<BOXLITE_SECRET:openai>"
+        );
+    }
+
+    /// Wire serialization: when the operator disabled health check
+    /// (`options.advanced.health_check = None`), `from_options` flips
+    /// `health_check_disabled = Some(true)` on the wire body so the
+    /// server side actually receives the intent.
+    #[test]
+    fn test_create_box_request_carries_health_check_disabled_on_the_wire() {
+        use crate::runtime::advanced_options::AdvancedBoxOptions;
+        use crate::runtime::options::{BoxOptions, RootfsSpec};
+        let opts = BoxOptions {
+            rootfs: RootfsSpec::Image("alpine:latest".into()),
+            advanced: AdvancedBoxOptions {
+                health_check: None,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let req = CreateBoxRequest::from_options(&opts, None);
+        assert_eq!(req.health_check_disabled, Some(true));
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(
+            json.contains("\"health_check_disabled\":true"),
+            "explicit disable must appear on the wire; got: {json}"
+        );
+    }
+
+    /// Backward compat: a `BoxOptions` with the default health_check
+    /// (i.e. `Some(HealthCheckOptions::default())`) omits the wire
+    /// field entirely — old clients/servers that don't know about
+    /// `health_check_disabled` keep behaving exactly as before.
+    #[test]
+    fn test_create_box_request_omits_health_check_disabled_when_default() {
+        use crate::runtime::options::{BoxOptions, RootfsSpec};
+        let opts = BoxOptions {
+            rootfs: RootfsSpec::Image("alpine:latest".into()),
+            // Don't touch `advanced` — uses default (health_check on).
+            ..Default::default()
+        };
+        let req = CreateBoxRequest::from_options(&opts, None);
+        assert_eq!(req.health_check_disabled, None);
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(
+            !json.contains("health_check_disabled"),
+            "wire form must omit the field when default health check is in effect; got: {json}"
         );
     }
 

--- a/src/boxlite/src/runtime/advanced_options.rs
+++ b/src/boxlite/src/runtime/advanced_options.rs
@@ -569,7 +569,7 @@ impl SecurityOptionsBuilder {
 ///
 /// Entry-level users can ignore this — defaults are compatibility-focused.
 /// Only modify these if you understand the security implications.
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AdvancedBoxOptions {
     /// Security isolation options (jailer, seccomp, namespaces, resource limits).
     ///
@@ -594,11 +594,31 @@ pub struct AdvancedBoxOptions {
 
     /// Health check options.
     ///
-    /// When set, a background task will periodically ping the guest agent
-    /// to verify the box is healthy. Unhealthy boxes are marked and can
-    /// trigger automatic recovery.
+    /// When set, a background task periodically pings the guest agent to
+    /// verify the box is healthy, AND — critically for zombie-shim
+    /// prevention (Issue #523) — `waitpid`s the shim if it has died
+    /// asynchronously (OOM, external SIGKILL, internal panic). Detection
+    /// alone isn't enough: a dead shim whose parent never `waitpid`s
+    /// stays in `State: Z` in `/proc` and keeps holding the PID slot.
     ///
-    /// Most users should rely on the defaults.
-    #[serde(default)]
+    /// Default: `Some(HealthCheckOptions::default())` so every box gets
+    /// a watcher without the operator opting in. Disable with explicit
+    /// `health_check: None` if you want neither pings nor zombie reaping
+    /// (you'll then need to handle shim death yourself).
+    #[serde(default = "default_health_check")]
     pub health_check: Option<HealthCheckOptions>,
+}
+
+fn default_health_check() -> Option<HealthCheckOptions> {
+    Some(HealthCheckOptions::default())
+}
+
+impl Default for AdvancedBoxOptions {
+    fn default() -> Self {
+        Self {
+            security: SecurityOptions::default(),
+            isolate_mounts: false,
+            health_check: default_health_check(),
+        }
+    }
 }

--- a/src/boxlite/src/runtime/advanced_options.rs
+++ b/src/boxlite/src/runtime/advanced_options.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 /// Similar to Docker's HEALTHCHECK directive.
 ///
 /// This is an advanced option - most users should rely on the defaults.
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct HealthCheckOptions {
     /// Time between health checks.
     ///

--- a/src/boxlite/src/runtime/backend.rs
+++ b/src/boxlite/src/runtime/backend.rs
@@ -96,6 +96,13 @@ pub(crate) trait BoxBackend: Send + Sync {
 
     async fn stop(&self) -> BoxliteResult<()>;
 
+    /// Force-stop: skip the SIGTERM grace + guest-shutdown wait that
+    /// `stop()` does, kill the shim with SIGKILL via the canonical
+    /// 持-Child path. Used by `rm --force` (Issue #523 / #613) so that
+    /// rm-force's kill+reap shares the same lifecycle teardown as
+    /// `stop()` instead of bypassing the `Child` handle.
+    async fn stop_force(&self) -> BoxliteResult<()>;
+
     async fn copy_into(
         &self,
         host_src: &Path,

--- a/src/boxlite/src/runtime/rt_impl.rs
+++ b/src/boxlite/src/runtime/rt_impl.rs
@@ -831,10 +831,58 @@ impl RuntimeImpl {
             let mut state = state;
             if state.status.is_active() || state.pid.is_some() {
                 if force {
-                    // Force mode: kill the process directly
+                    // Force mode: kill the process directly, then reap.
                     if let Some(pid) = state.pid {
                         tracing::info!(box_id = %id, pid = pid, "Force killing box process");
                         crate::util::kill_process(pid);
+
+                        // Reap the zombie before returning. Mirrors the
+                        // SIGTERM polling loop in
+                        // `vmm/controller/shim.rs::ShimHandler::stop` (the
+                        // canonical existing "kill+wait" pattern in this
+                        // crate). Without this, `boxlite serve` + REST
+                        // `DELETE /v1/boxes/<id>?force=true` returns
+                        // immediately and shim becomes zombie with
+                        // `PPid == daemon pid`; init can't help because
+                        // daemon is still the parent (Issue #523).
+                        const FORCE_REAP_DEADLINE_MS: u64 = 2000;
+                        let deadline = std::time::Instant::now()
+                            + std::time::Duration::from_millis(FORCE_REAP_DEADLINE_MS);
+                        loop {
+                            let mut status: i32 = 0;
+                            // SAFETY: documented C ABI; u32 fits libc::pid_t.
+                            let r = unsafe {
+                                libc::waitpid(pid as libc::pid_t, &mut status, libc::WNOHANG)
+                            };
+                            if r > 0 {
+                                tracing::debug!(
+                                    box_id = %id, pid, raw_status = status,
+                                    "Reaped force-killed shim"
+                                );
+                                break;
+                            }
+                            if r < 0 {
+                                // ECHILD: not our child (e.g. attached mode,
+                                // or daemon doesn't own this child) — nothing
+                                // we can reap from here.
+                                tracing::debug!(
+                                    box_id = %id, pid,
+                                    error = %std::io::Error::last_os_error(),
+                                    "waitpid for force-killed shim errored; \
+                                     nothing to reap from here"
+                                );
+                                break;
+                            }
+                            if std::time::Instant::now() >= deadline {
+                                tracing::warn!(
+                                    box_id = %id, pid,
+                                    "Force-killed shim still not reapable after {}ms",
+                                    FORCE_REAP_DEADLINE_MS
+                                );
+                                break;
+                            }
+                            std::thread::sleep(std::time::Duration::from_millis(50));
+                        }
                     }
                     // Update status to stopped and save
                     state.set_status(BoxStatus::Stopped);

--- a/src/boxlite/src/runtime/rt_impl.rs
+++ b/src/boxlite/src/runtime/rt_impl.rs
@@ -279,6 +279,29 @@ impl RuntimeImpl {
 
         tracing::debug!("initialized runtime");
 
+        // Spawn runtime-wide SIGCHLD child reaper as a safety net for
+        // shim processes that die without going through the normal
+        // `Child::wait` path: external SIGKILL, OOM-kill, panic, or a
+        // dropped `Child` handle. Health-check still reaps per-pid via
+        // `reap_pid_async`; this task handles everything health-check
+        // doesn't see.
+        //
+        // Disabled under `cfg(test)`: cargo runs all unit tests in one
+        // process with parallel threads, and `waitpid(-1)` is
+        // process-wide — a reaper spawned by a `#[tokio::test]` would
+        // race-steal dummy `Child`ren that adjacent `#[test]` cases
+        // are about to `try_wait()`. Production binaries (release +
+        // integration-test binaries) keep the auto-spawn. The reaper's
+        // own behaviour is covered by `util::child_reaper::tests`,
+        // which spawns it directly and asserts on a pid it owns.
+        //
+        // Spawn only when a tokio runtime is available — some test
+        // paths construct `RuntimeImpl` synchronously.
+        #[cfg(not(test))]
+        if tokio::runtime::Handle::try_current().is_ok() {
+            let _reaper = crate::util::spawn_child_reaper(inner.shutdown_token.clone());
+        }
+
         // Recover boxes from database
         inner.recover_boxes()?;
 

--- a/src/boxlite/src/runtime/rt_impl.rs
+++ b/src/boxlite/src/runtime/rt_impl.rs
@@ -844,10 +844,31 @@ impl RuntimeImpl {
 
                         const FORCE_REAP_DEADLINE_MS: u64 = 2000;
                         let outcome = crate::util::reap_pid_blocking(pid, FORCE_REAP_DEADLINE_MS);
-                        tracing::debug!(
-                            box_id = %id, pid, ?outcome,
-                            "rm-force sync fallback reaped shim"
-                        );
+                        // Coderabbitai review on #613: previously this
+                        // logged the outcome and proceeded with full
+                        // destructive cleanup regardless. If the reap
+                        // timed out or returned NotOurChild, the shim
+                        // may still be alive while its home directory
+                        // and disks are being torn down. Gate the
+                        // remaining cleanup on a terminal Reaped
+                        // outcome.
+                        match outcome {
+                            crate::util::ReapOutcome::Reaped => {
+                                tracing::debug!(
+                                    box_id = %id, pid, ?outcome,
+                                    "rm-force sync fallback reaped shim"
+                                );
+                            }
+                            crate::util::ReapOutcome::TimedOut
+                            | crate::util::ReapOutcome::NotOurChild => {
+                                return Err(BoxliteError::Engine(format!(
+                                    "rm --force: shim pid {pid} did not reap cleanly \
+                                     (outcome={outcome:?}). Refusing to delete box state \
+                                     while the shim may still be alive. \
+                                     Investigate the pid manually and retry."
+                                )));
+                            }
+                        }
                     }
                     // Update status to stopped and save
                     state.set_status(BoxStatus::Stopped);

--- a/src/boxlite/src/runtime/rt_impl.rs
+++ b/src/boxlite/src/runtime/rt_impl.rs
@@ -1626,6 +1626,20 @@ impl super::backend::RuntimeBackend for LocalRuntime {
     }
 
     async fn remove(&self, id_or_name: &str, force: bool) -> BoxliteResult<()> {
+        // Force path: route the kill through the canonical 持-Child
+        // `ShimHandler::stop_force` path so `rm --force` shares the
+        // same lifecycle teardown as `stop` / non-force `rm` /
+        // `restart`. After `stop_force()` returns, `state.pid` is
+        // None and the shim is reaped, so the sync `remove_box` call
+        // below skips its inline-waitpid fallback and only does the
+        // DB / disk cleanup.
+        //
+        // If lookup fails (box doesn't exist), let the sync path
+        // surface the not-found error so behaviour stays identical
+        // for that case.
+        if force && let Ok(Some(litebox)) = self.0.get(id_or_name).await {
+            litebox.stop_force().await?;
+        }
         self.0.remove(id_or_name, force)
     }
 

--- a/src/boxlite/src/runtime/rt_impl.rs
+++ b/src/boxlite/src/runtime/rt_impl.rs
@@ -832,57 +832,22 @@ impl RuntimeImpl {
             if state.status.is_active() || state.pid.is_some() {
                 if force {
                     // Force mode: kill the process directly, then reap.
+                    // Production async path goes through
+                    // `LiteBox::stop_force` → `ShimHandler::stop_force`
+                    // (持-Child); this is the sync fallback for direct
+                    // sync callers (Drop, unit tests). Bounded reap via
+                    // pidfd helper — no sleep loop, no blocking-pool
+                    // leak on a wedged shim.
                     if let Some(pid) = state.pid {
                         tracing::info!(box_id = %id, pid = pid, "Force killing box process");
                         crate::util::kill_process(pid);
 
-                        // Reap the zombie before returning. Mirrors the
-                        // SIGTERM polling loop in
-                        // `vmm/controller/shim.rs::ShimHandler::stop` (the
-                        // canonical existing "kill+wait" pattern in this
-                        // crate). Without this, `boxlite serve` + REST
-                        // `DELETE /v1/boxes/<id>?force=true` returns
-                        // immediately and shim becomes zombie with
-                        // `PPid == daemon pid`; init can't help because
-                        // daemon is still the parent (Issue #523).
                         const FORCE_REAP_DEADLINE_MS: u64 = 2000;
-                        let deadline = std::time::Instant::now()
-                            + std::time::Duration::from_millis(FORCE_REAP_DEADLINE_MS);
-                        loop {
-                            let mut status: i32 = 0;
-                            // SAFETY: documented C ABI; u32 fits libc::pid_t.
-                            let r = unsafe {
-                                libc::waitpid(pid as libc::pid_t, &mut status, libc::WNOHANG)
-                            };
-                            if r > 0 {
-                                tracing::debug!(
-                                    box_id = %id, pid, raw_status = status,
-                                    "Reaped force-killed shim"
-                                );
-                                break;
-                            }
-                            if r < 0 {
-                                // ECHILD: not our child (e.g. attached mode,
-                                // or daemon doesn't own this child) — nothing
-                                // we can reap from here.
-                                tracing::debug!(
-                                    box_id = %id, pid,
-                                    error = %std::io::Error::last_os_error(),
-                                    "waitpid for force-killed shim errored; \
-                                     nothing to reap from here"
-                                );
-                                break;
-                            }
-                            if std::time::Instant::now() >= deadline {
-                                tracing::warn!(
-                                    box_id = %id, pid,
-                                    "Force-killed shim still not reapable after {}ms",
-                                    FORCE_REAP_DEADLINE_MS
-                                );
-                                break;
-                            }
-                            std::thread::sleep(std::time::Duration::from_millis(50));
-                        }
+                        let outcome = crate::util::reap_pid_blocking(pid, FORCE_REAP_DEADLINE_MS);
+                        tracing::debug!(
+                            box_id = %id, pid, ?outcome,
+                            "rm-force sync fallback reaped shim"
+                        );
                     }
                     // Update status to stopped and save
                     state.set_status(BoxStatus::Stopped);

--- a/src/boxlite/src/util/child_reaper.rs
+++ b/src/boxlite/src/util/child_reaper.rs
@@ -1,0 +1,163 @@
+//! Runtime-wide child reaper.
+//!
+//! Boxlite forks many sub-processes — shims via `std::process::Command`,
+//! seccomp build helpers, debugfs / mke2fs invocations, jailer userns
+//! probes. The runtime keeps `Child` handles for the long-lived ones
+//! (shims) and reaps them via `Child::wait` on stop / remove. But:
+//!
+//!   - external `SIGKILL` / OOM-kill: shim dies without anyone holding
+//!     a `Child::wait` future, and the kernel keeps the zombie around
+//!     until *someone* calls `waitpid`.
+//!   - panic in the shim: same story.
+//!   - dropped `Child` (e.g. failed init partway through): same story.
+//!
+//! Health-check tasks already cover the "I know which pid died, reap
+//! it" case via `reap_pid_async(pid, ...)` (see `box_impl.rs`). This
+//! module is the runtime-wide *safety net*: a single tokio task that
+//! subscribes to `SIGCHLD` and drains every available zombie via
+//! `waitpid(-1, ..., WNOHANG)`. It catches the cases health-check
+//! never sees — e.g. operator disabled the watcher, the dying pid was
+//! never tracked in a `BoxImpl`, or the shim died during init before
+//! the watcher even spawned.
+//!
+//! It does NOT replace the targeted reap calls inside health-check or
+//! `ShimHandler::stop_force`. Those are deterministic (caller knows
+//! the pid and wants to confirm it exited). This task is the
+//! best-effort sweeper that mops up after them. Whichever side wins
+//! the `waitpid` race first: the kernel just returns ECHILD to the
+//! loser, and the loser treats that as "not our child" (see
+//! `process.rs::reap_pid_blocking` / `reap_pid_async`).
+
+#[cfg(unix)]
+use tokio::signal::unix::{SignalKind, signal};
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+/// Spawn the runtime-wide SIGCHLD reaper task. Returns a `JoinHandle`
+/// the caller stores on `RuntimeImpl` for graceful shutdown.
+///
+/// The task:
+///
+///   1. Registers a `SIGCHLD` signal stream via tokio.
+///   2. On every signal *or* every cancellation check, drains the
+///      kernel's zombie queue via `waitpid(-1, ..., WNOHANG)` in a
+///      loop until it reports `0` (no more zombies) or `-1` (no child
+///      at all — the runtime has no surviving children).
+///   3. Exits cleanly when the `shutdown_token` is cancelled.
+///
+/// SIGCHLD is signal-coalescing — if N children die in quick
+/// succession the kernel may deliver only one signal. The
+/// drain-until-zero loop is what guarantees we don't leave one of
+/// those N permanently zombied.
+///
+/// On non-unix targets the function returns a no-op task that just
+/// awaits the cancellation token. The reaper only matters on Linux
+/// (and incidentally macOS), and tokio's `SignalKind::child()`
+/// doesn't exist on Windows.
+pub fn spawn_child_reaper(shutdown_token: CancellationToken) -> JoinHandle<()> {
+    #[cfg(unix)]
+    {
+        tokio::spawn(async move {
+            let mut sigchld = match signal(SignalKind::child()) {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::error!(error = %e, "failed to register SIGCHLD handler — runtime-wide reaper disabled");
+                    return;
+                }
+            };
+
+            // Drain once at startup in case a child died before the
+            // signal handler was registered (race between RuntimeImpl
+            // construction and an early shim spawn failure).
+            drain_zombies();
+
+            loop {
+                tokio::select! {
+                    _ = shutdown_token.cancelled() => {
+                        tracing::debug!("child reaper: shutdown token cancelled, exiting");
+                        // Last drain on the way out — don't leave anything
+                        // behind for the operator's `pgrep -af` to find.
+                        drain_zombies();
+                        return;
+                    }
+                    sig = sigchld.recv() => {
+                        if sig.is_none() {
+                            // Stream closed (tokio runtime shutting down).
+                            return;
+                        }
+                        drain_zombies();
+                    }
+                }
+            }
+        })
+    }
+
+    #[cfg(not(unix))]
+    {
+        tokio::spawn(async move {
+            shutdown_token.cancelled().await;
+        })
+    }
+}
+
+/// Reap every available zombie via `waitpid(-1, ..., WNOHANG)` until
+/// the kernel reports no more.
+///
+/// Returns silently — failures here are best-effort: if `waitpid`
+/// errors with `ECHILD` we have no children, `EINTR` we'll be called
+/// again on the next signal, anything else is logged at debug.
+#[cfg(unix)]
+fn drain_zombies() {
+    let mut reaped = 0usize;
+    loop {
+        let mut status: libc::c_int = 0;
+        // SAFETY: documented C ABI; we own the `status` variable and
+        // pass a valid pointer. `-1` is the well-defined "any child"
+        // sentinel for `waitpid`.
+        let pid = unsafe { libc::waitpid(-1, &mut status, libc::WNOHANG) };
+        match pid {
+            // No more zombies ready right now.
+            0 => break,
+            // Error: ECHILD means no children at all (we just bail);
+            // EINTR means we were interrupted — next SIGCHLD will
+            // re-fire us; anything else gets a debug log.
+            -1 => {
+                let err = std::io::Error::last_os_error();
+                let errno = err.raw_os_error().unwrap_or(0);
+                if errno == libc::ECHILD || errno == libc::EINTR {
+                    break;
+                }
+                tracing::debug!(error = %err, "child reaper: waitpid(-1) failed");
+                break;
+            }
+            // Reaped one — log and keep draining.
+            reaped_pid => {
+                reaped += 1;
+                let exit_code = if libc::WIFEXITED(status) {
+                    Some(libc::WEXITSTATUS(status))
+                } else {
+                    None
+                };
+                let signal_num = if libc::WIFSIGNALED(status) {
+                    Some(libc::WTERMSIG(status))
+                } else {
+                    None
+                };
+                tracing::debug!(
+                    pid = reaped_pid,
+                    ?exit_code,
+                    ?signal_num,
+                    total_reaped_this_pass = reaped,
+                    "child reaper: reaped zombie"
+                );
+            }
+        }
+    }
+}
+
+// Tests live in `src/boxlite/tests/runtime_child_reaper.rs` — they
+// install a process-wide SIGCHLD handler and call `waitpid(-1)`, which
+// would race-steal `Child`ren spawned by adjacent lib unit tests if
+// kept in this module (cargo runs all lib unit tests in one process).
+// Each `tests/*.rs` file is its own binary, so the integration-test
+// process has no other children to interfere with.

--- a/src/boxlite/src/util/mod.rs
+++ b/src/boxlite/src/util/mod.rs
@@ -15,7 +15,8 @@ use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{EnvFilter, fmt};
 
 pub use process::{
-    ProcessExit, ProcessMonitor, is_process_alive, kill_process, process_start_time,
+    ProcessExit, ProcessMonitor, ReapOutcome, is_process_alive, kill_process, process_start_time,
+    reap_pid_async, reap_pid_blocking,
 };
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]

--- a/src/boxlite/src/util/mod.rs
+++ b/src/boxlite/src/util/mod.rs
@@ -1,8 +1,10 @@
 mod binary_finder;
+mod child_reaper;
 mod pid_file;
 pub mod process;
 
 pub use binary_finder::{RuntimeBinaryFinder, find_binary};
+pub use child_reaper::spawn_child_reaper;
 pub use pid_file::{PidFileReader, PidFileWriter, PidRecord, ProcessIdentity};
 
 use std::path::PathBuf;

--- a/src/boxlite/src/util/process.rs
+++ b/src/boxlite/src/util/process.rs
@@ -362,10 +362,25 @@ pub fn reap_pid_blocking(pid: u32, deadline_ms: u64) -> ReapOutcome {
     unsafe { libc::close(pidfd) };
     if r > 0 {
         let mut status: i32 = 0;
-        // SAFETY: pidfd was readable → child has exited; blocking
-        // waitpid returns immediately.
-        unsafe { libc::waitpid(pid as libc::pid_t, &mut status, 0) };
-        ReapOutcome::Reaped
+        // SAFETY: pidfd was readable → target PID has exited; calling
+        // waitpid here is non-blocking even with `WNOHANG` cleared.
+        // Crucially, `pidfd_open` will *also* succeed for PIDs that
+        // are not our children, in which case `waitpid` returns
+        // -1/ECHILD instead of reaping — we must NOT report `Reaped`
+        // in that case, because the runtime then frees state (PID
+        // file, DB record) for a shim it never owned. Coderabbitai
+        // review on #613 flagged this; the man-page citation is in
+        // the thread for archaeology.
+        let w = unsafe { libc::waitpid(pid as libc::pid_t, &mut status, 0) };
+        if w > 0 {
+            ReapOutcome::Reaped
+        } else {
+            // -1 → ECHILD (not our child) or another error. Either
+            // way: we did NOT reap. NotOurChild is the safer label
+            // because the runtime then routes through the inline
+            // SIGKILL+wait fallback rather than declaring success.
+            ReapOutcome::NotOurChild
+        }
     } else if r == 0 {
         ReapOutcome::TimedOut
     } else {
@@ -397,9 +412,18 @@ pub async fn reap_pid_async(pid: u32, deadline_ms: u64) -> ReapOutcome {
     .await
     {
         Ok(Ok(_guard)) => {
+            // Same gotcha as `reap_pid_blocking`: pidfd_open succeeds
+            // for non-child PIDs, and `waitpid(non_child_pid, ..., 0)`
+            // returns -1/ECHILD instead of reaping. Report NotOurChild
+            // in that case so the caller routes through its inline
+            // fallback rather than declaring success.
             let mut status: i32 = 0;
-            unsafe { libc::waitpid(pid as libc::pid_t, &mut status, 0) };
-            ReapOutcome::Reaped
+            let w = unsafe { libc::waitpid(pid as libc::pid_t, &mut status, 0) };
+            if w > 0 {
+                ReapOutcome::Reaped
+            } else {
+                ReapOutcome::NotOurChild
+            }
         }
         _ => ReapOutcome::TimedOut,
     }

--- a/src/boxlite/src/util/process.rs
+++ b/src/boxlite/src/util/process.rs
@@ -283,6 +283,122 @@ fn is_process_zombie_macos(pid: u32) -> bool {
     info.pbi_status == libc::SZOMB
 }
 
+// ============================================================================
+// Bounded reap: wait for `pid` to exit (with deadline) then waitpid
+// ============================================================================
+//
+// Used by the rm-force / health-check / attached-stop force paths to
+// replace the WNOHANG-poll-sleep loops that were scattered across
+// `box_impl.rs`, `rt_impl.rs`, and `shim.rs`. Implemented on top of
+// pidfd (Linux 5.3+) so:
+//   - the wait is *bounded* (deadline) without a polling sleep loop,
+//   - the wait is *interruptible* in both sync (poll(2)) and async
+//     (tokio AsyncFd) contexts without spawn_blocking thread leaks,
+//   - shim wedge (D state, uninterruptible sleep) returns
+//     `TimedOut` cleanly instead of hanging forever or burning a
+//     blocking-pool slot.
+//
+// On `pidfd_open` failure (PID not our child, not found, pre-5.3
+// kernel) the helpers fall back to a single WNOHANG attempt — never
+// to a sleep loop, so the worst case is "reaper missed it once."
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum ReapOutcome {
+    /// `waitpid` returned the exited child; PID slot freed.
+    Reaped,
+    /// `waitpid` returned -1 (ECHILD or similar). Common in attached
+    /// mode where the shim is owned by a different process.
+    NotOurChild,
+    /// Deadline elapsed; PID still alive (or in an uninterruptible
+    /// state the caller can't escape).
+    TimedOut,
+}
+
+/// One-shot non-blocking `waitpid(pid, _, WNOHANG)`. Fallback for the
+/// `pidfd_open` failure path — never invoked from the normal flow.
+fn reap_once(pid: u32) -> ReapOutcome {
+    let mut status: i32 = 0;
+    // SAFETY: documented C ABI; pid fits libc::pid_t.
+    let r = unsafe { libc::waitpid(pid as libc::pid_t, &mut status, libc::WNOHANG) };
+    if r > 0 {
+        ReapOutcome::Reaped
+    } else if r < 0 {
+        ReapOutcome::NotOurChild
+    } else {
+        ReapOutcome::TimedOut
+    }
+}
+
+/// Best-effort open a pidfd for `pid`. Returns the raw fd on success,
+/// or -1 on any failure.
+fn try_pidfd_open(pid: u32) -> i32 {
+    // pidfd_open is Linux 5.3+; libc 0.2 doesn't always have the
+    // wrapper, so go through SYS_pidfd_open directly.
+    let r = unsafe { libc::syscall(libc::SYS_pidfd_open, pid as libc::pid_t, 0_u32) };
+    if r < 0 { -1 } else { r as i32 }
+}
+
+/// Block until `pid` exits, then waitpid. Returns within
+/// `deadline_ms` even if the pid never exits.
+pub fn reap_pid_blocking(pid: u32, deadline_ms: u64) -> ReapOutcome {
+    let pidfd = try_pidfd_open(pid);
+    if pidfd < 0 {
+        return reap_once(pid);
+    }
+    let mut pollfd = libc::pollfd {
+        fd: pidfd,
+        events: libc::POLLIN,
+        revents: 0,
+    };
+    // SAFETY: pollfd is a valid pointer to a single entry; nfds = 1.
+    let r = unsafe { libc::poll(&mut pollfd, 1, deadline_ms as libc::c_int) };
+    unsafe { libc::close(pidfd) };
+    if r > 0 {
+        let mut status: i32 = 0;
+        // SAFETY: pidfd was readable → child has exited; blocking
+        // waitpid returns immediately.
+        unsafe { libc::waitpid(pid as libc::pid_t, &mut status, 0) };
+        ReapOutcome::Reaped
+    } else if r == 0 {
+        ReapOutcome::TimedOut
+    } else {
+        ReapOutcome::NotOurChild
+    }
+}
+
+/// Async counterpart. Drops cleanly on timeout — no `spawn_blocking`
+/// thread leak.
+pub async fn reap_pid_async(pid: u32, deadline_ms: u64) -> ReapOutcome {
+    use std::os::fd::FromRawFd;
+
+    let pidfd = try_pidfd_open(pid);
+    if pidfd < 0 {
+        return reap_once(pid);
+    }
+    // SAFETY: pidfd is a fresh fd from the kernel; OwnedFd takes
+    // ownership so Drop closes it whether or not AsyncFd succeeds.
+    let owned = unsafe { std::os::fd::OwnedFd::from_raw_fd(pidfd) };
+    let async_fd =
+        match tokio::io::unix::AsyncFd::with_interest(owned, tokio::io::Interest::READABLE) {
+            Ok(f) => f,
+            Err(_) => return reap_once(pid),
+        };
+    match tokio::time::timeout(
+        std::time::Duration::from_millis(deadline_ms),
+        async_fd.readable(),
+    )
+    .await
+    {
+        Ok(Ok(_guard)) => {
+            let mut status: i32 = 0;
+            unsafe { libc::waitpid(pid as libc::pid_t, &mut status, 0) };
+            ReapOutcome::Reaped
+        }
+        _ => ReapOutcome::TimedOut,
+    }
+    // async_fd Drop closes the pidfd.
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/boxlite/src/util/process.rs
+++ b/src/boxlite/src/util/process.rs
@@ -330,12 +330,19 @@ fn reap_once(pid: u32) -> ReapOutcome {
 }
 
 /// Best-effort open a pidfd for `pid`. Returns the raw fd on success,
-/// or -1 on any failure.
+/// or -1 on any failure (including non-Linux targets where pidfd_open
+/// is not a thing — callers fall back to the WNOHANG reap_once path).
+#[cfg(target_os = "linux")]
 fn try_pidfd_open(pid: u32) -> i32 {
     // pidfd_open is Linux 5.3+; libc 0.2 doesn't always have the
     // wrapper, so go through SYS_pidfd_open directly.
     let r = unsafe { libc::syscall(libc::SYS_pidfd_open, pid as libc::pid_t, 0_u32) };
     if r < 0 { -1 } else { r as i32 }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn try_pidfd_open(_pid: u32) -> i32 {
+    -1
 }
 
 /// Block until `pid` exits, then waitpid. Returns within

--- a/src/boxlite/src/vmm/controller/handler.rs
+++ b/src/boxlite/src/vmm/controller/handler.rs
@@ -16,8 +16,19 @@ use boxlite_shared::BoxliteResult;
 ///
 /// Other metadata (transport, boot duration) is stored in BoxConfig/BoxMetrics.
 pub trait VmmHandler: Send {
-    /// Stop the VM.
+    /// Stop the VM gracefully — SIGTERM, wait up to a budget, then
+    /// SIGKILL if needed.
     fn stop(&mut self) -> BoxliteResult<()>;
+
+    /// Stop the VM immediately with SIGKILL (no graceful SIGTERM phase).
+    ///
+    /// Used by `rm --force` so the kill+reap goes through the same
+    /// 持-Child path as the canonical `stop()` — instead of the
+    /// older `kill_process(pid) + libc::waitpid` shortcut that
+    /// bypassed the `Child` handle (Issue #523 / #613). Functionally
+    /// identical (kernel-level reap), but keeps a single canonical
+    /// kill path in the codebase.
+    fn stop_force(&mut self) -> BoxliteResult<()>;
 
     /// Get VM metrics (CPU, memory, disk usage).
     fn metrics(&self) -> BoxliteResult<VmmMetrics>;

--- a/src/boxlite/src/vmm/controller/shim.rs
+++ b/src/boxlite/src/vmm/controller/shim.rs
@@ -190,8 +190,27 @@ impl VmmHandlerTrait for ShimHandler {
             libc::kill(self.pid as i32, libc::SIGKILL);
         }
         const REAP_DEADLINE_MS: u64 = 2000;
-        let _ = crate::util::reap_pid_blocking(self.pid, REAP_DEADLINE_MS);
-        Ok(())
+        // Coderabbitai review on #613: previously this ignored the
+        // reap outcome and returned `Ok(())` unconditionally. That let
+        // `BoxImpl::stop_impl` clear the PID + remove the pid-file +
+        // persist `Stopped` even when the shim hadn't actually died
+        // (TimedOut) or wasn't ours (NotOurChild). Propagate the
+        // non-terminal cases as `Engine` errors so the caller bails
+        // before any destructive cleanup.
+        match crate::util::reap_pid_blocking(self.pid, REAP_DEADLINE_MS) {
+            crate::util::ReapOutcome::Reaped => Ok(()),
+            crate::util::ReapOutcome::TimedOut => Err(BoxliteError::Engine(format!(
+                "force-stop reap of shim pid {} timed out after {} ms; \
+                 shim may still be alive — refusing to declare success",
+                self.pid, REAP_DEADLINE_MS
+            ))),
+            crate::util::ReapOutcome::NotOurChild => Err(BoxliteError::Engine(format!(
+                "force-stop reap of shim pid {} returned NotOurChild; \
+                 the runtime doesn't own the SIGCHLD relationship and \
+                 cannot confirm the shim exited",
+                self.pid
+            ))),
+        }
     }
 
     fn metrics(&self) -> BoxliteResult<VmmMetrics> {

--- a/src/boxlite/src/vmm/controller/shim.rs
+++ b/src/boxlite/src/vmm/controller/shim.rs
@@ -184,36 +184,14 @@ impl VmmHandlerTrait for ShimHandler {
         }
 
         // Attached mode: no Child handle (the shim was reattached after
-        // a daemon restart). Use raw libc kill+waitpid same as
-        // `stop()`'s attached arm but with SIGKILL and no SIGTERM
-        // grace.
+        // a daemon restart). SIGKILL by PID, then reap via pidfd helper
+        // — bounded, sleep-free, returns cleanly on a wedged shim.
         unsafe {
             libc::kill(self.pid as i32, libc::SIGKILL);
         }
-        // Bounded reap — same deadline shape as the inline waitpid
-        // used in the old rt_impl force path, kept here for the
-        // attached-only fallback.
         const REAP_DEADLINE_MS: u64 = 2000;
-        let deadline =
-            std::time::Instant::now() + std::time::Duration::from_millis(REAP_DEADLINE_MS);
-        loop {
-            let mut status: i32 = 0;
-            let r = unsafe { libc::waitpid(self.pid as i32, &mut status, libc::WNOHANG) };
-            if r > 0 {
-                return Ok(());
-            }
-            if r < 0 {
-                // ECHILD — not our child in attached mode; nothing
-                // we can reap from here. The shim's actual parent
-                // (or init after the daemon that spawned it exited)
-                // will reap.
-                return Ok(());
-            }
-            if std::time::Instant::now() >= deadline {
-                return Ok(());
-            }
-            std::thread::sleep(std::time::Duration::from_millis(50));
-        }
+        let _ = crate::util::reap_pid_blocking(self.pid, REAP_DEADLINE_MS);
+        Ok(())
     }
 
     fn metrics(&self) -> BoxliteResult<VmmMetrics> {

--- a/src/boxlite/src/vmm/controller/shim.rs
+++ b/src/boxlite/src/vmm/controller/shim.rs
@@ -166,6 +166,56 @@ impl VmmHandlerTrait for ShimHandler {
         Ok(())
     }
 
+    fn stop_force(&mut self) -> BoxliteResult<()> {
+        // Skip the SIGTERM graceful phase — operator asked for force.
+        // Path mirrors `stop()` except SIGTERM never goes out, so the
+        // `process.try_wait()` poll loop is also unnecessary; we kill
+        // and immediately block on Child::wait (which reaps).
+        if let Some(mut process) = self.process.take() {
+            // SIGKILL via Child::kill (sends signal, doesn't wait).
+            let _ = process.kill();
+            // Child::wait — blocks until the kernel reaps, returns
+            // ExitStatus. Same blocking behaviour as `stop()`'s
+            // timeout-fallback `process.wait()` branch; std worker
+            // pattern in this crate is sync-inside-async (see
+            // ShimHandler::stop documentation).
+            let _ = process.wait();
+            return Ok(());
+        }
+
+        // Attached mode: no Child handle (the shim was reattached after
+        // a daemon restart). Use raw libc kill+waitpid same as
+        // `stop()`'s attached arm but with SIGKILL and no SIGTERM
+        // grace.
+        unsafe {
+            libc::kill(self.pid as i32, libc::SIGKILL);
+        }
+        // Bounded reap — same deadline shape as the inline waitpid
+        // used in the old rt_impl force path, kept here for the
+        // attached-only fallback.
+        const REAP_DEADLINE_MS: u64 = 2000;
+        let deadline =
+            std::time::Instant::now() + std::time::Duration::from_millis(REAP_DEADLINE_MS);
+        loop {
+            let mut status: i32 = 0;
+            let r = unsafe { libc::waitpid(self.pid as i32, &mut status, libc::WNOHANG) };
+            if r > 0 {
+                return Ok(());
+            }
+            if r < 0 {
+                // ECHILD — not our child in attached mode; nothing
+                // we can reap from here. The shim's actual parent
+                // (or init after the daemon that spawned it exited)
+                // will reap.
+                return Ok(());
+            }
+            if std::time::Instant::now() >= deadline {
+                return Ok(());
+            }
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+    }
+
     fn metrics(&self) -> BoxliteResult<VmmMetrics> {
         use sysinfo::Pid;
 

--- a/src/boxlite/tests/health_check.rs
+++ b/src/boxlite/tests/health_check.rs
@@ -149,4 +149,98 @@ async fn health_check_becomes_unhealthy_when_shim_killed() {
         health_status.state,
         health_status.failures
     );
+
+    // Belt-and-braces: the leak check in PerTestBoxHome::drop is the
+    // load-bearing assertion (any live PID at home-drop fails the
+    // test), but pin the kernel-level state of the killed shim here
+    // too so a fix regression shows the cause inline rather than only
+    // at the home-drop panic site.
+    let proc_status = std::fs::read_to_string(format!("/proc/{shim_pid}/status"));
+    match proc_status {
+        Ok(s) => {
+            let state_line = s
+                .lines()
+                .find(|l| l.starts_with("State:"))
+                .unwrap_or("State: <missing>")
+                .to_string();
+            assert!(
+                !state_line.contains('Z'),
+                "shim PID {shim_pid} still a zombie after health check fired: \
+                 {state_line}. Health check's shim_died branch must reap \
+                 (libc::waitpid)."
+            );
+        }
+        Err(_) => { /* /proc entry gone — already reaped, ideal */ }
+    }
+}
+
+/// Same shape as `health_check_becomes_unhealthy_when_shim_killed` but
+/// drives the death via `SIGTERM` instead of `SIGKILL`. Covers the
+/// canonical real-world variants — k8s liveness probe's initial signal,
+/// the cgroup OOM-killer's first attempt, `systemctl stop`, plain
+/// `kill <pid>` — anywhere the shim gets a polite "please exit" rather
+/// than an immediate kernel hard-kill.
+///
+/// The reap path inside health check is the same `WNOHANG` retry loop;
+/// nothing special-cases SIGTERM. This test is here so a regression
+/// that *only* handles the SIGKILL path doesn't slip through green.
+#[tokio::test]
+async fn health_check_becomes_unhealthy_when_shim_sigtermed() {
+    let t = BoxTestBase::with_options(health_check_opts(
+        Duration::from_secs(2),
+        Duration::from_secs(1),
+        2,
+        Duration::from_secs(1),
+    ))
+    .await;
+
+    let box_id = t.bx.id().clone();
+    t.bx.start().await.expect("Failed to start box");
+    sleep(Duration::from_secs(4)).await;
+
+    let info = t.runtime.get_info(box_id.as_str()).await.unwrap().unwrap();
+    assert_eq!(info.health_status.state, HealthState::Healthy);
+
+    let shim_pid = info.pid.expect("No shim PID found");
+    println!("SIGTERM-ing shim process with PID: {shim_pid}");
+
+    Command::new("kill")
+        .arg("-TERM")
+        .arg(shim_pid.to_string())
+        .output()
+        .expect("Failed to SIGTERM shim process");
+
+    // SIGTERM goes through shim's signal handler which can take longer
+    // than a SIGKILL hard-kill; reuse the SIGKILL test's 5 s budget.
+    sleep(Duration::from_secs(5)).await;
+
+    let info = t.runtime.get_info(box_id.as_str()).await.unwrap().unwrap();
+    assert_eq!(
+        info.status,
+        BoxStatus::Stopped,
+        "Expected box status to be Stopped after SIGTERM, got {:?}",
+        info.status
+    );
+
+    let health_status = info.health_status;
+    assert!(
+        health_status.state == HealthState::Unhealthy || health_status.failures > 0,
+        "Expected unhealthy state or failures after SIGTERM, got state={:?}, failures={}",
+        health_status.state,
+        health_status.failures
+    );
+
+    let proc_status = std::fs::read_to_string(format!("/proc/{shim_pid}/status"));
+    if let Ok(s) = proc_status {
+        let state_line = s
+            .lines()
+            .find(|l| l.starts_with("State:"))
+            .unwrap_or("State: <missing>")
+            .to_string();
+        assert!(
+            !state_line.contains('Z'),
+            "shim PID {shim_pid} still a zombie after SIGTERM + health check fired: \
+             {state_line}"
+        );
+    }
 }

--- a/src/boxlite/tests/health_check_perf.rs
+++ b/src/boxlite/tests/health_check_perf.rs
@@ -42,12 +42,21 @@ fn read_self_cpu_ticks() -> u64 {
 }
 
 fn cpu_ms_from_ticks(ticks: u64) -> u64 {
-    // sysconf(_SC_CLK_TCK) is usually 100 on Linux. Worth reading it
-    // for precision but the typical value lets us do "ticks * 10" to
-    // get milliseconds. Keep this approximation — the perf signal we
-    // care about (delta between health-check-on and off) is well above
-    // any rounding error.
-    ticks * 10
+    // /proc/<pid>/stat utime/stime are in clock ticks. The divisor
+    // is `sysconf(_SC_CLK_TCK)` — commonly 100 on x86_64 Linux, but
+    // the kernel may have been built with HZ=250/300/1000 (especially
+    // on ARM or low-latency profiles). Coderabbitai review on #613
+    // verified the man-page contract; previously this hardcoded
+    // `ticks * 10` (= a 100 Hz assumption), which would over- or
+    // under-report by 2.5× / 10× on those kernels.
+    //
+    // Read the real value at runtime and fall back to 100 only if
+    // sysconf returns something nonsensical (defensive — we still
+    // want a number to print in the report).
+    let hz = unsafe { libc::sysconf(libc::_SC_CLK_TCK) };
+    let hz = if hz > 0 { hz as u64 } else { 100 };
+    // ticks / hz = seconds; * 1000 = ms.
+    ticks.saturating_mul(1000) / hz
 }
 
 #[tokio::test]
@@ -103,8 +112,12 @@ async fn perf_health_check_default_on_vs_off_cpu_delta() {
 
     // Wait long enough for health check to land in Healthy before
     // measurement; otherwise the first window includes startup pings
-    // failing on a not-yet-ready guest.
+    // failing on a not-yet-ready guest. Coderabbitai review on #613:
+    // assert the box actually reached Healthy — otherwise a timed-out
+    // wait still records CPU against startup / unhealthy behaviour and
+    // prints it as steady-state overhead.
     let healthy_deadline = std::time::Instant::now() + Duration::from_secs(15);
+    let mut became_healthy = false;
     while std::time::Instant::now() < healthy_deadline {
         let info = t_on
             .runtime
@@ -113,10 +126,16 @@ async fn perf_health_check_default_on_vs_off_cpu_delta() {
             .unwrap()
             .unwrap();
         if info.health_status.state == HealthState::Healthy {
+            became_healthy = true;
             break;
         }
         sleep(Duration::from_millis(200)).await;
     }
+    assert!(
+        became_healthy,
+        "health-check-on box never reached Healthy within 15s; the perf number that follows \
+         would mix in startup / unhealthy pings instead of steady-state overhead"
+    );
 
     let cpu_on_before = read_self_cpu_ticks();
     sleep(Duration::from_secs(OBSERVATION_SECS)).await;

--- a/src/boxlite/tests/health_check_perf.rs
+++ b/src/boxlite/tests/health_check_perf.rs
@@ -1,0 +1,146 @@
+//! Perf-measurement test: how much CPU does the in-process health check
+//! task add per box? Spawns two alpine boxes — one with `health_check =
+//! None`, one with an aggressive `health_check = Some(100ms)` — measures
+//! the parent test process's `/proc/self/stat` CPU delta over 10 s, and
+//! prints the diff so a reviewer can see the per-tick + per-box overhead.
+//!
+//! Not a strict assertion (CPU varies with host load); the test passes
+//! as long as it can spawn + stop both boxes and read /proc.
+//!
+//! Methodology notes for whoever runs this:
+//!   * Health check interval: 100 ms → ~100 ticks in 10 s. Production
+//!     default is 30 s → 0.33 ticks / 10 s. Divide the measured delta
+//!     by 100 to project to the production cadence.
+//!   * The work is in the boxlite process (the test binary), not in
+//!     the shim subprocess — the tokio task lives in the parent.
+//!   * Each tick is one `gRPC Ping` over vsock to the guest agent;
+//!     wall-clock per tick is dominated by the vsock round-trip, not
+//!     the in-process state mutation.
+
+mod common;
+
+use boxlite::litebox::HealthState;
+use boxlite::runtime::advanced_options::{AdvancedBoxOptions, HealthCheckOptions};
+use boxlite::runtime::options::{BoxOptions, RootfsSpec};
+use common::box_test::BoxTestBase;
+use std::time::Duration;
+use tokio::time::sleep;
+
+/// Read cumulative (utime + stime) for /proc/self/stat. Returns clock
+/// ticks (sysconf(_SC_CLK_TCK) ticks per second; usually 100).
+fn read_self_cpu_ticks() -> u64 {
+    let s = std::fs::read_to_string("/proc/self/stat").expect("read /proc/self/stat");
+    // /proc/<pid>/stat fields: pid (comm) state ppid ... utime(14) stime(15)
+    // comm contains spaces, so split after the last ')'.
+    let after_comm = s.rsplit_once(')').expect("comm closing paren").1;
+    let fields: Vec<&str> = after_comm.split_whitespace().collect();
+    // After ')', field index is shifted: state is fields[0], so utime is
+    // fields[11] (14 - 3 = 11) and stime is fields[12].
+    let utime: u64 = fields[11].parse().expect("utime");
+    let stime: u64 = fields[12].parse().expect("stime");
+    utime + stime
+}
+
+fn cpu_ms_from_ticks(ticks: u64) -> u64 {
+    // sysconf(_SC_CLK_TCK) is usually 100 on Linux. Worth reading it
+    // for precision but the typical value lets us do "ticks * 10" to
+    // get milliseconds. Keep this approximation — the perf signal we
+    // care about (delta between health-check-on and off) is well above
+    // any rounding error.
+    ticks * 10
+}
+
+#[tokio::test]
+async fn perf_health_check_default_on_vs_off_cpu_delta() {
+    const OBSERVATION_SECS: u64 = 10;
+
+    // --- Phase 1: box with health check OFF -----------------------
+    let off_opts = BoxOptions {
+        rootfs: RootfsSpec::Image("alpine:latest".into()),
+        advanced: AdvancedBoxOptions {
+            health_check: None,
+            ..Default::default()
+        },
+        auto_remove: false,
+        ..Default::default()
+    };
+    let t_off = BoxTestBase::with_options(off_opts).await;
+    t_off.bx.start().await.expect("start off-box");
+
+    // Settle: give the runtime a beat to finish any post-start work
+    // so it doesn't bleed into the measurement window.
+    sleep(Duration::from_secs(1)).await;
+
+    let cpu_off_before = read_self_cpu_ticks();
+    sleep(Duration::from_secs(OBSERVATION_SECS)).await;
+    let cpu_off_after = read_self_cpu_ticks();
+    let cpu_off_delta = cpu_off_after - cpu_off_before;
+
+    t_off.bx.stop().await.expect("stop off-box");
+
+    // --- Phase 2: box with aggressive health check ON -------------
+    let on_opts = BoxOptions {
+        rootfs: RootfsSpec::Image("alpine:latest".into()),
+        advanced: AdvancedBoxOptions {
+            health_check: Some(HealthCheckOptions {
+                // Aggressive interval to make the per-tick overhead
+                // observable in a short window. Production default is
+                // 30 s — multiply our number by 1/300 to project.
+                interval: Duration::from_millis(100),
+                timeout: Duration::from_secs(1),
+                retries: 3,
+                // No startup grace — start counting immediately so we
+                // actually see ticks during the observation window.
+                start_period: Duration::from_millis(0),
+            }),
+            ..Default::default()
+        },
+        auto_remove: false,
+        ..Default::default()
+    };
+    let t_on = BoxTestBase::with_options(on_opts).await;
+    t_on.bx.start().await.expect("start on-box");
+
+    // Wait long enough for health check to land in Healthy before
+    // measurement; otherwise the first window includes startup pings
+    // failing on a not-yet-ready guest.
+    let healthy_deadline = std::time::Instant::now() + Duration::from_secs(15);
+    while std::time::Instant::now() < healthy_deadline {
+        let info = t_on
+            .runtime
+            .get_info(t_on.bx.id().as_str())
+            .await
+            .unwrap()
+            .unwrap();
+        if info.health_status.state == HealthState::Healthy {
+            break;
+        }
+        sleep(Duration::from_millis(200)).await;
+    }
+
+    let cpu_on_before = read_self_cpu_ticks();
+    sleep(Duration::from_secs(OBSERVATION_SECS)).await;
+    let cpu_on_after = read_self_cpu_ticks();
+    let cpu_on_delta = cpu_on_after - cpu_on_before;
+
+    t_on.bx.stop().await.expect("stop on-box");
+
+    // --- Report ---------------------------------------------------
+    let off_ms = cpu_ms_from_ticks(cpu_off_delta);
+    let on_ms = cpu_ms_from_ticks(cpu_on_delta);
+    let delta_ms = on_ms.saturating_sub(off_ms);
+
+    // Approximate ticks during the on-window: interval=100ms over
+    // OBSERVATION_SECS = OBSERVATION_SECS * 10 ticks.
+    let approx_ticks = OBSERVATION_SECS * 10;
+    let per_tick_us = (delta_ms * 1000).checked_div(approx_ticks).unwrap_or(0);
+
+    // Production projection: default interval 30 s ⇒ 0.033 ticks/s
+    // per box ⇒ delta_per_box_per_sec_us ≈ per_tick_us / 30
+    let prod_per_box_per_sec_us = per_tick_us / 30;
+
+    println!(
+        "PERF\n  observation window: {OBSERVATION_SECS}s\n  off-box CPU: {off_ms} ms\n  on-box CPU:  {on_ms} ms\n  delta:       {delta_ms} ms over ~{approx_ticks} ticks (100ms interval)\n  per-tick:    ~{per_tick_us} us\n  projected at default 30s interval, per box: ~{prod_per_box_per_sec_us} us/sec ({} ms/box/hour)",
+        prod_per_box_per_sec_us * 36 / 10_000,
+    );
+}

--- a/src/boxlite/tests/runtime_child_reaper.rs
+++ b/src/boxlite/tests/runtime_child_reaper.rs
@@ -1,0 +1,94 @@
+//! Integration tests for [`boxlite::util::spawn_child_reaper`].
+//!
+//! Lives in `tests/` rather than as a `#[cfg(test)] mod tests` inside
+//! `util/child_reaper.rs` because the reaper installs a process-wide
+//! SIGCHLD handler and calls `waitpid(-1, ..., WNOHANG)`. Inside the
+//! `boxlite --lib` test binary, cargo runs all unit tests in one
+//! process with parallel threads, so a co-resident reaper would
+//! race-steal `Child`ren spawned by tests like
+//! `runtime::rt_impl::tests::test_shutdown_sync_stops_non_detached_running_box`
+//! before their `try_wait()` call. Each `tests/*.rs` file is its own
+//! binary — this one only has reaper tests, so no other code in the
+//! same process is fighting for SIGCHLD.
+
+#![cfg(unix)]
+
+use boxlite::util::spawn_child_reaper;
+use std::process::{Command, Stdio};
+use std::time::Duration;
+use tokio_util::sync::CancellationToken;
+
+/// Returns true if `/proc/<pid>/status` exists at all (alive OR
+/// zombie). False if the slot has been freed — i.e. somebody called
+/// waitpid on it.
+#[cfg(target_os = "linux")]
+fn is_zombie_or_alive(pid: u32) -> bool {
+    std::fs::metadata(format!("/proc/{pid}/status")).is_ok()
+}
+
+/// macOS fallback: `kill(pid, 0)` returns 0 for alive *or* zombie,
+/// `ESRCH` for fully gone. (No `/proc` to read.)
+#[cfg(not(target_os = "linux"))]
+fn is_zombie_or_alive(pid: u32) -> bool {
+    let r = unsafe { libc::kill(pid as libc::pid_t, 0) };
+    r == 0 || std::io::Error::last_os_error().raw_os_error() != Some(libc::ESRCH)
+}
+
+/// Spawn the reaper, then spawn a child that exits immediately, drop
+/// the `Child` so nobody calls `wait` on it, and confirm the kernel's
+/// zombie slot for that pid is gone within a reasonable window.
+///
+/// Two-side: replacing the body of `drain_zombies` with `return;`
+/// leaves the pid in `/proc/<pid>/status: State: Z` past the deadline
+/// — `is_zombie_or_alive` then returns `true` and the assertion fails.
+#[tokio::test(flavor = "multi_thread")]
+async fn reaper_drains_zombie_left_by_dropped_child() {
+    let token = CancellationToken::new();
+    let task = spawn_child_reaper(token.clone());
+
+    // Spawn a child that exits immediately. Dropping the `Child`
+    // BEFORE calling `wait()` produces a zombie until somebody (the
+    // reaper) calls waitpid on it.
+    let child = Command::new("sh")
+        .arg("-c")
+        .arg("true")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn sh");
+    let pid = child.id();
+    drop(child); // <- no Child::wait happens here
+
+    // Wait up to 2s for the reaper to drain the SIGCHLD.
+    let deadline = std::time::Instant::now() + Duration::from_secs(2);
+    let mut became_gone = false;
+    while std::time::Instant::now() < deadline {
+        if !is_zombie_or_alive(pid) {
+            became_gone = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert!(
+        became_gone,
+        "child reaper should have drained pid {pid}, but it's still in /proc/<pid>/status"
+    );
+
+    // Clean shutdown.
+    token.cancel();
+    let _ = tokio::time::timeout(Duration::from_secs(1), task).await;
+}
+
+/// Cancellation contract: the reaper task must observe the shutdown
+/// token and exit, not block on SIGCHLD forever.
+#[tokio::test(flavor = "multi_thread")]
+async fn reaper_exits_on_shutdown_token() {
+    let token = CancellationToken::new();
+    let task = spawn_child_reaper(token.clone());
+    token.cancel();
+    tokio::time::timeout(Duration::from_secs(1), task)
+        .await
+        .expect("reaper must exit within 1s of cancellation")
+        .expect("reaper join");
+}

--- a/src/cli/src/cli.rs
+++ b/src/cli/src/cli.rs
@@ -693,12 +693,24 @@ pub struct ManagementFlags {
     /// Automatically remove the box when it exits
     #[arg(long)]
     pub rm: bool,
+
+    /// Disable the per-box health check (Issue #523: also disables the
+    /// async-death zombie reaper that piggybacks on the health-check
+    /// loop). Use when the box is so short-lived or low-priority that
+    /// the 30 s background tick isn't worth its cost — typical case:
+    /// very large fleets where the operator runs their own monitoring
+    /// and accepts having to clean up zombies if a shim dies asynchronously.
+    #[arg(long = "no-health-check")]
+    pub no_health_check: bool,
 }
 
 impl ManagementFlags {
     pub fn apply_to(&self, opts: &mut BoxOptions) {
         opts.detach = self.detach;
         opts.auto_remove = self.rm;
+        if self.no_health_check {
+            opts.advanced.health_check = None;
+        }
     }
 }
 
@@ -707,6 +719,52 @@ mod tests {
     use super::*;
     use std::fs;
     use tempfile::TempDir;
+
+    /// `--no-health-check` is the operator-level escape hatch for the
+    /// default-on health check introduced for zombie-shim reaping
+    /// (Issue #523 / #613). Setting it must clear
+    /// `BoxOptions.advanced.health_check` so the box-init pipeline
+    /// doesn't spawn a watcher task.
+    #[test]
+    fn management_flags_no_health_check_clears_advanced_field() {
+        let flags = ManagementFlags {
+            name: None,
+            detach: false,
+            rm: false,
+            no_health_check: true,
+        };
+        let mut opts = BoxOptions::default();
+        // Sanity-check the baseline default: health check is on at the
+        // schema level so `--no-health-check` actually has work to do.
+        assert!(
+            opts.advanced.health_check.is_some(),
+            "baseline must be health-check-on; otherwise this test isn't measuring the override"
+        );
+        flags.apply_to(&mut opts);
+        assert!(
+            opts.advanced.health_check.is_none(),
+            "--no-health-check must clear advanced.health_check"
+        );
+    }
+
+    /// Negative: leaving the flag off must leave the default-on
+    /// behaviour intact, so absence of the flag and presence of the
+    /// flag have distinguishable effects.
+    #[test]
+    fn management_flags_no_health_check_unset_keeps_default_on() {
+        let flags = ManagementFlags {
+            name: None,
+            detach: false,
+            rm: false,
+            no_health_check: false,
+        };
+        let mut opts = BoxOptions::default();
+        flags.apply_to(&mut opts);
+        assert!(
+            opts.advanced.health_check.is_some(),
+            "without --no-health-check the schema default (Some) must win"
+        );
+    }
 
     #[test]
     fn test_apply_env_vars_with_lookup() {

--- a/src/cli/src/commands/serve/mod.rs
+++ b/src/cli/src/commands/serve/mod.rs
@@ -656,14 +656,21 @@ fn build_box_options(req: &CreateBoxRequest) -> Result<BoxOptions, boxlite::Boxl
         None => NetworkSpec::default(),
     };
 
-    // Resolve health_check policy:
-    // - `health_check_disabled = Some(true)` → explicit None (operator opt-out)
-    // - `Some(false)` / absent → keep the schema default (currently
-    //   `Some(HealthCheckOptions::default())`), so we let
-    //   `AdvancedBoxOptions::default()` win via `..Default::default()`.
+    // Resolve health_check policy in priority order:
+    //  1. `health_check_disabled = Some(true)` → operator opt-out
+    //     wins, no watcher is spawned, even if custom settings are
+    //     also present (the operator is explicit; ignore the others).
+    //  2. `health_check_settings = Some(opts)` → use the caller's
+    //     custom settings verbatim. Added per coderabbitai review on
+    //     #613 — previously any caller-side `HealthCheckOptions`
+    //     diverging from defaults was silently rewritten server-side.
+    //  3. Neither → keep `AdvancedBoxOptions::default()`'s default-on
+    //     `Some(HealthCheckOptions::default())` behaviour.
     let mut advanced = boxlite::AdvancedBoxOptions::default();
     if req.health_check_disabled.unwrap_or(false) {
         advanced.health_check = None;
+    } else if let Some(custom) = req.health_check_settings.clone() {
+        advanced.health_check = Some(custom);
     }
 
     Ok(BoxOptions {
@@ -1073,6 +1080,60 @@ mod tests {
         assert!(
             opts.advanced.health_check.is_some(),
             "health_check_disabled=false must be treated as 'use default' (= on)"
+        );
+    }
+
+    /// Coderabbitai review #613: a request body carrying custom
+    /// `health_check_settings` must drive the server's
+    /// `advanced.health_check` with those exact settings — not the
+    /// server default. Reverting the `else if let Some(custom)` arm
+    /// in `build_box_options` flips this red.
+    #[test]
+    fn build_box_options_honours_custom_health_check_settings() {
+        let json = r#"{
+            "image": "alpine:latest",
+            "health_check_settings": {
+                "interval":     {"secs": 7,  "nanos": 0},
+                "timeout":      {"secs": 3,  "nanos": 0},
+                "retries":      2,
+                "start_period": {"secs": 11, "nanos": 0}
+            }
+        }"#;
+        let req: super::types::CreateBoxRequest =
+            serde_json::from_str(json).expect("must deserialize");
+        let opts = build_box_options(&req).expect("build_box_options");
+        let got = opts
+            .advanced
+            .health_check
+            .as_ref()
+            .expect("custom settings must produce a populated health_check");
+        assert_eq!(got.interval, std::time::Duration::from_secs(7));
+        assert_eq!(got.timeout, std::time::Duration::from_secs(3));
+        assert_eq!(got.retries, 2);
+        assert_eq!(got.start_period, std::time::Duration::from_secs(11));
+    }
+
+    /// Opt-out wins: if a request carries BOTH `health_check_disabled: true`
+    /// AND `health_check_settings`, the explicit disable is honoured
+    /// and the settings are ignored.
+    #[test]
+    fn build_box_options_disabled_wins_over_settings() {
+        let json = r#"{
+            "image": "alpine:latest",
+            "health_check_disabled": true,
+            "health_check_settings": {
+                "interval":     {"secs": 7,  "nanos": 0},
+                "timeout":      {"secs": 3,  "nanos": 0},
+                "retries":      2,
+                "start_period": {"secs": 11, "nanos": 0}
+            }
+        }"#;
+        let req: super::types::CreateBoxRequest =
+            serde_json::from_str(json).expect("must deserialize");
+        let opts = build_box_options(&req).expect("build_box_options");
+        assert!(
+            opts.advanced.health_check.is_none(),
+            "explicit disable must beat custom settings"
         );
     }
 

--- a/src/cli/src/commands/serve/mod.rs
+++ b/src/cli/src/commands/serve/mod.rs
@@ -656,6 +656,16 @@ fn build_box_options(req: &CreateBoxRequest) -> Result<BoxOptions, boxlite::Boxl
         None => NetworkSpec::default(),
     };
 
+    // Resolve health_check policy:
+    // - `health_check_disabled = Some(true)` → explicit None (operator opt-out)
+    // - `Some(false)` / absent → keep the schema default (currently
+    //   `Some(HealthCheckOptions::default())`), so we let
+    //   `AdvancedBoxOptions::default()` win via `..Default::default()`.
+    let mut advanced = boxlite::AdvancedBoxOptions::default();
+    if req.health_check_disabled.unwrap_or(false) {
+        advanced.health_check = None;
+    }
+
     Ok(BoxOptions {
         rootfs,
         cpus: req.cpus,
@@ -669,6 +679,7 @@ fn build_box_options(req: &CreateBoxRequest) -> Result<BoxOptions, boxlite::Boxl
         user: req.user.clone(),
         auto_remove: req.auto_remove.unwrap_or(false),
         detach: req.detach.unwrap_or(true),
+        advanced,
         ..Default::default()
     })
 }
@@ -1015,6 +1026,54 @@ mod tests {
         assert!(!constant_time_eq(b"abc", b"abd"));
         assert!(!constant_time_eq(b"abc", b"abcd"));
         assert!(constant_time_eq(b"", b""));
+    }
+
+    /// `POST /v1/boxes` body with `health_check_disabled: true` flips
+    /// `advanced.health_check` to `None` in the resulting BoxOptions —
+    /// the SDK→REST→server path's escape hatch for the default-on
+    /// behaviour introduced in Issue #523 / #613.
+    #[test]
+    fn build_box_options_health_check_disabled_true_clears_health_check() {
+        let json = r#"{"image": "alpine:latest", "health_check_disabled": true}"#;
+        let req: super::types::CreateBoxRequest =
+            serde_json::from_str(json).expect("must deserialize");
+        let opts = build_box_options(&req).expect("build_box_options");
+        assert!(
+            opts.advanced.health_check.is_none(),
+            "explicit health_check_disabled=true must clear advanced.health_check"
+        );
+    }
+
+    /// Backward compat: a request body that omits `health_check_disabled`
+    /// (i.e. every pre-#613 client) gets the server-side default, which
+    /// after #613 is `Some(HealthCheckOptions::default())`. The empty
+    /// body must not silently strip health check.
+    #[test]
+    fn build_box_options_no_health_check_field_keeps_default_on() {
+        let json = r#"{"image": "alpine:latest"}"#;
+        let req: super::types::CreateBoxRequest =
+            serde_json::from_str(json).expect("legacy body must still deserialize");
+        let opts = build_box_options(&req).expect("build_box_options");
+        assert!(
+            opts.advanced.health_check.is_some(),
+            "default-on health check must survive a request that doesn't mention it"
+        );
+    }
+
+    /// `Some(false)` is the explicit "I want the default" sentinel —
+    /// behaves identically to omitting the field. Documents the wire
+    /// contract so a confused client setting it to false doesn't get
+    /// the disabled behaviour.
+    #[test]
+    fn build_box_options_health_check_disabled_false_keeps_default_on() {
+        let json = r#"{"image": "alpine:latest", "health_check_disabled": false}"#;
+        let req: super::types::CreateBoxRequest =
+            serde_json::from_str(json).expect("must deserialize");
+        let opts = build_box_options(&req).expect("build_box_options");
+        assert!(
+            opts.advanced.health_check.is_some(),
+            "health_check_disabled=false must be treated as 'use default' (= on)"
+        );
     }
 
     /// Build an `ActiveExecution` backed by a stub `Execution` whose

--- a/src/cli/src/commands/serve/types.rs
+++ b/src/cli/src/commands/serve/types.rs
@@ -45,6 +45,14 @@ pub(super) struct CreateBoxRequest {
     /// (currently `Some(HealthCheckOptions::default())`).
     #[serde(default)]
     pub health_check_disabled: Option<bool>,
+    /// Non-default health-check settings (interval / timeout /
+    /// retries / start_period). When present AND `health_check_disabled`
+    /// is not `Some(true)`, replaces the server's default
+    /// `HealthCheckOptions`. Added in response to coderabbitai review
+    /// on #613 — without this field a caller's custom settings were
+    /// silently rewritten to defaults on the server.
+    #[serde(default)]
+    pub health_check_settings: Option<boxlite::HealthCheckOptions>,
 }
 
 #[derive(Deserialize)]

--- a/src/cli/src/commands/serve/types.rs
+++ b/src/cli/src/commands/serve/types.rs
@@ -39,6 +39,12 @@ pub(super) struct CreateBoxRequest {
     pub auto_remove: Option<bool>,
     #[serde(default)]
     pub detach: Option<bool>,
+    /// Disable the per-box health check (Issue #523: also disables the
+    /// async-death zombie reaper that piggybacks on health check).
+    /// `Some(true)` → disable; `Some(false)` / absent → server default
+    /// (currently `Some(HealthCheckOptions::default())`).
+    #[serde(default)]
+    pub health_check_disabled: Option<bool>,
 }
 
 #[derive(Deserialize)]

--- a/src/cli/tests/serve_rm_force_zombie.rs
+++ b/src/cli/tests/serve_rm_force_zombie.rs
@@ -1,0 +1,236 @@
+//! End-to-end test for the production zombie path:
+//! `boxlite serve` daemon receives a `rm --force` over REST, sends SIGKILL
+//! to the running shim, and the daemon stays alive. On `main` the shim
+//! lingers in `/proc` as `State: Z` forever (no `waitpid` ever fires from
+//! the daemon's `kill_process(pid)` path). On this branch the daemon's
+//! in-process `ShimReaper` sweeps the registered PID within a couple of
+//! `REAPER_TICK`s.
+//!
+//! This complements the lower-level library/SDK tests in
+//! `src/boxlite/tests/zombie_reaper.rs` by exercising the actual
+//! `boxlite serve` subprocess driven through the production REST surface
+//! (HTTP create + start + inspect + DELETE), so the upper layers (axum
+//! router, JSON shapes, CLI `--url` mode) are also in the path.
+//!
+//! Two-sided locally:
+//!   - reaper enabled  → `/proc/<shim_pid>/status` disappears within
+//!     `REAPER_TICK × 2` (250 ms × 2 ≈ 500 ms, budgeted at 5 s).
+//!   - `register()` patched to early-return → the same `/proc` entry
+//!     stays `State: Z` past the 5 s budget; the assertion fails with
+//!     the persisted zombie state surfaced verbatim.
+
+#![allow(dead_code)]
+
+use assert_cmd::Command as AssertCommand;
+use boxlite_test_utils::TEST_REGISTRIES;
+use boxlite_test_utils::home::PerTestBoxHome;
+use std::net::TcpListener;
+use std::process::{Child, Command as StdCommand, Stdio};
+use std::time::{Duration, Instant};
+
+fn pick_free_port() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind :0");
+    let port = listener.local_addr().expect("local_addr").port();
+    drop(listener);
+    port
+}
+
+/// Poll `GET /v1/config` via `curl` until 200 OR `timeout` elapses.
+fn wait_serve_ready(port: u16, timeout: Duration) -> bool {
+    let url = format!("http://127.0.0.1:{port}/v1/config");
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        let output = StdCommand::new("curl")
+            .args([
+                "-s",
+                "-o",
+                "/dev/null",
+                "-w",
+                "%{http_code}",
+                "--max-time",
+                "1",
+                &url,
+            ])
+            .output();
+        if let Ok(out) = output
+            && out.status.success()
+            && out.stdout == b"200"
+        {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(150));
+    }
+    false
+}
+
+/// `boxlite serve` subprocess wrapped in a `Drop` guard. SIGINT (not
+/// SIGTERM) so the daemon hits its `with_graceful_shutdown` future and
+/// runs `runtime.shutdown(timeout)` — without that the test could leak
+/// the box's shim through the daemon kill path itself.
+struct ServeGuard {
+    child: Child,
+}
+
+impl Drop for ServeGuard {
+    fn drop(&mut self) {
+        let pid = nix::unistd::Pid::from_raw(self.child.id() as i32);
+        let _ = nix::sys::signal::kill(pid, nix::sys::signal::Signal::SIGINT);
+        let deadline = Instant::now() + Duration::from_secs(15);
+        loop {
+            match self.child.try_wait() {
+                Ok(Some(_)) => return,
+                _ => {
+                    if Instant::now() >= deadline {
+                        let _ = self.child.kill();
+                        let _ = self.child.wait();
+                        return;
+                    }
+                    std::thread::sleep(Duration::from_millis(50));
+                }
+            }
+        }
+    }
+}
+
+/// Run the boxlite CLI in `--url` mode against the spawned daemon and
+/// return its captured stdout (trimmed). Panics on non-zero exit.
+fn cli(bin: &str, url: &str, args: &[&str]) -> String {
+    let mut cmd = AssertCommand::new(bin);
+    cmd.timeout(Duration::from_secs(120));
+    cmd.args(["--url", url]);
+    for reg in TEST_REGISTRIES {
+        cmd.arg("--registry").arg(reg);
+    }
+    cmd.args(args);
+    let out = cmd.output().expect("CLI invocation failed to spawn");
+    if !out.status.success() {
+        panic!(
+            "CLI {args:?} exited {:?}\nstdout: {}\nstderr: {}",
+            out.status.code(),
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+#[test]
+fn boxlite_serve_rm_force_active_box_no_zombie_left_in_proc() {
+    let bin = env!("CARGO_BIN_EXE_boxlite");
+    let server_home = PerTestBoxHome::new();
+
+    // 1. Spawn `boxlite serve` on an ephemeral port. The daemon is the
+    //    long-lived `parent` from the bug's point of view — when we
+    //    `rm --force` later, the daemon's `kill_process(pid)` path sends
+    //    SIGKILL to the shim and the daemon stays alive.
+    let port = pick_free_port();
+    let mut serve_cmd = StdCommand::new(bin);
+    serve_cmd
+        .arg("--home")
+        .arg(&server_home.path)
+        .args(["serve", "--port"])
+        .arg(port.to_string())
+        .args(["--host", "127.0.0.1"]);
+    for reg in TEST_REGISTRIES {
+        serve_cmd.arg("--registry").arg(reg);
+    }
+    serve_cmd.stdout(Stdio::null()).stderr(Stdio::null());
+    let child = serve_cmd.spawn().expect("spawn boxlite serve");
+    let daemon_pid = child.id();
+    let _serve_guard = ServeGuard { child };
+
+    assert!(
+        wait_serve_ready(port, Duration::from_secs(30)),
+        "boxlite serve never accepted GET /v1/config on 127.0.0.1:{port}"
+    );
+
+    let url = format!("http://127.0.0.1:{port}");
+
+    // 2. Create + start + inspect to capture the shim PID. Inspect's
+    //    `--format` `{{.pid}}` go-template style is the smallest output
+    //    we can parse without depending on JSON shape stability.
+    let client_home = PerTestBoxHome::new();
+    let mut create_cmd = AssertCommand::new(bin);
+    create_cmd
+        .timeout(Duration::from_secs(120))
+        .arg("--home")
+        .arg(&client_home.path)
+        .args(["--url", &url]);
+    for reg in TEST_REGISTRIES {
+        create_cmd.arg("--registry").arg(reg);
+    }
+    create_cmd.args(["create", "alpine:latest"]);
+    let out = create_cmd.output().expect("create");
+    if !out.status.success() {
+        panic!(
+            "create exited {:?}\nstderr: {}",
+            out.status.code(),
+            String::from_utf8_lossy(&out.stderr),
+        );
+    }
+    let box_id = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    assert!(!box_id.is_empty(), "create returned empty box ID");
+
+    // Start the box (no `--rm` so we explicitly hit `rm --force` below).
+    cli(bin, &url, &["start", &box_id]);
+
+    // Pull just the shim PID out of `inspect`. The go-template format
+    // is part of the CLI surface and stable across releases.
+    let shim_pid_str = cli(
+        bin,
+        &url,
+        &["inspect", "--format", "{{.State.Pid}}", &box_id],
+    );
+    let shim_pid: u32 = shim_pid_str
+        .parse()
+        .unwrap_or_else(|e| panic!("parse PID from {shim_pid_str:?}: {e}"));
+
+    // 3. The actual REST `rm --force` — daemon's REST handler invokes
+    //    `runtime.remove(box_id, true)` which calls
+    //    `kill_process(shim_pid)` (SIGKILL) and never `waitpid()`s.
+    cli(bin, &url, &["rm", "--force", &box_id]);
+
+    // 4. Watch `/proc/<shim_pid>/status` from outside the daemon. With
+    //    the reaper enabled the entry disappears within `REAPER_TICK × 2`
+    //    (~500 ms). Without it (the patched `register()` no-op simulation
+    //    of `main`) the entry stays `State: Z` until the daemon exits.
+    let status_path = format!("/proc/{shim_pid}/status");
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        let probe = std::fs::read_to_string(&status_path);
+        match &probe {
+            Err(_) => return, // /proc entry gone — reaper got it
+            Ok(content) if !content.contains("State:\tZ") => return, // not a zombie any more
+            _ => {}           // still `State: Z`
+        }
+        if Instant::now() >= deadline {
+            // Capture State + PPid so we can verify, on the failing path,
+            // that the kernel still considers the daemon (not init) the
+            // shim's parent — i.e. nothing reparented and init can't
+            // touch this zombie even though it's been a zombie for 5 s.
+            let (state, ppid) = probe
+                .as_ref()
+                .map(|c| {
+                    let line = |prefix: &str| {
+                        c.lines()
+                            .find(|l| l.starts_with(prefix))
+                            .unwrap_or("<none>")
+                            .to_string()
+                    };
+                    (line("State:"), line("PPid:"))
+                })
+                .unwrap_or_else(|_| ("GONE".into(), "GONE".into()));
+            panic!(
+                "boxlite serve daemon (PID {daemon_pid}) left zombie shim PID \
+                 {shim_pid} in /proc after REST `rm --force` — /proc/{shim_pid}/status \
+                 reports {state:?} {ppid:?} past 5 s. Compare {ppid:?} against the \
+                 daemon PID {daemon_pid} and init's PID 1: if `PPid:` matches the daemon \
+                 (not 1), nothing reparented — only the daemon can `waitpid()` this \
+                 zombie. On `main` this is the bug; on this branch the daemon's \
+                 in-process `ShimReaper` should sweep the registered PID within \
+                 `REAPER_TICK × 2` (~500 ms)."
+            );
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}


### PR DESCRIPTION
open health check by default(--no-health-check support), add wait so that the zombie shim PID can be swept while
1. SIGKILL (eg. OOM)
2. boxlite serve rm force (serve alive but shim died)

Then refactor `rm --force` to share the same hold-Child kill path as `stop` / non-force `rm` / `restart`, so the codebase has one canonical kill route instead of two.

## Test plan

| observed | pre-fix | post-fix |
|---|---|---|
| external `SIGKILL` shim | `/proc/<pid>` stays `State: Z`; `PerTestBoxHome::drop` panics with `live shim(s)` | `/proc` entry vanishes within one health-check tick + 500 ms reap retry |
| external `SIGTERM` shim | same — `State: Z` persists | clean |
| `boxlite serve` + REST `DELETE …?force=true` | shim stays `State: Z`, `PPid:` matches daemon (init can't reap) | reaped within ~50 ms via `Child::kill + Child::wait` |
| CLI / REST / SDK opt-out of health check | only Rust library users could set `health_check = None` | `boxlite run --no-health-check`; REST body `"health_check_disabled": true` (omitted by pre-#613 clients) |
| `rm --force` kill+reap | inline `kill_process + libc::waitpid` in `rt_impl::remove_box`, separate from `stop` path | `LiteBox::stop_force` → `ShimHandler::stop_force` → `Child::wait`; one canonical kill route |

### Reproducer tests

| test | trigger |
|---|---|
| `health_check_becomes_unhealthy_when_shim_killed` | external `kill -9` |
| `health_check_becomes_unhealthy_when_shim_sigtermed` | external `kill -TERM` |
| `boxlite_serve_rm_force_active_box_no_zombie_left_in_proc` | real `boxlite serve` + REST `DELETE …?force=true` |

### Escape-hatch unit tests

| test | layer |
|---|---|
| `management_flags_no_health_check_clears_advanced_field` | CLI |
| `management_flags_no_health_check_unset_keeps_default_on` | CLI |
| `test_create_box_request_carries_health_check_disabled_on_the_wire` | REST client |
| `test_create_box_request_omits_health_check_disabled_when_default` | REST client |
| `build_box_options_health_check_disabled_true_clears_health_check` | REST server |
| `build_box_options_no_health_check_field_keeps_default_on` | REST server |
| `build_box_options_health_check_disabled_false_keeps_default_on` | REST server |

### Refactor coverage

| caller | path | reaches kernel via |
|---|---|---|
| async `LocalRuntime::remove(force=true)` | `LiteBox::stop_force` → `ShimHandler::stop_force` | `Child::kill + Child::wait` |
| direct sync `RuntimeImpl::remove_box(force=true)` (Drop + 7 internal tests) | inline `kill_process + libc::waitpid` | retained fallback |

### Refactor three-side verification (rm-force production path)

| step | configuration | expected | actual |
|---|---|---|---|
| A | async stop_force OFF, sync inline ON | PASS (sync fallback) | ✅ PASS |
| B | both paths kill but skip wait | FAIL with `State: Z` (zombie) | ✅ FAIL — `State: Z`, `PPid: <daemon>` |
| C | async stop_force ON, sync wait OFF | PASS (async path alone reaps) | ✅ PASS |
| D | both intact (production) | PASS | ✅ PASS |

### Perf measurement

`perf_health_check_default_on_vs_off_cpu_delta` measures `/proc/self/stat` CPU delta with vs without health check at 100 ms interval. On this host: ~900 µs per tick. At the default 30 s interval: ~30 µs/sec per box (0.3 % of one core at 100 boxes, 3 % at 1000).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a force-stop option for immediate box termination (rm --force) and a CLI flag (--no-health-check) to disable per-box health checks
  * API now accepts optional health-check fields when creating boxes to control/disable health checks

* **Bug Fixes**
  * Health-check task is more resilient to missing guest session state
  * Improved bounded process reaping to avoid zombie shim processes

* **Tests**
  * New integration and performance tests for health-check and zombie-reaping behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->