### PR TITLE
fix(cli): wait through transient lifecycle state errors (POL-34)

### DIFF
--- a/src/cli/src/commands/restart.rs
+++ b/src/cli/src/commands/restart.rs
@@ -23,7 +23,13 @@ pub async fn execute(args: RestartArgs, global: &crate::cli::GlobalFlags) -> any
             }
         };
 
-        if let Err(e) = litebox.stop().await {
+        // Wait through any in-flight stop / start before issuing our
+        // own (POL-34). Without this, `restart` issued during a slow
+        // shutdown would surface the transient InvalidState as a
+        // permanent failure.
+        let stop_res =
+            crate::util::retry::retry_on_transient_state(|| async { litebox.stop().await }).await;
+        if let Err(e) = stop_res {
             // If stop fails, we should NOT proceed to start, because resources might still be locked.
             eprintln!("Error restarting box '{}': {}", target, e);
             errors.push(format!("{}: {}", target, e));
@@ -41,7 +47,9 @@ pub async fn execute(args: RestartArgs, global: &crate::cli::GlobalFlags) -> any
             }
         };
 
-        if let Err(e) = litebox.start().await {
+        let start_res =
+            crate::util::retry::retry_on_transient_state(|| async { litebox.start().await }).await;
+        if let Err(e) = start_res {
             eprintln!("Error restarting box '{}': {}", target, e);
             errors.push(format!("{}: {}", target, e));
         } else {

--- a/src/cli/src/commands/start.rs
+++ b/src/cli/src/commands/start.rs
@@ -23,7 +23,13 @@ pub async fn execute(args: StartArgs, global: &crate::cli::GlobalFlags) -> anyho
             }
         };
 
-        if let Err(e) = litebox.start().await {
+        // Retry briefly if the box is mid-transition (e.g. still
+        // Stopping from a previous call) so a `start` issued right
+        // after `stop` doesn't hard-fail on the transient state
+        // (POL-34).
+        let start_res =
+            crate::util::retry::retry_on_transient_state(|| async { litebox.start().await }).await;
+        if let Err(e) = start_res {
             eprintln!("Error starting box '{}': {}", target, e);
             errors.push(format!("{}: {}", target, e));
         } else {

--- a/src/cli/src/commands/stop.rs
+++ b/src/cli/src/commands/stop.rs
@@ -24,7 +24,12 @@ pub async fn execute(args: StopArgs, global: &crate::cli::GlobalFlags) -> anyhow
             }
         };
 
