### PR TITLE
Configure CLA Assistant

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Legal and contributor policy changes require project owner review.
+/CONTRIBUTING.md @DorianZheng
+/docs/legal/ @DorianZheng
+/.github/CODEOWNERS @DorianZheng

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,7 @@ Key test entry points:
 4. Run quality and tests (`make lint && make fmt:check && make test`)
 5. Commit with clear messages
 6. Open a Pull Request
+7. Sign the [BoxLite Contributor License Agreement](./docs/legal/CLA.md) when CLA Assistant asks you to do so
 
 ### Code Style
 
@@ -95,4 +96,6 @@ examples/         # Example code
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the Apache License 2.0.
+BoxLite is licensed under the Apache License, Version 2.0.
+
+By contributing, you agree that your contributions will be licensed under the Apache License, Version 2.0. Pull requests must satisfy CLA Assistant using the [BoxLite Contributor License Agreement](./docs/legal/CLA.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,3 +9,7 @@
 ## Architecture
 
 ## Contributing
+
+## Legal
+
+- [Contributor License Agreement](./legal/CLA.md)

--- a/docs/legal/CLA.md
+++ b/docs/legal/CLA.md
@@ -1,0 +1,20 @@
+# BoxLite Contributor License Agreement
+
+Version: 2026-06-03
+
+Canonical source: https://github.com/boxlite-ai/boxlite/blob/main/docs/legal/CLA.md
+
+Thank you for contributing to BoxLite.
+
+By submitting a pull request, issue patch, commit, or other contribution to the `boxlite-ai/boxlite` project, you agree to the following terms:
+
+1. You are legally entitled to submit the contribution.
+2. If your contribution was created for an employer or another legal entity, you have permission to submit it under these terms.
+3. Your contribution is submitted under the Apache License, Version 2.0, the same license used by the BoxLite project.
+4. You grant the BoxLite project and its recipients the rights needed to use, copy, modify, distribute, and sublicense your contribution as part of the project under the Apache License, Version 2.0.
+5. You are not knowingly submitting code, documentation, or other material that violates a third party's copyright, patent, trademark, trade secret, license, or other rights.
+6. This agreement is not a copyright assignment. You retain copyright ownership of your contribution, subject to the license grant above.
+
+The Apache License, Version 2.0 is available in the BoxLite repository at:
+
+https://github.com/boxlite-ai/boxlite/blob/main/LICENSE


### PR DESCRIPTION
## Summary

- Add a canonical BoxLite Contributor License Agreement under `docs/legal/CLA.md`.
- Update contributor docs to tell PR authors to satisfy CLA Assistant.
- Add CODEOWNERS coverage for contributor policy and legal document changes.
- Link the CLA from the documentation index.

## Why

CLA Assistant is now installed and the repository ruleset requires the `license/cla` status on protected branches. The repository should carry the canonical agreement and make the signing requirement visible to contributors.

## Validation

- `git diff --cached --check`
- `git show --check HEAD`
- Verified the CLA Assistant contributor-facing page renders the agreement text and canonical repo source.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Contributor License Agreement (CLA) documentation and integrated CLA signing requirement into the contribution process
  * Updated contribution guidelines to include CLA acknowledgment step for pull requests
  * Clarified Apache License 2.0 terminology in documentation
  * Established repository ownership governance for legal and contribution policy files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->