### PR TITLE
Improve boxes pagination UX

### DIFF
--- a/apps/dashboard/src/components/BoxTable/index.test.tsx
+++ b/apps/dashboard/src/components/BoxTable/index.test.tsx
@@ -149,6 +149,8 @@ describe('BoxTable pagination controls', () => {
       onPaginationChange,
     })
 
+    expect(document.body.textContent).toContain('Loading boxes...')
+    expect(document.body.textContent).not.toContain('Showing 26-50 of 92 boxes')
     expect(document.body.textContent).toContain('Loading page')
 
     const nextButton = getRequiredElement<HTMLButtonElement>('button[title="Next"]')

--- a/apps/dashboard/src/components/BoxTable/index.test.tsx
+++ b/apps/dashboard/src/components/BoxTable/index.test.tsx
@@ -1,0 +1,177 @@
+// @vitest-environment jsdom
+/*
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { act, type ReactNode } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import { Box, BoxState } from '@boxlite-ai/api-client'
+import { BoxTable } from './index'
+import { type BoxTableProps } from './types'
+
+vi.mock('@/hooks/useSelectedOrganization', () => ({
+  useSelectedOrganization: () => ({
+    authenticatedUserHasPermission: () => true,
+  }),
+}))
+
+vi.mock('@/components/ui/select', () => ({
+  Select: ({
+    value,
+    onValueChange,
+    disabled,
+    children,
+  }: {
+    value: string
+    onValueChange: (value: string) => void
+    disabled?: boolean
+    children: ReactNode
+  }) => (
+    <select
+      aria-label="Rows per page"
+      value={value}
+      disabled={disabled}
+      onChange={(event) => onValueChange(event.currentTarget.value)}
+    >
+      {children}
+    </select>
+  ),
+  SelectContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+  SelectItem: ({ value, children }: { value: string; children: ReactNode }) => (
+    <option value={value}>{children}</option>
+  ),
+  SelectTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  SelectValue: () => null,
+}))
+
+function makeBox(id: string): Box {
+  return {
+    id,
+    name: `box-${id}`,
+    state: BoxState.STOPPED,
+    cpu: 1,
+    memory: 2,
+    disk: 10,
+    createdAt: '2026-06-01T00:00:00.000Z',
+  } as Box
+}
+
+function getRequiredElement<T extends Element>(selector: string): T {
+  const element = document.querySelector<T>(selector)
+
+  if (!element) {
+    throw new Error(`Missing expected element: ${selector}`)
+  }
+
+  return element
+}
+
+const baseProps: BoxTableProps = {
+  data: Array.from({ length: 25 }, (_, index) => makeBox(`${index + 1}`)),
+  boxIsLoading: {},
+  boxStateIsTransitioning: {},
+  loading: false,
+  handleStart: vi.fn(),
+  handleStop: vi.fn(),
+  handleDelete: vi.fn(),
+  handleBulkDelete: vi.fn(),
+  handleBulkStart: vi.fn(),
+  handleBulkStop: vi.fn(),
+  onRowClick: vi.fn(),
+  pagination: {
+    pageIndex: 1,
+    pageSize: 25,
+  },
+  pageCount: 4,
+  totalItems: 92,
+  onPaginationChange: vi.fn(),
+  sorting: {},
+  onSortingChange: vi.fn(),
+  filters: {},
+  onFiltersChange: vi.fn(),
+  handleRecover: vi.fn(),
+}
+
+describe('BoxTable pagination controls', () => {
+  let root: Root | null = null
+
+  beforeAll(() => {
+    ;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+  })
+
+  afterEach(() => {
+    act(() => {
+      root?.unmount()
+    })
+    root = null
+    document.body.innerHTML = ''
+    vi.clearAllMocks()
+  })
+
+  function renderBoxTable(overrides: Partial<BoxTableProps> & { isPageFetching?: boolean } = {}) {
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    const props = {
+      ...baseProps,
+      ...overrides,
+    }
+
+    act(() => {
+      root = createRoot(host)
+      root.render(<BoxTable {...props} />)
+    })
+
+    return props
+  }
+
+  it('lets the user choose how many boxes are shown per page', () => {
+    const onPaginationChange = vi.fn()
+    renderBoxTable({ onPaginationChange })
+
+    const pageSizeSelect = getRequiredElement<HTMLSelectElement>('select[aria-label="Rows per page"]')
+
+    expect(pageSizeSelect.value).toBe('25')
+
+    act(() => {
+      pageSizeSelect.value = '50'
+      pageSizeSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    })
+
+    expect(onPaginationChange).toHaveBeenCalledWith({ pageIndex: 0, pageSize: 50 })
+  })
+
+  it('prevents stacked page requests while a page change is loading', () => {
+    const onPaginationChange = vi.fn()
+    renderBoxTable({
+      isPageFetching: true,
+      onPaginationChange,
+    })
+
+    expect(document.body.textContent).toContain('Loading page')
+
+    const nextButton = getRequiredElement<HTMLButtonElement>('button[title="Next"]')
+    expect(nextButton.disabled).toBe(true)
+
+    act(() => {
+      nextButton.click()
+    })
+
+    expect(onPaginationChange).not.toHaveBeenCalled()
+  })
+
+  it('allows pagination controls when the current page is not being replaced', () => {
+    const onPaginationChange = vi.fn()
+    renderBoxTable({ onPaginationChange })
+
+    const nextButton = getRequiredElement<HTMLButtonElement>('button[title="Next"]')
+    expect(nextButton.disabled).toBe(false)
+
+    act(() => {
+      nextButton.click()
+    })
+
+    expect(onPaginationChange).toHaveBeenCalledWith({ pageIndex: 2, pageSize: 25 })
+  })
+})

--- a/apps/dashboard/src/components/BoxTable/index.tsx
+++ b/apps/dashboard/src/components/BoxTable/index.tsx
@@ -7,7 +7,7 @@
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
 import { getBoxDisplayName, getBoxPublicIdLabel } from '@/lib/box-identity'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
-import { getRelativeTimeString } from '@/lib/utils'
+import { cn, getRelativeTimeString } from '@/lib/utils'
 import { isRecoverable, isStartable, isStoppable, isTransitioning } from '@/lib/utils/box'
 import { OrganizationRolePermissionsEnum, Box, BoxState } from '@boxlite-ai/api-client'
 import {
@@ -25,6 +25,8 @@ import {
 } from '@/components/ui/icon'
 import { type ReactNode } from 'react'
 import { BoxTableProps } from './types'
+import { PAGE_SIZE_OPTIONS } from '@/constants/Pagination'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 
 // Exact design palette (Boxes page.dc.html statusColors) — used inline so the
 // status dots/labels render at the precise hue, not a token approximation.
@@ -106,6 +108,7 @@ export function BoxTable({
   boxIsLoading,
   boxStateIsTransitioning,
   loading,
+  isPageFetching = false,
   handleStart,
   handleStop,
   handleDelete,
@@ -121,7 +124,32 @@ export function BoxTable({
   const deletePermitted = authenticatedUserHasPermission(OrganizationRolePermissionsEnum.DELETE_BOXES)
 
   const pageIndex = pagination.pageIndex
-  const goTo = (index: number) => onPaginationChange({ pageIndex: index, pageSize: pagination.pageSize })
+  const pageSize = pagination.pageSize
+  const isPagingLocked = loading || isPageFetching
+  const pageTotal = Math.max(pageCount, 1)
+  const shownFirstItem = totalItems === 0 || data.length === 0 ? 0 : Math.min(pageIndex * pageSize + 1, totalItems)
+  const shownLastItem =
+    totalItems === 0 || data.length === 0 ? 0 : Math.min(pageIndex * pageSize + data.length, totalItems)
+  const itemRangeLabel =
+    totalItems === 0
+      ? 'Showing 0 boxes'
+      : `Showing ${shownFirstItem.toLocaleString('en-US')}-${shownLastItem.toLocaleString('en-US')} of ${totalItems.toLocaleString('en-US')} boxes`
+  const goTo = (index: number) => {
+    if (isPagingLocked || index === pageIndex || index < 0 || index >= pageCount) {
+      return
+    }
+
+    onPaginationChange({ pageIndex: index, pageSize })
+  }
+  const handlePageSizeChange = (value: string) => {
+    const nextPageSize = Number(value)
+
+    if (!Number.isFinite(nextPageSize) || nextPageSize === pageSize) {
+      return
+    }
+
+    onPaginationChange({ pageIndex: 0, pageSize: nextPageSize })
+  }
   const canPrev = pageIndex > 0
   const canNext = pageCount > 0 && pageIndex < pageCount - 1
 
@@ -192,7 +220,13 @@ export function BoxTable({
       </div>
 
       {/* rows */}
