### PR TITLE
refactor(hooks): verdict gate validates self-declared claims, not file deltas

### DIFF
--- a/.claude/agents/verdict-auditor.md
+++ b/.claude/agents/verdict-auditor.md
@@ -1,6 +1,6 @@
 ---
 name: verdict-auditor
-description: Independent auditor that checks whether the agent's stated verdict — claims like "the fix works", "tests pass", "root cause is X", "<thing> is removed/unused", "done" — is backed by concrete, re-runnable proof rather than prose. MUST be invoked when .claude/hooks/preflight-verdict-check.sh blocks the agent from ending its turn. Reads the agent's last message (the claim) and the working-tree diff (the work) cold, judges proof against CLAUDE.md's Test/Verify rules, and writes a structured dossier to .claude/.last-verdict.json. The Stop hook only lets the turn end when the dossier is PASS (or IN_PROGRESS) and matches the current branch + working-tree hash.
+description: Independent auditor that checks whether the agent's stated verdict — claims like "the fix works", "tests pass", "root cause is X", "deploy is healthy", "found N issues" / "no issues", "<thing> is removed/unused", "done" — is backed by concrete, re-runnable proof rather than prose. MUST be invoked when .claude/hooks/preflight-verdict-check.sh blocks the agent from ending its turn. Reads the agent's last message (the claim) and the working-tree diff (the work) cold, judges proof against CLAUDE.md's Test/Verify rules, and writes a structured dossier to .claude/.last-verdict.json. The Stop hook only lets the turn end when the dossier is PASS (or IN_PROGRESS) and matches the current branch + working-tree hash.
 tools: Read, Bash, Write
 ---
 
