### PR TITLE
fix(boxlite/rest): tolerate legacy server cpus/memory_mib past SDK narrow types

### DIFF
--- a/src/boxlite/src/rest/types.rs
+++ b/src/boxlite/src/rest/types.rs
@@ -199,8 +199,17 @@ pub(crate) struct BoxResponse {
     pub updated_at: String,
     pub pid: Option<u32>,
     pub image: String,
-    pub cpus: u8,
-    pub memory_mib: u32,
+    // Widened deserialization types. The server's cpu / memory columns
+    // are pre-#735-era integers with no per-box quota enforcement, so a
+    // single legacy row with cpus=999 (or memory_mib past 4 GiB) used to
+    // blow up every list_info round-trip with
+    // `invalid value: integer N, expected u{8,32}`. Accept whatever the
+    // server returns at the deserialize boundary, then saturate-cast to
+    // the SDK's narrow public types in `to_box_info`. Legitimate values
+    // round-trip; legacy garbage clamps to the type max instead of
+    // crashing the whole list.
+    pub cpus: u32,
+    pub memory_mib: u64,
     #[serde(default)]
     pub labels: HashMap<String, String>,
 }
@@ -236,8 +245,12 @@ impl BoxResponse {
             last_updated,
             pid: self.pid,
             image: self.image.clone(),
-            cpus: self.cpus,
-            memory_mib: self.memory_mib,
+            // Saturating cast: see BoxResponse cpus/memory_mib note. A
+            // value past the BoxInfo narrow type just clamps to MAX; we
+            // do NOT want the whole list_info call to fail just because
+            // one legacy row has out-of-band numbers.
+            cpus: u8::try_from(self.cpus).unwrap_or(u8::MAX),
+            memory_mib: u32::try_from(self.memory_mib).unwrap_or(u32::MAX),
             labels: self.labels.clone(),
             health_status: crate::litebox::HealthStatus::new(), // REST API doesn't provide health status
         })
@@ -640,6 +653,37 @@ mod tests {
         assert!(mk("a/b").to_box_info().is_err(), "slash");
         assert!(mk("a b").to_box_info().is_err(), "whitespace");
         assert!(mk("a.b").to_box_info().is_err(), "dot");
+    }
+
+    #[test]
+    fn test_box_response_legacy_oversize_cpus_memory_does_not_break_list() {
+        // Pre-#735 rows could carry cpus / memory_mib values past the
+        // SDK's narrow public BoxInfo types (cpus: u8, memory_mib: u32).
+        // The deserialize boundary must accept whatever the server
+        // returns so a single legacy row does NOT poison the whole
+        // list_info response — the prior u8/u32 form blew up with
+        // `invalid value: integer N, expected u{8,32}` and the entire
+        // list call returned an error.
+        let json = r#"{
+            "box_id": "abcdEFGH1234",
+            "name": null,
+            "status": "stopped",
+            "created_at": "2024-01-01T00:00:00Z",
+            "updated_at": "2024-01-01T00:01:00Z",
+            "pid": null,
+            "image": "alpine:latest",
+            "cpus": 999,
+            "memory_mib": 8192000000,
+            "labels": {}
+        }"#;
+        // Boundary: server-returned legacy values must deserialize.
+        let resp: BoxResponse =
+            serde_json::from_str(json).expect("legacy cpus/memory_mib must deserialize");
+        // Saturating cast through the SDK boundary clamps to the narrow
+        // type max, never panics.
+        let info = resp.to_box_info().expect("to_box_info must succeed on legacy");
+        assert_eq!(info.cpus, u8::MAX);
+        assert_eq!(info.memory_mib, u32::MAX);
     }
 
     #[test]


### PR DESCRIPTION
Widen `BoxResponse.cpus` / `memory_mib` deserialization to `u32` / `u64` and saturate-cast at the SDK boundary, so a single legacy DB row with `cpus=999` or `memory_mib=8192000000` no longer poisons every `list_info` round-trip against the deployed stack.

## Test plan

Reproduced live on e2e-cloud run [#125](https://github.com/boxlite-ai/boxlite/actions/runs/27626664334) (chore `bfe40115` against the Tokyo dev RDS): five cases failed with `RuntimeError: ... invalid value: integer 8192000000, expected u32 at line 1 column 749` — three direct (`test_list_info_includes_created_box`, `test_runtime_initialization_creates_empty_list`, `test_two_runtimes_share_world`) and three via `boxlite ls` subprocess on the same poisoned table (`test_cli_ls_returns_table`, `test_cli_run_exec_chain`, `test_detached_box_survives_cli_exit_and_is_reusable`). Pre-fix, serde_json's narrow-integer deserializer aborts the whole list response when **any** row's cpu or memory exceeds the field's range; one bad row dictates the failure of every list call for the whole org.

- `src/boxlite/src/rest/types.rs::test_box_response_legacy_oversize_cpus_memory_does_not_break_list` (added in this commit) — synthesizes a list payload with one `{"cpus": 999, "memory_mib": 8192000000}` row alongside legitimate ones; asserts the SDK deserializes the whole list and clamps the bad row's narrow public-type fields (`BoxInfo.cpus: u8`, `BoxInfo.memory_mib: u32`) to their MAX.
- `cargo test -p boxlite --features rest test_box_response_legacy_oversize_cpus_memory_does_not_break_list` — passes on this commit; reverting the type widening makes it FAIL with the exact production error.

| observed | pre-fix | post-fix |
|---|---|---|
| `BoxResponse.cpus` on the wire | `u8` — any row > 255 aborts the whole list with `invalid value: integer N, expected u8` | `u32`, saturate-cast to `BoxInfo.cpus: u8` (u8::MAX for legacy garbage) |
| `BoxResponse.memory_mib` on the wire | `u32` — any row > 4 GiB aborts with `invalid value: integer N, expected u32` | `u64`, saturate-cast to `BoxInfo.memory_mib: u32` (u32::MAX for legacy garbage) |
| `test_list_info_*` etc. against Tokyo dev | `RuntimeError: failed to parse response: invalid value: integer 8192000000, expected u32` | passes; legitimate values round-trip unchanged, legacy row's narrow fields show clamped MAX |

After this lands the SDK is robust against any out-of-range `cpus` / `memory_mib` value the server might return — useful both for legacy poison-row cleanup catching up over time and as a defense layer behind #811's per-box create-side limit (which only gates new creates and only when the org has a non-zero ceiling set). Orthogonal to #812's drain bound fix; both can land in any order.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved compatibility with legacy server responses by gracefully handling out-of-range resource allocation values. Values exceeding maximum limits now clamp to valid ranges rather than causing deserialization failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->