### PR TITLE
fix(rest): forward exec `user=` field across SDK → API → Runner → C FFI

### DIFF
--- a/apps/api/src/boxlite-rest/dto/exec.dto.ts
+++ b/apps/api/src/boxlite-rest/dto/exec.dto.ts
@@ -26,6 +26,13 @@ export class ExecRequestDto {
   @IsString()
   working_dir?: string
 
+  // User to run the command as (format: <name|uid>[:<group|gid>], same as
+  // `docker exec --user`). Forwarded to the runner unchanged; the runner
+  // resolves user/group against the guest's /etc/passwd before exec.
+  @IsOptional()
+  @IsString()
+  user?: string
+
   @IsOptional()
   @IsBoolean()
   tty?: boolean

--- a/apps/runner/pkg/api/controllers/boxlite_exec.go
+++ b/apps/runner/pkg/api/controllers/boxlite_exec.go
@@ -19,7 +19,11 @@ type ExecRequest struct {
 	Env            map[string]string `json:"env"`
 	TimeoutSeconds *float64          `json:"timeout_seconds"`
 	WorkingDir     *string           `json:"working_dir"`
-	TTY            bool              `json:"tty"`
+	// User to run the command as (format: <name|uid>[:<group|gid>], same
+	// shape as `docker exec --user`). Optional; nil/empty inherits the
+	// container's default user from image config.
+	User *string `json:"user"`
+	TTY  bool   `json:"tty"`
 }
 
 type ExecResponse struct {
@@ -64,6 +68,9 @@ func BoxliteExec(ctx *gin.Context) {
 	}
 	if req.WorkingDir != nil {
 		startOpts.WorkingDir = *req.WorkingDir
+	}
+	if req.User != nil {
+		startOpts.User = *req.User
 	}
 	if req.TimeoutSeconds != nil {
 		// The Rust C-FFI treats `timeout_secs <= 0` as unbounded (see

--- a/apps/runner/pkg/boxlite/exec_manager.go
+++ b/apps/runner/pkg/boxlite/exec_manager.go
@@ -341,8 +341,12 @@ type StartOptions struct {
 	Args       []string
 	Env        map[string]string
 	WorkingDir string
-	Timeout    time.Duration
-	TTY        bool
+	// User is the per-exec uid/gid override forwarded to the guest
+	// (format: <name|uid>[:<group|gid>], same as `docker exec --user`).
+	// Empty inherits the container's default user.
+	User    string
+	Timeout time.Duration
+	TTY     bool
 }
 
 func (m *ExecManager) Start(ctx context.Context, bx *boxlite.Box, boxID string, opts StartOptions) (string, error) {
@@ -375,6 +379,7 @@ func (m *ExecManager) Start(ctx context.Context, bx *boxlite.Box, boxID string, 
 		Stderr:     exec.stderrBus,
 		Env:        opts.Env,
 		WorkingDir: opts.WorkingDir,
+		User:       opts.User,
 		Timeout:    opts.Timeout,
 	})
 	if err != nil {

--- a/scripts/test/e2e/cases/test_exec_user.py
+++ b/scripts/test/e2e/cases/test_exec_user.py
@@ -1,0 +1,68 @@
+"""E2E port of `src/boxlite/tests/exec_user.rs`.
+
+Verifies the `user=` exec override travels SDK → API → Runner → guest:
+
+  - `user="65534"` (nobody on alpine) makes `id -u` return 65534
+  - `user="65534:65534"` sets both uid and gid
+  - an obviously-invalid user name surfaces as a typed client error
+    (not a 5xx)
+
+The Rust FFI suite covers more user-string parsing variants; we keep the
+e2e cost at one box and pick the three cases that most likely break in
+REST/runner DTO wiring.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from conftest import drain
+
+
+@pytest.mark.asyncio
+async def test_exec_user_numeric_uid(box):
+    """Running with `user='65534'` causes `id -u` to report 65534."""
+    ex = await box.exec("id", ["-u"], None, user="65534")
+    out, _ = await drain(ex)
+    rc = await asyncio.wait_for(ex.wait(), timeout=30)
+    assert rc.exit_code == 0, f"`id -u` failed: rc={rc.exit_code}"
+    assert out.strip() == "65534", (
+        f"user= override not propagated: id -u returned {out!r}, expected 65534"
+    )
+
+
+@pytest.mark.asyncio
+async def test_exec_user_uid_gid_pair(box):
+    """`user='65534:65534'` sets both uid and gid. Alpine has user/group
+    `nobody` at 65534/65534, which is what we expect to see back."""
+    ex = await box.exec(
+        "sh", ["-c", "echo $(id -u):$(id -g)"], None, user="65534:65534",
+    )
+    out, _ = await drain(ex)
+    rc = await asyncio.wait_for(ex.wait(), timeout=30)
+    assert rc.exit_code == 0, f"`id` failed: rc={rc.exit_code}"
+    assert out.strip() == "65534:65534", (
+        f"uid:gid pair not propagated: got {out!r}, expected '65534:65534'"
+    )
+
+
+@pytest.mark.asyncio
+async def test_exec_user_invalid_is_typed_error(box):
+    """Asking to run as a user that doesn't exist must surface a typed
+    client error, not a bare 5xx. Catches API/runner mapping regressions
+    where a parser error leaks an Internal Server Error."""
+    with pytest.raises(Exception) as exc_info:
+        ex = await box.exec(
+            "echo", ["x"], None,
+            user="this-user-cannot-possibly-exist-boxlite-e2e",
+        )
+        # If exec dispatched, drain + wait so we see the actual failure
+        # mode rather than an unrelated leak.
+        await drain(ex)
+        await asyncio.wait_for(ex.wait(), timeout=30)
+    msg = str(exc_info.value)
+    assert "500" not in msg and "Internal" not in msg, (
+        f"invalid user= leaked a 5xx: {msg!r}"
+    )

--- a/sdks/go/exec.go
+++ b/sdks/go/exec.go
@@ -65,6 +65,12 @@ type ExecutionOptions struct {
 	// WorkingDir is the directory the process starts in. Empty inherits
 	// the container default.
 	WorkingDir string
+	// User overrides the uid/gid this execution runs as
+	// (format: <name|uid>[:<group|gid>], same as `docker exec --user`).
+	// Empty inherits the container's default user (image's USER directive
+	// or root). The C side parses this string against the guest's
+	// /etc/passwd before the exec syscall.
+	User string
 	// Timeout bounds the wall-clock lifetime of the execution. Zero
 	// means no timeout (the C side treats `timeout_secs <= 0` as
 	// unbounded — see `sdks/c/src/exec/command.rs`).
@@ -217,6 +223,12 @@ func (b *Box) StartExecution(_ context.Context, name string, args []string, opts
 		defer C.free(unsafe.Pointer(cWorkdir))
 	}
 
+	var cUser *C.char
+	if cfg.User != "" {
+		cUser = toCString(cfg.User)
+		defer C.free(unsafe.Pointer(cUser))
+	}
+
 	cCommand := C.BoxliteCommand{
 		command:      cCmd,
 		args:         cArgs,
@@ -224,7 +236,7 @@ func (b *Box) StartExecution(_ context.Context, name string, args []string, opts
 		env_pairs:    envPairs,
 		env_count:    C.int(envCount),
 		workdir:      cWorkdir,
-		user:         nil,
+		user:         cUser,
 		timeout_secs: C.double(cfg.Timeout.Seconds()),
 		tty:          boolToCInt(cfg.TTY),
 	}

--- a/src/boxlite/src/rest/types.rs
+++ b/src/boxlite/src/rest/types.rs
@@ -337,6 +337,8 @@ pub(crate) struct ExecRequest {
     pub timeout_seconds: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub working_dir: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user: Option<String>,
     #[serde(default)]
     pub tty: bool,
 }
@@ -355,6 +357,7 @@ impl ExecRequest {
             env,
             timeout_seconds,
             working_dir: cmd.working_dir.clone(),
+            user: cmd.user.clone(),
             tty: cmd.tty,
         }
     }


### PR DESCRIPTION
`box.exec(..., user="65534")` over REST silently dropped the field — guest exec always ran as uid 0 regardless of caller intent. Local-FFI mode honoured it; REST chain didn't. Five layers had their own ExecRequest/ExecutionOptions struct that lacked `user`; all five now plumb it through to the C FFI's already-present `user` field.

## Test plan — two-sided verified

Pin: `scripts/test/e2e/cases/test_exec_user.py`

Stack: local e2e (postgres + redis + API + runner + VM). Runner binary swapped between main and PR builds; SDK wheel rebuilt for each side.

| Case | Pre-fix (main) | Post-fix (this PR) |
|---|---|---|
| `test_exec_user_numeric_uid` (`box.exec("id",["-u"],user="65534")` stdout) | `'0
'` — uid stayed root | **`'65534
'`** — uid propagated |
| `test_exec_user_uid_gid_pair` (`echo $(id -u):$(id -g)` with `user="65534:65534"`) | `'0:0
'` | **`'65534:65534
'`** |
| `test_exec_user_invalid_is_typed_error` (`user="bogus-name"`) | `DID NOT RAISE` — bogus user silently ignored | runner correctly rejects with `User 'bogus-name' not found in /etc/passwd` BUT the runner wraps it in HTTP 500 instead of 4xx |

The third case is out of scope for this PR — it requires extending `classifyExecError` in `apps/runner/pkg/api/controllers/boxlite_exec.go` to map `spawn_failed: User not found` to 400. Filed as follow-up; this PR's contract (user= reaches the guest) is met.

Build:
- `make dist:c` ✓
- `cd apps/runner && go build ./cmd/runner` ✓
- `make dev:python` ✓ (rebuilds the PyO3 binding wheel with the new ExecRequest field)
