### PR TITLE
[WIP] fix(dex): stop shipping static admin password; restrict CORS

### DIFF
--- a/apps/dex/config.yaml
+++ b/apps/dex/config.yaml
@@ -9,7 +9,10 @@ storage:
 
 web:
   http: 0.0.0.0:5556
-  allowedOrigins: ['*']
+  # CORS origins allowed to call Dex endpoints. Rendered from DEX_ALLOWED_ORIGINS
+  # (entrypoint.sh / local-dex-env.mjs). Never ship '*' — that lets any site call
+  # the identity provider's auth/token endpoints. Default is the local dev origins.
+  allowedOrigins: ${DEX_ALLOWED_ORIGINS}
   allowedHeaders: ['x-requested-with']
 
 staticClients:
@@ -35,11 +38,11 @@ staticClients:
 oauth2:
   deviceFlow: {}
 
-enablePasswordDB: true
-
-staticPasswords:
-  - email: 'admin@boxlite.dev'
-    # password: password
-    hash: '$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W'
-    username: 'admin'
-    userID: '1234'
+# enablePasswordDB / staticPasswords are intentionally NOT hard-coded here.
+# Shipping the static `admin@boxlite.dev` / `password` account in the committed
+# config means any deployment using this file as-is has a known admin login.
+# The static dev account is now injected only when explicitly enabled:
+#   - entrypoint.sh (container/prod): appends it ONLY if DEX_ENABLE_STATIC_PASSWORD=true,
+#     otherwise renders `enablePasswordDB: false` (secure default).
+#   - local-dex-env.mjs (local dev / e2e): always injects it, so the documented
+#     `admin@boxlite.dev` / `password` dev login keeps working.

--- a/apps/dex/entrypoint.sh
+++ b/apps/dex/entrypoint.sh
@@ -1,13 +1,38 @@
 #!/bin/sh
 set -e
 
-# Simple string replacement for env vars in config
-CONFIG=/etc/dex/config.yaml
-TMP=/tmp/dex-config.yaml
+# Simple string replacement for env vars in config.
+# Paths and the dex binary are overridable so the rendering can be tested.
+CONFIG="${DEX_CONFIG_PATH:-/etc/dex/config.yaml}"
+TMP="${DEX_RENDERED_CONFIG_PATH:-/tmp/dex-config.yaml}"
+DEX_BIN="${DEX_BIN:-/usr/local/bin/dex}"
+
+# Default CORS origins to the local dev origins, never '*'. Operators set
+# DEX_ALLOWED_ORIGINS (a YAML list literal) to their dashboard origin in prod.
+DEX_ALLOWED_ORIGINS="${DEX_ALLOWED_ORIGINS:-['http://localhost:3000','http://localhost:5173','http://127.0.0.1:5555']}"
 
 cat "$CONFIG" | \
   sed "s|\${DEX_ISSUER}|${DEX_ISSUER:-http://localhost:5556/dex}|g" | \
-  sed "s|\${REDIRECT_URI}|${REDIRECT_URI:-http://localhost:3000}|g" \
+  sed "s|\${REDIRECT_URI}|${REDIRECT_URI:-http://localhost:3000}|g" | \
+  sed "s|\${DEX_ALLOWED_ORIGINS}|${DEX_ALLOWED_ORIGINS}|g" \
   > "$TMP"
 
-exec /usr/local/bin/dex serve "$TMP"
+# Static password DB is OFF by default (no admin@boxlite.dev login ships). Enable
+# the dev account only when explicitly requested via DEX_ENABLE_STATIC_PASSWORD=true.
+if [ "${DEX_ENABLE_STATIC_PASSWORD}" = "true" ]; then
+  echo "WARNING: DEX_ENABLE_STATIC_PASSWORD=true — enabling the static admin@boxlite.dev account (development only)" >&2
+  # Quoted heredoc: the bcrypt hash contains literal '$' and must not be expanded.
+  cat >> "$TMP" <<'STATIC_PW'
+enablePasswordDB: true
+staticPasswords:
+  - email: 'admin@boxlite.dev'
+    # password: password
+    hash: '$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W'
+    username: 'admin'
+    userID: '1234'
+STATIC_PW
+else
+  echo "enablePasswordDB: false" >> "$TMP"
+fi
+
+exec "$DEX_BIN" serve "$TMP"

--- a/apps/dex/render_test.sh
+++ b/apps/dex/render_test.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# Test that entrypoint.sh renders a SECURE production config by default:
+# no static admin credential, no wildcard CORS; dev account only with the flag.
+set -e
+HERE=$(CDPATH= cd "$(dirname "$0")" && pwd)
+CFG="$HERE/config.yaml"
+HASH='HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W'
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+# --- prod default (flag unset): static password DB disabled ---
+OUT=$(mktemp)
+DEX_CONFIG_PATH="$CFG" DEX_RENDERED_CONFIG_PATH="$OUT" DEX_BIN=/bin/true sh "$HERE/entrypoint.sh"
+grep -q "enablePasswordDB: false" "$OUT" || fail "prod render missing 'enablePasswordDB: false'"
+grep -q "$HASH" "$OUT" && fail "prod render LEAKS the static admin credential"
+grep -qF "allowedOrigins: ['*']" "$OUT" && fail "prod render still has wildcard CORS"
+grep -q "allowedOrigins:" "$OUT" || fail "prod render dropped allowedOrigins"
+
+# --- dev opt-in (flag=true): static account present ---
+OUT2=$(mktemp)
+DEX_ENABLE_STATIC_PASSWORD=true DEX_CONFIG_PATH="$CFG" DEX_RENDERED_CONFIG_PATH="$OUT2" DEX_BIN=/bin/true sh "$HERE/entrypoint.sh"
+grep -q "$HASH" "$OUT2" || fail "dev opt-in render missing the static admin credential"
+grep -q "enablePasswordDB: true" "$OUT2" || fail "dev opt-in render missing enablePasswordDB: true"
+
+echo "PASS: entrypoint render (prod secure-by-default, dev opt-in)"