-        if let Err(e) = litebox.stop().await {
+        // Retry briefly if the runtime is mid-transition — e.g. a prior
+        // `stop` is still draining — so a second user-initiated stop
+        // doesn't hard-fail on a transient state error (POL-34).
+        let stop_res =
+            crate::util::retry::retry_on_transient_state(|| async { litebox.stop().await }).await;
+        if let Err(e) = stop_res {
             eprintln!("Error stopping box '{}': {}", target, e);
             errors.push(format!("{}: {}", target, e));
         } else {

--- a/src/cli/src/util/mod.rs
+++ b/src/cli/src/util/mod.rs
@@ -1,5 +1,7 @@
 //! Utility functions shared across commands
 
+pub mod retry;
+
 /// Convert boxlite exit code to shell exit code.
 ///
 /// Boxlite encodes signal termination as negative values (e.g., -9 for SIGKILL).

--- a/src/cli/src/util/retry.rs
+++ b/src/cli/src/util/retry.rs
@@ -26,15 +26,21 @@ const MAX_BACKOFF_MS: u64 = 2_000;
 
 /// Returns true when the error message looks like a transient lifecycle
 /// state — the box is mid-transition and the same call will likely
-/// succeed once it settles. We deliberately key on string content
-/// because the server emits these messages via `BoxStatus::Display`
-/// and there is no dedicated `BoxliteError` variant today.
+/// succeed once it settles.
+///
+/// We key on string content because the server emits these messages
+/// via `BoxStatus::Display` and there is no dedicated `BoxliteError`
+/// variant today. The match list is intentionally narrow: of the
+/// `BoxStatus` variants in `src/boxlite/src/litebox/state.rs`, only
+/// `Stopping` is genuinely transient — `Running` is "already there",
+/// `Paused` is deliberate, `Failed` is permanent, `Configured` /
+/// `Stopped` are valid `start` targets. The single producer today is
+/// `box_impl.rs`'s `"Cannot start box in {} state"` (line 208), so the
+/// keyword set follows what that message can actually contain.
+/// Adding more keywords here without a corresponding producer would
+/// be dead matching — keep this in sync with real error text.
 fn is_transient_state(msg: &str) -> bool {
-    let m = msg.to_lowercase();
-    m.contains("stopping")
-        || m.contains("starting")
-        || m.contains("in progress")
-        || m.contains("transitioning")
+    msg.to_lowercase().contains("stopping")
 }
 
 fn budget() -> Duration {
@@ -213,5 +219,25 @@ mod tests {
         .await;
         assert!(matches!(result, Err(BoxliteError::NotFound(_))));
         assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
+
+    /// Pins the narrow `stopping`-only classifier: messages whose
+    /// keywords look transient but are not produced anywhere in
+    /// the runtime today must propagate, not retry. Without this,
+    /// the keyword list could silently grow back to "stopping /
+    /// starting / in progress / transitioning" and the helper would
+    /// happily burn the whole budget on dead-code matches.
+    #[test]
+    fn classifier_matches_only_stopping_today() {
+        assert!(is_transient_state("Cannot start box in stopping state"));
+        assert!(is_transient_state("STOPPING"));
+        // None of these are produced by `box_impl.rs` or any other
+        // `InvalidState` site in `src/boxlite`. They look plausible
+        // but would be dead matches.
+        assert!(!is_transient_state("Cannot start box in starting state"));
+        assert!(!is_transient_state("transition in progress"));
+        assert!(!is_transient_state("box is transitioning"));
+        assert!(!is_transient_state("Cannot start box in running state"));
+        assert!(!is_transient_state("Cannot start box in failed state"));
     }
 }

--- a/src/cli/src/util/retry.rs
+++ b/src/cli/src/util/retry.rs
@@ -7,12 +7,15 @@
 //! `starting` / `in progress` / `transitioning`) triggers the retry
 //! loop. Every other error — `NotFound`, `Unauthenticated`, generic
 //! `Internal` — propagates immediately so a real failure isn't masked
-//! by a 30-second wait.
+//! by a multi-second wait.
 //!
-//! The total wait budget is bounded (default 30 s, override with
+//! The total wait budget is bounded (default 10 s, override with
 //! `BOXLITE_TRANSIENT_RETRY_MS` for tests) and uses exponential backoff
 //! capped at 2 s so a long-running transition doesn't starve interactive
-//! CLI feedback.
+//! CLI feedback. 10 s comfortably covers a clean libkrun stop+restart
+//! (1-2 s each) plus host load slack; pathological hangs (shim deadlock,
+//! kernel stuck) won't unblock at 30 s either, so the longer default
+//! traded user-visible wait for no extra signal.
 
 use boxlite::{BoxliteError, BoxliteResult};
 use std::future::Future;
@@ -20,7 +23,7 @@ use std::time::{Duration, Instant};
 
 /// Default total time we'll spend waiting for a transient state to
 /// clear before giving up.
-const DEFAULT_BUDGET_MS: u64 = 30_000;
+const DEFAULT_BUDGET_MS: u64 = 10_000;
 const INITIAL_BACKOFF_MS: u64 = 200;
 const MAX_BACKOFF_MS: u64 = 2_000;
 

--- a/src/cli/src/util/retry.rs
+++ b/src/cli/src/util/retry.rs
@@ -1,0 +1,217 @@
+//! Retry an async lifecycle operation while the runtime reports a
+//! *transient* state — e.g. the box is `Stopping` so a follow-up
+//! `start` would otherwise hard-fail (POL-34).
+//!
+//! Scope is deliberately narrow: only `BoxliteError::InvalidState` with
+//! a message containing a transient-state keyword (`stopping` /
+//! `starting` / `in progress` / `transitioning`) triggers the retry
+//! loop. Every other error — `NotFound`, `Unauthenticated`, generic
+//! `Internal` — propagates immediately so a real failure isn't masked
+//! by a 30-second wait.
+//!
+//! The total wait budget is bounded (default 30 s, override with
+//! `BOXLITE_TRANSIENT_RETRY_MS` for tests) and uses exponential backoff
+//! capped at 2 s so a long-running transition doesn't starve interactive
+//! CLI feedback.
+
+use boxlite::{BoxliteError, BoxliteResult};
+use std::future::Future;
+use std::time::{Duration, Instant};
+
+/// Default total time we'll spend waiting for a transient state to
+/// clear before giving up.
+const DEFAULT_BUDGET_MS: u64 = 30_000;
+const INITIAL_BACKOFF_MS: u64 = 200;
+const MAX_BACKOFF_MS: u64 = 2_000;
+
+/// Returns true when the error message looks like a transient lifecycle
+/// state — the box is mid-transition and the same call will likely
+/// succeed once it settles. We deliberately key on string content
+/// because the server emits these messages via `BoxStatus::Display`
+/// and there is no dedicated `BoxliteError` variant today.
+fn is_transient_state(msg: &str) -> bool {
+    let m = msg.to_lowercase();
+    m.contains("stopping")
+        || m.contains("starting")
+        || m.contains("in progress")
+        || m.contains("transitioning")
+}
+
+fn budget() -> Duration {
+    let ms = std::env::var("BOXLITE_TRANSIENT_RETRY_MS")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(DEFAULT_BUDGET_MS);
+    Duration::from_millis(ms)
+}
+
+/// Run `op` and, if it returns `BoxliteError::InvalidState` with a
+/// transient-state message, sleep + retry until either it succeeds, a
+/// non-transient error surfaces, or the total wait budget elapses.
+/// Other errors propagate on the first attempt.
+pub async fn retry_on_transient_state<F, Fut, T>(op: F) -> BoxliteResult<T>
+where
+    F: Fn() -> Fut,
+    Fut: Future<Output = BoxliteResult<T>>,
+{
+    let total = budget();
+    let start = Instant::now();
+    let mut backoff = Duration::from_millis(INITIAL_BACKOFF_MS);
+    loop {
+        match op().await {
+            Ok(v) => return Ok(v),
+            Err(BoxliteError::InvalidState(msg)) if is_transient_state(&msg) => {
+                let elapsed = start.elapsed();
+                if elapsed + backoff > total {
+                    return Err(BoxliteError::InvalidState(format!(
+                        "{msg} (gave up after {}s of transient-state retries)",
+                        total.as_secs()
+                    )));
+                }
+                tokio::time::sleep(backoff).await;
+                backoff = (backoff * 2).min(Duration::from_millis(MAX_BACKOFF_MS));
+            }
+            Err(e) => return Err(e),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    /// Set `BOXLITE_TRANSIENT_RETRY_MS` for the duration of a test and
+    /// restore it on drop. Tests run sequentially in the same process,
+    /// so we hold a mutex across the whole test body.
+    struct BudgetGuard {
+        prev: Option<std::ffi::OsString>,
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    impl BudgetGuard {
+        fn new(ms: u64) -> Self {
+            let lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+            let prev = std::env::var_os("BOXLITE_TRANSIENT_RETRY_MS");
+            // SAFETY: mutex above serializes any env-var mutation in this module.
+            unsafe { std::env::set_var("BOXLITE_TRANSIENT_RETRY_MS", ms.to_string()) };
+            Self { prev, _lock: lock }
+        }
+    }
+    impl Drop for BudgetGuard {
+        fn drop(&mut self) {
+            unsafe {
+                match &self.prev {
+                    Some(v) => std::env::set_var("BOXLITE_TRANSIENT_RETRY_MS", v),
+                    None => std::env::remove_var("BOXLITE_TRANSIENT_RETRY_MS"),
+                }
+            }
+        }
+    }
+
+    /// A transient-state error eventually resolves: the closure fails
+    /// twice with "Cannot start box in stopping state" then succeeds,
+    /// and the helper returns the success without surfacing the
+    /// intermediate errors. Mirrors the POL-34 scenario where the user
+    /// hit `start` while the box was still finishing its previous
+    /// `stop`.
+    #[tokio::test]
+    async fn retries_through_transient_state_then_succeeds() {
+        let _g = BudgetGuard::new(5_000);
+        let attempts = Arc::new(AtomicU32::new(0));
+        let attempts_in = attempts.clone();
+        let result: BoxliteResult<&'static str> = retry_on_transient_state(|| {
+            let attempts = attempts_in.clone();
+            async move {
+                let n = attempts.fetch_add(1, Ordering::SeqCst);
+                if n < 2 {
+                    Err(BoxliteError::InvalidState(
+                        "Cannot start box in stopping state".into(),
+                    ))
+                } else {
+                    Ok("started")
+                }
+            }
+        })
+        .await;
+        assert_eq!(result.unwrap(), "started");
+        assert!(
+            attempts.load(Ordering::SeqCst) >= 3,
+            "must have retried at least twice before succeeding"
+        );
+    }
+
+    /// A persistent transient state hits the budget and gives up with
+    /// an InvalidState that names the timeout — so a script gets a
+    /// real failure signal instead of hanging.
+    #[tokio::test]
+    async fn gives_up_after_budget_elapses() {
+        let _g = BudgetGuard::new(400);
+        let attempts = Arc::new(AtomicU32::new(0));
+        let attempts_in = attempts.clone();
+        let result: BoxliteResult<()> = retry_on_transient_state(|| {
+            let attempts = attempts_in.clone();
+            async move {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                Err(BoxliteError::InvalidState(
+                    "Cannot stop box in stopping state".into(),
+                ))
+            }
+        })
+        .await;
+        match result {
+            Err(BoxliteError::InvalidState(msg)) => {
+                assert!(msg.contains("gave up"), "expected 'gave up' summary: {msg}");
+            }
+            other => panic!("expected InvalidState giving up, got {other:?}"),
+        }
+        assert!(attempts.load(Ordering::SeqCst) >= 1);
+    }
+
+    /// Non-transient InvalidState (e.g. "Cannot start box in failed state")
+    /// must propagate on the first attempt — the retry loop is for
+    /// in-flight transitions, not "wrong terminal state".
+    #[tokio::test]
+    async fn non_transient_invalid_state_propagates_immediately() {
+        let _g = BudgetGuard::new(60_000);
+        let attempts = Arc::new(AtomicU32::new(0));
+        let attempts_in = attempts.clone();
+        let result: BoxliteResult<()> = retry_on_transient_state(|| {
+            let attempts = attempts_in.clone();
+            async move {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                Err(BoxliteError::InvalidState(
+                    "Cannot remove box with live pid 123".into(),
+                ))
+            }
+        })
+        .await;
+        assert!(result.is_err(), "non-transient InvalidState must error");
+        assert_eq!(
+            attempts.load(Ordering::SeqCst),
+            1,
+            "must NOT retry a non-transient state error"
+        );
+    }
+
+    /// Any non-InvalidState error (NotFound, Internal, …) is a different
+    /// failure class — propagate immediately so retry logic can't mask
+    /// real bugs.
+    #[tokio::test]
+    async fn other_error_kinds_propagate_immediately() {
+        let _g = BudgetGuard::new(60_000);
+        let attempts = Arc::new(AtomicU32::new(0));
+        let attempts_in = attempts.clone();
+        let result: BoxliteResult<()> = retry_on_transient_state(|| {
+            let attempts = attempts_in.clone();
+            async move {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                Err(BoxliteError::NotFound("box ghost".into()))
+            }
+        })
+        .await;
+        assert!(matches!(result, Err(BoxliteError::NotFound(_))));
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
+}

--- a/src/cli/tests/transient_state_retry.rs
+++ b/src/cli/tests/transient_state_retry.rs
@@ -1,0 +1,238 @@
+//! POL-34 end-to-end: when the remote returns a transient-state
+//! `invalid_state` error for a lifecycle command (e.g. the box is
+//! still `Stopping` from a prior call), the CLI must wait and retry
+//! instead of surfacing the transient error to the user.
+
+use std::io::{BufRead, BufReader, Write};
+use std::net::TcpListener;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::Duration;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use tempfile::TempDir;
+
+struct Stub {
+    port: u16,
+}
+
+impl Stub {
+    fn start<H>(handler: H) -> Self
+    where
+        H: Fn(&str, &str) -> (u16, String) + Send + Sync + 'static,
+    {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+        let port = listener.local_addr().unwrap().port();
+        let handler = Arc::new(handler);
+        std::thread::spawn(move || {
+            for stream in listener.incoming() {
+                let Ok(mut stream) = stream else { continue };
+                let Ok(peek) = stream.try_clone() else {
+                    continue;
+                };
+                let mut reader = BufReader::new(peek);
+                let mut request_line = String::new();
+                if reader.read_line(&mut request_line).is_err() {
+                    continue;
+                }
+                loop {
+                    let mut line = String::new();
+                    match reader.read_line(&mut line) {
+                        Ok(0) => break,
+                        Ok(_) if line == "\r\n" || line == "\n" => break,
+                        Ok(_) => continue,
+                        Err(_) => break,
+                    }
+                }
+                let mut parts = request_line.split_whitespace();
+                let method = parts.next().unwrap_or("");
+                let raw_path = parts.next().unwrap_or("");
+                let path = raw_path.split('?').next().unwrap_or(raw_path);
+
+                let (status, body) = handler(method, path);
+                let reason = match status {
+                    200 => "OK",
+                    400 => "Bad Request",
+                    404 => "Not Found",
+                    409 => "Conflict",
+                    _ => "OK",
+                };
+                let _ = write!(
+                    stream,
+                    "HTTP/1.1 {status} {reason}\r\nContent-Type: application/json\r\n\
+                     Content-Length: {len}\r\nConnection: close\r\n\r\n{body}",
+                    len = body.len(),
+                );
+                let _ = stream.flush();
+            }
+        });
+        Self { port }
+    }
+
+    fn url(&self) -> String {
+        format!("http://127.0.0.1:{}", self.port)
+    }
+}
+
+fn cli(home: &TempDir) -> Command {
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("boxlite"));
+    cmd.env("BOXLITE_HOME", home.path())
+        .env_remove("BOXLITE_API_KEY")
+        .env_remove("BOXLITE_REST_URL")
+        .env_remove("BOXLITE_PROFILE")
+        .timeout(Duration::from_secs(30));
+    cmd
+}
+
+fn write_p1_creds(home: &TempDir, url: &str) {
+    let body = format!(
+        "[profiles.p1]\nurl = \"{url}\"\napi_key = \"k_test\"\nauth_method = \"api_key\"\n"
+    );
+    std::fs::write(home.path().join("credentials.toml"), body).unwrap();
+}
+
+const REAL_BOX_JSON: &str = r#"{
+  "box_id":"box_real",
+  "name":"real",
+  "image":"alpine",
+  "status":"Running",
+  "created_at":"2026-06-01T00:00:00Z",
+  "updated_at":"2026-06-01T00:00:00Z",
+  "cpus":1,
+  "memory_mib":256
+}"#;
+
+const STOPPED_BOX_JSON: &str = r#"{
+  "box_id":"box_real",
+  "name":"real",
+  "image":"alpine",
+  "status":"Stopped",
+  "created_at":"2026-06-01T00:00:00Z",
+  "updated_at":"2026-06-01T00:00:00Z",
+  "cpus":1,
+  "memory_mib":256
+}"#;
+
+const TRANSIENT_STATE_JSON: &str = r#"{"error":{"message":"Cannot start box in stopping state","type":"InvalidStateError","code":"invalid_state"}}"#;
+
+/// `start` while the server still reports a `stopping`-state error
+/// must succeed once the transient error stops firing. The stub
+/// returns 409/invalid_state with "stopping" message for the first
+/// two `POST /start` calls and then a 200 on the third — the CLI
+/// must wait through the first two and surface success.
+#[test]
+fn start_waits_through_transient_invalid_state() {
+    let attempts = Arc::new(AtomicU32::new(0));
+    let attempts_in = attempts.clone();
+    let stub = Stub::start(move |method, path| {
+        if method == "POST" && path.ends_with("/start") {
+            let n = attempts_in.fetch_add(1, Ordering::SeqCst);
+            if n < 2 {
+                (409, TRANSIENT_STATE_JSON.to_string())
+            } else {
+                (200, REAL_BOX_JSON.to_string())
+            }
+        } else if method == "GET" && path.starts_with("/v1/boxes/") {
+            (200, STOPPED_BOX_JSON.to_string())
+        } else {
+            (
+                404,
+                r#"{"error":{"message":"nope","type":"NotFoundError","code":"not_found"}}"#
+                    .to_string(),
+            )
+        }
+    });
+    let home = TempDir::new().unwrap();
+    write_p1_creds(&home, &stub.url());
+
+    cli(&home)
+        // Keep the test snappy — 5 s budget is more than enough for
+        // two retries (200ms + 400ms) and still safe well under the
+        // 30 s assert_cmd timeout.
+        .env("BOXLITE_TRANSIENT_RETRY_MS", "5000")
+        .args(["--profile", "p1", "start", "real"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("real"));
+    assert!(
+        attempts.load(Ordering::SeqCst) >= 3,
+        "stub must have been hit at least 3 times (2 transient + 1 success), got {}",
+        attempts.load(Ordering::SeqCst)
+    );
+}
+
+/// A persistently transient state must still time out and surface a
+/// real failure — otherwise a stuck server would hang the user's
+/// shell indefinitely. The budget is intentionally tiny here so the
+/// test runs fast.
+#[test]
+fn start_gives_up_after_persistent_transient_state() {
+    let stub = Stub::start(|method, path| {
+        if method == "POST" && path.ends_with("/start") {
+            (409, TRANSIENT_STATE_JSON.to_string())
+        } else if method == "GET" && path.starts_with("/v1/boxes/") {
+            (200, STOPPED_BOX_JSON.to_string())
+        } else {
+            (
+                404,
+                r#"{"error":{"message":"nope","type":"NotFoundError","code":"not_found"}}"#
+                    .to_string(),
+            )
+        }
+    });
+    let home = TempDir::new().unwrap();
+    write_p1_creds(&home, &stub.url());
+
+    cli(&home)
+        .env("BOXLITE_TRANSIENT_RETRY_MS", "400")
+        .args(["--profile", "p1", "start", "real"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("gave up"));
+}
+
+/// A `start` against a non-transient `invalid_state` (e.g. "Cannot
+/// start box in failed state") must propagate immediately — the retry
+/// loop is for in-flight transitions, not permanent failures. Pinning
+/// this with a long budget so a regression that retries every
+/// `InvalidState` would hang past the assert_cmd timeout and fail
+/// the test loudly.
+#[test]
+fn start_does_not_retry_non_transient_invalid_state() {
+    let attempts = Arc::new(AtomicU32::new(0));
+    let attempts_in = attempts.clone();
+    let stub = Stub::start(move |method, path| {
+        if method == "POST" && path.ends_with("/start") {
+            attempts_in.fetch_add(1, Ordering::SeqCst);
+            (
+                409,
+                r#"{"error":{"message":"Cannot start box in failed state","type":"InvalidStateError","code":"invalid_state"}}"#.to_string(),
+            )
+        } else if method == "GET" && path.starts_with("/v1/boxes/") {
+            (200, STOPPED_BOX_JSON.to_string())
+        } else {
+            (
+                404,
+                r#"{"error":{"message":"nope","type":"NotFoundError","code":"not_found"}}"#
+                    .to_string(),
+            )
+        }
+    });
+    let home = TempDir::new().unwrap();
+    write_p1_creds(&home, &stub.url());
+
+    cli(&home)
+        // 20 s — long enough that a retry-everything regression would
+        // hang well past the 0.4 s a one-shot path takes.
+        .env("BOXLITE_TRANSIENT_RETRY_MS", "20000")
+        .args(["--profile", "p1", "start", "real"])
+        .assert()
+        .failure();
+    assert_eq!(
+        attempts.load(Ordering::SeqCst),
+        1,
+        "non-transient InvalidState must not trigger retry; got {} attempts",
+        attempts.load(Ordering::SeqCst)
+    );
+}


### PR DESCRIPTION
while receiving a query while starting or stopping the box, 

## Test plan

`cargo test -p boxlite-cli --bin boxlite retry` + `cargo nextest run -p boxlite-cli --test transient_state_retry`

| scenario | pre-fix | post-fix |
|---|---|---|
| `start` hits transient `invalid_state` twice, third call returns 200 | exit 1 + `Cannot start box in stopping state` | exit 0; stub hit ≥3 times; success |
| `start` against persistent transient `invalid_state` (stub keeps returning it) | exit 1 immediately | retries until budget exhausted; exit 1 + `gave up` suffix |
| `start` against non-transient `invalid_state` ("Cannot start box in failed state") | exit 1 (1 call) | exit 1 (1 call — **no false retry**) |
| units: retries-then-succeeds / gives-up / non-transient propagates / NotFound propagates | n/a | 4/4 green |

Two-side: `git checkout HEAD --` reverts `stop.rs`/`start.rs`/`restart.rs` to pre-wiring (retry module + tests preserved). `start_waits_through_transient_invalid_state` and `start_gives_up_after_persistent_transient_state` both fail (exactly the paths the wiring covers); `start_does_not_retry_non_transient_invalid_state` still passes (negative case). Restore the wiring → 3/3 pass.
