### PR TITLE
feat(stability): hang defences — box.create deadline + per-box lock timeout

### DIFF
--- a/sdks/c/include/boxlite.h
+++ b/sdks/c/include/boxlite.h
@@ -62,6 +62,10 @@ typedef enum BoxliteErrorCode {
   // Interactive execution session was reaped server-side after disconnect.
   // Reattach is no longer possible — start a new exec.
   SessionReaped = 21,
+  // Operation exceeded its wall-clock deadline (e.g. `box.create`
+  // budget, lock acquisition timeout). Surfaced by the hang-defence
+  // wrappers in the Rust runtime.
+  Timeout = 22,
 } BoxliteErrorCode;
 
 typedef enum BoxliteRegistryTransport {

--- a/sdks/c/src/error.rs
+++ b/sdks/c/src/error.rs
@@ -64,6 +64,10 @@ pub enum BoxliteErrorCode {
     /// Interactive execution session was reaped server-side after disconnect.
     /// Reattach is no longer possible — start a new exec.
     SessionReaped = 21,
+    /// Operation exceeded its wall-clock deadline (e.g. `box.create`
+    /// budget, lock acquisition timeout). Surfaced by the hang-defence
+    /// wrappers in the Rust runtime.
+    Timeout = 22,
 }
 
 /// Extended error information for C API.
@@ -111,6 +115,7 @@ pub fn error_to_code(err: &BoxliteError) -> BoxliteErrorCode {
         BoxliteError::MetadataError(_) => BoxliteErrorCode::Metadata,
         BoxliteError::ResourceExhausted(_) => BoxliteErrorCode::ResourceExhausted,
         BoxliteError::SessionReaped(_) => BoxliteErrorCode::SessionReaped,
+        BoxliteError::Timeout(_) => BoxliteErrorCode::Timeout,
     }
 }
 

--- a/src/boxlite/src/litebox/box_impl.rs
+++ b/src/boxlite/src/litebox/box_impl.rs
@@ -650,8 +650,11 @@ impl BoxImpl {
         );
 
         // Hold the lock for the duration of build operations.
-        // LockGuard acquires lock on creation and releases on drop.
-        let _guard = LockGuard::new(&*locker);
+        // Uses the hang-defence variant with a deadline so a crashed-
+        // but-not-cleaned-up holder doesn't wedge box init forever.
+        // Default 30 s is generous for a healthy spawn pipeline and
+        // short enough that a stuck previous instance surfaces quickly.
+        let _guard = LockGuard::with_timeout(&*locker, std::time::Duration::from_secs(30))?;
 
         // Build the box (lock is held)
         // The returned cleanup_guard stays armed until we disarm it after all
@@ -1189,6 +1192,7 @@ mod tests {
         let runtime = RuntimeImpl::new(BoxliteOptions {
             home_dir: temp_dir.path().to_path_buf(),
             image_registries: vec![],
+            create_timeout: std::time::Duration::from_secs(90),
         })
         .expect("create runtime");
 

--- a/src/boxlite/src/litebox/init/types.rs
+++ b/src/boxlite/src/litebox/init/types.rs
@@ -395,6 +395,7 @@ mod tests {
         let runtime = RuntimeImpl::new(BoxliteOptions {
             home_dir: home.path.clone(),
             image_registries: vec![],
+            create_timeout: std::time::Duration::from_secs(90),
         })
         .expect("create runtime");
 

--- a/src/boxlite/src/lock/mod.rs
+++ b/src/boxlite/src/lock/mod.rs
@@ -160,6 +160,29 @@ pub trait Locker: Send + Sync {
     ///
     /// Returns `true` if the lock was acquired, `false` if it was already held.
     fn try_lock(&self) -> bool;
+
+    /// Try to acquire the lock, retrying with a 10 ms backoff until
+    /// `deadline` elapses. Returns `true` if the lock was acquired.
+    ///
+    /// Default implementation polls `try_lock()`. Implementations with a
+    /// kernel-level wait primitive (e.g., flock + signalfd) can override
+    /// for a tighter loop.
+    fn try_lock_until(&self, deadline: std::time::Instant) -> bool {
+        loop {
+            if self.try_lock() {
+                return true;
+            }
+            let now = std::time::Instant::now();
+            if now >= deadline {
+                return false;
+            }
+            // 10 ms × ~100 iterations/sec; cheap enough on a contested
+            // lock, and bounded by the per-attempt deadline above.
+            let remaining = deadline.saturating_duration_since(now);
+            let nap = std::time::Duration::from_millis(10).min(remaining);
+            std::thread::sleep(nap);
+        }
+    }
 }
 
 /// Convenience guard for RAII-style lock management.
@@ -168,7 +191,10 @@ pub struct LockGuard<'a> {
 }
 
 impl<'a> LockGuard<'a> {
-    /// Create a new guard, acquiring the lock.
+    /// Create a new guard, acquiring the lock (blocks until available).
+    ///
+    /// Prefer [`LockGuard::with_timeout`] in production paths so a
+    /// crashed-but-not-cleaned-up holder can't wedge the whole runtime.
     pub fn new(lock: &'a dyn Locker) -> Self {
         lock.lock();
         Self { lock }
@@ -182,6 +208,26 @@ impl<'a> LockGuard<'a> {
             Some(Self { lock })
         } else {
             None
+        }
+    }
+
+    /// Acquire the lock with a wall-clock deadline.
+    ///
+    /// Returns `Err(BoxliteError::Timeout)` if `timeout` elapses before
+    /// the lock can be obtained. This is the hang-defence variant: a
+    /// previous holder that crashed without releasing — or a stuck box
+    /// init in another process — will surface as a clear error instead
+    /// of an unbounded block.
+    pub fn with_timeout(lock: &'a dyn Locker, timeout: std::time::Duration) -> BoxliteResult<Self> {
+        let deadline = std::time::Instant::now() + timeout;
+        if lock.try_lock_until(deadline) {
+            Ok(Self { lock })
+        } else {
+            Err(BoxliteError::Timeout(format!(
+                "lock {} not acquired within {:?}",
+                lock.id(),
+                timeout
+            )))
         }
     }
 }
@@ -275,5 +321,72 @@ mod tests {
 
         assert!(lock.try_lock(), "should be able to acquire released lock");
         lock.unlock();
+    }
+
+    // ================================================================
+    // Hang-defence: LockGuard::with_timeout
+    //
+    // Side B (revert the deadline check in `try_lock_until` so it
+    // blocks forever) flips `with_timeout_returns_error_when_contended`
+    // red — the call would hang past the test's outer wall-clock.
+    // ================================================================
+
+    #[test]
+    fn with_timeout_returns_quickly_when_uncontended() {
+        let manager = InMemoryLockManager::new(16);
+        let id = manager.allocate().expect("allocate");
+        let lock = manager.retrieve(id).expect("retrieve");
+
+        let start = std::time::Instant::now();
+        let guard = LockGuard::with_timeout(lock.as_ref(), std::time::Duration::from_secs(5))
+            .expect("uncontended lock should succeed immediately");
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed < std::time::Duration::from_millis(50),
+            "uncontended acquire should be ~instant; got {:?}",
+            elapsed
+        );
+        drop(guard);
+    }
+
+    #[test]
+    fn with_timeout_returns_error_when_contended() {
+        let manager = InMemoryLockManager::new(16);
+        let id = manager.allocate().expect("allocate");
+        let lock = manager.retrieve(id).expect("retrieve");
+
+        // First holder takes the lock and never releases for the
+        // duration of the test.
+        let _held = LockGuard::new(lock.as_ref());
+
+        let start = std::time::Instant::now();
+        let res = LockGuard::with_timeout(lock.as_ref(), std::time::Duration::from_millis(150));
+        let elapsed = start.elapsed();
+
+        match &res {
+            Err(BoxliteError::Timeout(_)) => {}
+            other => panic!(
+                "contended acquire must return Timeout; got {}",
+                match other {
+                    Err(e) => format!("Err({})", e),
+                    Ok(_) => "Ok(_)".to_string(),
+                }
+            ),
+        }
+        // Drop the contested Result without forcing Debug on its Ok arm.
+        drop(res);
+        // Bound: ≥ requested timeout, but not orders of magnitude over.
+        // 10ms polling cadence × 15 iterations = 150ms minimum; upper
+        // bound is generous to avoid CI flake.
+        assert!(
+            elapsed >= std::time::Duration::from_millis(140),
+            "elapsed must be at least the timeout; got {:?}",
+            elapsed
+        );
+        assert!(
+            elapsed < std::time::Duration::from_millis(500),
+            "elapsed must not run wildly over; got {:?}",
+            elapsed
+        );
     }
 }

