### PR TITLE
Restore ClickHouse OTEL exporter auto-enable

### DIFF
--- a/apps/infra/.env.example
+++ b/apps/infra/.env.example
@@ -184,12 +184,11 @@ SSH_HOST_KEY_B64=
 # SVIX_SERVER_URL=
 
 # 5k. Observability backend — ClickHouse (trace/metric/log storage). All [optional];
-# unset = the OtelCollector targets a disabled endpoint and the API's observability
+# unset = the OtelCollector sends only to boxlite_exporter and the API's observability
 # reader stays dormant. Two independent paths: the collector WRITES, the API READS.
-#   Writer (OtelCollector → ClickHouse). CLICKHOUSE_EXPORTER_ENABLED=true makes the
-#   endpoint + password [required] (deploy throws otherwise). *_WRITER_* win over the
-#   unprefixed fallbacks, which win over CLICKHOUSE_OTEL_ENDPOINT.
-# CLICKHOUSE_EXPORTER_ENABLED=true
+#   Writer (OtelCollector → ClickHouse). Setting both endpoint + password auto-enables
+#   the clickhouse exporter. Setting only one deploy-fails. Use
+#   CLICKHOUSE_EXPORTER_ENABLED=false only to force-disable ClickHouse export.
 # CLICKHOUSE_WRITER_ENDPOINT=https://your-clickhouse:8443   # or CLICKHOUSE_ENDPOINT / CLICKHOUSE_OTEL_ENDPOINT
 # CLICKHOUSE_WRITER_PASSWORD=                               # or CLICKHOUSE_PASSWORD
 # CLICKHOUSE_WRITER_USERNAME=default                        # or CLICKHOUSE_USERNAME

--- a/apps/infra/clickhouse-exporter.test.ts
+++ b/apps/infra/clickhouse-exporter.test.ts
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { resolveClickHouseExporter } from './clickhouse-exporter'
+
+test('leaves ClickHouse export disabled when no writer config is present', () => {
+  assert.deepEqual(resolveClickHouseExporter({}), {
+    enabled: false,
+    exporters: '[boxlite_exporter]',
+    writerEndpoint: undefined,
+    writerPassword: undefined,
+  })
+})
+
+test('auto-enables ClickHouse export when writer endpoint and password are present', () => {
+  assert.deepEqual(
+    resolveClickHouseExporter({
+      CLICKHOUSE_WRITER_ENDPOINT: 'https://writer.example:8443',
+      CLICKHOUSE_WRITER_PASSWORD: 'secret',
+    }),
+    {
+      enabled: true,
+      exporters: '[boxlite_exporter,clickhouse]',
+      writerEndpoint: 'https://writer.example:8443',
+      writerPassword: 'secret',
+    },
+  )
+})
+
+test('keeps legacy unprefixed and OTEL endpoint fallbacks working', () => {
+  assert.deepEqual(
+    resolveClickHouseExporter({
+      CLICKHOUSE_OTEL_ENDPOINT: 'https://otel.example:8443',
+      CLICKHOUSE_PASSWORD: 'secret',
+    }),
+    {
+      enabled: true,
+      exporters: '[boxlite_exporter,clickhouse]',
+      writerEndpoint: 'https://otel.example:8443',
+      writerPassword: 'secret',
+    },
+  )
+})
+
+test('fails fast when only part of the writer config is present', () => {
+  assert.throws(
+    () =>
+      resolveClickHouseExporter({
+        CLICKHOUSE_WRITER_ENDPOINT: 'https://writer.example:8443',
+      }),
+    /ClickHouse writer endpoint and password must be configured together/,
+  )
+})
+
+test('fails fast when explicit true is set without writer config', () => {
+  assert.throws(
+    () =>
+      resolveClickHouseExporter({
+        CLICKHOUSE_EXPORTER_ENABLED: 'true',
+      }),
+    /ClickHouse writer endpoint and password must be configured together/,
+  )
+})
+
+test('allows an explicit false flag to force ClickHouse export off', () => {
+  assert.deepEqual(
+    resolveClickHouseExporter({
+      CLICKHOUSE_EXPORTER_ENABLED: 'false',
+      CLICKHOUSE_WRITER_ENDPOINT: 'https://writer.example:8443',
+      CLICKHOUSE_WRITER_PASSWORD: 'secret',
+    }),
+    {
+      enabled: false,
+      exporters: '[boxlite_exporter]',
+      writerEndpoint: 'https://writer.example:8443',
+      writerPassword: 'secret',
+    },
+  )
+})
+
+test('keeps explicit true supported when full writer config is present', () => {
+  assert.deepEqual(
+    resolveClickHouseExporter({
+      CLICKHOUSE_EXPORTER_ENABLED: 'true',
+      CLICKHOUSE_ENDPOINT: 'https://writer.example:8443',
+      CLICKHOUSE_PASSWORD: 'secret',
+    }),
+    {
+      enabled: true,
+      exporters: '[boxlite_exporter,clickhouse]',
+      writerEndpoint: 'https://writer.example:8443',
+      writerPassword: 'secret',
+    },
+  )
+})

