### PR TITLE
feat(deploy): enable prod stage via the lite deploy flow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,10 @@
 # One-click deploy button (MVP "lite+" — manual, reviewable, no static AWS keys).
 #
-# Pick a stage + diff|deploy. Auth = GitHub OIDC -> boxlite-app-<stage>-deploy.
+# Flow: dispatch -> [plan job: sst diff to Step Summary] -> [apply job: sst deploy,
+# gated by the stage's GitHub Environment]. plan always runs; apply only after the
+# environment's protection rules pass (e.g. prod's required reviewers). Auth =
+# GitHub OIDC -> boxlite-app-<stage>-deploy.
+#
 # Runs `npm run <sst|deploy>` in apps/infra; sst-with-cloudflare.mjs injects the
 # stage's Cloudflare creds + full env config from SSM (/boxlite/<stage>/{cloudflare-*,env/*}),
 # so CI has the same config a laptop's .env provides. No secrets in the repo.
@@ -23,9 +27,11 @@
 #      login cannot iam:CreateRole (verified 2026-06-22).
 #   2. boxlite-bounded-role-admin must allow PassRole + AddRoleToInstanceProfile on
 #      role/boxlite-<stage>-* (today it lists only boxlite-dev-* / boxlite-e2e-*).
-#   3. GitHub Environment named <stage> (this job's `environment:` gate).
+#   3. GitHub Environment named <stage> (the apply job's `environment:` gate).
+#      For prod, enable Required reviewers on env=prod so apply pauses for human
+#      approval after the plan job's diff is visible in the Step Summary.
 #   4. SSM seeded: /boxlite/<stage>/{cloudflare-*, env/*} (env via seed-prod-from-dev.mjs).
-#   5. `region` input set to the stage's region (dev = ap-southeast-1).
+#   5. `region` input set to the stage's region (dev = ap-southeast-1, prod = us-west-2).
 # ─────────────────────────────────────────────────────────────────────────────
 name: Deploy
 
@@ -37,13 +43,8 @@ on:
         type: choice
         options: [dev, prod]
         default: dev
-      mode:
-        description: diff (read-only preview) or deploy (apply)
-        type: choice
-        options: [diff, deploy]
-        default: diff
       region:
-        description: AWS region (dev lives in ap-southeast-1; a new stage may pick another)
+        description: AWS region (dev = ap-southeast-1, prod = us-west-2)
         type: choice
         options: [ap-southeast-1, us-east-1, us-west-2, eu-west-1, eu-central-1, ap-northeast-1]
         default: ap-southeast-1
@@ -57,12 +58,53 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  deploy:
+  plan:
+    name: Plan (sst diff)
     runs-on: ubuntu-latest
