### PR TITLE
feat(logs): tee exec stdout/stderr to shared/container.log

### DIFF
--- a/src/boxlite/src/runtime/layout.rs
+++ b/src/boxlite/src/runtime/layout.rs
@@ -499,6 +499,18 @@ impl BoxFilesystemLayout {
         self.logs_dir().join("console.log")
     }
 
+    /// Container exec output path: `~/.boxlite/boxes/{box_id}/shared/container.log`.
+    ///
+    /// Single appendable file the guest tees every exec's stdout+stderr into.
+    /// Lives inside `shared/` so it reaches the host via virtio-fs (guest sees
+    /// it at `/run/boxlite/shared/container.log`). `boxlite logs` reads this by
+    /// default — what most users want from `docker logs`-style commands. The
+    /// VM/agent console is still available via `--vm` (the
+    /// [`console_output_path`](Self::console_output_path) above).
+    pub fn container_output_path(&self) -> PathBuf {
+        self.shared_dir().join("container.log")
+    }
+
     /// PID file path: ~/.boxlite/boxes/{box_id}/shim.pid
     ///
     /// Written by the shim process in pre_exec (after fork, before exec).

--- a/src/cli/src/commands/logs.rs
+++ b/src/cli/src/commands/logs.rs
@@ -21,6 +21,16 @@ pub struct LogsArgs {
     /// Follow log output
     #[arg(short = 'f', long = "follow")]
     pub follow: bool,
+
+    /// Read the VM/guest-agent console (`logs/console.log`) instead of the
+    /// container's stdout/stderr. Useful when the box failed to boot or
+    /// the guest agent crashed.
+    ///
+    /// Default is the container's exec output (`shared/container.log` —
+    /// what every `docker logs` user expects): every `boxlite exec` /
+    /// `boxlite run` command tees its stdout+stderr there.
+    #[arg(long = "vm")]
+    pub vm: bool,
 }
 
 pub async fn execute(args: LogsArgs, global: &GlobalFlags) -> anyhow::Result<()> {
@@ -33,12 +43,25 @@ pub async fn execute(args: LogsArgs, global: &GlobalFlags) -> anyhow::Result<()>
         .await?
         .ok_or_else(|| anyhow::anyhow!("No such box: {}", args.target))?;
 
-    // Construct console.log path: {home_dir}/boxes/{box_id}/logs/console.log
     let box_id = litebox.id();
-
-    let log_path = FilesystemLayout::new(home_dir, FsLayoutConfig::with_bind_mount())
-        .box_layout(box_id.as_str(), false)?
-        .console_output_path();
+    let layout = FilesystemLayout::new(home_dir, FsLayoutConfig::with_bind_mount())
+        .box_layout(box_id.as_str(), /*isolate_mounts=*/ false)?;
+    // `--vm` → VM/agent console; default → container exec output. Fall back
+    // to console.log when container.log is absent (old box created before
+    // the tee landed, or `--vm` explicitly).
+    let container_path = layout.container_output_path();
+    let console_path = layout.console_output_path();
+    let log_path = if args.vm {
+        console_path
+    } else if container_path.exists() {
+        container_path
+    } else {
+        eprintln!(
+            "Note: no container exec output captured yet; falling back to VM/agent console. \
+             Re-run with --vm to silence this notice."
+        );
+        console_path
+    };
 
     if !log_path.exists() {
         eprintln!("No log file found for box '{}'", args.target);

--- a/src/cli/tests/logs_capture.rs
+++ b/src/cli/tests/logs_capture.rs
@@ -1,0 +1,76 @@
+//! `boxlite logs` returns the container's exec stdout (not the VM/agent
+//! console). Pins the user-visible contract introduced by the per-box
+//! `container.log` tee in `service::exec::tee`.
+
+use predicates::prelude::*;
+
+mod common;
+
+/// Default: `boxlite logs <box>` shows what the box's command printed.
+/// On `main` (no tee) this asserts on `console.log` instead and the
+/// marker is absent — the file is a VM/agent trace dump. With the tee
+/// in place the marker appears.
+#[test]
+fn boxlite_logs_shows_container_stdout() {
+    let mut ctx = common::boxlite();
+    let name = "logs-tee";
+    ctx.cmd
+        .args([
+            "run",
+            "-d",
+            "--name",
+            name,
+            "alpine:latest",
+            "sh",
+            "-c",
+            "echo MARK_LOGS_TEE_OK; sleep 60",
+        ])
+        .assert()
+        .success();
+
+    // Give the box a beat to actually print + tee to fsync.
+    std::thread::sleep(std::time::Duration::from_secs(2));
+
+    ctx.new_cmd()
+        .args(["logs", name])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("MARK_LOGS_TEE_OK"));
+
+    ctx.cleanup_box(name);
+}
+
+/// `--vm` still returns the VM/agent console (the pre-tee behavior is
+/// not lost — operators who need to see kernel boot / guest agent
+/// tracing can still get it). The marker we wrote via the container
+/// would NOT appear here, but the guest agent's tracing lines do.
+#[test]
+fn boxlite_logs_vm_flag_shows_guest_agent_console() {
+    let mut ctx = common::boxlite();
+    let name = "logs-vm";
+    ctx.cmd
+        .args([
+            "run",
+            "-d",
+            "--name",
+            name,
+            "alpine:latest",
+            "sh",
+            "-c",
+            "echo MARK_LOGS_VM_OK; sleep 60",
+        ])
+        .assert()
+        .success();
+    std::thread::sleep(std::time::Duration::from_secs(2));
+
+    // `--vm` reads the VM/agent console. The guest agent always logs
+    // its startup banner — a stable substring to assert on without
+    // coupling to whatever the user's command printed.
+    ctx.new_cmd()
+        .args(["logs", "--vm", name])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("BoxLite Guest Agent"));
+
+    ctx.cleanup_box(name);
+}

