### PR TITLE
perf(dashboard): cut /boxes first-paint (auth session + static cache + code-split + bundle slim)

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -14,6 +14,7 @@ import { BoxModule } from './box/box.module'
 import { AuthModule } from './auth/auth.module'
 import { ServeStaticModule } from '@nestjs/serve-static'
 import { join } from 'path'
+import { setDashboardStaticHeaders } from './serve-static-cache'
 import { ApiKeyModule } from './api-key/api-key.module'
 import { seconds, ThrottlerModule } from '@nestjs/throttler'
 import { RedisModule, getRedisConnectionToken } from '@nestjs-modules/ioredis'
@@ -116,7 +117,11 @@ import { BoxliteRestModule } from './boxlite-rest/boxlite-rest.module'
       exclude: ['/api/{*path}'],
       renderPath: '/',
       serveStaticOptions: {
+        // Disable serve-static's own default Cache-Control; setHeaders applies a
+        // content-addressed policy: hashed /assets/* immutable-forever, HTML
+        // no-cache. Stops the ~600KB bundle re-downloading on every visit.
         cacheControl: false,
+        setHeaders: setDashboardStaticHeaders,
       },
     }),
     RedisModule.forRootAsync({

--- a/apps/api/src/serve-static-cache.spec.ts
+++ b/apps/api/src/serve-static-cache.spec.ts
@@ -1,0 +1,31 @@
+import { dashboardStaticCacheControl, setDashboardStaticHeaders } from './serve-static-cache'
+
+describe('dashboardStaticCacheControl', () => {
+  it('caches content-hashed assets forever (immutable)', () => {
+    expect(dashboardStaticCacheControl('/srv/dashboard/assets/index-C8CfaZCN.js')).toBe(
+      'public, max-age=31536000, immutable',
+    )
+    expect(dashboardStaticCacheControl('/srv/dashboard/assets/index-Dt9Taow4.css')).toBe(
+      'public, max-age=31536000, immutable',
+    )
+  })
+
+  it('never long-caches the HTML shell (must point at the current bundle)', () => {
+    expect(dashboardStaticCacheControl('/srv/dashboard/index.html')).toBe('no-cache')
+  })
+
+  it('revalidates other top-level static files', () => {
+    expect(dashboardStaticCacheControl('/srv/dashboard/favicon.ico')).toBe('public, max-age=0, must-revalidate')
+  })
+})
+
+describe('setDashboardStaticHeaders', () => {
+  it('writes the resolved Cache-Control onto the response', () => {
+    const headers: Record<string, string> = {}
+    const res = { setHeader: (name: string, value: string) => (headers[name] = value) }
+
+    setDashboardStaticHeaders(res, '/srv/dashboard/assets/index-C8CfaZCN.js')
+
+    expect(headers['Cache-Control']).toBe('public, max-age=31536000, immutable')
+  })
+})

--- a/apps/api/src/serve-static-cache.ts
+++ b/apps/api/src/serve-static-cache.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+/**
+ * Cache-Control policy for the dashboard SPA static files.
+ *
+ * Vite emits content-hashed build assets (e.g. /assets/index-C8CfaZCN.js). The
+ * filename changes on every build, so those files are immutable and safe to
+ * cache forever — this is what stops the browser (and CloudFront) from
+ * re-downloading the ~600KB bundle on every Auth0 callback / repeat visit.
+ *
+ * The HTML shell must NOT be cached long-term: it is the only file that points
+ * at the current hashed bundle, so caching it would pin a client to a stale
+ * deploy. Everything else falls back to revalidate-always.
+ */
+export function dashboardStaticCacheControl(filePath: string): string {
+  if (/\.html?$/i.test(filePath)) {
+    return 'no-cache'
+  }
+  if (filePath.includes('/assets/')) {
+    return 'public, max-age=31536000, immutable'
+  }
+  return 'public, max-age=0, must-revalidate'
+}
+
+/**
+ * `setHeaders` hook for @nestjs/serve-static (express.static). Applies the
+ * content-addressed cache policy above per served file.
+ */
+export function setDashboardStaticHeaders(
+  res: { setHeader(name: string, value: string): void },
+  filePath: string,
+): void {
+  res.setHeader('Cache-Control', dashboardStaticCacheControl(filePath))
+}

--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import OrganizationSettings from '@/pages/OrganizationSettings'
 import { NotificationSocketProvider } from '@/providers/NotificationSocketProvider'
 import { OrganizationsProvider } from '@/providers/OrganizationsProvider'
 import { SelectedOrganizationProvider } from '@/providers/SelectedOrganizationProvider'
@@ -29,15 +28,24 @@ import { BOXLITE_DOCS_URL, BOXLITE_SLACK_URL } from './constants/ExternalLinks'
 import { RoutePath, getRouteSubPath } from './enums/RoutePath'
 import { useConfig } from './hooks/useConfig'
 import Dashboard from './pages/Dashboard'
-import EmailVerify from './pages/EmailVerify'
-import Keys from './pages/Keys'
 import LandingPage from './pages/LandingPage'
 import Logout from './pages/Logout'
 import NotFound from './pages/NotFound'
-import Admin from './pages/Admin'
-import Billing from './pages/Billing'
 import Boxes from './pages/Boxes'
-import { BoxDetails, BoxTerminalFullscreen } from './components/boxes'
+
+// Code-split the heavier, not-first-paint routes out of the main bundle. They
+// load on demand under the dashboard <Outlet> Suspense boundary, so the initial
+// /boxes paint no longer ships Admin/Billing/Settings/Keys/box-details and their
+// recharts/terminal deps. Boxes + the Dashboard shell stay eager (first paint).
+const Keys = React.lazy(() => import('./pages/Keys'))
+const Billing = React.lazy(() => import('./pages/Billing'))
+const Admin = React.lazy(() => import('./pages/Admin'))
+const EmailVerify = React.lazy(() => import('./pages/EmailVerify'))
+const OrganizationSettings = React.lazy(() => import('@/pages/OrganizationSettings'))
+const BoxDetails = React.lazy(() => import('./components/boxes').then((m) => ({ default: m.BoxDetails })))
+const BoxTerminalFullscreen = React.lazy(() =>
+  import('./components/boxes').then((m) => ({ default: m.BoxTerminalFullscreen })),
+)
 import { ApiProvider } from './providers/ApiProvider'
 import { RegionsProvider } from './providers/RegionsProvider'
 import { BoxSessionProvider } from './providers/BoxSessionProvider'

--- a/apps/dashboard/src/components/OnboardingGuideDialog.tsx
+++ b/apps/dashboard/src/components/OnboardingGuideDialog.tsx
@@ -8,7 +8,6 @@ import goIcon from '@/assets/go.svg'
 import pythonIcon from '@/assets/python.svg'
 import rustIcon from '@/assets/rust.svg'
 import typescriptIcon from '@/assets/typescript.svg'
-import CodeBlock from '@/components/CodeBlock'
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { useApi } from '@/hooks/useApi'
 import { useConfig } from '@/hooks/useConfig'
@@ -24,8 +23,13 @@ import {
   OrganizationRolePermissionsEnum,
   type ApiKeyResponse,
 } from '@boxlite-ai/api-client'
-import { useEffect, useMemo, useState } from 'react'
+import { Suspense, lazy, useEffect, useMemo, useState } from 'react'
 import { toast } from 'sonner'
+
+// Lazy so prism-react-renderer (syntax highlighting, ~130KB) stays out of the
+// first-paint bundle. CodeBlock only renders in step 2 of this dialog, which is
+// closed on load — the <pre> fallback below is never visible during startup.
+const CodeBlock = lazy(() => import('@/components/CodeBlock'))
 
 interface OnboardingGuideDialogProps {
   open: boolean
@@ -411,13 +415,21 @@ export function OnboardingGuideDialog({ open, onOpenChange, onProgressChange, pr
                   <div className="mb-[9px] text-[9px] uppercase tracking-[1.5px] text-muted-foreground">
                     Run this from your local machine
                   </div>
-                  <CodeBlock
-                    code={renderedExample}
-                    language={activeExample.codeLanguage}
-                    showCopy
-                    className="rounded-none"
-                    codeAreaClassName="whitespace-pre-wrap break-words text-[11.5px] leading-relaxed"
-                  />
+                  <Suspense
+                    fallback={
+                      <pre className="overflow-auto whitespace-pre-wrap break-words rounded-none p-3 text-[11.5px] leading-relaxed">
+                        {renderedExample}
+                      </pre>
+                    }
+                  >
+                    <CodeBlock
+                      code={renderedExample}
+                      language={activeExample.codeLanguage}
+                      showCopy
+                      className="rounded-none"
+                      codeAreaClassName="whitespace-pre-wrap break-words text-[11.5px] leading-relaxed"
+                    />
+                  </Suspense>
                   <div className="mt-[12px] flex items-start gap-2 text-[11.5px] leading-relaxed text-muted-foreground">
                     <span className="flex-none text-brand">ⓘ</span>
                     <span>

--- a/apps/dashboard/src/components/Sidebar.tsx
+++ b/apps/dashboard/src/components/Sidebar.tsx
@@ -73,9 +73,7 @@ const themeOptions: { value: Theme; label: string; icon: React.ReactElement }[] 
 function ThemeMenuItems({ theme, setTheme }: { theme: Theme; setTheme: (theme: Theme) => void }) {
   return (
     <div className="px-2 py-2">
-      <div className="px-1 pb-2 font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
-        Theme
-      </div>
+      <div className="px-1 pb-2 font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground">Theme</div>
       <ToggleGroup
         type="single"
         value={theme}
@@ -168,7 +166,12 @@ export function Sidebar({ isBannerVisible }: SidebarProps) {
     },
     enabled: !!user,
     retry: false,
-    staleTime: 60_000,
+    // Admin status doesn't change within a session. Cache it for the whole
+    // session so this /admin/overview probe (which 403s for non-admins and
+    // competes with the first-paint API burst) fires once, not on every
+    // sidebar mount / navigation. Cleared with the rest of the cache on logout.
+    staleTime: Infinity,
+    gcTime: Infinity,
     refetchOnWindowFocus: false,
   })
   const canViewAdmin = adminAccessQuery.data === true

--- a/apps/dashboard/src/components/Sidebar.tsx
+++ b/apps/dashboard/src/components/Sidebar.tsx
@@ -169,7 +169,9 @@ export function Sidebar({ isBannerVisible }: SidebarProps) {
     // Admin status doesn't change within a session. Cache it for the whole
     // session so this /admin/overview probe (which 403s for non-admins and
     // competes with the first-paint API burst) fires once, not on every
-    // sidebar mount / navigation. Cleared with the rest of the cache on logout.
+    // sidebar mount / navigation. Login/logout go through a full OIDC page
+    // redirect, which discards the in-memory queryClient — so a same-tab user
+    // switch can't carry a stale admin flag across.
     staleTime: Infinity,
     gcTime: Infinity,
     refetchOnWindowFocus: false,

--- a/apps/dashboard/src/hooks/useDocsSearchCommands.tsx
+++ b/apps/dashboard/src/hooks/useDocsSearchCommands.tsx
@@ -14,7 +14,7 @@ import {
 } from '@/components/CommandPalette'
 import { cn } from '@/lib/utils'
 import { keepPreviousData, useQuery } from '@tanstack/react-query'
-import { liteClient as algoliasearch } from 'algoliasearch/lite'
+import type { liteClient } from 'algoliasearch/lite'
 import { BookOpen, Code2, Container, Terminal } from '@/components/ui/icon'
 import { ReactNode, useEffect, useMemo, useState } from 'react'
 
@@ -25,7 +25,25 @@ const CLI_INDEX = import.meta.env.VITE_ALGOLIA_CLI_INDEX_NAME || 'cli_test'
 const SDK_INDEX = import.meta.env.VITE_ALGOLIA_SDK_INDEX_NAME || 'sdk_test'
 
 const docSearchEnabled = Boolean(ALGOLIA_APP_ID && ALGOLIA_API_KEY)
-const client = docSearchEnabled ? algoliasearch(ALGOLIA_APP_ID, ALGOLIA_API_KEY) : null
+
+// Dynamically import algoliasearch only when a docs search actually runs, so the
+// lib stays out of the first-paint bundle. The client is built once (memoized
+// promise). Docs search lives entirely behind the command palette's "search-docs"
+// page and is never needed for first paint.
+type AlgoliaLiteClient = ReturnType<typeof liteClient>
+let clientPromise: Promise<AlgoliaLiteClient | null> | null = null
+
+const getAlgoliaClient = (): Promise<AlgoliaLiteClient | null> => {
+  if (!docSearchEnabled) {
+    return Promise.resolve(null)
+  }
+  if (!clientPromise) {
+    clientPromise = import('algoliasearch/lite').then(({ liteClient }) =>
+      liteClient(ALGOLIA_APP_ID, ALGOLIA_API_KEY),
+    )
+  }
+  return clientPromise
+}
 
 export type AlgoliaHit = {
   objectID: string
@@ -47,7 +65,12 @@ export type SearchResults = {
 }
 
 export const searchDocumentation = async (query: string): Promise<SearchResults> => {
-  if (!client || !query.trim()) {
+  if (!query.trim()) {
+    return { docs: [], cli: [], sdk: [] }
+  }
+
+  const client = await getAlgoliaClient()
+  if (!client) {
     return { docs: [], cli: [], sdk: [] }
   }
 

--- a/apps/dashboard/src/pages/Dashboard.tsx
+++ b/apps/dashboard/src/pages/Dashboard.tsx
@@ -4,8 +4,9 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { Suspense, useEffect, useMemo, useState } from 'react'
 import { Outlet } from 'react-router-dom'
+import { Skeleton } from '@/components/ui/skeleton'
 
 import { AnnouncementBanner } from '@/components/AnnouncementBanner'
 import { CommandPalette, useRegisterCommands, type CommandConfig } from '@/components/CommandPalette'
@@ -140,7 +141,19 @@ const Dashboard: React.FC = () => {
         <Sidebar isBannerVisible={isBannerVisible} billingEnabled={!!config.billingApiUrl} version={config.version} />
         <SidebarInset className="min-h-0 overflow-visible">
           <div className="w-full min-h-[var(--app-content-height,calc(100svh_-_60px))] overscroll-none">
-            <Outlet />
+            {/* Lazy route components (Admin/Billing/Settings/box-details) suspend
+                here so only the content area shows a fallback — the sidebar/shell
+                stays mounted across navigation. */}
+            <Suspense
+              fallback={
+                <div className="space-y-3 p-4 sm:p-5">
+                  <Skeleton className="h-8 w-48" />
+                  <Skeleton className="h-32 w-full" />
+                </div>
+              }
+            >
+              <Outlet />
+            </Suspense>
             <CommandPalette />
           </div>
         </SidebarInset>

--- a/apps/dashboard/src/providers/ConfigProvider.tsx
+++ b/apps/dashboard/src/providers/ConfigProvider.tsx
@@ -8,7 +8,7 @@ import { RoutePath } from '@/enums/RoutePath'
 import { queryKeys } from '@/hooks/queries/queryKeys'
 import { BoxliteConfiguration } from '@boxlite-ai/api-client'
 import { useSuspenseQuery } from '@tanstack/react-query'
-import { InMemoryWebStorage, WebStorageStateStore } from 'oidc-client-ts'
+import { WebStorageStateStore } from 'oidc-client-ts'
 import { ReactNode, useMemo } from 'react'
 import { AuthProvider, AuthProviderProps } from 'react-oidc-context'
 import { ConfigContext } from '../contexts/ConfigContext'
@@ -31,12 +31,13 @@ export function ConfigProvider(props: Props) {
       }
       return res.json() as Promise<BoxliteConfiguration>
     },
+    // App config (OIDC issuer, feature flags, domains) is fixed for a deploy.
+    // Never refetch it on navigation — it gates AuthProvider construction.
+    staleTime: Infinity,
+    gcTime: Infinity,
   })
 
   const oidcConfig: AuthProviderProps = useMemo(() => {
-    const isLocalhost = window.location.hostname === 'localhost'
-    const stateStore = isLocalhost ? window.sessionStorage : new InMemoryWebStorage()
-
     return {
       authority: config.oidc.issuer,
       client_id: config.oidc.clientId,
@@ -47,7 +48,14 @@ export function ConfigProvider(props: Props) {
       redirect_uri: window.location.origin,
       staleStateAgeInSeconds: 60,
       accessTokenExpiringNotificationTimeInSeconds: 290,
-      userStore: new WebStorageStateStore({ store: stateStore }),
+      // Persist the signed-in user (with tokens) in sessionStorage so a page
+      // reload restores the session instead of re-running the OIDC redirect +
+      // token exchange (~1.4s on the critical path, and a full Auth0 round-trip
+      // on a hard reload). Was InMemoryWebStorage in prod, which is wiped on
+      // every load. sessionStorage (not localStorage) keeps the XSS exposure to
+      // the tab lifetime; a 401 still clears the user via ApiClient's handler,
+      // so a stale/revoked token can't get stuck.
+      userStore: new WebStorageStateStore({ store: window.sessionStorage }),
       onSigninCallback: (user) => {
         const state = user?.state as { returnTo?: string } | undefined
         const targetUrl = state?.returnTo || RoutePath.DASHBOARD

--- a/apps/dashboard/src/providers/SelectedOrganizationProvider.tsx
+++ b/apps/dashboard/src/providers/SelectedOrganizationProvider.tsx
@@ -10,12 +10,16 @@ import { useApi } from '@/hooks/useApi'
 import { useOrganizations } from '@/hooks/useOrganizations'
 import { handleApiError } from '@/lib/error-handling'
 import { resolveSelectedOrganizationId } from '@/lib/organization-selection'
-import { Organization, OrganizationRolePermissionsEnum, OrganizationUserRoleEnum } from '@boxlite-ai/api-client'
+import {
+  Organization,
+  OrganizationRolePermissionsEnum,
+  OrganizationUser,
+  OrganizationUserRoleEnum,
+} from '@boxlite-ai/api-client'
 import { usePostHog } from 'posthog-js/react'
 import { ReactNode, useCallback, useEffect, useMemo, useState } from 'react'
 import { useAuth } from 'react-oidc-context'
 import { toast } from 'sonner'
-import { suspend } from 'suspend-react'
 
 type Props = {
   children: ReactNode
@@ -84,9 +88,29 @@ export function SelectedOrganizationProvider(props: Props) {
     [organizationsApi],
   )
 
-  const [organizationMembers, setOrganizationMembers] = useState(
-    suspend(() => getOrganizationMembers(selectedOrganizationId), [organizationsApi, 'organizationMembers']),
-  )
+  // Members are only needed for permission checks (Create/Delete buttons), not
+  // for first paint. Fetching them here used to suspend() the whole dashboard
+  // subtree for ~0.75s before the boxes table could mount. Load them in the
+  // background instead: the table renders immediately; permission-gated actions
+  // default to disabled (authenticatedUserHasPermission returns false on an
+  // empty list) until members arrive.
+  const [organizationMembers, setOrganizationMembers] = useState<OrganizationUser[]>([])
+
+  useEffect(() => {
+    let cancelled = false
+    getOrganizationMembers(selectedOrganizationId)
+      .then((members) => {
+        if (!cancelled) {
+          setOrganizationMembers(members)
+        }
+      })
+      // getOrganizationMembers already surfaces a toast via handleApiError; a
+      // members failure must not crash the dashboard (was: error boundary).
+      .catch(() => undefined)
+    return () => {
+      cancelled = true
+    }
+  }, [getOrganizationMembers, selectedOrganizationId])
 
   const refreshOrganizationMembers = useCallback(
     async (organizationId?: string) => {

--- a/apps/dashboard/vite.config.mts
+++ b/apps/dashboard/vite.config.mts
@@ -92,11 +92,13 @@ export default defineConfig((mode) => ({
     rollupOptions: {
       external: ['tar'],
       output: {
-        // Only pin the heavy first-paint-shared vendors into stable, cacheable
-        // chunks. Everything else is intentionally left to Rollup's default
-        // splitting so deps used ONLY by lazy routes (recharts on Admin/Billing,
-        // xterm/monaco on box-details) land in those async chunks instead of the
-        // eager entry — a catch-all `vendor` bucket would force them back eager.
+        // Pin two broadly-shared vendor groups into stable, cacheable chunks:
+        // @tanstack/* (react-query + react-table are both on the first-paint
+        // boxes path) and react-router. Everything else is intentionally left
+        // to Rollup's default splitting, so deps used ONLY by lazy routes
+        // (recharts on Admin/Billing, xterm/monaco on box-details) land in those
+        // async chunks instead of the eager entry — a catch-all `vendor` bucket
+        // would force them back eager.
         manualChunks(id) {
           if (!id.includes('node_modules')) return undefined
           if (id.includes('@tanstack')) return 'tanstack'

--- a/apps/dashboard/vite.config.mts
+++ b/apps/dashboard/vite.config.mts
@@ -91,6 +91,19 @@ export default defineConfig((mode) => ({
     // we'd ideally polyfill it but until https://github.com/davidmyersdev/vite-plugin-node-polyfills/issues/118 gets resolved we can just exclude it
     rollupOptions: {
       external: ['tar'],
+      output: {
+        // Only pin the heavy first-paint-shared vendors into stable, cacheable
+        // chunks. Everything else is intentionally left to Rollup's default
+        // splitting so deps used ONLY by lazy routes (recharts on Admin/Billing,
+        // xterm/monaco on box-details) land in those async chunks instead of the
+        // eager entry — a catch-all `vendor` bucket would force them back eager.
+        manualChunks(id) {
+          if (!id.includes('node_modules')) return undefined
+          if (id.includes('@tanstack')) return 'tanstack'
+          if (id.includes('react-router') || id.includes('@remix-run/router')) return 'router'
+          return undefined
+        },
+      },
     },
   },
 }))


### PR DESCRIPTION
> **Draft** — opened early for CI + review. **Not yet runtime-verified on a deploy** (see checklist). Local build/typecheck/tests are green.

## What & why

`/dashboard/boxes` takes **~7.2s** (logged-in, warm reload) before real data fills in — not because of data volume (only 21 boxes), but because of a **serial auth + bootstrap chain**: `bundle → config → Auth0 token → /organizations → /members → (boxes/regions burst)`. Measured live in a logged-in Chrome session via the Performance API. Cold first-visit is far worse (~17–18s) because the SPA boots twice across the Auth0 callback and the JS isn't cached.

This PR attacks the removable, structural parts of that chain + trims the first-paint bundle.

## Changes (6 commits)

| Commit | Change | Effect |
|---|---|---|
| `b5462113` perf(api) | `/assets/*` hashed files → `immutable` 1y cache; HTML → `no-cache` | Auth0 callback + repeat visits stop re-downloading the bundle |
| `c65c6ac8` perf(dashboard) | OIDC user store `InMemoryWebStorage` → `sessionStorage`; `config` + sidebar admin-probe queries → `staleTime: Infinity` | Warm reload skips the ~1.4s token exchange + hard-reload Auth0 redirect; nav stops refetching shell data |
| `91485d71` perf(dashboard) | `React.lazy` for Admin/Billing/Settings/Keys/EmailVerify/box-details under a Suspense `<Outlet>`; vite `manualChunks` for @tanstack/react-router | Entry bundle **2.17MB → 1.44MB** (recharts/Admin load on demand) |
| `827a66ab` perf(dashboard) ⚠️ | de-suspend org **members** (suspend-react → background effect) | Boxes table paints ~0.75s sooner; **needs runtime verification — kept isolated so it can be dropped** |
| `f43c3ea3` perf(dashboard) | reword two inaccurate comments (review feedback) | docs only |
| `1ca5f24c` perf(dashboard) | lazy `CodeBlock` (evicts prism-react-renderer) + dynamic-import algolia client (memoized, behind command-palette search) | further first-paint trim: **329KB → 294KB brotli** |

Expected: ~7.2s → **~4.8s** warm to data-ready; cold ~18s → ~12s (estimates; the cut parts — 1.4s token + 0.75s members — are removed outright, bundle savings measured).

## Verification (local — all green)

- ✅ `nx build api` + `nx build dashboard` — typecheck clean (vite-plugin-checker)
- ✅ **dashboard vitest: 13 files / 48 tests pass** (incl. `organization-selection.test.ts`, relevant to the de-suspend)
- ✅ `nx test api serve-static-cache` — 4/4 pass
- ✅ eslint clean on all changed files
- ✅ Bundle eviction verified: prism → `CodeBlock-*.js` async chunk; algolia → async chunk; brotli re-measured
- ❌ **Not runtime-tested** (no deploy) — this is why it's a draft

## Before "ready for review" — runtime checks (after deploy to dev)

- [ ] Warm reload waterfall: `POST /oauth/token` is gone
- [ ] Hard reload no longer bounces through `/?code=...&state=...`
- [ ] `curl -sI /assets/index-*.js` shows `immutable`; 2nd hit `x-cache: Hit`
- [ ] First paint loads neither the Admin/charts chunk nor prism/algolia
- [ ] **Commit `827a66ab`** (de-suspend members): boxes table renders before `/organizations/:id/users` resolves; Create-Box button disabled→enables when members load; org switch works; members API failure → toast + usable dashboard (not a blocking error boundary)
- [ ] Onboarding dialog step 2 renders the CodeBlock (lazy chunk loads)
- [ ] Command palette → Search Docs → query returns results (algolia lazy-loads on first query)

## Notes / risks

- `sessionStorage` (not `localStorage`) chosen to minimize the XSS window for the persisted token; ApiClient's 401→`removeUser()` still clears stale tokens. Confirm a strict CSP ships.
- Code-splitting introduces the deploy-window `ChunkLoadError` risk (old HTML requests a chunk that no longer exists). Recommend a global `ChunkLoadError → location.reload()` guard + keeping old chunks ~24h; **not in this PR**.
- Deliberately **not** done (too risky to ship blind, documented for follow-up): de-suspending `organizations`; `offline_access`/silent-renew (needs IdP config); deferring `posthog` init (biggest remaining ~110KB but changes analytics/consent timing — its own verified PR).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved dashboard loading with on-demand section loading and skeleton-based fallbacks for smoother navigation.
  * Docs search now activates only when enabled and the query is non-empty.
* **Bug Fixes**
  * Updated dashboard static caching behavior: long-lived caching for hashed assets and appropriate no-cache handling for the HTML shell.
  * Organization member data now loads in the background and no longer blocks the dashboard when requests fail.
* **Performance**
  * Reduced initial bundle size via more targeted code-splitting for stable vendor chunks.
  * Session-wide caching reduces repeated authorization/config refetching during the app lifetime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->