### PR TITLE
feat(hooks): add turn-end verdict-proof gate; rename audit→commit-push

### DIFF
--- a/.claude/agents/commit-push-auditor.md
+++ b/.claude/agents/commit-push-auditor.md
@@ -1,6 +1,6 @@
 ---
-name: claude-md-auditor
-description: Independent auditor that judges a pending git commit or push against every applicable bullet in CLAUDE.md (Workflow section). MUST be invoked before retrying a `git commit` or `git push` that was blocked by .claude/hooks/preflight-claude-md.sh. Reads CLAUDE.md and the diff cold in fresh context, writes a structured verdict to .claude/.last-audit.json. The hook only allows the next retry when the verdict file is PASS and matches the current branch + HEAD.
+name: commit-push-auditor
+description: Independent auditor that judges a pending git commit or push against every applicable bullet in CLAUDE.md (Workflow section). MUST be invoked before retrying a `git commit` or `git push` that was blocked by .claude/hooks/preflight-commit-push.sh. Reads CLAUDE.md and the diff cold in fresh context, writes a structured verdict to .claude/.last-audit.json. The hook only allows the next retry when the verdict file is PASS and matches the current branch + HEAD.
 tools: Read, Bash, Write
 ---
 

--- a/.claude/agents/verdict-auditor.md
+++ b/.claude/agents/verdict-auditor.md
@@ -1,0 +1,103 @@
+---
+name: verdict-auditor
+description: Independent auditor that checks whether the agent's stated verdict — claims like "the fix works", "tests pass", "root cause is X", "<thing> is removed/unused", "done" — is backed by concrete, re-runnable proof rather than prose. MUST be invoked when .claude/hooks/preflight-verdict-check.sh blocks the agent from ending its turn. Reads the agent's last message (the claim) and the working-tree diff (the work) cold, judges proof against CLAUDE.md's Test/Verify rules, and writes a structured dossier to .claude/.last-verdict.json. The Stop hook only lets the turn end when the dossier is PASS (or IN_PROGRESS) and matches the current branch + working-tree hash.
+tools: Read, Bash, Write
+---
+
+You are the verdict proof auditor for this repository. Your job: decide whether the
+work the agent just did actually backs the claims it just made — with proof that could
+be **re-run**, not narrative. You judge the verdict cold; you do not trust the agent's
+own account of its proof.
+
+The parent agent must give you the path to the session transcript (`transcript_path`,
+a JSONL file). If it didn't, ask for it before proceeding.
+
+## Procedure
+
+1. **Identify the claims.** Read the agent's last assistant message from
+   `transcript_path`. Extract every *behavioral* claim about the work — e.g. "fixes
+   <bug>", "tests pass", "root cause is <X>", "<thing> is now removed/unused", "done".
+   Use judgment; do NOT pattern-match keywords. A turn with no behavioral claim (pure
+   explanation, a question to the user, research-only) has nothing to prove → `PASS`
+   with empty `proof`.
+
+2. **Capture state.** Run these EXACTLY (the tree hash must match what the hook
+   recomputes, so use this method verbatim):
+   - `git branch --show-current`
+   - `git rev-parse HEAD`
+   - working-tree hash (content-addressed, captures tracked + untracked, never touches
+     the real index):
+     ```bash
+     idx="$(mktemp)"; GIT_INDEX_FILE="$idx" git read-tree HEAD >/dev/null 2>&1
+     GIT_INDEX_FILE="$idx" git add -A >/dev/null 2>&1
+     GIT_INDEX_FILE="$idx" git write-tree; rm -f "$idx"
+     ```
+
+3. **Capture the work:** `git diff HEAD` (tracked, staged + unstaged) and
+   `git status --porcelain` (full file set, incl. untracked). Read the changed
+   production files as needed to judge the claims.
+
+4. **Judge proof per claim** against the repo's *existing* standards (CLAUDE.md Test /
+   Verify sections — read them). Proof must be ground truth, never the agent's prose:
+
+   | Claim | Tier-1 (always — cheap, non-fakeable for what it checks) | Tier-2 (selective) |
+   |---|---|---|
+   | Fix works | a reproducer exists in the diff AND references the production symbols under test (not tautological — CLAUDE.md:85) | run revert→fail→restore→pass (CLAUDE.md:81–84) in an isolated worktree |
+   | Tests pass | a concrete, re-runnable command is named (not "I ran the tests"); CLAUDE.md:95 | re-run that command → exit 0 |
+   | Root cause is X | the cited `file:line` / log lines resolve and actually support the claim; proven is separated from hypothesis | — (no mechanical ground truth) |
+   | Removal safe | `git grep` shows no remaining references | live-environment check |
+   | Subjective ("clean/good design") | OUT OF SCOPE — no concrete proof exists; do not gate it | — |
+
+   - **Tier-2 trigger:** only when the diff touches core runtime or security paths, OR
+     the agent's message explicitly asks for deep verification. Otherwise Tier-1 is
+     enough for `PASS` — but say in your reply that Tier-2 was not run.
+   - **Tier-2 safety invariant:** perform the two-side check in an ISOLATED git worktree
+     (`git worktree add --detach`), reconstruct the change there (apply `git diff HEAD`,
+     copy any untracked files that are part of the change), run the reproducer without
+     the production fix (must FAIL, log the signal) then with it (must PASS), then
+     `git worktree remove`. NEVER stash, revert, or mutate the live working tree.
+   - **FAIL** when: a "tests pass" claim names no re-runnable command; a reproducer is
+     tautological (CLAUDE.md:85) or absent for a fix claim; a root cause is asserted as
+     fact with no resolving citation; or Tier-2 (when triggered) does not show red→green.
+
+5. **Escape valves** (so the gate has teeth without misfiring into bypass):
+   - If proof genuinely can't be produced (e.g. cannot reproduce in this environment),
+     mark that proof entry `"status":"blocked"` with a one-line `blocker` stating the
+     residual risk (CLAUDE.md:95). Blocked proof still allows `PASS`, but it is surfaced.
+   - If the agent is NOT actually done (pausing mid-task, stopping to ask the user
+     something), set the whole dossier `"verdict":"IN_PROGRESS"` and list what remains
+     in `findings`.
+
+6. **Write** `.claude/.last-verdict.json` with EXACTLY this shape (no extra fields):
+   ```json
+   {
+     "branch": "<from step 2>",
+     "head": "<from step 2>",
+     "tree_hash": "<from step 2>",
+     "verdict": "PASS" | "FAIL" | "IN_PROGRESS",
+     "proof": [
+       {
+         "claim": "<the behavioral claim, one line>",
+         "kind": "fix-works" | "tests-pass" | "root-cause" | "removal-safe",
+         "evidence": "<re-runnable: test id / file:line / command + observed result>",
+         "method": "structural" | "rerun" | "two-side",
+         "status": "verified" | "blocked",
+         "blocker": null
+       }
+     ],
+     "findings": ["<phase/claim>: <one line on why proof is missing>", "..."]
+   }
+   ```
+   On `PASS` with every claim verified, `findings` is an empty array. On `FAIL`, each
+   finding names the gap concretely enough to act on.
+
+7. Reply to the parent agent with the verdict and findings.
+
+## Constraints
+
+- Only judge — do not fix code, do not edit the work, do not end the turn yourself.
+- Applicability is your judgment, not a regex on the message.
+- Tier-2 runs only in an isolated worktree; NEVER revert or mutate the live tree.
+- Subjective claims have no concrete proof — leave them out of the dossier entirely.
+- The hook reads only the JSON dossier; your chat reply is for the parent's benefit.
+  Both must agree.

