### PR TITLE
feat(runtime): default image registries to ghcr.io + docker.io

### DIFF
--- a/src/boxlite/src/runtime/options.rs
+++ b/src/boxlite/src/runtime/options.rs
@@ -25,8 +25,10 @@ pub struct BoxliteOptions {
     /// Use this to configure registry transport, TLS verification, auth, and
     /// whether the registry participates in unqualified image resolution.
     ///
-    /// - Empty list (default): Uses docker.io as the implicit default for
-    ///   unqualified references
+    /// - Default: `ghcr.io` and `docker.io`, both with `search = true`, so
+    ///   unqualified references resolve against them in that order
+    /// - Empty list: Uses docker.io as the implicit default for unqualified
+    ///   references
     /// - `search = true`: Includes the registry when resolving unqualified
     ///   image references
     /// - Fully qualified refs (e.g., `"quay.io/foo"`) use the matching
@@ -44,7 +46,7 @@ pub struct BoxliteOptions {
     /// }
     /// // "alpine" tries ghcr.io/myorg/alpine, then docker.io/alpine
     /// ```
-    #[serde(default)]
+    #[serde(default = "default_image_registries")]
     pub image_registries: Vec<ImageRegistry>,
 }
 
@@ -166,11 +168,21 @@ fn default_home_dir() -> PathBuf {
         })
 }
 
+/// Built-in registries used when none are configured: pull from `ghcr.io`
+/// (BoxLite's curated images) first, then `docker.io`. Both participate in
+/// unqualified reference resolution so users can drop the registry host.
+fn default_image_registries() -> Vec<ImageRegistry> {
+    vec![
+        ImageRegistry::https("ghcr.io").with_search(true),
+        ImageRegistry::https("docker.io").with_search(true),
+    ]
+}
+
 impl Default for BoxliteOptions {
     fn default() -> Self {
         Self {
             home_dir: default_home_dir(),
-            image_registries: Vec::new(),
+            image_registries: default_image_registries(),
         }
     }
 }

--- a/src/cli/src/config.rs
+++ b/src/cli/src/config.rs
@@ -83,8 +83,15 @@ mod tests {
         fs::write(&config_path, config_content).unwrap();
 
         let config = load_config(&config_path).unwrap();
-        // home_dir gets a default value, image_registries is empty
-        assert!(config.image_registries.is_empty());
+        // A missing `image_registries` field falls back to the built-in
+        // default (ghcr.io + docker.io), not an empty list.
+        assert_eq!(
+            config.image_registries,
+            vec![
+                ImageRegistry::https("ghcr.io").with_search(true),
+                ImageRegistry::https("docker.io").with_search(true),
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`BoxliteOptions` previously defaulted `image_registries` to an empty list, so unqualified image references only ever fell back to `docker.io`. This makes the built-in default **`ghcr.io` (BoxLite's curated images) first, then `docker.io`**, both with `search = true`, so callers can drop the registry host:

```
boxlite-ai/boxlite-agent-base:TAG   →   ghcr.io/boxlite-ai/boxlite-agent-base:TAG
```

Fully-qualified refs are unaffected — they are detected as already-qualified and bypass the search list entirely, so the existing curated flow that passes complete refs keeps pulling unchanged.

## What changed

- **`src/boxlite/src/runtime/options.rs`**: add a single `default_image_registries()` helper and wire it into **both** default paths — the `Default` impl and the field-level `#[serde(default = ...)]`. This keeps the two defaults consistent: a config file with a missing `image_registries` field now resolves to the same built-in default as code that constructs `BoxliteOptions` directly (previously the serde path silently produced an empty list). Field doc comment updated.
- **`src/cli/src/config.rs`**: update `test_load_empty_config` to assert the new default instead of `is_empty()`.

## Behavior notes

- Pure increment: only adds a "drop the host" shorthand; the full-ref path is byte-for-byte unchanged (the added `ghcr.io` entry uses `https` + anonymous + verify-TLS, identical to the previous no-match defaults).
- `search` only prepends a registry **host** — it does not synthesize namespaces. `base` does **not** become `ghcr.io/boxlite-ai/...`; users still write `boxlite-ai/boxlite-agent-base:TAG`. Short curated aliases (`base`/`python`/`node`) remain the API-layer concern (`curated-images.constant.ts`), not this default.
- This changes the default pull order for every direct `BoxliteOptions::default()` consumer to try `ghcr.io` first.

## Testing

Run on the Linux dev machine (`BOXLITE_DEPS_STUB=1`, CI-faithful):

- `cargo test -p boxlite --no-default-features --lib registr` → **15 passed / 0 failed** (incl. `registry_options_tests::options_*`, `store::validate_image_registries_*`, `images::test_qualified_bypasses_registries`)
- `cargo test -p boxlite-cli --bins` → **133 passed / 0 failed** (incl. `config::tests::test_load_empty_config`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Default image registries are now pre-configured with GitHub Container Registry and Docker Hub (both with search enabled), eliminating the need for manual registry configuration during initial setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->