### PR TITLE
fix: re-PR functional bits of #808 against main (stopped-box exec 409 + per-platform pull ref)

### DIFF
--- a/apps/runner/pkg/api/controllers/boxlite_exec.go
+++ b/apps/runner/pkg/api/controllers/boxlite_exec.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"time"
 
+	sdkboxlite "github.com/boxlite-ai/boxlite/sdks/go"
 	"github.com/boxlite-ai/runner/pkg/boxlite"
 	"github.com/boxlite-ai/runner/pkg/runner"
 	"github.com/gin-gonic/gin"
@@ -74,6 +75,19 @@ func BoxliteExec(ctx *gin.Context) {
 
 	execId, err := execManager.Start(ctx.Request.Context(), bx, boxId, startOpts)
 	if err != nil {
+		// Classify so a stopped / wrong-state box surfaces as 4xx, not
+		// 500. Without this the box-stopped case leaks
+		//   internal error: HTTP 500 Internal Server Error:
+		//   {"error":"exec failed: failed to start execution: boxlite: stopped:
+		//    Handle invalidated after stop(). ... (code=11)"}
+		// and the SDK's 'all 5xx is bug' guard fires. The Go SDK already
+		// gives us a typed bool for the two states that aren't 500 from
+		// the runner's perspective (the box exists but isn't accepting
+		// execs right now).
+		if sdkboxlite.IsStopped(err) || sdkboxlite.IsInvalidState(err) {
+			ctx.JSON(http.StatusConflict, gin.H{"error": fmt.Sprintf("exec failed: %s", err)})
+			return
+		}
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("exec failed: %s", err)})
 		return
 	}

