### PR TITLE
fix(net): normalize trailing-dot SNI in secret-injection matcher

### DIFF
--- a/src/deps/libgvproxy-sys/gvproxy-bridge/mitm.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/mitm.go
@@ -224,9 +224,18 @@ func matchesWildcard(hostname, suffix string) bool {
 		!strings.Contains(hostname[:len(hostname)-len(suffix)], ".")
 }
 
+// normalizeHost lower-cases and strips the FQDN trailing dot so a guest-supplied
+// SNI like "api.openai.com." matches the same way the allow_net filter normalizes
+// it (tcp_filter.go MatchesHostname). Without trimming, a trailing-dot SNI would
+// pass the allowlist but skip secret substitution, sending the raw placeholder
+// upstream.
+func normalizeHost(hostname string) string {
+	return strings.ToLower(strings.TrimSuffix(hostname, "."))
+}
+
 // Matches returns true if hostname has associated secrets.
 func (m *SecretHostMatcher) Matches(hostname string) bool {
-	h := strings.ToLower(hostname)
+	h := normalizeHost(hostname)
 	if m.exactHosts[h] {
 		return true
 	}
@@ -240,7 +249,7 @@ func (m *SecretHostMatcher) Matches(hostname string) bool {
 
 // SecretsForHost returns all secrets whose Hosts list includes hostname.
 func (m *SecretHostMatcher) SecretsForHost(hostname string) []SecretConfig {
-	h := strings.ToLower(hostname)
+	h := normalizeHost(hostname)
 	var result []SecretConfig
 	for _, s := range m.secrets {
 		for _, host := range s.Hosts {

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/mitm_test.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/mitm_test.go
@@ -876,3 +876,27 @@ func containsString(ss []string, target string) bool {
 	}
 	return false
 }
+
+// TestSecretHostMatcher_TrailingDot verifies that a guest-supplied SNI with a
+// FQDN trailing dot ("api.openai.com.") still matches secret rules, the same way
+// the allow_net filter normalizes it (tcp_filter.go MatchesHostname strips the
+// trailing dot). Before the fix, the allowlist would admit the trailing-dot SNI
+// but the secret matcher would not, so the placeholder was forwarded upstream
+// unsubstituted.
+func TestSecretHostMatcher_TrailingDot(t *testing.T) {
+	m := NewSecretHostMatcher([]SecretConfig{
+		{Name: "openai", Hosts: []string{"api.openai.com"}, Placeholder: "<S>", Value: "v"},
+		{Name: "wild", Hosts: []string{"*.example.com"}, Placeholder: "<W>", Value: "w"},
+	})
+
+	assertTrue(t, m.Matches("api.openai.com."), "exact host with trailing dot")
+	assertTrue(t, m.Matches("API.OPENAI.COM."), "trailing dot + uppercase")
+	assertTrue(t, m.Matches("api.example.com."), "wildcard host with trailing dot")
+
+	if got := m.SecretsForHost("api.openai.com."); len(got) != 1 || got[0].Name != "openai" {
+		t.Errorf("SecretsForHost(trailing dot) = %v, want the openai secret", got)
+	}
+	if got := m.SecretsForHost("api.example.com."); len(got) != 1 || got[0].Name != "wild" {
+		t.Errorf("SecretsForHost(wildcard trailing dot) = %v, want the wild secret", got)
+	}
+}


### PR DESCRIPTION
## Summary

Source-level security audit fix. A guest-supplied SNI carrying the FQDN trailing
dot (e.g. `api.openai.com.`) is admitted by the `allow_net` filter (which
strips the dot) but the secret-injection matcher lowercased only and did not trim
it — so the connection was allowed and MITM'd, yet the `<BOXLITE_SECRET:...>`
placeholder was forwarded upstream unsubstituted instead of replaced.

## Fix

Add a shared `normalizeHost` (lowercase + `TrimSuffix(".")`) and apply it in
both `Matches` and `SecretsForHost`, matching how the allowlist normalizes
hostnames. Behavior is unchanged for SNIs without a trailing dot.

## Test (two-sided)

`TestSecretHostMatcher_TrailingDot` fails on every assertion with the change
reverted (trailing-dot host not matched) and passes with it applied.

Audit finding #14 (low). Note: finding #13 (allow_net wildcard depth) was
intentionally not changed — deep-subdomain matching is documented existing
behavior (TestTCPFilter_Wildcard) and never escapes the allowed parent domain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
