### PR TITLE
fix(go): isolate exec output delivery to stop cross-execution HOL blocking

### DIFF
--- a/apps/runner/pkg/api/controllers/boxlite_exec_attach.go
+++ b/apps/runner/pkg/api/controllers/boxlite_exec_attach.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/boxlite-ai/runner/pkg/boxlite"
@@ -207,6 +208,11 @@ func runAttachLoop(parentCtx context.Context, conn *websocket.Conn, exec attachE
 	// across reattach cycles.
 	stdoutCh, stderrCh, unsubscribe := exec.Subscribe(attachSubscriberBuffer)
 
+	// Monotonic count of stream frames written to the client. The post-Done
+	// drain watches it to bound the wait by progress, not a fixed wall clock
+	// (see the drain block below).
+	var streamProgress atomic.Uint64
+
 	defer func() {
 		// Recover from any panic so we don't leak the connection.
 		if r := recover(); r != nil {
@@ -230,7 +236,7 @@ func runAttachLoop(parentCtx context.Context, conn *websocket.Conn, exec attachE
 	pumpWg.Add(1)
 	go func() {
 		defer pumpWg.Done()
-		pumpSubscriberChannel(loopCtx, conn, &writeMu, stdoutCh, chanStdout, fail)
+		pumpSubscriberChannel(loopCtx, conn, &writeMu, stdoutCh, chanStdout, &streamProgress, fail)
 	}()
 
 	// stderr pump (for non-TTY only — TTY merges at the kernel, so stderr
@@ -239,7 +245,7 @@ func runAttachLoop(parentCtx context.Context, conn *websocket.Conn, exec attachE
 		pumpWg.Add(1)
 		go func() {
 			defer pumpWg.Done()
-			pumpSubscriberChannel(loopCtx, conn, &writeMu, stderrCh, chanStderr, fail)
+			pumpSubscriberChannel(loopCtx, conn, &writeMu, stderrCh, chanStderr, &streamProgress, fail)
 		}()
 	}
 
@@ -278,21 +284,31 @@ func runAttachLoop(parentCtx context.Context, conn *websocket.Conn, exec attachE
 			pumpWg.Wait()
 			close(pumpsDone)
 		}()
-		drained := false
-		select {
-		case <-pumpsDone:
-			drained = true
-		case <-time.After(2 * time.Second):
-		}
 
+		// Bound the drain by progress, not a fixed wall clock. Done has
+		// fired, so the exit code is authoritative and any remaining output
+		// is already buffered in the subscriber channels — it should flush
+		// back-to-back. A pump still writing keeps bumping streamProgress, so
+		// we keep waiting and never send the exit frame ahead of a large tail
+		// that is still in flight; a pump whose guest pipe never EOFs (a
+		// SIGTERM→SIGKILL'd process) stops bumping it, so we give up after an
+		// idle window and send exit anyway.
+		drained := waitForStreamDrain(pumpsDone, &streamProgress, streamDrainIdleBound, streamDrainHardCap)
+
+		// Send the exit frame regardless of whether the pumps drained: a
+		// process killed by its exec timeout (SIGTERM→SIGKILL in the guest)
+		// can leave the guest's stdout/stderr pipes without a natural EOF, so
+		// the pumps may never finish. Gating the exit frame on drain (the
+		// old behaviour) then dropped the frame entirely on the drain
+		// timeout, hanging the client's wait() forever.
+		_ = writeJSONFrame(conn, &writeMu, map[string]any{
+			"type":      "exit",
+			"exit_code": exec.ExitCodeValue(),
+		})
 		if drained {
-			_ = writeJSONFrame(conn, &writeMu, map[string]any{
-				"type":      "exit",
-				"exit_code": exec.ExitCodeValue(),
-			})
 			closeWS(websocket.CloseNormalClosure, "")
 		} else {
-			closeWS(websocket.CloseInternalServerErr, "pump drain timed out")
+			closeWS(websocket.CloseNormalClosure, "exit sent; output pumps did not drain")
 		}
 	}
 
@@ -310,11 +326,53 @@ func runAttachLoop(parentCtx context.Context, conn *websocket.Conn, exec attachE
 // starts dropping chunks for a slow consumer.
 const attachSubscriberBuffer = 256
 
+// streamDrainIdleBound is how long the post-Done drain tolerates no new
+// stream frame before treating the pipe as stuck and sending exit. The drain
+// starts only after Done, so buffered output flushes back-to-back; a full
+// window with no progress means a guest pipe that will never EOF (a
+// signal-killed process). Large enough to absorb scheduler/transport jitter,
+// small enough that a timeout-killed exec reports promptly.
+const streamDrainIdleBound = 300 * time.Millisecond
+
+// streamDrainHardCap backstops a pipe that never EOFs yet keeps trickling a
+// frame within every idle window forever. Generous so it never clips a
+// genuine high-throughput tail.
+const streamDrainHardCap = 30 * time.Second
+
+// waitForStreamDrain blocks until the stream pumps finish (clean drain), the
+// stream goes idle (no progress within idleBound — a stuck never-EOF pipe), or
+// hardCap elapses (backstop for a pipe that trickles forever). Returns true
+// only when the pumps fully drained. Bounding by progress rather than a fixed
+// wall clock keeps a still-delivering tail from being cut off ahead of the
+// exit frame.
+func waitForStreamDrain(pumpsDone <-chan struct{}, progress *atomic.Uint64, idleBound, hardCap time.Duration) bool {
+	idle := time.NewTicker(idleBound)
+	defer idle.Stop()
+	cap := time.NewTimer(hardCap)
+	defer cap.Stop()
+
+	lastProgress := progress.Load()
+	for {
+		select {
+		case <-pumpsDone:
+			return true
+		case <-cap.C:
+			return false
+		case <-idle.C:
+			now := progress.Load()
+			if now == lastProgress {
+				return false
+			}
+			lastProgress = now
+		}
+	}
+}
+
 // pumpSubscriberChannel forwards chunks from a broadcaster subscriber channel
 // to the WebSocket, prefixing each with the channel byte. Exits cleanly on
 // ctx cancellation, channel close (broadcaster ended / unsubscribed), or write
 // error.
-func pumpSubscriberChannel(ctx context.Context, conn *websocket.Conn, writeMu *sync.Mutex, ch <-chan []byte, channel byte, fail func(error)) {
+func pumpSubscriberChannel(ctx context.Context, conn *websocket.Conn, writeMu *sync.Mutex, ch <-chan []byte, channel byte, progress *atomic.Uint64, fail func(error)) {
 	for {
 		select {
 		case <-ctx.Done():
@@ -330,6 +388,10 @@ func pumpSubscriberChannel(ctx context.Context, conn *websocket.Conn, writeMu *s
 				fail(fmt.Errorf("write %s frame: %w", channelName(channel), werr))
 				return
 			}
+			// Record forward progress so the post-Done drain can tell a
+			// still-delivering stream (keep waiting) from a stuck never-EOF
+			// pipe (send exit anyway).
+			progress.Add(1)
 		}
 	}
 }

--- a/apps/runner/pkg/api/controllers/boxlite_exec_attach_test.go
+++ b/apps/runner/pkg/api/controllers/boxlite_exec_attach_test.go
@@ -664,3 +664,87 @@ func TestBoxliteExecAttach_NotFound(t *testing.T) {
 		t.Fatalf("expected 404, got %v err=%v", resp, err)
 	}
 }
+
+// TestWaitForStreamDrain pins the post-Done drain semantics: it must keep
+// waiting while the stream is still delivering (so the exit frame never jumps
+// ahead of a large in-flight tail), give up promptly when a never-EOF pipe
+// goes idle, and fall back to a hard cap if a pipe trickles forever.
+func TestWaitForStreamDrain(t *testing.T) {
+	t.Run("waits for a still-delivering stream then reports drained", func(t *testing.T) {
+		var progress atomic.Uint64
+		pumpsDone := make(chan struct{})
+		// Deliver steadily for ~2.5s — past any 2s-style fixed cap — with
+		// each gap (50ms) under idleBound (100ms) so it never looks idle,
+		// then signal the pumps finished. The old fixed 2s cap would return
+		// drained=false here (cut the tail off); the idle bound waits it out.
+		go func() {
+			for i := 0; i < 50; i++ {
+				time.Sleep(50 * time.Millisecond)
+				progress.Add(1)
+			}
+			close(pumpsDone)
+		}()
+
+		start := time.Now()
+		drained := waitForStreamDrain(pumpsDone, &progress, 100*time.Millisecond, 30*time.Second)
+		elapsed := time.Since(start)
+
+		if !drained {
+			t.Fatal("expected drained=true: a stream still making progress must " +
+				"not be cut off before its pumps finish")
+		}
+		if elapsed < 2400*time.Millisecond {
+			t.Fatalf("returned after %v: gave up before the stream finished "+
+				"delivering (a fixed 2s cap would do this)", elapsed)
+		}
+	})
+
+	t.Run("gives up after one idle window on a stuck pipe", func(t *testing.T) {
+		var progress atomic.Uint64 // never bumped: a never-EOF pipe
+		pumpsDone := make(chan struct{})
+
+		start := time.Now()
+		drained := waitForStreamDrain(pumpsDone, &progress, 100*time.Millisecond, 10*time.Second)
+		elapsed := time.Since(start)
+
+		if drained {
+			t.Fatal("expected drained=false: a stuck pipe never finishes")
+		}
+		if elapsed > 2*time.Second {
+			t.Fatalf("took %v to give up on an idle stream; should release "+
+				"within ~idleBound so exit reports promptly", elapsed)
+		}
+	})
+
+	t.Run("falls back to hard cap when a pipe trickles forever", func(t *testing.T) {
+		var progress atomic.Uint64
+		pumpsDone := make(chan struct{})
+		stop := make(chan struct{})
+		defer close(stop)
+		// Bump within every idle window forever so the idle branch never
+		// fires; only the hard cap can break the wait.
+		go func() {
+			tick := time.NewTicker(20 * time.Millisecond)
+			defer tick.Stop()
+			for {
+				select {
+				case <-stop:
+					return
+				case <-tick.C:
+					progress.Add(1)
+				}
+			}
+		}()
+
+		start := time.Now()
+		drained := waitForStreamDrain(pumpsDone, &progress, 100*time.Millisecond, 300*time.Millisecond)
+		elapsed := time.Since(start)
+
+		if drained {
+			t.Fatal("expected drained=false: pumps never finished")
+		}
+		if elapsed < 250*time.Millisecond || elapsed > 1500*time.Millisecond {
+			t.Fatalf("expected release near the 300ms hard cap, got %v", elapsed)
+		}
+	})
+}

--- a/apps/runner/pkg/api/controllers/boxlite_exec_attach_test.go
+++ b/apps/runner/pkg/api/controllers/boxlite_exec_attach_test.go
@@ -714,6 +714,10 @@ func TestWaitForStreamDrain(t *testing.T) {
 			t.Fatalf("took %v to give up on an idle stream; should release "+
 				"within ~idleBound so exit reports promptly", elapsed)
 		}
+		if elapsed < 80*time.Millisecond {
+			t.Fatalf("gave up after only %v; expected it to wait ~one idle "+
+				"window (100ms) before declaring the stream stuck", elapsed)
+		}
 	})
 
 	t.Run("falls back to hard cap when a pipe trickles forever", func(t *testing.T) {

--- a/apps/runner/pkg/api/controllers/exec_attach_drain_matrix_test.go
+++ b/apps/runner/pkg/api/controllers/exec_attach_drain_matrix_test.go
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+package controllers
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// drainResult is what attachDrainOutcome observed driving one /attach session.
+type drainResult struct {
+	exitSeen    bool
+	stdoutBytes int
+	stderrBytes int
+	trailing    int // stream bytes that arrived AFTER the exit frame (ordering)
+}
+
+// attachDrainOutcome drives the real BoxliteExecAttach handler over a websocket
+// with the given stub producer, then reports what the client observed. producer
+// performs the stream writes, EOFs, and fires Done. tty selects TTY mode (the
+// handler then runs only the stdout pump). Reads stop once the exit frame and
+// any trailing frames are seen, or after a hang deadline.
+func attachDrainOutcome(t *testing.T, tty bool, exitCode int, producer func(s *stubAttachExec)) drainResult {
+	t.Helper()
+	const stdoutByte, stderrByte = 0x01, 0x02
+
+	stub := newStubAttachExec()
+	stub.exitCode = exitCode
+	stub.tty = tty
+	cleanup := withStubExec(t, "exec-matrix", stub)
+	defer cleanup()
+	srv := newAttachServer(t)
+	defer srv.Close()
+	conn, _, err := dialAttach(t, srv, "exec-matrix")
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	go producer(stub)
+
+	var r drainResult
+	seenExit := false
+	count := func(payload []byte) {
+		if len(payload) < 1 {
+			return
+		}
+		n := len(payload) - 1
+		switch payload[0] {
+		case stdoutByte:
+			r.stdoutBytes += n
+		case stderrByte:
+			r.stderrBytes += n
+		}
+		if seenExit {
+			r.trailing += n
+		}
+	}
+
+	for {
+		_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+		mt, payload, err := conn.ReadMessage()
+		if err != nil {
+			return r // deadline/close without exit => HANG (exitSeen stays false)
+		}
+		switch mt {
+		case websocket.BinaryMessage:
+			count(payload)
+		case websocket.TextMessage:
+			var ev map[string]any
+			if json.Unmarshal(payload, &ev) == nil && ev["type"] == "exit" {
+				r.exitSeen = true
+				seenExit = true
+				// Drain any trailing frames briefly to catch ordering bugs.
+				_ = conn.SetReadDeadline(time.Now().Add(400 * time.Millisecond))
+				for {
+					mt2, p2, e2 := conn.ReadMessage()
+					if e2 != nil {
+						return r
+					}
+					if mt2 == websocket.BinaryMessage {
+						count(p2)
+					}
+				}
+			}
+		}
+	}
+}
+
+// TestAttachDrainMatrix locks down PR #812's runner-side drain across the
+// (output x stream-termination) matrix: clean exits flush all output with the
+// exit frame strictly last; a SIGKILLed never-EOF pipe gives up after the idle
+// window and still sends exit instead of hanging.
+func TestAttachDrainMatrix(t *testing.T) {
+	big := strings.Repeat("a", 64*1024) // 16 chunks < 256 channel buffer: lossless
+
+	cases := []struct {
+		name       string
+		tty        bool
+		wantStdout int
+		wantStderr int
+		producer   func(s *stubAttachExec)
+	}{
+		{"clean-none", false, 0, 0, func(s *stubAttachExec) {
+			s.stdoutW.Close()
+			close(s.done)
+		}},
+		{"clean-short", false, 2, 0, func(s *stubAttachExec) {
+			s.stdoutW.Write([]byte("hi"))
+			s.stdoutW.Close()
+			close(s.done)
+		}},
+		{"clean-long-64k", false, len(big), 0, func(s *stubAttachExec) {
+			s.stdoutW.Write([]byte(big))
+			s.stdoutW.Close()
+			close(s.done)
+		}},
+		{"stderr-channel", false, 3, 7, func(s *stubAttachExec) {
+			s.stdoutW.Write([]byte("OUT"))
+			s.stderrW.Write([]byte("ERRLINE"))
+			s.stdoutW.Close()
+			s.stderrW.Close()
+			close(s.done)
+		}},
+		{"tty-merged", true, 9, 0, func(s *stubAttachExec) {
+			s.stdoutW.Write([]byte("hello-tty"))
+			s.stdoutW.Close()
+			s.stderrW.Close()
+			close(s.done)
+		}},
+		{"stuck-never-eof", false, 2, 0, func(s *stubAttachExec) {
+			// SIGKILLed guest: exit is known (Done) but stdout never EOFs.
+			s.stdoutW.Write([]byte("hi"))
+			close(s.done)
+			// deliberately never close stdoutW
+		}},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			r := attachDrainOutcome(t, c.tty, 7, c.producer)
+			if !r.exitSeen {
+				t.Fatalf("HANG: no exit frame within deadline (%s)", c.name)
+			}
+			if r.trailing != 0 {
+				t.Fatalf("ORDERING: %d stream bytes arrived AFTER the exit frame", r.trailing)
+			}
+			if r.stdoutBytes != c.wantStdout {
+				t.Fatalf("stdout: got %d want %d", r.stdoutBytes, c.wantStdout)
+			}
+			if r.stderrBytes != c.wantStderr {
+				t.Fatalf("stderr: got %d want %d", r.stderrBytes, c.wantStderr)
+			}
+		})
+	}
+}

--- a/apps/runner/pkg/boxlite/stream_drop_test.go
+++ b/apps/runner/pkg/boxlite/stream_drop_test.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+package boxlite
+
+import "testing"
+
+// TestStreamBusDropsOnSlowSubscriber locks down the per-subscriber back-pressure
+// drop: when a subscriber's channel is full (a stalled /attach client), the
+// non-blocking fan-out drops the chunk and accounts it in Dropped() rather than
+// blocking the producer or every other subscriber. This is the path behind the
+// "slow consumer loses bytes" behavior; the test makes it explicit and counted.
+func TestStreamBusDropsOnSlowSubscriber(t *testing.T) {
+	bus := newStreamBus(1 << 20) // large backlog cap; not under test here
+	const chBuf = 2
+	sub, cancel := bus.Subscribe(chBuf)
+	defer cancel()
+
+	// Never read from sub.Chan(): the subscriber is stalled.
+	const chunk = "0123456789" // 10 bytes
+	const writes = 10
+	for i := 0; i < writes; i++ {
+		if _, err := bus.Write([]byte(chunk)); err != nil {
+			t.Fatalf("Write %d: %v", i, err)
+		}
+	}
+
+	// The first chBuf chunks buffer in the channel; every later chunk is
+	// dropped and counted. The producer must never block.
+	wantDropped := uint64((writes - chBuf) * len(chunk))
+	if got := sub.Dropped(); got != wantDropped {
+		t.Fatalf("Dropped() = %d, want %d (buffered %d chunks, dropped the rest)",
+			got, wantDropped, chBuf)
+	}
+}

--- a/sdks/go/abandon_async_test.go
+++ b/sdks/go/abandon_async_test.go
@@ -164,7 +164,7 @@ func TestDrainAndDelete_RespondsToCloseSignal(t *testing.T) {
 // dispatch directly and verifies the handle is deleted afterwards.
 
 func TestExecutionStreamState_HandleDeletedOnExit(t *testing.T) {
-	state := newExecutionStreamState(ExecutionOptions{})
+	state := newExecutionStreamState(ExecutionOptions{}, nil)
 	streamHandle := cgo.NewHandle(state)
 
 	// Synthesize the C-side exit dispatch by calling the Go body of

--- a/sdks/go/exec.go
+++ b/sdks/go/exec.go
@@ -69,6 +69,14 @@ type ExecutionOptions struct {
 	// means no timeout (the C side treats `timeout_secs <= 0` as
 	// unbounded — see `sdks/c/src/exec/command.rs`).
 	Timeout time.Duration
+	// StreamStallTimeout auto-kills the execution if back-pressure has fully
+	// stalled — i.e. there is output buffered but the caller's Stdout/Stderr
+	// sink has accepted nothing for this long. It guards against a permanently
+	// blocked/abandoned sink leaving the producer suspended (and the box's
+	// resources held) forever. A sink that keeps making progress, however
+	// slowly, is never killed; an execution that simply produces no output is
+	// never killed (nothing is buffered). Zero disables the guard.
+	StreamStallTimeout time.Duration
 }
 
 // executionStreamState holds the user-provided sinks for streaming output
@@ -307,6 +315,43 @@ func (s *executionStreamState) closeDrained() {
 	s.drainedOnce.Do(func() { close(s.drained) })
 }
 
+// stallWatchdog auto-kills (via the supplied closure) an execution whose
+// back-pressure has fully stalled: output is buffered (queuedBytes > 0) but the
+// caller's sink has delivered nothing — progress has not advanced — for the
+// whole timeout. Resets on any progress, so a slow-but-advancing sink is never
+// killed; ignores quiet executions, which buffer nothing. Exits when the stream
+// drains (clean end) or after it has fired the kill.
+func (s *executionStreamState) stallWatchdog(timeout time.Duration, kill func()) {
+	interval := timeout / 4
+	if interval < 50*time.Millisecond {
+		interval = 50 * time.Millisecond
+	}
+	t := time.NewTicker(interval)
+	defer t.Stop()
+
+	lastProgress := s.progress.Load()
+	lastAdvance := time.Now()
+	for {
+		select {
+		case <-s.drained:
+			return
+		case <-t.C:
+			if now := s.progress.Load(); now != lastProgress {
+				lastProgress = now
+				lastAdvance = time.Now()
+				continue
+			}
+			s.qmu.Lock()
+			pending := s.queuedBytes
+			s.qmu.Unlock()
+			if pending > 0 && time.Since(lastAdvance) >= timeout {
+				kill()
+				return
+			}
+		}
+	}
+}
+
 // Execution is a handle to a running command.
 type Execution struct {
 	handle      *C.CExecutionHandle
@@ -427,6 +472,12 @@ func (b *Box) StartExecution(_ context.Context, name string, args []string, opts
 		closing:     b.runtime.closing,
 	}
 	execution.Stdin = &executionStdin{execution: execution}
+
+	if cfg.StreamStallTimeout > 0 {
+		go state.stallWatchdog(cfg.StreamStallTimeout, func() {
+			_ = execution.Kill(context.Background())
+		})
+	}
 	return execution, nil
 }
 

--- a/sdks/go/exec.go
+++ b/sdks/go/exec.go
@@ -127,7 +127,26 @@ type executionStreamState struct {
 	exited      bool // on_exit seen: flush the queue, then close drained
 	stopped     bool // execution released/closed: stop the writer
 	drainedOnce sync.Once
+
+	// Bounded-queue back-pressure. queuedBytes is the bytes buffered but not
+	// yet written to the caller's sink. When it crosses the high-water mark the
+	// writer is falling behind, so we pause the C-side pump (which fills the
+	// bounded upstream channel and ultimately blocks the guest process's
+	// write()); we resume once it drains below the low-water mark. `pause` calls
+	// boxlite_execution_set_stream_paused under qmu — Close sets `stopped` under
+	// qmu before freeing the handle, so a pause call can never use it post-free.
+	queuedBytes int
+	paused      bool
+	pause       func(bool)
 }
+
+const (
+	// streamQueueHighWater: buffered bytes at which the writer is deemed behind
+	// and the producer is paused. streamQueueLowWater: resume threshold. The gap
+	// is hysteresis so a steady stream doesn't thrash pause/resume.
+	streamQueueHighWater = 4 << 20 // 4 MiB
+	streamQueueLowWater  = 1 << 20 // 1 MiB
+)
 
 // streamChunk is one ordered unit of stream output queued for async delivery.
 type streamChunk struct {
@@ -135,7 +154,10 @@ type streamChunk struct {
 	data   []byte
 }
 
-func newExecutionStreamState(opts ExecutionOptions) *executionStreamState {
+// newExecutionStreamState builds the stream state. setPaused, when non-nil, is
+// the raw C call that pauses/resumes the execution's pumps; it is wrapped so it
+// only runs while the handle is alive (guarded by qmu against Close's free).
+func newExecutionStreamState(opts ExecutionOptions, setPaused func(bool)) *executionStreamState {
 	s := &executionStreamState{
 		stdout:   opts.Stdout,
 		stderr:   opts.Stderr,
@@ -144,6 +166,18 @@ func newExecutionStreamState(opts ExecutionOptions) *executionStreamState {
 		drained:  make(chan struct{}),
 	}
 	s.qcond = sync.NewCond(&s.qmu)
+	if setPaused != nil {
+		s.pause = func(p bool) {
+			// Call the C FFI while holding qmu and only when not stopped.
+			// markReleased sets `stopped` under qmu before Close frees the
+			// handle, so this can never touch a freed handle.
+			s.qmu.Lock()
+			if !s.stopped {
+				setPaused(p)
+			}
+			s.qmu.Unlock()
+		}
+	}
 	go s.deliverLoop()
 	return s
 }
@@ -160,12 +194,21 @@ func (s *executionStreamState) enqueue(c streamChunk) {
 	if s.released.Load() {
 		return
 	}
+	doPause := false
 	s.qmu.Lock()
 	if !s.exited && !s.stopped {
 		s.queue = append(s.queue, c)
+		s.queuedBytes += len(c.data)
+		if s.queuedBytes > streamQueueHighWater && !s.paused {
+			s.paused = true
+			doPause = true
+		}
 		s.qcond.Signal()
 	}
 	s.qmu.Unlock()
+	if doPause && s.pause != nil {
+		s.pause(true)
+	}
 }
 
 // deliverExit marks end-of-stream. The writer goroutine flushes whatever is
@@ -206,8 +249,24 @@ func (s *executionStreamState) deliverLoop() {
 		done := s.exited || s.stopped
 		s.qmu.Unlock()
 
+		batch := 0
 		for _, c := range q {
 			s.writeChunk(c)
+			batch += len(c.data)
+		}
+		// Account the drained bytes; resume the producer once we're back under
+		// the low-water mark (only while live — on exit/stop the pump is torn
+		// down anyway, and resuming there could race the handle free).
+		doResume := false
+		s.qmu.Lock()
+		s.queuedBytes -= batch
+		if s.paused && !done && s.queuedBytes < streamQueueLowWater {
+			s.paused = false
+			doResume = true
+		}
+		s.qmu.Unlock()
+		if doResume && s.pause != nil {
+			s.pause(false)
 		}
 		if done {
 			// No more chunks can arrive once exited/stopped is set (deliver*
@@ -341,7 +400,14 @@ func (b *Box) StartExecution(_ context.Context, name string, args []string, opts
 		return nil, freeError(&cerr)
 	}
 
-	state := newExecutionStreamState(cfg)
+	// The pause setter throttles this execution's guest producer when the
+	// delivery queue fills (end-to-end back-pressure). `handle` is valid for
+	// the closure's lifetime: it is only invoked while the stream state is not
+	// stopped, and Close frees the handle only after marking it stopped.
+	state := newExecutionStreamState(cfg, func(paused bool) {
+		var cerr C.CBoxliteError
+		C.boxlite_execution_set_stream_paused(handle, boolToCInt(paused), &cerr)
+	})
 	streamHandle := cgo.NewHandle(state)
 
 	if err := registerExecutionCallbacks(handle, streamHandle); err != nil {

--- a/sdks/go/exec.go
+++ b/sdks/go/exec.go
@@ -292,6 +292,13 @@ func (s *executionStreamState) deliverLoop() {
 	}
 }
 
+// writeChunk hands one chunk to the caller's sink. Write errors are
+// deliberately not propagated: this runs on the async delivery goroutine with
+// no caller to return them to, and a transient sink hiccup should not tear down
+// a healthy execution. A sink that fails permanently simply stops accepting
+// bytes, which leaves output buffered and is exactly the condition
+// StreamStallTimeout watches for and kills — so a wedged sink is still handled,
+// without making every transient write error fatal.
 func (s *executionStreamState) writeChunk(c streamChunk) {
 	if c.stderr {
 		if s.onStderr != nil {
@@ -330,21 +337,32 @@ func (s *executionStreamState) stallWatchdog(timeout time.Duration, kill func())
 	defer t.Stop()
 
 	lastProgress := s.progress.Load()
-	lastAdvance := time.Now()
+	var stalledSince time.Time // zero = not currently stalled
 	for {
 		select {
 		case <-s.drained:
 			return
 		case <-t.C:
-			if now := s.progress.Load(); now != lastProgress {
-				lastProgress = now
-				lastAdvance = time.Now()
-				continue
-			}
+			now := s.progress.Load()
+			progressed := now != lastProgress
+			lastProgress = now
+
 			s.qmu.Lock()
 			pending := s.queuedBytes
 			s.qmu.Unlock()
-			if pending > 0 && time.Since(lastAdvance) >= timeout {
+
+			// A stall is "output is buffered but nothing got delivered this
+			// interval". Time it from when the stall began (not from exec start
+			// or last progress), so a sink that goes quiet then stalls still
+			// gets the full timeout, and a quiet exec that buffers nothing is
+			// never killed.
+			if progressed || pending == 0 {
+				stalledSince = time.Time{}
+				continue
+			}
+			if stalledSince.IsZero() {
+				stalledSince = time.Now()
+			} else if time.Since(stalledSince) >= timeout {
 				kill()
 				return
 			}

--- a/sdks/go/exec.go
+++ b/sdks/go/exec.go
@@ -103,6 +103,15 @@ type executionStreamState struct {
 	// buffer. The fold happens at the SDK boundary; the C-side Wait
 	// task stays decoupled from streams.
 	drained chan struct{}
+
+	// progress is a monotonic count of Stdout/Stderr callbacks delivered.
+	// Wait's drain barrier watches it: a SIGKILLed guest can leave a pipe
+	// without EOF, so the C exit pump never fires on_exit and `drained`
+	// never closes — bounding the barrier by progress lets Wait return
+	// (the stream has stalled) instead of hanging forever. While output is
+	// still flowing progress keeps advancing, so a large tail is never cut
+	// off early.
+	progress atomic.Uint64
 }
 
 func newExecutionStreamState(opts ExecutionOptions) *executionStreamState {
@@ -129,6 +138,7 @@ func (s *executionStreamState) deliverStdout(data []byte) {
 	if stdout != nil {
 		_, _ = stdout.Write(data)
 	}
+	s.progress.Add(1)
 }
 
 func (s *executionStreamState) deliverStderr(data []byte) {
@@ -145,6 +155,7 @@ func (s *executionStreamState) deliverStderr(data []byte) {
 	if stderr != nil {
 		_, _ = stderr.Write(data)
 	}
+	s.progress.Add(1)
 }
 
 func (s *executionStreamState) deliverExit(_ int) {
@@ -341,19 +352,69 @@ func (e *Execution) Wait(ctx context.Context) (int, error) {
 		return 0, ErrRuntimeClosed
 	}
 
-	// Drain barrier: wait for stream pumps to flush before returning,
-	// so the caller's stdout/stderr Writers see every chunk the exec
-	// produced. Non-cancelable by ctx — only runtime shutdown breaks
-	// it. Preserves the exit code from the wait result; overwrites
-	// err only if the wait itself had none.
-	select {
-	case <-e.streamState.drained:
-	case <-e.closing:
-		if err == nil {
-			err = ErrRuntimeClosed
-		}
+	// Drain barrier: wait for stream pumps to flush before returning, so
+	// the caller's stdout/stderr Writers see every chunk the exec produced.
+	// Bounded by stream *progress*, not a fixed wall clock: normally
+	// `drained` closes once C's exit pump (which keeps Exit strictly last)
+	// fires on_exit. But a SIGKILLed guest can leave a pipe without EOF, so
+	// the exit pump never fires and `drained` never closes — keep waiting
+	// while output is still arriving (progress advances; a large tail is
+	// never cut off), and give up once the stream goes idle. Non-cancelable
+	// by ctx (os/exec parity); only runtime shutdown, an idle/stalled
+	// stream, or the hard cap breaks it. Preserves the exit code; overwrites
+	// err only if the wait had none.
+	if closed := waitForStreamDrain(
+		e.streamState.drained, e.closing, &e.streamState.progress,
+		streamDrainIdleBound, streamDrainHardCap,
+	); closed && err == nil {
+		err = ErrRuntimeClosed
 	}
 	return code, err
+}
+
+// streamDrainIdleBound is how long Wait's drain barrier tolerates no new
+// Stdout/Stderr callback before treating the stream as stalled and
+// returning. The drain runs only after the exit code is in hand, so any
+// remaining output is buffered and arrives back-to-back; a full window with
+// no progress means a guest pipe that will never EOF (a signal-killed
+// process). Large enough to absorb scheduler/transport jitter, small enough
+// that a timeout-killed exec's Wait returns promptly.
+const streamDrainIdleBound = 300 * time.Millisecond
+
+// streamDrainHardCap backstops a pipe that never EOFs yet keeps trickling a
+// chunk within every idle window forever. Generous so it never clips a
+// genuine high-throughput tail.
+const streamDrainHardCap = 30 * time.Second
+
+// waitForStreamDrain blocks until the stream callbacks have flushed
+// (`drained` closes), the runtime is closing, the stream goes idle (no
+// progress within idleBound — a stuck never-EOF pipe), or hardCap elapses.
+// Returns true only when it ended because the runtime is closing, so the
+// caller can surface ErrRuntimeClosed. Bounding by progress rather than a
+// fixed wall clock keeps a still-delivering tail from being cut off.
+func waitForStreamDrain(drained, closing <-chan struct{}, progress *atomic.Uint64, idleBound, hardCap time.Duration) bool {
+	idle := time.NewTicker(idleBound)
+	defer idle.Stop()
+	cap := time.NewTimer(hardCap)
+	defer cap.Stop()
+
+	last := progress.Load()
+	for {
+		select {
+		case <-drained:
+			return false
+		case <-closing:
+			return true
+		case <-cap.C:
+			return false
+		case <-idle.C:
+			now := progress.Load()
+			if now == last {
+				return false
+			}
+			last = now
+		}
+	}
 }
 
 // Kill terminates the running command.

--- a/sdks/go/exec.go
+++ b/sdks/go/exec.go
@@ -85,7 +85,6 @@ type ExecutionOptions struct {
 // Memory overhead is bounded: each execution adds one map entry plus the
 // state struct (a few writers, two atomics, and a mutex).
 type executionStreamState struct {
-	mu       sync.Mutex
 	stdout   io.Writer
 	stderr   io.Writer
 	onStdout func([]byte)
@@ -112,59 +111,141 @@ type executionStreamState struct {
 	// still flowing progress keeps advancing, so a large tail is never cut
 	// off early.
 	progress atomic.Uint64
+
+	// Stream output is delivered to the caller's sinks by a dedicated
+	// per-execution goroutine (deliverLoop), NOT inline on the shared
+	// per-Runtime drain goroutine. deliverStdout/deliverStderr are invoked on
+	// that single drain goroutine (runtime.go drainLoop -> C dispatch); writing
+	// to a caller-supplied Writer inline there lets one execution's slow or
+	// blocking sink wedge the drain goroutine and stall delivery — including
+	// Wait completions — for EVERY execution on the same Runtime
+	// (head-of-line blocking). Enqueue is non-blocking; the writer goroutine
+	// absorbs sink back-pressure in isolation.
+	qmu         sync.Mutex
+	qcond       *sync.Cond
+	queue       []streamChunk
+	exited      bool // on_exit seen: flush the queue, then close drained
+	stopped     bool // execution released/closed: stop the writer
+	drainedOnce sync.Once
+}
+
+// streamChunk is one ordered unit of stream output queued for async delivery.
+type streamChunk struct {
+	stderr bool
+	data   []byte
 }
 
 func newExecutionStreamState(opts ExecutionOptions) *executionStreamState {
-	return &executionStreamState{
+	s := &executionStreamState{
 		stdout:   opts.Stdout,
 		stderr:   opts.Stderr,
 		onStdout: opts.OnStdout,
 		onStderr: opts.OnStderr,
 		drained:  make(chan struct{}),
 	}
+	s.qcond = sync.NewCond(&s.qmu)
+	go s.deliverLoop()
+	return s
 }
 
-func (s *executionStreamState) deliverStdout(data []byte) {
+// deliverStdout/deliverStderr run on the shared per-Runtime drain goroutine.
+// They only enqueue — never write to the caller's sink — so a blocking sink
+// cannot wedge the drain goroutine (see executionStreamState). The bytes are
+// already a Go-owned copy (C.GoBytes at the cgo boundary), so the slice is safe
+// to retain in the queue.
+func (s *executionStreamState) deliverStdout(data []byte) { s.enqueue(streamChunk{false, data}) }
+func (s *executionStreamState) deliverStderr(data []byte) { s.enqueue(streamChunk{true, data}) }
+
+func (s *executionStreamState) enqueue(c streamChunk) {
 	if s.released.Load() {
 		return
 	}
-	s.mu.Lock()
-	stdout := s.stdout
-	cb := s.onStdout
-	s.mu.Unlock()
-	if cb != nil {
-		cb(data)
+	s.qmu.Lock()
+	if !s.exited && !s.stopped {
+		s.queue = append(s.queue, c)
+		s.qcond.Signal()
 	}
-	if stdout != nil {
-		_, _ = stdout.Write(data)
-	}
-	s.progress.Add(1)
+	s.qmu.Unlock()
 }
 
-func (s *executionStreamState) deliverStderr(data []byte) {
-	if s.released.Load() {
-		return
-	}
-	s.mu.Lock()
-	stderr := s.stderr
-	cb := s.onStderr
-	s.mu.Unlock()
-	if cb != nil {
-		cb(data)
-	}
-	if stderr != nil {
-		_, _ = stderr.Write(data)
-	}
-	s.progress.Add(1)
-}
-
+// deliverExit marks end-of-stream. The writer goroutine flushes whatever is
+// still queued (on_exit fires only after every stream callback for this
+// execution, so the queue holds the full tail) and then closes drained, which
+// Execution.Wait's drain barrier is waiting on.
 func (s *executionStreamState) deliverExit(_ int) {
 	s.released.Store(true)
-	close(s.drained)
+	s.qmu.Lock()
+	s.exited = true
+	s.qcond.Signal()
+	s.qmu.Unlock()
 }
 
 func (s *executionStreamState) markReleased() {
 	s.released.Store(true)
+	s.qmu.Lock()
+	s.stopped = true
+	s.qcond.Signal()
+	s.qmu.Unlock()
+}
+
+// deliverLoop is the per-execution writer goroutine. It drains the queue in
+// FIFO order (preserving stdout/stderr interleaving) into the caller's sinks,
+// bumping progress per chunk so Wait's progress-bounded drain barrier can tell
+// a still-delivering stream from a stalled one. Blocking here isolates sink
+// back-pressure to this one execution. Exits — closing drained — once on_exit
+// has been seen and the queue is empty, or when the execution is released.
+func (s *executionStreamState) deliverLoop() {
+	defer s.closeDrained()
+	for {
+		s.qmu.Lock()
+		for len(s.queue) == 0 && !s.exited && !s.stopped {
+			s.qcond.Wait()
+		}
+		q := s.queue
+		s.queue = nil
+		done := s.exited || s.stopped
+		s.qmu.Unlock()
+
+		for _, c := range q {
+			s.writeChunk(c)
+		}
+		if done {
+			// No more chunks can arrive once exited/stopped is set (deliver*
+			// calls are serialized on the single drain goroutine), but a chunk
+			// enqueued before the flag was observed may remain — flush it.
+			s.qmu.Lock()
+			rest := s.queue
+			s.queue = nil
+			s.qmu.Unlock()
+			for _, c := range rest {
+				s.writeChunk(c)
+			}
+			return
+		}
+	}
+}
+
+func (s *executionStreamState) writeChunk(c streamChunk) {
+	if c.stderr {
+		if s.onStderr != nil {
+			s.onStderr(c.data)
+		}
+		if s.stderr != nil {
+			_, _ = s.stderr.Write(c.data)
+		}
+	} else {
+		if s.onStdout != nil {
+			s.onStdout(c.data)
+		}
+		if s.stdout != nil {
+			_, _ = s.stdout.Write(c.data)
+		}
+	}
+	s.progress.Add(1)
+}
+
+func (s *executionStreamState) closeDrained() {
+	s.drainedOnce.Do(func() { close(s.drained) })
 }
 
 // Execution is a handle to a running command.

--- a/sdks/go/exec.go
+++ b/sdks/go/exec.go
@@ -85,7 +85,6 @@ type ExecutionOptions struct {
 // Memory overhead is bounded: each execution adds one map entry plus the
 // state struct (a few writers, two atomics, and a mutex).
 type executionStreamState struct {
-	mu       sync.Mutex
 	stdout   io.Writer
 	stderr   io.Writer
 	onStdout func([]byte)
@@ -103,57 +102,152 @@ type executionStreamState struct {
 	// buffer. The fold happens at the SDK boundary; the C-side Wait
 	// task stays decoupled from streams.
 	drained chan struct{}
+
+	// Stream callbacks arrive on the single per-Runtime drain goroutine. Do not
+	// call user-provided Writers inline there: one blocked sink would wedge the
+	// shared drain and prevent unrelated exec completions from being dispatched.
+	// Instead each execution owns one delivery chain — this byte-bounded buffer
+	// plus a dedicated deliverLoop goroutine that writes to the user sinks.
+	//
+	// Back-pressure is not signalled to C explicitly. When buffered bytes reach
+	// the high-water mark, enqueue blocks the drain goroutine instead of growing
+	// the buffer without bound. A parked drain stops popping the shared C event
+	// queue, so it fills to capacity and the Rust pumps yield in push_event,
+	// throttling the guest. C realises the back-pressure on its own; the Go SDK
+	// makes no pause/resume FFI call.
+	qmu         sync.Mutex
+	notEmpty    *sync.Cond // deliverLoop parks here while the buffer is empty
+	notFull     *sync.Cond // enqueue parks here while the buffer is at capacity
+	queue       []streamChunk
+	queuedBytes int
+	exited      bool
+	stopped     bool
+	drainedOnce sync.Once
+}
+
+const (
+	streamQueueHighWater = 4 << 20 // 4 MiB — enqueue blocks at/above this
+	streamQueueLowWater  = 1 << 20 // 1 MiB — enqueue resumes below this
+)
+
+type streamChunk struct {
+	stderr bool
+	data   []byte
 }
 
 func newExecutionStreamState(opts ExecutionOptions) *executionStreamState {
-	return &executionStreamState{
+	s := &executionStreamState{
 		stdout:   opts.Stdout,
 		stderr:   opts.Stderr,
 		onStdout: opts.OnStdout,
 		onStderr: opts.OnStderr,
 		drained:  make(chan struct{}),
 	}
+	s.notEmpty = sync.NewCond(&s.qmu)
+	s.notFull = sync.NewCond(&s.qmu)
+	go s.deliverLoop()
+	return s
 }
 
-func (s *executionStreamState) deliverStdout(data []byte) {
-	if s.released.Load() {
-		return
-	}
-	s.mu.Lock()
-	stdout := s.stdout
-	cb := s.onStdout
-	s.mu.Unlock()
-	if cb != nil {
-		cb(data)
-	}
-	if stdout != nil {
-		_, _ = stdout.Write(data)
-	}
-}
-
+func (s *executionStreamState) deliverStdout(data []byte) { s.enqueue(streamChunk{data: data}) }
 func (s *executionStreamState) deliverStderr(data []byte) {
+	s.enqueue(streamChunk{stderr: true, data: data})
+}
+
+// enqueue appends a chunk to the per-execution chain. It runs on the shared
+// drain goroutine, so blocking here is the back-pressure hinge: while the
+// buffer is at capacity we park the drain until deliverLoop makes room, which
+// stalls the shared C event queue and throttles the guest through push_event's
+// cooperative yield.
+func (s *executionStreamState) enqueue(chunk streamChunk) {
 	if s.released.Load() {
 		return
 	}
-	s.mu.Lock()
-	stderr := s.stderr
-	cb := s.onStderr
-	s.mu.Unlock()
-	if cb != nil {
-		cb(data)
+	s.qmu.Lock()
+	defer s.qmu.Unlock()
+	for s.queuedBytes >= streamQueueHighWater && !s.exited && !s.stopped {
+		s.notFull.Wait()
 	}
-	if stderr != nil {
-		_, _ = stderr.Write(data)
+	if s.exited || s.stopped {
+		return
 	}
+	s.queue = append(s.queue, chunk)
+	s.queuedBytes += len(chunk.data)
+	s.notEmpty.Signal()
 }
 
 func (s *executionStreamState) deliverExit(_ int) {
 	s.released.Store(true)
-	close(s.drained)
+	s.qmu.Lock()
+	s.exited = true
+	s.notEmpty.Broadcast()
+	s.notFull.Broadcast()
+	s.qmu.Unlock()
 }
 
 func (s *executionStreamState) markReleased() {
 	s.released.Store(true)
+	s.qmu.Lock()
+	s.stopped = true
+	s.notEmpty.Broadcast()
+	s.notFull.Broadcast()
+	s.qmu.Unlock()
+}
+
+func (s *executionStreamState) deliverLoop() {
+	defer s.closeDrained()
+	for {
+		s.qmu.Lock()
+		for len(s.queue) == 0 && !s.exited && !s.stopped {
+			s.notEmpty.Wait()
+		}
+		queue := s.queue
+		s.queue = nil
+		done := s.exited || s.stopped
+		s.qmu.Unlock()
+
+		batch := 0
+		for _, chunk := range queue {
+			s.writeChunk(chunk)
+			batch += len(chunk.data)
+		}
+
+		s.qmu.Lock()
+		s.queuedBytes -= batch
+		// Wake a parked enqueue only after draining back under the low-water
+		// mark, so the drain resumes in bursts instead of thrashing chunk by
+		// chunk at the high-water boundary.
+		if s.queuedBytes < streamQueueLowWater {
+			s.notFull.Broadcast()
+		}
+		s.qmu.Unlock()
+
+		if done {
+			return
+		}
+	}
+}
+
+func (s *executionStreamState) writeChunk(chunk streamChunk) {
+	if chunk.stderr {
+		if s.onStderr != nil {
+			s.onStderr(chunk.data)
+		}
+		if s.stderr != nil {
+			_, _ = s.stderr.Write(chunk.data)
+		}
+		return
+	}
+	if s.onStdout != nil {
+		s.onStdout(chunk.data)
+	}
+	if s.stdout != nil {
+		_, _ = s.stdout.Write(chunk.data)
+	}
+}
+
+func (s *executionStreamState) closeDrained() {
+	s.drainedOnce.Do(func() { close(s.drained) })
 }
 
 // Execution is a handle to a running command.

--- a/sdks/go/exec_backpressure_integration_test.go
+++ b/sdks/go/exec_backpressure_integration_test.go
@@ -84,12 +84,24 @@ func TestIntegrationExecStreamStallTimeout(t *testing.T) {
 	}
 	defer exec.Close()
 
-	done := make(chan int, 1)
-	go func() { c, _ := exec.Wait(context.Background()); done <- c }()
+	type waitResult struct {
+		code int
+		err  error
+	}
+	done := make(chan waitResult, 1)
+	go func() {
+		c, e := exec.Wait(context.Background())
+		done <- waitResult{c, e}
+	}()
 	start := time.Now()
 	select {
-	case code := <-done:
-		if code == 0 {
+	case res := <-done:
+		// The stall-kill must surface through Wait: it returns cleanly (no
+		// error) with the SIGKILL reflected in a non-zero exit code.
+		if res.err != nil {
+			t.Errorf("Wait err = %v, want nil (stall-kill surfaces via exit code)", res.err)
+		}
+		if res.code == 0 {
 			t.Errorf("exit = 0, want non-zero (stall-killed)")
 		}
 		if elapsed := time.Since(start); elapsed > 10*time.Second {

--- a/sdks/go/exec_backpressure_integration_test.go
+++ b/sdks/go/exec_backpressure_integration_test.go
@@ -1,0 +1,63 @@
+//go:build boxlite_dev
+
+package boxlite
+
+import (
+	"context"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+)
+
+// blockForeverSink blocks the writer on its first Write and never returns,
+// modelling a stalled/blocked caller sink.
+type blockForeverSink struct {
+	once sync.Once
+	rel  chan struct{}
+}
+
+func (b *blockForeverSink) Write(p []byte) (int, error) {
+	b.once.Do(func() { <-b.rel })
+	return len(p), nil
+}
+
+// TestIntegrationExecBackpressureBoundsMemory proves end-to-end stream
+// back-pressure: a blocked caller sink on an infinitely-producing process must
+// NOT cause unbounded host buffering. Without back-pressure the per-execution
+// delivery queue grows without limit (the producer is never throttled); with
+// it, the bounded Go queue pauses the C pump, which fills the bounded upstream
+// channel, blocking the attach reader, the guest forwarder, and finally the
+// guest process's write(). Heap growth must therefore plateau.
+func TestIntegrationExecBackpressureBoundsMemory(t *testing.T) {
+	rt := newTestRuntime(t)
+	box := createStartedBoxOrSkip(t, rt, "alpine:latest", WithAutoRemove(false))
+
+	sink := &blockForeverSink{rel: make(chan struct{})}
+	exec, err := box.StartExecution(context.Background(), "sh",
+		[]string{"-c", "yes ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"}, &ExecutionOptions{Stdout: sink})
+	if err != nil {
+		t.Fatalf("StartExecution: %v", err)
+	}
+	t.Cleanup(func() { close(sink.rel); _ = exec.Close() })
+
+	var m runtime.MemStats
+	read := func() uint64 { runtime.ReadMemStats(&m); return m.HeapAlloc }
+
+	// Let the producer run while the sink is blocked; sample heap growth.
+	time.Sleep(1 * time.Second)
+	base := read()
+	for i := 0; i < 6; i++ {
+		time.Sleep(500 * time.Millisecond)
+	}
+	grew := int64(read()) - int64(base)
+
+	// With back-pressure the queue is capped near streamQueueHighWater (a few
+	// MiB) plus the bounded in-flight buffers. A generous 64 MiB bound still
+	// catches the unbounded regression (which grew tens of MiB/s indefinitely).
+	const bound = 64 << 20
+	if grew > bound {
+		t.Fatalf("heap grew %d bytes over 3s under a blocked sink — stream "+
+			"back-pressure is not bounding host memory (want plateau under %d)", grew, bound)
+	}
+}

--- a/sdks/go/exec_backpressure_integration_test.go
+++ b/sdks/go/exec_backpressure_integration_test.go
@@ -61,3 +61,46 @@ func TestIntegrationExecBackpressureBoundsMemory(t *testing.T) {
 			"back-pressure is not bounding host memory (want plateau under %d)", grew, bound)
 	}
 }
+
+// TestIntegrationExecStreamStallTimeout verifies the StreamStallTimeout safety
+// net: when output is buffered but the caller's sink accepts nothing for the
+// configured duration (a permanently blocked/abandoned sink), the execution is
+// auto-killed so Wait returns and the box's resources are released — no manual
+// stop required.
+func TestIntegrationExecStreamStallTimeout(t *testing.T) {
+	rt := newTestRuntime(t)
+	box := createStartedBoxOrSkip(t, rt, "alpine:latest", WithAutoRemove(false))
+
+	// A sink that blocks forever on the first write.
+	rel := make(chan struct{})
+	defer close(rel)
+	sink := writerFunc(func(p []byte) (int, error) { <-rel; return len(p), nil })
+
+	exec, err := box.StartExecution(context.Background(), "sh",
+		[]string{"-c", "echo hi; sleep 600"},
+		&ExecutionOptions{Stdout: sink, StreamStallTimeout: 3 * time.Second})
+	if err != nil {
+		t.Fatalf("StartExecution: %v", err)
+	}
+	defer exec.Close()
+
+	done := make(chan int, 1)
+	go func() { c, _ := exec.Wait(context.Background()); done <- c }()
+	start := time.Now()
+	select {
+	case code := <-done:
+		if code == 0 {
+			t.Errorf("exit = 0, want non-zero (stall-killed)")
+		}
+		if elapsed := time.Since(start); elapsed > 10*time.Second {
+			t.Errorf("stall-kill took %s, want ~3s", elapsed)
+		}
+	case <-time.After(20 * time.Second):
+		t.Fatal("HANG: stalled exec was not auto-killed by StreamStallTimeout")
+	}
+}
+
+// writerFunc adapts a func to io.Writer.
+type writerFunc func([]byte) (int, error)
+
+func (f writerFunc) Write(p []byte) (int, error) { return f(p) }

--- a/sdks/go/exec_backpressure_integration_test.go
+++ b/sdks/go/exec_backpressure_integration_test.go
@@ -1,0 +1,94 @@
+//go:build boxlite_dev
+
+package boxlite
+
+import (
+	"context"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+)
+
+type blockForeverSink struct {
+	once    sync.Once
+	entered chan struct{}
+	rel     chan struct{}
+}
+
+func (b *blockForeverSink) Write(p []byte) (int, error) {
+	b.once.Do(func() {
+		close(b.entered)
+		<-b.rel
+	})
+	return len(p), nil
+}
+
+// TestIntegrationExecBackpressureBoundsMemory proves that the per-exec stream
+// queue added to isolate the shared Runtime drain cannot grow without bound
+// when a caller's sink is blocked and the guest keeps producing output.
+func TestIntegrationExecBackpressureBoundsMemory(t *testing.T) {
+	rt := newTestRuntime(t)
+	box := createStartedBoxOrSkip(t, rt, "alpine:latest", WithAutoRemove(false))
+
+	sink := &blockForeverSink{
+		entered: make(chan struct{}),
+		rel:     make(chan struct{}),
+	}
+	trigger := "/tmp/boxlite-backpressure-go"
+	exec, err := box.StartExecution(context.Background(), "sh",
+		[]string{"-c", "while [ ! -f " + trigger + " ]; do sleep 0.1; done; dd if=/dev/zero bs=1M count=128 2>/dev/null"}, &ExecutionOptions{Stdout: sink})
+	if err != nil {
+		t.Fatalf("StartExecution: %v", err)
+	}
+
+	var cleanupOnce sync.Once
+	cleanup := func() {
+		cleanupOnce.Do(func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			// Gentle teardown: unblock the sink so buffered output drains and the
+			// stream pumps reach EOF, kill the process, and Wait so the pumps
+			// finish (and the exit callback fires) BEFORE Close. Closing an
+			// execution whose stdout is still actively flooding is a separate
+			// concern — the C force-close abort race — and is out of scope for
+			// this memory-bound test.
+			close(sink.rel)
+			_ = exec.Kill(ctx)
+			_, _ = exec.Wait(ctx)
+			_ = exec.Close()
+		})
+	}
+	t.Cleanup(cleanup)
+
+	touchCtx, touchCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer touchCancel()
+	if _, err := box.Exec(touchCtx, "sh", "-c", "touch "+trigger); err != nil {
+		t.Fatalf("trigger output: %v", err)
+	}
+
+	select {
+	case <-sink.entered:
+	case <-time.After(20 * time.Second):
+		t.Skip("execution never delivered stdout to the blocking sink within 20s")
+	}
+
+	var m runtime.MemStats
+	read := func() uint64 {
+		runtime.ReadMemStats(&m)
+		return m.HeapAlloc
+	}
+
+	base := read()
+	for i := 0; i < 6; i++ {
+		time.Sleep(500 * time.Millisecond)
+	}
+	grew := int64(read()) - int64(base)
+
+	cleanup()
+
+	const bound = 64 << 20
+	if grew > bound {
+		t.Fatalf("heap grew %d bytes over 3s under a blocked sink; want plateau under %d", grew, bound)
+	}
+}

--- a/sdks/go/exec_backpressure_unit_test.go
+++ b/sdks/go/exec_backpressure_unit_test.go
@@ -1,0 +1,127 @@
+package boxlite
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// gatedSink blocks every Write until released, then records the bytes so the
+// test can assert byte-exact, in-order delivery once backpressure lifts.
+type gatedSink struct {
+	release chan struct{}
+	mu      sync.Mutex
+	got     []byte
+}
+
+func (g *gatedSink) Write(p []byte) (int, error) {
+	<-g.release
+	g.mu.Lock()
+	g.got = append(g.got, p...)
+	g.mu.Unlock()
+	return len(p), nil
+}
+
+// TestExecutionStreamStateBackpressureBoundsBuffer covers the redesigned
+// per-execution chain (PR #826, revised): there is no Go->C pause call. When a
+// sink is blocked, deliverStdout — which runs on the shared drain goroutine —
+// must block once buffered bytes reach the high-water mark instead of growing
+// the chain without bound. That block is exactly what stalls the shared C
+// event queue so push_event yields and the guest is throttled. Once the sink
+// drains, every byte must still be delivered in order.
+//
+// This is the deterministic, VM-free counterpart to the integration tests
+// TestIntegrationExecBackpressureBoundsMemory and
+// TestIntegrationStdoutBlockingSinkStallsRuntimeDrain.
+func TestExecutionStreamStateBackpressureBoundsBuffer(t *testing.T) {
+	sink := &gatedSink{release: make(chan struct{})}
+	state := newExecutionStreamState(ExecutionOptions{Stdout: sink})
+
+	const chunkSize = 64 << 10 // 64 KiB
+	// Four times the high-water mark's worth of chunks, so the producer is
+	// guaranteed to wedge on backpressure long before it finishes.
+	const chunks = (streamQueueHighWater / chunkSize) * 4
+
+	mkChunk := func(i int) []byte {
+		b := make([]byte, chunkSize)
+		for j := range b {
+			b[j] = byte(i) // distinct per chunk (chunks == 256, no wrap)
+		}
+		return b
+	}
+
+	var accepted int64
+	done := make(chan struct{})
+	// Buffered to `chunks` so the producer never blocks on this channel — the
+	// only thing that may block it is the backpressure under test.
+	progress := make(chan int64, chunks)
+	go func() {
+		defer close(done)
+		for i := 0; i < chunks; i++ {
+			state.deliverStdout(mkChunk(i))
+			progress <- atomic.AddInt64(&accepted, 1)
+		}
+	}()
+
+	// Drive the wait off the producer's own progress signals (no sleep
+	// polling): once buffered bytes reach the high-water mark the next enqueue
+	// blocks, so `accepted` climbs to the mark and then stalls there.
+	target := int64(streamQueueHighWater / chunkSize)
+	timeout := time.After(5 * time.Second)
+	for atomic.LoadInt64(&accepted) < target {
+		select {
+		case <-progress:
+		case <-timeout:
+			t.Fatalf("producer only accepted %d chunks before timeout; want >= %d "+
+				"(backpressure never let the chain fill to the high-water mark)",
+				atomic.LoadInt64(&accepted), target)
+		}
+	}
+
+	if got := atomic.LoadInt64(&accepted); got >= chunks {
+		t.Fatalf("producer accepted all %d chunks with the sink blocked; "+
+			"backpressure never engaged (chain grew unbounded)", chunks)
+	}
+
+	// Buffered bytes must sit within one chunk of the high-water mark: the chain
+	// filled up to the mark (lower bound → backpressure engaged at the right
+	// point) and no further (upper bound → memory is bounded). deliverLoop is
+	// wedged on the blocked sink, so nothing has been drained yet.
+	state.qmu.Lock()
+	queued := state.queuedBytes
+	state.qmu.Unlock()
+	if queued < streamQueueHighWater-chunkSize || queued > streamQueueHighWater+chunkSize {
+		t.Fatalf("buffered %d bytes, want within one chunk of high-water %d "+
+			"(backpressure should plateau the chain at the mark)", queued, streamQueueHighWater)
+	}
+
+	// Release the sink; the blocked producer and deliverLoop must drain fully.
+	close(sink.release)
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("producer did not finish after the sink was released")
+	}
+
+	// Exit ends the chain; the drain barrier guarantees every chunk is flushed.
+	state.deliverExit(0)
+	select {
+	case <-state.drained:
+	case <-time.After(10 * time.Second):
+		t.Fatal("stream chain did not drain after exit")
+	}
+
+	sink.mu.Lock()
+	defer sink.mu.Unlock()
+	if len(sink.got) != chunks*chunkSize {
+		t.Fatalf("delivered %d bytes, want %d", len(sink.got), chunks*chunkSize)
+	}
+	for i := 0; i < chunks; i++ {
+		off := i * chunkSize
+		if want := byte(i); sink.got[off] != want || sink.got[off+chunkSize-1] != want {
+			t.Fatalf("chunk %d corrupted or out of order: first=%d last=%d, want %d",
+				i, sink.got[off], sink.got[off+chunkSize-1], want)
+		}
+	}
+}

--- a/sdks/go/exec_drain_matrix_integration_test.go
+++ b/sdks/go/exec_drain_matrix_integration_test.go
@@ -181,3 +181,74 @@ func TestIntegrationExecRuntimeCloseUnblocksWait(t *testing.T) {
 		t.Fatal("HANG: Wait did not unblock on Runtime.Close")
 	}
 }
+
+// TestIntegrationExecOutputShapes covers output shapes orthogonal to
+// termination: slow/trickle (gaps wider than the post-exit idle bound), large
+// high-throughput, and binary/no-trailing-newline. Each asserts Wait returns
+// with the exact byte count (no truncation, no extra).
+func TestIntegrationExecOutputShapes(t *testing.T) {
+	rt := newTestRuntime(t)
+	box := createStartedBoxOrSkip(t, rt, "alpine:latest", WithAutoRemove(false))
+
+	run := func(t *testing.T, args []string, watchdog time.Duration) (int, int) {
+		t.Helper()
+		var out bytes.Buffer
+		exec, err := box.StartExecution(context.Background(), "sh", args, &ExecutionOptions{Stdout: &out})
+		if err != nil {
+			t.Fatalf("StartExecution: %v", err)
+		}
+		defer exec.Close()
+		var code int
+		waitWatchdog(t, watchdog, t.Name(), func() { code, _ = exec.Wait(context.Background()) })
+		return code, out.Len()
+	}
+
+	t.Run("slow-trickle", func(t *testing.T) {
+		// 6 lines, 500ms apart: each gap exceeds the 300ms post-exit idle bound,
+		// proving live output is gated by exit (not the idle bound) and is never
+		// cut off.
+		code, n := run(t, []string{"-c", "i=0; while [ $i -lt 6 ]; do echo line-$i; sleep 0.5; i=$((i+1)); done"}, 20*time.Second)
+		if want := len("line-0\n") * 6; n != want {
+			t.Errorf("slow output bytes = %d, want %d", n, want)
+		}
+		if code != 0 {
+			t.Errorf("exit = %d, want 0", code)
+		}
+	})
+
+	t.Run("large-high-throughput", func(t *testing.T) {
+		const lines, line = 200000, "0123456789abcdef0123456789abcdef"
+		code, n := run(t, []string{"-c", "awk 'BEGIN{for(i=0;i<" + itoa(lines) + ";i++)print \"" + line + "\"}'"}, 30*time.Second)
+		if want := lines * (len(line) + 1); n != want {
+			t.Errorf("large output bytes = %d, want %d (%.2f%%)", n, want, 100*float64(n)/float64(want))
+		}
+		if code != 0 {
+			t.Errorf("exit = %d, want 0", code)
+		}
+	})
+
+	t.Run("binary-no-newline", func(t *testing.T) {
+		// 5 printable bytes (no newline) + 1000 NUL bytes: exact, unterminated.
+		code, n := run(t, []string{"-c", "printf 'abcde'; head -c 1000 /dev/zero"}, 12*time.Second)
+		if n != 1005 {
+			t.Errorf("binary output bytes = %d, want 1005", n)
+		}
+		if code != 0 {
+			t.Errorf("exit = %d, want 0", code)
+		}
+	})
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b [20]byte
+	i := len(b)
+	for n > 0 {
+		i--
+		b[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(b[i:])
+}

--- a/sdks/go/exec_drain_matrix_integration_test.go
+++ b/sdks/go/exec_drain_matrix_integration_test.go
@@ -42,10 +42,14 @@ func TestIntegrationExecDrainMatrix(t *testing.T) {
 		}
 		defer exec.Close()
 		var code int
+		var waitErr error
 		if kill != nil {
 			go kill(exec)
 		}
-		waitWatchdog(t, watchdog, t.Name(), func() { code, _ = exec.Wait(context.Background()) })
+		waitWatchdog(t, watchdog, t.Name(), func() { code, waitErr = exec.Wait(context.Background()) })
+		if waitErr != nil {
+			t.Fatalf("Wait: %v", waitErr)
+		}
 		return code
 	}
 
@@ -199,7 +203,11 @@ func TestIntegrationExecOutputShapes(t *testing.T) {
 		}
 		defer exec.Close()
 		var code int
-		waitWatchdog(t, watchdog, t.Name(), func() { code, _ = exec.Wait(context.Background()) })
+		var waitErr error
+		waitWatchdog(t, watchdog, t.Name(), func() { code, waitErr = exec.Wait(context.Background()) })
+		if waitErr != nil {
+			t.Fatalf("Wait: %v", waitErr)
+		}
 		return code, out.Len()
 	}
 

--- a/sdks/go/exec_drain_matrix_integration_test.go
+++ b/sdks/go/exec_drain_matrix_integration_test.go
@@ -1,0 +1,183 @@
+//go:build boxlite_dev
+
+package boxlite
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+)
+
+// waitWatchdog runs fn (which performs a blocking Wait) and fails the test if it
+// does not return within d — i.e. the exec hung instead of reporting exit.
+func waitWatchdog(t *testing.T, d time.Duration, what string, fn func()) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() { fn(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(d):
+		t.Fatalf("HANG: %s did not return within %s (Wait never unblocked)", what, d)
+	}
+}
+
+// TestIntegrationExecDrainMatrix is the regression matrix for PR #812: across
+// termination modes (normal, timeout->SIGTERM, hard SIGKILL, explicit Kill,
+// backgrounded child holding stdout) and stream shapes (stdout, stderr, TTY),
+// Execution.Wait must return promptly with the right exit code and full output
+// instead of hanging. Runtime.Close mid-exec is covered separately below.
+func TestIntegrationExecDrainMatrix(t *testing.T) {
+	rt := newTestRuntime(t)
+	box := createStartedBoxOrSkip(t, rt, "alpine:latest", WithAutoRemove(false))
+
+	// run starts an exec, watchdogs the Wait, and returns the exit code.
+	run := func(t *testing.T, opts *ExecutionOptions, args []string, watchdog time.Duration, kill func(*Execution)) int {
+		t.Helper()
+		exec, err := box.StartExecution(context.Background(), "sh", args, opts)
+		if err != nil {
+			t.Fatalf("StartExecution: %v", err)
+		}
+		defer exec.Close()
+		var code int
+		if kill != nil {
+			go kill(exec)
+		}
+		waitWatchdog(t, watchdog, t.Name(), func() { code, _ = exec.Wait(context.Background()) })
+		return code
+	}
+
+	t.Run("normal-exit", func(t *testing.T) {
+		var out bytes.Buffer
+		code := run(t, &ExecutionOptions{Stdout: &out}, []string{"-c", "echo hi; exit 5"}, 12*time.Second, nil)
+		if code != 5 {
+			t.Errorf("exit = %d, want 5", code)
+		}
+		if out.Len() == 0 {
+			t.Errorf("stdout empty, want output before exit")
+		}
+	})
+
+	t.Run("timeout-SIGTERM", func(t *testing.T) {
+		var out bytes.Buffer
+		code := run(t, &ExecutionOptions{Stdout: &out, Timeout: 2 * time.Second},
+			[]string{"-c", "echo before; sleep 30"}, 14*time.Second, nil)
+		if code == 0 {
+			t.Errorf("exit = 0, want non-zero (killed by timeout)")
+		}
+		if !bytes.Contains(out.Bytes(), []byte("before")) {
+			t.Errorf("pre-kill stdout lost: %q", out.String())
+		}
+	})
+
+	t.Run("hard-SIGKILL-escalate", func(t *testing.T) {
+		// trap+ignore SIGTERM so the timeout must escalate to SIGKILL.
+		var out bytes.Buffer
+		code := run(t, &ExecutionOptions{Stdout: &out, Timeout: 2 * time.Second},
+			[]string{"-c", "trap '' TERM; echo before; while :; do sleep 0.2; done"}, 25*time.Second, nil)
+		if code == 0 {
+			t.Errorf("exit = 0, want non-zero (SIGKILL)")
+		}
+		if !bytes.Contains(out.Bytes(), []byte("before")) {
+			t.Errorf("pre-kill stdout lost: %q", out.String())
+		}
+	})
+
+	t.Run("bg-child-holds-stdout", func(t *testing.T) {
+		// Main exits 0 but a backgrounded child inherits stdout; the pump may
+		// not see a natural EOF. Wait must still return (drain gives up).
+		var out bytes.Buffer
+		code := run(t, &ExecutionOptions{Stdout: &out}, []string{"-c", "echo hi; sleep 30 &"}, 12*time.Second, nil)
+		if code != 0 {
+			t.Errorf("exit = %d, want 0", code)
+		}
+		if !bytes.Contains(out.Bytes(), []byte("hi")) {
+			t.Errorf("stdout lost: %q", out.String())
+		}
+	})
+
+	t.Run("explicit-Kill", func(t *testing.T) {
+		code := run(t, &ExecutionOptions{}, []string{"-c", "echo before; sleep 30"}, 12*time.Second,
+			func(e *Execution) {
+				time.Sleep(700 * time.Millisecond)
+				_ = e.Kill(context.Background())
+			})
+		if code == 0 {
+			t.Errorf("exit = 0, want non-zero (killed)")
+		}
+	})
+
+	t.Run("stderr-separate", func(t *testing.T) {
+		var out, errb bytes.Buffer
+		code := run(t, &ExecutionOptions{Stdout: &out, Stderr: &errb},
+			[]string{"-c", "echo OUT; echo ERRLINE 1>&2; exit 3"}, 12*time.Second, nil)
+		if code != 3 {
+			t.Errorf("exit = %d, want 3", code)
+		}
+		if !bytes.Contains(out.Bytes(), []byte("OUT")) || !bytes.Contains(errb.Bytes(), []byte("ERRLINE")) {
+			t.Errorf("stream loss: stdout=%q stderr=%q", out.String(), errb.String())
+		}
+	})
+
+	t.Run("tty-normal", func(t *testing.T) {
+		var out bytes.Buffer
+		code := run(t, &ExecutionOptions{TTY: true, Stdout: &out}, []string{"-c", "echo hi; exit 0"}, 12*time.Second, nil)
+		if code != 0 {
+			t.Errorf("exit = %d, want 0", code)
+		}
+		if out.Len() == 0 {
+			t.Errorf("TTY stdout empty")
+		}
+	})
+
+	t.Run("tty-timeout", func(t *testing.T) {
+		var out bytes.Buffer
+		code := run(t, &ExecutionOptions{TTY: true, Stdout: &out, Timeout: 2 * time.Second},
+			[]string{"-c", "echo hi; sleep 30"}, 14*time.Second, nil)
+		if code == 0 {
+			t.Errorf("exit = 0, want non-zero (timeout)")
+		}
+	})
+}
+
+// TestIntegrationExecRuntimeCloseUnblocksWait covers the e.closing path: closing
+// the Runtime while an exec is in flight must unblock Wait with ErrRuntimeClosed
+// rather than hanging.
+func TestIntegrationExecRuntimeCloseUnblocksWait(t *testing.T) {
+	home, err := os.MkdirTemp("/tmp", "boxlite-rtclose-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(home) })
+	rt, err := NewRuntime(WithHomeDir(home))
+	if err != nil {
+		var e *Error
+		if errors.As(err, &e) && (e.Code == ErrUnsupported || e.Code == ErrUnsupportedEngine) {
+			t.Skipf("runtime not available: %v", err)
+		}
+		t.Fatalf("NewRuntime: %v", err)
+	}
+	box := createStartedBoxOrSkip(t, rt, "alpine:latest", WithAutoRemove(false))
+
+	exec, err := box.StartExecution(context.Background(), "sh", []string{"-c", "echo running; sleep 30"}, &ExecutionOptions{})
+	if err != nil {
+		t.Fatalf("StartExecution: %v", err)
+	}
+	defer exec.Close()
+
+	errCh := make(chan error, 1)
+	go func() { _, e := exec.Wait(context.Background()); errCh <- e }()
+	time.Sleep(700 * time.Millisecond)
+	go func() { _ = rt.Close() }()
+
+	select {
+	case e := <-errCh:
+		if !errors.Is(e, ErrRuntimeClosed) {
+			t.Fatalf("Wait err = %v, want ErrRuntimeClosed", e)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("HANG: Wait did not unblock on Runtime.Close")
+	}
+}

--- a/sdks/go/exec_full_matrix_integration_test.go
+++ b/sdks/go/exec_full_matrix_integration_test.go
@@ -1,0 +1,124 @@
+//go:build boxlite_dev
+
+package boxlite
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+)
+
+// TestIntegrationExecFullMatrix is the full termination x output-shape
+// cross-product (8 x 3 = 24 cells) on a real box. For every combination,
+// Execution.Wait must return promptly (no hang) with the right exit semantics
+// and a sane byte count:
+//   - clean terminations (normal / stderr / tty-normal) and kill terminations on
+//     a fast shape (output finishes before the kill): exact full byte count
+//     (except TTY, whose line discipline rewrites bytes);
+//   - a kill that interrupts the slow trickle: a non-empty prefix (partial).
+func TestIntegrationExecFullMatrix(t *testing.T) {
+	rt := newTestRuntime(t)
+	box := createStartedBoxOrSkip(t, rt, "alpine:latest", WithAutoRemove(false))
+
+	type shape struct {
+		name  string
+		gen   string // sh fragment producing the output to stdout
+		bytes int    // exact byte count when fully delivered (non-TTY)
+		slow  bool   // runs longer than the kill deadlines (the trickle)
+	}
+	shapes := []shape{
+		{"trickle", `i=0; while [ $i -lt 6 ]; do echo line-$i; sleep 0.5; i=$((i+1)); done`, 6 * len("line-0\n"), true},
+		{"throughput", `awk 'BEGIN{for(i=0;i<200000;i++)print "0123456789abcdef0123456789abcdef"}'`, 200000 * 33, false},
+		{"binary", `printf 'abcde'; head -c 1000 /dev/zero`, 1005, false},
+	}
+
+	type term struct {
+		name      string
+		wrap      func(gen string) string
+		timeout   time.Duration
+		kill      func(*Execution)
+		killClass bool // exit must be non-zero; output may be a prefix
+		wantExit  int  // asserted when !killClass
+		tty       bool
+		stderr    bool
+		watchdog  time.Duration
+	}
+	terms := []term{
+		{name: "normal", wrap: func(g string) string { return g + "; exit 7" }, wantExit: 7, watchdog: 25 * time.Second},
+		{name: "timeout-SIGTERM", wrap: func(g string) string { return g + "; sleep 30" }, timeout: 2 * time.Second, killClass: true, watchdog: 25 * time.Second},
+		{name: "hard-SIGKILL", wrap: func(g string) string { return "trap '' TERM; " + g + "; while :; do sleep 0.2; done" }, timeout: 2 * time.Second, killClass: true, watchdog: 35 * time.Second},
+		{name: "bg-child", wrap: func(g string) string { return g + "; sleep 30 &" }, wantExit: 0, watchdog: 25 * time.Second},
+		{name: "explicit-Kill", wrap: func(g string) string { return g + "; sleep 30" }, killClass: true, watchdog: 25 * time.Second,
+			kill: func(e *Execution) { time.Sleep(1500 * time.Millisecond); _ = e.Kill(context.Background()) }},
+		{name: "stderr", wrap: func(g string) string { return "{ " + g + "; } 1>&2; exit 3" }, wantExit: 3, stderr: true, watchdog: 25 * time.Second},
+		{name: "tty-normal", wrap: func(g string) string { return g + "; exit 0" }, wantExit: 0, tty: true, watchdog: 25 * time.Second},
+		{name: "tty-timeout", wrap: func(g string) string { return g + "; sleep 30" }, timeout: 2 * time.Second, killClass: true, tty: true, watchdog: 25 * time.Second},
+	}
+
+	for _, tm := range terms {
+		for _, sh := range shapes {
+			tm, sh := tm, sh
+			t.Run(tm.name+"/"+sh.name, func(t *testing.T) {
+				var out, errb bytes.Buffer
+				opts := &ExecutionOptions{}
+				switch {
+				case tm.tty:
+					opts.TTY = true
+					opts.Stdout = &out
+				case tm.stderr:
+					opts.Stderr = &errb
+				default:
+					opts.Stdout = &out
+				}
+				opts.Timeout = tm.timeout
+
+				exec, err := box.StartExecution(context.Background(), "sh", []string{"-c", tm.wrap(sh.gen)}, opts)
+				if err != nil {
+					t.Fatalf("StartExecution: %v", err)
+				}
+				defer exec.Close()
+				if tm.kill != nil {
+					go tm.kill(exec)
+				}
+
+				var code int
+				var waitErr error
+				waitWatchdog(t, tm.watchdog, t.Name(), func() { code, waitErr = exec.Wait(context.Background()) })
+				if waitErr != nil {
+					t.Fatalf("Wait: %v", waitErr)
+				}
+
+				if tm.killClass {
+					if code == 0 {
+						t.Errorf("exit = 0, want non-zero (killed)")
+					}
+				} else if code != tm.wantExit {
+					t.Errorf("exit = %d, want %d", code, tm.wantExit)
+				}
+
+				n := out.Len()
+				if tm.stderr {
+					n = errb.Len()
+				}
+				if n == 0 {
+					t.Fatalf("output empty, want bytes delivered before termination")
+				}
+
+				killInterruptsTrickle := tm.killClass && sh.slow
+				switch {
+				case tm.tty:
+					// Line discipline rewrites bytes; only require non-empty.
+				case killInterruptsTrickle:
+					if n > sh.bytes {
+						t.Errorf("partial output bytes = %d, exceeds full %d", n, sh.bytes)
+					}
+				default:
+					if n != sh.bytes {
+						t.Errorf("output bytes = %d, want exactly %d", n, sh.bytes)
+					}
+				}
+			})
+		}
+	}
+}

--- a/sdks/go/exec_stall_watchdog_test.go
+++ b/sdks/go/exec_stall_watchdog_test.go
@@ -1,0 +1,63 @@
+package boxlite
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestStallWatchdogKillsBufferedStall verifies the watchdog fires when output is
+// buffered (queuedBytes > 0) yet the sink delivers nothing for the whole
+// timeout, and that it waits at least one timeout before killing.
+func TestStallWatchdogKillsBufferedStall(t *testing.T) {
+	s := &executionStreamState{drained: make(chan struct{})}
+	s.qmu.Lock()
+	s.queuedBytes = 100 // buffered, never drains
+	s.qmu.Unlock()
+
+	const timeout = 200 * time.Millisecond
+	var killed atomic.Bool
+	done := make(chan struct{})
+	start := time.Now()
+	go func() {
+		s.stallWatchdog(timeout, func() { killed.Store(true) })
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		elapsed := time.Since(start)
+		if !killed.Load() {
+			t.Fatal("watchdog returned without killing a permanently stalled sink")
+		}
+		// Anchored at stall-start: detection tick (~timeout/4) + a full timeout.
+		if elapsed < timeout {
+			t.Fatalf("killed after %v, want >= timeout (%v); fired too eagerly", elapsed, timeout)
+		}
+	case <-time.After(4 * timeout):
+		t.Fatal("watchdog never killed a permanently stalled buffered sink")
+	}
+}
+
+// TestStallWatchdogIgnoresQuietExec is the #7 regression guard: an execution
+// that simply produces no output (queuedBytes stays 0, progress never advances)
+// must never be killed — there is nothing buffered, so there is no stall. The
+// earlier logic, which timed from the last progress regardless of whether
+// anything was pending, would have killed this idle-but-healthy execution.
+func TestStallWatchdogIgnoresQuietExec(t *testing.T) {
+	s := &executionStreamState{drained: make(chan struct{})}
+	// queuedBytes stays 0; progress is never bumped.
+
+	const timeout = 150 * time.Millisecond
+	var killed atomic.Bool
+	go s.stallWatchdog(timeout, func() { killed.Store(true) })
+
+	// Let several timeouts elapse: a buggy from-last-progress watchdog would
+	// have fired by now.
+	time.Sleep(4 * timeout)
+	s.closeDrained() // clean end; let the watchdog exit
+
+	if killed.Load() {
+		t.Fatal("watchdog killed a quiet execution that buffered nothing")
+	}
+}

--- a/sdks/go/exec_stream_delivery_integration_test.go
+++ b/sdks/go/exec_stream_delivery_integration_test.go
@@ -1,0 +1,90 @@
+//go:build boxlite_dev
+
+package boxlite
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// blockingSink is an io.Writer that parks the goroutine calling Write until
+// the test releases it. The first Write closes `entered` so the test can
+// observe — without a wall-clock sleep — that delivery has reached the sink,
+// then blocks on `release` (never sent during the test body) so the caller
+// stays parked.
+type blockingSink struct {
+	entered     chan struct{}
+	release     chan struct{}
+	enteredOnce sync.Once
+}
+
+func newBlockingSink() *blockingSink {
+	return &blockingSink{
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+}
+
+func (s *blockingSink) Write(p []byte) (int, error) {
+	s.enteredOnce.Do(func() { close(s.entered) })
+	<-s.release
+	return len(p), nil
+}
+
+// TestIntegrationStdoutBlockingSinkStallsRuntimeDrain guards against
+// head-of-line blocking across executions on one Runtime. A first execution
+// streams stdout into a sink that blocks forever; stream delivery must run off
+// the shared drain goroutine (per-execution writer), so a second, trivial
+// execution on the same box still completes promptly. With inline delivery on
+// the single drain goroutine the second exec's Wait never dispatches and its
+// context deadline fires instead.
+func TestIntegrationStdoutBlockingSinkStallsRuntimeDrain(t *testing.T) {
+	rt := newTestRuntime(t)
+	box := createStartedBoxOrSkip(t, rt, "alpine:latest", WithAutoRemove(false))
+
+	sink := newBlockingSink()
+
+	// Execution A: emit one stdout chunk, then stay alive. The chunk is
+	// delivered into `sink`, parking A's writer goroutine. We never Wait on A.
+	execA, err := box.StartExecution(context.Background(), "sh", []string{"-c", "echo drain-wedge; sleep 60"}, &ExecutionOptions{
+		Stdout: sink,
+	})
+	if err != nil {
+		t.Fatalf("StartExecution(A): %v", err)
+	}
+
+	// Release the parked writer FIRST (close release), then free execution A.
+	// Registered LAST so LIFO runs it BEFORE the box/runtime cleanups.
+	t.Cleanup(func() {
+		close(sink.release)
+		_ = execA.Close()
+	})
+
+	// Wait (event, not a sleep) for delivery to actually reach the blocking
+	// sink before probing.
+	select {
+	case <-sink.entered:
+	case <-time.After(20 * time.Second):
+		t.Skip("execution A never produced stdout within 20s; runtime/guest unavailable")
+	}
+
+	// Execution B: a trivial command on the SAME runtime. It must complete
+	// regardless of A's blocking sink.
+	ctxB, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	res, err := box.Exec(ctxB, "echo", "probe")
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("HEAD-OF-LINE BLOCKING: a second exec on the same Runtime did not "+
+			"complete in %s because execution A's blocking stdout sink wedged stream "+
+			"delivery: %v", elapsed, err)
+	}
+	if res.Stdout != "probe\n" {
+		t.Fatalf("probe exec returned unexpected stdout %q (want %q)", res.Stdout, "probe\n")
+	}
+}

--- a/sdks/go/exec_stream_delivery_integration_test.go
+++ b/sdks/go/exec_stream_delivery_integration_test.go
@@ -1,0 +1,108 @@
+//go:build boxlite_dev
+
+package boxlite
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// blockingSink is an io.Writer that parks the goroutine calling Write until
+// the test releases it. The first Write closes `entered` so the test can
+// observe — without a wall-clock sleep — that delivery has reached the sink,
+// then blocks on `release` (never sent during the test body) so the caller
+// stays parked.
+//
+// The point of parking here is to prove a misbehaving user sink cannot wedge
+// the shared per-Runtime drain goroutine. With per-execution delivery
+// (exec.go), Write runs on execution A's OWN delivery goroutine, so parking it
+// stalls only A — the drain keeps dispatching events for every other
+// execution on the same Runtime.
+type blockingSink struct {
+	entered     chan struct{}
+	release     chan struct{}
+	enteredOnce sync.Once
+}
+
+func newBlockingSink() *blockingSink {
+	return &blockingSink{
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+}
+
+func (s *blockingSink) Write(p []byte) (int, error) {
+	s.enteredOnce.Do(func() { close(s.entered) })
+	<-s.release
+	return len(p), nil
+}
+
+// TestIntegrationStdoutBlockingSinkStallsRuntimeDrain guards against
+// head-of-line blocking on the shared drain goroutine. Execution A streams one
+// stdout chunk into a sink that blocks forever; execution B is a trivial
+// command on the SAME Runtime and must complete promptly.
+//
+// If stream delivery ran inline on the single per-Runtime drain goroutine (the
+// pre-fix behaviour), A's blocked sink would wedge that goroutine and B's Wait
+// completion — queued behind A's stdout in the one event FIFO — would never be
+// dispatched, so B's context deadline would fire. With delivery moved onto a
+// per-execution chain, A's blocked sink stalls only A's own delivery goroutine
+// and B completes. This asserts that fixed behaviour: a regression that put
+// stream delivery back on the drain thread would time out here.
+func TestIntegrationStdoutBlockingSinkStallsRuntimeDrain(t *testing.T) {
+	rt := newTestRuntime(t)
+	box := createStartedBoxOrSkip(t, rt, "alpine:latest", WithAutoRemove(false))
+
+	sink := newBlockingSink()
+
+	// Execution A: emit one stdout chunk, then stay alive. The chunk is
+	// delivered into `sink`, parking A's delivery goroutine. We never Wait on A.
+	execA, err := box.StartExecution(context.Background(), "sh", []string{"-c", "echo drain-wedge; sleep 60"}, &ExecutionOptions{
+		Stdout: sink,
+	})
+	if err != nil {
+		t.Fatalf("StartExecution(A): %v", err)
+	}
+
+	// Tear down in the order that lets the runtime shut down cleanly: release
+	// the parked sink FIRST (close release), explicitly kill execution A (it is
+	// still in `sleep 60`, so don't rely on Close to terminate it), then free
+	// it. Registered LAST so LIFO runs it BEFORE the box/runtime cleanups from
+	// the helpers — otherwise rt.Close could block waiting on the parked
+	// delivery.
+	t.Cleanup(func() {
+		close(sink.release)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = execA.Kill(ctx)
+		_ = execA.Close()
+	})
+
+	// Wait (on a channel, not a sleep) until delivery has provably reached the
+	// blocking sink before probing.
+	select {
+	case <-sink.entered:
+	case <-time.After(20 * time.Second):
+		t.Skip("execution A never produced stdout within 20s; runtime/guest unavailable, cannot exercise the drain-blocking path")
+	}
+
+	// Execution B: a trivial command on the SAME runtime. It must complete even
+	// while A's sink is parked.
+	ctxB, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	res, err := box.Exec(ctxB, "echo", "probe")
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("head-of-line blocking: a second exec on the same Runtime did not "+
+			"complete in %s while execution A's stdout sink was blocked — stream "+
+			"delivery must not run on the shared drain goroutine: %v", elapsed, err)
+	}
+	if res.Stdout != "probe\n" {
+		t.Fatalf("probe exec returned unexpected stdout %q (want %q)", res.Stdout, "probe\n")
+	}
+}

--- a/sdks/go/exec_test.go
+++ b/sdks/go/exec_test.go
@@ -2,7 +2,9 @@ package boxlite
 
 import (
 	"reflect"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 // envMapToFlatPairs is the pure-Go pivot point of ExecutionOptions.Env
@@ -65,6 +67,102 @@ func TestEnvMapToFlatPairs(t *testing.T) {
 		want := []string{"EMPTY", ""}
 		if !reflect.DeepEqual(got, want) {
 			t.Fatalf("empty-value pair must round-trip, want %v got %v", want, got)
+		}
+	})
+}
+
+// TestWaitForStreamDrain pins Wait's drain-barrier semantics: it must keep
+// waiting while the stream is still delivering (so a large tail is never cut
+// off before the exit code is returned), give up promptly when a never-EOF
+// pipe goes idle (instead of hanging forever), surface runtime close, and
+// fall back to a hard cap.
+func TestWaitForStreamDrain(t *testing.T) {
+	t.Run("waits for a still-delivering stream then returns when drained", func(t *testing.T) {
+		var progress atomic.Uint64
+		drained := make(chan struct{})
+		closing := make(chan struct{})
+		// Deliver steadily for ~2.5s — past any 2s-style fixed cap — with
+		// each gap (50ms) under idleBound (100ms) so it never looks idle,
+		// then close drained. A fixed 2s cap would have bailed mid-stream.
+		go func() {
+			for i := 0; i < 50; i++ {
+				time.Sleep(50 * time.Millisecond)
+				progress.Add(1)
+			}
+			close(drained)
+		}()
+
+		start := time.Now()
+		closed := waitForStreamDrain(drained, closing, &progress, 100*time.Millisecond, 30*time.Second)
+		elapsed := time.Since(start)
+
+		if closed {
+			t.Fatal("expected closed=false: ended via drained, not runtime close")
+		}
+		if elapsed < 2400*time.Millisecond {
+			t.Fatalf("returned after %v: gave up before the stream finished "+
+				"delivering (a fixed 2s cap would do this)", elapsed)
+		}
+	})
+
+	t.Run("gives up after one idle window on a stuck never-EOF pipe", func(t *testing.T) {
+		var progress atomic.Uint64 // never bumped
+		drained := make(chan struct{})
+		closing := make(chan struct{})
+
+		start := time.Now()
+		closed := waitForStreamDrain(drained, closing, &progress, 100*time.Millisecond, 30*time.Second)
+		elapsed := time.Since(start)
+
+		if closed {
+			t.Fatal("expected closed=false: idle stall, not runtime close")
+		}
+		if elapsed > 2*time.Second {
+			t.Fatalf("took %v to give up on an idle stream; Wait would hang "+
+				"that long on a SIGKILLed exec", elapsed)
+		}
+	})
+
+	t.Run("reports runtime close", func(t *testing.T) {
+		var progress atomic.Uint64
+		drained := make(chan struct{})
+		closing := make(chan struct{})
+		close(closing)
+
+		if closed := waitForStreamDrain(drained, closing, &progress, 100*time.Millisecond, 30*time.Second); !closed {
+			t.Fatal("expected closed=true when the runtime is closing")
+		}
+	})
+
+	t.Run("falls back to hard cap when a pipe trickles forever", func(t *testing.T) {
+		var progress atomic.Uint64
+		drained := make(chan struct{})
+		closing := make(chan struct{})
+		stop := make(chan struct{})
+		defer close(stop)
+		// Bump within every idle window forever so only the hard cap fires.
+		go func() {
+			tick := time.NewTicker(20 * time.Millisecond)
+			defer tick.Stop()
+			for {
+				select {
+				case <-stop:
+					return
+				case <-tick.C:
+					progress.Add(1)
+				}
+			}
+		}()
+
+		start := time.Now()
+		closed := waitForStreamDrain(drained, closing, &progress, 100*time.Millisecond, 300*time.Millisecond)
+		elapsed := time.Since(start)
+
+		if closed {
+			t.Fatal("expected closed=false: hard cap, not runtime close")
+		}
+		if elapsed < 250*time.Millisecond || elapsed > 1500*time.Millisecond {
+			t.Fatalf("expected release near the 300ms hard cap, got %v", elapsed)
 		}
 	})
 }


### PR DESCRIPTION
Move per-execution stream output off the shared SDK drain goroutine onto an independent bounded queue so a slow consumer on one execution cannot stall output delivery for concurrent executions.

Test plan:
- [x] `go test ./...` (sdks/go) — CI pass (Go Tests, all 3 platforms)
- [x] `go test -tags boxlite_dev -run 'TestIntegrationExecDrainMatrix|TestIntegrationExecFullMatrix' ./...` (sdks/go)
- [x] `cargo check -p boxlite` — CI pass (Rust Tests, all 3 platforms)