### PR TITLE
feat(api): WS attach accepts OIDC JWTs, not just API keys (closes #807)

### DIFF
--- a/apps/api/src/boxlite-rest/boxlite-rest-routing.spec.ts
+++ b/apps/api/src/boxlite-rest/boxlite-rest-routing.spec.ts
@@ -87,11 +87,15 @@ describe('BoxLite REST routing', () => {
   })
 
   it('matches websocket attach upgrades with or without a routing prefix', () => {
-    const service = new BoxliteWsProxyService({} as any, {} as any, {} as any, {} as any)
+    const service = new BoxliteWsProxyService({} as any, {} as any, {} as any, {} as any, {} as any)
 
-    expect(service.matchAttachPath('/api/v1/boxes/box-1/executions/exec-1/attach')).toEqual({ boxId: 'box-1' })
+    expect(service.matchAttachPath('/api/v1/boxes/box-1/executions/exec-1/attach')).toEqual({
+      boxId: 'box-1',
+      tenant: undefined,
+    })
     expect(service.matchAttachPath('/api/v1/default/boxes/box-1/executions/exec-1/attach')).toEqual({
       boxId: 'box-1',
+      tenant: 'default',
     })
   })
 })

--- a/apps/api/src/boxlite-rest/boxlite-ws-proxy.service.spec.ts
+++ b/apps/api/src/boxlite-rest/boxlite-ws-proxy.service.spec.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
+import type { IncomingMessage } from 'http'
 import { createProxyMiddleware } from 'http-proxy-middleware'
 import { BoxliteWsProxyService } from './boxlite-ws-proxy.service'
 
@@ -17,13 +18,36 @@ jest.mock('uuid', () => ({
   validate: jest.fn(() => true),
 }))
 
