### PR TITLE
Use public curated image tags

### DIFF
--- a/apps/api/src/box/constants/curated-images.constant.spec.ts
+++ b/apps/api/src/box/constants/curated-images.constant.spec.ts
@@ -26,12 +26,13 @@ describe('supported image allowlist', () => {
     }
   })
 
-  it('exposes the three pinned ghcr refs, base first (the default)', () => {
+  it('exposes the three curated ghcr refs, base first (the default)', () => {
     const supported = supportedImages()
-    expect(supported).toHaveLength(3)
-    expect(supported[0]).toContain('ghcr.io/boxlite-ai/boxlite-agent-base@sha256:')
-    expect(supported[1]).toContain('ghcr.io/boxlite-ai/boxlite-agent-python@sha256:')
-    expect(supported[2]).toContain('ghcr.io/boxlite-ai/boxlite-agent-node@sha256:')
+    expect(supported).toEqual([
+      'ghcr.io/boxlite-ai/boxlite-agent-base:20260605-p0-r3',
+      'ghcr.io/boxlite-ai/boxlite-agent-python:20260605-p0-r3',
+      'ghcr.io/boxlite-ai/boxlite-agent-node:20260605-p0-r3',
+    ])
   })
 
   it('accepts each supported ref verbatim', () => {
@@ -44,7 +45,7 @@ describe('supported image allowlist', () => {
     expect(assertSupportedImage(undefined)).toBe(supportedImages()[0])
   })
 
-  it('prefers the env-configured ref over the pinned fallback', () => {
+  it('prefers the env-configured ref over the curated fallback', () => {
     process.env.BOXLITE_SYSTEM_PYTHON_IMAGE = 'ghcr.io/boxlite-ai/override@sha256:deadbeef'
     expect(assertSupportedImage('ghcr.io/boxlite-ai/override@sha256:deadbeef')).toBe(
       'ghcr.io/boxlite-ai/override@sha256:deadbeef',

--- a/apps/api/src/box/constants/curated-images.constant.ts
+++ b/apps/api/src/box/constants/curated-images.constant.ts
@@ -7,14 +7,14 @@
 import { BadRequestError } from '../../exceptions/bad-request.exception'
 
 /**
- * Temporary curated-image gate: boxes may only boot from this fixed set of pinned OCI
+ * Temporary curated-image gate: boxes may only boot from this fixed set of curated OCI
  * refs, because the runner pulls with its own private-registry token and must never be
  * handed an arbitrary user-supplied image. The gate is deliberately thin and sits only
  * at the request boundary (BoxService create / warm-pool); everything downstream treats
  * `image` as an opaque OCI ref. When per-org custom images land, delete this file and
  * its call sites — no other layer knows the curated set exists.
  *
- * Env overrides (set on the Api service in apps/infra/sst.config.ts) allow digest
+ * Env overrides (set on the Api service in apps/infra/sst.config.ts) allow ref
  * rotation without a code deploy; the fallbacks cover local/dev runs.
  */
 type SupportedImageSource = {
@@ -25,22 +25,19 @@ type SupportedImageSource = {
 const SUPPORTED_IMAGE_SOURCES: SupportedImageSource[] = [
   {
     envVar: 'BOXLITE_SYSTEM_BASE_IMAGE',
-    fallbackRef:
-      'ghcr.io/boxlite-ai/boxlite-agent-base@sha256:834dcb65465985fc2f648451d76c81d166bc7672391c9064a0a115ce6306c85f',
+    fallbackRef: 'ghcr.io/boxlite-ai/boxlite-agent-base:20260605-p0-r3',
   },
   {
     envVar: 'BOXLITE_SYSTEM_PYTHON_IMAGE',
-    fallbackRef:
-      'ghcr.io/boxlite-ai/boxlite-agent-python@sha256:80d562a57f4bc12def4e54dbdb9e7d26d3268fe0767a2955ab5ad718041145d6',
+    fallbackRef: 'ghcr.io/boxlite-ai/boxlite-agent-python:20260605-p0-r3',
   },
   {
     envVar: 'BOXLITE_SYSTEM_NODE_IMAGE',
-    fallbackRef:
-      'ghcr.io/boxlite-ai/boxlite-agent-node@sha256:fcb8b840ab68567975853666c82fb6c59a3c1d14a0cdc31d7cbf3a01e6c6d247',
+    fallbackRef: 'ghcr.io/boxlite-ai/boxlite-agent-node:20260605-p0-r3',
   },
 ]
 
-/** Pinned OCI refs a box may boot from. The first entry is the default image. */
+/** Curated OCI refs a box may boot from. The first entry is the default image. */
 export function supportedImages(): string[] {
   return SUPPORTED_IMAGE_SOURCES.map(({ envVar, fallbackRef }) => process.env[envVar] || fallbackRef)
 }

--- a/apps/dashboard/src/components/Box/CreateBoxSheet.tsx
+++ b/apps/dashboard/src/components/Box/CreateBoxSheet.tsx
@@ -84,19 +84,19 @@ const SUPPORTED_BOX_IMAGES = [
   {
     id: 'base',
     name: 'Base',
-    ref: 'ghcr.io/boxlite-ai/boxlite-agent-base@sha256:834dcb65465985fc2f648451d76c81d166bc7672391c9064a0a115ce6306c85f',
+    ref: 'ghcr.io/boxlite-ai/boxlite-agent-base:20260605-p0-r3',
     isDefault: true,
   },
   {
     id: 'python',
     name: 'Python',
-    ref: 'ghcr.io/boxlite-ai/boxlite-agent-python@sha256:80d562a57f4bc12def4e54dbdb9e7d26d3268fe0767a2955ab5ad718041145d6',
+    ref: 'ghcr.io/boxlite-ai/boxlite-agent-python:20260605-p0-r3',
     isDefault: false,
   },
   {
     id: 'node',
     name: 'Node.js',
-    ref: 'ghcr.io/boxlite-ai/boxlite-agent-node@sha256:fcb8b840ab68567975853666c82fb6c59a3c1d14a0cdc31d7cbf3a01e6c6d247',
+    ref: 'ghcr.io/boxlite-ai/boxlite-agent-node:20260605-p0-r3',
     isDefault: false,
   },
 ] as const

--- a/apps/infra/sst.config.ts
+++ b/apps/infra/sst.config.ts
@@ -448,15 +448,15 @@ export default $config({
         BOXLITE_SYSTEM_IMAGE_TAG: envOr('BOXLITE_SYSTEM_IMAGE_TAG', '20260605-p0-r3'),
         BOXLITE_SYSTEM_BASE_IMAGE: envOr(
           'BOXLITE_SYSTEM_BASE_IMAGE',
-          'ghcr.io/boxlite-ai/boxlite-agent-base@sha256:834dcb65465985fc2f648451d76c81d166bc7672391c9064a0a115ce6306c85f',
+          'ghcr.io/boxlite-ai/boxlite-agent-base:20260605-p0-r3',
         ),
         BOXLITE_SYSTEM_PYTHON_IMAGE: envOr(
           'BOXLITE_SYSTEM_PYTHON_IMAGE',
-          'ghcr.io/boxlite-ai/boxlite-agent-python@sha256:80d562a57f4bc12def4e54dbdb9e7d26d3268fe0767a2955ab5ad718041145d6',
+          'ghcr.io/boxlite-ai/boxlite-agent-python:20260605-p0-r3',
         ),
         BOXLITE_SYSTEM_NODE_IMAGE: envOr(
           'BOXLITE_SYSTEM_NODE_IMAGE',
-          'ghcr.io/boxlite-ai/boxlite-agent-node@sha256:fcb8b840ab68567975853666c82fb6c59a3c1d14a0cdc31d7cbf3a01e6c6d247',
+          'ghcr.io/boxlite-ai/boxlite-agent-node:20260605-p0-r3',
         ),
         ...(process.env.BOXLITE_SYSTEM_SOURCE_REGISTRY_URL && {
           BOXLITE_SYSTEM_SOURCE_REGISTRY_NAME: envOr(


### PR DESCRIPTION
## Summary
- switch curated Box image refs from digest pins to public `20260605-p0-r3` tags
- keep API env overrides intact while updating fallback refs
- sync Dashboard Create Box presets and SST API env fallbacks

## Testing
- `git diff --check`
- `cd apps && yarn jest --config api/jest.config.ts api/src/box/constants/curated-images.constant.spec.ts`

Note: created from a clean branch off latest `origin/main` because the earlier `codex/fix-supported-images-dashboard` branch was already merged via PR #792.