### PR TITLE
fix: keep boxes and CLI terminals alive across API ECS rolling upgrades

### DIFF
--- a/apps/api/src/boxlite-rest/boxlite-ws-proxy.service.spec.ts
+++ b/apps/api/src/boxlite-rest/boxlite-ws-proxy.service.spec.ts
@@ -113,4 +113,41 @@ describe('BoxliteWsProxyService', () => {
     await expect(service.authenticate(authRequest(jwt), 'org-1')).resolves.toBeNull()
     expect(organizationUserService.findOne).toHaveBeenCalledWith('org-1', 'user-1')
   })
+
+  describe('buildCloseFrame', () => {
+    // Feed the hand-built frame into the `ws` library's RFC 6455 parser and
+    // assert it decodes back to a close frame with our code + reason. The bytes
+    // cross the encode→decode boundary through an independent parser, so the
+    // assertion proves wire interoperability rather than re-stating the bytes
+    // the test built. `ws` exports Receiver at runtime but not in its bundled
+    // type declarations, so it is loaded via require.
+    it('produces a 1012 close frame that the ws parser decodes', async () => {
+      const { Receiver } = require('ws') as {
+        Receiver: new (opts: { isServer: boolean }) => {
+          on(event: 'conclude', cb: (code: number, reason: Buffer) => void): void
+          on(event: 'error', cb: (err: Error) => void): void
+          write(chunk: Buffer): void
+        }
+      }
+      const frame = BoxliteWsProxyService.buildCloseFrame(1012, 'api-upgrade')
+
+      const decoded = await new Promise<{ code: number; reason: string }>((resolve, reject) => {
+        // `isServer: false` => the receiver expects unmasked server→client
+        // frames, which is exactly what buildCloseFrame emits.
+        const receiver = new Receiver({ isServer: false })
+        receiver.on('conclude', (code: number, reason: Buffer) => {
+          resolve({ code, reason: reason.toString('utf8') })
+        })
+        receiver.on('error', reject)
+        receiver.write(frame)
+      })
+
+      expect(decoded.code).toBe(1012)
+      expect(decoded.reason).toBe('api-upgrade')
+    })
+
+    it('rejects a reason that overflows the 7-bit length form', () => {
+      expect(() => BoxliteWsProxyService.buildCloseFrame(1012, 'x'.repeat(124))).toThrow(/too long/)
+    })
+  })
 })

--- a/apps/api/src/boxlite-rest/boxlite-ws-proxy.service.ts
+++ b/apps/api/src/boxlite-rest/boxlite-ws-proxy.service.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2025 BoxLite AI
  */
 
-import { Inject, Injectable, Logger } from '@nestjs/common'
+import { Inject, Injectable, Logger, type OnApplicationShutdown } from '@nestjs/common'
 import type { IncomingMessage } from 'http'
 import type { Socket } from 'net'
 import { createProxyMiddleware, type RequestHandler } from 'http-proxy-middleware'
@@ -36,9 +36,18 @@ const ATTACH_PATH = /^\/api\/v1\/(?:(?<tenant>[^/]+)\/)?boxes\/(?<boxId>[^/]+)\/
  * shared `createProxyMiddleware({ ws: true, ... })` instance.
  */
 @Injectable()
