### PR TITLE
fix(c): expose port options with host guest order

### DIFF
--- a/sdks/c/include/boxlite.h
+++ b/sdks/c/include/boxlite.h
@@ -64,6 +64,12 @@ typedef enum BoxliteErrorCode {
   SessionReaped = 21,
 } BoxliteErrorCode;
 
+typedef enum BoxlitePortProtocol {
+  BoxlitePortProtocolUnknown = 0,
+  BoxlitePortProtocolTcp = 1,
+  BoxlitePortProtocolUdp = 2,
+} BoxlitePortProtocol;
+
 typedef enum BoxliteRegistryTransport {
   BoxliteRegistryTransportHttps = 0,
   BoxliteRegistryTransportHttp = 1,
@@ -279,6 +285,13 @@ typedef struct CRuntimeMetrics {
 
 // Runtime metrics completion.
 typedef void (*CRuntimeMetricsCb)(struct CRuntimeMetrics*, CBoxliteError*, void*);
+
+typedef struct BoxlitePortSpec {
+  int host_port;
+  int guest_port;
+  enum BoxlitePortProtocol protocol;
+  const char *host_ip;
+} BoxlitePortSpec;
 
 typedef struct CredentialHandle CBoxliteCredential;
 
@@ -500,7 +513,11 @@ void boxlite_options_add_volume(CBoxliteOptions *opts,
                                 const char *guest_path,
                                 int read_only);
 
-void boxlite_options_add_port(CBoxliteOptions *opts, int guest_port, int host_port);
+void boxlite_options_add_port(CBoxliteOptions *opts, int host_port, int guest_port);
+
+enum BoxliteErrorCode boxlite_options_add_port_spec(CBoxliteOptions *opts,
+                                                    const struct BoxlitePortSpec *spec,
+                                                    CBoxliteError *out_error);
 
 void boxlite_options_set_network_enabled(CBoxliteOptions *opts);
 

--- a/sdks/c/src/options.rs
+++ b/sdks/c/src/options.rs
@@ -1,5 +1,6 @@
 use std::os::raw::{c_char, c_int};
 
+use boxlite::BoxliteError;
 use boxlite::runtime::options::{
     BoxOptions, NetworkSpec, PortProtocol, PortSpec, RootfsSpec, Secret, VolumeSpec,
 };
@@ -11,6 +12,23 @@ use crate::{CBoxliteError, CBoxliteOptions};
 pub struct OptionsHandle {
     pub options: BoxOptions,
     pub name: Option<String>,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BoxlitePortProtocol {
+    BoxlitePortProtocolUnknown = 0,
+    BoxlitePortProtocolTcp = 1,
+    BoxlitePortProtocolUdp = 2,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct BoxlitePortSpec {
+    pub host_port: c_int,
+    pub guest_port: c_int,
+    pub protocol: BoxlitePortProtocol,
+    pub host_ip: *const c_char,
 }
 
 #[unsafe(no_mangle)]
@@ -83,10 +101,19 @@ pub unsafe extern "C" fn boxlite_options_add_volume(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn boxlite_options_add_port(
     opts: *mut CBoxliteOptions,
-    guest_port: c_int,
     host_port: c_int,
+    guest_port: c_int,
 ) {
-    options_add_port(opts, guest_port, host_port)
+    options_add_port(opts, host_port, guest_port)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_options_add_port_spec(
+    opts: *mut CBoxliteOptions,
+    spec: *const BoxlitePortSpec,
+    out_error: *mut CBoxliteError,
+) -> BoxliteErrorCode {
+    options_add_port_spec(opts, spec, out_error)
 }
 
 #[unsafe(no_mangle)]
@@ -272,22 +299,93 @@ pub unsafe fn options_add_volume(
     }
 }
 
-pub unsafe fn options_add_port(handle: *mut OptionsHandle, guest_port: c_int, host_port: c_int) {
+pub unsafe fn options_add_port(handle: *mut OptionsHandle, host_port: c_int, guest_port: c_int) {
     unsafe {
         if handle.is_null() {
             return;
         }
-        (*handle).options.ports.push(PortSpec {
-            guest_port: guest_port as u16,
-            host_port: if host_port > 0 {
-                Some(host_port as u16)
-            } else {
-                None
-            },
-            protocol: PortProtocol::Tcp,
-            host_ip: None,
-        });
+        let spec = BoxlitePortSpec {
+            host_port,
+            guest_port,
+            protocol: BoxlitePortProtocol::BoxlitePortProtocolTcp,
+            host_ip: std::ptr::null(),
+        };
+        if let Ok(port) = parse_port_spec(&spec) {
+            (*handle).options.ports.push(port);
+        }
     }
+}
+
+pub unsafe fn options_add_port_spec(
+    handle: *mut OptionsHandle,
+    spec: *const BoxlitePortSpec,
+    out_error: *mut FFIError,
+) -> BoxliteErrorCode {
+    unsafe {
+        if handle.is_null() {
+            write_error(out_error, null_pointer_error("opts"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        if spec.is_null() {
+            write_error(out_error, null_pointer_error("spec"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+
+        match parse_port_spec(&*spec) {
+            Ok(port) => {
+                (*handle).options.ports.push(port);
+                BoxliteErrorCode::Ok
+            }
+            Err(err) => {
+                write_error(out_error, err);
+                BoxliteErrorCode::InvalidArgument
+            }
+        }
+    }
+}
+
+fn parse_port_spec(spec: &BoxlitePortSpec) -> Result<PortSpec, BoxliteError> {
+    if spec.guest_port < 1 || spec.guest_port > 65535 {
+        return Err(BoxliteError::InvalidArgument(format!(
+            "guest_port must be in range 1-65535, got {}",
+            spec.guest_port
+        )));
+    }
+    if spec.host_port < 0 || spec.host_port > 65535 {
+        return Err(BoxliteError::InvalidArgument(format!(
+            "host_port must be in range 0-65535, got {}",
+            spec.host_port
+        )));
+    }
+
+    let protocol = match spec.protocol {
+        BoxlitePortProtocol::BoxlitePortProtocolTcp => PortProtocol::Tcp,
+        BoxlitePortProtocol::BoxlitePortProtocolUdp => PortProtocol::Udp,
+        BoxlitePortProtocol::BoxlitePortProtocolUnknown => {
+            return Err(BoxliteError::InvalidArgument(
+                "port protocol must be TCP or UDP".to_string(),
+            ));
+        }
+    };
+
+    let host_ip = if spec.host_ip.is_null() {
+        None
+    } else {
+        let value = unsafe { c_str_to_string(spec.host_ip) }
+            .map_err(|e| BoxliteError::InvalidArgument(format!("invalid host_ip: {e}")))?;
+        if value.is_empty() { None } else { Some(value) }
+    };
+
+    Ok(PortSpec {
+        host_port: if spec.host_port > 0 {
+            Some(spec.host_port as u16)
+        } else {
+            None
+        },
+        guest_port: spec.guest_port as u16,
+        protocol,
+        host_ip,
+    })
 }
 
 pub unsafe fn options_set_network_enabled(handle: *mut OptionsHandle) {

--- a/sdks/c/src/tests.rs
+++ b/sdks/c/src/tests.rs
@@ -2,6 +2,7 @@ use crate::error::error_to_c_error;
 use crate::*;
 use boxlite::BoxliteError;
 use boxlite::runtime::BoxliteRuntime;
+use boxlite::runtime::options::PortProtocol;
 use std::ffi::{CStr, CString};
 use std::os::raw::c_void;
 use std::path::PathBuf;
@@ -239,6 +240,114 @@ fn test_runtime_images_unsupported_on_rest_runtime() {
 
     unsafe {
         boxlite_error_free(&mut error as *mut _);
+    }
+}
+
+#[test]
+fn test_options_add_port_uses_host_guest_order() {
+    let image = CString::new("alpine:latest").expect("image cstring");
+    let mut opts: *mut CBoxliteOptions = ptr::null_mut();
+    let mut error = FFIError::default();
+
+    let code =
+        unsafe { boxlite_options_new(image.as_ptr(), &mut opts as *mut _, &mut error as *mut _) };
+    assert_eq!(code, BoxliteErrorCode::Ok);
+    assert!(!opts.is_null());
+
+    unsafe {
+        boxlite_options_add_port(opts, 8080, 3000);
+        let ports = &(*opts).options.ports;
+        assert_eq!(ports.len(), 1);
+        let port = &ports[0];
+        assert_eq!(port.host_port, Some(8080));
+        assert_eq!(port.guest_port, 3000);
+        assert!(matches!(port.protocol, PortProtocol::Tcp));
+        assert_eq!(port.host_ip, None);
+        boxlite_options_free(opts);
+    }
+}
+
+#[test]
+fn test_options_add_port_spec_exposes_protocol_and_host_ip() {
+    let image = CString::new("alpine:latest").expect("image cstring");
+    let host_ip = CString::new("127.0.0.1").expect("host ip cstring");
+    let mut opts: *mut CBoxliteOptions = ptr::null_mut();
+    let mut error = FFIError::default();
+
+    let code =
+        unsafe { boxlite_options_new(image.as_ptr(), &mut opts as *mut _, &mut error as *mut _) };
+    assert_eq!(code, BoxliteErrorCode::Ok);
+    assert!(!opts.is_null());
+
+    let spec = BoxlitePortSpec {
+        host_port: 5353,
+        guest_port: 53,
+        protocol: BoxlitePortProtocol::BoxlitePortProtocolUdp,
+        host_ip: host_ip.as_ptr(),
+    };
+
+    let code = unsafe {
+        boxlite_options_add_port_spec(opts, &spec as *const _, &mut error as *mut _)
+    };
+    assert_eq!(code, BoxliteErrorCode::Ok);
+
+    unsafe {
+        let ports = &(*opts).options.ports;
+        assert_eq!(ports.len(), 1);
+        let port = &ports[0];
+        assert_eq!(port.host_port, Some(5353));
+        assert_eq!(port.guest_port, 53);
+        assert!(matches!(port.protocol, PortProtocol::Udp));
+        assert_eq!(port.host_ip.as_deref(), Some("127.0.0.1"));
+        boxlite_options_free(opts);
+    }
+}
+
+#[test]
+fn test_options_add_port_spec_rejects_invalid_values() {
+    let image = CString::new("alpine:latest").expect("image cstring");
+    let mut opts: *mut CBoxliteOptions = ptr::null_mut();
+    let mut error = FFIError::default();
+
+    let code =
+        unsafe { boxlite_options_new(image.as_ptr(), &mut opts as *mut _, &mut error as *mut _) };
+    assert_eq!(code, BoxliteErrorCode::Ok);
+    assert!(!opts.is_null());
+
+    let cases = [
+        BoxlitePortSpec {
+            host_port: 8080,
+            guest_port: 0,
+            protocol: BoxlitePortProtocol::BoxlitePortProtocolTcp,
+            host_ip: ptr::null(),
+        },
+        BoxlitePortSpec {
+            host_port: 65536,
+            guest_port: 80,
+            protocol: BoxlitePortProtocol::BoxlitePortProtocolTcp,
+            host_ip: ptr::null(),
+        },
+        BoxlitePortSpec {
+            host_port: 8080,
+            guest_port: 80,
+            protocol: BoxlitePortProtocol::BoxlitePortProtocolUnknown,
+            host_ip: ptr::null(),
+        },
+    ];
+
+    for spec in cases {
+        let code = unsafe {
+            boxlite_options_add_port_spec(opts, &spec as *const _, &mut error as *mut _)
+        };
+        assert_eq!(code, BoxliteErrorCode::InvalidArgument);
+        assert!(!error.message.is_null());
+        unsafe { boxlite_error_free(&mut error as *mut _) };
+    }
+
+    unsafe {
+        let ports = &(*opts).options.ports;
+        assert!(ports.is_empty());
+        boxlite_options_free(opts);
     }
 }
 


### PR DESCRIPTION
## Summary
- expose C port configuration through BoxlitePortProtocol and BoxlitePortSpec
- add boxlite_options_add_port_spec for host IP, protocol, host port, and guest port
- fix the C convenience port API order to host_port, guest_port

## Verification
- make fmt
- make test:unit:ffi
- two-sided check: with production changes reverted and tests kept, make test:unit:ffi fails with missing BoxlitePortSpec/BoxlitePortProtocol/boxlite_options_add_port_spec; after restoring production changes, make test:unit:ffi passes

Note: make test:unit:c builds the C SDK but cannot complete on this machine because cmake is not installed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * C API now supports TCP and UDP protocol specification for port mapping configurations.
  * Added new port configuration helper function enabling detailed setup with protocol type and optional host IP binding.

* **Breaking Changes**
  * Port mapping function parameter order has changed.

* **Tests**
  * Added test coverage for port configuration functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->