### PR TITLE
fix(api): source /v1/me expires_at from ApiKey.expiresAt (P1-2)

### DIFF
--- a/apps/api/jest.config.ts
+++ b/apps/api/jest.config.ts
@@ -11,6 +11,10 @@ export default {
   transform: {
     '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
   },
+  // uuid v14 ships ESM-only (`export` syntax). The nx preset ignores node_modules
+  // from transformation, so any spec that transitively imports an entity using
+  // `uuid` (e.g. via OrganizationService) crashes on the ESM. Let ts-jest down-level it.
+  transformIgnorePatterns: ['/node_modules/(?!(?:uuid)/)'],
   moduleFileExtensions: ['ts', 'js', 'html'],
   coverageDirectory: '../../coverage/apps/boxlite',
 }

--- a/apps/api/src/boxlite-rest/boxlite-me.controller.spec.ts
+++ b/apps/api/src/boxlite-rest/boxlite-me.controller.spec.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { ApiKey } from '../api-key/api-key.entity'
+import { AuthContext } from '../common/interfaces/auth-context.interface'
+import { OrganizationService } from '../organization/services/organization.service'
+import { BoxliteMeController } from './boxlite-me.controller'
+
+describe('BoxliteMeController', () => {
+  // resolvePathPrefix only touches OrganizationService on the user-session path;
+  // API-key contexts short-circuit on apiKey.organizationId.
+  function makeController(orgFindByUser: jest.Mock = jest.fn()): BoxliteMeController {
+    const organizationService = { findByUser: orgFindByUser } as unknown as OrganizationService
+    return new BoxliteMeController(organizationService)
+  }
+
+  function apiKeyContext(expiresAt?: Date): AuthContext {
+    const apiKey = {
+      organizationId: '11111111-1111-1111-1111-111111111111',
+      userId: 'user-1',
+      name: 'key-531',
+      expiresAt,
+    } as ApiKey
+    return {
+      userId: 'user-1',
+      email: 'svc@example.com',
+      role: 'user' as AuthContext['role'],
+      apiKey,
+      organizationId: apiKey.organizationId,
+    }
+  }
+
+  describe('GET /v1/me — expires_at is sourced from ApiKey.expiresAt', () => {
+    it('returns the API key expiry as an ISO string (same field the dashboard renders)', async () => {
+      const expiresAt = new Date('2026-06-07T12:00:00.000Z')
+      const result = await makeController().getMe(apiKeyContext(expiresAt))
+
+      expect(result.principal_type).toBe('service_account')
+      expect(result.expires_at).toBe(expiresAt.toISOString())
+    })
+
+    it('returns null for a non-expiring API key (expiresAt unset)', async () => {
+      const result = await makeController().getMe(apiKeyContext(undefined))
+
+      expect(result.expires_at).toBeNull()
+    })
+
+    it('returns null for an interactive user session (no API key)', async () => {
+      const findByUser = jest.fn().mockResolvedValue([])
+      const ctx: AuthContext = {
+        userId: 'user-2',
+        email: 'human@example.com',
+        role: 'user' as AuthContext['role'],
+      }
+
+      const result = await makeController(findByUser).getMe(ctx)
+
+      expect(result.principal_type).toBe('user')
+      expect(result.expires_at).toBeNull()
+    })
+  })
+})

--- a/apps/api/src/boxlite-rest/boxlite-me.controller.ts
+++ b/apps/api/src/boxlite-rest/boxlite-me.controller.ts
@@ -56,7 +56,11 @@ export class BoxliteMeController {
         'snapshot:delete',
         'me:read',
       ],
-      expires_at: null,
+      // Source of truth for key expiry is ApiKey.expiresAt — the same column the
+      // dashboard's `/api-keys` list renders. Returning a hardcoded null here let
+      // clients believe a soon-to-expire key was permanent (P1-2). `null` stays
+      // correct for non-expiring keys and for interactive user sessions (no apiKey).
+      expires_at: ctx.apiKey?.expiresAt ? ctx.apiKey.expiresAt.toISOString() : null,
     }
   }
 


### PR DESCRIPTION
## Problem (P1-2)

`/v1/me` and the dashboard's `/dashboard/keys` page showed **conflicting** key-expiry info, so a user couldn't tell when their key actually stops working:

- Dashboard "Expires" column showed an active key as `in 4d`
- `curl .../v1/me` for the **same** key returned `"expires_at": null`

Root cause: `boxlite-me.controller.ts` **hardcoded** `expires_at: null` and never read the key's real expiry. Meanwhile the dashboard list endpoint (`GET /api-keys`) correctly returns `ApiKey.expiresAt` — and that same column is what auth actually enforces (`api-key.strategy.ts` rejects on `apiKey.expiresAt < now`). So `/v1/me` was lying: a client trusting it would believe a soon-to-expire key was permanent, then hit an unexplained `403` at expiry.

## Fix

Source `expires_at` from the same backend field the dashboard renders and auth enforces — `ApiKey.expiresAt`:

```ts
expires_at: ctx.apiKey?.expiresAt ? ctx.apiKey.expiresAt.toISOString() : null,
```

- API key with expiry → real ISO timestamp (matches dashboard)
- Non-expiring key → `null` (correct)
- Interactive user session (no API key) → `null` (no key-expiry concept)

`PrincipalDto.expires_at` is already typed `string | null`, matching the OpenAPI contract — no DTO/spec change needed.

## Tests

New reproducer `boxlite-me.controller.spec.ts` (3 cases). Two-side verified:

1. Revert the fix → targeted case fails: `Expected "2026-06-07T12:00:00.000Z" / Received null` (points at the bug; other 2 cases stay green, so it's not tautological).
2. Restore the fix → 3/3 pass.

Full `nx test api` → **16/16 pass**; `eslint` exit 0.

### Note on the jest.config change
This app had no controller/service specs before, so a latent jest gap surfaced: `uuid@14` is ESM-only and the nx preset doesn't transform `node_modules`, so any spec transitively importing an entity that uses `uuid` (via `OrganizationService`) crashed on the ESM `export`. Added a scoped `transformIgnorePatterns` whitelist so ts-jest down-levels `uuid`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)