### PR TITLE
docs(cli,daemon): regenerate cobra docs and toolbox swagger after rename

### DIFF
--- a/apps/cli/docs/boxlite.md
+++ b/apps/cli/docs/boxlite.md
@@ -4,7 +4,7 @@ BoxLite CLI
 
 ### Synopsis
 
-Command line interface for BoxLite Sandboxes
+Command line interface for BoxLite Boxes
 
 ```
 boxlite [flags]
@@ -19,22 +19,23 @@ boxlite [flags]
 
 ### SEE ALSO
 
-* [boxlite archive](boxlite_archive.md)  - Archive a sandbox
-* [boxlite autocomplete](boxlite_autocomplete.md)  - Adds a completion script for your shell environment
-* [boxlite create](boxlite_create.md)  - Create a new sandbox
-* [boxlite delete](boxlite_delete.md)  - Delete a sandbox
-* [boxlite docs](boxlite_docs.md)  - Opens the BoxLite documentation in your default browser.
-* [boxlite exec](boxlite_exec.md)  - Execute a command in a sandbox
-* [boxlite info](boxlite_info.md)  - Get sandbox info
-* [boxlite list](boxlite_list.md)  - List sandboxes
-* [boxlite login](boxlite_login.md)  - Log in to BoxLite
-* [boxlite logout](boxlite_logout.md)  - Logout from BoxLite
-* [boxlite mcp](boxlite_mcp.md)  - Manage BoxLite MCP Server
-* [boxlite organization](boxlite_organization.md)  - Manage BoxLite organizations
-* [boxlite preview-url](boxlite_preview-url.md)  - Get signed preview URL for a sandbox port
-* [boxlite snapshot](boxlite_snapshot.md)  - Manage BoxLite snapshots
-* [boxlite ssh](boxlite_ssh.md)  - SSH into a sandbox
-* [boxlite start](boxlite_start.md)  - Start a sandbox
-* [boxlite stop](boxlite_stop.md)  - Stop a sandbox
-* [boxlite version](boxlite_version.md)  - Print the version number
-* [boxlite volume](boxlite_volume.md)  - Manage BoxLite volumes
+* [boxlite archive](boxlite_archive.md)	 - Archive a box
+* [boxlite autocomplete](boxlite_autocomplete.md)	 - Adds a completion script for your shell environment
+* [boxlite create](boxlite_create.md)	 - Create a new box
+* [boxlite delete](boxlite_delete.md)	 - Delete a box
+* [boxlite docs](boxlite_docs.md)	 - Opens the BoxLite documentation in your default browser.
+* [boxlite exec](boxlite_exec.md)	 - Execute a command in a box
+* [boxlite info](boxlite_info.md)	 - Get box info
+* [boxlite list](boxlite_list.md)	 - List boxes
+* [boxlite login](boxlite_login.md)	 - Log in to BoxLite
+* [boxlite logout](boxlite_logout.md)	 - Logout from BoxLite
+* [boxlite mcp](boxlite_mcp.md)	 - Manage BoxLite MCP Server
+* [boxlite organization](boxlite_organization.md)	 - Manage BoxLite organizations
+* [boxlite preview-url](boxlite_preview-url.md)	 - Get signed preview URL for a box port
+* [boxlite snapshot](boxlite_snapshot.md)	 - Manage BoxLite snapshots
+* [boxlite ssh](boxlite_ssh.md)	 - SSH into a box
+* [boxlite start](boxlite_start.md)	 - Start a box
+* [boxlite stop](boxlite_stop.md)	 - Stop a box
+* [boxlite version](boxlite_version.md)	 - Print the version number
+* [boxlite volume](boxlite_volume.md)	 - Manage BoxLite volumes
+

--- a/apps/cli/docs/boxlite_archive.md
+++ b/apps/cli/docs/boxlite_archive.md
@@ -1,9 +1,9 @@
 ## boxlite archive
 
-Archive a sandbox
+Archive a box
 
 ```
-boxlite archive [SANDBOX_ID] | [SANDBOX_NAME] [flags]
+boxlite archive [BOX_ID] | [BOX_NAME] [flags]
 ```
 
 ### Options inherited from parent commands
@@ -14,4 +14,5 @@ boxlite archive [SANDBOX_ID] | [SANDBOX_NAME] [flags]
 
 ### SEE ALSO
 
-* [boxlite](boxlite.md)  - BoxLite CLI
+* [boxlite](boxlite.md)	 - BoxLite CLI
+

--- a/apps/cli/docs/boxlite_autocomplete.md
+++ b/apps/cli/docs/boxlite_autocomplete.md
@@ -14,4 +14,5 @@ boxlite autocomplete [bash|zsh|fish|powershell] [flags]
 
 ### SEE ALSO
 
-* [boxlite](boxlite.md)  - BoxLite CLI
+* [boxlite](boxlite.md)	 - BoxLite CLI
+

--- a/apps/cli/docs/boxlite_create.md
+++ b/apps/cli/docs/boxlite_create.md
@@ -1,6 +1,6 @@
 ## boxlite create
 
-Create a new sandbox
+Create a new box
 
 ```
 boxlite create [flags]
@@ -12,22 +12,22 @@ boxlite create [flags]
       --auto-archive int32          Auto-archive interval in minutes (0 means the maximum interval will be used) (default 10080)
       --auto-delete int32           Auto-delete interval in minutes (negative value means disabled, 0 means delete immediately upon stopping) (default -1)
       --auto-stop int32             Auto-stop interval in minutes (0 means disabled) (default 15)