--- a/apps/infra/clickhouse-exporter.ts
+++ b/apps/infra/clickhouse-exporter.ts
@@ -1,0 +1,46 @@
+export interface ClickHouseExporterResolution {
+  enabled: boolean
+  exporters: string
+  writerEndpoint?: string
+  writerPassword?: string
+}
+
+const CLICKHOUSE_EXPORTERS = '[boxlite_exporter,clickhouse]'
+const BOXLITE_ONLY_EXPORTERS = '[boxlite_exporter]'
+
+export function resolveClickHouseExporter(env: NodeJS.ProcessEnv): ClickHouseExporterResolution {
+  const writerEndpoint = env.CLICKHOUSE_WRITER_ENDPOINT || env.CLICKHOUSE_ENDPOINT || env.CLICKHOUSE_OTEL_ENDPOINT
+  const writerPassword = env.CLICKHOUSE_WRITER_PASSWORD || env.CLICKHOUSE_PASSWORD
+  const isExplicitlyDisabled = env.CLICKHOUSE_EXPORTER_ENABLED === 'false'
+  const isExplicitlyEnabled = env.CLICKHOUSE_EXPORTER_ENABLED === 'true'
+  const hasWriterEndpoint = Boolean(writerEndpoint)
+  const hasWriterPassword = Boolean(writerPassword)
+  const hasPartialWriterConfig = hasWriterEndpoint !== hasWriterPassword
+
+  if (isExplicitlyDisabled) {
+    return {
+      enabled: false,
+      exporters: BOXLITE_ONLY_EXPORTERS,
+      writerEndpoint,
+      writerPassword,
+    }
+  }
+
+  if (
+    (isExplicitlyEnabled && (!hasWriterEndpoint || !hasWriterPassword)) ||
+    (!isExplicitlyEnabled && hasPartialWriterConfig)
+  ) {
+    throw new Error(
+      'ClickHouse writer endpoint and password must be configured together: set CLICKHOUSE_WRITER_ENDPOINT or CLICKHOUSE_ENDPOINT or CLICKHOUSE_OTEL_ENDPOINT, plus CLICKHOUSE_WRITER_PASSWORD or CLICKHOUSE_PASSWORD',
+    )
+  }
+
+  const enabled = isExplicitlyEnabled || (hasWriterEndpoint && hasWriterPassword)
+
+  return {
+    enabled,
+    exporters: enabled ? CLICKHOUSE_EXPORTERS : BOXLITE_ONLY_EXPORTERS,
+    writerEndpoint,
+    writerPassword,
+  }
+}

--- a/apps/infra/sst.config.ts
+++ b/apps/infra/sst.config.ts
@@ -5,6 +5,8 @@
 
 /// <reference path="./.sst/platform/config.d.ts" />
 
+import { resolveClickHouseExporter } from './clickhouse-exporter'
+
 // ─────────────────────────────────────────────────────────────────────────────
 // BoxLite control plane on AWS (ap-southeast-1).
 //
@@ -121,14 +123,8 @@ export default $config({
     const clickHouseWriterPassword = process.env.CLICKHOUSE_WRITER_PASSWORD || process.env.CLICKHOUSE_PASSWORD
     const clickHouseReaderUrl = process.env.CLICKHOUSE_READER_URL || process.env.CLICKHOUSE_URL
     const clickHouseReaderHost = process.env.CLICKHOUSE_READER_HOST || process.env.CLICKHOUSE_HOST
-    const clickHouseExporterEnabled = process.env.CLICKHOUSE_EXPORTER_ENABLED === 'true'
-    if (clickHouseExporterEnabled && !clickHouseWriterEndpoint) {
-      throw new Error('CLICKHOUSE_WRITER_ENDPOINT or CLICKHOUSE_ENDPOINT is required when CLICKHOUSE_EXPORTER_ENABLED=true')
-    }
-    if (clickHouseExporterEnabled && !clickHouseWriterPassword) {
-      throw new Error('CLICKHOUSE_WRITER_PASSWORD or CLICKHOUSE_PASSWORD is required when CLICKHOUSE_EXPORTER_ENABLED=true')
-    }
-    const collectorExporters = clickHouseExporterEnabled ? '[boxlite_exporter,clickhouse]' : '[boxlite_exporter]'
+    const clickHouseExporter = resolveClickHouseExporter(process.env)
+    const collectorExporters = clickHouseExporter.exporters
 
     // HTTPS everywhere: the Router CloudFront Function deletes customOriginConfig
     // for http origins and CF then falls back to match-viewer (→ tries HTTPS on a


### PR DESCRIPTION
## Summary
- restore ClickHouse OTEL exporter auto-enable when a writer endpoint and password are configured
- keep explicit `CLICKHOUSE_EXPORTER_ENABLED=false` as a force-disable switch
- fail fast on partial ClickHouse writer config so deploys do not silently drop telemetry
- document the auto-enable behavior in `apps/infra/.env.example`

## Verification
- `apps/node_modules/.bin/tsx --test apps/infra/clickhouse-exporter.test.ts`
- `make lint:apps`
- `apps/node_modules/.bin/prettier --check apps/infra/clickhouse-exporter.ts apps/infra/clickhouse-exporter.test.ts`
- `apps/node_modules/.bin/eslint infra/clickhouse-exporter.ts infra/clickhouse-exporter.test.ts infra/sst.config.ts` from `apps/`
- `git diff --check`

`make fmt:check:apps` still fails on existing generated api-client formatting warnings outside this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated ClickHouse observability backend configuration guidance: setting both endpoint and password auto-enables the exporter, while partial configuration now triggers a deployment error.

* **Chores**
  * Enhanced ClickHouse exporter configuration validation for consistency and reliability during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->