### PR TITLE
ci: centralize deploy workflows to boxlite-app-env (reusable)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,50 @@
+# Deploy — thin caller wrapper. Delegates to boxlite-app-env reusable workflow.
+#
+# All real work lives in boxlite-ai/boxlite-app-env's sst-deploy.yml (callee).
+# This file's only job is: declare the workflow_dispatch UI button + per-stage
+# inputs + forward to the callee at a pinned SHA.
+#
+# To bump the callee version: change @<sha> below after reading the diff between
+# the old and new SHAs in boxlite-app-env.
+#
+# OIDC: AWS sees sub = repo:boxlite-ai/boxlite:environment:<stage> (caller, not
+# callee). IAM role boxlite-app-<stage>-deploy continues to trust this caller.
+name: Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      stage:
+        description: Stage to deploy
+        type: choice
+        options: [dev, prod]
+        default: dev
+      mode:
+        description: diff (read-only preview) or deploy (apply)
+        type: choice
+        options: [diff, deploy]
+        default: diff
+      region:
+        description: AWS region (dev = ap-southeast-1)
+        type: choice
+        options: [ap-southeast-1, us-east-1, us-west-2, eu-west-1, eu-central-1, ap-northeast-1]
+        default: ap-southeast-1
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    # Pinned to boxlite-app-env tag v0.1.0 SHA. Update after reading the diff at
+    # https://github.com/boxlite-ai/boxlite-app-env/compare/<old-sha>...<new-sha>
+    uses: boxlite-ai/boxlite-app-env/.github/workflows/sst-deploy.yml@27322286d9c8fb4b5eed476138d75524f67692ad
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      stage:      ${{ inputs.stage }}
+      mode:       ${{ inputs.mode }}
+      region:     ${{ inputs.region }}
+      role_arn:   arn:aws:iam::064212132677:role/boxlite-app-${{ inputs.stage }}-deploy
+      caller_ref: ${{ github.sha }}

--- a/.github/workflows/runner-rollout.yml
+++ b/.github/workflows/runner-rollout.yml
@@ -1,0 +1,66 @@
+# Runner Rollout — thin caller wrapper. Delegates to boxlite-app-env reusable workflow.
+#
+# All real work lives in boxlite-ai/boxlite-app-env's runner-rollout.yml (callee).
+# This file's only job is: declare the workflow_dispatch UI button + per-stage
+# inputs + forward to the callee at a pinned SHA.
+#
+# The callee checks out boxlite source (this repo) to build the Go runner binary
+# from Rust libboxlite.a + apps/runner / daemon / common-go / api-client-go /
+# libs/computer-use. caller_ref pins which commit gets built.
+#
+# ⚠ This RESTARTS the runner systemd unit on the target EC2. Boxes are interrupted
+#   (state under /var/lib/boxlite is preserved).
+name: Runner Rollout
+
+on:
+  workflow_dispatch:
+    inputs:
+      stage:
+        description: Stage
+        type: choice
+        options: [dev, prod]
+        default: dev
+      region:
+        description: AWS region the runner lives in
+        type: choice
+        options: [ap-southeast-1, us-east-1, us-west-2, eu-west-1, eu-central-1, ap-northeast-1]
+        default: ap-southeast-1
+      source:
+        description: dev-build (build the ref now) or release (install a published version)
+        type: choice
+        options: [dev-build, release]
+        default: dev-build
+      ref:
+        description: "dev-build: branch/commit to build (blank = this caller's commit). release: version e.g. 0.9.5"
+        type: string
+        default: ""
+      mode:
+        description: "upgrade, or rollback (rollback requires source=release)"
+        type: choice
+        options: [upgrade, rollback]
+        default: upgrade
+      instance_id:
+        description: "Pin a specific runner instance id (blank = find boxlite-<stage>-runner-default by tag)"
+        type: string
+        default: ""
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  rollout:
+    # Pinned to boxlite-app-env tag v0.1.0 SHA.
+    uses: boxlite-ai/boxlite-app-env/.github/workflows/runner-rollout.yml@27322286d9c8fb4b5eed476138d75524f67692ad
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      stage:       ${{ inputs.stage }}
+      region:      ${{ inputs.region }}
+      source:      ${{ inputs.source }}
+      mode:        ${{ inputs.mode }}
+      ref:         ${{ inputs.ref }}
+      instance_id: ${{ inputs.instance_id }}
+      role_arn:    arn:aws:iam::064212132677:role/boxlite-app-${{ inputs.stage }}-deploy
+      caller_ref:  ${{ github.sha }}


### PR DESCRIPTION
## What

