### PR TITLE
chore(infra-local): consolidate local-stack state into .apps-local/ + modernize for post-squash schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,7 +209,10 @@ sdks/go/libboxlite.dylib
 sdks/go/boxlite-c-v*/
 
 l2-*.png
-apps/infra-local/.logs/
+
+# Local dev stack (apps/infra-local) — ALL generated state: data volumes,
+# SDK + runner homes, native binaries, logs
+/.apps-local/
 
 # Session test screenshots (Playwright runs)
 regions-*.png

--- a/apps/infra-local/CONNECTIONS.md
+++ b/apps/infra-local/CONNECTIONS.md
@@ -312,7 +312,7 @@ started + supervised by the `stack-*` Makefile targets under
 | Service | Process | Host port |
 |---|---|---|
 | Dashboard (React + Vite) | `corepack yarn nx serve dashboard` | `3000` |
-| API (NestJS) | `corepack yarn nx serve api --buildTargetOptions.generatePackageJson=false --buildTargetOptions.skipTypeChecking=true` (CWD: `apps/`; flags explained in `scripts/stack-up.sh`) | `3001` |
+| API (NestJS) | `corepack yarn nx serve api` (CWD: `apps/`) | `3001` |
 | Proxy (Go) | `/tmp/boxlite-proxy` | `4000` |
 | Runner (Go) | `/tmp/boxlite-runner` (native arm64; spawns box microVMs in `~/.boxlite-runner/`) | `3003` (API_PORT) |
 

--- a/apps/infra-local/Makefile
+++ b/apps/infra-local/Makefile
@@ -6,6 +6,12 @@
 
 PY ?= python
 
+# All recipes must agree with scripts/_stack-common.sh (and the python
+# orchestrator's own default) on where the L1 SDK home lives, so the
+# `boxlite` CLI here (stack-rebuild-l1-box) sees the same boxes.
+REPO_ROOT := $(abspath $(CURDIR)/../..)
+export BOXLITE_HOME ?= $(REPO_ROOT)/.apps-local/boxlite
+
 .PHONY: help up down ps doctor logs wipe itest test install migrate e2e itest-all \
         stack-build stack-up stack-down stack-restart stack-status stack-logs stack-reset stack-reset-hard stack-nuke \
         seed-init-data stack-rebuild-l1-box
@@ -34,23 +40,23 @@ doctor:                ## run preflight checks (SDK + runtime + port conflicts)
 	$(PY) -m boxlite_local doctor
 
 test:                  ## run unit tests (no BoxLite required)
-	pytest tests/unit -q
+	$(PY) -m pytest tests/unit -q
 
 itest:                 ## run integration smoke test (requires BoxLite runtime, ~30s)
-	BOXLITE_INTEGRATION=1 pytest tests/integration/test_multi_service.py -v -s
+	BOXLITE_INTEGRATION=1 $(PY) -m pytest tests/integration/test_multi_service.py -v -s
 
 e2e:                   ## run comprehensive E2E suite (~60s, ~90s with smoke)
-	BOXLITE_INTEGRATION=1 pytest tests/integration/test_e2e_full.py -v -s
+	BOXLITE_INTEGRATION=1 $(PY) -m pytest tests/integration/test_e2e_full.py -v -s
 
 itest-all:             ## run BOTH integration suites (~90s)
-	BOXLITE_INTEGRATION=1 pytest tests/integration -v
+	BOXLITE_INTEGRATION=1 $(PY) -m pytest tests/integration -v
 
 migrate:               ## build local pg schema by running all TypeORM migrations from scratch
 	cd ../api && set -a && . ../.env && set +a && \
 	  npx ts-node -P ./tsconfig.json -r tsconfig-paths/register \
 	    ../node_modules/typeorm/cli.js migration:run -d ./src/migrations/data-source.ts
 
-seed-init-data:        ## ensure dashboard-required base data (admin org, default region, wait snapshot)
+seed-init-data:        ## ensure dashboard-required base data (admin org, default region, wait runner)
 	./scripts/seed-init-data.sh
 
 # ── L2 stack wrappers (L1 + native API/Runner/Proxy/Dashboard) ───────────────

--- a/apps/infra-local/README.md
+++ b/apps/infra-local/README.md
@@ -15,10 +15,22 @@ single Apple Silicon Mac. It owns two layers:
   [`scripts/`](scripts/).
 
 User boxes (L3) are spawned by the L2 Runner as libkrun microVMs
-under `~/.boxlite-runner/`.
+under `<repo>/.apps-local/boxlite-runner/`.
+
+ALL generated state lives under one gitignored repo-root dir:
+
+```
+<repo>/.apps-local/
+├── bin/             native runner + proxy binaries (stack-build.sh)
+├── logs/            L2 process logs + pid files
+├── data/            L1 service volumes (pg / redis / minio / registry)
+├── boxlite/         SDK home for the L1 boxes (BOXLITE_HOME)
+└── boxlite-runner/  runner home for L3 user boxes (BOXLITE_HOME_DIR)
+```
 
 Cold-start to
