### PR TITLE
fix(cloud): reserve executor env for user requests only

### DIFF
--- a/apps/api/src/box/services/box.service.box-id.spec.ts
+++ b/apps/api/src/box/services/box.service.box-id.spec.ts
@@ -40,3 +40,28 @@ describe('BoxService public identity lookup', () => {
     )
   })
 })
+
+describe('BoxService reserved env validation', () => {
+  it('rejects BOXLITE_EXECUTOR during create before resolving runners', async () => {
+    const service = Object.create(BoxService.prototype) as BoxService
+
+    await expect(
+      service.create({ env: { BOXLITE_EXECUTOR: 'guest' } } as never, { id: 'org-1' } as never),
+    ).rejects.toThrow('BOXLITE_EXECUTOR is reserved')
+  })
+
+  it('rejects BOXLITE_EXECUTOR during recover before calling the runner', async () => {
+    const organizationId = '057963b2-60ca-4356-81fc-11503e15f249'
+    const box = new Box('us', 'data-loader')
+    box.organizationId = organizationId
+    box.state = BoxState.ERROR
+    box.env = { BOXLITE_EXECUTOR: 'guest' }
+
+    const findOne = jest.fn().mockResolvedValueOnce(box)
+    const service = createService(findOne)
+
+    await expect(service.recover(box.id, { id: organizationId } as never)).rejects.toThrow(
+      'BOXLITE_EXECUTOR is reserved',
+    )
+  })
+})

--- a/apps/api/src/box/services/box.service.ts
+++ b/apps/api/src/box/services/box.service.ts
@@ -74,6 +74,7 @@ import { BoxLookupCacheInvalidationService } from './box-lookup-cache-invalidati
 import { Region } from '../../region/entities/region.entity'
 import { BoxActivityService } from './box-activity.service'
 import { assertWithinPerBoxLimits } from './per-box-limits'
+import { RESERVED_ENV_MESSAGE, hasReservedEnv } from '../../common/utils/reserved-env.util'
 
 // TODO(image-rewrite): resource defaults previously came from the removed image subsystem;
 // these mirror the Box entity column defaults until image resolution is rebuilt.