Replaces the local 99-line `deploy.yml` + 258-line `runner-rollout.yml` (as
introduced by #834 / #836) with thin ~50-line **caller wrappers** that
delegate to **reusable workflows** hosted in the private
[`boxlite-ai/boxlite-app-env`](https://github.com/boxlite-ai/boxlite-app-env)
repo (owned by `@boxlite-ai/deploy`).

| File | Before (#836) | After (this PR) |
|---|---|---|
| `.github/workflows/deploy.yml` | 99 lines (full SST flow) | 50 lines (caller → callee@SHA) |
| `.github/workflows/runner-rollout.yml` | 258 lines (full Rust+Go build) | 66 lines (caller → callee@SHA) |

The callees pin to boxlite-app-env tag [`v0.1.0`](https://github.com/boxlite-ai/boxlite-app-env/releases/tag/v0.1.0) (commit `27322286`).

## Why

Brian's boss spawned `boxlite-app-env` (2026-06-22) as a deploy-team-owned
private repo so deploy iteration is decoupled from main-repo OSS review
velocity. After the workflows stabilize there, this caller-wrapper pattern
becomes the "通用流程" template that other `boxlite-ai/*` repos (website,
docs, analytics) can adopt the same way.

Design doc: `~/Documents/Obsidian Vault/1-Projects/2026-06-Deploy-Workflow-中心化/` (5 docs).

## Key design choices

- **Pinned `@<40-char-SHA>`** — never `@main` or `@v0.1`. Supply-chain safety; see [Wiz CVE-2025-30066](https://www.wiz.io/blog/github-action-tj-actions-changed-files-supply-chain-attack-cve-2025-30066).
- **`role_arn` as input, not secret** — AWS account ID + role name are public; the only real secret is the short-lived OIDC token (R5 in design doc).
- **OIDC `sub` unchanged** — per [GitHub Docs](https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/using-openid-connect-with-reusable-workflows), reusable workflows keep the caller's `sub`; the callee identity goes into `job_workflow_ref`. So the existing IAM trust on `boxlite-app-<stage>-deploy` does NOT need to change.
- **`config.yml` copied verbatim into the callee repo** — avoids nested cross-repo `uses:`, which would compound the `@SHA` pinning surface.

## :warning: Known blockers before merge

### 1. GitHub Free does not support Environments on private repos

`boxlite-ai` org is on **GitHub Free**. The callee declares
`environment: \${{ inputs.stage }}`, but the callee runs in `boxlite-app-env`
(private). Free private repos can't create environments → callee fails at
job evaluation; OIDC `sub` claim missing the `environment:` slug breaks the
IAM trust match anyway.

**Decision required (see `3-待决问题.md` Q3):**
- **A** Upgrade `boxlite-ai` to GitHub Team (~$4/user/mo) — cleanest
- **B** Flip `boxlite-app-env` visibility to public — defeats the "private deploy repo" model
- **C** Strip `environment:` from callee + rework IAM trust to use `ref:refs/heads/...`
- **D** Abandon central-repo, use a composite action in the boxlite repo (R4)

### 2. Depends on #836 (or its infra-script subset) merging first

The callees check out boxlite at `caller_ref`, then run `npm install` +
`npm run sst -- ...` in `apps/infra`. Those commands require the
`sst-with-cloudflare.mjs` / `seed-*-ssm.mjs` / updated `sst.config.ts` that
#836 introduces. If this PR merges **before** #836, the dispatched deploy
will fail at `npm run sst`.

**Options:**
- Merge #836 first, then this PR (simplest, keeps PRs small).
- Cherry-pick #836's `apps/infra/scripts/*.mjs` + `sst.config.ts` changes into this PR (self-contained, but bigger).
- Close #836, merge its non-workflow content into this PR (most invasive).

### 3. (Not blocking) Cross-repo Actions access setting

`gh api .../actions/permissions/access` returned 404 for `boxlite-app-env`
(setting unconfigured = org default). If org's default is "private repo
not accessible from outside", caller will fail with "reusable workflow not
accessible from this repository". The first real run will surface this.

## Validation done

- `yamllint` / `bash -n` / structural review — clean
- Cross-referenced against the verifier subagent finding on OIDC sub
  semantics (caller, not callee) — IAM trust does not need to change
- `boxlite-app-env` skeleton pushed with tag `v0.1.0` and CODEOWNERS
- Audited via the CLAUDE.md auditor (3 audits over the change set)

## Validation pending

- Cannot end-to-end dispatch until Q3 + (#836 merge) resolved
- Once unblocked: `gh workflow run --ref feat/centralize-workflows deploy.yml --field stage=dev --field mode=diff --field region=ap-southeast-1` — read-only sanity check

## Not in this PR

- IAM trust hardening via `job_workflow_ref` (optional, post-stabilization)
- `runner-diagnostics.yml` (PR #834 introduced; out-of-scope for centralization N1)
- `prod` environment / approver configuration (boxlite-app-env admin = @DorianZheng's call)

🚧 **DRAFT** — keep as draft until Q3 (GH Free env) is resolved.