### PR TITLE
docs(infra-local): box boot via the API is verified

### DIFF
--- a/apps/infra-local/README.md
+++ b/apps/infra-local/README.md
@@ -90,12 +90,12 @@ relies on — read-write host volumes + host port mapping — is pinned by
 | "Create Box" from the UI is incomplete | image resolution is mid-rewrite upstream + the picker is PostHog flag-gated | known limitation; use `POST /api/box` directly |
 
 > **Box boot via the API works** (verified 2026-06-29). `POST /api/v1/boxes` with
-> no `image` default-resolves to `ghcr.io/boxlite-ai/boxlite-agent-base:v0.1.0`,
-> creates the box, and it boots `creating → started`; `POST .../stop` stops it,
-> and a proxy call (`POST .../:id/exec`) on a stopped box auto-starts it. The
-> dashboard's **"Create Box" UI** is still incomplete (image picker removed /
-> PostHog-gated) — drive box creation through the API directly. L1 services, API,
-> runner, auth, and the dashboard all work.
+> no `image` default-resolves to the first curated `boxlite-agent-base` ref (see
+> `apps/api/src/box/constants/curated-images.constant.ts` — the tag rotates, so
+> it's not pinned here), creates the box, and it boots `creating → started`;
+> `POST .../stop` stops it. The dashboard's **"Create Box" UI** is still incomplete
+> (image picker removed / PostHog-gated) — drive box creation through the API
+> directly. L1 services, API, runner, auth, and the dashboard all work.
 
 ## Layout
 

--- a/apps/infra-local/README.md
+++ b/apps/infra-local/README.md
@@ -89,10 +89,13 @@ relies on — read-write host volumes + host port mapping — is pinned by
 | Any L1 box misbehaving | its stateful in-box process is wedged | `make restart COMPONENTS=<box>` |
 | "Create Box" from the UI is incomplete | image resolution is mid-rewrite upstream + the picker is PostHog flag-gated | known limitation; use `POST /api/box` directly |
 
-> **Box boot is unverified on this stack** — image resolution is mid-rewrite
-> upstream (`TODO(image-rewrite)` in `apps/api/src/box/services/box.service.ts`)
-> and the dashboard image picker was removed. L1 services, API, runner, auth, and
-> the dashboard all work.
+> **Box boot via the API works** (verified 2026-06-29). `POST /api/v1/boxes` with
+> no `image` default-resolves to `ghcr.io/boxlite-ai/boxlite-agent-base:v0.1.0`,
+> creates the box, and it boots `creating → started`; `POST .../stop` stops it,
+> and a proxy call (`POST .../:id/exec`) on a stopped box auto-starts it. The
+> dashboard's **"Create Box" UI** is still incomplete (image picker removed /
+> PostHog-gated) — drive box creation through the API directly. L1 services, API,
+> runner, auth, and the dashboard all work.
 
 ## Layout
 


### PR DESCRIPTION
## What

Corrects a stale caveat in `apps/infra-local/README.md`. The doc said **"Box boot is unverified on this stack"** — that's no longer true.

## Evidence (verified 2026-06-29 on the local stack)

End-to-end, API-only:

1. `POST /api/v1/boxes` (no `image`) → default-resolves `ghcr.io/boxlite-ai/boxlite-agent-base:v0.1.0` → box boots `creating → started`.
2. `POST /api/v1/boxes/:id/stop` → `stopped`.
3. Proxy call on the **stopped** box (`POST /api/v1/boxes/:id/exec`, also `/metrics`) → `desiredState` flips `STOPPED → STARTED` → `box_sync` auto-boots it back to `started`.
4. `exec` on the auto-started box → returns an `execution_id` (success).

## Scope

- Docs only. No code change.
- The dashboard **"Create Box" UI** is still incomplete (image picker removed / PostHog-gated) — that caveat is **kept**; only the box-boot claim is updated, with the API-direct path called out.

Discovered while running the exec-autostart e2e for #861; this fix is intentionally **separate** from that PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated troubleshooting guidance for box creation and execution workflows.
  * Clarified the expected box state flow when starting and stopping a box.
  * Noted that the dashboard create-box experience remains incomplete; API-based creation should be used instead.
  * Refined what happens when no image is provided, including the default image reference behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->