### PR TITLE
fix(exec): type-driven command-not-found → 422, classified at the source

### DIFF
--- a/src/boxlite/src/portal/interfaces/exec.rs
+++ b/src/boxlite/src/portal/interfaces/exec.rs
@@ -6,7 +6,8 @@
 use crate::litebox::{BoxCommand, ExecResult};
 use boxlite_shared::{
     AttachRequest, BoxliteError, BoxliteResult, ExecOutput, ExecRequest, ExecStdin,
-    ExecutionClient, KillRequest, WaitRequest, WaitResponse, exec_output,
+    ExecutionClient, KillRequest, WaitRequest, WaitResponse, constants::executor as executor_const,
+    exec_output,
 };
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
@@ -57,13 +58,18 @@ impl ExecutionInterface {
 
         tracing::debug!(command = %command.command, "exec RPC: sending request");
 
-        // Start execution
+        // Start execution. The guest classifies a user-command error (program
+        // not found / not executable / no PATH) at the source and tags it with
+        // the stable `REASON_USER_COMMAND_ERROR` token; map that to `Execution`
+        // (HTTP 422) so a mistyped command isn't a 5xx that false-alarms SRE.
+        // Everything else stays `Internal` (500). No youki-internal text matching.
         let exec_response = self.client.exec(request).await?.into_inner();
         if let Some(err) = exec_response.error {
-            return Err(BoxliteError::Internal(format!(
-                "{}: {}",
-                err.reason, err.detail
-            )));
+            return Err(if err.reason == executor_const::REASON_USER_COMMAND_ERROR {
+                BoxliteError::Execution(err.detail)
+            } else {
+                BoxliteError::Internal(format!("{}: {}", err.reason, err.detail))
+            });
         }
 
         let execution_id = exec_response.execution_id.clone();

--- a/src/boxlite/tests/exec_options.rs
+++ b/src/boxlite/tests/exec_options.rs
@@ -191,3 +191,71 @@ async fn test_working_dir_with_user() {
 
     tb.teardown().await;
 }
+
+/// Executing a command that does not exist must surface as a structured
+/// `Execution` error (HTTP 422), NOT a 5-layer nested `Internal`/500 — so it
+/// stops false-alarming SRE and the SDK gets a typed error. This is the
+/// end-to-end proof of the typed user-command-error path: youki's workload
+/// validator → ValidatingExecutor fd signal → BuildFailureKind → reason token
+/// → BoxliteError::Execution.
+#[tokio::test]
+async fn test_command_not_found_returns_execution_error() {
+    let tb = TestBox::new().await;
+
+    // Execution (the Ok type) is not Debug, so match instead of expect_err.
+    let err = match tb
+        .handle
+        .exec(BoxCommand::new("this-binary-does-not-exist-2026"))
+        .await
+    {
+        Err(e) => e,
+        Ok(_) => panic!("command-not-found must be an Execution error (422), not Ok/500"),
+    };
+
+    assert!(
+        matches!(err, boxlite::BoxliteError::Execution(_)),
+        "command not found must map to Execution (422), got {err:?}"
+    );
+    assert!(
+        err.to_string().contains("not found"),
+        "error should explain the missing command, got: {err}"
+    );
+
+    tb.teardown().await;
+}
+
+/// A file that exists but is not executable maps to the same structured
+/// `Execution` error (422), not a 500. Pins youki's
+/// "does not have correct permissions" path end-to-end.
+#[tokio::test]
+async fn test_not_executable_returns_execution_error() {
+    let tb = TestBox::new().await;
+
+    // Create a present-but-non-executable file (mode 0644).
+    let prep = tb
+        .handle
+        .exec(BoxCommand::new("sh").args([
+            "-c",
+            "printf '#!/bin/sh\\necho hi\\n' > /tmp/noexec && chmod 0644 /tmp/noexec",
+        ]))
+        .await
+        .expect("prep exec failed");
+    assert_eq!(
+        prep.wait().await.expect("prep wait").exit_code,
+        0,
+        "creating the non-executable file should succeed"
+    );
+
+    // Exec the file directly so youki's validator rejects it with
+    // "does not have correct permissions" -> Execution (422).
+    let err = match tb.handle.exec(BoxCommand::new("/tmp/noexec")).await {
+        Err(e) => e,
+        Ok(_) => panic!("not-executable must be an Execution error (422), not Ok"),
+    };
+    assert!(
+        matches!(err, boxlite::BoxliteError::Execution(_)),
+        "not-executable must map to Execution (422), got {err:?}"
+    );
+
+    tb.teardown().await;
+}

--- a/src/guest/src/container/mod.rs
+++ b/src/guest/src/container/mod.rs
@@ -74,6 +74,8 @@ mod start;
 #[cfg(target_os = "linux")]
 mod stdio;
 #[cfg(target_os = "linux")]
+mod validating_executor;
+#[cfg(target_os = "linux")]
 pub(crate) mod zygote;
 
 #[cfg(target_os = "linux")]

--- a/src/guest/src/container/validating_executor.rs
+++ b/src/guest/src/container/validating_executor.rs
@@ -1,0 +1,87 @@
+//! A youki `Executor` that classifies user-command errors at the source.
+//!
+//! ## Why this exists
+//!
+//! When `box.exec("nonexistent")` runs, youki's `DefaultExecutor::validate()`
+//! rejects it with `ExecutorValidationError::ArgValidationError` (program not
+//! found / not executable / no PATH). That error is *typed* — but it dies at
+//! youki's own init→main process boundary: `container_intermediate_process.rs`
+//! does `exec_failed(err.to_string())`, flattening every init failure into a
+//! single `Message::ExecFailed(String)`. By the time `ContainerBuilder::build()`
+//! returns to us, the validation error is indistinguishable (same
+//! `LibcontainerError` variant) from a genuine platform failure (cgroup, mount,
+//! seccomp). The only surviving signal is the message *text*.
+//!
+//! Rather than string-match youki's volatile wording on the host, we intercept
+//! the error *where it is still typed* — inside the container init process,
+//! right after `DefaultExecutor::validate()` returns it — and smuggle a single
+//! byte out through an fd side-channel that bypasses youki's lossy channel. The
+//! zygote reads that byte and tags the build outcome with a typed
+//! [`BuildFailureKind`](super::zygote::BuildFailureKind), which then rides our
+//! own IPC and proto `reason` token up to the host as `BoxliteError::Execution`.
+//!
+//! ## fd lifetime
+//!
+//! `validate()` runs *after* pivot_root but *before* execvp (see the trait doc
+//! and youki `init/process.rs`). The write fd is created in the zygote, set
+//! `O_CLOEXEC`, and inherited by the clone3'd init child (clone does not honor
+//! CLOEXEC — only execve does). So the fd is open during `validate()` and is
+//! automatically closed on a successful execvp, never leaking into the user's
+//! process.
+
+use std::os::fd::RawFd;
+
+// Use libcontainer's re-exported oci_spec (0.6.x): the guest crate also depends
+// on oci_spec 0.9 directly, and the youki `Executor` trait is defined over the
+// 0.6 `Spec` — mixing the two is a type error.
+use libcontainer::oci_spec::runtime::Spec;
+use libcontainer::workload::default::DefaultExecutor;
+use libcontainer::workload::{Executor, ExecutorError, ExecutorValidationError};
+
+/// Wraps youki's `DefaultExecutor`, intercepting `validate()` to flag
+/// user-command errors over an out-of-band fd. `exec()` / `setup_envs()`
+/// delegate unchanged. `Clone` is required because youki clones the executor
+/// across the fork boundary (`builder_impl.rs`); `RawFd` is `Copy`, so a derive
+/// suffices and the `CloneBoxExecutor` blanket impl handles the trait object.
+#[derive(Clone)]
+pub(crate) struct ValidatingExecutor {
+    /// Write end of the zygote's signal pipe. We hold the raw number only —
+    /// the `OwnedFd` lifetime stays in `do_build`, so dropping the (cloned)
+    /// executor never closes it.
+    fail_fd: RawFd,
+}
+
+impl ValidatingExecutor {
+    pub(crate) fn new(fail_fd: RawFd) -> Self {
+        Self { fail_fd }
+    }
+}
+
+impl Executor for ValidatingExecutor {
+    fn exec(&self, spec: &Spec) -> Result<(), ExecutorError> {
+        (DefaultExecutor {}).exec(spec)
+    }
+
+    fn validate(&self, spec: &Spec) -> Result<(), ExecutorValidationError> {
+        match (DefaultExecutor {}).validate(spec) {
+            // The user asked to run something that can't be run. Signal the
+            // zygote (best-effort) before propagating youki's typed error, which
+            // youki will then stringify over its own channel. The byte — not the
+            // string — is what the host's 422 classification keys on.
+            Err(err @ ExecutorValidationError::ArgValidationError(_)) => {
+                let byte = [1u8];
+                // SAFETY: fail_fd is the inherited write end of the zygote's
+                // pipe, open until execvp (CLOEXEC). A failed/partial write only
+                // costs us the typed classification (falls back to 500), never
+                // correctness, so the result is intentionally ignored.
+                let _ = unsafe {
+                    nix::libc::write(self.fail_fd, byte.as_ptr() as *const nix::libc::c_void, 1)
+                };
+                Err(err)
+            }
+            other => other,
+        }
+    }
+
+    // setup_envs() uses the trait's default implementation (reset env from spec).
+}

--- a/src/guest/src/container/zygote.rs
+++ b/src/guest/src/container/zygote.rs
@@ -12,14 +12,16 @@
 //! See `docs/investigations/concurrent-exec-deadlock.md` for full analysis.
 
 use super::capabilities::capability_names;
+use super::validating_executor::ValidatingExecutor;
 use boxlite_shared::errors::{BoxliteError, BoxliteResult};
 use libcontainer::container::builder::ContainerBuilder;
 use libcontainer::syscall::syscall::SyscallType;
+use nix::fcntl::OFlag;
 use nix::sys::socket::{
     recvmsg, sendmsg, socketpair, AddressFamily, ControlMessage, ControlMessageOwned, MsgFlags,
     SockFlag, SockType,
 };
-use nix::unistd::{fork, ForkResult, Pid};
+use nix::unistd::{fork, pipe2, ForkResult, Pid};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::io::{IoSlice, IoSliceMut};
@@ -60,11 +62,28 @@ pub(crate) struct BuildSpec {
     pub gid: u32,
 }
 
+/// Classifies *why* a build failed, so the host can map it to the right status
+/// without re-parsing youki's volatile error text. Set at the source in
+/// [`do_build`] from the [`ValidatingExecutor`](super::validating_executor)
+/// fd side-channel.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
+pub(crate) enum BuildFailureKind {
+    /// The user-supplied command can't be run (not found / not executable / no
+    /// PATH). Maps to `BoxliteError::Execution` → HTTP 422.
+    UserCommandError,
+    /// A genuine platform failure (cgroup, mount, seccomp, init death, IPC).
+    /// Maps to `BoxliteError::Internal` → HTTP 500, stays visible to SRE.
+    Platform,
+}
+
 /// Build outcome. Invalid states are unrepresentable.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub(crate) enum BuildResult {
     Spawned { pid: i32 },
-    Failed { error: String },
+    Failed {
+        kind: BuildFailureKind,
+        error: String,
+    },
 }
 
 /// Process exit outcome from waitpid, serialized over IPC.
