### PR TITLE
feat(secrets): support live box secret updates

### DIFF
--- a/src/cli/tests/cp.rs
+++ b/src/cli/tests/cp.rs
@@ -1,0 +1,103 @@
+//! Integration tests for the `boxlite cp` CLI command (host ↔ box file copy).
+//!
+//! Exercises the binary end-to-end: `cp` into a running box, confirm the file
+//! actually landed at the target path with the right content (by `exec cat`
+//! inside the box), then `cp` it back out and compare byte-for-byte. The lib
+//! API (`LiteBox::copy_into/out`) has its own coverage in `tests/copy.rs`; this
+//! guards the CLI argument parsing + `BOX:PATH` plumbing on top of it.
+
+mod common;
+
+use std::fs;
+use tempfile::TempDir;
+
+fn cleanup(ctx: &common::TestContext, box_id: &str) {
+    ctx.new_cmd()
+        .args(["rm", "--force", box_id])
+        .assert()
+        .success();
+}
+
+/// One box, two round-trips (text + binary). Each: `cp` in → `exec cat`/compare
+/// inside the box (proves the file reached the target path with intact content)
+/// → `cp` out → compare the host copy against the original.
+#[test]
+fn test_cp_roundtrip_lands_file_and_preserves_content() {
+    let mut ctx = common::boxlite();
+    let host = TempDir::new().expect("host temp dir");
+
+    // Start a long-lived box to copy in/out of.
+    ctx.cmd.args(["run", "-d", "alpine:latest", "sleep", "300"]);
+    let output = ctx.cmd.assert().success().get_output().clone();
+    let box_id = String::from_utf8_lossy(&output.stdout).trim().to_string();
+
+    // ── Text file ────────────────────────────────────────────────────────
+    let content = "hello from boxlite cp\nsecond line\n";
+    let src = host.path().join("input.txt");
+    fs::write(&src, content).unwrap();
+
+    // copy in: host → box
+    ctx.new_cmd()
+        .args([
+            "cp",
+            src.to_str().unwrap(),
+            &format!("{box_id}:/root/input.txt"),
+        ])
+        .assert()
+        .success();
+
+    // The file must exist at the target path inside the box with exact content
+    // — read it back via the box's own filesystem, not the host's.
+    ctx.new_cmd()
+        .args(["exec", &box_id, "--", "cat", "/root/input.txt"])
+        .assert()
+        .success()
+        .stdout(content);
+
+    // copy out: box → host, then compare to the original bytes.
+    let text_out = host.path().join("output.txt");
+    ctx.new_cmd()
+        .args([
+            "cp",
+            &format!("{box_id}:/root/input.txt"),
+            text_out.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+    assert_eq!(
+        fs::read_to_string(&text_out).unwrap(),
+        content,
+        "round-tripped text file must match the original"
+    );
+
+    // ── Binary fidelity (all 256 byte values) ────────────────────────────
+    let data: Vec<u8> = (0..=255).collect();
+    let bin_src = host.path().join("blob.bin");
+    fs::write(&bin_src, &data).unwrap();
+
+    ctx.new_cmd()
+        .args([
+            "cp",
+            bin_src.to_str().unwrap(),
+            &format!("{box_id}:/root/blob.bin"),
+        ])
+        .assert()
+        .success();
+
+    let bin_out = host.path().join("blob-out.bin");
+    ctx.new_cmd()
+        .args([
+            "cp",
+            &format!("{box_id}:/root/blob.bin"),
+            bin_out.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+    assert_eq!(
+        fs::read(&bin_out).unwrap(),
+        data,
+        "round-tripped binary must be byte-identical"
+    );
+
+    cleanup(&ctx, &box_id);
+}

--- a/src/cli/tests/cp_errors.rs
+++ b/src/cli/tests/cp_errors.rs
@@ -1,0 +1,80 @@
+//! `boxlite cp` rejection paths: the guest must refuse an unsafe or impossible
+//! copy instead of silently mis-resolving it.
+//!
+//! Each test runs against an otherwise-valid running box and a valid host file,
+//! so the *only* fault is the path under test — a copy that still fails (with
+//! the guard's own message) therefore exercises that specific guard, not some
+//! unrelated setup error. The happy paths live in `cp.rs` / `cp_runtime_mount.rs`.
+
+mod common;
+
+use predicates::prelude::*;
+use std::fs;
+use tempfile::TempDir;
+
+fn cleanup(ctx: &common::TestContext, box_id: &str) {
+    ctx.new_cmd()
+        .args(["rm", "--force", box_id])
+        .assert()
+        .success();
+}
+
+fn start_box(ctx: &mut common::TestContext) -> String {
+    ctx.cmd.args(["run", "-d", "alpine:latest", "sleep", "300"]);
+    let output = ctx.cmd.assert().success().get_output().clone();
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+/// A destination path containing `..` must be rejected — copying must not be
+/// able to escape the container rootfs / live mount namespace.
+#[test]
+fn cp_into_rejects_parent_dir_traversal() {
+    let mut ctx = common::boxlite();
+    let host = TempDir::new().expect("host temp dir");
+    let box_id = start_box(&mut ctx);
+
+    let src = host.path().join("payload.txt");
+    fs::write(&src, "payload\n").unwrap();
+
+    // Valid box, valid host file — the only fault is the `..` in the dest.
+    ctx.new_cmd()
+        .args([
+            "cp",
+            src.to_str().unwrap(),
+            &format!("{box_id}:/root/../escape.txt"),
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("must not contain"));
+
+    cleanup(&ctx, &box_id);
+}
+
+/// Copying *out* a path that does not exist inside the box must fail loudly
+/// (a not-found error), not produce an empty or partial host file.
+#[test]
+fn cp_out_of_missing_source_fails() {
+    let mut ctx = common::boxlite();
+    let host = TempDir::new().expect("host temp dir");
+    let box_id = start_box(&mut ctx);
+
+    let dst = host.path().join("out.txt");
+    ctx.new_cmd()
+        .args([
+            "cp",
+            &format!("{box_id}:/root/does-not-exist.txt"),
+            dst.to_str().unwrap(),
+        ])
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("does not exist").or(predicate::str::contains("not found")),
+        );
+
+    assert!(
+        !dst.exists(),
+        "no host file should be created when the box source is missing"
+    );
+
+    cleanup(&ctx, &box_id);
+}

--- a/src/cli/tests/cp_runtime_mount.rs
+++ b/src/cli/tests/cp_runtime_mount.rs
@@ -1,0 +1,51 @@
+//! `boxlite cp` into a running box's runtime mount (the tmpfs at `/tmp`).
+//!
+//! `/tmp` is a tmpfs mounted in the container's namespace, not part of the
+//! persistent rootfs disk. Resolving the copy against the on-disk rootfs lands
+//! the file *beneath* that tmpfs — invisible to the container (and the copy may
+//! fail outright). The fix resolves a running container's paths through its
+//! live mount namespace (`/proc/<init_pid>/root`), matching `docker cp`. This
+//! test copies into `/tmp` and asserts the container actually sees it; without
+//! the fix the `cat` finds nothing and the test fails.
+
+mod common;
+
+use std::fs;
+use tempfile::TempDir;
+
+fn cleanup(ctx: &common::TestContext, box_id: &str) {
+    ctx.new_cmd()
+        .args(["rm", "--force", box_id])
+        .assert()
+        .success();
+}
+
+#[test]
+fn cp_into_tmpfs_tmp_is_visible_in_container() {
+    let mut ctx = common::boxlite();
+    let host = TempDir::new().expect("host temp dir");
+
+    ctx.cmd.args(["run", "-d", "alpine:latest", "sleep", "300"]);
+    let output = ctx.cmd.assert().success().get_output().clone();
+    let box_id = String::from_utf8_lossy(&output.stdout).trim().to_string();
+
+    let content = "into-the-tmpfs\n";
+    let src = host.path().join("t.txt");
+    fs::write(&src, content).unwrap();
+
+    // Copy into the tmpfs at /tmp (a runtime mount, not the persistent rootfs).
+    ctx.new_cmd()
+        .args(["cp", src.to_str().unwrap(), &format!("{box_id}:/tmp/t.txt")])
+        .assert()
+        .success();
+
+    // The container must see it at /tmp with the exact content — i.e. the copy
+    // reached the live tmpfs, not the shadowed on-disk /tmp.
+    ctx.new_cmd()
+        .args(["exec", &box_id, "--", "cat", "/tmp/t.txt"])
+        .assert()
+        .success()
+        .stdout(content);
+
+    cleanup(&ctx, &box_id);
+}

--- a/src/guest/src/service/files.rs
+++ b/src/guest/src/service/files.rs
@@ -8,13 +8,14 @@ use crate::service::server::GuestServer;
 use boxlite_shared::{
     files_server::Files, DownloadChunk, DownloadRequest, UploadChunk, UploadResponse,
 };
+use std::os::fd::AsRawFd;
 use std::path::{Path, PathBuf};
 use tokio::fs::File;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Request, Response, Status, Streaming};
-use tracing::info;
+use tracing::{info, warn};
 
 const CHUNK_SIZE: usize = 1 << 20; // 1 MiB
 const MAX_UPLOAD_BYTES: u64 = 512 * 1024 * 1024; // 512 MiB safety cap
@@ -92,7 +93,7 @@ impl Files for GuestServer {
         let force_directory = dest_path.ends_with('/');
         boxlite_shared::tar::unpack(
             temp_path.clone(),
-            dest_root.clone(),
+            dest_root.path.clone(),
             boxlite_shared::tar::UnpackContext {
                 overwrite,
                 mkdir_parents,
@@ -105,7 +106,7 @@ impl Files for GuestServer {
         let _ = tokio::fs::remove_file(&temp_path).await;
 
         info!(
-            dest = %dest_root.display(),
+            dest = %dest_root.path.display(),
             bytes = total,
             container_id = %container_id,
             "upload completed"
@@ -133,7 +134,7 @@ impl Files for GuestServer {
             .map_err(Status::failed_precondition)?;
 
         let src_path = self.container_rootfs(&container_id, &req.src_path)?;
-        if !src_path.exists() {
+        if !src_path.path.exists() {
             return Err(Status::not_found("source path does not exist"));
         }
 
@@ -145,7 +146,7 @@ impl Files for GuestServer {
         let follow_symlinks = req.follow_symlinks;
 
         boxlite_shared::tar::pack(
-            src_path,
+            src_path.path.clone(),
             temp_path.clone(),
             boxlite_shared::tar::PackContext {
                 follow_symlinks,
@@ -225,7 +226,7 @@ impl GuestServer {
     }
 
     #[allow(clippy::result_large_err)]
-    fn container_rootfs(&self, container_id: &str, path: &str) -> Result<PathBuf, Status> {
+    fn container_rootfs(&self, container_id: &str, path: &str) -> Result<ContainerPath, Status> {
         let path_obj = Path::new(path);
         if path_obj
             .components()
@@ -240,36 +241,76 @@ impl GuestServer {
             path_obj.to_path_buf()
         };
 
-        // For a running container, resolve through its live mount namespace via
-        // `/proc/<init_pid>/root` so paths under runtime mounts (e.g. the tmpfs
-        // at /tmp, /run, /dev/shm) reach what the container actually sees —
-        // matching `docker cp`. Touching the on-disk rootfs dir instead lands
-        // *beneath* those mounts: invisible to the container, or rejected. When
-        // the container isn't running there are no such mounts, so fall back to
-        // the on-disk rootfs (offline copy to a stopped box).
+        // For a running container, resolve through its live mount namespace so
+        // paths under runtime mounts (the tmpfs at /tmp, /run, /dev/shm) reach
+        // what the container actually sees — matching `docker cp`. Touching the
+        // on-disk rootfs dir instead lands *beneath* those mounts: invisible to
+        // the container, or rejected.
+        //
+        // Open `/proc/<pid>/root` once, now, and resolve relative to that open
+        // handle (`/proc/self/fd/<n>`) rather than re-deriving the `/proc/<pid>`
+        // path at write time. The open follows the magic symlink immediately, so
+        // a PID recycled between this check and the tar I/O can't redirect the
+        // copy into another process's namespace; the handle lives in the
+        // returned `ContainerPath` until the copy completes.
         if let Some(pid) = self.container_init_pid(container_id) {
-            return Ok(PathBuf::from(format!("/proc/{pid}/root")).join(&rel));
+            let root = std::fs::File::open(format!("/proc/{pid}/root")).map_err(|e| {
+                Status::failed_precondition(format!(
+                    "container {container_id} is running (init pid {pid}) but its \
+                     mount-namespace root is unavailable: {e}"
+                ))
+            })?;
+            let path = PathBuf::from(format!("/proc/self/fd/{}", root.as_raw_fd())).join(&rel);
+            return Ok(ContainerPath {
+                path,
+                _root_pin: Some(root),
+            });
         }
 
+        // Not running: no runtime mounts exist, so the on-disk rootfs is the
+        // correct target (offline copy to a stopped box).
         let rootfs = self.layout.shared().container(container_id).rootfs_dir();
-        Ok(rootfs.join(rel))
+        Ok(ContainerPath {
+            path: rootfs.join(rel),
+            _root_pin: None,
+        })
     }
 
     /// PID of the container's init process when it is running, used to resolve
     /// copy paths through its live mount namespace (`/proc/<pid>/root`).
-    /// `None` if the container isn't running or its libcontainer state can't be
-    /// read — callers then fall back to the on-disk rootfs.
+    /// `None` when the container isn't running. A failure to read the
+    /// libcontainer state is logged and also yields `None` (callers fall back
+    /// to the on-disk rootfs): a running container always has loadable state, so
+    /// a read error means we can no longer tell it's running, and silently
+    /// landing the copy beneath a runtime mount would be an invisible drop.
     fn container_init_pid(&self, container_id: &str) -> Option<i32> {
         use libcontainer::container::{Container as LibContainer, ContainerStatus};
         let state_path = self
             .layout
             .container_state_dir(container_id)
             .join(container_id);
-        let container = LibContainer::load(state_path).ok()?;
-        if matches!(container.status(), ContainerStatus::Running) {
-            container.pid().map(|p| p.as_raw())
-        } else {
-            None
+        match LibContainer::load(state_path) {
+            Ok(container) if matches!(container.status(), ContainerStatus::Running) => {
+                container.pid().map(|p| p.as_raw())
+            }
+            Ok(_) => None,
+            Err(e) => {
+                warn!(
+                    container_id = %container_id,
+                    error = %e,
+                    "failed to load container state for copy; falling back to on-disk rootfs"
+                );
+                None
+            }
         }
     }
+}
+
+/// A resolved copy path plus an optional pin that keeps it valid for the
+/// duration of a pack/unpack. For a running container the path points through
+/// `/proc/self/fd/<n>`, where the held handle is the container's
+/// mount-namespace root captured at resolve time — see [`GuestServer::container_rootfs`].
+struct ContainerPath {
+    path: PathBuf,
+    _root_pin: Option<std::fs::File>,
 }

--- a/src/guest/src/service/files.rs
+++ b/src/guest/src/service/files.rs
@@ -226,9 +226,6 @@ impl GuestServer {
 
     #[allow(clippy::result_large_err)]
     fn container_rootfs(&self, container_id: &str, path: &str) -> Result<PathBuf, Status> {
-        let guest_layout = self.layout.shared().container(container_id);
-        let rootfs = guest_layout.rootfs_dir();
-
         let path_obj = Path::new(path);
         if path_obj
             .components()
@@ -243,6 +240,36 @@ impl GuestServer {
             path_obj.to_path_buf()
         };
 
+        // For a running container, resolve through its live mount namespace via
+        // `/proc/<init_pid>/root` so paths under runtime mounts (e.g. the tmpfs
+        // at /tmp, /run, /dev/shm) reach what the container actually sees —
+        // matching `docker cp`. Touching the on-disk rootfs dir instead lands
+        // *beneath* those mounts: invisible to the container, or rejected. When
+        // the container isn't running there are no such mounts, so fall back to
+        // the on-disk rootfs (offline copy to a stopped box).
+        if let Some(pid) = self.container_init_pid(container_id) {
+            return Ok(PathBuf::from(format!("/proc/{pid}/root")).join(&rel));
+        }
+
+        let rootfs = self.layout.shared().container(container_id).rootfs_dir();
         Ok(rootfs.join(rel))
+    }
+
+    /// PID of the container's init process when it is running, used to resolve
+    /// copy paths through its live mount namespace (`/proc/<pid>/root`).
+    /// `None` if the container isn't running or its libcontainer state can't be
+    /// read — callers then fall back to the on-disk rootfs.
+    fn container_init_pid(&self, container_id: &str) -> Option<i32> {
+        use libcontainer::container::{Container as LibContainer, ContainerStatus};
+        let state_path = self
+            .layout
+            .container_state_dir(container_id)
+            .join(container_id);
+        let container = LibContainer::load(state_path).ok()?;
+        if matches!(container.status(), ContainerStatus::Running) {
+            container.pid().map(|p| p.as_raw())
+        } else {
+            None
+        }
     }
 }


### PR DESCRIPTION
Adds live box secret updates through the REST API, runner v0/v2, and gvproxy admin socket.

Test plan:
- `go test ./...` in `src/deps/libgvproxy-sys/gvproxy-bridge`
- `BOXLITE_DEPS_STUB=1 cargo build -p boxlite-c`
- `go test -tags boxlite_dev ./pkg/api/dto ./pkg/api/controllers ./pkg/backend ./pkg/boxlite ./pkg/runner/v2/executor` in `apps/runner`
- `BOXLITE_DEPS_STUB=1 cargo test -p boxlite --lib net::gvproxy::config` (compiles; test filter currently reports 0 matched)

Note: `npx nx build api --configuration=development --skip-nx-cache` was not run because `apps/` has no installed Nx modules/node_modules in this checkout.