### PR TITLE
fix(ssh-gateway): pin runner host key for the gateway→runner hop

### DIFF
--- a/apps/ssh-gateway/main.go
+++ b/apps/ssh-gateway/main.go
@@ -31,11 +31,42 @@ const (
 )
 
 type SSHGateway struct {
-	port       int
-	apiClient  *apiclient.APIClient
-	hostKey    ssh.Signer
-	privateKey ssh.Signer
-	publicKey  ssh.PublicKey
+	port                  int
+	apiClient             *apiclient.APIClient
+	hostKey               ssh.Signer
+	privateKey            ssh.Signer
+	publicKey             ssh.PublicKey
+	runnerHostKeyCallback ssh.HostKeyCallback
+}
+
+// buildRunnerHostKeyCallback returns the HostKeyCallback used for the
+// gateway→runner SSH hop. When RUNNER_HOST_KEY (base64-encoded runner public
+// host key, authorized_keys or wire format) is configured, the runner's host
+// key is pinned via ssh.FixedHostKey, so a MITM on the gateway→runner path can
+// no longer impersonate the runner and intercept the proxied shell session.
+// When it is empty the previous (unverified) behavior is preserved so existing
+// deployments are not broken; the boolean reports whether verification is on so
+// the caller can log the downgrade.
+func buildRunnerHostKeyCallback(b64Key string) (ssh.HostKeyCallback, bool, error) {
+	if strings.TrimSpace(b64Key) == "" {
+		return ssh.InsecureIgnoreHostKey(), false, nil
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(b64Key)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to base64 decode RUNNER_HOST_KEY: %w", err)
+	}
+
+	// Accept either authorized_keys text ("ssh-ed25519 AAAA...") or raw wire format.
+	pub, _, _, _, err := ssh.ParseAuthorizedKey(decoded)
+	if err != nil {
+		pub, err = ssh.ParsePublicKey(decoded)
+		if err != nil {
+			return nil, false, fmt.Errorf("failed to parse RUNNER_HOST_KEY as public key: %w", err)
+		}
+	}
+
+	return ssh.FixedHostKey(pub), true, nil
 }
 
 func main() {
@@ -99,12 +130,23 @@ func main() {
 	// Generate public key from private key
 	publicKey := privateKey.PublicKey()
 
+	runnerHostKeyCallback, runnerHostKeyVerified, err := buildRunnerHostKeyCallback(getEnv("RUNNER_HOST_KEY", ""))
+	if err != nil {
+		log.Fatalf("Failed to configure runner host key verification: %v", err)
+	}
+	if runnerHostKeyVerified {
+		log.Printf("Runner host key pinned from RUNNER_HOST_KEY (gateway→runner host key verification enabled)")
+	} else {
+		log.Printf("WARNING: RUNNER_HOST_KEY not set; gateway→runner host key verification is DISABLED (MITM possible). Set RUNNER_HOST_KEY to the runner's base64 public host key to enable pinning.")
+	}
+
 	gateway := &SSHGateway{
-		port:       port,
-		apiClient:  apiClient,
-		hostKey:    hostKey,
-		privateKey: privateKey,
-		publicKey:  publicKey,
+		port:                  port,
+		apiClient:             apiClient,
+		hostKey:               hostKey,
+		privateKey:            privateKey,
+		publicKey:             publicKey,
+		runnerHostKeyCallback: runnerHostKeyCallback,
 	}
 
 	log.Printf("Host key loaded from SSH_HOST_KEY environment variable (base64 decoded)")
@@ -395,7 +437,7 @@ func (g *SSHGateway) connectToRunner(boxId string, runnerDomain string, signer s
 		Auth: []ssh.AuthMethod{
 			ssh.PublicKeys(signer),
 		},
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		HostKeyCallback: g.runnerHostKeyCallback,
 		Timeout:         30 * time.Second,
 	}
 

--- a/apps/ssh-gateway/runner_hostkey_test.go
+++ b/apps/ssh-gateway/runner_hostkey_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"net"
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+)
+
+func newTestHostKey(t *testing.T) (ssh.PublicKey, string) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer, err := ssh.NewSignerFromKey(priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = pub
+	authorized := ssh.MarshalAuthorizedKey(signer.PublicKey()) // "ssh-ed25519 AAAA...\n"
+	return signer.PublicKey(), base64.StdEncoding.EncodeToString(authorized)
+}
+
+// TestBuildRunnerHostKeyCallback_PinsConfiguredKey verifies that a configured
+// RUNNER_HOST_KEY pins the runner's host key: the matching key is accepted and a
+// different key is rejected. Before the fix the dial used
+// ssh.InsecureIgnoreHostKey(), which accepts ANY key (MITM possible).
+func TestBuildRunnerHostKeyCallback_PinsConfiguredKey(t *testing.T) {
+	wantPub, b64 := newTestHostKey(t)
+	otherPub, _ := newTestHostKey(t)
+
+	cb, verified, err := buildRunnerHostKeyCallback(b64)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !verified {
+		t.Fatal("expected verification enabled for a configured key")
+	}
+
+	addr := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 2220}
+	if err := cb("runner:2220", addr, wantPub); err != nil {
+		t.Errorf("pinned callback rejected the matching host key: %v", err)
+	}
+	if err := cb("runner:2220", addr, otherPub); err == nil {
+		t.Error("pinned callback accepted a DIFFERENT host key — MITM not prevented")
+	}
+}
+
+// TestBuildRunnerHostKeyCallback_EmptyPreservesBehavior documents that an unset
+// RUNNER_HOST_KEY keeps the previous (unverified) behavior rather than breaking
+// existing deployments — but reports verification as disabled.
+func TestBuildRunnerHostKeyCallback_EmptyPreservesBehavior(t *testing.T) {
+	cb, verified, err := buildRunnerHostKeyCallback("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if verified {
+		t.Fatal("expected verification disabled when no key configured")
+	}
+	anyPub, _ := newTestHostKey(t)
+	if err := cb("runner:2220", &net.TCPAddr{}, anyPub); err != nil {
+		t.Errorf("unconfigured callback should accept any key (legacy behavior), got: %v", err)
+	}
+}
+
+func TestBuildRunnerHostKeyCallback_InvalidKey(t *testing.T) {
+	if _, _, err := buildRunnerHostKeyCallback("!!!not-base64!!!"); err == nil {
+		t.Error("expected error for invalid base64 RUNNER_HOST_KEY")
+	}
+}


### PR DESCRIPTION
## Summary

Source-level security audit fix. The SSH gateway dialed the runner with
`ssh.InsecureIgnoreHostKey()`, so a MITM on the gateway↔runner path could
impersonate the runner and intercept the proxied interactive shell.

## Fix

Add `buildRunnerHostKeyCallback`, which pins the runner host key via
`ssh.FixedHostKey` when `RUNNER_HOST_KEY` (base64 public key) is configured —
mirroring how the gateway already loads its own `SSH_HOST_KEY`. When unset, the
previous behavior is preserved (no deployment breakage) but the downgrade is
logged loudly so operators can opt into verification.

## Test (two-sided)

`TestBuildRunnerHostKeyCallback_PinsConfiguredKey` accepts the matching host
key and rejects a different one; reverting the callback to the pre-fix
`ssh.InsecureIgnoreHostKey()` makes it accept the mismatched key and the test
fails ("MITM not prevented").

Audit finding #8 (medium).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