-    # GitHub Environment per stage — gates the deploy behind that environment's
-    # protection rules (required reviewers, branch restrictions). A `prod`
-    # environment must exist before a prod deploy runs; absence fails fast, which
-    # is the intended guard against an unconfigured prod deploy.
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+
+      - name: Assume AWS deploy role (GitHub OIDC, no static keys)
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        with:
+          role-to-assume: arn:aws:iam::064212132677:role/boxlite-app-${{ inputs.stage }}-deploy
+          aws-region: ${{ inputs.region }}
+          role-session-name: deploy-plan-${{ inputs.stage }}-${{ github.run_id }}
+
+      - name: Install infra deps
+        working-directory: apps/infra
+        run: npm install
+
+      - name: sst diff (read-only) → Step Summary
+        working-directory: apps/infra
+        run: |
+          set -o pipefail
+          {
+            echo "## sst diff"
+            echo ""
+            echo "- stage: \`${{ inputs.stage }}\`"
+            echo "- region: \`${{ inputs.region }}\`"
+            echo "- ref: \`${{ github.sha }}\`"
+            echo ""
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          npm run sst -- diff --stage ${{ inputs.stage }} 2>&1 | tee -a "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+  apply:
+    name: Apply (sst deploy)
+    needs: plan
+    runs-on: ubuntu-latest
+    # GitHub Environment per stage gates apply behind that environment's
+    # protection rules. Approvers see the plan job's Step Summary diff before
+    # approving. Prod MUST have Required reviewers configured for this to be a
+    # real gate; dev runs through automatically (no reviewers on env=dev).
     environment: ${{ inputs.stage }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -76,24 +118,14 @@ jobs:
       - name: Assume AWS deploy role (GitHub OIDC, no static keys)
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
-          # Per-stage role: boxlite-app-dev-deploy / boxlite-app-prod-deploy.
           role-to-assume: arn:aws:iam::064212132677:role/boxlite-app-${{ inputs.stage }}-deploy
-          # Exports AWS_REGION/AWS_DEFAULT_REGION to later steps; sst.config.ts + the
-          # SSM helpers read AWS_REGION, so the whole deploy targets this region.
           aws-region: ${{ inputs.region }}
+          role-session-name: deploy-apply-${{ inputs.stage }}-${{ github.run_id }}
 
-      # apps/infra is a standalone npm project; package-lock.json is gitignored,
-      # so use `npm install` (not `npm ci`) on a fresh checkout.
       - name: Install infra deps
         working-directory: apps/infra
         run: npm install
 
-      - name: sst diff (read-only)
-        if: ${{ inputs.mode == 'diff' }}
-        working-directory: apps/infra
-        run: npm run sst -- diff --stage ${{ inputs.stage }}
-
       - name: sst deploy
-        if: ${{ inputs.mode == 'deploy' }}
         working-directory: apps/infra
         run: npm run deploy -- --stage ${{ inputs.stage }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,16 +47,16 @@ jobs:
     runs-on: ubuntu-latest
     environment: dev
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
 
       - name: Assume AWS deploy role (GitHub OIDC, no static keys)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: arn:aws:iam::064212132677:role/boxlite-github-deployer-${{ inputs.stage }}
           aws-region: ap-southeast-1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,6 +48,8 @@ jobs:
     environment: dev
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,76 @@
+# One-click deploy button (MVP "lite+" — manual, reviewable, no static AWS keys).
+#
+# Pick a stage + diff|deploy. Auth = GitHub OIDC -> boxlite-github-deployer-<stage>.
+# Runs `npm run <sst|deploy>` in apps/infra; sst-with-cloudflare.mjs injects the
+# stage's Cloudflare creds + full env config from SSM (/boxlite/<stage>/{cloudflare-*,env/*}),
+# so CI has the same config a laptop's .env provides. No secrets in the repo.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# VALIDATED 2026-06-22: a real `deploy --stage dev` completes end-to-end via OIDC.
+#   ✅ OIDC assume of boxlite-github-deployer-dev (boxlite-bounded-role-admin +
+#      IAMReadOnlyAccess + PowerUserAccess) — can create/manage boxlite-* roles.
+#   ✅ env parity from SSM; 4 images build; sst deploy applies to completion.
+#   ✅ dev healthy after: all services running, ALBs active, api/dashboard 200,
+#      box create → runner krun VM verified.
+# One-time admin setup (account owner): boxlite-github-deployer-<stage> carries
+#   boxlite-bounded-role-admin (CreateRole / PutRolePermissionsBoundary / PassRole on
+#   boxlite-*, conditioned on iam:PermissionsBoundary == boxlite-role-boundary) +
+#   IAMReadOnlyAccess. The $transform in sst.config.ts stamps boxlite-role-boundary on
+#   every role this app creates, satisfying that conditional grant.
+# ─────────────────────────────────────────────────────────────────────────────
+name: Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      stage:
+        description: Stage to deploy
+        type: choice
+        options: [dev]
+        default: dev
+      mode:
+        description: diff (read-only preview) or deploy (apply)
+        type: choice
+        options: [diff, deploy]
+        default: diff
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: deploy-${{ inputs.stage }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: dev
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Assume AWS deploy role (GitHub OIDC, no static keys)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::064212132677:role/boxlite-github-deployer-${{ inputs.stage }}
+          aws-region: ap-southeast-1
+
+      # apps/infra is a standalone npm project; package-lock.json is gitignored,
+      # so use `npm install` (not `npm ci`) on a fresh checkout.
+      - name: Install infra deps
+        working-directory: apps/infra
+        run: npm install
+
+      - name: sst diff (read-only)
+        if: ${{ inputs.mode == 'diff' }}
+        working-directory: apps/infra
+        run: npm run sst -- diff --stage ${{ inputs.stage }}
+
+      - name: sst deploy
+        if: ${{ inputs.mode == 'deploy' }}
+        working-directory: apps/infra
+        run: npm run deploy -- --stage ${{ inputs.stage }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,10 +1,6 @@
 # One-click deploy button (MVP "lite+" — manual, reviewable, no static AWS keys).
 #
-# Flow: dispatch -> [plan job: sst diff to Step Summary] -> [apply job: sst deploy,
-# gated by the stage's GitHub Environment]. plan always runs; apply only after the
-# environment's protection rules pass (e.g. prod's required reviewers). Auth =
-# GitHub OIDC -> boxlite-app-<stage>-deploy.
-#
+# Pick a stage + diff|deploy. Auth = GitHub OIDC -> boxlite-app-<stage>-deploy.
 # Runs `npm run <sst|deploy>` in apps/infra; sst-with-cloudflare.mjs injects the
 # stage's Cloudflare creds + full env config from SSM (/boxlite/<stage>/{cloudflare-*,env/*}),
 # so CI has the same config a laptop's .env provides. No secrets in the repo.
@@ -27,11 +23,9 @@
 #      login cannot iam:CreateRole (verified 2026-06-22).
 #   2. boxlite-bounded-role-admin must allow PassRole + AddRoleToInstanceProfile on
 #      role/boxlite-<stage>-* (today it lists only boxlite-dev-* / boxlite-e2e-*).
-#   3. GitHub Environment named <stage> (the apply job's `environment:` gate).
-#      For prod, enable Required reviewers on env=prod so apply pauses for human
-#      approval after the plan job's diff is visible in the Step Summary.
+#   3. GitHub Environment named <stage> (this job's `environment:` gate).
 #   4. SSM seeded: /boxlite/<stage>/{cloudflare-*, env/*} (env via seed-prod-from-dev.mjs).
-#   5. `region` input set to the stage's region (dev = ap-southeast-1, prod = us-west-2).
+#   5. `region` input set to the stage's region (dev = ap-southeast-1).
 # ─────────────────────────────────────────────────────────────────────────────
 name: Deploy
 
@@ -43,8 +37,13 @@ on:
         type: choice
         options: [dev, prod]
         default: dev
+      mode:
+        description: diff (read-only preview) or deploy (apply)
+        type: choice
+        options: [diff, deploy]
+        default: diff
       region:
-        description: AWS region (dev = ap-southeast-1, prod = us-west-2)
+        description: AWS region (dev lives in ap-southeast-1; a new stage may pick another)
         type: choice
         options: [ap-southeast-1, us-east-1, us-west-2, eu-west-1, eu-central-1, ap-northeast-1]
         default: ap-southeast-1
@@ -58,53 +57,12 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  plan:
-    name: Plan (sst diff)
+  deploy:
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          persist-credentials: false
-
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: 22
-
-      - name: Assume AWS deploy role (GitHub OIDC, no static keys)
-        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
-        with:
-          role-to-assume: arn:aws:iam::064212132677:role/boxlite-app-${{ inputs.stage }}-deploy
-          aws-region: ${{ inputs.region }}
-          role-session-name: deploy-plan-${{ inputs.stage }}-${{ github.run_id }}
-
-      - name: Install infra deps
-        working-directory: apps/infra
-        run: npm install
-
-      - name: sst diff (read-only) → Step Summary
-        working-directory: apps/infra
-        run: |
-          set -o pipefail
-          {
-            echo "## sst diff"
-            echo ""
-            echo "- stage: \`${{ inputs.stage }}\`"
-            echo "- region: \`${{ inputs.region }}\`"
-            echo "- ref: \`${{ github.sha }}\`"
-            echo ""
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
-          npm run sst -- diff --stage ${{ inputs.stage }} 2>&1 | tee -a "$GITHUB_STEP_SUMMARY"
-          echo '```' >> "$GITHUB_STEP_SUMMARY"
-
-  apply:
-    name: Apply (sst deploy)
-    needs: plan
-    runs-on: ubuntu-latest
-    # GitHub Environment per stage gates apply behind that environment's
-    # protection rules. Approvers see the plan job's Step Summary diff before
-    # approving. Prod MUST have Required reviewers configured for this to be a
-    # real gate; dev runs through automatically (no reviewers on env=dev).
+    # GitHub Environment per stage — gates the deploy behind that environment's
+    # protection rules (required reviewers, branch restrictions). A `prod`
+    # environment must exist before a prod deploy runs; absence fails fast, which
+    # is the intended guard against an unconfigured prod deploy.
     environment: ${{ inputs.stage }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -118,14 +76,24 @@ jobs:
       - name: Assume AWS deploy role (GitHub OIDC, no static keys)
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
+          # Per-stage role: boxlite-app-dev-deploy / boxlite-app-prod-deploy.
           role-to-assume: arn:aws:iam::064212132677:role/boxlite-app-${{ inputs.stage }}-deploy
+          # Exports AWS_REGION/AWS_DEFAULT_REGION to later steps; sst.config.ts + the
+          # SSM helpers read AWS_REGION, so the whole deploy targets this region.
           aws-region: ${{ inputs.region }}
-          role-session-name: deploy-apply-${{ inputs.stage }}-${{ github.run_id }}
 
+      # apps/infra is a standalone npm project; package-lock.json is gitignored,
+      # so use `npm install` (not `npm ci`) on a fresh checkout.
       - name: Install infra deps
         working-directory: apps/infra
         run: npm install
 
+      - name: sst diff (read-only)
+        if: ${{ inputs.mode == 'diff' }}
+        working-directory: apps/infra
+        run: npm run sst -- diff --stage ${{ inputs.stage }}
+
       - name: sst deploy
+        if: ${{ inputs.mode == 'deploy' }}
         working-directory: apps/infra
         run: npm run deploy -- --stage ${{ inputs.stage }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,22 +1,31 @@
 # One-click deploy button (MVP "lite+" — manual, reviewable, no static AWS keys).
 #
-# Pick a stage + diff|deploy. Auth = GitHub OIDC -> boxlite-github-deployer-<stage>.
+# Pick a stage + diff|deploy. Auth = GitHub OIDC -> boxlite-app-<stage>-deploy.
 # Runs `npm run <sst|deploy>` in apps/infra; sst-with-cloudflare.mjs injects the
 # stage's Cloudflare creds + full env config from SSM (/boxlite/<stage>/{cloudflare-*,env/*}),
 # so CI has the same config a laptop's .env provides. No secrets in the repo.
 #
 # ─────────────────────────────────────────────────────────────────────────────
-# VALIDATED 2026-06-22: a real `deploy --stage dev` completes end-to-end via OIDC.
-#   ✅ OIDC assume of boxlite-github-deployer-dev (boxlite-bounded-role-admin +
-#      IAMReadOnlyAccess + PowerUserAccess) — can create/manage boxlite-* roles.
+# VALIDATED 2026-06-22: a real `deploy --stage dev` completes end-to-end via OIDC
+#   (validated under the role's former name boxlite-github-deployer-dev; the role is
+#   being renamed to boxlite-app-dev-deploy — see prerequisites below).
 #   ✅ env parity from SSM; 4 images build; sst deploy applies to completion.
 #   ✅ dev healthy after: all services running, ALBs active, api/dashboard 200,
 #      box create → runner krun VM verified.
-# One-time admin setup (account owner): boxlite-github-deployer-<stage> carries
-#   boxlite-bounded-role-admin (CreateRole / PutRolePermissionsBoundary / PassRole on
-#   boxlite-*, conditioned on iam:PermissionsBoundary == boxlite-role-boundary) +
-#   IAMReadOnlyAccess. The $transform in sst.config.ts stamps boxlite-role-boundary on
-#   every role this app creates, satisfying that conditional grant.
+# The deploy role boxlite-app-<stage>-deploy (admin, created by the account owner and
+#   NOT bounded) carries boxlite-bounded-role-admin + IAMReadOnlyAccess + PowerUserAccess,
+#   so it can create/manage boxlite-* roles. The $transform in sst.config.ts stamps
+#   boxlite-role-boundary on every role this app creates, satisfying that grant.
+#
+# Per-stage prerequisites before a stage is selectable here (e.g. prod):
+#   1. IAM role boxlite-app-dev-deploy / boxlite-app-prod-deploy (admin, unbounded;
+#      trust sub = environment:<stage>). Created by the account owner — a PowerUser SSO
+#      login cannot iam:CreateRole (verified 2026-06-22).
+#   2. boxlite-bounded-role-admin must allow PassRole + AddRoleToInstanceProfile on
+#      role/boxlite-<stage>-* (today it lists only boxlite-dev-* / boxlite-e2e-*).
+#   3. GitHub Environment named <stage> (this job's `environment:` gate).
+#   4. SSM seeded: /boxlite/<stage>/{cloudflare-*, env/*} (env via seed-prod-from-dev.mjs).
+#   5. `region` input set to the stage's region (dev = ap-southeast-1).
 # ─────────────────────────────────────────────────────────────────────────────
 name: Deploy
 
@@ -26,13 +35,18 @@ on:
       stage:
         description: Stage to deploy
         type: choice
-        options: [dev]
+        options: [dev, prod]
         default: dev
       mode:
         description: diff (read-only preview) or deploy (apply)
         type: choice
         options: [diff, deploy]
         default: diff
+      region:
+        description: AWS region (dev lives in ap-southeast-1; a new stage may pick another)
+        type: choice
+        options: [ap-southeast-1, us-east-1, us-west-2, eu-west-1, eu-central-1, ap-northeast-1]
+        default: ap-southeast-1
 
 permissions:
   id-token: write
@@ -45,7 +59,11 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    environment: dev
+    # GitHub Environment per stage — gates the deploy behind that environment's
+    # protection rules (required reviewers, branch restrictions). A `prod`
+    # environment must exist before a prod deploy runs; absence fails fast, which
+    # is the intended guard against an unconfigured prod deploy.
+    environment: ${{ inputs.stage }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
@@ -58,8 +76,11 @@ jobs:
       - name: Assume AWS deploy role (GitHub OIDC, no static keys)
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
-          role-to-assume: arn:aws:iam::064212132677:role/boxlite-github-deployer-${{ inputs.stage }}
-          aws-region: ap-southeast-1
+          # Per-stage role: boxlite-app-dev-deploy / boxlite-app-prod-deploy.
+          role-to-assume: arn:aws:iam::064212132677:role/boxlite-app-${{ inputs.stage }}-deploy
+          # Exports AWS_REGION/AWS_DEFAULT_REGION to later steps; sst.config.ts + the
+          # SSM helpers read AWS_REGION, so the whole deploy targets this region.
+          aws-region: ${{ inputs.region }}
 
       # apps/infra is a standalone npm project; package-lock.json is gitignored,
       # so use `npm install` (not `npm ci`) on a fresh checkout.

--- a/.github/workflows/runner-rollout.yml
+++ b/.github/workflows/runner-rollout.yml
@@ -80,6 +80,7 @@ jobs:
     name: Roll out runner
     needs: config
     runs-on: ubuntu-latest
+    environment: ${{ inputs.stage || 'dev' }}
     steps:
       - name: Resolve inputs (defaults make push-triggered runs sane)
         id: in
@@ -110,6 +111,12 @@ jobs:
         if: ${{ steps.in.outputs.mode == 'rollback' && steps.in.outputs.source != 'release' }}
         run: |
           echo "::error::rollback mode requires source=release with the target version in 'ref'"
+          exit 1
+
+      - name: Guard — prod installs releases only
+        if: ${{ steps.in.outputs.stage == 'prod' && steps.in.outputs.source != 'release' }}
+        run: |
+          echo "::error::prod runner rollout only supports source=release"
           exit 1
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/.github/workflows/runner-rollout.yml
+++ b/.github/workflows/runner-rollout.yml
@@ -84,11 +84,19 @@ jobs:
           IN_REF: ${{ inputs.ref }}
           IN_INSTANCE_ID: ${{ inputs.instance_id }}
         run: |
-          echo "stage=$IN_STAGE"             >> "$GITHUB_OUTPUT"
-          echo "source=$IN_SOURCE"           >> "$GITHUB_OUTPUT"
-          echo "mode=$IN_MODE"               >> "$GITHUB_OUTPUT"
-          echo "ref=$IN_REF"                 >> "$GITHUB_OUTPUT"
-          echo "instance_id=$IN_INSTANCE_ID" >> "$GITHUB_OUTPUT"
+          echo "stage=$IN_STAGE"   >> "$GITHUB_OUTPUT"
+          echo "source=$IN_SOURCE" >> "$GITHUB_OUTPUT"
+          echo "mode=$IN_MODE"     >> "$GITHUB_OUTPUT"
+          # ref / instance_id are free-text: write via heredoc delimiters so a value
+          # containing newlines can't inject extra GITHUB_OUTPUT keys.
+          {
+            echo "ref<<__BL_REF__"
+            echo "$IN_REF"
+            echo "__BL_REF__"
+            echo "instance_id<<__BL_IID__"
+            echo "$IN_INSTANCE_ID"
+            echo "__BL_IID__"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Guard — rollback requires a release version
         if: ${{ steps.in.outputs.mode == 'rollback' && steps.in.outputs.source != 'release' }}
@@ -96,7 +104,7 @@ jobs:
           echo "::error::rollback mode requires source=release with the target version in 'ref'"
           exit 1
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ (steps.in.outputs.source == 'dev-build' && steps.in.outputs.ref != '') && steps.in.outputs.ref || github.ref }}
           persist-credentials: false
@@ -110,7 +118,7 @@ jobs:
       # decoupling the build source from the runner-update-binary.sh version is TODO.
       - name: Set up Go
         if: ${{ steps.in.outputs.source == 'dev-build' }}
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: ${{ needs.config.outputs.go-version }}
 
@@ -195,7 +203,7 @@ jobs:
 
       # ── stage + roll out ──────────────────────────────────────────────────
       - name: Assume AWS deploy role (GitHub OIDC, no static keys)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: arn:aws:iam::064212132677:role/boxlite-github-deployer-${{ steps.in.outputs.stage }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/runner-rollout.yml
+++ b/.github/workflows/runner-rollout.yml
@@ -8,7 +8,7 @@
 #   release   : install an already-published version (e.g. 0.9.5) from GitHub
 #               Releases. This is the only source allowed for prod.
 #
-# Auth = GitHub OIDC -> boxlite-github-deployer-<stage> (same role as Deploy).
+# Auth = GitHub OIDC -> boxlite-app-<stage>-deploy (same role as Deploy).
 # The actual swap + integrity check + auto-rollback lives in
 # scripts/deploy/runner-update-binary.sh; this workflow only builds + stages the
 # artifact and hands the script a URL.
@@ -31,8 +31,13 @@ on:
       stage:
         description: Stage
         type: choice
-        options: [dev]
+        options: [dev, prod]
         default: dev
+      region:
+        description: AWS region the runner lives in (dev = ap-southeast-1)
+        type: choice
+        options: [ap-southeast-1, us-east-1, us-west-2, eu-west-1, eu-central-1, ap-northeast-1]
+        default: ap-southeast-1
       source:
         description: dev-build (build the ref now) or release (install a published version)
         type: choice
@@ -48,7 +53,7 @@ on:
         options: [upgrade, rollback]
         default: upgrade
       instance_id:
-        description: "Pin a specific runner instance id (blank = find boxlite-runner-default by tag)"
+        description: "Pin a specific runner instance id (blank = find boxlite-<stage>-runner-default by tag)"
         type: string
         default: ""
 
@@ -61,8 +66,11 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  AWS_REGION: ap-southeast-1
-  S3_BUCKET: boxlite-dev-runner-builds
+  # Stage-scoped so dev and prod don't collide. The S3 bucket only backs the
+  # dev-build source (release source pulls from GitHub Releases, never S3), and
+  # prod refuses dev-build (runner-update-binary.sh), so a prod run never touches it.
+  AWS_REGION: ${{ inputs.region || 'ap-southeast-1' }}
+  S3_BUCKET: boxlite-${{ inputs.stage || 'dev' }}-runner-builds
 
 jobs:
   config:
@@ -205,7 +213,8 @@ jobs:
       - name: Assume AWS deploy role (GitHub OIDC, no static keys)
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
-          role-to-assume: arn:aws:iam::064212132677:role/boxlite-github-deployer-${{ steps.in.outputs.stage }}
+          # Per-stage role: boxlite-app-dev-deploy / boxlite-app-prod-deploy
+          role-to-assume: arn:aws:iam::064212132677:role/boxlite-app-${{ steps.in.outputs.stage }}-deploy
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Upload dev build to S3 + presign

--- a/.github/workflows/runner-rollout.yml
+++ b/.github/workflows/runner-rollout.yml
@@ -1,0 +1,224 @@
+# Runner Rollout button (MVP "lite+" — manual, reviewable, no static AWS keys).
+#
+# Replaces the boxlite-runner binary on the live Runner EC2 in-place, via SSM.
+# Two sources:
+#   dev-build : build the runner from a branch/commit RIGHT HERE, upload to S3,
+#               and install it — lets you test an unreleased runner change without
+#               cutting a formal release (the "dev channel"). dev/staging only.
+#   release   : install an already-published version (e.g. 0.9.5) from GitHub
+#               Releases. This is the only source allowed for prod.
+#
+# Auth = GitHub OIDC -> boxlite-github-deployer-<stage> (same role as Deploy).
+# The actual swap + integrity check + auto-rollback lives in
+# scripts/deploy/runner-update-binary.sh; this workflow only builds + stages the
+# artifact and hands the script a URL.
+#
+# Inputs are resolved once (with defaults) so the workflow also runs sensibly if
+# triggered without dispatch inputs (e.g. a temporary push trigger during testing).
+#
+# Env vars passed to the script use the BOXLITE_RUNNER_ prefix (NOT RUNNER_):
+# GitHub Actions reserves the RUNNER_ prefix and drops step env vars named RUNNER_*
+# — validated 2026-06-20, that was why the dev-channel never received its tarball
+# URL / instance id.
+#
+# ⚠️ Rolling the binary RESTARTS the runner's systemd unit — boxes running on that
+#    EC2 are interrupted. Box state under /var/lib/boxlite is preserved.
+name: Runner Rollout
+
+on:
+  workflow_dispatch:
+    inputs:
+      stage:
+        description: Stage
+        type: choice
+        options: [dev]
+        default: dev
+      source:
+        description: dev-build (build the ref now) or release (install a published version)
+        type: choice
+        options: [dev-build, release]
+        default: dev-build
+      ref:
+        description: "dev-build: branch/commit to build (blank = this ref). release: version e.g. 0.9.5"
+        type: string
+        default: ""
+      mode:
+        description: "upgrade, or rollback (install an older release — requires source=release)"
+        type: choice
+        options: [upgrade, rollback]
+        default: upgrade
+      instance_id:
+        description: "Pin a specific runner instance id (blank = find boxlite-runner-default by tag)"
+        type: string
+        default: ""
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: runner-rollout-${{ inputs.stage || 'dev' }}
+  cancel-in-progress: false
+
+env:
+  AWS_REGION: ap-southeast-1
+  S3_BUCKET: boxlite-dev-runner-builds
+
+jobs:
+  config:
+    uses: ./.github/workflows/config.yml
+
+  rollout:
+    name: Roll out runner
+    needs: config
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve inputs (defaults make push-triggered runs sane)
+        id: in
+        run: |
+          echo "stage=${{ inputs.stage || 'dev' }}"        >> "$GITHUB_OUTPUT"
+          echo "source=${{ inputs.source || 'dev-build' }}" >> "$GITHUB_OUTPUT"
+          echo "mode=${{ inputs.mode || 'upgrade' }}"       >> "$GITHUB_OUTPUT"
+          echo "ref=${{ inputs.ref }}"                      >> "$GITHUB_OUTPUT"
+          echo "instance_id=${{ inputs.instance_id }}"      >> "$GITHUB_OUTPUT"
+
+      - name: Guard — rollback requires a release version
+        if: ${{ steps.in.outputs.mode == 'rollback' && steps.in.outputs.source != 'release' }}
+        run: |
+          echo "::error::rollback mode requires source=release with the target version in 'ref'"
+          exit 1
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ (steps.in.outputs.source == 'dev-build' && steps.in.outputs.ref != '') && steps.in.outputs.ref || github.ref }}
+
+      # ── dev-build: build the runner binary from this checkout ──────────────
+      # Faithful copy of build-runner-binary.yml's build recipe (could become a
+      # shared composite action later); the additions here are staging to S3 + SSM.
+      #
+      # NOTE: the checkout ref drives BOTH the build source AND this script. Building
+      # an ahead-of-release commit needs libboxlite.a built from source (see below);
+      # decoupling the build source from the runner-update-binary.sh version is TODO.
+      - name: Set up Go
+        if: ${{ steps.in.outputs.source == 'dev-build' }}
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ needs.config.outputs.go-version }}
+
+      - name: Install system dependencies
+        if: ${{ steps.in.outputs.source == 'dev-build' }}
+        run: sudo apt-get update && sudo apt-get install -y libx11-dev libxtst-dev libxinerama-dev
+
+      - name: Determine version + sha
+        id: version
+        run: |
+          VERSION=$(grep '^version = ' Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      # KNOWN LIMITATION: this downloads the RELEASED libboxlite.a for Cargo.toml's
+      # version. It only links if the checked-out runner source matches that release's
+      # C ABI. A commit AHEAD of the last release (new core symbols) fails to link
+      # ("undefined reference") — see 2026-06-20 validation. A true dev-build of
+      # unreleased source must build libboxlite.a from the Rust core here instead of
+      # downloading it. TODO: add the Rust libboxlite build for the dev-build path.
+      - name: Download prebuilt libboxlite.a
+        if: ${{ steps.in.outputs.source == 'dev-build' }}
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          ARCHIVE="boxlite-c-v${VERSION}-linux-x64-gnu.tar.gz"
+          URL="https://github.com/${GH_REPO}/releases/download/v${VERSION}/${ARCHIVE}"
+          echo "Downloading $URL"
+          curl -fsSL "${URL}" | tar xz -C /tmp/
+          cp "/tmp/boxlite-c-v${VERSION}-linux-x64-gnu/lib/libboxlite.a" sdks/go/libboxlite.a
+
+      - name: Rewrite go.work for minimal modules
+        if: ${{ steps.in.outputs.source == 'dev-build' }}
+        run: |
+          printf 'go 1.25.4\n\nuse (\n\t./runner\n\t./daemon\n\t./common-go\n\t./api-client-go\n\t./libs/computer-use\n\t../sdks/go\n)\n' > apps/go.work
+
+      - name: Download Go dependencies
+        if: ${{ steps.in.outputs.source == 'dev-build' }}
+        run: |
+          go -C apps/runner mod download
+          go -C apps/daemon mod download
+          go -C apps/common-go mod download
+          go -C apps/api-client-go mod download
+          go -C apps/libs/computer-use mod download
+
+      - name: Build daemon
+        if: ${{ steps.in.outputs.source == 'dev-build' }}
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -C apps \
+            -ldflags "-X 'github.com/boxlite-ai/daemon/internal.Version=${VERSION}'" \
+            -o runner/pkg/daemon/static/daemon-amd64 \
+            ./daemon/cmd/daemon/
+
+      - name: Build computer-use
+        if: ${{ steps.in.outputs.source == 'dev-build' }}
+        run: |
+          CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -C apps \
+            -o runner/pkg/daemon/static/boxlite-computer-use \
+            ./libs/computer-use/
+
+      - name: Build runner
+        if: ${{ steps.in.outputs.source == 'dev-build' }}
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -C apps \
+            -ldflags "-X 'github.com/boxlite-ai/runner/internal.Version=${VERSION}-dev-${{ steps.version.outputs.sha }}'" \
+            -o /tmp/boxlite-runner \
+            ./runner/cmd/runner/
+
+      - name: Package dev tarball
+        if: ${{ steps.in.outputs.source == 'dev-build' }}
+        id: package
+        run: |
+          TARBALL="boxlite-runner-dev-${{ steps.version.outputs.sha }}-linux-amd64.tar.gz"
+          tar czf "$TARBALL" -C /tmp boxlite-runner
+          sha256sum "$TARBALL" > "$TARBALL.sha256"
+          echo "tarball=$TARBALL" >> "$GITHUB_OUTPUT"
+
+      # ── stage + roll out ──────────────────────────────────────────────────
+      - name: Assume AWS deploy role (GitHub OIDC, no static keys)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::064212132677:role/boxlite-github-deployer-${{ steps.in.outputs.stage }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Upload dev build to S3 + presign
+        if: ${{ steps.in.outputs.source == 'dev-build' }}
+        id: s3
+        run: |
+          NAME="${{ steps.package.outputs.tarball }}"
+          KEY="runner-builds/${NAME}"
+          aws s3 cp "${NAME}"        "s3://${S3_BUCKET}/${KEY}"        --region "$AWS_REGION"
+          aws s3 cp "${NAME}.sha256" "s3://${S3_BUCKET}/${KEY}.sha256" --region "$AWS_REGION"
+          # Presigned URLs the runner EC2 can curl without AWS creds (30 min TTL).
+          TARBALL_URL=$(aws s3 presign "s3://${S3_BUCKET}/${KEY}"        --region "$AWS_REGION" --expires-in 1800)
+          SHA_URL=$(aws s3 presign     "s3://${S3_BUCKET}/${KEY}.sha256" --region "$AWS_REGION" --expires-in 1800)
+          echo "::add-mask::${TARBALL_URL}"
+          echo "::add-mask::${SHA_URL}"
+          echo "tarball_url=${TARBALL_URL}" >> "$GITHUB_OUTPUT"
+          echo "sha_url=${SHA_URL}" >> "$GITHUB_OUTPUT"
+
+      - name: Roll out — dev-build
+        if: ${{ steps.in.outputs.source == 'dev-build' }}
+        env:
+          STAGE: ${{ steps.in.outputs.stage }}
+          BOXLITE_RUNNER_TARBALL_URL: ${{ steps.s3.outputs.tarball_url }}
+          BOXLITE_RUNNER_TARBALL_SHA256_URL: ${{ steps.s3.outputs.sha_url }}
+          BOXLITE_RUNNER_INSTANCE_ID: ${{ steps.in.outputs.instance_id }}
+        run: bash scripts/deploy/runner-update-binary.sh
+
+      - name: Roll out — release
+        if: ${{ steps.in.outputs.source == 'release' }}
+        env:
+          STAGE: ${{ steps.in.outputs.stage }}
+          BOXLITE_RUNNER_INSTANCE_ID: ${{ steps.in.outputs.instance_id }}
+        run: bash scripts/deploy/runner-update-binary.sh "${{ steps.in.outputs.ref }}"

--- a/.github/workflows/runner-rollout.yml
+++ b/.github/workflows/runner-rollout.yml
@@ -75,12 +75,20 @@ jobs:
     steps:
       - name: Resolve inputs (defaults make push-triggered runs sane)
         id: in
+        # Pass inputs via env, not ${{ }} interpolated into the script text, so a crafted
+        # free-text input (ref / instance_id) is a shell value, never executable script.
+        env:
+          IN_STAGE: ${{ inputs.stage || 'dev' }}
+          IN_SOURCE: ${{ inputs.source || 'dev-build' }}
+          IN_MODE: ${{ inputs.mode || 'upgrade' }}
+          IN_REF: ${{ inputs.ref }}
+          IN_INSTANCE_ID: ${{ inputs.instance_id }}
         run: |
-          echo "stage=${{ inputs.stage || 'dev' }}"        >> "$GITHUB_OUTPUT"
-          echo "source=${{ inputs.source || 'dev-build' }}" >> "$GITHUB_OUTPUT"
-          echo "mode=${{ inputs.mode || 'upgrade' }}"       >> "$GITHUB_OUTPUT"
-          echo "ref=${{ inputs.ref }}"                      >> "$GITHUB_OUTPUT"
-          echo "instance_id=${{ inputs.instance_id }}"      >> "$GITHUB_OUTPUT"
+          echo "stage=$IN_STAGE"             >> "$GITHUB_OUTPUT"
+          echo "source=$IN_SOURCE"           >> "$GITHUB_OUTPUT"
+          echo "mode=$IN_MODE"               >> "$GITHUB_OUTPUT"
+          echo "ref=$IN_REF"                 >> "$GITHUB_OUTPUT"
+          echo "instance_id=$IN_INSTANCE_ID" >> "$GITHUB_OUTPUT"
 
       - name: Guard — rollback requires a release version
         if: ${{ steps.in.outputs.mode == 'rollback' && steps.in.outputs.source != 'release' }}
@@ -91,6 +99,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ (steps.in.outputs.source == 'dev-build' && steps.in.outputs.ref != '') && steps.in.outputs.ref || github.ref }}
+          persist-credentials: false
 
       # ── dev-build: build the runner binary from this checkout ──────────────
       # Faithful copy of build-runner-binary.yml's build recipe (could become a
@@ -221,4 +230,5 @@ jobs:
         env:
           STAGE: ${{ steps.in.outputs.stage }}
           BOXLITE_RUNNER_INSTANCE_ID: ${{ steps.in.outputs.instance_id }}
-        run: bash scripts/deploy/runner-update-binary.sh "${{ steps.in.outputs.ref }}"
+          REF: ${{ steps.in.outputs.ref }}
+        run: bash scripts/deploy/runner-update-binary.sh "$REF"

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -24,6 +24,11 @@ COPY apps/nx.json apps/tsconfig.base.json apps/NOTICE ./
 ENV NX_DAEMON=false
 ENV NX_SKIP_NX_CACHE=true
 
+# Sub-path the dashboard SPA is served under (e.g. '/dashboard' for prod scheme B). Becomes Vite's
+# `base` at build time, rewriting every asset URL the bundle emits. Empty (default) = served at root.
+# The Api's ServeStaticModule.renderPath (driven by DASHBOARD_PATH at runtime) MUST match this.
+ARG DASHBOARD_PATH=
+
 COPY apps/api/ api/
 COPY apps/dashboard/ dashboard/
 
@@ -33,7 +38,7 @@ COPY apps/libs/analytics-api-client/ libs/analytics-api-client/
 
 RUN yarn nx build api --configuration=production --nxBail=true --output-style=stream && node --check dist/apps/api/main.js
 
-RUN VITE_BASE_API_URL=%BOXLITE_BASE_API_URL% yarn nx build dashboard --configuration=production --nxBail=true --output-style=stream
+RUN VITE_BASE_API_URL=%BOXLITE_BASE_API_URL% VITE_DASHBOARD_PATH="${DASHBOARD_PATH}" yarn nx build dashboard --configuration=production --nxBail=true --output-style=stream
 
 FROM node:24-slim AS boxlite
 ENV CI=true

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -56,7 +56,9 @@ COPY --from=build --chown=node:node /boxlite/apps/dist/apps/api ./dist/apps/api
 COPY --from=build --chown=node:node /boxlite/apps/dist/apps/dashboard ./dist/apps/dashboard
 
 ARG VERSION=0.0.1
+ARG BOXLITE_API_ROLLOUT_MARKER=dev-api-ecs-redeploy-20260629T1350Z
 ENV VERSION=${VERSION}
+LABEL ai.boxlite.api-rollout-marker="${BOXLITE_API_ROLLOUT_MARKER}"
 
 EXPOSE 3000
 HEALTHCHECK CMD [ "curl", "-f", "http://localhost:3000/api/config" ]

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -112,10 +112,13 @@ import { BoxliteRestModule } from './boxlite-rest/boxlite-rest.module'
         cacheControl: false,
       },
     }),
+    // The dashboard SPA is served under DASHBOARD_PATH (defaults to '/' for the dev root; prod
+    // scheme B sets '/dashboard'). renderPath MUST match the Vite `base` the dashboard was built
+    // with (set via VITE_DASHBOARD_PATH at Dockerfile build time) — a mismatch breaks asset URLs.
     ServeStaticModule.forRoot({
       rootPath: join(__dirname, '..', 'dashboard'),
       exclude: ['/api/{*path}'],
-      renderPath: '/',
+      renderPath: process.env.DASHBOARD_PATH || '/',
       serveStaticOptions: {
         // Disable serve-static's own default Cache-Control; setHeaders applies a
         // content-addressed policy: hashed /assets/* immutable-forever, HTML

--- a/apps/dashboard/index.html
+++ b/apps/dashboard/index.html
@@ -2,8 +2,8 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" href="/favicon.ico" />
-    <link rel="shortcut icon" href="/favicon.ico" />
+    <link rel="icon" href="./favicon.ico" />
+    <link rel="shortcut icon" href="./favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>BoxLite</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/apps/dashboard/src/main.tsx
+++ b/apps/dashboard/src/main.tsx
@@ -37,7 +37,7 @@ enableMocking().then(() =>
           <ThemeProvider>
             <Suspense fallback={<LoadingFallback />}>
               <ConfigProvider>
-                <BrowserRouter>
+                <BrowserRouter basename={import.meta.env.BASE_URL}>
                   <PostHogProviderWrapper>
                     <NuqsAdapter>
                       <App />

--- a/apps/dashboard/src/providers/ConfigProvider.tsx
+++ b/apps/dashboard/src/providers/ConfigProvider.tsx
@@ -38,6 +38,11 @@ export function ConfigProvider(props: Props) {
   })
 
   const oidcConfig: AuthProviderProps = useMemo(() => {
+    // OIDC redirect target must match an Auth0 Allowed Callback URL exactly.
+    // The SPA is mounted under Vite's BASE_URL, so strip the trailing slash to
+    // produce either the origin root or a mounted path like /dashboard.
+    const appOrigin = window.location.origin + import.meta.env.BASE_URL.replace(/\/$/, '')
+
     return {
       authority: config.oidc.issuer,
       client_id: config.oidc.clientId,
@@ -45,7 +50,7 @@ export function ConfigProvider(props: Props) {
         audience: config.oidc.audience,
       },
       scope: 'openid profile email',
-      redirect_uri: window.location.origin,
+      redirect_uri: appOrigin,
       staleStateAgeInSeconds: 60,
       accessTokenExpiringNotificationTimeInSeconds: 290,
       // Persist the signed-in user (with tokens) in sessionStorage so a page
@@ -62,7 +67,7 @@ export function ConfigProvider(props: Props) {
         window.history.replaceState({}, '', targetUrl)
         window.dispatchEvent(new PopStateEvent('popstate'))
       },
-      post_logout_redirect_uri: window.location.origin,
+      post_logout_redirect_uri: appOrigin,
       // For IdPs (e.g. Dex) that don't advertise end_session_endpoint via discovery,
       // the API exposes a compatible endpoint and reports it here.
       ...(config.oidc.endSessionEndpoint && {

--- a/apps/dashboard/vite.config.mts
+++ b/apps/dashboard/vite.config.mts
@@ -10,8 +10,17 @@ import checker from 'vite-plugin-checker'
 
 const outDir = '../dist/apps/dashboard'
 
+// Sub-path the dashboard is served under in production (e.g. '/dashboard' for prod scheme B).
+// Vite rewrites every asset URL it emits to be relative to this base, so the bundle works when
+// the SPA is mounted at app.boxlite.ai/dashboard instead of the host root. Defaults to '/' so
+// dev (and any prod that serves at the root) is byte-for-byte unchanged. The Api's
+// ServeStaticModule.renderPath must match (driven by the same DASHBOARD_PATH env at runtime).
+const dashboardPath = process.env.VITE_DASHBOARD_PATH || ''
+const dashboardBase = dashboardPath ? `${dashboardPath.replace(/\/$/, '')}/` : '/'
+
 export default defineConfig((mode) => ({
   root: __dirname,
+  base: dashboardBase,
   cacheDir: '../../node_modules/.vite/apps/dashboard',
   server: {
     port: 3000,

--- a/apps/infra/README.md
+++ b/apps/infra/README.md
@@ -424,4 +424,4 @@ initial setup: `aws ecs update-service --force-new-deployment --service Proxy`.
 
 Figures are approximate (ap-southeast-1 on-demand). The **Runner and the load
 balancers dominate** — the NAT is ~$16, not a headline cost. `npm run remove -- --stage dev` tears it all down; S3 buckets and RDS snapshots are retained in
-production stage (`--stage production`) per SST's default.
+the prod stage (`--stage prod`), which the config marks for retention.

--- a/apps/infra/scripts/seed-deploy-env-ssm.mjs
+++ b/apps/infra/scripts/seed-deploy-env-ssm.mjs
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+/*
+ * Seed a stage's deploy-time env config + secrets into AWS SSM Parameter Store,
+ * so CI (GitHub Actions) can deploy with the SAME config a laptop's .env provides.
+ *
+ * Reads a .env file and writes each KEY=VALUE to /boxlite/<stage>/env/<KEY> as a
+ * SecureString. The companion `sst-with-cloudflare.mjs` loads these back at deploy
+ * time (an env var already set always wins, so laptops keep using .env unchanged).
+ *
+ * Secrets stay between this machine and AWS: values are passed to the AWS CLI as
+ * argv (no shell interpolation) and are NEVER printed — only KEY names are logged.
+ *
+ * Usage:
+ *   node scripts/seed-deploy-env-ssm.mjs                      # apps/infra/.env -> stage dev
+ *   node scripts/seed-deploy-env-ssm.mjs --env .env --stage dev
+ *   AWS_PROFILE=boxlite-sso node scripts/seed-deploy-env-ssm.mjs
+ *   node scripts/seed-deploy-env-ssm.mjs --dry-run            # list keys, write nothing
+ */
+
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+
+const REGION = process.env.AWS_REGION || 'ap-southeast-1'
+
+// Machine-specific or handled-elsewhere — never seed these.
+//   AWS_PROFILE       : a local profile name; on CI it would break OIDC creds.
+//   CLOUDFLARE_*      : already seeded at /boxlite/<stage>/cloudflare-* and loaded
+//                       by sst-with-cloudflare.mjs's existing CREDS path.
+const EXCLUDE = new Set(['AWS_PROFILE', 'CLOUDFLARE_API_TOKEN', 'CLOUDFLARE_DEFAULT_ACCOUNT_ID'])
+
+function arg(flag, fallback) {
+  const i = process.argv.indexOf(flag)
+  return i >= 0 && process.argv[i + 1] ? process.argv[i + 1] : fallback
+}
+const DRY = process.argv.includes('--dry-run')
+const envPath = arg('--env', '.env') // default: ./.env (run from apps/infra)
+const stage = arg('--stage', process.env.SST_STAGE || 'dev')
+
+function parseEnv(text) {
+  const out = []
+  for (const raw of text.split('\n')) {
+    const line = raw.trim()
+    if (!line || line.startsWith('#')) continue
+    const m = line.match(/^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/)
+    if (!m) continue
+    let [, key, val] = m
+    // strip a single layer of matching surrounding quotes
+    if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
+      val = val.slice(1, -1)
+    }
+    out.push([key, val])
+  }
+  return out
+}
+
+let text
+try {
+  text = readFileSync(envPath, 'utf8')
+} catch {
+  console.error(`seed-deploy-env-ssm: cannot read env file at '${envPath}' (cwd: ${process.cwd()})`)
+  process.exit(1)
+}
+
+const pairs = parseEnv(text).filter(([k, v]) => !EXCLUDE.has(k) && v !== '')
+console.log(`seed-deploy-env-ssm: stage=${stage} region=${REGION} -> /boxlite/${stage}/env/* (${pairs.length} keys)`)
+
+let ok = 0
+for (const [key, val] of pairs) {
+  const name = `/boxlite/${stage}/env/${key}`
+  if (DRY) {
+    console.log(`  would put ${name}`)
+    continue
+  }
+  try {
+    execFileSync(
+      'aws',
+      ['ssm', 'put-parameter', '--region', REGION, '--name', name, '--type', 'SecureString', '--overwrite', '--value', val],
+      { stdio: ['ignore', 'ignore', 'pipe'] }, // never echo the value or the version output
+    )
+    console.log(`  ✓ ${key}`)
+    ok++
+  } catch (err) {
+    const msg = (err.stderr ? err.stderr.toString() : err.message).split('\n')[0]
+    console.error(`  ✗ ${key}: ${msg}`)
+  }
+}
+console.log(DRY ? 'seed-deploy-env-ssm: dry-run, nothing written' : `seed-deploy-env-ssm: wrote ${ok}/${pairs.length}`)

--- a/apps/infra/scripts/seed-deploy-env-ssm.mjs
+++ b/apps/infra/scripts/seed-deploy-env-ssm.mjs
@@ -22,7 +22,10 @@
 import { execFileSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
 
-const REGION = process.env.AWS_REGION || 'ap-southeast-1'
+// SSM config region is FIXED (not the deploy region): all stages' /boxlite/<stage>/* config lives
+// in ap-southeast-1 regardless of where the stage deploys, matching sst-with-cloudflare.mjs so seeds
+// land where the deploy reads them. Override with BOXLITE_CONFIG_REGION.
+const REGION = process.env.BOXLITE_CONFIG_REGION || 'ap-southeast-1'
 
 // Machine-specific or handled-elsewhere — never seed these.
 //   AWS_PROFILE       : a local profile name; on CI it would break OIDC creds.

--- a/apps/infra/scripts/seed-prod-from-dev.mjs
+++ b/apps/infra/scripts/seed-prod-from-dev.mjs
@@ -28,12 +28,14 @@
  *   AWS_PROFILE=boxlite-sso node scripts/seed-prod-from-dev.mjs --apply        # actually write
  *   node scripts/seed-prod-from-dev.mjs --source-stage dev --target-stage prod
  *   node scripts/seed-prod-from-dev.mjs --dev-domain dev.boxlite.ai --prod-domain app.boxlite.ai
- *   AWS_REGION=us-west-2 node scripts/seed-prod-from-dev.mjs                    # target a region
+ *   BOXLITE_CONFIG_REGION=us-west-2 node scripts/seed-prod-from-dev.mjs         # override config region
  */
 
 import { execFileSync } from 'node:child_process'
 
-const REGION = process.env.AWS_REGION || 'ap-southeast-1'
+// SSM config region is FIXED (not the deploy region): all stages' config lives in ap-southeast-1
+// regardless of where the stage deploys, matching sst-with-cloudflare.mjs. Override BOXLITE_CONFIG_REGION.
+const REGION = process.env.BOXLITE_CONFIG_REGION || 'ap-southeast-1'
 
 function arg(flag, fallback) {
   const i = process.argv.indexOf(flag)

--- a/apps/infra/scripts/seed-prod-from-dev.mjs
+++ b/apps/infra/scripts/seed-prod-from-dev.mjs
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+/*
+ * Seed a new stage's deploy-time env config from an existing stage's, into AWS SSM.
+ *
+ * Bootstrapping a fresh stage (e.g. prod) needs the same /boxlite/<stage>/env/*
+ * parameters dev already has. Most carry over verbatim or with a domain swap; a handful
+ * are stage-identity (Auth0 tenant, SSH keys, the runner's private IP) that this script
+ * CANNOT know — it leaves those blank on purpose and prints the exact put-parameter
+ * command to fill each, so nothing wrong is silently written.
+ *
+ * Three buckets (see CLASSIFY below):
+ *   copy   : value carries over unchanged (e.g. POSTHOG_API_KEY, INTERNAL_ADMIN_EMAILS)
+ *   domain : value is the source value with <dev-domain> rewritten to <prod-domain> (STACK_DOMAIN only)
+ *   blank  : stage-identity / Auth0-coupled, unknowable here → SKIPPED, listed with a ready-to-paste
+ *            command (OIDC_AUDIENCE + OIDC_* tenant creds, PUBLIC_OIDC_DOMAIN, SSH_*_B64, RUNNER_PRIVATE_IP).
+ *            OIDC_AUDIENCE looks domain-shaped (dev = https://dev.boxlite.ai/api) but is whatever the prod
+ *            Auth0 API is named — a wrong guess silently breaks JWT validation, so it must be set by hand.
+ * Any source key not classified defaults to `blank` (safe — never auto-copy the unknown).
+ *
+ * Secrets stay between this machine and AWS: copied values are passed to the AWS CLI as
+ * argv (no shell interpolation) and are NEVER printed — only KEY names and the two
+ * non-secret derived domains are logged.
+ *
+ * Usage (dry-run by default — prints the plan, writes nothing):
+ *   AWS_PROFILE=boxlite-sso node scripts/seed-prod-from-dev.mjs
+ *   AWS_PROFILE=boxlite-sso node scripts/seed-prod-from-dev.mjs --apply        # actually write
+ *   node scripts/seed-prod-from-dev.mjs --source-stage dev --target-stage prod
+ *   node scripts/seed-prod-from-dev.mjs --dev-domain dev.boxlite.ai --prod-domain app.boxlite.ai
+ *   AWS_REGION=us-west-2 node scripts/seed-prod-from-dev.mjs                    # target a region
+ */
+
+import { execFileSync } from 'node:child_process'
+
+const REGION = process.env.AWS_REGION || 'ap-southeast-1'
+
+function arg(flag, fallback) {
+  const i = process.argv.indexOf(flag)
+  return i >= 0 && process.argv[i + 1] ? process.argv[i + 1] : fallback
+}
+const APPLY = process.argv.includes('--apply')
+const SOURCE_STAGE = arg('--source-stage', 'dev')
+const TARGET_STAGE = arg('--target-stage', 'prod')
+const DEV_DOMAIN = arg('--dev-domain', 'dev.boxlite.ai')
+const PROD_DOMAIN = arg('--prod-domain', 'app.boxlite.ai')
+
+// How each env key crosses from the source stage to the target stage.
+const CLASSIFY = {
+  // domain — rewrite <dev-domain> to <prod-domain> in the source value
+  STACK_DOMAIN: 'domain',
+  // copy — same value in both stages
+  INTERNAL_ADMIN_EMAILS: 'copy',
+  POSTHOG_API_KEY: 'copy',
+  POSTHOG_HOST: 'copy',
+  SVIX_AUTH_TOKEN: 'copy',
+  DEV_CLICKHOUSE_ENABLED: 'copy',
+  DEV_CLICKHOUSE_EBS_GB: 'copy',
+  OIDC_MANAGEMENT_API_ENABLED: 'copy',
+  // blank — stage-identity / Auth0-coupled / unknowable here; SKIP and list for manual seeding
+  OIDC_AUDIENCE: 'blank', // = the prod Auth0 API's audience id; must equal what you create in Auth0, not a domain guess
+  OIDC_ISSUER_BASE_URL: 'blank',
+  OIDC_CLIENT_ID: 'blank',
+  OIDC_MANAGEMENT_API_AUDIENCE: 'blank',
+  OIDC_MANAGEMENT_API_CLIENT_ID: 'blank',
+  OIDC_MANAGEMENT_API_CLIENT_SECRET: 'blank',
+  PUBLIC_OIDC_DOMAIN: 'blank',
+  SSH_HOST_KEY_B64: 'blank',
+  SSH_PRIVATE_KEY_B64: 'blank',
+  RUNNER_PRIVATE_IP: 'blank', // filled after the first deploy from the runner's private IP
+}
+
+function readSourceEnv(stage) {
+  const path = `/boxlite/${stage}/env/`
+  let json
+  try {
+    json = execFileSync(
+      'aws',
+      ['ssm', 'get-parameters-by-path', '--region', REGION, '--path', path, '--recursive',
+        '--with-decryption', '--query', 'Parameters[].{Name:Name,Value:Value}', '--output', 'json'],
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
+    )
+  } catch (err) {
+    const msg = err.stderr ? err.stderr.toString().split('\n')[0] : err.message
+    console.error(`seed-prod-from-dev: cannot read ${path}* in ${REGION}: ${msg}`)
+    process.exit(1)
+  }
+  const params = JSON.parse(json)
+  const out = new Map()
+  for (const p of params || []) out.set(p.Name.slice(path.length), p.Value)
+  return out
+}
+
+function putParam(key, value) {
+  const name = `/boxlite/${TARGET_STAGE}/env/${key}`
+  execFileSync(
+    'aws',
+    ['ssm', 'put-parameter', '--region', REGION, '--name', name, '--type', 'SecureString', '--overwrite', '--value', value],
+    { stdio: ['ignore', 'ignore', 'pipe'] }, // never echo the value or the version output
+  )
+}
+
+const source = readSourceEnv(SOURCE_STAGE)
+console.log(
+  `seed-prod-from-dev: ${SOURCE_STAGE} -> ${TARGET_STAGE} | region=${REGION} | ` +
+    `${DEV_DOMAIN} -> ${PROD_DOMAIN} | ${APPLY ? 'APPLY (writing)' : 'DRY-RUN (nothing written)'}`,
+)
+console.log(`  source has ${source.size} key(s) under /boxlite/${SOURCE_STAGE}/env/\n`)
+
+const written = []
+const blanks = []
+let failures = 0
+
+for (const [key, srcVal] of source) {
+  const kind = CLASSIFY[key] || 'blank' // unknown keys are not auto-copied
+  if (kind === 'blank') {
+    blanks.push(key)
+    continue
+  }
+  let value = srcVal
+  let note = 'copied'
+  if (kind === 'domain') {
+    value = srcVal.split(DEV_DOMAIN).join(PROD_DOMAIN)
+    note = `${srcVal} -> ${value}` // non-secret domains: safe to show the rewrite
+    if (!srcVal.includes(DEV_DOMAIN)) {
+      note = `WARNING source value has no '${DEV_DOMAIN}' to rewrite; writing as-is (${value})`
+    }
+  }
+  if (APPLY) {
+    try {
+      putParam(key, value)
+    } catch (err) {
+      const msg = err.stderr ? err.stderr.toString().split('\n')[0] : err.message
+      console.error(`  ✗ ${key}: ${msg}`)
+      failures++
+      continue
+    }
+  }
+  written.push(key)
+  console.log(`  ${APPLY ? '✓' : '·'} ${key.padEnd(34)} ${kind === 'domain' ? note : 'copied'}`)
+}
+
+console.log(`\n  ${APPLY ? 'wrote' : 'would write'} ${written.length} key(s); ${blanks.length} left BLANK (need a human):`)
+for (const key of blanks) {
+  console.log(
+    `    /boxlite/${TARGET_STAGE}/env/${key}\n` +
+      `      aws ssm put-parameter --region ${REGION} --type SecureString --overwrite \\\n` +
+      `        --name /boxlite/${TARGET_STAGE}/env/${key} --value '<...>'`,
+  )
+}
+
+console.log(
+  `\n  Cloudflare creds are NOT handled here. Seed the target stage's (a fresh prod-scoped\n` +
+    `  token is recommended) before the first deploy:\n` +
+    `    aws ssm put-parameter --region ${REGION} --type SecureString --overwrite \\\n` +
+    `      --name /boxlite/${TARGET_STAGE}/cloudflare-api-token  --value '<token>'\n` +
+    `    aws ssm put-parameter --region ${REGION} --type SecureString --overwrite \\\n` +
+    `      --name /boxlite/${TARGET_STAGE}/cloudflare-account-id --value '<account-id>'`,
+)
+
+if (failures) {
+  console.error(`\nseed-prod-from-dev: ${failures} write(s) failed`)
+  process.exit(1)
+}
+console.log(`\nseed-prod-from-dev: ${APPLY ? 'done' : 'dry-run complete — re-run with --apply to write'}`)

--- a/apps/infra/scripts/sst-with-cloudflare.mjs
+++ b/apps/infra/scripts/sst-with-cloudflare.mjs
@@ -31,7 +31,11 @@
 
 import { execFileSync, spawnSync } from 'node:child_process'
 
-const REGION = process.env.AWS_REGION || 'ap-southeast-1'
+// SSM config lives in a FIXED region, decoupled from the deploy region: a prod stage may deploy
+// to another region (e.g. us-west-2) while its /boxlite/<stage>/* config + cloudflare creds stay
+// in ap-southeast-1 (the deploy role reads them cross-region). This also lets a region-restricted
+// SSO seed config in ap-southeast-1 for a stage deployed elsewhere. Override with BOXLITE_CONFIG_REGION.
+const REGION = process.env.BOXLITE_CONFIG_REGION || 'ap-southeast-1'
 
 // SSM param consulted only when the matching env var is unset.
 const CREDS = [

--- a/apps/infra/scripts/sst-with-cloudflare.mjs
+++ b/apps/infra/scripts/sst-with-cloudflare.mjs
@@ -70,6 +70,41 @@ function fetchFromSsm(name) {
   }
 }
 
+// Beyond the Cloudflare creds above, a deploy needs the stage's app config + secrets
+// (STACK_DOMAIN, OIDC_*, SVIX_AUTH_TOKEN, …). On a laptop these come from .env; in CI
+// there is no .env, so they live in SSM under /boxlite/<stage>/env/<KEY> (seed them with
+// scripts/seed-deploy-env-ssm.mjs). An env var already set always wins, so laptops keep
+// using their .env unchanged. Only the COUNT is logged — never any value.
+function loadEnvFromSsm(stage) {
+  const path = `/boxlite/${stage}/env/`
+  let json
+  try {
+    json = execFileSync(
+      'aws',
+      ['ssm', 'get-parameters-by-path', '--region', REGION, '--path', path, '--recursive',
+        '--with-decryption', '--query', 'Parameters[].{Name:Name,Value:Value}', '--output', 'json'],
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
+    )
+  } catch (err) {
+    if (err.code === 'ENOENT') console.warn('sst-with-cloudflare: `aws` CLI not found; skipping SSM env load')
+    return
+  }
+  let params
+  try {
+    params = JSON.parse(json)
+  } catch {
+    return
+  }
+  let loaded = 0
+  for (const p of params || []) {
+    const key = p.Name.slice(path.length) // segment after the prefix = env var name
+    if (!key || process.env[key]) continue // already set (e.g. from .env) wins
+    process.env[key] = p.Value
+    loaded++
+  }
+  if (loaded) console.log(`sst-with-cloudflare: loaded ${loaded} env var(s) from SSM ${path}*`)
+}
+
 const stage = resolveStage(sstArgs)
 
 for (const { env, param } of CREDS) {
@@ -85,6 +120,8 @@ for (const { env, param } of CREDS) {
     )
   }
 }
+
+loadEnvFromSsm(stage)
 
 // node_modules/.bin is on PATH because this runs via `npm run`, so `sst` resolves.
 const result = spawnSync('sst', sstArgs, { stdio: 'inherit', env: process.env })

--- a/apps/infra/sst.config.ts
+++ b/apps/infra/sst.config.ts
@@ -18,7 +18,11 @@
 //   5. observability               10. runner (EC2 + nested KVM)
 // ─────────────────────────────────────────────────────────────────────────────
 
-const REGION = 'ap-southeast-1'
+// Deploy region. Defaults to ap-southeast-1 (where dev lives); a stage can deploy
+// elsewhere by setting AWS_REGION — the deploy workflow exports it from its `region`
+// input, and the SSM helpers (sst-with-cloudflare / seed scripts) already key off the
+// same env var, so a stage's config + creds resolve from the region it deploys to.
+const REGION = process.env.AWS_REGION || 'ap-southeast-1'
 
 // Container ports each service listens on internally
 const PORTS = {
@@ -94,7 +98,7 @@ export default $config({
   app(input) {
     return {
       name: 'boxlite',
-      removal: input?.stage === 'production' ? 'retain' : 'remove',
+      removal: input?.stage === 'prod' ? 'retain' : 'remove',
       home: 'aws',
       providers: {
         aws: { region: REGION, ...(process.env.AWS_PROFILE ? { profile: process.env.AWS_PROFILE } : {}) },
@@ -108,12 +112,13 @@ export default $config({
   },
 
   async run() {
-    // Stamp every IAM role this app creates with the workload permissions
-    // boundary. The deploy principal's grant to create/manage boxlite-* roles is
-    // CONDITIONAL on the created role carrying this boundary (see boxlite-deploy-delegation
-    // `AllowCreateBoundedRoles` / `AllowSetBoundary`, which require the boundary to be
-    // boxlite-workload-boundary or boxlite-cd-boundary); without it CreateRole/PutRolePermissionsBoundary
-    // are denied. Registered first, before any resource — including SST-internal roles — is created.
+    // Stamp every IAM role this app creates with the workload permissions boundary
+    // boxlite-role-boundary. The deploy principal's grant to create/manage boxlite-*
+    // roles is CONDITIONAL on the created role carrying exactly this boundary (see
+    // boxlite-bounded-role-admin `AllowCreateBoundedRoles` / `AllowSetBoundary`, whose
+    // condition is iam:PermissionsBoundary == boxlite-role-boundary); without it
+    // CreateRole / PutRolePermissionsBoundary are denied. Registered first, before any
+    // resource — including SST-internal roles — is created.
     $transform(aws.iam.Role, (args) => {
       args.permissionsBoundary ??= 'arn:aws:iam::064212132677:policy/boxlite-role-boundary'
     })
@@ -223,7 +228,7 @@ export default $config({
     // S3 versioning is on in every stage: cheap, and the only guard against an
     // object-level overwrite/delete (which `removal` never covers). Redis is a
     // transient cache, so it needs neither.
-    const isProd = $app.stage === 'production'
+    const isProd = $app.stage === 'prod'
     // Unique-but-stable suffix for the DB final snapshot: a fixed name would collide
     // with the snapshot a prior teardown of the same stage already created (RDS requires
     // unique final-snapshot ids). RandomId is stable across deploys (no drift) and is
@@ -969,7 +974,10 @@ export default $config({
     // Default runner — auto-seeded by the API at boot via DEFAULT_RUNNER_*.
     // Pulumi resource id stays 'Runner' (renaming it would replace a protect:true
     // instance); only the AWS Name tag carries the explicit `-default` suffix.
-    makeRunner('Runner', 'boxlite-runner-default', runnerUserData)
+    // The tag is stage-scoped (boxlite-<stage>-runner-default) so dev and prod
+    // runners in the same account/region stay distinguishable — runner-rollout's
+    // tag lookup targets the stage's runner, never the other stage's.
+    makeRunner('Runner', `${$app.name}-${$app.stage}-runner-default`, runnerUserData)
 
     // Multi-runner provisioning. Extra runners share the same OTel endpoint as
     // the default runner.

--- a/apps/infra/sst.config.ts
+++ b/apps/infra/sst.config.ts
@@ -18,10 +18,11 @@
 //   5. observability               10. runner (EC2 + nested KVM)
 // ─────────────────────────────────────────────────────────────────────────────
 
-// Deploy region. Defaults to ap-southeast-1 (where dev lives); a stage can deploy
-// elsewhere by setting AWS_REGION — the deploy workflow exports it from its `region`
-// input, and the SSM helpers (sst-with-cloudflare / seed scripts) already key off the
-// same env var, so a stage's config + creds resolve from the region it deploys to.
+// Deploy region for this stack's AWS resources. Defaults to ap-southeast-1 (where dev lives);
+// a stage can deploy elsewhere by setting AWS_REGION (the deploy workflow exports it from its
+// `region` input). NOTE: this is the RESOURCE region only — the SSM config helpers
+// (sst-with-cloudflare / seed scripts) read from a FIXED region (BOXLITE_CONFIG_REGION ||
+// ap-southeast-1), so a stage's config + creds stay in ap-southeast-1 even when it deploys elsewhere.
 const REGION = process.env.AWS_REGION || 'ap-southeast-1'
 
 // Container ports each service listens on internally

--- a/apps/infra/sst.config.ts
+++ b/apps/infra/sst.config.ts
@@ -124,6 +124,15 @@ export default $config({
       args.permissionsBoundary ??= 'arn:aws:iam::064212132677:policy/boxlite-role-boundary'
     })
 
+    // Force every auto-created InstanceProfile (e.g. SST's VpcNatInstanceProfile) into
+    // the boxlite-<stage>-* namespace so the deploy role's `instance-profile/boxlite-<stage>-*`
+    // grant matches. Without this, SST names instance profiles "<LogicalId>-<hash>" which is
+    // outside the deploy role's allowed resource scope → iam:CreateInstanceProfile denied.
+    // Explicit `name:` on a profile (e.g. RunnerProfile) wins because of `??=`.
+    $transform(aws.iam.InstanceProfile, (args, _opts, resourceName) => {
+      args.name ??= `${$app.name}-${$app.stage}-${resourceName}`
+    })
+
     // Load .env overrides (anything unset falls back to auto-generated values)
     const { config } = await import('dotenv')
     config()

--- a/apps/infra/sst.config.ts
+++ b/apps/infra/sst.config.ts
@@ -397,6 +397,11 @@ export default $config({
       image: {
         context: '../..',
         dockerfile: 'apps/api/Dockerfile',
+        // Pass the dashboard sub-path to the Vite build (Dockerfile ARG DASHBOARD_PATH ->
+        // VITE_DASHBOARD_PATH). When DASHBOARD_PATH is unset (dev / prod-A) this is '' so Vite's
+        // `base` stays '/'; for prod scheme B (DASHBOARD_PATH=/dashboard) Vite rewrites every
+        // asset URL in the bundle to be /dashboard/-prefixed. Matches ServeStaticModule.renderPath.
+        args: { DASHBOARD_PATH: dashboardPath },
       },
       loadBalancer: {
         domain: serviceDomain('api'),

--- a/apps/infra/sst.config.ts
+++ b/apps/infra/sst.config.ts
@@ -108,6 +108,16 @@ export default $config({
   },
 
   async run() {
+    // Stamp every IAM role this app creates with the workload permissions
+    // boundary. The deploy principal's grant to create/manage boxlite-* roles is
+    // CONDITIONAL on the created role carrying this boundary (see boxlite-deploy-delegation
+    // `AllowCreateBoundedRoles` / `AllowSetBoundary`, which require the boundary to be
+    // boxlite-workload-boundary or boxlite-cd-boundary); without it CreateRole/PutRolePermissionsBoundary
+    // are denied. Registered first, before any resource — including SST-internal roles — is created.
+    $transform(aws.iam.Role, (args) => {
+      args.permissionsBoundary ??= 'arn:aws:iam::064212132677:policy/boxlite-role-boundary'
+    })
+
     // Load .env overrides (anything unset falls back to auto-generated values)
     const { config } = await import('dotenv')
     config()
@@ -803,6 +813,11 @@ export default $config({
     })
 
     const runnerRole = new aws.iam.Role('RunnerRole', {
+      // Explicit name so the role falls under the deploy principal's boxlite-* IAM
+      // grant (LimitedIAM scopes role management to role/boxlite-*). The default
+      // auto-generated "RunnerRole-<hash>" name is outside that scope, so a deploy
+      // would be denied PutRolePermissionsBoundary/CreateRole on it.
+      name: `${$app.name}-${$app.stage}-runner`,
       assumeRolePolicy: JSON.stringify({
         Version: '2012-10-17',
         Statement: [{ Effect: 'Allow', Principal: { Service: 'ec2.amazonaws.com' }, Action: 'sts:AssumeRole' }],
@@ -833,7 +848,10 @@ export default $config({
         ],
       }),
     })
-    const runnerInstanceProfile = new aws.iam.InstanceProfile('RunnerProfile', { role: runnerRole.name })
+    const runnerInstanceProfile = new aws.iam.InstanceProfile('RunnerProfile', {
+      name: `${$app.name}-${$app.stage}-runner`,
+      role: runnerRole.name,
+    })
 
     // Dedicated runner security group (least-privilege, explicit in IaC).
     // Without it the runner falls back to the VPC's shared default SG, which

--- a/apps/infra/sst.config.ts
+++ b/apps/infra/sst.config.ts
@@ -224,7 +224,7 @@ export default $config({
     // Durable state survives accidental teardown the way the runner does (§10).
     // `removal: 'retain'` (above) already keeps prod resources on `sst remove`, but it
     // does NOT stop a targeted destroy, a replace-on-immutable-change, or an AWS-console
-    // delete — so production also gets RDS deletion-protection + a final snapshot.
+    // delete — so prod also gets RDS deletion-protection + a final snapshot.
     // S3 versioning is on in every stage: cheap, and the only guard against an
     // object-level overwrite/delete (which `removal` never covers). Redis is a
     // transient cache, so it needs neither.

--- a/apps/infra/sst.config.ts
+++ b/apps/infra/sst.config.ts
@@ -154,9 +154,16 @@ export default $config({
     if (!stackDomain) {
       throw new Error('STACK_DOMAIN is required (Cloudflare-managed subdomain, e.g. dev.boxlite.ai)')
     }
+    // Base for the service subdomains (api/proxy/ssh). Defaults to stackDomain so dev is unchanged
+    // (api.dev.boxlite.ai); prod sets SERVICES_DOMAIN=boxlite.ai so services live at api.boxlite.ai
+    // while the dashboard host stays on stackDomain (app.boxlite.ai).
+    const servicesDomain = process.env.SERVICES_DOMAIN || stackDomain
+    // Sub-path the dashboard is served under. Defaults to '' (root) so dev is unchanged; prod sets
+    // DASHBOARD_PATH=/dashboard so the dashboard is at app.boxlite.ai/dashboard. Leading slash, no trailing.
+    const dashboardPath = process.env.DASHBOARD_PATH || ''
     const cloudflareDns = sst.cloudflare.dns()
     const serviceDomain = (name: string) => ({
-      name: `${name}.${stackDomain}`,
+      name: `${name}.${servicesDomain}`,
       dns: cloudflareDns,
     })
 
@@ -374,7 +381,7 @@ export default $config({
         CLICKHOUSE_PASSWORD: clickHouseWriterPassword || 'unused',
         CLICKHOUSE_CREATE_SCHEMA: envOr('CLICKHOUSE_CREATE_SCHEMA', 'false'),
         CLICKHOUSE_COMPRESS: envOr('CLICKHOUSE_COMPRESS', 'none'),
-        BOXLITE_API_URL: envOr('BOXLITE_API_URL', `https://api.${stackDomain}/api`),
+        BOXLITE_API_URL: envOr('BOXLITE_API_URL', `https://api.${servicesDomain}/api`),
         BOXLITE_API_KEY: envOr(
           'BOXLITE_API_KEY',
           envOr('OTEL_COLLECTOR_API_KEY', envOr('ADMIN_API_KEY', adminApiKey.result)),
@@ -557,14 +564,14 @@ export default $config({
         S3_ROLE_NAME: s3AccessRoleName,
 
         // Proxy
-        PROXY_DOMAIN: envOr('PROXY_DOMAIN', `proxy.${stackDomain}`),
+        PROXY_DOMAIN: envOr('PROXY_DOMAIN', `proxy.${servicesDomain}`),
         PROXY_PROTOCOL: envOr('PROXY_PROTOCOL', 'https'),
         PROXY_API_KEY: envOr('PROXY_API_KEY', proxyApiKey.result),
-        PROXY_TEMPLATE_URL: envOr('PROXY_TEMPLATE_URL', `https://proxy.${stackDomain}`),
+        PROXY_TEMPLATE_URL: envOr('PROXY_TEMPLATE_URL', `https://proxy.${servicesDomain}`),
 
-        // SSH Gateway — friendly hostname `ssh.<stackDomain>` is provisioned
+        // SSH Gateway — friendly hostname `ssh.<servicesDomain>` is provisioned
         // as a Cloudflare CNAME pointing at the SshGateway NLB further below.
-        SSH_GATEWAY_URL: envOr('SSH_GATEWAY_URL', `ssh://ssh.${stackDomain}:${PORTS.SSH_GATEWAY}`),
+        SSH_GATEWAY_URL: envOr('SSH_GATEWAY_URL', `ssh://ssh.${servicesDomain}:${PORTS.SSH_GATEWAY}`),
         SSH_GATEWAY_API_KEY: envOr('SSH_GATEWAY_API_KEY', sshGatewayApiKey.result),
 
         // Admin
@@ -634,7 +641,11 @@ export default $config({
         // so this cross-origin dashboard→API path is explicitly allowed.
         DASHBOARD_URL: envOr('DASHBOARD_URL', `https://${stackDomain}`),
         APP_URL: envOr('APP_URL', ''),
-        DASHBOARD_BASE_API_URL: envOr('DASHBOARD_BASE_API_URL', `https://api.${stackDomain}`),
+        DASHBOARD_BASE_API_URL: envOr('DASHBOARD_BASE_API_URL', `https://api.${servicesDomain}`),
+        // Sub-path the dashboard SPA is served under ('' = root for dev; '/dashboard' for prod).
+        // Drives the Api's static-serve renderPath and the SPA's OIDC redirect_uri. DASHBOARD_URL
+        // stays the bare origin (no path) so the Api's CORS allow-list keeps matching.
+        DASHBOARD_PATH: dashboardPath,
 
         // Default runner — the API auto-seeds it at boot; v2 runners self-report
         DEFAULT_RUNNER_NAME: envOr('DEFAULT_RUNNER_NAME', 'default'),
@@ -683,7 +694,7 @@ export default $config({
     // ─── 7. EDGE SERVICES ────────────────────────────────────────────────────
     // Proxy: routes `<port>-<boxid>.proxy.<stack>` to the box port.
     // Wildcard cert covers *.proxy.<stack>; Cloudflare serves wildcard DNS.
-    const proxyDomain = `proxy.${stackDomain}`
+    const proxyDomain = `proxy.${servicesDomain}`
     new sst.aws.Service('Proxy', {
       cluster,
       image: { context: '../..', dockerfile: 'apps/proxy/Dockerfile', cache: false },
@@ -738,7 +749,7 @@ export default $config({
     cloudflareDns.createAlias(
       'SshGateway',
       {
-        name: `ssh.${stackDomain}`,
+        name: `ssh.${servicesDomain}`,
         aliasName: sshGateway.nodes.loadBalancer.dnsName,
         aliasZone: sshGateway.nodes.loadBalancer.zoneId,
       },

--- a/apps/infra/sst.config.ts
+++ b/apps/infra/sst.config.ts
@@ -129,8 +129,17 @@ export default $config({
     // grant matches. Without this, SST names instance profiles "<LogicalId>-<hash>" which is
     // outside the deploy role's allowed resource scope → iam:CreateInstanceProfile denied.
     // Explicit `name:` on a profile (e.g. RunnerProfile) wins because of `??=`.
+    //
+    // prod-only: prod was a fresh deploy, so its profiles are created under this name from the
+    // start. Stages that predate this transform (dev) already hold an auto-named profile
+    // (VpcNatInstanceProfile-<hash>); applying the rename there forces RemoveRoleFromInstanceProfile
+    // on the OLD name, which the stage's boxlite-<stage>-*-scoped deploy role cannot touch →
+    // iam:RemoveRoleFromInstanceProfile AccessDenied. Leaving those stages on SST's default name
+    // is a no-op against their existing state.
     $transform(aws.iam.InstanceProfile, (args, _opts, resourceName) => {
-      args.name ??= `${$app.name}-${$app.stage}-${resourceName}`
+      if ($app.stage === 'prod') {
+        args.name ??= `${$app.name}-${$app.stage}-${resourceName}`
+      }
     })
 
     // Load .env overrides (anything unset falls back to auto-generated values)

--- a/scripts/deploy/runner-update-binary.sh
+++ b/scripts/deploy/runner-update-binary.sh
@@ -37,17 +37,31 @@ fi
 echo "==> Upgrading boxlite-runner on stage=$STAGE region=$AWS_REGION"
 
 # Target instance: pin via BOXLITE_RUNNER_INSTANCE_ID (skips the tag lookup — for a specific
-# runner, or when the tag describe is unavailable), else find the default by Name tag.
+# runner, or when the tag describe is unavailable), else find the stage's default by Name tag.
+# The runner's tag is boxlite-<stage>-runner-default (set in sst.config.ts). For dev we also
+# accept the legacy un-staged "boxlite-runner-default" so a rollout still works in the window
+# before the next dev deploy re-tags the existing instance; prod never matches the legacy tag,
+# keeping a prod rollout from ever picking up the dev runner.
 if [[ -n "${BOXLITE_RUNNER_INSTANCE_ID:-}" ]]; then
   INSTANCE_ID="$BOXLITE_RUNNER_INSTANCE_ID"
 else
+  TAG_VALUES="boxlite-${STAGE}-runner-default"
+  if [[ "$STAGE" == "dev" ]]; then
+    TAG_VALUES="${TAG_VALUES},boxlite-runner-default"
+  fi
   INSTANCE_ID=$(aws ec2 describe-instances --region "$AWS_REGION" \
-    --filters "Name=tag:Name,Values=boxlite-runner-default" "Name=instance-state-name,Values=running" \
+    --filters "Name=tag:Name,Values=${TAG_VALUES}" "Name=instance-state-name,Values=running" \
     --query 'Reservations[].Instances[].InstanceId' --output text)
 fi
 
 if [[ -z "$INSTANCE_ID" || "$INSTANCE_ID" == "None" ]]; then
-  echo "error: no running boxlite-runner-default instance found in region $AWS_REGION" >&2
+  echo "error: no running boxlite-${STAGE}-runner-default instance found in region $AWS_REGION" >&2
+  exit 1
+fi
+# describe-instances returns whitespace-separated ids; more than one means the tag filter
+# matched multiple runners. Refuse rather than roll an ambiguous target — pin via BOXLITE_RUNNER_INSTANCE_ID.
+if [[ "$INSTANCE_ID" == *[[:space:]]* ]]; then
+  echo "error: tag filter matched multiple instances ($INSTANCE_ID); pin one via BOXLITE_RUNNER_INSTANCE_ID" >&2
   exit 1
 fi
 echo "    instance: $INSTANCE_ID"

--- a/scripts/deploy/runner-update-binary.sh
+++ b/scripts/deploy/runner-update-binary.sh
@@ -13,6 +13,8 @@
 # Usage:
 #   scripts/deploy/runner-update-binary.sh                  # version from Cargo.toml
 #   scripts/deploy/runner-update-binary.sh 0.9.5            # explicit version
+#   BOXLITE_RUNNER_TARBALL_URL=<url> STAGE=dev scripts/deploy/runner-update-binary.sh   # dev channel: install an unreleased build (refused on prod)
+#   BOXLITE_RUNNER_TARBALL_URL=<url> BOXLITE_RUNNER_TARBALL_SHA256_URL=<url> STAGE=dev ...       # dev channel with a separate sha256 URL (S3 presigned: ".sha256" can't be appended)
 #   AWS_REGION=us-west-2 scripts/deploy/runner-update-binary.sh
 #   STAGE=production scripts/deploy/runner-update-binary.sh
 
@@ -32,11 +34,17 @@ else
   fi
 fi
 
-echo "==> Upgrading boxlite-runner to v$VERSION on stage=$STAGE region=$AWS_REGION"
+echo "==> Upgrading boxlite-runner on stage=$STAGE region=$AWS_REGION"
 
-INSTANCE_ID=$(aws ec2 describe-instances --region "$AWS_REGION" \
-  --filters "Name=tag:Name,Values=boxlite-runner-default" "Name=instance-state-name,Values=running" \
-  --query 'Reservations[].Instances[].InstanceId' --output text)
+# Target instance: pin via BOXLITE_RUNNER_INSTANCE_ID (skips the tag lookup — for a specific
+# runner, or when the tag describe is unavailable), else find the default by Name tag.
+if [[ -n "${BOXLITE_RUNNER_INSTANCE_ID:-}" ]]; then
+  INSTANCE_ID="$BOXLITE_RUNNER_INSTANCE_ID"
+else
+  INSTANCE_ID=$(aws ec2 describe-instances --region "$AWS_REGION" \
+    --filters "Name=tag:Name,Values=boxlite-runner-default" "Name=instance-state-name,Values=running" \
+    --query 'Reservations[].Instances[].InstanceId' --output text)
+fi
 
 if [[ -z "$INSTANCE_ID" || "$INSTANCE_ID" == "None" ]]; then
   echo "error: no running boxlite-runner-default instance found in region $AWS_REGION" >&2
@@ -44,8 +52,27 @@ if [[ -z "$INSTANCE_ID" || "$INSTANCE_ID" == "None" ]]; then
 fi
 echo "    instance: $INSTANCE_ID"
 
-ASSET_BASE="https://github.com/boxlite-ai/boxlite/releases/download/v${VERSION}"
-ASSET_TARBALL="boxlite-runner-v${VERSION}-linux-amd64.tar.gz"
+# Dev channel: install an UNRELEASED build by passing its full tarball URL (a CI
+# build artifact / S3 dev path) instead of a published GitHub Release — lets us test
+# a runner change without cutting a formal release. Prod refuses it: prod only ever
+# installs a released version.
+if [[ -n "${BOXLITE_RUNNER_TARBALL_URL:-}" ]]; then
+  if [[ "$STAGE" == "prod" || "$STAGE" == "production" ]]; then
+    echo "error: BOXLITE_RUNNER_TARBALL_URL is not allowed on stage=$STAGE (prod installs released versions only)" >&2
+    exit 1
+  fi
+  ASSET_URL="$BOXLITE_RUNNER_TARBALL_URL"
+  echo "    source: dev tarball $ASSET_URL"
+else
+  ASSET_URL="https://github.com/boxlite-ai/boxlite/releases/download/v${VERSION}/boxlite-runner-v${VERSION}-linux-amd64.tar.gz"
+  echo "    source: release v$VERSION"
+fi
+
+# The .sha256 integrity manifest URL. For a GitHub release it sits next to the
+# tarball (URL + ".sha256"); for a dev tarball served via an S3 presigned URL that
+# suffix can't be appended (the signed query string would absorb it), so accept it
+# as a separate URL via BOXLITE_RUNNER_TARBALL_SHA256_URL.
+SHA_URL="${BOXLITE_RUNNER_TARBALL_SHA256_URL:-${ASSET_URL}.sha256}"
 
 # Remote upgrade script. Mirrors the boot user-data's integrity policy and adds a
 # rollback: download + checksum-verify BEFORE stopping the unit (so a failed or
@@ -58,14 +85,14 @@ echo "current version:"
 
 WORK=\$(mktemp -d)
 trap 'rm -rf "\$WORK"' EXIT
-curl -fsSL "${ASSET_BASE}/${ASSET_TARBALL}" -o "\$WORK/runner.tar.gz"
-if curl -fsSL "${ASSET_BASE}/${ASSET_TARBALL}.sha256" -o "\$WORK/runner.sha256"; then
+curl -fsSL "${ASSET_URL}" -o "\$WORK/runner.tar.gz"
+if curl -fsSL "${SHA_URL}" -o "\$WORK/runner.sha256"; then
   EXPECTED=\$(awk '{print \$1}' "\$WORK/runner.sha256")
   ACTUAL=\$(sha256sum "\$WORK/runner.tar.gz" | awk '{print \$1}')
   [ "\$EXPECTED" = "\$ACTUAL" ] || { echo "FATAL: checksum mismatch (want \$EXPECTED got \$ACTUAL)" >&2; exit 1; }
   echo "checksum verified (\$ACTUAL)"
 else
-  echo "WARNING: no .sha256 published for v${VERSION}; installing without integrity verification" >&2
+  echo "WARNING: no .sha256 at ${SHA_URL}; installing without integrity verification" >&2
 fi
 tar -xzf "\$WORK/runner.tar.gz" -C "\$WORK"
 test -x "\$WORK/boxlite-runner" || { echo "FATAL: tarball has no boxlite-runner binary" >&2; exit 1; }
@@ -84,7 +111,9 @@ if install -m 0755 "\$WORK/boxlite-runner" /usr/local/bin/boxlite-runner && syst
   [ "\$HAD_PREVIOUS" = true ] && rm -f /usr/local/bin/boxlite-runner.bak
   echo "systemd unit: active"
   echo "new version:"
-  /usr/local/bin/boxlite-runner --version
+  # --version exits non-zero standalone (it wants runtime config); never let that
+  # cosmetic print fail an already-successful install under set -e (false "Failed").
+  /usr/local/bin/boxlite-runner --version || true
 else
   echo "upgrade failed; rolling back" >&2
   if [ "\$HAD_PREVIOUS" = true ]; then

--- a/scripts/deploy/runner-update-binary.sh
+++ b/scripts/deploy/runner-update-binary.sh
@@ -16,7 +16,7 @@
 #   BOXLITE_RUNNER_TARBALL_URL=<url> STAGE=dev scripts/deploy/runner-update-binary.sh   # dev channel: install an unreleased build (refused on prod)
 #   BOXLITE_RUNNER_TARBALL_URL=<url> BOXLITE_RUNNER_TARBALL_SHA256_URL=<url> STAGE=dev ...       # dev channel with a separate sha256 URL (S3 presigned: ".sha256" can't be appended)
 #   AWS_REGION=us-west-2 scripts/deploy/runner-update-binary.sh
-#   STAGE=production scripts/deploy/runner-update-binary.sh
+#   STAGE=prod scripts/deploy/runner-update-binary.sh
 
 set -euo pipefail
 
@@ -35,6 +35,11 @@ else
 fi
 
 echo "==> Upgrading boxlite-runner on stage=$STAGE region=$AWS_REGION"
+
+if [[ "$STAGE" != "dev" && "$STAGE" != "prod" ]]; then
+  echo "error: unsupported STAGE=$STAGE (expected dev or prod)" >&2
+  exit 2
+fi
 
 # Target instance: pin via BOXLITE_RUNNER_INSTANCE_ID (skips the tag lookup — for a specific
 # runner, or when the tag describe is unavailable), else find the stage's default by Name tag.
@@ -71,7 +76,7 @@ echo "    instance: $INSTANCE_ID"
 # a runner change without cutting a formal release. Prod refuses it: prod only ever
 # installs a released version.
 if [[ -n "${BOXLITE_RUNNER_TARBALL_URL:-}" ]]; then
-  if [[ "$STAGE" == "prod" || "$STAGE" == "production" ]]; then
+  if [[ "$STAGE" == "prod" ]]; then
     echo "error: BOXLITE_RUNNER_TARBALL_URL is not allowed on stage=$STAGE (prod installs released versions only)" >&2
     exit 1
   fi


### PR DESCRIPTION
## What

Enables a second SST stage (**prod**) through the existing one-click **Deploy** + **Runner Rollout** buttons, without changing the dev flow. This branch is built on top of the dev-button work (#834) and **supersedes it** — it contains those commits plus the prod-enablement, so #834 does not need to be merged separately.

## Changes

- **`sst.config.ts`** — `REGION` reads `AWS_REGION` (default `ap-southeast-1`); runner EC2 `Name` tag is stage-scoped (`boxlite-<stage>-runner-default`) so dev/prod runners stay distinguishable.
- **`deploy.yml` / `runner-rollout.yml`** — stage choice adds `prod`; new `region` input replaces the hardcoded region; deploy gates on a per-stage GitHub Environment (`environment: ${{ inputs.stage }}`); runner-rollout `S3_BUCKET` is stage-scoped.
- **Deploy role renamed** `boxlite-github-deployer-<stage>` → `boxlite-app-<stage>-deploy` (assumed via OIDC).
- **`runner-update-binary.sh`** — stage-scoped tag lookup with a dev-only legacy fallback + a multi-match guard.
- **`scripts/seed-prod-from-dev.mjs`** (new) — copies a stage's SSM env to another, domain-rewriting `STACK_DOMAIN`, leaving Auth0 / SSH / runner-ip blank for manual seeding. Dry-run by default.

## Prerequisites before a prod deploy can run (account owner)

1. Create **`boxlite-app-dev-deploy`** and **`boxlite-app-prod-deploy`** (admin, **unbounded**; OIDC trust sub `repo:boxlite-ai/boxlite:environment:<stage>`). The existing dev role is renamed to `boxlite-app-dev-deploy`.
2. Extend **`boxlite-bounded-role-admin`** so `PassRole` + `AddRoleToInstanceProfile` cover `role/boxlite-prod-*` (today they list only `boxlite-dev-*` / `boxlite-e2e-*`).
3. Create a **`prod`** GitHub Environment.
4. Seed SSM `/boxlite/prod/{cloudflare-*, env/*}` (env via `seed-prod-from-dev.mjs`; Auth0 values filled once the prod Auth0 app exists).

## Safety

dev flow is unchanged (region defaults to `ap-southeast-1`, the `dev` GitHub Environment already exists). Reviewed for dev-safety, region-correctness, and GitHub Actions semantics; verified locally (YAML parse, `node --check`, `bash -n`, seed dry-run).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added manually-triggered deployment and runner rollout workflows with stage/region selection, diff/preview vs deploy, and upgrade/rollback controls.
* **Improvements**
  * Centralized deploy-time configuration in AWS SSM: seed dev→prod, auto-load stage-specific environment variables during `sst`, and updated teardown guidance.
  * Runner binary updates are now stage-aware, support installing from dev tarballs or release builds, and target the correct runner instances by stage.
  * Deploy configuration now uses an explicit AWS region fallback and applies a default IAM permissions boundary where needed.
* **Bug Fixes**
  * Prevented non-critical runner version checks from failing deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