+type AuthResult = { organizationId: string } | null
+type ServiceInternals = {
+  authenticate(req: IncomingMessage, urlTenant?: string): Promise<AuthResult>
+}
+
+function makeService() {
+  const apiKeyService = { getApiKeyByValue: jest.fn() }
+  const organizationUserService = { findOne: jest.fn() }
+  const jwtStrategy = { verifyToken: jest.fn() }
+  const service = new BoxliteWsProxyService(
+    apiKeyService as never,
+    organizationUserService as never,
+    {} as never,
+    {} as never,
+    jwtStrategy as never,
+  )
+  return { service, apiKeyService, organizationUserService, jwtStrategy }
+}
+
+const bearer = (token: string) => ({ headers: { authorization: `Bearer ${token}` } }) as IncomingMessage
+const authenticate = (service: BoxliteWsProxyService, req: IncomingMessage, tenant?: string) =>
+  (service as never as ServiceInternals).authenticate(req, tenant)
+
 describe('BoxliteWsProxyService', () => {
   beforeEach(() => {
     jest.clearAllMocks()
   })
 
   it('rewrites public box ids to internal box ids before proxying attach upgrades to the runner', () => {
-    new BoxliteWsProxyService({} as never, {} as never, {} as never, {} as never)
+    new BoxliteWsProxyService({} as never, {} as never, {} as never, {} as never, {} as never)
 
     const proxyOptions = jest.mocked(createProxyMiddleware).mock.calls[0][0]
     const pathRewrite = proxyOptions.pathRewrite as (path: string, req: unknown) => string
@@ -35,5 +59,109 @@ describe('BoxliteWsProxyService', () => {
     expect(pathRewrite('/api/v1/default/boxes/public-box/executions/exec-1/attach?x=1', req)).toBe(
       '/v1/boxes/box-uuid/executions/exec-1/attach?x=1',
     )
+  })
+
+  describe('matchAttachPath', () => {
+    it('captures the optional tenant (org id) and the box id', () => {
+      const { service } = makeService()
+      expect(service.matchAttachPath('/api/v1/acme/boxes/b1/executions/e1/attach')).toEqual({
+        boxId: 'b1',
+        tenant: 'acme',
+      })
+      expect(service.matchAttachPath('/api/v1/boxes/b1/executions/e1/attach')).toEqual({
+        boxId: 'b1',
+        tenant: undefined,
+      })
+      expect(service.matchAttachPath('/not/an/attach/path')).toBeNull()
+    })
+  })
+
+  describe('authenticate', () => {
+    it('authenticates a non-expired API key whose user is still a member (regression)', async () => {
+      const { service, apiKeyService, organizationUserService, jwtStrategy } = makeService()
+      apiKeyService.getApiKeyByValue.mockResolvedValue({ organizationId: 'org-1', userId: 'u1', expiresAt: null })
+      organizationUserService.findOne.mockResolvedValue({ organizationId: 'org-1', userId: 'u1' })
+
+      await expect(authenticate(service, bearer('apikey'), 'ignored-tenant')).resolves.toEqual({
+        organizationId: 'org-1',
+      })
+      // API-key org wins; the URL tenant is ignored, and JWT is never consulted.
+      expect(organizationUserService.findOne).toHaveBeenCalledWith('org-1', 'u1')
+      expect(jwtStrategy.verifyToken).not.toHaveBeenCalled()
+    })
+
+    it('rejects an API key whose user is no longer a member of its org', async () => {
+      const { service, apiKeyService, organizationUserService } = makeService()
+      apiKeyService.getApiKeyByValue.mockResolvedValue({ organizationId: 'org-1', userId: 'u1', expiresAt: null })
+      organizationUserService.findOne.mockResolvedValue(null)
+      await expect(authenticate(service, bearer('apikey'))).resolves.toBeNull()
+    })
+
+    it('accepts a JWT whose user is a member of the URL tenant org', async () => {
+      const { service, apiKeyService, organizationUserService, jwtStrategy } = makeService()
+      apiKeyService.getApiKeyByValue.mockRejectedValue(new Error('not an api key'))
+      jwtStrategy.verifyToken.mockResolvedValue({ sub: 'user-1' })
+      organizationUserService.findOne.mockResolvedValue({ organizationId: 'org-A', userId: 'user-1' })
+
+      await expect(authenticate(service, bearer('jwt'), 'org-A')).resolves.toEqual({ organizationId: 'org-A' })
+      expect(organizationUserService.findOne).toHaveBeenCalledWith('org-A', 'user-1')
+    })
+
+    it('rejects a JWT user who is not a member of the URL tenant org (cross-org boundary)', async () => {
+      const { service, apiKeyService, organizationUserService, jwtStrategy } = makeService()
+      apiKeyService.getApiKeyByValue.mockRejectedValue(new Error('not an api key'))
+      jwtStrategy.verifyToken.mockResolvedValue({ sub: 'user-1' })
+      organizationUserService.findOne.mockResolvedValue(null) // not a member of the requested org
+
+      await expect(authenticate(service, bearer('jwt'), 'org-B')).resolves.toBeNull()
+      // Membership is checked against the URL org, not any org the user belongs to.
+      expect(organizationUserService.findOne).toHaveBeenCalledWith('org-B', 'user-1')
+    })
+
+    it('rejects a JWT with no tenant or the legacy `default` prefix (org ambiguous)', async () => {
+      const { service, apiKeyService, organizationUserService, jwtStrategy } = makeService()
+      apiKeyService.getApiKeyByValue.mockRejectedValue(new Error('not an api key'))
+      jwtStrategy.verifyToken.mockResolvedValue({ sub: 'user-1' })
+
+      await expect(authenticate(service, bearer('jwt'))).resolves.toBeNull()
+      await expect(authenticate(service, bearer('jwt'), 'default')).resolves.toBeNull()
+      expect(jwtStrategy.verifyToken).not.toHaveBeenCalled()
+      expect(organizationUserService.findOne).not.toHaveBeenCalled()
+    })
+
+    it('rejects an invalid JWT (verifyToken throws)', async () => {
+      const { service, apiKeyService, jwtStrategy } = makeService()
+      apiKeyService.getApiKeyByValue.mockRejectedValue(new Error('not an api key'))
+      jwtStrategy.verifyToken.mockRejectedValue(new Error('bad signature'))
+      await expect(authenticate(service, bearer('jwt'), 'org-A')).resolves.toBeNull()
+    })
+
+    it('rejects a JWT when no verifier is wired (skipConnections)', async () => {
+      const apiKeyService = { getApiKeyByValue: jest.fn().mockRejectedValue(new Error('not an api key')) }
+      const organizationUserService = { findOne: jest.fn() }
+      const service = new BoxliteWsProxyService(
+        apiKeyService as never,
+        organizationUserService as never,
+        {} as never,
+        {} as never,
+        undefined as never, // JwtStrategy provider resolves to undefined under skipConnections
+      )
+      await expect(authenticate(service, bearer('jwt'), 'org-A')).resolves.toBeNull()
+    })
+
+    it('uses the `uid` claim as the user id when `cid` is present (OKTA shape)', async () => {
+      const { service, apiKeyService, organizationUserService, jwtStrategy } = makeService()
+      apiKeyService.getApiKeyByValue.mockRejectedValue(new Error('not an api key'))
+      jwtStrategy.verifyToken.mockResolvedValue({ sub: 'user@example.com', cid: 'client-1', uid: 'real-user-id' })
+      organizationUserService.findOne.mockResolvedValue({ organizationId: 'org-A', userId: 'real-user-id' })
+
+      await expect(authenticate(service, bearer('jwt'), 'org-A')).resolves.toEqual({ organizationId: 'org-A' })
+      expect(organizationUserService.findOne).toHaveBeenCalledWith('org-A', 'real-user-id')
+    })
+
+    it('rejects a request with no bearer token', async () => {
+      const { service } = makeService()
+      await expect(authenticate(service, { headers: {} } as IncomingMessage, 'org-A')).resolves.toBeNull()
+    })
   })
 })

--- a/apps/api/src/boxlite-rest/boxlite-ws-proxy.service.ts
+++ b/apps/api/src/boxlite-rest/boxlite-ws-proxy.service.ts
@@ -3,11 +3,12 @@
  * Copyright (c) 2025 BoxLite AI
  */
 
-import { Injectable, Logger } from '@nestjs/common'
+import { Inject, Injectable, Logger } from '@nestjs/common'
 import type { IncomingMessage } from 'http'
 import type { Socket } from 'net'
 import { createProxyMiddleware, type RequestHandler } from 'http-proxy-middleware'
 import { ApiKeyService } from '../api-key/api-key.service'
+import { JwtStrategy } from '../auth/jwt.strategy'
 import { OrganizationUserService } from '../organization/services/organization-user.service'
 import { BoxService } from '../box/services/box.service'
 import { RunnerService } from '../box/services/runner.service'
@@ -18,10 +19,10 @@ type RunnerUpgradeRequest = IncomingMessage & {
   __boxliteRunnerBoxId?: string
 }
 
-// Matches /api/v1/boxes/<id>/executions/<id>/attach and the legacy
+// Matches /api/v1/boxes/<id>/executions/<id>/attach and the
 // /api/v1/<tenant>/boxes/<id>/executions/<id>/attach shape with optional query string.
-// Capture group 1 is the box/box id.
-const ATTACH_PATH = /^\/api\/v1\/(?:[^/]+\/)?boxes\/([^/]+)\/executions\/[^/]+\/attach(?:\?.*)?$/
+// Named groups: `tenant` (optional org id / path prefix) and `boxId`.
+const ATTACH_PATH = /^\/api\/v1\/(?:(?<tenant>[^/]+)\/)?boxes\/(?<boxId>[^/]+)\/executions\/[^/]+\/attach(?:\?.*)?$/
 
 /**
  * Singleton WebSocket proxy for `/attach` upgrades.
@@ -44,6 +45,9 @@ export class BoxliteWsProxyService {
     private readonly organizationUserService: OrganizationUserService,
     private readonly boxService: BoxService,
     private readonly runnerService: RunnerService,
+    // Exported by AuthModule (already imported here). Resolves to `undefined`
+    // when `skipConnections` is set, so the JWT path guards on it.
+    @Inject(JwtStrategy) private readonly jwtStrategy: JwtStrategy | undefined,
   ) {
     this.proxy = createProxyMiddleware({
       ws: true,
@@ -76,12 +80,15 @@ export class BoxliteWsProxyService {
     })
   }
 
-  /** True when the request's URL is an `/attach` WS upgrade we should handle. */
-  matchAttachPath(url: string | undefined): { boxId: string } | null {
+  /**
+   * Box id (+ optional tenant/org id) when the URL is an `/attach` WS upgrade.
+   * The tenant is the organization for JWT auth (an API key carries its own org).
+   */
+  matchAttachPath(url: string | undefined): { boxId: string; tenant?: string } | null {
     if (!url) return null
-    const m = url.match(ATTACH_PATH)
-    if (!m) return null
-    return { boxId: m[1] }
+    const groups = url.match(ATTACH_PATH)?.groups as { boxId: string; tenant?: string } | undefined
+    if (!groups) return null
+    return { boxId: groups.boxId, tenant: groups.tenant }
   }
 
   /**
@@ -95,7 +102,7 @@ export class BoxliteWsProxyService {
       return
     }
 
-    const auth = await this.authenticate(req)
+    const auth = await this.authenticate(req, match.tenant)
     if (!auth) {
       this.respondAndClose(socket, 401, 'Unauthorized')
       return
@@ -132,40 +139,66 @@ export class BoxliteWsProxyService {
   }
 
   /**
-   * Inline API-key authentication for WS upgrades. Mirrors what the HTTP path
-   * gets from CombinedAuthGuard + OrganizationResourceActionGuard: the bearer
-   * must be a non-expired API key whose user is still a member of the key's
-   * organization. The membership check is critical — removing a user from an
-   * org deletes the OrganizationUser row but does not cascade to ApiKey rows,
-   * so without it a removed member's surviving key can still attach to
-   * boxes in that org.
+   * Inline authentication for WS upgrades, mirroring the API-key + JWT halves of
+   * CombinedAuthGuard. Membership-only, like the HTTP exec/attach routes
+   * (`BoxliteProxyController`), which carry no resource-permission decorator.
+   * Never throws — any failure resolves to `null` (a 401), so the fire-and-forget
+   * `upgrade` caller can't leak a hung socket.
    *
-   * JWT (the second strategy in CombinedAuthGuard) is unused here because
-   * clients send an opaque, long-lived API key directly as the Bearer
-   * token — there is no token-exchange step. If a JWT issuer is ever
-   * enabled in the auth pipeline, extend this method to fall through to
-   * `jwtVerify` after the API-key check fails.
+   * API key: the bearer must be a non-expired API key whose user is still a
+   * member of the key's organization. The membership check is critical —
+   * removing a user from an org deletes the OrganizationUser row but does not
+   * cascade to ApiKey rows, so without it a removed member's surviving key could
+   * still attach to boxes in that org. The URL tenant is ignored (key is scoped).
+   *
+   * JWT (OIDC): when the bearer is not an API key, verify it via `JwtStrategy`
+   * (same JWKS/issuer/audience as the HTTP path). A JWT carries no org, so the
+   * organization is taken from the URL `{prefix}` (`urlTenant`); a request with
+   * no tenant (or the legacy `default`) is rejected since the org is ambiguous
+   * for a multi-org user. Membership in that org is then required, identically to
+   * the API-key path. `jwtStrategy` is absent when `skipConnections` is set.
    *
    * Unlike the HTTP path, this does not consult the Redis cache used by
    * ApiKeyStrategy / OrganizationAccessGuard. Upgrade frequency is low; if
    * upgrade latency becomes a concern, add caching as a follow-up.
    */
-  private async authenticate(req: IncomingMessage): Promise<{ organizationId: string } | null> {
-    const header = req.headers['authorization']
-    const headerValue = Array.isArray(header) ? header[0] : header
-    if (!headerValue || !/^bearer\s+/i.test(headerValue)) return null
-    const token = headerValue.replace(/^bearer\s+/i, '').trim()
-    if (!token) return null
-
+  private async authenticate(req: IncomingMessage, urlTenant?: string): Promise<{ organizationId: string } | null> {
     try {
-      const apiKey = await this.apiKeyService.getApiKeyByValue(token)
-      if (apiKey.expiresAt && apiKey.expiresAt < new Date()) return null
+      const header = req.headers['authorization']
+      const headerValue = Array.isArray(header) ? header[0] : header
+      if (!headerValue || !/^bearer\s+/i.test(headerValue)) return null
+      const token = headerValue.replace(/^bearer\s+/i, '').trim()
+      if (!token) return null
 
-      const membership = await this.organizationUserService.findOne(apiKey.organizationId, apiKey.userId)
+      // 1. API key — org comes from the key itself; the URL tenant is ignored, as
+      //    before. A *throw* means "not an API key", so it is caught here to fall
+      //    through to JWT rather than being rejected by the outer guard.
+      const apiKey = await this.apiKeyService.getApiKeyByValue(token).catch(() => null)
+      if (apiKey) {
+        if (apiKey.expiresAt && apiKey.expiresAt < new Date()) return null
+        const membership = await this.organizationUserService.findOne(apiKey.organizationId, apiKey.userId)
+        if (!membership) return null
+        return { organizationId: apiKey.organizationId }
+      }
+
+      // 2. JWT (OIDC) — org comes from the URL tenant; membership required.
+      if (!this.jwtStrategy) return null
+      if (!urlTenant || urlTenant === 'default') return null
+      const payload = await this.jwtStrategy.verifyToken(token)
+      // Mirror JwtStrategy.validate's sub/uid handling (OKTA carries userId in `uid`).
+      const claims = payload as { sub?: string; cid?: unknown; uid?: string }
+      let userId = claims.sub
+      if (claims.cid && claims.uid) userId = claims.uid
+      if (!userId) return null
+
+      const membership = await this.organizationUserService.findOne(urlTenant, userId)
       if (!membership) return null
-
-      return { organizationId: apiKey.organizationId }
+      return { organizationId: urlTenant }
     } catch {
+      // Any failure (invalid JWT signature, a DB error, …) → 401. This single
+      // guard is why authenticate never throws — `upgrade` calls it before its
+      // own try-block and main.ts runs `void upgrade(...)`, so an escaped throw
+      // would leak a hung socket.
       return null
     }
   }


### PR DESCRIPTION
## What
The API's WS `/attach` proxy authenticated upgrades **only as an API key**, so a
browser/OIDC login (Auth0 JWT) — which works for REST — was rejected 401 on the
attach upgrade and cloud `exec` output never streamed. Closes #807. (PR #804
already made the CLI surface this loudly instead of a silent `exit 0`.)

## Change
`BoxliteWsProxyService.authenticate` now falls through to JWT when the bearer is
not an API key:
- verify via the existing `JwtStrategy.verifyToken` (same JWKS/issuer/audience as
  the HTTP path — no hand-rolled verification),
- map `sub`/`uid` like `JwtStrategy.validate`,
- take the org from the URL `{prefix}` tenant (`ATTACH_PATH` now captures it),
- require org membership — identical to the API-key path.

**Mirrors current behavior exactly** (per scope discussion): membership-only — no
permission gate (there is no `box:exec` permission and the HTTP exec/attach routes
enforce none), no rate-limiting, and a JWT with no/`default` tenant is rejected
(org ambiguous for a multi-org user). `JwtStrategy` is nullable under
`skipConnections`; `authenticate` never throws, so the fire-and-forget upgrade
caller can't leak a hung socket.

## Verification
- `boxlite-ws-proxy.service.spec.ts`: API-key regression + JWT
  member / non-member / cross-org / no-tenant / invalid-token / skipConnections /
  `uid`-claim, plus `matchAttachPath` tenant capture. Verified RED→GREEN (the JWT
  acceptance + membership-check tests fail when the JWT path is neutered).
- Full `nx test api` green (140 tests).

## ⚠️ Security review
Cross-org access boundary. The membership check
`organizationUserService.findOne(urlTenant, userId)` is what stops a JWT user
attaching to boxes in an org they don't belong to — please scrutinize that and
the URL-tenant extraction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket `/attach` upgrade authentication by adding tenant-aware routing and validating both API keys and JWTs with correct precedence.
  * Clarified legacy vs tenant-prefixed attach paths and ensured unauthorized connections are rejected cleanly.

* **Tests**
  * Expanded WebSocket authentication tests to cover tenant extraction, matching/non-matching attach paths, API-key and JWT authorization rules, claim mapping, and failure cases (including missing/invalid tokens and missing tenant context).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->