### PR TITLE
chore(codeowners): map subsystem ownership to maintainers/builder teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,20 @@
+# Code ownership for boxlite-ai/boxlite.
+# Order matters: the LAST matching pattern for a path wins.
+# Referenced teams must have explicit repo access or the rule is ignored by GitHub.
+
+# Default — maintainers own anything not matched by a more specific rule below.
+*                          @boxlite-ai/maintainers
+
+# Security-critical isolation and external-facing surfaces — maintainer review.
+/src/boxlite/src/jailer/   @boxlite-ai/maintainers
+/src/boxlite/src/rest/     @boxlite-ai/maintainers
+/sdks/                     @boxlite-ai/maintainers
+/.github/                  @boxlite-ai/maintainers
+
+# Docs can be owned by the broader contributor team.
+/docs/                     @boxlite-ai/builder
+
 # Legal and contributor policy changes require project owner review.
-/CONTRIBUTING.md @DorianZheng
-/docs/legal/ @DorianZheng
-/.github/CODEOWNERS @DorianZheng
+/CONTRIBUTING.md           @DorianZheng
+/docs/legal/               @DorianZheng
+/.github/CODEOWNERS        @DorianZheng

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,17 +2,8 @@
 # Order matters: the LAST matching pattern for a path wins.
 # Referenced teams must have explicit repo access or the rule is ignored by GitHub.
 
-# Default — maintainers own anything not matched by a more specific rule below.
-*                          @boxlite-ai/maintainers
-
-# Security-critical isolation and external-facing surfaces — maintainer review.
-/src/boxlite/src/jailer/   @boxlite-ai/maintainers
-/src/boxlite/src/rest/     @boxlite-ai/maintainers
-/sdks/                     @boxlite-ai/maintainers
-/.github/                  @boxlite-ai/maintainers
-
-# Docs can be owned by the broader reviewers team.
-/docs/                     @boxlite-ai/reviewers
+# All code is owned by the reviewers team.
+*                          @boxlite-ai/reviewers
 
 # Legal and contributor policy changes require project owner review.
 /CONTRIBUTING.md           @DorianZheng

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,8 +11,8 @@
 /sdks/                     @boxlite-ai/maintainers
 /.github/                  @boxlite-ai/maintainers
 
-# Docs can be owned by the broader contributor team.
-/docs/                     @boxlite-ai/builder
+# Docs can be owned by the broader reviewers team.
+/docs/                     @boxlite-ai/reviewers
 
 # Legal and contributor policy changes require project owner review.
 /CONTRIBUTING.md           @DorianZheng


### PR DESCRIPTION
## What

Expands `.github/CODEOWNERS` from the 3 legal/policy paths to a full subsystem map, now that the **maintainers** (admin) and **builder** (write) teams have explicit repo access.

| Path | Owner |
|------|-------|
| `*` (default) | `@boxlite-ai/maintainers` |
| `/src/boxlite/src/jailer/` | `@boxlite-ai/maintainers` |
| `/src/boxlite/src/rest/` | `@boxlite-ai/maintainers` |
| `/sdks/` | `@boxlite-ai/maintainers` |
| `/.github/` | `@boxlite-ai/maintainers` |
| `/docs/` | `@boxlite-ai/builder` |
| `/CONTRIBUTING.md`, `/docs/legal/`, `/.github/CODEOWNERS` | `@DorianZheng` (unchanged) |

## Why

The `main` ruleset enforces `require_code_owner_review`, but CODEOWNERS previously only matched legal/policy files — so most PRs required no code-owner approval. This makes code-owner review meaningful per subsystem while keeping security-critical paths (jailer, REST, SDKs, CI) under maintainer review and legal/policy paths owner-gated.

## Notes

- Referenced teams now have explicit repo access (`maintainers`=admin, `builder`=push), so GitHub will honor these rules.
- Last-matching-pattern-wins ordering: owner-gated legal paths are listed last so they take precedence over the default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated repository code ownership configuration to expand default maintainer coverage.
  * Added explicit ownership for security-critical and external-facing areas.
  * Assigned documentation ownership to the review team.
  * Scoped project/legal and contribution policy files to a designated maintainer.
  * Clarified header note on pattern precedence and that referenced teams require explicit repository access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->