### PR TITLE
chore(infra-local): make `make up` work on Apple Silicon + arm64 boxes

### DIFF
--- a/apps/infra-local/Makefile
+++ b/apps/infra-local/Makefile
@@ -2,7 +2,9 @@
 # The Python CLI is the source of truth: `python -m compose --help`.
 # This Makefile exists for muscle memory + tab completion.
 
-PY ?= python
+# Prefer the repo-local venv (.venv-infra) if present, so `make up` just works
+# without the caller needing to activate it; override with `make up PY=...`.
+PY ?= $(shell [ -x ../../.venv-infra/bin/python ] && echo ../../.venv-infra/bin/python || echo python)
 
 .PHONY: help install up down status logs restart reset nuke
 

--- a/apps/infra-local/Makefile
+++ b/apps/infra-local/Makefile
@@ -2,35 +2,44 @@
 # The Python CLI is the source of truth: `python -m compose --help`.
 # This Makefile exists for muscle memory + tab completion.
 
-# Prefer the repo-local venv (.venv-infra) if present, so `make up` just works
-# without the caller needing to activate it; override with `make up PY=...`.
-PY ?= $(shell [ -x ../../.venv-infra/bin/python ] && echo ../../.venv-infra/bin/python || echo python)
+# Repo-local venv so `make up` works with zero manual setup — no activate, no
+# global pip, no PEP-668 hassle. Created on first use (see the venv target).
+# Override PY to use your own interpreter instead.
+VENV ?= ../../.venv-infra
+PY ?= $(VENV)/bin/python
 
 .PHONY: help install up down status logs restart reset nuke
 
 help:      ## show this help
 	@awk -F':.*## ' '/^[a-zA-Z][a-zA-Z0-9_-]*:.*## / { printf "  %-9s %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
 
-install:   ## install the package (editable; pulls the boxlite SDK)
-	$(PY) -m pip install -e .
+# Create the repo-local venv + install the compose package. A file target, so
+# it runs only when the venv's python is missing (idempotent). Everything below
+# depends on it, so a fresh checkout's first `make <anything>` bootstraps once.
+$(VENV)/bin/python:
+	@echo "[infra-local] creating repo-local venv + installing compose package (first run only)..."
+	python3 -m venv $(VENV)
+	$(VENV)/bin/pip install -q -e .
 
-up:        ## ensure L1 boxes + start L2 (COMPONENTS="api runner")
+install: $(VENV)/bin/python   ## create the venv + install the package (editable)
+
+up: $(VENV)/bin/python   ## ensure L1 boxes + start L2 (COMPONENTS="api runner")
 	$(PY) -m compose up $(COMPONENTS)
 
-down:      ## stop L2 procs (ARGS=--all also stops L1 boxes)
+down: $(VENV)/bin/python   ## stop L2 procs (ARGS=--all also stops L1 boxes)
 	$(PY) -m compose down $(ARGS) $(COMPONENTS)
 
-status:    ## one-screen L1 + L2 health
+status: $(VENV)/bin/python   ## one-screen L1 + L2 health
 	$(PY) -m compose status
 
-logs:      ## tail a component log (COMPONENT=api|all)
+logs: $(VENV)/bin/python   ## tail a component log (COMPONENT=api|all)
 	$(PY) -m compose logs $(COMPONENT)
 
-restart:   ## restart L2 proc(s) / recreate L1 box(es) (COMPONENTS="runner dex")
+restart: $(VENV)/bin/python   ## restart L2 proc(s) / recreate L1 box(es) (COMPONENTS="runner dex")
 	$(PY) -m compose restart $(COMPONENTS)
 
-reset:     ## wipe L2 runtime state (ARGS=--hard also rebuilds the schema)
+reset: $(VENV)/bin/python   ## wipe L2 runtime state (ARGS=--hard also rebuilds the schema)
 	$(PY) -m compose reset $(ARGS)
 
-nuke:      ## tear down EVERYTHING (L1 boxes + data + logs)
+nuke: $(VENV)/bin/python   ## tear down EVERYTHING (L1 boxes + data + logs)
 	$(PY) -m compose nuke

--- a/apps/infra-local/compose/_local_arm64.py
+++ b/apps/infra-local/compose/_local_arm64.py
@@ -4,13 +4,14 @@ and a no-op when its work is already done (or its tools are absent), so it is
 safe to call on every `up`.
 
 Why these exist (gaps `compose up` otherwise assumes are pre-handled):
-  • docker.io pulls (L1 images + the box base) need auth or they hit the
-    anonymous Docker Hub rate limit — the BoxLite puller does NOT read
-    ~/.docker/config.json, so creds must be threaded in.
+  • image pulls (L1 images + the box base) need registry auth or they hit the
+    anonymous Docker Hub rate limit / a private-ghcr 401 — the BoxLite puller
+    does NOT read ~/.docker/config.json, so creds must be threaded in.
   • the maturin *editable* SDK build does not embed boxlite-guest/shim into the
     runtime cache, so box boot fails with "boxlite-guest not found".
