### PR TITLE
feat(rest): box state snapshot operations end-to-end (Class A, surface 1)

### DIFF
--- a/apps/api/src/boxlite-rest/boxlite-config.controller.ts
+++ b/apps/api/src/boxlite-rest/boxlite-config.controller.ts
@@ -14,7 +14,7 @@ export class BoxliteConfigController {
   getConfig() {
     return {
       capabilities: {
-        snapshots_enabled: false,
+        snapshots_enabled: true,
         clone_enabled: false,
         export_enabled: false,
         import_enabled: false,

--- a/apps/api/src/boxlite-rest/boxlite-proxy.controller.ts
+++ b/apps/api/src/boxlite-rest/boxlite-proxy.controller.ts
@@ -127,6 +127,55 @@ export class BoxliteProxyController {
     return this.proxyToRunner(authContext, boxId, `/v1/boxes/${boxId}/metrics`, req, res, next)
   }
 
+  @All(':boxId/snapshots')
+  async proxySnapshotsRoot(
+    @AuthContext() authContext: OrganizationAuthContext,
+    @Param('boxId') boxId: string,
+    @Req() req: Request,
+    @Res() res: Response,
+    @Next() next: NextFunction,
+  ) {
+    return this.proxyToRunner(authContext, boxId, `/v1/boxes/${boxId}/snapshots`, req, res, next)
+  }
+
+  @All(':boxId/snapshots/:name')
+  async proxySnapshotNamed(
+    @AuthContext() authContext: OrganizationAuthContext,
+    @Param('boxId') boxId: string,
+    @Param('name') name: string,
+    @Req() req: Request,
+    @Res() res: Response,
+    @Next() next: NextFunction,
+  ) {
+    return this.proxyToRunner(
+      authContext,
+      boxId,
+      `/v1/boxes/${boxId}/snapshots/${encodeURIComponent(name)}`,
+      req,
+      res,
+      next,
+    )
+  }
+
+  @All(':boxId/snapshots/:name/restore')
+  async proxySnapshotRestore(
+    @AuthContext() authContext: OrganizationAuthContext,
+    @Param('boxId') boxId: string,
+    @Param('name') name: string,
+    @Req() req: Request,
+    @Res() res: Response,
+    @Next() next: NextFunction,
+  ) {
+    return this.proxyToRunner(
+      authContext,
+      boxId,
+      `/v1/boxes/${boxId}/snapshots/${encodeURIComponent(name)}/restore`,
+      req,
+      res,
+      next,
+    )
+  }
+
   private async proxyToRunner(
     authContext: OrganizationAuthContext,
     boxId: string,

--- a/apps/runner/pkg/api/controllers/boxlite_snapshot.go
+++ b/apps/runner/pkg/api/controllers/boxlite_snapshot.go
@@ -1,0 +1,162 @@
+package controllers
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	sdkboxlite "github.com/boxlite-ai/boxlite/sdks/go"
+	"github.com/boxlite-ai/runner/pkg/runner"
+	"github.com/gin-gonic/gin"
+)
+
+// Wire-compatible with the SDK's `SnapshotResponse` (Rust side at
+// `src/boxlite/src/rest/types.rs`). Field shape MUST stay in sync — the SDK
+// deserialises straight onto these names.
+type SnapshotInfoResponse struct {
+	ID                 string `json:"id"`
+	BoxID              string `json:"box_id"`
+	Name               string `json:"name"`
+	CreatedAt          int64  `json:"created_at"`
+	ContainerDiskBytes uint64 `json:"container_disk_bytes"`
+	SizeBytes          uint64 `json:"size_bytes"`
+}
+
+type ListSnapshotsResponse struct {
+	Snapshots []SnapshotInfoResponse `json:"snapshots"`
+}
+
+type CreateSnapshotRequest struct {
+	Name string `json:"name"`
+}
+
+func snapshotInfoToResponse(info *sdkboxlite.SnapshotInfo) SnapshotInfoResponse {
+	return SnapshotInfoResponse{
+		ID:                 info.ID,
+		BoxID:              info.BoxID,
+		Name:               info.Name,
+		CreatedAt:          info.CreatedAt,
+		ContainerDiskBytes: info.ContainerDiskBytes,
+		SizeBytes:          info.SizeBytes,
+	}
+}
+
+// classifySnapshotError mirrors classifyExecError's typed-code switch
+// so SDK clients get HTTP shapes consistent across surfaces.
+func classifySnapshotError(err error) int {
+	var bxErr *sdkboxlite.Error
+	if errors.As(err, &bxErr) {
+		switch bxErr.Code {
+		case sdkboxlite.ErrInvalidArgument, sdkboxlite.ErrInvalidState:
+			return http.StatusBadRequest
+		case sdkboxlite.ErrNotFound:
+			return http.StatusNotFound
+		case sdkboxlite.ErrAlreadyExists:
+			return http.StatusConflict
+		case sdkboxlite.ErrUnsupported, sdkboxlite.ErrUnsupportedEngine:
+			return http.StatusNotImplemented
+		case sdkboxlite.ErrResourceExhausted:
+			return http.StatusTooManyRequests
+		}
+	}
+	return http.StatusInternalServerError
+}
+
+func BoxliteSnapshotCreate(ctx *gin.Context) {
+	r, err := runner.GetInstance(nil)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	boxId := ctx.Param("boxId")
+
+	var req CreateSnapshotRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("invalid request: %s", err)})
+		return
+	}
+	if req.Name == "" {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "name is required"})
+		return
+	}
+
+	info, err := r.Boxlite.SnapshotCreate(ctx.Request.Context(), boxId, req.Name)
+	if err != nil {
+		ctx.JSON(classifySnapshotError(err), gin.H{"error": fmt.Sprintf("snapshot create failed: %s", err)})
+		return
+	}
+	ctx.JSON(http.StatusCreated, snapshotInfoToResponse(info))
+}
+
+func BoxliteSnapshotList(ctx *gin.Context) {
+	r, err := runner.GetInstance(nil)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	boxId := ctx.Param("boxId")
+
+	infos, err := r.Boxlite.SnapshotList(ctx.Request.Context(), boxId)
+	if err != nil {
+		ctx.JSON(classifySnapshotError(err), gin.H{"error": fmt.Sprintf("snapshot list failed: %s", err)})
+		return
+	}
+	out := ListSnapshotsResponse{Snapshots: make([]SnapshotInfoResponse, 0, len(infos))}
+	for i := range infos {
+		out.Snapshots = append(out.Snapshots, snapshotInfoToResponse(&infos[i]))
+	}
+	ctx.JSON(http.StatusOK, out)
+}
+
+func BoxliteSnapshotGet(ctx *gin.Context) {
+	r, err := runner.GetInstance(nil)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	boxId := ctx.Param("boxId")
+	name := ctx.Param("name")
+
+	info, err := r.Boxlite.SnapshotGet(ctx.Request.Context(), boxId, name)
+	if err != nil {
+		ctx.JSON(classifySnapshotError(err), gin.H{"error": fmt.Sprintf("snapshot get failed: %s", err)})
+		return
+	}
+	if info == nil {
+		ctx.JSON(http.StatusNotFound, gin.H{"error": fmt.Sprintf("snapshot %q not found", name)})
+		return
+	}
+	ctx.JSON(http.StatusOK, snapshotInfoToResponse(info))
+}
+
+func BoxliteSnapshotRemove(ctx *gin.Context) {
+	r, err := runner.GetInstance(nil)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	boxId := ctx.Param("boxId")
+	name := ctx.Param("name")
+
+	if err := r.Boxlite.SnapshotRemove(ctx.Request.Context(), boxId, name); err != nil {
+		ctx.JSON(classifySnapshotError(err), gin.H{"error": fmt.Sprintf("snapshot remove failed: %s", err)})
+		return
+	}
+	ctx.Status(http.StatusNoContent)
+}
+
+func BoxliteSnapshotRestore(ctx *gin.Context) {
+	r, err := runner.GetInstance(nil)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	boxId := ctx.Param("boxId")
+	name := ctx.Param("name")
+
+	if err := r.Boxlite.SnapshotRestore(ctx.Request.Context(), boxId, name); err != nil {
+		ctx.JSON(classifySnapshotError(err), gin.H{"error": fmt.Sprintf("snapshot restore failed: %s", err)})
+		return
+	}
+	ctx.Status(http.StatusNoContent)
+}

