### PR TITLE
fix(rest): honour copy_in(overwrite=False) end-to-end

### DIFF
--- a/apps/runner/pkg/api/controllers/boxlite_files.go
+++ b/apps/runner/pkg/api/controllers/boxlite_files.go
@@ -26,26 +26,108 @@ func BoxliteFileUpload(ctx *gin.Context) {
 		return
 	}
 
-	tmpFile, err := os.CreateTemp("", "boxlite-upload-*.tar")
+	// The SDK uploads a tar archive (Content-Type: application/x-tar) so
+	// that copy_in(host_dir, ...) can move trees in a single request.
+	// We MUST extract the archive into a staging dir on the runner host
+	// before handing it to the Go SDK's CopyInto — that lower-level call
+	// expects a *real path*, not a tar file, and would otherwise dump the
+	// entire .tar blob into the guest as a single binary file (which
+	// silently breaks both single-file and directory uploads).
+	stagingDir, err := os.MkdirTemp("", "boxlite-upload-stage-*")
 	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create temp file"})
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create staging dir"})
 		return
 	}
-	defer os.Remove(tmpFile.Name())
-	defer tmpFile.Close()
+	defer os.RemoveAll(stagingDir)
 
-	if _, err := io.Copy(tmpFile, ctx.Request.Body); err != nil {
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": "failed to read upload body"})
+	stagedPath, isSingleFile, err := extractTarToDir(ctx.Request.Body, stagingDir)
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("failed to extract upload tar: %s", err)})
 		return
 	}
-	tmpFile.Close()
 
-	if err := r.Boxlite.CopyInto(ctx.Request.Context(), boxId, tmpFile.Name(), destPath); err != nil {
+	// If the archive contained exactly one regular file, CopyInto its
+	// extracted path (a real file) so the guest sees the file at destPath.
+	// Otherwise CopyInto the staging dir as a whole — the Go SDK's
+	// recursive copy handles directories natively.
+	src := stagingDir
+	if isSingleFile {
+		src = stagedPath
+	}
+
+	if err := r.Boxlite.CopyInto(ctx.Request.Context(), boxId, src, destPath); err != nil {
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("copy failed: %s", err)})
 		return
 	}
 
 	ctx.Status(http.StatusNoContent)