-  • the curated agent images are published amd64-only; an arm64 Mac needs a
-    locally-built arm64 image (debian + the toolbox daemon) to boot a usable box.
+  • the box base is pulled from the published multi-arch agent image
+    (ghcr.io/boxlite-ai/boxlite-agent-base), which now carries linux/arm64 — so
+    an arm64 Mac boots a usable box straight from ghcr, no local image build.
   • the Go runner links the real libboxlite.a, which must be built once.
 """
 
@@ -20,16 +21,28 @@ import json
 import os
 import shutil
 import subprocess
-import tempfile
-import urllib.request
+import sys
 from pathlib import Path
 
 # repo root: this file is <repo>/apps/infra-local/compose/_local_arm64.py
 REPO = Path(__file__).resolve().parents[3]
-AGENT_IMG = "127.0.0.1:25000/boxlite-agent-base:local-arm64"
-# Machine-global cache: build the arm64 image once, then every worktree's
-# `make up` just pushes this tar to its own L1 registry (seconds, no rebuild).
-AGENT_TAR = Path.home() / ".cache" / "boxlite" / "agent-base-arm64.tar"
+
+# The box base image. The curated agent images are now published multi-arch
+# (linux/amd64 + linux/arm64) under the v0.1.0 tag, so the runner pulls the
+# arch matching the host straight from ghcr — no local arm64 build/push to the
+# L1 registry. (The default curated tag, …-p0-r3, is still amd64-only, hence
+# the explicit v0.1.0 override for local arm64 dev.)
+REMOTE_AGENT_IMAGE = os.environ.get(
+    "BOXLITE_LOCAL_AGENT_IMAGE", "ghcr.io/boxlite-ai/boxlite-agent-base:v0.1.0"
+)
+
+# Machine-global cargo target dir. A fresh worktree's target/ is symlinked here
+# so the first worktree to build pays the slow libkrun/e2fsprogs compile once,
+# and every other worktree just relinks against the shared artifacts — "build
+# once per machine, reuse across worktrees".
+SHARED_CARGO_TARGET = Path(
+    os.environ.get("BOXLITE_LOCAL_CARGO_TARGET") or (Path.home() / ".cache" / "boxlite" / "cargo-target")
+).expanduser()
 
 
 def dockerhub_creds() -> tuple[str | None, str | None]:
@@ -39,11 +52,41 @@ def dockerhub_creds() -> tuple[str | None, str | None]:
     t = os.environ.get("BOXLITE_DOCKERHUB_TOKEN") or os.environ.get("DOCKERHUB_TOKEN")
     if u and t:
         return u, t
+    return _credstore_get("https://index.docker.io/v1/")
+
+
+def ghcr_creds() -> tuple[str | None, str | None]:
+    """(username, token) for ghcr.io, so the runner can pull the private
+    multi-arch agent image. Resolution order, each per-developer (no shared
+    secret to distribute):
+      1. explicit env (GHCR_USERNAME/GHCR_TOKEN or BOXLITE_GHCR_*)
+      2. the GitHub CLI token (`gh auth token`) — its scope already covers
+         read:packages for whoever is logged in
+      3. Docker's credStore (populated by `docker login ghcr.io`)
+    (None, None) if none resolve."""
+    u = os.environ.get("GHCR_USERNAME") or os.environ.get("BOXLITE_GHCR_USER")
+    t = os.environ.get("GHCR_TOKEN") or os.environ.get("BOXLITE_GHCR_TOKEN")
+    if u and t:
+        return u, t
+    if shutil.which("gh"):
+        try:
+            token = subprocess.run(["gh", "auth", "token"], capture_output=True,
+                                   text=True, timeout=5).stdout.strip()
+            user = subprocess.run(["gh", "api", "user", "--jq", ".login"],
+                                  capture_output=True, text=True, timeout=5).stdout.strip()
+            if token and user:
+                return user, token
+        except Exception:
+            pass
+    return _credstore_get("ghcr.io")
+
+
+def _credstore_get(registry: str) -> tuple[str | None, str | None]:
+    """Read (username, secret) for `registry` from Docker Desktop's credStore."""
     try:
         out = subprocess.run(
             ["docker-credential-desktop", "get"],
-            input="https://index.docker.io/v1/",
-            capture_output=True, text=True, timeout=5,
+            input=registry, capture_output=True, text=True, timeout=5,
         )
         d = json.loads(out.stdout or "{}")
         return d.get("Username") or None, d.get("Secret") or None
@@ -52,9 +95,9 @@ def dockerhub_creds() -> tuple[str | None, str | None]:
 
 
 def ensure_tools_on_path() -> None:
-    """The seed step shells out to `psql`, and the agent-image step to `crane`;
-    add their Homebrew keg-only / go-install dirs to PATH if they're not already
-    resolvable, so a bare `make up` finds them."""
+    """The seed step shells out to `psql`; add Homebrew's keg-only libpq bin
+    (and the go-install bin) to PATH if not already resolvable, so a bare
+    `make up` finds them."""
     extra = ["/opt/homebrew/opt/libpq/bin", str(Path.home() / "go" / "bin")]
     parts = os.environ.get("PATH", "").split(os.pathsep)
     for d in extra:
@@ -72,6 +115,18 @@ def export_dockerhub_env() -> None:
         os.environ.setdefault("BOXLITE_DOCKERHUB_TOKEN", t)
         os.environ.setdefault("DOCKERHUB_USERNAME", u)
         os.environ.setdefault("DOCKERHUB_TOKEN", t)
+
+
+def export_ghcr_env() -> None:
+    """Thread ghcr.io creds into os.environ under the names the runner reads
+    (GHCR_USERNAME/GHCR_TOKEN via envconfig) so it can pull the private
+    multi-arch agent image. No-op if none resolve."""
+    u, t = ghcr_creds()
+    if u and t:
+        os.environ.setdefault("GHCR_USERNAME", u)
+        os.environ.setdefault("GHCR_TOKEN", t)
+        os.environ.setdefault("BOXLITE_GHCR_USER", u)
+        os.environ.setdefault("BOXLITE_GHCR_TOKEN", t)
 
 
 def fix_runtime_cache() -> None:
@@ -92,94 +147,103 @@ def fix_runtime_cache() -> None:
             return
 
 
-def ensure_native_lib() -> None:
-    """Build the real libboxlite.a (the Go runner links it) if missing,
-    initializing the libkrun/e2fsprogs submodules first if needed."""
-    if (REPO / "target" / "debug" / "libboxlite.a").is_file():
+def ensure_shared_target() -> None:
+    """Point this worktree's `target/` at the machine-global cargo dir, so the
+    Rust artifacts (libkrun, e2fsprogs, libboxlite.a, the python ext) are shared
+    across worktrees — the first build is slow, the rest just relink.
+
+    Only acts on a fresh worktree (no `target/` yet); an existing real `target/`
+    is left untouched (e.g. a checkout that already built locally). Both the
+    maturin build and `make dev:go` write through `target/` (cargo's default),
+    and the Go dev cgo links `target/debug/libboxlite.a`, so the symlink makes
+    all three share one cache with no recipe changes."""
+    target = REPO / "target"
+    if target.exists() or target.is_symlink():
         return
+    SHARED_CARGO_TARGET.mkdir(parents=True, exist_ok=True)
+    try:
+        target.symlink_to(SHARED_CARGO_TARGET)
+        print(f"  target/ -> shared cargo cache {SHARED_CARGO_TARGET}")
+    except OSError as e:
+        print(f"  could not symlink target/ to the shared cargo cache ({e}); building per-worktree")
+
+
+def ensure_submodules() -> None:
+    """Init the libkrun/e2fsprogs/bubblewrap submodules if any are missing —
+    their vendored sources are needed to build the native lib + python ext."""
     status = subprocess.run(["git", "submodule", "status"], cwd=str(REPO),
                             capture_output=True, text=True)
     if any(ln.startswith("-") for ln in status.stdout.splitlines()):
         print("  initializing git submodules (libkrun/e2fsprogs)...")
         subprocess.run(["git", "submodule", "update", "--init", "--recursive"], cwd=str(REPO), check=True)
-    print("  building native libboxlite.a (real libkrun — slow on first run)...")
+
+
+def ensure_native_lib() -> None:
+    """Build the real libboxlite.a (the Go runner links it) if missing."""
+    if (REPO / "target" / "debug" / "libboxlite.a").is_file():
+        return
+    ensure_shared_target()
+    ensure_submodules()
+    print("  building native libboxlite.a (real libkrun — slow on first run, shared cache after)...")
     subprocess.run(["make", "dev:go"], cwd=str(REPO), check=True)
 
 
