### PR TITLE
feat(billing): Phase 2 — Rating + Wallet backend (draft)

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -21,6 +21,7 @@ import { ScheduleModule } from '@nestjs/schedule'
 import { EventEmitterModule } from '@nestjs/event-emitter'
 import { AnalyticsModule } from './analytics/analytics.module'
 import { UsageModule } from './usage/usage.module'
+import { BillingModule } from './billing/billing.module'
 import { OrganizationModule } from './organization/organization.module'
 import { EmailModule } from './email/email.module'
 import { TypedConfigService } from './config/typed-config.service'
@@ -171,6 +172,7 @@ import { BoxliteRestModule } from './boxlite-rest/boxlite-rest.module'
     ScheduleModule.forRoot(),
     AnalyticsModule,
     UsageModule,
+    BillingModule,
     OrganizationModule,
     RegionModule,
     AdminModule,

--- a/apps/api/src/billing/billing-webhook.controller.ts
+++ b/apps/api/src/billing/billing-webhook.controller.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Body, Controller, Headers, HttpCode, Post } from '@nestjs/common'
+import { ApiExcludeEndpoint } from '@nestjs/swagger'
+import { WebhookService, WebhookOutcome } from './payment/webhook.service'
+
+/**
+ * Public payment-provider webhook sink — NO auth guard; trust comes from the
+ * provider signature, which WebhookService verifies. Settlement is idempotent
+ * (processed_stripe_event PK), so the provider can safely retry.
+ *
+ * TODO(stripe): the real Stripe integration needs the RAW request body for
+ * signature verification — enable `rawBody` on the Nest app and read it here
+ * instead of the parsed JSON. With FakePaymentProvider the JSON body IS the
+ * normalized event, which is enough to exercise the settlement path in tests.
+ */
+@Controller('billing/webhook')
+export class BillingWebhookController {
+  constructor(private readonly webhooks: WebhookService) {}
+
+  @Post()
+  @HttpCode(200)
+  @ApiExcludeEndpoint()
+  async ingest(
+    @Body() body: unknown,
+    @Headers('stripe-signature') signature = '',
+  ): Promise<{ outcome: WebhookOutcome }> {
+    const raw = Buffer.from(JSON.stringify(body ?? {}))
+    return { outcome: await this.webhooks.ingest(raw, signature) }
+  }
+}

--- a/apps/api/src/billing/billing.controller.ts
+++ b/apps/api/src/billing/billing.controller.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Body, Controller, Get, Post, UseGuards } from '@nestjs/common'
+import { ApiOAuth2, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger'
+import { CombinedAuthGuard } from '../auth/combined-auth.guard'
+import { AuthContext } from '../common/decorators/auth-context.decorator'
+import { AuthContext as IAuthContext } from '../common/interfaces/auth-context.interface'
+import { AuthenticatedRateLimitGuard } from '../common/guards/authenticated-rate-limit.guard'
+import { OrganizationResourceActionGuard } from '../organization/guards/organization-resource-action.guard'
+import { TopUpCheckoutDto, TopUpRequestDto, WalletResponseDto } from './dto/wallet.dto'
+import { TopUpService } from './payment/top-up.service'
+import { PricingService } from './rating/pricing.service'
+import { WalletService } from './wallet/wallet.service'
+
+/**
+ * Org-scoped wallet API. The org comes from the authenticated context (not a
+ * path param), matching the rest of the API. Read + top-up only: granting free
+ * credit is an admin operation and is intentionally NOT exposed here (a member
+ * must never be able to credit their own wallet).
+ */
+@ApiTags('billing')
+@Controller('billing')
+@UseGuards(CombinedAuthGuard, OrganizationResourceActionGuard, AuthenticatedRateLimitGuard)
+@ApiOAuth2(['openid', 'profile', 'email'])
+export class BillingController {
+  constructor(
+    private readonly wallet: WalletService,
+    private readonly pricing: PricingService,
+    private readonly topUp: TopUpService,
+  ) {}
+
+  @Get('wallet')
+  @ApiOperation({ summary: "Get the organization's wallet balance + billing status", operationId: 'getWallet' })
+  @ApiResponse({ status: 200, type: WalletResponseDto })
+  async getWallet(@AuthContext() ctx: IAuthContext): Promise<WalletResponseDto> {
+    const warnThresholdCents = await this.pricing.warnThresholdCents()
+    const view = await this.wallet.getView(ctx.organizationId!, warnThresholdCents)
+    // TODO: surface the org display name (OrganizationService) instead of the id.
+    return WalletResponseDto.fromView(view, ctx.organizationId!)
+  }
+
+  @Post('wallet/top-up')
+  @ApiOperation({ summary: 'Start a manual wallet top-up (returns a checkout URL)', operationId: 'topUpWallet' })
+  @ApiResponse({ status: 201, type: TopUpCheckoutDto })
+  async startTopUp(@AuthContext() ctx: IAuthContext, @Body() body: TopUpRequestDto): Promise<TopUpCheckoutDto> {
+    return this.topUp.createCheckout(ctx.organizationId!, body.amountCents)
+  }
+}

--- a/apps/api/src/billing/billing.integration.spec.ts
+++ b/apps/api/src/billing/billing.integration.spec.ts
@@ -1,0 +1,182 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ *
+ * Real-Postgres integration test for Phase 2 billing. Skipped by default (no DB
+ * in CI); run against the local docker billing-pg with:
+ *
+ *   RUN_DB_IT=1 npx nx test api --testPathPatterns=billing.integration --skip-nx-cache
+ *
+ * It runs the Phase-2 migration, then exercises rating + wallet + webhook against
+ * the live schema so the DB-level guarantees (CHECK, UNIQUE idempotency,
+ * pessimistic-locked debit) are verified, not just the pure logic.
+ */
+
+import { DataSource, QueryFailedError } from 'typeorm'
+import { UsagePeriod } from '../usage/entities/usage-period.entity'
+import { CreditGrant } from './entities/credit-grant.entity'
+import { CustomerRateOverride } from './entities/customer-rate-override.entity'
+import { PricingPlan } from './entities/pricing-plan.entity'
+import { ProcessedStripeEvent } from './entities/processed-stripe-event.entity'
+import { RatedPeriod } from './entities/rated-period.entity'
+import { TopUpRecord } from './entities/top-up-record.entity'
+import { Wallet } from './entities/wallet.entity'
+import { WalletTransaction } from './entities/wallet-transaction.entity'
+import { Migration1782500000000 } from '../migrations/pre-deploy/1782500000000-migration'
+import { FakePaymentProvider } from './payment/fake-payment-provider'
+import { WebhookService } from './payment/webhook.service'
+import { RatingService } from './rating/rating.service'
+import { WalletService } from './wallet/wallet.service'
+
+const dbDescribe = process.env.RUN_DB_IT ? describe : describe.skip
+
+const PHASE2_TABLES = [
+  'top_up_record',
+  'processed_stripe_event',
+  'credit_grant',
+  'wallet_transaction',
+  'wallet',
+  'rated_period',
+  'customer_rate_override',
+  'pricing_plan',
+]
+
+dbDescribe('Phase 2 billing — real Postgres', () => {
+  let ds: DataSource
+
+  beforeAll(async () => {
+    ds = new DataSource({
+      type: 'postgres',
+      host: process.env.DB_HOST ?? 'localhost',
+      port: Number(process.env.DB_PORT ?? 5433),
+      username: process.env.DB_USERNAME ?? 'daytona',
+      password: process.env.DB_PASSWORD ?? 'daytona',
+      database: process.env.DB_DATABASE ?? 'daytona',
+      entities: [
+        PricingPlan,
+        CustomerRateOverride,
+        RatedPeriod,
+        Wallet,
+        WalletTransaction,
+        CreditGrant,
+        ProcessedStripeEvent,
+        TopUpRecord,
+        UsagePeriod,
+      ],
+      synchronize: false,
+    })
+    await ds.initialize()
+
+    const qr = ds.createQueryRunner()
+    // Clean slate for the Phase-2 tables, then run the migration under test.
+    for (const t of PHASE2_TABLES) await qr.query(`DROP TABLE IF EXISTS "${t}" CASCADE`)
+    await new Migration1782500000000().up(qr)
+    // usage_period (Phase 1) is the rating input; ensure it exists for a self-contained run.
+    await qr.query(`CREATE EXTENSION IF NOT EXISTS "uuid-ossp"`)
+    await qr.query(`CREATE TABLE IF NOT EXISTS "usage_period" (
+      "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+      "boxId" varchar NOT NULL, "organizationId" varchar NOT NULL, "region" varchar,
+      "periodStart" timestamptz NOT NULL, "periodEnd" timestamptz,
+      "kind" varchar NOT NULL, "allocCpu" int NOT NULL, "allocMemGib" int NOT NULL, "allocDiskGib" int NOT NULL,
+      "actualCpuSeconds" double precision, "actualRssAvgBytes" bigint, "actualRssPeakBytes" bigint,
+      "sampleCount" int, "sealed" boolean DEFAULT true,
+      "createdAt" timestamptz NOT NULL DEFAULT now(), "updatedAt" timestamptz NOT NULL DEFAULT now(),
+      CONSTRAINT "usage_period_id_pk2" PRIMARY KEY ("id"))`)
+    await qr.query(`DELETE FROM "usage_period" WHERE "organizationId" = 'it-org'`)
+    await qr.release()
+  }, 60000)
+
+  afterAll(async () => {
+    if (!ds?.isInitialized) return
+    const qr = ds.createQueryRunner()
+    for (const t of PHASE2_TABLES) await qr.query(`DROP TABLE IF EXISTS "${t}" CASCADE`)
+    await qr.query(`DELETE FROM "usage_period" WHERE "organizationId" = 'it-org'`)
+    await qr.release()
+    await ds.destroy()
+  })
+
+  it('enforces the wallet CHECK constraints (free/paid >= 0)', async () => {
+    const wallet = await ds.getRepository(Wallet).save({ organizationId: 'it-chk', freeBalanceCents: '0' })
+    await expect(ds.getRepository(Wallet).update(wallet.id, { freeBalanceCents: '-1' })).rejects.toBeInstanceOf(
+      QueryFailedError,
+    )
+  })
+
+  it('rates a closed usage period exactly once (UNIQUE idempotency)', async () => {
+    await ds.getRepository(PricingPlan).save({
+      version: 1,
+      cpuRateCentsPerSec: '2',
+      memRateCentsPerSec: '1',
+      diskRateCentsPerSec: '0.5',
+      warnThresholdCents: '500',
+      defaultGrantCents: '0',
+      effectiveFrom: new Date('2026-01-01T00:00:00Z'),
+      effectiveTo: null,
+    })
+    // 60s running, alloc 2cpu/4ram/10disk → 60×(4+4+5) = 780 cents
+    await ds.query(
+      `INSERT INTO "usage_period" ("boxId","organizationId","periodStart","periodEnd","kind","allocCpu","allocMemGib","allocDiskGib")
+       VALUES ('box-it','it-org','2026-06-27T00:00:00Z','2026-06-27T00:01:00Z','running',2,4,10)`,
+    )
+
+    const rating = new RatingService(
+      ds.getRepository(UsagePeriod),
+      ds.getRepository(RatedPeriod),
+      ds.getRepository(PricingPlan),
+      ds.getRepository(CustomerRateOverride),
+    )
+
+    const first = await rating.rateClosedPeriods()
+    expect(first.rated).toBe(1)
+    const rated = await ds.getRepository(RatedPeriod).findOneByOrFail({ organizationId: 'it-org' })
+    expect(rated.ratedCents).toBe('780')
+    expect(rated.pricingVersion).toBe(1)
+
+    // re-run the sweep — the UNIQUE(usagePeriodId) makes it a no-op, no double bill
+    const second = await rating.rateClosedPeriods()
+    expect(second.rated).toBe(0)
+    expect(await ds.getRepository(RatedPeriod).countBy({ organizationId: 'it-org' })).toBe(1)
+  })
+
+  it('runs the dual-pool wallet end to end (grant → debit → overage)', async () => {
+    const wallet = new WalletService(ds)
+    await wallet.grant('it-wallet', 300, { reason: 'trial', operatorId: 'system' }) // free pool 300
+    await wallet.topUp('it-wallet', 500) // paid pool 500 → balance 800
+
+    const afterDebit = await wallet.debit('it-wallet', 400, { source: 'usage', ratedPeriodId: null })
+    expect(afterDebit).toEqual({ balanceCents: 400, freeBalanceCents: 0, paidBalanceCents: 400 })
+
+    // overdraw both pools → bounded negative, CHECK keeps pools at 0
+    const afterOverage = await wallet.debit('it-wallet', 1000, { source: 'usage', ratedPeriodId: null })
+    expect(afterOverage.balanceCents).toBe(-600)
+    expect(afterOverage.freeBalanceCents).toBe(0)
+    expect(afterOverage.paidBalanceCents).toBe(0)
+
+    // ledger sums to the balance
+    const rows = await ds.getRepository(WalletTransaction).find({ where: {} })
+    const w = await ds.getRepository(Wallet).findOneByOrFail({ organizationId: 'it-wallet' })
+    const sum = rows
+      .filter((r) => r.walletId === w.id)
+      .reduce((s, r) => s + (r.direction === 'inbound' ? Number(r.amountCents) : -Number(r.amountCents)), 0)
+    expect(sum).toBe(Number(w.balanceCents))
+  })
+
+  it('settles a webhook top-up exactly once (processed_stripe_event idempotency)', async () => {
+    const wallet = new WalletService(ds)
+    const webhooks = new WebhookService(ds, wallet, new FakePaymentProvider())
+    const event = Buffer.from(
+      JSON.stringify({
+        eventId: 'evt_it_1',
+        type: 'topup.succeeded',
+        organizationId: 'it-hook',
+        amountCents: 1000,
+        providerRef: 'cs_it',
+      }),
+    )
+
+    expect(await webhooks.ingest(event, 'sig')).toBe('processed')
+    expect(await webhooks.ingest(event, 'sig')).toBe('duplicate') // re-delivery
+    const w = await ds.getRepository(Wallet).findOneByOrFail({ organizationId: 'it-hook' })
+    expect(Number(w.balanceCents)).toBe(1000) // credited once, not twice
+  })
+})

--- a/apps/api/src/billing/billing.module.ts
+++ b/apps/api/src/billing/billing.module.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Module } from '@nestjs/common'
+import { TypeOrmModule } from '@nestjs/typeorm'
+import { OrganizationModule } from '../organization/organization.module'
+import { UsagePeriod } from '../usage/entities/usage-period.entity'
+import { BillingController } from './billing.controller'
+import { BillingWebhookController } from './billing-webhook.controller'
+import { CreditGrant } from './entities/credit-grant.entity'
+import { CustomerRateOverride } from './entities/customer-rate-override.entity'
+import { PricingPlan } from './entities/pricing-plan.entity'
+import { ProcessedStripeEvent } from './entities/processed-stripe-event.entity'
+import { RatedPeriod } from './entities/rated-period.entity'
+import { TopUpRecord } from './entities/top-up-record.entity'
+import { Wallet } from './entities/wallet.entity'
+import { WalletTransaction } from './entities/wallet-transaction.entity'
+import { FakePaymentProvider } from './payment/fake-payment-provider'
+import { PAYMENT_PROVIDER } from './payment/payment-provider.interface'
+import { TopUpService } from './payment/top-up.service'
+import { WebhookService } from './payment/webhook.service'
+import { PricingService } from './rating/pricing.service'
+import { RatingService } from './rating/rating.service'
+import { WalletService } from './wallet/wallet.service'
+
+/**
+ * Phase 2 billing: rates closed usage periods (RatingService) and runs the
+ * dual-pool wallet (WalletService) + payment seam (Fake provider tonight,
+ * Stripe later). OrganizationModule satisfies the controller guard deps (same
+ * reason UsageModule imports it). UsagePeriod is read-only here — the rating
+ * sweep consumes it.
+ */
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([
+      PricingPlan,
+      CustomerRateOverride,
+      RatedPeriod,
+      Wallet,
+      WalletTransaction,
+      CreditGrant,
+      ProcessedStripeEvent,
+      TopUpRecord,
+      UsagePeriod,
+    ]),
+    OrganizationModule,
+  ],
+  controllers: [BillingController, BillingWebhookController],
+  providers: [
+    RatingService,
+    PricingService,
+    WalletService,
+    WebhookService,
+    TopUpService,
+    { provide: PAYMENT_PROVIDER, useClass: FakePaymentProvider },
+  ],
+  exports: [RatingService, WalletService],
+})
+export class BillingModule {}

--- a/apps/api/src/billing/dto/wallet.dto.ts
+++ b/apps/api/src/billing/dto/wallet.dto.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger'
+import { IsInt, IsOptional, IsPositive, IsString, MaxLength } from 'class-validator'
+import { BillingStatus } from '../wallet/wallet-math'
+import { WalletView } from '../wallet/wallet.service'
+
+/**
+ * Mirrors the dashboard `OrganizationWallet` contract. The first block is the
+ * frozen, already-shipped shape; the Phase-2 dual-pool fields are added as
+ * OPTIONAL so the existing UI keeps working unchanged.
+ */
+export class WalletResponseDto {
+  @ApiProperty() balanceCents: number
+  @ApiProperty() ongoingBalanceCents: number
+  @ApiProperty() name: string
+  @ApiProperty() creditCardConnected: boolean
+
+  @ApiPropertyOptional() freeBalanceCents?: number
+  @ApiPropertyOptional() paidBalanceCents?: number
+  @ApiPropertyOptional({ enum: ['trial', 'active', 'low_balance', 'zero_balance', 'suspended', 'closed'] })
+  billingStatus?: BillingStatus
+  @ApiPropertyOptional() hasFailedOrPendingInvoice?: boolean
+
+  static fromView(view: WalletView, name: string): WalletResponseDto {
+    return {
+      balanceCents: view.balanceCents,
+      ongoingBalanceCents: view.balanceCents, // ongoing-estimate refresh job deferred to M2
+      name,
+      creditCardConnected: view.creditCardConnected,
+      freeBalanceCents: view.freeBalanceCents,
+      paidBalanceCents: view.paidBalanceCents,
+      billingStatus: view.billingStatus,
+      hasFailedOrPendingInvoice: false,
+    }
+  }
+}
+
+export class TopUpRequestDto {
+  @ApiProperty({ description: 'Amount to top up, in cents' })
+  @IsInt()
+  @IsPositive()
+  amountCents: number
+}
+
+export class TopUpCheckoutDto {
+  @ApiProperty({ description: 'Provider checkout URL to redirect the user to' })
+  url: string
+}
+
+export class GrantRequestDto {
+  @ApiProperty({ description: 'Free credit to grant, in cents' })
+  @IsInt()
+  @IsPositive()
+  amountCents: number
+
+  @ApiProperty()
+  @IsString()
+  @MaxLength(200)
+  reason: string
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  @MaxLength(1000)
+  note?: string
+}
+
+export class WalletBalancesDto {
+  @ApiProperty() balanceCents: number
+  @ApiProperty() freeBalanceCents: number
+  @ApiProperty() paidBalanceCents: number
+}

