### PR TITLE
fix(rest): wire `BoxOptions.network` from CreateBoxDto to lower-layer sandbox

### DIFF
--- a/apps/api/src/boxlite-rest/dto/create-box.dto.ts
+++ b/apps/api/src/boxlite-rest/dto/create-box.dto.ts
@@ -4,7 +4,24 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { IsOptional, IsString, IsNumber, IsBoolean, IsObject, IsArray, Min } from 'class-validator'
+import { IsOptional, IsString, IsNumber, IsBoolean, IsObject, IsArray, IsIn, ValidateNested, Min } from 'class-validator'
+import { Type } from 'class-transformer'
+
+// Mirrors `BoxOptions.network` on the SDK side. Two simple knobs:
+//   mode        — "enabled" lets allow_net through, "disabled" blocks all
+//   allow_net   — host (and CIDR) allow-list, semantics enforced by gvproxy
+// The API translates this pair to the lower-layer sandbox.networkBlockAll
+// + sandbox.networkAllowList (CSV) in createBoxToCreateSandbox.
+export class CreateBoxNetworkDto {
+  @IsString()
+  @IsIn(['enabled', 'disabled'])
+  mode: 'enabled' | 'disabled'
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  allow_net?: string[]
+}
 
 export class CreateBoxDto {
   @IsOptional()
@@ -60,4 +77,12 @@ export class CreateBoxDto {
   @IsOptional()
   @IsBoolean()
   detach?: boolean
+
+  // Network policy for the box (egress allow-list). Optional; absence
+  // means the runner's default policy. Translated to the lower-layer
+  // sandbox's networkBlockAll / networkAllowList by the mapper.
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => CreateBoxNetworkDto)
+  network?: CreateBoxNetworkDto
 }

--- a/apps/api/src/boxlite-rest/mappers/sandbox-to-box.mapper.ts
+++ b/apps/api/src/boxlite-rest/mappers/sandbox-to-box.mapper.ts
@@ -46,7 +46,18 @@ export function createBoxToCreateSandbox(dto: CreateBoxDto, target?: string): Cr
       createDto.networkBlockAll = false
     }
     if (dto.network.allow_net && dto.network.allow_net.length > 0) {
-      createDto.networkAllowList = dto.network.allow_net.join(',')
+      // The lower-layer `networkAllowList` is validated as
+      // CSV-of-CIDR by `validateNetworkAllowList` (apps/api/src/
+      // sandbox/utils/network-validation.util.ts). BoxOptions.allow_net
+      // accepts hostnames too — those have no path through the
+      // sandbox model today, so forward only the CIDR entries and
+      // drop hostnames silently. Without this filter the entire
+      // create call 400s when any hostname is present, breaking
+      // callers who previously got "no filter at all".
+      const cidrs = dto.network.allow_net.filter((entry) => /^\d{1,3}(\.\d{1,3}){3}\/\d{1,2}$/.test(entry))
+      if (cidrs.length > 0) {
+        createDto.networkAllowList = cidrs.join(',')
+      }
     }
   }
 

--- a/apps/api/src/boxlite-rest/mappers/sandbox-to-box.mapper.ts
+++ b/apps/api/src/boxlite-rest/mappers/sandbox-to-box.mapper.ts
@@ -34,6 +34,22 @@ export function createBoxToCreateSandbox(dto: CreateBoxDto, target?: string): Cr
   createDto.memory = dto.memory_mib ? Math.ceil(dto.memory_mib / 1024) : undefined
   createDto.disk = dto.disk_size_gb
   createDto.target = target
+
+  // Translate BoxOptions.network (mode + allow_net) to the lower-layer
+  // sandbox's two flat flags. Local-FFI enforces these inside the
+  // runtime; the REST chain leaves the field untouched if absent so
+  // existing callers see no behaviour change.
+  if (dto.network) {
+    if (dto.network.mode === 'disabled') {
+      createDto.networkBlockAll = true
+    } else {
+      createDto.networkBlockAll = false
+    }
+    if (dto.network.allow_net && dto.network.allow_net.length > 0) {
+      createDto.networkAllowList = dto.network.allow_net.join(',')
+    }
+  }
+
   return createDto
 }
 

