### PR TITLE
feat(dashboard): same-origin /api proxy for local dev against any API env

### DIFF
--- a/apps/CLAUDE.md
+++ b/apps/CLAUDE.md
@@ -1,7 +1,25 @@
 ## Local Dashboard And E2E Commands
 
-- Use `npm run start` from the repository root for dashboard-only work against the shared dev API.
-- Use `npm run dev:dex` from the repository root for full local Dex development. It starts Docker Postgres, Redis, Dex, and the apps workspace with OIDC pointed at Dex.
-- Use `npm run e2e:local` from the repository root for local browser E2E. This is the only E2E startup entrypoint; do not use `start`, `start:dex`, or `serve-slim` directly for E2E.
-- The local Dex test account is `admin@boxlite.dev` / `password`. Browser E2E should log in through Dex when redirected and should not depend on cached cookies.
-- `dev:dex` and `e2e:local` require Docker Desktop and create/reuse `boxlite-local-postgres`, `boxlite-local-redis`, and `boxlite-local-dex`.
+Run these from `apps/` (the nx workspace root), **not** the repository root.
+
+The dashboard always calls a same-origin `/api` path; Vite proxies `/api` to the
+selected backend, so the browser never makes a cross-origin (CORS-gated) request
+and no backend has to allow-list `localhost`. The proxy target is chosen by the
+command and read by `apps/dashboard/vite.config.mts` via `DASHBOARD_API_PROXY_TARGET`
+(see the `API_TARGETS` map in `apps/scripts/start-dashboard.mjs`). Auth follows the
+selected API: login uses whatever OIDC issuer that API's `/api/config` reports.
+
+- `npm run start` / `npm run start:dev` — dashboard against the **dev API** (default).
+- `npm run start:local` — dashboard against a **local API** (`/api` → `http://localhost:3001`).
+- `npm run start:prod` — dashboard against the **prod API**. Guarded: requires
+  `--yes-prod`, and prod is unconfigured until the prod stage exists.
+- `npm run start -- --api=<url>` — proxy `/api` to **any** API URL (staging, a PR preview, …).
+- `npm run start:mock` — MSW mocks; no backend, no login.
+- `npm run dev:dex` — full local Dex development. Starts Docker Postgres, Redis, Dex,
+  and the apps workspace with OIDC pointed at Dex.
+- `npm run e2e:local` — the only E2E startup entrypoint; do not use `start`,
+  `start:dex`, or `serve-slim` directly for E2E.
+- The local Dex test account is `admin@boxlite.dev` / `password`. Browser E2E should
+  log in through Dex when redirected and should not depend on cached cookies.
+- `dev:dex` and `e2e:local` require Docker Desktop and create/reuse
+  `boxlite-local-postgres`, `boxlite-local-redis`, and `boxlite-local-dex`.

