### PR TITLE
feat(engine): orchestrator external_ref on boxes (CRI uid analog)

### DIFF
--- a/apps/runner/pkg/boxlite/client.go
+++ b/apps/runner/pkg/boxlite/client.go
@@ -221,7 +221,10 @@ func (c *Client) Create(ctx context.Context, boxDto dto.CreateBoxDTO) (string, s
 		memoryMiB = 128
 	}
 	opts := []boxlite.BoxOption{
-		boxlite.WithName(boxDto.Id),
+		// Attach the control-plane box id as the orchestrator reference (CRI
+		// PodSandboxMetadata.uid analog); the engine mints its own internal id
+		// and the name slot stays free for a future user-facing name.
+		boxlite.WithExternalRef(boxDto.Id),
 		boxlite.WithCPUs(cpus),
 		boxlite.WithMemory(memoryMiB),
 		boxlite.WithAutoRemove(false),

--- a/sdks/c/include/boxlite.h
+++ b/sdks/c/include/boxlite.h
@@ -237,6 +237,8 @@ typedef void (*CBoxImageListCb)(struct CImageInfoList*, CBoxliteError*, void*);
 typedef struct CBoxInfo {
   char *id;
   char *name;
+  // Orchestrator-issued external reference; NULL when unset.
+  char *external_ref;
   char *image;
   char *status;
   int running;
@@ -490,6 +492,13 @@ enum BoxliteErrorCode boxlite_options_new(const char *image,
 void boxlite_options_set_rootfs_path(CBoxliteOptions *opts, const char *path);
 
 void boxlite_options_set_name(CBoxliteOptions *opts, const char *name);
+
+// Set an orchestrator-issued external reference on the box (opaque, unique
+// when present; boxes can be looked up by it). See BoxOptions::external_ref.
+//
+// # Safety
+// `opts` must be a valid options handle; `external_ref` a valid C string.
+void boxlite_options_set_external_ref(CBoxliteOptions *opts, const char *external_ref);
 
 void boxlite_options_set_cpus(CBoxliteOptions *opts, int cpus);
 

--- a/sdks/c/src/event_queue.rs
+++ b/sdks/c/src/event_queue.rs
@@ -1118,6 +1118,7 @@ mod owned_ffi_ptr_nested_leak_tests {
         let payload = Box::new(CBoxInfo {
             id: test_cstr("box-id-1"),
             name: test_cstr("test-box"),
+            external_ref: test_cstr("ext-ref-1"),
             image: test_cstr("alpine:latest"),
             status: test_cstr("running"),
             running: 1,
@@ -1133,9 +1134,9 @@ mod owned_ffi_ptr_nested_leak_tests {
         let after = FREE_STR_CALLS.load(AtomicOrdering::SeqCst);
         assert_eq!(
             after - before,
-            4,
+            5,
             "OwnedFfiPtr<CBoxInfo>::drop reclaimed {} inner CStrings; \
-             expected 4 (id + name + image + status). Inner allocations leak.",
+             expected 5 (id + name + external_ref + image + status). Inner allocations leak.",
             after - before
         );
     }
@@ -1185,6 +1186,7 @@ mod owned_ffi_ptr_nested_leak_tests {
         let mut items_vec = vec![CBoxInfo {
             id: test_cstr("box-id-2"),
             name: test_cstr("another-box"),
+            external_ref: std::ptr::null_mut(),
             image: test_cstr("ubuntu:24.04"),
             status: test_cstr("stopped"),
             running: 0,

--- a/sdks/c/src/info.rs
+++ b/sdks/c/src/info.rs
@@ -20,6 +20,8 @@ use crate::{CBoxHandle, CBoxliteError, CBoxliteRuntime};
 pub struct CBoxInfo {
     pub id: *mut c_char,
     pub name: *mut c_char,
+    /// Orchestrator-issued external reference; NULL when unset.
+    pub external_ref: *mut c_char,
     pub image: *mut c_char,
     pub status: *mut c_char,
     pub running: c_int,
@@ -62,6 +64,11 @@ impl CBoxInfo {
                 .as_deref()
                 .map(to_c_str)
                 .unwrap_or(ptr::null_mut()),
+            external_ref: info
+                .external_ref
+                .as_deref()
+                .map(to_c_str)
+                .unwrap_or(ptr::null_mut()),
             image: to_c_str(&info.image),
             status: to_c_str(status_to_str(info.status)),
             running: if info.status.is_running() { 1 } else { 0 },
@@ -81,6 +88,7 @@ pub unsafe fn free_box_info(info: *mut CBoxInfo) {
         let info_ref = &mut *info;
         free_str(info_ref.id);
         free_str(info_ref.name);
+        free_str(info_ref.external_ref);
         free_str(info_ref.image);
         free_str(info_ref.status);
     }

--- a/sdks/c/src/options.rs
+++ b/sdks/c/src/options.rs
@@ -35,6 +35,19 @@ pub unsafe extern "C" fn boxlite_options_set_name(opts: *mut CBoxliteOptions, na
     options_set_name(opts, name)
 }
 
+/// Set an orchestrator-issued external reference on the box (opaque, unique
+/// when present; boxes can be looked up by it). See BoxOptions::external_ref.
+///
+/// # Safety
+/// `opts` must be a valid options handle; `external_ref` a valid C string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_options_set_external_ref(
+    opts: *mut CBoxliteOptions,
+    external_ref: *const c_char,
+) {
+    options_set_external_ref(opts, external_ref)
+}
+
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn boxlite_options_set_cpus(opts: *mut CBoxliteOptions, cpus: c_int) {
     options_set_cpus(opts, cpus)
@@ -220,6 +233,17 @@ pub unsafe fn options_set_name(handle: *mut OptionsHandle, name: *const c_char) 
         }
         if let Ok(s) = c_str_to_string(name) {
             (*handle).name = Some(s);
+        }
+    }
+}
+
+pub unsafe fn options_set_external_ref(handle: *mut OptionsHandle, external_ref: *const c_char) {
+    unsafe {
+        if handle.is_null() || external_ref.is_null() {
+            return;
+        }
+        if let Ok(s) = c_str_to_string(external_ref) {
+            (*handle).options.external_ref = Some(s);
         }
     }
 }

--- a/sdks/go/info.go
+++ b/sdks/go/info.go
@@ -23,15 +23,16 @@ const (
 
 // BoxInfo holds information about a box.
 type BoxInfo struct {
-	ID        string
-	Name      string
-	Image     string
-	State     State
-	Running   bool
-	PID       int
-	CPUs      int
-	MemoryMiB int
-	CreatedAt time.Time
+	ID          string
+	Name        string
+	ExternalRef string
+	Image       string
+	State       State
+	Running     bool
+	PID         int
+	CPUs        int
+	MemoryMiB   int
+	CreatedAt   time.Time
 }
 
 // Info returns information about the box.
@@ -112,15 +113,16 @@ func (r *Runtime) GetInfo(ctx context.Context, idOrName string) (*BoxInfo, error
 func cBoxInfoToGo(info *C.CBoxInfo) BoxInfo {
 	pid := int(info.pid)
 	return BoxInfo{
-		ID:        cString(info.id),
-		Name:      cString(info.name),
-		Image:     cString(info.image),
-		State:     State(cString(info.status)),
-		Running:   info.running != 0,
-		PID:       pid,
-		CPUs:      int(info.cpus),
-		MemoryMiB: int(info.memory_mib),
-		CreatedAt: time.Unix(int64(info.created_at), 0),
+		ID:          cString(info.id),
+		Name:        cString(info.name),
+		ExternalRef: cString(info.external_ref),
+		Image:       cString(info.image),
+		State:       State(cString(info.status)),
+		Running:     info.running != 0,
+		PID:         pid,
+		CPUs:        int(info.cpus),
+		MemoryMiB:   int(info.memory_mib),
+		CreatedAt:   time.Unix(int64(info.created_at), 0),
 	}
 }
 

--- a/sdks/go/options.go
+++ b/sdks/go/options.go
@@ -171,21 +171,22 @@ type Secret struct {
 }
 
 type boxConfig struct {
-	name       string
-	cpus       int
-	memoryMiB  int
-	diskSizeGB int
-	rootfsPath string
-	env        [][2]string
-	volumes    []volumeEntry
-	ports      []PortSpec
-	workDir    string
-	entrypoint []string
-	cmd        []string
-	autoRemove *bool
-	detach     *bool
-	network    *NetworkSpec
-	secrets    []Secret
+	name        string
+	externalRef string
+	cpus        int
+	memoryMiB   int
+	diskSizeGB  int
+	rootfsPath  string
+	env         [][2]string
+	volumes     []volumeEntry
+	ports       []PortSpec
+	workDir     string
+	entrypoint  []string
+	cmd         []string
+	autoRemove  *bool
+	detach      *bool
+	network     *NetworkSpec
+	secrets     []Secret
 }
 
 type volumeEntry struct {
@@ -197,6 +198,13 @@ type volumeEntry struct {
 // WithName sets a human-readable name for the box.
 func WithName(name string) BoxOption {
 	return func(c *boxConfig) { c.name = name }
+}
+
+// WithExternalRef attaches an orchestrator-issued reference to the box
+// (opaque to the engine, unique when present). The box can later be
+// retrieved with runtime.Get(externalRef).
+func WithExternalRef(externalRef string) BoxOption {
+	return func(c *boxConfig) { c.externalRef = externalRef }
 }
 
 // WithCPUs sets the number of virtual CPUs.
@@ -337,6 +345,11 @@ func buildCOptions(image string, cfg *boxConfig) (*C.CBoxliteOptions, error) {
 		cName := toCString(cfg.name)
 		C.boxlite_options_set_name(cOpts, cName)
 		C.free(unsafe.Pointer(cName))
+	}
+	if cfg.externalRef != "" {
+		cRef := toCString(cfg.externalRef)
+		C.boxlite_options_set_external_ref(cOpts, cRef)
+		C.free(unsafe.Pointer(cRef))
 	}
 	if cfg.cpus > 0 {
 		C.boxlite_options_set_cpus(cOpts, C.int(cfg.cpus))

--- a/sdks/node/src/options.rs
+++ b/sdks/node/src/options.rs
@@ -407,6 +407,9 @@ impl TryFrom<JsBoxOptions> for BoxOptions {
             .collect();
 
         Ok(BoxOptions {
+            // Not exposed in the Node SDK yet: external refs are an
+            // orchestrator-facing knob (see the Go SDK's WithExternalRef).
+            external_ref: None,
             cpus: js_opts.cpus,
             memory_mib: js_opts.memory_mib,
             disk_size_gb: js_opts.disk_size_gb.map(|v| v as u64),

--- a/src/boxlite/src/litebox/manager.rs
+++ b/src/boxlite/src/litebox/manager.rs
@@ -115,6 +115,13 @@ impl BoxManager {
             }
         }
 
+        // Exact external_ref match (orchestrator-issued correlation key)
+        for (config, state) in &all {
+            if config.options.external_ref.as_deref() == Some(id_or_name) {
+                return Ok(Some((config.clone(), state.clone())));
+            }
+        }
+
         // ID prefix match
         let matches: Vec<_> = all
             .iter()
@@ -320,6 +327,22 @@ mod tests {
         let result = manager.lookup_box("my-box").unwrap();
         assert!(result.is_some());
         assert_eq!(result.unwrap().0.id.as_str(), TEST_ID_1);
+    }
+
+    #[test]
+    fn test_lookup_box_by_external_ref() {
+        let store = create_test_store();
+        let manager = BoxManager::new(store);
+        let mut config = create_test_config(TEST_ID_1);
+        config.options.external_ref = Some("a7Kf93mQpX2z".to_string());
+        manager
+            .add_box(&config, &create_test_state(BoxStatus::Configured))
+            .unwrap();
+
+        let found = manager.lookup_box("a7Kf93mQpX2z").unwrap();
+        assert_eq!(found.unwrap().0.id.as_str(), TEST_ID_1);
+
+        assert!(manager.lookup_box("not-a-ref-anywhere").unwrap().is_none());
     }
 
     #[test]

--- a/src/boxlite/src/rest/types.rs
+++ b/src/boxlite/src/rest/types.rs
@@ -230,6 +230,9 @@ impl BoxResponse {
 
         Ok(crate::BoxInfo {
             id,
+            // In REST mode the id IS the control plane's id; there is no
+            // separate orchestrator reference to carry.
+            external_ref: None,
             name: self.name.clone(),
             status,
             created_at,

--- a/src/boxlite/src/runtime/options.rs
+++ b/src/boxlite/src/runtime/options.rs
@@ -314,6 +314,12 @@ mod registry_options_tests {
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[serde(default)]
 pub struct BoxOptions {
+    /// Opaque reference attached by an external orchestrator (e.g. the cloud
+    /// control plane's box id), mirroring CRI's `PodSandboxMetadata.uid`.
+    /// The engine never interprets it; it is unique when present and boxes
+    /// can be looked up by it. Locally created boxes leave it unset.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub external_ref: Option<String>,
     pub cpus: Option<u8>,
     pub memory_mib: Option<u32>,
     /// Disk size in GB for the container rootfs (sparse, grows as needed).
@@ -481,6 +487,7 @@ fn default_detach() -> bool {
 impl Default for BoxOptions {
     fn default() -> Self {
         Self {
+            external_ref: None,
             cpus: None,
             memory_mib: None,
             disk_size_gb: None,

--- a/src/boxlite/src/runtime/rt_impl.rs
+++ b/src/boxlite/src/runtime/rt_impl.rs
@@ -366,6 +366,17 @@ impl RuntimeImpl {
             };
         }
 
+        // external_ref is an orchestrator-issued correlation key; like name it
+        // must resolve to at most one box, so reject duplicates at create time.
+        if let Some(ref external_ref) = options.external_ref
+            && self.box_manager.lookup_box(external_ref)?.is_some()
+        {
+            return Err(BoxliteError::InvalidArgument(format!(
+                "box with external_ref '{}' already exists",
+                external_ref
+            )));
+        }
+
         // Initialize box variables with defaults
         let (config, mut state) = self.init_box_variables(&options, name.clone());
 

--- a/src/boxlite/src/runtime/types.rs
+++ b/src/boxlite/src/runtime/types.rs
@@ -289,6 +289,10 @@ pub struct BoxInfo {
     /// User-defined name (optional).
     pub name: Option<String>,
 
+    /// Orchestrator-issued external reference (optional; omitted when unset).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub external_ref: Option<String>,
+
     /// Current lifecycle status.
     pub status: BoxStatus,
 
@@ -325,6 +329,7 @@ impl BoxInfo {
         Self {
             id: config.id.clone(),
             name: config.name.clone(),
+            external_ref: config.options.external_ref.clone(),
             status: state.status,
             created_at: config.created_at,
             last_updated: state.last_updated,

--- a/src/cli/src/commands/inspect.rs
+++ b/src/cli/src/commands/inspect.rs
@@ -29,6 +29,8 @@ struct InspectPresenter {
     id: String,
     #[serde(rename = "Name")]
     name: String,
+    #[serde(rename = "ExternalRef", skip_serializing_if = "Option::is_none")]
+    external_ref: Option<String>,
     #[serde(rename = "Image")]
     image: String,
     #[serde(rename = "Created")]
@@ -59,6 +61,7 @@ impl From<&BoxInfo> for InspectPresenter {
         Self {
             id: info.id.to_string(),
             name: info.name.as_deref().unwrap_or("").to_string(),
+            external_ref: info.external_ref.clone(),
             image: info.image.clone(),
             created: info.created_at.to_rfc3339(),
             status: info.status.as_str().to_string(),


### PR DESCRIPTION
## Summary

Stacked on #744. Implements the identity follow-up discussed on #735 (see the "Identity model note" comment there): the engine gains a CRI-style orchestrator reference, and the runner stops squatting the engine's `name` slot to carry the control-plane box id.

```text
before                                after
──────                                ─────
runner: WithName(cloudId)             runner: WithExternalRef(cloudId)
engine: name = cloudId (squatted)     engine: external_ref = cloudId
        name unavailable for users            name free for a future
                                              user-facing box name
```

Industry precedent (verified sources):
- CRI `PodSandboxMetadata.uid` — the orchestrator's id travels as a dedicated metadata field; the runtime mints its own id ([cri-api api.proto](https://github.com/kubernetes/cri-api/blob/master/pkg/apis/runtime/v1/api.proto), `message PodSandboxMetadata`)
- ECS agent attaches `com.amazonaws.ecs.task-arn` as a docker label ([docker_task_engine.go](https://github.com/aws/amazon-ecs-agent/blob/master/agent/engine/docker_task_engine.go))
- The caller-supplied-id pattern (OCI runtime spec `create <container-id>`) applies to stateless executors (runc/firecracker), not to stateful daemons like this engine — hence a reference field, not id injection.

## What changed

- **engine**: `BoxOptions.external_ref` (opaque, json-persisted via the existing config blob — no DB migration; `lookup_box` already scans configs). Duplicate refs are rejected at create. Lookup order: exact id → name → external_ref → id prefix. `BoxInfo` exposes it, omitted when unset.
- **C SDK**: `boxlite_options_set_external_ref`, `CBoxInfo.external_ref` (NULL when unset, freed on drop — the leak-count test now expects 5 inner CStrings), header regenerated by the crate build.
- **Go SDK**: `WithExternalRef`, `BoxInfo.ExternalRef`.
- **Node SDK**: field filled with `None` (orchestrator-facing knob; not exposed in JS options yet).
- **CLI**: `inspect` shows `ExternalRef` only when present; `list` columns unchanged (nothing empty is rendered).
- **runner**: `WithName(dto.Id)` → `WithExternalRef(dto.Id)`; restart recovery (`runtime.Get(dto.Id)`) resolves through the external_ref match.

## Verification

- engine lib tests: 735/735; the new `lookup_box_by_external_ref` test was verified two-sided (fails with the lookup clause reverted, passes restored)
- boxlite-c: 55/55
- CLI / Node / Python crates compile; `go vet` clean on `sdks/go` and `apps/runner/pkg/boxlite` (final cgo link needs the prebuilt `libboxlite.a`, absent in this worktree)

## Merge order

#743 → #735 → #744 → this PR. Self-contained: reverting is closing this PR.