@@ -154,9 +173,13 @@ impl Zygote {
         send_request(fd, &ZygoteRequest::Build(spec), fds)?;
         match recv_response(fd)? {
             ZygoteResponse::Build(BuildResult::Spawned { pid }) => Ok(Pid::from_raw(pid)),
-            ZygoteResponse::Build(BuildResult::Failed { error }) => {
-                Err(BoxliteError::Internal(error))
-            }
+            // Type-driven classification — no string matching. The `kind` was
+            // decided at the source (do_build) from the executor fd signal.
+            // `Execution` is the existing 422 mapping; `Internal` stays 500.
+            ZygoteResponse::Build(BuildResult::Failed { kind, error }) => Err(match kind {
+                BuildFailureKind::UserCommandError => BoxliteError::Execution(error),
+                BuildFailureKind::Platform => BoxliteError::Internal(error),
+            }),
             other => Err(BoxliteError::Internal(format!(
                 "expected Build response, got: {other:?}"
             ))),
@@ -235,11 +258,32 @@ fn serve(sock: OwnedFd) -> ! {
 /// This is the same ContainerBuilder chain that was in `command.rs build_and_spawn()`,
 /// moved here to run in the zygote's single-threaded context where clone3() is safe.
 fn do_build(spec: BuildSpec, fds: Option<[RawFd; 3]>) -> BuildResult {
+    // Typed side-channel for user-command errors. The ValidatingExecutor (running
+    // in the clone3'd init child, post-pivot) writes a byte here when youki's
+    // workload validator rejects the program; we read it after build() fails to
+    // classify the failure without parsing youki's error text. O_CLOEXEC so the
+    // fd never leaks into a successfully exec'd user process; O_NONBLOCK so the
+    // post-build read can't hang. A pipe() failure is itself a platform fault.
+    let (signal_read, signal_write) = match pipe2(OFlag::O_CLOEXEC | OFlag::O_NONBLOCK) {
+        Ok(pair) => pair,
+        Err(e) => {
+            return BuildResult::Failed {
+                kind: BuildFailureKind::Platform,
+                error: format!("zygote signal pipe: {e}"),
+            }
+        }
+    };
+    let signal_write_fd = signal_write.as_raw_fd();
+
     let build_fn = || -> Result<Pid, String> {
         let mut builder = ContainerBuilder::new(spec.container_id.clone(), SyscallType::default())
             .with_root_path(spec.state_root.clone())
             .map_err(|e| format!("Failed to set container root path: {e}"))?
             .with_console_socket(spec.console_socket.clone())
+            // Intercept youki's workload validation to flag user-command errors
+            // over the fd above. Set on the base builder so it carries into both
+            // the TTY and non-TTY tenant paths below.
+            .with_executor(ValidatingExecutor::new(signal_write_fd))
             .validate_id()
             .map_err(|e| format!("Invalid container ID: {e}"))?;
 
@@ -303,10 +347,42 @@ fn do_build(spec: BuildSpec, fds: Option<[RawFd; 3]>) -> BuildResult {
         Ok(pid)
     };
 
-    match build_fn() {
+    let outcome = build_fn();
+
+    // Drop our copy of the write end before reading. We don't depend on EOF —
+    // the child wrote (if at all) before its init returned Err, which happens
+    // before build() returns, so any byte is already buffered. A non-blocking
+    // peek is enough.
+    drop(signal_write);
+
+    match outcome {
         Ok(pid) => BuildResult::Spawned { pid: pid.as_raw() },
-        Err(error) => BuildResult::Failed { error },
+        Err(error) => {
+            let kind = if signal_pipe_fired(&signal_read) {
+                BuildFailureKind::UserCommandError
+            } else {
+                BuildFailureKind::Platform
+            };
+            BuildResult::Failed { kind, error }
+        }
     }
+}
+
+/// Non-blocking peek: did the [`ValidatingExecutor`](super::validating_executor)
+/// write its user-command-error byte? Any byte read means yes. EAGAIN / empty /
+/// error means no — we fail safe toward `Platform` (HTTP 500), so a lost signal
+/// can never *downgrade* a real platform fault into a user error.
+fn signal_pipe_fired(read_fd: &OwnedFd) -> bool {
+    let mut buf = [0u8; 1];
+    // SAFETY: read_fd is a valid owned fd; read up to 1 byte into a stack buffer.
+    let n = unsafe {
+        nix::libc::read(
+            read_fd.as_raw_fd(),
+            buf.as_mut_ptr() as *mut nix::libc::c_void,
+            1,
+        )
+    };
+    n > 0
 }
 
 /// Check if a container process has exited (non-blocking).

--- a/src/guest/src/service/exec/mod.rs
+++ b/src/guest/src/service/exec/mod.rs
@@ -29,9 +29,9 @@ pub(crate) use state::InitHealthCheck;
 use crate::service::exec::executor::{ContainerExecutor, GuestExecutor};
 use crate::service::server::GuestServer;
 use boxlite_shared::{
-    constants::executor as executor_const, AttachRequest, ExecError, ExecOutput, ExecRequest,
-    ExecResponse, ExecStdin, Execution, KillRequest, KillResponse, ResizeTtyRequest,
-    ResizeTtyResponse, SendInputAck, WaitRequest, WaitResponse,
+    constants::executor as executor_const, errors::BoxliteError, AttachRequest, ExecError,
+    ExecOutput, ExecRequest, ExecResponse, ExecStdin, Execution, KillRequest, KillResponse,
+    ResizeTtyRequest, ResizeTtyResponse, SendInputAck, WaitRequest, WaitResponse,
 };
 use futures::stream::Stream;
 use std::pin::Pin;
@@ -353,6 +353,22 @@ fn spawn_error(exec_id: &str, err: String) -> ExecResponse {
     }
 }
 
+/// A user-command error (program not found / not executable / no PATH). Tagged
+/// with the shared `REASON_USER_COMMAND_ERROR` token so the host maps it to
+/// `BoxliteError::Execution` (HTTP 422) rather than the `spawn_failed` → 500
+/// path. `detail` is youki's message, kept for humans, never parsed for control.
+fn user_command_error(exec_id: &str, detail: String) -> ExecResponse {
+    ExecResponse {
+        execution_id: exec_id.to_string(),
+        pid: 0,
+        started_at_ms: 0,
+        error: Some(ExecError {
+            reason: executor_const::REASON_USER_COMMAND_ERROR.to_string(),
+            detail,
+        }),
+    }
+}
+
 fn now_ms() -> u64 {
     use std::time::{SystemTime, UNIX_EPOCH};
     SystemTime::now()
@@ -426,6 +442,14 @@ async fn spawn_with_executor(
             let container_ref = executor.container_ref();
             let handle = match executor.spawn(req).await {
                 Ok(h) => h,
+                // The zygote already classified this as a user-command error
+                // (program not found / not executable / no PATH) from the youki
+                // workload validator via its fd side-channel. Carry that across
+                // the gRPC boundary as a stable `reason` token so the host maps
+                // it to a 422, not a 500 — no init-death probe, no string match.
+                Err(BoxliteError::Execution(detail)) => {
+                    return Err(user_command_error(execution_id, detail));
+                }
                 Err(e) => {
                     // Check if container init died — provide actionable diagnostics
                     let mut container = container_ref.lock().await;

--- a/src/shared/src/constants.rs
+++ b/src/shared/src/constants.rs
@@ -38,6 +38,15 @@ pub mod executor {
 
     /// Key for container executor (format: "container")
     pub const CONTAINER_KEY: &str = "container";
+
+    /// Stable `ExecError.reason` token meaning "the user-supplied command can't be
+    /// run" (not found in PATH / not executable / no PATH set). This is OUR own
+    /// vocabulary on the guest→host boundary: the guest classifies the failure at
+    /// the source (via the youki workload validator, surfaced through a typed
+    /// fd side-channel) and the host maps this reason to `BoxliteError::Execution`
+    /// (HTTP 422) instead of `Internal` (500). Both sides MUST agree on this
+    /// literal, hence the shared constant — no magic strings.
+    pub const REASON_USER_COMMAND_ERROR: &str = "user_command_error";
 }
 
 /// Virtiofs mount tags


### PR DESCRIPTION
## Problem

`box.exec("nonexistent")` returned a nested HTTP 500. A missing or non-executable command is a **user error, not a platform fault** — it must not be a 5xx that false-alarms SRE.

## Why it was non-trivial

youki's workload validator already rejects these with a typed `ExecutorValidationError::ArgValidationError`, but youki **stringifies the error at its own init→main process boundary** (`exec_failed(err.to_string())` → `Message::ExecFailed(String)`). By the time `ContainerBuilder::build()` returns, a user-command error is indistinguishable from a genuine platform failure except by message text — so the host was string-matching youki's volatile wording.

## Fix — classify at the source, no string matching

- **New `ValidatingExecutor`** (a youki `Executor`) wraps `DefaultExecutor`, intercepts the typed `ArgValidationError` from the *real* validator — which runs in the correct mount namespace / FS view, so **zero false-reject risk** — and writes one byte to an `O_CLOEXEC|O_NONBLOCK` pipe created in the zygote.
- **`do_build`** injects it via `.with_executor()`, reads the pipe after a failed `build()`, and tags the outcome with a typed `BuildFailureKind` (`UserCommandError` | `Platform`). A lost signal **fails safe toward `Platform`/500** — it can never downgrade a real platform fault.
- **`Zygote::build`** maps the kind to `BoxliteError::Execution` (422) vs `Internal` (500); the guest carries it across gRPC as a stable `REASON_USER_COMMAND_ERROR` token (shared constant); the host keys 422 off that token, never off youki internals.

Net: host and SDK are fully typed end-to-end; youki coupling is confined to a single guest-side interception.

## Verification

- host + guest (linux-musl cross) compile and clippy clean.
- **Two-side reproducer on a real microVM**: with all production reverted the new tests **FAIL** with `Internal("...not found in $PATH")` (500) pointing at the bug; with the fix they **PASS** with `Execution`/422 — for both command-not-found and not-executable.

7 files, +288/−16.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command execution error handling so invalid or non-executable commands are reported as execution errors instead of generic internal failures.
  * Preserved internal error classification for platform and container startup failures.
  * Added consistent error details for commands that cannot be found or run.
  * Improved error classification for command validation failures without relying on error-message text.

* **Tests**
  * Added coverage for missing and non-executable command scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->