### PR TITLE
test(cli): avoid fixed publish ports

### DIFF
--- a/make/test.mk
+++ b/make/test.mk
@@ -13,12 +13,19 @@ export FAIL_FAST
 # go: regex, pytest -k / vitest -t: expression/substring).
 export FILTER
 
-NEXTEST_FILTER   = $(if $(FILTER),-E 'test(~$(FILTER))',)
+# Advanced nextest-only filter expression. Use this for CI-specific exclusions
+# that cannot be expressed as a simple positive FILTER pattern.
+export NEXTEST_FILTER_EXPR
+
+NEXTEST_FILTER   = $(if $(NEXTEST_FILTER_EXPR),-E '$(NEXTEST_FILTER_EXPR)',$(if $(FILTER),-E 'test(~$(FILTER))',))
+NEXTEST_CLI_FILTER = $(if $(NEXTEST_FILTER_EXPR),-E '$(NEXTEST_FILTER_EXPR)',$(if $(FILTER),-E 'test(~$(FILTER))',-E 'not binary(stress_disk)'))
 CARGOTEST_FILTER = $(if $(FILTER),$(FILTER),)
 PYTEST_FILTER    = $(if $(FILTER),-k '$(FILTER)',)
 VITEST_FILTER    = $(if $(FILTER),-t '$(FILTER)',)
 CTEST_FILTER     = $(if $(FILTER),-R '$(FILTER)',)
 GOTEST_FILTER    = $(if $(FILTER),-run '$(FILTER)',)
+
+CLI_INTEGRATION_TESTS = $(basename $(notdir $(filter-out src/cli/tests/stress_disk.rs,$(wildcard src/cli/tests/*.rs))))
 
 # $(call run_suites,<space-separated make targets>)
 # Runs each target via a recursive $(MAKE). With FAIL_FAST=false the loop
@@ -153,6 +160,13 @@ test\:integration:
 	@echo ""
 	@echo "✅ Integration test matrix passed"
 
+# Stress suites: intentionally excluded from the default integration matrix.
+test\:stress:
+	@echo "── Stress tests ──"
+	$(call run_integration_suites,test:stress:disk)
+	@echo ""
+	@echo "✅ Stress test matrix passed"
+
 # Core unit suites: Rust unit + FFI unit.
 test\:unit\:core:
 	@echo "── Core unit suites (rust, ffi) ──"
@@ -231,9 +245,23 @@ test\:integration\:cli: $(if $(SETUP_DONE),,runtime\:debug)
 	@echo "🧪 Running CLI integration tests..."
 	@if command -v cargo-nextest >/dev/null 2>&1; then \
 		cargo nextest run -p boxlite-cli --tests --profile vm --no-fail-fast \
+		$(NEXTEST_CLI_FILTER); \
+	else \
+		rc=0; \
+		for test_name in $(CLI_INTEGRATION_TESTS); do \
+			cargo test -p boxlite-cli --test $$test_name --no-fail-fast -- --test-threads=4 \
+			$(CARGOTEST_FILTER) || rc=$$?; \
+		done; \
+		exit $$rc; \
+	fi
+
+test\:stress\:disk: $(if $(SETUP_DONE),,runtime\:debug)
+	@echo "🧪 Running disk pressure stress tests..."
+	@if command -v cargo-nextest >/dev/null 2>&1; then \
+		cargo nextest run -p boxlite-cli --test stress_disk --profile vm --no-fail-fast \
 		$(NEXTEST_FILTER); \
 	else \
-		cargo test -p boxlite-cli --tests --no-fail-fast -- --test-threads=4 \
+		cargo test -p boxlite-cli --test stress_disk --no-fail-fast -- --test-threads=1 \
 		$(CARGOTEST_FILTER); \
 	fi
 

--- a/src/cli/tests/run.rs
+++ b/src/cli/tests/run.rs
@@ -1,6 +1,12 @@
 use predicates::prelude::*;
+use std::net::TcpListener;
 
 mod common;
+
+fn free_host_port() -> u16 {
+    let listener = TcpListener::bind("0.0.0.0:0").expect("bind ephemeral host port");
+    listener.local_addr().expect("read local addr").port()
+}
 
 // ============================================================================
 // Exit Code Tests
@@ -465,11 +471,12 @@ fn test_run_rm_cleanup() {
 #[test]
 fn test_run_with_publish_success() {
     let mut ctx = common::boxlite();
+    let host_port = free_host_port();
     ctx.cmd.args([
         "run",
         "--rm",
         "-p",
-        "18789:18789",
+        &format!("{host_port}:18789"),
         "alpine:latest",
         "echo",
         "ok",
@@ -480,11 +487,12 @@ fn test_run_with_publish_success() {
 #[test]
 fn test_run_with_publish_short_flag() {
     let mut ctx = common::boxlite();
+    let host_port = free_host_port();
     ctx.cmd.args([
         "run",
         "--rm",
         "-p",
-        "8080:80",
+        &format!("{host_port}:80"),
         "alpine:latest",
         "sh",
         "-c",
@@ -496,11 +504,12 @@ fn test_run_with_publish_short_flag() {
 #[test]
 fn test_run_with_publish_tcp_suffix() {
     let mut ctx = common::boxlite();
+    let host_port = free_host_port();
     ctx.cmd.args([
         "run",
         "--rm",
         "--publish",
-        "9000:9000/tcp",
+        &format!("{host_port}:9000/tcp"),
         "alpine:latest",
         "echo",
         "tcp",


### PR DESCRIPTION
Use ephemeral host ports in CLI publish happy-path tests and move the disk-pressure `stress_disk` suite out of the default integration matrix into `make test:stress`.

## Test plan
- [x] `cargo fmt --package boxlite-cli`
- [x] `BOXLITE_DEPS_STUB=1 cargo test -p boxlite-cli --test run --no-run`
- [x] `make -n test:integration:cli SETUP_DONE=1`
- [x] `make -n test:stress:disk SETUP_DONE=1`
- [x] `BOXLITE_DEPS_STUB=1 cargo nextest list -p boxlite-cli --tests -E 'not binary(stress_disk)'`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new stress-test targets, including a disk stress test, to make pressure testing easier to run.

* **Bug Fixes**
  * Improved test selection so integration tests exclude stress cases by default when appropriate.
  * Updated CLI port-publishing tests to use available host ports dynamically, reducing flaky failures from port conflicts.
  * Changed CLI integration fallback behavior to run tests individually and report failures more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->