-export class BoxliteWsProxyService {
+export class BoxliteWsProxyService implements OnApplicationShutdown {
   private readonly logger = new Logger(BoxliteWsProxyService.name)
   private readonly proxy: RequestHandler
+
+  // Client sockets we have successfully proxied. On shutdown (SIGTERM from an
+  // ECS rolling deploy) we send each a graceful WS Close so the CLI reconnects
+  // at once instead of stalling on a TCP RST. Only the client (browser/CLI)
+  // side is tracked: http-proxy-middleware owns the upstream runner socket and
+  // does not hand it back here, so we cannot close it directly. Ending the
+  // client socket tears down the proxied pair, and the runner's own keepalive
+  // reaps the orphaned session shortly after.
+  private readonly liveSockets = new Set<Socket>()
 
   constructor(
     private readonly apiKeyService: ApiKeyService,
@@ -127,12 +136,18 @@ export class BoxliteWsProxyService {
       }
       ;(req as RunnerUpgradeRequest).__boxliteRunner = runner
       ;(req as RunnerUpgradeRequest).__boxliteRunnerBoxId = box.id
+      // Track only sockets we actually proxy (auth + routing succeeded), and
+      // deregister on close or error so the set never leaks dead sockets.
+      this.liveSockets.add(socket)
+      socket.once('close', () => this.liveSockets.delete(socket))
+      socket.once('error', () => this.liveSockets.delete(socket))
       ;(
         this.proxy as unknown as {
           upgrade: (req: IncomingMessage, socket: Socket, head: Buffer) => void
         }
       ).upgrade(req, socket, head)
     } catch (err) {
+      this.liveSockets.delete(socket)
       this.logger.warn(`upgrade failed for ${req.url}: ${(err as Error).message}`)
       this.respondAndClose(socket, 404, 'Not Found')
     }
@@ -210,5 +225,48 @@ export class BoxliteWsProxyService {
       // Socket may already be torn down — ignore.
     }
     socket.destroy()
+  }
+
+  /**
+   * On SIGTERM (ECS rolling deploy) `app.enableShutdownHooks()` invokes this.
+   * Send every proxied client a WS Close (1012 "Service Restart") so the CLI
+   * reconnects immediately rather than waiting out its disconnect backoff after
+   * a silent TCP RST. Best-effort and per-socket — one dead socket must not
+   * abort the loop.
+   */
+  onApplicationShutdown(): void {
+    if (this.liveSockets.size === 0) return
+    const frame = BoxliteWsProxyService.buildCloseFrame(1012, 'api-upgrade')
+    this.logger.log(`shutdown: closing ${this.liveSockets.size} proxied WS socket(s) with 1012`)
+    for (const socket of this.liveSockets) {
+      try {
+        socket.write(frame)
+        socket.end()
+      } catch {
+        // Socket already torn down — skip it and keep closing the rest.
+      }
+    }
+    this.liveSockets.clear()
+  }
+
+  /**
+   * Build an unmasked (server→client) RFC 6455 Close frame. Server frames are
+   * never masked. Layout: byte0 = 0x88 (FIN + opcode 0x8 Close); byte1 = payload
+   * length (7-bit form — `reason` is short); payload = 2-byte big-endian status
+   * code followed by the UTF-8 reason. The 7-bit length form caps payload at
+   * 125 bytes, so the reason must stay short.
+   */
+  static buildCloseFrame(code: number, reason: string): Buffer {
+    const reasonBytes = Buffer.from(reason, 'utf8')
+    const payloadLength = 2 + reasonBytes.length
+    if (payloadLength >= 126) {
+      throw new Error(`ws close reason too long: ${payloadLength} bytes (max 125)`)
+    }
+    const frame = Buffer.alloc(2 + payloadLength)
+    frame[0] = 0x88
+    frame[1] = payloadLength
+    frame.writeUInt16BE(code, 2)
+    reasonBytes.copy(frame, 4)
+    return frame
   }
 }

--- a/src/boxlite/src/jailer/cgroup.rs
+++ b/src/boxlite/src/jailer/cgroup.rs
@@ -33,6 +33,7 @@
 use super::common;
 use super::error::JailerError;
 use crate::runtime::advanced_options::ResourceLimits;
