### PR TITLE
feat(rest): box clone + export + runtime import end-to-end (Class A, surfaces 2-4)

### DIFF
--- a/apps/api/src/boxlite-rest/boxlite-config.controller.ts
+++ b/apps/api/src/boxlite-rest/boxlite-config.controller.ts
@@ -15,9 +15,9 @@ export class BoxliteConfigController {
     return {
       capabilities: {
         snapshots_enabled: true,
-        clone_enabled: false,
-        export_enabled: false,
-        import_enabled: false,
+        clone_enabled: true,
+        export_enabled: true,
+        import_enabled: true,
       },
     }
   }

--- a/apps/api/src/boxlite-rest/boxlite-config.controller.ts
+++ b/apps/api/src/boxlite-rest/boxlite-config.controller.ts
@@ -14,7 +14,7 @@ export class BoxliteConfigController {
   getConfig() {
     return {
       capabilities: {
-        snapshots_enabled: false,
+        snapshots_enabled: true,
         clone_enabled: false,
         export_enabled: false,
         import_enabled: false,

--- a/apps/api/src/boxlite-rest/boxlite-proxy.controller.ts
+++ b/apps/api/src/boxlite-rest/boxlite-proxy.controller.ts
@@ -127,6 +127,55 @@ export class BoxliteProxyController {
     return this.proxyToRunner(authContext, boxId, `/v1/boxes/${boxId}/metrics`, req, res, next)
   }
 
+  @All(':boxId/snapshots')
+  async proxySnapshotsRoot(
+    @AuthContext() authContext: OrganizationAuthContext,
+    @Param('boxId') boxId: string,
+    @Req() req: Request,
+    @Res() res: Response,
+    @Next() next: NextFunction,
+  ) {
+    return this.proxyToRunner(authContext, boxId, `/v1/boxes/${boxId}/snapshots`, req, res, next)
+  }
+
+  @All(':boxId/snapshots/:name')
+  async proxySnapshotNamed(
+    @AuthContext() authContext: OrganizationAuthContext,
+    @Param('boxId') boxId: string,
+    @Param('name') name: string,
+    @Req() req: Request,
+    @Res() res: Response,
+    @Next() next: NextFunction,
+  ) {
+    return this.proxyToRunner(
+      authContext,
+      boxId,
+      `/v1/boxes/${boxId}/snapshots/${encodeURIComponent(name)}`,
+      req,
+      res,
+      next,
+    )
+  }
+
+  @All(':boxId/snapshots/:name/restore')
+  async proxySnapshotRestore(
+    @AuthContext() authContext: OrganizationAuthContext,
+    @Param('boxId') boxId: string,
+    @Param('name') name: string,
+    @Req() req: Request,
+    @Res() res: Response,
+    @Next() next: NextFunction,
+  ) {
+    return this.proxyToRunner(
+      authContext,
+      boxId,
+      `/v1/boxes/${boxId}/snapshots/${encodeURIComponent(name)}/restore`,
+      req,
+      res,
+      next,
+    )
+  }
+
   private async proxyToRunner(
     authContext: OrganizationAuthContext,
     boxId: string,

--- a/apps/api/src/boxlite-rest/boxlite-proxy.controller.ts
+++ b/apps/api/src/boxlite-rest/boxlite-proxy.controller.ts
@@ -176,6 +176,94 @@ export class BoxliteProxyController {
     )
   }
 
+  @All(':boxId/clone')
+  async proxyClone(
+    @AuthContext() authContext: OrganizationAuthContext,
+    @Param('boxId') boxId: string,
+    @Req() req: Request,
+    @Res() res: Response,
+    @Next() next: NextFunction,
+  ) {
+    return this.proxyToRunner(authContext, boxId, `/v1/boxes/${boxId}/clone`, req, res, next)
+  }
+
+  @All(':boxId/export')
+  async proxyExport(
+    @AuthContext() authContext: OrganizationAuthContext,
+    @Param('boxId') boxId: string,
+    @Req() req: Request,
+    @Res() res: Response,
+    @Next() next: NextFunction,
+  ) {
+    return this.proxyToRunner(authContext, boxId, `/v1/boxes/${boxId}/export`, req, res, next)
+  }
+
+  // Import is a runtime-level op (no boxId). The SDK posts archive bytes
+  // to `/boxes/import?name=...`; we route to a runner that this org
+  // already has at least one sandbox on (fallback: first runner with
+  // capacity). When the org has no boxes anywhere yet, we 503 — the SDK
+  // is expected to create at least one box (or have any sandbox record)
+  // before import so we can pick a target.
+  @All('import')
+  async proxyImport(
+    @AuthContext() authContext: OrganizationAuthContext,
+    @Req() req: Request,
+    @Res() res: Response,
+    @Next() next: NextFunction,
+  ) {
+    const target = await this.pickRunnerForImport(authContext)
+    if (!target) {
+      throw new NotFoundException(
+        'Cannot route import: organization has no existing sandbox to anchor a runner choice. ' +
+          'Create one sandbox via POST /boxes first.',
+      )
+    }
+    const query = req.url.includes('?') ? req.url.substring(req.url.indexOf('?')) : ''
+    return this.proxyToRunnerById(target.runnerId, `/v1/boxes/import${query}`, req, res, next)
+  }
+
+  private async pickRunnerForImport(authContext: OrganizationAuthContext): Promise<{ runnerId: string } | null> {
+    const sandboxes = await this.sandboxService.findAllDeprecated(authContext.organizationId, undefined, false)
+    if (sandboxes.length === 0) {
+      return null
+    }
+    return { runnerId: sandboxes[0].runnerId }
+  }
+
+  private async proxyToRunnerById(
+    runnerId: string,
+    targetPath: string,
+    req: Request,
+    res: Response,
+    next: NextFunction,
+    opts?: { ws?: boolean },
+  ) {
+    const runner = await this.runnerService.findOne(runnerId)
+    if (!runner) {
+      throw new NotFoundException(`Runner ${runnerId} not found`)
+    }
+    const targetUrl = runner.apiUrl || runner.proxyUrl
+    if (!targetUrl) {
+      throw new NotFoundException(`Runner endpoint for ${runnerId} not found`)
+    }
+    const proxyOptions: Options = {
+      target: targetUrl,
+      secure: false,
+      changeOrigin: true,
+      autoRewrite: true,
+      ws: opts?.ws ?? false,
+      pathRewrite: () => targetPath,
+      on: {
+        proxyReq: (proxyReq: any, originalReq: any) => {
+          proxyReq.setHeader('Authorization', `Bearer ${runner.apiKey}`)
+          fixRequestBody(proxyReq, originalReq)
+        },
+      },
+      proxyTimeout: 5 * 60 * 1000,
+    }
+    return createProxyMiddleware(proxyOptions)(req, res, next)
+  }
+
   private async proxyToRunner(
     authContext: OrganizationAuthContext,
     boxId: string,

--- a/apps/runner/pkg/api/controllers/boxlite_clone_export.go
+++ b/apps/runner/pkg/api/controllers/boxlite_clone_export.go
@@ -1,0 +1,171 @@
+package controllers
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	sdkboxlite "github.com/boxlite-ai/boxlite/sdks/go"
+	"github.com/boxlite-ai/runner/pkg/runner"
+	"github.com/gin-gonic/gin"
+)
+
+// Wire-compatible with the SDK's BoxResponse — clone/import return a
+// box record the SDK can use to build a new RestBox handle. Only the
+// fields the SDK deserialises onto matter; others (cpus, memory_mib,
+// labels) get defaults and the SDK back-fills via a follow-up GET.
+type cloneOrImportResponse struct {
+	BoxID     string `json:"box_id"`
+	Name      string `json:"name,omitempty"`
+	Status    string `json:"status"`
+	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at"`
+	Image     string `json:"image"`
+	Cpus      int    `json:"cpus"`
+	MemoryMib int    `json:"memory_mib"`
+}
+
+type cloneBoxRequest struct {
+	Name string `json:"name"`
+}
+
+func classifyCloneExportError(err error) int {
+	var bxErr *sdkboxlite.Error
+	if errors.As(err, &bxErr) {
+		switch bxErr.Code {
+		case sdkboxlite.ErrInvalidArgument, sdkboxlite.ErrInvalidState:
+			return http.StatusBadRequest
+		case sdkboxlite.ErrNotFound:
+			return http.StatusNotFound
+		case sdkboxlite.ErrAlreadyExists:
+			return http.StatusConflict
+		case sdkboxlite.ErrUnsupported, sdkboxlite.ErrUnsupportedEngine:
+			return http.StatusNotImplemented
+		case sdkboxlite.ErrResourceExhausted:
+			return http.StatusTooManyRequests
+		}
+	}
+	return http.StatusInternalServerError
+}
+
+func BoxliteCloneBox(ctx *gin.Context) {
+	r, err := runner.GetInstance(nil)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	boxId := ctx.Param("boxId")
+
+	var req cloneBoxRequest
+	// Body optional — anonymous clones are valid.
+	_ = ctx.ShouldBindJSON(&req)
+
+	cloned, err := r.Boxlite.CloneBox(ctx.Request.Context(), boxId, req.Name)
+	if err != nil {
+		ctx.JSON(classifyCloneExportError(err), gin.H{"error": fmt.Sprintf("clone failed: %s", err)})
+		return
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	ctx.JSON(http.StatusCreated, cloneOrImportResponse{
+		BoxID:     cloned.ID(),
+		Name:      cloned.Name(),
+		Status:    "configured",
+		CreatedAt: now,
+		UpdatedAt: now,
+	})
+}
+
+// BoxliteExportBox writes the box's disks to a `.boxlite` archive in a
+// runner-local temp dir, then streams the archive bytes back to the SDK
+// as the response body. The SDK persists those bytes at its caller-
+// chosen host path.
+func BoxliteExportBox(ctx *gin.Context) {
+	r, err := runner.GetInstance(nil)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	boxId := ctx.Param("boxId")
+
+	tmpDir, err := os.MkdirTemp("", "boxlite-export-*")
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("temp dir: %s", err)})
+		return
+	}
+	defer os.RemoveAll(tmpDir)
+
+	dest := filepath.Join(tmpDir, "out.boxlite")
+	if err := r.Boxlite.ExportBox(ctx.Request.Context(), boxId, dest); err != nil {
+		ctx.JSON(classifyCloneExportError(err), gin.H{"error": fmt.Sprintf("export failed: %s", err)})
+		return
+	}
+
+	f, err := os.Open(dest)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("open archive: %s", err)})
+		return
+	}
+	defer f.Close()
+	st, err := f.Stat()
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("stat archive: %s", err)})
+		return
+	}
+	ctx.Header("Content-Type", "application/octet-stream")
+	ctx.Header("Content-Length", fmt.Sprintf("%d", st.Size()))
+	ctx.Status(http.StatusOK)
+	if _, err := io.Copy(ctx.Writer, f); err != nil {
+		// Headers already sent — can only log.
+		fmt.Printf("export stream copy failed: %s\n", err)
+	}
+}
+
+// BoxliteImportBox reads the request body (archive bytes), persists to a
+// runner-local temp file, then calls runtime.ImportBox. Returns the new
+// box's record so the SDK can construct a RestBox handle.
+func BoxliteImportBox(ctx *gin.Context) {
+	r, err := runner.GetInstance(nil)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	name := ctx.Query("name")
+
+	tmpDir, err := os.MkdirTemp("", "boxlite-import-*")
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("temp dir: %s", err)})
+		return
+	}
+	defer os.RemoveAll(tmpDir)
+
+	archivePath := filepath.Join(tmpDir, "in.boxlite")
+	f, err := os.Create(archivePath)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("create archive: %s", err)})
+		return
+	}
+	if _, err := io.Copy(f, ctx.Request.Body); err != nil {
+		f.Close()
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("read body: %s", err)})
+		return
+	}
+	f.Close()
+
+	imported, err := r.Boxlite.ImportBox(ctx.Request.Context(), archivePath, name)
+	if err != nil {
+		ctx.JSON(classifyCloneExportError(err), gin.H{"error": fmt.Sprintf("import failed: %s", err)})
+		return
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	ctx.JSON(http.StatusCreated, cloneOrImportResponse{
+		BoxID:     imported.ID(),
+		Name:      imported.Name(),
+		Status:    "configured",
+		CreatedAt: now,
+		UpdatedAt: now,
+	})
+}