-      --class string                Sandbox class type (small, medium, large)
+      --class string                Box class type (small, medium, large)
   -c, --context stringArray         Files or directories to include in the build context (can be specified multiple times)
-      --cpu int32                   CPU cores allocated to the sandbox
-      --disk int32                  Disk space allocated to the sandbox in GB
-  -f, --dockerfile string           Path to Dockerfile for Sandbox snapshot
+      --cpu int32                   CPU cores allocated to the box
+      --disk int32                  Disk space allocated to the box in GB
+  -f, --dockerfile string           Path to Dockerfile for Box snapshot
   -e, --env stringArray             Environment variables (format: KEY=VALUE)
-      --gpu int32                   GPU units allocated to the sandbox
+      --gpu int32                   GPU units allocated to the box
   -l, --label stringArray           Labels (format: KEY=VALUE)
-      --memory int32                Memory allocated to the sandbox in MB
-      --name string                 Name of the sandbox
-      --network-allow-list string   Comma-separated list of allowed CIDR network addresses for the sandbox
-      --network-block-all           Whether to block all network access for the sandbox
-      --public                      Make sandbox publicly accessible
-      --snapshot string             Snapshot to use for the sandbox
+      --memory int32                Memory allocated to the box in MB
+      --name string                 Name of the box
+      --network-allow-list string   Comma-separated list of allowed CIDR network addresses for the box
+      --network-block-all           Whether to block all network access for the box
+      --public                      Make box publicly accessible
+      --snapshot string             Snapshot to use for the box
       --target string               Target region (eu, us)
-      --user string                 User associated with the sandbox
+      --user string                 User associated with the box
   -v, --volume stringArray          Volumes to mount (format: VOLUME_NAME:MOUNT_PATH)
 ```
 
@@ -39,4 +39,5 @@ boxlite create [flags]
 
 ### SEE ALSO
 
-* [boxlite](boxlite.md)  - BoxLite CLI
+* [boxlite](boxlite.md)	 - BoxLite CLI
+

--- a/apps/cli/docs/boxlite_delete.md
+++ b/apps/cli/docs/boxlite_delete.md
@@ -1,15 +1,15 @@
 ## boxlite delete
 
-Delete a sandbox
+Delete a box
 
 ```
-boxlite delete [SANDBOX_ID] | [SANDBOX_NAME] [flags]
+boxlite delete [BOX_ID] | [BOX_NAME] [flags]
 ```
 
 ### Options
 
 ```
-  -a, --all   Delete all sandboxes
+  -a, --all   Delete all boxes
 ```
 
 ### Options inherited from parent commands
@@ -20,4 +20,5 @@ boxlite delete [SANDBOX_ID] | [SANDBOX_NAME] [flags]
 
 ### SEE ALSO
 
-* [boxlite](boxlite.md)  - BoxLite CLI
+* [boxlite](boxlite.md)	 - BoxLite CLI
+

--- a/apps/cli/docs/boxlite_docs.md
+++ b/apps/cli/docs/boxlite_docs.md
@@ -14,4 +14,5 @@ boxlite docs [flags]
 
 ### SEE ALSO
 
-* [boxlite](boxlite.md)  - BoxLite CLI
+* [boxlite](boxlite.md)	 - BoxLite CLI
+

--- a/apps/cli/docs/boxlite_exec.md
+++ b/apps/cli/docs/boxlite_exec.md
@@ -1,13 +1,13 @@
 ## boxlite exec
 
-Execute a command in a sandbox
+Execute a command in a box
 
 ### Synopsis
 
-Execute a command in a running sandbox
+Execute a command in a running box
 
 ```
-boxlite exec [SANDBOX_ID | SANDBOX_NAME] -- [COMMAND] [ARGS...] [flags]
+boxlite exec [BOX_ID | BOX_NAME] -- [COMMAND] [ARGS...] [flags]
 ```
 
 ### Options
@@ -25,4 +25,5 @@ boxlite exec [SANDBOX_ID | SANDBOX_NAME] -- [COMMAND] [ARGS...] [flags]
 
 ### SEE ALSO
 
-* [boxlite](boxlite.md)  - BoxLite CLI
+* [boxlite](boxlite.md)	 - BoxLite CLI
+

--- a/apps/cli/docs/boxlite_info.md
+++ b/apps/cli/docs/boxlite_info.md
@@ -1,9 +1,9 @@
 ## boxlite info
 
-Get sandbox info
+Get box info
 
 ```
-boxlite info [SANDBOX_ID] | [SANDBOX_NAME] [flags]
+boxlite info [BOX_ID] | [BOX_NAME] [flags]
 ```
 
 ### Options
@@ -20,4 +20,5 @@ boxlite info [SANDBOX_ID] | [SANDBOX_NAME] [flags]
 
 ### SEE ALSO
 
-* [boxlite](boxlite.md)  - BoxLite CLI
+* [boxlite](boxlite.md)	 - BoxLite CLI
+

--- a/apps/cli/docs/boxlite_list.md
+++ b/apps/cli/docs/boxlite_list.md
@@ -1,6 +1,6 @@
 ## boxlite list
 
-List sandboxes
+List boxes
 
 ```
 boxlite list [flags]
@@ -22,4 +22,5 @@ boxlite list [flags]
 
 ### SEE ALSO
 
-* [boxlite](boxlite.md)  - BoxLite CLI
+* [boxlite](boxlite.md)	 - BoxLite CLI
+

--- a/apps/cli/docs/boxlite_login.md
+++ b/apps/cli/docs/boxlite_login.md
@@ -20,4 +20,5 @@ boxlite login [flags]
 
 ### SEE ALSO
 
