### PR TITLE
fix(infra): harden control-plane durability, deploy safety, config hygiene

### DIFF
--- a/apps/api/src/config/configuration.ts
+++ b/apps/api/src/config/configuration.ts
@@ -73,6 +73,10 @@ const configuration = {
   dashboardUrl: process.env.DASHBOARD_URL,
   // Default to empty string - dashboard will then hit '/api'
   dashboardBaseApiUrl: process.env.DASHBOARD_BASE_API_URL || '',
+  // Currently unconsumed (Daytona-port residue): nothing reads `systemSourceRegistry`.
+  // Box images are a fixed curated set of digest-pinned ghcr.io refs pulled directly by
+  // the runner (see box/constants/curated-images.constant.ts), not mirrored from a source
+  // registry. Kept as a reserved surface for a future per-org custom-image path.
   systemSourceRegistry: {
     name: process.env.BOXLITE_SYSTEM_SOURCE_REGISTRY_NAME || 'BoxLite System Source Registry',
     url: process.env.BOXLITE_SYSTEM_SOURCE_REGISTRY_URL,

--- a/apps/infra/.env.example
+++ b/apps/infra/.env.example
@@ -155,12 +155,12 @@ SSH_HOST_KEY_B64=
 #   PGADMIN_DEFAULT_PASSWORD=                # default: auto-generated
 #   PGADMIN_CONFIG_SERVER_MODE=True          # False disables the login screen (desktop mode)
 #   PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED=True
-# Jaeger (trace UI) and MailDev (mail catcher) are also internal-only by default
-# — both are unauthenticated and expose sensitive data (spans / captured emails).
-# Reach them the same way (VPN / bastion / SSM). Opt into an internet-facing ALB
-# only if you understand the exposure:
+# Jaeger (trace UI) is internal-only by default — unauthenticated and exposing
+# sensitive spans, so reach it via VPN / bastion / SSM. Opt into an internet-facing
+# ALB only if you understand the exposure:
 #   JAEGER_PUBLIC=true                       # NOT recommended (no auth)
-#   MAILDEV_PUBLIC=true                      # NOT recommended (no auth)
+# MailDev (mail catcher) is internal-only with NO public option: it has no built-in
+# auth, so MAILDEV_PUBLIC=true is rejected at deploy time (fail loud, not silent).
 # The OtelCollector OTLP endpoint is internal-only with no toggle: every emitter
 # (API, runner, boxes) is in-VPC, so there is no reason to expose ingest.
 
@@ -182,3 +182,69 @@ SSH_HOST_KEY_B64=
 # pins a self-hosted Svix instance (defaults to Svix cloud).
 # SVIX_AUTH_TOKEN=
 # SVIX_SERVER_URL=
+
+# 5k. Observability backend — ClickHouse (trace/metric/log storage). All [optional];
+# unset = the OtelCollector targets a disabled endpoint and the API's observability
+# reader stays dormant. Two independent paths: the collector WRITES, the API READS.
+#   Writer (OtelCollector → ClickHouse). CLICKHOUSE_EXPORTER_ENABLED=true makes the
+#   endpoint + password [required] (deploy throws otherwise). *_WRITER_* win over the
+#   unprefixed fallbacks, which win over CLICKHOUSE_OTEL_ENDPOINT.
+# CLICKHOUSE_EXPORTER_ENABLED=true
+# CLICKHOUSE_WRITER_ENDPOINT=https://your-clickhouse:8443   # or CLICKHOUSE_ENDPOINT / CLICKHOUSE_OTEL_ENDPOINT
+# CLICKHOUSE_WRITER_PASSWORD=                               # or CLICKHOUSE_PASSWORD
+# CLICKHOUSE_WRITER_USERNAME=default                        # or CLICKHOUSE_USERNAME
+# CLICKHOUSE_WRITER_DATABASE=otel                           # or CLICKHOUSE_DATABASE
+# CLICKHOUSE_CREATE_SCHEMA=false
+# CLICKHOUSE_COMPRESS=none
+#   Reader (API → ClickHouse, admin observability panel). Prefer a full URL; else
+#   host+port. *_READER_* win over the unprefixed fallbacks.
+# CLICKHOUSE_READER_URL=https://your-clickhouse:8443        # or CLICKHOUSE_URL
+# CLICKHOUSE_READER_HOST=your-clickhouse                    # or CLICKHOUSE_HOST (used when no URL)
+# CLICKHOUSE_READER_PORT=443                                # or CLICKHOUSE_PORT
+# CLICKHOUSE_READER_PROTOCOL=https                          # or CLICKHOUSE_PROTOCOL
+# CLICKHOUSE_READER_DATABASE=otel                           # or CLICKHOUSE_DATABASE
+# CLICKHOUSE_READER_USERNAME=default                        # or CLICKHOUSE_USERNAME
+# CLICKHOUSE_READER_PASSWORD=                               # or CLICKHOUSE_PASSWORD
+
+# 5l. Admin observability panel — sources surfaced in the dashboard's admin view.
+# All [optional] with defaults derived from the stack.
+#   CloudWatch (defaults to this region + the SST cluster log-group prefix):
+# ADMIN_OBSERVABILITY_CLOUDWATCH_REGION=ap-southeast-1
+# ADMIN_OBSERVABILITY_CLOUDWATCH_LOG_GROUPS=                # comma-separated; empty = prefix-discovered
+# ADMIN_OBSERVABILITY_CLOUDWATCH_LIMIT_PER_GROUP=25
+# ADMIN_OBSERVABILITY_CLOUDWATCH_MAX_LOG_GROUPS=20
+#   S3 (defaults to the stack's Storage bucket, this region):
+# ADMIN_OBSERVABILITY_S3_REGION=ap-southeast-1
+# ADMIN_OBSERVABILITY_S3_BUCKETS=                           # comma-separated; default = Storage bucket
+# ADMIN_OBSERVABILITY_S3_MAX_OBJECTS=25
+#   ClickStack (external HyperDX-style dashboard links; no defaults):
+# ADMIN_OBSERVABILITY_CLICKSTACK_URL=
+# ADMIN_OBSERVABILITY_CLICKSTACK_DASHBOARD_URL=
+# ADMIN_OBSERVABILITY_CLICKSTACK_LOG_SOURCE_ID=
+# ADMIN_OBSERVABILITY_CLICKSTACK_TRACE_SOURCE_ID=
+# ADMIN_OBSERVABILITY_CLICKSTACK_METRIC_SOURCE_ID=
+
+# 5m. OpenTelemetry export (API + boxes → collector). All [optional]; default to the
+# in-cluster OtelCollector wired automatically.
+# OTEL_ENABLED=true
+# OTEL_EXPORTER_OTLP_ENDPOINT=                              # default: in-cluster collector
+# OTEL_EXPORTER_OTLP_HEADERS=                               # e.g. authorization=Bearer xxx
+# OTEL_COLLECTOR_API_KEY=                                   # collector→API key; default: ADMIN_API_KEY
+
+# 5n. System box images. The live images are the three digest-pinned refs in
+# sst.config.ts (BOXLITE_SYSTEM_{BASE,PYTHON,NODE}_IMAGE), pulled from ghcr.io with the
+# runner's GHCR_TOKEN. The vars below are currently INERT — no code reads them (Daytona-
+# port residue, see apps/api configuration.ts); setting them has no effect. Documented
+# only as reserved names for a future source-registry path.
+# BOXLITE_SYSTEM_IMAGE_TAG=20260605-p0-r3
+# BOXLITE_SYSTEM_SOURCE_REGISTRY_URL=
+# BOXLITE_SYSTEM_SOURCE_REGISTRY_USERNAME=
+# BOXLITE_SYSTEM_SOURCE_REGISTRY_PASSWORD=
+# BOXLITE_SYSTEM_SOURCE_REGISTRY_PROJECT_ID=
+
+# 5o. Misc. All [optional].
+# DEFAULT_REGION_ID — region id the extra-runner registration targets (default "us").
+# DEFAULT_REGION_ID=us
+# BOXLITE_API_URL — API base URL the OtelCollector calls back (default
+# https://api.<STACK_DOMAIN>/api).
+# BOXLITE_API_URL=

--- a/apps/infra/README.md
+++ b/apps/infra/README.md
@@ -188,7 +188,7 @@ For Auth0 specifically:
 | **Jaeger**          | Trace viewer (no auth)               | internal ALB (set `JAEGER_PUBLIC=true` to expose) |
 | **OtelCollector**   | OTLP ingest + health                 | internal ALB (in-VPC emitters only)          |
 | **PgAdmin**         | Postgres admin UI                    | internal ALB (set `PGADMIN_PUBLIC=true` to expose) |
-| **MailDev**         | Mock SMTP + web UI (no auth)         | internal ALB (set `MAILDEV_PUBLIC=true` to expose) |
+| **MailDev**         | Mock SMTP + web UI (no auth)         | internal ALB only — no public option (`MAILDEV_PUBLIC=true` is rejected) |
 | **ClickHouse Cloud** | Managed OTel storage                 | external service; configured by env         |
 | **ClickStack**      | Logs/traces/metrics explorer         | external ClickHouse Cloud UI                |
 
@@ -231,9 +231,12 @@ scripts/deploy/runner-update-binary.sh           # latest from Cargo.toml
 scripts/deploy/runner-update-binary.sh 0.9.5     # explicit
 ```
 
-The script uses AWS SSM Run Command to stop the systemd unit, download the
-release tarball from GitHub Releases, swap `/usr/local/bin/boxlite-runner`,
-and restart. Box state under `/var/lib/boxlite` is untouched.
+The script uses AWS SSM Run Command to download the release tarball from
+GitHub Releases and verify its SHA-256 *before* stopping the systemd unit — so
+a failed or corrupt fetch never takes the runner down — then backs up the live
+binary, swaps `/usr/local/bin/boxlite-runner`, and restarts. If the new binary
+fails to come up, it performs a rollback to the backup. Box state under
+`/var/lib/boxlite` is untouched.
 
 ### Deliberate decommission (three-step ceremony)
 

--- a/apps/infra/scripts/register-runners.mjs
+++ b/apps/infra/scripts/register-runners.mjs
@@ -55,25 +55,44 @@ async function waitForApi() {
 }
 
 async function register({ name, apiKey }) {
-  const res = await fetch(`${base}/api/admin/runners`, {
-    method: 'POST',
-    headers: {
-      'content-type': 'application/json',
-      authorization: `Bearer ${ADMIN_API_KEY}`,
-    },
-    body: JSON.stringify({ name, apiKey, apiVersion: '2', regionId: REGION_ID }),
-  })
+  // 201 = created, 409 = already exists (idempotent). A 5xx or a network error is
+  // transient — the API passed /api/health but a single request can still blip — so
+  // retry with backoff before failing the deploy. A 4xx (bad payload / auth) is a real
+  // client error and fails immediately; no retry would help.
+  const maxAttempts = 4
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    let res
+    try {
+      res = await fetch(`${base}/api/admin/runners`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: `Bearer ${ADMIN_API_KEY}`,
+        },
+        body: JSON.stringify({ name, apiKey, apiVersion: '2', regionId: REGION_ID }),
+      })
+    } catch (err) {
+      if (attempt === maxAttempts) throw new Error(`register-runners: ${name} failed (network): ${err}`)
+      await sleep(attempt * 2000)
+      continue
+    }
 
-  if (res.status === 201) {
-    console.log(`register-runners: ${name} registered`)
-    return
+    if (res.status === 201) {
+      console.log(`register-runners: ${name} registered`)
+      return
+    }
+    if (res.status === 409) {
+      console.log(`register-runners: ${name} already registered`)
+      return
+    }
+    const body = await res.text().catch(() => '')
+    if (res.status >= 500 && attempt < maxAttempts) {
+      console.warn(`register-runners: ${name} attempt ${attempt} got ${res.status}; retrying`)
+      await sleep(attempt * 2000)
+      continue
+    }
+    throw new Error(`register-runners: ${name} failed (${res.status}): ${body}`)
   }
-  if (res.status === 409) {
-    console.log(`register-runners: ${name} already registered`)
-    return
-  }
-  const body = await res.text().catch(() => '')
-  throw new Error(`register-runners: ${name} failed (${res.status}): ${body}`)
 }
 
 await waitForApi()

--- a/apps/infra/sst.config.ts
+++ b/apps/infra/sst.config.ts
@@ -75,12 +75,19 @@ const requireOidcIssuer = () => {
   return v
 }
 
-// Runner endpoint overrides — use RUNNER_PRIVATE_IP shortcut when set.
+// Required env var, with the reason it's needed (for vars that become mandatory
+// only under a feature flag). Throws a clear error at deploy time instead of
+// silently shipping the TS non-null assertion's `undefined` into the container.
+const requireEnv = (key: string, why: string) => {
+  const v = process.env[key]
+  if (!v) throw new Error(`${key} is required ${why}`)
+  return v
+}
+
+// Runner endpoint default — localhost. v2 runners self-report their address via
+// healthcheck, so the DEFAULT_RUNNER_* override is rarely needed.
 const runnerEndpoint = (override: string, port: number, scheme: string) =>
-  envOr(
-    override,
-    process.env.RUNNER_PRIVATE_IP ? `${scheme}${process.env.RUNNER_PRIVATE_IP}:${port}` : `${scheme}localhost:${port}`,
-  )
+  envOr(override, `${scheme}localhost:${port}`)
 
 // ── app config ───────────────────────────────────────────────────────────────
 export default $config({
@@ -183,9 +190,35 @@ export default $config({
         },
       },
     })
-    const db = new sst.aws.Postgres('Database', { vpc, instance: 't4g.micro', storage: '20 GB' })
+    // Durable state survives accidental teardown the way the runner does (§10).
+    // `removal: 'retain'` (above) already keeps prod resources on `sst remove`, but it
+    // does NOT stop a targeted destroy, a replace-on-immutable-change, or an AWS-console
+    // delete — so production also gets RDS deletion-protection + a final snapshot.
+    // S3 versioning is on in every stage: cheap, and the only guard against an
+    // object-level overwrite/delete (which `removal` never covers). Redis is a
+    // transient cache, so it needs neither.
+    const isProd = $app.stage === 'production'
+    // Unique-but-stable suffix for the DB final snapshot: a fixed name would collide
+    // with the snapshot a prior teardown of the same stage already created (RDS requires
+    // unique final-snapshot ids). RandomId is stable across deploys (no drift) and is
+    // regenerated on a full recreate, so each incarnation gets a distinct snapshot name.
+    const dbFinalSnapshotId = isProd ? new random.RandomId('DbFinalSnapshotSuffix', { byteLength: 4 }) : undefined
+    const db = new sst.aws.Postgres('Database', {
+      vpc,
+      instance: 't4g.micro',
+      storage: '20 GB',
+      transform: {
+        instance: (args) => {
+          args.deletionProtection = isProd
+          args.skipFinalSnapshot = !isProd
+          if (dbFinalSnapshotId) {
+            args.finalSnapshotIdentifier = $interpolate`${$app.name}-${$app.stage}-db-final-${dbFinalSnapshotId.hex}`
+          }
+        },
+      },
+    })
     const redis = new sst.aws.Redis('Cache', { vpc, cluster: false }) // NestJS uses SELECT (multi-DB)
-    const storage = new sst.aws.Bucket('Storage')
+    const storage = new sst.aws.Bucket('Storage', { versioning: true })
     // Services run in PRIVATE subnets. SST's Vpc component otherwise defaults Fargate
     // tasks to public subnets with public IPs; passing the cluster a plain vpc object
     // (SST's documented escape hatch) overrides that: containerSubnets = private (no
@@ -201,6 +234,17 @@ export default $config({
         cloudmapNamespaceId: vpc.nodes.cloudmapNamespace.id,
         cloudmapNamespaceName: vpc.nodes.cloudmapNamespace.name,
       },
+    })
+
+    // Keep S3 traffic off the NAT: a Gateway VPC endpoint sends the private subnets'
+    // S3 calls (box-volume objects + ECR layer blobs, which are stored in S3) straight
+    // to S3 over the AWS backbone. It's free, and now that every service is private it
+    // removes the single largest by-volume consumer of fck-nat egress.
+    new aws.ec2.VpcEndpoint('S3Gateway', {
+      vpcId: vpc.nodes.vpc.id,
+      serviceName: `com.amazonaws.${REGION}.s3`,
+      vpcEndpointType: 'Gateway',
+      routeTableIds: vpc.nodes.privateRouteTables.apply((tables) => tables.map((t) => t.id)),
     })
 
     // ─── 3. IAM ──────────────────────────────────────────────────────────────
@@ -318,6 +362,10 @@ export default $config({
       loadBalancer: {
         domain: serviceDomain('api'),
         rules: [{ listen: '443/https', forward: `${PORTS.API}/http` }],
+        // Probe the NestJS health route explicitly. The ALB default ('/') doesn't
+        // match the API (globally mounted under /api), so a default probe would fail
+        // healthy tasks; /api/health is the same endpoint register-runners.mjs polls.
+        health: { [`${PORTS.API}/http`]: httpHealth('/api/health') },
       },
       // AWS ALB default idle_timeout is 60s; per AWS docs (HTTP 408 troubleshooting),
       // raise to match expected WebSocket session length so SDK exec attaches survive
@@ -392,6 +440,11 @@ export default $config({
         VERSION: '0.1.0',
         DEFAULT_REGION_ENFORCE_QUOTAS: 'false',
         DEFAULT_TEMPLATE: envOr('DEFAULT_TEMPLATE', 'boxlite/base'),
+        // Box base images: only the three digest-pinned *_IMAGE refs below are live — the
+        // API gates box creation to that curated set (apps/api curated-images.constant.ts)
+        // and the runner pulls them straight from ghcr.io with its GHCR_TOKEN. IMAGE_TAG and
+        // the SOURCE_REGISTRY_* block are inert Daytona-port residue (no consumer — see
+        // apps/api configuration.ts), kept only as reserved names for a future registry path.
         BOXLITE_SYSTEM_IMAGE_TAG: envOr('BOXLITE_SYSTEM_IMAGE_TAG', '20260605-p0-r3'),
         BOXLITE_SYSTEM_BASE_IMAGE: envOr(
           'BOXLITE_SYSTEM_BASE_IMAGE',
@@ -443,9 +496,9 @@ export default $config({
         // Optional: Auth0 Management API (enables account linking etc.)
         ...(process.env.OIDC_MANAGEMENT_API_ENABLED === 'true' && {
           OIDC_MANAGEMENT_API_ENABLED: 'true',
-          OIDC_MANAGEMENT_API_CLIENT_ID: process.env.OIDC_MANAGEMENT_API_CLIENT_ID!,
-          OIDC_MANAGEMENT_API_CLIENT_SECRET: process.env.OIDC_MANAGEMENT_API_CLIENT_SECRET!,
-          OIDC_MANAGEMENT_API_AUDIENCE: process.env.OIDC_MANAGEMENT_API_AUDIENCE!,
+          OIDC_MANAGEMENT_API_CLIENT_ID: requireEnv('OIDC_MANAGEMENT_API_CLIENT_ID', 'when OIDC_MANAGEMENT_API_ENABLED=true'),
+          OIDC_MANAGEMENT_API_CLIENT_SECRET: requireEnv('OIDC_MANAGEMENT_API_CLIENT_SECRET', 'when OIDC_MANAGEMENT_API_ENABLED=true'),
+          OIDC_MANAGEMENT_API_AUDIENCE: requireEnv('OIDC_MANAGEMENT_API_AUDIENCE', 'when OIDC_MANAGEMENT_API_ENABLED=true'),
         }),
         // RP-initiated logout fallback. Safe to set unconditionally: the API
         // probes the IdP's discovery doc at startup and only exposes this URL
@@ -548,7 +601,7 @@ export default $config({
         APP_URL: envOr('APP_URL', ''),
         DASHBOARD_BASE_API_URL: envOr('DASHBOARD_BASE_API_URL', `https://api.${stackDomain}`),
 
-        // Default runner — wire via RUNNER_PRIVATE_IP after the first deploy
+        // Default runner — the API auto-seeds it at boot; v2 runners self-report
         DEFAULT_RUNNER_NAME: envOr('DEFAULT_RUNNER_NAME', 'default'),
         DEFAULT_RUNNER_API_KEY: envOr('DEFAULT_RUNNER_API_KEY', defaultRunnerApiKey.result),
         DEFAULT_RUNNER_DOMAIN: runnerEndpoint('DEFAULT_RUNNER_DOMAIN', PORTS.RUNNER, ''),
@@ -699,15 +752,21 @@ export default $config({
       },
     })
 
-    // Internal ALB by default: MailDev is an unauthenticated mail catcher.
-    // Anything it captures (password resets, magic links, invites) would be
-    // world-readable on a public ALB. Reach it via VPN / bastion / SSM.
-    // MAILDEV_PUBLIC=true opts into an internet-facing ALB.
-    const maildevPublic = envOr('MAILDEV_PUBLIC', 'false') === 'true'
+    // MailDev is an unauthenticated mail catcher with no first-class web auth, so it
+    // is VPC-internal only — reach it via VPN / bastion / `aws ssm start-session`.
+    // Anything it captures (password resets, magic links, invites) would otherwise be
+    // world-readable. MAILDEV_PUBLIC is rejected (fail loud) rather than silently
+    // honored: unlike pgAdmin there is no auth gate that would make public exposure safe.
+    if (envOr('MAILDEV_PUBLIC', 'false') === 'true') {
+      throw new Error(
+        'MAILDEV_PUBLIC is not supported: MailDev has no built-in auth, so it cannot be ' +
+          'safely exposed to the internet. Reach it via VPN / bastion / `aws ssm start-session`.',
+      )
+    }
     new sst.aws.Service('MailDev', {
       cluster,
       image: IMAGES.maildev,
-      loadBalancer: { public: maildevPublic, rules: [{ listen: '80/http', forward: `${PORTS.MAILDEV_UI}/http` }] },
+      loadBalancer: { public: false, rules: [{ listen: '80/http', forward: `${PORTS.MAILDEV_UI}/http` }] },
     })
 
     // ─── 9. CDN ROUTES ───────────────────────────────────────────────────────
@@ -804,7 +863,9 @@ export default $config({
     const ghcrToken = process.env.GHCR_TOKEN?.trim() || ''
     const ghcrSecret =
       ghcrUsername && ghcrToken
-        ? new aws.secretsmanager.Secret('GhcrPullToken', { recoveryWindowInDays: 0 })
+        ? // 7-day recovery window: an accidental delete during rotation is undoable
+          // (vs 0 = immediate, irreversible — which would break all runner image pulls).
+          new aws.secretsmanager.Secret('GhcrPullToken', { recoveryWindowInDays: 7 })
         : undefined
     if (ghcrSecret) {
       new aws.secretsmanager.SecretVersion('GhcrPullTokenValue', {
@@ -831,49 +892,47 @@ export default $config({
       buildRunnerUserData({ apiUrl, token, otelEndpoint, ghcrSecretArn: ghcrSecretArn || undefined, ghcrUsername }),
     )
 
-    // Runner holds load-bearing box state (/var/lib/boxlite + in-memory
-    // libkrun VMs). Two Pulumi resource options keep it persistent across
-    // routine deploys:
-    //
-    //   ignoreChanges: drift in `ami` (Ubuntu publishes new AMIs monthly)
-    //   and `userDataBase64` (Cargo.toml version bumps rewrite the embedded
-    //   RUNNER_VERSION) no longer triggers replacement. The new runner
-    //   binary lands via `scripts/deploy/runner-update-binary.sh` (SSM Run
-    //   Command) instead of by recreating the EC2.
-    //
-    //   protect: refuses any deletion attempt, including an errant
-    //   `pulumi destroy` or stack-wide teardown. Deliberate decommission
-    //   requires editing this file to `protect: false`, deploying that
-    //   change, then `pulumi destroy --target ...Runner`.
-    new aws.ec2.Instance(
-      'Runner',
-      {
-        ami: ubuntuAmi.then((a) => a.id),
-        instanceType: RUNNER.instanceType,
-        // Public subnet + public IP is the runner's egress path: it leaves via
-        // the Internet Gateway (not the NAT, which serves the private services)
-        // for image pulls (ghcr/github), S3, Secrets Manager, and control-plane
-        // callbacks. RunnerSecurityGroup makes this an EGRESS-ONLY public IP:
-        // inbound is limited to the runner port from inside the VPC, so the
-        // internet can't reach it.
-        subnetId: vpc.publicSubnets[0],
-        associatePublicIpAddress: true,
-        vpcSecurityGroupIds: [runnerSecurityGroup.id],
-        iamInstanceProfile: runnerInstanceProfile.name,
-        cpuOptions: { nestedVirtualization: 'enabled' },
-        // Enforce IMDSv2 + a 1-hop limit so a container escape or SSRF on this
-        // untrusted-code host can't read the instance-role creds (S3
-        // boxlite-volume-*, the ghcr token in Secrets Manager, SSM).
-        metadataOptions: { httpEndpoint: 'enabled', httpTokens: 'required', httpPutResponseHopLimit: 1 },
-        userDataBase64: runnerUserData,
-        rootBlockDevice: { volumeSize: RUNNER.rootDiskGB },
-        tags: { Name: 'boxlite-runner' },
-      },
-      {
-        ignoreChanges: ['ami', 'userDataBase64'],
-        protect: true,
-      },
-    )
+    // Runners hold load-bearing box state (/var/lib/boxlite + in-memory libkrun VMs).
+    // The default runner and every extra runner are identical except for resource
+    // name, Name tag, and per-runner user-data, so they share one factory. Two Pulumi
+    // options keep a runner persistent across routine deploys:
+    //   • ignoreChanges ['ami','userDataBase64']: monthly Ubuntu AMIs and Cargo.toml
+    //     version bumps no longer force replacement; a new binary lands out-of-band via
+    //     SSM instead of recreating the EC2 — scripts/deploy/runner-update-binary.sh
+    //     upgrades the DEFAULT runner (matches its tag only); extra runners separately.
+    //   • protect: refuses any delete (errant `pulumi destroy` / teardown). Deliberate
+    //     decommission = set protect:false, deploy, then `pulumi destroy --target ...`.
+    const makeRunner = (resourceName: string, nameTag: string, userData: $util.Input<string>) =>
+      new aws.ec2.Instance(
+        resourceName,
+        {
+          ami: ubuntuAmi.then((a) => a.id),
+          instanceType: RUNNER.instanceType,
+          // Egress-only public IP: public subnet → Internet Gateway (not the NAT that
+          // serves the private services) for image pulls (ghcr/github), S3, Secrets
+          // Manager, and control-plane callbacks. Inbound is locked to the runner port
+          // from inside the VPC by RunnerSecurityGroup, so the internet can't reach it.
+          subnetId: vpc.publicSubnets[0],
+          associatePublicIpAddress: true,
+          vpcSecurityGroupIds: [runnerSecurityGroup.id],
+          iamInstanceProfile: runnerInstanceProfile.name,
+          cpuOptions: { nestedVirtualization: 'enabled' },
+          // Enforce IMDSv2 + a 1-hop limit so a container escape or SSRF on this
+          // untrusted-code host can't read the instance-role creds (S3
+          // boxlite-volume-*, the ghcr token in Secrets Manager, SSM).
+          metadataOptions: { httpEndpoint: 'enabled', httpTokens: 'required', httpPutResponseHopLimit: 1 },
+          userDataBase64: userData,
+          rootBlockDevice: { volumeSize: RUNNER.rootDiskGB },
+          tags: { Name: nameTag },
+        },
+        {
+          ignoreChanges: ['ami', 'userDataBase64'],
+          protect: true,
+        },
+      )
+
+    // Default runner — auto-seeded by the API at boot via DEFAULT_RUNNER_*.
+    makeRunner('Runner', 'boxlite-runner', runnerUserData)
 
     // Multi-runner provisioning. Extra runners share the same OTel endpoint as
     // the default runner.
@@ -891,30 +950,13 @@ export default $config({
     const extraRunners = Array.from({ length: totalRunners - 1 }, (_, i) => {
       const name = `runner-${i + 2}` // default is runner #1
       const apiKey = randomKey(`RunnerApiKey-${name}`)
-      const instance = new aws.ec2.Instance(
+      const instance = makeRunner(
         `Runner-${name}`,
-        {
-          ami: ubuntuAmi.then((a) => a.id),
-          instanceType: RUNNER.instanceType,
-          // Egress-only public IP, same rationale as the default runner above:
-          // public subnet for IGW egress (no NAT), inbound locked by the SG.
-          subnetId: vpc.publicSubnets[0],
-          associatePublicIpAddress: true,
-          vpcSecurityGroupIds: [runnerSecurityGroup.id],
-          iamInstanceProfile: runnerInstanceProfile.name,
-          cpuOptions: { nestedVirtualization: 'enabled' },
-          metadataOptions: { httpEndpoint: 'enabled', httpTokens: 'required', httpPutResponseHopLimit: 1 },
-          userDataBase64: $resolve([api.url, apiKey.result, otelCollectorOtlpHttpUrl, ghcrSecret ? ghcrSecret.arn : '']).apply(
-            ([apiUrl, token, otelEndpoint, ghcrSecretArn]) =>
-              buildRunnerUserData({ apiUrl, token, otelEndpoint, ghcrSecretArn: ghcrSecretArn || undefined, ghcrUsername }),
-          ),
-          rootBlockDevice: { volumeSize: RUNNER.rootDiskGB },
-          tags: { Name: `boxlite-runner-${name}` },
-        },
-        {
-          ignoreChanges: ['ami', 'userDataBase64'],
-          protect: true,
-        },
+        `boxlite-runner-${name}`,
+        $resolve([api.url, apiKey.result, otelCollectorOtlpHttpUrl, ghcrSecret ? ghcrSecret.arn : '']).apply(
+          ([apiUrl, token, otelEndpoint, ghcrSecretArn]) =>
+            buildRunnerUserData({ apiUrl, token, otelEndpoint, ghcrSecretArn: ghcrSecretArn || undefined, ghcrUsername }),
+        ),
       )
       return { name, apiKey, instance }
     })
@@ -959,9 +1001,12 @@ async function buildRunnerUserData(input: {
   const { resolve } = await import('path')
 
   // SST invokes from apps/infra/ as cwd; Cargo.toml lives at repo root.
-  const RUNNER_VERSION = readFileSync(resolve(process.cwd(), '../../Cargo.toml'), 'utf-8').match(
-    /^version\s*=\s*"(.+?)"/m,
-  )![1]
+  const cargoToml = readFileSync(resolve(process.cwd(), '../../Cargo.toml'), 'utf-8')
+  const versionMatch = cargoToml.match(/^version\s*=\s*"(.+?)"/m)
+  if (!versionMatch) {
+    throw new Error('could not parse runner version from ../../Cargo.toml (expected a top-level `version = "X.Y.Z"`)')
+  }
+  const RUNNER_VERSION = versionMatch[1]
 
   // ghcr pull credential delivery (option B, rotation-capable): install AWS CLI v2
   // and write a start-wrapper that re-fetches the TOKEN from Secrets Manager on

--- a/scripts/deploy/runner-update-binary.sh
+++ b/scripts/deploy/runner-update-binary.sh
@@ -44,30 +44,67 @@ if [[ -z "$INSTANCE_ID" || "$INSTANCE_ID" == "None" ]]; then
 fi
 echo "    instance: $INSTANCE_ID"
 
-ASSET_URL="https://github.com/boxlite-ai/boxlite/releases/download/v${VERSION}/boxlite-runner-v${VERSION}-linux-amd64.tar.gz"
+ASSET_BASE="https://github.com/boxlite-ai/boxlite/releases/download/v${VERSION}"
+ASSET_TARBALL="boxlite-runner-v${VERSION}-linux-amd64.tar.gz"
 
+# Remote upgrade script. Mirrors the boot user-data's integrity policy and adds a
+# rollback: download + checksum-verify BEFORE stopping the unit (so a failed or
+# corrupt fetch never takes the runner down), back up the live binary, swap it in,
+# and restore the backup if the new binary fails to come up.
 read -r -d '' SCRIPT <<EOF || true
 set -euo pipefail
 echo "current version:"
 /usr/local/bin/boxlite-runner --version || true
 
-systemctl stop boxlite-runner
-curl -fsSL "${ASSET_URL}" | tar xz -C /usr/local/bin/
-chmod +x /usr/local/bin/boxlite-runner
-systemctl start boxlite-runner
+WORK=\$(mktemp -d)
+trap 'rm -rf "\$WORK"' EXIT
+curl -fsSL "${ASSET_BASE}/${ASSET_TARBALL}" -o "\$WORK/runner.tar.gz"
+if curl -fsSL "${ASSET_BASE}/${ASSET_TARBALL}.sha256" -o "\$WORK/runner.sha256"; then
+  EXPECTED=\$(awk '{print \$1}' "\$WORK/runner.sha256")
+  ACTUAL=\$(sha256sum "\$WORK/runner.tar.gz" | awk '{print \$1}')
+  [ "\$EXPECTED" = "\$ACTUAL" ] || { echo "FATAL: checksum mismatch (want \$EXPECTED got \$ACTUAL)" >&2; exit 1; }
+  echo "checksum verified (\$ACTUAL)"
+else
+  echo "WARNING: no .sha256 published for v${VERSION}; installing without integrity verification" >&2
+fi
+tar -xzf "\$WORK/runner.tar.gz" -C "\$WORK"
+test -x "\$WORK/boxlite-runner" || { echo "FATAL: tarball has no boxlite-runner binary" >&2; exit 1; }
 
-sleep 2
-echo "new version:"
-/usr/local/bin/boxlite-runner --version
-
-systemctl is-active --quiet boxlite-runner && echo "systemd unit: active" || (echo "systemd unit FAILED"; journalctl -u boxlite-runner --no-pager -n 50; exit 1)
+# Back up the live binary (if any) so a failed swap or start can roll back.
+HAD_PREVIOUS=false
+if [ -x /usr/local/bin/boxlite-runner ]; then
+  cp -a /usr/local/bin/boxlite-runner /usr/local/bin/boxlite-runner.bak
+  HAD_PREVIOUS=true
+fi
+systemctl stop boxlite-runner || true
+# Swap + start + health as one guarded condition: a failing step here (install error,
+# start failure, or an unhealthy unit) routes to the rollback branch instead of aborting
+# the script under set -e — commands in an if-condition are exempt from set -e.
+if install -m 0755 "\$WORK/boxlite-runner" /usr/local/bin/boxlite-runner && systemctl start boxlite-runner && sleep 2 && systemctl is-active --quiet boxlite-runner; then
+  [ "\$HAD_PREVIOUS" = true ] && rm -f /usr/local/bin/boxlite-runner.bak
+  echo "systemd unit: active"
+  echo "new version:"
+  /usr/local/bin/boxlite-runner --version
+else
+  echo "upgrade failed; rolling back" >&2
+  if [ "\$HAD_PREVIOUS" = true ]; then
+    mv -f /usr/local/bin/boxlite-runner.bak /usr/local/bin/boxlite-runner
+    systemctl restart boxlite-runner || true
+  fi
+  journalctl -u boxlite-runner --no-pager -n 50 || true
+  exit 1
+fi
 EOF
 
+# Hand the script to SSM base64-encoded rather than quote-escaped: the payload
+# becomes a single token with no shell metacharacters, sidestepping the brittle
+# sed-escaping of a multi-line script inside the commands=[...] shorthand.
+SCRIPT_B64=$(printf '%s' "$SCRIPT" | base64 | tr -d '\n')
 CMD_ID=$(aws ssm send-command --region "$AWS_REGION" \
   --document-name "AWS-RunShellScript" \
   --instance-ids "$INSTANCE_ID" \
   --comment "boxlite-runner upgrade to v$VERSION" \
-  --parameters "commands=[\"$(printf '%s' "$SCRIPT" | sed 's/"/\\"/g')\"]" \
+  --parameters "commands=[\"echo $SCRIPT_B64 | base64 -d | bash\"]" \
   --query 'Command.CommandId' --output text)
 
 echo "    command:  $CMD_ID"


### PR DESCRIPTION
## Summary
Hardens the BoxLite control-plane infra (`apps/infra`, SST v4 / Pulumi) and the
runner deploy script, with a one-line annotation in `apps/api` config. No change
to the public/private topology established earlier.

### Durability & correctness
- **Datastores**: RDS `deletionProtection` + a `RandomId`-suffixed final snapshot, and S3 bucket `versioning`, all gated on the `production` stage. Closes the asymmetry where only the runner had teardown protection.
- **Api health check**: explicit `/api/health` ALB probe (previously relied on the default `/`, which the NestJS API — mounted under `/api` — would fail).
- **Fail-fast**: `requireEnv()` replaces three `process.env.X!` assertions for the OIDC management vars; the Cargo version regex now throws a clear error instead of `null![1]`.
- **ghcr secret**: `recoveryWindowInDays: 0 -> 7`.

### Deploy / runtime safety
- **`runner-update-binary.sh`**: verify the checksum *before* stopping the unit, atomic swap with rollback if the new binary fails to start, and a base64 SSM payload (drops brittle `sed` quote-escaping). Fixes a rollback-bypass where a failed `install` under `set -e` left the runner down.
- **`register-runners.mjs`**: bounded retry on transient 5xx / network errors (201/409 handling unchanged).

### Hygiene & posture
- **MailDev**: `MAILDEV_PUBLIC=true` now throws — an unauthenticated mail catcher has no safe public form.
- **Runner factory**: de-duplicate the ~95%-identical default/extra runner EC2 definitions into `makeRunner()` (logical names unchanged -> no resource replacement).
- **S3 gateway VPC endpoint**: keeps private-subnet service S3 traffic off the fck-nat NAT (free).
- **Removed** vestigial `RUNNER_PRIVATE_IP` wiring; **annotated** the inert `BOXLITE_SYSTEM_IMAGE_TAG` / `SOURCE_REGISTRY_*` config as unconsumed Daytona-port residue (no consumer in `apps/api`).
- **Docs**: `.env.example` synced with ~47 previously-undocumented vars; README runner-upgrade paragraph + MailDev row corrected.

### Verification
- `sst.config.ts` + `configuration.ts` transpile (esbuild); `register-runners.mjs` `node --check`; `runner-update-binary.sh` `bash -n` + `shellcheck` clean, including the *expanded* remote SSM script.
- A prior multi-agent review plus one adversarial-iteration round were applied; all findings fixed.

### Deploy caveat
Run `sst diff` before deploying and confirm only in-place attribute updates (deletionProtection, health check, versioning, S3 endpoint add) — **no `replace`** on RDS / Redis / the bucket / runners.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved runner registration reliability with automatic retry logic for transient failures.
  * Enhanced runner binary update process with verification, backup, and rollback capabilities.

* **Chores**
  * Hardened MailDev configuration to enforce internal-only deployment.

* **Documentation**
  * Expanded infrastructure configuration documentation with observability and optional settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->