--- a/src/boxlite/src/runtime/options.rs
+++ b/src/boxlite/src/runtime/options.rs
@@ -46,6 +46,28 @@ pub struct BoxliteOptions {
     /// ```
     #[serde(default)]
     pub image_registries: Vec<ImageRegistry>,
+
+    /// Wall-clock budget for `runtime.create(...)`.
+    ///
+    /// Default: 90 seconds. The create pipeline runs many awaits
+    /// (image pull, rootfs prep, shim spawn, guest ready, init
+    /// gRPC). Any of them can wedge — corp DNS times out an OCI
+    /// registry pull, libkrun fails to negotiate, guest agent
+    /// crashes without signalling ready. Without a deadline, the
+    /// caller's `.await` blocks indefinitely.
+    ///
+    /// On timeout the future is dropped, `CleanupGuard::Drop` rolls
+    /// back any partially-built state, and the caller sees
+    /// `BoxliteError::Timeout`.
+    ///
+    /// Set to `Duration::from_secs(0)` to disable the deadline
+    /// (caller is on its own for hang detection).
+    #[serde(
+        default = "default_create_timeout",
+        with = "duration_seconds",
+        skip_serializing_if = "is_default_create_timeout"
+    )]
+    pub create_timeout: std::time::Duration,
 }
 
 /// Registry host configuration for OCI image pulls.
@@ -166,11 +188,47 @@ fn default_home_dir() -> PathBuf {
         })
 }
 
+fn default_create_timeout() -> std::time::Duration {
+    std::time::Duration::from_secs(90)
+}
+
+/// Skip serialising `create_timeout` when it equals the default —
+/// keeps existing JSON snapshots / round-trip tests stable for the
+/// 99 % case where operators don't override the budget.
+#[allow(clippy::trivially_copy_pass_by_ref)]
+fn is_default_create_timeout(d: &std::time::Duration) -> bool {
+    *d == default_create_timeout()
+}
+
+/// Serialize/deserialize a `Duration` as whole seconds. Keeps the wire
+/// shape readable (`"create_timeout": 90`) and matches how config
+/// authors think about deadlines.
+mod duration_seconds {
+    use serde::{Deserialize, Deserializer, Serializer};
+    use std::time::Duration;
+
+    pub fn serialize<S>(d: &Duration, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        s.serialize_u64(d.as_secs())
+    }
+
+    pub fn deserialize<'de, D>(d: D) -> Result<Duration, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let secs = u64::deserialize(d)?;
+        Ok(Duration::from_secs(secs))
+    }
+}
+
 impl Default for BoxliteOptions {
     fn default() -> Self {
         Self {
             home_dir: default_home_dir(),
             image_registries: Vec::new(),
+            create_timeout: default_create_timeout(),
         }
     }
 }
@@ -255,6 +313,7 @@ mod registry_options_tests {
                     .with_basic_auth("alice", password.as_str()),
                 ImageRegistry::https("registry.example.com").with_bearer_auth(token.as_str()),
             ],
+            create_timeout: std::time::Duration::from_secs(90),
         };
 
         let value = serde_json::to_value(options).unwrap();

--- a/src/boxlite/src/runtime/rt_impl.rs
+++ b/src/boxlite/src/runtime/rt_impl.rs
@@ -136,6 +136,14 @@ pub struct RuntimeImpl {
     /// BOXLITE_HOME directory
     pub(crate) _runtime_lock: RuntimeLock,
 
+    /// Wall-clock budget for `runtime.create()`. Captured from
+    /// `BoxliteOptions.create_timeout` at construction. Used by
+    /// `LocalRuntime::create` to wrap the inner init pipeline in a
+    /// `tokio::time::timeout` so a wedged step (corp-DNS-blocked image
+    /// pull, libkrun handshake stuck, guest ready signal lost)
+    /// surfaces as a clean error instead of an unbounded await.
+    pub(crate) create_timeout: std::time::Duration,
+
     // ========================================================================
     // SHUTDOWN COORDINATION
     // ========================================================================
@@ -274,6 +282,7 @@ impl RuntimeImpl {
             snapshot_mgr,
             lock_manager,
             _runtime_lock: runtime_lock,
+            create_timeout: options.create_timeout,
             shutdown_token: CancellationToken::new(),
         });
 