-* [boxlite](boxlite.md)  - BoxLite CLI
+* [boxlite](boxlite.md)	 - BoxLite CLI
+

--- a/apps/cli/docs/boxlite_logout.md
+++ b/apps/cli/docs/boxlite_logout.md
@@ -14,4 +14,5 @@ boxlite logout [flags]
 
 ### SEE ALSO
 
-* [boxlite](boxlite.md)  - BoxLite CLI
+* [boxlite](boxlite.md)	 - BoxLite CLI
+

--- a/apps/cli/docs/boxlite_mcp.md
+++ b/apps/cli/docs/boxlite_mcp.md
@@ -14,7 +14,8 @@ Commands for managing BoxLite MCP Server
 
 ### SEE ALSO
 
-* [boxlite](boxlite.md)  - BoxLite CLI
-* [boxlite mcp config](boxlite_mcp_config.md)  - Outputs JSON configuration for BoxLite MCP Server
-* [boxlite mcp init](boxlite_mcp_init.md)  - Initialize BoxLite MCP Server with an agent (currently supported: claude, windsurf, cursor)
-* [boxlite mcp start](boxlite_mcp_start.md)  - Start BoxLite MCP Server
+* [boxlite](boxlite.md)	 - BoxLite CLI
+* [boxlite mcp config](boxlite_mcp_config.md)	 - Outputs JSON configuration for BoxLite MCP Server
+* [boxlite mcp init](boxlite_mcp_init.md)	 - Initialize BoxLite MCP Server with an agent (currently supported: claude, windsurf, cursor)
+* [boxlite mcp start](boxlite_mcp_start.md)	 - Start BoxLite MCP Server
+

--- a/apps/cli/docs/boxlite_mcp_config.md
+++ b/apps/cli/docs/boxlite_mcp_config.md
@@ -14,4 +14,5 @@ boxlite mcp config [AGENT_NAME] [flags]
 
 ### SEE ALSO
 
-* [boxlite mcp](boxlite_mcp.md)  - Manage BoxLite MCP Server
+* [boxlite mcp](boxlite_mcp.md)	 - Manage BoxLite MCP Server
+

--- a/apps/cli/docs/boxlite_mcp_init.md
+++ b/apps/cli/docs/boxlite_mcp_init.md
@@ -14,4 +14,5 @@ boxlite mcp init [AGENT_NAME] [flags]
 
 ### SEE ALSO
 
-* [boxlite mcp](boxlite_mcp.md)  - Manage BoxLite MCP Server
+* [boxlite mcp](boxlite_mcp.md)	 - Manage BoxLite MCP Server
+

--- a/apps/cli/docs/boxlite_mcp_start.md
+++ b/apps/cli/docs/boxlite_mcp_start.md
@@ -14,4 +14,5 @@ boxlite mcp start [flags]
 
 ### SEE ALSO
 
-* [boxlite mcp](boxlite_mcp.md)  - Manage BoxLite MCP Server
+* [boxlite mcp](boxlite_mcp.md)	 - Manage BoxLite MCP Server
+

--- a/apps/cli/docs/boxlite_organization.md
+++ b/apps/cli/docs/boxlite_organization.md
@@ -14,8 +14,9 @@ Commands for managing BoxLite organizations
 
 ### SEE ALSO
 
-* [boxlite](boxlite.md)  - BoxLite CLI
-* [boxlite organization create](boxlite_organization_create.md)  - Create a new organization and set it as active
-* [boxlite organization delete](boxlite_organization_delete.md)  - Delete an organization
-* [boxlite organization list](boxlite_organization_list.md)  - List all organizations
-* [boxlite organization use](boxlite_organization_use.md)  - Set active organization
+* [boxlite](boxlite.md)	 - BoxLite CLI
+* [boxlite organization create](boxlite_organization_create.md)	 - Create a new organization and set it as active
+* [boxlite organization delete](boxlite_organization_delete.md)	 - Delete an organization
+* [boxlite organization list](boxlite_organization_list.md)	 - List all organizations
+* [boxlite organization use](boxlite_organization_use.md)	 - Set active organization
+

--- a/apps/cli/docs/boxlite_organization_create.md
+++ b/apps/cli/docs/boxlite_organization_create.md
@@ -14,4 +14,5 @@ boxlite organization create [ORGANIZATION_NAME] [flags]
 
 ### SEE ALSO
 
-* [boxlite organization](boxlite_organization.md)  - Manage BoxLite organizations
+* [boxlite organization](boxlite_organization.md)	 - Manage BoxLite organizations
+

--- a/apps/cli/docs/boxlite_organization_delete.md
+++ b/apps/cli/docs/boxlite_organization_delete.md
@@ -14,4 +14,5 @@ boxlite organization delete [ORGANIZATION] [flags]
 
 ### SEE ALSO
 
-* [boxlite organization](boxlite_organization.md)  - Manage BoxLite organizations
+* [boxlite organization](boxlite_organization.md)	 - Manage BoxLite organizations
+

--- a/apps/cli/docs/boxlite_organization_list.md
+++ b/apps/cli/docs/boxlite_organization_list.md
@@ -20,4 +20,5 @@ boxlite organization list [flags]
 
 ### SEE ALSO
 
-* [boxlite organization](boxlite_organization.md)  - Manage BoxLite organizations
+* [boxlite organization](boxlite_organization.md)	 - Manage BoxLite organizations
+

--- a/apps/cli/docs/boxlite_organization_use.md
+++ b/apps/cli/docs/boxlite_organization_use.md
@@ -14,4 +14,5 @@ boxlite organization use [ORGANIZATION] [flags]
 
 ### SEE ALSO
 
