### PR TITLE
fix(api): anchor OIDC-created user's Personal org to the default region

### DIFF
--- a/apps/api/src/auth/jwt.strategy.spec.ts
+++ b/apps/api/src/auth/jwt.strategy.spec.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Request } from 'express'
+import { JwtStrategy } from './jwt.strategy'
+import { UserService } from '../user/user.service'
+import { TypedConfigService } from '../config/typed-config.service'
+
+const DEFAULT_REGION_ID = 'region-default-id'
+const DEFAULT_ORG_QUOTA = { totalCpuQuota: 8 }
+
+function buildStrategy() {
+  const createdUser = { id: 'user-1', role: 'user', email: 'new@boxlite.dev' }
+
+  const userService = {
+    findOne: jest.fn().mockResolvedValue(null), // new user → triggers create()
+    create: jest.fn().mockResolvedValue(createdUser),
+    update: jest.fn(),
+  } as unknown as UserService
+
+  const configService = {
+    getOrThrow: jest.fn((key: string) => {
+      if (key === 'defaultRegion.id') return DEFAULT_REGION_ID
+      if (key === 'defaultOrganizationQuota') return DEFAULT_ORG_QUOTA
+      throw new Error(`unexpected config key: ${key}`)
+    }),
+  } as unknown as TypedConfigService
+
+  const strategy = new JwtStrategy(
+    { jwksUri: 'https://example.com/.well-known/jwks.json', audience: 'aud', issuer: 'iss' },
+    userService,
+    configService,
+  )
+
+  return { strategy, userService }
+}
+
+describe('JwtStrategy.validate — auto-created user', () => {
+  it('anchors the Personal org to the default region for a new OIDC user', async () => {
+    const { strategy, userService } = buildStrategy()
+    const request = { get: jest.fn().mockReturnValue(undefined) } as unknown as Request
+
+    await strategy.validate(request, { sub: 'user-1', email: 'new@boxlite.dev', email_verified: true })
+
+    // The bug: without personalOrganizationDefaultRegionId, the downstream
+    // UserCreatedEvent → handleUserCreatedEvent creates the Personal org with
+    // defaultRegionId=undefined. Assert the strategy forwards the configured
+    // region id into the create DTO.
+    expect(userService.create).toHaveBeenCalledTimes(1)
+    expect(userService.create).toHaveBeenCalledWith(
+      expect.objectContaining({ personalOrganizationDefaultRegionId: DEFAULT_REGION_ID }),
+    )
+  })
+})

--- a/apps/api/src/auth/jwt.strategy.ts
+++ b/apps/api/src/auth/jwt.strategy.ts
@@ -72,6 +72,12 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
         email: email || '',
         emailVerified: payload.email_verified || false,
         personalOrganizationQuota: this.configService.getOrThrow('defaultOrganizationQuota'),
+        // Anchor the auto-created Personal organization to the platform's
+        // default region, matching the admin-seed path in AppService. Without
+        // this, OrganizationService.handleUserCreatedEvent creates the org
+        // with defaultRegionId=undefined and downstream callers that read
+        // organization.defaultRegionId fail for every OIDC-created user.
+        personalOrganizationDefaultRegionId: this.configService.getOrThrow('defaultRegion.id'),
       })
       this.logger.debug(`Created new user with ID: ${userId}`)
     } else if (user.name === 'Unknown' || !user.email) {


### PR DESCRIPTION
## Summary

On first OIDC login, `JwtStrategy.validate` auto-creates the user. It passed `personalOrganizationQuota` but **not** `personalOrganizationDefaultRegionId`, so the downstream chain:

`UserService.create` → `UserCreatedEvent` → `OrganizationService.handleUserCreatedEvent`

created the user's **Personal** organization with `defaultRegionId: undefined`. Any downstream caller that reads `organization.defaultRegionId` then fails for every OIDC-created user.

`AppService`'s admin-seed path already sets `personalOrganizationDefaultRegionId` (`app.service.ts`); this just brings the normal login path in line — a one-field change mirroring existing, proven code.

## Why a separate PR

This was originally bundled into #595 (infra-local). Per @DorianZheng's review ("why change this in this PR?") it's been pulled out, since it's an app-behavior fix unrelated to the local-dev stack.

## Test

Adds `apps/api/src/auth/jwt.strategy.spec.ts` asserting the create DTO carries the configured `defaultRegion.id`.

Two-sided verification (CLAUDE.md reproduce-before-fix):
- **Without the fix:** ❌ fails — `create()` is called with the DTO missing `personalOrganizationDefaultRegionId`.
- **With the fix:** ✅ passes.

```
nx test api --testPathPatterns="jwt.strategy.spec"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed auto-created user initialization to ensure proper default region assignment during OIDC authentication, preventing potential downstream errors.

* **Tests**
  * Added test coverage for user auto-creation during authentication validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->