### PR TITLE
fix(runner): adopt existing box on CREATE_BOX replay via GetOrCreate (no more "already exists")

### DIFF
--- a/apps/runner/pkg/boxlite/client.go
+++ b/apps/runner/pkg/boxlite/client.go
@@ -256,7 +256,13 @@ func (c *Client) Create(ctx context.Context, boxDto dto.CreateBoxDTO) (string, s
 
 	opts = append(opts, boxlite.WithNetwork(networkSpec(boxDto.NetworkBlockAll, boxDto.NetworkAllowList)))
 
-	bx, err := c.runtime.Create(ctx, boxDto.Image, opts...)
+	// GetOrCreate (not Create) so a CREATE_BOX replay is idempotent. The local
+	// box name is boxDto.Id — the control plane's globally-unique box id — so if
+	// the box was already persisted by a prior CREATE_BOX for the SAME box (e.g.
+	// the host rebooted before the job was marked COMPLETED and the poller is
+	// replaying the still-IN_PROGRESS job), the core adopts it instead of
+	// failing with "already exists", which the API would surface as a 400.
+	bx, err := c.runtime.GetOrCreate(ctx, boxDto.Image, opts...)
 	if err != nil {
 		if len(volumeMounts) > 0 {
 			if cleanupErr := c.removeBoxVolumeMountRecord(ctx, boxDto.Id); cleanupErr != nil {

--- a/apps/runner/pkg/boxlite/client.go
+++ b/apps/runner/pkg/boxlite/client.go
@@ -262,7 +262,9 @@ func (c *Client) Create(ctx context.Context, boxDto dto.CreateBoxDTO) (string, s
 	// the host rebooted before the job was marked COMPLETED and the poller is
 	// replaying the still-IN_PROGRESS job), the core adopts it instead of
 	// failing with "already exists", which the API would surface as a 400.
-	bx, err := c.runtime.GetOrCreate(ctx, boxDto.Image, opts...)
+	// The created flag (new vs adopted) is irrelevant here: either way the box
+	// now exists locally and the job can proceed, so it is discarded.
+	bx, _, err := c.runtime.GetOrCreate(ctx, boxDto.Image, opts...)
 	if err != nil {
 		if len(volumeMounts) > 0 {
 			if cleanupErr := c.removeBoxVolumeMountRecord(ctx, boxDto.Id); cleanupErr != nil {

--- a/apps/runner/pkg/boxlite/client_create_idempotent_test.go
+++ b/apps/runner/pkg/boxlite/client_create_idempotent_test.go
@@ -1,0 +1,67 @@
+//go:build boxlite_dev
+
+// Copyright 2026 BoxLite AI
+// SPDX-License-Identifier: AGPL-3.0
+
+package boxlite
+
+import (
+	"context"
+	"testing"
+
+	"github.com/boxlite-ai/runner/pkg/api/dto"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+// A CREATE_BOX job can be replayed against the same runner — e.g. the host
+// rebooted between persisting the box locally and the job being marked
+// COMPLETED, so the poller re-executes the still-IN_PROGRESS job. Because the
+// local box name is the control plane's globally-unique box id, a plain
+// runtime.Create on replay hits "box with name '<id>' already exists" in
+// boxlite-core, which the API surfaces to the user as a 400.
+//
+// Client.Create now routes through runtime.GetOrCreate, so a replay adopts the
+// existing box instead of failing. This test reproduces the replay: it creates
+// a box, then calls Create again with the SAME dto.Id, and asserts the second
+// call succeeds and returns the same container id.
+//
+// SkipStart keeps the box at Configured so the assertion isolates the
+// create/adopt path (no VM boot, no network), which is exactly where the
+// duplicate-name error originated.
+func TestIntegrationCreateBoxIdempotentOnReplay(t *testing.T) {
+	ctx := context.Background()
+
+	client, err := NewClient(ctx, ClientConfig{HomeDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+
+	createDto := dto.CreateBoxDTO{
+		Id:           "replay-idempotency-box",
+		Image:        "alpine:latest",
+		OsUser:       "root",
+		CpuQuota:     1,
+		MemoryQuota:  1,
+		StorageQuota: 1,
+		SkipStart:    boolPtr(true),
+	}
+
+	firstID, _, err := client.Create(ctx, createDto)
+	if err != nil {
+		// Pulling the image / preparing the box is an infrastructure
+		// prerequisite, not the behavior under test — skip rather than fail
+		// when it is unavailable (mirrors the SDK integration tests).
+		t.Skipf("first create could not complete (infrastructure prerequisite): %v", err)
+	}
+
+	// The replay: same dto.Id, box already persisted locally.
+	secondID, _, err := client.Create(ctx, createDto)
+	if err != nil {
+		t.Fatalf("replayed Create must adopt the existing box, got error: %v", err)
+	}
+	if secondID != firstID {
+		t.Fatalf("replayed Create must return the same container id: first=%q second=%q", firstID, secondID)
+	}
+}

--- a/sdks/c/include/boxlite.h
+++ b/sdks/c/include/boxlite.h
@@ -340,6 +340,19 @@ enum BoxliteErrorCode boxlite_create_box(CBoxliteRuntime *runtime,
                                          void *user_data,
                                          CBoxliteError *out_error);
 
+// Get an existing box by name, or create a new one if it does not exist.
+//
+// Same shape as [`boxlite_create_box`] (it reuses the create callback), but
+// when a box with the given name already exists it returns that box instead
+// of failing with "already exists". The `created` flag from the core
+// `get_or_create` is not surfaced over the FFI; callers that only need a box
+// handle (create-if-absent, idempotent retry) do not depend on it.
+enum BoxliteErrorCode boxlite_get_or_create_box(CBoxliteRuntime *runtime,
+                                                CBoxliteOptions *opts,
+                                                CBoxCreateBoxCb cb,
+                                                void *user_data,
+                                                CBoxliteError *out_error);
+
 enum BoxliteErrorCode boxlite_stop_box(CBoxHandle *handle,
                                        CBoxStopBoxCb cb,
                                        void *user_data,

--- a/sdks/c/include/boxlite.h
+++ b/sdks/c/include/boxlite.h
@@ -134,6 +134,10 @@ typedef struct FFIError CBoxliteError;
 // Box creation completion.
 typedef void (*CBoxCreateBoxCb)(CBoxHandle*, CBoxliteError*, void*);
 
+// Get-or-create completion. Same shape as create plus a `bool` that is `true`
+// when a new box was created and `false` when an existing box was adopted.
+typedef void (*CBoxGetOrCreateBoxCb)(CBoxHandle*, bool, CBoxliteError*, void*);
+
 // Box stop completion.
 typedef void (*CBoxStopBoxCb)(CBoxliteError*, void*);
 
@@ -342,14 +346,14 @@ enum BoxliteErrorCode boxlite_create_box(CBoxliteRuntime *runtime,
 
 // Get an existing box by name, or create a new one if it does not exist.
 //
-// Same shape as [`boxlite_create_box`] (it reuses the create callback), but
-// when a box with the given name already exists it returns that box instead
-// of failing with "already exists". The `created` flag from the core
-// `get_or_create` is not surfaced over the FFI; callers that only need a box
-// handle (create-if-absent, idempotent retry) do not depend on it.
+// When a box with the given name already exists it returns that box instead
+// of failing with "already exists". The callback receives an extra `created`
+// flag: `true` when a new box was created, `false` when an existing box was
+// adopted — letting callers distinguish the two (e.g. skip re-initialization
+// for an adopted box).
 enum BoxliteErrorCode boxlite_get_or_create_box(CBoxliteRuntime *runtime,
                                                 CBoxliteOptions *opts,
-                                                CBoxCreateBoxCb cb,
+                                                CBoxGetOrCreateBoxCb cb,
                                                 void *user_data,
                                                 CBoxliteError *out_error);
 

--- a/sdks/c/src/box_handle.rs
+++ b/sdks/c/src/box_handle.rs
@@ -49,6 +49,24 @@ pub unsafe extern "C" fn boxlite_create_box(
     create_box(runtime, opts, cb, user_data, out_error)
 }
 
+/// Get an existing box by name, or create a new one if it does not exist.
+///
+/// Same shape as [`boxlite_create_box`] (it reuses the create callback), but
+/// when a box with the given name already exists it returns that box instead
+/// of failing with "already exists". The `created` flag from the core
+/// `get_or_create` is not surfaced over the FFI; callers that only need a box
+/// handle (create-if-absent, idempotent retry) do not depend on it.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_get_or_create_box(
+    runtime: *mut CBoxliteRuntime,
+    opts: *mut CBoxliteOptions,
+    cb: CBoxCreateBoxCb,
+    user_data: *mut c_void,
+    out_error: *mut CBoxliteError,
+) -> BoxliteErrorCode {
+    get_or_create_box(runtime, opts, cb, user_data, out_error)
+}
+
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn boxlite_stop_box(
     handle: *mut CBoxHandle,
@@ -137,6 +155,62 @@ unsafe fn create_box(
                 .create(opts_handle.options, opts_handle.name)
                 .await
                 .map(|handle| {
+                    let box_id = handle.id().clone();
+                    let boxed = Box::new(BoxHandle {
+                        handle: Arc::new(handle),
+                        box_id,
+                        tokio_rt: task_tokio_rt,
+                        queue: task_queue.clone(),
+                    });
+                    crate::event_queue::OwnedFfiPtr::new(boxed)
+                });
+            push_event(
+                &queue,
+                RuntimeEvent::CreateBox {
+                    cb,
+                    user_data: user_data_addr,
+                    result,
+                },
+            )
+            .await;
+        });
+
+        BoxliteErrorCode::Ok
+    }
+}
+
+unsafe fn get_or_create_box(
+    runtime: *mut RuntimeHandle,
+    opts: *mut OptionsHandle,
+    cb: CBoxCreateBoxCb,
+    user_data: *mut c_void,
+    out_error: *mut FFIError,
+) -> BoxliteErrorCode {
+    unsafe {
+        if runtime.is_null() {
+            write_error(out_error, null_pointer_error("runtime"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        if opts.is_null() {
+            write_error(out_error, null_pointer_error("opts"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        let cb = crate::unwrap_cb_or_return!(cb, out_error);
+
+        let runtime_ref = &*runtime;
+        let opts_handle = Box::from_raw(opts);
+        let runtime_clone = runtime_ref.runtime.clone();
+        let tokio_rt = runtime_ref.tokio_rt.clone();
+        let queue = runtime_ref.queue.clone();
+        let user_data_addr = user_data as usize;
+        let task_tokio_rt = tokio_rt.clone();
+        let task_queue = queue.clone();
+
+        tokio_rt.spawn(async move {
+            let result = runtime_clone
+                .get_or_create(opts_handle.options, opts_handle.name)
+                .await
+                .map(|(handle, _created)| {
                     let box_id = handle.id().clone();
                     let boxed = Box::new(BoxHandle {
                         handle: Arc::new(handle),

--- a/sdks/c/src/box_handle.rs
+++ b/sdks/c/src/box_handle.rs
@@ -18,8 +18,8 @@ use boxlite::litebox::LiteBox;
 
 use crate::error::{BoxliteErrorCode, FFIError, null_pointer_error, write_error};
 use crate::event_queue::{
-    CBoxCreateBoxCb, CBoxGetBoxCb, CBoxRemoveBoxCb, CBoxStartBoxCb, CBoxStopBoxCb, EventQueue,
-    RuntimeEvent, push_event,
+    CBoxCreateBoxCb, CBoxGetBoxCb, CBoxGetOrCreateBoxCb, CBoxRemoveBoxCb, CBoxStartBoxCb,
+    CBoxStopBoxCb, EventQueue, RuntimeEvent, push_event,
 };
 use crate::options::OptionsHandle;
 use crate::runtime::RuntimeHandle;
@@ -51,16 +51,16 @@ pub unsafe extern "C" fn boxlite_create_box(
 
 /// Get an existing box by name, or create a new one if it does not exist.
 ///
-/// Same shape as [`boxlite_create_box`] (it reuses the create callback), but
-/// when a box with the given name already exists it returns that box instead
-/// of failing with "already exists". The `created` flag from the core
-/// `get_or_create` is not surfaced over the FFI; callers that only need a box
-/// handle (create-if-absent, idempotent retry) do not depend on it.
+/// When a box with the given name already exists it returns that box instead
+/// of failing with "already exists". The callback receives an extra `created`
+/// flag: `true` when a new box was created, `false` when an existing box was
+/// adopted — letting callers distinguish the two (e.g. skip re-initialization
+/// for an adopted box).
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn boxlite_get_or_create_box(
     runtime: *mut CBoxliteRuntime,
     opts: *mut CBoxliteOptions,
-    cb: CBoxCreateBoxCb,
+    cb: CBoxGetOrCreateBoxCb,
     user_data: *mut c_void,
     out_error: *mut CBoxliteError,
 ) -> BoxliteErrorCode {
@@ -182,7 +182,7 @@ unsafe fn create_box(
 unsafe fn get_or_create_box(
     runtime: *mut RuntimeHandle,
     opts: *mut OptionsHandle,
-    cb: CBoxCreateBoxCb,
+    cb: CBoxGetOrCreateBoxCb,
     user_data: *mut c_void,
     out_error: *mut FFIError,
 ) -> BoxliteErrorCode {
@@ -210,7 +210,7 @@ unsafe fn get_or_create_box(
             let result = runtime_clone
                 .get_or_create(opts_handle.options, opts_handle.name)
                 .await
-                .map(|(handle, _created)| {
+                .map(|(handle, created)| {
                     let box_id = handle.id().clone();
                     let boxed = Box::new(BoxHandle {
                         handle: Arc::new(handle),
@@ -218,11 +218,11 @@ unsafe fn get_or_create_box(
                         tokio_rt: task_tokio_rt,
                         queue: task_queue.clone(),
                     });
-                    crate::event_queue::OwnedFfiPtr::new(boxed)
+                    (crate::event_queue::OwnedFfiPtr::new(boxed), created)
                 });
             push_event(
                 &queue,
-                RuntimeEvent::CreateBox {
+                RuntimeEvent::GetOrCreateBox {
                     cb,
                     user_data: user_data_addr,
                     result,

--- a/sdks/c/src/event_queue.rs
+++ b/sdks/c/src/event_queue.rs
@@ -81,6 +81,13 @@ pub type CBoxCreateBoxCb =
 pub(crate) type CBoxCreateBoxFn =
     extern "C" fn(*mut crate::CBoxHandle, *mut crate::CBoxliteError, *mut c_void);
 
+/// Get-or-create completion. Same shape as create plus a `bool` that is `true`
+/// when a new box was created and `false` when an existing box was adopted.
+pub type CBoxGetOrCreateBoxCb =
+    Option<extern "C" fn(*mut crate::CBoxHandle, bool, *mut crate::CBoxliteError, *mut c_void)>;
+pub(crate) type CBoxGetOrCreateBoxFn =
+    extern "C" fn(*mut crate::CBoxHandle, bool, *mut crate::CBoxliteError, *mut c_void);
+
 /// Box start completion.
 pub type CBoxStartBoxCb = Option<extern "C" fn(*mut crate::CBoxliteError, *mut c_void)>;
 pub(crate) type CBoxStartBoxFn = extern "C" fn(*mut crate::CBoxliteError, *mut c_void);
@@ -276,6 +283,11 @@ pub enum RuntimeEvent {
         cb: CBoxCreateBoxFn,
         user_data: usize,
         result: Result<OwnedFfiPtr<crate::CBoxHandle>, BoxliteError>,
+    },
+    GetOrCreateBox {
+        cb: CBoxGetOrCreateBoxFn,
+        user_data: usize,
+        result: Result<(OwnedFfiPtr<crate::CBoxHandle>, bool), BoxliteError>,
     },
     StartBox {
         cb: CBoxStartBoxFn,

--- a/sdks/c/src/runtime.rs
+++ b/sdks/c/src/runtime.rs
@@ -484,6 +484,11 @@ unsafe fn dispatch_event(event: RuntimeEvent) {
                 user_data,
                 result,
             } => dispatch_handle_event::<crate::CBoxHandle>(result, user_data, cb),
+            RuntimeEvent::GetOrCreateBox {
+                cb,
+                user_data,
+                result,
+            } => dispatch_get_or_create_event(result, user_data, cb),
             RuntimeEvent::StartBox {
                 cb,
                 user_data,
@@ -621,6 +626,30 @@ unsafe fn dispatch_handle_event<T>(
             }
         };
         cb(ptr, &mut err as *mut _, user_data as *mut c_void);
+        if !err.message.is_null() {
+            crate::boxlite_error_free(&mut err);
+        }
+    }
+}
+
+/// Like [`dispatch_handle_event`] for the box handle, but also forwards the
+/// `created` flag (`true` = newly created, `false` = adopted existing box).
+/// On error the handle is null and `created` is reported as `false`.
+unsafe fn dispatch_get_or_create_event(
+    result: Result<(crate::event_queue::OwnedFfiPtr<crate::CBoxHandle>, bool), BoxliteError>,
+    user_data: usize,
+    cb: crate::event_queue::CBoxGetOrCreateBoxFn,
+) {
+    unsafe {
+        let mut err = FFIError::default();
+        let (ptr, created) = match result {
+            Ok((owned, created)) => (owned.take(), created),
+            Err(e) => {
+                err = crate::error::error_to_c_error(e);
+                (ptr::null_mut(), false)
+            }
+        };
+        cb(ptr, created, &mut err as *mut _, user_data as *mut c_void);
         if !err.message.is_null() {
             crate::boxlite_error_free(&mut err);
         }

--- a/sdks/go/bridge.c
+++ b/sdks/go/bridge.c
@@ -13,6 +13,7 @@ extern void goBoxliteOnStderr(uint8_t const *data, size_t len, void *ud);
 extern void goBoxliteOnExit(int exit_code, void *ud);
 
 extern void goBoxliteOnCreateBox(CBoxHandle *box, CBoxliteError *err, void *ud);
+extern void goBoxliteOnGetOrCreateBox(CBoxHandle *box, bool created, CBoxliteError *err, void *ud);
 extern void goBoxliteOnGetBox(CBoxHandle *box, CBoxliteError *err, void *ud);
 extern void goBoxliteOnStartBox(CBoxliteError *err, void *ud);
 extern void goBoxliteOnStopBox(CBoxliteError *err, void *ud);
@@ -40,6 +41,7 @@ CBoxStderrCb cbStderr(void) { return (CBoxStderrCb)goBoxliteOnStderr; }
 CBoxExitCb cbExit(void) { return (CBoxExitCb)goBoxliteOnExit; }
 
 CBoxCreateBoxCb cbCreateBox(void) { return (CBoxCreateBoxCb)goBoxliteOnCreateBox; }
+CBoxGetOrCreateBoxCb cbGetOrCreateBox(void) { return (CBoxGetOrCreateBoxCb)goBoxliteOnGetOrCreateBox; }
 CBoxGetBoxCb cbGetBox(void) { return (CBoxGetBoxCb)goBoxliteOnGetBox; }
 CBoxStartBoxCb cbStartBox(void) { return (CBoxStartBoxCb)goBoxliteOnStartBox; }
 CBoxStopBoxCb cbStopBox(void) { return (CBoxStopBoxCb)goBoxliteOnStopBox; }

--- a/sdks/go/bridge.h
+++ b/sdks/go/bridge.h
@@ -12,6 +12,7 @@ extern CBoxStderrCb cbStderr(void);
 extern CBoxExitCb cbExit(void);
 
 extern CBoxCreateBoxCb cbCreateBox(void);
+extern CBoxGetOrCreateBoxCb cbGetOrCreateBox(void);
 extern CBoxGetBoxCb cbGetBox(void);
 extern CBoxStartBoxCb cbStartBox(void);
 extern CBoxStopBoxCb cbStopBox(void);

--- a/sdks/go/bridge_callback.go
+++ b/sdks/go/bridge_callback.go
@@ -103,6 +103,35 @@ func goBoxliteOnCreateBox(box *C.CBoxHandle, errPtr *C.CBoxliteError, userData u
 	ch <- handleResult[*C.CBoxHandle]{value: box, err: errorFromCError(errPtr)}
 }
 
+// boxAndCreated carries a get-or-create result across the dispatch channel: the
+// box handle plus whether it was newly created (true) or an adopted existing
+// box (false). Wrapping both in one value lets GetOrCreate reuse the generic
+// handleResult/abandonAsync machinery.
+type boxAndCreated struct {
+	box     *C.CBoxHandle
+	created bool
+}
+
+//export goBoxliteOnGetOrCreateBox
+func goBoxliteOnGetOrCreateBox(box *C.CBoxHandle, created C.bool, errPtr *C.CBoxliteError, userData unsafe.Pointer) {
+	h := ptrToHandle(userData)
+	if h == 0 {
+		return
+	}
+	if !claimOrFreePayload(h, &box, freeBoxHandlePayload) {
+		return
+	}
+	defer h.Delete()
+	ch, ok := h.Value().(chan handleResult[boxAndCreated])
+	if !ok {
+		return
+	}
+	ch <- handleResult[boxAndCreated]{
+		value: boxAndCreated{box: box, created: bool(created)},
+		err:   errorFromCError(errPtr),
+	}
+}
+
 //export goBoxliteOnGetBox
 func goBoxliteOnGetBox(box *C.CBoxHandle, errPtr *C.CBoxliteError, userData unsafe.Pointer) {
 	h := ptrToHandle(userData)

--- a/sdks/go/get_or_create_integration_test.go
+++ b/sdks/go/get_or_create_integration_test.go
@@ -1,0 +1,57 @@
+//go:build boxlite_dev
+
+// Copyright 2026 BoxLite AI
+// SPDX-License-Identifier: AGPL-3.0
+
+package boxlite
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// TestIntegrationGetOrCreateReportsCreatedFlag proves the created flag the FFI
+// now carries back actually reaches the Go caller and reflects reality: the
+// first GetOrCreate of a name creates the box (created=true), a second
+// GetOrCreate of the SAME name adopts it (created=false) and returns the same
+// box id.
+//
+// This is a real cross-boundary test: created originates in boxlite-core's
+// get_or_create, travels the C FFI callback (the bool added in this change),
+// and is asserted on the Go side — nothing in the test body fabricates it.
+func TestIntegrationGetOrCreateReportsCreatedFlag(t *testing.T) {
+	rt := newTestRuntime(t)
+	ctx := context.Background()
+	const name = "get-or-create-created-flag-box"
+
+	first, created, err := rt.GetOrCreate(ctx, "alpine:latest", WithName(name), WithAutoRemove(false))
+	if err != nil {
+		// Image pull / prepare is an infrastructure prerequisite, not the
+		// behavior under test — skip rather than fail when unavailable.
+		var e *Error
+		if errors.As(err, &e) && (e.Code == ErrStorage || e.Code == ErrImage || e.Code == ErrNetwork) {
+			t.Skipf("infrastructure prerequisite unavailable (code=%d): %v", e.Code, err)
+		}
+		t.Fatalf("first GetOrCreate: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = rt.ForceRemove(ctx, first.ID())
+		_ = first.Close()
+	})
+	if !created {
+		t.Fatalf("first GetOrCreate of a fresh name must report created=true, got false")
+	}
+
+	second, created, err := rt.GetOrCreate(ctx, "alpine:latest", WithName(name), WithAutoRemove(false))
+	if err != nil {
+		t.Fatalf("second GetOrCreate must adopt the existing box, got error: %v", err)
+	}
+	defer func() { _ = second.Close() }()
+	if created {
+		t.Fatalf("second GetOrCreate of an existing name must report created=false (adopted), got true")
+	}
+	if second.ID() != first.ID() {
+		t.Fatalf("adopted box must have the same id: first=%q second=%q", first.ID(), second.ID())
+	}
+}

--- a/sdks/go/runtime.go
+++ b/sdks/go/runtime.go
@@ -188,17 +188,18 @@ func (r *Runtime) Create(ctx context.Context, image string, opts ...BoxOption) (
 // runtime's get_or_create() (also bound by the Python and Node SDKs) and makes
 // create idempotent for callers that key a box on a stable unique name.
 //
+// The second return value, created, is true when a new box was created and
+// false when an existing box was adopted — letting callers skip one-time
+// initialization for an adopted box.
+//
 // On context cancellation it only frees the returned handle (like Get); it
-// never force-removes the box. This is a deliberate trade-off: the FFI drops
-// the core's `created` flag, so this layer cannot tell whether the box was
-// ADOPTED (pre-existing — must not be destroyed) or freshly CREATED (which
-// Create would force-remove on cancel). It conservatively never destroys, so a
-// genuine create that is then cancelled leaks one persisted box (a Configured
-// row + its lock). The leak is bounded and self-heals for the runner — the only
-// caller on this path — because the box name is the control plane's unique box
-// id, so a replayed CREATE_BOX re-adopts the orphan. Surfacing `created` over
-// the FFI to branch the cleanup (force-remove vs free) is a tracked follow-up.
-func (r *Runtime) GetOrCreate(ctx context.Context, image string, opts ...BoxOption) (*Box, error) {
+// never force-removes the box, because an adopted box may be one the caller did
+// not create and must not be destroyed. A genuine create that is then cancelled
+// therefore leaks one persisted box; the leak is bounded and self-heals for the
+// runner — the only caller on this path — because the box name is the control
+// plane's unique box id, so a replayed CREATE_BOX re-adopts the orphan.
+// Force-removing only the created case on cancel is a tracked follow-up.
+func (r *Runtime) GetOrCreate(ctx context.Context, image string, opts ...BoxOption) (*Box, bool, error) {
 	r.ensureDrainRunning()
 
 	cfg := &boxConfig{}
@@ -208,39 +209,39 @@ func (r *Runtime) GetOrCreate(ctx context.Context, image string, opts ...BoxOpti
 
 	cOpts, err := buildCOptions(image, cfg)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
-	ch := make(chan handleResult[*C.CBoxHandle], 1)
+	ch := make(chan handleResult[boxAndCreated], 1)
 	h := registerHandleForDispatch(cgo.NewHandle(ch))
 
 	var cerr C.CBoxliteError
-	code := C.boxlite_get_or_create_box(r.handle, cOpts, C.cbCreateBox(), handleToPtr(h), &cerr)
+	code := C.boxlite_get_or_create_box(r.handle, cOpts, C.cbGetOrCreateBox(), handleToPtr(h), &cerr)
 	if code != C.Ok {
 		deleteHandleForDispatch(h)
 		// boxlite_get_or_create_box consumes opts on success but not on synchronous failure.
 		C.boxlite_options_free(cOpts)
-		return nil, freeError(&cerr)
+		return nil, false, freeError(&cerr)
 	}
 
-	freeOrphanHandle := func(handle *C.CBoxHandle) {
-		if handle != nil {
-			C.boxlite_box_free(handle)
+	freeOrphanHandle := func(v boxAndCreated) {
+		if v.box != nil {
+			C.boxlite_box_free(v.box)
 		}
 	}
 
 	select {
 	case res := <-ch:
 		if res.err != nil {
-			return nil, res.err
+			return nil, false, res.err
 		}
-		return newBoxFromHandle(r, res.value, cfg.name), nil
+		return newBoxFromHandle(r, res.value.box, cfg.name), res.value.created, nil
 	case <-ctx.Done():
 		abandonAsync(ch, h, r.closing, freeOrphanHandle)
-		return nil, ctx.Err()
+		return nil, false, ctx.Err()
 	case <-r.closing:
 		abandonAsync(ch, h, r.closing, freeOrphanHandle)
-		return nil, ErrRuntimeClosed
+		return nil, false, ErrRuntimeClosed
 	}
 }
 

--- a/sdks/go/runtime.go
+++ b/sdks/go/runtime.go
@@ -188,9 +188,16 @@ func (r *Runtime) Create(ctx context.Context, image string, opts ...BoxOption) (
 // runtime's get_or_create() (also bound by the Python and Node SDKs) and makes
 // create idempotent for callers that key a box on a stable unique name.
 //
-// On context cancellation it only frees the returned handle (like Get); it does
-// NOT force-remove the box, because an adopted box may be one the caller did
-// not create and must not be destroyed.
+// On context cancellation it only frees the returned handle (like Get); it
+// never force-removes the box. This is a deliberate trade-off: the FFI drops
+// the core's `created` flag, so this layer cannot tell whether the box was
+// ADOPTED (pre-existing — must not be destroyed) or freshly CREATED (which
+// Create would force-remove on cancel). It conservatively never destroys, so a
+// genuine create that is then cancelled leaks one persisted box (a Configured
+// row + its lock). The leak is bounded and self-heals for the runner — the only
+// caller on this path — because the box name is the control plane's unique box
+// id, so a replayed CREATE_BOX re-adopts the orphan. Surfacing `created` over
+// the FFI to branch the cleanup (force-remove vs free) is a tracked follow-up.
 func (r *Runtime) GetOrCreate(ctx context.Context, image string, opts ...BoxOption) (*Box, error) {
 	r.ensureDrainRunning()
 

--- a/sdks/go/runtime.go
+++ b/sdks/go/runtime.go
@@ -182,6 +182,61 @@ func (r *Runtime) Create(ctx context.Context, image string, opts ...BoxOption) (
 	}
 }
 
+// GetOrCreate returns the box with the given name, creating it only if no box
+// with that name exists. Unlike Create it does not fail with "already exists"
+// when the box is already present — it adopts it. This mirrors the core
+// runtime's get_or_create() (also bound by the Python and Node SDKs) and makes
+// create idempotent for callers that key a box on a stable unique name.
+//
+// On context cancellation it only frees the returned handle (like Get); it does
+// NOT force-remove the box, because an adopted box may be one the caller did
+// not create and must not be destroyed.
+func (r *Runtime) GetOrCreate(ctx context.Context, image string, opts ...BoxOption) (*Box, error) {
+	r.ensureDrainRunning()
+
+	cfg := &boxConfig{}
+	for _, o := range opts {
+		o(cfg)
+	}
+
+	cOpts, err := buildCOptions(image, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	ch := make(chan handleResult[*C.CBoxHandle], 1)
+	h := registerHandleForDispatch(cgo.NewHandle(ch))
+
+	var cerr C.CBoxliteError
+	code := C.boxlite_get_or_create_box(r.handle, cOpts, C.cbCreateBox(), handleToPtr(h), &cerr)
+	if code != C.Ok {
+		deleteHandleForDispatch(h)
+		// boxlite_get_or_create_box consumes opts on success but not on synchronous failure.
+		C.boxlite_options_free(cOpts)
+		return nil, freeError(&cerr)
+	}
+
+	freeOrphanHandle := func(handle *C.CBoxHandle) {
+		if handle != nil {
+			C.boxlite_box_free(handle)
+		}
+	}
+
+	select {
+	case res := <-ch:
+		if res.err != nil {
+			return nil, res.err
+		}
+		return newBoxFromHandle(r, res.value, cfg.name), nil
+	case <-ctx.Done():
+		abandonAsync(ch, h, r.closing, freeOrphanHandle)
+		return nil, ctx.Err()
+	case <-r.closing:
+		abandonAsync(ch, h, r.closing, freeOrphanHandle)
+		return nil, ErrRuntimeClosed
+	}
+}
+
 // Get retrieves an existing box by ID or name.
 func (r *Runtime) Get(ctx context.Context, idOrName string) (*Box, error) {
 	r.ensureDrainRunning()


### PR DESCRIPTION
## Problem

Users running many box creates hit:

```
Box failed to start: failed to create box: boxlite: invalid argument:
box with name 'WkPOzazvU8nC' already exists (code=5)
```

`WkPOzazvU8nC` is the API box id, which the runner uses verbatim as the local BoxLite name (`apps/runner/pkg/boxlite/client.go` → `boxlite.WithName(boxDto.Id)`). It is **not** an API-side name collision.

### Root cause — a replayed CREATE_BOX

1. `CREATE_BOX` runs → box is persisted to the runner's local BoxLite DB (status `Configured`).
2. The runner host reboots **before** the API job is marked `COMPLETED` (observed in prod: a single overloaded runner in a hard reboot loop).
3. The runner restarts and its poller replays `IN_PROGRESS` jobs (`apps/runner/pkg/runner/v2/poller/poller.go`).
4. The replay re-runs `runtime.Create` with the **same** name → boxlite-core's name-uniqueness check fails → `already exists` → the API marks the box `ERROR` and returns a **400**.

`CREATE_BOX` was not idempotent, so any replay of an already-persisted box failed.

## Fix — expose `get_or_create` Rust → Go, and use it

boxlite-core **already** has idempotent create-or-adopt: `get_or_create()` returns the existing box (no error) when the name is present. The Python and Node SDKs already bind it — only the **Go SDK never did**, so the runner could only call `create()`. This wires the existing method all the way up:

```
core            runtime.get_or_create()            (already existed)
  │
sdks/c (FFI)    + boxlite_get_or_create_box         box_handle.rs; mirrors boxlite_create_box,
  │                                                  reuses the create callback/event
  │             cbindgen regenerates the decl in    sdks/c/include/boxlite.h
sdks/go         + Runtime.GetOrCreate               runtime.go
  │
apps/runner     Client.Create → runtime.GetOrCreate client.go
```

Because the local name is the control plane's globally-unique box id, a box already present under that name can only be one we created in a prior `CREATE_BOX` for the **same** box — so adopting it is correct and replay-safe.

Note: `GetOrCreate` on context cancellation only frees the handle (like `Get`); it never force-removes, because an adopted box may be one the caller did not create.

**Diff:** 5 files, +216/-1. `box_handle.rs` (FFI) + `boxlite.h` (cbindgen-generated decl) + `runtime.go` (Go method) + `client.go` (use it) + integration test.

## Scope

Fixes **only** the user-facing `already exists` error. It does **not** touch the separate boot-loop amplifiers (runner `box_sync` auto-start, the PR #573 reconcile cron, PR #578 rootfs rebuild) — those are tracked separately.

## Verification — two-side, run locally on a real runtime

Reproducer: `apps/runner/pkg/boxlite/client_create_idempotent_test.go` (`//go:build boxlite_dev`) creates a box, then replays `Client.Create` with the same id and asserts the replay adopts it (same container id).

- [x] `cargo build -p boxlite-c` (regenerates the header), `go build -tags boxlite_dev ./...`, `gofmt`, `cargo fmt` — all clean
- [x] **Two-side verified** against a real (stubbed-VMM) runtime:
  - Revert the runner to `runtime.Create` (pre-fix) → reproducer **FAILS** with the exact prod error: `box with name 'replay-idempotency-box' already exists (code=5)`
  - Restore `runtime.GetOrCreate` → reproducer **PASSES**, replay returns the same container id

## Follow-up (not in this PR)

boxlite-core returns the name collision as `InvalidArgument` (code=5) rather than the dedicated `AlreadyExists` (code=3) at `src/boxlite/src/runtime/rt_impl.rs`. Worth correcting for taxonomy, but unrelated to this fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an idempotent box creation flow that reuses an existing box when the same name is requested again.
  * Exposed a new “get or create” API across the Go and C SDKs, including a flag that indicates whether a box was newly created.

* **Bug Fixes**
  * Improved replay behavior so repeated create requests no longer fail when the box already exists.
  * Preserved the original box identity when an existing box is adopted.

* **Tests**
  * Added integration coverage for replay-safe box creation and correct created/not-created reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->