### PR TITLE
[WIP] feat(net): optional allow_net filtering for UDP

### DIFF
--- a/src/deps/libgvproxy-sys/gvproxy-bridge/forked_udp.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/forked_udp.go
@@ -1,0 +1,149 @@
+package main
+
+// forked_udp.go — Optional AllowNet filtering for UDP.
+//
+// allow_net only constrained TCP: UDP went through gvproxy's default NAT
+// forwarder, so a restricted box could exfiltrate to any host over UDP/QUIC
+// (audit finding #2). This installs a UDP forwarder that drops datagrams to
+// destinations not permitted by the AllowNet filter.
+//
+// WIP / NOT INTEGRATION-VERIFIED: the policy decision (udpAllowed) is unit
+// tested, but the live forwarder path — in particular whether overriding the UDP
+// protocol handler bypasses gvproxy's embedded DNS resolver endpoint, and the
+// datagram relay/idle-timeout behavior — has NOT been validated against a running
+// network stack. It is therefore gated behind BOXLITE_UDP_FILTER=true and is OFF
+// by default (live behavior unchanged). See OverrideUDPHandlerIfEnabled.
+
+import (
+	"fmt"
+	"net"
+	"reflect"
+	"sync"
+	"time"
+	"unsafe"
+
+	"github.com/containers/gvisor-tap-vsock/pkg/types"
+	"github.com/containers/gvisor-tap-vsock/pkg/virtualnetwork"
+	logrus "github.com/sirupsen/logrus"
+	"gvisor.dev/gvisor/pkg/tcpip"
+	"gvisor.dev/gvisor/pkg/tcpip/adapters/gonet"
+	"gvisor.dev/gvisor/pkg/tcpip/stack"
+	"gvisor.dev/gvisor/pkg/tcpip/transport/udp"
+	"gvisor.dev/gvisor/pkg/waiter"
+)
+
+// udpIdleTimeout closes an idle forwarded UDP flow so endpoints don't leak.
+const udpIdleTimeout = 60 * time.Second
+
+// udpAllowed reports whether a UDP datagram to (destIP, destPort) is permitted.
+//
+// With no AllowNet filter configured (filter == nil) all UDP is allowed, exactly
+// as before. With a filter, only destinations whose IP is allowed by the filter
+// pass — this includes the gateway/internal IPs (always-allow), so DNS to the
+// gateway resolver still works, while UDP to a non-allowlisted host (including
+// DNS-over-UDP exfiltration to an attacker on port 53, or QUIC/HTTP-3 on 443) is
+// dropped.
+func udpAllowed(destIP net.IP, destPort uint16, filter *TCPFilter) bool {
+	_ = destPort // reserved: port-specific policy may be added later
+	if filter == nil {
+		return true
+	}
+	return filter.MatchesIP(destIP)
+}
+
+// OverrideUDPHandlerIfEnabled installs the filtered UDP forwarder only when a
+// filter is configured AND BOXLITE_UDP_FILTER=true. Default (env unset) is a
+// no-op so the live UDP path is unchanged until the forwarder is integration
+// verified.
+func OverrideUDPHandlerIfEnabled(
+	vn *virtualnetwork.VirtualNetwork,
+	config *types.Configuration,
+	filter *TCPFilter,
+	enabled bool,
+) error {
+	if filter == nil || !enabled {
+		return nil
+	}
+	return OverrideUDPHandler(vn, config, filter)
+}
+
+// OverrideUDPHandler replaces the default UDP protocol handler with one that
+// enforces the AllowNet filter. Mirrors OverrideTCPHandler's reflective access
+// to the VirtualNetwork's private stack field.
+func OverrideUDPHandler(
+	vn *virtualnetwork.VirtualNetwork,
+	config *types.Configuration,
+	filter *TCPFilter,
+) error {
+	v := reflect.ValueOf(vn).Elem()
+	stackField := v.FieldByName("stack")
+	if !stackField.IsValid() {
+		return fmt.Errorf("VirtualNetwork has no 'stack' field (gvisor-tap-vsock API changed?)")
+	}
+	// #nosec G103 — accessing private field to override UDP handler, same as TCP.
+	s := (*stack.Stack)(unsafe.Pointer(stackField.Pointer()))
+
+	nat := make(map[tcpip.Address]tcpip.Address)
+	for source, destination := range config.NAT {
+		nat[tcpip.AddrFrom4Slice(net.ParseIP(source).To4())] =
+			tcpip.AddrFrom4Slice(net.ParseIP(destination).To4())
+	}
+	var natLock sync.Mutex
+
+	fwd := udp.NewForwarder(s, func(r *udp.ForwarderRequest) {
+		localAddress := r.ID().LocalAddress
+		destIP, dialAddress := resolveTCPDestination(localAddress, nat, &natLock)
+		destPort := r.ID().LocalPort
+
+		if !udpAllowed(destIP, destPort, filter) {
+			logrus.WithFields(logrus.Fields{
+				"dst_ip":   destIP,
+				"dst_port": destPort,
+			}).Info("allowNet UDP: blocked (no matching rule)")
+			return // drop: do not create an endpoint
+		}
+
+		var wq waiter.Queue
+		ep, udpErr := r.CreateEndpoint(&wq)
+		if udpErr != nil {
+			logrus.Debugf("udp r.CreateEndpoint() = %v", udpErr)
+			return
+		}
+		guestConn := gonet.NewUDPConn(&wq, ep)
+
+		destAddr := fmt.Sprintf("%s:%d", dialAddress, destPort)
+		outbound, err := net.Dial("udp", destAddr)
+		if err != nil {
+			logrus.Tracef("udp net.Dial(%s) = %v", destAddr, err)
+			guestConn.Close()
+			return
+		}
+
+		go relayUDP(guestConn, outbound)
+		go relayUDP(outbound, guestConn)
+	})
+
+	s.SetTransportProtocolHandler(udp.ProtocolNumber, fwd.HandlePacket)
+	logrus.Info("allowNet UDP: handler overridden with filtering forwarder (experimental)")
+	return nil
+}
+
+// relayUDP copies datagrams one way until an idle timeout or error, then closes
+// both ends so the paired copier unblocks.
+func relayUDP(dst, src net.Conn) {
+	buf := make([]byte, 65535)
+	for {
+		_ = src.SetReadDeadline(time.Now().Add(udpIdleTimeout))
+		n, err := src.Read(buf)
+		if n > 0 {
+			if _, werr := dst.Write(buf[:n]); werr != nil {
+				break
+			}
+		}
+		if err != nil {
+			break
+		}
+	}
+	src.Close()
+	dst.Close()
+}

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/forked_udp.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/forked_udp.go
@@ -7,12 +7,16 @@ package main
 // (audit finding #2). This installs a UDP forwarder that drops datagrams to
 // destinations not permitted by the AllowNet filter.
 //
