### PR TITLE
feat(infra): name default runner boxlite-runner-default, fix extra-runner tags

### DIFF
--- a/apps/api/src/box/services/per-box-limits.ts
+++ b/apps/api/src/box/services/per-box-limits.ts
@@ -21,12 +21,7 @@ export interface PerBoxLimits {
  * persisted them, which then poisoned every list_info round-trip for the
  * whole org. Memory and disk are compared in GB (the CreateBoxDto unit).
  */
-export function assertWithinPerBoxLimits(
-  cpu: number,
-  memoryGb: number,
-  diskGb: number,
-  limits: PerBoxLimits,
-): void {
+export function assertWithinPerBoxLimits(cpu: number, memoryGb: number, diskGb: number, limits: PerBoxLimits): void {
   const violations: string[] = []
   if (limits.maxCpuPerBox > 0 && cpu > limits.maxCpuPerBox) {
     violations.push(`cpu ${cpu} exceeds the per-box limit of ${limits.maxCpuPerBox}`)

--- a/apps/infra/README.md
+++ b/apps/infra/README.md
@@ -256,7 +256,7 @@ npm run remove -- --stage dev       # destroy everything
 
 ## Runner lifecycle
 
-The Runner EC2 instance (`tag:Name=boxlite-runner`) holds load-bearing state:
+The Runner EC2 instance (`tag:Name=boxlite-runner-default`) holds load-bearing state:
 `/var/lib/boxlite` on its root disk, plus the in-memory libkrun VMs that back
 running boxes. **It must not be replaced by routine deploys.** Two Pulumi
 resource options on `sst.config.ts`'s Runner enforce that:

--- a/apps/infra/sst.config.ts
+++ b/apps/infra/sst.config.ts
@@ -949,7 +949,9 @@ export default $config({
       )
 
     // Default runner — auto-seeded by the API at boot via DEFAULT_RUNNER_*.
-    makeRunner('Runner', 'boxlite-runner', runnerUserData)
+    // Pulumi resource id stays 'Runner' (renaming it would replace a protect:true
+    // instance); only the AWS Name tag carries the explicit `-default` suffix.
+    makeRunner('Runner', 'boxlite-runner-default', runnerUserData)
 
     // Multi-runner provisioning. Extra runners share the same OTel endpoint as
     // the default runner.
@@ -965,11 +967,14 @@ export default $config({
     // replace a state-holding runner.
     const totalRunners = Math.max(1, parseInt(envOr('RUNNERS', '1'), 10) || 1)
     const extraRunners = Array.from({ length: totalRunners - 1 }, (_, i) => {
-      const name = `runner-${i + 2}` // default is runner #1
+      const index = i + 2 // default runner is #1, so extras start at #2
+      const name = `runner-${index}` // control-plane registration name
       const apiKey = randomKey(`RunnerApiKey-${name}`)
+      // Resource id stays `Runner-runner-N` (stable — these are protect:true);
+      // only the AWS Name tag takes the cleaner `boxlite-runner-N` form.
       const instance = makeRunner(
         `Runner-${name}`,
-        `boxlite-runner-${name}`,
+        `boxlite-runner-${index}`,
         $resolve([api.url, apiKey.result, otelCollectorOtlpHttpUrl, ghcrSecret ? ghcrSecret.arn : '']).apply(
           ([apiUrl, token, otelEndpoint, ghcrSecretArn]) =>
             buildRunnerUserData({ apiUrl, token, otelEndpoint, ghcrSecretArn: ghcrSecretArn || undefined, ghcrUsername }),

--- a/scripts/deploy/runner-update-binary.sh
+++ b/scripts/deploy/runner-update-binary.sh
@@ -35,11 +35,11 @@ fi
 echo "==> Upgrading boxlite-runner to v$VERSION on stage=$STAGE region=$AWS_REGION"
 
 INSTANCE_ID=$(aws ec2 describe-instances --region "$AWS_REGION" \
-  --filters "Name=tag:Name,Values=boxlite-runner" "Name=instance-state-name,Values=running" \
+  --filters "Name=tag:Name,Values=boxlite-runner-default" "Name=instance-state-name,Values=running" \
   --query 'Reservations[].Instances[].InstanceId' --output text)
 
 if [[ -z "$INSTANCE_ID" || "$INSTANCE_ID" == "None" ]]; then
-  echo "error: no running boxlite-runner instance found in region $AWS_REGION" >&2
+  echo "error: no running boxlite-runner-default instance found in region $AWS_REGION" >&2
   exit 1
 fi
 echo "    instance: $INSTANCE_ID"


### PR DESCRIPTION
## What

Makes the boxlite runner AWS EC2 `Name` tags explicit and consistent:

- **Default runner**: `boxlite-runner` → `boxlite-runner-default`
- **Extra runners**: `boxlite-runner-runner-N` → `boxlite-runner-N` (drops the doubled "runner")

## Why

The default runner carried a generic `boxlite-runner` tag while extra runners
got an awkward doubled tag (`boxlite-runner-runner-2`). The new scheme reads
cleanly in the AWS console and ops tooling: `boxlite-runner-default`,
`boxlite-runner-2`, `boxlite-runner-3`.

## How / safety

Only the **AWS `Name` tag** changes. The Pulumi resource logical ids
(`'Runner'`, `'Runner-runner-N'`) and the control-plane registration names
(`runner-N`) are deliberately left unchanged — runner instances are
`protect: true` and hold load-bearing state (`/var/lib/boxlite` + in-memory
libkrun VMs), so renaming a logical id would force a destructive replace. Tags
update in place.

The default-runner binary-upgrade path
(`scripts/deploy/runner-update-binary.sh`) selects the runner by this tag, so
its `describe-instances` filter and error message move to
`boxlite-runner-default` in lockstep. `apps/infra/README.md` runner-lifecycle
reference is updated to match.

## Commits

- `feat(infra):` the rename — `sst.config.ts` + `runner-update-binary.sh` + `README.md`
- `style(api):` an incidental prettier autofix of pre-existing drift in
  `per-box-limits.ts` (from #811). The workspace-wide `make lint:fix`
  pre-commit hook reformats it on every commit touching `apps/`, so it had to
  be committed clean to unblock this change. No behavior change — signature
  collapsed to one line (117 chars, under the repo's printWidth=120). Kept as
  its own commit; happy to split into a separate PR if preferred.

## Deploy note

The first `sst deploy` after merge issues an **in-place tag update** on the
live `protect:true` runners — expected and non-destructive. Systemd unit,
binary path, OTel `ServiceName`, and S3 buckets are intentionally unchanged, so
runbooks keyed off those still work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated runner infrastructure documentation to reflect current naming conventions.

* **Chores**
  * Standardized runner instance naming conventions across deployment configuration.
  * Refined deployment automation scripts for runner management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->