### PR TITLE
fix(infra-local): register the CLI auth-login loopback redirect URI in dex

### DIFF
--- a/apps/infra-local/compose/services.py
+++ b/apps/infra-local/compose/services.py
@@ -198,6 +198,10 @@ staticClients:
       - '${REDIRECT_URI}'
       - 'http://localhost:3000'
       - 'http://localhost:5173'
+      # `boxlite auth login` (browser/OIDC) loopback callback — RFC 8252 §8.3
+      # loopback IP literal on the CLI's fixed default port 5555. The CLI binds
+      # exactly this port or fails; `--callback-port N` needs its own entry.
+      - 'http://127.0.0.1:5555/callback'
     name: 'BoxLite'
     public: true
 enablePasswordDB: true


### PR DESCRIPTION
## What
`boxlite auth login` (browser/OIDC) redirects to a fixed loopback callback
`http://127.0.0.1:5555/callback` (RFC 8252 §8.3). The local dex `boxlite` static
client only allowed the dashboard URIs, so the CLI flow failed with
"Unregistered redirect_uri".

## Change
Add the loopback callback to the dex `boxlite` client's `redirectURIs`. Recreate
the dex box (`make restart COMPONENTS=dex`) to apply.

## Verification
Drove the full dex OIDC flow against the recreated box; it issues a code to
`http://127.0.0.1:5555/callback`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated local development authentication configuration to support loopback callback URI for the authentication login flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->