--- a/apps/runner/pkg/api/server.go
+++ b/apps/runner/pkg/api/server.go
@@ -172,6 +172,13 @@ func (a *ApiServer) Start(ctx context.Context) error {
 		boxliteApi.PUT("/:boxId/files", controllers.BoxliteFileUpload)
 		boxliteApi.GET("/:boxId/files", controllers.BoxliteFileDownload)
 		boxliteApi.GET("/:boxId/metrics", controllers.BoxliteMetrics)
+
+		// Box state snapshots (disk snapshot lifecycle).
+		boxliteApi.POST("/:boxId/snapshots", controllers.BoxliteSnapshotCreate)
+		boxliteApi.GET("/:boxId/snapshots", controllers.BoxliteSnapshotList)
+		boxliteApi.GET("/:boxId/snapshots/:name", controllers.BoxliteSnapshotGet)
+		boxliteApi.DELETE("/:boxId/snapshots/:name", controllers.BoxliteSnapshotRemove)
+		boxliteApi.POST("/:boxId/snapshots/:name/restore", controllers.BoxliteSnapshotRestore)
 	}
 
 	a.httpServer = &http.Server{

--- a/apps/runner/pkg/boxlite/client.go
+++ b/apps/runner/pkg/boxlite/client.go
@@ -332,6 +332,51 @@ func (c *Client) Exec(ctx context.Context, sandboxId string, command string, arg
 	}, nil
 }
 
+// SnapshotCreate creates a snapshot of the given sandbox's disk state.
+func (c *Client) SnapshotCreate(ctx context.Context, sandboxId string, name string) (*boxlite.SnapshotInfo, error) {
+	bx, err := c.getOrFetchBox(ctx, sandboxId)
+	if err != nil {
+		return nil, err
+	}
+	return bx.SnapshotCreate(ctx, name)
+}
+
+// SnapshotList lists snapshots for the given sandbox.
+func (c *Client) SnapshotList(ctx context.Context, sandboxId string) ([]boxlite.SnapshotInfo, error) {
+	bx, err := c.getOrFetchBox(ctx, sandboxId)
+	if err != nil {
+		return nil, err
+	}
+	return bx.SnapshotList(ctx)
+}
+
+// SnapshotGet retrieves a snapshot by name; (nil, nil) if missing.
+func (c *Client) SnapshotGet(ctx context.Context, sandboxId string, name string) (*boxlite.SnapshotInfo, error) {
+	bx, err := c.getOrFetchBox(ctx, sandboxId)
+	if err != nil {
+		return nil, err
+	}
+	return bx.SnapshotGet(ctx, name)
+}
+
+// SnapshotRemove deletes a snapshot by name.
+func (c *Client) SnapshotRemove(ctx context.Context, sandboxId string, name string) error {
+	bx, err := c.getOrFetchBox(ctx, sandboxId)
+	if err != nil {
+		return err
+	}
+	return bx.SnapshotRemove(ctx, name)
+}
+
+// SnapshotRestore reverts the sandbox's disks to the named snapshot.
+func (c *Client) SnapshotRestore(ctx context.Context, sandboxId string, name string) error {
+	bx, err := c.getOrFetchBox(ctx, sandboxId)
+	if err != nil {
+		return err
+	}
+	return bx.SnapshotRestore(ctx, name)
+}
+
 // CopyInto copies a file from host into a sandbox.
 func (c *Client) CopyInto(ctx context.Context, sandboxId string, hostSrc, guestDst string) error {
 	bx, err := c.getOrFetchBox(ctx, sandboxId)

--- a/apps/runner/pkg/boxlite/client.go
+++ b/apps/runner/pkg/boxlite/client.go
@@ -332,9 +332,68 @@ func (c *Client) Exec(ctx context.Context, sandboxId string, command string, arg
 	}, nil
 }
 