-* [boxlite organization](boxlite_organization.md)  - Manage BoxLite organizations
+* [boxlite organization](boxlite_organization.md)	 - Manage BoxLite organizations
+

--- a/apps/cli/docs/boxlite_preview-url.md
+++ b/apps/cli/docs/boxlite_preview-url.md
@@ -1,9 +1,9 @@
 ## boxlite preview-url
 
-Get signed preview URL for a sandbox port
+Get signed preview URL for a box port
 
 ```
-boxlite preview-url [SANDBOX_ID | SANDBOX_NAME] [flags]
+boxlite preview-url [BOX_ID | BOX_NAME] [flags]
 ```
 
 ### Options
@@ -21,4 +21,5 @@ boxlite preview-url [SANDBOX_ID | SANDBOX_NAME] [flags]
 
 ### SEE ALSO
 
-* [boxlite](boxlite.md)  - BoxLite CLI
+* [boxlite](boxlite.md)	 - BoxLite CLI
+

--- a/apps/cli/docs/boxlite_snapshot.md
+++ b/apps/cli/docs/boxlite_snapshot.md
@@ -14,8 +14,9 @@ Commands for managing BoxLite snapshots
 
 ### SEE ALSO
 
-* [boxlite](boxlite.md)  - BoxLite CLI
-* [boxlite snapshot create](boxlite_snapshot_create.md)  - Create a snapshot
-* [boxlite snapshot delete](boxlite_snapshot_delete.md)  - Delete a snapshot
-* [boxlite snapshot list](boxlite_snapshot_list.md)  - List all snapshots
-* [boxlite snapshot push](boxlite_snapshot_push.md)  - Push local snapshot
+* [boxlite](boxlite.md)	 - BoxLite CLI
+* [boxlite snapshot create](boxlite_snapshot_create.md)	 - Create a snapshot
+* [boxlite snapshot delete](boxlite_snapshot_delete.md)	 - Delete a snapshot
+* [boxlite snapshot list](boxlite_snapshot_list.md)	 - List all snapshots
+* [boxlite snapshot push](boxlite_snapshot_push.md)	 - Push local snapshot
+

--- a/apps/cli/docs/boxlite_snapshot_create.md
+++ b/apps/cli/docs/boxlite_snapshot_create.md
@@ -10,12 +10,12 @@ boxlite snapshot create [SNAPSHOT] [flags]
 
 ```
   -c, --context stringArray   Files or directories to include in the build context (can be specified multiple times). If not provided, context will be automatically determined from COPY/ADD commands in the Dockerfile
-      --cpu int32             CPU cores that will be allocated to the underlying sandboxes (default: 1)
-      --disk int32            Disk space that will be allocated to the underlying sandboxes in GB (default: 3)
+      --cpu int32             CPU cores that will be allocated to the underlying boxes (default: 1)
+      --disk int32            Disk space that will be allocated to the underlying boxes in GB (default: 3)
   -f, --dockerfile string     Path to Dockerfile to build
   -e, --entrypoint string     The entrypoint command for the snapshot
   -i, --image string          The image name for the snapshot
-      --memory int32          Memory that will be allocated to the underlying sandboxes in GB (default: 1)
+      --memory int32          Memory that will be allocated to the underlying boxes in GB (default: 1)
       --region string         ID of the region where the snapshot will be available (defaults to organization default region)
 ```
 
@@ -27,4 +27,5 @@ boxlite snapshot create [SNAPSHOT] [flags]
 
 ### SEE ALSO
 
-* [boxlite snapshot](boxlite_snapshot.md)  - Manage BoxLite snapshots
+* [boxlite snapshot](boxlite_snapshot.md)	 - Manage BoxLite snapshots
+

--- a/apps/cli/docs/boxlite_snapshot_delete.md
+++ b/apps/cli/docs/boxlite_snapshot_delete.md
@@ -3,7 +3,7 @@
 Delete a snapshot
 
 ```
-boxlite snapshot delete [SNAPSHOT_ID] [flags]
+boxlite snapshot delete [SNAPSHOT_ID | SNAPSHOT_NAME] [flags]
 ```
 
 ### Options
@@ -20,4 +20,5 @@ boxlite snapshot delete [SNAPSHOT_ID] [flags]
 
 ### SEE ALSO
 
-* [boxlite snapshot](boxlite_snapshot.md)  - Manage BoxLite snapshots
+* [boxlite snapshot](boxlite_snapshot.md)	 - Manage BoxLite snapshots
+

--- a/apps/cli/docs/boxlite_snapshot_list.md
+++ b/apps/cli/docs/boxlite_snapshot_list.md
@@ -26,4 +26,5 @@ boxlite snapshot list [flags]
 
 ### SEE ALSO
 
-* [boxlite snapshot](boxlite_snapshot.md)  - Manage BoxLite snapshots
+* [boxlite snapshot](boxlite_snapshot.md)	 - Manage BoxLite snapshots
+

--- a/apps/cli/docs/boxlite_snapshot_push.md
+++ b/apps/cli/docs/boxlite_snapshot_push.md
@@ -13,10 +13,10 @@ boxlite snapshot push [SNAPSHOT] [flags]
 ### Options
 
 ```
-      --cpu int32           CPU cores that will be allocated to the underlying sandboxes (default: 1)
-      --disk int32          Disk space that will be allocated to the underlying sandboxes in GB (default: 3)
+      --cpu int32           CPU cores that will be allocated to the underlying boxes (default: 1)
+      --disk int32          Disk space that will be allocated to the underlying boxes in GB (default: 3)
   -e, --entrypoint string   The entrypoint command for the image
-      --memory int32        Memory that will be allocated to the underlying sandboxes in GB (default: 1)
+      --memory int32        Memory that will be allocated to the underlying boxes in GB (default: 1)
   -n, --name string         Specify the Snapshot name
       --region string       ID of the region where the snapshot will be available (defaults to organization default region)
 ```
