### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/examples/python/06_ai_agents/README.md
+++ b/examples/python/06_ai_agents/README.md
@@ -5,7 +5,7 @@ Using BoxLite as a sandbox for AI agent workflows.
 | File | Description |
 |------|-------------|
 | `drive_box_with_llm.py` | Let an LLM drive a SimpleBox via tool-use loop (OpenAI) |
-| `drive_box_with_minimax.py` | Let MiniMax M2.7 drive a SimpleBox via tool-use loop |
+| `drive_box_with_minimax.py` | Let MiniMax M3 drive a SimpleBox via tool-use loop |
 | `use_skillbox.py` | Run Claude Code CLI with skills inside a box |
 | `chat_with_claude.py` | Multi-turn Claude conversation via stdin JSON protocol |
 | `order_starbucks.py` | End-to-end agent: order Starbucks via browser automation |
@@ -19,4 +19,4 @@ Most examples require `CLAUDE_CODE_OAUTH_TOKEN` to be set.
 
 BoxLite works with any LLM provider to create secure sandboxed environments for AI agents.
 The examples in this directory include ready-to-run integrations for
-OpenAI and [MiniMax](https://platform.minimax.io) (`MiniMax-M2.7`, `MiniMax-M2.7-highspeed`, `MiniMax-M2.5`, `MiniMax-M2.5-highspeed`).
+OpenAI and [MiniMax](https://platform.minimax.io) (`MiniMax-M3`, `MiniMax-M2.7`, `MiniMax-M2.7-highspeed`).

--- a/examples/python/06_ai_agents/drive_box_with_minimax.py
+++ b/examples/python/06_ai_agents/drive_box_with_minimax.py
@@ -12,10 +12,9 @@ MiniMax uses an OpenAI-compatible API, so we reuse the openai SDK
 with a custom base_url pointing to MiniMax's endpoint.
 
 Supported models:
-- MiniMax-M2.7              (default) — Latest flagship with enhanced reasoning and coding.
+- MiniMax-M3                (default) — Latest flagship with enhanced reasoning and coding.
+- MiniMax-M2.7                       — Previous flagship model.
 - MiniMax-M2.7-highspeed             — High-speed version of M2.7 for low-latency scenarios.
-- MiniMax-M2.5                       — Previous flagship model.
-- MiniMax-M2.5-highspeed             — High-speed version of M2.5.
 
 API docs: https://platform.minimax.io/docs/api-reference/text-openai-api
 """
@@ -29,7 +28,7 @@ import boxlite
 from openai import AsyncOpenAI
 
 MINIMAX_BASE_URL = os.getenv('MINIMAX_BASE_URL', 'https://api.minimax.io/v1')
-MINIMAX_DEFAULT_MODEL = 'MiniMax-M2.7'
+MINIMAX_DEFAULT_MODEL = 'MiniMax-M3'
 
 TOOLS = [
     {


### PR DESCRIPTION
## Summary
Upgrade the MiniMax example agent to use the latest M3 model as the default.

## Changes
- Add `MiniMax-M3` to the supported model list and set it as the new default in `examples/python/06_ai_agents/drive_box_with_minimax.py`
- Retain `MiniMax-M2.7` as an alternative
- Retain `MiniMax-M2.7-highspeed` for low-latency scenarios
- Remove deprecated `MiniMax-M2.5` and `MiniMax-M2.5-highspeed`
- Update `examples/python/06_ai_agents/README.md` to reflect the new model list

## Why
MiniMax-M3 is the latest flagship model and is OpenAI-API compatible just like the previous M2.x family, so the example switches over without any code-path changes — only the default model ID and supported-models list move forward.

## Testing
- `python3 -m py_compile examples/python/06_ai_agents/drive_box_with_minimax.py` passes
- Verified `MiniMax-M3` is accepted by the MiniMax OpenAI-compatible endpoint at `https://api.minimax.io/v1/chat/completions`