### PR TITLE
fix(jailer): stop deriving RLIMIT_NPROC from per-box max_processes

### DIFF
--- a/src/boxlite/src/jailer/common/rlimit.rs
+++ b/src/boxlite/src/jailer/common/rlimit.rs
@@ -73,6 +73,13 @@ pub fn apply_limits_raw(limits: &ResourceLimits) -> Result<(), i32> {
     // non-bypassable fork-bomb cap is the cgroup `pids.max` (set from
     // `max_processes` in jailer::cgroup), so RLIMIT_NPROC is left at its
     // inherited value here.
+    //
+    // Previous behaviour, kept for reference (do not re-enable without moving
+    // the drop-to-per-box-UID before this point — see PR #891):
+    //   if let Some(max_procs) = limits.max_processes {
+    //       // Note: Ignore errors for NPROC on macOS (works differently)
+    //       let _ = set_rlimit_raw(libc::RLIMIT_NPROC, max_procs);
+    //   }
 
     if let Some(max_mem) = limits.max_memory {
         set_rlimit_raw(libc::RLIMIT_AS, max_mem)?;

--- a/src/boxlite/src/jailer/common/rlimit.rs
+++ b/src/boxlite/src/jailer/common/rlimit.rs
@@ -62,10 +62,17 @@ pub fn apply_limits_raw(limits: &ResourceLimits) -> Result<(), i32> {
         set_rlimit_raw(libc::RLIMIT_FSIZE, max_fsize)?;
     }
 
-    if let Some(max_procs) = limits.max_processes {
-        // Note: Ignore errors for NPROC on macOS (works differently)
-        let _ = set_rlimit_raw(libc::RLIMIT_NPROC, max_procs);
-    }
+    // NOTE: `max_processes` is deliberately NOT applied as RLIMIT_NPROC.
+    // RLIMIT_NPROC is enforced per *real UID across the whole host*, and it is
+    // checked during bwrap's namespace setup while the process still runs as
+    // the spawning UID (before the box drops to its own UID). A small per-box
+    // value therefore makes box spawn fail
+    //   bwrap: Creating new namespace failed: Resource temporarily unavailable
+    // as soon as the spawning UID already has that many tasks — routine on a
+    // runner hosting several boxes or any loaded host. The correct, per-box,
+    // non-bypassable fork-bomb cap is the cgroup `pids.max` (set from
+    // `max_processes` in jailer::cgroup), so RLIMIT_NPROC is left at its
+    // inherited value here.
 
     if let Some(max_mem) = limits.max_memory {
         set_rlimit_raw(libc::RLIMIT_AS, max_mem)?;

--- a/src/boxlite/src/runtime/advanced_options.rs
+++ b/src/boxlite/src/runtime/advanced_options.rs
@@ -230,7 +230,12 @@ impl Default for SecurityOptions {
             resource_limits: ResourceLimits {
                 max_open_files: Some(1024),
                 max_file_size: Some(1024 * 1024 * 1024), // 1GB
-                max_processes: Some(100),
+                // Per-box cgroup `pids.max` — the fork-bomb cap for the box's
+                // host-side process tree (bwrap + shim + libkrun/gvproxy
+                // threads), which sits well under this. Deliberately does NOT
+                // set RLIMIT_NPROC anymore: that is per-host-UID and broke box
+                // spawn on busy hosts (see jailer::common::rlimit::apply_limits_raw).
+                max_processes: Some(1024),
                 max_memory: None,   // VM config handles this
                 max_cpu_time: None, // VM config handles this
             },


### PR DESCRIPTION
Decouple `RLIMIT_NPROC` from the per-box `max_processes` (which now drives only the cgroup `pids.max`, default raised 100 → 1024) so a busy spawning UID no longer makes a box fail to start with `bwrap: Creating new namespace failed: Resource temporarily unavailable`.

## Test plan:
- [x] `jailer::common::rlimit` unit tests (3) pass
- [x] `jailer::cgroup` unit tests (4) pass
- [x] `make clippy` clean

Note: on Linux without cgroup v2 this drops the rlimit fork-bomb backstop, which was only ever per-UID (never per-box) and already ignored on macOS; a replacement, if wanted, should be a separate generous limit, not the per-box number.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the default process limit for sandboxed workloads, reducing failures when many tasks run under the same account.
  * Process limits now rely on container-level enforcement, avoiding unexpected host-wide process cap issues that could block setup or execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->