--- a/src/guest/src/container/command.rs
+++ b/src/guest/src/container/command.rs
@@ -286,6 +286,15 @@ impl ContainerCommand {
         let pipes = Some((stdin_read, stdout_write, stderr_write));
         let pid = self.build_and_spawn(pipes).await?;
 
+        // Tee container stdout/stderr through to `container.log` on the
+        // shared virtio-fs so `boxlite logs` can read it. Tee returns the
+        // SAME fd when the log file can't be opened (e.g. in unit tests
+        // where /run/boxlite/shared doesn't exist), so this is safe to
+        // always do.
+        let log_path = std::path::PathBuf::from(crate::service::exec::tee::CONTAINER_LOG_PATH);
+        let stdout_read = crate::service::exec::tee::wrap_with_tee(stdout_read, log_path.clone())?;
+        let stderr_read = crate::service::exec::tee::wrap_with_tee(stderr_read, log_path)?;
+
         tracing::debug!(pid = pid.as_raw(), "spawned with pipes");
         // Non-PTY mode: stdout and stderr are separate pipes
         Ok(ExecHandle::new(
@@ -477,6 +486,11 @@ impl SpawnedPty {
 fn create_pty_child(pid: Pid, pty_master: OwnedFd, config: PtyConfig) -> BoxliteResult<ExecHandle> {
     set_pty_window_size(&pty_master, &config)?;
     let (stdin, stdout) = reconcile_pty_fds(&pty_master)?;
+
+    // Tee PTY output through `container.log` (same shared file the pipe
+    // path writes to) so `boxlite logs` sees TTY-mode exec output too.
+    let log_path = std::path::PathBuf::from(crate::service::exec::tee::CONTAINER_LOG_PATH);
+    let stdout = crate::service::exec::tee::wrap_with_tee(stdout, log_path)?;
 
     // PTY mode: stderr is None (merged into stdout)
     let mut child = ExecHandle::new(pid, stdin, stdout, None);

--- a/src/guest/src/service/exec/executor.rs
+++ b/src/guest/src/service/exec/executor.rs
@@ -156,6 +156,12 @@ fn spawn_with_pipes(req: &ExecRequest) -> BoxliteResult<ExecHandle> {
 
     let pid = child.id();
 
+    // Tee guest-side exec output to `container.log` (same single-file path
+    // the container exec path uses) so `boxlite logs` sees the bytes.
+    let log_path = std::path::PathBuf::from(super::tee::CONTAINER_LOG_PATH);
+    let stdout_read = super::tee::wrap_with_tee(stdout_read, log_path.clone())?;
+    let stderr_read = super::tee::wrap_with_tee(stderr_read, log_path)?;
+
     // Non-PTY mode: stdout and stderr are separate pipes
     Ok(ExecHandle::new(
         Pid::from_raw(pid as i32),
@@ -251,6 +257,10 @@ fn spawn_with_pty(req: &ExecRequest, config: PtyConfig) -> BoxliteResult<ExecHan
 
     let stdin = unsafe { OwnedFd::from_raw_fd(stdin_fd) };
     let stdout = unsafe { OwnedFd::from_raw_fd(stdout_fd) };
+
+    // Tee guest PTY output through container.log.
+    let log_path = std::path::PathBuf::from(super::tee::CONTAINER_LOG_PATH);
+    let stdout = super::tee::wrap_with_tee(stdout, log_path)?;
 
     // PTY mode: stderr is None (merged into stdout)
     let mut handle = ExecHandle::new(Pid::from_raw(pid as i32), stdin, stdout, None);

--- a/src/guest/src/service/exec/mod.rs
+++ b/src/guest/src/service/exec/mod.rs
@@ -21,6 +21,7 @@ pub mod exec_handle;
 pub(in crate::service) mod executor;
 pub(in crate::service) mod registry;
 mod state;
+pub(crate) mod tee;
 mod timeout;
 
 // Re-export trait so container module can implement it

--- a/src/guest/src/service/exec/tee.rs
+++ b/src/guest/src/service/exec/tee.rs
@@ -1,0 +1,176 @@
+//! Tee an exec's stdout/stderr pipe (or PTY master) into a log file while
+//! still forwarding the live bytes to whoever consumes the
+//! [`crate::service::exec::exec_handle::ExecHandle`].
+//!
+//! Why: `boxlite run` runs the user's command as a tenant `exec` inside the
+//! container, not as the container's PID 1. The exec's stdout fd is a pipe
+//! that the gRPC `Attach` consumer drains. When the CLI detaches
+//! (`boxlite run -d`) nobody attaches and the bytes pile up in the pipe
+//! buffer until the user later attaches — or never appear at all if the
+//! command exited without an attach.
+//!
+//! This module inserts a single always-on reader between the kernel pipe
+//! and the consumer-facing fd: it forks the stream into the log file (an
+//! append-only file on the `/run/boxlite/shared` virtio-fs share, host-
+//! visible as `<box_dir>/shared/container.log`) and a new pipe whose
+//! read-end takes the original's place in `ExecHandle`. Consumers see the
+//! same bytes; the file gets a persistent copy.
+
+use boxlite_shared::errors::{BoxliteError, BoxliteResult};
+use nix::unistd::pipe;
+use std::fs::OpenOptions;
+use std::io::{Read, Write};
+use std::os::unix::io::{AsRawFd, OwnedFd};
+use std::path::PathBuf;
+
+/// Single-file location the guest tees every exec's stream into. Path is
+/// inside the virtio-fs share, so writes here surface to the host at
+/// `<box_dir>/shared/container.log` (the host-visible path the CLI's
+/// `boxlite logs` reads).
+pub const CONTAINER_LOG_PATH: &str = "/run/boxlite/shared/container.log";
+
+/// Wrap a child-process output fd so its bytes ALSO land in `log_path`.
+///
+/// Returns a new fd (the read-end of an internal relay pipe). The caller
+/// hands this new fd to `ExecHandle::new` instead of `source_fd`; the gRPC
+/// attach stream then reads from the relay pipe and is byte-for-byte
+/// identical to what the original pipe carried.
+///
+/// `source_fd` must be readable (a pipe read-end or a PTY master). The
+/// background thread closes its end on EOF / error and drops out cleanly.
+/// If `log_path` can't be opened (e.g. running outside a real box where
+/// the virtio-fs share doesn't exist), the function logs a warning and
+/// returns the original fd unchanged — never blocks a working exec on
+/// log-file plumbing.
+pub(crate) fn wrap_with_tee(source_fd: OwnedFd, log_path: PathBuf) -> BoxliteResult<OwnedFd> {
+    let log = match OpenOptions::new().create(true).append(true).open(&log_path) {
+        Ok(f) => f,
+        Err(e) => {
+            // Best-effort: hand back the original fd so exec still works.
+            tracing::warn!(
+                path = %log_path.display(),
+                error = %e,
+                "exec tee disabled — could not open log file; output will not be captured for `boxlite logs`"
+            );
+            return Ok(source_fd);
+        }
+    };
+    let (relay_read, relay_write) =
+        pipe().map_err(|e| BoxliteError::Internal(format!("Failed to create relay pipe: {e}")))?;
+    spawn_tee_thread(source_fd, relay_write, log, log_path);
+    Ok(relay_read)
+}
+
+/// One OS thread per stream. Reads from `src`, writes to BOTH the relay pipe
+/// `relay` (so the gRPC consumer sees the bytes) AND `log` (so `boxlite
+/// logs` sees them later, even if no one ever attached). `fsync` after each
+/// batch is the load-bearing call on virtio-fs: without it the host sees
+/// the appended bytes only when the file is finally closed.
+fn spawn_tee_thread(src: OwnedFd, relay: OwnedFd, mut log: std::fs::File, log_path: PathBuf) {
+    std::thread::spawn(move || {
+        let log_fd = log.as_raw_fd();
+        let mut src = std::fs::File::from(src);
+        let mut relay = std::fs::File::from(relay);
+        let mut buf = [0u8; 4096];
+        loop {
+            match src.read(&mut buf) {
+                Ok(0) => break, // EOF — child closed its write-end
+                Ok(n) => {
+                    // File first: it's local disk + virtio-fs, fast and
+                    // unaffected by gRPC backpressure. The relay write
+                    // can block if the gRPC consumer is slow; we accept
+                    // that — backpressure is the existing behaviour, and
+                    // the log captures the bytes regardless.
+                    if let Err(e) = log.write_all(&buf[..n]) {
+                        tracing::warn!(path = %log_path.display(), error = %e, "exec log write failed");
+                    } else {
+                        let _ = nix::unistd::fsync(log_fd);
+                    }
+                    if relay.write_all(&buf[..n]).is_err() {
+                        // Consumer dropped (CLI detached, attach closed) —
+                        // keep draining `src` into the file so the log
+                        // stays complete even with no live consumer.
+                        loop {
+                            match src.read(&mut buf) {
+                                Ok(0) => break,
+                                Ok(n) => {
+                                    if log.write_all(&buf[..n]).is_ok() {
+                                        let _ = nix::unistd::fsync(log_fd);
+                                    }
+                                }
+                                Err(_) => break,
+                            }
+                        }
+                        break;
+                    }
+                }
+                Err(_) => break, // EIO on closed PTY master, etc.
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::io::AsRawFd;
+
+    /// File path that can't be opened (no such directory) → tee disables
+    /// itself and returns the original fd; exec must keep working.
+    #[test]
+    fn wrap_with_tee_returns_source_when_log_unopenable() {
+        use nix::unistd::pipe;
+        let (rx, _tx) = pipe().unwrap();
+        let raw_before = rx.as_raw_fd();
+        let result = wrap_with_tee(rx, PathBuf::from("/nonexistent/dir/x.log")).unwrap();
+        assert_eq!(
+            result.as_raw_fd(),
+            raw_before,
+            "fallback must hand back the same fd, not a fresh pipe"
+        );
+    }
+
+    /// End-to-end fanout: bytes written to the source-side write-end show
+    /// up both on the relay read-end (what the gRPC consumer sees) and in
+    /// the log file (what `boxlite logs` will read).
+    #[test]
+    fn wrap_with_tee_writes_to_both_relay_and_file() {
+        use nix::unistd::pipe;
+        use std::io::Read as _;
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("container.log");
+        let (src_rx, src_tx) = pipe().unwrap();
+
+        // Wrap the source: caller passes src_rx and gets back a relay read-end.
+        let relay_rx = wrap_with_tee(src_rx, log_path.clone()).unwrap();
+
+        // Simulate the child writing through src_tx.
+        nix::unistd::write(&src_tx, b"TEE_PAYLOAD\n").unwrap();
+        // Close the write-end so the tee thread exits on EOF and drops `log`,
+        // flushing any buffered bytes.
+        drop(src_tx);
+
+        // Consumer side — reads from the relay (the new "stdout" fd).
+        let mut consumer = std::fs::File::from(relay_rx);
+        let mut got = String::new();
+        consumer.read_to_string(&mut got).unwrap();
+        assert!(
+            got.contains("TEE_PAYLOAD"),
+            "relay missing payload: {got:?}"
+        );
+
+        // File side — reads independently.
+        // Brief poll: the tee thread is async; give it up to 2 s.
+        for _ in 0..100 {
+            let body = std::fs::read_to_string(&log_path).unwrap_or_default();
+            if body.contains("TEE_PAYLOAD") {
+                return;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        }
+        panic!(
+            "log file never received payload: {:?}",
+            std::fs::read_to_string(&log_path).unwrap_or_default()
+        );
+    }
+}


### PR DESCRIPTION
Draft — opening for review/CI; will fill in detailed Bug/Fix/Test plan once tests are confirmed green.

## Summary

Tees exec stdout/stderr to `shared/container.log` so the host can read live exec output without having to attach. Changes:

- `src/boxlite/src/runtime/layout.rs` — add `shared/container.log` slot
- `src/guest/src/service/exec/tee.rs` (new) + `command.rs` / `executor.rs` plumbing — guest-side tee
- `src/cli/src/commands/logs.rs` + `src/cli/tests/logs_capture.rs` — CLI surface + test

7 files, +317 -5. Single commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)