-def _ensure_crane() -> str | None:
-    crane = shutil.which("crane") or str(Path.home() / "go" / "bin" / "crane")
-    if Path(crane).exists():
-        return crane
-    print("  installing crane (host-side OCI push tool)...")
-    subprocess.run(["go", "install", "github.com/google/go-containerregistry/cmd/crane@latest"],
-                   env={**os.environ, "GOBIN": str(Path.home() / "go" / "bin"), "GOTOOLCHAIN": "auto"})
-    crane = str(Path.home() / "go" / "bin" / "crane")
-    return crane if Path(crane).exists() else None
+def _boxlite_is_local_build() -> bool:
+    """True when the importable boxlite is the repo's own (editable) build, not
+    the PyPI wheel — maturin develop installs an editable, the wheel doesn't."""
+    try:
+        import importlib.metadata as md
 
-
-def _build_agent_tar() -> bool:
-    """Build the arm64 agent image (debian + toolbox daemon) and save it to the
-    machine-global tar. Once per machine; needs docker. Returns True on success."""
-    if not shutil.which("docker") or subprocess.run(["docker", "info"], capture_output=True).returncode != 0:
-        print("  docker daemon not running — can't build the arm64 agent image (boxes won't boot)")
+        durl = md.distribution("boxlite").read_text("direct_url.json")
+        return bool(durl) and '"editable": true' in durl
+    except Exception:
         return False
-    print("  building arm64 agent image (debian + boxlite-daemon) — once per machine...")
-    ctx = Path(tempfile.mkdtemp())
-    try:
-        subprocess.run(
-            ["go", "build", "-tags", "netgo", "-ldflags", "-s -w",
-             "-o", str(ctx / "boxlite-daemon"), "./cmd/daemon"],
-            cwd=str(REPO / "apps" / "daemon"),
-            env={**os.environ, "GOOS": "linux", "GOARCH": "arm64",
-                 "CGO_ENABLED": "0", "GOTOOLCHAIN": "auto"},
-            check=True,
-        )
-        (ctx / "start-agent-runtime.sh").write_text(
-            '#!/bin/sh\nset -eu\nmkdir -p /workspace\n'
-            '[ -n "${BOXLITE_SANDBOX_ID:-}" ] || { BOXLITE_SANDBOX_ID="$(hostname)"; export BOXLITE_SANDBOX_ID; }\n'
-            'exec /boxlite/bin/boxlite-daemon "$@"\n'
-        )
-        (ctx / "Dockerfile").write_text(
-            "FROM debian:bookworm-slim\n"
-            "COPY boxlite-daemon /boxlite/bin/boxlite-daemon\n"
-            "COPY start-agent-runtime.sh /boxlite/bin/start-agent-runtime\n"
-            "RUN chmod 0755 /boxlite/bin/boxlite-daemon /boxlite/bin/start-agent-runtime && mkdir -p /workspace\n"
-            "WORKDIR /workspace\n"
-            'ENTRYPOINT ["/boxlite/bin/start-agent-runtime"]\n'
-            'CMD ["sleep", "infinity"]\n'
-        )
-        subprocess.run(["docker", "build", "--platform", "linux/arm64", "-t", AGENT_IMG, str(ctx)], check=True)
-        AGENT_TAR.parent.mkdir(parents=True, exist_ok=True)
-        subprocess.run(["docker", "save", AGENT_IMG, "-o", str(AGENT_TAR)], check=True)
-    finally:
-        shutil.rmtree(ctx, ignore_errors=True)
-    return True
 
 
-def ensure_agent_image() -> str | None:
-    """Ensure this worktree's L1 registry has an arm64 agent image (no arm64
-    curated image exists). Build is cached machine-globally as a tar, so every
-    worktree after the first only pushes the tar (seconds). Returns the ref to
-    use as BOXLITE_SYSTEM_BASE_IMAGE, or None if it can't be made available."""
-    crane = _ensure_crane()
-    if crane is None:
+def ensure_local_boxlite() -> None:
+    """Install the repo's own boxlite engine build into the running venv,
+    replacing the PyPI wheel — the wheel lacks fixes the local stack needs
+    (e.g. the macOS OCI read-only-dir removal fix). maturin-develops from
+    sdks/python; the Rust compile lands in the shared cargo cache so other
+    worktrees reuse it. No-op when a local (editable) boxlite is already in.
+
+    Skipped outside a venv (no isolated site-packages to install into) — the
+    caller's pip path then falls back to the PyPI wheel.
+    """
+    if _boxlite_is_local_build():
+        return
+    in_venv = sys.prefix != getattr(sys, "base_prefix", sys.prefix)
+    if not in_venv:
+        print("  not running in a venv — skipping local boxlite build (will use PyPI wheel)")
+        return
+    venv = Path(sys.prefix)
+    print("  building boxlite engine from source (first time per machine is slow — "
+          "libkrun compile; later worktrees reuse the shared cargo cache)...")
+    ensure_shared_target()
+    ensure_submodules()
+    maturin = venv / "bin" / "maturin"
+    if not maturin.exists():
+        subprocess.run([str(venv / "bin" / "pip"), "install", "-q", "maturin"], check=True)
+    subprocess.run(
+        [str(maturin), "develop"],
+        cwd=str(REPO / "sdks" / "python"),
+        env={**os.environ, "VIRTUAL_ENV": str(venv)},
+        check=True,
+    )
+
+
+def resolve_agent_image() -> str | None:
+    """The box base image ref to use as BOXLITE_SYSTEM_BASE_IMAGE.
+
+    The published agent image is now multi-arch (linux/arm64 included), so the
+    runner pulls the host-matching arch straight from ghcr — no local build or
+    L1-registry push. Returns the remote ref when ghcr creds are available (the
+    runner needs them to pull a private image), else None so the caller leaves
+    the curated default in place (amd64-only — won't boot on arm64, but the
+    failure is then an explicit, logged pull error rather than a silent one)."""
+    u, t = ghcr_creds()
+    if not (u and t):
+        print("  no ghcr.io creds (try `gh auth login` or `docker login ghcr.io`) — "
+              "runner can't pull the arm64 agent image; boxes won't boot")
         return None
-    try:
-        urllib.request.urlopen("http://127.0.0.1:25000/v2/", timeout=5)
-    except Exception:
-        return None  # L1 registry not up yet
-    try:
-        ls = subprocess.run([crane, "ls", "127.0.0.1:25000/boxlite-agent-base", "--insecure"],
-                            capture_output=True, text=True, timeout=15)
-        if "local-arm64" in ls.stdout:
-            return AGENT_IMG  # already in THIS worktree's registry
-    except Exception:
-        pass
-    # Build once per machine (cached tar); every worktree just pushes the tar.
-    if not AGENT_TAR.is_file():
-        if not _build_agent_tar():
-            return None
-    print(f"  pushing arm64 agent image to local registry (from cached {AGENT_TAR.name})...")
-    # host-side HTTP push: the docker VM cannot reach the host's :25000.
-    subprocess.run([crane, "push", str(AGENT_TAR), AGENT_IMG, "--insecure"], check=True)
-    return AGENT_IMG
+    return REMOTE_AGENT_IMAGE

