### PR TITLE
refactor(api): drop the legacy boxId DTO field and regenerate API clients

### DIFF
--- a/apps/api-client-go/api/openapi.yaml
+++ b/apps/api-client-go/api/openapi.yaml
@@ -9937,7 +9937,6 @@ components:
     Box:
       example:
         id: fd955d93-e74a-48e7-9f2d-fcbe6dd9e920
-        boxId: aB3cD4eF5gH6
         organizationId: organization123
         name: MyBox
         user: boxlite
@@ -9977,10 +9976,6 @@ components:
         id:
           description: The internal UUID of the box
           example: fd955d93-e74a-48e7-9f2d-fcbe6dd9e920
-          type: string
-        boxId:
-          description: The public Box ID shown to users and SDK clients
-          example: aB3cD4eF5gH6
           type: string
         organizationId:
           description: The organization ID of the box
@@ -10107,7 +10102,6 @@ components:
           example: https://proxy.app.boxlite.io/toolbox
           type: string
       required:
-      - boxId
       - cpu
       - disk
       - env
@@ -10128,7 +10122,6 @@ components:
       example:
         items:
         - id: fd955d93-e74a-48e7-9f2d-fcbe6dd9e920
-          boxId: aB3cD4eF5gH6
           organizationId: organization123
           name: MyBox
           user: boxlite
@@ -10165,7 +10158,6 @@ components:
           runnerId: runner123
           toolboxProxyUrl: https://proxy.app.boxlite.io/toolbox
         - id: fd955d93-e74a-48e7-9f2d-fcbe6dd9e920
-          boxId: aB3cD4eF5gH6
           organizationId: organization123
           name: MyBox
           user: boxlite
@@ -12494,7 +12486,6 @@ components:
     Workspace:
       example:
         id: fd955d93-e74a-48e7-9f2d-fcbe6dd9e920
-        boxId: aB3cD4eF5gH6
         organizationId: organization123
         name: MyBox
         user: boxlite
@@ -12535,10 +12526,6 @@ components:
         id:
           description: The internal UUID of the box
           example: fd955d93-e74a-48e7-9f2d-fcbe6dd9e920
-          type: string
-        boxId:
-          description: The public Box ID shown to users and SDK clients
-          example: aB3cD4eF5gH6
           type: string
         organizationId:
           description: The organization ID of the box
@@ -12669,7 +12656,6 @@ components:
           - $ref: "#/components/schemas/BoxInfo"
           description: Additional information about the box
       required:
-      - boxId
       - cpu
       - disk
       - env
@@ -13463,8 +13449,7 @@ components:
     AdminBoxItem:
       example:
         id: box_abc123
-        boxId: abc123XYZ
-        organizationId: org_xyz
+        organizationId: abc123XYZ
         state: started
         runnerId: runner-uuid
         cpu: 2
@@ -13481,13 +13466,9 @@ components:
           description: Box ID
           example: box_abc123
           type: string
-        boxId:
+        organizationId:
           description: Public box ID shown to users
           example: abc123XYZ
-          type: string
-        organizationId:
-          description: Organization ID
-          example: org_xyz
           type: string
         state:
           allOf:
@@ -13515,7 +13496,6 @@ components:
       - cpu
       - createdAt
       - id
-      - organizationId
       - owner
       - state
       type: object
@@ -14807,8 +14787,7 @@ components:
               value: 0.8008281904610115
         boxes:
         - id: box_abc123
-          boxId: abc123XYZ
-          organizationId: org_xyz
+          organizationId: abc123XYZ
           state: started
           runnerId: runner-uuid
           cpu: 2
@@ -14821,8 +14800,7 @@ components:
             orgName: Alice Personal
             personal: true
         - id: box_abc123
-          boxId: abc123XYZ
-          organizationId: org_xyz
+          organizationId: abc123XYZ
           state: started
           runnerId: runner-uuid
           cpu: 2

