### PR TITLE
fix(proxy): scope CORS reflection to trusted origins, not all origins

### DIFF
--- a/apps/proxy/cmd/proxy/config/config.go
+++ b/apps/proxy/cmd/proxy/config/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	ProxyProtocol         string             `envconfig:"PROXY_PROTOCOL" validate:"required"`
 	ProxyApiKey           string             `envconfig:"PROXY_API_KEY" validate:"required"`
 	CookieDomain          *string            `envconfig:"COOKIE_DOMAIN"`
+	CorsAllowedOrigins    []string           `envconfig:"CORS_ALLOWED_ORIGINS"`
 	TLSCertFile           string             `envconfig:"TLS_CERT_FILE"`
 	TLSKeyFile            string             `envconfig:"TLS_KEY_FILE"`
 	EnableTLS             bool               `envconfig:"ENABLE_TLS"`

--- a/apps/proxy/pkg/proxy/cors.go
+++ b/apps/proxy/pkg/proxy/cors.go
@@ -1,0 +1,98 @@
+// Copyright 2025 BoxLite AI (originally Daytona Platforms Inc.
+// Modified by BoxLite AI, 2025-2026
+// SPDX-License-Identifier: AGPL-3.0
+
+package proxy
+
+import (
+	"maps"
+	"net"
+	"net/url"
+	"slices"
+	"strings"
+
+	"github.com/gin-contrib/cors"
+	"github.com/gin-gonic/gin"
+)
+
+// corsMiddleware reflects the request Origin with credentials only for trusted
+// origins. The previous implementation reflected ANY origin while also setting
+// Access-Control-Allow-Credentials: true, which let any website read a victim's
+// authenticated box preview / toolbox responses cross-origin. CORS credentialed
+// access is now scoped to origins that share the box-serving (cookie) domain —
+// the same scope the auth cookie is set on — plus an explicit operator allowlist
+// (e.g. a dashboard hosted on a different domain).
+func corsMiddleware(allowedOrigins []string, cookieDomain *string) gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		if ctx.Request.Header.Get("X-BoxLite-Disable-CORS") == "true" {
+			ctx.Request.Header.Del("X-BoxLite-Disable-CORS")
+			return
+		}
+
+		requestHost := ctx.Request.Host
+		corsConfig := cors.DefaultConfig()
+		corsConfig.AllowOriginFunc = func(origin string) bool {
+			return corsOriginAllowed(origin, requestHost, cookieDomain, allowedOrigins)
+		}
+		corsConfig.AllowCredentials = true
+		corsConfig.AllowHeaders = slices.Collect(maps.Keys(ctx.Request.Header))
+		corsConfig.AllowHeaders = append(corsConfig.AllowHeaders, ctx.Request.Header.Values("Access-Control-Request-Headers")...)
+
+		cors.New(corsConfig)(ctx)
+	}
+}
+
+// corsOriginAllowed reports whether origin may receive a credentialed CORS
+// response for a request served on requestHost. An origin is trusted when it is
+// the same host as the request, shares the configured cookie/serving domain, or
+// is listed verbatim in the operator allowlist. Everything else (e.g. evil.com)
+// is rejected, so the browser blocks cross-origin reads of authenticated content.
+func corsOriginAllowed(origin, requestHost string, cookieDomain *string, allowlist []string) bool {
+	if origin == "" {
+		return false
+	}
+
+	for _, allowed := range allowlist {
+		if strings.EqualFold(strings.TrimSpace(allowed), origin) {
+			return true
+		}
+	}
+
+	parsed, err := url.Parse(origin)
+	if err != nil {
+		return false
+	}
+	originHost := strings.ToLower(parsed.Hostname())
+	if originHost == "" {
+		return false
+	}
+
+	reqHost := strings.ToLower(hostWithoutPort(requestHost))
+	if originHost == reqHost {
+		return true
+	}
+
+	base := corsBaseDomain(cookieDomain, reqHost)
+	if base == "" {
+		return false
+	}
+	return originHost == base || strings.HasSuffix(originHost, "."+base)
+}
+
+// corsBaseDomain returns the registrable serving domain (no leading dot, lower
+// case) that box subdomains live under. It prefers the configured cookie domain
+// (which is exactly the scope the auth cookie is shared on) and falls back to the
+// request host so that, absent configuration, only the exact host is trusted.
+func corsBaseDomain(cookieDomain *string, reqHost string) string {
+	if cookieDomain != nil && *cookieDomain != "" {
+		return strings.ToLower(strings.TrimPrefix(hostWithoutPort(*cookieDomain), "."))
+	}
+	return reqHost
+}
+
+func hostWithoutPort(host string) string {
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		return h
+	}
+	return host
+}

