### PR TITLE
fix(api): un-quote orderBy column refs in sandbox lifecycle crons

### DIFF
--- a/apps/api/src/sandbox/managers/sandbox.manager.ts
+++ b/apps/api/src/sandbox/managers/sandbox.manager.ts
@@ -117,7 +117,7 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
             .andWhere('sandbox.pending != true')
             .andWhere('sandbox."autoStopInterval" != 0')
             .andWhere('activity."lastActivityAt" < NOW() - INTERVAL \'1 minute\' * sandbox."autoStopInterval"')
-            .orderBy('sandbox."lastBackupAt"', 'ASC')
+            .orderBy('sandbox.lastBackupAt', 'ASC')
             .limit(100)
             .getMany()
 
@@ -189,7 +189,7 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
         .andWhere('sandbox.pending != true')
         .andWhere('sandbox."autoArchiveInterval" != 0')
         .andWhere('activity."lastActivityAt" < NOW() - INTERVAL \'1 minute\' * sandbox."autoArchiveInterval"')
-        .orderBy('sandbox."lastBackupAt"', 'ASC')
+        .orderBy('sandbox.lastBackupAt', 'ASC')
         .limit(100)
         .getMany()
 
@@ -256,7 +256,7 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
             .andWhere('sandbox.pending != true')
             .andWhere('sandbox."autoDeleteInterval" >= 0')
             .andWhere('activity."lastActivityAt" < NOW() - INTERVAL \'1 minute\' * sandbox."autoDeleteInterval"')
-            .orderBy('activity."lastActivityAt"', 'ASC')
+            .orderBy('activity.lastActivityAt', 'ASC')
             .limit(100)
             .getMany()
 
@@ -699,7 +699,7 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
         })
         .andWhere('sandbox."desiredState"::text != sandbox.state::text')
         .andWhere('sandbox."desiredState"::text != :archived', { archived: SandboxDesiredState.ARCHIVED })
-        .orderBy('activity."lastActivityAt"', 'DESC', 'NULLS LAST')
+        .orderBy('activity.lastActivityAt', 'DESC', 'NULLS LAST')
 
       const stream = await queryBuilder.stream()
       let processedCount = 0


### PR DESCRIPTION
## Summary

The sandbox auto-stop / auto-archive / auto-delete cron queries passed pre-quoted column refs (`sandbox."lastBackupAt"`, `activity."lastActivityAt"`) to `QueryBuilder.orderBy(...)`. TypeORM interprets the `alias.property` form and applies its **own** identifier quoting, so the already-quoted column gets double-escaped into invalid SQL and the cron crashes.

Fix: pass the plain `alias.property` and let TypeORM map + quote it. `CustomNamingStrategy` (extends `DefaultNamingStrategy`) preserves the camelCase column name, so the generated SQL is correct.

## Why a separate PR

Extracted from the infra-local stack PR (#595) per review — it's a general API fix to the lifecycle crons, unrelated to the local-dev stack.

## Verification

Verified against dev RDS (the in-VPC API box): the lifecycle crons run without the TypeORM crash. (No unit test added — a meaningful test requires a live Postgres + full TypeORM entity metadata; this codebase has no integration-test harness for the cron query builders.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed ordering behavior in sandbox lifecycle management operations, including auto-stop checks, auto-archive checks, auto-delete checks, and state synchronization to ensure proper sequencing of sandbox operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->