+// quiesceBox waits for the runner-side libboxlite view of `sandboxId`
+// to settle before handing the Box to a snapshot operation that needs
+// a stable shim. The REST stop path is asynchronous (the API writes
+// `desiredState=STOPPED` and emits an event; runner.Stop() runs later
+// from the event handler), so back-to-back `b.stop() ; b.snapshot.
+// create(...)` calls can hit the snapshot endpoint while the shim is
+// still being torn down. Libboxlite's snapshot path needs to SIGSTOP
+// the shim via its control socket — mid-teardown the socket refuses
+// connection (ECONNREFUSED → "Failed to SIGSTOP shim process").
+//
+// Mechanism:
+//   - Drop any cached Go SDK Box handle, so the next getOrFetchBox is
+//     a fresh `runtime.Get` (matches the local-FFI pattern in
+//     `src/boxlite/tests/snapshot.rs::create_stopped_box`).
+//   - Apply a baseline 5s settle window. Empirically the API event
+//     handler takes 3–5s to flush, and the bx.Info() State field
+//     flips to "stopped" before libboxlite has finished releasing the
+//     shim's control socket, so a polling-only loop sees a green
+//     light too early.
+//   - Then poll up to 30s for State to leave the Configured/Stopping
+//     transient bucket.
+func (c *Client) quiesceBox(ctx context.Context, sandboxId string) (*boxlite.Box, error) {
+	const (
+		pollInterval = 250 * time.Millisecond
+		timeout      = 30 * time.Second
+	)
+	time.Sleep(5 * time.Second)
+	deadline := time.Now().Add(timeout)
+
+	for {
+		c.mu.Lock()
+		if bx, ok := c.boxes[sandboxId]; ok {
+			bx.Close()
+			delete(c.boxes, sandboxId)
+		}
+		c.mu.Unlock()
+
+		bx, err := c.getOrFetchBox(ctx, sandboxId)
+		if err != nil {
+			return nil, err
+		}
+		info, infoErr := bx.Info(ctx)
+		if infoErr == nil && info.State != boxlite.StateConfigured && info.State != boxlite.StateStopping {
+			return bx, nil
+		}
+		if time.Now().After(deadline) {
+			// Fall through with the latest handle — let libboxlite
+			// surface the real error rather than masking it with a
+			// generic timeout from this layer.
+			return bx, nil
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(pollInterval):
+		}
+	}
+}
+
 // SnapshotCreate creates a snapshot of the given sandbox's disk state.
 func (c *Client) SnapshotCreate(ctx context.Context, sandboxId string, name string) (*boxlite.SnapshotInfo, error) {
-	bx, err := c.getOrFetchBox(ctx, sandboxId)
+	bx, err := c.quiesceBox(ctx, sandboxId)
 	if err != nil {
 		return nil, err
 	}
@@ -370,7 +429,7 @@ func (c *Client) SnapshotRemove(ctx context.Context, sandboxId string, name stri
 
 // SnapshotRestore reverts the sandbox's disks to the named snapshot.
 func (c *Client) SnapshotRestore(ctx context.Context, sandboxId string, name string) error {
-	bx, err := c.getOrFetchBox(ctx, sandboxId)
+	bx, err := c.quiesceBox(ctx, sandboxId)
 	if err != nil {
 		return err
 	}

--- a/scripts/test/e2e/cases/test_snapshot_clone.py
+++ b/scripts/test/e2e/cases/test_snapshot_clone.py
@@ -1,0 +1,171 @@
+"""E2E port of `src/boxlite/tests/snapshot.rs` + `clone_export_import.rs`.
+
+Verifies the snapshot / clone / export / import chain through the REST
+runtime. The Rust FFI suite has ~67 sub-cases across these files; we
+mirror only the round-trips that prove disk content actually crosses
+the SDK → API → Runner → VM boundary intact:
+
+  - snapshot.create produces an id that snapshot.list reports
+  - snapshot.restore re-materializes earlier guest disk state
+  - clone_box yields an independent disk (write to clone doesn't leak
+    to the parent)
+  - export → import round-trip preserves a guest-side file
+
+Anything covered by FFI alone (snapshot metadata fields, options
+parsing, error variants) stays in the FFI suite — re-running it here
+just burns VMs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import tempfile
+from pathlib import Path
+
+import boxlite
+import pytest
+
+from conftest import drain
+
+
+async def _put_file(b, path: str, content: str) -> None:
+    ex = await b.exec("sh", ["-c", f"mkdir -p $(dirname {path}) && printf %s {content!r} > {path}"], None)
+    await drain(ex)
+    rc = await asyncio.wait_for(ex.wait(), timeout=30)
+    assert rc.exit_code == 0, f"seed write failed: rc={rc.exit_code}"
+
+
+async def _read_file(b, path: str) -> tuple[int, str]:
+    ex = await b.exec("cat", [path], None)
+    out, _ = await drain(ex)
+    rc = await asyncio.wait_for(ex.wait(), timeout=30)
+    return rc.exit_code, out
+
+
+@pytest.mark.asyncio
+async def test_snapshot_create_appears_in_list(rt, image):
+    """A box snapshot's name shows up in snapshot.list() right away.
+    This is the smallest hop in the snapshot REST path — if the create
+    call silently no-ops, list will catch it."""
+    b = await rt.create(boxlite.BoxOptions(image=image, auto_remove=False))
+    try:
+        await b.stop()  # snapshots typically require a quiesced box
+        snap = await b.snapshot.create(name="e2e-snap-1")
+        assert snap is not None and snap.name == "e2e-snap-1", (
+            f"snapshot.create returned wrong shape: {snap}"
+        )
+        listed = await b.snapshot.list()
+        names = {s.name for s in listed}
+        assert "e2e-snap-1" in names, (
+            f"snapshot.list missed created snapshot: {names}"
+        )
+    finally:
+        try:
+            await rt.remove(b.id, force=True)
+        except Exception:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_snapshot_restore_reverts_disk(rt, image):
+    """Write content A, snapshot, write content B, restore: disk reads
+    A again. This is the disk-roundtrip contract — any silent
+    serialization bug in the snapshot REST path drops bytes here."""
+    b = await rt.create(boxlite.BoxOptions(image=image, auto_remove=False))
+    try:
+        await _put_file(b, "/var/state", "before-snapshot")
+        await b.stop()
+        await b.snapshot.create(name="e2e-restore")
+        await b.start()
+        await _put_file(b, "/var/state", "after-snapshot")
+        rc, out = await _read_file(b, "/var/state")
+        assert rc == 0 and out == "after-snapshot", (
+            f"sanity: pre-restore state wrong: rc={rc} out={out!r}"
+        )
+
+        await b.stop()
+        await b.snapshot.restore("e2e-restore")
+        await b.start()
+        rc, out = await _read_file(b, "/var/state")
+        assert rc == 0, f"read after restore failed: rc={rc}"
+        assert out == "before-snapshot", (
+            f"snapshot.restore did not revert disk: got {out!r}"
+        )
+    finally:
+        try:
+            await rt.remove(b.id, force=True)
+        except Exception:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_clone_box_yields_independent_disk(rt, image):
+    """Clone the box, then write to the clone. The original's disk
+    must not see the write — proves clone made a copy, not a shared
+    reference."""
+    parent = await rt.create(boxlite.BoxOptions(image=image, auto_remove=False))
+    clone = None
+    try:
+        await _put_file(parent, "/var/shared", "from-parent")
+        await parent.stop()
+        clone = await parent.clone_box(name=None)
+        await parent.start()
+        await clone.start()
+
+        # Mutate the clone, not the parent.
+        await _put_file(clone, "/var/shared", "from-clone")
+
+        rc_p, out_p = await _read_file(parent, "/var/shared")
+        rc_c, out_c = await _read_file(clone, "/var/shared")
+        assert rc_p == 0 and rc_c == 0
+        assert out_p == "from-parent", (
+            f"clone write leaked to parent: parent now {out_p!r}"
+        )
+        assert out_c == "from-clone", (
+            f"clone disk write didn't stick: clone shows {out_c!r}"
+        )
+    finally:
+        for box_handle in (clone, parent):
+            if box_handle is None:
+                continue
+            try:
+                await rt.remove(box_handle.id, force=True)
+            except Exception:
+                pass
+
+
+@pytest.mark.asyncio
+async def test_export_import_roundtrip(rt, image):
+    """Export a box to a `.boxlite` archive, import it as a new box,
+    and confirm guest-side state crossed the archive boundary."""
+    src = await rt.create(boxlite.BoxOptions(image=image, auto_remove=False))
+    imported = None
+    archive_path = None
+    try:
+        marker = "e2e-export-marker-" + os.urandom(4).hex()
+        await _put_file(src, "/var/marker", marker)
+        await src.stop()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dest = str(Path(tmpdir) / "box.boxlite")
+            archive_path = await src.export(dest=dest)
+            assert archive_path and os.path.exists(archive_path), (
+                f"export returned {archive_path!r} but file is missing"
+            )
+
+            imported = await rt.import_box(archive_path, name=None)
+            await imported.start()
+            rc, out = await _read_file(imported, "/var/marker")
+        assert rc == 0, f"read after import failed: rc={rc}"
+        assert out == marker, (
+            f"export/import lost marker: expected {marker!r}, got {out!r}"
+        )
+    finally:
+        for box_handle in (imported, src):
+            if box_handle is None:
+                continue
+            try:
+                await rt.remove(box_handle.id, force=True)
+            except Exception:
+                pass

--- a/sdks/c/include/boxlite.h
+++ b/sdks/c/include/boxlite.h
@@ -297,6 +297,33 @@ typedef struct BoxliteImageRegistry {
 // Runtime shutdown completion.
 typedef void (*CRuntimeShutdownCb)(CBoxliteError*, void*);
 
+typedef struct CSnapshotInfo {
+  char *id;
+  char *box_id;
+  char *name;
+  int64_t created_at;
+  uint64_t container_disk_bytes;
+  uint64_t size_bytes;
+} CSnapshotInfo;
+
+// Snapshot create / get completion. Both ops return a single
+// `CSnapshotInfo` so they share the callback shape.
+typedef void (*CBoxSnapshotCreateCb)(struct CSnapshotInfo*, CBoxliteError*, void*);
+
+typedef struct CSnapshotInfoList {
+  struct CSnapshotInfo *items;
+  int count;
+} CSnapshotInfoList;
+
+// Snapshot list completion.
+typedef void (*CBoxSnapshotListCb)(struct CSnapshotInfoList*, CBoxliteError*, void*);
+
+// Snapshot remove completion.
+typedef void (*CBoxSnapshotRemoveCb)(CBoxliteError*, void*);
+
+// Snapshot restore completion.
+typedef void (*CBoxSnapshotRestoreCb)(CBoxliteError*, void*);
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
@@ -647,6 +674,39 @@ void boxlite_runtime_free(CBoxliteRuntime *runtime);
 //
 // Returns the number of dispatched events, or `-1` on error.
 int boxlite_runtime_drain(CBoxliteRuntime *runtime, int timeout_ms, CBoxliteError *out_error);
+
+enum BoxliteErrorCode boxlite_box_snapshot_create(CBoxHandle *handle,
+                                                  const char *name,
+                                                  CBoxSnapshotCreateCb cb,
+                                                  void *user_data,
+                                                  CBoxliteError *out_error);
+
+enum BoxliteErrorCode boxlite_box_snapshot_list(CBoxHandle *handle,
+                                                CBoxSnapshotListCb cb,
+                                                void *user_data,
+                                                CBoxliteError *out_error);
+
+enum BoxliteErrorCode boxlite_box_snapshot_get(CBoxHandle *handle,
+                                               const char *name,
+                                               CBoxSnapshotCreateCb cb,
+                                               void *user_data,
+                                               CBoxliteError *out_error);
+
+enum BoxliteErrorCode boxlite_box_snapshot_remove(CBoxHandle *handle,
+                                                  const char *name,
+                                                  CBoxSnapshotRemoveCb cb,
+                                                  void *user_data,
+                                                  CBoxliteError *out_error);
+
+enum BoxliteErrorCode boxlite_box_snapshot_restore(CBoxHandle *handle,
+                                                   const char *name,
+                                                   CBoxSnapshotRestoreCb cb,
+                                                   void *user_data,
+                                                   CBoxliteError *out_error);
+
+void boxlite_free_snapshot_info(struct CSnapshotInfo *info);
+
+void boxlite_free_snapshot_info_list(struct CSnapshotInfoList *list);
 
 void boxlite_free_string(char *s);
 

--- a/sdks/c/src/event_queue.rs
+++ b/sdks/c/src/event_queue.rs
@@ -160,6 +160,33 @@ pub(crate) type CExecutionSignalFn = extern "C" fn(*mut crate::CBoxliteError, *m
 pub type CExecutionResizeCb = Option<extern "C" fn(*mut crate::CBoxliteError, *mut c_void)>;
 pub(crate) type CExecutionResizeFn = extern "C" fn(*mut crate::CBoxliteError, *mut c_void);
 
+/// Snapshot create / get completion. Both ops return a single
+/// `CSnapshotInfo` so they share the callback shape.
+pub type CBoxSnapshotCreateCb = Option<
+    extern "C" fn(*mut crate::snapshot::CSnapshotInfo, *mut crate::CBoxliteError, *mut c_void),
+>;
+pub(crate) type CBoxSnapshotCreateFn =
+    extern "C" fn(*mut crate::snapshot::CSnapshotInfo, *mut crate::CBoxliteError, *mut c_void);
+
+/// Snapshot list completion.
+pub type CBoxSnapshotListCb = Option<
+    extern "C" fn(
+        *mut crate::snapshot::CSnapshotInfoList,
+        *mut crate::CBoxliteError,
+        *mut c_void,
+    ),
+>;
+pub(crate) type CBoxSnapshotListFn =
+    extern "C" fn(*mut crate::snapshot::CSnapshotInfoList, *mut crate::CBoxliteError, *mut c_void);
+
+/// Snapshot remove completion.
+pub type CBoxSnapshotRemoveCb = Option<extern "C" fn(*mut crate::CBoxliteError, *mut c_void)>;
+pub(crate) type CBoxSnapshotRemoveFn = extern "C" fn(*mut crate::CBoxliteError, *mut c_void);
+
+/// Snapshot restore completion.
+pub type CBoxSnapshotRestoreCb = Option<extern "C" fn(*mut crate::CBoxliteError, *mut c_void)>;
+pub(crate) type CBoxSnapshotRestoreFn = extern "C" fn(*mut crate::CBoxliteError, *mut c_void);
+
 // ─── Owned FFI payload ─────────────────────────────────────────────────────
 //
 // Wraps a `Box::into_raw`'d FFI struct that will eventually be transferred
@@ -354,6 +381,28 @@ pub enum RuntimeEvent {
     },
     Resize {
         cb: CExecutionResizeFn,
+        user_data: usize,
+        result: Result<(), BoxliteError>,
+    },
+
+    /* Snapshots */
+    SnapshotCreate {
+        cb: CBoxSnapshotCreateFn,
+        user_data: usize,
+        result: Result<OwnedFfiPtr<crate::snapshot::CSnapshotInfo>, BoxliteError>,
+    },
+    SnapshotList {
+        cb: CBoxSnapshotListFn,
+        user_data: usize,
+        result: Result<OwnedFfiPtr<crate::snapshot::CSnapshotInfoList>, BoxliteError>,
+    },
+    SnapshotRemove {
+        cb: CBoxSnapshotRemoveFn,
+        user_data: usize,
+        result: Result<(), BoxliteError>,
+    },
+    SnapshotRestore {
+        cb: CBoxSnapshotRestoreFn,
         user_data: usize,
         result: Result<(), BoxliteError>,
     },

--- a/sdks/c/src/lib.rs
+++ b/sdks/c/src/lib.rs
@@ -18,6 +18,7 @@ mod metrics;
 mod options;
 mod rest;
 mod runtime;
+pub mod snapshot;
 #[cfg(test)]
 mod tests;
 mod util;

--- a/sdks/c/src/runtime.rs
+++ b/sdks/c/src/runtime.rs
@@ -577,6 +577,26 @@ unsafe fn dispatch_event(event: RuntimeEvent) {
                 user_data,
                 result,
             } => dispatch_unit_event(result, user_data, cb),
+            RuntimeEvent::SnapshotCreate {
+                cb,
+                user_data,
+                result,
+            } => dispatch_handle_event::<crate::snapshot::CSnapshotInfo>(result, user_data, cb),
+            RuntimeEvent::SnapshotList {
+                cb,
+                user_data,
+                result,
+            } => dispatch_handle_event::<crate::snapshot::CSnapshotInfoList>(result, user_data, cb),
+            RuntimeEvent::SnapshotRemove {
+                cb,
+                user_data,
+                result,
+            } => dispatch_unit_event(result, user_data, cb),
+            RuntimeEvent::SnapshotRestore {
+                cb,
+                user_data,
+                result,
+            } => dispatch_unit_event(result, user_data, cb),
         }
     }
 }

--- a/sdks/c/src/snapshot.rs
+++ b/sdks/c/src/snapshot.rs
@@ -1,0 +1,412 @@
+//! Box state snapshot operations for the BoxLite C SDK.
+//!
+//! Exposes the five snapshot lifecycle ops the Rust core already supports
+//! (`LiteBox::snapshots().create / list / get / restore / remove`) across
+//! the C ABI. Async + callback shape matches the rest of the SDK
+//! (copy_into / box info / get_info etc.) so the post-and-drain queue
+//! delivers results on the host's drain thread, never on a Tokio worker.
+
+use std::ffi::CString;
+use std::os::raw::{c_char, c_int, c_void};
+use std::ptr;
+
+use boxlite::BoxliteError;
+use boxlite::runtime::options::SnapshotOptions;
+
+use crate::box_handle::BoxHandle;
+use crate::error::{BoxliteErrorCode, FFIError, null_pointer_error, write_error};
+use crate::event_queue::{
+    CBoxSnapshotCreateCb, CBoxSnapshotListCb, CBoxSnapshotRemoveCb, CBoxSnapshotRestoreCb,
+    OwnedFfiPtr, RuntimeEvent, push_event,
+};
+use crate::{CBoxHandle, CBoxliteError};
+
+// ─── FFI types ─────────────────────────────────────────────────────────────
+
+#[repr(C)]
+pub struct CSnapshotInfo {
+    pub id: *mut c_char,
+    pub box_id: *mut c_char,
+    pub name: *mut c_char,
+    pub created_at: i64,
+    pub container_disk_bytes: u64,
+    pub size_bytes: u64,
+}
+
+#[repr(C)]
+pub struct CSnapshotInfoList {
+    pub items: *mut CSnapshotInfo,
+    pub count: c_int,
+}
+
+fn to_c_str(s: &str) -> *mut c_char {
+    CString::new(s)
+        .map(|c| c.into_raw())
+        .unwrap_or(ptr::null_mut())
+}
+
+unsafe fn free_str(s: *mut c_char) {
+    if !s.is_null() {
+        unsafe {
+            drop(CString::from_raw(s));
+        }
+    }
+}
+
+impl CSnapshotInfo {
+    pub fn from_snapshot_info(info: &boxlite::SnapshotInfo) -> Self {
+        Self {
+            id: to_c_str(&info.id),
+            box_id: to_c_str(&info.box_id),
+            name: to_c_str(&info.name),
+            created_at: info.created_at,
+            container_disk_bytes: info.disk_info.container_disk_bytes,
+            size_bytes: info.disk_info.size_bytes,
+        }
+    }
+}
+
+pub unsafe fn free_snapshot_info(info: *mut CSnapshotInfo) {
+    unsafe {
+        if info.is_null() {
+            return;
+        }
+        let r = &mut *info;
+        free_str(r.id);
+        free_str(r.box_id);
+        free_str(r.name);
+    }
+}
+
+pub unsafe fn free_snapshot_info_ptr(info: *mut CSnapshotInfo) {
+    unsafe {
+        if info.is_null() {
+            return;
+        }
+        free_snapshot_info(info);
+        drop(Box::from_raw(info));
+    }
+}
+
+pub unsafe fn free_snapshot_info_list(list: *mut CSnapshotInfoList) {
+    unsafe {
+        if list.is_null() {
+            return;
+        }
+        let l = &mut *list;
+        for idx in 0..l.count {
+            free_snapshot_info(l.items.add(idx as usize));
+        }
+        if !l.items.is_null() {
+            drop(Vec::from_raw_parts(
+                l.items,
+                l.count as usize,
+                l.count as usize,
+            ));
+        }
+        drop(Box::from_raw(list));
+    }
+}
+
+// ─── FFI entry points ──────────────────────────────────────────────────────
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_box_snapshot_create(
+    handle: *mut CBoxHandle,
+    name: *const c_char,
+    cb: CBoxSnapshotCreateCb,
+    user_data: *mut c_void,
+    out_error: *mut CBoxliteError,
+) -> BoxliteErrorCode {
+    box_snapshot_create(handle, name, cb, user_data, out_error)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_box_snapshot_list(
+    handle: *mut CBoxHandle,
+    cb: CBoxSnapshotListCb,
+    user_data: *mut c_void,
+    out_error: *mut CBoxliteError,
+) -> BoxliteErrorCode {
+    box_snapshot_list(handle, cb, user_data, out_error)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_box_snapshot_get(
+    handle: *mut CBoxHandle,
+    name: *const c_char,
+    cb: CBoxSnapshotCreateCb,
+    user_data: *mut c_void,
+    out_error: *mut CBoxliteError,
+) -> BoxliteErrorCode {
+    box_snapshot_get(handle, name, cb, user_data, out_error)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_box_snapshot_remove(
+    handle: *mut CBoxHandle,
+    name: *const c_char,
+    cb: CBoxSnapshotRemoveCb,
+    user_data: *mut c_void,
+    out_error: *mut CBoxliteError,
+) -> BoxliteErrorCode {
+    box_snapshot_remove(handle, name, cb, user_data, out_error)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_box_snapshot_restore(
+    handle: *mut CBoxHandle,
+    name: *const c_char,
+    cb: CBoxSnapshotRestoreCb,
+    user_data: *mut c_void,
+    out_error: *mut CBoxliteError,
+) -> BoxliteErrorCode {
+    box_snapshot_restore(handle, name, cb, user_data, out_error)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_free_snapshot_info(info: *mut CSnapshotInfo) {
+    free_snapshot_info_ptr(info)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_free_snapshot_info_list(list: *mut CSnapshotInfoList) {
+    free_snapshot_info_list(list)
+}
+
+// ─── internals ─────────────────────────────────────────────────────────────
+
+unsafe fn box_snapshot_create(
+    handle: *mut BoxHandle,
+    name: *const c_char,
+    cb: CBoxSnapshotCreateCb,
+    user_data: *mut c_void,
+    out_error: *mut FFIError,
+) -> BoxliteErrorCode {
+    unsafe {
+        if handle.is_null() {
+            write_error(out_error, null_pointer_error("handle"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        let name = match crate::util::c_str_to_string(name) {
+            Ok(s) => s,
+            Err(e) => {
+                write_error(out_error, e);
+                return BoxliteErrorCode::InvalidArgument;
+            }
+        };
+        let cb = crate::unwrap_cb_or_return!(cb, out_error);
+
+        let handle_ref = &*handle;
+        let lite = handle_ref.handle.clone();
+        let queue = handle_ref.queue.clone();
+        let user_data_addr = user_data as usize;
+
+        handle_ref.tokio_rt.spawn(async move {
+            let result = lite
+                .snapshots()
+                .create(SnapshotOptions::default(), &name)
+                .await
+                .map(|info| {
+                    OwnedFfiPtr::new_with(
+                        Box::new(CSnapshotInfo::from_snapshot_info(&info)),
+                        free_snapshot_info_ptr,
+                    )
+                });
+            push_event(
+                &queue,
+                RuntimeEvent::SnapshotCreate {
+                    cb,
+                    user_data: user_data_addr,
+                    result,
+                },
+            )
+            .await;
+        });
+
+        BoxliteErrorCode::Ok
+    }
+}
+
+unsafe fn box_snapshot_list(
+    handle: *mut BoxHandle,
+    cb: CBoxSnapshotListCb,
+    user_data: *mut c_void,
+    out_error: *mut FFIError,
+) -> BoxliteErrorCode {
+    unsafe {
+        if handle.is_null() {
+            write_error(out_error, null_pointer_error("handle"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        let cb = crate::unwrap_cb_or_return!(cb, out_error);
+
+        let handle_ref = &*handle;
+        let lite = handle_ref.handle.clone();
+        let queue = handle_ref.queue.clone();
+        let user_data_addr = user_data as usize;
+
+        handle_ref.tokio_rt.spawn(async move {
+            let result = lite.snapshots().list().await.map(|infos| {
+                let mut items: Vec<CSnapshotInfo> = infos
+                    .iter()
+                    .map(CSnapshotInfo::from_snapshot_info)
+                    .collect();
+                let count = items.len() as c_int;
+                let ptr = items.as_mut_ptr();
+                std::mem::forget(items);
+                OwnedFfiPtr::new_with(
+                    Box::new(CSnapshotInfoList { items: ptr, count }),
+                    free_snapshot_info_list,
+                )
+            });
+            push_event(
+                &queue,
+                RuntimeEvent::SnapshotList {
+                    cb,
+                    user_data: user_data_addr,
+                    result,
+                },
+            )
+            .await;
+        });
+
+        BoxliteErrorCode::Ok
+    }
+}
+
+unsafe fn box_snapshot_get(
+    handle: *mut BoxHandle,
+    name: *const c_char,
+    cb: CBoxSnapshotCreateCb,
+    user_data: *mut c_void,
+    out_error: *mut FFIError,
+) -> BoxliteErrorCode {
+    unsafe {
+        if handle.is_null() {
+            write_error(out_error, null_pointer_error("handle"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        let name = match crate::util::c_str_to_string(name) {
+            Ok(s) => s,
+            Err(e) => {
+                write_error(out_error, e);
+                return BoxliteErrorCode::InvalidArgument;
+            }
+        };
+        let cb = crate::unwrap_cb_or_return!(cb, out_error);
+
+        let handle_ref = &*handle;
+        let lite = handle_ref.handle.clone();
+        let queue = handle_ref.queue.clone();
+        let user_data_addr = user_data as usize;
+
+        handle_ref.tokio_rt.spawn(async move {
+            let result = match lite.snapshots().get(&name).await {
+                Ok(Some(info)) => Ok(OwnedFfiPtr::new_with(
+                    Box::new(CSnapshotInfo::from_snapshot_info(&info)),
+                    free_snapshot_info_ptr,
+                )),
+                Ok(None) => Err(BoxliteError::NotFound(format!("snapshot not found: {name}"))),
+                Err(e) => Err(e),
+            };
+            push_event(
+                &queue,
+                RuntimeEvent::SnapshotCreate {
+                    cb,
+                    user_data: user_data_addr,
+                    result,
+                },
+            )
+            .await;
+        });
+
+        BoxliteErrorCode::Ok
+    }
+}
+
+unsafe fn box_snapshot_remove(
+    handle: *mut BoxHandle,
+    name: *const c_char,
+    cb: CBoxSnapshotRemoveCb,
+    user_data: *mut c_void,
+    out_error: *mut FFIError,
+) -> BoxliteErrorCode {
+    unsafe {
+        if handle.is_null() {
+            write_error(out_error, null_pointer_error("handle"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        let name = match crate::util::c_str_to_string(name) {
+            Ok(s) => s,
+            Err(e) => {
+                write_error(out_error, e);
+                return BoxliteErrorCode::InvalidArgument;
+            }
+        };
+        let cb = crate::unwrap_cb_or_return!(cb, out_error);
+
+        let handle_ref = &*handle;
+        let lite = handle_ref.handle.clone();
+        let queue = handle_ref.queue.clone();
+        let user_data_addr = user_data as usize;
+
+        handle_ref.tokio_rt.spawn(async move {
+            let result = lite.snapshots().remove(&name).await;
+            push_event(
+                &queue,
+                RuntimeEvent::SnapshotRemove {
+                    cb,
+                    user_data: user_data_addr,
+                    result,
+                },
+            )
+            .await;
+        });
+
+        BoxliteErrorCode::Ok
+    }
+}
+
+unsafe fn box_snapshot_restore(
+    handle: *mut BoxHandle,
+    name: *const c_char,
+    cb: CBoxSnapshotRestoreCb,
+    user_data: *mut c_void,
+    out_error: *mut FFIError,
+) -> BoxliteErrorCode {
+    unsafe {
+        if handle.is_null() {
+            write_error(out_error, null_pointer_error("handle"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        let name = match crate::util::c_str_to_string(name) {
+            Ok(s) => s,
+            Err(e) => {
+                write_error(out_error, e);
+                return BoxliteErrorCode::InvalidArgument;
+            }
+        };
+        let cb = crate::unwrap_cb_or_return!(cb, out_error);
+
+        let handle_ref = &*handle;
+        let lite = handle_ref.handle.clone();
+        let queue = handle_ref.queue.clone();
+        let user_data_addr = user_data as usize;
+
+        handle_ref.tokio_rt.spawn(async move {
+            let result = lite.snapshots().restore(&name).await;
+            push_event(
+                &queue,
+                RuntimeEvent::SnapshotRestore {
+                    cb,
+                    user_data: user_data_addr,
+                    result,
+                },
+            )
+            .await;
+        });
+
+        BoxliteErrorCode::Ok
+    }
+}

--- a/sdks/go/bridge.c
+++ b/sdks/go/bridge.c
@@ -35,6 +35,11 @@ extern void goBoxliteOnExecutionKill(CBoxliteError *err, void *ud);
 extern void goBoxliteOnExecutionSignal(CBoxliteError *err, void *ud);
 extern void goBoxliteOnExecutionResize(CBoxliteError *err, void *ud);
 
+extern void goBoxliteOnSnapshotCreate(CSnapshotInfo *info, CBoxliteError *err, void *ud);
+extern void goBoxliteOnSnapshotList(CSnapshotInfoList *list, CBoxliteError *err, void *ud);
+extern void goBoxliteOnSnapshotRemove(CBoxliteError *err, void *ud);
+extern void goBoxliteOnSnapshotRestore(CBoxliteError *err, void *ud);
+
 CBoxStdoutCb cbStdout(void) { return (CBoxStdoutCb)goBoxliteOnStdout; }
 CBoxStderrCb cbStderr(void) { return (CBoxStderrCb)goBoxliteOnStderr; }
 CBoxExitCb cbExit(void) { return (CBoxExitCb)goBoxliteOnExit; }
@@ -61,3 +66,8 @@ CExecutionWaitCb cbExecutionWait(void) { return (CExecutionWaitCb)goBoxliteOnExe
 CExecutionKillCb cbExecutionKill(void) { return (CExecutionKillCb)goBoxliteOnExecutionKill; }
 CExecutionSignalCb cbExecutionSignal(void) { return (CExecutionSignalCb)goBoxliteOnExecutionSignal; }
 CExecutionResizeCb cbExecutionResize(void) { return (CExecutionResizeCb)goBoxliteOnExecutionResize; }
+
+CBoxSnapshotCreateCb cbSnapshotCreate(void) { return (CBoxSnapshotCreateCb)goBoxliteOnSnapshotCreate; }
+CBoxSnapshotListCb cbSnapshotList(void) { return (CBoxSnapshotListCb)goBoxliteOnSnapshotList; }
+CBoxSnapshotRemoveCb cbSnapshotRemove(void) { return (CBoxSnapshotRemoveCb)goBoxliteOnSnapshotRemove; }
+CBoxSnapshotRestoreCb cbSnapshotRestore(void) { return (CBoxSnapshotRestoreCb)goBoxliteOnSnapshotRestore; }

--- a/sdks/go/bridge.h
+++ b/sdks/go/bridge.h
@@ -34,4 +34,9 @@ extern CExecutionKillCb cbExecutionKill(void);
 extern CExecutionSignalCb cbExecutionSignal(void);
 extern CExecutionResizeCb cbExecutionResize(void);
 
+extern CBoxSnapshotCreateCb cbSnapshotCreate(void);
+extern CBoxSnapshotListCb cbSnapshotList(void);
+extern CBoxSnapshotRemoveCb cbSnapshotRemove(void);
+extern CBoxSnapshotRestoreCb cbSnapshotRestore(void);
+
 #endif // BOXLITE_GO_BRIDGE_H

--- a/sdks/go/snapshot.go
+++ b/sdks/go/snapshot.go
@@ -1,0 +1,308 @@
+package boxlite
+
+/*
+#include "bridge.h"
+#include <stdlib.h>
+*/
+import "C"
+import (
+	"context"
+	"runtime/cgo"
+	"unsafe"
+)
+
+// SnapshotInfo describes a box state snapshot.
+type SnapshotInfo struct {
+	ID                  string
+	BoxID               string
+	Name                string
+	CreatedAt           int64
+	ContainerDiskBytes  uint64
+	SizeBytes           uint64
+}
+
+type snapshotCreateResult struct {
+	value *SnapshotInfo
+	err   error
+}
+
+type snapshotListResult struct {
+	value []SnapshotInfo
+	err   error
+}
+
+// SnapshotCreate creates a snapshot of the box's current disk state with the
+// given name.
+func (b *Box) SnapshotCreate(ctx context.Context, name string) (*SnapshotInfo, error) {
+	b.runtime.ensureDrainRunning()
+
+	cName := toCString(name)
+	defer C.free(unsafe.Pointer(cName))
+
+	ch := make(chan snapshotCreateResult, 1)
+	h := registerHandleForDispatch(cgo.NewHandle(ch))
+
+	var cerr C.CBoxliteError
+	code := C.boxlite_box_snapshot_create(b.handle, cName, C.cbSnapshotCreate(), handleToPtr(h), &cerr)
+	if code != C.Ok {
+		deleteHandleForDispatch(h)
+		return nil, freeError(&cerr)
+	}
+
+	select {
+	case res := <-ch:
+		return res.value, res.err
+	case <-ctx.Done():
+		drainAndDelete(ch, h, b.runtime.closing)
+		return nil, ctx.Err()
+	case <-b.runtime.closing:
+		drainAndDelete(ch, h, b.runtime.closing)
+		return nil, ErrRuntimeClosed
+	}
+}
+
+// SnapshotList returns every snapshot belonging to this box.
+func (b *Box) SnapshotList(ctx context.Context) ([]SnapshotInfo, error) {
+	b.runtime.ensureDrainRunning()
+
+	ch := make(chan snapshotListResult, 1)
+	h := registerHandleForDispatch(cgo.NewHandle(ch))
+
+	var cerr C.CBoxliteError
+	code := C.boxlite_box_snapshot_list(b.handle, C.cbSnapshotList(), handleToPtr(h), &cerr)
+	if code != C.Ok {
+		deleteHandleForDispatch(h)
+		return nil, freeError(&cerr)
+	}
+
+	select {
+	case res := <-ch:
+		return res.value, res.err
+	case <-ctx.Done():
+		drainAndDelete(ch, h, b.runtime.closing)
+		return nil, ctx.Err()
+	case <-b.runtime.closing:
+		drainAndDelete(ch, h, b.runtime.closing)
+		return nil, ErrRuntimeClosed
+	}
+}
+
+// SnapshotGet looks up a snapshot by name. Returns (nil, nil) when the
+// snapshot is not present (404).
+func (b *Box) SnapshotGet(ctx context.Context, name string) (*SnapshotInfo, error) {
+	b.runtime.ensureDrainRunning()
+
+	cName := toCString(name)
+	defer C.free(unsafe.Pointer(cName))
+
+	ch := make(chan snapshotCreateResult, 1)
+	h := registerHandleForDispatch(cgo.NewHandle(ch))
+
+	var cerr C.CBoxliteError
+	code := C.boxlite_box_snapshot_get(b.handle, cName, C.cbSnapshotCreate(), handleToPtr(h), &cerr)
+	if code != C.Ok {
+		deleteHandleForDispatch(h)
+		return nil, freeError(&cerr)
+	}
+
+	select {
+	case res := <-ch:
+		if res.err != nil {
+			// "snapshot not found" surfaces from libboxlite as NotFound; the
+			// caller-friendly shape is (nil, nil).
+			if be, ok := res.err.(*Error); ok && be.Code == ErrNotFound {
+				return nil, nil
+			}
+			return nil, res.err
+		}
+		return res.value, nil
+	case <-ctx.Done():
+		drainAndDelete(ch, h, b.runtime.closing)
+		return nil, ctx.Err()
+	case <-b.runtime.closing:
+		drainAndDelete(ch, h, b.runtime.closing)
+		return nil, ErrRuntimeClosed
+	}
+}
+
+// SnapshotRemove deletes the named snapshot.
+func (b *Box) SnapshotRemove(ctx context.Context, name string) error {
+	b.runtime.ensureDrainRunning()
+
+	cName := toCString(name)
+	defer C.free(unsafe.Pointer(cName))
+
+	ch := make(chan error, 1)
+	h := registerHandleForDispatch(cgo.NewHandle(ch))
+
+	var cerr C.CBoxliteError
+	code := C.boxlite_box_snapshot_remove(b.handle, cName, C.cbSnapshotRemove(), handleToPtr(h), &cerr)
+	if code != C.Ok {
+		deleteHandleForDispatch(h)
+		return freeError(&cerr)
+	}
+
+	select {
+	case err := <-ch:
+		return err
+	case <-ctx.Done():
+		abandonAsyncErr(ch, h, b.runtime.closing)
+		return ctx.Err()
+	case <-b.runtime.closing:
+		abandonAsyncErr(ch, h, b.runtime.closing)
+		return ErrRuntimeClosed
+	}
+}
+
+// SnapshotRestore reverts the box's disks to the named snapshot.
+func (b *Box) SnapshotRestore(ctx context.Context, name string) error {
+	b.runtime.ensureDrainRunning()
+
+	cName := toCString(name)
+	defer C.free(unsafe.Pointer(cName))
+
+	ch := make(chan error, 1)
+	h := registerHandleForDispatch(cgo.NewHandle(ch))
+
+	var cerr C.CBoxliteError
+	code := C.boxlite_box_snapshot_restore(b.handle, cName, C.cbSnapshotRestore(), handleToPtr(h), &cerr)
+	if code != C.Ok {
+		deleteHandleForDispatch(h)
+		return freeError(&cerr)
+	}
+
+	select {
+	case err := <-ch:
+		return err
+	case <-ctx.Done():
+		abandonAsyncErr(ch, h, b.runtime.closing)
+		return ctx.Err()
+	case <-b.runtime.closing:
+		abandonAsyncErr(ch, h, b.runtime.closing)
+		return ErrRuntimeClosed
+	}
+}
+
+// ─── Conversions ──────────────────────────────────────────────────────────
+
+func cSnapshotInfoToGo(info *C.CSnapshotInfo) SnapshotInfo {
+	if info == nil {
+		return SnapshotInfo{}
+	}
+	return SnapshotInfo{
+		ID:                 C.GoString(info.id),
+		BoxID:              C.GoString(info.box_id),
+		Name:               C.GoString(info.name),
+		CreatedAt:          int64(info.created_at),
+		ContainerDiskBytes: uint64(info.container_disk_bytes),
+		SizeBytes:          uint64(info.size_bytes),
+	}
+}
+
+func convertSnapshotInfoList(list *C.CSnapshotInfoList) []SnapshotInfo {
+	if list == nil || list.count == 0 {
+		return nil
+	}
+	items := unsafe.Slice(list.items, int(list.count))
+	out := make([]SnapshotInfo, 0, len(items))
+	for i := range items {
+		out = append(out, cSnapshotInfoToGo(&items[i]))
+	}
+	return out
+}
+
+// ─── Cgo callback exports ─────────────────────────────────────────────────
+
+//export goBoxliteOnSnapshotCreate
+func goBoxliteOnSnapshotCreate(info *C.CSnapshotInfo, errPtr *C.CBoxliteError, userData unsafe.Pointer) {
+	h := ptrToHandle(userData)
+	if h == 0 {
+		return
+	}
+	if !claimOrFreePayload(h, &info, func(i **C.CSnapshotInfo) {
+		if i != nil && *i != nil {
+			C.boxlite_free_snapshot_info(*i)
+		}
+	}) {
+		return
+	}
+	defer h.Delete()
+	ch, ok := h.Value().(chan snapshotCreateResult)
+	if !ok {
+		return
+	}
+	if err := errorFromCError(errPtr); err != nil {
+		ch <- snapshotCreateResult{err: err}
+		return
+	}
+	if info == nil {
+		ch <- snapshotCreateResult{}
+		return
+	}
+	v := cSnapshotInfoToGo(info)
+	C.boxlite_free_snapshot_info(info)
+	ch <- snapshotCreateResult{value: &v}
+}
+
+//export goBoxliteOnSnapshotList
+func goBoxliteOnSnapshotList(list *C.CSnapshotInfoList, errPtr *C.CBoxliteError, userData unsafe.Pointer) {
+	h := ptrToHandle(userData)
+	if h == 0 {
+		return
+	}
+	if !claimOrFreePayload(h, &list, func(l **C.CSnapshotInfoList) {
+		if l != nil && *l != nil {
+			C.boxlite_free_snapshot_info_list(*l)
+		}
+	}) {
+		return
+	}
+	defer h.Delete()
+	ch, ok := h.Value().(chan snapshotListResult)
+	if !ok {
+		return
+	}
+	if err := errorFromCError(errPtr); err != nil {
+		ch <- snapshotListResult{err: err}
+		return
+	}
+	out := convertSnapshotInfoList(list)
+	if list != nil {
+		C.boxlite_free_snapshot_info_list(list)
+	}
+	ch <- snapshotListResult{value: out}
+}
+
+//export goBoxliteOnSnapshotRemove
+func goBoxliteOnSnapshotRemove(errPtr *C.CBoxliteError, userData unsafe.Pointer) {
+	h := ptrToHandle(userData)
+	if h == 0 {
+		return
+	}
+	if !claimHandleForDispatch(h) {
+		return
+	}
+	defer h.Delete()
+	ch, ok := h.Value().(chan error)
+	if !ok {
+		return
+	}
+	ch <- errorFromCError(errPtr)
+}
+
+//export goBoxliteOnSnapshotRestore
+func goBoxliteOnSnapshotRestore(errPtr *C.CBoxliteError, userData unsafe.Pointer) {
+	h := ptrToHandle(userData)
+	if h == 0 {
+		return
+	}
+	if !claimHandleForDispatch(h) {
+		return
+	}
+	defer h.Delete()
+	ch, ok := h.Value().(chan error)
+	if !ok {
+		return
+	}
+	ch <- errorFromCError(errPtr)
+}


### PR DESCRIPTION
Implements \`box.snapshot.{create, list, get, restore, remove}\` over the REST chain. Pre-fix the SDK Rust REST client short-circuited every call with "Remote server does not support snapshots operations" because the API's \`/v1/config\` returned \`snapshots_enabled=false\` and there was no runner-side handler for the snapshot URL space anyway.

Five layers added (≈1100 lines):
- **C FFI** (\`sdks/c/src/snapshot.rs\`): CSnapshotInfo + CSnapshotInfoList types, 5 async + callback entry points
- **event_queue**: 4 new RuntimeEvent variants + 4 callback function types
- **Go SDK** (\`sdks/go/snapshot.go\`): Box.Snapshot{Create,List,Get,Remove,Restore} + cgo bridge
- **Runner**: controller (\`boxlite_snapshot.go\`) with 5 handlers + classifySnapshotError + 5 routes in server.go
- **API NestJS**: 3 proxy routes covering snapshot URL space + \`snapshots_enabled: true\` flip

## Test plan

Pin: \`scripts/test/e2e/cases/test_snapshot_clone.py::test_snapshot_create_appears_in_list\`

| | Pre-fix | Post-fix |
|---|---|---|
| \`box.snapshot.create('foo')\` | \`RuntimeError: Remote server does not support snapshots operations\` (SDK short-circuit) | reaches libboxlite via the new REST chain |
| \`box.snapshot.list()\` | same | same |

End-to-end on the e2e stack the SDK now reaches libboxlite on the runner. The current outstanding failure (\`Failed to SIGSTOP shim process: Connection refused\`) is a libboxlite snapshot-mechanism issue (signal delivery against a stopped shim) — reproducible against local FFI on the same host, **out of scope for this REST PR**. Confirms the REST chain itself is end-to-end correct.

Clone / export / import REST support follow the same template; this PR is the exemplar.
