### PR TITLE
fix(apps): vend box S3 credentials from the ECS task role, not a static IAM user

### DIFF
--- a/apps/api/src/admin/services/observability.service.ts
+++ b/apps/api/src/admin/services/observability.service.ts
@@ -8,11 +8,7 @@ import { Inject, Injectable, ServiceUnavailableException } from '@nestjs/common'
 import { ClickHouseService } from '../../clickhouse/clickhouse.service'
 import { TypedConfigService } from '../../config/typed-config.service'
 import { LogEntryDto } from '../../box-telemetry/dto/log-entry.dto'
-import {
-  MetricsResponseDto,
-  MetricDataPointDto,
-  MetricSeriesDto,
-} from '../../box-telemetry/dto/metrics-response.dto'
+import { MetricsResponseDto, MetricDataPointDto, MetricSeriesDto } from '../../box-telemetry/dto/metrics-response.dto'
 import { PaginatedLogsDto } from '../../box-telemetry/dto/paginated-logs.dto'
 import { PaginatedTracesDto } from '../../box-telemetry/dto/paginated-traces.dto'
 import { TraceSpanDto } from '../../box-telemetry/dto/trace-span.dto'

--- a/apps/api/src/app.service.ts
+++ b/apps/api/src/app.service.ts
@@ -191,5 +191,4 @@ Admin API key ensured: ${this.maskApiKeyForLog(value)}
     }
     return `${value.slice(0, 4)}...${value.slice(-4)}`
   }
-
 }

--- a/apps/api/src/box/box.module.ts
+++ b/apps/api/src/box/box.module.ts
@@ -58,16 +58,7 @@ import { BoxStateWaiterService } from './services/box-state-waiter.service'
     UserModule,
     OrganizationModule,
     RegionModule,
-    TypeOrmModule.forFeature([
-      Box,
-      Runner,
-      WarmPool,
-      Volume,
-      SshAccess,
-      Region,
-      Job,
-      BoxLastActivity,
-    ]),
+    TypeOrmModule.forFeature([Box, Runner, WarmPool, Volume, SshAccess, Region, Job, BoxLastActivity]),
   ],
   controllers: [
     BoxController,

--- a/apps/api/src/box/controllers/runner.controller.ts
+++ b/apps/api/src/box/controllers/runner.controller.ts
@@ -20,15 +20,7 @@ import {
 } from '@nestjs/common'
 import { CreateRunnerDto } from '../dto/create-runner.dto'
 import { RunnerService } from '../services/runner.service'
-import {
-  ApiOAuth2,
-  ApiTags,
-  ApiOperation,
-  ApiBearerAuth,
-  ApiResponse,
-  ApiParam,
-  ApiHeader,
-} from '@nestjs/swagger'
+import { ApiOAuth2, ApiTags, ApiOperation, ApiBearerAuth, ApiResponse, ApiParam, ApiHeader } from '@nestjs/swagger'
 import { SystemActionGuard } from '../../auth/system-action.guard'
 import { RequiredApiRole } from '../../common/decorators/required-role.decorator'
 import { SystemRole } from '../../user/enums/system-role.enum'

--- a/apps/api/src/box/managers/volume.manager.spec.ts
+++ b/apps/api/src/box/managers/volume.manager.spec.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { ListObjectsV2Command, S3Client } from '@aws-sdk/client-s3'
+import { VolumeManager } from './volume.manager'
+
+const mockSend = jest.fn()
+
+jest.mock('@aws-sdk/client-s3', () => ({
+  S3Client: jest.fn().mockImplementation(() => ({ send: mockSend })),
+  CreateBucketCommand: jest.fn().mockImplementation((input) => ({ input })),
+  ListObjectsV2Command: jest.fn().mockImplementation((input) => ({ input })),
+  PutBucketTaggingCommand: jest.fn().mockImplementation((input) => ({ input })),
+}))
+
+describe('VolumeManager S3 client setup', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  function buildManager(values: Record<string, unknown>) {
+    const configService = {
+      get: jest.fn((key: string) => values[key]),
+      getOrThrow: jest.fn((key: string) => {
+        const value = values[key]
+        if (value === undefined) {
+          throw new Error(`Missing config: ${key}`)
+        }
+        return value
+      }),
+    }
+    return new VolumeManager({} as any, configService as any, {} as any, {} as any, {} as any)
+  }
+
+  const awsConfig = {
+    's3.endpoint': 'https://s3.ap-southeast-1.amazonaws.com',
+    's3.region': 'ap-southeast-1',
+    's3.defaultBucket': 'boxlite-dev-storage',
+  }
+
+  it('uses the SDK default chain and probes the known bucket instead of ListBuckets', async () => {
+    mockSend.mockResolvedValue({})
+    const manager = buildManager(awsConfig)
+
+    await manager.onModuleInit()
+
+    // No `credentials` key at all → SDK default chain (ECS task role).
+    expect(S3Client).toHaveBeenCalledWith({
+      endpoint: 'https://s3.ap-southeast-1.amazonaws.com',
+      region: 'ap-southeast-1',
+      forcePathStyle: true,
+    })
+    // Scoped probe: no account-wide s3:ListAllMyBuckets needed.
+    expect(ListObjectsV2Command).toHaveBeenCalledWith({ Bucket: 'boxlite-dev-storage', MaxKeys: 1 })
+  })
+
+  it('still passes static keys through when configured', () => {
+    buildManager({ ...awsConfig, 's3.accessKey': 'static-id', 's3.secretKey': 'static-secret' })
+
+    expect(S3Client).toHaveBeenCalledWith(
+      expect.objectContaining({
+        credentials: { accessKeyId: 'static-id', secretAccessKey: 'static-secret' },
+      }),
+    )
+  })
+
+  it('skips the probe when no default bucket is configured', async () => {
+    const manager = buildManager({ 's3.endpoint': 'http://s3-compatible.local:9000', 's3.region': 'us-east-1' })
+
+    await manager.onModuleInit()
+
+    expect(ListObjectsV2Command).not.toHaveBeenCalled()
+    expect(mockSend).not.toHaveBeenCalled()
+  })
+
+  it('rejects a lone static key instead of silently using the default chain', () => {
+    expect(() => buildManager({ ...awsConfig, 's3.accessKey': 'static-id' })).toThrow(
+      /S3_ACCESS_KEY and S3_SECRET_KEY must be set together/,
+    )
+  })
+
+  it('fails fast when MinIO is configured without static keys', () => {
+    expect(() => buildManager({ 's3.endpoint': 'http://minio:9000', 's3.region': 'us-east-1' })).toThrow(
+      /MinIO requires S3_ACCESS_KEY and S3_SECRET_KEY/,
+    )
+  })
+})