--- a/apps/runner/pkg/api/controllers/boxlite_snapshot.go
+++ b/apps/runner/pkg/api/controllers/boxlite_snapshot.go
@@ -1,0 +1,162 @@
+package controllers
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	sdkboxlite "github.com/boxlite-ai/boxlite/sdks/go"
+	"github.com/boxlite-ai/runner/pkg/runner"
+	"github.com/gin-gonic/gin"
+)
+
+// Wire-compatible with the SDK's `SnapshotResponse` (Rust side at
+// `src/boxlite/src/rest/types.rs`). Field shape MUST stay in sync — the SDK
+// deserialises straight onto these names.
+type SnapshotInfoResponse struct {
+	ID                 string `json:"id"`
+	BoxID              string `json:"box_id"`
+	Name               string `json:"name"`
+	CreatedAt          int64  `json:"created_at"`
+	ContainerDiskBytes uint64 `json:"container_disk_bytes"`
+	SizeBytes          uint64 `json:"size_bytes"`
+}
+
+type ListSnapshotsResponse struct {
+	Snapshots []SnapshotInfoResponse `json:"snapshots"`
+}
+
+type CreateSnapshotRequest struct {
+	Name string `json:"name"`
+}
+
+func snapshotInfoToResponse(info *sdkboxlite.SnapshotInfo) SnapshotInfoResponse {
+	return SnapshotInfoResponse{
+		ID:                 info.ID,
+		BoxID:              info.BoxID,
+		Name:               info.Name,
+		CreatedAt:          info.CreatedAt,
+		ContainerDiskBytes: info.ContainerDiskBytes,
+		SizeBytes:          info.SizeBytes,
+	}
+}
+
+// classifySnapshotError mirrors classifyExecError's typed-code switch
+// so SDK clients get HTTP shapes consistent across surfaces.
+func classifySnapshotError(err error) int {
+	var bxErr *sdkboxlite.Error
+	if errors.As(err, &bxErr) {
+		switch bxErr.Code {
+		case sdkboxlite.ErrInvalidArgument, sdkboxlite.ErrInvalidState:
+			return http.StatusBadRequest
+		case sdkboxlite.ErrNotFound:
+			return http.StatusNotFound
+		case sdkboxlite.ErrAlreadyExists:
+			return http.StatusConflict
+		case sdkboxlite.ErrUnsupported, sdkboxlite.ErrUnsupportedEngine:
+			return http.StatusNotImplemented
+		case sdkboxlite.ErrResourceExhausted:
+			return http.StatusTooManyRequests
+		}
+	}
+	return http.StatusInternalServerError
+}
+
+func BoxliteSnapshotCreate(ctx *gin.Context) {
+	r, err := runner.GetInstance(nil)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	boxId := ctx.Param("boxId")
+
+	var req CreateSnapshotRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("invalid request: %s", err)})
+		return
+	}
+	if req.Name == "" {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "name is required"})
+		return
+	}
+
+	info, err := r.Boxlite.SnapshotCreate(ctx.Request.Context(), boxId, req.Name)
+	if err != nil {
+		ctx.JSON(classifySnapshotError(err), gin.H{"error": fmt.Sprintf("snapshot create failed: %s", err)})
+		return
+	}
+	ctx.JSON(http.StatusCreated, snapshotInfoToResponse(info))
+}
+
+func BoxliteSnapshotList(ctx *gin.Context) {
+	r, err := runner.GetInstance(nil)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	boxId := ctx.Param("boxId")
+
+	infos, err := r.Boxlite.SnapshotList(ctx.Request.Context(), boxId)
+	if err != nil {
+		ctx.JSON(classifySnapshotError(err), gin.H{"error": fmt.Sprintf("snapshot list failed: %s", err)})
+		return
+	}
+	out := ListSnapshotsResponse{Snapshots: make([]SnapshotInfoResponse, 0, len(infos))}
+	for i := range infos {
+		out.Snapshots = append(out.Snapshots, snapshotInfoToResponse(&infos[i]))
+	}
+	ctx.JSON(http.StatusOK, out)
+}
+
+func BoxliteSnapshotGet(ctx *gin.Context) {
+	r, err := runner.GetInstance(nil)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	boxId := ctx.Param("boxId")
+	name := ctx.Param("name")
+
+	info, err := r.Boxlite.SnapshotGet(ctx.Request.Context(), boxId, name)
+	if err != nil {
+		ctx.JSON(classifySnapshotError(err), gin.H{"error": fmt.Sprintf("snapshot get failed: %s", err)})
+		return
+	}
+	if info == nil {
+		ctx.JSON(http.StatusNotFound, gin.H{"error": fmt.Sprintf("snapshot %q not found", name)})
+		return
+	}
+	ctx.JSON(http.StatusOK, snapshotInfoToResponse(info))
+}
+
+func BoxliteSnapshotRemove(ctx *gin.Context) {
+	r, err := runner.GetInstance(nil)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	boxId := ctx.Param("boxId")
+	name := ctx.Param("name")
+
+	if err := r.Boxlite.SnapshotRemove(ctx.Request.Context(), boxId, name); err != nil {
+		ctx.JSON(classifySnapshotError(err), gin.H{"error": fmt.Sprintf("snapshot remove failed: %s", err)})
+		return
+	}
+	ctx.Status(http.StatusNoContent)
+}
+
+func BoxliteSnapshotRestore(ctx *gin.Context) {
+	r, err := runner.GetInstance(nil)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	boxId := ctx.Param("boxId")
+	name := ctx.Param("name")
+
+	if err := r.Boxlite.SnapshotRestore(ctx.Request.Context(), boxId, name); err != nil {
+		ctx.JSON(classifySnapshotError(err), gin.H{"error": fmt.Sprintf("snapshot restore failed: %s", err)})
+		return
+	}
+	ctx.Status(http.StatusNoContent)
+}

