### PR TITLE
[codex] add research agent example

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -66,6 +66,9 @@ scripts/
 
 BoxLite includes 9 comprehensive Python examples demonstrating all major use cases.
 
+For the PR 825 agent-in-box verification flow, see
+[Agent In Box Test Runbook](agent-in-box-test.md).
+
 ### Prerequisites
 
 ```bash

--- a/docs/guides/agent-in-box-test.md
+++ b/docs/guides/agent-in-box-test.md
@@ -1,0 +1,169 @@
+# Agent In Box Test Runbook
+
+This runbook is written for Codex, Claude, or another code agent to read after
+cloning the repository. It focuses on reproducing the PR 825 agent-in-box tests
+against a cloud REST environment and reporting actionable results.
+
+Do not use the local e2e stack for this runbook. Do not run
+`scripts/test/e2e/bootstrap.sh` or `scripts/test/e2e/fixture_setup.py`.
+
+## Test Goals
+
+1. `research_agent.py` can be copied into a REST-backed box and executed there.
+2. Real LLM calls use a BoxLite secret placeholder inside the box, while the
+   plaintext API key stays on the host.
+3. Agent work files written inside the box survive `stop` followed by `start`.
+
+## Relevant Files
+
+| File | Purpose |
+|------|---------|
+| `examples/python/06_ai_agents/research_agent.py` | Agent under test |
+| `examples/python/06_ai_agents/research_agent_fixture.json` | Deterministic search fixture |
+| `scripts/test/e2e/cases/test_research_agent_example.py` | REST box e2e tests |
+| `examples/python/06_ai_agents/run_codex_in_box.py` | Manual Codex CLI in-box smoke test |
+
+## Prerequisites
+
+Run commands from the repository root:
+
+```bash
+cd boxlite
+PYTHON="${PYTHON:-$(test -x .venv/bin/python && echo .venv/bin/python || echo python)}"
+```
+
+The REST e2e tests need a working cloud BoxLite API profile. By default they
+read the `p1` profile from `~/.boxlite/credentials.toml`. To use a different
+cloud profile:
+
+```bash
+export BOXLITE_E2E_PROFILE="p1"
+```
+
+The profile must point at the cloud API, not a local API. The file should have
+this shape:
+
+```toml
+[profiles.p1]
+url = "https://<cloud-api-host>/api"
+api_key = "<cloud-api-key>"
+auth_method = "api_key"
+path_prefix = "<path-prefix-if-required>"
+```
+
+Always skip local runner journal path verification for this cloud-only flow:
+
+```bash
+export BOXLITE_E2E_SKIP_PATH_VERIFY=1
+```
+
+If cloud image discovery fails, or if the default image is unavailable, pin a
+Python-capable image:
+
+```bash
+export BOXLITE_E2E_RESEARCH_IMAGE="ghcr.io/boxlite-ai/boxlite-agent-python:20260605-p0-r3"
+```
+
+The real LLM e2e test requires a host-side environment variable:
+
+```bash
+export BOXLITE_E2E_OPENAI_API_KEY="sk-..."
+export BOXLITE_E2E_OPENAI_MODEL="${BOXLITE_E2E_OPENAI_MODEL:-gpt-4.1-mini}"
+```
+
+Do not write API keys into the repository, fixtures, or logs.
+
+## Run Order
+
+Run the smallest REST box e2e first. It creates a real cloud box, copies the
+agent and fixture into it, and executes the echo provider inside the box:
+
+```bash
+"$PYTHON" -m pytest \
+  scripts/test/e2e/cases/test_research_agent_example.py::test_research_agent_example_runs_inside_rest_box \
+  -vv -s --tb=short
+```
+
+Next, verify that agent work files survive `stop` followed by `start`:
+
+```bash
+"$PYTHON" -m pytest \
+  scripts/test/e2e/cases/test_research_agent_example.py::test_research_agent_worklog_persists_after_stop_and_rerun \
+  -vv -s --tb=short
+```
+
+Finally, if `BOXLITE_E2E_OPENAI_API_KEY` is set, run the real LLM e2e. This test
+does not skip; without a key, it is expected to fail:
+
+```bash
+"$PYTHON" -m pytest \
+  scripts/test/e2e/cases/test_research_agent_example.py::test_research_agent_openai_provider_uses_boxlite_secret_in_rest_box \
+  -vv -s --tb=short
+```
+
+To run the full focused e2e file:
+
+```bash
+"$PYTHON" -m pytest scripts/test/e2e/cases/test_research_agent_example.py -vv -s --tb=short
+```
+
+## Expected Signals
+
+The REST echo e2e agent output should include:
+
+```text
+Echo provider summary for: What can this agent do?
+BoxLite AI agent examples
+Codex tool-use loop
+```
+
+The worklog persistence e2e should read both markers after the second start:
+
+```text
+run=first
+run=second
+```
+
+The real LLM e2e first verifies that the box can only see the placeholder:
+
+```text
+<BOXLITE_SECRET:openai_api_key>
+```
+
+The final agent output must not contain `sk-` and must not contain
+`<BOXLITE_SECRET:openai_api_key>`.
+
+## Relationship To Secret Passthrough
+
+The PR 825 tests create a box with a secret and expect the REST -> runner ->
+box/gvproxy path to deliver the secret placeholder into the box. The tests only
+validate agent-in-box behavior. If the target REST environment does not include
+create secret passthrough support, the real LLM e2e can fail because the
+placeholder is missing or the outbound request is unauthorized.
+
+When validating PR 825 itself, run the echo e2e and worklog e2e first. When
+validating the full real LLM agent-in-box path, also make sure the target
+environment includes the secret passthrough fix.
+
+## Common Failures
+
+| Symptom | Action |
+|---------|--------|
+| `~/.boxlite/credentials.toml` is missing | Configure a cloud REST profile |
+| The desired profile is not `p1` | Set `BOXLITE_E2E_PROFILE` |
+| Local path verification fails | Set `BOXLITE_E2E_SKIP_PATH_VERIFY=1` |
+| The box image has no Python | Set `BOXLITE_E2E_RESEARCH_IMAGE` to a Python image |
+| The real LLM e2e reports a missing key | Set `BOXLITE_E2E_OPENAI_API_KEY` |
+| The box does not contain `<BOXLITE_SECRET:openai_api_key>` | The current REST/runner path is not passing create secrets into the box |
+| Agent output contains a plaintext key or placeholder | Treat this as a security failure and inspect secret substitution |
+
+## Minimal Prompt For A Code Agent
+
+Give this prompt to Codex or Claude:
+
+```text
+Read docs/guides/agent-in-box-test.md. From the repo root, run the deterministic
+REST echo e2e and worklog persistence e2e against the configured cloud profile.
+If BOXLITE_E2E_OPENAI_API_KEY is set, also run the real LLM e2e. Report exact
+commands, pass/fail, and any box ids left behind.
+```

--- a/examples/python/06_ai_agents/README.md
+++ b/examples/python/06_ai_agents/README.md
@@ -155,6 +155,11 @@ python examples/python/06_ai_agents/run_codex_in_box.py \
   "Reply exactly: codex inside box works"
 ```
 
+The script reads `OPENAI_API_KEY` from the current environment, or prompts for
+it interactively when running in a terminal. The box is created through the
+cloud REST profile from `~/.boxlite/credentials.toml`; use `--profile`,
+`BOXLITE_E2E_PROFILE`, or `BOXLITE_PROFILE` to select it.
+
 This path creates a Node.js box, installs `@openai/codex`, logs in with
 `BOXLITE_SECRET_OPENAI_API_KEY`, and runs `codex exec`. The API key stays on the
 host. The box stores and sends only the placeholder, and gvproxy substitutes the

--- a/examples/python/06_ai_agents/README.md
+++ b/examples/python/06_ai_agents/README.md
@@ -81,12 +81,15 @@ logs in with a BoxLite secret-backed API key, and runs `codex exec`:
 
 ```bash
 python examples/python/06_ai_agents/run_codex_in_box.py \
+  --profile p1 \
   "Reply exactly: codex inside box works"
 ```
 
 The script reads `OPENAI_API_KEY` from the current environment first, then
 falls back to `~/.config/boxlite/e2e-openai.env` (`OPENAI_API_KEY` or
-`BOXLITE_E2E_OPENAI_API_KEY`). Use `--env-file` to point at another file.
+`BOXLITE_E2E_OPENAI_API_KEY`). Use `--env-file` to point at another file. The
+box is created through the cloud REST profile from `~/.boxlite/credentials.toml`;
+use `--profile`, `BOXLITE_E2E_PROFILE`, or `BOXLITE_PROFILE` to select it.
 
 The box receives `BOXLITE_SECRET_OPENAI_API_KEY=<BOXLITE_SECRET:openai_api_key>`;
 `codex login --with-api-key` stores that placeholder in the box, and gvproxy
@@ -151,6 +154,7 @@ LLM-backed agent can run inside a box:
 ```bash
 export OPENAI_API_KEY="sk-..."
 python examples/python/06_ai_agents/run_codex_in_box.py \
+  --profile p1 \
   "Reply exactly: codex inside box works"
 ```
 

--- a/examples/python/06_ai_agents/README.md
+++ b/examples/python/06_ai_agents/README.md
@@ -6,6 +6,8 @@ Using BoxLite as a sandbox for AI agent workflows.
 |------|-------------|
 | `drive_box_with_llm.py` | Let an LLM drive a SimpleBox via tool-use loop (OpenAI) |
 | `drive_box_with_minimax.py` | Let MiniMax M3 drive a SimpleBox via tool-use loop |
+| `research_agent.py` | Search the web, ask an LLM through host-side secret substitution, and answer a question |
+| `run_codex_in_box.py` | Install and run OpenAI Codex CLI inside a BoxLite box |
 | `use_skillbox.py` | Run Claude Code CLI with skills inside a box |
 | `chat_with_claude.py` | Multi-turn Claude conversation via stdin JSON protocol |
 | `order_starbucks.py` | End-to-end agent: order Starbucks via browser automation |