@@ -1546,7 +1555,26 @@ pub(crate) struct LocalRuntime(pub(crate) SharedRuntimeImpl);
 #[async_trait::async_trait]
 impl super::backend::RuntimeBackend for LocalRuntime {
     async fn create(&self, options: BoxOptions, name: Option<String>) -> BoxliteResult<LiteBox> {
-        self.0.create(options, name).await
+        let budget = self.0.create_timeout;
+        let inner = self.0.create(options, name);
+        if budget.is_zero() {
+            // Operator opted out of the deadline — fall through to the
+            // raw .await. (Useful for tests that need to verify the
+            // un-wrapped pipeline still works.)
+            return inner.await;
+        }
+        // Wrap in tokio::time::timeout so a wedged init step (image
+        // pull stuck, libkrun handshake hung, guest ready never
+        // signals) surfaces as `BoxliteError::Timeout`. The future
+        // drop fires `CleanupGuard::Drop`, which rolls back the
+        // partially-built box.
+        match tokio::time::timeout(budget, inner).await {
+            Ok(result) => result,
+            Err(_) => Err(BoxliteError::Timeout(format!(
+                "box.create exceeded {budget:?} wall-clock budget; \
+                 the partially-built box was rolled back via CleanupGuard"
+            ))),
+        }
     }
 
     async fn get_or_create(
@@ -1654,6 +1682,7 @@ mod tests {
         let options = BoxliteOptions {
             home_dir: temp_dir.path().to_path_buf(),
             image_registries: vec![],
+            create_timeout: std::time::Duration::from_secs(90),
         };
         let runtime = RuntimeImpl::new(options).expect("Failed to create runtime");
         (runtime, temp_dir)
@@ -2879,5 +2908,85 @@ mod tests {
         // mark_stop runs for non-Configured states; Failed -> Stopped.
         let (_, db_state) = runtime.box_manager.box_by_id(&config.id).unwrap().unwrap();
         assert_eq!(db_state.status, BoxStatus::Stopped);
+    }
+
+    // ===========================================================
+    // Hang-defence: LocalRuntime::create wall-clock budget
+    //
+    // The 3-line wrapper in `LocalRuntime::create`:
+    //
+    //   if budget.is_zero() { return inner.await; }
+    //   tokio::time::timeout(budget, inner).await ...
+    //
+    // is exercised below via the budget-zero escape hatch. The
+    // budget-fires path needs time-injection scaffolding (the inner
+    // pipeline does real fs/network work that doesn't react to
+    // `tokio::time::advance`) and is left as a follow-up. Reverting
+    // the `if budget.is_zero()` short-circuit would not flip this
+    // test red — the test would simply also exercise the timeout
+    // wrap with a 0-duration budget, which `tokio::time::timeout`
+    // treats as "elapsed already" and the test would observe a
+    // Timeout error instead of the inner's natural error. That's
+    // exactly the assertion below: side B (no escape hatch) yields
+    // `Err(Timeout(_))` instead of the inner's `Err(Image(_))`.
+    // ===========================================================
+
+    /// Side A: with the default (non-zero) budget, a successful
+    /// `create` runs through the wrapper without surfacing Timeout.
+    /// This rules out the wrapper accidentally swallowing the inner
+    /// result on the happy path. Side B (the operator-opt-out branch)
+    /// is exercised below by setting budget to zero.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn local_runtime_create_default_budget_does_not_wrap_to_timeout() {
+        let (runtime, _dir) = create_test_runtime();
+        let local = LocalRuntime(runtime);
+        let opts = BoxOptions {
+            rootfs: RootfsSpec::Image("alpine:latest".into()),
+            ..Default::default()
+        };
+        let res = local.create(opts, None).await;
+        // `create()` defers image pull to `start()`, so this is the
+        // fast path: persist + return handle. The wrapper must allow
+        // that to succeed.
+        let lb = match res {
+            Ok(lb) => lb,
+            Err(BoxliteError::Timeout(msg)) => {
+                panic!("happy-path create must NOT surface Timeout; got {msg}")
+            }
+            Err(other) => panic!("unexpected error on happy-path create: {other}"),
+        };
+        // Drop the handle (no start() to avoid pulling real images).
+        drop(lb);
+    }
+
+    /// Side B (escape hatch): a `budget == Duration::ZERO` config
+    /// must bypass `tokio::time::timeout` entirely — otherwise a
+    /// zero-second budget would treat every awaited future as
+    /// "already elapsed" and return Timeout immediately. Reverting
+    /// the `if budget.is_zero() { return inner.await }` short-circuit
+    /// flips this red.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn local_runtime_create_zero_budget_escape_hatch_does_not_timeout() {
+        let tmp = TempDir::new_in("/tmp").expect("tmp");
+        let options = BoxliteOptions {
+            home_dir: tmp.path().to_path_buf(),
+            image_registries: vec![],
+            create_timeout: std::time::Duration::ZERO,
+        };
+        let runtime = RuntimeImpl::new(options).expect("runtime");
+        let local = LocalRuntime(runtime);
+
+        let opts = BoxOptions {
+            rootfs: RootfsSpec::Image("alpine:latest".into()),
+            ..Default::default()
+        };
+        let res = local.create(opts, None).await;
+        match res {
+            Ok(_) => {} // happy path — wrapper correctly bypassed
+            Err(BoxliteError::Timeout(msg)) => panic!(
+                "budget=0 must NOT translate happy-path create into Timeout; got {msg}"
+            ),
+            Err(other) => panic!("unexpected error: {other}"),
+        }
     }
 }

--- a/src/boxlite/src/runtime/rt_impl.rs
+++ b/src/boxlite/src/runtime/rt_impl.rs
@@ -2983,9 +2983,9 @@ mod tests {
         let res = local.create(opts, None).await;
         match res {
             Ok(_) => {} // happy path — wrapper correctly bypassed
-            Err(BoxliteError::Timeout(msg)) => panic!(
-                "budget=0 must NOT translate happy-path create into Timeout; got {msg}"
-            ),
+            Err(BoxliteError::Timeout(msg)) => {
+                panic!("budget=0 must NOT translate happy-path create into Timeout; got {msg}")
+            }
             Err(other) => panic!("unexpected error: {other}"),
         }
     }

--- a/src/boxlite/tests/README.md
+++ b/src/boxlite/tests/README.md
@@ -82,6 +82,7 @@ async fn test_box_lifecycle() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+            create_timeout: std::time::Duration::from_secs(90),
     }).expect("create runtime");
     let handle = runtime.create(alpine_opts(), None).await.unwrap();
     handle.start().await.unwrap();
@@ -104,6 +105,7 @@ async fn test_shutdown_idempotent() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+            create_timeout: std::time::Duration::from_secs(90),
     }).expect("create runtime");
     // ... test logic using runtime ...
 }

--- a/src/boxlite/tests/clone_export_import.rs
+++ b/src/boxlite/tests/clone_export_import.rs
@@ -55,6 +55,7 @@ async fn test_clone_produces_independent_box() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
     let source = create_stopped_box(&runtime).await;
@@ -84,6 +85,7 @@ async fn test_export_import_roundtrip() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
     let source = create_stopped_box(&runtime).await;
@@ -124,6 +126,7 @@ async fn test_export_import_preserves_box_options() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -161,6 +164,7 @@ async fn test_clone_running_box() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
     let source = create_running_box(&runtime, "clone-src").await;
@@ -205,6 +209,7 @@ async fn test_export_running_box() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
     let source = create_running_box(&runtime, "export-running").await;
@@ -251,6 +256,7 @@ async fn test_export_import_running_box_roundtrip() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
     let source = create_running_box(&runtime, "roundtrip-running").await;
@@ -312,6 +318,7 @@ async fn test_clone_snapshot_isolation() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
     let source = create_running_box(&runtime, "isolation-src").await;
@@ -368,6 +375,7 @@ async fn test_clone_10x_benchmark() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
     let source = create_stopped_box(&runtime).await;
@@ -414,6 +422,7 @@ async fn test_export_under_write_pressure() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
     let source = create_running_box(&runtime, "write-stress").await;

--- a/src/boxlite/tests/copy.rs
+++ b/src/boxlite/tests/copy.rs
@@ -54,6 +54,7 @@ async fn copy_integration() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
     let bx = runtime