--- a/.claude/hooks/preflight-commit-push.sh
+++ b/.claude/hooks/preflight-commit-push.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # PreToolUse hook: gate `git commit` / `git push` on a fresh verdict from the
-# claude-md-auditor subagent (see .claude/agents/claude-md-auditor.md).
+# commit-push-auditor subagent (see .claude/agents/commit-push-auditor.md).
 #
 # The hook itself does not call any model; it only reads the verdict artifact
 # the subagent writes at .claude/.last-audit.json and checks that the verdict
@@ -8,7 +8,7 @@
 #
 # Flow on a denied attempt:
 #   1. Hook denies the git tool call.
-#   2. Reason text instructs the parent agent to invoke the claude-md-auditor
+#   2. Reason text instructs the parent agent to invoke the commit-push-auditor
 #      subagent via the Task tool, then retry the same git command.
 #   3. Subagent writes .claude/.last-audit.json.
 #   4. Parent retries -> hook reads the artifact and allows on PASS.
@@ -31,7 +31,7 @@
 #   commit-then-push of the same HEAD must re-audit; the user has accepted
 #   this trade-off to avoid stale-audit-passes-new-content failure modes.
 #
-# Tests: bash .claude/hooks/preflight-claude-md.test.sh
+# Tests: bash .claude/hooks/preflight-commit-push.test.sh
 set -euo pipefail
 
 payload="$(cat)"
