### PR TITLE
feat: reviewer-friendly, non-bloated commit & PR messages

### DIFF
--- a/.claude/agents/commit-push-auditor.md
+++ b/.claude/agents/commit-push-auditor.md
@@ -1,6 +1,6 @@
 ---
 name: commit-push-auditor
-description: Independent auditor that judges a pending git commit or push against every applicable bullet in CLAUDE.md (Workflow section). MUST be invoked before retrying a `git commit` or `git push` that was blocked by .claude/hooks/preflight-commit-push.sh. Reads CLAUDE.md and the diff cold in fresh context, writes a structured verdict to .claude/.last-audit.json. The hook only allows the next retry when the verdict file is PASS and matches the current branch + HEAD.
+description: Independent auditor that judges a pending git commit or push against every applicable bullet in CLAUDE.md (Workflow section) plus the CONTRIBUTING.md commit-message convention. MUST be invoked before retrying a `git commit` or `git push` that was blocked by .claude/hooks/preflight-commit-push.sh. Reads CLAUDE.md and the diff cold in fresh context, writes a structured verdict to .claude/.last-audit.json. The hook only allows the next retry when the verdict file is PASS and matches the current branch + HEAD.
 tools: Read, Bash, Write
 ---
 
@@ -26,7 +26,16 @@ The parent agent must tell you the exact git command they are about to retry
    - Judge PASS or FAIL against what the diff actually shows. Be skeptical:
      missing tests, scope creep, undocumented new dependencies, secrets,
      weakened assertions, comments that restate code, etc.
-5. Write `.claude/.last-audit.json` with EXACTLY this shape (no extra fields):
+5. Judge the commit message(s) against CONTRIBUTING.md's "Commit & PR messages"
+   section (read it):
+   - commit: parse the message from the target command's `-m` / `-F` argument(s).
+     If the commit uses an editor (no inline message), say so and defer to the
+     push-time check rather than guessing.
+   - push: read `git log origin/main..HEAD --format=%B`.
+   FAIL on: a subject that isn't `type(scope): summary` or exceeds 72 chars;
+   process / AI / conversation narrative; pasted logs or excerpts; secrets. A
+   CodeRabbit auto-summary block is allowed (tool-generated, not narrative).
+6. Write `.claude/.last-audit.json` with EXACTLY this shape (no extra fields):
    ```json
    {
      "branch": "<from step 2>",
@@ -37,7 +46,7 @@ The parent agent must tell you the exact git command they are about to retry
    }
    ```
    On PASS, `findings` is an empty array.
-6. Reply to the parent agent with the verdict and findings.
+7. Reply to the parent agent with the verdict and findings.
 
 ## Constraints
 

--- a/.claude/hooks/preflight-pr-review.sh
+++ b/.claude/hooks/preflight-pr-review.sh
@@ -77,6 +77,27 @@ deny() {
   exit 0
 }
 