--- a/apps/api/src/billing/dto/wallet.dto.ts
+++ b/apps/api/src/billing/dto/wallet.dto.ts
@@ -4,7 +4,10 @@
  */
 
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger'
-import { IsInt, IsOptional, IsPositive, IsString, MaxLength } from 'class-validator'
+import { IsInt, IsOptional, IsPositive, IsString, Max, MaxLength } from 'class-validator'
+
+/** Upper bound on a single top-up: $1,000,000. Guards against fat-finger / abuse amounts. */
+const MAX_TOP_UP_CENTS = 100_000_000
 import { BillingStatus } from '../wallet/wallet-math'
 import { WalletView } from '../wallet/wallet.service'
 
@@ -43,6 +46,7 @@ export class TopUpRequestDto {
   @ApiProperty({ description: 'Amount to top up, in cents' })
   @IsInt()
   @IsPositive()
+  @Max(MAX_TOP_UP_CENTS)
   amountCents: number
 }
 

--- a/apps/api/src/billing/entities/credit-grant.entity.ts
+++ b/apps/api/src/billing/entities/credit-grant.entity.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn } from 'typeorm'
+import { Pool } from '../wallet/wallet-math'
+
+export type GrantType = 'grant' | 'revoke'
+
+/**
+ * A support-initiated balance adjustment (PRD L-3/L-4). Immutable audit record —
+ * a grant and its revoke are two separate rows, never an in-place edit
+ * (OpenMeter VoidGrant). The actual money movement is a corresponding
+ * `wallet_transaction`; this table is the "who/why" trail.
+ */
+@Entity()
+@Index('credit_grant_org_idx', ['organizationId', 'createdAt'])
+export class CreditGrant {
+  @PrimaryGeneratedColumn('uuid')
+  id: string
+
+  @Column()
+  organizationId: string
+
+  @Column({ type: 'bigint' })
+  amountCents: string
+
+  @Column({ type: 'varchar' })
+  type: GrantType
+
+  @Column({ type: 'varchar' })
+  pool: Pool
+
+  @Column()
+  reason: string
+
+  @Column({ type: 'text', nullable: true })
+  note: string | null
+
+  @Column()
+  operatorId: string
+
+  @Column({ type: 'timestamptz', nullable: true })
+  expiresAt: Date | null
+
+  /** The ledger row this grant produced. */
+  @Column({ type: 'uuid', nullable: true })
+  walletTransactionId: string | null
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt: Date
+}

--- a/apps/api/src/billing/entities/customer-rate-override.entity.ts
+++ b/apps/api/src/billing/entities/customer-rate-override.entity.ts
@@ -3,11 +3,12 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn } from 'typeorm'
+import { Check, Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn } from 'typeorm'
 
 /** Per-customer rate override (PRD §13.1 P-2). `effectiveRates` beats `discountFactor`. */
 @Entity()
 @Index('rate_override_org_active_idx', ['organizationId'], { unique: true, where: '"effectiveTo" IS NULL' })
+@Check('rate_override_discount_range', '"discountFactor" IS NULL OR ("discountFactor" >= 0 AND "discountFactor" <= 1)')
 export class CustomerRateOverride {
   @PrimaryGeneratedColumn('uuid')
   id: string

--- a/apps/api/src/billing/entities/customer-rate-override.entity.ts
+++ b/apps/api/src/billing/entities/customer-rate-override.entity.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn } from 'typeorm'
+
+/** Per-customer rate override (PRD §13.1 P-2). `effectiveRates` beats `discountFactor`. */
+@Entity()
+@Index('rate_override_org_active_idx', ['organizationId'], { unique: true, where: '"effectiveTo" IS NULL' })
+export class CustomerRateOverride {
+  @PrimaryGeneratedColumn('uuid')
+  id: string
+
+  @Column()
+  organizationId: string
+
+  /** e.g. 0.85 = 15% off list. */
+  @Column({ type: 'numeric', precision: 6, scale: 5, nullable: true })
+  discountFactor: string | null
+
+  /** Full per-second rate replacement (cents/sec) — wins over discountFactor. */
+  @Column({ type: 'jsonb', nullable: true })
+  effectiveRates: { cpu: string; mem: string; disk: string } | null
+
+  @Column({ type: 'timestamptz' })
+  effectiveFrom: Date
+
+  @Column({ type: 'timestamptz', nullable: true })
+  effectiveTo: Date | null
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt: Date
+}

--- a/apps/api/src/billing/entities/pricing-plan.entity.ts
+++ b/apps/api/src/billing/entities/pricing-plan.entity.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn } from 'typeorm'
+
+/**
+ * A versioned pricing snapshot (canon I7). Rates are cents-per-unit-second as
+ * numeric strings (sub-cent allowed). Changing a price = INSERT a new version +
+ * stamp `effectiveTo` on the old one; rate columns are NEVER updated, so a
+ * historical bill always re-computes to the same number. "active" is derived
+ * (`effectiveFrom <= now < effectiveTo`), not stored — OpenMeter StatusAt.
+ */
+@Entity()
+@Index('pricing_plan_version_idx', ['version'], { unique: true })
+@Index('pricing_plan_effective_idx', ['effectiveFrom'])
+export class PricingPlan {
+  @PrimaryGeneratedColumn('uuid')
+  id: string
+
+  /** Monotonic version; INSERT a new row to change price. */
+  @Column({ type: 'int' })
+  version: number
+
+  // ---- per-second rates (cents, sub-cent allowed) — frozen, never updated ----
+  @Column({ type: 'numeric', precision: 30, scale: 10 })
+  cpuRateCentsPerSec: string
+
+  @Column({ type: 'numeric', precision: 30, scale: 10 })
+  memRateCentsPerSec: string
+
+  @Column({ type: 'numeric', precision: 30, scale: 10 })
+  diskRateCentsPerSec: string
+
+  // ---- wallet/trial knobs (PRD §13.1 P-1) ----
+  @Column({ type: 'bigint' })
+  warnThresholdCents: string
+
+  @Column({ type: 'bigint' })
+  defaultGrantCents: string
+
+  // ---- effective window ----
+  @Column({ type: 'timestamptz' })
+  effectiveFrom: Date
+
+  /** `null` = current version; stamped when a newer version supersedes it. */
+  @Column({ type: 'timestamptz', nullable: true })
+  effectiveTo: Date | null
+
+  @Column({ nullable: true })
+  createdBy: string
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt: Date
+}

--- a/apps/api/src/billing/entities/processed-stripe-event.entity.ts
+++ b/apps/api/src/billing/entities/processed-stripe-event.entity.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Column, CreateDateColumn, Entity, PrimaryColumn } from 'typeorm'
+
+/**
+ * Webhook idempotency ledger (Stripe official guidance: "log event IDs, don't
+ * reprocess"). The Stripe event id is the PK; inserting it in the same
+ * transaction as the balance change means a duplicate webhook hits the unique
+ * key, rolls the transaction back, and never double-credits the wallet.
+ */
+@Entity()
+export class ProcessedStripeEvent {
+  @PrimaryColumn({ type: 'text' })
+  stripeEventId: string
+
+  @Column({ type: 'text' })
+  eventType: string
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  processedAt: Date
+}

--- a/apps/api/src/billing/entities/rated-period.entity.ts
+++ b/apps/api/src/billing/entities/rated-period.entity.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn } from 'typeorm'
+
+/** The frozen rates a rated period was computed against (≈ OpenMeter SnapshotLineQuantity). */
+export interface FrozenUnitRates {
+  cpuRateCentsPerSec: string
+  memRateCentsPerSec: string
+  diskRateCentsPerSec: string
+  discountFactor: string
+}
+
+/**
+ * The output of rating one Phase-1 `usage_period`: raw seconds × a frozen rate
+ * snapshot = USD. `usagePeriodId` is UNIQUE so re-running the rating sweep is
+ * idempotent (one usage period → at most one rated row). Reads never join the
+ * live pricing plan — `unitRates` is the source of truth, so price changes can't
+ * move a historical bill.
+ */
+@Entity()
+@Index('rated_period_usage_period_idx', ['usagePeriodId'], { unique: true })
+@Index('rated_period_org_rated_at_idx', ['organizationId', 'ratedAt'])
+export class RatedPeriod {
+  @PrimaryGeneratedColumn('uuid')
+  id: string
+
+  /** The Phase-1 usage_period this rates. UNIQUE → idempotent rating. */
+  @Column()
+  usagePeriodId: string
+
+  @Column()
+  organizationId: string
+
+  @Column()
+  boxId: string
+
+  /** Pricing plan version in force when the usage happened. */
+  @Column({ type: 'int' })
+  pricingVersion: number
+
+  /** Frozen per-second rates + discount (defensive copy — never re-joined). */
+  @Column({ type: 'jsonb' })
+  unitRates: FrozenUnitRates
+
+  /** Billed seconds carried from Phase 1 (kept for auditability). */
+  @Column({ type: 'numeric', precision: 30, scale: 5 })
+  billedSeconds: string
+
+  /** Sub-cent precise value (Lago precise_amount_cents) — keeps accumulation honest. */
+  @Column({ type: 'numeric', precision: 30, scale: 5 })
+  preciseCents: string
+
+  /** Whole cents actually billed (round-half-up of preciseCents). */
+  @Column({ type: 'bigint' })
+  ratedCents: string
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  ratedAt: Date
+}

--- a/apps/api/src/billing/entities/rated-period.entity.ts
+++ b/apps/api/src/billing/entities/rated-period.entity.ts
@@ -28,7 +28,7 @@ export class RatedPeriod {
   id: string
 
   /** The Phase-1 usage_period this rates. UNIQUE → idempotent rating. */
-  @Column()
+  @Column({ type: 'uuid' })
   usagePeriodId: string
 
   @Column()

--- a/apps/api/src/billing/entities/top-up-record.entity.ts
+++ b/apps/api/src/billing/entities/top-up-record.entity.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm'
+
+export type TopUpMethod = 'manual' | 'auto'
+export type TopUpStatus = 'pending' | 'paid' | 'failed'
+
+/**
+ * A top-up intent (PRD J8). Two-stage (Stripe): the row is `pending` at intent
+ * creation — the wallet balance does NOT move — and flips to `paid` only when the
+ * provider webhook confirms, at which point the linked `wallet_transaction`
+ * settles. `failed` carries no money movement (auto-reload failure degrades back
+ * to low_balance, never debt).
+ */
+@Entity()
+@Index('top_up_org_idx', ['organizationId', 'createdAt'])
+export class TopUpRecord {
+  @PrimaryGeneratedColumn('uuid')
+  id: string
+
+  @Column()
+  organizationId: string
+
+  @Column({ type: 'bigint' })
+  amountCents: string
+
+  @Column({ type: 'varchar' })
+  method: TopUpMethod
+
+  @Column({ type: 'varchar', default: 'pending' })
+  status: TopUpStatus
+
+  /** The (pending → settled) ledger row this intent will settle. */
+  @Column({ type: 'uuid', nullable: true })
+  walletTransactionId: string | null
+
+  // ---- Stripe seam ----
+  @Column({ type: 'text', nullable: true })
+  stripeSessionId: string | null
+
+  @Column({ type: 'text', nullable: true })
+  stripePaymentIntentId: string | null
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt: Date
+
+  @UpdateDateColumn({ type: 'timestamptz' })
+  updatedAt: Date
+}

--- a/apps/api/src/billing/entities/wallet-transaction.entity.ts
+++ b/apps/api/src/billing/entities/wallet-transaction.entity.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Check, Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn } from 'typeorm'
+import { Pool } from '../wallet/wallet-math'
+
+export type TxDirection = 'inbound' | 'outbound'
+export type TxStatus = 'pending' | 'settled' | 'failed'
+export type TxSource = 'manual' | 'threshold' | 'usage' | 'grant' | 'refund' | 'chargeback'
+
+/**
+ * Append-only wallet ledger (Lago's core). Every credit (top-up/grant) and debit
+ * (usage) is a row; nothing is ever updated except `remainingCents` (a credit lot
+ * burning down) and `voidedAt` (a reversal stamp — Lago/OpenMeter never delete).
+ * Inbound rows carry `remainingCents` + `expiresAt` and burn in `priority` order
+ * (free=1, paid=2). The wallet's materialized balance is `SUM` of these rows.
+ */
+@Entity()
+@Index('wallet_tx_wallet_idx', ['walletId', 'createdAt'])
+@Index('wallet_tx_provider_event_idx', ['providerEventId'], { unique: true, where: '"providerEventId" IS NOT NULL' })
+@Check('wallet_tx_remaining_non_negative', '"remainingCents" IS NULL OR "remainingCents" >= 0')
+export class WalletTransaction {
+  @PrimaryGeneratedColumn('uuid')
+  id: string
+
+  @Column()
+  walletId: string
+
+  @Column({ type: 'varchar' })
+  pool: Pool
+
+  /** Consumption order: free=1, paid=2 (lower drains first). */
+  @Column({ type: 'int' })
+  priority: number
+
+  @Column({ type: 'varchar' })
+  direction: TxDirection
+
+  @Column({ type: 'bigint' })
+  amountCents: string
+
+  /** Inbound only: remaining spendable balance of this lot (burns toward 0). */
+  @Column({ type: 'bigint', nullable: true })
+  remainingCents: string | null
+
+  /** Inbound free lots only: when this credit lapses. */
+  @Column({ type: 'timestamptz', nullable: true })
+  expiresAt: Date | null
+
+  @Column({ type: 'varchar', default: 'settled' })
+  status: TxStatus
+
+  @Column({ type: 'varchar' })
+  source: TxSource
+
+  /** Outbound only: which rated period this debit paid for. */
+  @Column({ type: 'uuid', nullable: true })
+  ratedPeriodId: string | null
+
+  /** Reversal stamp — set instead of deleting the row. */
+  @Column({ type: 'timestamptz', nullable: true })
+  voidedAt: Date | null
+
+  /** Stripe charge/refund reference (the payment-provider seam). */
+  @Column({ type: 'text', nullable: true })
+  stripeRef: string | null
+
+  /** Provider webhook event id — UNIQUE (partial) for idempotent ingest. */
+  @Column({ type: 'text', nullable: true })
+  providerEventId: string | null
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt: Date
+}

--- a/apps/api/src/billing/entities/wallet.entity.ts
+++ b/apps/api/src/billing/entities/wallet.entity.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Check, Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm'
+import { StoredBillingStatus } from '../wallet/wallet-math'
+
+/**
+ * The org's USD wallet — two pools (free → paid). Balances here are a
+ * materialized cache of `SUM(wallet_transaction)`; the transaction ledger is the
+ * source of truth. `lockVersion` gives optimistic concurrency (Lago lock_version):
+ * a debit reads the version, computes, then `UPDATE ... WHERE lockVersion = ?`,
+ * retrying on conflict — never last-write-wins. Only `{trial,active,suspended,
+ * closed}` are stored; `low_balance`/`zero_balance` are derived from the balance
+ * so they can't drift (OpenMeter StatusAt).
+ */
+@Entity()
+@Index('wallet_org_idx', ['organizationId'], { unique: true })
+@Check('wallet_free_non_negative', '"freeBalanceCents" >= 0')
+@Check('wallet_paid_non_negative', '"paidBalanceCents" >= 0')
+export class Wallet {
+  @PrimaryGeneratedColumn('uuid')
+  id: string
+
+  @Column()
+  organizationId: string
+
+  /** = free + paid (settled). Materialized; truth is SUM(transactions). */
+  @Column({ type: 'bigint', default: 0 })
+  balanceCents: string
+
+  /** Includes an estimate of unsettled open-period usage (Lago ongoing_balance). */
+  @Column({ type: 'bigint', default: 0 })
+  ongoingBalanceCents: string
+
+  @Column({ type: 'bigint', default: 0 })
+  freeBalanceCents: string
+
+  @Column({ type: 'bigint', default: 0 })
+  paidBalanceCents: string
+
+  /** Free-pool overall expiry (per-lot expiry lives on the transactions). */
+  @Column({ type: 'timestamptz', nullable: true })
+  freeExpiresAt: Date | null
+
+  @Column({ type: 'varchar', default: 'trial' })
+  billingStatus: StoredBillingStatus
+
+  /** Risk-control freeze — orthogonal to balance (Lago expiration/alert split). */
+  @Column({ type: 'boolean', default: false })
+  frozen: boolean
+
+  /** Optimistic-lock token; bumped on every balance mutation. */
+  @Column({ type: 'int', default: 0 })
+  lockVersion: number
+
+  // ---- auto-reload (PRD §7.3) ----
+  @Column({ type: 'bigint', nullable: true })
+  autoTopupThresholdCents: string | null
+
+  @Column({ type: 'bigint', nullable: true })
+  autoTopupTargetCents: string | null
+
+  /** True once a reusable off-session payment method is stored (Stripe SetupIntent). */
+  @Column({ type: 'boolean', default: false })
+  creditCardConnected: boolean
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt: Date
+
+  @UpdateDateColumn({ type: 'timestamptz' })
+  updatedAt: Date
+}

--- a/apps/api/src/billing/payment/fake-payment-provider.ts
+++ b/apps/api/src/billing/payment/fake-payment-provider.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Injectable } from '@nestjs/common'
+import {
+  ChargeResult,
+  ChargeSavedMethodInput,
+  CreateTopUpIntentInput,
+  PaymentProvider,
+  RefundInput,
+  RefundResult,
+  SaveMethodSetupInput,
+  SaveMethodSetupResult,
+  TopUpIntentResult,
+  VerifiedWebhookEvent,
+} from './payment-provider.interface'
+
+/**
+ * In-memory payment provider for tests + local dev. No network, no signature
+ * check: `createTopUpIntent` hands back a fake checkout url, and `parseWebhook`
+ * just JSON-parses a hand-built event so tests can drive the settlement path
+ * (top-up confirmed / refund / saved method) directly. The real StripeProvider
+ * implements the same interface; nothing in WalletService changes.
+ */
+@Injectable()
+export class FakePaymentProvider implements PaymentProvider {
+  async createTopUpIntent(input: CreateTopUpIntentInput): Promise<TopUpIntentResult> {
+    const ref = `fake_cs_${input.idempotencyKey}`
+    return { redirectUrl: `https://fake-checkout.local/${ref}`, providerRef: ref, status: 'processing' }
+  }
+
+  async chargeSavedMethod(input: ChargeSavedMethodInput): Promise<ChargeResult> {
+    return { providerRef: `fake_pi_${input.idempotencyKey}`, status: 'succeeded' }
+  }
+
+  async refund(input: RefundInput): Promise<RefundResult> {
+    return { providerRef: `fake_re_${input.idempotencyKey}`, status: 'succeeded' }
+  }
+
+  async setupSaveMethod(input: SaveMethodSetupInput): Promise<SaveMethodSetupResult> {
+    const ref = `fake_seti_${input.organizationId}`
+    return { redirectUrl: `https://fake-setup.local/${ref}`, providerRef: ref }
+  }
+
+  /** No signature verification — the raw body IS the normalized event (test driver). */
+  parseWebhook(rawBody: Buffer, _signature: string): VerifiedWebhookEvent {
+    return JSON.parse(rawBody.toString('utf8')) as VerifiedWebhookEvent
+  }
+}

