### PR TITLE
fix(rest): copy_out single-file mode writes at host_dst, not inside it

### DIFF
--- a/src/boxlite/src/rest/litebox.rs
+++ b/src/boxlite/src/rest/litebox.rs
@@ -890,19 +890,98 @@ fn create_tar_from_path(host_src: &Path) -> BoxliteResult<Vec<u8>> {
         .map_err(|e| BoxliteError::Internal(format!("failed to finalize tar archive: {}", e)))
 }
 
-/// Extract a tar archive to a host directory.
+/// Extract a tar archive to a host path.
+///
+/// When the archive contains exactly one regular file (the common case
+/// for `copy_out("/guest/file", "/host/file")`), the file is written
+/// at `host_dst` directly so the caller sees the layout they asked
+/// for. When the archive contains multiple entries (or any directory
+/// entry), `host_dst` is treated as a destination directory and the
+/// tree is unpacked into it.
+///
+/// Pre-fix this always called `archive.unpack(host_dst)`, which
+/// always treats `host_dst` as a directory and produces the wrong
+/// shape on single-file `copy_out` (callers received `/host/file/`
+/// as a directory containing the actual file under it).
 fn extract_tar_to_path(tar_bytes: &[u8], host_dst: &Path) -> BoxliteResult<()> {
-    // Ensure parent directory exists
-    if let Some(parent) = host_dst.parent() {
-        std::fs::create_dir_all(parent).map_err(|e| {
-            BoxliteError::Internal(format!(
-                "failed to create directory {}: {}",
-                parent.display(),
-                e
-            ))
+    // Probe the archive once to decide single-file vs multi-entry.
+    // tar::Archive iterators consume the underlying reader, so we
+    // re-open a fresh Archive for the actual extraction step.
+    let mut probe = tar::Archive::new(tar_bytes);
+    let mut file_count = 0usize;
+    let mut other_count = 0usize;
+    let mut single_entry_path: Option<std::path::PathBuf> = None;
+    for entry in probe.entries().map_err(|e| {
+        BoxliteError::Internal(format!("failed to read tar archive: {}", e))
+    })? {
+        let entry = entry.map_err(|e| {
+            BoxliteError::Internal(format!("failed to read tar entry: {}", e))
         })?;
+        let header = entry.header();
+        match header.entry_type() {
+            tar::EntryType::Regular => {
+                file_count += 1;
+                if single_entry_path.is_none() {
+                    single_entry_path =
+                        Some(entry.path().map(|c| c.into_owned()).unwrap_or_default());
+                }
+            }
+            _ => other_count += 1,
+        }
     }
 
+    if file_count == 1 && other_count == 0 {
+        if let Some(parent) = host_dst.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                BoxliteError::Internal(format!(
+                    "failed to create directory {}: {}",
+                    parent.display(),
+                    e
+                ))
+            })?;
+        }
+        // Re-read the (single) entry from a fresh Archive and copy
+        // its bytes into host_dst directly.
+        let mut archive = tar::Archive::new(tar_bytes);
+        for entry in archive.entries().map_err(|e| {
+            BoxliteError::Internal(format!("failed to re-read tar archive: {}", e))
+        })? {
+            let mut entry = entry.map_err(|e| {
+                BoxliteError::Internal(format!("failed to re-read tar entry: {}", e))
+            })?;
+            if entry.header().entry_type() != tar::EntryType::Regular {
+                continue;
+            }
+            let mut out = std::fs::File::create(host_dst).map_err(|e| {
+                BoxliteError::Internal(format!(
+                    "failed to create {}: {}",
+                    host_dst.display(),
+                    e
+                ))
+            })?;
+            std::io::copy(&mut entry, &mut out).map_err(|e| {
+                BoxliteError::Internal(format!(
+                    "failed to write {}: {}",
+                    host_dst.display(),
+                    e
+                ))
+            })?;
+            return Ok(());
+        }
+        // Probe said one regular file but the second pass found
+        // none — defensive fallthrough; shouldn't happen.
+        let _ = single_entry_path;
+    }
+
+    // Multi-entry archive: treat host_dst as a directory and unpack
+    // the tree into it. Matches the historical contract.
+    std::fs::create_dir_all(host_dst).map_err(|e| {
+        BoxliteError::Internal(format!(
+            "failed to create directory {}: {}",
+            host_dst.display(),
+            e
+        ))
+    })?;
     let mut archive = tar::Archive::new(tar_bytes);
     archive.unpack(host_dst).map_err(|e| {
         BoxliteError::Internal(format!(

--- a/src/boxlite/src/rest/litebox.rs
+++ b/src/boxlite/src/rest/litebox.rs
@@ -911,12 +911,12 @@ fn extract_tar_to_path(tar_bytes: &[u8], host_dst: &Path) -> BoxliteResult<()> {
     let mut file_count = 0usize;
     let mut other_count = 0usize;
     let mut single_entry_path: Option<std::path::PathBuf> = None;
-    for entry in probe.entries().map_err(|e| {
-        BoxliteError::Internal(format!("failed to read tar archive: {}", e))
-    })? {
-        let entry = entry.map_err(|e| {
-            BoxliteError::Internal(format!("failed to read tar entry: {}", e))
-        })?;
+    for entry in probe
+        .entries()
+        .map_err(|e| BoxliteError::Internal(format!("failed to read tar archive: {}", e)))?
+    {
+        let entry = entry
+            .map_err(|e| BoxliteError::Internal(format!("failed to read tar entry: {}", e)))?;
         let header = entry.header();
         match header.entry_type() {
             tar::EntryType::Regular => {
@@ -943,9 +943,10 @@ fn extract_tar_to_path(tar_bytes: &[u8], host_dst: &Path) -> BoxliteResult<()> {
         // Re-read the (single) entry from a fresh Archive and copy
         // its bytes into host_dst directly.
         let mut archive = tar::Archive::new(tar_bytes);
-        for entry in archive.entries().map_err(|e| {
-            BoxliteError::Internal(format!("failed to re-read tar archive: {}", e))
-        })? {
+        for entry in archive
+            .entries()
+            .map_err(|e| BoxliteError::Internal(format!("failed to re-read tar archive: {}", e)))?
+        {
             let mut entry = entry.map_err(|e| {
                 BoxliteError::Internal(format!("failed to re-read tar entry: {}", e))
             })?;
@@ -953,18 +954,10 @@ fn extract_tar_to_path(tar_bytes: &[u8], host_dst: &Path) -> BoxliteResult<()> {
                 continue;
             }
             let mut out = std::fs::File::create(host_dst).map_err(|e| {
-                BoxliteError::Internal(format!(
-                    "failed to create {}: {}",
-                    host_dst.display(),
-                    e
-                ))
+                BoxliteError::Internal(format!("failed to create {}: {}", host_dst.display(), e))
             })?;
             std::io::copy(&mut entry, &mut out).map_err(|e| {
-                BoxliteError::Internal(format!(
-                    "failed to write {}: {}",
-                    host_dst.display(),
-                    e
-                ))
+                BoxliteError::Internal(format!("failed to write {}: {}", host_dst.display(), e))
             })?;
             return Ok(());
         }


### PR DESCRIPTION
copy_out single-file mode writes a directory wrapping the file instead of the file at host_dst

## Bug

`box.copy_out("/guest/blob", "/host/blob_copy")` over REST landed at the
wrong layout on the host:

```
expected:  /host/blob_copy           = the file
actual:    /host/blob_copy/blob      = the file inside a new directory
```

Local-FFI `copy_out` keeps single-file semantics (dest is the file path);
REST broke that contract.

Root cause: the SDK Rust REST client used `tar::Archive::unpack(host_dst)`
unconditionally. `unpack` always treats its arg as a destination directory
and extracts every entry under it. For a single-file archive that means
writing the entry as a child of `host_dst` rather than AT `host_dst`.

## Fix

Detect single-file archives and write the entry directly at `host_dst`:

| Archive shape | Behaviour |
|---|---|
| 1 regular file, no other entries | write at `host_dst` |
| Multiple / dirs / symlinks / specials | `unpack(host_dst)` as before |

Mirror of #688's runner-side single-file detection — same situation,
opposite direction.

## Test plan — two-sided verified

Pin: `scripts/test/e2e/cases/test_files_io.py::test_copy_out_binary_roundtrips_sha256`

Stack: local e2e. C lib + Python wheel rebuilt; no runner change needed (this is SDK-side only).

| | Pre-fix | Post-fix |
|---|---|---|
| `copy_out('/root/blob', '/host/blob_copy')` then `read_bytes('/host/blob_copy')` | `IsADirectoryError: '/host/blob_copy'` (host wrote a directory wrapping the file) | **bytes match guest sha256** |
| `copy_out('/root/dir/', '/host/dir/')` (multi-entry archive) | unchanged | unchanged (falls through to `archive.unpack`) |

Defensive: the single-file path is gated on `file_count == 1 && other_count == 0`, so any directory/symlink/link entry demotes to the multi-entry path. Zero-file archives go through the multi-entry path too (does nothing, same as before).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tar extraction now preserves single-file archives by writing the single file directly to the intended destination (creating its parent directory if needed), while multi-entry or non-regular archives continue to unpack into a destination directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->