### PR TITLE
fix: reject unsupported parameters when creating a box

### DIFF
--- a/apps/api/src/boxlite-rest/boxlite-box.controller.ts
+++ b/apps/api/src/boxlite-rest/boxlite-box.controller.ts
@@ -33,6 +33,7 @@ import { SandboxDesiredState } from '../sandbox/enums/sandbox-desired-state.enum
 import { BoxResponseDto, ListBoxesResponseDto } from './dto/box-response.dto'
 import { CreateBoxDto } from './dto/create-box.dto'
 import { sandboxToBoxResponse, createBoxToCreateSandbox } from './mappers/sandbox-to-box.mapper'
+import { strictBodyValidationPipe } from '../common/pipes/strict-body-validation.pipe'
 import { Audit, MASKED_AUDIT_VALUE, TypedRequest } from '../audit/decorators/audit.decorator'
 import { AuditAction } from '../audit/enums/audit-action.enum'
 import { AuditTarget } from '../audit/enums/audit-target.enum'
@@ -76,7 +77,7 @@ export class BoxliteBoxController {
   })
   async createBox(
     @AuthContext() authContext: OrganizationAuthContext,
-    @Body() dto: CreateBoxDto,
+    @Body(strictBodyValidationPipe) dto: CreateBoxDto,
   ): Promise<BoxResponseDto> {
     const organization = authContext.organization
     const createSandboxDto = createBoxToCreateSandbox(dto)

--- a/apps/api/src/common/pipes/strict-body-validation.pipe.spec.ts
+++ b/apps/api/src/common/pipes/strict-body-validation.pipe.spec.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2025 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { ArgumentMetadata, BadRequestException } from '@nestjs/common'
+import { strictBodyValidationPipe } from './strict-body-validation.pipe'
+import { CreateBoxDto } from '../../boxlite-rest/dto/create-box.dto'
+import { CreateSandboxDto } from '../../sandbox/dto/create-sandbox.dto'
+
+/**
+ * Verifies the scoped pipe rejects unsupported body fields instead of silently
+ * dropping them. Runs the real pipe against the real creation DTOs — the same
+ * objects wired onto the box/sandbox creation handlers.
+ */
+describe('strictBodyValidationPipe', () => {
+  const boxMeta: ArgumentMetadata = { type: 'body', metatype: CreateBoxDto, data: undefined }
+  const sandboxMeta: ArgumentMetadata = { type: 'body', metatype: CreateSandboxDto, data: undefined }
+
+  it('rejects an unknown field on CreateBoxDto and names it', async () => {
+    await expect(
+      strictBodyValidationPipe.transform({ image: 'alpine:latest', auto_delete_minutes: 5 }, boxMeta),
+    ).rejects.toBeInstanceOf(BadRequestException)
+
+    try {
+      await strictBodyValidationPipe.transform({ image: 'alpine:latest', auto_delete_minutes: 5 }, boxMeta)
+      fail('expected BadRequestException')
+    } catch (err) {
+      const messages = (err as BadRequestException).getResponse() as { message: string[] }
+      expect(JSON.stringify(messages.message)).toContain('auto_delete_minutes')
+      expect(JSON.stringify(messages.message)).toContain('should not exist')
+    }
+  })
+
+  it('rejects an unknown field on CreateSandboxDto', async () => {
+    await expect(
+      strictBodyValidationPipe.transform({ snapshot: 'ubuntu', auto_stop_minutes: 5 }, sandboxMeta),
+    ).rejects.toBeInstanceOf(BadRequestException)
+  })
+
+  it('accepts a fully-supported CreateBoxDto body', async () => {
+    const result = await strictBodyValidationPipe.transform(
+      { image: 'alpine:latest', cpus: 2, memory_mib: 256, auto_remove: false, detach: false },
+      boxMeta,
+    )
+    expect(result.image).toBe('alpine:latest')
+    expect(result.cpus).toBe(2)
+    expect(result.auto_remove).toBe(false)
+  })
+
+  it('accepts a fully-supported CreateSandboxDto body', async () => {
+    const result = await strictBodyValidationPipe.transform(
+      { snapshot: 'ubuntu:24.04', cpu: 2, memory: 4, autoDeleteInterval: 30 },
+      sandboxMeta,
+    )
+    expect(result.snapshot).toBe('ubuntu:24.04')
+    expect(result.autoDeleteInterval).toBe(30)
+  })
+})

--- a/apps/api/src/common/pipes/strict-body-validation.pipe.ts
+++ b/apps/api/src/common/pipes/strict-body-validation.pipe.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2025 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { ValidationPipe } from '@nestjs/common'
+
+/**
+ * A scoped ValidationPipe that REJECTS request-body fields the DTO does not
+ * declare, returning 400 instead of silently dropping them.
+ *
+ * The global pipe in `main.ts` only runs `transform`, so unknown fields
+ * (typos, removed params like `auto_delete_minutes`) pass through unnoticed.
+ * Attach this to box/sandbox creation handlers via `@Body(strictBodyValidationPipe)`
+ * to make unsupported parameters fail loudly at the boundary.
+ *
+ * Scoped on purpose — not applied globally — to keep the blast radius to the
+ * creation endpoints and avoid 400-ing other endpoints that tolerate extra fields.
+ */
+export const strictBodyValidationPipe = new ValidationPipe({
+  whitelist: true,
+  forbidNonWhitelisted: true,
+  transform: true,
+})

--- a/apps/api/src/sandbox/controllers/sandbox.controller.ts
+++ b/apps/api/src/sandbox/controllers/sandbox.controller.ts
@@ -27,6 +27,7 @@ import {
 import { CombinedAuthGuard } from '../../auth/combined-auth.guard'
 import { SandboxService } from '../services/sandbox.service'
 import { CreateSandboxDto } from '../dto/create-sandbox.dto'
+import { strictBodyValidationPipe } from '../../common/pipes/strict-body-validation.pipe'
 import {
   ApiOAuth2,
   ApiResponse,
@@ -277,7 +278,7 @@ export class SandboxController {
   })
   async createSandbox(
     @AuthContext() authContext: OrganizationAuthContext,
-    @Body() createSandboxDto: CreateSandboxDto,
+    @Body(strictBodyValidationPipe) createSandboxDto: CreateSandboxDto,
   ): Promise<SandboxDto> {
     const organization = authContext.organization
     let sandbox: SandboxDto

--- a/sdks/node/lib/simplebox.ts
+++ b/sdks/node/lib/simplebox.ts
@@ -252,6 +252,38 @@ export interface SimpleBoxOptions {
 }
 
 /**
+ * Every key the SimpleBox constructor accepts. Used to reject unknown options
+ * at the boundary instead of silently dropping them (napi ignores extra JS
+ * keys at runtime). Keep this in sync with the SimpleBoxOptions interface.
+ *
+ * Subclasses (CodeBox/BrowserBox/ComputerBox/SkillBox/InteractiveBox) strip
+ * their own extra keys before calling super(), so this set never rejects
+ * legitimate subclass usage.
+ */
+const KNOWN_SIMPLE_BOX_OPTION_KEYS: ReadonlySet<string> = new Set([
+  "image",
+  "rootfsPath",
+  "memoryMib",
+  "cpus",
+  "diskSizeGb",
+  "runtime",
+  "name",
+  "autoRemove",
+  "reuseExisting",
+  "detach",
+  "workingDir",
+  "env",
+  "volumes",
+  "ports",
+  "network",
+  "secrets",
+  "entrypoint",
+  "cmd",
+  "user",
+  "security",
+]);
+
+/**
  * Base class for specialized container types.
  *
  * This class provides the foundation for all specialized boxes:
@@ -316,8 +348,8 @@ export class SimpleBox {
    * ```
    */
   constructor(options: SimpleBoxOptions = {}) {
-    const JsBoxlite = getJsBoxlite();
-    const security = normalizeSecurityOptions(options.security);
+    // Validate input at the boundary, before touching the runtime, so an
+    // unsupported parameter fails loudly instead of being silently dropped.
     const legacyOptions = options as SimpleBoxOptions & {
       allowNet?: unknown;
       network?: unknown;
@@ -334,6 +366,19 @@ export class SimpleBox {
         "SimpleBoxOptions.network must be an object. Use network: { mode, allowNet }.",
       );
     }
+
+    const unknownKeys = Object.keys(options).filter(
+      (key) => !KNOWN_SIMPLE_BOX_OPTION_KEYS.has(key),
+    );
+    if (unknownKeys.length > 0) {
+      throw new TypeError(
+        `Unknown SimpleBoxOptions: ${unknownKeys.join(", ")}. ` +
+          `Supported options: ${[...KNOWN_SIMPLE_BOX_OPTION_KEYS].join(", ")}.`,
+      );
+    }
+
+    const JsBoxlite = getJsBoxlite();
+    const security = normalizeSecurityOptions(options.security);
 
     // Use provided runtime or get global default
     if (options.runtime) {

--- a/sdks/node/tests/simplebox-options-validation.integration.test.ts
+++ b/sdks/node/tests/simplebox-options-validation.integration.test.ts
@@ -1,0 +1,27 @@
+/**
+ * E2E: SimpleBox option validation against the REAL built native module
+ * (no mock). Proves the unsupported-parameter guard fires in the shipped SDK,
+ * not just under a stubbed runtime.
+ *
+ * Requires the native binary (`npm run build:native`).
+ */
+
+import { describe, test, expect } from "vitest";
+import { SimpleBox } from "../lib/simplebox.js";
+
+describe("SimpleBox option validation (real native)", () => {
+  test("unsupported option throws and names it", () => {
+    expect(
+      () =>
+        new SimpleBox({ image: "alpine:latest", auto_delete_minutes: 5 } as never),
+    ).toThrow(/auto_delete_minutes/);
+  });
+
+  test("valid options construct without throwing", () => {
+    // Construction is lazy (no VM boot), but this still exercises the real
+    // getJsBoxlite() + runtime handle, so a false-positive rejection would surface.
+    expect(
+      () => new SimpleBox({ image: "alpine:latest", autoRemove: false }),
+    ).not.toThrow();
+  });
+});

--- a/sdks/node/tests/simplebox-options-validation.test.ts
+++ b/sdks/node/tests/simplebox-options-validation.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Unit tests for SimpleBox constructor option validation (no VM / native required).
+ *
+ * The native loader is mocked so construction does not touch the real runtime;
+ * this lets us observe that an UNSUPPORTED option fails loudly at the boundary
+ * instead of being silently dropped by the napi conversion.
+ */
+
+import { describe, test, expect, vi } from "vitest";
+
+// Mock the native loader: SimpleBox's only runtime import from ./native.js is
+// getJsBoxlite(). Returning a stub runtime lets valid construction succeed
+// without the prebuilt .node binary, so the only thing under test is the
+// constructor's own input validation.
+vi.mock("../lib/native.js", () => ({
+  getJsBoxlite: () => ({
+    withDefaultConfig: () => ({}),
+  }),
+}));
+
+import { SimpleBox } from "../lib/simplebox.js";
+
+describe("SimpleBox option validation", () => {
+  test("rejects an unknown option and names it", () => {
+    expect(
+      () => new SimpleBox({ image: "alpine:latest", bogusOption: 1 } as never),
+    ).toThrow(TypeError);
+    expect(
+      () => new SimpleBox({ image: "alpine:latest", bogusOption: 1 } as never),
+    ).toThrow(/bogusOption/);
+  });
+
+  test("rejects removed lifecycle params (auto_stop / auto_delete)", () => {
+    // These were never wired into the SDK; passing them must error, not be ignored.
+    expect(() => new SimpleBox({ autoStopMinutes: 5 } as never)).toThrow(
+      /autoStopMinutes/,
+    );
+    expect(() => new SimpleBox({ autoDeleteMinutes: 5 } as never)).toThrow(
+      /autoDeleteMinutes/,
+    );
+  });
+
+  test("lists every unknown key when several are passed", () => {
+    let message = "";
+    try {
+      new SimpleBox({ foo: 1, bar: 2 } as never);
+    } catch (err) {
+      message = (err as Error).message;
+    }
+    expect(message).toContain("foo");
+    expect(message).toContain("bar");
+  });
+
+  test("accepts the full set of supported options without throwing", () => {
+    expect(
+      () =>
+        new SimpleBox({
+          image: "alpine:latest",
+          cpus: 1,
+          memoryMib: 256,
+          autoRemove: false,
+          detach: false,
+          workingDir: "/tmp",
+          env: { A: "1" },
+          name: "ok-box",
+          reuseExisting: true,
+        }),
+    ).not.toThrow();
+  });
+
+  test("preserves the specific migration error for the removed allowNet option", () => {
+    expect(() => new SimpleBox({ allowNet: [] } as never)).toThrow(
+      /allowNet was removed/,
+    );
+  });
+});

--- a/src/cli/src/commands/serve/types.rs
+++ b/src/cli/src/commands/serve/types.rs
@@ -255,3 +255,42 @@ pub(super) struct RemoveQuery {
 pub(super) struct FileQuery {
     pub path: String,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Locks the `#[serde(deny_unknown_fields)]` contract on CreateBoxRequest:
+    // an unsupported parameter on the `boxlite serve` REST path must be rejected
+    // at deserialization (→ HTTP 400), never silently dropped. Removing the
+    // attribute makes this test fail.
+    #[test]
+    fn create_box_request_rejects_unknown_field() {
+        let json = r#"{"image":"alpine:latest","auto_delete_minutes":5}"#;
+        let result = serde_json::from_str::<CreateBoxRequest>(json);
+        // CreateBoxRequest deliberately does not derive Debug, so avoid expect_err.
+        assert!(
+            result.is_err(),
+            "unknown field must be rejected, not silently dropped"
+        );
+        let msg = result.err().unwrap().to_string();
+        assert!(
+            msg.contains("auto_delete_minutes"),
+            "rejection should name the offending field, got: {msg}"
+        );
+        assert!(
+            msg.contains("unknown field"),
+            "expected serde deny_unknown_fields message, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn create_box_request_accepts_supported_fields() {
+        let json = r#"{"image":"alpine:latest","cpus":2,"auto_remove":false}"#;
+        let req = serde_json::from_str::<CreateBoxRequest>(json)
+            .expect("supported fields must deserialize");
+        assert_eq!(req.image.as_deref(), Some("alpine:latest"));
+        assert_eq!(req.cpus, Some(2));
+        assert_eq!(req.auto_remove, Some(false));
+    }
+}


### PR DESCRIPTION
## What

Creating a box with an unsupported parameter — a typo, or a field a layer
doesn't accept — used to drop it silently. Now it fails fast with a clear
error that names the offending field, so mistakes surface instead of being
ignored.

## Changes

- **Node SDK (`SimpleBox`)** — the constructor validates option keys against
  the known set before touching the runtime; unknown keys throw a `TypeError`
  listing them.
- **REST API** — the box/sandbox creation endpoints reject unknown body fields
  with `400`. Scoped to those handlers; the global validation pipe is left
  unchanged to keep the blast radius small.
- **`boxlite serve`** — already rejected unknown fields; added a regression
  test to lock that behavior in.

Python, Go, and C SDKs already reject unknown parameters (named params /
compile-time checks) and are unchanged.

## Testing

Unit and integration tests on each touched boundary, each confirmed to fail
without the change and pass with it. Also exercised end-to-end over HTTP
(`boxlite serve` plus REST clients) and against the built native module.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Box and sandbox creation endpoints now enforce stricter validation, rejecting unsupported request fields with detailed error messages.
  * Node SDK constructor validates options at initialization and rejects unsupported settings with clear error feedback.
  * Improved input validation across API and SDK boundaries prevents silent failures and provides better error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->