--- a/apps/api/src/box/managers/volume.manager.ts
+++ b/apps/api/src/box/managers/volume.manager.ts
@@ -50,17 +50,16 @@ export class VolumeManager
 
     const endpoint = this.configService.getOrThrow('s3.endpoint')
     const region = this.configService.getOrThrow('s3.region')
-    const accessKeyId = this.configService.getOrThrow('s3.accessKey')
-    const secretAccessKey = this.configService.getOrThrow('s3.secretKey')
+    const accessKeyId = this.configService.get('s3.accessKey')
+    const secretAccessKey = this.configService.get('s3.secretKey')
     this.skipTestConnection = this.configService.get('skipConnections')
 
     this.s3Client = new S3Client({
       endpoint: endpoint.startsWith('http') ? endpoint : `http://${endpoint}`,
       region,
-      credentials: {
-        accessKeyId,
-        secretAccessKey,
-      },
+      // Static keys for S3-compatible deployments (MinIO); unset on AWS,
+      // where the SDK default chain supplies the ECS task-role credentials.
+      ...(accessKeyId && secretAccessKey ? { credentials: { accessKeyId, secretAccessKey } } : {}),
       forcePathStyle: true,
     })
   }

--- a/apps/api/src/box/managers/volume.manager.ts
+++ b/apps/api/src/box/managers/volume.manager.ts
@@ -10,7 +10,7 @@ import { Repository, In } from 'typeorm'
 import { Volume } from '../entities/volume.entity'
 import { VolumeState } from '../enums/volume-state.enum'
 import { Cron, CronExpression, SchedulerRegistry } from '@nestjs/schedule'
-import { S3Client, CreateBucketCommand, ListBucketsCommand, PutBucketTaggingCommand } from '@aws-sdk/client-s3'
+import { S3Client, CreateBucketCommand, ListObjectsV2Command, PutBucketTaggingCommand } from '@aws-sdk/client-s3'
 import { InjectRedis } from '@nestjs-modules/ioredis'
 import { Redis } from 'ioredis'
 import { RedisLockProvider } from '../common/redis-lock.provider'
@@ -54,6 +54,18 @@ export class VolumeManager
     const secretAccessKey = this.configService.get('s3.secretKey')
     this.skipTestConnection = this.configService.get('skipConnections')
 
