### PR TITLE
fix(runner): drop dead-on-arrival toolbox HTTP readiness check

### DIFF
--- a/apps/runner/cmd/runner/config/config.go
+++ b/apps/runner/cmd/runner/config/config.go
@@ -37,7 +37,6 @@ type Config struct {
 	AWSSecretAccessKey                 string        `envconfig:"AWS_SECRET_ACCESS_KEY"`
 	AWSDefaultBucket                   string        `envconfig:"AWS_DEFAULT_BUCKET"`
 	ResourceLimitsDisabled             bool          `envconfig:"RESOURCE_LIMITS_DISABLED"`
-	DaemonStartTimeoutSec              int           `envconfig:"DAEMON_START_TIMEOUT_SEC"`
 	BoxStartTimeoutSec                 int           `envconfig:"BOX_START_TIMEOUT_SEC"`
 	UseSnapshotEntrypoint              bool          `envconfig:"USE_SNAPSHOT_ENTRYPOINT"`
 	Domain                             string        `envconfig:"RUNNER_DOMAIN" validate:"omitempty,hostname|ip"`

--- a/apps/runner/cmd/runner/main.go
+++ b/apps/runner/cmd/runner/main.go
@@ -118,7 +118,6 @@ func run() int {
 		VolumeCleanupInterval:        cfg.VolumeCleanupInterval,
 		VolumeCleanupDryRun:          cfg.VolumeCleanupDryRun,
 		VolumeCleanupExclusionPeriod: cfg.VolumeCleanupExclusionPeriod,
-		ToolboxReadyTimeout:          time.Duration(cfg.DaemonStartTimeoutSec) * time.Second,
 	})
 	if err != nil {
 		logger.Error("Error creating BoxLite client", "error", err)

--- a/apps/runner/pkg/boxlite/client.go
+++ b/apps/runner/pkg/boxlite/client.go
@@ -37,7 +37,6 @@ type Client struct {
 	volumeMutexesMutex  sync.Mutex
 	volumeCleanupMutex  sync.Mutex
 	toolboxPortMutex    sync.Mutex
-	toolboxReadyTimeout time.Duration
 	lastVolumeCleanup   time.Time
 	volumeCleanup       volumeCleanupConfig
 }
@@ -56,7 +55,6 @@ type ClientConfig struct {
 	VolumeCleanupInterval        time.Duration
 	VolumeCleanupDryRun          bool
 	VolumeCleanupExclusionPeriod time.Duration
-	ToolboxReadyTimeout          time.Duration
 }
 
 func networkSpec(blockAll *bool, allowList *string) boxlite.NetworkSpec {
@@ -136,11 +134,6 @@ func buildImageRegistries(insecureRegistries []string, ghcrUsername, ghcrToken s
 
 // NewClient creates a new BoxLite client backed by the BoxLite VM runtime.
 func NewClient(ctx context.Context, config ClientConfig) (*Client, error) {
-	toolboxReadyTimeout := config.ToolboxReadyTimeout
-	if toolboxReadyTimeout <= 0 {
-		toolboxReadyTimeout = 30 * time.Second
-	}
-
 	var opts []boxlite.RuntimeOption
 	if config.HomeDir != "" {
 		opts = append(opts, boxlite.WithHomeDir(config.HomeDir))
@@ -171,7 +164,6 @@ func NewClient(ctx context.Context, config ClientConfig) (*Client, error) {
 		awsAccessKeyId:      config.AWSAccessKeyId,
 		awsSecretAccessKey:  config.AWSSecretAccessKey,
 		volumeMutexes:       make(map[string]*sync.Mutex),
-		toolboxReadyTimeout: toolboxReadyTimeout,
 		volumeCleanup: volumeCleanupConfig{
 			interval:        config.VolumeCleanupInterval,
 			dryRun:          config.VolumeCleanupDryRun,
@@ -305,9 +297,6 @@ func (c *Client) Create(ctx context.Context, boxDto dto.CreateBoxDTO) (string, s
 		if err := bx.Start(ctx); err != nil {
 			return bx.ID(), "", fmt.Errorf("failed to start box: %w", err)
 		}
-		if err := c.waitForToolboxReady(ctx, boxDto.Id); err != nil {
-			return bx.ID(), "", err
-		}
 	}
 
 	return bx.ID(), "boxlite", nil
@@ -324,9 +313,6 @@ func (c *Client) Start(ctx context.Context, boxId string, authToken *string, met
 		return "", err
 	}
 	if err := bx.Start(ctx); err != nil {
-		return "", err
-	}
-	if err := c.waitForToolboxReady(ctx, boxId); err != nil {
 		return "", err
 	}
 	return "boxlite", nil

--- a/apps/runner/pkg/boxlite/toolbox_ports.go
+++ b/apps/runner/pkg/boxlite/toolbox_ports.go
@@ -7,14 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net"
-	"net/http"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
-	"time"
 )
 
 const (
@@ -60,55 +57,6 @@ func (c *Client) ToolboxHostPort(boxID string) (int, error) {
 	defer c.toolboxPortMutex.Unlock()
 
 	return c.readToolboxHostPort(boxID)
-}
-
-func (c *Client) waitForToolboxReady(ctx context.Context, boxID string) error {
-	hostPort, err := c.ToolboxHostPort(boxID)
-	if err != nil {
-		return fmt.Errorf("toolbox host port not available for box %s: %w", boxID, err)
-	}
-
-	timeout := c.toolboxReadyTimeout
-	if timeout <= 0 {
-		timeout = 30 * time.Second
-	}
-	readyCtx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-
-	url := fmt.Sprintf("http://127.0.0.1:%d/version", hostPort)
-	client := http.Client{Timeout: time.Second}
-	ticker := time.NewTicker(200 * time.Millisecond)
-	defer ticker.Stop()
-
-	var lastErr error
-	for {
-		req, reqErr := http.NewRequestWithContext(readyCtx, http.MethodGet, url, nil)
-		if reqErr != nil {
-			return reqErr
-		}
-
-		resp, reqErr := client.Do(req)
-		if reqErr == nil {
-			_, _ = io.Copy(io.Discard, resp.Body)
-			_ = resp.Body.Close()
-			if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-				c.logger.InfoContext(ctx, "box toolbox is ready", "box", boxID, "hostPort", hostPort)
-				return nil
-			}
-			lastErr = fmt.Errorf("unexpected status %d from %s", resp.StatusCode, url)
-		} else {
-			lastErr = reqErr
-		}
-
-		select {
-		case <-readyCtx.Done():
-			if lastErr != nil {
-				return fmt.Errorf("box toolbox not ready after %s (box=%s hostPort=%d): %w", timeout, boxID, hostPort, lastErr)
-			}
-			return fmt.Errorf("box toolbox not ready after %s (box=%s hostPort=%d)", timeout, boxID, hostPort)
-		case <-ticker.C:
-		}
-	}
 }
 
 func (c *Client) removeToolboxPortRecord(ctx context.Context, boxID string) error {

--- a/apps/runner/pkg/boxlite/toolbox_ports_test.go
+++ b/apps/runner/pkg/boxlite/toolbox_ports_test.go
@@ -6,10 +6,7 @@ package boxlite
 import (
 	"io"
 	"log/slog"
-	"net"
-	"net/http"
 	"testing"
-	"time"
 )
 
 func TestReserveToolboxHostPortPersistsRecord(t *testing.T) {
@@ -55,60 +52,3 @@ func TestRemoveToolboxPortRecord(t *testing.T) {
 	}
 }
 
-func TestWaitForToolboxReadyReturnsAfterVersionEndpointResponds(t *testing.T) {
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("listen: %v", err)
-	}
-	mux := http.NewServeMux()
-	mux.HandleFunc("/version", func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"version":"test"}`))
-	})
-	server := &http.Server{Handler: mux}
-	go func() {
-		_ = server.Serve(listener)
-	}()
-	defer server.Close()
-
-	port := listener.Addr().(*net.TCPAddr).Port
-	client := &Client{
-		homeDir:             t.TempDir(),
-		logger:              slog.New(slog.NewTextHandler(io.Discard, nil)),
-		toolboxReadyTimeout: time.Second,
-	}
-	if err := client.writeToolboxPortRecord(toolboxPortRecord{
-		BoxID:     "box-1",
-		GuestPort: ToolboxGuestPort,
-		HostPort:  port,
-	}); err != nil {
-		t.Fatalf("writeToolboxPortRecord: %v", err)
-	}
-
-	if err := client.waitForToolboxReady(t.Context(), "box-1"); err != nil {
-		t.Fatalf("waitForToolboxReady: %v", err)
-	}
-}
-
-func TestWaitForToolboxReadyTimesOutWhenEndpointDoesNotRespond(t *testing.T) {
-	port, err := findAvailableLocalPort()
-	if err != nil {
-		t.Fatalf("findAvailableLocalPort: %v", err)
-	}
-	client := &Client{
-		homeDir:             t.TempDir(),
-		logger:              slog.New(slog.NewTextHandler(io.Discard, nil)),
-		toolboxReadyTimeout: 20 * time.Millisecond,
-	}
-	if err := client.writeToolboxPortRecord(toolboxPortRecord{
-		BoxID:     "box-1",
-		GuestPort: ToolboxGuestPort,
-		HostPort:  port,
-	}); err != nil {
-		t.Fatalf("writeToolboxPortRecord: %v", err)
-	}
-
-	if err := client.waitForToolboxReady(t.Context(), "box-1"); err == nil {
-		t.Fatal("expected waitForToolboxReady to time out")
-	}
-}


### PR DESCRIPTION
**Draft.** Targets `chore/e2e-required-merge-gate` (PR #724) so the e2e-cloud stack picks this up on the next dispatch.

`waitForToolboxReady` was introduced in `fc88aa0b` ("feat: add agent-ready runtime catalog") and landed on `main` via PR #715 on 2026-06-10. It HTTP-polls `http://127.0.0.1:<hostPort>/version` expecting a daemon on guest TCP port 2280 — the Daytona-daemon interface that was never reimplemented after the Rust guest agent rewrite in `dbb11ec8` (2026-04-01). The new agent binds **vsock://2695** for gRPC + notifies the host via vsock://2696; nothing in the VM listens on TCP:2280, so libkrun's port-forward accepts the SYN and the guest end immediately RST's, timing out every `CREATE_BOX` 30 s in.

Production data from the live Tokyo runner:

```
$ sudo journalctl -u boxlite-runner --since "24 hours ago" | grep -E "CREATE_BOX|toolbox is ready|toolbox not ready"
CREATE_BOX events: 490
toolbox-ready ok:  0
toolbox-ready fail: 181
```

The exec request that fires immediately after CREATE_BOX (over the same vsock gRPC channel) **always succeeds** — confirming the box VM and the guest agent are healthy. The readiness probe itself is the bug.

## Test plan

| | Before | After |
|---|---|---|
| `make test:integration:*` (PyO3 / FFI path, bypasses the runner) | ✓ pass | ✓ pass (unchanged) |
| `go test ./pkg/boxlite/` | 4 tests, 2 of them assert against the dead HTTP probe | 2 tests (the dead two are deleted) |
| `go build ./...` + `go vet ./...` | ✓ | ✓ |
| Live Tokyo: `CREATE_BOX` for `docker.io/library/alpine:3.23` via e2e-cloud-test | always `box toolbox not ready after 30s` | expected to succeed (next dispatch on this branch) |
| `journalctl -u boxlite-runner` post-deploy | `toolbox not ready` per CREATE_BOX | no `toolbox` lines at all (probe gone) |

## Iteration plan (no full e2e-cloud needed)

1. Dispatch `Deploy Runner Binary` on this branch — rebuilds libboxlite.a + the runner Go binary and pushes via SSH+SCP.
2. Dispatch `Deploy API` on this branch (no-op if no API changes, just to make sure the LB/health side is fresh).
3. Dispatch `E2E test (Tokyo)` standalone — runs the pytest suite against the freshly-deployed runner.

That triple is ~30-40 min total vs running the full `e2e-cloud.yml` umbrella.

## Files

* `apps/runner/pkg/boxlite/client.go` — drop the two `waitForToolboxReady` call sites + the `toolboxReadyTimeout` field + plumbing.
* `apps/runner/pkg/boxlite/toolbox_ports.go` — delete `waitForToolboxReady`, drop now-unused `io / net/http / time` imports.
* `apps/runner/pkg/boxlite/toolbox_ports_test.go` — delete the two tests that asserted against the dead probe.
* `apps/runner/cmd/runner/main.go` — drop `ToolboxReadyTimeout: time.Duration(cfg.DaemonStartTimeoutSec) * time.Second`.
* `apps/runner/cmd/runner/config/config.go` — drop `DaemonStartTimeoutSec` env var.
