### PR TITLE
[WIP] fix(api): make API→runner TLS verification configurable

### DIFF
--- a/apps/api/src/boxlite-rest/boxlite-proxy.controller.ts
+++ b/apps/api/src/boxlite-rest/boxlite-proxy.controller.ts
@@ -196,9 +196,17 @@ export class BoxliteProxyController {
       throw new NotFoundException(`Runner endpoint for box ${boxId} not found`)
     }
 
+    // TLS verification for the internal API→runner hop. Defaults to the prior
+    // behavior (disabled) so deployments whose runners present an internal /
+    // self-signed certificate are not broken, but can be enabled by operators
+    // whose runners present a verifiable certificate by setting
+    // BOXLITE_RUNNER_TLS_VERIFY=true. Without verification the Bearer-authed hop
+    // still lacks integrity/MITM protection (audit finding #17).
+    const verifyRunnerTls = process.env.BOXLITE_RUNNER_TLS_VERIFY === 'true'
+
     const proxyOptions: Options = {
       target: targetUrl,
-      secure: false,
+      secure: verifyRunnerTls,
       changeOrigin: true,
       autoRewrite: true,
       ws: opts?.ws ?? false,


### PR DESCRIPTION
> ⚠️ **[WIP — not verified locally]** Part of a source-level security audit. This
> change compiles conceptually but was **not built/run** in the audit environment
> (no NestJS build). Needs maintainer verification before un-drafting.

## Problem

The internal API→runner proxy hop hard-coded `secure: false`
(`boxlite-proxy.controller.ts`), disabling TLS certificate verification. The hop
is Bearer-authenticated but has no integrity/MITM protection.

## Change

Drive `secure` from `BOXLITE_RUNNER_TLS_VERIFY`, defaulting to `false` (prior
behavior — no breakage for runners with internal/self-signed certs), opt-in
`true` for operators whose runners present a verifiable certificate.

## What needs a resource to verify
- Build/run the NestJS API (`apps/api`) — not run here.
- A runner presenting a **verifiable TLS cert** to confirm the hop succeeds with
  `BOXLITE_RUNNER_TLS_VERIFY=true`, and an e2e exec/proxy call through it.

Audit finding #17 (low).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