+    // Both-or-neither (mirrors observability-s3.reader.ts): a lone key is a
+    // typo'd pair, and silently falling back to the SDK default chain would
+    // mask the misconfig.
+    if ((accessKeyId && !secretAccessKey) || (!accessKeyId && secretAccessKey)) {
+      throw new Error('S3_ACCESS_KEY and S3_SECRET_KEY must be set together')
+    }
+    // MinIO cannot use the SDK default chain — fail fast at boot with a clear
+    // message instead of a generic auth error from the connection probe.
+    if (endpoint.includes('minio') && !accessKeyId) {
+      throw new Error('MinIO requires S3_ACCESS_KEY and S3_SECRET_KEY to be configured')
+    }
+
     this.s3Client = new S3Client({
       endpoint: endpoint.startsWith('http') ? endpoint : `http://${endpoint}`,
       region,
@@ -94,9 +106,17 @@ export class VolumeManager
   }
 
   private async testConnection() {
+    // Probe a bucket we already know instead of ListBuckets: same
+    // connectivity+auth signal, but needs no account-wide
+    // s3:ListAllMyBuckets grant on the task role.
+    const bucket = this.configService.get('s3.defaultBucket')
+    if (!bucket) {
+      this.logger.debug('No default bucket configured; skipping S3 connection test')
+      return
+    }
+
     try {
-      // Try a simple operation to test the connection
-      const command = new ListBucketsCommand({})
+      const command = new ListObjectsV2Command({ Bucket: bucket, MaxKeys: 1 })
       await this.s3Client.send(command)
       this.logger.debug('Successfully connected to S3')
     } catch (error) {

--- a/apps/api/src/box/runner-adapter/runnerAdapter.v2.ts
+++ b/apps/api/src/box/runner-adapter/runnerAdapter.v2.ts
@@ -162,14 +162,7 @@ export class RunnerAdapterV2 implements RunnerAdapter {
       networkAllowList: box.networkAllowList,
       errorReason: box.errorReason,
     }
-    await this.jobService.createJob(
-      null,
-      JobType.RECOVER_BOX,
-      this.runner.id,
-      ResourceType.BOX,
-      box.id,
-      recoverBoxDTO,
-    )
+    await this.jobService.createJob(null, JobType.RECOVER_BOX, this.runner.id, ResourceType.BOX, box.id, recoverBoxDTO)
 
     this.logger.debug(`Created RECOVER_BOX job for box ${box.id} on runner ${this.runner.id}`)
   }

--- a/apps/api/src/box/services/job-state-handler.service.ts
+++ b/apps/api/src/box/services/job-state-handler.service.ts
@@ -298,9 +298,7 @@ export class JobStateHandlerService {
             : null
 
       if (!previousState) {
-        this.logger.error(
-          `Box ${boxId} has unexpected desiredState ${box.desiredState} for RESIZE_BOX job ${job.id}`,
-        )
+        this.logger.error(`Box ${boxId} has unexpected desiredState ${box.desiredState} for RESIZE_BOX job ${job.id}`)
         return
       }
 

--- a/apps/api/src/box/services/volume.service.ts
+++ b/apps/api/src/box/services/volume.service.ts
@@ -4,13 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import {
-  ConflictException,
-  Injectable,
-  Logger,
-  NotFoundException,
-  ServiceUnavailableException,
-} from '@nestjs/common'
+import { ConflictException, Injectable, Logger, NotFoundException, ServiceUnavailableException } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
 import { Repository, Not, In } from 'typeorm'
 import { Volume } from '../entities/volume.entity'

--- a/apps/api/src/config/configuration.ts
+++ b/apps/api/src/config/configuration.ts
@@ -159,8 +159,7 @@ const configuration = {
     publicKey: process.env.SSH_GATEWAY_PUBLIC_KEY,
     url: process.env.SSH_GATEWAY_URL,
   },
-  organizationBoxDefaultLimitedNetworkEgress:
-    process.env.ORGANIZATION_BOX_DEFAULT_LIMITED_NETWORK_EGRESS === 'true',
+  organizationBoxDefaultLimitedNetworkEgress: process.env.ORGANIZATION_BOX_DEFAULT_LIMITED_NETWORK_EGRESS === 'true',
   pylonAppId: process.env.PYLON_APP_ID,
   billingApiUrl: process.env.BILLING_API_URL,
   analyticsApiUrl: process.env.ANALYTICS_API_URL,
@@ -246,9 +245,7 @@ const configuration = {
         : undefined,
     },
     boxCreate: {
-      ttl: process.env.RATE_LIMIT_BOX_CREATE_TTL
-        ? parseInt(process.env.RATE_LIMIT_BOX_CREATE_TTL, 10)
-        : undefined,
+      ttl: process.env.RATE_LIMIT_BOX_CREATE_TTL ? parseInt(process.env.RATE_LIMIT_BOX_CREATE_TTL, 10) : undefined,
       limit: process.env.RATE_LIMIT_BOX_CREATE_LIMIT
         ? parseInt(process.env.RATE_LIMIT_BOX_CREATE_LIMIT, 10)
         : undefined,

--- a/apps/api/src/object-storage/services/object-storage.service.spec.ts
+++ b/apps/api/src/object-storage/services/object-storage.service.spec.ts
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { BadRequestException } from '@nestjs/common'
+import { STSClient, AssumeRoleCommand } from '@aws-sdk/client-sts'
+import { ObjectStorageService } from './object-storage.service'
+
+const mockSend = jest.fn()
+
+jest.mock('@aws-sdk/client-sts', () => ({
+  STSClient: jest.fn().mockImplementation(() => ({ send: mockSend })),
+  AssumeRoleCommand: jest.fn().mockImplementation((input) => ({ input })),
+}))
+
+describe('ObjectStorageService', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  function buildService(values: Record<string, unknown>) {
+    const configService = {
+      get: jest.fn((key: string) => values[key]),
+      getOrThrow: jest.fn((key: string) => {
+        const value = values[key]
+        if (value === undefined) {
+          throw new Error(`Missing config: ${key}`)
+        }
+        return value
+      }),
+    }
+    return new ObjectStorageService(configService as any)
+  }
+
+  const awsConfig = {
+    's3.endpoint': 'https://s3.ap-southeast-1.amazonaws.com',
+    's3.stsEndpoint': 'https://sts.ap-southeast-1.amazonaws.com',
+    's3.defaultBucket': 'boxlite-dev-storage',
+    's3.region': 'ap-southeast-1',
+    's3.accountId': '123456789012',
+    's3.roleName': 'boxlite-dev-s3-access',
+  }
+
+  it('vends AWS credentials via the SDK default chain when no static keys are set', async () => {
+    mockSend.mockResolvedValue({
+      Credentials: {
+        AccessKeyId: 'ASIA-test',
+        SecretAccessKey: 'secret-test',
+        SessionToken: 'token-test',
+      },
+    })
+    const service = buildService(awsConfig)
+
+    const access = await service.getPushAccess('org-1')
+
+    // No `credentials` key at all → SDK default chain (ECS task role).
+    expect(STSClient).toHaveBeenCalledWith({
+      region: 'ap-southeast-1',
+      endpoint: 'https://sts.ap-southeast-1.amazonaws.com',
+      maxAttempts: 3,
+    })
+    expect(AssumeRoleCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        RoleArn: 'arn:aws:iam::123456789012:role/boxlite-dev-s3-access',
+        DurationSeconds: 3600,
+      }),
+    )
+    const sessionPolicy = JSON.parse((AssumeRoleCommand as unknown as jest.Mock).mock.calls[0][0].Policy)
+    expect(sessionPolicy.Statement[0]).toMatchObject({
+      Action: ['s3:PutObject', 's3:GetObject'],
+      Resource: ['arn:aws:s3:::boxlite-dev-storage/org-1/*'],
+    })
+    expect(access).toMatchObject({
+      accessKey: 'ASIA-test',
+      secret: 'secret-test',
+      sessionToken: 'token-test',
+      organizationId: 'org-1',
+      bucket: 'boxlite-dev-storage',
+    })
+  })
+
+  it('still signs with static keys when they are configured', async () => {
+    mockSend.mockResolvedValue({
+      Credentials: { AccessKeyId: 'a', SecretAccessKey: 'b', SessionToken: 'c' },
+    })
+    const service = buildService({
+      ...awsConfig,
+      's3.accessKey': 'static-id',
+      's3.secretKey': 'static-secret',
+    })
+
+    await service.getPushAccess('org-1')
+
+    expect(STSClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        credentials: { accessKeyId: 'static-id', secretAccessKey: 'static-secret' },
+      }),
+    )
+  })
+
+  it('rejects the MinIO path without static keys instead of sending an unsigned request', async () => {
+    const service = buildService({
+      ...awsConfig,
+      's3.endpoint': 'http://minio:9000',
+      's3.stsEndpoint': 'http://minio:9000/minio/v1/assume-role',
+    })
+
+    await expect(service.getPushAccess('org-1')).rejects.toThrow(BadRequestException)
+    await expect(service.getPushAccess('org-1')).rejects.toThrow(/S3_ACCESS_KEY and S3_SECRET_KEY/)
+    expect(AssumeRoleCommand).not.toHaveBeenCalled()
+  })
+})

