### PR TITLE
feat(box): restrict box creation to the supported pinned images

### DIFF
--- a/apps/api/src/box/constants/curated-images.constant.spec.ts
+++ b/apps/api/src/box/constants/curated-images.constant.spec.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { BadRequestError } from '../../exceptions/bad-request.exception'
+import { assertSupportedImage, supportedImages } from './curated-images.constant'
+
+describe('supported image allowlist', () => {
+  const ENV_KEYS = ['BOXLITE_SYSTEM_BASE_IMAGE', 'BOXLITE_SYSTEM_PYTHON_IMAGE', 'BOXLITE_SYSTEM_NODE_IMAGE']
+  const saved: Record<string, string | undefined> = {}
+
+  beforeEach(() => {
+    // Isolate from the host env so the pinned fallback refs are deterministic.
+    for (const k of ENV_KEYS) {
+      saved[k] = process.env[k]
+      delete process.env[k]
+    }
+  })
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k]
+      else process.env[k] = saved[k]
+    }
+  })
+
+  it('exposes the three pinned ghcr refs, base first (the default)', () => {
+    const supported = supportedImages()
+    expect(supported).toHaveLength(3)
+    expect(supported[0]).toContain('ghcr.io/boxlite-ai/boxlite-agent-base@sha256:')
+    expect(supported[1]).toContain('ghcr.io/boxlite-ai/boxlite-agent-python@sha256:')
+    expect(supported[2]).toContain('ghcr.io/boxlite-ai/boxlite-agent-node@sha256:')
+  })
+
+  it('accepts each supported ref verbatim', () => {
+    for (const ref of supportedImages()) {
+      expect(assertSupportedImage(ref)).toBe(ref)
+    }
+  })
+
+  it('defaults to the base ref when no image is supplied', () => {
+    expect(assertSupportedImage(undefined)).toBe(supportedImages()[0])
+  })
+
+  it('prefers the env-configured ref over the pinned fallback', () => {
+    process.env.BOXLITE_SYSTEM_PYTHON_IMAGE = 'ghcr.io/boxlite-ai/override@sha256:deadbeef'
+    expect(assertSupportedImage('ghcr.io/boxlite-ai/override@sha256:deadbeef')).toBe(
+      'ghcr.io/boxlite-ai/override@sha256:deadbeef',
+    )
+  })
+
+  it('rejects anything outside the allowlist, naming the supported refs', () => {
+    expect(() => assertSupportedImage('alpine:3.23')).toThrow(BadRequestError)
+    expect(() => assertSupportedImage('ghcr.io/evil/image:latest')).toThrow(BadRequestError)
+    // legacy curated keys are no longer accepted -- only full refs are
+    expect(() => assertSupportedImage('python')).toThrow(BadRequestError)
+    expect(() => assertSupportedImage('nope')).toThrow(/Supported images: .*boxlite-agent-base/)
+  })
+})

