### PR TITLE
fix(ffi): isolate exec stream delivery and backpressure

### DIFF
--- a/apps/runner/pkg/api/controllers/boxlite_exec_attach.go
+++ b/apps/runner/pkg/api/controllers/boxlite_exec_attach.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/boxlite-ai/runner/pkg/boxlite"
@@ -207,6 +208,11 @@ func runAttachLoop(parentCtx context.Context, conn *websocket.Conn, exec attachE
 	// across reattach cycles.
 	stdoutCh, stderrCh, unsubscribe := exec.Subscribe(attachSubscriberBuffer)
 
+	// Monotonic count of stream frames written to the client. The post-Done
+	// drain watches it to bound the wait by progress, not a fixed wall clock
+	// (see the drain block below).
+	var streamProgress atomic.Uint64
+
 	defer func() {
 		// Recover from any panic so we don't leak the connection.
 		if r := recover(); r != nil {
@@ -230,7 +236,7 @@ func runAttachLoop(parentCtx context.Context, conn *websocket.Conn, exec attachE
 	pumpWg.Add(1)
 	go func() {
 		defer pumpWg.Done()
-		pumpSubscriberChannel(loopCtx, conn, &writeMu, stdoutCh, chanStdout, fail)
+		pumpSubscriberChannel(loopCtx, conn, &writeMu, stdoutCh, chanStdout, &streamProgress, fail)
 	}()
 
 	// stderr pump (for non-TTY only — TTY merges at the kernel, so stderr
@@ -239,7 +245,7 @@ func runAttachLoop(parentCtx context.Context, conn *websocket.Conn, exec attachE
 		pumpWg.Add(1)
 		go func() {
 			defer pumpWg.Done()
-			pumpSubscriberChannel(loopCtx, conn, &writeMu, stderrCh, chanStderr, fail)
+			pumpSubscriberChannel(loopCtx, conn, &writeMu, stderrCh, chanStderr, &streamProgress, fail)
 		}()
 	}
 
@@ -278,21 +284,31 @@ func runAttachLoop(parentCtx context.Context, conn *websocket.Conn, exec attachE
 			pumpWg.Wait()
 			close(pumpsDone)
 		}()
-		drained := false
-		select {
-		case <-pumpsDone:
-			drained = true
-		case <-time.After(2 * time.Second):
-		}
 
+		// Bound the drain by progress, not a fixed wall clock. Done has
+		// fired, so the exit code is authoritative and any remaining output
+		// is already buffered in the subscriber channels — it should flush
+		// back-to-back. A pump still writing keeps bumping streamProgress, so
+		// we keep waiting and never send the exit frame ahead of a large tail
+		// that is still in flight; a pump whose guest pipe never EOFs (a
+		// SIGTERM→SIGKILL'd process) stops bumping it, so we give up after an
+		// idle window and send exit anyway.
+		drained := waitForStreamDrain(pumpsDone, &streamProgress, streamDrainIdleBound, streamDrainHardCap)
+
+		// Send the exit frame regardless of whether the pumps drained: a
+		// process killed by its exec timeout (SIGTERM→SIGKILL in the guest)
+		// can leave the guest's stdout/stderr pipes without a natural EOF, so
+		// the pumps may never finish. Gating the exit frame on drain (the
+		// old behaviour) then dropped the frame entirely on the drain
+		// timeout, hanging the client's wait() forever.
+		_ = writeJSONFrame(conn, &writeMu, map[string]any{
+			"type":      "exit",
+			"exit_code": exec.ExitCodeValue(),
+		})
 		if drained {
-			_ = writeJSONFrame(conn, &writeMu, map[string]any{
-				"type":      "exit",
-				"exit_code": exec.ExitCodeValue(),
-			})
 			closeWS(websocket.CloseNormalClosure, "")
 		} else {
-			closeWS(websocket.CloseInternalServerErr, "pump drain timed out")
+			closeWS(websocket.CloseNormalClosure, "exit sent; output pumps did not drain")
 		}
 	}
 
@@ -310,11 +326,53 @@ func runAttachLoop(parentCtx context.Context, conn *websocket.Conn, exec attachE
 // starts dropping chunks for a slow consumer.
 const attachSubscriberBuffer = 256
 
+// streamDrainIdleBound is how long the post-Done drain tolerates no new
+// stream frame before treating the pipe as stuck and sending exit. The drain
+// starts only after Done, so buffered output flushes back-to-back; a full
+// window with no progress means a guest pipe that will never EOF (a
+// signal-killed process). Large enough to absorb scheduler/transport jitter,
+// small enough that a timeout-killed exec reports promptly.
+const streamDrainIdleBound = 300 * time.Millisecond
+
+// streamDrainHardCap backstops a pipe that never EOFs yet keeps trickling a
+// frame within every idle window forever. Generous so it never clips a
+// genuine high-throughput tail.
+const streamDrainHardCap = 30 * time.Second
+
+// waitForStreamDrain blocks until the stream pumps finish (clean drain), the
+// stream goes idle (no progress within idleBound — a stuck never-EOF pipe), or
+// hardCap elapses (backstop for a pipe that trickles forever). Returns true
+// only when the pumps fully drained. Bounding by progress rather than a fixed
+// wall clock keeps a still-delivering tail from being cut off ahead of the
+// exit frame.
+func waitForStreamDrain(pumpsDone <-chan struct{}, progress *atomic.Uint64, idleBound, hardCap time.Duration) bool {
+	idle := time.NewTicker(idleBound)
+	defer idle.Stop()
+	cap := time.NewTimer(hardCap)
+	defer cap.Stop()
+
+	lastProgress := progress.Load()
+	for {
+		select {
+		case <-pumpsDone:
+			return true
+		case <-cap.C:
+			return false
+		case <-idle.C:
+			now := progress.Load()
+			if now == lastProgress {
+				return false
+			}
+			lastProgress = now
+		}
+	}
+}
+
 // pumpSubscriberChannel forwards chunks from a broadcaster subscriber channel
 // to the WebSocket, prefixing each with the channel byte. Exits cleanly on
 // ctx cancellation, channel close (broadcaster ended / unsubscribed), or write
 // error.
-func pumpSubscriberChannel(ctx context.Context, conn *websocket.Conn, writeMu *sync.Mutex, ch <-chan []byte, channel byte, fail func(error)) {
+func pumpSubscriberChannel(ctx context.Context, conn *websocket.Conn, writeMu *sync.Mutex, ch <-chan []byte, channel byte, progress *atomic.Uint64, fail func(error)) {
 	for {
 		select {
 		case <-ctx.Done():
@@ -330,6 +388,10 @@ func pumpSubscriberChannel(ctx context.Context, conn *websocket.Conn, writeMu *s
 				fail(fmt.Errorf("write %s frame: %w", channelName(channel), werr))
 				return
 			}
+			// Record forward progress so the post-Done drain can tell a
+			// still-delivering stream (keep waiting) from a stuck never-EOF
+			// pipe (send exit anyway).
+			progress.Add(1)
 		}
 	}
 }

--- a/apps/runner/pkg/api/controllers/boxlite_exec_attach.go
+++ b/apps/runner/pkg/api/controllers/boxlite_exec_attach.go
@@ -64,7 +64,9 @@ type attachExec interface {
 	// channels plus a cancel function that must be called when the /attach
 	// session ends. The broadcaster owns the underlying pipe readers for
 	// the exec's lifetime, so there is no stale-pump race on reattach.
-	Subscribe(bufSize int) (stdout, stderr <-chan []byte, cancel func())
+	// dropped reports the cumulative bytes this subscriber lost to
+	// back-pressure (slow client); the handler surfaces it as a lag warning.
+	Subscribe(bufSize int) (stdout, stderr <-chan []byte, dropped func() uint64, cancel func())
 
 	WriteStdin(data []byte) (int, error)
 	DoneCh() <-chan struct{}
@@ -206,7 +208,7 @@ func runAttachLoop(parentCtx context.Context, conn *websocket.Conn, exec attachE
 	// from bounded channels that respond to ctx cancellation cleanly.
 	// Unsubscribe is deferred so the subscriber slice cannot grow unbounded
 	// across reattach cycles.
-	stdoutCh, stderrCh, unsubscribe := exec.Subscribe(attachSubscriberBuffer)
+	stdoutCh, stderrCh, dropped, unsubscribe := exec.Subscribe(attachSubscriberBuffer)
 
 	// Monotonic count of stream frames written to the client. The post-Done
 	// drain watches it to bound the wait by progress, not a fixed wall clock
@@ -294,6 +296,16 @@ func runAttachLoop(parentCtx context.Context, conn *websocket.Conn, exec attachE
 		// SIGTERM→SIGKILL'd process) stops bumping it, so we give up after an
 		// idle window and send exit anyway.
 		drained := waitForStreamDrain(pumpsDone, &streamProgress, streamDrainIdleBound, streamDrainHardCap)
+
+		// If this client lagged enough that the broadcaster dropped output for
+		// it, tell it so before the terminal exit frame — its captured stream
+		// is incomplete by that many bytes.
+		if n := dropped(); n > 0 {
+			_ = writeJSONFrame(conn, &writeMu, map[string]any{
+				"type":    "warning",
+				"message": fmt.Sprintf("%d bytes dropped (slow consumer)", n),
+			})
+		}
 
 		// Send the exit frame regardless of whether the pumps drained: a
 		// process killed by its exec timeout (SIGTERM→SIGKILL in the guest)
@@ -540,9 +552,10 @@ type managedExecAttach struct {
 	me *boxlite.ManagedExec
 }
 
-func (m managedExecAttach) Subscribe(bufSize int) (stdout, stderr <-chan []byte, cancel func()) {
+func (m managedExecAttach) Subscribe(bufSize int) (stdout, stderr <-chan []byte, dropped func() uint64, cancel func()) {
 	outSub, errSub, cancel := m.me.Subscribe(bufSize)
-	return outSub.Chan(), errSub.Chan(), cancel
+	dropped = func() uint64 { return outSub.Dropped() + errSub.Dropped() }
+	return outSub.Chan(), errSub.Chan(), dropped, cancel
 }
 
 func (m managedExecAttach) WriteStdin(data []byte) (int, error) { return m.me.AttachWriteStdin(data) }

--- a/apps/runner/pkg/api/controllers/boxlite_exec_attach_test.go
+++ b/apps/runner/pkg/api/controllers/boxlite_exec_attach_test.go
@@ -52,6 +52,10 @@ type stubAttachExec struct {
 	subMu        sync.Mutex
 	subs         []stubSubscriber
 	broadcasting bool
+
+	// droppedN is returned by the Subscribe dropped() accessor so tests can
+	// exercise the slow-consumer lag-warning path.
+	droppedN uint64
 }
 
 type stubSubscriber struct {
@@ -107,7 +111,7 @@ func (s *stubAttachExec) Subscribe(bufSize int) (stdout, stderr <-chan []byte, d
 			close(errCh)
 		})
 	}
-	return outCh, errCh, func() uint64 { return 0 }, cancel
+	return outCh, errCh, func() uint64 { return s.droppedN }, cancel
 }
 
 // broadcastPipe is the test-side analog of ManagedExec.broadcastPipe. Same

--- a/apps/runner/pkg/api/controllers/boxlite_exec_attach_test.go
+++ b/apps/runner/pkg/api/controllers/boxlite_exec_attach_test.go
@@ -76,7 +76,7 @@ func newStubAttachExec() *stubAttachExec {
 // production fan-out broadcaster); each subscriber gets its own channels and
 // sees all subsequent bytes. The pump goroutines exit when the stdout/stderr
 // pipes EOF or when the subscriber is cancelled.
-func (s *stubAttachExec) Subscribe(bufSize int) (stdout, stderr <-chan []byte, cancel func()) {
+func (s *stubAttachExec) Subscribe(bufSize int) (stdout, stderr <-chan []byte, dropped func() uint64, cancel func()) {
 	if bufSize <= 0 {
 		bufSize = 256
 	}
@@ -107,7 +107,7 @@ func (s *stubAttachExec) Subscribe(bufSize int) (stdout, stderr <-chan []byte, c
 			close(errCh)
 		})
 	}
-	return outCh, errCh, cancel
+	return outCh, errCh, func() uint64 { return 0 }, cancel
 }
 
 // broadcastPipe is the test-side analog of ManagedExec.broadcastPipe. Same

--- a/apps/runner/pkg/api/controllers/boxlite_exec_attach_test.go
+++ b/apps/runner/pkg/api/controllers/boxlite_exec_attach_test.go
@@ -664,3 +664,87 @@ func TestBoxliteExecAttach_NotFound(t *testing.T) {
 		t.Fatalf("expected 404, got %v err=%v", resp, err)
 	}
 }
+
+// TestWaitForStreamDrain pins the post-Done drain semantics: it must keep
+// waiting while the stream is still delivering (so the exit frame never jumps
+// ahead of a large in-flight tail), give up promptly when a never-EOF pipe
+// goes idle, and fall back to a hard cap if a pipe trickles forever.
+func TestWaitForStreamDrain(t *testing.T) {
+	t.Run("waits for a still-delivering stream then reports drained", func(t *testing.T) {
+		var progress atomic.Uint64
+		pumpsDone := make(chan struct{})
+		// Deliver steadily for ~2.5s — past any 2s-style fixed cap — with
+		// each gap (50ms) under idleBound (100ms) so it never looks idle,
+		// then signal the pumps finished. The old fixed 2s cap would return
+		// drained=false here (cut the tail off); the idle bound waits it out.
+		go func() {
+			for i := 0; i < 50; i++ {
+				time.Sleep(50 * time.Millisecond)
+				progress.Add(1)
+			}
+			close(pumpsDone)
+		}()
+
+		start := time.Now()
+		drained := waitForStreamDrain(pumpsDone, &progress, 100*time.Millisecond, 30*time.Second)
+		elapsed := time.Since(start)
+
+		if !drained {
+			t.Fatal("expected drained=true: a stream still making progress must " +
+				"not be cut off before its pumps finish")
+		}
+		if elapsed < 2400*time.Millisecond {
+			t.Fatalf("returned after %v: gave up before the stream finished "+
+				"delivering (a fixed 2s cap would do this)", elapsed)
+		}
+	})
+
+	t.Run("gives up after one idle window on a stuck pipe", func(t *testing.T) {
+		var progress atomic.Uint64 // never bumped: a never-EOF pipe
+		pumpsDone := make(chan struct{})
+
+		start := time.Now()
+		drained := waitForStreamDrain(pumpsDone, &progress, 100*time.Millisecond, 10*time.Second)
+		elapsed := time.Since(start)
+
+		if drained {
+			t.Fatal("expected drained=false: a stuck pipe never finishes")
+		}
+		if elapsed > 2*time.Second {
+			t.Fatalf("took %v to give up on an idle stream; should release "+
+				"within ~idleBound so exit reports promptly", elapsed)
+		}
+	})
+
+	t.Run("falls back to hard cap when a pipe trickles forever", func(t *testing.T) {
+		var progress atomic.Uint64
+		pumpsDone := make(chan struct{})
+		stop := make(chan struct{})
+		defer close(stop)
+		// Bump within every idle window forever so the idle branch never
+		// fires; only the hard cap can break the wait.
+		go func() {
+			tick := time.NewTicker(20 * time.Millisecond)
+			defer tick.Stop()
+			for {
+				select {
+				case <-stop:
+					return
+				case <-tick.C:
+					progress.Add(1)
+				}
+			}
+		}()
+
+		start := time.Now()
+		drained := waitForStreamDrain(pumpsDone, &progress, 100*time.Millisecond, 300*time.Millisecond)
+		elapsed := time.Since(start)
+
+		if drained {
+			t.Fatal("expected drained=false: pumps never finished")
+		}
+		if elapsed < 250*time.Millisecond || elapsed > 1500*time.Millisecond {
+			t.Fatalf("expected release near the 300ms hard cap, got %v", elapsed)
+		}
+	})
+}

--- a/apps/runner/pkg/api/controllers/boxlite_exec_attach_test.go
+++ b/apps/runner/pkg/api/controllers/boxlite_exec_attach_test.go
@@ -718,6 +718,10 @@ func TestWaitForStreamDrain(t *testing.T) {
 			t.Fatalf("took %v to give up on an idle stream; should release "+
 				"within ~idleBound so exit reports promptly", elapsed)
 		}
+		if elapsed < 80*time.Millisecond {
+			t.Fatalf("gave up after only %v; expected it to wait ~one idle "+
+				"window (100ms) before declaring the stream stuck", elapsed)
+		}
 	})
 
 	t.Run("falls back to hard cap when a pipe trickles forever", func(t *testing.T) {

--- a/apps/runner/pkg/api/controllers/exec_attach_drain_matrix_test.go
+++ b/apps/runner/pkg/api/controllers/exec_attach_drain_matrix_test.go
@@ -173,3 +173,52 @@ func TestAttachDrainMatrix(t *testing.T) {
 		})
 	}
 }
+
+// TestAttachLagWarning verifies FIX #3: when the broadcaster dropped output for
+// a slow client (dropped() > 0), the handler surfaces a `warning` frame before
+// the exit frame.
+func TestAttachLagWarning(t *testing.T) {
+	stub := newStubAttachExec()
+	stub.exitCode = 0
+	stub.droppedN = 42
+	cleanup := withStubExec(t, "exec-lag", stub)
+	defer cleanup()
+	srv := newAttachServer(t)
+	defer srv.Close()
+	conn, _, err := dialAttach(t, srv, "exec-lag")
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	go func() { stub.stdoutW.Close(); close(stub.done) }()
+
+	sawWarning := false
+	for {
+		_ = conn.SetReadDeadline(time.Now().Add(10 * time.Second))
+		mt, payload, err := conn.ReadMessage()
+		if err != nil {
+			break
+		}
+		if mt != websocket.TextMessage {
+			continue
+		}
+		var ev map[string]any
+		if json.Unmarshal(payload, &ev) != nil {
+			continue
+		}
+		switch ev["type"] {
+		case "warning":
+			if msg, _ := ev["message"].(string); !strings.Contains(msg, "42 bytes dropped") {
+				t.Fatalf("warning message = %q, want it to mention 42 bytes dropped", msg)
+			}
+			sawWarning = true
+		case "exit":
+			if !sawWarning {
+				t.Fatal("exit frame arrived but no lag warning was sent despite dropped()=42")
+			}
+			return
+		}
+	}
+	t.Fatal("no exit frame seen")
+}

--- a/apps/runner/pkg/api/controllers/exec_attach_drain_matrix_test.go
+++ b/apps/runner/pkg/api/controllers/exec_attach_drain_matrix_test.go
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+package controllers
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// drainResult is what attachDrainOutcome observed driving one /attach session.
+type drainResult struct {
+	exitSeen    bool
+	stdoutBytes int
+	stderrBytes int
+	trailing    int // stream bytes that arrived AFTER the exit frame (ordering)
+}
+
+// attachDrainOutcome drives the real BoxliteExecAttach handler over a websocket
+// with the given stub producer, then reports what the client observed. producer
+// performs the stream writes, EOFs, and fires Done. tty selects TTY mode (the
+// handler then runs only the stdout pump). Reads stop once the exit frame and
+// any trailing frames are seen, or after a hang deadline.
+func attachDrainOutcome(t *testing.T, tty bool, exitCode int, producer func(s *stubAttachExec)) drainResult {
+	t.Helper()
+	const stdoutByte, stderrByte = 0x01, 0x02
+
+	stub := newStubAttachExec()
+	stub.exitCode = exitCode
+	stub.tty = tty
+	cleanup := withStubExec(t, "exec-matrix", stub)
+	defer cleanup()
+	srv := newAttachServer(t)
+	defer srv.Close()
+	conn, _, err := dialAttach(t, srv, "exec-matrix")
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	go producer(stub)
+
+	var r drainResult
+	seenExit := false
+	count := func(payload []byte) {
+		if len(payload) < 1 {
+			return
+		}
+		n := len(payload) - 1
+		switch payload[0] {
+		case stdoutByte:
+			r.stdoutBytes += n
+		case stderrByte:
+			r.stderrBytes += n
+		}
+		if seenExit {
+			r.trailing += n
+		}
+	}
+
+	for {
+		_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+		mt, payload, err := conn.ReadMessage()
+		if err != nil {
+			return r // deadline/close without exit => HANG (exitSeen stays false)
+		}
+		switch mt {
+		case websocket.BinaryMessage:
+			count(payload)
+		case websocket.TextMessage:
+			var ev map[string]any
+			if json.Unmarshal(payload, &ev) == nil && ev["type"] == "exit" {
+				r.exitSeen = true
+				seenExit = true
+				// Drain any trailing frames briefly to catch ordering bugs.
+				_ = conn.SetReadDeadline(time.Now().Add(400 * time.Millisecond))
+				for {
+					mt2, p2, e2 := conn.ReadMessage()
+					if e2 != nil {
+						return r
+					}
+					if mt2 == websocket.BinaryMessage {
+						count(p2)
+					}
+				}
+			}
+		}
+	}
+}
+
+// TestAttachDrainMatrix locks down PR #812's runner-side drain across the
+// (output x stream-termination) matrix: clean exits flush all output with the
+// exit frame strictly last; a SIGKILLed never-EOF pipe gives up after the idle
+// window and still sends exit instead of hanging.
+func TestAttachDrainMatrix(t *testing.T) {
+	big := strings.Repeat("a", 64*1024) // 16 chunks < 256 channel buffer: lossless
+
+	cases := []struct {
+		name       string
+		tty        bool
+		wantStdout int
+		wantStderr int
+		producer   func(s *stubAttachExec)
+	}{
+		{"clean-none", false, 0, 0, func(s *stubAttachExec) {
+			s.stdoutW.Close()
+			close(s.done)
+		}},
+		{"clean-short", false, 2, 0, func(s *stubAttachExec) {
+			s.stdoutW.Write([]byte("hi"))
+			s.stdoutW.Close()
+			close(s.done)
+		}},
+		{"clean-long-64k", false, len(big), 0, func(s *stubAttachExec) {
+			s.stdoutW.Write([]byte(big))
+			s.stdoutW.Close()
+			close(s.done)
+		}},
+		{"stderr-channel", false, 3, 7, func(s *stubAttachExec) {
+			s.stdoutW.Write([]byte("OUT"))
+			s.stderrW.Write([]byte("ERRLINE"))
+			s.stdoutW.Close()
+			s.stderrW.Close()
+			close(s.done)
+		}},
+		{"tty-merged", true, 9, 0, func(s *stubAttachExec) {
+			s.stdoutW.Write([]byte("hello-tty"))
+			s.stdoutW.Close()
+			s.stderrW.Close()
+			close(s.done)
+		}},
+		{"stuck-never-eof", false, 2, 0, func(s *stubAttachExec) {
+			// SIGKILLed guest: exit is known (Done) but stdout never EOFs.
+			s.stdoutW.Write([]byte("hi"))
+			close(s.done)
+			// deliberately never close stdoutW
+		}},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			r := attachDrainOutcome(t, c.tty, 7, c.producer)
+			if !r.exitSeen {
+				t.Fatalf("HANG: no exit frame within deadline (%s)", c.name)
+			}
+			if r.trailing != 0 {
+				t.Fatalf("ORDERING: %d stream bytes arrived AFTER the exit frame", r.trailing)
+			}
+			if r.stdoutBytes != c.wantStdout {
+				t.Fatalf("stdout: got %d want %d", r.stdoutBytes, c.wantStdout)
+			}
+			if r.stderrBytes != c.wantStderr {
+				t.Fatalf("stderr: got %d want %d", r.stderrBytes, c.wantStderr)
+			}
+		})
+	}
+}

--- a/apps/runner/pkg/api/controllers/exec_attach_drain_matrix_test.go
+++ b/apps/runner/pkg/api/controllers/exec_attach_drain_matrix_test.go
@@ -63,7 +63,7 @@ func attachDrainOutcome(t *testing.T, tty bool, exitCode int, producer func(s *s
 	}
 
 	for {
-		_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+		_ = conn.SetReadDeadline(time.Now().Add(15 * time.Second))
 		mt, payload, err := conn.ReadMessage()
 		if err != nil {
 			return r // deadline/close without exit => HANG (exitSeen stays false)
@@ -77,7 +77,7 @@ func attachDrainOutcome(t *testing.T, tty bool, exitCode int, producer func(s *s
 				r.exitSeen = true
 				seenExit = true
 				// Drain any trailing frames briefly to catch ordering bugs.
-				_ = conn.SetReadDeadline(time.Now().Add(400 * time.Millisecond))
+				_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
 				for {
 					mt2, p2, e2 := conn.ReadMessage()
 					if e2 != nil {
@@ -99,6 +99,14 @@ func attachDrainOutcome(t *testing.T, tty bool, exitCode int, producer func(s *s
 func TestAttachDrainMatrix(t *testing.T) {
 	big := strings.Repeat("a", 64*1024) // 16 chunks < 256 channel buffer: lossless
 
+	// fireDone models Exit-strictly-last: settle so the broadcaster fully fans
+	// out everything the producer wrote before exit is observed, otherwise
+	// close(done) -> unsubscribe races the fan-out and can drop trailing bytes.
+	fireDone := func(s *stubAttachExec) {
+		time.Sleep(50 * time.Millisecond)
+		close(s.done)
+	}
+
 	cases := []struct {
 		name       string
 		tty        bool
@@ -108,35 +116,40 @@ func TestAttachDrainMatrix(t *testing.T) {
 	}{
 		{"clean-none", false, 0, 0, func(s *stubAttachExec) {
 			s.stdoutW.Close()
-			close(s.done)
+			fireDone(s)
 		}},
 		{"clean-short", false, 2, 0, func(s *stubAttachExec) {
 			s.stdoutW.Write([]byte("hi"))
 			s.stdoutW.Close()
-			close(s.done)
+			fireDone(s)
 		}},
 		{"clean-long-64k", false, len(big), 0, func(s *stubAttachExec) {
 			s.stdoutW.Write([]byte(big))
 			s.stdoutW.Close()
-			close(s.done)
+			fireDone(s)
 		}},
 		{"stderr-channel", false, 3, 7, func(s *stubAttachExec) {
 			s.stdoutW.Write([]byte("OUT"))
 			s.stderrW.Write([]byte("ERRLINE"))
 			s.stdoutW.Close()
 			s.stderrW.Close()
-			close(s.done)
+			fireDone(s)
 		}},
 		{"tty-merged", true, 9, 0, func(s *stubAttachExec) {
 			s.stdoutW.Write([]byte("hello-tty"))
 			s.stdoutW.Close()
 			s.stderrW.Close()
-			close(s.done)
+			fireDone(s)
 		}},
 		{"stuck-never-eof", false, 2, 0, func(s *stubAttachExec) {
 			// SIGKILLed guest: exit is known (Done) but stdout never EOFs.
+			// Model Exit-strictly-last: the "hi" the process emitted is fully
+			// delivered before its exit is observed. Without the settle the stub
+			// races close(done) (-> unsubscribe) against the broadcaster's
+			// fan-out and can drop "hi" (in-process delivery is microseconds;
+			// the settle is many orders of margin).
 			s.stdoutW.Write([]byte("hi"))
-			close(s.done)
+			fireDone(s)
 			// deliberately never close stdoutW
 		}},
 	}

--- a/apps/runner/pkg/boxlite/stream_drop_test.go
+++ b/apps/runner/pkg/boxlite/stream_drop_test.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+package boxlite
+
+import "testing"
+
+// TestStreamBusDropsOnSlowSubscriber locks down the per-subscriber back-pressure
+// drop: when a subscriber's channel is full (a stalled /attach client), the
+// non-blocking fan-out drops the chunk and accounts it in Dropped() rather than
+// blocking the producer or every other subscriber. This is the path behind the
+// "slow consumer loses bytes" behavior; the test makes it explicit and counted.
+func TestStreamBusDropsOnSlowSubscriber(t *testing.T) {
+	bus := newStreamBus(1 << 20) // large backlog cap; not under test here
+	const chBuf = 2
+	sub, cancel := bus.Subscribe(chBuf)
+	defer cancel()
+
+	// Never read from sub.Chan(): the subscriber is stalled.
+	const chunk = "0123456789" // 10 bytes
+	const writes = 10
+	for i := 0; i < writes; i++ {
+		if _, err := bus.Write([]byte(chunk)); err != nil {
+			t.Fatalf("Write %d: %v", i, err)
+		}
+	}
+
+	// The first chBuf chunks buffer in the channel; every later chunk is
+	// dropped and counted. The producer must never block.
+	wantDropped := uint64((writes - chBuf) * len(chunk))
+	if got := sub.Dropped(); got != wantDropped {
+		t.Fatalf("Dropped() = %d, want %d (buffered %d chunks, dropped the rest)",
+			got, wantDropped, chBuf)
+	}
+}

--- a/sdks/c/cbindgen.toml
+++ b/sdks/c/cbindgen.toml
@@ -14,3 +14,8 @@ usize_is_size_t = true
 
 [parse]
 parse_deps = false
+
+[export]
+exclude = [
+    "boxlite_execution_set_stream_paused",
+]

--- a/sdks/c/include/boxlite.h
+++ b/sdks/c/include/boxlite.h
@@ -417,6 +417,16 @@ enum BoxliteErrorCode boxlite_execution_stdin_write(CExecutionHandle *execution,
 enum BoxliteErrorCode boxlite_execution_stdin_close(CExecutionHandle *execution,
                                                     CBoxliteError *out_error);
 
+// Pause (paused != 0) or resume (paused == 0) delivery of this execution's
+// stdout/stderr. While paused, the stream pumps stop reading their bounded
+// upstream channel, which fills and back-pressures the guest process's
+// write() — letting a slow consumer throttle the producer instead of buffering
+// unboundedly. The Go SDK drives this from its delivery queue's high/low-water
+// marks. Idempotent; safe to call repeatedly.
+enum BoxliteErrorCode boxlite_execution_set_stream_paused(CExecutionHandle *execution,
+                                                          int paused,
+                                                          CBoxliteError *out_error);
+
 enum BoxliteErrorCode boxlite_execution_wait(CExecutionHandle *execution,
                                              CExecutionWaitCb cb,
                                              void *user_data,

--- a/sdks/c/include/boxlite.h
+++ b/sdks/c/include/boxlite.h
@@ -417,16 +417,6 @@ enum BoxliteErrorCode boxlite_execution_stdin_write(CExecutionHandle *execution,
 enum BoxliteErrorCode boxlite_execution_stdin_close(CExecutionHandle *execution,
                                                     CBoxliteError *out_error);
 
-// Pause (paused != 0) or resume (paused == 0) delivery of this execution's
-// stdout/stderr. While paused, the stream pumps stop reading their bounded
-// upstream channel, which fills and back-pressures the guest process's
-// write() — letting a slow consumer throttle the producer instead of buffering
-// unboundedly. The Go SDK drives this from its delivery queue's high/low-water
-// marks. Idempotent; safe to call repeatedly.
-enum BoxliteErrorCode boxlite_execution_set_stream_paused(CExecutionHandle *execution,
-                                                          int paused,
-                                                          CBoxliteError *out_error);
-
 enum BoxliteErrorCode boxlite_execution_wait(CExecutionHandle *execution,
                                              CExecutionWaitCb cb,
                                              void *user_data,

--- a/sdks/c/src/exec/execution.rs
+++ b/sdks/c/src/exec/execution.rs
@@ -928,6 +928,7 @@ mod tests {
             tokio_rt: runtime,
             process_completed: Arc::new(AtomicBool::new(false)),
             exit_dispatched: Arc::new(AtomicBool::new(false)),
+            stream_paused: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -1404,7 +1405,7 @@ mod tests {
         ];
         let stream = stream_iter(chunks.into_iter());
 
-        stdout_pump(stream, noop_stdout_cb, 0xFEED_DEAD, queue.clone(), done_tx).await;
+        stdout_pump(stream, noop_stdout_cb, 0xFEED_DEAD, queue.clone(), Arc::new(AtomicBool::new(false)), done_tx).await;
 
         let bytes = drain_stdout_bytes(&queue);
         assert_eq!(bytes.len(), 4, "expected 4 stdout events");
@@ -1430,7 +1431,7 @@ mod tests {
         let chunks = vec!["error".to_string(), "trace".to_string()];
         let stream = stream_iter(chunks.into_iter());
 
-        stderr_pump(stream, noop_stderr_cb, 0xCAFE_BABE, queue.clone(), done_tx).await;
+        stderr_pump(stream, noop_stderr_cb, 0xCAFE_BABE, queue.clone(), Arc::new(AtomicBool::new(false)), done_tx).await;
 
         let bytes = drain_stderr_bytes(&queue);
         assert_eq!(bytes.len(), 2);

--- a/sdks/c/src/exec/execution.rs
+++ b/sdks/c/src/exec/execution.rs
@@ -766,7 +766,8 @@ unsafe fn execution_free(execution: *mut ExecutionHandle) {
 /// Block while the execution's stream is paused (Go-side back-pressure). The
 /// pump calls this AFTER delivering a chunk so it stops reading the next one
 /// from the bounded upstream channel — which then fills and back-pressures the
-/// guest. Sleep-poll (2ms) is coarse but cheap; pauses are seconds-scale.
+/// guest. Blocks on the watch channel (zero CPU) until the pause flag changes,
+/// so resumes wake the pump immediately; pauses are seconds-scale.
 async fn await_unpaused(rx: &mut watch::Receiver<bool>) {
     // Block (zero CPU) while paused; wake on the next pause-flag change. watch
     // is version-tracked, so a resume that races the check is never missed. A

--- a/sdks/c/src/exec/execution.rs
+++ b/sdks/c/src/exec/execution.rs
@@ -1405,7 +1405,15 @@ mod tests {
         ];
         let stream = stream_iter(chunks.into_iter());
 
-        stdout_pump(stream, noop_stdout_cb, 0xFEED_DEAD, queue.clone(), Arc::new(AtomicBool::new(false)), done_tx).await;
+        stdout_pump(
+            stream,
+            noop_stdout_cb,
+            0xFEED_DEAD,
+            queue.clone(),
+            Arc::new(AtomicBool::new(false)),
+            done_tx,
+        )
+        .await;
 
         let bytes = drain_stdout_bytes(&queue);
         assert_eq!(bytes.len(), 4, "expected 4 stdout events");
@@ -1431,7 +1439,15 @@ mod tests {
         let chunks = vec!["error".to_string(), "trace".to_string()];
         let stream = stream_iter(chunks.into_iter());
 
-        stderr_pump(stream, noop_stderr_cb, 0xCAFE_BABE, queue.clone(), Arc::new(AtomicBool::new(false)), done_tx).await;
+        stderr_pump(
+            stream,
+            noop_stderr_cb,
+            0xCAFE_BABE,
+            queue.clone(),
+            Arc::new(AtomicBool::new(false)),
+            done_tx,
+        )
+        .await;
 
         let bytes = drain_stderr_bytes(&queue);
         assert_eq!(bytes.len(), 2);

--- a/sdks/c/src/exec/execution.rs
+++ b/sdks/c/src/exec/execution.rs
@@ -92,12 +92,14 @@ pub struct ExecutionHandle {
     /// claimer pushes Exit. Both `execution_free` and `exit_pump`
     /// race for it; the loser silently no-ops.
     exit_dispatched: Arc<AtomicBool>,
-    /// Per-execution stream back-pressure flag. When the Go SDK's bounded
-    /// delivery queue fills it sets this (via `boxlite_execution_set_stream_paused`);
-    /// the stdout/stderr pumps then stop reading their bounded upstream channel,
-    /// which fills, blocking the attach reader's `send().await`, which stops
-    /// draining the guest gRPC stream and ultimately blocks the guest process's
-    /// write(). Cleared when the queue drains below its low-water mark.
+    /// Per-execution stream back-pressure flag driven by high-level bindings
+    /// with their own delivery queues. The Go SDK sets this via
+    /// `boxlite_execution_set_stream_paused` when its bounded queue crosses
+    /// high/low-water marks; direct C callback delivery is already bounded by
+    /// the runtime EventQueue. When set, stdout/stderr pumps stop reading their
+    /// bounded upstream channel, which fills, blocks the attach reader's
+    /// `send().await`, stops draining the guest gRPC stream, and ultimately
+    /// blocks the guest process's write().
     stream_pause_tx: watch::Sender<bool>,
 }
 
@@ -165,14 +167,13 @@ pub unsafe extern "C" fn boxlite_execution_stdin_close(
     close_stdin(execution, out_error)
 }
 
-/// Pause (paused != 0) or resume (paused == 0) delivery of this execution's
-/// stdout/stderr. While paused, the stream pumps stop reading their bounded
-/// upstream channel, which fills and back-pressures the guest process's
-/// write() — letting a slow consumer throttle the producer instead of buffering
-/// unboundedly. The Go SDK drives this from its delivery queue's high/low-water
-/// marks. Idempotent; safe to call repeatedly.
+/// Binding-only hook for SDKs with their own delivery queues to pause or
+/// resume stdout/stderr. It is intentionally not part of the public C header:
+/// direct C callback delivery is already bounded by the runtime EventQueue,
+/// while higher-level bindings such as Go drive this automatically from their
+/// own high/low-water marks.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn boxlite_execution_set_stream_paused(
+pub(crate) unsafe extern "C" fn boxlite_execution_set_stream_paused(
     execution: *mut CExecutionHandle,
     paused: c_int,
     out_error: *mut CBoxliteError,

--- a/sdks/c/src/exec/execution.rs
+++ b/sdks/c/src/exec/execution.rs
@@ -92,6 +92,13 @@ pub struct ExecutionHandle {
     /// claimer pushes Exit. Both `execution_free` and `exit_pump`
     /// race for it; the loser silently no-ops.
     exit_dispatched: Arc<AtomicBool>,
+    /// Per-execution stream back-pressure flag. When the Go SDK's bounded
+    /// delivery queue fills it sets this (via `boxlite_execution_set_stream_paused`);
+    /// the stdout/stderr pumps then stop reading their bounded upstream channel,
+    /// which fills, blocking the attach reader's `send().await`, which stops
+    /// draining the guest gRPC stream and ultimately blocks the guest process's
+    /// write(). Cleared when the queue drains below its low-water mark.
+    stream_paused: Arc<AtomicBool>,
 }
 
 #[unsafe(no_mangle)]
@@ -156,6 +163,29 @@ pub unsafe extern "C" fn boxlite_execution_stdin_close(
     out_error: *mut CBoxliteError,
 ) -> BoxliteErrorCode {
     close_stdin(execution, out_error)
+}
+
+/// Pause (paused != 0) or resume (paused == 0) delivery of this execution's
+/// stdout/stderr. While paused, the stream pumps stop reading their bounded
+/// upstream channel, which fills and back-pressures the guest process's
+/// write() — letting a slow consumer throttle the producer instead of buffering
+/// unboundedly. The Go SDK drives this from its delivery queue's high/low-water
+/// marks. Idempotent; safe to call repeatedly.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_execution_set_stream_paused(
+    execution: *mut CExecutionHandle,
+    paused: c_int,
+    out_error: *mut CBoxliteError,
+) -> BoxliteErrorCode {
+    unsafe {
+        if execution.is_null() {
+            write_error(out_error, null_pointer_error("execution"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        let exec_ref = &*execution;
+        exec_ref.stream_paused.store(paused != 0, Ordering::Release);
+        BoxliteErrorCode::Ok
+    }
 }
 
 #[unsafe(no_mangle)]
@@ -266,6 +296,7 @@ unsafe fn box_exec(
                     tokio_rt: handle_ref.tokio_rt.clone(),
                     process_completed: Arc::new(AtomicBool::new(false)),
                     exit_dispatched: Arc::new(AtomicBool::new(false)),
+                    stream_paused: Arc::new(AtomicBool::new(false)),
                 };
                 *out_execution = Box::into_raw(Box::new(exec_handle));
                 BoxliteErrorCode::Ok
@@ -306,9 +337,14 @@ unsafe fn register_stdout(
         let user_data_addr = user_data as usize;
         let (done_tx, done_rx) = oneshot::channel::<()>();
         exec_ref.stream_done_rx.lock().unwrap().push(done_rx);
-        let pump = exec_ref
-            .tokio_rt
-            .spawn(stdout_pump(stream, cb, user_data_addr, queue, done_tx));
+        let pump = exec_ref.tokio_rt.spawn(stdout_pump(
+            stream,
+            cb,
+            user_data_addr,
+            queue,
+            exec_ref.stream_paused.clone(),
+            done_tx,
+        ));
         exec_ref.pumps.lock().unwrap().push(pump);
         BoxliteErrorCode::Ok
     }
@@ -341,9 +377,14 @@ unsafe fn register_stderr(
         let user_data_addr = user_data as usize;
         let (done_tx, done_rx) = oneshot::channel::<()>();
         exec_ref.stream_done_rx.lock().unwrap().push(done_rx);
-        let pump = exec_ref
-            .tokio_rt
-            .spawn(stderr_pump(stream, cb, user_data_addr, queue, done_tx));
+        let pump = exec_ref.tokio_rt.spawn(stderr_pump(
+            stream,
+            cb,
+            user_data_addr,
+            queue,
+            exec_ref.stream_paused.clone(),
+            done_tx,
+        ));
         exec_ref.pumps.lock().unwrap().push(pump);
         BoxliteErrorCode::Ok
     }
@@ -719,11 +760,22 @@ unsafe fn execution_free(execution: *mut ExecutionHandle) {
 
 // ─── Pump tasks ────────────────────────────────────────────────────────────
 
+/// Block while the execution's stream is paused (Go-side back-pressure). The
+/// pump calls this AFTER delivering a chunk so it stops reading the next one
+/// from the bounded upstream channel — which then fills and back-pressures the
+/// guest. Sleep-poll (2ms) is coarse but cheap; pauses are seconds-scale.
+async fn await_unpaused(paused: &AtomicBool) {
+    while paused.load(Ordering::Acquire) {
+        tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+    }
+}
+
 async fn stdout_pump<S>(
     mut stream: S,
     cb: CBoxStdoutFn,
     user_data_addr: usize,
     queue: Arc<EventQueue>,
+    paused: Arc<AtomicBool>,
     done_tx: oneshot::Sender<()>,
 ) where
     S: futures::Stream<Item = String> + Unpin,
@@ -738,6 +790,7 @@ async fn stdout_pump<S>(
             },
         )
         .await;
+        await_unpaused(&paused).await;
     }
     // Signal the exit pump we're done. Failure (rx dropped) means exit_pump
     // already completed or was never registered — either way harmless.
@@ -749,6 +802,7 @@ async fn stderr_pump<S>(
     cb: CBoxStderrFn,
     user_data_addr: usize,
     queue: Arc<EventQueue>,
+    paused: Arc<AtomicBool>,
     done_tx: oneshot::Sender<()>,
 ) where
     S: futures::Stream<Item = String> + Unpin,
@@ -763,6 +817,7 @@ async fn stderr_pump<S>(
             },
         )
         .await;
+        await_unpaused(&paused).await;
     }
     let _ = done_tx.send(());
 }

--- a/sdks/c/src/exec/execution.rs
+++ b/sdks/c/src/exec/execution.rs
@@ -17,7 +17,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use tokio::runtime::Runtime as TokioRuntime;
-use tokio::sync::oneshot;
+use tokio::sync::{oneshot, watch};
 use tokio::task::JoinHandle;
 
 /// Synthetic exit code emitted when `boxlite_execution_free` tears down a
@@ -98,7 +98,7 @@ pub struct ExecutionHandle {
     /// which fills, blocking the attach reader's `send().await`, which stops
     /// draining the guest gRPC stream and ultimately blocks the guest process's
     /// write(). Cleared when the queue drains below its low-water mark.
-    stream_paused: Arc<AtomicBool>,
+    stream_pause_tx: watch::Sender<bool>,
 }
 
 #[unsafe(no_mangle)]
@@ -183,7 +183,7 @@ pub unsafe extern "C" fn boxlite_execution_set_stream_paused(
             return BoxliteErrorCode::InvalidArgument;
         }
         let exec_ref = &*execution;
-        exec_ref.stream_paused.store(paused != 0, Ordering::Release);
+        exec_ref.stream_pause_tx.send_replace(paused != 0);
         BoxliteErrorCode::Ok
     }
 }
@@ -296,7 +296,10 @@ unsafe fn box_exec(
                     tokio_rt: handle_ref.tokio_rt.clone(),
                     process_completed: Arc::new(AtomicBool::new(false)),
                     exit_dispatched: Arc::new(AtomicBool::new(false)),
-                    stream_paused: Arc::new(AtomicBool::new(false)),
+                    stream_pause_tx: {
+                        let (tx, _rx) = watch::channel(false);
+                        tx
+                    },
                 };
                 *out_execution = Box::into_raw(Box::new(exec_handle));
                 BoxliteErrorCode::Ok
@@ -342,7 +345,7 @@ unsafe fn register_stdout(
             cb,
             user_data_addr,
             queue,
-            exec_ref.stream_paused.clone(),
+            exec_ref.stream_pause_tx.subscribe(),
             done_tx,
         ));
         exec_ref.pumps.lock().unwrap().push(pump);
@@ -382,7 +385,7 @@ unsafe fn register_stderr(
             cb,
             user_data_addr,
             queue,
-            exec_ref.stream_paused.clone(),
+            exec_ref.stream_pause_tx.subscribe(),
             done_tx,
         ));
         exec_ref.pumps.lock().unwrap().push(pump);
@@ -764,9 +767,15 @@ unsafe fn execution_free(execution: *mut ExecutionHandle) {
 /// pump calls this AFTER delivering a chunk so it stops reading the next one
 /// from the bounded upstream channel — which then fills and back-pressures the
 /// guest. Sleep-poll (2ms) is coarse but cheap; pauses are seconds-scale.
-async fn await_unpaused(paused: &AtomicBool) {
-    while paused.load(Ordering::Acquire) {
-        tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+async fn await_unpaused(rx: &mut watch::Receiver<bool>) {
+    // Block (zero CPU) while paused; wake on the next pause-flag change. watch
+    // is version-tracked, so a resume that races the check is never missed. A
+    // dropped sender (Err) means the execution is torn down — return and let
+    // the pump finish.
+    while *rx.borrow_and_update() {
+        if rx.changed().await.is_err() {
+            return;
+        }
     }
 }
 
@@ -775,7 +784,7 @@ async fn stdout_pump<S>(
     cb: CBoxStdoutFn,
     user_data_addr: usize,
     queue: Arc<EventQueue>,
-    paused: Arc<AtomicBool>,
+    mut paused: watch::Receiver<bool>,
     done_tx: oneshot::Sender<()>,
 ) where
     S: futures::Stream<Item = String> + Unpin,
@@ -790,7 +799,7 @@ async fn stdout_pump<S>(
             },
         )
         .await;
-        await_unpaused(&paused).await;
+        await_unpaused(&mut paused).await;
     }
     // Signal the exit pump we're done. Failure (rx dropped) means exit_pump
     // already completed or was never registered — either way harmless.
@@ -802,7 +811,7 @@ async fn stderr_pump<S>(
     cb: CBoxStderrFn,
     user_data_addr: usize,
     queue: Arc<EventQueue>,
-    paused: Arc<AtomicBool>,
+    mut paused: watch::Receiver<bool>,
     done_tx: oneshot::Sender<()>,
 ) where
     S: futures::Stream<Item = String> + Unpin,
@@ -817,7 +826,7 @@ async fn stderr_pump<S>(
             },
         )
         .await;
-        await_unpaused(&paused).await;
+        await_unpaused(&mut paused).await;
     }
     let _ = done_tx.send(());
 }
@@ -928,7 +937,10 @@ mod tests {
             tokio_rt: runtime,
             process_completed: Arc::new(AtomicBool::new(false)),
             exit_dispatched: Arc::new(AtomicBool::new(false)),
-            stream_paused: Arc::new(AtomicBool::new(false)),
+            stream_pause_tx: {
+                let (tx, _rx) = watch::channel(false);
+                tx
+            },
         }
     }
 
@@ -1410,7 +1422,7 @@ mod tests {
             noop_stdout_cb,
             0xFEED_DEAD,
             queue.clone(),
-            Arc::new(AtomicBool::new(false)),
+            watch::channel(false).1,
             done_tx,
         )
         .await;
@@ -1444,7 +1456,7 @@ mod tests {
             noop_stderr_cb,
             0xCAFE_BABE,
             queue.clone(),
-            Arc::new(AtomicBool::new(false)),
+            watch::channel(false).1,
             done_tx,
         )
         .await;

--- a/sdks/go/abandon_async_test.go
+++ b/sdks/go/abandon_async_test.go
@@ -164,7 +164,7 @@ func TestDrainAndDelete_RespondsToCloseSignal(t *testing.T) {
 // dispatch directly and verifies the handle is deleted afterwards.
 
 func TestExecutionStreamState_HandleDeletedOnExit(t *testing.T) {
-	state := newExecutionStreamState(ExecutionOptions{})
+	state := newExecutionStreamState(ExecutionOptions{}, nil)
 	streamHandle := cgo.NewHandle(state)
 
 	// Synthesize the C-side exit dispatch by calling the Go body of

--- a/sdks/go/bridge.h
+++ b/sdks/go/bridge.h
@@ -34,4 +34,12 @@ extern CExecutionKillCb cbExecutionKill(void);
 extern CExecutionSignalCb cbExecutionSignal(void);
 extern CExecutionResizeCb cbExecutionResize(void);
 
+// Binding-only back-pressure hook. This symbol is exported by the C SDK for
+// language bindings but intentionally omitted from the public boxlite.h API:
+// direct C callback delivery is already bounded by the runtime EventQueue,
+// while the Go SDK drives pause/resume automatically from high/low-water marks.
+enum BoxliteErrorCode boxlite_execution_set_stream_paused(CExecutionHandle *execution,
+                                                          int paused,
+                                                          CBoxliteError *out_error);
+
 #endif // BOXLITE_GO_BRIDGE_H

--- a/sdks/go/exec.go
+++ b/sdks/go/exec.go
@@ -69,6 +69,14 @@ type ExecutionOptions struct {
 	// means no timeout (the C side treats `timeout_secs <= 0` as
 	// unbounded — see `sdks/c/src/exec/command.rs`).
 	Timeout time.Duration
+	// StreamStallTimeout auto-kills the execution if back-pressure has fully
+	// stalled — i.e. there is output buffered but the caller's Stdout/Stderr
+	// sink has accepted nothing for this long. It guards against a permanently
+	// blocked/abandoned sink leaving the producer suspended (and the box's
+	// resources held) forever. A sink that keeps making progress, however
+	// slowly, is never killed; an execution that simply produces no output is
+	// never killed (nothing is buffered). Zero disables the guard.
+	StreamStallTimeout time.Duration
 }
 
 // executionStreamState holds the user-provided sinks for streaming output
@@ -307,6 +315,43 @@ func (s *executionStreamState) closeDrained() {
 	s.drainedOnce.Do(func() { close(s.drained) })
 }
 
+// stallWatchdog auto-kills (via the supplied closure) an execution whose
+// back-pressure has fully stalled: output is buffered (queuedBytes > 0) but the
+// caller's sink has delivered nothing — progress has not advanced — for the
+// whole timeout. Resets on any progress, so a slow-but-advancing sink is never
+// killed; ignores quiet executions, which buffer nothing. Exits when the stream
+// drains (clean end) or after it has fired the kill.
+func (s *executionStreamState) stallWatchdog(timeout time.Duration, kill func()) {
+	interval := timeout / 4
+	if interval < 50*time.Millisecond {
+		interval = 50 * time.Millisecond
+	}
+	t := time.NewTicker(interval)
+	defer t.Stop()
+
+	lastProgress := s.progress.Load()
+	lastAdvance := time.Now()
+	for {
+		select {
+		case <-s.drained:
+			return
+		case <-t.C:
+			if now := s.progress.Load(); now != lastProgress {
+				lastProgress = now
+				lastAdvance = time.Now()
+				continue
+			}
+			s.qmu.Lock()
+			pending := s.queuedBytes
+			s.qmu.Unlock()
+			if pending > 0 && time.Since(lastAdvance) >= timeout {
+				kill()
+				return
+			}
+		}
+	}
+}
+
 // Execution is a handle to a running command.
 type Execution struct {
 	handle      *C.CExecutionHandle
@@ -427,6 +472,12 @@ func (b *Box) StartExecution(_ context.Context, name string, args []string, opts
 		closing:     b.runtime.closing,
 	}
 	execution.Stdin = &executionStdin{execution: execution}
+
+	if cfg.StreamStallTimeout > 0 {
+		go state.stallWatchdog(cfg.StreamStallTimeout, func() {
+			_ = execution.Kill(context.Background())
+		})
+	}
 	return execution, nil
 }
 

--- a/sdks/go/exec.go
+++ b/sdks/go/exec.go
@@ -127,7 +127,26 @@ type executionStreamState struct {
 	exited      bool // on_exit seen: flush the queue, then close drained
 	stopped     bool // execution released/closed: stop the writer
 	drainedOnce sync.Once
+
+	// Bounded-queue back-pressure. queuedBytes is the bytes buffered but not
+	// yet written to the caller's sink. When it crosses the high-water mark the
+	// writer is falling behind, so we pause the C-side pump (which fills the
+	// bounded upstream channel and ultimately blocks the guest process's
+	// write()); we resume once it drains below the low-water mark. `pause` calls
+	// boxlite_execution_set_stream_paused under qmu — Close sets `stopped` under
+	// qmu before freeing the handle, so a pause call can never use it post-free.
+	queuedBytes int
+	paused      bool
+	pause       func(bool)
 }
+
+const (
+	// streamQueueHighWater: buffered bytes at which the writer is deemed behind
+	// and the producer is paused. streamQueueLowWater: resume threshold. The gap
+	// is hysteresis so a steady stream doesn't thrash pause/resume.
+	streamQueueHighWater = 4 << 20 // 4 MiB
+	streamQueueLowWater  = 1 << 20 // 1 MiB
+)
 
 // streamChunk is one ordered unit of stream output queued for async delivery.
 type streamChunk struct {
@@ -135,7 +154,10 @@ type streamChunk struct {
 	data   []byte
 }
 
-func newExecutionStreamState(opts ExecutionOptions) *executionStreamState {
+// newExecutionStreamState builds the stream state. setPaused, when non-nil, is
+// the raw C call that pauses/resumes the execution's pumps; it is wrapped so it
+// only runs while the handle is alive (guarded by qmu against Close's free).
+func newExecutionStreamState(opts ExecutionOptions, setPaused func(bool)) *executionStreamState {
 	s := &executionStreamState{
 		stdout:   opts.Stdout,
 		stderr:   opts.Stderr,
@@ -144,6 +166,18 @@ func newExecutionStreamState(opts ExecutionOptions) *executionStreamState {
 		drained:  make(chan struct{}),
 	}
 	s.qcond = sync.NewCond(&s.qmu)
+	if setPaused != nil {
+		s.pause = func(p bool) {
+			// Call the C FFI while holding qmu and only when not stopped.
+			// markReleased sets `stopped` under qmu before Close frees the
+			// handle, so this can never touch a freed handle.
+			s.qmu.Lock()
+			if !s.stopped {
+				setPaused(p)
+			}
+			s.qmu.Unlock()
+		}
+	}
 	go s.deliverLoop()
 	return s
 }
@@ -160,12 +194,21 @@ func (s *executionStreamState) enqueue(c streamChunk) {
 	if s.released.Load() {
 		return
 	}
+	doPause := false
 	s.qmu.Lock()
 	if !s.exited && !s.stopped {
 		s.queue = append(s.queue, c)
+		s.queuedBytes += len(c.data)
+		if s.queuedBytes > streamQueueHighWater && !s.paused {
+			s.paused = true
+			doPause = true
+		}
 		s.qcond.Signal()
 	}
 	s.qmu.Unlock()
+	if doPause && s.pause != nil {
+		s.pause(true)
+	}
 }
 
 // deliverExit marks end-of-stream. The writer goroutine flushes whatever is
@@ -206,8 +249,24 @@ func (s *executionStreamState) deliverLoop() {
 		done := s.exited || s.stopped
 		s.qmu.Unlock()
 
+		batch := 0
 		for _, c := range q {
 			s.writeChunk(c)
+			batch += len(c.data)
+		}
+		// Account the drained bytes; resume the producer once we're back under
+		// the low-water mark (only while live — on exit/stop the pump is torn
+		// down anyway, and resuming there could race the handle free).
+		doResume := false
+		s.qmu.Lock()
+		s.queuedBytes -= batch
+		if s.paused && !done && s.queuedBytes < streamQueueLowWater {
+			s.paused = false
+			doResume = true
+		}
+		s.qmu.Unlock()
+		if doResume && s.pause != nil {
+			s.pause(false)
 		}
 		if done {
 			// No more chunks can arrive once exited/stopped is set (deliver*
@@ -341,7 +400,14 @@ func (b *Box) StartExecution(_ context.Context, name string, args []string, opts
 		return nil, freeError(&cerr)
 	}
 
-	state := newExecutionStreamState(cfg)
+	// The pause setter throttles this execution's guest producer when the
+	// delivery queue fills (end-to-end back-pressure). `handle` is valid for
+	// the closure's lifetime: it is only invoked while the stream state is not
+	// stopped, and Close frees the handle only after marking it stopped.
+	state := newExecutionStreamState(cfg, func(paused bool) {
+		var cerr C.CBoxliteError
+		C.boxlite_execution_set_stream_paused(handle, boolToCInt(paused), &cerr)
+	})
 	streamHandle := cgo.NewHandle(state)
 
 	if err := registerExecutionCallbacks(handle, streamHandle); err != nil {

--- a/sdks/go/exec.go
+++ b/sdks/go/exec.go
@@ -292,6 +292,13 @@ func (s *executionStreamState) deliverLoop() {
 	}
 }
 
+// writeChunk hands one chunk to the caller's sink. Write errors are
+// deliberately not propagated: this runs on the async delivery goroutine with
+// no caller to return them to, and a transient sink hiccup should not tear down
+// a healthy execution. A sink that fails permanently simply stops accepting
+// bytes, which leaves output buffered and is exactly the condition
+// StreamStallTimeout watches for and kills — so a wedged sink is still handled,
+// without making every transient write error fatal.
 func (s *executionStreamState) writeChunk(c streamChunk) {
 	if c.stderr {
 		if s.onStderr != nil {
@@ -330,21 +337,32 @@ func (s *executionStreamState) stallWatchdog(timeout time.Duration, kill func())
 	defer t.Stop()
 
 	lastProgress := s.progress.Load()
-	lastAdvance := time.Now()
+	var stalledSince time.Time // zero = not currently stalled
 	for {
 		select {
 		case <-s.drained:
 			return
 		case <-t.C:
-			if now := s.progress.Load(); now != lastProgress {
-				lastProgress = now
-				lastAdvance = time.Now()
-				continue
-			}
+			now := s.progress.Load()
+			progressed := now != lastProgress
+			lastProgress = now
+
 			s.qmu.Lock()
 			pending := s.queuedBytes
 			s.qmu.Unlock()
-			if pending > 0 && time.Since(lastAdvance) >= timeout {
+
+			// A stall is "output is buffered but nothing got delivered this
+			// interval". Time it from when the stall began (not from exec start
+			// or last progress), so a sink that goes quiet then stalls still
+			// gets the full timeout, and a quiet exec that buffers nothing is
+			// never killed.
+			if progressed || pending == 0 {
+				stalledSince = time.Time{}
+				continue
+			}
+			if stalledSince.IsZero() {
+				stalledSince = time.Now()
+			} else if time.Since(stalledSince) >= timeout {
 				kill()
 				return
 			}

--- a/sdks/go/exec.go
+++ b/sdks/go/exec.go
@@ -103,6 +103,15 @@ type executionStreamState struct {
 	// buffer. The fold happens at the SDK boundary; the C-side Wait
 	// task stays decoupled from streams.
 	drained chan struct{}
+
+	// progress is a monotonic count of Stdout/Stderr callbacks delivered.
+	// Wait's drain barrier watches it: a SIGKILLed guest can leave a pipe
+	// without EOF, so the C exit pump never fires on_exit and `drained`
+	// never closes — bounding the barrier by progress lets Wait return
+	// (the stream has stalled) instead of hanging forever. While output is
+	// still flowing progress keeps advancing, so a large tail is never cut
+	// off early.
+	progress atomic.Uint64
 }
 
 func newExecutionStreamState(opts ExecutionOptions) *executionStreamState {
@@ -129,6 +138,7 @@ func (s *executionStreamState) deliverStdout(data []byte) {
 	if stdout != nil {
 		_, _ = stdout.Write(data)
 	}
+	s.progress.Add(1)
 }
 
 func (s *executionStreamState) deliverStderr(data []byte) {
@@ -145,6 +155,7 @@ func (s *executionStreamState) deliverStderr(data []byte) {
 	if stderr != nil {
 		_, _ = stderr.Write(data)
 	}
+	s.progress.Add(1)
 }
 
 func (s *executionStreamState) deliverExit(_ int) {
@@ -341,19 +352,69 @@ func (e *Execution) Wait(ctx context.Context) (int, error) {
 		return 0, ErrRuntimeClosed
 	}
 
-	// Drain barrier: wait for stream pumps to flush before returning,
-	// so the caller's stdout/stderr Writers see every chunk the exec
-	// produced. Non-cancelable by ctx — only runtime shutdown breaks
-	// it. Preserves the exit code from the wait result; overwrites
-	// err only if the wait itself had none.
-	select {
-	case <-e.streamState.drained:
-	case <-e.closing:
-		if err == nil {
-			err = ErrRuntimeClosed
-		}
+	// Drain barrier: wait for stream pumps to flush before returning, so
+	// the caller's stdout/stderr Writers see every chunk the exec produced.
+	// Bounded by stream *progress*, not a fixed wall clock: normally
+	// `drained` closes once C's exit pump (which keeps Exit strictly last)
+	// fires on_exit. But a SIGKILLed guest can leave a pipe without EOF, so
+	// the exit pump never fires and `drained` never closes — keep waiting
+	// while output is still arriving (progress advances; a large tail is
+	// never cut off), and give up once the stream goes idle. Non-cancelable
+	// by ctx (os/exec parity); only runtime shutdown, an idle/stalled
+	// stream, or the hard cap breaks it. Preserves the exit code; overwrites
+	// err only if the wait had none.
+	if closed := waitForStreamDrain(
+		e.streamState.drained, e.closing, &e.streamState.progress,
+		streamDrainIdleBound, streamDrainHardCap,
+	); closed && err == nil {
+		err = ErrRuntimeClosed
 	}
 	return code, err
+}
+
+// streamDrainIdleBound is how long Wait's drain barrier tolerates no new
+// Stdout/Stderr callback before treating the stream as stalled and
+// returning. The drain runs only after the exit code is in hand, so any
+// remaining output is buffered and arrives back-to-back; a full window with
+// no progress means a guest pipe that will never EOF (a signal-killed
+// process). Large enough to absorb scheduler/transport jitter, small enough
+// that a timeout-killed exec's Wait returns promptly.
+const streamDrainIdleBound = 300 * time.Millisecond
+
+// streamDrainHardCap backstops a pipe that never EOFs yet keeps trickling a
+// chunk within every idle window forever. Generous so it never clips a
+// genuine high-throughput tail.
+const streamDrainHardCap = 30 * time.Second
+
+// waitForStreamDrain blocks until the stream callbacks have flushed
+// (`drained` closes), the runtime is closing, the stream goes idle (no
+// progress within idleBound — a stuck never-EOF pipe), or hardCap elapses.
+// Returns true only when it ended because the runtime is closing, so the
+// caller can surface ErrRuntimeClosed. Bounding by progress rather than a
+// fixed wall clock keeps a still-delivering tail from being cut off.
+func waitForStreamDrain(drained, closing <-chan struct{}, progress *atomic.Uint64, idleBound, hardCap time.Duration) bool {
+	idle := time.NewTicker(idleBound)
+	defer idle.Stop()
+	cap := time.NewTimer(hardCap)
+	defer cap.Stop()
+
+	last := progress.Load()
+	for {
+		select {
+		case <-drained:
+			return false
+		case <-closing:
+			return true
+		case <-cap.C:
+			return false
+		case <-idle.C:
+			now := progress.Load()
+			if now == last {
+				return false
+			}
+			last = now
+		}
+	}
 }
 
 // Kill terminates the running command.

--- a/sdks/go/exec.go
+++ b/sdks/go/exec.go
@@ -85,7 +85,6 @@ type ExecutionOptions struct {
 // Memory overhead is bounded: each execution adds one map entry plus the
 // state struct (a few writers, two atomics, and a mutex).
 type executionStreamState struct {
-	mu       sync.Mutex
 	stdout   io.Writer
 	stderr   io.Writer
 	onStdout func([]byte)
@@ -112,59 +111,141 @@ type executionStreamState struct {
 	// still flowing progress keeps advancing, so a large tail is never cut
 	// off early.
 	progress atomic.Uint64
+
+	// Stream output is delivered to the caller's sinks by a dedicated
+	// per-execution goroutine (deliverLoop), NOT inline on the shared
+	// per-Runtime drain goroutine. deliverStdout/deliverStderr are invoked on
+	// that single drain goroutine (runtime.go drainLoop -> C dispatch); writing
+	// to a caller-supplied Writer inline there lets one execution's slow or
+	// blocking sink wedge the drain goroutine and stall delivery — including
+	// Wait completions — for EVERY execution on the same Runtime
+	// (head-of-line blocking). Enqueue is non-blocking; the writer goroutine
+	// absorbs sink back-pressure in isolation.
+	qmu         sync.Mutex
+	qcond       *sync.Cond
+	queue       []streamChunk
+	exited      bool // on_exit seen: flush the queue, then close drained
+	stopped     bool // execution released/closed: stop the writer
+	drainedOnce sync.Once
+}
+
+// streamChunk is one ordered unit of stream output queued for async delivery.
+type streamChunk struct {
+	stderr bool
+	data   []byte
 }
 
 func newExecutionStreamState(opts ExecutionOptions) *executionStreamState {
-	return &executionStreamState{
+	s := &executionStreamState{
 		stdout:   opts.Stdout,
 		stderr:   opts.Stderr,
 		onStdout: opts.OnStdout,
 		onStderr: opts.OnStderr,
 		drained:  make(chan struct{}),
 	}
+	s.qcond = sync.NewCond(&s.qmu)
+	go s.deliverLoop()
+	return s
 }
 
-func (s *executionStreamState) deliverStdout(data []byte) {
+// deliverStdout/deliverStderr run on the shared per-Runtime drain goroutine.
+// They only enqueue — never write to the caller's sink — so a blocking sink
+// cannot wedge the drain goroutine (see executionStreamState). The bytes are
+// already a Go-owned copy (C.GoBytes at the cgo boundary), so the slice is safe
+// to retain in the queue.
+func (s *executionStreamState) deliverStdout(data []byte) { s.enqueue(streamChunk{false, data}) }
+func (s *executionStreamState) deliverStderr(data []byte) { s.enqueue(streamChunk{true, data}) }
+
+func (s *executionStreamState) enqueue(c streamChunk) {
 	if s.released.Load() {
 		return
 	}
-	s.mu.Lock()
-	stdout := s.stdout
-	cb := s.onStdout
-	s.mu.Unlock()
-	if cb != nil {
-		cb(data)
+	s.qmu.Lock()
+	if !s.exited && !s.stopped {
+		s.queue = append(s.queue, c)
+		s.qcond.Signal()
 	}
-	if stdout != nil {
-		_, _ = stdout.Write(data)
-	}
-	s.progress.Add(1)
+	s.qmu.Unlock()
 }
 
-func (s *executionStreamState) deliverStderr(data []byte) {
-	if s.released.Load() {
-		return
-	}
-	s.mu.Lock()
-	stderr := s.stderr
-	cb := s.onStderr
-	s.mu.Unlock()
-	if cb != nil {
-		cb(data)
-	}
-	if stderr != nil {
-		_, _ = stderr.Write(data)
-	}
-	s.progress.Add(1)
-}
-
+// deliverExit marks end-of-stream. The writer goroutine flushes whatever is
+// still queued (on_exit fires only after every stream callback for this
+// execution, so the queue holds the full tail) and then closes drained, which
+// Execution.Wait's drain barrier is waiting on.
 func (s *executionStreamState) deliverExit(_ int) {
 	s.released.Store(true)
-	close(s.drained)
+	s.qmu.Lock()
+	s.exited = true
+	s.qcond.Signal()
+	s.qmu.Unlock()
 }
 
 func (s *executionStreamState) markReleased() {
 	s.released.Store(true)
+	s.qmu.Lock()
+	s.stopped = true
+	s.qcond.Signal()
+	s.qmu.Unlock()
+}
+
+// deliverLoop is the per-execution writer goroutine. It drains the queue in
+// FIFO order (preserving stdout/stderr interleaving) into the caller's sinks,
+// bumping progress per chunk so Wait's progress-bounded drain barrier can tell
+// a still-delivering stream from a stalled one. Blocking here isolates sink
+// back-pressure to this one execution. Exits — closing drained — once on_exit
+// has been seen and the queue is empty, or when the execution is released.
+func (s *executionStreamState) deliverLoop() {
+	defer s.closeDrained()
+	for {
+		s.qmu.Lock()
+		for len(s.queue) == 0 && !s.exited && !s.stopped {
+			s.qcond.Wait()
+		}
+		q := s.queue
+		s.queue = nil
+		done := s.exited || s.stopped
+		s.qmu.Unlock()
+
+		for _, c := range q {
+			s.writeChunk(c)
+		}
+		if done {
+			// No more chunks can arrive once exited/stopped is set (deliver*
+			// calls are serialized on the single drain goroutine), but a chunk
+			// enqueued before the flag was observed may remain — flush it.
+			s.qmu.Lock()
+			rest := s.queue
+			s.queue = nil
+			s.qmu.Unlock()
+			for _, c := range rest {
+				s.writeChunk(c)
+			}
+			return
+		}
+	}
+}
+
+func (s *executionStreamState) writeChunk(c streamChunk) {
+	if c.stderr {
+		if s.onStderr != nil {
+			s.onStderr(c.data)
+		}
+		if s.stderr != nil {
+			_, _ = s.stderr.Write(c.data)
+		}
+	} else {
+		if s.onStdout != nil {
+			s.onStdout(c.data)
+		}
+		if s.stdout != nil {
+			_, _ = s.stdout.Write(c.data)
+		}
+	}
+	s.progress.Add(1)
+}
+
+func (s *executionStreamState) closeDrained() {
+	s.drainedOnce.Do(func() { close(s.drained) })
 }
 
 // Execution is a handle to a running command.

--- a/sdks/go/exec_backpressure_integration_test.go
+++ b/sdks/go/exec_backpressure_integration_test.go
@@ -84,12 +84,24 @@ func TestIntegrationExecStreamStallTimeout(t *testing.T) {
 	}
 	defer exec.Close()
 
-	done := make(chan int, 1)
-	go func() { c, _ := exec.Wait(context.Background()); done <- c }()
+	type waitResult struct {
+		code int
+		err  error
+	}
+	done := make(chan waitResult, 1)
+	go func() {
+		c, e := exec.Wait(context.Background())
+		done <- waitResult{c, e}
+	}()
 	start := time.Now()
 	select {
-	case code := <-done:
-		if code == 0 {
+	case res := <-done:
+		// The stall-kill must surface through Wait: it returns cleanly (no
+		// error) with the SIGKILL reflected in a non-zero exit code.
+		if res.err != nil {
+			t.Errorf("Wait err = %v, want nil (stall-kill surfaces via exit code)", res.err)
+		}
+		if res.code == 0 {
 			t.Errorf("exit = 0, want non-zero (stall-killed)")
 		}
 		if elapsed := time.Since(start); elapsed > 10*time.Second {

--- a/sdks/go/exec_backpressure_integration_test.go
+++ b/sdks/go/exec_backpressure_integration_test.go
@@ -1,0 +1,63 @@
+//go:build boxlite_dev
+
+package boxlite
+
+import (
+	"context"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+)
+
+// blockForeverSink blocks the writer on its first Write and never returns,
+// modelling a stalled/blocked caller sink.
+type blockForeverSink struct {
+	once sync.Once
+	rel  chan struct{}
+}
+
+func (b *blockForeverSink) Write(p []byte) (int, error) {
+	b.once.Do(func() { <-b.rel })
+	return len(p), nil
+}
+
+// TestIntegrationExecBackpressureBoundsMemory proves end-to-end stream
+// back-pressure: a blocked caller sink on an infinitely-producing process must
+// NOT cause unbounded host buffering. Without back-pressure the per-execution
+// delivery queue grows without limit (the producer is never throttled); with
+// it, the bounded Go queue pauses the C pump, which fills the bounded upstream
+// channel, blocking the attach reader, the guest forwarder, and finally the
+// guest process's write(). Heap growth must therefore plateau.
+func TestIntegrationExecBackpressureBoundsMemory(t *testing.T) {
+	rt := newTestRuntime(t)
+	box := createStartedBoxOrSkip(t, rt, "alpine:latest", WithAutoRemove(false))
+
+	sink := &blockForeverSink{rel: make(chan struct{})}
+	exec, err := box.StartExecution(context.Background(), "sh",
+		[]string{"-c", "yes ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"}, &ExecutionOptions{Stdout: sink})
+	if err != nil {
+		t.Fatalf("StartExecution: %v", err)
+	}
+	t.Cleanup(func() { close(sink.rel); _ = exec.Close() })
+
+	var m runtime.MemStats
+	read := func() uint64 { runtime.ReadMemStats(&m); return m.HeapAlloc }
+
+	// Let the producer run while the sink is blocked; sample heap growth.
+	time.Sleep(1 * time.Second)
+	base := read()
+	for i := 0; i < 6; i++ {
+		time.Sleep(500 * time.Millisecond)
+	}
+	grew := int64(read()) - int64(base)
+
+	// With back-pressure the queue is capped near streamQueueHighWater (a few
+	// MiB) plus the bounded in-flight buffers. A generous 64 MiB bound still
+	// catches the unbounded regression (which grew tens of MiB/s indefinitely).
+	const bound = 64 << 20
+	if grew > bound {
+		t.Fatalf("heap grew %d bytes over 3s under a blocked sink — stream "+
+			"back-pressure is not bounding host memory (want plateau under %d)", grew, bound)
+	}
+}

--- a/sdks/go/exec_backpressure_integration_test.go
+++ b/sdks/go/exec_backpressure_integration_test.go
@@ -61,3 +61,46 @@ func TestIntegrationExecBackpressureBoundsMemory(t *testing.T) {
 			"back-pressure is not bounding host memory (want plateau under %d)", grew, bound)
 	}
 }
+
+// TestIntegrationExecStreamStallTimeout verifies the StreamStallTimeout safety
+// net: when output is buffered but the caller's sink accepts nothing for the
+// configured duration (a permanently blocked/abandoned sink), the execution is
+// auto-killed so Wait returns and the box's resources are released — no manual
+// stop required.
+func TestIntegrationExecStreamStallTimeout(t *testing.T) {
+	rt := newTestRuntime(t)
+	box := createStartedBoxOrSkip(t, rt, "alpine:latest", WithAutoRemove(false))
+
+	// A sink that blocks forever on the first write.
+	rel := make(chan struct{})
+	defer close(rel)
+	sink := writerFunc(func(p []byte) (int, error) { <-rel; return len(p), nil })
+
+	exec, err := box.StartExecution(context.Background(), "sh",
+		[]string{"-c", "echo hi; sleep 600"},
+		&ExecutionOptions{Stdout: sink, StreamStallTimeout: 3 * time.Second})
+	if err != nil {
+		t.Fatalf("StartExecution: %v", err)
+	}
+	defer exec.Close()
+
+	done := make(chan int, 1)
+	go func() { c, _ := exec.Wait(context.Background()); done <- c }()
+	start := time.Now()
+	select {
+	case code := <-done:
+		if code == 0 {
+			t.Errorf("exit = 0, want non-zero (stall-killed)")
+		}
+		if elapsed := time.Since(start); elapsed > 10*time.Second {
+			t.Errorf("stall-kill took %s, want ~3s", elapsed)
+		}
+	case <-time.After(20 * time.Second):
+		t.Fatal("HANG: stalled exec was not auto-killed by StreamStallTimeout")
+	}
+}
+
+// writerFunc adapts a func to io.Writer.
+type writerFunc func([]byte) (int, error)
+
+func (f writerFunc) Write(p []byte) (int, error) { return f(p) }

--- a/sdks/go/exec_drain_matrix_integration_test.go
+++ b/sdks/go/exec_drain_matrix_integration_test.go
@@ -181,3 +181,74 @@ func TestIntegrationExecRuntimeCloseUnblocksWait(t *testing.T) {
 		t.Fatal("HANG: Wait did not unblock on Runtime.Close")
 	}
 }
+
+// TestIntegrationExecOutputShapes covers output shapes orthogonal to
+// termination: slow/trickle (gaps wider than the post-exit idle bound), large
+// high-throughput, and binary/no-trailing-newline. Each asserts Wait returns
+// with the exact byte count (no truncation, no extra).
+func TestIntegrationExecOutputShapes(t *testing.T) {
+	rt := newTestRuntime(t)
+	box := createStartedBoxOrSkip(t, rt, "alpine:latest", WithAutoRemove(false))
+
+	run := func(t *testing.T, args []string, watchdog time.Duration) (int, int) {
+		t.Helper()
+		var out bytes.Buffer
+		exec, err := box.StartExecution(context.Background(), "sh", args, &ExecutionOptions{Stdout: &out})
+		if err != nil {
+			t.Fatalf("StartExecution: %v", err)
+		}
+		defer exec.Close()
+		var code int
+		waitWatchdog(t, watchdog, t.Name(), func() { code, _ = exec.Wait(context.Background()) })
+		return code, out.Len()
+	}
+
+	t.Run("slow-trickle", func(t *testing.T) {
+		// 6 lines, 500ms apart: each gap exceeds the 300ms post-exit idle bound,
+		// proving live output is gated by exit (not the idle bound) and is never
+		// cut off.
+		code, n := run(t, []string{"-c", "i=0; while [ $i -lt 6 ]; do echo line-$i; sleep 0.5; i=$((i+1)); done"}, 20*time.Second)
+		if want := len("line-0\n") * 6; n != want {
+			t.Errorf("slow output bytes = %d, want %d", n, want)
+		}
+		if code != 0 {
+			t.Errorf("exit = %d, want 0", code)
+		}
+	})
+
+	t.Run("large-high-throughput", func(t *testing.T) {
+		const lines, line = 200000, "0123456789abcdef0123456789abcdef"
+		code, n := run(t, []string{"-c", "awk 'BEGIN{for(i=0;i<" + itoa(lines) + ";i++)print \"" + line + "\"}'"}, 30*time.Second)
+		if want := lines * (len(line) + 1); n != want {
+			t.Errorf("large output bytes = %d, want %d (%.2f%%)", n, want, 100*float64(n)/float64(want))
+		}
+		if code != 0 {
+			t.Errorf("exit = %d, want 0", code)
+		}
+	})
+
+	t.Run("binary-no-newline", func(t *testing.T) {
+		// 5 printable bytes (no newline) + 1000 NUL bytes: exact, unterminated.
+		code, n := run(t, []string{"-c", "printf 'abcde'; head -c 1000 /dev/zero"}, 12*time.Second)
+		if n != 1005 {
+			t.Errorf("binary output bytes = %d, want 1005", n)
+		}
+		if code != 0 {
+			t.Errorf("exit = %d, want 0", code)
+		}
+	})
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b [20]byte
+	i := len(b)
+	for n > 0 {
+		i--
+		b[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(b[i:])
+}

--- a/sdks/go/exec_drain_matrix_integration_test.go
+++ b/sdks/go/exec_drain_matrix_integration_test.go
@@ -42,10 +42,14 @@ func TestIntegrationExecDrainMatrix(t *testing.T) {
 		}
 		defer exec.Close()
 		var code int
+		var waitErr error
 		if kill != nil {
 			go kill(exec)
 		}
-		waitWatchdog(t, watchdog, t.Name(), func() { code, _ = exec.Wait(context.Background()) })
+		waitWatchdog(t, watchdog, t.Name(), func() { code, waitErr = exec.Wait(context.Background()) })
+		if waitErr != nil {
+			t.Fatalf("Wait: %v", waitErr)
+		}
 		return code
 	}
 
@@ -199,7 +203,11 @@ func TestIntegrationExecOutputShapes(t *testing.T) {
 		}
 		defer exec.Close()
 		var code int
-		waitWatchdog(t, watchdog, t.Name(), func() { code, _ = exec.Wait(context.Background()) })
+		var waitErr error
+		waitWatchdog(t, watchdog, t.Name(), func() { code, waitErr = exec.Wait(context.Background()) })
+		if waitErr != nil {
+			t.Fatalf("Wait: %v", waitErr)
+		}
 		return code, out.Len()
 	}
 

--- a/sdks/go/exec_drain_matrix_integration_test.go
+++ b/sdks/go/exec_drain_matrix_integration_test.go
@@ -1,0 +1,183 @@
+//go:build boxlite_dev
+
+package boxlite
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+)
+
+// waitWatchdog runs fn (which performs a blocking Wait) and fails the test if it
+// does not return within d — i.e. the exec hung instead of reporting exit.
+func waitWatchdog(t *testing.T, d time.Duration, what string, fn func()) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() { fn(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(d):
+		t.Fatalf("HANG: %s did not return within %s (Wait never unblocked)", what, d)
+	}
+}
+
+// TestIntegrationExecDrainMatrix is the regression matrix for PR #812: across
+// termination modes (normal, timeout->SIGTERM, hard SIGKILL, explicit Kill,
+// backgrounded child holding stdout) and stream shapes (stdout, stderr, TTY),
+// Execution.Wait must return promptly with the right exit code and full output
+// instead of hanging. Runtime.Close mid-exec is covered separately below.
+func TestIntegrationExecDrainMatrix(t *testing.T) {
+	rt := newTestRuntime(t)
+	box := createStartedBoxOrSkip(t, rt, "alpine:latest", WithAutoRemove(false))
+
+	// run starts an exec, watchdogs the Wait, and returns the exit code.
+	run := func(t *testing.T, opts *ExecutionOptions, args []string, watchdog time.Duration, kill func(*Execution)) int {
+		t.Helper()
+		exec, err := box.StartExecution(context.Background(), "sh", args, opts)
+		if err != nil {
+			t.Fatalf("StartExecution: %v", err)
+		}
+		defer exec.Close()
+		var code int
+		if kill != nil {
+			go kill(exec)
+		}
+		waitWatchdog(t, watchdog, t.Name(), func() { code, _ = exec.Wait(context.Background()) })
+		return code
+	}
+
+	t.Run("normal-exit", func(t *testing.T) {
+		var out bytes.Buffer
+		code := run(t, &ExecutionOptions{Stdout: &out}, []string{"-c", "echo hi; exit 5"}, 12*time.Second, nil)
+		if code != 5 {
+			t.Errorf("exit = %d, want 5", code)
+		}
+		if out.Len() == 0 {
+			t.Errorf("stdout empty, want output before exit")
+		}
+	})
+
+	t.Run("timeout-SIGTERM", func(t *testing.T) {
+		var out bytes.Buffer
+		code := run(t, &ExecutionOptions{Stdout: &out, Timeout: 2 * time.Second},
+			[]string{"-c", "echo before; sleep 30"}, 14*time.Second, nil)
+		if code == 0 {
+			t.Errorf("exit = 0, want non-zero (killed by timeout)")
+		}
+		if !bytes.Contains(out.Bytes(), []byte("before")) {
+			t.Errorf("pre-kill stdout lost: %q", out.String())
+		}
+	})
+
+	t.Run("hard-SIGKILL-escalate", func(t *testing.T) {
+		// trap+ignore SIGTERM so the timeout must escalate to SIGKILL.
+		var out bytes.Buffer
+		code := run(t, &ExecutionOptions{Stdout: &out, Timeout: 2 * time.Second},
+			[]string{"-c", "trap '' TERM; echo before; while :; do sleep 0.2; done"}, 25*time.Second, nil)
+		if code == 0 {
+			t.Errorf("exit = 0, want non-zero (SIGKILL)")
+		}
+		if !bytes.Contains(out.Bytes(), []byte("before")) {
+			t.Errorf("pre-kill stdout lost: %q", out.String())
+		}
+	})
+
+	t.Run("bg-child-holds-stdout", func(t *testing.T) {
+		// Main exits 0 but a backgrounded child inherits stdout; the pump may
+		// not see a natural EOF. Wait must still return (drain gives up).
+		var out bytes.Buffer
+		code := run(t, &ExecutionOptions{Stdout: &out}, []string{"-c", "echo hi; sleep 30 &"}, 12*time.Second, nil)
+		if code != 0 {
+			t.Errorf("exit = %d, want 0", code)
+		}
+		if !bytes.Contains(out.Bytes(), []byte("hi")) {
+			t.Errorf("stdout lost: %q", out.String())
+		}
+	})
+
+	t.Run("explicit-Kill", func(t *testing.T) {
+		code := run(t, &ExecutionOptions{}, []string{"-c", "echo before; sleep 30"}, 12*time.Second,
+			func(e *Execution) {
+				time.Sleep(700 * time.Millisecond)
+				_ = e.Kill(context.Background())
+			})
+		if code == 0 {
+			t.Errorf("exit = 0, want non-zero (killed)")
+		}
+	})
+
+	t.Run("stderr-separate", func(t *testing.T) {
+		var out, errb bytes.Buffer
+		code := run(t, &ExecutionOptions{Stdout: &out, Stderr: &errb},
+			[]string{"-c", "echo OUT; echo ERRLINE 1>&2; exit 3"}, 12*time.Second, nil)
+		if code != 3 {
+			t.Errorf("exit = %d, want 3", code)
+		}
+		if !bytes.Contains(out.Bytes(), []byte("OUT")) || !bytes.Contains(errb.Bytes(), []byte("ERRLINE")) {
+			t.Errorf("stream loss: stdout=%q stderr=%q", out.String(), errb.String())
+		}
+	})
+
+	t.Run("tty-normal", func(t *testing.T) {
+		var out bytes.Buffer
+		code := run(t, &ExecutionOptions{TTY: true, Stdout: &out}, []string{"-c", "echo hi; exit 0"}, 12*time.Second, nil)
+		if code != 0 {
+			t.Errorf("exit = %d, want 0", code)
+		}
+		if out.Len() == 0 {
+			t.Errorf("TTY stdout empty")
+		}
+	})
+
+	t.Run("tty-timeout", func(t *testing.T) {
+		var out bytes.Buffer
+		code := run(t, &ExecutionOptions{TTY: true, Stdout: &out, Timeout: 2 * time.Second},
+			[]string{"-c", "echo hi; sleep 30"}, 14*time.Second, nil)
+		if code == 0 {
+			t.Errorf("exit = 0, want non-zero (timeout)")
+		}
+	})
+}
+
+// TestIntegrationExecRuntimeCloseUnblocksWait covers the e.closing path: closing
+// the Runtime while an exec is in flight must unblock Wait with ErrRuntimeClosed
+// rather than hanging.
+func TestIntegrationExecRuntimeCloseUnblocksWait(t *testing.T) {
+	home, err := os.MkdirTemp("/tmp", "boxlite-rtclose-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(home) })
+	rt, err := NewRuntime(WithHomeDir(home))
+	if err != nil {
+		var e *Error
+		if errors.As(err, &e) && (e.Code == ErrUnsupported || e.Code == ErrUnsupportedEngine) {
+			t.Skipf("runtime not available: %v", err)
+		}
+		t.Fatalf("NewRuntime: %v", err)
+	}
+	box := createStartedBoxOrSkip(t, rt, "alpine:latest", WithAutoRemove(false))
+
+	exec, err := box.StartExecution(context.Background(), "sh", []string{"-c", "echo running; sleep 30"}, &ExecutionOptions{})
+	if err != nil {
+		t.Fatalf("StartExecution: %v", err)
+	}
+	defer exec.Close()
+
+	errCh := make(chan error, 1)
+	go func() { _, e := exec.Wait(context.Background()); errCh <- e }()
+	time.Sleep(700 * time.Millisecond)
+	go func() { _ = rt.Close() }()
+
+	select {
+	case e := <-errCh:
+		if !errors.Is(e, ErrRuntimeClosed) {
+			t.Fatalf("Wait err = %v, want ErrRuntimeClosed", e)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("HANG: Wait did not unblock on Runtime.Close")
+	}
+}

--- a/sdks/go/exec_full_matrix_integration_test.go
+++ b/sdks/go/exec_full_matrix_integration_test.go
@@ -1,0 +1,124 @@
+//go:build boxlite_dev
+
+package boxlite
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+)
+
+// TestIntegrationExecFullMatrix is the full termination x output-shape
+// cross-product (8 x 3 = 24 cells) on a real box. For every combination,
+// Execution.Wait must return promptly (no hang) with the right exit semantics
+// and a sane byte count:
+//   - clean terminations (normal / stderr / tty-normal) and kill terminations on
+//     a fast shape (output finishes before the kill): exact full byte count
+//     (except TTY, whose line discipline rewrites bytes);
+//   - a kill that interrupts the slow trickle: a non-empty prefix (partial).
+func TestIntegrationExecFullMatrix(t *testing.T) {
+	rt := newTestRuntime(t)
+	box := createStartedBoxOrSkip(t, rt, "alpine:latest", WithAutoRemove(false))
+
+	type shape struct {
+		name  string
+		gen   string // sh fragment producing the output to stdout
+		bytes int    // exact byte count when fully delivered (non-TTY)
+		slow  bool   // runs longer than the kill deadlines (the trickle)
+	}
+	shapes := []shape{
+		{"trickle", `i=0; while [ $i -lt 6 ]; do echo line-$i; sleep 0.5; i=$((i+1)); done`, 6 * len("line-0\n"), true},
+		{"throughput", `awk 'BEGIN{for(i=0;i<200000;i++)print "0123456789abcdef0123456789abcdef"}'`, 200000 * 33, false},
+		{"binary", `printf 'abcde'; head -c 1000 /dev/zero`, 1005, false},
+	}
+
+	type term struct {
+		name      string
+		wrap      func(gen string) string
+		timeout   time.Duration
+		kill      func(*Execution)
+		killClass bool // exit must be non-zero; output may be a prefix
+		wantExit  int  // asserted when !killClass
+		tty       bool
+		stderr    bool
+		watchdog  time.Duration
+	}
+	terms := []term{
+		{name: "normal", wrap: func(g string) string { return g + "; exit 7" }, wantExit: 7, watchdog: 25 * time.Second},
+		{name: "timeout-SIGTERM", wrap: func(g string) string { return g + "; sleep 30" }, timeout: 2 * time.Second, killClass: true, watchdog: 25 * time.Second},
+		{name: "hard-SIGKILL", wrap: func(g string) string { return "trap '' TERM; " + g + "; while :; do sleep 0.2; done" }, timeout: 2 * time.Second, killClass: true, watchdog: 35 * time.Second},
+		{name: "bg-child", wrap: func(g string) string { return g + "; sleep 30 &" }, wantExit: 0, watchdog: 25 * time.Second},
+		{name: "explicit-Kill", wrap: func(g string) string { return g + "; sleep 30" }, killClass: true, watchdog: 25 * time.Second,
+			kill: func(e *Execution) { time.Sleep(1500 * time.Millisecond); _ = e.Kill(context.Background()) }},
+		{name: "stderr", wrap: func(g string) string { return "{ " + g + "; } 1>&2; exit 3" }, wantExit: 3, stderr: true, watchdog: 25 * time.Second},
+		{name: "tty-normal", wrap: func(g string) string { return g + "; exit 0" }, wantExit: 0, tty: true, watchdog: 25 * time.Second},
+		{name: "tty-timeout", wrap: func(g string) string { return g + "; sleep 30" }, timeout: 2 * time.Second, killClass: true, tty: true, watchdog: 25 * time.Second},
+	}
+
+	for _, tm := range terms {
+		for _, sh := range shapes {
+			tm, sh := tm, sh
+			t.Run(tm.name+"/"+sh.name, func(t *testing.T) {
+				var out, errb bytes.Buffer
+				opts := &ExecutionOptions{}
+				switch {
+				case tm.tty:
+					opts.TTY = true
+					opts.Stdout = &out
+				case tm.stderr:
+					opts.Stderr = &errb
+				default:
+					opts.Stdout = &out
+				}
+				opts.Timeout = tm.timeout
+
+				exec, err := box.StartExecution(context.Background(), "sh", []string{"-c", tm.wrap(sh.gen)}, opts)
+				if err != nil {
+					t.Fatalf("StartExecution: %v", err)
+				}
+				defer exec.Close()
+				if tm.kill != nil {
+					go tm.kill(exec)
+				}
+
+				var code int
+				var waitErr error
+				waitWatchdog(t, tm.watchdog, t.Name(), func() { code, waitErr = exec.Wait(context.Background()) })
+				if waitErr != nil {
+					t.Fatalf("Wait: %v", waitErr)
+				}
+
+				if tm.killClass {
+					if code == 0 {
+						t.Errorf("exit = 0, want non-zero (killed)")
+					}
+				} else if code != tm.wantExit {
+					t.Errorf("exit = %d, want %d", code, tm.wantExit)
+				}
+
+				n := out.Len()
+				if tm.stderr {
+					n = errb.Len()
+				}
+				if n == 0 {
+					t.Fatalf("output empty, want bytes delivered before termination")
+				}
+
+				killInterruptsTrickle := tm.killClass && sh.slow
+				switch {
+				case tm.tty:
+					// Line discipline rewrites bytes; only require non-empty.
+				case killInterruptsTrickle:
+					if n > sh.bytes {
+						t.Errorf("partial output bytes = %d, exceeds full %d", n, sh.bytes)
+					}
+				default:
+					if n != sh.bytes {
+						t.Errorf("output bytes = %d, want exactly %d", n, sh.bytes)
+					}
+				}
+			})
+		}
+	}
+}

--- a/sdks/go/exec_stall_watchdog_test.go
+++ b/sdks/go/exec_stall_watchdog_test.go
@@ -1,0 +1,63 @@
+package boxlite
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestStallWatchdogKillsBufferedStall verifies the watchdog fires when output is
+// buffered (queuedBytes > 0) yet the sink delivers nothing for the whole
+// timeout, and that it waits at least one timeout before killing.
+func TestStallWatchdogKillsBufferedStall(t *testing.T) {
+	s := &executionStreamState{drained: make(chan struct{})}
+	s.qmu.Lock()
+	s.queuedBytes = 100 // buffered, never drains
+	s.qmu.Unlock()
+
+	const timeout = 200 * time.Millisecond
+	var killed atomic.Bool
+	done := make(chan struct{})
+	start := time.Now()
+	go func() {
+		s.stallWatchdog(timeout, func() { killed.Store(true) })
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		elapsed := time.Since(start)
+		if !killed.Load() {
+			t.Fatal("watchdog returned without killing a permanently stalled sink")
+		}
+		// Anchored at stall-start: detection tick (~timeout/4) + a full timeout.
+		if elapsed < timeout {
+			t.Fatalf("killed after %v, want >= timeout (%v); fired too eagerly", elapsed, timeout)
+		}
+	case <-time.After(4 * timeout):
+		t.Fatal("watchdog never killed a permanently stalled buffered sink")
+	}
+}
+
+// TestStallWatchdogIgnoresQuietExec is the #7 regression guard: an execution
+// that simply produces no output (queuedBytes stays 0, progress never advances)
+// must never be killed — there is nothing buffered, so there is no stall. The
+// earlier logic, which timed from the last progress regardless of whether
+// anything was pending, would have killed this idle-but-healthy execution.
+func TestStallWatchdogIgnoresQuietExec(t *testing.T) {
+	s := &executionStreamState{drained: make(chan struct{})}
+	// queuedBytes stays 0; progress is never bumped.
+
+	const timeout = 150 * time.Millisecond
+	var killed atomic.Bool
+	go s.stallWatchdog(timeout, func() { killed.Store(true) })
+
+	// Let several timeouts elapse: a buggy from-last-progress watchdog would
+	// have fired by now.
+	time.Sleep(4 * timeout)
+	s.closeDrained() // clean end; let the watchdog exit
+
+	if killed.Load() {
+		t.Fatal("watchdog killed a quiet execution that buffered nothing")
+	}
+}

--- a/sdks/go/exec_stream_delivery_integration_test.go
+++ b/sdks/go/exec_stream_delivery_integration_test.go
@@ -1,0 +1,90 @@
+//go:build boxlite_dev
+
+package boxlite
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// blockingSink is an io.Writer that parks the goroutine calling Write until
+// the test releases it. The first Write closes `entered` so the test can
+// observe — without a wall-clock sleep — that delivery has reached the sink,
+// then blocks on `release` (never sent during the test body) so the caller
+// stays parked.
+type blockingSink struct {
+	entered     chan struct{}
+	release     chan struct{}
+	enteredOnce sync.Once
+}
+
+func newBlockingSink() *blockingSink {
+	return &blockingSink{
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+}
+
+func (s *blockingSink) Write(p []byte) (int, error) {
+	s.enteredOnce.Do(func() { close(s.entered) })
+	<-s.release
+	return len(p), nil
+}
+
+// TestIntegrationStdoutBlockingSinkStallsRuntimeDrain guards against
+// head-of-line blocking across executions on one Runtime. A first execution
+// streams stdout into a sink that blocks forever; stream delivery must run off
+// the shared drain goroutine (per-execution writer), so a second, trivial
+// execution on the same box still completes promptly. With inline delivery on
+// the single drain goroutine the second exec's Wait never dispatches and its
+// context deadline fires instead.
+func TestIntegrationStdoutBlockingSinkStallsRuntimeDrain(t *testing.T) {
+	rt := newTestRuntime(t)
+	box := createStartedBoxOrSkip(t, rt, "alpine:latest", WithAutoRemove(false))
+
+	sink := newBlockingSink()
+
+	// Execution A: emit one stdout chunk, then stay alive. The chunk is
+	// delivered into `sink`, parking A's writer goroutine. We never Wait on A.
+	execA, err := box.StartExecution(context.Background(), "sh", []string{"-c", "echo drain-wedge; sleep 60"}, &ExecutionOptions{
+		Stdout: sink,
+	})
+	if err != nil {
+		t.Fatalf("StartExecution(A): %v", err)
+	}
+
+	// Release the parked writer FIRST (close release), then free execution A.
+	// Registered LAST so LIFO runs it BEFORE the box/runtime cleanups.
+	t.Cleanup(func() {
+		close(sink.release)
+		_ = execA.Close()
+	})
+
+	// Wait (event, not a sleep) for delivery to actually reach the blocking
+	// sink before probing.
+	select {
+	case <-sink.entered:
+	case <-time.After(20 * time.Second):
+		t.Skip("execution A never produced stdout within 20s; runtime/guest unavailable")
+	}
+
+	// Execution B: a trivial command on the SAME runtime. It must complete
+	// regardless of A's blocking sink.
+	ctxB, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	res, err := box.Exec(ctxB, "echo", "probe")
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("HEAD-OF-LINE BLOCKING: a second exec on the same Runtime did not "+
+			"complete in %s because execution A's blocking stdout sink wedged stream "+
+			"delivery: %v", elapsed, err)
+	}
+	if res.Stdout != "probe\n" {
+		t.Fatalf("probe exec returned unexpected stdout %q (want %q)", res.Stdout, "probe\n")
+	}
+}

--- a/sdks/go/exec_test.go
+++ b/sdks/go/exec_test.go
@@ -2,7 +2,9 @@ package boxlite
 
 import (
 	"reflect"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 // envMapToFlatPairs is the pure-Go pivot point of ExecutionOptions.Env
@@ -65,6 +67,102 @@ func TestEnvMapToFlatPairs(t *testing.T) {
 		want := []string{"EMPTY", ""}
 		if !reflect.DeepEqual(got, want) {
 			t.Fatalf("empty-value pair must round-trip, want %v got %v", want, got)
+		}
+	})
+}
+
+// TestWaitForStreamDrain pins Wait's drain-barrier semantics: it must keep
+// waiting while the stream is still delivering (so a large tail is never cut
+// off before the exit code is returned), give up promptly when a never-EOF
+// pipe goes idle (instead of hanging forever), surface runtime close, and
+// fall back to a hard cap.
+func TestWaitForStreamDrain(t *testing.T) {
+	t.Run("waits for a still-delivering stream then returns when drained", func(t *testing.T) {
+		var progress atomic.Uint64
+		drained := make(chan struct{})
+		closing := make(chan struct{})
+		// Deliver steadily for ~2.5s — past any 2s-style fixed cap — with
+		// each gap (50ms) under idleBound (100ms) so it never looks idle,
+		// then close drained. A fixed 2s cap would have bailed mid-stream.
+		go func() {
+			for i := 0; i < 50; i++ {
+				time.Sleep(50 * time.Millisecond)
+				progress.Add(1)
+			}
+			close(drained)
+		}()
+
+		start := time.Now()
+		closed := waitForStreamDrain(drained, closing, &progress, 100*time.Millisecond, 30*time.Second)
+		elapsed := time.Since(start)
+
+		if closed {
+			t.Fatal("expected closed=false: ended via drained, not runtime close")
+		}
+		if elapsed < 2400*time.Millisecond {
+			t.Fatalf("returned after %v: gave up before the stream finished "+
+				"delivering (a fixed 2s cap would do this)", elapsed)
+		}
+	})
+
+	t.Run("gives up after one idle window on a stuck never-EOF pipe", func(t *testing.T) {
+		var progress atomic.Uint64 // never bumped
+		drained := make(chan struct{})
+		closing := make(chan struct{})
+
+		start := time.Now()
+		closed := waitForStreamDrain(drained, closing, &progress, 100*time.Millisecond, 30*time.Second)
+		elapsed := time.Since(start)
+
+		if closed {
+			t.Fatal("expected closed=false: idle stall, not runtime close")
+		}
+		if elapsed > 2*time.Second {
+			t.Fatalf("took %v to give up on an idle stream; Wait would hang "+
+				"that long on a SIGKILLed exec", elapsed)
+		}
+	})
+
+	t.Run("reports runtime close", func(t *testing.T) {
+		var progress atomic.Uint64
+		drained := make(chan struct{})
+		closing := make(chan struct{})
+		close(closing)
+
+		if closed := waitForStreamDrain(drained, closing, &progress, 100*time.Millisecond, 30*time.Second); !closed {
+			t.Fatal("expected closed=true when the runtime is closing")
+		}
+	})
+
+	t.Run("falls back to hard cap when a pipe trickles forever", func(t *testing.T) {
+		var progress atomic.Uint64
+		drained := make(chan struct{})
+		closing := make(chan struct{})
+		stop := make(chan struct{})
+		defer close(stop)
+		// Bump within every idle window forever so only the hard cap fires.
+		go func() {
+			tick := time.NewTicker(20 * time.Millisecond)
+			defer tick.Stop()
+			for {
+				select {
+				case <-stop:
+					return
+				case <-tick.C:
+					progress.Add(1)
+				}
+			}
+		}()
+
+		start := time.Now()
+		closed := waitForStreamDrain(drained, closing, &progress, 100*time.Millisecond, 300*time.Millisecond)
+		elapsed := time.Since(start)
+
+		if closed {
+			t.Fatal("expected closed=false: hard cap, not runtime close")
+		}
+		if elapsed < 250*time.Millisecond || elapsed > 1500*time.Millisecond {
+			t.Fatalf("expected release near the 300ms hard cap, got %v", elapsed)
 		}
 	})
 }

--- a/src/boxlite/src/litebox/exec.rs
+++ b/src/boxlite/src/litebox/exec.rs
@@ -287,8 +287,8 @@ impl Execution {
         id: &str,
     ) -> (
         Self,
-        mpsc::UnboundedSender<String>,
-        mpsc::UnboundedSender<String>,
+        mpsc::Sender<String>,
+        mpsc::Sender<String>,
         mpsc::UnboundedReceiver<Vec<u8>>,
         mpsc::UnboundedSender<ExecResult>,
     ) {
@@ -312,8 +312,8 @@ impl Execution {
             }
         }
 
-        let (stdout_tx, stdout_rx) = mpsc::unbounded_channel::<String>();
-        let (stderr_tx, stderr_rx) = mpsc::unbounded_channel::<String>();
+        let (stdout_tx, stdout_rx) = mpsc::channel::<String>(64);
+        let (stderr_tx, stderr_rx) = mpsc::channel::<String>(64);
         let (stdin_tx, stdin_rx) = mpsc::unbounded_channel::<Vec<u8>>();
         let (result_tx, result_rx) = mpsc::unbounded_channel::<ExecResult>();
 
@@ -393,11 +393,11 @@ impl ExecStdin {
 
 /// Standard output stream (read-only).
 pub struct ExecStdout {
-    receiver: mpsc::UnboundedReceiver<String>,
+    receiver: mpsc::Receiver<String>,
 }
 
 impl ExecStdout {
-    pub(crate) fn new(receiver: mpsc::UnboundedReceiver<String>) -> Self {
+    pub(crate) fn new(receiver: mpsc::Receiver<String>) -> Self {
         Self { receiver }
     }
 }
@@ -412,11 +412,11 @@ impl Stream for ExecStdout {
 
 /// Standard error stream (read-only).
 pub struct ExecStderr {
-    receiver: mpsc::UnboundedReceiver<String>,
+    receiver: mpsc::Receiver<String>,
 }
 
 impl ExecStderr {
-    pub(crate) fn new(receiver: mpsc::UnboundedReceiver<String>) -> Self {
+    pub(crate) fn new(receiver: mpsc::Receiver<String>) -> Self {
         Self { receiver }
     }
 }

--- a/src/boxlite/src/portal/interfaces/exec.rs
+++ b/src/boxlite/src/portal/interfaces/exec.rs
@@ -19,12 +19,20 @@ pub struct ExecutionInterface {
     client: ExecutionClient<Channel>,
 }
 
+/// Bounded capacity for the per-execution stdout/stderr text channels.
+/// Bounding these (rather than the original unbounded channels) is what lets
+/// host-side back-pressure propagate: when the consumer pauses, this channel
+/// fills, `DecodedStream::send_bytes().await` blocks the attach reader, which
+/// stops draining the guest gRPC stream and ultimately blocks the guest
+/// process's write(). Keep stdin/result channels unbounded (single messages).
+const STREAM_CHANNEL_CAP: usize = 64;
+
 /// Components for building an Execution.
 pub struct ExecComponents {
     pub execution_id: String,
     pub stdin_tx: mpsc::UnboundedSender<Vec<u8>>,
-    pub stdout_rx: mpsc::UnboundedReceiver<String>,
-    pub stderr_rx: mpsc::UnboundedReceiver<String>,
+    pub stdout_rx: mpsc::Receiver<String>,
+    pub stderr_rx: mpsc::Receiver<String>,
     pub result_rx: mpsc::UnboundedReceiver<ExecResult>,
 }
 
@@ -48,8 +56,8 @@ impl ExecutionInterface {
     ) -> BoxliteResult<ExecComponents> {
         // Create channels
         let (stdin_tx, stdin_rx) = mpsc::unbounded_channel::<Vec<u8>>();
-        let (stdout_tx, stdout_rx) = mpsc::unbounded_channel::<String>();
-        let (stderr_tx, stderr_rx) = mpsc::unbounded_channel::<String>();
+        let (stdout_tx, stdout_rx) = mpsc::channel::<String>(STREAM_CHANNEL_CAP);
+        let (stderr_tx, stderr_rx) = mpsc::channel::<String>(STREAM_CHANNEL_CAP);
         let (result_tx, result_rx) = mpsc::unbounded_channel();
 
         // Build request
@@ -253,8 +261,8 @@ impl ExecProtocol {
     fn spawn_attach(
         mut client: ExecutionClient<Channel>,
         execution_id: String,
-        stdout_tx: mpsc::UnboundedSender<String>,
-        stderr_tx: mpsc::UnboundedSender<String>,
+        stdout_tx: mpsc::Sender<String>,
+        stderr_tx: mpsc::Sender<String>,
         shutdown_token: CancellationToken,
     ) {
         tokio::spawn(async move {
@@ -298,8 +306,8 @@ impl ExecProtocol {
                                     message_count,
                                     "Attach stream cancelled during shutdown"
                                 );
-                                stdout.flush();
-                                stderr.flush();
+                                stdout.flush().await;
+                                stderr.flush().await;
                                 break;
                             }
                             msg = stream.message() => msg,
@@ -308,7 +316,7 @@ impl ExecProtocol {
                         match output.transpose() {
                             Some(Ok(output)) => {
                                 message_count += 1;
-                                Self::route_output(output, &mut stdout, &mut stderr);
+                                Self::route_output(output, &mut stdout, &mut stderr).await;
                             }
                             Some(Err(e)) => {
                                 tracing::debug!(
@@ -321,9 +329,9 @@ impl ExecProtocol {
                                 // the held-over partial bytes (as U+FFFD)
                                 // arrive in correct order ahead of the
                                 // synthesized "Attach stream error: …" line.
-                                stdout.flush();
-                                stderr.flush();
-                                let _ = stderr.tx.send(format!("Attach stream error: {}", e));
+                                stdout.flush().await;
+                                stderr.flush().await;
+                                let _ = stderr.tx.send(format!("Attach stream error: {}", e)).await;
                                 break;
                             }
                             None => {
@@ -331,8 +339,8 @@ impl ExecProtocol {
                                 // bytes still in the decoders as U+FFFD,
                                 // matching `from_utf8_lossy` semantics for
                                 // a truncated input at EOF.
-                                stdout.flush();
-                                stderr.flush();
+                                stdout.flush().await;
+                                stderr.flush().await;
                                 break;
                             }
                         }
@@ -346,21 +354,25 @@ impl ExecProtocol {
                 }
                 Err(e) => {
                     tracing::debug!(execution_id = %execution_id, error = %e, "Attach failed");
-                    let _ = stderr_tx.send(format!("Attach failed: {}", e));
+                    let _ = stderr_tx.send(format!("Attach failed: {}", e)).await;
                 }
             }
         });
     }
 
-    fn route_output(output: ExecOutput, stdout: &mut DecodedStream, stderr: &mut DecodedStream) {
+    async fn route_output(
+        output: ExecOutput,
+        stdout: &mut DecodedStream,
+        stderr: &mut DecodedStream,
+    ) {
         match output.event {
             Some(exec_output::Event::Stdout(chunk)) => {
                 tracing::trace!(len = chunk.data.len(), "Received exec stdout");
-                stdout.send_bytes(chunk.data);
+                stdout.send_bytes(chunk.data).await;
             }
             Some(exec_output::Event::Stderr(chunk)) => {
                 tracing::trace!(len = chunk.data.len(), "Received exec stderr");
-                stderr.send_bytes(chunk.data);
+                stderr.send_bytes(chunk.data).await;
             }
             None => {}
         }
@@ -638,12 +650,12 @@ impl Utf8StreamDecoder {
 /// so the two can't drift apart across the attach loop's branches (the same
 /// co-location tungstenite uses in `StringCollector`).
 struct DecodedStream {
-    tx: mpsc::UnboundedSender<String>,
+    tx: mpsc::Sender<String>,
     decoder: Utf8StreamDecoder,
 }
 
 impl DecodedStream {
-    fn new(tx: mpsc::UnboundedSender<String>) -> Self {
+    fn new(tx: mpsc::Sender<String>) -> Self {
         Self {
             tx,
             decoder: Utf8StreamDecoder::default(),
@@ -651,18 +663,20 @@ impl DecodedStream {
     }
 
     /// Decode a wire chunk and forward any completed text to the receiver.
-    fn send_bytes(&mut self, data: Vec<u8>) {
+    /// The send is awaited on a bounded channel: if the consumer has paused,
+    /// this blocks the attach reader and back-pressures the guest.
+    async fn send_bytes(&mut self, data: Vec<u8>) {
         let text = self.decoder.decode(data);
         if !text.is_empty() {
-            let _ = self.tx.send(text);
+            let _ = self.tx.send(text).await;
         }
     }
 
     /// Drain a held partial codepoint as U+FFFD when the stream ends.
-    fn flush(&mut self) {
+    async fn flush(&mut self) {
         let tail = self.decoder.flush();
         if !tail.is_empty() {
-            let _ = self.tx.send(tail);
+            let _ = self.tx.send(tail).await;
         }
     }
 }
@@ -1088,12 +1102,12 @@ mod tests {
     /// route_output uses the decoder; verify it doesn't double-emit U+FFFD
     /// when a 3-byte char straddles two ExecOutput messages. This is the
     /// integration-shaped reproducer for the original bug.
-    #[test]
-    fn route_output_recovers_split_codepoint_across_messages() {
+    #[tokio::test]
+    async fn route_output_recovers_split_codepoint_across_messages() {
         use boxlite_shared::{Stdout as StdoutMsg, exec_output};
 
-        let (stdout_tx, mut stdout_rx) = mpsc::unbounded_channel::<String>();
-        let (stderr_tx, mut stderr_rx) = mpsc::unbounded_channel::<String>();
+        let (stdout_tx, mut stdout_rx) = mpsc::channel::<String>(STREAM_CHANNEL_CAP);
+        let (stderr_tx, mut stderr_rx) = mpsc::channel::<String>(STREAM_CHANNEL_CAP);
         let mut stdout = DecodedStream::new(stdout_tx);
         let mut stderr = DecodedStream::new(stderr_tx);
 
@@ -1102,8 +1116,8 @@ mod tests {
         };
 
         // "─" split into [E2] and [94 80] across two messages.
-        ExecProtocol::route_output(mk_stdout(vec![0xE2]), &mut stdout, &mut stderr);
-        ExecProtocol::route_output(mk_stdout(vec![0x94, 0x80]), &mut stdout, &mut stderr);
+        ExecProtocol::route_output(mk_stdout(vec![0xE2]), &mut stdout, &mut stderr).await;
+        ExecProtocol::route_output(mk_stdout(vec![0x94, 0x80]), &mut stdout, &mut stderr).await;
 
         // First message: holdover only, no emission.
         // Second message: complete "─" emitted.
@@ -1121,22 +1135,22 @@ mod tests {
     /// shutdown cancellation) so trailing partial UTF-8 bytes are never
     /// silently dropped — keeping the helper correct keeps all three paths
     /// correct.
-    #[test]
-    fn decoded_stream_flush_drains_held_bytes_on_any_exit_path() {
-        let (stdout_tx, mut stdout_rx) = mpsc::unbounded_channel::<String>();
-        let (stderr_tx, mut stderr_rx) = mpsc::unbounded_channel::<String>();
+    #[tokio::test]
+    async fn decoded_stream_flush_drains_held_bytes_on_any_exit_path() {
+        let (stdout_tx, mut stdout_rx) = mpsc::channel::<String>(STREAM_CHANNEL_CAP);
+        let (stderr_tx, mut stderr_rx) = mpsc::channel::<String>(STREAM_CHANNEL_CAP);
         let mut stdout = DecodedStream::new(stdout_tx);
         let mut stderr = DecodedStream::new(stderr_tx);
 
         // Seed each stream with the first byte of a 3-byte codepoint so it
         // has held-over bytes that would be lost without an explicit flush.
-        stdout.send_bytes(vec![0xE2]);
-        stderr.send_bytes(vec![0xE2]);
+        stdout.send_bytes(vec![0xE2]).await;
+        stderr.send_bytes(vec![0xE2]).await;
         assert!(stdout_rx.try_recv().is_err());
         assert!(stderr_rx.try_recv().is_err());
 
-        stdout.flush();
-        stderr.flush();
+        stdout.flush().await;
+        stderr.flush().await;
 
         // Both channels must receive U+FFFD (matches from_utf8_lossy on a
         // truncated tail). Without the flush, error/shutdown paths silently
@@ -1144,8 +1158,8 @@ mod tests {
         assert_eq!(stdout_rx.try_recv().ok(), Some("\u{FFFD}".to_string()));
         assert_eq!(stderr_rx.try_recv().ok(), Some("\u{FFFD}".to_string()));
         // Idempotent: a second flush is a no-op (channels stay empty).
-        stdout.flush();
-        stderr.flush();
+        stdout.flush().await;
+        stderr.flush().await;
         assert!(stdout_rx.try_recv().is_err());
         assert!(stderr_rx.try_recv().is_err());
     }

--- a/src/boxlite/src/rest/litebox.rs
+++ b/src/boxlite/src/rest/litebox.rs
@@ -93,8 +93,8 @@ impl BoxBackend for RestBox {
         let execution_id = resp.execution_id;
 
         // 2. Set up channels for stdout, stderr, stdin, and result
-        let (stdout_tx, stdout_rx) = mpsc::unbounded_channel::<String>();
-        let (stderr_tx, stderr_rx) = mpsc::unbounded_channel::<String>();
+        let (stdout_tx, stdout_rx) = mpsc::channel::<String>(64);
+        let (stderr_tx, stderr_rx) = mpsc::channel::<String>(64);
         let (stdin_tx, stdin_rx) = mpsc::unbounded_channel::<Vec<u8>>();
         let (result_tx, result_rx) = mpsc::unbounded_channel::<ExecResult>();
 
@@ -151,8 +151,8 @@ impl BoxBackend for RestBox {
             other => other,
         })?;
 
-        let (stdout_tx, stdout_rx) = mpsc::unbounded_channel::<String>();
-        let (stderr_tx, stderr_rx) = mpsc::unbounded_channel::<String>();
+        let (stdout_tx, stdout_rx) = mpsc::channel::<String>(64);
+        let (stderr_tx, stderr_rx) = mpsc::channel::<String>(64);
         let (stdin_tx, stdin_rx) = mpsc::unbounded_channel::<Vec<u8>>();
         let (result_tx, result_rx) = mpsc::unbounded_channel::<ExecResult>();
 
@@ -503,8 +503,8 @@ async fn attach_ws(
     box_id: &str,
     execution_id: &str,
     stdin_rx: mpsc::UnboundedReceiver<Vec<u8>>,
-    stdout_tx: mpsc::UnboundedSender<String>,
-    stderr_tx: mpsc::UnboundedSender<String>,
+    stdout_tx: mpsc::Sender<String>,
+    stderr_tx: mpsc::Sender<String>,
     result_tx: mpsc::UnboundedSender<ExecResult>,
 ) {
     let path = format!("/boxes/{}/executions/{}/attach", box_id, execution_id);
@@ -557,8 +557,8 @@ async fn attach_ws_pump(
         tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
     >,
     mut stdin_rx: mpsc::UnboundedReceiver<Vec<u8>>,
-    stdout_tx: mpsc::UnboundedSender<String>,
-    stderr_tx: mpsc::UnboundedSender<String>,
+    stdout_tx: mpsc::Sender<String>,
+    stderr_tx: mpsc::Sender<String>,
     result_tx: mpsc::UnboundedSender<ExecResult>,
 ) {
     use futures::{SinkExt, StreamExt};
@@ -674,11 +674,11 @@ async fn attach_ws_pump(
                                 match *channel {
                                     0x01 => {
                                         tracing::trace!(len = text.len(), "WS attach: stdout frame");
-                                        let _ = stdout_tx.send(text);
+                                        let _ = stdout_tx.send(text).await;
                                     }
                                     0x02 => {
                                         tracing::trace!(len = text.len(), "WS attach: stderr frame");
-                                        let _ = stderr_tx.send(text);
+                                        let _ = stderr_tx.send(text).await;
                                     }
                                     other => {
                                         tracing::warn!(channel = other, "WS attach: unknown channel prefix");

--- a/src/boxlite/src/rest/litebox.rs
+++ b/src/boxlite/src/rest/litebox.rs
@@ -580,6 +580,11 @@ async fn attach_ws_pump(
     // Sticky across reconnects: once the server has ever sent a frame the
     // exec is real, so a later reconnect uses the steady-state watchdog.
     let mut first_frame_seen = false;
+    // Counts stdout/stderr frames dropped when the consumer's bounded channel
+    // is full. We warn once on the first drop (so backpressure-induced output
+    // loss is visible without flooding logs) and report the running total on
+    // clean exit.
+    let mut dropped_output_frames: u64 = 0;
 
     let mut current_stream = Some(initial_stream);
 
@@ -678,11 +683,23 @@ async fn attach_ws_pump(
                                     // slow consumer would stall exit propagation and hang Wait.
                                     0x01 => {
                                         tracing::trace!(len = text.len(), "WS attach: stdout frame");
-                                        let _ = stdout_tx.try_send(text);
+                                        if let Err(err) = stdout_tx.try_send(text) {
+                                            note_dropped_frame(
+                                                "stdout",
+                                                err,
+                                                &mut dropped_output_frames,
+                                            );
+                                        }
                                     }
                                     0x02 => {
                                         tracing::trace!(len = text.len(), "WS attach: stderr frame");
-                                        let _ = stderr_tx.try_send(text);
+                                        if let Err(err) = stderr_tx.try_send(text) {
+                                            note_dropped_frame(
+                                                "stderr",
+                                                err,
+                                                &mut dropped_output_frames,
+                                            );
+                                        }
                                     }
                                     other => {
                                         tracing::warn!(channel = other, "WS attach: unknown channel prefix");
@@ -693,6 +710,12 @@ async fn attach_ws_pump(
                         Message::Text(text) => match parse_control_frame(&text) {
                             ControlFrame::Exit { exit_code } => {
                                 tracing::debug!(exit_code, "WS attach: exit control frame");
+                                if dropped_output_frames > 0 {
+                                    tracing::warn!(
+                                        dropped_output_frames,
+                                        "WS attach: exec completed but some output frames were dropped (consumer fell behind)"
+                                    );
+                                }
                                 let _ = result_tx.send(ExecResult {
                                     exit_code,
                                     error_message: None,
@@ -828,6 +851,28 @@ async fn probe_execution_status(
         // the reconnect budget against something that isn't there.
         Ok(Err(BoxliteError::NotFound(_))) => ProbeResult::Gone,
         _ => ProbeResult::Unavailable,
+    }
+}
+
+/// Record a stdout/stderr frame that couldn't be delivered to the consumer's
+/// bounded channel. `Full` means backpressure dropped output — warn once (on the
+/// first drop) so the loss is visible without flooding logs, and keep counting.
+/// `Closed` means the consumer is gone — that's the normal teardown race, so it
+/// stays at debug.
+fn note_dropped_frame(stream: &str, err: mpsc::error::TrySendError<String>, dropped: &mut u64) {
+    match err {
+        mpsc::error::TrySendError::Full(_) => {
+            *dropped += 1;
+            if *dropped == 1 {
+                tracing::warn!(
+                    stream,
+                    "WS attach: dropping output frame (consumer channel full)"
+                );
+            }
+        }
+        mpsc::error::TrySendError::Closed(_) => {
+            tracing::debug!(stream, "WS attach: consumer channel closed; dropping frame");
+        }
     }
 }
 
@@ -1500,5 +1545,28 @@ mod tests {
 
         attach.await.unwrap();
         server.abort();
+    }
+
+    #[test]
+    fn note_dropped_frame_counts_full_not_closed() {
+        // A full bounded channel yields TrySendError::Full — that's a real
+        // backpressure drop and must be counted.
+        let (tx, _rx) = mpsc::channel::<String>(1);
+        tx.try_send("first".to_string()).unwrap(); // fills the single slot
+        let full = tx.try_send("dropped".to_string()).unwrap_err();
+        assert!(matches!(full, mpsc::error::TrySendError::Full(_)));
+
+        let mut dropped = 0u64;
+        note_dropped_frame("stdout", full, &mut dropped);
+        assert_eq!(dropped, 1, "a Full drop must be counted");
+
+        // A closed channel (consumer gone) is the normal teardown race, not a
+        // backpressure drop — it must NOT inflate the dropped-output count.
+        let (tx2, rx2) = mpsc::channel::<String>(1);
+        drop(rx2);
+        let closed = tx2.try_send("after-close".to_string()).unwrap_err();
+        assert!(matches!(closed, mpsc::error::TrySendError::Closed(_)));
+        note_dropped_frame("stdout", closed, &mut dropped);
+        assert_eq!(dropped, 1, "a Closed send must not be counted as a drop");
     }
 }

--- a/src/boxlite/src/rest/litebox.rs
+++ b/src/boxlite/src/rest/litebox.rs
@@ -672,13 +672,17 @@ async fn attach_ws_pump(
                             if let Some((channel, payload)) = bytes.split_first() {
                                 let text = String::from_utf8_lossy(payload).into_owned();
                                 match *channel {
+                                    // try_send (drop on full), NOT send().await: this single
+                                    // loop also processes the Exit/Error control frames, so a
+                                    // back-pressured stdout/stderr must never block — otherwise a
+                                    // slow consumer would stall exit propagation and hang Wait.
                                     0x01 => {
                                         tracing::trace!(len = text.len(), "WS attach: stdout frame");
-                                        let _ = stdout_tx.send(text).await;
+                                        let _ = stdout_tx.try_send(text);
                                     }
                                     0x02 => {
                                         tracing::trace!(len = text.len(), "WS attach: stderr frame");
-                                        let _ = stderr_tx.send(text).await;
+                                        let _ = stderr_tx.try_send(text);
                                     }
                                     other => {
                                         tracing::warn!(channel = other, "WS attach: unknown channel prefix");

--- a/src/boxlite/src/rest/litebox.rs
+++ b/src/boxlite/src/rest/litebox.rs
@@ -1298,8 +1298,8 @@ mod tests {
         });
 
         let client = client_for(port);
-        let (stdout_tx, mut stdout_rx) = mpsc::unbounded_channel::<String>();
-        let (stderr_tx, _stderr_rx) = mpsc::unbounded_channel::<String>();
+        let (stdout_tx, mut stdout_rx) = mpsc::channel::<String>(64);
+        let (stderr_tx, _stderr_rx) = mpsc::channel::<String>(64);
         let (stdin_tx, stdin_rx) = mpsc::unbounded_channel::<Vec<u8>>();
         let (result_tx, mut result_rx) = mpsc::unbounded_channel::<ExecResult>();
 
@@ -1365,8 +1365,8 @@ mod tests {
         });
 
         let client = client_for(port);
-        let (stdout_tx, _stdout_rx) = mpsc::unbounded_channel::<String>();
-        let (stderr_tx, _stderr_rx) = mpsc::unbounded_channel::<String>();
+        let (stdout_tx, _stdout_rx) = mpsc::channel::<String>(64);
+        let (stderr_tx, _stderr_rx) = mpsc::channel::<String>(64);
         let (_stdin_tx, stdin_rx) = mpsc::unbounded_channel::<Vec<u8>>();
         let (result_tx, mut result_rx) = mpsc::unbounded_channel::<ExecResult>();
 
@@ -1421,8 +1421,8 @@ mod tests {
         });
 
         let client = client_for(port);
-        let (stdout_tx, _stdout_rx) = mpsc::unbounded_channel::<String>();
-        let (stderr_tx, _stderr_rx) = mpsc::unbounded_channel::<String>();
+        let (stdout_tx, _stdout_rx) = mpsc::channel::<String>(64);
+        let (stderr_tx, _stderr_rx) = mpsc::channel::<String>(64);
         let (_stdin_tx, stdin_rx) = mpsc::unbounded_channel::<Vec<u8>>();
         let (result_tx, mut result_rx) = mpsc::unbounded_channel::<ExecResult>();
 
@@ -1472,8 +1472,8 @@ mod tests {
         });
 
         let client = client_for(port);
-        let (stdout_tx, _stdout_rx) = mpsc::unbounded_channel::<String>();
-        let (stderr_tx, _stderr_rx) = mpsc::unbounded_channel::<String>();
+        let (stdout_tx, _stdout_rx) = mpsc::channel::<String>(64);
+        let (stderr_tx, _stderr_rx) = mpsc::channel::<String>(64);
         let (_stdin_tx, stdin_rx) = mpsc::unbounded_channel::<Vec<u8>>();
         let (result_tx, mut result_rx) = mpsc::unbounded_channel::<ExecResult>();
 

--- a/src/cli/src/commands/serve/mod.rs
+++ b/src/cli/src/commands/serve/mod.rs
@@ -1105,8 +1105,8 @@ mod tests {
     /// stdout/stderr/result channels we control from the test.
     fn make_test_active() -> (
         Arc<ActiveExecution>,
-        tokio::sync::mpsc::UnboundedSender<String>, // stdout driver
-        tokio::sync::mpsc::UnboundedSender<String>, // stderr driver
+        tokio::sync::mpsc::Sender<String>, // stdout driver
+        tokio::sync::mpsc::Sender<String>, // stderr driver
         tokio::sync::mpsc::UnboundedSender<boxlite::ExecResult>, // result driver
     ) {
         let (exec, stdout_tx, stderr_tx, _stdin_rx, result_tx) =
@@ -1135,7 +1135,7 @@ mod tests {
         // task inside ActiveExecution::new reads these and broadcasts
         // them.
         for i in 1..=5 {
-            stdout_tx.send(format!("line-{i}\n")).unwrap();
+            stdout_tx.send(format!("line-{i}\n")).await.unwrap();
         }
         // Give the pump task a tick to broadcast all 5 chunks.
         tokio::time::sleep(Duration::from_millis(50)).await;
@@ -1147,7 +1147,7 @@ mod tests {
 
         // Push one more line AFTER the subscribe so we can prove the
         // channel is alive.
-        stdout_tx.send("line-6\n".to_string()).unwrap();
+        stdout_tx.send("line-6\n".to_string()).await.unwrap();
         tokio::time::sleep(Duration::from_millis(20)).await;
 
         let mut received = Vec::new();
@@ -1194,7 +1194,7 @@ mod tests {
 
         // Push output, then signal exit immediately. The pump task
         // must read from ExecStdout and broadcast BEFORE done fires.
-        stdout_tx.send("final-line\n".to_string()).unwrap();
+        stdout_tx.send("final-line\n".to_string()).await.unwrap();
         drop(stdout_tx);
         drop(stderr_tx);
         result_tx


### PR DESCRIPTION
Move the Go/C SDK and FFI stream-drain/backpressure work out of #841.

Test plan:
- BOXLITE_DEPS_STUB=1 cargo build -p boxlite-c
- cp target/debug/libboxlite.a sdks/go/libboxlite.a
- cd sdks/go && go test . -run 'TestWaitForStreamDrain|TestStreamStall|TestExecutionStream|TestWait|TestBackpressure' -count=1
