### PR TITLE
docs: add communication rules to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,4 +99,9 @@ Every change goes: understand → research → design → implement → test →
 - Verify external findings against the working tree before acting. `/codex:adversarial-review`, lint, and PR comments work from a snapshot — they may name deleted code. `git grep` and `git diff` first.
 - Honor scope reduction: "drop X" means drop X. Don't bundle adjacent improvements unprompted.
 
+**Communication**
+
+- Words: as concise and simple as possible, unless explicitly asked otherwise.
+- A simple call graph (func name, class name, file name, LOC, short annotation) is the first choice when explaining code.
+
 Adapted from Clean Code (Robert C. Martin) via the polygala-inc AGENTS.md distillation.


### PR DESCRIPTION
## Summary
Adds a new **Communication** block to `CLAUDE.md` capturing two working preferences:

- Keep words as concise and simple as possible, unless explicitly asked otherwise.
- Prefer a simple call graph (func name, class name, file name, LOC, short annotation) as the first choice when explaining code.

## Notes
Documentation-only change. The block sits at the end of the Workflow section, just before the closing attribution line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated communication guidelines for response writing standards, emphasizing concise and simple wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->