### PR TITLE
fix(runner): pull snapshot layers for the host arch, not hardcoded amd64

### DIFF
--- a/apps/runner/pkg/boxlite/registry.go
+++ b/apps/runner/pkg/boxlite/registry.go
@@ -7,6 +7,7 @@ package boxlite
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"strings"
 
 	"github.com/boxlite-ai/runner/pkg/api/dto"
@@ -16,7 +17,14 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 )
 
-var linuxAmd64Platform = v1.Platform{OS: "linux", Architecture: "amd64"}
+// Default registry-pull platform. Daytona's original hardcode of
+// `linux/amd64` is correct for prod EC2 runners but breaks on Apple Silicon
+// (`/bin/sh` lands as x86 ELF → `ENOEXEC: Exec format error` when libkrun
+// tries to exec inside the microVM). Detect at startup based on host arch.
+var linuxHostPlatform = v1.Platform{
+	OS:           "linux",
+	Architecture: runtime.GOARCH, // "amd64", "arm64", etc.
+}
 
 // PullSnapshot pulls a snapshot image and mirrors it to the destination registry when requested.
 func (c *Client) PullSnapshot(ctx context.Context, req dto.PullSnapshotRequestDTO) error {
@@ -167,7 +175,7 @@ func (c *Client) parseReference(imageName string, registry *dto.RegistryDTO) (na
 func (c *Client) remoteOptions(ctx context.Context, registry *dto.RegistryDTO) []remote.Option {
 	opts := []remote.Option{
 		remote.WithContext(ctx),
-		remote.WithPlatform(linuxAmd64Platform),
+		remote.WithPlatform(linuxHostPlatform),
 	}
 
 	if registry != nil && registry.HasAuth() {

--- a/apps/runner/pkg/boxlite/registry_test.go
+++ b/apps/runner/pkg/boxlite/registry_test.go
@@ -4,6 +4,7 @@
 package boxlite
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/boxlite-ai/runner/pkg/api/dto"
@@ -66,5 +67,18 @@ func TestSanitizeImageReferenceStripsScheme(t *testing.T) {
 
 	if got != want {
 		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestLinuxHostPlatformMatchesHostArch(t *testing.T) {
+	// Registry pulls must target the runner host's architecture: a layer
+	// pulled as linux/amd64 onto an arm64 host produces x86 ELF binaries that
+	// fail with ENOEXEC when libkrun execs them inside the microVM. Guard
+	// against re-hardcoding a fixed arch.
+	if linuxHostPlatform.OS != "linux" {
+		t.Errorf("OS = %q, want linux", linuxHostPlatform.OS)
+	}
+	if linuxHostPlatform.Architecture != runtime.GOARCH {
+		t.Errorf("Architecture = %q, want host arch %q", linuxHostPlatform.Architecture, runtime.GOARCH)
 	}
 }


### PR DESCRIPTION
## Summary

`PullSnapshot` hardcoded `linux/amd64` when pulling snapshot image layers. On a non-amd64 runner host (e.g. an Apple Silicon dev runner) that pulls x86 layers, so `/bin/sh` and other binaries land as x86 ELF and fail with `ENOEXEC: Exec format error` the moment libkrun execs them inside the microVM.

Fix: use `runtime.GOARCH` so the pulled image matches the architecture of the host that will actually run it. Also renames the now-misleading `linuxAmd64Platform` → `linuxHostPlatform`.

## Why a separate PR

Extracted from the infra-local stack PR (#595) per review — it's a general runner correctness fix unrelated to the local-dev stack, so it should land and be reviewed on its own.

## Test

Adds `TestLinuxHostPlatformMatchesHostArch` asserting the pull platform tracks `runtime.GOARCH` (fails if re-hardcoded to a fixed arch on a mismatched host). Verified on arm64:

```
go test ./pkg/boxlite/ -run TestLinuxHostPlatform -v   # PASS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Registry operations now dynamically detect the host system's processor architecture, ensuring container image pulls and related operations are compatible with the runner's actual hardware rather than relying on a hardcoded value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->