@@ -72,8 +72,8 @@ deny() {
   exit 0
 }
 
-invoke_instruction="Invoke the claude-md-auditor subagent now:
-  Task(subagent_type='claude-md-auditor',
+invoke_instruction="Invoke the commit-push-auditor subagent now:
+  Task(subagent_type='commit-push-auditor',
        description='CLAUDE.md audit',
        prompt='Audit the pending \`${command}\` on branch ${branch}.')
 The subagent will write its verdict to .claude/.last-audit.json. Retry the
@@ -116,7 +116,7 @@ if [[ "$audit_verdict" != "PASS" ]]; then
 
 ${findings}
 
-Address each finding, then re-invoke claude-md-auditor before retrying \`${command}\`."
+Address each finding, then re-invoke commit-push-auditor before retrying \`${command}\`."
 fi
 
 # Verdict is PASS, recent, and matches current state — let the git command run.

--- a/.claude/hooks/preflight-commit-push.test.sh
+++ b/.claude/hooks/preflight-commit-push.test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tests for .claude/hooks/preflight-claude-md.sh
+# Tests for .claude/hooks/preflight-commit-push.sh
 #
 # Covers the two areas CLAUDE.md flags for required tests on this change:
 #   1. Command matcher (parsing + branching): direct invocation vs. chain
@@ -7,12 +7,12 @@
 #   2. Gate logic (branching + boundary validation): missing / mismatched /
 #      stale / FAIL / consumed audit-file paths.
 #
-# Run with:  bash .claude/hooks/preflight-claude-md.test.sh
+# Run with:  bash .claude/hooks/preflight-commit-push.test.sh
 # Exits non-zero on any failure.
 set -uo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
-HOOK="$REPO_ROOT/.claude/hooks/preflight-claude-md.sh"
+HOOK="$REPO_ROOT/.claude/hooks/preflight-commit-push.sh"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 

--- a/.claude/hooks/preflight-pr-review.sh
+++ b/.claude/hooks/preflight-pr-review.sh
@@ -16,7 +16,7 @@
 #
 # Design notes
 # ------------
-# * Matcher scope: same reason as preflight-claude-md.sh — PreToolUse matchers
+# * Matcher scope: same reason as preflight-commit-push.sh — PreToolUse matchers
 #   are tool-name-only. This script does the actual `gh pr <subcmd>` filtering
 #   and exits 0 immediately on unrelated bash calls.
 #
@@ -28,7 +28,7 @@
 #
 # * One-shot consumption: the marker file is `rm -f`'d on the allow path so
 #   each successive gh pr command forces a fresh ack, even at the same HEAD.
-#   Mirrors the trade-off in preflight-claude-md.sh.
+#   Mirrors the trade-off in preflight-commit-push.sh.
 #
 # Tests: bash .claude/hooks/preflight-pr-review.test.sh
 set -euo pipefail
@@ -38,7 +38,7 @@ command="$(printf '%s' "$payload" | jq -r '.tool_input.command // ""')"
 
 # Match `gh pr create|edit|ready` at start of command OR at start of any chain
 # segment (after &&, ||, ;, |, &, $(, (, `). Same shape as the git matcher in
-# preflight-claude-md.sh so chained invocations are caught.
+# preflight-commit-push.sh so chained invocations are caught.
 #
 # Scan only the FIRST physical line of the command. Multi-line commands almost
 # always put the gh invocation on the first line; this excludes heredoc bodies

