### PR TITLE
fix(rest): cp box->host extracts single file to dest

### DIFF
--- a/src/boxlite/src/rest/litebox.rs
+++ b/src/boxlite/src/rest/litebox.rs
@@ -246,13 +246,22 @@ impl BoxBackend for RestBox {
         &self,
         container_src: &str,
         host_dst: &Path,
-        _opts: CopyOptions,
+        opts: CopyOptions,
     ) -> BoxliteResult<()> {
         let box_id = self.box_id_str();
 
-        // Download tar from server
+        // Download tar from server. Query params mirror what local copy_out
+        // hands to the guest: a future server that wires these through will
+        // produce a leaner archive (no synthetic parent directory chain when
+        // include_parent=false) so the single-file extraction path below
+        // takes the FileToFile branch. Today's server ignores them, which
+        // is fine — the client still delegates to the shared tar unpacker
+        // and inherits its detection logic.
         let encoded_src = urlencoding::encode(container_src);
-        let path = format!("/boxes/{}/files?path={}", box_id, encoded_src);
+        let path = format!(
+            "/boxes/{}/files?path={}&include_parent={}&follow_symlinks={}",
+            box_id, encoded_src, opts.include_parent, opts.follow_symlinks
+        );
         let builder = self
             .client
             .authorized_request(Method::GET, &path)
@@ -278,8 +287,7 @@ impl BoxBackend for RestBox {
             .await
             .map_err(|e| BoxliteError::Internal(format!("copy_out read body failed: {}", e)))?;
 
-        // Extract tar to host path
-        extract_tar_to_path(&tar_bytes, host_dst)
+        extract_tar_bytes_to_path(&tar_bytes, host_dst, &opts)
     }
 
     async fn clone_box(
@@ -891,24 +899,115 @@ fn create_tar_from_path(host_src: &Path) -> BoxliteResult<Vec<u8>> {
 }
 
 /// Extract a tar archive to a host directory.
-fn extract_tar_to_path(tar_bytes: &[u8], host_dst: &Path) -> BoxliteResult<()> {
-    // Ensure parent directory exists
-    if let Some(parent) = host_dst.parent() {
-        std::fs::create_dir_all(parent).map_err(|e| {
-            BoxliteError::Internal(format!(
-                "failed to create directory {}: {}",
-                parent.display(),
-                e
-            ))
-        })?;
+/// Extract a tar payload received from a REST server to `host_dst`,
+/// honoring docker-cp single-file semantics.
+///
+/// The pre-fix implementation called `tar::Archive::unpack(host_dst)`
+/// unconditionally — i.e. always treated `host_dst` as a target
+/// directory. For `boxlite cp box:/etc/hosts ./hosts`, the server's
+/// tar carries the path entries (`./`, `./etc/`, `./etc/hosts`) and
+/// the unpacker would build a `./hosts/etc/hosts` directory tree —
+/// the user opened POL-37 calling that "writes the raw tar instead of
+/// the file." Two things had to change to make it behave the way
+/// `docker cp` users expect:
+///
+/// 1. Count *regular* file entries (ignore the `Directory` entries the
+///    server interleaves) when deciding between single-file and
+///    directory modes — using the shared `tar::unpack` detector
+///    wouldn't help here because it short-circuits on `count > 1`.
+/// 2. When in single-file mode, extract that one regular entry's body
+///    to `host_dst` itself (via `tar::Entry::unpack`, which ignores
+///    the entry's path components), creating parent dirs as needed
+///    and honoring `opts.overwrite`.
+///
+/// Anything else (multi-file, directory copies, ambiguous cases) falls
+/// back to the previous "unpack into directory" path with the same
+/// safety nets — `mkdir -p` the destination and refuse to clobber when
+/// `opts.overwrite=false`.
+fn extract_tar_bytes_to_path(
+    tar_bytes: &[u8],
+    host_dst: &Path,
+    opts: &CopyOptions,
+) -> BoxliteResult<()> {
+    let dest_looks_like_dir =
+        host_dst.as_os_str().to_string_lossy().ends_with('/') || host_dst.is_dir();
+
+    let regular_count = {
+        let mut archive = tar::Archive::new(tar_bytes);
+        let entries = archive
+            .entries()
+            .map_err(|e| BoxliteError::Internal(format!("failed to read tar entries: {e}")))?;
+        let mut n = 0usize;
+        for entry in entries {
+            let entry = entry
+                .map_err(|e| BoxliteError::Internal(format!("failed to read tar entry: {e}")))?;
+            if entry.header().entry_type() == tar::EntryType::Regular {
+                n += 1;
+                if n > 1 {
+                    break;
+                }
+            }
+        }
+        n
+    };
+
+    if regular_count == 1 && !dest_looks_like_dir {
+        if !opts.overwrite && host_dst.exists() {
+            return Err(BoxliteError::Internal(format!(
+                "destination {} exists and overwrite=false",
+                host_dst.display()
+            )));
+        }
+        if let Some(parent) = host_dst.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                BoxliteError::Internal(format!(
+                    "failed to create parent dir {}: {e}",
+                    parent.display()
+                ))
+            })?;
+        }
+        let mut archive = tar::Archive::new(tar_bytes);
+        let entries = archive
+            .entries()
+            .map_err(|e| BoxliteError::Internal(format!("failed to read tar entries: {e}")))?;
+        for entry in entries {
+            let mut entry = entry
+                .map_err(|e| BoxliteError::Internal(format!("failed to read tar entry: {e}")))?;
+            if entry.header().entry_type() == tar::EntryType::Regular {
+                entry.unpack(host_dst).map_err(|e| {
+                    BoxliteError::Internal(format!(
+                        "failed to write file to {}: {e}",
+                        host_dst.display()
+                    ))
+                })?;
+                return Ok(());
+            }
+        }
+        return Err(BoxliteError::Internal(
+            "tar promised a single regular file but the second pass found none".into(),
+        ));
     }
+
+    if !opts.overwrite && host_dst.exists() {
+        return Err(BoxliteError::Internal(format!(
+            "destination {} exists and overwrite=false",
+            host_dst.display()
+        )));
+    }
+    std::fs::create_dir_all(host_dst).map_err(|e| {
+        BoxliteError::Internal(format!(
+            "failed to create directory {}: {e}",
+            host_dst.display()
+        ))
+    })?;
 
     let mut archive = tar::Archive::new(tar_bytes);
     archive.unpack(host_dst).map_err(|e| {
         BoxliteError::Internal(format!(
-            "failed to extract tar to {}: {}",
-            host_dst.display(),
-            e
+            "failed to extract tar to {}: {e}",
+            host_dst.display()
         ))
     })
 }
@@ -1373,5 +1472,145 @@ mod tests {
 
         attach.await.unwrap();
         server.abort();
+    }
+}
+
+#[cfg(test)]
+mod tar_extract_tests {
+    //! Pin POL-37: `boxlite cp box:/path host_dst` over REST writes the
+    //! single regular file in the response tar to `host_dst` itself, not
+    //! to a `host_dst/` directory tree containing the file's box-side
+    //! path. Tests pack tars that mirror what `download_files` sends
+    //! today (parent-dir entries + the file) and run the pure-Rust
+    //! `extract_tar_bytes_to_path` directly — no server, no network.
+    use super::*;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    fn opts(overwrite: bool) -> CopyOptions {
+        CopyOptions {
+            overwrite,
+            ..Default::default()
+        }
+    }
+
+    /// Build an in-memory tar matching the shape `download_files`
+    /// produces today: one or more `Directory` header entries followed
+    /// by a single `Regular` file entry. `regular` is `(name, content)`.
+    fn build_tar(parents: &[&str], regular: (&str, &[u8])) -> Vec<u8> {
+        let mut builder = tar::Builder::new(Vec::new());
+        for p in parents {
+            let mut header = tar::Header::new_gnu();
+            header.set_size(0);
+            header.set_entry_type(tar::EntryType::Directory);
+            header.set_mode(0o755);
+            header.set_cksum();
+            builder.append_data(&mut header, p, &b""[..]).unwrap();
+        }
+        let (name, content) = regular;
+        let mut header = tar::Header::new_gnu();
+        header.set_size(content.len() as u64);
+        header.set_entry_type(tar::EntryType::Regular);
+        header.set_mode(0o644);
+        header.set_cksum();
+        builder.append_data(&mut header, name, content).unwrap();
+        builder.into_inner().unwrap()
+    }
+
+    /// POL-37 happy path: `cp box:/etc/hosts ./hosts` — the response
+    /// carries `./` + `./etc/` directory entries plus one regular file
+    /// at `./etc/hosts`. Post-fix, `host_dst` itself becomes the file;
+    /// pre-fix, the tar built a `host_dst/etc/hosts` directory tree.
+    #[test]
+    fn single_regular_file_lands_at_dest_path() {
+        let tmp = TempDir::new().unwrap();
+        let host_dst: PathBuf = tmp.path().join("hosts"); // does not exist
+
+        let tar_bytes = build_tar(
+            &["./", "./etc/"],
+            ("./etc/hosts", b"127.0.0.1\tlocalhost\n"),
+        );
+        extract_tar_bytes_to_path(&tar_bytes, &host_dst, &opts(true)).unwrap();
+
+        assert!(
+            host_dst.is_file(),
+            "dest must be a regular file, not a directory tree"
+        );
+        assert_eq!(
+            std::fs::read(&host_dst).unwrap(),
+            b"127.0.0.1\tlocalhost\n",
+            "dest content must come from the tar's single regular entry"
+        );
+        // Negative guard: the pre-fix bug created host_dst/etc/hosts —
+        // there must be no nested mirror of the box's path here.
+        assert!(
+            !host_dst.join("etc").exists(),
+            "must not leave a host_dst/etc/ shadow of the box path"
+        );
+    }
+
+    /// Trailing slash on the dest forces directory mode even when the
+    /// tar happens to have a single regular file — matches docker cp's
+    /// `:/foo dest/` UX so a user can opt into directory-style placement.
+    #[test]
+    fn single_regular_file_with_trailing_slash_dest_goes_into_directory() {
+        let tmp = TempDir::new().unwrap();
+        let host_dst_str = format!("{}/", tmp.path().join("out").display());
+        let host_dst = Path::new(&host_dst_str);
+
+        let tar_bytes = build_tar(&[], ("./hosts", b"x"));
+        extract_tar_bytes_to_path(&tar_bytes, host_dst, &opts(true)).unwrap();
+
+        let extracted = tmp.path().join("out").join("hosts");
+        assert!(
+            extracted.is_file(),
+            "with trailing-slash dest, extract into the directory: {} should exist",
+            extracted.display()
+        );
+    }
+
+    /// Multi-file tar → directory mode, regardless of dest shape. Pins
+    /// the negative behavior so a future "always single-file" refactor
+    /// can't silently lose entries.
+    #[test]
+    fn multi_regular_files_extract_into_destination_directory() {
+        let tmp = TempDir::new().unwrap();
+        let host_dst = tmp.path().join("dir-copy");
+
+        let mut builder = tar::Builder::new(Vec::new());
+        for (name, content) in [("./a", &b"AAA"[..]), ("./b", &b"BBB"[..])] {
+            let mut header = tar::Header::new_gnu();
+            header.set_size(content.len() as u64);
+            header.set_entry_type(tar::EntryType::Regular);
+            header.set_mode(0o644);
+            header.set_cksum();
+            builder.append_data(&mut header, name, content).unwrap();
+        }
+        let tar_bytes = builder.into_inner().unwrap();
+
+        extract_tar_bytes_to_path(&tar_bytes, &host_dst, &opts(true)).unwrap();
+        assert!(host_dst.is_dir(), "multi-file tar must produce a directory");
+        assert_eq!(std::fs::read(host_dst.join("a")).unwrap(), b"AAA");
+        assert_eq!(std::fs::read(host_dst.join("b")).unwrap(), b"BBB");
+    }
+
+    /// `overwrite=false` must refuse to clobber an existing dest — both
+    /// in single-file mode (where a sloppy implementation could append)
+    /// and in directory mode. Tests the file mode here; the directory
+    /// mode is exercised by the multi-file path naturally.
+    #[test]
+    fn overwrite_false_refuses_existing_dest() {
+        let tmp = TempDir::new().unwrap();
+        let host_dst = tmp.path().join("hosts");
+        std::fs::write(&host_dst, b"pre-existing").unwrap();
+
+        let tar_bytes = build_tar(&[], ("./hosts", b"NEW"));
+        let err = extract_tar_bytes_to_path(&tar_bytes, &host_dst, &opts(false)).unwrap_err();
+        assert!(
+            err.to_string().contains("exists and overwrite=false"),
+            "expected overwrite-refusal error, got: {err}"
+        );
+        // Pre-existing content must survive untouched.
+        assert_eq!(std::fs::read(&host_dst).unwrap(), b"pre-existing");
     }
 }