--- a/apps/scripts/local-dex-env.mjs
+++ b/apps/scripts/local-dex-env.mjs
@@ -123,12 +123,40 @@ function ensureDexConfig(config) {
 
   fs.mkdirSync(targetDir, { recursive: true })
 
-  const configText = fs
-    .readFileSync(sourcePath, 'utf8')
-    .replaceAll('${DEX_ISSUER}', config.dexIssuer)
-    .replaceAll('${REDIRECT_URI}', config.dashboardUrl)
+  const configText = renderDexConfig(fs.readFileSync(sourcePath, 'utf8'), {
+    dexIssuer: config.dexIssuer,
+    dashboardUrl: config.dashboardUrl,
+  })
 
   fs.writeFileSync(targetPath, configText)
+}
+
+// renderDexConfig fills the committed Dex config template for LOCAL DEV / e2e.
+// The committed config no longer hard-codes `allowedOrigins: ['*']` or the static
+// admin password (so production is secure by default); dev re-injects both here
+// so the documented `admin@boxlite.dev` / `password` login keeps working.
+export function renderDexConfig(rawText, { dexIssuer, dashboardUrl }) {
+  // Local dev CORS origins (dashboard, Vite, CLI loopback callback) — never '*'.
+  const localAllowedOrigins = "['http://localhost:3000','http://localhost:5173','http://127.0.0.1:5555']"
+
+  const staticPasswordBlock = [
+    '',
+    'enablePasswordDB: true',
+    'staticPasswords:',
+    "  - email: 'admin@boxlite.dev'",
+    '    # password: password',
+    "    hash: '$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W'",
+    "    username: 'admin'",
+    "    userID: '1234'",
+    '',
+  ].join('\n')
+
+  return (
+    rawText
+      .replaceAll('${DEX_ISSUER}', dexIssuer)
+      .replaceAll('${REDIRECT_URI}', dashboardUrl)
+      .replaceAll('${DEX_ALLOWED_ORIGINS}', localAllowedOrigins) + staticPasswordBlock
+  )
 }
 
 function ensurePostgres(config) {

--- a/apps/scripts/local-dex-env.test.mjs
+++ b/apps/scripts/local-dex-env.test.mjs
@@ -1,0 +1,23 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { renderDexConfig } from './local-dex-env.mjs'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const raw = fs.readFileSync(path.join(here, '..', 'dex', 'config.yaml'), 'utf8')
+
+test('dev render keeps the documented admin@boxlite.dev / password login', () => {
+  const out = renderDexConfig(raw, { dexIssuer: 'http://localhost:5556/dex', dashboardUrl: 'http://localhost:3000' })
+  assert.match(out, /enablePasswordDB: true/)
+  assert.match(out, /email: 'admin@boxlite\.dev'/)
+  assert.match(out, /\$2a\$10\$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W/)
+})
+
+test('dev render substitutes placeholders and never emits wildcard CORS', () => {
+  const out = renderDexConfig(raw, { dexIssuer: 'http://localhost:5556/dex', dashboardUrl: 'http://localhost:3000' })
+  assert.ok(!out.includes('${DEX_ALLOWED_ORIGINS}'), 'DEX_ALLOWED_ORIGINS placeholder left unrendered')
+  assert.ok(!out.includes("allowedOrigins: ['*']"), 'wildcard CORS present')
+  assert.match(out, /allowedOrigins: \['http:\/\/localhost:3000'/)
+})


### PR DESCRIPTION
> ⚠️ **[WIP — rendering tested locally; full Dex/e2e needs Docker]** Part of a
> source-level security audit. The config-rendering logic is unit-tested here;
> confirming Dex actually rejects/accepts the login end to end needs Docker
> (postgres/redis/dex containers), which was unavailable in the audit environment.

## Problem

The committed Dex config shipped `enablePasswordDB: true` with a static
`admin@boxlite.dev` / `password` account and `allowedOrigins: ['*']`. Any
deployment using it as-is had a known admin OIDC login, and the IdP endpoints
accepted any origin.

## Change (secure by default, dev unaffected)
- `config.yaml`: no longer hard-codes `staticPasswords` or `['*']`;
  `allowedOrigins: ${DEX_ALLOWED_ORIGINS}`.
- `entrypoint.sh` (prod): `enablePasswordDB: false` unless
  `DEX_ENABLE_STATIC_PASSWORD=true`; `allowedOrigins` defaults to local dev
  origins (never `*`), operators set `DEX_ALLOWED_ORIGINS` in prod.
- `local-dex-env.mjs` (dev/e2e — it renders the config itself, bypassing
  entrypoint.sh): always injects the dev account so `admin@boxlite.dev` /
  `password` keeps working (per apps/CLAUDE.md).

## Tests (two-sided, run locally)
- `apps/dex/render_test.sh`: prod default render → `enablePasswordDB: false`, no
  admin hash, no `['*']`; dev opt-in → account present. Reverting the config +
  gating makes the prod render keep `enablePasswordDB: true` → test fails.
- `apps/scripts/local-dex-env.test.mjs` (`node --test`): dev render keeps the
  admin login, emits no wildcard CORS / unrendered placeholder.

## What needs a resource to verify
- **Docker**: run `npm run e2e:local` to confirm the browser login still works in
  dev, and a prod-style render (flag unset) actually rejects the static admin.

Audit findings #4 (high) and #12 (medium).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
