### PR TITLE
fix(api/box): reject per-box cpu/memory/disk over the org limit

### DIFF
--- a/apps/api/src/box/services/box.service.quota.spec.ts
+++ b/apps/api/src/box/services/box.service.quota.spec.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { BadRequestException } from '@nestjs/common'
+import { assertWithinPerBoxLimits } from './per-box-limits'
+
+const limits = { maxCpuPerBox: 4, maxMemoryPerBox: 8, maxDiskPerBox: 20 }
+
+describe('assertWithinPerBoxLimits', () => {
+  it('allows a request within the per-box limits', () => {
+    expect(() => assertWithinPerBoxLimits(4, 8, 20, limits)).not.toThrow()
+    expect(() => assertWithinPerBoxLimits(1, 1, 10, limits)).not.toThrow()
+  })
+
+  it('rejects cpu above the per-box limit (the cpu=999 leak)', () => {
+    expect(() => assertWithinPerBoxLimits(999, 8, 20, limits)).toThrow(BadRequestException)
+  })
+
+  it('rejects memory above the per-box limit (the 8 PiB leak)', () => {
+    // 8_192_000_000 MiB === the absurd value that used to be persisted.
+    expect(() => assertWithinPerBoxLimits(4, 8_192_000_000, 20, limits)).toThrow(BadRequestException)
+  })
+
+  it('rejects disk above the per-box limit', () => {
+    expect(() => assertWithinPerBoxLimits(4, 8, 9999, limits)).toThrow(BadRequestException)
+  })
+
+  it('reports every violated dimension in one message', () => {
+    expect(() => assertWithinPerBoxLimits(999, 999, 999, limits)).toThrow(/cpu .*memory .*disk/s)
+  })
+
+  it('treats a non-positive limit as unset (not enforced)', () => {
+    const unset = { maxCpuPerBox: 0, maxMemoryPerBox: 0, maxDiskPerBox: 0 }
+    expect(() => assertWithinPerBoxLimits(999, 999, 999, unset)).not.toThrow()
+  })
+})

--- a/apps/api/src/box/services/box.service.ts
+++ b/apps/api/src/box/services/box.service.ts
@@ -73,6 +73,7 @@ import {
 import { BoxLookupCacheInvalidationService } from './box-lookup-cache-invalidation.service'
 import { Region } from '../../region/entities/region.entity'
 import { BoxActivityService } from './box-activity.service'
+import { assertWithinPerBoxLimits } from './per-box-limits'
 
 // TODO(image-rewrite): resource defaults previously came from the removed image subsystem;
 // these mirror the Box entity column defaults until image resolution is rebuilt.
@@ -157,6 +158,9 @@ export class BoxService {
       const mem = createBoxDto.memory ?? DEFAULT_BOX_MEM
       const disk = createBoxDto.disk ?? DEFAULT_BOX_DISK
       const gpu = createBoxDto.gpu ?? DEFAULT_BOX_GPU
+      // Reject over-limit requests at the boundary (the "security option"
+      // per-box ceilings) rather than persisting out-of-range values.
+      assertWithinPerBoxLimits(cpu, mem, disk, organization)
       // Restrict box creation to the supported pinned images; reject anything else
       // at the request boundary (defaults undefined -> base image).
       const image = assertSupportedImage(createBoxDto.image)

--- a/apps/api/src/box/services/per-box-limits.ts
+++ b/apps/api/src/box/services/per-box-limits.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { BadRequestException } from '@nestjs/common'
+
+/** Per-box resource ceilings carried on the organization (the "security
+ * option" numbers). A value <= 0 means "unset" and is not enforced. */
+export interface PerBoxLimits {
+  maxCpuPerBox: number
+  maxMemoryPerBox: number
+  maxDiskPerBox: number
+}
+
+/**
+ * Reject a box create whose requested cpu / memory / disk exceeds the org's
+ * per-box limits, instead of silently storing out-of-range values. Without
+ * this, the API accepted absurd inputs (e.g. cpu=999, memory past 4 GiB) and
+ * persisted them, which then poisoned every list_info round-trip for the
+ * whole org. Memory and disk are compared in GB (the CreateBoxDto unit).
+ */
+export function assertWithinPerBoxLimits(
+  cpu: number,
+  memoryGb: number,
+  diskGb: number,
+  limits: PerBoxLimits,
+): void {
+  const violations: string[] = []
+  if (limits.maxCpuPerBox > 0 && cpu > limits.maxCpuPerBox) {
+    violations.push(`cpu ${cpu} exceeds the per-box limit of ${limits.maxCpuPerBox}`)
+  }
+  if (limits.maxMemoryPerBox > 0 && memoryGb > limits.maxMemoryPerBox) {
+    violations.push(`memory ${memoryGb}GB exceeds the per-box limit of ${limits.maxMemoryPerBox}GB`)
+  }
+  if (limits.maxDiskPerBox > 0 && diskGb > limits.maxDiskPerBox) {
+    violations.push(`disk ${diskGb}GB exceeds the per-box limit of ${limits.maxDiskPerBox}GB`)
+  }
+  if (violations.length > 0) {
+    throw new BadRequestException(`Requested resources exceed per-box limits: ${violations.join('; ')}`)
+  }
+}


### PR DESCRIPTION
## Problem

Box create accepted whatever `cpu` / `memory` / `disk` the client sent and persisted it verbatim. A garbage request (e.g. `cpu=999`, or memory past the org ceiling) was stored, then poisoned every `list_info` round-trip for the whole org.

The C SDK "tolerate widened `cpus`/`memory_mib`" change (dropped from #808) was only papering over this — widening the wire types just lets the bad value travel further. The real defect is the **server accepting the value at all**.

## Fix

Validate at the create boundary against the organization's per-box ceilings — `maxCpuPerBox` / `maxMemoryPerBox` / `maxDiskPerBox`, the same "security option" numbers already on the `Organization` entity — and return **400** when exceeded. A non-positive limit means "unset" and is not enforced, matching the existing quota-zero default.

The check lives in a small standalone `per-box-limits.ts` module so it unit-tests in isolation without dragging in the `Box` entity (whose `nanoid` import is ESM-only and breaks the jest transform).

## Tests

`box.service.quota.spec.ts` — 6 cases (within-limit allowed; cpu/memory/disk over-limit rejected; all-dimensions reported; non-positive limit treated as unset). Two-side verified: neutering the function fails the 4 reject cases; restoring passes all 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-box resource limit enforcement during box creation to validate CPU, memory, and disk allocations against configured organizational ceilings, rejecting out-of-range requests with clear error messages (including when multiple limits are exceeded).

* **Tests**
  * Added comprehensive unit tests covering within-limit behavior, individual and multi-dimension overage errors, and behavior when limits are unset (non-positive values).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->