--- a/.claude/hooks/preflight-verdict-check.sh
+++ b/.claude/hooks/preflight-verdict-check.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# Stop hook: gate the agent from ENDING ITS TURN while it has unproven behavioral
+# work, on a fresh dossier from the verdict-auditor subagent
+# (see .claude/agents/verdict-auditor.md).
+#
+# The hook itself does not call any model; it reads the dossier the subagent
+# writes at .claude/.last-verdict.json and checks that the verdict is PASS (or
+# IN_PROGRESS), recent, and bound to the current branch + HEAD + working-tree hash.
+#
+# Flow on a blocked stop:
+#   1. Hook blocks the turn from ending.
+#   2. The `reason` reaches the model; it invokes the verdict-auditor subagent.
+#   3. Subagent writes .claude/.last-verdict.json.
+#   4. Model ends its turn again -> hook reads the dossier and allows on PASS.
+# The subagent's own completion is a SubagentStop event, not Stop, so it does not
+# re-trigger this hook (no recursion).
+#
+# Wired in .claude/settings.json under hooks.Stop (no matcher — fires every turn end).
+#
+# Design notes
+# ------------
+# * Every-turn-end: a Stop hook fires whenever the agent ends a turn, with no
+#   "done vs paused" signal in the payload. So we first apply a cheap, deterministic
+#   PRE-FILTER: unless there are uncommitted changes to PRODUCTION files, we allow
+#   immediately. Pure chat / research / docs-only turns never gate. Production is
+#   decided by PATH, never by parsing the message (no string-match intent guessing).
+#
+# * Tree-hash binding: at stop time the work is usually UNCOMMITTED (HEAD has not
+#   moved), so HEAD alone can't tell "audited" from "changed since audit". We bind
+#   the dossier to a content-addressed hash of the full working tree, computed via a
+#   throwaway index + `git write-tree` (deterministic; no timestamps; never touches
+#   the real index). The verdict-auditor computes it the SAME way.
+#
+# * Loop-safety: the block is satisfiable — a fresh PASS or IN_PROGRESS dossier
+#   always lets the turn end — so we never depend on the (undocumented) stop_hook_active.
+#
+# * One-shot consumption: the dossier is `rm -f`'d on the allow path so the next
+#   "done" re-checks. Mirrors the trade-off in preflight-commit-push.sh.
+#
+# Tests: bash .claude/hooks/preflight-verdict-check.test.sh
+set -uo pipefail
+
+payload="$(cat)"
+transcript_path="$(printf '%s' "$payload" | jq -r '.transcript_path // ""' 2>/dev/null || echo '')"
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+project_dir="${CLAUDE_PROJECT_DIR:-$repo_root}"
+branch="$(git -C "$repo_root" branch --show-current 2>/dev/null || echo '?')"
+head="$(git -C "$repo_root" rev-parse HEAD 2>/dev/null || echo '?')"
+verdict_file="$project_dir/.claude/.last-verdict.json"
+max_age_seconds=600
+
+allow()           { exit 0; }                                              # let the turn end
+allow_with_note() { jq -nc --arg m "$1" '{continue:true, systemMessage:$m}'; exit 0; }
+# Soft mode (default): emit a non-blocking nudge instead of hard-blocking, so the
+# gate does not trap conversational turn-ends while the working tree is dirty. The
+# hard proof checkpoint belongs at the commit/push boundary (preflight-commit-push.sh).
+# Set VERDICT_GATE_HARD_BLOCK=1 to restore turn-end blocking.
+block() {
+  if [[ "${VERDICT_GATE_HARD_BLOCK:-0}" == "1" ]]; then
+    jq -nc --arg r "$1" '{decision:"block", reason:$r}'
+  else
+    jq -nc --arg r "$1" '{continue:true, systemMessage:("[verdict-gate] " + $r)}'
+  fi
+  exit 0
+}
+
+# Content-addressed hash of the full working tree (tracked + untracked, full
+# content), via a throwaway index. Deterministic and read-only w.r.t. the real
+# index/tree. Keep IDENTICAL to the snippet in verdict-auditor.md.
+compute_tree_hash() {
+  local idx; idx="$(mktemp)"
+  GIT_INDEX_FILE="$idx" git -C "$repo_root" read-tree HEAD >/dev/null 2>&1
+  GIT_INDEX_FILE="$idx" git -C "$repo_root" add -A >/dev/null 2>&1
+  GIT_INDEX_FILE="$idx" git -C "$repo_root" write-tree 2>/dev/null
+  rm -f "$idx"
+}
+
+# ── Pre-filter: is there pending PRODUCTION work worth proving? ───────────────
+# Count changed paths that are NOT docs (*.md, docs/) and NOT agent/tooling infra
+# (.claude/, .codex/). `grep -c` reads all input (no early-exit SIGPIPE under
+# pipefail); `|| true` keeps the no-match exit-1 from aborting.
+n_prod="$(git -C "$repo_root" status --porcelain 2>/dev/null \
+  | sed -E 's/^.{3}//' \
+  | grep -Ecv '(\.md$|^docs/|/docs/|^\.claude/|^\.codex/)' || true)"
+if [[ "${n_prod:-0}" -eq 0 ]]; then
+  allow
+fi
+
+# ── Gate: require a fresh, matching dossier ──────────────────────────────────
+# ─────────────────────────────────────────────────────────────────────────────
+# TODO(user, learning-mode): this block `reason` is the gate's UX and its
+# anti-cheating contract — what Claude reads when it tries to end a turn with
+# unproven behavioral work. Refine the wording to taste, but keep these invariants:
+#   • Direct Claude to invoke the verdict-auditor subagent (Task tool), passing the
+#     transcript path so the auditor can read the very claim it must check.
+#   • The AUDITOR — not Claude — writes ${verdict_file}. Claude must not write or
+#     hand-edit the dossier (that is grading its own homework / confabulating proof).
+#   • Offer the honest exits: IN_PROGRESS if not actually done; a `blocked` proof
+#     entry (with residual risk) if proof genuinely can't be produced in this env.
+#   • After the auditor reports, end the turn again; this hook re-checks.
+#
+# Variables available: ${transcript_path} ${branch} ${head} ${verdict_file}
+verdict_instruction="You are ending your turn with unproven changes on branch '${branch}'.
+Attach proof for what you claim you did before finishing.
+
+Invoke the verdict-auditor subagent now:
+  Task(subagent_type='verdict-auditor',
+       description='verdict proof check',
+       prompt='Check my last message'\\''s verdict against the working-tree diff.
+               transcript_path: ${transcript_path}')
+
+It judges your claims against CLAUDE.md'\\''s Test/Verify rules and writes its dossier
+to ${verdict_file}. Do NOT write that file yourself.
+
+If you are not actually done (pausing, or asking the user something), have the
+auditor record verdict IN_PROGRESS with what remains. If a claim genuinely cannot
+be proven in this environment, the auditor can mark that proof 'blocked' with the
+residual risk. Then end your turn again."
+# ─────────────────────────────────────────────────────────────────────────────
+
+if [[ ! -r "$verdict_file" ]]; then
+  block "No verdict dossier found for the changes in your working tree.
+
+${verdict_instruction}"
+fi
+
+v_branch="$(jq -r '.branch // ""'    "$verdict_file" 2>/dev/null || echo '')"
+v_head="$(jq -r '.head // ""'        "$verdict_file" 2>/dev/null || echo '')"
+v_tree="$(jq -r '.tree_hash // ""'   "$verdict_file" 2>/dev/null || echo '')"
+v_verdict="$(jq -r '.verdict // ""'  "$verdict_file" 2>/dev/null || echo '')"
+
+# mtime as freshness signal — portable across BSD (stat -f %m) and GNU (stat -c %Y).
+v_mtime="$(stat -f '%m' "$verdict_file" 2>/dev/null || stat -c '%Y' "$verdict_file" 2>/dev/null || echo 0)"
+now_epoch="$(date +%s)"
+age=$(( now_epoch - v_mtime ))
+
+cur_tree="$(compute_tree_hash)"
+
+if [[ "$v_branch" != "$branch" ]] || \
+   [[ "$v_head" != "$head" ]] || \
+   [[ "$v_tree" != "$cur_tree" ]] || \
+   (( age > max_age_seconds )); then
+  block "Existing verdict dossier does not match the current working tree:
+  dossier.branch=${v_branch}  current=${branch}
+  dossier.head=${v_head}      current=${head}
+  dossier.tree_hash=${v_tree:0:12}  current=${cur_tree:0:12}
+  dossier age: ${age}s (max ${max_age_seconds}s)
+
+The work changed since it was audited. Re-audit is required.
+${verdict_instruction}"
+fi
+
+if [[ "$v_verdict" == "PASS" ]]; then
+  rm -f "$verdict_file"   # consume; next "done" re-checks
+  allow
+fi
+
+if [[ "$v_verdict" == "IN_PROGRESS" ]]; then
+  remaining="$(jq -r '.findings[]? | "  - " + .' "$verdict_file" 2>/dev/null || echo '')"
+  rm -f "$verdict_file"
+  allow_with_note "Verdict: IN_PROGRESS — proof deferred, work not yet complete:
+${remaining}"
+fi
+
+# FAIL or any unexpected verdict → block with the findings.
+findings="$(jq -r '.findings[]? | "  - " + .' "$verdict_file" 2>/dev/null || echo '')"
+block "Verdict proof check FAILED on branch '${branch}':
+
+${findings}
+
+Address each finding, then re-invoke verdict-auditor before ending your turn.
+${verdict_instruction}"

--- a/.claude/hooks/preflight-verdict-check.test.sh
+++ b/.claude/hooks/preflight-verdict-check.test.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Tests for .claude/hooks/preflight-verdict-check.sh (the Stop-stage verdict gate).
+#
+# Unlike the commit-push gate (which keys off an artifact + the real repo's
+# branch/HEAD), this hook's decision depends on the WORKING-TREE STATE. So each
+# case builds a throwaway git repo in a controlled state and runs the hook there
+# (cwd + CLAUDE_PROJECT_DIR both pointed at it), asserting allow vs block.
+#
+# Stop contract: allow = empty stdout (exit 0); block = stdout {"decision":"block"};
+# IN_PROGRESS = {"continue":true,...} (non-empty but no block decision = allow).
+#
+# Run with:  bash .claude/hooks/preflight-verdict-check.test.sh
+# Exits non-zero on any failure.
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+HOOK="$REPO_ROOT/.claude/hooks/preflight-verdict-check.sh"
+PAYLOAD='{"transcript_path":"/dev/null","hook_event_name":"Stop"}'
+
+pass=0
+fail=0
+
+# Fresh git repo with one committed production file.
+setup() {
+  local d; d="$(mktemp -d)"
+  git -C "$d" init -q
+  git -C "$d" config user.email t@t.test
+  git -C "$d" config user.name tester
+  mkdir -p "$d/src"
+  printf 'pub fn base() {}\n' > "$d/src/lib.rs"
+  # Mirror the real repo: the dossier is gitignored, so it never enters the
+  # working-tree hash. Without this the hook's `git add -A` would fold the
+  # dossier into the hash and never match what the auditor computed.
+  printf '.claude/.last-verdict.json\n' > "$d/.gitignore"
+  git -C "$d" add -A
+  git -C "$d" commit -qm base
+  printf '%s' "$d"
+}
+
+# Same content-addressed tree hash the hook computes (keep in sync).
+tree_hash_of() {
+  local repo="$1" idx; idx="$(mktemp)"
+  GIT_INDEX_FILE="$idx" git -C "$repo" read-tree HEAD >/dev/null 2>&1
+  GIT_INDEX_FILE="$idx" git -C "$repo" add -A >/dev/null 2>&1
+  GIT_INDEX_FILE="$idx" git -C "$repo" write-tree 2>/dev/null
+  rm -f "$idx"
+}
+
+# Write a dossier; tree_hash defaults to the repo's current working-tree hash.
+write_verdict() {
+  local repo="$1" verdict="$2" findings="$3" tree="${4:-$(tree_hash_of "$1")}"
+  local br hd; br="$(git -C "$repo" branch --show-current)"; hd="$(git -C "$repo" rev-parse HEAD)"
+  mkdir -p "$repo/.claude"
+  jq -nc --arg b "$br" --arg h "$hd" --arg t "$tree" --arg v "$verdict" --argjson f "$findings" \
+    '{branch:$b, head:$h, tree_hash:$t, verdict:$v, proof:[], findings:$f}' \
+    > "$repo/.claude/.last-verdict.json"
+}
+
+# Run the hook inside repo and classify the decision.
+decide() {
+  local repo="$1" out d
+  # Decision-logic cases run in HARD mode so a block condition is observable as
+  # decision:block. Soft mode (the default) is covered in its own section below.
+  out="$(printf '%s' "$PAYLOAD" | ( cd "$repo" && CLAUDE_PROJECT_DIR="$repo" VERDICT_GATE_HARD_BLOCK=1 bash "$HOOK" ) 2>/dev/null)"
+  if [[ -z "$out" ]]; then
+    printf 'allow'
+  else
+    d="$(printf '%s' "$out" | jq -r '.decision // "allow"' 2>/dev/null || echo parse_error)"
+    [[ "$d" == "block" ]] && printf 'block' || printf 'allow'
+  fi
+}
+
+check() {  # desc  repo  expect
+  local desc="$1" repo="$2" expect="$3" got
+  got="$(decide "$repo")"
+  if [[ "$got" == "$expect" ]]; then
+    pass=$((pass + 1)); printf '  PASS  %s\n' "$desc"
+  else
+    fail=$((fail + 1)); printf '  FAIL  %s  (got=%s expected=%s)\n' "$desc" "$got" "$expect"
+  fi
+}
+
+echo "## Pre-filter: turns with no production work end freely"
+R="$(setup)";                                                check "clean tree → allow"            "$R" "allow"; rm -rf "$R"
+R="$(setup)"; printf 'docs\n' > "$R/README.md";              check "docs-only (*.md) → allow"      "$R" "allow"; rm -rf "$R"
+R="$(setup)"; mkdir -p "$R/docs"; printf 'x\n' > "$R/docs/a.txt"; check "docs/ dir → allow"         "$R" "allow"; rm -rf "$R"
+R="$(setup)"; mkdir -p "$R/.claude"; printf 'x\n' > "$R/.claude/note.md"; check "agent infra (.claude/) → allow" "$R" "allow"; rm -rf "$R"
+
+echo
+echo "## Gate: production change present"
+R="$(setup)"; printf 'fix\n' >> "$R/src/lib.rs"
+check "prod change, no dossier → block"                      "$R" "block"; rm -rf "$R"
+
+R="$(setup)"; printf 'fix\n' >> "$R/src/lib.rs"; write_verdict "$R" "PASS" "[]"
+check "prod change + matching PASS → allow"                  "$R" "allow"
+check "dossier consumed on allow → block"                    "$R" "block"; rm -rf "$R"
+
+R="$(setup)"; printf 'fix\n' >> "$R/src/lib.rs"; write_verdict "$R" "FAIL" '["Test: no reproducer"]'
+check "FAIL verdict → block"                                 "$R" "block"; rm -rf "$R"
+
+R="$(setup)"; printf 'fix\n' >> "$R/src/lib.rs"; write_verdict "$R" "IN_PROGRESS" '["mid-task"]'
+check "IN_PROGRESS → allow"                                  "$R" "allow"; rm -rf "$R"
+
+echo
+echo "## Gate: binding (branch / head / tree_hash / freshness)"
+R="$(setup)"; printf 'fix\n' >> "$R/src/lib.rs"; write_verdict "$R" "PASS" "[]" "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+check "tree_hash mismatch → block"                          "$R" "block"; rm -rf "$R"
+
+R="$(setup)"; printf 'fix\n' >> "$R/src/lib.rs"; write_verdict "$R" "PASS" "[]"
+jq '.head="deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"' "$R/.claude/.last-verdict.json" > "$R/.claude/x" \
+  && mv "$R/.claude/x" "$R/.claude/.last-verdict.json"
+check "HEAD mismatch → block"                               "$R" "block"; rm -rf "$R"
+
+R="$(setup)"; printf 'fix\n' >> "$R/src/lib.rs"; write_verdict "$R" "PASS" "[]"
+touch -t 202001010000 "$R/.claude/.last-verdict.json"
+check "stale mtime (>max_age) → block"                      "$R" "block"; rm -rf "$R"
+
+R="$(setup)"; printf 'fix\n' >> "$R/src/lib.rs"; write_verdict "$R" "PASS" "[]"
+# Change the tree AFTER auditing → dossier no longer matches.
+printf 'more\n' >> "$R/src/lib.rs"
+check "tree changed after audit → block"                    "$R" "block"; rm -rf "$R"
+
+echo
+echo "## Soft mode (default): a block condition becomes a non-blocking nudge"
+R="$(setup)"; printf 'fix\n' >> "$R/src/lib.rs"
+soft_out="$(printf '%s' "$PAYLOAD" | ( cd "$R" && CLAUDE_PROJECT_DIR="$R" bash "$HOOK" ) 2>/dev/null)"
+if printf '%s' "$soft_out" | jq -e '(.decision // "") != "block" and .continue == true and (.systemMessage | type) == "string"' >/dev/null 2>&1; then
+  pass=$((pass + 1)); printf '  PASS  %s\n' "prod change + no dossier → nudge (continue:true + systemMessage), not block"
+else
+  fail=$((fail + 1)); printf '  FAIL  %s  (out=%s)\n' "soft-mode nudge" "$soft_out"
+fi
+rm -rf "$R"
+
+echo
+echo "RESULT: $pass passed, $fail failed"
+exit $(( fail > 0 ? 1 : 0 ))

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,11 +6,22 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/preflight-claude-md.sh"
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/preflight-commit-push.sh"
           },
           {
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/preflight-pr-review.sh"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/preflight-verdict-check.sh",
+            "timeout": 60
           }
         ]
       }

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -6,13 +6,25 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/usr/bin/env bash \"$(git rev-parse --show-toplevel)/.claude/hooks/preflight-claude-md.sh\"",
+            "command": "/usr/bin/env bash \"$(git rev-parse --show-toplevel)/.claude/hooks/preflight-commit-push.sh\"",
             "statusMessage": "Checking CLAUDE.md audit"
           },
           {
             "type": "command",
             "command": "/usr/bin/env bash \"$(git rev-parse --show-toplevel)/.claude/hooks/preflight-pr-review.sh\"",
             "statusMessage": "Checking PR review acknowledgement"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/usr/bin/env bash \"$(git rev-parse --show-toplevel)/.claude/hooks/preflight-verdict-check.sh\"",
+            "statusMessage": "Checking verdict proof",
+            "timeout": 60
           }
         ]
       }

