### PR TITLE
fix(infra): lock down service exposure, runner SG/IMDS, and API CORS

### DIFF
--- a/.github/workflows/build-runner-binary.yml
+++ b/.github/workflows/build-runner-binary.yml
@@ -108,12 +108,17 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           tar czf "boxlite-runner-v${VERSION}-linux-amd64.tar.gz" -C /tmp boxlite-runner
+          # Integrity manifest the runner's user-data verifies before installing
+          # the binary (apps/infra/sst.config.ts buildRunnerUserData).
+          sha256sum "boxlite-runner-v${VERSION}-linux-amd64.tar.gz" > "boxlite-runner-v${VERSION}-linux-amd64.tar.gz.sha256"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: runner-linux-amd64
-          path: boxlite-runner-v*-linux-amd64.tar.gz
+          path: |
+            boxlite-runner-v*-linux-amd64.tar.gz
+            boxlite-runner-v*-linux-amd64.tar.gz.sha256
           if-no-files-found: error
           retention-days: ${{ needs.config.outputs.artifact-retention-days }}
 
@@ -145,5 +150,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ steps.version.outputs.version }}
-          files: dist/boxlite-runner-v*.tar.gz
+          files: |
+            dist/boxlite-runner-v*.tar.gz
+            dist/boxlite-runner-v*.tar.gz.sha256
           fail_on_unmatched_files: true

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -50,8 +50,32 @@ async function bootstrap() {
   })
   app.useLogger(app.get(PinoLogger))
   app.flushLogs()
+  // Pin CORS to known first-party origins rather than reflecting any origin.
+  // With `credentials: true`, `origin: true` would let any site make
+  // credentialed cross-origin calls to the API. The dashboard SPA (served at
+  // DASHBOARD_URL) is the only legitimate cross-origin caller; CORS_ALLOWED_ORIGINS
+  // (comma-separated) adds extras (e.g. local dev). If nothing is configured we
+  // fall back to reflecting the origin and warn — so an unconfigured deployment
+  // is never silently broken, while configured stacks (SST sets DASHBOARD_URL)
+  // are locked down.
+  // Gather configured origins, trim them, drop unset/empty entries (the
+  // `is string` guard also narrows the array to string[]), then dedupe.
+  const allowedOrigins = [
+    process.env.DASHBOARD_URL,
+    process.env.APP_URL,
+    ...(process.env.CORS_ALLOWED_ORIGINS?.split(',') ?? []),
+  ]
+    .map((origin) => origin?.trim())
+    .filter((origin): origin is string => !!origin)
+  const uniqueAllowedOrigins = [...new Set(allowedOrigins)]
+  if (uniqueAllowedOrigins.length === 0) {
+    Logger.warn(
+      'CORS: no DASHBOARD_URL / APP_URL / CORS_ALLOWED_ORIGINS set; reflecting request origin. Set one to restrict cross-origin access.',
+      'Bootstrap',
+    )
+  }
   app.enableCors({
-    origin: true,
+    origin: uniqueAllowedOrigins.length > 0 ? uniqueAllowedOrigins : true,
     methods: 'GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS',
     credentials: true,
   })

--- a/apps/infra/.env.example
+++ b/apps/infra/.env.example
@@ -108,19 +108,7 @@ SSH_HOST_KEY_B64=
 # SSH_GATEWAY_API_KEY=
 # DEFAULT_RUNNER_API_KEY=
 
-# 5c. Internal registry credentials.
-# WARNING: these default to admin/password. CHANGE them for any shared or
-# production stack — the registry is reachable in-VPC.
-# TRANSIENT_REGISTRY_URL=
-# TRANSIENT_REGISTRY_ADMIN=admin
-# TRANSIENT_REGISTRY_PASSWORD=password
-# TRANSIENT_REGISTRY_PROJECT_ID=boxlite
-# INTERNAL_REGISTRY_URL=
-# INTERNAL_REGISTRY_ADMIN=admin
-# INTERNAL_REGISTRY_PASSWORD=password
-# INTERNAL_REGISTRY_PROJECT_ID=boxlite
-
-# 5d. Endpoints & URLs — auto-derived from STACK_DOMAIN; pin for custom DNS /
+# 5c. Endpoints & URLs — auto-derived from STACK_DOMAIN; pin for custom DNS /
 # topology.
 # PROXY_DOMAIN=proxy.dev.example.com
 # PROXY_PROTOCOL=https
@@ -131,11 +119,11 @@ SSH_HOST_KEY_B64=
 # DASHBOARD_BASE_API_URL=https://api.dev.example.com
 # APP_URL=
 
-# 5e. Default runner name (rarely changed). v2 runners self-report their
+# 5d. Default runner name (rarely changed). v2 runners self-report their
 # address, so there are no domain/url knobs to pin.
 # DEFAULT_RUNNER_NAME=default
 
-# 5f. Auth0 Management API (account linking).
+# 5e. Auth0 Management API (account linking).
 # Gated behind OIDC_MANAGEMENT_API_ENABLED — off by default. Create a
 # Machine-to-Machine application in Auth0, authorize it for the Auth0
 # Management API with permissions: read:users, update:users, read:connections,
