### PR TITLE
docs: add failure-class sweep principle to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,7 @@ Every change goes: understand → research → design → implement → test →
 **Cross-cutting** (apply at every phase)
 
 - Verify external findings against the working tree before acting. `/codex:adversarial-review`, lint, and PR comments work from a snapshot — they may name deleted code. `git grep` and `git diff` first.
+- Treat every failure as a class, not an instance: when one surfaces, find and fix every sibling of the same shape in the same pass — grounded in what's actually there, not speculation. A single-site fix to a systemic bug isn't done.
 - Honor scope reduction: "drop X" means drop X. Don't bundle adjacent improvements unprompted.
 
 **Communication**


### PR DESCRIPTION
Adds a Cross-cutting workflow bullet: when a failure surfaces, treat it as a class, not an instance, and find+fix every sibling of the same shape in the same pass — grounded in what's actually there, not speculation, with no pre-scoped tool or domain. A single-site fix to a systemic bug isn't done.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

No user-visible changes. This release includes internal documentation updates to development workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->