### PR TITLE
ci(build-runner-binary): build libboxlite.a inline on workflow_dispatch

### DIFF
--- a/.github/workflows/build-runner-binary.yml
+++ b/.github/workflows/build-runner-binary.yml
@@ -18,6 +18,19 @@ on:
     workflows: ["Build C SDK"]
     types: [completed]
   workflow_dispatch:
+    inputs:
+      libboxlite_source:
+        description: |
+          Where to get libboxlite.a:
+          - dev: build inline from the current ref (slow, always ABI-correct)
+          - prebuilt: fetch the v${Cargo.toml.version} release asset
+            (fast; only ABI-correct when the current ref equals that
+            release tag's commit — Frankenstein link otherwise)
+        type: choice
+        options:
+          - dev
+          - prebuilt
+        default: dev
 
 permissions:
   contents: read
@@ -56,16 +69,56 @@ jobs:
           VERSION=$(grep '^version = ' Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Download prebuilt libboxlite.a
+      # The v${VERSION} release prebuilt is only ABI-correct when the
+      # checked-out ref equals that release tag's commit. Dispatching on
+      # a ref ahead of the latest release (where sdks/go references FFI
+      # symbols added since) silently links wrong — `undefined reference
+      # to boxlite_*`. Default to building inline on dispatch; let the
+      # operator opt back into prebuilt when they want to test the
+      # release asset against the current Go bindings on purpose
+      # (e.g. ABI-regression detection).
+      #
+      # workflow_run path is always release-aligned by construction:
+      # it fires after Build C SDK after `release: published`, where the
+      # tag, Cargo.toml version, and the asset all came from the same
+      # commit. Default to prebuilt there for speed.
+      - name: Set up Rust (inline build only)
+        if: github.event_name == 'workflow_dispatch' && inputs.libboxlite_source == 'dev'
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: ${{ needs.config.outputs.rust-toolchain }}
+
+      # vendor submodules (bubblewrap, e2fsprogs, ...) are needed for the
+      # Rust build but skipped by default `actions/checkout`. Prebuilt path
+      # doesn't need them.
+      - name: Init submodules (inline build only)
+        if: github.event_name == 'workflow_dispatch' && inputs.libboxlite_source == 'dev'
+        run: git submodule update --init --recursive
+
+      # Rust C SDK build needs meson/ninja/musl-tools/etc. — installed by
+      # the project's setup script. Prebuilt path doesn't need them.
+      - name: Install Rust build deps (inline build only)
+        if: github.event_name == 'workflow_dispatch' && inputs.libboxlite_source == 'dev'
+        run: make setup:build
+
+      - name: Get libboxlite.a
         env:
           VERSION: ${{ steps.version.outputs.version }}
           GH_REPO: ${{ github.repository }}
+          # dispatch: honor input; everything else (workflow_run): prebuilt
+          SOURCE: ${{ github.event_name == 'workflow_dispatch' && inputs.libboxlite_source || 'prebuilt' }}
         run: |
-          ARCHIVE="boxlite-c-v${VERSION}-linux-x64-gnu.tar.gz"
-          URL="https://github.com/${GH_REPO}/releases/download/v${VERSION}/${ARCHIVE}"
-          echo "Downloading $URL"
-          curl -fsSL "${URL}" | tar xz -C /tmp/
-          cp "/tmp/boxlite-c-v${VERSION}-linux-x64-gnu/lib/libboxlite.a" sdks/go/libboxlite.a
+          if [[ "$SOURCE" == "dev" ]]; then
+            echo "==> Building libboxlite.a inline from current ref"
+            make dist:c
+            cp sdks/c/dist/lib/libboxlite.a sdks/go/libboxlite.a
+          else
+            ARCHIVE="boxlite-c-v${VERSION}-linux-x64-gnu.tar.gz"
+            URL="https://github.com/${GH_REPO}/releases/download/v${VERSION}/${ARCHIVE}"
+            echo "==> Fetching prebuilt libboxlite.a from $URL"
+            curl -fsSL "${URL}" | tar xz -C /tmp/
+            cp "/tmp/boxlite-c-v${VERSION}-linux-x64-gnu/lib/libboxlite.a" sdks/go/libboxlite.a
+          fi
 
       - name: Rewrite go.work for minimal modules
         run: |


### PR DESCRIPTION
## Problem

The release prebuilt at \`v\${Cargo.toml.version}\` is only ABI-correct when the checked-out ref **is** that release tag's commit. \`workflow_dispatch\` advertises itself as \"Manual trigger for testing\" but silently produces a Frankenstein link whenever the dispatched ref has FFI changes since the last release.

### Reproducer

\`\`\`
$ gh workflow run build-runner-binary.yml --ref main --repo boxlite-ai/boxlite
# (link step fails)
/usr/bin/ld: undefined reference to \`boxlite_rest_options_set_path_prefix'
collect2: error: ld returned 1 exit status
\`\`\`

Symbol was added by #581 (\`dcb3df40\`, 2026-05-23, post-v0.9.5). The check:

\`\`\`
$ git log v0.9.5..origin/main -S 'boxlite_rest_options_set_path_prefix'
dcb3df40 feat(auth): URL prefix authoritative + OIDC device flow (#581)

$ git diff v0.9.5..origin/main -- sdks/c/include/boxlite.h | grep '^+void boxlite_'
+void boxlite_rest_options_set_path_prefix(CBoxliteRestOptions *options, const char *path_prefix);
\`\`\`

The 51-commit gap between v0.9.5 and current main has exactly one new FFI symbol (above). Any future PR adding FFI surface between releases will rearm the same trap.

Last successful \`workflow_dispatch\` on \`boxlite-ai/boxlite\` main: \`f04b4383\` on 2026-05-14 — predates #581. After that, anyone dispatching on main hits the same link error. The breakage isn't being seen because no one has tried — it isn't fixed by anything in main.

### Why workflow_run is fine

Release-triggered runs are \`workflow_run\` after \`Build C SDK\` after a \`release: published\` event. Tag, Cargo.toml version, release asset, and current ref all come from the same commit — symbol set is consistent by construction.

## Fix

Branch the \`libboxlite.a\` source on event type. \`workflow_run\` keeps the prebuilt fast path (release-aligned). \`workflow_dispatch\` builds inline from the current ref via \`make dist:c\`, so libboxlite's exported symbols match the \`sdks/go\` cgo references being linked.

\`Set up Rust\` is \`if: github.event_name == 'workflow_dispatch'\` so release runs don't pay setup time they don't need.

## Cost

- \`workflow_dispatch\`: + ~10 min on first run for full Rust build (sccache subsequent). Acceptable for a manual testing trigger.
- \`workflow_run\` / \`release\`: unchanged.

## Verification

Dispatched the patched branch on the fork to confirm the inline path links cleanly: https://github.com/G4614/boxlite/actions/runs/27119657784 (run in progress at PR open — will edit once complete).

The same ref + dispatch on a fork-mirrored \`v0.9.5\` release (which inadvertently triggered the full release pipeline → fresh libboxlite.a → ABI match) already produced a working binary, demonstrating the fix in spirit: https://github.com/G4614/boxlite/actions/runs/27119208260

## Notes / out of scope

- Could go further (修法 C): convert \`build-c.yml\` to \`workflow_call\` and depend on it from the dispatch path → zero duplication. Bigger structural change; left as follow-up.
- Inline build uses \`ubuntu-latest\` glibc, not manylinux. Acceptable for a testing trigger; release path still produces the manylinux-baselined binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)