### PR TITLE
feat(box): image pipeline + single box identity (drop dual boxId)

### DIFF
--- a/apps/api-client-go/api/openapi.yaml
+++ b/apps/api-client-go/api/openapi.yaml
@@ -9565,8 +9565,7 @@ components:
           - member
           type: string
         assignedRoleIds:
-          default:
-          - 00000000-0000-0000-0000-000000000001
+          default: []
           description: Array of assigned role IDs
           items:
             type: string
@@ -9596,8 +9595,7 @@ components:
           - member
           type: string
         assignedRoleIds:
-          default:
-          - 00000000-0000-0000-0000-000000000001
+          default: []
           description: Array of assigned role IDs for the invitee
           items:
             type: string
@@ -9939,12 +9937,12 @@ components:
     Box:
       example:
         id: fd955d93-e74a-48e7-9f2d-fcbe6dd9e920
-        boxId: aB3cD4eF5gH6
         organizationId: organization123
         name: MyBox
         user: boxlite
         env:
           NODE_ENV: production
+        image: ghcr.io/boxlite-ai/boxlite-agent-python@sha256:80d562a57f4bc12def4e54dbdb9e7d26d3268fe0767a2955ab5ad718041145d6
         labels:
           boxlite.io/public: "true"
         public: false
@@ -9979,10 +9977,6 @@ components:
           description: The internal UUID of the box
           example: fd955d93-e74a-48e7-9f2d-fcbe6dd9e920
           type: string
-        boxId:
-          description: The public Box ID shown to users and SDK clients
-          example: aB3cD4eF5gH6
-          type: string
         organizationId:
           description: The organization ID of the box
           example: organization123
@@ -10002,6 +9996,10 @@ components:
           example:
             NODE_ENV: production
           type: object
+        image:
+          description: The OCI image ref the box boots from
+          example: ghcr.io/boxlite-ai/boxlite-agent-python@sha256:80d562a57f4bc12def4e54dbdb9e7d26d3268fe0767a2955ab5ad718041145d6
+          type: string
         labels:
           additionalProperties:
             type: string
@@ -10104,12 +10102,12 @@ components:
           example: https://proxy.app.boxlite.io/toolbox
           type: string
       required:
-      - boxId
       - cpu
       - disk
       - env
       - gpu
       - id
+      - image
       - labels
       - memory
       - name
@@ -10124,12 +10122,12 @@ components:
       example:
         items:
         - id: fd955d93-e74a-48e7-9f2d-fcbe6dd9e920
-          boxId: aB3cD4eF5gH6
           organizationId: organization123
           name: MyBox
           user: boxlite
           env:
             NODE_ENV: production
+          image: ghcr.io/boxlite-ai/boxlite-agent-python@sha256:80d562a57f4bc12def4e54dbdb9e7d26d3268fe0767a2955ab5ad718041145d6
           labels:
             boxlite.io/public: "true"
           public: false
@@ -10160,12 +10158,12 @@ components:
           runnerId: runner123
           toolboxProxyUrl: https://proxy.app.boxlite.io/toolbox
         - id: fd955d93-e74a-48e7-9f2d-fcbe6dd9e920
-          boxId: aB3cD4eF5gH6
           organizationId: organization123
           name: MyBox
           user: boxlite
           env:
             NODE_ENV: production
+          image: ghcr.io/boxlite-ai/boxlite-agent-python@sha256:80d562a57f4bc12def4e54dbdb9e7d26d3268fe0767a2955ab5ad718041145d6
           labels:
             boxlite.io/public: "true"
           public: false
@@ -12488,12 +12486,12 @@ components:
     Workspace:
       example:
         id: fd955d93-e74a-48e7-9f2d-fcbe6dd9e920
-        boxId: aB3cD4eF5gH6
         organizationId: organization123
         name: MyBox
         user: boxlite
         env:
           NODE_ENV: production
+        image: ghcr.io/boxlite-ai/boxlite-agent-python@sha256:80d562a57f4bc12def4e54dbdb9e7d26d3268fe0767a2955ab5ad718041145d6
         labels:
           boxlite.io/public: "true"
         public: false
@@ -12523,16 +12521,11 @@ components:
         daemonVersion: 1.0.0
         runnerId: runner123
         toolboxProxyUrl: https://proxy.app.boxlite.io/toolbox
-        image: boxlite-ai/workspace:latest
         info: ""
       properties:
         id:
           description: The internal UUID of the box
           example: fd955d93-e74a-48e7-9f2d-fcbe6dd9e920
-          type: string
-        boxId:
-          description: The public Box ID shown to users and SDK clients
-          example: aB3cD4eF5gH6
           type: string
         organizationId:
           description: The organization ID of the box
@@ -12553,6 +12546,10 @@ components:
           example:
             NODE_ENV: production
           type: object
+        image:
+          description: The OCI image ref the box boots from
+          example: ghcr.io/boxlite-ai/boxlite-agent-python@sha256:80d562a57f4bc12def4e54dbdb9e7d26d3268fe0767a2955ab5ad718041145d6
+          type: string
         labels:
           additionalProperties:
             type: string
@@ -12654,21 +12651,17 @@ components:
           description: The toolbox proxy URL for the box
           example: https://proxy.app.boxlite.io/toolbox
           type: string
-        image:
-          description: The image used for the workspace
-          example: boxlite-ai/workspace:latest
-          type: string
         info:
           allOf:
           - $ref: "#/components/schemas/BoxInfo"
           description: Additional information about the box
       required:
-      - boxId
       - cpu
       - disk
       - env
       - gpu
       - id
+      - image
       - labels
       - memory
       - name
@@ -13456,8 +13449,7 @@ components:
     AdminBoxItem:
       example:
         id: box_abc123
-        boxId: abc123XYZ
-        organizationId: org_xyz
+        organizationId: abc123XYZ
         state: started
         runnerId: runner-uuid
         cpu: 2
@@ -13474,13 +13466,9 @@ components:
           description: Box ID
           example: box_abc123
           type: string
-        boxId:
+        organizationId:
           description: Public box ID shown to users
           example: abc123XYZ
-          type: string
-        organizationId:
-          description: Organization ID
-          example: org_xyz
           type: string
         state:
           allOf:
@@ -13508,7 +13496,6 @@ components:
       - cpu
       - createdAt
       - id
-      - organizationId
       - owner
       - state
       type: object
@@ -14800,8 +14787,7 @@ components:
               value: 0.8008281904610115
         boxes:
         - id: box_abc123
-          boxId: abc123XYZ
-          organizationId: org_xyz
+          organizationId: abc123XYZ
           state: started
           runnerId: runner-uuid
           cpu: 2
@@ -14814,8 +14800,7 @@ components:
             orgName: Alice Personal
             personal: true
         - id: box_abc123
-          boxId: abc123XYZ
-          organizationId: org_xyz
+          organizationId: abc123XYZ
           state: started
           runnerId: runner-uuid
           cpu: 2

