### PR TITLE
feat(jailer): per-box dedicated host UID + RLIMIT_NPROC scoped to it

### DIFF
--- a/src/boxlite/src/jailer/mod.rs
+++ b/src/boxlite/src/jailer/mod.rs
@@ -503,50 +503,77 @@ impl<S: Sandbox> Jail for Jailer<S> {
     }
 }
 
+/// Fail-closed UID for a root runner that can't get a dedicated one: the box
+/// drops to `nobody` rather than ever staying root.
+#[cfg(target_os = "linux")]
+const NOBODY_UID: u32 = 65534;
+
 impl<S: Sandbox> Jailer<S> {
-    /// Resolve the per-box `(uid, gid)` the child should `setresuid` into, or
-    /// `None` to run as the spawning UID.
+    /// Resolve the `(uid, gid, supplementary_gids)` the child should
+    /// `setresuid`/`setgroups` into, or `None` to keep the (already non-root)
+    /// spawning UID.
     ///
-    /// `Some` only when privileged: an explicit `security.uid`, or an
-    /// auto-allocated dedicated UID (then the box dir is chowned to it so the
-    /// dropped process can reach its own disks/sockets/shim). Rootless callers
-    /// get `None` and rely on cgroup `pids.max` alone.
+    /// Invariant: **the box never runs as root.** A privileged (root) runner
+    /// therefore *always* drops — to a dedicated per-box UID when one can be
+    /// allocated, otherwise to `nobody` as a fail-closed fallback (never back to
+    /// root). A non-root runner already satisfies the invariant, so it keeps its
+    /// UID (`None`) and relies on cgroup `pids.max`. Supplementary groups carry
+    /// the device groups the box still needs (kvm).
     #[cfg(target_os = "linux")]
-    fn resolve_box_credentials(&self) -> Option<(u32, u32)> {
+    fn resolve_box_credentials(&self) -> Option<(u32, u32, Vec<u32>)> {
         if !self.security.jailer_enabled {
             return None;
         }
+        // Device groups the dropped UID keeps: kvm (libkrun opens /dev/kvm,
+        // root:kvm 0660). /dev/net/tun is world-accessible (0666), needs none.
+        let groups: Vec<u32> = uid_alloc::group_gid("kvm").into_iter().collect();
+
+        // Explicit override from SecurityOptions.
         if let Some(uid) = self.security.uid {
-            return Some((uid, self.security.gid.unwrap_or(uid)));
+            return Some((uid, self.security.gid.unwrap_or(uid), groups));
         }
+
+        // A non-root runner is already non-root; setresuid into a foreign UID
+        // needs CAP_SETUID anyway. Keep the UID, rely on cgroup pids.max.
         if !uid_alloc::UidAllocator::is_supported() {
             return None;
         }
+
+        // Root runner: must drop to a non-root UID. Prefer a dedicated one.
         let box_dir = self.layout.root();
-        let boxes_dir = box_dir.parent()?.to_path_buf();
-        let allocator =
-            uid_alloc::UidAllocator::new(boxes_dir.clone(), boxes_dir.join(".uidpool.lock"));
-        let creds = match allocator.allocate(box_dir) {
-            Ok(creds) => creds,
-            Err(e) => {
-                tracing::warn!(error = %e, "per-box UID allocation failed; running without a dedicated UID");
-                return None;
-            }
+        let creds = box_dir
+            .parent()
+            .map(|boxes_dir| {
+                uid_alloc::UidAllocator::new(
+                    boxes_dir.to_path_buf(),
+                    boxes_dir.join(".uidpool.lock"),
+                )
+            })
+            .and_then(|allocator| match allocator.allocate(box_dir) {
+                Ok(creds) => Some(creds),
+                Err(e) => {
+                    tracing::warn!(error = %e, "per-box UID allocation failed; box will drop to nobody");
+                    None
+                }
+            });
+
+        // Fail closed to `nobody` (65534) rather than ever leaving the box root.
+        let (uid, gid) = match creds {
+            Some(c) => (c.uid, c.gid),
+            None => (NOBODY_UID, NOBODY_UID),
         };
-        if let Err(e) = uid_alloc::chown_tree(box_dir, creds.uid, creds.gid) {
-            tracing::warn!(error = %e, uid = creds.uid, "chown box dir to dedicated UID failed; running without a dedicated UID");
-            return None;
+
+        // Best-effort: the dropped UID must own its working tree to use it. A
+        // failure here breaks the box, but the box still drops (never root).
+        if let Err(e) = uid_alloc::chown_tree(box_dir, uid, gid) {
+            tracing::warn!(error = %e, uid, "chown box dir to dropped UID failed");
         }
-        tracing::info!(
-            uid = creds.uid,
-            gid = creds.gid,
-            "box will drop to its dedicated host UID"
-        );
-        Some((creds.uid, creds.gid))
+        tracing::info!(uid, gid, "box will drop to a non-root host UID");
+        Some((uid, gid, groups))
     }
 
     #[cfg(not(target_os = "linux"))]
-    fn resolve_box_credentials(&self) -> Option<(u32, u32)> {
+    fn resolve_box_credentials(&self) -> Option<(u32, u32, Vec<u32>)> {
         None
     }
 

--- a/src/boxlite/src/jailer/mod.rs
+++ b/src/boxlite/src/jailer/mod.rs
@@ -524,6 +524,16 @@ impl<S: Sandbox> Jailer<S> {
         if !self.security.jailer_enabled {
             return None;
         }
+
+        // Any UID drop needs CAP_SETUID, which in practice means root. A
+        // non-root runner can't `setresuid` into a foreign UID — and it is
+        // already non-root — so keep its UID and rely on cgroup pids.max. This
+        // gate is FIRST, before honoring `security.uid`: attempting the drop
+        // unprivileged would fail the pre_exec hook with EPERM and abort spawn.
+        if !uid_alloc::UidAllocator::is_supported() {
+            return None;
+        }
+
         // Device groups the dropped UID keeps: kvm (libkrun opens /dev/kvm,
         // root:kvm 0660). /dev/net/tun is world-accessible (0666), needs none.
         let groups: Vec<u32> = uid_alloc::group_gid("kvm").into_iter().collect();
@@ -531,12 +541,6 @@ impl<S: Sandbox> Jailer<S> {
         // Explicit override from SecurityOptions.
         if let Some(uid) = self.security.uid {
             return Some((uid, self.security.gid.unwrap_or(uid), groups));
-        }
-
-        // A non-root runner is already non-root; setresuid into a foreign UID
-        // needs CAP_SETUID anyway. Keep the UID, rely on cgroup pids.max.
-        if !uid_alloc::UidAllocator::is_supported() {
-            return None;
         }
 
         // Root runner: must drop to a non-root UID. Prefer a dedicated one.

--- a/src/boxlite/src/jailer/mod.rs
+++ b/src/boxlite/src/jailer/mod.rs
@@ -75,6 +75,8 @@ pub(crate) mod credentials;
 pub mod landlock;
 #[cfg(target_os = "linux")]
 pub mod seccomp;
+#[cfg(target_os = "linux")]
+pub(crate) mod uid_alloc;
 
 // ============================================================================
 // Public re-exports
@@ -473,10 +475,21 @@ impl<S: Sandbox> Jail for Jailer<S> {
             tracing::info!("Jailer disabled, running shim without sandbox isolation");
         }
 
-        // Pre-exec hook: FD preservation, FD cleanup, rlimits, PID file.
+        // Per-box dedicated UID. When privileged, allocate one and chown the box
+        // dir to it; the pre_exec hook then `setresuid`s into it so RLIMIT_NPROC
+        // is charged against this clean per-box UID instead of the shared runner
+        // UID. When not privileged (no dedicated UID), drop the per-box NPROC —
+        // applying it to the shared runner UID is exactly what broke spawn on a
+        // busy host; the cgroup `pids.max` cap still bounds the box.
+        let drop_to = self.resolve_box_credentials();
+        let mut resource_limits = self.security.resource_limits.clone();
+        if drop_to.is_none() {
+            resource_limits.max_processes = None;
+        }
+
+        // Pre-exec hook: FD preservation, FD cleanup, rlimits, PID file, UID drop.
         // Sandbox-specific pre_exec hooks (cgroup, Landlock) are already added
         // by sandbox.apply() above — Command supports multiple pre_exec closures.
-        let resource_limits = self.security.resource_limits.clone();
         let pid_writer = self.pid_file_writer();
         pre_exec::add_pre_exec_hook(
             &mut cmd,
@@ -484,12 +497,59 @@ impl<S: Sandbox> Jail for Jailer<S> {
             pid_writer,
             self.preserved_fds.clone(),
             self.detach,
+            drop_to,
         );
         cmd
     }
 }
 
 impl<S: Sandbox> Jailer<S> {
+    /// Resolve the per-box `(uid, gid)` the child should `setresuid` into, or
+    /// `None` to run as the spawning UID.
+    ///
+    /// `Some` only when privileged: an explicit `security.uid`, or an
+    /// auto-allocated dedicated UID (then the box dir is chowned to it so the
+    /// dropped process can reach its own disks/sockets/shim). Rootless callers
+    /// get `None` and rely on cgroup `pids.max` alone.
+    #[cfg(target_os = "linux")]
+    fn resolve_box_credentials(&self) -> Option<(u32, u32)> {
+        if !self.security.jailer_enabled {
+            return None;
+        }
+        if let Some(uid) = self.security.uid {
+            return Some((uid, self.security.gid.unwrap_or(uid)));
+        }
+        if !uid_alloc::UidAllocator::is_supported() {
+            return None;
+        }
+        let box_dir = self.layout.root();
+        let boxes_dir = box_dir.parent()?.to_path_buf();
+        let allocator =
+            uid_alloc::UidAllocator::new(boxes_dir.clone(), boxes_dir.join(".uidpool.lock"));
+        let creds = match allocator.allocate(box_dir) {
+            Ok(creds) => creds,
+            Err(e) => {
+                tracing::warn!(error = %e, "per-box UID allocation failed; running without a dedicated UID");
+                return None;
+            }
+        };
+        if let Err(e) = uid_alloc::chown_tree(box_dir, creds.uid, creds.gid) {
+            tracing::warn!(error = %e, uid = creds.uid, "chown box dir to dedicated UID failed; running without a dedicated UID");
+            return None;
+        }
+        tracing::info!(
+            uid = creds.uid,
+            gid = creds.gid,
+            "box will drop to its dedicated host UID"
+        );
+        Some((creds.uid, creds.gid))
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn resolve_box_credentials(&self) -> Option<(u32, u32)> {
+        None
+    }
+
     /// Get the security options.
     pub fn security(&self) -> &SecurityOptions {
         &self.security

--- a/src/boxlite/src/jailer/mod.rs
+++ b/src/boxlite/src/jailer/mod.rs
@@ -557,6 +557,16 @@ impl<S: Sandbox> Jailer<S> {
         if !self.security.jailer_enabled {
             return None;
         }
+
+        // Any UID drop needs CAP_SETUID, which in practice means root. A
+        // non-root runner can't `setresuid` into a foreign UID — and it is
+        // already non-root — so keep its UID and rely on cgroup pids.max. This
+        // gate is FIRST, before honoring `security.uid`: attempting the drop
+        // unprivileged would fail the pre_exec hook with EPERM and abort spawn.
+        if !uid_alloc::UidAllocator::is_supported() {
+            return None;
+        }
+
         // Device groups the dropped UID keeps: kvm (libkrun opens /dev/kvm,
         // root:kvm 0660). /dev/net/tun is world-accessible (0666), needs none.
         let groups: Vec<u32> = uid_alloc::group_gid("kvm").into_iter().collect();
@@ -564,12 +574,6 @@ impl<S: Sandbox> Jailer<S> {
         // Explicit override from SecurityOptions.
         if let Some(uid) = self.security.uid {
             return Some((uid, self.security.gid.unwrap_or(uid), groups));
-        }
-
-        // A non-root runner is already non-root; setresuid into a foreign UID
-        // needs CAP_SETUID anyway. Keep the UID, rely on cgroup pids.max.
-        if !uid_alloc::UidAllocator::is_supported() {
-            return None;
         }
 
         // Root runner: must drop to a non-root UID. Prefer a dedicated one.

--- a/src/boxlite/src/jailer/mod.rs
+++ b/src/boxlite/src/jailer/mod.rs
@@ -536,50 +536,77 @@ impl<S: Sandbox> Jail for Jailer<S> {
     }
 }
 
+/// Fail-closed UID for a root runner that can't get a dedicated one: the box
+/// drops to `nobody` rather than ever staying root.
+#[cfg(target_os = "linux")]
+const NOBODY_UID: u32 = 65534;
+
 impl<S: Sandbox> Jailer<S> {
-    /// Resolve the per-box `(uid, gid)` the child should `setresuid` into, or
-    /// `None` to run as the spawning UID.
+    /// Resolve the `(uid, gid, supplementary_gids)` the child should
+    /// `setresuid`/`setgroups` into, or `None` to keep the (already non-root)
+    /// spawning UID.
     ///
-    /// `Some` only when privileged: an explicit `security.uid`, or an
-    /// auto-allocated dedicated UID (then the box dir is chowned to it so the
-    /// dropped process can reach its own disks/sockets/shim). Rootless callers
-    /// get `None` and rely on cgroup `pids.max` alone.
+    /// Invariant: **the box never runs as root.** A privileged (root) runner
+    /// therefore *always* drops — to a dedicated per-box UID when one can be
+    /// allocated, otherwise to `nobody` as a fail-closed fallback (never back to
+    /// root). A non-root runner already satisfies the invariant, so it keeps its
+    /// UID (`None`) and relies on cgroup `pids.max`. Supplementary groups carry
+    /// the device groups the box still needs (kvm).
     #[cfg(target_os = "linux")]
-    fn resolve_box_credentials(&self) -> Option<(u32, u32)> {
+    fn resolve_box_credentials(&self) -> Option<(u32, u32, Vec<u32>)> {
         if !self.security.jailer_enabled {
             return None;
         }
+        // Device groups the dropped UID keeps: kvm (libkrun opens /dev/kvm,
+        // root:kvm 0660). /dev/net/tun is world-accessible (0666), needs none.
+        let groups: Vec<u32> = uid_alloc::group_gid("kvm").into_iter().collect();
+
+        // Explicit override from SecurityOptions.
         if let Some(uid) = self.security.uid {
-            return Some((uid, self.security.gid.unwrap_or(uid)));
+            return Some((uid, self.security.gid.unwrap_or(uid), groups));
         }
+
+        // A non-root runner is already non-root; setresuid into a foreign UID
+        // needs CAP_SETUID anyway. Keep the UID, rely on cgroup pids.max.
         if !uid_alloc::UidAllocator::is_supported() {
             return None;
         }
+
+        // Root runner: must drop to a non-root UID. Prefer a dedicated one.
         let box_dir = self.layout.root();
-        let boxes_dir = box_dir.parent()?.to_path_buf();
-        let allocator =
-            uid_alloc::UidAllocator::new(boxes_dir.clone(), boxes_dir.join(".uidpool.lock"));
-        let creds = match allocator.allocate(box_dir) {
-            Ok(creds) => creds,
-            Err(e) => {
-                tracing::warn!(error = %e, "per-box UID allocation failed; running without a dedicated UID");
-                return None;
-            }
+        let creds = box_dir
+            .parent()
+            .map(|boxes_dir| {
+                uid_alloc::UidAllocator::new(
+                    boxes_dir.to_path_buf(),
+                    boxes_dir.join(".uidpool.lock"),
+                )
+            })
+            .and_then(|allocator| match allocator.allocate(box_dir) {
+                Ok(creds) => Some(creds),
+                Err(e) => {
+                    tracing::warn!(error = %e, "per-box UID allocation failed; box will drop to nobody");
+                    None
+                }
+            });
+
+        // Fail closed to `nobody` (65534) rather than ever leaving the box root.
+        let (uid, gid) = match creds {
+            Some(c) => (c.uid, c.gid),
+            None => (NOBODY_UID, NOBODY_UID),
         };
-        if let Err(e) = uid_alloc::chown_tree(box_dir, creds.uid, creds.gid) {
-            tracing::warn!(error = %e, uid = creds.uid, "chown box dir to dedicated UID failed; running without a dedicated UID");
-            return None;
+
+        // Best-effort: the dropped UID must own its working tree to use it. A
+        // failure here breaks the box, but the box still drops (never root).
+        if let Err(e) = uid_alloc::chown_tree(box_dir, uid, gid) {
+            tracing::warn!(error = %e, uid, "chown box dir to dropped UID failed");
         }
-        tracing::info!(
-            uid = creds.uid,
-            gid = creds.gid,
-            "box will drop to its dedicated host UID"
-        );
-        Some((creds.uid, creds.gid))
+        tracing::info!(uid, gid, "box will drop to a non-root host UID");
+        Some((uid, gid, groups))
     }
 
     #[cfg(not(target_os = "linux"))]
-    fn resolve_box_credentials(&self) -> Option<(u32, u32)> {
+    fn resolve_box_credentials(&self) -> Option<(u32, u32, Vec<u32>)> {
         None
     }
 

--- a/src/boxlite/src/jailer/mod.rs
+++ b/src/boxlite/src/jailer/mod.rs
@@ -75,6 +75,8 @@ pub(crate) mod credentials;
 pub mod landlock;
 #[cfg(target_os = "linux")]
 pub mod seccomp;
+#[cfg(target_os = "linux")]
+pub(crate) mod uid_alloc;
 
 // ============================================================================
 // Public re-exports
@@ -505,11 +507,22 @@ impl<S: Sandbox> Jail for Jailer<S> {
             tracing::info!("Jailer disabled, running shim without sandbox isolation");
         }
 
-        // Pre-exec hook: PID file, FD preservation, FD cleanup, rlimits. The
-        // PID file goes first on purpose — see `pre_exec`'s module docs.
+        // Per-box dedicated UID. When privileged, allocate one and chown the box
+        // dir to it; the pre_exec hook then `setresuid`s into it so RLIMIT_NPROC
+        // is charged against this clean per-box UID instead of the shared runner
+        // UID. When not privileged (no dedicated UID), drop the per-box NPROC —
+        // applying it to the shared runner UID is exactly what broke spawn on a
+        // busy host; the cgroup `pids.max` cap still bounds the box.
+        let drop_to = self.resolve_box_credentials();
+        let mut resource_limits = self.security.resource_limits.clone();
+        if drop_to.is_none() {
+            resource_limits.max_processes = None;
+        }
+
+        // Pre-exec hook: PID file, FD preservation, FD cleanup, rlimits, UID
+        // drop. The PID file goes first on purpose — see `pre_exec`'s module docs.
         // Sandbox-specific pre_exec hooks (cgroup, Landlock) are already added
         // by sandbox.apply() above — Command supports multiple pre_exec closures.
-        let resource_limits = self.security.resource_limits.clone();
         let pid_writer = self.pid_file_writer();
         pre_exec::add_pre_exec_hook(
             &mut cmd,
@@ -517,12 +530,59 @@ impl<S: Sandbox> Jail for Jailer<S> {
             pid_writer,
             self.preserved_fds.clone(),
             self.detach,
+            drop_to,
         );
         cmd
     }
 }
 
 impl<S: Sandbox> Jailer<S> {
+    /// Resolve the per-box `(uid, gid)` the child should `setresuid` into, or
+    /// `None` to run as the spawning UID.
+    ///
+    /// `Some` only when privileged: an explicit `security.uid`, or an
+    /// auto-allocated dedicated UID (then the box dir is chowned to it so the
+    /// dropped process can reach its own disks/sockets/shim). Rootless callers
+    /// get `None` and rely on cgroup `pids.max` alone.
+    #[cfg(target_os = "linux")]
+    fn resolve_box_credentials(&self) -> Option<(u32, u32)> {
+        if !self.security.jailer_enabled {
+            return None;
+        }
+        if let Some(uid) = self.security.uid {
+            return Some((uid, self.security.gid.unwrap_or(uid)));
+        }
+        if !uid_alloc::UidAllocator::is_supported() {
+            return None;
+        }
+        let box_dir = self.layout.root();
+        let boxes_dir = box_dir.parent()?.to_path_buf();
+        let allocator =
+            uid_alloc::UidAllocator::new(boxes_dir.clone(), boxes_dir.join(".uidpool.lock"));
+        let creds = match allocator.allocate(box_dir) {
+            Ok(creds) => creds,
+            Err(e) => {
+                tracing::warn!(error = %e, "per-box UID allocation failed; running without a dedicated UID");
+                return None;
+            }
+        };
+        if let Err(e) = uid_alloc::chown_tree(box_dir, creds.uid, creds.gid) {
+            tracing::warn!(error = %e, uid = creds.uid, "chown box dir to dedicated UID failed; running without a dedicated UID");
+            return None;
+        }
+        tracing::info!(
+            uid = creds.uid,
+            gid = creds.gid,
+            "box will drop to its dedicated host UID"
+        );
+        Some((creds.uid, creds.gid))
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn resolve_box_credentials(&self) -> Option<(u32, u32)> {
+        None
+    }
+
     /// Get the security options.
     pub fn security(&self) -> &SecurityOptions {
         &self.security

--- a/src/boxlite/src/jailer/pre_exec.rs
+++ b/src/boxlite/src/jailer/pre_exec.rs
@@ -63,7 +63,7 @@ pub fn add_pre_exec_hook(
     pid_writer: Option<PidFileWriter>,
     preserved_fds: Vec<(RawFd, i32)>,
     detach: bool,
-    drop_to: Option<(u32, u32)>,
+    drop_to: Option<(u32, u32, Vec<u32>)>,
 ) {
     use std::os::unix::process::CommandExt;
 
@@ -122,11 +122,16 @@ pub fn add_pre_exec_hook(
             // then uid (so CAP_SETGID/CAP_SETUID are dropped last). All three
             // are async-signal-safe.
             #[cfg(target_os = "linux")]
-            if let Some((uid, gid)) = drop_to {
+            if let Some((uid, gid, ref groups)) = drop_to {
                 if libc::setresgid(gid, gid, gid) != 0 {
                     return Err(std::io::Error::last_os_error());
                 }
-                if libc::setgroups(0, std::ptr::null()) != 0 {
+                // Set the supplementary groups to exactly `groups` (device
+                // groups like kvm, so the dropped UID can still open /dev/kvm);
+                // empty list clears all. `as_ptr()` on an empty Vec is unused
+                // because the count is 0.
+                let (n, ptr) = (groups.len() as libc::size_t, groups.as_ptr());
+                if libc::setgroups(n, ptr) != 0 {
                     return Err(std::io::Error::last_os_error());
                 }
                 if libc::setresuid(uid, uid, uid) != 0 {
@@ -134,7 +139,7 @@ pub fn add_pre_exec_hook(
                 }
             }
             #[cfg(not(target_os = "linux"))]
-            let _ = drop_to;
+            let _ = &drop_to;
 
             // 5. Detach=true → setsid: child becomes a session leader,
             // detaching from the parent's controlling terminal. Without
@@ -203,7 +208,7 @@ mod tests {
             max_processes: Some(100),
             ..Default::default()
         };
-        add_pre_exec_hook(&mut cmd, limits, None, vec![], false, Some((uid, uid)));
+        add_pre_exec_hook(&mut cmd, limits, None, vec![], false, Some((uid, uid, vec![])));
 
         let out = cmd.output().expect("spawn /bin/sh");
         let report = String::from_utf8_lossy(&out.stdout);

--- a/src/boxlite/src/jailer/pre_exec.rs
+++ b/src/boxlite/src/jailer/pre_exec.rs
@@ -63,6 +63,7 @@ pub fn add_pre_exec_hook(
     pid_writer: Option<PidFileWriter>,
     preserved_fds: Vec<(RawFd, i32)>,
     detach: bool,
+    drop_to: Option<(u32, u32)>,
 ) {
     use std::os::unix::process::CommandExt;
 
@@ -113,7 +114,29 @@ pub fn add_pre_exec_hook(
                     .map_err(std::io::Error::from_raw_os_error)?;
             }
 
-            // 4. Detach=true → setsid: child becomes a session leader,
+            // 4. Drop to the box's dedicated UID/GID (privileged callers only).
+            // Done after rlimits so RLIMIT_NPROC — set above while still the
+            // spawning UID — is enforced at bwrap's `clone(CLONE_NEWUSER)`
+            // against this clean per-box UID, not the shared runner UID. Order
+            // mirrors Firecracker's jailer: gid, drop supplementary groups,
+            // then uid (so CAP_SETGID/CAP_SETUID are dropped last). All three
+            // are async-signal-safe.
+            #[cfg(target_os = "linux")]
+            if let Some((uid, gid)) = drop_to {
+                if libc::setresgid(gid, gid, gid) != 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                if libc::setgroups(0, std::ptr::null()) != 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                if libc::setresuid(uid, uid, uid) != 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+            }
+            #[cfg(not(target_os = "linux"))]
+            let _ = drop_to;
+
+            // 5. Detach=true → setsid: child becomes a session leader,
             // detaching from the parent's controlling terminal. Without
             // this a SIGHUP on the parent's terminal cascades into the
             // daemon (the `BoxOptions::detach` contract relies on it).
@@ -136,7 +159,7 @@ mod tests {
         let mut cmd = Command::new("/bin/echo");
         let limits = ResourceLimits::default();
 
-        add_pre_exec_hook(&mut cmd, limits, None, vec![], false);
+        add_pre_exec_hook(&mut cmd, limits, None, vec![], false, None);
     }
 
     #[test]
@@ -144,7 +167,7 @@ mod tests {
         let mut cmd = Command::new("/bin/echo");
         let limits = ResourceLimits::default();
         let writer = PidFileWriter::at(std::path::Path::new("/tmp/test.pid")).ok();
-        add_pre_exec_hook(&mut cmd, limits, writer, vec![], false);
+        add_pre_exec_hook(&mut cmd, limits, writer, vec![], false, None);
     }
 
     #[test]
@@ -153,6 +176,50 @@ mod tests {
         let limits = ResourceLimits::default();
 
         // Simulate preserving fd 5 → target fd 3
-        add_pre_exec_hook(&mut cmd, limits, None, vec![(5, 3)], false);
+        add_pre_exec_hook(&mut cmd, limits, None, vec![(5, 3)], false, None);
+    }
+
+    /// Verifies, via the child's own `/proc` files, that `drop_to` lands the
+    /// child on the dedicated UID and that `RLIMIT_NPROC` is in force there —
+    /// i.e. the per-box process cap is charged against the dedicated UID, not
+    /// the spawning UID. Needs `CAP_SETUID` (root), so it self-skips otherwise.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn drop_to_sets_child_uid_and_scopes_nproc() {
+        if unsafe { libc::geteuid() } != 0 {
+            eprintln!(
+                "skipping drop_to_sets_child_uid_and_scopes_nproc: requires root (CAP_SETUID)"
+            );
+            return;
+        }
+        use std::process::Stdio;
+        let uid = 2_000_123u32;
+        let mut cmd = Command::new("/bin/sh");
+        cmd.arg("-c")
+            .arg("grep '^Uid:' /proc/self/status; grep 'Max processes' /proc/self/limits")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null());
+        let limits = ResourceLimits {
+            max_processes: Some(100),
+            ..Default::default()
+        };
+        add_pre_exec_hook(&mut cmd, limits, None, vec![], false, Some((uid, uid)));
+
+        let out = cmd.output().expect("spawn /bin/sh");
+        let report = String::from_utf8_lossy(&out.stdout);
+        eprintln!("--- child /proc evidence ---\n{report}---");
+
+        // Real/effective/saved UID are all the dedicated UID.
+        assert!(
+            report.contains(&format!("Uid:\t{uid}\t{uid}\t{uid}")),
+            "child should run as dedicated UID {uid}; got:\n{report}"
+        );
+        // RLIMIT_NPROC soft cap is 100, accounted against UID {uid}.
+        assert!(
+            report
+                .lines()
+                .any(|l| l.starts_with("Max processes") && l.contains("100")),
+            "child RLIMIT_NPROC should be 100; got:\n{report}"
+        );
     }
 }

--- a/src/boxlite/src/jailer/pre_exec.rs
+++ b/src/boxlite/src/jailer/pre_exec.rs
@@ -8,6 +8,8 @@
 //! 1. **Write PID file** - Single source of truth for process tracking
 //! 2. **Close inherited FDs** - Prevents information leakage
 //! 3. **Apply rlimits** - Resource limits (max files, memory, CPU time, etc.)
+//! 4. **Drop to the box's dedicated UID/GID** - privileged callers only; done
+//!    after rlimits so `RLIMIT_NPROC` is charged against the dedicated UID
 //!
 //! The order is load-bearing. `Command::spawn` blocks the parent only until
 //! the child closes its CLOEXEC exec-error pipe, and step 2 is what closes
@@ -38,7 +40,8 @@ use std::process::Command;
 ///
 /// Runs after fork() but before the new program starts in the child process.
 /// Applies, in order: PID file writing, FD preservation (dup2), FD cleanup,
-/// rlimits. See the module docs for why the PID file goes first.
+/// rlimits, dedicated-UID drop. See the module docs for why the PID file
+/// goes first.
 ///
 /// # Arguments
 ///
@@ -69,6 +72,7 @@ pub fn add_pre_exec_hook(
     pid_writer: Option<PidFileWriter>,
     preserved_fds: Vec<(RawFd, i32)>,
     detach: bool,
+    drop_to: Option<(u32, u32)>,
 ) {
     use std::os::unix::process::CommandExt;
 
@@ -130,7 +134,29 @@ pub fn add_pre_exec_hook(
             common::rlimit::apply_limits_raw(&resource_limits)
                 .map_err(std::io::Error::from_raw_os_error)?;
 
-            // 4. Detach=true → setsid: child becomes a session leader,
+            // 4. Drop to the box's dedicated UID/GID (privileged callers only).
+            // Done after rlimits so RLIMIT_NPROC — set above while still the
+            // spawning UID — is enforced at bwrap's `clone(CLONE_NEWUSER)`
+            // against this clean per-box UID, not the shared runner UID. Order
+            // mirrors Firecracker's jailer: gid, drop supplementary groups,
+            // then uid (so CAP_SETGID/CAP_SETUID are dropped last). All three
+            // are async-signal-safe.
+            #[cfg(target_os = "linux")]
+            if let Some((uid, gid)) = drop_to {
+                if libc::setresgid(gid, gid, gid) != 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                if libc::setgroups(0, std::ptr::null()) != 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                if libc::setresuid(uid, uid, uid) != 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+            }
+            #[cfg(not(target_os = "linux"))]
+            let _ = drop_to;
+
+            // 5. Detach=true → setsid: child becomes a session leader,
             // detaching from the parent's controlling terminal. Without
             // this a SIGHUP on the parent's terminal cascades into the
             // daemon (the `BoxOptions::detach` contract relies on it).
@@ -153,7 +179,7 @@ mod tests {
         let mut cmd = Command::new("/bin/echo");
         let limits = ResourceLimits::default();
 
-        add_pre_exec_hook(&mut cmd, limits, None, vec![], false);
+        add_pre_exec_hook(&mut cmd, limits, None, vec![], false, None);
     }
 
     #[test]
@@ -161,7 +187,7 @@ mod tests {
         let mut cmd = Command::new("/bin/echo");
         let limits = ResourceLimits::default();
         let writer = PidFileWriter::at(std::path::Path::new("/tmp/test.pid")).ok();
-        add_pre_exec_hook(&mut cmd, limits, writer, vec![], false);
+        add_pre_exec_hook(&mut cmd, limits, writer, vec![], false, None);
     }
 
     #[test]
@@ -184,6 +210,7 @@ mod tests {
             // descriptors; this stand-in otherwise has none.
             vec![(keepalive.as_raw_fd(), 1023)],
             false,
+            None,
         );
         let status = cmd.status().expect("spawn child with pre-exec hook");
         assert!(status.success());
@@ -251,6 +278,7 @@ mod tests {
                     Some(writer),
                     preserved_fds.clone(),
                     detach,
+                    None,
                 );
 
                 let mut child = cmd.spawn().expect("spawn child with pre-exec hook");
@@ -279,6 +307,50 @@ mod tests {
         let limits = ResourceLimits::default();
 
         // Simulate preserving fd 5 → target fd 3
-        add_pre_exec_hook(&mut cmd, limits, None, vec![(5, 3)], false);
+        add_pre_exec_hook(&mut cmd, limits, None, vec![(5, 3)], false, None);
+    }
+
+    /// Verifies, via the child's own `/proc` files, that `drop_to` lands the
+    /// child on the dedicated UID and that `RLIMIT_NPROC` is in force there —
+    /// i.e. the per-box process cap is charged against the dedicated UID, not
+    /// the spawning UID. Needs `CAP_SETUID` (root), so it self-skips otherwise.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn drop_to_sets_child_uid_and_scopes_nproc() {
+        if unsafe { libc::geteuid() } != 0 {
+            eprintln!(
+                "skipping drop_to_sets_child_uid_and_scopes_nproc: requires root (CAP_SETUID)"
+            );
+            return;
+        }
+        use std::process::Stdio;
+        let uid = 2_000_123u32;
+        let mut cmd = Command::new("/bin/sh");
+        cmd.arg("-c")
+            .arg("grep '^Uid:' /proc/self/status; grep 'Max processes' /proc/self/limits")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null());
+        let limits = ResourceLimits {
+            max_processes: Some(100),
+            ..Default::default()
+        };
+        add_pre_exec_hook(&mut cmd, limits, None, vec![], false, Some((uid, uid)));
+
+        let out = cmd.output().expect("spawn /bin/sh");
+        let report = String::from_utf8_lossy(&out.stdout);
+        eprintln!("--- child /proc evidence ---\n{report}---");
+
+        // Real/effective/saved UID are all the dedicated UID.
+        assert!(
+            report.contains(&format!("Uid:\t{uid}\t{uid}\t{uid}")),
+            "child should run as dedicated UID {uid}; got:\n{report}"
+        );
+        // RLIMIT_NPROC soft cap is 100, accounted against UID {uid}.
+        assert!(
+            report
+                .lines()
+                .any(|l| l.starts_with("Max processes") && l.contains("100")),
+            "child RLIMIT_NPROC should be 100; got:\n{report}"
+        );
     }
 }

--- a/src/boxlite/src/jailer/pre_exec.rs
+++ b/src/boxlite/src/jailer/pre_exec.rs
@@ -72,7 +72,7 @@ pub fn add_pre_exec_hook(
     pid_writer: Option<PidFileWriter>,
     preserved_fds: Vec<(RawFd, i32)>,
     detach: bool,
-    drop_to: Option<(u32, u32)>,
+    drop_to: Option<(u32, u32, Vec<u32>)>,
 ) {
     use std::os::unix::process::CommandExt;
 
@@ -142,11 +142,16 @@ pub fn add_pre_exec_hook(
             // then uid (so CAP_SETGID/CAP_SETUID are dropped last). All three
             // are async-signal-safe.
             #[cfg(target_os = "linux")]
-            if let Some((uid, gid)) = drop_to {
+            if let Some((uid, gid, ref groups)) = drop_to {
                 if libc::setresgid(gid, gid, gid) != 0 {
                     return Err(std::io::Error::last_os_error());
                 }
-                if libc::setgroups(0, std::ptr::null()) != 0 {
+                // Set the supplementary groups to exactly `groups` (device
+                // groups like kvm, so the dropped UID can still open /dev/kvm);
+                // empty list clears all. `as_ptr()` on an empty Vec is unused
+                // because the count is 0.
+                let (n, ptr) = (groups.len() as libc::size_t, groups.as_ptr());
+                if libc::setgroups(n, ptr) != 0 {
                     return Err(std::io::Error::last_os_error());
                 }
                 if libc::setresuid(uid, uid, uid) != 0 {
@@ -154,7 +159,7 @@ pub fn add_pre_exec_hook(
                 }
             }
             #[cfg(not(target_os = "linux"))]
-            let _ = drop_to;
+            let _ = &drop_to;
 
             // 5. Detach=true → setsid: child becomes a session leader,
             // detaching from the parent's controlling terminal. Without
@@ -334,7 +339,14 @@ mod tests {
             max_processes: Some(100),
             ..Default::default()
         };
-        add_pre_exec_hook(&mut cmd, limits, None, vec![], false, Some((uid, uid)));
+        add_pre_exec_hook(
+            &mut cmd,
+            limits,
+            None,
+            vec![],
+            false,
+            Some((uid, uid, vec![])),
+        );
 
         let out = cmd.output().expect("spawn /bin/sh");
         let report = String::from_utf8_lossy(&out.stdout);

--- a/src/boxlite/src/jailer/uid_alloc.rs
+++ b/src/boxlite/src/jailer/uid_alloc.rs
@@ -1,0 +1,274 @@
+//! Per-box dedicated host UID/GID allocation.
+//!
+//! The box's host-side process tree (bwrap monitor + shim + libkrun vCPU and
+//! gvproxy threads) drops to a dedicated, per-box UID via `setresuid` in the
+//! [`pre_exec`](super::pre_exec) hook before `execve(bwrap)`. This is what makes
+//! `RLIMIT_NPROC` correct: the kernel accounts that limit per *real UID*, so
+//! charging it against a clean per-box UID bounds the box's own process tree
+//! instead of the shared runner UID (which broke box spawn — see
+//! [`super::common::rlimit::apply_limits_raw`]). bwrap keeps its identity uid
+//! map (no `--uid`), so the dedicated UID maps 1:1 into the new userns.
+//!
+//! ## Why the claim lives in the box dir
+//!
+//! A detached box outlives the runner process, so a claim held only by an open
+//! `flock` (Nix's `UserLock` model) would be released the moment the runner
+//! restarts — and a fresh box could then grab a UID a live box is still using.
+//! Instead the *only* durable record of a claim is the `host_uid` file inside
+//! the box's own working dir, so the in-use set is always recomputed from the
+//! live box dirs — never a separate mutable counter that can desync across a
+//! restart. A short `flock` serializes the allocate critical section only.
+//! Release is implicit: removing the box dir drops its `host_uid` file.
+//!
+//! Modeled on Nix's build-user pool and systemd `DynamicUser=`.
+
+use boxlite_shared::errors::{BoxliteError, BoxliteResult};
+use std::fs;
+use std::os::unix::io::AsRawFd;
+use std::path::{Path, PathBuf};
+
+/// First UID of the pool. Chosen above any real system user and the common
+/// `/etc/subuid` delegation range (which typically starts at 100000 and runs to
+/// a few million) to avoid colliding with host accounts or rootless container
+/// id maps.
+pub const POOL_BASE: u32 = 2_000_000;
+
+/// Number of UIDs in the pool — the per-host ceiling on concurrent boxes.
+pub const POOL_SIZE: u32 = 60_000;
+
+/// File inside a box dir recording its claimed host UID (decimal text).
+const CLAIM_FILE: &str = "host_uid";
+
+/// A box's dedicated host credentials. `gid == uid` by convention: one number
+/// per box keeps file ownership and group accounting aligned and the pool
+/// trivially collision-free.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct BoxCredentials {
+    pub uid: u32,
+    pub gid: u32,
+}
+
+/// Allocates and records per-box host UIDs out of a fixed pool.
+///
+/// Facade: callers use [`allocate`](Self::allocate) (idempotent) and treat the
+/// box dir as the durable owner of the claim. There is no `release` — the claim
+/// is freed when the box dir is removed.
+pub struct UidAllocator {
+    boxes_dir: PathBuf,
+    lock_path: PathBuf,
+    base: u32,
+    size: u32,
+}
+
+impl UidAllocator {
+    /// `boxes_dir` is the parent of every box's working dir (the source of truth
+    /// for in-use UIDs); `lock_path` is a file used only to serialize allocation.
+    pub fn new(boxes_dir: PathBuf, lock_path: PathBuf) -> Self {
+        Self {
+            boxes_dir,
+            lock_path,
+            base: POOL_BASE,
+            size: POOL_SIZE,
+        }
+    }
+
+    /// Whether this process can hand a child a dedicated UID at all. `setresuid`
+    /// to an arbitrary UID needs `CAP_SETUID`, which in practice means running
+    /// as root. Rootless callers get `None` and must rely on the cgroup
+    /// `pids.max` cap alone (no `RLIMIT_NPROC`, no UID drop).
+    pub fn is_supported() -> bool {
+        // Safe: getuid never fails.
+        unsafe { libc::geteuid() == 0 }
+    }
+
+    /// Read a box dir's existing claim, if any.
+    pub fn recorded(box_dir: &Path) -> Option<u32> {
+        fs::read_to_string(box_dir.join(CLAIM_FILE))
+            .ok()
+            .and_then(|s| s.trim().parse::<u32>().ok())
+    }
+
+    /// Allocate (or re-read) the dedicated credentials for `box_dir`.
+    ///
+    /// Idempotent: a box that already recorded a UID (e.g. a stop→start, or a
+    /// runner restart re-adopting the box) keeps the same one. Persists the
+    /// claim as `<box_dir>/host_uid`. The critical section — scan in-use UIDs,
+    /// pick a free one, write the claim — is serialized by an `flock`.
+    pub fn allocate(&self, box_dir: &Path) -> BoxliteResult<BoxCredentials> {
+        if let Some(uid) = Self::recorded(box_dir) {
+            return Ok(BoxCredentials { uid, gid: uid });
+        }
+
+        let _guard = PoolLock::acquire(&self.lock_path)?;
+
+        // Re-check under the lock: another caller may have just written it.
+        if let Some(uid) = Self::recorded(box_dir) {
+            return Ok(BoxCredentials { uid, gid: uid });
+        }
+
+        let in_use = self.in_use_uids();
+        let uid = (self.base..self.base + self.size)
+            .find(|u| !in_use.contains(u))
+            .ok_or_else(|| {
+                BoxliteError::Internal(format!(
+                    "host UID pool exhausted ({}..{})",
+                    self.base,
+                    self.base + self.size
+                ))
+            })?;
+
+        // Write the claim before releasing the lock so the next scan sees it.
+        let claim = box_dir.join(CLAIM_FILE);
+        fs::write(&claim, uid.to_string())
+            .map_err(|e| BoxliteError::Internal(format!("write {}: {e}", claim.display())))?;
+
+        Ok(BoxCredentials { uid, gid: uid })
+    }
+
+    /// UIDs currently claimed by any box dir. Recomputed every allocation so the
+    /// pool stays consistent with reality across runner restarts and crashes.
+    fn in_use_uids(&self) -> std::collections::HashSet<u32> {
+        let mut set = std::collections::HashSet::new();
+        let Ok(entries) = fs::read_dir(&self.boxes_dir) else {
+            return set;
+        };
+        for entry in entries.flatten() {
+            if let Some(uid) = Self::recorded(&entry.path()) {
+                set.insert(uid);
+            }
+        }
+        set
+    }
+}
+
+/// An exclusive `flock` held for the allocate critical section only.
+struct PoolLock {
+    _file: fs::File,
+}
+
+impl PoolLock {
+    fn acquire(lock_path: &Path) -> BoxliteResult<Self> {
+        let file = fs::OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(lock_path)
+            .map_err(|e| {
+                BoxliteError::Internal(format!("open uid lock {}: {e}", lock_path.display()))
+            })?;
+        // Safe: flock on a valid fd. Blocks until the exclusive lock is held;
+        // released by close (Drop) — including on crash, by the kernel.
+        let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) };
+        if rc != 0 {
+            return Err(BoxliteError::Internal(format!(
+                "flock uid pool: {}",
+                std::io::Error::last_os_error()
+            )));
+        }
+        Ok(Self { _file: file })
+    }
+}
+
+/// Recursively `lchown` `root` and everything under it to `uid:gid`.
+///
+/// The box process drops to the dedicated UID, so its private working tree
+/// (disks, sockets, the copied shim, logs) must be owned by that UID. Symlinks
+/// are chowned without following (`lchown`) so a link inside the box dir can't
+/// redirect ownership changes onto a shared file outside it. The box dir holds
+/// only per-box files, so this never touches shared bases/images/runtimes.
+pub fn chown_tree(root: &Path, uid: u32, gid: u32) -> std::io::Result<()> {
+    use std::os::unix::fs as unix_fs;
+    unix_fs::lchown(root, Some(uid), Some(gid))?;
+    let meta = fs::symlink_metadata(root)?;
+    if meta.is_dir() {
+        for entry in fs::read_dir(root)? {
+            chown_tree(&entry?.path(), uid, gid)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn alloc(dir: &Path) -> UidAllocator {
+        let boxes = dir.join("boxes");
+        fs::create_dir_all(&boxes).unwrap();
+        UidAllocator::new(boxes, dir.join("uidpool.lock"))
+    }
+
+    fn box_dir(a: &UidAllocator, name: &str) -> PathBuf {
+        let d = a.boxes_dir.join(name);
+        fs::create_dir_all(&d).unwrap();
+        d
+    }
+
+    #[test]
+    fn allocates_distinct_uids_from_pool_base() {
+        let tmp = tempfile::tempdir().unwrap();
+        let a = alloc(tmp.path());
+        let b1 = box_dir(&a, "b1");
+        let b2 = box_dir(&a, "b2");
+
+        let c1 = a.allocate(&b1).unwrap();
+        let c2 = a.allocate(&b2).unwrap();
+
+        assert_eq!(c1.uid, POOL_BASE);
+        assert_eq!(c1.gid, c1.uid);
+        assert_eq!(c2.uid, POOL_BASE + 1);
+        assert_ne!(c1.uid, c2.uid);
+    }
+
+    #[test]
+    fn allocate_is_idempotent_per_box() {
+        let tmp = tempfile::tempdir().unwrap();
+        let a = alloc(tmp.path());
+        let b1 = box_dir(&a, "b1");
+
+        let first = a.allocate(&b1).unwrap();
+        let again = a.allocate(&b1).unwrap();
+        assert_eq!(
+            first, again,
+            "a box keeps its UID across stop/start/restart"
+        );
+    }
+
+    #[test]
+    fn freed_uid_is_reused_after_box_dir_removed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let a = alloc(tmp.path());
+        let b1 = box_dir(&a, "b1");
+        let b2 = box_dir(&a, "b2");
+
+        let c1 = a.allocate(&b1).unwrap();
+        let _c2 = a.allocate(&b2).unwrap();
+        assert_eq!(c1.uid, POOL_BASE);
+
+        // Box 1 destroyed: its dir (and host_uid claim) is gone.
+        fs::remove_dir_all(&b1).unwrap();
+
+        let b3 = box_dir(&a, "b3");
+        let c3 = a.allocate(&b3).unwrap();
+        assert_eq!(c3.uid, POOL_BASE, "the lowest free UID is reclaimed");
+    }
+
+    #[test]
+    fn in_use_set_is_rebuilt_from_box_dirs_not_memory() {
+        // Simulates a runner restart: a brand-new allocator instance must still
+        // see UIDs claimed by existing box dirs.
+        let tmp = tempfile::tempdir().unwrap();
+        let a1 = alloc(tmp.path());
+        let b1 = box_dir(&a1, "b1");
+        let c1 = a1.allocate(&b1).unwrap();
+
+        let a2 = UidAllocator::new(a1.boxes_dir.clone(), tmp.path().join("uidpool.lock"));
+        let b2 = box_dir(&a2, "b2");
+        let c2 = a2.allocate(&b2).unwrap();
+        assert_ne!(
+            c1.uid, c2.uid,
+            "fresh allocator must not reissue a live UID"
+        );
+    }
+}

--- a/src/boxlite/src/jailer/uid_alloc.rs
+++ b/src/boxlite/src/jailer/uid_alloc.rs
@@ -170,6 +170,24 @@ impl PoolLock {
     }
 }
 
+/// Resolve a local group's GID by name from `/etc/group`.
+///
+/// The dropped box process keeps a few device groups as supplementary groups so
+/// it can still open group-gated host devices (notably `/dev/kvm`, `root:kvm`).
+/// `/etc/group` is parsed directly — thread-safe (unlike `getgrnam`) and the
+/// relevant groups (`kvm`) are always local. Returns `None` if absent.
+pub fn group_gid(name: &str) -> Option<u32> {
+    let contents = fs::read_to_string("/etc/group").ok()?;
+    for line in contents.lines() {
+        let mut fields = line.split(':');
+        if fields.next() == Some(name) {
+            // group:passwd:GID:members
+            return fields.nth(1).and_then(|g| g.trim().parse::<u32>().ok());
+        }
+    }
+    None
+}
+
 /// Recursively `lchown` `root` and everything under it to `uid:gid`.
 ///
 /// The box process drops to the dedicated UID, so its private working tree

--- a/src/boxlite/src/litebox/init/tasks/guest_connect.rs
+++ b/src/boxlite/src/litebox/init/tasks/guest_connect.rs
@@ -146,6 +146,20 @@ async fn wait_for_guest_ready(
         ))
     })?;
 
+    // The box may have dropped to a dedicated non-root UID (see jailer
+    // resolve_box_credentials), so the in-VM side connects to this host-bound
+    // socket as that UID — which needs write permission on the socket file.
+    // Connecting to a unix socket requires `w`; grant it. The per-box sockets
+    // dir already gates who can reach this path.
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Err(e) =
+            std::fs::set_permissions(ready_socket_path, std::fs::Permissions::from_mode(0o666))
+        {
+            tracing::warn!(error = %e, socket = %ready_socket_path.display(), "chmod ready socket connectable failed");
+        }
+    }
+
     tracing::debug!(
         socket = %ready_socket_path.display(),
         "Listening for guest ready notification"

--- a/src/boxlite/src/litebox/init/tasks/guest_connect.rs
+++ b/src/boxlite/src/litebox/init/tasks/guest_connect.rs
@@ -147,6 +147,20 @@ async fn wait_for_guest_ready(
         ))
     })?;
 
+    // The box may have dropped to a dedicated non-root UID (see jailer
+    // resolve_box_credentials), so the in-VM side connects to this host-bound
+    // socket as that UID — which needs write permission on the socket file.
+    // Connecting to a unix socket requires `w`; grant it. The per-box sockets
+    // dir already gates who can reach this path.
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Err(e) =
+            std::fs::set_permissions(ready_socket_path, std::fs::Permissions::from_mode(0o666))
+        {
+            tracing::warn!(error = %e, socket = %ready_socket_path.display(), "chmod ready socket connectable failed");
+        }
+    }
+
     tracing::debug!(
         socket = %ready_socket_path.display(),
         "Listening for guest ready notification"

--- a/src/boxlite/src/net/socket_path.rs
+++ b/src/boxlite/src/net/socket_path.rs
@@ -230,14 +230,19 @@ impl BoxSockets {
     }
 }
 
-/// Create `dir` as a 0700 directory owned by the current user, verifying an
+/// Create `dir` as a 0711 directory owned by the current user, verifying an
 /// existing entry the way tmux verifies `/tmp/tmux-{uid}`: must be a real
-/// directory (not a symlink) owned by us; group/other permission bits are
+/// directory (not a symlink) owned by us; group/other read/write bits are
 /// repaired; anything else is a loud error (a squatted parent is a denial of
 /// service, never a redirection).
+///
+/// 0711 (not 0700) so a box that dropped to its own dedicated UID can still
+/// *traverse* this per-runner parent to reach its binding symlink. Listing is
+/// denied (no `r`), and each box's sockets stay protected by the ownership of
+/// the symlink target (the box's sockets dir), so traverse-only is safe.
 fn ensure_owned_private_dir(dir: &Path) -> BoxliteResult<()> {
     use std::os::unix::fs::DirBuilderExt;
-    match std::fs::DirBuilder::new().mode(0o700).create(dir) {
+    match std::fs::DirBuilder::new().mode(0o711).create(dir) {
         Ok(()) => return Ok(()),
         Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
         Err(e) => {
@@ -268,9 +273,11 @@ fn ensure_owned_private_dir(dir: &Path) -> BoxliteResult<()> {
             uid,
         )));
     }
-    // Repair permissions opened up by a foreign umask or an older release.
-    if meta.permissions().mode() & 0o077 != 0 {
-        std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700)).map_err(|e| {
+    // Normalize to exactly 0711: strip any group/other read/write opened up by
+    // a foreign umask or an older release, and add the traverse bit that older
+    // 0700 dirs lack (so a dropped-UID box can reach its binding symlink).
+    if meta.permissions().mode() & 0o777 != 0o711 {
+        std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o711)).map_err(|e| {
             BoxliteError::Storage(format!(
                 "Failed to tighten permissions on {}: {}",
                 dir.display(),
@@ -415,8 +422,9 @@ mod tests {
 
     #[test]
     fn ensure_repairs_parent_permissions() {
-        // A pre-existing 0755 parent (older release / foreign umask) gets
-        // tightened to 0700 rather than rejected.
+        // A pre-existing 0755 parent (older release / foreign umask) gets its
+        // group/other read/write stripped, normalized to 0711 (traverse kept so
+        // a dropped-UID box can reach its binding symlink) rather than rejected.
         let parent = BoxSockets::parent_dir();
         std::fs::create_dir_all(&parent).unwrap();
         std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o755)).unwrap();
@@ -428,7 +436,7 @@ mod tests {
             .unwrap()
             .permissions()
             .mode();
-        assert_eq!(mode & 0o777, 0o700, "parent must be repaired to 0700");
+        assert_eq!(mode & 0o777, 0o711, "parent must be normalized to 0711");
         s.remove();
     }
 

--- a/src/boxlite/src/net/socket_path.rs
+++ b/src/boxlite/src/net/socket_path.rs
@@ -239,14 +239,19 @@ impl BoxSockets {
     }
 }
 
-/// Create `dir` as a 0700 directory owned by the current user, verifying an
+/// Create `dir` as a 0711 directory owned by the current user, verifying an
 /// existing entry the way tmux verifies `/tmp/tmux-{uid}`: must be a real
-/// directory (not a symlink) owned by us; group/other permission bits are
+/// directory (not a symlink) owned by us; group/other read/write bits are
 /// repaired; anything else is a loud error (a squatted parent is a denial of
 /// service, never a redirection).
+///
+/// 0711 (not 0700) so a box that dropped to its own dedicated UID can still
+/// *traverse* this per-runner parent to reach its binding symlink. Listing is
+/// denied (no `r`), and each box's sockets stay protected by the ownership of
+/// the symlink target (the box's sockets dir), so traverse-only is safe.
 fn ensure_owned_private_dir(dir: &Path) -> BoxliteResult<()> {
     use std::os::unix::fs::DirBuilderExt;
-    match std::fs::DirBuilder::new().mode(0o700).create(dir) {
+    match std::fs::DirBuilder::new().mode(0o711).create(dir) {
         Ok(()) => return Ok(()),
         Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
         Err(e) => {
@@ -277,9 +282,11 @@ fn ensure_owned_private_dir(dir: &Path) -> BoxliteResult<()> {
             uid,
         )));
     }
-    // Repair permissions opened up by a foreign umask or an older release.
-    if meta.permissions().mode() & 0o077 != 0 {
-        std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700)).map_err(|e| {
+    // Normalize to exactly 0711: strip any group/other read/write opened up by
+    // a foreign umask or an older release, and add the traverse bit that older
+    // 0700 dirs lack (so a dropped-UID box can reach its binding symlink).
+    if meta.permissions().mode() & 0o777 != 0o711 {
+        std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o711)).map_err(|e| {
             BoxliteError::Storage(format!(
                 "Failed to tighten permissions on {}: {}",
                 dir.display(),
@@ -430,8 +437,9 @@ mod tests {
 
     #[test]
     fn ensure_repairs_parent_permissions() {
-        // A pre-existing 0755 parent (older release / foreign umask) gets
-        // tightened to 0700 rather than rejected.
+        // A pre-existing 0755 parent (older release / foreign umask) gets its
+        // group/other read/write stripped, normalized to 0711 (traverse kept so
+        // a dropped-UID box can reach its binding symlink) rather than rejected.
         let parent = BoxSockets::parent_dir();
         std::fs::create_dir_all(&parent).unwrap();
         std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o755)).unwrap();
@@ -443,7 +451,7 @@ mod tests {
             .unwrap()
             .permissions()
             .mode();
-        assert_eq!(mode & 0o777, 0o700, "parent must be repaired to 0700");
+        assert_eq!(mode & 0o777, 0o711, "parent must be normalized to 0711");
         s.remove();
     }
 

--- a/src/boxlite/src/runtime/advanced_options.rs
+++ b/src/boxlite/src/runtime/advanced_options.rs
@@ -218,8 +218,8 @@ impl Default for SecurityOptions {
         Self {
             jailer_enabled: true,
             seccomp_enabled: cfg!(target_os = "linux"),
-            uid: Some(65534), // nobody
-            gid: Some(65534), // nogroup
+            uid: None, // auto-allocate a dedicated per-box UID (jailer); see resolve_box_credentials
+            gid: None, // auto-allocate a dedicated per-box GID
             new_pid_ns: cfg!(target_os = "linux"),
             new_net_ns: false, // gvproxy provides networking
             chroot_base: default_chroot_base(),

--- a/src/boxlite/src/runtime/advanced_options.rs
+++ b/src/boxlite/src/runtime/advanced_options.rs
@@ -221,8 +221,8 @@ impl Default for SecurityOptions {
         Self {
             jailer_enabled: true,
             seccomp_enabled: cfg!(target_os = "linux"),
-            uid: Some(65534), // nobody
-            gid: Some(65534), // nogroup
+            uid: None, // auto-allocate a dedicated per-box UID (jailer); see resolve_box_credentials
+            gid: None, // auto-allocate a dedicated per-box GID
             new_pid_ns: cfg!(target_os = "linux"),
             new_net_ns: false, // gvproxy provides networking
             chroot_base: default_chroot_base(),

--- a/src/boxlite/src/runtime/options.rs
+++ b/src/boxlite/src/runtime/options.rs
@@ -1007,7 +1007,7 @@ mod tests {
         assert!(direct.jailer_enabled);
         assert!(direct.close_fds);
         assert!(direct.sanitize_env);
-        assert_eq!(direct.uid, Some(65534));
+        assert_eq!(direct.uid, None); // default: auto-allocate a dedicated per-box UID
         #[cfg(target_os = "linux")]
         {
             assert!(direct.seccomp_enabled);

--- a/src/boxlite/src/runtime/options.rs
+++ b/src/boxlite/src/runtime/options.rs
@@ -2019,7 +2019,7 @@ mod tests {
         assert!(direct.jailer_enabled);
         assert!(direct.close_fds);
         assert!(direct.sanitize_env);
-        assert_eq!(direct.uid, Some(65534));
+        assert_eq!(direct.uid, None); // default: auto-allocate a dedicated per-box UID
         #[cfg(target_os = "linux")]
         {
             assert!(direct.seccomp_enabled);


### PR DESCRIPTION
## Why

`RLIMIT_NPROC` is accounted by the kernel **per real UID**, system-wide. Because every box's host process tree (bwrap + shim + libkrun vCPU/gvproxy threads) ran under the **shared runner UID**, the per-box process cap was charged against *all* the runner's processes at once — on a busy host that made even a single box fail to spawn (`EAGAIN`). The same shared UID also meant a box launched from a root runner **ran as root**.

## What

Give each box a **dedicated host UID** and `setresuid` into it (in the `pre_exec` hook, before `execve(bwrap)`) so `RLIMIT_NPROC` is charged against a clean per-box UID that owns nothing else — and the box **never runs as root**. bwrap keeps its identity uid map (no `--uid`), so the dedicated UID maps 1:1 into the new userns.

## Design

- **Allocation** (`uid_alloc.rs`): pool `2_000_000 .. +60_000` (above system users and the `/etc/subuid` range). `allocate()` is idempotent per box and serialized by a short `flock`.
- **Claim + reclamation without a counter**: the *only* durable record of a claim is a `host_uid` file inside the box's own dir. The in-use set is **recomputed from the live box dirs** every allocation — never a separate mutable counter that can desync. This is restart/crash safe (a detached box outlives the runner, so an flock-only claim would be lost on restart). **Release is implicit**: removing the box dir drops its claim; the lowest free UID is then reused. Modeled on Nix's build-user pool and systemd `DynamicUser=`.
- **Invariant — the box never runs as root.** A privileged (root) runner *always* drops: to a dedicated per-box UID, or **fail-closed to `nobody` (65534)** if allocation fails — never back to root.
- **Rootless runner**: `setresuid` to a foreign UID needs `CAP_SETUID`, which it lacks — and it's already non-root, so it keeps its UID (`None`) and **drops the per-box `RLIMIT_NPROC`** (applying it to the shared UID is exactly what broke spawn). The cgroup `pids.max` cap still bounds the box.
- **Drop sequence** (mirrors Firecracker's jailer, all async-signal-safe, after rlimits): `setresgid` → `setgroups` → `setresuid`, so `CAP_SETGID/SETUID` drop last. `kvm` is kept as a supplementary group so the dropped UID can still open `/dev/kvm` (`root:kvm 0660`).
- **Socket access**: the box dir is `chown`'d (via `lchown`, symlink-safe) to the dropped UID. The per-runner sockets parent goes `0700 → 0711` (traverse-only, listing still denied) and the ready socket to `0666` so the dropped UID can connect; per-box isolation stays on the symlink-target ownership.

## Tests
- `uid_alloc` (4): distinct allocation from the pool, idempotent per box, lowest free UID reused after a box dir is removed, in-use set rebuilt from box dirs (runner-restart safe).
- `drop_to_sets_child_uid_and_scopes_nproc` (root-gated): a child spawned through the hook reports `Uid: 2000123…` / `Max processes 100` from its own `/proc`. Two-sided verified: neutering the drop fails it (child stays `Uid 0`).

## Verified end-to-end (real boxes)
- **Rootless** runner: box boots and runs the guest command; box runs as the (non-root) runner UID.
- **Root** runner: box boots and runs the guest command; its whole host process tree (bwrap, shim, libkrun) runs as a **dedicated per-box UID (e.g. 2000005), never root** — each box gets a distinct UID.

Note (Ubuntu 23.10+): bwrap's unprivileged userns needs the bundled AppArmor profile (`apparmor_parser -r ~/.boxlite/apparmor/boxlite-bwrap`) or the userns sysctl relaxed — pre-existing boxlite requirement, unrelated to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic per-box user and group identity allocation on supported Linux systems, improving isolation between boxes.
  * Existing security settings can continue to specify a custom user and group.
  * Boxes now run with reduced privileges and appropriate supplementary access where supported.

* **Bug Fixes**
  * Improved communication for non-root boxes by correcting permissions on required sockets and directories.
  * Prevented process limits from being incorrectly applied to a shared runner identity when dedicated credentials are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->