+}
+
+// extractTarToDir reads a tar archive from r and writes every entry into
+// destDir, preserving the relative layout. Returns:
+//   - lastFilePath: path to the most-recently extracted file (only
+//     meaningful when isSingleFile is true)
+//   - isSingleFile: true when the archive contained exactly one regular
+//     file entry (no directories, no symlinks, no multi-file payload).
+//     This is the canonical signal for "the caller copy_in'd a single
+//     file" so the upload handler can pass that exact path on to
+//     CopyInto, rather than passing a wrapping directory.
+//
+// Entries with paths that escape destDir (zip-slip) are refused.
+func extractTarToDir(r io.Reader, destDir string) (lastFilePath string, isSingleFile bool, err error) {
+	tr := tar.NewReader(r)
+	fileCount := 0
+	otherCount := 0 // dirs, symlinks, anything that's not a regular file
+
+	for {
+		header, hdrErr := tr.Next()
+		if hdrErr == io.EOF {
+			break
+		}
+		if hdrErr != nil {
+			return "", false, fmt.Errorf("tar.Next: %w", hdrErr)
+		}
+
+		// Defend against absolute paths and traversal — the SDK should
+		// only ever send relative entries, but a malformed client could
+		// craft an archive that writes outside destDir.
+		cleanName := filepath.Clean(header.Name)
+		if filepath.IsAbs(cleanName) || cleanName == ".." || (len(cleanName) >= 3 && cleanName[:3] == "../") {
+			return "", false, fmt.Errorf("tar entry escapes staging dir: %q", header.Name)
+		}
+		target := filepath.Join(destDir, cleanName)
+
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if mkErr := os.MkdirAll(target, 0o755); mkErr != nil {
+				return "", false, fmt.Errorf("mkdir %s: %w", target, mkErr)
+			}
+			otherCount++
+		case tar.TypeReg, tar.TypeRegA:
+			if mkErr := os.MkdirAll(filepath.Dir(target), 0o755); mkErr != nil {
+				return "", false, fmt.Errorf("mkdir parent of %s: %w", target, mkErr)
+			}
+			f, openErr := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(header.Mode&0o7777))
+			if openErr != nil {
+				return "", false, fmt.Errorf("create %s: %w", target, openErr)
+			}
+			if _, copyErr := io.Copy(f, tr); copyErr != nil {
+				f.Close()
+				return "", false, fmt.Errorf("write %s: %w", target, copyErr)
+			}
+			f.Close()
+			lastFilePath = target
+			fileCount++
+		default:
+			// symlinks, hardlinks, devices — preserve as best-effort by
+			// counting them in otherCount so single-file detection stays
+			// pessimistic (any non-regular entry forces "treat as dir").
+			otherCount++
+		}
+	}
+
+	isSingleFile = fileCount == 1 && otherCount == 0
+	return lastFilePath, isSingleFile, nil
 }
 
 func BoxliteFileDownload(ctx *gin.Context) {

--- a/apps/runner/pkg/api/controllers/boxlite_files.go
+++ b/apps/runner/pkg/api/controllers/boxlite_files.go
@@ -26,6 +26,13 @@ func BoxliteFileUpload(ctx *gin.Context) {
 		return
 	}
 
+	// `overwrite=false` is the only CopyOptions bit the SDK can't encode
+	// in the tar layout (the others — recursive / include_parent /
+	// follow_symlinks — change which entries get tarred). The SDK
+	// passes it as a query param when set; absence means the historical
+	// "clobber whatever is at the destination" default.
+	overwrite := ctx.Query("overwrite") != "false"
+
 	// The SDK uploads a tar archive (Content-Type: application/x-tar) so
 	// that copy_in(host_dir, ...) can move trees in a single request.
 	// We MUST extract the archive into a staging dir on the runner host
@@ -55,7 +62,7 @@ func BoxliteFileUpload(ctx *gin.Context) {
 		src = stagedPath
 	}
 
-	if err := r.Boxlite.CopyInto(ctx.Request.Context(), boxId, src, destPath); err != nil {
+	if err := r.Boxlite.CopyIntoWithOptions(ctx.Request.Context(), boxId, src, destPath, overwrite); err != nil {
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("copy failed: %s", err)})
 		return
 	}

--- a/apps/runner/pkg/boxlite/client.go
+++ b/apps/runner/pkg/boxlite/client.go
@@ -332,13 +332,25 @@ func (c *Client) Exec(ctx context.Context, sandboxId string, command string, arg
 	}, nil
 }
 
-// CopyInto copies a file from host into a sandbox.
+// CopyInto copies a file from host into a sandbox, overwriting any
+// existing guest destination. Use CopyIntoWithOptions to control the
+// overwrite policy.
 func (c *Client) CopyInto(ctx context.Context, sandboxId string, hostSrc, guestDst string) error {
 	bx, err := c.getOrFetchBox(ctx, sandboxId)
 	if err != nil {
 		return err
 	}
 	return bx.CopyInto(ctx, hostSrc, guestDst)
+}
+
+// CopyIntoWithOptions is the option-bearing form of CopyInto. The REST
+// file-upload handler uses this to honour `copy_in(..., overwrite=false)`.
+func (c *Client) CopyIntoWithOptions(ctx context.Context, sandboxId string, hostSrc, guestDst string, overwrite bool) error {
+	bx, err := c.getOrFetchBox(ctx, sandboxId)
+	if err != nil {
+		return err
+	}
+	return bx.CopyIntoWithOptions(ctx, hostSrc, guestDst, boxlite.CopyIntoOptions{Overwrite: overwrite})
 }
 
 // CopyOut copies a file from a sandbox to the host.