--- a/apps/api-client-go/model_admin_box_item.go
+++ b/apps/api-client-go/model_admin_box_item.go
@@ -24,9 +24,7 @@ type AdminBoxItem struct {
 	// Box ID
 	Id string `json:"id"`
 	// Public box ID shown to users
-	BoxId *string `json:"boxId,omitempty"`
-	// Organization ID
-	OrganizationId string `json:"organizationId"`
+	OrganizationId *string `json:"organizationId,omitempty"`
 	State BoxState `json:"state"`
 	// Runner ID the box is assigned to
 	RunnerId *string `json:"runnerId,omitempty"`
@@ -46,10 +44,9 @@ type _AdminBoxItem AdminBoxItem
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewAdminBoxItem(id string, organizationId string, state BoxState, cpu float32, createdAt string, owner AdminBoxOwner) *AdminBoxItem {
+func NewAdminBoxItem(id string, state BoxState, cpu float32, createdAt string, owner AdminBoxOwner) *AdminBoxItem {
 	this := AdminBoxItem{}
 	this.Id = id
-	this.OrganizationId = organizationId
 	this.State = state
 	this.Cpu = cpu
 	this.CreatedAt = createdAt
@@ -89,60 +86,36 @@ func (o *AdminBoxItem) SetId(v string) {
 	o.Id = v
 }
 
-// GetBoxId returns the BoxId field value if set, zero value otherwise.
-func (o *AdminBoxItem) GetBoxId() string {
-	if o == nil || IsNil(o.BoxId) {
+// GetOrganizationId returns the OrganizationId field value if set, zero value otherwise.
+func (o *AdminBoxItem) GetOrganizationId() string {
+	if o == nil || IsNil(o.OrganizationId) {
 		var ret string
 		return ret
 	}
-	return *o.BoxId
+	return *o.OrganizationId
 }
 
-// GetBoxIdOk returns a tuple with the BoxId field value if set, nil otherwise
+// GetOrganizationIdOk returns a tuple with the OrganizationId field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *AdminBoxItem) GetBoxIdOk() (*string, bool) {
-	if o == nil || IsNil(o.BoxId) {
+func (o *AdminBoxItem) GetOrganizationIdOk() (*string, bool) {
+	if o == nil || IsNil(o.OrganizationId) {
 		return nil, false
 	}
-	return o.BoxId, true
+	return o.OrganizationId, true
 }
 
-// HasBoxId returns a boolean if a field has been set.
-func (o *AdminBoxItem) HasBoxId() bool {
-	if o != nil && !IsNil(o.BoxId) {
+// HasOrganizationId returns a boolean if a field has been set.
+func (o *AdminBoxItem) HasOrganizationId() bool {
+	if o != nil && !IsNil(o.OrganizationId) {
 		return true
 	}
 
 	return false
 }
 
-// SetBoxId gets a reference to the given string and assigns it to the BoxId field.
-func (o *AdminBoxItem) SetBoxId(v string) {
-	o.BoxId = &v
-}
-
-// GetOrganizationId returns the OrganizationId field value
-func (o *AdminBoxItem) GetOrganizationId() string {
-	if o == nil {
-		var ret string
-		return ret
-	}
-
-	return o.OrganizationId
-}
-
-// GetOrganizationIdOk returns a tuple with the OrganizationId field value
-// and a boolean to check if the value has been set.
-func (o *AdminBoxItem) GetOrganizationIdOk() (*string, bool) {
-	if o == nil {
-		return nil, false
-	}
-	return &o.OrganizationId, true
-}
-
-// SetOrganizationId sets field value
+// SetOrganizationId gets a reference to the given string and assigns it to the OrganizationId field.
 func (o *AdminBoxItem) SetOrganizationId(v string) {
-	o.OrganizationId = v
+	o.OrganizationId = &v
 }
 
 // GetState returns the State field value
@@ -316,10 +289,9 @@ func (o AdminBoxItem) MarshalJSON() ([]byte, error) {
 func (o AdminBoxItem) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["id"] = o.Id
-	if !IsNil(o.BoxId) {
-		toSerialize["boxId"] = o.BoxId
+	if !IsNil(o.OrganizationId) {
+		toSerialize["organizationId"] = o.OrganizationId
 	}
-	toSerialize["organizationId"] = o.OrganizationId
 	toSerialize["state"] = o.State
 	if !IsNil(o.RunnerId) {
 		toSerialize["runnerId"] = o.RunnerId
@@ -344,7 +316,6 @@ func (o *AdminBoxItem) UnmarshalJSON(data []byte) (err error) {
 	// that every required field exists as a key in the generic map.
 	requiredProperties := []string{
 		"id",
-		"organizationId",
 		"state",
 		"cpu",
 		"createdAt",
@@ -379,7 +350,6 @@ func (o *AdminBoxItem) UnmarshalJSON(data []byte) (err error) {
 
 	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "id")
-		delete(additionalProperties, "boxId")
 		delete(additionalProperties, "organizationId")
 		delete(additionalProperties, "state")
 		delete(additionalProperties, "runnerId")

--- a/apps/api-client-go/model_box.go
+++ b/apps/api-client-go/model_box.go
@@ -23,8 +23,6 @@ var _ MappedNullable = &Box{}
 type Box struct {
 	// The internal UUID of the box
 	Id string `json:"id"`
-	// The public Box ID shown to users and SDK clients
-	BoxId string `json:"boxId"`
 	// The organization ID of the box
 	OrganizationId string `json:"organizationId"`
 	// The name of the box
@@ -89,10 +87,9 @@ type _Box Box
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewBox(id string, boxId string, organizationId string, name string, user string, env map[string]string, image string, labels map[string]string, public bool, networkBlockAll bool, target string, cpu float32, gpu float32, memory float32, disk float32, toolboxProxyUrl string) *Box {
+func NewBox(id string, organizationId string, name string, user string, env map[string]string, image string, labels map[string]string, public bool, networkBlockAll bool, target string, cpu float32, gpu float32, memory float32, disk float32, toolboxProxyUrl string) *Box {
 	this := Box{}
 	this.Id = id
-	this.BoxId = boxId
 	this.OrganizationId = organizationId
 	this.Name = name
 	this.User = user
@@ -140,30 +137,6 @@ func (o *Box) GetIdOk() (*string, bool) {
 // SetId sets field value
 func (o *Box) SetId(v string) {
 	o.Id = v
-}
-
-// GetBoxId returns the BoxId field value
-func (o *Box) GetBoxId() string {
-	if o == nil {
-		var ret string
-		return ret
-	}
-
-	return o.BoxId
-}
-
-// GetBoxIdOk returns a tuple with the BoxId field value
-// and a boolean to check if the value has been set.
-func (o *Box) GetBoxIdOk() (*string, bool) {
-	if o == nil {
-		return nil, false
-	}
-	return &o.BoxId, true
-}
-
-// SetBoxId sets field value
-func (o *Box) SetBoxId(v string) {
-	o.BoxId = v
 }
 
 // GetOrganizationId returns the OrganizationId field value
@@ -932,7 +905,6 @@ func (o Box) MarshalJSON() ([]byte, error) {
 func (o Box) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["id"] = o.Id
-	toSerialize["boxId"] = o.BoxId
 	toSerialize["organizationId"] = o.OrganizationId
 	toSerialize["name"] = o.Name
 	toSerialize["user"] = o.User
@@ -1000,7 +972,6 @@ func (o *Box) UnmarshalJSON(data []byte) (err error) {
 	// that every required field exists as a key in the generic map.
 	requiredProperties := []string{
 		"id",
-		"boxId",
 		"organizationId",
 		"name",
 		"user",
@@ -1045,7 +1016,6 @@ func (o *Box) UnmarshalJSON(data []byte) (err error) {
 
 	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "id")
-		delete(additionalProperties, "boxId")
 		delete(additionalProperties, "organizationId")
 		delete(additionalProperties, "name")
 		delete(additionalProperties, "user")

--- a/apps/api-client-go/model_workspace.go
+++ b/apps/api-client-go/model_workspace.go
@@ -23,8 +23,6 @@ var _ MappedNullable = &Workspace{}
 type Workspace struct {
 	// The internal UUID of the box
 	Id string `json:"id"`
-	// The public Box ID shown to users and SDK clients
-	BoxId string `json:"boxId"`
 	// The organization ID of the box
 	OrganizationId string `json:"organizationId"`
 	// The name of the box
@@ -91,10 +89,9 @@ type _Workspace Workspace
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewWorkspace(id string, boxId string, organizationId string, name string, user string, env map[string]string, image string, labels map[string]string, public bool, networkBlockAll bool, target string, cpu float32, gpu float32, memory float32, disk float32, toolboxProxyUrl string) *Workspace {
+func NewWorkspace(id string, organizationId string, name string, user string, env map[string]string, image string, labels map[string]string, public bool, networkBlockAll bool, target string, cpu float32, gpu float32, memory float32, disk float32, toolboxProxyUrl string) *Workspace {
 	this := Workspace{}
 	this.Id = id
-	this.BoxId = boxId
 	this.OrganizationId = organizationId
 	this.Name = name
 	this.User = user
@@ -142,30 +139,6 @@ func (o *Workspace) GetIdOk() (*string, bool) {
 // SetId sets field value
 func (o *Workspace) SetId(v string) {
 	o.Id = v
-}
-
-// GetBoxId returns the BoxId field value
-func (o *Workspace) GetBoxId() string {
-	if o == nil {
-		var ret string
-		return ret
-	}
-
-	return o.BoxId
-}
-
-// GetBoxIdOk returns a tuple with the BoxId field value
-// and a boolean to check if the value has been set.
-func (o *Workspace) GetBoxIdOk() (*string, bool) {
-	if o == nil {
-		return nil, false
-	}
-	return &o.BoxId, true
-}
-
-// SetBoxId sets field value
-func (o *Workspace) SetBoxId(v string) {
-	o.BoxId = v
 }
 
 // GetOrganizationId returns the OrganizationId field value
@@ -966,7 +939,6 @@ func (o Workspace) MarshalJSON() ([]byte, error) {
 func (o Workspace) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["id"] = o.Id
-	toSerialize["boxId"] = o.BoxId
 	toSerialize["organizationId"] = o.OrganizationId
 	toSerialize["name"] = o.Name
 	toSerialize["user"] = o.User
@@ -1037,7 +1009,6 @@ func (o *Workspace) UnmarshalJSON(data []byte) (err error) {
 	// that every required field exists as a key in the generic map.
 	requiredProperties := []string{
 		"id",
-		"boxId",
 		"organizationId",
 		"name",
 		"user",
@@ -1082,7 +1053,6 @@ func (o *Workspace) UnmarshalJSON(data []byte) (err error) {
 
 	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "id")
-		delete(additionalProperties, "boxId")
 		delete(additionalProperties, "organizationId")
 		delete(additionalProperties, "name")
 		delete(additionalProperties, "user")

--- a/apps/api/src/admin/dto/admin-overview.dto.ts
+++ b/apps/api/src/admin/dto/admin-overview.dto.ts
@@ -110,8 +110,6 @@ export class AdminBoxItemDto {
   id: string
 
   @ApiPropertyOptional({ description: 'Public box ID shown to users', example: 'abc123XYZ' })
-  boxId?: string
-
   @ApiProperty({ description: 'Organization ID', example: 'org_xyz' })
   organizationId: string
 

--- a/apps/api/src/admin/services/observability.service.spec.ts
+++ b/apps/api/src/admin/services/observability.service.spec.ts
@@ -398,7 +398,6 @@ describe('AdminObservabilityService', () => {
     overviewService.listBoxes.mockResolvedValue([
       {
         id: 'box-1',
-        boxId: 'box-1',
         organizationId: 'org-1',
         state: 'started',
         runnerId: 'runner-1',
@@ -408,7 +407,6 @@ describe('AdminObservabilityService', () => {
       },
       {
         id: 'box-2',
-        boxId: 'box-2',
         organizationId: 'org-1',
         state: 'started',
         runnerId: 'runner-2',
@@ -435,7 +433,6 @@ describe('AdminObservabilityService', () => {
       serviceNames: ['box-box-1'],
     })
     expect(result.boxes.map((box) => box.id)).toEqual(['box-1'])
-    expect(result.boxes.map((box) => box.boxId)).toEqual(['box-1'])
     expect(result.runners.map((runner) => runner.id)).toEqual(['runner-1'])
     expect(result.machines.map((machine) => machine.host)).toEqual(['runner-1'])
     expect(cloudWatchLogReader.getRelatedLogs).toHaveBeenCalledWith(
@@ -479,7 +476,6 @@ describe('AdminObservabilityService', () => {
     overviewService.listBoxes.mockResolvedValue([
       {
         id: 'box-1',
-        boxId: 'box-1',
         organizationId: 'org-1',
         state: 'started',
         runnerId: 'runner-1',
@@ -593,7 +589,6 @@ describe('AdminObservabilityService', () => {
     overviewService.listBoxes.mockResolvedValue([
       {
         id: 'box-1',
-        boxId: 'box-1',
         organizationId: 'org-1',
         state: 'started',
         runnerId: 'runner-1',
@@ -809,7 +804,6 @@ describe('AdminObservabilityService', () => {
     overviewService.listBoxes.mockResolvedValue([
       {
         id: 'box-1',
-        boxId: 'box-1',
         organizationId: 'org-1',
         state: 'stopped',
         runnerId: 'runner-1',
@@ -876,7 +870,6 @@ describe('AdminObservabilityService', () => {
     overviewService.listBoxes.mockResolvedValue([
       {
         id: 'box-1',
-        boxId: 'box-1',
         organizationId: 'org-1',
         state: 'started',
         runnerId: 'runner-1',

--- a/apps/api/src/admin/services/observability.service.ts
+++ b/apps/api/src/admin/services/observability.service.ts
@@ -1519,7 +1519,6 @@ export class AdminObservabilityService {
       for (const box of boxes) {
         this.addUnique(correlation.orgIds, box.organizationId)
         this.addUnique(correlation.boxIds, box.id)
-        this.addUnique(correlation.boxIds, box.boxId)
         this.addUnique(correlation.runnerIds, box.runnerId)
       }
 
@@ -1676,7 +1675,7 @@ export class AdminObservabilityService {
   }
 
   private matchesBox(box: AdminBoxItemDto, correlation: AdminObservabilityCorrelationDto): boolean {
-    if (correlation.boxIds.includes(box.id) || (box.boxId && correlation.boxIds.includes(box.boxId))) {
+    if (correlation.boxIds.includes(box.id)) {
       return true
     }
 

--- a/apps/api/src/admin/services/overview.service.ts
+++ b/apps/api/src/admin/services/overview.service.ts
@@ -116,7 +116,6 @@ export class AdminOverviewService {
 
     return boxes.map((s) => ({
       id: s.id,
-      boxId: s.id,
       organizationId: s.organizationId,
       state: s.state,
       runnerId: s.runnerId,

--- a/apps/api/src/box/dto/box.dto.spec.ts
+++ b/apps/api/src/box/dto/box.dto.spec.ts
@@ -8,7 +8,7 @@ import { Box } from '../entities/box.entity'
 import { BoxDto } from './box.dto'
 
 describe('BoxDto identity', () => {
-  it('exposes the single box id under both id and the legacy boxId field', () => {
+  it('exposes the single box id', () => {
     const box = new Box('us', 'data-loader')
     box.organizationId = '057963b2-60ca-4356-81fc-11503e15f249'
     box.osUser = 'boxlite'
@@ -16,6 +16,6 @@ describe('BoxDto identity', () => {
     const dto = BoxDto.fromBox(box, 'https://proxy.boxlite.dev/toolbox')
 
     expect(dto.id).toBe(box.id)
-    expect(dto.boxId).toBe(box.id)
+    expect('boxId' in dto).toBe(false)
   })
 })

--- a/apps/api/src/box/dto/box.dto.ts
+++ b/apps/api/src/box/dto/box.dto.ts
@@ -42,12 +42,6 @@ export class BoxDto {
   id: string
 
   @ApiProperty({
-    description: 'The public Box ID shown to users and SDK clients',
-    example: 'aB3cD4eF5gH6',
-  })
-  boxId: string
-
-  @ApiProperty({
     description: 'The organization ID of the box',
     example: 'organization123',
   })
@@ -251,7 +245,6 @@ export class BoxDto {
   static fromBox(box: Box, toolboxProxyUrl: string): BoxDto {
     return {
       id: box.id,
-      boxId: box.id,
       organizationId: box.organizationId,
       name: box.name,
       target: box.region,

--- a/apps/api/src/boxlite-rest/mappers/box-to-box.mapper.spec.ts
+++ b/apps/api/src/boxlite-rest/mappers/box-to-box.mapper.spec.ts
@@ -11,7 +11,6 @@ describe('box-to-box mapper', () => {
   it('maps REST box_id from the single box id', () => {
     const response = boxToBoxResponse({
       id: 'aB3cD4eF5gH6',
-      boxId: 'aB3cD4eF5gH6',
       organizationId: '057963b2-60ca-4356-81fc-11503e15f249',
       name: 'data-loader',
       state: 'started',
@@ -59,7 +58,6 @@ describe('box-to-box mapper', () => {
 
   it('echoes the image ref stored on the box', () => {
     const response = boxToBoxResponse({
-      boxId: 'aB3cD4eF5gH6',
       state: 'started',
       image:
         'ghcr.io/boxlite-ai/boxlite-agent-node@sha256:fcb8b840ab68567975853666c82fb6c59a3c1d14a0cdc31d7cbf3a01e6c6d247',

--- a/apps/dashboard/src/components/BoxTable/BoxTableActions.tsx
+++ b/apps/dashboard/src/components/BoxTable/BoxTableActions.tsx
@@ -165,7 +165,6 @@ export function BoxTableActions({
     deletePermitted,
     box.state,
     box.id,
-    box.boxId,
     isLoading,
     box.recoverable,
     onStart,

--- a/apps/dashboard/src/components/admin/AdminPeopleBoxesView.tsx
+++ b/apps/dashboard/src/components/admin/AdminPeopleBoxesView.tsx
@@ -197,7 +197,7 @@ const AdminPeopleBoxesView: React.FC<AdminPeopleBoxesViewProps> = ({
                               variant="ghost"
                               size="sm"
                               className="h-7 px-2 text-xs"
-                              aria-label={`Diagnose box ${box.boxId ?? box.id}`}
+                              aria-label={`Diagnose box ${box.id}`}
                               onClick={(event) => {
                                 event.stopPropagation()
                                 onOpenBox(box)

--- a/apps/dashboard/src/components/admin/adminDiagnoseTarget.ts
+++ b/apps/dashboard/src/components/admin/adminDiagnoseTarget.ts
@@ -39,7 +39,7 @@ export function createBoxDiagnoseTarget(box: AdminBox): AdminDiagnoseTarget {
   return {
     kind: 'box',
     title: 'Diagnose box',
-    subtitle: box.boxId ? `${box.boxId} · ${box.id}` : box.id,
+    subtitle: box.id,
     state: box.state,
     box,
     params: {

--- a/apps/dashboard/src/components/admin/adminHelpers.ts
+++ b/apps/dashboard/src/components/admin/adminHelpers.ts
@@ -199,9 +199,7 @@ export function filterOwnerGroups(groups: OwnerGroup[], query: string): OwnerGro
       result.push(group)
       continue
     }
-    const matchingBoxes = group.boxes.filter(
-      (b) => b.id.toLowerCase().includes(q) || b.boxId?.toLowerCase().includes(q),
-    )
+    const matchingBoxes = group.boxes.filter((b) => b.id.toLowerCase().includes(q))
     if (matchingBoxes.length > 0) {
       result.push({ ...group, boxes: matchingBoxes, breakdown: getBoxBreakdown(matchingBoxes) })
     }
@@ -224,7 +222,7 @@ export function selectErroringOwners(groups: OwnerGroup[]): ErroringOwner[] {
 export function findBoxById(groups: OwnerGroup[], boxId: string): { box: AdminBox; group: OwnerGroup } | undefined {
   const targetBoxId = boxId.trim().toLowerCase()
   for (const group of groups) {
-    const box = group.boxes.find((b) => b.id.toLowerCase() === targetBoxId || b.boxId?.toLowerCase() === targetBoxId)
+    const box = group.boxes.find((b) => b.id.toLowerCase() === targetBoxId)
     if (box) return { box, group }
   }
   return undefined

--- a/apps/dashboard/src/hooks/useBoxWsSync.ts
+++ b/apps/dashboard/src/hooks/useBoxWsSync.ts
@@ -44,16 +44,13 @@ export function useBoxWsSync({ boxId, refetchOnCreate = false }: UseBoxWsSyncOpt
       })
     }
 
-    const matchesActiveBox = (box: Box) => !boxId || box.id === boxId || box.boxId === boxId
+    const matchesActiveBox = (box: Box) => !boxId || box.id === boxId
 
     const optimisticUpdate = (box: Box, state: BoxState) => {
       updateStateInListCache(box.id, state)
       if (boxId) {
         updateStateInDetailCache(boxId, state)
         updateStateInDetailCache(box.id, state)
-        if (box.boxId) {
-          updateStateInDetailCache(box.boxId, state)
-        }
       }
     }
 

--- a/apps/dashboard/src/lib/box-identity.ts
+++ b/apps/dashboard/src/lib/box-identity.ts
@@ -6,25 +6,26 @@
 
 import { Box, BoxDesiredState } from '@boxlite-ai/api-client'
 
-type BoxIdentity = Pick<Box, 'id' | 'name'> & Partial<Pick<Box, 'boxId' | 'desiredState'>>
+type BoxIdentity = Pick<Box, 'id' | 'name'> & Partial<Pick<Box, 'desiredState'>>
 
 export const MISSING_BOX_ID_LABEL = 'Not available'
 
-export function getBoxPublicId(box: Partial<Pick<Box, 'boxId'>> | undefined): string {
-  return box?.boxId || ''
+export function getBoxPublicId(box: Partial<Pick<Box, 'id'>> | undefined): string {
+  return box?.id || ''
 }
 
-export function getBoxPublicIdLabel(box: Partial<Pick<Box, 'boxId'>> | undefined): string {
+export function getBoxPublicIdLabel(box: Partial<Pick<Box, 'id'>> | undefined): string {
   return getBoxPublicId(box) || MISSING_BOX_ID_LABEL
 }
 
-export function getBoxRouteId(box: Partial<Pick<Box, 'boxId' | 'id'>> | undefined): string {
-  return box?.boxId || box?.id || ''
+export function getBoxRouteId(box: Partial<Pick<Box, 'id'>> | undefined): string {
+  return box?.id || ''
 }
 
 export function getBoxDisplayName(box: BoxIdentity): string {
   const name = getNormalizedBoxName(box)
-  if (name && name !== box.id && !isUuidLike(name)) {
+  // An unnamed box falls back to name === id at create time; show the id label then.
+  if (name && name !== box.id) {
     return name
   }
   return getBoxPublicId(box) || 'Box'
@@ -41,8 +42,4 @@ function getNormalizedBoxName(box: BoxIdentity): string {
   }
 
   return box.name
-}
-
-function isUuidLike(value: string): boolean {
-  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value)
 }

--- a/apps/libs/api-client/src/docs/AdminBoxItem.md
+++ b/apps/libs/api-client/src/docs/AdminBoxItem.md
@@ -6,8 +6,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **id** | **string** | Box ID | [default to undefined]
-**boxId** | **string** | Public box ID shown to users | [optional] [default to undefined]
-**organizationId** | **string** | Organization ID | [default to undefined]
+**organizationId** | **string** | Public box ID shown to users | [optional] [default to undefined]
 **state** | [**BoxState**](BoxState.md) |  | [default to undefined]
 **runnerId** | **string** | Runner ID the box is assigned to | [optional] [default to undefined]
 **cpu** | **number** | Allocated CPU (vCPUs) | [default to undefined]
@@ -22,7 +21,6 @@ import { AdminBoxItem } from './api';
 
 const instance: AdminBoxItem = {
     id,
-    boxId,
     organizationId,
     state,
     runnerId,

--- a/apps/libs/api-client/src/docs/Box.md
+++ b/apps/libs/api-client/src/docs/Box.md
@@ -6,7 +6,6 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **id** | **string** | The internal UUID of the box | [default to undefined]
-**boxId** | **string** | The public Box ID shown to users and SDK clients | [default to undefined]
 **organizationId** | **string** | The organization ID of the box | [default to undefined]
 **name** | **string** | The name of the box | [default to undefined]
 **user** | **string** | The user associated with the project | [default to undefined]
@@ -42,7 +41,6 @@ import { Box } from './api';
 
 const instance: Box = {
     id,
-    boxId,
     organizationId,
     name,
     user,

--- a/apps/libs/api-client/src/docs/Workspace.md
+++ b/apps/libs/api-client/src/docs/Workspace.md
@@ -6,7 +6,6 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **id** | **string** | The internal UUID of the box | [default to undefined]
-**boxId** | **string** | The public Box ID shown to users and SDK clients | [default to undefined]
 **organizationId** | **string** | The organization ID of the box | [default to undefined]
 **name** | **string** | The name of the box | [default to undefined]
 **user** | **string** | The user associated with the project | [default to undefined]
@@ -43,7 +42,6 @@ import { Workspace } from './api';
 
 const instance: Workspace = {
     id,
-    boxId,
     organizationId,
     name,
     user,

--- a/apps/libs/api-client/src/models/admin-box-item.ts
+++ b/apps/libs/api-client/src/models/admin-box-item.ts
@@ -28,11 +28,7 @@ export interface AdminBoxItem {
     /**
      * Public box ID shown to users
      */
-    'boxId'?: string;
-    /**
-     * Organization ID
-     */
-    'organizationId': string;
+    'organizationId'?: string;
     'state': BoxState;
     /**
      * Runner ID the box is assigned to

--- a/apps/libs/api-client/src/models/box.ts
+++ b/apps/libs/api-client/src/models/box.ts
@@ -29,10 +29,6 @@ export interface Box {
      */
     'id': string;
     /**
-     * The public Box ID shown to users and SDK clients
-     */
-    'boxId': string;
-    /**
      * The organization ID of the box
      */
     'organizationId': string;

--- a/apps/libs/api-client/src/models/workspace.ts
+++ b/apps/libs/api-client/src/models/workspace.ts
@@ -32,10 +32,6 @@ export interface Workspace {
      */
     'id': string;
     /**
-     * The public Box ID shown to users and SDK clients
-     */
-    'boxId': string;
-    /**
      * The organization ID of the box
      */
     'organizationId': string;

--- a/apps/runner/pkg/boxlite/client.go
+++ b/apps/runner/pkg/boxlite/client.go
@@ -221,7 +221,10 @@ func (c *Client) Create(ctx context.Context, boxDto dto.CreateBoxDTO) (string, s
 		memoryMiB = 128
 	}
 	opts := []boxlite.BoxOption{
-		boxlite.WithName(boxDto.Id),
+		// Attach the control-plane box id as the orchestrator reference (CRI
+		// PodSandboxMetadata.uid analog); the engine mints its own internal id
+		// and the name slot stays free for a future user-facing name.
+		boxlite.WithExternalRef(boxDto.Id),
 		boxlite.WithCPUs(cpus),
 		boxlite.WithMemory(memoryMiB),
 		boxlite.WithAutoRemove(false),

--- a/sdks/c/include/boxlite.h
+++ b/sdks/c/include/boxlite.h
@@ -237,6 +237,8 @@ typedef void (*CBoxImageListCb)(struct CImageInfoList*, CBoxliteError*, void*);
 typedef struct CBoxInfo {
   char *id;
   char *name;
+  // Orchestrator-issued external reference; NULL when unset.
+  char *external_ref;
   char *image;
   char *status;
   int running;
@@ -490,6 +492,13 @@ enum BoxliteErrorCode boxlite_options_new(const char *image,
 void boxlite_options_set_rootfs_path(CBoxliteOptions *opts, const char *path);
 
 void boxlite_options_set_name(CBoxliteOptions *opts, const char *name);
+
+// Set an orchestrator-issued external reference on the box (opaque, unique
+// when present; boxes can be looked up by it). See BoxOptions::external_ref.
+//
+// # Safety
+// `opts` must be a valid options handle; `external_ref` a valid C string.
+void boxlite_options_set_external_ref(CBoxliteOptions *opts, const char *external_ref);
 
 void boxlite_options_set_cpus(CBoxliteOptions *opts, int cpus);
 

--- a/sdks/c/src/event_queue.rs
+++ b/sdks/c/src/event_queue.rs
@@ -1118,6 +1118,7 @@ mod owned_ffi_ptr_nested_leak_tests {
         let payload = Box::new(CBoxInfo {
             id: test_cstr("box-id-1"),
             name: test_cstr("test-box"),
+            external_ref: test_cstr("ext-ref-1"),
             image: test_cstr("alpine:latest"),
             status: test_cstr("running"),
             running: 1,
@@ -1133,9 +1134,9 @@ mod owned_ffi_ptr_nested_leak_tests {
         let after = FREE_STR_CALLS.load(AtomicOrdering::SeqCst);
         assert_eq!(
             after - before,
-            4,
+            5,
             "OwnedFfiPtr<CBoxInfo>::drop reclaimed {} inner CStrings; \
-             expected 4 (id + name + image + status). Inner allocations leak.",
+             expected 5 (id + name + external_ref + image + status). Inner allocations leak.",
             after - before
         );
     }
@@ -1185,6 +1186,7 @@ mod owned_ffi_ptr_nested_leak_tests {
         let mut items_vec = vec![CBoxInfo {
             id: test_cstr("box-id-2"),
             name: test_cstr("another-box"),
+            external_ref: std::ptr::null_mut(),
             image: test_cstr("ubuntu:24.04"),
             status: test_cstr("stopped"),
             running: 0,

--- a/sdks/c/src/info.rs
+++ b/sdks/c/src/info.rs
@@ -20,6 +20,8 @@ use crate::{CBoxHandle, CBoxliteError, CBoxliteRuntime};
 pub struct CBoxInfo {
     pub id: *mut c_char,
     pub name: *mut c_char,
+    /// Orchestrator-issued external reference; NULL when unset.
+    pub external_ref: *mut c_char,
     pub image: *mut c_char,
     pub status: *mut c_char,
     pub running: c_int,
@@ -62,6 +64,11 @@ impl CBoxInfo {
                 .as_deref()
                 .map(to_c_str)
                 .unwrap_or(ptr::null_mut()),
+            external_ref: info
+                .external_ref
+                .as_deref()
+                .map(to_c_str)
+                .unwrap_or(ptr::null_mut()),
             image: to_c_str(&info.image),
             status: to_c_str(status_to_str(info.status)),
             running: if info.status.is_running() { 1 } else { 0 },
@@ -81,6 +88,7 @@ pub unsafe fn free_box_info(info: *mut CBoxInfo) {
         let info_ref = &mut *info;
         free_str(info_ref.id);
         free_str(info_ref.name);
+        free_str(info_ref.external_ref);
         free_str(info_ref.image);
         free_str(info_ref.status);
     }

--- a/sdks/c/src/options.rs
+++ b/sdks/c/src/options.rs
@@ -35,6 +35,19 @@ pub unsafe extern "C" fn boxlite_options_set_name(opts: *mut CBoxliteOptions, na
     options_set_name(opts, name)
 }
 
+/// Set an orchestrator-issued external reference on the box (opaque, unique
+/// when present; boxes can be looked up by it). See BoxOptions::external_ref.
+///
+/// # Safety
+/// `opts` must be a valid options handle; `external_ref` a valid C string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_options_set_external_ref(
+    opts: *mut CBoxliteOptions,
+    external_ref: *const c_char,
+) {
+    options_set_external_ref(opts, external_ref)
+}
+
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn boxlite_options_set_cpus(opts: *mut CBoxliteOptions, cpus: c_int) {
     options_set_cpus(opts, cpus)
@@ -220,6 +233,17 @@ pub unsafe fn options_set_name(handle: *mut OptionsHandle, name: *const c_char) 
         }
         if let Ok(s) = c_str_to_string(name) {
             (*handle).name = Some(s);
+        }
+    }
+}
+
+pub unsafe fn options_set_external_ref(handle: *mut OptionsHandle, external_ref: *const c_char) {
+    unsafe {
+        if handle.is_null() || external_ref.is_null() {
+            return;
+        }
+        if let Ok(s) = c_str_to_string(external_ref) {
+            (*handle).options.external_ref = Some(s);
         }
     }
 }

--- a/sdks/go/info.go
+++ b/sdks/go/info.go
@@ -23,15 +23,16 @@ const (
 
 // BoxInfo holds information about a box.
 type BoxInfo struct {
-	ID        string
-	Name      string
-	Image     string
-	State     State
-	Running   bool
-	PID       int
-	CPUs      int
-	MemoryMiB int
-	CreatedAt time.Time
+	ID          string
+	Name        string
+	ExternalRef string
+	Image       string
+	State       State
+	Running     bool
+	PID         int
+	CPUs        int
+	MemoryMiB   int
+	CreatedAt   time.Time
 }
 
 // Info returns information about the box.
@@ -112,15 +113,16 @@ func (r *Runtime) GetInfo(ctx context.Context, idOrName string) (*BoxInfo, error
 func cBoxInfoToGo(info *C.CBoxInfo) BoxInfo {
 	pid := int(info.pid)
 	return BoxInfo{
-		ID:        cString(info.id),
-		Name:      cString(info.name),
-		Image:     cString(info.image),
-		State:     State(cString(info.status)),
-		Running:   info.running != 0,
-		PID:       pid,
-		CPUs:      int(info.cpus),
-		MemoryMiB: int(info.memory_mib),
-		CreatedAt: time.Unix(int64(info.created_at), 0),
+		ID:          cString(info.id),
+		Name:        cString(info.name),
+		ExternalRef: cString(info.external_ref),
+		Image:       cString(info.image),
+		State:       State(cString(info.status)),
+		Running:     info.running != 0,
+		PID:         pid,
+		CPUs:        int(info.cpus),
+		MemoryMiB:   int(info.memory_mib),
+		CreatedAt:   time.Unix(int64(info.created_at), 0),
 	}
 }
 

--- a/sdks/go/options.go
+++ b/sdks/go/options.go
@@ -171,21 +171,22 @@ type Secret struct {
 }
 
 type boxConfig struct {
-	name       string
-	cpus       int
-	memoryMiB  int
-	diskSizeGB int
-	rootfsPath string
-	env        [][2]string
-	volumes    []volumeEntry
-	ports      []PortSpec
-	workDir    string
-	entrypoint []string
-	cmd        []string
-	autoRemove *bool
-	detach     *bool
-	network    *NetworkSpec
-	secrets    []Secret
+	name        string
+	externalRef string
+	cpus        int
+	memoryMiB   int
+	diskSizeGB  int
+	rootfsPath  string
+	env         [][2]string
+	volumes     []volumeEntry
+	ports       []PortSpec
+	workDir     string
+	entrypoint  []string
+	cmd         []string
+	autoRemove  *bool
+	detach      *bool
+	network     *NetworkSpec
+	secrets     []Secret
 }
 
 type volumeEntry struct {
@@ -197,6 +198,13 @@ type volumeEntry struct {
 // WithName sets a human-readable name for the box.
 func WithName(name string) BoxOption {
 	return func(c *boxConfig) { c.name = name }
+}
+
+// WithExternalRef attaches an orchestrator-issued reference to the box
+// (opaque to the engine, unique when present). The box can later be
+// retrieved with runtime.Get(externalRef).
+func WithExternalRef(externalRef string) BoxOption {
+	return func(c *boxConfig) { c.externalRef = externalRef }
 }
 
 // WithCPUs sets the number of virtual CPUs.
@@ -337,6 +345,11 @@ func buildCOptions(image string, cfg *boxConfig) (*C.CBoxliteOptions, error) {
 		cName := toCString(cfg.name)
 		C.boxlite_options_set_name(cOpts, cName)
 		C.free(unsafe.Pointer(cName))
+	}
+	if cfg.externalRef != "" {
+		cRef := toCString(cfg.externalRef)
+		C.boxlite_options_set_external_ref(cOpts, cRef)
+		C.free(unsafe.Pointer(cRef))
 	}
 	if cfg.cpus > 0 {
 		C.boxlite_options_set_cpus(cOpts, C.int(cfg.cpus))

--- a/sdks/node/src/options.rs
+++ b/sdks/node/src/options.rs
@@ -407,6 +407,9 @@ impl TryFrom<JsBoxOptions> for BoxOptions {
             .collect();
 
         Ok(BoxOptions {
+            // Not exposed in the Node SDK yet: external refs are an
+            // orchestrator-facing knob (see the Go SDK's WithExternalRef).
+            external_ref: None,
             cpus: js_opts.cpus,
             memory_mib: js_opts.memory_mib,
             disk_size_gb: js_opts.disk_size_gb.map(|v| v as u64),

--- a/src/boxlite/src/litebox/manager.rs
+++ b/src/boxlite/src/litebox/manager.rs
@@ -115,6 +115,13 @@ impl BoxManager {
             }
         }
 
+        // Exact external_ref match (orchestrator-issued correlation key)
+        for (config, state) in &all {
+            if config.options.external_ref.as_deref() == Some(id_or_name) {
+                return Ok(Some((config.clone(), state.clone())));
+            }
+        }
+
         // ID prefix match
         let matches: Vec<_> = all
             .iter()
@@ -320,6 +327,22 @@ mod tests {
         let result = manager.lookup_box("my-box").unwrap();
         assert!(result.is_some());
         assert_eq!(result.unwrap().0.id.as_str(), TEST_ID_1);
+    }
+
+    #[test]
+    fn test_lookup_box_by_external_ref() {
+        let store = create_test_store();
+        let manager = BoxManager::new(store);
+        let mut config = create_test_config(TEST_ID_1);
+        config.options.external_ref = Some("a7Kf93mQpX2z".to_string());
+        manager
+            .add_box(&config, &create_test_state(BoxStatus::Configured))
+            .unwrap();
+
+        let found = manager.lookup_box("a7Kf93mQpX2z").unwrap();
+        assert_eq!(found.unwrap().0.id.as_str(), TEST_ID_1);
+
+        assert!(manager.lookup_box("not-a-ref-anywhere").unwrap().is_none());
     }
 
     #[test]

--- a/src/boxlite/src/rest/types.rs
+++ b/src/boxlite/src/rest/types.rs
@@ -230,6 +230,9 @@ impl BoxResponse {
 
         Ok(crate::BoxInfo {
             id,
+            // In REST mode the id IS the control plane's id; there is no
+            // separate orchestrator reference to carry.
+            external_ref: None,
             name: self.name.clone(),
             status,
             created_at,

--- a/src/boxlite/src/runtime/options.rs
+++ b/src/boxlite/src/runtime/options.rs
@@ -314,6 +314,12 @@ mod registry_options_tests {
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[serde(default)]
 pub struct BoxOptions {
+    /// Opaque reference attached by an external orchestrator (e.g. the cloud
+    /// control plane's box id), mirroring CRI's `PodSandboxMetadata.uid`.
+    /// The engine never interprets it; it is unique when present and boxes
+    /// can be looked up by it. Locally created boxes leave it unset.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub external_ref: Option<String>,
     pub cpus: Option<u8>,
     pub memory_mib: Option<u32>,
     /// Disk size in GB for the container rootfs (sparse, grows as needed).
@@ -481,6 +487,7 @@ fn default_detach() -> bool {
 impl Default for BoxOptions {
     fn default() -> Self {
         Self {
+            external_ref: None,
             cpus: None,
             memory_mib: None,
             disk_size_gb: None,

--- a/src/boxlite/src/runtime/rt_impl.rs
+++ b/src/boxlite/src/runtime/rt_impl.rs
@@ -366,6 +366,17 @@ impl RuntimeImpl {
             };
         }
 
+        // external_ref is an orchestrator-issued correlation key; like name it
+        // must resolve to at most one box, so reject duplicates at create time.
+        if let Some(ref external_ref) = options.external_ref
+            && self.box_manager.lookup_box(external_ref)?.is_some()
+        {
+            return Err(BoxliteError::InvalidArgument(format!(
+                "box with external_ref '{}' already exists",
+                external_ref
+            )));
+        }
+
         // Initialize box variables with defaults
         let (config, mut state) = self.init_box_variables(&options, name.clone());
 

--- a/src/boxlite/src/runtime/types.rs
+++ b/src/boxlite/src/runtime/types.rs
@@ -289,6 +289,10 @@ pub struct BoxInfo {
     /// User-defined name (optional).
     pub name: Option<String>,
 
+    /// Orchestrator-issued external reference (optional; omitted when unset).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub external_ref: Option<String>,
+
     /// Current lifecycle status.
     pub status: BoxStatus,
 
@@ -325,6 +329,7 @@ impl BoxInfo {
         Self {
             id: config.id.clone(),
             name: config.name.clone(),
+            external_ref: config.options.external_ref.clone(),
             status: state.status,
             created_at: config.created_at,
             last_updated: state.last_updated,

--- a/src/cli/src/commands/inspect.rs
+++ b/src/cli/src/commands/inspect.rs
@@ -29,6 +29,8 @@ struct InspectPresenter {
     id: String,
     #[serde(rename = "Name")]
     name: String,
+    #[serde(rename = "ExternalRef", skip_serializing_if = "Option::is_none")]
+    external_ref: Option<String>,
     #[serde(rename = "Image")]
     image: String,
     #[serde(rename = "Created")]
@@ -59,6 +61,7 @@ impl From<&BoxInfo> for InspectPresenter {
         Self {
             id: info.id.to_string(),
             name: info.name.as_deref().unwrap_or("").to_string(),
+            external_ref: info.external_ref.clone(),
             image: info.image.clone(),
             created: info.created_at.to_rfc3339(),
             status: info.status.as_str().to_string(),


### PR DESCRIPTION
## Summary

Stacked on #735. The Box entity's identity collapsed there into a single 12-char id; the `boxId` fields on `BoxDto` / the admin overview DTO were kept only as value mirrors of `id` to avoid touching the API contract and generated clients in that PR. This PR removes the mirror everywhere:

```text
before (after #735)                 after (this PR)
───────────────────                 ───────────────
entity/DB:   id  ✅ single          unchanged
BoxDto:      id + boxId (same       id only
             value, legacy shape)
admin DTO:   id + boxId mirror      id only
clients:     Box/AdminBoxItem/      boxId field gone (TS + Go)
             Workspace carry boxId
dashboard:   reads .boxId ?? .id    reads .id
```

- API: `BoxDto.boxId`, admin overview `boxId`, dual-id correlation matching in admin observability — all removed.
- Dashboard: `box-identity` helpers read `.id`; dual-id cache updates and the uuid-shaped-name special case removed (after the DB rebuild a box name can never be a uuid).
- Generated clients: regenerated with the repo's own codegen **inside a disposable BoxLite box** (CI-faithful: Linux + JDK + GNU sed, no host gofmt drift). Drift is exactly the `boxId` removal on the `Box` / `AdminBoxItem` / `Workspace` models in the TS and Go clients.
- Untouched on purpose: route/query parameter names like `:boxId` (they carry the single id), other tables' `boxId` FK column names, and the analytics `ModelsBoxUsage.boxId` (a real data field, not the mirror).

## Verification

- API jest: 38 suites / 112 tests pass
- Dashboard: `tsc --noEmit` clean against the regenerated client
- Regen ran in a BoxLite box (`boxlite run node:22-bookworm`); output is byte-for-byte what CI's api-client-drift check regenerates

## Merge order

#743 (remove TS cloud SDK) → #735 (image pipeline + single box identity) → this PR.