--- a/apps/api/src/billing/payment/payment-provider.interface.ts
+++ b/apps/api/src/billing/payment/payment-provider.interface.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+/**
+ * The payment-provider seam. The provider only understands *money movement*
+ * (checkout, charge a saved card, refund, verify a webhook); all dual-pool
+ * wallet logic lives in WalletService. This lets us run the whole billing loop
+ * tonight against a FakeProvider and drop in a real StripeProvider later without
+ * touching wallet code.
+ */
+export const PAYMENT_PROVIDER = Symbol('PAYMENT_PROVIDER')
+
+export interface CreateTopUpIntentInput {
+  organizationId: string
+  amountCents: number
+  /** Our idempotency key, derived from the top_up_record id. */
+  idempotencyKey: string
+  successUrl: string
+  cancelUrl: string
+}
+
+export interface TopUpIntentResult {
+  /** Where to send the user to pay (Stripe Checkout url). */
+  redirectUrl: string
+  /** Provider-side handle (Checkout Session id) for later reconciliation. */
+  providerRef: string
+  status: 'processing'
+}
+
+export interface ChargeSavedMethodInput {
+  organizationId: string
+  amountCents: number
+  idempotencyKey: string
+}
+
+export interface ChargeResult {
+  providerRef: string
+  status: 'succeeded' | 'failed'
+}
+
+export interface RefundInput {
+  providerRef: string
+  amountCents: number
+  idempotencyKey: string
+}
+
+export interface RefundResult {
+  providerRef: string
+  status: 'succeeded' | 'failed'
+}
+
+export interface SaveMethodSetupInput {
+  organizationId: string
+  successUrl: string
+  cancelUrl: string
+}
+
+export interface SaveMethodSetupResult {
+  redirectUrl: string
+  providerRef: string
+}
+
+/** A provider webhook, normalized to a provider-neutral shape. */
+export interface VerifiedWebhookEvent {
+  /** Provider event id — used for idempotent ingest (processed_stripe_event). */
+  eventId: string
+  type: 'topup.succeeded' | 'topup.failed' | 'refund.succeeded' | 'method.saved' | 'ignored'
+  organizationId: string | null
+  amountCents: number | null
+  providerRef: string | null
+}
+
+export interface PaymentProvider {
+  /** Manual top-up — Stripe Checkout Session (mode=payment). */
+  createTopUpIntent(input: CreateTopUpIntentInput): Promise<TopUpIntentResult>
+  /** Auto-reload — off-session PaymentIntent against a saved method. */
+  chargeSavedMethod(input: ChargeSavedMethodInput): Promise<ChargeResult>
+  refund(input: RefundInput): Promise<RefundResult>
+  /** Store a reusable off-session method — Stripe SetupIntent. */
+  setupSaveMethod(input: SaveMethodSetupInput): Promise<SaveMethodSetupResult>
+  /** Verify signature + parse a raw webhook body into a neutral event. */
+  parseWebhook(rawBody: Buffer, signature: string): VerifiedWebhookEvent
+}

--- a/apps/api/src/billing/payment/stripe-payment-provider.ts
+++ b/apps/api/src/billing/payment/stripe-payment-provider.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Injectable } from '@nestjs/common'
+import {
+  ChargeResult,
+  ChargeSavedMethodInput,
+  CreateTopUpIntentInput,
+  PaymentProvider,
+  RefundInput,
+  RefundResult,
+  SaveMethodSetupInput,
+  SaveMethodSetupResult,
+  TopUpIntentResult,
+  VerifiedWebhookEvent,
+} from './payment-provider.interface'
+
+/**
+ * Real Stripe provider — STUB. Phase 2 ships the seam, not the live integration
+ * (no `stripe` SDK dependency, no keys tonight). Each method documents exactly
+ * what the implementation must do so wiring it up later is mechanical.
+ *
+ * TODO(stripe), when wiring up:
+ *  - createTopUpIntent → Checkout Session, `mode: 'payment'`, pass our
+ *    `idempotencyKey` as the Stripe idempotency key; return session.url.
+ *  - chargeSavedMethod → PaymentIntent `off_session: true, confirm: true` against
+ *    the saved payment method; map card errors to status: 'failed'.
+ *  - setupSaveMethod → SetupIntent / Checkout `mode: 'setup'`.
+ *  - refund → refunds.create; idempotencyKey from the refund row.
+ *  - parseWebhook → stripe.webhooks.constructEvent(RAW body, sig, endpointSecret).
+ *    MUST use the raw request body (not the parsed JSON), a restricted `rk_` key,
+ *    and the default signature tolerance. Map checkout.session.completed →
+ *    'topup.succeeded', charge.refunded → 'refund.succeeded', etc.; everything
+ *    else → 'ignored'. The returned eventId is `event.id` (webhook idempotency).
+ */
+@Injectable()
+export class StripePaymentProvider implements PaymentProvider {
+  private notWired(method: string): never {
+    throw new Error(`StripePaymentProvider.${method} is not wired up yet (Phase 2 ships the seam only)`)
+  }
+
+  createTopUpIntent(_input: CreateTopUpIntentInput): Promise<TopUpIntentResult> {
+    return this.notWired('createTopUpIntent')
+  }
+
+  chargeSavedMethod(_input: ChargeSavedMethodInput): Promise<ChargeResult> {
+    return this.notWired('chargeSavedMethod')
+  }
+
+  refund(_input: RefundInput): Promise<RefundResult> {
+    return this.notWired('refund')
+  }
+
+  setupSaveMethod(_input: SaveMethodSetupInput): Promise<SaveMethodSetupResult> {
+    return this.notWired('setupSaveMethod')
+  }
+
+  parseWebhook(_rawBody: Buffer, _signature: string): VerifiedWebhookEvent {
+    return this.notWired('parseWebhook')
+  }
+}

--- a/apps/api/src/billing/payment/top-up.service.ts
+++ b/apps/api/src/billing/payment/top-up.service.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Inject, Injectable } from '@nestjs/common'
+import { InjectDataSource } from '@nestjs/typeorm'
+import { DataSource } from 'typeorm'
+import { TopUpRecord } from '../entities/top-up-record.entity'
+import { PAYMENT_PROVIDER, PaymentProvider } from './payment-provider.interface'
+
+const DASHBOARD_URL = process.env.DASHBOARD_URL ?? 'https://app.boxlite.ai'
+
+/**
+ * Starts a manual top-up: the two-stage flow Stripe requires. We record a
+ * `pending` top_up_record (the wallet balance does NOT move yet), ask the
+ * provider for a checkout intent, and hand back the redirect URL. The wallet is
+ * credited later, once, by WebhookService when the provider confirms payment.
+ */
+@Injectable()
+export class TopUpService {
+  constructor(
+    @InjectDataSource() private readonly dataSource: DataSource,
+    @Inject(PAYMENT_PROVIDER) private readonly provider: PaymentProvider,
+  ) {}
+
+  async createCheckout(organizationId: string, amountCents: number): Promise<{ url: string }> {
+    if (amountCents <= 0) throw new Error(`top-up amount must be positive, got ${amountCents}`)
+    const records = this.dataSource.getRepository(TopUpRecord)
+
+    const record = await records.save(
+      records.create({ organizationId, amountCents: String(amountCents), method: 'manual', status: 'pending' }),
+    )
+
+    const intent = await this.provider.createTopUpIntent({
+      organizationId,
+      amountCents,
+      idempotencyKey: record.id, // derive idempotency from the pending row
+      successUrl: `${DASHBOARD_URL}/billing?topup=success`,
+      cancelUrl: `${DASHBOARD_URL}/billing?topup=cancel`,
+    })
+
+    await records.update(record.id, { stripeSessionId: intent.providerRef })
+    return { url: intent.redirectUrl }
+  }
+}

--- a/apps/api/src/billing/payment/webhook.service.spec.ts
+++ b/apps/api/src/billing/payment/webhook.service.spec.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { DataSource, QueryFailedError } from 'typeorm'
+import { WalletService } from '../wallet/wallet.service'
+import { PaymentProvider, VerifiedWebhookEvent } from './payment-provider.interface'
+import { WebhookService } from './webhook.service'
+
+/** A DataSource whose processed_stripe_event "table" enforces PK uniqueness in-memory. */
+function makeDataSource(seen: Set<string>) {
+  const manager = {
+    insert: async (entity: { name: string }, row: { stripeEventId?: string }) => {
+      if (entity.name === 'ProcessedStripeEvent') {
+        if (seen.has(row.stripeEventId!)) {
+          throw new QueryFailedError('insert', [], { code: '23505' } as unknown as Error) // duplicate PK
+        }
+        seen.add(row.stripeEventId!)
+      }
+      return { identifiers: [{ id: 'x' }] }
+    },
+    update: async () => undefined,
+  }
+  return {
+    transaction: async (cb: (m: typeof manager) => unknown) => cb(manager),
+  } as unknown as DataSource
+}
+
+function topupEvent(eventId: string): VerifiedWebhookEvent {
+  return { eventId, type: 'topup.succeeded', organizationId: 'org-1', amountCents: 1000, providerRef: 'cs_1' }
+}
+
+function makeService(event: VerifiedWebhookEvent) {
+  const seen = new Set<string>()
+  const topUpWithin = jest.fn(async () => ({ balanceCents: 1000, freeBalanceCents: 0, paidBalanceCents: 1000 }))
+  const wallet = { topUpWithin } as unknown as WalletService
+  const provider = { parseWebhook: () => event } as unknown as PaymentProvider
+  return { service: new WebhookService(makeDataSource(seen), wallet, provider), topUpWithin }
+}
+
+describe('WebhookService.ingest idempotency', () => {
+  it('credits the wallet on first delivery', async () => {
+    const { service, topUpWithin } = makeService(topupEvent('evt_1'))
+    expect(await service.ingest(Buffer.from('{}'), 'sig')).toBe('processed')
+    expect(topUpWithin).toHaveBeenCalledTimes(1)
+    expect(topUpWithin).toHaveBeenCalledWith(expect.anything(), 'org-1', 1000, 'manual', 'evt_1')
+  })
+
+  it('does NOT credit again when the same event id is re-delivered (the marker guard)', async () => {
+    const { service, topUpWithin } = makeService(topupEvent('evt_1'))
+    expect(await service.ingest(Buffer.from('{}'), 'sig')).toBe('processed')
+    // re-deliver the identical event — marker insert hits the unique PK, txn rolls back
+    expect(await service.ingest(Buffer.from('{}'), 'sig')).toBe('duplicate')
+    expect(topUpWithin).toHaveBeenCalledTimes(1) // still once — no double credit
+  })
+
+  it('ignores event types with no wallet effect', async () => {
+    const { service, topUpWithin } = makeService({
+      eventId: 'evt_x',
+      type: 'ignored',
+      organizationId: null,
+      amountCents: null,
+      providerRef: null,
+    })
+    expect(await service.ingest(Buffer.from('{}'), 'sig')).toBe('ignored')
+    expect(topUpWithin).not.toHaveBeenCalled()
+  })
+})

--- a/apps/api/src/billing/payment/webhook.service.spec.ts
+++ b/apps/api/src/billing/payment/webhook.service.spec.ts
@@ -10,6 +10,7 @@ import { WebhookService } from './webhook.service'
 
 /** A DataSource whose processed_stripe_event "table" enforces PK uniqueness in-memory. */
 function makeDataSource(seen: Set<string>) {
+  const updates: { entity: string; patch: unknown }[] = []
   const manager = {
     insert: async (entity: { name: string }, row: { stripeEventId?: string }) => {
       if (entity.name === 'ProcessedStripeEvent') {
@@ -20,11 +21,15 @@ function makeDataSource(seen: Set<string>) {
       }
       return { identifiers: [{ id: 'x' }] }
     },
-    update: async () => undefined,
+    findOne: async () => ({ id: 'tx-fake' }),
+    update: async (entity: { name: string }, _where: unknown, patch: unknown) => {
+      updates.push({ entity: entity.name, patch })
+    },
   }
-  return {
+  const dataSource = {
     transaction: async (cb: (m: typeof manager) => unknown) => cb(manager),
   } as unknown as DataSource
+  return { dataSource, updates }
 }
 
 function topupEvent(eventId: string): VerifiedWebhookEvent {
@@ -33,18 +38,22 @@ function topupEvent(eventId: string): VerifiedWebhookEvent {
 
 function makeService(event: VerifiedWebhookEvent) {
   const seen = new Set<string>()
+  const { dataSource, updates } = makeDataSource(seen)
   const topUpWithin = jest.fn(async () => ({ balanceCents: 1000, freeBalanceCents: 0, paidBalanceCents: 1000 }))
-  const wallet = { topUpWithin } as unknown as WalletService
+  const getOrCreateWallet = jest.fn(async () => ({ id: 'w1', organizationId: 'org-1' }))
+  const wallet = { topUpWithin, getOrCreateWallet } as unknown as WalletService
   const provider = { parseWebhook: () => event } as unknown as PaymentProvider
-  return { service: new WebhookService(makeDataSource(seen), wallet, provider), topUpWithin }
+  return { service: new WebhookService(dataSource, wallet, provider), topUpWithin, getOrCreateWallet, updates }
 }
 
 describe('WebhookService.ingest idempotency', () => {
-  it('credits the wallet on first delivery', async () => {
-    const { service, topUpWithin } = makeService(topupEvent('evt_1'))
+  it('credits the wallet and settles the pending top-up record on first delivery', async () => {
+    const { service, topUpWithin, updates } = makeService(topupEvent('evt_1'))
     expect(await service.ingest(Buffer.from('{}'), 'sig')).toBe('processed')
     expect(topUpWithin).toHaveBeenCalledTimes(1)
     expect(topUpWithin).toHaveBeenCalledWith(expect.anything(), 'org-1', 1000, 'manual', 'evt_1')
+    // the pending top_up_record flips to paid and links its ledger row (no longer stuck pending)
+    expect(updates).toContainEqual({ entity: 'TopUpRecord', patch: { status: 'paid', walletTransactionId: 'tx-fake' } })
   })
 
   it('does NOT credit again when the same event id is re-delivered (the marker guard)', async () => {
@@ -65,5 +74,31 @@ describe('WebhookService.ingest idempotency', () => {
     })
     expect(await service.ingest(Buffer.from('{}'), 'sig')).toBe('ignored')
     expect(topUpWithin).not.toHaveBeenCalled()
+  })
+
+  it('marks the top-up record failed (no credit) on a failed event', async () => {
+    const { service, topUpWithin, updates } = makeService({
+      eventId: 'evt_f',
+      type: 'topup.failed',
+      organizationId: 'org-1',
+      amountCents: 1000,
+      providerRef: 'cs_1',
+    })
+    expect(await service.ingest(Buffer.from('{}'), 'sig')).toBe('processed')
+    expect(topUpWithin).not.toHaveBeenCalled()
+    expect(updates).toContainEqual({ entity: 'TopUpRecord', patch: { status: 'failed', walletTransactionId: null } })
+  })
+
+  it('ensures the wallet row exists before flagging a saved card (no silent drop)', async () => {
+    const { service, getOrCreateWallet, updates } = makeService({
+      eventId: 'evt_m',
+      type: 'method.saved',
+      organizationId: 'org-1',
+      amountCents: null,
+      providerRef: null,
+    })
+    expect(await service.ingest(Buffer.from('{}'), 'sig')).toBe('processed')
+    expect(getOrCreateWallet).toHaveBeenCalledWith('org-1') // lazy-create before the UPDATE
+    expect(updates).toContainEqual({ entity: 'Wallet', patch: { creditCardConnected: true } })
   })
 })

--- a/apps/api/src/billing/payment/webhook.service.ts
+++ b/apps/api/src/billing/payment/webhook.service.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Inject, Injectable, Logger } from '@nestjs/common'
+import { InjectDataSource } from '@nestjs/typeorm'
+import { DataSource, EntityManager, QueryFailedError } from 'typeorm'
+import { ProcessedStripeEvent } from '../entities/processed-stripe-event.entity'
+import { Wallet } from '../entities/wallet.entity'
+import { WalletService } from '../wallet/wallet.service'
+import { PAYMENT_PROVIDER, PaymentProvider, VerifiedWebhookEvent } from './payment-provider.interface'
+
+const PG_UNIQUE_VIOLATION = '23505'
+
+function isUniqueViolation(err: unknown): boolean {
+  return err instanceof QueryFailedError && (err.driverError as { code?: string })?.code === PG_UNIQUE_VIOLATION
+}
+
+export type WebhookOutcome = 'processed' | 'duplicate' | 'ignored'
+
+/**
+ * Ingests payment-provider webhooks and settles their effect on the wallet.
+ * Idempotency is structural: the provider event id is inserted into
+ * `processed_stripe_event` IN THE SAME TRANSACTION as the balance change, so a
+ * re-delivered webhook hits the unique PK, the whole transaction rolls back, and
+ * the wallet is never credited twice (Stripe's official "log event ids" guidance).
+ * The settlement ledger row also carries `providerEventId` (partial-unique) as a
+ * second guard.
+ */
+@Injectable()
+export class WebhookService {
+  private readonly logger = new Logger(WebhookService.name)
+
+  constructor(
+    @InjectDataSource() private readonly dataSource: DataSource,
+    private readonly wallet: WalletService,
+    @Inject(PAYMENT_PROVIDER) private readonly provider: PaymentProvider,
+  ) {}
+
+  /** Verify + parse a raw webhook, then apply it exactly once. */
+  async ingest(rawBody: Buffer, signature: string): Promise<WebhookOutcome> {
+    const event = this.provider.parseWebhook(rawBody, signature)
+    if (event.type === 'ignored') return 'ignored'
+
+    try {
+      await this.dataSource.transaction(async (manager) => {
+        await manager.insert(ProcessedStripeEvent, { stripeEventId: event.eventId, eventType: event.type })
+        await this.apply(manager, event)
+      })
+      return 'processed'
+    } catch (err) {
+      if (isUniqueViolation(err)) {
+        this.logger.log(`duplicate webhook ${event.eventId} (${event.type}) ignored`)
+        return 'duplicate'
+      }
+      throw err
+    }
+  }
+
+  private async apply(manager: EntityManager, event: VerifiedWebhookEvent): Promise<void> {
+    switch (event.type) {
+      case 'topup.succeeded': {
+        if (!event.organizationId || event.amountCents == null) {
+          throw new Error(`topup webhook ${event.eventId} missing organizationId/amountCents`)
+        }
+        await this.wallet.topUpWithin(manager, event.organizationId, event.amountCents, 'manual', event.eventId)
+        return
+      }
+      case 'method.saved': {
+        if (event.organizationId) {
+          await manager.update(Wallet, { organizationId: event.organizationId }, { creditCardConnected: true })
+        }
+        return
+      }
+      case 'topup.failed':
+        // No money moved; the pending top_up_record is marked failed elsewhere. Auto-reload
+        // failure degrades the wallet back to low_balance, never to debt.
+        this.logger.warn(`top-up failed webhook ${event.eventId}`)
+        return
+      case 'refund.succeeded':
+        // TODO(stripe, M2): reverse the wallet (debit the paid pool by the refunded
+        // amount). Deferred — refund/chargeback policy (PRD Q15) is still open.
+        this.logger.warn(`refund webhook ${event.eventId} received; wallet reversal not wired yet`)
+        return
+    }
+  }
+}

--- a/apps/api/src/billing/payment/webhook.service.ts
+++ b/apps/api/src/billing/payment/webhook.service.ts
@@ -7,7 +7,9 @@ import { Inject, Injectable, Logger } from '@nestjs/common'
 import { InjectDataSource } from '@nestjs/typeorm'
 import { DataSource, EntityManager, QueryFailedError } from 'typeorm'
 import { ProcessedStripeEvent } from '../entities/processed-stripe-event.entity'
+import { TopUpRecord, TopUpStatus } from '../entities/top-up-record.entity'
 import { Wallet } from '../entities/wallet.entity'
+import { WalletTransaction } from '../entities/wallet-transaction.entity'
 import { WalletService } from '../wallet/wallet.service'
 import { PAYMENT_PROVIDER, PaymentProvider, VerifiedWebhookEvent } from './payment-provider.interface'
 
@@ -65,24 +67,46 @@ export class WebhookService {
           throw new Error(`topup webhook ${event.eventId} missing organizationId/amountCents`)
         }
         await this.wallet.topUpWithin(manager, event.organizationId, event.amountCents, 'manual', event.eventId)
+        await this.settleTopUpRecord(manager, event, 'paid')
         return
       }
+      case 'topup.failed':
+        // Auto-reload / checkout failure: no money moves, just flip the pending record.
+        // The wallet stays at its current (possibly low) balance — never debt.
+        await this.settleTopUpRecord(manager, event, 'failed')
+        return
       case 'method.saved': {
         if (event.organizationId) {
+          // Ensure the wallet row exists first — a card can be saved before any wallet
+          // activity, where a bare UPDATE would match zero rows and silently drop the flag.
+          await this.wallet.getOrCreateWallet(event.organizationId)
           await manager.update(Wallet, { organizationId: event.organizationId }, { creditCardConnected: true })
         }
         return
       }
-      case 'topup.failed':
-        // No money moved; the pending top_up_record is marked failed elsewhere. Auto-reload
-        // failure degrades the wallet back to low_balance, never to debt.
-        this.logger.warn(`top-up failed webhook ${event.eventId}`)
-        return
       case 'refund.succeeded':
         // TODO(stripe, M2): reverse the wallet (debit the paid pool by the refunded
         // amount). Deferred — refund/chargeback policy (PRD Q15) is still open.
         this.logger.warn(`refund webhook ${event.eventId} received; wallet reversal not wired yet`)
         return
     }
+  }
+
+  /**
+   * Close out the pending top_up_record this webhook resolves (matched by the
+   * provider checkout ref), and on success link the settlement ledger row.
+   * A no-op when the event carries no provider ref.
+   */
+  private async settleTopUpRecord(
+    manager: EntityManager,
+    event: VerifiedWebhookEvent,
+    status: Extract<TopUpStatus, 'paid' | 'failed'>,
+  ): Promise<void> {
+    if (!event.providerRef) return
+    const walletTransactionId =
+      status === 'paid'
+        ? ((await manager.findOne(WalletTransaction, { where: { providerEventId: event.eventId } }))?.id ?? null)
+        : null
+    await manager.update(TopUpRecord, { stripeSessionId: event.providerRef }, { status, walletTransactionId })
   }
 }

--- a/apps/api/src/billing/rating/pricing.service.ts
+++ b/apps/api/src/billing/rating/pricing.service.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Injectable } from '@nestjs/common'
+import { InjectRepository } from '@nestjs/typeorm'
+import { Repository } from 'typeorm'
+import { PricingPlan } from '../entities/pricing-plan.entity'
+
+/**
+ * Read access to the active pricing version. Kept tiny and separate from
+ * RatingService so the wallet read-path can ask for the warn threshold without
+ * depending on the rating sweep. "Active" is derived from the effective window
+ * (`effectiveFrom <= at < effectiveTo`), never a stored flag.
+ */
+@Injectable()
+export class PricingService {
+  constructor(@InjectRepository(PricingPlan) private readonly plans: Repository<PricingPlan>) {}
+
+  getActivePlan(at: Date = new Date()): Promise<PricingPlan | null> {
+    return this.plans
+      .createQueryBuilder('p')
+      .where('p."effectiveFrom" <= :at', { at })
+      .andWhere('(p."effectiveTo" IS NULL OR :at < p."effectiveTo")', { at })
+      .orderBy('p.version', 'DESC')
+      .getOne()
+  }
+
+  /** Low-balance warning line from the active plan (0 when no plan is configured yet). */
+  async warnThresholdCents(at: Date = new Date()): Promise<number> {
+    const plan = await this.getActivePlan(at)
+    return plan ? Number(plan.warnThresholdCents) : 0
+  }
+}

