### PR TITLE
chore(infra-local): make `make up` work on Apple Silicon + arm64 boxes

### DIFF
--- a/apps/infra-local/Makefile
+++ b/apps/infra-local/Makefile
@@ -2,7 +2,9 @@
 # The Python CLI is the source of truth: `python -m compose --help`.
 # This Makefile exists for muscle memory + tab completion.
 
-PY ?= python
+# Prefer the repo-local venv (.venv-infra) if present, so `make up` just works
+# without the caller needing to activate it; override with `make up PY=...`.
+PY ?= $(shell [ -x ../../.venv-infra/bin/python ] && echo ../../.venv-infra/bin/python || echo python)
 
 .PHONY: help install up down status logs restart reset nuke
 

--- a/apps/infra-local/compose/_local_arm64.py
+++ b/apps/infra-local/compose/_local_arm64.py
@@ -1,0 +1,164 @@
+"""Apple-Silicon local-dev helpers, folded into `compose up` so a fresh arm64
+Mac can `make up` with no manual env/build steps. Every function is idempotent
+and a no-op when its work is already done (or its tools are absent), so it is
+safe to call on every `up`.
+
+Why these exist (gaps `compose up` otherwise assumes are pre-handled):
+  • docker.io pulls (L1 images + the box base) need auth or they hit the
+    anonymous Docker Hub rate limit — the BoxLite puller does NOT read
+    ~/.docker/config.json, so creds must be threaded in.
+  • the maturin *editable* SDK build does not embed boxlite-guest/shim into the
+    runtime cache, so box boot fails with "boxlite-guest not found".
+  • the curated agent images are published amd64-only; an arm64 Mac needs a
+    locally-built arm64 image (debian + the toolbox daemon) to boot a usable box.
+  • the Go runner links the real libboxlite.a, which must be built once.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import urllib.request
+from pathlib import Path
+
+# repo root: this file is <repo>/apps/infra-local/compose/_local_arm64.py
+REPO = Path(__file__).resolve().parents[3]
+AGENT_IMG = "127.0.0.1:25000/boxlite-agent-base:local-arm64"
+
+
+def dockerhub_creds() -> tuple[str | None, str | None]:
+    """(username, token) for docker.io: explicit env first, then Docker
+    Desktop's credStore (populated by `docker login`). (None, None) if neither."""
+    u = os.environ.get("BOXLITE_DOCKERHUB_USER") or os.environ.get("DOCKERHUB_USERNAME")
+    t = os.environ.get("BOXLITE_DOCKERHUB_TOKEN") or os.environ.get("DOCKERHUB_TOKEN")
+    if u and t:
+        return u, t
+    try:
+        out = subprocess.run(
+            ["docker-credential-desktop", "get"],
+            input="https://index.docker.io/v1/",
+            capture_output=True, text=True, timeout=5,
+        )
+        d = json.loads(out.stdout or "{}")
+        return d.get("Username") or None, d.get("Secret") or None
+    except Exception:
+        return None, None
+
+
+def ensure_tools_on_path() -> None:
+    """The seed step shells out to `psql`, and the agent-image step to `crane`;
+    add their Homebrew keg-only / go-install dirs to PATH if they're not already
+    resolvable, so a bare `make up` finds them."""
+    extra = ["/opt/homebrew/opt/libpq/bin", str(Path.home() / "go" / "bin")]
+    parts = os.environ.get("PATH", "").split(os.pathsep)
+    for d in extra:
+        if d not in parts and Path(d).is_dir():
+            parts.append(d)
+    os.environ["PATH"] = os.pathsep.join(parts)
+
+
+def export_dockerhub_env() -> None:
+    """Put docker.io creds into os.environ under every name the stack reads:
+    the orchestrator (L1 SDK) and the Go runner (envconfig). No-op if absent."""
+    u, t = dockerhub_creds()
+    if u and t:
+        os.environ.setdefault("BOXLITE_DOCKERHUB_USER", u)
+        os.environ.setdefault("BOXLITE_DOCKERHUB_TOKEN", t)
+        os.environ.setdefault("DOCKERHUB_USERNAME", u)
+        os.environ.setdefault("DOCKERHUB_TOKEN", t)
+
+
+def fix_runtime_cache() -> None:
+    """maturin editable builds leave the SDK runtime cache missing the big
+    boxlite-guest/shim binaries; copy them from the cargo build output."""
+    base = Path.home() / "Library" / "Application Support" / "boxlite" / "runtimes"
+    caches = sorted(base.glob("v*"))
+    if not caches:
+        return
+    cache = caches[0]
+    if (cache / "boxlite-guest").is_file():
+        return
+    for d in REPO.glob("target/debug/build/boxlite-*/out/runtime"):
+        if (d / "boxlite-guest").is_file():
+            for f in ("boxlite-guest", "boxlite-shim"):
+                shutil.copy2(d / f, cache / f)
+            print(f"  patched runtime cache: boxlite-guest+shim -> {cache}")
+            return
+
+
+def ensure_native_lib() -> None:
+    """Build the real libboxlite.a (the Go runner links it) if missing,
+    initializing the libkrun/e2fsprogs submodules first if needed."""
+    if (REPO / "target" / "debug" / "libboxlite.a").is_file():
+        return
+    status = subprocess.run(["git", "submodule", "status"], cwd=str(REPO),
+                            capture_output=True, text=True)
+    if any(ln.startswith("-") for ln in status.stdout.splitlines()):
+        print("  initializing git submodules (libkrun/e2fsprogs)...")
+        subprocess.run(["git", "submodule", "update", "--init", "--recursive"], cwd=str(REPO), check=True)
+    print("  building native libboxlite.a (real libkrun — slow on first run)...")
+    subprocess.run(["make", "dev:go"], cwd=str(REPO), check=True)
+
+
+def ensure_agent_image() -> str | None:
+    """Build + push an arm64 agent image (debian + toolbox daemon) to the L1
+    registry, since no arm64 curated image exists. Returns the ref to use as
+    BOXLITE_SYSTEM_BASE_IMAGE, or None if docker/crane/registry aren't ready."""
+    if not shutil.which("docker"):
+        return None
+    crane = shutil.which("crane") or str(Path.home() / "go" / "bin" / "crane")
+    if not Path(crane).exists():
+        print("  installing crane (host-side OCI push tool)...")
+        subprocess.run(["go", "install", "github.com/google/go-containerregistry/cmd/crane@latest"],
+                       env={**os.environ, "GOBIN": str(Path.home() / "go" / "bin"), "GOTOOLCHAIN": "auto"},
+                       check=True)
+        crane = str(Path.home() / "go" / "bin" / "crane")
+    try:
+        urllib.request.urlopen("http://127.0.0.1:25000/v2/", timeout=5)
+    except Exception:
+        return None  # L1 registry not up yet
+    try:
+        ls = subprocess.run([crane, "ls", "127.0.0.1:25000/boxlite-agent-base", "--insecure"],
+                            capture_output=True, text=True, timeout=15)
+        if "local-arm64" in ls.stdout:
+            return AGENT_IMG  # already pushed
+    except Exception:
+        pass
+    if subprocess.run(["docker", "info"], capture_output=True).returncode != 0:
+        print("  docker daemon not running — skipping arm64 agent image (boxes won't boot)")
+        return None
+    print("  building arm64 agent image (debian + boxlite-daemon)...")
+    ctx = Path(tempfile.mkdtemp())
+    try:
+        subprocess.run(
+            ["go", "build", "-tags", "netgo", "-ldflags", "-s -w",
+             "-o", str(ctx / "boxlite-daemon"), "./cmd/daemon"],
+            cwd=str(REPO / "apps" / "daemon"),
+            env={**os.environ, "GOOS": "linux", "GOARCH": "arm64",
+                 "CGO_ENABLED": "0", "GOTOOLCHAIN": "auto"},
+            check=True,
+        )
+        (ctx / "start-agent-runtime.sh").write_text(
+            '#!/bin/sh\nset -eu\nmkdir -p /workspace\n'
+            '[ -n "${BOXLITE_SANDBOX_ID:-}" ] || { BOXLITE_SANDBOX_ID="$(hostname)"; export BOXLITE_SANDBOX_ID; }\n'
+            'exec /boxlite/bin/boxlite-daemon "$@"\n'
+        )
+        (ctx / "Dockerfile").write_text(
+            "FROM debian:bookworm-slim\n"
+            "COPY boxlite-daemon /boxlite/bin/boxlite-daemon\n"
+            "COPY start-agent-runtime.sh /boxlite/bin/start-agent-runtime\n"
+            "RUN chmod 0755 /boxlite/bin/boxlite-daemon /boxlite/bin/start-agent-runtime && mkdir -p /workspace\n"
+            "WORKDIR /workspace\n"
+            'ENTRYPOINT ["/boxlite/bin/start-agent-runtime"]\n'
+            'CMD ["sleep", "infinity"]\n'
+        )
+        subprocess.run(["docker", "build", "--platform", "linux/arm64", "-t", AGENT_IMG, str(ctx)], check=True)
+        subprocess.run(["docker", "save", AGENT_IMG, "-o", str(ctx / "img.tar")], check=True)
+        # host-side HTTP push: the docker VM cannot reach the host's :25000.
+        subprocess.run([crane, "push", str(ctx / "img.tar"), AGENT_IMG, "--insecure"], check=True)
+    finally:
+        shutil.rmtree(ctx, ignore_errors=True)
+    return AGENT_IMG