@@ -29,4 +29,5 @@ boxlite snapshot push [SNAPSHOT] [flags]
 
 ### SEE ALSO
 
-* [boxlite snapshot](boxlite_snapshot.md)  - Manage BoxLite snapshots
+* [boxlite snapshot](boxlite_snapshot.md)	 - Manage BoxLite snapshots
+

--- a/apps/cli/docs/boxlite_ssh.md
+++ b/apps/cli/docs/boxlite_ssh.md
@@ -1,13 +1,13 @@
 ## boxlite ssh
 
-SSH into a sandbox
+SSH into a box
 
 ### Synopsis
 
-Establish an SSH connection to a running sandbox
+Establish an SSH connection to a running box
 
 ```
-boxlite ssh [SANDBOX_ID] | [SANDBOX_NAME] [flags]
+boxlite ssh [BOX_ID] | [BOX_NAME] [flags]
 ```
 
 ### Options
@@ -24,4 +24,5 @@ boxlite ssh [SANDBOX_ID] | [SANDBOX_NAME] [flags]
 
 ### SEE ALSO
 
-* [boxlite](boxlite.md)  - BoxLite CLI
+* [boxlite](boxlite.md)	 - BoxLite CLI
+

--- a/apps/cli/docs/boxlite_start.md
+++ b/apps/cli/docs/boxlite_start.md
@@ -1,9 +1,9 @@
 ## boxlite start
 
-Start a sandbox
+Start a box
 
 ```
-boxlite start [SANDBOX_ID] | [SANDBOX_NAME] [flags]
+boxlite start [BOX_ID] | [BOX_NAME] [flags]
 ```
 
 ### Options inherited from parent commands
@@ -14,4 +14,5 @@ boxlite start [SANDBOX_ID] | [SANDBOX_NAME] [flags]
 
 ### SEE ALSO
 
-* [boxlite](boxlite.md)  - BoxLite CLI
+* [boxlite](boxlite.md)	 - BoxLite CLI
+

--- a/apps/cli/docs/boxlite_stop.md
+++ b/apps/cli/docs/boxlite_stop.md
@@ -1,9 +1,15 @@
 ## boxlite stop
 
-Stop a sandbox
+Stop a box
 
 ```
-boxlite stop [SANDBOX_ID] | [SANDBOX_NAME] [flags]
+boxlite stop [BOX_ID] | [BOX_NAME] [flags]
+```
+
+### Options
+
+```
+  -f, --force   Force stop the box using SIGKILL
 ```
 
 ### Options inherited from parent commands
@@ -14,4 +20,5 @@ boxlite stop [SANDBOX_ID] | [SANDBOX_NAME] [flags]
 
 ### SEE ALSO
 
-* [boxlite](boxlite.md)  - BoxLite CLI
+* [boxlite](boxlite.md)	 - BoxLite CLI
+

--- a/apps/cli/docs/boxlite_version.md
+++ b/apps/cli/docs/boxlite_version.md
@@ -14,4 +14,5 @@ boxlite version [flags]
 
 ### SEE ALSO
 
-* [boxlite](boxlite.md)  - BoxLite CLI
+* [boxlite](boxlite.md)	 - BoxLite CLI
+

--- a/apps/cli/docs/boxlite_volume.md
+++ b/apps/cli/docs/boxlite_volume.md
@@ -14,8 +14,9 @@ Commands for managing BoxLite volumes
 
 ### SEE ALSO
 
-* [boxlite](boxlite.md)  - BoxLite CLI
-* [boxlite volume create](boxlite_volume_create.md)  - Create a volume
-* [boxlite volume delete](boxlite_volume_delete.md)  - Delete a volume
-* [boxlite volume get](boxlite_volume_get.md)  - Get volume details
-* [boxlite volume list](boxlite_volume_list.md)  - List all volumes
+* [boxlite](boxlite.md)	 - BoxLite CLI
+* [boxlite volume create](boxlite_volume_create.md)	 - Create a volume
+* [boxlite volume delete](boxlite_volume_delete.md)	 - Delete a volume
+* [boxlite volume get](boxlite_volume_get.md)	 - Get volume details
+* [boxlite volume list](boxlite_volume_list.md)	 - List all volumes
+

--- a/apps/cli/docs/boxlite_volume_create.md
+++ b/apps/cli/docs/boxlite_volume_create.md
@@ -20,4 +20,5 @@ boxlite volume create [NAME] [flags]
 
 ### SEE ALSO
 
-* [boxlite volume](boxlite_volume.md)  - Manage BoxLite volumes
+* [boxlite volume](boxlite_volume.md)	 - Manage BoxLite volumes
+

--- a/apps/cli/docs/boxlite_volume_delete.md
+++ b/apps/cli/docs/boxlite_volume_delete.md
@@ -14,4 +14,5 @@ boxlite volume delete [VOLUME_ID] [flags]
 
 ### SEE ALSO
 
-* [boxlite volume](boxlite_volume.md)  - Manage BoxLite volumes
+* [boxlite volume](boxlite_volume.md)	 - Manage BoxLite volumes
+

--- a/apps/cli/docs/boxlite_volume_get.md
+++ b/apps/cli/docs/boxlite_volume_get.md
@@ -20,4 +20,5 @@ boxlite volume get [VOLUME_ID] [flags]
 
 ### SEE ALSO
 
