### PR TITLE
docs(ci): add e2e-local CI runbook, de-stale workflow docs

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -161,51 +161,14 @@ is enabled. The workflow is dormant until repository variable
 
 ### `e2e-local.yml`
 
-Runs VM-based E2E integration tests on an ephemeral AWS EC2 self-hosted runner.
+Runs VM-based integration tests on a persistent, self-hosted AWS EC2 runner — GitHub-hosted
+runners can't expose `/dev/kvm`, which BoxLite's libkrun microVMs need. The instance is
+started before a run and stopped (not terminated) after, so caches persist. AWS auth is
+GitHub OIDC → STS; runner registration is a GitHub App. A pull request must carry the
+`e2e-local` label (the cost gate) to run.
 
-**Why:** GitHub-hosted runners (including larger paid runners) do not support `/dev/kvm`. BoxLite integration tests need real VMs via libkrun.
-
-**Architecture:** Three-job ephemeral pattern:
-1. `start-runner` (ubuntu-latest) — launches an AWS EC2 c8i.2xlarge instance, registers an ephemeral GitHub Actions runner
-2. `e2e-tests` (self-hosted) — builds runtime, runs all integration test suites
-3. `stop-runner` (ubuntu-latest, `if: always()`) — terminates instance, deregisters runner
-
-**Triggers:**
-- Push to `main` (path-filtered to `src/`, `sdks/`, `Cargo.*`)
-- Pull request with `e2e-local` label (cost-gated)
-- Manual dispatch (`workflow_dispatch`)
-
-**Cost:** ~$0.34/hr (c8i.2xlarge). Typical run: 15-25 min → ~$0.09-0.14 per run.
-
-**Safety mechanisms:**
-- `--ephemeral` runner auto-deregisters after one job
-- `if: always()` ensures cleanup on failure/cancellation
-- 45-minute self-destruct timer on the instance (EC2 self-termination)
-- Runner deregistration API call (belt-and-suspenders)
-- 35-minute job timeout prevents runaway tests
-- `instance-initiated-shutdown-behavior: terminate` auto-cleans on shutdown
-
-**Authentication:** GitHub OIDC → AWS STS (no stored AWS credentials).
-
-**Required secret:**
-- `GH_PAT` - GitHub PAT with `repo` scope (for runner registration API)
-
-**Required variables** (Settings → Variables → Actions):
-- `AWS_ACCOUNT_ID` - AWS account ID
-- `AWS_SUBNET_ID` - Subnet with auto-assign public IP
-- `AWS_SECURITY_GROUP_ID` - Security group allowing outbound HTTPS
-
-**Required AWS resources** (provisioned by `scripts/ci/setup-aws-oidc.sh`):
-- OIDC identity provider (`token.actions.githubusercontent.com`)
-- IAM role `boxlite-e2e-github-actions` with trust policy for this repo
-- IAM instance profile `boxlite-e2e-runner` with `ec2:TerminateInstances` on self
-- Subnet with internet access + security group (outbound 443)
-
-**Jobs:**
-1. `should-run` - Gate check (label present on PR?)
-2. `start-runner` - Launch EC2 c8i.2xlarge, register runner, wait for online
-3. `e2e-tests` - Build runtime, run Rust/CLI/Python/Node/C integration tests
-4. `stop-runner` - Terminate instance, deregister runner
+See the **[E2E Local CI runbook](../../docs/ci/e2e-local.md)** for the jobs, the instance,
+one-time provisioning (`scripts/ci/setup-ci-runner.sh`), and troubleshooting.
 
 ## Trigger Behavior
 
@@ -257,7 +220,7 @@ Additional platforms (darwin-x64, linux-arm64-gnu) can be added to `config.yml` 
 - `CARGO_REGISTRY_TOKEN` - crates.io API token for publishing Rust crates
 - `PYPI_API_TOKEN` - PyPI API token for publishing Python wheels
 - `NPM_TOKEN` - npm access token for publishing Node.js packages
-- `GH_PAT` - GitHub PAT with `repo` scope (for self-hosted runner registration)
+- `GH_APP_PRIVATE_KEY` - GitHub App private key for self-hosted E2E runner registration (see the [E2E Local CI runbook](../../docs/ci/e2e-local.md))
 
 Set these in repository Settings → Secrets and variables → Actions.
 

--- a/.github/workflows/e2e-local.yml
+++ b/.github/workflows/e2e-local.yml
@@ -7,19 +7,20 @@
 # Architecture:
 #   start-runner (ubuntu-latest)  →  e2e-tests (self-hosted)  →  stop-runner (ubuntu-latest)
 #     Start stopped EC2               Build + run tests             Stop EC2
-#     Wait for runner online           35-min timeout               if: always()
+#     Wait for runner online           50-min timeout               if: always()
 #
 # Concurrency: only ONE e2e run at a time (single persistent instance).
 # Queued runs wait; in-progress runs are cancelled by newer pushes.
 #