--- a/apps/dashboard/vite.config.mts
+++ b/apps/dashboard/vite.config.mts
@@ -18,7 +18,11 @@ export default defineConfig((mode) => ({
     host: '0.0.0.0',
     proxy: {
       '/api': {
-        target: 'http://localhost:3001',
+        // Defaults to the local API. Override with DASHBOARD_API_PROXY_TARGET to
+        // point the dashboard at a remote API (e.g. https://dev.boxlite.ai) through
+        // this same-origin proxy, so the browser never makes a cross-origin
+        // (CORS-gated) request — Vite talks to the API server-to-server.
+        target: process.env.DASHBOARD_API_PROXY_TARGET || 'http://localhost:3001',
         ws: true,
         changeOrigin: true,
         rewriteWsOrigin: true,

--- a/apps/package.json
+++ b/apps/package.json
@@ -8,6 +8,7 @@
     "start": "node scripts/start-dashboard.mjs",
     "clickstack:cloud": "node scripts/clickstack-cloud.mjs",
     "start:dev": "node scripts/start-dashboard.mjs --target=dev",
+    "start:prod": "node scripts/start-dashboard.mjs --target=prod",
     "start:mock": "node scripts/start-dashboard.mjs --target=mock",
     "start:local": "node scripts/start-dashboard.mjs --target=local",
     "start:dex": "node scripts/start-dashboard.mjs --target=dex",

--- a/apps/scripts/start-dashboard.mjs
+++ b/apps/scripts/start-dashboard.mjs
@@ -141,7 +141,10 @@ const rawTarget = api || selected.proxyTarget
 const proxyTarget = rawTarget ? rawTarget.replace(/\/api\/?$/, '').replace(/\/$/, '') : undefined
 
 // PROD guard: real user data, and prod Auth0 would have to allow http://localhost:3000.
-if (selected.prod && !api) {
+// Runs for ANY prod-target invocation — including `--api=<prod-url>`, which would
+// otherwise bypass the confirmation. Only the "unconfigured" check depends on the
+// built-in mapping (an explicit --api always supplies a target).
+if (selected.prod) {
   if (!proxyTarget) {
     console.error('The "prod" API environment is not configured yet (no prod stage).')
     console.error('Set API_TARGETS.prod in apps/scripts/start-dashboard.mjs once prod exists.')
@@ -162,6 +165,10 @@ const env = {
 
 if (proxyTarget) {
   env.DASHBOARD_API_PROXY_TARGET = proxyTarget
+  // Force a same-origin `/api` path: clear any inherited/exported VITE_BASE_API_URL
+  // so ConfigProvider can't build a cross-origin apiUrl and bypass the proxy (which
+  // would re-introduce the very CORS failure this proxy exists to avoid).
+  env.VITE_BASE_API_URL = ''
 }
 
 env.PATH = [appsBinPath, process.env.PATH].filter(Boolean).join(path.delimiter)

--- a/apps/scripts/start-dashboard.mjs
+++ b/apps/scripts/start-dashboard.mjs
@@ -7,40 +7,55 @@ import { fileURLToPath } from 'node:url'
 const appsRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const appsBinPath = path.join(appsRoot, 'node_modules', '.bin')
 
+// ── API environments ─────────────────────────────────────────────────────────
+// Single source of truth: an API environment maps to a Vite `/api` proxy target.
+// The dashboard always calls a SAME-ORIGIN `/api` path; Vite proxies it to the
+// selected backend. The browser therefore never makes a cross-origin request, so
+// CORS is out of the path (the proxy reaches the API server-to-server, where the
+// browser's same-origin policy does not apply — so no backend has to allow-list
+// localhost). Add an environment by adding a line here; `--api <url>` proxies to
+// an arbitrary URL without touching this map.
+const API_TARGETS = {
+  local: 'http://localhost:3001',
+  dev: 'https://dev.boxlite.ai',
+  // prod: 'https://api.boxlite.ai', // placeholder — set the real prod API origin and
+  //                                  // uncomment once the prod stage exists. Prod is
+  //                                  // also guarded below (needs --yes-prod).
+}
+
 const targets = {
   dev: {
-    label: 'local dashboard + dev Auth0/dev API',
-    env: {
-      VITE_BASE_API_URL: 'https://dev.boxlite.ai',
-    },
-  },
-  auth0: {
-    label: 'local dashboard + dev Auth0/dev API',
-    env: {
-      VITE_BASE_API_URL: 'https://dev.boxlite.ai',
-    },
-  },
-  mock: {
-    label: 'local dashboard + dev Auth0/dev API + MSW billing mocks',
-    env: {
-      VITE_BASE_API_URL: 'https://dev.boxlite.ai',
-      VITE_API_URL: 'https://dev.boxlite.ai/api',
-      VITE_ENABLE_MOCKING: 'true',
-    },
+    label: `local dashboard + dev API via same-origin /api proxy → ${API_TARGETS.dev}`,
+    proxyTarget: API_TARGETS.dev,
   },
   local: {
-    label: 'local dashboard + local API via Vite /api proxy',
-    env: {},
+    label: `local dashboard + local API via /api proxy → ${API_TARGETS.local}`,
+    proxyTarget: API_TARGETS.local,
   },
   dex: {
-    label: 'local dashboard + local API/Dex via Vite /api proxy',
-    env: {},
+    label: `local dashboard + local API/Dex via /api proxy → ${API_TARGETS.local}`,
+    proxyTarget: API_TARGETS.local,
+  },
+  prod: {
+    label: 'local dashboard + PROD API (controlled)',
+    proxyTarget: API_TARGETS.prod, // undefined until configured; guarded below
+    prod: true,
+  },
+  mock: {
+    label: 'local dashboard + MSW mocks (no backend, no login)',
+    // MSW intercepts requests in the browser; keep the keys its handlers read.
+    extraEnv: {
+      VITE_BASE_API_URL: API_TARGETS.dev,
+      VITE_API_URL: `${API_TARGETS.dev}/api`,
+      VITE_ENABLE_MOCKING: 'true',
+    },
   },
 }
 
 function parseArgs(argv) {
   let target = 'dev'
   let api
+  let yesProd = false
   const forward = []
 
   for (let i = 0; i < argv.length; i += 1) {
@@ -77,37 +92,37 @@ function parseArgs(argv) {
       continue
     }
 
+    if (arg === '--yes-prod') {
+      yesProd = true
+      continue
+    }
+
     forward.push(arg)
   }
 
-  return { help: false, target, api, forward }
+  return { help: false, target, api, yesProd, forward }
 }
 
 function printHelp() {
   console.log(`Usage:
-  npm run start
-  npm run start:dev
-  npm run start:mock
-  npm run start:local
-  npm run start:dex
-  npm run start:storybook
-  npm run dev:dex
-  npm run e2e:local
+  npm run start            # default → dev API (via same-origin /api proxy)
+  npm run start:dev        # dev API
+  npm run start:local      # local API (localhost:3001)
+  npm run start:prod       # PROD API — controlled, requires --yes-prod
+  npm run start:mock       # MSW mocks, no backend, no login
+  npm run start:dex        # local API/Dex
+  npm run start -- --api=https://any.example.com   # proxy to ANY API URL
 
-Targets:
-  dev    local dashboard + dev Auth0/dev API (default)
-  auth0  alias of dev
-  mock   dev Auth0/dev API plus existing MSW billing mocks
-  local  local dashboard + local API through /api proxy
-  dex    alias of local; start local API/Dex separately
+How it works:
+  The dashboard always calls a same-origin /api path. Vite proxies /api to the
+  selected backend (server-to-server), so the browser never goes cross-origin and
+  the backend never has to allow-list localhost — there is no CORS to configure.
 
-Local Dex:
-  dev:dex    full local Dex development environment
-  e2e:local  only supported local browser E2E entrypoint
-`)
+Auth follows the API: login uses whatever OIDC issuer the selected API's
+/api/config reports (dev → dev Auth0, prod → prod Auth0, …).`)
 }
 
-const { help, target, api, forward } = parseArgs(process.argv.slice(2))
+const { help, target, api, yesProd, forward } = parseArgs(process.argv.slice(2))
 
 if (help) {
   printHelp()
@@ -120,22 +135,42 @@ if (!selected) {
   process.exit(1)
 }
 
+// Resolve the proxy target: --api wins (arbitrary URL), else the env's mapping.
+// Strip a trailing /api or / so it isn't doubled (Vite already mounts on /api).
+const rawTarget = api || selected.proxyTarget
+const proxyTarget = rawTarget ? rawTarget.replace(/\/api\/?$/, '').replace(/\/$/, '') : undefined
+
+// PROD guard: real user data, and prod Auth0 would have to allow http://localhost:3000.
+if (selected.prod && !api) {
+  if (!proxyTarget) {
+    console.error('The "prod" API environment is not configured yet (no prod stage).')
+    console.error('Set API_TARGETS.prod in apps/scripts/start-dashboard.mjs once prod exists.')
+    process.exit(1)
+  }
+  if (!yesProd) {
+    console.error('Refusing to connect to PROD by default.')
+    console.error('PROD = real user data, and its Auth0 app must allow http://localhost:3000 (do not leave that on).')
+    console.error('Re-run with --yes-prod if you really intend to.')
+    process.exit(1)
+  }
+}
+
 const env = {
   ...process.env,
-  ...selected.env,
+  ...(selected.extraEnv || {}),
+}
+
+if (proxyTarget) {
+  env.DASHBOARD_API_PROXY_TARGET = proxyTarget
 }
 
 env.PATH = [appsBinPath, process.env.PATH].filter(Boolean).join(path.delimiter)
-
-if (api) {
-  env.VITE_BASE_API_URL = api.replace(/\/api\/?$/, '').replace(/\/$/, '')
-}
 
 const nxCommand = process.platform === 'win32' ? 'nx.cmd' : 'nx'
 const args = ['serve', 'dashboard', ...forward]
 
 console.log(`[dashboard] ${selected.label}`)
-console.log(`[dashboard] API origin: ${env.VITE_BASE_API_URL || 'local /api proxy -> http://localhost:3001'}`)
+console.log(`[dashboard] /api proxied to: ${proxyTarget || '(none — MSW mocks / no backend)'}`)
 console.log(`[dashboard] Command: ${nxCommand} ${args.join(' ')}`)
 
 const child = spawn(nxCommand, args, {


### PR DESCRIPTION
## What
Local dashboard dev reaches any API environment through a same-origin Vite `/api` proxy, instead of calling the API cross-origin.

## Why
Serving the dashboard on `localhost:3000` and calling `https://dev.boxlite.ai` directly is cross-origin. The browser requires the dev API to return a CORS `Access-Control-Allow-Origin` for `localhost`, which it does not — so requests failed with `TypeError: Failed to fetch`.

Fix is the standard React/Vite approach: the dashboard calls a same-origin `/api` path, and the Vite dev server proxies it to the selected backend server-to-server (no same-origin policy between servers). No backend has to allow-list `localhost`, and no dev/prod infra changes.

## How
- `start-dashboard.mjs`: single `API_TARGETS` map (`local`, `dev`, `prod` placeholder). `--api=<url>` proxies to any URL; `--yes-prod` guards prod (real data + prod Auth0 would have to allow localhost).
- `vite.config.mts`: `/api` proxy target read from `DASHBOARD_API_PROXY_TARGET` (defaults to local API; `nx serve dashboard` unchanged).
- `package.json`: `start:prod` (replaces a throwaway `start:dev-proxy`).
- `apps/CLAUDE.md`: corrects "from the repository root" (scripts live in `apps/`) and documents the proxy model.

## Commands
| command | API |
|---|---|
| `npm run start` / `start:dev` | dev (default) |
| `npm run start:local` | local API (:3001) |
| `npm run start:prod` | prod (guarded, `--yes-prod`) |
| `npm run start -- --api=<url>` | any URL |
| `npm run start:mock` | MSW mocks |

## Test
`npm run start:dev` → browser fetch `/api/config` returns 200 with real dev config (`oidc.issuer = auth.dev.boxlite.ai`), no CORS error. Logged in to the dev dashboard locally and saw real boxes + the image picker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable same-origin dashboard `/api` proxy routing via `DASHBOARD_API_PROXY_TARGET` (with `--api` override support) and improved PROD gating for production runs.

* **Documentation**
  * Updated dashboard/E2E instructions to run commands from the `apps/` workspace root and clarified proxy/auth behavior and required local/test setup.

* **Chores**
  * Added `start:prod` for production dashboard startup.
  * Refined dashboard startup/proxy configuration and environment handling for more predictable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->