### PR TITLE
[urgent] fix(guest): declare terminal=true for TTY execs (libcontainer 0.6 check_terminal) follow-up #611

### DIFF
--- a/src/boxlite/tests/exec_options.rs
+++ b/src/boxlite/tests/exec_options.rs
@@ -138,6 +138,34 @@ async fn test_timeout_kills_sigalrm_ignoring_process() {
     tb.teardown().await;
 }
 
+/// A TTY exec must run to natural completion and surface its real exit code
+/// through the zygote's `waitpid` — not lose it or default to 0.
+///
+/// libcontainer 0.6's `check_terminal` forced TTY execs onto the
+/// `with_detach(true)` + console-socket path. Detach changes how youki starts
+/// the process, so this guards that the zygote still reaps the detached PTY
+/// child and returns its exit status. The existing `resize_tty` tests only
+/// `kill()` then `wait()`; none assert a *natural* exit code for a TTY exec.
+#[tokio::test]
+async fn test_tty_exec_collects_natural_exit_code() {
+    let tb = TestBox::new().await;
+
+    let execution = tb
+        .handle
+        .exec(BoxCommand::new("sh").args(["-c", "exit 7"]).tty(true))
+        .await
+        .expect("tty exec failed to spawn");
+
+    let result = execution.wait().await.expect("wait failed");
+    assert_eq!(
+        result.exit_code, 7,
+        "TTY exec exit code must propagate through the zygote reaper; got {}",
+        result.exit_code
+    );
+
+    tb.teardown().await;
+}
+
 /// Combine working_dir and user in a single command.
 #[tokio::test]
 async fn test_working_dir_with_user() {

--- a/src/guest/src/container/spec.rs
+++ b/src/guest/src/container/spec.rs
@@ -341,6 +341,38 @@ fn build_process_spec(
         .map_err(|e| BoxliteError::Internal(format!("Failed to build process spec: {}", e)))
 }
 
+/// Build an OCI `Process` for a TTY tenant exec, with `terminal=true`.
+///
+/// libcontainer 0.6's `check_terminal` rejects a console socket unless the
+/// process declares `terminal=true` (and the build is detached). The tenant
+/// builder has no per-exec terminal setter, so this Process is serialized to a
+/// process.json and passed via `ContainerBuilder::with_process`. Same shape as
+/// `build_process_spec` but with the terminal flag on.
+pub(crate) fn build_tty_exec_process(
+    args: &[String],
+    env: &[String],
+    cwd: &str,
+    uid: u32,
+    gid: u32,
+) -> BoxliteResult<oci_spec::runtime::Process> {
+    let user = UserBuilder::default()
+        .uid(uid)
+        .gid(gid)
+        .build()
+        .map_err(|e| BoxliteError::Internal(format!("Failed to build user spec: {}", e)))?;
+
+    ProcessBuilder::default()
+        .terminal(true)
+        .user(user)
+        .args(args.to_vec())
+        .env(env)
+        .cwd(cwd)
+        .capabilities(build_default_capabilities()?)
+        .no_new_privileges(false)
+        .build()
+        .map_err(|e| BoxliteError::Internal(format!("Failed to build tty exec process: {}", e)))
+}
+
 /// Build root filesystem specification
 fn build_root_spec(rootfs: &str) -> BoxliteResult<oci_spec::runtime::Root> {
     RootBuilder::default()

--- a/src/guest/src/container/zygote.rs
+++ b/src/guest/src/container/zygote.rs
@@ -254,18 +254,51 @@ fn do_build(spec: BuildSpec, fds: Option<[RawFd; 3]>) -> BuildResult {
                 .with_stderr(stderr);
         }
 
-        let pid = builder
-            .as_tenant()
-            .with_capabilities(capability_names())
-            .with_no_new_privs(false)
-            .with_detach(false)
-            .with_cwd(Some(spec.cwd))
-            .with_env(spec.env)
-            .with_container_args(spec.args)
-            .with_user(Some(spec.uid))
-            .with_group(Some(spec.gid))
-            .build()
-            .map_err(|e| format!("build failed: {e}"))?;
+        // libcontainer 0.6's check_terminal requires a console socket iff
+        // (detached && terminal). The tenant builder has no per-exec terminal
+        // setter, so the two exec shapes diverge here.
+        let pid = if spec.console_socket.is_some() {
+            // TTY exec: hand youki a process.json with terminal=true (via
+            // with_process) and detach=true, so it allocates the PTY, relays
+            // the master fd over the console socket (received by ConsoleSocket),
+            // and returns the pid (the zygote reaps it via waitpid). The PTY
+            // path passes no stdio fds — youki wires the PTY slave instead.
+            let env_vec: Vec<String> = spec.env.iter().map(|(k, v)| format!("{k}={v}")).collect();
+            let cwd = spec.cwd.to_str().unwrap_or("/");
+            let process =
+                super::spec::build_tty_exec_process(&spec.args, &env_vec, cwd, spec.uid, spec.gid)
+                    .map_err(|e| format!("build tty exec process: {e}"))?;
+            let process_json = serde_json::to_vec(&process)
+                .map_err(|e| format!("serialize tty process.json: {e}"))?;
+            let process_path = spec
+                .state_root
+                .join(format!("exec-process-{}.json", spec.container_id));
+            std::fs::write(&process_path, process_json)
+                .map_err(|e| format!("write tty process.json: {e}"))?;
+            let result = builder
+                .as_tenant()
+                .with_detach(true)
+                .with_process(Some(process_path.clone()))
+                .build()
+                .map_err(|e| format!("build failed: {e}"));
+            let _ = std::fs::remove_file(&process_path);
+            result?
+        } else {
+            // Non-TTY exec: stdio via the passed pipe fds, no console socket,
+            // terminal=false, non-detached.
+            builder
+                .as_tenant()
+                .with_capabilities(capability_names())
+                .with_no_new_privs(false)
+                .with_detach(false)
+                .with_cwd(Some(spec.cwd))
+                .with_env(spec.env)
+                .with_container_args(spec.args)
+                .with_user(Some(spec.uid))
+                .with_group(Some(spec.gid))
+                .build()
+                .map_err(|e| format!("build failed: {e}"))?
+        };
 
         Ok(pid)
     };


### PR DESCRIPTION
boxlike exec -t requires strict check in libcontainer 0.6.0+ (follow-up #611 )
requires terminal=true

## Test plan

Two-sided on `main` (libcontainer 0.6): pre-fix = `invalid runtime spec`, post-fix = pass.

| test | pre-fix | post-fix |
|---|---|---|
| cli `test_exec_detach_with_tty_allowed` | `spawn_failed: build failed: invalid runtime spec` | **pass** |
| python `test_resize_tty_*` | same | **9 pass** |
| node `resizeTty on TTY-enabled run` | same | **pass** |
| rust `test_tty_exec_collects_natural_exit_code` | same | **pass** (TTY `sh -c 'exit 7'` → exit 7 reaped via zygote) |
| non-TTY `concurrent_exec` (regression guard) | pass | **9/9 pass** (unaffected) |