-* [boxlite volume](boxlite_volume.md)  - Manage BoxLite volumes
+* [boxlite volume](boxlite_volume.md)	 - Manage BoxLite volumes
+

--- a/apps/cli/docs/boxlite_volume_list.md
+++ b/apps/cli/docs/boxlite_volume_list.md
@@ -20,4 +20,5 @@ boxlite volume list [flags]
 
 ### SEE ALSO
 
-* [boxlite volume](boxlite_volume.md)  - Manage BoxLite volumes
+* [boxlite volume](boxlite_volume.md)	 - Manage BoxLite volumes
+

--- a/apps/cli/hack/docs/boxlite.yaml
+++ b/apps/cli/hack/docs/boxlite.yaml
@@ -1,6 +1,6 @@
 name: boxlite
 synopsis: BoxLite CLI
-description: Command line interface for BoxLite Sandboxes
+description: Command line interface for BoxLite Boxes
 usage: boxlite [flags]
 options:
   - name: help
@@ -11,22 +11,22 @@ options:
     default_value: 'false'
     usage: Display the version of BoxLite
 see_also:
-  - boxlite archive - Archive a sandbox
+  - boxlite archive - Archive a box
   - boxlite autocomplete - Adds a completion script for your shell environment
-  - boxlite create - Create a new sandbox
-  - boxlite delete - Delete a sandbox
+  - boxlite create - Create a new box
+  - boxlite delete - Delete a box
   - boxlite docs - Opens the BoxLite documentation in your default browser.
-  - boxlite exec - Execute a command in a sandbox
-  - boxlite info - Get sandbox info
-  - boxlite list - List sandboxes
+  - boxlite exec - Execute a command in a box
+  - boxlite info - Get box info
+  - boxlite list - List boxes
   - boxlite login - Log in to BoxLite
   - boxlite logout - Logout from BoxLite
   - boxlite mcp - Manage BoxLite MCP Server
   - boxlite organization - Manage BoxLite organizations
-  - boxlite preview-url - Get signed preview URL for a sandbox port
+  - boxlite preview-url - Get signed preview URL for a box port
   - boxlite snapshot - Manage BoxLite snapshots
-  - boxlite ssh - SSH into a sandbox
-  - boxlite start - Start a sandbox
-  - boxlite stop - Stop a sandbox
+  - boxlite ssh - SSH into a box
+  - boxlite start - Start a box
+  - boxlite stop - Stop a box
   - boxlite version - Print the version number
   - boxlite volume - Manage BoxLite volumes

--- a/apps/cli/hack/docs/boxlite_archive.yaml
+++ b/apps/cli/hack/docs/boxlite_archive.yaml
@@ -1,6 +1,6 @@
 name: boxlite archive
-synopsis: Archive a sandbox
-usage: boxlite archive [SANDBOX_ID] | [SANDBOX_NAME] [flags]
+synopsis: Archive a box
+usage: boxlite archive [BOX_ID] | [BOX_NAME] [flags]
 inherited_options:
   - name: help
     default_value: 'false'

--- a/apps/cli/hack/docs/boxlite_create.yaml
+++ b/apps/cli/hack/docs/boxlite_create.yaml
@@ -1,5 +1,5 @@
 name: boxlite create
-synopsis: Create a new sandbox
+synopsis: Create a new box
 usage: boxlite create [flags]
 options:
   - name: auto-archive
@@ -14,7 +14,7 @@ options:
     default_value: '15'
     usage: Auto-stop interval in minutes (0 means disabled)
   - name: class
-    usage: Sandbox class type (small, medium, large)
+    usage: Box class type (small, medium, large)
   - name: context
     shorthand: c
     default_value: '[]'
@@ -22,44 +22,44 @@ options:
       Files or directories to include in the build context (can be specified multiple times)
   - name: cpu
     default_value: '0'
-    usage: CPU cores allocated to the sandbox
+    usage: CPU cores allocated to the box
   - name: disk
     default_value: '0'
-    usage: Disk space allocated to the sandbox in GB
+    usage: Disk space allocated to the box in GB
   - name: dockerfile
     shorthand: f
-    usage: Path to Dockerfile for Sandbox snapshot
+    usage: Path to Dockerfile for Box snapshot
   - name: env
     shorthand: e
     default_value: '[]'
     usage: 'Environment variables (format: KEY=VALUE)'
   - name: gpu
     default_value: '0'
-    usage: GPU units allocated to the sandbox
+    usage: GPU units allocated to the box
   - name: label
     shorthand: l
     default_value: '[]'
     usage: 'Labels (format: KEY=VALUE)'
   - name: memory
     default_value: '0'
-    usage: Memory allocated to the sandbox in MB
+    usage: Memory allocated to the box in MB
   - name: name
-    usage: Name of the sandbox
+    usage: Name of the box
   - name: network-allow-list
     usage: |
-      Comma-separated list of allowed CIDR network addresses for the sandbox
+      Comma-separated list of allowed CIDR network addresses for the box
   - name: network-block-all
     default_value: 'false'
-    usage: Whether to block all network access for the sandbox
+    usage: Whether to block all network access for the box
   - name: public
     default_value: 'false'
-    usage: Make sandbox publicly accessible
+    usage: Make box publicly accessible
   - name: snapshot
-    usage: Snapshot to use for the sandbox
+    usage: Snapshot to use for the box
   - name: target
     usage: Target region (eu, us)
   - name: user
-    usage: User associated with the sandbox
+    usage: User associated with the box
   - name: volume
     shorthand: v
     default_value: '[]'