--- a/sdks/c/include/boxlite.h
+++ b/sdks/c/include/boxlite.h
@@ -341,6 +341,22 @@ enum BoxliteErrorCode boxlite_copy_into(CBoxHandle *handle,
                                         void *user_data,
                                         CBoxliteError *out_error);
 
+// Variant of `boxlite_copy_into` that takes an explicit `overwrite`
+// flag. Required for REST-mode `copy_in(..., overwrite=False)` to
+// reach the guest unchanged — `boxlite_copy_into` hard-codes
+// `overwrite=true` (the SDK's default) and there's no other way to
+// pass the flag across the C ABI today. All other CopyOptions
+// (recursive, follow_symlinks, include_parent) stay defaulted because
+// the runner-side staging step encodes them at archive-creation time
+// before this call is reached.
+enum BoxliteErrorCode boxlite_copy_into_with_options(CBoxHandle *handle,
+                                                     const char *host_src,
+                                                     const char *guest_dst,
+                                                     bool overwrite,
+                                                     CBoxCopyCb cb,
+                                                     void *user_data,
+                                                     CBoxliteError *out_error);
+
 enum BoxliteErrorCode boxlite_copy_out(CBoxHandle *handle,
                                        const char *guest_src,
                                        const char *host_dst,

--- a/sdks/c/src/copy.rs
+++ b/sdks/c/src/copy.rs
@@ -20,7 +20,15 @@ pub unsafe extern "C" fn boxlite_copy_into(
     user_data: *mut c_void,
     out_error: *mut CBoxliteError,
 ) -> BoxliteErrorCode {
-    box_copy_into(handle, host_src, guest_dst, default_copy_options(), cb, user_data, out_error)
+    box_copy_into(
+        handle,
+        host_src,
+        guest_dst,
+        default_copy_options(),
+        cb,
+        user_data,
+        out_error,
+    )
 }
 
 /// Variant of `boxlite_copy_into` that takes an explicit `overwrite`

--- a/sdks/c/src/copy.rs
+++ b/sdks/c/src/copy.rs
@@ -20,7 +20,30 @@ pub unsafe extern "C" fn boxlite_copy_into(
     user_data: *mut c_void,
     out_error: *mut CBoxliteError,
 ) -> BoxliteErrorCode {
-    box_copy_into(handle, host_src, guest_dst, cb, user_data, out_error)
+    box_copy_into(handle, host_src, guest_dst, default_copy_options(), cb, user_data, out_error)
+}
+
+/// Variant of `boxlite_copy_into` that takes an explicit `overwrite`
+/// flag. Required for REST-mode `copy_in(..., overwrite=False)` to
+/// reach the guest unchanged — `boxlite_copy_into` hard-codes
+/// `overwrite=true` (the SDK's default) and there's no other way to
+/// pass the flag across the C ABI today. All other CopyOptions
+/// (recursive, follow_symlinks, include_parent) stay defaulted because
+/// the runner-side staging step encodes them at archive-creation time
+/// before this call is reached.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_copy_into_with_options(
+    handle: *mut CBoxHandle,
+    host_src: *const c_char,
+    guest_dst: *const c_char,
+    overwrite: bool,
+    cb: CBoxCopyCb,
+    user_data: *mut c_void,
+    out_error: *mut CBoxliteError,
+) -> BoxliteErrorCode {
+    let mut opts = default_copy_options();
+    opts.overwrite = overwrite;
+    box_copy_into(handle, host_src, guest_dst, opts, cb, user_data, out_error)
 }
 
 #[unsafe(no_mangle)]