--- a/src/boxlite/src/images/store.rs
+++ b/src/boxlite/src/images/store.rs
@@ -684,7 +684,7 @@ impl ImageStore {
 
         let platform_manifest = self.select_platform_manifest(index, platform_os, platform_arch)?;
 
-        let platform_ref = format!("{}@{}", reference.whole(), platform_manifest.digest);
+        let platform_ref = build_platform_ref(reference, &platform_manifest.digest);
         let platform_reference: Reference = platform_ref
             .parse()
             .map_err(|e| BoxliteError::Storage(format!("invalid platform reference: {e}")))?;
@@ -1082,6 +1082,23 @@ fn validate_image_registries(image_registries: &[ImageRegistry]) -> BoxliteResul
 /// Used by `ImageManager` and `ImageObject` to share the same store.
 pub type SharedImageStore = Arc<ImageStore>;
 
+/// Build the per-platform pull reference from registry+repository only.
+///
+/// `Reference::whole()` preserves any incoming tag *or* digest, so naively
+/// appending `"@{platform_digest}"` produces the invalid double-`@` form
+/// `repo@sha256:idx@sha256:plat` for digest-pinned refs (e.g.
+/// `ghcr.io/.../base@sha256:...`). The OCI distribution spec accepts at
+/// most one tag-or-digest qualifier per reference, so the per-platform
+/// ref must be rebuilt from the host+path components.
+fn build_platform_ref(reference: &Reference, platform_digest: &str) -> String {
+    format!(
+        "{}/{}@{}",
+        reference.registry(),
+        reference.repository(),
+        platform_digest
+    )
+}
+
 // ============================================================================
 // TESTS
 // ============================================================================
@@ -1098,6 +1115,49 @@ mod tests {
 
     fn test_bearer_token() -> String {
         String::from_utf8(vec![111, 112, 97, 113, 117, 101]).unwrap()
+    }
+
+    #[test]
+    fn build_platform_ref_collapses_digest_pinned_input_to_single_digest() {
+        // Digest-pinned input — previous impl returned
+        // `ghcr.io/.../base@sha256:idx@sha256:plat`, which fails to parse.
+        let reference: Reference =
+            "ghcr.io/boxlite-ai/boxlite-agent-base@sha256:834dcb65465985fc2f648451d76c81d166bc7672391c9064a0a115ce6306c85f"
+                .parse()
+                .expect("parse digest-pinned input");
+        let platform_digest =
+            "sha256:abc1230000000000000000000000000000000000000000000000000000000000";
+
+        let platform_ref = build_platform_ref(&reference, platform_digest);
+
+        assert_eq!(
+            platform_ref,
+            "ghcr.io/boxlite-ai/boxlite-agent-base@sha256:abc1230000000000000000000000000000000000000000000000000000000000",
+        );
+        // Has exactly one `@` qualifier and round-trips through Reference.
+        assert_eq!(platform_ref.matches('@').count(), 1);
+        let _: Reference = platform_ref
+            .parse()
+            .expect("rebuilt platform ref must parse");
+    }
+
+    #[test]
+    fn build_platform_ref_drops_tag_when_resolving_to_platform_digest() {
+        let reference: Reference = "docker.io/library/alpine:3.23"
+            .parse()
+            .expect("parse tagged input");
+        let platform_digest =
+            "sha256:def4560000000000000000000000000000000000000000000000000000000000";
+
+        let platform_ref = build_platform_ref(&reference, platform_digest);
+
+        let parsed: Reference = platform_ref
+            .parse()
+            .expect("rebuilt platform ref must parse");
+        assert_eq!(parsed.registry(), "docker.io");
+        assert_eq!(parsed.repository(), "library/alpine");
+        assert_eq!(parsed.digest(), Some(platform_digest));
+        assert_eq!(parsed.tag(), None);
     }
 
     #[test]

--- a/src/boxlite/src/rest/litebox.rs
+++ b/src/boxlite/src/rest/litebox.rs
@@ -209,9 +209,28 @@ impl BoxBackend for RestBox {
         &self,
         host_src: &Path,
         container_dst: &str,
-        _opts: CopyOptions,
+        opts: CopyOptions,
     ) -> BoxliteResult<()> {
         let box_id = self.box_id_str();
+
+        // Honor overwrite=false at the REST boundary. The runner's
+        // upload handler always extracts the tar over whatever's at
+        // container_dst (the test in scripts/test/e2e/cases/test_files_io.py::
+        // test_copy_in_overwrite_false_rejects_conflict was catching
+        // 'overwrite=False replaced guest content'). The test contract
+        // explicitly accepts a raised exception OR a no-op — the
+        // invariant is "guest content must be unchanged". We can't
+        // express the per-entry "skip if dst exists" semantics over
+        // the current single-tar upload protocol, so refuse the call
+        // outright instead of silently clobbering.
+        if !opts.overwrite {
+            return Err(BoxliteError::Unsupported(
+                "copy_into with overwrite=false is not supported over the REST backend; \
+                 the current upload protocol cannot express per-entry skip-if-exists. \
+                 Use the FFI backend or pre-check the destination before calling."
+                    .into(),
+            ));
+        }
 
         // Create tar archive from host path
         let tar_bytes = create_tar_from_path(host_src)?;


### PR DESCRIPTION
Two real bug fixes from #808 ended up only on `chore/e2e-required-merge-gate` (#724's branch), not on `main`. Re-PR'ing them so they actually land on `main`. Both already reviewed/merged via #808 — straight cherry-picks, no edits.

## Fixes

**`fix(boxlite/images)`: build per-platform pull ref from registry+repository**

Image index → platform manifest resolution used
```rust
format!("{}@{}", reference.whole(), platform_digest)
```
For digest-pinned inputs (e.g. `ghcr.io/boxlite-ai/boxlite-agent-base@sha256:834dcb65…`), `Reference::whole()` returns the input *with* its existing digest, so appending the platform digest yields a malformed double-`@` form:
```
ghcr.io/.../boxlite-agent-base@sha256:idx@sha256:plat
```
which `oci_client` rejects with `invalid reference format` — the live Tokyo runner error
```
storage error: Failed to pull image '<digest-pinned ref>' …
  invalid platform reference: invalid reference format
```

Fix rebuilds the per-platform ref from `registry()` + `repository()` only, replacing (not extending) the index digest.

Two-side verified against `cargo test -p boxlite build_platform_ref`:
- impl reverted → both tests FAIL with double-`@` string
- impl restored → both tests pass.

**`fix(runner+boxlite/rest)`: classify stopped-box exec as 409 and refuse overwrite=false over REST**

Two related real bugs:

1. `test_copy_in_overwrite_false_rejects_conflict` — `src/boxlite/src/rest/litebox.rs::copy_into` named the `CopyOptions` argument `_opts` (dropped on the floor). REST upload is a single tar the runner extracts unconditionally → `overwrite=false` silently became `overwrite=true`. Fix returns `BoxliteError::Unsupported` up front rather than silently clobbering.

2. `test_exec_on_stopped_box_is_typed_error` — `apps/runner/pkg/api/controllers/boxlite_exec.go::BoxliteExec` wrapped every `execManager.Start` error in generic 500. A stopped-box exec surfaces from libboxlite as Go SDK code 11 (`ErrStopped`) — `sdkboxlite.IsStopped`/`IsInvalidState` helpers map it to `409 Conflict`.

Local-verified per #808.

## Why this re-PR
#808's base was set to `chore/e2e-required-merge-gate` (an in-flight #724 branch) instead of `main`. The merge landed there but never reached main.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed invalid reference generation in platform manifest pulling for digest-pinned references.
  * Enforced overwrite option validation in REST-based copy operations.

* **Improvements**
  * Enhanced error handling in exec operations to return more specific HTTP status codes (409 Conflict for stopped/invalid states).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->