### PR TITLE
fix(proxy): validate post-login returnTo to prevent open redirect

### DIFF
--- a/apps/proxy/pkg/proxy/auth_callback.go
+++ b/apps/proxy/pkg/proxy/auth_callback.go
@@ -127,8 +127,10 @@ func (p *Proxy) AuthCallback(ctx *gin.Context) {
 
 	ctx.SetCookie(BOX_AUTH_COOKIE_NAME+boxId, encoded, 3600, "/", cookieDomain, p.config.EnableTLS, true)
 
-	// Redirect back to the original URL
-	ctx.Redirect(http.StatusFound, returnTo)
+	// Redirect back to the original URL. returnTo comes from the (unsigned)
+	// state parameter, so validate it against the proxy's own host to avoid an
+	// open redirect; safeRedirectTarget falls back to "/" when it isn't trusted.
+	ctx.Redirect(http.StatusFound, safeRedirectTarget(returnTo, ctx.Request.Host, p.cookieDomain))
 }
 
 func (p *Proxy) getAuthUrl(ctx *gin.Context, boxId string) (string, error) {

--- a/apps/proxy/pkg/proxy/auth_redirect.go
+++ b/apps/proxy/pkg/proxy/auth_redirect.go
@@ -1,0 +1,70 @@
+// Copyright 2025 BoxLite AI (originally Daytona Platforms Inc.
+// Modified by BoxLite AI, 2025-2026
+// SPDX-License-Identifier: AGPL-3.0
+
+package proxy
+
+import (
+	"net"
+	"net/url"
+	"strings"
+)
+
+// safeRedirectTarget validates the post-login `returnTo` taken from the OAuth
+// `state` parameter before it is used in an HTTP redirect. The legitimate value
+// is always an absolute URL on the proxy's own host (see getAuthUrl), but state
+// is only base64-encoded and is attacker-controllable, so an unvalidated value
+// is an open redirect. Returns the target unchanged when it is safe, otherwise
+// falls back to "/" on the current origin.
+//
+// Safe means: a host-relative path, or an absolute URL whose host is the request
+// host or shares the box-serving (cookie) domain. Protocol-relative ("//host")
+// and backslash-obfuscated targets are rejected outright.
+func safeRedirectTarget(returnTo, requestHost string, cookieDomain *string) string {
+	const fallback = "/"
+
+	if returnTo == "" {
+		return fallback
+	}
+	// "//evil.com" is protocol-relative; "/\evil.com" and "\\evil.com" are
+	// browser-normalized to a host. Reject before parsing.
+	if strings.HasPrefix(returnTo, "//") || strings.Contains(returnTo, "\\") {
+		return fallback
+	}
+
+	parsed, err := url.Parse(returnTo)
+	if err != nil {
+		return fallback
+	}
+
+	// Host-relative path on the current origin.
+	if parsed.Host == "" {
+		if strings.HasPrefix(returnTo, "/") {
+			return returnTo
+		}
+		return fallback
+	}
+
+	host := strings.ToLower(redirectHostWithoutPort(parsed.Host))
+	reqHost := strings.ToLower(redirectHostWithoutPort(requestHost))
+	if host == reqHost {
+		return returnTo
+	}
+
+	base := ""
+	if cookieDomain != nil && *cookieDomain != "" {
+		base = strings.ToLower(strings.TrimPrefix(redirectHostWithoutPort(*cookieDomain), "."))
+	}
+	if base != "" && (host == base || strings.HasSuffix(host, "."+base)) {
+		return returnTo
+	}
+
+	return fallback
+}
+
+func redirectHostWithoutPort(host string) string {
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		return h
+	}
+	return host
+}

--- a/apps/proxy/pkg/proxy/auth_redirect_test.go
+++ b/apps/proxy/pkg/proxy/auth_redirect_test.go
@@ -1,0 +1,39 @@
+// Copyright 2025 BoxLite AI (originally Daytona Platforms Inc.
+// Modified by BoxLite AI, 2025-2026
+// SPDX-License-Identifier: AGPL-3.0
+
+package proxy
+
+import "testing"
+
+func TestSafeRedirectTarget(t *testing.T) {
+	cookieDomain := ".example.com"
+	const reqHost = "box.example.com"
+
+	// Untrusted / malicious targets must fall back to "/".
+	unsafe := []string{
+		"https://evil.com/phish",
+		"http://evil.com",
+		"//evil.com",
+		"/\\evil.com",
+		"https://box.example.com.evil.com/x",
+		"https://notexample.com",
+	}
+	for _, rt := range unsafe {
+		if got := safeRedirectTarget(rt, reqHost, &cookieDomain); got != "/" {
+			t.Errorf("safeRedirectTarget(%q) = %q, want \"/\" (open-redirect must be blocked)", rt, got)
+		}
+	}
+
+	// Trusted targets pass through unchanged.
+	safe := []string{
+		"/path/back",
+		"https://box.example.com/app",
+		"https://app.example.com/dashboard",
+	}
+	for _, rt := range safe {
+		if got := safeRedirectTarget(rt, reqHost, &cookieDomain); got != rt {
+			t.Errorf("safeRedirectTarget(%q) = %q, want it unchanged", rt, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Source-level security audit fix. The OAuth callback redirected to the
`returnTo` value taken from the `state` parameter without validation. `state`
is only base64-encoded (not signed), so a crafted link turns the login flow into
an open redirect.

## Fix

Add `safeRedirectTarget`, which passes `returnTo` through only when it is a
host-relative path or an absolute URL whose host is the request host or shares
the box-serving cookie domain. Protocol-relative (`//host`) and
backslash-obfuscated targets are rejected; anything untrusted falls back to `/`.

## Test (two-sided)

`TestSafeRedirectTarget` fails for every malicious target (external host,
protocol-relative, backslash, suffix-confusion) when `safeRedirectTarget` is
reverted to returning the raw value, and passes with the fix while leaving
legitimate same-origin / same-domain / relative targets unchanged.

Audit finding #16 (low).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
