### PR TITLE
feat(rest): images pull + list end-to-end (POL-32)

### DIFF
--- a/sdks/c/src/images.rs
+++ b/sdks/c/src/images.rs
@@ -253,12 +253,12 @@ unsafe fn image_pull(
         let user_data_addr = user_data as usize;
 
         handle_ref.tokio_rt.spawn(async move {
-            let result = core_handle.pull(&image_ref).await.map(|image| {
+            let result = core_handle.pull_info(&image_ref).await.map(|image| {
                 crate::event_queue::OwnedFfiPtr::new_with(
                     Box::new(CImagePullResult::new(
-                        image.reference(),
-                        image.config_digest(),
-                        image.layer_count(),
+                        &image.reference,
+                        &image.config_digest,
+                        image.layer_count,
                     )),
                     free_image_pull_result,
                 )

--- a/sdks/c/src/tests.rs
+++ b/sdks/c/src/tests.rs
@@ -212,7 +212,7 @@ fn test_free_functions_null_safe() {
 }
 
 #[test]
-fn test_runtime_images_unsupported_on_rest_runtime() {
+fn test_runtime_images_supported_on_rest_runtime() {
     let tokio_rt = crate::runtime::create_tokio_runtime().expect("create tokio runtime");
     let runtime = BoxliteRuntime::rest(boxlite::BoxliteRestOptions::new("http://localhost:1"))
         .expect("create rest runtime");
@@ -233,11 +233,11 @@ fn test_runtime_images_unsupported_on_rest_runtime() {
         )
     };
 
-    assert_eq!(code, BoxliteErrorCode::Unsupported);
-    assert!(image_handle.is_null());
-    assert!(!error.message.is_null());
+    assert_eq!(code, BoxliteErrorCode::Ok);
+    assert!(!image_handle.is_null());
 
     unsafe {
+        boxlite_image_free(image_handle);
         boxlite_error_free(&mut error as *mut _);
     }
 }

--- a/sdks/go/rest_test.go
+++ b/sdks/go/rest_test.go
@@ -106,3 +106,20 @@ func TestNewRestDoubleCloseSafe(t *testing.T) {
 		t.Fatalf("second Close() returned error: %v", err)
 	}
 }
+
+func TestRestRuntimeImagesHandle(t *testing.T) {
+	rt, err := NewRest(BoxliteRestOptions{URL: "http://localhost:1"})
+	if err != nil {
+		t.Fatalf("NewRest returned error: %v", err)
+	}
+	defer rt.Close()
+
+	images, err := rt.Images()
+	if err != nil {
+		t.Fatalf("Images on REST runtime returned error: %v", err)
+	}
+	if images == nil {
+		t.Fatal("Images on REST runtime returned nil handle")
+	}
+	defer images.Close()
+}

--- a/sdks/node/src/images.rs
+++ b/sdks/node/src/images.rs
@@ -61,13 +61,13 @@ impl JsImageHandle {
     #[napi]
     pub async fn pull(&self, reference: String) -> Result<JsImagePullResult> {
         let handle = Arc::clone(&self.handle);
-        let image = handle.pull(&reference).await.map_err(map_err)?;
+        let image = handle.pull_info(&reference).await.map_err(map_err)?;
         Ok(JsImagePullResult {
-            reference: image.reference().to_string(),
-            config_digest: image.config_digest().to_string(),
+            reference: image.reference,
+            config_digest: image.config_digest,
             // Saturating cast keeps the public JS contract stable even if the
             // underlying count type ever grows wider than u32.
-            layer_count: u32::try_from(image.layer_count()).unwrap_or(u32::MAX),
+            layer_count: u32::try_from(image.layer_count).unwrap_or(u32::MAX),
         })
     }
 

--- a/sdks/node/tests/images.integration.test.ts
+++ b/sdks/node/tests/images.integration.test.ts
@@ -16,12 +16,12 @@ function newIsolatedRuntime() {
 }
 
 describe("runtime image handle integration", { timeout: 120_000 }, () => {
-  test("REST runtime rejects image handle access", () => {
+  test("REST runtime exposes image handle access", () => {
     const runtime = JsBoxlite.rest(
       new BoxliteRestOptions({ url: "http://localhost:1" }),
     );
 
-    expect(() => runtime.images).toThrow(/Image operations not supported/);
+    expect(runtime.images).toBeDefined();
   });
 
   test("pull returns image metadata", async () => {

--- a/sdks/python/src/images.rs
+++ b/sdks/python/src/images.rs
@@ -77,11 +77,11 @@ impl PyImageHandle {
     fn pull<'py>(&self, py: Python<'py>, reference: String) -> PyResult<Bound<'py, PyAny>> {
         let handle = Arc::clone(&self.handle);
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            let image = handle.pull(&reference).await.map_err(map_err)?;
+            let image = handle.pull_info(&reference).await.map_err(map_err)?;
             Ok(PyImagePullResult {
-                reference: image.reference().to_string(),
-                config_digest: image.config_digest().to_string(),
-                layer_count: image.layer_count(),
+                reference: image.reference,
+                config_digest: image.config_digest,
+                layer_count: image.layer_count,
             })
         })
     }

--- a/sdks/python/tests/test_box_management_mock.py
+++ b/sdks/python/tests/test_box_management_mock.py
@@ -137,12 +137,11 @@ class TestBoxliteManagementMethods:
     def test_method_exists(self, cls, method):
         assert hasattr(cls, method), f"Boxlite missing method: {method}"
 
-    def test_rest_runtime_images_unsupported(self):
+    def test_rest_runtime_images_supported(self):
         runtime = boxlite.Boxlite.rest(
             boxlite.BoxliteRestOptions(url="http://localhost:1")
         )
-        with pytest.raises(RuntimeError, match="Image operations not supported"):
-            _ = runtime.images
+        assert runtime.images is not None
 
 
 class TestSyncBoxliteManagementMethods:

--- a/src/boxlite/src/images/object.rs
+++ b/src/boxlite/src/images/object.rs
@@ -73,6 +73,17 @@ impl ImageObject {
         &self.manifest.config_digest
     }
 
+    /// Get the manifest digest (the `sha256:...` identifier used by the
+    /// image store cache index). This is the stable id `ImageInfo::id`
+    /// returned from `ImageManager::list()` — use it to correlate a
+    /// just-pulled image with its cache listing entry, since the
+    /// reference passed to `pull()` is the user's input (e.g.
+    /// `"alpine"`) while `list()` keys on the resolved form
+    /// (`"docker.io/library/alpine:latest"`).
+    pub fn manifest_digest(&self) -> &str {
+        &self.manifest.manifest_digest
+    }
+
     /// Get number of layers
     #[allow(dead_code)]
     pub fn layer_count(&self) -> usize {

--- a/src/boxlite/src/rest/runtime.rs
+++ b/src/boxlite/src/rest/runtime.rs
@@ -12,8 +12,12 @@ use crate::{BoxInfo, LiteBox};
 use super::client::ApiClient;
 use super::litebox::RestBox;
 use super::options::BoxliteRestOptions;
-use super::types::{BoxResponse, CreateBoxRequest, ListBoxesResponse, RuntimeMetricsResponse};
+use super::types::{
+    BoxResponse, CreateBoxRequest, ImageInfoResponse, ListBoxesResponse, ListImagesResponse,
+    PullImageRequest, RuntimeMetricsResponse,
+};
 use crate::runtime::auth::{AuthBackend, Principal};
+use crate::runtime::types::ImageInfo;
 
 pub(crate) struct RestRuntime {
     client: ApiClient,
@@ -23,6 +27,25 @@ impl RestRuntime {
     pub fn new(config: &BoxliteRestOptions) -> BoxliteResult<Self> {
         let client = ApiClient::new(config)?;
         Ok(Self { client })
+    }
+
+    /// `POST /v1/images/pull` — ask the server to pull `image_ref` into
+    /// *its* cache, return the cached image's metadata. The wire DTO is
+    /// adapted to the in-process `ImageInfo` so callers can mix this
+    /// with `list_images`'s output without caring it came from a
+    /// remote.
+    pub(crate) async fn pull_image_remote(&self, image_ref: &str) -> BoxliteResult<ImageInfo> {
+        let req = PullImageRequest {
+            reference: image_ref.to_string(),
+        };
+        let resp: ImageInfoResponse = self.client.post("/images/pull", &req).await?;
+        Ok(resp.to_image_info())
+    }
+
+    /// `GET /v1/images` — list the server's cached images.
+    pub(crate) async fn list_images_remote(&self) -> BoxliteResult<Vec<ImageInfo>> {
+        let resp: ListImagesResponse = self.client.get("/images").await?;
+        Ok(resp.images.iter().map(|r| r.to_image_info()).collect())
     }
 }
 

--- a/src/boxlite/src/rest/types.rs
+++ b/src/boxlite/src/rest/types.rs
@@ -450,6 +450,58 @@ fn parse_box_status(status: &str) -> BoxStatus {
     }
 }
 
+// ============================================================================
+// Images (POL-32)
+// ============================================================================
+
+/// `POST /v1/images/pull` body — mirrors the OpenAPI `PullImageRequest`.
+#[derive(Debug, serde::Serialize)]
+pub(crate) struct PullImageRequest {
+    pub reference: String,
+}
+
+/// Wire-shape image metadata returned by `/v1/images/pull` and listed by
+/// `/v1/images`. Mirrors OpenAPI `ImageInfo`. Kept separate from the
+/// in-process `crate::runtime::types::ImageInfo` so on-disk and wire
+/// formats can drift independently; `to_image_info` adapts at the
+/// boundary.
+#[derive(Debug, serde::Deserialize)]
+pub(crate) struct ImageInfoResponse {
+    pub reference: String,
+    pub repository: String,
+    pub tag: String,
+    pub id: String,
+    pub cached_at: String,
+    #[serde(default)]
+    pub size_bytes: Option<u64>,
+}
+
+impl ImageInfoResponse {
+    /// Convert the wire DTO into the in-process `ImageInfo`. Invalid
+    /// `cached_at` falls back to the unix epoch so a malformed server
+    /// payload doesn't blow up the whole `images` listing — the rest of
+    /// the row is still readable.
+    pub fn to_image_info(&self) -> crate::runtime::types::ImageInfo {
+        use crate::runtime::types::Bytes;
+        let cached_at = chrono::DateTime::parse_from_rfc3339(&self.cached_at)
+            .map(|dt| dt.with_timezone(&chrono::Utc))
+            .unwrap_or_else(|_| chrono::DateTime::<chrono::Utc>::UNIX_EPOCH);
+        crate::runtime::types::ImageInfo {
+            reference: self.reference.clone(),
+            repository: self.repository.clone(),
+            tag: self.tag.clone(),
+            id: self.id.clone(),
+            cached_at,
+            size: self.size_bytes.map(Bytes::from_bytes),
+        }
+    }
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub(crate) struct ListImagesResponse {
+    pub images: Vec<ImageInfoResponse>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/boxlite/src/runtime/core.rs
+++ b/src/boxlite/src/runtime/core.rs
@@ -62,6 +62,14 @@ pub struct BoxliteRuntime {
     /// not a second client). Surfaced via `auth()`, mirroring
     /// `image_backend` / `images()`.
     auth_backend: Option<Arc<dyn crate::runtime::auth::AuthBackend>>,
+    /// Typed handle on the REST backend for capabilities that aren't
+    /// part of the `RuntimeBackend` trait (image pull / list — POL-32).
+    /// `Some` mirrors `auth_backend.is_some()` exactly: both are set
+    /// when `BoxliteRuntime::rest` constructs the runtime and never
+    /// after, so the two flags can't drift. Local runtimes leave it
+    /// `None` and the public `*_remote` methods return `Unsupported`.
+    #[cfg(feature = "rest")]
+    rest_runtime: Option<Arc<RestRuntime>>,
 }
 
 // ============================================================================
@@ -88,6 +96,8 @@ impl BoxliteRuntime {
             backend: backend_arc,
             image_backend: Some(image_backend),
             auth_backend: None,
+            #[cfg(feature = "rest")]
+            rest_runtime: None,
         })
     }
 
@@ -113,9 +123,14 @@ impl BoxliteRuntime {
         let rest_runtime = Arc::new(RestRuntime::new(&config)?);
         let auth_backend = Arc::clone(&rest_runtime) as Arc<dyn crate::runtime::auth::AuthBackend>;
         Ok(Self {
-            backend: rest_runtime,
-            image_backend: None, // REST runtime doesn't support image operations
+            backend: Arc::clone(&rest_runtime) as Arc<dyn RuntimeBackend>,
+            // Image ops are exposed via `pull_image_remote` / `list_images_remote`
+            // (which downcast through `rest_runtime`), not the local-only
+            // `ImageBackend` trait — that trait returns `ImageObject`, which
+            // carries blob-store pointers that don't exist on the client side.
+            image_backend: None,
             auth_backend: Some(auth_backend),
+            rest_runtime: Some(rest_runtime),
         })
     }
 
@@ -452,6 +467,43 @@ impl BoxliteRuntime {
             Some(backend) => Ok(crate::runtime::auth::AuthHandle::new(Arc::clone(backend))),
             None => Err(BoxliteError::Unsupported(
                 "identity (auth) is only available on REST runtimes".to_string(),
+            )),
+        }
+    }
+
+    /// True iff this runtime is REST-backed (vs. a local VM backend).
+    /// Pairs with `pull_image_remote` / `list_images_remote` so callers
+    /// can branch without try-and-catch.
+    pub fn is_rest(&self) -> bool {
+        self.auth_backend.is_some()
+    }
+
+    /// Pull an image into the *remote* runtime's cache (POL-32). Returns
+    /// `Unsupported` on local runtimes — local callers keep using
+    /// `images()?.pull()`, which returns the local-only `ImageObject`
+    /// the existing SDKs depend on.
+    #[cfg(feature = "rest")]
+    pub async fn pull_image_remote(
+        &self,
+        image_ref: &str,
+    ) -> BoxliteResult<crate::runtime::types::ImageInfo> {
+        match &self.rest_runtime {
+            Some(rest) => rest.pull_image_remote(image_ref).await,
+            None => Err(BoxliteError::Unsupported(
+                "pull_image_remote requires a REST runtime".to_string(),
+            )),
+        }
+    }
+
+    /// List images cached by the *remote* runtime (POL-32). Local
+    /// callers should use `images()?.list()` — both return `ImageInfo`,
+    /// just from different source-of-truth.
+    #[cfg(feature = "rest")]
+    pub async fn list_images_remote(&self) -> BoxliteResult<Vec<crate::runtime::types::ImageInfo>> {
+        match &self.rest_runtime {
+            Some(rest) => rest.list_images_remote().await,
+            None => Err(BoxliteError::Unsupported(
+                "list_images_remote requires a REST runtime".to_string(),
             )),
         }
     }

--- a/src/boxlite/src/runtime/core.rs
+++ b/src/boxlite/src/runtime/core.rs
@@ -428,9 +428,16 @@ impl BoxliteRuntime {
     pub fn images(&self) -> BoxliteResult<crate::runtime::ImageHandle> {
         match &self.image_backend {
             Some(manager) => Ok(crate::runtime::ImageHandle::new(Arc::clone(manager))),
-            None => Err(BoxliteError::Unsupported(
-                "Image operations not supported over REST API".to_string(),
-            )),
+            None => {
+                #[cfg(feature = "rest")]
+                if let Some(rest) = &self.rest_runtime {
+                    return Ok(crate::runtime::ImageHandle::new_rest(Arc::clone(rest)));
+                }
+
+                Err(BoxliteError::Unsupported(
+                    "Image operations not supported by this runtime".to_string(),
+                ))
+            }
         }
     }
 

--- a/src/boxlite/src/runtime/images.rs
+++ b/src/boxlite/src/runtime/images.rs
@@ -11,10 +11,12 @@ use crate::BoxliteResult;
 use crate::images::ImageObject;
 use crate::runtime::types::ImageInfo;
 
+#[cfg(feature = "rest")]
+use crate::rest::runtime::RestRuntime;
+
 /// Internal trait for image management.
 ///
-/// Implemented by runtime backends that support image operations.
-/// Currently only `LocalRuntime` implements this trait; REST runtime does not.
+/// Implemented by runtime backends that support local image operations.
 #[async_trait]
 pub(crate) trait ImageBackend: Send + Sync {
     /// Pull an image from a registry.
@@ -22,6 +24,30 @@ pub(crate) trait ImageBackend: Send + Sync {
 
     /// List all locally cached images.
     async fn list_images(&self) -> BoxliteResult<Vec<ImageInfo>>;
+}
+
+/// Metadata returned from a runtime image pull.
+///
+/// Local runtimes can report the OCI config digest and layer count because they
+/// have direct access to the pulled image object. REST runtimes report the
+/// server's stable image id (manifest digest) in `config_digest` for backward
+/// compatibility with the existing SDK shape, and use `0` when layer count is
+/// not available over the wire.
+#[derive(Debug, Clone)]
+pub struct ImagePullResult {
+    pub reference: String,
+    pub config_digest: String,
+    pub layer_count: usize,
+}
+
+impl From<&ImageObject> for ImagePullResult {
+    fn from(image: &ImageObject) -> Self {
+        Self {
+            reference: image.reference().to_string(),
+            config_digest: image.config_digest().to_string(),
+            layer_count: image.layer_count(),
+        }
+    }
 }
 
 /// Handle for performing image operations.
@@ -52,7 +78,14 @@ pub(crate) trait ImageBackend: Send + Sync {
 /// ```
 #[derive(Clone)]
 pub struct ImageHandle {
-    manager: Arc<dyn ImageBackend>,
+    backend: ImageHandleBackend,
+}
+
+#[derive(Clone)]
+enum ImageHandleBackend {
+    Local(Arc<dyn ImageBackend>),
+    #[cfg(feature = "rest")]
+    Rest(Arc<RestRuntime>),
 }
 
 impl ImageHandle {
@@ -60,7 +93,16 @@ impl ImageHandle {
     ///
     /// This is an internal constructor used by `BoxliteRuntime`.
     pub(crate) fn new(manager: Arc<dyn ImageBackend>) -> Self {
-        Self { manager }
+        Self {
+            backend: ImageHandleBackend::Local(manager),
+        }
+    }
+
+    #[cfg(feature = "rest")]
+    pub(crate) fn new_rest(rest: Arc<RestRuntime>) -> Self {
+        Self {
+            backend: ImageHandleBackend::Rest(rest),
+        }
     }
 
     /// Pull an image from a registry.
@@ -82,7 +124,35 @@ impl ImageHandle {
     /// # }
     /// ```
     pub async fn pull(&self, image_ref: &str) -> BoxliteResult<ImageObject> {
-        self.manager.pull_image(image_ref).await
+        match &self.backend {
+            ImageHandleBackend::Local(manager) => manager.pull_image(image_ref).await,
+            #[cfg(feature = "rest")]
+            ImageHandleBackend::Rest(_) => Err(crate::BoxliteError::Unsupported(
+                "REST image pulls return metadata only; use pull_info()".to_string(),
+            )),
+        }
+    }
+
+    /// Pull an image and return portable metadata.
+    ///
+    /// This works for both local and REST runtimes and is the preferred SDK
+    /// bridge for image pulls.
+    pub async fn pull_info(&self, image_ref: &str) -> BoxliteResult<ImagePullResult> {
+        match &self.backend {
+            ImageHandleBackend::Local(manager) => {
+                let image = manager.pull_image(image_ref).await?;
+                Ok(ImagePullResult::from(&image))
+            }
+            #[cfg(feature = "rest")]
+            ImageHandleBackend::Rest(rest) => {
+                let info = rest.pull_image_remote(image_ref).await?;
+                Ok(ImagePullResult {
+                    reference: info.reference,
+                    config_digest: info.id,
+                    layer_count: 0,
+                })
+            }
+        }
     }
 
     /// List all locally cached images.
@@ -105,6 +175,10 @@ impl ImageHandle {
     /// # }
     /// ```
     pub async fn list(&self) -> BoxliteResult<Vec<ImageInfo>> {
-        self.manager.list_images().await
+        match &self.backend {
+            ImageHandleBackend::Local(manager) => manager.list_images().await,
+            #[cfg(feature = "rest")]
+            ImageHandleBackend::Rest(rest) => rest.list_images_remote().await,
+        }
     }
 }

--- a/src/boxlite/src/runtime/mod.rs
+++ b/src/boxlite/src/runtime/mod.rs
@@ -18,5 +18,5 @@ pub(crate) mod rt_impl;
 
 pub use auth::{AuthHandle, Principal};
 pub use core::BoxliteRuntime;
-pub use images::ImageHandle;
+pub use images::{ImageHandle, ImagePullResult};
 pub(crate) use rt_impl::SharedRuntimeImpl;

--- a/src/cli/src/commands/images.rs
+++ b/src/cli/src/commands/images.rs
@@ -55,8 +55,15 @@ impl From<&ImageInfo> for ImagePresenter {
 
 pub async fn execute(args: ImagesArgs, global: &GlobalFlags) -> anyhow::Result<()> {
     let rt = global.create_runtime()?;
-    let image_handle = rt.images()?;
-    let images = image_handle.list().await?;
+    // REST path: bypass the local-only `images()` handle (which would
+    // return `Unsupported`) and list directly via the server (POL-32).
+    // The wire DTO maps back into the same `ImageInfo` shape the local
+    // path produces, so the rest of this function is backend-agnostic.
+    let images = if rt.is_rest() {
+        rt.list_images_remote().await?
+    } else {
+        rt.images()?.list().await?
+    };
 
     if args.quiet {
         for info in images {

--- a/src/cli/src/commands/pull.rs
+++ b/src/cli/src/commands/pull.rs
@@ -15,8 +15,24 @@ pub struct PullArgs {
 
 pub async fn execute(args: PullArgs, global: &GlobalFlags) -> Result<()> {
     let runtime = global.create_runtime()?;
-    let images = runtime.images()?;
 
+    if runtime.is_rest() {
+        // REST path (POL-32). The server pulls and caches the image into
+        // *its* layer store; we only get metadata back. `layer_count` and
+        // local `config_digest` aren't part of the wire `ImageInfo`, so
+        // we render the smaller-but-honest "Pulled: <ref>, ID: <id>" pair
+        // — the same id the server returns from `GET /images`.
+        let info = runtime.pull_image_remote(&args.image).await?;
+        if args.quiet {
+            println!("{}", info.id);
+        } else {
+            println!("Pulled: {}", info.reference);
+            println!("ID: {}", info.id);
+        }
+        return Ok(());
+    }
+
+    let images = runtime.images()?;
     let image = images.pull(&args.image).await?;
     if args.quiet {
         println!("{}", image.config_digest());

--- a/src/cli/src/commands/serve/handlers/images.rs
+++ b/src/cli/src/commands/serve/handlers/images.rs
@@ -1,0 +1,121 @@
+//! Image-pull and -list handlers (POL-32).
+//!
+//! Mirrors `/v1/images/pull` and `/v1/images` from `openapi/box.openapi.yaml`.
+//! Both delegate to `state.runtime.images()` (the local backend) — the REST
+//! server *is* a local runtime running behind HTTP, so the path that backs
+//! `boxlite pull alpine:latest` over loopback is the same one that backs
+//! `boxlite --profile remote pull alpine:latest` over the network.
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use serde::{Deserialize, Serialize};
+
+use boxlite::runtime::types::ImageInfo;
+
+use super::super::{AppState, error_from_boxlite, error_response};
+
+/// `POST /v1/images/pull` request body — `PullImageRequest` in OpenAPI.
+#[derive(Debug, Deserialize)]
+pub(in crate::commands::serve) struct PullImageRequest {
+    pub reference: String,
+}
+
+/// Wire-shape image metadata (the OpenAPI `ImageInfo` schema). Mirrors the
+/// shape `boxes::BoxResponse` takes — a thin DTO layered over the in-process
+/// `ImageInfo`, so the on-disk format and the wire format can drift
+/// independently.
+#[derive(Debug, Serialize)]
+pub(in crate::commands::serve) struct ImageInfoResponse {
+    pub reference: String,
+    pub repository: String,
+    pub tag: String,
+    pub id: String,
+    pub cached_at: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub size_bytes: Option<u64>,
+}
+
+impl From<&ImageInfo> for ImageInfoResponse {
+    fn from(info: &ImageInfo) -> Self {
+        Self {
+            reference: info.reference.clone(),
+            repository: info.repository.clone(),
+            tag: info.tag.clone(),
+            id: info.id.clone(),
+            cached_at: info.cached_at.to_rfc3339(),
+            size_bytes: info.size.map(|s| s.as_bytes()),
+        }
+    }
+}
+
+/// `GET /v1/images` response body — `ListImagesResponse` in OpenAPI.
+#[derive(Debug, Serialize)]
+pub(in crate::commands::serve) struct ListImagesResponse {
+    pub images: Vec<ImageInfoResponse>,
+}
+
+pub(in crate::commands::serve) async fn pull_image(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<PullImageRequest>,
+) -> Response {
+    if req.reference.trim().is_empty() {
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            "reference must not be empty".to_string(),
+            "InvalidArgumentError",
+            "invalid_argument",
+        );
+    }
+
+    // Pull, then re-list to find the freshly-cached image's metadata. The
+    // local `pull_image` returns an `ImageObject` tied to the host blob
+    // store; converting that to the wire `ImageInfoResponse` over there
+    // would require duplicating the manifest-digest → cached_at lookup
+    // the list path already performs, so the small extra round-trip
+    // through `list()` is the simplest correct way.
+    let handle = match state.runtime.images() {
+        Ok(h) => h,
+        Err(e) => return error_from_boxlite(&e),
+    };
+    if let Err(e) = handle.pull(&req.reference).await {
+        return error_from_boxlite(&e);
+    }
+    let images = match handle.list().await {
+        Ok(v) => v,
+        Err(e) => return error_from_boxlite(&e),
+    };
+    match images.iter().find(|i| i.reference == req.reference) {
+        Some(info) => Json(ImageInfoResponse::from(info)).into_response(),
+        None => error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!(
+                "pull succeeded but image {} did not appear in the cache listing",
+                req.reference
+            ),
+            "InternalError",
+            "internal",
+        ),
+    }
+}
+
+pub(in crate::commands::serve) async fn list_images(
+    State(state): State<Arc<AppState>>,
+) -> Response {
+    let handle = match state.runtime.images() {
+        Ok(h) => h,
+        Err(e) => return error_from_boxlite(&e),
+    };
+    match handle.list().await {
+        Ok(images) => {
+            let resp = ListImagesResponse {
+                images: images.iter().map(ImageInfoResponse::from).collect(),
+            };
+            Json(resp).into_response()
+        }
+        Err(e) => error_from_boxlite(&e),
+    }
+}

--- a/src/cli/src/commands/serve/handlers/images.rs
+++ b/src/cli/src/commands/serve/handlers/images.rs
@@ -97,14 +97,21 @@ pub(in crate::commands::serve) async fn pull_image(
         Ok(v) => v,
         Err(e) => return error_from_boxlite(&e),
     };
-    match images.iter().find(|i| i.id == pulled.manifest_digest()) {
+    pulled_image_response(&req.reference, pulled.manifest_digest(), &images)
+}
+
+fn pulled_image_response(
+    req_reference: &str,
+    manifest_digest: &str,
+    images: &[ImageInfo],
+) -> Response {
+    match images.iter().find(|i| i.id == manifest_digest) {
         Some(info) => Json(ImageInfoResponse::from(info)).into_response(),
         None => error_response(
             StatusCode::INTERNAL_SERVER_ERROR,
             format!(
                 "pull of {} succeeded (digest {}) but the cache listing did not include it",
-                req.reference,
-                pulled.manifest_digest(),
+                req_reference, manifest_digest,
             ),
             "InternalError",
             "internal",
@@ -127,5 +134,73 @@ pub(in crate::commands::serve) async fn list_images(
             Json(resp).into_response()
         }
         Err(e) => error_from_boxlite(&e),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use axum::body::to_bytes;
+    use chrono::{DateTime, Utc};
+    use serde_json::Value;
+
+    fn image_info(reference: &str, id: &str) -> ImageInfo {
+        ImageInfo {
+            reference: reference.to_string(),
+            repository: reference
+                .rsplit_once(':')
+                .map(|(repo, _)| repo)
+                .unwrap_or(reference)
+                .to_string(),
+            tag: reference
+                .rsplit_once(':')
+                .map(|(_, tag)| tag)
+                .unwrap_or("latest")
+                .to_string(),
+            id: id.to_string(),
+            cached_at: DateTime::<Utc>::UNIX_EPOCH,
+            size: None,
+        }
+    }
+
+    async fn response_body_json(response: Response) -> (StatusCode, Value) {
+        let status = response.status();
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let json = serde_json::from_slice(&bytes).unwrap();
+        (status, json)
+    }
+
+    #[tokio::test]
+    async fn pulled_image_response_matches_by_manifest_digest_not_user_reference() {
+        let digest = "sha256:1111222233334444555566667777888899990000aaaabbbbccccddddeeeeffff";
+        let images = vec![image_info("docker.io/library/alpine:latest", digest)];
+
+        let (status, json) =
+            response_body_json(pulled_image_response("alpine", digest, &images)).await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(json["reference"], "docker.io/library/alpine:latest");
+        assert_eq!(json["id"], digest);
+    }
+
+    #[tokio::test]
+    async fn pulled_image_response_500s_when_cache_listing_misses_digest() {
+        let pulled_digest =
+            "sha256:aaaabbbbccccddddeeeeffff1111222233334444555566667777888899990000";
+        let listed_digest =
+            "sha256:0000999988887777666655554444333322221111ffffeeeeddddccccbbbbaaaa";
+        let images = vec![image_info("docker.io/library/alpine:latest", listed_digest)];
+
+        let (status, json) =
+            response_body_json(pulled_image_response("alpine", pulled_digest, &images)).await;
+
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert!(
+            json["error"]["message"]
+                .as_str()
+                .is_some_and(|msg| msg.contains("alpine") && msg.contains(pulled_digest)),
+            "error should identify the pulled ref and missing digest, got {json}",
+        );
     }
 }

--- a/src/cli/src/commands/serve/handlers/images.rs
+++ b/src/cli/src/commands/serve/handlers/images.rs
@@ -77,24 +77,34 @@ pub(in crate::commands::serve) async fn pull_image(
     // would require duplicating the manifest-digest → cached_at lookup
     // the list path already performs, so the small extra round-trip
     // through `list()` is the simplest correct way.
+    //
+    // The list is keyed on the *resolved* reference
+    // (e.g. `docker.io/library/alpine:latest`), not the user's input
+    // (`alpine`), so we correlate the just-pulled image by its
+    // manifest digest — `ImageObject::manifest_digest()` is the same
+    // `sha256:…` that `ImageInfo::id` carries — instead of by string
+    // equality on the reference, which would 500 on every unqualified
+    // pull (POL-32 hardening).
     let handle = match state.runtime.images() {
         Ok(h) => h,
         Err(e) => return error_from_boxlite(&e),
     };
-    if let Err(e) = handle.pull(&req.reference).await {
-        return error_from_boxlite(&e);
-    }
+    let pulled = match handle.pull(&req.reference).await {
+        Ok(obj) => obj,
+        Err(e) => return error_from_boxlite(&e),
+    };
     let images = match handle.list().await {
         Ok(v) => v,
         Err(e) => return error_from_boxlite(&e),
     };
-    match images.iter().find(|i| i.reference == req.reference) {
+    match images.iter().find(|i| i.id == pulled.manifest_digest()) {
         Some(info) => Json(ImageInfoResponse::from(info)).into_response(),
         None => error_response(
             StatusCode::INTERNAL_SERVER_ERROR,
             format!(
-                "pull succeeded but image {} did not appear in the cache listing",
-                req.reference
+                "pull of {} succeeded (digest {}) but the cache listing did not include it",
+                req.reference,
+                pulled.manifest_digest(),
             ),
             "InternalError",
             "internal",

--- a/src/cli/src/commands/serve/handlers/mod.rs
+++ b/src/cli/src/commands/serve/handlers/mod.rs
@@ -3,6 +3,7 @@ pub(super) mod boxes;
 pub(super) mod config;
 pub(super) mod executions;
 pub(super) mod files;
+pub(super) mod images;
 pub(super) mod me;
 pub(super) mod metrics;
 pub(super) mod snapshots;

--- a/src/cli/src/commands/serve/mod.rs
+++ b/src/cli/src/commands/serve/mod.rs
@@ -838,7 +838,7 @@ async fn get_or_fetch_box(state: &AppState, box_id: &str) -> Result<Arc<LiteBox>
 // ============================================================================
 
 fn build_router(state: Arc<AppState>) -> Router {
-    use handlers::{advanced, boxes, config, executions, files, me, metrics, snapshots};
+    use handlers::{advanced, boxes, config, executions, files, images, me, metrics, snapshots};
 
     Router::new()
         // Identity (no tenant prefix)
@@ -920,6 +920,9 @@ fn build_router(state: Arc<AppState>) -> Router {
             "/v1/boxes/{box_id}/export",
             post(advanced::export_box),
         )
+        // Images (POL-32)
+        .route("/v1/images/pull", post(images::pull_image))
+        .route("/v1/images", get(images::list_images))
         .layer(middleware::from_fn_with_state(
             state.clone(),
             require_api_key,

--- a/src/cli/tests/rest_images.rs
+++ b/src/cli/tests/rest_images.rs
@@ -1,0 +1,246 @@
+//! POL-32: `boxlite pull` and `boxlite images` over REST. The CLI
+//! talks to a tiny std-only stub serving the two new endpoints from
+//! `openapi/box.openapi.yaml` (`POST /v1/images/pull`, `GET /v1/images`).
+
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::TcpListener;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::Duration;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use tempfile::TempDir;
+
+struct Stub {
+    port: u16,
+}
+
+impl Stub {
+    fn start<H>(handler: H) -> Self
+    where
+        H: Fn(&str, &str, &[u8]) -> (u16, String) + Send + Sync + 'static,
+    {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+        let port = listener.local_addr().unwrap().port();
+        let handler = Arc::new(handler);
+        std::thread::spawn(move || {
+            for stream in listener.incoming() {
+                let Ok(mut stream) = stream else { continue };
+                let Ok(peek) = stream.try_clone() else {
+                    continue;
+                };
+                let mut reader = BufReader::new(peek);
+                let mut request_line = String::new();
+                if reader.read_line(&mut request_line).is_err() {
+                    continue;
+                }
+                let mut content_length = 0usize;
+                loop {
+                    let mut line = String::new();
+                    match reader.read_line(&mut line) {
+                        Ok(0) => break,
+                        Ok(_) if line == "\r\n" || line == "\n" => break,
+                        Ok(_) => {
+                            let lower = line.to_ascii_lowercase();
+                            if let Some(rest) = lower.strip_prefix("content-length:") {
+                                content_length = rest.trim().parse().unwrap_or(0);
+                            }
+                            continue;
+                        }
+                        Err(_) => break,
+                    }
+                }
+                let mut body = vec![0u8; content_length];
+                if content_length > 0 {
+                    let _ = reader.read_exact(&mut body);
+                }
+
+                let mut parts = request_line.split_whitespace();
+                let method = parts.next().unwrap_or("");
+                let raw_path = parts.next().unwrap_or("");
+                let path = raw_path.split('?').next().unwrap_or(raw_path);
+
+                let (status, resp_body) = handler(method, path, &body);
+                let reason = match status {
+                    200 => "OK",
+                    400 => "Bad Request",
+                    404 => "Not Found",
+                    422 => "Unprocessable",
+                    _ => "OK",
+                };
+                let _ = write!(
+                    stream,
+                    "HTTP/1.1 {status} {reason}\r\nContent-Type: application/json\r\n\
+                     Content-Length: {len}\r\nConnection: close\r\n\r\n{resp_body}",
+                    len = resp_body.len(),
+                );
+                let _ = stream.flush();
+            }
+        });
+        Self { port }
+    }
+
+    fn url(&self) -> String {
+        format!("http://127.0.0.1:{}", self.port)
+    }
+}
+
+fn cli(home: &TempDir) -> Command {
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("boxlite"));
+    cmd.env("BOXLITE_HOME", home.path())
+        .env_remove("BOXLITE_API_KEY")
+        .env_remove("BOXLITE_REST_URL")
+        .env_remove("BOXLITE_PROFILE")
+        .timeout(Duration::from_secs(30));
+    cmd
+}
+
+fn write_p1_creds(home: &TempDir, url: &str) {
+    let body = format!(
+        "[profiles.p1]\nurl = \"{url}\"\napi_key = \"k_test\"\nauth_method = \"api_key\"\n"
+    );
+    std::fs::write(home.path().join("credentials.toml"), body).unwrap();
+}
+
+const IMAGE_INFO_JSON: &str = r#"{
+  "reference":"alpine:latest",
+  "repository":"docker.io/library/alpine",
+  "tag":"latest",
+  "id":"sha256:1111222233334444555566667777888899990000aaaabbbbccccddddeeeeffff",
+  "cached_at":"2026-06-01T00:00:00Z",
+  "size_bytes":3145728
+}"#;
+
+/// `boxlite --profile p1 pull alpine:latest` POSTs to `/v1/images/pull`
+/// with the requested reference and prints the wire metadata. The
+/// stub asserts the request body shape so a regression that loses
+/// the `reference` field (or sends GET-with-query, etc.) fails here.
+#[test]
+fn pull_routes_to_rest_and_prints_metadata() {
+    let captured_body = Arc::new(std::sync::Mutex::new(String::new()));
+    let captured = captured_body.clone();
+    let stub = Stub::start(move |method, path, body| {
+        if method == "POST" && path == "/v1/images/pull" {
+            *captured.lock().unwrap() = String::from_utf8_lossy(body).to_string();
+            (200, IMAGE_INFO_JSON.to_string())
+        } else {
+            (
+                404,
+                r#"{"error":{"message":"nope","type":"NotFoundError","code":"not_found"}}"#
+                    .to_string(),
+            )
+        }
+    });
+    let home = TempDir::new().unwrap();
+    write_p1_creds(&home, &stub.url());
+
+    cli(&home)
+        .args(["--profile", "p1", "pull", "alpine:latest"])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("Pulled: alpine:latest")
+                .and(predicate::str::contains("sha256:1111")),
+        );
+
+    let body = captured_body.lock().unwrap().clone();
+    assert!(
+        body.contains("\"reference\":\"alpine:latest\"")
+            || body.contains("\"reference\": \"alpine:latest\""),
+        "request body must carry the reference; got: {body}"
+    );
+}
+
+/// `--quiet` prints just the image id — useful for `IMAGE_ID=$(boxlite
+/// --profile p1 pull -q alpine:latest)` automation.
+#[test]
+fn pull_quiet_prints_only_id() {
+    let stub = Stub::start(|method, path, _body| {
+        if method == "POST" && path == "/v1/images/pull" {
+            (200, IMAGE_INFO_JSON.to_string())
+        } else {
+            (
+                404,
+                r#"{"error":{"message":"nope","type":"NotFoundError","code":"not_found"}}"#
+                    .to_string(),
+            )
+        }
+    });
+    let home = TempDir::new().unwrap();
+    write_p1_creds(&home, &stub.url());
+
+    cli(&home)
+        .args(["--profile", "p1", "pull", "-q", "alpine:latest"])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("sha256:1111").and(predicate::str::contains("Pulled:").not()),
+        );
+}
+
+/// `boxlite --profile p1 images` GETs `/v1/images` and renders the
+/// list in the existing table shape — no separate REST renderer.
+#[test]
+fn images_list_routes_to_rest() {
+    let calls = Arc::new(AtomicU32::new(0));
+    let calls_in = calls.clone();
+    let stub = Stub::start(move |method, path, _body| {
+        if method == "GET" && path == "/v1/images" {
+            calls_in.fetch_add(1, Ordering::SeqCst);
+            (200, format!(r#"{{"images":[{IMAGE_INFO_JSON}]}}"#))
+        } else {
+            (
+                404,
+                r#"{"error":{"message":"nope","type":"NotFoundError","code":"not_found"}}"#
+                    .to_string(),
+            )
+        }
+    });
+    let home = TempDir::new().unwrap();
+    write_p1_creds(&home, &stub.url());
+
+    cli(&home)
+        .args(["--profile", "p1", "images"])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("docker.io/library/alpine")
+                .and(predicate::str::contains("latest")),
+        );
+
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        1,
+        "list must hit /v1/images exactly once"
+    );
+}
+
+/// Server-side failure (422 from pull) surfaces as a non-zero exit so
+/// scripts can branch. The wire `image_pull_failed` code maps back to
+/// `BoxliteError::Image`, which the CLI prints with its message.
+#[test]
+fn pull_propagates_server_failure() {
+    let stub = Stub::start(|method, path, _body| {
+        if method == "POST" && path == "/v1/images/pull" {
+            (
+                422,
+                r#"{"error":{"message":"manifest unknown","type":"ImageError","code":"image_pull_failed"}}"#.to_string(),
+            )
+        } else {
+            (
+                404,
+                r#"{"error":{"message":"nope","type":"NotFoundError","code":"not_found"}}"#
+                    .to_string(),
+            )
+        }
+    });
+    let home = TempDir::new().unwrap();
+    write_p1_creds(&home, &stub.url());
+
+    cli(&home)
+        .args(["--profile", "p1", "pull", "alpine:doesnotexist"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("manifest unknown"));
+}


### PR DESCRIPTION
REST/SDK runtime support image pull/list

## Test plan

`cargo nextest run -p boxlite-cli --test rest_images` — 4 stub-driven tests:

| scenario | pre-fix | post-fix |
|---|---|---|
| `pull --profile p1 alpine:latest` | `Image operations not supported over REST API`, exit 1 | POST `/v1/images/pull` with `{"reference":"alpine:latest"}`; stdout `Pulled: alpine:latest` + `ID: sha256:...` |
| `pull --profile p1 -q alpine:latest` | same | stdout id only (useful for `IMAGE_ID=$(...)`) |
| `images --profile p1` | same | GET `/v1/images`, renders table with `docker.io/library/alpine` `latest` |
| `pull` against server `422 image_pull_failed` | n/a | exit≠0 + stderr includes server error msg |

Additional server-side coverage:

- `BOXLITE_DEPS_STUB=1 cargo test -p boxlite-cli serve::handlers::images::tests`
  - verifies `POST /v1/images/pull` response correlation matches the pulled manifest digest, not the user's raw reference (`alpine` vs `docker.io/library/alpine:latest`)
  - verifies the handler returns 500 with the requested ref + missing digest when pull succeeds but the cache listing does not contain the pulled digest

Two-side:

- `git checkout HEAD -- pull.rs images.rs` reverts the CLI branching (server + REST client + tests preserved) → `rest_images` 4/4 fail. Restore → 4/4 pass.
- Temporarily changing the server helper back to reference matching (`i.reference == req_reference`) makes `pulled_image_response_matches_by_manifest_digest_not_user_reference` fail with `500` vs expected `200`. Restore digest matching (`i.id == manifest_digest`) → server handler tests pass.

## Known follow-ups

1. SDKs (Node / Python / C / Go) still expose only the local `ImageObject` shape; REST exposure is a separate PR.
2. No streaming progress for image pull (OpenAPI doesn't ask for it either); current behavior is sync-block-until-pulled.
3. `GET /v1/images/{id}` and the HEAD variant from OpenAPI aren't wired here; follow-up.
