### PR TITLE
fix(api): sync box state when exec auto-starts a stopped box

### DIFF
--- a/apps/api/src/box/repositories/box.repository.spec.ts
+++ b/apps/api/src/box/repositories/box.repository.spec.ts
@@ -4,6 +4,7 @@
  */
 
 import { BoxRepository } from './box.repository'
+import { Box } from '../entities/box.entity'
 import { BoxState } from '../enums/box-state.enum'
 import { BoxDesiredState } from '../enums/box-desired-state.enum'
 
@@ -26,9 +27,13 @@ function makeQueryBuilder(execute: jest.Mock) {
 function makeRepository(execute: jest.Mock) {
   const query = jest.fn().mockResolvedValue(undefined)
   const queryBuilder = makeQueryBuilder(execute)
+  // create() hydrates the RETURNING * raw row into a Box; the stub echoes the
+  // row back so return-shape assertions stay on the same object.
+  const create = jest.fn((_entity, raw) => raw)
   const entityManager = {
     query,
     createQueryBuilder: jest.fn(() => queryBuilder),
+    create,
   }
   const manager = {
     transaction: jest.fn(async (cb: (em: typeof entityManager) => Promise<unknown>) => cb(entityManager)),
@@ -38,7 +43,7 @@ function makeRepository(execute: jest.Mock) {
   // invalidateLookupCacheOnUpdate touches the real cache service; stub it out —
   // it is incidental to the lock-timeout behavior under test.
   jest.spyOn(repo as any, 'invalidateLookupCacheOnUpdate').mockImplementation(() => undefined)
-  return { repo, query, execute }
+  return { repo, query, execute, create }
 }
 
 const startedRow = {
@@ -54,11 +59,14 @@ const startedRow = {
 describe('BoxRepository.conditionalStartForProxy', () => {
   it('bounds the row-lock wait with a lock_timeout before the UPDATE', async () => {
     const execute = jest.fn().mockResolvedValue({ raw: [startedRow] })
-    const { repo, query } = makeRepository(execute)
+    const { repo, query, create } = makeRepository(execute)
 
     const updated = await repo.conditionalStartForProxy('box-1', 'org-1')
 
     expect(updated).toEqual(startedRow)
+    // The RETURNING * row is a plain pg object; the repo must hydrate it into a
+    // Box entity, not leak a raw row through the Promise<Box> contract.
+    expect(create).toHaveBeenCalledWith(Box, startedRow)
     // The fix's core: the transaction sets a per-statement lock_timeout so a
     // contended row aborts at the DB instead of pinning the connection.
     expect(query).toHaveBeenCalledWith(expect.stringContaining('SET LOCAL lock_timeout'))

--- a/apps/api/src/box/repositories/box.repository.spec.ts
+++ b/apps/api/src/box/repositories/box.repository.spec.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2025 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { BoxRepository } from './box.repository'
+import { BoxState } from '../enums/box-state.enum'
+import { BoxDesiredState } from '../enums/box-desired-state.enum'
+
+// A chainable UPDATE query-builder stub whose terminal execute() is supplied
+// per-test. update/set/where/andWhere/returning all return the same builder.
+function makeQueryBuilder(execute: jest.Mock) {
+  const qb: any = {}
+  qb.update = jest.fn(() => qb)
+  qb.set = jest.fn(() => qb)
+  qb.where = jest.fn(() => qb)
+  qb.andWhere = jest.fn(() => qb)
+  qb.returning = jest.fn(() => qb)
+  qb.execute = execute
+  return qb
+}
+
+// Build a BoxRepository whose `manager.transaction` runs the callback against a
+// fake entityManager. We bypass DI: only `manager` (a BaseRepository getter
+// over repository.manager) and the cache-invalidation hook are exercised here.
+function makeRepository(execute: jest.Mock) {
+  const query = jest.fn().mockResolvedValue(undefined)
+  const queryBuilder = makeQueryBuilder(execute)
+  const entityManager = {
+    query,
+    createQueryBuilder: jest.fn(() => queryBuilder),
+  }
+  const manager = {
+    transaction: jest.fn(async (cb: (em: typeof entityManager) => Promise<unknown>) => cb(entityManager)),
+  }
+  const dataSource = { getRepository: () => ({ manager }) } as any
+  const repo = new BoxRepository(dataSource, {} as any, {} as any)
+  // invalidateLookupCacheOnUpdate touches the real cache service; stub it out —
+  // it is incidental to the lock-timeout behavior under test.
+  jest.spyOn(repo as any, 'invalidateLookupCacheOnUpdate').mockImplementation(() => undefined)
+  return { repo, query, execute }
+}
+
+const startedRow = {
+  id: 'box-1',
+  organizationId: 'org-1',
+  name: 'box-1',
+  authToken: 'tok',
+  state: BoxState.STOPPED,
+  desiredState: BoxDesiredState.STARTED,
+  pending: true,
+}
+
+describe('BoxRepository.conditionalStartForProxy', () => {
+  it('bounds the row-lock wait with a lock_timeout before the UPDATE', async () => {
+    const execute = jest.fn().mockResolvedValue({ raw: [startedRow] })
+    const { repo, query } = makeRepository(execute)
+
+    const updated = await repo.conditionalStartForProxy('box-1', 'org-1')
+
+    expect(updated).toEqual(startedRow)
+    // The fix's core: the transaction sets a per-statement lock_timeout so a
+    // contended row aborts at the DB instead of pinning the connection.
+    expect(query).toHaveBeenCalledWith(expect.stringContaining('SET LOCAL lock_timeout'))
+  })
+
+  // Lock wait exceeded lock_timeout (SQLSTATE 55P03): the row is being
+  // started/stopped concurrently. Treated as a race-lost no-op, NOT propagated —
+  // without the catch this rejects and surfaces as an error to the caller.
+  it('returns null when the lock_timeout fires (SQLSTATE 55P03)', async () => {
+    const lockTimeout = Object.assign(new Error('canceling statement due to lock timeout'), { code: '55P03' })
+    const execute = jest.fn().mockRejectedValue(lockTimeout)
+    const { repo } = makeRepository(execute)
+
+    await expect(repo.conditionalStartForProxy('box-1', 'org-1')).resolves.toBeNull()
+  })
+
+  it('re-throws DB errors that are not lock timeouts', async () => {
+    const dbError = Object.assign(new Error('connection terminated'), { code: '08006' })
+    const execute = jest.fn().mockRejectedValue(dbError)
+    const { repo } = makeRepository(execute)
+
+    await expect(repo.conditionalStartForProxy('box-1', 'org-1')).rejects.toThrow('connection terminated')
+  })
+
+  it('returns null when the conditional UPDATE matches no row', async () => {
+    const execute = jest.fn().mockResolvedValue({ raw: [] })
+    const { repo } = makeRepository(execute)
+
+    await expect(repo.conditionalStartForProxy('box-1', 'org-1')).resolves.toBeNull()
+  })
+})

--- a/apps/api/src/box/repositories/box.repository.spec.ts
+++ b/apps/api/src/box/repositories/box.repository.spec.ts
@@ -45,7 +45,7 @@ const startedRow = {
   id: 'box-1',
   organizationId: 'org-1',
   name: 'box-1',
-  authToken: 'tok',
+  authToken: 'redacted',
   state: BoxState.STOPPED,
   desiredState: BoxDesiredState.STARTED,
   pending: true,
@@ -62,6 +62,10 @@ describe('BoxRepository.conditionalStartForProxy', () => {
     // The fix's core: the transaction sets a per-statement lock_timeout so a
     // contended row aborts at the DB instead of pinning the connection.
     expect(query).toHaveBeenCalledWith(expect.stringContaining('SET LOCAL lock_timeout'))
+    // ...and it must be armed BEFORE the UPDATE runs — otherwise the UPDATE
+    // could block on the row lock with no bound. Assert call order, not just
+    // presence.
+    expect(query.mock.invocationCallOrder[0]).toBeLessThan(execute.mock.invocationCallOrder[0])
   })
 
   // Lock wait exceeded lock_timeout (SQLSTATE 55P03): the row is being

--- a/apps/api/src/box/repositories/box.repository.ts
+++ b/apps/api/src/box/repositories/box.repository.ts
@@ -230,8 +230,13 @@ export class BoxRepository extends BaseRepository<Box> {
           .returning('*')
           .execute()
 
-        const updated = (result.raw as Box[])[0]
-        if (!updated) return null
+        const raw = (result.raw as Box[])[0]
+        if (!raw) return null
+
+        // RETURNING * yields a plain pg row; hydrate it into a real Box so the
+        // value honors the Promise<Box> contract and downstream consumers (the
+        // caller's events → toBoxDto) get an entity, not a raw row.
+        const updated = entityManager.create(Box, raw)
 
         // id / name / org haven't changed, but the cached entity snapshot still
         // holds the old desiredState/pending — invalidate so subsequent

--- a/apps/api/src/box/repositories/box.repository.ts
+++ b/apps/api/src/box/repositories/box.repository.ts
@@ -7,6 +7,8 @@
 import { DataSource, EntityManager, FindOptionsWhere } from 'typeorm'
 import { Box } from '../entities/box.entity'
 import { BoxLastActivity } from '../entities/box-last-activity.entity'
+import { BoxState } from '../enums/box-state.enum'
+import { BoxDesiredState } from '../enums/box-desired-state.enum'
 import { Injectable, Logger, NotFoundException } from '@nestjs/common'
 import { BoxConflictError } from '../errors/box-conflict.error'
 import { InjectDataSource } from '@nestjs/typeorm'
@@ -170,6 +172,50 @@ export class BoxRepository extends BaseRepository<Box> {
 
       return box
     })
+  }
+
+  /**
+   * Conditionally flip a STOPPED box to desiredState=STARTED for the proxy
+   * auto-start hint (exec / files / metrics). Single atomic UPDATE — no
+   * SELECT FOR UPDATE, no transaction overhead — so a contended row never
+   * blocks this call. Critical: this sits in front of every proxy request,
+   * pessimistic locking here would let one slow update stall the whole pool.
+   *
+   * Returns the updated box on success, `null` when the WHERE filter matched
+   * nothing (already started, pending, destroy-intent, or race lost).
+   *
+   * @throws DB errors (not wrapped) — caller decides whether to swallow.
+   */
+  async conditionalStartForProxy(boxId: string, organizationId: string): Promise<Box | null> {
+    const result = await this.manager
+      .createQueryBuilder()
+      .update(Box)
+      .set({
+        pending: true,
+        desiredState: BoxDesiredState.STARTED,
+        updatedAt: new Date(),
+      })
+      .where('id = :id', { id: boxId })
+      .andWhere('"organizationId" = :org', { org: organizationId })
+      .andWhere('pending = false')
+      .andWhere('state = :s', { s: BoxState.STOPPED })
+      .andWhere('"desiredState" = :d', { d: BoxDesiredState.STOPPED })
+      .returning('*')
+      .execute()
+
+    const updated = (result.raw as Box[])[0]
+    if (!updated) return null
+
+    // id / name / org haven't changed, but the cached entity snapshot still
+    // holds the old desiredState/pending — invalidate so subsequent
+    // findOneByIdOrName fetches fresh values.
+    this.invalidateLookupCacheOnUpdate(updated, {
+      organizationId: updated.organizationId,
+      name: updated.name,
+      authToken: updated.authToken,
+    })
+
+    return updated
   }
 
   /**

--- a/apps/api/src/box/repositories/box.repository.ts
+++ b/apps/api/src/box/repositories/box.repository.ts
@@ -21,6 +21,20 @@ import { BoxPublicStatusUpdatedEvent } from '../events/box-public-status-updated
 import { BoxOrganizationUpdatedEvent } from '../events/box-organization-updated.event'
 import { BoxLookupCacheInvalidationService } from '../services/box-lookup-cache-invalidation.service'
 
+// Cap how long the proxy auto-start UPDATE waits to acquire the box row's
+// write lock. Concurrent start/stop/sync go through updateWhere(), which holds
+// a pessimistic_write lock on the same row; there is no global statement/lock
+// timeout configured (see app.module.ts datasource `extra`), so without this
+// bound a contended row could pin a pooled connection indefinitely. On timeout
+// Postgres aborts the statement with SQLSTATE 55P03 and we treat it as a
+// race-lost no-op. Aligned with the caller-side wait cap in
+// boxlite-proxy.controller.ts (PROXY_START_HINT_TIMEOUT_MS).
+const PROXY_START_LOCK_TIMEOUT_MS = 2000
+
+// SQLSTATE for `lock_not_available` — raised when a statement waits longer than
+// lock_timeout to acquire a lock.
+const PG_LOCK_TIMEOUT_CODE = '55P03'
+
 @Injectable()
 export class BoxRepository extends BaseRepository<Box> {
   private readonly logger = new Logger(BoxRepository.name)
@@ -176,46 +190,69 @@ export class BoxRepository extends BaseRepository<Box> {
 
   /**
    * Conditionally flip a STOPPED box to desiredState=STARTED for the proxy
-   * auto-start hint (exec / files / metrics). Single atomic UPDATE — no
-   * SELECT FOR UPDATE, no transaction overhead — so a contended row never
-   * blocks this call. Critical: this sits in front of every proxy request,
-   * pessimistic locking here would let one slow update stall the whole pool.
+   * auto-start hint (exec / files / metrics). A single conditional UPDATE — no
+   * SELECT FOR UPDATE — guarded by a short lock_timeout so that a row held by a
+   * concurrent start/stop/sync (updateWhere's pessimistic_write lock) aborts
+   * this statement at the DB level instead of pinning the connection. This sits
+   * in front of every proxy request; an unbounded lock wait here would let one
+   * contended row stall the pool.
    *
-   * Returns the updated box on success, `null` when the WHERE filter matched
-   * nothing (already started, pending, destroy-intent, or race lost).
+   * Returns the updated box on success, or `null` when nothing changed: the
+   * WHERE filter matched no row (already started, pending, destroy-intent, or
+   * race lost) or the lock_timeout fired (row being started/stopped right now).
    *
-   * @throws DB errors (not wrapped) — caller decides whether to swallow.
+   * @throws DB errors other than lock-timeout (not wrapped) — caller decides
+   *   whether to swallow.
    */
   async conditionalStartForProxy(boxId: string, organizationId: string): Promise<Box | null> {
-    const result = await this.manager
-      .createQueryBuilder()
-      .update(Box)
-      .set({
-        pending: true,
-        desiredState: BoxDesiredState.STARTED,
-        updatedAt: new Date(),
+    try {
+      return await this.manager.transaction(async (entityManager) => {
+        // Bound the row-lock wait at the DB level. SET LOCAL scopes the timeout
+        // to this transaction only, so it never leaks to other queries sharing
+        // the pooled connection. The value is a hardcoded constant — no
+        // injection surface — but cannot be a bind parameter (SET takes a
+        // literal), hence the interpolation.
+        await entityManager.query(`SET LOCAL lock_timeout = '${PROXY_START_LOCK_TIMEOUT_MS}ms'`)
+
+        const result = await entityManager
+          .createQueryBuilder()
+          .update(Box)
+          .set({
+            pending: true,
+            desiredState: BoxDesiredState.STARTED,
+            updatedAt: new Date(),
+          })
+          .where('id = :id', { id: boxId })
+          .andWhere('"organizationId" = :org', { org: organizationId })
+          .andWhere('pending = false')
+          .andWhere('state = :s', { s: BoxState.STOPPED })
+          .andWhere('"desiredState" = :d', { d: BoxDesiredState.STOPPED })
+          .returning('*')
+          .execute()
+
+        const updated = (result.raw as Box[])[0]
+        if (!updated) return null
+
+        // id / name / org haven't changed, but the cached entity snapshot still
+        // holds the old desiredState/pending — invalidate so subsequent
+        // findOneByIdOrName fetches fresh values.
+        this.invalidateLookupCacheOnUpdate(updated, {
+          organizationId: updated.organizationId,
+          name: updated.name,
+          authToken: updated.authToken,
+        })
+
+        return updated
       })
-      .where('id = :id', { id: boxId })
-      .andWhere('"organizationId" = :org', { org: organizationId })
-      .andWhere('pending = false')
-      .andWhere('state = :s', { s: BoxState.STOPPED })
-      .andWhere('"desiredState" = :d', { d: BoxDesiredState.STOPPED })
-      .returning('*')
-      .execute()
-
-    const updated = (result.raw as Box[])[0]
-    if (!updated) return null
-
-    // id / name / org haven't changed, but the cached entity snapshot still
-    // holds the old desiredState/pending — invalidate so subsequent
-    // findOneByIdOrName fetches fresh values.
-    this.invalidateLookupCacheOnUpdate(updated, {
-      organizationId: updated.organizationId,
-      name: updated.name,
-      authToken: updated.authToken,
-    })
-
-    return updated
+    } catch (err) {
+      // Lock wait exceeded lock_timeout: the row is being started/stopped
+      // concurrently, so we lost the race. No-op — same semantics as a zero-row
+      // match. Any other DB error propagates for the caller to handle.
+      if ((err as { code?: string }).code === PG_LOCK_TIMEOUT_CODE) {
+        return null
+      }
+      throw err
+    }
   }
 
   /**

--- a/apps/api/src/box/services/box.service.spec.ts
+++ b/apps/api/src/box/services/box.service.spec.ts
@@ -108,4 +108,15 @@ describe('BoxService.ensureStartedForExec', () => {
     await expect(service.ensureStartedForExec('box-1', 'org-1')).resolves.toBeUndefined()
     expect(eventEmitter.emit).not.toHaveBeenCalled()
   })
+
+  it('swallows an unexpected (non-conflict) failure without emitting', async () => {
+    const { service, boxRepository, eventEmitter } = makeService()
+    jest.spyOn(service, 'findOneByIdOrName').mockResolvedValue(stoppedBox as any)
+    boxRepository.updateWhere.mockRejectedValue(new Error('db connection lost'))
+    const warn = jest.spyOn((service as any).logger, 'warn').mockImplementation(() => undefined)
+
+    await expect(service.ensureStartedForExec('box-1', 'org-1')).resolves.toBeUndefined()
+    expect(eventEmitter.emit).not.toHaveBeenCalled()
+    expect(warn).toHaveBeenCalled()
+  })
 })

--- a/apps/api/src/box/services/box.service.spec.ts
+++ b/apps/api/src/box/services/box.service.spec.ts
@@ -3,17 +3,29 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
+import { ForbiddenException } from '@nestjs/common'
 import { BoxService } from './box.service'
 import { BoxState } from '../enums/box-state.enum'
 import { BoxDesiredState } from '../enums/box-desired-state.enum'
 import { BoxEvents } from '../constants/box-events.constants'
-import { BoxConflictError } from '../errors/box-conflict.error'
 
-// ensureStartedForExec only touches boxRepository + eventEmitter; every other
-// injected dependency is irrelevant to this unit, so they are stubbed out.
+// ensureStartedForProxy only touches boxRepository + eventEmitter +
+// organizationService; every other injected dependency is irrelevant.
 function makeService() {
-  const boxRepository = { findOneByIdOrName: jest.fn(), updateWhere: jest.fn() } as any
+  const boxRepository = {
+    findOneByIdOrName: jest.fn(),
+    conditionalStartForProxy: jest.fn(),
+  } as any
   const eventEmitter = { emit: jest.fn(), emitAsync: jest.fn() } as any
+  // assertOrganizationIsNotSuspended mirrors the real implementation: throw
+  // ForbiddenException when the org is suspended, no-op otherwise.
+  const organizationService = {
+    assertOrganizationIsNotSuspended: jest.fn((org: any) => {
+      if (org?.suspended) {
+        throw new ForbiddenException('Organization is suspended')
+      }
+    }),
+  } as any
   const noop = {} as any
   const service = new BoxService(
     boxRepository, // boxRepository
@@ -24,7 +36,7 @@ function makeService() {
     noop, // configService
     noop, // warmPoolService
     eventEmitter, // eventEmitter
-    noop, // organizationService
+    organizationService, // organizationService
     noop, // runnerAdapterFactory
     noop, // redisLockProvider
     noop, // redis
@@ -32,8 +44,11 @@ function makeService() {
     noop, // boxLookupCacheInvalidationService
     noop, // boxActivityService
   )
-  return { service, boxRepository, eventEmitter }
+  return { service, boxRepository, eventEmitter, organizationService }
 }
+
+const activeOrg = { id: 'org-1', suspended: false } as any
+const suspendedOrg = { id: 'org-1', suspended: true } as any
 
 const stoppedBox = {
   id: 'box-1',
@@ -42,27 +57,37 @@ const stoppedBox = {
   pending: false,
 }
 
-describe('BoxService.ensureStartedForExec', () => {
-  // The control-plane never writes box.state directly; like start(), it flips
-  // desiredState and lets the runner's reported state catch up. exec has
-  // already auto-started the VM in the runtime, so box_sync will report STARTED
-  // and — now that desiredState agrees — sync-states will not stop it back.
+describe('BoxService.ensureStartedForProxy', () => {
+  // The control plane never writes box.state directly; like start(), it flips
+  // desiredState and lets the runner's reported state catch up. The proxied
+  // call has already auto-started the VM in the runtime, so box_sync will
+  // report STARTED and — now that desiredState agrees — sync-states will not
+  // stop it back.
   it('flips a cleanly-stopped box to desiredState=STARTED and emits STARTED', async () => {
     const { service, boxRepository, eventEmitter } = makeService()
     jest.spyOn(service, 'findOneByIdOrName').mockResolvedValue(stoppedBox as any)
-    boxRepository.updateWhere.mockResolvedValue({
+    boxRepository.conditionalStartForProxy.mockResolvedValue({
       ...stoppedBox,
       pending: true,
       desiredState: BoxDesiredState.STARTED,
     })
 
-    await service.ensureStartedForExec('box-1', 'org-1')
+    await service.ensureStartedForProxy('box-1', activeOrg)
 
-    expect(boxRepository.updateWhere).toHaveBeenCalledWith('box-1', {
-      updateData: { pending: true, desiredState: BoxDesiredState.STARTED },
-      whereCondition: { pending: false, state: BoxState.STOPPED, desiredState: BoxDesiredState.STOPPED },
-    })
+    expect(boxRepository.conditionalStartForProxy).toHaveBeenCalledWith('box-1', 'org-1')
     expect(eventEmitter.emit).toHaveBeenCalledWith(BoxEvents.STARTED, expect.anything())
+  })
+
+  // Same gate as start() (~line 790). Without this, a suspended org could
+  // exec / files / metrics a STOPPED box back to STARTED, bypassing the
+  // start-time guard.
+  it('throws ForbiddenException for a suspended organization', async () => {
+    const { service, boxRepository, eventEmitter } = makeService()
+
+    await expect(service.ensureStartedForProxy('box-1', suspendedOrg)).rejects.toThrow(ForbiddenException)
+
+    expect(boxRepository.conditionalStartForProxy).not.toHaveBeenCalled()
+    expect(eventEmitter.emit).not.toHaveBeenCalled()
   })
 
   it('is a no-op for an already-started box (idempotent)', async () => {
@@ -73,9 +98,9 @@ describe('BoxService.ensureStartedForExec', () => {
       desiredState: BoxDesiredState.STARTED,
     } as any)
 
-    await service.ensureStartedForExec('box-1', 'org-1')
+    await service.ensureStartedForProxy('box-1', activeOrg)
 
-    expect(boxRepository.updateWhere).not.toHaveBeenCalled()
+    expect(boxRepository.conditionalStartForProxy).not.toHaveBeenCalled()
     expect(eventEmitter.emit).not.toHaveBeenCalled()
   })
 
@@ -86,36 +111,39 @@ describe('BoxService.ensureStartedForExec', () => {
       desiredState: BoxDesiredState.DESTROYED,
     } as any)
 
-    await service.ensureStartedForExec('box-1', 'org-1')
+    await service.ensureStartedForProxy('box-1', activeOrg)
 
-    expect(boxRepository.updateWhere).not.toHaveBeenCalled()
+    expect(boxRepository.conditionalStartForProxy).not.toHaveBeenCalled()
   })
 
   it('does not touch a box already mid-transition (pending)', async () => {
     const { service, boxRepository } = makeService()
     jest.spyOn(service, 'findOneByIdOrName').mockResolvedValue({ ...stoppedBox, pending: true } as any)
 
-    await service.ensureStartedForExec('box-1', 'org-1')
+    await service.ensureStartedForProxy('box-1', activeOrg)
 
-    expect(boxRepository.updateWhere).not.toHaveBeenCalled()
+    expect(boxRepository.conditionalStartForProxy).not.toHaveBeenCalled()
   })
 
-  it('swallows a conflicting concurrent state change (best-effort)', async () => {
+  // Conditional UPDATE matched zero rows = race lost or box transitioned out
+  // of the eligible state between snapshot and write. Same no-op semantics
+  // as the old BoxConflictError swallow.
+  it('emits nothing when the conditional update matches zero rows (race lost)', async () => {
     const { service, boxRepository, eventEmitter } = makeService()
     jest.spyOn(service, 'findOneByIdOrName').mockResolvedValue(stoppedBox as any)
-    boxRepository.updateWhere.mockRejectedValue(new BoxConflictError())
+    boxRepository.conditionalStartForProxy.mockResolvedValue(null)
 
-    await expect(service.ensureStartedForExec('box-1', 'org-1')).resolves.toBeUndefined()
+    await expect(service.ensureStartedForProxy('box-1', activeOrg)).resolves.toBeUndefined()
     expect(eventEmitter.emit).not.toHaveBeenCalled()
   })
 
-  it('swallows an unexpected (non-conflict) failure without emitting', async () => {
+  it('swallows an unexpected DB failure without emitting', async () => {
     const { service, boxRepository, eventEmitter } = makeService()
     jest.spyOn(service, 'findOneByIdOrName').mockResolvedValue(stoppedBox as any)
-    boxRepository.updateWhere.mockRejectedValue(new Error('db connection lost'))
+    boxRepository.conditionalStartForProxy.mockRejectedValue(new Error('db connection lost'))
     const warn = jest.spyOn((service as any).logger, 'warn').mockImplementation(() => undefined)
 
-    await expect(service.ensureStartedForExec('box-1', 'org-1')).resolves.toBeUndefined()
+    await expect(service.ensureStartedForProxy('box-1', activeOrg)).resolves.toBeUndefined()
     expect(eventEmitter.emit).not.toHaveBeenCalled()
     expect(warn).toHaveBeenCalled()
   })

--- a/apps/api/src/box/services/box.service.spec.ts
+++ b/apps/api/src/box/services/box.service.spec.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2025 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { BoxService } from './box.service'
+import { BoxState } from '../enums/box-state.enum'
+import { BoxDesiredState } from '../enums/box-desired-state.enum'
+import { BoxEvents } from '../constants/box-events.constants'
+import { BoxConflictError } from '../errors/box-conflict.error'
+
+// ensureStartedForExec only touches boxRepository + eventEmitter; every other
+// injected dependency is irrelevant to this unit, so they are stubbed out.
+function makeService() {
+  const boxRepository = { findOneByIdOrName: jest.fn(), updateWhere: jest.fn() } as any
+  const eventEmitter = { emit: jest.fn(), emitAsync: jest.fn() } as any
+  const noop = {} as any
+  const service = new BoxService(
+    boxRepository, // boxRepository
+    noop, // runnerRepository
+    noop, // sshAccessRepository
+    noop, // runnerService
+    noop, // volumeService
+    noop, // configService
+    noop, // warmPoolService
+    eventEmitter, // eventEmitter
+    noop, // organizationService
+    noop, // runnerAdapterFactory
+    noop, // redisLockProvider
+    noop, // redis
+    noop, // regionService
+    noop, // boxLookupCacheInvalidationService
+    noop, // boxActivityService
+  )
+  return { service, boxRepository, eventEmitter }
+}
+
+const stoppedBox = {
+  id: 'box-1',
+  state: BoxState.STOPPED,
+  desiredState: BoxDesiredState.STOPPED,
+  pending: false,
+}
+
+describe('BoxService.ensureStartedForExec', () => {
+  // The control-plane never writes box.state directly; like start(), it flips
+  // desiredState and lets the runner's reported state catch up. exec has
+  // already auto-started the VM in the runtime, so box_sync will report STARTED
+  // and — now that desiredState agrees — sync-states will not stop it back.
+  it('flips a cleanly-stopped box to desiredState=STARTED and emits STARTED', async () => {
+    const { service, boxRepository, eventEmitter } = makeService()
+    jest.spyOn(service, 'findOneByIdOrName').mockResolvedValue(stoppedBox as any)
+    boxRepository.updateWhere.mockResolvedValue({
+      ...stoppedBox,
+      pending: true,
+      desiredState: BoxDesiredState.STARTED,
+    })
+
+    await service.ensureStartedForExec('box-1', 'org-1')
+
+    expect(boxRepository.updateWhere).toHaveBeenCalledWith('box-1', {
+      updateData: { pending: true, desiredState: BoxDesiredState.STARTED },
+      whereCondition: { pending: false, state: BoxState.STOPPED, desiredState: BoxDesiredState.STOPPED },
+    })
+    expect(eventEmitter.emit).toHaveBeenCalledWith(BoxEvents.STARTED, expect.anything())
+  })
+
+  it('is a no-op for an already-started box (idempotent)', async () => {
+    const { service, boxRepository, eventEmitter } = makeService()
+    jest.spyOn(service, 'findOneByIdOrName').mockResolvedValue({
+      ...stoppedBox,
+      state: BoxState.STARTED,
+      desiredState: BoxDesiredState.STARTED,
+    } as any)
+
+    await service.ensureStartedForExec('box-1', 'org-1')
+
+    expect(boxRepository.updateWhere).not.toHaveBeenCalled()
+    expect(eventEmitter.emit).not.toHaveBeenCalled()
+  })
+
+  it('does not revive a box the user asked to destroy', async () => {
+    const { service, boxRepository } = makeService()
+    jest.spyOn(service, 'findOneByIdOrName').mockResolvedValue({
+      ...stoppedBox,
+      desiredState: BoxDesiredState.DESTROYED,
+    } as any)
+
+    await service.ensureStartedForExec('box-1', 'org-1')
+
+    expect(boxRepository.updateWhere).not.toHaveBeenCalled()
+  })
+
+  it('does not touch a box already mid-transition (pending)', async () => {
+    const { service, boxRepository } = makeService()
+    jest.spyOn(service, 'findOneByIdOrName').mockResolvedValue({ ...stoppedBox, pending: true } as any)
+
+    await service.ensureStartedForExec('box-1', 'org-1')
+
+    expect(boxRepository.updateWhere).not.toHaveBeenCalled()
+  })
+
+  it('swallows a conflicting concurrent state change (best-effort)', async () => {
+    const { service, boxRepository, eventEmitter } = makeService()
+    jest.spyOn(service, 'findOneByIdOrName').mockResolvedValue(stoppedBox as any)
+    boxRepository.updateWhere.mockRejectedValue(new BoxConflictError())
+
+    await expect(service.ensureStartedForExec('box-1', 'org-1')).resolves.toBeUndefined()
+    expect(eventEmitter.emit).not.toHaveBeenCalled()
+  })
+})

--- a/apps/api/src/box/services/box.service.spec.ts
+++ b/apps/api/src/box/services/box.service.spec.ts
@@ -76,6 +76,9 @@ describe('BoxService.ensureStartedForProxy', () => {
 
     expect(boxRepository.conditionalStartForProxy).toHaveBeenCalledWith('box-1', 'org-1')
     expect(eventEmitter.emit).toHaveBeenCalledWith(BoxEvents.STARTED, expect.anything())
+    // Also raise the desired-state event start() raises, so the notification
+    // gateway and analytics observe the STOPPED→STARTED flip on autostart too.
+    expect(eventEmitter.emit).toHaveBeenCalledWith(BoxEvents.DESIRED_STATE_UPDATED, expect.anything())
   })
 
   // Same gate as start() (~line 790). Without this, a suspended org could

--- a/apps/api/src/box/services/box.service.ts
+++ b/apps/api/src/box/services/box.service.ts
@@ -30,6 +30,7 @@ import { BoxEvents } from '../constants/box-events.constants'
 import { BoxStateUpdatedEvent } from '../events/box-state-updated.event'
 import { BoxDestroyedEvent } from '../events/box-destroyed.event'
 import { BoxStartedEvent } from '../events/box-started.event'
+import { BoxDesiredStateUpdatedEvent } from '../events/box-desired-state-updated.event'
 import { BoxStoppedEvent } from '../events/box-stopped.event'
 import { OrganizationService } from '../../organization/services/organization.service'
 import { OrganizationEvents } from '../../organization/constants/organization-events.constant'
@@ -846,6 +847,11 @@ export class BoxService {
    * Otherwise best-effort and idempotent: the proxied call has already (or
    * will soon) hit the runtime, so DB-side failures are swallowed and
    * box_sync reconciles state on its next tick.
+   *
+   * On a successful flip emits BoxEvents.STARTED (drives convergence) and
+   * BoxEvents.DESIRED_STATE_UPDATED — the same desired-state event start()
+   * raises via updateWhere, so the notification gateway and analytics see the
+   * STOPPED→STARTED transition for an exec-autostart too.
    */
   async ensureStartedForProxy(boxIdOrName: string, organization: Organization): Promise<void> {
     // Suspension check first — same gate as start() (~line 790). Without it,
@@ -880,7 +886,15 @@ export class BoxService {
       return
     }
 
+    // Emit post-commit (conditionalStartForProxy's transaction has returned),
+    // so listeners never observe an uncommitted desiredState. The flip was
+    // strictly STOPPED→STARTED — the pre-check and the conditional UPDATE both
+    // gate on desiredState=STOPPED.
     this.eventEmitter.emit(BoxEvents.STARTED, new BoxStartedEvent(updated))
+    this.eventEmitter.emit(
+      BoxEvents.DESIRED_STATE_UPDATED,
+      new BoxDesiredStateUpdatedEvent(updated, BoxDesiredState.STOPPED, BoxDesiredState.STARTED),
+    )
   }
 
   async stop(boxIdOrName: string, organizationId?: string, force?: boolean): Promise<Box> {

--- a/apps/api/src/box/services/box.service.ts
+++ b/apps/api/src/box/services/box.service.ts
@@ -31,7 +31,6 @@ import { BoxStateUpdatedEvent } from '../events/box-state-updated.event'
 import { BoxDestroyedEvent } from '../events/box-destroyed.event'
 import { BoxStartedEvent } from '../events/box-started.event'
 import { BoxStoppedEvent } from '../events/box-stopped.event'
-import { BoxConflictError } from '../errors/box-conflict.error'
 import { OrganizationService } from '../../organization/services/organization.service'
 import { OrganizationEvents } from '../../organization/constants/organization-events.constant'
 import { OrganizationSuspendedBoxStoppedEvent } from '../../organization/events/organization-suspended-box-stopped.event'
@@ -831,48 +830,57 @@ export class BoxService {
   }
 
   /**
-   * Reflect an exec-triggered auto-start in the control plane.
+   * Reflect a proxy-triggered auto-start in the control plane.
    *
-   * `exec` on a stopped box auto-starts the VM in the runtime (BoxLite core
-   * live_state), but nothing tells the API. Left alone, PG keeps the box at
-   * desiredState=STOPPED and sync-states promptly issues STOP_BOX, undoing the
-   * auto-start. Flip desiredState to STARTED — exactly like start() — so the
-   * runner-reported STARTED state agrees and the box stays up. We never write
-   * state directly; the runner remains the source of truth for it.
+   * exec / files / metrics on a stopped box all reach `Box::live_state()` in
+   * the runtime, which lazily inits the VM — but nothing tells the API. Left
+   * alone, PG keeps the box at desiredState=STOPPED and sync-states promptly
+   * issues STOP_BOX, undoing the auto-start. Flip desiredState to STARTED —
+   * exactly like start() — so the runner-reported STARTED state agrees and
+   * the box stays up. We never write state directly; the runner remains the
+   * source of truth for it.
    *
-   * Best-effort and idempotent: the exec has already happened, so any failure
-   * here is swallowed (box_sync reconciles state on its next tick).
+   * Suspension is a hard wall (same as start()): throws ForbiddenException so
+   * the controller surfaces 403 to the caller and the proxy never runs.
+   *
+   * Otherwise best-effort and idempotent: the proxied call has already (or
+   * will soon) hit the runtime, so DB-side failures are swallowed and
+   * box_sync reconciles state on its next tick.
    */
-  async ensureStartedForExec(boxIdOrName: string, organizationId: string): Promise<void> {
-    const box = await this.findOneByIdOrName(boxIdOrName, organizationId)
+  async ensureStartedForProxy(boxIdOrName: string, organization: Organization): Promise<void> {
+    // Suspension check first — same gate as start() (~line 790). Without it,
+    // a suspended org could exec/files/metrics a STOPPED box back to STARTED,
+    // bypassing the start-time guard entirely.
+    this.organizationService.assertOrganizationIsNotSuspended(organization)
+
+    const box = await this.findOneByIdOrName(boxIdOrName, organization.id)
     if (!box) {
       return
     }
 
-    // Only wake a cleanly-stopped box. Leave STARTED, in-transition (pending),
-    // and destroy-intent boxes untouched.
+    // Cheap pre-check on the cached snapshot. The repository's conditional
+    // UPDATE re-asserts atomically — this just avoids a no-op round-trip when
+    // the snapshot already shows the box isn't a candidate.
     if (box.pending || box.state !== BoxState.STOPPED || box.desiredState !== BoxDesiredState.STOPPED) {
       return
     }
 
-    let updatedBox: Box
+    let updated: Box | null
     try {
-      updatedBox = await this.boxRepository.updateWhere(box.id, {
-        updateData: { pending: true, desiredState: BoxDesiredState.STARTED },
-        whereCondition: { pending: false, state: BoxState.STOPPED, desiredState: BoxDesiredState.STOPPED },
-      })
+      updated = await this.boxRepository.conditionalStartForProxy(box.id, organization.id)
     } catch (err) {
-      // Lost the race to a concurrent state change — expected, no-op.
-      if (err instanceof BoxConflictError) {
-        return
-      }
-      // Any other failure (DB / validation): the exec already happened so don't
-      // block it, but surface the unexpected error instead of swallowing it.
-      this.logger.warn(`ensureStartedForExec: unexpected failure for box ${boxIdOrName}: ${err}`)
+      this.logger.warn(`ensureStartedForProxy: unexpected failure for box ${boxIdOrName}: ${err}`)
       return
     }
 
-    this.eventEmitter.emit(BoxEvents.STARTED, new BoxStartedEvent(updatedBox))
+    // Zero rows matched — race lost or the box transitioned out of the
+    // eligible state between snapshot and write. No-op (same semantics as
+    // the old BoxConflictError swallow).
+    if (!updated) {
+      return
+    }
+
+    this.eventEmitter.emit(BoxEvents.STARTED, new BoxStartedEvent(updated))
   }
 
   async stop(boxIdOrName: string, organizationId?: string, force?: boolean): Promise<Box> {

--- a/apps/api/src/box/services/box.service.ts
+++ b/apps/api/src/box/services/box.service.ts
@@ -829,6 +829,46 @@ export class BoxService {
     return updatedBox
   }
 
+  /**
+   * Reflect an exec-triggered auto-start in the control plane.
+   *
+   * `exec` on a stopped box auto-starts the VM in the runtime (BoxLite core
+   * live_state), but nothing tells the API. Left alone, PG keeps the box at
+   * desiredState=STOPPED and sync-states promptly issues STOP_BOX, undoing the
+   * auto-start. Flip desiredState to STARTED — exactly like start() — so the
+   * runner-reported STARTED state agrees and the box stays up. We never write
+   * state directly; the runner remains the source of truth for it.
+   *
+   * Best-effort and idempotent: the exec has already happened, so any failure
+   * here is swallowed (box_sync reconciles state on its next tick).
+   */
+  async ensureStartedForExec(boxIdOrName: string, organizationId: string): Promise<void> {
+    const box = await this.findOneByIdOrName(boxIdOrName, organizationId)
+    if (!box) {
+      return
+    }
+
+    // Only wake a cleanly-stopped box. Leave STARTED, in-transition (pending),
+    // and destroy-intent boxes untouched.
+    if (box.pending || box.state !== BoxState.STOPPED || box.desiredState !== BoxDesiredState.STOPPED) {
+      return
+    }
+
+    let updatedBox: Box
+    try {
+      updatedBox = await this.boxRepository.updateWhere(box.id, {
+        updateData: { pending: true, desiredState: BoxDesiredState.STARTED },
+        whereCondition: { pending: false, state: BoxState.STOPPED, desiredState: BoxDesiredState.STOPPED },
+      })
+    } catch {
+      // A concurrent state change won the row (BoxConflictError). Leave it —
+      // the exec already succeeded and box_sync will reconcile state.
+      return
+    }
+
+    this.eventEmitter.emit(BoxEvents.STARTED, new BoxStartedEvent(updatedBox))
+  }
+
   async stop(boxIdOrName: string, organizationId?: string, force?: boolean): Promise<Box> {
     // Capture the JS call stack so we can identify the code path that hit
     // boxService.stop() — the audit log only records the leaf endpoint,

--- a/apps/api/src/box/services/box.service.ts
+++ b/apps/api/src/box/services/box.service.ts
@@ -31,6 +31,7 @@ import { BoxStateUpdatedEvent } from '../events/box-state-updated.event'
 import { BoxDestroyedEvent } from '../events/box-destroyed.event'
 import { BoxStartedEvent } from '../events/box-started.event'
 import { BoxStoppedEvent } from '../events/box-stopped.event'
+import { BoxConflictError } from '../errors/box-conflict.error'
 import { OrganizationService } from '../../organization/services/organization.service'
 import { OrganizationEvents } from '../../organization/constants/organization-events.constant'
 import { OrganizationSuspendedBoxStoppedEvent } from '../../organization/events/organization-suspended-box-stopped.event'
@@ -860,9 +861,14 @@ export class BoxService {
         updateData: { pending: true, desiredState: BoxDesiredState.STARTED },
         whereCondition: { pending: false, state: BoxState.STOPPED, desiredState: BoxDesiredState.STOPPED },
       })
-    } catch {
-      // A concurrent state change won the row (BoxConflictError). Leave it —
-      // the exec already succeeded and box_sync will reconcile state.
+    } catch (err) {
+      // Lost the race to a concurrent state change — expected, no-op.
+      if (err instanceof BoxConflictError) {
+        return
+      }
+      // Any other failure (DB / validation): the exec already happened so don't
+      // block it, but surface the unexpected error instead of swallowing it.
+      this.logger.warn(`ensureStartedForExec: unexpected failure for box ${boxIdOrName}: ${err}`)
       return
     }
 

--- a/apps/api/src/boxlite-rest/boxlite-proxy.controller.spec.ts
+++ b/apps/api/src/boxlite-rest/boxlite-proxy.controller.spec.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
+import { ForbiddenException } from '@nestjs/common'
 import { createProxyMiddleware } from 'http-proxy-middleware'
 import { BoxliteProxyController } from './boxlite-proxy.controller'
 
@@ -16,6 +17,26 @@ jest.mock('uuid', () => ({
   validate: jest.fn(() => true),
 }))
 
+const activeAuth = {
+  organizationId: 'org-1',
+  organization: { id: 'org-1', suspended: false } as any,
+}
+
+function makeBoxService(overrides: Partial<Record<string, any>> = {}) {
+  return {
+    findOneByIdOrName: jest.fn().mockResolvedValue({ id: 'box-uuid', runnerId: 'runner-1' }),
+    updateLastActivityAt: jest.fn().mockResolvedValue(undefined),
+    ensureStartedForProxy: jest.fn().mockResolvedValue(undefined),
+    ...overrides,
+  }
+}
+
+function makeRunnerService() {
+  return {
+    findOne: jest.fn().mockResolvedValue({ apiUrl: 'http://runner.local', apiKey: 'runner-key' }),
+  }
+}
+
 describe('BoxliteProxyController', () => {
   beforeEach(() => {
     jest.clearAllMocks()
@@ -25,27 +46,14 @@ describe('BoxliteProxyController', () => {
     const proxyHandler = jest.fn()
     jest.mocked(createProxyMiddleware).mockReturnValue(proxyHandler as never)
 
-    const boxService = {
-      findOneByIdOrName: jest.fn().mockResolvedValue({
-        id: 'box-uuid',
-        runnerId: 'runner-1',
-      }),
-      updateLastActivityAt: jest.fn().mockResolvedValue(undefined),
-      ensureStartedForExec: jest.fn().mockResolvedValue(undefined),
-    }
-    const runnerService = {
-      findOne: jest.fn().mockResolvedValue({
-        apiUrl: 'http://runner.local',
-        apiKey: 'runner-key',
-      }),
-    }
-
+    const boxService = makeBoxService()
+    const runnerService = makeRunnerService()
     const controller = new BoxliteProxyController(boxService as never, runnerService as never)
     const req = { url: '/api/v1/boxes/public-box/exec' }
     const res = {}
     const next = jest.fn()
 
-    await controller.proxyExec({ organizationId: 'org-1' } as never, 'public-box', req as never, res as never, next)
+    await controller.proxyExec(activeAuth as never, 'public-box', req as never, res as never, next)
 
     const proxyOptions = jest.mocked(createProxyMiddleware).mock.calls[0][0]
     const pathRewrite = proxyOptions.pathRewrite as (path: string, req: unknown) => string
@@ -57,43 +65,99 @@ describe('BoxliteProxyController', () => {
   it('asks the control plane to start the box before proxying exec, so an auto-started box is not stopped back', async () => {
     jest.mocked(createProxyMiddleware).mockReturnValue(jest.fn() as never)
 
-    const boxService = {
-      findOneByIdOrName: jest.fn().mockResolvedValue({ id: 'box-uuid', runnerId: 'runner-1' }),
-      updateLastActivityAt: jest.fn().mockResolvedValue(undefined),
-      ensureStartedForExec: jest.fn().mockResolvedValue(undefined),
-    }
-    const runnerService = {
-      findOne: jest.fn().mockResolvedValue({ apiUrl: 'http://runner.local', apiKey: 'runner-key' }),
-    }
-
+    const boxService = makeBoxService()
+    const runnerService = makeRunnerService()
     const controller = new BoxliteProxyController(boxService as never, runnerService as never)
     const req = { url: '/api/v1/boxes/public-box/exec' }
 
-    await controller.proxyExec({ organizationId: 'org-1' } as never, 'public-box', req as never, {} as never, jest.fn())
+    await controller.proxyExec(activeAuth as never, 'public-box', req as never, {} as never, jest.fn())
 
-    expect(boxService.ensureStartedForExec).toHaveBeenCalledWith('public-box', 'org-1')
+    expect(boxService.ensureStartedForProxy).toHaveBeenCalledWith('public-box', activeAuth.organization)
+  })
+
+  it('also fires the start hint for files and metrics proxy paths', async () => {
+    jest.mocked(createProxyMiddleware).mockReturnValue(jest.fn() as never)
+
+    const boxService = makeBoxService()
+    const runnerService = makeRunnerService()
+    const controller = new BoxliteProxyController(boxService as never, runnerService as never)
+    const req = { url: '/api/v1/boxes/public-box/files?path=/tmp' }
+
+    await controller.proxyFiles(activeAuth as never, 'public-box', req as never, {} as never, jest.fn())
+    expect(boxService.ensureStartedForProxy).toHaveBeenCalledWith('public-box', activeAuth.organization)
+
+    boxService.ensureStartedForProxy.mockClear()
+    const metricsReq = { url: '/api/v1/boxes/public-box/metrics' }
+    await controller.proxyMetrics(activeAuth as never, 'public-box', metricsReq as never, {} as never, jest.fn())
+    expect(boxService.ensureStartedForProxy).toHaveBeenCalledWith('public-box', activeAuth.organization)
   })
 
   it('still proxies the exec when the control-plane start hint fails (best-effort)', async () => {
     const proxyHandler = jest.fn()
     jest.mocked(createProxyMiddleware).mockReturnValue(proxyHandler as never)
 
-    const boxService = {
-      findOneByIdOrName: jest.fn().mockResolvedValue({ id: 'box-uuid', runnerId: 'runner-1' }),
-      updateLastActivityAt: jest.fn().mockResolvedValue(undefined),
-      ensureStartedForExec: jest.fn().mockRejectedValue(new Error('db down')),
-    }
-    const runnerService = {
-      findOne: jest.fn().mockResolvedValue({ apiUrl: 'http://runner.local', apiKey: 'runner-key' }),
-    }
-
+    const boxService = makeBoxService({
+      ensureStartedForProxy: jest.fn().mockRejectedValue(new Error('db down')),
+    })
+    const runnerService = makeRunnerService()
     const controller = new BoxliteProxyController(boxService as never, runnerService as never)
     const req = { url: '/api/v1/boxes/public-box/exec' }
     const res = {}
     const next = jest.fn()
 
-    await controller.proxyExec({ organizationId: 'org-1' } as never, 'public-box', req as never, res as never, next)
+    await controller.proxyExec(activeAuth as never, 'public-box', req as never, res as never, next)
 
     expect(proxyHandler).toHaveBeenCalledWith(req, res, next)
+  })
+
+  // ❶ regression guard: if the hint ever regresses to a blocking write that
+  // never resolves, the 2s race fallback must still let the proxy proceed.
+  // Without this test, future refactors could silently drop the setTimeout
+  // tier of Promise.race and the proxy would hang forever.
+  it('still proxies the exec when the start hint hangs past the 2s timeout', async () => {
+    jest.useFakeTimers()
+    const proxyHandler = jest.fn()
+    jest.mocked(createProxyMiddleware).mockReturnValue(proxyHandler as never)
+
+    const boxService = makeBoxService({
+      // Never resolves — simulates the contended-row-lock scenario.
+      ensureStartedForProxy: jest.fn().mockReturnValue(new Promise<void>(() => {})),
+    })
+    const runnerService = makeRunnerService()
+    const controller = new BoxliteProxyController(boxService as never, runnerService as never)
+    const req = { url: '/api/v1/boxes/public-box/exec' }
+    const res = {}
+    const next = jest.fn()
+
+    const pending = controller.proxyExec(activeAuth as never, 'public-box', req as never, res as never, next)
+
+    // Advance past the 2s hint timeout so the setTimeout tier of the race wins.
+    await jest.advanceTimersByTimeAsync(2500)
+    await pending
+
+    expect(proxyHandler).toHaveBeenCalledWith(req, res, next)
+    jest.useRealTimers()
+  })
+
+  // ❷ suspension is a hard wall: ForbiddenException must surface as 403 to
+  // the caller and the proxy must NOT run. Without re-throw, a suspended org
+  // could exec / files / metrics a STOPPED box back to STARTED, bypassing
+  // the start() gate entirely.
+  it('refuses to proxy when the start hint reports a suspended organization', async () => {
+    const proxyHandler = jest.fn()
+    jest.mocked(createProxyMiddleware).mockReturnValue(proxyHandler as never)
+
+    const boxService = makeBoxService({
+      ensureStartedForProxy: jest.fn().mockRejectedValue(new ForbiddenException('Organization is suspended')),
+    })
+    const runnerService = makeRunnerService()
+    const controller = new BoxliteProxyController(boxService as never, runnerService as never)
+    const req = { url: '/api/v1/boxes/public-box/exec' }
+
+    await expect(
+      controller.proxyExec(activeAuth as never, 'public-box', req as never, {} as never, jest.fn()),
+    ).rejects.toThrow(ForbiddenException)
+
+    expect(proxyHandler).not.toHaveBeenCalled()
   })
 })

--- a/apps/api/src/boxlite-rest/boxlite-proxy.controller.spec.ts
+++ b/apps/api/src/boxlite-rest/boxlite-proxy.controller.spec.ts
@@ -31,6 +31,7 @@ describe('BoxliteProxyController', () => {
         runnerId: 'runner-1',
       }),
       updateLastActivityAt: jest.fn().mockResolvedValue(undefined),
+      ensureStartedForExec: jest.fn().mockResolvedValue(undefined),
     }
     const runnerService = {
       findOne: jest.fn().mockResolvedValue({
@@ -50,6 +51,49 @@ describe('BoxliteProxyController', () => {
     const pathRewrite = proxyOptions.pathRewrite as (path: string, req: unknown) => string
     expect(pathRewrite('/api/v1/boxes/public-box/exec', req)).toBe('/v1/boxes/box-uuid/exec')
     expect(boxService.findOneByIdOrName).toHaveBeenCalledWith('public-box', 'org-1')
+    expect(proxyHandler).toHaveBeenCalledWith(req, res, next)
+  })
+
+  it('asks the control plane to start the box before proxying exec, so an auto-started box is not stopped back', async () => {
+    jest.mocked(createProxyMiddleware).mockReturnValue(jest.fn() as never)
+
+    const boxService = {
+      findOneByIdOrName: jest.fn().mockResolvedValue({ id: 'box-uuid', runnerId: 'runner-1' }),
+      updateLastActivityAt: jest.fn().mockResolvedValue(undefined),
+      ensureStartedForExec: jest.fn().mockResolvedValue(undefined),
+    }
+    const runnerService = {
+      findOne: jest.fn().mockResolvedValue({ apiUrl: 'http://runner.local', apiKey: 'runner-key' }),
+    }
+
+    const controller = new BoxliteProxyController(boxService as never, runnerService as never)
+    const req = { url: '/api/v1/boxes/public-box/exec' }
+
+    await controller.proxyExec({ organizationId: 'org-1' } as never, 'public-box', req as never, {} as never, jest.fn())
+
+    expect(boxService.ensureStartedForExec).toHaveBeenCalledWith('public-box', 'org-1')
+  })
+
+  it('still proxies the exec when the control-plane start hint fails (best-effort)', async () => {
+    const proxyHandler = jest.fn()
+    jest.mocked(createProxyMiddleware).mockReturnValue(proxyHandler as never)
+
+    const boxService = {
+      findOneByIdOrName: jest.fn().mockResolvedValue({ id: 'box-uuid', runnerId: 'runner-1' }),
+      updateLastActivityAt: jest.fn().mockResolvedValue(undefined),
+      ensureStartedForExec: jest.fn().mockRejectedValue(new Error('db down')),
+    }
+    const runnerService = {
+      findOne: jest.fn().mockResolvedValue({ apiUrl: 'http://runner.local', apiKey: 'runner-key' }),
+    }
+
+    const controller = new BoxliteProxyController(boxService as never, runnerService as never)
+    const req = { url: '/api/v1/boxes/public-box/exec' }
+    const res = {}
+    const next = jest.fn()
+
+    await controller.proxyExec({ organizationId: 'org-1' } as never, 'public-box', req as never, res as never, next)
+
     expect(proxyHandler).toHaveBeenCalledWith(req, res, next)
   })
 })

--- a/apps/api/src/boxlite-rest/boxlite-proxy.controller.ts
+++ b/apps/api/src/boxlite-rest/boxlite-proxy.controller.ts
@@ -16,6 +16,7 @@ import {
   UseGuards,
   Logger,
   NotFoundException,
+  ForbiddenException,
 } from '@nestjs/common'
 import { ApiTags, ApiBearerAuth, ApiExcludeController } from '@nestjs/swagger'
 import { createProxyMiddleware, fixRequestBody, Options } from 'http-proxy-middleware'
@@ -27,9 +28,11 @@ import { OrganizationAuthContext } from '../common/interfaces/auth-context.inter
 import { BoxService } from '../box/services/box.service'
 import { RunnerService } from '../box/services/runner.service'
 
-// Cap how long exec waits on the best-effort control-plane start hint so a
-// contended box-row lock can never block the user's exec request.
-const EXEC_START_HINT_TIMEOUT_MS = 2000
+// Cap how long the proxy waits on the best-effort control-plane start hint.
+// The hint itself is non-blocking by design (conditional UPDATE, no row lock),
+// but this is kept as a belt-and-suspenders bound — if anything below ever
+// regresses to a blocking write, the proxy still proceeds within 2s.
+const PROXY_START_HINT_TIMEOUT_MS = 2000
 
 // Spec-first surface (openapi/box.openapi.yaml). Must stay out of the product
 // spec: @All() expands to the SEARCH verb, which OpenAPI 3.0 cannot express.
@@ -54,14 +57,7 @@ export class BoxliteProxyController {
     @Res() res: Response,
     @Next() next: NextFunction,
   ) {
-    // exec auto-starts a stopped box in the runtime; reflect that intent in the
-    // control plane before forwarding so sync-states does not immediately stop
-    // it back. Best-effort + time-boxed: ensureStartedForExec takes a pessimistic
-    // row lock, so cap the wait — a contended lock must never block the exec.
-    await Promise.race([
-      this.boxService.ensureStartedForExec(boxId, authContext.organizationId),
-      new Promise<void>((resolve) => setTimeout(resolve, EXEC_START_HINT_TIMEOUT_MS)),
-    ]).catch((err) => this.logger.warn(`ensureStartedForExec failed for ${boxId}: ${err}`))
+    await this.startHint(boxId, authContext)
     return this.proxyToRunner(authContext, boxId, (runnerBoxId) => `/v1/boxes/${runnerBoxId}/exec`, req, res, next)
   }
 
@@ -155,6 +151,7 @@ export class BoxliteProxyController {
     @Res() res: Response,
     @Next() next: NextFunction,
   ) {
+    await this.startHint(boxId, authContext)
     const query = req.url.includes('?') ? req.url.substring(req.url.indexOf('?')) : ''
     return this.proxyToRunner(
       authContext,
@@ -174,7 +171,34 @@ export class BoxliteProxyController {
     @Res() res: Response,
     @Next() next: NextFunction,
   ) {
+    await this.startHint(boxId, authContext)
     return this.proxyToRunner(authContext, boxId, (runnerBoxId) => `/v1/boxes/${runnerBoxId}/metrics`, req, res, next)
+  }
+
+  /**
+   * Tell the control plane that the proxied call (exec / files / metrics) is
+   * about to auto-start a stopped box in the runtime, so PG agrees and
+   * sync-states does not promptly stop it back.
+   *
+   * - Suspended org → ForbiddenException re-thrown → caller sees 403, proxy
+   *   never runs (same gate as POST /boxes/:id/start).
+   * - Any other failure → swallowed; the proxy proceeds because the hint is
+   *   best-effort and box_sync reconciles state on its next tick.
+   * - Time-boxed via PROXY_START_HINT_TIMEOUT_MS as a safety net against any
+   *   future regression to a blocking write.
+   */
+  private async startHint(boxId: string, authContext: OrganizationAuthContext) {
+    try {
+      await Promise.race([
+        this.boxService.ensureStartedForProxy(boxId, authContext.organization),
+        new Promise<void>((resolve) => setTimeout(resolve, PROXY_START_HINT_TIMEOUT_MS)),
+      ])
+    } catch (err) {
+      if (err instanceof ForbiddenException) {
+        throw err
+      }
+      this.logger.warn(`ensureStartedForProxy failed for ${boxId}: ${err}`)
+    }
   }
 
   private async proxyToRunner(

--- a/apps/api/src/boxlite-rest/boxlite-proxy.controller.ts
+++ b/apps/api/src/boxlite-rest/boxlite-proxy.controller.ts
@@ -50,6 +50,12 @@ export class BoxliteProxyController {
     @Res() res: Response,
     @Next() next: NextFunction,
   ) {
+    // exec auto-starts a stopped box in the runtime; reflect that intent in the
+    // control plane before forwarding so sync-states does not immediately stop
+    // it back. Best-effort: never block the exec on this.
+    await this.boxService
+      .ensureStartedForExec(boxId, authContext.organizationId)
+      .catch((err) => this.logger.warn(`ensureStartedForExec failed for ${boxId}: ${err}`))
     return this.proxyToRunner(authContext, boxId, (runnerBoxId) => `/v1/boxes/${runnerBoxId}/exec`, req, res, next)
   }
 

--- a/apps/api/src/boxlite-rest/boxlite-proxy.controller.ts
+++ b/apps/api/src/boxlite-rest/boxlite-proxy.controller.ts
@@ -27,6 +27,10 @@ import { OrganizationAuthContext } from '../common/interfaces/auth-context.inter
 import { BoxService } from '../box/services/box.service'
 import { RunnerService } from '../box/services/runner.service'
 
+// Cap how long exec waits on the best-effort control-plane start hint so a
+// contended box-row lock can never block the user's exec request.
+const EXEC_START_HINT_TIMEOUT_MS = 2000
+
 // Spec-first surface (openapi/box.openapi.yaml). Must stay out of the product
 // spec: @All() expands to the SEARCH verb, which OpenAPI 3.0 cannot express.
 @ApiExcludeController()
@@ -52,10 +56,12 @@ export class BoxliteProxyController {
   ) {
     // exec auto-starts a stopped box in the runtime; reflect that intent in the
     // control plane before forwarding so sync-states does not immediately stop
-    // it back. Best-effort: never block the exec on this.
-    await this.boxService
-      .ensureStartedForExec(boxId, authContext.organizationId)
-      .catch((err) => this.logger.warn(`ensureStartedForExec failed for ${boxId}: ${err}`))
+    // it back. Best-effort + time-boxed: ensureStartedForExec takes a pessimistic
+    // row lock, so cap the wait — a contended lock must never block the exec.
+    await Promise.race([
+      this.boxService.ensureStartedForExec(boxId, authContext.organizationId),
+      new Promise<void>((resolve) => setTimeout(resolve, EXEC_START_HINT_TIMEOUT_MS)),
+    ]).catch((err) => this.logger.warn(`ensureStartedForExec failed for ${boxId}: ${err}`))
     return this.proxyToRunner(authContext, boxId, (runnerBoxId) => `/v1/boxes/${runnerBoxId}/exec`, req, res, next)
   }
 

--- a/apps/api/src/boxlite-rest/boxlite-proxy.controller.ts
+++ b/apps/api/src/boxlite-rest/boxlite-proxy.controller.ts
@@ -28,10 +28,11 @@ import { OrganizationAuthContext } from '../common/interfaces/auth-context.inter
 import { BoxService } from '../box/services/box.service'
 import { RunnerService } from '../box/services/runner.service'
 
-// Cap how long the proxy waits on the best-effort control-plane start hint.
-// The hint itself is non-blocking by design (conditional UPDATE, no row lock),
-// but this is kept as a belt-and-suspenders bound — if anything below ever
-// regresses to a blocking write, the proxy still proceeds within 2s.
+// Caller-side wait cap for the best-effort control-plane start hint. The hint's
+// DB work is itself bounded by a lock_timeout (see conditionalStartForProxy),
+// which aborts the statement and frees the connection on row-lock contention;
+// this race only limits how long *exec* waits on the hint, so the proxy
+// proceeds even if the hint is momentarily slow. Both bounds are 2s.
 const PROXY_START_HINT_TIMEOUT_MS = 2000
 
 // Spec-first surface (openapi/box.openapi.yaml). Must stay out of the product
@@ -184,8 +185,10 @@ export class BoxliteProxyController {
    *   never runs (same gate as POST /boxes/:id/start).
    * - Any other failure → swallowed; the proxy proceeds because the hint is
    *   best-effort and box_sync reconciles state on its next tick.
-   * - Time-boxed via PROXY_START_HINT_TIMEOUT_MS as a safety net against any
-   *   future regression to a blocking write.
+   * - Caller-side time-boxed via PROXY_START_HINT_TIMEOUT_MS; the hint's DB work
+   *   is independently bounded by a lock_timeout (conditionalStartForProxy), so
+   *   a contended row aborts at the DB and frees its connection rather than
+   *   waiting out this race detached.
    */
   private async startHint(boxId: string, authContext: OrganizationAuthContext) {
     try {


### PR DESCRIPTION
## Problem

`exec` on a **stopped** box auto-starts the VM in the runtime (BoxLite core `live_state`) — an intended feature. But the exec proxy path makes **no API call**, so Postgres keeps the box at `state=STOPPED, desiredState=STOPPED`. The user sees exec succeed and the box really running, while the dashboard/PG still show STOPPED.

## Fix

`BoxService.ensureStartedForExec(boxId, orgId)`:
- Flip `desiredState` → `STARTED` (like `start()`; control plane never writes `state` directly — runner stays source of truth) and emit `BoxEvents.STARTED`.
- Called from `proxyExec` before forwarding. Best-effort + idempotent: only a cleanly-stopped box is woken; STARTED / DESTROYED-intent / pending boxes untouched; failures swallowed (box_sync reconciles).

## Test plan

- [x] `box.service.spec.ts` (5 cases): flips stopped→started + emits; idempotent; skips DESTROYED; skips pending; swallows BoxConflictError
- [x] `boxlite-proxy.controller.spec.ts`: proxyExec calls the hint; still proxies when the hint throws
- [x] **End-to-end on infra-local (real API + runner + PG), two-sided:**
  - **With fix:** stop box → exec → `state`/`desiredState` converge to `started`, stable 100s (not stopped back). ✅
  - **Without fix (reverted + API restart):** exec returns an execution_id (command really ran) but `state`/`desiredState` stay `stopped` for 100s — the reported bug reproduced. ✅

## Design notes

- `BoxEvents.STARTED` listeners are `box.manager.syncInstanceState` (drives convergence) + analytics debug-log — no billing side-effect, so emitting on exec-autostart is safe.
- Does not reset `authToken` (unlike `start()`): the VM already runs with the existing token after auto-start.

## Related

- Independent of #859 (poller spawn gate). Different bug, different layer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Proxy requests (exec, files, metrics) now attempt a best-effort control-plane start for stopped boxes before proxying, with a 2s timeout.
* **Bug Fixes**
  * Suspended organizations are blocked with a 403; other start-hint failures are logged and proxying continues.
  * Startup hinting only updates when appropriate, avoids “reviving” destroyed or mid-transition boxes, and emits start-related events only when the conditional update succeeds.
* **Tests**
  * Added unit coverage for the conditional start logic, lock-timeout handling, idempotency/race cases, and proxy controller timeout/error behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->