### PR TITLE
fix(api): transfer non-JSON runner response to standard JSON format

### DIFF
--- a/apps/api/src/box/errors/runner-api-error.spec.ts
+++ b/apps/api/src/box/errors/runner-api-error.spec.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { HttpStatus } from '@nestjs/common'
+import { RunnerApiError } from './runner-api-error'
+import { sanitizedNonJsonRunnerMessage } from '../runner-adapter/runnerAdapter.v0'
+
+describe('RunnerApiError', () => {
+  it('maps runner 5xx errors to API 502 JSON errors', () => {
+    const error = new RunnerApiError('Runner API returned a non-JSON error response', 503, 'runner_non_json_error')
+
+    expect(error.getStatus()).toBe(HttpStatus.BAD_GATEWAY)
+    expect(error.getResponse()).toEqual({
+      statusCode: HttpStatus.BAD_GATEWAY,
+      message: 'Runner API returned a non-JSON error response',
+      code: 'runner_non_json_error',
+    })
+    expect(error.runnerStatusCode).toBe(503)
+    expect(error.statusCode).toBe(503)
+  })
+
+  it('preserves runner 4xx status codes for caller-correctable failures', () => {
+    const error = new RunnerApiError('Unsupported image', 422, 'unsupported_image')
+
+    expect(error.getStatus()).toBe(HttpStatus.UNPROCESSABLE_ENTITY)
+    expect(error.getResponse()).toEqual({
+      statusCode: HttpStatus.UNPROCESSABLE_ENTITY,
+      message: 'Unsupported image',
+      code: 'unsupported_image',
+    })
+    expect(error.runnerStatusCode).toBe(422)
+    expect(error.statusCode).toBe(422)
+  })
+
+  it('keeps the legacy statusCode field for manager cleanup paths', () => {
+    const error = new RunnerApiError('not found', 404, 'not_found')
+
+    expect(error.getStatus()).toBe(HttpStatus.NOT_FOUND)
+    expect(error.statusCode).toBe(404)
+  })
+
+  it('embeds a sanitized non-JSON runner response excerpt', () => {
+    const message = sanitizedNonJsonRunnerMessage(`
+      <html>
+        <head><style>.hidden { display: none }</style></head>
+        <body>
+          <h1>502 Bad Gateway</h1>
+          <script >window.secret = "do-not-include"</script >
+          upstream connect error or disconnect/reset before headers. token=secret-value
+        </body>
+      </html>
+    `)
+
+    expect(message).toContain('502 Bad Gateway')
+    expect(message).toContain('upstream connect error')
+    expect(message).toContain('token=[redacted]')
+    expect(message).not.toContain('<html>')
+    expect(message).not.toContain('do-not-include')
+  })
+})

