### PR TITLE
fix(runner): make config getters nil-safe before initialization

### DIFF
--- a/apps/runner/cmd/runner/config/config.go
+++ b/apps/runner/cmd/runner/config/config.go
@@ -137,17 +137,32 @@ func (c *Config) GetOtelHeaders() map[string]string {
 }
 
 func GetContainerRuntime() string {
+	if config == nil {
+		return os.Getenv("CONTAINER_RUNTIME")
+	}
 	return config.ContainerRuntime
 }
 
 func GetContainerNetwork() string {
+	if config == nil {
+		return os.Getenv("CONTAINER_NETWORK")
+	}
 	return config.ContainerNetwork
 }
 
 func GetEnvironment() string {
+	if config == nil {
+		return os.Getenv("ENVIRONMENT")
+	}
 	return config.Environment
 }
 
 func GetBuildEngine() string {
+	if config == nil {
+		if buildEngine := os.Getenv("BUILD_ENGINE"); buildEngine != "" {
+			return buildEngine
+		}
+		return "buildkit"
+	}
 	return config.BuildEngine
 }

--- a/apps/runner/cmd/runner/config/config_test.go
+++ b/apps/runner/cmd/runner/config/config_test.go
@@ -1,0 +1,43 @@
+package config
+
+import "testing"
+
+func TestGettersFallbackToEnvironmentWhenConfigIsUninitialized(t *testing.T) {
+	oldConfig := config
+	config = nil
+	t.Cleanup(func() {
+		config = oldConfig
+	})
+
+	t.Setenv("CONTAINER_RUNTIME", "containerd")
+	t.Setenv("CONTAINER_NETWORK", "boxlite-net")
+	t.Setenv("ENVIRONMENT", "development")
+	t.Setenv("BUILD_ENGINE", "legacy")
+
+	if got := GetContainerRuntime(); got != "containerd" {
+		t.Fatalf("GetContainerRuntime() = %q, want containerd", got)
+	}
+	if got := GetContainerNetwork(); got != "boxlite-net" {
+		t.Fatalf("GetContainerNetwork() = %q, want boxlite-net", got)
+	}
+	if got := GetEnvironment(); got != "development" {
+		t.Fatalf("GetEnvironment() = %q, want development", got)
+	}
+	if got := GetBuildEngine(); got != "legacy" {
+		t.Fatalf("GetBuildEngine() = %q, want legacy", got)
+	}
+}
+
+func TestGetBuildEngineDefaultsWhenConfigIsUninitialized(t *testing.T) {
+	oldConfig := config
+	config = nil
+	t.Cleanup(func() {
+		config = oldConfig
+	})
+
+	t.Setenv("BUILD_ENGINE", "")
+
+	if got := GetBuildEngine(); got != "buildkit" {
+		t.Fatalf("GetBuildEngine() = %q, want buildkit", got)
+	}
+}


### PR DESCRIPTION
runner cannot panic while getting a nil config

## Tests
- go test ./cmd/runner/config


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Improved stability by ensuring configuration accessor functions safely handle cases where the configuration is not yet initialized, with graceful fallbacks to environment variables for runtime, network, and build engine settings.

## Tests
- Added comprehensive test coverage for configuration fallback behavior when the configuration is uninitialized, including tests for default value handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->