@@ -145,7 +133,7 @@ SSH_HOST_KEY_B64=
 # OIDC_MANAGEMENT_API_CLIENT_SECRET=
 # OIDC_MANAGEMENT_API_AUDIENCE=https://your-tenant.auth0.com/api/v2/
 
-# 5g. OIDC logout overrides.
+# 5f. OIDC logout overrides.
 # OIDC_END_SESSION_ENDPOINT — RP-initiated logout fallback URL. Auto-derived to
 # `https://<STACK_DOMAIN>/api/auth/end-session`. The Api only advertises this to
 # the dashboard when the IdP itself lacks `end_session_endpoint`; for Auth0/Okta
@@ -157,7 +145,7 @@ SSH_HOST_KEY_B64=
 # [DASHBOARD_URL].
 # OIDC_POST_LOGOUT_REDIRECT_ALLOWLIST=https://staging.example.com,https://preview.example.com
 
-# 5h. Admin UI exposure — SECURITY-SENSITIVE. Defaults are safe: pgAdmin sits on
+# 5g. Admin UI exposure — SECURITY-SENSITIVE. Defaults are safe: pgAdmin sits on
 # an internal-only ALB (reach it via VPN / bastion / `aws ssm start-session`)
 # with the login screen enabled. PGADMIN_PUBLIC=true is gated in sst.config.ts —
 # it requires SERVER_MODE + MASTER_PASSWORD to stay True, so you cannot expose a
@@ -167,19 +155,29 @@ SSH_HOST_KEY_B64=
 #   PGADMIN_DEFAULT_PASSWORD=                # default: auto-generated
 #   PGADMIN_CONFIG_SERVER_MODE=True          # False disables the login screen (desktop mode)
 #   PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED=True
-# Future: JAEGER_PUBLIC / MAILDEV_PUBLIC / REGISTRYUI_PUBLIC toggles land here.
+# Jaeger (trace UI) and MailDev (mail catcher) are also internal-only by default
+# — both are unauthenticated and expose sensitive data (spans / captured emails).
+# Reach them the same way (VPN / bastion / SSM). Opt into an internet-facing ALB
+# only if you understand the exposure:
+#   JAEGER_PUBLIC=true                       # NOT recommended (no auth)
+#   MAILDEV_PUBLIC=true                      # NOT recommended (no auth)
+# The OtelCollector OTLP endpoint is internal-only with no toggle: every emitter
+# (API, runner, boxes) is in-VPC, so there is no reason to expose ingest.
 
-# 5i. Runtime defaults.
-# DEFAULT_SNAPSHOT=ubuntu:latest
+# 5h. API CORS allowlist. The API pins CORS to DASHBOARD_URL (+ APP_URL).
+# Set CORS_ALLOWED_ORIGINS (comma-separated) to permit additional first-party
+# origins (e.g. a local dashboard during development). If none of the three are
+# set the API reflects the request origin and logs a warning.
+# CORS_ALLOWED_ORIGINS=http://localhost:5173,https://preview.example.com
 
-# 5j. Analytics & feature flags (PostHog) — product analytics/metrics plus the
+# 5i. Analytics & feature flags (PostHog) — product analytics/metrics plus the
 # dashboard's feature flags. Without POSTHOG_API_KEY the DASHBOARD_CREATE_BOX
 # flag can't resolve, so the "Create Box" button stays disabled, and API
 # request metrics stop recording.
 # POSTHOG_API_KEY=
 # POSTHOG_HOST=https://us.posthog.com
 
-# 5k. Webhooks (Svix) — outbound event delivery (box/snapshot/volume events).
+# 5j. Webhooks (Svix) — outbound event delivery (box/snapshot/volume events).
 # Without SVIX_AUTH_TOKEN the dashboard logs cosmetic errors. SVIX_SERVER_URL
 # pins a self-hosted Svix instance (defaults to Svix cloud).
 # SVIX_AUTH_TOKEN=

