### PR TITLE
fix(images): fail closed on DiffID/layer count mismatch

### DIFF
--- a/src/boxlite/src/images/object.rs
+++ b/src/boxlite/src/images/object.rs
@@ -183,18 +183,19 @@ impl ImageObject {
 
         // Empty diff_ids is only legitimate for the LocalBundle path —
         // local OCI bundles can be loaded without a config.json and so
-        // carry no diff_ids list. A remote (Store) pull, by contrast,
-        // ALWAYS goes through a config-download that populates
-        // rootfs.diff_ids; an empty list there means either the config
-        // was tampered / dropped or the parser failed silently, and
-        // skipping verification turns the chain of trust into a no-op.
-        // Fail closed in the Store case; keep the LocalBundle skip.
+        // carry no diff_ids list. A remote (Store) pull resolves its
+        // diff_ids from a digest-verified config, and the loader
+        // (`load_diff_ids_from_config`) now errors instead of yielding an
+        // empty list when that config can't be read or parsed — so an empty
+        // list here means the config genuinely declared no DiffIDs, leaving
+        // the layers unverifiable. Fail closed in the Store case; keep the
+        // LocalBundle skip.
         if diff_ids.is_empty() {
             return match self.blob_source {
                 BlobSource::LocalBundle(_) => Ok(()),
                 BlobSource::Store(_) => Err(BoxliteError::Image(
-                    "rootfs.diff_ids is empty on a remote-pulled image; refusing to use image \
-                     without DiffID verification (config tampering / parse failure)"
+                    "rootfs.diff_ids is empty for a remote-pulled image; refusing to use image \
+                     without DiffID verification (config declared no DiffIDs)"
                         .to_string(),
                 )),
             };
@@ -215,10 +216,6 @@ impl ImageObject {
 
         for (i, (layer, diff_id)) in layers.iter().zip(diff_ids.iter()).enumerate() {
             let tarball_path = self.blob_source.layer_tarball_path(&layer.digest);
-            // A malformed diff_id in the list (wrong algorithm prefix,
-            // empty hash, etc.) means the config is tampered or
-            // malformed. Skipping that one layer's verification turned
-            // into a targetable per-layer bypass — fail closed.
             // A malformed diff_id in the list (wrong algorithm prefix,
             // empty hash, etc.) means the config is tampered or
             // malformed. Skipping that one layer's verification turned
@@ -428,9 +425,9 @@ mod tests {
             vec![],
             store_blob_source(&tmp),
         );
-        let err = obj.verify_diff_ids().expect_err(
-            "empty diff_ids on a remote-pulled (Store) image must fail closed",
-        );
+        let err = obj
+            .verify_diff_ids()
+            .expect_err("empty diff_ids on a remote-pulled (Store) image must fail closed");
         let msg = format!("{}", err);
         assert!(
             msg.contains("empty"),

--- a/src/boxlite/src/images/object.rs
+++ b/src/boxlite/src/images/object.rs
@@ -155,6 +155,10 @@ impl ImageObject {
     /// // extracted[2] = /images/extracted/sha256:ghi.../  (layer 2)
     /// ```
     pub async fn layer_extracted(&self) -> BoxliteResult<Vec<PathBuf>> {
+        // Reject a malformed/tampered manifest (empty-on-Store / count mismatch)
+        // before doing any extraction work or writing to the layer cache.
+        self.validate_diff_id_count()?;
+
         let digests: Vec<String> = self
             .manifest
             .layers
@@ -164,19 +168,17 @@ impl ImageObject {
 
         let extracted = self.blob_source.extract_layers(&digests).await?;
 
-        // Verify DiffIDs if available
+        // Full per-layer DiffID hashing (re-runs the cheap count check).
         self.verify_diff_ids()?;
 
         Ok(extracted)
     }
 
-    /// Verify layer DiffIDs against the image config's rootfs.diff_ids.
-    ///
-    /// DiffIDs are SHA256 hashes of the uncompressed layer tar content.
-    /// This ensures the decompressed filesystem content matches what the
-    /// image author intended.
-    fn verify_diff_ids(&self) -> BoxliteResult<()> {
-        use crate::images::archive::LayerVerifier;
+    /// Cheap structural check of `rootfs.diff_ids` against the layer list — no
+    /// I/O. Run before layer extraction so a malformed/tampered manifest is
+    /// rejected before any layer is decompressed or written to the cache, and
+    /// again inside [`verify_diff_ids`](Self::verify_diff_ids) for direct callers.
+    fn validate_diff_id_count(&self) -> BoxliteResult<()> {
         use crate::images::blob_source::BlobSource;
 
         let diff_ids = &self.manifest.diff_ids;
@@ -185,13 +187,13 @@ impl ImageObject {
         // local OCI bundles can be loaded without a config.json and so
         // carry no diff_ids list. A remote (Store) pull resolves its
         // diff_ids from a digest-verified config, and the loader
-        // (`load_diff_ids_from_config`) now errors instead of yielding an
-        // empty list when that config can't be read or parsed — so an empty
-        // list here means the config genuinely declared no DiffIDs, leaving
-        // the layers unverifiable. Fail closed in the Store case; keep the
-        // LocalBundle skip.
+        // (`load_diff_ids_from_config`) errors instead of yielding an empty
+        // list when that config can't be read, verified, or parsed — so an
+        // empty list here means the config genuinely declared no DiffIDs,
+        // leaving the layers unverifiable. Fail closed in the Store case;
+        // keep the LocalBundle skip.
         if diff_ids.is_empty() {
-            return match self.blob_source {
+            return match &self.blob_source {
                 BlobSource::LocalBundle(_) => Ok(()),
                 BlobSource::Store(_) => Err(BoxliteError::Image(
                     "rootfs.diff_ids is empty for a remote-pulled image; refusing to use image \
@@ -201,12 +203,12 @@ impl ImageObject {
             };
         }
 
+        // OCI requires exactly one diff_id per layer. A non-matching count is a
+        // malformed or tampered manifest, so fail closed instead of silently
+        // skipping verification (which would let an attacker disable DiffID
+        // checks by supplying a short list).
         let layers = &self.manifest.layers;
         if diff_ids.len() != layers.len() {
-            // The config declares rootfs.diff_ids; OCI requires exactly one per
-            // layer. A non-matching count is a malformed or tampered manifest, so
-            // fail closed instead of silently skipping verification (which would
-            // let an attacker disable DiffID checks by supplying a short list).
             return Err(BoxliteError::Image(format!(
                 "DiffID count ({}) does not match layer count ({}); refusing to use image with inconsistent rootfs.diff_ids",
                 diff_ids.len(),
@@ -214,6 +216,23 @@ impl ImageObject {
             )));
         }
 
+        Ok(())
+    }
+
+    /// Verify layer DiffIDs against the image config's rootfs.diff_ids.
+    ///
+    /// DiffIDs are SHA256 hashes of the uncompressed layer tar content.
+    /// This ensures the decompressed filesystem content matches what the
+    /// image author intended.
+    fn verify_diff_ids(&self) -> BoxliteResult<()> {
+        use crate::images::archive::LayerVerifier;
+
+        self.validate_diff_id_count()?;
+
+        // Empty diff_ids (LocalBundle) returned Ok above, so this zip runs zero
+        // times; otherwise the counts are equal and every layer is checked.
+        let diff_ids = &self.manifest.diff_ids;
+        let layers = &self.manifest.layers;
         for (i, (layer, diff_id)) in layers.iter().zip(diff_ids.iter()).enumerate() {
             let tarball_path = self.blob_source.layer_tarball_path(&layer.digest);
             // A malformed diff_id in the list (wrong algorithm prefix,
@@ -388,6 +407,25 @@ mod tests {
         assert!(
             obj.verify_diff_ids().is_err(),
             "expected count-mismatch diff_ids to be rejected"
+        );
+
+        // Inverse direction: a SHORT diff_ids list (fewer entries than layers)
+        // must also be rejected — otherwise an attacker could disable the check
+        // for the unlisted layers by truncating rootfs.diff_ids.
+        let obj = object_with(
+            vec![
+                layer("sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+                layer("sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"),
+            ],
+            vec![
+                "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                    .to_string(),
+            ],
+            local_bundle_blob_source(),
+        );
+        assert!(
+            obj.verify_diff_ids().is_err(),
+            "expected short diff_ids list to be rejected"
         );
     }
 

--- a/src/boxlite/src/images/object.rs
+++ b/src/boxlite/src/images/object.rs
@@ -177,10 +177,27 @@ impl ImageObject {
     /// image author intended.
     fn verify_diff_ids(&self) -> BoxliteResult<()> {
         use crate::images::archive::LayerVerifier;
+        use crate::images::blob_source::BlobSource;
 
         let diff_ids = &self.manifest.diff_ids;
+
+        // Empty diff_ids is only legitimate for the LocalBundle path —
+        // local OCI bundles can be loaded without a config.json and so
+        // carry no diff_ids list. A remote (Store) pull, by contrast,
+        // ALWAYS goes through a config-download that populates
+        // rootfs.diff_ids; an empty list there means either the config
+        // was tampered / dropped or the parser failed silently, and
+        // skipping verification turns the chain of trust into a no-op.
+        // Fail closed in the Store case; keep the LocalBundle skip.
         if diff_ids.is_empty() {
-            return Ok(());
+            return match self.blob_source {
+                BlobSource::LocalBundle(_) => Ok(()),
+                BlobSource::Store(_) => Err(BoxliteError::Image(
+                    "rootfs.diff_ids is empty on a remote-pulled image; refusing to use image \
+                     without DiffID verification (config tampering / parse failure)"
+                        .to_string(),
+                )),
+            };
         }
 
         let layers = &self.manifest.layers;
@@ -198,13 +215,20 @@ impl ImageObject {
 
         for (i, (layer, diff_id)) in layers.iter().zip(diff_ids.iter()).enumerate() {
             let tarball_path = self.blob_source.layer_tarball_path(&layer.digest);
-            let verifier = match LayerVerifier::new(diff_id) {
-                Ok(v) => v,
-                Err(e) => {
-                    tracing::warn!("DiffID parse error for layer {}: {}", i, e);
-                    continue;
-                }
-            };
+            // A malformed diff_id in the list (wrong algorithm prefix,
+            // empty hash, etc.) means the config is tampered or
+            // malformed. Skipping that one layer's verification turned
+            // into a targetable per-layer bypass — fail closed.
+            // A malformed diff_id in the list (wrong algorithm prefix,
+            // empty hash, etc.) means the config is tampered or
+            // malformed. Skipping that one layer's verification turned
+            // into a targetable per-layer bypass — fail closed.
+            let verifier = LayerVerifier::new(diff_id).map_err(|e| {
+                BoxliteError::Image(format!(
+                    "DiffID parse error for layer {} ({}): {}",
+                    i, layer.digest, e
+                ))
+            })?;
             match verifier.verify_tarball(&tarball_path) {
                 Ok(true) => {
                     tracing::debug!("DiffID verified for layer {}: {}", i, layer.digest);
@@ -217,8 +241,19 @@ impl ImageObject {
                     )));
                 }
                 Err(e) => {
-                    tracing::warn!("DiffID verification error for layer {}: {}", i, e);
-                    // Don't fail the pull on verification errors (e.g., unsupported format)
+                    // The historical comment here claimed this branch
+                    // existed for "unsupported format" — but TarballReader
+                    // only distinguishes gzip vs raw (treats anything
+                    // that isn't gzip magic as raw tar), so an
+                    // unsupported compression format surfaces as
+                    // Ok(false) hash mismatch, not Err. The Err variants
+                    // are real IO failures (file missing, mid-stream
+                    // read error) — that's a verification gap, not an
+                    // unverifiable layer. Fail closed.
+                    return Err(BoxliteError::Image(format!(
+                        "DiffID verification IO error for layer {} ({}): {}",
+                        i, layer.digest, e
+                    )));
                 }
             }
         }
@@ -285,9 +320,12 @@ impl std::fmt::Display for ImageObject {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::images::blob_source::{BlobSource, LocalBundleBlobSource};
+    use crate::images::blob_source::{BlobSource, LocalBundleBlobSource, StoreBlobSource};
     use crate::images::manager::{ImageManifest, LayerInfo};
+    use crate::images::storage::ImageStorage;
     use std::path::PathBuf;
+    use std::sync::Arc;
+    use tempfile::TempDir;
 
     fn layer(digest: &str) -> LayerInfo {
         LayerInfo {
@@ -297,7 +335,28 @@ mod tests {
         }
     }
 
-    fn object_with(layers: Vec<LayerInfo>, diff_ids: Vec<String>) -> ImageObject {
+    fn local_bundle_blob_source() -> BlobSource {
+        // Dummy paths — the branches under test reject the manifest
+        // before any blob is read, so nothing actually touches them.
+        BlobSource::LocalBundle(LocalBundleBlobSource::new(
+            PathBuf::from("/nonexistent/bundle"),
+            PathBuf::from("/nonexistent/cache"),
+        ))
+    }
+
+    fn store_blob_source(_tmp: &TempDir) -> BlobSource {
+        // A real ImageStorage rooted at a tmpdir so the BlobSource::Store
+        // discriminant is exercised. Empty-diff_ids and parse-error
+        // branches fire before any blob path is dereferenced.
+        let storage = Arc::new(ImageStorage::new(_tmp.path().to_path_buf()).unwrap());
+        BlobSource::Store(StoreBlobSource::new(storage))
+    }
+
+    fn object_with(
+        layers: Vec<LayerInfo>,
+        diff_ids: Vec<String>,
+        blob_source: BlobSource,
+    ) -> ImageObject {
         let manifest = ImageManifest {
             manifest_digest:
                 "sha256:0000000000000000000000000000000000000000000000000000000000000000"
@@ -308,12 +367,6 @@ mod tests {
                     .to_string(),
             diff_ids,
         };
-        // count-mismatch is rejected before any blob is touched, so a dummy
-        // blob source with unused paths is sufficient.
-        let blob_source = BlobSource::LocalBundle(LocalBundleBlobSource::new(
-            PathBuf::from("/nonexistent/bundle"),
-            PathBuf::from("/nonexistent/cache"),
-        ));
         ImageObject::new("test:image".to_string(), manifest, blob_source)
     }
 
@@ -333,6 +386,7 @@ mod tests {
                 "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
                     .to_string(),
             ],
+            local_bundle_blob_source(),
         );
         assert!(
             obj.verify_diff_ids().is_err(),
@@ -340,20 +394,113 @@ mod tests {
         );
     }
 
-    // Empty diff_ids (e.g. local bundles, or config not yet downloaded) remain a
-    // skip, not a hard failure — preserving existing behavior and avoiding
-    // breakage of legitimate local-bundle loads.
+    // Local bundles can legitimately load without a config.json (no diff_ids
+    // available), so an empty list on the LocalBundle path stays a skip —
+    // matches docker save / OCI bundle ergonomics and is the only path
+    // intentionally left lenient by the audit.
     #[test]
-    fn verify_diff_ids_allows_empty() {
+    fn verify_diff_ids_allows_empty_for_local_bundle() {
         let obj = object_with(
             vec![layer(
                 "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             )],
             vec![],
+            local_bundle_blob_source(),
         );
         assert!(
             obj.verify_diff_ids().is_ok(),
-            "empty diff_ids should skip verification"
+            "empty diff_ids on a local bundle should skip verification"
+        );
+    }
+
+    // A remote-pulled image ALWAYS goes through a config-download step that
+    // populates rootfs.diff_ids; an empty list there is tampering or a parse
+    // failure, and the previous "skip on empty" branch was a global bypass.
+    // With the fix reverted to `Ok(())` for the empty case, this returns Ok
+    // and the assertion fails.
+    #[test]
+    fn verify_diff_ids_rejects_empty_for_remote_store_source() {
+        let tmp = TempDir::new().unwrap();
+        let obj = object_with(
+            vec![layer(
+                "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            )],
+            vec![],
+            store_blob_source(&tmp),
+        );
+        let err = obj.verify_diff_ids().expect_err(
+            "empty diff_ids on a remote-pulled (Store) image must fail closed",
+        );
+        let msg = format!("{}", err);
+        assert!(
+            msg.contains("empty"),
+            "error should explain the empty-diff_ids cause, got: {msg}",
+        );
+    }
+
+    // A malformed diff_id in the list (wrong algorithm prefix, empty hash, etc.)
+    // is a tampered/malformed manifest. The previous `continue` swallowed the
+    // parse error and skipped that one layer's verification — turning into a
+    // targetable per-layer bypass. With the fix reverted to `continue`, this
+    // returns Ok and the assertion fails.
+    #[test]
+    fn verify_diff_ids_rejects_malformed_diff_id_in_list() {
+        let tmp = TempDir::new().unwrap();
+        // Put the malformed entry FIRST so LayerVerifier::new fires before
+        // verify_diff_ids walks past it to read any layer tarball from
+        // disk — otherwise the test would race with the (also-correct)
+        // IO-error fail-closed branch on a missing layer file.
+        let obj = object_with(
+            vec![
+                layer("sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+                layer("sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+            ],
+            vec![
+                // Wrong algorithm prefix — LayerVerifier::new returns Err.
+                "md5:dddddddddddddddddddddddddddddddd".to_string(),
+                "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                    .to_string(),
+            ],
+            store_blob_source(&tmp),
+        );
+        let err = obj
+            .verify_diff_ids()
+            .expect_err("malformed diff_id must fail closed (was: silently `continue`)");
+        let msg = format!("{}", err);
+        assert!(
+            msg.contains("parse error") || msg.contains("Invalid diff_id"),
+            "error should explain the parse failure, got: {msg}",
+        );
+    }
+
+    // A real IO error during verify_tarball (e.g. the layer tarball doesn't
+    // exist on disk) is a verification gap, not an unverifiable layer — the
+    // historical "skip on Err" branch claimed to be for "unsupported format",
+    // but TarballReader treats anything that isn't gzip magic as raw tar
+    // (unsupported-compression surfaces as Ok(false) hash mismatch). With the
+    // fix reverted to skip-on-Err, this returns Ok and the assertion fails.
+    #[test]
+    fn verify_diff_ids_rejects_io_error_during_verify() {
+        let tmp = TempDir::new().unwrap();
+        // diff_id well-formed → parse step succeeds → verify_tarball gets
+        // called on a path the BlobSource resolves to but no file exists.
+        let obj = object_with(
+            vec![layer(
+                "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            )],
+            vec![
+                "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                    .to_string(),
+            ],
+            store_blob_source(&tmp),
+        );
+        let err = obj
+            .verify_diff_ids()
+            .expect_err("IO error during verify must fail closed (was: silently warn-and-pass)");
+        let msg = format!("{}", err);
+        assert!(
+            msg.contains("IO error") || msg.contains("Failed to open"),
+            "error should surface the IO cause, got: {msg}",
         );
     }
 }

--- a/src/boxlite/src/images/object.rs
+++ b/src/boxlite/src/images/object.rs
@@ -185,12 +185,15 @@ impl ImageObject {
 
         let layers = &self.manifest.layers;
         if diff_ids.len() != layers.len() {
-            tracing::warn!(
-                "DiffID count ({}) doesn't match layer count ({}), skipping verification",
+            // The config declares rootfs.diff_ids; OCI requires exactly one per
+            // layer. A non-matching count is a malformed or tampered manifest, so
+            // fail closed instead of silently skipping verification (which would
+            // let an attacker disable DiffID checks by supplying a short list).
+            return Err(BoxliteError::Image(format!(
+                "DiffID count ({}) does not match layer count ({}); refusing to use image with inconsistent rootfs.diff_ids",
                 diff_ids.len(),
                 layers.len()
-            );
-            return Ok(());
+            )));
         }
 
         for (i, (layer, diff_id)) in layers.iter().zip(diff_ids.iter()).enumerate() {
@@ -276,5 +279,81 @@ impl std::fmt::Display for ImageObject {
             self.reference,
             self.manifest.layers.len()
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::images::blob_source::{BlobSource, LocalBundleBlobSource};
+    use crate::images::manager::{ImageManifest, LayerInfo};
+    use std::path::PathBuf;
+
+    fn layer(digest: &str) -> LayerInfo {
+        LayerInfo {
+            digest: digest.to_string(),
+            media_type: "application/vnd.oci.image.layer.v1.tar+gzip".to_string(),
+            size: 1,
+        }
+    }
+
+    fn object_with(layers: Vec<LayerInfo>, diff_ids: Vec<String>) -> ImageObject {
+        let manifest = ImageManifest {
+            manifest_digest:
+                "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+                    .to_string(),
+            layers,
+            config_digest:
+                "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+                    .to_string(),
+            diff_ids,
+        };
+        // count-mismatch is rejected before any blob is touched, so a dummy
+        // blob source with unused paths is sufficient.
+        let blob_source = BlobSource::LocalBundle(LocalBundleBlobSource::new(
+            PathBuf::from("/nonexistent/bundle"),
+            PathBuf::from("/nonexistent/cache"),
+        ));
+        ImageObject::new("test:image".to_string(), manifest, blob_source)
+    }
+
+    // A config that declares a different number of diff_ids than there are layers
+    // is malformed/tampered; verification must fail closed rather than silently
+    // skip (which would let an attacker disable DiffID checks). With the fix
+    // reverted this returns Ok and the assertion fails.
+    #[test]
+    fn verify_diff_ids_rejects_count_mismatch() {
+        let obj = object_with(
+            vec![layer(
+                "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            )],
+            vec![
+                "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                    .to_string(),
+                "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                    .to_string(),
+            ],
+        );
+        assert!(
+            obj.verify_diff_ids().is_err(),
+            "expected count-mismatch diff_ids to be rejected"
+        );
+    }
+
+    // Empty diff_ids (e.g. local bundles, or config not yet downloaded) remain a
+    // skip, not a hard failure — preserving existing behavior and avoiding
+    // breakage of legitimate local-bundle loads.
+    #[test]
+    fn verify_diff_ids_allows_empty() {
+        let obj = object_with(
+            vec![layer(
+                "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            )],
+            vec![],
+        );
+        assert!(
+            obj.verify_diff_ids().is_ok(),
+            "empty diff_ids should skip verification"
+        );
     }
 }

--- a/src/boxlite/src/images/store.rs
+++ b/src/boxlite/src/images/store.rs
@@ -510,27 +510,44 @@ impl ImageStore {
     ///
     /// Returns the DiffIDs the config declares — possibly an empty list, if the
     /// config genuinely declares none. Returns `Err` when the config blob can't
-    /// be read or parsed: a read/parse failure must NOT be silently mapped to an
-    /// empty list, because downstream `ImageObject::verify_diff_ids` treats an
-    /// empty list as "nothing to verify" and would skip DiffID verification
-    /// entirely — disabling the integrity check on a config we simply failed to
-    /// load. Distinguishing "config says none" from "we couldn't read the
-    /// config" keeps that decision honest.
+    /// be read, fails its digest check, or can't be parsed: none of these may be
+    /// silently mapped to an empty list, because downstream
+    /// `ImageObject::verify_diff_ids` treats an empty list as "nothing to verify"
+    /// and would skip DiffID verification entirely — disabling the integrity
+    /// check on a config we never actually trusted. Distinguishing "config says
+    /// none" from "we couldn't load/trust the config" keeps that decision honest.
     fn load_diff_ids_from_config(
         &self,
         inner: &ImageStoreInner,
         config_digest: &str,
     ) -> BoxliteResult<Vec<String>> {
+        use sha2::{Digest, Sha256};
+
         let config_path = inner.storage.config_path(config_digest);
-        let config_json = std::fs::read_to_string(&config_path).map_err(|e| {
+        let config_bytes = std::fs::read(&config_path).map_err(|e| {
             BoxliteError::Storage(format!(
                 "failed to read image config {} for diff_ids: {}",
                 config_digest, e
             ))
         })?;
 
-        let image_config: oci_spec::image::ImageConfiguration = serde_json::from_str(&config_json)
-            .map_err(|e| {
+        // The config blob is content-addressed by config_digest, but
+        // download_config takes an existence-only fast path and the cache-hit
+        // path never re-downloads — so re-verify the bytes here before trusting
+        // their DiffIDs. Otherwise a corrupted / tampered cached config could
+        // supply attacker-chosen rootfs.diff_ids and defeat layer verification.
+        let computed = format!("sha256:{:x}", Sha256::digest(&config_bytes));
+        if computed != config_digest {
+            return Err(BoxliteError::Storage(format!(
+                "image config digest mismatch: expected {}, computed {} ({} bytes)",
+                config_digest,
+                computed,
+                config_bytes.len()
+            )));
+        }
+
+        let image_config: oci_spec::image::ImageConfiguration =
+            serde_json::from_slice(&config_bytes).map_err(|e| {
                 BoxliteError::Storage(format!(
                     "failed to parse image config {} for diff_ids: {}",
                     config_digest, e
@@ -584,9 +601,9 @@ impl ImageStore {
         self.download_config(&client, reference, &image_manifest.config_digest)
             .await?;
 
-        // Step 5b: Parse diff_ids from config for DiffID verification. The
-        // config was just downloaded and digest-verified, so a read/parse
-        // failure here is a genuine fault (not tampering) and fails the pull.
+        // Step 5b: Parse diff_ids from config for DiffID verification.
+        // load_diff_ids_from_config re-verifies the config digest, so a
+        // read/digest/parse failure here is a genuine fault and fails the pull.
         {
             let inner = self.inner.read().await;
             image_manifest.diff_ids =
@@ -1614,30 +1631,72 @@ mod tests {
         ImageStore::new(temp_dir.join("images"), db, vec![]).unwrap()
     }
 
-    // A config blob that exists but isn't valid JSON must surface as an error,
-    // not an empty diff_ids list. The old code logged at debug and returned
-    // Vec::new(), which downstream `verify_diff_ids` would treat as "nothing to
-    // verify" — silently disabling DiffID verification for a config we merely
-    // failed to parse. With the fix reverted to `return Vec::new()` this returns
-    // Ok(empty) and `expect_err` panics.
+    /// Store `bytes` as a content-addressed config blob and return the digest
+    /// they hash to — mirrors how a real (untampered) config is stored, so
+    /// `load_diff_ids_from_config`'s digest check passes.
+    fn write_config_blob(inner: &ImageStoreInner, bytes: &[u8]) -> String {
+        use sha2::{Digest, Sha256};
+        let digest = format!("sha256:{:x}", Sha256::digest(bytes));
+        let path = inner.storage.config_path(&digest);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, bytes).unwrap();
+        digest
+    }
+
+    // A config blob whose bytes hash to its digest but aren't valid JSON must
+    // surface as an error, not an empty diff_ids list. The old code logged at
+    // debug and returned Vec::new(), which downstream `verify_diff_ids` would
+    // treat as "nothing to verify" — silently disabling DiffID verification for
+    // a config we merely failed to parse. With the fix reverted to
+    // `return Vec::new()` this returns Ok(empty) and `expect_err` panics.
     #[tokio::test]
     async fn load_diff_ids_from_config_errors_on_unparseable_config() {
         let temp_dir = tempfile::tempdir().unwrap();
         let store = store_with_tmp(temp_dir.path());
-        let config_digest =
-            "sha256:1111111111111111111111111111111111111111111111111111111111111111";
 
         let inner = store.inner.read().await;
-        let config_path = inner.storage.config_path(config_digest);
-        std::fs::create_dir_all(config_path.parent().unwrap()).unwrap();
-        std::fs::write(&config_path, b"{ not valid json").unwrap();
+        // Honestly-stored bytes (digest matches) that aren't valid JSON, so the
+        // failure is the parse step rather than the digest check.
+        let config_digest = write_config_blob(&inner, b"{ not valid json");
 
         let err = store
-            .load_diff_ids_from_config(&inner, config_digest)
+            .load_diff_ids_from_config(&inner, &config_digest)
             .expect_err("unparseable config must error, not yield empty diff_ids");
         assert!(
             err.to_string().contains("parse"),
             "error should name the parse failure, got: {err}"
+        );
+    }
+
+    // A config whose on-disk bytes do NOT hash to the requested digest must be
+    // rejected — a corrupted/tampered cache blob must not supply DiffIDs.
+    // Without the digest check the valid JSON parses fine and returns Ok, so
+    // `expect_err` panics.
+    #[tokio::test]
+    async fn load_diff_ids_from_config_errors_on_digest_mismatch() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let store = store_with_tmp(temp_dir.path());
+        let wrong_digest =
+            "sha256:0000000000000000000000000000000000000000000000000000000000000000";
+
+        let inner = store.inner.read().await;
+        // Valid config bytes deliberately stored under a digest they don't hash to.
+        let path = inner.storage.config_path(wrong_digest);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &path,
+            image_config_with_diff_ids(&[
+                "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            ]),
+        )
+        .unwrap();
+
+        let err = store
+            .load_diff_ids_from_config(&inner, wrong_digest)
+            .expect_err("config whose bytes don't match its digest must be rejected");
+        assert!(
+            err.to_string().contains("digest mismatch"),
+            "error should name the digest mismatch, got: {err}"
         );
     }
 
@@ -1661,26 +1720,22 @@ mod tests {
     }
 
     // The happy path: a valid config's declared diff_ids round-trip back through
-    // the JSON read + oci_spec parse (the value crosses a real boundary, not
+    // the digest check + oci_spec parse (the value crosses a real boundary, not
     // built by the test body).
     #[tokio::test]
     async fn load_diff_ids_from_config_returns_declared_diff_ids() {
         let temp_dir = tempfile::tempdir().unwrap();
         let store = store_with_tmp(temp_dir.path());
-        let config_digest =
-            "sha256:3333333333333333333333333333333333333333333333333333333333333333";
         let want = [
             "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
         ];
 
         let inner = store.inner.read().await;
-        let config_path = inner.storage.config_path(config_digest);
-        std::fs::create_dir_all(config_path.parent().unwrap()).unwrap();
-        std::fs::write(&config_path, image_config_with_diff_ids(&want)).unwrap();
+        let config_digest = write_config_blob(&inner, image_config_with_diff_ids(&want).as_bytes());
 
         let got = store
-            .load_diff_ids_from_config(&inner, config_digest)
+            .load_diff_ids_from_config(&inner, &config_digest)
             .unwrap();
         let want: Vec<String> = want.iter().map(|s| s.to_string()).collect();
         assert_eq!(got, want);
@@ -1688,21 +1743,17 @@ mod tests {
 
     // A config that genuinely declares no DiffIDs parses successfully and yields
     // an empty list — Ok, NOT Err. This is the distinction the fix preserves:
-    // "config says none" stays lenient, only "couldn't read/parse" fails.
+    // "config says none" stays lenient, only "couldn't read/verify/parse" fails.
     #[tokio::test]
     async fn load_diff_ids_from_config_allows_genuinely_empty() {
         let temp_dir = tempfile::tempdir().unwrap();
         let store = store_with_tmp(temp_dir.path());
-        let config_digest =
-            "sha256:4444444444444444444444444444444444444444444444444444444444444444";
 
         let inner = store.inner.read().await;
-        let config_path = inner.storage.config_path(config_digest);
-        std::fs::create_dir_all(config_path.parent().unwrap()).unwrap();
-        std::fs::write(&config_path, image_config_with_diff_ids(&[])).unwrap();
+        let config_digest = write_config_blob(&inner, image_config_with_diff_ids(&[]).as_bytes());
 
         let got = store
-            .load_diff_ids_from_config(&inner, config_digest)
+            .load_diff_ids_from_config(&inner, &config_digest)
             .unwrap();
         assert!(
             got.is_empty(),

--- a/src/boxlite/src/images/store.rs
+++ b/src/boxlite/src/images/store.rs
@@ -493,8 +493,10 @@ impl ImageStore {
             }
         };
 
-        // Load diff_ids from config if available
-        let diff_ids = self.load_diff_ids_from_config(inner, &config_digest);
+        // Load diff_ids from config. A cached config that can't be read/parsed
+        // errors here rather than yielding empty diff_ids (which would silently
+        // skip DiffID verification at extraction time).
+        let diff_ids = self.load_diff_ids_from_config(inner, &config_digest)?;
 
         Ok(ImageManifest {
             manifest_digest: cached.manifest_digest.clone(),
@@ -504,36 +506,43 @@ impl ImageStore {
         })
     }
 
-    /// Load diff_ids from image config on disk. Returns empty vec on any failure.
+    /// Load `rootfs.diff_ids` from the image config on disk.
+    ///
+    /// Returns the DiffIDs the config declares — possibly an empty list, if the
+    /// config genuinely declares none. Returns `Err` when the config blob can't
+    /// be read or parsed: a read/parse failure must NOT be silently mapped to an
+    /// empty list, because downstream `ImageObject::verify_diff_ids` treats an
+    /// empty list as "nothing to verify" and would skip DiffID verification
+    /// entirely — disabling the integrity check on a config we simply failed to
+    /// load. Distinguishing "config says none" from "we couldn't read the
+    /// config" keeps that decision honest.
     fn load_diff_ids_from_config(
         &self,
         inner: &ImageStoreInner,
         config_digest: &str,
-    ) -> Vec<String> {
+    ) -> BoxliteResult<Vec<String>> {
         let config_path = inner.storage.config_path(config_digest);
-        let config_json = match std::fs::read_to_string(&config_path) {
-            Ok(json) => json,
-            Err(e) => {
-                tracing::debug!("Cannot read config for diff_ids: {}", e);
-                return Vec::new();
-            }
-        };
+        let config_json = std::fs::read_to_string(&config_path).map_err(|e| {
+            BoxliteError::Storage(format!(
+                "failed to read image config {} for diff_ids: {}",
+                config_digest, e
+            ))
+        })?;
 
-        let image_config: oci_spec::image::ImageConfiguration =
-            match serde_json::from_str(&config_json) {
-                Ok(c) => c,
-                Err(e) => {
-                    tracing::debug!("Cannot parse config for diff_ids: {}", e);
-                    return Vec::new();
-                }
-            };
+        let image_config: oci_spec::image::ImageConfiguration = serde_json::from_str(&config_json)
+            .map_err(|e| {
+                BoxliteError::Storage(format!(
+                    "failed to parse image config {} for diff_ids: {}",
+                    config_digest, e
+                ))
+            })?;
 
-        image_config
+        Ok(image_config
             .rootfs()
             .diff_ids()
             .iter()
             .map(|d| d.to_string())
-            .collect()
+            .collect())
     }
 
     // ========================================================================
@@ -575,11 +584,13 @@ impl ImageStore {
         self.download_config(&client, reference, &image_manifest.config_digest)
             .await?;
 
-        // Step 5b: Parse diff_ids from config for DiffID verification
+        // Step 5b: Parse diff_ids from config for DiffID verification. The
+        // config was just downloaded and digest-verified, so a read/parse
+        // failure here is a genuine fault (not tampering) and fails the pull.
         {
             let inner = self.inner.read().await;
             image_manifest.diff_ids =
-                self.load_diff_ids_from_config(&inner, &image_manifest.config_digest);
+                self.load_diff_ids_from_config(&inner, &image_manifest.config_digest)?;
         }
 
         // Step 6: Update index using reference.whole() as the cache key
@@ -1579,6 +1590,123 @@ mod tests {
         assert!(
             err.contains("foreign") || err.contains("nondistributable"),
             "error should indicate rejection: {err}"
+        );
+    }
+
+    /// A minimal, valid OCI image config JSON declaring the given diff_ids.
+    fn image_config_with_diff_ids(diff_ids: &[&str]) -> String {
+        let ids = diff_ids
+            .iter()
+            .map(|d| format!("\"{d}\""))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!(
+            r#"{{
+                "architecture": "amd64",
+                "os": "linux",
+                "rootfs": {{ "type": "layers", "diff_ids": [{ids}] }}
+            }}"#
+        )
+    }
+
+    fn store_with_tmp(temp_dir: &Path) -> ImageStore {
+        let db = Database::open(&temp_dir.join("test.db")).unwrap();
+        ImageStore::new(temp_dir.join("images"), db, vec![]).unwrap()
+    }
+
+    // A config blob that exists but isn't valid JSON must surface as an error,
+    // not an empty diff_ids list. The old code logged at debug and returned
+    // Vec::new(), which downstream `verify_diff_ids` would treat as "nothing to
+    // verify" — silently disabling DiffID verification for a config we merely
+    // failed to parse. With the fix reverted to `return Vec::new()` this returns
+    // Ok(empty) and `expect_err` panics.
+    #[tokio::test]
+    async fn load_diff_ids_from_config_errors_on_unparseable_config() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let store = store_with_tmp(temp_dir.path());
+        let config_digest =
+            "sha256:1111111111111111111111111111111111111111111111111111111111111111";
+
+        let inner = store.inner.read().await;
+        let config_path = inner.storage.config_path(config_digest);
+        std::fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+        std::fs::write(&config_path, b"{ not valid json").unwrap();
+
+        let err = store
+            .load_diff_ids_from_config(&inner, config_digest)
+            .expect_err("unparseable config must error, not yield empty diff_ids");
+        assert!(
+            err.to_string().contains("parse"),
+            "error should name the parse failure, got: {err}"
+        );
+    }
+
+    // A missing config blob is likewise a load failure, not "no diff_ids".
+    // Reverting the fix makes this return Ok(empty) and `expect_err` panics.
+    #[tokio::test]
+    async fn load_diff_ids_from_config_errors_on_missing_config() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let store = store_with_tmp(temp_dir.path());
+        let config_digest =
+            "sha256:2222222222222222222222222222222222222222222222222222222222222222";
+
+        let inner = store.inner.read().await;
+        let err = store
+            .load_diff_ids_from_config(&inner, config_digest)
+            .expect_err("missing config must error, not yield empty diff_ids");
+        assert!(
+            err.to_string().contains("read"),
+            "error should name the read failure, got: {err}"
+        );
+    }
+
+    // The happy path: a valid config's declared diff_ids round-trip back through
+    // the JSON read + oci_spec parse (the value crosses a real boundary, not
+    // built by the test body).
+    #[tokio::test]
+    async fn load_diff_ids_from_config_returns_declared_diff_ids() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let store = store_with_tmp(temp_dir.path());
+        let config_digest =
+            "sha256:3333333333333333333333333333333333333333333333333333333333333333";
+        let want = [
+            "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        ];
+
+        let inner = store.inner.read().await;
+        let config_path = inner.storage.config_path(config_digest);
+        std::fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+        std::fs::write(&config_path, image_config_with_diff_ids(&want)).unwrap();
+
+        let got = store
+            .load_diff_ids_from_config(&inner, config_digest)
+            .unwrap();
+        let want: Vec<String> = want.iter().map(|s| s.to_string()).collect();
+        assert_eq!(got, want);
+    }
+
+    // A config that genuinely declares no DiffIDs parses successfully and yields
+    // an empty list — Ok, NOT Err. This is the distinction the fix preserves:
+    // "config says none" stays lenient, only "couldn't read/parse" fails.
+    #[tokio::test]
+    async fn load_diff_ids_from_config_allows_genuinely_empty() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let store = store_with_tmp(temp_dir.path());
+        let config_digest =
+            "sha256:4444444444444444444444444444444444444444444444444444444444444444";
+
+        let inner = store.inner.read().await;
+        let config_path = inner.storage.config_path(config_digest);
+        std::fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+        std::fs::write(&config_path, image_config_with_diff_ids(&[])).unwrap();
+
+        let got = store
+            .load_diff_ids_from_config(&inner, config_digest)
+            .unwrap();
+        assert!(
+            got.is_empty(),
+            "genuinely-empty diff_ids must be Ok, got {got:?}"
         );
     }
 }


### PR DESCRIPTION
## Summary

Source-level security audit fix. `verify_diff_ids()` silently skipped
verification (warn + Ok) when the config's `rootfs.diff_ids` count did not match
the layer count. OCI requires exactly one diff_id per layer, so a mismatch is a
malformed/tampered manifest — and the silent skip let an attacker disable DiffID
verification by supplying a short/long list.

## Fix

Return an error on count mismatch. Scope: this is the unambiguously-safe part of
finding #19. Empty `diff_ids` remain a skip (local bundles legitimately carry
none; the blob-path traversal vector is closed separately by `validate_digest`),
and per-layer verify errors stay lenient (intentional, for layer compression
formats the verifier can't decode).

## Test (two-sided)

`verify_diff_ids_rejects_count_mismatch` fails (returns Ok) with the change
reverted and passes with it applied; `verify_diff_ids_allows_empty` guards that
empty diff_ids still skip on both sides.

Audit finding #19 (low, partial).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Image validation now fails closed for DiffID verification, rejecting mismatched DiffID/layer counts with clearer errors.
  * Empty DiffIDs are allowed only for `LocalBundle` sources and rejected for `Store` sources.
  * Malformed DiffIDs and tarball verification IO/verification failures now produce hard errors instead of being logged and skipped.
  * Pulls and manifest loading now fail when DiffID extraction from OCI configs cannot be completed or verified.

* **Tests**
  * Added coverage for DiffID count mismatches, source-specific empty DiffID handling, malformed DiffIDs, and verification error propagation.
  * Added checks that missing, unreadable, or unparseable OCI configs no longer silently yield empty DiffIDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->