### PR TITLE
fix(net): allowlist DNS resilience by retrying, fail closed and allow longest-suffix wins

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -263,6 +263,69 @@ async with boxlite.SimpleBox(image="alpine:latest") as box:
     print(result.stdout)
 ```
 
+### An `allow_net` host resolves to `0.0.0.0` inside the box (or `box.create` failed with a DNS error)
+
+When `allow_net` is set, BoxLite resolves each allow-listed hostname on
+the **host** at box-creation time and pins the IPs into the guest's DNS
+sinkhole. Anything not in the sinkhole answers `0.0.0.0`. So if an
+allow-listed host shows up as `0.0.0.0` inside the box, the host's
+resolver couldn't answer for it when the box was being created — most
+often a VPN that hadn't fully come up, a slow corporate DNS server, or
+mDNSResponder churn.
+
+**1. Check the gvproxy log for the host that failed.**
+
+```bash
+# Find the most recent box
+ls -t ~/.boxlite/boxes/
+
+# Then grep its shim log
+grep -i allowNet ~/.boxlite/boxes/<id>/logs/boxlite-shim.log.<date>
+```
+
+A successful create looks like this — `allow_zones == hostnames`:
+
+```
+INFO gvproxy: allowNet: DNS sinkhole configured allow_zones=5 total_zones=6
+INFO gvproxy: allowNet TCP: filter initialized hostnames=5 ...
+```
+
+When a host couldn't be resolved you'll see retry warnings followed by
+either a recovery (newer builds — the box still comes up cleanly):
+
+```
+WARN gvproxy: allowNet: DNS resolution failed, will retry attempt=1 hostname=iapi.example.com next_delay=100ms
+INFO gvproxy: allowNet: DNS resolution succeeded after retry attempts=2 hostname=iapi.example.com
+```
+
+…or a hard failure, which now aborts `box.create`:
+
+```
+ERROR gvproxy: allowNet: DNS resolution failed after retries attempts=4 hostname=iapi.example.com error="..."
+ERROR gvproxy: Failed to build gvproxy tap config error="allowNet: resolve \"iapi.example.com\": ..."
+```
+
+On older builds without the retry/fail-closed behavior the symptom is
+quieter: `allow_zones=N-1 total_zones=N` with no error, and the missing
+host silently sinkholes to `0.0.0.0` for the lifetime of the box.
+
+**2. Verify the host can actually resolve and reach the name.**
+
+```bash
+getent hosts iapi.example.com    # or: dscacheutil -q host -a name <host>
+nc -vz iapi.example.com 443
+```
+
+If the host can't reach it (`Connection refused`, `0.0.0.0`, NXDOMAIN),
+no amount of allow-listing will help — the VM only knows what the host
+told it at create time.
+
+**3. Recreate the box once DNS is healthy.**
+
+The sinkhole is built once at `box.create` and never refreshed for the
+life of that box, so you must destroy and recreate it after fixing the
+host's networking — restarting the VM or its services is not enough.
+
 ### How do I expose ports from a box?
 
 Use the `ports` parameter for port forwarding:

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -160,6 +160,14 @@ Structured network configuration for outbound connectivity.
   reaching host loopback services and is not governed by `allow_net`.
 - Security: when networking is enabled, any service bound to host loopback can
   be reached from inside the box via `host.boxlite.internal` or `192.168.127.254`.
+- Each allow-listed hostname is resolved on the **host** at box creation
+  time and the IPs are pinned into the guest's DNS sinkhole. The lookup
+  retries with exponential backoff to ride out transient host-side DNS
+  hiccups (VPN flap, slow corp resolver). If a hostname still cannot be
+  resolved after all retries, `box.create` fails — by design, so a
+  half-baked sinkhole never silently sinkholes an allow-listed host to
+  `0.0.0.0`. Make sure the host can resolve every entry in `allow_net`
+  before creating the box.
 
 **Supported patterns:**
 - Exact hostname: `"api.openai.com"`

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -164,10 +164,19 @@ Structured network configuration for outbound connectivity.
   time and the IPs are pinned into the guest's DNS sinkhole. The lookup
   retries with exponential backoff to ride out transient host-side DNS
   hiccups (VPN flap, slow corp resolver). If a hostname still cannot be
-  resolved after all retries, `box.create` fails — by design, so a
-  half-baked sinkhole never silently sinkholes an allow-listed host to
-  `0.0.0.0`. Make sure the host can resolve every entry in `allow_net`
-  before creating the box.
+  resolved after all retries — or if it resolves only to AAAA (IPv6)
+  addresses, since gvisor-tap-vsock zones can only carry A records —
+  `box.create` fails by design, so a half-baked sinkhole never silently
+  sinkholes an allow-listed host to `0.0.0.0`. Make sure the host can
+  resolve every entry in `allow_net` to at least one IPv4 address before
+  creating the box.
+- Latency: a hostname that fails every retry attempt costs roughly
+  `attempts × per-attempt-timeout + cumulative backoff` ≈ 12s on the
+  defaults (4 attempts, 2s timeout, 100ms × 3× backoff). Hosts are
+  resolved sequentially, so an `allow_net` of N dead hosts costs ≈ 12s
+  × N to fail. Cancelling the runtime context (e.g. Ctrl-C in the host
+  process) breaks out of both the in-flight lookup and the inter-attempt
+  backoff sleep promptly.
 
 **Supported patterns:**
 - Exact hostname: `"api.openai.com"`

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/config_build_test.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/config_build_test.go
@@ -32,7 +32,10 @@ func testGvproxyConfig() GvproxyConfig {
 }
 
 func TestBuildTapConfig_UsesHostAliasDNSZone(t *testing.T) {
-	tapConfig := buildTapConfig(testGvproxyConfig(), types.QemuProtocol)
+	tapConfig, err := buildTapConfig(testGvproxyConfig(), types.QemuProtocol)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	if len(tapConfig.DNS) == 0 {
 		t.Fatal("expected at least one DNS zone")
@@ -57,7 +60,10 @@ func TestBuildTapConfig_KeepsBuiltinZonesBeforeAllowNet(t *testing.T) {
 	config := testGvproxyConfig()
 	config.AllowNet = []string{"example.com"}
 
-	tapConfig := buildTapConfig(config, types.QemuProtocol)
+	tapConfig, err := buildTapConfig(config, types.QemuProtocol)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	if len(tapConfig.DNS) < 2 {
 		t.Fatalf("expected built-in and allowlist DNS zones, got %d", len(tapConfig.DNS))
@@ -72,7 +78,10 @@ func TestBuildTapConfig_KeepsBuiltinZonesBeforeAllowNet(t *testing.T) {
 }
 
 func TestBuildTapConfig_RoutesHostAliasToLoopback(t *testing.T) {
-	tapConfig := buildTapConfig(testGvproxyConfig(), types.QemuProtocol)
+	tapConfig, err := buildTapConfig(testGvproxyConfig(), types.QemuProtocol)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	if got := tapConfig.NAT["192.168.127.254"]; got != "127.0.0.1" {
 		t.Fatalf("expected host IP NAT to loopback, got %q", got)

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/config_build_test.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/config_build_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"net"
 	"testing"
 
@@ -32,7 +33,7 @@ func testGvproxyConfig() GvproxyConfig {
 }
 
 func TestBuildTapConfig_UsesHostAliasDNSZone(t *testing.T) {
-	tapConfig, err := buildTapConfig(testGvproxyConfig(), types.QemuProtocol)
+	tapConfig, err := buildTapConfig(context.Background(), testGvproxyConfig(), types.QemuProtocol)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -60,7 +61,7 @@ func TestBuildTapConfig_KeepsBuiltinZonesBeforeAllowNet(t *testing.T) {
 	config := testGvproxyConfig()
 	config.AllowNet = []string{"example.com"}
 
-	tapConfig, err := buildTapConfig(config, types.QemuProtocol)
+	tapConfig, err := buildTapConfig(context.Background(), config, types.QemuProtocol)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -78,7 +79,7 @@ func TestBuildTapConfig_KeepsBuiltinZonesBeforeAllowNet(t *testing.T) {
 }
 
 func TestBuildTapConfig_RoutesHostAliasToLoopback(t *testing.T) {
-	tapConfig, err := buildTapConfig(testGvproxyConfig(), types.QemuProtocol)
+	tapConfig, err := buildTapConfig(context.Background(), testGvproxyConfig(), types.QemuProtocol)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/dns_filter.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/dns_filter.go
@@ -7,25 +7,70 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"regexp"
+	"sort"
 	"strings"
+	"time"
 
 	"github.com/containers/gvisor-tap-vsock/pkg/types"
 	logrus "github.com/sirupsen/logrus"
 )
 
+// Tunables for allowlist DNS resolution. Each allow-listed hostname is
+// resolved against the host OS resolver at box-create time and the
+// resulting IPs are baked into the DNS sinkhole. A transient host-side
+// DNS hiccup (VPN flap, slow corp resolver, mDNSResponder churn) used to
+// silently drop the host's zone, leaving the VM permanently sinkholing
+// it to 0.0.0.0 for the life of the box. We now retry with backoff and
+// fail closed if every attempt fails.
+//
+// Exposed as `var` (not `const`) so tests can override timing without
+// slowing the suite. Production callers MUST treat them as immutable.
+const dnsLookupAttempts = 4
+
+var (
+	dnsLookupInitialBackoffVar = 100 * time.Millisecond
+	dnsLookupBackoffFactor     = 3
+	dnsLookupAttemptTimeoutVar = 2 * time.Second
+)
+
+// hostResolver is the interface buildAllowNetDNSZones uses to look up
+// allow-listed hostnames. The production implementation calls the host
+// OS resolver via net.Resolver. Tests inject a fake to exercise the
+// retry/backoff/fail-closed paths without depending on real DNS.
+type hostResolver interface {
+	LookupIPAddr(ctx context.Context, host string) ([]net.IPAddr, error)
+}
+
+// defaultResolver is the production resolver: PreferGo:false uses the
+// platform's getaddrinfo, which honors VPN/corp DNS configuration.
+var defaultResolver hostResolver = &net.Resolver{PreferGo: false}
+
 // buildAllowNetDNSZones creates DNS zones that implement allowlist filtering.
 //
 // Strategy:
-//   - For each allowed hostname: resolve to IPs, create a zone with A records
-//   - For wildcard patterns (*.example.com): create zone with Regexp records
-//   - Add catch-all root zone "" with DefaultIP 0.0.0.0 (sinkhole)
+//   - For each allowed hostname: resolve to IPs (with retry/backoff), create
+//     a zone with A records.
+//   - For wildcard patterns (*.example.com): create zone with Regexp records.
+//   - Add catch-all root zone "" with DefaultIP 0.0.0.0 (sinkhole).
 //
 // Zone matching is first-match-wins with suffix matching. Specific zones
 // are added before the root zone, so allowed hosts resolve normally while
 // everything else gets sinkholed.
-func buildAllowNetDNSZones(allowNet []string) []types.Zone {
+//
+// Fail-closed: if any allow-listed hostname cannot be resolved after all
+// retry attempts, this function returns an error instead of producing a
+// silently-incomplete sinkhole. The caller is expected to abort box
+// creation rather than ship a misconfigured network.
+func buildAllowNetDNSZones(allowNet []string) ([]types.Zone, error) {
+	return buildAllowNetDNSZonesWith(allowNet, defaultResolver)
+}
+
+// buildAllowNetDNSZonesWith is the testable form: same behavior as
+// buildAllowNetDNSZones, with an injectable resolver.
+func buildAllowNetDNSZonesWith(allowNet []string, resolver hostResolver) ([]types.Zone, error) {
 	zoneRecords := make(map[string][]types.Record)
 
 	for _, rule := range allowNet {
@@ -55,7 +100,9 @@ func buildAllowNetDNSZones(allowNet []string) []types.Zone {
 			zoneRecords[zoneName] = append(zoneRecords[zoneName], types.Record{
 				Regexp: regexp.MustCompile(".*"),
 			})
-			resolveAndAddRecords(domain, domain+".", zoneRecords)
+			if err := resolveAndAddRecords(resolver, domain, domain+".", zoneRecords); err != nil {
+				return nil, err
+			}
 			continue
 		}
 
@@ -63,14 +110,39 @@ func buildAllowNetDNSZones(allowNet []string) []types.Zone {
 		parts := strings.SplitN(host, ".", 2)
 		if len(parts) == 2 {
 			zoneName := parts[1] + "."
-			resolveAndAddRecords(host, zoneName, zoneRecords)
+			if err := resolveAndAddRecords(resolver, host, zoneName, zoneRecords); err != nil {
+				return nil, err
+			}
 		} else {
-			resolveAndAddRecords(host, host+".", zoneRecords)
+			if err := resolveAndAddRecords(resolver, host, host+".", zoneRecords); err != nil {
+				return nil, err
+			}
 		}
 	}
 
+	// Build the zone slice in deterministic, longest-name-first order.
+	//
+	// gvisor-tap-vsock's DNS handler is *first-match-wins on suffix*, with no
+	// most-specific-match preference. If we left `zoneRecords` in map-iteration
+	// order, an `iapi.merck.com` query could land on the `com.` zone (created
+	// because we allow-listed `github.com`) before the `merck.com.` zone, fall
+	// through to that zone's DefaultIP=0.0.0.0, and return a sinkhole answer —
+	// even though we *do* have a real record for it under a more specific zone.
+	//
+	// Sorting longest-name-first guarantees the most-specific suffix wins,
+	// which matches both standard DNS semantics and the behavior callers
+	// expect from an allow-list ("the host I named must resolve").
+	zoneNames := make([]string, 0, len(zoneRecords))
+	for zoneName := range zoneRecords {
+		zoneNames = append(zoneNames, zoneName)
+	}
+	sort.Slice(zoneNames, func(i, j int) bool {
+		return len(zoneNames[i]) > len(zoneNames[j])
+	})
+
 	var zones []types.Zone
-	for zoneName, records := range zoneRecords {
+	for _, zoneName := range zoneNames {
+		records := zoneRecords[zoneName]
 		zones = append(zones, types.Zone{
 			Name:      zoneName,
 			Records:   records,
@@ -93,37 +165,96 @@ func buildAllowNetDNSZones(allowNet []string) []types.Zone {
 		"total_zones": len(zones),
 	}).Info("allowNet: DNS sinkhole configured")
 
-	return zones
+	return zones, nil
 }
 
-// resolveAndAddRecords resolves a hostname and adds A records to the zone.
-func resolveAndAddRecords(hostname, zoneName string, zoneRecords map[string][]types.Record) {
-	ctx := context.Background()
-	resolver := &net.Resolver{PreferGo: false}
-	ips, err := resolver.LookupIPAddr(ctx, hostname)
+// resolveAndAddRecords resolves a hostname (with retry + per-attempt
+// timeout) and adds A records to the zone. Returns the final error if
+// every attempt fails so callers can fail closed.
+func resolveAndAddRecords(resolver hostResolver, hostname, zoneName string, zoneRecords map[string][]types.Record) error {
+	ips, err := lookupWithRetry(resolver, hostname)
 	if err != nil {
-		logrus.WithFields(logrus.Fields{
-			"hostname": hostname,
-			"error":    err,
-		}).Warn("allowNet: DNS resolution failed for allowed host")
-		return
+		return fmt.Errorf("allowNet: resolve %q: %w", hostname, err)
 	}
 
 	trimmed := strings.TrimSuffix(hostname+".", "."+zoneName)
 
+	v4Count := 0
+	v4Strs := make([]string, 0, len(ips))
 	for _, ip := range ips {
 		if ip.IP.To4() == nil {
 			continue // Skip IPv6 for now
 		}
+		v4Count++
+		v4Strs = append(v4Strs, ip.IP.String())
 		zoneRecords[zoneName] = append(zoneRecords[zoneName], types.Record{
 			Name: trimmed,
 			IP:   ip.IP.To4(),
 		})
-		logrus.WithFields(logrus.Fields{
-			"hostname": hostname,
-			"ip":       ip.IP,
-			"zone":     zoneName,
-			"label":    trimmed,
-		}).Debug("allowNet: resolved and added DNS record")
 	}
+
+	// One Info line per allow-listed host. Without this it's invisible
+	// whether a hostname's lookup succeeded but yielded only IPv6 (which
+	// we drop), which would silently sinkhole that host even though no
+	// retry/error fired. v4_count=0 is the smoking gun for that case.
+	logrus.WithFields(logrus.Fields{
+		"hostname": hostname,
+		"zone":     zoneName,
+		"label":    trimmed,
+		"v4_count": v4Count,
+		"v4_ips":   v4Strs,
+	}).Info("allowNet: host resolved")
+
+	return nil
+}
+
+// lookupWithRetry calls resolver.LookupIPAddr up to dnsLookupAttempts
+// times, with a per-attempt context timeout and exponential backoff
+// between attempts. Each attempt that returns at least one IP wins
+// immediately. Each attempt that returns an empty list with no error is
+// treated as a failure so we retry rather than bake an empty zone.
+func lookupWithRetry(resolver hostResolver, hostname string) ([]net.IPAddr, error) {
+	var (
+		ips     []net.IPAddr
+		lastErr error
+	)
+	backoff := dnsLookupInitialBackoffVar
+
+	for attempt := 1; attempt <= dnsLookupAttempts; attempt++ {
+		ctx, cancel := context.WithTimeout(context.Background(), dnsLookupAttemptTimeoutVar)
+		ips, lastErr = resolver.LookupIPAddr(ctx, hostname)
+		cancel()
+
+		if lastErr == nil && len(ips) > 0 {
+			if attempt > 1 {
+				logrus.WithFields(logrus.Fields{
+					"hostname": hostname,
+					"attempts": attempt,
+				}).Info("allowNet: DNS resolution succeeded after retry")
+			}
+			return ips, nil
+		}
+
+		if lastErr == nil {
+			lastErr = fmt.Errorf("no A records returned")
+		}
+
+		if attempt < dnsLookupAttempts {
+			logrus.WithFields(logrus.Fields{
+				"hostname":   hostname,
+				"attempt":    attempt,
+				"error":      lastErr,
+				"next_delay": backoff,
+			}).Warn("allowNet: DNS resolution failed, will retry")
+			time.Sleep(backoff)
+			backoff *= time.Duration(dnsLookupBackoffFactor)
+		}
+	}
+
+	logrus.WithFields(logrus.Fields{
+		"hostname": hostname,
+		"attempts": dnsLookupAttempts,
+		"error":    lastErr,
+	}).Error("allowNet: DNS resolution failed after retries")
+	return nil, lastErr
 }

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/dns_filter.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/dns_filter.go
@@ -64,13 +64,18 @@ var defaultResolver hostResolver = &net.Resolver{PreferGo: false}
 // retry attempts, this function returns an error instead of producing a
 // silently-incomplete sinkhole. The caller is expected to abort box
 // creation rather than ship a misconfigured network.
-func buildAllowNetDNSZones(allowNet []string) ([]types.Zone, error) {
-	return buildAllowNetDNSZonesWith(allowNet, defaultResolver)
+//
+// `ctx` is honored throughout the resolution loop: cancellation aborts
+// the current attempt and the inter-attempt backoff sleep, so a Ctrl-C
+// or process shutdown ends `box.create` promptly instead of waiting for
+// the full retry budget to drain.
+func buildAllowNetDNSZones(ctx context.Context, allowNet []string) ([]types.Zone, error) {
+	return buildAllowNetDNSZonesWith(ctx, allowNet, defaultResolver)
 }
 
 // buildAllowNetDNSZonesWith is the testable form: same behavior as
 // buildAllowNetDNSZones, with an injectable resolver.
-func buildAllowNetDNSZonesWith(allowNet []string, resolver hostResolver) ([]types.Zone, error) {
+func buildAllowNetDNSZonesWith(ctx context.Context, allowNet []string, resolver hostResolver) ([]types.Zone, error) {
 	zoneRecords := make(map[string][]types.Record)
 
 	for _, rule := range allowNet {
@@ -100,7 +105,7 @@ func buildAllowNetDNSZonesWith(allowNet []string, resolver hostResolver) ([]type
 			zoneRecords[zoneName] = append(zoneRecords[zoneName], types.Record{
 				Regexp: regexp.MustCompile(".*"),
 			})
-			if err := resolveAndAddRecords(resolver, domain, domain+".", zoneRecords); err != nil {
+			if err := resolveAndAddRecords(ctx, resolver, domain, domain+".", zoneRecords); err != nil {
 				return nil, err
 			}
 			continue
@@ -110,11 +115,11 @@ func buildAllowNetDNSZonesWith(allowNet []string, resolver hostResolver) ([]type
 		parts := strings.SplitN(host, ".", 2)
 		if len(parts) == 2 {
 			zoneName := parts[1] + "."
-			if err := resolveAndAddRecords(resolver, host, zoneName, zoneRecords); err != nil {
+			if err := resolveAndAddRecords(ctx, resolver, host, zoneName, zoneRecords); err != nil {
 				return nil, err
 			}
 		} else {
-			if err := resolveAndAddRecords(resolver, host, host+".", zoneRecords); err != nil {
+			if err := resolveAndAddRecords(ctx, resolver, host, host+".", zoneRecords); err != nil {
 				return nil, err
 			}
 		}
@@ -170,9 +175,11 @@ func buildAllowNetDNSZonesWith(allowNet []string, resolver hostResolver) ([]type
 
 // resolveAndAddRecords resolves a hostname (with retry + per-attempt
 // timeout) and adds A records to the zone. Returns the final error if
-// every attempt fails so callers can fail closed.
-func resolveAndAddRecords(resolver hostResolver, hostname, zoneName string, zoneRecords map[string][]types.Record) error {
-	ips, err := lookupWithRetry(resolver, hostname)
+// every attempt fails so callers can fail closed. Honors `ctx` so a
+// caller cancellation propagates through both the in-flight lookup and
+// the inter-attempt backoff.
+func resolveAndAddRecords(ctx context.Context, resolver hostResolver, hostname, zoneName string, zoneRecords map[string][]types.Record) error {
+	ips, err := lookupWithRetry(ctx, resolver, hostname)
 	if err != nil {
 		return fmt.Errorf("allowNet: resolve %q: %w", hostname, err)
 	}
@@ -213,7 +220,14 @@ func resolveAndAddRecords(resolver hostResolver, hostname, zoneName string, zone
 // between attempts. Each attempt that returns at least one IP wins
 // immediately. Each attempt that returns an empty list with no error is
 // treated as a failure so we retry rather than bake an empty zone.
-func lookupWithRetry(resolver hostResolver, hostname string) ([]net.IPAddr, error) {
+//
+// `parentCtx` is the caller's lifetime context (typically a process-
+// level signal-aware ctx from `gvproxy_create`). Each attempt's deadline
+// is derived from it, so a cancellation (Ctrl-C, shutdown) terminates
+// both the in-flight lookup *and* the inter-attempt backoff sleep —
+// without this, a hung resolver could keep `box.create` blocked for the
+// full retry budget even after the user has asked for it to stop.
+func lookupWithRetry(parentCtx context.Context, resolver hostResolver, hostname string) ([]net.IPAddr, error) {
 	var (
 		ips     []net.IPAddr
 		lastErr error
@@ -221,7 +235,12 @@ func lookupWithRetry(resolver hostResolver, hostname string) ([]net.IPAddr, erro
 	backoff := dnsLookupInitialBackoffVar
 
 	for attempt := 1; attempt <= dnsLookupAttempts; attempt++ {
-		ctx, cancel := context.WithTimeout(context.Background(), dnsLookupAttemptTimeoutVar)
+		// Bail before spending another attempt if the caller already cancelled.
+		if err := parentCtx.Err(); err != nil {
+			return nil, err
+		}
+
+		ctx, cancel := context.WithTimeout(parentCtx, dnsLookupAttemptTimeoutVar)
 		ips, lastErr = resolver.LookupIPAddr(ctx, hostname)
 		cancel()
 
@@ -235,6 +254,15 @@ func lookupWithRetry(resolver hostResolver, hostname string) ([]net.IPAddr, erro
 			return ips, nil
 		}
 
+		// If the parent ctx was cancelled mid-attempt, surface that as the
+		// terminal error rather than retrying — the caller has gone away.
+		if parentCtx.Err() != nil {
+			if lastErr != nil {
+				return nil, lastErr
+			}
+			return nil, parentCtx.Err()
+		}
+
 		if lastErr == nil {
 			lastErr = fmt.Errorf("no A records returned")
 		}
@@ -246,7 +274,16 @@ func lookupWithRetry(resolver hostResolver, hostname string) ([]net.IPAddr, erro
 				"error":      lastErr,
 				"next_delay": backoff,
 			}).Warn("allowNet: DNS resolution failed, will retry")
-			time.Sleep(backoff)
+
+			// Interruptible backoff: react to Ctrl-C / shutdown immediately
+			// instead of sleeping out the (potentially multi-second) delay.
+			timer := time.NewTimer(backoff)
+			select {
+			case <-parentCtx.Done():
+				timer.Stop()
+				return nil, parentCtx.Err()
+			case <-timer.C:
+			}
 			backoff *= time.Duration(dnsLookupBackoffFactor)
 		}
 	}

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/dns_filter.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/dns_filter.go
@@ -25,15 +25,15 @@ import (
 // silently drop the host's zone, leaving the VM permanently sinkholing
 // it to 0.0.0.0 for the life of the box. We now retry with backoff and
 // fail closed if every attempt fails.
-//
-// Exposed as `var` (not `const`) so tests can override timing without
-// slowing the suite. Production callers MUST treat them as immutable.
 const dnsLookupAttempts = 4
 
+// Timing tunables — exposed as `var` (not `const`) so tests can override
+// them to keep the suite fast. Production callers MUST treat them as
+// immutable.
 var (
-	dnsLookupInitialBackoffVar = 100 * time.Millisecond
-	dnsLookupBackoffFactor     = 3
-	dnsLookupAttemptTimeoutVar = 2 * time.Second
+	dnsLookupInitialBackoff = 100 * time.Millisecond
+	dnsLookupBackoffFactor  = 3
+	dnsLookupAttemptTimeout = 2 * time.Second
 )
 
 // hostResolver is the interface buildAllowNetDNSZones uses to look up
@@ -141,8 +141,15 @@ func buildAllowNetDNSZonesWith(ctx context.Context, allowNet []string, resolver 
 	for zoneName := range zoneRecords {
 		zoneNames = append(zoneNames, zoneName)
 	}
-	sort.Slice(zoneNames, func(i, j int) bool {
-		return len(zoneNames[i]) > len(zoneNames[j])
+	// Length-descending primary key, lexical secondary so equal-length
+	// zones land in deterministic order. Without the lexical tiebreak,
+	// sort.Slice's underlying introsort is unstable and two equal-length
+	// zones (`boxlite.com.` vs `litebox.com.`) could swap order across runs.
+	sort.SliceStable(zoneNames, func(i, j int) bool {
+		if len(zoneNames[i]) != len(zoneNames[j]) {
+			return len(zoneNames[i]) > len(zoneNames[j])
+		}
+		return zoneNames[i] < zoneNames[j]
 	})
 
 	var zones []types.Zone
@@ -186,13 +193,11 @@ func resolveAndAddRecords(ctx context.Context, resolver hostResolver, hostname, 
 
 	trimmed := strings.TrimSuffix(hostname+".", "."+zoneName)
 
-	v4Count := 0
 	v4Strs := make([]string, 0, len(ips))
 	for _, ip := range ips {
 		if ip.IP.To4() == nil {
-			continue // Skip IPv6 for now
+			continue // gvisor-tap-vsock's DNS records carry an IPv4-only IP
 		}
-		v4Count++
 		v4Strs = append(v4Strs, ip.IP.String())
 		zoneRecords[zoneName] = append(zoneRecords[zoneName], types.Record{
 			Name: trimmed,
@@ -200,15 +205,27 @@ func resolveAndAddRecords(ctx context.Context, resolver hostResolver, hostname, 
 		})
 	}
 
-	// One Info line per allow-listed host. Without this it's invisible
-	// whether a hostname's lookup succeeded but yielded only IPv6 (which
-	// we drop), which would silently sinkhole that host even though no
-	// retry/error fired. v4_count=0 is the smoking gun for that case.
+	// Fail closed when the host resolved but yielded only AAAA records.
+	// gvisor-tap-vsock zones can only carry A records today, so an
+	// AAAA-only result would produce a zone with zero records and a
+	// DefaultIP of 0.0.0.0 — exactly the silent-sinkhole symptom this
+	// fix set out to kill. The retry/backoff path already fails closed
+	// on resolver errors; this closes the second hole the docs already
+	// promise we cover (docs/reference/README.md "fails — by design").
+	if len(v4Strs) == 0 {
+		logrus.WithFields(logrus.Fields{
+			"hostname": hostname,
+			"zone":     zoneName,
+			"label":    trimmed,
+		}).Error("allowNet: host resolved with no IPv4 addresses (AAAA-only)")
+		return fmt.Errorf("allowNet: resolve %q: no IPv4 records (only IPv6); allow-listing AAAA-only hosts is not supported", hostname)
+	}
+
 	logrus.WithFields(logrus.Fields{
 		"hostname": hostname,
 		"zone":     zoneName,
 		"label":    trimmed,
-		"v4_count": v4Count,
+		"v4_count": len(v4Strs),
 		"v4_ips":   v4Strs,
 	}).Info("allowNet: host resolved")
 
@@ -232,7 +249,7 @@ func lookupWithRetry(parentCtx context.Context, resolver hostResolver, hostname 
 		ips     []net.IPAddr
 		lastErr error
 	)
-	backoff := dnsLookupInitialBackoffVar
+	backoff := dnsLookupInitialBackoff
 
 	for attempt := 1; attempt <= dnsLookupAttempts; attempt++ {
 		// Bail before spending another attempt if the caller already cancelled.
@@ -240,7 +257,7 @@ func lookupWithRetry(parentCtx context.Context, resolver hostResolver, hostname 
 			return nil, err
 		}
 
-		ctx, cancel := context.WithTimeout(parentCtx, dnsLookupAttemptTimeoutVar)
+		ctx, cancel := context.WithTimeout(parentCtx, dnsLookupAttemptTimeout)
 		ips, lastErr = resolver.LookupIPAddr(ctx, hostname)
 		cancel()
 

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/dns_filter_test.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/dns_filter_test.go
@@ -1,16 +1,24 @@
 package main
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"net"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestBuildAllowNetDNSZones(t *testing.T) {
-	zones := buildAllowNetDNSZones([]string{
+	zones, err := buildAllowNetDNSZones([]string{
 		"api.openai.com",
 		"*.anthropic.com",
 		"192.168.1.1", // IP — skipped (DNS only handles hostnames)
 	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	if len(zones) < 2 {
 		t.Errorf("expected at least 2 zones, got %d", len(zones))
@@ -27,7 +35,10 @@ func TestBuildAllowNetDNSZones(t *testing.T) {
 }
 
 func TestBuildAllowNetDNSZones_PerTLDZonesHaveSinkholeDefaultIP(t *testing.T) {
-	zones := buildAllowNetDNSZones([]string{"example.com"})
+	zones, err := buildAllowNetDNSZones([]string{"example.com"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	// Should have 2 zones: "com." (per-TLD) + "" (root catch-all)
 	if len(zones) != 2 {
@@ -43,8 +54,67 @@ func TestBuildAllowNetDNSZones_PerTLDZonesHaveSinkholeDefaultIP(t *testing.T) {
 	}
 }
 
+// TestBuildAllowNetDNSZones_LongestSuffixWinsBeforeRoot pins the bug fix
+// where an `iapi.merck.com` query was sometimes answered with `0.0.0.0`
+// even though the host had been allow-listed. Root cause: gvisor-tap-vsock
+// matches zones with first-suffix-wins (no most-specific preference), and
+// our zones used to be emitted in Go map-iteration order, so a `com.`
+// zone (created because `github.com` was allow-listed) could win the
+// match for `iapi.merck.com.` and serve its DefaultIP=0.0.0.0 even
+// though a `merck.com.` zone with the right record also existed.
+//
+// Sorting zones longest-name-first guarantees the most-specific suffix
+// matches first.
+func TestBuildAllowNetDNSZones_LongestSuffixWinsBeforeRoot(t *testing.T) {
+	zones, err := buildAllowNetDNSZones([]string{
+		"github.com",
+		"api.github.com",
+		"raw.githubusercontent.com",
+		"codeload.github.com",
+		"iapi.merck.com",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Walk zones in returned order; index of each zone name in the slice.
+	indexOf := make(map[string]int, len(zones))
+	for i, z := range zones {
+		indexOf[z.Name] = i
+	}
+
+	// Sanity: all the expected zones are present (one per distinct DNS suffix).
+	for _, name := range []string{"github.com.", "githubusercontent.com.", "merck.com.", "com."} {
+		if _, ok := indexOf[name]; !ok {
+			t.Fatalf("expected zone %q in result, got zones %v", name, indexOf)
+		}
+	}
+
+	// merck.com. (10 chars) MUST come before com. (4 chars) so an
+	// `iapi.merck.com.` query hits the merck.com. zone first.
+	if indexOf["merck.com."] >= indexOf["com."] {
+		t.Errorf("merck.com. (idx=%d) must precede com. (idx=%d) — first-match-wins matcher would otherwise sinkhole iapi.merck.com",
+			indexOf["merck.com."], indexOf["com."])
+	}
+	// github.com. (11) MUST come before com. for the same reason
+	if indexOf["github.com."] >= indexOf["com."] {
+		t.Errorf("github.com. must precede com.")
+	}
+	// githubusercontent.com. (22) MUST come before com.
+	if indexOf["githubusercontent.com."] >= indexOf["com."] {
+		t.Errorf("githubusercontent.com. must precede com.")
+	}
+	// And the catch-all root zone "" must always be last.
+	if zones[len(zones)-1].Name != "" {
+		t.Errorf("expected root sinkhole zone last, got %q", zones[len(zones)-1].Name)
+	}
+}
+
 func TestBuildAllowNetDNSZones_EmptyList(t *testing.T) {
-	zones := buildAllowNetDNSZones([]string{})
+	zones, err := buildAllowNetDNSZones([]string{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	if len(zones) != 1 {
 		t.Errorf("expected 1 zone (root only), got %d", len(zones))
@@ -52,4 +122,211 @@ func TestBuildAllowNetDNSZones_EmptyList(t *testing.T) {
 	if zones[0].Name != "" {
 		t.Errorf("single zone should be root, got %q", zones[0].Name)
 	}
+}
+
+// --- Test doubles for the resolver ----------------------------------------
+
+// flakyResolver fails the first failBefore attempts per hostname, then
+// succeeds with a fixed IP. Used to simulate a brief host-DNS hiccup
+// during box.create (VPN flap, slow corp resolver, mDNSResponder churn).
+type flakyResolver struct {
+	failBefore  int                    // fail this many calls per host before succeeding
+	calls       map[string]*int32      // per-host call counter
+	failWith    error                  // error returned during the failing window
+	successIPs  map[string][]net.IPAddr // per-host IPs returned on success (defaults to 1.2.3.4)
+	attemptHook func(host string, n int32, ctx context.Context)
+}
+
+func newFlakyResolver(failBefore int, failWith error) *flakyResolver {
+	return &flakyResolver{
+		failBefore: failBefore,
+		calls:      make(map[string]*int32),
+		failWith:   failWith,
+		successIPs: make(map[string][]net.IPAddr),
+	}
+}
+
+func (f *flakyResolver) LookupIPAddr(ctx context.Context, host string) ([]net.IPAddr, error) {
+	counter, ok := f.calls[host]
+	if !ok {
+		counter = new(int32)
+		f.calls[host] = counter
+	}
+	n := atomic.AddInt32(counter, 1)
+	if f.attemptHook != nil {
+		f.attemptHook(host, n, ctx)
+	}
+	if int(n) <= f.failBefore {
+		return nil, f.failWith
+	}
+	if ips, ok := f.successIPs[host]; ok {
+		return ips, nil
+	}
+	return []net.IPAddr{{IP: net.IPv4(1, 2, 3, 4)}}, nil
+}
+
+func (f *flakyResolver) callsFor(host string) int {
+	if c, ok := f.calls[host]; ok {
+		return int(atomic.LoadInt32(c))
+	}
+	return 0
+}
+
+// alwaysFailResolver returns the configured error for every lookup.
+type alwaysFailResolver struct {
+	err   error
+	calls int32
+}
+
+func (r *alwaysFailResolver) LookupIPAddr(_ context.Context, _ string) ([]net.IPAddr, error) {
+	atomic.AddInt32(&r.calls, 1)
+	return nil, r.err
+}
+
+// hangingResolver blocks until ctx is cancelled, then returns ctx.Err().
+// Used to verify the per-attempt timeout actually fires.
+type hangingResolver struct {
+	calls int32
+}
+
+func (h *hangingResolver) LookupIPAddr(ctx context.Context, _ string) ([]net.IPAddr, error) {
+	atomic.AddInt32(&h.calls, 1)
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+// --- Reproducer + behavior tests ------------------------------------------
+
+// TestBuildAllowNetDNSZones_RetriesTransientResolverFailure is the
+// reproducer for the intermittent "0.0.0.0 for an allow-listed host"
+// bug. With the old single-shot lookup the first failure dropped the
+// zone permanently; with retry we recover and bake the host's records.
+func TestBuildAllowNetDNSZones_RetriesTransientResolverFailure(t *testing.T) {
+	res := newFlakyResolver(2, errors.New("simulated transient DNS error"))
+
+	zones, err := buildAllowNetDNSZonesWith([]string{"iapi.example.com"}, res)
+	if err != nil {
+		t.Fatalf("expected retry to recover, got error: %v", err)
+	}
+
+	if got := res.callsFor("iapi.example.com"); got != 3 {
+		t.Errorf("expected 3 lookup attempts (2 fail + 1 success), got %d", got)
+	}
+
+	// Confirm the host got an A record — no silent zone drop.
+	found := false
+	for _, z := range zones {
+		for _, r := range z.Records {
+			if r.IP != nil && r.IP.Equal(net.IPv4(1, 2, 3, 4)) {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("expected iapi.example.com record in zones, got %+v", zones)
+	}
+}
+
+// TestBuildAllowNetDNSZones_FailsClosedAfterRetries is the second half
+// of the contract: when retries are exhausted, return an error so
+// box.create aborts loudly instead of producing a half-baked sinkhole.
+func TestBuildAllowNetDNSZones_FailsClosedAfterRetries(t *testing.T) {
+	res := &alwaysFailResolver{err: errors.New("DNS server unreachable")}
+
+	_, err := buildAllowNetDNSZonesWith([]string{"iapi.example.com"}, res)
+	if err == nil {
+		t.Fatal("expected error when every retry attempt fails, got nil")
+	}
+	if got := atomic.LoadInt32(&res.calls); int(got) != dnsLookupAttempts {
+		t.Errorf("expected %d attempts, got %d", dnsLookupAttempts, got)
+	}
+}
+
+// TestBuildAllowNetDNSZones_HonorsPerAttemptTimeout pins down the
+// per-attempt context timeout: a hanging resolver must be cancelled per
+// attempt (not just after the entire retry loop). We can't measure the
+// exact 2s without slowing the suite, so we override it for the test.
+func TestBuildAllowNetDNSZones_HonorsPerAttemptTimeout(t *testing.T) {
+	origTimeout := dnsLookupAttemptTimeoutVar
+	origBackoff := dnsLookupInitialBackoffVar
+	t.Cleanup(func() {
+		dnsLookupAttemptTimeoutVar = origTimeout
+		dnsLookupInitialBackoffVar = origBackoff
+	})
+	dnsLookupAttemptTimeoutVar = 30 * time.Millisecond
+	dnsLookupInitialBackoffVar = 1 * time.Millisecond
+
+	res := &hangingResolver{}
+	start := time.Now()
+	_, err := buildAllowNetDNSZonesWith([]string{"slow.example.com"}, res)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	// Each attempt must terminate at the per-attempt timeout, not hang
+	// forever; total time should be roughly attempts * timeout, not
+	// unbounded. Generous upper bound to avoid flakes on slow CI.
+	maxExpected := time.Duration(dnsLookupAttempts) * dnsLookupAttemptTimeoutVar * 4
+	if elapsed > maxExpected {
+		t.Errorf("retry loop took %v; expected <= %v (per-attempt timeout not honored?)", elapsed, maxExpected)
+	}
+	if got := atomic.LoadInt32(&res.calls); int(got) != dnsLookupAttempts {
+		t.Errorf("expected %d attempts, got %d", dnsLookupAttempts, got)
+	}
+}
+
+// TestBuildAllowNetDNSZones_PerHostFailureFailsAggregate makes sure
+// that one bad host in a multi-host allow-list aborts the whole build.
+// Previously the sinkhole would silently come up with allow_zones=N-1
+// total_zones=N — exactly the symptom reported from production.
+func TestBuildAllowNetDNSZones_PerHostFailureFailsAggregate(t *testing.T) {
+	good := []net.IPAddr{{IP: net.IPv4(8, 8, 8, 8)}}
+	res := &mixedResolver{
+		good: map[string][]net.IPAddr{"github.com": good, "api.github.com": good},
+		bad:  map[string]error{"iapi.example.com": errors.New("permafail")},
+	}
+
+	_, err := buildAllowNetDNSZonesWith(
+		[]string{"github.com", "api.github.com", "iapi.example.com"},
+		res,
+	)
+	if err == nil {
+		t.Fatal("expected aggregate error when one host fails to resolve, got nil")
+	}
+	want := "iapi.example.com"
+	if !contains(err.Error(), want) {
+		t.Errorf("error %q should mention failing host %q", err.Error(), want)
+	}
+}
+
+// mixedResolver returns canned IPs for some hosts and canned errors
+// for others, with no retry-flakiness — every call has a deterministic
+// outcome based on the host.
+type mixedResolver struct {
+	good map[string][]net.IPAddr
+	bad  map[string]error
+}
+
+func (m *mixedResolver) LookupIPAddr(_ context.Context, host string) ([]net.IPAddr, error) {
+	if err, ok := m.bad[host]; ok {
+		return nil, err
+	}
+	if ips, ok := m.good[host]; ok {
+		return ips, nil
+	}
+	return nil, fmt.Errorf("no test data for %q", host)
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || (len(sub) > 0 && indexOf(s, sub) >= 0))
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
 }

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/dns_filter_test.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/dns_filter_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -65,6 +66,14 @@ func TestBuildAllowNetDNSZones_PerTLDZonesHaveSinkholeDefaultIP(t *testing.T) {
 //
 // Sorting zones longest-name-first guarantees the most-specific suffix
 // matches first.
+//
+// Upstream contract this test depends on: gvisor-tap-vsock's DNS handler
+// iterates zones in slice order and returns on the first matching suffix,
+// so slice order = match priority. See pkg/services/dns/dns.go in
+// containers/gvisor-tap-vsock@v0.8.7 (the version pinned in go.mod). If a
+// future bump changes the matcher to "most-specific wins", this test
+// keeps passing but becomes redundant; if it changes to "round-robin" or
+// "exact-match-only", this test will catch the regression.
 func TestBuildAllowNetDNSZones_LongestSuffixWinsBeforeRoot(t *testing.T) {
 	zones, err := buildAllowNetDNSZones(context.Background(), []string{
 		"github.com",
@@ -130,11 +139,9 @@ func TestBuildAllowNetDNSZones_EmptyList(t *testing.T) {
 // succeeds with a fixed IP. Used to simulate a brief host-DNS hiccup
 // during box.create (VPN flap, slow corp resolver, mDNSResponder churn).
 type flakyResolver struct {
-	failBefore  int                    // fail this many calls per host before succeeding
-	calls       map[string]*int32      // per-host call counter
-	failWith    error                  // error returned during the failing window
-	successIPs  map[string][]net.IPAddr // per-host IPs returned on success (defaults to 1.2.3.4)
-	attemptHook func(host string, n int32, ctx context.Context)
+	failBefore int               // fail this many calls per host before succeeding
+	calls      map[string]*int32 // per-host call counter
+	failWith   error             // error returned during the failing window
 }
 
 func newFlakyResolver(failBefore int, failWith error) *flakyResolver {
@@ -142,25 +149,18 @@ func newFlakyResolver(failBefore int, failWith error) *flakyResolver {
 		failBefore: failBefore,
 		calls:      make(map[string]*int32),
 		failWith:   failWith,
-		successIPs: make(map[string][]net.IPAddr),
 	}
 }
 
-func (f *flakyResolver) LookupIPAddr(ctx context.Context, host string) ([]net.IPAddr, error) {
+func (f *flakyResolver) LookupIPAddr(_ context.Context, host string) ([]net.IPAddr, error) {
 	counter, ok := f.calls[host]
 	if !ok {
 		counter = new(int32)
 		f.calls[host] = counter
 	}
 	n := atomic.AddInt32(counter, 1)
-	if f.attemptHook != nil {
-		f.attemptHook(host, n, ctx)
-	}
 	if int(n) <= f.failBefore {
 		return nil, f.failWith
-	}
-	if ips, ok := f.successIPs[host]; ok {
-		return ips, nil
 	}
 	return []net.IPAddr{{IP: net.IPv4(1, 2, 3, 4)}}, nil
 }
@@ -247,14 +247,14 @@ func TestBuildAllowNetDNSZones_FailsClosedAfterRetries(t *testing.T) {
 // attempt (not just after the entire retry loop). We can't measure the
 // exact 2s without slowing the suite, so we override it for the test.
 func TestBuildAllowNetDNSZones_HonorsPerAttemptTimeout(t *testing.T) {
-	origTimeout := dnsLookupAttemptTimeoutVar
-	origBackoff := dnsLookupInitialBackoffVar
+	origTimeout := dnsLookupAttemptTimeout
+	origBackoff := dnsLookupInitialBackoff
 	t.Cleanup(func() {
-		dnsLookupAttemptTimeoutVar = origTimeout
-		dnsLookupInitialBackoffVar = origBackoff
+		dnsLookupAttemptTimeout = origTimeout
+		dnsLookupInitialBackoff = origBackoff
 	})
-	dnsLookupAttemptTimeoutVar = 30 * time.Millisecond
-	dnsLookupInitialBackoffVar = 1 * time.Millisecond
+	dnsLookupAttemptTimeout = 30 * time.Millisecond
+	dnsLookupInitialBackoff = 1 * time.Millisecond
 
 	res := &hangingResolver{}
 	start := time.Now()
@@ -267,7 +267,7 @@ func TestBuildAllowNetDNSZones_HonorsPerAttemptTimeout(t *testing.T) {
 	// Each attempt must terminate at the per-attempt timeout, not hang
 	// forever; total time should be roughly attempts * timeout, not
 	// unbounded. Generous upper bound to avoid flakes on slow CI.
-	maxExpected := time.Duration(dnsLookupAttempts) * dnsLookupAttemptTimeoutVar * 4
+	maxExpected := time.Duration(dnsLookupAttempts) * dnsLookupAttemptTimeout * 4
 	if elapsed > maxExpected {
 		t.Errorf("retry loop took %v; expected <= %v (per-attempt timeout not honored?)", elapsed, maxExpected)
 	}
@@ -288,16 +288,16 @@ func TestBuildAllowNetDNSZones_HonorsPerAttemptTimeout(t *testing.T) {
 // few ms of the cancel; if it ignored ctx, it'd wait out the budget
 // and the test would fail the elapsed-time bound.
 func TestBuildAllowNetDNSZones_ParentCtxCancellationStopsRetryLoop(t *testing.T) {
-	origBackoff := dnsLookupInitialBackoffVar
-	origTimeout := dnsLookupAttemptTimeoutVar
+	origBackoff := dnsLookupInitialBackoff
+	origTimeout := dnsLookupAttemptTimeout
 	t.Cleanup(func() {
-		dnsLookupInitialBackoffVar = origBackoff
-		dnsLookupAttemptTimeoutVar = origTimeout
+		dnsLookupInitialBackoff = origBackoff
+		dnsLookupAttemptTimeout = origTimeout
 	})
 	// Big backoff window relative to test timing — if the sleep is
 	// not interruptible, the test elapsed time will exceed the bound.
-	dnsLookupInitialBackoffVar = 5 * time.Second
-	dnsLookupAttemptTimeoutVar = 50 * time.Millisecond
+	dnsLookupInitialBackoff = 5 * time.Second
+	dnsLookupAttemptTimeout = 50 * time.Millisecond
 
 	res := &alwaysFailResolver{err: errors.New("always fails so we hit the backoff")}
 
@@ -344,7 +344,38 @@ func TestBuildAllowNetDNSZones_PerHostFailureFailsAggregate(t *testing.T) {
 		t.Fatal("expected aggregate error when one host fails to resolve, got nil")
 	}
 	want := "iapi.example.com"
-	if !contains(err.Error(), want) {
+	if !strings.Contains(err.Error(), want) {
+		t.Errorf("error %q should mention failing host %q", err.Error(), want)
+	}
+}
+
+// TestBuildAllowNetDNSZones_AAAAonlyHostFailsClosed pins the second half
+// of the fail-closed promise. Resolution can succeed without raising an
+// error, yet still yield zero usable A records when a host returns only
+// AAAA (IPv6) addresses. With the old behaviour the resulting zone would
+// have DefaultIP=0.0.0.0 and zero records, sinkholing the host in
+// exactly the same shape we set out to fix on the resolution-error path.
+//
+// docs/reference/README.md states box.create "fails — by design, so a
+// half-baked sinkhole never silently sinkholes an allow-listed host to
+// 0.0.0.0". This test makes sure that promise covers AAAA-only hosts as
+// well as resolver errors.
+func TestBuildAllowNetDNSZones_AAAAonlyHostFailsClosed(t *testing.T) {
+	v6 := []net.IPAddr{{IP: net.ParseIP("2606:4700:4700::1111")}}
+	res := &mixedResolver{
+		good: map[string][]net.IPAddr{"v6only.example.com": v6},
+	}
+
+	_, err := buildAllowNetDNSZonesWith(
+		context.Background(),
+		[]string{"v6only.example.com"},
+		res,
+	)
+	if err == nil {
+		t.Fatal("expected error when allow-listed host has only AAAA records, got nil")
+	}
+	want := "v6only.example.com"
+	if !strings.Contains(err.Error(), want) {
 		t.Errorf("error %q should mention failing host %q", err.Error(), want)
 	}
 }
@@ -367,15 +398,3 @@ func (m *mixedResolver) LookupIPAddr(_ context.Context, host string) ([]net.IPAd
 	return nil, fmt.Errorf("no test data for %q", host)
 }
 
-func contains(s, sub string) bool {
-	return len(s) >= len(sub) && (s == sub || (len(sub) > 0 && indexOf(s, sub) >= 0))
-}
-
-func indexOf(s, sub string) int {
-	for i := 0; i+len(sub) <= len(s); i++ {
-		if s[i:i+len(sub)] == sub {
-			return i
-		}
-	}
-	return -1
-}

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/dns_filter_test.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/dns_filter_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestBuildAllowNetDNSZones(t *testing.T) {
-	zones, err := buildAllowNetDNSZones([]string{
+	zones, err := buildAllowNetDNSZones(context.Background(), []string{
 		"api.openai.com",
 		"*.anthropic.com",
 		"192.168.1.1", // IP — skipped (DNS only handles hostnames)
@@ -35,7 +35,7 @@ func TestBuildAllowNetDNSZones(t *testing.T) {
 }
 
 func TestBuildAllowNetDNSZones_PerTLDZonesHaveSinkholeDefaultIP(t *testing.T) {
-	zones, err := buildAllowNetDNSZones([]string{"example.com"})
+	zones, err := buildAllowNetDNSZones(context.Background(), []string{"example.com"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -66,7 +66,7 @@ func TestBuildAllowNetDNSZones_PerTLDZonesHaveSinkholeDefaultIP(t *testing.T) {
 // Sorting zones longest-name-first guarantees the most-specific suffix
 // matches first.
 func TestBuildAllowNetDNSZones_LongestSuffixWinsBeforeRoot(t *testing.T) {
-	zones, err := buildAllowNetDNSZones([]string{
+	zones, err := buildAllowNetDNSZones(context.Background(), []string{
 		"github.com",
 		"api.github.com",
 		"raw.githubusercontent.com",
@@ -111,7 +111,7 @@ func TestBuildAllowNetDNSZones_LongestSuffixWinsBeforeRoot(t *testing.T) {
 }
 
 func TestBuildAllowNetDNSZones_EmptyList(t *testing.T) {
-	zones, err := buildAllowNetDNSZones([]string{})
+	zones, err := buildAllowNetDNSZones(context.Background(), []string{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -204,7 +204,7 @@ func (h *hangingResolver) LookupIPAddr(ctx context.Context, _ string) ([]net.IPA
 func TestBuildAllowNetDNSZones_RetriesTransientResolverFailure(t *testing.T) {
 	res := newFlakyResolver(2, errors.New("simulated transient DNS error"))
 
-	zones, err := buildAllowNetDNSZonesWith([]string{"iapi.example.com"}, res)
+	zones, err := buildAllowNetDNSZonesWith(context.Background(), []string{"iapi.example.com"}, res)
 	if err != nil {
 		t.Fatalf("expected retry to recover, got error: %v", err)
 	}
@@ -233,7 +233,7 @@ func TestBuildAllowNetDNSZones_RetriesTransientResolverFailure(t *testing.T) {
 func TestBuildAllowNetDNSZones_FailsClosedAfterRetries(t *testing.T) {
 	res := &alwaysFailResolver{err: errors.New("DNS server unreachable")}
 
-	_, err := buildAllowNetDNSZonesWith([]string{"iapi.example.com"}, res)
+	_, err := buildAllowNetDNSZonesWith(context.Background(), []string{"iapi.example.com"}, res)
 	if err == nil {
 		t.Fatal("expected error when every retry attempt fails, got nil")
 	}
@@ -258,7 +258,7 @@ func TestBuildAllowNetDNSZones_HonorsPerAttemptTimeout(t *testing.T) {
 
 	res := &hangingResolver{}
 	start := time.Now()
-	_, err := buildAllowNetDNSZonesWith([]string{"slow.example.com"}, res)
+	_, err := buildAllowNetDNSZonesWith(context.Background(), []string{"slow.example.com"}, res)
 	elapsed := time.Since(start)
 
 	if err == nil {
@@ -276,6 +276,54 @@ func TestBuildAllowNetDNSZones_HonorsPerAttemptTimeout(t *testing.T) {
 	}
 }
 
+// TestBuildAllowNetDNSZones_ParentCtxCancellationStopsRetryLoop pins
+// the contract that a cancellation on the caller-supplied context
+// (e.g. a SIGINT-aware ctx in gvproxy_create) propagates through both
+// the in-flight resolver call AND the inter-attempt backoff sleep.
+//
+// Without this, hitting Ctrl-C while a hung corp resolver is being
+// retried would block `box.create` for the full retry budget. We use
+// an inflated backoff so the wait between attempts is the dominant
+// time spent — if the loop honored ctx, the test returns within a
+// few ms of the cancel; if it ignored ctx, it'd wait out the budget
+// and the test would fail the elapsed-time bound.
+func TestBuildAllowNetDNSZones_ParentCtxCancellationStopsRetryLoop(t *testing.T) {
+	origBackoff := dnsLookupInitialBackoffVar
+	origTimeout := dnsLookupAttemptTimeoutVar
+	t.Cleanup(func() {
+		dnsLookupInitialBackoffVar = origBackoff
+		dnsLookupAttemptTimeoutVar = origTimeout
+	})
+	// Big backoff window relative to test timing — if the sleep is
+	// not interruptible, the test elapsed time will exceed the bound.
+	dnsLookupInitialBackoffVar = 5 * time.Second
+	dnsLookupAttemptTimeoutVar = 50 * time.Millisecond
+
+	res := &alwaysFailResolver{err: errors.New("always fails so we hit the backoff")}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel after the first failed attempt so we land in the
+	// inter-attempt sleep — the case the reviewer flagged.
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	_, err := buildAllowNetDNSZonesWith(ctx, []string{"slow.example.com"}, res)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected error after parent ctx cancellation, got nil")
+	}
+	// Bound: attempt timeouts (~50ms each) + cancel delay (150ms) +
+	// generous slack — anything close to the 5s backoff means the
+	// sleep wasn't interruptible.
+	if elapsed > 2*time.Second {
+		t.Errorf("retry loop kept running for %v after ctx cancel; expected to bail out promptly", elapsed)
+	}
+}
+
 // TestBuildAllowNetDNSZones_PerHostFailureFailsAggregate makes sure
 // that one bad host in a multi-host allow-list aborts the whole build.
 // Previously the sinkhole would silently come up with allow_zones=N-1
@@ -288,6 +336,7 @@ func TestBuildAllowNetDNSZones_PerHostFailureFailsAggregate(t *testing.T) {
 	}
 
 	_, err := buildAllowNetDNSZonesWith(
+		context.Background(),
 		[]string{"github.com", "api.github.com", "iapi.example.com"},
 		res,
 	)

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/gvproxy_create_latency_test.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/gvproxy_create_latency_test.go
@@ -28,15 +28,24 @@ func TestVirtualNetworkNewWithinLatencyBudget(t *testing.T) {
 
 	// Warm up once: the first construction pays one-time lazy-init costs
 	// that are not representative of the steady-state per-box cost.
-	if vn, err := virtualnetwork.New(buildTapConfig(testGvproxyConfig(), types.QemuProtocol)); err != nil {
-		t.Fatalf("warmup virtualnetwork.New failed: %v", err)
-	} else {
-		_ = vn
+	{
+		cfg, err := buildTapConfig(testGvproxyConfig(), types.QemuProtocol)
+		if err != nil {
+			t.Fatalf("warmup buildTapConfig failed: %v", err)
+		}
+		if vn, err := virtualnetwork.New(cfg); err != nil {
+			t.Fatalf("warmup virtualnetwork.New failed: %v", err)
+		} else {
+			_ = vn
+		}
 	}
 
 	samples := make([]time.Duration, 0, iters)
 	for i := 0; i < iters; i++ {
-		cfg := buildTapConfig(testGvproxyConfig(), types.QemuProtocol)
+		cfg, err := buildTapConfig(testGvproxyConfig(), types.QemuProtocol)
+		if err != nil {
+			t.Fatalf("iter %d: buildTapConfig failed: %v", i, err)
+		}
 		start := time.Now()
 		vn, err := virtualnetwork.New(cfg)
 		elapsed := time.Since(start)

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/gvproxy_create_latency_test.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/gvproxy_create_latency_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"sort"
 	"testing"
 	"time"
@@ -29,7 +30,7 @@ func TestVirtualNetworkNewWithinLatencyBudget(t *testing.T) {
 	// Warm up once: the first construction pays one-time lazy-init costs
 	// that are not representative of the steady-state per-box cost.
 	{
-		cfg, err := buildTapConfig(testGvproxyConfig(), types.QemuProtocol)
+		cfg, err := buildTapConfig(context.Background(), testGvproxyConfig(), types.QemuProtocol)
 		if err != nil {
 			t.Fatalf("warmup buildTapConfig failed: %v", err)
 		}
@@ -42,7 +43,7 @@ func TestVirtualNetworkNewWithinLatencyBudget(t *testing.T) {
 
 	samples := make([]time.Duration, 0, iters)
 	for i := 0; i < iters; i++ {
-		cfg, err := buildTapConfig(testGvproxyConfig(), types.QemuProtocol)
+		cfg, err := buildTapConfig(context.Background(), testGvproxyConfig(), types.QemuProtocol)
 		if err != nil {
 			t.Fatalf("iter %d: buildTapConfig failed: %v", i, err)
 		}

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/main.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/main.go
@@ -214,7 +214,7 @@ type GvproxyInstance struct {
 	secretMatcher *SecretHostMatcher             // Hostname→secrets lookup (nil if no secrets)
 }
 
-func buildDNSZones(config GvproxyConfig) []types.Zone {
+func buildDNSZones(config GvproxyConfig) ([]types.Zone, error) {
 	dnsZones := make([]types.Zone, 0, len(config.DNSZones)+1)
 	for _, zone := range config.DNSZones {
 		dnsZone := types.Zone{
@@ -231,15 +231,18 @@ func buildDNSZones(config GvproxyConfig) []types.Zone {
 	}
 
 	if len(config.AllowNet) > 0 {
-		allowNetZones := buildAllowNetDNSZones(config.AllowNet)
+		allowNetZones, err := buildAllowNetDNSZones(config.AllowNet)
+		if err != nil {
+			return nil, err
+		}
 		dnsZones = append(dnsZones, allowNetZones...)
 		logrus.WithField("rules", len(config.AllowNet)).Info("Network allowlist enabled (DNS sinkhole)")
 	}
 
-	return dnsZones
+	return dnsZones, nil
 }
 
-func buildTapConfig(config GvproxyConfig, protocol types.Protocol) *types.Configuration {
+func buildTapConfig(config GvproxyConfig, protocol types.Protocol) (*types.Configuration, error) {
 	nat := make(map[string]string)
 	gatewayVirtualIPs := []string{config.GatewayIP}
 	if config.HostIP != "" {
@@ -247,6 +250,11 @@ func buildTapConfig(config GvproxyConfig, protocol types.Protocol) *types.Config
 		if config.HostIP != config.GatewayIP {
 			gatewayVirtualIPs = append(gatewayVirtualIPs, config.HostIP)
 		}
+	}
+
+	dnsZones, err := buildDNSZones(config)
+	if err != nil {
+		return nil, err
 	}
 
 	return &types.Configuration{
@@ -262,10 +270,10 @@ func buildTapConfig(config GvproxyConfig, protocol types.Protocol) *types.Config
 		NAT:               nat,
 		GatewayVirtualIPs: gatewayVirtualIPs,
 		Protocol:          protocol,
-		DNS:               buildDNSZones(config),
+		DNS:               dnsZones,
 		DNSSearchDomains:  config.DNSSearchDomains,
 		CaptureFile:       "",
-	}
+	}, nil
 }
 
 var (
@@ -274,12 +282,61 @@ var (
 	nextID      int64 = 1
 )
 
+// bridgeBuildID is a hand-bumped tag that identifies the gvproxy-bridge
+// source tree this binary was built from. Bump it whenever you change
+// behavior you need to observe in the field — it's the cheapest way to
+// confirm `make runtime:debug` actually produced a fresh shim and that
+// the running boxlite-shim is loading *this* code rather than a cached
+// older build.
+//
+// Why a hand-bumped tag and not just `vcs.revision`?
+//   - `vcs.revision` from BuildInfo only reflects committed state; if
+//     you're iterating with uncommitted changes, two different
+//     in-progress versions will share the same SHA.
+//   - It also goes "dirty" once you have any local edits, which hides
+//     which behavior you actually shipped.
+// Bumping a constant is a deliberate "I changed something worth
+// distinguishing" signal that survives both situations.
+const bridgeBuildID = "gvproxy-bridge:allownet-dns-resilience-2026-06"
+
+// logBridgeBuildOnce prints the build identity exactly once per shim
+// process, the first time gvproxy_create runs. We deliberately do NOT
+// log this from package init() because logrus may not be configured
+// yet at that point (the Rust caller redirects logrus output to its own
+// log destination during shim startup, after init runs).
+var logBridgeBuildOnce sync.Once
+
+func logBridgeBuild() {
+	logBridgeBuildOnce.Do(func() {
+		fields := logrus.Fields{
+			"build_id":  bridgeBuildID,
+			"go_module": "github.com/boxlite/gvproxy-bridge",
+		}
+		if info, ok := debug.ReadBuildInfo(); ok {
+			for _, s := range info.Settings {
+				switch s.Key {
+				case "vcs.revision":
+					fields["vcs_revision"] = s.Value
+				case "vcs.modified":
+					fields["vcs_modified"] = s.Value
+				case "vcs.time":
+					fields["vcs_time"] = s.Value
+				}
+			}
+			fields["go_version"] = info.GoVersion
+		}
+		logrus.WithFields(fields).Info("gvproxy-bridge: build identity")
+	})
+}
+
 //export gvproxy_create
 //
 // On failure (return -1), the underlying error message is written to `*errOut`
 // as a heap-allocated C string. Caller must free it via gvproxy_free_string.
 // `errOut` may be nil if the caller doesn't want the message.
 func gvproxy_create(configJSON *C.char, errOut **C.char) C.longlong {
+	logBridgeBuild()
+
 	// setErr surfaces the underlying error back to the FFI caller so the
 	// Rust runtime can include it in the user-visible BoxliteError message
 	// (e.g. "listen tcp 0.0.0.0:27380: bind: address already in use" instead
@@ -325,8 +382,16 @@ func gvproxy_create(configJSON *C.char, errOut **C.char) C.longlong {
 		protocol = types.QemuProtocol
 	}
 
-	// Create gvisor-tap-vsock configuration from provided config
-	tapConfig := buildTapConfig(config, protocol)
+	// Create gvisor-tap-vsock configuration from provided config.
+	// Fails closed if any allow-listed hostname can't be resolved on the
+	// host (after retries) — better to fail box.create than ship a
+	// silently-incomplete DNS sinkhole.
+	tapConfig, err := buildTapConfig(config, protocol)
+	if err != nil {
+		logrus.WithError(err).Error("Failed to build gvproxy tap config")
+		setErr(err)
+		return -1
+	}
 
 	// Set CaptureFile if provided
 	if config.CaptureFile != nil && *config.CaptureFile != "" {
@@ -349,7 +414,6 @@ func gvproxy_create(configJSON *C.char, errOut **C.char) C.longlong {
 	// Platform-specific socket creation
 	var conn net.Conn
 	var listener net.Listener
-	var err error
 
 	if runtime.GOOS == "darwin" {
 		// macOS: Use UnixDgram with VFKit protocol (SOCK_DGRAM)

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/main.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/main.go
@@ -20,9 +20,11 @@ import (
 	"log"
 	"net"
 	"os"
+	"os/signal"
 	"runtime"
 	"runtime/debug"
 	"sync"
+	"syscall"
 	"time"
 	"unsafe"
 
@@ -214,7 +216,7 @@ type GvproxyInstance struct {
 	secretMatcher *SecretHostMatcher             // Hostname→secrets lookup (nil if no secrets)
 }
 
-func buildDNSZones(config GvproxyConfig) ([]types.Zone, error) {
+func buildDNSZones(ctx context.Context, config GvproxyConfig) ([]types.Zone, error) {
 	dnsZones := make([]types.Zone, 0, len(config.DNSZones)+1)
 	for _, zone := range config.DNSZones {
 		dnsZone := types.Zone{
@@ -231,7 +233,7 @@ func buildDNSZones(config GvproxyConfig) ([]types.Zone, error) {
 	}
 
 	if len(config.AllowNet) > 0 {
-		allowNetZones, err := buildAllowNetDNSZones(config.AllowNet)
+		allowNetZones, err := buildAllowNetDNSZones(ctx, config.AllowNet)
 		if err != nil {
 			return nil, err
 		}
@@ -242,7 +244,7 @@ func buildDNSZones(config GvproxyConfig) ([]types.Zone, error) {
 	return dnsZones, nil
 }
 
-func buildTapConfig(config GvproxyConfig, protocol types.Protocol) (*types.Configuration, error) {
+func buildTapConfig(ctx context.Context, config GvproxyConfig, protocol types.Protocol) (*types.Configuration, error) {
 	nat := make(map[string]string)
 	gatewayVirtualIPs := []string{config.GatewayIP}
 	if config.HostIP != "" {
@@ -252,7 +254,7 @@ func buildTapConfig(config GvproxyConfig, protocol types.Protocol) (*types.Confi
 		}
 	}
 
-	dnsZones, err := buildDNSZones(config)
+	dnsZones, err := buildDNSZones(ctx, config)
 	if err != nil {
 		return nil, err
 	}
@@ -282,34 +284,30 @@ var (
 	nextID      int64 = 1
 )
 
-// bridgeBuildID is a hand-bumped tag that identifies the gvproxy-bridge
-// source tree this binary was built from. Bump it whenever you change
-// behavior you need to observe in the field — it's the cheapest way to
-// confirm `make runtime:debug` actually produced a fresh shim and that
-// the running boxlite-shim is loading *this* code rather than a cached
-// older build.
-//
-// Why a hand-bumped tag and not just `vcs.revision`?
-//   - `vcs.revision` from BuildInfo only reflects committed state; if
-//     you're iterating with uncommitted changes, two different
-//     in-progress versions will share the same SHA.
-//   - It also goes "dirty" once you have any local edits, which hides
-//     which behavior you actually shipped.
-// Bumping a constant is a deliberate "I changed something worth
-// distinguishing" signal that survives both situations.
-const bridgeBuildID = "gvproxy-bridge:allownet-dns-resilience-2026-06"
-
 // logBridgeBuildOnce prints the build identity exactly once per shim
-// process, the first time gvproxy_create runs. We deliberately do NOT
-// log this from package init() because logrus may not be configured
-// yet at that point (the Rust caller redirects logrus output to its own
-// log destination during shim startup, after init runs).
+// process, the first time gvproxy_create runs. Lets a user confirm
+// whether a freshly built shim is actually what's loaded — without it,
+// "did the rebuild take effect?" is answered by guesswork.
+//
+// We deliberately do NOT log this from package init() because logrus
+// may not be configured yet at that point (the Rust caller redirects
+// logrus output to its own log destination during shim startup, after
+// init runs).
+//
+// All fields are derived from runtime/debug.ReadBuildInfo so they
+// can't drift out of sync with the source tree:
+//
+//   - vcs_revision: HEAD SHA of the gvproxy-bridge module at build time.
+//   - vcs_modified: "true" when there were uncommitted edits (the most
+//     reliable "is this my in-progress build?" signal — a user iterating
+//     locally always sees true, a CI build always sees false).
+//   - vcs_time:     commit timestamp of HEAD.
+//   - go_version:   toolchain version.
 var logBridgeBuildOnce sync.Once
 
 func logBridgeBuild() {
 	logBridgeBuildOnce.Do(func() {
 		fields := logrus.Fields{
-			"build_id":  bridgeBuildID,
 			"go_module": "github.com/boxlite/gvproxy-bridge",
 		}
 		if info, ok := debug.ReadBuildInfo(); ok {
@@ -386,7 +384,15 @@ func gvproxy_create(configJSON *C.char, errOut **C.char) C.longlong {
 	// Fails closed if any allow-listed hostname can't be resolved on the
 	// host (after retries) — better to fail box.create than ship a
 	// silently-incomplete DNS sinkhole.
-	tapConfig, err := buildTapConfig(config, protocol)
+	//
+	// The ctx here is signal-aware: SIGINT/SIGTERM during the allow-list
+	// resolution loop (which can take seconds when retries fire on a slow
+	// corp resolver) cancels the in-flight lookup *and* the inter-attempt
+	// backoff, so Ctrl-C ends `box.create` promptly rather than waiting
+	// out the full retry budget.
+	resolveCtx, stopResolve := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	tapConfig, err := buildTapConfig(resolveCtx, config, protocol)
+	stopResolve()
 	if err != nil {
 		logrus.WithError(err).Error("Failed to build gvproxy tap config")
 		setErr(err)

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/main.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/main.go
@@ -20,11 +20,9 @@ import (
 	"log"
 	"net"
 	"os"
-	"os/signal"
 	"runtime"
 	"runtime/debug"
 	"sync"
-	"syscall"
 	"time"
 	"unsafe"
 
@@ -385,14 +383,17 @@ func gvproxy_create(configJSON *C.char, errOut **C.char) C.longlong {
 	// host (after retries) — better to fail box.create than ship a
 	// silently-incomplete DNS sinkhole.
 	//
-	// The ctx here is signal-aware: SIGINT/SIGTERM during the allow-list
-	// resolution loop (which can take seconds when retries fire on a slow
-	// corp resolver) cancels the in-flight lookup *and* the inter-attempt
-	// backoff, so Ctrl-C ends `box.create` promptly rather than waiting
-	// out the full retry budget.
-	resolveCtx, stopResolve := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	tapConfig, err := buildTapConfig(resolveCtx, config, protocol)
-	stopResolve()
+	// We deliberately do NOT install our own SIGINT/SIGTERM handler here.
+	// gvproxy_create runs inside the embedder's process (rust/python/node
+	// SDKs all link this go code as a c-shared library), and grabbing the
+	// host's signal disposition for the duration of every box.create
+	// would override whatever signal handling the embedder has installed.
+	// The cost is that a SIGTERM mid-create can't interrupt the resolver
+	// loop — worst case ~12s per dead allow_net entry, sequentially. The
+	// embedder is expected to either (a) accept that latency on shutdown,
+	// or (b) run box.create on a worker thread and abandon the worker on
+	// shutdown. See docs/reference/README.md for the latency note.
+	tapConfig, err := buildTapConfig(context.Background(), config, protocol)
 	if err != nil {
 		logrus.WithError(err).Error("Failed to build gvproxy tap config")
 		setErr(err)


### PR DESCRIPTION
  ## Issue
When `allow_net` is set, allow-listed hostnames sometimes resolve to `0.0.0.0` inside the guest, even though the host is reachable and `box.create` reports success. The failure is intermittent and silent — the only signal is `allow_zones=N-1 total_zones=N` in the gvproxy log.

  ```
  # inside the guest
  $ getent hosts iapi.example.com
  0.0.0.0   iapi.example.com
  ```

  These are the root causes and fixes:

  1. Host-side resolution had no retry or timeout — one transient hiccup (VPN flap, slow corp DNS) silently dropped the zone.
  2. When resolution definitively failed, `box.create` proceeded with a half-baked sinkhole instead of failing loudly.
  3. Zones were emitted in Go map-iteration order. gvisor-tap-vsock matches first-suffix-wins, so an `subdomain.domain.com.` query could land on a `com.` zone (created for `github.com`) before the `domain.com.` zone and return that zone's `DefaultIP=0.0.0.0`.

  ## Changes

  - [x] Retry host-side `LookupIPAddr` with exponential backoff (4 attempts: 100/300/900/2700 ms) and a 2 s per-attempt deadline
  - [x] Fail-closed: propagate resolver errors through `buildAllowNetDNSZones` → `buildTapConfig` → `gvproxy_create`, surfaced via the new `errOut` channel from #612
  - [x] Sort zones longest-name-first so the most-specific suffix wins; catch-all root zone stays last

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DNS lookups during box creation now use automatic retries with exponential backoff and per-attempt timeouts.
  * DNS resolution is signal-aware and cancels promptly on SIGINT/SIGTERM.

* **Bug Fixes**
  * Deterministic longest-suffix DNS zone ordering to avoid incorrectly sinkholing allow-listed hosts.
  * Box creation fails explicitly if allow-list hostnames cannot be resolved.

* **Documentation**
  * Added troubleshooting and reference guidance for allow_net DNS behavior and recovery.

* **Tests**
  * Expanded tests covering retries, timeouts, cancellation, and ordering.

* **Chores**
  * Log build identity once per process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->