### PR TITLE
fix(rest): re-attach to drain backlog before emitting terminal result

### DIFF
--- a/src/boxlite/src/rest/litebox.rs
+++ b/src/boxlite/src/rest/litebox.rs
@@ -557,6 +557,10 @@ async fn attach_ws_pump(
     // Sticky across reconnects: once the server has ever sent a frame the
     // exec is real, so a later reconnect uses the steady-state watchdog.
     let mut first_frame_seen = false;
+    // Set once we've already re-attached to drain the backlog after the exec
+    // went terminal. Bounds that drain to a single attempt so a runner that
+    // never sends a closing exit frame can't spin this loop.
+    let mut terminal_drain_attempted = false;
 
     let mut current_stream = Some(initial_stream);
 
@@ -681,6 +685,28 @@ async fn attach_ws_pump(
         // distinguish "exec really finished" from "transient WS drop".
         match probe_execution_status(client, box_id, execution_id).await {
             ProbeResult::Terminal(result) => {
+                // The exec finished, but the WS dropped before we saw its
+                // exit frame — so the runner may still hold the tail of
+                // stdout/stderr in its replay backlog that this attach never
+                // received. This is the silent-loss case over a proxied /
+                // high-latency link: a fast command exits before the first
+                // attach drains, the connection is cut, and the status probe
+                // reports "completed" with the output still buffered
+                // server-side. Emitting the exit code here would surface a
+                // clean exit with empty stdout.
+                //
+                // Re-attach once, immediately (the data is already there — no
+                // backoff), so the runner replays its backlog and we leave via
+                // its authoritative exit frame. Bounded to a single attempt;
+                // fall back to the probed result if we can't re-attach (reaped
+                // between probe and connect, or unreachable) so we never hang.
+                if !terminal_drain_attempted {
+                    terminal_drain_attempted = true;
+                    if let Ok(new_stream) = client.connect_ws(&path).await {
+                        current_stream = Some(new_stream);
+                        continue 'session;
+                    }
+                }
                 let _ = result_tx.send(result);
                 return;
             }
@@ -1372,6 +1398,137 @@ mod tests {
         assert!(res.error_message.is_none());
 
         attach.await.unwrap();
+        server.abort();
+    }
+
+    // ─── ws_terminal_probe_after_cut_must_not_drop_buffered_stdout ───────
+    //
+    // Reproduces the cloud "fast command → empty stdout, exit 0" loss.
+    //
+    // Timeline of a proxied cloud attach to a command that has already
+    // finished (e.g. `uptime`):
+    //   1. The client opens `/attach`. The WS upgrade succeeds, but the
+    //      connection is cut BEFORE the runner flushes the command's stdout
+    //      — an idle-cut / latency stall in the proxy in front of the
+    //      runner. The bytes are NOT gone server-side: they sit in the
+    //      runner's per-exec backlog, replayed to any fresh subscriber.
+    //   2. The pump probes `GET /executions/{id}` → "completed", exit 0.
+    //   3. The buffered stdout ("hello\n") is still obtainable by
+    //      re-attaching — the 2nd WS connection below replays it, exactly as
+    //      the runner's stream backlog does for a late/reconnecting client.
+    //
+    // Bug: a `ProbeResult::Terminal` short-circuits the pump — it emits the
+    // exit code and `return`s WITHOUT re-attaching, so the backlog stdout is
+    // never drained. The consumer sees a clean exit with EMPTY stdout, and
+    // because the exit code is the correct 0 the drop is silent.
+    //
+    // This exercises the REST attach path (`attach_ws_pump` /
+    // `probe_execution_status`). PR #563 is an `sdks/c` FFI change that does
+    // not touch this file (`git diff main..HEAD -- src/boxlite/src/rest/\
+    // litebox.rs` is empty), so this test fails identically on `main` and on
+    // the #563 branch.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn ws_terminal_probe_after_cut_must_not_drop_buffered_stdout() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let state: SharedState = Arc::new(Mutex::new(ServerState::default()));
+        let state_clone = state.clone();
+
+        // 1st WS upgrade: accept then close immediately, before any output
+        // frame (the proxy cut). GET status: completed / exit 0. 2nd WS
+        // upgrade: replay the runner backlog ("hello\n") then the exit frame,
+        // as a real re-attach would receive. The buggy client never opens
+        // the 2nd WS — it bails out on the Terminal status probe.
+        let server = tokio::spawn(async move {
+            let mut ws_conn = 0u32;
+            loop {
+                let (mut stream, _) = match listener.accept().await {
+                    Ok(p) => p,
+                    Err(_) => return,
+                };
+                let head = read_request_head(&mut stream).await;
+                let is_upgrade = String::from_utf8_lossy(&head)
+                    .to_ascii_lowercase()
+                    .contains("upgrade: websocket");
+                if is_upgrade {
+                    ws_conn += 1;
+                    let chained = ChainedStream {
+                        head,
+                        head_pos: 0,
+                        inner: stream,
+                    };
+                    let mut ws = match tokio_tungstenite::accept_async(chained).await {
+                        Ok(ws) => ws,
+                        Err(_) => continue,
+                    };
+                    if ws_conn == 1 {
+                        // Cut the connection before flushing buffered stdout.
+                        let _ = ws.close(None).await;
+                    } else {
+                        // Re-attach: runner replays its backlog, then exits.
+                        let mut frame = vec![0x01u8];
+                        frame.extend_from_slice(b"hello\n");
+                        let _ = ws.send(Message::Binary(frame)).await;
+                        let _ = ws
+                            .send(Message::Text(r#"{"type":"exit","exit_code":0}"#.into()))
+                            .await;
+                        let _ = ws.close(None).await;
+                    }
+                } else {
+                    let mut s = state_clone.lock().await;
+                    s.status_calls += 1;
+                    drop(s);
+                    write_status_response(
+                        &mut stream,
+                        r#"{"execution_id":"exec1","status":"completed","exit_code":0}"#,
+                    )
+                    .await;
+                }
+            }
+        });
+
+        let client = client_for(port);
+        let (stdout_tx, mut stdout_rx) = mpsc::unbounded_channel::<String>();
+        let (stderr_tx, _stderr_rx) = mpsc::unbounded_channel::<String>();
+        let (_stdin_tx, stdin_rx) = mpsc::unbounded_channel::<Vec<u8>>();
+        let (result_tx, mut result_rx) = mpsc::unbounded_channel::<ExecResult>();
+
+        let attach = tokio::spawn(async move {
+            attach_ws(
+                &client, "box1", "exec1", stdin_rx, stdout_tx, stderr_tx, result_tx,
+            )
+            .await;
+        });
+
+        // The pump finishes once it emits a terminal result. Bounded so a
+        // regression that hangs fails loudly instead of stalling CI.
+        tokio::time::timeout(Duration::from_secs(10), attach)
+            .await
+            .expect("attach pump did not finish")
+            .unwrap();
+
+        // Everything the consumer actually received after the pump returned.
+        let mut collected = String::new();
+        while let Ok(chunk) = stdout_rx.try_recv() {
+            collected.push_str(&chunk);
+        }
+        let res = result_rx
+            .try_recv()
+            .expect("pump emitted no terminal ExecResult");
+
+        // The exit code is (correctly) 0 — which is exactly why the loss is
+        // silent: callers trust the clean exit and never notice the drop.
+        assert_eq!(res.exit_code, 0, "exit code should surface as 0");
+
+        // The real assertion: the command's stdout must reach the consumer.
+        assert_eq!(
+            collected, "hello\n",
+            "buffered stdout was dropped — consumer saw empty stdout with a clean \
+             exit. The WS pump short-circuited on a Terminal status probe \
+             (rest/litebox.rs `ProbeResult::Terminal`) and returned without \
+             re-attaching to drain the runner's backlog."
+        );
+
         server.abort();
     }
 }

--- a/src/cli/tests/rest_e2e.rs
+++ b/src/cli/tests/rest_e2e.rs
@@ -1,0 +1,315 @@
+//! End-to-end deterministic reproducer of the bug PR #627 fixes
+//! (`ws_terminal_probe_after_cut_must_not_drop_buffered_stdout`).
+//!
+//! The PR-bundled unit test mocks the WS server in-process. This test runs
+//! the real production stack: a `boxlite serve` subprocess, and the
+//! production `BoxliteRuntime::rest` REST client (which goes through
+//! `attach_ws_pump` — the function PR #627 patches). A small TCP proxy
+//! between them deterministically cuts the FIRST WebSocket upgrade after
+//! the 101 response, forcing the client onto the `ProbeResult::Terminal`
+//! short-circuit branch. The fix's re-attach is what lets the buffered
+//! `"hello\n"` reach the consumer; without it stdout would silently be
+//! empty.
+//!
+//! Two-sided in practice:
+//!   - With PR #627 applied: the client re-attaches, the proxy lets the
+//!     2nd WS through transparently, the runner replays its backlog,
+//!     stdout collects `"hello\n"`, the test PASSES.
+//!   - With PR #627 reverted (set `terminal_drain_attempted = true` at
+//!     `litebox.rs:563`): the client bails on the Terminal probe, stdout
+//!     is empty, the test FAILS with the assertion comparing `"" vs
+//!     "hello\n"`. Verified locally.
+
+#![allow(dead_code)]
+
+use boxlite::runtime::options::{BoxOptions, RootfsSpec};
+use boxlite::{BoxCommand, BoxliteRestOptions, BoxliteRuntime};
+use boxlite_test_utils::TEST_REGISTRIES;
+use boxlite_test_utils::home::PerTestBoxHome;
+use std::net::TcpListener;
+use std::process::{Child, Command as StdCommand, Stdio};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+
+// ---------------------------------------------------------------------------
+// Helpers: free port, serve readiness, subprocess teardown
+// ---------------------------------------------------------------------------
+
+fn pick_free_port() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind :0");
+    let port = listener.local_addr().expect("local_addr").port();
+    drop(listener);
+    port
+}
+
+async fn wait_serve_ready(port: u16, timeout: Duration) -> bool {
+    let url = format!("http://127.0.0.1:{port}/v1/config");
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        // System `curl` deliberately: proves the REST surface speaks to *any*
+        // HTTP client, not just our own reqwest.
+        let output = StdCommand::new("curl")
+            .args([
+                "-s",
+                "-o",
+                "/dev/null",
+                "-w",
+                "%{http_code}",
+                "--max-time",
+                "1",
+                &url,
+            ])
+            .output();
+        if let Ok(out) = output
+            && out.status.success()
+            && out.stdout == b"200"
+        {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(150)).await;
+    }
+    false
+}
+
+/// `boxlite serve` subprocess wrapped in a `Drop` guard. SIGINT (not SIGTERM)
+/// so the daemon hits its axum `with_graceful_shutdown` future and calls
+/// `runtime.shutdown(timeout)` — stopping every running box before exit and
+/// keeping `PerTestBoxHome::Drop`'s leak check happy.
+struct ServeGuard {
+    child: Child,
+}
+
+impl Drop for ServeGuard {
+    fn drop(&mut self) {
+        let pid = nix::unistd::Pid::from_raw(self.child.id() as i32);
+        let _ = nix::sys::signal::kill(pid, nix::sys::signal::Signal::SIGINT);
+        let deadline = Instant::now() + Duration::from_secs(15);
+        loop {
+            match self.child.try_wait() {
+                Ok(Some(_)) => return,
+                _ => {
+                    if Instant::now() >= deadline {
+                        let _ = self.child.kill();
+                        let _ = self.child.wait();
+                        return;
+                    }
+                    std::thread::sleep(Duration::from_millis(50));
+                }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TCP proxy that cuts the FIRST WebSocket upgrade
+// ---------------------------------------------------------------------------
+
+/// Proxy listens on its own port and forwards every byte to `target_port`,
+/// EXCEPT the first time it sees a `Connection: Upgrade` / `Upgrade: websocket`
+/// header pair. For that one connection it forwards the request, lets the
+/// server send the `101 Switching Protocols` response back, then closes both
+/// halves of the TCP pair — exactly the "proxy idle-cut on the upgrade
+/// without any data frames" pattern that PR #627's mock test pins.
+///
+/// Subsequent connections — including the *second* WS upgrade that the fixed
+/// client opens — are forwarded transparently. So:
+///   - WS attach #1 → proxy cuts → client sees an immediate WS close.
+///   - GET /v1/.../executions/{id} → HTTP, transparent → "completed" probe.
+///   - WS attach #2 (only on the fixed path) → transparent → runner replays
+///     `"hello\n"` + exit frame, client collects them.
+async fn spawn_ws_cut_proxy(target_port: u16) -> (u16, tokio::task::JoinHandle<()>) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("proxy bind :0");
+    let proxy_port = listener.local_addr().expect("proxy local_addr").port();
+    let ws_seen = Arc::new(AtomicU64::new(0));
+
+    let handle = tokio::spawn(async move {
+        loop {
+            let Ok((client, _)) = listener.accept().await else {
+                return;
+            };
+            let ws_seen = ws_seen.clone();
+            tokio::spawn(async move {
+                let _ = handle_proxy_conn(client, target_port, ws_seen).await;
+            });
+        }
+    });
+    (proxy_port, handle)
+}
+
+async fn handle_proxy_conn(
+    client: TcpStream,
+    target_port: u16,
+    ws_seen: Arc<AtomicU64>,
+) -> std::io::Result<()> {
+    let server = TcpStream::connect(("127.0.0.1", target_port)).await?;
+    let (mut client_read, mut client_write) = client.into_split();
+    let (mut server_read, mut server_write) = server.into_split();
+
+    // Read just the request head (up to `\r\n\r\n`). We need it to decide if
+    // this is a WS upgrade; everything after the head is opaque to us.
+    let mut request_head = Vec::with_capacity(4096);
+    let mut buf = [0u8; 1024];
+    loop {
+        let n = client_read.read(&mut buf).await?;
+        if n == 0 {
+            return Ok(());
+        }
+        request_head.extend_from_slice(&buf[..n]);
+        if request_head.windows(4).any(|w| w == b"\r\n\r\n") {
+            break;
+        }
+        if request_head.len() > 16384 {
+            return Ok(()); // safety cap on malformed input
+        }
+    }
+    let head_lower = String::from_utf8_lossy(&request_head).to_ascii_lowercase();
+    let is_ws_upgrade =
+        head_lower.contains("upgrade: websocket") && head_lower.contains("connection: ");
+
+    // Forward the request head to the server unmodified.
+    server_write.write_all(&request_head).await?;
+
+    if !is_ws_upgrade {
+        // Plain HTTP — fully transparent, copy both halves until either side
+        // closes.
+        let _ = tokio::join!(
+            tokio::io::copy(&mut client_read, &mut server_write),
+            tokio::io::copy(&mut server_read, &mut client_write),
+        );
+        return Ok(());
+    }
+
+    let is_first_ws = ws_seen.fetch_add(1, Ordering::SeqCst) == 0;
+
+    if !is_first_ws {
+        // 2nd+ WS upgrade — transparent. This is the path the fixed client's
+        // re-attach uses, and it MUST work so the runner backlog can flow.
+        let _ = tokio::join!(
+            tokio::io::copy(&mut client_read, &mut server_write),
+            tokio::io::copy(&mut server_read, &mut client_write),
+        );
+        return Ok(());
+    }
+
+    // First WS upgrade: forward the `101 Switching Protocols` response head
+    // back, then close both halves. The client sees a valid upgrade followed
+    // immediately by a WS close — same shape as a proxy idle-cut.
+    let mut response_head = Vec::with_capacity(4096);
+    loop {
+        let n = server_read.read(&mut buf).await?;
+        if n == 0 {
+            break;
+        }
+        response_head.extend_from_slice(&buf[..n]);
+        if response_head.windows(4).any(|w| w == b"\r\n\r\n") {
+            break;
+        }
+        if response_head.len() > 16384 {
+            break;
+        }
+    }
+    let _ = client_write.write_all(&response_head).await;
+    // Drop everything — the half-streams close their underlying socket on
+    // drop, which is precisely the "cut" we're simulating.
+    drop(client_write);
+    drop(client_read);
+    drop(server_write);
+    drop(server_read);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// The test
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn boxlite_rest_attach_drain_after_proxy_cut_serves_stdout() {
+    let server_home = PerTestBoxHome::new();
+    let bin = env!("CARGO_BIN_EXE_boxlite");
+
+    // 1. `boxlite serve` on an ephemeral port.
+    let serve_port = pick_free_port();
+    let mut serve_cmd = StdCommand::new(bin);
+    serve_cmd
+        .arg("--home")
+        .arg(&server_home.path)
+        .args(["serve", "--port"])
+        .arg(serve_port.to_string())
+        .args(["--host", "127.0.0.1"]);
+    for reg in TEST_REGISTRIES {
+        serve_cmd.arg("--registry").arg(reg);
+    }
+    serve_cmd.stdout(Stdio::null()).stderr(Stdio::null());
+    let child = serve_cmd.spawn().expect("spawn boxlite serve");
+    let _serve_guard = ServeGuard { child };
+
+    assert!(
+        wait_serve_ready(serve_port, Duration::from_secs(30)).await,
+        "boxlite serve never accepted GET /v1/config on 127.0.0.1:{serve_port}"
+    );
+
+    // 2. Proxy in front of serve. The client will talk to the proxy port; the
+    // proxy cuts the first WS upgrade.
+    let (proxy_port, proxy_handle) = spawn_ws_cut_proxy(serve_port).await;
+
+    // 3. Production REST client (the path through `attach_ws_pump`).
+    let opts = BoxliteRestOptions::new(format!("http://127.0.0.1:{proxy_port}"));
+    let rt = BoxliteRuntime::rest(opts).expect("rest runtime");
+
+    let box_opts = BoxOptions {
+        rootfs: RootfsSpec::Image("alpine:latest".into()),
+        auto_remove: true,
+        ..Default::default()
+    };
+    let lb = rt
+        .create(box_opts, None)
+        .await
+        .expect("create box via REST");
+    let mut exec = lb
+        .exec(BoxCommand::new("sh").args(["-c", "echo hello"]))
+        .await
+        .expect("exec echo via REST");
+
+    // 4. Collect stdout. The first WS will be cut by the proxy. With PR
+    // #627 applied the runtime re-attaches once (the proxy passes the 2nd
+    // WS through transparently) and the runner's replay reaches us. Without
+    // it, the pump short-circuits on the Terminal probe and this channel
+    // never receives anything before closing.
+    use futures::StreamExt;
+    let mut stdout_stream = exec.stdout().expect("stdout handle");
+    let mut collected = String::new();
+    let collect = async {
+        while let Some(chunk) = stdout_stream.next().await {
+            collected.push_str(&chunk);
+        }
+    };
+    let _ = tokio::time::timeout(Duration::from_secs(60), collect).await;
+
+    // 5. Wait for the exec result. Must time out cleanly rather than hang;
+    // with the fix this completes in well under a second of the proxy cut.
+    let result = tokio::time::timeout(Duration::from_secs(30), exec.wait())
+        .await
+        .expect("exec.wait() timed out — the pump never produced a terminal frame")
+        .expect("exec.wait() error");
+
+    assert_eq!(
+        result.exit_code, 0,
+        "echo hello should exit 0; got {}",
+        result.exit_code
+    );
+    assert_eq!(
+        collected, "hello\n",
+        "stdout was dropped: the proxy cut the first WS attach, and without \
+         PR #627's `terminal_drain_attempted` re-attach in `attach_ws_pump`, \
+         the client bails on the Terminal status probe with empty stdout. \
+         If this assertion fails reading `\"\"`, the fix has regressed."
+    );
+
+    proxy_handle.abort();
+    let _ = proxy_handle.await;
+}


### PR DESCRIPTION
Re-attach once to drain server-buffered stdout when the attach WebSocket is cut before the exit frame, fixing silent stdout loss.
use local `boxlite serve` and REST POST request for E2E test

## Test plan

Two-sided (re-attach disabled vs applied), toggled on the branch since the tests ship with the fix.

### In-process unit reproducer (mock WS)

- `ws_terminal_probe_after_cut_must_not_drop_buffered_stdout` — in-process mock-WS in `rest/litebox.rs`: the first attach is cut before the exit frame, `GET /executions/{id}` reports completed/exit 0, and the backlog (`hello\n`) is served **only** on re-attach.

| observed | pre-fix (re-attach disabled) | post-fix |
|---|---|---|
| consumer stdout (fast cmd, late attach) | **`""`** — clean exit 0, output dropped | `"hello\n"` — backlog drained |
| 50×4 fast-command repro (Go SDK, cloud) | 18–26/50 loss | 0/50 |
| test result | **FAIL** (`left:"" right:"hello\n"`) | **PASS** |

### End-to-end reproducer (real `boxlite serve` + TCP proxy)

`boxlite_rest_attach_drain_after_proxy_cut_serves_stdout` (`src/cli/tests/rest_e2e.rs`) runs the actual production stack: real `boxlite serve` subprocess on an ephemeral port, the production `BoxliteRuntime::rest` client (the path through `attach_ws_pump`), and an inline async TCP proxy in front of the daemon that deterministically cuts the **first** WS upgrade after the 101 response and lets every subsequent connection (HTTP status probes, the second WS for the re-attach) through transparently. Inside the box: `sh -c "echo hello"` in alpine.

| step | code state | result |
|---|---|---|
| A | fix applied | `ok` (6.57 s) — 1st WS cut → status Terminal → re-attach (2nd WS transparent) → runner replays `hello\n` + exit frame |
| B | `terminal_drain_attempted = true` at `rest/litebox.rs:563` (re-attach short-circuited) | **FAILED** — `assertion left == right` `left: "", right: "hello\n"` — the silent stdout loss this PR fixes |
| C | fix restored | `ok` (8.71 s) |

What this end-to-end test catches that the mock unit test doesn't:
- Real WS upgrade handshake between axum (serve) and reqwest-tungstenite (REST client).
- `BoxliteRuntime::rest` end-to-end: box create + exec + attach + status probe through one TCP proxy without any in-process scaffolding.
- The 2nd-WS re-attach actually receiving the runner's backlog over a real WS subprotocol exchange (not a hand-crafted `Message::Binary` reply in the mock).
- `boxlite serve` accepting the proxy-mediated traffic exactly as it would from any external REST consumer.

Orthogonal to #563 (an `sdks/c` FFI drain fix at the SDK layer): this is the REST client attach path, and the loss reproduced on **both `main` and the #563 branch**. Tradeoff: the re-attach replays the runner's full backlog without an offset, so a partial prefix delivered before the cut can be **duplicated** — this matches existing `StillRunning`/`Unavailable` reconnect semantics and is strictly preferable to silent loss (offset-based replay is out of scope).
