### PR TITLE
refactor(box): drop the dead userId field from the runner payload

### DIFF
--- a/apps/api/src/box/runner-adapter/runnerAdapter.v0.ts
+++ b/apps/api/src/box/runner-adapter/runnerAdapter.v0.ts
@@ -147,7 +147,6 @@ export class RunnerAdapterV0 implements RunnerAdapter {
   async createBox(box: Box, metadata?: { [key: string]: string }): Promise<StartBoxResponse | undefined> {
     const response = await this.boxApiClient.create({
       id: box.id,
-      userId: box.organizationId,
       image: box.image ?? '',
       osUser: box.osUser,
       cpuQuota: box.cpu,
@@ -213,7 +212,6 @@ export class RunnerAdapterV0 implements RunnerAdapter {
 
   async recoverBox(box: Box): Promise<void> {
     const recoverBoxDTO: RecoverBoxDTO = {
-      userId: box.organizationId,
       osUser: box.osUser,
       cpuQuota: box.cpu,
       gpuQuota: box.gpu,

--- a/apps/api/src/box/runner-adapter/runnerAdapter.v2.ts
+++ b/apps/api/src/box/runner-adapter/runnerAdapter.v2.ts
@@ -121,7 +121,6 @@ export class RunnerAdapterV2 implements RunnerAdapter {
 
     const payload = {
       id: box.id,
-      userId: box.organizationId,
       image: box.image,
       osUser: box.osUser,
       cpuQuota: box.cpu,
@@ -182,7 +181,6 @@ export class RunnerAdapterV2 implements RunnerAdapter {
 
   async recoverBox(box: Box): Promise<void> {
     const recoverBoxDTO: RecoverBoxDTO = {
-      userId: box.organizationId,
       osUser: box.osUser,
       cpuQuota: box.cpu,
       gpuQuota: box.gpu,

--- a/apps/libs/runner-api-client/src/models/create-box-dto.ts
+++ b/apps/libs/runner-api-client/src/models/create-box-dto.ts
@@ -43,7 +43,6 @@ export interface CreateBoxDTO {
     'skipStart'?: boolean;
     'image': string;
     'storageQuota'?: number;
-    'userId': string;
     'volumes'?: Array<DtoVolumeDTO>;
 }
 

--- a/apps/libs/runner-api-client/src/models/recover-box-dto.ts
+++ b/apps/libs/runner-api-client/src/models/recover-box-dto.ts
@@ -30,7 +30,6 @@ export interface RecoverBoxDTO {
     'osUser': string;
     'snapshot'?: string;
     'storageQuota'?: number;
-    'userId': string;
     'volumes'?: Array<DtoVolumeDTO>;
 }
 

--- a/apps/runner/pkg/api/docs/docs.go
+++ b/apps/runner/pkg/api/docs/docs.go
@@ -1360,8 +1360,7 @@ const docTemplate = `{
             "required": [
                 "id",
                 "osUser",
-                "image",
-                "userId"
+                "image"
             ],
             "properties": {
                 "authToken": {
@@ -1434,9 +1433,6 @@ const docTemplate = `{
                 "storageQuota": {
                     "type": "integer",
                     "minimum": 1
-                },
-                "userId": {
-                    "type": "string"
                 },
                 "volumes": {
                     "type": "array",
@@ -1543,8 +1539,7 @@ const docTemplate = `{
             "type": "object",
             "required": [
                 "errorReason",
-                "osUser",
-                "userId"
+                "osUser"
             ],
             "properties": {
                 "backupErrorReason": {
@@ -1589,9 +1584,6 @@ const docTemplate = `{
                 "storageQuota": {
                     "type": "integer",
                     "minimum": 1
-                },
-                "userId": {
-                    "type": "string"
                 },
                 "volumes": {
                     "type": "array",

--- a/apps/runner/pkg/api/docs/swagger.json
+++ b/apps/runner/pkg/api/docs/swagger.json
@@ -1265,7 +1265,7 @@
     },
     "CreateBoxDTO": {
       "type": "object",
-      "required": ["id", "osUser", "image", "userId"],
+      "required": ["id", "osUser", "image"],
       "properties": {
         "authToken": {
           "type": "string"
@@ -1337,9 +1337,6 @@
         "storageQuota": {
           "type": "integer",
           "minimum": 1
-        },
-        "userId": {
-          "type": "string"
         },
         "volumes": {
           "type": "array",
@@ -1433,7 +1430,7 @@
     },
     "RecoverBoxDTO": {
       "type": "object",
-      "required": ["errorReason", "osUser", "userId"],
+      "required": ["errorReason", "osUser"],
       "properties": {
         "backupErrorReason": {
           "type": "string"
@@ -1477,9 +1474,6 @@
         "storageQuota": {
           "type": "integer",
           "minimum": 1
-        },
-        "userId": {
-          "type": "string"
         },
         "volumes": {
           "type": "array",

--- a/apps/runner/pkg/api/docs/swagger.yaml
+++ b/apps/runner/pkg/api/docs/swagger.yaml
@@ -98,8 +98,6 @@ definitions:
       storageQuota:
         minimum: 1
         type: integer
-      userId:
-        type: string
       volumes:
         items:
           $ref: '#/definitions/dto.VolumeDTO'
@@ -108,7 +106,6 @@ definitions:
       - id
       - osUser
       - image
-      - userId
     type: object
   ErrorResponse:
     description: Error response
@@ -206,8 +203,6 @@ definitions:
       storageQuota:
         minimum: 1
         type: integer
-      userId:
-        type: string
       volumes:
         items:
           $ref: '#/definitions/dto.VolumeDTO'
@@ -215,7 +210,6 @@ definitions:
     required:
       - errorReason
       - osUser
-      - userId
     type: object
   RegistryDTO:
     properties:

--- a/apps/runner/pkg/api/dto/box.go
+++ b/apps/runner/pkg/api/dto/box.go
@@ -8,7 +8,6 @@ type CreateBoxDTO struct {
 	Id               string            `json:"id" validate:"required"`
 	BoxId            string            `json:"boxId,omitempty"`
 	FromVolumeId     string            `json:"fromVolumeId,omitempty"`
-	UserId           string            `json:"userId" validate:"required"`
 	Image            string            `json:"image" validate:"required"`
 	OsUser           string            `json:"osUser" validate:"required"`
 	CpuQuota         int64             `json:"cpuQuota" validate:"min=1"`
@@ -46,7 +45,6 @@ type UpdateNetworkSettingsDTO struct {
 
 type RecoverBoxDTO struct {
 	FromVolumeId     string            `json:"fromVolumeId,omitempty"`
-	UserId           string            `json:"userId" validate:"required"`
 	OsUser           string            `json:"osUser" validate:"required"`
 	CpuQuota         int64             `json:"cpuQuota" validate:"min=1"`
 	GpuQuota         int64             `json:"gpuQuota" validate:"min=0"`

--- a/apps/runner/pkg/boxlite/stubs.go
+++ b/apps/runner/pkg/boxlite/stubs.go
@@ -104,7 +104,6 @@ func (c *Client) RecoverBox(ctx context.Context, boxId string, recoverDto dto.Re
 		NetworkBlockAll:  recoverDto.NetworkBlockAll,
 		NetworkAllowList: recoverDto.NetworkAllowList,
 		FromVolumeId:     recoverDto.FromVolumeId,
-		UserId:           recoverDto.UserId,
 	}
 
 	_, _, err := c.Create(ctx, createDto)


### PR DESCRIPTION
userId was a required-but-unused field in the runner CreateBoxDTO/RecoverBoxDTO — nothing reads it; the runner keys off organizationId. Removed from the Go DTOs + stub, the v2/v0 adapter payloads, the generated runner-api-client DTOs, and the swagger docs (json/yaml/docs.go). Auth/User userId is untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed `userId` field from box creation and recovery operations, streamlining the API request structure.
  * Updated API documentation and schemas to reflect the simplified contract.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->