### PR TITLE
chore(infra-local): drop dead DYLD/snapshot config + pin boxlite CLI …

### DIFF
--- a/apps/infra-local/Makefile
+++ b/apps/infra-local/Makefile
@@ -12,6 +12,11 @@ PY ?= python
 REPO_ROOT := $(abspath $(CURDIR)/../..)
 export BOXLITE_HOME ?= $(REPO_ROOT)/.apps-local/boxlite
 
+# Prefer a boxlite CLI built from THIS checkout over a stale global install
+# (an older PATH `boxlite` can fail to read this version's box-config rows).
+# Matches the resolver in scripts/_stack-common.sh.
+BOXLITE_CLI := $(firstword $(wildcard $(REPO_ROOT)/target/release/boxlite $(REPO_ROOT)/target/debug/boxlite) boxlite)
+
 .PHONY: help up down ps doctor logs wipe itest test install migrate e2e itest-all \
         stack-build stack-up stack-down stack-restart stack-status stack-logs stack-reset stack-reset-hard stack-nuke \
         seed-init-data stack-rebuild-l1-box
@@ -90,5 +95,5 @@ stack-nuke:            ## ABSOLUTE NUKE: L1 boxes destroyed + data wiped + logs 
 
 stack-rebuild-l1-box:  ## destroy + recreate one L1 box (BOX=dex|registry|...) — for stuck stateful services
 	@if [ -z "$(BOX)" ]; then echo "usage: make stack-rebuild-l1-box BOX=<name>"; echo "e.g. BOX=dex   when login returns stale tokens"; echo "e.g. BOX=registry  when image pulls hang"; exit 1; fi
-	boxlite rm boxlite-local-$(BOX) --force
+	$(BOXLITE_CLI) rm boxlite-local-$(BOX) --force
 	python -m boxlite_local up $(BOX)

--- a/apps/infra-local/configs/api.env
+++ b/apps/infra-local/configs/api.env
@@ -43,9 +43,6 @@ PUBLIC_OIDC_DOMAIN=http://localhost:25556/dex
 # Dashboard (Vite dev)
 DASHBOARD_URL=http://localhost:3000
 
-# Default snapshot for boxes
-DEFAULT_SNAPSHOT=ubuntu:22.04
-
 # MinIO S3 (infra-local: 29000, user/pass "minioadmin")
 S3_ENDPOINT=http://127.0.0.1:29000
 S3_REGION=us-east-1
@@ -95,8 +92,6 @@ ADMIN_MAX_CPU_PER_BOX=8
 ADMIN_MAX_MEMORY_PER_BOX=16
 ADMIN_MAX_DISK_PER_BOX=50
 ADMIN_VOLUME_QUOTA=100
-ADMIN_SNAPSHOT_QUOTA=100
-ADMIN_MAX_SNAPSHOT_SIZE=20
 
 # Admin API key (for internal admin endpoints)
 ADMIN_API_KEY=local-dev-admin-key