-# Cost: ~$0.17/hr (c8i.xlarge) only while running + ~$4/mo EBS storage.
+# Cost: c8i.4xlarge on-demand rate only while running + ~$4/mo EBS storage.
 # Subsequent runs skip setup/compilation (cached) → ~5-10 min → ~$0.03/run.
 #
 # Authentication:
 #   AWS: GitHub OIDC → AWS STS (no stored AWS credentials)
 #   GitHub: GitHub App → short-lived installation token (no PAT)
 #
-# Setup: ./scripts/ci/setup-ci-runner.sh
+# Setup:   ./scripts/ci/setup-ci-runner.sh
+# Runbook: docs/ci/e2e-local.md
 name: E2E local
 
 on:

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,10 @@
 
 ## Architecture
 
+## CI / Infrastructure
+
+- [E2E Local CI runbook](./ci/e2e-local.md) — VM-based integration tests on a self-hosted EC2 runner
+
 ## Contributing
 
 ## Legal

--- a/docs/ci/e2e-local.md
+++ b/docs/ci/e2e-local.md
@@ -1,0 +1,122 @@
+# E2E Local CI Runbook
+
+`e2e-local.yml` runs BoxLite's VM-based integration tests on a self-hosted AWS EC2
+runner. This is the operational reference for that workflow: how it runs, how it is
+provisioned, and how to fix it when it breaks.
+
+## Overview
+
+GitHub-hosted runners cannot expose `/dev/kvm`, so BoxLite's integration tests — which boot
+real microVMs through libkrun — only run on hardware that allows nested virtualization. The
+workflow keeps a single **persistent** EC2 instance for this: it is started before a run,
+runs the tests, then is **stopped** (never terminated) so its build and image caches survive
+on the EBS volume. Because there is exactly one instance, only one e2e run executes at a
+time — a newer run cancels an older queued one.
+
+## How it runs
+
+The workflow is four jobs:
+
+```mermaid
+flowchart LR
+  gate["should-run (label gate)"] --> start["start-runner (boot EC2)"]
+  start --> tests["e2e-tests (integration tests)"]
+  tests --> stop["stop-runner (stop EC2)"]
+```
+
+- **should-run** — decides whether to run. Pushes and manual dispatches always run; a pull
+  request runs only when a maintainer adds the `e2e-local` label.
+- **start-runner** — authenticates to AWS, starts the stopped instance (or creates one if
+  none exists), and waits up to 3 minutes for the self-hosted runner to come online.
+- **e2e-tests** — runs on the self-hosted runner (`boxlite-e2e` label, 50-minute timeout):
+  verifies `/dev/kvm`, installs build dependencies, then runs `make test:integration`.
+- **stop-runner** — always runs at the end and stops the instance so it stops costing money.
+
+### Triggers
+
+- Push to `main` touching runtime code (`src/boxlite`, `src/shared`, `src/cli`, `src/guest`,
+  `sdks/**`, any `Cargo.toml`, `Cargo.lock`, or the workflow file itself).
+- A pull request labeled `e2e-local` — the label is the cost gate, and only maintainers can
+  add it.
+- Manual `workflow_dispatch`, with an optional `debug` input that opens an SSH session if the
+  tests fail.
+
+## Instance & auth
+
+| Property | Value |
+|---|---|
+| Instance type | `c8i.4xlarge` (nested virtualization enabled) |
+| AMI / region | `ami-05cf1e9f73fbad2e2` / `us-east-1` |
+| Runner label | `boxlite-e2e` |
+| Lifecycle | persistent — stopped between runs, never terminated |
+| Storage | gp3 root volume kept across runs; holds `~/.cargo`, `target/`, and `~/.boxlite` caches |
+
+Keeping the instance warm is what makes repeat runs fast: the first run on a fresh instance
+compiles everything (~5–10 minutes of setup), and later runs reuse the cached toolchain and
+build output. Cost is roughly the `c8i.4xlarge` on-demand rate while a run is in progress,
+plus a few dollars a month for the persistent EBS volume — check the current `us-east-1` rate
+before quoting a figure.
+
+Authentication uses no long-lived secrets:
+
+- **AWS** — GitHub OIDC is exchanged for short-lived STS credentials via the
+  `boxlite-e2e-github-actions` IAM role. No AWS keys are stored in the repo.
+- **GitHub** — a GitHub App (`boxlite-e2e-runner`) mints the runner registration token at
+  run time. There is no personal access token.
+
+## One-time setup
+
+All AWS and GitHub infrastructure is provisioned by one script:
+
+```bash
+./scripts/ci/setup-ci-runner.sh
+```
+
+It auto-detects the AWS account, repository, default VPC, and public subnets, and is
+idempotent — re-running it reconciles existing resources. Use `--skip-github` to provision
+only the AWS side, or `--region` / `--vpc-id` / `--subnet-id` to override discovery.
+
+It creates these AWS resources:
+
+| Resource | Purpose |
+|---|---|
+| OIDC provider `token.actions.githubusercontent.com` | lets GitHub Actions assume an AWS role |
+| IAM role `boxlite-e2e-github-actions` | what the workflow assumes (EC2 start/stop/run + pass-role) |
+| IAM role + instance profile `boxlite-e2e-runner` | what the EC2 instance runs as |
+| Security group `boxlite-e2e-runner` | outbound 443/80 only |
+
+And sets these on the repository:
+
+| Variables | Secret |
+|---|---|
+| `AWS_ACCOUNT_ID`, `AWS_SUBNET_IDS`, `AWS_SECURITY_GROUP_ID`, `GH_APP_ID`, `EC2_E2E_INSTANCE_ID` | `GH_APP_PRIVATE_KEY` |
+
+The GitHub App is created through a browser manifest flow the script drives — follow its
+prompts to confirm and install the app. `EC2_E2E_INSTANCE_ID` is written automatically the
+first time an instance is created, so later runs find it directly.
+
+When setup finishes, trigger a run with:
+
+```bash
+gh workflow run e2e-local.yml
+```
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `start-runner` times out waiting for the runner to come online | the instance booted but the runner service did not register | inspect the instance's runner logs; re-run the workflow to retry registration |
+| Launch fails with `InsufficientInstanceCapacity` | the AZ is out of `c8i.4xlarge` capacity | none needed — the launch loop already retries every subnet/AZ; re-run if all were exhausted |
+| `e2e-tests` fails on low disk | `target/` build artifacts filled the volume | the job evicts caches at 80% use and refuses below 20 GB free; if it still fails, free space on the instance manually |
+| A run can't find the instance, or targets the wrong one | `EC2_E2E_INSTANCE_ID` is stale | it self-heals via the `Name=boxlite-e2e` tag; clear the variable to force rediscovery |
+| A pull request doesn't trigger the workflow | the `e2e-local` label is missing | a maintainer adds the label (it is the cost gate) |
+
+For an interactive session, dispatch the workflow with `debug: true`; on failure it opens a
+tmate SSH session and leaves the instance running (it auto-stops after 30 minutes idle).
+
+## References
+
+- Workflow: [`.github/workflows/e2e-local.yml`](../../.github/workflows/e2e-local.yml)
+- Provisioning script: [`scripts/ci/setup-ci-runner.sh`](../../scripts/ci/setup-ci-runner.sh)
+- Build-dependency setup: [`scripts/setup/setup-ubuntu.sh`](../../scripts/setup/setup-ubuntu.sh)
+- CI overview: [`.github/workflows/README.md`](../../.github/workflows/README.md)