--- a/apps/infra-local/compose/_local_arm64.py
+++ b/apps/infra-local/compose/_local_arm64.py
@@ -1,0 +1,185 @@
+"""Apple-Silicon local-dev helpers, folded into `compose up` so a fresh arm64
+Mac can `make up` with no manual env/build steps. Every function is idempotent
+and a no-op when its work is already done (or its tools are absent), so it is
+safe to call on every `up`.
+
+Why these exist (gaps `compose up` otherwise assumes are pre-handled):
+  • docker.io pulls (L1 images + the box base) need auth or they hit the
+    anonymous Docker Hub rate limit — the BoxLite puller does NOT read
+    ~/.docker/config.json, so creds must be threaded in.
+  • the maturin *editable* SDK build does not embed boxlite-guest/shim into the
+    runtime cache, so box boot fails with "boxlite-guest not found".
+  • the curated agent images are published amd64-only; an arm64 Mac needs a
+    locally-built arm64 image (debian + the toolbox daemon) to boot a usable box.
+  • the Go runner links the real libboxlite.a, which must be built once.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import urllib.request
+from pathlib import Path
+
+# repo root: this file is <repo>/apps/infra-local/compose/_local_arm64.py
+REPO = Path(__file__).resolve().parents[3]
+AGENT_IMG = "127.0.0.1:25000/boxlite-agent-base:local-arm64"
+# Machine-global cache: build the arm64 image once, then every worktree's
+# `make up` just pushes this tar to its own L1 registry (seconds, no rebuild).
+AGENT_TAR = Path.home() / ".cache" / "boxlite" / "agent-base-arm64.tar"
+
+
+def dockerhub_creds() -> tuple[str | None, str | None]:
+    """(username, token) for docker.io: explicit env first, then Docker
+    Desktop's credStore (populated by `docker login`). (None, None) if neither."""
+    u = os.environ.get("BOXLITE_DOCKERHUB_USER") or os.environ.get("DOCKERHUB_USERNAME")
+    t = os.environ.get("BOXLITE_DOCKERHUB_TOKEN") or os.environ.get("DOCKERHUB_TOKEN")
+    if u and t:
+        return u, t
+    try:
+        out = subprocess.run(
+            ["docker-credential-desktop", "get"],
+            input="https://index.docker.io/v1/",
+            capture_output=True, text=True, timeout=5,
+        )
+        d = json.loads(out.stdout or "{}")
+        return d.get("Username") or None, d.get("Secret") or None
+    except Exception:
+        return None, None
+
+
+def ensure_tools_on_path() -> None:
+    """The seed step shells out to `psql`, and the agent-image step to `crane`;
+    add their Homebrew keg-only / go-install dirs to PATH if they're not already
+    resolvable, so a bare `make up` finds them."""
+    extra = ["/opt/homebrew/opt/libpq/bin", str(Path.home() / "go" / "bin")]
+    parts = os.environ.get("PATH", "").split(os.pathsep)
+    for d in extra:
+        if d not in parts and Path(d).is_dir():
+            parts.append(d)
+    os.environ["PATH"] = os.pathsep.join(parts)
+
+
+def export_dockerhub_env() -> None:
+    """Put docker.io creds into os.environ under every name the stack reads:
+    the orchestrator (L1 SDK) and the Go runner (envconfig). No-op if absent."""
+    u, t = dockerhub_creds()
+    if u and t:
+        os.environ.setdefault("BOXLITE_DOCKERHUB_USER", u)
+        os.environ.setdefault("BOXLITE_DOCKERHUB_TOKEN", t)
+        os.environ.setdefault("DOCKERHUB_USERNAME", u)
+        os.environ.setdefault("DOCKERHUB_TOKEN", t)
+
+
+def fix_runtime_cache() -> None:
+    """maturin editable builds leave the SDK runtime cache missing the big
+    boxlite-guest/shim binaries; copy them from the cargo build output."""
+    base = Path.home() / "Library" / "Application Support" / "boxlite" / "runtimes"
+    caches = sorted(base.glob("v*"))
+    if not caches:
+        return
+    cache = caches[0]
+    if (cache / "boxlite-guest").is_file():
+        return
+    for d in REPO.glob("target/debug/build/boxlite-*/out/runtime"):
+        if (d / "boxlite-guest").is_file():
+            for f in ("boxlite-guest", "boxlite-shim"):
+                shutil.copy2(d / f, cache / f)
+            print(f"  patched runtime cache: boxlite-guest+shim -> {cache}")
+            return
+
+
+def ensure_native_lib() -> None:
+    """Build the real libboxlite.a (the Go runner links it) if missing,
+    initializing the libkrun/e2fsprogs submodules first if needed."""
+    if (REPO / "target" / "debug" / "libboxlite.a").is_file():
+        return
+    status = subprocess.run(["git", "submodule", "status"], cwd=str(REPO),
+                            capture_output=True, text=True)
+    if any(ln.startswith("-") for ln in status.stdout.splitlines()):
+        print("  initializing git submodules (libkrun/e2fsprogs)...")
+        subprocess.run(["git", "submodule", "update", "--init", "--recursive"], cwd=str(REPO), check=True)
+    print("  building native libboxlite.a (real libkrun — slow on first run)...")
+    subprocess.run(["make", "dev:go"], cwd=str(REPO), check=True)
+
+
+def _ensure_crane() -> str | None:
+    crane = shutil.which("crane") or str(Path.home() / "go" / "bin" / "crane")
+    if Path(crane).exists():
+        return crane
+    print("  installing crane (host-side OCI push tool)...")
+    subprocess.run(["go", "install", "github.com/google/go-containerregistry/cmd/crane@latest"],
+                   env={**os.environ, "GOBIN": str(Path.home() / "go" / "bin"), "GOTOOLCHAIN": "auto"})
+    crane = str(Path.home() / "go" / "bin" / "crane")
+    return crane if Path(crane).exists() else None
+
+
+def _build_agent_tar() -> bool:
+    """Build the arm64 agent image (debian + toolbox daemon) and save it to the
+    machine-global tar. Once per machine; needs docker. Returns True on success."""
+    if not shutil.which("docker") or subprocess.run(["docker", "info"], capture_output=True).returncode != 0:
+        print("  docker daemon not running — can't build the arm64 agent image (boxes won't boot)")
+        return False
+    print("  building arm64 agent image (debian + boxlite-daemon) — once per machine...")
+    ctx = Path(tempfile.mkdtemp())
+    try:
+        subprocess.run(
+            ["go", "build", "-tags", "netgo", "-ldflags", "-s -w",
+             "-o", str(ctx / "boxlite-daemon"), "./cmd/daemon"],
+            cwd=str(REPO / "apps" / "daemon"),
+            env={**os.environ, "GOOS": "linux", "GOARCH": "arm64",
+                 "CGO_ENABLED": "0", "GOTOOLCHAIN": "auto"},
+            check=True,
+        )
+        (ctx / "start-agent-runtime.sh").write_text(
+            '#!/bin/sh\nset -eu\nmkdir -p /workspace\n'
+            '[ -n "${BOXLITE_SANDBOX_ID:-}" ] || { BOXLITE_SANDBOX_ID="$(hostname)"; export BOXLITE_SANDBOX_ID; }\n'
+            'exec /boxlite/bin/boxlite-daemon "$@"\n'
+        )
+        (ctx / "Dockerfile").write_text(
+            "FROM debian:bookworm-slim\n"
+            "COPY boxlite-daemon /boxlite/bin/boxlite-daemon\n"
+            "COPY start-agent-runtime.sh /boxlite/bin/start-agent-runtime\n"
+            "RUN chmod 0755 /boxlite/bin/boxlite-daemon /boxlite/bin/start-agent-runtime && mkdir -p /workspace\n"
+            "WORKDIR /workspace\n"
+            'ENTRYPOINT ["/boxlite/bin/start-agent-runtime"]\n'
+            'CMD ["sleep", "infinity"]\n'
+        )
+        subprocess.run(["docker", "build", "--platform", "linux/arm64", "-t", AGENT_IMG, str(ctx)], check=True)
+        AGENT_TAR.parent.mkdir(parents=True, exist_ok=True)
+        subprocess.run(["docker", "save", AGENT_IMG, "-o", str(AGENT_TAR)], check=True)
+    finally:
+        shutil.rmtree(ctx, ignore_errors=True)
+    return True
+
+
+def ensure_agent_image() -> str | None:
+    """Ensure this worktree's L1 registry has an arm64 agent image (no arm64
+    curated image exists). Build is cached machine-globally as a tar, so every
+    worktree after the first only pushes the tar (seconds). Returns the ref to
+    use as BOXLITE_SYSTEM_BASE_IMAGE, or None if it can't be made available."""
+    crane = _ensure_crane()
+    if crane is None:
+        return None
+    try:
+        urllib.request.urlopen("http://127.0.0.1:25000/v2/", timeout=5)
+    except Exception:
+        return None  # L1 registry not up yet
+    try:
+        ls = subprocess.run([crane, "ls", "127.0.0.1:25000/boxlite-agent-base", "--insecure"],
+                            capture_output=True, text=True, timeout=15)
+        if "local-arm64" in ls.stdout:
+            return AGENT_IMG  # already in THIS worktree's registry
+    except Exception:
+        pass
+    # Build once per machine (cached tar); every worktree just pushes the tar.
+    if not AGENT_TAR.is_file():
+        if not _build_agent_tar():
+            return None
+    print(f"  pushing arm64 agent image to local registry (from cached {AGENT_TAR.name})...")
+    # host-side HTTP push: the docker VM cannot reach the host's :25000.
+    subprocess.run([crane, "push", str(AGENT_TAR), AGENT_IMG, "--insecure"], check=True)
+    return AGENT_IMG

