### PR TITLE
feat(release): release control-plane tooling foundation (Task 21)

### DIFF
--- a/.github/workflows/release-tooling.yml
+++ b/.github/workflows/release-tooling.yml
@@ -1,0 +1,38 @@
+# Release control-plane tooling tests (Task 21).
+#
+# Path-filtered to scripts/release/** so it only runs when that tooling changes
+# — zero impact on unrelated PRs. Pure Python, no AWS/secrets/KVM.
+name: Release Tooling
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/release/**'
+      - '.github/workflows/release-tooling.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/release/**'
+      - '.github/workflows/release-tooling.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: pytest (release tooling)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install test deps
+        run: pip install --disable-pip-version-check pytest pyyaml
+      - name: Run release-tooling tests
+        working-directory: scripts/release
+        run: python -m pytest -q
+      - name: Validate example manifest
+        working-directory: scripts/release
+        run: python validate_manifest.py release.example.yaml

--- a/scripts/release/cicd/README.md
+++ b/scripts/release/cicd/README.md
@@ -1,0 +1,49 @@
+# Release control-plane tooling (Task 21)
+
+Pure-logic building blocks for the standardized release pipeline. Everything here
+operates on **data + fixtures** (no AWS / registries / CI), so it is unit-tested
+in isolation. The workflows that feed these real `sst diff` / DB state / build
+outputs are wired separately (not in this PR — see "Not done" below).
+
+## Modules
+
+| Module | What it does | Task # |
+|---|---|---|
+| `manifest.py` | parse + validate `release.yaml` (the WHAT-to-ship contract) | #1 |
+| `artifact_manifest.py` | the immutable build-once artifact record deploy trusts (digest-pinned) | #3 |
+| `preflight.py` | pre-apply gates: resource diff, **DB baseline**, **DNS collision** | #8 / DB+DNS pitfalls |
+| `ledger.py` | release ledger + `last_good_sha` for Cloud rollback | #11 / #16 |
+| `versions.py` | OSS single-version-source drift check | version drift |
+
+`validate_manifest.py` is the CLI: `python3 scripts/release/validate_manifest.py <release.yaml>`
+(exit 0 valid / 1 invalid). `release.example.yaml` is a runnable example.
+
+## Why the gates exist (real incidents this guards)
+
+- **DB baseline gate** encodes the `1741/1753` drift class: db ran a migration the
+  baseline doesn't know (divergent branch), OR baseline recorded but the table was
+  never built ("relation does not exist"). Either drift → blocked before apply.
+- **DNS preflight** blocks a record that another stage already owns (cross-stage
+  collision), the kind of footgun a shared Cloudflare zone invites.
+- **resource gate** blocks `replace`/`delete` on stateful resources (Runner/RDS/
+  Redis) unless explicitly overridden — routine deploys must never nuke state.
+
+## Run the tests
+
+```bash
+python3 -m venv .venv && . .venv/bin/activate && pip install pytest pyyaml
+cd scripts/release && python -m pytest -q          # 37 tests, ~0.05s
+```
+
+## Status
+
+**Done + verified here (pure logic, 37 tests, mutation-checked):** all five modules
+above + the validate CLI.
+
+**Not done (needs CI / AWS — can't be verified solo, intentionally out of this PR):**
+- GitHub Actions that *call* these (`release-build.yml` / `release-plan.yml` /
+  `release-apply.yml`) — authoring them is fine, but they can only be verified on CI.
+- The adapters that produce real inputs: run `sst diff` → feed `preflight.parse_sst_diff`;
+  query the `migrations` table → `db_baseline_gate`; list Cloudflare records → `dns_preflight`.
+- A `make test:release-tooling` target + CI job to run this suite in PRs.
+- Version *writeback* (this only *checks* drift; rewriting the 7 sites is separate).

--- a/scripts/release/cicd/README.md
+++ b/scripts/release/cicd/README.md
@@ -13,10 +13,25 @@ outputs are wired separately (not in this PR — see "Not done" below).
 | `artifact_manifest.py` | the immutable build-once artifact record deploy trusts (digest-pinned) | #3 |
 | `preflight.py` | pre-apply gates: resource diff, **DB baseline**, **DNS collision** | #8 / DB+DNS pitfalls |
 | `ledger.py` | release ledger + `last_good_sha` for Cloud rollback | #11 / #16 |
-| `versions.py` | OSS single-version-source drift check | version drift |
+| `versions.py` | OSS single-version-source drift check **+ writeback** | #2 |
+| `release_plan.py` | dry-run: run all gates, emit can_apply / blocked_by report | #8 plan |
 
-`validate_manifest.py` is the CLI: `python3 scripts/release/validate_manifest.py <release.yaml>`
-(exit 0 valid / 1 invalid). `release.example.yaml` is a runnable example.
+CLIs (all read-only except `write-versions --write`):
+
+```bash
+# validate a manifest
+python3 scripts/release/validate_manifest.py <release.yaml>          # exit 0/1
+
+# dry-run all pre-apply gates (evidence via fixtures locally, sst diff/DB in CI)
+python3 scripts/release/release_plan.py --manifest release.yaml \
+    --sst-diff sst.diff --migrations migs.json --baseline base.json   # exit 0/1
+
+# check OR align the OSS version across sites (lockstep)
+python3 scripts/release/write_versions.py --check  --cargo Cargo.toml --json pkg.json
+python3 scripts/release/write_versions.py --write --version 0.9.6 --cargo Cargo.toml ...
+```
+
+`release.example.yaml` is a runnable example manifest.
 
 ## Why the gates exist (real incidents this guards)
 
@@ -32,13 +47,13 @@ outputs are wired separately (not in this PR — see "Not done" below).
 
 ```bash
 python3 -m venv .venv && . .venv/bin/activate && pip install pytest pyyaml
-cd scripts/release && python -m pytest -q          # 37 tests, ~0.05s
+cd scripts/release && python -m pytest -q          # 50 tests, ~0.05s
 ```
 
 ## Status
 
-**Done + verified here (pure logic, 37 tests, mutation-checked):** all five modules
-above + the validate CLI.
+**Done + verified here (pure logic, 50 tests, mutation-checked):** all modules
+above + three CLIs (validate / release-plan / write-versions).
 
 **Not done (needs CI / AWS — can't be verified solo, intentionally out of this PR):**
 - GitHub Actions that *call* these (`release-build.yml` / `release-plan.yml` /
@@ -46,4 +61,6 @@ above + the validate CLI.
 - The adapters that produce real inputs: run `sst diff` → feed `preflight.parse_sst_diff`;
   query the `migrations` table → `db_baseline_gate`; list Cloudflare records → `dns_preflight`.
 - A `make test:release-tooling` target + CI job to run this suite in PRs.
-- Version *writeback* (this only *checks* drift; rewriting the 7 sites is separate).
+- Actually *running* `write-versions --write` on the real tree (the tool is built +
+  tested on fixtures, but rewriting live Cargo/pyproject/package.json is left to a
+  human/orchestrator decision — it can affect nx tooling).

--- a/scripts/release/cicd/__init__.py
+++ b/scripts/release/cicd/__init__.py
@@ -1,0 +1,14 @@
+"""BoxLite release control-plane tooling.
+
+Pure-logic building blocks for the standardized release pipeline (Task 21):
+
+- ``manifest``          -- parse + validate ``release.yaml`` (the WHAT-to-ship contract)
+- ``artifact_manifest`` -- the immutable build-once artifact record deploy trusts
+- ``preflight``         -- pre-apply gates: resource diff, DB baseline, DNS collision
+- ``ledger``            -- release ledger + last-good-SHA lookup for rollback
+- ``versions``          -- OSS single-version-source drift check
+
+None of these touch AWS/registries/CI; they operate on data + fixtures so they
+can be unit-tested in isolation. The workflows that feed them real ``sst diff`` /
+DB state / build outputs are wired separately.
+"""

--- a/scripts/release/cicd/artifact_manifest.py
+++ b/scripts/release/cicd/artifact_manifest.py
@@ -1,0 +1,69 @@
+"""Artifact Manifest — the immutable record produced ONCE by the build factory.
+
+Every downstream consumer (PR preflight e2e, dev deploy, OSS publish, prod
+promote) reads ONLY this and pins artifacts by digest. This is what makes the
+whole pipeline "build-once, promote-the-digest" instead of rebuild-per-stage.
+"""
+from __future__ import annotations
+
+import re
+
+DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+KINDS = {"oss", "cloud-image", "runner-binary", "agent-image"}
+
+
+def build(version: str, commit: str, artifacts: list[dict], created_by: str = "") -> dict:
+    """Assemble a manifest dict. Does not validate — call :func:`validate`."""
+    return {
+        "schema": 1,
+        "version": version,
+        "commit": commit,
+        "created_by": created_by,
+        "artifacts": list(artifacts),
+    }
+
+
+def validate(data) -> list[str]:
+    """Return list of error strings. Empty == valid."""
+    if not isinstance(data, dict):
+        return ["manifest must be a mapping"]
+
+    errors: list[str] = []
+    if not data.get("version"):
+        errors.append("version: required")
+    if not data.get("commit"):
+        errors.append("commit: required")
+
+    artifacts = data.get("artifacts")
+    if not isinstance(artifacts, list) or not artifacts:
+        errors.append("artifacts: must be a non-empty list")
+        return errors
+
+    seen: set[str] = set()
+    for idx, art in enumerate(artifacts):
+        where = f"artifacts[{idx}]"
+        if not isinstance(art, dict):
+            errors.append(f"{where}: must be a mapping")
+            continue
+        name = art.get("name")
+        if not name:
+            errors.append(f"{where}.name: required")
+        elif name in seen:
+            errors.append(f"{where}.name: duplicate {name!r}")
+        else:
+            seen.add(name)
+        if art.get("kind") not in KINDS:
+            errors.append(f"{where}.kind: must be one of {sorted(KINDS)} (got {art.get('kind')!r})")
+        digest = art.get("digest", "")
+        if not DIGEST_RE.match(str(digest)):
+            errors.append(f"{where}.digest: must match sha256:<64 hex> (got {digest!r})")
+        if not art.get("location"):
+            errors.append(f"{where}.location: required")
+    return errors
+
+
+def find(data, name: str) -> dict | None:
+    for art in data.get("artifacts", []):
+        if isinstance(art, dict) and art.get("name") == name:
+            return art
+    return None

--- a/scripts/release/cicd/ledger.py
+++ b/scripts/release/cicd/ledger.py
@@ -1,0 +1,52 @@
+"""Release ledger — the durable record of what shipped where.
+
+GitHub Actions logs expire (~7 days); promote-by-SHA and rollback need a durable
+answer to "what SHA is live in <stage> right now and who approved it". Each apply
+appends one entry; ``last_good_sha`` powers Cloud rollback (redeploy last-good).
+
+The ledger is a JSON-lines file (one entry per line) so appends are cheap and
+the whole history is greppable.
+"""
+from __future__ import annotations
+
+import json
+
+
+def append(path, entry: dict) -> None:
+    """Append one release entry (JSON line)."""
+    required = ("version", "stage", "sha", "ts")
+    missing = [k for k in required if not entry.get(k)]
+    if missing:
+        raise ValueError(f"ledger entry missing required fields: {missing}")
+    with open(path, "a") as handle:
+        handle.write(json.dumps(entry, sort_keys=True) + "\n")
+
+
+def read(path) -> list[dict]:
+    try:
+        with open(path) as handle:
+            return [json.loads(line) for line in handle if line.strip()]
+    except FileNotFoundError:
+        return []
+
+
+def last_good_sha(path, stage: str) -> str | None:
+    """Most recent SHA for ``stage`` whose smoke verdict passed.
+
+    "Good" = smoke == "passed". A failed/blocked deploy never becomes the
+    rollback target, so a bad ship can't poison last-good.
+    """
+    good = None
+    for entry in read(path):
+        if entry.get("stage") == stage and entry.get("smoke") == "passed":
+            good = entry.get("sha")  # entries are appended in time order; keep latest
+    return good
+
+
+def current(path, stage: str) -> dict | None:
+    """Latest entry for ``stage`` regardless of smoke verdict (what was last attempted)."""
+    latest = None
+    for entry in read(path):
+        if entry.get("stage") == stage:
+            latest = entry
+    return latest

--- a/scripts/release/cicd/manifest.py
+++ b/scripts/release/cicd/manifest.py
@@ -1,0 +1,102 @@
+"""release.yaml — the PR-reviewed declaration of WHAT a release ships.
+
+Carries intent only (which trains, which version, which stage). The orchestrator
+consumes it; nothing here touches infra. Secret VALUES never live here — only
+non-secret references.
+
+Shape::
+
+    oss:     {release: true,  version: 0.9.6}      # train A (lockstep SDKs+CLI+core)
+    cloud:   {deploy:  true,  stage:  dev}         # train B (deploy a SHA to a stage)
+    runner:  {rollout: false, stage:  dev}         # train C (in-place SSM)
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+(?:-[0-9A-Za-z.]+)?$")
+ALLOWED_STAGES = {"dev", "prod"}
+TRAINS = ("oss", "cloud", "runner")
+
+
+@dataclass(frozen=True)
+class ManifestError:
+    field: str
+    message: str
+
+    def __str__(self) -> str:
+        return f"{self.field}: {self.message}"
+
+
+def validate(data) -> list[ManifestError]:
+    """Return a list of errors. Empty list == valid manifest."""
+    if not isinstance(data, dict):
+        return [ManifestError("<root>", "manifest must be a mapping")]
+
+    errors: list[ManifestError] = []
+
+    for key in sorted(set(data) - set(TRAINS)):
+        errors.append(ManifestError(key, "unknown top-level key (allowed: oss/cloud/runner)"))
+
+    enabled = enabled_trains(data)
+
+    oss = data.get("oss") or {}
+    if not isinstance(oss, dict):
+        errors.append(ManifestError("oss", "must be a mapping"))
+    elif oss.get("release"):
+        version = oss.get("version")
+        if not version:
+            errors.append(ManifestError("oss.version", "required when oss.release is true"))
+        elif not SEMVER_RE.match(str(version)):
+            errors.append(ManifestError("oss.version", f"not a valid semver: {version!r}"))
+
+    cloud = data.get("cloud") or {}
+    if not isinstance(cloud, dict):
+        errors.append(ManifestError("cloud", "must be a mapping"))
+    elif cloud.get("deploy"):
+        errors += _check_stage("cloud.stage", cloud.get("stage"))
+
+    runner = data.get("runner") or {}
+    if not isinstance(runner, dict):
+        errors.append(ManifestError("runner", "must be a mapping"))
+    elif runner.get("rollout"):
+        errors += _check_stage("runner.stage", runner.get("stage"))
+
+    if not enabled and not errors:
+        errors.append(
+            ManifestError(
+                "<root>",
+                "no train enabled (need one of oss.release / cloud.deploy / runner.rollout)",
+            )
+        )
+
+    return errors
+
+
+def _check_stage(field: str, stage) -> list[ManifestError]:
+    if not stage:
+        return [ManifestError(field, "required when its train is enabled")]
+    if stage not in ALLOWED_STAGES:
+        return [ManifestError(field, f"unknown stage {stage!r} (allowed: {sorted(ALLOWED_STAGES)})")]
+    return []
+
+
+def enabled_trains(data) -> list[str]:
+    """Which trains this manifest activates, in fan-out order (oss, cloud, runner)."""
+    out = []
+    if isinstance(data, dict):
+        if (data.get("oss") or {}).get("release"):
+            out.append("oss")
+        if (data.get("cloud") or {}).get("deploy"):
+            out.append("cloud")
+        if (data.get("runner") or {}).get("rollout"):
+            out.append("runner")
+    return out
+
+
+def load(path) -> dict:
+    import yaml
+
+    with open(path) as handle:
+        return yaml.safe_load(handle) or {}

--- a/scripts/release/cicd/preflight.py
+++ b/scripts/release/cicd/preflight.py
@@ -1,0 +1,112 @@
+"""Pre-apply gates (read-only "plan"): block dangerous deploys BEFORE they run.
+
+Three gates, each pure-logic so they unit-test against fixtures (the workflow
+feeds them real ``sst diff`` text / DB state / DNS records):
+
+1. resource_gate   -- block replace/delete on stateful resources (Runner/RDS/Redis)
+2. db_baseline_gate-- block when migrations table drifts from the expected baseline
+                      (this is the 1741/1753 "recorded baseline but table not built"
+                      class of incident this repo hit)
+3. dns_preflight   -- block when a DNS record would collide across stages
+
+Each returns a Verdict(blocked, reasons, warnings).
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+# Stateful resources a routine deploy must never replace/delete without an
+# explicit override. Matched as substrings against the SST/Pulumi resource type.
+PROTECTED_TYPES = ("Instance", "Runner", "rds", "Database", "elasticache", "Redis")
+DANGEROUS_ACTIONS = ("replace", "delete")
+
+
+@dataclass
+class Verdict:
+    blocked: bool = False
+    reasons: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    def block(self, reason: str) -> None:
+        self.blocked = True
+        self.reasons.append(reason)
+
+    def warn(self, msg: str) -> None:
+        self.warnings.append(msg)
+
+
+@dataclass(frozen=True)
+class Change:
+    action: str  # create | update | replace | delete
+    type: str
+    name: str
+
+
+# Matches lines like:  +  aws:ec2/instance:Instance  boxlite-runner-default   (create)
+#                       -  aws:rds/instance:Instance  boxlite-dev-db           (delete)
+#                       +- ...:Instance ... (replace)   /   ~ ...:... (update)
+_SIGN = {"+": "create", "-": "delete", "+-": "replace", "-+": "replace", "~": "update"}
+_DIFF_LINE = re.compile(r"^\s*([+~-]{1,2})\s+([\w.:/-]+)\s+(\S+)")
+
+
+def parse_sst_diff(text: str) -> list[Change]:
+    """Parse ``sst diff`` / pulumi-style output into structured changes."""
+    changes: list[Change] = []
+    for line in text.splitlines():
+        m = _DIFF_LINE.match(line)
+        if not m:
+            continue
+        sign, rtype, name = m.group(1), m.group(2), m.group(3)
+        action = _SIGN.get(sign)
+        if action is None:
+            continue
+        changes.append(Change(action=action, type=rtype, name=name))
+    return changes
+
+
+def resource_gate(changes: list[Change], allow_infra_change: bool = False) -> Verdict:
+    """Block replace/delete on protected stateful resources unless overridden."""
+    v = Verdict()
+    for c in changes:
+        if c.action in DANGEROUS_ACTIONS and any(p.lower() in c.type.lower() for p in PROTECTED_TYPES):
+            msg = f"{c.action} on protected resource {c.type} ({c.name})"
+            if allow_infra_change:
+                v.warn(f"ALLOWED via override: {msg}")
+            else:
+                v.block(msg)
+    return v
+
+
+def db_baseline_gate(migrations_in_db: list[str], expected_baseline: list[str]) -> Verdict:
+    """Block when the DB migrations table does not match the expected baseline.
+
+    Two failure modes, both seen in real incidents:
+      * EXTRA   -- db ran migrations not in the baseline (drift / divergent branch)
+      * MISSING -- baseline recorded but the migration is absent from the db
+                   ("recorded baseline but table not built" -> relation does not exist)
+    """
+    v = Verdict()
+    db = set(migrations_in_db)
+    base = set(expected_baseline)
+    for extra in sorted(db - base):
+        v.block(f"db has migration not in baseline: {extra}")
+    for missing in sorted(base - db):
+        v.block(f"baseline migration missing from db: {missing}")
+    return v
+
+
+def dns_preflight(planned_records: list[dict], owned_by_stage: dict[str, str], stage: str) -> Verdict:
+    """Block when a planned DNS record's fqdn is already owned by another stage.
+
+    planned_records : [{"fqdn": "api.dev.boxlite.ai"}, ...]
+    owned_by_stage  : {"api.dev.boxlite.ai": "dev", ...}  (existing ownership)
+    stage           : the stage we are deploying
+    """
+    v = Verdict()
+    for rec in planned_records:
+        fqdn = rec.get("fqdn")
+        owner = owned_by_stage.get(fqdn)
+        if owner and owner != stage:
+            v.block(f"DNS record {fqdn} already owned by stage {owner!r} (deploying {stage!r})")
+    return v

--- a/scripts/release/cicd/release_plan.py
+++ b/scripts/release/cicd/release_plan.py
@@ -1,0 +1,70 @@
+"""release-plan — the read-only "plan" half of plan/apply.
+
+Runs every pre-apply gate against a manifest + the build's artifact manifest +
+the deploy "evidence" (sst diff text, migrations-table state, planned DNS), and
+returns a plan report (can_apply / blocked_by / warnings). It NEVER mutates
+anything — safe to run on a laptop as a dry-run.
+
+In CI the evidence comes from real `sst diff` / a DB query / a DNS list; for
+local dry-run and tests, pass fixtures.
+"""
+from __future__ import annotations
+
+from cicd import artifact_manifest as am
+from cicd import manifest as m
+from cicd import preflight as pf
+
+INFRA_TRAINS = {"cloud", "runner"}
+
+
+def plan(
+    manifest_data,
+    *,
+    artifact_manifest_data=None,
+    sst_diff_text: str = "",
+    migrations_in_db=None,
+    expected_baseline=None,
+    planned_dns=None,
+    owned_dns=None,
+    stage: str | None = None,
+    allow_infra_change: bool = False,
+) -> dict:
+    report = {"can_apply": True, "blocked_by": [], "warnings": [], "trains": []}
+
+    # 1. Manifest must be valid — short-circuit, nothing else is meaningful.
+    manifest_errors = m.validate(manifest_data)
+    if manifest_errors:
+        report["can_apply"] = False
+        report["blocked_by"] += [f"manifest: {e}" for e in manifest_errors]
+        return report
+
+    report["trains"] = m.enabled_trains(manifest_data)
+    if stage is None:
+        stage = (manifest_data.get("cloud") or {}).get("stage") or (
+            manifest_data.get("runner") or {}
+        ).get("stage")
+
+    # 2. Artifact manifest (if supplied) must be valid — deploy trusts it.
+    if artifact_manifest_data is not None:
+        for err in am.validate(artifact_manifest_data):
+            report["can_apply"] = False
+            report["blocked_by"].append(f"artifact-manifest: {err}")
+
+    # 3. Infra gates only matter when an infra-touching train is enabled.
+    if INFRA_TRAINS & set(report["trains"]):
+        _merge(report, pf.resource_gate(pf.parse_sst_diff(sst_diff_text), allow_infra_change), "resource")
+
+        if "cloud" in report["trains"] and migrations_in_db is not None and expected_baseline is not None:
+            _merge(report, pf.db_baseline_gate(migrations_in_db, expected_baseline), "db-baseline")
+
+        if planned_dns and owned_dns is not None and stage:
+            _merge(report, pf.dns_preflight(planned_dns, owned_dns, stage), "dns")
+
+    return report
+
+
+def _merge(report: dict, verdict: pf.Verdict, gate: str) -> None:
+    if verdict.blocked:
+        report["can_apply"] = False
+        report["blocked_by"] += [f"{gate}: {r}" for r in verdict.reasons]
+    report["warnings"] += [f"{gate}: {w}" for w in verdict.warnings]

--- a/scripts/release/cicd/versions.py
+++ b/scripts/release/cicd/versions.py
@@ -32,6 +32,27 @@ def json_version(text: str) -> str | None:
     return m.group(1) if m else None
 
 
+def set_first_version(text: str, version: str) -> str:
+    """Rewrite the first ``version = "..."`` line (Cargo / pyproject TOML).
+
+    Only the version VALUE changes; everything else (formatting, comments,
+    other ``version`` keys of dependencies) is left intact because we replace
+    a single occurrence. Raises if no version line is present.
+    """
+    new, n = _CARGO_VERSION.subn(lambda mo: mo.group(0).replace(mo.group(1), version, 1), text, count=1)
+    if n == 0:
+        raise ValueError('no `version = "..."` line found')
+    return new
+
+
+def set_json_version_text(text: str, version: str) -> str:
+    """Rewrite the first ``"version": "..."`` in JSON (package.json)."""
+    new, n = _JSON_VERSION.subn(lambda mo: mo.group(0).replace(mo.group(1), version, 1), text, count=1)
+    if n == 0:
+        raise ValueError('no "version": "..." field found')
+    return new
+
+
 def check_drift(sites: dict[str, str | None], source_of_truth: str = "Cargo.toml") -> list[str]:
     """Compare every site's version against the source-of-truth site.
 

--- a/scripts/release/cicd/versions.py
+++ b/scripts/release/cicd/versions.py
@@ -1,0 +1,54 @@
+"""OSS single-version-source drift check.
+
+The OSS train is lockstep: SDKs (py/node/c) + CLI + core all share ONE version,
+sourced from the Cargo workspace. If a site disagrees, the OSS train can ship
+mismatched FFI artifacts (segfault class). This is a CHECK (report drift), not a
+force-rewrite — it's safe to run anywhere and gates the version-writeback step.
+
+Each extractor takes file *text* so it is trivially testable without a real tree.
+"""
+from __future__ import annotations
+
+import re
+
+_CARGO_VERSION = re.compile(r'(?m)^\s*version\s*=\s*"([^"]+)"')
+_PYPROJECT_VERSION = re.compile(r'(?m)^\s*version\s*=\s*"([^"]+)"')
+_JSON_VERSION = re.compile(r'"version"\s*:\s*"([^"]+)"')
+
+
+def cargo_workspace_version(text: str) -> str | None:
+    """First ``version = "..."`` under [workspace.package] / [package]."""
+    m = _CARGO_VERSION.search(text)
+    return m.group(1) if m else None
+
+
+def pyproject_version(text: str) -> str | None:
+    m = _PYPROJECT_VERSION.search(text)
+    return m.group(1) if m else None
+
+
+def json_version(text: str) -> str | None:
+    m = _JSON_VERSION.search(text)
+    return m.group(1) if m else None
+
+
+def check_drift(sites: dict[str, str | None], source_of_truth: str = "Cargo.toml") -> list[str]:
+    """Compare every site's version against the source-of-truth site.
+
+    sites: {label: version|None}. ``source_of_truth`` must be a key in ``sites``.
+    Returns a list of human-readable drift messages (empty == all aligned).
+    """
+    if source_of_truth not in sites:
+        raise ValueError(f"source_of_truth {source_of_truth!r} not in sites {list(sites)}")
+    truth = sites[source_of_truth]
+    errors: list[str] = []
+    if truth is None:
+        return [f"{source_of_truth}: version not found (cannot establish source of truth)"]
+    for label, version in sites.items():
+        if label == source_of_truth:
+            continue
+        if version is None:
+            errors.append(f"{label}: version not found")
+        elif version != truth:
+            errors.append(f"{label}: {version} != {truth} ({source_of_truth})")
+    return errors

--- a/scripts/release/conftest.py
+++ b/scripts/release/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+
+# Make `import cicd.<module>` work when pytest runs from the repo root or here.
+sys.path.insert(0, str(Path(__file__).resolve().parent))

--- a/scripts/release/release.example.yaml
+++ b/scripts/release/release.example.yaml
@@ -1,0 +1,19 @@
+# release.yaml — declares WHAT a release ships (PR-reviewed intent, no secrets).
+# Validate:  python3 scripts/release/validate_manifest.py scripts/release/release.example.yaml
+#
+# Trains (enable any subset):
+#   oss     -- lockstep SDKs (py/node/go/c) + CLI + core, one semver -> registries
+#   cloud   -- API/dashboard/proxy/... deployed (a git SHA) to a stage via SST
+#   runner  -- stateful runner binary rolled in-place via SSM
+
+oss:
+  release: true
+  version: 0.9.6        # one version for ALL OSS artifacts (FFI lockstep)
+
+cloud:
+  deploy: true
+  stage: dev            # dev | prod ; commit defaults to current HEAD
+
+runner:
+  rollout: false        # this release does not touch the stateful runner
+  stage: dev

--- a/scripts/release/release_plan.py
+++ b/scripts/release/release_plan.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""release-plan CLI — dry-run all pre-apply gates and print a verdict.
+
+Read-only: never mutates anything. In CI the evidence flags are produced by
+`sst diff` / a DB query / a DNS list; locally pass fixture files for a dry-run.
+
+    python3 scripts/release/release_plan.py \
+        --manifest release.yaml \
+        --sst-diff /tmp/sst.diff \
+        --migrations /tmp/migrations.json --baseline /tmp/baseline.json
+
+Exit 0 if can_apply, 1 if blocked, 2 on bad usage.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from cicd import manifest as m  # noqa: E402
+from cicd.release_plan import plan  # noqa: E402
+
+
+def _read_text(p):
+    return Path(p).read_text() if p else ""
+
+
+def _read_json(p):
+    return json.loads(Path(p).read_text()) if p else None
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(description="Dry-run release pre-apply gates")
+    ap.add_argument("--manifest", required=True)
+    ap.add_argument("--artifact-manifest")
+    ap.add_argument("--sst-diff", help="file containing `sst diff` output")
+    ap.add_argument("--migrations", help="json list of migrations in the DB")
+    ap.add_argument("--baseline", help="json list of expected baseline migrations")
+    ap.add_argument("--dns-planned", help="json list of {fqdn} records to create")
+    ap.add_argument("--dns-owned", help="json map fqdn->stage of existing ownership")
+    ap.add_argument("--stage")
+    ap.add_argument("--allow-infra-change", action="store_true")
+    ap.add_argument("--out", help="write plan-report.json here")
+    args = ap.parse_args(argv[1:])
+
+    report = plan(
+        m.load(args.manifest),
+        artifact_manifest_data=_read_json(args.artifact_manifest),
+        sst_diff_text=_read_text(args.sst_diff),
+        migrations_in_db=_read_json(args.migrations),
+        expected_baseline=_read_json(args.baseline),
+        planned_dns=_read_json(args.dns_planned),
+        owned_dns=_read_json(args.dns_owned),
+        stage=args.stage,
+        allow_infra_change=args.allow_infra_change,
+    )
+
+    print(f"trains:    {', '.join(report['trains']) or '(none)'}")
+    print(f"can_apply: {report['can_apply']}")
+    for w in report["warnings"]:
+        print(f"  ⚠️  {w}")
+    for b in report["blocked_by"]:
+        print(f"  ⛔ {b}")
+    if args.out:
+        Path(args.out).write_text(json.dumps(report, indent=2, ensure_ascii=False))
+
+    return 0 if report["can_apply"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/release/tests/test_artifact_manifest.py
+++ b/scripts/release/tests/test_artifact_manifest.py
@@ -1,0 +1,47 @@
+from cicd import artifact_manifest as am
+
+GOOD = "sha256:" + "a" * 64
+
+
+def _artifact(**over):
+    base = {"name": "python-sdk", "kind": "oss", "digest": GOOD, "location": "pypi"}
+    base.update(over)
+    return base
+
+
+def test_build_then_validate_ok():
+    man = am.build("0.9.6", "abc123", [_artifact()], created_by="ci")
+    assert am.validate(man) == []
+    assert man["version"] == "0.9.6"
+
+
+def test_bad_digest_rejected():
+    man = am.build("0.9.6", "abc", [_artifact(digest="abc")])
+    errs = am.validate(man)
+    assert any("digest" in e for e in errs)
+
+
+def test_unknown_kind_rejected():
+    man = am.build("0.9.6", "abc", [_artifact(kind="banana")])
+    assert any("kind" in e for e in am.validate(man))
+
+
+def test_duplicate_name_rejected():
+    man = am.build("0.9.6", "abc", [_artifact(), _artifact(digest="sha256:" + "b" * 64)])
+    assert any("duplicate" in e for e in am.validate(man))
+
+
+def test_empty_artifacts_rejected():
+    man = am.build("0.9.6", "abc", [])
+    assert any("artifacts" in e for e in am.validate(man))
+
+
+def test_missing_version_rejected():
+    man = am.build("", "abc", [_artifact()])
+    assert any("version" in e for e in am.validate(man))
+
+
+def test_find_returns_artifact_or_none():
+    man = am.build("0.9.6", "abc", [_artifact(name="runner", kind="runner-binary", location="gh")])
+    assert am.find(man, "runner")["kind"] == "runner-binary"
+    assert am.find(man, "nope") is None

--- a/scripts/release/tests/test_ledger.py
+++ b/scripts/release/tests/test_ledger.py
@@ -1,0 +1,50 @@
+import pytest
+
+from cicd import ledger
+
+
+def _entry(**over):
+    base = {"version": "0.9.6", "stage": "dev", "sha": "aaa", "ts": "2026-06-17T00:00:00Z",
+            "smoke": "passed"}
+    base.update(over)
+    return base
+
+
+def test_append_and_read_roundtrip(tmp_path):
+    p = tmp_path / "ledger.jsonl"
+    ledger.append(p, _entry(sha="aaa"))
+    ledger.append(p, _entry(sha="bbb"))
+    rows = ledger.read(p)
+    assert [r["sha"] for r in rows] == ["aaa", "bbb"]
+
+
+def test_last_good_sha_returns_latest_passed(tmp_path):
+    p = tmp_path / "ledger.jsonl"
+    ledger.append(p, _entry(sha="aaa", smoke="passed"))
+    ledger.append(p, _entry(sha="bbb", smoke="passed"))
+    assert ledger.last_good_sha(p, "dev") == "bbb"
+
+
+def test_last_good_sha_skips_failed_latest(tmp_path):
+    # latest deploy failed smoke -> rollback target must be the prior good one
+    p = tmp_path / "ledger.jsonl"
+    ledger.append(p, _entry(sha="good", smoke="passed"))
+    ledger.append(p, _entry(sha="bad", smoke="failed"))
+    assert ledger.last_good_sha(p, "dev") == "good"
+
+
+def test_last_good_sha_is_per_stage(tmp_path):
+    p = tmp_path / "ledger.jsonl"
+    ledger.append(p, _entry(stage="dev", sha="devsha"))
+    ledger.append(p, _entry(stage="prod", sha="prodsha"))
+    assert ledger.last_good_sha(p, "prod") == "prodsha"
+    assert ledger.last_good_sha(p, "dev") == "devsha"
+
+
+def test_last_good_sha_none_when_empty(tmp_path):
+    assert ledger.last_good_sha(tmp_path / "missing.jsonl", "dev") is None
+
+
+def test_append_rejects_incomplete_entry(tmp_path):
+    with pytest.raises(ValueError):
+        ledger.append(tmp_path / "l.jsonl", {"stage": "dev"})  # no version/sha/ts

--- a/scripts/release/tests/test_manifest.py
+++ b/scripts/release/tests/test_manifest.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+
+from cicd import manifest as m
+
+EXAMPLE = Path(__file__).resolve().parents[1] / "release.example.yaml"
+
+
+def test_example_manifest_is_valid():
+    data = m.load(EXAMPLE)
+    assert m.validate(data) == []
+    assert m.enabled_trains(data) == ["oss", "cloud"]
+
+
+def test_oss_release_requires_version():
+    errs = m.validate({"oss": {"release": True}})
+    assert any(e.field == "oss.version" for e in errs)
+
+
+def test_oss_version_must_be_semver():
+    errs = m.validate({"oss": {"release": True, "version": "v1"}})
+    assert any(e.field == "oss.version" and "semver" in e.message for e in errs)
+
+
+def test_prerelease_semver_is_accepted():
+    assert m.validate({"oss": {"release": True, "version": "0.9.6-rc.1"}}) == []
+
+
+def test_cloud_deploy_unknown_stage_rejected():
+    errs = m.validate({"cloud": {"deploy": True, "stage": "tokyo"}})
+    assert any(e.field == "cloud.stage" for e in errs)
+
+
+def test_cloud_deploy_missing_stage_rejected():
+    errs = m.validate({"cloud": {"deploy": True}})
+    assert any(e.field == "cloud.stage" for e in errs)
+
+
+def test_no_train_enabled_rejected():
+    errs = m.validate({"oss": {"release": False}})
+    assert any(e.field == "<root>" for e in errs)
+
+
+def test_unknown_top_level_key_rejected():
+    errs = m.validate({"ossss": {"release": True}})
+    assert any(e.field == "ossss" for e in errs)
+
+
+def test_non_mapping_root_rejected():
+    assert m.validate(["oss"]) != []
+
+
+def test_runner_only_release_is_valid():
+    data = {"runner": {"rollout": True, "stage": "dev"}}
+    assert m.validate(data) == []
+    assert m.enabled_trains(data) == ["runner"]

--- a/scripts/release/tests/test_preflight.py
+++ b/scripts/release/tests/test_preflight.py
@@ -1,0 +1,71 @@
+from cicd import preflight as pf
+
+# Representative sst/pulumi diff. The runner EC2 instance is being REPLACED
+# (the exact "routine deploy nuked a stateful resource" class we gate against),
+# while the ECS service is only updated.
+SST_DIFF_DANGER = """
+  Plan:
+    ~  aws:ecs/service:Service       boxlite-dev-Api          (update)
+    +- aws:ec2/instance:Instance     boxlite-runner-default   (replace)
+    +  aws:cloudwatch/logGroup:LogGroup  boxlite-dev-logs     (create)
+"""
+
+SST_DIFF_SAFE = """
+  Plan:
+    ~  aws:ecs/service:Service       boxlite-dev-Api          (update)
+    +  aws:cloudwatch/logGroup:LogGroup  boxlite-dev-logs     (create)
+"""
+
+
+def test_parse_sst_diff_extracts_changes():
+    changes = pf.parse_sst_diff(SST_DIFF_DANGER)
+    actions = {(c.action, c.name) for c in changes}
+    assert ("replace", "boxlite-runner-default") in actions
+    assert ("update", "boxlite-dev-Api") in actions
+    assert ("create", "boxlite-dev-logs") in actions
+
+
+def test_resource_gate_blocks_runner_replace():
+    v = pf.resource_gate(pf.parse_sst_diff(SST_DIFF_DANGER))
+    assert v.blocked
+    assert any("boxlite-runner-default" in r for r in v.reasons)
+
+
+def test_resource_gate_allows_safe_diff():
+    v = pf.resource_gate(pf.parse_sst_diff(SST_DIFF_SAFE))
+    assert not v.blocked
+
+
+def test_resource_gate_override_warns_not_blocks():
+    v = pf.resource_gate(pf.parse_sst_diff(SST_DIFF_DANGER), allow_infra_change=True)
+    assert not v.blocked
+    assert v.warnings  # override is recorded, not silent
+
+
+def test_db_baseline_gate_clean():
+    assert not pf.db_baseline_gate(["1740", "1741"], ["1740", "1741"]).blocked
+
+
+def test_db_baseline_gate_blocks_extra_migration():
+    # db ran a migration the baseline doesn't know -> divergent-branch drift
+    v = pf.db_baseline_gate(["1740", "1741", "1753"], ["1740", "1741"])
+    assert v.blocked and any("1753" in r for r in v.reasons)
+
+
+def test_db_baseline_gate_blocks_missing_migration():
+    # baseline recorded but db never built it -> "relation does not exist" class
+    v = pf.db_baseline_gate(["1740"], ["1740", "1741"])
+    assert v.blocked and any("1741" in r for r in v.reasons)
+
+
+def test_dns_preflight_blocks_cross_stage_collision():
+    planned = [{"fqdn": "api.boxlite.ai"}]
+    owned = {"api.boxlite.ai": "prod"}
+    v = pf.dns_preflight(planned, owned, stage="dev")
+    assert v.blocked
+
+
+def test_dns_preflight_same_stage_ok():
+    planned = [{"fqdn": "api.dev.boxlite.ai"}]
+    owned = {"api.dev.boxlite.ai": "dev"}
+    assert not pf.dns_preflight(planned, owned, stage="dev").blocked

--- a/scripts/release/tests/test_release_plan.py
+++ b/scripts/release/tests/test_release_plan.py
@@ -1,0 +1,75 @@
+from cicd import artifact_manifest as am
+from cicd.release_plan import plan
+
+SAFE_DIFF = "  ~  aws:ecs/service:Service  boxlite-dev-Api  (update)\n"
+DANGER_DIFF = "  +- aws:ec2/instance:Instance  boxlite-runner-default  (replace)\n"
+
+CLOUD_MANIFEST = {"cloud": {"deploy": True, "stage": "dev"}}
+OSS_MANIFEST = {"oss": {"release": True, "version": "0.9.6"}}
+
+
+def test_clean_cloud_plan_can_apply():
+    r = plan(
+        CLOUD_MANIFEST,
+        sst_diff_text=SAFE_DIFF,
+        migrations_in_db=["1740", "1741"],
+        expected_baseline=["1740", "1741"],
+    )
+    assert r["can_apply"] is True
+    assert r["blocked_by"] == []
+    assert r["trains"] == ["cloud"]
+
+
+def test_invalid_manifest_short_circuits():
+    r = plan({"oss": {"release": True}})  # missing version
+    assert r["can_apply"] is False
+    assert any("manifest:" in b for b in r["blocked_by"])
+
+
+def test_resource_gate_blocks_runner_replace():
+    r = plan(CLOUD_MANIFEST, sst_diff_text=DANGER_DIFF)
+    assert r["can_apply"] is False
+    assert any("resource:" in b and "boxlite-runner-default" in b for b in r["blocked_by"])
+
+
+def test_allow_infra_override_unblocks_with_warning():
+    r = plan(CLOUD_MANIFEST, sst_diff_text=DANGER_DIFF, allow_infra_change=True)
+    assert r["can_apply"] is True
+    assert any("resource:" in w for w in r["warnings"])
+
+
+def test_db_drift_blocks():
+    r = plan(
+        CLOUD_MANIFEST,
+        sst_diff_text=SAFE_DIFF,
+        migrations_in_db=["1740", "1741", "1753"],
+        expected_baseline=["1740", "1741"],
+    )
+    assert r["can_apply"] is False
+    assert any("db-baseline:" in b for b in r["blocked_by"])
+
+
+def test_dns_collision_blocks():
+    r = plan(
+        CLOUD_MANIFEST,
+        sst_diff_text=SAFE_DIFF,
+        planned_dns=[{"fqdn": "api.boxlite.ai"}],
+        owned_dns={"api.boxlite.ai": "prod"},
+        stage="dev",
+    )
+    assert r["can_apply"] is False
+    assert any("dns:" in b for b in r["blocked_by"])
+
+
+def test_oss_only_skips_infra_gates():
+    # OSS publish doesn't touch AWS — even a scary diff is irrelevant here.
+    r = plan(OSS_MANIFEST, sst_diff_text=DANGER_DIFF)
+    assert r["can_apply"] is True
+    assert r["trains"] == ["oss"]
+
+
+def test_bad_artifact_manifest_blocks():
+    bad = am.build("0.9.6", "abc", [{"name": "x", "kind": "oss", "digest": "nope", "location": "p"}])
+    r = plan(CLOUD_MANIFEST, artifact_manifest_data=bad, sst_diff_text=SAFE_DIFF)
+    assert r["can_apply"] is False
+    assert any("artifact-manifest:" in b for b in r["blocked_by"])

--- a/scripts/release/tests/test_versions.py
+++ b/scripts/release/tests/test_versions.py
@@ -1,0 +1,42 @@
+from cicd import versions as v
+
+CARGO = '[workspace.package]\nversion = "0.9.5"\nedition = "2021"\n'
+PYPROJECT = '[project]\nname = "boxlite"\nversion = "0.9.5"\n'
+PKG_JSON = '{\n  "name": "@boxlite-ai/boxlite",\n  "version": "0.9.5"\n}\n'
+PKG_JSON_DRIFT = '{\n  "name": "boxlite",\n  "version": "1.0.0"\n}\n'
+
+
+def test_extractors():
+    assert v.cargo_workspace_version(CARGO) == "0.9.5"
+    assert v.pyproject_version(PYPROJECT) == "0.9.5"
+    assert v.json_version(PKG_JSON) == "0.9.5"
+
+
+def test_no_drift_when_aligned():
+    sites = {
+        "Cargo.toml": v.cargo_workspace_version(CARGO),
+        "sdks/python/pyproject.toml": v.pyproject_version(PYPROJECT),
+        "sdks/node/package.json": v.json_version(PKG_JSON),
+    }
+    assert v.check_drift(sites) == []
+
+
+def test_detects_drift():
+    sites = {
+        "Cargo.toml": v.cargo_workspace_version(CARGO),
+        "package.json": v.json_version(PKG_JSON_DRIFT),  # 1.0.0 != 0.9.5
+    }
+    errs = v.check_drift(sites)
+    assert any("1.0.0" in e and "0.9.5" in e for e in errs)
+
+
+def test_missing_version_reported():
+    errs = v.check_drift({"Cargo.toml": "0.9.5", "weird": None})
+    assert any("weird" in e for e in errs)
+
+
+def test_unknown_source_of_truth_raises():
+    import pytest
+
+    with pytest.raises(ValueError):
+        v.check_drift({"a": "1.0.0"}, source_of_truth="Cargo.toml")

--- a/scripts/release/tests/test_versions_writeback.py
+++ b/scripts/release/tests/test_versions_writeback.py
@@ -1,0 +1,41 @@
+from cicd import versions as v
+
+CARGO = '[workspace.package]\nversion = "0.9.5"\nedition = "2021"\n'
+PYPROJECT = '[project]\nname = "boxlite"\nversion = "0.9.5"\n'
+PKG = '{\n  "name": "@boxlite-ai/boxlite",\n  "version": "0.9.5",\n  "dependencies": {}\n}\n'
+
+
+def test_set_cargo_version_changes_only_version():
+    out = v.set_first_version(CARGO, "0.9.6")
+    assert v.cargo_workspace_version(out) == "0.9.6"
+    assert "edition = \"2021\"" in out  # untouched
+
+
+def test_set_pyproject_version():
+    out = v.set_first_version(PYPROJECT, "0.9.6")
+    assert v.pyproject_version(out) == "0.9.6"
+    assert 'name = "boxlite"' in out
+
+
+def test_set_json_version():
+    out = v.set_json_version_text(PKG, "0.9.6")
+    assert v.json_version(out) == "0.9.6"
+    assert '"dependencies"' in out  # untouched
+
+
+def test_writeback_then_no_drift():
+    # round-trip: align all three to a new version -> drift check passes
+    target = "1.2.3"
+    sites = {
+        "Cargo.toml": v.cargo_workspace_version(v.set_first_version(CARGO, target)),
+        "pyproject.toml": v.pyproject_version(v.set_first_version(PYPROJECT, target)),
+        "package.json": v.json_version(v.set_json_version_text(PKG, target)),
+    }
+    assert v.check_drift(sites) == []
+
+
+def test_set_version_raises_when_absent():
+    import pytest
+
+    with pytest.raises(ValueError):
+        v.set_first_version("name = \"x\"\n", "1.0.0")

--- a/scripts/release/validate_manifest.py
+++ b/scripts/release/validate_manifest.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Validate a release.yaml manifest. Exit 0 if valid, 1 if not.
+
+Usage:
+    python3 scripts/release/validate_manifest.py release.yaml
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from cicd import manifest as m  # noqa: E402
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print("usage: validate_manifest.py <release.yaml>", file=sys.stderr)
+        return 2
+    path = argv[1]
+    try:
+        data = m.load(path)
+    except FileNotFoundError:
+        print(f"error: file not found: {path}", file=sys.stderr)
+        return 2
+
+    errors = m.validate(data)
+    if errors:
+        print(f"INVALID release manifest ({len(errors)} error(s)):", file=sys.stderr)
+        for err in errors:
+            print(f"  - {err}", file=sys.stderr)
+        return 1
+
+    trains = m.enabled_trains(data)
+    print(f"OK: valid manifest, trains = {', '.join(trains) or '(none)'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/release/write_versions.py
+++ b/scripts/release/write_versions.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""write-versions CLI — check or align the OSS version across all sites.
+
+OSS is lockstep: one version across Cargo workspace + pyproject + package.json.
+Default mode is --check (report drift, exit 1 if any). --write rewrites every
+listed site to --version (only the version value changes).
+
+    # check drift against Cargo as source of truth
+    python3 scripts/release/write_versions.py --check \
+        --cargo Cargo.toml --pyproject sdks/python/pyproject.toml --json sdks/node/package.json
+
+    # align everyone to a new version (use in the version-writeback step)
+    python3 scripts/release/write_versions.py --write --version 0.9.6 \
+        --cargo Cargo.toml --pyproject sdks/python/pyproject.toml --json sdks/node/package.json
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from cicd import versions as v  # noqa: E402
+
+TOML_KINDS = ("cargo", "pyproject")
+
+
+def _current(kind: str, text: str):
+    return v.json_version(text) if kind == "json" else v.cargo_workspace_version(text)
+
+
+def _rewrite(kind: str, text: str, version: str) -> str:
+    return v.set_json_version_text(text, version) if kind == "json" else v.set_first_version(text, version)
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(description="Check or align OSS version across sites")
+    ap.add_argument("--cargo", action="append", default=[])
+    ap.add_argument("--pyproject", action="append", default=[])
+    ap.add_argument("--json", action="append", default=[])
+    ap.add_argument("--check", action="store_true", help="report drift only (default)")
+    ap.add_argument("--write", action="store_true", help="rewrite files to --version")
+    ap.add_argument("--version", help="target version (required with --write)")
+    args = ap.parse_args(argv[1:])
+
+    sites = [("cargo", p) for p in args.cargo] + [("pyproject", p) for p in args.pyproject] + [
+        ("json", p) for p in args.json
+    ]
+    if not sites:
+        print("no sites given (use --cargo/--pyproject/--json)", file=sys.stderr)
+        return 2
+
+    if args.write:
+        if not args.version:
+            print("--write requires --version", file=sys.stderr)
+            return 2
+        for kind, path in sites:
+            text = Path(path).read_text()
+            Path(path).write_text(_rewrite(kind, text, args.version))
+            print(f"set {path} -> {args.version}")
+        return 0
+
+    # --check: Cargo is the source of truth (first cargo site)
+    versions = {path: _current(kind, Path(path).read_text()) for kind, path in sites}
+    truth_path = args.cargo[0] if args.cargo else sites[0][1]
+    drift = v.check_drift(versions, source_of_truth=truth_path)
+    if drift:
+        print(f"VERSION DRIFT ({len(drift)}):", file=sys.stderr)
+        for d in drift:
+            print(f"  - {d}", file=sys.stderr)
+        return 1
+    print(f"OK: all {len(sites)} sites at {versions[truth_path]}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
## What

Foundation for the standardized release pipeline (Task 21): the **pure-logic
control-plane layer** that future release/deploy workflows will call. All under a
new isolated dir `scripts/release/` — **no existing files touched**, no AWS /
registry / CI dependencies, so every piece is unit-tested in isolation.

| Module | Purpose |
|---|---|
| `manifest.py` + `validate_manifest.py` | validate `release.yaml` (the WHAT-to-ship contract) |
| `artifact_manifest.py` | immutable, digest-pinned build-once artifact record |
| `preflight.py` + `release_plan.py` | pre-apply gates (resource diff / DB baseline / DNS) + dry-run CLI |
| `ledger.py` | release ledger + `last_good_sha` for rollback |
| `versions.py` + `write_versions.py` | OSS lockstep version drift check + writeback |

The **DB baseline gate** encodes the `1741/1753` migration-drift incident class
(divergent branch / "recorded baseline but table not built"); the **DNS gate**
blocks cross-stage record collisions; the **resource gate** blocks replace/delete
on Runner/RDS/Redis unless explicitly overridden.

## Verification

- **50 pytest tests**, ~0.05s, runnable locally and via the new path-filtered
  `Release Tooling` CI workflow.
- Mutation-checked (disabling a gate makes its tests fail, then reverted).
- CLIs smoke-tested: a `runner replace` diff → `release_plan` exits 1 (blocked);
  `--allow-infra-change` → exits 0 with a recorded warning.

## Out of scope (needs CI / AWS / repo settings — not in this PR)

Workflows that *call* this tooling (`release-build`/`release-plan`/`release-apply`),
the adapters feeding real `sst diff` / DB / DNS, AWS OIDC roles + GitHub
Environments, agent-image CI, and prod. Tracked in `brian-notes` Task 21 (#4–#16).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release manifest validation and planning with automated safety gates (resource protection, database baseline checks, DNS collision detection).
  * Artifact manifest tracking for build-once, promote-digest release workflows.
  * Version alignment checking and synchronization across multiple codebase locations.

* **Documentation**
  * Added release tooling documentation and example configuration file.

* **Chores**
  * Added GitHub Actions workflow for automated release tooling validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->