### PR TITLE
fix(api): reject undersized box resources at the create boundary

### DIFF
--- a/apps/api/src/boxlite-rest/dto/create-box.dto.spec.ts
+++ b/apps/api/src/boxlite-rest/dto/create-box.dto.spec.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { validate } from 'class-validator'
+import { plainToInstance } from 'class-transformer'
+import { CreateBoxDto } from './create-box.dto'
+
+// A box with 0 vCPUs can never boot (libkrun set_vm_config(0, ...) -> EINVAL),
+// so the create endpoint must reject undersized resources at the request
+// boundary. These assert the @Min constraints stay wired on CreateBoxDto —
+// drop a decorator and the matching case goes red. (The global ValidationPipe
+// in main.ts turns these constraint violations into HTTP 400s; that wiring is
+// verified live, not here.)
+describe('CreateBoxDto resource minimums', () => {
+  it.each([
+    ['cpus', { cpus: 0 }],
+    ['memory_mib', { memory_mib: 128 }],
+    ['disk_size_gb', { disk_size_gb: 0 }],
+  ])('rejects undersized %s with a min constraint', async (field, body) => {
+    const errors = await validate(plainToInstance(CreateBoxDto, body))
+
+    const fieldError = errors.find((e) => e.property === field)
+    expect(fieldError?.constraints).toHaveProperty('min')
+  })
+
+  it('accepts values exactly at the minimum boundary', async () => {
+    const errors = await validate(plainToInstance(CreateBoxDto, { cpus: 1, memory_mib: 256, disk_size_gb: 1 }))
+
+    expect(errors).toHaveLength(0)
+  })
+
+  it('accepts a request that omits resource fields (engine defaults)', async () => {
+    const errors = await validate(plainToInstance(CreateBoxDto, { image: 'alpine:3.23' }))
+
+    expect(errors).toHaveLength(0)
+  })
+})

--- a/apps/api/src/boxlite-rest/dto/create-box.dto.ts
+++ b/apps/api/src/boxlite-rest/dto/create-box.dto.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { IsOptional, IsString, IsNumber, IsBoolean, IsObject, IsArray } from 'class-validator'
+import { IsOptional, IsString, IsNumber, IsBoolean, IsObject, IsArray, Min } from 'class-validator'
 
 export class CreateBoxDto {
   @IsOptional()
@@ -15,16 +15,22 @@ export class CreateBoxDto {
   @IsString()
   image?: string
 
+  // A box with 0 vCPUs can never boot (libkrun set_vm_config(0, ...) → EINVAL),
+  // so reject undersized resources at the request boundary instead of accepting
+  // a box that fails to start.
   @IsOptional()
   @IsNumber()
+  @Min(1)
   cpus?: number
 
   @IsOptional()
   @IsNumber()
+  @Min(256)
   memory_mib?: number
 
   @IsOptional()
   @IsNumber()
+  @Min(1)
   disk_size_gb?: number
 
   @IsOptional()


### PR DESCRIPTION
## Problem

Creating a box with `cpus=0` (or undersized memory/disk) via the cloud API was **silently accepted**: `POST /v1/{prefix}/boxes` returned a `box_id`, but the box could never boot — libkrun `set_vm_config(0, ...)` returns `EINVAL` — and, under `auto_remove`, vanished on first start, leaving the caller chasing a dangling id (`get_info()` → `None`, `remove()` → 404).

The cloud create path is `SDK → apps/api → runner → engine`. `apps/api` already enforces per-org **maximums** in `validateOrganizationQuotas`, but nothing enforced **minimums**.

## Fix

Validate resource floors at the **cloud API request boundary** — where untrusted input enters — rather than in the core runtime. Per review (@DorianZheng): resource limits are *service policy*, not a core-runtime invariant; every service owns its own.

- `CreateBoxDto`: `@Min(1) cpus`, `@Min(256) memory_mib`, `@Min(1) disk_size_gb`.
- The global `ValidationPipe({ transform: true })` turns violations into **HTTP 400** before the request reaches business logic.
- Lower-bound only; omitted fields stay `@IsOptional` and keep engine defaults.

## Changed from the original approach

Earlier revisions validated in the Rust core (`BoxOptions::validate_resources()`, called from `create_inner`). That has been **fully removed** — the cloud path reaches the engine via in-process FFI, not the core REST boundary, so the policy belongs in `apps/api`. `src/` is now net-zero vs `main`.

## Testing

- **Unit** (`create-box.dto.spec.ts`): asserts the `@Min` constraints stay wired on the DTO (drop a decorator → red); boundary (1 / 256 / 1) and omitted-field cases guard against over-rejection. Two-side verified: without `@Min` → 3 fail; with → 5 pass.
- **Live E2E** (authenticated, against an api instance carrying this change): `cpus=0` / `memory_mib=128` / `disk_size_gb=0` → **400** with the matching min message; `cpus=1` passes validation then fails later on snapshot lookup (proves no over-rejection); the same request without the fix lets `cpus=0` through to snapshot lookup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API now enforces minimum resource constraints on compute configurations: 1 vCPU, 256 MB memory, and 1 GB disk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->