### PR TITLE
fix(disk,runtime): cross-filesystem-safe clone/snapshot moves (EXDEV fallback)

### DIFF
--- a/src/boxlite/src/disk/mod.rs
+++ b/src/boxlite/src/disk/mod.rs
@@ -207,15 +207,36 @@ pub(crate) fn fork_qcow2(source: &Path, dest: &Path) -> BoxliteResult<Disk> {
     // Read virtual size BEFORE moving (file won't exist at old path after rename)
     let virtual_size = Qcow2Helper::qcow2_virtual_size(source)?;
 
-    // Move disk → destination (makes it immutable)
-    std::fs::rename(source, dest).map_err(|e| {
-        BoxliteError::Storage(format!(
-            "Failed to move disk {} to {}: {}",
-            source.display(),
-            dest.display(),
-            e
-        ))
-    })?;
+    // Move disk → destination (makes it immutable). Fall back to copy+remove
+    // on EXDEV: the box home and the base store can sit on different
+    // filesystems (e.g. a /tmp tmpfs home vs the on-disk data dir), where a
+    // plain rename() fails with "Invalid cross-device link".
+    if let Err(e) = std::fs::rename(source, dest) {
+        if e.raw_os_error() == Some(libc::EXDEV) {
+            std::fs::copy(source, dest).map_err(|e| {
+                BoxliteError::Storage(format!(
+                    "Failed to copy disk {} to {}: {}",
+                    source.display(),
+                    dest.display(),
+                    e
+                ))
+            })?;
+            std::fs::remove_file(source).map_err(|e| {
+                BoxliteError::Storage(format!(
+                    "Failed to remove source disk after cross-fs copy {}: {}",
+                    source.display(),
+                    e
+                ))
+            })?;
+        } else {
+            return Err(BoxliteError::Storage(format!(
+                "Failed to move disk {} to {}: {}",
+                source.display(),
+                dest.display(),
+                e
+            )));
+        }
+    }
 
     // Create COW child at original path (keeps the original path usable).
     // leak() prevents the Disk RAII guard from deleting the file on drop.

--- a/src/boxlite/src/runtime/rt_impl.rs
+++ b/src/boxlite/src/runtime/rt_impl.rs
@@ -44,6 +44,41 @@ pub(crate) fn stash_exit_file(layout: &BoxFilesystemLayout) {
     }
 }
 
+/// Move a directory tree, falling back to recursive copy + remove if rename
+/// fails with EXDEV. The import/clone staging dir and the canonical boxes dir
+/// can live on different filesystems (e.g. a tmpfs scratch area vs the on-disk
+/// data dir), where a plain `rename()` fails with "Invalid cross-device link".
+fn move_dir_cross_fs(src: &std::path::Path, dst: &std::path::Path) -> std::io::Result<()> {
+    match std::fs::rename(src, dst) {
+        Ok(()) => Ok(()),
+        Err(e) if e.raw_os_error() == Some(libc::EXDEV) => {
+            copy_dir_recursive(src, dst)?;
+            std::fs::remove_dir_all(src)
+        }
+        Err(e) => Err(e),
+    }
+}
+
+/// Recursively copy a directory tree, preserving symlinks as symlinks.
+fn copy_dir_recursive(src: &std::path::Path, dst: &std::path::Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(dst)?;
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let from = entry.path();
+        let to = dst.join(entry.file_name());
+        let ty = entry.file_type()?;
+        if ty.is_dir() {
+            copy_dir_recursive(&from, &to)?;
+        } else if ty.is_symlink() {
+            let target = std::fs::read_link(&from)?;
+            std::os::unix::fs::symlink(target, &to)?;
+        } else {
+            std::fs::copy(&from, &to)?;
+        }
+    }
+    Ok(())
+}
+
 /// Internal runtime state protected by single lock.
 ///
 /// **Shared via Arc**: This is the actual shared state that can be cloned cheaply.
@@ -1024,11 +1059,12 @@ impl RuntimeImpl {
         let container_id = ContainerID::new();
         let now = Utc::now();
 
-        // Move staging dir to canonical path.
+        // Move staging dir to canonical path (cross-fs safe: staging may be on
+        // a different filesystem than the boxes dir).
         let box_home = self.layout.boxes_dir().join(box_id.as_str());
-        std::fs::rename(&staging_dir, &box_home).map_err(|e| {
+        move_dir_cross_fs(&staging_dir, &box_home).map_err(|e| {
             BoxliteError::Storage(format!(
-                "Failed to rename {} to {}: {}",
+                "Failed to move {} to {}: {}",
                 staging_dir.display(),
                 box_home.display(),
                 e


### PR DESCRIPTION
rename cannot be operated between different mounted file systems (eg. /tmp mounted independently )
## Test plan

Two-sided (fix reverted vs applied), the clone/snapshot/export integration tests, run with the per-test box home on a tmpfs `/tmp` and the base store on an ext4 disk (i.e. different filesystems):

- `clone_export_import` (9) + `snapshot_clone_deep` (28) — clone / snapshot-clone / export-import flows that promote a disk to the base store and/or move an import staging dir into `boxes/`.

| observed | pre-fix (`disk/mod.rs` + `rt_impl.rs` reverted) | post-fix |
|---|---|---|
| disk promotion (`fork_qcow2`) | `Storage("Failed to move disk … : Invalid cross-device link (os error 18)")` | copies across fs, succeeds |
| staging-dir move (`provision_box`) | `Storage("Failed to rename …/staging → …/boxes/… : Invalid cross-device link")` | recursive-copies across fs, succeeds |
| test result | **37 FAIL** (cross-device) | **clone 28/28 + export 15/15 PASS** |

`archive.rs::move_file` already handled `EXDEV`; this brings the clone/snapshot move paths in line. Same-filesystem setups (most CI) take the plain `rename` fast path and are unaffected.
