### PR TITLE
fix(api): validate Box API network allowlist

### DIFF
--- a/apps/api/src/box/utils/network-validation.util.spec.ts
+++ b/apps/api/src/box/utils/network-validation.util.spec.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { isValidNetworkAllowEntry, validateNetworkAllowList } from './network-validation.util'
+
+describe('network allow list validation', () => {
+  it.each(['api.openai.com', '*.anthropic.com', '192.168.1.1', '10.0.0.0/8'])(
+    'accepts supported allow_net entry %s',
+    (entry) => {
+      expect(isValidNetworkAllowEntry(entry)).toBe(true)
+    },
+  )
+
+  it.each(['', 'https://api.openai.com', '*example.com', 'api..openai.com', '10.0.0.0/33', '999.0.0.1'])(
+    'rejects invalid allow_net entry %s',
+    (entry) => {
+      expect(isValidNetworkAllowEntry(entry)).toBe(false)
+    },
+  )
+
+  it('accepts comma-separated allow_net lists with hostnames, wildcards, IPs, and CIDRs', () => {
+    expect(() => validateNetworkAllowList('api.openai.com, *.anthropic.com, 192.168.1.1, 10.0.0.0/8')).not.toThrow()
+  })
+
+  it('rejects more than ten allow_net entries', () => {
+    const entries = Array.from({ length: 11 }, (_, index) => `api-${index}.example.com`).join(',')
+
+    expect(() => validateNetworkAllowList(entries)).toThrow('more than 10 networks')
+  })
+
+  it('rejects invalid comma-separated allow_net entries', () => {
+    expect(() => validateNetworkAllowList('api.openai.com,10.0.0.0/33')).toThrow('Invalid network allow list entry')
+  })
+})

--- a/apps/api/src/box/utils/network-validation.util.ts
+++ b/apps/api/src/box/utils/network-validation.util.ts
@@ -5,35 +5,71 @@
  */
 import { isIPv4 } from 'net'
 
+export const MAX_NETWORK_ALLOW_LIST_ENTRIES = 10
+
+const IPV4_LIKE_PATTERN = /^(\d{1,3}\.){3}\d{1,3}$/
+const HOSTNAME_LABEL_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$/
+
 /**
- * Validates network allow list to ensure valid CIDR network addresses are allowed
+ * Validates network allow list entries accepted by the Box API/core contract:
+ * exact IPv4, IPv4 CIDR, exact hostname, and wildcard hostname.
  * @param networkAllowList - Comma-separated string of network addresses
  * @returns null if valid, error message string if invalid
  */
 export function validateNetworkAllowList(networkAllowList: string): void {
-  const networks = networkAllowList.split(',').map((net: string) => net.trim())
+  const networks = networkAllowList
+    .split(',')
+    .map((net: string) => net.trim())
+    .filter(Boolean)
+
+  if (networks.length > MAX_NETWORK_ALLOW_LIST_ENTRIES) {
+    throw new Error(`Network allow list cannot contain more than ${MAX_NETWORK_ALLOW_LIST_ENTRIES} networks`)
+  }
 
   for (const network of networks) {
-    if (!network) continue // Skip empty entries
-
-    const [ipAddress, prefixLength] = network.split('/')
-
-    if (!isIPv4(ipAddress)) {
-      throw new Error(`Invalid IP address: "${ipAddress}" in network "${network}". Must be a valid IPv4 address`)
-    }
-
-    if (!prefixLength) {
-      throw new Error(`Invalid network format: "${network}". Missing CIDR prefix length (e.g., /24)`)
-    }
-
-    // Validate CIDR prefix length (0-32 for IPv4)
-    const prefix = parseInt(prefixLength, 10)
-    if (prefix < 0 || prefix > 32) {
-      throw new Error(`Invalid CIDR prefix length: ${network}. Prefix must be between 0 and 32`)
+    if (!isValidNetworkAllowEntry(network)) {
+      throw new Error(
+        `Invalid network allow list entry: "${network}". Must be an IPv4 address, IPv4 CIDR, hostname, or wildcard hostname`,
+      )
     }
   }
+}
 
-  if (networks.length > 10) {
-    throw new Error(`Network allow list cannot contain more than 10 networks`)
+export function isValidNetworkAllowEntry(entry: string): boolean {
+  const network = entry.trim()
+  if (!network) {
+    return false
   }
+
+  if (isIPv4(network)) {
+    return true
+  }
+
+  if (network.includes('/')) {
+    const [ipAddress, prefixLength, extra] = network.split('/')
+    if (extra !== undefined || !isIPv4(ipAddress) || !/^\d+$/.test(prefixLength)) {
+      return false
+    }
+
+    const prefix = Number(prefixLength)
+    return prefix >= 0 && prefix <= 32
+  }
+
+  if (IPV4_LIKE_PATTERN.test(network)) {
+    return false
+  }
+
+  if (network.startsWith('*.')) {
+    return isValidHostname(network.slice(2))
+  }
+
+  return isValidHostname(network)
+}
+
+function isValidHostname(hostname: string): boolean {
+  if (hostname.length === 0 || hostname.length > 253 || hostname.includes('..')) {
+    return false
+  }
+
+  return hostname.split('.').every((label) => HOSTNAME_LABEL_PATTERN.test(label))
 }

--- a/apps/api/src/boxlite-rest/dto/create-box.dto.spec.ts
+++ b/apps/api/src/boxlite-rest/dto/create-box.dto.spec.ts
@@ -39,3 +39,57 @@ describe('CreateBoxDto resource minimums', () => {
     expect(errors).toHaveLength(0)
   })
 })