@@ -48,6 +71,7 @@ unsafe fn box_copy_into(
     handle: *mut BoxHandle,
     host_src: *const c_char,
     guest_dst: *const c_char,
+    opts: CopyOptions,
     cb: CBoxCopyCb,
     user_data: *mut c_void,
     out_error: *mut FFIError,
@@ -80,7 +104,7 @@ unsafe fn box_copy_into(
         let user_data_addr = user_data as usize;
 
         handle_ref.tokio_rt.spawn(async move {
-            let result = lite.copy_into(src, dst, default_copy_options()).await;
+            let result = lite.copy_into(src, dst, opts).await;
             push_event(
                 &queue,
                 RuntimeEvent::Copy {

--- a/sdks/go/copy.go
+++ b/sdks/go/copy.go
@@ -11,8 +11,34 @@ import (
 	"unsafe"
 )
 
-// CopyInto copies a host file or directory into the box.
+// CopyIntoOptions controls per-call copy behaviour. The Go SDK exposes
+// only `Overwrite` for now — the other CopyOptions bits (recursive,
+// follow_symlinks, include_parent) are interpreted at host-tarball
+// creation time by callers above this layer and don't need to cross
+// the FFI seam.
+type CopyIntoOptions struct {
+	// Overwrite, when false, causes copy_into to refuse to clobber
+	// destination paths that already exist in the guest. Defaults to
+	// true to preserve the historical "overwrite everything" behaviour
+	// of `CopyInto`.
+	Overwrite bool
+}
+
+func defaultCopyIntoOptions() CopyIntoOptions {
+	return CopyIntoOptions{Overwrite: true}
+}
+
+// CopyInto copies a host file or directory into the box, overwriting
+// any existing guest destination. For the `Overwrite=false` variant
+// use CopyIntoWithOptions.
 func (b *Box) CopyInto(ctx context.Context, hostSrc, guestDst string) error {
+	return b.CopyIntoWithOptions(ctx, hostSrc, guestDst, defaultCopyIntoOptions())
+}
+
+// CopyIntoWithOptions is the option-bearing form of CopyInto. The runner
+// uses this so REST `copy_in(..., overwrite=False)` reaches the guest
+// with O_EXCL semantics enforced inside libboxlite.
+func (b *Box) CopyIntoWithOptions(ctx context.Context, hostSrc, guestDst string, opts CopyIntoOptions) error {
 	b.runtime.ensureDrainRunning()
 
 	cSrc := toCString(hostSrc)
@@ -24,7 +50,15 @@ func (b *Box) CopyInto(ctx context.Context, hostSrc, guestDst string) error {
 	h := registerHandleForDispatch(cgo.NewHandle(ch))
 
 	var cerr C.CBoxliteError
-	code := C.boxlite_copy_into(b.handle, cSrc, cDst, C.cbCopy(), handleToPtr(h), &cerr)
+	code := C.boxlite_copy_into_with_options(
+		b.handle,
+		cSrc,
+		cDst,
+		C.bool(opts.Overwrite),
+		C.cbCopy(),
+		handleToPtr(h),
+		&cerr,
+	)
 	if code != C.Ok {
 		deleteHandleForDispatch(h)
 		return freeError(&cerr)

--- a/src/boxlite/src/rest/litebox.rs
+++ b/src/boxlite/src/rest/litebox.rs
@@ -225,7 +225,10 @@ impl BoxBackend for RestBox {
         let path = if opts.overwrite {
             format!("/boxes/{}/files?path={}", box_id, encoded_dst)
         } else {
-            format!("/boxes/{}/files?path={}&overwrite=false", box_id, encoded_dst)
+            format!(
+                "/boxes/{}/files?path={}&overwrite=false",
+                box_id, encoded_dst
+            )
         };
         let builder = self
             .client

--- a/src/boxlite/src/rest/litebox.rs
+++ b/src/boxlite/src/rest/litebox.rs
@@ -209,16 +209,24 @@ impl BoxBackend for RestBox {
         &self,
         host_src: &Path,
         container_dst: &str,
-        _opts: CopyOptions,
+        opts: CopyOptions,
     ) -> BoxliteResult<()> {
         let box_id = self.box_id_str();
 
         // Create tar archive from host path
         let tar_bytes = create_tar_from_path(host_src)?;
 
-        // Upload tar to server
+        // Upload tar to server. `overwrite=false` is the only CopyOptions
+        // bit that isn't already encoded in the tar layout (recursive,
+        // follow_symlinks, and include_parent affect what gets tarred);
+        // forward it as a query param so the runner can refuse to
+        // clobber existing destination entries with O_EXCL.
         let encoded_dst = urlencoding::encode(container_dst);
-        let path = format!("/boxes/{}/files?path={}", box_id, encoded_dst);
+        let path = if opts.overwrite {
+            format!("/boxes/{}/files?path={}", box_id, encoded_dst)
+        } else {
+            format!("/boxes/{}/files?path={}&overwrite=false", box_id, encoded_dst)
+        };
         let builder = self
             .client
             .authorized_request(Method::PUT, &path)


### PR DESCRIPTION
copy_in(overwrite=False) silently clobbers existing guest files

## Bug

`box.copy_in(host, dst, copy_options=CopyOptions(overwrite=False))` over
REST has no effect — the SDK accepts the flag but the runner extracts
the tar with `O_TRUNC` regardless:

```
seed /root/v.txt = "guest-original"
copy_in("host-replacement", "/root/v.txt", CopyOptions(overwrite=False))
cat /root/v.txt
  → ""   (truncated by the extract, contents lost)
```

Root cause: the option is dropped at three seams across the SDK chain:
- SDK Rust REST client doesn't serialise it onto the request.
- Runner file-upload handler doesn't parse it off the query string.
- C FFI has only `boxlite_copy_into(...)` (no overwrite arg) — the bool
  is hard-coded `true` at the FFI boundary, so even local-FFI callers
  that opted out got an overwrite-everything copy.

## Fix

Plumb the option end-to-end. ABI-stable on the C surface so existing
callers keep working unchanged:

| Layer | Change |
|---|---|
| C FFI | new `boxlite_copy_into_with_options(...)`; existing `boxlite_copy_into` kept (defaults `overwrite=true`) |
| Go SDK | new `CopyIntoWithOptions(ctx, src, dst, CopyIntoOptions{Overwrite: bool})` |
| Runner | file-upload handler reads `?overwrite=false` query param |
| SDK Rust REST client | appends `&overwrite=false` when caller sets it |

Defaults unchanged: old callers still get `overwrite=true` — the
historical behaviour. Stacks on #688: the underlying tar-extract path
needs to exist before `overwrite=False` has a place to refuse.

## Test plan — two-sided verified

Pin: `scripts/test/e2e/cases/test_files_io.py::test_copy_in_overwrite_false_rejects_conflict`

Stack: local e2e. C lib + runner + Go SDK static + Python wheel all rebuilt and hot-swapped.

| | Pre-fix | Post-fix |
|---|---|---|
| seed `/root/v.txt='guest-original'`, then `copy_in('host-replacement', '/root/v.txt', CopyOptions(overwrite=False))`, then `cat /root/v.txt` | `''` (silently clobbered to empty by tar extract + O_TRUNC) | **`'guest-original'`** — refusal honoured by libboxlite |
| default `overwrite=True` callers (existing PR #688 paths) | unchanged | unchanged |

Build: `make dist:c` ✓, `cd apps/runner && go build ./cmd/runner` ✓. Note that this PR's runner build requires the refreshed `libboxlite.a` from `make dist:c` because of the new C-FFI symbol — `make dist:c` handles staging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File uploads now support explicit overwrite control (default: overwrite=true; set overwrite=false to preserve existing files).
  * Uploads may target either a single file or a directory—both are handled automatically.

* **Bug Fixes**
  * Improved upload safety: incoming archives are securely staged and extracted to prevent path-traversal issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->