@@ -146,6 +147,10 @@ export class BoxService {
   }
 
   async create(createBoxDto: CreateBoxDto, organization: Organization): Promise<BoxDto> {
+    if (hasReservedEnv(createBoxDto.env)) {
+      throw new BadRequestError(RESERVED_ENV_MESSAGE)
+    }
+
     const region = await this.getValidatedOrDefaultRegion(organization, createBoxDto.target)
 
     try {
@@ -858,6 +863,9 @@ export class BoxService {
 
     if (box.state !== BoxState.ERROR) {
       throw new BadRequestError('Box must be in error state to recover')
+    }
+    if (hasReservedEnv(box.env)) {
+      throw new BadRequestError(RESERVED_ENV_MESSAGE)
     }
 
     if (box.pending) {

--- a/apps/api/src/boxlite-rest/boxlite-proxy.controller.spec.ts
+++ b/apps/api/src/boxlite-rest/boxlite-proxy.controller.spec.ts
@@ -52,4 +52,38 @@ describe('BoxliteProxyController', () => {
     expect(boxService.findOneByIdOrName).toHaveBeenCalledWith('public-box', 'org-1')
     expect(proxyHandler).toHaveBeenCalledWith(req, res, next)
   })
+
+  it('rejects reserved executor env vars before proxying exec requests', async () => {
+    const proxyHandler = jest.fn()
+    jest.mocked(createProxyMiddleware).mockReturnValue(proxyHandler as never)
+
+    const boxService = {
+      findOneByIdOrName: jest.fn(),
+      updateLastActivityAt: jest.fn(),
+    }
+    const runnerService = {
+      findOne: jest.fn(),
+    }
+
+    const controller = new BoxliteProxyController(boxService as never, runnerService as never)
+    const req = {
+      url: '/api/v1/boxes/public-box/exec',
+      body: { command: 'sh', env: { BOXLITE_EXECUTOR: 'guest' } },
+    }
+    const res = {}
+    const next = jest.fn()
+
+    await expect(
+      controller.proxyExec({ organizationId: 'org-1' } as never, 'public-box', req as never, res as never, next),
+    ).rejects.toMatchObject({
+      status: 400,
+      response: expect.objectContaining({
+        message: 'BOXLITE_EXECUTOR is reserved and cannot be set by user requests',
+      }),
+    })
+
+    expect(createProxyMiddleware).not.toHaveBeenCalled()
+    expect(boxService.findOneByIdOrName).not.toHaveBeenCalled()
+    expect(proxyHandler).not.toHaveBeenCalled()
+  })
 })

--- a/apps/api/src/boxlite-rest/boxlite-proxy.controller.ts
+++ b/apps/api/src/boxlite-rest/boxlite-proxy.controller.ts
@@ -16,6 +16,7 @@ import {
   UseGuards,
   Logger,
   NotFoundException,
+  BadRequestException,
 } from '@nestjs/common'
 import { ApiTags, ApiBearerAuth, ApiExcludeController } from '@nestjs/swagger'
 import { createProxyMiddleware, fixRequestBody, Options } from 'http-proxy-middleware'
@@ -26,6 +27,7 @@ import { AuthContext } from '../common/decorators/auth-context.decorator'
 import { OrganizationAuthContext } from '../common/interfaces/auth-context.interface'
 import { BoxService } from '../box/services/box.service'
 import { RunnerService } from '../box/services/runner.service'
+import { RESERVED_ENV_MESSAGE, hasReservedEnvInBody } from '../common/utils/reserved-env.util'
 
 // Spec-first surface (openapi/box.openapi.yaml). Must stay out of the product
 // spec: @All() expands to the SEARCH verb, which OpenAPI 3.0 cannot express.
@@ -50,6 +52,9 @@ export class BoxliteProxyController {
     @Res() res: Response,
     @Next() next: NextFunction,
   ) {
+    if (hasReservedEnvInBody(req.body)) {
+      throw new BadRequestException(RESERVED_ENV_MESSAGE)
+    }
     return this.proxyToRunner(authContext, boxId, (runnerBoxId) => `/v1/boxes/${runnerBoxId}/exec`, req, res, next)
   }
 

--- a/apps/api/src/common/utils/reserved-env.util.spec.ts
+++ b/apps/api/src/common/utils/reserved-env.util.spec.ts
@@ -1,0 +1,15 @@
+import { RESERVED_ENV_MESSAGE, hasReservedEnv, hasReservedEnvInBody } from './reserved-env.util'
+
+describe('reserved env validation', () => {
+  it('detects BOXLITE_EXECUTOR in create or exec env payloads', () => {
+    expect(hasReservedEnv({ BOXLITE_EXECUTOR: 'guest' })).toBe(true)
+    expect(hasReservedEnvInBody({ env: { BOXLITE_EXECUTOR: 'guest' } })).toBe(true)
+  })
+
+  it('allows ordinary env payloads and malformed env shapes', () => {
+    expect(hasReservedEnv({ NODE_ENV: 'production' })).toBe(false)
+    expect(hasReservedEnvInBody({ env: { NODE_ENV: 'production' } })).toBe(false)
+    expect(hasReservedEnvInBody({ env: ['BOXLITE_EXECUTOR=guest'] })).toBe(false)
+    expect(RESERVED_ENV_MESSAGE).toContain('BOXLITE_EXECUTOR')
+  })
+})

--- a/apps/api/src/common/utils/reserved-env.util.ts
+++ b/apps/api/src/common/utils/reserved-env.util.ts
@@ -1,0 +1,17 @@
+const RESERVED_ENV_VARS = new Set(['BOXLITE_EXECUTOR'])
+
+export const RESERVED_ENV_MESSAGE = 'BOXLITE_EXECUTOR is reserved and cannot be set by user requests'
+
+export function hasReservedEnv(env: unknown): boolean {
+  if (!env || typeof env !== 'object' || Array.isArray(env)) {
+    return false
+  }
+  return Object.keys(env).some((key) => RESERVED_ENV_VARS.has(key))
+}
+
+export function hasReservedEnvInBody(body: unknown): boolean {
+  if (!body || typeof body !== 'object') {
+    return false
+  }
+  return hasReservedEnv((body as { env?: unknown }).env)
+}

--- a/apps/runner/pkg/api/controllers/box.go
+++ b/apps/runner/pkg/api/controllers/box.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	"github.com/boxlite-ai/runner/pkg/api/dto"
+	"github.com/boxlite-ai/runner/pkg/boxlite"
 	"github.com/boxlite-ai/runner/pkg/common"
 	"github.com/boxlite-ai/runner/pkg/models/enums"
 	"github.com/boxlite-ai/runner/pkg/runner"
@@ -37,6 +38,10 @@ func Create(ctx *gin.Context) {
 	err := ctx.ShouldBindJSON(&createBoxDto)
 	if err != nil {
 		ctx.Error(common_errors.NewInvalidBodyRequestError(err))
+		return
+	}
+	if err := boxlite.ValidateReservedEnv(createBoxDto.Env); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 
@@ -381,6 +386,10 @@ func Recover(ctx *gin.Context) {
 	err := ctx.ShouldBindJSON(&recoverDto)
 	if err != nil {
 		ctx.Error(common_errors.NewInvalidBodyRequestError(err))
+		return
+	}
+	if err := boxlite.ValidateReservedEnv(recoverDto.Env); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/apps/runner/pkg/api/controllers/boxlite_exec.go
+++ b/apps/runner/pkg/api/controllers/boxlite_exec.go
@@ -37,6 +37,16 @@ type ResizeRequest struct {
 }
 
 func BoxliteExec(ctx *gin.Context) {
+	var req ExecRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("invalid request: %s", err)})
+		return
+	}
+	if err := boxlite.ValidateReservedEnv(req.Env); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
 	r, err := runner.GetInstance(nil)
 	if err != nil {
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
@@ -44,12 +54,6 @@ func BoxliteExec(ctx *gin.Context) {
 	}
 
 	boxId := ctx.Param("boxId")
-
-	var req ExecRequest
-	if err := ctx.ShouldBindJSON(&req); err != nil {
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("invalid request: %s", err)})
-		return
-	}
 
 	bx, err := r.Boxlite.GetBox(ctx.Request.Context(), boxId)
 	if err != nil {

--- a/apps/runner/pkg/api/controllers/boxlite_exec_test.go
+++ b/apps/runner/pkg/api/controllers/boxlite_exec_test.go
@@ -87,6 +87,51 @@ func seedManagedExecForBox(mgr *boxlite.ExecManager, id, boxID string, handle bo
 	return exec
 }
 
+func TestBoxliteExecRejectsReservedExecutorEnv(t *testing.T) {
+	w := runHandler(http.MethodPost,
+		"/v1/boxes/:boxId/exec",
+		"/v1/boxes/box/exec",
+		strings.NewReader(`{"command":"sh","env":{"BOXLITE_EXECUTOR":"guest"}}`),
+		BoxliteExec)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "BOXLITE_EXECUTOR is reserved") {
+		t.Fatalf("expected reserved env message, got body=%s", w.Body.String())
+	}
+}
+
+func TestCreateRejectsReservedExecutorEnv(t *testing.T) {
+	w := runHandler(http.MethodPost,
+		"/v1/boxes",
+		"/v1/boxes",
+		strings.NewReader(`{"id":"box","image":"boxlite/base","osUser":"boxlite","cpuQuota":1,"memoryQuota":1,"storageQuota":1,"env":{"BOXLITE_EXECUTOR":"guest"}}`),
+		Create)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "BOXLITE_EXECUTOR is reserved") {
+		t.Fatalf("expected reserved env message, got body=%s", w.Body.String())
+	}
+}
+
+func TestRecoverRejectsReservedExecutorEnv(t *testing.T) {
+	w := runHandler(http.MethodPost,
+		"/v1/boxes/:boxId/recover",
+		"/v1/boxes/box/recover",
+		strings.NewReader(`{"osUser":"boxlite","cpuQuota":1,"memoryQuota":1,"storageQuota":1,"errorReason":"boom","env":{"BOXLITE_EXECUTOR":"guest"}}`),
+		Recover)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "BOXLITE_EXECUTOR is reserved") {
+		t.Fatalf("expected reserved env message, got body=%s", w.Body.String())
+	}
+}
+
 // Phase 2.1: GET /executions/{id} reports running, then exited+exit_code
 // after Done fires, with no other state surgery.
 func TestBoxliteGetExecutionReturnsRunningThenExited(t *testing.T) {

--- a/apps/runner/pkg/boxlite/env.go
+++ b/apps/runner/pkg/boxlite/env.go
@@ -1,0 +1,12 @@
+package boxlite
+
+import "fmt"
+
+const ReservedExecutorEnv = "BOXLITE_EXECUTOR"
+
+func ValidateReservedEnv(env map[string]string) error {
+	if _, ok := env[ReservedExecutorEnv]; ok {
+		return fmt.Errorf("%s is reserved and cannot be set by user requests", ReservedExecutorEnv)
+	}
+	return nil
+}

--- a/apps/runner/pkg/boxlite/reserved_env_integration_test.go
+++ b/apps/runner/pkg/boxlite/reserved_env_integration_test.go
@@ -1,0 +1,140 @@
+//go:build boxlite_dev
+
+package boxlite
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+
+	sdkboxlite "github.com/boxlite-ai/boxlite/sdks/go"
+	"github.com/boxlite-ai/runner/cmd/runner/config"
+	"github.com/boxlite-ai/runner/pkg/api/dto"
+)
+
+func newIntegrationClient(t *testing.T) *Client {
+	t.Helper()
+
+	homeDir, err := os.MkdirTemp("/tmp", "boxlite-runner-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.RemoveAll(homeDir)
+	})
+
+	t.Setenv("BOXLITE_API_URL", "http://127.0.0.1")
+	t.Setenv("BOXLITE_RUNNER_TOKEN", "test-token")
+	t.Setenv("ENVIRONMENT", "development")
+	if _, err := config.GetConfig(); err != nil {
+		t.Fatalf("GetConfig: %v", err)
+	}
+
+	client, err := NewClient(context.Background(), ClientConfig{
+		HomeDir: homeDir,
+		Logger:  slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn})),
+	})
+	if err != nil {
+		var boxErr *sdkboxlite.Error
+		if errors.As(err, &boxErr) && (boxErr.Code == sdkboxlite.ErrUnsupported || boxErr.Code == sdkboxlite.ErrUnsupportedEngine) {
+			t.Skipf("runtime not available: %v", err)
+		}
+		t.Fatalf("NewClient: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = client.Close()
+	})
+	return client
+}
+
+func TestIntegrationReservedExecutorEnvPolicyWithRealVM(t *testing.T) {
+	ctx := context.Background()
+	client := newIntegrationClient(t)
+
+	const boxID = "reserved-env-real-vm"
+	_, _, err := client.Create(ctx, dto.CreateBoxDTO{
+		Id:           boxID,
+		Image:        "alpine:latest",
+		OsUser:       "boxlite",
+		CpuQuota:     1,
+		MemoryQuota:  1,
+		StorageQuota: 1,
+		Env: map[string]string{
+			ReservedExecutorEnv: "guest",
+			"BOXLITE_TEST_KEY":  "from-create",
+		},
+	})
+	if err != nil {
+		var boxErr *sdkboxlite.Error
+		if errors.As(err, &boxErr) && (boxErr.Code == sdkboxlite.ErrStorage || boxErr.Code == sdkboxlite.ErrImage || boxErr.Code == sdkboxlite.ErrNetwork) {
+			t.Skipf("infrastructure prerequisite unavailable (code=%d): %v", boxErr.Code, err)
+		}
+		t.Fatalf("Create normal VM: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = client.Destroy(ctx, boxID)
+	})
+
+	var out bytes.Buffer
+	exec, err := client.StartExecution(ctx, boxID, "sh", []string{"-c", "printenv BOXLITE_EXECUTOR && printenv BOXLITE_TEST_KEY"}, &out, &out, false)
+	if err != nil {
+		t.Fatalf("StartExecution: %v", err)
+	}
+	if _, err := exec.Wait(ctx); err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected executor and create env lines, got %q", out.String())
+	}
+	if !strings.HasPrefix(lines[0], "container=") {
+		t.Fatalf("default exec should use container executor, got %q", lines[0])
+	}
+	if lines[1] != "from-create" {
+		t.Fatalf("ordinary create env did not reach VM: got %q", lines[1])
+	}
+
+	bx, err := client.GetBox(ctx, boxID)
+	if err != nil {
+		t.Fatalf("GetBox: %v", err)
+	}
+
+	manager := NewExecManager()
+	t.Cleanup(manager.Stop)
+	localExecID, err := manager.Start(ctx, bx, boxID, StartOptions{
+		Command: "sh",
+		Args:    []string{"-c", "printenv BOXLITE_EXECUTOR"},
+		Env: map[string]string{
+			ReservedExecutorEnv: "guest",
+		},
+	})
+	if err != nil {
+		if strings.Contains(err.Error(), "BOXLITE_EXECUTOR is reserved") {
+			t.Fatalf("local admin executor env should not be rejected: %v", err)
+		}
+		t.Fatalf("Start local admin exec: %v", err)
+	}
+
+	localExec, ok := manager.Get(localExecID)
+	if !ok {
+		t.Fatalf("local exec %s was not registered", localExecID)
+	}
+	<-localExec.Done
+	if localExec.Err != nil {
+		t.Fatalf("local admin exec wait: %v", localExec.Err)
+	}
+	stdout, _, cancel := localExec.Subscribe(4)
+	defer cancel()
+	var localOut bytes.Buffer
+	for chunk := range stdout.Chan() {
+		localOut.Write(chunk)
+	}
+	if strings.TrimSpace(localOut.String()) != "guest" {
+		t.Fatalf("local admin executor env did not reach execution: got %q", localOut.String())
+	}
+}

