### PR TITLE
feat(infra): install bwrap AppArmor profile + bubblewrap on runner EC2

### DIFF
--- a/apps/infra/sst.config.ts
+++ b/apps/infra/sst.config.ts
@@ -831,7 +831,7 @@ exec > /var/log/runner-setup.log 2>&1
 while fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1; do sleep 5; done
 
 apt-get update
-apt-get install -y curl
+apt-get install -y curl bubblewrap
 
 # Install Mountpoint for Amazon S3, used by volume mounts
 MOUNT_S3_VERSION=1.20.0
@@ -839,6 +839,57 @@ MOUNT_S3_ARCH=x86_64
 curl -fsSL "https://s3.amazonaws.com/mountpoint-s3-release/\${MOUNT_S3_VERSION}/\${MOUNT_S3_ARCH}/mount-s3-\${MOUNT_S3_VERSION}-\${MOUNT_S3_ARCH}.deb" -o /tmp/mount-s3.deb
 apt-get install -y /tmp/mount-s3.deb
 rm -f /tmp/mount-s3.deb
+
+# Ubuntu 24.04 ships kernel.apparmor_restrict_unprivileged_userns=1 but does NOT
+# ship the bwrap-userns-restrict AppArmor profile that Ubuntu 25.04+ includes.
+# Without this profile the system bwrap (used by BoxLite's jailer for sandbox
+# isolation) is DENIED the userns capability and every box fails with
+# "Timeout waiting for guest ready / VM subprocess exited before guest became
+# ready". Install the same profile Ubuntu 25.04+ ships, scoped to /usr/bin/bwrap
+# so the kernel restriction stays in place for everything else on the host.
+# See docs/faq.md "Ubuntu 24.04: Timeout waiting for guest ready" §Fix A.
+cat > /etc/apparmor.d/bwrap-userns-restrict << 'PROFILE'
+abi <abi/4.0>,
+
+include <tunables/global>
+
+profile bwrap /usr/bin/bwrap flags=(attach_disconnected,mediate_deleted) {
+  allow capability,
+  allow file rwlkm /{**,},
+  allow network,
+  allow unix,
+  allow ptrace,
+  allow signal,
+  allow mqueue,
+  allow io_uring,
+  allow userns,
+  allow mount,
+  allow umount,
+  allow pivot_root,
+  allow dbus,
+  allow pix /** -> &bwrap//&unpriv_bwrap,
+  include if exists <local/bwrap-userns-restrict>
+}
+
+profile unpriv_bwrap flags=(attach_disconnected,mediate_deleted) {
+  allow file rwlkm /{**,},
+  allow network,
+  allow unix,
+  allow ptrace,
+  allow signal,
+  allow mqueue,
+  allow io_uring,
+  allow userns,
+  allow mount,
+  allow umount,
+  allow pivot_root,
+  allow dbus,
+  allow pix /** -> &unpriv_bwrap,
+  audit deny capability,
+  include if exists <local/unpriv_bwrap>
+}
+PROFILE
+apparmor_parser -r /etc/apparmor.d/bwrap-userns-restrict
 
 # Download prebuilt runner binary from GitHub Releases
 curl -fsSL "https://github.com/boxlite-ai/boxlite/releases/download/v${RUNNER_VERSION}/boxlite-runner-v${RUNNER_VERSION}-linux-amd64.tar.gz" | tar xz -C /usr/local/bin/


### PR DESCRIPTION
## Bug

The runner EC2 AMI is Ubuntu 24.04 (noble). Ubuntu 24.04 ships `kernel.apparmor_restrict_unprivileged_userns=1` but does NOT ship the `bwrap-userns-restrict` AppArmor profile that Ubuntu 25.04+ includes. Without that profile, bwrap (used by BoxLite's jailer for sandbox isolation — `SecurityOptions::strict`) is DENIED the userns capability and every box fails:

```
Timeout waiting for guest ready (30s)
VM subprocess exited before guest became ready
dmesg: apparmor="DENIED" ... comm="bwrap" capability=8
```

So BoxLite's security option (`SecurityOptions::strict`, default for prod) is unusable on every freshly-provisioned runner — boxes only start if you `SecurityOptions::development()` (disable jailer) or manually patch the host.

## Fix

`apps/infra/sst.config.ts` user-data — two additions to `buildRunnerUserData()`:

1. **`apt-get install -y bubblewrap`** so `/usr/bin/bwrap` exists. The AppArmor profile is scoped to that exact path; the runner's fallback bundled-bwrap (from `bubblewrap-sys`) extracts to an arbitrary cache path that the profile can't match.
2. **Write `/etc/apparmor.d/bwrap-userns-restrict`** with the same profile Ubuntu 25.04+ ships (`bwrap` + `unpriv_bwrap`), then `apparmor_parser -r` to load it.

The global kernel restriction (`apparmor_restrict_unprivileged_userns=1`) stays on — only `/usr/bin/bwrap` gets the userns + capability allowances it needs. This is `docs/faq.md` "Ubuntu 24.04: Timeout waiting for guest ready" §Fix A (the targeted, recommended option).

Why not the alternatives:

| Option | Why not |
|---|---|
| `sysctl -w kernel.apparmor_restrict_unprivileged_userns=0` (FAQ Fix B) | Disables userns AppArmor protection host-wide — worse posture than the targeted profile that only allows it for /usr/bin/bwrap. |
| `SecurityOptions::development()` (FAQ Fix C) | Turns OFF the jailer. Acceptable for local dev, not for the production runner this user-data provisions. |
| Bake into the AMI | This stack pins a generic Canonical-owned AMI by name pattern; baking a custom AMI couples infra to image-build pipeline. The fix is one cloud-init block. |

## Test plan — manual deploy verification

Can't unit-test cloud-init from the repo. Verify on next `pulumi up`:

- [ ] `pulumi up` on a stack with `RUNNERS=1` (or more) brings up Runner EC2(s) with the new user-data.
- [ ] `ssh runner` → `cat /var/log/runner-setup.log` shows the AppArmor profile write + `apparmor_parser -r` exit 0.
- [ ] `aa-status | grep bwrap` shows `bwrap` (the new profile) loaded.
- [ ] Create a box via the API (any default-`strict` security profile). It reaches "guest ready" without the 30s timeout.
- [ ] `dmesg | grep apparmor | grep bwrap` no longer shows `DENIED` lines for `comm="bwrap" capability=8`.

The user-data only re-runs on instance replacement; the Runner's `ignoreChanges: ["userDataBase64"]` is intentional (in-place upgrades go through `scripts/deploy/runner-update-binary.sh`). So this change lands on the NEXT runner replacement — for existing runners, the same AppArmor profile + bwrap install must be applied via SSM Run Command. Suggested follow-up: a one-shot SSM doc that idempotently applies the same `tee` + `apparmor_parser` block on existing runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