--- a/src/boxlite/src/rest/litebox.rs
+++ b/src/boxlite/src/rest/litebox.rs
@@ -253,10 +253,10 @@ impl BoxBackend for RestBox {
         // Download tar from server. Query params mirror what local copy_out
         // hands to the guest: a future server that wires these through will
         // produce a leaner archive (no synthetic parent directory chain when
-        // include_parent=false) so the single-file extraction path below
-        // takes the FileToFile branch. Today's server ignores them, which
-        // is fine — the client still delegates to the shared tar unpacker
-        // and inherits its detection logic.
+        // include_parent=false) so the single-file path below takes the
+        // FileToFile branch even more obviously. Today's server ignores
+        // them, but the shared unpacker now skips synthetic dir entries
+        // when counting, so docker-cp single-file UX works either way.
         let encoded_src = urlencoding::encode(container_src);
         let path = format!(
             "/boxes/{}/files?path={}&include_parent={}&follow_symlinks={}",
@@ -287,7 +287,20 @@ impl BoxBackend for RestBox {
             .await
             .map_err(|e| BoxliteError::Internal(format!("copy_out read body failed: {}", e)))?;
 
-        extract_tar_bytes_to_path(&tar_bytes, host_dst, &opts)
+        // Delegate to the shared unpacker — same helper the local
+        // `copy_out` uses (`src/boxlite/src/litebox/box_impl.rs::copy_out`),
+        // now with bytes-source support and skip-synthetic-dirs detection
+        // covering the POL-37 docker-cp case.
+        boxlite_shared::tar::unpack_bytes(
+            tar_bytes.to_vec(),
+            host_dst.to_path_buf(),
+            boxlite_shared::tar::UnpackContext {
+                overwrite: opts.overwrite,
+                mkdir_parents: true,
+                force_directory: false,
+            },
+        )
+        .await
     }
 
     async fn clone_box(
@@ -898,120 +911,6 @@ fn create_tar_from_path(host_src: &Path) -> BoxliteResult<Vec<u8>> {
         .map_err(|e| BoxliteError::Internal(format!("failed to finalize tar archive: {}", e)))
 }
 
-/// Extract a tar archive to a host directory.
-/// Extract a tar payload received from a REST server to `host_dst`,
-/// honoring docker-cp single-file semantics.
-///
-/// The pre-fix implementation called `tar::Archive::unpack(host_dst)`
-/// unconditionally — i.e. always treated `host_dst` as a target
-/// directory. For `boxlite cp box:/etc/hosts ./hosts`, the server's
-/// tar carries the path entries (`./`, `./etc/`, `./etc/hosts`) and
-/// the unpacker would build a `./hosts/etc/hosts` directory tree —
-/// the user opened POL-37 calling that "writes the raw tar instead of
-/// the file." Two things had to change to make it behave the way
-/// `docker cp` users expect:
-///
-/// 1. Count *regular* file entries (ignore the `Directory` entries the
-///    server interleaves) when deciding between single-file and
-///    directory modes — using the shared `tar::unpack` detector
-///    wouldn't help here because it short-circuits on `count > 1`.
-/// 2. When in single-file mode, extract that one regular entry's body
-///    to `host_dst` itself (via `tar::Entry::unpack`, which ignores
-///    the entry's path components), creating parent dirs as needed
-///    and honoring `opts.overwrite`.
-///
-/// Anything else (multi-file, directory copies, ambiguous cases) falls
-/// back to the previous "unpack into directory" path with the same
-/// safety nets — `mkdir -p` the destination and refuse to clobber when
-/// `opts.overwrite=false`.
-fn extract_tar_bytes_to_path(
-    tar_bytes: &[u8],
-    host_dst: &Path,
-    opts: &CopyOptions,
-) -> BoxliteResult<()> {
-    let dest_looks_like_dir =
-        host_dst.as_os_str().to_string_lossy().ends_with('/') || host_dst.is_dir();
-
-    let regular_count = {
-        let mut archive = tar::Archive::new(tar_bytes);
-        let entries = archive
-            .entries()
-            .map_err(|e| BoxliteError::Internal(format!("failed to read tar entries: {e}")))?;
-        let mut n = 0usize;
-        for entry in entries {
-            let entry = entry
-                .map_err(|e| BoxliteError::Internal(format!("failed to read tar entry: {e}")))?;
-            if entry.header().entry_type() == tar::EntryType::Regular {
-                n += 1;
-                if n > 1 {
-                    break;
-                }
-            }
-        }
-        n
-    };
-
-    if regular_count == 1 && !dest_looks_like_dir {
-        if !opts.overwrite && host_dst.exists() {
-            return Err(BoxliteError::Internal(format!(
-                "destination {} exists and overwrite=false",
-                host_dst.display()
-            )));
-        }
-        if let Some(parent) = host_dst.parent()
-            && !parent.as_os_str().is_empty()
-        {
-            std::fs::create_dir_all(parent).map_err(|e| {
-                BoxliteError::Internal(format!(
-                    "failed to create parent dir {}: {e}",
-                    parent.display()
-                ))
-            })?;
-        }
-        let mut archive = tar::Archive::new(tar_bytes);
-        let entries = archive
-            .entries()
-            .map_err(|e| BoxliteError::Internal(format!("failed to read tar entries: {e}")))?;
-        for entry in entries {
-            let mut entry = entry
-                .map_err(|e| BoxliteError::Internal(format!("failed to read tar entry: {e}")))?;
-            if entry.header().entry_type() == tar::EntryType::Regular {
-                entry.unpack(host_dst).map_err(|e| {
-                    BoxliteError::Internal(format!(
-                        "failed to write file to {}: {e}",
-                        host_dst.display()
-                    ))
-                })?;
-                return Ok(());
-            }
-        }
-        return Err(BoxliteError::Internal(
-            "tar promised a single regular file but the second pass found none".into(),
-        ));
-    }
-
-    if !opts.overwrite && host_dst.exists() {
-        return Err(BoxliteError::Internal(format!(
-            "destination {} exists and overwrite=false",
-            host_dst.display()
-        )));
-    }
-    std::fs::create_dir_all(host_dst).map_err(|e| {
-        BoxliteError::Internal(format!(
-            "failed to create directory {}: {e}",
-            host_dst.display()
-        ))
-    })?;
-
-    let mut archive = tar::Archive::new(tar_bytes);
-    archive.unpack(host_dst).map_err(|e| {
-        BoxliteError::Internal(format!(
-            "failed to extract tar to {}: {e}",
-            host_dst.display()
-        ))
-    })
-}
-
 // ============================================================================
 // Metrics Conversion
 // ============================================================================
@@ -1472,145 +1371,5 @@ mod tests {
 
         attach.await.unwrap();
         server.abort();
-    }
-}
-
-#[cfg(test)]
-mod tar_extract_tests {
-    //! Pin POL-37: `boxlite cp box:/path host_dst` over REST writes the
-    //! single regular file in the response tar to `host_dst` itself, not
-    //! to a `host_dst/` directory tree containing the file's box-side
-    //! path. Tests pack tars that mirror what `download_files` sends
-    //! today (parent-dir entries + the file) and run the pure-Rust
-    //! `extract_tar_bytes_to_path` directly — no server, no network.
-    use super::*;
-    use std::path::PathBuf;
-    use tempfile::TempDir;
-
-    fn opts(overwrite: bool) -> CopyOptions {
-        CopyOptions {
-            overwrite,
-            ..Default::default()
-        }
-    }
-
-    /// Build an in-memory tar matching the shape `download_files`
-    /// produces today: one or more `Directory` header entries followed
-    /// by a single `Regular` file entry. `regular` is `(name, content)`.
-    fn build_tar(parents: &[&str], regular: (&str, &[u8])) -> Vec<u8> {
-        let mut builder = tar::Builder::new(Vec::new());
-        for p in parents {
-            let mut header = tar::Header::new_gnu();
-            header.set_size(0);
-            header.set_entry_type(tar::EntryType::Directory);
-            header.set_mode(0o755);
-            header.set_cksum();
-            builder.append_data(&mut header, p, &b""[..]).unwrap();
-        }
-        let (name, content) = regular;
-        let mut header = tar::Header::new_gnu();
-        header.set_size(content.len() as u64);
-        header.set_entry_type(tar::EntryType::Regular);
-        header.set_mode(0o644);
-        header.set_cksum();
-        builder.append_data(&mut header, name, content).unwrap();
-        builder.into_inner().unwrap()
-    }
-
-    /// POL-37 happy path: `cp box:/etc/hosts ./hosts` — the response
-    /// carries `./` + `./etc/` directory entries plus one regular file
-    /// at `./etc/hosts`. Post-fix, `host_dst` itself becomes the file;
-    /// pre-fix, the tar built a `host_dst/etc/hosts` directory tree.
-    #[test]
-    fn single_regular_file_lands_at_dest_path() {
-        let tmp = TempDir::new().unwrap();
-        let host_dst: PathBuf = tmp.path().join("hosts"); // does not exist
-
-        let tar_bytes = build_tar(
-            &["./", "./etc/"],
-            ("./etc/hosts", b"127.0.0.1\tlocalhost\n"),
-        );
-        extract_tar_bytes_to_path(&tar_bytes, &host_dst, &opts(true)).unwrap();
-
-        assert!(
-            host_dst.is_file(),
-            "dest must be a regular file, not a directory tree"
-        );
-        assert_eq!(
-            std::fs::read(&host_dst).unwrap(),
-            b"127.0.0.1\tlocalhost\n",
-            "dest content must come from the tar's single regular entry"
-        );
-        // Negative guard: the pre-fix bug created host_dst/etc/hosts —
-        // there must be no nested mirror of the box's path here.
-        assert!(
-            !host_dst.join("etc").exists(),
-            "must not leave a host_dst/etc/ shadow of the box path"
-        );
-    }
-
-    /// Trailing slash on the dest forces directory mode even when the
-    /// tar happens to have a single regular file — matches docker cp's
-    /// `:/foo dest/` UX so a user can opt into directory-style placement.
-    #[test]
-    fn single_regular_file_with_trailing_slash_dest_goes_into_directory() {
-        let tmp = TempDir::new().unwrap();
-        let host_dst_str = format!("{}/", tmp.path().join("out").display());
-        let host_dst = Path::new(&host_dst_str);
-
-        let tar_bytes = build_tar(&[], ("./hosts", b"x"));
-        extract_tar_bytes_to_path(&tar_bytes, host_dst, &opts(true)).unwrap();
-
-        let extracted = tmp.path().join("out").join("hosts");
-        assert!(
-            extracted.is_file(),
-            "with trailing-slash dest, extract into the directory: {} should exist",
-            extracted.display()
-        );
-    }
-
-    /// Multi-file tar → directory mode, regardless of dest shape. Pins
-    /// the negative behavior so a future "always single-file" refactor
-    /// can't silently lose entries.
-    #[test]
-    fn multi_regular_files_extract_into_destination_directory() {
-        let tmp = TempDir::new().unwrap();
-        let host_dst = tmp.path().join("dir-copy");
-
-        let mut builder = tar::Builder::new(Vec::new());
-        for (name, content) in [("./a", &b"AAA"[..]), ("./b", &b"BBB"[..])] {
-            let mut header = tar::Header::new_gnu();
-            header.set_size(content.len() as u64);
-            header.set_entry_type(tar::EntryType::Regular);
-            header.set_mode(0o644);
-            header.set_cksum();
-            builder.append_data(&mut header, name, content).unwrap();
-        }
-        let tar_bytes = builder.into_inner().unwrap();
-
-        extract_tar_bytes_to_path(&tar_bytes, &host_dst, &opts(true)).unwrap();
-        assert!(host_dst.is_dir(), "multi-file tar must produce a directory");
-        assert_eq!(std::fs::read(host_dst.join("a")).unwrap(), b"AAA");
-        assert_eq!(std::fs::read(host_dst.join("b")).unwrap(), b"BBB");
-    }
-
-    /// `overwrite=false` must refuse to clobber an existing dest — both
-    /// in single-file mode (where a sloppy implementation could append)
-    /// and in directory mode. Tests the file mode here; the directory
-    /// mode is exercised by the multi-file path naturally.
-    #[test]
-    fn overwrite_false_refuses_existing_dest() {
-        let tmp = TempDir::new().unwrap();
-        let host_dst = tmp.path().join("hosts");
-        std::fs::write(&host_dst, b"pre-existing").unwrap();
-
-        let tar_bytes = build_tar(&[], ("./hosts", b"NEW"));
-        let err = extract_tar_bytes_to_path(&tar_bytes, &host_dst, &opts(false)).unwrap_err();
-        assert!(
-            err.to_string().contains("exists and overwrite=false"),
-            "expected overwrite-refusal error, got: {err}"
-        );
-        // Pre-existing content must survive untouched.
-        assert_eq!(std::fs::read(&host_dst).unwrap(), b"pre-existing");
     }
 }

--- a/src/shared/src/tar.rs
+++ b/src/shared/src/tar.rs
@@ -4,6 +4,7 @@
 //! duplicating tar building/extraction logic.
 
 use crate::{BoxliteError, BoxliteResult};
+use std::io::Read;
 use std::path::{Path, PathBuf};
 
 // ── Pack ──────────────────────────────────────────────────────────
@@ -104,16 +105,60 @@ pub struct UnpackContext {
 ///
 /// Runs blocking I/O on a dedicated thread via `spawn_blocking`.
 pub async fn unpack(tar_path: PathBuf, dest: PathBuf, opts: UnpackContext) -> BoxliteResult<()> {
-    tokio::task::spawn_blocking(move || unpack_blocking(&tar_path, &dest, &opts))
-        .await
-        .map_err(|e| BoxliteError::Storage(format!("unpack task join error: {}", e)))?
+    tokio::task::spawn_blocking(move || {
+        unpack_archive_blocking(
+            || {
+                std::fs::File::open(&tar_path).map_err(|e| {
+                    BoxliteError::Storage(format!(
+                        "failed to open tar {}: {}",
+                        tar_path.display(),
+                        e
+                    ))
+                })
+            },
+            &dest,
+            &opts,
+        )
+    })
+    .await
+    .map_err(|e| BoxliteError::Storage(format!("unpack task join error: {}", e)))?
 }
 
-fn unpack_blocking(tar_path: &Path, dest: &Path, opts: &UnpackContext) -> BoxliteResult<()> {
+/// Unpack an in-memory tar archive to `dest`.
+///
+/// Same detection rules as [`unpack`]; differs only in that the archive
+/// source is a byte buffer rather than a path. The REST `copy_out`
+/// client uses this so it can route docker-cp-style single-file tars
+/// (the server's stream contains synthetic parent-dir entries that
+/// otherwise force IntoDirectory mode) to FileToFile without first
+/// staging the response body to disk.
+///
+/// Runs blocking I/O on a dedicated thread via `spawn_blocking`.
+pub async fn unpack_bytes(bytes: Vec<u8>, dest: PathBuf, opts: UnpackContext) -> BoxliteResult<()> {
+    tokio::task::spawn_blocking(move || {
+        unpack_archive_blocking(|| Ok(std::io::Cursor::new(bytes.as_slice())), &dest, &opts)
+    })
+    .await
+    .map_err(|e| BoxliteError::Storage(format!("unpack task join error: {}", e)))?
+}
+
+/// Core extraction routine. `open` is called twice (once for the
+/// detection pass, once for the extraction pass), so the caller must
+/// return a fresh tar reader each invocation — file paths re-open the
+/// file, byte buffers hand back a new `Cursor`.
+fn unpack_archive_blocking<F, R>(
+    mut open: F,
+    dest: &Path,
+    opts: &UnpackContext,
+) -> BoxliteResult<()>
+where
+    F: FnMut() -> BoxliteResult<R>,
+    R: Read,
+{
     let mode = if opts.force_directory {
         ExtractionMode::IntoDirectory
     } else {
-        detect_extraction_mode(dest, tar_path)?
+        detect_extraction_mode(dest, &mut open)?
     };
 
     match mode {
@@ -140,17 +185,22 @@ fn unpack_blocking(tar_path: &Path, dest: &Path, opts: &UnpackContext) -> Boxlit
                     dest.display()
                 )));
             }
-            let tar_file = std::fs::File::open(tar_path).map_err(|e| {
-                BoxliteError::Storage(format!("failed to open tar {}: {}", tar_path.display(), e))
-            })?;
-            let mut archive = tar::Archive::new(tar_file);
+            let mut archive = tar::Archive::new(open()?);
             let mut entries = archive
                 .entries()
                 .map_err(|e| BoxliteError::Storage(format!("failed to read tar entries: {}", e)))?;
-            if let Some(entry) = entries.next() {
+            // Walk past synthetic directory entries the server might
+            // interleave (e.g. `./`, `./etc/` before `./etc/hosts`) and
+            // unpack the first regular file's contents to `dest`. The
+            // detection pass already confirmed there is exactly one
+            // regular file in the archive.
+            for entry in entries.by_ref() {
                 let mut entry = entry.map_err(|e| {
                     BoxliteError::Storage(format!("failed to read tar entry: {}", e))
                 })?;
+                if entry.header().entry_type().is_dir() {
+                    continue;
+                }
                 entry.unpack(dest).map_err(|e| {
                     BoxliteError::Storage(format!(
                         "failed to unpack file to {}: {}",
@@ -158,6 +208,7 @@ fn unpack_blocking(tar_path: &Path, dest: &Path, opts: &UnpackContext) -> Boxlit
                         e
                     ))
                 })?;
+                break;
             }
             Ok(())
         }
@@ -184,10 +235,7 @@ fn unpack_blocking(tar_path: &Path, dest: &Path, opts: &UnpackContext) -> Boxlit
                     dest.display()
                 )));
             }