--- a/apps/infra-local/compose/config.py
+++ b/apps/infra-local/compose/config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import os
 import sys
 from dataclasses import dataclass, field
@@ -102,6 +103,33 @@ def _default_state_root() -> Path:
     return _detect_repo_root() / ".apps-local"
 
 
+def _machine_short_root() -> Path:
+    """Machine-global parent for socket-bearing BoxLite homes.
+
+    A box's control sockets live at <home>/boxes/<id>/sockets/ready.sock, and
+    macOS caps unix socket paths at 104 bytes (SUN_LEN). A repo-scoped home
+    under a deep worktree path (…/boxlite-wt/<name>/.apps-local/boxlite) blows
+    that budget, so EVERY worktree past a short prefix fails to boot a box.
+
+    Anchoring the socket-bearing home here — short and constant (~/.bl) — keeps
+    any worktree, however deep, comfortably under the cap. Override with
+    BOXLITE_LOCAL_STATE_ROOT.
+    """
+    return Path(os.environ.get("BOXLITE_LOCAL_STATE_ROOT") or (Path.home() / ".bl")).expanduser()
+
+
+def worktree_home(repo_root: Path, leaf: str) -> Path:
+    """Per-worktree socket-bearing home under the machine-global short root.
+
+    Keyed by a short hash of the worktree path so each checkout is isolated
+    (every BoxliteRuntime takes an exclusive flock on its home). `leaf`
+    separates the L1 SDK home ("h") from the runner home ("r") — distinct
+    runtimes that must not share a home/flock.
+    """
+    tag = hashlib.sha1(str(repo_root).encode()).hexdigest()[:8]
+    return _machine_short_root() / tag / leaf
+
+
 @dataclass
 class InfraConfig:
     host_hub: str = "host.boxlite.internal"
@@ -137,10 +165,11 @@ class InfraConfig:
 
     data_dir: Path = field(default_factory=lambda: _default_state_root() / "data")
     # SDK home for the L1 boxes (exported as BOXLITE_HOME before the runtime
-    # singleton is built — see orchestrator.ensure_home_env). Separate from the
-    # runner's home (.apps-local/boxlite-runner): each BoxliteRuntime takes an
-    # exclusive lock on its home dir.
-    boxlite_home: Path = field(default_factory=lambda: _default_state_root() / "boxlite")
+    # singleton is built — see orchestrator.ensure_home_env). Anchored at the
+    # machine-global short root (NOT under the deep worktree path) so box
+    # sockets stay under the macOS SUN_LEN cap — see worktree_home(). Separate
+    # from the runner's home (…/r): each BoxliteRuntime flocks its own home.
+    boxlite_home: Path = field(default_factory=lambda: worktree_home(_detect_repo_root(), "h"))
     repo_root: Path = field(default_factory=_detect_repo_root)
 
     @classmethod
@@ -167,7 +196,7 @@ class InfraConfig:
             # InfraConfig and a user-pinned SDK home in agreement.
             boxlite_home=Path(
                 os.environ.get("BOXLITE_HOME")
-                or str(_default_state_root() / "boxlite")
+                or str(worktree_home(_detect_repo_root(), "h"))
             ).expanduser(),
         )
 

--- a/apps/infra-local/compose/native.py
+++ b/apps/infra-local/compose/native.py
@@ -25,13 +25,14 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 
+from . import _local_arm64
 from . import orchestrator
 from .config import InfraConfig
 from .doctor import _lsof_owner
 from .services import SERVICES
 
 # ── L2 ports + identities (the native host processes) ──────────────────────
-PORT_API = 3001
+PORT_API = int(os.environ.get("BOXLITE_LOCAL_API_PORT", "3001"))  # override if :3001 is taken
 PORT_RUNNER = 3003
 PORT_PROXY = 4000
 PORT_DASHBOARD = 3000
@@ -408,7 +409,12 @@ def _go_build(p: _Paths, comp: str) -> None:
     out = p.runner_bin if comp == "runner" else p.proxy_bin
     p.bin.mkdir(parents=True, exist_ok=True)
     log(f"go build {comp} → {out}")
