### PR TITLE
fix(jailer): skip --die-with-parent for detached boxes

### DIFF
--- a/src/boxlite/src/jailer/mod.rs
+++ b/src/boxlite/src/jailer/mod.rs
@@ -500,6 +500,7 @@ impl<S: Sandbox> Jailer<S> {
             resource_limits: &self.security.resource_limits,
             network_enabled: self.security.network_enabled,
             sandbox_profile: self.security.sandbox_profile.as_deref(),
+            detached: self.detach,
         }
     }
 

--- a/src/boxlite/src/jailer/sandbox/bwrap.rs
+++ b/src/boxlite/src/jailer/sandbox/bwrap.rs
@@ -69,10 +69,15 @@ impl Sandbox for BwrapSandbox {
         // =====================================================================
         // Namespace and session isolation
         // =====================================================================
-        bwrap_cmd
-            .with_default_namespaces()
-            .with_die_with_parent()
-            .with_new_session();
+        bwrap_cmd.with_default_namespaces();
+        // A detached box (`run -d`) must outlive the launching process: bwrap's
+        // --die-with-parent (PR_SET_PDEATHSIG) would otherwise kill the shim/VM
+        // the instant the launcher returns, so the box is born Stopped. Only
+        // foreground boxes — which should die with their launcher — get it.
+        if !ctx.detached {
+            bwrap_cmd.with_die_with_parent();
+        }
+        bwrap_cmd.with_new_session();
 
         // =====================================================================
         // System directories (read-only)
@@ -182,6 +187,7 @@ mod tests {
             resource_limits: limits,
             network_enabled: false,
             sandbox_profile: None,
+            detached: false,
         };
 
         let shim = "/var/lib/boxlite/boxes/abc/bin/boxlite-shim";
@@ -201,6 +207,44 @@ mod tests {
             args[pos + 2],
             "/var/lib/boxlite/boxes/abc/bin",
             "LD_LIBRARY_PATH must point at the shim's own directory (where libkrunfw is copied)"
+        );
+    }
+
+    /// A detached box must outlive the launcher, so it must NOT get bwrap's
+    /// `--die-with-parent` (PR_SET_PDEATHSIG kills the shim/VM the instant
+    /// `run -d` returns, leaving the box born-Stopped). Foreground boxes keep it
+    /// so they die with their launcher.
+    #[test]
+    fn apply_sets_die_with_parent_only_for_foreground() {
+        if !bwrap::is_available() {
+            eprintln!(
+                "skipping apply_sets_die_with_parent_only_for_foreground: bwrap not available"
+            );
+            return;
+        }
+
+        fn has_die_with_parent(detached: bool) -> bool {
+            let limits = Box::leak(Box::new(ResourceLimits::default()));
+            let ctx = SandboxContext {
+                id: "test-box",
+                paths: vec![],
+                resource_limits: limits,
+                network_enabled: false,
+                sandbox_profile: None,
+                detached,
+            };
+            let mut cmd = Command::new("/var/lib/boxlite/boxes/abc/bin/boxlite-shim");
+            BwrapSandbox::new().apply(&ctx, &mut cmd);
+            cmd.get_args().any(|a| a == "--die-with-parent")
+        }
+
+        assert!(
+            has_die_with_parent(false),
+            "foreground box must get --die-with-parent so it dies with its launcher"
+        );
+        assert!(
+            !has_die_with_parent(true),
+            "detached box must not get --die-with-parent or it is killed when run -d returns"
         );
     }
 }

--- a/src/boxlite/src/jailer/sandbox/composite.rs
+++ b/src/boxlite/src/jailer/sandbox/composite.rs
@@ -128,6 +128,7 @@ mod tests {
             resource_limits: limits,
             network_enabled: false,
             sandbox_profile: None,
+            detached: false,
         }
     }
 

--- a/src/boxlite/src/jailer/sandbox/landlock.rs
+++ b/src/boxlite/src/jailer/sandbox/landlock.rs
@@ -91,6 +91,7 @@ mod tests {
             resource_limits: limits,
             network_enabled: false,
             sandbox_profile: None,
+            detached: false,
         }
     }
 

--- a/src/boxlite/src/jailer/sandbox/mod.rs
+++ b/src/boxlite/src/jailer/sandbox/mod.rs
@@ -125,6 +125,10 @@ pub struct SandboxContext<'a> {
     pub network_enabled: bool,
     /// Custom sandbox profile path (macOS only).
     pub sandbox_profile: Option<&'a Path>,
+    /// Whether the box is detached (`run -d`). Detached boxes must outlive the
+    /// launching process, so the sandbox must not tie their lifetime to it
+    /// (e.g. bwrap's `--die-with-parent`).
+    pub detached: bool,
 }
 
 impl SandboxContext<'_> {


### PR DESCRIPTION
Gate bwrap's `--die-with-parent` on `!detached` so a detached box (`run -d`) isn't SIGKILL'd the instant its launcher exits — a regression from #652 making the jailer default-on that left every detached box born-`Stopped` (history + #602/#275 context in the comment below).

## Test plan
- [x] Guard unit test `apply_sets_die_with_parent_only_for_foreground` (foreground keeps the flag, detached drops it)
- [x] On a real box: `run -d … sleep 300` now stays `Running`; foreground `run` still works
- [ ] e2e-local: the 9 detached failures go green (`lifecycle_journey`, `rm::test_rm_force_running`, 6× `stress_disk`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for detached sandbox sessions, allowing boxes to keep running independently of the launching process.

* **Bug Fixes**
  * Fixed sandbox startup behavior so foreground sessions still terminate with the parent process, while detached sessions remain alive.
  * Improved consistency across sandbox setup and tests to match the new detached-session behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->