### PR TITLE
feat: runner ghcr auth (direct private-image pull) + W3C traceId propagation [A2 4/5]

### DIFF
--- a/apps/daemon/cmd/daemon/config/config.go
+++ b/apps/daemon/cmd/daemon/config/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	RecordingsDir            string        `envconfig:"BOXLITE_RECORDINGS_DIR"`
 	OrganizationId           *string       `envconfig:"BOXLITE_ORGANIZATION_ID"`
 	RegionId                 *string       `envconfig:"BOXLITE_REGION_ID"`
+	TraceParent              *string       `envconfig:"BOXLITE_TRACEPARENT"`
 }
 
 var defaultDaemonLogFilePath = "/tmp/boxlite-daemon.log"

--- a/apps/daemon/cmd/daemon/main.go
+++ b/apps/daemon/cmd/daemon/main.go
@@ -178,6 +178,7 @@ func run() int {
 		RecordingService:      recordingService,
 		OrganizationId:        c.OrganizationId,
 		RegionId:              c.RegionId,
+		TraceParent:           c.TraceParent,
 		EntrypointLogFilePath: entrypointLogFilePath,
 	})
 

--- a/apps/daemon/pkg/toolbox/controller.go
+++ b/apps/daemon/pkg/toolbox/controller.go
@@ -22,7 +22,7 @@ import (
 //	@Router			/init [post]
 //
 //	@id				Initialize
-func (s *server) Initialize(otelServiceName string, entrypointLogFilePath string, organizationId, regionId *string) gin.HandlerFunc {
+func (s *server) Initialize(otelServiceName string, entrypointLogFilePath string, organizationId, regionId, traceParent *string) gin.HandlerFunc {
 	return func(ctx *gin.Context) {
 		var req InitializeRequest
 		if err := ctx.ShouldBindJSON(&req); err != nil {
@@ -32,7 +32,7 @@ func (s *server) Initialize(otelServiceName string, entrypointLogFilePath string
 
 		s.authToken = req.Token
 
-		err := s.initTelemetry(ctx.Request.Context(), otelServiceName, entrypointLogFilePath, organizationId, regionId)
+		err := s.initTelemetry(ctx.Request.Context(), otelServiceName, entrypointLogFilePath, organizationId, regionId, traceParent)
 		if err != nil {
 			ctx.AbortWithError(http.StatusBadRequest, err)
 			return

--- a/apps/daemon/pkg/toolbox/server.go
+++ b/apps/daemon/pkg/toolbox/server.go
@@ -61,6 +61,7 @@ type ServerConfig struct {
 	RecordingService      *recording.RecordingService
 	OrganizationId        *string
 	RegionId              *string
+	TraceParent           *string
 	EntrypointLogFilePath string
 }
 
@@ -76,6 +77,7 @@ func NewServer(config ServerConfig) *server {
 		recordingService:      config.RecordingService,
 		organizationId:        config.OrganizationId,
 		regionId:              config.RegionId,
+		traceParent:           config.TraceParent,
 		entrypointLogFilePath: config.EntrypointLogFilePath,
 	}
 }
@@ -96,6 +98,7 @@ type server struct {
 	httpServer            *http.Server
 	organizationId        *string
 	regionId              *string
+	traceParent           *string
 	ctx                   context.Context
 	cancel                context.CancelFunc
 }
@@ -152,7 +155,7 @@ func (s *server) Start() error {
 		r.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerfiles.Handler))
 	}
 
-	r.POST("/init", s.Initialize(otelServiceName, s.entrypointLogFilePath, s.organizationId, s.regionId))
+	r.POST("/init", s.Initialize(otelServiceName, s.entrypointLogFilePath, s.organizationId, s.regionId, s.traceParent))
 
 	r.GET("/version", s.GetVersion)
 

--- a/apps/daemon/pkg/toolbox/telemetry.go
+++ b/apps/daemon/pkg/toolbox/telemetry.go
@@ -11,9 +11,25 @@ import (
 	"github.com/boxlite-ai/common-go/pkg/log"
 	"github.com/boxlite-ai/common-go/pkg/telemetry"
 	"github.com/boxlite-ai/daemon/internal"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
 )
 
-func (s *server) initTelemetry(ctx context.Context, serviceName, entrypointLogFilePath string, organizationId, regionId *string) error {
+// seedBootSpanFromTraceParent starts+ends one "sandbox.boot" span parented on the propagated
+// W3C traceparent (BOXLITE_TRACEPARENT, injected by the runner at sandbox create) so the box's
+// telemetry joins the SAME traceId as the api->runner spans instead of rooting a fresh trace.
+// No-op when traceParent is nil/empty, so behavior is unchanged unless a trace was propagated.
+// Pure (takes the tracer) so it is unit-testable with an in-memory TracerProvider.
+func seedBootSpanFromTraceParent(ctx context.Context, tracer trace.Tracer, traceParent *string) {
+	if traceParent == nil || *traceParent == "" {
+		return
+	}
+	bootCtx := propagation.TraceContext{}.Extract(ctx, propagation.MapCarrier{"traceparent": *traceParent})
+	_, bootSpan := tracer.Start(bootCtx, "sandbox.boot")
+	bootSpan.End()
+}
+
+func (s *server) initTelemetry(ctx context.Context, serviceName, entrypointLogFilePath string, organizationId, regionId, traceParent *string) error {
 	if s.otelEndpoint == nil {
 		s.logger.InfoContext(ctx, "Otel endpoint not provided, skipping telemetry initialization")
 		return nil
@@ -133,6 +149,9 @@ func (s *server) initTelemetry(ctx context.Context, serviceName, entrypointLogFi
 	s.telemetry.TracerProvider = tp
 	s.telemetry.MeterProvider = mp
 	s.telemetry.LoggerProvider = lp
+
+	// Make the box's telemetry join the api->runner traceId (instead of rooting a fresh trace).
+	seedBootSpanFromTraceParent(ctx, tp.Tracer("boxlite.sandbox"), traceParent)
 
 	s.logger.InfoContext(ctx, "Telemetry initialized successfully")
 	return nil

--- a/apps/daemon/pkg/toolbox/telemetry_traceparent_test.go
+++ b/apps/daemon/pkg/toolbox/telemetry_traceparent_test.go
@@ -1,0 +1,53 @@
+// Copyright 2026 BoxLite AI
+// SPDX-License-Identifier: AGPL-3.0
+
+package toolbox
+
+import (
+	"context"
+	"testing"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+// With a propagated W3C traceparent, the daemon's boot span must share the SAME traceId as the
+// api->runner spans and carry a remote parent — this is what makes "one traceId finds the box".
+// TraceID comes from production code (Extract+Start), so the assertion is non-tautological.
+func TestSeedBootSpanFromTraceParentJoinsApiTraceId(t *testing.T) {
+	exp := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exp))
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+
+	traceParent := "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+	seedBootSpanFromTraceParent(context.Background(), tp.Tracer("boxlite.sandbox"), &traceParent)
+
+	spans := exp.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("want exactly 1 boot span, got %d", len(spans))
+	}
+	if spans[0].Name != "sandbox.boot" {
+		t.Fatalf("boot span name = %q, want sandbox.boot", spans[0].Name)
+	}
+	if got := spans[0].SpanContext.TraceID().String(); got != "0af7651916cd43dd8448eb211c80319c" {
+		t.Fatalf("boot span traceID = %s, want api traceID 0af7651916cd43dd8448eb211c80319c", got)
+	}
+	if !spans[0].Parent.IsRemote() {
+		t.Fatalf("boot span parent must be the remote api/runner span context")
+	}
+}
+
+// No traceparent => no boot span (behavior identical to before the fix; safe to ship dark).
+func TestSeedBootSpanFromTraceParentNoopWhenAbsent(t *testing.T) {
+	exp := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exp))
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+
+	seedBootSpanFromTraceParent(context.Background(), tp.Tracer("boxlite.sandbox"), nil)
+	empty := ""
+	seedBootSpanFromTraceParent(context.Background(), tp.Tracer("boxlite.sandbox"), &empty)
+
+	if n := len(exp.GetSpans()); n != 0 {
+		t.Fatalf("expected no boot span when traceparent absent, got %d", n)
+	}
+}

--- a/apps/runner/cmd/runner/config/config.go
+++ b/apps/runner/cmd/runner/config/config.go
@@ -64,6 +64,8 @@ type Config struct {
 	BuildEngine                        string        `envconfig:"BUILD_ENGINE" default:"buildkit" validate:"oneof=buildkit legacy"`
 	BoxliteHomeDir                     string        `envconfig:"BOXLITE_HOME_DIR"`
 	InsecureRegistries                 string        `envconfig:"INSECURE_REGISTRIES"`
+	GhcrUsername                       string        `envconfig:"GHCR_USERNAME"`
+	GhcrToken                          string        `envconfig:"GHCR_TOKEN"`
 }
 
 var DEFAULT_API_PORT int = 8080

--- a/apps/runner/cmd/runner/main.go
+++ b/apps/runner/cmd/runner/main.go
@@ -110,6 +110,8 @@ func run() int {
 		Logger:                       logger,
 		HomeDir:                      cfg.BoxliteHomeDir,
 		InsecureRegistries:           insecureRegs,
+		GhcrUsername:                 cfg.GhcrUsername,
+		GhcrToken:                    cfg.GhcrToken,
 		AWSRegion:                    cfg.AWSRegion,
 		AWSEndpointUrl:               cfg.AWSEndpointUrl,
 		AWSAccessKeyId:               cfg.AWSAccessKeyId,

--- a/apps/runner/pkg/boxlite/client.go
+++ b/apps/runner/pkg/boxlite/client.go
@@ -19,6 +19,7 @@ import (
 	"github.com/boxlite-ai/runner/pkg/api/dto"
 	"github.com/boxlite-ai/runner/pkg/models/enums"
 	"github.com/containerd/errdefs"
+	"go.opentelemetry.io/otel/propagation"
 )
 
 // Client wraps the BoxLite Go SDK to provide the same interface as the Docker client.
@@ -48,6 +49,8 @@ type ClientConfig struct {
 	Logger                       *slog.Logger
 	HomeDir                      string
 	InsecureRegistries           []string
+	GhcrUsername                 string
+	GhcrToken                    string
 	AWSRegion                    string
 	AWSEndpointUrl               string
 	AWSAccessKeyId               string
@@ -77,7 +80,7 @@ func networkSpec(blockAll *bool, allowList *string) boxlite.NetworkSpec {
 	return spec
 }
 
-func daemonSandboxEnv(sandboxDto dto.CreateSandboxDTO) map[string]string {
+func daemonSandboxEnv(ctx context.Context, sandboxDto dto.CreateSandboxDTO) map[string]string {
 	env := map[string]string{
 		"BOXLITE_SANDBOX_ID": sandboxDto.Id,
 	}
@@ -90,7 +93,47 @@ func daemonSandboxEnv(sandboxDto dto.CreateSandboxDTO) map[string]string {
 	if sandboxDto.RegionId != nil && *sandboxDto.RegionId != "" {
 		env["BOXLITE_REGION_ID"] = *sandboxDto.RegionId
 	}
+	// Propagate the active W3C trace context into the box so the in-box daemon's telemetry
+	// joins the SAME traceId as the api->runner spans, instead of rooting a fresh disjoint
+	// trace. With no active span the carrier is empty => env is byte-identical to before.
+	carrier := propagation.MapCarrier{}
+	propagation.TraceContext{}.Inject(ctx, carrier)
+	if traceParent := carrier.Get("traceparent"); traceParent != "" {
+		env["BOXLITE_TRACEPARENT"] = traceParent
+		if traceState := carrier.Get("tracestate"); traceState != "" {
+			env["BOXLITE_TRACESTATE"] = traceState
+		}
+	}
 	return env
+}
+
+// buildImageRegistries assembles the runtime-scoped OCI registry list handed to boxlite-core:
+// the existing insecure (HTTP, no-auth) registries, plus — when ghcr credentials are provided —
+// a single authenticated ghcr.io HTTPS entry so core can pull our private first-party images
+// directly from ghcr (no self-hosted registry mirror required). Auth is runtime-scoped because
+// boxlite.Runtime.Create has no per-call credential parameter. When ghcrUsername/ghcrToken are
+// empty this is byte-for-byte the previous behavior (anonymous), so it is safe to ship dark.
+// Kept as a pure function so the wiring can be unit-tested without constructing a real runtime.
+func buildImageRegistries(insecureRegistries []string, ghcrUsername, ghcrToken string) []boxlite.ImageRegistry {
+	registries := make([]boxlite.ImageRegistry, 0, len(insecureRegistries)+1)
+	for _, host := range insecureRegistries {
+		registries = append(registries, boxlite.ImageRegistry{
+			Host:       host,
+			Transport:  boxlite.RegistryTransportHTTP,
+			SkipVerify: true,
+		})
+	}
+	if ghcrUsername != "" && ghcrToken != "" {
+		registries = append(registries, boxlite.ImageRegistry{
+			Host:      "ghcr.io",
+			Transport: boxlite.RegistryTransportHTTPS,
+			Auth: boxlite.ImageRegistryAuth{
+				Username: ghcrUsername,
+				Password: ghcrToken,
+			},
+		})
+	}
+	return registries
 }
 
 // NewClient creates a new BoxLite client backed by the BoxLite VM runtime.
@@ -105,15 +148,8 @@ func NewClient(ctx context.Context, config ClientConfig) (*Client, error) {
 		opts = append(opts, boxlite.WithHomeDir(config.HomeDir))
 	}
 	insecureRegistries := normalizeRegistryHosts(config.InsecureRegistries)
-	if len(insecureRegistries) > 0 {
-		registries := make([]boxlite.ImageRegistry, 0, len(insecureRegistries))
-		for _, host := range insecureRegistries {
-			registries = append(registries, boxlite.ImageRegistry{
-				Host:       host,
-				Transport:  boxlite.RegistryTransportHTTP,
-				SkipVerify: true,
-			})
-		}
+	registries := buildImageRegistries(insecureRegistries, config.GhcrUsername, config.GhcrToken)
+	if len(registries) > 0 {
 		opts = append(opts, boxlite.WithImageRegistries(registries...))
 	}
 
@@ -206,7 +242,7 @@ func (c *Client) Create(ctx context.Context, sandboxDto dto.CreateSandboxDTO) (s
 	for k, v := range sandboxDto.Env {
 		opts = append(opts, boxlite.WithEnv(k, v))
 	}
-	for k, v := range daemonSandboxEnv(sandboxDto) {
+	for k, v := range daemonSandboxEnv(ctx, sandboxDto) {
 		opts = append(opts, boxlite.WithEnv(k, v))
 	}
 

--- a/apps/runner/pkg/boxlite/client_ghcr_test.go
+++ b/apps/runner/pkg/boxlite/client_ghcr_test.go
@@ -1,0 +1,63 @@
+package boxlite
+
+import (
+	"testing"
+
+	boxlite "github.com/boxlite-ai/boxlite/sdks/go"
+)
+
+func findRegistry(registries []boxlite.ImageRegistry, host string) (boxlite.ImageRegistry, bool) {
+	for _, r := range registries {
+		if r.Host == host {
+			return r, true
+		}
+	}
+	return boxlite.ImageRegistry{}, false
+}
+
+// When ghcr creds are present, buildImageRegistries must add exactly one authenticated
+// ghcr.io HTTPS entry alongside the unchanged insecure registries. This is the runtime-scoped
+// auth that lets boxlite-core pull our private first-party images directly (no self-hosted
+// mirror). The asserted data is produced by the production helper, not the test body.
+func TestBuildImageRegistries_GhcrAuthAddedWhenCredsPresent(t *testing.T) {
+	registries := buildImageRegistries([]string{"10.0.0.5:5000"}, "boxlite-ci", "ghp_secret")
+
+	insecure, ok := findRegistry(registries, "10.0.0.5:5000")
+	if !ok {
+		t.Fatalf("expected insecure registry 10.0.0.5:5000 to be preserved, got %+v", registries)
+	}
+	if insecure.Transport != boxlite.RegistryTransportHTTP || !insecure.SkipVerify {
+		t.Errorf("insecure registry should stay HTTP + SkipVerify, got %+v", insecure)
+	}
+	if insecure.Auth.Username != "" || insecure.Auth.Password != "" {
+		t.Errorf("insecure registry must not carry auth, got %+v", insecure.Auth)
+	}
+
+	ghcr, ok := findRegistry(registries, "ghcr.io")
+	if !ok {
+		t.Fatalf("expected ghcr.io entry when creds set, got %+v", registries)
+	}
+	if ghcr.Transport != boxlite.RegistryTransportHTTPS {
+		t.Errorf("ghcr.io must use HTTPS, got %q", ghcr.Transport)
+	}
+	if ghcr.Auth.Username != "boxlite-ci" || ghcr.Auth.Password != "ghp_secret" {
+		t.Errorf("ghcr.io must carry the provided Basic creds, got %+v", ghcr.Auth)
+	}
+}
+
+// Absent (or partial) creds must reproduce the legacy behavior exactly: no ghcr.io entry,
+// so shipping this dark cannot change anything until GHCR_USERNAME+GHCR_TOKEN are set.
+func TestBuildImageRegistries_NoGhcrWhenCredsAbsent(t *testing.T) {
+	registries := buildImageRegistries([]string{"10.0.0.5:5000"}, "", "")
+	if _, ok := findRegistry(registries, "ghcr.io"); ok {
+		t.Errorf("ghcr.io must NOT be added when creds absent, got %+v", registries)
+	}
+	if len(registries) != 1 {
+		t.Errorf("expected only the insecure registry, got %d: %+v", len(registries), registries)
+	}
+
+	partial := buildImageRegistries(nil, "boxlite-ci", "")
+	if _, ok := findRegistry(partial, "ghcr.io"); ok {
+		t.Errorf("ghcr.io must NOT be added with partial creds (username only), got %+v", partial)
+	}
+}

--- a/apps/runner/pkg/boxlite/daemon_env_test.go
+++ b/apps/runner/pkg/boxlite/daemon_env_test.go
@@ -4,9 +4,11 @@
 package boxlite
 
 import (
+	"context"
 	"testing"
 
 	"github.com/boxlite-ai/runner/pkg/api/dto"
+	"go.opentelemetry.io/otel/trace"
 )
 
 func TestDaemonSandboxEnvIncludesRequiredSandboxIdentity(t *testing.T) {
@@ -14,7 +16,7 @@ func TestDaemonSandboxEnvIncludesRequiredSandboxIdentity(t *testing.T) {
 	regionID := "region-1"
 	otelEndpoint := "http://otel.local:4318"
 
-	got := daemonSandboxEnv(dto.CreateSandboxDTO{
+	got := daemonSandboxEnv(context.Background(), dto.CreateSandboxDTO{
 		Id:             "sandbox-1",
 		OrganizationId: &organizationID,
 		RegionId:       &regionID,
@@ -41,7 +43,7 @@ func TestDaemonSandboxEnvIncludesRequiredSandboxIdentity(t *testing.T) {
 func TestDaemonSandboxEnvOmitsEmptyOptionalValues(t *testing.T) {
 	empty := ""
 
-	got := daemonSandboxEnv(dto.CreateSandboxDTO{
+	got := daemonSandboxEnv(context.Background(), dto.CreateSandboxDTO{
 		Id:             "sandbox-1",
 		OrganizationId: &empty,
 		RegionId:       &empty,
@@ -53,5 +55,43 @@ func TestDaemonSandboxEnvOmitsEmptyOptionalValues(t *testing.T) {
 	}
 	if got["BOXLITE_SANDBOX_ID"] != "sandbox-1" {
 		t.Fatalf("BOXLITE_SANDBOX_ID = %q, want sandbox-1", got["BOXLITE_SANDBOX_ID"])
+	}
+}
+
+// With an active (remote) span in context, daemonSandboxEnv must propagate it as a W3C
+// BOXLITE_TRACEPARENT env so the in-box daemon joins the same traceId. The value crosses
+// propagation.TraceContext{}.Inject (production code), so this is non-tautological.
+func TestDaemonSandboxEnvPropagatesTraceparentWhenSpanActive(t *testing.T) {
+	traceID, err := trace.TraceIDFromHex("0af7651916cd43dd8448eb211c80319c")
+	if err != nil {
+		t.Fatalf("trace id: %v", err)
+	}
+	spanID, err := trace.SpanIDFromHex("b7ad6b7169203331")
+	if err != nil {
+		t.Fatalf("span id: %v", err)
+	}
+	sc := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     spanID,
+		TraceFlags: trace.FlagsSampled,
+		Remote:     true,
+	})
+	ctx := trace.ContextWithSpanContext(context.Background(), sc)
+
+	got := daemonSandboxEnv(ctx, dto.CreateSandboxDTO{Id: "sandbox-1"})
+
+	wantTP := "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+	if got["BOXLITE_TRACEPARENT"] != wantTP {
+		t.Fatalf("BOXLITE_TRACEPARENT = %q, want %q", got["BOXLITE_TRACEPARENT"], wantTP)
+	}
+}
+
+// With no active span, BOXLITE_TRACEPARENT must be absent (behavior identical to before the
+// propagation change), so the fix is safe to ship dark.
+func TestDaemonSandboxEnvOmitsTraceparentWhenNoSpan(t *testing.T) {
+	got := daemonSandboxEnv(context.Background(), dto.CreateSandboxDTO{Id: "sandbox-1"})
+
+	if _, ok := got["BOXLITE_TRACEPARENT"]; ok {
+		t.Fatalf("BOXLITE_TRACEPARENT must be absent without an active span, got %#v", got)
 	}
 }


### PR DESCRIPTION
## Summary

**PR 4 of 5** (effort: A2). Stacks on #701. Runner direct-ghcr auth + end-to-end traceId. Go-only, additive. Draft / WIP.

These two changes are what make A2's "box pulls private ghcr **directly**" possible — the deletion PR (5/5) relies on this runner auth. Incremental diff only (11 files).

## Before

```text
Runner image pull
+------------------------------------------+
| runner pulls via internal ArtifactRegistry|
| (no direct ghcr credentials)             |
+------------------------------------------+
traceId: the API creates one, but it is LOST at the
runner -> box (daemon) boundary -> can't follow one box end to end.
```

## After

```text
Runner image pull
+------------------------------------------+
| runtime-scoped ghcr auth (env-gated:     |
|   GHCR_USERNAME / GHCR_TOKEN)            |
| -> runner pulls private ghcr DIRECTLY    |
+------------------------------------------+
traceId: W3C traceparent injected api -> runner -> daemon
-> ONE traceId spans the whole box-create lifecycle.
```

## What Changed

- Runner `buildImageRegistries` adds a `ghcr.io` HTTPS + Basic-auth registry entry when `GHCR_USERNAME` / `GHCR_TOKEN` are set (env-gated; behavior identical when unset).
- Inject `BOXLITE_TRACEPARENT` into the box env (runner) and seed a `sandbox.boot` span from it (daemon) so the box joins the API traceId.

## Next

**5/5 (later):** delete the `snapshotManager` machinery (registry / backup / build) and collapse the schema to `box_template` + `runner_artifact_cache` (rebuilt clean). Held until the e2e track and the `sandbox` -> `box` rename land.