+
+describe('CreateBoxDto network validation', () => {
+  it('accepts supported allow_net entry types', async () => {
+    const errors = await validate(
+      plainToInstance(CreateBoxDto, {
+        network: {
+          mode: 'enabled',
+          allow_net: ['api.openai.com', '*.anthropic.com', '192.168.1.1', '10.0.0.0/8'],
+        },
+      }),
+    )
+
+    expect(errors).toHaveLength(0)
+  })
+
+  it.each(['', 'https://api.openai.com', '*example.com', 'api..openai.com', '10.0.0.0/33', '999.0.0.1'])(
+    'rejects invalid allow_net entry %s',
+    async (entry) => {
+      const errors = await validate(
+        plainToInstance(CreateBoxDto, {
+          network: {
+            mode: 'enabled',
+            allow_net: [entry],
+          },
+        }),
+      )
+
+      expect(JSON.stringify(errors)).toContain('isNetworkAllowEntry')
+    },
+  )
+
+  it('rejects more than ten allow_net entries', async () => {
+    const errors = await validate(
+      plainToInstance(CreateBoxDto, {
+        network: {
+          mode: 'enabled',
+          allow_net: Array.from({ length: 11 }, (_, index) => `api-${index}.example.com`),
+        },
+      }),
+    )
+
+    expect(JSON.stringify(errors)).toContain('arrayMaxSize')
+  })
+
+  it('rejects unsupported network modes', async () => {
+    const errors = await validate(
+      plainToInstance(CreateBoxDto, {
+        network: { mode: 'public' },
+      }),
+    )
+
+    expect(JSON.stringify(errors)).toContain('isIn')
+  })
+})

--- a/apps/api/src/boxlite-rest/dto/create-box.dto.ts
+++ b/apps/api/src/boxlite-rest/dto/create-box.dto.ts
@@ -6,6 +6,7 @@
 
 import { Type } from 'class-transformer'
 import {
+  ArrayMaxSize,
   IsOptional,
   IsString,
   IsNumber,
@@ -14,8 +15,23 @@ import {
   IsArray,
   Min,
   IsIn,
+  Validate,
   ValidateNested,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
 } from 'class-validator'
+import { isValidNetworkAllowEntry, MAX_NETWORK_ALLOW_LIST_ENTRIES } from '../../box/utils/network-validation.util'
+
+@ValidatorConstraint({ name: 'isNetworkAllowEntry', async: false })
+class IsNetworkAllowEntryConstraint implements ValidatorConstraintInterface {
+  validate(value: unknown): boolean {
+    return typeof value === 'string' && isValidNetworkAllowEntry(value)
+  }
+
+  defaultMessage(): string {
+    return 'each allow_net entry must be an IPv4 address, IPv4 CIDR, hostname, or wildcard hostname'
+  }
+}
 
 export class NetworkSpecDto {
   @IsIn(['enabled', 'disabled'])
@@ -23,7 +39,9 @@ export class NetworkSpecDto {
 
   @IsOptional()
   @IsArray()
+  @ArrayMaxSize(MAX_NETWORK_ALLOW_LIST_ENTRIES)
   @IsString({ each: true })
+  @Validate(IsNetworkAllowEntryConstraint, { each: true })
   allow_net?: string[]
 }
 

--- a/apps/api/src/boxlite-rest/mappers/box-to-box.mapper.spec.ts
+++ b/apps/api/src/boxlite-rest/mappers/box-to-box.mapper.spec.ts
@@ -57,7 +57,7 @@ describe('box-to-box mapper', () => {
 
   it('maps enabled network allowlist onto the internal create dto', () => {
     const dto = createBoxToCreateBox({
-      network: { mode: 'enabled', allow_net: ['api.openai.com', 'github.com'] },
+      network: { mode: 'enabled', allow_net: [' api.openai.com ', 'github.com'] },
     })
 
     expect(dto.networkBlockAll).toBe(false)

--- a/apps/api/src/boxlite-rest/mappers/box-to-box.mapper.ts
+++ b/apps/api/src/boxlite-rest/mappers/box-to-box.mapper.ts
@@ -35,9 +35,9 @@ export function createBoxToCreateBox(dto: RestCreateBoxDto, target?: string): Cr
   createDto.disk = dto.disk_size_gb
   createDto.target = target
   if (dto.network) {
+    const allowNet = dto.network.allow_net?.map((entry) => entry.trim()).filter(Boolean)
     createDto.networkBlockAll = dto.network.mode === 'disabled'
-    createDto.networkAllowList =
-      dto.network.mode === 'enabled' && dto.network.allow_net?.length ? dto.network.allow_net.join(',') : undefined
+    createDto.networkAllowList = dto.network.mode === 'enabled' && allowNet?.length ? allowNet.join(',') : undefined
   }
   return createDto
 }


### PR DESCRIPTION
## Summary
- validate Box API allow_net entries at the DTO boundary
- keep the Box API contract aligned with core support for hostnames, wildcard hostnames, IPv4 addresses, and IPv4 CIDRs
- trim allow_net entries before mapping to the internal create DTO

## Validation
- NX_DAEMON=false yarn jest api/src/boxlite-rest/dto/create-box.dto.spec.ts api/src/boxlite-rest/mappers/box-to-box.mapper.spec.ts api/src/box/utils/network-validation.util.spec.ts --config api/jest.config.ts --runInBand
- NX_DAEMON=false yarn nx run api:build:development
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for network allow list validation scenarios.

* **Refactor**
  * Network allow list validation now accepts IPv4 addresses, CIDR notation, hostnames, and wildcard domains.
  * Automatic whitespace trimming applied to network entries.
  * Enforced maximum limit of 10 entries per allow list.
  * Improved error messaging for invalid entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->