### PR TITLE
ci: prep test/lint workflows for a merge queue

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -310,6 +310,7 @@ jobs:
     needs: [config, changes, rustfmt, clippy, python, node, c, go, install_script]
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: All lint jobs passed or were skipped
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,7 @@
 name: Lint and Format
 
 on:
+  merge_group:
   push:
     branches: [ main ]
     paths:
@@ -64,9 +65,13 @@ jobs:
       install_script: ${{ steps.filter.outputs.install_script }}
     steps:
       - uses: actions/checkout@v5
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
+          # In a merge queue, diff against the merge-group base/head (no PR base
+          # exists). Empty on pull_request/push, where paths-filter ignores them.
+          base: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_sha || '' }}
+          ref: ${{ github.event_name == 'merge_group' && github.event.merge_group.head_sha || '' }}
           filters: |
             rust:
               - '**/*.rs'
@@ -294,3 +299,19 @@ jobs:
 
       - name: Run installer script smoke test
         run: make test:install-script
+
+  # Single required status check for branch protection / merge queue.
+  # Passes only if every job above succeeded or was skipped (path-filtered).
+  # `if: !cancelled()` is required: without it a failed dependency would skip
+  # this job, and GitHub treats a skipped required check as success.
+  # NOTE: keep `needs` in sync with the jobs above when adding/removing jobs.
+  lint-conclusion:
+    name: Lint (conclusion)
+    needs: [config, changes, rustfmt, clippy, python, node, c, go, install_script]
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: All lint jobs passed or were skipped
+        run: |
+          jq -C <<< '${{ toJSON(needs) }}'
+          jq --exit-status 'all(.result == "success" or .result == "skipped")' <<< '${{ toJSON(needs) }}'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -291,6 +291,7 @@ jobs:
     needs: [config, changes, rust, cli, python, node, go]
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: All test jobs passed or were skipped
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@
 name: Test
 
 on:
+  merge_group:
   push:
     branches: [main]
     paths:
@@ -58,9 +59,13 @@ jobs:
       go: ${{ steps.filter.outputs.go }}
     steps:
       - uses: actions/checkout@v5
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
+          # In a merge queue, diff against the merge-group base/head (no PR base
+          # exists). Empty on pull_request/push, where paths-filter ignores them.
+          base: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_sha || '' }}
+          ref: ${{ github.event_name == 'merge_group' && github.event.merge_group.head_sha || '' }}
           filters: |
             rust:
               - 'src/boxlite/**'
@@ -275,3 +280,19 @@ jobs:
 
       - name: Run Go unit tests
         run: make test:unit:go
+
+  # Single required status check for branch protection / merge queue.
+  # Passes only if every job above succeeded or was skipped (path-filtered).
+  # `if: !cancelled()` is required: without it a failed dependency would skip
+  # this job, and GitHub treats a skipped required check as success.
+  # NOTE: keep `needs` in sync with the jobs above when adding/removing jobs.
+  test-conclusion:
+    name: Test (conclusion)
+    needs: [config, changes, rust, cli, python, node, go]
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: All test jobs passed or were skipped
+        run: |
+          jq -C <<< '${{ toJSON(needs) }}'
+          jq --exit-status 'all(.result == "success" or .result == "skipped")' <<< '${{ toJSON(needs) }}'


### PR DESCRIPTION
## What

Prepares `test.yml` and `lint.yml` so they can gate a GitHub **merge queue**, without enabling the queue yet.

Three edits per workflow:

1. **Bare `merge_group:` trigger** — a merge queue blocks until required checks report; a workflow that's path-filtered out of the `merge_group` event never runs and freezes the queue. The trigger has no top-level `paths:`.
2. **`dorny/paths-filter@v3 → @v4` + explicit merge-group `base`/`ref`** — v4 adds `merge_group` support; passing `base_sha`/`head_sha` lets it diff the merge group so only affected suites run in the queue. `base`/`ref` are empty on `pull_request`/`push`, where paths-filter ignores them. (PyO3 / vector pattern.)
3. **`{test,lint}-conclusion` aggregator** — one required status check that passes only if every job succeeded **or was skipped** (path-filtered). `if: !cancelled()` is required so a failed dependency can't *skip* the gate, which GitHub would read as success. `needs` must be kept in sync when jobs are added/removed.

## Why now (not enabling the queue here)

The conclusion checks must run at least once on a PR before they can be selected as required status checks. This PR makes that happen. Enabling the merge queue is a follow-up **ruleset** change (swap `license/cla` → the two conclusion checks, turn off strict "require up to date", turn on "require merge queue").

## Verification

- `actionlint` parses both files with no new errors (pre-existing warnings on `test.yml:128` codecov input and `lint.yml:142` shellcheck are in untouched jobs).
- On this PR, expect `Test (conclusion)` and `Lint (conclusion)` to appear as checks.

Full runbook: `docs/development/merge-queue-setup.md` (separate).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configurations to improve merge queue handling and status checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->