### PR TITLE
fix(runner): classify SDK errors at exec boundary (404/409 not 500)

### DIFF
--- a/apps/runner/pkg/api/controllers/boxlite_exec.go
+++ b/apps/runner/pkg/api/controllers/boxlite_exec.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"time"
 
+	sdkboxlite "github.com/boxlite-ai/boxlite/sdks/go"
 	"github.com/boxlite-ai/runner/pkg/boxlite"
 	"github.com/boxlite-ai/runner/pkg/runner"
 	"github.com/gin-gonic/gin"
@@ -74,7 +75,7 @@ func BoxliteExec(ctx *gin.Context) {
 
 	execId, err := execManager.Start(ctx.Request.Context(), bx, boxId, startOpts)
 	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("exec failed: %s", err)})
+		ctx.JSON(classifyExecError(err), gin.H{"error": fmt.Sprintf("exec failed: %s", err)})
 		return
 	}
 
@@ -231,7 +232,16 @@ func classifyExecError(err error) int {
 		return http.StatusConflict
 	case errors.Is(err, boxlite.ErrExecNotTTY):
 		return http.StatusBadRequest
-	default:
-		return http.StatusInternalServerError
 	}
+	// SDK typed errors (sdks/go/errors.go) — the Start() path tunnels
+	// these out of the Rust core when the box was already gone / stopped
+	// before the call landed. The canonical mapping
+	// (src/shared/src/errors.rs:198-280) puts them at 404 / 409 / 409.
+	if sdkboxlite.IsNotFound(err) {
+		return http.StatusNotFound
+	}
+	if sdkboxlite.IsStopped(err) || sdkboxlite.IsInvalidState(err) {
+		return http.StatusConflict
+	}
+	return http.StatusInternalServerError
 }


### PR DESCRIPTION
stopped/removed boxes are not internal error, but bad request

## Bug

\`POST /v1/{prefix}/boxes/{id}/exec\` leaked HTTP 500 when the underlying box was already gone / stopped / in a non-runnable state by the time the runner tried to spawn:

\`\`\`
exec on a removed box   → 500 \"spawn_failed: build failed\"
exec on a stopped box   → 500 (same shape)
exec on box mid-rebuild → 500 (same shape)
\`\`\`

Root cause: \`BoxliteExec\` called \`execManager.Start(...)\` and unconditionally wrapped any non-nil error as 500. The SDK Start path already tunnels typed errors from the Rust core (\`sdks/go/errors.go\`: \`IsNotFound\` / \`IsStopped\` / \`IsInvalidState\`) when the box state changed under the request — they just weren't being read.

## Fix

Extend \`classifyExecError\` to peek for the SDK typed errors and return the canonical mapping from \`src/shared/src/errors.rs:198-280\`:

| SDK error | HTTP |
|---|---|
| \`IsNotFound\` | 404 Not Found |
| \`IsStopped\` | 409 Conflict |
| \`IsInvalidState\` | 409 Conflict |
| (other / no SDK match) | 500 (unchanged) |

Also routes the \`Start()\` error site through \`classifyExecError\` instead of hard-coding 500.

## xfail flipped

Removes the \`@pytest.mark.xfail(strict=True)\` from \`test_exec_after_box_removed_is_typed_error\` (PR-B added it). Under strict=True the case now xpassing would fail CI — removing the marker is what lands it green.

Other related xfails in \`test_error_code_mapping.py\` are **not** addressed here (they need DTO ValidationPipe / per-sandbox quota / Rust spawn_failed reclassification — separate follow-ups).

## Stack

| | what |
|---|---|
| A (#682) | reorganize (rename + wiring) |
| B (#683) | 21 new e2e cases (xfails pin bugs) |
| **C (this)** | **runner exec error mapping fix + flip 1 xfail** |
| D | FFI exec drain race fix |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for execution failures to return more specific HTTP status codes based on the failure type: 404 for not found, 409 for stopped or invalid state conditions, and 500 for other errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->