--- a/apps/runner/pkg/runner/v2/executor/box.go
+++ b/apps/runner/pkg/runner/v2/executor/box.go
@@ -11,6 +11,7 @@ import (
 
 	apiclient "github.com/boxlite-ai/boxlite/libs/api-client-go"
 	"github.com/boxlite-ai/runner/pkg/api/dto"
+	runnerboxlite "github.com/boxlite-ai/runner/pkg/boxlite"
 	"github.com/boxlite-ai/runner/pkg/common"
 )
 
@@ -19,6 +20,9 @@ func (e *Executor) createBox(ctx context.Context, job *apiclient.Job) (any, erro
 	err := e.parsePayload(job.Payload, &createBoxDto)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal payload: %w", err)
+	}
+	if err := runnerboxlite.ValidateReservedEnv(createBoxDto.Env); err != nil {
+		return nil, common.FormatRecoverableError(err)
 	}
 
 	_, daemonVersion, err := e.backend.Create(ctx, createBoxDto)
@@ -92,6 +96,9 @@ func (e *Executor) recoverBox(ctx context.Context, job *apiclient.Job) (any, err
 	err := e.parsePayload(job.Payload, &recoverBoxDto)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal payload: %w", err)
+	}
+	if err := runnerboxlite.ValidateReservedEnv(recoverBoxDto.Env); err != nil {
+		return nil, common.FormatRecoverableError(err)
 	}
 
 	err = e.backend.RecoverBox(ctx, job.ResourceId, recoverBoxDto)

