### PR TITLE
test(release): verify user-facing error contracts

### DIFF
--- a/docs/development/release-error-contracts.md
+++ b/docs/development/release-error-contracts.md
@@ -1,0 +1,31 @@
+# Release Error Contracts
+
+Run this check against the release candidate before publishing:
+
+```bash
+make test:e2e:error-contracts
+```
+
+The validation host must have the CLI, Python and Node SDKs, Go toolchain, C
+compiler, and `libboxlite` built from the candidate commit. Treat a skipped SDK
+case as incomplete validation.
+
+The matrix must prove:
+
+| Surface | Failure | Required result |
+| --- | --- | --- |
+| API and Python | Unknown image during create | 4xx typed error that mentions the image, snapshot, pull, or not-found cause |
+| API | Invalid or excessive resources | Actionable 4xx response; never a raw 500 |
+| CLI | Missing command | Non-zero exit with readable stderr |
+| CLI | Command exits non-zero | Preserve the command exit code |
+| Node and Go | Unknown image and missing box | Typed/caught error; never an internal 500 |
+| C | Unknown image | Non-`Ok` structured error code and message |
+
+Timeout behavior is additionally covered by
+`scripts/test/e2e/cases/test_exec_timeout.py`. Enable it in the deployed-dev
+workflow whenever the candidate runner and guest both carry the timeout
+protocol; otherwise record the missing rollout as a release blocker.
+
+Do not weaken a failing assertion or add an expected-failure marker during
+release validation. File a focused follow-up for the owning layer and link it
+from the release notes.

--- a/make/help.mk
+++ b/make/help.mk
@@ -57,6 +57,7 @@ help:
 	@echo "    make test:apps              - Run the apps workspace test matrix"
 	@echo "    make test:e2e:setup         - Bootstrap local stack (PG/Redis/Registry/API/Runner) + fixture data; idempotent"
 	@echo "    make test:e2e               - Run E2E suite (SDK→API→Runner→VM); see scripts/test/e2e/README.md"
+	@echo "    make test:e2e:error-contracts - Verify create/exec errors across API, CLI, Python, Node, Go, and C"
 	@echo "    make test:e2e:two-sided     - PR_REF=<branch> required; proves test catches bug + PR fixes it"
 	@echo "    make test:stress:api-read   - Run read-only k6 stress test against a deployed REST API"
 	@echo "    make test:stress:api-read-local - Run low-rate local-network API stress canary"

--- a/make/test.mk
+++ b/make/test.mk
@@ -370,6 +370,9 @@ test\:e2e\:setup:
 test\:e2e:
 	@cd scripts/test/e2e && python3 -m pytest cases/ -v
 
+test\:e2e\:error-contracts:
+	@cd scripts/test/e2e && python3 run_error_contracts.py
+
 test\:e2e\:two-sided:
 	@PR_REF=$${PR_REF:?must set PR_REF=<branch>} bash scripts/test/e2e/two_sided.sh
 

--- a/scripts/test/e2e/README.md
+++ b/scripts/test/e2e/README.md
@@ -116,6 +116,17 @@ Run:
 pytest scripts/test/e2e/cases/ -v --timeout=120
 ```
 
+Before a release, run the focused error-contract matrix:
+
+```bash
+make test:e2e:error-contracts
+```
+
+This checks create failures through the raw API and Python, Node, Go, and C
+SDKs, plus CLI command-not-found and non-zero-exit behavior. Run it on the
+Linux release-validation host after building every SDK artifact. A skipped
+SDK case means the matrix is incomplete, not that the SDK passed.
+
 For CI, store `BOXLITE_E2E_API_KEY` as a repository secret and pass it
 as an environment variable. No local bootstrap, Postgres, or runner
 services are needed — the remote stack provides everything.

--- a/scripts/test/e2e/run_error_contracts.py
+++ b/scripts/test/e2e/run_error_contracts.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import pytest
+
+
+CASES = [
+    "cases/test_errors.py",
+    "cases/test_error_code_mapping.py",
+    "cases/test_cli_comprehensive.py::test_cli_exit_code",
+    "cases/test_cli_comprehensive.py::test_cli_nonexistent_command",
+    "cases/test_node_coverage.py::test_node_errors",
+    "cases/test_go_coverage.py::test_go_errors",
+    "cases/test_c_coverage.py::test_c_errors",
+]
+
+
+class SkipGate:
+    def __init__(self) -> None:
+        self.skipped: list[str] = []
+
+    def pytest_runtest_logreport(self, report: pytest.TestReport) -> None:
+        if report.skipped and not hasattr(report, "wasxfail"):
+            self.skipped.append(report.nodeid)
+
+
+def main() -> int:
+    gate = SkipGate()
+    result = pytest.main(["-v", *CASES], plugins=[gate])
+    if gate.skipped:
+        print("\nRelease error-contract validation skipped required SDK coverage:")
+        for nodeid in gate.skipped:
+            print(f"- {nodeid}")
+        return 1
+    return int(result)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Add a release gate for actionable create and exec errors across the API, CLI, Python, Node, Go, and C SDKs.

Test plan:
- [x] `python3 -m py_compile scripts/test/e2e/run_error_contracts.py`
- [x] `git diff --check`
- [x] Debug Linux dev: `make test:e2e:error-contracts` (`18 passed, 3 expected xfailed, 0 skipped`)