### PR TITLE
fix(dashboard): refresh terminal from box detail

### DIFF
--- a/apps/dashboard/src/components/boxes/BoxDetails.test.tsx
+++ b/apps/dashboard/src/components/boxes/BoxDetails.test.tsx
@@ -1,0 +1,186 @@
+// @vitest-environment jsdom
+/*
+ * Modified by BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { Box, BoxState } from '@boxlite-ai/api-client'
+import BoxDetails from './BoxDetails'
+
+const mocks = vi.hoisted(() => ({
+  box: undefined as unknown,
+  boxRefetch: vi.fn(),
+  terminalRefetch: vi.fn(),
+  terminalReset: vi.fn(),
+  navigate: vi.fn(),
+  setSearchParams: vi.fn(),
+  mutateAsync: vi.fn(),
+}))
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mocks.navigate,
+  useParams: () => ({ boxId: 'box-1' }),
+  useSearchParams: () => [new URLSearchParams(), mocks.setSearchParams],
+}))
+
+vi.mock('react-oidc-context', () => ({
+  useAuth: () => ({ user: { profile: { sub: 'user-1' } } }),
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+  },
+}))
+
+vi.mock('@/components/OnboardingGuideDialog', () => ({
+  OnboardingGuideDialog: () => null,
+}))
+
+vi.mock('@/hooks/useConfig', () => ({
+  useConfig: () => ({}),
+}))
+
+vi.mock('@/hooks/useRegions', () => ({
+  useRegions: () => ({
+    getRegionName: (target?: string) => target,
+  }),
+}))
+
+vi.mock('@/hooks/useSelectedOrganization', () => ({
+  useSelectedOrganization: () => ({
+    selectedOrganization: { id: 'org-1' },
+    authenticatedUserOrganizationMember: { role: 'OWNER' },
+    authenticatedUserHasPermission: () => true,
+  }),
+}))
+
+vi.mock('@/hooks/useBoxWsSync', () => ({
+  useBoxWsSync: () => undefined,
+}))
+
+vi.mock('@/hooks/useBoxSessionContext', () => ({
+  useBoxSessionContext: () => ({
+    isTerminalActivated: () => true,
+    activateTerminal: vi.fn(),
+  }),
+}))
+
+vi.mock('@/hooks/queries/useBoxQuery', () => ({
+  useBoxQuery: () => ({
+    data: mocks.box,
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: mocks.boxRefetch,
+  }),
+}))
+
+vi.mock('@/hooks/queries/useTerminalSessionQuery', () => ({
+  useTerminalSessionQuery: () => ({
+    data: { url: 'https://terminal.example/session-1', expiresAt: Date.now() + 300000 },
+    isLoading: false,
+    isError: false,
+    isFetching: false,
+    refetch: mocks.terminalRefetch,
+    reset: mocks.terminalReset,
+  }),
+}))
+
+vi.mock('@/hooks/mutations/useStartBoxMutation', () => ({
+  useStartBoxMutation: () => ({ isPending: false, mutateAsync: mocks.mutateAsync }),
+}))
+
+vi.mock('@/hooks/mutations/useStopBoxMutation', () => ({
+  useStopBoxMutation: () => ({ isPending: false, mutateAsync: mocks.mutateAsync }),
+}))
+
+vi.mock('@/hooks/mutations/useRecoverBoxMutation', () => ({
+  useRecoverBoxMutation: () => ({ isPending: false, mutateAsync: mocks.mutateAsync }),
+}))
+
+vi.mock('@/hooks/mutations/useDeleteBoxMutation', () => ({
+  useDeleteBoxMutation: () => ({ isPending: false, mutateAsync: mocks.mutateAsync }),
+}))
+
+vi.mock('./BoxTerminalFrame', () => ({
+  BoxTerminalFrame: ({ sessionUrl }: { sessionUrl: string }) => <div data-testid="terminal-frame">{sessionUrl}</div>,
+}))
+
+function makeRunningBox(): Box {
+  return {
+    id: 'box-1',
+    name: 'box-one',
+    state: BoxState.STARTED,
+    cpu: 1,
+    memory: 2,
+    disk: 10,
+    image: 'ubuntu:24.04',
+    target: 'us-east-1',
+    createdAt: '2026-06-01T00:00:00.000Z',
+    updatedAt: '2026-06-01T00:01:00.000Z',
+  } as Box
+}
+
+async function flushReactWork() {
+  await act(async () => {
+    await Promise.resolve()
+  })
+}
+
+describe('BoxDetails refresh', () => {
+  let root: Root | null = null
+
+  beforeAll(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+  })
+
+  beforeEach(() => {
+    mocks.box = makeRunningBox()
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    act(() => {
+      root?.unmount()
+    })
+    root = null
+    document.body.innerHTML = ''
+    vi.clearAllMocks()
+  })
+
+  async function renderBoxDetails() {
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+
+    await act(async () => {
+      root = createRoot(host)
+      root.render(<BoxDetails />)
+    })
+
+    await flushReactWork()
+  }
+
+  it('reconnects an active terminal when the detail refresh button is clicked', async () => {
+    await renderBoxDetails()
+
+    expect(mocks.terminalRefetch).not.toHaveBeenCalled()
+    const frameBeforeRefresh = document.querySelector('[data-testid="terminal-frame"]')
+    expect(frameBeforeRefresh).not.toBeNull()
+
+    const refreshButton = document.querySelector<HTMLButtonElement>('button[title="refresh"]')
+    expect(refreshButton).not.toBeNull()
+
+    await act(async () => {
+      refreshButton?.click()
+    })
+    await flushReactWork()
+
+    expect(mocks.boxRefetch).toHaveBeenCalledTimes(1)
+    expect(mocks.terminalRefetch).toHaveBeenCalledTimes(1)
+    expect(document.querySelector('[data-testid="terminal-frame"]')).toBe(frameBeforeRefresh)
+  })
+})

--- a/apps/dashboard/src/components/boxes/BoxDetails.tsx
+++ b/apps/dashboard/src/components/boxes/BoxDetails.tsx
@@ -118,6 +118,7 @@ export default function BoxDetails() {
   const [showOnboardingDialog, setShowOnboardingDialog] = useState(false)
   const [onboardingProgress, setOnboardingProgress] = useState<OnboardingProgress>(() => readOnboardingProgress(userId))
   const [copied, setCopied] = useState(false)
+  const [terminalRefreshSignal, setTerminalRefreshSignal] = useState(0)
   const refreshRef = useRef<HTMLSpanElement>(null)
 
   const updateOnboardingProgress = useCallback(
@@ -236,6 +237,7 @@ export default function BoxDetails() {
 
   const handleRefresh = () => {
     refetch()
+    setTerminalRefreshSignal((signal) => signal + 1)
     const el = refreshRef.current
     if (el) {
       el.style.animation = 'none'
@@ -356,15 +358,19 @@ export default function BoxDetails() {
                   <Pause className="size-[13px]" fill="currentColor" /> stop
                 </button>
               )}
-              {writePermitted && isTransitioning(box) && !isRecoverable(box) && !isStartable(box) && !isStoppable(box) && (
-                <button
-                  type="button"
-                  disabled
-                  className="flex min-h-10 items-center gap-2 border border-border px-[15px] py-2 text-[13px] font-medium text-muted-foreground"
-                >
-                  <RefreshCw className="size-[14px] animate-spin" /> working…
-                </button>
-              )}
+              {writePermitted &&
+                isTransitioning(box) &&
+                !isRecoverable(box) &&
+                !isStartable(box) &&
+                !isStoppable(box) && (
+                  <button
+                    type="button"
+                    disabled
+                    className="flex min-h-10 items-center gap-2 border border-border px-[15px] py-2 text-[13px] font-medium text-muted-foreground"
+                  >
+                    <RefreshCw className="size-[14px] animate-spin" /> working…
+                  </button>
+                )}
               {deletePermitted && (
                 <DropdownMenu>
                   <DropdownMenuTrigger
@@ -457,7 +463,7 @@ export default function BoxDetails() {
                 </span>
               </div>
               <div className="flex min-h-0 flex-1 flex-col">
-                <BoxTerminalTab box={box} />
+                <BoxTerminalTab box={box} refreshSignal={terminalRefreshSignal} />
               </div>
             </div>
           </div>

--- a/apps/dashboard/src/components/boxes/BoxTerminalTab.tsx
+++ b/apps/dashboard/src/components/boxes/BoxTerminalTab.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from '@/components/ui/empty'
 import { BOXLITE_DOCS_URL } from '@/constants/ExternalLinks'
@@ -21,7 +21,7 @@ import { Play, RefreshCw, TerminalSquare } from '@/components/ui/icon'
 import { toast } from 'sonner'
 import { BoxTerminalFrame } from './BoxTerminalFrame'
 
-export function BoxTerminalTab({ box }: { box: Box }) {
+export function BoxTerminalTab({ box, refreshSignal = 0 }: { box: Box; refreshSignal?: number }) {
   const running = isStoppable(box)
   const { isTerminalActivated, activateTerminal } = useBoxSessionContext()
   const { authenticatedUserHasPermission } = useSelectedOrganization()
@@ -39,12 +39,27 @@ export function BoxTerminalTab({ box }: { box: Box }) {
 
   const [activated, setActivated] = useState(() => isTerminalActivated(box.id))
 
-  const { data: session, isLoading, isError, isFetching, reset } = useTerminalSessionQuery(box.id, running && activated)
+  const {
+    data: session,
+    isLoading,
+    isError,
+    isFetching,
+    reset,
+    refetch,
+  } = useTerminalSessionQuery(box.id, running && activated)
+  const lastRefreshSignalRef = useRef(refreshSignal)
 
   const handleConnect = () => {
     activateTerminal(box.id)
     setActivated(true)
   }
+
+  useEffect(() => {
+    if (refreshSignal === lastRefreshSignalRef.current) return
+    lastRefreshSignalRef.current = refreshSignal
+    if (!running || !activated) return
+    void refetch()
+  }, [activated, refetch, refreshSignal, running])
 
   if (!running) {
     return (
@@ -142,7 +157,12 @@ export function BoxTerminalTab({ box }: { box: Box }) {
   return (
     <div className="flex-1 flex flex-col">
       <div className="relative flex-1 min-h-0 bg-black overflow-hidden">
-        <BoxTerminalFrame sessionUrl={session.url} fullscreenHref={fullscreenHref} className="h-full" />
+        <BoxTerminalFrame
+          key={session.url}
+          sessionUrl={session.url}
+          fullscreenHref={fullscreenHref}
+          className="h-full"
+        />
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- Make the box detail refresh button also refresh the active terminal session query.
- Remount the terminal iframe after refresh so the signed preview URL is renewed and the terminal reconnects.
- Add a regression test covering box detail refresh triggering both box and terminal refetches.

## Verification
- `cd apps && npx vitest run dashboard/src/components/boxes/BoxDetails.test.tsx --config dashboard/vite.config.mts`
- `cd apps && npx eslint dashboard/src/components/boxes/BoxDetails.tsx dashboard/src/components/boxes/BoxTerminalTab.tsx dashboard/src/components/boxes/BoxDetails.test.tsx`
- `cd apps && npx prettier --check dashboard/src/components/boxes/BoxDetails.tsx dashboard/src/components/boxes/BoxTerminalTab.tsx dashboard/src/components/boxes/BoxDetails.test.tsx --config ../.prettierrc`
- `git diff --check`
- `make lint`

## Manual E2E
- Ran local dashboard frontend on `localhost:5174` against dev API `https://dev.boxlite.ai`.
- Started real dev box `tidy-beaver` (`Mx8TECCmM8t0`), connected the terminal, then clicked the box detail refresh button.
- Observed a fresh `GET /api/box/Mx8TECCmM8t0/ports/22222/signed-preview-url?expiresInSeconds=300` returning 200.
- Confirmed terminal iframe URL changed from the previous signed proxy host to a new signed proxy host and the shell prompt returned.
- Stopped `tidy-beaver` after the test.

## Notes
- Full `make test` was not used as the gating signal here because the earlier attempt hit an external GitHub SSL failure while downloading kernel headers, before exercising this dashboard change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refreshing a box now properly reconnects the active terminal session.
  * The terminal view reliably reloads after the refresh action so the latest running state is shown.

* **Tests**
  * Added a React Testing Library + Vitest suite covering the refresh flow, verifying both the box and terminal refetch behavior and that the terminal frame remains consistent through the refresh.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->