### PR TITLE
test(sdk-typescript): pass jest target when no test files exist

### DIFF
--- a/apps/libs/sdk-typescript/jest.config.js
+++ b/apps/libs/sdk-typescript/jest.config.js
@@ -12,4 +12,5 @@ module.exports = {
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   testMatch: ['**/__tests__/**/*.test.ts'],
+  passWithNoTests: true,
 }


### PR DESCRIPTION
#460 added test config but didn't add real tests, now pass with no test should be set

## Test plan
`yarn nx test sdk-typescript --skip-nx-cache` (no VM):

| jest config | result |
|---|---|
| without `passWithNoTests` | **FAIL** — `No tests found, exiting with code 1` (nx task fails, rc=1) |
| with `passWithNoTests: true` | **PASS** — `No tests found, exiting with code 0` (rc=0) |
