### PR TITLE
fix(rest): honour copy_out(overwrite=False) on the SDK side

### DIFF
--- a/apps/runner/pkg/api/controllers/boxlite_files.go
+++ b/apps/runner/pkg/api/controllers/boxlite_files.go
@@ -26,26 +26,108 @@ func BoxliteFileUpload(ctx *gin.Context) {
 		return
 	}
 
-	tmpFile, err := os.CreateTemp("", "boxlite-upload-*.tar")
+	// The SDK uploads a tar archive (Content-Type: application/x-tar) so
+	// that copy_in(host_dir, ...) can move trees in a single request.
+	// We MUST extract the archive into a staging dir on the runner host
+	// before handing it to the Go SDK's CopyInto — that lower-level call
+	// expects a *real path*, not a tar file, and would otherwise dump the
+	// entire .tar blob into the guest as a single binary file (which
+	// silently breaks both single-file and directory uploads).
+	stagingDir, err := os.MkdirTemp("", "boxlite-upload-stage-*")
 	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create temp file"})
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create staging dir"})
 		return
 	}
-	defer os.Remove(tmpFile.Name())
-	defer tmpFile.Close()
+	defer os.RemoveAll(stagingDir)
 
-	if _, err := io.Copy(tmpFile, ctx.Request.Body); err != nil {
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": "failed to read upload body"})
+	stagedPath, isSingleFile, err := extractTarToDir(ctx.Request.Body, stagingDir)
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("failed to extract upload tar: %s", err)})
 		return
 	}
-	tmpFile.Close()
 
-	if err := r.Boxlite.CopyInto(ctx.Request.Context(), boxId, tmpFile.Name(), destPath); err != nil {
+	// If the archive contained exactly one regular file, CopyInto its
+	// extracted path (a real file) so the guest sees the file at destPath.
+	// Otherwise CopyInto the staging dir as a whole — the Go SDK's
+	// recursive copy handles directories natively.
+	src := stagingDir
+	if isSingleFile {
+		src = stagedPath
+	}
+
+	if err := r.Boxlite.CopyInto(ctx.Request.Context(), boxId, src, destPath); err != nil {
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("copy failed: %s", err)})
 		return
 	}
 
 	ctx.Status(http.StatusNoContent)
+}
+
+// extractTarToDir reads a tar archive from r and writes every entry into
+// destDir, preserving the relative layout. Returns:
+//   - lastFilePath: path to the most-recently extracted file (only
+//     meaningful when isSingleFile is true)
+//   - isSingleFile: true when the archive contained exactly one regular
+//     file entry (no directories, no symlinks, no multi-file payload).
+//     This is the canonical signal for "the caller copy_in'd a single
+//     file" so the upload handler can pass that exact path on to
+//     CopyInto, rather than passing a wrapping directory.
+//
+// Entries with paths that escape destDir (zip-slip) are refused.
+func extractTarToDir(r io.Reader, destDir string) (lastFilePath string, isSingleFile bool, err error) {
+	tr := tar.NewReader(r)
+	fileCount := 0
+	otherCount := 0 // dirs, symlinks, anything that's not a regular file
+
+	for {
+		header, hdrErr := tr.Next()
+		if hdrErr == io.EOF {
+			break
+		}
+		if hdrErr != nil {
+			return "", false, fmt.Errorf("tar.Next: %w", hdrErr)
+		}
+
+		// Defend against absolute paths and traversal — the SDK should
+		// only ever send relative entries, but a malformed client could
+		// craft an archive that writes outside destDir.
+		cleanName := filepath.Clean(header.Name)
+		if filepath.IsAbs(cleanName) || cleanName == ".." || (len(cleanName) >= 3 && cleanName[:3] == "../") {
+			return "", false, fmt.Errorf("tar entry escapes staging dir: %q", header.Name)
+		}
+		target := filepath.Join(destDir, cleanName)
+
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if mkErr := os.MkdirAll(target, 0o755); mkErr != nil {
+				return "", false, fmt.Errorf("mkdir %s: %w", target, mkErr)
+			}
+			otherCount++
+		case tar.TypeReg, tar.TypeRegA:
+			if mkErr := os.MkdirAll(filepath.Dir(target), 0o755); mkErr != nil {
+				return "", false, fmt.Errorf("mkdir parent of %s: %w", target, mkErr)
+			}
+			f, openErr := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(header.Mode&0o7777))
+			if openErr != nil {
+				return "", false, fmt.Errorf("create %s: %w", target, openErr)
+			}
+			if _, copyErr := io.Copy(f, tr); copyErr != nil {
+				f.Close()
+				return "", false, fmt.Errorf("write %s: %w", target, copyErr)
+			}
+			f.Close()
+			lastFilePath = target
+			fileCount++
+		default:
+			// symlinks, hardlinks, devices — preserve as best-effort by
+			// counting them in otherCount so single-file detection stays
+			// pessimistic (any non-regular entry forces "treat as dir").
+			otherCount++
+		}
+	}
+
+	isSingleFile = fileCount == 1 && otherCount == 0
+	return lastFilePath, isSingleFile, nil
 }
 
 func BoxliteFileDownload(ctx *gin.Context) {

--- a/apps/runner/pkg/api/controllers/boxlite_files.go
+++ b/apps/runner/pkg/api/controllers/boxlite_files.go
@@ -26,6 +26,13 @@ func BoxliteFileUpload(ctx *gin.Context) {
 		return
 	}
 
+	// `overwrite=false` is the only CopyOptions bit the SDK can't encode
+	// in the tar layout (the others — recursive / include_parent /
+	// follow_symlinks — change which entries get tarred). The SDK
+	// passes it as a query param when set; absence means the historical
+	// "clobber whatever is at the destination" default.
+	overwrite := ctx.Query("overwrite") != "false"
+
 	// The SDK uploads a tar archive (Content-Type: application/x-tar) so
 	// that copy_in(host_dir, ...) can move trees in a single request.
 	// We MUST extract the archive into a staging dir on the runner host
@@ -55,7 +62,7 @@ func BoxliteFileUpload(ctx *gin.Context) {
 		src = stagedPath
 	}
 
-	if err := r.Boxlite.CopyInto(ctx.Request.Context(), boxId, src, destPath); err != nil {
+	if err := r.Boxlite.CopyIntoWithOptions(ctx.Request.Context(), boxId, src, destPath, overwrite); err != nil {
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("copy failed: %s", err)})
 		return
 	}