+use crate::runtime::id::BoxID;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -136,6 +137,35 @@ pub fn is_cgroup_v2_available() -> bool {
 /// - User: `/sys/fs/cgroup/user.slice/user-{uid}.slice/user@{uid}.service/boxlite/{box_id}`
 pub fn cgroup_path(box_id: &str) -> PathBuf {
     get_cgroup_base().join(BOXLITE_CGROUP).join(box_id)
+}
+
+/// Kill every process in a box's cgroup via cgroup v2 `cgroup.kill`.
+///
+/// Reaps the box's *entire* process tree atomically — the outer bwrap launcher,
+/// the inner pid-namespace bwrap, the shim, and the VM — regardless of
+/// pid-namespace or process-group structure. A single-pid `SIGKILL` of the
+/// recorded pid only hits the outer bwrap; a detached box's inner tree survives
+/// it, since #851 stopped applying `--die-with-parent` to detached boxes. The
+/// whole tree lives in the box's cgroup, so killing the cgroup by id reaps it
+/// even after `state.pid` has been cleared.
+///
+/// Best-effort and idempotent: a no-op if the cgroup is gone, already empty, or
+/// `cgroup.kill` is unavailable (kernel < 5.14 / cgroup v1 / no jailer). Returns
+/// `true` if the kill file was written.
+///
+/// Takes a [`BoxID`] rather than a raw `&str` on purpose: this writes to a path
+/// derived from the id, so it must be a safe single path component. `BoxID`'s
+/// constructor ([`BoxID::parse`]/mint) is the one choke point that guarantees
+/// that — its charset (`[A-Za-z0-9_-]`) excludes `/`, `\`, and `.`, so `..`/`.`
+/// and path separators are unrepresentable. The type carries the guarantee, so
+/// no per-call traversal check is needed (or could drift) here.
+///
+/// `pub(super)` on purpose: this is the cgroup *mechanism*, reached only through
+/// the jailer's [`super::reap_box`] facade. Layers above the jailer (box,
+/// runtime) reap by box semantics and never name cgroups.
+pub(super) fn kill_cgroup(box_id: &BoxID) -> bool {
+    let kill_file = cgroup_path(box_id.as_str()).join("cgroup.kill");
+    std::fs::write(&kill_file, "1").is_ok()
 }
 
 /// Setup cgroup for a box.
@@ -424,6 +454,25 @@ mod tests {
         let available = is_cgroup_v2_available();
         println!("Cgroup v2 available: {}", available);
     }
+
+    #[test]
+    fn kill_cgroup_absent_is_noop() {
+        // No cgroup exists for this id, so `cgroup.kill` can't be written:
+        // kill_cgroup must report `false` and not panic. This locks the
+        // best-effort/idempotent contract relied on by the no-jailer and
+        // macOS-seatbelt paths (where there is no box cgroup to kill).
+        let box_id = BoxID::parse("nonexistentbox000000000000").expect("valid id");
+        assert!(
+            !kill_cgroup(&box_id),
+            "kill_cgroup must be a no-op (false) when the box has no cgroup"
+        );
+    }
+
+    // Note: there is no `kill_cgroup_rejects_non_component_box_ids` test anymore.
+    // The path-traversal guard moved into the type: `kill_cgroup` takes a
+    // `BoxID`, and `BoxID::parse` already rejects `/`, `\`, `.`, `..`, and empty
+    // ids (see `id::tests::test_parse_rejects_unsafe_characters`). A non-component
+    // id is now unrepresentable at this call site, not merely rejected at runtime.
 
     #[test]
     fn test_cgroup_config_from_limits() {

--- a/src/boxlite/src/jailer/cgroup.rs
+++ b/src/boxlite/src/jailer/cgroup.rs
@@ -150,8 +150,11 @@ pub fn cgroup_path(box_id: &str) -> PathBuf {
 /// even after `state.pid` has been cleared.
 ///
 /// Best-effort and idempotent: a no-op if the cgroup is gone, already empty, or
-/// `cgroup.kill` is unavailable (kernel < 5.14 / cgroup v1 / no jailer). Returns
-/// `true` if the kill file was written.
+/// `cgroup.kill` is unavailable (kernel < 5.14 / cgroup v1 / no jailer). On a
+/// successful write it then waits (bounded) for the cgroup to drain — see
+/// [`wait_for_empty_cgroup`] — so a caller that respawns immediately (restart)
+/// doesn't race a host port the dying tree hasn't released yet. Returns `true`
+/// if the kill file was written.
 ///
 /// Takes a [`BoxID`] rather than a raw `&str` on purpose: this writes to a path
 /// derived from the id, so it must be a safe single path component. `BoxID`'s
@@ -164,8 +167,40 @@ pub fn cgroup_path(box_id: &str) -> PathBuf {
 /// the jailer's [`super::reap_box`] facade. Layers above the jailer (box,
 /// runtime) reap by box semantics and never name cgroups.
 pub(super) fn kill_cgroup(box_id: &BoxID) -> bool {
-    let kill_file = cgroup_path(box_id.as_str()).join("cgroup.kill");
-    std::fs::write(&kill_file, "1").is_ok()
+    let box_cgroup = cgroup_path(box_id.as_str());
+    let kill_file = box_cgroup.join("cgroup.kill");
+    if fs::write(&kill_file, "1").is_err() {
+        return false;
+    }
+    wait_for_empty_cgroup(&box_cgroup);
+    true
+}
+
+/// Wait (bounded) for a box's cgroup to drain after `cgroup.kill`.
+///
+/// `cgroup.kill` delivers SIGKILL asynchronously: the kernel reaps the processes
+/// and only then releases what they held — notably the host TCP port the shim's
+/// in-process gvproxy bound for a port mapping. A restart that respawns and
+/// rebinds that same persisted host port before the old tree is gone fails with
+/// "address already in use", so a caller reaping *before respawn* needs the
+/// cgroup empty, not merely killed. Polls `cgroup.procs` until empty (or the
+/// cgroup disappears), giving up after 2s so reaping stays best-effort.
+fn wait_for_empty_cgroup(box_cgroup: &Path) {
+    let procs_file = box_cgroup.join("cgroup.procs");
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+
+    while std::time::Instant::now() < deadline {
+        match fs::read_to_string(&procs_file) {
+            Ok(procs) if procs.trim().is_empty() => return,
+            Err(_) => return,
+            _ => std::thread::sleep(std::time::Duration::from_millis(25)),
+        }
+    }
+
+    tracing::warn!(
+        cgroup = %box_cgroup.display(),
+        "Timed out waiting for box cgroup to empty after cgroup.kill"
+    );
 }
 
 /// Setup cgroup for a box.

--- a/src/boxlite/src/jailer/mod.rs
+++ b/src/boxlite/src/jailer/mod.rs
@@ -88,6 +88,28 @@ pub use sandbox::{
     CompositeSandbox, NoopSandbox, PathAccess, PlatformSandbox, Sandbox, SandboxContext,
 };
 
+// ============================================================================
+// Teardown facade
+// ============================================================================
+
+/// Reap any OS processes still belonging to a box's sandbox (best-effort).
+///
+/// The semantic teardown entry for the isolation layer: callers name the
+/// *box*, not the mechanism, so nothing above the jailer has to know how a box
+/// is confined. On Linux the box's whole process tree lives in its cgroup, so
+/// this reaps it by id; on platforms with no host-side sandbox tree it is a
+/// no-op. Idempotent — safe on an already-stopped or never-started box.
+#[cfg(target_os = "linux")]
+pub(crate) fn reap_box(box_id: &crate::runtime::id::BoxID) -> bool {
+    cgroup::kill_cgroup(box_id)
+}
+
+/// See the Linux variant. No host-side sandbox process tree to reap here.
+#[cfg(not(target_os = "linux"))]
+pub(crate) fn reap_box(_box_id: &crate::runtime::id::BoxID) -> bool {
+    false
+}
+
 // Volume specification (convenience re-export)
 pub use crate::runtime::options::VolumeSpec;
 

--- a/src/boxlite/src/litebox/init/mod.rs
+++ b/src/boxlite/src/litebox/init/mod.rs
@@ -201,6 +201,20 @@ impl BoxBuilder {
         let reuse_rootfs = status == BoxStatus::Stopped;
         let skip_guest_wait = status == BoxStatus::Running;
 
+        // Restart path (Stopped/Failed): a prior run can leave a stale process
+        // tree — inner bwrap + shim + the shim's in-process gvproxy — alive in
+        // the box's cgroup if it was stopped non-gracefully (host/API process
+        // killed before the cgroup reap ran, or an engine that only signalled
+        // the recorded outer pid). That stale gvproxy still holds the box's
+        // persisted host port, so the upcoming VmmSpawn → gvproxy_create would
+        // fail to bind it. Reap the cgroup and wait for it to drain before
+        // respawning; best-effort and idempotent (~no-op when nothing survived).
+        // Run off-thread so the bounded drain wait can't block the async runtime.
+        if matches!(status, BoxStatus::Stopped | BoxStatus::Failed) {
+            let box_id = config.id.clone();
+            let _ = tokio::task::spawn_blocking(move || crate::jailer::reap_box(&box_id)).await;
+        }
+
         let ctx = InitPipelineContext::new(config, runtime.clone(), reuse_rootfs, skip_guest_wait);
         let ctx = Arc::new(Mutex::new(ctx));
         let ctx_for_cleanup = Arc::clone(&ctx);

--- a/src/boxlite/src/rest/litebox.rs
+++ b/src/boxlite/src/rest/litebox.rs
@@ -624,6 +624,10 @@ async fn attach_ws_pump(
 
         // Cause that ended the inner loop — used by the reconnect/fallback path.
         let disconnect_cause: String;
+        // Set when the server closed with a "restarting" close code (1012/1013),
+        // e.g. an API rolling deploy. The reconnect path then skips the initial
+        // backoff sleep and reattaches immediately instead of waiting it out.
+        let mut reconnect_immediately = false;
 
         // Inner pump loop. Reads from WS and forwards stdin from the
         // SDK-side channel. Returns by setting `disconnect_cause` and
@@ -738,7 +742,9 @@ async fn attach_ws_pump(
                                 tracing::warn!(text = %text, "WS attach: unrecognized text frame");
                             }
                         },
-                        Message::Close(_) => {
+                        Message::Close(frame) => {
+                            let code = frame.as_ref().map(|f| f.code);
+                            reconnect_immediately = should_reconnect_immediately(code);
                             disconnect_cause = last_error_message.clone().unwrap_or_else(|| {
                                 "WS closed before exit frame (likely connection idle timeout or proxy cut)".to_string()
                             });
@@ -774,6 +780,10 @@ async fn attach_ws_pump(
 
         // Reconnect attempt loop with exponential backoff.
         let mut backoff = WS_RECONNECT_BACKOFF_INITIAL;
+        // A "server restarting" close (1012/1013) bypasses the first backoff
+        // sleep so a rolling API deploy reattaches immediately; later retries in
+        // this loop still back off normally.
+        let mut skip_first_backoff = reconnect_immediately;
         let reconnect_start = Instant::now();
         loop {
             if reconnect_budget.is_zero() {
@@ -787,9 +797,13 @@ async fn attach_ws_pump(
                 return;
             }
 
-            let sleep_for = backoff.min(reconnect_budget);
-            tokio::time::sleep(sleep_for).await;
-            reconnect_budget = reconnect_budget.saturating_sub(sleep_for);
+            if skip_first_backoff {
+                skip_first_backoff = false;
+            } else {
+                let sleep_for = backoff.min(reconnect_budget);
+                tokio::time::sleep(sleep_for).await;
+                reconnect_budget = reconnect_budget.saturating_sub(sleep_for);
+            }
 
             match client.connect_ws(&path).await {
                 Ok(new_stream) => {
@@ -815,6 +829,17 @@ async fn attach_ws_pump(
             }
         }
     }
+}
+
+/// Whether a server close code signals "I'm restarting, come back now" — in
+/// which case the reconnect path skips its initial backoff sleep. Only the
+/// `Restart` (1012) and `Again` (1013) codes qualify; every other close code
+/// (and a bare close with no code) keeps the normal backoff.
+fn should_reconnect_immediately(
+    code: Option<tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode>,
+) -> bool {
+    use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
+    matches!(code, Some(CloseCode::Restart) | Some(CloseCode::Again))
 }
 
 /// Outcome of probing `/executions/{id}` after a WS disconnect.
@@ -1606,5 +1631,22 @@ mod tests {
 
         attach.await.unwrap();
         server.abort();
+    }
+
+    /// `should_reconnect_immediately` must skip the initial backoff only for the
+    /// "server restarting" close codes (1012 Restart / 1013 Again). The inputs
+    /// are real tungstenite `CloseCode` values, so the mapping crosses from the
+    /// library's enum into the helper under test rather than being rebuilt here.
+    #[test]
+    fn restart_close_codes_reconnect_immediately() {
+        use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
+
+        assert!(should_reconnect_immediately(Some(CloseCode::Restart)));
+        assert!(should_reconnect_immediately(Some(CloseCode::Again)));
+
+        assert!(!should_reconnect_immediately(Some(CloseCode::Normal)));
+        assert!(!should_reconnect_immediately(Some(CloseCode::Away)));
+        assert!(!should_reconnect_immediately(Some(CloseCode::Abnormal)));
+        assert!(!should_reconnect_immediately(None));
     }
 }

--- a/src/boxlite/src/runtime/rt_impl.rs
+++ b/src/boxlite/src/runtime/rt_impl.rs
@@ -12,6 +12,7 @@ use crate::runtime::options::{BoxArchive, BoxOptions, BoxliteOptions};
 use crate::runtime::signal_handler::timeout_to_duration;
 use crate::runtime::types::{BoxInfo, BoxState, BoxStatus, ContainerID};
 use crate::vmm::VmmKind;
+use crate::vmm::controller::{ShimHandler, VmmHandler};
 use boxlite_shared::{BoxliteError, BoxliteResult};
 use chrono::Utc;
 use std::collections::HashMap;
@@ -834,10 +835,16 @@ impl RuntimeImpl {
             let mut state = state;
             if state.status.is_active() || state.pid.is_some() {
                 if force {
-                    // Force mode: kill the process directly
+                    // Stop the box's whole process tree through the same handler
+                    // teardown `LiteBox::stop()` uses: it SIGTERMs the recorded
+                    // pid (the outer launcher), then reaps any survivors of a
+                    // detached box's inner pid-ns tree (inner bwrap + shim + VM) —
+                    // which a single-pid kill misses, since #851 stopped tying
+                    // detached boxes to the launcher's lifetime.
                     if let Some(pid) = state.pid {
-                        tracing::info!(box_id = %id, pid = pid, "Force killing box process");
-                        crate::util::kill_process(pid);
+                        tracing::info!(box_id = %id, pid = pid, "Force stopping box process tree");
+                        let mut handler = ShimHandler::from_pid(pid, config.id.clone());
+                        let _ = handler.stop();
                     }
                     // Update status to stopped and save
                     state.set_status(BoxStatus::Stopped);

--- a/src/boxlite/src/vmm/controller/shim.rs
+++ b/src/boxlite/src/vmm/controller/shim.rs
@@ -76,14 +76,13 @@ impl ShimHandler {
             metrics_sys: Mutex::new(sysinfo::System::new()),
         }
     }
-}
 
-impl VmmHandlerTrait for ShimHandler {
-    fn pid(&self) -> u32 {
-        self.pid
-    }
-
-    fn stop(&mut self) -> BoxliteResult<()> {
+    /// Graceful shutdown of the recorded process: SIGTERM, wait, then SIGKILL.
+    ///
+    /// Signals only `self.pid` (the outer launcher). The full process-tree
+    /// sweep happens in `stop()` after this returns — see the comment there for
+    /// why the order matters (libkrun must flush before the hard cgroup kill).
+    fn graceful_stop(&mut self) -> BoxliteResult<()> {
         // Graceful shutdown: SIGTERM first, wait, then SIGKILL if needed.
         // This gives libkrun time to flush its virtio-blk buffers to disk,
         // preventing qcow2 corruption.
@@ -164,6 +163,26 @@ impl VmmHandlerTrait for ShimHandler {
 
         #[allow(unreachable_code)]
         Ok(())
+    }
+}
+
+impl VmmHandlerTrait for ShimHandler {
+    fn pid(&self) -> u32 {
+        self.pid
+    }
+
+    fn stop(&mut self) -> BoxliteResult<()> {
+        // Graceful shutdown of the recorded pid first, then sweep the box's
+        // whole tree. `graceful_stop` only signals the recorded pid — the outer
+        // bwrap launcher — and a detached box's inner pid-ns tree (inner bwrap +
+        // shim + VM) outlives it, since #851 stopped applying `--die-with-parent`
+        // to detached boxes. The whole tree lives in the box's cgroup, so reap it
+        // by id — *after* graceful shutdown, so libkrun can flush its virtio-blk
+        // buffers first (a cgroup kill is a hard kill; reaping mid-flush risks
+        // qcow2 corruption). Best-effort and idempotent.
+        let result = self.graceful_stop();
+        crate::jailer::reap_box(&self.box_id);
+        result
     }
 
     fn metrics(&self) -> BoxliteResult<VmmMetrics> {

--- a/src/boxlite/tests/detach.rs
+++ b/src/boxlite/tests/detach.rs
@@ -21,6 +21,49 @@ fn pid_file_path(home_dir: &Path, box_id: &str) -> PathBuf {
     home_dir.join("boxes").join(box_id).join("shim.pid")
 }
 
+/// Count live processes whose argv references `box_id` (Linux `/proc` scan).
+///
+/// A detached box's whole tree — the outer bwrap launcher, the inner
+/// pid-namespace bwrap, the shim, and the VM — carries the unique box id in its
+/// bwrap bind paths, so this counts every process in the tree. Used to assert
+/// that the production reap path tears the *whole* tree down, not just the
+/// recorded outer-bwrap pid.
+#[cfg(target_os = "linux")]
+fn box_proc_count(box_id: &str) -> usize {
+    let mut count = 0;
+    let Ok(entries) = std::fs::read_dir("/proc") else {
+        return 0;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+        if name.parse::<u32>().is_err() {
+            continue; // not a pid dir
+        }
+        if let Ok(cmdline) = std::fs::read(entry.path().join("cmdline"))
+            && cmdline
+                .windows(box_id.len())
+                .any(|w| w == box_id.as_bytes())
+        {
+            count += 1;
+        }
+    }
+    count
+}
+
+#[cfg(target_os = "linux")]
+async fn wait_for_box_proc_count_zero(box_id: &str) -> usize {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    let mut count = box_proc_count(box_id);
+
+    while count != 0 && std::time::Instant::now() < deadline {
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        count = box_proc_count(box_id);
+    }
+
+    count
+}
+
 // ============================================================================
 // DETACH MODE TESTS
 // ============================================================================
@@ -279,4 +322,106 @@ async fn detached_box_recoverable_after_restart() {
         // Cleanup
         runtime.remove(&box_id, false).await.unwrap();
     }
+}
+
+/// `runtime.remove(force)` on a detached box must reap its *entire* process
+/// tree. `kill_process` only signals the recorded outer bwrap; since #851
+/// dropped `--die-with-parent`, the inner pid-ns tree (inner bwrap + shim + VM)
+/// survives that. The production fix reaps the box's cgroup. This is the
+/// regression guard for the silent orphan VM that `boxlite rm -f` used to leave
+/// behind — note `PerTestBoxHome`'s `shim.pid`-based leak check can't see it
+/// (force-remove deletes the file), so the explicit `box_proc_count` is the
+/// real assertion here.
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn detached_box_force_remove_reaps_whole_tree() {
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+
+    let handle = runtime
+        .create(
+            boxlite::runtime::options::BoxOptions {
+                detach: true,
+                ..common::alpine_opts()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+    handle
+        .exec(BoxCommand::new("sleep").args(["300"]))
+        .await
+        .expect("start detached sleep workload");
+    let box_id = handle.id().to_string();
+
+    assert!(
+        box_proc_count(&box_id) > 0,
+        "detached box should have a live process tree after start"
+    );
+
+    // Production reap path.
+    runtime.remove(&box_id, true).await.unwrap();
+    let proc_count = wait_for_box_proc_count_zero(&box_id).await;
+
+    assert_eq!(
+        proc_count, 0,
+        "force remove must reap the whole detached box tree \
+         (outer + inner bwrap + shim + VM), not just the recorded pid"
+    );
+}
+
+/// `box.stop()` on a detached box must reap the full process tree while
+/// preserving the box record and disk state for a later start.
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn detached_box_stop_reaps_whole_tree_and_keeps_box() {
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+
+    let handle = runtime
+        .create(
+            boxlite::runtime::options::BoxOptions {
+                detach: true,
+                ..common::alpine_opts()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+    handle
+        .exec(BoxCommand::new("sleep").args(["300"]))
+        .await
+        .expect("start detached sleep workload");
+    let box_id = handle.id().to_string();
+
+    assert!(
+        box_proc_count(&box_id) > 0,
+        "detached box should have a live process tree after start"
+    );
+
+    handle.stop().await.unwrap();
+    let proc_count = wait_for_box_proc_count_zero(&box_id).await;
+
+    assert_eq!(
+        proc_count, 0,
+        "stop must reap the whole detached box tree \
+         (outer + inner bwrap + shim + VM), not just the recorded pid"
+    );
+
+    let info = runtime
+        .get_info(&box_id)
+        .await
+        .unwrap()
+        .expect("stopped box should still exist");
+    assert_eq!(info.status, BoxStatus::Stopped);
+
+    runtime.remove(&box_id, false).await.unwrap();
 }

--- a/src/boxlite/tests/detach.rs
+++ b/src/boxlite/tests/detach.rs
@@ -7,7 +7,7 @@ mod common;
 
 use boxlite::BoxliteRuntime;
 use boxlite::litebox::BoxCommand;
-use boxlite::runtime::options::BoxliteOptions;
+use boxlite::runtime::options::{BoxliteOptions, PortSpec};
 use boxlite::runtime::types::BoxStatus;
 use boxlite::util::{PidFileReader, is_process_alive};
 use std::path::{Path, PathBuf};
@@ -62,6 +62,17 @@ async fn wait_for_box_proc_count_zero(box_id: &str) -> usize {
     }
 
     count
+}
+
+/// Reserve, then release, an ephemeral host TCP port to use as a port mapping.
+///
+/// The box's gvproxy binds this host port; picking a known-free one keeps the
+/// test off unrelated host listeners. There is an inherent reserve→use race,
+/// but it is vanishingly unlikely in a test sandbox.
+#[cfg(target_os = "linux")]
+fn free_host_port() -> u16 {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral host port");
+    listener.local_addr().expect("local addr").port()
 }
 
 // ============================================================================
@@ -422,6 +433,101 @@ async fn detached_box_stop_reaps_whole_tree_and_keeps_box() {
         .unwrap()
         .expect("stopped box should still exist");
     assert_eq!(info.status, BoxStatus::Stopped);
+
+    runtime.remove(&box_id, false).await.unwrap();
+}
+
+/// `start()` on a `Stopped`/`Failed` box must reap a *legacy* stale tree before
+/// it respawns. If a prior run was stopped non-gracefully (only the recorded
+/// outer pid killed — pre-reap behaviour), the detached inner tree keeps running
+/// and keeps gvproxy's host port bound. The next `start()` rebinds that same
+/// persisted port in `VmmSpawn`, so without a reap-before-spawn it fails with
+/// "address already in use". This reproduces that exact state and asserts start
+/// recovers it (and that the subsequent stop still reaps the whole tree).
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn detached_box_restart_reaps_legacy_stale_tree_before_spawn() {
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let host_port = free_host_port();
+    let box_id: String;
+    let recorded_pid: u32;
+
+    {
+        let runtime = BoxliteRuntime::new(BoxliteOptions {
+            home_dir: home.path.clone(),
+            image_registries: common::test_registries(),
+        })
+        .expect("create runtime");
+
+        let mut opts = common::alpine_opts();
+        opts.detach = true;
+        opts.ports.push(PortSpec {
+            host_port: Some(host_port),
+            guest_port: 8080,
+            ..Default::default()
+        });
+
+        let handle = runtime.create(opts, None).await.unwrap();
+        handle
+            .exec(BoxCommand::new("sleep").args(["300"]))
+            .await
+            .expect("start detached sleep workload");
+
+        box_id = handle.id().to_string();
+        let pf = pid_file_path(&home.path, &box_id);
+        recorded_pid = PidFileReader::at(&pf).read().map(|r| r.pid).unwrap();
+
+        assert!(
+            box_proc_count(&box_id) > 0,
+            "detached box should have a live process tree after start"
+        );
+
+        // Simulate the legacy stop bug: only the recorded outer pid is killed,
+        // while the detached inner tree keeps running and keeps gvproxy's host
+        // port bound. The next runtime sync sees the dead recorded pid and
+        // treats the box as stopped, but the stale tree is still present.
+        assert!(
+            boxlite::util::kill_process(recorded_pid),
+            "failed to kill recorded outer pid {recorded_pid}"
+        );
+    }
+
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create replacement runtime");
+
+    let info = runtime
+        .get_info(&box_id)
+        .await
+        .unwrap()
+        .expect("box should still exist");
+    assert_eq!(info.status, BoxStatus::Stopped);
+    assert!(
+        box_proc_count(&box_id) > 0,
+        "legacy stale process tree should remain before restart"
+    );
+
+    let handle = runtime.get(&box_id).await.unwrap().unwrap();
+    handle
+        .start()
+        .await
+        .expect("restart should reap stale tree before binding gvproxy port");
+
+    let info = runtime
+        .get_info(&box_id)
+        .await
+        .unwrap()
+        .expect("box should still exist after restart");
+    assert_eq!(info.status, BoxStatus::Running);
+
+    handle.stop().await.unwrap();
+    let proc_count = wait_for_box_proc_count_zero(&box_id).await;
+    assert_eq!(
+        proc_count, 0,
+        "stop should reap restarted detached box tree"
+    );
 
     runtime.remove(&box_id, false).await.unwrap();
 }


### PR DESCRIPTION
## Summary

Two fixes for the same operational event — an **API ECS rolling upgrade** — which today degrades box and CLI-terminal availability.

### 1. Start Box fails after a non-graceful stop (`runtime`)

When the API is bounced and a box is stopped non-gracefully (the host/API process is killed, or an engine that only signals the recorded outer pid), the box's detached inner tree — inner `bwrap` + shim + the shim's in-process gvproxy — can survive in the box's cgroup and keep the box's **persisted host port** bound. The next **Start Box** then fails in `VmmSpawn`:

```
gvproxy_create failed ... listen tcp 0.0.0.0:<port>: bind: address already in use
```

**Fix:** before the `Stopped`/`Failed` restart pipeline respawns, reap the box's cgroup and wait (bounded) for it to drain, so the host port is released before the new gvproxy rebinds. `kill_cgroup` now polls `cgroup.procs` after `cgroup.kill`; the reap runs off-thread so the drain wait cannot block the async runtime. This builds on the stop/remove cgroup reap (#876), which is cherry-picked here because `feat/prod-enable` did not have it.

### 2. CLI exec terminals stall on API shutdown (`api` + CLI)

In-flight CLI `exec` WebSockets proxied through the API are handled by a raw HTTP `upgrade` listener that sits outside Nest's shutdown hooks, so on SIGTERM they were never closed — the CLI saw a TCP reset and waited out its reconnect backoff (~15s) before reattaching.

**Fix:** the API now tracks proxied client sockets and, on application shutdown, sends each a graceful WS Close (code `1012`); the CLI inspects the close code and skips the initial backoff on `1012`/`1013`, reconnecting immediately.

> **Scope note:** only the **CLI exec** path transits the API. The **dashboard terminal** goes through a separate proxy service (not the API), so it is unaffected by an API upgrade and is intentionally left unchanged. The ssh-gateway and runner-upgrade scenarios are out of scope for this PR.

## Commits

1. `#876` cherry-pick — reap detached box's full cgroup tree on stop/remove (already merged on `main`, absent from `feat/prod-enable`).
2. The fix above (restart-reap + drain-wait + WS 1012 graceful close + CLI fast-reconnect).

## Test status

| Test | Type | Status |
|------|------|--------|
| `boxlite-ws-proxy.service.spec.ts` (`buildCloseFrame`) | API unit (jest) | ✅ **Passed (7/7).** The frame is decoded by the `ws` library's `Receiver` (independent parser, non-tautological) and two-side verified (corrupt the frame → parser `RangeError` → restore → green). |
| API `tsc --noEmit` + `eslint` | static | ✅ Clean. |
| `cargo fmt` (Rust) | static | ✅ Clean. |
| `detached_box_restart_reaps_legacy_stale_tree_before_spawn` (`tests/detach.rs`) | Rust integration reproducer | ⚠️ **Not run.** Requires Linux + libkrun/KVM; not buildable on macOS. |
| `restart_close_codes_reconnect_immediately` (`rest/litebox.rs`) | Rust unit | ⚠️ **Not run.** Same cargo/Linux constraint. |

**Why this is a draft:** the Rust reproducer and unit test have not been executed — the project's Rust tests need a Linux + KVM host, and the dev machine was unreachable at authoring time. Before this leaves draft, the reproducer must get two-side verification on Linux: revert the production change → the test fails on `bind: address already in use` → restore → it passes.

## Risk

- The restart reap is best-effort and idempotent (a no-op when nothing survived); the drain wait is bounded (2s) and runs off the async runtime.
- The WS change only adds a graceful close on shutdown plus a faster client reconnect; it does not alter steady-state behavior.