--- a/apps/runner/pkg/runner/v2/executor/box_reserved_env_test.go
+++ b/apps/runner/pkg/runner/v2/executor/box_reserved_env_test.go
@@ -1,0 +1,118 @@
+package executor
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	apiclient "github.com/boxlite-ai/boxlite/libs/api-client-go"
+	"github.com/boxlite-ai/runner/pkg/api/dto"
+	"github.com/boxlite-ai/runner/pkg/models/enums"
+)
+
+type reservedEnvBackend struct {
+	createCalls  int
+	recoverCalls int
+}
+
+func (b *reservedEnvBackend) Create(context.Context, dto.CreateBoxDTO) (string, string, error) {
+	b.createCalls++
+	return "", "", errors.New("Create should not be called")
+}
+
+func (b *reservedEnvBackend) Start(context.Context, string, *string, map[string]string) (string, error) {
+	return "", nil
+}
+
+func (b *reservedEnvBackend) Stop(context.Context, string, bool) error {
+	return nil
+}
+
+func (b *reservedEnvBackend) Destroy(context.Context, string) error {
+	return nil
+}
+
+func (b *reservedEnvBackend) Resize(context.Context, string, dto.ResizeBoxDTO) error {
+	return nil
+}
+
+func (b *reservedEnvBackend) RecoverBox(context.Context, string, dto.RecoverBoxDTO) error {
+	b.recoverCalls++
+	return errors.New("RecoverBox should not be called")
+}
+
+func (b *reservedEnvBackend) UpdateNetworkSettings(context.Context, string, dto.UpdateNetworkSettingsDTO) error {
+	return nil
+}
+
+func (b *reservedEnvBackend) GetBoxState(context.Context, string) (enums.BoxState, error) {
+	return enums.BoxStateStarted, nil
+}
+
+func (b *reservedEnvBackend) Ping(context.Context) error {
+	return nil
+}
+
+func TestCreateBoxRejectsReservedExecutorEnvBeforeBackend(t *testing.T) {
+	payload := mustJSON(t, dto.CreateBoxDTO{
+		Id:           "box",
+		Image:        "boxlite/base",
+		OsUser:       "boxlite",
+		CpuQuota:     1,
+		MemoryQuota:  1,
+		StorageQuota: 1,
+		Env: map[string]string{
+			"BOXLITE_EXECUTOR": "guest",
+		},
+	})
+	backend := &reservedEnvBackend{}
+	executor := &Executor{backend: backend}
+	job := apiclient.NewJob("job-create", apiclient.JOBTYPE_CREATE_BOX, apiclient.JOBSTATUS_IN_PROGRESS, "box", "box", "now")
+	job.SetPayload(payload)
+
+	_, err := executor.createBox(context.Background(), job)
+
+	if err == nil || !strings.Contains(err.Error(), "BOXLITE_EXECUTOR is reserved") {
+		t.Fatalf("expected reserved env error, got %v", err)
+	}
+	if backend.createCalls != 0 {
+		t.Fatalf("backend Create called %d times, want 0", backend.createCalls)
+	}
+}
+
+func TestRecoverBoxRejectsReservedExecutorEnvBeforeBackend(t *testing.T) {
+	payload := mustJSON(t, dto.RecoverBoxDTO{
+		OsUser:       "boxlite",
+		CpuQuota:     1,
+		MemoryQuota:  1,
+		StorageQuota: 1,
+		ErrorReason:  "boom",
+		Env: map[string]string{
+			"BOXLITE_EXECUTOR": "guest",
+		},
+	})
+	backend := &reservedEnvBackend{}
+	executor := &Executor{backend: backend}
+	job := apiclient.NewJob("job-recover", apiclient.JOBTYPE_RECOVER_BOX, apiclient.JOBSTATUS_IN_PROGRESS, "box", "box", "now")
+	job.SetPayload(payload)
+
+	_, err := executor.recoverBox(context.Background(), job)
+
+	if err == nil || !strings.Contains(err.Error(), "BOXLITE_EXECUTOR is reserved") {
+		t.Fatalf("expected reserved env error, got %v", err)
+	}
+	if backend.recoverCalls != 0 {
+		t.Fatalf("backend RecoverBox called %d times, want 0", backend.recoverCalls)
+	}
+}
+
+func mustJSON(t *testing.T, v any) string {
+	t.Helper()
+	payload, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	return string(payload)
+}

