### PR TITLE
fix(guest): reset SIGPIPE to SIG_DFL for container execs so a closed-pipe consumer no longer hangs the exec

### DIFF
--- a/sdks/go/exec_sigpipe_integration_test.go
+++ b/sdks/go/exec_sigpipe_integration_test.go
@@ -1,0 +1,63 @@
+//go:build boxlite_dev
+
+package boxlite
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestIntegrationExecPipeConsumerExitsEarly proves that a pipeline whose
+// downstream consumer exits before the upstream producer finishes does not hang
+// the exec.
+//
+// The guest agent is a Rust program, and the Rust runtime installs SIG_IGN for
+// SIGPIPE at startup. That disposition used to be inherited by every container
+// process the guest forks, so a producer that writes to a pipe whose reader has
+// already exited got EPIPE instead of being killed by SIGPIPE. A producer that
+// loops without checking write errors (`yes`, or a shell `while :; do echo`
+// loop) then never terminated: it spun, the pipeline never completed, the exec
+// never exited, and Wait blocked forever while a vCPU stayed pegged.
+//
+// The guest now restores the default SIGPIPE disposition across the container
+// fork, so such a producer is killed by SIGPIPE and the exec completes promptly.
+//
+// Pre-fix this hangs deterministically; post-fix it returns in well under a
+// second. The generous watchdog distinguishes "fixed" from "hung" without being
+// sensitive to host timing.
+func TestIntegrationExecPipeConsumerExitsEarly(t *testing.T) {
+	rt := newTestRuntime(t)
+	box := createStartedBoxOrSkip(t, rt, "alpine:latest", WithAutoRemove(false))
+
+	// Two producers that both rely on SIGPIPE to die when `head` closes the
+	// pipe: busybox `yes`, and the very common shell `while :; do echo; done`
+	// idiom. The 8-byte payload is one that reproduced the hang deterministically.
+	cases := []struct {
+		name string
+		cmd  string
+	}{
+		{"busybox-yes", "yes aaaaaaaa | head -n 5"},
+		{"shell-echo-loop", "while :; do echo aaaaaaaa; done | head -n 5"},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			cmd := box.Command("sh", "-c", c.cmd)
+			done := make(chan error, 1)
+			go func() { done <- cmd.Run(context.Background()) }()
+
+			select {
+			case err := <-done:
+				if err != nil {
+					t.Fatalf("exec returned error: %v", err)
+				}
+			case <-time.After(20 * time.Second):
+				t.Fatalf("exec HUNG: %q did not return within 20s — the producer "+
+					"spun on a closed pipe because SIGPIPE was not reset to "+
+					"SIG_DFL for the container process", c.cmd)
+			}
+		})
+	}
+}

--- a/src/guest/src/container/zygote.rs
+++ b/src/guest/src/container/zygote.rs
@@ -303,7 +303,36 @@ fn do_build(spec: BuildSpec, fds: Option<[RawFd; 3]>) -> BuildResult {
         Ok(pid)
     };
 
-    match build_fn() {
+    // Restore the default SIGPIPE disposition across the fork so the container
+    // init — and the user process it execs — does not inherit the guest agent's
+    // process-wide SIG_IGN.
+    //
+    // The agent is a Rust program, and the Rust runtime installs SIG_IGN for
+    // SIGPIPE at startup; that disposition is inherited by the zygote and by
+    // every container process youki forks here. With SIGPIPE ignored, a process
+    // that writes to a pipe whose reader has exited (e.g. the producer in
+    // `yes | head`, or `while :; do echo; done | head`) gets EPIPE instead of
+    // being killed by SIGPIPE. A producer that loops without checking write
+    // errors then never terminates: it spins, the pipeline never completes, the
+    // exec never exits, and Wait hangs forever while a vCPU stays pegged.
+    //
+    // youki's init does not reset SIGPIPE, so set SIG_DFL just for the fork and
+    // restore SIG_IGN immediately after — the long-lived single-threaded zygote
+    // keeps the agent's EPIPE-as-error behavior on its own IPC socket, while the
+    // forked child (and everything it execs) starts with the standard default.
+    use nix::sys::signal::{signal, SigHandler, Signal};
+    let prev_sigpipe = unsafe { signal(Signal::SIGPIPE, SigHandler::SigDfl) };
+
+    let result = build_fn();
+
+    if let Ok(prev) = prev_sigpipe {
+        // SAFETY: restoring the disposition we just read; single-threaded zygote.
+        unsafe {
+            let _ = signal(Signal::SIGPIPE, prev);
+        }
+    }
+
+    match result {
         Ok(pid) => BuildResult::Spawned { pid: pid.as_raw() },
         Err(error) => BuildResult::Failed { error },
     }


### PR DESCRIPTION
## Summary

Reset SIGPIPE to its default disposition for forked container execs so closed-pipe pipelines like `yes | head` terminate normally instead of spinning forever and hanging `Execution.Wait`.

## Test plan

- Added `sdks/go/exec_sigpipe_integration_test.go` covering `yes aaaaaaaa | head -n 5` and `while :; do echo aaaaaaaa; done | head -n 5` under `boxlite_dev`.
- Verified on a real box that the repros hang before the fix and return promptly with exit 0 after the fix.