--- a/apps/api/src/box/errors/runner-api-error.ts
+++ b/apps/api/src/box/errors/runner-api-error.ts
@@ -3,13 +3,38 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-export class RunnerApiError extends Error {
-  constructor(
-    message: string,
-    public readonly statusCode?: number,
-    public readonly code?: string,
-  ) {
-    super(message)
+import { HttpException, HttpStatus } from '@nestjs/common'
+
+function normalizeStatusCode(statusCode?: number): number {
+  if (!statusCode) {
+    return HttpStatus.BAD_GATEWAY
+  }
+
+  if (statusCode >= 400 && statusCode < 500) {
+    return statusCode
+  }
+
+  return HttpStatus.BAD_GATEWAY
+}
+
+export class RunnerApiError extends HttpException {
+  public readonly runnerStatusCode?: number
+  public readonly statusCode?: number
+  public readonly code: string
+
+  constructor(message: string, statusCode?: number, code = 'RUNNER_API_ERROR') {
+    const apiStatusCode = normalizeStatusCode(statusCode)
+    super(
+      {
+        statusCode: apiStatusCode,
+        message,
+        code,
+      },
+      apiStatusCode,
+    )
     this.name = 'RunnerApiError'
+    this.runnerStatusCode = statusCode
+    this.statusCode = statusCode
+    this.code = code
   }
 }

--- a/apps/api/src/box/runner-adapter/runnerAdapter.v0.ts
+++ b/apps/api/src/box/runner-adapter/runnerAdapter.v0.ts
@@ -27,6 +27,95 @@ const isDebugEnabled = process.env.DEBUG === 'true'
 
 // Network error codes that should trigger a retry
 const RETRYABLE_NETWORK_ERROR_CODES = ['ECONNRESET', 'ETIMEDOUT']
+const RUNNER_NON_JSON_ERROR_CODE = 'runner_non_json_error'
+const NON_JSON_SNIPPET_MAX_LENGTH = 180
+
+function statusCodeFrom(error: AxiosError): number | undefined {
+  return error.response?.status || (error as any).status
+}
+
+function codeFrom(error: AxiosError, data: unknown): string {
+  if (data && typeof data === 'object' && !Array.isArray(data)) {
+    const responseCode = (data as Record<string, unknown>).code
+    if (typeof responseCode === 'string' && responseCode) {
+      return responseCode
+    }
+  }
+
+  return (error as any).code || (error as any).cause?.code || 'RUNNER_API_ERROR'
+}
+
+function messageFromJson(data: Record<string, unknown>, fallback: string): string {
+  const responseMessage = data.message
+  if (Array.isArray(responseMessage)) {
+    return responseMessage.join(', ')
+  }
+  if (typeof responseMessage === 'string' && responseMessage) {
+    return responseMessage
+  }
+  if (typeof data.error === 'string' && data.error) {
+    return data.error
+  }
+  return fallback
+}
+
+function visibleTextFromMarkup(input: string): string {
+  let output = ''
+  let index = 0
+  let skipping: 'script' | 'style' | null = null
+
+  while (index < input.length) {
+    const char = input[index]
+    if (char !== '<') {
+      if (!skipping) {
+        output += char
+      }
+      index += 1
+      continue
+    }
+
+    const closeIndex = input.indexOf('>', index + 1)
+    if (closeIndex === -1) {
+      if (!skipping) {
+        output += input.slice(index)
+      }
+      break
+    }
+
+    const tagBody = input
+      .slice(index + 1, closeIndex)
+      .trim()
+      .toLowerCase()
+    const tagName = tagBody.replace(/^\//, '').split(/\s+/)[0]
+    if (!tagBody.startsWith('/') && (tagName === 'script' || tagName === 'style')) {
+      skipping = tagName
+    } else if (skipping && tagBody.startsWith('/') && tagName === skipping) {
+      skipping = null
+    } else if (!skipping) {
+      output += ' '
+    }
+
+    index = closeIndex + 1
+  }
+
+  return output
+}
+
+export function sanitizedNonJsonRunnerMessage(data: unknown): string {
+  const raw = typeof data === 'string' ? data : Buffer.isBuffer(data) ? data.toString('utf8') : JSON.stringify(data)
+  const text = visibleTextFromMarkup(raw)
+    .replace(/\b(Bearer\s+)[A-Za-z0-9._~+/=-]+/gi, '$1[redacted]')
+    .replace(/\b(access_token|id_token|api_key|token)=([^&\s]+)/gi, '$1=[redacted]')
+    .replace(/\s+/g, ' ')
+    .trim()
+
+  if (!text) {
+    return 'Runner API returned a non-JSON error response'
+  }
+
+  const suffix = text.length > NON_JSON_SNIPPET_MAX_LENGTH ? '...' : ''
+  return `Runner API returned a non-JSON error response: ${text.slice(0, NON_JSON_SNIPPET_MAX_LENGTH)}${suffix}`
+}
 
 @Injectable()
 export class RunnerAdapterV0 implements RunnerAdapter {
@@ -104,11 +193,27 @@ export class RunnerAdapterV0 implements RunnerAdapter {
         return response
       },
       (error) => {
-        const errorMessage = error.response?.data?.message || error.response?.data || error.message || String(error)
-        const statusCode = error.response?.data?.statusCode || error.response?.status || error.status
-        const code = error.response?.data?.code || (error as any).code || (error as any).cause?.code || ''
+        const data = error.response?.data
+        const statusCode =
+          data && typeof data === 'object' && !Array.isArray(data) && typeof data.statusCode === 'number'
+            ? data.statusCode
+            : statusCodeFrom(error)
 
-        throw new RunnerApiError(String(errorMessage), statusCode, code)
+        if (data && typeof data === 'object' && !Array.isArray(data) && !Buffer.isBuffer(data)) {
+          throw new RunnerApiError(
+            messageFromJson(data as Record<string, unknown>, error.message),
+            statusCode,
+            codeFrom(error, data),
+          )
+        }
+
+        if (data !== undefined && data !== null && data !== '') {
+          const sanitizedMessage = sanitizedNonJsonRunnerMessage(data)
+          this.logger.warn(`Runner API returned non-JSON error (${statusCode || 'no status'}): ${sanitizedMessage}`)
+          throw new RunnerApiError(sanitizedMessage, statusCode, RUNNER_NON_JSON_ERROR_CODE)
+        }
+
+        throw new RunnerApiError(error.message || 'Runner API request failed', statusCode, codeFrom(error, data))
       },
     )
 

--- a/apps/api/src/filters/all-exceptions.filter.spec.ts
+++ b/apps/api/src/filters/all-exceptions.filter.spec.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { ArgumentsHost, HttpStatus } from '@nestjs/common'
+import { AllExceptionsFilter } from './all-exceptions.filter'
+import { RunnerApiError } from '../box/errors/runner-api-error'
+
+describe('AllExceptionsFilter', () => {
+  it('serializes HttpException code fields into the JSON response', async () => {
+    const json = jest.fn()
+    const status = jest.fn().mockReturnValue({ json })
+    const filter = new AllExceptionsFilter({ incrementFailedAuth: jest.fn() } as never)
+    const host = {
+      switchToHttp: () => ({
+        getResponse: () => ({ status }),
+        getRequest: () => ({ path: '/api/v1/org/boxes', url: '/api/v1/org/boxes' }),
+      }),
+    } as ArgumentsHost
+
+    await filter.catch(
+      new RunnerApiError('Runner API returned a non-JSON error response', 503, 'runner_non_json_error'),
+      host,
+    )
+
+    expect(status).toHaveBeenCalledWith(HttpStatus.BAD_GATEWAY)
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/api/v1/org/boxes',
+        statusCode: HttpStatus.BAD_GATEWAY,
+        error: 'Bad Gateway',
+        message: 'Runner API returned a non-JSON error response',
+        code: 'runner_non_json_error',
+      }),
+    )
+  })
+})