-// WIP / NOT INTEGRATION-VERIFIED: the policy decision (udpAllowed) is unit
-// tested, but the live forwarder path — in particular whether overriding the UDP
-// protocol handler bypasses gvproxy's embedded DNS resolver endpoint, and the
-// datagram relay/idle-timeout behavior — has NOT been validated against a running
-// network stack. It is therefore gated behind BOXLITE_UDP_FILTER=true and is OFF
-// by default (live behavior unchanged). See OverrideUDPHandlerIfEnabled.
+// DNS safety is verified: gvproxy binds its DNS resolver as a UDP *endpoint*
+// (services.go: gonet.DialUDP gateway:53), and gvisor's transport demuxer
+// delivers to a bound endpoint before the SetTransportProtocolHandler forwarder.
+// TestUDPFilter_BoundDNSEndpointNotBypassed injects real packets through a gvisor
+// stack and confirms :53 reaches the resolver endpoint while other UDP reaches
+// this forwarder — so replacing the UDP handler does not break DNS.
+//
+// Still gated behind BOXLITE_UDP_FILTER=true (OFF by default): the drop path and
+// DNS preservation are tested, but end-to-end relay of *allowed* flows under real
+// guest traffic has not been load-tested. See OverrideUDPHandlerIfEnabled.
 
 import (
 	"fmt"

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/forked_udp_integration_test.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/forked_udp_integration_test.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"gvisor.dev/gvisor/pkg/buffer"
+	"gvisor.dev/gvisor/pkg/tcpip"
+	"gvisor.dev/gvisor/pkg/tcpip/checksum"
+	"gvisor.dev/gvisor/pkg/tcpip/header"
+	"gvisor.dev/gvisor/pkg/tcpip/link/channel"
+	"gvisor.dev/gvisor/pkg/tcpip/network/ipv4"
+	"gvisor.dev/gvisor/pkg/tcpip/stack"
+	"gvisor.dev/gvisor/pkg/tcpip/transport/udp"
+	"gvisor.dev/gvisor/pkg/waiter"
+
+	"gvisor.dev/gvisor/pkg/tcpip/adapters/gonet"
+)
+
+// injectUDP crafts an IPv4+UDP datagram and injects it inbound on the NIC,
+// exactly as a guest packet would arrive at the stack.
+func injectUDP(ch *channel.Endpoint, src, dst tcpip.Address, dstPort uint16, payload []byte) {
+	udpSize := header.UDPMinimumSize + len(payload)
+	total := header.IPv4MinimumSize + udpSize
+	buf := make([]byte, total)
+
+	ip := header.IPv4(buf)
+	ip.Encode(&header.IPv4Fields{
+		TotalLength: uint16(total),
+		TTL:         64,
+		Protocol:    uint8(udp.ProtocolNumber),
+		SrcAddr:     src,
+		DstAddr:     dst,
+	})
+	ip.SetChecksum(^ip.CalculateChecksum())
+
+	u := header.UDP(buf[header.IPv4MinimumSize:])
+	u.Encode(&header.UDPFields{SrcPort: 40000, DstPort: dstPort, Length: uint16(udpSize)})
+	copy(buf[header.IPv4MinimumSize+header.UDPMinimumSize:], payload)
+	xsum := header.PseudoHeaderChecksum(udp.ProtocolNumber, src, dst, uint16(udpSize))
+	xsum = checksum.Checksum(payload, xsum)
+	u.SetChecksum(^u.CalculateChecksum(xsum))
+
+	pkt := stack.NewPacketBuffer(stack.PacketBufferOptions{Payload: buffer.MakeWithData(buf)})
+	ch.InjectInbound(ipv4.ProtocolNumber, pkt)
+	pkt.DecRef()
+}
+
+// TestUDPFilter_BoundDNSEndpointNotBypassed verifies the load-bearing assumption
+// behind OverrideUDPHandler: gvproxy binds its DNS resolver as a UDP *endpoint*
+// (services.go: gonet.DialUDP gateway:53), and gvisor's transport demuxer
+// delivers to a bound endpoint BEFORE the SetTransportProtocolHandler forwarder.
+// So replacing the UDP handler to enforce allow_net does NOT bypass DNS: the
+// resolver endpoint still receives :53 traffic, while the filtering forwarder
+// only sees guest→internet UDP (which it drops when not allow-listed).
+func TestUDPFilter_BoundDNSEndpointNotBypassed(t *testing.T) {
+	s := stack.New(stack.Options{
+		NetworkProtocols:   []stack.NetworkProtocolFactory{ipv4.NewProtocol},
+		TransportProtocols: []stack.TransportProtocolFactory{udp.NewProtocol},
+	})
+	defer s.Close()
+
+	ch := channel.New(16, 1500, "")
+	if err := s.CreateNIC(1, ch); err != nil {
+		t.Fatalf("CreateNIC: %v", err)
+	}
+	gateway := tcpip.AddrFrom4([4]byte{192, 168, 127, 1})
+	if err := s.AddProtocolAddress(1, tcpip.ProtocolAddress{
+		Protocol:          ipv4.ProtocolNumber,
+		AddressWithPrefix: gateway.WithPrefix(),
+	}, stack.AddressProperties{}); err != nil {
+		t.Fatalf("AddProtocolAddress: %v", err)
+	}
+	s.SetSpoofing(1, true)
+	s.SetPromiscuousMode(1, true)
+	s.SetRouteTable([]tcpip.Route{{Destination: header.IPv4EmptySubnet, NIC: 1}})
+
+	// Bind a UDP endpoint on gateway:53 — stands in for gvproxy's DNS resolver.
+	dnsConn, err := gonet.DialUDP(s, &tcpip.FullAddress{NIC: 1, Addr: gateway, Port: 53}, nil, ipv4.ProtocolNumber)
+	if err != nil {
+		t.Fatalf("DialUDP(gateway:53): %v", err)
+	}
+	defer dnsConn.Close()
+
+	// Install a filtering forwarder (the production mechanism) that records which
+	// dest ports reach it and drops everything (filter denies).
+	var mu sync.Mutex
+	forwarded := map[uint16]bool{}
+	fwd := udp.NewForwarder(s, func(r *udp.ForwarderRequest) {
+		mu.Lock()
+		forwarded[r.ID().LocalPort] = true
+		mu.Unlock()
+		// deny: create then immediately close so nothing is relayed
+		var wq waiter.Queue
+		if ep, e := r.CreateEndpoint(&wq); e == nil {
+			ep.Close()
+		}
+	})
+	s.SetTransportProtocolHandler(udp.ProtocolNumber, fwd.HandlePacket)
+
+	src := tcpip.AddrFrom4([4]byte{192, 168, 127, 2})
+
+	// (1) DNS to gateway:53 — must reach the bound resolver endpoint, NOT the forwarder.
+	injectUDP(ch, src, gateway, 53, []byte("dns-query"))
+	gotDNS := make([]byte, 64)
+	_ = dnsConn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	n, _, rerr := dnsConn.ReadFrom(gotDNS)
+	if rerr != nil || string(gotDNS[:n]) != "dns-query" {
+		t.Fatalf("DNS resolver endpoint did not receive :53 datagram (err=%v, got=%q) — override BYPASSED DNS", rerr, string(gotDNS[:n]))
+	}
+	mu.Lock()
+	dnsHitForwarder := forwarded[53]
+	mu.Unlock()
+	if dnsHitForwarder {
+		t.Error(":53 reached the filtering forwarder — DNS would be filtered/broken")
+	}
+
+	// (2) Guest→internet UDP to a port with no bound endpoint — must reach the
+	// forwarder (where allow_net filtering / drop happens).
+	injectUDP(ch, src, gateway, 9999, []byte("exfil"))
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		mu.Lock()
+		hit := forwarded[9999]
+		mu.Unlock()
+		if hit {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("non-DNS UDP never reached the filtering forwarder")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/forked_udp_test.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/forked_udp_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"net"
+	"testing"
+)
+
+// TestUDPAllowed is the security regression for finding #2: with allow_net set,
+// UDP to non-allowlisted destinations (e.g. DNS-over-UDP exfiltration to an
+// attacker on :53, or QUIC on :443) must be blocked, while allowlisted hosts and
+// the gateway DNS resolver still pass. With no filter, all UDP is allowed
+// (unchanged behavior).
+func TestUDPAllowed(t *testing.T) {
+	// allow_net = api allowlisted IP; internal/gateway IPs always allowed.
+	f := NewTCPFilter([]string{"1.2.3.4"}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
+
+	cases := []struct {
+		name string
+		ip   string
+		port uint16
+		want bool
+	}{
+		{"allowlisted dest", "1.2.3.4", 443, true},
+		{"gateway DNS", "192.168.127.1", 53, true},
+		{"attacker DNS exfil blocked", "203.0.113.9", 53, false},
+		{"attacker QUIC blocked", "203.0.113.9", 443, false},
+		{"unlisted host blocked", "8.8.8.8", 12345, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := udpAllowed(net.ParseIP(tc.ip), tc.port, f)
+			if got != tc.want {
+				t.Errorf("udpAllowed(%s:%d) = %v, want %v", tc.ip, tc.port, got, tc.want)
+			}
+		})
+	}
+
+	// No filter: everything allowed (prior behavior).
+	if !udpAllowed(net.ParseIP("203.0.113.9"), 53, nil) {
+		t.Error("udpAllowed with nil filter should allow all UDP")
+	}
+}

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/main.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/main.go
@@ -454,6 +454,11 @@ func gvproxy_create(configJSON *C.char, errOut **C.char) C.longlong {
 			if err := OverrideTCPHandler(vn, tapConfig, tapConfig.Ec2MetadataAccess, tcpFilter, instance.ca, instance.secretMatcher); err != nil {
 				logrus.WithError(err).Error("TCP: failed to override handler")
 			}
+			// Optional UDP filtering (audit finding #2). Experimental and OFF by
+			// default — see forked_udp.go. Only enforces when allow_net is set.
+			if err := OverrideUDPHandlerIfEnabled(vn, tapConfig, tcpFilter, os.Getenv("BOXLITE_UDP_FILTER") == "true"); err != nil {
+				logrus.WithError(err).Error("UDP: failed to override handler")
+			}
 		}
 
 		// Store VirtualNetwork reference for stats collection


### PR DESCRIPTION
> ⚠️ **[WIP — decision logic tested; live forwarder NOT integration-verified]**
> Part of a source-level security audit. The UDP policy (`udpAllowed`) is unit
> tested; the live forwarder is gated behind `BOXLITE_UDP_FILTER=true` (OFF by
> default) because its interaction with gvproxy's embedded DNS resolver and the
> datagram relay path could not be validated without a network-stack harness.

## Problem

`allow_net` only filtered TCP. UDP used gvproxy's default NAT forwarder, so a
restricted box could exfiltrate to **any** host over UDP/QUIC (DNS-over-UDP to an
attacker on :53, HTTP/3 on :443, custom UDP channels). The DNS sinkhole governs
only name resolution, not datagram destinations.

## Change
- `udpAllowed(destIP, destPort, filter)` — drops UDP to destinations not permitted
  by the AllowNet filter; reuses `TCPFilter.MatchesIP`, so gateway/internal IPs
  (incl. the DNS resolver) and allowlisted hosts pass. No filter → all UDP allowed.
- `OverrideUDPHandler` installs a filtered `udp.NewForwarder` (mirrors the TCP
  override). Wired in `main.go` behind `BOXLITE_UDP_FILTER=true`, **OFF by
  default** so the live path is unchanged.

## Test (two-sided) — policy, runs locally
`TestUDPAllowed`: attacker `:53`/`:443` and unlisted hosts blocked; allowlisted +
gateway DNS pass. Reverting `udpAllowed` to "always allow" (pre-fix) makes the
blocked cases pass and the test fails. Full bridge suite + `go vet` green.

## What needs a resource to verify (before enabling by default)
- A **gvisor netstack integration harness** (the repo has none — `forked_network_test`
  only reflect-checks the `stack` field) to drive real UDP/DNS packets and confirm:
  (a) non-allowlisted UDP is dropped end to end, (b) **DNS still resolves** (i.e.
  overriding the UDP handler does not bypass the embedded resolver endpoint), and
  (c) the datagram relay/idle-timeout works for allowed flows.

Audit finding #2 (high).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