--- a/apps/api/src/billing/rating/rate-math.spec.ts
+++ b/apps/api/src/billing/rating/rate-math.spec.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { UsageTotals } from '../../usage/billing/usage-math'
+import { computeRatedCents, resolveRateSnapshot, RateSnapshot } from './rate-math'
+
+const totals = (cpu: number, ram: number, disk: number): UsageTotals => ({
+  totalCpuSeconds: cpu,
+  totalRamGbSeconds: ram,
+  totalDiskGbSeconds: disk,
+})
+
+describe('resolveRateSnapshot', () => {
+  const plan = { cpuRateCentsPerSec: '2', memRateCentsPerSec: '1', diskRateCentsPerSec: '0.5' }
+
+  it('uses plan list rates at factor 1 when there is no override', () => {
+    expect(resolveRateSnapshot(plan)).toEqual({
+      cpuRateCentsPerSec: '2',
+      memRateCentsPerSec: '1',
+      diskRateCentsPerSec: '0.5',
+      discountFactor: '1',
+    })
+  })
+
+  it('applies a discount factor while keeping plan rates', () => {
+    expect(resolveRateSnapshot(plan, { discountFactor: '0.85', effectiveRates: null }).discountFactor).toBe('0.85')
+  })
+
+  it('lets effectiveRates fully override the plan rates', () => {
+    const snap = resolveRateSnapshot(plan, {
+      discountFactor: null,
+      effectiveRates: { cpu: '5', mem: '4', disk: '3' },
+    })
+    expect(snap).toEqual({
+      cpuRateCentsPerSec: '5',
+      memRateCentsPerSec: '4',
+      diskRateCentsPerSec: '3',
+      discountFactor: '1',
+    })
+  })
+})
+
+describe('computeRatedCents', () => {
+  const snap = (cpu: string, mem: string, disk: string, discount = '1'): RateSnapshot => ({
+    cpuRateCentsPerSec: cpu,
+    memRateCentsPerSec: mem,
+    diskRateCentsPerSec: disk,
+    discountFactor: discount,
+  })
+
+  it('sums all three dimensions × their rates', () => {
+    // 10s×2 + 20s×1 + 100s×0.5 = 20 + 20 + 50 = 90 cents
+    const r = computeRatedCents(totals(10, 20, 100), snap('2', '1', '0.5'))
+    expect(r.ratedCents).toBe(90)
+    expect(r.preciseCents).toBe('90')
+  })
+
+  it('applies the discount factor to the total', () => {
+    // 90 × 0.5 = 45
+    expect(computeRatedCents(totals(10, 20, 100), snap('2', '1', '0.5', '0.5')).ratedCents).toBe(45)
+  })
+
+  it('keeps sub-cent precision while accumulating, only rounding at the end', () => {
+    // rate 0.0001 cents/sec × 10000s = 1.0 cent exactly — a float would drift.
+    const r = computeRatedCents(totals(10000, 0, 0), snap('0.0001', '0', '0'))
+    expect(r.preciseCents).toBe('1')
+    expect(r.ratedCents).toBe(1)
+  })
+
+  it('rounds half-up at the cent boundary (0.4 down, 0.6 up)', () => {
+    expect(computeRatedCents(totals(1, 0, 0), snap('20.4', '0', '0')).ratedCents).toBe(20)
+    expect(computeRatedCents(totals(1, 0, 0), snap('20.6', '0', '0')).ratedCents).toBe(21)
+    expect(computeRatedCents(totals(1, 0, 0), snap('20.5', '0', '0')).ratedCents).toBe(21)
+  })
+
+  it('preserves the sub-cent precise value separately from the billed cents', () => {
+    const r = computeRatedCents(totals(3, 0, 0), snap('0.333', '0', '0'))
+    expect(r.preciseCents).toBe('0.999')
+    expect(r.ratedCents).toBe(1)
+  })
+
+  it('a zero-usage period rates to 0', () => {
+    expect(computeRatedCents(totals(0, 0, 0), snap('2', '1', '0.5'))).toEqual({ preciseCents: '0', ratedCents: 0 })
+  })
+})

--- a/apps/api/src/billing/rating/rate-math.spec.ts
+++ b/apps/api/src/billing/rating/rate-math.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { UsageTotals } from '../../usage/billing/usage-math'
-import { computeRatedCents, resolveRateSnapshot, RateSnapshot } from './rate-math'
+import { computeRatedCents, periodBillableTotals, resolveRateSnapshot, RateSnapshot } from './rate-math'
 
 const totals = (cpu: number, ram: number, disk: number): UsageTotals => ({
   totalCpuSeconds: cpu,
@@ -83,5 +83,28 @@ describe('computeRatedCents', () => {
 
   it('a zero-usage period rates to 0', () => {
     expect(computeRatedCents(totals(0, 0, 0), snap('2', '1', '0.5'))).toEqual({ preciseCents: '0', ratedCents: 0 })
+  })
+})
+
+describe('periodBillableTotals', () => {
+  const start = new Date('2026-06-27T00:00:00Z')
+  const end = new Date('2026-06-27T00:01:00Z') // 60s
+  const alloc = { allocCpu: 2, allocMemGib: 4, allocDiskGib: 10 }
+
+  it('bills cpu+ram+disk for a running period', () => {
+    const r = periodBillableTotals({ periodStart: start, periodEnd: end, kind: 'running', ...alloc })
+    expect(r.billedSeconds).toBe(60)
+    expect(r.totals).toEqual({ totalCpuSeconds: 120, totalRamGbSeconds: 240, totalDiskGbSeconds: 600 })
+  })
+
+  it('bills only disk for a stopped period (cpu/ram zero)', () => {
+    const r = periodBillableTotals({ periodStart: start, periodEnd: end, kind: 'stopped', ...alloc })
+    expect(r.totals).toEqual({ totalCpuSeconds: 0, totalRamGbSeconds: 0, totalDiskGbSeconds: 600 })
+  })
+
+  it('never returns negative seconds for an inverted span', () => {
+    expect(periodBillableTotals({ periodStart: end, periodEnd: start, kind: 'running', ...alloc }).billedSeconds).toBe(
+      0,
+    )
   })
 })

--- a/apps/api/src/billing/rating/rate-math.ts
+++ b/apps/api/src/billing/rating/rate-math.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import Decimal from 'decimal.js'
+import { UsageTotals } from '../../usage/billing/usage-math'
+
+/**
+ * Pure rating math — turns Phase 1's raw usage totals (CPU/RAM/Disk seconds)
+ * into a USD amount, with sub-cent precision and a version-frozen rate snapshot.
+ *
+ * Grounded in OpenMeter `SnapshotLineQuantity` (freeze the rate onto the rated
+ * row) + Lago `precise_amount_cents decimal(30,5)` (accumulate in Decimal, round
+ * to whole cents only at the boundary). No DB, no I/O — deterministic and
+ * unit-testable. The control-plane service freezes the returned snapshot onto
+ * `rated_period.unit_rates`; reads never re-join the live plan, so changing a
+ * price never moves a historical bill (canon I7).
+ */
+
+/** A frozen, per-second rate (cents per unit-second) for one rating event. */
+export interface RateSnapshot {
+  /** Cents per vCPU-second (may be fractional, kept as a decimal string). */
+  cpuRateCentsPerSec: string
+  /** Cents per GiB-second. */
+  memRateCentsPerSec: string
+  /** Cents per GiB-second. */
+  diskRateCentsPerSec: string
+  /** Multiplier, "1" = list price, "0.85" = 15% off. */
+  discountFactor: string
+}
+
+/** A pricing-plan version (already selected for the usage moment by the caller). */
+export interface PricingPlanLike {
+  cpuRateCentsPerSec: string
+  memRateCentsPerSec: string
+  diskRateCentsPerSec: string
+}
+
+/** A per-customer rate override (optional). `effectiveRates` beats `discountFactor`. */
+export interface RateOverrideLike {
+  discountFactor: string | null
+  effectiveRates: { cpu: string; mem: string; disk: string } | null
+}
+
+/** Result of rating one usage period: a sub-cent precise value + the billed (rounded) cents. */
+export interface RatedAmount {
+  /** Sub-cent precise value as a decimal string (what we persist to keep accumulation honest). */
+  preciseCents: string
+  /** Whole cents actually billed (round-half-up of `preciseCents`). */
+  ratedCents: number
+}
+
+/**
+ * Build the frozen rate snapshot for a usage moment: a per-customer override (if
+ * present) replaces the rates and/or applies a discount; otherwise the plan's
+ * list rates at factor 1. The caller selects which plan *version* applies (by
+ * `effective_from <= usageStart < effective_to`); this function just composes
+ * the final per-second rates so they can be frozen onto the rated row.
+ */
+export function resolveRateSnapshot(plan: PricingPlanLike, override?: RateOverrideLike | null): RateSnapshot {
+  const rates = override?.effectiveRates
+    ? { cpu: override.effectiveRates.cpu, mem: override.effectiveRates.mem, disk: override.effectiveRates.disk }
+    : { cpu: plan.cpuRateCentsPerSec, mem: plan.memRateCentsPerSec, disk: plan.diskRateCentsPerSec }
+
+  return {
+    cpuRateCentsPerSec: rates.cpu,
+    memRateCentsPerSec: rates.mem,
+    diskRateCentsPerSec: rates.disk,
+    discountFactor: override?.discountFactor ?? '1',
+  }
+}
+
+/**
+ * Rate a usage period: `Σ_dim (seconds_dim × rate_dim) × discount`, accumulated
+ * in Decimal so per-second sub-cent amounts never lose precision, then rounded
+ * half-up to whole cents at the very end.
+ */
+export function computeRatedCents(totals: UsageTotals, snap: RateSnapshot): RatedAmount {
+  const cpu = new Decimal(totals.totalCpuSeconds).times(snap.cpuRateCentsPerSec)
+  const mem = new Decimal(totals.totalRamGbSeconds).times(snap.memRateCentsPerSec)
+  const disk = new Decimal(totals.totalDiskGbSeconds).times(snap.diskRateCentsPerSec)
+
+  const precise = cpu.plus(mem).plus(disk).times(snap.discountFactor)
+  const rounded = precise.toDecimalPlaces(0, Decimal.ROUND_HALF_UP)
+
+  return {
+    preciseCents: precise.toString(),
+    ratedCents: rounded.toNumber(),
+  }
+}

--- a/apps/api/src/billing/rating/rate-math.ts
+++ b/apps/api/src/billing/rating/rate-math.ts
@@ -89,3 +89,32 @@ export function computeRatedCents(totals: UsageTotals, snap: RateSnapshot): Rate
     ratedCents: rounded.toNumber(),
   }
 }
+
+/** One closed Phase-1 usage period, just the fields rating needs. */
+export interface ClosedPeriodLike {
+  periodStart: Date
+  periodEnd: Date
+  /** `running` (cpu+ram+disk) or `stopped` (disk only) — matches Phase 1 aggregatePeriods. */
+  kind: string
+  allocCpu: number
+  allocMemGib: number
+  allocDiskGib: number
+}
+
+/**
+ * Turn one closed usage period into billable totals: disk is charged whether the
+ * box was running or stopped; CPU and RAM only while running (the same split
+ * Phase 1 uses to aggregate). `billedSeconds` is the wall-clock span.
+ */
+export function periodBillableTotals(period: ClosedPeriodLike): { totals: UsageTotals; billedSeconds: number } {
+  const billedSeconds = Math.max(0, (period.periodEnd.getTime() - period.periodStart.getTime()) / 1000)
+  const running = period.kind === 'running'
+  return {
+    billedSeconds,
+    totals: {
+      totalCpuSeconds: running ? period.allocCpu * billedSeconds : 0,
+      totalRamGbSeconds: running ? period.allocMemGib * billedSeconds : 0,
+      totalDiskGbSeconds: period.allocDiskGib * billedSeconds,
+    },
+  }
+}

