### PR TITLE
fix(jailer): set LD_LIBRARY_PATH in bwrap sandbox so the shim can dlopen libkrunfw

### DIFF
--- a/src/boxlite/resources/seccomp/aarch64-unknown-linux-gnu.json
+++ b/src/boxlite/resources/seccomp/aarch64-unknown-linux-gnu.json
@@ -3,6 +3,54 @@
         "default_action": "trap",
         "filter_action": "allow",
         "filter": [
+      {
+        "syscall": "getxattr",
+        "comment": "virtiofs xattr passthrough (e.g. dropping security.capability on write); a blocked xattr syscall SIGSYS-kills the VMM"
+      },
+      {
+        "syscall": "lgetxattr",
+        "comment": "virtiofs xattr passthrough (e.g. dropping security.capability on write); a blocked xattr syscall SIGSYS-kills the VMM"
+      },
+      {
+        "syscall": "fgetxattr",
+        "comment": "virtiofs xattr passthrough (e.g. dropping security.capability on write); a blocked xattr syscall SIGSYS-kills the VMM"
+      },
+      {
+        "syscall": "setxattr",
+        "comment": "virtiofs xattr passthrough (e.g. dropping security.capability on write); a blocked xattr syscall SIGSYS-kills the VMM"
+      },
+      {
+        "syscall": "lsetxattr",
+        "comment": "virtiofs xattr passthrough (e.g. dropping security.capability on write); a blocked xattr syscall SIGSYS-kills the VMM"
+      },
+      {
+        "syscall": "fsetxattr",
+        "comment": "virtiofs xattr passthrough (e.g. dropping security.capability on write); a blocked xattr syscall SIGSYS-kills the VMM"
+      },
+      {
+        "syscall": "listxattr",
+        "comment": "virtiofs xattr passthrough (e.g. dropping security.capability on write); a blocked xattr syscall SIGSYS-kills the VMM"
+      },
+      {
+        "syscall": "llistxattr",
+        "comment": "virtiofs xattr passthrough (e.g. dropping security.capability on write); a blocked xattr syscall SIGSYS-kills the VMM"
+      },
+      {
+        "syscall": "flistxattr",
+        "comment": "virtiofs xattr passthrough (e.g. dropping security.capability on write); a blocked xattr syscall SIGSYS-kills the VMM"
+      },
+      {
+        "syscall": "removexattr",
+        "comment": "virtiofs xattr passthrough (e.g. dropping security.capability on write); a blocked xattr syscall SIGSYS-kills the VMM"
+      },
+      {
+        "syscall": "lremovexattr",
+        "comment": "virtiofs xattr passthrough (e.g. dropping security.capability on write); a blocked xattr syscall SIGSYS-kills the VMM"
+      },
+      {
+        "syscall": "fremovexattr",
+        "comment": "virtiofs xattr passthrough (e.g. dropping security.capability on write); a blocked xattr syscall SIGSYS-kills the VMM"
+      },
             {
                 "syscall": "newfstatat",
                 "comment": "Used when creating snapshots in vmm:persist::snapshot_memory_to_file through std::fs::File::metadata"

--- a/src/boxlite/resources/seccomp/aarch64-unknown-linux-musl.json
+++ b/src/boxlite/resources/seccomp/aarch64-unknown-linux-musl.json
@@ -3,6 +3,54 @@
         "default_action": "trap",
         "filter_action": "allow",
         "filter": [
+      {
+        "syscall": "getxattr",
+        "comment": "virtiofs xattr passthrough (e.g. dropping security.capability on write); a blocked xattr syscall SIGSYS-kills the VMM"
+      },
+      {
+        "syscall": "lgetxattr",
+        "comment": "virtiofs xattr passthrough (e.g. dropping security.capability on write); a blocked xattr syscall SIGSYS-kills the VMM"
+      },
+      {
+        "syscall": "fgetxattr",
+        "comment": "virtiofs xattr passthrough (e.g. dropping security.capability on write); a blocked xattr syscall SIGSYS-kills the VMM"
+      },
+      {
+        "syscall": "setxattr",
+        "comment": "virtiofs xattr passthrough (e.g. dropping security.capability on write); a blocked xattr syscall SIGSYS-kills the VMM"
+      },
+      {
+        "syscall": "lsetxattr",
+        "comment": "virtiofs xattr passthrough (e.g. dropping security.capability on write); a blocked xattr syscall SIGSYS-kills the VMM"
+      },
+      {
+        "syscall": "fsetxattr",
+        "comment": "virtiofs xattr passthrough (e.g. dropping security.capability on write); a blocked xattr syscall SIGSYS-kills the VMM"
+      },
+      {
+        "syscall": "listxattr",
+        "comment": "virtiofs xattr passthrough (e.g. dropping security.capability on write); a blocked xattr syscall SIGSYS-kills the VMM"
+      },
+      {
+        "syscall": "llistxattr",
+        "comment": "virtiofs xattr passthrough (e.g. dropping security.capability on write); a blocked xattr syscall SIGSYS-kills the VMM"
+      },
+      {
+        "syscall": "flistxattr",
+        "comment": "virtiofs xattr passthrough (e.g. dropping security.capability on write); a blocked xattr syscall SIGSYS-kills the VMM"
+      },
+      {
+        "syscall": "removexattr",
+        "comment": "virtiofs xattr passthrough (e.g. dropping security.capability on write); a blocked xattr syscall SIGSYS-kills the VMM"
+      },
+      {
+        "syscall": "lremovexattr",
+        "comment": "virtiofs xattr passthrough (e.g. dropping security.capability on write); a blocked xattr syscall SIGSYS-kills the VMM"
+      },
+      {
+        "syscall": "fremovexattr",
+        "comment": "virtiofs xattr passthrough (e.g. dropping security.capability on write); a blocked xattr syscall SIGSYS-kills the VMM"
+      },
             {
                 "syscall": "newfstatat",
                 "comment": "Used when creating snapshots in vmm:persist::snapshot_memory_to_file through std::fs::File::metadata"

--- a/src/boxlite/resources/seccomp/x86_64-unknown-linux-gnu.json
+++ b/src/boxlite/resources/seccomp/x86_64-unknown-linux-gnu.json
@@ -4,6 +4,54 @@
     "filter_action": "allow",
     "filter": [
       {
+        "syscall": "getxattr",
+        "comment": "virtiofs xattr passthrough (e.g. dropping security.capability on write); a blocked xattr syscall SIGSYS-kills the VMM"
+      },
+      {
+        "syscall": "lgetxattr",
+        "comment": "virtiofs xattr passthrough (e.g. dropping security.capability on write); a blocked xattr syscall SIGSYS-kills the VMM"
+      },
+      {
+        "syscall": "fgetxattr",
+        "comment": "virtiofs xattr passthrough (e.g. dropping security.capability on write); a blocked xattr syscall SIGSYS-kills the VMM"
+      },
+      {
+        "syscall": "setxattr",
+        "comment": "virtiofs xattr passthrough (e.g. dropping security.capability on write); a blocked xattr syscall SIGSYS-kills the VMM"
+      },
+      {
+        "syscall": "lsetxattr",
+        "comment": "virtiofs xattr passthrough (e.g. dropping security.capability on write); a blocked xattr syscall SIGSYS-kills the VMM"
+      },
+      {
+        "syscall": "fsetxattr",
+        "comment": "virtiofs xattr passthrough (e.g. dropping security.capability on write); a blocked xattr syscall SIGSYS-kills the VMM"
+      },
+      {
+        "syscall": "listxattr",
+        "comment": "virtiofs xattr passthrough (e.g. dropping security.capability on write); a blocked xattr syscall SIGSYS-kills the VMM"
+      },
+      {
+        "syscall": "llistxattr",
+        "comment": "virtiofs xattr passthrough (e.g. dropping security.capability on write); a blocked xattr syscall SIGSYS-kills the VMM"
+      },
+      {
+        "syscall": "flistxattr",
+        "comment": "virtiofs xattr passthrough (e.g. dropping security.capability on write); a blocked xattr syscall SIGSYS-kills the VMM"
+      },
+      {
+        "syscall": "removexattr",
+        "comment": "virtiofs xattr passthrough (e.g. dropping security.capability on write); a blocked xattr syscall SIGSYS-kills the VMM"
+      },
+      {
+        "syscall": "lremovexattr",
+        "comment": "virtiofs xattr passthrough (e.g. dropping security.capability on write); a blocked xattr syscall SIGSYS-kills the VMM"
+      },
+      {
+        "syscall": "fremovexattr",
+        "comment": "virtiofs xattr passthrough (e.g. dropping security.capability on write); a blocked xattr syscall SIGSYS-kills the VMM"
+      },
+      {
         "syscall": "stat",
         "comment": "Used when creating snapshots in vmm:persist::snapshot_memory_to_file through std::fs::File::metadata"
       },

--- a/src/boxlite/resources/seccomp/x86_64-unknown-linux-musl.json
+++ b/src/boxlite/resources/seccomp/x86_64-unknown-linux-musl.json
@@ -4,6 +4,54 @@
     "filter_action": "allow",
     "filter": [
       {
+        "syscall": "getxattr",
+        "comment": "virtiofs xattr passthrough (e.g. dropping security.capability on write); a blocked xattr syscall SIGSYS-kills the VMM"
+      },
+      {
+        "syscall": "lgetxattr",
+        "comment": "virtiofs xattr passthrough (e.g. dropping security.capability on write); a blocked xattr syscall SIGSYS-kills the VMM"
+      },
+      {
+        "syscall": "fgetxattr",
+        "comment": "virtiofs xattr passthrough (e.g. dropping security.capability on write); a blocked xattr syscall SIGSYS-kills the VMM"
+      },
+      {
+        "syscall": "setxattr",
+        "comment": "virtiofs xattr passthrough (e.g. dropping security.capability on write); a blocked xattr syscall SIGSYS-kills the VMM"
+      },
+      {
+        "syscall": "lsetxattr",
+        "comment": "virtiofs xattr passthrough (e.g. dropping security.capability on write); a blocked xattr syscall SIGSYS-kills the VMM"
+      },
+      {
+        "syscall": "fsetxattr",
+        "comment": "virtiofs xattr passthrough (e.g. dropping security.capability on write); a blocked xattr syscall SIGSYS-kills the VMM"
+      },
+      {
+        "syscall": "listxattr",
+        "comment": "virtiofs xattr passthrough (e.g. dropping security.capability on write); a blocked xattr syscall SIGSYS-kills the VMM"
+      },
+      {
+        "syscall": "llistxattr",
+        "comment": "virtiofs xattr passthrough (e.g. dropping security.capability on write); a blocked xattr syscall SIGSYS-kills the VMM"
+      },
+      {
+        "syscall": "flistxattr",
+        "comment": "virtiofs xattr passthrough (e.g. dropping security.capability on write); a blocked xattr syscall SIGSYS-kills the VMM"
+      },
+      {
+        "syscall": "removexattr",
+        "comment": "virtiofs xattr passthrough (e.g. dropping security.capability on write); a blocked xattr syscall SIGSYS-kills the VMM"
+      },
+      {
+        "syscall": "lremovexattr",
+        "comment": "virtiofs xattr passthrough (e.g. dropping security.capability on write); a blocked xattr syscall SIGSYS-kills the VMM"
+      },
+      {
+        "syscall": "fremovexattr",
+        "comment": "virtiofs xattr passthrough (e.g. dropping security.capability on write); a blocked xattr syscall SIGSYS-kills the VMM"
+      },
+      {
         "syscall": "stat",
         "comment": "Used when creating snapshots in vmm:persist::snapshot_memory_to_file through std::fs::File::metadata"
       },

--- a/src/boxlite/src/jailer/sandbox/bwrap.rs
+++ b/src/boxlite/src/jailer/sandbox/bwrap.rs
@@ -114,6 +114,17 @@ impl Sandbox for BwrapSandbox {
             .setenv("PATH", "/usr/bin:/bin:/usr/sbin:/sbin")
             .setenv("HOME", "/root");
 
+        // libkrun `dlopen`s libkrunfw.so.5 during `krun_start_enter`. The shim
+        // is statically linked, so its `$ORIGIN` rpath is ineffective for
+        // dlopen, and `--clearenv` above wiped the `LD_LIBRARY_PATH` the shim
+        // would otherwise inherit from the spawning process. The shim's own
+        // directory (`<box>/bin`) holds the copied libkrunfw and is bound into
+        // the sandbox, so point the loader there — without this the VM fails to
+        // start with "Couldn't find or load libkrunfw.so.5" (libkrun status=-2).
+        if let Some(shim_dir) = std::path::Path::new(&binary).parent() {
+            bwrap_cmd.setenv("LD_LIBRARY_PATH", shim_dir.to_string_lossy().into_owned());
+        }
+
         // Preserve debugging environment variables
         if let Ok(rust_log) = std::env::var("RUST_LOG") {
             bwrap_cmd.setenv("RUST_LOG", rust_log);
@@ -141,5 +152,54 @@ impl Sandbox for BwrapSandbox {
 
     fn name(&self) -> &'static str {
         "bwrap"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::advanced_options::ResourceLimits;
+
+    /// The shim is statically linked, so libkrun's `dlopen` of `libkrunfw.so.5`
+    /// can only be satisfied via `LD_LIBRARY_PATH` inside the `--clearenv`
+    /// sandbox — the shim's `$ORIGIN` rpath is absent and the inherited
+    /// `LD_LIBRARY_PATH` is wiped by `--clearenv`. Without this the VM fails to
+    /// start ("Couldn't find or load libkrunfw.so.5", libkrun status=-2). This
+    /// guards the env var the composable `apply()` dropped relative to the
+    /// legacy `build_shim_command`.
+    #[test]
+    fn apply_sets_ld_library_path_to_shim_dir() {
+        if !bwrap::is_available() {
+            eprintln!("skipping apply_sets_ld_library_path_to_shim_dir: bwrap not available");
+            return;
+        }
+
+        let limits = Box::leak(Box::new(ResourceLimits::default()));
+        let ctx = SandboxContext {
+            id: "test-box",
+            paths: vec![],
+            resource_limits: limits,
+            network_enabled: false,
+            sandbox_profile: None,
+        };
+
+        let shim = "/var/lib/boxlite/boxes/abc/bin/boxlite-shim";
+        let mut cmd = Command::new(shim);
+        BwrapSandbox::new().apply(&ctx, &mut cmd);
+
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+
+        let pos = args
+            .windows(3)
+            .position(|w| w[0] == "--setenv" && w[1] == "LD_LIBRARY_PATH")
+            .expect("bwrap must --setenv LD_LIBRARY_PATH so the static shim can dlopen libkrunfw");
+        assert_eq!(
+            args[pos + 2],
+            "/var/lib/boxlite/boxes/abc/bin",
+            "LD_LIBRARY_PATH must point at the shim's own directory (where libkrunfw is copied)"
+        );
     }
 }

--- a/src/boxlite/src/jailer/sandbox/bwrap.rs
+++ b/src/boxlite/src/jailer/sandbox/bwrap.rs
@@ -112,22 +112,19 @@ impl Sandbox for BwrapSandbox {
         // The statically-linked shim dlopen's libkrunfw via LD_LIBRARY_PATH (its
         // `$ORIGIN` rpath is ineffective), and `--clearenv` wipes it — without
         // this the VM fails to start ("Couldn't find or load libkrunfw.so.5",
-        // libkrun status=-2). Prefer the value `configure_library_env`
-        // precomputed for the parent (the bound runtime dir holding every
-        // bundled library); fall back to the shim's own directory (`<box>/bin`,
-        // also bound and holding the copied libkrunfw) when nothing was inherited.
-        let ld_library_path = std::env::var("LD_LIBRARY_PATH").unwrap_or_else(|_| {
-            std::path::Path::new(&binary)
-                .parent()
-                .map(|dir| dir.to_string_lossy().into_owned())
-                .unwrap_or_default()
-        });
+        // libkrun status=-2). Point it at the shim's own directory (`<box>/bin`),
+        // which is bound into the sandbox and is exactly where `copy_libkrunfw`
+        // placed the library the shim loads.
+        let shim_dir = std::path::Path::new(&binary)
+            .parent()
+            .map(|dir| dir.to_string_lossy().into_owned())
+            .unwrap_or_default();
 
         bwrap_cmd
             .with_clearenv()
             .setenv("PATH", "/usr/bin:/bin:/usr/sbin:/sbin")
             .setenv("HOME", "/root")
-            .setenv("LD_LIBRARY_PATH", ld_library_path);
+            .setenv("LD_LIBRARY_PATH", shim_dir);
 
         // Preserve debugging environment variables
         if let Ok(rust_log) = std::env::var("RUST_LOG") {
@@ -200,12 +197,10 @@ mod tests {
             .windows(3)
             .position(|w| w[0] == "--setenv" && w[1] == "LD_LIBRARY_PATH")
             .expect("bwrap must --setenv LD_LIBRARY_PATH so the static shim can dlopen libkrunfw");
-        // The value is either the inherited LD_LIBRARY_PATH or the shim dir
-        // fallback; both are non-empty. (We can't assert the exact value: the
-        // test process may itself have LD_LIBRARY_PATH set, which wins.)
-        assert!(
-            !args[pos + 2].is_empty(),
-            "LD_LIBRARY_PATH must be set to a non-empty search path"
+        assert_eq!(
+            args[pos + 2],
+            "/var/lib/boxlite/boxes/abc/bin",
+            "LD_LIBRARY_PATH must point at the shim's own directory (where libkrunfw is copied)"
         );
     }
 }

--- a/src/boxlite/src/jailer/sandbox/bwrap.rs
+++ b/src/boxlite/src/jailer/sandbox/bwrap.rs
@@ -117,11 +117,16 @@ impl Sandbox for BwrapSandbox {
         // libkrun `dlopen`s libkrunfw.so.5 during `krun_start_enter`. The shim
         // is statically linked, so its `$ORIGIN` rpath is ineffective for
         // dlopen, and `--clearenv` above wiped the `LD_LIBRARY_PATH` the shim
-        // would otherwise inherit from the spawning process. The shim's own
-        // directory (`<box>/bin`) holds the copied libkrunfw and is bound into
-        // the sandbox, so point the loader there — without this the VM fails to
-        // start with "Couldn't find or load libkrunfw.so.5" (libkrun status=-2).
-        if let Some(shim_dir) = std::path::Path::new(&binary).parent() {
+        // would otherwise inherit — without it the VM fails to start with
+        // "Couldn't find or load libkrunfw.so.5" (libkrun status=-2).
+        //
+        // Prefer the value `configure_library_env` precomputed for the parent
+        // (it points at the bound runtime dir holding every bundled library);
+        // fall back to the shim's own directory (`<box>/bin`, also bound and
+        // holding the copied libkrunfw) when nothing was inherited.
+        if let Ok(ld_library_path) = std::env::var("LD_LIBRARY_PATH") {
+            bwrap_cmd.setenv("LD_LIBRARY_PATH", ld_library_path);
+        } else if let Some(shim_dir) = std::path::Path::new(&binary).parent() {
             bwrap_cmd.setenv("LD_LIBRARY_PATH", shim_dir.to_string_lossy().into_owned());
         }
 
@@ -196,10 +201,12 @@ mod tests {
             .windows(3)
             .position(|w| w[0] == "--setenv" && w[1] == "LD_LIBRARY_PATH")
             .expect("bwrap must --setenv LD_LIBRARY_PATH so the static shim can dlopen libkrunfw");
-        assert_eq!(
-            args[pos + 2],
-            "/var/lib/boxlite/boxes/abc/bin",
-            "LD_LIBRARY_PATH must point at the shim's own directory (where libkrunfw is copied)"
+        // The value is either the inherited LD_LIBRARY_PATH or the shim dir
+        // fallback; both are non-empty. (We can't assert the exact value: the
+        // test process may itself have LD_LIBRARY_PATH set, which wins.)
+        assert!(
+            !args[pos + 2].is_empty(),
+            "LD_LIBRARY_PATH must be set to a non-empty search path"
         );
     }
 }

--- a/src/boxlite/src/jailer/sandbox/bwrap.rs
+++ b/src/boxlite/src/jailer/sandbox/bwrap.rs
@@ -109,26 +109,25 @@ impl Sandbox for BwrapSandbox {
         // =====================================================================
         // Environment sanitization
         // =====================================================================
+        // The statically-linked shim dlopen's libkrunfw via LD_LIBRARY_PATH (its
+        // `$ORIGIN` rpath is ineffective), and `--clearenv` wipes it — without
+        // this the VM fails to start ("Couldn't find or load libkrunfw.so.5",
+        // libkrun status=-2). Prefer the value `configure_library_env`
+        // precomputed for the parent (the bound runtime dir holding every
+        // bundled library); fall back to the shim's own directory (`<box>/bin`,
+        // also bound and holding the copied libkrunfw) when nothing was inherited.
+        let ld_library_path = std::env::var("LD_LIBRARY_PATH").unwrap_or_else(|_| {
+            std::path::Path::new(&binary)
+                .parent()
+                .map(|dir| dir.to_string_lossy().into_owned())
+                .unwrap_or_default()
+        });
+
         bwrap_cmd
             .with_clearenv()
             .setenv("PATH", "/usr/bin:/bin:/usr/sbin:/sbin")
-            .setenv("HOME", "/root");
-
-        // libkrun `dlopen`s libkrunfw.so.5 during `krun_start_enter`. The shim
-        // is statically linked, so its `$ORIGIN` rpath is ineffective for
-        // dlopen, and `--clearenv` above wiped the `LD_LIBRARY_PATH` the shim
-        // would otherwise inherit — without it the VM fails to start with
-        // "Couldn't find or load libkrunfw.so.5" (libkrun status=-2).
-        //
-        // Prefer the value `configure_library_env` precomputed for the parent
-        // (it points at the bound runtime dir holding every bundled library);
-        // fall back to the shim's own directory (`<box>/bin`, also bound and
-        // holding the copied libkrunfw) when nothing was inherited.
-        if let Ok(ld_library_path) = std::env::var("LD_LIBRARY_PATH") {
-            bwrap_cmd.setenv("LD_LIBRARY_PATH", ld_library_path);
-        } else if let Some(shim_dir) = std::path::Path::new(&binary).parent() {
-            bwrap_cmd.setenv("LD_LIBRARY_PATH", shim_dir.to_string_lossy().into_owned());
-        }
+            .setenv("HOME", "/root")
+            .setenv("LD_LIBRARY_PATH", ld_library_path);
 
         // Preserve debugging environment variables
         if let Ok(rust_log) = std::env::var("RUST_LOG") {

--- a/src/boxlite/tests/jailer.rs
+++ b/src/boxlite/tests/jailer.rs
@@ -168,21 +168,17 @@ fn write_deny_boxes_profile(home_dir: &std::path::Path) -> std::path::PathBuf {
 // DEFAULT CONFIGURATION TESTS
 // ============================================================================
 
-/// Verify SecurityOptions::default() enables the jailer on macOS only.
+/// Verify SecurityOptions::default() enables the jailer (secure by default).
+///
+/// Since #652 the default profile is fully enabled on every supported
+/// platform, so `jailer_enabled` is `true` on both macOS and Linux.
 #[test]
 fn default_security_options_enable_jailer_on_supported_platforms() {
     let opts = SecurityOptions::default();
 
-    #[cfg(target_os = "macos")]
     assert!(
         opts.jailer_enabled,
-        "Jailer should be enabled by default on macOS"
-    );
-
-    #[cfg(not(target_os = "macos"))]
-    assert!(
-        !opts.jailer_enabled,
-        "Jailer should be disabled by default on Linux and unsupported platforms"
+        "Jailer should be enabled by default (secure by default)"
     );
 }
 

--- a/src/boxlite/tests/jailer.rs
+++ b/src/boxlite/tests/jailer.rs
@@ -327,6 +327,46 @@ async fn jailer_disabled_with_same_profile_still_starts() {
 // LINUX-ONLY: Namespace isolation enforcement
 // ============================================================================
 
+/// Find a descendant of `root` whose mount namespace differs from `host`.
+///
+/// `shim.pid` records the *outer* bwrap launcher, which stays in the host mount
+/// namespace. bwrap runs with `--unshare-pid`, so it forks: the sandboxed
+/// processes — the inner bwrap and the shim itself (which runs under libkrun,
+/// so its `comm` shows as "libkrun VM", not "boxlite-shim") — live in a new
+/// namespace below it. Walk `/proc` parent links from `root` and return the
+/// first descendant that is actually isolated. Returns `None` only if no
+/// descendant left the host namespace, i.e. isolation genuinely failed.
+#[cfg(target_os = "linux")]
+fn isolated_descendant(root: u32, host: &std::path::Path) -> Option<u32> {
+    let procs: Vec<(u32, u32)> = std::fs::read_dir("/proc")
+        .ok()?
+        .flatten()
+        .filter_map(|e| {
+            let pid = e.file_name().to_str()?.parse::<u32>().ok()?;
+            let status = std::fs::read_to_string(format!("/proc/{pid}/status")).ok()?;
+            let ppid = status
+                .lines()
+                .find_map(|l| l.strip_prefix("PPid:")?.trim().parse::<u32>().ok())?;
+            Some((pid, ppid))
+        })
+        .collect();
+
+    let mut stack = vec![root];
+    while let Some(cur) = stack.pop() {
+        for (pid, ppid) in &procs {
+            if *ppid == cur {
+                let isolated = std::fs::read_link(format!("/proc/{pid}/ns/mnt"))
+                    .is_ok_and(|ns| ns.as_path() != host);
+                if isolated {
+                    return Some(*pid);
+                }
+                stack.push(*pid);
+            }
+        }
+    }
+    None
+}
+
 /// On Linux, verify bwrap creates an isolated mount namespace for the shim.
 #[cfg(target_os = "linux")]
 #[tokio::test]
@@ -347,18 +387,23 @@ async fn jailer_creates_isolated_mount_namespace() {
         .join("boxes")
         .join(t.bx.id().as_str())
         .join("shim.pid");
-    let shim_pid = boxlite::util::PidFileReader::at(&pid_file)
+    let recorded_pid = boxlite::util::PidFileReader::at(&pid_file)
         .read()
         .map(|r| r.pid)
         .expect("Should read shim PID file");
 
     let self_mnt_ns =
         std::fs::read_link("/proc/self/ns/mnt").expect("Should read own mount namespace");
-    let shim_mnt_ns = std::fs::read_link(format!("/proc/{}/ns/mnt", shim_pid))
-        .expect("Should read shim mount namespace");
 
-    assert_ne!(
-        self_mnt_ns, shim_mnt_ns,
-        "Shim should be in a different mount namespace (bwrap isolation active)"
+    // The recorded pid is the outer bwrap launcher, which shares the test's
+    // (host) mount namespace; the sandboxed processes are its descendants in a
+    // new namespace. Verify at least one descendant is actually isolated.
+    let isolated = isolated_descendant(recorded_pid, &self_mnt_ns);
+
+    assert!(
+        isolated.is_some(),
+        "bwrap should place the sandboxed process tree in a different mount \
+         namespace than the test, but recorded pid {recorded_pid} and all of its \
+         descendants share the test namespace {self_mnt_ns:?} (bwrap isolation inactive)"
     );
 }

--- a/src/boxlite/tests/jailer.rs
+++ b/src/boxlite/tests/jailer.rs
@@ -338,8 +338,10 @@ async fn jailer_disabled_with_same_profile_still_starts() {
 /// descendant left the host namespace, i.e. isolation genuinely failed.
 #[cfg(target_os = "linux")]
 fn isolated_descendant(root: u32, host: &std::path::Path) -> Option<u32> {
+    // A failure to read /proc is a broken test environment, not "no isolation";
+    // fail fast with the real cause rather than reporting an isolation failure.
     let procs: Vec<(u32, u32)> = std::fs::read_dir("/proc")
-        .ok()?
+        .expect("read /proc to walk the process tree")
         .flatten()
         .filter_map(|e| {
             let pid = e.file_name().to_str()?.parse::<u32>().ok()?;


### PR DESCRIPTION
miss the LD_LIBRARY_PATH env so the libkrunfw cannot be found while static links

## Test plan

Unit guard `apply_sets_ld_library_path_to_shim_dir` (two-sided):
- **with fix** → `ok`
- **revert fix** → `FAILED` ("bwrap must --setenv LD_LIBRARY_PATH so the static shim can dlopen libkrunfw")

Root cause was reproduced/confirmed live on the `boxlite-e2e` runner: captured `shim.stderr` showed the libkrunfw dlopen failure; the bwrap cmdline had `--clearenv --setenv PATH … --setenv HOME …` with no `LD_LIBRARY_PATH`; `<box>/bin` contained `libkrunfw.so.5` and was bound in.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox startup so the runtime can find required libraries more reliably.
  * Updated jailer checks to better reflect isolation behavior across supported platforms.
  * Fixed containerized filesystem support for extended attributes, improving compatibility with virtualized file sharing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->