### PR TITLE
ci: run test/lint on every PR so required conclusion checks always report

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,28 +24,13 @@ on:
       - '.github/workflows/config.yml'
       - '.github/workflows/build-runtime.yml'
       - 'scripts/release/**'
+  # No path filter on pull_request: the `Lint (conclusion)` job is a required
+  # status check, so this workflow must run on EVERY PR and report it. A
+  # path-skipped workflow leaves the required check stuck "Pending" → PR blocked.
+  # Per-suite filtering still happens in the `changes` job (jobs skip when
+  # unaffected); the conclusion job reports success-or-skipped.
   pull_request:
     branches: [ main ]
-    paths:
-      - '**/*.rs'
-      - '**/*.py'
-      - '**/*.ts'
-      - '**/*.c'
-      - '**/*.h'
-      - '**/*.go'
-      - '**/Cargo.toml'
-      - 'Cargo.lock'
-      - 'sdks/python/**'
-      - 'sdks/node/**'
-      - 'sdks/c/**'
-      - 'sdks/go/**'
-      - 'make/quality.mk'
-      - 'make/test.mk'
-      - '.pre-commit-config.yaml'
-      - '.github/workflows/lint.yml'
-      - '.github/workflows/config.yml'
-      - '.github/workflows/build-runtime.yml'
-      - 'scripts/release/**'
 
 jobs:
   config:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,18 +24,13 @@ on:
       - 'Cargo.lock'
       - '.github/workflows/test.yml'
       - '.github/workflows/config.yml'
+  # No path filter on pull_request: the `Test (conclusion)` job is a required
+  # status check, so this workflow must run on EVERY PR and report it. A
+  # path-skipped workflow leaves the required check stuck "Pending" → PR blocked.
+  # Per-suite filtering still happens in the `changes` job (jobs skip when
+  # unaffected); the conclusion job reports success-or-skipped.
   pull_request:
     branches: [main]
-    paths:
-      - 'src/boxlite/**'
-      - 'src/shared/**'
-      - 'src/cli/**'
-      - 'src/guest/**'
-      - 'sdks/**'
-      - '**/Cargo.toml'
-      - 'Cargo.lock'
-      - '.github/workflows/test.yml'
-      - '.github/workflows/config.yml'
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Problem

After enabling the merge queue, `Test (conclusion)` and `Lint (conclusion)` were made **required** status checks. But `test.yml` / `lint.yml` still had a `paths:` filter on the **`pull_request`** trigger, so a PR not touching those paths never runs the workflow — and the required conclusion check stays **Pending**, blocking the PR from merging.

Observed live on #678 (changed only `scripts/test/e2e/**` + `make/**` → `test.yml` never ran → `Test (conclusion)` missing). Confirmed by [GitHub docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks): *"a workflow skipped due to path filtering... checks... remain 'Pending'... blocked from merging."*

## Fix

Remove the `paths:` filter from the `pull_request` trigger on both workflows so they run on **every** PR (matches rust-analyzer/bevy, which have no top-level paths on their gating workflows). Nothing else changes:
- Per-suite filtering still happens in the `changes` job (heavy jobs skip when unaffected).
- The conclusion job reports `success`-or-`skipped`, so it always reports green for unrelated PRs.
- `push:` paths are kept as-is (irrelevant to PR gating).

Cost: ~3 small jobs (config/changes/conclusion) per workflow per PR.

## Note

PRs opened before #677 merged still lack the conclusion jobs entirely and need a rebase onto `main` to pick them up — separate from this fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to ensure status checks remain responsive on all pull requests targeting main, preventing them from getting stuck in a pending state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->