### PR TITLE
feat(runner): add drain guard for rollouts

### DIFF
--- a/apps/runner/cmd/runner/main.go
+++ b/apps/runner/cmd/runner/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/boxlite-ai/runner/pkg/api"
 	"github.com/boxlite-ai/runner/pkg/backend"
 	blclient "github.com/boxlite-ai/runner/pkg/boxlite"
+	"github.com/boxlite-ai/runner/pkg/drain"
 	"github.com/boxlite-ai/runner/pkg/runner"
 	"github.com/boxlite-ai/runner/pkg/runner/v2/executor"
 	"github.com/boxlite-ai/runner/pkg/runner/v2/healthcheck"
@@ -249,19 +250,23 @@ func run() int {
 	case <-interruptChannel:
 		logger.Info("Signal received, shutting down")
 
-		// Gracefully stop all running boxes BEFORE freeing the runtime / killing
-		// the API server. Without this step, the systemd SIGTERM that restarts
-		// this runner would kill libkrun mid-write, leaving boxes that can't
-		// re-boot (the original CL84LvGx7RBE incident).
-		//
-		// Timeout budget: 25s is well under systemd's default
-		// TimeoutStopSec=90s for the unit, leaving 60s+ for in-flight HTTP
-		// handlers and the deferred Close() that follows.
-		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 30*time.Second)
-		if err := boxliteClient.Shutdown(shutdownCtx, 25*time.Second); err != nil {
-			logger.Warn("BoxLite graceful shutdown failed; boxes may be in inconsistent state", "error", err)
+		if drain.IsDraining() {
+			logger.Info("Runner is draining; skipping BoxLite runtime shutdown")
+		} else {
+			// Gracefully stop all running boxes BEFORE freeing the runtime / killing
+			// the API server. Without this step, the systemd SIGTERM that restarts
+			// this runner would kill libkrun mid-write, leaving boxes that can't
+			// re-boot (the original CL84LvGx7RBE incident).
+			//
+			// Timeout budget: 25s is well under systemd's default
+			// TimeoutStopSec=90s for the unit, leaving 60s+ for in-flight HTTP
+			// handlers and the deferred Close() that follows.
+			shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 30*time.Second)
+			if err := boxliteClient.Shutdown(shutdownCtx, 25*time.Second); err != nil {
+				logger.Warn("BoxLite graceful shutdown failed; boxes may be in inconsistent state", "error", err)
+			}
+			shutdownCancel()
 		}
-		shutdownCancel()
 
 		apiServer.Stop()
 		logger.Info("Shutdown complete")

--- a/apps/runner/pkg/api/controllers/box.go
+++ b/apps/runner/pkg/api/controllers/box.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/boxlite-ai/runner/pkg/api/dto"
 	"github.com/boxlite-ai/runner/pkg/common"
+	"github.com/boxlite-ai/runner/pkg/drain"
 	"github.com/boxlite-ai/runner/pkg/models/enums"
 	"github.com/boxlite-ai/runner/pkg/runner"
 	"github.com/gin-gonic/gin"