### PR DESCRIPTION
## Summary

Adds an operational runbook for the `e2e-local.yml` CI workflow and collapses the stale, contradictory documentation around it into a single source of truth.

`e2e-local.yml` runs BoxLite's VM-based integration tests on a persistent self-hosted AWS EC2 runner (GitHub-hosted runners can't expose `/dev/kvm`, which libkrun microVMs need). It had no dedicated doc, and its only writeup — the `### e2e-local.yml` section in `.github/workflows/README.md` — had drifted badly, contradicting the workflow on nearly every concrete fact.

## Changes

- **New `docs/ci/e2e-local.md`** — runbook: overview, how it runs (jobs + triggers), instance & auth (OIDC → STS for AWS, GitHub App for runner registration), one-time setup via `scripts/ci/setup-ci-runner.sh`, and troubleshooting.
- **`.github/workflows/README.md`** — replaced the stale `e2e-local.yml` section with a short summary + link; fixed the orphaned `GH_PAT` secret reference (registration is a GitHub App: `GH_APP_PRIVATE_KEY`).
- **`.github/workflows/e2e-local.yml`** — comment-only: fixed the header's instance type (`c8i.xlarge` → `c8i.4xlarge`), timeout (`35` → `50` min), and cost line; added a `# Runbook:` pointer.
- **`docs/README.md`** — indexed the runbook under a new *CI / Infrastructure* section.

## Drift corrected (was documented 3+ ways)

| Was | Now |
|---|---|
| instance `c8i.2xlarge` / `c8i.xlarge` | `c8i.4xlarge` |
| "ephemeral / terminate / deregister" | persistent — stopped, never terminated |
| secret `GH_PAT` | GitHub App (`GH_APP_ID` + `GH_APP_PRIVATE_KEY`) |
| `scripts/ci/setup-aws-oidc.sh` | `scripts/ci/setup-ci-runner.sh` |

## Verification

- `git grep` for `GH_PAT` / `setup-aws-oidc` / `c8i.2xlarge` / `c8i.xlarge` across `.github` + `docs` → none remain
- All runbook + pointer links resolve to real files
- `e2e-local.yml` diff is comment-only (zero behavior change)
- Every concrete value sourced from the workflow or `setup-ci-runner.sh`; cost left as "check current rate" rather than a stale number

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CI workflow documentation for E2E Local testing infrastructure.
  * Added comprehensive E2E Local CI runbook with setup and troubleshooting guidance.

* **Chores**
  * Updated workflow configurations and runner architecture documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->