--- a/apps/api/src/box/constants/curated-images.constant.ts
+++ b/apps/api/src/box/constants/curated-images.constant.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { BadRequestError } from '../../exceptions/bad-request.exception'
+
+/**
+ * Temporary curated-image gate: boxes may only boot from this fixed set of pinned OCI
+ * refs, because the runner pulls with its own private-registry token and must never be
+ * handed an arbitrary user-supplied image. The gate is deliberately thin and sits only
+ * at the request boundary (BoxService create / warm-pool); everything downstream treats
+ * `image` as an opaque OCI ref. When per-org custom images land, delete this file and
+ * its call sites — no other layer knows the curated set exists.
+ *
+ * Env overrides (set on the Api service in apps/infra/sst.config.ts) allow digest
+ * rotation without a code deploy; the fallbacks cover local/dev runs.
+ */
+const SUPPORTED_IMAGE_SOURCES: Array<{ envVar: string; fallbackRef: string }> = [
+  {
+    envVar: 'BOXLITE_SYSTEM_BASE_IMAGE',
+    fallbackRef:
+      'ghcr.io/boxlite-ai/boxlite-agent-base@sha256:834dcb65465985fc2f648451d76c81d166bc7672391c9064a0a115ce6306c85f',
+  },
+  {
+    envVar: 'BOXLITE_SYSTEM_PYTHON_IMAGE',
+    fallbackRef:
+      'ghcr.io/boxlite-ai/boxlite-agent-python@sha256:80d562a57f4bc12def4e54dbdb9e7d26d3268fe0767a2955ab5ad718041145d6',
+  },
+  {
+    envVar: 'BOXLITE_SYSTEM_NODE_IMAGE',
+    fallbackRef:
+      'ghcr.io/boxlite-ai/boxlite-agent-node@sha256:fcb8b840ab68567975853666c82fb6c59a3c1d14a0cdc31d7cbf3a01e6c6d247',
+  },
+]
+
+/** Pinned OCI refs a box may boot from. The first entry is the default image. */
+export function supportedImages(): string[] {
+  return SUPPORTED_IMAGE_SOURCES.map(({ envVar, fallbackRef }) => process.env[envVar] || fallbackRef)
+}
+
+/**
+ * Validate a user-supplied OCI ref at the request boundary. Undefined selects the
+ * default image; anything outside the supported set is rejected with the full list so
+ * callers can self-correct.
+ */
+export function assertSupportedImage(image: string | undefined): string {
+  const supported = supportedImages()
+
+  if (image === undefined) {
+    return supported[0]
+  }
+  if (!supported.includes(image)) {
+    throw new BadRequestError(`Unsupported image '${image}'. Supported images: ${supported.join(', ')}`)
+  }
+  return image
+}

--- a/apps/api/src/box/services/box.service.ts
+++ b/apps/api/src/box/services/box.service.ts
@@ -18,6 +18,7 @@ import { BoxError } from '../../exceptions/box-error.exception'
 import { BadRequestError } from '../../exceptions/bad-request.exception'
 import { Cron, CronExpression } from '@nestjs/schedule'
 import { BOX_WARM_POOL_UNASSIGNED_ORGANIZATION } from '../constants/box.constants'
+import { assertSupportedImage } from '../constants/curated-images.constant'
 import { BoxWarmPoolService } from './box-warm-pool.service'
 import { EventEmitter2, OnEvent } from '@nestjs/event-emitter'
 import { WarmPoolEvents } from '../constants/warmpool-events.constants'
@@ -158,7 +159,9 @@ export class BoxService {
       const mem = createBoxDto.memory ?? DEFAULT_BOX_MEM
       const disk = createBoxDto.disk ?? DEFAULT_BOX_DISK
       const gpu = createBoxDto.gpu ?? DEFAULT_BOX_GPU
-      const image = createBoxDto.image
+      // Restrict box creation to the supported pinned images; reject anything else
+      // at the request boundary (defaults undefined -> base image).
+      const image = assertSupportedImage(createBoxDto.image)
 
       this.organizationService.assertOrganizationIsNotSuspended(organization)
 


### PR DESCRIPTION
## Summary

main already accepts a free-form `image` string on box creation (landed in #755). **This PR adds only the curated allowlist on top** — the pre-launch security gate.

```text
main (#755):   create accepts ANY image string  →  runner pulls it
this PR:       create validates image against the supported pinned set
               (base / python / node, sha256-pinned ghcr refs)
               unsupported  → 400 listing the supported refs
               undefined    → defaults to the base image
```

Without this gate, a request can make the runner pull an arbitrary image using its private-registry token — so the allowlist is required before launch.

## Changes (server-side only)

- `apps/api/src/box/constants/curated-images.constant.ts` — `supportedImages()` / `assertSupportedImage()`; env-overridable (`BOXLITE_SYSTEM_{BASE,PYTHON,NODE}_IMAGE`) with sha256-pinned fallbacks. + spec.
- `box.service` create: validate `createBoxDto.image` at the request boundary.

## Scope boundary (what this PR is NOT)

- **No client regen** — the `image` field shape is unchanged (still a string), only its accepted values are restricted server-side.
- **No SDK / dashboard / identity changes.** The single-id collapse and the SDK removal are separate PRs.

## Verification

API jest 106/106 (curated allowlist spec 5/5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for image allowlist validation.

* **New Features**
  * The API now validates container image requests against a curated allowlist. Unsupported images are rejected with error messages listing available options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->