### PR TITLE
Add project hook registration

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,21 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "^Bash$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/usr/bin/env bash \"$(git rev-parse --show-toplevel)/.claude/hooks/preflight-claude-md.sh\"",
+            "statusMessage": "Checking CLAUDE.md audit"
+          },
+          {
+            "type": "command",
+            "command": "/usr/bin/env bash \"$(git rev-parse --show-toplevel)/.claude/hooks/preflight-pr-review.sh\"",
+            "statusMessage": "Checking PR review acknowledgement"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
Adds project-local lifecycle hook registration that runs the existing preflight shell checks before Bash tool use.

The registration resolves scripts from the git root, so it still works when sessions start from a subdirectory.

## Impact
Trusted project sessions can reuse the existing commit, push, and PR-review gates after the hooks are reviewed and trusted.

## Validation
- Validated the hook config JSON.
- Commit hook reported no applicable files for quality autofix.
- Push hook reported no applicable files for the changed-component test matrix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic pre-run checks for shell commands to help ensure required review and documentation steps are completed before execution.
  * Displayed clearer status messages during these checks so users know what is being verified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->