--- a/apps/infra/NETWORKING.md
+++ b/apps/infra/NETWORKING.md
@@ -1,0 +1,108 @@
+# BoxLite infra — network model
+
+Why the VPC is laid out the way it is: who can reach what, how things reach the
+internet, and the reasoning (with AWS docs) behind the two different egress
+patterns. Defined in [`sst.config.ts`](./sst.config.ts) §2 PLATFORM + §10 RUNNER.
+
+## Layout (ap-southeast-1, 2 AZs)
+
+```
+                              ☁  INTERNET
+                   (users ↓)        (↑ ghcr.io, Auth0, ClickHouse, ECR…)
+                        │                         ▲
+                        ▼                         │
+        ╔═══════════════════════════════════════════════════╗
+        ║              INTERNET GATEWAY (IGW)                ║  one per VPC
+        ╚════╦═══════════════╦════════════════╦═════════════╝
+   inbound   │    egress     │                │   (runner egress, direct)
+             ▼               │                │
+   ┌──── AZ-a ───────────────┼────┐   ┌───────┼──── AZ-b ──────────┐
+   │ PUBLIC subnet           │    │   │       │  PUBLIC subnet      │
+   │  [ALB node]  [NAT-a]  [Runner+pubIP]     │  [ALB node] [NAT-b] │
+   │      │          ▲          (direct out)  │      │         ▲    │
+   │ ─────┼──────────┼───────  │    │   │ ─────┼─────────┼──────────│
+   │ PRIVATE subnet  │ egress  │    │   │ PRIVATE subnet │ egress   │
+   │      ▼          │ (local) │    │   │      ▼         │ (local)  │
+   │  [Api/Proxy]────┘         │    │   │  [Api/Proxy]───┘          │
+   │  [DB] [Redis]             │    │   │  (tasks)                  │
+   └──────────────────────────┘    │   └───────────────────────────┘
+```
+
+- **Public subnets:** internet-facing ALBs, the per-AZ NAT, and the EC2 runner.
+- **Private subnets:** Fargate service tasks (Api, Proxy, SshGateway, Otel,
+  Jaeger, MailDev, PgAdmin), Postgres, Redis. No public IPs.
+
+## Traffic flows
+
+| Flow | Path |
+|------|------|
+| User → API (ingress) | Internet → IGW → **ALB** (public) → Api task (private) |
+| Service → internet (egress) | task (private) → **NAT in its own AZ** → IGW → ghcr/Auth0/ClickHouse |
+| Runner → internet (egress) | runner (public IP) → IGW (**no NAT**) |
+| API → external, reply back | stateful return through the NAT (API initiated) |
+
+The NAT and ALB are asymmetric on purpose: the **ALB is the only inbound door**;
+the **NAT is egress-only**. The service hosts themselves are never directly
+addressable from the internet.
+
+## Two egress patterns (and why)
+
+Both let a host reach the internet *outbound-only* — because both NAT and
+security groups are **stateful** (return traffic for a flow you started is
+allowed). The difference is the failure mode.
+
+```
+ A — PRIVATE subnet + NAT            B — PUBLIC subnet + public IP + SG
+ (Api, Proxy, DB, Redis …)          (Runner — must be EC2 w/ direct egress)
+
+ no public IP, no inbound route      has a public IP + IGW route
+ → internet has NO PATH in           → internet HAS a path; the SG is the gate
+ → 2 layers (no-route + SG)          → 1 layer (SG only)
+ → FAIL-CLOSED: open the SG to        → FAIL-OPEN: one `0.0.0.0/0` inbound rule
+   0.0.0.0/0 and it's still unreachable  and it's exposed
+```
+
+- **Services use A.** Defense-in-depth for hosts holding user data + secrets.
+- **The runner uses B** by necessity (EC2, high-bandwidth image-pull egress).
+  Because the SG is its *entire* inbound control surface, it is pinned to
+  `:3003` from the VPC CIDR only → an **egress-only public IP**, nothing inbound
+  from the internet. See `RunnerSecurityGroup` in `sst.config.ts`.
+
+## Why two NAT instances
+
+One NAT (`t4g.nano`, fck-nat) **per AZ** — the VPC defaults to 2 AZs. Each
+private task egresses through the NAT **in its own AZ**:
+
+- **AZ fault isolation** — if AZ-a dies, AZ-b's tasks still egress via NAT-b. A
+  single shared NAT would strand the other AZ on an AZ outage.
+- **No cross-AZ data charge / latency** — local NAT means egress never crosses
+  the AZ boundary.
+
+Cost: ~$16/mo (2× t4g.nano + 2 public IPv4 + small EBS) — vs ~$86/mo for 2
+managed NAT Gateways. The lever to drop to one NAT is `az: 1` (single-AZ, no
+HA); not worth the destructive VPC change on a live stack.
+
+## AWS references (the claims above, verbatim)
+
+- **Security groups are stateful** → public-IP host *can* be outbound-only:
+  > "Security groups are stateful… if you send a request from an instance, the
+  > response traffic for that request is allowed to reach the instance
+  > regardless of the inbound security group rules."
+  — [Security groups](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-security-groups.html)
+- **Inbound is default-deny** (the SG is the only gate for a public host):
+  > "The only traffic that reaches the instance is the traffic allowed by the
+  > security group rules."
+  — same page. And the fail-open warning:
+  > "If you specify 0.0.0.0/0 … this enables anyone to access your instances from
+  > any IP address using the specified protocol."
+- **NAT is outbound-only:**
+  > "instances in a private subnet can connect to services outside your VPC but
+  > external services can't initiate a connection with those instances… Connections
+  > must always be initiated from within the VPC."
+  — [NAT gateways](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-nat-gateway.html)
+  (We use a NAT *instance* via fck-nat — same source-NAT + connection-tracking.)
+- **Private subnet = no route in** (fail-closed), and AWS's recommendation:
+  > "Private subnet – The subnet does not have a direct route to an internet
+  > gateway." … "we recommend that you use private subnets. Use a bastion host or
+  > NAT device to provide internet access."
+  — [Subnets](https://docs.aws.amazon.com/vpc/latest/userguide/configure-subnets.html)

--- a/apps/infra/README.md
+++ b/apps/infra/README.md
@@ -10,8 +10,8 @@ One-command deploy of the BoxLite control plane: ECS Fargate services, an
 EC2 runner with nested KVM, RDS Postgres, ElastiCache Redis, S3, CloudFront.
 
 - **Region:** `ap-southeast-1`
-- **IaC:** SST v3 (Pulumi under the hood)
-- **Cost at rest:** ~$500/month always-on (tear down with one command)
+- **IaC:** SST v4 (Pulumi under the hood)
+- **Cost at rest:** ~$570/month always-on — Runner + load balancers dominate (tear down with one command)
 
 ## Prerequisites
 
@@ -179,20 +179,18 @@ For Auth0 specifically:
 
 ## Service URLs
 
-| Service             | Purpose                              | Public hostname                              |
+| Service             | Purpose                              | Exposure                                     |
 |---------------------|--------------------------------------|----------------------------------------------|
-| **Dashboard SPA**   | Browser UI (static assets via CDN)   | `https://<STACK_DOMAIN>`                     |
-| **Api**             | REST API + WebSocket `/attach`       | `https://api.<STACK_DOMAIN>` (direct ALB)    |
-| **Proxy**           | `<port>-<id>.proxy.<domain>` previews | `https://*.proxy.<STACK_DOMAIN>` (direct ALB) |
-| **SshGateway**      | `ssh <token>@ssh.<domain>:2222`      | `ssh.<STACK_DOMAIN>:2222` (NLB, raw TCP)     |
-| **ArtifactRegistry** | S3-backed docker registry            | internal only                                |
-| **Jaeger**          | Trace viewer                         | public ALB                                   |
-| **OtelCollector**   | OTLP ingest                          | internal + public health                     |
+| **Dashboard SPA**   | Browser UI (static assets via CDN)   | `https://<STACK_DOMAIN>` (CloudFront)        |
+| **Api**             | REST API + WebSocket `/attach`       | `https://api.<STACK_DOMAIN>` (public ALB)    |
+| **Proxy**           | `<port>-<id>.proxy.<domain>` previews | `https://*.proxy.<STACK_DOMAIN>` (public ALB) |
+| **SshGateway**      | `ssh <token>@ssh.<domain>:2222`      | `ssh.<STACK_DOMAIN>:2222` (public NLB, raw TCP) |
+| **Jaeger**          | Trace viewer (no auth)               | internal ALB (set `JAEGER_PUBLIC=true` to expose) |
+| **OtelCollector**   | OTLP ingest + health                 | internal ALB (in-VPC emitters only)          |
+| **PgAdmin**         | Postgres admin UI                    | internal ALB (set `PGADMIN_PUBLIC=true` to expose) |
+| **MailDev**         | Mock SMTP + web UI (no auth)         | internal ALB (set `MAILDEV_PUBLIC=true` to expose) |
 | **ClickHouse Cloud** | Managed OTel storage                 | external service; configured by env         |
 | **ClickStack**      | Logs/traces/metrics explorer         | external ClickHouse Cloud UI                |
-| **PgAdmin**         | Postgres admin UI                    | internal ALB (set `PGADMIN_PUBLIC=true` to expose) |
-| **RegistryUI**      | Browse snapshot images               | public ALB                                   |
-| **MailDev**         | Mock SMTP + web UI                   | public ALB                                   |
 
 Run `npx sst deploy --stage dev` without changes to reprint all URLs. See
 [Public hostnames](#public-hostnames) below for the rationale behind the
@@ -288,17 +286,16 @@ follows that. Not yet implemented.
   ssh client ▶ SshGateway NLB ──▶ ssh-gateway ──▶ runner ──▶ box
                 ssh.<STACK_DOMAIN>:2222  (raw TCP, no TLS termination)
 
-                          ┌───────┬────────┬────────┬──────────┐
-                          │  RDS  │ Redis  │   S3   │ Snapshot │ ← Api links
-                          │  PG   │        │ bucket │ Manager  │
-                          └───────┴────────┴────────┴──────────┘
-                                                       ▲
-                                                       │ docker push
-  private VPC                                          │
-                          ┌───────────────────────────────┐
-                          │  EC2 c8i.2xlarge Runner       │
-                          │  (nested KVM, privileged)     │
-                          └───────────────────────────────┘
+                          ┌───────┬────────┬────────┐
+                          │  RDS  │ Redis  │   S3   │  Api → DB/Redis (linked);
+                          │  PG   │        │ bucket │  S3 via vended STS creds
+                          └───────┴────────┴────────┘
+  private VPC
+                          ┌────────────────────────────────┐
+                          │  EC2 c8i.2xlarge Runner        │
+                          │  (nested KVM; pulls box images  │
+                          │   from ghcr.io)                │
+                          └────────────────────────────────┘
 
 Auth: OIDC provider (Auth0/Okta/Keycloak/Dex/…) ← Api validates JWT via JWKS;
       /api/auth/end-session provides RP-initiated-logout fallback for IdPs
@@ -363,16 +360,18 @@ initial setup: `aws ecs update-service --force-new-deployment --service Proxy`.
 
 ## Cost (ap-southeast-1, always-on)
 
-| Resource                           | Monthly |
-|------------------------------------|---------|
-| EC2 c8i.2xlarge (Runner)           | ~$245   |
-| NAT EC2 instance                   | ~$5     |
-| 9x Fargate 0.25 vCPU / 0.5 GB     | ~$70    |
-| RDS `t4g.micro` Postgres           | ~$15    |
-| ElastiCache Redis                  | ~$15    |
-| ALBs (10x)                         | ~$160   |
-| CloudFront + S3 + CloudWatch Logs  | ~$20    |
-| **Total**                          | **~$530** |
+| Resource                              | Monthly |
+|---------------------------------------|---------|
+| EC2 c8i.2xlarge (Runner)              | ~$325   |
+| Load balancers (6 ALB + 1 NLB)        | ~$115   |
+| 7x Fargate 0.25 vCPU / 0.5 GB         | ~$65    |
+| 2x NAT EC2 (`t4g.nano`) + public IPv4 | ~$16    |
+| RDS `t4g.micro` Postgres              | ~$15    |
+| ElastiCache Redis                     | ~$15    |
+| CloudFront + S3 + CloudWatch Logs     | ~$20    |
+| **Total**                             | **~$570** |
 
-`npx sst remove --stage dev` tears it all down; S3 buckets and RDS snapshots
-are retained in production stage (`--stage production`) per SST's default.
+Figures are approximate (ap-southeast-1 on-demand). The **Runner and the load
+balancers dominate** — the NAT is ~$16, not a headline cost. `npx sst remove
+--stage dev` tears it all down; S3 buckets and RDS snapshots are retained in
+production stage (`--stage production`) per SST's default.

--- a/apps/infra/sst.config.ts
+++ b/apps/infra/sst.config.ts
@@ -14,7 +14,7 @@
 //   1. secrets (auto-generated)     6. API
 //   2. platform (VPC/DB/Redis/S3)   7. edge services (Proxy, SshGateway)
 //   3. IAM                          8. admin UIs (PgAdmin/MailDev)
-//   4. auth (Dex)                   9. CDN (CloudFront)
+//   4. auth (external OIDC)         9. CDN (CloudFront)
 //   5. observability               10. runner (EC2 + nested KVM)
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -25,7 +25,6 @@ const PORTS = {
   API: 3000,
   PROXY: 4000,
   SSH_GATEWAY: 2222,
-  DEX: 5556,
   RUNNER: 3003,
   JAEGER_UI: 16686,
   OTLP_HTTP: 4318,
@@ -38,7 +37,7 @@ const PORTS = {
 const IMAGES = {
   jaeger: 'jaegertracing/all-in-one:1.67.0',
   pgadmin: 'dpage/pgadmin4:9.2.0',
-  maildev: 'maildev/maildev:latest',
+  maildev: 'maildev/maildev:2.2.1',
 } as const
 
 // Runner EC2 sizing
@@ -94,8 +93,8 @@ export default $config({
         aws: { region: REGION, ...(process.env.AWS_PROFILE ? { profile: process.env.AWS_PROFILE } : {}) },
         cloudflare: '6.15.0',
         random: '4.16.6',
-        // MERGE-REVIEW: command provider grafted from main for multi-runner
-        // post-deploy registration (see RegisterExtraRunners in run()).
+        // command provider: multi-runner post-deploy registration
+        // (see RegisterExtraRunners in run()).
         command: '1.0.1',
       },
     }
@@ -152,11 +151,57 @@ export default $config({
     const pgAdminPassword = randomKey('PgAdminPassword', 24)
 
     // ─── 2. PLATFORM ─────────────────────────────────────────────────────────
-    const vpc = new sst.aws.Vpc('Vpc', { nat: 'ec2' })
+    // Network model + rationale (subnets / NAT / egress-only public IP, AWS citations): ./NETWORKING.md
+    // NAT instance (fck-nat, ~10× cheaper than a managed NAT Gateway). The Fargate
+    // services run in private subnets (see Cluster below) with no public IP, so they
+    // reach ECR, Docker Hub, the OIDC issuer, external ClickHouse, and AWS APIs
+    // through this NAT. EC2 runners stay in public subnets and egress via the
+    // Internet Gateway, not this NAT.
+    const vpc = new sst.aws.Vpc('Vpc', {
+      nat: 'ec2',
+      // Name the VPC-created NAT resources (SST defaults: generic "Vpc NAT
+      // Instance", unnamed EIP + SG). Name tags only — SST's own tags
+      // (e.g. sst:is-nat) and the SG ingress/egress are left untouched.
+      transform: {
+        // resourceName is SST's logical id ("VpcNatInstance1"/"…2"); its trailing
+        // digit is the per-AZ index. Resolve the instance's real AZ from its
+        // subnet so the tag reads e.g. boxlite-dev-nat-1-ap-southeast-1a.
+        natInstance: (args, _opts, resourceName) => {
+          const idx = resourceName.match(/\d+$/)?.[0] ?? ''
+          const az = aws.ec2.getSubnetOutput({ id: args.subnetId }).availabilityZone
+          args.tags = { ...args.tags, Name: $interpolate`${$app.name}-${$app.stage}-nat-${idx}-${az}` }
+        },
+        // EIP i pairs with NAT instance i; it has no subnet of its own, so the
+        // index alone is enough to keep the names aligned (…-nat-eip-1/2).
+        elasticIp: (args, _opts, resourceName) => {
+          const idx = resourceName.match(/\d+$/)?.[0] ?? ''
+          args.tags = { ...args.tags, Name: `${$app.name}-${$app.stage}-nat-eip-${idx}` }
+        },
+        // One security group is shared by both NAT instances → a single name.
+        natSecurityGroup: (args) => {
+          args.tags = { ...args.tags, Name: `${$app.name}-${$app.stage}-nat-sg` }
+        },
+      },
+    })
     const db = new sst.aws.Postgres('Database', { vpc, instance: 't4g.micro', storage: '20 GB' })
     const redis = new sst.aws.Redis('Cache', { vpc, cluster: false }) // NestJS uses SELECT (multi-DB)
     const storage = new sst.aws.Bucket('Storage')
-    const cluster = new sst.aws.Cluster('Cluster', { vpc, forceUpgrade: 'v2' })
+    // Services run in PRIVATE subnets. SST's Vpc component otherwise defaults Fargate
+    // tasks to public subnets with public IPs; passing the cluster a plain vpc object
+    // (SST's documented escape hatch) overrides that: containerSubnets = private (no
+    // public IP, egress via the NAT above), loadBalancerSubnets = public (ALBs stay
+    // internet-facing, fronted by Cloudflare).
+    const cluster = new sst.aws.Cluster('Cluster', {
+      forceUpgrade: 'v2',
+      vpc: {
+        id: vpc.id,
+        securityGroups: vpc.securityGroups,
+        containerSubnets: vpc.privateSubnets,
+        loadBalancerSubnets: vpc.publicSubnets,
+        cloudmapNamespaceId: vpc.nodes.cloudmapNamespace.id,
+        cloudmapNamespaceName: vpc.nodes.cloudmapNamespace.name,
+      },
+    })
 
     // ─── 3. IAM ──────────────────────────────────────────────────────────────
     // Box-storage credential vending. The Api's ECS task role assumes the
@@ -204,10 +249,15 @@ export default $config({
     // Created before Api so API, runner, host, and box can all emit OTLP to the
     // same Collector. ClickHouse is external/managed only; no in-cluster
     // ClickHouseSpike fallback is part of the target architecture.
+    // Internal ALB by default: the trace UI exposes every span (URLs, headers,
+    // IDs, SQL, error bodies) with no auth, and nothing outside the VPC needs
+    // to read it. Reach it via VPN / bastion / `aws ssm start-session`.
+    // JAEGER_PUBLIC=true opts into an internet-facing ALB.
+    const jaegerPublic = envOr('JAEGER_PUBLIC', 'false') === 'true'
     new sst.aws.Service('Jaeger', {
       cluster,
       image: IMAGES.jaeger,
-      loadBalancer: { rules: [{ listen: '80/http', forward: `${PORTS.JAEGER_UI}/http` }] },
+      loadBalancer: { public: jaegerPublic, rules: [{ listen: '80/http', forward: `${PORTS.JAEGER_UI}/http` }] },
       environment: { COLLECTOR_OTLP_ENABLED: 'true' },
     })
 
@@ -225,6 +275,12 @@ export default $config({
         `service::pipelines::logs::exporters=${collectorExporters}`,
       ],
       loadBalancer: {
+        // Internal only: every OTLP emitter (API, runner, boxes) is in-VPC. A
+        // public ingest endpoint would accept unauthenticated telemetry from
+        // anywhere (injection / DoS / cost) and forward it to ClickHouse + the
+        // API — there is no legitimate cross-internet producer. `.url` still
+        // resolves (internal ALB DNS), so the OTLP endpoint wiring is unchanged.
+        public: false,
         rules: [
           { listen: `${PORTS.OTLP_HTTP}/http`, forward: `${PORTS.OTLP_HTTP}/http` },
           { listen: '80/http', forward: `${PORTS.OTEL_HEALTH}/http` },
@@ -486,8 +542,8 @@ export default $config({
         // uploads bypass CloudFront (CF imposes a 10-min hard WS cap and a
         // 60s origin-read timeout that breaks streaming). Static SPA assets
         // (index.html + /assets/*) still serve through the CF Router at the
-        // root domain. CORS on the API is already `origin: true` so the
-        // cross-origin dashboard→API path works without further changes.
+        // root domain. The API pins CORS to DASHBOARD_URL (apps/api main.ts),
+        // so this cross-origin dashboard→API path is explicitly allowed.
         DASHBOARD_URL: envOr('DASHBOARD_URL', `https://${stackDomain}`),
         APP_URL: envOr('APP_URL', ''),
         DASHBOARD_BASE_API_URL: envOr('DASHBOARD_BASE_API_URL', `https://api.${stackDomain}`),
@@ -605,7 +661,7 @@ export default $config({
     )
 
     // ─── 8. ADMIN UIs ────────────────────────────────────────────────────────
-    // MERGE-REVIEW: pgAdmin security gate grafted from main. pgAdmin is a
+    // pgAdmin security gate. pgAdmin is a
     // Postgres admin console one hop from RDS. Knobs are overridable via env;
     // unset falls back to the secure default below (internal ALB + login
     // enabled). The two values are coupled, not independent: exposing it
@@ -643,10 +699,15 @@ export default $config({
       },
     })
 
+    // Internal ALB by default: MailDev is an unauthenticated mail catcher.
+    // Anything it captures (password resets, magic links, invites) would be
+    // world-readable on a public ALB. Reach it via VPN / bastion / SSM.
+    // MAILDEV_PUBLIC=true opts into an internet-facing ALB.
+    const maildevPublic = envOr('MAILDEV_PUBLIC', 'false') === 'true'
     new sst.aws.Service('MailDev', {
       cluster,
       image: IMAGES.maildev,
-      loadBalancer: { rules: [{ listen: '80/http', forward: `${PORTS.MAILDEV_UI}/http` }] },
+      loadBalancer: { public: maildevPublic, rules: [{ listen: '80/http', forward: `${PORTS.MAILDEV_UI}/http` }] },
     })
 
     // ─── 9. CDN ROUTES ───────────────────────────────────────────────────────
@@ -654,7 +715,8 @@ export default $config({
     router.route('/', api.url)
 
     // ─── 10. RUNNER (EC2 with nested KVM) ────────────────────────────────────
-    // Pulls runner image from ECR, runs privileged with /dev/kvm mounted.
+    // Boots an Ubuntu EC2 that runs the prebuilt runner binary (downloaded from
+    // GitHub Releases) under systemd, with nested KVM enabled for box VMs.
     const ubuntuAmi = aws.ec2.getAmi({
       mostRecent: true,
       owners: [RUNNER.ubuntuOwnerId],
@@ -696,6 +758,39 @@ export default $config({
       }),
     })
     const runnerInstanceProfile = new aws.iam.InstanceProfile('RunnerProfile', { role: runnerRole.name })
+
+    // Dedicated runner security group (least-privilege, explicit in IaC).
+    // Without it the runner falls back to the VPC's shared default SG, which
+    // allows ALL ports from the whole VPC CIDR. The runner multiplexes its
+    // control-plane API, box proxy, and (when enabled) ssh-gateway onto a single
+    // port (API_PORT = PORTS.RUNNER); box ports are served INSIDE the runner and
+    // never bound on the host NIC. So one inbound port — reachable only from
+    // inside the VPC — is the complete surface. Combined with the public-subnet
+    // placement (the runner egresses via the Internet Gateway, not the NAT that
+    // serves the private services), this yields an egress-only public IP:
+    // nothing on the internet can reach the runner.
+    const runnerSecurityGroup = new aws.ec2.SecurityGroup('RunnerSecurityGroup', {
+      vpcId: vpc.nodes.vpc.id,
+      description: 'BoxLite runner — inbound only on the runner API port from within the VPC',
+      ingress: [
+        {
+          protocol: 'tcp',
+          fromPort: PORTS.RUNNER,
+          toPort: PORTS.RUNNER,
+          cidrBlocks: [vpc.nodes.vpc.cidrBlock],
+          description: 'control-plane API + box proxy + ssh-gateway (multiplexed on the runner API port)',
+        },
+      ],
+      egress: [
+        {
+          protocol: '-1',
+          fromPort: 0,
+          toPort: 0,
+          cidrBlocks: ['0.0.0.0/0'],
+          description: 'image pulls (ghcr/github/aws), S3, Secrets Manager, OTLP, control-plane callbacks',
+        },
+      ],
+    })
 
     // ── Runner ghcr pull credential (private image access) ────────────────────
     // Runners pull box images straight from private ghcr.io (the self-hosted
@@ -755,10 +850,21 @@ export default $config({
       {
         ami: ubuntuAmi.then((a) => a.id),
         instanceType: RUNNER.instanceType,
+        // Public subnet + public IP is the runner's egress path: it leaves via
+        // the Internet Gateway (not the NAT, which serves the private services)
+        // for image pulls (ghcr/github), S3, Secrets Manager, and control-plane
+        // callbacks. RunnerSecurityGroup makes this an EGRESS-ONLY public IP:
+        // inbound is limited to the runner port from inside the VPC, so the
+        // internet can't reach it.
         subnetId: vpc.publicSubnets[0],
+        associatePublicIpAddress: true,
+        vpcSecurityGroupIds: [runnerSecurityGroup.id],
         iamInstanceProfile: runnerInstanceProfile.name,
         cpuOptions: { nestedVirtualization: 'enabled' },
-        associatePublicIpAddress: true,
+        // Enforce IMDSv2 + a 1-hop limit so a container escape or SSRF on this
+        // untrusted-code host can't read the instance-role creds (S3
+        // boxlite-volume-*, the ghcr token in Secrets Manager, SSM).
+        metadataOptions: { httpEndpoint: 'enabled', httpTokens: 'required', httpPutResponseHopLimit: 1 },
         userDataBase64: runnerUserData,
         rootBlockDevice: { volumeSize: RUNNER.rootDiskGB },
         tags: { Name: 'boxlite-runner' },
@@ -769,10 +875,8 @@ export default $config({
       },
     )
 
-    // MERGE-REVIEW: multi-runner provisioning grafted from main. Translated to
-    // our buildRunnerUserData({ apiUrl, token, otelEndpoint }) signature —
-    // main's registry.url arg was dropped with the self-hosted registry, so
-    // extra runners share the same OTel endpoint as the default runner.
+    // Multi-runner provisioning. Extra runners share the same OTel endpoint as
+    // the default runner.
     //
     // ── Extra runners (RUNNERS > 1) ──────────────────────────────────────────
     // The default runner above is auto-seeded by the API at boot via
@@ -792,10 +896,14 @@ export default $config({
         {
           ami: ubuntuAmi.then((a) => a.id),
           instanceType: RUNNER.instanceType,
+          // Egress-only public IP, same rationale as the default runner above:
+          // public subnet for IGW egress (no NAT), inbound locked by the SG.
           subnetId: vpc.publicSubnets[0],
+          associatePublicIpAddress: true,
+          vpcSecurityGroupIds: [runnerSecurityGroup.id],
           iamInstanceProfile: runnerInstanceProfile.name,
           cpuOptions: { nestedVirtualization: 'enabled' },
-          associatePublicIpAddress: true,
+          metadataOptions: { httpEndpoint: 'enabled', httpTokens: 'required', httpPutResponseHopLimit: 1 },
           userDataBase64: $resolve([api.url, apiKey.result, otelCollectorOtlpHttpUrl, ghcrSecret ? ghcrSecret.arn : '']).apply(
             ([apiUrl, token, otelEndpoint, ghcrSecretArn]) =>
               buildRunnerUserData({ apiUrl, token, otelEndpoint, ghcrSecretArn: ghcrSecretArn || undefined, ghcrUsername }),
@@ -897,6 +1005,9 @@ chmod +x /usr/local/bin/boxlite-runner-start.sh
 
   const script = `#!/bin/bash
 exec > /var/log/runner-setup.log 2>&1
+# Fail fast + loud: a half-finished bootstrap must not leave a runner that looks
+# up but silently skipped the binary download or its checksum verification.
+set -euo pipefail
 
 # Wait for dpkg locks
 while fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1; do sleep 5; done
@@ -911,8 +1022,23 @@ curl -fsSL "https://s3.amazonaws.com/mountpoint-s3-release/\${MOUNT_S3_VERSION}/
 apt-get install -y /tmp/mount-s3.deb
 rm -f /tmp/mount-s3.deb
 
-# Download prebuilt runner binary from GitHub Releases
-curl -fsSL "https://github.com/boxlite-ai/boxlite/releases/download/v${RUNNER_VERSION}/boxlite-runner-v${RUNNER_VERSION}-linux-amd64.tar.gz" | tar xz -C /usr/local/bin/
+# Download the prebuilt runner binary, then verify its SHA-256 against the
+# checksum published next to the release asset before installing (it runs as
+# root). Best-effort for backward compatibility: a release with no .sha256 asset
+# warns and proceeds; a present-but-mismatched checksum is fatal (fail-closed).
+RUNNER_BASE="https://github.com/boxlite-ai/boxlite/releases/download/v${RUNNER_VERSION}"
+RUNNER_TARBALL="boxlite-runner-v${RUNNER_VERSION}-linux-amd64.tar.gz"
+curl -fsSL "\${RUNNER_BASE}/\${RUNNER_TARBALL}" -o "/tmp/\${RUNNER_TARBALL}"
+if curl -fsSL "\${RUNNER_BASE}/\${RUNNER_TARBALL}.sha256" -o /tmp/runner.sha256; then
+  EXPECTED=\$(awk '{print \$1}' /tmp/runner.sha256)
+  ACTUAL=\$(sha256sum "/tmp/\${RUNNER_TARBALL}" | awk '{print \$1}')
+  [ "\$EXPECTED" = "\$ACTUAL" ] || { echo "FATAL: runner checksum mismatch (want \$EXPECTED got \$ACTUAL)" >&2; exit 1; }
+  echo "runner tarball checksum verified (\$ACTUAL)"
+else
+  echo "WARNING: no .sha256 published for v${RUNNER_VERSION}; installing without integrity verification" >&2
+fi
+tar -xzf "/tmp/\${RUNNER_TARBALL}" -C /usr/local/bin/
+rm -f "/tmp/\${RUNNER_TARBALL}" /tmp/runner.sha256
 chmod +x /usr/local/bin/boxlite-runner
 
 # Get host IP via IMDSv2


### PR DESCRIPTION
- make Jaeger, OtelCollector, and MailDev internal-only (were public, unauthenticated); JAEGER_PUBLIC/MAILDEV_PUBLIC opt-ins
- give the runner a dedicated least-privilege security group (inbound :3003 from the VPC only) instead of the shared VPC default SG, and enforce IMDSv2 + hop-limit 1
- pin API CORS to DASHBOARD_URL/APP_URL/CORS_ALLOWED_ORIGINS instead of reflecting any origin with credentials
- verify the runner binary SHA-256 on boot (fail-closed) and publish the checksum from the release workflow; set -euo pipefail in user-data
- name the NAT instances/EIPs/SG, pin maildev to 2.2.1, drop dead config (PORTS.DEX, registry creds, DEFAULT_SNAPSHOT, MERGE-REVIEW markers)
- refresh README to match current topology and cost; add NETWORKING.md (subnets/NAT/SG rationale with AWS citations)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Runner binary downloads now include SHA-256 checksum verification.

* **Security**
  * Updated CORS configuration to restrict API access to specific allowed origins.
  * Enhanced runner instance network isolation with dedicated security controls.
  * Enforced IMDSv2 for secure runner metadata access.

* **Documentation**
  * Added comprehensive VPC networking architecture guide.
  * Updated infrastructure cost estimates and service availability details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->