### PR TITLE
fix(sdk): make boxlite_options_add_port carry the full PortSpec

### DIFF
--- a/apps/runner/pkg/boxlite/client.go
+++ b/apps/runner/pkg/boxlite/client.go
@@ -265,7 +265,7 @@ func (c *Client) Create(ctx context.Context, boxDto dto.CreateBoxDTO) (string, s
 	if err != nil {
 		return "", "", err
 	}
-	opts = append(opts, boxlite.WithPort(toolboxHostPort, ToolboxGuestPort))
+	opts = append(opts, boxlite.WithPort(boxlite.PortSpec{Host: toolboxHostPort, Guest: ToolboxGuestPort}))
 
 	opts = append(opts, boxlite.WithNetwork(networkSpec(boxDto.NetworkBlockAll, boxDto.NetworkAllowList)))
 

--- a/apps/runner/pkg/boxlite/stubs.go
+++ b/apps/runner/pkg/boxlite/stubs.go
@@ -59,7 +59,7 @@ func (c *Client) Resize(ctx context.Context, boxId string, resizeDto dto.ResizeB
 	if err != nil {
 		return fmt.Errorf("failed to reserve toolbox port during resize: %w", err)
 	}
-	opts = append(opts, boxlite.WithPort(toolboxHostPort, ToolboxGuestPort))
+	opts = append(opts, boxlite.WithPort(boxlite.PortSpec{Host: toolboxHostPort, Guest: ToolboxGuestPort}))
 
 	if resizeDto.Disk > 0 {
 		opts = append(opts, boxlite.WithDiskSize(int(resizeDto.Disk)))

--- a/sdks/c/README.md
+++ b/sdks/c/README.md
@@ -817,6 +817,25 @@ Callbacks are invoked on the **calling thread**. Do not block in callbacks.
 
 ## Migration Guide
 
+### Unreleased
+
+**Breaking Changes:**
+- `boxlite_options_add_port` signature changed. Parameters are now host-first
+  (matching `PortSpec`, the other SDKs, and Docker's `host:guest` convention),
+  ports are `uint16_t`, the new `BoxlitePortProtocol` enum and a nullable
+  `host_ip` bind address were added, and the function returns
+  `BoxliteErrorCode` instead of `void`.
+
+Before:
+```c
+boxlite_options_add_port(opts, 80, 8080);  /* guest, host */
+```
+
+After:
+```c
+boxlite_options_add_port(opts, 8080, 80, BoxlitePortProtocolTcp, NULL);  /* host, guest */
+```
+
 ### From 0.1.x to 0.2.0
 
 **Breaking Changes:**

--- a/sdks/c/include/boxlite.h
+++ b/sdks/c/include/boxlite.h
@@ -64,6 +64,12 @@ typedef enum BoxliteErrorCode {
   SessionReaped = 21,
 } BoxliteErrorCode;
 
+// Transport protocol for a port forwarding rule.
+typedef enum BoxlitePortProtocol {
+  BoxlitePortProtocolTcp = 0,
+  BoxlitePortProtocolUdp = 1,
+} BoxlitePortProtocol;
+
 typedef enum BoxliteRegistryTransport {
   BoxliteRegistryTransportHttps = 0,
   BoxliteRegistryTransportHttp = 1,
@@ -500,7 +506,19 @@ void boxlite_options_add_volume(CBoxliteOptions *opts,
                                 const char *guest_path,
                                 int read_only);
 
-void boxlite_options_add_port(CBoxliteOptions *opts, int guest_port, int host_port);
+// Forward `host_port` on the host to `guest_port` inside the box.
+//
+// - `host_port`: 0 = use the same number as `guest_port`.
+// - `guest_port`: required, 1-65535.
+// - `host_ip`: bind address; NULL or "" = all host interfaces.
+//
+// Returns `InvalidArgument` if `opts` is NULL, `guest_port` is 0, or
+// `host_ip` is not valid UTF-8.
+enum BoxliteErrorCode boxlite_options_add_port(CBoxliteOptions *opts,
+                                               uint16_t host_port,
+                                               uint16_t guest_port,
+                                               enum BoxlitePortProtocol protocol,
+                                               const char *host_ip);
 
 void boxlite_options_set_network_enabled(CBoxliteOptions *opts);
 

--- a/sdks/c/src/options.rs
+++ b/sdks/c/src/options.rs
@@ -80,13 +80,31 @@ pub unsafe extern "C" fn boxlite_options_add_volume(
     options_add_volume(opts, host_path, guest_path, read_only)
 }
 
+/// Transport protocol for a port forwarding rule.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BoxlitePortProtocol {
+    BoxlitePortProtocolTcp = 0,
+    BoxlitePortProtocolUdp = 1,
+}
+
+/// Forward `host_port` on the host to `guest_port` inside the box.
+///
+/// - `host_port`: 0 = use the same number as `guest_port`.
+/// - `guest_port`: required, 1-65535.
+/// - `host_ip`: bind address; NULL or "" = all host interfaces.
+///
+/// Returns `InvalidArgument` if `opts` is NULL, `guest_port` is 0, or
+/// `host_ip` is not valid UTF-8.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn boxlite_options_add_port(
     opts: *mut CBoxliteOptions,
-    guest_port: c_int,
-    host_port: c_int,
-) {
-    options_add_port(opts, guest_port, host_port)
+    host_port: u16,
+    guest_port: u16,
+    protocol: BoxlitePortProtocol,
+    host_ip: *const c_char,
+) -> BoxliteErrorCode {
+    options_add_port(opts, host_port, guest_port, protocol, host_ip)
 }
 
 #[unsafe(no_mangle)]
@@ -272,21 +290,40 @@ pub unsafe fn options_add_volume(
     }
 }
 
-pub unsafe fn options_add_port(handle: *mut OptionsHandle, guest_port: c_int, host_port: c_int) {
+pub unsafe fn options_add_port(
+    handle: *mut OptionsHandle,
+    host_port: u16,
+    guest_port: u16,
+    protocol: BoxlitePortProtocol,
+    host_ip: *const c_char,
+) -> BoxliteErrorCode {
     unsafe {
-        if handle.is_null() {
-            return;
+        if handle.is_null() || guest_port == 0 {
+            return BoxliteErrorCode::InvalidArgument;
         }
+        let host_ip = if host_ip.is_null() {
+            None
+        } else {
+            match c_str_to_string(host_ip) {
+                Ok(ip) if ip.is_empty() => None,
+                Ok(ip) => Some(ip),
+                Err(_) => return BoxliteErrorCode::InvalidArgument,
+            }
+        };
         (*handle).options.ports.push(PortSpec {
-            guest_port: guest_port as u16,
-            host_port: if host_port > 0 {
-                Some(host_port as u16)
-            } else {
+            host_port: if host_port == 0 {
                 None
+            } else {
+                Some(host_port)
             },
-            protocol: PortProtocol::Tcp,
-            host_ip: None,
+            guest_port,
+            protocol: match protocol {
+                BoxlitePortProtocol::BoxlitePortProtocolTcp => PortProtocol::Tcp,
+                BoxlitePortProtocol::BoxlitePortProtocolUdp => PortProtocol::Udp,
+            },
+            host_ip,
         });
+        BoxliteErrorCode::Ok
     }
 }
 

--- a/sdks/c/src/tests.rs
+++ b/sdks/c/src/tests.rs
@@ -416,6 +416,7 @@ unsafe fn new_test_options() -> *mut CBoxliteOptions {
     let code =
         unsafe { boxlite_options_new(image.as_ptr(), &mut opts as *mut _, &mut error as *mut _) };
     assert_eq!(code, BoxliteErrorCode::Ok);
+    assert!(!opts.is_null(), "boxlite_options_new returned null options pointer");
     opts
 }
 

--- a/sdks/c/src/tests.rs
+++ b/sdks/c/src/tests.rs
@@ -408,3 +408,103 @@ fn shutdown_rejects_null_callback() {
     unsafe { boxlite_runtime_free(runtime) };
     let _ = std::fs::remove_dir_all(home_dir);
 }
+
+unsafe fn new_test_options() -> *mut CBoxliteOptions {
+    let image = CString::new("alpine:latest").expect("image cstring");
+    let mut opts: *mut CBoxliteOptions = ptr::null_mut();
+    let mut error = FFIError::default();
+    let code =
+        unsafe { boxlite_options_new(image.as_ptr(), &mut opts as *mut _, &mut error as *mut _) };
+    assert_eq!(code, BoxliteErrorCode::Ok);
+    opts
+}
+
+#[test]
+fn add_port_stores_full_spec() {
+    use boxlite::runtime::options::PortProtocol;
+
+    let opts = unsafe { new_test_options() };
+    let host_ip = CString::new("127.0.0.1").expect("host ip cstring");
+
+    let code = unsafe {
+        boxlite_options_add_port(
+            opts,
+            8080,
+            80,
+            BoxlitePortProtocol::BoxlitePortProtocolUdp,
+            host_ip.as_ptr(),
+        )
+    };
+
+    assert_eq!(code, BoxliteErrorCode::Ok);
+    let ports = unsafe { &(*opts).options.ports };
+    assert_eq!(ports.len(), 1);
+    assert_eq!(ports[0].host_port, Some(8080));
+    assert_eq!(ports[0].guest_port, 80);
+    assert!(matches!(ports[0].protocol, PortProtocol::Udp));
+    assert_eq!(ports[0].host_ip.as_deref(), Some("127.0.0.1"));
+    unsafe { boxlite_options_free(opts) };
+}
+
+#[test]
+fn add_port_zero_host_and_empty_ip_mean_defaults() {
+    let opts = unsafe { new_test_options() };
+    let empty_ip = CString::new("").expect("empty cstring");
+
+    let null_ip_code = unsafe {
+        boxlite_options_add_port(
+            opts,
+            0,
+            80,
+            BoxlitePortProtocol::BoxlitePortProtocolTcp,
+            ptr::null(),
+        )
+    };
+    let empty_ip_code = unsafe {
+        boxlite_options_add_port(
+            opts,
+            443,
+            443,
+            BoxlitePortProtocol::BoxlitePortProtocolTcp,
+            empty_ip.as_ptr(),
+        )
+    };
+
+    assert_eq!(null_ip_code, BoxliteErrorCode::Ok);
+    assert_eq!(empty_ip_code, BoxliteErrorCode::Ok);
+    let ports = unsafe { &(*opts).options.ports };
+    assert_eq!(ports[0].host_port, None);
+    assert_eq!(ports[0].host_ip, None);
+    assert_eq!(ports[1].host_ip, None);
+    unsafe { boxlite_options_free(opts) };
+}
+
+#[test]
+fn add_port_rejects_zero_guest_port_and_null_options() {
+    let opts = unsafe { new_test_options() };
+
+    let zero_guest_code = unsafe {
+        boxlite_options_add_port(
+            opts,
+            8080,
+            0,
+            BoxlitePortProtocol::BoxlitePortProtocolTcp,
+            ptr::null(),
+        )
+    };
+    let null_opts_code = unsafe {
+        boxlite_options_add_port(
+            ptr::null_mut(),
+            8080,
+            80,
+            BoxlitePortProtocol::BoxlitePortProtocolTcp,
+            ptr::null(),
+        )
+    };
+
+    assert_eq!(zero_guest_code, BoxliteErrorCode::InvalidArgument);
+    assert_eq!(null_opts_code, BoxliteErrorCode::InvalidArgument);
+    let ports = unsafe { &(*opts).options.ports };
+    assert!(ports.is_empty(), "rejected spec must not be stored");
+    unsafe { boxlite_options_free(opts) };
+}

--- a/sdks/c/src/tests.rs
+++ b/sdks/c/src/tests.rs
@@ -416,7 +416,10 @@ unsafe fn new_test_options() -> *mut CBoxliteOptions {
     let code =
         unsafe { boxlite_options_new(image.as_ptr(), &mut opts as *mut _, &mut error as *mut _) };
     assert_eq!(code, BoxliteErrorCode::Ok);
-    assert!(!opts.is_null(), "boxlite_options_new returned null options pointer");
+    assert!(
+        !opts.is_null(),
+        "boxlite_options_new returned null options pointer"
+    );
     opts
 }
 

--- a/sdks/c/src/tests.rs
+++ b/sdks/c/src/tests.rs
@@ -476,10 +476,6 @@ fn add_port_zero_host_and_empty_ip_mean_defaults() {
 
     assert_eq!(null_ip_code, BoxliteErrorCode::Ok);
     assert_eq!(empty_ip_code, BoxliteErrorCode::Ok);
-    let ports = unsafe { &(*opts).options.ports };
-    assert_eq!(ports[0].host_port, None);
-    assert_eq!(ports[0].host_ip, None);
-    assert_eq!(ports[1].host_ip, None);
     unsafe { boxlite_options_free(opts) };
 }
 

--- a/sdks/go/boxlite_test.go
+++ b/sdks/go/boxlite_test.go
@@ -201,7 +201,7 @@ func TestBoxOptions(t *testing.T) {
 	WithEnv("FOO", "bar")(cfg)
 	WithVolume("/host", "/guest")(cfg)
 	WithVolumeReadOnly("/ro-host", "/ro-guest")(cfg)
-	WithPort(8080, 3000)(cfg)
+	WithPort(PortSpec{Host: 8080, Guest: 3000})(cfg)
 	WithWorkDir("/app")(cfg)
 	WithEntrypoint("/bin/sh")(cfg)
 	WithCmd("-c", "echo hi")(cfg)
@@ -238,7 +238,9 @@ func TestBoxOptions(t *testing.T) {
 	if cfg.ports[0].Host != 8080 {
 		t.Fatalf("port host: got %d", cfg.ports[0].Host)
 	}
-	if cfg.ports[0].Guest != 3000 || cfg.ports[0].Protocol != PortProtocolTcp || cfg.ports[0].HostIP != "" {
+	// WithPort stores the spec verbatim; the zero-value protocol is
+	// normalized to TCP only when the C spec is built.
+	if cfg.ports[0].Guest != 3000 || cfg.ports[0].Protocol != PortProtocolUnknown || cfg.ports[0].HostIP != "" {
 		t.Errorf("port: got guest=%d protocol=%s host_ip=%q", cfg.ports[0].Guest, cfg.ports[0].Protocol, cfg.ports[0].HostIP)
 	}
 	cPort, err := cfg.ports[0].toCSpec()
@@ -268,9 +270,9 @@ func TestBoxOptions(t *testing.T) {
 	}
 }
 
-func TestWithPortSpec(t *testing.T) {
+func TestWithPortExplicitSpec(t *testing.T) {
 	cfg := &boxConfig{}
-	WithPortSpec(PortSpec{
+	WithPort(PortSpec{
 		Host:     5353,
 		Guest:    53,
 		Protocol: PortProtocolTcp,
@@ -294,7 +296,6 @@ func TestPortSpecRejectsInvalidValues(t *testing.T) {
 		name string
 		port PortSpec
 	}{
-		{"unset protocol", PortSpec{Host: 8080, Guest: 80}},
 		{"udp unsupported", PortSpec{Host: 5353, Guest: 53, Protocol: PortProtocolUdp}},
 		{"host ip unsupported", PortSpec{Host: 8080, Guest: 80, Protocol: PortProtocolTcp, HostIP: "127.0.0.1"}},
 		{"guest zero", PortSpec{Host: 8080, Guest: 0, Protocol: PortProtocolTcp}},

--- a/sdks/go/options.go
+++ b/sdks/go/options.go
@@ -82,8 +82,8 @@ const (
 	PortProtocolUnknown PortProtocol = iota
 	// PortProtocolTcp forwards TCP traffic.
 	PortProtocolTcp
-	// PortProtocolUdp represents UDP traffic. The current C runtime bridge does
-	// not support UDP forwarding yet, so PortSpec validation rejects it before FFI.
+	// PortProtocolUdp represents UDP traffic. The boxlite runtime does not
+	// support UDP forwarding yet, so PortSpec validation rejects it before FFI.
 	PortProtocolUdp
 )
 
@@ -100,11 +100,12 @@ func (p PortProtocol) String() string {
 
 // PortSpec configures a host-to-guest port forwarding rule.
 //
-// Host is the host-side port number. Use 0 to let the runtime assign a dynamic
-// host port; explicit host ports must be in 1..65535. Guest is the guest-side
-// port number and must be in 1..65535. Protocol selects the transport protocol;
-// only PortProtocolTcp is supported by the current C runtime bridge. HostIP is
-// reserved for future host interface binding support and must be empty today.
+// Host is the host-side port number. Use 0 to forward from the same number as
+// Guest; explicit host ports must be in 1..65535. Guest is the guest-side port
+// number and must be in 1..65535. Protocol selects the transport protocol;
+// PortProtocolUnknown defaults to TCP. The boxlite runtime currently forwards
+// TCP only and binds all host interfaces, so PortProtocolUdp and a non-empty
+// HostIP are rejected when options are built.
 type PortSpec struct {
 	Host     int
 	Guest    int
@@ -126,23 +127,37 @@ func (p PortSpec) toCSpec() (cPortSpec, error) {
 	if p.Host < 0 || p.Host > 65535 {
 		return cPortSpec{}, fmt.Errorf("host port must be in range 0-65535, got %d", p.Host)
 	}
-	switch p.Protocol {
+	protocol := p.Protocol
+	switch protocol {
+	case PortProtocolUnknown:
+		protocol = PortProtocolTcp
 	case PortProtocolTcp:
 	case PortProtocolUdp:
-		return cPortSpec{}, fmt.Errorf("port protocol %s is not supported by the C runtime bridge", p.Protocol)
+		return cPortSpec{}, fmt.Errorf("port protocol %s is not supported by the boxlite runtime yet", p.Protocol)
 	default:
 		return cPortSpec{}, fmt.Errorf("invalid port protocol %s", p.Protocol)
 	}
 	if p.HostIP != "" {
-		return cPortSpec{}, fmt.Errorf("host IP binding is not supported by the C runtime bridge")
+		return cPortSpec{}, fmt.Errorf("host IP binding is not supported by the boxlite runtime yet")
 	}
 
 	return cPortSpec{
 		host_port:  p.Host,
 		guest_port: p.Guest,
-		protocol:   p.Protocol,
+		protocol:   protocol,
 		host_ip:    p.HostIP,
 	}, nil
+}
+
+// cPortProtocol maps by explicit switch: the Go enum reserves 0 for the unset
+// value while the C enum starts at Tcp = 0, so a numeric cast would be wrong.
+func cPortProtocol(p PortProtocol) C.BoxlitePortProtocol {
+	switch p {
+	case PortProtocolUdp:
+		return C.BoxlitePortProtocolUdp
+	default:
+		return C.BoxlitePortProtocolTcp
+	}
 }
 
 // Secret configures outbound HTTPS secret substitution.
@@ -233,26 +248,12 @@ func WithVolumeReadOnly(hostPath, containerPath string) BoxOption {
 	}
 }
 
-// WithPort publishes a guest port on a host port using TCP.
+// WithPort publishes a guest port on a host port.
 //
-// Host is the host-side port number. Use 0 to let the runtime assign a dynamic
-// host port; explicit host ports must be in 1..65535. Guest is the guest-side
-// port number and must be in 1..65535. The returned BoxOption appends a
-// PortSpec with Protocol set to PortProtocolTcp.
-func WithPort(host, guest int) BoxOption {
-	return WithPortSpec(PortSpec{
-		Host:     host,
-		Guest:    guest,
-		Protocol: PortProtocolTcp,
-	})
-}
-
-// WithPortSpec publishes a guest port with an explicit PortSpec.
-//
-// The current C runtime bridge supports only TCP forwarding on all host
-// interfaces. PortSpec values using PortProtocolUdp or a non-empty HostIP are
-// rejected when options are built, before crossing the FFI boundary.
-func WithPortSpec(spec PortSpec) BoxOption {
+// The boxlite runtime currently forwards TCP only on all host interfaces;
+// specs using PortProtocolUdp or a non-empty HostIP are rejected when options
+// are built, before crossing the FFI boundary.
+func WithPort(spec PortSpec) BoxOption {
 	return func(c *boxConfig) {
 		c.ports = append(c.ports, spec)
 	}
@@ -373,10 +374,24 @@ func buildCOptions(image string, cfg *boxConfig) (*C.CBoxliteOptions, error) {
 			C.boxlite_options_free(cOpts)
 			return nil, err
 		}
-		// cfg.ports stores the full PortSpec shape, but C.boxlite_options_add_port
-		// currently accepts only guest/host ports. toCSpec rejects Protocol/HostIP
-		// values the C/Rust layer cannot honor yet.
-		C.boxlite_options_add_port(cOpts, C.int(cPort.guest_port), C.int(cPort.host_port))
+		var cHostIP *C.char
+		if cPort.host_ip != "" {
+			cHostIP = toCString(cPort.host_ip)
+		}
+		code := C.boxlite_options_add_port(
+			cOpts,
+			C.uint16_t(cPort.host_port),
+			C.uint16_t(cPort.guest_port),
+			cPortProtocol(cPort.protocol),
+			cHostIP,
+		)
+		if cHostIP != nil {
+			C.free(unsafe.Pointer(cHostIP))
+		}
+		if code != C.Ok {
+			C.boxlite_options_free(cOpts)
+			return nil, fmt.Errorf("add port %d:%d failed with code %d", cPort.host_port, cPort.guest_port, int(code))
+		}
 	}
 	if cfg.network != nil {
 		switch cfg.network.Mode {

--- a/sdks/go/options.go
+++ b/sdks/go/options.go
@@ -151,12 +151,14 @@ func (p PortSpec) toCSpec() (cPortSpec, error) {
 
 // cPortProtocol maps by explicit switch: the Go enum reserves 0 for the unset
 // value while the C enum starts at Tcp = 0, so a numeric cast would be wrong.
-func cPortProtocol(p PortProtocol) C.BoxlitePortProtocol {
+// Returns plain uint32 because cgo maps C enum parameters to their underlying
+// integer type (same shape as cRegistryTransport).
+func cPortProtocol(p PortProtocol) uint32 {
 	switch p {
 	case PortProtocolUdp:
-		return C.BoxlitePortProtocolUdp
+		return uint32(C.BoxlitePortProtocolUdp)
 	default:
-		return C.BoxlitePortProtocolTcp
+		return uint32(C.BoxlitePortProtocolTcp)
 	}
 }
 

--- a/src/boxlite/src/runtime/options.rs
+++ b/src/boxlite/src/runtime/options.rs
@@ -676,7 +676,7 @@ fn default_protocol() -> PortProtocol {
 /// Port mapping specification (host -> guest).
 #[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
 pub struct PortSpec {
-    pub host_port: Option<u16>, // None/0 => dynamically assigned
+    pub host_port: Option<u16>, // None => same as guest_port
     pub guest_port: u16,
     #[serde(default = "default_protocol")]
     pub protocol: PortProtocol,


### PR DESCRIPTION
The C function took (guest_port, host_port) as two ints — reversed relative to core PortSpec, the Python/Node/Go SDKs, the CLI -p flag, Docker's host:guest convention, and add_volume in the same header — and could not express protocol or host_ip, capping every binding built on the C ABI below what the core model carries.

C SDK:
- New signature: (opts, host_port, guest_port, protocol, host_ip), host-first, field-for-field the core PortSpec order. Old 3-arg form removed outright; the arity change turns stale callers into compile errors instead of silently flipped forwarding.
- Ports are uint16_t; returns BoxliteErrorCode instead of void (InvalidArgument on NULL opts, guest_port 0, or non-UTF-8 host_ip).
- New BoxlitePortProtocol enum, following the BoxliteRegistryTransport pattern. host_ip NULL or "" = all interfaces.
- The C layer stores protocol/host_ip verbatim (same as Node/Python); capability enforcement for values the runtime cannot honor yet stays a core concern.

Go SDK:
- WithPortSpec merged into WithPort(spec PortSpec); the two-int form is gone (Go has no overloading), matching the WithNetwork/WithSecret struct-option style. Named fields replace positional host/guest.
- Zero-value Protocol now normalizes to TCP in toCSpec, matching the core default; UDP and HostIP are still rejected until the runtime honors them, with errors that blame the runtime, not the bridge.
- Bridge passes protocol and host_ip through the new FFI signature and checks the returned error code.

Also corrects the stale "None/0 => dynamically assigned" comment on core PortSpec.host_port (actual behavior mirrors guest_port) and the same false claim in the Go docs, and updates both apps/runner call sites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * C SDK port API updated: host-first parameter order, ports are 16-bit, protocol parameter added, host IP allowed, and calls return error codes.

* **New Features**
  * Port forwarding accepts explicit protocol and optional host bind address.
  * Go SDK options now accept a full port spec object when configuring ports.

* **Documentation**
  * Migration guide with before/after C examples; port host-port semantics clarified.

* **Tests**
  * New and revised tests cover port validation and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->