--- a/apps/infra-local/compose/native.py
+++ b/apps/infra-local/compose/native.py
@@ -25,13 +25,14 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 
+from . import _local_arm64
 from . import orchestrator
 from .config import InfraConfig
 from .doctor import _lsof_owner
 from .services import SERVICES
 
 # ── L2 ports + identities (the native host processes) ──────────────────────
-PORT_API = 3001
+PORT_API = int(os.environ.get("BOXLITE_LOCAL_API_PORT", "3001"))  # override if :3001 is taken
 PORT_RUNNER = 3003
 PORT_PROXY = 4000
 PORT_DASHBOARD = 3000
@@ -408,7 +409,12 @@ def _go_build(p: _Paths, comp: str) -> None:
     out = p.runner_bin if comp == "runner" else p.proxy_bin
     p.bin.mkdir(parents=True, exist_ok=True)
     log(f"go build {comp} → {out}")
-    subprocess.run(["go", "build", "-o", str(out), f"./cmd/{comp}"],
+    # The runner links the BoxLite SDK's native lib. Build it with the
+    # boxlite_dev tag so it links this worktree's target/debug/libboxlite.a
+    # (matching the local sdks/go via go.work) instead of a downloaded
+    # prebuilt — otherwise a locally-changed FFI surface fails to link.
+    tags = ["-tags", "boxlite_dev"] if comp == "runner" else []
+    subprocess.run(["go", "build", *tags, "-o", str(out), f"./cmd/{comp}"],
                    cwd=str(p.apps / comp), env={**os.environ, "GOTOOLCHAIN": "auto"}, check=True)
 
 
@@ -443,11 +449,31 @@ def _ensure_installed(p: _Paths) -> None:
     os.execv(sys.executable, [sys.executable, "-m", "compose", *sys.argv[1:]])
 
 
-def _seed_api_env(p: _Paths) -> None:
+def _set_env_kv(path: Path, key: str, value: str) -> None:
+    """Idempotently set KEY=value in a dotenv file (replace or append)."""
+    lines = path.read_text().splitlines() if path.exists() else []
+    out, found = [], False
+    for ln in lines:
+        if ln.startswith(f"{key}="):
+            out.append(f"{key}={value}"); found = True
+        else:
+            out.append(ln)
+    if not found:
+        out.append(f"{key}={value}")
+    path.write_text("\n".join(out) + "\n")
+
+
+def _seed_api_env(p: _Paths, agent_img: str | None = None) -> None:
     api_env = p.apps / "api" / ".env"
     if not api_env.exists():
         log("apps/api/.env missing — seeding from the infra-local template")
         shutil.copy(p.infra_local / "api.env", api_env)
+    # Keep the API's listen port in lockstep with PORT_API (env-overridable),
+    # and point the curated-image allowlist at the local arm64 agent image.
+    _set_env_kv(api_env, "PORT", str(PORT_API))
+    _set_env_kv(api_env, "APP_URL", f"http://localhost:{PORT_API}")
+    if agent_img:
+        _set_env_kv(api_env, "BOXLITE_SYSTEM_BASE_IMAGE", agent_img)
     apps_env = p.apps / ".env"  # NestJS reads .env from cwd=apps/
     if not apps_env.is_symlink():
         try:
@@ -463,7 +489,13 @@ def up(cfg: InfraConfig, components: list[str] | None = None) -> int:
         if name not in ALL_COMPONENTS:
             err(f"unknown component: {name} (valid: {' '.join(ALL_COMPONENTS)})")
             return 2
+    # 0. Apple-Silicon bootstrap (idempotent no-ops once done): thread docker.io
+    # creds through to L1 + runner, build the native lib, fix the runtime cache.
+    _local_arm64.ensure_tools_on_path()
+    _local_arm64.export_dockerhub_env()
     _ensure_installed(p)
+    _local_arm64.ensure_native_lib()
+    _local_arm64.fix_runtime_cache()
 
     # 1. ensure L1 boxes (single asyncio.run; brings L1 up if postgres is down)
     l1_recreated = asyncio.run(_ensure_l1_async(cfg))
@@ -479,8 +511,12 @@ def up(cfg: InfraConfig, components: list[str] | None = None) -> int:
         log("native binaries missing — building")
         build(cfg)
 
-    # 4. API .env template + the apps/.env symlink NestJS needs
-    _seed_api_env(p)
+    # 3.5 arm64 agent image: L1 registry is up now, so build+push a bootable
+    # arm64 box base (no arm64 curated image exists). None on non-arm64 / no docker.
+    agent_img = _local_arm64.ensure_agent_image()
+
+    # 4. API .env template + port + curated-image override + the apps/.env symlink
+    _seed_api_env(p, agent_img)
 
     # 5. start the requested L2 components
     table = _components(p)

--- a/apps/infra-local/compose/orchestrator.py
+++ b/apps/infra-local/compose/orchestrator.py
@@ -126,6 +126,25 @@ def ensure_home_env(config: InfraConfig) -> None:
 def get_runtime():
     ensure_runtime_env()
     Boxlite, _ = import_sdk()
+    # Local override: authenticate docker.io pulls when creds are supplied via
+    # env, so L1 image pulls don't hit the anonymous Docker Hub rate limit.
+    # The BoxLite puller does NOT read ~/.docker/config.json — auth must come
+    # through the runtime's image_registries config.
+    from . import _local_arm64
+    user, secret = _local_arm64.dockerhub_creds()
+    if user and secret:
+        from boxlite import ImageRegistry, Options
+        opts = Options(image_registries=[
+            ImageRegistry("docker.io", username=user, password=secret, search=True),
+        ])
+        # Seed the PROCESS-WIDE default runtime with auth, then return that
+        # shared singleton — NOT a fresh Boxlite(opts). A fresh runtime per call
+        # would re-acquire the home-dir flock and collide with itself when
+        # get_runtime() runs more than once in a process.
+        try:
+            Boxlite.init_default(opts)
+        except Exception:
+            pass  # default runtime already initialized in this process
     return Boxlite.default()
 
 

--- a/apps/runner/cmd/runner/config/config.go
+++ b/apps/runner/cmd/runner/config/config.go
@@ -60,6 +60,8 @@ type Config struct {
 	InsecureRegistries                 string        `envconfig:"INSECURE_REGISTRIES"`
 	GhcrUsername                       string        `envconfig:"GHCR_USERNAME"`
 	GhcrToken                          string        `envconfig:"GHCR_TOKEN"`
+	DockerHubUsername                  string        `envconfig:"DOCKERHUB_USERNAME"`
+	DockerHubToken                     string        `envconfig:"DOCKERHUB_TOKEN"`
 }
 
 var DEFAULT_API_PORT int = 8080

--- a/apps/runner/cmd/runner/main.go
+++ b/apps/runner/cmd/runner/main.go
@@ -111,6 +111,8 @@ func run() int {
 		InsecureRegistries:           insecureRegs,
 		GhcrUsername:                 cfg.GhcrUsername,
 		GhcrToken:                    cfg.GhcrToken,
+		DockerHubUsername:            cfg.DockerHubUsername,
+		DockerHubToken:               cfg.DockerHubToken,
 		AWSRegion:                    cfg.AWSRegion,
 		AWSEndpointUrl:               cfg.AWSEndpointUrl,
 		AWSAccessKeyId:               cfg.AWSAccessKeyId,

--- a/apps/runner/pkg/boxlite/client.go
+++ b/apps/runner/pkg/boxlite/client.go
@@ -48,6 +48,8 @@ type ClientConfig struct {
 	InsecureRegistries           []string
 	GhcrUsername                 string
 	GhcrToken                    string
+	DockerHubUsername            string
+	DockerHubToken               string
 	AWSRegion                    string
 	AWSEndpointUrl               string
 	AWSAccessKeyId               string
@@ -140,6 +142,19 @@ func NewClient(ctx context.Context, config ClientConfig) (*Client, error) {
 	}
 	insecureRegistries := normalizeRegistryHosts(config.InsecureRegistries)
 	registries := buildImageRegistries(insecureRegistries, config.GhcrUsername, config.GhcrToken)
+	// docker.io auth (local dev): boxlite-core pulls box base images (e.g. the
+	// debian base disk + public user images) from docker.io; without auth those
+	// hit the anonymous Docker Hub rate limit. Mirror the ghcr.io auth entry.
+	if config.DockerHubUsername != "" && config.DockerHubToken != "" {
+		registries = append(registries, boxlite.ImageRegistry{
+			Host:      "docker.io",
+			Transport: boxlite.RegistryTransportHTTPS,
+			Auth: boxlite.ImageRegistryAuth{
+				Username: config.DockerHubUsername,
+				Password: config.DockerHubToken,
+			},
+		})
+	}
 	if len(registries) > 0 {
 		opts = append(opts, boxlite.WithImageRegistries(registries...))
 	}


### PR DESCRIPTION
Stacked on #855. Base will retarget to `main` once #855 merges.

## What

Folds the gaps a fresh Apple-Silicon Mac hits into the `compose` package itself,
so the native `make up` brings up a fully usable local stack (L1 microVMs + API +
runner + a bootable, exec-able arm64 box) with **no manual env/build steps**.

Before this, `make up` assumed a bunch of prerequisites and silently failed on
arm64 / behind a rate-limited network. The folded-in helpers (all idempotent, all
no-ops once done) handle:

- **docker.io auth** — threaded to both L1 (Python SDK) and the runner, read from
  Docker Desktop's credStore. The BoxLite puller does not read `~/.docker/config.json`,
  so box base + L1 images otherwise hit the anonymous Docker Hub rate limit.
- **runtime cache** — the maturin *editable* SDK build omits `boxlite-guest`/`shim`
  from the cache, so box boot failed with "boxlite-guest not found"; copy them from
  the cargo build output.
- **arm64 agent image** — the curated agent images are published amd64-only; build
  + push an arm64 image (debian + the toolbox daemon) to the L1 registry so boxes
  boot and `exec` works on Apple Silicon.
- **native lib + submodules** — build `libboxlite.a` (the Go runner links it),
  initializing libkrun/e2fsprogs submodules first.
- **misc** — put `psql`/`crane` on PATH; API port is env-overridable
  (`BOXLITE_LOCAL_API_PORT`); Makefile auto-uses `.venv-infra`.

## Files

- `compose/_local_arm64.py` (new) — the idempotent bootstrap helpers.
- `compose/native.py` — wire helpers into `up`; env-overridable port; `_seed_api_env`
  writes PORT + `BOXLITE_SYSTEM_BASE_IMAGE`.
- `compose/orchestrator.py` — read docker.io creds from credStore; seed the default
  runtime via `init_default` (a fresh `Boxlite(opts)` per call self-deadlocks on the
  home-dir flock).
- `Makefile` — auto-use `.venv-infra`.
- `apps/runner/{config,client,main}.go` — add docker.io auth alongside the existing
  ghcr.io auth.

## Verified

Cold `make down --all` → `make up` (only `BOXLITE_LOCAL_API_PORT=3011`, no manual
creds/image/cache env) brings up all 10 L1 microVMs + API + runner + seed, then a
box created with no image specified boots and `exec` returns `aarch64` / Debian
bookworm. Also drove the live #855 replay scenario (force a CREATE_BOX job back to
IN_PROGRESS, restart the runner) and confirmed the replay adopts instead of
failing with "already exists".