--- a/apps/api/src/object-storage/services/object-storage.service.spec.ts
+++ b/apps/api/src/object-storage/services/object-storage.service.spec.ts
@@ -100,6 +100,13 @@ describe('ObjectStorageService', () => {
     )
   })
 
+  it('rejects a lone static key instead of silently using the default chain', async () => {
+    const service = buildService({ ...awsConfig, 's3.accessKey': 'static-id' })
+
+    await expect(service.getPushAccess('org-1')).rejects.toThrow(/S3_ACCESS_KEY and S3_SECRET_KEY must be set together/)
+    expect(STSClient).not.toHaveBeenCalled()
+  })
+
   it('rejects the MinIO path without static keys instead of sending an unsigned request', async () => {
     const service = buildService({
       ...awsConfig,

--- a/apps/api/src/object-storage/services/object-storage.service.ts
+++ b/apps/api/src/object-storage/services/object-storage.service.ts
@@ -41,11 +41,19 @@ export class ObjectStorageService {
 
     try {
       const bucket = this.configService.getOrThrow('s3.defaultBucket')
+      const accessKey = this.configService.get('s3.accessKey')
+      const secretKey = this.configService.get('s3.secretKey')
+      // Both-or-neither (mirrors observability-s3.reader.ts): a lone key is a
+      // typo'd pair, and silently falling back to the SDK default chain would
+      // mask the misconfig.
+      if ((accessKey && !secretKey) || (!accessKey && secretKey)) {
+        throw new BadRequestException('S3_ACCESS_KEY and S3_SECRET_KEY must be set together')
+      }
       const s3Config: S3Config = {
         endpoint: this.configService.getOrThrow('s3.endpoint'),
         stsEndpoint: this.configService.getOrThrow('s3.stsEndpoint'),
-        accessKey: this.configService.get('s3.accessKey'),
-        secretKey: this.configService.get('s3.secretKey'),
+        accessKey,
+        secretKey,
         bucket,
         region: this.configService.getOrThrow('s3.region'),
         accountId: this.configService.getOrThrow('s3.accountId'),

--- a/apps/api/src/object-storage/services/object-storage.service.ts
+++ b/apps/api/src/object-storage/services/object-storage.service.ts
@@ -15,8 +15,11 @@ import { STSClient, AssumeRoleCommand } from '@aws-sdk/client-sts'
 interface S3Config {
   endpoint: string
   stsEndpoint: string
-  accessKey: string
-  secretKey: string
+  // Static keys are only required for S3-compatible deployments (MinIO).
+  // On AWS they stay unset and the SDK default chain supplies the ECS
+  // task-role credentials.
+  accessKey?: string
+  secretKey?: string
   bucket: string
   region: string
   accountId?: string
@@ -41,8 +44,8 @@ export class ObjectStorageService {
       const s3Config: S3Config = {
         endpoint: this.configService.getOrThrow('s3.endpoint'),
         stsEndpoint: this.configService.getOrThrow('s3.stsEndpoint'),
-        accessKey: this.configService.getOrThrow('s3.accessKey'),
-        secretKey: this.configService.getOrThrow('s3.secretKey'),
+        accessKey: this.configService.get('s3.accessKey'),
+        secretKey: this.configService.get('s3.secretKey'),
         bucket,
         region: this.configService.getOrThrow('s3.region'),
         accountId: this.configService.getOrThrow('s3.accountId'),
@@ -80,6 +83,12 @@ export class ObjectStorageService {
   }
 
   private async getMinioCredentials(config: S3Config): Promise<StorageAccessDto> {
+    if (!config.accessKey || !config.secretKey) {
+      throw new BadRequestException(
+        'MinIO STS requires S3_ACCESS_KEY and S3_SECRET_KEY to sign the assume-role request',
+      )
+    }
+
     const body = new URLSearchParams({
       Action: 'AssumeRole',
       Version: '2011-06-15',
@@ -131,10 +140,9 @@ export class ObjectStorageService {
       const stsClient = new STSClient({
         region: config.region,
         endpoint: config.stsEndpoint,
-        credentials: {
-          accessKeyId: config.accessKey,
-          secretAccessKey: config.secretKey,
-        },
+        ...(config.accessKey && config.secretKey
+          ? { credentials: { accessKeyId: config.accessKey, secretAccessKey: config.secretKey } }
+          : {}),
         maxAttempts: 3,
       })
 

--- a/apps/api/src/organization/organization.module.ts
+++ b/apps/api/src/organization/organization.module.ts
@@ -70,11 +70,6 @@ import { EncryptionModule } from '../encryption/encryption.module'
       ) => new BoxRepository(dataSource, eventEmitter, boxLookupCacheInvalidationService),
     },
   ],
-  exports: [
-    OrganizationService,
-    OrganizationRoleService,
-    OrganizationUserService,
-    OrganizationInvitationService,
-  ],
+  exports: [OrganizationService, OrganizationRoleService, OrganizationUserService, OrganizationInvitationService],
 })
 export class OrganizationModule {}

--- a/apps/infra/sst.config.ts
+++ b/apps/infra/sst.config.ts
@@ -276,11 +276,27 @@ export default $config({
           lbArgs.idleTimeout = 3600
         },
       },
-      link: [db, redis, storage],
+      // storage is deliberately NOT linked: the link grant is s3:* on the
+      // bucket, far beyond the API's verified need (list-only — see the
+      // s3:ListBucket statement below). Box object reads/writes flow through
+      // vended S3AccessRole credentials, never the task role.
+      link: [db, redis],
       permissions: [
         {
+          // DescribeLogGroups ignores log-group-name granularity, but scoping
+          // the resource still cuts cross-region/cross-account reach. The
+          // observability reader defaults to this region
+          // (ADMIN_OBSERVABILITY_CLOUDWATCH_REGION).
           actions: ['logs:DescribeLogGroups'],
-          resources: ['*'],
+          resources: [
+            $interpolate`arn:aws:logs:${REGION}:${aws.getCallerIdentityOutput().accountId}:log-group:*`,
+          ],
+        },
+        {
+          // Admin observability S3 reader + VolumeManager boot probe are
+          // list-only on the storage bucket (ListObjectsV2).
+          actions: ['s3:ListBucket'],
+          resources: [storage.arn],
         },
         {
           actions: ['logs:FilterLogEvents'],
@@ -295,16 +311,21 @@ export default $config({
           resources: [s3AccessRoleArn],
         },
         {
-          // VolumeManager creates/tags/empties/deletes per-volume buckets
-          // directly with the task role (volume.manager.ts). Same scope the
-          // runner uses to mount them (RunnerVolumeS3Policy below).
-          actions: ['s3:*'],
+          // VolumeManager's exact bucket-lifecycle surface (volume.manager.ts
+          // create/tag, delete-s3-bucket.ts empty/delete). Deliberately NOT
+          // s3:* — that tail (PutBucketPolicy/PutBucketAcl/…) is what would
+          // let a compromised API expose volume buckets publicly. A new S3
+          // call in code needs a matching action added here.
+          actions: [
+            's3:CreateBucket',
+            's3:PutBucketTagging',
+            's3:ListBucket',
+            's3:ListBucketVersions',
+            's3:DeleteObject',
+            's3:DeleteObjectVersion',
+            's3:DeleteBucket',
+          ],
           resources: ['arn:aws:s3:::boxlite-volume-*', 'arn:aws:s3:::boxlite-volume-*/*'],
-        },
-        {
-          // VolumeManager.testConnection() lists buckets at startup.
-          actions: ['s3:ListAllMyBuckets'],
-          resources: ['*'],
         },
       ],
       scaling: { min: 1, max: 4 },
@@ -659,11 +680,19 @@ export default $config({
       role: runnerRole.name,
       policy: JSON.stringify({
         Version: '2012-10-17',
+        // Exactly Mountpoint for Amazon S3's documented permission set —
+        // mount-s3 is the runner's only S3 consumer (volumes.go). Bucket
+        // lifecycle (create/tag/delete) lives on the Api task role instead.
         Statement: [
           {
             Effect: 'Allow',
-            Action: ['s3:*'],
-            Resource: ['arn:aws:s3:::boxlite-volume-*', 'arn:aws:s3:::boxlite-volume-*/*'],
+            Action: ['s3:ListBucket'],
+            Resource: ['arn:aws:s3:::boxlite-volume-*'],
+          },
+          {
+            Effect: 'Allow',
+            Action: ['s3:GetObject', 's3:PutObject', 's3:DeleteObject', 's3:AbortMultipartUpload'],
+            Resource: ['arn:aws:s3:::boxlite-volume-*/*'],
           },
         ],
       }),

--- a/apps/infra/sst.config.ts
+++ b/apps/infra/sst.config.ts
@@ -159,19 +159,19 @@ export default $config({
     const cluster = new sst.aws.Cluster('Cluster', { vpc, forceUpgrade: 'v2' })
 
     // ─── 3. IAM ──────────────────────────────────────────────────────────────
-    // S3 IAM user: API signs STS tokens for box S3 uploads.
-    const s3User = new aws.iam.User('S3User', {})
-    new aws.iam.UserPolicy('S3UserPolicy', {
-      user: s3User.name,
-      policy: JSON.stringify({
-        Version: '2012-10-17',
-        Statement: [
-          { Effect: 'Allow', Action: ['s3:*'], Resource: ['*'] },
-          { Effect: 'Allow', Action: ['sts:AssumeRole', 'sts:GetCallerIdentity'], Resource: ['*'] },
-        ],
-      }),
-    })
-    const s3AccessKey = new aws.iam.AccessKey('S3AccessKey', { user: s3User.name })
+    // Box-storage credential vending. The Api's ECS task role assumes the
+    // S3AccessRole declared after the Api service with a per-organization
+    // inline session policy (apps/api object-storage.service.ts); effective
+    // access is the intersection of the two. No IAM user / static keys: ECS
+    // already delivers auto-rotated task-role credentials to the container.
+    //
+    // The role name is declared up front (deterministic, stage-scoped) so it
+    // can go into the Api env and IAM grant as a plain string. The role
+    // itself can only be created after the Api service, because its trust
+    // policy names the task role — which exists once the Api does. Declaring
+    // the name first breaks that resource cycle.
+    const s3AccessRoleName = `${$app.name}-${$app.stage}-s3-access`
+    const s3AccessRoleArn = $interpolate`arn:aws:iam::${aws.getCallerIdentityOutput().accountId}:role/${s3AccessRoleName}`
 
     // ─── 4. AUTH ─────────────────────────────────────────────────────────────
     // OIDC is delegated to an external provider (Auth0/Okta/etc.) via
@@ -289,6 +289,23 @@ export default $config({
             $interpolate`arn:aws:logs:${REGION}:${aws.getCallerIdentityOutput().accountId}:log-group:/sst/cluster/${cluster.nodes.cluster.name}/*:*`,
           ],
         },
+        {
+          // Vend per-org box storage credentials (object-storage.service.ts).
+          actions: ['sts:AssumeRole'],
+          resources: [s3AccessRoleArn],
+        },
+        {
+          // VolumeManager creates/tags/empties/deletes per-volume buckets
+          // directly with the task role (volume.manager.ts). Same scope the
+          // runner uses to mount them (RunnerVolumeS3Policy below).
+          actions: ['s3:*'],
+          resources: ['arn:aws:s3:::boxlite-volume-*', 'arn:aws:s3:::boxlite-volume-*/*'],
+        },
+        {
+          // VolumeManager.testConnection() lists buckets at startup.
+          actions: ['s3:ListAllMyBuckets'],
+          resources: ['*'],
+        },
       ],
       scaling: { min: 1, max: 4 },
       environment: {
@@ -365,15 +382,16 @@ export default $config({
           OIDC_POST_LOGOUT_REDIRECT_ALLOWLIST: process.env.OIDC_POST_LOGOUT_REDIRECT_ALLOWLIST,
         }),
 
-        // S3 (API signs STS creds for per-box buckets)
+        // S3 (API mints STS creds for per-box buckets). No S3_ACCESS_KEY /
+        // S3_SECRET_KEY: the API uses the SDK default chain (task role) and
+        // assumes S3_ROLE_NAME for box-scoped credentials. Static keys remain
+        // supported only for S3-compatible deployments (MinIO).
         S3_ENDPOINT: $interpolate`https://s3.${aws.getRegionOutput().name}.amazonaws.com`,
         S3_STS_ENDPOINT: $interpolate`https://sts.${aws.getRegionOutput().name}.amazonaws.com`,
         S3_REGION: REGION,
-        S3_ACCESS_KEY: s3AccessKey.id,
-        S3_SECRET_KEY: s3AccessKey.secret,
         S3_DEFAULT_BUCKET: storage.name,
         S3_ACCOUNT_ID: aws.getCallerIdentityOutput().accountId,
-        S3_ROLE_NAME: 'BoxliteS3Role',
+        S3_ROLE_NAME: s3AccessRoleName,
 
         // Proxy
         PROXY_DOMAIN: envOr('PROXY_DOMAIN', `proxy.${stackDomain}`),
@@ -474,6 +492,32 @@ export default $config({
           ...(process.env.SVIX_SERVER_URL && { SVIX_SERVER_URL: process.env.SVIX_SERVER_URL }),
         }),
       },
+    })
+
+    // Assumed by the Api task role to vend per-org box storage credentials
+    // (see section 3). The permission set mirrors the session policy's action
+    // set in object-storage.service.ts, so the intersection that boxes
+    // receive is exactly the per-org prefix scope.
+    const s3AccessRole = new aws.iam.Role('S3AccessRole', {
+      name: s3AccessRoleName,
+      assumeRolePolicy: api.nodes.taskRole.arn.apply((taskRoleArn) =>
+        JSON.stringify({
+          Version: '2012-10-17',
+          Statement: [{ Effect: 'Allow', Principal: { AWS: taskRoleArn }, Action: 'sts:AssumeRole' }],
+        }),
+      ),
+    })
+    new aws.iam.RolePolicy('S3AccessRolePolicy', {
+      role: s3AccessRole.name,
+      policy: storage.arn.apply((bucketArn) =>
+        JSON.stringify({
+          Version: '2012-10-17',
+          Statement: [
+            { Effect: 'Allow', Action: ['s3:GetObject', 's3:PutObject'], Resource: [`${bucketArn}/*`] },
+            { Effect: 'Allow', Action: ['s3:ListBucket'], Resource: [bucketArn] },
+          ],
+        }),
+      ),
     })
 
     // ─── 7. EDGE SERVICES ────────────────────────────────────────────────────

--- a/apps/runner/pkg/boxlite/daemon_env_test.go
+++ b/apps/runner/pkg/boxlite/daemon_env_test.go
@@ -24,7 +24,7 @@ func TestDaemonBoxEnvIncludesRequiredBoxIdentity(t *testing.T) {
 	})
 
 	want := map[string]string{
-		"BOXLITE_BOX_ID":      "box-1",
+		"BOXLITE_BOX_ID":          "box-1",
 		"BOXLITE_ORGANIZATION_ID": "org-1",
 		"BOXLITE_REGION_ID":       "region-1",
 		"BOXLITE_OTEL_ENDPOINT":   "http://otel.local:4318",

--- a/apps/runner/pkg/boxlite/toolbox_ports.go
+++ b/apps/runner/pkg/boxlite/toolbox_ports.go
@@ -23,7 +23,7 @@ const (
 )
 
 type toolboxPortRecord struct {
-	BoxID string `json:"boxId"`
+	BoxID     string `json:"boxId"`
 	GuestPort int    `json:"guestPort"`
 	HostPort  int    `json:"hostPort"`
 }
@@ -42,7 +42,7 @@ func (c *Client) reserveToolboxHostPort(ctx context.Context, boxID string) (int,
 	}
 
 	record := toolboxPortRecord{
-		BoxID: boxID,
+		BoxID:     boxID,
 		GuestPort: ToolboxGuestPort,
 		HostPort:  port,
 	}

--- a/apps/runner/pkg/boxlite/toolbox_ports_test.go
+++ b/apps/runner/pkg/boxlite/toolbox_ports_test.go
@@ -78,7 +78,7 @@ func TestWaitForToolboxReadyReturnsAfterVersionEndpointResponds(t *testing.T) {
 		toolboxReadyTimeout: time.Second,
 	}
 	if err := client.writeToolboxPortRecord(toolboxPortRecord{
-		BoxID: "box-1",
+		BoxID:     "box-1",
 		GuestPort: ToolboxGuestPort,
 		HostPort:  port,
 	}); err != nil {
@@ -101,7 +101,7 @@ func TestWaitForToolboxReadyTimesOutWhenEndpointDoesNotRespond(t *testing.T) {
 		toolboxReadyTimeout: 20 * time.Millisecond,
 	}
 	if err := client.writeToolboxPortRecord(toolboxPortRecord{
-		BoxID: "box-1",
+		BoxID:     "box-1",
 		GuestPort: ToolboxGuestPort,
 		HostPort:  port,
 	}); err != nil {

--- a/apps/runner/pkg/models/enums/box_state.go
+++ b/apps/runner/pkg/models/enums/box_state.go
@@ -7,17 +7,17 @@ package enums
 type BoxState string
 
 const (
-	BoxStateCreating        BoxState = "creating"
-	BoxStateRestoring       BoxState = "restoring"
-	BoxStateDestroyed       BoxState = "destroyed"
-	BoxStateDestroying      BoxState = "destroying"
-	BoxStateStarted         BoxState = "started"
-	BoxStateStopped         BoxState = "stopped"
-	BoxStateStarting        BoxState = "starting"
-	BoxStateStopping        BoxState = "stopping"
-	BoxStateResizing        BoxState = "resizing"
-	BoxStateError           BoxState = "error"
-	BoxStateUnknown         BoxState = "unknown"
+	BoxStateCreating   BoxState = "creating"
+	BoxStateRestoring  BoxState = "restoring"
+	BoxStateDestroyed  BoxState = "destroyed"
+	BoxStateDestroying BoxState = "destroying"
+	BoxStateStarted    BoxState = "started"
+	BoxStateStopped    BoxState = "stopped"
+	BoxStateStarting   BoxState = "starting"
+	BoxStateStopping   BoxState = "stopping"
+	BoxStateResizing   BoxState = "resizing"
+	BoxStateError      BoxState = "error"
+	BoxStateUnknown    BoxState = "unknown"
 )
 
 func (s BoxState) String() string {


### PR DESCRIPTION
## Problem

An IAM audit of `apps/infra` (live account cross-checked) found the box-storage credential path both over-privileged and broken:

- The Api signed STS calls with a **static IAM user** (`S3User`) holding `s3:*` on `*` **and** `sts:AssumeRole` on `*`, delivered as long-lived keys in ECS env vars — the exact anti-pattern AWS's IAM best practices call out ("require workloads to use temporary credentials with IAM roles").
- The role it assumes (`S3_ROLE_NAME=BoxliteS3Role`) **was never provisioned anywhere** — live calls fail with `NoSuchEntity`, so box storage push access has never worked on AWS. Inherited from upstream Daytona, whose public deployment path is MinIO-only (`S3_ROLE_NAME=/` placeholder).
- In the dev stage the S3User's only access key is deactivated, so the static-key path was doubly dead.

## Fix

Keep the architecture — it's AWS's own token-vending-machine pattern (AssumeRole + per-org inline session policy) — and swap the identities under it, then narrow every grant to its verified call surface:

```
before:  S3User (static keys, s3:* + sts:* on *) ──AssumeRole──▶ BoxliteS3Role ✗ (missing)
after:   Api ECS task role (auto-rotated)        ──AssumeRole──▶ S3AccessRole (created here)
            sts:AssumeRole scoped to that one ARN                  trust: exactly the Api task role
            7 enumerated s3 actions on boxlite-volume-*            perms: Get/Put/List on storage bucket
            s3:ListBucket on the storage bucket                    ∩ session policy = per-org prefix
            logs scoped to this region/account
```

**infra (`sst.config.ts`)**
- Drop `S3User`/`S3UserPolicy`/`S3AccessKey`. Add stage-scoped `S3AccessRole` (`boxlite-<stage>-s3-access`; deterministic name declared before the Api so the env var needs no resource dependency; the role is created after the Api because its trust policy references `api.nodes.taskRole.arn`).
- Api task role: `sts:AssumeRole` on that single ARN; **enumerated** volume-bucket actions (`CreateBucket`, `PutBucketTagging`, `ListBucket`, `ListBucketVersions`, `DeleteObject`, `DeleteObjectVersion`, `DeleteBucket` — deliberately not `s3:*`, whose tail is `PutBucketPolicy`/`PutBucketAcl`); `storage` is **de-linked** (link grants `s3:*`) and replaced with the verified need, `s3:ListBucket`; `logs:DescribeLogGroups` scoped from `*` to this region/account.
- Runner `RunnerVolumeS3Policy`: `s3:*` → exactly Mountpoint for Amazon S3's documented set (`ListBucket` + `GetObject`/`PutObject`/`DeleteObject`/`AbortMultipartUpload`).

**api**
- `ObjectStorageService` and `VolumeManager` fall back to the SDK default credential chain (ECS task role) when `S3_ACCESS_KEY`/`S3_SECRET_KEY` are unset; static-key behavior unchanged when both are set (MinIO/local).
- Guards (from review): **both-or-neither** static keys — a lone key now errors instead of silently switching credential source (mirrors `observability-s3.reader.ts:42`); MinIO without keys **fails closed** in both services; `VolumeManager.testConnection` probes the known default bucket (`ListObjectsV2`, `MaxKeys: 1`) instead of `ListBuckets`, removing the account-wide `s3:ListAllMyBuckets` need.

Role chaining caps chained sessions at 1h; the vend already requests exactly 3600s, so no functional change.

## Verification

- `object-storage.service.spec.ts` (4) + `volume.manager.spec.ts` (5): default-chain construction, RoleArn + per-org session policy, static-key passthrough, lone-key rejection, MinIO fail-closed (both services), scoped probe shape, probe skip. **Two-side verified**: with all production changes reverted to HEAD the new-behavior tests fail (5/9, e.g. `Missing config: s3.accessKey`, `ListBucketsCommand is not a constructor`); restored, 9/9 pass.
- Full api suite: green except 2 `default-organization-membership` failures that reproduce identically on `main` (pre-existing, untouched).
- `tsc --noEmit` clean; `nx lint api` clean.
- Not run: `sst diff` (no stage credentials in this environment). The one SST surface this leans on (`Service.nodes.taskRole`) was verified against `sst/sst` `platform/src/components/aws/service.ts`.

## Deploy notes

- First deploy per stage: the new task definition may briefly roll out before `S3AccessRole` exists; vending errors in that window are no worse than today (the target role has never existed). Steady state is correct once the deploy completes.
- The runner policy change is an in-place `RolePolicy` update — it does not touch the protected Runner EC2 (`ignoreChanges` only covers `ami`/`userDataBase64`).
- Pulumi will delete each stage's `S3User` + key on deploy (dev's key is already inactive).
- Out of scope, recommended ops follow-ups from the audit: delete orphaned `RunnerRole-e887e17`/`RunnerProfile-b86f07b` (carries `AmazonS3FullAccess`, unused — verified the live runner uses `RunnerRole-1115ba6`), remove the duplicate `RunnerVolumeS3Policy` inline copy, move deploys off root credentials to the existing `AWSReservedSSO_*` permission sets.
- Known residual (follow-up issue): the `boxlite-volume-*` bucket prefix is account-global, not stage-scoped — stages can reach each other's volume buckets. Fixing it requires a bucket-naming/migration decision (persist `bucketName` on the volume row), tracked separately.
