### PR TITLE
fix(images): validate content digests before using them as paths

### DIFF
--- a/src/boxlite/src/images/mod.rs
+++ b/src/boxlite/src/images/mod.rs
@@ -13,7 +13,46 @@ pub use image_disk::ImageDiskManager;
 pub use manager::ImageManager;
 pub use object::ImageObject;
 
+use boxlite_shared::{BoxliteError, BoxliteResult};
 use oci_client::Reference;
+
+/// Validate that a content digest is a well-formed `algorithm:hex` string before
+/// it is used to build filesystem paths.
+///
+/// Digests read from OCI `index.json` / image manifests are attacker-controlled
+/// for locally loaded bundles (and not content-verified there), yet they are
+/// interpolated into blob paths via `digest.replace(':', "/")` /
+/// `digest.replace(':', "-")`. Without this check a crafted digest such as
+/// `sha256:../../../../etc/passwd` escapes the blob directory (path traversal —
+/// arbitrary host file read, or a confused-deputy write into the cache). A valid
+/// digest contains exactly one `:` and a fixed-length lower-case hex body, so it
+/// can never contain `/`, `\`, or `..`.
+pub(crate) fn validate_digest(digest: &str) -> BoxliteResult<()> {
+    let (algorithm, hex) = digest.split_once(':').ok_or_else(|| {
+        BoxliteError::Storage(format!(
+            "invalid digest {digest:?}: missing 'algorithm:' prefix"
+        ))
+    })?;
+
+    // Registered OCI digest algorithms; lengths are the hex-encoded digest sizes.
+    let expected_len = match algorithm {
+        "sha256" => 64,
+        "sha512" => 128,
+        _ => {
+            return Err(BoxliteError::Storage(format!(
+                "invalid digest {digest:?}: unsupported algorithm {algorithm:?}"
+            )));
+        }
+    };
+
+    if hex.len() != expected_len || !hex.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return Err(BoxliteError::Storage(format!(
+            "invalid digest {digest:?}: malformed {algorithm} hex body"
+        )));
+    }
+
+    Ok(())
+}
 
 // ============================================================================
 // Registry Resolution (Reference Iterator)