+# Deterministic title check: when a quoted --title is given, require a
+# Conventional-Commit subject <=72 chars. (Short `-t` / unquoted forms aren't
+# inspected; body quality / no-narrative is confirmed in the ack below.)
+pr_title=""
+if [[ "$command" =~ --title[[:space:]]+\"([^\"]*)\" ]]; then
+  pr_title="${BASH_REMATCH[1]}"
+elif [[ "$command" =~ --title[[:space:]]+\'([^\']*)\' ]]; then
+  pr_title="${BASH_REMATCH[1]}"
+fi
+if [[ -n "$pr_title" ]]; then
+  title_re='^(feat|fix|docs|refactor|test|chore|perf|ci|build)(\([^)]+\))?!?:[[:space:]].+'
+  if [[ ! "$pr_title" =~ $title_re ]] || (( ${#pr_title} > 72 )); then
+    deny "PR title is not a Conventional-Commit subject <=72 chars.
+  title (${#pr_title} chars): ${pr_title}
+  required: type(scope): summary  — e.g. feat(api): cute default box names
+  types: feat fix docs refactor test chore perf ci build
+
+Fix --title and retry. See CONTRIBUTING.md #commit--pr-messages."
+  fi
+fi
+
 # ─────────────────────────────────────────────────────────────────────────────
 # TODO(user, learning-mode): author the ack instructions Claude reads on every
 # deny. This is the actual UX of the gate — keep it tight, unambiguous, and
@@ -113,7 +134,9 @@ on the question's 'notes' annotation (not the 'answers' field).
 
 Use this AskUserQuestion payload:
   question: 'PR-review acknowledgment for: ${command}
-             Pick \"Other\" and type your acknowledgment in this exact shape:
+             First confirm the description follows the PR template and has no
+             internal/AI narrative, pasted logs, or secrets. Then pick \"Other\"
+             and type your acknowledgment in this exact shape:
                  reviewed: <one-line summary, in your own words, of what
                             this PR changes>'
   header:   'PR review'

--- a/.claude/hooks/preflight-pr-review.test.sh
+++ b/.claude/hooks/preflight-pr-review.test.sh
@@ -107,5 +107,13 @@ touch -t 202001010000 "$TMP/.claude/.pr-reviewed.json"
 run "stale mtime (>max_age) → deny"     "gh pr create -t foo"               "deny"
 
 echo
+echo "## Title check: quoted --title must be a Conventional-Commit subject <=72"
+write_marker "reviewed: title cases"
+run "bad --title (no type prefix) → deny"  'gh pr create --title "add a cool thing" --body x'  "deny"
+run "over-72 --title → deny"               'gh pr create --title "feat(api): this title is far too long and clearly exceeds the seventy-two character ceiling"'  "deny"
+run "good --title + valid marker → allow"  'gh pr create --title "feat(api): add a cool thing"'  "passthrough"
+run "marker consumed after allow → deny"   'gh pr create --title "feat(api): add a cool thing"'  "deny"
+
+echo
 echo "RESULT: $pass passed, $fail failed"
 exit $(( fail > 0 ? 1 : 0 ))

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Summary
+<!-- 1-2 sentences: what this changes and why. -->
+
+## Changes
+- <!-- notable change — what changed, not a restatement of the diff -->
+
+## How to verify
+- <!-- a command or step a reviewer can run -->
+
+## Risks / rollout
+- <!-- only if any; delete this section otherwise -->
+
+<!-- Describe the change, not the process: no pasted logs, no AI/conversation
+     narrative, no secrets. Keep it tight and delete sections that don't apply. -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,5 +104,6 @@ Every change goes: understand → research → design → implement → test →
 
 - Words: as concise and simple as possible, unless explicitly asked otherwise.
 - A simple call graph (func name, class name, file name, LOC, short annotation) is the first choice when explaining code.
+- Commit/PR text: describe the change, not the process that produced it. Conventional-Commit subject ≤72; no process/AI narrative, pasted logs, or secrets. See [CONTRIBUTING.md](./CONTRIBUTING.md#commit--pr-messages).
 
 Adapted from Clean Code (Robert C. Martin) via the polygala-inc AGENTS.md distillation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,9 +56,25 @@ Key test entry points:
 2. Create a feature branch (`git checkout -b feature/my-feature`)
 3. Make your changes
 4. Run quality and tests (`make lint && make fmt:check && make test`)
-5. Commit with clear messages
+5. Commit with clear messages — see [Commit & PR messages](#commit--pr-messages)
 6. Open a Pull Request
 7. Sign the [BoxLite Contributor License Agreement](./docs/legal/CLA.md) when CLA Assistant asks you to do so
+
+### Commit & PR messages
+
+Write for a reviewer skimming in ~30 seconds. Describe the change, not the process that produced it.
+
+**Commits** — [Conventional Commits](https://www.conventionalcommits.org):
+
+- Subject: `type(scope): summary` — imperative, ≤72 chars, no trailing period. Types: `feat` `fix` `docs` `refactor` `test` `chore` `perf` `ci` `build`.
+- Body (only when it adds value): the *why* and *what* at a high level; wrap ~72.
+
+**PRs:**
+
+- Title: a Conventional-Commit subject (same rule as above).
+- Description: fill in [`.github/pull_request_template.md`](./.github/pull_request_template.md); delete sections that don't apply.
+
+**Never put in a commit or PR** the process that produced the change (conversation / AI / step-by-step narrative), pasted logs or tickets, or secrets.
 
 ### Code Style
 


### PR DESCRIPTION
## Summary
Give commit messages and PR titles/descriptions one tight target so reviewers can
grok a change fast, and agents stop leaking process/AI narrative into public artifacts.

## Changes
- `.github/pull_request_template.md` — Summary / Changes / How to verify / Risks.
- `CONTRIBUTING.md` "Commit & PR messages" convention (Conventional-Commit subject <=72;
  describe the change, not the process; no narrative/logs/secrets); `CLAUDE.md` points to it.
- `commit-push-auditor` now judges the commit message against the convention.
- `preflight-pr-review.sh` rejects a non-conventional / >72 `--title`; the human ack
  confirms the body has no internal/AI narrative.

## How to verify
- `bash .claude/hooks/preflight-pr-review.test.sh` -> 29/29 (title check incl. red->green)
- `bash .claude/hooks/preflight-commit-push.test.sh` -> 19/19
- `bash .claude/hooks/preflight-verdict-check.test.sh` -> 14/14

## Risks / rollout
- Agent tooling + docs only; no product code. Title check inspects only the quoted
  `--title` form (short `-t` / unquoted not checked); body no-narrative relies on the
  convention + human ack.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a pull request template with clear sections for summary, changes, verification steps, and rollout risks.
  * Added stronger guidance for commit and PR message formatting, including subject length and allowed styles.

* **Bug Fixes**
  * PR creation/editing now blocks titles that don’t match the required format or exceed the length limit.
  * Review prompts now more clearly require clean PR descriptions without logs, secrets, or AI/process notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->