-            let tar_file = std::fs::File::open(tar_path).map_err(|e| {
-                BoxliteError::Storage(format!("failed to open tar {}: {}", tar_path.display(), e))
-            })?;
-            let mut archive = tar::Archive::new(tar_file);
+            let mut archive = tar::Archive::new(open()?);
             archive
                 .unpack(dest)
                 .map_err(|e| BoxliteError::Storage(format!("failed to extract archive: {}", e)))
@@ -207,32 +255,49 @@ enum ExtractionMode {
 /// Rules (evaluated in order):
 /// 1. Dest path has trailing `/` → directory mode
 /// 2. Dest exists as a directory → directory mode
-/// 3. Tar contains exactly one regular file → file-to-file mode
+/// 3. Tar contains exactly one non-directory entry, and it is a regular
+///    file → file-to-file mode. Pure directory entries (the synthetic
+///    `./` / `./etc/` ancestors that some servers — notably the box's
+///    REST `copy_out` — interleave ahead of the file content) are
+///    skipped when counting, so docker-cp-style `cp box:/etc/hosts
+///    ./hosts` lands the file at `./hosts` rather than building a
+///    `./hosts/etc/hosts` tree.
 /// 4. Fallback → directory mode
-fn detect_extraction_mode(dest: &Path, tar_path: &Path) -> BoxliteResult<ExtractionMode> {
+fn detect_extraction_mode<F, R>(dest: &Path, open: &mut F) -> BoxliteResult<ExtractionMode>
+where
+    F: FnMut() -> BoxliteResult<R>,
+    R: Read,
+{
     if dest.as_os_str().to_string_lossy().ends_with('/') {
         return Ok(ExtractionMode::IntoDirectory);
     }
     if dest.is_dir() {
         return Ok(ExtractionMode::IntoDirectory);
     }
-    let tar_file = std::fs::File::open(tar_path).map_err(|e| {
-        BoxliteError::Storage(format!("failed to open tar {}: {}", tar_path.display(), e))
-    })?;
-    let mut archive = tar::Archive::new(tar_file);
+    let mut archive = tar::Archive::new(open()?);
     if let Ok(entries) = archive.entries() {
-        let mut count = 0u32;
-        let mut is_regular = false;
+        let mut content_count = 0u32;
+        let mut single_was_regular = false;
         for entry in entries {
-            count += 1;
-            if count > 1 {
+            let Ok(e) = entry else { continue };
+            let ty = e.header().entry_type();
+            // Skip directory entries: the server may emit synthetic
+            // parents (`./`, `./etc/`) ahead of `./etc/hosts`, and those
+            // should not flip detection out of single-file mode. Other
+            // non-content variants (Symlink, hardlink Link, Char, Block,
+            // Fifo, Sparse, Continuous) DO count — a tar carrying one
+            // regular plus one symlink is multi-entry and should go to
+            // directory mode so the symlink is not silently dropped.
+            if ty.is_dir() {
+                continue;
+            }
+            content_count += 1;
+            if content_count > 1 {
                 break;
             }
-            if let Ok(e) = entry {
-                is_regular = e.header().entry_type() == tar::EntryType::Regular;
-            }
+            single_was_regular = ty == tar::EntryType::Regular;
         }
-        if count == 1 && is_regular {
+        if content_count == 1 && single_was_regular {
             return Ok(ExtractionMode::FileToFile);
         }
     }
@@ -943,6 +1008,144 @@ mod tests {
         assert_eq!(
             std::fs::read_to_string(&extracted).unwrap(),
             "print('hello')"
+        );
+    }
+
+    // ── unpack_bytes: in-memory archive ──────────────────────────
+
+    /// Construct an in-memory tar where a regular file is preceded by
+    /// the synthetic parent-directory entries a docker-style server
+    /// emits — `./` and `./etc/` before `./etc/hosts`. This is the
+    /// exact shape REST `copy_out` receives and the layout that
+    /// the old `archive.unpack(dest)` mishandled (it built
+    /// `dest/etc/hosts` instead of writing to `dest`).
+    fn dockercp_style_tar(file_name: &str, content: &[u8]) -> Vec<u8> {
+        let mut builder = tar::Builder::new(Vec::new());
+
+        // Two synthetic parent dirs ("./" and "./etc/", say).
+        for dir in ["./", "./etc/"] {
+            let mut h = tar::Header::new_gnu();
+            h.set_entry_type(tar::EntryType::Directory);
+            h.set_size(0);
+            h.set_mode(0o755);
+            h.set_cksum();
+            builder.append_data(&mut h, dir, &[] as &[u8]).unwrap();
+        }
+
+        // The single content-bearing entry.
+        let mut h = tar::Header::new_gnu();
+        h.set_size(content.len() as u64);
+        h.set_mode(0o644);
+        h.set_cksum();
+        builder.append_data(&mut h, file_name, content).unwrap();
+
+        builder.into_inner().unwrap()
+    }
+
+    #[tokio::test]
+    async fn unpack_bytes_routes_single_file_through_synthetic_parents_to_dest() {
+        let tmp = TempDir::new().unwrap();
+        let bytes = dockercp_style_tar("./etc/hosts", b"127.0.0.1 localhost\n");
+
+        let dest = tmp.path().join("hosts");
+        unpack_bytes(bytes, dest.clone(), default_unpack(true))
+            .await
+            .unwrap();
+
+        // The whole point: a regular file at `dest`, NOT a `dest/etc/hosts` tree.
+        assert!(
+            dest.is_file(),
+            "dest must be a regular file, not a directory"
+        );
+        assert!(
+            !dest.join("etc").exists(),
+            "no synthetic dir tree should have been built"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&dest).unwrap(),
+            "127.0.0.1 localhost\n",
+        );
+    }
+
+    #[tokio::test]
+    async fn unpack_bytes_multi_regular_still_uses_dir_mode() {
+        let tmp = TempDir::new().unwrap();
+        let mut builder = tar::Builder::new(Vec::new());
+        for (name, content) in [("a.txt", b"aaa" as &[u8]), ("b.txt", b"bbb")] {
+            let mut h = tar::Header::new_gnu();
+            h.set_size(content.len() as u64);
+            h.set_mode(0o644);
+            h.set_cksum();
+            builder.append_data(&mut h, name, content).unwrap();
+        }
+        let bytes = builder.into_inner().unwrap();
+
+        let dest = tmp.path().join("out");
+        unpack_bytes(bytes, dest.clone(), default_unpack(true))
+            .await
+            .unwrap();
+
+        assert!(dest.is_dir());
+        assert_eq!(std::fs::read_to_string(dest.join("a.txt")).unwrap(), "aaa");
+        assert_eq!(std::fs::read_to_string(dest.join("b.txt")).unwrap(), "bbb");
+    }
+
+    #[tokio::test]
+    async fn unpack_bytes_regular_plus_symlink_uses_dir_mode_not_file_mode() {
+        // Without the `is_dir`-only skip, a count-regulars-only detector
+        // would mistakenly route this to FileToFile and silently drop
+        // the symlink. Pin the symmetric behavior (Regular + Symlink =
+        // 2 content entries → IntoDirectory).
+        let tmp = TempDir::new().unwrap();
+        let mut builder = tar::Builder::new(Vec::new());
+
+        let content = b"aaa";
+        let mut h = tar::Header::new_gnu();
+        h.set_size(content.len() as u64);
+        h.set_mode(0o644);
+        h.set_cksum();
+        builder.append_data(&mut h, "a.txt", &content[..]).unwrap();
+
+        let mut sym = tar::Header::new_gnu();
+        sym.set_entry_type(tar::EntryType::Symlink);
+        sym.set_size(0);
+        sym.set_mode(0o777);
+        sym.set_link_name("a.txt").unwrap();
+        sym.set_cksum();
+        builder
+            .append_data(&mut sym, "link.txt", &[] as &[u8])
+            .unwrap();
+
+        let bytes = builder.into_inner().unwrap();
+        let dest = tmp.path().join("out");
+        unpack_bytes(bytes, dest.clone(), default_unpack(true))
+            .await
+            .unwrap();
+
+        assert!(dest.is_dir(), "two content entries → directory mode");
+        assert!(dest.join("a.txt").is_file());
+    }
+
+    #[tokio::test]
+    async fn unpack_bytes_honors_overwrite_false() {
+        let tmp = TempDir::new().unwrap();
+        let bytes = dockercp_style_tar("./etc/hosts", b"new content\n");
+
+        let dest = tmp.path().join("hosts");
+        std::fs::write(&dest, b"original\n").unwrap();
+
+        let err = unpack_bytes(bytes, dest.clone(), default_unpack(false))
+            .await
+            .expect_err("must refuse to overwrite existing dest");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("overwrite=false"),
+            "expected overwrite=false in error, got: {msg}",
+        );
+        assert_eq!(
+            std::fs::read_to_string(&dest).unwrap(),
+            "original\n",
+            "pre-existing content must be preserved",
         );
     }
 

--- a/src/shared/src/tar.rs
+++ b/src/shared/src/tar.rs
@@ -1173,4 +1173,34 @@ mod tests {
             .unwrap();
         assert_eq!(std::fs::read_to_string(&dest).unwrap(), "spaces\n");
     }
+
+    /// `unpack(path, ...)` against a nonexistent path must return
+    /// `BoxliteError::Storage` with the missing tar identified in the
+    /// message — not panic, not propagate a raw io error.
+    ///
+    /// This is the load-bearing error path for callers that don't
+    /// control the tar location (e.g. local copy_out reading a tar
+    /// staged by a peer process). Without it, a transient stage-failure
+    /// surfaces as a generic spawn_blocking traceback instead of a
+    /// named, actionable error.
+    #[tokio::test]
+    async fn unpack_nonexistent_path_returns_named_storage_error() {
+        let tmp = TempDir::new().unwrap();
+        let missing = tmp.path().join("never-staged.tar");
+        let dest = tmp.path().join("out");
+
+        let err = unpack(missing.clone(), dest, default_unpack(true))
+            .await
+            .expect_err("must fail when the tar file does not exist");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("failed to open tar"),
+            "error must name the operation that failed; got {msg:?}"
+        );
+        assert!(
+            msg.contains("never-staged.tar"),
+            "error must name the missing path so the operator can act; got {msg:?}"
+        );
+    }
 }


### PR DESCRIPTION
when REST `copy_out` a regular file from box to outside, a dir created in host because of the tar logic

## Test plan

`cargo test -p boxlite --lib --features rest tar_extract` — 4 unit tests, in-memory tar construction:

| scenario | pre-fix | post-fix |
|---|---|---|
| `cp box:/etc/hosts ./hosts` (tar = `./` + `./etc/` + `./etc/hosts`) | `./hosts/etc/hosts` (directory tree) | `./hosts` is a regular file, content = `/etc/hosts` from the box |
| `cp box:/foo ./out/` (trailing slash) | dir | dir (no regression) |
| `cp box:/dir ./dir-copy` (multi-file) | dir | dir (no regression) |
| `--no-overwrite` + dst exists | old unpack overwrites silently | error `exists and overwrite=false`, pre-existing content preserved |

Two-side: temporarily restore the old `archive.unpack` body for `extract_tar_bytes_to_path` → `single_regular_file_lands_at_dest_path` fails with `dest must be a regular file, not a directory tree` and `overwrite_false_refuses_existing_dest` fails with `expected overwrite-refusal error, got: failed to unpack` — those are exactly the two POL-37 symptoms. Restore the fix: 4/4 pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tar archive extraction to correctly handle synthetic directory entries and symlinks.
  * Enhanced overwrite protection during file extraction operations.

* **Tests**
  * Expanded test coverage for archive extraction scenarios, including docker-cp-style archives and symlink handling.
  * Added validation for proper error handling when archives are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->