--- a/apps/infra-local/scripts/_stack-common.sh
+++ b/apps/infra-local/scripts/_stack-common.sh
@@ -122,5 +122,21 @@ wait_http() {
 # this exact value to the runner process).
 RUNNER_HOME="${BOXLITE_HOME_DIR:-${APPS_LOCAL_DIR}/boxlite-runner}"
 
-# Library path the runner needs at startup (libboxlite.dylib for CGO).
-RUNNER_DYLIB_DIR="${REPO_ROOT}/sdks/go"
+# Resolve the `boxlite` CLI these scripts use to inspect/manage L1 boxes.
+# Prefer a binary built from THIS checkout (release, then debug) over a
+# global PATH install: a stale global CLI can be an older version that
+# fails to read this version's box-config DB rows, which makes `boxlite ls`
+# silently report no L1 boxes (so stack-up wrongly "recreates" a live L1).
+# Falls back to PATH with a one-line heads-up; build a matched one via `make cli`.
+if [ -x "${REPO_ROOT}/target/release/boxlite" ]; then
+  BOXLITE_CLI="${REPO_ROOT}/target/release/boxlite"
+elif [ -x "${REPO_ROOT}/target/debug/boxlite" ]; then
+  BOXLITE_CLI="${REPO_ROOT}/target/debug/boxlite"
+else
+  BOXLITE_CLI="boxlite"
+  if command -v boxlite >/dev/null 2>&1; then
+    printf '%s⚠%s using PATH boxlite (%s); no repo build found — if make stack-* mis-detects L1 boxes, build a version-matched CLI with `make -C %s/../.. cli`\n' \
+      "${C_YELLOW:-}" "${C_RESET:-}" "$(command -v boxlite)" "${INFRA_LOCAL_DIR}" >&2
+  fi
+fi
+export BOXLITE_CLI

--- a/apps/infra-local/scripts/stack-reset.sh
+++ b/apps/infra-local/scripts/stack-reset.sh
@@ -25,7 +25,7 @@ log "wiping runner home: ${RUNNER_HOME}"
 rm -rf "${RUNNER_HOME}"/{db,boxes,images,rootfs,logs} 2>/dev/null || true
 
 if [ "$MODE" = "soft" ]; then
-  if boxlite ls 2>/dev/null | grep -q boxlite-local-postgres; then
+  if "${BOXLITE_CLI}" ls 2>/dev/null | grep -q boxlite-local-postgres; then
     log "truncating runtime data (identity + infra rows preserved)..."
     # PRESERVE identity + infra so an already-logged-in browser session
     # stays valid across a reset (no forced re-login):
@@ -51,7 +51,7 @@ if [ "$MODE" = "soft" ]; then
   ok "soft reset complete (identity + L1 boxes + schema preserved — no browser re-login needed)"
   log "next: \`make stack-up\` — runner re-registers via heartbeat"
 elif [ "$MODE" = "hard" ]; then
-  if boxlite ls 2>/dev/null | grep -q boxlite-local-postgres; then
+  if "${BOXLITE_CLI}" ls 2>/dev/null | grep -q boxlite-local-postgres; then
     log "wiping schema + rebuilding via migrations..."
     PGPASSWORD=boxlite psql -h 127.0.0.1 -p 25432 -U boxlite -d boxlite -c "
       DROP SCHEMA public CASCADE;

--- a/apps/infra-local/scripts/stack-status.sh
+++ b/apps/infra-local/scripts/stack-status.sh
@@ -8,10 +8,10 @@ set -euo pipefail
 EXIT_CODE=0
 
 echo "${C_BOLD}L1 — infra-local boxes${C_RESET}"
-if boxlite ls 2>/dev/null | grep -q boxlite-local-postgres; then
+if "${BOXLITE_CLI}" ls 2>/dev/null | grep -q boxlite-local-postgres; then
   # boxlite ls outputs a unicode-bordered table; pluck name + status by
   # filtering for our box-name pattern then awking by the │ delimiter.
-  boxlite ls 2>/dev/null \
+  "${BOXLITE_CLI}" ls 2>/dev/null \
     | grep boxlite-local- \
     | awk -F'│' '{
         # Trim leading/trailing whitespace on each field then print name + status

--- a/apps/infra-local/scripts/stack-up.sh
+++ b/apps/infra-local/scripts/stack-up.sh
@@ -36,7 +36,7 @@ fi
 
 # ---------- L1 boxes ----------
 L1_RECREATED=false
-if ! boxlite ls 2>/dev/null | grep -q boxlite-local-postgres; then
+if ! "${BOXLITE_CLI}" ls 2>/dev/null | grep -q boxlite-local-postgres; then
   log "L1 boxes not running — starting..."
   ( cd "${INFRA_LOCAL_DIR}" && make up )
   L1_RECREATED=true
@@ -146,7 +146,6 @@ start_runner() {
   BOXLITE_HOME_DIR="${RUNNER_HOME}" \
   INSECURE_REGISTRIES=127.0.0.1:25000 \
   AWS_REGION=us-east-1 \
-  DYLD_LIBRARY_PATH="${RUNNER_DYLIB_DIR}" \
   nohup "${RUNNER_BIN}" > "$(log_file runner)" 2>&1 &
   echo $! > "$(pid_file runner)"
   if wait_port "${PORT_RUNNER}" 60; then


### PR DESCRIPTION
…to repo build

Follow-up cleanup to #789.

- Remove the dead DYLD_LIBRARY_PATH/RUNNER_DYLIB_DIR vestige: the Go runner static-links sdks/go/libboxlite.a (there is no .dylib there), so the env var pointed at nothing loadable — `otool -L` on the runner shows no libboxlite.dylib dependency.
- Remove 3 api.env entries the API no longer reads (the snapshot/template subsystem was removed upstream): DEFAULT_SNAPSHOT, ADMIN_SNAPSHOT_QUOTA, ADMIN_MAX_SNAPSHOT_SIZE. Kept DEFAULT_RUNNER_PROXY_URL — still read at configuration.ts:169 (feeds the default-runner seed).
- Pin the boxlite CLI the scripts use to a repo build (target/release, then target/debug) over a global PATH install: a stale global CLI fails to read this version's box-config DB rows, making `boxlite ls` silently report no L1 boxes (so stack-up wrongly "recreates" a live L1). Resolver in _stack-common.sh + Makefile, routed through stack-up/stack-reset/stack-status; falls back to PATH with a stderr heads-up.

Tests: tests/unit 44/44; live stack-status lists all 10 L1 boxes via the repo CLI (0.9.5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated local development infrastructure to use locally-built CLI binary, preferring release and debug builds over system-installed versions
  * Removed snapshot-related configuration entries from local environment settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->