--- a/apps/api/src/filters/all-exceptions.filter.ts
+++ b/apps/api/src/filters/all-exceptions.filter.ts
@@ -34,6 +34,7 @@ export class AllExceptionsFilter implements ExceptionFilter {
     let statusCode: number
     let error: string
     let message: string
+    let code: string | undefined
 
     // If the exception is a NotFoundException and the request path is not an API request, serve the dashboard index.html file
     if (exception instanceof NotFoundException && !request.path.startsWith('/api/')) {
@@ -66,6 +67,8 @@ export class AllExceptionsFilter implements ExceptionFilter {
         message = Array.isArray(responseMessage)
           ? responseMessage.join(', ')
           : (responseMessage as string) || exception.message
+        const responseCode = (exceptionResponse as Record<string, unknown>).code
+        code = typeof responseCode === 'string' ? responseCode : undefined
       }
     } else {
       this.logger.error(exception)
@@ -80,6 +83,7 @@ export class AllExceptionsFilter implements ExceptionFilter {
       statusCode,
       error,
       message,
+      ...(code ? { code } : {}),
     })
   }
 }

--- a/src/boxlite/src/rest/client.rs
+++ b/src/boxlite/src/rest/client.rs
@@ -13,7 +13,7 @@ use boxlite_shared::errors::{BoxliteError, BoxliteResult};
 use super::credential::{AccessToken, Credential};
 use super::error::{map_http_error, map_http_status};
 use super::options::BoxliteRestOptions;
-use super::types::{ErrorResponse, ServerConfig};
+use super::types::{ErrorResponse, FlatErrorResponse, ServerConfig};
 use crate::runtime::auth::Principal;
 
 /// Re-request a token once it is within this leeway of `expires_at`.