--- a/src/boxlite/src/rest/types.rs
+++ b/src/boxlite/src/rest/types.rs
@@ -557,6 +557,49 @@ mod tests {
     }
 
     #[test]
+    fn test_create_box_request_carries_reserved_executor_env_to_rest_boundary() {
+        use crate::runtime::options::{BoxOptions, RootfsSpec};
+
+        let opts = BoxOptions {
+            rootfs: RootfsSpec::Image("alpine:latest".into()),
+            env: vec![("BOXLITE_EXECUTOR".into(), "guest".into())],
+            ..Default::default()
+        };
+
+        let req = CreateBoxRequest::from_options(&opts, Some("test-box".into()));
+
+        assert_eq!(
+            req.env
+                .as_ref()
+                .and_then(|env| env.get("BOXLITE_EXECUTOR"))
+                .map(String::as_str),
+            Some("guest")
+        );
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("\"BOXLITE_EXECUTOR\":\"guest\""));
+    }
+
+    #[test]
+    fn test_exec_request_carries_reserved_executor_env_to_rest_boundary() {
+        let command = crate::BoxCommand::new("sh")
+            .arg("-c")
+            .arg("true")
+            .env("BOXLITE_EXECUTOR", "guest");
+
+        let req = ExecRequest::from_command(&command);
+
+        assert_eq!(
+            req.env
+                .as_ref()
+                .and_then(|env| env.get("BOXLITE_EXECUTOR"))
+                .map(String::as_str),
+            Some("guest")
+        );
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("\"BOXLITE_EXECUTOR\":\"guest\""));
+    }
+
+    #[test]
     fn test_create_box_request_from_options_disabled_network() {
         use crate::runtime::options::{BoxOptions, NetworkSpec, RootfsSpec};
 


### PR DESCRIPTION
BOXLITE_EXECUTOR env setting
reject requests from API create/recover, API REST exec proxy, runner HTTP create/recover/exec, and v2 job payloads
accept requests from runner inside / Go SDK

## Tests
- yarn nx test api --testFile=reserved-env.util.spec.ts --testFile=box.service.box-id.spec.ts --testFile=boxlite-proxy.controller.spec.ts --runInBand
- go test ./pkg/boxlite ./pkg/api/controllers ./pkg/runner/v2/executor
- cargo build -p boxlite-c
- bash scripts/build/build-guest.sh --profile debug --dest-dir /tmp/boxlite-pr682-runtime-debug
- SKIP_GUEST_BUILD=1 bash scripts/build/build-runtime.sh --profile debug --dest-dir /tmp/boxlite-pr682-runtime-debug
- BOXLITE_RUNTIME_DIR=/tmp/boxlite-pr682-runtime-debug go test -tags boxlite_dev ./pkg/boxlite -run TestIntegrationReservedExecutorEnvPolicyWithRealVM -count=1 -v
