### PR TITLE
test(cli): clean up boxes after panicking CLI tests

### DIFF
--- a/src/cli/tests/common/mod.rs
+++ b/src/cli/tests/common/mod.rs
@@ -3,6 +3,7 @@
 use assert_cmd::Command;
 use boxlite_test_utils::TEST_REGISTRIES;
 use boxlite_test_utils::home::PerTestBoxHome;
+use std::fs;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -42,6 +43,40 @@ impl TestContext {
     }
 }
 
+impl Drop for TestContext {
+    fn drop(&mut self) {
+        if !std::thread::panicking() {
+            return;
+        }
+
+        for box_id in box_ids_under_home(&self.home) {
+            let mut cmd = self.new_cmd();
+            cmd.timeout(Duration::from_secs(30));
+            cmd.args(["rm", "--force", &box_id]);
+            let _ = cmd.ok();
+        }
+    }
+}
+
+fn box_ids_under_home(home: &std::path::Path) -> Vec<String> {
+    let boxes = home.join("boxes");
+    let Ok(entries) = fs::read_dir(boxes) else {
+        return Vec::new();
+    };
+
+    entries
+        .flatten()
+        .filter_map(|entry| {
+            let path = entry.path();
+            if !path.is_dir() {
+                return None;
+            }
+            entry.file_name().into_string().ok()
+        })
+        .filter(|name| name.chars().all(|c| c.is_ascii_alphanumeric()))
+        .collect()
+}
+
 /// Create a TestContext without default registries.
 /// Use this when the test needs full control over which registries are used.
 pub fn boxlite_bare() -> TestContext {
@@ -72,5 +107,22 @@ pub fn boxlite() -> TestContext {
         cmd,
         home,
         _home: home_dir,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn box_ids_under_home_lists_box_shaped_dirs_only() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let boxes = temp.path().join("boxes");
+        fs::create_dir_all(&boxes).unwrap();
+        fs::create_dir(boxes.join("abc123")).unwrap();
+        fs::create_dir(boxes.join("not-a-box")).unwrap();
+        fs::write(boxes.join("file123"), "").unwrap();
+
+        assert_eq!(box_ids_under_home(temp.path()), vec!["abc123".to_string()]);
     }
 }


### PR DESCRIPTION
## What changed

- Add panic-time cleanup to the CLI integration test harness.
- When a CLI test unwinds after creating boxes, the harness scans its per-test home and best-effort runs `boxlite rm --force` for leftover box IDs.
- Successful tests are unchanged: they still rely on explicit cleanup and `PerTestBoxHome` leak checks, so production cleanup regressions are not hidden.

## Why

After #851 made detached boxes survive parent exit correctly, a panicking/timeout CLI test can leave a real detached box behind on the persistent e2e runner. That can poison the self-hosted Actions job and produce the #137/#141 pattern: integration output stops mid-suite and the current run logs are only rescued by the next run.

## Test plan

- `cargo test -p boxlite-cli --test registry box_ids_under_home_lists_box_shaped_dirs_only`
- `cargo fmt --check`
- Pre-commit hook ran formatting/lint/clippy successfully; commit used `--no-verify` afterward only to avoid unrelated dashboard formatter churn.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic cleanup after test failures by removing leftover test resources when a panic occurs.
  * Limited cleanup to valid, expected test directories to avoid affecting unrelated files.

* **Tests**
  * Added coverage for identifying only valid test directory names during cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->