### PR TITLE
fix(net): fail closed on WebSocket upgrades for secret-injected hosts

### DIFF
--- a/src/deps/libgvproxy-sys/gvproxy-bridge/mitm_proxy.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/mitm_proxy.go
@@ -62,6 +62,15 @@ func mitmAndForward(guestConn net.Conn, hostname string, destAddr string, ca *Bo
 		},
 	}
 
+	// mitmAndForward is only entered for hosts that have secrets configured, so
+	// fail closed on WebSocket upgrades: httputil.ReverseProxy relays Upgrade
+	// connections by copying frames verbatim, and secret substitution only runs
+	// on the HTTP request headers/body — a `<BOXLITE_SECRET:...>` placeholder
+	// inside a WebSocket message frame would be forwarded upstream unsubstituted.
+	// Reliable in-frame substitution is impractical (frames may be fragmented
+	// arbitrarily), so reject the upgrade rather than leak the placeholder.
+	handler := rejectWebSocketUpgrade(proxy, hostname, len(secrets) > 0)
+
 	if err := tlsGuest.Handshake(); err != nil {
 		logrus.WithError(err).WithField("hostname", hostname).Debug("MITM: TLS handshake failed")
 		guestConn.Close()
@@ -70,13 +79,13 @@ func mitmAndForward(guestConn net.Conn, hostname string, destAddr string, ca *Bo
 
 	if tlsGuest.ConnectionState().NegotiatedProtocol == "h2" {
 		h2srv := &http2.Server{}
-		h2srv.ServeConn(tlsGuest, &http2.ServeConnOpts{Handler: proxy})
+		h2srv.ServeConn(tlsGuest, &http2.ServeConnOpts{Handler: handler})
 	} else {
 		// HTTP/1.1: use http.Server with a proper shutdown mechanism.
 		// After the single connection closes, shut down the server to avoid
 		// leaking a goroutine blocked in Accept().
 		listener := newSingleConnListener(tlsGuest)
-		srv := &http.Server{Handler: proxy}
+		srv := &http.Server{Handler: handler}
 		srv.Serve(listener) //nolint:errcheck
 		// Serve returns when the connection closes — shut down to release resources
 		srv.Close()

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/mitm_websocket.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/mitm_websocket.go
@@ -30,6 +30,27 @@ func isWebSocketUpgrade(req *http.Request) bool {
 	return strings.EqualFold(upgrade, "websocket")
 }
 
+// rejectWebSocketUpgrade wraps the MITM reverse-proxy handler. When the host has
+// secrets configured (guard=true), it refuses WebSocket upgrades fail-closed:
+// frame bodies are relayed verbatim by httputil.ReverseProxy and are never
+// scanned for secret placeholders, so allowing the upgrade could leak a
+// `<BOXLITE_SECRET:...>` placeholder upstream. When guard=false the request is
+// passed through unchanged.
+func rejectWebSocketUpgrade(next http.Handler, hostname string, guard bool) http.Handler {
+	if !guard {
+		return next
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if isWebSocketUpgrade(req) {
+			logrus.WithField("hostname", hostname).
+				Warn("MITM: refusing WebSocket upgrade for secret-bearing host (frame bodies are not scrubbed)")
+			http.Error(w, "websocket upgrade not permitted for secret-injected host", http.StatusForbidden)
+			return
+		}
+		next.ServeHTTP(w, req)
+	})
+}
+
 // handleWebSocketUpgrade handles a WebSocket upgrade through the MITM proxy.
 // Optional upstreamTLSConfig overrides upstream TLS (nil = derive from hostname).
 //

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/mitm_websocket_test.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/mitm_websocket_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"io"
 	"net"
@@ -244,5 +245,83 @@ func TestHandleWebSocketUpgrade_BidirectionalRelay(t *testing.T) {
 
 	if strings.TrimSpace(line) != "hello" {
 		t.Errorf("expected echo 'hello', got %q", strings.TrimSpace(line))
+	}
+}
+
+// TestMitmAndForward_RejectsWebSocketForSecretHost drives the production MITM
+// entry point (mitmAndForward, only reached for secret-bearing hosts) and asserts
+// a WebSocket upgrade is refused fail-closed (403) and never relayed upstream.
+// Without the guard, httputil.ReverseProxy relays the upgrade verbatim, so the
+// guest receives 101 and the upstream sees the request — a `<BOXLITE_SECRET:...>`
+// placeholder embedded in a later frame body would be forwarded unsubstituted.
+// This test references only mitmAndForward so it compiles (and fails) with the
+// production change fully reverted.
+func TestMitmAndForward_RejectsWebSocketForSecretHost(t *testing.T) {
+	const host = "api.openai.com"
+	ca := newTestCA(t)
+
+	// TLS upstream: records if it is ever reached, replies with a 101 so the
+	// reverted (vulnerable) path would surface a switching-protocols response.
+	upstreamCert, err := ca.GenerateHostCert(host)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rawLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	upstreamLn := tls.NewListener(rawLn, &tls.Config{Certificates: []tls.Certificate{*upstreamCert}})
+	defer upstreamLn.Close()
+
+	upstreamHit := make(chan struct{}, 1)
+	go func() {
+		conn, err := upstreamLn.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		if _, err := http.ReadRequest(bufio.NewReader(conn)); err != nil {
+			return
+		}
+		select {
+		case upstreamHit <- struct{}{}:
+		default:
+		}
+		conn.Write([]byte("HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n"))
+	}()
+
+	guestConn, proxySide := net.Pipe()
+	defer guestConn.Close()
+	secrets := []SecretConfig{{Name: "o", Hosts: []string{host}, Placeholder: "<BOXLITE_SECRET:o>", Value: "v"}}
+	go mitmAndForward(proxySide, host, upstreamLn.Addr().String(), ca, secrets, &tls.Config{InsecureSkipVerify: true})
+
+	pool := x509.NewCertPool()
+	pool.AddCert(ca.cert)
+	cli := tls.Client(guestConn, &tls.Config{RootCAs: pool, ServerName: host, NextProtos: []string{"http/1.1"}})
+	_ = guestConn.SetDeadline(time.Now().Add(5 * time.Second))
+
+	req, err := http.NewRequest("GET", "https://"+host+"/ws", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Connection", "Upgrade")
+	req.Header.Set("Upgrade", "websocket")
+	if err := req.Write(cli); err != nil {
+		t.Fatalf("write upgrade request: %v", err)
+	}
+	resp, err := http.ReadResponse(bufio.NewReader(cli), req)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("WebSocket upgrade to secret host: status = %d, want %d (fail-closed)", resp.StatusCode, http.StatusForbidden)
+	}
+	select {
+	case <-upstreamHit:
+		t.Error("upstream received the WebSocket upgrade — guard did not block it; frame-body placeholders could leak")
+	case <-time.After(300 * time.Millisecond):
+		// expected: the guard rejected before any upstream dial
 	}
 }


### PR DESCRIPTION
## Summary

Source-level security audit fix. `mitmAndForward` (entered only for
secret-bearing hosts) relays WebSocket upgrades verbatim via
`httputil.ReverseProxy`. Secret substitution runs only on HTTP request
headers/body, so a `<BOXLITE_SECRET:...>` placeholder inside a WebSocket frame
body would be forwarded upstream unsubstituted.

## Fix

Wrap the MITM handler with `rejectWebSocketUpgrade`, which returns 403 for
`Upgrade: websocket` requests when the host has secrets (the only case
`mitmAndForward` handles). Reliable in-frame substitution is impractical
(frames may be fragmented arbitrarily), so fail closed.

## Test (two-sided)

`TestMitmAndForward_RejectsWebSocketForSecretHost` drives the real
`mitmAndForward`. With the change reverted the guest gets 101 and the upstream
sees the upgrade (test fails); with the fix the upgrade is refused (403) and
never dialed upstream.

Audit finding #15 (low).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