-working box + browser terminal in ~80 s. Daily dev workflow
+working box + browser terminal in ~80 s (box boot / image resolution is
+mid-rewrite upstream and unverified here — see limitation #4). Daily dev workflow
 documented in the [Usage guide](#usage-guide) below.
 Known limitations: see [§Known limitations](#known-limitations).
 
@@ -56,6 +68,24 @@ make stack-down ARGS=--all
 > rebuild after pulling new code), but you don't have to — stack-up
 > runs them automatically when they're needed.
 
+### Migrating from the pre-`.apps-local` layout
+
+Older checkouts kept state in `~/.boxlite` (L1 boxes),
+`~/.boxlite-local/data` (volumes), `~/.boxlite-runner/` (runner home),
+`/tmp/boxlite-{runner,proxy}` (binaries) and `apps/infra-local/.logs/`.
+One-time cleanup:
+
+```bash
+cd apps/infra-local
+BOXLITE_HOME=$HOME/.boxlite make down        # stop L2 + remove OLD L1 boxes
+rm -rf ~/.boxlite-local ~/.boxlite-runner    # old volumes + runner home
+rm -f /tmp/boxlite-runner /tmp/boxlite-proxy # old binaries
+# optional — only if nothing else on this machine uses BoxLite:
+# rm -rf ~/.boxlite
+
+make stack-up                                # cold start under <repo>/.apps-local/
+```
+
 ### Make targets
 
 L1-only (just the BoxLite boxes):
@@ -68,7 +98,7 @@ L1-only (just the BoxLite boxes):
   ps                 list running boxlite-local-* boxes
   doctor             run preflight checks (SDK + runtime + port conflicts)
   migrate            build local pg schema by running all TypeORM migrations from scratch
-  seed-init-data     ensure dashboard-required base data (admin org, default region, wait snapshot)
+  seed-init-data     ensure dashboard-required base data (admin org, default region, wait runner)
 ```
 
 L2 stack wrappers (L1 + native API/Runner/Proxy/Dashboard):
@@ -130,7 +160,7 @@ After `make stack-up` you have 10 L1 daemon boxes + 1 one-shot bootstrap
 | Dashboard (Vite) | `http://127.0.0.1:3000/`   | React + OIDC login flow                  |
 | API (NestJS)     | `http://127.0.0.1:3001/api`| Reads `apps/.env` (→ `apps/api/.env`, seeded on first `stack-up` from `configs/api.env`); auto-seeds admin org + default region |
 | Proxy (Go)       | `http://127.0.0.1:4000`    | Box port-preview `<port>-<token>.localhost:28080` reverse-proxy target |
-| Runner (Go)      | `http://127.0.0.1:3003`    | Native arm64; spawns L3 microVMs in `~/.boxlite-runner/` |
+| Runner (Go)      | `http://127.0.0.1:3003`    | Native arm64; spawns L3 microVMs in `.apps-local/boxlite-runner/` |
 
 See [`CONNECTIONS.md`](CONNECTIONS.md) for full credentials, env vars,
 and per-service env override surface.
@@ -175,7 +205,17 @@ BOXLITE_OTEL_HTTP_PORT=24318
 BOXLITE_OTEL_HEALTH_PORT=23133
 BOXLITE_CADDY_HTTP_PORT=28080
 BOXLITE_CADDY_HTTPS_PORT=28443   # currently mapped but TLS not enabled
-BOXLITE_DATA_DIR=~/.boxlite-local/data   # persistent volume mounts root
+BOXLITE_DATA_DIR=<repo>/.apps-local/data      # persistent volume mounts root
+BOXLITE_HOME=<repo>/.apps-local/boxlite       # SDK home for the L1 boxes
+```
+
+`BOXLITE_HOME` is exported by the Makefile and `scripts/_stack-common.sh`,
+so every `make` target and stack script sees the same L1 boxes. To inspect
+them from a plain shell (`boxlite ls`, `boxlite logs ...`), export it
+yourself first:
+
+```bash
+export BOXLITE_HOME=<repo>/.apps-local/boxlite
 ```
 
 Hostname inside boxes for reaching the host machine:
@@ -250,7 +290,7 @@ trace debugging; swap in the custom build above for exporter parity.
 
 ### 3. SDK gotchas worked around (file these as feedback)
 
-This codebase contains workarounds for ~9 distinct SDK behaviours that
+This codebase contains workarounds for several SDK behaviours that
 are worth filing back to the BoxLite team. They're all noted in the
 relevant source files. Summary:
 
@@ -258,15 +298,39 @@ relevant source files. Summary:
 |---|---|---|
 | 1 | `host.boxlite.internal` failed on first run | Env (Docker Desktop) — not SDK |
 | 2 | brew postgres collided on default ports | Use non-default host ports (§3.8) |
-| 3 | `r-x` dir layers (RHEL UBI base) break rootfs merge | `_ensure_image_cache_writable` chmod |
-| 4 | First pull's freshly-extracted layers also need chmod | `_start_with_perm_retry` |
-| 5 | SDK rejects file volume mounts (must be dirs) | inline scripts via `cmd=sh -c '...'` |
-| 6 | `ServiceSpec` lacked `entrypoint` field; SDK has it | `entrypoint=["sh"]` for image-overriding |
-| 7 | `list_info().state.status` stays "running" after init exits | exec-probe in `_wait_one_shot_exit` |
-| 8 | `runtime.remove()` rejects "running" VM after init exits | `runtime.remove(name, force=True)` |
-| 9 | `runtime.get(name)` returns None (not raises) for missing | `if box is None: return False` |
-| 10 | EXPOSE 443 (or other privileged) silently breaks ALL port forwards for that box | Map every EXPOSE'd port explicitly |
-| 11 | `box.exec` race during box startup (`InitReady vs IntermediateReady`) | `_wait_healthy_exec` retries on any exception |
+| 3 | SDK rejects file volume mounts (must be dirs) | inline scripts via `cmd=sh -c '...'` |
+| 4 | `list_info().state.status` stays "running" after one-shot init exits | exec-probe in `_wait_one_shot_exit` |
+| 5 | `runtime.remove()` rejects "running" VM after init exits | `runtime.remove(name, force=True)` |
+| 6 | `box.exec` race during box startup (`InitReady vs IntermediateReady`) | `_wait_healthy_exec` retries on any exception |
+| 7 | microVM↔host transport can wedge a PG connection mid-query | server-side `statement_timeout` + `tcp_keepalives_*` (SPEC_PG) — root fix belongs in the transport |
+| 8 | SDK has no typed "already running" error | message-substring sniff in `_is_already_running_error` |
+
+Fixed upstream and removed from this codebase:
+- `r-x` dir-layer rootfs-merge chmod workarounds (SDK #607/#697).
+- EXPOSE'd-privileged-port auto-bind trap — the SDK no longer auto-binds
+  image-EXPOSE'd ports, so placeholder mappings are gone (verified by
+  rebuilding boxes without them).
+- `runtime.get()` returning `Option` is the documented API contract now,
+  not a gotcha.
+
+### 4. Box boot / image resolution is mid-rewrite upstream (unverified here)
+
+The migration squash removed the box-template/snapshot subsystem, then
+`#755`/`#758` reintroduced an **image-keyed** boot path (the box-start
+`UNKNOWN` handler now calls `runnerAdapter.createBox` —
+`apps/api/src/box/managers/box-actions/box-start.action.ts`) and restricted
+creation to supported pinned images. What's still *not* rebuilt is image
+**resolution** — see the `TODO(image-rewrite)` markers in
+`apps/api/src/box/services/box.service.ts:136,:155` (and ~20 more across
+`apps/api`/`apps/dashboard` for the removed template webhooks, metrics, and
+the dashboard image/template picker — e.g. `CreateBoxSheet.tsx:138,:228`).
+
+Net: a box with no image fails fast (`'Box has no image to create from'`),
+and the dashboard's image picker is gone, so end-to-end "Create Box" from
+the UI is incomplete. We have **not** verified a successful box boot on this
+stack since the rebase (it also needs a rebuilt `libboxlite.a` for the
+runner). Everything else — L1 services, API, runner registration, auth,
+dashboard — works.
 
 ---
 
@@ -290,7 +354,7 @@ apps/infra-local/
 │   └── services.py                   # SPEC_* + SERVICES registry
 ├── scripts/                          # L2 stack wrappers (called by `make stack-*`)
 │   ├── _stack-common.sh
-│   ├── seed-init-data.sh             # wait for API self-seed + default snapshot
+│   ├── seed-init-data.sh             # wait for API self-seed + registered runner
 │   ├── stack-build.sh                # build runner + proxy binaries
 │   ├── stack-up.sh / stack-down.sh / stack-restart.sh
 │   ├── stack-status.sh / stack-logs.sh
@@ -324,10 +388,9 @@ apps/infra-local/
 
 **Add a new L1 service:** define a `ServiceSpec` in `services.py`, add an
 entry to the `SERVICES` dict, add the host port default to `InfraConfig`,
-add `BOXLITE_<NAME>_HOST_PORT` to `.load()`, run `make up`. Don't forget
-to map ALL of the image's `EXPOSE`'d ports explicitly (the SDK auto-bind
-silently breaks ALL forwards for that box if any EXPOSE'd port can't be
-bound — see SDK gotcha #10 above).
+add `BOXLITE_<NAME>_HOST_PORT` to `.load()`, run `make up`. Map only the
+ports you actually use — the SDK no longer auto-binds image-`EXPOSE`'d
+ports.
 
 **Restart one L2 component** (90 % of daily iteration):
 `make stack-restart COMPONENTS=runner` (or `api`, `proxy`, `dashboard`;
@@ -335,18 +398,19 @@ multiple as `COMPONENTS="api proxy"`). `runner` includes an automatic
 rebuild.
 
 **Rebuild one L1 box** (when a stateful service goes weird — typical
-symptoms: dex returns stale tokens, registry pull hangs):
+symptoms: dex issues already-expired tokens after the Mac slept (clock
+drift — see [§Common issues](#7-common-issues)), registry pull hangs):
 `make stack-rebuild-l1-box BOX=dex` (or `registry`, `pgadmin`, ...).
 
 **Debug a stuck service:** `make stack-status` first → identify the red
 component → use the lightest possible cleanup. `python -m boxlite_local ps`
 shows L1 box state; `boxlite logs boxlite-local-<name>` shows guest
 logs; `make stack-logs COMPONENT=<name>` tails L2 logs from
-`apps/infra-local/.logs/`.
+`.apps-local/logs/`.
 
 **Reset DB to clean state** (most-common scenario): `make stack-reset &&
 make stack-up` — truncates PG user data and clears
-`~/.boxlite-runner/`, preserves schema + L1 boxes + image cache. Use
+`.apps-local/boxlite-runner/`, preserves schema + L1 boxes + image cache. Use
 `stack-reset-hard` to also drop + rebuild the schema via migrations. Use
 `stack-nuke` only when you want a full cold rebuild (~3-5 min).
 
@@ -424,7 +488,7 @@ make stack-status   # one-screen health
 ```
 
 Cold-start time: ~5-7 minutes on first run (most of it is pulling the
-`ubuntu:22.04` default snapshot into the local registry). Subsequent
+10 L1 service images). Subsequent
 `stack-up` runs reuse the image cache and complete in ~30 s to 1 min.
 
 ✅ `stack-up.sh` is **self-healing** — a single `make stack-up` works
@@ -432,11 +496,11 @@ from a fresh checkout, after a reboot, or after `make stack-down`,
 because it automatically:
 1. Installed the orchestrator package (`make install`) if `boxlite_local` wasn't importable yet
 2. Brought up L1 boxes (`make up`) if they weren't running; the API then runs all TypeORM migrations on boot against the pg box (a no-op when the schema is already present, e.g. the PG data volume survived a reboot)
-3. Built the native binaries (`stack-build.sh`) if `/tmp/boxlite-runner` / `/tmp/boxlite-proxy` were missing (e.g. `/tmp` cleared on reboot)
-4. Created the two symlinks NestJS needs (`apps/.env`, `apps/apps`)
+3. Built the native binaries (`stack-build.sh`) if `.apps-local/bin/boxlite-runner` / `boxlite-proxy` were missing (fresh checkout or wiped state dir)
+4. Created the `apps/.env` symlink NestJS needs
 5. Started api → runner → proxy → dashboard in dependency order, waiting for each to be healthy before the next
 6. Detected ports already in use and freed them first (prevents EADDRINUSE)
-7. Written PIDs to `apps/infra-local/.logs/<comp>.pid` and logs to `<comp>.log`
+7. Written PIDs to `.apps-local/logs/<comp>.pid` and logs to `<comp>.log`
 
 > You can still run `make install` / `make stack-build` explicitly — e.g.
 > to force a binary rebuild after changing runner/proxy source — but
@@ -453,6 +517,11 @@ preseeded accounts (see [`apps/infra-local/CONNECTIONS.md` §4](CONNECTIONS.md))
 
 Then click **Create Box** → pick region `us` → **Create** → open
 the **Terminal** tab → **Connect** → you should see `root@boxlite:~#`.
+
+> ⚠️ Box creation is mid-rewrite upstream and unverified on this stack: image
+> **resolution** isn't rebuilt yet and the dashboard's image picker was
+> removed, so "Create Box" from the UI is incomplete. See
+> [Known limitations](#known-limitations) #4. The rest of the stack works.
 
 ### 2. Day-to-day dashboard development loop
 
@@ -480,7 +549,7 @@ the **Terminal** tab → **Connect** → you should see `root@boxlite:~#`.
 | Change | How to handle it |
 |---|---|
 | Edit `*.entity.ts` (DB schema) | Write a migration at `apps/api/src/migrations/<ts>-name-migration.ts`; the restart runs it automatically |
-| Edit `.env` | Ctrl-C + re-run via `make stack-restart COMPONENTS=api` (or copy the full `nx serve api --buildTargetOptions.*` invocation from `scripts/stack-up.sh`) |
+| Edit `.env` | Ctrl-C + re-run via `make stack-restart COMPONENTS=api` (or copy the `nx serve api` invocation from `scripts/stack-up.sh`) |
 | Edit OpenAPI (controller `@Api*` decorators) | `yarn nx run api:openapi` regenerates `dist/apps/api/openapi.json` → SDK client regenerates → restart dashboard |
 
 ### 4. Runner development loop
@@ -488,7 +557,7 @@ the **Terminal** tab → **Connect** → you should see `root@boxlite:~#`.
 ```bash
 # Runner is a native Go binary with no watch mode
 pkill -9 -f boxlite-runner
-cd apps/runner && go build -o /tmp/boxlite-runner ./cmd/runner && cd -
+cd apps/runner && go build -o ../../.apps-local/bin/boxlite-runner ./cmd/runner && cd -
 # Re-run it (use the cheatsheet in the status doc)
 ```
 
@@ -505,19 +574,19 @@ cd -
 
 # Or just truncate user data, preserving schema / migrations state
 PGPASSWORD=boxlite psql -h 127.0.0.1 -p 25432 -U boxlite -d boxlite -c "
-  TRUNCATE TABLE box, snapshot, snapshot_runner, runner, region, 
-                 organization, organization_user, organization_role, 
+  TRUNCATE TABLE box, job, volume, runner, region,
+                 organization, organization_user, organization_role,
                  api_key, audit_log CASCADE;
 "
 
 # Then restart the API so it re-seeds default region + default runner
 ```
 
-`~/.boxlite-runner/` must also be cleared, otherwise the runner still thinks the old boxes exist:
+`.apps-local/boxlite-runner/` must also be cleared, otherwise the runner still thinks the old boxes exist:
 
 ```bash
 pkill -9 -f boxlite-runner
-rm -rf ~/.boxlite-runner/{db,boxes,images,rootfs}/
+rm -rf .apps-local/boxlite-runner/{db,boxes,images,rootfs}/
 # Restart runner
 ```
 
@@ -545,9 +614,9 @@ make stack-nuke && make stack-up
 What it does:
 - Stops the 4 L2 native processes
 - Deletes all 10 L1 boxes (microVM kernels + rootfs)
-- Clears data volumes + `.logs/`
+- Clears data volumes + `.apps-local/logs/`
 - Re-pulls the 10 images + reloads the prod schema
-- Starts L2; the API self-seeds (region / admin / snapshot pulled to active)
+- Starts L2; the API self-seeds (admin org / default region); the runner re-registers
 
 **When to use it:** new-hire onboarding / schema upgrade / "I did a bunch of weird stuff and want to go back to a clean state".
 
@@ -558,7 +627,7 @@ cd apps/infra-local
 make stack-reset && make stack-up
 ```
 
-Differences from ⑤ — this one **preserves**: L1 boxes, PG schema, image cache, historical logs. It only clears PG **user data** + `~/.boxlite-runner/` runtime state.
+Differences from ⑤ — this one **preserves**: L1 boxes, PG schema, image cache, historical logs. It only clears PG **user data** + `.apps-local/boxlite-runner/` runtime state.
 
 **When to use it:** mid-iteration the data got dirty and you want to clear box/org/user; testing "fresh DB" behavior.
 
@@ -624,7 +693,7 @@ pytest tests/
 
 ```bash
 # Inspect box state
-sqlite3 ~/.boxlite-runner/db/boxlite.db -header -column \
+sqlite3 .apps-local/boxlite-runner/db/boxlite.db -header -column \
   "SELECT id, image, status FROM boxes WHERE status='running';"
 
 # Inspect the API primary DB
@@ -643,11 +712,12 @@ PGPASSWORD=boxlite psql -h 127.0.0.1 -p 25432 -U boxlite -d boxlite -c "
 # Proxy stdout: same
 
 # Box-internal logs (the 10 infra-local boxes)
+# (plain shells need: export BOXLITE_HOME=<repo>/.apps-local/boxlite)
 boxlite logs boxlite-local-postgres
 boxlite logs boxlite-local-caddy
 
 # Box microVM-internal logs (managed by the runner)
-ls -lt ~/.boxlite-runner/boxes/<id>/logs/
+ls -lt .apps-local/boxlite-runner/boxes/<id>/logs/
 ```
 
 ### 7. Common issues
@@ -655,13 +725,13 @@ ls -lt ~/.boxlite-runner/boxes/<id>/logs/
 | Symptom | Likely cause | Fix |
 |---|---|---|
 | All API calls return 401 | `SSH_GATEWAY_API_KEY` or `PROXY_API_KEY` not set | Check `apps/api/.env` — both must be non-empty |
-| Box stuck in PENDING | snapshot has not finished PULLING | Wait 30-60 s; if still stuck, check runner log for image-pull errors |
+| "Create Box" from the dashboard is incomplete / box doesn't boot | Expected: image resolution is mid-rewrite upstream and the dashboard image picker was removed (`TODO(image-rewrite)`) | See [Known limitations](#known-limitations) #4 — the rest of the stack is unaffected |
 | Box reaches STARTED but the terminal is blank + `Connection closed` | image is amd64 but runner runs an arm64 microVM | Already fixed (`runner/registry.go` uses `runtime.GOARCH`) — clear the old image cache and re-pull |
 | "Create Box" missing in the dashboard | Expected: PostHog isn't configured locally, so flag-gated UI stays hidden (no local flag bootstrap) | Use `POST /api/box` directly, or set `POSTHOG_API_KEY`/`POSTHOG_HOST` in `apps/api/.env` with the flags enabled in PostHog |
 | `POST /api/regions` → 404 "Cannot POST" | Expected: same — flag-gated admin routes stay hidden without a configured PostHog | Same as above; the seed path (`seed-init-data.sh`) doesn't need these routes |
-| Boxlite-runner hits `Another BoxliteRuntime is already using directory` | Another runner process is holding `~/.boxlite-runner/.lock` | `lsof ~/.boxlite-runner/.lock` to find the PID; decide whether to kill it or that you've used the wrong home dir |
+| Boxlite-runner hits `Another BoxliteRuntime is already using directory` | Another runner process is holding `.apps-local/boxlite-runner/.lock` | `lsof .apps-local/boxlite-runner/.lock` to find the PID; decide whether to kill it or that you've used the wrong home dir |
 | Terminal `Connection closed` and won't reconnect | signed-url expired (default 300 s) | Click Connect again; the dashboard re-fetches a fresh URL |
-| Dashboard loads `Unauthorized` / `401` even just after OIDC login | **Dex SQLite session db cached an old grant** and the new login reuses a stale token (common after a box SIGKILL or long idle). Diagnostic: decode the token; `accessTokenIat` is days old | `make stack-rebuild-l1-box BOX=dex` + `sessionStorage.clear()` in the browser + log in again |
+| Dashboard loads `Unauthorized` / `401` even just after OIDC login | **The dex box's clock has drifted behind the host.** Long-running L1 microVMs freeze their clock while the Mac sleeps (observed ~37h behind after a few days), so dex stamps every token's `iat`/`exp` from its own past clock — the token is *born expired* by the host's time and the API rejects it on `exp`. (Passport-jwt logs nothing for an expired token, so the API log looks like the token never arrived.) Diagnostic: `boxlite exec boxlite-local-dex -- date -u` vs host `date -u`; or decode the token — `iat`/`exp` are hours/days old. NOT a stale session-db grant and NOT a browser-storage problem. | `make stack-rebuild-l1-box BOX=dex` (fresh clock at boot) + clear browser storage / re-login (the cached token is genuinely expired) |
 | Box `pulling` is stuck for several minutes | **Registry box TCP still listens but the internal registry process is hung** (SIGKILL side-effect). Confirm: `curl http://127.0.0.1:25000/v2/_catalog` times out after 5 s | `make stack-rebuild-l1-box BOX=registry`; the stuck pull recovers automatically |
 | Any L1 box (pgadmin / jaeger / minio / ...) behaves weirdly | Same as above — the box's stateful internal process is broken | `make stack-rebuild-l1-box BOX=<name>` blows it away and rebuilds in one shot |
 
@@ -695,6 +765,7 @@ pkill -9 -f "boxlite-runner"
 pkill -9 -f "boxlite-proxy"
 
 # Stop the 10 infra boxes (preserve data)
+export BOXLITE_HOME="$(git rev-parse --show-toplevel)/.apps-local/boxlite"
 for b in caddy registry-ui pgadmin otel jaeger dex registry minio redis postgres; do
   boxlite stop boxlite-local-$b
 done
@@ -705,4 +776,4 @@ cd apps/infra-local && make down
 
 ### One-liner
 
-**Editing `.tsx` + Vite HMR is the default development rhythm.** API / Runner / Proxy are stable infrastructure that run in the background and you don't touch day-to-day. To wipe state: `make stack-reset-hard` + clear `~/.boxlite-runner/`. To demo: freeze a commit and run §1 once.
+**Editing `.tsx` + Vite HMR is the default development rhythm.** API / Runner / Proxy are stable infrastructure that run in the background and you don't touch day-to-day. To wipe state: `make stack-reset-hard` + clear `.apps-local/boxlite-runner/`. To demo: freeze a commit and run §1 once.

--- a/apps/infra-local/boxlite_local/cli.py
+++ b/apps/infra-local/boxlite_local/cli.py
@@ -12,7 +12,7 @@ import sys
 
 from .config import InfraConfig
 from .doctor import doctor, format_report
-from .orchestrator import down, ps, up
+from .orchestrator import down, ensure_home_env, ps, up
 from .services import SERVICES
 from .types import DoctorError
 
@@ -70,6 +70,9 @@ async def _cmd_ps(config: InfraConfig) -> int:
 async def _async_main(argv: list[str] | None = None) -> int:
     args = _build_parser().parse_args(argv)
     config = InfraConfig.load()
+    # Pin BOXLITE_HOME before any subcommand touches Boxlite.default() —
+    # the standalone `doctor` builds it via check_runtime_reachable.
+    ensure_home_env(config)
     if args.cmd == "doctor":
         return await _cmd_doctor(config)
     if args.cmd == "up":

--- a/apps/infra-local/boxlite_local/config.py
+++ b/apps/infra-local/boxlite_local/config.py
@@ -77,15 +77,37 @@ def _parse_int_env(name: str, default: str) -> int:
         raise ValueError(f"{name} must be an integer, got: {raw!r}") from e
 
 
-def _detect_repo_root() -> Path:
-    """Walk up from this file's directory until we find one containing apps/infra-local/."""
-    here = Path(__file__).resolve().parent
+def find_repo_root_from(here: Path) -> Path:
+    """Walk up from `here` to the first dir containing apps/infra-local/.
+
+    `apps` must be a REAL directory: older stack-up versions created an
+    `apps/apps -> .` symlink (webpack path quirk), which would otherwise make
+    `apps/` itself satisfy the predicate and mis-root all generated state at
+    `apps/.apps-local/`. The guard keeps the walk safe on checkouts where
+    that symlink still exists.
+    """
     for parent in (here, *here.parents):
-        if (parent / "apps" / "infra-local" / "pyproject.toml").exists():
+        apps = parent / "apps"
+        if not apps.is_symlink() and (apps / "infra-local" / "pyproject.toml").exists():
             return parent
     raise RuntimeError(
         f"could not locate repo root (no apps/infra-local/pyproject.toml found above {here})"
     )
+
+
+def _detect_repo_root() -> Path:
+    return find_repo_root_from(Path(__file__).resolve().parent)
+
+
+def _default_state_root() -> Path:
+    """Repo-scoped root for ALL generated local-stack state: <repo>/.apps-local/.
+
+    One gitignored dir holds the data volumes, the L1 SDK home, the runner
+    home, the native binaries, and the L2 logs — discoverable footprint,
+    per-checkout isolation, and deliberately NOT under cargo's target/ so a
+    `cargo clean` can never delete a live Postgres volume.
+    """
+    return _detect_repo_root() / ".apps-local"
 
 
 @dataclass
@@ -132,7 +154,12 @@ class InfraConfig:
     otel_http_port: int = 24318
     otel_health_port: int = 23133
 
-    data_dir: Path = field(default_factory=lambda: Path.home() / ".boxlite-local" / "data")
+    data_dir: Path = field(default_factory=lambda: _default_state_root() / "data")
+    # SDK home for the L1 boxes (exported as BOXLITE_HOME before the runtime
+    # singleton is built — see orchestrator.ensure_home_env). Separate from the
+    # runner's home (.apps-local/boxlite-runner): each BoxliteRuntime takes an
+    # exclusive lock on its home dir.
+    boxlite_home: Path = field(default_factory=lambda: _default_state_root() / "boxlite")
     repo_root: Path = field(default_factory=_detect_repo_root)
 
     @classmethod
@@ -160,11 +187,17 @@ class InfraConfig:
             otel_http_port=_parse_int_env("BOXLITE_OTEL_HTTP_PORT", "24318"),
             otel_health_port=_parse_int_env("BOXLITE_OTEL_HEALTH_PORT", "23133"),
             # .expanduser() so a documented value like
-            # BOXLITE_DATA_DIR=~/.boxlite-local/data expands the leading ~
-            # instead of creating a literal "~" dir under the cwd.
+            # BOXLITE_DATA_DIR=~/my-data expands the leading ~ instead of
+            # creating a literal "~" dir under the cwd.
             data_dir=Path(
                 os.environ.get("BOXLITE_DATA_DIR")
-                or str(Path.home() / ".boxlite-local" / "data")
+                or str(_default_state_root() / "data")
+            ).expanduser(),
+            # BOXLITE_HOME is the SDK's own env var — respecting it here keeps
+            # InfraConfig and a user-pinned SDK home in agreement.
+            boxlite_home=Path(
+                os.environ.get("BOXLITE_HOME")
+                or str(_default_state_root() / "boxlite")
             ).expanduser(),
         )
 

--- a/apps/infra-local/boxlite_local/orchestrator.py
+++ b/apps/infra-local/boxlite_local/orchestrator.py
@@ -88,6 +88,17 @@ def ensure_runtime_env() -> None:
         print(f"  pinned BOXLITE_RUNTIME_DIR to cached runtime: {runtime_dir}")
 
 
+def ensure_home_env(config: InfraConfig) -> None:
+    """Export BOXLITE_HOME from config so the SDK uses the repo-scoped home.
+
+    Must run before the FIRST `Boxlite.default()` anywhere in the process
+    (doctor's runtime-reachable check included): the default runtime is a
+    process-wide singleton that captures its home dir at construction.
+    Idempotent — config already respects a pre-set BOXLITE_HOME.
+    """
+    os.environ["BOXLITE_HOME"] = str(config.boxlite_home)
+
+
 def get_runtime():
     ensure_runtime_env()
     try:
@@ -127,60 +138,6 @@ def _http_probe(url: str) -> bool:
         return False
 
 
-# ─── image-cache writable workaround ──────────────────────────────────────
-
-_IMAGE_CACHE = Path.home() / ".boxlite" / "images" / "extracted"
-_TMP_CACHE = Path.home() / ".boxlite" / "tmp"
-
-
-def _ensure_image_cache_writable() -> None:
-    """Workaround for SDK rootfs-merge failures on images whose layers contain
-    `r-x` directories (e.g. RHEL UBI-based images like minio/minio:latest,
-    minio/mc:latest).
-
-    The SDK's per-start rootfs merge tries to write into directories whose
-    owner-write bit is unset in the extracted layer cache, which produces
-    `RuntimeError: storage error: Failed to ... Permission denied (os error 13)`
-    and (sometimes) `RustPanic: rust future panicked: unknown error`.
-
-    Walks `~/.boxlite/images/extracted/` AND `~/.boxlite/tmp/` adding owner-write
-    to every directory. Idempotent + cheap (~10ms on a populated cache).
-    Remove when the SDK relaxes dir perms at extract time.
-    """
-    import os, stat
-    for root_path in (_IMAGE_CACHE, _TMP_CACHE):
-        if not root_path.exists():
-            continue
-        for root, dirs, _files in os.walk(root_path):
-            for d in dirs:
-                p = os.path.join(root, d)
-                try:
-                    st = os.stat(p).st_mode
-                    if not (st & stat.S_IWUSR):
-                        os.chmod(p, st | stat.S_IWUSR | stat.S_IXUSR | stat.S_IRUSR)
-                except OSError:
-                    pass  # best-effort
-
-
-def _is_rootfs_perm_error(exc: Exception) -> bool:
-    """Detect the SDK's rootfs-merge permission-denied error so we can retry after chmod."""
-    msg = str(exc)
-    return "Permission denied (os error 13)" in msg and "/usr/bin/" in msg
-
-
-async def _start_with_perm_retry(box, label: str) -> None:
-    """Call `box.start()`. If it hits the SDK's r-x rootfs-perm bug, chmod the
-    image cache (which is now populated post-extract) and retry once."""
-    try:
-        await box.start()
-    except Exception as e:
-        if not _is_rootfs_perm_error(e):
-            raise
-        print(f"  {label}: hit SDK rootfs perm error; re-chmodding cache and retrying")
-        _ensure_image_cache_writable()
-        await box.start()
-
-
 # ─── start / stop / wait ──────────────────────────────────────────────────
 
 async def start_service(runtime, spec: ServiceSpec, config: InfraConfig) -> None:
@@ -188,7 +145,6 @@ async def start_service(runtime, spec: ServiceSpec, config: InfraConfig) -> None
     volumes = spec.volumes(config)
     opts = _build_box_options_with_volumes(spec, config, volumes)
     config.data_dir.mkdir(parents=True, exist_ok=True)
-    _ensure_image_cache_writable()
     for host_path, _ in volumes:
         p = Path(host_path)
         # Heuristic: only auto-create directory mounts. Paths with a suffix
@@ -209,10 +165,11 @@ async def start_service(runtime, spec: ServiceSpec, config: InfraConfig) -> None
                 pass
             await runtime.remove(name)
             box, _ = await runtime.get_or_create(opts, name=name)
-        await _start_with_perm_retry(box, label=spec.name)
+        await box.start()
         await _wait_one_shot_exit(runtime, name, label=spec.name)
-        # One-shot box's VM is still "running" per SDK even after init exited;
-        # force=True stops the VM as part of remove.
+        # One-shot box's VM is still "running" per the SDK even after init
+        # exited; force=True stops the VM as part of remove (SDK gotcha —
+        # see the README gotcha table).
         try:
             await runtime.remove(name, force=True)
         except Exception as e:
@@ -221,10 +178,10 @@ async def start_service(runtime, spec: ServiceSpec, config: InfraConfig) -> None
         return
 
     if created:
-        await _start_with_perm_retry(box, label=spec.name)
+        await box.start()
     else:
         try:
-            await _start_with_perm_retry(box, label=spec.name)
+            await box.start()
         except Exception as e:
             if not _is_already_running_error(e):
                 raise
@@ -331,19 +288,19 @@ async def _wait_one_shot_exit(runtime, name: str, *, label: str, timeout_s: floa
     """Wait until the named one-shot box's init process exits.
 
     SDK's `list_info().state.status` stays "running" as long as the VM is up,
-    independent of whether the OCI container's init process inside has exited.
-    For one-shot bootstrap services we need the init-exit signal — which the
-    SDK only surfaces by failing `box.exec(...)` with a specific error message
+    independent of whether the OCI container's init process inside has exited
+    (SDK gotcha — see the README gotcha table; re-verified still present on
+    current main). The init-exit signal only
+    surfaces by `box.exec(...)` failing with a specific error message
     ("incorrect container status" / "Container init process exited").
 
-    We probe via `box.exec("true")` every second: success means init still
-    running; the specific exit-related failure means we're done.
+    Fast path: poll `list_info()` in case the SDK starts reporting it.
+    Slow path: probe via `box.exec("true")` every second — success means init
+    is still running; the specific exit-related failure means we're done.
     """
     start = time.monotonic()
     last_err: str = ""
     while time.monotonic() - start < timeout_s:
-        # First, fast path: if list_info DOES update (older SDK versions did),
-        # use it.
         infos = await runtime.list_info()
         info = next((i for i in infos if i.name == name), None)
         if info is None:
@@ -353,22 +310,18 @@ async def _wait_one_shot_exit(runtime, name: str, *, label: str, timeout_s: floa
             print(f"  {label}: one-shot exited with state={status}")
             return
 
-        # Slow path: probe via exec; init-exited returns a specific error.
         try:
             box = await runtime.get(name)
             if box is not None:
-                exec_collect_was_ok = False
                 try:
                     rc, _o, _e = await exec_collect(box, "true", [])
-                    exec_collect_was_ok = (rc == 0)
+                    _ = rc  # init still running; keep polling
                 except Exception as e:
                     msg = str(e)
                     last_err = msg
                     if "Container init process exited" in msg or "incorrect container status" in msg:
                         print(f"  {label}: one-shot init process has exited")
                         return
-                # If exec_collect succeeded, init is still running; loop.
-                _ = exec_collect_was_ok  # quiet linter
         except Exception:
             pass
 
@@ -387,8 +340,10 @@ async def up(
     only: list[str] | None = None,
     skip_doctor: bool = False,
 ) -> None:
-    # Pin the runtime dir before anything builds a Boxlite.default() singleton
-    # (doctor below does), so box starts find boxlite-guest deterministically.
+    # Pin home + runtime dir before anything builds a Boxlite.default()
+    # singleton (doctor below does), so box starts hit the repo-scoped home
+    # and find boxlite-guest deterministically.
+    ensure_home_env(config)
     ensure_runtime_env()
     if not skip_doctor:
         await doctor(config, services, strict=True)
@@ -411,6 +366,7 @@ async def down(
     only: list[str] | None = None,
     wipe: bool = False,
 ) -> None:
+    ensure_home_env(config)
     runtime = get_runtime()
     for layer in reversed(topo_sort(services)):
         targets = [n for n in layer if only is None or n in only]
@@ -424,6 +380,7 @@ async def down(
 
 async def ps(config: InfraConfig) -> list[tuple[str, str, str]]:
     """Return list of (name, status, image) for boxlite-local-* boxes. Also prints."""
+    ensure_home_env(config)
     runtime = get_runtime()
     infos = await runtime.list_info()
     rows: list[tuple[str, str, str]] = []

--- a/apps/infra-local/boxlite_local/services.py
+++ b/apps/infra-local/boxlite_local/services.py
@@ -252,12 +252,7 @@ SPEC_PGADMIN = ServiceSpec(
     image="dpage/pgadmin4:9.2.0",
     cpus=1,
     memory_mib=512,
-    # The pgadmin4 image EXPOSEs 80 AND 443. The SDK auto-binds every
-    # EXPOSE'd guest port to the same host port unless we map it explicitly;
-    # auto-binding 443 on the host fails (privileged) and the whole port
-    # forwarding setup silently breaks. Explicitly mapping 443 → an unused
-    # high port short-circuits the auto-bind and restores the 80 → host forward.
-    ports=[(25051, 80), (25053, 443)],     # 25053 is a placeholder for the 443 EXPOSE
+    ports=[(25051, 80)],
     env=lambda cfg: {
         "PGADMIN_DEFAULT_EMAIL": cfg.pgadmin_email,
         "PGADMIN_DEFAULT_PASSWORD": cfg.pgadmin_password,
@@ -281,11 +276,7 @@ SPEC_REGISTRY_UI = ServiceSpec(
     image="joxit/docker-registry-ui:main",
     cpus=1,
     memory_mib=256,            # 128 OOMs during nginx-alpine entrypoint init
-    # nginx-alpine image EXPOSEs 80 AND 443. Same SDK auto-bind trap as
-    # pgadmin — map both explicitly so 25052 -> 80 shim actually gets bound.
-    # (Earlier in 3b this appeared to work but the shim was leaked from a
-    # prior session; clean state reveals the bug.)
-    ports=[(25052, 80), (25054, 443)],
+    ports=[(25052, 80)],
     env=lambda cfg: {
         "REGISTRY_TITLE": "BoxLite local registry",
         "NGINX_PROXY_PASS_URL": f"http://{cfg.host_hub}:{cfg.registry_host_port}",
@@ -456,13 +447,10 @@ SPEC_CADDY = ServiceSpec(
     image="caddy:2-alpine",
     cpus=1,
     memory_mib=256,
-    # caddy:2-alpine EXPOSEs 80, 443, 2019. Map all three explicitly per the
-    # SDK auto-bind workaround (see SPEC_PGADMIN comment). 80/443 -> our
-    # non-priv host ports; 2019 (Caddy admin API) -> 12019.
     ports=[
         (28080, 80),
-        (28443, 443),
-        (12019, 2019),
+        (28443, 443),    # reserved for future `tls internal` (see README §TLS)
+        (12019, 2019),   # Caddy admin API — used by the healthcheck below
     ],
     entrypoint=["sh"],
     cmd=lambda cfg: ["-c", _CADDY_ENTRYPOINT_TEMPLATE.format(caddyfile=_caddyfile(cfg))],

--- a/apps/infra-local/scripts/_stack-common.sh
+++ b/apps/infra-local/scripts/_stack-common.sh
@@ -10,13 +10,27 @@ INFRA_LOCAL_DIR="$( cd "${SCRIPT_DIR}/.." && pwd )"
 APPS_DIR="$( cd "${INFRA_LOCAL_DIR}/.." && pwd )"
 REPO_ROOT="$( cd "${APPS_DIR}/.." && pwd )"
 
-LOGS_DIR="${INFRA_LOCAL_DIR}/.logs"
-mkdir -p "${LOGS_DIR}"
+# Repo-scoped state root — ALL generated local-stack artifacts live here
+# (gitignored):
+#   bin/             native runner + proxy binaries
+#   logs/            L2 process logs + pid files
+#   data/            L1 service volumes (pg / redis / minio / registry)
+#   boxlite/         SDK home for the L1 boxes (BOXLITE_HOME)
+#   boxlite-runner/  runner home for L3 user boxes (BOXLITE_HOME_DIR)
+APPS_LOCAL_DIR="${REPO_ROOT}/.apps-local"
 
-# Native binary locations (built by stack-build.sh, kept under /tmp because
-# they are large and platform-specific — not committed).
-RUNNER_BIN="${RUNNER_BIN:-/tmp/boxlite-runner}"
-PROXY_BIN="${PROXY_BIN:-/tmp/boxlite-proxy}"
+# Exported so the `boxlite` CLI (these scripts grep `boxlite ls` to inspect
+# L1 boxes) and the python orchestrator resolve the SAME home. The runner is
+# unaffected: stack-up.sh hands it its own sibling home via BOXLITE_HOME_DIR.
+export BOXLITE_HOME="${BOXLITE_HOME:-${APPS_LOCAL_DIR}/boxlite}"
+
+LOGS_DIR="${APPS_LOCAL_DIR}/logs"
+mkdir -p "${LOGS_DIR}" "${APPS_LOCAL_DIR}/bin"
+
+# Native binary locations (built by stack-build.sh; large and
+# platform-specific, kept out of git via the .apps-local ignore).
+RUNNER_BIN="${RUNNER_BIN:-${APPS_LOCAL_DIR}/bin/boxlite-runner}"
+PROXY_BIN="${PROXY_BIN:-${APPS_LOCAL_DIR}/bin/boxlite-proxy}"
 
 # Ports
 PORT_API=3001
@@ -103,7 +117,10 @@ wait_http() {
 }
 
 # Resolve the runner home directory (where its SQLite + boxes live).
-RUNNER_HOME="${BOXLITE_HOME_DIR:-${HOME}/.boxlite-runner}"
+# Defaults into the repo-scoped state root; BOXLITE_HOME_DIR still wins
+# so a user-pinned runner home stays respected (stack-up.sh forwards
+# this exact value to the runner process).
+RUNNER_HOME="${BOXLITE_HOME_DIR:-${APPS_LOCAL_DIR}/boxlite-runner}"
 
 # Library path the runner needs at startup (libboxlite.dylib for CGO).
 RUNNER_DYLIB_DIR="${REPO_ROOT}/sdks/go"

--- a/apps/infra-local/scripts/seed-init-data.sh
+++ b/apps/infra-local/scripts/seed-init-data.sh
@@ -9,15 +9,14 @@
 #                                      + organization_user + admin API key
 #   3. initialize{Internal,Backup,Transient}Registry
 #   4. initializeDefaultRunner       → 'local-m5' DB row (async)
-#   5. initializeDefaultSnapshot     → 'ubuntu:22.04' snapshot (depends
-#                                      on adminPersonalOrg existing)
+#   5. default runner registration   → runner row via heartbeat
 #
 # Each step has "skip if exists" guards. As long as the related tables
 # were truncated (`stack-reset` does this), the API re-seeds from scratch.
 #
 # This script's only job: ensure the API is running, restart it if a
 # stale state could have left auto-seed incomplete, and wait for the
-# default snapshot to reach 'active' (the long pole).
+# default runner to register (boxes can't schedule without one).
 #
 # Idempotent: re-running is safe.
 
@@ -46,14 +45,16 @@ verify_api_seeded() {
     return 1
   fi
   local has_admin_org
+  # The `personal` org column was dropped in the pre-launch schema squash
+  # (#736); the API now seeds a "Default Organization" owned by the admin.
   has_admin_org=$("${PSQL[@]}" -c "
     SELECT count(*) FROM organization
-    WHERE \"createdBy\" = 'boxlite-admin' AND personal = true;
+    WHERE \"createdBy\" = 'boxlite-admin';
   " || echo "0")
   if [ "$has_admin_org" -gt 0 ]; then
-    ok "admin personal org present"
+    ok "admin org present"
   else
-    warn "admin personal org missing — API initializeAdminUser may have failed"
+    warn "admin org missing — API initializeAdminUser may have failed"
     return 1
   fi
   local has_region
@@ -81,39 +82,22 @@ bounce_api_if_running() {
   fi
 }
 
-# Wait for the default snapshot's lifecycle to reach 'active'. The state
-# machine is pulling → ready → active and takes ~30-60s on a cold pull.
-wait_for_default_snapshot() {
-  local timeout=420   # Cold pull of ubuntu:22.04 from local registry can take 2-5min on M5
+# Verify the default runner registered (the API seeds it; boxes can't be
+# scheduled without one). Snapshots/templates no longer exist post-squash
+# (#736): boxes are created directly from images, so there is no pre-pull
+# phase to wait for anymore.
+wait_for_default_runner() {
+  local timeout=60
   local elapsed=0
-  log "waiting for default snapshot (ubuntu:22.04) to become active..."
+  log "waiting for the default runner to register..."
   while true; do
-    local state
-    state=$("${PSQL[@]}" -c "SELECT COALESCE(state::text, 'missing') FROM snapshot WHERE name='ubuntu:22.04';" 2>/dev/null || echo "missing")
-    [ -z "$state" ] && state="missing"
-    case "$state" in
-      active) ok "ubuntu:22.04 snapshot active"; return 0 ;;
-      missing)
-        if [ "$elapsed" -ge "$timeout" ]; then
-          warn "snapshot row never appeared after ${timeout}s — is the API running and authenticated?"
-          return 1
-        fi
-        ;;
-      pulling|pending|ready|building)
-        echo "  T+${elapsed}s: $state"
-        ;;
-      error|failed|inactive|deactivated)
-        err "snapshot reached terminal failure state: $state"
-        return 1
-        ;;
-      *)
-        echo "  T+${elapsed}s: $state (unknown)"
-        ;;
-    esac
-    sleep 5
-    elapsed=$((elapsed + 5))
+    local count
+    count=$("${PSQL[@]}" -c "SELECT count(*) FROM runner;" 2>/dev/null || echo "0")
+    [ "${count:-0}" -gt 0 ] && { ok "runner registered"; return 0; }
+    sleep 2
+    elapsed=$((elapsed + 2))
     if [ "$elapsed" -ge "$timeout" ]; then
-      warn "snapshot still '$state' after ${timeout}s — check runner logs"
+      warn "no runner row after ${timeout}s — check runner logs"
       return 1
     fi
   done
@@ -142,9 +126,9 @@ while ! verify_api_seeded 2>/dev/null; do
 done
 
 if [ "${1:-}" = "--no-wait" ] || [ "${2:-}" = "--no-wait" ]; then
-  log "skipping snapshot wait (--no-wait)"
+  log "skipping runner wait (--no-wait)"
 else
-  wait_for_default_snapshot || warn "default snapshot not ready — dashboard create-box will 400 until it is"
+  wait_for_default_runner || warn "runner not registered — box create will fail until it is"
 fi
 
 ok "init data ready"

--- a/apps/infra-local/scripts/stack-build.sh
+++ b/apps/infra-local/scripts/stack-build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Build the two native Go binaries that L2 needs:
-#   - /tmp/boxlite-runner  (apps/runner)
-#   - /tmp/boxlite-proxy   (apps/proxy)
+#   - .apps-local/bin/boxlite-runner  (apps/runner)
+#   - .apps-local/bin/boxlite-proxy   (apps/proxy)
 #
 # Also runs `yarn install` if node_modules is missing. Idempotent.
 

--- a/apps/infra-local/scripts/stack-reset.sh
+++ b/apps/infra-local/scripts/stack-reset.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Wipe L2 runtime state. Keeps L1 boxes alive (db schema preserved by default).
 #
-# Usage: stack-reset.sh             # clear boxes/snapshots, KEEP users+orgs
+# Usage: stack-reset.sh             # clear boxes/jobs/volumes, KEEP users+orgs
 #                                     → browser stays logged in, no re-login
 #        stack-reset.sh --hard      # wipe PG schema entirely (rebuilds it by
 #                                     re-running migrations) → identity gone, re-login needed
@@ -29,27 +29,27 @@ if [ "$MODE" = "soft" ]; then
     log "truncating runtime data (identity + infra rows preserved)..."
     # PRESERVE identity + infra so an already-logged-in browser session
     # stays valid across a reset (no forced re-login):
-    #   user, organization, organization_user, organization_role,
-    #   region, runner, api_key
+    #   user, organization + its FK children (organization_user, roles,
+    #   assignments, invitations), region, runner, api_key,
+    #   warm_pool (pool config, not runtime state)
     # CLEAR only runtime/user-created state:
-    #   box, snapshot, snapshot_runner, audit_log (+ CASCADE children
-    #   like ssh_access). The API re-seeds the default snapshot on next
-    #   boot (initializeDefaultSnapshot finds the preserved admin org),
-    #   and the runner re-registers via heartbeat (matched by apiKey).
+    #   box (+ CASCADE children box_last_activity, ssh_access), job,
+    #   volume, audit_log. The runner re-registers via heartbeat
+    #   (matched by apiKey).
     #
     # Why preserve user+org TOGETHER: a half-state (user kept, org dropped)
     # strands initializeAdminUser's early-exit guard. Keeping both keeps
     # the seed cycle consistent AND keeps OIDC sessions alive. For a true
     # from-scratch identity wipe use --hard.
     PGPASSWORD=boxlite psql -h 127.0.0.1 -p 25432 -U boxlite -d boxlite -v ON_ERROR_STOP=1 -c "
-      TRUNCATE TABLE box, snapshot, snapshot_runner, audit_log
+      TRUNCATE TABLE box, job, volume, audit_log
                      RESTART IDENTITY CASCADE;
     " 2>&1 | tail -2 || warn "truncate had errors (some tables may not exist on fresh schema)"
   else
     warn "PG not running — skipping data truncate"
   fi
   ok "soft reset complete (identity + L1 boxes + schema preserved — no browser re-login needed)"
-  log "next: \`make stack-up\` — API re-seeds default snapshot; runner re-registers"
+  log "next: \`make stack-up\` — runner re-registers via heartbeat"
 elif [ "$MODE" = "hard" ]; then
   if boxlite ls 2>/dev/null | grep -q boxlite-local-postgres; then
     log "wiping schema + rebuilding via migrations..."
@@ -64,7 +64,7 @@ elif [ "$MODE" = "hard" ]; then
   fi
   ok "hard reset complete (L1 boxes alive, schema rebuilt — identity wiped)"
   warn "browser must re-login: clear sessionStorage + localStorage, then sign in via dex"
-  log "next: \`make stack-up\` — API will auto-seed all base data + wait for default snapshot"
+  log "next: \`make stack-up\` — API will auto-seed all base data on boot"
 else
   log "nuking everything (L1 boxes + data + logs)..."
   ( cd "${INFRA_LOCAL_DIR}" && make wipe )

--- a/apps/infra-local/scripts/stack-up.sh
+++ b/apps/infra-local/scripts/stack-up.sh
@@ -2,7 +2,7 @@
 # Bring up the full L1+L2 local stack.
 #
 # Behaves like an "ensure-running" — components already alive are skipped.
-# All native processes go in background; logs to apps/infra-local/.logs/<comp>.log.
+# All native processes go in background; logs to <repo>/.apps-local/logs/<comp>.log.
 #
 # Order:
 #   1. L1 boxes (10) via `python -m boxlite_local up` (skipped if already up)
@@ -58,9 +58,9 @@ if [ "${L1_RECREATED}" = "true" ]; then
 fi
 
 # ---------- Binaries present? ----------
-# stack-up auto-builds missing binaries (e.g. /tmp cleared after a reboot).
-# It does NOT rebuild a binary that already exists — to pick up source
-# changes use `make stack-restart COMPONENTS=runner` (which rebuilds).
+# stack-up auto-builds missing binaries (fresh checkout, or .apps-local/bin
+# wiped). It does NOT rebuild a binary that already exists — to pick up
+# source changes use `make stack-restart COMPONENTS=runner` (which rebuilds).
 for bin in "${RUNNER_BIN}" "${PROXY_BIN}"; do
   if [ ! -x "${bin}" ]; then
     log "missing ${bin} — running stack-build.sh"
@@ -81,8 +81,6 @@ fi
 # ---------- Symlinks NestJS needs ----------
 # apps/.env → apps/api/.env (NestJS reads .env from cwd=apps/)
 [ -L "${APPS_DIR}/.env" ] || ln -sf api/.env "${APPS_DIR}/.env"
-# apps/apps → . (webpack.config.js path resolution quirk)
-[ -L "${APPS_DIR}/apps" ] || ln -sf . "${APPS_DIR}/apps"
 
 # ---------- Component starters ----------
 start_api() {
@@ -112,24 +110,14 @@ start_api() {
   #   - RUNNER_DISK_PENALTY_THRESHOLD=95        (prod default 75)
   # Set BEFORE sourcing apps/.env so anything explicitly set there still
   # wins (set -a + . ./.env exports .env values).
-  #
-  # The two buildTargetOptions keep apps/api/webpack.config.js unmodified:
-  #   - generatePackageJson=false: @nx/webpack's GeneratePackageJsonPlugin
-  #     crashes in this workspace (yarn4 + gitignored lockfile leaves npm
-  #     deps out of the project graph: "Cannot read properties of undefined
-  #     (reading 'data')").
-  #   - skipTypeChecking=true: ForkTsCheckerWebpackPlugin fails on a
-  #     pre-existing type-only @opentelemetry/otlp-exporter-base version
-  #     skew (the exporters work at runtime).
-  # Local serve invocation only — CI/prod builds keep both plugins.
+  # (generatePackageJson=false / skipTypeChecking=true now live in
+  # apps/api/project.json — no serve-time overrides needed.)
   ( cd "${APPS_DIR}" && \
     export RUNNER_AVAILABILITY_SCORE_THRESHOLD=5 \
            RUNNER_MEMORY_PENALTY_THRESHOLD=95 \
            RUNNER_DISK_PENALTY_THRESHOLD=95 && \
     set -a && . ./.env && set +a && \
     nohup corepack yarn nx serve api \
-      --buildTargetOptions.generatePackageJson=false \
-      --buildTargetOptions.skipTypeChecking=true \
       > "$(log_file api)" 2>&1 & \
     echo $! > "$(pid_file api)" )
   if wait_http "http://localhost:${PORT_API}/api/health" 180; then
@@ -240,13 +228,13 @@ done
 
 echo
 # If api + runner just started, ensure init data is in place + wait for
-# default snapshot. This is the chain dashboard needs to actually let a
-# user click "Create Box" successfully. Without it, the page works
-# but the first box-create call 400s ("Snapshot ubuntu:22.04 not
-# found"). Idempotent — skips work that's done.
+# the runner to register. This is the chain the dashboard needs to
+# schedule a box at all — without a registered runner the first
+# box-create 400s ("No available runners"). Idempotent — skips work
+# that's done.
 case " ${COMPONENTS[*]} " in
   *" api "*|*" runner "*)
-    log "ensuring init data + default snapshot..."
+    log "ensuring init data + registered runner..."
     # --no-bounce: api is already alive and we just woke it up;
     # restarting again would be wasteful.
     "${SCRIPT_DIR}/seed-init-data.sh" --no-bounce || warn "init-data seed reported issues — see output above"

--- a/apps/infra-local/tests/unit/test_config.py
+++ b/apps/infra-local/tests/unit/test_config.py
@@ -69,7 +69,9 @@ def test_defaults():
     assert cfg.pg_user == "boxlite"
     assert cfg.pg_password == "boxlite"
     assert cfg.pg_db == "boxlite"
-    assert cfg.data_dir == Path.home() / ".boxlite-local" / "data"
+    # All generated state lives under the repo-scoped .apps-local/ root.
+    assert cfg.data_dir == cfg.repo_root / ".apps-local" / "data"
+    assert cfg.boxlite_home == cfg.repo_root / ".apps-local" / "boxlite"
 
 
 def test_pg_url_uses_host_hub_and_port():
@@ -84,6 +86,7 @@ def test_load_picks_up_env_overrides(monkeypatch, tmp_path):
     monkeypatch.setenv("BOXLITE_PG_PASSWORD", "s3cret")
     monkeypatch.setenv("BOXLITE_PG_DB", "appdb")
     monkeypatch.setenv("BOXLITE_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("BOXLITE_HOME", str(tmp_path / "bx-home"))
 
     cfg = InfraConfig.load()
 
@@ -93,18 +96,22 @@ def test_load_picks_up_env_overrides(monkeypatch, tmp_path):
     assert cfg.pg_password == "s3cret"
     assert cfg.pg_db == "appdb"
     assert cfg.data_dir == tmp_path
+    assert cfg.boxlite_home == tmp_path / "bx-home"
 
 
 def test_load_expands_tilde_in_data_dir_env(monkeypatch):
-    # Docs tell users they can set BOXLITE_DATA_DIR=~/.boxlite-local/data.
+    # Users may set BOXLITE_DATA_DIR / BOXLITE_HOME with a leading ~.
     # Path("~/...") does NOT expand ~ on its own, so .load() must expanduser()
     # — otherwise a literal "~" dir gets created under the cwd.
-    monkeypatch.setenv("BOXLITE_DATA_DIR", "~/.boxlite-local/data")
+    monkeypatch.setenv("BOXLITE_DATA_DIR", "~/my-data")
+    monkeypatch.setenv("BOXLITE_HOME", "~/my-boxlite-home")
 
     cfg = InfraConfig.load()
 
     assert "~" not in str(cfg.data_dir)
-    assert cfg.data_dir == Path.home() / ".boxlite-local" / "data"
+    assert cfg.data_dir == Path.home() / "my-data"
+    assert "~" not in str(cfg.boxlite_home)
+    assert cfg.boxlite_home == Path.home() / "my-boxlite-home"
 
 
 def test_load_raises_clear_error_on_malformed_int_env(monkeypatch):
@@ -117,6 +124,7 @@ def test_load_falls_back_to_defaults_when_env_unset(monkeypatch):
     for var in (
         "BOXLITE_HOST_HUB", "BOXLITE_PG_HOST_PORT", "BOXLITE_PG_USER",
         "BOXLITE_PG_PASSWORD", "BOXLITE_PG_DB", "BOXLITE_DATA_DIR",
+        "BOXLITE_HOME",
     ):
         monkeypatch.delenv(var, raising=False)
 
@@ -124,7 +132,8 @@ def test_load_falls_back_to_defaults_when_env_unset(monkeypatch):
 
     assert cfg.host_hub == "host.boxlite.internal"
     assert cfg.pg_host_port == 25432
-    assert cfg.data_dir == Path.home() / ".boxlite-local" / "data"
+    assert cfg.data_dir == cfg.repo_root / ".apps-local" / "data"
+    assert cfg.boxlite_home == cfg.repo_root / ".apps-local" / "boxlite"
 
 
 def test_new_3a_defaults():
@@ -160,6 +169,22 @@ def test_repo_root_points_at_repo_with_pyproject_in_apps_infra_local():
     cfg = InfraConfig()
     assert (cfg.repo_root / "apps" / "infra-local" / "pyproject.toml").exists(), \
         f"_detect_repo_root returned wrong dir: {cfg.repo_root}"
+
+
+def test_repo_root_walk_is_not_fooled_by_apps_apps_symlink(tmp_path):
+    # Reproducer for the stray apps/.apps-local bug: stack-up creates an
+    # `apps/apps -> .` symlink (webpack quirk), which makes `apps/` itself
+    # contain a path matching apps/infra-local/pyproject.toml. The walk must
+    # skip symlinked `apps` components and return the real repo root.
+    from boxlite_local.config import find_repo_root_from
+
+    repo = tmp_path / "repo"
+    pkg = repo / "apps" / "infra-local" / "boxlite_local"
+    pkg.mkdir(parents=True)
+    (repo / "apps" / "infra-local" / "pyproject.toml").write_text("")
+    (repo / "apps" / "apps").symlink_to(".")
+
+    assert find_repo_root_from(pkg) == repo
 
 
 def test_load_raises_clear_error_on_malformed_redis_port_env(monkeypatch):

--- a/apps/infra-local/tests/unit/test_orchestrator.py
+++ b/apps/infra-local/tests/unit/test_orchestrator.py
@@ -153,3 +153,18 @@ def test_build_box_options_resolves_callable_cmd():
     opts = build_box_options(spec, cfg)
     # The cmd attribute on BoxOptions is a list[str] — assert resolution happened.
     assert opts.cmd == ["sh", "-c", "echo hub=custom.host"]
+
+
+# ─── ensure_home_env ─────────────────────────────────────────────────────
+
+def test_ensure_home_env_exports_config_home(monkeypatch, tmp_path):
+    """The SDK's default-runtime singleton captures BOXLITE_HOME at first
+    construction — ensure_home_env must export the config value verbatim."""
+    import os
+
+    from boxlite_local.orchestrator import ensure_home_env
+
+    monkeypatch.delenv("BOXLITE_HOME", raising=False)
+    cfg = InfraConfig(boxlite_home=tmp_path / "bx-home")
+    ensure_home_env(cfg)
+    assert os.environ["BOXLITE_HOME"] == str(tmp_path / "bx-home")


### PR DESCRIPTION
## What

Consolidates **all** generated `apps/infra-local` local-dev-stack state into one gitignored `<repo>/.apps-local/` directory, and modernizes the orchestrator/scripts/docs for the current (post-migration-squash) backend.

```
<repo>/.apps-local/
├── bin/             native runner + proxy binaries
├── logs/            L2 process logs + pid files
├── data/            L1 service volumes (pg / redis / minio / registry)
├── boxlite/         SDK home for the L1 boxes (BOXLITE_HOME)
└── boxlite-runner/  runner home for L3 user boxes (BOXLITE_HOME_DIR)
```

Deliberately **not** under `target/`, so a `cargo clean` can never delete a live Postgres volume.

## Why / details

- **Single state root.** Replaces the scattered `~/.boxlite`, `~/.boxlite-local/data`, `~/.boxlite-runner`, `/tmp/boxlite-{runner,proxy}`, `apps/infra-local/.logs/` layout with one discoverable, per-checkout-isolated dir. `BOXLITE_HOME` is exported before the first `Boxlite.default()` (the runtime singleton captures its home at construction); the runner home defaults to `.apps-local/boxlite-runner`.
- **Post-squash schema.** The snapshot/template subsystem was removed upstream, so `seed-init-data` now waits for a **registered runner** (not a default snapshot), and `stack-reset` truncates `box,job,volume,audit_log`.
- **Workaround cleanup.** Drops SDK workarounds upstream has fixed: the rootfs-chmod retry family, EXPOSE'd-port placeholder mappings, the `apps/apps` webpack symlink, and the nx `--buildTargetOptions` serve flags (now in `apps/api/project.json`).
- **Robustness.** Guards the repo-root walk against a legacy `apps/apps -> .` symlink (which would otherwise mis-root all state at `apps/.apps-local/`).
- **Docs.** README updated for box terminology, the `.apps-local` tree, an accurate **dex clock-skew** troubleshooting entry (the real cause of "Unauthorized after login" — long-running microVMs drift behind the host after sleep; *not* a stale session db), and a verified box-boot/image-rewrite limitation (`#755`/`#758` restored an image-keyed boot path; image resolution still carries `TODO(image-rewrite)`).

## Testing

- `tests/unit` 44/44 green (adds a repo-root symlink-guard test and an `ensure_home_env` export test, both exercising real project symbols).
- Full stack brought up end-to-end on this changeset: 10 L1 boxes + 4 L2 processes healthy, schema migrated, runner registered, dashboard OIDC login verified working (server-side `GET /api/organizations` → 200 with the auto-provisioned admin user).

## Scope

Touches only `apps/infra-local/` + `.gitignore` (15 files). No product/runtime code. The BoxSockets `sun_path` fix this work originally surfaced landed separately in #742.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated comprehensive local development setup guide with migration instructions for the new repository-scoped state directory structure
  * Revised connection documentation, local service configuration, and troubleshooting guidance

* **Chores**
  * Consolidated local generated state, binaries, and logs into a unified repository-scoped directory
  * Reconfigured local service port mappings and updated initialization verification to reflect current system behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->