-      <div className="hidden min-h-0 flex-1 overflow-y-auto md:block">
+      <div
+        className={cn(
+          'hidden min-h-0 flex-1 overflow-y-auto md:block',
+          isPageFetching && 'opacity-60 transition-opacity',
+        )}
+        aria-busy={loading || isPageFetching}
+      >
         {loading ? (
           Array.from({ length: 5 }).map((_, i) => (
             <div key={i} className={`grid ${GRID} items-center border-b border-border px-[18px] py-3`}>
@@ -249,7 +283,13 @@ export function BoxTable({
         )}
       </div>
 
-      <div className="min-h-0 flex-1 space-y-3 overflow-y-auto md:hidden">
+      <div
+        className={cn(
+          'min-h-0 flex-1 space-y-3 overflow-y-auto md:hidden',
+          isPageFetching && 'opacity-60 transition-opacity',
+        )}
+        aria-busy={loading || isPageFetching}
+      >
         {loading ? (
           Array.from({ length: 4 }).map((_, i) => (
             <div key={i} className="border border-border bg-card p-4">
@@ -328,28 +368,58 @@ export function BoxTable({
 
       {/* footer */}
       <div className="flex flex-none flex-col gap-3 px-0 py-4 font-mono text-[10px] uppercase tracking-[1px] text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
-        <span>
-          Showing {data.length} of {totalItems.toLocaleString('en-US')} boxes
-        </span>
-        {pageCount > 1 && (
-          <div className="flex items-center gap-[7px]">
-            <span className="normal-case tracking-normal">
-              Page {pageIndex + 1} of {pageCount}
-            </span>
-            <PagerButton disabled={!canPrev} title="First" onClick={() => goTo(0)}>
-              <ChevronsLeft className="size-3.5" />
-            </PagerButton>
-            <PagerButton disabled={!canPrev} title="Previous" onClick={() => goTo(pageIndex - 1)}>
-              <ChevronLeft className="size-3.5" />
-            </PagerButton>
-            <PagerButton disabled={!canNext} title="Next" onClick={() => goTo(pageIndex + 1)}>
-              <ChevronRight className="size-3.5" />
-            </PagerButton>
-            <PagerButton disabled={!canNext} title="Last" onClick={() => goTo(pageCount - 1)}>
-              <ChevronsRight className="size-3.5" />
-            </PagerButton>
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-4">
+          <span>{itemRangeLabel}</span>
+          <div className="flex items-center gap-2">
+            <span className="normal-case tracking-normal">Show</span>
+            <Select value={`${pageSize}`} onValueChange={handlePageSizeChange} disabled={isPagingLocked}>
+              <SelectTrigger
+                aria-label="Rows per page"
+                size="xs"
+                className="h-8 w-[76px] border-border bg-background px-2 font-mono text-[10px] uppercase tracking-[1px]"
+                loading={isPagingLocked}
+              >
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent side="top">
+                {PAGE_SIZE_OPTIONS.map((option) => (
+                  <SelectItem key={option} value={`${option}`}>
+                    {option}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <span className="normal-case tracking-normal">per page</span>
           </div>
-        )}
+        </div>
+        <div className="flex items-center gap-[7px] pr-14">
+          <span className="inline-flex min-w-[92px] items-center justify-end gap-1 normal-case tracking-normal">
+            {isPageFetching ? (
+              <>
+                <Loader2 className="size-3 animate-spin" strokeWidth={1.5} />
+                Loading page {pageIndex + 1}
+              </>
+            ) : (
+              `Page ${pageIndex + 1} of ${pageTotal}`
+            )}
+          </span>
+          {pageCount > 1 && (
+            <>
+              <PagerButton disabled={isPagingLocked || !canPrev} title="First" onClick={() => goTo(0)}>
+                <ChevronsLeft className="size-3.5" />
+              </PagerButton>
+              <PagerButton disabled={isPagingLocked || !canPrev} title="Previous" onClick={() => goTo(pageIndex - 1)}>
+                <ChevronLeft className="size-3.5" />
+              </PagerButton>
+              <PagerButton disabled={isPagingLocked || !canNext} title="Next" onClick={() => goTo(pageIndex + 1)}>
+                <ChevronRight className="size-3.5" />
+              </PagerButton>
+              <PagerButton disabled={isPagingLocked || !canNext} title="Last" onClick={() => goTo(pageCount - 1)}>
+                <ChevronsRight className="size-3.5" />
+              </PagerButton>
+            </>
+          )}
+        </div>
       </div>
     </div>
   )

--- a/apps/dashboard/src/components/BoxTable/index.tsx
+++ b/apps/dashboard/src/components/BoxTable/index.tsx
@@ -131,9 +131,11 @@ export function BoxTable({
   const shownLastItem =
     totalItems === 0 || data.length === 0 ? 0 : Math.min(pageIndex * pageSize + data.length, totalItems)
   const itemRangeLabel =
-    totalItems === 0
-      ? 'Showing 0 boxes'
-      : `Showing ${shownFirstItem.toLocaleString('en-US')}-${shownLastItem.toLocaleString('en-US')} of ${totalItems.toLocaleString('en-US')} boxes`
+    isPageFetching
+      ? 'Loading boxes...'
+      : totalItems === 0
+        ? 'Showing 0 boxes'
+        : `Showing ${shownFirstItem.toLocaleString('en-US')}-${shownLastItem.toLocaleString('en-US')} of ${totalItems.toLocaleString('en-US')} boxes`
   const goTo = (index: number) => {
     if (isPagingLocked || index === pageIndex || index < 0 || index >= pageCount) {
       return

--- a/apps/dashboard/src/components/BoxTable/types.ts
+++ b/apps/dashboard/src/components/BoxTable/types.ts
@@ -19,6 +19,7 @@ export interface BoxTableProps {
   boxIsLoading: Record<string, boolean>
   boxStateIsTransitioning: Record<string, boolean>
   loading: boolean
+  isPageFetching?: boolean
   handleStart: (id: string) => void
   handleStop: (id: string) => void
   handleDelete: (id: string) => void

--- a/apps/dashboard/src/pages/Boxes.tsx
+++ b/apps/dashboard/src/pages/Boxes.tsx
@@ -152,7 +152,12 @@ const Boxes: React.FC = () => {
     [selectedOrganization?.id, queryParams],
   )
 
-  const { data: boxesData, isLoading: boxesDataIsLoading, error: boxesDataError } = useBoxes(queryKey, queryParams)
+  const {
+    data: boxesData,
+    isLoading: boxesDataIsLoading,
+    isPlaceholderData: boxesDataIsPlaceholderData,
+    error: boxesDataError,
+  } = useBoxes(queryKey, queryParams)
   const hasBoxes = (boxesData?.items.length ?? 0) > 0 || (boxesData?.total ?? 0) > 0
 
   useEffect(() => {
@@ -776,6 +781,7 @@ const Boxes: React.FC = () => {
           handleBulkStop={handleBulkStop}
           data={boxesData?.items || []}
           loading={boxesDataIsLoading}
+          isPageFetching={boxesDataIsPlaceholderData}
           onRowClick={(box: Box) => {
             navigate(generatePath(RoutePath.BOX_DETAILS, { boxId: getBoxRouteId(box) }))
           }}


### PR DESCRIPTION
## Summary
- Add page-size controls and explicit item range/total display to the boxes table footer.
- Lock pagination controls and show a small loading state only while a new page is replacing the current rows.
- Keep existing rows visually dimmed during page replacement and add focused tests for page-size changes and stacked-click prevention.

## Test Plan
- [x] yarn vitest run -c dashboard/vite.config.mts dashboard/src/components/BoxTable/index.test.tsx
- [x] yarn tsc --noEmit -p dashboard/tsconfig.app.json
- [x] make lint:apps
- [x] make test:apps
- [x] VERSION=0.0.0-dev GOFLAGS=-tags=boxlite_dev make build:apps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Rows per page” selector and updated the boxes table footer with page and item-range labels.
  * Introduced a distinct page-loading state to show “Loading page…” feedback during background fetching.

* **Bug Fixes**
  * Prevented page navigation while paging is locked (including page background loading) and ensured page-size changes reset back to the first page.

* **Tests**
  * Added tests covering rows-per-page updates, loading-state rendering/disabled controls, and next-page navigation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->