@@ -33,19 +33,33 @@ a JSONL file). If it didn't, ask for it before proceeding.
      GIT_INDEX_FILE="$idx" git write-tree; rm -f "$idx"
      ```
 
-3. **Capture the work:** `git diff HEAD` (tracked, staged + unstaged) and
-   `git status --porcelain` (full file set, incl. untracked). Read the changed
-   production files as needed to judge the claims.
+3. **Capture the evidence.** Proof lives in more than the diff — gather whatever the
+   claim actually rests on:
+   - code / file changes: `git diff HEAD` (staged + unstaged) and `git status
+     --porcelain` (full set, incl. untracked); read the changed files as needed.
+   - what the agent ran (ops checks, CLI / tool output, queries): the transcript's
+     tool calls and their results —
+     `jq -s '.[]|select(.type=="assistant" or .type=="user")|.message.content[]|select(.type=="tool_use" or .type=="tool_result")|{type,name,is_error,content:(.content//.input)}' "$transcript_path"`
+   - cited files, logs, or `file:line` the message points to — resolve them.
 
 4. **Judge proof per claim** against the repo's *existing* standards (CLAUDE.md Test /
-   Verify sections — read them). Proof must be ground truth, never the agent's prose:
+   Verify sections — read them). Proof must be ground truth — concrete and DIRECT:
+   never the agent's prose, your own guess, or an indirect inference. If the evidence
+   does not directly show the claim, it is NOT proven (FAIL, or `blocked` with the
+   residual risk) — do not pass it on a plausible-sounding conclusion.
+   The claim set is OPEN — the rows below are examples, not a closed taxonomy. A verdict
+   may be about code, ops/infra, data, or a factual answer; match each claim to whatever
+   evidence backs it (diff, transcript tool output, or cited logs), and leave anything
+   that asserts nothing verifiable out entirely.
 
-   | Claim | Tier-1 (always — cheap, non-fakeable for what it checks) | Tier-2 (selective) |
+   | Claim (examples) | Tier-1 (always — cheap, non-fakeable for what it checks) | Tier-2 (selective) |
    |---|---|---|
    | Fix works | a reproducer exists in the diff AND references the production symbols under test (not tautological — CLAUDE.md:85) | run revert→fail→restore→pass (CLAUDE.md:81–84) in an isolated worktree |
    | Tests pass | a concrete, re-runnable command is named (not "I ran the tests"); CLAUDE.md:95 | re-run that command → exit 0 |
    | Root cause is X | the cited `file:line` / log lines resolve and actually support the claim; proven is separated from hypothesis | — (no mechanical ground truth) |
    | Removal safe | `git grep` shows no remaining references | live-environment check |
+   | Ops / finding ("deploy healthy", "found N issues", "no issues") | the command AND its output appear in the transcript and actually show it (`method:"transcript"`); the finding cites that output, not recollection | re-run the command if it is safe + reproducible |
+   | Factual answer asserted as established | the cited source (file / doc / command output) resolves and supports it | — |
    | Subjective ("clean/good design") | OUT OF SCOPE — no concrete proof exists; do not gate it | — |
 
    - **Tier-2 trigger:** only when the diff touches core runtime or security paths, OR
@@ -57,8 +71,10 @@ a JSONL file). If it didn't, ask for it before proceeding.
      the production fix (must FAIL, log the signal) then with it (must PASS), then
      `git worktree remove`. NEVER stash, revert, or mutate the live working tree.
    - **FAIL** when: a "tests pass" claim names no re-runnable command; a reproducer is
-     tautological (CLAUDE.md:85) or absent for a fix claim; a root cause is asserted as
-     fact with no resolving citation; or Tier-2 (when triggered) does not show red→green.
+     tautological (CLAUDE.md:85) or absent for a fix claim; a root cause or factual
+     answer is asserted as fact with no resolving citation; a finding ("found N issues",
+     "healthy") cites no supporting command output in the transcript; or Tier-2 (when
+     triggered) does not show red→green.
 
 5. **Escape valves** (so the gate has teeth without misfiring into bypass):
    - If proof genuinely can't be produced (e.g. cannot reproduce in this environment),
@@ -78,9 +94,9 @@ a JSONL file). If it didn't, ask for it before proceeding.
      "proof": [
        {
          "claim": "<the behavioral claim, one line>",
-         "kind": "fix-works" | "tests-pass" | "root-cause" | "removal-safe",
-         "evidence": "<re-runnable: test id / file:line / command + observed result>",
-         "method": "structural" | "rerun" | "two-side",
+         "kind": "fix-works" | "tests-pass" | "root-cause" | "removal-safe" | "finding" | "factual" | "other",
+         "evidence": "<re-runnable / resolvable: test id / file:line / command + observed result / transcript tool output>",
+         "method": "structural" | "transcript" | "rerun" | "two-side",
          "status": "verified" | "blocked",
          "blocker": null
        }

--- a/.claude/hooks/preflight-verdict-check.sh
+++ b/.claude/hooks/preflight-verdict-check.sh
@@ -1,17 +1,19 @@
 #!/usr/bin/env bash
-# Stop hook: gate the agent from ENDING ITS TURN while it has unproven behavioral
-# work, on a fresh dossier from the verdict-auditor subagent
+# Stop hook: VALIDATE a self-declared verdict before the agent ends its turn
 # (see .claude/agents/verdict-auditor.md).
 #
-# The hook itself does not call any model; it reads the dossier the subagent
-# writes at .claude/.last-verdict.json and checks that the verdict is PASS (or
-# IN_PROGRESS), recent, and bound to the current branch + HEAD + working-tree hash.
+# Self-declared gating: the hook does NOT detect verdicts. The agent decides when it
+# has made a behavioral verdict (per CLAUDE.md's Verify rule) and self-invokes the
+# verdict-auditor subagent, which writes the dossier at .claude/.last-verdict.json.
+# This hook only validates that dossier; it calls no model and reads no transcript.
 #
-# Flow on a blocked stop:
-#   1. Hook blocks the turn from ending.
-#   2. The `reason` reaches the model; it invokes the verdict-auditor subagent.
-#   3. Subagent writes .claude/.last-verdict.json.
-#   4. Model ends its turn again -> hook reads the dossier and allows on PASS.
+# Flow (agent self-declared):
+#   1. The agent ends a turn asserting a verdict; per CLAUDE.md it first invokes the
+#      verdict-auditor subagent, which writes .claude/.last-verdict.json.
+#   2. Hook validates: a fresh, matching PASS/IN_PROGRESS dossier -> allow.
+#   3. NO dossier -> allow (the agent declared nothing to prove). Gating is opt-in.
+#   4. A stale / mismatched / FAIL dossier -> block (hard) or nudge (soft); the agent
+#      re-audits and ends again.
 # The subagent's own completion is a SubagentStop event, not Stop, so it does not
 # re-trigger this hook (no recursion).
 #
@@ -19,23 +21,25 @@
 #
 # Design notes
 # ------------
-# * Every-turn-end: a Stop hook fires whenever the agent ends a turn, with no
-#   "done vs paused" signal in the payload. So we first apply a cheap, deterministic
-#   PRE-FILTER: unless there are uncommitted changes to PRODUCTION files, we allow
-#   immediately. Pure chat / research / docs-only turns never gate. Production is
-#   decided by PATH, never by parsing the message (no string-match intent guessing).
+# * No detection: a Stop hook fires whenever the agent ends a turn, with no
+#   "done vs paused" signal. Rather than guess from changed files (which misses any
+#   verdict that touches no files — an ops check, a factual answer, "no issues") or
+#   parse the message, we let the AGENT decide: it self-invokes the auditor when it
+#   made a verdict. No dossier => nothing to prove.
 #
-# * Tree-hash binding: at stop time the work is usually UNCOMMITTED (HEAD has not
-#   moved), so HEAD alone can't tell "audited" from "changed since audit". We bind
-#   the dossier to a content-addressed hash of the full working tree, computed via a
-#   throwaway index + `git write-tree` (deterministic; no timestamps; never touches
-#   the real index). The verdict-auditor computes it the SAME way.
+# * Tree-hash binding (present-dossier only): at stop time the work is usually
+#   UNCOMMITTED (HEAD has not moved), so HEAD alone can't tell "audited" from
+#   "changed since audit". We bind the dossier to a content-addressed hash of the
+#   full working tree, computed via a throwaway index + `git write-tree`
+#   (deterministic; no timestamps; never touches the real index). The verdict-auditor
+#   computes it the SAME way. Computed only when a dossier exists — the common
+#   no-dossier turn does no git work.
 #
 # * Loop-safety: the block is satisfiable — a fresh PASS or IN_PROGRESS dossier
 #   always lets the turn end — so we never depend on the (undocumented) stop_hook_active.
 #
 # * One-shot consumption: the dossier is `rm -f`'d on the allow path so the next
-#   "done" re-checks. Mirrors the trade-off in preflight-commit-push.sh.
+#   verdict re-audits. Mirrors the trade-off in preflight-commit-push.sh.
 #
 # Tests: bash .claude/hooks/preflight-verdict-check.test.sh
 set -uo pipefail
@@ -76,22 +80,18 @@ compute_tree_hash() {
   rm -f "$idx"
 }
 
-# ── Pre-filter: is there pending PRODUCTION work worth proving? ───────────────
-# Count changed paths that are NOT docs (*.md, docs/) and NOT agent/tooling infra
-# (.claude/, .codex/). `grep -c` reads all input (no early-exit SIGPIPE under
-# pipefail); `|| true` keeps the no-match exit-1 from aborting.
-n_prod="$(git -C "$repo_root" status --porcelain 2>/dev/null \
-  | sed -E 's/^.{3}//' \
-  | grep -Ecv '(\.md$|^docs/|/docs/|^\.claude/|^\.codex/)' || true)"
-if [[ "${n_prod:-0}" -eq 0 ]]; then
+# ── No dossier → the agent self-declared nothing to prove → allow ────────────
+# This is the heart of self-declared gating: absence is the agent's decision, not a
+# gap to punish. Gating is opt-in; the agent invokes the auditor (per CLAUDE.md) only
+# when it made a verdict. Cheap: the common turn does no git work and reads no file.
+if [[ ! -r "$verdict_file" ]]; then
   allow
 fi
 
-# ── Gate: require a fresh, matching dossier ──────────────────────────────────
+# ── Validate the self-declared dossier ───────────────────────────────────────
 # ─────────────────────────────────────────────────────────────────────────────
-# TODO(user, learning-mode): this block `reason` is the gate's UX and its
-# anti-cheating contract — what Claude reads when it tries to end a turn with
-# unproven behavioral work. Refine the wording to taste, but keep these invariants:
+# The block `reason` below is the gate's UX + anti-cheating contract — what Claude
+# reads when a present dossier is stale / mismatched / FAIL. Invariants to preserve:
 #   • Direct Claude to invoke the verdict-auditor subagent (Task tool), passing the
 #     transcript path so the auditor can read the very claim it must check.
 #   • The AUDITOR — not Claude — writes ${verdict_file}. Claude must not write or
@@ -101,29 +101,20 @@ fi
 #   • After the auditor reports, end the turn again; this hook re-checks.
 #
 # Variables available: ${transcript_path} ${branch} ${head} ${verdict_file}
-verdict_instruction="You are ending your turn with unproven changes on branch '${branch}'.
-Attach proof for what you claim you did before finishing.
-
-Invoke the verdict-auditor subagent now:
+verdict_instruction="Re-audit before ending: invoke the verdict-auditor subagent.
   Task(subagent_type='verdict-auditor',
        description='verdict proof check',
-       prompt='Check my last message'\\''s verdict against the working-tree diff.
-               transcript_path: ${transcript_path}')
+       prompt='Audit my last message: each claim it presents as established must have
+               concrete, direct proof in the evidence — the working-tree diff, the
+               commands and their output in the transcript, or cited files/logs. A claim
+               backed only by guessing or indirect inference is NOT proven. A turn that
+               asserts nothing verifiable is a PASS. transcript_path: ${transcript_path}')
 
-It judges your claims against CLAUDE.md'\\''s Test/Verify rules and writes its dossier
-to ${verdict_file}. Do NOT write that file yourself.
-
-If you are not actually done (pausing, or asking the user something), have the
-auditor record verdict IN_PROGRESS with what remains. If a claim genuinely cannot
-be proven in this environment, the auditor can mark that proof 'blocked' with the
+The AUDITOR — not you — writes ${verdict_file}; do not write it yourself. If you are
+pausing or asking the user something, have it record IN_PROGRESS with what remains;
+if a claim genuinely cannot be proven here, it can mark that proof 'blocked' with the
 residual risk. Then end your turn again."
 # ─────────────────────────────────────────────────────────────────────────────
-
-if [[ ! -r "$verdict_file" ]]; then
-  block "No verdict dossier found for the changes in your working tree.
-
-${verdict_instruction}"
-fi
 
 v_branch="$(jq -r '.branch // ""'    "$verdict_file" 2>/dev/null || echo '')"
 v_head="$(jq -r '.head // ""'        "$verdict_file" 2>/dev/null || echo '')"

--- a/.claude/hooks/preflight-verdict-check.test.sh
+++ b/.claude/hooks/preflight-verdict-check.test.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
 # Tests for .claude/hooks/preflight-verdict-check.sh (the Stop-stage verdict gate).
 #
-# Unlike the commit-push gate (which keys off an artifact + the real repo's
-# branch/HEAD), this hook's decision depends on the WORKING-TREE STATE. So each
-# case builds a throwaway git repo in a controlled state and runs the hook there
-# (cwd + CLAUDE_PROJECT_DIR both pointed at it), asserting allow vs block.
+# This hook is a VALIDATOR of a self-declared dossier (.claude/.last-verdict.json):
+#   - no dossier                                -> allow (agent declared nothing to prove)
+#   - present, PASS/IN_PROGRESS, matching+fresh -> allow (PASS is consumed)
+#   - present, stale / mismatched / FAIL        -> block (hard) or nudge (soft)
+# Each case builds a throwaway git repo, optionally writes a dossier, and runs the
+# hook there (cwd + CLAUDE_PROJECT_DIR pointed at it), asserting allow vs block.
 #
 # Stop contract: allow = empty stdout (exit 0); block = stdout {"decision":"block"};
-# IN_PROGRESS = {"continue":true,...} (non-empty but no block decision = allow).
+# soft nudge / IN_PROGRESS = {"continue":true,...} (non-empty, no block = allow).
 #
 # Run with:  bash .claude/hooks/preflight-verdict-check.test.sh
 # Exits non-zero on any failure.
@@ -80,52 +82,67 @@ check() {  # desc  repo  expect
   fi
 }
 
-echo "## Pre-filter: turns with no production work end freely"
-R="$(setup)";                                                check "clean tree → allow"            "$R" "allow"; rm -rf "$R"
-R="$(setup)"; printf 'docs\n' > "$R/README.md";              check "docs-only (*.md) → allow"      "$R" "allow"; rm -rf "$R"
-R="$(setup)"; mkdir -p "$R/docs"; printf 'x\n' > "$R/docs/a.txt"; check "docs/ dir → allow"         "$R" "allow"; rm -rf "$R"
-R="$(setup)"; mkdir -p "$R/.claude"; printf 'x\n' > "$R/.claude/note.md"; check "agent infra (.claude/) → allow" "$R" "allow"; rm -rf "$R"
+# Assert the dossier file was consumed (removed) by the hook's allow path.
+check_consumed() {  # desc  repo
+  local desc="$1" repo="$2"
+  if [[ ! -e "$repo/.claude/.last-verdict.json" ]]; then
+    pass=$((pass + 1)); printf '  PASS  %s\n' "$desc"
+  else
+    fail=$((fail + 1)); printf '  FAIL  %s  (dossier still present after allow)\n' "$desc"
+  fi
+}
+
+echo "## No dossier → allow (the agent self-declared nothing to prove)"
+R="$(setup)";                                    check "clean tree, no dossier → allow"   "$R" "allow"; rm -rf "$R"
+# The key inversion: a production change is NOT force-gated; gating is agent-declared.
+R="$(setup)"; printf 'fix\n' >> "$R/src/lib.rs"; check "prod change, no dossier → allow"  "$R" "allow"; rm -rf "$R"
 
 echo
-echo "## Gate: production change present"
-R="$(setup)"; printf 'fix\n' >> "$R/src/lib.rs"
-check "prod change, no dossier → block"                      "$R" "block"; rm -rf "$R"
-
+echo "## Present dossier → validate verdict"
 R="$(setup)"; printf 'fix\n' >> "$R/src/lib.rs"; write_verdict "$R" "PASS" "[]"
-check "prod change + matching PASS → allow"                  "$R" "allow"
-check "dossier consumed on allow → block"                    "$R" "block"; rm -rf "$R"
+check "code change + matching PASS → allow"      "$R" "allow"
+check_consumed "PASS dossier consumed on allow"  "$R"
+check "after consume (no dossier) → allow"       "$R" "allow"; rm -rf "$R"
+
+# A verdict with NO file change (ops / investigation) still validates against the
+# clean-tree hash — this is the whole point of covering non-code verdicts.
+R="$(setup)"; write_verdict "$R" "PASS" "[]"
+check "no-file-change verdict + PASS → allow"    "$R" "allow"; rm -rf "$R"
 
 R="$(setup)"; printf 'fix\n' >> "$R/src/lib.rs"; write_verdict "$R" "FAIL" '["Test: no reproducer"]'
-check "FAIL verdict → block"                                 "$R" "block"; rm -rf "$R"
+check "FAIL verdict → block"                     "$R" "block"; rm -rf "$R"
+
+R="$(setup)"; write_verdict "$R" "FAIL" '["finding cites no command output"]'
+check "no-file-change verdict + FAIL → block"    "$R" "block"; rm -rf "$R"
 
 R="$(setup)"; printf 'fix\n' >> "$R/src/lib.rs"; write_verdict "$R" "IN_PROGRESS" '["mid-task"]'
-check "IN_PROGRESS → allow"                                  "$R" "allow"; rm -rf "$R"
+check "IN_PROGRESS → allow"                      "$R" "allow"; rm -rf "$R"
 
 echo
-echo "## Gate: binding (branch / head / tree_hash / freshness)"
+echo "## Present dossier → binding (branch / head / tree_hash / freshness)"
 R="$(setup)"; printf 'fix\n' >> "$R/src/lib.rs"; write_verdict "$R" "PASS" "[]" "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
-check "tree_hash mismatch → block"                          "$R" "block"; rm -rf "$R"
+check "tree_hash mismatch → block"               "$R" "block"; rm -rf "$R"
 
 R="$(setup)"; printf 'fix\n' >> "$R/src/lib.rs"; write_verdict "$R" "PASS" "[]"
 jq '.head="deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"' "$R/.claude/.last-verdict.json" > "$R/.claude/x" \
   && mv "$R/.claude/x" "$R/.claude/.last-verdict.json"
-check "HEAD mismatch → block"                               "$R" "block"; rm -rf "$R"
+check "HEAD mismatch → block"                    "$R" "block"; rm -rf "$R"
 
 R="$(setup)"; printf 'fix\n' >> "$R/src/lib.rs"; write_verdict "$R" "PASS" "[]"
 touch -t 202001010000 "$R/.claude/.last-verdict.json"
-check "stale mtime (>max_age) → block"                      "$R" "block"; rm -rf "$R"
+check "stale mtime (>max_age) → block"           "$R" "block"; rm -rf "$R"
 
 R="$(setup)"; printf 'fix\n' >> "$R/src/lib.rs"; write_verdict "$R" "PASS" "[]"
 # Change the tree AFTER auditing → dossier no longer matches.
 printf 'more\n' >> "$R/src/lib.rs"
-check "tree changed after audit → block"                    "$R" "block"; rm -rf "$R"
+check "tree changed after audit → block"         "$R" "block"; rm -rf "$R"
 
 echo
 echo "## Soft mode (default): a block condition becomes a non-blocking nudge"
-R="$(setup)"; printf 'fix\n' >> "$R/src/lib.rs"
+R="$(setup)"; printf 'fix\n' >> "$R/src/lib.rs"; write_verdict "$R" "FAIL" '["no reproducer"]'
 soft_out="$(printf '%s' "$PAYLOAD" | ( cd "$R" && CLAUDE_PROJECT_DIR="$R" bash "$HOOK" ) 2>/dev/null)"
 if printf '%s' "$soft_out" | jq -e '(.decision // "") != "block" and .continue == true and (.systemMessage | type) == "string"' >/dev/null 2>&1; then
-  pass=$((pass + 1)); printf '  PASS  %s\n' "prod change + no dossier → nudge (continue:true + systemMessage), not block"
+  pass=$((pass + 1)); printf '  PASS  %s\n' "FAIL dossier → nudge (continue:true + systemMessage), not block"
 else
   fail=$((fail + 1)); printf '  FAIL  %s  (out=%s)\n' "soft-mode nudge" "$soft_out"
 fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,7 @@ Every change goes: understand → research → design → implement → test →
 
 - Run the smallest relevant verification first (`make test`, package-scoped test), then broaden if risk justifies.
 - Don't claim tests passed unless they actually ran. If verification can't run, state the blocker and the residual risk.
+- Self-declare verdicts: when you end a turn asserting anything as established — a fix that works, tests that pass, a root cause, an ops/infra finding, "no issues", a factual answer — invoke the `verdict-auditor` subagent (Task) to attach proof before ending. You decide when a turn carries a verdict; a turn with nothing verifiable needs no audit. The auditor — not you — writes the dossier (`.claude/.last-verdict.json`); never hand-write it.
 
 **Cross-cutting** (apply at every phase)
 


### PR DESCRIPTION
## Summary
The Stop-stage verdict gate triggered on a working-tree **production-file delta**, so read-only verdicts slipped through unproven — e.g. "find vercel issues" asserts findings but changes no files, so the gate allowed it. This makes the hook a pure **validator** of a dossier the agent **self-declares**:

- no dossier → allow (the agent declared nothing to prove)
- present PASS/IN_PROGRESS, matching branch/HEAD/tree + fresh → allow (PASS consumed)
- stale / mismatched / FAIL → block (hard) or soft nudge

The hook no longer reads `git status` or the transcript; gating is agent-declared and opt-in. The `verdict-auditor` now verifies **any** established claim — code, ops/infra, or a factual answer — against whatever evidence backs it (diff, transcript tool output, cited logs), and only on **concrete, direct proof** (guessing or indirect inference is not proof). Adds one CLAUDE.md Verify rule operationalizing self-declaration.

## Trade-off
Code-change verdicts are no longer force-gated; gating is agent-declared. The auditor stays an independent fresh-context judge (catches honest-but-wrong claims), and a FAIL/stale/mismatched dossier still blocks (hard) or nudges (soft).

## Tests
- `preflight-verdict-check.test.sh` → 14/14. Two-side reproducer: reverted only the hook → 3 behavior-change assertions failed pointing at the change (incl. `no-file-change verdict + FAIL → block`, the case the old file-delta gate let through) → restored → 14/14.
- Sibling gates unaffected: `preflight-commit-push` 19/19, `preflight-pr-review` 25/25.

## Follow-ups (not in this PR)
- `verdict-auditor.md` frontmatter `description` still says "the working-tree diff (the work)" while the body generalizes evidence — cosmetic, flagged by the audit.
- `preflight-commit-push.sh` treats `&& || ; | & $( ( \`` as chain separators but not newlines, so a `git commit` on its own line after a newline slips the gate (observed this session).

Agent-tooling only; no product code, no new deps.

https://claude.ai/code/session_01SvZdGVgTqr5rkpsRG36Dvj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a required verification step for self-declared results, so completed turns now include a proof dossier before ending.
  * Improved the verification record with clearer status, evidence, and outcome tracking.

* **Bug Fixes**
  * Made the end-of-turn check more permissive when no verification dossier is present, avoiding unnecessary blocking.
  * Strengthened validation of submitted proof so incomplete or unsupported claims are flagged more reliably.

* **Tests**
  * Expanded automated checks for allow/block behavior, dossier handling, and soft-warning responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->