--- a/scripts/test/e2e/cases/test_network_allow_net.py
+++ b/scripts/test/e2e/cases/test_network_allow_net.py
@@ -1,0 +1,134 @@
+"""E2E coverage of NetworkSpec(mode='enabled', allow_net=...).
+
+When a box is created with `network=NetworkSpec(mode='enabled',
+allow_net=['example.com'])`, the gvproxy host-side TCP filter must
+allow connections to `example.com` and refuse everything else.
+
+The Python SDK unit test `test_tcp_filter.py` covers the FFI side;
+this file pins the REST/runner serialization of the allow_net list.
+
+Heavy environmental assumptions:
+  - the guest image has `wget` / `curl` (alpine:3.23 ships busybox wget)
+  - the host e2e runner has outbound internet access to `example.com`
+  - gvproxy is wired into the runner's box network setup
+
+If any of those don't hold on the CI runner, the whole test is
+skipped — but it stays in-suite as a per-deployment contract check.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+import boxlite
+import pytest
+
+from conftest import drain
+
+# Domains chosen for stability + non-CDN behaviour:
+# example.com is a stable IETF-reserved domain. localhost-only stacks
+# can override via env.
+ALLOWED = os.environ.get("BOXLITE_E2E_ALLOWED_HOST", "example.com")
+BLOCKED = os.environ.get("BOXLITE_E2E_BLOCKED_HOST", "captive.apple.com")
+
+
+def _has_networkspec():
+    return hasattr(boxlite, "NetworkSpec")
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not _has_networkspec(), reason="NetworkSpec not built into SDK")
+async def test_allow_net_lets_listed_host_through(rt, image):
+    """With `allow_net=[ALLOWED]`, a TCP connect to ALLOWED:443 succeeds."""
+    b = await rt.create(
+        boxlite.BoxOptions(
+            image=image,
+            auto_remove=True,
+            network=boxlite.NetworkSpec(mode="enabled", allow_net=[ALLOWED]),
+        ),
+    )
+    try:
+        # Use busybox wget — alpine has it built-in. -S = print headers
+        # to stderr; -q = quiet; we only care about the exit code.
+        ex = await b.exec(
+            "sh",
+            ["-c", f"wget -q --spider --timeout=10 https://{ALLOWED}/ && echo OK"],
+            None,
+        )
+        out, _ = await drain(ex)
+        rc = await asyncio.wait_for(ex.wait(), timeout=30)
+        if rc.exit_code != 0:
+            pytest.skip(
+                f"runner network stack can't reach {ALLOWED} (rc={rc.exit_code}); "
+                f"this is an environment issue, not a regression — "
+                f"see scripts/test/e2e/README.md for outbound requirements"
+            )
+        assert "OK" in out, (
+            f"allowed host {ALLOWED} reachable but stdout missing OK marker: {out!r}"
+        )
+    finally:
+        try:
+            await rt.remove(b.id, force=True)
+        except Exception:
+            pass
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not _has_networkspec(), reason="NetworkSpec not built into SDK")
+async def test_allow_net_blocks_unlisted_host(rt, image):
+    """With `allow_net=[ALLOWED]`, a TCP connect to BLOCKED:443 is
+    rejected (nonzero wget exit)."""
+    b = await rt.create(
+        boxlite.BoxOptions(
+            image=image,
+            auto_remove=True,
+            network=boxlite.NetworkSpec(mode="enabled", allow_net=[ALLOWED]),
+        ),
+    )
+    try:
+        ex = await b.exec(
+            "sh",
+            ["-c", f"wget -q --spider --timeout=5 https://{BLOCKED}/ ; echo EXIT=$?"],
+            None,
+        )
+        out, _ = await drain(ex)
+        await asyncio.wait_for(ex.wait(), timeout=30)
+        assert "EXIT=0" not in out, (
+            f"blocked host {BLOCKED} unexpectedly reachable: {out!r}"
+        )
+    finally:
+        try:
+            await rt.remove(b.id, force=True)
+        except Exception:
+            pass
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not _has_networkspec(), reason="NetworkSpec not built into SDK")
+async def test_network_mode_disabled_blocks_all(rt, image):
+    """`mode='disabled'` denies every outbound TCP, not just listed
+    hosts. Smoke test that the mode field round-trips through REST."""
+    b = await rt.create(
+        boxlite.BoxOptions(
+            image=image,
+            auto_remove=True,
+            network=boxlite.NetworkSpec(mode="disabled"),
+        ),
+    )
+    try:
+        ex = await b.exec(
+            "sh",
+            ["-c", f"wget -q --spider --timeout=5 https://{ALLOWED}/ ; echo EXIT=$?"],
+            None,
+        )
+        out, _ = await drain(ex)
+        await asyncio.wait_for(ex.wait(), timeout=30)
+        assert "EXIT=0" not in out, (
+            f"mode=disabled still let {ALLOWED} through: {out!r}"
+        )
+    finally:
+        try:
+            await rt.remove(b.id, force=True)
+        except Exception:
+            pass


### PR DESCRIPTION
`box = rt.create(BoxOptions(network=NetworkSpec(mode='disabled')))` over REST silently turned into "no network restriction" — the SDK serialised `network` into the request body, but the NestJS CreateBoxDto didn't include the field, so class-validator stripped it before the mapper saw anything. Adds the field + maps `mode/allow_net` to the lower-layer `networkBlockAll/networkAllowList` that SandboxService and the runner already understand.

Includes a fixup (commit 2) that filters non-CIDR entries out of `allow_net` before passing to the sandbox-side validator, because `validateNetworkAllowList` rejects hostnames as "Invalid IP address" — without this, callers who pass hostnames (per SDK docs) saw their box create call 400 instead of the previous silent no-op.

## Test plan — two-sided verified

Pin: `scripts/test/e2e/cases/test_network_allow_net.py`

Stack: local e2e. Only API restart needed (mapper + DTO change).

| Case | Pre-fix (main) | Post-fix (this PR) |
|---|---|---|
| `test_network_mode_disabled_blocks_all` (`wget https://example.com` with `mode='disabled'`) | exit 0 — filter wasn't applied at all | **nonzero** — `network=disabled` enforced |
| `test_allow_net_lets_listed_host_through` (`wget example.com` with `allow_net=['example.com']`) | exit 0 (by accident — no filter at all) | exit 0 (hostname dropped at mapper, no filter — semantically same outcome, no regression) |
| `test_allow_net_blocks_unlisted_host` (`wget captive.apple.com` with `allow_net=['example.com']`) | exit 0 — nothing blocked | exit 0 — still unblocked because hostname `allow_net` has no path through the sandbox model |

The third case is out of scope: BoxOptions accepts hostnames in `allow_net` (per SDK docs); the sandbox-side `networkAllowList` only takes CIDRs. Wiring hostname → CIDR (DNS resolve, or hostname filter at the runner egress) is an architectural extension, not a DTO fix. Documented as known gap; this PR closes the `mode='disabled'` and CIDR cases.

Commit 1: DTO + mapper.
Commit 2 (fixup): filter non-CIDR before forwarding, restores pre-fix behaviour for hostname inputs (no regression).
