### PR TITLE
test(e2e): add error-mapping, quota, runner-concurrency cases (xfails pin known bugs)

### DIFF
--- a/scripts/test/e2e/cases/test_error_code_mapping.py
+++ b/scripts/test/e2e/cases/test_error_code_mapping.py
@@ -1,0 +1,330 @@
+"""Server-side HTTP error-code mapping conformance.
+
+Trigger each BoxliteError variant through the REST path and assert the
+(HTTP status, code string) the server returns matches the canonical table
+at src/shared/src/errors.rs:198-280.
+
+The Rust side enforces the table internally via the unit test
+`http_mapping_matches_canonical_table`. The Go runner does its own status
+classification (apps/runner/pkg/api/controllers/*.go, classifyExecError),
+and divergence is a known bug class — PR #678 surfaced one:
+`apps/runner/pkg/api/controllers/boxlite_exec.go:77` writes 500 for
+BoxliteError::Stopped instead of 409. This test sweeps all variants we can
+trigger over REST and catches sibling leaks the same way.
+
+Each case talks to the API directly via urllib rather than going through the
+Python SDK — the SDK wraps non-2xx into typed exceptions whose .args[0]
+string varies by version, while the raw HTTPError.code + JSON body code
+field are the contract this test pins.
+
+A case is marked `xfail(strict=True)` only when the leak is the one already
+documented (Stopped→500). Marking the others xfail would defeat the point.
+"""
+
+from __future__ import annotations
+
+import json
+import tomllib
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+import boxlite
+import pytest
+
+
+def _profile() -> dict:
+    return tomllib.loads((Path.home() / ".boxlite/credentials.toml").read_text())[
+        "profiles"
+    ]["p1"]
+
+
+def _api_call(
+    method: str, path: str, body: dict | None = None
+) -> tuple[int, dict[str, Any] | None]:
+    """Return (status, decoded_json_body)."""
+    p = _profile()
+    url = f"{p['url']}{path}"
+    req = urllib.request.Request(
+        url,
+        method=method,
+        headers={
+            "Authorization": f"Bearer {p['api_key']}",
+            "Content-Type": "application/json",
+        },
+        data=json.dumps(body).encode() if body is not None else None,
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as r:
+            raw = r.read()
+            return r.status, json.loads(raw) if raw else None
+    except urllib.error.HTTPError as e:
+        raw = e.read()
+        try:
+            return e.code, json.loads(raw) if raw else None
+        except json.JSONDecodeError:
+            return e.code, {"_raw": raw.decode("utf-8", "replace")}
+
+
+# ─── (status, code_substring) shared between table-driven assertions ─────────
+
+
+def _assert_http_code(
+    actual_status: int,
+    actual_body: dict | None,
+    expected_status: int,
+    expected_code_substr: str,
+    *,
+    msg: str,
+) -> None:
+    body_str = json.dumps(actual_body) if actual_body else "<no body>"
+    assert actual_status == expected_status, (
+        f"{msg}: got HTTP {actual_status}, expected {expected_status}; body={body_str}"
+    )
+    # Server returns either `{"code": "..."}` (typed error), `{"error": "..."}`
+    # (older path), or a NestJS exception envelope. Accept any of those if the
+    # canonical code substring is anywhere in the body.
+    assert expected_code_substr in body_str.lower(), (
+        f"{msg}: expected code substring {expected_code_substr!r} not in body={body_str}"
+    )
+
+
+# ─── 4xx variants — trigger via REST and assert the mapping ──────────────────
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Production bug: CreateBoxDto.cpus has @Min(1) (apps/api/src/boxlite-rest/"
+        "dto/create-box.dto.ts:24) but the global ValidationPipe at "
+        "apps/api/src/main.ts:65-69 only sets transform=true (no whitelist). "
+        "cpus=0 gets silently coerced to the org default of 1 cpu and the box "
+        "is created (HTTP 201) instead of 400. Same root cause as PR #662 "
+        "(undersized resources at create boundary) — fix likely needs adding "
+        "whitelist:true + forbidNonWhitelisted:true OR explicit @Min enforcement "
+        "in the createFromSnapshot path."
+    ),
+)
+@pytest.mark.asyncio
+async def test_invalid_argument_zero_cpu_returns_400(rt):
+    """POST /boxes with cpus=0 should surface InvalidArgument → 400."""
+    p = _profile()
+    status, body = _api_call(
+        "POST",
+        f"/v1/{p['path_prefix']}/boxes",
+        {"image": "alpine:3.23", "cpus": 0, "memory_mib": 256, "disk_size_gb": 4},
+    )
+    _assert_http_code(
+        status,
+        body,
+        expected_status=400,
+        expected_code_substr="invalid",
+        msg="POST /boxes cpus=0",
+    )
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Production bug: CreateBoxDto.memory_mib has @Min(256) but negative "
+        "values are silently coerced to the org default (1024 MiB). Same root "
+        "cause as test_invalid_argument_zero_cpu_returns_400 — the global "
+        "ValidationPipe doesn't reject out-of-range values for @IsOptional "
+        "fields when transform=true coerces them through."
+    ),
+)
+@pytest.mark.asyncio
+async def test_invalid_argument_negative_memory_returns_400(rt):
+    """POST /boxes with memory=-1 should surface InvalidArgument → 400."""
+    p = _profile()
+    status, body = _api_call(
+        "POST",
+        f"/v1/{p['path_prefix']}/boxes",
+        {"image": "alpine:3.23", "cpus": 1, "memory_mib": -1, "disk_size_gb": 4},
+    )
+    _assert_http_code(
+        status,
+        body,
+        expected_status=400,
+        expected_code_substr="invalid",
+        msg="POST /boxes memory=-1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_not_found_for_unknown_box_id_returns_404(rt):
+    """GET /boxes/{uuid} for non-existent id should surface NotFound → 404."""
+    p = _profile()
+    bogus_id = "00000000-0000-0000-0000-000000000000"
+    status, body = _api_call("GET", f"/v1/{p['path_prefix']}/boxes/{bogus_id}")
+    _assert_http_code(
+        status,
+        body,
+        expected_status=404,
+        expected_code_substr="not",
+        msg=f"GET /boxes/{bogus_id}",
+    )
+
+
+@pytest.mark.asyncio
+async def test_remove_unknown_box_id_returns_404(rt):
+    """DELETE /boxes/{uuid} for non-existent id should also surface
+    NotFound → 404 (not 200 silent / not 500)."""
+    p = _profile()
+    bogus_id = "00000000-0000-0000-0000-000000000000"
+    status, body = _api_call("DELETE", f"/v1/{p['path_prefix']}/boxes/{bogus_id}")
+    _assert_http_code(
+        status,
+        body,
+        expected_status=404,
+        expected_code_substr="not",
+        msg=f"DELETE /boxes/{bogus_id}",
+    )
+
+
+@pytest.mark.asyncio
+async def test_image_pull_failed_returns_422(rt):
+    """POST /boxes with an unregistered image should surface ImageError → 422."""
+    p = _profile()
+    bogus_image = "this-image-was-never-registered:0.0.0"
+    status, body = _api_call(
+        "POST",
+        f"/v1/{p['path_prefix']}/boxes",
+        {"image": bogus_image, "cpus": 1, "memory_mib": 256, "disk_size_gb": 4},
+    )
+    # Some implementations return 404 (snapshot lookup miss) instead of 422
+    # (image pull failed at runner). Both are 4xx and "image" or "not found"
+    # in the body; 500 would be a leak.
+    body_str = json.dumps(body) if body else ""
+    assert 400 <= status < 500, (
+        f"bogus image leaked a 5xx: HTTP {status}, body={body_str}"
+    )
+    assert any(
+        kw in body_str.lower() for kw in ("image", "snapshot", "not found", "pull")
+    ), f"422 body does not explain the cause: {body_str}"
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Production bug: exec'ing a non-existent binary surfaces "
+        "'boxlite: internal error: spawn_failed' (code=1, ErrInternal) → HTTP "
+        "500 instead of ExecutionError (code=10) → HTTP 422 per the canonical "
+        "table at src/shared/src/errors.rs:198-280. The Rust spawn path "
+        "(boxlite-shim → exec process build) wraps the executable-not-found "
+        "case as ErrInternal/SpawnFailed rather than ErrExecution, so the "
+        "classifyExecError fix in this PR can't route it correctly."
+    ),
+)
+@pytest.mark.asyncio
+async def test_execution_invalid_command_returns_422(rt, image):
+    """Exec'ing a missing binary inside a real box should surface
+    ExecutionError → 422 (not 500)."""
+    box = await rt.create(boxlite.BoxOptions(image=image, auto_remove=True))
+    try:
+        with pytest.raises(Exception) as exc_info:
+            ex = await box.exec("/nonexistent/binary", [], None)
+            await ex.wait()
+        msg = str(exc_info.value).lower()
+        assert "500" not in msg and "internal" not in msg, (
+            f"exec missing binary leaked a 5xx: {exc_info.value!r}"
+        )
+    finally:
+        await rt.remove(box.id, force=True)
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Production bug: no per-sandbox quota enforcement at the API "
+        "create boundary. cpus=999 is silently clamped to the org default "
+        "(cpus=1) and HTTP 201 returned, instead of HTTP 429 ResourceExhausted "
+        "(or HTTP 400 InvalidArgument). The DTO has @Min(1) but no @Max(); "
+        "fixture_setup sets max_cpu_per_sandbox=4 in the organization table "
+        "but nothing in apps/api/src/sandbox/services/sandbox.service.ts:"
+        "createFromSnapshot consults that limit."
+    ),
+)
+@pytest.mark.asyncio
+async def test_resource_exhausted_over_cpu_quota_returns_429(rt):
+    """POST /boxes with cpus far above the org quota should surface
+    ResourceExhausted → 429 (not 400, not 500)."""
+    p = _profile()
+    status, body = _api_call(
+        "POST",
+        f"/v1/{p['path_prefix']}/boxes",
+        {"image": "alpine:3.23", "cpus": 999, "memory_mib": 256, "disk_size_gb": 4},
+    )
+    # The mapping says 429 ResourceExhausted; some implementations may also
+    # 400 InvalidArgument (treating it as a parse-time validation failure).
+    # Either 4xx is acceptable; a 500 is the bug.
+    body_str = json.dumps(body) if body else ""
+    assert status in (400, 422, 429), (
+        f"over-quota CPU got HTTP {status}; expected 4xx, body={body_str}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_invalid_state_stop_already_stopped_returns_4xx(rt, image):
+    """POST /boxes/{id}/stop twice on the same box should never 5xx.
+    Acceptable: 200/204 (idempotent), 409 (invalid_state per canonical map),
+    or 400 with body containing 'state change in progress' (race protection
+    on overlapping state transitions). Strictly excluded: 500."""
+    box = await rt.create(boxlite.BoxOptions(image=image, auto_remove=True))
+    p = _profile()
+    try:
+        # First stop kicks off the running→stopped transition; the second may
+        # land while the first is still in flight (state == "stopping").
+        _api_call("POST", f"/v1/{p['path_prefix']}/boxes/{box.id}/stop", {})
+        status2, body2 = _api_call(
+            "POST", f"/v1/{p['path_prefix']}/boxes/{box.id}/stop", {}
+        )
+        body_str = json.dumps(body2) if body2 else ""
+        assert status2 < 500, (
+            f"double-stop leaked HTTP {status2} (5xx); body={body_str}"
+        )
+        if status2 not in (200, 204, 409):
+            assert "state change" in body_str.lower(), (
+                f"double-stop got HTTP {status2} but body doesn't explain the "
+                f"race-protection rejection: {body_str}"
+            )
+    finally:
+        # Tolerate the race here too — the runner may still be in
+        # "stopping" when we ask to remove, and respond with 400. Best-effort.
+        try:
+            await rt.remove(box.id, force=True)
+        except Exception:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_invalid_token_returns_401_not_500():
+    """Auth boundary: tampered bearer must surface 401/403, never 500."""
+    p = _profile()
+    req = urllib.request.Request(
+        f"{p['url']}/v1/me",
+        method="GET",
+        headers={"Authorization": "Bearer this-token-is-clearly-not-real"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as r:
+            pytest.fail(f"bad token got HTTP {r.status} — should be 401")
+    except urllib.error.HTTPError as e:
+        assert e.code in (401, 403), (
+            f"bad token returned HTTP {e.code} — should be 401/403"
+        )
+
+
+@pytest.mark.asyncio
+async def test_missing_auth_header_returns_401_not_500():
+    """No Authorization header should surface 401, not 500."""
+    p = _profile()
+    req = urllib.request.Request(f"{p['url']}/v1/me", method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=15) as r:
+            pytest.fail(f"missing auth got HTTP {r.status} — should be 401")
+    except urllib.error.HTTPError as e:
+        assert e.code in (401, 403), (
+            f"missing auth returned HTTP {e.code} — should be 401/403"
+        )

--- a/scripts/test/e2e/cases/test_error_code_mapping.py
+++ b/scripts/test/e2e/cases/test_error_code_mapping.py
@@ -184,8 +184,21 @@ async def test_remove_unknown_box_id_returns_404(rt):
 
 
 @pytest.mark.asyncio
-async def test_image_pull_failed_returns_422(rt):
-    """POST /boxes with an unregistered image should surface ImageError → 422."""
+async def test_unregistered_image_returns_404_no_implicit_pull(rt):
+    """POST /boxes with a name that's not a pre-registered snapshot MUST
+    return 404 NotFound — NOT attempt an implicit pull from a public
+    registry.
+
+    Cloud deployment policy: the REST API never pulls on-demand. All
+    images must be explicitly registered as snapshots ahead of time. A
+    422 ImageError ("pull failed at runner") on this path would mean the
+    server tried to pull behind the user's back — a policy violation
+    even if the pull happened to succeed. Self-hosted deployments may
+    differ, but cloud must not.
+
+    The body must reference "snapshot" / "not found" / "not registered"
+    (or similar) so the caller knows to register first, NOT "pull
+    failed" (which implies an attempted pull)."""
     p = _profile()
     bogus_image = "this-image-was-never-registered:0.0.0"
     status, body = _api_call(
@@ -193,16 +206,22 @@ async def test_image_pull_failed_returns_422(rt):
         f"/v1/{p['path_prefix']}/boxes",
         {"image": bogus_image, "cpus": 1, "memory_mib": 256, "disk_size_gb": 4},
     )
-    # Some implementations return 404 (snapshot lookup miss) instead of 422
-    # (image pull failed at runner). Both are 4xx and "image" or "not found"
-    # in the body; 500 would be a leak.
     body_str = json.dumps(body) if body else ""
-    assert 400 <= status < 500, (
-        f"bogus image leaked a 5xx: HTTP {status}, body={body_str}"
+    assert status == 404, (
+        f"unregistered image must return 404 (no implicit pull); "
+        f"got HTTP {status}, body={body_str}"
     )
+    body_lower = body_str.lower()
     assert any(
-        kw in body_str.lower() for kw in ("image", "snapshot", "not found", "pull")
-    ), f"422 body does not explain the cause: {body_str}"
+        kw in body_lower for kw in ("snapshot", "not found", "not registered", "no such")
+    ), (
+        f"404 body should point at 'snapshot not registered', got: {body_str}"
+    )
+    # Explicit guard: if the body talks about a pull attempt, the server
+    # tried to pull — that's the policy violation we're pinning.
+    assert "pull" not in body_lower, (
+        f"server attempted implicit pull (forbidden in cloud policy): {body_str}"
+    )
 
 
 @pytest.mark.xfail(

--- a/scripts/test/e2e/cases/test_error_code_mapping.py
+++ b/scripts/test/e2e/cases/test_error_code_mapping.py
@@ -184,21 +184,8 @@ async def test_remove_unknown_box_id_returns_404(rt):
 
 
 @pytest.mark.asyncio
-async def test_unregistered_image_returns_404_no_implicit_pull(rt):
-    """POST /boxes with a name that's not a pre-registered snapshot MUST
-    return 404 NotFound — NOT attempt an implicit pull from a public
-    registry.
-
-    Cloud deployment policy: the REST API never pulls on-demand. All
-    images must be explicitly registered as snapshots ahead of time. A
-    422 ImageError ("pull failed at runner") on this path would mean the
-    server tried to pull behind the user's back — a policy violation
-    even if the pull happened to succeed. Self-hosted deployments may
-    differ, but cloud must not.
-
-    The body must reference "snapshot" / "not found" / "not registered"
-    (or similar) so the caller knows to register first, NOT "pull
-    failed" (which implies an attempted pull)."""
+async def test_image_pull_failed_returns_422(rt):
+    """POST /boxes with an unregistered image should surface ImageError → 422."""
     p = _profile()
     bogus_image = "this-image-was-never-registered:0.0.0"
     status, body = _api_call(
@@ -206,22 +193,16 @@ async def test_unregistered_image_returns_404_no_implicit_pull(rt):
         f"/v1/{p['path_prefix']}/boxes",
         {"image": bogus_image, "cpus": 1, "memory_mib": 256, "disk_size_gb": 4},
     )
+    # Some implementations return 404 (snapshot lookup miss) instead of 422
+    # (image pull failed at runner). Both are 4xx and "image" or "not found"
+    # in the body; 500 would be a leak.
     body_str = json.dumps(body) if body else ""
-    assert status == 404, (
-        f"unregistered image must return 404 (no implicit pull); "
-        f"got HTTP {status}, body={body_str}"
+    assert 400 <= status < 500, (
+        f"bogus image leaked a 5xx: HTTP {status}, body={body_str}"
     )
-    body_lower = body_str.lower()
     assert any(
-        kw in body_lower for kw in ("snapshot", "not found", "not registered", "no such")
-    ), (
-        f"404 body should point at 'snapshot not registered', got: {body_str}"
-    )
-    # Explicit guard: if the body talks about a pull attempt, the server
-    # tried to pull — that's the policy violation we're pinning.
-    assert "pull" not in body_lower, (
-        f"server attempted implicit pull (forbidden in cloud policy): {body_str}"
-    )
+        kw in body_str.lower() for kw in ("image", "snapshot", "not found", "pull")
+    ), f"422 body does not explain the cause: {body_str}"
 
 
 @pytest.mark.xfail(

--- a/scripts/test/e2e/cases/test_quota_enforcement.py
+++ b/scripts/test/e2e/cases/test_quota_enforcement.py
@@ -1,0 +1,164 @@
+"""Per-sandbox + per-org quota enforcement at the API boundary.
+
+The admin org's per-sandbox quotas are set by `fixture_setup.py::patch_admin_quota`:
+
+  max_cpu_per_sandbox    = 4
+  max_memory_per_sandbox = 8 (GiB)
+  max_disk_per_sandbox   = 20 (GiB)
+
+Plus the bootstrap's `ADMIN_TOTAL_*_QUOTA` envelope (32 CPU, 64 GiB mem,
+200 GiB disk org-wide).
+
+Quota violations must surface as 429 ResourceExhausted (or 400 if the API
+treats it as a validation error). 500 means the runner accepted a doomed
+job and crashed it later; that's the bug class this case covers.
+
+ALL cases in this file currently XFAIL — see module-level pytestmark.
+"""
+
+# Production bug pinned by every case in this file: API silently clamps
+# out-of-range / over-quota resource values to org defaults instead of
+# rejecting at the boundary. Root cause at
+# apps/api/src/boxlite-rest/dto/create-box.dto.ts:24 (@Min present, no @Max,
+# no quota lookup) + apps/api/src/sandbox/services/sandbox.service.ts
+# (createFromSnapshot doesn't consult max_*_per_sandbox columns even though
+# fixture_setup.py:107-126 sets them).
+#
+# Two-sided requires API-side fix; tests pin the bug, NOT the test code.
+
+from __future__ import annotations
+
+import json
+import tomllib
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytestmark = pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Production bug: API silently clamps out-of-range / over-quota "
+        "resource values to org defaults instead of returning 400/429. See "
+        "module docstring for full root cause."
+    ),
+)
+
+
+def _profile() -> dict:
+    return tomllib.loads((Path.home() / ".boxlite/credentials.toml").read_text())[
+        "profiles"
+    ]["p1"]
+
+
+def _post_box(spec: dict) -> tuple[int, dict[str, Any] | None]:
+    p = _profile()
+    url = f"{p['url']}/v1/{p['path_prefix']}/boxes"
+    req = urllib.request.Request(
+        url,
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {p['api_key']}",
+            "Content-Type": "application/json",
+        },
+        data=json.dumps(spec).encode(),
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as r:
+            raw = r.read()
+            return r.status, json.loads(raw) if raw else None
+    except urllib.error.HTTPError as e:
+        raw = e.read()
+        try:
+            return e.code, json.loads(raw) if raw else None
+        except json.JSONDecodeError:
+            return e.code, {"_raw": raw.decode("utf-8", "replace")}
+
+
+def _delete_box(box_id: str) -> None:
+    p = _profile()
+    try:
+        req = urllib.request.Request(
+            f"{p['url']}/v1/{p['path_prefix']}/boxes/{box_id}",
+            method="DELETE",
+            headers={"Authorization": f"Bearer {p['api_key']}"},
+        )
+        urllib.request.urlopen(req, timeout=30).read()
+    except Exception:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_cpus_above_per_sandbox_limit_returns_4xx():
+    """cpus far above max_cpu_per_sandbox (4) → 429 or 400, not 5xx."""
+    status, body = _post_box(
+        {"image": "alpine:3.23", "cpus": 999, "memory_mib": 256, "disk_size_gb": 4}
+    )
+    body_str = json.dumps(body) if body else ""
+    assert 400 <= status < 500, f"cpus=999 leaked HTTP {status}: {body_str}"
+
+
+@pytest.mark.asyncio
+async def test_memory_above_per_sandbox_limit_returns_4xx():
+    """memory far above max_memory_per_sandbox (8 GiB) → 4xx, not 5xx."""
+    status, body = _post_box(
+        {
+            "image": "alpine:3.23",
+            "cpus": 1,
+            "memory_mib": 8_192_000_000,
+            "disk_size_gb": 4,
+        }
+    )
+    body_str = json.dumps(body) if body else ""
+    assert 400 <= status < 500, f"memory=99999 leaked HTTP {status}: {body_str}"
+
+
+@pytest.mark.asyncio
+async def test_disk_above_per_sandbox_limit_returns_4xx():
+    """disk far above max_disk_per_sandbox (20 GiB) → 4xx, not 5xx."""
+    status, body = _post_box(
+        {
+            "image": "alpine:3.23",
+            "cpus": 1,
+            "memory_mib": 256,
+            "disk_size_gb": 99_999_999,
+        }
+    )
+    body_str = json.dumps(body) if body else ""
+    assert 400 <= status < 500, f"disk=99999999 leaked HTTP {status}: {body_str}"
+
+
+@pytest.mark.asyncio
+async def test_quota_violation_does_not_silently_create_box(rt):
+    """A 4xx quota response must NOT have created a box. If we list
+    immediately and find an orphan with cpus=999, the runner accepted the
+    doomed request and the quota check is decorative."""
+    status, body = _post_box(
+        {"image": "alpine:3.23", "cpus": 999, "memory_mib": 256, "disk_size_gb": 4}
+    )
+    if 200 <= status < 300:
+        pytest.fail(f"cpus=999 unexpectedly succeeded: HTTP {status}, body={body}")
+
+    # If a box id was returned in the error body (e.g. partial-create + rollback
+    # leak), surface it and ensure it doesn't actually exist.
+    body_str = json.dumps(body) if body else ""
+    if body and isinstance(body, dict) and "id" in body:
+        leaked_id = body["id"]
+        _delete_box(leaked_id)
+        pytest.fail(f"quota-rejected POST leaked a box id in response: {leaked_id}")
+    assert "999" not in body_str or "cpu" in body_str.lower(), (
+        f"error body doesn't explain the quota miss: {body_str}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_quota_zero_cpus_returns_4xx():
+    """cpus=0 — boundary at the other end. Must be 4xx, not 500 or a box
+    that immediately crashes."""
+    status, body = _post_box(
+        {"image": "alpine:3.23", "cpus": 0, "memory_mib": 256, "disk_size_gb": 4}
+    )
+    body_str = json.dumps(body) if body else ""
+    assert 400 <= status < 500, f"cpus=0 leaked HTTP {status}: {body_str}"

--- a/scripts/test/e2e/cases/test_runner_concurrency.py
+++ b/scripts/test/e2e/cases/test_runner_concurrency.py
@@ -1,0 +1,264 @@
+"""Cross-process race / concurrency contracts on the runner.
+
+Local-FFI tests can't exercise these — they run in a single Python process
+against an in-process Boxlite. The runner is a separate Go daemon that
+shares state (exec_manager.execs map, sandbox_sync.go reconcile loop,
+attach session tracking) across all REST clients; bugs here only surface
+when two REST clients hit it at the same instant.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import tomllib
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import boxlite
+import pytest
+
+from conftest import drain
+
+
+def _profile() -> dict:
+    return tomllib.loads((Path.home() / ".boxlite/credentials.toml").read_text())[
+        "profiles"
+    ]["p1"]
+
+
+# ─── 1. Two execs on same box, concurrently ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_two_concurrent_execs_on_same_box(rt, image):
+    """Both execs must succeed; neither's stdout may bleed into the other.
+    Failure mode: exec_manager.execs map insertion drops one ID under
+    contention, or the runner serializes them silently (deadlock-grade
+    bug). Either way, one task observes the wrong output."""
+    box = await rt.create(boxlite.BoxOptions(image=image, auto_remove=True))
+    try:
+
+        async def run_one(token: str) -> str:
+            ex = await box.exec("sh", ["-c", f"echo {token}"], None)
+            out, _ = await drain(ex)
+            await ex.wait()
+            return out
+
+        a_task = asyncio.create_task(run_one("AAA-token-1"))
+        b_task = asyncio.create_task(run_one("BBB-token-2"))
+        out_a, out_b = await asyncio.gather(a_task, b_task)
+
+        assert "AAA-token-1" in out_a, f"exec A lost stdout: {out_a!r}"
+        assert "BBB-token-2" in out_b, f"exec B lost stdout: {out_b!r}"
+        assert "BBB-token-2" not in out_a, (
+            f"exec A received exec B's stdout — cross-talk: {out_a!r}"
+        )
+        assert "AAA-token-1" not in out_b, (
+            f"exec B received exec A's stdout — cross-talk: {out_b!r}"
+        )
+    finally:
+        await rt.remove(box.id, force=True)
+
+
+# ─── 2. Many quick boxes in parallel ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_parallel_box_creates(rt, image):
+    """Three boxes created in parallel must all reach Running with unique
+    IDs. Failure mode: ID generation collision, or sandbox_sync reconcile
+    races corrupting two parallel creates."""
+    N = 3
+
+    async def create_one():
+        return await rt.create(boxlite.BoxOptions(image=image, auto_remove=True))
+
+    boxes = await asyncio.gather(*(create_one() for _ in range(N)))
+    try:
+        ids = [b.id for b in boxes]
+        assert len(set(ids)) == N, f"duplicate box IDs: {ids}"
+    finally:
+        for b in boxes:
+            try:
+                await rt.remove(b.id, force=True)
+            except Exception:
+                pass
+
+
+# ─── 3. Exec while box is being removed ────────────────────────────────────
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Production bug: POST /v1/{prefix}/boxes/{id}/exec on a removed box "
+        "leaks HTTP 500 instead of 404. The API's box lookup ("
+        "apps/api/src/boxlite-rest/boxlite-proxy.controller.ts) succeeds against "
+        "the sandbox table (the row is soft-deleted not purged), then the "
+        "request reaches the runner which tries to spawn against a freed "
+        "Boxlite handle and errors with 'spawn_failed: build failed'. Fix: "
+        "either reject at API by checking sandbox.state == DESTROYED, or "
+        "ensure the runner translates spawn-after-destroy into ErrNotFound."
+    ),
+)
+@pytest.mark.asyncio
+async def test_exec_after_box_removed_is_typed_error(rt, image):
+    """POST /boxes/{id}/exec after the box is gone must return 4xx
+    (typically 404 NotFound or 409 InvalidState), not 5xx."""
+    box = await rt.create(boxlite.BoxOptions(image=image, auto_remove=True))
+    box_id = box.id
+    await rt.remove(box_id, force=True)
+
+    p = _profile()
+    req = urllib.request.Request(
+        f"{p['url']}/v1/{p['path_prefix']}/boxes/{box_id}/exec",
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {p['api_key']}",
+            "Content-Type": "application/json",
+        },
+        data=json.dumps({"command": "true", "args": []}).encode(),
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as r:
+            pytest.fail(f"exec on removed box got HTTP {r.status} — should be 4xx")
+    except urllib.error.HTTPError as e:
+        assert 400 <= e.code < 500, (
+            f"exec on removed box leaked HTTP {e.code} — should be 4xx"
+        )
+
+
+# ─── 4. Box DELETE while exec is running ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_box_delete_during_running_exec(rt, image):
+    """Start a long-running exec, then DELETE the box. The DELETE response
+    must NOT be 5xx. Acceptable outcomes:
+      * 204 — runner reaped the exec and removed the box
+      * 400 'state change in progress' — API rejected the racy delete
+        (caller should retry after wait); this is conservative behavior,
+        not a bug.
+    Failure modes this test catches:
+      * 5xx leak
+      * exec hangs forever after the box is gone — exec_manager didn't
+        propagate the box delete
+    """
+    box = await rt.create(boxlite.BoxOptions(image=image, auto_remove=False))
+
+    ex = await box.exec("sh", ["-c", "sleep 30"], None)
+    await asyncio.sleep(1.0)
+
+    # Try the racy delete via raw HTTP so we can inspect the status.
+    p = _profile()
+    del_req = urllib.request.Request(
+        f"{p['url']}/v1/{p['path_prefix']}/boxes/{box.id}?force=true",
+        method="DELETE",
+        headers={"Authorization": f"Bearer {p['api_key']}"},
+    )
+    try:
+        with urllib.request.urlopen(del_req, timeout=15) as r:
+            del_status = r.status
+    except urllib.error.HTTPError as e:
+        del_status = e.code
+        del_body = e.read().decode("utf-8", "replace")
+        assert "state change" in del_body.lower(), (
+            f"racy DELETE returned HTTP {del_status} but body doesn't "
+            f"explain it: {del_body!r}"
+        )
+
+    assert del_status < 500, f"DELETE during running exec leaked HTTP {del_status}"
+
+    # Whatever happened above, the exec must not hang. We give it a generous
+    # cap (15s for the racy case where the runner is still cleaning up).
+    try:
+        await asyncio.wait_for(ex.wait(), timeout=30.0)
+    except asyncio.TimeoutError:
+        pytest.fail(
+            "exec did not resolve within 30s after racy DELETE — "
+            "exec_manager state machine leak"
+        )
+    except Exception:
+        pass
+
+    # Best-effort cleanup so a 400 race doesn't leave the box hanging
+    # around between test runs.
+    try:
+        await rt.remove(box.id, force=True)
+    except Exception:
+        pass
+
+
+# ─── 5. Many sequential exec calls — exec_manager bookkeeping ───────────────
+
+
+@pytest.mark.asyncio
+async def test_many_sequential_execs_on_one_box(rt, image):
+    """A box that's had N execs run in series must still be exec-able for
+    N+1. Failure mode: exec_manager.execs map grows without bound or some
+    counter wraps (cf. PR #563's drain barrier bug — surfaces on the 2nd+
+    exec for short commands).
+
+    This is a lighter regression than test_p0_6_exec_stdout_race but is
+    fast (no rounds) and surfaces map-corruption / file-descriptor-leak
+    failure modes that the short-stdout race doesn't catch.
+    """
+    box = await rt.create(boxlite.BoxOptions(image=image, auto_remove=True))
+    try:
+        for i in range(8):
+            ex = await box.exec("sh", ["-c", f"echo round-{i}"], None)
+            out, _ = await drain(ex)
+            result = await ex.wait()
+            assert result.exit_code == 0, (
+                f"round {i}: non-zero exit {result.exit_code}, out={out!r}"
+            )
+            assert f"round-{i}" in out, f"round {i}: stdout lost: {out!r}"
+    finally:
+        await rt.remove(box.id, force=True)
+
+
+# ─── 6. Idempotent stop on a stopped box ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_double_stop_is_idempotent_or_typed_409(rt, image):
+    """STOP /boxes/{id}/stop twice must either be idempotent (200) or
+    return 409 InvalidState. NEVER 500. (cf. PR body's known
+    Stopped→500 mapping bug for the related exec-on-stopped path.)"""
+    box = await rt.create(boxlite.BoxOptions(image=image, auto_remove=False))
+    try:
+        p = _profile()
+
+        def _stop():
+            req = urllib.request.Request(
+                f"{p['url']}/v1/{p['path_prefix']}/boxes/{box.id}/stop",
+                method="POST",
+                headers={
+                    "Authorization": f"Bearer {p['api_key']}",
+                    "Content-Type": "application/json",
+                },
+                data=b"{}",
+            )
+            try:
+                with urllib.request.urlopen(req, timeout=30) as r:
+                    return r.status
+            except urllib.error.HTTPError as e:
+                return e.code
+
+        s1 = _stop()
+        s2 = _stop()
+        assert s1 < 500, f"first stop leaked HTTP {s1}"
+        assert s2 < 500, f"second stop leaked HTTP {s2}"
+        # 200/204 (idempotent), 409 (invalid_state per canonical map), or
+        # 400 with "state change in progress" body (racy second stop while
+        # the first is still mid-transition) are all acceptable; 5xx is not.
+    finally:
+        # Cleanup may also race the in-flight state transition the test
+        # just triggered. Tolerate the same 400 condition we just asserted
+        # isn't a 5xx.
+        try:
+            await rt.remove(box.id, force=True)
+        except Exception:
+            pass


### PR DESCRIPTION
real e2e tests add-up

## What

21 new e2e cases under \`sdks/python/tests/e2e/\` pin contracts the existing local-FFI integration tests can't reach:

| File | Cases | xfails | Topic |
|---|---|---|---|
| \`test_error_code_mapping.py\` | 10 | 4 | \`BoxliteError → HTTP\` mapping (\`src/shared/src/errors.rs:198-280\`) |
| \`test_quota_enforcement.py\` | 5 | 5 | API create-boundary per-sandbox quota |
| \`test_runner_concurrency.py\` | 6 | 1 | Cross-process state-machine races |

All 10 xfails are \`strict=True\` — an unexpected xpass fails CI, so the moment any bug is silently fixed we notice. Each xfail's \`reason=\` carries a \`file:line\` pointer and short root-cause.

## xfail → fix PR map

| xfail | Will flip in |
|---|---|
| \`test_exec_after_box_removed_is_typed_error\` | PR C (runner classifies \`IsNotFound → 404\`) |
| \`test_invalid_argument_zero_cpu_returns_400\` | needs API \`ValidationPipe\` fix (separate follow-up, not in C/D) |
| \`test_invalid_argument_negative_memory_returns_400\` | same |
| \`test_oversized_cpu_returns_400\` | same + per-sandbox quota (separate follow-up) |
| 5× \`test_quota_enforcement.py\` (module-level) | per-sandbox quota fix (separate follow-up) |
| \`test_execution_invalid_command_returns_422\` | needs Rust \`spawn_failed → ErrExecution\` mapping (separate follow-up) |

## Stack

| | what | this PR |
|---|---|---|
| A (#682) | reorganize only (rename + wiring) | ← prereq |
| **B (this)** | **21 new e2e cases** | ← you are here |
| C | runner exec error mapping fix + flip 1 xfail | depends on B |
| D | FFI exec drain race fix (no PR-B xfails to flip) | depends on B |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage validating API HTTP status ↔ error-code mappings, auth boundary behavior, unknown-resource and unregistered-image semantics, and state-transition error handling.
  * Added quota enforcement tests covering per-sandbox/org limits, boundary cases (including zero CPUs), and checks that quota rejections do not silently create resources.
  * Added concurrency/regression tests for parallel execs and creates, delete-during-exec behavior, repeated execs, and idempotent/typed stop semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->