--- a/apps/proxy/pkg/proxy/cors_test.go
+++ b/apps/proxy/pkg/proxy/cors_test.go
@@ -1,0 +1,75 @@
+// Copyright 2025 BoxLite AI (originally Daytona Platforms Inc.
+// Modified by BoxLite AI, 2025-2026
+// SPDX-License-Identifier: AGPL-3.0
+
+package proxy
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func init() { gin.SetMode(gin.TestMode) }
+
+// runCORS sends a GET carrying the given Origin/Host through the production
+// corsMiddleware and returns the reflected Access-Control-Allow-Origin header.
+func runCORS(t *testing.T, origin, host string, cookieDomain *string, allowlist []string) (string, string) {
+	t.Helper()
+	r := gin.New()
+	r.Use(corsMiddleware(allowlist, cookieDomain))
+	r.GET("/x", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	req.Host = host
+	req.Header.Set("Origin", origin)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+	return rr.Header().Get("Access-Control-Allow-Origin"), rr.Header().Get("Access-Control-Allow-Credentials")
+}
+
+func strptr(s string) *string { return &s }
+
+// TestCORSMiddleware_RejectsUntrustedOrigin is the security regression: an
+// attacker origin must NOT be reflected with credentials. Before the fix the
+// middleware reflected every origin alongside Access-Control-Allow-Credentials,
+// so evil.com could read a victim's authenticated box/toolbox responses.
+func TestCORSMiddleware_RejectsUntrustedOrigin(t *testing.T) {
+	cookieDomain := strptr(".example.com")
+
+	acao, _ := runCORS(t, "https://evil.com", "box.example.com", cookieDomain, nil)
+	if acao == "https://evil.com" || acao == "*" {
+		t.Errorf("untrusted origin reflected: Access-Control-Allow-Origin = %q, want empty", acao)
+	}
+}
+
+// TestCORSMiddleware_AllowsTrustedOrigins verifies legitimate cross-origin
+// access still works: a sibling subdomain under the cookie domain and an
+// explicitly allowlisted origin are reflected with credentials. (Same-origin
+// requests need no CORS header and are short-circuited by the CORS library.)
+func TestCORSMiddleware_AllowsTrustedOrigins(t *testing.T) {
+	cookieDomain := strptr(".example.com")
+
+	cases := []struct {
+		name      string
+		origin    string
+		host      string
+		allowlist []string
+	}{
+		{"sibling subdomain", "https://app.example.com", "box.example.com", nil},
+		{"allowlisted other domain", "https://dashboard.acme.io", "box.example.com", []string{"https://dashboard.acme.io"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			acao, acac := runCORS(t, tc.origin, tc.host, cookieDomain, tc.allowlist)
+			if acao != tc.origin {
+				t.Errorf("trusted origin not reflected: Access-Control-Allow-Origin = %q, want %q", acao, tc.origin)
+			}
+			if acac != "true" {
+				t.Errorf("Access-Control-Allow-Credentials = %q, want \"true\"", acac)
+			}
+		})
+	}
+}

--- a/apps/proxy/pkg/proxy/proxy.go
+++ b/apps/proxy/pkg/proxy/proxy.go
@@ -8,10 +8,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"maps"
 	"net"
 	"net/http"
-	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -19,7 +17,6 @@ import (
 	apiclient "github.com/boxlite-ai/boxlite/libs/api-client-go"
 	"github.com/boxlite-ai/proxy/cmd/proxy/config"
 	"github.com/boxlite-ai/proxy/internal"
-	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/securecookie"
 
@@ -145,22 +142,7 @@ func StartProxy(ctx context.Context, config *config.Config) error {
 		}
 	}))
 
-	router.Use(func(ctx *gin.Context) {
-		if ctx.Request.Header.Get("X-BoxLite-Disable-CORS") == "true" {
-			ctx.Request.Header.Del("X-BoxLite-Disable-CORS")
-			return
-		}
-
-		corsConfig := cors.DefaultConfig()
-		corsConfig.AllowOriginFunc = func(origin string) bool {
-			return true
-		}
-		corsConfig.AllowCredentials = true
-		corsConfig.AllowHeaders = slices.Collect(maps.Keys(ctx.Request.Header))
-		corsConfig.AllowHeaders = append(corsConfig.AllowHeaders, ctx.Request.Header.Values("Access-Control-Request-Headers")...)
-
-		cors.New(corsConfig)(ctx)
-	})
+	router.Use(corsMiddleware(config.CorsAllowedOrigins, proxy.cookieDomain))
 
 	if config.PreviewWarningEnabled {
 		router.Use(proxy.browserWarningMiddleware())


### PR DESCRIPTION
## Summary

Part of a source-level security audit of BoxLite. The preview/toolbox proxy set
a wildcard, credential-reflecting CORS policy:

```go
corsConfig.AllowOriginFunc = func(origin string) bool { return true }
corsConfig.AllowCredentials = true
```

applied globally in front of the cookie-authenticated box preview / `/toolbox/<id>`
handlers. Any site a victim visited could then issue `fetch(..., {credentials:'include'})`
and read the victim's authenticated box content cross-origin.

## Fix

Replace the reflect-all `AllowOriginFunc` with `corsOriginAllowed`, which trusts
an origin only when it is the same host, shares the box-serving cookie domain
(the exact scope the auth cookie lives on), or is in the new optional
`CORS_ALLOWED_ORIGINS` operator allowlist. Untrusted origins receive no
`Access-Control-Allow-Origin`. Same-origin requests are unaffected; the
`X-BoxLite-Disable-CORS` bypass header is preserved.

## Test (two-sided)

`TestCORSMiddleware_RejectsUntrustedOrigin` drives the real `corsMiddleware`
through a gin engine. With `corsOriginAllowed` reverted to its pre-fix
reflect-all behavior, `evil.com` is reflected and the test fails; with the fix
it is not. `TestCORSMiddleware_AllowsTrustedOrigins` confirms sibling-subdomain
and allowlisted origins still work.

Audit finding #3 (high).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
