### PR TITLE
chore(ci): rename e2e-test workflow and label to e2e-local

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -159,7 +159,7 @@ is enabled. The workflow is dormant until repository variable
 4. Trigger a new push, pull request update, or manual dispatch and verify CodeQL analysis uploads successfully.
 5. Roll back by setting `CODEQL_ADVANCED_SETUP_ENABLED=false` and re-enabling default setup.
 
-### `e2e-test.yml`
+### `e2e-local.yml`
 
 Runs VM-based E2E integration tests on an ephemeral AWS EC2 self-hosted runner.
 
@@ -172,7 +172,7 @@ Runs VM-based E2E integration tests on an ephemeral AWS EC2 self-hosted runner.
 
 **Triggers:**
 - Push to `main` (path-filtered to `src/`, `sdks/`, `Cargo.*`)
-- Pull request with `e2e` label (cost-gated)
+- Pull request with `e2e-local` label (cost-gated)
 - Manual dispatch (`workflow_dispatch`)
 
 **Cost:** ~$0.34/hr (c8i.2xlarge). Typical run: 15-25 min → ~$0.09-0.14 per run.

--- a/.github/workflows/e2e-local.yml
+++ b/.github/workflows/e2e-local.yml
@@ -20,7 +20,7 @@
 #   GitHub: GitHub App → short-lived installation token (no PAT)
 #
 # Setup: ./scripts/ci/setup-ci-runner.sh
-name: E2E Tests
+name: E2E local
 
 on:
   push:
@@ -33,7 +33,7 @@ on:
       - 'sdks/**'
       - '**/Cargo.toml'
       - 'Cargo.lock'
-      - '.github/workflows/e2e-test.yml'
+      - '.github/workflows/e2e-local.yml'
   pull_request:
     types: [labeled, synchronize]
     branches: [main]
@@ -71,7 +71,7 @@ env:
 
 jobs:
   # =========================================================================
-  # Gate: PRs require 'e2e-test' label (only maintainers can add it)
+  # Gate: PRs require 'e2e-local' label (only maintainers can add it)
   # =========================================================================
   should-run:
     runs-on: ubuntu-latest
@@ -83,7 +83,7 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             LABELS='${{ toJson(github.event.pull_request.labels.*.name) }}'
-            if echo "$LABELS" | jq -e 'index("e2e-test")' > /dev/null 2>&1; then
+            if echo "$LABELS" | jq -e 'index("e2e-local")' > /dev/null 2>&1; then
               echo "run=true" >> "$GITHUB_OUTPUT"
             else
               echo "run=false" >> "$GITHUB_OUTPUT"
@@ -340,7 +340,7 @@ jobs:
       - name: Upload rescued prior-run logs
         uses: actions/upload-artifact@v4
         with:
-          name: e2e-test-logs-rescued-${{ github.run_id }}-${{ github.run_attempt }}
+          name: e2e-local-logs-rescued-${{ github.run_id }}-${{ github.run_attempt }}
           path: /tmp/boxlite-rescue/
           retention-days: 7
           if-no-files-found: ignore
@@ -455,7 +455,7 @@ jobs:
         if: failure() || cancelled()
         uses: actions/upload-artifact@v4
         with:
-          name: e2e-test-logs-${{ github.run_id }}-${{ github.run_attempt }}
+          name: e2e-local-logs-${{ github.run_id }}-${{ github.run_attempt }}
           path: |
             target/nextest/
             /tmp/boxlite-*/

--- a/scripts/ci/setup-ci-runner.sh
+++ b/scripts/ci/setup-ci-runner.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Set up AWS infrastructure for E2E integration test runner.
 #
-# This provisions everything needed to run the e2e-test.yml workflow:
+# This provisions everything needed to run the e2e-local.yml workflow:
 #   AWS: OIDC provider, IAM roles, instance profile, security group
 #   GitHub: Repository variables and secrets
 #
@@ -475,7 +475,7 @@ step_configure_github() {
     # hook_attributes.url is required by the API even if unused
     local manifest
     # default_permissions:
-    #   administration:     write — mint runner registration tokens (used by e2e-test.yml)
+    #   administration:     write — mint runner registration tokens (used by e2e-local.yml)
     #   actions_variables:  write — persist EC2_E2E_INSTANCE_ID across runs
     manifest=$(jq -n \
         --arg name "boxlite-e2e-runner" \
@@ -713,7 +713,7 @@ main() {
     print_info "Instance Profile: $INSTANCE_PROFILE_NAME"
     print_info "Security Group: $SG_ID"
     echo ""
-    print_success "Run: gh workflow run e2e-test.yml"
+    print_success "Run: gh workflow run e2e-local.yml"
 }
 
 main "$@"


### PR DESCRIPTION
## What

Renames the `e2e-test` workflow + cost-gate label to **`e2e-local`**, to mirror the sibling `e2e-stack` and make the split obvious:

| Workflow | Runs | Path |
|---|---|---|
| **`e2e-local.yml`** (was `e2e-test.yml`) | `make test:integration` | local / in-process — `Boxlite.default()` via PyO3/FFI, bypasses REST API + runner |
| `e2e-stack.yml` | `make test:e2e` | full stack — SDK → REST → runner → libkrun VM |

## Changes

- `git mv .github/workflows/e2e-test.yml → e2e-local.yml`; `name:` → **`E2E local`** (matches `E2E stack`)
- PR cost-gate: `jq index("e2e-test")` → `index("e2e-local")` (+ comment)
- `paths:` self-ref → `e2e-local.yml` (keeps it re-triggering on self-edits)
- upload artifacts `e2e-test-logs-*` → `e2e-local-logs-*`
- `.github/workflows/README.md`: heading + **fixed a stale bug** — it said the gate was the `e2e` label, the code actually checks the renamed label; both now read `e2e-local`
- `scripts/ci/setup-ci-runner.sh`: 2 comments + the `gh workflow run` hint

**Kept as-is:** internal job id `e2e-tests` (names the test-running job, not the workflow identity); unrelated `e2e-test-*` test fixtures.

## ⚠️ Merge-time follow-up (required)

The live GitHub label is still `e2e-test`. PR workflows run the **base-branch** copy of the workflow file, so the label must flip *together* with this landing on `main`, or labeled PRs silently stop gating. Right after merge:

```bash
gh label edit e2e-test --name e2e-local \
  --description "Triggers the local (in-process) E2E suite on the self-hosted runner"
```

(Atomic rename — preserves the color and every existing PR association.)

## Notes

- Not a required status check (it's label-gated → can't be required), so no branch-protection impact.
- actionlint reports two findings on this file (`boxlite-e2e` runner label, an `&&...||` KVM check) — both pre-existing, on lines this PR doesn't touch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated workflow documentation to reference the E2E local testing process.

* **Chores**
  * Renamed E2E testing workflow and updated PR trigger label to `e2e-local`.
  * Updated artifact naming for test logs and recovery files in E2E workflow.
  * Updated CI setup script to reference new workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->