### PR TITLE
fix(rest): resolve hostname allow_net entries to /32 CIDRs at create time

### DIFF
--- a/apps/api/src/boxlite-rest/boxlite-box.controller.ts
+++ b/apps/api/src/boxlite-rest/boxlite-box.controller.ts
@@ -32,6 +32,7 @@ import { BoxDesiredState } from '../box/enums/box-desired-state.enum'
 import { BoxResponseDto, ListBoxesResponseDto } from './dto/box-response.dto'
 import { CreateBoxDto } from './dto/create-box.dto'
 import { boxToBoxResponse, createBoxToCreateBox } from './mappers/box-to-box.mapper'
+import { resolveAllowNetHostnames } from './mappers/resolve-allow-net'
 import { Audit, MASKED_AUDIT_VALUE, TypedRequest } from '../audit/decorators/audit.decorator'
 import { AuditAction } from '../audit/enums/audit-action.enum'
 import { AuditTarget } from '../audit/enums/audit-target.enum'
@@ -85,6 +86,14 @@ export class BoxliteBoxController {
     @Body() dto: CreateBoxDto,
   ): Promise<BoxResponseDto> {
     const organization = authContext.organization
+
+    // Resolve hostname allow_net entries to /32 CIDRs before mapping, so egress
+    // is bound to concrete IPs rather than a guest-supplied SNI/Host (audit
+    // finding #1, REST-side layer).
+    if (dto.network?.mode === 'enabled' && dto.network.allow_net?.length) {
+      dto.network = { ...dto.network, allow_net: await resolveAllowNetHostnames(dto.network.allow_net) }
+    }
+
     const createBoxDto = createBoxToCreateBox(dto)
 
     let box = await this.boxService.create(createBoxDto, organization)

--- a/apps/api/src/boxlite-rest/mappers/resolve-allow-net.spec.ts
+++ b/apps/api/src/boxlite-rest/mappers/resolve-allow-net.spec.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { promises as dns } from 'dns'
+import { resolveAllowNetHostnames } from './resolve-allow-net'
+
+describe('resolveAllowNetHostnames', () => {
+  afterEach(() => jest.restoreAllMocks())
+
+  it('passes CIDR entries through unchanged', async () => {
+    expect(await resolveAllowNetHostnames(['10.0.0.0/8'])).toEqual(['10.0.0.0/8'])
+  })
+
+  it('appends /32 to bare IPv4 addresses', async () => {
+    expect(await resolveAllowNetHostnames(['1.2.3.4'])).toEqual(['1.2.3.4/32'])
+  })
+
+  // Security-relevant: a hostname becomes concrete /32s so egress is bound to
+  // real IPs instead of trusting a guest-supplied SNI/Host (audit finding #1).
+  it('resolves hostnames to /32 CIDRs', async () => {
+    jest.spyOn(dns, 'resolve4').mockResolvedValue(['203.0.113.10', '203.0.113.11'])
+    expect(await resolveAllowNetHostnames(['api.openai.com'])).toEqual(['203.0.113.10/32', '203.0.113.11/32'])
+  })
+
+  it('drops hostnames that fail to resolve rather than failing the create', async () => {
+    jest.spyOn(dns, 'resolve4').mockRejectedValue(new Error('ENOTFOUND'))
+    expect(await resolveAllowNetHostnames(['nope.invalid'])).toEqual([])
+  })
+
+  it('caps the expanded list at the allow_net entry limit', async () => {
+    jest.spyOn(dns, 'resolve4').mockResolvedValue(Array.from({ length: 15 }, (_, i) => `10.0.0.${i}`))
+    expect(await resolveAllowNetHostnames(['many.example.com'])).toHaveLength(10)
+  })
+
+  it('handles a mix of CIDR, IPv4 and hostname entries', async () => {
+    jest.spyOn(dns, 'resolve4').mockResolvedValue(['198.51.100.5'])
+    expect(await resolveAllowNetHostnames(['10.0.0.0/8', '1.2.3.4', 'host.example.com'])).toEqual([
+      '10.0.0.0/8',
+      '1.2.3.4/32',
+      '198.51.100.5/32',
+    ])
+  })
+})

--- a/apps/api/src/boxlite-rest/mappers/resolve-allow-net.ts
+++ b/apps/api/src/boxlite-rest/mappers/resolve-allow-net.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { promises as dns } from 'dns'
+import { Logger } from '@nestjs/common'
+import { MAX_NETWORK_ALLOW_LIST_ENTRIES } from '../../box/utils/network-validation.util'
+
+const logger = new Logger('resolveAllowNetHostnames')
+
+const CIDR_RE = /^\d{1,3}(\.\d{1,3}){3}\/\d{1,2}$/
+const IPV4_RE = /^\d{1,3}(\.\d{1,3}){3}$/
+
+// Bound the DNS lookup so a slow resolver can't pin the create call.
+// 2s matches the rest of the API's outbound timeouts.
+const DNS_LOOKUP_TIMEOUT_MS = 2_000
+
+/**
+ * Convert `network.allow_net` hostnames to /32 CIDRs at box-create time so the
+ * lower layer can bind egress to concrete IPs instead of trusting a
+ * guest-supplied SNI/Host (audit finding #1, REST-side layer; the gvproxy-side
+ * SNI↔IP binding is the universal layer). CIDR entries pass through unchanged;
+ * bare IPv4 addresses get `/32` appended.
+ *
+ * Hostnames that don't resolve (NXDOMAIN, timeout, refused) are dropped with a
+ * warning rather than failing the whole create call — "any unresolvable hostname
+ * rejects the box" is a sharp footgun for callers whose DNS state is transient.
+ *
+ * Caveat: the resulting /32 list captures the hostname's resolution **at create
+ * time**; records that change later are not reflected. The gvproxy-side filter
+ * (bound to the guest's live sinkhole resolution) covers the dynamic case.
+ */
+export async function resolveAllowNetHostnames(allowNet: string[]): Promise<string[]> {
+  const result: string[] = []
+
+  for (const raw of allowNet) {
+    const entry = raw.trim()
+    if (!entry) continue
+    if (result.length >= MAX_NETWORK_ALLOW_LIST_ENTRIES) {
+      logger.warn(`allow_net cap of ${MAX_NETWORK_ALLOW_LIST_ENTRIES} hit — dropping remaining entries`)
+      break
+    }
+
+    if (CIDR_RE.test(entry)) {
+      result.push(entry)
+      continue
+    }
+    if (IPV4_RE.test(entry)) {
+      result.push(`${entry}/32`)
+      continue
+    }
+
+    // Treat as hostname (incl. wildcard). Resolve to /32 entries.
+    try {
+      const addrs = await resolveWithTimeout(entry, DNS_LOOKUP_TIMEOUT_MS)
+      if (addrs.length === 0) {
+        logger.warn(`allow_net hostname "${entry}" resolved to zero A records — dropped`)
+        continue
+      }
+      for (const a of addrs) {
+        if (result.length >= MAX_NETWORK_ALLOW_LIST_ENTRIES) {
+          logger.warn(`allow_net cap of ${MAX_NETWORK_ALLOW_LIST_ENTRIES} hit while expanding "${entry}" — truncating`)
+          break
+        }
+        result.push(`${a}/32`)
+      }
+    } catch (err: any) {
+      logger.warn(`allow_net hostname "${entry}" resolve failed: ${err?.message ?? err} — dropped`)
+    }
+  }
+
+  return result
+}
+
+async function resolveWithTimeout(hostname: string, timeoutMs: number): Promise<string[]> {
+  let timer: NodeJS.Timeout | undefined
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`DNS lookup timed out after ${timeoutMs}ms`)), timeoutMs)
+  })
+  try {
+    return await Promise.race([dns.resolve4(hostname), timeout])
+  } finally {
+    if (timer) clearTimeout(timer)
+  }
+}