@@ -33,6 +34,11 @@ import (
 //
 //	@id				Create
 func Create(ctx *gin.Context) {
+	if drain.IsDraining() {
+		ctx.JSON(http.StatusServiceUnavailable, gin.H{"error": "runner is draining"})
+		return
+	}
+
 	var createBoxDto dto.CreateBoxDTO
 	err := ctx.ShouldBindJSON(&createBoxDto)
 	if err != nil {
@@ -237,6 +243,11 @@ func GetNetworkSettings(ctx *gin.Context) {
 //
 //	@id				Start
 func Start(ctx *gin.Context) {
+	if drain.IsDraining() {
+		ctx.JSON(http.StatusServiceUnavailable, gin.H{"error": "runner is draining"})
+		return
+	}
+
 	boxId := ctx.Param("boxId")
 
 	runner, err := runner.GetInstance(nil)
@@ -377,6 +388,11 @@ type BoxInfoResponse struct {
 //
 //	@id				Recover
 func Recover(ctx *gin.Context) {
+	if drain.IsDraining() {
+		ctx.JSON(http.StatusServiceUnavailable, gin.H{"error": "runner is draining"})
+		return
+	}
+
 	var recoverDto dto.RecoverBoxDTO
 	err := ctx.ShouldBindJSON(&recoverDto)
 	if err != nil {

--- a/apps/runner/pkg/api/controllers/boxlite_exec.go
+++ b/apps/runner/pkg/api/controllers/boxlite_exec.go
@@ -8,6 +8,7 @@ import (
 
 	sdkboxlite "github.com/boxlite-ai/boxlite/sdks/go"
 	"github.com/boxlite-ai/runner/pkg/boxlite"
+	"github.com/boxlite-ai/runner/pkg/drain"
 	"github.com/boxlite-ai/runner/pkg/runner"
 	"github.com/gin-gonic/gin"
 )
@@ -37,6 +38,11 @@ type ResizeRequest struct {
 }
 
 func BoxliteExec(ctx *gin.Context) {
+	if drain.IsDraining() {
+		ctx.JSON(http.StatusServiceUnavailable, gin.H{"error": "runner is draining"})
+		return
+	}
+
 	r, err := runner.GetInstance(nil)
 	if err != nil {
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})

--- a/apps/runner/pkg/api/controllers/boxlite_exec_attach.go
+++ b/apps/runner/pkg/api/controllers/boxlite_exec_attach.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/boxlite-ai/runner/pkg/boxlite"
+	"github.com/boxlite-ai/runner/pkg/drain"
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
 )
@@ -135,6 +136,11 @@ func BoxliteExecAttach(ctx *gin.Context) {
 	boxId := ctx.Param("boxId")
 	execId := ctx.Param("execId")
 
+	if drain.IsDraining() {
+		ctx.JSON(http.StatusServiceUnavailable, gin.H{"error": "runner is draining"})
+		return
+	}
+
 	target, ok := resolveAttachExec(execId, boxId)
 	if !ok {
 		ctx.JSON(http.StatusNotFound, gin.H{"error": fmt.Sprintf("execution %s not found", execId)})
@@ -155,6 +161,9 @@ func BoxliteExecAttach(ctx *gin.Context) {
 		target.MarkDisconnected()
 		return
 	}
+
+	drain.BeginAttach()
+	defer drain.EndAttach()
 
 	runAttachLoop(ctx.Request.Context(), conn, target)
 }

--- a/apps/runner/pkg/api/controllers/boxlite_exec_attach_test.go
+++ b/apps/runner/pkg/api/controllers/boxlite_exec_attach_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/boxlite-ai/runner/pkg/drain"
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
 )
@@ -363,6 +364,73 @@ func TestBoxliteExecAttach_SingleAttach409(t *testing.T) {
 	if resp2.StatusCode != http.StatusConflict {
 		t.Fatalf("expected status 409, got %d", resp2.StatusCode)
 	}
+}
+
+func TestBoxliteExecAttach_DrainingRejectsNewAttach(t *testing.T) {
+	drain.Enable()
+	t.Cleanup(drain.Disable)
+
+	stub := newStubAttachExec()
+	cleanup := withStubExec(t, "exec-draining", stub)
+	defer cleanup()
+
+	srv := newAttachServer(t)
+	defer srv.Close()
+
+	conn, resp, err := dialAttach(t, srv, "exec-draining")
+	if err == nil {
+		conn.Close()
+		t.Fatal("expected draining attach to fail")
+	}
+	if resp == nil {
+		t.Fatalf("expected http response, got nil (err=%v)", err)
+	}
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("expected status 503, got %d", resp.StatusCode)
+	}
+	if drain.ActiveAttachCount() != 0 {
+		t.Fatalf("rejected attach must not increment active count, got %d", drain.ActiveAttachCount())
+	}
+}
+
+func TestBoxliteExecAttach_TracksActiveAttachCount(t *testing.T) {
+	drain.Disable()
+	t.Cleanup(drain.Disable)
+
+	stub := newStubAttachExec()
+	cleanup := withStubExec(t, "exec-active-count", stub)
+	defer cleanup()
+
+	srv := newAttachServer(t)
+	defer srv.Close()
+
+	conn, _, err := dialAttach(t, srv, "exec-active-count")
+	if err != nil {
+		t.Fatalf("dial attach: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if drain.ActiveAttachCount() == 1 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if drain.ActiveAttachCount() != 1 {
+		t.Fatalf("expected active attach count 1, got %d", drain.ActiveAttachCount())
+	}
+
+	_ = conn.Close()
+	close(stub.done)
+
+	deadline = time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if drain.ActiveAttachCount() == 0 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("expected active attach count 0 after close, got %d", drain.ActiveAttachCount())
 }
 
 func TestBoxliteExecAttach_ResizeFrame(t *testing.T) {

--- a/apps/runner/pkg/api/controllers/boxlite_exec_test.go
+++ b/apps/runner/pkg/api/controllers/boxlite_exec_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/boxlite-ai/runner/pkg/boxlite"
+	"github.com/boxlite-ai/runner/pkg/drain"
 	"github.com/gin-gonic/gin"
 )
 
@@ -85,6 +86,21 @@ func seedManagedExecForBox(mgr *boxlite.ExecManager, id, boxID string, handle bo
 	exec.SetExecHandle(handle)
 	mgr.Register(id, exec)
 	return exec
+}
+
+func TestBoxliteExecRejectsNewExecWhileDraining(t *testing.T) {
+	drain.Enable()
+	t.Cleanup(drain.Disable)
+
+	w := runHandler(http.MethodPost,
+		"/v1/boxes/:boxId/exec",
+		"/v1/boxes/box/exec",
+		strings.NewReader(`{"command":"sh","args":["-lc","true"]}`),
+		BoxliteExec)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 while draining, got %d body=%s", w.Code, w.Body.String())
+	}
 }
 
 // Phase 2.1: GET /executions/{id} reports running, then exited+exit_code

--- a/apps/runner/pkg/api/controllers/drain.go
+++ b/apps/runner/pkg/api/controllers/drain.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+package controllers
+
+import (
+	"net/http"
+
+	"github.com/boxlite-ai/runner/pkg/drain"
+	"github.com/gin-gonic/gin"
+)
+
+type DrainRequest struct {
+	Draining bool `json:"draining"`
+}
+
+type DrainStatusResponse struct {
+	Draining          bool  `json:"draining"`
+	ActiveAttachCount int64 `json:"active_attach_count"`
+}
+
+func DrainStatus(ctx *gin.Context) {
+	ctx.JSON(http.StatusOK, drainStatusResponse())
+}
+
+func SetDrain(ctx *gin.Context) {
+	var req DrainRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid request"})
+		return
+	}
+
+	if req.Draining {
+		drain.Enable()
+	} else {
+		drain.Disable()
+	}
+
+	ctx.JSON(http.StatusOK, drainStatusResponse())
+}
+
+func drainStatusResponse() DrainStatusResponse {
+	return DrainStatusResponse{
+		Draining:          drain.IsDraining(),
+		ActiveAttachCount: drain.ActiveAttachCount(),
+	}
+}

--- a/apps/runner/pkg/api/controllers/drain_test.go
+++ b/apps/runner/pkg/api/controllers/drain_test.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+package controllers
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/boxlite-ai/runner/pkg/drain"
+)
+
+func TestSetDrainAndStatus(t *testing.T) {
+	drain.Disable()
+	t.Cleanup(drain.Disable)
+
+	w := runHandler(http.MethodPost,
+		"/admin/drain",
+		"/admin/drain",
+		strings.NewReader(`{"draining":true}`),
+		SetDrain)
+	if w.Code != http.StatusOK {
+		t.Fatalf("enable drain: expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+
+	w = runHandler(http.MethodGet, "/admin/drain", "/admin/drain", nil, DrainStatus)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+
+	var status DrainStatusResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &status); err != nil {
+		t.Fatalf("unmarshal status: %v", err)
+	}
+	if !status.Draining {
+		t.Fatalf("expected draining=true, got %+v", status)
+	}
+}

--- a/apps/runner/pkg/api/server.go
+++ b/apps/runner/pkg/api/server.go
@@ -128,6 +128,12 @@ func (a *ApiServer) Start(ctx context.Context) error {
 		infoController.GET("", controllers.RunnerInfo)
 	}
 
+	adminController := protected.Group("/admin")
+	{
+		adminController.GET("/drain", controllers.DrainStatus)
+		adminController.POST("/drain", controllers.SetDrain)
+	}
+
 	boxControllerLogger := a.logger.With(slog.String("component", "box_controller"))
 	boxController := protected.Group("/boxes")
 	{

--- a/apps/runner/pkg/drain/drain.go
+++ b/apps/runner/pkg/drain/drain.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+package drain
+
+import "sync/atomic"
+
+var (
+	draining     atomic.Bool
+	activeAttach atomic.Int64
+)
+
+func Enable() {
+	draining.Store(true)
+}
+
+func Disable() {
+	draining.Store(false)
+}
+
+func IsDraining() bool {
+	return draining.Load()
+}
+
+func BeginAttach() {
+	activeAttach.Add(1)
+}
+
+func EndAttach() {
+	activeAttach.Add(-1)
+}
+
+func ActiveAttachCount() int64 {
+	return activeAttach.Load()
+}

--- a/apps/runner/pkg/runner/v2/healthcheck/healthcheck.go
+++ b/apps/runner/pkg/runner/v2/healthcheck/healthcheck.go
@@ -16,6 +16,7 @@ import (
 	"github.com/boxlite-ai/runner/internal/metrics"
 	runnerapiclient "github.com/boxlite-ai/runner/pkg/apiclient"
 	blclient "github.com/boxlite-ai/runner/pkg/boxlite"
+	"github.com/boxlite-ai/runner/pkg/drain"
 )
 
 type HealthcheckServiceConfig struct {
@@ -94,6 +95,11 @@ func (s *Service) Start(ctx context.Context) {
 }
 
 func (s *Service) sendHealthcheck(ctx context.Context) error {
+	if drain.IsDraining() {
+		s.log.DebugContext(ctx, "Skipping healthcheck while runner is draining")
+		return nil
+	}
+
 	reqCtx, cancel := context.WithTimeout(ctx, s.timeout)
 	defer cancel()
 


### PR DESCRIPTION
Add runner drain mode so rollout tooling can reject new box operations while keeping health checks observable.

Test plan:
- [x] gofmt -w apps/runner/cmd/runner/main.go apps/runner/pkg/api/controllers/box.go apps/runner/pkg/api/controllers/boxlite_exec.go apps/runner/pkg/api/controllers/boxlite_exec_attach.go apps/runner/pkg/api/controllers/boxlite_exec_attach_test.go apps/runner/pkg/api/controllers/boxlite_exec_test.go apps/runner/pkg/api/controllers/drain.go apps/runner/pkg/api/controllers/drain_test.go apps/runner/pkg/api/server.go apps/runner/pkg/drain/drain.go apps/runner/pkg/runner/v2/healthcheck/healthcheck.go
- [x] git diff --check origin/main...HEAD
- [x] go test ./runner/pkg/drain ./runner/pkg/api/controllers ./runner/pkg/runner/v2/healthcheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added admin controls to view and enable or disable runner draining.
  * Drain status includes the number of active attach sessions.
  * New workloads and execution sessions are rejected with HTTP 503 while draining.
  * Existing attach sessions continue to be tracked until they close.

* **Behavior Changes**
  * Health checks and runtime shutdown are skipped while draining.
  * Added coverage for drain status, request rejection, and active session tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->