@@ -20,3 +22,143 @@ Most examples require `CLAUDE_CODE_OAUTH_TOKEN` to be set.
 BoxLite works with any LLM provider to create secure sandboxed environments for AI agents.
 The examples in this directory include ready-to-run integrations for
 OpenAI and [MiniMax](https://platform.minimax.io) (`MiniMax-M3`, `MiniMax-M2.7`, `MiniMax-M2.7-highspeed`).
+
+## Research Agent
+
+`research_agent.py` is a minimal research loop that can use BoxLite secret
+substitution for LLM credentials:
+
+1. Accept a user question.
+2. Search the web with DuckDuckGo HTML search, or read fixture results for smoke tests.
+3. Send the search context to an OpenAI-compatible chat completion endpoint.
+4. Print the final answer.
+
+The default `echo` provider is deterministic and needs no credentials:
+
+```bash
+python examples/python/06_ai_agents/research_agent.py \
+  --search-provider fixture \
+  --search-fixture examples/python/06_ai_agents/research_agent_fixture.json \
+  "What can this agent do?"
+```
+
+Inside a BoxLite box, pass the real API key as a host-side secret and let the
+agent use only the placeholder env var:
+
+```python
+box = runtime.create(
+    boxlite.BoxOptions(
+        image="python:3.12-slim",
+        network=boxlite.NetworkSpec(
+            mode="enabled",
+            allow_net=["api.openai.com"],
+        ),
+        secrets=[
+            boxlite.Secret(
+                name="openai_api_key",
+                value=os.environ["OPENAI_API_KEY"],
+                hosts=["api.openai.com"],
+            ),
+        ],
+    )
+)
+```
+
+The container sees `BOXLITE_SECRET_OPENAI_API_KEY=<BOXLITE_SECRET:openai_api_key>`.
+When the agent calls `https://api.openai.com/v1/chat/completions`, gvproxy
+replaces that placeholder with the real key at the network boundary:
+
+```bash
+python /root/research_agent.py \
+  --answer-provider openai \
+  "What is BoxLite?"
+```
+
+## Codex CLI In A Box
+
+`run_codex_in_box.py` installs the real `@openai/codex` CLI in a Node.js box,
+logs in with a BoxLite secret-backed API key, and runs `codex exec`:
+
+```bash
+python examples/python/06_ai_agents/run_codex_in_box.py \
+  "Reply exactly: codex inside box works"
+```
+
+The script reads `OPENAI_API_KEY` from the current environment first, then
+falls back to `~/.config/boxlite/e2e-openai.env` (`OPENAI_API_KEY` or
+`BOXLITE_E2E_OPENAI_API_KEY`). Use `--env-file` to point at another file.
+
+The box receives `BOXLITE_SECRET_OPENAI_API_KEY=<BOXLITE_SECRET:openai_api_key>`;
+`codex login --with-api-key` stores that placeholder in the box, and gvproxy
+substitutes the real key only on outbound requests to `api.openai.com`.
+
+## Testing
+
+These agent examples currently have two small test paths. For the full
+agent-in-box verification flow, see
+[`docs/guides/agent-in-box-test.md`](../../../docs/guides/agent-in-box-test.md).
+
+### Research Agent
+
+The unit test is deterministic and runs entirely on the host:
+
+```bash
+python -m unittest examples/python/06_ai_agents/test_research_agent.py
+```
+
+It checks DuckDuckGo HTML parsing, fixture-based prompt construction, and that
+OpenAI requests use the BoxLite secret placeholder instead of a plaintext API
+key.
+
+The REST e2e copies `research_agent.py` into a real REST-backed box and executes
+it there:
+
+```bash
+python -m pytest \
+  scripts/test/e2e/cases/test_research_agent_example.py::test_research_agent_example_runs_inside_rest_box \
+  -vv -s
+```
+
+The worklog persistence e2e verifies that files written by the agent inside the
+box survive `stop` followed by `start`:
+
+```bash
+python -m pytest \
+  scripts/test/e2e/cases/test_research_agent_example.py::test_research_agent_worklog_persists_after_stop_and_rerun \
+  -vv -s
+```
+
+The real LLM version does not skip. Provide the key on the host before running
+the OpenAI-backed case:
+
+```bash
+export BOXLITE_E2E_OPENAI_API_KEY="sk-..."
+python -m pytest \
+  scripts/test/e2e/cases/test_research_agent_example.py::test_research_agent_openai_provider_uses_boxlite_secret_in_rest_box \
+  -vv -s
+```
+
+This case first asserts that the box can only see
+`<BOXLITE_SECRET:openai_api_key>`, then asks the model through
+`api.openai.com`, and finally confirms the agent output contains neither the
+plaintext key nor the placeholder.
+
+### Codex In Box
+
+`run_codex_in_box.py` is a manual smoke test for verifying that a real
+LLM-backed agent can run inside a box:
+
+```bash
+export OPENAI_API_KEY="sk-..."
+python examples/python/06_ai_agents/run_codex_in_box.py \
+  "Reply exactly: codex inside box works"
+```
+
+If you do not want to export the key every time, put `OPENAI_API_KEY` or
+`BOXLITE_E2E_OPENAI_API_KEY` in `~/.config/boxlite/e2e-openai.env`, or pass a
+different file with `--env-file`.
+
+This path creates a Node.js box, installs `@openai/codex`, logs in with
+`BOXLITE_SECRET_OPENAI_API_KEY`, and runs `codex exec`. The API key stays on the
+host. The box stores and sends only the placeholder, and gvproxy substitutes the
+real key only for requests to `api.openai.com`.

--- a/examples/python/06_ai_agents/README.md
+++ b/examples/python/06_ai_agents/README.md
@@ -154,7 +154,6 @@ LLM-backed agent can run inside a box:
 ```bash
 export OPENAI_API_KEY="sk-..."
 python examples/python/06_ai_agents/run_codex_in_box.py \
-  --profile p1 \
   "Reply exactly: codex inside box works"
 ```
 
@@ -172,14 +171,12 @@ directly into the box:
 
 ```bash
 python examples/python/06_ai_agents/run_codex_in_box.py \
-  --profile p1 \
-  --image ghcr.io/boxlite-ai/boxlite-agent-node:20260605-p0-r3 \
-  --env-file ~/.config/boxlite/e2e-openai.env \
-  --unsafe-direct-api-key \
   --code-smoke
 ```
 
-This unsafe mode is only for manual smoke testing because the plaintext API key
-is visible inside the box. The `--code-smoke` path asks Codex to create
+This direct-key mode is the default for manual smoke testing because current
+cloud secret passthrough does not yet cover Codex's Responses API path. The
+plaintext API key is visible inside the box. Pass `--secret-passthrough` to test
+BoxLite secret substitution instead. The `--code-smoke` path asks Codex to create
 `/workspace/fib.js`, run it, and then verifies the file by running
 `node /workspace/fib.js 10` inside the same box.

--- a/examples/python/06_ai_agents/README.md
+++ b/examples/python/06_ai_agents/README.md
@@ -166,3 +166,18 @@ This path creates a Node.js box, installs `@openai/codex`, logs in with
 `BOXLITE_SECRET_OPENAI_API_KEY`, and runs `codex exec`. The API key stays on the
 host. The box stores and sends only the placeholder, and gvproxy substitutes the
 real key only for requests to `api.openai.com`.
+
+To verify Codex CLI itself when secret passthrough is unavailable, pass the key
+directly into the box:
+
+```bash
+python examples/python/06_ai_agents/run_codex_in_box.py \
+  --profile p1 \
+  --image ghcr.io/boxlite-ai/boxlite-agent-node:20260605-p0-r3 \
+  --env-file ~/.config/boxlite/e2e-openai.env \
+  --unsafe-direct-api-key \
+  "Reply exactly: codex inside box works"
+```
+
+This unsafe mode is only for manual smoke testing because the plaintext API key
+is visible inside the box.

--- a/examples/python/06_ai_agents/README.md
+++ b/examples/python/06_ai_agents/README.md
@@ -85,11 +85,9 @@ python examples/python/06_ai_agents/run_codex_in_box.py \
   "Reply exactly: codex inside box works"
 ```
 
-The script reads `OPENAI_API_KEY` from the current environment first, then
-falls back to `~/.config/boxlite/e2e-openai.env` (`OPENAI_API_KEY` or
-`BOXLITE_E2E_OPENAI_API_KEY`). Use `--env-file` to point at another file. The
-box is created through the cloud REST profile from `~/.boxlite/credentials.toml`;
-use `--profile`, `BOXLITE_E2E_PROFILE`, or `BOXLITE_PROFILE` to select it.
+The script reads `OPENAI_API_KEY` from the current environment. The box is
+created through the cloud REST profile from `~/.boxlite/credentials.toml`; use
+`--profile`, `BOXLITE_E2E_PROFILE`, or `BOXLITE_PROFILE` to select it.
 
 The box receives `BOXLITE_SECRET_OPENAI_API_KEY=<BOXLITE_SECRET:openai_api_key>`;
 `codex login --with-api-key` stores that placeholder in the box, and gvproxy
@@ -156,10 +154,6 @@ export OPENAI_API_KEY="sk-..."
 python examples/python/06_ai_agents/run_codex_in_box.py \
   "Reply exactly: codex inside box works"
 ```
-
-If you do not want to export the key every time, put `OPENAI_API_KEY` or
-`BOXLITE_E2E_OPENAI_API_KEY` in `~/.config/boxlite/e2e-openai.env`, or pass a
-different file with `--env-file`.
 
 This path creates a Node.js box, installs `@openai/codex`, logs in with
 `BOXLITE_SECRET_OPENAI_API_KEY`, and runs `codex exec`. The API key stays on the

--- a/examples/python/06_ai_agents/README.md
+++ b/examples/python/06_ai_agents/README.md
@@ -176,8 +176,10 @@ python examples/python/06_ai_agents/run_codex_in_box.py \
   --image ghcr.io/boxlite-ai/boxlite-agent-node:20260605-p0-r3 \
   --env-file ~/.config/boxlite/e2e-openai.env \
   --unsafe-direct-api-key \
-  "Reply exactly: codex inside box works"
+  --code-smoke
 ```
 
 This unsafe mode is only for manual smoke testing because the plaintext API key
-is visible inside the box.
+is visible inside the box. The `--code-smoke` path asks Codex to create
+`/workspace/fib.js`, run it, and then verifies the file by running
+`node /workspace/fib.js 10` inside the same box.

--- a/examples/python/06_ai_agents/README.md
+++ b/examples/python/06_ai_agents/README.md
@@ -8,6 +8,8 @@ Using BoxLite as a sandbox for AI agent workflows.
 | `drive_box_with_minimax.py` | Let MiniMax M3 drive a SimpleBox via tool-use loop |
 | `research_agent.py` | Search the web, ask an LLM through host-side secret substitution, and answer a question |
 | `run_codex_in_box.py` | Install and run OpenAI Codex CLI inside a BoxLite box |
+| `run_code_agent_in_box.py` | Run a tiny OpenAI-powered code agent inside a cloud BoxLite box |
+| `code_agent.py` | In-box code agent with write-file, read-file, and run-command tools |
 | `use_skillbox.py` | Run Claude Code CLI with skills inside a box |
 | `chat_with_claude.py` | Multi-turn Claude conversation via stdin JSON protocol |
 | `order_starbucks.py` | End-to-end agent: order Starbucks via browser automation |
@@ -179,3 +181,18 @@ plaintext API key is visible inside the box. Pass `--secret-passthrough` to test
 BoxLite secret substitution instead. The `--code-smoke` path asks Codex to create
 `/workspace/fib.js`, run it, and then verifies the file by running
 `node /workspace/fib.js 10` inside the same box.
+
+## Tiny Code Agent In A Box
+
+`run_code_agent_in_box.py` runs a small custom code agent inside a cloud
+BoxLite box. The host creates the box and copies `code_agent.py` into it; the
+agent then calls an OpenAI chat model from inside the box and uses local tools
+to write files, read files, and run commands.
+
+```bash
+python examples/python/06_ai_agents/run_code_agent_in_box.py --code-smoke
+```
+
+The smoke path prompts for `OPENAI_API_KEY` if it is not set, asks the agent to
+create `/workspace/fib.py`, and verifies `python /workspace/fib.py 10` prints
+`55`.

--- a/examples/python/06_ai_agents/code_agent.py
+++ b/examples/python/06_ai_agents/code_agent.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Tiny code-writing agent that runs inside a BoxLite box."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+import urllib.error
+import urllib.request
+
+
+DEFAULT_MODEL = os.getenv("OPENAI_MODEL", "gpt-4.1-mini")
+OPENAI_BASE_URL = os.getenv("OPENAI_BASE_URL", "https://api.openai.com/v1")
+WORKSPACE = Path(os.getenv("CODE_AGENT_WORKSPACE", "/workspace")).resolve()
+
+
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "write_file",
+            "description": "Write UTF-8 text to a file under /workspace.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string"},
+                    "content": {"type": "string"},
+                },
+                "required": ["path", "content"],
+                "additionalProperties": False,
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "read_file",
+            "description": "Read UTF-8 text from a file under /workspace.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string"},
+                },
+                "required": ["path"],
+                "additionalProperties": False,
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "run_command",
+            "description": "Run a shell command from /workspace and return stdout, stderr, and exit code.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "command": {"type": "string"},
+                },
+                "required": ["command"],
+                "additionalProperties": False,
+            },
+        },
+    },
+]
+
+
+def api_key() -> str:
+    value = os.getenv("OPENAI_API_KEY")
+    if not value:
+        raise SystemExit("OPENAI_API_KEY is required inside the box")
+    return value
+
+
+def workspace_path(path: str) -> Path:
+    candidate = Path(path)
+    if not candidate.is_absolute():
+        candidate = WORKSPACE / candidate
+    resolved = candidate.resolve()
+    if resolved != WORKSPACE and WORKSPACE not in resolved.parents:
+        raise ValueError(f"path must stay under {WORKSPACE}: {path}")
+    return resolved
+
+
+def call_openai(messages: list[dict[str, Any]], model: str, timeout: int) -> dict[str, Any]:
+    payload = {
+        "model": model,
+        "messages": messages,
+        "tools": TOOLS,
+        "tool_choice": "auto",
+        "temperature": 0,
+    }
+    request = urllib.request.Request(
+        f"{OPENAI_BASE_URL.rstrip('/')}/chat/completions",
+        data=json.dumps(payload).encode("utf-8"),
+        headers={
+            "Authorization": f"Bearer {api_key()}",
+            "Content-Type": "application/json",
+            "User-Agent": "boxlite-code-agent/0.1",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return json.loads(response.read().decode("utf-8", "replace"))
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", "replace")
+        raise RuntimeError(f"OpenAI request failed with HTTP {exc.code}: {body[:1000]}") from exc
+
+
+def run_tool(name: str, args: dict[str, Any], timeout: int) -> str:
+    if name == "write_file":
+        target = workspace_path(args["path"])
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(args["content"], encoding="utf-8")
+        return json.dumps({"ok": True, "path": str(target)})
+
+    if name == "read_file":
+        target = workspace_path(args["path"])
+        return json.dumps({"path": str(target), "content": target.read_text(encoding="utf-8")})
+
+    if name == "run_command":
+        result = subprocess.run(
+            args["command"],
+            cwd=str(WORKSPACE),
+            shell=True,
+            text=True,
+            capture_output=True,
+            timeout=timeout,
+            check=False,
+        )
+        return json.dumps(
+            {
+                "exit_code": result.returncode,
+                "stdout": result.stdout[-4000:],
+                "stderr": result.stderr[-4000:],
+            }
+        )
+
+    raise ValueError(f"unknown tool: {name}")
+
+
+def run_agent(goal: str, model: str, max_steps: int, timeout: int) -> str:
+    WORKSPACE.mkdir(parents=True, exist_ok=True)
+    messages: list[dict[str, Any]] = [
+        {
+            "role": "system",
+            "content": (
+                "You are a code agent running inside /workspace. Use tools to write files "
+                "and run commands. Finish with a concise summary and include the final command output."
+            ),
+        },
+        {"role": "user", "content": goal},
+    ]
+
+    for step in range(1, max_steps + 1):
+        data = call_openai(messages, model, timeout)
+        message = data["choices"][0]["message"]
+        messages.append(message)
+        tool_calls = message.get("tool_calls") or []
+        if not tool_calls:
+            return message.get("content") or ""
+
+        for call in tool_calls:
+            name = call["function"]["name"]
+            args = json.loads(call["function"].get("arguments") or "{}")
+            print(f"[step {step}] tool={name} args={json.dumps(args, ensure_ascii=False)}", flush=True)
+            output = run_tool(name, args, timeout)
+            print(f"[step {step}] output={output}", flush=True)
+            messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": call["id"],
+                    "content": output,
+                }
+            )
+
+    raise RuntimeError(f"agent did not finish within {max_steps} steps")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run a tiny code agent inside a BoxLite box.")
+    parser.add_argument("goal", nargs="+")
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument("--max-steps", type=int, default=8)
+    parser.add_argument("--timeout", type=int, default=60)
+    args = parser.parse_args()
+
+    final = run_agent(" ".join(args.goal), args.model, args.max_steps, args.timeout)
+    print("\nFinal answer:")
+    print(final)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/python/06_ai_agents/research_agent.py
+++ b/examples/python/06_ai_agents/research_agent.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""
+Research agent example.
+
+Accepts a question, searches the web, asks an OpenAI-compatible chat
+completion endpoint to synthesize an answer, and prints the final response.
+
+When this runs inside a BoxLite box, the API key can be supplied as a BoxLite
+secret placeholder. The real key stays on the host side and gvproxy substitutes
+it only when the request reaches the configured LLM API host.
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import os
+import textwrap
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from html.parser import HTMLParser
+from typing import Iterable
+
+
+DEFAULT_USER_AGENT = "boxlite-research-agent/0.1"
+DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1"
+DEFAULT_OPENAI_MODEL = "gpt-4.1-mini"
+
+
+@dataclass
+class SearchResult:
+    title: str
+    url: str
+    snippet: str
+
+
+class DuckDuckGoHTMLParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.results: list[SearchResult] = []
+        self._in_title = False
+        self._in_snippet = False
+        self._title_parts: list[str] = []
+        self._snippet_parts: list[str] = []
+        self._current_url = ""
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        attrs_dict = dict(attrs)
+        classes = attrs_dict.get("class", "")
+        if tag == "a" and ("result__a" in classes or "result-link" in classes):
+            self._in_title = True
+            self._title_parts = []
+            self._snippet_parts = []
+            self._current_url = attrs_dict.get("href") or ""
+        elif tag in {"a", "div", "td"} and ("result__snippet" in classes or "result-snippet" in classes):
+            self._in_snippet = True
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "a" and self._in_title:
+            self._in_title = False
+        elif tag in {"a", "div", "td"} and self._in_snippet:
+            self._in_snippet = False
+            title = clean_text(" ".join(self._title_parts))
+            snippet = clean_text(" ".join(self._snippet_parts))
+            if title and self._current_url:
+                self.results.append(SearchResult(title=title, url=normalize_ddg_url(self._current_url), snippet=snippet))
+
+    def handle_data(self, data: str) -> None:
+        if self._in_title:
+            self._title_parts.append(data)
+        elif self._in_snippet:
+            self._snippet_parts.append(data)
+
+
+def clean_text(value: str) -> str:
+    return " ".join(html.unescape(value).split())
+
+
+def normalize_ddg_url(url: str) -> str:
+    if url.startswith("//"):
+        url = f"https:{url}"
+    parsed = urllib.parse.urlparse(url)
+    query = urllib.parse.parse_qs(parsed.query)
+    if "uddg" in query:
+        return query["uddg"][0]
+    return url
+
+
+def search_duckduckgo(question: str, limit: int, timeout: float) -> list[SearchResult]:
+    params = urllib.parse.urlencode({"q": question})
+    for endpoint in ("https://html.duckduckgo.com/html/", "https://lite.duckduckgo.com/lite/"):
+        request = urllib.request.Request(
+            f"{endpoint}?{params}",
+            headers={"User-Agent": DEFAULT_USER_AGENT},
+        )
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            body = response.read().decode("utf-8", errors="replace")
+
+        parser = DuckDuckGoHTMLParser()
+        parser.feed(body)
+        if parser.results:
+            return parser.results[:limit]
+
+    return []
+
+
+def search_from_fixture(path: str, limit: int) -> list[SearchResult]:
+    with open(path, "r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    results = []
+    for item in payload[:limit]:
+        results.append(SearchResult(title=item["title"], url=item["url"], snippet=item.get("snippet", "")))
+    return results
+
+
+def format_context(results: Iterable[SearchResult]) -> str:
+    lines = []
+    for index, result in enumerate(results, start=1):
+        lines.append(f"[{index}] {result.title}\nURL: {result.url}\nSnippet: {result.snippet}")
+    return "\n\n".join(lines)
+
+
+def build_answer_prompt(question: str, results: list[SearchResult]) -> str:
+    return textwrap.dedent(
+        f"""
+        You are a concise research agent. Answer the user's question using the
+        web search results below. Cite sources inline as [1], [2], etc. If the
+        search results are insufficient, say what is missing.
+
+        Question:
+        {question}
+
+        Search results:
+        {format_context(results)}
+        """
+    ).strip()
+
+
+def openai_api_key() -> str | None:
+    return os.getenv("OPENAI_API_KEY") or os.getenv("BOXLITE_SECRET_OPENAI_API_KEY")
+
+
+def ask_openai(prompt: str, model: str, base_url: str, timeout: float) -> str:
+    api_key = openai_api_key()
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY or BOXLITE_SECRET_OPENAI_API_KEY is required")
+
+    payload = {
+        "model": model,
+        "messages": [
+            {
+                "role": "system",
+                "content": "You answer with concise, cited research summaries.",
+            },
+            {"role": "user", "content": prompt},
+        ],
+        "temperature": 0.2,
+    }
+    request = urllib.request.Request(
+        f"{base_url.rstrip('/')}/chat/completions",
+        data=json.dumps(payload).encode("utf-8"),
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            "User-Agent": DEFAULT_USER_AGENT,
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            body = response.read().decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"OpenAI request failed with HTTP {exc.code}: {body[:500]}") from exc
+
+    data = json.loads(body)
+    choices = data.get("choices") or []
+    if not choices:
+        raise RuntimeError(f"OpenAI response did not include choices: {body[:500]}")
+    message = choices[0].get("message") or {}
+    return str(message.get("content", "")).strip()
+
+
+def ask_echo(question: str, results: list[SearchResult]) -> str:
+    if not results:
+        return f"No search results were available for: {question}"
+    bullets = "\n".join(f"- [{idx}] {result.title}: {result.snippet}" for idx, result in enumerate(results, start=1))
+    return f"Echo provider summary for: {question}\n\n{bullets}"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Search the web, ask an LLM, and answer a question.")
+    parser.add_argument("question", nargs="+", help="Question to answer")
+    parser.add_argument("--search-provider", choices=["duckduckgo", "fixture"], default=os.getenv("RESEARCH_AGENT_SEARCH_PROVIDER", "duckduckgo"))
+    parser.add_argument("--search-fixture", default=os.getenv("RESEARCH_AGENT_SEARCH_FIXTURE"))
+    parser.add_argument("--answer-provider", choices=["openai", "echo"], default=os.getenv("RESEARCH_AGENT_ANSWER_PROVIDER", "echo"))
+    parser.add_argument("--openai-model", default=os.getenv("OPENAI_MODEL", DEFAULT_OPENAI_MODEL))
+    parser.add_argument("--openai-base-url", default=os.getenv("OPENAI_BASE_URL", DEFAULT_OPENAI_BASE_URL))
+    parser.add_argument("--limit", type=int, default=int(os.getenv("RESEARCH_AGENT_SEARCH_LIMIT", "5")))
+    parser.add_argument("--timeout", type=float, default=float(os.getenv("RESEARCH_AGENT_TIMEOUT", "20")))
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    question = " ".join(args.question)
+
+    if args.search_provider == "fixture":
+        if not args.search_fixture:
+            raise SystemExit("--search-fixture is required with fixture search provider")
+        results = search_from_fixture(args.search_fixture, args.limit)
+    else:
+        results = search_duckduckgo(question, args.limit, args.timeout)
+
+    prompt = build_answer_prompt(question, results)
+    if args.answer_provider == "openai":
+        answer = ask_openai(prompt, args.openai_model, args.openai_base_url, args.timeout)
+    else:
+        answer = ask_echo(question, results)
+
+    print(answer)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/python/06_ai_agents/research_agent_fixture.json
+++ b/examples/python/06_ai_agents/research_agent_fixture.json
@@ -1,0 +1,12 @@
+[
+  {
+    "title": "BoxLite AI agent examples",
+    "url": "https://github.com/boxlite-ai/boxlite/tree/main/examples/python/06_ai_agents",
+    "snippet": "BoxLite examples show how to run AI agent workflows in sandboxed boxes."
+  },
+  {
+    "title": "Codex tool-use loop",
+    "url": "https://platform.openai.com/docs",
+    "snippet": "A tool-use loop lets a model request actions, observe results, and continue reasoning."
+  }
+]

--- a/examples/python/06_ai_agents/run_code_agent_in_box.py
+++ b/examples/python/06_ai_agents/run_code_agent_in_box.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Launch the tiny code agent inside a cloud REST-backed BoxLite box."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import getpass
+import json
+import os
+import sys
+import urllib.request
+from pathlib import Path
+
+import boxlite
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 fallback
+    import tomli as tomllib  # type: ignore[no-redef]
+
+
+DEFAULT_IMAGE = os.getenv("BOXLITE_CODE_AGENT_IMAGE", "ghcr.io/boxlite-ai/boxlite-agent-python:20260605-p0-r3")
+DEFAULT_MODEL = os.getenv("OPENAI_MODEL", "gpt-4.1-mini")
+DEFAULT_PROFILE = os.getenv("BOXLITE_E2E_PROFILE") or os.getenv("BOXLITE_PROFILE") or "p1"
+CODE_SMOKE_GOAL = (
+    "Create /workspace/fib.py. It must read n from sys.argv[1], compute fibonacci(n), "
+    "print only the number, then run `python /workspace/fib.py 10` and make sure it prints 55."
+)
+
+
+def prompt_openai_api_key() -> str | None:
+    value = os.getenv("OPENAI_API_KEY")
+    if value:
+        return value
+    if not sys.stdin.isatty():
+        return None
+    value = getpass.getpass("OPENAI_API_KEY: ").strip()
+    return value or None
+
+
+def credentials_path() -> Path:
+    if os.getenv("BOXLITE_HOME"):
+        return Path(os.environ["BOXLITE_HOME"]) / "credentials.toml"
+    return Path.home() / ".boxlite" / "credentials.toml"
+
+
+def discover_path_prefix(url: str, token: str) -> str:
+    request = urllib.request.Request(
+        f"{url.rstrip('/')}/v1/me",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    with urllib.request.urlopen(request, timeout=15) as response:
+        body = json.loads(response.read() or "null")
+    return (body or {}).get("path_prefix") or ""
+
+
+def rest_runtime_from_profile(profile_name: str):
+    path = credentials_path()
+    if not path.exists():
+        print(f"ERROR: {path} is missing")
+        print("Create a cloud REST profile first, for example:")
+        print("")
+        print("  mkdir -p ~/.boxlite")
+        print("  cat > ~/.boxlite/credentials.toml <<'EOF'")
+        print("  [profiles.p1]")
+        print('  url = "https://api.dev.boxlite.ai/api"')
+        print('  api_key = "<boxlite-api-key>"')
+        print('  auth_method = "api_key"')
+        print("  EOF")
+        raise SystemExit(1)
+
+    data = tomllib.loads(path.read_text(encoding="utf-8"))
+    profile = data.get("profiles", {}).get(profile_name)
+    if not profile:
+        print(f"ERROR: profile {profile_name!r} not found in {path}")
+        print(f"Run: export BOXLITE_PROFILE='{profile_name}'")
+        print(f"Or pass: --profile {profile_name}")
+        raise SystemExit(1)
+
+    url = os.getenv("BOXLITE_E2E_API_URL") or profile.get("url")
+    token = os.getenv("BOXLITE_E2E_API_KEY") or profile.get("api_key") or os.getenv("BOXLITE_E2E_OIDC_TOKEN") or profile.get("access_token")
+    if not url or not token:
+        print(f"ERROR: profile {profile_name!r} must include url and api_key/access_token")
+        raise SystemExit(1)
+
+    explicit_prefix = os.getenv("BOXLITE_E2E_PREFIX")
+    if explicit_prefix is not None:
+        path_prefix = explicit_prefix
+    elif os.getenv("BOXLITE_E2E_DISCOVER_PREFIX", "1") != "0":
+        path_prefix = discover_path_prefix(url, token)
+    else:
+        path_prefix = profile.get("path_prefix") or ""
+
+    print(f"Runtime: REST profile={profile_name} url={url} prefix={path_prefix or '<none>'}", flush=True)
+    return boxlite.Boxlite.rest(
+        boxlite.BoxliteRestOptions(
+            url=url,
+            credential=boxlite.ApiKeyCredential(token),
+            path_prefix=path_prefix,
+        )
+    )
+
+
+async def drain(execution, *, stream: bool = False) -> tuple[str, str]:
+    stdout_chunks: list[str] = []
+    stderr_chunks: list[str] = []
+
+    async def collect(source, chunks: list[str], label: str) -> None:
+        async for chunk in source:
+            text = chunk.decode() if isinstance(chunk, bytes) else str(chunk)
+            chunks.append(text)
+            if stream:
+                print(f"[{label}] {text}", end="", flush=True)
+
+    await asyncio.gather(
+        collect(execution.stdout(), stdout_chunks, "stdout"),
+        collect(execution.stderr(), stderr_chunks, "stderr"),
+    )
+    return "".join(stdout_chunks), "".join(stderr_chunks)
+
+
+async def run(box, command: str, args: list[str], *, env: list[tuple[str, str]] | None = None, timeout: int = 300, stream: bool = False) -> tuple[int, str, str]:
+    print(f"$ {command} {' '.join(args)}", flush=True)
+    execution = await box.exec(command, args, env)
+    stdout, stderr = await drain(execution, stream=stream)
+    result = await asyncio.wait_for(execution.wait(), timeout=timeout)
+    return result.exit_code, stdout, stderr
+
+
+async def verify_code_smoke(box) -> None:
+    print("Verifying agent-created code inside the box...", flush=True)
+    exit_code, stdout, stderr = await run(
+        box,
+        "sh",
+        ["-lc", "set -eu\ntest -f /workspace/fib.py\npython /workspace/fib.py 10\n"],
+        timeout=60,
+        stream=True,
+    )
+    if exit_code != 0:
+        raise RuntimeError(f"code-agent verification failed\nstdout={stdout}\nstderr={stderr}")
+    if stdout.strip() != "55":
+        raise RuntimeError(f"code-agent printed {stdout.strip()!r}, expected '55'")
+    print("Verified: /workspace/fib.py prints 55", flush=True)
+
+
+async def main() -> int:
+    parser = argparse.ArgumentParser(description="Run a tiny OpenAI-powered code agent inside a BoxLite box.")
+    parser.add_argument("goal", nargs="*", help="Goal for the code agent")
+    parser.add_argument("--profile", default=DEFAULT_PROFILE)
+    parser.add_argument("--image", default=DEFAULT_IMAGE)
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument("--code-smoke", action="store_true")
+    parser.add_argument("--keep-box", action="store_true")
+    args = parser.parse_args()
+
+    api_key = prompt_openai_api_key()
+    if not api_key:
+        print("ERROR: OPENAI_API_KEY not set")
+        print("Run: export OPENAI_API_KEY='sk-...'")
+        raise SystemExit(1)
+
+    runtime = rest_runtime_from_profile(args.profile)
+    box = await runtime.create(
+        boxlite.BoxOptions(
+            image=args.image,
+            memory_mib=1024,
+            disk_size_gb=4,
+            auto_remove=not args.keep_box,
+            network=boxlite.NetworkSpec(mode="enabled", allow_net=["api.openai.com"]),
+        )
+    )
+    try:
+        print(f"Box: {box.id}", flush=True)
+        agent_path = Path(__file__).with_name("code_agent.py")
+        await box.copy_in(str(agent_path), "/workspace/code_agent.py")
+        goal = CODE_SMOKE_GOAL if args.code_smoke or not args.goal else " ".join(args.goal)
+        exit_code, stdout, stderr = await run(
+            box,
+            "python",
+            ["/workspace/code_agent.py", goal, "--model", args.model],
+            env=[("OPENAI_API_KEY", api_key)],
+            timeout=600,
+            stream=True,
+        )
+        if exit_code != 0:
+            raise RuntimeError(f"code-agent failed with exit code {exit_code}\nstdout={stdout}\nstderr={stderr}")
+        if args.code_smoke:
+            await verify_code_smoke(box)
+        return 0
+    finally:
+        if not args.keep_box:
+            try:
+                await runtime.remove(box.id, force=True)
+            except Exception:
+                pass
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/examples/python/06_ai_agents/run_codex_in_box.py
+++ b/examples/python/06_ai_agents/run_codex_in_box.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""
+Run OpenAI Codex CLI inside a BoxLite box.
+
+This is intentionally small and explicit:
+1. create a Node.js box,
+2. install @openai/codex with npm,
+3. expose only a BoxLite secret placeholder as OPENAI_API_KEY inside the box,
+4. run `codex exec` non-interactively.
+
+Prerequisites:
+    export OPENAI_API_KEY="sk-..."
+
+Or put OPENAI_API_KEY / BOXLITE_E2E_OPENAI_API_KEY in:
+    ~/.config/boxlite/e2e-openai.env
+
+Usage:
+    python examples/python/06_ai_agents/run_codex_in_box.py \
+      "Say exactly: codex inside box works"
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import textwrap
+from pathlib import Path
+
+import boxlite
+
+
+DEFAULT_IMAGE = os.getenv("BOXLITE_CODEX_IMAGE", "node:20-bookworm-slim")
+DEFAULT_MODEL = os.getenv("OPENAI_MODEL", "gpt-4.1-mini")
+DEFAULT_ENV_FILE = Path(os.getenv("BOXLITE_OPENAI_ENV_FILE", "~/.config/boxlite/e2e-openai.env")).expanduser()
+
+
+def load_env_file(path: Path) -> dict[str, str]:
+    if not path.exists():
+        return {}
+
+    values: dict[str, str] = {}
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[len("export ") :].strip()
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip().strip("'\"")
+        if key:
+            values[key] = value
+    return values
+
+
+def openai_api_key(env_file: Path) -> str | None:
+    if os.getenv("OPENAI_API_KEY"):
+        return os.getenv("OPENAI_API_KEY")
+
+    values = load_env_file(env_file)
+    return values.get("OPENAI_API_KEY") or values.get("BOXLITE_E2E_OPENAI_API_KEY")
+
+
+async def drain(execution) -> tuple[str, str]:
+    stdout_chunks: list[str] = []
+    stderr_chunks: list[str] = []
+
+    async def collect(stream, chunks: list[str]) -> None:
+        async for chunk in stream:
+            chunks.append(chunk.decode() if isinstance(chunk, bytes) else str(chunk))
+
+    await asyncio.gather(
+        collect(execution.stdout(), stdout_chunks),
+        collect(execution.stderr(), stderr_chunks),
+    )
+    return "".join(stdout_chunks), "".join(stderr_chunks)
+
+
+async def run(box, command: str, args: list[str], timeout: int = 300) -> tuple[int, str, str]:
+    execution = await box.exec(command, args, None)
+    stdout, stderr = await drain(execution)
+    result = await asyncio.wait_for(execution.wait(), timeout=timeout)
+    return result.exit_code, stdout, stderr
+
+
+async def install_codex(box) -> None:
+    exit_code, stdout, stderr = await run(
+        box,
+        "sh",
+        [
+            "-lc",
+            "command -v codex >/dev/null 2>&1 || npm install -g @openai/codex",
+        ],
+        timeout=600,
+    )
+    if exit_code != 0:
+        raise RuntimeError(f"failed to install Codex CLI\nstdout={stdout}\nstderr={stderr}")
+
+    exit_code, stdout, stderr = await run(box, "codex", ["--version"], timeout=60)
+    if exit_code != 0:
+        raise RuntimeError(f"failed to verify Codex CLI\nstdout={stdout}\nstderr={stderr}")
+    print(f"Codex CLI: {stdout.strip()}")
+
+
+async def run_codex(box, prompt: str, model: str) -> str:
+    command = textwrap.dedent(
+        f"""
+        export OPENAI_API_KEY="$BOXLITE_SECRET_OPENAI_API_KEY"
+        export CODEX_HOME=/root/.codex-boxlite
+        mkdir -p "$CODEX_HOME"
+        printf '%s' "$OPENAI_API_KEY" | codex login --with-api-key >/dev/null
+        mkdir -p /workspace
+        cd /workspace
+        codex exec \
+          --skip-git-repo-check \
+          --ignore-user-config \
+          --sandbox read-only \
+          --model {model} \
+          {prompt!r} \
+          </dev/null
+        """
+    ).strip()
+    exit_code, stdout, stderr = await run(box, "sh", ["-lc", command], timeout=600)
+    if exit_code != 0:
+        raise RuntimeError(f"Codex CLI failed with exit code {exit_code}\nstdout={stdout}\nstderr={stderr}")
+    return stdout.strip()
+
+
+async def main() -> int:
+    parser = argparse.ArgumentParser(description="Install and run OpenAI Codex CLI inside a BoxLite box.")
+    parser.add_argument("prompt", nargs="+", help="Prompt for codex exec")
+    parser.add_argument("--image", default=DEFAULT_IMAGE)
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument("--env-file", type=Path, default=DEFAULT_ENV_FILE)
+    parser.add_argument("--keep-box", action="store_true", help="Keep the box after the run for inspection")
+    args = parser.parse_args()
+
+    api_key = openai_api_key(args.env_file.expanduser())
+    if not api_key:
+        raise SystemExit(f"OPENAI_API_KEY is required on the host or in {args.env_file}")
+
+    runtime = boxlite.Boxlite.default()
+    box = await runtime.create(
+        boxlite.BoxOptions(
+            image=args.image,
+            memory_mib=2048,
+            disk_size_gb=8,
+            auto_remove=not args.keep_box,
+            network=boxlite.NetworkSpec(mode="enabled"),
+            secrets=[
+                boxlite.Secret(
+                    name="openai_api_key",
+                    value=api_key,
+                    hosts=["api.openai.com"],
+                )
+            ],
+        )
+    )
+    try:
+        print(f"Box: {box.id}")
+        await install_codex(box)
+        answer = await run_codex(box, " ".join(args.prompt), args.model)
+        print(answer)
+        return 0
+    finally:
+        if not args.keep_box:
+            try:
+                await runtime.remove(box.id, force=True)
+            except Exception:
+                pass
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/examples/python/06_ai_agents/run_codex_in_box.py
+++ b/examples/python/06_ai_agents/run_codex_in_box.py
@@ -23,16 +23,24 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import json
 import os
 import textwrap
+import urllib.request
 from pathlib import Path
 
 import boxlite
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 fallback
+    import tomli as tomllib  # type: ignore[no-redef]
 
 
 DEFAULT_IMAGE = os.getenv("BOXLITE_CODEX_IMAGE", "node:20-bookworm-slim")
 DEFAULT_MODEL = os.getenv("OPENAI_MODEL", "gpt-4.1-mini")
 DEFAULT_ENV_FILE = Path(os.getenv("BOXLITE_OPENAI_ENV_FILE", "~/.config/boxlite/e2e-openai.env")).expanduser()
+DEFAULT_PROFILE = os.getenv("BOXLITE_E2E_PROFILE") or os.getenv("BOXLITE_PROFILE") or "p1"
 
 
 def load_env_file(path: Path) -> dict[str, str]:
@@ -64,29 +72,87 @@ def openai_api_key(env_file: Path) -> str | None:
     return values.get("OPENAI_API_KEY") or values.get("BOXLITE_E2E_OPENAI_API_KEY")
 
 
-async def drain(execution) -> tuple[str, str]:
+def credentials_path() -> Path:
+    if os.getenv("BOXLITE_HOME"):
+        return Path(os.environ["BOXLITE_HOME"]) / "credentials.toml"
+    return Path.home() / ".boxlite" / "credentials.toml"
+
+
+def discover_path_prefix(url: str, token: str) -> str:
+    request = urllib.request.Request(
+        f"{url.rstrip('/')}/v1/me",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    with urllib.request.urlopen(request, timeout=15) as response:
+        body = json.loads(response.read() or "null")
+    return (body or {}).get("path_prefix") or ""
+
+
+def rest_runtime_from_profile(profile_name: str):
+    path = credentials_path()
+    if not path.exists():
+        raise SystemExit(f"{path} is missing; configure a cloud profile first")
+
+    data = tomllib.loads(path.read_text(encoding="utf-8"))
+    profile = data.get("profiles", {}).get(profile_name)
+    if not profile:
+        raise SystemExit(f"profile {profile_name!r} not found in {path}")
+
+    url = os.getenv("BOXLITE_E2E_API_URL") or profile.get("url")
+    token = (
+        os.getenv("BOXLITE_E2E_API_KEY")
+        or profile.get("api_key")
+        or os.getenv("BOXLITE_E2E_OIDC_TOKEN")
+        or profile.get("access_token")
+    )
+    if not url or not token:
+        raise SystemExit(f"profile {profile_name!r} must include url and api_key/access_token")
+
+    explicit_prefix = os.getenv("BOXLITE_E2E_PREFIX")
+    if explicit_prefix is not None:
+        path_prefix = explicit_prefix
+    elif os.getenv("BOXLITE_E2E_DISCOVER_PREFIX", "1") != "0":
+        path_prefix = discover_path_prefix(url, token)
+    else:
+        path_prefix = profile.get("path_prefix") or ""
+
+    print(f"Runtime: REST profile={profile_name} url={url} prefix={path_prefix or '<none>'}", flush=True)
+    return boxlite.Boxlite.rest(
+        boxlite.BoxliteRestOptions(
+            url=url,
+            credential=boxlite.ApiKeyCredential(token),
+            path_prefix=path_prefix,
+        )
+    )
+
+
+async def drain(execution, *, stream: bool = False) -> tuple[str, str]:
     stdout_chunks: list[str] = []
     stderr_chunks: list[str] = []
 
-    async def collect(stream, chunks: list[str]) -> None:
-        async for chunk in stream:
+    async def collect(source, chunks: list[str], label: str) -> None:
+        async for chunk in source:
             chunks.append(chunk.decode() if isinstance(chunk, bytes) else str(chunk))
+            if stream:
+                print(f"[{label}] {chunks[-1]}", end="", flush=True)
 
     await asyncio.gather(
-        collect(execution.stdout(), stdout_chunks),
-        collect(execution.stderr(), stderr_chunks),
+        collect(execution.stdout(), stdout_chunks, "stdout"),
+        collect(execution.stderr(), stderr_chunks, "stderr"),
     )
     return "".join(stdout_chunks), "".join(stderr_chunks)
 
 
-async def run(box, command: str, args: list[str], timeout: int = 300) -> tuple[int, str, str]:
+async def run(box, command: str, args: list[str], timeout: int = 300, *, stream: bool = False) -> tuple[int, str, str]:
+    print(f"$ {command} {' '.join(args)}", flush=True)
     execution = await box.exec(command, args, None)
-    stdout, stderr = await drain(execution)
+    stdout, stderr = await drain(execution, stream=stream)
     result = await asyncio.wait_for(execution.wait(), timeout=timeout)
     return result.exit_code, stdout, stderr
 
 
 async def install_codex(box) -> None:
+    print("Installing Codex CLI inside the box...", flush=True)
     exit_code, stdout, stderr = await run(
         box,
         "sh",
@@ -95,6 +161,7 @@ async def install_codex(box) -> None:
             "command -v codex >/dev/null 2>&1 || npm install -g @openai/codex",
         ],
         timeout=600,
+        stream=True,
     )
     if exit_code != 0:
         raise RuntimeError(f"failed to install Codex CLI\nstdout={stdout}\nstderr={stderr}")
@@ -135,6 +202,7 @@ async def main() -> int:
     parser.add_argument("--image", default=DEFAULT_IMAGE)
     parser.add_argument("--model", default=DEFAULT_MODEL)
     parser.add_argument("--env-file", type=Path, default=DEFAULT_ENV_FILE)
+    parser.add_argument("--profile", default=DEFAULT_PROFILE, help="Cloud REST profile from ~/.boxlite/credentials.toml")
     parser.add_argument("--keep-box", action="store_true", help="Keep the box after the run for inspection")
     args = parser.parse_args()
 
@@ -142,7 +210,7 @@ async def main() -> int:
     if not api_key:
         raise SystemExit(f"OPENAI_API_KEY is required on the host or in {args.env_file}")
 
-    runtime = boxlite.Boxlite.default()
+    runtime = rest_runtime_from_profile(args.profile)
     box = await runtime.create(
         boxlite.BoxOptions(
             image=args.image,

--- a/examples/python/06_ai_agents/run_codex_in_box.py
+++ b/examples/python/06_ai_agents/run_codex_in_box.py
@@ -41,6 +41,10 @@ DEFAULT_IMAGE = os.getenv("BOXLITE_CODEX_IMAGE", "node:20-bookworm-slim")
 DEFAULT_MODEL = os.getenv("OPENAI_MODEL", "gpt-4.1-mini")
 DEFAULT_ENV_FILE = Path(os.getenv("BOXLITE_OPENAI_ENV_FILE", "~/.config/boxlite/e2e-openai.env")).expanduser()
 DEFAULT_PROFILE = os.getenv("BOXLITE_E2E_PROFILE") or os.getenv("BOXLITE_PROFILE") or "p1"
+CODE_SMOKE_PROMPT = (
+    "Create /workspace/fib.js. It must read n from process.argv[2], compute fibonacci(n), "
+    "print only the number, then run `node /workspace/fib.js 10` and ensure it prints 55."
+)
 
 
 def load_env_file(path: Path) -> dict[str, str]:
@@ -195,7 +199,7 @@ async def run_codex(box, prompt: str, model: str, *, direct_api_key: str | None 
         codex exec \
           --skip-git-repo-check \
           --ignore-user-config \
-          --sandbox read-only \
+          --sandbox workspace-write \
           --model {model} \
           {prompt!r} \
           </dev/null
@@ -208,9 +212,28 @@ async def run_codex(box, prompt: str, model: str, *, direct_api_key: str | None 
     return stdout.strip()
 
 
+async def verify_code_smoke(box) -> None:
+    print("Verifying Codex-created code inside the box...", flush=True)
+    exit_code, stdout, stderr = await run(
+        box,
+        "sh",
+        [
+            "-lc",
+            "test -f /workspace/fib.js && node /workspace/fib.js 10",
+        ],
+        timeout=60,
+        stream=True,
+    )
+    if exit_code != 0:
+        raise RuntimeError(f"Codex code smoke verification failed\nstdout={stdout}\nstderr={stderr}")
+    if stdout.strip() != "55":
+        raise RuntimeError(f"Codex code smoke printed {stdout.strip()!r}, expected '55'")
+    print("Verified: /workspace/fib.js prints 55", flush=True)
+
+
 async def main() -> int:
     parser = argparse.ArgumentParser(description="Install and run OpenAI Codex CLI inside a BoxLite box.")
-    parser.add_argument("prompt", nargs="+", help="Prompt for codex exec")
+    parser.add_argument("prompt", nargs="*", help="Prompt for codex exec")
     parser.add_argument("--image", default=DEFAULT_IMAGE)
     parser.add_argument("--model", default=DEFAULT_MODEL)
     parser.add_argument("--env-file", type=Path, default=DEFAULT_ENV_FILE)
@@ -219,6 +242,11 @@ async def main() -> int:
         "--unsafe-direct-api-key",
         action="store_true",
         help="Pass the plaintext OpenAI API key into the box to verify Codex CLI itself; do not use for secret-passthrough validation.",
+    )
+    parser.add_argument(
+        "--code-smoke",
+        action="store_true",
+        help="Ask Codex to create and run /workspace/fib.js, then verify the file by running node in the box.",
     )
     parser.add_argument("--keep-box", action="store_true", help="Keep the box after the run for inspection")
     args = parser.parse_args()
@@ -247,13 +275,16 @@ async def main() -> int:
     try:
         print(f"Box: {box.id}")
         await install_codex(box)
+        prompt = CODE_SMOKE_PROMPT if args.code_smoke or not args.prompt else " ".join(args.prompt)
         answer = await run_codex(
             box,
-            " ".join(args.prompt),
+            prompt,
             args.model,
             direct_api_key=api_key if args.unsafe_direct_api_key else None,
         )
         print(answer)
+        if args.code_smoke:
+            await verify_code_smoke(box)
         return 0
     finally:
         if not args.keep_box:

--- a/examples/python/06_ai_agents/run_codex_in_box.py
+++ b/examples/python/06_ai_agents/run_codex_in_box.py
@@ -11,9 +11,6 @@ This is intentionally small and explicit:
 Prerequisites:
     export OPENAI_API_KEY="sk-..."
 
-Or put OPENAI_API_KEY / BOXLITE_E2E_OPENAI_API_KEY in:
-    ~/.config/boxlite/e2e-openai.env
-
 Usage:
     python examples/python/06_ai_agents/run_codex_in_box.py \
       "Say exactly: codex inside box works"
@@ -39,7 +36,6 @@ except ModuleNotFoundError:  # pragma: no cover - Python 3.10 fallback
 
 DEFAULT_IMAGE = os.getenv("BOXLITE_CODEX_IMAGE", "ghcr.io/boxlite-ai/boxlite-agent-node:20260605-p0-r3")
 DEFAULT_MODEL = os.getenv("OPENAI_MODEL", "gpt-4.1-mini")
-DEFAULT_ENV_FILE = Path(os.getenv("BOXLITE_OPENAI_ENV_FILE", "~/.config/boxlite/e2e-openai.env")).expanduser()
 DEFAULT_PROFILE = os.getenv("BOXLITE_E2E_PROFILE") or os.getenv("BOXLITE_PROFILE") or "p1"
 DEFAULT_DIRECT_KEY = os.getenv("BOXLITE_CODEX_SECRET_PASSTHROUGH", "").lower() not in ("1", "true", "yes", "on")
 CODE_SMOKE_PROMPT = (
@@ -50,42 +46,13 @@ CODE_SMOKE_PROMPT = (
 )
 
 
-def load_env_file(path: Path) -> dict[str, str]:
-    if not path.exists():
-        return {}
-
-    values: dict[str, str] = {}
-    for raw_line in path.read_text(encoding="utf-8").splitlines():
-        line = raw_line.strip()
-        if not line or line.startswith("#"):
-            continue
-        if line.startswith("export "):
-            line = line[len("export ") :].strip()
-        if "=" not in line:
-            continue
-        key, value = line.split("=", 1)
-        key = key.strip()
-        value = value.strip().strip("'\"")
-        if key:
-            values[key] = value
-    return values
-
-
-def print_openai_auth_help(env_file: Path) -> None:
+def print_openai_auth_help() -> None:
     print("ERROR: OPENAI_API_KEY not set")
     print("Run: export OPENAI_API_KEY='sk-...'")
-    print(f"Or create {env_file}:")
-    print("  mkdir -p ~/.config/boxlite")
-    print(f"  printf 'export BOXLITE_E2E_OPENAI_API_KEY=\"sk-...\"\\n' > {env_file}")
-    print(f"  chmod 600 {env_file}")
 
 
-def openai_api_key(env_file: Path) -> str | None:
-    if os.getenv("OPENAI_API_KEY"):
-        return os.getenv("OPENAI_API_KEY")
-
-    values = load_env_file(env_file)
-    return values.get("OPENAI_API_KEY") or values.get("BOXLITE_E2E_OPENAI_API_KEY")
+def openai_api_key() -> str | None:
+    return os.getenv("OPENAI_API_KEY")
 
 
 def credentials_path() -> Path:
@@ -280,7 +247,6 @@ async def main() -> int:
     parser.add_argument("prompt", nargs="*", help="Prompt for codex exec")
     parser.add_argument("--image", default=DEFAULT_IMAGE)
     parser.add_argument("--model", default=DEFAULT_MODEL)
-    parser.add_argument("--env-file", type=Path, default=DEFAULT_ENV_FILE)
     parser.add_argument("--profile", default=DEFAULT_PROFILE, help="Cloud REST profile from ~/.boxlite/credentials.toml")
     parser.add_argument(
         "--unsafe-direct-api-key",
@@ -302,9 +268,9 @@ async def main() -> int:
     parser.add_argument("--keep-box", action="store_true", help="Keep the box after the run for inspection")
     args = parser.parse_args()
 
-    api_key = openai_api_key(args.env_file.expanduser())
+    api_key = openai_api_key()
     if not api_key:
-        print_openai_auth_help(args.env_file.expanduser())
+        print_openai_auth_help()
         raise SystemExit(1)
 
     runtime = rest_runtime_from_profile(args.profile)

--- a/examples/python/06_ai_agents/run_codex_in_box.py
+++ b/examples/python/06_ai_agents/run_codex_in_box.py
@@ -175,7 +175,8 @@ async def install_codex(box) -> None:
 async def run_codex(box, prompt: str, model: str) -> str:
     command = textwrap.dedent(
         f"""
-        export OPENAI_API_KEY="$BOXLITE_SECRET_OPENAI_API_KEY"
+        export OPENAI_API_KEY="${{BOXLITE_SECRET_OPENAI_API_KEY:-<BOXLITE_SECRET:openai_api_key>}}"
+        test -n "$OPENAI_API_KEY"
         export CODEX_HOME=/root/.codex-boxlite
         mkdir -p "$CODEX_HOME"
         printf '%s' "$OPENAI_API_KEY" | codex login --with-api-key >/dev/null

--- a/examples/python/06_ai_agents/run_codex_in_box.py
+++ b/examples/python/06_ai_agents/run_codex_in_box.py
@@ -143,9 +143,17 @@ async def drain(execution, *, stream: bool = False) -> tuple[str, str]:
     return "".join(stdout_chunks), "".join(stderr_chunks)
 
 
-async def run(box, command: str, args: list[str], timeout: int = 300, *, stream: bool = False) -> tuple[int, str, str]:
+async def run(
+    box,
+    command: str,
+    args: list[str],
+    timeout: int = 300,
+    *,
+    stream: bool = False,
+    env: list[tuple[str, str]] | None = None,
+) -> tuple[int, str, str]:
     print(f"$ {command} {' '.join(args)}", flush=True)
-    execution = await box.exec(command, args, None)
+    execution = await box.exec(command, args, env)
     stdout, stderr = await drain(execution, stream=stream)
     result = await asyncio.wait_for(execution.wait(), timeout=timeout)
     return result.exit_code, stdout, stderr
@@ -172,10 +180,12 @@ async def install_codex(box) -> None:
     print(f"Codex CLI: {stdout.strip()}")
 
 
-async def run_codex(box, prompt: str, model: str) -> str:
+async def run_codex(box, prompt: str, model: str, *, direct_api_key: str | None = None) -> str:
+    key_source = "direct env key" if direct_api_key else "BoxLite secret placeholder"
+    print(f"Running Codex CLI with {key_source}...", flush=True)
     command = textwrap.dedent(
         f"""
-        export OPENAI_API_KEY="${{BOXLITE_SECRET_OPENAI_API_KEY:-<BOXLITE_SECRET:openai_api_key>}}"
+        export OPENAI_API_KEY="${{OPENAI_API_KEY:-${{BOXLITE_SECRET_OPENAI_API_KEY:-<BOXLITE_SECRET:openai_api_key>}}}}"
         test -n "$OPENAI_API_KEY"
         export CODEX_HOME=/root/.codex-boxlite
         mkdir -p "$CODEX_HOME"
@@ -191,7 +201,8 @@ async def run_codex(box, prompt: str, model: str) -> str:
           </dev/null
         """
     ).strip()
-    exit_code, stdout, stderr = await run(box, "sh", ["-lc", command], timeout=600)
+    env = [("OPENAI_API_KEY", direct_api_key)] if direct_api_key else None
+    exit_code, stdout, stderr = await run(box, "sh", ["-lc", command], timeout=600, env=env)
     if exit_code != 0:
         raise RuntimeError(f"Codex CLI failed with exit code {exit_code}\nstdout={stdout}\nstderr={stderr}")
     return stdout.strip()
@@ -204,6 +215,11 @@ async def main() -> int:
     parser.add_argument("--model", default=DEFAULT_MODEL)
     parser.add_argument("--env-file", type=Path, default=DEFAULT_ENV_FILE)
     parser.add_argument("--profile", default=DEFAULT_PROFILE, help="Cloud REST profile from ~/.boxlite/credentials.toml")
+    parser.add_argument(
+        "--unsafe-direct-api-key",
+        action="store_true",
+        help="Pass the plaintext OpenAI API key into the box to verify Codex CLI itself; do not use for secret-passthrough validation.",
+    )
     parser.add_argument("--keep-box", action="store_true", help="Keep the box after the run for inspection")
     args = parser.parse_args()
 
@@ -231,7 +247,12 @@ async def main() -> int:
     try:
         print(f"Box: {box.id}")
         await install_codex(box)
-        answer = await run_codex(box, " ".join(args.prompt), args.model)
+        answer = await run_codex(
+            box,
+            " ".join(args.prompt),
+            args.model,
+            direct_api_key=api_key if args.unsafe_direct_api_key else None,
+        )
         print(answer)
         return 0
     finally:

--- a/examples/python/06_ai_agents/run_codex_in_box.py
+++ b/examples/python/06_ai_agents/run_codex_in_box.py
@@ -20,8 +20,10 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import getpass
 import json
 import os
+import sys
 import textwrap
 import urllib.request
 from pathlib import Path
@@ -44,6 +46,13 @@ CODE_SMOKE_PROMPT = (
     "Run `node /workspace/fib.js 10`; if stdout is not exactly 55, fix the file and rerun it. "
     "Do not finish until `node /workspace/fib.js 10` prints exactly 55."
 )
+
+
+def prompt_openai_api_key() -> str | None:
+    if not sys.stdin.isatty():
+        return None
+    value = getpass.getpass("OPENAI_API_KEY: ").strip()
+    return value or None
 
 
 def print_openai_auth_help() -> None:
@@ -270,8 +279,10 @@ async def main() -> int:
 
     api_key = openai_api_key()
     if not api_key:
-        print_openai_auth_help()
-        raise SystemExit(1)
+        api_key = prompt_openai_api_key()
+        if not api_key:
+            print_openai_auth_help()
+            raise SystemExit(1)
 
     runtime = rest_runtime_from_profile(args.profile)
     if args.unsafe_direct_api_key:

--- a/examples/python/06_ai_agents/run_codex_in_box.py
+++ b/examples/python/06_ai_agents/run_codex_in_box.py
@@ -37,13 +37,16 @@ except ModuleNotFoundError:  # pragma: no cover - Python 3.10 fallback
     import tomli as tomllib  # type: ignore[no-redef]
 
 
-DEFAULT_IMAGE = os.getenv("BOXLITE_CODEX_IMAGE", "node:20-bookworm-slim")
+DEFAULT_IMAGE = os.getenv("BOXLITE_CODEX_IMAGE", "ghcr.io/boxlite-ai/boxlite-agent-node:20260605-p0-r3")
 DEFAULT_MODEL = os.getenv("OPENAI_MODEL", "gpt-4.1-mini")
 DEFAULT_ENV_FILE = Path(os.getenv("BOXLITE_OPENAI_ENV_FILE", "~/.config/boxlite/e2e-openai.env")).expanduser()
 DEFAULT_PROFILE = os.getenv("BOXLITE_E2E_PROFILE") or os.getenv("BOXLITE_PROFILE") or "p1"
+DEFAULT_DIRECT_KEY = os.getenv("BOXLITE_CODEX_SECRET_PASSTHROUGH", "").lower() not in ("1", "true", "yes", "on")
 CODE_SMOKE_PROMPT = (
-    "Create /workspace/fib.js. It must read n from process.argv[2], compute fibonacci(n), "
-    "print only the number, then run `node /workspace/fib.js 10` and ensure it prints 55."
+    "Create /workspace/fib.js. The file must read n from process.argv[2], compute fibonacci(n), "
+    "and call console.log(String(result)) so stdout is exactly the number plus a newline. "
+    "Run `node /workspace/fib.js 10`; if stdout is not exactly 55, fix the file and rerun it. "
+    "Do not finish until `node /workspace/fib.js 10` prints exactly 55."
 )
 
 
@@ -66,6 +69,15 @@ def load_env_file(path: Path) -> dict[str, str]:
         if key:
             values[key] = value
     return values
+
+
+def print_openai_auth_help(env_file: Path) -> None:
+    print("ERROR: OPENAI_API_KEY not set")
+    print("Run: export OPENAI_API_KEY='sk-...'")
+    print(f"Or create {env_file}:")
+    print("  mkdir -p ~/.config/boxlite")
+    print(f"  printf 'export BOXLITE_E2E_OPENAI_API_KEY=\"sk-...\"\\n' > {env_file}")
+    print(f"  chmod 600 {env_file}")
 
 
 def openai_api_key(env_file: Path) -> str | None:
@@ -95,12 +107,25 @@ def discover_path_prefix(url: str, token: str) -> str:
 def rest_runtime_from_profile(profile_name: str):
     path = credentials_path()
     if not path.exists():
-        raise SystemExit(f"{path} is missing; configure a cloud profile first")
+        print(f"ERROR: {path} is missing")
+        print("Create a cloud REST profile first, for example:")
+        print("")
+        print("  mkdir -p ~/.boxlite")
+        print("  cat > ~/.boxlite/credentials.toml <<'EOF'")
+        print("  [profiles.p1]")
+        print('  url = "https://api.dev.boxlite.ai/api"')
+        print('  api_key = "<boxlite-api-key>"')
+        print('  auth_method = "api_key"')
+        print("  EOF")
+        raise SystemExit(1)
 
     data = tomllib.loads(path.read_text(encoding="utf-8"))
     profile = data.get("profiles", {}).get(profile_name)
     if not profile:
-        raise SystemExit(f"profile {profile_name!r} not found in {path}")
+        print(f"ERROR: profile {profile_name!r} not found in {path}")
+        print(f"Run: export BOXLITE_PROFILE='{profile_name}'")
+        print(f"Or pass: --profile {profile_name}")
+        raise SystemExit(1)
 
     url = os.getenv("BOXLITE_E2E_API_URL") or profile.get("url")
     token = (
@@ -110,7 +135,14 @@ def rest_runtime_from_profile(profile_name: str):
         or profile.get("access_token")
     )
     if not url or not token:
-        raise SystemExit(f"profile {profile_name!r} must include url and api_key/access_token")
+        print(f"ERROR: profile {profile_name!r} must include url and api_key/access_token")
+        print("For API-key auth, the profile should look like:")
+        print("")
+        print(f"  [profiles.{profile_name}]")
+        print('  url = "https://api.dev.boxlite.ai/api"')
+        print('  api_key = "<boxlite-api-key>"')
+        print('  auth_method = "api_key"')
+        raise SystemExit(1)
 
     explicit_prefix = os.getenv("BOXLITE_E2E_PREFIX")
     if explicit_prefix is not None:
@@ -219,7 +251,9 @@ async def verify_code_smoke(box) -> None:
         "sh",
         [
             "-lc",
-            "test -f /workspace/fib.js && node /workspace/fib.js 10",
+            "set -eu\n"
+            "test -f /workspace/fib.js\n"
+            "node /workspace/fib.js 10\n",
         ],
         timeout=60,
         stream=True,
@@ -227,7 +261,17 @@ async def verify_code_smoke(box) -> None:
     if exit_code != 0:
         raise RuntimeError(f"Codex code smoke verification failed\nstdout={stdout}\nstderr={stderr}")
     if stdout.strip() != "55":
-        raise RuntimeError(f"Codex code smoke printed {stdout.strip()!r}, expected '55'")
+        _, file_contents, _ = await run(
+            box,
+            "sh",
+            ["-lc", "cat /workspace/fib.js"],
+            timeout=30,
+            stream=True,
+        )
+        raise RuntimeError(
+            "Codex code smoke printed "
+            f"{stdout.strip()!r}, expected '55'\n/workspace/fib.js:\n{file_contents}"
+        )
     print("Verified: /workspace/fib.js prints 55", flush=True)
 
 
@@ -241,7 +285,14 @@ async def main() -> int:
     parser.add_argument(
         "--unsafe-direct-api-key",
         action="store_true",
-        help="Pass the plaintext OpenAI API key into the box to verify Codex CLI itself; do not use for secret-passthrough validation.",
+        default=DEFAULT_DIRECT_KEY,
+        help="Pass the plaintext OpenAI API key into the box to verify Codex CLI itself; this is the default until secret passthrough supports Codex.",
+    )
+    parser.add_argument(
+        "--secret-passthrough",
+        action="store_false",
+        dest="unsafe_direct_api_key",
+        help="Use the BoxLite secret placeholder instead of passing the plaintext key into the box.",
     )
     parser.add_argument(
         "--code-smoke",
@@ -253,9 +304,13 @@ async def main() -> int:
 
     api_key = openai_api_key(args.env_file.expanduser())
     if not api_key:
-        raise SystemExit(f"OPENAI_API_KEY is required on the host or in {args.env_file}")
+        print_openai_auth_help(args.env_file.expanduser())
+        raise SystemExit(1)
 
     runtime = rest_runtime_from_profile(args.profile)
+    if args.unsafe_direct_api_key:
+        print("WARNING: using plaintext OPENAI_API_KEY inside the box for this smoke test.", flush=True)
+        print("         Pass --secret-passthrough to test BoxLite secret substitution instead.", flush=True)
     box = await runtime.create(
         boxlite.BoxOptions(
             image=args.image,

--- a/examples/python/06_ai_agents/test_research_agent.py
+++ b/examples/python/06_ai_agents/test_research_agent.py
@@ -1,0 +1,93 @@
+import importlib.util
+import json
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+MODULE_PATH = Path(__file__).with_name("research_agent.py")
+spec = importlib.util.spec_from_file_location("research_agent", MODULE_PATH)
+research_agent = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules["research_agent"] = research_agent
+spec.loader.exec_module(research_agent)
+
+
+class ResearchAgentTest(unittest.TestCase):
+    def test_duckduckgo_lite_parser_extracts_results(self):
+        parser = research_agent.DuckDuckGoHTMLParser()
+        parser.feed(
+            """
+            <a rel="nofollow" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com" class='result-link'>
+              Example Result
+            </a>
+            <td class='result-snippet'>A useful result snippet.</td>
+            """
+        )
+
+        self.assertEqual(len(parser.results), 1)
+        self.assertEqual(parser.results[0].title, "Example Result")
+        self.assertEqual(parser.results[0].url, "https://example.com")
+        self.assertEqual(parser.results[0].snippet, "A useful result snippet.")
+
+    def test_fixture_search_and_prompt_include_citations(self):
+        fixture = Path(__file__).with_name("research_agent_fixture.json")
+        results = research_agent.search_from_fixture(str(fixture), limit=2)
+        prompt = research_agent.build_answer_prompt("Question?", results)
+
+        self.assertIn("Question?", prompt)
+        self.assertIn("[1] BoxLite AI agent examples", prompt)
+        self.assertIn("[2] Codex tool-use loop", prompt)
+
+    def test_openai_provider_uses_boxlite_secret_placeholder(self):
+        class FakeResponse:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return json.dumps({
+                    "choices": [
+                        {"message": {"content": "Answer from model with [1]."}}
+                    ]
+                }).encode()
+
+        captured = {}
+
+        def fake_urlopen(request, timeout):
+            captured["request"] = request
+            captured["timeout"] = timeout
+            return FakeResponse()
+
+        with mock.patch.dict(
+            os.environ,
+            {
+                "BOXLITE_SECRET_OPENAI_API_KEY": "<BOXLITE_SECRET:openai_api_key>",
+            },
+            clear=True,
+        ), mock.patch.object(research_agent.urllib.request, "urlopen", fake_urlopen):
+            answer = research_agent.ask_openai(
+                "Prompt",
+                model="gpt-test",
+                base_url="https://api.openai.com/v1",
+                timeout=7,
+            )
+
+        self.assertEqual(answer, "Answer from model with [1].")
+        request = captured["request"]
+        self.assertEqual(captured["timeout"], 7)
+        self.assertEqual(
+            request.headers["Authorization"],
+            "Bearer <BOXLITE_SECRET:openai_api_key>",
+        )
+        body = json.loads(request.data.decode())
+        self.assertEqual(body["model"], "gpt-test")
+        self.assertEqual(body["messages"][1]["content"], "Prompt")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test/e2e/cases/test_research_agent_example.py
+++ b/scripts/test/e2e/cases/test_research_agent_example.py
@@ -1,0 +1,319 @@
+"""Cloud/REST smoke coverage for the research-agent example.
+
+This proves the example can be copied into and executed inside a REST-backed
+box. The default test uses the deterministic echo provider. An optional OpenAI
+test uses BoxLite secret substitution so the real API key stays host-side.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import re
+import tomllib
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import boxlite
+import pytest
+
+from conftest import CRED_PATH, DEFAULT_PROFILE, drain
+
+
+REPO = Path(__file__).resolve().parents[4]
+RESEARCH_AGENT = REPO / "examples/python/06_ai_agents/research_agent.py"
+RESEARCH_FIXTURE = REPO / "examples/python/06_ai_agents/research_agent_fixture.json"
+DEFAULT_CLOUD_PYTHON_IMAGE = "ghcr.io/boxlite-ai/boxlite-agent-python:20260605-p0-r3"
+
+
+def _redact_sensitive(value: str, *secrets: str | None) -> str:
+    redacted = value
+    for secret in secrets:
+        if secret:
+            redacted = redacted.replace(secret, "<redacted-secret>")
+    return re.sub(r"sk-[A-Za-z0-9_-]+", "<redacted-openai-key>", redacted)
+
+
+def _supported_images() -> list[str]:
+    if not CRED_PATH.exists():
+        return []
+    try:
+        profile = tomllib.loads(CRED_PATH.read_text())["profiles"][DEFAULT_PROFILE]
+        url = (
+            f"{profile['url'].rstrip('/')}/v1/{profile.get('path_prefix') or ''}/boxes"
+            .replace("//boxes", "/boxes")
+        )
+        req = urllib.request.Request(
+            url,
+            method="POST",
+            headers={
+                "Authorization": f"Bearer {profile['api_key']}",
+                "Content-Type": "application/json",
+            },
+            data=json.dumps({
+                "image": "__research_agent_probe_not_supported__",
+                "cpus": 1,
+                "memory_mib": 256,
+            }).encode(),
+        )
+        urllib.request.urlopen(req, timeout=10).read()
+    except urllib.error.HTTPError as exc:
+        if exc.code != 400:
+            return []
+        body = exc.read().decode("utf-8", "replace")
+        match = re.search(r"Supported images:\s*(.+?)\s*(?:\"|$)", body)
+        if not match:
+            return []
+        return [item.strip() for item in match.group(1).split(",") if item.strip()]
+    except Exception:
+        return []
+    return []
+
+
+def _research_image(default_image: str) -> str:
+    explicit = os.environ.get("BOXLITE_E2E_RESEARCH_IMAGE")
+    if explicit:
+        return explicit
+    supported = _supported_images()
+    if DEFAULT_CLOUD_PYTHON_IMAGE in supported:
+        return DEFAULT_CLOUD_PYTHON_IMAGE
+    for image in supported:
+        if "python" in image:
+            return image
+    return default_image
+
+
+async def _create_research_box(rt, image, *, auto_remove=True):
+    box_image = _research_image(image)
+    box = await rt.create(boxlite.BoxOptions(image=box_image, auto_remove=auto_remove))
+    ex = await box.exec(
+        "sh",
+        ["-lc", "command -v python3 || command -v python"],
+        None,
+    )
+    out, err = await drain(ex)
+    result = await asyncio.wait_for(ex.wait(), timeout=30)
+    if result.exit_code != 0:
+        try:
+            await rt.remove(box.id, force=True)
+        except Exception:
+            pass
+        pytest.skip(f"box image {box_image!r} has no python interpreter: {err!r}")
+
+    await box.copy_in(str(RESEARCH_AGENT), "/root/research_agent.py")
+    await box.copy_in(str(RESEARCH_FIXTURE), "/root/research_agent_fixture.json")
+    return box, box_image, out.strip().splitlines()[0]
+
+
+async def _create_openai_research_box(rt, image, api_key):
+    box_image = _research_image(image)
+    box = await rt.create(
+        boxlite.BoxOptions(
+            image=box_image,
+            auto_remove=True,
+            network=boxlite.NetworkSpec(
+                mode="enabled",
+                allow_net=["api.openai.com"],
+            ),
+            secrets=[
+                boxlite.Secret(
+                    name="openai_api_key",
+                    value=api_key,
+                    hosts=["api.openai.com"],
+                )
+            ],
+        )
+    )
+    ex = await box.exec(
+        "sh",
+        ["-lc", "command -v python3 || command -v python"],
+        None,
+    )
+    out, err = await drain(ex)
+    result = await asyncio.wait_for(ex.wait(), timeout=30)
+    if result.exit_code != 0:
+        try:
+            await rt.remove(box.id, force=True)
+        except Exception:
+            pass
+        pytest.skip(f"box image {box_image!r} has no python interpreter: {err!r}")
+
+    await box.copy_in(str(RESEARCH_AGENT), "/root/research_agent.py")
+    await box.copy_in(str(RESEARCH_FIXTURE), "/root/research_agent_fixture.json")
+    return box, box_image, out.strip().splitlines()[0]
+
+
+async def _start_after_stop(box, timeout=90):
+    deadline = asyncio.get_running_loop().time() + timeout
+    last_error = None
+    while asyncio.get_running_loop().time() < deadline:
+        try:
+            await box.start()
+            return
+        except Exception as exc:
+            last_error = exc
+            if "State change in progress" not in str(exc):
+                raise
+            await asyncio.sleep(2)
+    raise AssertionError(f"box did not become startable after stop within {timeout}s: {last_error!r}")
+
+
+@pytest.mark.asyncio
+async def test_research_agent_example_runs_inside_rest_box(rt, image):
+    box, box_image, python_bin = await _create_research_box(rt, image)
+    try:
+        ex = await box.exec(
+            python_bin,
+            [
+                "/root/research_agent.py",
+                "--search-provider",
+                "fixture",
+                "--search-fixture",
+                "/root/research_agent_fixture.json",
+                "What can this agent do?",
+            ],
+            None,
+        )
+        out, err = await drain(ex)
+        result = await asyncio.wait_for(ex.wait(), timeout=60)
+
+        assert result.exit_code == 0, (
+            f"research_agent.py failed in REST box image={box_image}: "
+            f"stdout={out!r} stderr={err!r}"
+        )
+        assert "Echo provider summary for: What can this agent do?" in out
+        assert "BoxLite AI agent examples" in out
+        assert "Codex tool-use loop" in out
+    finally:
+        try:
+            await rt.remove(box.id, force=True)
+        except Exception:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_research_agent_worklog_persists_after_stop_and_rerun(rt, image):
+    """Agent work written inside the box must survive stop/start and rerun."""
+    box, box_image, python_bin = await _create_research_box(rt, image, auto_remove=False)
+    worklog = "/root/.agent/worklog.txt"
+    try:
+        first_ex = await box.exec(
+            "sh",
+            [
+                "-lc",
+                (
+                    "set -eu\n"
+                    "mkdir -p /root/.agent\n"
+                    f"{python_bin} /root/research_agent.py "
+                    "--search-provider fixture "
+                    "--search-fixture /root/research_agent_fixture.json "
+                    "'What can this agent do?' > /tmp/agent-answer.txt\n"
+                    "printf 'run=first\\n' > /root/.agent/worklog.txt\n"
+                    "cat /tmp/agent-answer.txt >> /root/.agent/worklog.txt\n"
+                ),
+            ],
+            None,
+        )
+        first_out, first_err = await drain(first_ex)
+        first_result = await asyncio.wait_for(first_ex.wait(), timeout=60)
+        assert first_result.exit_code == 0, (
+            f"first research-agent run failed in REST box image={box_image}: "
+            f"stdout={first_out!r} stderr={first_err!r}"
+        )
+
+        await box.stop()
+        await _start_after_stop(box)
+
+        second_ex = await box.exec(
+            "sh",
+            [
+                "-lc",
+                (
+                    "set -eu\n"
+                    f"test -f {worklog}\n"
+                    "grep -q 'run=first' /root/.agent/worklog.txt\n"
+                    "grep -q 'Echo provider summary for: What can this agent do?' /root/.agent/worklog.txt\n"
+                    "printf 'run=second\\n' >> /root/.agent/worklog.txt\n"
+                    "cat /root/.agent/worklog.txt\n"
+                ),
+            ],
+            None,
+        )
+        second_out, second_err = await drain(second_ex)
+        second_result = await asyncio.wait_for(second_ex.wait(), timeout=60)
+        assert second_result.exit_code == 0, (
+            f"agent worklog did not survive stop/start in REST box image={box_image}: "
+            f"stdout={second_out!r} stderr={second_err!r}"
+        )
+        assert "run=first" in second_out
+        assert "run=second" in second_out
+        assert "BoxLite AI agent examples" in second_out
+    finally:
+        try:
+            await rt.remove(box.id, force=True)
+        except Exception:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_research_agent_openai_provider_uses_boxlite_secret_in_rest_box(rt, image):
+    """Run the agent against a real LLM API without putting the key in the VM."""
+    api_key = os.environ.get("BOXLITE_E2E_OPENAI_API_KEY")
+    if not api_key:
+        pytest.fail("BOXLITE_E2E_OPENAI_API_KEY is required for the real LLM e2e")
+
+    box, box_image, python_bin = await _create_openai_research_box(rt, image, api_key)
+    try:
+        env_ex = await box.exec(
+            "sh",
+            ["-lc", "printenv BOXLITE_SECRET_OPENAI_API_KEY || true"],
+            None,
+        )
+        env_out, env_err = await drain(env_ex)
+        env_result = await asyncio.wait_for(env_ex.wait(), timeout=30)
+        assert env_result.exit_code == 0, (
+            f"failed to inspect secret placeholder env in REST box image={box_image}: "
+            f"stdout={_redact_sensitive(env_out, api_key)!r} "
+            f"stderr={_redact_sensitive(env_err, api_key)!r}"
+        )
+        assert env_out.strip() == "<BOXLITE_SECRET:openai_api_key>", (
+            "REST box did not receive the OpenAI secret placeholder env; "
+            f"stdout={_redact_sensitive(env_out, api_key)!r} "
+            f"stderr={_redact_sensitive(env_err, api_key)!r}"
+        )
+
+        ex = await box.exec(
+            python_bin,
+            [
+                "/root/research_agent.py",
+                "--search-provider",
+                "fixture",
+                "--search-fixture",
+                "/root/research_agent_fixture.json",
+                "--answer-provider",
+                "openai",
+                "--openai-model",
+                os.environ.get("BOXLITE_E2E_OPENAI_MODEL", "gpt-4.1-mini"),
+                "What can this agent do?",
+            ],
+            None,
+        )
+        out, err = await drain(ex)
+        result = await asyncio.wait_for(ex.wait(), timeout=120)
+
+        assert result.exit_code == 0, (
+            f"research_agent.py OpenAI mode failed in REST box image={box_image}: "
+            f"stdout={_redact_sensitive(out, api_key)!r} "
+            f"stderr={_redact_sensitive(err, api_key)!r}"
+        )
+        assert "BoxLite" in out or "sandbox" in out.lower()
+        assert api_key not in out
+        assert "sk-" not in out
+        assert "<BOXLITE_SECRET:openai_api_key>" not in out
+    finally:
+        try:
+            await rt.remove(box.id, force=True)
+        except Exception:
+            pass


### PR DESCRIPTION
Adds the research-agent example and e2e coverage.\n\nScope kept to the agent/example side:\n- research_agent.py supports fixture/DuckDuckGo search plus OpenAI-compatible answer provider\n- agent uses BOXLITE_SECRET_OPENAI_API_KEY placeholder rather than a real key in the box\n- unit coverage for prompt construction and placeholder Authorization header\n- REST-box e2e checks that the placeholder env exists before attempting the real LLM call\n\nDepends on #826 for cloud REST secret passthrough. Until #826 is deployed, the cloud e2e fails early because BOXLITE_SECRET_OPENAI_API_KEY is not injected into REST-created boxes.\n\nLocal BoxLite core/gvproxy verification has been run manually: the box saw only <BOXLITE_SECRET:openai_api_key>, gvproxy substituted the real key, and OpenAI returned a model answer.