--- a/src/boxlite/src/images/storage.rs
+++ b/src/boxlite/src/images/storage.rs
@@ -284,6 +284,11 @@ impl ImageStorage {
         digest: &str,
         expected_size: i64,
     ) -> BoxliteResult<StagedDownload> {
+        // Reject malformed digests before interpolating them into a file path
+        // (defense in depth: the staged file is created before commit() verifies
+        // the content hash).
+        super::validate_digest(digest)?;
+
         // Extract expected hash from digest
         let expected_hash = digest
             .strip_prefix("sha256:")
@@ -373,6 +378,10 @@ impl ImageStorage {
     /// Use `staged.file()` to get the file for writing, then `staged.commit()`
     /// to verify and atomically move to final location.
     pub async fn stage_config_download(&self, digest: &str) -> BoxliteResult<StagedDownload> {
+        // Reject malformed digests before interpolating them into a file path
+        // (defense in depth: see stage_layer_download).
+        super::validate_digest(digest)?;
+
         // Extract expected hash from digest
         let expected_hash = digest
             .strip_prefix("sha256:")

--- a/src/boxlite/src/images/store.rs
+++ b/src/boxlite/src/images/store.rs
@@ -296,7 +296,10 @@ impl ImageStore {
         // 4. Resolve to ImageManifest (handles at most one level of ImageIndex)
         let manifest_digest = self.get_image_manifest(&path, manifest_desc)?;
 
-        // 5. Parse ImageManifest to extract config and layers
+        // 5. Parse ImageManifest to extract config and layers. The digest comes
+        // from attacker-controlled bundle metadata and is interpolated into a
+        // path below, so reject anything that isn't a well-formed digest.
+        super::validate_digest(&manifest_digest)?;
         let manifest_blob_path = path.join("blobs").join(manifest_digest.replace(':', "/"));
 
         let (config_digest_str, layers) = self.parse_oci_manifest_from_path(
@@ -349,6 +352,10 @@ impl ImageStore {
         match media_type {
             MediaType::ImageIndex => {
                 tracing::info!("ImageIndex detected, selecting platform-specific manifest");
+
+                // descriptor.digest is attacker-controlled bundle metadata and is
+                // interpolated into a path below; reject malformed digests.
+                super::validate_digest(&descriptor.digest)?;
 
                 // Load the ImageIndex blob
                 let index_blob_path = image_dir
@@ -1009,6 +1016,15 @@ impl ImageStore {
         let config_digest_str = oci_manifest.config.digest.clone();
         let layers = Self::layers_from_image(&oci_manifest)?;
 
+        // config and layer digests flow into blob paths (LocalBundleBlobSource /
+        // ImageStorage build paths from them). For local bundles the blobs are
+        // not content-verified, so a malformed digest would be a path-traversal
+        // primitive — validate every digest at this parse boundary.
+        super::validate_digest(&config_digest_str)?;
+        for layer in &layers {
+            super::validate_digest(&layer.digest)?;
+        }
+
         Ok((config_digest_str, layers))
     }
 }
@@ -1326,6 +1342,83 @@ mod tests {
         assert_eq!(manifest.layers[0].digest, layer_digest);
         assert!(!manifest.config_digest.is_empty());
         assert!(!manifest.manifest_digest.is_empty());
+    }
+
+    /// Build a local OCI bundle whose manifest declares a layer digest containing
+    /// a path-traversal payload instead of a real `sha256:<hex>`. The config blob
+    /// and the index→manifest reference are well-formed so that the only invalid
+    /// digest is the layer digest.
+    fn create_traversal_layer_bundle(bundle_dir: &Path, malicious_layer_digest: &str) {
+        use sha2::Digest;
+
+        std::fs::create_dir_all(bundle_dir.join("blobs/sha256")).unwrap();
+        std::fs::write(
+            bundle_dir.join("oci-layout"),
+            r#"{"imageLayoutVersion": "1.0.0"}"#,
+        )
+        .unwrap();
+
+        let config =
+            r#"{"architecture":"amd64","os":"linux","rootfs":{"type":"layers","diff_ids":[]}}"#;
+        let config_bytes = config.as_bytes();
+        let config_hex = sha2::Sha256::digest(config_bytes)
+            .iter()
+            .map(|b| format!("{:02x}", b))
+            .collect::<String>();
+        let config_digest = format!("sha256:{config_hex}");
+        std::fs::write(
+            bundle_dir.join("blobs/sha256").join(&config_hex),
+            config_bytes,
+        )
+        .unwrap();
+
+        let manifest = format!(
+            r#"{{"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json","config":{{"mediaType":"application/vnd.oci.image.config.v1+json","digest":"{config_digest}","size":{}}},"layers":[{{"mediaType":"application/vnd.oci.image.layer.v1.tar+gzip","digest":"{malicious_layer_digest}","size":123}}]}}"#,
+            config_bytes.len()
+        );
+        let manifest_bytes = manifest.as_bytes();
+        let manifest_hex = sha2::Sha256::digest(manifest_bytes)
+            .iter()
+            .map(|b| format!("{:02x}", b))
+            .collect::<String>();
+        let manifest_digest = format!("sha256:{manifest_hex}");
+        std::fs::write(
+            bundle_dir.join("blobs/sha256").join(&manifest_hex),
+            manifest_bytes,
+        )
+        .unwrap();
+
+        let index = format!(
+            r#"{{"schemaVersion":2,"manifests":[{{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"{manifest_digest}","size":{}}}]}}"#,
+            manifest_bytes.len()
+        );
+        std::fs::write(bundle_dir.join("index.json"), index).unwrap();
+    }
+
+    /// A layer digest carrying `../` path-traversal must be rejected at load time
+    /// rather than flowing into LocalBundleBlobSource's blob path (where, since
+    /// local bundles are not content-verified, it would be an arbitrary host-file
+    /// read primitive). With the digest validation reverted, load_from_local
+    /// accepts the malicious manifest and returns it (test fails); with the fix it
+    /// returns an error.
+    #[tokio::test]
+    async fn test_load_from_local_rejects_traversal_layer_digest() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let bundle_dir = temp_dir.path().join("bundle");
+        let images_dir = temp_dir.path().join("images");
+        let db_path = temp_dir.path().join("test.db");
+
+        create_traversal_layer_bundle(&bundle_dir, "sha256:../../../../../../../../etc/passwd");
+
+        let db = Database::open(&db_path).unwrap();
+        let store = ImageStore::new(images_dir, db, vec![]).unwrap();
+
+        let result = store.load_from_local(bundle_dir).await;
+        assert!(
+            result.is_err(),
+            "load_from_local accepted a path-traversal layer digest: {:?}",
+            result.map(|m| m.layers)
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Source-level security audit fix. OCI digests read from a local bundle's
`index.json` / image manifest are attacker-controlled, and (unlike registry
pulls) a local bundle's blobs are not content-verified, yet the digest is
interpolated into the blob path via `digest.replace(':', "/")`. A crafted
digest such as `sha256:../../../../../../etc/passwd` escapes the blob directory
— an arbitrary host-file read primitive (and a confused-deputy cache write on
writable paths).

## Fix

Add `images::validate_digest` (requires `sha256:`/`sha512:` + fixed-length
hex, so it can never contain `/`, `\`, or `..`) and call it at the parse
boundaries: `store.rs` `load_from_local` / `get_image_manifest` /
`parse_oci_manifest_from_path` (finding #5), and `storage.rs`
`stage_layer_download` / `stage_config_download` which create the staged file
before `commit()` verifies the hash (defense in depth, finding #11).

## Test (two-sided)

`test_load_from_local_rejects_traversal_layer_digest` loads a bundle whose
manifest declares a `sha256:../../../../../../../../etc/passwd` layer digest.
With the validation reverted, `load_from_local` returns the malicious manifest
and the test fails; with the fix it errors. The existing 132 image tests pass.

Audit findings #5 (high) and #11 (medium).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