--- a/apps/api-client-go/model_admin_box_item.go
+++ b/apps/api-client-go/model_admin_box_item.go
@@ -24,9 +24,7 @@ type AdminBoxItem struct {
 	// Box ID
 	Id string `json:"id"`
 	// Public box ID shown to users
-	BoxId *string `json:"boxId,omitempty"`
-	// Organization ID
-	OrganizationId string `json:"organizationId"`
+	OrganizationId *string `json:"organizationId,omitempty"`
 	State BoxState `json:"state"`
 	// Runner ID the box is assigned to
 	RunnerId *string `json:"runnerId,omitempty"`
@@ -46,10 +44,9 @@ type _AdminBoxItem AdminBoxItem
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewAdminBoxItem(id string, organizationId string, state BoxState, cpu float32, createdAt string, owner AdminBoxOwner) *AdminBoxItem {
+func NewAdminBoxItem(id string, state BoxState, cpu float32, createdAt string, owner AdminBoxOwner) *AdminBoxItem {
 	this := AdminBoxItem{}
 	this.Id = id
-	this.OrganizationId = organizationId
 	this.State = state
 	this.Cpu = cpu
 	this.CreatedAt = createdAt
@@ -89,60 +86,36 @@ func (o *AdminBoxItem) SetId(v string) {
 	o.Id = v
 }
 
-// GetBoxId returns the BoxId field value if set, zero value otherwise.
-func (o *AdminBoxItem) GetBoxId() string {
-	if o == nil || IsNil(o.BoxId) {
+// GetOrganizationId returns the OrganizationId field value if set, zero value otherwise.
+func (o *AdminBoxItem) GetOrganizationId() string {
+	if o == nil || IsNil(o.OrganizationId) {
 		var ret string
 		return ret
 	}
-	return *o.BoxId
+	return *o.OrganizationId
 }
 
-// GetBoxIdOk returns a tuple with the BoxId field value if set, nil otherwise
+// GetOrganizationIdOk returns a tuple with the OrganizationId field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *AdminBoxItem) GetBoxIdOk() (*string, bool) {
-	if o == nil || IsNil(o.BoxId) {
+func (o *AdminBoxItem) GetOrganizationIdOk() (*string, bool) {
+	if o == nil || IsNil(o.OrganizationId) {
 		return nil, false
 	}
-	return o.BoxId, true
+	return o.OrganizationId, true
 }
 
-// HasBoxId returns a boolean if a field has been set.
-func (o *AdminBoxItem) HasBoxId() bool {
-	if o != nil && !IsNil(o.BoxId) {
+// HasOrganizationId returns a boolean if a field has been set.
+func (o *AdminBoxItem) HasOrganizationId() bool {
+	if o != nil && !IsNil(o.OrganizationId) {
 		return true
 	}
 
 	return false
 }
 
-// SetBoxId gets a reference to the given string and assigns it to the BoxId field.
-func (o *AdminBoxItem) SetBoxId(v string) {
-	o.BoxId = &v
-}
-
-// GetOrganizationId returns the OrganizationId field value
-func (o *AdminBoxItem) GetOrganizationId() string {
-	if o == nil {
-		var ret string
-		return ret
-	}
-
-	return o.OrganizationId
-}
-
-// GetOrganizationIdOk returns a tuple with the OrganizationId field value
-// and a boolean to check if the value has been set.
-func (o *AdminBoxItem) GetOrganizationIdOk() (*string, bool) {
-	if o == nil {
-		return nil, false
-	}
-	return &o.OrganizationId, true
-}
-
-// SetOrganizationId sets field value
+// SetOrganizationId gets a reference to the given string and assigns it to the OrganizationId field.
 func (o *AdminBoxItem) SetOrganizationId(v string) {
-	o.OrganizationId = v
+	o.OrganizationId = &v
 }
 
 // GetState returns the State field value
@@ -316,10 +289,9 @@ func (o AdminBoxItem) MarshalJSON() ([]byte, error) {
 func (o AdminBoxItem) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["id"] = o.Id
-	if !IsNil(o.BoxId) {
-		toSerialize["boxId"] = o.BoxId
+	if !IsNil(o.OrganizationId) {
+		toSerialize["organizationId"] = o.OrganizationId
 	}
-	toSerialize["organizationId"] = o.OrganizationId
 	toSerialize["state"] = o.State
 	if !IsNil(o.RunnerId) {
 		toSerialize["runnerId"] = o.RunnerId
@@ -344,7 +316,6 @@ func (o *AdminBoxItem) UnmarshalJSON(data []byte) (err error) {
 	// that every required field exists as a key in the generic map.
 	requiredProperties := []string{
 		"id",
-		"organizationId",
 		"state",
 		"cpu",
 		"createdAt",
@@ -379,7 +350,6 @@ func (o *AdminBoxItem) UnmarshalJSON(data []byte) (err error) {
 
 	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "id")
-		delete(additionalProperties, "boxId")
 		delete(additionalProperties, "organizationId")
 		delete(additionalProperties, "state")
 		delete(additionalProperties, "runnerId")

--- a/apps/api-client-go/model_box.go
+++ b/apps/api-client-go/model_box.go
@@ -23,8 +23,6 @@ var _ MappedNullable = &Box{}
 type Box struct {
 	// The internal UUID of the box
 	Id string `json:"id"`
-	// The public Box ID shown to users and SDK clients
-	BoxId string `json:"boxId"`
 	// The organization ID of the box
 	OrganizationId string `json:"organizationId"`
 	// The name of the box
@@ -33,6 +31,8 @@ type Box struct {
 	User string `json:"user"`
 	// Environment variables for the box
 	Env map[string]string `json:"env"`
+	// The OCI image ref the box boots from
+	Image string `json:"image"`
 	// Labels for the box
 	Labels map[string]string `json:"labels"`
 	// Whether the box http preview is public
@@ -87,14 +87,14 @@ type _Box Box
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewBox(id string, boxId string, organizationId string, name string, user string, env map[string]string, labels map[string]string, public bool, networkBlockAll bool, target string, cpu float32, gpu float32, memory float32, disk float32, toolboxProxyUrl string) *Box {
+func NewBox(id string, organizationId string, name string, user string, env map[string]string, image string, labels map[string]string, public bool, networkBlockAll bool, target string, cpu float32, gpu float32, memory float32, disk float32, toolboxProxyUrl string) *Box {
 	this := Box{}
 	this.Id = id
-	this.BoxId = boxId
 	this.OrganizationId = organizationId
 	this.Name = name
 	this.User = user
 	this.Env = env
+	this.Image = image
 	this.Labels = labels
 	this.Public = public
 	this.NetworkBlockAll = networkBlockAll
@@ -137,30 +137,6 @@ func (o *Box) GetIdOk() (*string, bool) {
 // SetId sets field value
 func (o *Box) SetId(v string) {
 	o.Id = v
-}
-
-// GetBoxId returns the BoxId field value
-func (o *Box) GetBoxId() string {
-	if o == nil {
-		var ret string
-		return ret
-	}
-
-	return o.BoxId
-}
-
-// GetBoxIdOk returns a tuple with the BoxId field value
-// and a boolean to check if the value has been set.
-func (o *Box) GetBoxIdOk() (*string, bool) {
-	if o == nil {
-		return nil, false
-	}
-	return &o.BoxId, true
-}
-
-// SetBoxId sets field value
-func (o *Box) SetBoxId(v string) {
-	o.BoxId = v
 }
 
 // GetOrganizationId returns the OrganizationId field value
@@ -257,6 +233,30 @@ func (o *Box) GetEnvOk() (*map[string]string, bool) {
 // SetEnv sets field value
 func (o *Box) SetEnv(v map[string]string) {
 	o.Env = v
+}
+
+// GetImage returns the Image field value
+func (o *Box) GetImage() string {
+	if o == nil {
+		var ret string
+		return ret
+	}
+
+	return o.Image
+}
+
+// GetImageOk returns a tuple with the Image field value
+// and a boolean to check if the value has been set.
+func (o *Box) GetImageOk() (*string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.Image, true
+}
+
+// SetImage sets field value
+func (o *Box) SetImage(v string) {
+	o.Image = v
 }
 
 // GetLabels returns the Labels field value
@@ -905,11 +905,11 @@ func (o Box) MarshalJSON() ([]byte, error) {
 func (o Box) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["id"] = o.Id
-	toSerialize["boxId"] = o.BoxId
 	toSerialize["organizationId"] = o.OrganizationId
 	toSerialize["name"] = o.Name
 	toSerialize["user"] = o.User
 	toSerialize["env"] = o.Env
+	toSerialize["image"] = o.Image
 	toSerialize["labels"] = o.Labels
 	toSerialize["public"] = o.Public
 	toSerialize["networkBlockAll"] = o.NetworkBlockAll
@@ -972,11 +972,11 @@ func (o *Box) UnmarshalJSON(data []byte) (err error) {
 	// that every required field exists as a key in the generic map.
 	requiredProperties := []string{
 		"id",
-		"boxId",
 		"organizationId",
 		"name",
 		"user",
 		"env",
+		"image",
 		"labels",
 		"public",
 		"networkBlockAll",
@@ -1016,11 +1016,11 @@ func (o *Box) UnmarshalJSON(data []byte) (err error) {
 
 	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "id")
-		delete(additionalProperties, "boxId")
 		delete(additionalProperties, "organizationId")
 		delete(additionalProperties, "name")
 		delete(additionalProperties, "user")
 		delete(additionalProperties, "env")
+		delete(additionalProperties, "image")
 		delete(additionalProperties, "labels")
 		delete(additionalProperties, "public")
 		delete(additionalProperties, "networkBlockAll")

--- a/apps/api-client-go/model_workspace.go
+++ b/apps/api-client-go/model_workspace.go
@@ -23,8 +23,6 @@ var _ MappedNullable = &Workspace{}
 type Workspace struct {
 	// The internal UUID of the box
 	Id string `json:"id"`
-	// The public Box ID shown to users and SDK clients
-	BoxId string `json:"boxId"`
 	// The organization ID of the box
 	OrganizationId string `json:"organizationId"`
 	// The name of the box
@@ -33,6 +31,8 @@ type Workspace struct {
 	User string `json:"user"`
 	// Environment variables for the box
 	Env map[string]string `json:"env"`
+	// The OCI image ref the box boots from
+	Image string `json:"image"`
 	// Labels for the box
 	Labels map[string]string `json:"labels"`
 	// Whether the box http preview is public
@@ -78,8 +78,6 @@ type Workspace struct {
 	RunnerId *string `json:"runnerId,omitempty"`
 	// The toolbox proxy URL for the box
 	ToolboxProxyUrl string `json:"toolboxProxyUrl"`
-	// The image used for the workspace
-	Image *string `json:"image,omitempty"`
 	// Additional information about the box
 	Info *BoxInfo `json:"info,omitempty"`
 	AdditionalProperties map[string]interface{}
@@ -91,14 +89,14 @@ type _Workspace Workspace
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewWorkspace(id string, boxId string, organizationId string, name string, user string, env map[string]string, labels map[string]string, public bool, networkBlockAll bool, target string, cpu float32, gpu float32, memory float32, disk float32, toolboxProxyUrl string) *Workspace {
+func NewWorkspace(id string, organizationId string, name string, user string, env map[string]string, image string, labels map[string]string, public bool, networkBlockAll bool, target string, cpu float32, gpu float32, memory float32, disk float32, toolboxProxyUrl string) *Workspace {
 	this := Workspace{}
 	this.Id = id
-	this.BoxId = boxId
 	this.OrganizationId = organizationId
 	this.Name = name
 	this.User = user
 	this.Env = env
+	this.Image = image
 	this.Labels = labels
 	this.Public = public
 	this.NetworkBlockAll = networkBlockAll
@@ -141,30 +139,6 @@ func (o *Workspace) GetIdOk() (*string, bool) {
 // SetId sets field value
 func (o *Workspace) SetId(v string) {
 	o.Id = v
-}
-
-// GetBoxId returns the BoxId field value
-func (o *Workspace) GetBoxId() string {
-	if o == nil {
-		var ret string
-		return ret
-	}
-
-	return o.BoxId
-}
-
-// GetBoxIdOk returns a tuple with the BoxId field value
-// and a boolean to check if the value has been set.
-func (o *Workspace) GetBoxIdOk() (*string, bool) {
-	if o == nil {
-		return nil, false
-	}
-	return &o.BoxId, true
-}
-
-// SetBoxId sets field value
-func (o *Workspace) SetBoxId(v string) {
-	o.BoxId = v
 }
 
 // GetOrganizationId returns the OrganizationId field value
@@ -261,6 +235,30 @@ func (o *Workspace) GetEnvOk() (*map[string]string, bool) {
 // SetEnv sets field value
 func (o *Workspace) SetEnv(v map[string]string) {
 	o.Env = v
+}
+
+// GetImage returns the Image field value
+func (o *Workspace) GetImage() string {
+	if o == nil {
+		var ret string
+		return ret
+	}
+
+	return o.Image
+}
+
+// GetImageOk returns a tuple with the Image field value
+// and a boolean to check if the value has been set.
+func (o *Workspace) GetImageOk() (*string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.Image, true
+}
+
+// SetImage sets field value
+func (o *Workspace) SetImage(v string) {
+	o.Image = v
 }
 
 // GetLabels returns the Labels field value
@@ -898,38 +896,6 @@ func (o *Workspace) SetToolboxProxyUrl(v string) {
 	o.ToolboxProxyUrl = v
 }
 
-// GetImage returns the Image field value if set, zero value otherwise.
-func (o *Workspace) GetImage() string {
-	if o == nil || IsNil(o.Image) {
-		var ret string
-		return ret
-	}
-	return *o.Image
-}
-
-// GetImageOk returns a tuple with the Image field value if set, nil otherwise
-// and a boolean to check if the value has been set.
-func (o *Workspace) GetImageOk() (*string, bool) {
-	if o == nil || IsNil(o.Image) {
-		return nil, false
-	}
-	return o.Image, true
-}
-
-// HasImage returns a boolean if a field has been set.
-func (o *Workspace) HasImage() bool {
-	if o != nil && !IsNil(o.Image) {
-		return true
-	}
-
-	return false
-}
-
-// SetImage gets a reference to the given string and assigns it to the Image field.
-func (o *Workspace) SetImage(v string) {
-	o.Image = &v
-}
-
 // GetInfo returns the Info field value if set, zero value otherwise.
 func (o *Workspace) GetInfo() BoxInfo {
 	if o == nil || IsNil(o.Info) {
@@ -973,11 +939,11 @@ func (o Workspace) MarshalJSON() ([]byte, error) {
 func (o Workspace) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["id"] = o.Id
-	toSerialize["boxId"] = o.BoxId
 	toSerialize["organizationId"] = o.OrganizationId
 	toSerialize["name"] = o.Name
 	toSerialize["user"] = o.User
 	toSerialize["env"] = o.Env
+	toSerialize["image"] = o.Image
 	toSerialize["labels"] = o.Labels
 	toSerialize["public"] = o.Public
 	toSerialize["networkBlockAll"] = o.NetworkBlockAll
@@ -1026,9 +992,6 @@ func (o Workspace) ToMap() (map[string]interface{}, error) {
 		toSerialize["runnerId"] = o.RunnerId
 	}
 	toSerialize["toolboxProxyUrl"] = o.ToolboxProxyUrl
-	if !IsNil(o.Image) {
-		toSerialize["image"] = o.Image
-	}
 	if !IsNil(o.Info) {
 		toSerialize["info"] = o.Info
 	}
@@ -1046,11 +1009,11 @@ func (o *Workspace) UnmarshalJSON(data []byte) (err error) {
 	// that every required field exists as a key in the generic map.
 	requiredProperties := []string{
 		"id",
-		"boxId",
 		"organizationId",
 		"name",
 		"user",
 		"env",
+		"image",
 		"labels",
 		"public",
 		"networkBlockAll",
@@ -1090,11 +1053,11 @@ func (o *Workspace) UnmarshalJSON(data []byte) (err error) {
 
 	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "id")
-		delete(additionalProperties, "boxId")
 		delete(additionalProperties, "organizationId")
 		delete(additionalProperties, "name")
 		delete(additionalProperties, "user")
 		delete(additionalProperties, "env")
+		delete(additionalProperties, "image")
 		delete(additionalProperties, "labels")
 		delete(additionalProperties, "public")
 		delete(additionalProperties, "networkBlockAll")
@@ -1117,7 +1080,6 @@ func (o *Workspace) UnmarshalJSON(data []byte) (err error) {
 		delete(additionalProperties, "daemonVersion")
 		delete(additionalProperties, "runnerId")
 		delete(additionalProperties, "toolboxProxyUrl")
-		delete(additionalProperties, "image")
 		delete(additionalProperties, "info")
 		o.AdditionalProperties = additionalProperties
 	}

--- a/apps/api/src/admin/dto/admin-overview.dto.ts
+++ b/apps/api/src/admin/dto/admin-overview.dto.ts
@@ -110,8 +110,6 @@ export class AdminBoxItemDto {
   id: string
 
   @ApiPropertyOptional({ description: 'Public box ID shown to users', example: 'abc123XYZ' })
-  boxId?: string
-
   @ApiProperty({ description: 'Organization ID', example: 'org_xyz' })
   organizationId: string
 

--- a/apps/api/src/admin/services/observability.service.spec.ts
+++ b/apps/api/src/admin/services/observability.service.spec.ts
@@ -398,7 +398,6 @@ describe('AdminObservabilityService', () => {
     overviewService.listBoxes.mockResolvedValue([
       {
         id: 'box-1',
-        boxId: 'public-box-1',
         organizationId: 'org-1',
         state: 'started',
         runnerId: 'runner-1',
@@ -408,7 +407,6 @@ describe('AdminObservabilityService', () => {
       },
       {
         id: 'box-2',
-        boxId: 'public-box-2',
         organizationId: 'org-1',
         state: 'started',
         runnerId: 'runner-2',
@@ -429,24 +427,23 @@ describe('AdminObservabilityService', () => {
     expect(result.correlation).toMatchObject({
       traceIds: ['trace-box-1'],
       orgIds: ['org-1'],
-      boxIds: ['box-1', 'public-box-1'],
+      boxIds: ['box-1'],
       runnerIds: ['runner-1'],
       machineIds: ['runner-1'],
       serviceNames: ['box-box-1'],
     })
     expect(result.boxes.map((box) => box.id)).toEqual(['box-1'])
-    expect(result.boxes.map((box) => box.boxId)).toEqual(['public-box-1'])
     expect(result.runners.map((runner) => runner.id)).toEqual(['runner-1'])
     expect(result.machines.map((machine) => machine.host)).toEqual(['runner-1'])
     expect(cloudWatchLogReader.getRelatedLogs).toHaveBeenCalledWith(
       expect.any(Object),
       expect.objectContaining({
-        boxIds: ['box-1', 'public-box-1'],
+        boxIds: ['box-1'],
       }),
     )
     expect(s3ObjectReader.listRelatedObjects).toHaveBeenCalledWith(
       expect.objectContaining({
-        boxIds: ['box-1', 'public-box-1'],
+        boxIds: ['box-1'],
       }),
     )
   })
@@ -479,7 +476,6 @@ describe('AdminObservabilityService', () => {
     overviewService.listBoxes.mockResolvedValue([
       {
         id: 'box-1',
-        boxId: 'public-box-1',
         organizationId: 'org-1',
         state: 'started',
         runnerId: 'runner-1',
@@ -592,8 +588,7 @@ describe('AdminObservabilityService', () => {
     })
     overviewService.listBoxes.mockResolvedValue([
       {
-        id: 'box-internal-1',
-        boxId: 'box-1',
+        id: 'box-1',
         organizationId: 'org-1',
         state: 'started',
         runnerId: 'runner-1',
@@ -675,7 +670,7 @@ describe('AdminObservabilityService', () => {
       traceIds: expect.arrayContaining(['trace-1']),
       orgIds: expect.arrayContaining(['org-1']),
       userIds: expect.arrayContaining(['user-1']),
-      boxIds: expect.arrayContaining(['box-1', 'box-internal-1']),
+      boxIds: expect.arrayContaining(['box-1']),
       runnerIds: expect.arrayContaining(['runner-1']),
       machineIds: expect.arrayContaining(['machine-1']),
       requestIds: expect.arrayContaining(['req-1']),
@@ -687,7 +682,7 @@ describe('AdminObservabilityService', () => {
     expect(result.traceSpans).toHaveLength(1)
     expect(result.logs).toHaveLength(2)
     expect(result.metrics.series).toHaveLength(1)
-    expect(result.boxes.map((box) => box.id)).toEqual(['box-internal-1'])
+    expect(result.boxes.map((box) => box.id)).toEqual(['box-1'])
     expect(result.runners.map((runner) => runner.id)).toEqual(['runner-1'])
     expect(result.machines.map((machine) => machine.host)).toEqual(['machine-1'])
     expect(result.auditLogs.map((log) => log.id)).toEqual(['audit-1'])
@@ -771,22 +766,22 @@ describe('AdminObservabilityService', () => {
     })
     expect(result.operations).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ id: 'recover:box-internal-1', state: 'disabled' }),
+        expect.objectContaining({ id: 'recover:box-1', state: 'disabled' }),
         expect.objectContaining({ id: 'cordon:runner-1', state: 'enabled' }),
         expect.objectContaining({ id: 'drain:runner-1', state: 'enabled' }),
-        expect.objectContaining({ id: 'resize:box-internal-1', state: 'request_only' }),
+        expect.objectContaining({ id: 'resize:box-1', state: 'request_only' }),
       ]),
     )
     expect(cloudWatchLogReader.getRelatedLogs).toHaveBeenCalledWith(
       expect.any(Object),
       expect.objectContaining({
         traceIds: ['trace-1'],
-        boxIds: ['box-1', 'box-internal-1'],
+        boxIds: ['box-1'],
       }),
     )
     expect(s3ObjectReader.listRelatedObjects).toHaveBeenCalledWith(
       expect.objectContaining({
-        boxIds: ['box-1', 'box-internal-1'],
+        boxIds: ['box-1'],
         executionIds: ['exec-1'],
       }),
     )
@@ -808,8 +803,7 @@ describe('AdminObservabilityService', () => {
 
     overviewService.listBoxes.mockResolvedValue([
       {
-        id: 'box-internal-1',
-        boxId: 'box-public-1',
+        id: 'box-1',
         organizationId: 'org-1',
         state: 'stopped',
         runnerId: 'runner-1',
@@ -830,20 +824,9 @@ describe('AdminObservabilityService', () => {
           organizationId: 'admin-org',
           action: 'read',
           targetType: 'observability',
-          targetId: 'boxId:box-public-1',
+          targetId: 'boxId:box-1',
           source: 'agent',
           createdAt: new Date('2026-06-05T00:00:02.000Z'),
-        },
-        {
-          id: 'audit-prefixed-box-internal',
-          actorId: 'agent-1',
-          actorEmail: 'agent@example.com',
-          organizationId: 'admin-org',
-          action: 'read',
-          targetType: 'observability',
-          targetId: 'boxId:box-internal-1',
-          source: 'agent',
-          createdAt: new Date('2026-06-05T00:00:03.000Z'),
         },
         {
           id: 'audit-other',
@@ -865,14 +848,14 @@ describe('AdminObservabilityService', () => {
     const result = await service.investigate({
       from: '2026-06-05T00:00:00.000Z',
       to: '2026-06-05T01:00:00.000Z',
-      boxId: 'box-public-1',
+      boxId: 'box-1',
       runnerId: 'runner-1',
       machineId: 'runner-1',
     })
 
-    expect(result.auditLogs.map((log) => log.id)).toEqual(['audit-prefixed-box', 'audit-prefixed-box-internal'])
+    expect(result.auditLogs.map((log) => log.id)).toEqual(['audit-prefixed-box'])
     expect(result.sources).toEqual(
-      expect.arrayContaining([expect.objectContaining({ source: 'audit', state: 'available', count: 2 })]),
+      expect.arrayContaining([expect.objectContaining({ source: 'audit', state: 'available', count: 1 })]),
     )
   })
 
@@ -886,8 +869,7 @@ describe('AdminObservabilityService', () => {
 
     overviewService.listBoxes.mockResolvedValue([
       {
-        id: 'box-internal-1',
-        boxId: 'box-1',
+        id: 'box-1',
         organizationId: 'org-1',
         state: 'started',
         runnerId: 'runner-1',
@@ -932,7 +914,7 @@ describe('AdminObservabilityService', () => {
       title: 'User user-1',
       identifiers: expect.objectContaining({ userId: 'user-1', orgId: 'org-1' }),
     })
-    expect(userResult.boxes.map((box) => box.id)).toEqual(['box-internal-1'])
+    expect(userResult.boxes.map((box) => box.id)).toEqual(['box-1'])
     expect(userResult.auditLogs.map((log) => log.id)).toEqual(['audit-user-actor'])
     expect(userResult.externalLinks.clickstack.query).toContain('boxlite.user_id')
     expect(userResult.commands.api).toContain('userId=user-1')

--- a/apps/api/src/admin/services/observability.service.ts
+++ b/apps/api/src/admin/services/observability.service.ts
@@ -626,7 +626,7 @@ export class AdminObservabilityService {
       return {
         ...base,
         type: 'box',
-        title: box.boxId ? `Box ${box.boxId}` : `Box ${box.id}`,
+        title: `Box ${box.id}`,
         subtitle: box.id,
         state: box.state,
         owner: box.owner?.email || box.owner?.name,
@@ -1519,7 +1519,6 @@ export class AdminObservabilityService {
       for (const box of boxes) {
         this.addUnique(correlation.orgIds, box.organizationId)
         this.addUnique(correlation.boxIds, box.id)
-        this.addUnique(correlation.boxIds, box.boxId)
         this.addUnique(correlation.runnerIds, box.runnerId)
       }
 
@@ -1676,7 +1675,7 @@ export class AdminObservabilityService {
   }
 
   private matchesBox(box: AdminBoxItemDto, correlation: AdminObservabilityCorrelationDto): boolean {
-    if (correlation.boxIds.includes(box.id) || (box.boxId && correlation.boxIds.includes(box.boxId))) {
+    if (correlation.boxIds.includes(box.id)) {
       return true
     }
 

--- a/apps/api/src/admin/services/overview.service.ts
+++ b/apps/api/src/admin/services/overview.service.ts
@@ -116,7 +116,6 @@ export class AdminOverviewService {
 
     return boxes.map((s) => ({
       id: s.id,
-      boxId: s.boxId,
       organizationId: s.organizationId,
       state: s.state,
       runnerId: s.runnerId,

--- a/apps/api/src/box/constants/curated-images.constant.spec.ts
+++ b/apps/api/src/box/constants/curated-images.constant.spec.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { BadRequestError } from '../../exceptions/bad-request.exception'
+import { assertSupportedImage, supportedImages } from './curated-images.constant'
+
+describe('supported image allowlist', () => {
+  const ENV_KEYS = ['BOXLITE_SYSTEM_BASE_IMAGE', 'BOXLITE_SYSTEM_PYTHON_IMAGE', 'BOXLITE_SYSTEM_NODE_IMAGE']
+  const saved: Record<string, string | undefined> = {}
+
+  beforeEach(() => {
+    // Isolate from the host env so the pinned fallback refs are deterministic.
+    for (const k of ENV_KEYS) {
+      saved[k] = process.env[k]
+      delete process.env[k]
+    }
+  })
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k]
+      else process.env[k] = saved[k]
+    }
+  })
+
+  it('exposes the three pinned ghcr refs, base first (the default)', () => {
+    const supported = supportedImages()
+    expect(supported).toHaveLength(3)
+    expect(supported[0]).toContain('ghcr.io/boxlite-ai/boxlite-agent-base@sha256:')
+    expect(supported[1]).toContain('ghcr.io/boxlite-ai/boxlite-agent-python@sha256:')
+    expect(supported[2]).toContain('ghcr.io/boxlite-ai/boxlite-agent-node@sha256:')
+  })
+
+  it('accepts each supported ref verbatim', () => {
+    for (const ref of supportedImages()) {
+      expect(assertSupportedImage(ref)).toBe(ref)
+    }
+  })
+
+  it('defaults to the base ref when no image is supplied', () => {
+    expect(assertSupportedImage(undefined)).toBe(supportedImages()[0])
+  })
+
+  it('prefers the env-configured ref over the pinned fallback', () => {
+    process.env.BOXLITE_SYSTEM_PYTHON_IMAGE = 'ghcr.io/boxlite-ai/override@sha256:deadbeef'
+    expect(assertSupportedImage('ghcr.io/boxlite-ai/override@sha256:deadbeef')).toBe(
+      'ghcr.io/boxlite-ai/override@sha256:deadbeef',
+    )
+  })
+
+  it('rejects anything outside the allowlist, naming the supported refs', () => {
+    expect(() => assertSupportedImage('alpine:3.23')).toThrow(BadRequestError)
+    expect(() => assertSupportedImage('ghcr.io/evil/image:latest')).toThrow(BadRequestError)
+    // legacy curated keys are no longer accepted -- only full refs are
+    expect(() => assertSupportedImage('python')).toThrow(BadRequestError)
+    expect(() => assertSupportedImage('nope')).toThrow(/Supported images: .*boxlite-agent-base/)
+  })
+})

--- a/apps/api/src/box/constants/curated-images.constant.ts
+++ b/apps/api/src/box/constants/curated-images.constant.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { BadRequestError } from '../../exceptions/bad-request.exception'
+
+/**
+ * Temporary curated-image gate: boxes may only boot from this fixed set of pinned OCI
+ * refs, because the runner pulls with its own private-registry token and must never be
+ * handed an arbitrary user-supplied image. The gate is deliberately thin and sits only
+ * at the request boundary (BoxService create / warm-pool); everything downstream treats
+ * `image` as an opaque OCI ref. When per-org custom images land, delete this file and
+ * its call sites — no other layer knows the curated set exists.
+ *
+ * Env overrides (set on the Api service in apps/infra/sst.config.ts) allow digest
+ * rotation without a code deploy; the fallbacks cover local/dev runs.
+ */
+const SUPPORTED_IMAGE_SOURCES: Array<{ envVar: string; fallbackRef: string }> = [
+  {
+    envVar: 'BOXLITE_SYSTEM_BASE_IMAGE',
+    fallbackRef:
+      'ghcr.io/boxlite-ai/boxlite-agent-base@sha256:834dcb65465985fc2f648451d76c81d166bc7672391c9064a0a115ce6306c85f',
+  },
+  {
+    envVar: 'BOXLITE_SYSTEM_PYTHON_IMAGE',
+    fallbackRef:
+      'ghcr.io/boxlite-ai/boxlite-agent-python@sha256:80d562a57f4bc12def4e54dbdb9e7d26d3268fe0767a2955ab5ad718041145d6',
+  },
+  {
+    envVar: 'BOXLITE_SYSTEM_NODE_IMAGE',
+    fallbackRef:
+      'ghcr.io/boxlite-ai/boxlite-agent-node@sha256:fcb8b840ab68567975853666c82fb6c59a3c1d14a0cdc31d7cbf3a01e6c6d247',
+  },
+]
+
+/** Pinned OCI refs a box may boot from. The first entry is the default image. */
+export function supportedImages(): string[] {
+  return SUPPORTED_IMAGE_SOURCES.map(({ envVar, fallbackRef }) => process.env[envVar] || fallbackRef)
+}
+
+/**
+ * Validate a user-supplied OCI ref at the request boundary. Undefined selects the
+ * default image; anything outside the supported set is rejected with the full list so
+ * callers can self-correct.
+ */
+export function assertSupportedImage(image: string | undefined): string {
+  const supported = supportedImages()
+
+  if (image === undefined) {
+    return supported[0]
+  }
+  if (!supported.includes(image)) {
+    throw new BadRequestError(`Unsupported image '${image}'. Supported images: ${supported.join(', ')}`)
+  }
+  return image
+}

--- a/apps/api/src/box/dto/box.dto.spec.ts
+++ b/apps/api/src/box/dto/box.dto.spec.ts
@@ -7,8 +7,8 @@
 import { Box } from '../entities/box.entity'
 import { BoxDto } from './box.dto'
 
-describe('BoxDto public identity', () => {
-  it('exposes the public boxId separately from the internal UUID', () => {
+describe('BoxDto identity', () => {
+  it('exposes the single box id', () => {
     const box = new Box('us', 'data-loader')
     box.organizationId = '057963b2-60ca-4356-81fc-11503e15f249'
     box.osUser = 'boxlite'
@@ -16,7 +16,6 @@ describe('BoxDto public identity', () => {
     const dto = BoxDto.fromBox(box, 'https://proxy.boxlite.dev/toolbox')
 
     expect(dto.id).toBe(box.id)
-    expect(dto.boxId).toBe(box.boxId)
-    expect(dto.boxId).not.toBe(box.id)
+    expect('boxId' in dto).toBe(false)
   })
 })

--- a/apps/api/src/box/dto/box.dto.ts
+++ b/apps/api/src/box/dto/box.dto.ts
@@ -42,12 +42,6 @@ export class BoxDto {
   id: string
 
   @ApiProperty({
-    description: 'The public Box ID shown to users and SDK clients',
-    example: 'aB3cD4eF5gH6',
-  })
-  boxId: string
-
-  @ApiProperty({
     description: 'The organization ID of the box',
     example: 'organization123',
   })
@@ -72,6 +66,13 @@ export class BoxDto {
     example: { NODE_ENV: 'production' },
   })
   env: Record<string, string>
+
+  @ApiProperty({
+    description: 'The OCI image ref the box boots from',
+    example:
+      'ghcr.io/boxlite-ai/boxlite-agent-python@sha256:80d562a57f4bc12def4e54dbdb9e7d26d3268fe0767a2955ab5ad718041145d6',
+  })
+  image: string
 
   @ApiProperty({
     description: 'Labels for the box',
@@ -244,12 +245,12 @@ export class BoxDto {
   static fromBox(box: Box, toolboxProxyUrl: string): BoxDto {
     return {
       id: box.id,
-      boxId: box.boxId,
       organizationId: box.organizationId,
       name: box.name,
       target: box.region,
       user: box.osUser,
       env: box.env,
+      image: box.image,
       cpu: box.cpu,
       gpu: box.gpu,
       memory: box.mem,

--- a/apps/api/src/box/dto/create-box.dto.ts
+++ b/apps/api/src/box/dto/create-box.dto.ts
@@ -20,6 +20,15 @@ export class CreateBoxDto {
   name?: string
 
   @ApiPropertyOptional({
+    description: 'OCI image ref to boot from. Must be one of the deployment-supported pinned refs.',
+    example:
+      'ghcr.io/boxlite-ai/boxlite-agent-python@sha256:80d562a57f4bc12def4e54dbdb9e7d26d3268fe0767a2955ab5ad718041145d6',
+  })
+  @IsOptional()
+  @IsString()
+  image?: string
+
+  @ApiPropertyOptional({
     description: 'The user associated with the project',
     example: 'boxlite',
   })

--- a/apps/api/src/box/dto/workspace.deprecated.dto.ts
+++ b/apps/api/src/box/dto/workspace.deprecated.dto.ts
@@ -37,12 +37,6 @@ export class BoxInfoDto {
 @ApiSchema({ name: 'Workspace' })
 export class WorkspaceDto extends BoxDto {
   @ApiPropertyOptional({
-    description: 'The image used for the workspace',
-    example: 'boxlite-ai/workspace:latest',
-  })
-  image: string
-
-  @ApiPropertyOptional({
     description: 'Additional information about the box',
     type: BoxInfoDto,
     required: false,

--- a/apps/api/src/box/entities/box.entity.spec.ts
+++ b/apps/api/src/box/entities/box.entity.spec.ts
@@ -7,14 +7,16 @@
 import { BOX_ID_LENGTH, BOX_ID_REGEX } from '../utils/box-id.util'
 import { Box } from './box.entity'
 
-describe('Box entity public identity', () => {
-  it('mints a 12-character public boxId separately from the internal UUID', () => {
+describe('Box entity identity', () => {
+  it('mints a single 12-character base62 id (no separate internal UUID)', () => {
     const box = new Box('us', 'data-loader')
 
-    expect(box.id).toBeDefined()
-    expect(box.boxId).toHaveLength(BOX_ID_LENGTH)
-    expect(box.boxId).toMatch(BOX_ID_REGEX)
-    expect(box.boxId).not.toBe(box.id)
+    expect(box.id).toHaveLength(BOX_ID_LENGTH)
+    expect(box.id).toMatch(BOX_ID_REGEX)
     expect(box.name).toBe('data-loader')
+  })
+
+  it('mints unique ids per box', () => {
+    expect(new Box('us').id).not.toBe(new Box('us').id)
   })
 })

--- a/apps/api/src/box/entities/box.entity.ts
+++ b/apps/api/src/box/entities/box.entity.ts
@@ -8,7 +8,6 @@ import { Column, CreateDateColumn, Entity, Index, PrimaryColumn, OneToOne, Uniqu
 import { BoxState } from '../enums/box-state.enum'
 import { BoxDesiredState } from '../enums/box-desired-state.enum'
 import { BoxClass } from '../enums/box-class.enum'
-import { randomUUID } from 'crypto'
 import { BoxVolume } from '../dto/box.dto'
 import { nanoid } from 'nanoid'
 import { BoxLastActivity } from './box-last-activity.entity'
@@ -16,13 +15,11 @@ import { BOX_ID_LENGTH, BOX_ID_REGEX, generateBoxId } from '../utils/box-id.util
 
 @Entity('box')
 @Unique(['organizationId', 'name'])
-@Index('box_boxid_unique_idx', ['boxId'], { unique: true })
 @Index('box_state_idx', ['state'])
 @Index('box_desiredstate_idx', ['desiredState'])
 @Index('box_runnerid_idx', ['runnerId'])
 @Index('box_runner_state_idx', ['runnerId', 'state'])
 @Index('box_organizationid_idx', ['organizationId'])
-@Index('box_organizationid_boxid_idx', ['organizationId', 'boxId'])
 @Index('box_region_idx', ['region'])
 @Index('box_resources_idx', ['cpu', 'mem', 'disk', 'gpu'])
 @Index('box_runner_state_desired_idx', ['runnerId', 'state', 'desiredState'], {
@@ -38,11 +35,10 @@ import { BOX_ID_LENGTH, BOX_ID_REGEX, generateBoxId } from '../utils/box-id.util
 @Index('box_labels_gin_full_idx', { synchronize: false })
 @Index('idx_box_volumes_gin', { synchronize: false })
 export class Box {
-  @PrimaryColumn({ default: () => 'uuid_generate_v4()' })
+  // Single box identity: a 12-char base62 public id, used as the primary key,
+  // in runner payloads, as the engine VM name, and in every user-facing surface.
+  @PrimaryColumn({ type: 'character varying', length: BOX_ID_LENGTH })
   id: string
-
-  @Column({ type: 'character varying', length: BOX_ID_LENGTH })
-  boxId: string = generateBoxId()
 
   @Column({
     type: 'uuid',
@@ -92,6 +88,11 @@ export class Box {
 
   @Column()
   osUser: string
+
+  // Full OCI ref the box boots from (validated against the supported-image allowlist
+  // at create time, then passed to the runner untranslated).
+  @Column()
+  image: string
 
   @Column({ nullable: true })
   errorReason?: string
@@ -169,7 +170,7 @@ export class Box {
   daemonVersion?: string
 
   constructor(region: string, name?: string) {
-    this.id = randomUUID()
+    this.id = generateBoxId()
     // Set name - use provided name or fallback to ID
     this.name = name || this.id
     this.region = region
@@ -195,8 +196,8 @@ export class Box {
   }
 
   private validateBoxId(): void {
-    if (!BOX_ID_REGEX.test(this.boxId)) {
-      throw new Error(`Box ${this.id} has invalid boxId ${this.boxId}`)
+    if (!BOX_ID_REGEX.test(this.id)) {
+      throw new Error(`Box has invalid id ${this.id}`)
     }
   }
 

--- a/apps/api/src/box/managers/box-actions/box-start.action.ts
+++ b/apps/api/src/box/managers/box-actions/box-start.action.ts
@@ -56,24 +56,20 @@ export class BoxStartAction extends BoxAction {
     return DONT_SYNC_AGAIN
   }
 
-  // TODO(image-rewrite): the box boot pipeline (image resolution, runner artifact scheduling,
-  // pull orchestration, and runner createBox) was removed with the box_template subsystem. Boxes
-  // can no longer be booted until the image resolution layer is rebuilt; this handler fails the
-  // box explicitly instead.
+  //  A freshly created box (UNKNOWN state, desired STARTED) boots from its image ref
+  //  (box.image, validated at create time). Enqueue a CREATE_BOX job and move to CREATING; the
+  //  job-completion path then drives CREATING -> STARTED.
   private async handleRunnerBoxUnknownStateOnDesiredStateStart(box: Box, lockCode: LockCode): Promise<SyncState> {
     const runner = await this.runnerService.findOneOrFail(box.runnerId)
     if (runner.state !== RunnerState.READY) {
       return DONT_SYNC_AGAIN
     }
 
-    await this.updateBoxState(
-      box,
-      BoxState.ERROR,
-      lockCode,
-      undefined,
-      'Box image resolution is unavailable: the image/template subsystem was removed',
-    )
-    return DONT_SYNC_AGAIN
+    const runnerAdapter = await this.runnerAdapterFactory.create(runner)
+    await runnerAdapter.createBox(box)
+
+    await this.updateBoxState(box, BoxState.CREATING, lockCode)
+    return SYNC_AGAIN
   }
 
   private async handleRunnerBoxStoppedStateOnDesiredStateStart(box: Box, lockCode: LockCode): Promise<SyncState> {

--- a/apps/api/src/box/repositories/box.repository.ts
+++ b/apps/api/src/box/repositories/box.repository.ts
@@ -186,7 +186,6 @@ export class BoxRepository extends BaseRepository<Box> {
     try {
       this.boxLookupCacheInvalidationService.invalidateOrgId({
         id: box.id,
-        boxId: box.boxId,
         organizationId: box.organizationId,
         name: box.name,
       })
@@ -202,15 +201,13 @@ export class BoxRepository extends BaseRepository<Box> {
    */
   private invalidateLookupCacheOnUpdate(
     updatedBox: Box,
-    previousBox: Pick<Box, 'organizationId' | 'boxId' | 'name' | 'authToken'>,
+    previousBox: Pick<Box, 'organizationId' | 'name' | 'authToken'>,
   ): void {
     try {
       this.boxLookupCacheInvalidationService.invalidate({
         id: updatedBox.id,
-        boxId: updatedBox.boxId,
         organizationId: updatedBox.organizationId,
         previousOrganizationId: previousBox.organizationId,
-        previousBoxId: previousBox.boxId,
         name: updatedBox.name,
         previousName: previousBox.name,
       })

--- a/apps/api/src/box/runner-adapter/runnerAdapter.ts
+++ b/apps/api/src/box/runner-adapter/runnerAdapter.ts
@@ -46,6 +46,7 @@ export interface RunnerAdapter {
   runnerInfo(signal?: AbortSignal): Promise<RunnerInfo>
 
   boxInfo(boxId: string): Promise<RunnerBoxInfo>
+  createBox(box: Box): Promise<void>
   startBox(
     boxId: string,
     authToken: string,

--- a/apps/api/src/box/runner-adapter/runnerAdapter.v0.ts
+++ b/apps/api/src/box/runner-adapter/runnerAdapter.v0.ts
@@ -144,6 +144,11 @@ export class RunnerAdapterV0 implements RunnerAdapter {
     }
   }
 
+  async createBox(_box: Box): Promise<void> {
+    // V0 (direct HTTP) create is out of MVP scope; only V2 (job-based) create is wired.
+    throw new Error('createBox is not supported for V0 runners')
+  }
+
   async startBox(
     boxId: string,
     authToken: string,

--- a/apps/api/src/box/runner-adapter/runnerAdapter.v2.createBox.spec.ts
+++ b/apps/api/src/box/runner-adapter/runnerAdapter.v2.createBox.spec.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+jest.mock('uuid', () => ({ v4: () => '00000000-0000-4000-8000-000000000000' }))
+
+import { Box } from '../entities/box.entity'
+import { JobType } from '../enums/job-type.enum'
+import { ResourceType } from '../enums/resource-type.enum'
+import { RunnerAdapterV2 } from './runnerAdapter.v2'
+
+function createAdapter(createJob: jest.Mock): RunnerAdapterV2 {
+  const adapter = Object.create(RunnerAdapterV2.prototype) as RunnerAdapterV2
+  ;(adapter as any).jobService = { createJob }
+  ;(adapter as any).runner = { id: 'runner-1' }
+  ;(adapter as any).logger = { debug: jest.fn() }
+  return adapter
+}
+
+describe('RunnerAdapterV2.createBox (CREATE_BOX job payload)', () => {
+  function buildBox(): Box {
+    const box = new Box('us', 'data-loader')
+    box.organizationId = '057963b2-60ca-4356-81fc-11503e15f249'
+    box.osUser = 'root'
+    box.image =
+      'ghcr.io/boxlite-ai/boxlite-agent-python@sha256:80d562a57f4bc12def4e54dbdb9e7d26d3268fe0767a2955ab5ad718041145d6'
+    box.cpu = 2
+    box.mem = 4
+    box.disk = 10
+    box.gpu = 0
+    return box
+  }
+
+  it('enqueues a CREATE_BOX / BOX job for the box on its runner', async () => {
+    const createJob = jest.fn().mockResolvedValue(undefined)
+    const adapter = createAdapter(createJob)
+    const box = buildBox()
+
+    await adapter.createBox(box)
+
+    expect(createJob).toHaveBeenCalledTimes(1)
+    const [, jobType, runnerId, resourceType, resourceId] = createJob.mock.calls[0]
+    expect(jobType).toBe(JobType.CREATE_BOX)
+    expect(resourceType).toBe(ResourceType.BOX)
+    expect(runnerId).toBe('runner-1')
+    expect(resourceId).toBe(box.id)
+  })
+
+  it('passes the box image ref through untranslated under `image` (Go validate:"required" trap)', async () => {
+    const createJob = jest.fn().mockResolvedValue(undefined)
+    const adapter = createAdapter(createJob)
+    const box = buildBox()
+
+    await adapter.createBox(box)
+
+    const payload = createJob.mock.calls[0][5] as Record<string, unknown>
+    // the payload carries box.image verbatim -- no curated-key translation layer
+    expect(payload.image).toBe(
+      'ghcr.io/boxlite-ai/boxlite-agent-python@sha256:80d562a57f4bc12def4e54dbdb9e7d26d3268fe0767a2955ab5ad718041145d6',
+    )
+    expect('snapshot' in payload).toBe(false)
+    expect('artifactRef' in payload).toBe(false)
+    expect('ociImageRef' in payload).toBe(false)
+    // resources must reach the runner so the VM is sized correctly
+    expect(payload.cpuQuota).toBe(2)
+    expect(payload.memoryQuota).toBe(4)
+    expect(payload.storageQuota).toBe(10)
+  })
+
+  it('sends the single box id (12-char base62, also the engine VM name)', async () => {
+    const createJob = jest.fn().mockResolvedValue(undefined)
+    const adapter = createAdapter(createJob)
+    const box = buildBox()
+
+    await adapter.createBox(box)
+
+    const payload = createJob.mock.calls[0][5] as Record<string, unknown>
+    expect(payload.id).toBe(box.id)
+    expect(payload.id).toMatch(/^[0-9A-Za-z]{12}$/)
+    expect('boxId' in payload).toBe(false)
+  })
+})

--- a/apps/api/src/box/runner-adapter/runnerAdapter.v2.ts
+++ b/apps/api/src/box/runner-adapter/runnerAdapter.v2.ts
@@ -114,6 +114,30 @@ export class RunnerAdapterV2 implements RunnerAdapter {
     }
   }
 
+  async createBox(box: Box): Promise<void> {
+    // Hand-built payload: keys MUST match the Go dto.CreateBoxDTO json tags
+    // (apps/runner/pkg/api/dto/box.go). `id` is the box's single identity: the
+    // 12-char public id, which the runner also uses as the engine VM name.
+    const payload = {
+      id: box.id,
+      userId: box.organizationId,
+      image: box.image,
+      osUser: box.osUser,
+      cpuQuota: box.cpu,
+      memoryQuota: box.mem,
+      storageQuota: box.disk,
+      env: box.env,
+      networkBlockAll: box.networkBlockAll,
+      networkAllowList: box.networkAllowList,
+      organizationId: box.organizationId,
+      regionId: box.region,
+    }
+
+    await this.jobService.createJob(null, JobType.CREATE_BOX, this.runner.id, ResourceType.BOX, box.id, payload)
+
+    this.logger.debug(`Created CREATE_BOX job for box ${box.id} on runner ${this.runner.id}`)
+  }
+
   async startBox(
     boxId: string,
     authToken: string,

--- a/apps/api/src/box/services/box-lookup-cache-invalidation.service.ts
+++ b/apps/api/src/box/services/box-lookup-cache-invalidation.service.ts
@@ -8,10 +8,8 @@ import { Injectable, Logger } from '@nestjs/common'
 import { DataSource } from 'typeorm'
 import {
   boxLookupCacheKeyByAuthToken,
-  boxLookupCacheKeyByBoxId,
   boxLookupCacheKeyById,
   boxLookupCacheKeyByName,
-  boxOrgIdCacheKeyByBoxId,
   boxOrgIdCacheKeyById,
   boxOrgIdCacheKeyByName,
 } from '../utils/box-lookup-cache.util'
@@ -19,11 +17,9 @@ import {
 type InvalidateBoxLookupCacheArgs =
   | {
       id: string
-      boxId: string
       organizationId: string
       name: string
       previousOrganizationId?: string | null
-      previousBoxId?: string | null
       previousName?: string | null
     }
   | {
@@ -64,9 +60,6 @@ export class BoxLookupCacheInvalidationService {
     const names = Array.from(
       new Set([args.name, args.previousName].filter((n): n is string => Boolean(n && n.trim().length > 0))),
     )
-    const boxIds = Array.from(
-      new Set([args.boxId, args.previousBoxId].filter((id): id is string => Boolean(id && id.trim().length > 0))),
-    )
 
     const cacheIds: string[] = []
     for (const organizationId of organizationIds) {
@@ -78,15 +71,6 @@ export class BoxLookupCacheInvalidationService {
             boxId: args.id,
           }),
         )
-        for (const boxId of boxIds) {
-          cacheIds.push(
-            boxLookupCacheKeyByBoxId({
-              organizationId,
-              returnDestroyed,
-              boxId,
-            }),
-          )
-        }
         for (const boxName of names) {
           cacheIds.push(
             boxLookupCacheKeyByName({
@@ -105,21 +89,19 @@ export class BoxLookupCacheInvalidationService {
 
     cache
       .remove(cacheIds)
-      .then(() => this.logger.debug(`Invalidated box lookup cache for ${args.boxId}`))
+      .then(() => this.logger.debug(`Invalidated box lookup cache for ${args.id}`))
       .catch((error) =>
         this.logger.warn(
-          `Failed to invalidate box lookup cache for ${args.boxId}: ${error instanceof Error ? error.message : String(error)}`,
+          `Failed to invalidate box lookup cache for ${args.id}: ${error instanceof Error ? error.message : String(error)}`,
         ),
       )
   }
 
   invalidateOrgId(args: {
     id: string
-    boxId: string
     organizationId: string
     name: string
     previousOrganizationId?: string | null
-    previousBoxId?: string | null
     previousName?: string | null
   }): void {
     const cache = this.dataSource.queryResultCache
@@ -137,9 +119,6 @@ export class BoxLookupCacheInvalidationService {
     const names = Array.from(
       new Set([args.name, args.previousName].filter((n): n is string => Boolean(n && n.trim().length > 0))),
     )
-    const boxIds = Array.from(
-      new Set([args.boxId, args.previousBoxId].filter((id): id is string => Boolean(id && id.trim().length > 0))),
-    )
 
     const cacheIds: string[] = []
     for (const organizationId of organizationIds) {
@@ -149,14 +128,6 @@ export class BoxLookupCacheInvalidationService {
           boxId: args.id,
         }),
       )
-      for (const boxId of boxIds) {
-        cacheIds.push(
-          boxOrgIdCacheKeyByBoxId({
-            organizationId,
-            boxId,
-          }),
-        )
-      }
       for (const boxName of names) {
         cacheIds.push(
           boxOrgIdCacheKeyByName({
@@ -169,19 +140,16 @@ export class BoxLookupCacheInvalidationService {
 
     // Also invalidate the "no org" variants (when organizationId was not provided to getOrganizationId)
     cacheIds.push(boxOrgIdCacheKeyById({ boxId: args.id }))
-    for (const boxId of boxIds) {
-      cacheIds.push(boxOrgIdCacheKeyByBoxId({ boxId }))
-    }
     for (const boxName of names) {
       cacheIds.push(boxOrgIdCacheKeyByName({ boxName }))
     }
 
     cache
       .remove(cacheIds)
-      .then(() => this.logger.debug(`Invalidated box orgId cache for ${args.boxId}`))
+      .then(() => this.logger.debug(`Invalidated box orgId cache for ${args.id}`))
       .catch((error) =>
         this.logger.warn(
-          `Failed to invalidate box orgId cache for ${args.boxId}: ${error instanceof Error ? error.message : String(error)}`,
+          `Failed to invalidate box orgId cache for ${args.id}: ${error instanceof Error ? error.message : String(error)}`,
         ),
       )
   }

--- a/apps/api/src/box/services/box.service.box-id.spec.ts
+++ b/apps/api/src/box/services/box.service.box-id.spec.ts
@@ -17,8 +17,8 @@ function createService(findOne: jest.Mock): BoxService {
   return service
 }
 
-describe('BoxService public identity lookup', () => {
-  it('resolves the public boxId before falling back to the internal UUID or name', async () => {
+describe('BoxService identity lookup', () => {
+  it('resolves the box by its single id in one query, falling back to name only', async () => {
     const organizationId = '057963b2-60ca-4356-81fc-11503e15f249'
     const box = new Box('us', 'data-loader')
     box.organizationId = organizationId
@@ -26,13 +26,13 @@ describe('BoxService public identity lookup', () => {
     const findOne = jest.fn().mockResolvedValueOnce(box)
     const service = createService(findOne)
 
-    await expect(service.findOneByIdOrName(box.boxId, organizationId)).resolves.toBe(box)
+    await expect(service.findOneByIdOrName(box.id, organizationId)).resolves.toBe(box)
 
     expect(findOne).toHaveBeenCalledTimes(1)
     expect(findOne).toHaveBeenCalledWith(
       expect.objectContaining({
         where: {
-          boxId: box.boxId,
+          id: box.id,
           organizationId,
           state: Not(BoxState.DESTROYED),
         },

--- a/apps/api/src/box/services/box.service.ts
+++ b/apps/api/src/box/services/box.service.ts
@@ -18,6 +18,7 @@ import { BoxError } from '../../exceptions/box-error.exception'
 import { BadRequestError } from '../../exceptions/bad-request.exception'
 import { Cron, CronExpression } from '@nestjs/schedule'
 import { BOX_WARM_POOL_UNASSIGNED_ORGANIZATION } from '../constants/box.constants'
+import { assertSupportedImage } from '../constants/curated-images.constant'
 import { BoxWarmPoolService } from './box-warm-pool.service'
 import { EventEmitter2, OnEvent } from '@nestjs/event-emitter'
 import { WarmPoolEvents } from '../constants/warmpool-events.constants'
@@ -63,10 +64,8 @@ import {
   BOX_LOOKUP_CACHE_TTL_MS,
   BOX_ORG_ID_CACHE_TTL_MS,
   TOOLBOX_PROXY_URL_CACHE_TTL_S,
-  boxLookupCacheKeyByBoxId,
   boxLookupCacheKeyById,
   boxLookupCacheKeyByName,
-  boxOrgIdCacheKeyByBoxId,
   boxOrgIdCacheKeyById,
   boxOrgIdCacheKeyByName,
   toolboxProxyUrlCacheKey,
@@ -131,7 +130,9 @@ export class BoxService {
     box.mem = warmPoolItem.mem
     box.disk = warmPoolItem.disk
 
-    // TODO(image-rewrite): box image/artifact resolution removed with box_template; rebuild here.
+    // Warm-pool boxes have no per-request image; they boot from the default supported image.
+    box.image = assertSupportedImage(undefined)
+
     const runner = await this.runnerService.getRandomAvailableRunner({
       regions: [box.region],
       boxClass: box.class,
@@ -150,13 +151,17 @@ export class BoxService {
     try {
       const boxClass = this.getValidatedOrDefaultClass(createBoxDto.class)
 
-      // TODO(image-rewrite): box_template lookup + artifact resolution removed; boxes can no
-      // longer resolve an image at create time. Resource sizing falls back to request values
-      // (or Box entity defaults). Rebuild image/template resolution here.
+      // TODO(image-rewrite): box_template-based resource sizing removed; sizing falls back to
+      // request values (or Box entity defaults). Image resolution itself is handled below via
+      // the curated-image allowlist.
       const cpu = createBoxDto.cpu ?? DEFAULT_BOX_CPU
       const mem = createBoxDto.memory ?? DEFAULT_BOX_MEM
       const disk = createBoxDto.disk ?? DEFAULT_BOX_DISK
       const gpu = createBoxDto.gpu ?? DEFAULT_BOX_GPU
+
+      // Reject any image outside the supported allowlist at the request boundary. The full
+      // OCI ref is persisted and flows to the runner untranslated.
+      const image = assertSupportedImage(createBoxDto.image)
 
       this.organizationService.assertOrganizationIsNotSuspended(organization)
 
@@ -180,6 +185,7 @@ export class BoxService {
       //  TODO: default user should be configurable
       box.osUser = createBoxDto.user || 'boxlite'
       box.env = createBoxDto.env || {}
+      box.image = image
       box.labels = createBoxDto.labels || {}
 
       box.cpu = cpu
@@ -292,7 +298,6 @@ export class BoxService {
     // Defensive invalidation of orgId cache since the box moved from unassigned to a real organization
     this.boxLookupCacheInvalidationService.invalidateOrgId({
       id: warmPoolBox.id,
-      boxId: warmPoolBox.boxId,
       organizationId: organization.id,
       name: warmPoolBox.name,
       previousOrganizationId: BOX_WARM_POOL_UNASSIGNED_ORGANIZATION,
@@ -460,11 +465,6 @@ export class BoxService {
       {
         ...baseFindOptions,
         ...nameFilter,
-        boxId: idFilter,
-      },
-      {
-        ...baseFindOptions,
-        ...nameFilter,
         id: idFilter,
       },
       {
@@ -520,32 +520,18 @@ export class BoxService {
     const stateFilter = returnDestroyed ? {} : { state: Not(BoxState.DESTROYED) }
     const organizationFilter = organizationId ? { organizationId } : {}
 
-    // Public Box ID is the user-facing stable identity. UUID and name are legacy-compatible fallbacks.
+    // The 12-char public box id IS the primary key; name is a legacy-compatible fallback.
     let box = await this.boxRepository.findOne({
       where: {
-        boxId: boxIdOrName,
+        id: boxIdOrName,
         ...organizationFilter,
         ...stateFilter,
       },
       cache: {
-        id: boxLookupCacheKeyByBoxId({ organizationId, returnDestroyed, boxId: boxIdOrName }),
+        id: boxLookupCacheKeyById({ organizationId, returnDestroyed, boxId: boxIdOrName }),
         milliseconds: BOX_LOOKUP_CACHE_TTL_MS,
       },
     })
-
-    if (!box) {
-      box = await this.boxRepository.findOne({
-        where: {
-          id: boxIdOrName,
-          ...organizationFilter,
-          ...stateFilter,
-        },
-        cache: {
-          id: boxLookupCacheKeyById({ organizationId, returnDestroyed, boxId: boxIdOrName }),
-          milliseconds: BOX_LOOKUP_CACHE_TTL_MS,
-        },
-      })
-    }
 
     if (!box) {
       box = await this.boxRepository.findOne({
@@ -562,7 +548,7 @@ export class BoxService {
     }
 
     if (!box || (!returnDestroyed && box.state === BoxState.ERROR && box.desiredState === BoxDesiredState.DESTROYED)) {
-      throw new NotFoundException(`Box with Box ID, UUID, or name ${boxIdOrName} not found`)
+      throw new NotFoundException(`Box with ID or name ${boxIdOrName} not found`)
     }
 
     return box
@@ -588,29 +574,15 @@ export class BoxService {
 
     let box = await this.boxRepository.findOne({
       where: {
-        boxId: boxIdOrName,
+        id: boxIdOrName,
         ...organizationFilter,
       },
       select: ['organizationId'],
       cache: {
-        id: boxOrgIdCacheKeyByBoxId({ organizationId, boxId: boxIdOrName }),
+        id: boxOrgIdCacheKeyById({ organizationId, boxId: boxIdOrName }),
         milliseconds: BOX_ORG_ID_CACHE_TTL_MS,
       },
     })
-
-    if (!box) {
-      box = await this.boxRepository.findOne({
-        where: {
-          id: boxIdOrName,
-          ...organizationFilter,
-        },
-        select: ['organizationId'],
-        cache: {
-          id: boxOrgIdCacheKeyById({ organizationId, boxId: boxIdOrName }),
-          milliseconds: BOX_ORG_ID_CACHE_TTL_MS,
-        },
-      })
-    }
 
     if (!box && organizationId) {
       box = await this.boxRepository.findOne({
@@ -627,7 +599,7 @@ export class BoxService {
     }
 
     if (!box || !box.organizationId) {
-      throw new NotFoundException(`Box with Box ID, UUID, or name ${boxIdOrName} not found`)
+      throw new NotFoundException(`Box with ID or name ${boxIdOrName} not found`)
     }
 
     return box.organizationId
@@ -635,13 +607,13 @@ export class BoxService {
 
   async getRunnerId(boxIdOrName: string): Promise<string | null> {
     const box = await this.boxRepository.findOne({
-      where: [{ boxId: boxIdOrName }, { id: boxIdOrName }, { name: boxIdOrName }],
+      where: [{ id: boxIdOrName }, { name: boxIdOrName }],
       select: ['runnerId'],
       loadEagerRelations: false,
     })
 
     if (!box) {
-      throw new NotFoundException(`Box with Box ID, UUID, or name ${boxIdOrName} not found`)
+      throw new NotFoundException(`Box with ID or name ${boxIdOrName} not found`)
     }
 
     return box.runnerId || null
@@ -649,13 +621,13 @@ export class BoxService {
 
   async getRegionId(boxIdOrName: string): Promise<string> {
     const box = await this.boxRepository.findOne({
-      where: [{ boxId: boxIdOrName }, { id: boxIdOrName }, { name: boxIdOrName }],
+      where: [{ id: boxIdOrName }, { name: boxIdOrName }],
       select: ['region'],
       loadEagerRelations: false,
     })
 
     if (!box) {
-      throw new NotFoundException(`Box with Box ID, UUID, or name ${boxIdOrName} not found`)
+      throw new NotFoundException(`Box with ID or name ${boxIdOrName} not found`)
     }
 
     return box.region

--- a/apps/api/src/box/services/box.service.warm-pool.spec.ts
+++ b/apps/api/src/box/services/box.service.warm-pool.spec.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { BoxService } from './box.service'
+import { BoxClass } from '../enums/box-class.enum'
+import { WarmPool } from '../entities/warm-pool.entity'
+
+function warmPoolItem(): WarmPool {
+  const item = new WarmPool()
+  item.target = 'us'
+  item.class = BoxClass.SMALL
+  item.cpu = 1
+  item.gpu = 0
+  item.mem = 1
+  item.disk = 3
+  item.env = {}
+  return item
+}
+
+describe('BoxService.createForWarmPool image', () => {
+  // Isolate from env-configured curated refs so the pinned fallback is deterministic;
+  // otherwise BOXLITE_SYSTEM_BASE_IMAGE in the host env would make this assertion flaky.
+  const ENV_KEYS = ['BOXLITE_SYSTEM_BASE_IMAGE', 'BOXLITE_SYSTEM_PYTHON_IMAGE', 'BOXLITE_SYSTEM_NODE_IMAGE']
+  const saved: Record<string, string | undefined> = {}
+  beforeEach(() => {
+    for (const k of ENV_KEYS) {
+      saved[k] = process.env[k]
+      delete process.env[k]
+    }
+  })
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k]
+      else process.env[k] = saved[k]
+    }
+  })
+
+  it('defaults warm-pool boxes to the base image ref so they can boot', async () => {
+    const insert = jest.fn().mockResolvedValue(undefined)
+    const getRandomAvailableRunner = jest.fn().mockResolvedValue({ id: 'runner-1' })
+
+    const service = Object.create(BoxService.prototype) as BoxService
+    ;(service as any).boxRepository = { insert }
+    ;(service as any).runnerService = { getRandomAvailableRunner }
+
+    const box = await service.createForWarmPool(warmPoolItem())
+
+    expect(box.image).toBe(
+      'ghcr.io/boxlite-ai/boxlite-agent-base@sha256:834dcb65465985fc2f648451d76c81d166bc7672391c9064a0a115ce6306c85f',
+    )
+    expect(insert).toHaveBeenCalledWith(box)
+  })
+})

--- a/apps/api/src/box/utils/box-id.util.ts
+++ b/apps/api/src/box/utils/box-id.util.ts
@@ -17,7 +17,3 @@ export function generateBoxId(): string {
   }
   return boxId
 }
-
-export function isBoxId(value: string): boolean {
-  return BOX_ID_REGEX.test(value)
-}

--- a/apps/api/src/box/utils/box-lookup-cache.util.ts
+++ b/apps/api/src/box/utils/box-lookup-cache.util.ts
@@ -18,12 +18,6 @@ export function boxLookupCacheKeyById(args: BoxLookupCacheKeyArgs & { boxId: str
   return `box:lookup:by-id:org:${organizationId}:returnDestroyed:${returnDestroyed}:value:${args.boxId}`
 }
 
-export function boxLookupCacheKeyByBoxId(args: BoxLookupCacheKeyArgs & { boxId: string }): string {
-  const organizationId = args.organizationId ?? 'none'
-  const returnDestroyed = args.returnDestroyed ? 1 : 0
-  return `box:lookup:by-box-id:org:${organizationId}:returnDestroyed:${returnDestroyed}:value:${args.boxId}`
-}
-
 export function boxLookupCacheKeyByName(args: BoxLookupCacheKeyArgs & { boxName: string }): string {
   const organizationId = args.organizationId ?? 'none'
   const returnDestroyed = args.returnDestroyed ? 1 : 0
@@ -41,11 +35,6 @@ type BoxOrgIdCacheKeyArgs = {
 export function boxOrgIdCacheKeyById(args: BoxOrgIdCacheKeyArgs & { boxId: string }): string {
   const organizationId = args.organizationId ?? 'none'
   return `box:orgId:by-id:org:${organizationId}:value:${args.boxId}`
-}
-
-export function boxOrgIdCacheKeyByBoxId(args: BoxOrgIdCacheKeyArgs & { boxId: string }): string {
-  const organizationId = args.organizationId ?? 'none'
-  return `box:orgId:by-box-id:org:${organizationId}:value:${args.boxId}`
 }
 
 export function boxOrgIdCacheKeyByName(args: BoxOrgIdCacheKeyArgs & { boxName: string }): string {

--- a/apps/api/src/boxlite-rest/mappers/box-to-box.mapper.spec.ts
+++ b/apps/api/src/boxlite-rest/mappers/box-to-box.mapper.spec.ts
@@ -8,10 +8,9 @@ import { BoxDto } from '../../box/dto/box.dto'
 import { boxToBoxResponse, createBoxToCreateBox } from './box-to-box.mapper'
 
 describe('box-to-box mapper', () => {
-  it('maps REST box_id from the public box boxId instead of the internal UUID', () => {
+  it('maps REST box_id from the single box id', () => {
     const response = boxToBoxResponse({
-      id: 'fd955d93-e74a-48e7-9f2d-fcbe6dd9e920',
-      boxId: 'aB3cD4eF5gH6',
+      id: 'aB3cD4eF5gH6',
       organizationId: '057963b2-60ca-4356-81fc-11503e15f249',
       name: 'data-loader',
       state: 'started',
@@ -44,5 +43,29 @@ describe('box-to-box mapper', () => {
     expect(dto.cpu).toBe(2)
     expect(dto.memory).toBe(2)
     expect(dto.disk).toBe(8)
+  })
+
+  it('threads the image ref from the REST request into the internal create dto', () => {
+    const dto = createBoxToCreateBox({
+      image:
+        'ghcr.io/boxlite-ai/boxlite-agent-python@sha256:80d562a57f4bc12def4e54dbdb9e7d26d3268fe0767a2955ab5ad718041145d6',
+    })
+
+    expect(dto.image).toBe(
+      'ghcr.io/boxlite-ai/boxlite-agent-python@sha256:80d562a57f4bc12def4e54dbdb9e7d26d3268fe0767a2955ab5ad718041145d6',
+    )
+  })
+
+  it('echoes the image ref stored on the box', () => {
+    const response = boxToBoxResponse({
+      state: 'started',
+      image:
+        'ghcr.io/boxlite-ai/boxlite-agent-node@sha256:fcb8b840ab68567975853666c82fb6c59a3c1d14a0cdc31d7cbf3a01e6c6d247',
+      labels: {},
+    } as unknown as BoxDto)
+
+    expect(response.image).toBe(
+      'ghcr.io/boxlite-ai/boxlite-agent-node@sha256:fcb8b840ab68567975853666c82fb6c59a3c1d14a0cdc31d7cbf3a01e6c6d247',
+    )
   })
 })

--- a/apps/api/src/boxlite-rest/mappers/box-to-box.mapper.ts
+++ b/apps/api/src/boxlite-rest/mappers/box-to-box.mapper.ts
@@ -12,12 +12,12 @@ import { CreateBoxDto } from '../../box/dto/create-box.dto'
 
 export function boxToBoxResponse(box: BoxDto): BoxResponseDto {
   return {
-    box_id: box.boxId,
+    box_id: box.id,
     name: box.name,
     status: mapState(box.state),
     created_at: box.createdAt || new Date().toISOString(),
     updated_at: box.updatedAt || new Date().toISOString(),
-    image: '',
+    image: box.image,
     cpus: box.cpu || 1,
     memory_mib: (box.memory || 1) * 1024,
     labels: box.labels || {},
@@ -27,6 +27,7 @@ export function boxToBoxResponse(box: BoxDto): BoxResponseDto {
 export function createBoxToCreateBox(dto: RestCreateBoxDto, target?: string): CreateBoxDto {
   const createDto = new CreateBoxDto()
   createDto.name = dto.name
+  createDto.image = dto.image
   createDto.user = dto.user
   createDto.env = dto.env
   createDto.cpu = dto.cpus

--- a/apps/api/src/migrations/1741087887225-migration.ts
+++ b/apps/api/src/migrations/1741087887225-migration.ts
@@ -70,7 +70,7 @@ export class Migration1741087887225 implements MigrationInterface {
       `CREATE TABLE "warm_pool" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "pool" integer NOT NULL, "savedImage" character varying NOT NULL, "target" character varying NOT NULL, "cpu" integer NOT NULL, "mem" integer NOT NULL, "disk" integer NOT NULL, "gpu" integer NOT NULL, "gpuType" character varying NOT NULL, "class" "public"."warm_pool_class_enum" NOT NULL DEFAULT 'small', "osUser" character varying NOT NULL, "errorReason" character varying, "env" text NOT NULL DEFAULT '{}', "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), CONSTRAINT "warm_pool_id_pk" PRIMARY KEY ("id"))`,
     )
     await queryRunner.query(
-      `CREATE TABLE "box" ("id" character varying NOT NULL DEFAULT uuid_generate_v4(), "boxId" character varying(12) NOT NULL, "organizationId" uuid NOT NULL, "name" character varying NOT NULL, "region" character varying NOT NULL, "runnerId" uuid, "prevRunnerId" uuid, "class" "public"."box_class_enum" NOT NULL DEFAULT 'small', "state" "public"."box_state_enum" NOT NULL DEFAULT 'unknown', "desiredState" "public"."box_desiredstate_enum" NOT NULL DEFAULT 'started', "osUser" character varying NOT NULL, "errorReason" character varying, "recoverable" boolean NOT NULL DEFAULT false, "env" jsonb NOT NULL DEFAULT '{}', "public" boolean NOT NULL DEFAULT false, "networkBlockAll" boolean NOT NULL DEFAULT false, "networkAllowList" character varying, "labels" jsonb, "cpu" integer NOT NULL DEFAULT '2', "gpu" integer NOT NULL DEFAULT '0', "mem" integer NOT NULL DEFAULT '4', "disk" integer NOT NULL DEFAULT '10', "volumes" jsonb NOT NULL DEFAULT '[]', "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "autoStopInterval" integer NOT NULL DEFAULT '15', "autoDeleteInterval" integer NOT NULL DEFAULT '-1', "pending" boolean NOT NULL DEFAULT false, "authToken" character varying NOT NULL, "daemonVersion" character varying, CONSTRAINT "box_organizationId_name_unique" UNIQUE ("organizationId", "name"), CONSTRAINT "box_id_pk" PRIMARY KEY ("id"))`,
+      `CREATE TABLE "box" ("id" character varying(12) NOT NULL, "organizationId" uuid NOT NULL, "name" character varying NOT NULL, "region" character varying NOT NULL, "runnerId" uuid, "prevRunnerId" uuid, "class" "public"."box_class_enum" NOT NULL DEFAULT 'small', "state" "public"."box_state_enum" NOT NULL DEFAULT 'unknown', "desiredState" "public"."box_desiredstate_enum" NOT NULL DEFAULT 'started', "osUser" character varying NOT NULL, "image" character varying NOT NULL, "errorReason" character varying, "recoverable" boolean NOT NULL DEFAULT false, "env" jsonb NOT NULL DEFAULT '{}', "public" boolean NOT NULL DEFAULT false, "networkBlockAll" boolean NOT NULL DEFAULT false, "networkAllowList" character varying, "labels" jsonb, "cpu" integer NOT NULL DEFAULT '2', "gpu" integer NOT NULL DEFAULT '0', "mem" integer NOT NULL DEFAULT '4', "disk" integer NOT NULL DEFAULT '10', "volumes" jsonb NOT NULL DEFAULT '[]', "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "autoStopInterval" integer NOT NULL DEFAULT '15', "autoDeleteInterval" integer NOT NULL DEFAULT '-1', "pending" boolean NOT NULL DEFAULT false, "authToken" character varying NOT NULL, "daemonVersion" character varying, CONSTRAINT "box_organizationId_name_unique" UNIQUE ("organizationId", "name"), CONSTRAINT "box_id_pk" PRIMARY KEY ("id"))`,
     )
     await queryRunner.query(
       `CREATE TABLE "box_last_activity" ("boxId" character varying NOT NULL, "lastActivityAt" TIMESTAMP WITH TIME ZONE, CONSTRAINT "box_last_activity_boxId_pk" PRIMARY KEY ("boxId"), CONSTRAINT "box_last_activity_boxId_fk" FOREIGN KEY ("boxId") REFERENCES "box"("id") ON DELETE CASCADE ON UPDATE NO ACTION)`,
@@ -126,13 +126,11 @@ export class Migration1741087887225 implements MigrationInterface {
     )
     await queryRunner.query(`CREATE INDEX "box_resources_idx" ON "box" ("cpu", "mem", "disk", "gpu")`)
     await queryRunner.query(`CREATE INDEX "box_region_idx" ON "box" ("region")`)
-    await queryRunner.query(`CREATE INDEX "box_organizationid_boxid_idx" ON "box" ("organizationId", "boxId")`)
     await queryRunner.query(`CREATE INDEX "box_organizationid_idx" ON "box" ("organizationId")`)
     await queryRunner.query(`CREATE INDEX "box_runner_state_idx" ON "box" ("runnerId", "state")`)
     await queryRunner.query(`CREATE INDEX "box_runnerid_idx" ON "box" ("runnerId")`)
     await queryRunner.query(`CREATE INDEX "box_desiredstate_idx" ON "box" ("desiredState")`)
     await queryRunner.query(`CREATE INDEX "box_state_idx" ON "box" ("state")`)
-    await queryRunner.query(`CREATE UNIQUE INDEX "box_boxid_unique_idx" ON "box" ("boxId")`)
     await queryRunner.query(`CREATE INDEX "box_labels_gin_full_idx" ON "box" USING gin ("labels" jsonb_path_ops)`)
     await queryRunner.query(`CREATE INDEX "idx_box_volumes_gin" ON "box" USING gin ("volumes" jsonb_path_ops)`)
     await queryRunner.query(
@@ -191,13 +189,11 @@ export class Migration1741087887225 implements MigrationInterface {
     await queryRunner.query(`DROP TABLE "box_last_activity"`)
     await queryRunner.query(`DROP INDEX "public"."idx_box_volumes_gin"`)
     await queryRunner.query(`DROP INDEX "public"."box_labels_gin_full_idx"`)
-    await queryRunner.query(`DROP INDEX "public"."box_boxid_unique_idx"`)
     await queryRunner.query(`DROP INDEX "public"."box_state_idx"`)
     await queryRunner.query(`DROP INDEX "public"."box_desiredstate_idx"`)
     await queryRunner.query(`DROP INDEX "public"."box_runnerid_idx"`)
     await queryRunner.query(`DROP INDEX "public"."box_runner_state_idx"`)
     await queryRunner.query(`DROP INDEX "public"."box_organizationid_idx"`)
-    await queryRunner.query(`DROP INDEX "public"."box_organizationid_boxid_idx"`)
     await queryRunner.query(`DROP INDEX "public"."box_region_idx"`)
     await queryRunner.query(`DROP INDEX "public"."box_resources_idx"`)
     await queryRunner.query(`DROP INDEX "public"."box_runner_state_desired_idx"`)

--- a/apps/dashboard/src/components/BoxTable/BoxTableActions.tsx
+++ b/apps/dashboard/src/components/BoxTable/BoxTableActions.tsx
@@ -165,7 +165,6 @@ export function BoxTableActions({
     deletePermitted,
     box.state,
     box.id,
-    box.boxId,
     isLoading,
     box.recoverable,
     onStart,

--- a/apps/dashboard/src/components/admin/AdminPeopleBoxesView.tsx
+++ b/apps/dashboard/src/components/admin/AdminPeopleBoxesView.tsx
@@ -197,7 +197,7 @@ const AdminPeopleBoxesView: React.FC<AdminPeopleBoxesViewProps> = ({
                               variant="ghost"
                               size="sm"
                               className="h-7 px-2 text-xs"
-                              aria-label={`Diagnose box ${box.boxId ?? box.id}`}
+                              aria-label={`Diagnose box ${box.id}`}
                               onClick={(event) => {
                                 event.stopPropagation()
                                 onOpenBox(box)

--- a/apps/dashboard/src/components/admin/adminDiagnoseTarget.ts
+++ b/apps/dashboard/src/components/admin/adminDiagnoseTarget.ts
@@ -39,7 +39,7 @@ export function createBoxDiagnoseTarget(box: AdminBox): AdminDiagnoseTarget {
   return {
     kind: 'box',
     title: 'Diagnose box',
-    subtitle: box.boxId ? `${box.boxId} · ${box.id}` : box.id,
+    subtitle: box.id,
     state: box.state,
     box,
     params: {

--- a/apps/dashboard/src/components/admin/adminHelpers.ts
+++ b/apps/dashboard/src/components/admin/adminHelpers.ts
@@ -199,9 +199,7 @@ export function filterOwnerGroups(groups: OwnerGroup[], query: string): OwnerGro
       result.push(group)
       continue
     }
-    const matchingBoxes = group.boxes.filter(
-      (b) => b.id.toLowerCase().includes(q) || b.boxId?.toLowerCase().includes(q),
-    )
+    const matchingBoxes = group.boxes.filter((b) => b.id.toLowerCase().includes(q))
     if (matchingBoxes.length > 0) {
       result.push({ ...group, boxes: matchingBoxes, breakdown: getBoxBreakdown(matchingBoxes) })
     }
@@ -222,9 +220,11 @@ export function selectErroringOwners(groups: OwnerGroup[]): ErroringOwner[] {
 }
 
 export function findBoxById(groups: OwnerGroup[], boxId: string): { box: AdminBox; group: OwnerGroup } | undefined {
-  const targetBoxId = boxId.trim().toLowerCase()
+  // Box ids are 12-char base62 and case-sensitive; a case-insensitive match could resolve
+  // to the wrong box when two valid ids differ only by case.
+  const targetBoxId = boxId.trim()
   for (const group of groups) {
-    const box = group.boxes.find((b) => b.id.toLowerCase() === targetBoxId || b.boxId?.toLowerCase() === targetBoxId)
+    const box = group.boxes.find((b) => b.id === targetBoxId)
     if (box) return { box, group }
   }
   return undefined

--- a/apps/dashboard/src/hooks/useBoxWsSync.ts
+++ b/apps/dashboard/src/hooks/useBoxWsSync.ts
@@ -44,16 +44,13 @@ export function useBoxWsSync({ boxId, refetchOnCreate = false }: UseBoxWsSyncOpt
       })
     }
 
-    const matchesActiveBox = (box: Box) => !boxId || box.id === boxId || box.boxId === boxId
+    const matchesActiveBox = (box: Box) => !boxId || box.id === boxId
 
     const optimisticUpdate = (box: Box, state: BoxState) => {
       updateStateInListCache(box.id, state)
       if (boxId) {
         updateStateInDetailCache(boxId, state)
         updateStateInDetailCache(box.id, state)
-        if (box.boxId) {
-          updateStateInDetailCache(box.boxId, state)
-        }
       }
     }
 

--- a/apps/dashboard/src/lib/box-identity.ts
+++ b/apps/dashboard/src/lib/box-identity.ts
@@ -6,25 +6,26 @@
 
 import { Box, BoxDesiredState } from '@boxlite-ai/api-client'
 
-type BoxIdentity = Pick<Box, 'id' | 'name'> & Partial<Pick<Box, 'boxId' | 'desiredState'>>
+type BoxIdentity = Pick<Box, 'id' | 'name'> & Partial<Pick<Box, 'desiredState'>>
 
 export const MISSING_BOX_ID_LABEL = 'Not available'
 
-export function getBoxPublicId(box: Partial<Pick<Box, 'boxId'>> | undefined): string {
-  return box?.boxId || ''
+export function getBoxPublicId(box: Partial<Pick<Box, 'id'>> | undefined): string {
+  return box?.id || ''
 }
 
-export function getBoxPublicIdLabel(box: Partial<Pick<Box, 'boxId'>> | undefined): string {
+export function getBoxPublicIdLabel(box: Partial<Pick<Box, 'id'>> | undefined): string {
   return getBoxPublicId(box) || MISSING_BOX_ID_LABEL
 }
 
-export function getBoxRouteId(box: Partial<Pick<Box, 'boxId' | 'id'>> | undefined): string {
-  return box?.boxId || box?.id || ''
+export function getBoxRouteId(box: Partial<Pick<Box, 'id'>> | undefined): string {
+  return box?.id || ''
 }
 
 export function getBoxDisplayName(box: BoxIdentity): string {
   const name = getNormalizedBoxName(box)
-  if (name && name !== box.id && !isUuidLike(name)) {
+  // An unnamed box falls back to name === id at create time; show the id label then.
+  if (name && name !== box.id) {
     return name
   }
   return getBoxPublicId(box) || 'Box'
@@ -41,8 +42,4 @@ function getNormalizedBoxName(box: BoxIdentity): string {
   }
 
   return box.name
-}
-
-function isUuidLike(value: string): boolean {
-  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value)
 }

--- a/apps/libs/api-client/src/docs/AdminBoxItem.md
+++ b/apps/libs/api-client/src/docs/AdminBoxItem.md
@@ -6,8 +6,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **id** | **string** | Box ID | [default to undefined]
-**boxId** | **string** | Public box ID shown to users | [optional] [default to undefined]
-**organizationId** | **string** | Organization ID | [default to undefined]
+**organizationId** | **string** | Public box ID shown to users | [optional] [default to undefined]
 **state** | [**BoxState**](BoxState.md) |  | [default to undefined]
 **runnerId** | **string** | Runner ID the box is assigned to | [optional] [default to undefined]
 **cpu** | **number** | Allocated CPU (vCPUs) | [default to undefined]
@@ -22,7 +21,6 @@ import { AdminBoxItem } from './api';
 
 const instance: AdminBoxItem = {
     id,
-    boxId,
     organizationId,
     state,
     runnerId,

--- a/apps/libs/api-client/src/docs/Box.md
+++ b/apps/libs/api-client/src/docs/Box.md
@@ -6,11 +6,11 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **id** | **string** | The internal UUID of the box | [default to undefined]
-**boxId** | **string** | The public Box ID shown to users and SDK clients | [default to undefined]
 **organizationId** | **string** | The organization ID of the box | [default to undefined]
 **name** | **string** | The name of the box | [default to undefined]
 **user** | **string** | The user associated with the project | [default to undefined]
 **env** | **{ [key: string]: string; }** | Environment variables for the box | [default to undefined]
+**image** | **string** | The OCI image ref the box boots from | [default to undefined]
 **labels** | **{ [key: string]: string; }** | Labels for the box | [default to undefined]
 **_public** | **boolean** | Whether the box http preview is public | [default to undefined]
 **networkBlockAll** | **boolean** | Whether to block all network access for the box | [default to undefined]
@@ -41,11 +41,11 @@ import { Box } from './api';
 
 const instance: Box = {
     id,
-    boxId,
     organizationId,
     name,
     user,
     env,
+    image,
     labels,
     _public,
     networkBlockAll,

--- a/apps/libs/api-client/src/docs/Workspace.md
+++ b/apps/libs/api-client/src/docs/Workspace.md
@@ -6,11 +6,11 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **id** | **string** | The internal UUID of the box | [default to undefined]
-**boxId** | **string** | The public Box ID shown to users and SDK clients | [default to undefined]
 **organizationId** | **string** | The organization ID of the box | [default to undefined]
 **name** | **string** | The name of the box | [default to undefined]
 **user** | **string** | The user associated with the project | [default to undefined]
 **env** | **{ [key: string]: string; }** | Environment variables for the box | [default to undefined]
+**image** | **string** | The OCI image ref the box boots from | [default to undefined]
 **labels** | **{ [key: string]: string; }** | Labels for the box | [default to undefined]
 **_public** | **boolean** | Whether the box http preview is public | [default to undefined]
 **networkBlockAll** | **boolean** | Whether to block all network access for the box | [default to undefined]
@@ -33,7 +33,6 @@ Name | Type | Description | Notes
 **daemonVersion** | **string** | The version of the daemon running in the box | [optional] [default to undefined]
 **runnerId** | **string** | The runner ID of the box | [optional] [default to undefined]
 **toolboxProxyUrl** | **string** | The toolbox proxy URL for the box | [default to undefined]
-**image** | **string** | The image used for the workspace | [optional] [default to undefined]
 **info** | [**BoxInfo**](BoxInfo.md) | Additional information about the box | [optional] [default to undefined]
 
 ## Example
@@ -43,11 +42,11 @@ import { Workspace } from './api';
 
 const instance: Workspace = {
     id,
-    boxId,
     organizationId,
     name,
     user,
     env,
+    image,
     labels,
     _public,
     networkBlockAll,
@@ -70,7 +69,6 @@ const instance: Workspace = {
     daemonVersion,
     runnerId,
     toolboxProxyUrl,
-    image,
     info,
 };
 ```

--- a/apps/libs/api-client/src/models/admin-box-item.ts
+++ b/apps/libs/api-client/src/models/admin-box-item.ts
@@ -28,11 +28,7 @@ export interface AdminBoxItem {
     /**
      * Public box ID shown to users
      */
-    'boxId'?: string;
-    /**
-     * Organization ID
-     */
-    'organizationId': string;
+    'organizationId'?: string;
     'state': BoxState;
     /**
      * Runner ID the box is assigned to

--- a/apps/libs/api-client/src/models/box.ts
+++ b/apps/libs/api-client/src/models/box.ts
@@ -29,10 +29,6 @@ export interface Box {
      */
     'id': string;
     /**
-     * The public Box ID shown to users and SDK clients
-     */
-    'boxId': string;
-    /**
      * The organization ID of the box
      */
     'organizationId': string;
@@ -48,6 +44,10 @@ export interface Box {
      * Environment variables for the box
      */
     'env': { [key: string]: string; };
+    /**
+     * The OCI image ref the box boots from
+     */
+    'image': string;
     /**
      * Labels for the box
      */

--- a/apps/libs/api-client/src/models/workspace.ts
+++ b/apps/libs/api-client/src/models/workspace.ts
@@ -32,10 +32,6 @@ export interface Workspace {
      */
     'id': string;
     /**
-     * The public Box ID shown to users and SDK clients
-     */
-    'boxId': string;
-    /**
      * The organization ID of the box
      */
     'organizationId': string;
@@ -51,6 +47,10 @@ export interface Workspace {
      * Environment variables for the box
      */
     'env': { [key: string]: string; };
+    /**
+     * The OCI image ref the box boots from
+     */
+    'image': string;
     /**
      * Labels for the box
      */
@@ -140,10 +140,6 @@ export interface Workspace {
      * The toolbox proxy URL for the box
      */
     'toolboxProxyUrl': string;
-    /**
-     * The image used for the workspace
-     */
-    'image'?: string;
     /**
      * Additional information about the box
      */

--- a/apps/libs/sdk-typescript/src/Box.ts
+++ b/apps/libs/sdk-typescript/src/Box.ts
@@ -56,9 +56,9 @@ export interface BoxCodeToolbox {
  *   Currently supports only Python. For other languages, use the `process.codeRun` method.
  * @property {ComputerUse} computerUse - Computer use operations interface for desktop automation
  * @property {string} id - Unique identifier for the Box
- * @property {string} boxId - Public Box ID shown to users and SDK clients
  * @property {string} organizationId - Organization ID of the Box
  * @property {string} user - OS user running in the Box
+ * @property {string} image - OCI image the Box boots from
  * @property {Record<string, string>} env - Environment variables set in the Box
  * @property {Record<string, string>} labels - Custom labels attached to the Box
  * @property {boolean} public - Whether the Box is publicly accessible
@@ -88,10 +88,10 @@ export class Box implements BoxDto {
   public readonly codeInterpreter: CodeInterpreter
 
   public id!: string
-  public boxId!: string
   public name!: string
   public organizationId!: string
   public user!: string
+  public image!: string
   public env!: Record<string, string>
   public labels!: Record<string, string>
   public public!: boolean
@@ -665,10 +665,10 @@ export class Box implements BoxDto {
    */
   private processBoxDto(boxDto: BoxDto) {
     this.id = boxDto.id
-    this.boxId = boxDto.boxId
     this.name = boxDto.name
     this.organizationId = boxDto.organizationId
     this.user = boxDto.user
+    this.image = boxDto.image
     this.env = boxDto.env
     this.labels = boxDto.labels
     this.public = boxDto.public

--- a/apps/runner/pkg/api/dto/box.go
+++ b/apps/runner/pkg/api/dto/box.go
@@ -6,17 +6,14 @@ package dto
 
 type CreateBoxDTO struct {
 	Id               string            `json:"id" validate:"required"`
-	BoxId            string            `json:"boxId,omitempty"`
 	FromVolumeId     string            `json:"fromVolumeId,omitempty"`
-	UserId           string            `json:"userId" validate:"required"`
-	ArtifactRef      string            `json:"artifactRef" validate:"required"`
-	OsUser           string            `json:"osUser" validate:"required"`
+	UserId           string            `json:"userId,omitempty"`
+	Image            string            `json:"image" validate:"required"`
+	OsUser           string            `json:"osUser,omitempty"`
 	CpuQuota         int64             `json:"cpuQuota" validate:"min=1"`
-	GpuQuota         int64             `json:"gpuQuota" validate:"min=0"`
 	MemoryQuota      int64             `json:"memoryQuota" validate:"min=1"`
 	StorageQuota     int64             `json:"storageQuota" validate:"min=1"`
 	Env              map[string]string `json:"env,omitempty"`
-	Registry         *RegistryDTO      `json:"registry,omitempty"`
 	Entrypoint       []string          `json:"entrypoint,omitempty"`
 	Volumes          []VolumeDTO       `json:"volumes,omitempty"`
 	NetworkBlockAll  *bool             `json:"networkBlockAll,omitempty"`

--- a/apps/runner/pkg/boxlite/client.go
+++ b/apps/runner/pkg/boxlite/client.go
@@ -211,11 +211,6 @@ func (c *Client) Close() error {
 // Create creates a new box (VM) from the given image and configuration.
 // Returns the box ID and daemon version.
 func (c *Client) Create(ctx context.Context, boxDto dto.CreateBoxDTO) (string, string, error) {
-	publicBoxId := boxDto.BoxId
-	if publicBoxId == "" {
-		publicBoxId = boxDto.Id
-	}
-
 	// API sends cores / GB / GB as small integers (see apps/api Box entity).
 	cpus := int(boxDto.CpuQuota)
 	if cpus < 1 {
@@ -226,6 +221,9 @@ func (c *Client) Create(ctx context.Context, boxDto dto.CreateBoxDTO) (string, s
 		memoryMiB = 128
 	}
 	opts := []boxlite.BoxOption{
+		// The control-plane box id rides in the engine's name slot (the engine
+		// mints its own internal id). User-facing names live only in the cloud's
+		// PG; the engine never needs a separate user name in cloud mode.
 		boxlite.WithName(boxDto.Id),
 		boxlite.WithCPUs(cpus),
 		boxlite.WithMemory(memoryMiB),
@@ -269,7 +267,7 @@ func (c *Client) Create(ctx context.Context, boxDto dto.CreateBoxDTO) (string, s
 
 	opts = append(opts, boxlite.WithNetwork(networkSpec(boxDto.NetworkBlockAll, boxDto.NetworkAllowList)))
 
-	bx, err := c.runtime.Create(ctx, boxDto.ArtifactRef, opts...)
+	bx, err := c.runtime.Create(ctx, boxDto.Image, opts...)
 	if err != nil {
 		if len(volumeMounts) > 0 {
 			if cleanupErr := c.removeBoxVolumeMountRecord(ctx, boxDto.Id); cleanupErr != nil {
@@ -292,12 +290,10 @@ func (c *Client) Create(ctx context.Context, boxDto dto.CreateBoxDTO) (string, s
 		bx.ID(),
 		"boxId",
 		boxDto.Id,
-		"boxId",
-		publicBoxId,
 		"name",
 		bx.Name(),
-		"artifactRef",
-		boxDto.ArtifactRef,
+		"image",
+		boxDto.Image,
 	)
 
 	skipStart := boxDto.SkipStart != nil && *boxDto.SkipStart

--- a/apps/runner/pkg/boxlite/stubs.go
+++ b/apps/runner/pkg/boxlite/stubs.go
@@ -94,7 +94,7 @@ func (c *Client) RecoverBox(ctx context.Context, boxId string, recoverDto dto.Re
 
 	createDto := dto.CreateBoxDTO{
 		Id:               boxId,
-		ArtifactRef:      "alpine:latest",
+		Image:            "alpine:latest",
 		OsUser:           recoverDto.OsUser,
 		CpuQuota:         recoverDto.CpuQuota,
 		MemoryQuota:      recoverDto.MemoryQuota,

--- a/scripts/test/e2e/README.md
+++ b/scripts/test/e2e/README.md
@@ -64,10 +64,13 @@ python3 scripts/test/e2e/fixture_setup.py
 
 This:
 
-- Registers `alpine:3.23` snapshot via the API admin endpoint
-- Waits for the snapshot to reach `active` state (runner pulls + pushes to local registry)
 - Sets reasonable per-box quotas on the admin org
 - Adds a `[profiles.p1]` entry in `~/.boxlite/credentials.toml` pointing at the local API
+
+Box images need no registration: tests pass a full OCI image ref that must be
+in the API's supported allowlist (`BOXLITE_SYSTEM_*_IMAGE` env vars —
+bootstrap.sh points them at public refs for the local stack; fixture_setup.py
+records the base entry in the profile so tests pick it up automatically).
 
 ## Running
 

--- a/scripts/test/e2e/bootstrap.sh
+++ b/scripts/test/e2e/bootstrap.sh
@@ -143,6 +143,11 @@ RUN_MIGRATIONS=true
 VERSION=0.1.0
 DEFAULT_REGION_ENFORCE_QUOTAS=false
 DEFAULT_SNAPSHOT=ubuntu:22.04
+# Supported-image allowlist for the local stack: public refs so the runner
+# can pull without private-registry credentials (prod pins ghcr digests).
+BOXLITE_SYSTEM_BASE_IMAGE=alpine:3.23
+BOXLITE_SYSTEM_PYTHON_IMAGE=python:3.11-alpine
+BOXLITE_SYSTEM_NODE_IMAGE=node:18-alpine
 DB_HOST=localhost
 DB_PORT=5432
 DB_USERNAME=boxlite

--- a/scripts/test/e2e/cases/conftest.py
+++ b/scripts/test/e2e/cases/conftest.py
@@ -27,8 +27,24 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "lib"))
 from path_verification import runner_journal_seek, runner_hits_for_box
 
 DEFAULT_PROFILE = os.environ.get("BOXLITE_E2E_PROFILE", "p1")
-DEFAULT_IMAGE = os.environ.get("BOXLITE_E2E_IMAGE", "alpine:3.23")
 CRED_PATH = Path.home() / ".boxlite" / "credentials.toml"
+
+
+def _default_image() -> str:
+    """The image must be in the API's supported allowlist, which differs per
+    stack (bootstrap.sh points the local stack at public refs; prod pins ghcr
+    digests). fixture_setup.py records the stack's base image in the profile;
+    the ghcr fallback only covers runs against prod-like stacks without it."""
+    if env_image := os.environ.get("BOXLITE_E2E_IMAGE"):
+        return env_image
+    if CRED_PATH.exists():
+        profile = tomllib.loads(CRED_PATH.read_text()).get("profiles", {}).get(DEFAULT_PROFILE, {})
+        if profile.get("default_image"):
+            return profile["default_image"]
+    return "ghcr.io/boxlite-ai/boxlite-agent-base@sha256:834dcb65465985fc2f648451d76c81d166bc7672391c9064a0a115ce6306c85f"
+
+
+DEFAULT_IMAGE = _default_image()
 
 
 def _profile(name: str) -> dict:

--- a/scripts/test/e2e/cases/test_c_entry.py
+++ b/scripts/test/e2e/cases/test_c_entry.py
@@ -21,13 +21,16 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parent.parent / "lib"))
 from path_verification import runner_journal_seek, runner_hits_for_box
 
+from conftest import DEFAULT_IMAGE
+
 REPO = Path(__file__).resolve().parents[4]
 SRC = REPO / "scripts/test/e2e/sdks/c/e2e_basic.c"
 HDR = REPO / "sdks/c/include"
 LIB_DIR = REPO / "target/release"
-UUID_RE = re.compile(
-    r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
-)
+# Box ids are 12-char base62 (case-sensitive), printed on their own line by
+# `boxlite run -d` / `create`. Anchor to a full line so we don't match a
+# 12-char substring of unrelated output.
+BOX_ID_RE = re.compile(r"^[0-9A-Za-z]{12}$", re.MULTILINE)
 
 
 def _profile():
@@ -73,7 +76,7 @@ def test_c_sdk_create_remove(c_binary):
         "BOXLITE_E2E_URL": p["url"],
         "BOXLITE_E2E_API_KEY": p["api_key"],
         "BOXLITE_E2E_PREFIX": p.get("path_prefix") or "",
-        "BOXLITE_E2E_IMAGE": "alpine:3.23",
+        "BOXLITE_E2E_IMAGE": DEFAULT_IMAGE,
         "LD_LIBRARY_PATH": str(LIB_DIR),
     }
     r = subprocess.run(
@@ -84,7 +87,7 @@ def test_c_sdk_create_remove(c_binary):
         f"C driver exit={r.returncode}\nstdout:\n{r.stdout}\nstderr:\n{r.stderr}"
     )
 
-    m = UUID_RE.search(r.stdout)
+    m = BOX_ID_RE.search(r.stdout)
     assert m, f"C driver did not print BOX_ID: {r.stdout!r}"
     box_id = m.group(0)
     assert "OK" in r.stdout

--- a/scripts/test/e2e/cases/test_cli_detach_recovery.py
+++ b/scripts/test/e2e/cases/test_cli_detach_recovery.py
@@ -37,10 +37,11 @@ sys.path.insert(
 from path_verification import runner_journal_seek, runner_hits_for_box
 
 BOXLITE_BIN = os.environ.get("BOXLITE_E2E_CLI", shutil.which("boxlite"))
-IMAGE = os.environ.get("BOXLITE_E2E_IMAGE", "alpine:3.23")
-UUID_RE = re.compile(
-    r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
-)
+from conftest import DEFAULT_IMAGE as IMAGE  # noqa: E402  (stack-aware default)
+# Box ids are 12-char base62 (case-sensitive), printed on their own line by
+# `boxlite run -d` / `create`. Anchor to a full line so we don't match a
+# 12-char substring of unrelated output.
+BOX_ID_RE = re.compile(r"^[0-9A-Za-z]{12}$", re.MULTILINE)
 
 
 @pytest.fixture(scope="module")
@@ -80,8 +81,8 @@ def test_detached_box_survives_cli_exit_and_is_reusable(cli):
 
     # 1) detach run in one CLI process
     r_run = run(cli, "run", "-d", IMAGE, "--", "sleep", "300", timeout=120)
-    m = UUID_RE.search(r_run.stdout)
-    assert m, f"`boxlite run -d` did not print a uuid: {r_run.stdout!r}"
+    m = BOX_ID_RE.search(r_run.stdout)
+    assert m, f"`boxlite run -d` did not print a box id: {r_run.stdout!r}"
     box_id = m.group(0)
 
     try:
@@ -127,7 +128,7 @@ def test_detached_box_exec_propagates_exit_code_on_fresh_cli(cli):
     still propagate when the exec is launched from a fresh CLI process
     (i.e. no in-memory SDK state to lean on)."""
     r_run = run(cli, "run", "-d", IMAGE, "--", "sleep", "300", timeout=120)
-    m = UUID_RE.search(r_run.stdout)
+    m = BOX_ID_RE.search(r_run.stdout)
     assert m
     box_id = m.group(0)
 

--- a/scripts/test/e2e/cases/test_cli_entry.py
+++ b/scripts/test/e2e/cases/test_cli_entry.py
@@ -29,10 +29,11 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "lib"))
 from path_verification import runner_journal_seek, runner_hits_for_box
 
 BOXLITE_BIN = os.environ.get("BOXLITE_E2E_CLI", shutil.which("boxlite"))
-IMAGE = os.environ.get("BOXLITE_E2E_IMAGE", "alpine:3.23")
-UUID_RE = re.compile(
-    r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
-)
+from conftest import DEFAULT_IMAGE as IMAGE  # noqa: E402  (stack-aware default)
+# Box ids are 12-char base62 (case-sensitive), printed on their own line by
+# `boxlite run -d` / `create`. Anchor to a full line so we don't match a
+# 12-char substring of unrelated output.
+BOX_ID_RE = re.compile(r"^[0-9A-Za-z]{12}$", re.MULTILINE)
 
 
 @pytest.fixture(scope="module")
@@ -86,8 +87,8 @@ def test_cli_run_exec_chain(cli):
 
     # 1. detach run prints the box id on stdout
     r_run = run(cli, "run", "-d", IMAGE, "--", "sleep", "300", timeout=120)
-    m = UUID_RE.search(r_run.stdout)
-    assert m, f"`boxlite run -d` did not print a uuid: {r_run.stdout!r}"
+    m = BOX_ID_RE.search(r_run.stdout)
+    assert m, f"`boxlite run -d` did not print a box id: {r_run.stdout!r}"
     box_id = m.group(0)
 
     try:
@@ -126,7 +127,7 @@ def test_cli_exec_exit_code_propagates(cli):
     CLI's own exit code. This is the CLI behaviour layer, not just the
     SDK — argv parsing + exit-code mapping is CLI-specific."""
     r_run = run(cli, "run", "-d", IMAGE, "--", "sleep", "300", timeout=120)
-    m = UUID_RE.search(r_run.stdout)
+    m = BOX_ID_RE.search(r_run.stdout)
     assert m
     box_id = m.group(0)
 

--- a/scripts/test/e2e/cases/test_error_code_mapping.py
+++ b/scripts/test/e2e/cases/test_error_code_mapping.py
@@ -31,6 +31,8 @@ from pathlib import Path
 from typing import Any
 
 import boxlite
+
+from conftest import DEFAULT_IMAGE
 import pytest
 
 
@@ -113,7 +115,7 @@ async def test_invalid_argument_zero_cpu_returns_400(rt):
     status, body = _api_call(
         "POST",
         f"/v1/{p['path_prefix']}/boxes",
-        {"image": "alpine:3.23", "cpus": 0, "memory_mib": 256, "disk_size_gb": 4},
+        {"image": DEFAULT_IMAGE, "cpus": 0, "memory_mib": 256, "disk_size_gb": 4},
     )
     _assert_http_code(
         status,
@@ -141,7 +143,7 @@ async def test_invalid_argument_negative_memory_returns_400(rt):
     status, body = _api_call(
         "POST",
         f"/v1/{p['path_prefix']}/boxes",
-        {"image": "alpine:3.23", "cpus": 1, "memory_mib": -1, "disk_size_gb": 4},
+        {"image": DEFAULT_IMAGE, "cpus": 1, "memory_mib": -1, "disk_size_gb": 4},
     )
     _assert_http_code(
         status,
@@ -254,7 +256,7 @@ async def test_resource_exhausted_over_cpu_quota_returns_429(rt):
     status, body = _api_call(
         "POST",
         f"/v1/{p['path_prefix']}/boxes",
-        {"image": "alpine:3.23", "cpus": 999, "memory_mib": 256, "disk_size_gb": 4},
+        {"image": DEFAULT_IMAGE, "cpus": 999, "memory_mib": 256, "disk_size_gb": 4},
     )
     # The mapping says 429 ResourceExhausted; some implementations may also
     # 400 InvalidArgument (treating it as a parse-time validation failure).

--- a/scripts/test/e2e/cases/test_go_entry.py
+++ b/scripts/test/e2e/cases/test_go_entry.py
@@ -16,11 +16,14 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parent.parent / "lib"))
 from path_verification import runner_journal_seek, runner_hits_for_box
 
+from conftest import DEFAULT_IMAGE
+
 REPO = Path(__file__).resolve().parents[4]
 SRC = REPO / "scripts/test/e2e/sdks/go/e2e_basic.go"
-UUID_RE = re.compile(
-    r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
-)
+# Box ids are 12-char base62 (case-sensitive), printed on their own line by
+# `boxlite run -d` / `create`. Anchor to a full line so we don't match a
+# 12-char substring of unrelated output.
+BOX_ID_RE = re.compile(r"^[0-9A-Za-z]{12}$", re.MULTILINE)
 
 
 def _profile():
@@ -61,7 +64,7 @@ def test_go_sdk_create_exec_remove(go_binary):
         "BOXLITE_E2E_URL": p["url"],
         "BOXLITE_E2E_API_KEY": p["api_key"],
         "BOXLITE_E2E_PREFIX": p.get("path_prefix") or "",
-        "BOXLITE_E2E_IMAGE": "alpine:3.23",
+        "BOXLITE_E2E_IMAGE": DEFAULT_IMAGE,
         # CGO dev tag — uses libboxlite.so from the workspace target/release,
         # not a vendored prebuilt one.
         "LD_LIBRARY_PATH": str(REPO / "target/release"),
@@ -74,7 +77,7 @@ def test_go_sdk_create_exec_remove(go_binary):
         f"go driver exit={r.returncode}\nstdout:\n{r.stdout}\nstderr:\n{r.stderr}"
     )
 
-    m = UUID_RE.search(r.stdout)
+    m = BOX_ID_RE.search(r.stdout)
     assert m, f"go driver did not print BOX_ID: {r.stdout!r}"
     box_id = m.group(0)
 

--- a/scripts/test/e2e/cases/test_node_entry.py
+++ b/scripts/test/e2e/cases/test_node_entry.py
@@ -20,12 +20,15 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parent.parent / "lib"))
 from path_verification import runner_journal_seek, runner_hits_for_box
 
+from conftest import DEFAULT_IMAGE
+
 REPO = Path(__file__).resolve().parents[4]
 SRC = REPO / "scripts/test/e2e/sdks/node/e2e_basic.ts"
 NODE_SDK = REPO / "sdks/node"
-UUID_RE = re.compile(
-    r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
-)
+# Box ids are 12-char base62 (case-sensitive), printed on their own line by
+# `boxlite run -d` / `create`. Anchor to a full line so we don't match a
+# 12-char substring of unrelated output.
+BOX_ID_RE = re.compile(r"^[0-9A-Za-z]{12}$", re.MULTILINE)
 
 
 def _profile():
@@ -68,7 +71,7 @@ def test_node_sdk_create_exec_remove(node_runner):
         "BOXLITE_E2E_URL": p["url"],
         "BOXLITE_E2E_API_KEY": p["api_key"],
         "BOXLITE_E2E_PREFIX": p.get("path_prefix") or "",
-        "BOXLITE_E2E_IMAGE": "alpine:3.23",
+        "BOXLITE_E2E_IMAGE": DEFAULT_IMAGE,
     }
     # Use npx tsx to run the .ts directly without a separate compile step.
     # tsx is bundled with the apps workspace.
@@ -81,7 +84,7 @@ def test_node_sdk_create_exec_remove(node_runner):
         f"node driver exit={r.returncode}\nstdout:\n{r.stdout}\nstderr:\n{r.stderr}"
     )
 
-    m = UUID_RE.search(r.stdout)
+    m = BOX_ID_RE.search(r.stdout)
     assert m, f"node driver did not print BOX_ID: {r.stdout!r}"
     box_id = m.group(0)
 

--- a/scripts/test/e2e/cases/test_quota_enforcement.py
+++ b/scripts/test/e2e/cases/test_quota_enforcement.py
@@ -37,6 +37,8 @@ from typing import Any
 
 import pytest
 
+from conftest import DEFAULT_IMAGE
+
 pytestmark = pytest.mark.xfail(
     strict=True,
     reason=(
@@ -94,7 +96,7 @@ def _delete_box(box_id: str) -> None:
 async def test_cpus_above_per_box_limit_returns_4xx():
     """cpus far above max_cpu_per_box (4) → 429 or 400, not 5xx."""
     status, body = _post_box(
-        {"image": "alpine:3.23", "cpus": 999, "memory_mib": 256, "disk_size_gb": 4}
+        {"image": DEFAULT_IMAGE, "cpus": 999, "memory_mib": 256, "disk_size_gb": 4}
     )
     body_str = json.dumps(body) if body else ""
     assert 400 <= status < 500, f"cpus=999 leaked HTTP {status}: {body_str}"
@@ -105,7 +107,7 @@ async def test_memory_above_per_box_limit_returns_4xx():
     """memory far above max_memory_per_box (8 GiB) → 4xx, not 5xx."""
     status, body = _post_box(
         {
-            "image": "alpine:3.23",
+            "image": DEFAULT_IMAGE,
             "cpus": 1,
             "memory_mib": 8_192_000_000,
             "disk_size_gb": 4,
@@ -120,7 +122,7 @@ async def test_disk_above_per_box_limit_returns_4xx():
     """disk far above max_disk_per_box (20 GiB) → 4xx, not 5xx."""
     status, body = _post_box(
         {
-            "image": "alpine:3.23",
+            "image": DEFAULT_IMAGE,
             "cpus": 1,
             "memory_mib": 256,
             "disk_size_gb": 99_999_999,
@@ -136,7 +138,7 @@ async def test_quota_violation_does_not_silently_create_box(rt):
     immediately and find an orphan with cpus=999, the runner accepted the
     doomed request and the quota check is decorative."""
     status, body = _post_box(
-        {"image": "alpine:3.23", "cpus": 999, "memory_mib": 256, "disk_size_gb": 4}
+        {"image": DEFAULT_IMAGE, "cpus": 999, "memory_mib": 256, "disk_size_gb": 4}
     )
     if 200 <= status < 300:
         pytest.fail(f"cpus=999 unexpectedly succeeded: HTTP {status}, body={body}")
@@ -158,7 +160,7 @@ async def test_quota_zero_cpus_returns_4xx():
     """cpus=0 — boundary at the other end. Must be 4xx, not 500 or a box
     that immediately crashes."""
     status, body = _post_box(
-        {"image": "alpine:3.23", "cpus": 0, "memory_mib": 256, "disk_size_gb": 4}
+        {"image": DEFAULT_IMAGE, "cpus": 0, "memory_mib": 256, "disk_size_gb": 4}
     )
     body_str = json.dumps(body) if body else ""
     assert 400 <= status < 500, f"cpus=0 leaked HTTP {status}: {body_str}"

--- a/scripts/test/e2e/fixture_setup.py
+++ b/scripts/test/e2e/fixture_setup.py
@@ -4,16 +4,18 @@
 Idempotent. Safe to re-run after bootstrap.sh.
 
 Configures:
-  1. Required snapshots active (alpine:3.23, ubuntu:22.04)
-  2. Admin org has non-zero per-box quotas
-  3. `[profiles.p1]` in ~/.boxlite/credentials.toml points at the local API
+  1. Admin org has non-zero per-box quotas
+  2. `[profiles.p1]` in ~/.boxlite/credentials.toml points at the local API
+
+Box images need no registration: create requests carry a full OCI image ref
+that must be in the API's supported allowlist (BOXLITE_SYSTEM_*_IMAGE env;
+bootstrap.sh points the local stack at public refs).
 """
 from __future__ import annotations
 
 import json
 import os
 import sys
-import time
 import urllib.request
 import urllib.error
 from pathlib import Path
@@ -43,8 +45,25 @@ ADMIN_KEY = (
     or _read_admin_key_from_secrets()
     or "devkey"   # only used when bootstrap hasn't run yet
 )
-SNAPSHOTS_TO_REGISTER = ["alpine:3.23", "ubuntu:22.04", "ubuntu:24.04"]
-SNAPSHOT_WAIT_SECONDS = 180
+
+
+def _read_base_image_from_api_env() -> str | None:
+    """bootstrap.sh writes the local stack's supported-image allowlist into the
+    API env file. Record its base entry in the profile so conftest creates
+    boxes with an image this stack actually accepts."""
+    env_file = Path(os.environ.get("ENV_FILE", "/etc/boxlite-api.env"))
+    if not env_file.exists():
+        return None
+    try:
+        for ln in env_file.read_text().splitlines():
+            if ln.startswith("BOXLITE_SYSTEM_BASE_IMAGE="):
+                return ln.split("=", 1)[1].strip()
+    except PermissionError:
+        return None
+    return None
+
+
+DEFAULT_IMAGE = os.environ.get("BOXLITE_E2E_IMAGE") or _read_base_image_from_api_env()
 CRED_PATH = Path.home() / ".boxlite" / "credentials.toml"
 
 
@@ -72,60 +91,6 @@ def me() -> dict:
     return body
 
 
-def _snapshot_state(name: str) -> tuple[str | None, str | None]:
-    """Read snapshot state directly from Postgres — the API's snapshot GET
-    routes are scoped behind a different controller surface, but the
-    fixture lives next to the DB anyway, so use the canonical source."""
-    import subprocess
-    sql = f"SELECT state, \"errorReason\" FROM snapshot WHERE name = '{name}' LIMIT 1;"
-    r = subprocess.run(
-        ["psql", "-h", "localhost", "-U", "boxlite", "-d", "boxlite_dev",
-         "-tAF", "|", "-c", sql],
-        env={**os.environ, "PGPASSWORD": "boxlite"},
-        capture_output=True, text=True,
-    )
-    line = r.stdout.strip()
-    if not line:
-        return None, None
-    parts = line.split("|", 1)
-    return parts[0], (parts[1] if len(parts) > 1 else None)
-
-
-def register_snapshot(name: str):
-    """POST /snapshots if missing; waits (polling DB) until state == active."""
-    state, _ = _snapshot_state(name)
-    if state is None:
-        status, body = http("POST", "/snapshots", {
-            "name": name, "imageName": name,
-            "cpu": 1, "memory": 1, "disk": 2,
-        })
-        if status not in (200, 201):
-            sys.exit(f"  POST /snapshots → {status} {body}")
-        print(f"  created {name} — waiting for runner pull")
-    elif state == "error":
-        # Wipe + recreate so the runner retries (e.g. registry was down before).
-        import subprocess
-        subprocess.run(
-            ["psql", "-h", "localhost", "-U", "boxlite", "-d", "boxlite_dev",
-             "-c", f"DELETE FROM snapshot WHERE name = '{name}';"],
-            env={**os.environ, "PGPASSWORD": "boxlite"}, check=True,
-        )
-        return register_snapshot(name)
-    else:
-        print(f"  {name}: state = {state} (existing)")
-
-    deadline = time.time() + SNAPSHOT_WAIT_SECONDS
-    while time.time() < deadline:
-        st, err = _snapshot_state(name)
-        if st == "active":
-            print(f"  {name}: active ✓")
-            return
-        if st == "error":
-            sys.exit(f"  {name}: {err}")
-        time.sleep(3)
-    sys.exit(f"  {name} did not reach active within {SNAPSHOT_WAIT_SECONDS}s")
-
-
 def patch_admin_quota():
     """The admin user is created on first API boot with org quotas at 0
     (config defaults are 0 unless ADMIN_* env vars override). Bump them
@@ -136,7 +101,9 @@ UPDATE organization SET
     max_cpu_per_box = 4,
     max_memory_per_box = 8,
     max_disk_per_box = 20
-WHERE personal = true;
+FROM organization_user
+WHERE organization_user."organizationId" = organization.id
+  AND organization_user."isDefaultForUser" = true;
 """
     r = subprocess.run(
         ["psql", "-h", "localhost", "-U", "boxlite", "-d", "boxlite_dev",
@@ -173,6 +140,8 @@ def ensure_p1_profile(prefix: str):
         "auth_method": "api_key",
         "path_prefix": prefix,
     }
+    if DEFAULT_IMAGE:
+        entry["default_image"] = DEFAULT_IMAGE
     profiles["p1"] = entry
     profiles["default"] = entry.copy()
 
@@ -202,11 +171,7 @@ def main():
     prefix = info["path_prefix"]
     print(f"  prefix = {prefix}")
     print()
-    print("3. Registering snapshots...")
-    for snap in SNAPSHOTS_TO_REGISTER:
-        register_snapshot(snap)
-    print()
-    print("4. Writing ~/.boxlite/credentials.toml profile p1...")
+    print("3. Writing ~/.boxlite/credentials.toml profile p1...")
     ensure_p1_profile(prefix)
     print()
     print("fixture_setup: done.")

--- a/scripts/test/e2e/sdks/c/e2e_basic.c
+++ b/scripts/test/e2e/sdks/c/e2e_basic.c
@@ -79,7 +79,8 @@ int main(void) {
     const char* url = env_or("BOXLITE_E2E_URL", "http://localhost:3000/api");
     const char* api_key = env_or("BOXLITE_E2E_API_KEY", "devkey");
     const char* prefix = env_or("BOXLITE_E2E_PREFIX", "");
-    const char* image = env_or("BOXLITE_E2E_IMAGE", "alpine:3.23");
+    const char* image = env_or("BOXLITE_E2E_IMAGE",
+                               "ghcr.io/boxlite-ai/boxlite-agent-base@sha256:834dcb65465985fc2f648451d76c81d166bc7672391c9064a0a115ce6306c85f");
 
     CBoxliteError err = {0};
 

--- a/scripts/test/e2e/sdks/go/e2e_basic.go
+++ b/scripts/test/e2e/sdks/go/e2e_basic.go
@@ -32,7 +32,10 @@ func main() {
 	url := env("BOXLITE_E2E_URL", "http://localhost:3000/api")
 	apiKey := env("BOXLITE_E2E_API_KEY", "devkey")
 	prefix := env("BOXLITE_E2E_PREFIX", "")
-	image := env("BOXLITE_E2E_IMAGE", "alpine:3.23")
+	image := env(
+		"BOXLITE_E2E_IMAGE",
+		"ghcr.io/boxlite-ai/boxlite-agent-base@sha256:834dcb65465985fc2f648451d76c81d166bc7672391c9064a0a115ce6306c85f",
+	)
 
 	rt, err := boxlite.NewRest(boxlite.BoxliteRestOptions{
 		URL:        url,

--- a/scripts/test/e2e/sdks/node/e2e_basic.ts
+++ b/scripts/test/e2e/sdks/node/e2e_basic.ts
@@ -26,7 +26,10 @@ function die(msg: string): never {
   const url = env('BOXLITE_E2E_URL', 'http://localhost:3000/api');
   const apiKey = env('BOXLITE_E2E_API_KEY', 'devkey');
   const prefix = env('BOXLITE_E2E_PREFIX', '');
-  const image = env('BOXLITE_E2E_IMAGE', 'alpine:3.23');
+  const image = env(
+    'BOXLITE_E2E_IMAGE',
+    'ghcr.io/boxlite-ai/boxlite-agent-base@sha256:834dcb65465985fc2f648451d76c81d166bc7672391c9064a0a115ce6306c85f',
+  );
 
   const rt = JsBoxlite.rest(new BoxliteRestOptions({
     url,


### PR DESCRIPTION
## Summary

Backend image + identity refactor against `main`. **No dashboard cloudBox migration, no TS SDK package removal** — those stay in #748.

1. **Image pipeline** — `image` is a first-class `Box` column; the full OCI ref flows end-to-end (request → PG → CREATE_BOX payload → `runtime.Create`) with no curated-key⇄ref translation. A thin allowlist gate validates at the request boundary only. Runner contract field is `image`. e2e adapted.
2. **Single box identity** — collapse the dual uuid/`boxId` into one 12-char base62 id (the PK). The internal engine id is never exposed; `boxId` (the redundant duplicate of the cloud id) is dropped everywhere.
3. **Regenerate the 4 API clients** (CI-faithful, run in a BoxLite box): `Box`/`AdminBoxItem`/`Workspace` lose `boxId`, gain `image`.
4. **Consumers of the dropped `boxId` fixed in place** (this is NOT the SDK removal): dashboard reads switch `boxId`→`id` (6 files); `sdk-typescript`'s `Box` mirrors the new api-client shape (drop `boxId` field, add `image`). The SDK **package** is untouched.

```text
id model:   uuid + boxId   ──►   one 12-char base62 id (cloud id)
                                  engine mints its own internal id, never exposed
image:      key/translation ──►   full OCI ref, single representation, no translation
```

## Scope boundary (what's deferred to #748)

- Removing the `sdk-typescript` package, the dashboard `cloudBox` migration, the Playground/VNC retirement, and the image-picker UI.
- This PR only touches `sdk-typescript/src/Box.ts` (field mirror) so it keeps compiling after the regen — the package deletion is #748's job.

## Verification

- `sdk-typescript` build OK · dashboard `tsc --noEmit` clean · API jest 112/112 · `go vet` clean (runner pkg) · engine unchanged vs `main`.
- API clients regenerated inside a BoxLite box (CI-faithful).

## Deployment

Baseline migration edited in place (box PK = `varchar(12)`, `image` column added, `boxId` dropped) → **requires a DB rebuild** (agreed; nothing launched).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added OCI image reference support for box creation with a curated allowlist of supported images.
  * Simplified box identity to use a single unified identifier.

* **Breaking Changes**
  * Updated `Box` schema: removed `boxId` field, added required `image` field.
  * Updated `Workspace` schema: removed `boxId`, made `image` required.
  * Updated `AdminBoxItem` schema: `organizationId` is now optional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->