--- a/apps/cli/hack/docs/boxlite_delete.yaml
+++ b/apps/cli/hack/docs/boxlite_delete.yaml
@@ -1,11 +1,11 @@
 name: boxlite delete
-synopsis: Delete a sandbox
-usage: boxlite delete [SANDBOX_ID] | [SANDBOX_NAME] [flags]
+synopsis: Delete a box
+usage: boxlite delete [BOX_ID] | [BOX_NAME] [flags]
 options:
   - name: all
     shorthand: a
     default_value: 'false'
-    usage: Delete all sandboxes
+    usage: Delete all boxes
 inherited_options:
   - name: help
     default_value: 'false'

--- a/apps/cli/hack/docs/boxlite_exec.yaml
+++ b/apps/cli/hack/docs/boxlite_exec.yaml
@@ -1,7 +1,7 @@
 name: boxlite exec
-synopsis: Execute a command in a sandbox
-description: Execute a command in a running sandbox
-usage: boxlite exec [SANDBOX_ID | SANDBOX_NAME] -- [COMMAND] [ARGS...] [flags]
+synopsis: Execute a command in a box
+description: Execute a command in a running box
+usage: boxlite exec [BOX_ID | BOX_NAME] -- [COMMAND] [ARGS...] [flags]
 options:
   - name: cwd
     usage: Working directory for command execution

--- a/apps/cli/hack/docs/boxlite_info.yaml
+++ b/apps/cli/hack/docs/boxlite_info.yaml
@@ -1,6 +1,6 @@
 name: boxlite info
-synopsis: Get sandbox info
-usage: boxlite info [SANDBOX_ID] | [SANDBOX_NAME] [flags]
+synopsis: Get box info
+usage: boxlite info [BOX_ID] | [BOX_NAME] [flags]
 options:
   - name: format
     shorthand: f

--- a/apps/cli/hack/docs/boxlite_list.yaml
+++ b/apps/cli/hack/docs/boxlite_list.yaml
@@ -1,5 +1,5 @@
 name: boxlite list
-synopsis: List sandboxes
+synopsis: List boxes
 usage: boxlite list [flags]
 options:
   - name: format

--- a/apps/cli/hack/docs/boxlite_preview-url.yaml
+++ b/apps/cli/hack/docs/boxlite_preview-url.yaml
@@ -1,6 +1,6 @@
 name: boxlite preview-url
-synopsis: Get signed preview URL for a sandbox port
-usage: boxlite preview-url [SANDBOX_ID | SANDBOX_NAME] [flags]
+synopsis: Get signed preview URL for a box port
+usage: boxlite preview-url [BOX_ID | BOX_NAME] [flags]
 options:
   - name: expires
     default_value: '3600'

--- a/apps/cli/hack/docs/boxlite_snapshot_create.yaml
+++ b/apps/cli/hack/docs/boxlite_snapshot_create.yaml
@@ -10,11 +10,11 @@ options:
   - name: cpu
     default_value: '0'
     usage: |
-      CPU cores that will be allocated to the underlying sandboxes (default: 1)
+      CPU cores that will be allocated to the underlying boxes (default: 1)
   - name: disk
     default_value: '0'
     usage: |
-      Disk space that will be allocated to the underlying sandboxes in GB (default: 3)
+      Disk space that will be allocated to the underlying boxes in GB (default: 3)
   - name: dockerfile
     shorthand: f
     usage: Path to Dockerfile to build
@@ -27,7 +27,7 @@ options:
   - name: memory
     default_value: '0'
     usage: |
-      Memory that will be allocated to the underlying sandboxes in GB (default: 1)
+      Memory that will be allocated to the underlying boxes in GB (default: 1)
   - name: region
     usage: |
       ID of the region where the snapshot will be available (defaults to organization default region)

--- a/apps/cli/hack/docs/boxlite_snapshot_delete.yaml
+++ b/apps/cli/hack/docs/boxlite_snapshot_delete.yaml
@@ -1,6 +1,6 @@
 name: boxlite snapshot delete
 synopsis: Delete a snapshot
-usage: boxlite snapshot delete [SNAPSHOT_ID] [flags]
+usage: boxlite snapshot delete [SNAPSHOT_ID | SNAPSHOT_NAME] [flags]
 options:
   - name: all
     shorthand: a

--- a/apps/cli/hack/docs/boxlite_snapshot_push.yaml
+++ b/apps/cli/hack/docs/boxlite_snapshot_push.yaml
@@ -7,18 +7,18 @@ options:
   - name: cpu
     default_value: '0'
     usage: |
-      CPU cores that will be allocated to the underlying sandboxes (default: 1)
+      CPU cores that will be allocated to the underlying boxes (default: 1)
   - name: disk
     default_value: '0'
     usage: |
-      Disk space that will be allocated to the underlying sandboxes in GB (default: 3)
+      Disk space that will be allocated to the underlying boxes in GB (default: 3)
   - name: entrypoint
     shorthand: e
     usage: The entrypoint command for the image
   - name: memory
     default_value: '0'
     usage: |
-      Memory that will be allocated to the underlying sandboxes in GB (default: 1)
+      Memory that will be allocated to the underlying boxes in GB (default: 1)
   - name: name
     shorthand: 'n'
     usage: Specify the Snapshot name

--- a/apps/cli/hack/docs/boxlite_ssh.yaml
+++ b/apps/cli/hack/docs/boxlite_ssh.yaml
@@ -1,7 +1,7 @@
 name: boxlite ssh
-synopsis: SSH into a sandbox
-description: Establish an SSH connection to a running sandbox
-usage: boxlite ssh [SANDBOX_ID] | [SANDBOX_NAME] [flags]
+synopsis: SSH into a box
+description: Establish an SSH connection to a running box
+usage: boxlite ssh [BOX_ID] | [BOX_NAME] [flags]
 options:
   - name: expires
     default_value: '1440'

