### PR TITLE
fix(runtime): reap detached box's full cgroup tree on stop/remove

### DIFF
--- a/src/boxlite/src/jailer/cgroup.rs
+++ b/src/boxlite/src/jailer/cgroup.rs
@@ -159,7 +159,11 @@ pub fn cgroup_path(box_id: &str) -> PathBuf {
 /// that — its charset (`[A-Za-z0-9_-]`) excludes `/`, `\`, and `.`, so `..`/`.`
 /// and path separators are unrepresentable. The type carries the guarantee, so
 /// no per-call traversal check is needed (or could drift) here.
-pub fn kill_cgroup(box_id: &BoxID) -> bool {
+///
+/// `pub(super)` on purpose: this is the cgroup *mechanism*, reached only through
+/// the jailer's [`super::reap_sandbox`] facade. Layers above the jailer (box,
+/// runtime) reap by box semantics and never name cgroups.
+pub(super) fn kill_cgroup(box_id: &BoxID) -> bool {
     let kill_file = cgroup_path(box_id.as_str()).join("cgroup.kill");
     std::fs::write(&kill_file, "1").is_ok()
 }

--- a/src/boxlite/src/jailer/cgroup.rs
+++ b/src/boxlite/src/jailer/cgroup.rs
@@ -161,7 +161,7 @@ pub fn cgroup_path(box_id: &str) -> PathBuf {
 /// no per-call traversal check is needed (or could drift) here.
 ///
 /// `pub(super)` on purpose: this is the cgroup *mechanism*, reached only through
-/// the jailer's [`super::reap_sandbox`] facade. Layers above the jailer (box,
+/// the jailer's [`super::reap_box`] facade. Layers above the jailer (box,
 /// runtime) reap by box semantics and never name cgroups.
 pub(super) fn kill_cgroup(box_id: &BoxID) -> bool {
     let kill_file = cgroup_path(box_id.as_str()).join("cgroup.kill");

--- a/src/boxlite/src/jailer/cgroup.rs
+++ b/src/boxlite/src/jailer/cgroup.rs
@@ -138,6 +138,24 @@ pub fn cgroup_path(box_id: &str) -> PathBuf {
     get_cgroup_base().join(BOXLITE_CGROUP).join(box_id)
 }
 
+/// Kill every process in a box's cgroup via cgroup v2 `cgroup.kill`.
+///
+/// Reaps the box's *entire* process tree atomically — the outer bwrap launcher,
+/// the inner pid-namespace bwrap, the shim, and the VM — regardless of
+/// pid-namespace or process-group structure. A single-pid `SIGKILL` of the
+/// recorded pid only hits the outer bwrap; a detached box's inner tree survives
+/// it, since #851 stopped applying `--die-with-parent` to detached boxes. The
+/// whole tree lives in the box's cgroup, so killing the cgroup by id reaps it
+/// even after `state.pid` has been cleared.
+///
+/// Best-effort and idempotent: a no-op if the cgroup is gone, already empty, or
+/// `cgroup.kill` is unavailable (kernel < 5.14 / cgroup v1 / no jailer). Returns
+/// `true` if the kill file was written.
+pub fn kill_cgroup(box_id: &str) -> bool {
+    let kill_file = cgroup_path(box_id).join("cgroup.kill");
+    std::fs::write(&kill_file, "1").is_ok()
+}
+
 /// Setup cgroup for a box.
 ///
 /// Creates the cgroup directory and configures resource limits.
@@ -423,6 +441,18 @@ mod tests {
     fn test_cgroup_v2_detection() {
         let available = is_cgroup_v2_available();
         println!("Cgroup v2 available: {}", available);
+    }
+
+    #[test]
+    fn kill_cgroup_absent_is_noop() {
+        // No cgroup exists for this id, so `cgroup.kill` can't be written:
+        // kill_cgroup must report `false` and not panic. This locks the
+        // best-effort/idempotent contract relied on by the no-jailer and
+        // macOS-seatbelt paths (where there is no box cgroup to kill).
+        assert!(
+            !kill_cgroup("nonexistent-box-000000000000"),
+            "kill_cgroup must be a no-op (false) when the box has no cgroup"
+        );
     }
 
     #[test]

--- a/src/boxlite/src/jailer/cgroup.rs
+++ b/src/boxlite/src/jailer/cgroup.rs
@@ -152,6 +152,14 @@ pub fn cgroup_path(box_id: &str) -> PathBuf {
 /// `cgroup.kill` is unavailable (kernel < 5.14 / cgroup v1 / no jailer). Returns
 /// `true` if the kill file was written.
 pub fn kill_cgroup(box_id: &str) -> bool {
+    if box_id.is_empty()
+        || box_id == "."
+        || box_id == ".."
+        || box_id.bytes().any(|b| matches!(b, b'/' | b'\\'))
+    {
+        return false;
+    }
+
     let kill_file = cgroup_path(box_id).join("cgroup.kill");
     std::fs::write(&kill_file, "1").is_ok()
 }
@@ -453,6 +461,16 @@ mod tests {
             !kill_cgroup("nonexistent-box-000000000000"),
             "kill_cgroup must be a no-op (false) when the box has no cgroup"
         );
+    }
+
+    #[test]
+    fn kill_cgroup_rejects_non_component_box_ids() {
+        for box_id in ["", ".", "..", "../escape", "nested/box", r"nested\box"] {
+            assert!(
+                !kill_cgroup(box_id),
+                "kill_cgroup must reject non-component box id {box_id:?}"
+            );
+        }
     }
 
     #[test]

--- a/src/boxlite/src/jailer/cgroup.rs
+++ b/src/boxlite/src/jailer/cgroup.rs
@@ -33,6 +33,7 @@
 use super::common;
 use super::error::JailerError;
 use crate::runtime::advanced_options::ResourceLimits;
+use crate::runtime::id::BoxID;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -151,16 +152,15 @@ pub fn cgroup_path(box_id: &str) -> PathBuf {
 /// Best-effort and idempotent: a no-op if the cgroup is gone, already empty, or
 /// `cgroup.kill` is unavailable (kernel < 5.14 / cgroup v1 / no jailer). Returns
 /// `true` if the kill file was written.
-pub fn kill_cgroup(box_id: &str) -> bool {
-    if box_id.is_empty()
-        || box_id == "."
-        || box_id == ".."
-        || box_id.bytes().any(|b| matches!(b, b'/' | b'\\'))
-    {
-        return false;
-    }
-
-    let kill_file = cgroup_path(box_id).join("cgroup.kill");
+///
+/// Takes a [`BoxID`] rather than a raw `&str` on purpose: this writes to a path
+/// derived from the id, so it must be a safe single path component. `BoxID`'s
+/// constructor ([`BoxID::parse`]/mint) is the one choke point that guarantees
+/// that — its charset (`[A-Za-z0-9_-]`) excludes `/`, `\`, and `.`, so `..`/`.`
+/// and path separators are unrepresentable. The type carries the guarantee, so
+/// no per-call traversal check is needed (or could drift) here.
+pub fn kill_cgroup(box_id: &BoxID) -> bool {
+    let kill_file = cgroup_path(box_id.as_str()).join("cgroup.kill");
     std::fs::write(&kill_file, "1").is_ok()
 }
 
@@ -457,21 +457,18 @@ mod tests {
         // kill_cgroup must report `false` and not panic. This locks the
         // best-effort/idempotent contract relied on by the no-jailer and
         // macOS-seatbelt paths (where there is no box cgroup to kill).
+        let box_id = BoxID::parse("nonexistentbox000000000000").expect("valid id");
         assert!(
-            !kill_cgroup("nonexistent-box-000000000000"),
+            !kill_cgroup(&box_id),
             "kill_cgroup must be a no-op (false) when the box has no cgroup"
         );
     }
 
-    #[test]
-    fn kill_cgroup_rejects_non_component_box_ids() {
-        for box_id in ["", ".", "..", "../escape", "nested/box", r"nested\box"] {
-            assert!(
-                !kill_cgroup(box_id),
-                "kill_cgroup must reject non-component box id {box_id:?}"
-            );
-        }
-    }
+    // Note: there is no `kill_cgroup_rejects_non_component_box_ids` test anymore.
+    // The path-traversal guard moved into the type: `kill_cgroup` takes a
+    // `BoxID`, and `BoxID::parse` already rejects `/`, `\`, `.`, `..`, and empty
+    // ids (see `id::tests::test_parse_rejects_unsafe_characters`). A non-component
+    // id is now unrepresentable at this call site, not merely rejected at runtime.
 
     #[test]
     fn test_cgroup_config_from_limits() {

--- a/src/boxlite/src/jailer/mod.rs
+++ b/src/boxlite/src/jailer/mod.rs
@@ -100,13 +100,13 @@ pub use sandbox::{
 /// this reaps it by id; on platforms with no host-side sandbox tree it is a
 /// no-op. Idempotent — safe on an already-stopped or never-started box.
 #[cfg(target_os = "linux")]
-pub(crate) fn reap_sandbox(box_id: &crate::runtime::id::BoxID) -> bool {
+pub(crate) fn reap_box(box_id: &crate::runtime::id::BoxID) -> bool {
     cgroup::kill_cgroup(box_id)
 }
 
 /// See the Linux variant. No host-side sandbox process tree to reap here.
 #[cfg(not(target_os = "linux"))]
-pub(crate) fn reap_sandbox(_box_id: &crate::runtime::id::BoxID) -> bool {
+pub(crate) fn reap_box(_box_id: &crate::runtime::id::BoxID) -> bool {
     false
 }
 

--- a/src/boxlite/src/jailer/mod.rs
+++ b/src/boxlite/src/jailer/mod.rs
@@ -88,6 +88,28 @@ pub use sandbox::{
     CompositeSandbox, NoopSandbox, PathAccess, PlatformSandbox, Sandbox, SandboxContext,
 };
 
+// ============================================================================
+// Teardown facade
+// ============================================================================
+
+/// Reap any OS processes still belonging to a box's sandbox (best-effort).
+///
+/// The semantic teardown entry for the isolation layer: callers name the
+/// *box*, not the mechanism, so nothing above the jailer has to know how a box
+/// is confined. On Linux the box's whole process tree lives in its cgroup, so
+/// this reaps it by id; on platforms with no host-side sandbox tree it is a
+/// no-op. Idempotent — safe on an already-stopped or never-started box.
+#[cfg(target_os = "linux")]
+pub(crate) fn reap_sandbox(box_id: &crate::runtime::id::BoxID) -> bool {
+    cgroup::kill_cgroup(box_id)
+}
+
+/// See the Linux variant. No host-side sandbox process tree to reap here.
+#[cfg(not(target_os = "linux"))]
+pub(crate) fn reap_sandbox(_box_id: &crate::runtime::id::BoxID) -> bool {
+    false
+}
+
 // Volume specification (convenience re-export)
 pub use crate::runtime::options::VolumeSpec;
 

--- a/src/boxlite/src/litebox/box_impl.rs
+++ b/src/boxlite/src/litebox/box_impl.rs
@@ -396,7 +396,8 @@ impl BoxImpl {
         // is the outer bwrap and the inner pid-ns tree (inner bwrap + shim + VM)
         // can survive `handler.stop()` — since #851, detached boxes don't get
         // `--die-with-parent`. cgroup.kill reaps the whole tree by id; a no-op
-        // once the box has exited (or when there is no cgroup: jailer off / macOS).
+        // once the box has exited (or when there is no cgroup: jailer off).
+        #[cfg(target_os = "linux")]
         crate::jailer::cgroup::kill_cgroup(self.config.id.as_str());
 
         // Check if box was persisted

--- a/src/boxlite/src/litebox/box_impl.rs
+++ b/src/boxlite/src/litebox/box_impl.rs
@@ -398,7 +398,7 @@ impl BoxImpl {
         // `--die-with-parent`. cgroup.kill reaps the whole tree by id; a no-op
         // once the box has exited (or when there is no cgroup: jailer off).
         #[cfg(target_os = "linux")]
-        crate::jailer::cgroup::kill_cgroup(self.config.id.as_str());
+        crate::jailer::cgroup::kill_cgroup(&self.config.id);
 
         // Check if box was persisted
         let was_persisted = self.state.read().lock_id.is_some();

--- a/src/boxlite/src/litebox/box_impl.rs
+++ b/src/boxlite/src/litebox/box_impl.rs
@@ -391,13 +391,6 @@ impl BoxImpl {
             ),
         }
 
-        // Make sure no OS processes belonging to this box are left running.
-        // Graceful shutdown above should have torn the VM down, but a detached
-        // box's process tree can outlive `handler.stop()` (since #851 it is no
-        // longer tied to the launcher's lifetime), so ask the runtime to reap
-        // anything of ours that remains. Best-effort and idempotent.
-        self.runtime.reap_box_processes(&self.config.id);
-
         // Check if box was persisted
         let was_persisted = self.state.read().lock_id.is_some();
 

--- a/src/boxlite/src/litebox/box_impl.rs
+++ b/src/boxlite/src/litebox/box_impl.rs
@@ -391,14 +391,12 @@ impl BoxImpl {
             ),
         }
 
-        // Reap any process still in the box's cgroup. Graceful shutdown above
-        // should have torn the VM down, but for a detached box the recorded pid
-        // is the outer bwrap and the inner pid-ns tree (inner bwrap + shim + VM)
-        // can survive `handler.stop()` — since #851, detached boxes don't get
-        // `--die-with-parent`. cgroup.kill reaps the whole tree by id; a no-op
-        // once the box has exited (or when there is no cgroup: jailer off).
-        #[cfg(target_os = "linux")]
-        crate::jailer::cgroup::kill_cgroup(&self.config.id);
+        // Make sure no OS processes belonging to this box are left running.
+        // Graceful shutdown above should have torn the VM down, but a detached
+        // box's process tree can outlive `handler.stop()` (since #851 it is no
+        // longer tied to the launcher's lifetime), so ask the runtime to reap
+        // anything of ours that remains. Best-effort and idempotent.
+        self.runtime.reap_box_processes(&self.config.id);
 
         // Check if box was persisted
         let was_persisted = self.state.read().lock_id.is_some();

--- a/src/boxlite/src/litebox/box_impl.rs
+++ b/src/boxlite/src/litebox/box_impl.rs
@@ -391,6 +391,14 @@ impl BoxImpl {
             ),
         }
 
+        // Reap any process still in the box's cgroup. Graceful shutdown above
+        // should have torn the VM down, but for a detached box the recorded pid
+        // is the outer bwrap and the inner pid-ns tree (inner bwrap + shim + VM)
+        // can survive `handler.stop()` — since #851, detached boxes don't get
+        // `--die-with-parent`. cgroup.kill reaps the whole tree by id; a no-op
+        // once the box has exited (or when there is no cgroup: jailer off / macOS).
+        crate::jailer::cgroup::kill_cgroup(self.config.id.as_str());
+
         // Check if box was persisted
         let was_persisted = self.state.read().lock_id.is_some();
 

--- a/src/boxlite/src/runtime/rt_impl.rs
+++ b/src/boxlite/src/runtime/rt_impl.rs
@@ -12,6 +12,7 @@ use crate::runtime::options::{BoxArchive, BoxOptions, BoxliteOptions};
 use crate::runtime::signal_handler::timeout_to_duration;
 use crate::runtime::types::{BoxInfo, BoxState, BoxStatus, ContainerID};
 use crate::vmm::VmmKind;
+use crate::vmm::controller::{ShimHandler, VmmHandler};
 use boxlite_shared::{BoxliteError, BoxliteResult};
 use chrono::Utc;
 use std::collections::HashMap;
@@ -810,15 +811,6 @@ impl RuntimeImpl {
             .ok_or_else(|| BoxliteError::NotFound(id_or_name.to_string()))
     }
 
-    /// Reap any OS processes still belonging to a box (best-effort).
-    ///
-    /// Delegates to the isolation layer by box id, so it works even when no
-    /// live handler or recorded pid remains (e.g. after recovery). The box
-    /// lifecycle asks the runtime for this; neither layer names the mechanism.
-    pub(crate) fn reap_box_processes(&self, id: &BoxID) {
-        crate::jailer::reap_sandbox(id);
-    }
-
     /// Remove a box from the runtime (internal implementation).
     ///
     /// This is the internal implementation called by both `BoxliteRuntime::remove()`
@@ -841,23 +833,18 @@ impl RuntimeImpl {
         if let Some((config, state)) = self.box_manager.box_by_id(id)? {
             // Box exists in database - handle as before
             let mut state = state;
-            // Reap the box's whole process tree through the isolation layer
-            // before anything else. `kill_process` (below) only signals the
-            // recorded pid — the launcher — and a detached box's inner process
-            // tree survives that, since #851 stopped tying detached boxes to the
-            // launcher's lifetime. Reaping by box id tears the whole tree down
-            // atomically, even after recovery has cleared `state.pid`. Best
-            // -effort and idempotent — a no-op on a genuinely-stopped box.
-            if force {
-                self.reap_box_processes(id);
-            }
             if state.status.is_active() || state.pid.is_some() {
                 if force {
-                    // Fallback for hosts without the cgroup jailer (disabled /
-                    // macOS seatbelt), where the tree is a single shim process.
+                    // Stop the box's whole process tree through the same handler
+                    // teardown `LiteBox::stop()` uses: it SIGTERMs the recorded
+                    // pid (the outer launcher), then reaps any survivors of a
+                    // detached box's inner pid-ns tree (inner bwrap + shim + VM) —
+                    // which a single-pid kill misses, since #851 stopped tying
+                    // detached boxes to the launcher's lifetime.
                     if let Some(pid) = state.pid {
-                        tracing::info!(box_id = %id, pid = pid, "Force killing box process");
-                        crate::util::kill_process(pid);
+                        tracing::info!(box_id = %id, pid = pid, "Force stopping box process tree");
+                        let mut handler = ShimHandler::from_pid(pid, config.id.clone());
+                        let _ = handler.stop();
                     }
                     // Update status to stopped and save
                     state.set_status(BoxStatus::Stopped);

--- a/src/boxlite/src/runtime/rt_impl.rs
+++ b/src/boxlite/src/runtime/rt_impl.rs
@@ -841,6 +841,7 @@ impl RuntimeImpl {
             // even after recovery has cleared `state.pid`. No-op when the cgroup
             // is gone/empty (genuinely-stopped box) or absent (jailer off /
             // macOS seatbelt).
+            #[cfg(target_os = "linux")]
             if force {
                 crate::jailer::cgroup::kill_cgroup(id.as_str());
             }

--- a/src/boxlite/src/runtime/rt_impl.rs
+++ b/src/boxlite/src/runtime/rt_impl.rs
@@ -825,6 +825,15 @@ impl RuntimeImpl {
     /// # Errors
     /// - Box not found
     /// - Box is active and force=false
+    /// Reap any OS processes still belonging to a box (best-effort).
+    ///
+    /// Delegates to the isolation layer by box id, so it works even when no
+    /// live handler or recorded pid remains (e.g. after recovery). The box
+    /// lifecycle asks the runtime for this; neither layer names the mechanism.
+    pub(crate) fn reap_box_processes(&self, id: &BoxID) {
+        crate::jailer::reap_sandbox(id);
+    }
+
     pub(crate) fn remove_box(&self, id: &BoxID, force: bool) -> BoxliteResult<()> {
         tracing::debug!(box_id = %id, force = force, "RuntimeInnerImpl::remove_box called");
 
@@ -832,18 +841,15 @@ impl RuntimeImpl {
         if let Some((config, state)) = self.box_manager.box_by_id(id)? {
             // Box exists in database - handle as before
             let mut state = state;
-            // Reap the box's whole process tree by its cgroup before anything
-            // else. `kill_process` (below) only signals the recorded pid — the
-            // outer bwrap launcher — and a detached box's inner pid-ns tree
-            // (inner bwrap + shim + VM) survives that, since #851 stopped
-            // applying `--die-with-parent` to detached boxes. The cgroup holds
-            // every box process, so killing it by id reaps the tree atomically,
-            // even after recovery has cleared `state.pid`. No-op when the cgroup
-            // is gone/empty (genuinely-stopped box) or absent (jailer off /
-            // macOS seatbelt).
-            #[cfg(target_os = "linux")]
+            // Reap the box's whole process tree through the isolation layer
+            // before anything else. `kill_process` (below) only signals the
+            // recorded pid — the launcher — and a detached box's inner process
+            // tree survives that, since #851 stopped tying detached boxes to the
+            // launcher's lifetime. Reaping by box id tears the whole tree down
+            // atomically, even after recovery has cleared `state.pid`. Best
+            // -effort and idempotent — a no-op on a genuinely-stopped box.
             if force {
-                crate::jailer::cgroup::kill_cgroup(id);
+                self.reap_box_processes(id);
             }
             if state.status.is_active() || state.pid.is_some() {
                 if force {

--- a/src/boxlite/src/runtime/rt_impl.rs
+++ b/src/boxlite/src/runtime/rt_impl.rs
@@ -810,6 +810,15 @@ impl RuntimeImpl {
             .ok_or_else(|| BoxliteError::NotFound(id_or_name.to_string()))
     }
 
+    /// Reap any OS processes still belonging to a box (best-effort).
+    ///
+    /// Delegates to the isolation layer by box id, so it works even when no
+    /// live handler or recorded pid remains (e.g. after recovery). The box
+    /// lifecycle asks the runtime for this; neither layer names the mechanism.
+    pub(crate) fn reap_box_processes(&self, id: &BoxID) {
+        crate::jailer::reap_sandbox(id);
+    }
+
     /// Remove a box from the runtime (internal implementation).
     ///
     /// This is the internal implementation called by both `BoxliteRuntime::remove()`
@@ -825,15 +834,6 @@ impl RuntimeImpl {
     /// # Errors
     /// - Box not found
     /// - Box is active and force=false
-    /// Reap any OS processes still belonging to a box (best-effort).
-    ///
-    /// Delegates to the isolation layer by box id, so it works even when no
-    /// live handler or recorded pid remains (e.g. after recovery). The box
-    /// lifecycle asks the runtime for this; neither layer names the mechanism.
-    pub(crate) fn reap_box_processes(&self, id: &BoxID) {
-        crate::jailer::reap_sandbox(id);
-    }
-
     pub(crate) fn remove_box(&self, id: &BoxID, force: bool) -> BoxliteResult<()> {
         tracing::debug!(box_id = %id, force = force, "RuntimeInnerImpl::remove_box called");
 

--- a/src/boxlite/src/runtime/rt_impl.rs
+++ b/src/boxlite/src/runtime/rt_impl.rs
@@ -843,7 +843,7 @@ impl RuntimeImpl {
             // macOS seatbelt).
             #[cfg(target_os = "linux")]
             if force {
-                crate::jailer::cgroup::kill_cgroup(id.as_str());
+                crate::jailer::cgroup::kill_cgroup(id);
             }
             if state.status.is_active() || state.pid.is_some() {
                 if force {

--- a/src/boxlite/src/runtime/rt_impl.rs
+++ b/src/boxlite/src/runtime/rt_impl.rs
@@ -832,9 +832,22 @@ impl RuntimeImpl {
         if let Some((config, state)) = self.box_manager.box_by_id(id)? {
             // Box exists in database - handle as before
             let mut state = state;
+            // Reap the box's whole process tree by its cgroup before anything
+            // else. `kill_process` (below) only signals the recorded pid — the
+            // outer bwrap launcher — and a detached box's inner pid-ns tree
+            // (inner bwrap + shim + VM) survives that, since #851 stopped
+            // applying `--die-with-parent` to detached boxes. The cgroup holds
+            // every box process, so killing it by id reaps the tree atomically,
+            // even after recovery has cleared `state.pid`. No-op when the cgroup
+            // is gone/empty (genuinely-stopped box) or absent (jailer off /
+            // macOS seatbelt).
+            if force {
+                crate::jailer::cgroup::kill_cgroup(id.as_str());
+            }
             if state.status.is_active() || state.pid.is_some() {
                 if force {
-                    // Force mode: kill the process directly
+                    // Fallback for hosts without the cgroup jailer (disabled /
+                    // macOS seatbelt), where the tree is a single shim process.
                     if let Some(pid) = state.pid {
                         tracing::info!(box_id = %id, pid = pid, "Force killing box process");
                         crate::util::kill_process(pid);

--- a/src/boxlite/src/vmm/controller/shim.rs
+++ b/src/boxlite/src/vmm/controller/shim.rs
@@ -76,14 +76,13 @@ impl ShimHandler {
             metrics_sys: Mutex::new(sysinfo::System::new()),
         }
     }
-}
 
-impl VmmHandlerTrait for ShimHandler {
-    fn pid(&self) -> u32 {
-        self.pid
-    }
-
-    fn stop(&mut self) -> BoxliteResult<()> {
+    /// Graceful shutdown of the recorded process: SIGTERM, wait, then SIGKILL.
+    ///
+    /// Signals only `self.pid` (the outer launcher). The full process-tree
+    /// sweep happens in `stop()` after this returns — see the comment there for
+    /// why the order matters (libkrun must flush before the hard cgroup kill).
+    fn graceful_stop(&mut self) -> BoxliteResult<()> {
         // Graceful shutdown: SIGTERM first, wait, then SIGKILL if needed.
         // This gives libkrun time to flush its virtio-blk buffers to disk,
         // preventing qcow2 corruption.
@@ -164,6 +163,26 @@ impl VmmHandlerTrait for ShimHandler {
 
         #[allow(unreachable_code)]
         Ok(())
+    }
+}
+
+impl VmmHandlerTrait for ShimHandler {
+    fn pid(&self) -> u32 {
+        self.pid
+    }
+
+    fn stop(&mut self) -> BoxliteResult<()> {
+        // Graceful shutdown of the recorded pid first, then sweep the box's
+        // whole tree. `graceful_stop` only signals the recorded pid — the outer
+        // bwrap launcher — and a detached box's inner pid-ns tree (inner bwrap +
+        // shim + VM) outlives it, since #851 stopped applying `--die-with-parent`
+        // to detached boxes. The whole tree lives in the box's cgroup, so reap it
+        // by id — *after* graceful shutdown, so libkrun can flush its virtio-blk
+        // buffers first (a cgroup kill is a hard kill; reaping mid-flush risks
+        // qcow2 corruption). Best-effort and idempotent.
+        let result = self.graceful_stop();
+        crate::jailer::reap_sandbox(&self.box_id);
+        result
     }
 
     fn metrics(&self) -> BoxliteResult<VmmMetrics> {

--- a/src/boxlite/src/vmm/controller/shim.rs
+++ b/src/boxlite/src/vmm/controller/shim.rs
@@ -181,7 +181,7 @@ impl VmmHandlerTrait for ShimHandler {
         // buffers first (a cgroup kill is a hard kill; reaping mid-flush risks
         // qcow2 corruption). Best-effort and idempotent.
         let result = self.graceful_stop();
-        crate::jailer::reap_sandbox(&self.box_id);
+        crate::jailer::reap_box(&self.box_id);
         result
     }
 

--- a/src/boxlite/tests/detach.rs
+++ b/src/boxlite/tests/detach.rs
@@ -21,6 +21,36 @@ fn pid_file_path(home_dir: &Path, box_id: &str) -> PathBuf {
     home_dir.join("boxes").join(box_id).join("shim.pid")
 }
 
+/// Count live processes whose argv references `box_id` (Linux `/proc` scan).
+///
+/// A detached box's whole tree — the outer bwrap launcher, the inner
+/// pid-namespace bwrap, the shim, and the VM — carries the unique box id in its
+/// bwrap bind paths, so this counts every process in the tree. Used to assert
+/// that the production reap path tears the *whole* tree down, not just the
+/// recorded outer-bwrap pid.
+#[cfg(target_os = "linux")]
+fn box_proc_count(box_id: &str) -> usize {
+    let mut count = 0;
+    let Ok(entries) = std::fs::read_dir("/proc") else {
+        return 0;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+        if name.parse::<u32>().is_err() {
+            continue; // not a pid dir
+        }
+        if let Ok(cmdline) = std::fs::read(entry.path().join("cmdline"))
+            && cmdline
+                .windows(box_id.len())
+                .any(|w| w == box_id.as_bytes())
+        {
+            count += 1;
+        }
+    }
+    count
+}
+
 // ============================================================================
 // DETACH MODE TESTS
 // ============================================================================
@@ -279,4 +309,52 @@ async fn detached_box_recoverable_after_restart() {
         // Cleanup
         runtime.remove(&box_id, false).await.unwrap();
     }
+}
+
+/// `runtime.remove(force)` on a detached box must reap its *entire* process
+/// tree. `kill_process` only signals the recorded outer bwrap; since #851
+/// dropped `--die-with-parent`, the inner pid-ns tree (inner bwrap + shim + VM)
+/// survives that. The production fix reaps the box's cgroup. This is the
+/// regression guard for the silent orphan VM that `boxlite rm -f` used to leave
+/// behind — note `PerTestBoxHome`'s `shim.pid`-based leak check can't see it
+/// (force-remove deletes the file), so the explicit `box_proc_count` is the
+/// real assertion here.
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn detached_box_force_remove_reaps_whole_tree() {
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+
+    let handle = runtime
+        .create(
+            boxlite::runtime::options::BoxOptions {
+                detach: true,
+                ..common::alpine_opts()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+    let _ = handle.exec(BoxCommand::new("sleep").args(["300"])).await;
+    let box_id = handle.id().to_string();
+
+    assert!(
+        box_proc_count(&box_id) > 0,
+        "detached box should have a live process tree after start"
+    );
+
+    // Production reap path.
+    runtime.remove(&box_id, true).await.unwrap();
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+    assert_eq!(
+        box_proc_count(&box_id),
+        0,
+        "force remove must reap the whole detached box tree \
+         (outer + inner bwrap + shim + VM), not just the recorded pid"
+    );
 }

--- a/src/boxlite/tests/detach.rs
+++ b/src/boxlite/tests/detach.rs
@@ -358,3 +358,53 @@ async fn detached_box_force_remove_reaps_whole_tree() {
          (outer + inner bwrap + shim + VM), not just the recorded pid"
     );
 }
+
+/// `box.stop()` on a detached box must reap the full process tree while
+/// preserving the box record and disk state for a later start.
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn detached_box_stop_reaps_whole_tree_and_keeps_box() {
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+
+    let handle = runtime
+        .create(
+            boxlite::runtime::options::BoxOptions {
+                detach: true,
+                ..common::alpine_opts()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+    let _ = handle.exec(BoxCommand::new("sleep").args(["300"])).await;
+    let box_id = handle.id().to_string();
+
+    assert!(
+        box_proc_count(&box_id) > 0,
+        "detached box should have a live process tree after start"
+    );
+
+    handle.stop().await.unwrap();
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+    assert_eq!(
+        box_proc_count(&box_id),
+        0,
+        "stop must reap the whole detached box tree \
+         (outer + inner bwrap + shim + VM), not just the recorded pid"
+    );
+
+    let info = runtime
+        .get_info(&box_id)
+        .await
+        .unwrap()
+        .expect("stopped box should still exist");
+    assert_eq!(info.status, BoxStatus::Stopped);
+
+    runtime.remove(&box_id, false).await.unwrap();
+}

--- a/src/boxlite/tests/detach.rs
+++ b/src/boxlite/tests/detach.rs
@@ -51,6 +51,19 @@ fn box_proc_count(box_id: &str) -> usize {
     count
 }
 
+#[cfg(target_os = "linux")]
+async fn wait_for_box_proc_count_zero(box_id: &str) -> usize {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    let mut count = box_proc_count(box_id);
+
+    while count != 0 && std::time::Instant::now() < deadline {
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        count = box_proc_count(box_id);
+    }
+
+    count
+}
+
 // ============================================================================
 // DETACH MODE TESTS
 // ============================================================================
@@ -339,7 +352,10 @@ async fn detached_box_force_remove_reaps_whole_tree() {
         )
         .await
         .unwrap();
-    let _ = handle.exec(BoxCommand::new("sleep").args(["300"])).await;
+    handle
+        .exec(BoxCommand::new("sleep").args(["300"]))
+        .await
+        .expect("start detached sleep workload");
     let box_id = handle.id().to_string();
 
     assert!(
@@ -349,11 +365,10 @@ async fn detached_box_force_remove_reaps_whole_tree() {
 
     // Production reap path.
     runtime.remove(&box_id, true).await.unwrap();
-    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    let proc_count = wait_for_box_proc_count_zero(&box_id).await;
 
     assert_eq!(
-        box_proc_count(&box_id),
-        0,
+        proc_count, 0,
         "force remove must reap the whole detached box tree \
          (outer + inner bwrap + shim + VM), not just the recorded pid"
     );
@@ -381,7 +396,10 @@ async fn detached_box_stop_reaps_whole_tree_and_keeps_box() {
         )
         .await
         .unwrap();
-    let _ = handle.exec(BoxCommand::new("sleep").args(["300"])).await;
+    handle
+        .exec(BoxCommand::new("sleep").args(["300"]))
+        .await
+        .expect("start detached sleep workload");
     let box_id = handle.id().to_string();
 
     assert!(
@@ -390,11 +408,10 @@ async fn detached_box_stop_reaps_whole_tree_and_keeps_box() {
     );
 
     handle.stop().await.unwrap();
-    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    let proc_count = wait_for_box_proc_count_zero(&box_id).await;
 
     assert_eq!(
-        box_proc_count(&box_id),
-        0,
+        proc_count, 0,
         "stop must reap the whole detached box tree \
          (outer + inner bwrap + shim + VM), not just the recorded pid"
     );


### PR DESCRIPTION
Reap detached boxes by cgroup on stop and force-remove so the VM process tree cannot survive after the box is stopped or deleted.

Test plan:
- [x] `cargo fmt --check`
- [x] `cargo test -p boxlite --features krun,gvproxy detached_box_force_remove_reaps_whole_tree -- --nocapture` as root on the VM test host
- [x] Root runner A/B check: recorded-pid SIGKILL leaked inner bwrap/shim processes; cgroup reap left 0 box processes
- [x] E2E local #174: https://github.com/boxlite-ai/boxlite/actions/runs/28287852262