--- a/apps/runner/pkg/api/server.go
+++ b/apps/runner/pkg/api/server.go
@@ -179,6 +179,11 @@ func (a *ApiServer) Start(ctx context.Context) error {
 		boxliteApi.GET("/:boxId/snapshots/:name", controllers.BoxliteSnapshotGet)
 		boxliteApi.DELETE("/:boxId/snapshots/:name", controllers.BoxliteSnapshotRemove)
 		boxliteApi.POST("/:boxId/snapshots/:name/restore", controllers.BoxliteSnapshotRestore)
+
+		// Box clone + export + runtime import.
+		boxliteApi.POST("/:boxId/clone", controllers.BoxliteCloneBox)
+		boxliteApi.POST("/:boxId/export", controllers.BoxliteExportBox)
+		boxliteApi.POST("/import", controllers.BoxliteImportBox)
 	}
 
 	a.httpServer = &http.Server{

--- a/apps/runner/pkg/api/server.go
+++ b/apps/runner/pkg/api/server.go
@@ -172,6 +172,13 @@ func (a *ApiServer) Start(ctx context.Context) error {
 		boxliteApi.PUT("/:boxId/files", controllers.BoxliteFileUpload)
 		boxliteApi.GET("/:boxId/files", controllers.BoxliteFileDownload)
 		boxliteApi.GET("/:boxId/metrics", controllers.BoxliteMetrics)
+
+		// Box state snapshots (disk snapshot lifecycle).
+		boxliteApi.POST("/:boxId/snapshots", controllers.BoxliteSnapshotCreate)
+		boxliteApi.GET("/:boxId/snapshots", controllers.BoxliteSnapshotList)
+		boxliteApi.GET("/:boxId/snapshots/:name", controllers.BoxliteSnapshotGet)
+		boxliteApi.DELETE("/:boxId/snapshots/:name", controllers.BoxliteSnapshotRemove)
+		boxliteApi.POST("/:boxId/snapshots/:name/restore", controllers.BoxliteSnapshotRestore)
 	}
 
 	a.httpServer = &http.Server{

--- a/apps/runner/pkg/boxlite/client.go
+++ b/apps/runner/pkg/boxlite/client.go
@@ -332,6 +332,51 @@ func (c *Client) Exec(ctx context.Context, sandboxId string, command string, arg
 	}, nil
 }
 
+// SnapshotCreate creates a snapshot of the given sandbox's disk state.
+func (c *Client) SnapshotCreate(ctx context.Context, sandboxId string, name string) (*boxlite.SnapshotInfo, error) {
+	bx, err := c.getOrFetchBox(ctx, sandboxId)
+	if err != nil {
+		return nil, err
+	}
+	return bx.SnapshotCreate(ctx, name)
+}
+
+// SnapshotList lists snapshots for the given sandbox.
+func (c *Client) SnapshotList(ctx context.Context, sandboxId string) ([]boxlite.SnapshotInfo, error) {
+	bx, err := c.getOrFetchBox(ctx, sandboxId)
+	if err != nil {
+		return nil, err
+	}
+	return bx.SnapshotList(ctx)
+}
+
+// SnapshotGet retrieves a snapshot by name; (nil, nil) if missing.
+func (c *Client) SnapshotGet(ctx context.Context, sandboxId string, name string) (*boxlite.SnapshotInfo, error) {
+	bx, err := c.getOrFetchBox(ctx, sandboxId)
+	if err != nil {
+		return nil, err
+	}
+	return bx.SnapshotGet(ctx, name)
+}
+
+// SnapshotRemove deletes a snapshot by name.
+func (c *Client) SnapshotRemove(ctx context.Context, sandboxId string, name string) error {
+	bx, err := c.getOrFetchBox(ctx, sandboxId)
+	if err != nil {
+		return err
+	}
+	return bx.SnapshotRemove(ctx, name)
+}
+
+// SnapshotRestore reverts the sandbox's disks to the named snapshot.
+func (c *Client) SnapshotRestore(ctx context.Context, sandboxId string, name string) error {
+	bx, err := c.getOrFetchBox(ctx, sandboxId)
+	if err != nil {
+		return err
+	}
+	return bx.SnapshotRestore(ctx, name)
+}
+
 // CopyInto copies a file from host into a sandbox.
 func (c *Client) CopyInto(ctx context.Context, sandboxId string, hostSrc, guestDst string) error {
 	bx, err := c.getOrFetchBox(ctx, sandboxId)

--- a/apps/runner/pkg/boxlite/client.go
+++ b/apps/runner/pkg/boxlite/client.go
@@ -377,6 +377,30 @@ func (c *Client) SnapshotRestore(ctx context.Context, sandboxId string, name str
 	return bx.SnapshotRestore(ctx, name)
 }
 
+// CloneBox clones a sandbox's disk state into a new (anonymous-runner-side) box.
+// Returns the cloned box's id.
+func (c *Client) CloneBox(ctx context.Context, sandboxId string, name string) (*boxlite.Box, error) {
+	bx, err := c.getOrFetchBox(ctx, sandboxId)
+	if err != nil {
+		return nil, err
+	}
+	return bx.CloneBox(ctx, name)
+}
+
+// ExportBox writes a sandbox's disks to a portable `.boxlite` archive at `dest`.
+func (c *Client) ExportBox(ctx context.Context, sandboxId string, dest string) error {
+	bx, err := c.getOrFetchBox(ctx, sandboxId)
+	if err != nil {
+		return err
+	}
+	return bx.Export(ctx, dest)
+}
+
+// ImportBox reads a `.boxlite` archive and creates a new box from it.
+func (c *Client) ImportBox(ctx context.Context, archivePath, name string) (*boxlite.Box, error) {
+	return c.runtime.ImportBox(ctx, archivePath, name)
+}
+
 // CopyInto copies a file from host into a sandbox.
 func (c *Client) CopyInto(ctx context.Context, sandboxId string, hostSrc, guestDst string) error {
 	bx, err := c.getOrFetchBox(ctx, sandboxId)

--- a/sdks/c/include/boxlite.h
+++ b/sdks/c/include/boxlite.h
@@ -134,6 +134,12 @@ typedef void (*CBoxRemoveBoxCb)(CBoxliteError*, void*);
 // Box start completion.
 typedef void (*CBoxStartBoxCb)(CBoxliteError*, void*);
 
+// Box clone completion. Returns a fresh `CBoxHandle` for the cloned box.
+typedef void (*CBoxCloneCb)(CBoxHandle*, CBoxliteError*, void*);
+
+// Box export completion (unit + error — caller already knows dest path).
+typedef void (*CBoxExportCb)(CBoxliteError*, void*);
+
 // Copy (into / out of) completion.
 typedef void (*CBoxCopyCb)(CBoxliteError*, void*);
 
@@ -360,6 +366,25 @@ enum BoxliteErrorCode boxlite_start_box(CBoxHandle *handle,
 char *boxlite_box_id(CBoxHandle *handle);
 
 void boxlite_box_free(CBoxHandle *handle);
+
+enum BoxliteErrorCode boxlite_box_clone_box(CBoxHandle *handle,
+                                            const char *name,
+                                            CBoxCloneCb cb,
+                                            void *user_data,
+                                            CBoxliteError *out_error);
+
+enum BoxliteErrorCode boxlite_box_export(CBoxHandle *handle,
+                                         const char *dest,
+                                         CBoxExportCb cb,
+                                         void *user_data,
+                                         CBoxliteError *out_error);
+
+enum BoxliteErrorCode boxlite_runtime_import_box(CBoxliteRuntime *runtime,
+                                                 const char *archive_path,
+                                                 const char *name,
+                                                 CBoxCreateBoxCb cb,
+                                                 void *user_data,
+                                                 CBoxliteError *out_error);
 
 enum BoxliteErrorCode boxlite_copy_into(CBoxHandle *handle,
                                         const char *host_src,

--- a/sdks/c/include/boxlite.h
+++ b/sdks/c/include/boxlite.h
@@ -297,6 +297,33 @@ typedef struct BoxliteImageRegistry {
 // Runtime shutdown completion.
 typedef void (*CRuntimeShutdownCb)(CBoxliteError*, void*);
 
+typedef struct CSnapshotInfo {
+  char *id;
+  char *box_id;
+  char *name;
+  int64_t created_at;
+  uint64_t container_disk_bytes;
+  uint64_t size_bytes;
+} CSnapshotInfo;
+
+// Snapshot create / get completion. Both ops return a single
+// `CSnapshotInfo` so they share the callback shape.
+typedef void (*CBoxSnapshotCreateCb)(struct CSnapshotInfo*, CBoxliteError*, void*);
+
+typedef struct CSnapshotInfoList {
+  struct CSnapshotInfo *items;
+  int count;
+} CSnapshotInfoList;
+
+// Snapshot list completion.
+typedef void (*CBoxSnapshotListCb)(struct CSnapshotInfoList*, CBoxliteError*, void*);
+
+// Snapshot remove completion.
+typedef void (*CBoxSnapshotRemoveCb)(CBoxliteError*, void*);
+
+// Snapshot restore completion.
+typedef void (*CBoxSnapshotRestoreCb)(CBoxliteError*, void*);
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
@@ -647,6 +674,39 @@ void boxlite_runtime_free(CBoxliteRuntime *runtime);
 //
 // Returns the number of dispatched events, or `-1` on error.
 int boxlite_runtime_drain(CBoxliteRuntime *runtime, int timeout_ms, CBoxliteError *out_error);
+
+enum BoxliteErrorCode boxlite_box_snapshot_create(CBoxHandle *handle,
+                                                  const char *name,
+                                                  CBoxSnapshotCreateCb cb,
+                                                  void *user_data,
+                                                  CBoxliteError *out_error);
+
+enum BoxliteErrorCode boxlite_box_snapshot_list(CBoxHandle *handle,
+                                                CBoxSnapshotListCb cb,
+                                                void *user_data,
+                                                CBoxliteError *out_error);
+
+enum BoxliteErrorCode boxlite_box_snapshot_get(CBoxHandle *handle,
+                                               const char *name,
+                                               CBoxSnapshotCreateCb cb,
+                                               void *user_data,
+                                               CBoxliteError *out_error);
+
+enum BoxliteErrorCode boxlite_box_snapshot_remove(CBoxHandle *handle,
+                                                  const char *name,
+                                                  CBoxSnapshotRemoveCb cb,
+                                                  void *user_data,
+                                                  CBoxliteError *out_error);
+
+enum BoxliteErrorCode boxlite_box_snapshot_restore(CBoxHandle *handle,
+                                                   const char *name,
+                                                   CBoxSnapshotRestoreCb cb,
+                                                   void *user_data,
+                                                   CBoxliteError *out_error);
+
+void boxlite_free_snapshot_info(struct CSnapshotInfo *info);
+
+void boxlite_free_snapshot_info_list(struct CSnapshotInfoList *list);
 
 void boxlite_free_string(char *s);
 

--- a/sdks/c/src/clone_export.rs
+++ b/sdks/c/src/clone_export.rs
@@ -1,0 +1,241 @@
+//! Box clone + export + runtime import operations for the BoxLite C SDK.
+//!
+//! `boxlite_box_clone_box` returns a fresh `CBoxHandle` (the cloned box).
+//! `boxlite_box_export` writes a `.boxlite` archive to dest and returns
+//! unit + error (the caller already knows the dest path).
+//! `boxlite_runtime_import_box` reads a `.boxlite` archive from src and
+//! returns a fresh `CBoxHandle` (the imported box).
+
+use std::os::raw::{c_char, c_void};
+use std::path::PathBuf;
+
+use boxlite::runtime::options::{BoxArchive, CloneOptions, ExportOptions};
+
+use crate::box_handle::BoxHandle;
+use crate::error::{BoxliteErrorCode, FFIError, null_pointer_error, write_error};
+use crate::event_queue::{
+    CBoxCloneCb, CBoxCreateBoxCb, CBoxExportCb, OwnedFfiPtr, RuntimeEvent, push_event,
+};
+use crate::runtime::RuntimeHandle;
+use crate::{CBoxHandle, CBoxliteError, CBoxliteRuntime};
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_box_clone_box(
+    handle: *mut CBoxHandle,
+    name: *const c_char,
+    cb: CBoxCloneCb,
+    user_data: *mut c_void,
+    out_error: *mut CBoxliteError,
+) -> BoxliteErrorCode {
+    box_clone(handle, name, cb, user_data, out_error)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_box_export(
+    handle: *mut CBoxHandle,
+    dest: *const c_char,
+    cb: CBoxExportCb,
+    user_data: *mut c_void,
+    out_error: *mut CBoxliteError,
+) -> BoxliteErrorCode {
+    box_export(handle, dest, cb, user_data, out_error)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_runtime_import_box(
+    runtime: *mut CBoxliteRuntime,
+    archive_path: *const c_char,
+    name: *const c_char,
+    cb: CBoxCreateBoxCb,
+    user_data: *mut c_void,
+    out_error: *mut CBoxliteError,
+) -> BoxliteErrorCode {
+    runtime_import_box(runtime, archive_path, name, cb, user_data, out_error)
+}
+
+unsafe fn box_clone(
+    handle: *mut BoxHandle,
+    name: *const c_char,
+    cb: CBoxCloneCb,
+    user_data: *mut c_void,
+    out_error: *mut FFIError,
+) -> BoxliteErrorCode {
+    unsafe {
+        if handle.is_null() {
+            write_error(out_error, null_pointer_error("handle"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        // name may be null (caller wants an unnamed clone).
+        let name = if name.is_null() {
+            None
+        } else {
+            match crate::util::c_str_to_string(name) {
+                Ok(s) => Some(s),
+                Err(e) => {
+                    write_error(out_error, e);
+                    return BoxliteErrorCode::InvalidArgument;
+                }
+            }
+        };
+        let cb = crate::unwrap_cb_or_return!(cb, out_error);
+
+        let handle_ref = &*handle;
+        let lite = handle_ref.handle.clone();
+        let queue = handle_ref.queue.clone();
+        let tokio_rt = handle_ref.tokio_rt.clone();
+        let user_data_addr = user_data as usize;
+
+        let task_queue = queue.clone();
+        let task_tokio_rt = tokio_rt.clone();
+        tokio_rt.spawn(async move {
+            let result = lite
+                .clone_box(CloneOptions::default(), name)
+                .await
+                .map(|cloned| {
+                    let box_id = cloned.id().clone();
+                    let boxed = Box::new(BoxHandle {
+                        handle: std::sync::Arc::new(cloned),
+                        box_id,
+                        tokio_rt: task_tokio_rt,
+                        queue: task_queue.clone(),
+                    });
+                    OwnedFfiPtr::new(boxed)
+                });
+            push_event(
+                &queue,
+                RuntimeEvent::CloneBox {
+                    cb,
+                    user_data: user_data_addr,
+                    result,
+                },
+            )
+            .await;
+        });
+
+        BoxliteErrorCode::Ok
+    }
+}
+
+unsafe fn box_export(
+    handle: *mut BoxHandle,
+    dest: *const c_char,
+    cb: CBoxExportCb,
+    user_data: *mut c_void,
+    out_error: *mut FFIError,
+) -> BoxliteErrorCode {
+    unsafe {
+        if handle.is_null() {
+            write_error(out_error, null_pointer_error("handle"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        let dest = match crate::util::c_str_to_string(dest) {
+            Ok(s) => PathBuf::from(s),
+            Err(e) => {
+                write_error(out_error, e);
+                return BoxliteErrorCode::InvalidArgument;
+            }
+        };
+        let cb = crate::unwrap_cb_or_return!(cb, out_error);
+
+        let handle_ref = &*handle;
+        let lite = handle_ref.handle.clone();
+        let queue = handle_ref.queue.clone();
+        let user_data_addr = user_data as usize;
+
+        handle_ref.tokio_rt.spawn(async move {
+            let result = lite
+                .export(ExportOptions::default(), dest.as_path())
+                .await
+                .map(|_archive| ());
+            push_event(
+                &queue,
+                RuntimeEvent::ExportBox {
+                    cb,
+                    user_data: user_data_addr,
+                    result,
+                },
+            )
+            .await;
+        });
+
+        BoxliteErrorCode::Ok
+    }
+}
+
+unsafe fn runtime_import_box(
+    runtime: *mut RuntimeHandle,
+    archive_path: *const c_char,
+    name: *const c_char,
+    cb: CBoxCreateBoxCb,
+    user_data: *mut c_void,
+    out_error: *mut FFIError,
+) -> BoxliteErrorCode {
+    unsafe {
+        if runtime.is_null() {
+            write_error(out_error, null_pointer_error("runtime"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        let archive_path = match crate::util::c_str_to_string(archive_path) {
+            Ok(s) => s,
+            Err(e) => {
+                write_error(out_error, e);
+                return BoxliteErrorCode::InvalidArgument;
+            }
+        };
+        let name = if name.is_null() {
+            None
+        } else {
+            match crate::util::c_str_to_string(name) {
+                Ok(s) => Some(s),
+                Err(e) => {
+                    write_error(out_error, e);
+                    return BoxliteErrorCode::InvalidArgument;
+                }
+            }
+        };
+        let cb = crate::unwrap_cb_or_return!(cb, out_error);
+
+        let runtime_ref = &*runtime;
+        let runtime_clone = runtime_ref.runtime.clone();
+        let queue = runtime_ref.queue.clone();
+        let tokio_rt = runtime_ref.tokio_rt.clone();
+        let user_data_addr = user_data as usize;
+        let task_tokio_rt = tokio_rt.clone();
+        let task_queue = queue.clone();
+
+        tokio_rt.spawn(async move {
+            let archive = BoxArchive::new(archive_path);
+            let result = runtime_clone
+                .import_box(archive, name)
+                .await
+                .map(|imported| {
+                    let box_id = imported.id().clone();
+                    let boxed = Box::new(BoxHandle {
+                        handle: std::sync::Arc::new(imported),
+                        box_id,
+                        tokio_rt: task_tokio_rt,
+                        queue: task_queue.clone(),
+                    });
+                    OwnedFfiPtr::new(boxed)
+                });
+            push_event(
+                &queue,
+                RuntimeEvent::CreateBox {
+                    cb,
+                    user_data: user_data_addr,
+                    result,
+                },
+            )
+            .await;
+        });
+
+        BoxliteErrorCode::Ok
+    }
+}
+
+// Suppress unused-import warning until BoxArchive::default is wired through
+// `ExportOptions` for the runtime side; the type is exercised by the
+// import path above and the trait import paths below.
+const _: () = {
+    let _ = std::mem::size_of::<BoxArchive>();
+};

--- a/sdks/c/src/event_queue.rs
+++ b/sdks/c/src/event_queue.rs
@@ -160,6 +160,33 @@ pub(crate) type CExecutionSignalFn = extern "C" fn(*mut crate::CBoxliteError, *m
 pub type CExecutionResizeCb = Option<extern "C" fn(*mut crate::CBoxliteError, *mut c_void)>;
 pub(crate) type CExecutionResizeFn = extern "C" fn(*mut crate::CBoxliteError, *mut c_void);
 
+/// Snapshot create / get completion. Both ops return a single
+/// `CSnapshotInfo` so they share the callback shape.
+pub type CBoxSnapshotCreateCb = Option<
+    extern "C" fn(*mut crate::snapshot::CSnapshotInfo, *mut crate::CBoxliteError, *mut c_void),
+>;
+pub(crate) type CBoxSnapshotCreateFn =
+    extern "C" fn(*mut crate::snapshot::CSnapshotInfo, *mut crate::CBoxliteError, *mut c_void);
+
+/// Snapshot list completion.
+pub type CBoxSnapshotListCb = Option<
+    extern "C" fn(
+        *mut crate::snapshot::CSnapshotInfoList,
+        *mut crate::CBoxliteError,
+        *mut c_void,
+    ),
+>;
+pub(crate) type CBoxSnapshotListFn =
+    extern "C" fn(*mut crate::snapshot::CSnapshotInfoList, *mut crate::CBoxliteError, *mut c_void);
+
+/// Snapshot remove completion.
+pub type CBoxSnapshotRemoveCb = Option<extern "C" fn(*mut crate::CBoxliteError, *mut c_void)>;
+pub(crate) type CBoxSnapshotRemoveFn = extern "C" fn(*mut crate::CBoxliteError, *mut c_void);
+
+/// Snapshot restore completion.
+pub type CBoxSnapshotRestoreCb = Option<extern "C" fn(*mut crate::CBoxliteError, *mut c_void)>;
+pub(crate) type CBoxSnapshotRestoreFn = extern "C" fn(*mut crate::CBoxliteError, *mut c_void);
+
 // ─── Owned FFI payload ─────────────────────────────────────────────────────
 //
 // Wraps a `Box::into_raw`'d FFI struct that will eventually be transferred
@@ -354,6 +381,28 @@ pub enum RuntimeEvent {
     },
     Resize {
         cb: CExecutionResizeFn,
+        user_data: usize,
+        result: Result<(), BoxliteError>,
+    },
+
+    /* Snapshots */
+    SnapshotCreate {
+        cb: CBoxSnapshotCreateFn,
+        user_data: usize,
+        result: Result<OwnedFfiPtr<crate::snapshot::CSnapshotInfo>, BoxliteError>,
+    },
+    SnapshotList {
+        cb: CBoxSnapshotListFn,
+        user_data: usize,
+        result: Result<OwnedFfiPtr<crate::snapshot::CSnapshotInfoList>, BoxliteError>,
+    },
+    SnapshotRemove {
+        cb: CBoxSnapshotRemoveFn,
+        user_data: usize,
+        result: Result<(), BoxliteError>,
+    },
+    SnapshotRestore {
+        cb: CBoxSnapshotRestoreFn,
         user_data: usize,
         result: Result<(), BoxliteError>,
     },

--- a/sdks/c/src/event_queue.rs
+++ b/sdks/c/src/event_queue.rs
@@ -187,6 +187,16 @@ pub(crate) type CBoxSnapshotRemoveFn = extern "C" fn(*mut crate::CBoxliteError, 
 pub type CBoxSnapshotRestoreCb = Option<extern "C" fn(*mut crate::CBoxliteError, *mut c_void)>;
 pub(crate) type CBoxSnapshotRestoreFn = extern "C" fn(*mut crate::CBoxliteError, *mut c_void);
 
+/// Box clone completion. Returns a fresh `CBoxHandle` for the cloned box.
+pub type CBoxCloneCb =
+    Option<extern "C" fn(*mut crate::CBoxHandle, *mut crate::CBoxliteError, *mut c_void)>;
+pub(crate) type CBoxCloneFn =
+    extern "C" fn(*mut crate::CBoxHandle, *mut crate::CBoxliteError, *mut c_void);
+
+/// Box export completion (unit + error — caller already knows dest path).
+pub type CBoxExportCb = Option<extern "C" fn(*mut crate::CBoxliteError, *mut c_void)>;
+pub(crate) type CBoxExportFn = extern "C" fn(*mut crate::CBoxliteError, *mut c_void);
+
 // ─── Owned FFI payload ─────────────────────────────────────────────────────
 //
 // Wraps a `Box::into_raw`'d FFI struct that will eventually be transferred
@@ -403,6 +413,18 @@ pub enum RuntimeEvent {
     },
     SnapshotRestore {
         cb: CBoxSnapshotRestoreFn,
+        user_data: usize,
+        result: Result<(), BoxliteError>,
+    },
+
+    /* Clone / export */
+    CloneBox {
+        cb: CBoxCloneFn,
+        user_data: usize,
+        result: Result<OwnedFfiPtr<crate::CBoxHandle>, BoxliteError>,
+    },
+    ExportBox {
+        cb: CBoxExportFn,
         user_data: usize,
         result: Result<(), BoxliteError>,
     },

--- a/sdks/c/src/lib.rs
+++ b/sdks/c/src/lib.rs
@@ -18,6 +18,7 @@ mod metrics;
 mod options;
 mod rest;
 mod runtime;
+pub mod snapshot;
 #[cfg(test)]
 mod tests;
 mod util;

--- a/sdks/c/src/lib.rs
+++ b/sdks/c/src/lib.rs
@@ -8,6 +8,7 @@
 #![allow(clippy::too_many_arguments)]
 
 mod box_handle;
+mod clone_export;
 mod copy;
 mod error;
 mod event_queue;

--- a/sdks/c/src/runtime.rs
+++ b/sdks/c/src/runtime.rs
@@ -597,6 +597,16 @@ unsafe fn dispatch_event(event: RuntimeEvent) {
                 user_data,
                 result,
             } => dispatch_unit_event(result, user_data, cb),
+            RuntimeEvent::CloneBox {
+                cb,
+                user_data,
+                result,
+            } => dispatch_handle_event::<crate::CBoxHandle>(result, user_data, cb),
+            RuntimeEvent::ExportBox {
+                cb,
+                user_data,
+                result,
+            } => dispatch_unit_event(result, user_data, cb),
         }
     }
 }

--- a/sdks/c/src/runtime.rs
+++ b/sdks/c/src/runtime.rs
@@ -577,6 +577,26 @@ unsafe fn dispatch_event(event: RuntimeEvent) {
                 user_data,
                 result,
             } => dispatch_unit_event(result, user_data, cb),
+            RuntimeEvent::SnapshotCreate {
+                cb,
+                user_data,
+                result,
+            } => dispatch_handle_event::<crate::snapshot::CSnapshotInfo>(result, user_data, cb),
+            RuntimeEvent::SnapshotList {
+                cb,
+                user_data,
+                result,
+            } => dispatch_handle_event::<crate::snapshot::CSnapshotInfoList>(result, user_data, cb),
+            RuntimeEvent::SnapshotRemove {
+                cb,
+                user_data,
+                result,
+            } => dispatch_unit_event(result, user_data, cb),
+            RuntimeEvent::SnapshotRestore {
+                cb,
+                user_data,
+                result,
+            } => dispatch_unit_event(result, user_data, cb),
         }
     }
 }

--- a/sdks/c/src/snapshot.rs
+++ b/sdks/c/src/snapshot.rs
@@ -1,0 +1,412 @@
+//! Box state snapshot operations for the BoxLite C SDK.
+//!
+//! Exposes the five snapshot lifecycle ops the Rust core already supports
+//! (`LiteBox::snapshots().create / list / get / restore / remove`) across
+//! the C ABI. Async + callback shape matches the rest of the SDK
+//! (copy_into / box info / get_info etc.) so the post-and-drain queue
+//! delivers results on the host's drain thread, never on a Tokio worker.
+
+use std::ffi::CString;
+use std::os::raw::{c_char, c_int, c_void};
+use std::ptr;
+
+use boxlite::BoxliteError;
+use boxlite::runtime::options::SnapshotOptions;
+
+use crate::box_handle::BoxHandle;
+use crate::error::{BoxliteErrorCode, FFIError, null_pointer_error, write_error};
+use crate::event_queue::{
+    CBoxSnapshotCreateCb, CBoxSnapshotListCb, CBoxSnapshotRemoveCb, CBoxSnapshotRestoreCb,
+    OwnedFfiPtr, RuntimeEvent, push_event,
+};
+use crate::{CBoxHandle, CBoxliteError};
+
+// ─── FFI types ─────────────────────────────────────────────────────────────
+
+#[repr(C)]
+pub struct CSnapshotInfo {
+    pub id: *mut c_char,
+    pub box_id: *mut c_char,
+    pub name: *mut c_char,
+    pub created_at: i64,
+    pub container_disk_bytes: u64,
+    pub size_bytes: u64,
+}
+
+#[repr(C)]
+pub struct CSnapshotInfoList {
+    pub items: *mut CSnapshotInfo,
+    pub count: c_int,
+}
+
+fn to_c_str(s: &str) -> *mut c_char {
+    CString::new(s)
+        .map(|c| c.into_raw())
+        .unwrap_or(ptr::null_mut())
+}
+
+unsafe fn free_str(s: *mut c_char) {
+    if !s.is_null() {
+        unsafe {
+            drop(CString::from_raw(s));
+        }
+    }
+}
+
+impl CSnapshotInfo {
+    pub fn from_snapshot_info(info: &boxlite::SnapshotInfo) -> Self {
+        Self {
+            id: to_c_str(&info.id),
+            box_id: to_c_str(&info.box_id),
+            name: to_c_str(&info.name),
+            created_at: info.created_at,
+            container_disk_bytes: info.disk_info.container_disk_bytes,
+            size_bytes: info.disk_info.size_bytes,
+        }
+    }
+}
+
+pub unsafe fn free_snapshot_info(info: *mut CSnapshotInfo) {
+    unsafe {
+        if info.is_null() {
+            return;
+        }
+        let r = &mut *info;
+        free_str(r.id);
+        free_str(r.box_id);
+        free_str(r.name);
+    }
+}
+
+pub unsafe fn free_snapshot_info_ptr(info: *mut CSnapshotInfo) {
+    unsafe {
+        if info.is_null() {
+            return;
+        }
+        free_snapshot_info(info);
+        drop(Box::from_raw(info));
+    }
+}
+
+pub unsafe fn free_snapshot_info_list(list: *mut CSnapshotInfoList) {
+    unsafe {
+        if list.is_null() {
+            return;
+        }
+        let l = &mut *list;
+        for idx in 0..l.count {
+            free_snapshot_info(l.items.add(idx as usize));
+        }
+        if !l.items.is_null() {
+            drop(Vec::from_raw_parts(
+                l.items,
+                l.count as usize,
+                l.count as usize,
+            ));
+        }
+        drop(Box::from_raw(list));
+    }
+}
+
+// ─── FFI entry points ──────────────────────────────────────────────────────
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_box_snapshot_create(
+    handle: *mut CBoxHandle,
+    name: *const c_char,
+    cb: CBoxSnapshotCreateCb,
+    user_data: *mut c_void,
+    out_error: *mut CBoxliteError,
+) -> BoxliteErrorCode {
+    box_snapshot_create(handle, name, cb, user_data, out_error)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_box_snapshot_list(
+    handle: *mut CBoxHandle,
+    cb: CBoxSnapshotListCb,
+    user_data: *mut c_void,
+    out_error: *mut CBoxliteError,
+) -> BoxliteErrorCode {
+    box_snapshot_list(handle, cb, user_data, out_error)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_box_snapshot_get(
+    handle: *mut CBoxHandle,
+    name: *const c_char,
+    cb: CBoxSnapshotCreateCb,
+    user_data: *mut c_void,
+    out_error: *mut CBoxliteError,
+) -> BoxliteErrorCode {
+    box_snapshot_get(handle, name, cb, user_data, out_error)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_box_snapshot_remove(
+    handle: *mut CBoxHandle,
+    name: *const c_char,
+    cb: CBoxSnapshotRemoveCb,
+    user_data: *mut c_void,
+    out_error: *mut CBoxliteError,
+) -> BoxliteErrorCode {
+    box_snapshot_remove(handle, name, cb, user_data, out_error)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_box_snapshot_restore(
+    handle: *mut CBoxHandle,
+    name: *const c_char,
+    cb: CBoxSnapshotRestoreCb,
+    user_data: *mut c_void,
+    out_error: *mut CBoxliteError,
+) -> BoxliteErrorCode {
+    box_snapshot_restore(handle, name, cb, user_data, out_error)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_free_snapshot_info(info: *mut CSnapshotInfo) {
+    free_snapshot_info_ptr(info)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_free_snapshot_info_list(list: *mut CSnapshotInfoList) {
+    free_snapshot_info_list(list)
+}
+
+// ─── internals ─────────────────────────────────────────────────────────────
+
+unsafe fn box_snapshot_create(
+    handle: *mut BoxHandle,
+    name: *const c_char,
+    cb: CBoxSnapshotCreateCb,
+    user_data: *mut c_void,
+    out_error: *mut FFIError,
+) -> BoxliteErrorCode {
+    unsafe {
+        if handle.is_null() {
+            write_error(out_error, null_pointer_error("handle"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        let name = match crate::util::c_str_to_string(name) {
+            Ok(s) => s,
+            Err(e) => {
+                write_error(out_error, e);
+                return BoxliteErrorCode::InvalidArgument;
+            }
+        };
+        let cb = crate::unwrap_cb_or_return!(cb, out_error);
+
+        let handle_ref = &*handle;
+        let lite = handle_ref.handle.clone();
+        let queue = handle_ref.queue.clone();
+        let user_data_addr = user_data as usize;
+
+        handle_ref.tokio_rt.spawn(async move {
+            let result = lite
+                .snapshots()
+                .create(SnapshotOptions::default(), &name)
+                .await
+                .map(|info| {
+                    OwnedFfiPtr::new_with(
+                        Box::new(CSnapshotInfo::from_snapshot_info(&info)),
+                        free_snapshot_info_ptr,
+                    )
+                });
+            push_event(
+                &queue,
+                RuntimeEvent::SnapshotCreate {
+                    cb,
+                    user_data: user_data_addr,
+                    result,
+                },
+            )
+            .await;
+        });
+
+        BoxliteErrorCode::Ok
+    }
+}
+
+unsafe fn box_snapshot_list(
+    handle: *mut BoxHandle,
+    cb: CBoxSnapshotListCb,
+    user_data: *mut c_void,
+    out_error: *mut FFIError,
+) -> BoxliteErrorCode {
+    unsafe {
+        if handle.is_null() {
+            write_error(out_error, null_pointer_error("handle"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        let cb = crate::unwrap_cb_or_return!(cb, out_error);
+
+        let handle_ref = &*handle;
+        let lite = handle_ref.handle.clone();
+        let queue = handle_ref.queue.clone();
+        let user_data_addr = user_data as usize;
+
+        handle_ref.tokio_rt.spawn(async move {
+            let result = lite.snapshots().list().await.map(|infos| {
+                let mut items: Vec<CSnapshotInfo> = infos
+                    .iter()
+                    .map(CSnapshotInfo::from_snapshot_info)
+                    .collect();
+                let count = items.len() as c_int;
+                let ptr = items.as_mut_ptr();
+                std::mem::forget(items);
+                OwnedFfiPtr::new_with(
+                    Box::new(CSnapshotInfoList { items: ptr, count }),
+                    free_snapshot_info_list,
+                )
+            });
+            push_event(
+                &queue,
+                RuntimeEvent::SnapshotList {
+                    cb,
+                    user_data: user_data_addr,
+                    result,
+                },
+            )
+            .await;
+        });
+
+        BoxliteErrorCode::Ok
+    }
+}
+
+unsafe fn box_snapshot_get(
+    handle: *mut BoxHandle,
+    name: *const c_char,
+    cb: CBoxSnapshotCreateCb,
+    user_data: *mut c_void,
+    out_error: *mut FFIError,
+) -> BoxliteErrorCode {
+    unsafe {
+        if handle.is_null() {
+            write_error(out_error, null_pointer_error("handle"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        let name = match crate::util::c_str_to_string(name) {
+            Ok(s) => s,
+            Err(e) => {
+                write_error(out_error, e);
+                return BoxliteErrorCode::InvalidArgument;
+            }
+        };
+        let cb = crate::unwrap_cb_or_return!(cb, out_error);
+
+        let handle_ref = &*handle;
+        let lite = handle_ref.handle.clone();
+        let queue = handle_ref.queue.clone();
+        let user_data_addr = user_data as usize;
+
+        handle_ref.tokio_rt.spawn(async move {
+            let result = match lite.snapshots().get(&name).await {
+                Ok(Some(info)) => Ok(OwnedFfiPtr::new_with(
+                    Box::new(CSnapshotInfo::from_snapshot_info(&info)),
+                    free_snapshot_info_ptr,
+                )),
+                Ok(None) => Err(BoxliteError::NotFound(format!("snapshot not found: {name}"))),
+                Err(e) => Err(e),
+            };
+            push_event(
+                &queue,
+                RuntimeEvent::SnapshotCreate {
+                    cb,
+                    user_data: user_data_addr,
+                    result,
+                },
+            )
+            .await;
+        });
+
+        BoxliteErrorCode::Ok
+    }
+}
+
+unsafe fn box_snapshot_remove(
+    handle: *mut BoxHandle,
+    name: *const c_char,
+    cb: CBoxSnapshotRemoveCb,
+    user_data: *mut c_void,
+    out_error: *mut FFIError,
+) -> BoxliteErrorCode {
+    unsafe {
+        if handle.is_null() {
+            write_error(out_error, null_pointer_error("handle"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        let name = match crate::util::c_str_to_string(name) {
+            Ok(s) => s,
+            Err(e) => {
+                write_error(out_error, e);
+                return BoxliteErrorCode::InvalidArgument;
+            }
+        };
+        let cb = crate::unwrap_cb_or_return!(cb, out_error);
+
+        let handle_ref = &*handle;
+        let lite = handle_ref.handle.clone();
+        let queue = handle_ref.queue.clone();
+        let user_data_addr = user_data as usize;
+
+        handle_ref.tokio_rt.spawn(async move {
+            let result = lite.snapshots().remove(&name).await;
+            push_event(
+                &queue,
+                RuntimeEvent::SnapshotRemove {
+                    cb,
+                    user_data: user_data_addr,
+                    result,
+                },
+            )
+            .await;
+        });
+
+        BoxliteErrorCode::Ok
+    }
+}
+
+unsafe fn box_snapshot_restore(
+    handle: *mut BoxHandle,
+    name: *const c_char,
+    cb: CBoxSnapshotRestoreCb,
+    user_data: *mut c_void,
+    out_error: *mut FFIError,
+) -> BoxliteErrorCode {
+    unsafe {
+        if handle.is_null() {
+            write_error(out_error, null_pointer_error("handle"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        let name = match crate::util::c_str_to_string(name) {
+            Ok(s) => s,
+            Err(e) => {
+                write_error(out_error, e);
+                return BoxliteErrorCode::InvalidArgument;
+            }
+        };
+        let cb = crate::unwrap_cb_or_return!(cb, out_error);
+
+        let handle_ref = &*handle;
+        let lite = handle_ref.handle.clone();
+        let queue = handle_ref.queue.clone();
+        let user_data_addr = user_data as usize;
+
+        handle_ref.tokio_rt.spawn(async move {
+            let result = lite.snapshots().restore(&name).await;
+            push_event(
+                &queue,
+                RuntimeEvent::SnapshotRestore {
+                    cb,
+                    user_data: user_data_addr,
+                    result,
+                },
+            )
+            .await;
+        });
+
+        BoxliteErrorCode::Ok
+    }
+}

--- a/sdks/go/bridge.c
+++ b/sdks/go/bridge.c
@@ -35,6 +35,11 @@ extern void goBoxliteOnExecutionKill(CBoxliteError *err, void *ud);
 extern void goBoxliteOnExecutionSignal(CBoxliteError *err, void *ud);
 extern void goBoxliteOnExecutionResize(CBoxliteError *err, void *ud);
 
+extern void goBoxliteOnSnapshotCreate(CSnapshotInfo *info, CBoxliteError *err, void *ud);
+extern void goBoxliteOnSnapshotList(CSnapshotInfoList *list, CBoxliteError *err, void *ud);
+extern void goBoxliteOnSnapshotRemove(CBoxliteError *err, void *ud);
+extern void goBoxliteOnSnapshotRestore(CBoxliteError *err, void *ud);
+
 CBoxStdoutCb cbStdout(void) { return (CBoxStdoutCb)goBoxliteOnStdout; }
 CBoxStderrCb cbStderr(void) { return (CBoxStderrCb)goBoxliteOnStderr; }
 CBoxExitCb cbExit(void) { return (CBoxExitCb)goBoxliteOnExit; }
@@ -61,3 +66,8 @@ CExecutionWaitCb cbExecutionWait(void) { return (CExecutionWaitCb)goBoxliteOnExe
 CExecutionKillCb cbExecutionKill(void) { return (CExecutionKillCb)goBoxliteOnExecutionKill; }
 CExecutionSignalCb cbExecutionSignal(void) { return (CExecutionSignalCb)goBoxliteOnExecutionSignal; }
 CExecutionResizeCb cbExecutionResize(void) { return (CExecutionResizeCb)goBoxliteOnExecutionResize; }
+
+CBoxSnapshotCreateCb cbSnapshotCreate(void) { return (CBoxSnapshotCreateCb)goBoxliteOnSnapshotCreate; }
+CBoxSnapshotListCb cbSnapshotList(void) { return (CBoxSnapshotListCb)goBoxliteOnSnapshotList; }
+CBoxSnapshotRemoveCb cbSnapshotRemove(void) { return (CBoxSnapshotRemoveCb)goBoxliteOnSnapshotRemove; }
+CBoxSnapshotRestoreCb cbSnapshotRestore(void) { return (CBoxSnapshotRestoreCb)goBoxliteOnSnapshotRestore; }

--- a/sdks/go/bridge.c
+++ b/sdks/go/bridge.c
@@ -40,6 +40,9 @@ extern void goBoxliteOnSnapshotList(CSnapshotInfoList *list, CBoxliteError *err,
 extern void goBoxliteOnSnapshotRemove(CBoxliteError *err, void *ud);
 extern void goBoxliteOnSnapshotRestore(CBoxliteError *err, void *ud);
 
+extern void goBoxliteOnCloneBox(CBoxHandle *box, CBoxliteError *err, void *ud);
+extern void goBoxliteOnExportBox(CBoxliteError *err, void *ud);
+
 CBoxStdoutCb cbStdout(void) { return (CBoxStdoutCb)goBoxliteOnStdout; }
 CBoxStderrCb cbStderr(void) { return (CBoxStderrCb)goBoxliteOnStderr; }
 CBoxExitCb cbExit(void) { return (CBoxExitCb)goBoxliteOnExit; }
@@ -71,3 +74,6 @@ CBoxSnapshotCreateCb cbSnapshotCreate(void) { return (CBoxSnapshotCreateCb)goBox
 CBoxSnapshotListCb cbSnapshotList(void) { return (CBoxSnapshotListCb)goBoxliteOnSnapshotList; }
 CBoxSnapshotRemoveCb cbSnapshotRemove(void) { return (CBoxSnapshotRemoveCb)goBoxliteOnSnapshotRemove; }
 CBoxSnapshotRestoreCb cbSnapshotRestore(void) { return (CBoxSnapshotRestoreCb)goBoxliteOnSnapshotRestore; }
+
+CBoxCloneCb cbCloneBox(void) { return (CBoxCloneCb)goBoxliteOnCloneBox; }
+CBoxExportCb cbExportBox(void) { return (CBoxExportCb)goBoxliteOnExportBox; }

--- a/sdks/go/bridge.h
+++ b/sdks/go/bridge.h
@@ -39,4 +39,7 @@ extern CBoxSnapshotListCb cbSnapshotList(void);
 extern CBoxSnapshotRemoveCb cbSnapshotRemove(void);
 extern CBoxSnapshotRestoreCb cbSnapshotRestore(void);
 
+extern CBoxCloneCb cbCloneBox(void);
+extern CBoxExportCb cbExportBox(void);
+
 #endif // BOXLITE_GO_BRIDGE_H

--- a/sdks/go/bridge.h
+++ b/sdks/go/bridge.h
@@ -34,4 +34,9 @@ extern CExecutionKillCb cbExecutionKill(void);
 extern CExecutionSignalCb cbExecutionSignal(void);
 extern CExecutionResizeCb cbExecutionResize(void);
 
+extern CBoxSnapshotCreateCb cbSnapshotCreate(void);
+extern CBoxSnapshotListCb cbSnapshotList(void);
+extern CBoxSnapshotRemoveCb cbSnapshotRemove(void);
+extern CBoxSnapshotRestoreCb cbSnapshotRestore(void);
+
 #endif // BOXLITE_GO_BRIDGE_H

--- a/sdks/go/clone_export.go
+++ b/sdks/go/clone_export.go
@@ -1,0 +1,166 @@
+package boxlite
+
+/*
+#include "bridge.h"
+#include <stdlib.h>
+*/
+import "C"
+import (
+	"context"
+	"runtime/cgo"
+	"unsafe"
+)
+
+// CloneBox creates a new box that's a copy of the receiver's disk state.
+// `name` may be empty to leave the clone unnamed.
+func (b *Box) CloneBox(ctx context.Context, name string) (*Box, error) {
+	b.runtime.ensureDrainRunning()
+
+	var cName *C.char
+	if name != "" {
+		cName = toCString(name)
+		defer C.free(unsafe.Pointer(cName))
+	}
+
+	ch := make(chan handleResult[*C.CBoxHandle], 1)
+	h := registerHandleForDispatch(cgo.NewHandle(ch))
+
+	var cerr C.CBoxliteError
+	code := C.boxlite_box_clone_box(b.handle, cName, C.cbCloneBox(), handleToPtr(h), &cerr)
+	if code != C.Ok {
+		deleteHandleForDispatch(h)
+		return nil, freeError(&cerr)
+	}
+
+	select {
+	case res := <-ch:
+		if res.err != nil {
+			return nil, res.err
+		}
+		return newBoxFromHandle(b.runtime, res.value, name), nil
+	case <-ctx.Done():
+		abandonAsync(ch, h, b.runtime.closing, b.runtime.forceRemoveOrphanBox)
+		return nil, ctx.Err()
+	case <-b.runtime.closing:
+		abandonAsync(ch, h, b.runtime.closing, b.runtime.forceRemoveOrphanBox)
+		return nil, ErrRuntimeClosed
+	}
+}
+
+// Export writes the box's disks to a portable `.boxlite` archive at `dest`.
+func (b *Box) Export(ctx context.Context, dest string) error {
+	b.runtime.ensureDrainRunning()
+
+	cDest := toCString(dest)
+	defer C.free(unsafe.Pointer(cDest))
+
+	ch := make(chan error, 1)
+	h := registerHandleForDispatch(cgo.NewHandle(ch))
+
+	var cerr C.CBoxliteError
+	code := C.boxlite_box_export(b.handle, cDest, C.cbExportBox(), handleToPtr(h), &cerr)
+	if code != C.Ok {
+		deleteHandleForDispatch(h)
+		return freeError(&cerr)
+	}
+
+	select {
+	case err := <-ch:
+		return err
+	case <-ctx.Done():
+		abandonAsyncErr(ch, h, b.runtime.closing)
+		return ctx.Err()
+	case <-b.runtime.closing:
+		abandonAsyncErr(ch, h, b.runtime.closing)
+		return ErrRuntimeClosed
+	}
+}
+
+// ImportBox reads a `.boxlite` archive from `archivePath` and returns the
+// newly-imported box. `name` may be empty to leave it unnamed.
+func (r *Runtime) ImportBox(ctx context.Context, archivePath, name string) (*Box, error) {
+	r.ensureDrainRunning()
+
+	cPath := toCString(archivePath)
+	defer C.free(unsafe.Pointer(cPath))
+	var cName *C.char
+	if name != "" {
+		cName = toCString(name)
+		defer C.free(unsafe.Pointer(cName))
+	}
+
+	ch := make(chan handleResult[*C.CBoxHandle], 1)
+	h := registerHandleForDispatch(cgo.NewHandle(ch))
+
+	var cerr C.CBoxliteError
+	code := C.boxlite_runtime_import_box(
+		r.handle,
+		cPath,
+		cName,
+		C.cbCreateBox(),
+		handleToPtr(h),
+		&cerr,
+	)
+	if code != C.Ok {
+		deleteHandleForDispatch(h)
+		return nil, freeError(&cerr)
+	}
+
+	select {
+	case res := <-ch:
+		if res.err != nil {
+			return nil, res.err
+		}
+		return newBoxFromHandle(r, res.value, name), nil
+	case <-ctx.Done():
+		abandonAsync(ch, h, r.closing, r.forceRemoveOrphanBox)
+		return nil, ctx.Err()
+	case <-r.closing:
+		abandonAsync(ch, h, r.closing, r.forceRemoveOrphanBox)
+		return nil, ErrRuntimeClosed
+	}
+}
+
+// ─── Cgo callback exports ─────────────────────────────────────────────────
+
+//export goBoxliteOnCloneBox
+func goBoxliteOnCloneBox(box *C.CBoxHandle, errPtr *C.CBoxliteError, userData unsafe.Pointer) {
+	h := ptrToHandle(userData)
+	if h == 0 {
+		return
+	}
+	if !claimOrFreePayload(h, &box, func(b **C.CBoxHandle) {
+		if b != nil && *b != nil {
+			C.boxlite_box_free(*b)
+		}
+	}) {
+		return
+	}
+	defer h.Delete()
+	ch, ok := h.Value().(chan handleResult[*C.CBoxHandle])
+	if !ok {
+		return
+	}
+	if err := errorFromCError(errPtr); err != nil {
+		ch <- handleResult[*C.CBoxHandle]{err: err}
+		return
+	}
+	ch <- handleResult[*C.CBoxHandle]{value: box}
+}
+
+//export goBoxliteOnExportBox
+func goBoxliteOnExportBox(errPtr *C.CBoxliteError, userData unsafe.Pointer) {
+	h := ptrToHandle(userData)
+	if h == 0 {
+		return
+	}
+	if !claimHandleForDispatch(h) {
+		return
+	}
+	defer h.Delete()
+	ch, ok := h.Value().(chan error)
+	if !ok {
+		return
+	}
+	ch <- errorFromCError(errPtr)
+}

--- a/sdks/go/snapshot.go
+++ b/sdks/go/snapshot.go
@@ -1,0 +1,308 @@
+package boxlite
+
+/*
+#include "bridge.h"
+#include <stdlib.h>
+*/
+import "C"
+import (
+	"context"
+	"runtime/cgo"
+	"unsafe"
+)
+
+// SnapshotInfo describes a box state snapshot.
+type SnapshotInfo struct {
+	ID                  string
+	BoxID               string
+	Name                string
+	CreatedAt           int64
+	ContainerDiskBytes  uint64
+	SizeBytes           uint64
+}
+
+type snapshotCreateResult struct {
+	value *SnapshotInfo
+	err   error
+}
+
+type snapshotListResult struct {
+	value []SnapshotInfo
+	err   error
+}
+
+// SnapshotCreate creates a snapshot of the box's current disk state with the
+// given name.
+func (b *Box) SnapshotCreate(ctx context.Context, name string) (*SnapshotInfo, error) {
+	b.runtime.ensureDrainRunning()
+
+	cName := toCString(name)
+	defer C.free(unsafe.Pointer(cName))
+
+	ch := make(chan snapshotCreateResult, 1)
+	h := registerHandleForDispatch(cgo.NewHandle(ch))
+
+	var cerr C.CBoxliteError
+	code := C.boxlite_box_snapshot_create(b.handle, cName, C.cbSnapshotCreate(), handleToPtr(h), &cerr)
+	if code != C.Ok {
+		deleteHandleForDispatch(h)
+		return nil, freeError(&cerr)
+	}
+
+	select {
+	case res := <-ch:
+		return res.value, res.err
+	case <-ctx.Done():
+		drainAndDelete(ch, h, b.runtime.closing)
+		return nil, ctx.Err()
+	case <-b.runtime.closing:
+		drainAndDelete(ch, h, b.runtime.closing)
+		return nil, ErrRuntimeClosed
+	}
+}
+
+// SnapshotList returns every snapshot belonging to this box.
+func (b *Box) SnapshotList(ctx context.Context) ([]SnapshotInfo, error) {
+	b.runtime.ensureDrainRunning()
+
+	ch := make(chan snapshotListResult, 1)
+	h := registerHandleForDispatch(cgo.NewHandle(ch))
+
+	var cerr C.CBoxliteError
+	code := C.boxlite_box_snapshot_list(b.handle, C.cbSnapshotList(), handleToPtr(h), &cerr)
+	if code != C.Ok {
+		deleteHandleForDispatch(h)
+		return nil, freeError(&cerr)
+	}
+
+	select {
+	case res := <-ch:
+		return res.value, res.err
+	case <-ctx.Done():
+		drainAndDelete(ch, h, b.runtime.closing)
+		return nil, ctx.Err()
+	case <-b.runtime.closing:
+		drainAndDelete(ch, h, b.runtime.closing)
+		return nil, ErrRuntimeClosed
+	}
+}
+
+// SnapshotGet looks up a snapshot by name. Returns (nil, nil) when the
+// snapshot is not present (404).
+func (b *Box) SnapshotGet(ctx context.Context, name string) (*SnapshotInfo, error) {
+	b.runtime.ensureDrainRunning()
+
+	cName := toCString(name)
+	defer C.free(unsafe.Pointer(cName))
+
+	ch := make(chan snapshotCreateResult, 1)
+	h := registerHandleForDispatch(cgo.NewHandle(ch))
+
+	var cerr C.CBoxliteError
+	code := C.boxlite_box_snapshot_get(b.handle, cName, C.cbSnapshotCreate(), handleToPtr(h), &cerr)
+	if code != C.Ok {
+		deleteHandleForDispatch(h)
+		return nil, freeError(&cerr)
+	}
+
+	select {
+	case res := <-ch:
+		if res.err != nil {
+			// "snapshot not found" surfaces from libboxlite as NotFound; the
+			// caller-friendly shape is (nil, nil).
+			if be, ok := res.err.(*Error); ok && be.Code == ErrNotFound {
+				return nil, nil
+			}
+			return nil, res.err
+		}
+		return res.value, nil
+	case <-ctx.Done():
+		drainAndDelete(ch, h, b.runtime.closing)
+		return nil, ctx.Err()
+	case <-b.runtime.closing:
+		drainAndDelete(ch, h, b.runtime.closing)
+		return nil, ErrRuntimeClosed
+	}
+}
+
+// SnapshotRemove deletes the named snapshot.
+func (b *Box) SnapshotRemove(ctx context.Context, name string) error {
+	b.runtime.ensureDrainRunning()
+
+	cName := toCString(name)
+	defer C.free(unsafe.Pointer(cName))
+
+	ch := make(chan error, 1)
+	h := registerHandleForDispatch(cgo.NewHandle(ch))
+
+	var cerr C.CBoxliteError
+	code := C.boxlite_box_snapshot_remove(b.handle, cName, C.cbSnapshotRemove(), handleToPtr(h), &cerr)
+	if code != C.Ok {
+		deleteHandleForDispatch(h)
+		return freeError(&cerr)
+	}
+
+	select {
+	case err := <-ch:
+		return err
+	case <-ctx.Done():
+		abandonAsyncErr(ch, h, b.runtime.closing)
+		return ctx.Err()
+	case <-b.runtime.closing:
+		abandonAsyncErr(ch, h, b.runtime.closing)
+		return ErrRuntimeClosed
+	}
+}
+
+// SnapshotRestore reverts the box's disks to the named snapshot.
+func (b *Box) SnapshotRestore(ctx context.Context, name string) error {
+	b.runtime.ensureDrainRunning()
+
+	cName := toCString(name)
+	defer C.free(unsafe.Pointer(cName))
+
+	ch := make(chan error, 1)
+	h := registerHandleForDispatch(cgo.NewHandle(ch))
+
+	var cerr C.CBoxliteError
+	code := C.boxlite_box_snapshot_restore(b.handle, cName, C.cbSnapshotRestore(), handleToPtr(h), &cerr)
+	if code != C.Ok {
+		deleteHandleForDispatch(h)
+		return freeError(&cerr)
+	}
+
+	select {
+	case err := <-ch:
+		return err
+	case <-ctx.Done():
+		abandonAsyncErr(ch, h, b.runtime.closing)
+		return ctx.Err()
+	case <-b.runtime.closing:
+		abandonAsyncErr(ch, h, b.runtime.closing)
+		return ErrRuntimeClosed
+	}
+}
+
+// ─── Conversions ──────────────────────────────────────────────────────────
+
+func cSnapshotInfoToGo(info *C.CSnapshotInfo) SnapshotInfo {
+	if info == nil {
+		return SnapshotInfo{}
+	}
+	return SnapshotInfo{
+		ID:                 C.GoString(info.id),
+		BoxID:              C.GoString(info.box_id),
+		Name:               C.GoString(info.name),
+		CreatedAt:          int64(info.created_at),
+		ContainerDiskBytes: uint64(info.container_disk_bytes),
+		SizeBytes:          uint64(info.size_bytes),
+	}
+}
+
+func convertSnapshotInfoList(list *C.CSnapshotInfoList) []SnapshotInfo {
+	if list == nil || list.count == 0 {
+		return nil
+	}
+	items := unsafe.Slice(list.items, int(list.count))
+	out := make([]SnapshotInfo, 0, len(items))
+	for i := range items {
+		out = append(out, cSnapshotInfoToGo(&items[i]))
+	}
+	return out
+}
+
+// ─── Cgo callback exports ─────────────────────────────────────────────────
+
+//export goBoxliteOnSnapshotCreate
+func goBoxliteOnSnapshotCreate(info *C.CSnapshotInfo, errPtr *C.CBoxliteError, userData unsafe.Pointer) {
+	h := ptrToHandle(userData)
+	if h == 0 {
+		return
+	}
+	if !claimOrFreePayload(h, &info, func(i **C.CSnapshotInfo) {
+		if i != nil && *i != nil {
+			C.boxlite_free_snapshot_info(*i)
+		}
+	}) {
+		return
+	}
+	defer h.Delete()
+	ch, ok := h.Value().(chan snapshotCreateResult)
+	if !ok {
+		return
+	}
+	if err := errorFromCError(errPtr); err != nil {
+		ch <- snapshotCreateResult{err: err}
+		return
+	}
+	if info == nil {
+		ch <- snapshotCreateResult{}
+		return
+	}
+	v := cSnapshotInfoToGo(info)
+	C.boxlite_free_snapshot_info(info)
+	ch <- snapshotCreateResult{value: &v}
+}
+
+//export goBoxliteOnSnapshotList
+func goBoxliteOnSnapshotList(list *C.CSnapshotInfoList, errPtr *C.CBoxliteError, userData unsafe.Pointer) {
+	h := ptrToHandle(userData)
+	if h == 0 {
+		return
+	}
+	if !claimOrFreePayload(h, &list, func(l **C.CSnapshotInfoList) {
+		if l != nil && *l != nil {
+			C.boxlite_free_snapshot_info_list(*l)
+		}
+	}) {
+		return
+	}
+	defer h.Delete()
+	ch, ok := h.Value().(chan snapshotListResult)
+	if !ok {
+		return
+	}
+	if err := errorFromCError(errPtr); err != nil {
+		ch <- snapshotListResult{err: err}
+		return
+	}
+	out := convertSnapshotInfoList(list)
+	if list != nil {
+		C.boxlite_free_snapshot_info_list(list)
+	}
+	ch <- snapshotListResult{value: out}
+}
+
+//export goBoxliteOnSnapshotRemove
+func goBoxliteOnSnapshotRemove(errPtr *C.CBoxliteError, userData unsafe.Pointer) {
+	h := ptrToHandle(userData)
+	if h == 0 {
+		return
+	}
+	if !claimHandleForDispatch(h) {
+		return
+	}
+	defer h.Delete()
+	ch, ok := h.Value().(chan error)
+	if !ok {
+		return
+	}
+	ch <- errorFromCError(errPtr)
+}
+
+//export goBoxliteOnSnapshotRestore
+func goBoxliteOnSnapshotRestore(errPtr *C.CBoxliteError, userData unsafe.Pointer) {
+	h := ptrToHandle(userData)
+	if h == 0 {
+		return
+	}
+	if !claimHandleForDispatch(h) {
+		return
+	}
+	defer h.Delete()
+	ch, ok := h.Value().(chan error)
+	if !ok {
+		return
+	}
+	ch <- errorFromCError(errPtr)
+}


### PR DESCRIPTION
Adds clone, export, runtime import over the REST chain following the same template as #694 (snapshot). Pre-fix the SDK Rust REST client short-circuited each call with "Remote server does not support {clone,export,import} operations" because /v1/config returned all three capabilities as false.

Layers added (≈765 lines):
- **C FFI** (\`sdks/c/src/clone_export.rs\`): \`boxlite_box_clone_box\`, \`boxlite_box_export\`, \`boxlite_runtime_import_box\`
- **event_queue**: 2 new RuntimeEvent variants + callback function types
- **Go SDK** (\`sdks/go/clone_export.go\`): \`Box.CloneBox\`, \`Box.Export\`, \`Runtime.ImportBox\`
- **Runner**: controller with 3 handlers (export streams archive bytes back; import reads body bytes to temp file) + 3 routes
- **API NestJS**: 3 proxy routes; import is runtime-level (no boxId) so we pick a runner via \`pickRunnerForImport\` (any runner the org has a sandbox on); config flips clone/export/import capabilities to true

## Test plan

Pins: \`scripts/test/e2e/cases/test_snapshot_clone.py::{test_clone_box_yields_independent_disk, test_export_import_roundtrip}\`

| | Pre-fix | Post-fix |
|---|---|---|
| \`box.clone_box()\` | \`Remote server does not support clone\` | reaches libboxlite via REST chain |
| \`box.export(dest=...)\` | \`Remote server does not support export\` | reaches libboxlite via REST chain |
| \`runtime.import_box(path)\` | \`Remote server does not support import\` | reaches libboxlite via REST chain |

Outstanding failure (\`Failed to SIGSTOP shim process: Connection refused\`) is a libboxlite snapshot-mechanism issue — same signature as #694's residual, reproducible against local FFI on the same host. **Out of scope for this REST surface PR.**

Branched off #694 — depends on snapshot baseline + cbindgen header refresh landing first.