--- a/apps/api/src/billing/rating/rating.service.spec.ts
+++ b/apps/api/src/billing/rating/rating.service.spec.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { QueryFailedError, Repository } from 'typeorm'
+import { UsagePeriod } from '../../usage/entities/usage-period.entity'
+import { CustomerRateOverride } from '../entities/customer-rate-override.entity'
+import { PricingPlan } from '../entities/pricing-plan.entity'
+import { RatedPeriod } from '../entities/rated-period.entity'
+import { RatingService } from './rating.service'
+
+/** Minimal chainable query-builder mock whose terminal calls return canned data. */
+function qb(result: unknown) {
+  const self: Record<string, unknown> = {}
+  for (const m of ['leftJoin', 'where', 'andWhere', 'orderBy']) self[m] = () => self
+  self.getOne = async () => result
+  self.getMany = async () => result
+  return self
+}
+
+const PLAN: PricingPlan = {
+  id: 'plan-1',
+  version: 3,
+  cpuRateCentsPerSec: '2',
+  memRateCentsPerSec: '1',
+  diskRateCentsPerSec: '0.5',
+  warnThresholdCents: '500',
+  defaultGrantCents: '0',
+  effectiveFrom: new Date('2026-01-01T00:00:00Z'),
+  effectiveTo: null,
+  createdBy: 'seed',
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+}
+
+const PERIOD: UsagePeriod = {
+  id: 'up-1',
+  boxId: 'box-1',
+  organizationId: 'org-1',
+  region: 'us',
+  periodStart: new Date('2026-06-27T00:00:00Z'),
+  periodEnd: new Date('2026-06-27T00:01:00Z'), // 60s running
+  kind: 'running',
+  allocCpu: 2,
+  allocMemGib: 4,
+  allocDiskGib: 10,
+} as UsagePeriod
+
+function makeService(opts: {
+  plan?: PricingPlan | null
+  override?: CustomerRateOverride | null
+  save?: jest.Mock
+  unrated?: UsagePeriod[]
+}) {
+  const saveMock = opts.save ?? jest.fn(async (r) => ({ id: 'rated-1', ...r }))
+  const ratedPeriods = {
+    create: (r: Partial<RatedPeriod>) => r,
+    save: saveMock,
+    createQueryBuilder: () => qb(opts.unrated ?? []),
+  } as unknown as Repository<RatedPeriod>
+  const usagePeriods = { createQueryBuilder: () => qb(opts.unrated ?? []) } as unknown as Repository<UsagePeriod>
+  const plans = {
+    createQueryBuilder: () => qb(opts.plan === undefined ? PLAN : opts.plan),
+  } as unknown as Repository<PricingPlan>
+  const overrides = {
+    createQueryBuilder: () => qb(opts.override ?? null),
+  } as unknown as Repository<CustomerRateOverride>
+
+  return { service: new RatingService(usagePeriods, ratedPeriods, plans, overrides), saveMock }
+}
+
+describe('RatingService.ratePeriod', () => {
+  it('rates a running period and freezes the rate snapshot onto the row', async () => {
+    const { service, saveMock } = makeService({})
+    const row = await service.ratePeriod(PERIOD)
+
+    // 60s × (2cpu×2 + 4ram×1 + 10disk×0.5) = 60 × (4 + 4 + 5) = 60 × 13 = 780
+    expect(saveMock).toHaveBeenCalledTimes(1)
+    const saved = saveMock.mock.calls[0][0]
+    expect(saved.ratedCents).toBe('780')
+    expect(saved.billedSeconds).toBe('60')
+    expect(saved.pricingVersion).toBe(3)
+    expect(saved.unitRates).toEqual({
+      cpuRateCentsPerSec: '2',
+      memRateCentsPerSec: '1',
+      diskRateCentsPerSec: '0.5',
+      discountFactor: '1',
+    })
+    expect(row).not.toBeNull()
+  })
+
+  it('applies a per-customer discount when an override is active', async () => {
+    const override = { discountFactor: '0.5', effectiveRates: null } as CustomerRateOverride
+    const { service, saveMock } = makeService({ override })
+    await service.ratePeriod(PERIOD)
+    expect(saveMock.mock.calls[0][0].ratedCents).toBe('390') // 780 × 0.5
+    expect(saveMock.mock.calls[0][0].unitRates.discountFactor).toBe('0.5')
+  })
+
+  it('is idempotent: a duplicate (UNIQUE violation) save returns null, not an error', async () => {
+    const save = jest.fn(async () => {
+      throw new QueryFailedError('insert', [], { code: '23505' } as unknown as Error)
+    })
+    const { service } = makeService({ save })
+    await expect(service.ratePeriod(PERIOD)).resolves.toBeNull()
+  })
+
+  it('rethrows non-unique DB errors', async () => {
+    const save = jest.fn(async () => {
+      throw new QueryFailedError('insert', [], { code: '23502' } as unknown as Error) // not-null violation
+    })
+    const { service } = makeService({ save })
+    await expect(service.ratePeriod(PERIOD)).rejects.toBeInstanceOf(QueryFailedError)
+  })
+
+  it('skips a period with no effective pricing plan', async () => {
+    const { service, saveMock } = makeService({ plan: null })
+    expect(await service.ratePeriod(PERIOD)).toBeNull()
+    expect(saveMock).not.toHaveBeenCalled()
+  })
+
+  it('skips a still-open period (no periodEnd)', async () => {
+    const { service, saveMock } = makeService({})
+    expect(await service.ratePeriod({ ...PERIOD, periodEnd: null } as UsagePeriod)).toBeNull()
+    expect(saveMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('RatingService.rateClosedPeriods', () => {
+  it('counts rated vs skipped across the work list', async () => {
+    const { service, saveMock } = makeService({ unrated: [PERIOD, { ...PERIOD, id: 'up-2' } as UsagePeriod] })
+    const result = await service.rateClosedPeriods()
+    expect(result).toEqual({ rated: 2, skipped: 0 })
+    expect(saveMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/apps/api/src/billing/rating/rating.service.ts
+++ b/apps/api/src/billing/rating/rating.service.ts
@@ -101,7 +101,7 @@ export class RatingService {
   private findUnratedClosedPeriods(): Promise<UsagePeriod[]> {
     return this.usagePeriods
       .createQueryBuilder('up')
-      .leftJoin(RatedPeriod, 'rp', 'rp."usagePeriodId" = up.id::text')
+      .leftJoin(RatedPeriod, 'rp', 'rp."usagePeriodId" = up.id')
       .where('up."periodEnd" IS NOT NULL')
       .andWhere('rp.id IS NULL')
       .orderBy('up."periodStart"', 'ASC')

--- a/apps/api/src/billing/rating/rating.service.ts
+++ b/apps/api/src/billing/rating/rating.service.ts
@@ -1,0 +1,131 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Injectable, Logger } from '@nestjs/common'
+import { Cron, CronExpression } from '@nestjs/schedule'
+import { InjectRepository } from '@nestjs/typeorm'
+import { QueryFailedError, Repository } from 'typeorm'
+import { UsagePeriod } from '../../usage/entities/usage-period.entity'
+import { CustomerRateOverride } from '../entities/customer-rate-override.entity'
+import { PricingPlan } from '../entities/pricing-plan.entity'
+import { RatedPeriod } from '../entities/rated-period.entity'
+import { computeRatedCents, periodBillableTotals, resolveRateSnapshot } from './rate-math'
+
+const PG_UNIQUE_VIOLATION = '23505'
+
+function isUniqueViolation(err: unknown): boolean {
+  return err instanceof QueryFailedError && (err.driverError as { code?: string })?.code === PG_UNIQUE_VIOLATION
+}
+
+/**
+ * Rates closed Phase-1 usage periods into `rated_period` rows. Runs as a sweep
+ * (not on a live event) because a period is only billable once it is *closed*
+ * (`periodEnd` set on a state change / reconcile). Idempotent: one usage period
+ * → at most one rated row, enforced by `UNIQUE(usagePeriodId)`; a duplicate save
+ * is swallowed, so re-running the sweep (or a crash mid-sweep) never double-bills.
+ * The rate snapshot is frozen onto the row, so a later price change can't move it.
+ */
+@Injectable()
+export class RatingService {
+  private readonly logger = new Logger(RatingService.name)
+
+  constructor(
+    @InjectRepository(UsagePeriod) private readonly usagePeriods: Repository<UsagePeriod>,
+    @InjectRepository(RatedPeriod) private readonly ratedPeriods: Repository<RatedPeriod>,
+    @InjectRepository(PricingPlan) private readonly plans: Repository<PricingPlan>,
+    @InjectRepository(CustomerRateOverride) private readonly overrides: Repository<CustomerRateOverride>,
+  ) {}
+
+  @Cron(CronExpression.EVERY_5_MINUTES)
+  async scheduledSweep(): Promise<void> {
+    const { rated, skipped } = await this.rateClosedPeriods()
+    if (rated || skipped) this.logger.log(`rating sweep: rated ${rated}, skipped ${skipped}`)
+  }
+
+  /** Rate every closed-but-unrated usage period. Safe to re-run. */
+  async rateClosedPeriods(): Promise<{ rated: number; skipped: number }> {
+    const periods = await this.findUnratedClosedPeriods()
+    let rated = 0
+    let skipped = 0
+    for (const period of periods) {
+      const row = await this.ratePeriod(period)
+      row ? rated++ : skipped++
+    }
+    return { rated, skipped }
+  }
+
+  /** Rate one period; returns null if it was already rated (idempotent) or has no plan. */
+  async ratePeriod(period: UsagePeriod): Promise<RatedPeriod | null> {
+    if (!period.periodEnd) return null
+
+    const plan = await this.planForMoment(period.periodStart)
+    if (!plan) {
+      this.logger.warn(`no pricing plan effective at ${period.periodStart.toISOString()} for period ${period.id}`)
+      return null
+    }
+    const override = await this.overrideForOrg(period.organizationId, period.periodStart)
+
+    const snapshot = resolveRateSnapshot(plan, override ?? undefined)
+    const { totals, billedSeconds } = periodBillableTotals({
+      periodStart: period.periodStart,
+      periodEnd: period.periodEnd,
+      kind: period.kind,
+      allocCpu: period.allocCpu,
+      allocMemGib: period.allocMemGib,
+      allocDiskGib: period.allocDiskGib,
+    })
+    const { preciseCents, ratedCents } = computeRatedCents(totals, snapshot)
+
+    const row = this.ratedPeriods.create({
+      usagePeriodId: period.id,
+      organizationId: period.organizationId,
+      boxId: period.boxId,
+      pricingVersion: plan.version,
+      unitRates: snapshot,
+      billedSeconds: String(billedSeconds),
+      preciseCents,
+      ratedCents: String(ratedCents),
+    })
+
+    try {
+      return await this.ratedPeriods.save(row)
+    } catch (err) {
+      if (isUniqueViolation(err)) return null // already rated by a concurrent/earlier sweep
+      throw err
+    }
+  }
+
+  /** Closed usage periods with no rated_period yet (the rating work list). */
+  private findUnratedClosedPeriods(): Promise<UsagePeriod[]> {
+    return this.usagePeriods
+      .createQueryBuilder('up')
+      .leftJoin(RatedPeriod, 'rp', 'rp."usagePeriodId" = up.id::text')
+      .where('up."periodEnd" IS NOT NULL')
+      .andWhere('rp.id IS NULL')
+      .orderBy('up."periodStart"', 'ASC')
+      .getMany()
+  }
+
+  /** The pricing version in force at `at` (effectiveFrom <= at < effectiveTo). */
+  private planForMoment(at: Date): Promise<PricingPlan | null> {
+    return this.plans
+      .createQueryBuilder('p')
+      .where('p."effectiveFrom" <= :at', { at })
+      .andWhere('(p."effectiveTo" IS NULL OR :at < p."effectiveTo")', { at })
+      .orderBy('p.version', 'DESC')
+      .getOne()
+  }
+
+  /** The active per-customer override at `at`, if any. */
+  private overrideForOrg(organizationId: string, at: Date): Promise<CustomerRateOverride | null> {
+    return this.overrides
+      .createQueryBuilder('o')
+      .where('o."organizationId" = :organizationId', { organizationId })
+      .andWhere('o."effectiveFrom" <= :at', { at })
+      .andWhere('(o."effectiveTo" IS NULL OR :at < o."effectiveTo")', { at })
+      .orderBy('o."effectiveFrom"', 'DESC')
+      .getOne()
+  }
+}

--- a/apps/api/src/billing/wallet/wallet-math.spec.ts
+++ b/apps/api/src/billing/wallet/wallet-math.spec.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { applyTopUp, burnDown, deriveBillingStatus, InboundLot } from './wallet-math'
+
+const T0 = new Date('2026-06-27T12:00:00Z')
+const lot = (
+  over: Partial<InboundLot> & { id: string; pool: 'free' | 'paid'; remainingCents: number },
+): InboundLot => ({
+  priority: over.pool === 'free' ? 1 : 2,
+  expiresAt: null,
+  createdAt: T0,
+  ...over,
+})
+
+describe('burnDown', () => {
+  it('drains the free pool before the paid pool', () => {
+    const lots = [
+      lot({ id: 'paid1', pool: 'paid', remainingCents: 500 }),
+      lot({ id: 'free1', pool: 'free', remainingCents: 300 }),
+    ]
+    // burn 400 → free 300 fully, then paid 100
+    expect(burnDown(lots, 400, T0)).toEqual({
+      debits: [
+        { lotId: 'free1', pool: 'free', cents: 300 },
+        { lotId: 'paid1', pool: 'paid', cents: 100 },
+      ],
+      overageCents: 0,
+    })
+  })
+
+  it('reports overage when both pools are exhausted', () => {
+    const lots = [
+      lot({ id: 'free1', pool: 'free', remainingCents: 300 }),
+      lot({ id: 'paid1', pool: 'paid', remainingCents: 500 }),
+    ]
+    const r = burnDown(lots, 1000, T0)
+    expect(r.debits.reduce((s, d) => s + d.cents, 0)).toBe(800)
+    expect(r.overageCents).toBe(200)
+  })
+
+  it('excludes lots that are already expired at `now`', () => {
+    const lots = [
+      lot({ id: 'freeExpired', pool: 'free', remainingCents: 300, expiresAt: new Date('2026-06-26T12:00:00Z') }),
+      lot({ id: 'paid1', pool: 'paid', remainingCents: 500 }),
+    ]
+    // free is expired → 400 comes entirely from paid
+    expect(burnDown(lots, 400, T0)).toEqual({
+      debits: [{ lotId: 'paid1', pool: 'paid', cents: 400 }],
+      overageCents: 0,
+    })
+  })
+
+  it('within a pool, burns the soonest-expiring lot first', () => {
+    const lots = [
+      lot({ id: 'late', pool: 'free', remainingCents: 200, expiresAt: new Date('2026-07-10T00:00:00Z') }),
+      lot({ id: 'soon', pool: 'free', remainingCents: 200, expiresAt: new Date('2026-06-30T00:00:00Z') }),
+    ]
+    const r = burnDown(lots, 200, T0)
+    expect(r.debits).toEqual([{ lotId: 'soon', pool: 'free', cents: 200 }])
+  })
+
+  it('is a no-op for non-positive amounts', () => {
+    expect(burnDown([lot({ id: 'f', pool: 'free', remainingCents: 300 })], 0, T0)).toEqual({
+      debits: [],
+      overageCents: 0,
+    })
+  })
+})
+
+describe('applyTopUp', () => {
+  it('funds the paid pool entirely when the balance is non-negative', () => {
+    expect(applyTopUp(0, 1000)).toEqual({ settleNegativeCents: 0, toPaidPoolCents: 1000 })
+  })
+
+  it('settles a carried negative balance first, surplus to the paid pool', () => {
+    expect(applyTopUp(-50, 1000)).toEqual({ settleNegativeCents: 50, toPaidPoolCents: 950 })
+  })
+
+  it('uses the whole top-up to settle when it does not cover the deficit', () => {
+    expect(applyTopUp(-1500, 1000)).toEqual({ settleNegativeCents: 1000, toPaidPoolCents: 0 })
+  })
+})
+
+describe('deriveBillingStatus', () => {
+  it('refines active into low_balance / zero_balance from the live balance', () => {
+    expect(deriveBillingStatus('active', 5000, 1000)).toBe('active')
+    expect(deriveBillingStatus('active', 800, 1000)).toBe('low_balance')
+    expect(deriveBillingStatus('active', 0, 1000)).toBe('zero_balance')
+    expect(deriveBillingStatus('active', -20, 1000)).toBe('zero_balance')
+  })
+
+  it('passes through authoritative stored states unchanged', () => {
+    expect(deriveBillingStatus('trial', 5000, 1000)).toBe('trial')
+    expect(deriveBillingStatus('suspended', 5000, 1000)).toBe('suspended')
+    expect(deriveBillingStatus('closed', 5000, 1000)).toBe('closed')
+  })
+})

--- a/apps/api/src/billing/wallet/wallet-math.ts
+++ b/apps/api/src/billing/wallet/wallet-math.ts
@@ -1,0 +1,126 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+/**
+ * Pure wallet math — the dual-pool (free → paid) burn-down, top-up settlement,
+ * and billing-status derivation. No DB, no I/O; the WalletService wraps these in
+ * an optimistic-locked transaction and writes append-only transaction rows.
+ *
+ * Grounded in Lago's per-lot `remaining_amount_cents` FIFO burn + `lock_version`
+ * optimistic locking, and OpenMeter's "status is derived, not stored" rule
+ * (`StatusAt`). All amounts are integer cents (never float).
+ */
+
+export type Pool = 'free' | 'paid'
+
+/** Stored billing status (the only states persisted; low/zero are derived). */
+export type StoredBillingStatus = 'trial' | 'active' | 'suspended' | 'closed'
+
+/** The full billing status surfaced to callers (derived states included). */
+export type BillingStatus = 'trial' | 'active' | 'low_balance' | 'zero_balance' | 'suspended' | 'closed'
+
+/** One inbound credit lot (a top-up or grant) with a running remaining balance. */
+export interface InboundLot {
+  id: string
+  pool: Pool
+  /** free = 1, paid = 2 — lower drains first. */
+  priority: number
+  remainingCents: number
+  /** Lot expires (free credits); `null` = never. */
+  expiresAt: Date | null
+  createdAt: Date
+}
+
+/** One debit against a specific lot. */
+export interface LotDebit {
+  lotId: string
+  pool: Pool
+  cents: number
+}
+
+/** Result of burning an amount across the available lots. */
+export interface BurnResult {
+  debits: LotDebit[]
+  /** Amount that could not be covered by any lot (drives bounded-negative overage). */
+  overageCents: number
+}
+
+/**
+ * Order lots for consumption: lower priority first (free before paid), then
+ * soonest-expiring first (use credits before they lapse), then oldest first
+ * (FIFO tie-break). Lots already expired at `now` are excluded.
+ *
+ * NOTE: the SQL `ORDER BY` that mirrors this is left as a TODO pending a `gh`
+ * confirm of Lago's exact `in_consumption_order` (2-key vs 3-key with a
+ * granted/purchased CASE); this explicit-priority form is correct for both.
+ */
+function consumptionOrder(lots: InboundLot[], now: Date): InboundLot[] {
+  return lots
+    .filter((l) => l.remainingCents > 0 && (l.expiresAt === null || l.expiresAt.getTime() > now.getTime()))
+    .sort((a, b) => {
+      if (a.priority !== b.priority) return a.priority - b.priority
+      const ax = a.expiresAt ? a.expiresAt.getTime() : Number.POSITIVE_INFINITY
+      const bx = b.expiresAt ? b.expiresAt.getTime() : Number.POSITIVE_INFINITY
+      if (ax !== bx) return ax - bx
+      return a.createdAt.getTime() - b.createdAt.getTime()
+    })
+}
+
+/**
+ * Burn `amountCents` across the lots in consumption order, draining each lot to
+ * zero before moving on. Returns the per-lot debits and any uncovered overage
+ * (the bounded-negative amount that gets carried until the next top-up).
+ */
+export function burnDown(lots: InboundLot[], amountCents: number, now: Date): BurnResult {
+  if (amountCents <= 0) return { debits: [], overageCents: 0 }
+
+  const debits: LotDebit[] = []
+  let remaining = amountCents
+
+  for (const lot of consumptionOrder(lots, now)) {
+    if (remaining <= 0) break
+    const take = Math.min(lot.remainingCents, remaining)
+    debits.push({ lotId: lot.id, pool: lot.pool, cents: take })
+    remaining -= take
+  }
+
+  return { debits, overageCents: remaining }
+}
+
+/** What a top-up does: clear any carried negative balance first, the rest funds the paid pool. */
+export interface TopUpPlan {
+  /** Cents used to settle a prior bounded-negative balance (no new spendable credit). */
+  settleNegativeCents: number
+  /** Cents that become a fresh spendable paid-pool lot. */
+  toPaidPoolCents: number
+}
+
+/**
+ * Apply a top-up against the current (possibly negative) balance: a negative
+ * balance is settled first, only the surplus becomes spendable paid credit.
+ */
+export function applyTopUp(currentBalanceCents: number, topUpCents: number): TopUpPlan {
+  if (topUpCents <= 0) return { settleNegativeCents: 0, toPaidPoolCents: 0 }
+
+  const deficit = currentBalanceCents < 0 ? -currentBalanceCents : 0
+  const settle = Math.min(deficit, topUpCents)
+  return { settleNegativeCents: settle, toPaidPoolCents: topUpCents - settle }
+}
+
+/**
+ * Derive the surfaced billing status. `suspended` / `closed` / `trial` are
+ * authoritative (stored); `active` refines into `low_balance` / `zero_balance`
+ * from the live balance so the two can never drift out of sync.
+ */
+export function deriveBillingStatus(
+  stored: StoredBillingStatus,
+  balanceCents: number,
+  warnThresholdCents: number,
+): BillingStatus {
+  if (stored !== 'active') return stored
+  if (balanceCents <= 0) return 'zero_balance'
+  if (balanceCents <= warnThresholdCents) return 'low_balance'
+  return 'active'
+}

--- a/apps/api/src/billing/wallet/wallet-plan.spec.ts
+++ b/apps/api/src/billing/wallet/wallet-plan.spec.ts
@@ -1,0 +1,117 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { InboundLot } from './wallet-math'
+import { planCredit, planDebit } from './wallet-plan'
+
+const T0 = new Date('2026-06-27T12:00:00Z')
+const lot = (id: string, pool: 'free' | 'paid', remainingCents: number): InboundLot => ({
+  id,
+  pool,
+  priority: pool === 'free' ? 1 : 2,
+  remainingCents,
+  expiresAt: null,
+  createdAt: T0,
+})
+
+const sumLedger = (rows: { direction: string; amountCents: number }[]) =>
+  rows.reduce((s, r) => s + (r.direction === 'inbound' ? r.amountCents : -r.amountCents), 0)
+
+describe('planDebit', () => {
+  it('burns free then paid, balance stays = free + paid when non-negative', () => {
+    const plan = planDebit(
+      { balanceCents: 800, freeBalanceCents: 300, paidBalanceCents: 500 },
+      [lot('f', 'free', 300), lot('p', 'paid', 500)],
+      400,
+      T0,
+      { source: 'usage', ratedPeriodId: 'r1' },
+    )
+
+    expect(plan.balances).toEqual({ balanceCents: 400, freeBalanceCents: 0, paidBalanceCents: 400 })
+    expect(plan.overageCents).toBe(0)
+    expect(plan.balances.balanceCents).toBe(plan.balances.freeBalanceCents + plan.balances.paidBalanceCents)
+    // two outbound rows summing to the debit; balance change = SUM(ledger)
+    expect(sumLedger(plan.ledgerRows)).toBe(-400)
+    expect(plan.lotBurns).toEqual([
+      { lotId: 'f', newRemainingCents: 0 },
+      { lotId: 'p', newRemainingCents: 400 },
+    ])
+  })
+
+  it('goes bounded-negative on overage, with a debt row keeping SUM(ledger) exact', () => {
+    const plan = planDebit(
+      { balanceCents: 300, freeBalanceCents: 300, paidBalanceCents: 0 },
+      [lot('f', 'free', 300)],
+      500,
+      T0,
+      { source: 'usage', ratedPeriodId: 'r2' },
+    )
+
+    expect(plan.balances).toEqual({ balanceCents: -200, freeBalanceCents: 0, paidBalanceCents: 0 })
+    expect(plan.overageCents).toBe(200)
+    expect(sumLedger(plan.ledgerRows)).toBe(-500) // 300 covered + 200 debt
+    expect(plan.ledgerRows).toHaveLength(2)
+  })
+
+  it('the rated period id rides onto every outbound row (audit trail)', () => {
+    const plan = planDebit(
+      { balanceCents: 100, freeBalanceCents: 100, paidBalanceCents: 0 },
+      [lot('f', 'free', 100)],
+      50,
+      T0,
+      { source: 'usage', ratedPeriodId: 'rp-9' },
+    )
+    expect(plan.ledgerRows.every((r) => r.ratedPeriodId === 'rp-9')).toBe(true)
+  })
+})
+
+describe('planCredit', () => {
+  it('top-up funds the paid pool when the balance is non-negative', () => {
+    const plan = planCredit({ balanceCents: 0, freeBalanceCents: 0, paidBalanceCents: 0 }, 1000, 'paid', {
+      source: 'manual',
+      expiresAt: null,
+    })
+    expect(plan.balances).toEqual({ balanceCents: 1000, freeBalanceCents: 0, paidBalanceCents: 1000 })
+    expect(plan.settledNegativeCents).toBe(0)
+    expect(plan.ledgerRow).toMatchObject({
+      pool: 'paid',
+      direction: 'inbound',
+      amountCents: 1000,
+      remainingCents: 1000,
+    })
+  })
+
+  it('top-up settles a carried negative balance first, surplus is spendable', () => {
+    const plan = planCredit({ balanceCents: -50, freeBalanceCents: 0, paidBalanceCents: 0 }, 1000, 'paid', {
+      source: 'manual',
+      expiresAt: null,
+    })
+    expect(plan.balances).toEqual({ balanceCents: 950, freeBalanceCents: 0, paidBalanceCents: 950 })
+    expect(plan.settledNegativeCents).toBe(50)
+    expect(plan.ledgerRow.remainingCents).toBe(950) // only the surplus can be burned later
+    // invariant restored: balance == free + paid once non-negative
+    expect(plan.balances.balanceCents).toBe(plan.balances.freeBalanceCents + plan.balances.paidBalanceCents)
+  })
+
+  it('grant funds the free pool and carries an expiry', () => {
+    const expiry = new Date('2026-07-27T00:00:00Z')
+    const plan = planCredit({ balanceCents: 0, freeBalanceCents: 0, paidBalanceCents: 0 }, 500, 'free', {
+      source: 'grant',
+      expiresAt: expiry,
+    })
+    expect(plan.balances).toEqual({ balanceCents: 500, freeBalanceCents: 500, paidBalanceCents: 0 })
+    expect(plan.ledgerRow).toMatchObject({ pool: 'free', amountCents: 500, remainingCents: 500, expiresAt: expiry })
+  })
+
+  it('grant settles debt first too (keeps balance == free + paid)', () => {
+    const plan = planCredit({ balanceCents: -100, freeBalanceCents: 0, paidBalanceCents: 0 }, 300, 'free', {
+      source: 'grant',
+      expiresAt: null,
+    })
+    expect(plan.balances).toEqual({ balanceCents: 200, freeBalanceCents: 200, paidBalanceCents: 0 })
+    expect(plan.settledNegativeCents).toBe(100)
+    expect(plan.balances.balanceCents).toBe(plan.balances.freeBalanceCents + plan.balances.paidBalanceCents)
+  })
+})

--- a/apps/api/src/billing/wallet/wallet-plan.ts
+++ b/apps/api/src/billing/wallet/wallet-plan.ts
@@ -1,0 +1,156 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { applyTopUp, burnDown, InboundLot, Pool } from './wallet-math'
+import { TxSource } from '../entities/wallet-transaction.entity'
+
+/**
+ * Higher-level wallet planners — pure functions that turn a debit / top-up /
+ * grant into "which ledger rows to write, which lots to burn, and the wallet's
+ * new materialized balances". No DB: the WalletService loads the state inside an
+ * optimistic-locked transaction, calls a planner, then persists the plan. Keeping
+ * the money arithmetic here makes every balance transition unit-testable, and
+ * preserves the core invariant: `balanceCents == SUM(ledger)`, and whenever
+ * `balanceCents >= 0` it equals `freeBalanceCents + paidBalanceCents`.
+ */
+
+export const FREE_PRIORITY = 1
+export const PAID_PRIORITY = 2
+
+/** The materialized balance triple carried on the wallet row. */
+export interface WalletBalances {
+  /** Signed authoritative balance (can be bounded-negative on overage). */
+  balanceCents: number
+  freeBalanceCents: number
+  paidBalanceCents: number
+}
+
+/** A ledger row to insert (shape mirrors WalletTransaction's writable columns). */
+export interface PlannedLedgerRow {
+  pool: Pool
+  priority: number
+  direction: 'inbound' | 'outbound'
+  amountCents: number
+  /** Inbound: spendable remaining of this lot. Outbound: null. */
+  remainingCents: number | null
+  expiresAt: Date | null
+  source: TxSource
+  ratedPeriodId: string | null
+}
+
+/** A decrement to apply to an existing inbound lot's remaining balance. */
+export interface LotBurn {
+  lotId: string
+  newRemainingCents: number
+}
+
+export interface DebitPlan {
+  balances: WalletBalances
+  ledgerRows: PlannedLedgerRow[]
+  lotBurns: LotBurn[]
+  overageCents: number
+}
+
+export interface CreditPlan {
+  balances: WalletBalances
+  ledgerRow: PlannedLedgerRow
+  /** Cents that paid down a prior bounded-negative balance (no spendable credit). */
+  settledNegativeCents: number
+}
+
+const sumByPool = (debits: { pool: Pool; cents: number }[], pool: Pool) =>
+  debits.filter((d) => d.pool === pool).reduce((s, d) => s + d.cents, 0)
+
+/**
+ * Plan a usage debit: burn free→paid across the lots, write one outbound ledger
+ * row per burned lot (plus one uncovered-overage row so the ledger still sums to
+ * the full amount), and drop the signed balance by the full amount — letting it
+ * go bounded-negative when usage outruns the pools.
+ */
+export function planDebit(
+  balances: WalletBalances,
+  lots: InboundLot[],
+  amountCents: number,
+  now: Date,
+  opts: { source: TxSource; ratedPeriodId: string | null },
+): DebitPlan {
+  const burn = burnDown(lots, amountCents, now)
+  const byId = new Map(lots.map((l) => [l.id, l]))
+
+  const ledgerRows: PlannedLedgerRow[] = burn.debits.map((d) => ({
+    pool: d.pool,
+    priority: d.pool === 'free' ? FREE_PRIORITY : PAID_PRIORITY,
+    direction: 'outbound',
+    amountCents: d.cents,
+    remainingCents: null,
+    expiresAt: null,
+    source: opts.source,
+    ratedPeriodId: opts.ratedPeriodId,
+  }))
+
+  if (burn.overageCents > 0) {
+    // Uncovered usage — a debt row backed by no lot, so SUM(ledger) stays exact.
+    ledgerRows.push({
+      pool: 'paid',
+      priority: PAID_PRIORITY,
+      direction: 'outbound',
+      amountCents: burn.overageCents,
+      remainingCents: null,
+      expiresAt: null,
+      source: opts.source,
+      ratedPeriodId: opts.ratedPeriodId,
+    })
+  }
+
+  const lotBurns: LotBurn[] = burn.debits.map((d) => ({
+    lotId: d.lotId,
+    newRemainingCents: (byId.get(d.lotId)?.remainingCents ?? 0) - d.cents,
+  }))
+
+  return {
+    balances: {
+      balanceCents: balances.balanceCents - amountCents,
+      freeBalanceCents: balances.freeBalanceCents - sumByPool(burn.debits, 'free'),
+      paidBalanceCents: balances.paidBalanceCents - sumByPool(burn.debits, 'paid'),
+    },
+    ledgerRows,
+    lotBurns,
+    overageCents: burn.overageCents,
+  }
+}
+
+/**
+ * Plan an inbound credit (top-up → paid pool, grant → free pool). A carried
+ * negative balance is settled first; only the surplus becomes a spendable lot.
+ * The lot's `amountCents` is the full credit, but its `remainingCents` is just
+ * the spendable surplus, so the settled part can never be double-spent.
+ */
+export function planCredit(
+  balances: WalletBalances,
+  amountCents: number,
+  pool: Pool,
+  opts: { source: TxSource; expiresAt: Date | null },
+): CreditPlan {
+  const { settleNegativeCents, toPaidPoolCents: spendable } = applyTopUp(balances.balanceCents, amountCents)
+
+  return {
+    balances: {
+      balanceCents: balances.balanceCents + amountCents,
+      freeBalanceCents: balances.freeBalanceCents + (pool === 'free' ? spendable : 0),
+      paidBalanceCents: balances.paidBalanceCents + (pool === 'paid' ? spendable : 0),
+    },
+    ledgerRow: {
+      pool,
+      priority: pool === 'free' ? FREE_PRIORITY : PAID_PRIORITY,
+      direction: 'inbound',
+      amountCents,
+      remainingCents: spendable,
+      expiresAt: opts.expiresAt,
+      source: opts.source,
+      ratedPeriodId: null,
+    },
+    settledNegativeCents: settleNegativeCents,
+  }
+}

--- a/apps/api/src/billing/wallet/wallet.service.spec.ts
+++ b/apps/api/src/billing/wallet/wallet.service.spec.ts
@@ -113,7 +113,7 @@ describe('WalletService.grant', () => {
 
     expect(balances).toEqual({ balanceCents: 500, freeBalanceCents: 500, paidBalanceCents: 0 })
 
-    const tx = inserts.find((i) => i.entity === 'WalletTransaction')!.rows as Record<string, unknown>
+    const tx = (inserts.find((i) => i.entity === 'WalletTransaction')!.rows as Record<string, unknown>[])[0]
     expect(tx).toMatchObject({
       pool: 'free',
       direction: 'inbound',
@@ -141,7 +141,7 @@ describe('WalletService.topUp', () => {
     const { service, inserts } = makeService({ balanceCents: '-50', freeBalanceCents: '0', paidBalanceCents: '0' }, [])
     const balances = await service.topUp('org-1', 1000)
     expect(balances).toEqual({ balanceCents: 950, freeBalanceCents: 0, paidBalanceCents: 950 })
-    const tx = inserts.find((i) => i.entity === 'WalletTransaction')!.rows as Record<string, unknown>
+    const tx = (inserts.find((i) => i.entity === 'WalletTransaction')!.rows as Record<string, unknown>[])[0]
     expect(tx).toMatchObject({ pool: 'paid', amountCents: '1000', remainingCents: '950' }) // only surplus spendable
   })
 })

--- a/apps/api/src/billing/wallet/wallet.service.spec.ts
+++ b/apps/api/src/billing/wallet/wallet.service.spec.ts
@@ -1,0 +1,147 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { DataSource } from 'typeorm'
+import { CreditGrant } from '../entities/credit-grant.entity'
+import { Wallet } from '../entities/wallet.entity'
+import { WalletTransaction } from '../entities/wallet-transaction.entity'
+import { WalletService } from './wallet.service'
+
+const T0 = new Date('2026-06-27T12:00:00Z')
+
+type Insert = { entity: string; rows: unknown }
+type Update = { entity: string; id: unknown; patch: Record<string, unknown> }
+
+function makeService(wallet: Partial<Wallet>, lots: Partial<WalletTransaction>[]) {
+  const walletRow = {
+    id: 'w1',
+    organizationId: 'org-1',
+    balanceCents: '0',
+    freeBalanceCents: '0',
+    paidBalanceCents: '0',
+    lockVersion: 0,
+    billingStatus: 'active',
+    creditCardConnected: false,
+    ...wallet,
+  } as Wallet
+
+  const inserts: Insert[] = []
+  const updates: Update[] = []
+  const manager = {
+    findOneOrFail: async () => walletRow,
+    find: async () => lots,
+    insert: async (entity: { name: string }, rows: unknown) => {
+      inserts.push({ entity: entity.name, rows })
+      return { identifiers: [{ id: 'tx-new' }] }
+    },
+    update: async (entity: { name: string }, id: unknown, patch: Record<string, unknown>) => {
+      updates.push({ entity: entity.name, id, patch })
+    },
+  }
+  const dataSource = {
+    transaction: async (cb: (m: typeof manager) => unknown) => cb(manager),
+    getRepository: () => ({ findOne: async () => walletRow }),
+  } as unknown as DataSource
+
+  return { service: new WalletService(dataSource), inserts, updates }
+}
+
+const lot = (id: string, pool: 'free' | 'paid', remainingCents: string): Partial<WalletTransaction> => ({
+  id,
+  pool,
+  priority: pool === 'free' ? 1 : 2,
+  remainingCents,
+  expiresAt: null,
+  createdAt: T0,
+  direction: 'inbound',
+  status: 'settled',
+})
+
+describe('WalletService.debit', () => {
+  it('writes one outbound row per burned pool, decrements the lots, and updates the balance', async () => {
+    const { service, inserts, updates } = makeService(
+      { balanceCents: '800', freeBalanceCents: '300', paidBalanceCents: '500' },
+      [lot('f', 'free', '300'), lot('p', 'paid', '500')],
+    )
+
+    const balances = await service.debit('org-1', 400, { source: 'usage', ratedPeriodId: 'rp-1' }, T0)
+
+    expect(balances).toEqual({ balanceCents: 400, freeBalanceCents: 0, paidBalanceCents: 400 })
+
+    // outbound ledger rows (free 300 + paid 100)
+    const ledger = inserts.find((i) => i.entity === 'WalletTransaction')!.rows as Record<string, unknown>[]
+    expect(ledger).toHaveLength(2)
+    expect(ledger.map((r) => [r.pool, r.amountCents, r.direction])).toEqual([
+      ['free', '300', 'outbound'],
+      ['paid', '100', 'outbound'],
+    ])
+    expect(ledger.every((r) => r.ratedPeriodId === 'rp-1')).toBe(true)
+
+    // lot burns
+    const lotUpdates = updates.filter((u) => u.entity === 'WalletTransaction')
+    expect(lotUpdates).toEqual([
+      { entity: 'WalletTransaction', id: 'f', patch: { remainingCents: '0' } },
+      { entity: 'WalletTransaction', id: 'p', patch: { remainingCents: '400' } },
+    ])
+
+    // wallet materialization + lockVersion bump
+    const walletUpdate = updates.find((u) => u.entity === 'Wallet')!
+    expect(walletUpdate.patch).toEqual({
+      balanceCents: '400',
+      freeBalanceCents: '0',
+      paidBalanceCents: '400',
+      lockVersion: 1,
+    })
+  })
+
+  it('rejects a non-positive debit', async () => {
+    const { service } = makeService({}, [])
+    await expect(service.debit('org-1', 0, { source: 'usage', ratedPeriodId: null })).rejects.toThrow(/positive/)
+  })
+})
+
+describe('WalletService.grant', () => {
+  it('credits the free pool and writes an immutable credit_grant trail', async () => {
+    const { service, inserts, updates } = makeService(
+      { balanceCents: '0', freeBalanceCents: '0', paidBalanceCents: '0' },
+      [],
+    )
+
+    const balances = await service.grant('org-1', 500, { reason: 'goodwill', operatorId: 'op-1', note: 'demo' })
+
+    expect(balances).toEqual({ balanceCents: 500, freeBalanceCents: 500, paidBalanceCents: 0 })
+
+    const tx = inserts.find((i) => i.entity === 'WalletTransaction')!.rows as Record<string, unknown>
+    expect(tx).toMatchObject({
+      pool: 'free',
+      direction: 'inbound',
+      amountCents: '500',
+      remainingCents: '500',
+      source: 'grant',
+    })
+
+    const grant = inserts.find((i) => i.entity === 'CreditGrant')!.rows as Record<string, unknown>
+    expect(grant).toMatchObject({
+      type: 'grant',
+      pool: 'free',
+      amountCents: '500',
+      reason: 'goodwill',
+      operatorId: 'op-1',
+      walletTransactionId: 'tx-new',
+    })
+
+    expect(updates.find((u) => u.entity === 'Wallet')!.patch.lockVersion).toBe(1)
+  })
+})
+
+describe('WalletService.topUp', () => {
+  it('settles a carried negative balance then funds the paid pool', async () => {
+    const { service, inserts } = makeService({ balanceCents: '-50', freeBalanceCents: '0', paidBalanceCents: '0' }, [])
+    const balances = await service.topUp('org-1', 1000)
+    expect(balances).toEqual({ balanceCents: 950, freeBalanceCents: 0, paidBalanceCents: 950 })
+    const tx = inserts.find((i) => i.entity === 'WalletTransaction')!.rows as Record<string, unknown>
+    expect(tx).toMatchObject({ pool: 'paid', amountCents: '1000', remainingCents: '950' }) // only surplus spendable
+  })
+})

--- a/apps/api/src/billing/wallet/wallet.service.ts
+++ b/apps/api/src/billing/wallet/wallet.service.ts
@@ -10,7 +10,7 @@ import { CreditGrant } from '../entities/credit-grant.entity'
 import { Wallet } from '../entities/wallet.entity'
 import { TxSource, WalletTransaction } from '../entities/wallet-transaction.entity'
 import { BillingStatus, deriveBillingStatus, InboundLot, Pool } from './wallet-math'
-import { planCredit, planDebit, WalletBalances } from './wallet-plan'
+import { planCredit, planDebit, PlannedLedgerRow, WalletBalances } from './wallet-plan'
 
 const PG_UNIQUE_VIOLATION = '23505'
 const n = (cents: string): number => Number(cents)
@@ -38,6 +38,10 @@ export interface WalletView {
  * (planDebit/planCredit) decide the new balances and ledger rows. `lockVersion`
  * is bumped on every mutation as a monotonic audit/version counter.
  *
+ * The `*Within(manager, ...)` variants let a caller (e.g. WebhookService) fold a
+ * credit into its OWN transaction, so an idempotency marker and the balance
+ * change commit atomically.
+ *
  * NOTE: the design doc weighed optimistic-lock-with-retry (Lago) vs a pessimistic
  * row lock; we take the pessimistic lock here because every step is already
  * inside one transaction, which makes it simpler with the same no-lost-update
@@ -56,44 +60,50 @@ export class WalletService {
     opts: { source: TxSource; ratedPeriodId: string | null },
     now: Date = new Date(),
   ): Promise<WalletBalances> {
+    return this.dataSource.transaction((manager) => this.debitWithin(manager, organizationId, amountCents, opts, now))
+  }
+
+  /** debit() body, runnable inside a caller-provided transaction. */
+  async debitWithin(
+    manager: EntityManager,
+    organizationId: string,
+    amountCents: number,
+    opts: { source: TxSource; ratedPeriodId: string | null },
+    now: Date = new Date(),
+  ): Promise<WalletBalances> {
     if (amountCents <= 0) throw new Error(`debit amount must be positive, got ${amountCents}`)
+    const wallet = await this.lockWallet(manager, organizationId)
+    const lots = await this.openInboundLots(manager, wallet.id)
+    const plan = planDebit(toBalances(wallet), lots, amountCents, now, opts)
 
-    return this.dataSource.transaction(async (manager) => {
-      const wallet = await this.lockWallet(manager, organizationId)
-      const lots = await this.openInboundLots(manager, wallet.id)
-
-      const plan = planDebit(toBalances(wallet), lots, amountCents, now, opts)
-
-      await manager.insert(
-        WalletTransaction,
-        plan.ledgerRows.map((row) => ({
-          walletId: wallet.id,
-          status: 'settled' as const,
-          amountCents: s(row.amountCents),
-          remainingCents: row.remainingCents === null ? null : s(row.remainingCents),
-          pool: row.pool,
-          priority: row.priority,
-          direction: row.direction,
-          expiresAt: row.expiresAt,
-          source: row.source,
-          ratedPeriodId: row.ratedPeriodId,
-        })),
-      )
-      for (const burn of plan.lotBurns) {
-        await manager.update(WalletTransaction, burn.lotId, { remainingCents: s(burn.newRemainingCents) })
-      }
-      await this.persistBalances(manager, wallet, plan.balances)
-      return plan.balances
-    })
+    await this.insertLedger(manager, wallet.id, plan.ledgerRows, null)
+    for (const burn of plan.lotBurns) {
+      await manager.update(WalletTransaction, burn.lotId, { remainingCents: s(burn.newRemainingCents) })
+    }
+    await this.persistBalances(manager, wallet, plan.balances)
+    return plan.balances
   }
 
   /** Top up the paid pool (settles any carried negative first). */
-  async topUp(
+  topUp(
     organizationId: string,
     amountCents: number,
     source: Extract<TxSource, 'manual' | 'threshold'> = 'manual',
   ): Promise<WalletBalances> {
-    return this.credit(organizationId, amountCents, 'paid', { source, expiresAt: null })
+    return this.dataSource.transaction((manager) =>
+      this.topUpWithin(manager, organizationId, amountCents, source, null),
+    )
+  }
+
+  /** topUp() body, runnable inside a caller-provided transaction (e.g. webhook settlement). */
+  topUpWithin(
+    manager: EntityManager,
+    organizationId: string,
+    amountCents: number,
+    source: Extract<TxSource, 'manual' | 'threshold'>,
+    providerEventId: string | null,
+  ): Promise<WalletBalances> {
+    return this.creditWithin(manager, organizationId, amountCents, 'paid', { source, expiresAt: null, providerEventId })
   }
 
   /** Grant free credit (support adjustment); records an immutable credit_grant trail. */
@@ -108,18 +118,7 @@ export class WalletService {
         source: 'grant',
         expiresAt: opts.expiresAt ?? null,
       })
-      const inserted = await manager.insert(WalletTransaction, {
-        walletId: wallet.id,
-        status: 'settled' as const,
-        amountCents: s(plan.ledgerRow.amountCents),
-        remainingCents: plan.ledgerRow.remainingCents === null ? null : s(plan.ledgerRow.remainingCents),
-        pool: plan.ledgerRow.pool,
-        priority: plan.ledgerRow.priority,
-        direction: plan.ledgerRow.direction,
-        expiresAt: plan.ledgerRow.expiresAt,
-        source: plan.ledgerRow.source,
-        ratedPeriodId: null,
-      })
+      const [txId] = await this.insertLedger(manager, wallet.id, [plan.ledgerRow], null)
       await manager.insert(CreditGrant, {
         organizationId,
         amountCents: s(amountCents),
@@ -129,7 +128,7 @@ export class WalletService {
         note: opts.note ?? null,
         operatorId: opts.operatorId,
         expiresAt: opts.expiresAt ?? null,
-        walletTransactionId: inserted.identifiers[0].id as string,
+        walletTransactionId: txId,
       })
       await this.persistBalances(manager, wallet, plan.balances)
       return plan.balances
@@ -165,31 +164,45 @@ export class WalletService {
 
   // ── internals ───────────────────────────────────────────────────────────────
 
-  private async credit(
+  private async creditWithin(
+    manager: EntityManager,
     organizationId: string,
     amountCents: number,
     pool: Pool,
-    opts: { source: TxSource; expiresAt: Date | null },
+    opts: { source: TxSource; expiresAt: Date | null; providerEventId: string | null },
   ): Promise<WalletBalances> {
     if (amountCents <= 0) throw new Error(`credit amount must be positive, got ${amountCents}`)
-    return this.dataSource.transaction(async (manager) => {
-      const wallet = await this.lockWallet(manager, organizationId)
-      const plan = planCredit(toBalances(wallet), amountCents, pool, opts)
-      await manager.insert(WalletTransaction, {
-        walletId: wallet.id,
+    const wallet = await this.lockWallet(manager, organizationId)
+    const plan = planCredit(toBalances(wallet), amountCents, pool, { source: opts.source, expiresAt: opts.expiresAt })
+    await this.insertLedger(manager, wallet.id, [plan.ledgerRow], opts.providerEventId)
+    await this.persistBalances(manager, wallet, plan.balances)
+    return plan.balances
+  }
+
+  /** Insert ledger rows; returns their ids in order. */
+  private async insertLedger(
+    manager: EntityManager,
+    walletId: string,
+    rows: PlannedLedgerRow[],
+    providerEventId: string | null,
+  ): Promise<string[]> {
+    const result = await manager.insert(
+      WalletTransaction,
+      rows.map((row) => ({
+        walletId,
         status: 'settled' as const,
-        amountCents: s(plan.ledgerRow.amountCents),
-        remainingCents: plan.ledgerRow.remainingCents === null ? null : s(plan.ledgerRow.remainingCents),
-        pool: plan.ledgerRow.pool,
-        priority: plan.ledgerRow.priority,
-        direction: plan.ledgerRow.direction,
-        expiresAt: plan.ledgerRow.expiresAt,
-        source: plan.ledgerRow.source,
-        ratedPeriodId: null,
-      })
-      await this.persistBalances(manager, wallet, plan.balances)
-      return plan.balances
-    })
+        amountCents: s(row.amountCents),
+        remainingCents: row.remainingCents === null ? null : s(row.remainingCents),
+        pool: row.pool,
+        priority: row.priority,
+        direction: row.direction,
+        expiresAt: row.expiresAt,
+        source: row.source,
+        ratedPeriodId: row.ratedPeriodId,
+        providerEventId,
+      })),
+    )
+    return result.identifiers.map((i) => i.id as string)
   }
 
   /** Lock the wallet row for update (creates it first if missing). */

--- a/apps/api/src/billing/wallet/wallet.service.ts
+++ b/apps/api/src/billing/wallet/wallet.service.ts
@@ -1,0 +1,235 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Injectable, Logger } from '@nestjs/common'
+import { InjectDataSource } from '@nestjs/typeorm'
+import { DataSource, EntityManager, IsNull, MoreThan, QueryFailedError } from 'typeorm'
+import { CreditGrant } from '../entities/credit-grant.entity'
+import { Wallet } from '../entities/wallet.entity'
+import { TxSource, WalletTransaction } from '../entities/wallet-transaction.entity'
+import { BillingStatus, deriveBillingStatus, InboundLot, Pool } from './wallet-math'
+import { planCredit, planDebit, WalletBalances } from './wallet-plan'
+
+const PG_UNIQUE_VIOLATION = '23505'
+const n = (cents: string): number => Number(cents)
+const s = (cents: number): string => String(cents)
+
+function isUniqueViolation(err: unknown): boolean {
+  return err instanceof QueryFailedError && (err.driverError as { code?: string })?.code === PG_UNIQUE_VIOLATION
+}
+
+/** Wallet read-view with the derived billing status (low/zero computed live). */
+export interface WalletView {
+  organizationId: string
+  balanceCents: number
+  freeBalanceCents: number
+  paidBalanceCents: number
+  billingStatus: BillingStatus
+  creditCardConnected: boolean
+}
+
+/**
+ * Owns all wallet money movement. Every mutation runs in a transaction that
+ * pessimistically locks the wallet row (`SELECT ... FOR UPDATE`), so concurrent
+ * debits/top-ups on the same wallet serialize and can't lose an update — and
+ * because all work happens inside that transaction, the pure planners
+ * (planDebit/planCredit) decide the new balances and ledger rows. `lockVersion`
+ * is bumped on every mutation as a monotonic audit/version counter.
+ *
+ * NOTE: the design doc weighed optimistic-lock-with-retry (Lago) vs a pessimistic
+ * row lock; we take the pessimistic lock here because every step is already
+ * inside one transaction, which makes it simpler with the same no-lost-update
+ * guarantee. The lockVersion column keeps the optimistic path open later.
+ */
+@Injectable()
+export class WalletService {
+  private readonly logger = new Logger(WalletService.name)
+
+  constructor(@InjectDataSource() private readonly dataSource: DataSource) {}
+
+  /** Debit usage cost; burns free→paid and goes bounded-negative on overage. */
+  async debit(
+    organizationId: string,
+    amountCents: number,
+    opts: { source: TxSource; ratedPeriodId: string | null },
+    now: Date = new Date(),
+  ): Promise<WalletBalances> {
+    if (amountCents <= 0) throw new Error(`debit amount must be positive, got ${amountCents}`)
+
+    return this.dataSource.transaction(async (manager) => {
+      const wallet = await this.lockWallet(manager, organizationId)
+      const lots = await this.openInboundLots(manager, wallet.id)
+
+      const plan = planDebit(toBalances(wallet), lots, amountCents, now, opts)
+
+      await manager.insert(
+        WalletTransaction,
+        plan.ledgerRows.map((row) => ({
+          walletId: wallet.id,
+          status: 'settled' as const,
+          amountCents: s(row.amountCents),
+          remainingCents: row.remainingCents === null ? null : s(row.remainingCents),
+          pool: row.pool,
+          priority: row.priority,
+          direction: row.direction,
+          expiresAt: row.expiresAt,
+          source: row.source,
+          ratedPeriodId: row.ratedPeriodId,
+        })),
+      )
+      for (const burn of plan.lotBurns) {
+        await manager.update(WalletTransaction, burn.lotId, { remainingCents: s(burn.newRemainingCents) })
+      }
+      await this.persistBalances(manager, wallet, plan.balances)
+      return plan.balances
+    })
+  }
+
+  /** Top up the paid pool (settles any carried negative first). */
+  async topUp(
+    organizationId: string,
+    amountCents: number,
+    source: Extract<TxSource, 'manual' | 'threshold'> = 'manual',
+  ): Promise<WalletBalances> {
+    return this.credit(organizationId, amountCents, 'paid', { source, expiresAt: null })
+  }
+
+  /** Grant free credit (support adjustment); records an immutable credit_grant trail. */
+  async grant(
+    organizationId: string,
+    amountCents: number,
+    opts: { reason: string; operatorId: string; note?: string; expiresAt?: Date | null },
+  ): Promise<WalletBalances> {
+    return this.dataSource.transaction(async (manager) => {
+      const wallet = await this.lockWallet(manager, organizationId)
+      const plan = planCredit(toBalances(wallet), amountCents, 'free', {
+        source: 'grant',
+        expiresAt: opts.expiresAt ?? null,
+      })
+      const inserted = await manager.insert(WalletTransaction, {
+        walletId: wallet.id,
+        status: 'settled' as const,
+        amountCents: s(plan.ledgerRow.amountCents),
+        remainingCents: plan.ledgerRow.remainingCents === null ? null : s(plan.ledgerRow.remainingCents),
+        pool: plan.ledgerRow.pool,
+        priority: plan.ledgerRow.priority,
+        direction: plan.ledgerRow.direction,
+        expiresAt: plan.ledgerRow.expiresAt,
+        source: plan.ledgerRow.source,
+        ratedPeriodId: null,
+      })
+      await manager.insert(CreditGrant, {
+        organizationId,
+        amountCents: s(amountCents),
+        type: 'grant',
+        pool: 'free',
+        reason: opts.reason,
+        note: opts.note ?? null,
+        operatorId: opts.operatorId,
+        expiresAt: opts.expiresAt ?? null,
+        walletTransactionId: inserted.identifiers[0].id as string,
+      })
+      await this.persistBalances(manager, wallet, plan.balances)
+      return plan.balances
+    })
+  }
+
+  /** Read the wallet with a freshly-derived billing status. `warnThresholdCents` comes from the active plan. */
+  async getView(organizationId: string, warnThresholdCents: number): Promise<WalletView> {
+    const wallet = await this.getOrCreateWallet(organizationId)
+    const balance = n(wallet.balanceCents)
+    return {
+      organizationId,
+      balanceCents: balance,
+      freeBalanceCents: n(wallet.freeBalanceCents),
+      paidBalanceCents: n(wallet.paidBalanceCents),
+      billingStatus: deriveBillingStatus(wallet.billingStatus, balance, warnThresholdCents),
+      creditCardConnected: wallet.creditCardConnected,
+    }
+  }
+
+  /** Find or lazily create the org's wallet (trial, empty pools). */
+  async getOrCreateWallet(organizationId: string): Promise<Wallet> {
+    const repo = this.dataSource.getRepository(Wallet)
+    const existing = await repo.findOne({ where: { organizationId } })
+    if (existing) return existing
+    try {
+      return await repo.save(repo.create({ organizationId, billingStatus: 'trial' }))
+    } catch (err) {
+      if (isUniqueViolation(err)) return repo.findOneOrFail({ where: { organizationId } }) // lost the create race
+      throw err
+    }
+  }
+
+  // ── internals ───────────────────────────────────────────────────────────────
+
+  private async credit(
+    organizationId: string,
+    amountCents: number,
+    pool: Pool,
+    opts: { source: TxSource; expiresAt: Date | null },
+  ): Promise<WalletBalances> {
+    if (amountCents <= 0) throw new Error(`credit amount must be positive, got ${amountCents}`)
+    return this.dataSource.transaction(async (manager) => {
+      const wallet = await this.lockWallet(manager, organizationId)
+      const plan = planCredit(toBalances(wallet), amountCents, pool, opts)
+      await manager.insert(WalletTransaction, {
+        walletId: wallet.id,
+        status: 'settled' as const,
+        amountCents: s(plan.ledgerRow.amountCents),
+        remainingCents: plan.ledgerRow.remainingCents === null ? null : s(plan.ledgerRow.remainingCents),
+        pool: plan.ledgerRow.pool,
+        priority: plan.ledgerRow.priority,
+        direction: plan.ledgerRow.direction,
+        expiresAt: plan.ledgerRow.expiresAt,
+        source: plan.ledgerRow.source,
+        ratedPeriodId: null,
+      })
+      await this.persistBalances(manager, wallet, plan.balances)
+      return plan.balances
+    })
+  }
+
+  /** Lock the wallet row for update (creates it first if missing). */
+  private async lockWallet(manager: EntityManager, organizationId: string): Promise<Wallet> {
+    await this.getOrCreateWallet(organizationId) // ensure the row exists before locking it
+    return manager.findOneOrFail(Wallet, {
+      where: { organizationId },
+      lock: { mode: 'pessimistic_write' },
+    })
+  }
+
+  /** Settled inbound lots with spendable balance left, in no particular order (planner sorts). */
+  private async openInboundLots(manager: EntityManager, walletId: string): Promise<InboundLot[]> {
+    const rows = await manager.find(WalletTransaction, {
+      where: { walletId, direction: 'inbound', status: 'settled', voidedAt: IsNull(), remainingCents: MoreThan('0') },
+    })
+    return rows.map((r) => ({
+      id: r.id,
+      pool: r.pool,
+      priority: r.priority,
+      remainingCents: n(r.remainingCents as string),
+      expiresAt: r.expiresAt,
+      createdAt: r.createdAt,
+    }))
+  }
+
+  private async persistBalances(manager: EntityManager, wallet: Wallet, balances: WalletBalances): Promise<void> {
+    await manager.update(Wallet, wallet.id, {
+      balanceCents: s(balances.balanceCents),
+      freeBalanceCents: s(balances.freeBalanceCents),
+      paidBalanceCents: s(balances.paidBalanceCents),
+      lockVersion: wallet.lockVersion + 1,
+    })
+  }
+}
+
+function toBalances(wallet: Wallet): WalletBalances {
+  return {
+    balanceCents: n(wallet.balanceCents),
+    freeBalanceCents: n(wallet.freeBalanceCents),
+    paidBalanceCents: n(wallet.paidBalanceCents),
+  }
+}

--- a/apps/api/src/migrations/pre-deploy/1782500000000-migration.ts
+++ b/apps/api/src/migrations/pre-deploy/1782500000000-migration.ts
@@ -1,0 +1,175 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class Migration1782500000000 implements MigrationInterface {
+  name = 'Migration1782500000000'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // ─── pricing_plan ─────────────────────────────────────────────────────────
+    await queryRunner.query(
+      `CREATE TABLE "pricing_plan" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "version" integer NOT NULL,
+        "cpuRateCentsPerSec" numeric(30,10) NOT NULL,
+        "memRateCentsPerSec" numeric(30,10) NOT NULL,
+        "diskRateCentsPerSec" numeric(30,10) NOT NULL,
+        "warnThresholdCents" bigint NOT NULL,
+        "defaultGrantCents" bigint NOT NULL,
+        "effectiveFrom" TIMESTAMP WITH TIME ZONE NOT NULL,
+        "effectiveTo" TIMESTAMP WITH TIME ZONE,
+        "createdBy" character varying,
+        "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        CONSTRAINT "pricing_plan_id_pk" PRIMARY KEY ("id")
+      )`,
+    )
+    await queryRunner.query(`CREATE UNIQUE INDEX "pricing_plan_version_idx" ON "pricing_plan" ("version")`)
+    await queryRunner.query(`CREATE INDEX "pricing_plan_effective_idx" ON "pricing_plan" ("effectiveFrom")`)
+
+    // ─── customer_rate_override ───────────────────────────────────────────────
+    await queryRunner.query(
+      `CREATE TABLE "customer_rate_override" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "organizationId" character varying NOT NULL,
+        "discountFactor" numeric(6,5),
+        "effectiveRates" jsonb,
+        "effectiveFrom" TIMESTAMP WITH TIME ZONE NOT NULL,
+        "effectiveTo" TIMESTAMP WITH TIME ZONE,
+        "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        CONSTRAINT "customer_rate_override_id_pk" PRIMARY KEY ("id")
+      )`,
+    )
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "rate_override_org_active_idx" ON "customer_rate_override" ("organizationId") WHERE "effectiveTo" IS NULL`,
+    )
+
+    // ─── rated_period ─────────────────────────────────────────────────────────
+    await queryRunner.query(
+      `CREATE TABLE "rated_period" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "usagePeriodId" character varying NOT NULL,
+        "organizationId" character varying NOT NULL,
+        "boxId" character varying NOT NULL,
+        "pricingVersion" integer NOT NULL,
+        "unitRates" jsonb NOT NULL,
+        "billedSeconds" numeric(30,5) NOT NULL,
+        "preciseCents" numeric(30,5) NOT NULL,
+        "ratedCents" bigint NOT NULL,
+        "ratedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        CONSTRAINT "rated_period_id_pk" PRIMARY KEY ("id")
+      )`,
+    )
+    await queryRunner.query(`CREATE UNIQUE INDEX "rated_period_usage_period_idx" ON "rated_period" ("usagePeriodId")`)
+    await queryRunner.query(
+      `CREATE INDEX "rated_period_org_rated_at_idx" ON "rated_period" ("organizationId", "ratedAt")`,
+    )
+
+    // ─── wallet ───────────────────────────────────────────────────────────────
+    await queryRunner.query(
+      `CREATE TABLE "wallet" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "organizationId" character varying NOT NULL,
+        "balanceCents" bigint NOT NULL DEFAULT '0',
+        "ongoingBalanceCents" bigint NOT NULL DEFAULT '0',
+        "freeBalanceCents" bigint NOT NULL DEFAULT '0',
+        "paidBalanceCents" bigint NOT NULL DEFAULT '0',
+        "freeExpiresAt" TIMESTAMP WITH TIME ZONE,
+        "billingStatus" character varying NOT NULL DEFAULT 'trial',
+        "frozen" boolean NOT NULL DEFAULT false,
+        "lockVersion" integer NOT NULL DEFAULT 0,
+        "autoTopupThresholdCents" bigint,
+        "autoTopupTargetCents" bigint,
+        "creditCardConnected" boolean NOT NULL DEFAULT false,
+        "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        CONSTRAINT "wallet_id_pk" PRIMARY KEY ("id"),
+        CONSTRAINT "wallet_free_non_negative" CHECK ("freeBalanceCents" >= 0),
+        CONSTRAINT "wallet_paid_non_negative" CHECK ("paidBalanceCents" >= 0)
+      )`,
+    )
+    await queryRunner.query(`CREATE UNIQUE INDEX "wallet_org_idx" ON "wallet" ("organizationId")`)
+
+    // ─── wallet_transaction ───────────────────────────────────────────────────
+    await queryRunner.query(
+      `CREATE TABLE "wallet_transaction" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "walletId" uuid NOT NULL,
+        "pool" character varying NOT NULL,
+        "priority" integer NOT NULL,
+        "direction" character varying NOT NULL,
+        "amountCents" bigint NOT NULL,
+        "remainingCents" bigint,
+        "expiresAt" TIMESTAMP WITH TIME ZONE,
+        "status" character varying NOT NULL DEFAULT 'settled',
+        "source" character varying NOT NULL,
+        "ratedPeriodId" uuid,
+        "voidedAt" TIMESTAMP WITH TIME ZONE,
+        "stripeRef" text,
+        "providerEventId" text,
+        "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        CONSTRAINT "wallet_transaction_id_pk" PRIMARY KEY ("id"),
+        CONSTRAINT "wallet_tx_remaining_non_negative" CHECK ("remainingCents" IS NULL OR "remainingCents" >= 0)
+      )`,
+    )
+    await queryRunner.query(`CREATE INDEX "wallet_tx_wallet_idx" ON "wallet_transaction" ("walletId", "createdAt")`)
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "wallet_tx_provider_event_idx" ON "wallet_transaction" ("providerEventId") WHERE "providerEventId" IS NOT NULL`,
+    )
+
+    // ─── credit_grant ─────────────────────────────────────────────────────────
+    await queryRunner.query(
+      `CREATE TABLE "credit_grant" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "organizationId" character varying NOT NULL,
+        "amountCents" bigint NOT NULL,
+        "type" character varying NOT NULL,
+        "pool" character varying NOT NULL,
+        "reason" character varying NOT NULL,
+        "note" text,
+        "operatorId" character varying NOT NULL,
+        "expiresAt" TIMESTAMP WITH TIME ZONE,
+        "walletTransactionId" uuid,
+        "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        CONSTRAINT "credit_grant_id_pk" PRIMARY KEY ("id")
+      )`,
+    )
+    await queryRunner.query(`CREATE INDEX "credit_grant_org_idx" ON "credit_grant" ("organizationId", "createdAt")`)
+
+    // ─── processed_stripe_event ───────────────────────────────────────────────
+    await queryRunner.query(
+      `CREATE TABLE "processed_stripe_event" (
+        "stripeEventId" text NOT NULL,
+        "eventType" text NOT NULL,
+        "processedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        CONSTRAINT "processed_stripe_event_pk" PRIMARY KEY ("stripeEventId")
+      )`,
+    )
+
+    // ─── top_up_record ────────────────────────────────────────────────────────
+    await queryRunner.query(
+      `CREATE TABLE "top_up_record" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "organizationId" character varying NOT NULL,
+        "amountCents" bigint NOT NULL,
+        "method" character varying NOT NULL,
+        "status" character varying NOT NULL DEFAULT 'pending',
+        "walletTransactionId" uuid,
+        "stripeSessionId" text,
+        "stripePaymentIntentId" text,
+        "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        CONSTRAINT "top_up_record_id_pk" PRIMARY KEY ("id")
+      )`,
+    )
+    await queryRunner.query(`CREATE INDEX "top_up_org_idx" ON "top_up_record" ("organizationId", "createdAt")`)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "top_up_record"`)
+    await queryRunner.query(`DROP TABLE "processed_stripe_event"`)
+    await queryRunner.query(`DROP TABLE "credit_grant"`)
+    await queryRunner.query(`DROP TABLE "wallet_transaction"`)
+    await queryRunner.query(`DROP TABLE "wallet"`)
+    await queryRunner.query(`DROP TABLE "rated_period"`)
+    await queryRunner.query(`DROP TABLE "customer_rate_override"`)
+    await queryRunner.query(`DROP TABLE "pricing_plan"`)
+  }
+}

--- a/apps/api/src/migrations/pre-deploy/1782500000000-migration.ts
+++ b/apps/api/src/migrations/pre-deploy/1782500000000-migration.ts
@@ -34,7 +34,8 @@ export class Migration1782500000000 implements MigrationInterface {
         "effectiveFrom" TIMESTAMP WITH TIME ZONE NOT NULL,
         "effectiveTo" TIMESTAMP WITH TIME ZONE,
         "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
-        CONSTRAINT "customer_rate_override_id_pk" PRIMARY KEY ("id")
+        CONSTRAINT "customer_rate_override_id_pk" PRIMARY KEY ("id"),
+        CONSTRAINT "rate_override_discount_range" CHECK ("discountFactor" IS NULL OR ("discountFactor" >= 0 AND "discountFactor" <= 1))
       )`,
     )
     await queryRunner.query(
@@ -45,7 +46,7 @@ export class Migration1782500000000 implements MigrationInterface {
     await queryRunner.query(
       `CREATE TABLE "rated_period" (
         "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
-        "usagePeriodId" character varying NOT NULL,
+        "usagePeriodId" uuid NOT NULL,
         "organizationId" character varying NOT NULL,
         "boxId" character varying NOT NULL,
         "pricingVersion" integer NOT NULL,

--- a/apps/package.json
+++ b/apps/package.json
@@ -147,6 +147,7 @@
     "cmdk": "^1.1.1",
     "cookie-parser": "^1.4.7",
     "date-fns": "^4.1.0",
+    "decimal.js": "^10.6.0",
     "dockerode": "^4.0.4",
     "dotenv": "^17.0.1",
     "ejs": "^3.1.10",

--- a/docs/superpowers/specs/2026-06-27-billing-phase2-rating-wallet-design.md
+++ b/docs/superpowers/specs/2026-06-27-billing-phase2-rating-wallet-design.md
@@ -1,0 +1,72 @@
+# Billing Phase 2 — Rating + Wallet (backend) design
+
+Status: implemented (this branch). Stripe stubbed; UI/auto-suspend deferred.
+Grounded in: Lago (self-hosted billing), OpenMeter (grant/version-snapshot), the
+forked dashboard `OrganizationWallet` contract, Stripe webhook idempotency docs.
+
+## Scope
+
+In: rating (usage→USD, version-frozen), dual-pool wallet (free→paid), append-only
+ledger, payment-provider seam (Fake now / Stripe later), idempotent webhook
+settlement, pre-deploy migration, unit + (env-gated) integration tests.
+
+Out (deferred): live Stripe, dashboard UI wiring, auto-suspend box, refund/chargeback
+reversal, ongoing-balance refresh job.
+
+## Data flow
+
+```
+usage_period (Phase 1, closed)
+   └─ RatingService sweep ── resolve plan version + override, freeze snapshot
+        └─ rated_period (UNIQUE usagePeriodId → idempotent; unitRates jsonb frozen)
+             └─ WalletService.debit ── burn free→paid (planDebit)
+                  └─ wallet_transaction (append-only) + wallet (materialized, FOR UPDATE)
+TopUpService.createCheckout → provider intent → (user pays) → webhook
+   └─ WebhookService.ingest ── processed_stripe_event PK + topUpWithin (one txn)
+```
+
+## Components (one purpose each)
+
+| Unit | Responsibility | Depends on |
+|---|---|---|
+| `rate-math.ts` | pure: rate snapshot, seconds×rate (decimal.js), per-period totals | decimal.js |
+| `rating.service.ts` | sweep closed→unrated periods, freeze rate, write rated_period | usage_period, rated_period, pricing_plan, override |
+| `pricing.service.ts` | active plan + warn-threshold read | pricing_plan |
+| `wallet-math.ts` | pure: burnDown, applyTopUp, deriveBillingStatus | — |
+| `wallet-plan.ts` | pure: planDebit / planCredit → ledger rows + balances | wallet-math |
+| `wallet.service.ts` | txn + FOR UPDATE; debit/topUp/grant; `*Within` variants | DataSource |
+| `payment-provider.interface.ts` | money-movement seam | — |
+| `fake/stripe-payment-provider.ts` | Fake (tests) / Stripe (stub) | — |
+| `webhook.service.ts` | idempotent settlement (marker + credit, one txn) | DataSource, WalletService, provider |
+| `top-up.service.ts` | two-stage top-up (pending record + checkout intent) | DataSource, provider |
+
+## Invariants (enforced)
+
+1. Version snapshot — rated_period freezes `unitRates`; reads never join the live
+   plan; plan rate columns never updated. (price change can't move history)
+2. Burn order — free(1)→paid(2), soonest-expiry, FIFO; expired lots excluded.
+3. Append-only — ledger only inserts; reversals stamp `voidedAt`.
+4. Idempotency — rating `UNIQUE(usagePeriodId)`; webhook `processed_stripe_event`
+   PK inserted in the SAME transaction as the credit.
+5. Balance — `balanceCents == SUM(ledger)`; when `>= 0` it equals `free + paid`;
+   overage writes a debt row and goes bounded-negative.
+6. Concurrency — every wallet mutation runs in one txn with `SELECT FOR UPDATE`.
+7. Precision — decimal.js accumulate; round half-up only at the cent boundary;
+   money is integer-cents bigint, never float.
+
+## Key decisions (deviations noted)
+
+- **Pessimistic lock** (`SELECT FOR UPDATE`) over optimistic-retry: all work is in
+  one transaction, so it's simpler with the same no-lost-update guarantee.
+  `lockVersion` retained for a future optimistic path.
+- **grant is not an HTTP endpoint** — admin-only (a member must not self-credit).
+- **Two-stage top-up** — POST returns a checkout URL; the wallet is credited only
+  by the confirming webhook.
+
+## Tests
+
+68 unit (pure math + service orchestration + webhook idempotency-guard) + an
+env-gated real-Postgres integration spec (`RUN_DB_IT=1`): migration + CHECK +
+rating idempotency + dual-pool end-to-end + webhook idempotency.
+
+Full report + ASCII diagrams: Obsidian `1-Projects/2026-06-Billing/08-Phase2-实现报告.md`.


### PR DESCRIPTION
> **Phase 2 backend = Rating + Wallet.** Stacked on Phase 1 (#857).
> Grounded in real open-source billing code: Lago (self-hosted billing) + OpenMeter (grant / version snapshot) + the forked dashboard `OrganizationWallet` contract + Stripe webhook-idempotency guidance.
> **Draft: please review the direction before deciding to merge. Stripe is stubbed; UI / auto-suspend are deferred.**

## Data flow

```
usage_period (Phase 1, closed)
  └─ RatingService sweep ── pick plan version + override, freeze the rate snapshot
       └─ rated_period (UNIQUE usagePeriodId → idempotent; unitRates jsonb frozen → price change can't move history)
            └─ WalletService.debit ── burn free → paid
                 └─ wallet_transaction (append-only) + wallet (materialized, SELECT FOR UPDATE)
TopUpService → provider checkout → (user pays) → WebhookService.ingest
  └─ processed_stripe_event PK + topUpWithin (same transaction → idempotent, never double-credits)
```

## What's in this PR

| Layer | Files | Responsibility |
|---|---|---|
| Pure logic | `rate-math` / `wallet-math` / `wallet-plan` | rating math (decimal.js precision) + dual-pool burn / top-up / grant planners |
| Services | `rating.service` / `wallet.service` / `webhook.service` / `top-up.service` / `pricing.service` | rate closed periods / dual-pool debit (txn + pessimistic lock) / idempotent settlement / two-stage top-up |
| Seam | `PaymentProvider` + `FakeProvider` + `StripeProvider` (stub) | money-movement abstraction, Stripe-ready |
| Schema | 8 entities + pre-deploy migration | pricing_plan / rated_period / wallet / wallet_transaction / credit_grant / + 3 |
| API | `BillingController` (GET wallet, POST top-up) + webhook controller + DTOs | aligned to the dashboard `OrganizationWallet` contract |

## Invariants enforced

- **Version snapshot** — `rated_period` freezes `unitRates`; reads never join the live plan; plan rate columns are never updated → a price change can't move a historical bill (OpenMeter SnapshotLineQuantity).
- **Balance** — `balanceCents == SUM(ledger)`; when `>= 0` it equals `free + paid`; overage writes a debt row and the balance goes bounded-negative (the debt row keeps SUM exact).
- **Idempotency (two layers)** — rating `UNIQUE(usagePeriodId)` ‖ webhook `processed_stripe_event` PK inserted in the SAME transaction as the credit.
- **Concurrency** — every wallet mutation runs in one transaction with `SELECT FOR UPDATE` → no lost updates.
- **Precision** — decimal.js accumulate; round half-up only at the cent boundary; money is integer cents (bigint), never float.
- **Append-only** — the ledger only inserts; reversals stamp `voidedAt`.

## Tests

- **70 unit tests green + tsc clean across the app** (pure logic + service orchestration + webhook idempotency guard).
- **Real-Postgres integration test — RAN ✅ 4/4** against Postgres 17 (env-gated `RUN_DB_IT=1`, skipped in CI): migration applies, wallet CHECK fires, rating `UNIQUE(usagePeriodId)` idempotency (re-sweep = 0), dual-pool grant→debit→bounded-negative overage with ledger SUM == balance, webhook `processed_stripe_event` idempotency. Run: `RUN_DB_IT=1 npx nx test api --testPathPatterns=billing.integration`.
- **Full local stack (infra-local) — verified L1→L4 ✅**:
  - **L1**: boxlite microVM boxes (postgres / redis / dex / minio / …) boot on Apple Silicon.
  - **L3**: the API boots cleanly with `BillingModule` → `BillingController {/api/billing}` registered → "Nest application successfully started". All 8 Phase-2 tables created by the migration in the real Postgres box.
  - **L4** (HTTP → controller → service → real Postgres box): `POST /api/billing/webhook` with a top-up event → `{"outcome":"processed"}`; re-delivering the same event → `{"outcome":"duplicate"}`; the wallet is credited **exactly once** (balanceCents=1234, one ledger row, one dedup marker). `GET /api/billing/wallet` without auth → `401` (route + guard live).

## Adversarial review (4 dimensions → skeptical verify → fixed)

```
Raw findings: P0×3 P1×7  ── after adversarial verification ──► real P0 = 0
The three hardest accounting properties (balance invariant / txn atomicity / rating idempotency) were all confirmed correct. Quality: B+.
Fixed: P1 (decimal.js into the manifest) + P2 (top-up state machine closed) + P2 (method.saved card-flag drop) + 3× P3.
```

## ⚠️ Launch blockers (must handle before merging to main)

1. **rawBody webhook** — real Stripe signature verification needs the raw request bytes; today the FakeProvider doesn't verify (self-documented TODO in the webhook controller).
2. **Wire up Stripe** — `stripe-payment-provider.ts` is a stub (each method documents exactly what the real implementation must do); needs API keys.

## Deferred (explicitly not done)

Live Stripe / dashboard UI wiring / auto-suspend box / refund-chargeback reversal / ongoing-balance refresh job = M2+.

## Key decisions (deviations from the design doc)

- **Pessimistic lock** (`SELECT FOR UPDATE`) instead of the optimistic-retry the design sketched: all work is in one transaction, so it's simpler with the same no-lost-update guarantee (`lockVersion` kept for the optimistic path later).
- **grant is not an HTTP endpoint** — a member must never be able to self-credit free balance; it stays service-only for admin tooling.
- **Two-stage top-up** — POST returns a checkout URL and does not move money; the wallet is credited only by the confirming webhook.

---
🤖 Built autonomously overnight. Full report: Obsidian `1-Projects/2026-06-Billing/08-Phase2-实现报告.md` and repo `docs/superpowers/specs/2026-06-27-billing-phase2-rating-wallet-design.md`.