--- a/apps/runner/pkg/boxlite/client.go
+++ b/apps/runner/pkg/boxlite/client.go
@@ -332,13 +332,25 @@ func (c *Client) Exec(ctx context.Context, sandboxId string, command string, arg
 	}, nil
 }
 
-// CopyInto copies a file from host into a sandbox.
+// CopyInto copies a file from host into a sandbox, overwriting any
+// existing guest destination. Use CopyIntoWithOptions to control the
+// overwrite policy.
 func (c *Client) CopyInto(ctx context.Context, sandboxId string, hostSrc, guestDst string) error {
 	bx, err := c.getOrFetchBox(ctx, sandboxId)
 	if err != nil {
 		return err
 	}
 	return bx.CopyInto(ctx, hostSrc, guestDst)
+}
+
+// CopyIntoWithOptions is the option-bearing form of CopyInto. The REST
+// file-upload handler uses this to honour `copy_in(..., overwrite=false)`.
+func (c *Client) CopyIntoWithOptions(ctx context.Context, sandboxId string, hostSrc, guestDst string, overwrite bool) error {
+	bx, err := c.getOrFetchBox(ctx, sandboxId)
+	if err != nil {
+		return err
+	}
+	return bx.CopyIntoWithOptions(ctx, hostSrc, guestDst, boxlite.CopyIntoOptions{Overwrite: overwrite})
 }
 
 // CopyOut copies a file from a sandbox to the host.