-    subprocess.run(["go", "build", "-o", str(out), f"./cmd/{comp}"],
+    # The runner links the BoxLite SDK's native lib. Build it with the
+    # boxlite_dev tag so it links this worktree's target/debug/libboxlite.a
+    # (matching the local sdks/go via go.work) instead of a downloaded
+    # prebuilt — otherwise a locally-changed FFI surface fails to link.
+    tags = ["-tags", "boxlite_dev"] if comp == "runner" else []
+    subprocess.run(["go", "build", *tags, "-o", str(out), f"./cmd/{comp}"],
                    cwd=str(p.apps / comp), env={**os.environ, "GOTOOLCHAIN": "auto"}, check=True)
 
 
@@ -443,11 +449,31 @@ def _ensure_installed(p: _Paths) -> None:
     os.execv(sys.executable, [sys.executable, "-m", "compose", *sys.argv[1:]])
 
 
-def _seed_api_env(p: _Paths) -> None:
+def _set_env_kv(path: Path, key: str, value: str) -> None:
+    """Idempotently set KEY=value in a dotenv file (replace or append)."""
+    lines = path.read_text().splitlines() if path.exists() else []
+    out, found = [], False
+    for ln in lines:
+        if ln.startswith(f"{key}="):
+            out.append(f"{key}={value}"); found = True
+        else:
+            out.append(ln)
+    if not found:
+        out.append(f"{key}={value}")
+    path.write_text("\n".join(out) + "\n")
+
+
+def _seed_api_env(p: _Paths, agent_img: str | None = None) -> None:
     api_env = p.apps / "api" / ".env"
     if not api_env.exists():
         log("apps/api/.env missing — seeding from the infra-local template")
         shutil.copy(p.infra_local / "api.env", api_env)
+    # Keep the API's listen port in lockstep with PORT_API (env-overridable),
+    # and point the curated-image allowlist at the local arm64 agent image.
+    _set_env_kv(api_env, "PORT", str(PORT_API))
+    _set_env_kv(api_env, "APP_URL", f"http://localhost:{PORT_API}")
+    if agent_img:
+        _set_env_kv(api_env, "BOXLITE_SYSTEM_BASE_IMAGE", agent_img)
     apps_env = p.apps / ".env"  # NestJS reads .env from cwd=apps/
     if not apps_env.is_symlink():
         try:
@@ -463,7 +489,13 @@ def up(cfg: InfraConfig, components: list[str] | None = None) -> int:
         if name not in ALL_COMPONENTS:
             err(f"unknown component: {name} (valid: {' '.join(ALL_COMPONENTS)})")
             return 2
+    # 0. Apple-Silicon bootstrap (idempotent no-ops once done): thread docker.io
+    # creds through to L1 + runner, build the native lib, fix the runtime cache.
+    _local_arm64.ensure_tools_on_path()
+    _local_arm64.export_dockerhub_env()
     _ensure_installed(p)
+    _local_arm64.ensure_native_lib()
+    _local_arm64.fix_runtime_cache()
 
     # 1. ensure L1 boxes (single asyncio.run; brings L1 up if postgres is down)
     l1_recreated = asyncio.run(_ensure_l1_async(cfg))
@@ -479,8 +511,12 @@ def up(cfg: InfraConfig, components: list[str] | None = None) -> int:
         log("native binaries missing — building")
         build(cfg)
 
-    # 4. API .env template + the apps/.env symlink NestJS needs
-    _seed_api_env(p)
+    # 3.5 arm64 agent image: L1 registry is up now, so build+push a bootable
+    # arm64 box base (no arm64 curated image exists). None on non-arm64 / no docker.
+    agent_img = _local_arm64.ensure_agent_image()
+
+    # 4. API .env template + port + curated-image override + the apps/.env symlink
+    _seed_api_env(p, agent_img)
 
     # 5. start the requested L2 components
     table = _components(p)

--- a/apps/infra-local/compose/native.py
+++ b/apps/infra-local/compose/native.py
@@ -27,7 +27,7 @@ from pathlib import Path
 
 from . import _local_arm64
 from . import orchestrator
-from .config import InfraConfig
+from .config import InfraConfig, worktree_home
 from .doctor import _lsof_owner
 from .services import SERVICES
 
@@ -102,7 +102,11 @@ class _Paths:
 
     @property
     def runner_home(self) -> Path:
-        return Path(os.environ.get("BOXLITE_HOME_DIR") or (self.state / "boxlite-runner"))
+        # Anchored at the machine-global short root (NOT under .apps-local): the
+        # runner's box sockets live at <home>/boxes/<id>/sockets/ready.sock and
+        # macOS caps unix socket paths at 104 bytes (SUN_LEN), which a deep
+        # worktree path overflows. See config.worktree_home.
+        return Path(os.environ.get("BOXLITE_HOME_DIR") or worktree_home(self.repo_root, "r"))
 
 
 def _paths(cfg: InfraConfig) -> _Paths:
@@ -438,9 +442,13 @@ def build(cfg: InfraConfig) -> int:
 
 
 def _ensure_installed(p: _Paths) -> None:
-    """Zero-config bring-up: if the boxlite SDK isn't importable, `pip install -e .`
-    (which pulls it in) and re-exec — a fresh interpreter then sees the install.
-    The sentinel env var prevents an install loop if it still doesn't import."""
+    """Zero-config bring-up. Ensures the venv has the repo's own boxlite engine
+    build (with local fixes the PyPI wheel lacks — e.g. the macOS OCI read-only
+    removal fix), then that the SDK is importable; otherwise `pip install -e .`
+    + re-exec. The sentinel env var prevents an install loop."""
+    # boxlite must be the local source build, not the PyPI wheel. This builds it
+    # once (shared cargo cache → reused across worktrees) and no-ops thereafter.
+    _local_arm64.ensure_local_boxlite()
     try:
         import boxlite  # noqa: F401
         return
@@ -497,9 +505,11 @@ def up(cfg: InfraConfig, components: list[str] | None = None) -> int:
             err(f"unknown component: {name} (valid: {' '.join(ALL_COMPONENTS)})")
             return 2
     # 0. Apple-Silicon bootstrap (idempotent no-ops once done): thread docker.io
-    # creds through to L1 + runner, build the native lib, fix the runtime cache.
+    # + ghcr.io creds through to L1 + runner, build the native lib, fix the
+    # runtime cache.
     _local_arm64.ensure_tools_on_path()
     _local_arm64.export_dockerhub_env()
+    _local_arm64.export_ghcr_env()
     _ensure_installed(p)
     _local_arm64.ensure_native_lib()
     _local_arm64.fix_runtime_cache()
@@ -518,9 +528,11 @@ def up(cfg: InfraConfig, components: list[str] | None = None) -> int:
         log("native binaries missing — building")
         build(cfg)
 
-    # 3.5 arm64 agent image: L1 registry is up now, so build+push a bootable
-    # arm64 box base (no arm64 curated image exists). None on non-arm64 / no docker.
-    agent_img = _local_arm64.ensure_agent_image()
+    # 3.5 box base image: the published agent image is multi-arch now, so the
+    # runner pulls the host-matching arch straight from ghcr — no local build or
+    # L1-registry push. None when ghcr creds are absent (caller logs it and
+    # leaves the amd64-only curated default in place).
+    agent_img = _local_arm64.resolve_agent_image()
 
     # 4. API .env template + port + curated-image override + the apps/.env symlink
     _seed_api_env(p, agent_img)

--- a/apps/infra-local/compose/native.py
+++ b/apps/infra-local/compose/native.py
@@ -202,7 +202,7 @@ class _Component:
     timeout_s: int
     argv: list[str]
     cwd: Path | None
-    env: dict[str, str]   # extra env layered on top of os.environ
+    env: dict[str, str | None]   # extra env layered on top of os.environ; None unsets
     pkill_pattern: str    # orphan-sweep fallback (matches the bash pkill -f)
 
 
@@ -236,6 +236,11 @@ def _components(p: _Paths) -> dict[str, _Component]:
                 "BOXLITE_HOME_DIR": str(p.runner_home),
                 "INSECURE_REGISTRIES": "127.0.0.1:25000",
                 "AWS_REGION": "us-east-1",
+                # The runner links the locally-built core, whose embedded guest
+                # may differ from the PyPI SDK version that ensure_runtime_env()
+                # pins for L1. Unset that pin so the runner resolves the runtime
+                # matching its OWN core (avoids "Guest binary hash mismatch").
+                "BOXLITE_RUNTIME_DIR": None,
             },
             "boxlite-runner$",
         ),
