### PR TITLE
fix(runner): wait for toolbox readiness through daemon port

### DIFF
--- a/apps/runner/cmd/runner/config/config.go
+++ b/apps/runner/cmd/runner/config/config.go
@@ -37,6 +37,7 @@ type Config struct {
 	AWSSecretAccessKey                 string        `envconfig:"AWS_SECRET_ACCESS_KEY"`
 	AWSDefaultBucket                   string        `envconfig:"AWS_DEFAULT_BUCKET"`
 	ResourceLimitsDisabled             bool          `envconfig:"RESOURCE_LIMITS_DISABLED"`
+	DaemonStartTimeoutSec              int           `envconfig:"DAEMON_START_TIMEOUT_SEC"`
 	BoxStartTimeoutSec                 int           `envconfig:"BOX_START_TIMEOUT_SEC"`
 	UseSnapshotEntrypoint              bool          `envconfig:"USE_SNAPSHOT_ENTRYPOINT"`
 	Domain                             string        `envconfig:"RUNNER_DOMAIN" validate:"omitempty,hostname|ip"`

--- a/apps/runner/cmd/runner/main.go
+++ b/apps/runner/cmd/runner/main.go
@@ -118,6 +118,7 @@ func run() int {
 		VolumeCleanupInterval:        cfg.VolumeCleanupInterval,
 		VolumeCleanupDryRun:          cfg.VolumeCleanupDryRun,
 		VolumeCleanupExclusionPeriod: cfg.VolumeCleanupExclusionPeriod,
+		ToolboxReadyTimeout:          time.Duration(cfg.DaemonStartTimeoutSec) * time.Second,
 	})
 	if err != nil {
 		logger.Error("Error creating BoxLite client", "error", err)

--- a/apps/runner/pkg/boxlite/client.go
+++ b/apps/runner/pkg/boxlite/client.go
@@ -37,6 +37,7 @@ type Client struct {
 	volumeMutexesMutex  sync.Mutex
 	volumeCleanupMutex  sync.Mutex
 	toolboxPortMutex    sync.Mutex
+	toolboxReadyTimeout time.Duration
 	lastVolumeCleanup   time.Time
 	volumeCleanup       volumeCleanupConfig
 }
@@ -55,6 +56,7 @@ type ClientConfig struct {
 	VolumeCleanupInterval        time.Duration
 	VolumeCleanupDryRun          bool
 	VolumeCleanupExclusionPeriod time.Duration
+	ToolboxReadyTimeout          time.Duration
 }
 
 func networkSpec(blockAll *bool, allowList *string) boxlite.NetworkSpec {
@@ -134,6 +136,11 @@ func buildImageRegistries(insecureRegistries []string, ghcrUsername, ghcrToken s
 
 // NewClient creates a new BoxLite client backed by the BoxLite VM runtime.
 func NewClient(ctx context.Context, config ClientConfig) (*Client, error) {
+	toolboxReadyTimeout := config.ToolboxReadyTimeout
+	if toolboxReadyTimeout <= 0 {
+		toolboxReadyTimeout = 30 * time.Second
+	}
+
 	var opts []boxlite.RuntimeOption
 	if config.HomeDir != "" {
 		opts = append(opts, boxlite.WithHomeDir(config.HomeDir))
@@ -164,6 +171,7 @@ func NewClient(ctx context.Context, config ClientConfig) (*Client, error) {
 		awsAccessKeyId:      config.AWSAccessKeyId,
 		awsSecretAccessKey:  config.AWSSecretAccessKey,
 		volumeMutexes:       make(map[string]*sync.Mutex),
+		toolboxReadyTimeout: toolboxReadyTimeout,
 		volumeCleanup: volumeCleanupConfig{
 			interval:        config.VolumeCleanupInterval,
 			dryRun:          config.VolumeCleanupDryRun,
@@ -297,6 +305,9 @@ func (c *Client) Create(ctx context.Context, boxDto dto.CreateBoxDTO) (string, s
 		if err := bx.Start(ctx); err != nil {
 			return bx.ID(), "", fmt.Errorf("failed to start box: %w", err)
 		}
+		if err := c.waitForToolboxReady(ctx, boxDto.Id); err != nil {
+			return bx.ID(), "", err
+		}
 	}
 
 	return bx.ID(), "boxlite", nil
@@ -313,6 +324,9 @@ func (c *Client) Start(ctx context.Context, boxId string, authToken *string, met
 		return "", err
 	}
 	if err := bx.Start(ctx); err != nil {
+		return "", err
+	}
+	if err := c.waitForToolboxReady(ctx, boxId); err != nil {
 		return "", err
 	}
 	return "boxlite", nil

--- a/apps/runner/pkg/boxlite/toolbox_ports.go
+++ b/apps/runner/pkg/boxlite/toolbox_ports.go
@@ -7,11 +7,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const (
@@ -57,6 +60,55 @@ func (c *Client) ToolboxHostPort(boxID string) (int, error) {
 	defer c.toolboxPortMutex.Unlock()
 
 	return c.readToolboxHostPort(boxID)
+}
+
+func (c *Client) waitForToolboxReady(ctx context.Context, boxID string) error {
+	hostPort, err := c.ToolboxHostPort(boxID)
+	if err != nil {
+		return fmt.Errorf("toolbox host port not available for box %s: %w", boxID, err)
+	}
+
+	timeout := c.toolboxReadyTimeout
+	if timeout <= 0 {
+		timeout = 30 * time.Second
+	}
+	readyCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	url := fmt.Sprintf("http://127.0.0.1:%d/version", hostPort)
+	client := http.Client{Timeout: time.Second}
+	ticker := time.NewTicker(200 * time.Millisecond)
+	defer ticker.Stop()
+
+	var lastErr error
+	for {
+		req, reqErr := http.NewRequestWithContext(readyCtx, http.MethodGet, url, nil)
+		if reqErr != nil {
+			return reqErr
+		}
+
+		resp, reqErr := client.Do(req)
+		if reqErr == nil {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+			if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+				c.logger.InfoContext(ctx, "box toolbox is ready", "box", boxID, "hostPort", hostPort)
+				return nil
+			}
+			lastErr = fmt.Errorf("unexpected status %d from %s", resp.StatusCode, url)
+		} else {
+			lastErr = reqErr
+		}
+
+		select {
+		case <-readyCtx.Done():
+			if lastErr != nil {
+				return fmt.Errorf("box toolbox not ready after %s (box=%s hostPort=%d): %w", timeout, boxID, hostPort, lastErr)
+			}
+			return fmt.Errorf("box toolbox not ready after %s (box=%s hostPort=%d)", timeout, boxID, hostPort)
+		case <-ticker.C:
+		}
+	}
 }
 
 func (c *Client) removeToolboxPortRecord(ctx context.Context, boxID string) error {

--- a/apps/runner/pkg/boxlite/toolbox_ports_test.go
+++ b/apps/runner/pkg/boxlite/toolbox_ports_test.go
@@ -6,7 +6,10 @@ package boxlite
 import (
 	"io"
 	"log/slog"
+	"net"
+	"net/http"
 	"testing"
+	"time"
 )
 
 func TestReserveToolboxHostPortPersistsRecord(t *testing.T) {
@@ -52,3 +55,60 @@ func TestRemoveToolboxPortRecord(t *testing.T) {
 	}
 }
 
+func TestWaitForToolboxReadyReturnsAfterVersionEndpointResponds(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/version", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"version":"test"}`))
+	})
+	server := &http.Server{Handler: mux}
+	go func() {
+		_ = server.Serve(listener)
+	}()
+	defer server.Close()
+
+	port := listener.Addr().(*net.TCPAddr).Port
+	client := &Client{
+		homeDir:             t.TempDir(),
+		logger:              slog.New(slog.NewTextHandler(io.Discard, nil)),
+		toolboxReadyTimeout: time.Second,
+	}
+	if err := client.writeToolboxPortRecord(toolboxPortRecord{
+		BoxID:     "box-1",
+		GuestPort: ToolboxGuestPort,
+		HostPort:  port,
+	}); err != nil {
+		t.Fatalf("writeToolboxPortRecord: %v", err)
+	}
+
+	if err := client.waitForToolboxReady(t.Context(), "box-1"); err != nil {
+		t.Fatalf("waitForToolboxReady: %v", err)
+	}
+}
+
+func TestWaitForToolboxReadyTimesOutWhenEndpointDoesNotRespond(t *testing.T) {
+	port, err := findAvailableLocalPort()
+	if err != nil {
+		t.Fatalf("findAvailableLocalPort: %v", err)
+	}
+	client := &Client{
+		homeDir:             t.TempDir(),
+		logger:              slog.New(slog.NewTextHandler(io.Discard, nil)),
+		toolboxReadyTimeout: 20 * time.Millisecond,
+	}
+	if err := client.writeToolboxPortRecord(toolboxPortRecord{
+		BoxID:     "box-1",
+		GuestPort: ToolboxGuestPort,
+		HostPort:  port,
+	}); err != nil {
+		t.Fatalf("writeToolboxPortRecord: %v", err)
+	}
+
+	if err := client.waitForToolboxReady(t.Context(), "box-1"); err == nil {
+		t.Fatal("expected waitForToolboxReady to time out")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `DAEMON_START_TIMEOUT_SEC` wiring into the runner client as the toolbox readiness timeout.
- After create/start, wait for the recorded toolbox host port to respond on `/version` before reporting the box as ready.
- Add focused tests for successful readiness and timeout behavior.

## Split
- Independent from the dashboard/API cleanup stack.
- Base: `main`

## Validation
- `gofmt` on touched runner files
- `git diff --check`

## Notes
- `NX_DAEMON=false yarn nx run runner:test` and `runner:lint` were blocked because this worktree lives under `.worktrees/` and Yarn Berry treats it as outside the declared workspace.
- `go test ./pkg/boxlite` was blocked by missing `sdks/go/libboxlite.a`.
- `make dev:go` was attempted to rebuild that library, but local vendored sources/submodules are not initialized: `ERROR: Vendored sources not found`.