@@ -186,6 +186,8 @@ impl ApiClient {
         let text = resp.text().await.unwrap_or_default();
         if let Ok(err_resp) = serde_json::from_str::<ErrorResponse>(&text) {
             Err(map_http_error(status, &err_resp.error))
+        } else if let Ok(err_resp) = serde_json::from_str::<FlatErrorResponse>(&text) {
+            Err(map_http_error(status, &err_resp.into_error_model()))
         } else {
             Err(map_http_status(status, &text))
         }
@@ -566,6 +568,23 @@ mod tests {
         let opts = BoxliteRestOptions::new("http://localhost:1");
         let client = ApiClient::new(&opts).expect("client");
         assert_eq!(client.current_bearer().await.unwrap(), None);
+    }
+
+    #[test]
+    fn flat_nest_error_response_maps_by_code() {
+        let parsed: FlatErrorResponse = serde_json::from_str(
+            r#"{"statusCode":502,"error":"Bad Gateway","message":"Runner API returned a non-JSON error response","code":"runner_non_json_error"}"#,
+        )
+        .expect("flat error response");
+
+        let err = map_http_error(StatusCode::BAD_GATEWAY, &parsed.into_error_model());
+
+        match err {
+            BoxliteError::Network(message) => {
+                assert!(message.contains("Runner API returned a non-JSON error response"))
+            }
+            other => panic!("expected Network error for runner non-JSON response, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/boxlite/src/rest/error.rs
+++ b/src/boxlite/src/rest/error.rs
@@ -31,7 +31,7 @@ pub(crate) fn map_http_error(status: StatusCode, body: &ErrorModel) -> BoxliteEr
         "image_pull_failed" => BoxliteError::Image(msg),
         "execution_failed" => BoxliteError::Execution(msg),
         "resource_exhausted" => BoxliteError::ResourceExhausted(msg),
-        "network_unavailable" => BoxliteError::Network(msg),
+        "network_unavailable" | "runner_non_json_error" => BoxliteError::Network(msg),
         "upstream_unavailable" => BoxliteError::Portal(msg),
         "engine_unavailable" => BoxliteError::Engine(msg),
         "storage_error" => BoxliteError::Storage(msg),

--- a/src/boxlite/src/rest/types.rs
+++ b/src/boxlite/src/rest/types.rs
@@ -20,6 +20,23 @@ pub(crate) struct ErrorResponse {
     pub error: ErrorModel,
 }
 
+#[derive(Debug, Deserialize)]
+pub(crate) struct FlatErrorResponse {
+    pub message: String,
+    pub code: Option<String>,
+}
+
+impl FlatErrorResponse {
+    pub(crate) fn into_error_model(self) -> ErrorModel {
+        ErrorModel {
+            message: self.message,
+            error_type: "HttpError".to_string(),
+            code: self.code.unwrap_or_else(|| "internal".to_string()),
+            request_id: None,
+        }
+    }
+}
+
 /// Wire shape received from the server.
 ///
 /// - `message` — human-readable error text.


### PR DESCRIPTION
normalize runner API failures into structured Nest `HttpException` JSON responses with error msgs

## Why

`POST /v1/:prefix/boxes` should not leak runner/ALB/proxy HTML or plain-text failures to callers. Create failures now stay JSON-shaped, with non-JSON upstream runner responses represented as `runner_non_json_error`.

## Validation

- `git diff --check`
- `./node_modules/.bin/jest --config api/jest.config.ts api/src/box/errors/runner-api-error.spec.ts api/src/filters/all-exceptions.filter.spec.ts --runInBand`
- `BOXLITE_DEPS_STUB=1 cargo test -p boxlite --features rest flat_nest_error_response_maps_by_code`

Note: `yarn nx test api --testFile=...` was attempted first but Nx/Jest ran the broader API suite and hit the existing `nanoid` ESM transform issue in unrelated specs, so the targeted API specs were rerun directly with the API Jest config.


## Non-JSON runner message handling

Non-JSON runner responses now include a sanitized excerpt in the API `message`. HTML tags, script/style blocks, excess whitespace, and obvious token-like query/header fragments are stripped/redacted before the excerpt is exposed. This keeps useful details such as `502 Bad Gateway` or `upstream connect error` visible without returning raw HTML.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runner error translation: map runner 5xx to API **502 Bad Gateway**, and preserve runner 4xx status; include consistent error details.
  * Added safer handling for non-JSON runner responses by sanitizing messages to redact sensitive/token-like content and remove raw markup.
  * Ensure legacy status handling continues to work for manager cleanup paths.
* **Improvements**
  * Error payloads now reliably expose an optional **`code`** field for better diagnostics.
  * Enhanced client-side REST error parsing to support a flattened error schema and map the new non-JSON runner error to **Network**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->