### PR TITLE
test(net): hermetic + e2e coverage for #645 allowlist DNS resilience

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -263,6 +263,69 @@ async with boxlite.SimpleBox(image="alpine:latest") as box:
     print(result.stdout)
 ```
 
+### An `allow_net` host resolves to `0.0.0.0` inside the box (or `box.create` failed with a DNS error)
+
+When `allow_net` is set, BoxLite resolves each allow-listed hostname on
+the **host** at box-creation time and pins the IPs into the guest's DNS
+sinkhole. Anything not in the sinkhole answers `0.0.0.0`. So if an
+allow-listed host shows up as `0.0.0.0` inside the box, the host's
+resolver couldn't answer for it when the box was being created — most
+often a VPN that hadn't fully come up, a slow corporate DNS server, or
+mDNSResponder churn.
+
+**1. Check the gvproxy log for the host that failed.**
+
+```bash
+# Find the most recent box
+ls -t ~/.boxlite/boxes/
+
+# Then grep its shim log
+grep -i allowNet ~/.boxlite/boxes/<id>/logs/boxlite-shim.log.<date>
+```
+
+A successful create looks like this — `allow_zones == hostnames`:
+
+```
+INFO gvproxy: allowNet: DNS sinkhole configured allow_zones=5 total_zones=6
+INFO gvproxy: allowNet TCP: filter initialized hostnames=5 ...
+```
+
+When a host couldn't be resolved you'll see retry warnings followed by
+either a recovery (newer builds — the box still comes up cleanly):
+
+```
+WARN gvproxy: allowNet: DNS resolution failed, will retry attempt=1 hostname=iapi.example.com next_delay=100ms
+INFO gvproxy: allowNet: DNS resolution succeeded after retry attempts=2 hostname=iapi.example.com
+```
+
+…or a hard failure, which now aborts `box.create`:
+
+```
+ERROR gvproxy: allowNet: DNS resolution failed after retries attempts=4 hostname=iapi.example.com error="..."
+ERROR gvproxy: Failed to build gvproxy tap config error="allowNet: resolve \"iapi.example.com\": ..."
+```
+
+On older builds without the retry/fail-closed behavior the symptom is
+quieter: `allow_zones=N-1 total_zones=N` with no error, and the missing
+host silently sinkholes to `0.0.0.0` for the lifetime of the box.
+
+**2. Verify the host can actually resolve and reach the name.**
+
+```bash
+getent hosts iapi.example.com    # or: dscacheutil -q host -a name <host>
+nc -vz iapi.example.com 443
+```
+
+If the host can't reach it (`Connection refused`, `0.0.0.0`, NXDOMAIN),
+no amount of allow-listing will help — the VM only knows what the host
+told it at create time.
+
+**3. Recreate the box once DNS is healthy.**
+
+The sinkhole is built once at `box.create` and never refreshed for the
+life of that box, so you must destroy and recreate it after fixing the
+host's networking — restarting the VM or its services is not enough.
+
 ### How do I expose ports from a box?
 
 Use the `ports` parameter for port forwarding:

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -160,6 +160,14 @@ Structured network configuration for outbound connectivity.
   reaching host loopback services and is not governed by `allow_net`.
 - Security: when networking is enabled, any service bound to host loopback can
   be reached from inside the box via `host.boxlite.internal` or `192.168.127.254`.
+- Each allow-listed hostname is resolved on the **host** at box creation
+  time and the IPs are pinned into the guest's DNS sinkhole. The lookup
+  retries with exponential backoff to ride out transient host-side DNS
+  hiccups (VPN flap, slow corp resolver). If a hostname still cannot be
+  resolved after all retries, `box.create` fails — by design, so a
+  half-baked sinkhole never silently sinkholes an allow-listed host to
+  `0.0.0.0`. Make sure the host can resolve every entry in `allow_net`
+  before creating the box.
 
 **Supported patterns:**
 - Exact hostname: `"api.openai.com"`

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/config_build_test.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/config_build_test.go
@@ -32,7 +32,10 @@ func testGvproxyConfig() GvproxyConfig {
 }
 
 func TestBuildTapConfig_UsesHostAliasDNSZone(t *testing.T) {
-	tapConfig := buildTapConfig(testGvproxyConfig(), types.QemuProtocol)
+	tapConfig, err := buildTapConfig(testGvproxyConfig(), types.QemuProtocol)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	if len(tapConfig.DNS) == 0 {
 		t.Fatal("expected at least one DNS zone")
@@ -57,7 +60,10 @@ func TestBuildTapConfig_KeepsBuiltinZonesBeforeAllowNet(t *testing.T) {
 	config := testGvproxyConfig()
 	config.AllowNet = []string{"example.com"}
 
-	tapConfig := buildTapConfig(config, types.QemuProtocol)
+	tapConfig, err := buildTapConfig(config, types.QemuProtocol)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	if len(tapConfig.DNS) < 2 {
 		t.Fatalf("expected built-in and allowlist DNS zones, got %d", len(tapConfig.DNS))
@@ -72,7 +78,10 @@ func TestBuildTapConfig_KeepsBuiltinZonesBeforeAllowNet(t *testing.T) {
 }
 
 func TestBuildTapConfig_RoutesHostAliasToLoopback(t *testing.T) {
-	tapConfig := buildTapConfig(testGvproxyConfig(), types.QemuProtocol)
+	tapConfig, err := buildTapConfig(testGvproxyConfig(), types.QemuProtocol)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	if got := tapConfig.NAT["192.168.127.254"]; got != "127.0.0.1" {
 		t.Fatalf("expected host IP NAT to loopback, got %q", got)

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/dns_filter.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/dns_filter.go
@@ -7,25 +7,70 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"regexp"
+	"sort"
 	"strings"
+	"time"
 
 	"github.com/containers/gvisor-tap-vsock/pkg/types"
 	logrus "github.com/sirupsen/logrus"
 )
 
+// Tunables for allowlist DNS resolution. Each allow-listed hostname is
+// resolved against the host OS resolver at box-create time and the
+// resulting IPs are baked into the DNS sinkhole. A transient host-side
+// DNS hiccup (VPN flap, slow corp resolver, mDNSResponder churn) used to
+// silently drop the host's zone, leaving the VM permanently sinkholing
+// it to 0.0.0.0 for the life of the box. We now retry with backoff and
+// fail closed if every attempt fails.
+//
+// Exposed as `var` (not `const`) so tests can override timing without
+// slowing the suite. Production callers MUST treat them as immutable.
+const dnsLookupAttempts = 4
+
+var (
+	dnsLookupInitialBackoffVar = 100 * time.Millisecond
+	dnsLookupBackoffFactor     = 3
+	dnsLookupAttemptTimeoutVar = 2 * time.Second
+)
+
+// hostResolver is the interface buildAllowNetDNSZones uses to look up
+// allow-listed hostnames. The production implementation calls the host
+// OS resolver via net.Resolver. Tests inject a fake to exercise the
+// retry/backoff/fail-closed paths without depending on real DNS.
+type hostResolver interface {
+	LookupIPAddr(ctx context.Context, host string) ([]net.IPAddr, error)
+}
+
+// defaultResolver is the production resolver: PreferGo:false uses the
+// platform's getaddrinfo, which honors VPN/corp DNS configuration.
+var defaultResolver hostResolver = &net.Resolver{PreferGo: false}
+
 // buildAllowNetDNSZones creates DNS zones that implement allowlist filtering.
 //
 // Strategy:
-//   - For each allowed hostname: resolve to IPs, create a zone with A records
-//   - For wildcard patterns (*.example.com): create zone with Regexp records
-//   - Add catch-all root zone "" with DefaultIP 0.0.0.0 (sinkhole)
+//   - For each allowed hostname: resolve to IPs (with retry/backoff), create
+//     a zone with A records.
+//   - For wildcard patterns (*.example.com): create zone with Regexp records.
+//   - Add catch-all root zone "" with DefaultIP 0.0.0.0 (sinkhole).
 //
 // Zone matching is first-match-wins with suffix matching. Specific zones
 // are added before the root zone, so allowed hosts resolve normally while
 // everything else gets sinkholed.
-func buildAllowNetDNSZones(allowNet []string) []types.Zone {
+//
+// Fail-closed: if any allow-listed hostname cannot be resolved after all
+// retry attempts, this function returns an error instead of producing a
+// silently-incomplete sinkhole. The caller is expected to abort box
+// creation rather than ship a misconfigured network.
+func buildAllowNetDNSZones(allowNet []string) ([]types.Zone, error) {
+	return buildAllowNetDNSZonesWith(allowNet, defaultResolver)
+}
+
+// buildAllowNetDNSZonesWith is the testable form: same behavior as
+// buildAllowNetDNSZones, with an injectable resolver.
+func buildAllowNetDNSZonesWith(allowNet []string, resolver hostResolver) ([]types.Zone, error) {
 	zoneRecords := make(map[string][]types.Record)
 
 	for _, rule := range allowNet {
@@ -55,7 +100,9 @@ func buildAllowNetDNSZones(allowNet []string) []types.Zone {
 			zoneRecords[zoneName] = append(zoneRecords[zoneName], types.Record{
 				Regexp: regexp.MustCompile(".*"),
 			})
-			resolveAndAddRecords(domain, domain+".", zoneRecords)
+			if err := resolveAndAddRecords(resolver, domain, domain+".", zoneRecords); err != nil {
+				return nil, err
+			}
 			continue
 		}
 
@@ -63,14 +110,39 @@ func buildAllowNetDNSZones(allowNet []string) []types.Zone {
 		parts := strings.SplitN(host, ".", 2)
 		if len(parts) == 2 {
 			zoneName := parts[1] + "."
-			resolveAndAddRecords(host, zoneName, zoneRecords)
+			if err := resolveAndAddRecords(resolver, host, zoneName, zoneRecords); err != nil {
+				return nil, err
+			}
 		} else {
-			resolveAndAddRecords(host, host+".", zoneRecords)
+			if err := resolveAndAddRecords(resolver, host, host+".", zoneRecords); err != nil {
+				return nil, err
+			}
 		}
 	}
 
+	// Build the zone slice in deterministic, longest-name-first order.
+	//
+	// gvisor-tap-vsock's DNS handler is *first-match-wins on suffix*, with no
+	// most-specific-match preference. If we left `zoneRecords` in map-iteration
+	// order, an `iapi.merck.com` query could land on the `com.` zone (created
+	// because we allow-listed `github.com`) before the `merck.com.` zone, fall
+	// through to that zone's DefaultIP=0.0.0.0, and return a sinkhole answer —
+	// even though we *do* have a real record for it under a more specific zone.
+	//
+	// Sorting longest-name-first guarantees the most-specific suffix wins,
+	// which matches both standard DNS semantics and the behavior callers
+	// expect from an allow-list ("the host I named must resolve").
+	zoneNames := make([]string, 0, len(zoneRecords))
+	for zoneName := range zoneRecords {
+		zoneNames = append(zoneNames, zoneName)
+	}
+	sort.Slice(zoneNames, func(i, j int) bool {
+		return len(zoneNames[i]) > len(zoneNames[j])
+	})
+
 	var zones []types.Zone
-	for zoneName, records := range zoneRecords {
+	for _, zoneName := range zoneNames {
+		records := zoneRecords[zoneName]
 		zones = append(zones, types.Zone{
 			Name:      zoneName,
 			Records:   records,
@@ -93,37 +165,96 @@ func buildAllowNetDNSZones(allowNet []string) []types.Zone {
 		"total_zones": len(zones),
 	}).Info("allowNet: DNS sinkhole configured")
 
-	return zones
+	return zones, nil
 }
 
-// resolveAndAddRecords resolves a hostname and adds A records to the zone.
-func resolveAndAddRecords(hostname, zoneName string, zoneRecords map[string][]types.Record) {
-	ctx := context.Background()
-	resolver := &net.Resolver{PreferGo: false}
-	ips, err := resolver.LookupIPAddr(ctx, hostname)
+// resolveAndAddRecords resolves a hostname (with retry + per-attempt
+// timeout) and adds A records to the zone. Returns the final error if
+// every attempt fails so callers can fail closed.
+func resolveAndAddRecords(resolver hostResolver, hostname, zoneName string, zoneRecords map[string][]types.Record) error {
+	ips, err := lookupWithRetry(resolver, hostname)
 	if err != nil {
-		logrus.WithFields(logrus.Fields{
-			"hostname": hostname,
-			"error":    err,
-		}).Warn("allowNet: DNS resolution failed for allowed host")
-		return
+		return fmt.Errorf("allowNet: resolve %q: %w", hostname, err)
 	}
 
 	trimmed := strings.TrimSuffix(hostname+".", "."+zoneName)
 
+	v4Count := 0
+	v4Strs := make([]string, 0, len(ips))
 	for _, ip := range ips {
 		if ip.IP.To4() == nil {
 			continue // Skip IPv6 for now
 		}
+		v4Count++
+		v4Strs = append(v4Strs, ip.IP.String())
 		zoneRecords[zoneName] = append(zoneRecords[zoneName], types.Record{
 			Name: trimmed,
 			IP:   ip.IP.To4(),
 		})
-		logrus.WithFields(logrus.Fields{
-			"hostname": hostname,
-			"ip":       ip.IP,
-			"zone":     zoneName,
-			"label":    trimmed,
-		}).Debug("allowNet: resolved and added DNS record")
 	}
+
+	// One Info line per allow-listed host. Without this it's invisible
+	// whether a hostname's lookup succeeded but yielded only IPv6 (which
+	// we drop), which would silently sinkhole that host even though no
+	// retry/error fired. v4_count=0 is the smoking gun for that case.
+	logrus.WithFields(logrus.Fields{
+		"hostname": hostname,
+		"zone":     zoneName,
+		"label":    trimmed,
+		"v4_count": v4Count,
+		"v4_ips":   v4Strs,
+	}).Info("allowNet: host resolved")
+
+	return nil
+}
+
+// lookupWithRetry calls resolver.LookupIPAddr up to dnsLookupAttempts
+// times, with a per-attempt context timeout and exponential backoff
+// between attempts. Each attempt that returns at least one IP wins
+// immediately. Each attempt that returns an empty list with no error is
+// treated as a failure so we retry rather than bake an empty zone.
+func lookupWithRetry(resolver hostResolver, hostname string) ([]net.IPAddr, error) {
+	var (
+		ips     []net.IPAddr
+		lastErr error
+	)
+	backoff := dnsLookupInitialBackoffVar
+
+	for attempt := 1; attempt <= dnsLookupAttempts; attempt++ {
+		ctx, cancel := context.WithTimeout(context.Background(), dnsLookupAttemptTimeoutVar)
+		ips, lastErr = resolver.LookupIPAddr(ctx, hostname)
+		cancel()
+
+		if lastErr == nil && len(ips) > 0 {
+			if attempt > 1 {
+				logrus.WithFields(logrus.Fields{
+					"hostname": hostname,
+					"attempts": attempt,
+				}).Info("allowNet: DNS resolution succeeded after retry")
+			}
+			return ips, nil
+		}
+
+		if lastErr == nil {
+			lastErr = fmt.Errorf("no A records returned")
+		}
+
+		if attempt < dnsLookupAttempts {
+			logrus.WithFields(logrus.Fields{
+				"hostname":   hostname,
+				"attempt":    attempt,
+				"error":      lastErr,
+				"next_delay": backoff,
+			}).Warn("allowNet: DNS resolution failed, will retry")
+			time.Sleep(backoff)
+			backoff *= time.Duration(dnsLookupBackoffFactor)
+		}
+	}
+
+	logrus.WithFields(logrus.Fields{
+		"hostname": hostname,
+		"attempts": dnsLookupAttempts,
+		"error":    lastErr,
+	}).Error("allowNet: DNS resolution failed after retries")
+	return nil, lastErr
 }

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/dns_filter_test.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/dns_filter_test.go
@@ -8,6 +8,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/containers/gvisor-tap-vsock/pkg/types"
 )
 
 func TestBuildAllowNetDNSZones(t *testing.T) {
@@ -65,14 +67,22 @@ func TestBuildAllowNetDNSZones_PerTLDZonesHaveSinkholeDefaultIP(t *testing.T) {
 //
 // Sorting zones longest-name-first guarantees the most-specific suffix
 // matches first.
+//
+// NOTE: uses fixedIPResolver (not real DNS) so the test is hermetic.
+// The original version that called the real resolver via
+// buildAllowNetDNSZones() died with NXDOMAIN whenever the test runner
+// had no view of internal corp DNS (which is every CI machine on the
+// public internet) — the test then failed for the WRONG reason and
+// never exercised the sort logic it was meant to pin.
 func TestBuildAllowNetDNSZones_LongestSuffixWinsBeforeRoot(t *testing.T) {
-	zones, err := buildAllowNetDNSZones([]string{
+	res := &fixedIPResolver{ip: net.IPv4(1, 2, 3, 4)}
+	zones, err := buildAllowNetDNSZonesWith([]string{
 		"github.com",
 		"api.github.com",
 		"raw.githubusercontent.com",
 		"codeload.github.com",
 		"iapi.merck.com",
-	})
+	}, res)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -108,6 +118,52 @@ func TestBuildAllowNetDNSZones_LongestSuffixWinsBeforeRoot(t *testing.T) {
 	if zones[len(zones)-1].Name != "" {
 		t.Errorf("expected root sinkhole zone last, got %q", zones[len(zones)-1].Name)
 	}
+}
+
+// TestBuildAllowNetDNSZones_CatchAllRootZoneAlwaysLast pins the
+// invariant the body of dns_filter.go states but never asserted:
+// "Catch-all root zone: sinkhole everything not explicitly allowed"
+// must be appended *after* every per-suffix zone, regardless of how
+// long or short the explicit allow-list is. Without this, gvisor's
+// first-match-wins matcher could let the empty zone hijack a query
+// before reaching the merck.com / github.com per-suffix zone.
+func TestBuildAllowNetDNSZones_CatchAllRootZoneAlwaysLast(t *testing.T) {
+	res := &fixedIPResolver{ip: net.IPv4(1, 2, 3, 4)}
+
+	for _, hosts := range [][]string{
+		{"example.com"},
+		{"a.b.c.example.com"},
+		{"x.com", "y.org", "z.net", "very.deep.subdomain.example.io"},
+		{},
+	} {
+		t.Run(fmt.Sprintf("%d_hosts", len(hosts)), func(t *testing.T) {
+			zones, err := buildAllowNetDNSZonesWith(hosts, res)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(zones) == 0 {
+				t.Fatal("expected at least the root catch-all zone")
+			}
+			last := zones[len(zones)-1]
+			if last.Name != "" {
+				t.Errorf("last zone must be root catch-all (Name==\"\"), got %q at index %d/%d",
+					last.Name, len(zones)-1, len(zones))
+			}
+			if !last.DefaultIP.Equal(net.IPv4(0, 0, 0, 0)) {
+				t.Errorf("catch-all DefaultIP must be 0.0.0.0 (sinkhole), got %v", last.DefaultIP)
+			}
+		})
+	}
+}
+
+// fixedIPResolver returns the same IP for every lookup. Useful for
+// tests that care about ordering / structure rather than resolution
+// content. Keeps the suite hermetic — no dependency on real DNS,
+// network reachability, or specific corporate domains.
+type fixedIPResolver struct{ ip net.IP }
+
+func (f *fixedIPResolver) LookupIPAddr(_ context.Context, _ string) ([]net.IPAddr, error) {
+	return []net.IPAddr{{IP: f.ip}}, nil
 }
 
 func TestBuildAllowNetDNSZones_EmptyList(t *testing.T) {
@@ -329,4 +385,168 @@ func indexOf(s, sub string) int {
 		}
 	}
 	return -1
+}
+
+// ─── End-to-end propagation through buildTapConfig ───────────────────────
+//
+// The PR body promises the fix "propagates resolver errors through
+// buildAllowNetDNSZones → buildTapConfig → gvproxy_create". The
+// resolver-level tests above cover the first leg; the tests here cover
+// the second leg (buildAllowNetDNSZones → buildTapConfig). We can't
+// exercise gvproxy_create directly from Go tests because it's a cgo
+// //export function that requires a real Unix-socket path and an
+// actual VM transport; the leg from buildTapConfig to gvproxy_create
+// is a straight `if err != nil { return -1; setErr(err); }` block at
+// main.go:418 — pinned implicitly by both buildTapConfig returning the
+// error and the gvproxy_create_latency_test.go init-error coverage.
+//
+// Strategy: drive buildTapConfig with an allow_net entry that the
+// system resolver is guaranteed to refuse (RFC 6761 reserved `.invalid`
+// TLD always NXDOMAINs), override dnsLookupAttemptTimeoutVar /
+// dnsLookupInitialBackoffVar to keep the test fast, observe that the
+// error reaches the caller AND no half-baked config is returned.
+
+// TestBuildTapConfig_DNSResolutionFailure_PropagatesErrorNotSilentConfig
+// is the end-to-end fail-closed guard: a single bad allow_net host
+// must cause buildTapConfig to surface the error (not return a
+// "looks-fine" *types.Configuration with allow_zones=N-1 total_zones=N).
+//
+// Pre-fix (silent half-baked) behavior — what production reported:
+//   gvproxy log line:  allow_zones=0 total_zones=1
+//   box.create result: SUCCESS
+//   guest behavior:    getent hosts allowed.host → 0.0.0.0
+//
+// Post-fix: buildTapConfig returns (nil, err) and the caller refuses to
+// continue.
+func TestBuildTapConfig_DNSResolutionFailure_PropagatesErrorNotSilentConfig(t *testing.T) {
+	origTimeout := dnsLookupAttemptTimeoutVar
+	origBackoff := dnsLookupInitialBackoffVar
+	t.Cleanup(func() {
+		dnsLookupAttemptTimeoutVar = origTimeout
+		dnsLookupInitialBackoffVar = origBackoff
+	})
+	dnsLookupAttemptTimeoutVar = 200 * time.Millisecond
+	dnsLookupInitialBackoffVar = 1 * time.Millisecond
+
+	cfg := testGvproxyConfig()
+	// RFC 6761 reserves `.invalid` — every conforming resolver MUST
+	// return NXDOMAIN. Both glibc and systemd-resolved enforce it.
+	cfg.AllowNet = []string{"nonexistent-pin-545-d8ac1b2.invalid"}
+
+	tapCfg, err := buildTapConfig(cfg, types.QemuProtocol)
+
+	if err == nil {
+		t.Fatalf(
+			"expected error from buildTapConfig when allow_net host doesn't resolve; "+
+				"got nil err and tapCfg=%+v — this is the silent half-baked sinkhole the fix should prevent",
+			tapCfg,
+		)
+	}
+	if tapCfg != nil {
+		t.Errorf(
+			"expected nil tapCfg on DNS failure (caller must refuse to continue); got %+v",
+			tapCfg,
+		)
+	}
+	// Error must name the failing host so operators can act on the message.
+	if !contains(err.Error(), "nonexistent-pin-545-d8ac1b2.invalid") {
+		t.Errorf("error should name the failing host; got: %v", err)
+	}
+}
+
+// TestBuildTapConfig_NoAllowNet_HappyPath_NoDNSLookup is the negative
+// control for the test above: when allow_net is empty, buildTapConfig
+// must NOT do any DNS lookups (no slow path even when host DNS is
+// broken) and must return a usable config. Pins that the retry +
+// fail-closed machinery only kicks in when allow_net is actually used.
+func TestBuildTapConfig_NoAllowNet_HappyPath_NoDNSLookup(t *testing.T) {
+	// Make any accidental real-DNS attempt fail loudly + slowly so a
+	// regression that calls the resolver on the no-allow_net path
+	// surfaces as a test timeout rather than passing silently.
+	origTimeout := dnsLookupAttemptTimeoutVar
+	t.Cleanup(func() { dnsLookupAttemptTimeoutVar = origTimeout })
+	dnsLookupAttemptTimeoutVar = 50 * time.Millisecond
+
+	cfg := testGvproxyConfig()
+	cfg.AllowNet = nil // explicit: no DNS resolution should occur
+
+	start := time.Now()
+	tapCfg, err := buildTapConfig(cfg, types.QemuProtocol)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("unexpected error on no-allow_net path: %v", err)
+	}
+	if tapCfg == nil {
+		t.Fatal("expected a valid *types.Configuration, got nil")
+	}
+	// Should be near-instant — only the in-process DNSZones static config.
+	// Anything > 50ms suggests a resolver call slipped in.
+	if elapsed > 50*time.Millisecond {
+		t.Errorf("no-allow_net build took %v; expected near-instant — did a DNS lookup leak in?", elapsed)
+	}
+	// The hard-coded DNSZones from testGvproxyConfig must be present.
+	if len(tapCfg.DNS) == 0 {
+		t.Fatal("expected at least the hard-coded boxlite.internal. zone")
+	}
+}
+
+// TestBuildTapConfig_ProductionSymptomReproducer is the exact wire-level
+// reproducer of the symptom users reported: "box.create returns SUCCESS
+// but allow_zones=N-1 total_zones=N in the gvproxy log, and the guest
+// later sees getent hosts <allowed> → 0.0.0.0". Constructs the failure
+// shape — N hosts in allow_net, one of them unresolvable — and asserts:
+//   (a) Pre-fix path: would produce a config with len(DNS)=N (= silent
+//       failure). Post-fix: returns error + nil config.
+//   (b) Error message identifies WHICH host failed (so the operator can
+//       fix their typo / DNS setup, not have to read gvproxy debug logs).
+func TestBuildTapConfig_ProductionSymptomReproducer(t *testing.T) {
+	origTimeout := dnsLookupAttemptTimeoutVar
+	origBackoff := dnsLookupInitialBackoffVar
+	t.Cleanup(func() {
+		dnsLookupAttemptTimeoutVar = origTimeout
+		dnsLookupInitialBackoffVar = origBackoff
+	})
+	dnsLookupAttemptTimeoutVar = 200 * time.Millisecond
+	dnsLookupInitialBackoffVar = 1 * time.Millisecond
+
+	cfg := testGvproxyConfig()
+	// 3 hosts: 2 resolvable (mock via example.com — RFC 2606), 1 reserved-NXDOMAIN.
+	// example.com & www.example.com are IANA-managed and ALWAYS resolve.
+	cfg.AllowNet = []string{
+		"example.com",
+		"www.example.com",
+		"pin-545-d8ac1b2.invalid", // RFC 6761 — guaranteed NXDOMAIN
+	}
+
+	tapCfg, err := buildTapConfig(cfg, types.QemuProtocol)
+
+	// Verdict assertions
+	if err == nil {
+		// The exact "production silent half-baked sinkhole" shape — pin it.
+		var allowZones, totalZones int
+		if tapCfg != nil {
+			totalZones = len(tapCfg.DNS)
+			for _, z := range tapCfg.DNS {
+				if z.Name != "" {
+					allowZones++
+				}
+			}
+		}
+		t.Fatalf(
+			"REGRESSION — fix gone: buildTapConfig returned a silent half-baked config "+
+				"with allow_zones=%d total_zones=%d while one allow_net host failed to resolve. "+
+				"This is the exact symptom users reported.",
+			allowZones, totalZones,
+		)
+	}
+	if tapCfg != nil {
+		t.Errorf("expected nil tapCfg on failure (caller must abort); got %+v", tapCfg)
+	}
+	if !contains(err.Error(), "pin-545-d8ac1b2.invalid") {
+		t.Errorf(
+			"error must identify the failing host (operator-debuggable); got: %v",
+			err,
+		)
+	}
 }

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/dns_filter_test.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/dns_filter_test.go
@@ -1,16 +1,24 @@
 package main
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"net"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestBuildAllowNetDNSZones(t *testing.T) {
-	zones := buildAllowNetDNSZones([]string{
+	zones, err := buildAllowNetDNSZones([]string{
 		"api.openai.com",
 		"*.anthropic.com",
 		"192.168.1.1", // IP — skipped (DNS only handles hostnames)
 	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	if len(zones) < 2 {
 		t.Errorf("expected at least 2 zones, got %d", len(zones))
@@ -27,7 +35,10 @@ func TestBuildAllowNetDNSZones(t *testing.T) {
 }
 
 func TestBuildAllowNetDNSZones_PerTLDZonesHaveSinkholeDefaultIP(t *testing.T) {
-	zones := buildAllowNetDNSZones([]string{"example.com"})
+	zones, err := buildAllowNetDNSZones([]string{"example.com"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	// Should have 2 zones: "com." (per-TLD) + "" (root catch-all)
 	if len(zones) != 2 {
@@ -43,8 +54,67 @@ func TestBuildAllowNetDNSZones_PerTLDZonesHaveSinkholeDefaultIP(t *testing.T) {
 	}
 }
 
+// TestBuildAllowNetDNSZones_LongestSuffixWinsBeforeRoot pins the bug fix
+// where an `iapi.merck.com` query was sometimes answered with `0.0.0.0`
+// even though the host had been allow-listed. Root cause: gvisor-tap-vsock
+// matches zones with first-suffix-wins (no most-specific preference), and
+// our zones used to be emitted in Go map-iteration order, so a `com.`
+// zone (created because `github.com` was allow-listed) could win the
+// match for `iapi.merck.com.` and serve its DefaultIP=0.0.0.0 even
+// though a `merck.com.` zone with the right record also existed.
+//
+// Sorting zones longest-name-first guarantees the most-specific suffix
+// matches first.
+func TestBuildAllowNetDNSZones_LongestSuffixWinsBeforeRoot(t *testing.T) {
+	zones, err := buildAllowNetDNSZones([]string{
+		"github.com",
+		"api.github.com",
+		"raw.githubusercontent.com",
+		"codeload.github.com",
+		"iapi.merck.com",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Walk zones in returned order; index of each zone name in the slice.
+	indexOf := make(map[string]int, len(zones))
+	for i, z := range zones {
+		indexOf[z.Name] = i
+	}
+
+	// Sanity: all the expected zones are present (one per distinct DNS suffix).
+	for _, name := range []string{"github.com.", "githubusercontent.com.", "merck.com.", "com."} {
+		if _, ok := indexOf[name]; !ok {
+			t.Fatalf("expected zone %q in result, got zones %v", name, indexOf)
+		}
+	}
+
+	// merck.com. (10 chars) MUST come before com. (4 chars) so an
+	// `iapi.merck.com.` query hits the merck.com. zone first.
+	if indexOf["merck.com."] >= indexOf["com."] {
+		t.Errorf("merck.com. (idx=%d) must precede com. (idx=%d) — first-match-wins matcher would otherwise sinkhole iapi.merck.com",
+			indexOf["merck.com."], indexOf["com."])
+	}
+	// github.com. (11) MUST come before com. for the same reason
+	if indexOf["github.com."] >= indexOf["com."] {
+		t.Errorf("github.com. must precede com.")
+	}
+	// githubusercontent.com. (22) MUST come before com.
+	if indexOf["githubusercontent.com."] >= indexOf["com."] {
+		t.Errorf("githubusercontent.com. must precede com.")
+	}
+	// And the catch-all root zone "" must always be last.
+	if zones[len(zones)-1].Name != "" {
+		t.Errorf("expected root sinkhole zone last, got %q", zones[len(zones)-1].Name)
+	}
+}
+
 func TestBuildAllowNetDNSZones_EmptyList(t *testing.T) {
-	zones := buildAllowNetDNSZones([]string{})
+	zones, err := buildAllowNetDNSZones([]string{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	if len(zones) != 1 {
 		t.Errorf("expected 1 zone (root only), got %d", len(zones))
@@ -52,4 +122,211 @@ func TestBuildAllowNetDNSZones_EmptyList(t *testing.T) {
 	if zones[0].Name != "" {
 		t.Errorf("single zone should be root, got %q", zones[0].Name)
 	}
+}
+
+// --- Test doubles for the resolver ----------------------------------------
+
+// flakyResolver fails the first failBefore attempts per hostname, then
+// succeeds with a fixed IP. Used to simulate a brief host-DNS hiccup
+// during box.create (VPN flap, slow corp resolver, mDNSResponder churn).
+type flakyResolver struct {
+	failBefore  int                    // fail this many calls per host before succeeding
+	calls       map[string]*int32      // per-host call counter
+	failWith    error                  // error returned during the failing window
+	successIPs  map[string][]net.IPAddr // per-host IPs returned on success (defaults to 1.2.3.4)
+	attemptHook func(host string, n int32, ctx context.Context)
+}
+
+func newFlakyResolver(failBefore int, failWith error) *flakyResolver {
+	return &flakyResolver{
+		failBefore: failBefore,
+		calls:      make(map[string]*int32),
+		failWith:   failWith,
+		successIPs: make(map[string][]net.IPAddr),
+	}
+}
+
+func (f *flakyResolver) LookupIPAddr(ctx context.Context, host string) ([]net.IPAddr, error) {
+	counter, ok := f.calls[host]
+	if !ok {
+		counter = new(int32)
+		f.calls[host] = counter
+	}
+	n := atomic.AddInt32(counter, 1)
+	if f.attemptHook != nil {
+		f.attemptHook(host, n, ctx)
+	}
+	if int(n) <= f.failBefore {
+		return nil, f.failWith
+	}
+	if ips, ok := f.successIPs[host]; ok {
+		return ips, nil
+	}
+	return []net.IPAddr{{IP: net.IPv4(1, 2, 3, 4)}}, nil
+}
+
+func (f *flakyResolver) callsFor(host string) int {
+	if c, ok := f.calls[host]; ok {
+		return int(atomic.LoadInt32(c))
+	}
+	return 0
+}
+
+// alwaysFailResolver returns the configured error for every lookup.
+type alwaysFailResolver struct {
+	err   error
+	calls int32
+}
+
+func (r *alwaysFailResolver) LookupIPAddr(_ context.Context, _ string) ([]net.IPAddr, error) {
+	atomic.AddInt32(&r.calls, 1)
+	return nil, r.err
+}
+
+// hangingResolver blocks until ctx is cancelled, then returns ctx.Err().
+// Used to verify the per-attempt timeout actually fires.
+type hangingResolver struct {
+	calls int32
+}
+
+func (h *hangingResolver) LookupIPAddr(ctx context.Context, _ string) ([]net.IPAddr, error) {
+	atomic.AddInt32(&h.calls, 1)
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+// --- Reproducer + behavior tests ------------------------------------------
+
+// TestBuildAllowNetDNSZones_RetriesTransientResolverFailure is the
+// reproducer for the intermittent "0.0.0.0 for an allow-listed host"
+// bug. With the old single-shot lookup the first failure dropped the
+// zone permanently; with retry we recover and bake the host's records.
+func TestBuildAllowNetDNSZones_RetriesTransientResolverFailure(t *testing.T) {
+	res := newFlakyResolver(2, errors.New("simulated transient DNS error"))
+
+	zones, err := buildAllowNetDNSZonesWith([]string{"iapi.example.com"}, res)
+	if err != nil {
+		t.Fatalf("expected retry to recover, got error: %v", err)
+	}
+
+	if got := res.callsFor("iapi.example.com"); got != 3 {
+		t.Errorf("expected 3 lookup attempts (2 fail + 1 success), got %d", got)
+	}
+
+	// Confirm the host got an A record — no silent zone drop.
+	found := false
+	for _, z := range zones {
+		for _, r := range z.Records {
+			if r.IP != nil && r.IP.Equal(net.IPv4(1, 2, 3, 4)) {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("expected iapi.example.com record in zones, got %+v", zones)
+	}
+}
+
+// TestBuildAllowNetDNSZones_FailsClosedAfterRetries is the second half
+// of the contract: when retries are exhausted, return an error so
+// box.create aborts loudly instead of producing a half-baked sinkhole.
+func TestBuildAllowNetDNSZones_FailsClosedAfterRetries(t *testing.T) {
+	res := &alwaysFailResolver{err: errors.New("DNS server unreachable")}
+
+	_, err := buildAllowNetDNSZonesWith([]string{"iapi.example.com"}, res)
+	if err == nil {
+		t.Fatal("expected error when every retry attempt fails, got nil")
+	}
+	if got := atomic.LoadInt32(&res.calls); int(got) != dnsLookupAttempts {
+		t.Errorf("expected %d attempts, got %d", dnsLookupAttempts, got)
+	}
+}
+
+// TestBuildAllowNetDNSZones_HonorsPerAttemptTimeout pins down the
+// per-attempt context timeout: a hanging resolver must be cancelled per
+// attempt (not just after the entire retry loop). We can't measure the
+// exact 2s without slowing the suite, so we override it for the test.
+func TestBuildAllowNetDNSZones_HonorsPerAttemptTimeout(t *testing.T) {
+	origTimeout := dnsLookupAttemptTimeoutVar
+	origBackoff := dnsLookupInitialBackoffVar
+	t.Cleanup(func() {
+		dnsLookupAttemptTimeoutVar = origTimeout
+		dnsLookupInitialBackoffVar = origBackoff
+	})
+	dnsLookupAttemptTimeoutVar = 30 * time.Millisecond
+	dnsLookupInitialBackoffVar = 1 * time.Millisecond
+
+	res := &hangingResolver{}
+	start := time.Now()
+	_, err := buildAllowNetDNSZonesWith([]string{"slow.example.com"}, res)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	// Each attempt must terminate at the per-attempt timeout, not hang
+	// forever; total time should be roughly attempts * timeout, not
+	// unbounded. Generous upper bound to avoid flakes on slow CI.
+	maxExpected := time.Duration(dnsLookupAttempts) * dnsLookupAttemptTimeoutVar * 4
+	if elapsed > maxExpected {
+		t.Errorf("retry loop took %v; expected <= %v (per-attempt timeout not honored?)", elapsed, maxExpected)
+	}
+	if got := atomic.LoadInt32(&res.calls); int(got) != dnsLookupAttempts {
+		t.Errorf("expected %d attempts, got %d", dnsLookupAttempts, got)
+	}
+}
+
+// TestBuildAllowNetDNSZones_PerHostFailureFailsAggregate makes sure
+// that one bad host in a multi-host allow-list aborts the whole build.
+// Previously the sinkhole would silently come up with allow_zones=N-1
+// total_zones=N — exactly the symptom reported from production.
+func TestBuildAllowNetDNSZones_PerHostFailureFailsAggregate(t *testing.T) {
+	good := []net.IPAddr{{IP: net.IPv4(8, 8, 8, 8)}}
+	res := &mixedResolver{
+		good: map[string][]net.IPAddr{"github.com": good, "api.github.com": good},
+		bad:  map[string]error{"iapi.example.com": errors.New("permafail")},
+	}
+
+	_, err := buildAllowNetDNSZonesWith(
+		[]string{"github.com", "api.github.com", "iapi.example.com"},
+		res,
+	)
+	if err == nil {
+		t.Fatal("expected aggregate error when one host fails to resolve, got nil")
+	}
+	want := "iapi.example.com"
+	if !contains(err.Error(), want) {
+		t.Errorf("error %q should mention failing host %q", err.Error(), want)
+	}
+}
+
+// mixedResolver returns canned IPs for some hosts and canned errors
+// for others, with no retry-flakiness — every call has a deterministic
+// outcome based on the host.
+type mixedResolver struct {
+	good map[string][]net.IPAddr
+	bad  map[string]error
+}
+
+func (m *mixedResolver) LookupIPAddr(_ context.Context, host string) ([]net.IPAddr, error) {
+	if err, ok := m.bad[host]; ok {
+		return nil, err
+	}
+	if ips, ok := m.good[host]; ok {
+		return ips, nil
+	}
+	return nil, fmt.Errorf("no test data for %q", host)
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || (len(sub) > 0 && indexOf(s, sub) >= 0))
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
 }

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/gvproxy_create_latency_test.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/gvproxy_create_latency_test.go
@@ -28,15 +28,24 @@ func TestVirtualNetworkNewWithinLatencyBudget(t *testing.T) {
 
 	// Warm up once: the first construction pays one-time lazy-init costs
 	// that are not representative of the steady-state per-box cost.
-	if vn, err := virtualnetwork.New(buildTapConfig(testGvproxyConfig(), types.QemuProtocol)); err != nil {
-		t.Fatalf("warmup virtualnetwork.New failed: %v", err)
-	} else {
-		_ = vn
+	{
+		cfg, err := buildTapConfig(testGvproxyConfig(), types.QemuProtocol)
+		if err != nil {
+			t.Fatalf("warmup buildTapConfig failed: %v", err)
+		}
+		if vn, err := virtualnetwork.New(cfg); err != nil {
+			t.Fatalf("warmup virtualnetwork.New failed: %v", err)
+		} else {
+			_ = vn
+		}
 	}
 
 	samples := make([]time.Duration, 0, iters)
 	for i := 0; i < iters; i++ {
-		cfg := buildTapConfig(testGvproxyConfig(), types.QemuProtocol)
+		cfg, err := buildTapConfig(testGvproxyConfig(), types.QemuProtocol)
+		if err != nil {
+			t.Fatalf("iter %d: buildTapConfig failed: %v", i, err)
+		}
 		start := time.Now()
 		vn, err := virtualnetwork.New(cfg)
 		elapsed := time.Since(start)

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/main.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/main.go
@@ -214,7 +214,7 @@ type GvproxyInstance struct {
 	secretMatcher *SecretHostMatcher             // Hostname→secrets lookup (nil if no secrets)
 }
 
-func buildDNSZones(config GvproxyConfig) []types.Zone {
+func buildDNSZones(config GvproxyConfig) ([]types.Zone, error) {
 	dnsZones := make([]types.Zone, 0, len(config.DNSZones)+1)
 	for _, zone := range config.DNSZones {
 		dnsZone := types.Zone{
@@ -231,15 +231,18 @@ func buildDNSZones(config GvproxyConfig) []types.Zone {
 	}
 
 	if len(config.AllowNet) > 0 {
-		allowNetZones := buildAllowNetDNSZones(config.AllowNet)
+		allowNetZones, err := buildAllowNetDNSZones(config.AllowNet)
+		if err != nil {
+			return nil, err
+		}
 		dnsZones = append(dnsZones, allowNetZones...)
 		logrus.WithField("rules", len(config.AllowNet)).Info("Network allowlist enabled (DNS sinkhole)")
 	}
 
-	return dnsZones
+	return dnsZones, nil
 }
 
-func buildTapConfig(config GvproxyConfig, protocol types.Protocol) *types.Configuration {
+func buildTapConfig(config GvproxyConfig, protocol types.Protocol) (*types.Configuration, error) {
 	nat := make(map[string]string)
 	gatewayVirtualIPs := []string{config.GatewayIP}
 	if config.HostIP != "" {
@@ -247,6 +250,11 @@ func buildTapConfig(config GvproxyConfig, protocol types.Protocol) *types.Config
 		if config.HostIP != config.GatewayIP {
 			gatewayVirtualIPs = append(gatewayVirtualIPs, config.HostIP)
 		}
+	}
+
+	dnsZones, err := buildDNSZones(config)
+	if err != nil {
+		return nil, err
 	}
 
 	return &types.Configuration{
@@ -262,10 +270,10 @@ func buildTapConfig(config GvproxyConfig, protocol types.Protocol) *types.Config
 		NAT:               nat,
 		GatewayVirtualIPs: gatewayVirtualIPs,
 		Protocol:          protocol,
-		DNS:               buildDNSZones(config),
+		DNS:               dnsZones,
 		DNSSearchDomains:  config.DNSSearchDomains,
 		CaptureFile:       "",
-	}
+	}, nil
 }
 
 var (
@@ -274,12 +282,61 @@ var (
 	nextID      int64 = 1
 )
 
+// bridgeBuildID is a hand-bumped tag that identifies the gvproxy-bridge
+// source tree this binary was built from. Bump it whenever you change
+// behavior you need to observe in the field — it's the cheapest way to
+// confirm `make runtime:debug` actually produced a fresh shim and that
+// the running boxlite-shim is loading *this* code rather than a cached
+// older build.
+//
+// Why a hand-bumped tag and not just `vcs.revision`?
+//   - `vcs.revision` from BuildInfo only reflects committed state; if
+//     you're iterating with uncommitted changes, two different
+//     in-progress versions will share the same SHA.
+//   - It also goes "dirty" once you have any local edits, which hides
+//     which behavior you actually shipped.
+// Bumping a constant is a deliberate "I changed something worth
+// distinguishing" signal that survives both situations.
+const bridgeBuildID = "gvproxy-bridge:allownet-dns-resilience-2026-06"
+
+// logBridgeBuildOnce prints the build identity exactly once per shim
+// process, the first time gvproxy_create runs. We deliberately do NOT
+// log this from package init() because logrus may not be configured
+// yet at that point (the Rust caller redirects logrus output to its own
+// log destination during shim startup, after init runs).
+var logBridgeBuildOnce sync.Once
+
+func logBridgeBuild() {
+	logBridgeBuildOnce.Do(func() {
+		fields := logrus.Fields{
+			"build_id":  bridgeBuildID,
+			"go_module": "github.com/boxlite/gvproxy-bridge",
+		}
+		if info, ok := debug.ReadBuildInfo(); ok {
+			for _, s := range info.Settings {
+				switch s.Key {
+				case "vcs.revision":
+					fields["vcs_revision"] = s.Value
+				case "vcs.modified":
+					fields["vcs_modified"] = s.Value
+				case "vcs.time":
+					fields["vcs_time"] = s.Value
+				}
+			}
+			fields["go_version"] = info.GoVersion
+		}
+		logrus.WithFields(fields).Info("gvproxy-bridge: build identity")
+	})
+}
+
 //export gvproxy_create
 //
 // On failure (return -1), the underlying error message is written to `*errOut`
 // as a heap-allocated C string. Caller must free it via gvproxy_free_string.
 // `errOut` may be nil if the caller doesn't want the message.
 func gvproxy_create(configJSON *C.char, errOut **C.char) C.longlong {
+	logBridgeBuild()
+
 	// setErr surfaces the underlying error back to the FFI caller so the
 	// Rust runtime can include it in the user-visible BoxliteError message
 	// (e.g. "listen tcp 0.0.0.0:27380: bind: address already in use" instead
@@ -325,8 +382,16 @@ func gvproxy_create(configJSON *C.char, errOut **C.char) C.longlong {
 		protocol = types.QemuProtocol
 	}
 
-	// Create gvisor-tap-vsock configuration from provided config
-	tapConfig := buildTapConfig(config, protocol)
+	// Create gvisor-tap-vsock configuration from provided config.
+	// Fails closed if any allow-listed hostname can't be resolved on the
+	// host (after retries) — better to fail box.create than ship a
+	// silently-incomplete DNS sinkhole.
+	tapConfig, err := buildTapConfig(config, protocol)
+	if err != nil {
+		logrus.WithError(err).Error("Failed to build gvproxy tap config")
+		setErr(err)
+		return -1
+	}
 
 	// Set CaptureFile if provided
 	if config.CaptureFile != nil && *config.CaptureFile != "" {
@@ -349,7 +414,6 @@ func gvproxy_create(configJSON *C.char, errOut **C.char) C.longlong {
 	// Platform-specific socket creation
 	var conn net.Conn
 	var listener net.Listener
-	var err error
 
 	if runtime.GOOS == "darwin" {
 		// macOS: Use UnixDgram with VFKit protocol (SOCK_DGRAM)


### PR DESCRIPTION
Paired with #645 — adds the test coverage audit flagged as missing on that PR (PR slot `feat/runtime-guard-and-df` reused per request; original disk-guard content superseded by #647).

## Two-sided verification

Toggled each of the 3 fixes in `dns_filter.go` and observed the corresponding new test flip red → green:

| toggle (revert the fix) | which test goes red | red message |
|---|---|---|
| `sort.Slice(... > ...)` → `<` (shortest-first instead of longest-first) | `LongestSuffixWinsBeforeRoot` | `github.com. must precede com.` |
| `return nil, lastErr` → `return nil, nil` in `lookupWithRetry` (silent failure on exhausted retries) | `ProductionSymptomReproducer` | `REGRESSION — fix gone: buildTapConfig returned a silent half-baked config with allow_zones=3 total_zones=4 while one allow_net host failed to resolve. This is the exact symptom users reported.` |
| Catch-all root zone `append(zones, ...)` → prepend (move sinkhole to front) | `CatchAllRootZoneAlwaysLast` (3/4 sub-tests; `0_hosts` stays green because there's no other zone to displace it) | `last zone must be root catch-all (Name==""), got "net." at index 4/5` |

Each toggle was applied in isolation, the affected test was run, the message above captured, then the file restored and the full suite re-run to confirm all 14 tests green again. This is the verification mode #645 itself didn't have — its tests asserted invariants but none was confirmed to flip red when the corresponding production line is removed.

## Test plan

```sh
cd src/deps/libgvproxy-sys/gvproxy-bridge
go test -run 'TestBuildAllowNetDNSZones_|TestBuildTapConfig_' -v -timeout 60s
```

All 14 tests green. The 4 original tests from #645 are unchanged.

## What's added (brief)

- `LongestSuffixWinsBeforeRoot` rewritten to use `fixedIPResolver` instead of calling the real system resolver against `iapi.merck.com` (Merck-internal — NXDOMAINs on every public CI host, so the test was failing for the wrong reason and never exercised the sort logic).
- `CatchAllRootZoneAlwaysLast` (sub-tests 0/1/4 hosts) — pins the invariant the source comments state but no test asserted.
- `BuildTapConfig_DNSResolutionFailure_PropagatesErrorNotSilentConfig` — end-to-end through `buildAllowNetDNSZones → buildTapConfig` with an RFC 6761 `.invalid` host.
- `BuildTapConfig_NoAllowNet_HappyPath_NoDNSLookup` — negative control with 50ms upper-bound timer.
- `BuildTapConfig_ProductionSymptomReproducer` — operator-shaped reproducer, message names the exact `allow_zones=N-1 total_zones=N` shape.

Delta: `dns_filter_test.go` +222 / -2. One small mock helper (`fixedIPResolver`, ~5 lines).

## Out of scope

- True FFI-level e2e through `gvproxy_create` (cgo `//export`, needs socket + VM stub).
- Rust-side `box.create` integration test.
- The 4 other silent goroutines in `main.go` (`OverrideTCPHandler`, VFKit/Qemu `Accept`, protocol handlers) — same shape as #612's race, separate PR worth of work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)