### PR TITLE
ci(codeql): switch to advanced setup so fork PRs are scanned

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -129,6 +129,24 @@ Runs code quality checks.
 4. `node` - Run Node lint and format checks via `make lint:node` and `make fmt:check:node`
 5. `c` - Run C SDK lint and format checks via `make lint:c` and `make fmt:check:c`
 
+### `codeql.yml`
+
+Runs CodeQL code scanning (advanced setup) across all analyzed languages.
+
+**Why advanced setup:** CodeQL *default setup* does not analyze pull requests
+from forks, so the `code_scanning` ruleset rule ("Require code scanning
+results") permanently blocks fork PRs. Advanced setup runs on `pull_request`,
+so fork PRs in this public repo are scanned and the gate is satisfiable without
+an admin bypass.
+
+**Triggers:**
+- Push to `main`
+- Pull requests against `main` (including fork PRs)
+- Weekly schedule (Mondays 03:31 UTC)
+
+**Jobs:**
+1. `analyze` - Matrix over `actions`, `c-cpp`, `go`, `javascript-typescript`, `python`, `rust`, each with `build-mode: none` (source-only analysis, no compile step)
+
 ### `e2e-test.yml`
 
 Runs VM-based E2E integration tests on an ephemeral AWS EC2 self-hosted runner.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -145,7 +145,7 @@ an admin bypass.
 - Weekly schedule (Mondays 03:31 UTC)
 
 **Jobs:**
-1. `analyze` - Matrix over `actions`, `c-cpp`, `go`, `javascript-typescript`, `python`, `rust`, each with `build-mode: none` (source-only analysis, no compile step)
+1. `analyze` - Matrix over `actions`, `c-cpp`, `go`, `javascript-typescript`, `python`, `rust`. All use `build-mode: none` (source-only, no compile) except `go`, which requires `autobuild` (Go's extractor must observe a build)
 
 ### `e2e-test.yml`
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -139,13 +139,25 @@ results") permanently blocks fork PRs. Advanced setup runs on `pull_request`,
 so fork PRs in this public repo are scanned and the gate is satisfiable without
 an admin bypass.
 
+**Bootstrap guard:** GitHub rejects advanced CodeQL uploads while default setup
+is enabled. The workflow is dormant until repository variable
+`CODEQL_ADVANCED_SETUP_ENABLED` is set to `true`.
+
 **Triggers:**
 - Push to `main`
 - Pull requests against `main` (including fork PRs)
+- Manual dispatch
 - Weekly schedule (Mondays 03:31 UTC)
 
 **Jobs:**
-1. `analyze` - Matrix over `actions`, `c-cpp`, `go`, `javascript-typescript`, `python`, `rust`. All use `build-mode: none` (source-only, no compile) except `go`, which requires `autobuild` (Go's extractor must observe a build)
+1. `analyze` - Matrix over `actions`, `c-cpp`, `go`, `javascript-typescript`, `python`, `rust`. All use `build-mode: none` (source-only, no compile) except `go`, which requires `autobuild` (Go's extractor must observe a build). Uses `github/codeql-action@v4`.
+
+**Activation sequence:**
+1. Merge this workflow while `CODEQL_ADVANCED_SETUP_ENABLED` is unset or `false`, so default setup remains the active scanner.
+2. Disable CodeQL default setup.
+3. Set repository variable `CODEQL_ADVANCED_SETUP_ENABLED=true`.
+4. Trigger a new push, pull request update, or manual dispatch and verify CodeQL analysis uploads successfully.
+5. Roll back by setting `CODEQL_ADVANCED_SETUP_ENABLED=false` and re-enabling default setup.
 
 ### `e2e-test.yml`
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -59,17 +59,17 @@ jobs:
             build-mode: none
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,60 @@
+# CodeQL advanced setup.
+#
+# Replaces CodeQL "default setup", which does not analyze pull requests from
+# forks. Advanced setup runs on `pull_request`, so fork PRs are scanned and the
+# "Require code scanning results" ruleset rule can be satisfied without an admin
+# bypass.
+#
+# All languages use `build-mode: none` (source-only analysis, no compile step)
+# so the workflow cannot fail to build. Switch a language to `autobuild`/manual
+# later if deeper, build-aware analysis is needed.
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly full scan of the default branch (Mondays 03:31 UTC).
+    - cron: "31 3 * * 1"
+
+# Cancel in-progress analysis when a PR is updated.
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      # Required to upload code scanning results.
+      security-events: write
+      # Required by the CodeQL action to read the repository and Actions runs.
+      contents: read
+      actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - actions
+          - c-cpp
+          - go
+          - javascript-typescript
+          - python
+          - rust
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,9 +5,10 @@
 # "Require code scanning results" ruleset rule can be satisfied without an admin
 # bypass.
 #
-# All languages use `build-mode: none` (source-only analysis, no compile step)
-# so the workflow cannot fail to build. Switch a language to `autobuild`/manual
-# later if deeper, build-aware analysis is needed.
+# Languages use `build-mode: none` (source-only analysis, no compile step) where
+# CodeQL supports it. Go does not support `none` — its extractor must observe a
+# build — so Go uses `autobuild` (the same mode default setup used successfully
+# for this repo).
 name: CodeQL
 
 on:
@@ -37,13 +38,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language:
-          - actions
-          - c-cpp
-          - go
-          - javascript-typescript
-          - python
-          - rust
+        include:
+          - language: actions
+            build-mode: none
+          - language: c-cpp
+            build-mode: none
+          - language: go
+            build-mode: autobuild
+          - language: javascript-typescript
+            build-mode: none
+          - language: python
+            build-mode: none
+          - language: rust
+            build-mode: none
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -52,7 +59,7 @@ jobs:
         uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
-          build-mode: none
+          build-mode: ${{ matrix.build-mode }}
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,6 +5,10 @@
 # "Require code scanning results" ruleset rule can be satisfied without an admin
 # bypass.
 #
+# GitHub rejects advanced CodeQL uploads while default setup is enabled, so keep
+# this workflow dormant until repository variable CODEQL_ADVANCED_SETUP_ENABLED
+# is set to "true" after default setup is disabled.
+#
 # Languages use `build-mode: none` (source-only analysis, no compile step) where
 # CodeQL supports it. Go does not support `none` — its extractor must observe a
 # build — so Go uses `autobuild` (the same mode default setup used successfully
@@ -16,6 +20,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
   schedule:
     # Weekly full scan of the default branch (Mondays 03:31 UTC).
     - cron: "31 3 * * 1"
@@ -27,6 +32,7 @@ concurrency:
 
 jobs:
   analyze:
+    if: vars.CODEQL_ADVANCED_SETUP_ENABLED == 'true'
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
     permissions:
@@ -53,15 +59,17 @@ jobs:
             build-mode: none
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Why

CodeQL default setup does not analyze pull requests from forks. The `main`/`release` rulesets require CodeQL code scanning results, so fork PRs can remain blocked waiting for results that never arrive.

This PR adds a CodeQL advanced-setup workflow that can run on `pull_request` once default setup is disabled.

## What

- Adds `.github/workflows/codeql.yml` with a matrix over the analyzed languages: `actions`, `c-cpp`, `go`, `javascript-typescript`, `python`, and `rust`.
- Uses `build-mode: none` where CodeQL supports source-only analysis.
- Uses `build-mode: autobuild` for Go because Go does not support `none`.
- Uses `github/codeql-action@v4` and `actions/checkout@v6`.
- Disables checkout credential persistence with `persist-credentials: false`.
- Keeps the workflow dormant behind repository variable `CODEQL_ADVANCED_SETUP_ENABLED=true` while default setup is still enabled.
- Documents the activation sequence in `.github/workflows/README.md`.

## Required activation after merge

GitHub rejects advanced CodeQL uploads while CodeQL default setup is enabled, so this workflow is intentionally feature-gated for the bootstrap PR.

1. Merge this PR with `CODEQL_ADVANCED_SETUP_ENABLED` unset or `false`, leaving default setup as the active scanner.
2. Disable CodeQL default setup.
3. Set repository variable `CODEQL_ADVANCED_SETUP_ENABLED=true`.
4. Trigger a new push, pull request update, or manual `CodeQL` workflow dispatch.
5. Verify the advanced workflow uploads CodeQL results successfully.
6. Roll back by setting `CODEQL_ADVANCED_SETUP_ENABLED=false` and re-enabling default setup.

## Validation

- `actionlint .github/workflows/codeql.yml`
- `git diff --check origin/main...HEAD -- .github/workflows/README.md .github/workflows/codeql.yml`
- `make lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an opt-in advanced CodeQL security scan with reduced permissions, concurrency cancellation for outdated runs, and language-aware analysis; runs on pushes, pull requests (including from forks), manual triggers, and a weekly schedule.

* **Documentation**
  * Added guidance covering the advanced scan configuration, activation/rollback sequence, scheduling, and per-language build requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->