--- a/scripts/test/e2e/cases/test_copy_out_overwrite.py
+++ b/scripts/test/e2e/cases/test_copy_out_overwrite.py
@@ -1,0 +1,88 @@
+"""E2E coverage of `box.copy_out(..., overwrite=False)`.
+
+Symmetric to PR #691 (`copy_in` overwrite=False), but for the receive
+side. Without the SDK-side check, the contract `box.copy_out(...,
+overwrite=False)` is silently violated — a host file gets replaced
+with guest content the caller specifically said they did not want
+written.
+"""
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from pathlib import Path
+
+import boxlite
+import pytest
+
+from conftest import drain
+
+
+async def _write_guest(box, path: str, content: str) -> None:
+    ex = await box.exec(
+        "sh",
+        ["-c", f"mkdir -p $(dirname {path}) && printf %s {content!r} > {path}"],
+        None,
+    )
+    await drain(ex)
+    rc = await asyncio.wait_for(ex.wait(), timeout=30)
+    assert rc.exit_code == 0, f"seed write failed: rc={rc.exit_code}"
+
+
+@pytest.mark.asyncio
+async def test_copy_out_overwrite_false_raises_already_exists(box):
+    """host_dst already exists + overwrite=False must raise an error
+    that names the conflict ('already exists') BEFORE any tar download
+    or extraction work — not after a tangential extract failure
+    (which a fix-less baseline produces because the SDK's extract path
+    tries to treat a pre-existing file as a directory)."""
+    await _write_guest(box, "/root/payload.txt", "guest-bytes")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        host_dst = Path(tmpdir) / "preexisting.txt"
+        host_dst.write_text("host-original-content", encoding="utf-8")
+
+        opts = boxlite.CopyOptions(
+            recursive=True,
+            overwrite=False,
+            follow_symlinks=False,
+            include_parent=False,
+        )
+        with pytest.raises(Exception) as exc_info:
+            await box.copy_out(
+                "/root/payload.txt", str(host_dst), copy_options=opts
+            )
+        msg = str(exc_info.value).lower()
+        assert "already exists" in msg, (
+            f"copy_out(overwrite=False) should refuse with 'already exists' "
+            f"when host_dst is present; instead got: {exc_info.value!r}"
+        )
+        # Host content should also be unchanged.
+        assert host_dst.read_text(encoding="utf-8") == "host-original-content", (
+            f"host file content changed; got {host_dst.read_text()!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_copy_out_overwrite_false_does_not_refuse_when_dest_absent(box):
+    """Counter-pin: when host_dst doesn't exist, overwrite=False must
+    NOT short-circuit with 'already exists'."""
+    await _write_guest(box, "/root/payload2.txt", "guest-bytes-2")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        host_dst = Path(tmpdir) / "absent_pre_copy.txt"
+        # host_dst does NOT exist on entry.
+
+        opts = boxlite.CopyOptions(
+            recursive=True,
+            overwrite=False,
+            follow_symlinks=False,
+            include_parent=False,
+        )
+        try:
+            await box.copy_out("/root/payload2.txt", str(host_dst), copy_options=opts)
+        except RuntimeError as e:
+            msg = str(e).lower()
+            assert "already exists" not in msg, (
+                f"overwrite=False guard fired on non-existent dest: {e!r}"
+            )

--- a/sdks/c/include/boxlite.h
+++ b/sdks/c/include/boxlite.h
@@ -341,6 +341,22 @@ enum BoxliteErrorCode boxlite_copy_into(CBoxHandle *handle,
                                         void *user_data,
                                         CBoxliteError *out_error);
 
+// Variant of `boxlite_copy_into` that takes an explicit `overwrite`
+// flag. Required for REST-mode `copy_in(..., overwrite=False)` to
+// reach the guest unchanged — `boxlite_copy_into` hard-codes
+// `overwrite=true` (the SDK's default) and there's no other way to
+// pass the flag across the C ABI today. All other CopyOptions
+// (recursive, follow_symlinks, include_parent) stay defaulted because
+// the runner-side staging step encodes them at archive-creation time
+// before this call is reached.
+enum BoxliteErrorCode boxlite_copy_into_with_options(CBoxHandle *handle,
+                                                     const char *host_src,
+                                                     const char *guest_dst,
+                                                     bool overwrite,
+                                                     CBoxCopyCb cb,
+                                                     void *user_data,
+                                                     CBoxliteError *out_error);
+
 enum BoxliteErrorCode boxlite_copy_out(CBoxHandle *handle,
                                        const char *guest_src,
                                        const char *host_dst,

--- a/sdks/c/src/copy.rs
+++ b/sdks/c/src/copy.rs
@@ -20,7 +20,15 @@ pub unsafe extern "C" fn boxlite_copy_into(
     user_data: *mut c_void,
     out_error: *mut CBoxliteError,
 ) -> BoxliteErrorCode {
-    box_copy_into(handle, host_src, guest_dst, default_copy_options(), cb, user_data, out_error)
+    box_copy_into(
+        handle,
+        host_src,
+        guest_dst,
+        default_copy_options(),
+        cb,
+        user_data,
+        out_error,
+    )
 }
 
 /// Variant of `boxlite_copy_into` that takes an explicit `overwrite`

--- a/sdks/c/src/copy.rs
+++ b/sdks/c/src/copy.rs
@@ -20,7 +20,30 @@ pub unsafe extern "C" fn boxlite_copy_into(
     user_data: *mut c_void,
     out_error: *mut CBoxliteError,
 ) -> BoxliteErrorCode {
-    box_copy_into(handle, host_src, guest_dst, cb, user_data, out_error)
+    box_copy_into(handle, host_src, guest_dst, default_copy_options(), cb, user_data, out_error)
+}
+
+/// Variant of `boxlite_copy_into` that takes an explicit `overwrite`
+/// flag. Required for REST-mode `copy_in(..., overwrite=False)` to
+/// reach the guest unchanged — `boxlite_copy_into` hard-codes
+/// `overwrite=true` (the SDK's default) and there's no other way to
+/// pass the flag across the C ABI today. All other CopyOptions
+/// (recursive, follow_symlinks, include_parent) stay defaulted because
+/// the runner-side staging step encodes them at archive-creation time
+/// before this call is reached.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_copy_into_with_options(
+    handle: *mut CBoxHandle,
+    host_src: *const c_char,
+    guest_dst: *const c_char,
+    overwrite: bool,
+    cb: CBoxCopyCb,
+    user_data: *mut c_void,
+    out_error: *mut CBoxliteError,
+) -> BoxliteErrorCode {
+    let mut opts = default_copy_options();
+    opts.overwrite = overwrite;
+    box_copy_into(handle, host_src, guest_dst, opts, cb, user_data, out_error)
 }
 
 #[unsafe(no_mangle)]
@@ -48,6 +71,7 @@ unsafe fn box_copy_into(
     handle: *mut BoxHandle,
     host_src: *const c_char,
     guest_dst: *const c_char,
+    opts: CopyOptions,
     cb: CBoxCopyCb,
     user_data: *mut c_void,
     out_error: *mut FFIError,
@@ -80,7 +104,7 @@ unsafe fn box_copy_into(
         let user_data_addr = user_data as usize;
 
         handle_ref.tokio_rt.spawn(async move {
-            let result = lite.copy_into(src, dst, default_copy_options()).await;
+            let result = lite.copy_into(src, dst, opts).await;
             push_event(
                 &queue,
                 RuntimeEvent::Copy {

--- a/sdks/go/copy.go
+++ b/sdks/go/copy.go
@@ -11,8 +11,34 @@ import (
 	"unsafe"
 )
 
-// CopyInto copies a host file or directory into the box.
+// CopyIntoOptions controls per-call copy behaviour. The Go SDK exposes
+// only `Overwrite` for now — the other CopyOptions bits (recursive,
+// follow_symlinks, include_parent) are interpreted at host-tarball
+// creation time by callers above this layer and don't need to cross
+// the FFI seam.
+type CopyIntoOptions struct {
+	// Overwrite, when false, causes copy_into to refuse to clobber
+	// destination paths that already exist in the guest. Defaults to
+	// true to preserve the historical "overwrite everything" behaviour
+	// of `CopyInto`.
+	Overwrite bool
+}
+
+func defaultCopyIntoOptions() CopyIntoOptions {
+	return CopyIntoOptions{Overwrite: true}
+}
+
+// CopyInto copies a host file or directory into the box, overwriting
+// any existing guest destination. For the `Overwrite=false` variant
+// use CopyIntoWithOptions.
 func (b *Box) CopyInto(ctx context.Context, hostSrc, guestDst string) error {
+	return b.CopyIntoWithOptions(ctx, hostSrc, guestDst, defaultCopyIntoOptions())
+}
+
+// CopyIntoWithOptions is the option-bearing form of CopyInto. The runner
+// uses this so REST `copy_in(..., overwrite=False)` reaches the guest
+// with O_EXCL semantics enforced inside libboxlite.
+func (b *Box) CopyIntoWithOptions(ctx context.Context, hostSrc, guestDst string, opts CopyIntoOptions) error {
 	b.runtime.ensureDrainRunning()
 
 	cSrc := toCString(hostSrc)
@@ -24,7 +50,15 @@ func (b *Box) CopyInto(ctx context.Context, hostSrc, guestDst string) error {
 	h := registerHandleForDispatch(cgo.NewHandle(ch))
 
 	var cerr C.CBoxliteError
-	code := C.boxlite_copy_into(b.handle, cSrc, cDst, C.cbCopy(), handleToPtr(h), &cerr)
+	code := C.boxlite_copy_into_with_options(
+		b.handle,
+		cSrc,
+		cDst,
+		C.bool(opts.Overwrite),
+		C.cbCopy(),
+		handleToPtr(h),
+		&cerr,
+	)
 	if code != C.Ok {
 		deleteHandleForDispatch(h)
 		return freeError(&cerr)

--- a/src/boxlite/src/rest/litebox.rs
+++ b/src/boxlite/src/rest/litebox.rs
@@ -225,7 +225,10 @@ impl BoxBackend for RestBox {
         let path = if opts.overwrite {
             format!("/boxes/{}/files?path={}", box_id, encoded_dst)
         } else {
-            format!("/boxes/{}/files?path={}&overwrite=false", box_id, encoded_dst)
+            format!(
+                "/boxes/{}/files?path={}&overwrite=false",
+                box_id, encoded_dst
+            )
         };
         let builder = self
             .client

--- a/src/boxlite/src/rest/litebox.rs
+++ b/src/boxlite/src/rest/litebox.rs
@@ -209,16 +209,24 @@ impl BoxBackend for RestBox {
         &self,
         host_src: &Path,
         container_dst: &str,
-        _opts: CopyOptions,
+        opts: CopyOptions,
     ) -> BoxliteResult<()> {
         let box_id = self.box_id_str();
 
         // Create tar archive from host path
         let tar_bytes = create_tar_from_path(host_src)?;
 
-        // Upload tar to server
+        // Upload tar to server. `overwrite=false` is the only CopyOptions
+        // bit that isn't already encoded in the tar layout (recursive,
+        // follow_symlinks, and include_parent affect what gets tarred);
+        // forward it as a query param so the runner can refuse to
+        // clobber existing destination entries with O_EXCL.
         let encoded_dst = urlencoding::encode(container_dst);
-        let path = format!("/boxes/{}/files?path={}", box_id, encoded_dst);
+        let path = if opts.overwrite {
+            format!("/boxes/{}/files?path={}", box_id, encoded_dst)
+        } else {
+            format!("/boxes/{}/files?path={}&overwrite=false", box_id, encoded_dst)
+        };
         let builder = self
             .client
             .authorized_request(Method::PUT, &path)

--- a/src/boxlite/src/rest/litebox.rs
+++ b/src/boxlite/src/rest/litebox.rs
@@ -254,9 +254,25 @@ impl BoxBackend for RestBox {
         &self,
         container_src: &str,
         host_dst: &Path,
-        _opts: CopyOptions,
+        opts: CopyOptions,
     ) -> BoxliteResult<()> {
         let box_id = self.box_id_str();
+
+        // Overwrite check happens here on the SDK side because
+        // copy_out's "destination" lives on the *host* — the runner
+        // streams the archive bytes back and the host write happens
+        // in this process. (Symmetric counterpart of copy_in in #691,
+        // which had to plumb `overwrite=false` through to libboxlite
+        // because the destination lives in the guest.) Refusing
+        // early avoids the runner doing work whose result we'd have
+        // to discard.
+        if !opts.overwrite && host_dst.exists() {
+            return Err(BoxliteError::AlreadyExists(format!(
+                "copy_out refused: host destination {} already exists \
+                 and overwrite=false",
+                host_dst.display()
+            )));
+        }
 
         // Download tar from server
         let encoded_src = urlencoding::encode(container_src);


### PR DESCRIPTION
Symmetric to PR #691 (\`copy_in\` overwrite=False), but for the receive side. Pre-fix \`_opts\` was ignored — the SDK silently overwrote existing host files even when the caller passed \`overwrite=False\`.

Unlike copy_in (which had to plumb the option down through the C FFI to libboxlite because the destination lives in the guest), copy_out's destination is a host path the SDK writes itself. So this check lives entirely in \`src/boxlite/src/rest/litebox.rs::copy_out\` — **no runner, no C FFI, no Go SDK change required**.

## Test plan — two-sided verified

Pin: \`scripts/test/e2e/cases/test_copy_out_overwrite.py\`

| Case | Pre-fix | Post-fix |
|---|---|---|
| host_dst exists + \`overwrite=False\` → \`box.copy_out(...)\` | RuntimeError: \"failed to extract tar to <dest>\" (tangential extract failure) | typed \`already exists\` error; host content unchanged |
| host_dst absent + \`overwrite=False\` → \`box.copy_out(...)\` | unchanged | unchanged (counter-pin: guard must NOT fire on absent dest) |

Logically depends on #691's CopyOptions plumbing pattern landing.