--- a/src/boxlite/tests/detach.rs
+++ b/src/boxlite/tests/detach.rs
@@ -31,6 +31,7 @@ async fn detached_box_creates_pid_file() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -65,6 +66,7 @@ async fn detached_box_survives_runtime_drop() {
         let runtime = BoxliteRuntime::new(BoxliteOptions {
             home_dir: home.path.clone(),
             image_registries: common::test_registries(),
+            create_timeout: std::time::Duration::from_secs(90),
         })
         .unwrap();
 
@@ -102,6 +104,7 @@ async fn detached_box_survives_runtime_drop() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .unwrap();
     runtime.remove(&box_id, true).await.unwrap();
@@ -124,6 +127,7 @@ async fn non_detached_box_exits_on_runtime_drop() {
         let runtime = BoxliteRuntime::new(BoxliteOptions {
             home_dir: home_dir.clone(),
             image_registries: common::test_registries(),
+            create_timeout: std::time::Duration::from_secs(90),
         })
         .unwrap();
 
@@ -170,6 +174,7 @@ async fn multiple_detached_boxes_each_have_pid_file() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -225,6 +230,7 @@ async fn detached_box_recoverable_after_restart() {
         let runtime = BoxliteRuntime::new(BoxliteOptions {
             home_dir: home.path.clone(),
             image_registries: common::test_registries(),
+            create_timeout: std::time::Duration::from_secs(90),
         })
         .unwrap();
 
@@ -248,6 +254,7 @@ async fn detached_box_recoverable_after_restart() {
         let runtime = BoxliteRuntime::new(BoxliteOptions {
             home_dir: home.path.clone(),
             image_registries: common::test_registries(),
+            create_timeout: std::time::Duration::from_secs(90),
         })
         .unwrap();
 

--- a/src/boxlite/tests/exec_options.rs
+++ b/src/boxlite/tests/exec_options.rs
@@ -39,6 +39,7 @@ impl TestBox {
         let runtime = boxlite::BoxliteRuntime::new(boxlite::runtime::options::BoxliteOptions {
             home_dir: home.path.clone(),
             image_registries: common::test_registries(),
+            create_timeout: std::time::Duration::from_secs(90),
         })
         .expect("create runtime");
         let handle = runtime.create(common::alpine_opts(), None).await.unwrap();

--- a/src/boxlite/tests/exec_user.rs
+++ b/src/boxlite/tests/exec_user.rs
@@ -37,6 +37,7 @@ impl TestBox {
         let runtime = boxlite::BoxliteRuntime::new(boxlite::runtime::options::BoxliteOptions {
             home_dir: home.path.clone(),
             image_registries: common::test_registries(),
+            create_timeout: std::time::Duration::from_secs(90),
         })
         .expect("create runtime");
         let handle = runtime.create(common::alpine_opts(), None).await.unwrap();

--- a/src/boxlite/tests/execution_shutdown.rs
+++ b/src/boxlite/tests/execution_shutdown.rs
@@ -25,6 +25,7 @@ async fn test_wait_behavior_on_box_stop() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
     let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
@@ -100,6 +101,7 @@ async fn test_wait_behavior_on_runtime_shutdown() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
     let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
@@ -173,6 +175,7 @@ async fn test_stdout_stream_on_box_stop() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
     let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
@@ -232,6 +235,7 @@ async fn test_exec_on_stopped_box() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
     let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
@@ -289,6 +293,7 @@ async fn test_existing_execution_after_box_stop() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
     let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
@@ -330,6 +335,7 @@ async fn test_wait_timing_after_stop() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
     let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
@@ -389,6 +395,7 @@ async fn test_multiple_executions_on_box_stop() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
     let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
@@ -479,6 +486,7 @@ async fn test_run_command_returns_stopped_error() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
     let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
@@ -525,6 +533,7 @@ async fn test_start_returns_stopped_error() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
     let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
@@ -563,6 +572,7 @@ async fn test_metrics_returns_stopped_error() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
     let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
@@ -601,6 +611,7 @@ async fn test_create_after_shutdown_returns_stopped() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -636,6 +647,7 @@ async fn test_wait_returns_promptly_on_stop() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
     let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
@@ -700,6 +712,7 @@ async fn test_all_waits_return_on_stop() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
     let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
@@ -782,6 +795,7 @@ async fn test_runtime_shutdown_stops_all_boxes() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -874,6 +888,7 @@ async fn test_exec_completes_then_shutdown_is_clean() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
     let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
@@ -898,6 +913,7 @@ async fn test_sequential_exec_same_box() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
     let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
@@ -931,6 +947,7 @@ async fn test_exec_exit_code_preserved() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
     let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
@@ -963,6 +980,7 @@ async fn test_exec_then_shutdown_sequential() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
     let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
@@ -1119,6 +1137,7 @@ fn create_test_runtime() -> (boxlite_test_utils::home::PerTestBoxHome, BoxliteRu
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
     (home, runtime)

--- a/src/boxlite/tests/image_registries.rs
+++ b/src/boxlite/tests/image_registries.rs
@@ -12,6 +12,7 @@ async fn structured_image_registries_pull_unqualified_image() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .unwrap();
 
@@ -39,6 +40,7 @@ fn structured_image_registries_validate_at_runtime_start() {
     let result = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: vec![ImageRegistry::https("https://registry.local")],
+        create_timeout: std::time::Duration::from_secs(90),
     });
 
     assert!(result.is_err());

--- a/src/boxlite/tests/lifecycle.rs
+++ b/src/boxlite/tests/lifecycle.rs
@@ -17,6 +17,7 @@ async fn runtime_initialization_creates_empty_list() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
     assert!(runtime.list_info().await.unwrap().is_empty());
@@ -32,6 +33,7 @@ async fn create_generates_unique_ids() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
     let box1 = runtime.create(common::alpine_opts(), None).await.unwrap();
@@ -65,6 +67,7 @@ async fn create_stores_custom_options() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
     let handle = runtime.create(options, None).await.unwrap();
@@ -92,6 +95,7 @@ async fn list_info_returns_all_boxes() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -123,6 +127,7 @@ async fn list_info_sorted_by_creation_time_newest_first() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -160,6 +165,7 @@ async fn get_info_returns_box_metadata() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
     let handle = runtime
@@ -188,6 +194,7 @@ async fn get_info_returns_none_for_nonexistent() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
     let missing = runtime.get_info("nonexistent-id").await.unwrap();
@@ -200,6 +207,7 @@ async fn exists_returns_true_for_existing_box() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
     let handle = runtime
@@ -220,6 +228,7 @@ async fn exists_returns_false_for_nonexistent() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
     assert!(!runtime.exists("nonexistent-id").await.unwrap());
@@ -235,6 +244,7 @@ async fn remove_nonexistent_returns_not_found() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
     let result = runtime.remove("nonexistent-id", false).await;
@@ -254,6 +264,7 @@ async fn remove_stopped_box_succeeds() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
     let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
@@ -275,6 +286,7 @@ async fn remove_active_without_force_fails() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
     let handle = runtime
@@ -314,6 +326,7 @@ async fn remove_active_with_force_stops_and_removes() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
     let handle = runtime
@@ -343,6 +356,7 @@ async fn remove_deletes_box_from_database() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
     let handle = runtime
@@ -371,6 +385,7 @@ async fn stop_marks_box_as_stopped() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
     let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
@@ -401,6 +416,7 @@ async fn litebox_info_returns_correct_metadata() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
     let handle = runtime
@@ -434,12 +450,14 @@ async fn multiple_runtimes_are_isolated() {
     let runtime1 = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home1.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
     let home2 = boxlite_test_utils::home::PerTestBoxHome::isolated();
     let runtime2 = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home2.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -481,6 +499,7 @@ async fn boxes_persist_across_runtime_restart() {
         let options = BoxliteOptions {
             home_dir: home.path.clone(),
             image_registries: common::test_registries(),
+            create_timeout: std::time::Duration::from_secs(90),
         };
         let runtime = BoxliteRuntime::new(options).expect("Failed to create runtime");
         let litebox = runtime.create(common::alpine_opts(), None).await.unwrap();
@@ -500,6 +519,7 @@ async fn boxes_persist_across_runtime_restart() {
         let options = BoxliteOptions {
             home_dir: home.path.clone(),
             image_registries: common::test_registries(),
+            create_timeout: std::time::Duration::from_secs(90),
         };
         let runtime = BoxliteRuntime::new(options).expect("Failed to create runtime");
 
@@ -530,6 +550,7 @@ async fn multiple_boxes_persist_and_recover_without_lock_errors() {
         let options = BoxliteOptions {
             home_dir: home.path.clone(),
             image_registries: common::test_registries(),
+            create_timeout: std::time::Duration::from_secs(90),
         };
         let runtime = BoxliteRuntime::new(options).expect("Failed to create runtime");
 
@@ -563,6 +584,7 @@ async fn multiple_boxes_persist_and_recover_without_lock_errors() {
         let options = BoxliteOptions {
             home_dir: home.path.clone(),
             image_registries: common::test_registries(),
+            create_timeout: std::time::Duration::from_secs(90),
         };
         let runtime = BoxliteRuntime::new(options).expect("Failed to create runtime after restart");
 
@@ -615,6 +637,7 @@ async fn auto_remove_true_removes_box_on_stop() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
     let handle = runtime
@@ -642,6 +665,7 @@ async fn auto_remove_false_preserves_box_on_stop() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
     let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
@@ -687,6 +711,7 @@ async fn detach_option_is_stored_in_box_config() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 

--- a/src/boxlite/tests/mount_security.rs
+++ b/src/boxlite/tests/mount_security.rs
@@ -69,6 +69,7 @@ async fn mount_security_integration() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 

--- a/src/boxlite/tests/network_spec.rs
+++ b/src/boxlite/tests/network_spec.rs
@@ -72,6 +72,7 @@ async fn disabled_network_returns_no_network_config() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .unwrap();
 
@@ -90,6 +91,7 @@ async fn disabled_network_runs_without_eth0() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .unwrap();
 
@@ -232,6 +234,7 @@ async fn dns_sinkhole_blocks_unlisted_host() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .unwrap();
 
@@ -262,6 +265,7 @@ async fn dns_sinkhole_allows_listed_host() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .unwrap();
 
@@ -292,6 +296,7 @@ async fn empty_allowlist_allows_all() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .unwrap();
 
@@ -319,6 +324,7 @@ async fn tcp_filter_blocks_direct_ip_connection() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .unwrap();
 
@@ -355,6 +361,7 @@ async fn tcp_filter_sni_allows_https_to_allowed_host() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .unwrap();
 
@@ -390,6 +397,7 @@ async fn host_alias_resolves_to_dedicated_host_ip() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .unwrap();
 
@@ -412,6 +420,7 @@ async fn host_alias_reaches_host_loopback_service() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .unwrap();
 
@@ -438,6 +447,7 @@ async fn host_alias_reaches_host_loopback_service_with_restrictive_allowlist() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .unwrap();
 
@@ -477,6 +487,7 @@ async fn disabled_network_cannot_reach_host_virtual_ip() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .unwrap();
 

--- a/src/boxlite/tests/pid_file.rs
+++ b/src/boxlite/tests/pid_file.rs
@@ -33,6 +33,7 @@ async fn pid_file_created_on_box_start() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -56,6 +57,7 @@ async fn pid_file_contains_correct_pid() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -96,6 +98,7 @@ async fn pid_file_deleted_on_normal_stop() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -120,6 +123,7 @@ async fn pid_matches_box_info() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -156,6 +160,7 @@ async fn pid_available_immediately_after_run() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -192,6 +197,7 @@ async fn pid_file_path_is_correct() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -224,6 +230,7 @@ async fn force_remove_deletes_pid_file() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -247,6 +254,7 @@ async fn box_directory_cleanup_includes_pid_file() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -273,6 +281,7 @@ async fn start_time_fingerprint_validates_boxlite_shim() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 

--- a/src/boxlite/tests/recovery.rs
+++ b/src/boxlite/tests/recovery.rs
@@ -39,6 +39,7 @@ async fn recovery_with_live_process() {
         let runtime = BoxliteRuntime::new(BoxliteOptions {
             home_dir: home.path.clone(),
             image_registries: common::test_registries(),
+            create_timeout: std::time::Duration::from_secs(90),
         })
         .unwrap();
 
@@ -65,6 +66,7 @@ async fn recovery_with_live_process() {
         let runtime = BoxliteRuntime::new(BoxliteOptions {
             home_dir: home.path.clone(),
             image_registries: common::test_registries(),
+            create_timeout: std::time::Duration::from_secs(90),
         })
         .unwrap();
 
@@ -92,6 +94,7 @@ async fn recovery_with_dead_process() {
         let runtime = BoxliteRuntime::new(BoxliteOptions {
             home_dir: home.path.clone(),
             image_registries: common::test_registries(),
+            create_timeout: std::time::Duration::from_secs(90),
         })
         .unwrap();
 
@@ -126,6 +129,7 @@ async fn recovery_with_dead_process() {
         let runtime = BoxliteRuntime::new(BoxliteOptions {
             home_dir: home.path.clone(),
             image_registries: common::test_registries(),
+            create_timeout: std::time::Duration::from_secs(90),
         })
         .unwrap();
 
@@ -164,6 +168,7 @@ async fn recovery_with_missing_pid_file() {
         let runtime = BoxliteRuntime::new(BoxliteOptions {
             home_dir: home.path.clone(),
             image_registries: common::test_registries(),
+            create_timeout: std::time::Duration::from_secs(90),
         })
         .unwrap();
 
@@ -191,6 +196,7 @@ async fn recovery_with_missing_pid_file() {
         let runtime = BoxliteRuntime::new(BoxliteOptions {
             home_dir: home.path.clone(),
             image_registries: common::test_registries(),
+            create_timeout: std::time::Duration::from_secs(90),
         })
         .unwrap();
 
@@ -221,6 +227,7 @@ async fn recovery_with_corrupted_pid_file() {
         let runtime = BoxliteRuntime::new(BoxliteOptions {
             home_dir: home.path.clone(),
             image_registries: common::test_registries(),
+            create_timeout: std::time::Duration::from_secs(90),
         })
         .unwrap();
 
@@ -248,6 +255,7 @@ async fn recovery_with_corrupted_pid_file() {
         let runtime = BoxliteRuntime::new(BoxliteOptions {
             home_dir: home.path.clone(),
             image_registries: common::test_registries(),
+            create_timeout: std::time::Duration::from_secs(90),
         })
         .unwrap();
 
@@ -282,6 +290,7 @@ async fn recovery_preserves_stopped_boxes() {
         let runtime = BoxliteRuntime::new(BoxliteOptions {
             home_dir: home.path.clone(),
             image_registries: common::test_registries(),
+            create_timeout: std::time::Duration::from_secs(90),
         })
         .unwrap();
 
@@ -303,6 +312,7 @@ async fn recovery_preserves_stopped_boxes() {
         let runtime = BoxliteRuntime::new(BoxliteOptions {
             home_dir: home.path.clone(),
             image_registries: common::test_registries(),
+            create_timeout: std::time::Duration::from_secs(90),
         })
         .unwrap();
 
@@ -334,6 +344,7 @@ async fn recovery_marks_box_failed_when_exit_file_present() {
         let runtime = BoxliteRuntime::new(BoxliteOptions {
             home_dir: home.path.clone(),
             image_registries: common::test_registries(),
+            create_timeout: std::time::Duration::from_secs(90),
         })
         .unwrap();
         let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
@@ -356,6 +367,7 @@ async fn recovery_marks_box_failed_when_exit_file_present() {
         let runtime = BoxliteRuntime::new(BoxliteOptions {
             home_dir: home.path.clone(),
             image_registries: common::test_registries(),
+            create_timeout: std::time::Duration::from_secs(90),
         })
         .unwrap();
 
@@ -387,6 +399,7 @@ async fn successful_start_stashes_stale_exit_file() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .unwrap();
 
@@ -444,6 +457,7 @@ async fn recovery_removes_auto_remove_true_boxes() {
         let options = BoxliteOptions {
             home_dir: home_dir.clone(),
             image_registries: common::test_registries(),
+            create_timeout: std::time::Duration::from_secs(90),
         };
         let runtime = BoxliteRuntime::new(options).expect("Failed to create runtime");
 
@@ -476,6 +490,7 @@ async fn recovery_removes_auto_remove_true_boxes() {
         let options = BoxliteOptions {
             home_dir,
             image_registries: common::test_registries(),
+            create_timeout: std::time::Duration::from_secs(90),
         };
         let runtime = BoxliteRuntime::new(options).expect("Failed to create runtime after restart");
 
@@ -515,6 +530,7 @@ async fn recovery_removes_orphaned_stopped_boxes_without_directory() {
         let options = BoxliteOptions {
             home_dir: home.path.clone(),
             image_registries: common::test_registries(),
+            create_timeout: std::time::Duration::from_secs(90),
         };
         let runtime = BoxliteRuntime::new(options).expect("Failed to create runtime");
 
@@ -542,6 +558,7 @@ async fn recovery_removes_orphaned_stopped_boxes_without_directory() {
         let options = BoxliteOptions {
             home_dir: home.path.clone(),
             image_registries: common::test_registries(),
+            create_timeout: std::time::Duration::from_secs(90),
         };
         let runtime = BoxliteRuntime::new(options).expect("Failed to create runtime after restart");
 

--- a/src/boxlite/tests/runtime.rs
+++ b/src/boxlite/tests/runtime.rs
@@ -16,6 +16,7 @@ fn test_runtime_prevents_concurrent_access() {
     let config1 = BoxliteOptions {
         home_dir: temp_dir.path().to_path_buf(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     };
     let runtime1 = BoxliteRuntime::new(config1).unwrap();
 
@@ -23,6 +24,7 @@ fn test_runtime_prevents_concurrent_access() {
     let config2 = BoxliteOptions {
         home_dir: temp_dir.path().to_path_buf(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     };
     let result = BoxliteRuntime::new(config2);
     assert!(result.is_err());
@@ -38,6 +40,7 @@ fn test_runtime_prevents_concurrent_access() {
     let config3 = BoxliteOptions {
         home_dir: temp_dir.path().to_path_buf(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     };
     let _runtime2 = BoxliteRuntime::new(config3).unwrap();
 }
@@ -51,6 +54,7 @@ fn test_runtime_lock_released_on_drop() {
         let config = BoxliteOptions {
             home_dir: temp_dir.path().to_path_buf(),
             image_registries: common::test_registries(),
+            create_timeout: std::time::Duration::from_secs(90),
         };
         let _runtime = BoxliteRuntime::new(config).unwrap();
     } // Lock released here
@@ -59,6 +63,7 @@ fn test_runtime_lock_released_on_drop() {
     let config2 = BoxliteOptions {
         home_dir: temp_dir.path().to_path_buf(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     };
     let _runtime2 = BoxliteRuntime::new(config2).unwrap();
 }
@@ -72,6 +77,7 @@ fn test_runtime_lock_across_threads() {
     let config1 = BoxliteOptions {
         home_dir: dir_path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     };
     let _runtime1 = BoxliteRuntime::new(config1).unwrap();
 
@@ -81,6 +87,7 @@ fn test_runtime_lock_across_threads() {
         let config = BoxliteOptions {
             home_dir: dir_clone,
             image_registries: common::test_registries(),
+            create_timeout: std::time::Duration::from_secs(90),
         };
         BoxliteRuntime::new(config)
     });
@@ -98,6 +105,7 @@ fn test_different_home_dirs_independent() {
     let config1 = BoxliteOptions {
         home_dir: temp_dir1.path().to_path_buf(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     };
     let _runtime1 = BoxliteRuntime::new(config1).unwrap();
 
@@ -105,6 +113,7 @@ fn test_different_home_dirs_independent() {
     let config2 = BoxliteOptions {
         home_dir: temp_dir2.path().to_path_buf(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     };
     let _runtime2 = BoxliteRuntime::new(config2).unwrap();
 
@@ -120,6 +129,7 @@ fn test_lock_file_created() {
     let config = BoxliteOptions {
         home_dir: temp_dir.path().to_path_buf(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     };
     let _runtime = BoxliteRuntime::new(config).unwrap();
 
@@ -135,6 +145,7 @@ fn test_lock_survives_short_operations() {
     let config1 = BoxliteOptions {
         home_dir: temp_dir.path().to_path_buf(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     };
     let runtime = BoxliteRuntime::new(config1).unwrap();
 
@@ -145,6 +156,7 @@ fn test_lock_survives_short_operations() {
     let config2 = BoxliteOptions {
         home_dir: temp_dir.path().to_path_buf(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     };
     let result = BoxliteRuntime::new(config2);
     assert!(result.is_err());

--- a/src/boxlite/tests/security_enforcement.rs
+++ b/src/boxlite/tests/security_enforcement.rs
@@ -63,6 +63,7 @@ async fn virtiofs_readonly_and_capabilities() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -237,6 +238,7 @@ async fn disabled_network_blocks_tsi_socket_forwarding() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 

--- a/src/boxlite/tests/shutdown.rs
+++ b/src/boxlite/tests/shutdown.rs
@@ -24,6 +24,7 @@ async fn shutdown_is_idempotent() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -41,6 +42,7 @@ async fn shutdown_with_timeout() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -55,6 +57,7 @@ async fn shutdown_empty_runtime() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -73,6 +76,7 @@ async fn shutdown_does_not_affect_other_runtimes() {
     let runtime1 = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home1.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -80,6 +84,7 @@ async fn shutdown_does_not_affect_other_runtimes() {
     let runtime2 = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home2.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -100,6 +105,7 @@ async fn read_operations_work_after_shutdown() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -125,6 +131,7 @@ fn drop_releases_lock() {
         let options = BoxliteOptions {
             home_dir: home.path.clone(),
             image_registries: common::test_registries(),
+            create_timeout: std::time::Duration::from_secs(90),
         };
         let _rt = BoxliteRuntime::new(options).unwrap();
     } // Drop fires here
@@ -133,6 +140,7 @@ fn drop_releases_lock() {
     let options2 = BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     };
     let _rt2 = BoxliteRuntime::new(options2).unwrap();
 }
@@ -145,6 +153,7 @@ async fn cloned_runtime_shares_shutdown_state() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
     let clone = runtime.clone();
@@ -172,6 +181,7 @@ async fn shutdown_timeout_edge_values() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
     assert!(runtime.shutdown(Some(0)).await.is_ok());
@@ -181,6 +191,7 @@ async fn shutdown_timeout_edge_values() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
     assert!(runtime.shutdown(Some(-1)).await.is_ok());
@@ -190,6 +201,7 @@ async fn shutdown_timeout_edge_values() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
     assert!(runtime.shutdown(Some(30)).await.is_ok());
@@ -199,6 +211,7 @@ async fn shutdown_timeout_edge_values() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
     assert!(runtime.shutdown(Some(-5)).await.is_ok());
@@ -215,6 +228,7 @@ async fn concurrent_shutdown_is_safe() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -246,6 +260,7 @@ async fn create_after_shutdown_is_rejected() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 

--- a/src/boxlite/tests/sigstop_quiesce.rs
+++ b/src/boxlite/tests/sigstop_quiesce.rs
@@ -24,6 +24,7 @@ async fn test_sigstop_sigcont_preserves_vm() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 

--- a/src/boxlite/tests/snapshot.rs
+++ b/src/boxlite/tests/snapshot.rs
@@ -91,6 +91,7 @@ async fn test_cow_child_disks_exist_after_snapshot_create() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
     let litebox = create_stopped_box(&runtime).await;
@@ -144,6 +145,7 @@ async fn test_box_restartable_after_snapshot_create() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
     let litebox = create_stopped_box(&runtime).await;
@@ -183,6 +185,7 @@ async fn test_cow_child_disks_exist_after_snapshot_restore() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
     let litebox = create_stopped_box(&runtime).await;
@@ -225,6 +228,7 @@ async fn test_box_startable_after_snapshot_restore() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
     let litebox = create_stopped_box(&runtime).await;
@@ -280,6 +284,7 @@ async fn test_snapshot_list_returns_created_snapshot() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
     let litebox = create_stopped_box(&runtime).await;

--- a/src/boxlite/tests/snapshot_clone_deep.rs
+++ b/src/boxlite/tests/snapshot_clone_deep.rs
@@ -115,6 +115,7 @@ async fn test_multiple_snapshots_list_order() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -177,6 +178,7 @@ async fn test_snapshot_data_isolation_across_versions() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -225,6 +227,7 @@ async fn test_snapshot_restore_discards_post_snapshot_writes() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -264,6 +267,7 @@ async fn test_multiple_restore_cycles() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -316,6 +320,7 @@ async fn test_snapshot_get_returns_correct_metadata() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -352,6 +357,7 @@ async fn test_snapshot_created_at_ordering() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -392,6 +398,7 @@ async fn test_snapshot_remove_success() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -448,6 +455,7 @@ async fn test_snapshot_remove_then_recreate_same_name() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -492,6 +500,7 @@ async fn test_snapshot_remove_nonexistent_returns_error() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -512,6 +521,7 @@ async fn test_snapshot_remove_current_backing_rejected() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -540,6 +550,7 @@ async fn test_snapshot_remove_after_restore_different() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -585,6 +596,7 @@ async fn test_snapshot_chain_remove_oldest_with_newer_depending() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -641,6 +653,7 @@ async fn test_snapshot_remove_middle_of_three() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -690,6 +703,7 @@ async fn test_snapshot_running_box_with_quiesce() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -723,6 +737,7 @@ async fn test_snapshot_restore_rejected_while_running() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -753,6 +768,7 @@ async fn test_snapshot_remove_while_running() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -796,6 +812,7 @@ async fn test_two_snapshots_while_running() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -837,6 +854,7 @@ async fn test_clone_after_snapshot_preserves_snapshot_data() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -887,6 +905,7 @@ async fn test_snapshot_then_clone_then_remove_snapshot() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -937,6 +956,7 @@ async fn test_clone_then_snapshot_clone() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -986,6 +1006,7 @@ async fn test_clone_of_clone() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -1027,6 +1048,7 @@ async fn test_clone_source_snapshot_independence() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -1078,6 +1100,7 @@ async fn test_batch_clone_produces_correct_count() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -1117,6 +1140,7 @@ async fn test_batch_clone_names_count_mismatch_errors() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -1144,6 +1168,7 @@ async fn test_clone_count_zero_returns_empty() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -1165,6 +1190,7 @@ async fn test_clone_data_preserved() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -1193,6 +1219,7 @@ async fn test_clone_write_isolation_from_source() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -1234,6 +1261,7 @@ async fn test_clone_without_name() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -1262,6 +1290,7 @@ async fn test_clone_with_duplicate_name_errors() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -1287,6 +1316,7 @@ async fn test_multiple_clones_share_base_disk() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -1321,6 +1351,7 @@ async fn test_export_import_preserves_file_contents() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -1372,6 +1403,7 @@ async fn test_export_to_directory_uses_box_name() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -1398,6 +1430,7 @@ async fn test_double_import_from_same_archive() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -1446,6 +1479,7 @@ async fn test_imported_box_has_no_snapshots() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -1490,6 +1524,7 @@ async fn test_export_import_cloned_box() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -1524,6 +1559,7 @@ async fn test_import_validates_no_backing_references() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -1552,6 +1588,7 @@ async fn test_export_unnamed_box_uses_default_filename() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -1581,6 +1618,7 @@ async fn test_export_import_box_with_custom_options() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -1614,6 +1652,7 @@ async fn test_export_archive_has_boxlite_extension() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -1648,6 +1687,7 @@ async fn test_snapshot_name_validation_integration() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -1676,6 +1716,7 @@ async fn test_snapshot_duplicate_name_rejected() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -1705,6 +1746,7 @@ async fn test_remove_box_with_snapshots_cleans_up() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -1747,6 +1789,7 @@ async fn test_remove_source_box_blocked_by_clone() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -1776,6 +1819,7 @@ async fn test_snapshot_on_never_started_box() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -1803,6 +1847,7 @@ async fn test_restore_nonexistent_snapshot() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -1823,6 +1868,7 @@ async fn test_clone_box_without_container_disk() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -1846,6 +1892,7 @@ async fn test_snapshot_name_max_length() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -1880,6 +1927,7 @@ async fn test_snapshot_under_write_pressure() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -1929,6 +1977,7 @@ async fn test_clone_under_write_pressure() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -1972,6 +2021,7 @@ async fn test_rapid_snapshot_cycle() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -2052,6 +2102,7 @@ async fn test_export_under_write_pressure_with_data_check() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -2108,6 +2159,7 @@ async fn test_snapshot_survives_box_restart() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -2148,6 +2200,7 @@ async fn test_box_info_status_correct_throughout_snapshot_lifecycle() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -2185,6 +2238,7 @@ async fn test_snapshot_after_clone_source_modification() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -2231,6 +2285,7 @@ async fn test_multiple_boxes_snapshot_independently() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -2277,6 +2332,7 @@ async fn test_clone_and_export_same_box_sequentially() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -2325,6 +2381,7 @@ async fn test_snapshot_preserves_file_permissions() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -2380,6 +2437,7 @@ async fn test_snapshot_preserves_nested_directories() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -2427,6 +2485,7 @@ async fn test_clone_preserves_multiple_files() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -2464,6 +2523,7 @@ async fn test_export_import_preserves_symlinks() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -2518,6 +2578,7 @@ async fn test_remove_clone_triggers_base_gc_when_last_dependent() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -2556,6 +2617,7 @@ async fn test_remove_one_of_two_clones_preserves_base() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -2591,6 +2653,7 @@ async fn test_remove_all_clones_cascades_gc() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -2636,6 +2699,7 @@ async fn test_box_removal_cleans_all_snapshots() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -2681,6 +2745,7 @@ async fn test_archive_file_is_valid_zstd_tar() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -2710,6 +2775,7 @@ async fn test_archive_roundtrip_checksum_integrity() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -2746,6 +2812,7 @@ async fn test_export_produces_deterministic_extension() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 

--- a/src/boxlite/tests/timing_profile.rs
+++ b/src/boxlite/tests/timing_profile.rs
@@ -45,6 +45,7 @@ async fn boot_timing_profile() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 
@@ -179,6 +180,7 @@ async fn boot_timing_profile_no_jailer() {
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
 

--- a/src/boxlite/tests/zygote_integration.rs
+++ b/src/boxlite/tests/zygote_integration.rs
@@ -30,6 +30,7 @@ fn create_test_runtime() -> (boxlite_test_utils::home::PerTestBoxHome, BoxliteRu
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
+        create_timeout: std::time::Duration::from_secs(90),
     })
     .expect("create runtime");
     (home, runtime)

--- a/src/shared/src/errors.rs
+++ b/src/shared/src/errors.rs
@@ -82,6 +82,13 @@ pub enum BoxliteError {
     /// a new exec instead.
     #[error("session reaped: {0}")]
     SessionReaped(String),
+
+    /// Operation exceeded its wall-clock deadline. Surfaced by the
+    /// hang-defence wrappers (`box.create` total budget, lock
+    /// acquisition timeout, …) instead of letting the caller block
+    /// indefinitely on a wedged or crash-leaked counterparty.
+    #[error("timed out: {0}")]
+    Timeout(String),
 }
 
 // Implement From for common error types to enable `?` operator
@@ -168,6 +175,11 @@ impl BoxliteError {
             BoxliteError::ResourceExhausted(_) => {
                 (429, "ResourceExhaustedError", "resource_exhausted")
             }
+            // 408 Request Timeout: caller waited longer than the
+            // operation's wall-clock budget. Retryable in principle,
+            // so we surface a distinct status rather than collapsing
+            // onto 500.
+            BoxliteError::Timeout(_) => (408, "TimeoutError", "timeout"),
             BoxliteError::Network(_) => (503, "NetworkError", "network_unavailable"),
             BoxliteError::Portal(_) | BoxliteError::Rpc(_) | BoxliteError::RpcTransport(_) => {
                 (503, "UpstreamUnavailableError", "upstream_unavailable")
@@ -262,6 +274,12 @@ mod tests {
                 429,
                 "ResourceExhaustedError",
                 "resource_exhausted",
+            ),
+            (
+                BoxliteError::Timeout("box.create budget exceeded".into()),
+                408,
+                "TimeoutError",
+                "timeout",
             ),
             (
                 BoxliteError::Network("tap setup failed".into()),

--- a/src/test-utils/src/box_test.rs
+++ b/src/test-utils/src/box_test.rs
@@ -67,6 +67,7 @@ impl BoxTestBase {
         let runtime = BoxliteRuntime::new(BoxliteOptions {
             home_dir: home.path.clone(),
             image_registries: test_registries(),
+            create_timeout: std::time::Duration::from_secs(90),
         })
         .expect("create BoxTestBase runtime");
 
@@ -88,6 +89,7 @@ impl BoxTestBase {
         let runtime = BoxliteRuntime::new(BoxliteOptions {
             home_dir: home.path.clone(),
             image_registries: test_registries(),
+            create_timeout: std::time::Duration::from_secs(90),
         })
         .expect("create isolated BoxTestBase runtime");
 

--- a/src/test-utils/src/cache.rs
+++ b/src/test-utils/src/cache.rs
@@ -201,6 +201,7 @@ impl SharedResources {
                 let runtime = BoxliteRuntime::new(BoxliteOptions {
                     home_dir: home.clone(),
                     image_registries: test_registries(),
+                    create_timeout: std::time::Duration::from_secs(90),
                 })
                 .unwrap();
 

--- a/src/test-utils/src/config_matrix.rs
+++ b/src/test-utils/src/config_matrix.rs
@@ -267,6 +267,7 @@ where
         let runtime = boxlite::BoxliteRuntime::new(BoxliteOptions {
             home_dir: home.path.clone(),
             image_registries: crate::test_registries(),
+            create_timeout: std::time::Duration::from_secs(90),
         })
         .expect("create runtime for config matrix");
 
@@ -336,6 +337,7 @@ macro_rules! config_matrix_tests {
                         ::boxlite::runtime::options::BoxliteOptions {
                             home_dir: home.path.clone(),
                             image_registries: $crate::test_registries(),
+                                                    create_timeout: std::time::Duration::from_secs(90),
                         }
                     ).expect("create runtime for config matrix test");
 


### PR DESCRIPTION
Two structural defences against `boxlite call blocks forever` — D1 wraps `LocalRuntime::create` in a wall-clock budget (default 90s, configurable via `BoxliteOptions.create_timeout`, `Duration::ZERO` opts out) and D2 adds `LockGuard::with_timeout` on top of a `Locker::try_lock_until(deadline)` default impl so a crash-leaked per-box lock holder doesn't wedge every subsequent `start()`.

## Test plan

Two-sided (reverted vs applied) via `lock::tests::with_timeout_*` + `runtime::rt_impl::tests::local_runtime_create_*`, the reverted side toggling whether the deadline / escape-hatch branch is in place.

- **`lock::tests::with_timeout_returns_error_when_contended`** — side B: replace `try_lock_until` body with `lock.lock()` → hangs past the test wall-clock. Side A asserts `Err(Timeout(_))` *and* the elapsed window `[140ms, 500ms)` so a no-op poll loop is also caught.
- **`runtime::rt_impl::tests::local_runtime_create_zero_budget_escape_hatch_does_not_timeout`** — side B for the `if budget.is_zero() { return inner.await }` short-circuit: reverting it makes `tokio::time::timeout` treat a 0-duration budget as "already elapsed" and surface Timeout on every call. Side A confirms the escape hatch actually bypasses the wrap.
- **`runtime::rt_impl::tests::local_runtime_create_default_budget_does_not_wrap_to_timeout`** — happy-path control: rules out the wrapper swallowing inner `Ok` on the normal path.

| observed | pre-fix | post-fix |
|---|---|---|
| previous box init crashed mid-spawn without releasing the per-box flock | every subsequent `box.start()` blocks on `lock.lock()` indefinitely | `LockGuard::with_timeout(_, 30s)` in `box_impl.rs:654` returns `BoxliteError::Timeout("lock <id> not acquired within 30s")` |
| corp DNS times out a registry pull, libkrun handshake stuck, guest agent never signals ready | `runtime.create(...).await` blocks the caller indefinitely | `tokio::time::timeout(budget, inner)` fires; future drops, `CleanupGuard::Drop` rolls back partially-built state; caller sees `BoxliteError::Timeout(...)` |
| operator on a slow host where 90s is too tight | n/a | `BoxliteOptions.create_timeout = Duration::from_secs(N)` raises the cap; `Duration::ZERO` opts out entirely |
| existing JSON wire snapshots / round-trip tests | n/a | `create_timeout` is `skip_serializing_if = is_default_create_timeout` so the field is omitted from output when at default — pre-existing `BoxliteOptions` JSON fixtures stay byte-identical |
| `BoxliteError → HTTP` mapping | n/a | new `Timeout` variant maps to 408 Request Timeout, pinned in the canonical-table test |

Both defences are independent and additive; the lock timeout fires only on contended local acquire, the create deadline fires only on whole-pipeline budget overrun. Draft because the third planned defence (gvproxy post-init liveness probe, covering the silent-failure class #634 doesn't catch via ErrSink) is not in this commit — happy to add it if reviewers want it bundled.

Full lib sweep: 732/732 green.
