### PR TITLE
[codex] Fix API image production build blockers

### DIFF
--- a/apps/api/src/interceptors/metrics.interceptor.ts
+++ b/apps/api/src/interceptors/metrics.interceptor.ts
@@ -428,7 +428,6 @@ export class MetricsInterceptor implements NestInterceptor, OnApplicationShutdow
       box_memory_mb_request: request.memory_mib,
       box_memory_mb: response.memory_mib,
       box_disk_gb_request: request.disk_size_gb,
-      box_public_request: request.public,
       box_env_vars_length_request: envVarsLength,
     }
 

--- a/apps/dashboard/project.json
+++ b/apps/dashboard/project.json
@@ -14,7 +14,7 @@
       "dependsOn": [
         {
           "target": "build",
-          "projects": ["analytics-api-client"]
+          "projects": ["api-client", "analytics-api-client"]
         }
       ]
     },

--- a/apps/dashboard/src/components/ui/toggle-group.tsx
+++ b/apps/dashboard/src/components/ui/toggle-group.tsx
@@ -40,9 +40,9 @@ function ToggleGroup({
       data-variant={variant}
       data-size={size}
       data-spacing={spacing}
-      style={{ '--gap': spacing } as React.CSSProperties}
+      style={{ '--gap': `${spacing * 0.25}rem` } as React.CSSProperties}
       className={cn(
-        'group/toggle-group flex w-fit items-center gap-[--spacing(var(--gap))] rounded-md data-[spacing=default]:data-[variant=outline]:shadow-xs',
+        'group/toggle-group flex w-fit items-center gap-[var(--gap)] rounded-md data-[spacing=default]:data-[variant=outline]:shadow-xs',
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary

- Remove the stale `box_public_request: request.public` create-box metric after #762 moved metrics to the REST create DTO.
- Replace the Tailwind v4-only toggle group gap class with valid Tailwind 3/CSS-var output.
- Make `dashboard:build` depend on `api-client:build` so clean Docker builds have `dist/libs/api-client` before dashboard typecheck.

## Root cause

`sst deploy --stage dev` failed while building the API image. The first blocker was `api:build:production` typechecking `request.public` against the REST `CreateBoxDto`, which intentionally has no `public` field. After that was fixed, the same clean Docker image path exposed two dashboard production blockers: invalid generated CSS from `gap-[--spacing(var(--gap))]`, and a missing `api-client` build dependency.

## Validation

- `git diff --check`
- Remote dev machine: `cd apps && NX_DAEMON=false yarn nx build api --configuration=production --nxBail=true --output-style=stream`
- Remote dev machine: `docker build -f apps/api/Dockerfile --target boxlite .`

## Notes

I checked current open PRs before opening this. #719 and #541 both touch `metrics.interceptor.ts`, but neither contains this stale `request.public` fix; #719 is also a broad draft for older API production webpack issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced toggle group component spacing behavior for improved visual consistency

* **Chores**
  * Updated build dependency configuration for dashboard production builds
  * Refined analytics metric collection payload structure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->