### PR TITLE
fix(dashboard): recover from a 401 by bouncing to a fresh login

### DIFF
--- a/apps/dashboard/src/api/apiClient.test.ts
+++ b/apps/dashboard/src/api/apiClient.test.ts
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const config = { apiUrl: 'http://api.test/api' } as never
+
+// Fresh module per test so the module-level `isHandlingUnauthorized` guard
+// doesn't leak across cases. A custom axios adapter makes every request resolve
+// to `status` with an empty body, so the response interceptor sees the 401.
+async function makeClient(onUnauthorized: () => Promise<void> | void, status = 401) {
+  vi.resetModules()
+  const axios = (await import('axios')).default
+  // A custom adapter must settle the response itself (axios doesn't re-apply
+  // validateStatus to a custom adapter's return), so reject non-2xx with an
+  // AxiosError carrying `.response`, exactly like the built-in adapters.
+  axios.defaults.adapter = (async (cfg: unknown) => {
+    const response = { data: {}, status, statusText: '', headers: {}, config: cfg }
+    if (status >= 200 && status < 300) return response
+    const err = new Error(`Request failed with status code ${status}`) as Error & Record<string, unknown>
+    err.response = response
+    err.config = cfg
+    err.isAxiosError = true
+    throw err
+  }) as never
+  const { ApiClient } = await import('./apiClient')
+  return new ApiClient(config, 'tok', onUnauthorized)
+}
+
+describe('ApiClient 401 -> bounded re-login recovery', () => {
+  beforeEach(() => {
+    window.sessionStorage.clear()
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('first 401 triggers onUnauthorized once and suspends the caller (no error flash)', async () => {
+    const onUnauthorized = vi.fn(() => Promise.resolve())
+    const api = await makeClient(onUnauthorized)
+    let settled = false
+    void api.organizationsApi.listOrganizations().then(
+      () => (settled = true),
+      () => (settled = true),
+    )
+    await new Promise((r) => setTimeout(r, 30))
+    expect(onUnauthorized).toHaveBeenCalledTimes(1)
+    // Never-settling while the redirect navigates the page away — not an error.
+    expect(settled).toBe(false)
+  })
+
+  it('a 401 that persists after a re-auth attempt rejects instead of bouncing forever', async () => {
+    window.sessionStorage.setItem('boxlite.reauth-attempted', '1')
+    const onUnauthorized = vi.fn(() => Promise.resolve())
+    const api = await makeClient(onUnauthorized)
+    await expect(api.organizationsApi.listOrganizations()).rejects.toBeTruthy()
+    expect(onUnauthorized).not.toHaveBeenCalled()
+  })
+
+  it('a rejecting onUnauthorized resets state and surfaces an error (no hang)', async () => {
+    const onUnauthorized = vi.fn(() => Promise.reject(new Error('redirect start failed')))
+    const api = await makeClient(onUnauthorized)
+    await expect(api.organizationsApi.listOrganizations()).rejects.toBeTruthy()
+    // Marker cleared so a later genuine 401 still gets its one recovery attempt.
+    expect(window.sessionStorage.getItem('boxlite.reauth-attempted')).toBeNull()
+  })
+})

--- a/apps/dashboard/src/api/apiClient.ts
+++ b/apps/dashboard/src/api/apiClient.ts
@@ -26,8 +26,48 @@ import {
 import axios, { AxiosError } from 'axios'
 import { BoxliteError } from './errors'
 
+// A burst of in-flight requests can all 401 at once when the access token goes
+// invalid; this in-page guard ensures at most one re-login redirect per page
+// load. It is reset if onUnauthorized throws (a failed handler must not wedge
+// recovery) and is naturally cleared when signinRedirect reloads the page.
+let isHandlingUnauthorized = false
+
+// Survives the full-page reload signinRedirect triggers, so a first stale-token
+// 401 (recover silently) is distinguishable from one that persists *after* a
+// re-auth already happened this session (revoked user / wrong audience / backend
+// auth bug). Without a cross-reload marker a fresh-but-still-rejected token would
+// bounce to login forever. sessionStorage scopes it to this tab.
+const REAUTH_ATTEMPTED_KEY = 'boxlite.reauth-attempted'
+
+function reauthAlreadyAttempted(): boolean {
+  try {
+    return window.sessionStorage.getItem(REAUTH_ATTEMPTED_KEY) !== null
+  } catch {
+    // sessionStorage can be unavailable (privacy mode, sandboxed iframe). Treat
+    // as "not attempted" so we still try recovery once.
+    return false
+  }
+}
+
+function markReauthAttempted(): void {
+  try {
+    window.sessionStorage.setItem(REAUTH_ATTEMPTED_KEY, '1')
+  } catch {
+    // best-effort; see reauthAlreadyAttempted
+  }
+}
+
+function clearReauthAttempted(): void {
+  try {
+    window.sessionStorage.removeItem(REAUTH_ATTEMPTED_KEY)
+  } catch {
+    // best-effort; see reauthAlreadyAttempted
+  }
+}
+
 export class ApiClient {
   private config: Configuration
+  private onUnauthorized?: () => Promise<void> | void
   private _boxApi: BoxApi
   private _userApi: UsersApi
   private _apiKeyApi: ApiKeysApi
@@ -41,7 +81,8 @@ export class ApiClient {
   private _analyticsUsageApi: AnalyticsUsageApi | null
   private _analyticsTelemetryApi: AnalyticsTelemetryApi | null
 
-  constructor(config: DashboardConfig, accessToken: string) {
+  constructor(config: DashboardConfig, accessToken: string, onUnauthorized?: () => Promise<void> | void) {
+    this.onUnauthorized = onUnauthorized
     this.config = new Configuration({
       basePath: config.apiUrl,
       accessToken: accessToken,
@@ -57,9 +98,22 @@ export class ApiClient {
     })
     axiosInstance.interceptors.response.use(
       (response) => {
+        // A request succeeded → the token is good again; clear the cross-reload
+        // marker so a future stale token still gets its one silent recovery.
+        clearReauthAttempted()
         return response
       },
       (error) => {
+        // A 401 means the access token is no longer accepted — it expired, or
+        // (the common case in the local Dex stack) it was signed by a key that
+        // rotated when the Dex box was recreated. oidc-client-ts only tracks
+        // local expiry, so it still believes the user is signed in and keeps
+        // replaying the dead token on every reload. Drop the session and bounce
+        // to a fresh login instead of a dead-end "Unauthorized" screen.
+        if (error?.response?.status === 401 && this.onUnauthorized) {
+          return this.handleUnauthorized(error)
+        }
+
         let errorMessage: string
 
         if (error instanceof AxiosError && error.message.includes('timeout of')) {
@@ -100,6 +154,49 @@ export class ApiClient {
       this._analyticsUsageApi = null
       this._analyticsTelemetryApi = null
     }
+  }
+
+  // Recovery is bounded to ONE re-login attempt per session: the first 401
+  // drops the session and bounces to a fresh login (suppressing the error so
+  // the user sees a loading state, not a dead-end screen); a 401 that persists
+  // *after* that re-auth is surfaced as an error instead of bouncing forever.
+  private async handleUnauthorized(error: unknown): Promise<never> {
+    // De-dupe a concurrent 401 burst: only the first drives recovery, the rest
+    // suspend on the in-flight redirect. Checked BEFORE the cross-reload marker
+    // so a second concurrent 401 isn't misread as a failed post-reauth attempt.
+    if (isHandlingUnauthorized) {
+      return new Promise<never>(() => {})
+    }
+
+    if (reauthAlreadyAttempted()) {
+      // We already sent the user through a fresh login this session and the new
+      // token is still rejected (revoked user / wrong audience / backend bug).
+      // Bouncing again would loop forever, so surface the failure.
+      throw BoxliteError.fromString('Authentication failed after re-login. Please sign in again.', {
+        cause: error instanceof Error ? error : undefined,
+      })
+    }
+
+    isHandlingUnauthorized = true
+    markReauthAttempted()
+    try {
+      // onUnauthorized clears the OIDC user; ApiProvider's effect then runs
+      // signinRedirect, which navigates the page away. Awaited so a failed
+      // start (e.g. a rejecting removeUser) surfaces an error instead of
+      // hanging forever on the suspend below.
+      await this.onUnauthorized?.()
+    } catch (handlerError) {
+      isHandlingUnauthorized = false
+      clearReauthAttempted()
+      throw BoxliteError.fromString('Failed to start re-authentication.', {
+        cause: handlerError instanceof Error ? handlerError : undefined,
+      })
+    }
+
+    // Suspend the caller (never-settling promise) so it shows the loading
+    // state, not an error, while the redirect navigates the page away. Reached
+    // only on a successfully-started re-auth.
+    return new Promise<never>(() => {})
   }
 
   public setAccessToken(accessToken: string) {

--- a/apps/dashboard/src/providers/ApiProvider.tsx
+++ b/apps/dashboard/src/providers/ApiProvider.tsx
@@ -13,7 +13,7 @@ import { useLocation } from 'react-router-dom'
 import { useConfig } from '@/hooks/useConfig'
 
 export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const { user, isAuthenticated, isLoading, signinRedirect } = useAuth()
+  const { user, isAuthenticated, isLoading, signinRedirect, removeUser } = useAuth()
   const config = useConfig()
   const location = useLocation()
 
@@ -24,7 +24,14 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
   useEffect(() => {
     if (user) {
       if (!apiRef.current) {
-        apiRef.current = new ApiClient(config, user.access_token)
+        // On a 401 the stored token is invalid (expired, or signed by a rotated
+        // Dex key). Clearing the user flips isAuthenticated false, which the
+        // effect below turns into a redirect to a fresh login (preserving
+        // returnTo). Return the removeUser promise (don't void it) so the 401
+        // handler can tell a started recovery (suspend) from a failed one
+        // (surface an error). The redirect stays owned by the effect below to
+        // avoid a double-redirect.
+        apiRef.current = new ApiClient(config, user.access_token, () => removeUser())
       } else {
         apiRef.current.setAccessToken(user.access_token)
       }
@@ -32,7 +39,7 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
     } else {
       setIsApiReady(false)
     }
-  }, [user, config])
+  }, [user, config, removeUser])
 
   useEffect(() => {
     if (!isLoading && !isAuthenticated) {


### PR DESCRIPTION
## What
The dashboard showed a dead-end "Unauthorized" screen when the access token
became invalid — most commonly when the local Dex box was recreated, rotating
its signing keys, so an unexpired-but-invalid token kept being replayed
(oidc-client-ts only tracks local expiry and can't detect this).

## Change
On a 401 the API client drops the OIDC session (`removeUser`), which the existing
ApiProvider effect turns into a `signinRedirect` (preserving `returnTo`). Recovery
is bounded to one attempt per session via a `sessionStorage` marker (a token still
rejected after re-login surfaces an error instead of bouncing forever); concurrent
401s de-dupe to a single redirect (guard checked before the marker); a failed
redirect start surfaces an error rather than hanging.

Note: this is the minimal scope — the separate billing/analytics clients still
hold their own token and don't share this recovery (pre-existing; tracked as a
follow-up).

## Verification
- Reproducer `apps/dashboard/src/api/apiClient.test.ts` verified RED→GREEN on the 401 path.
- Full dashboard suite green; typecheck clean on touched files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced session recovery handling to prevent infinite redirect loops and duplicate re-authentication attempts when tokens expire.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->