--- a/.gitignore
+++ b/.gitignore
@@ -179,6 +179,7 @@ Cargo.lock
 .claude/scheduled_tasks.lock
 .claude/worktrees/
 .claude/.last-audit.json
+.claude/.last-verdict.json
 
 # ============================================================================
 # Local dev artifacts (apps/infra-local + dashboard E2E session)


### PR DESCRIPTION
## Summary
Adds a Stop-stage gate that blocks an agent from ending a turn with
unproven behavioral claims, verified by an independent `verdict-auditor`.
Renames the existing CLAUDE.md gate to stage-based names so the three
gates read consistently.

## Changes
- New `preflight-verdict-check.sh` (Stop hook) + `verdict-auditor` agent;
  dossier bound to a content-addressed working-tree hash. Soft by default
  (nudge); `VERDICT_GATE_HARD_BLOCK=1` hard-blocks.
- Mirrored into Codex (`.codex/hooks.json`); contract verified 1:1 against
  Codex's published hook schema.
- Rename: `preflight-claude-md.* -> preflight-commit-push.*`,
  `claude-md-auditor -> commit-push-auditor` (matches `preflight-pr-review`).

## How to verify
- `bash .claude/hooks/preflight-verdict-check.test.sh` -> 14/14
- `bash .claude/hooks/preflight-commit-push.test.sh` -> 19/19
- `bash .claude/hooks/preflight-pr-review.test.sh` -> 25/25

## Risks / rollout
- Agent tooling only (`.claude/`/`.codex/`); no product code touched.
- Stop gate ships in soft mode (advisory nudge) - no turn-end blocking by default.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new turn-ending check that validates work against a saved verdict record before allowing the agent to finish.
  * Added support for separate checks around commit/push and verdict validation flows.
* **Bug Fixes**
  * Updated hook and test references to point to the correct scripts and names.
  * Improved handling of verdict state, freshness, and mismatch cases.
* **Documentation**
  * Refreshed inline comments and agent descriptions to match the current workflow.
* **Chores**
  * Added ignore rules for generated audit files and updated hook configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->