--- a/apps/cli/hack/docs/boxlite_start.yaml
+++ b/apps/cli/hack/docs/boxlite_start.yaml
@@ -1,6 +1,6 @@
 name: boxlite start
-synopsis: Start a sandbox
-usage: boxlite start [SANDBOX_ID] | [SANDBOX_NAME] [flags]
+synopsis: Start a box
+usage: boxlite start [BOX_ID] | [BOX_NAME] [flags]
 inherited_options:
   - name: help
     default_value: 'false'

--- a/apps/cli/hack/docs/boxlite_stop.yaml
+++ b/apps/cli/hack/docs/boxlite_stop.yaml
@@ -1,6 +1,11 @@
 name: boxlite stop
-synopsis: Stop a sandbox
-usage: boxlite stop [SANDBOX_ID] | [SANDBOX_NAME] [flags]
+synopsis: Stop a box
+usage: boxlite stop [BOX_ID] | [BOX_NAME] [flags]
+options:
+  - name: force
+    shorthand: f
+    default_value: 'false'
+    usage: Force stop the box using SIGKILL
 inherited_options:
   - name: help
     default_value: 'false'

--- a/apps/cli/hack/generate-cli-docs.sh
+++ b/apps/cli/hack/generate-cli-docs.sh
@@ -8,3 +8,6 @@ rm -rf docs hack/docs
 
 # Generate default CLI documentation files in folder "docs"
 go run main.go generate-docs
+
+# Match the repo's committed formatting (same as the daemon docs target)
+../node_modules/.bin/prettier --write "hack/docs/**/*.yaml"

--- a/apps/daemon/pkg/toolbox/docs/docs.go
+++ b/apps/daemon/pkg/toolbox/docs/docs.go
@@ -2585,7 +2585,7 @@ const docTemplate = `{
         },
         "/process/session/entrypoint/logs": {
             "get": {
-                "description": "Get logs for a sandbox entrypoint session. Supports both HTTP and WebSocket streaming.",
+                "description": "Get logs for a box entrypoint session. Supports both HTTP and WebSocket streaming.",
                 "produces": [
                     "text/plain"
                 ],

--- a/apps/daemon/pkg/toolbox/docs/swagger.json
+++ b/apps/daemon/pkg/toolbox/docs/swagger.json
@@ -2223,7 +2223,7 @@
     },
     "/process/session/entrypoint/logs": {
       "get": {
-        "description": "Get logs for a sandbox entrypoint session. Supports both HTTP and WebSocket streaming.",
+        "description": "Get logs for a box entrypoint session. Supports both HTTP and WebSocket streaming.",
         "produces": ["text/plain"],
         "tags": ["process"],
         "summary": "Get entrypoint logs",

--- a/apps/daemon/pkg/toolbox/docs/swagger.yaml
+++ b/apps/daemon/pkg/toolbox/docs/swagger.yaml
@@ -2761,8 +2761,8 @@ paths:
         - process
   /process/session/entrypoint/logs:
     get:
-      description: Get logs for a sandbox entrypoint session. Supports both HTTP and
-        WebSocket streaming.
+      description: Get logs for a box entrypoint session. Supports both HTTP and WebSocket
+        streaming.
       operationId: GetEntrypointLogs
       parameters:
         - description: Follow logs in real-time (WebSocket only)


### PR DESCRIPTION
Closes the "Regenerate cli cobra docs + daemon swaggo docs" checkbox from #711.

CLI Go source and daemon toolbox source are fully renamed (verified 0 `sandbox` tokens before regenerating), but the committed generated docs predated the rename — cobra markdown/YAML still said "Create a new sandbox" etc., and the toolbox swagger carried one stale token.

## Changes (all generator output + one script fix)

- `apps/cli/docs/*.md`, `apps/cli/hack/docs/*.yaml` — regenerated via `hack/generate-cli-docs.sh` (`go run main.go generate-docs`). Diff = sandbox→box description catch-up + genuine drift catch-up (newly documented flags such as `--force`, `snapshot delete` usage gaining `SNAPSHOT_NAME`).
- `apps/daemon/pkg/toolbox/docs/{docs.go,swagger.json,swagger.yaml}` — regenerated via the daemon `docs` target command (`swag fmt && swag init … && prettier`). Now 0 sandbox tokens.
- `apps/cli/hack/generate-cli-docs.sh` (+3) — adds a prettier pass over `hack/docs/**/*.yaml`: the committed YAML is prettier-formatted while raw cobra output is not, so without this every regen produces ~700 lines of quoting/indent churn (observed 1172→478 changed lines). Mirrors what the daemon docs target already does.

## Verification

- 0 `sandbox` tokens in all regenerated outputs (`git grep -i sandbox` over the three docs trees: empty).
- Every changed line mechanically classified: rename catch-up, prettier/cobra whitespace normalization, or the named new-flag drift — nothing unexplained.
- shellcheck clean on the script.

Note: unlike the API clients (#716 added a drift gate), these docs have no CI gate — staleness will accumulate again until regenerated; a sibling drift job is a possible follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI documentation to use "box" terminology instead of "sandbox" across all commands and help text.
  * Improved documentation formatting and alignment in command reference guides.

* **New Features**
  * Added `boxlite autocomplete` command for shell completion support.
  * Enhanced `boxlite snapshot delete` to accept both snapshot ID and snapshot name.
  * Added `--force` flag to `boxlite stop` command for force-stopping boxes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->