@@ -281,7 +286,9 @@ def start_component(p: _Paths, comp: _Component) -> bool:
         proc = subprocess.Popen(
             comp.argv,
             cwd=str(comp.cwd) if comp.cwd else None,
-            env={**os.environ, **comp.env},
+            # A None value in comp.env unsets an inherited var (e.g. the L1
+            # BOXLITE_RUNTIME_DIR pin must not leak to the runner — see below).
+            env={k: v for k, v in {**os.environ, **comp.env}.items() if v is not None},
             stdout=logf,
             stderr=subprocess.STDOUT,
             start_new_session=True,  # detach: survives our exit + own process group

--- a/apps/infra-local/compose/orchestrator.py
+++ b/apps/infra-local/compose/orchestrator.py
@@ -126,6 +126,25 @@ def ensure_home_env(config: InfraConfig) -> None:
 def get_runtime():
     ensure_runtime_env()
     Boxlite, _ = import_sdk()
+    # Local override: authenticate docker.io pulls when creds are supplied via
+    # env, so L1 image pulls don't hit the anonymous Docker Hub rate limit.
+    # The BoxLite puller does NOT read ~/.docker/config.json — auth must come
+    # through the runtime's image_registries config.
+    from . import _local_arm64
+    user, secret = _local_arm64.dockerhub_creds()
+    if user and secret:
+        from boxlite import ImageRegistry, Options
+        opts = Options(image_registries=[
+            ImageRegistry("docker.io", username=user, password=secret, search=True),
+        ])
+        # Seed the PROCESS-WIDE default runtime with auth, then return that
+        # shared singleton — NOT a fresh Boxlite(opts). A fresh runtime per call
+        # would re-acquire the home-dir flock and collide with itself when
+        # get_runtime() runs more than once in a process.
+        try:
+            Boxlite.init_default(opts)
+        except Exception:
+            pass  # default runtime already initialized in this process
     return Boxlite.default()
 
 

--- a/apps/runner/cmd/runner/config/config.go
+++ b/apps/runner/cmd/runner/config/config.go
@@ -60,6 +60,8 @@ type Config struct {
 	InsecureRegistries                 string        `envconfig:"INSECURE_REGISTRIES"`
 	GhcrUsername                       string        `envconfig:"GHCR_USERNAME"`
 	GhcrToken                          string        `envconfig:"GHCR_TOKEN"`
+	DockerHubUsername                  string        `envconfig:"DOCKERHUB_USERNAME"`
+	DockerHubToken                     string        `envconfig:"DOCKERHUB_TOKEN"`
 }
 
 var DEFAULT_API_PORT int = 8080

--- a/apps/runner/cmd/runner/main.go
+++ b/apps/runner/cmd/runner/main.go
@@ -111,6 +111,8 @@ func run() int {
 		InsecureRegistries:           insecureRegs,
 		GhcrUsername:                 cfg.GhcrUsername,
 		GhcrToken:                    cfg.GhcrToken,
+		DockerHubUsername:            cfg.DockerHubUsername,
+		DockerHubToken:               cfg.DockerHubToken,
 		AWSRegion:                    cfg.AWSRegion,
 		AWSEndpointUrl:               cfg.AWSEndpointUrl,
 		AWSAccessKeyId:               cfg.AWSAccessKeyId,

--- a/apps/runner/pkg/boxlite/client.go
+++ b/apps/runner/pkg/boxlite/client.go
@@ -48,6 +48,8 @@ type ClientConfig struct {
 	InsecureRegistries           []string
 	GhcrUsername                 string
 	GhcrToken                    string
+	DockerHubUsername            string
+	DockerHubToken               string
 	AWSRegion                    string
 	AWSEndpointUrl               string
 	AWSAccessKeyId               string
@@ -140,6 +142,19 @@ func NewClient(ctx context.Context, config ClientConfig) (*Client, error) {
 	}
 	insecureRegistries := normalizeRegistryHosts(config.InsecureRegistries)
 	registries := buildImageRegistries(insecureRegistries, config.GhcrUsername, config.GhcrToken)
+	// docker.io auth (local dev): boxlite-core pulls box base images (e.g. the
+	// debian base disk + public user images) from docker.io; without auth those
+	// hit the anonymous Docker Hub rate limit. Mirror the ghcr.io auth entry.
+	if config.DockerHubUsername != "" && config.DockerHubToken != "" {
+		registries = append(registries, boxlite.ImageRegistry{
+			Host:      "docker.io",
+			Transport: boxlite.RegistryTransportHTTPS,
+			Auth: boxlite.ImageRegistryAuth{
+				Username: config.DockerHubUsername,
+				Password: config.DockerHubToken,
+			},
+		})
+	}
 	if len(registries) > 0 {
 		opts = append(opts, boxlite.WithImageRegistries(registries...))
 	}

--- a/src/boxlite/src/images/archive/extractor.rs
+++ b/src/boxlite/src/images/archive/extractor.rs
@@ -413,10 +413,26 @@ impl<'a> LayerExtractor<'a> {
                 if keep_if_dir && is_real_dir {
                     return Ok(());
                 }
-                if is_real_dir {
+                let first = if is_real_dir {
                     fs::remove_dir_all(path)
                 } else {
                     fs::remove_file(path)
+                };
+                // OCI layers can mark a dir read-only (e.g. /usr/bin at 0555);
+                // a whiteout or higher-layer overwrite still has to delete
+                // inside it, but std `remove_*` can't unlink within a read-only
+                // parent. On EACCES/EPERM, make the target subtree and its
+                // parent user-writable, then retry once.
+                match first {
+                    Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
+                        Self::make_removable(path, is_real_dir);
+                        if is_real_dir {
+                            fs::remove_dir_all(path)
+                        } else {
+                            fs::remove_file(path)
+                        }
+                    }
+                    other => other,
                 }
                 .map_err(|e| {
                     BoxliteError::Storage(format!("Failed to remove {}: {}", path.display(), e))
@@ -428,6 +444,37 @@ impl<'a> LayerExtractor<'a> {
                 path.display(),
                 e
             ))),
+        }
+    }
+
+    /// Make `path` (and, for a directory, its whole subtree) plus its parent
+    /// user-writable, so a read-only OCI dir (e.g. `/usr/bin` at 0555) can't
+    /// block a whiteout/overwrite unlink. Best-effort: chmod errors are
+    /// ignored — the caller's retry surfaces any genuine failure.
+    fn make_removable(path: &Path, is_dir: bool) {
+        if let Some(parent) = path.parent() {
+            Self::make_user_writable(parent);
+        }
+        if is_dir {
+            for entry in WalkDir::new(path).into_iter().flatten() {
+                Self::make_user_writable(entry.path());
+            }
+        } else {
+            Self::make_user_writable(path);
+        }
+    }
+
+    /// Add the owner-write bit to `path` when missing. Skips symlinks (chmod
+    /// would follow to the target); no-op when already writable.
+    fn make_user_writable(path: &Path) {
+        if let Ok(meta) = fs::symlink_metadata(path) {
+            if meta.file_type().is_symlink() {
+                return;
+            }
+            let mode = meta.permissions().mode();
+            if mode & 0o200 == 0 {
+                let _ = fs::set_permissions(path, Permissions::from_mode(mode | 0o200));
+            }
         }
     }
 
@@ -1945,6 +1992,63 @@ mod tests {
              a fix that relaxes perms to bypass EACCES would corrupt the \
              override_stat xattr written by fix_rootfs_permissions",
             bin_mode,
+        );
+
+        // Restore u+w so TempDir's Drop can recurse-remove.
+        let _ = fs::set_permissions(dest.join("usr/bin"), Permissions::from_mode(0o755));
+    }
+
+    /// Whiteout regression: a `.wh.` marker deleting a file inside an
+    /// already-finalized read-only parent dir must succeed. OCI base layers
+    /// ship system dirs like `/usr/bin` at 0o555; a higher layer whiteouting a
+    /// file there (e.g. removing coreutils `[`) hits a parent the previous
+    /// layer's `finalize` already chmod'd to 0o555 on disk, so std `remove_*`
+    /// can't unlink within it — pre-fix this surfaced as a cold `make up`
+    /// failure on macOS: "Failed to remove …/usr/bin/[: Permission denied".
+    /// `remove_nofollow` must make the target writable and proceed.
+    #[test]
+    fn whiteout_removes_file_inside_finalized_readonly_parent_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dest = tmp.path().join("merged");
+
+        // Layer 1: lay down /usr/bin at 0o555 with a file, then finalize so the
+        // read-only mode is applied on disk (a later layer sees 0o555).
+        let mut ex1 = LayerExtractor::new(&dest);
+        ex1.extract_reader(std::io::Cursor::new(create_raw_tar(&[
+            raw_dir("usr"),
+            RawTarEntry {
+                path: "usr/bin",
+                kind: RawTarEntryKind::Directory,
+                mode: 0o555,
+            },
+            raw_file("usr/bin/[", b"coreutils"),
+        ])))
+        .unwrap();
+        ex1.finalize().unwrap();
+
+        let bin_mode = fs::symlink_metadata(dest.join("usr/bin"))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(
+            bin_mode, 0o555,
+            "precondition: /usr/bin must be read-only on disk before the whiteout layer",
+        );
+
+        // Layer 2: whiteout /usr/bin/[ — its parent is 0o555 on disk now, so the
+        // unlink only succeeds if remove_nofollow makes the target writable.
+        let mut ex2 = LayerExtractor::new(&dest);
+        ex2.extract_reader(std::io::Cursor::new(create_raw_tar(&[raw_file(
+            "usr/bin/.wh.[",
+            b"",
+        )])))
+        .expect("whiteout must delete a file inside a read-only parent dir");
+        ex2.finalize().unwrap();
+
+        assert!(
+            !dest.join("usr/bin/[").exists(),
+            "whiteout should have removed /usr/bin/[",
         );
 
         // Restore u+w so TempDir's Drop can recurse-remove.


### PR DESCRIPTION
Independent of #855 (the name-exist fix). The earlier #865 was accidentally based
on the #855 branch instead of `main`; this re-targets the same change to `main`
as its own PR. One self-contained commit — touches only `apps/infra-local` + the
runner's docker.io auth.

## What

Folds the gaps a fresh Apple-Silicon Mac hits into the `compose` package, so the
native `make up` brings up a fully usable local stack (L1 microVMs + API + runner
+ a bootable, exec-able arm64 box) with **no manual env/build steps**. All helpers
are idempotent:

- **docker.io auth** — read from Docker Desktop's credStore, threaded to L1 + the
  runner (the BoxLite puller doesn't read `~/.docker/config.json`, so images
  otherwise hit the anonymous Docker Hub rate limit).
- **runtime cache** — the maturin editable build omits `boxlite-guest`/`shim`;
  copy them from the cargo build output so box boot works.
- **arm64 agent image** — curated agent images are amd64-only; build + push an
  arm64 image (debian + toolbox daemon) to the L1 registry.
- **native lib + submodules** — build `libboxlite.a` (init submodules first).
- **misc** — psql/crane on PATH; env-overridable API port; Makefile auto-uses .venv-infra.
- **runner** — docker.io auth alongside the existing ghcr.io auth.

## Verified

Cold `make down --all` → `make up` (only `BOXLITE_LOCAL_API_PORT=3011`) brings up
all 10 L1 microVMs + API + runner + seed; a box created with no image boots and
`exec` returns `aarch64` / Debian bookworm.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Docker Hub credential support via `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` for authenticated image pulls.
  * Improved Apple Silicon local development with an ARM64 bootstrap, multi-arch agent image selection, and optional local engine installation.
  * Made the local API port configurable via `BOXLITE_LOCAL_API_PORT` and updated local runtime home placement to be machine-short, per-worktree.
* **Bug Fixes**
  * Reduced unintended environment-variable inheritance and improved API `.env` seeding reliability.
  * Fixed whiteout/tar extraction failing on permission-denied cases in read-only parents.
* **Tests**
  * Added a regression test covering the finalized read-only parent whiteout scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->