### PR DESCRIPTION
Building on #687, callers passing hostnames in \`BoxOptions.network.allow_net\` saw "no filter at all" because #687's fixup dropped non-CIDR entries to dodge the sandbox-side validator's IPv4-CIDR-only rule. So \`allow_net=['example.com']\` became "default allow" and \`test_allow_net_blocks_unlisted_host\` couldn't enforce.

Pre-resolve hostnames in the create controller. CIDR pass-through, bare IPv4 → \`/32\`, hostname → DNS resolve. Caps at 10 entries (sandbox-side validator's limit) and bounds lookup at 2s.

Caveat in the helper's docs: resolution happens at create time, so records that change while the box is alive aren't reflected. The proper fix is a hostname-aware egress filter inside gvproxy; this is the half-step.

## Test plan — two-sided verified

Pin: \`scripts/test/e2e/cases/test_network_allow_net.py::test_allow_net_blocks_unlisted_host\`

| | Pre-fix (#687 fixup) | Post-fix (this PR) |
|---|---|---|
| \`allow_net=['example.com']\`, wget \`captive.apple.com\` | exit 0 — no filter applied | **nonzero — blocked** |
| \`allow_net=['example.com']\`, wget \`example.com\` | exit 0 (by accident) | exit 0 (by intent, /32 entries cover it) |
| unresolvable hostname e.g. \`allow_net=['not-real.invalid']\` | silently no-op | silently no-op (with warning log) |

Branched off \`fix/rest-boxoptions-network\` (#687) — please merge #687 first.
