### PR TITLE
feat(hooks): default-deny verdict gate, always-on

### DIFF
--- a/.claude/hooks/preflight-verdict-check.sh
+++ b/.claude/hooks/preflight-verdict-check.sh
@@ -1,45 +1,66 @@
 #!/usr/bin/env bash
-# Stop hook: VALIDATE a self-declared verdict before the agent ends its turn
+# Stop hook: REQUIRE a verdict dossier before the agent ends its turn
 # (see .claude/agents/verdict-auditor.md).
 #
-# Self-declared gating: the hook does NOT detect verdicts. The agent decides when it
-# has made a behavioral verdict (per CLAUDE.md's Verify rule) and self-invokes the
-# verdict-auditor subagent, which writes the dossier at .claude/.last-verdict.json.
-# This hook only validates that dossier; it calls no model and reads no transcript.
+# Default-deny gating: the hook does NOT detect verdicts and does NOT decide which turns
+# need proof. Every turn-end must produce a dossier at .claude/.last-verdict.json,
+# written by the verdict-auditor subagent (per CLAUDE.md's Verify rule). A turn that
+# asserts nothing verifiable still produces one — the auditor records a trivial PASS with
+# empty proof. This hook only validates that dossier; it calls no model, reads no transcript.
 #
-# Flow (agent self-declared):
-#   1. The agent ends a turn asserting a verdict; per CLAUDE.md it first invokes the
-#      verdict-auditor subagent, which writes .claude/.last-verdict.json.
+# Flow:
+#   1. Before ending, the agent invokes the verdict-auditor subagent, which writes
+#      .claude/.last-verdict.json (PASS even when there is nothing to prove).
 #   2. Hook validates: a fresh, matching PASS/IN_PROGRESS dossier -> allow.
-#   3. NO dossier -> allow (the agent declared nothing to prove). Gating is opt-in.
-#   4. A stale / mismatched / FAIL dossier -> block (hard) or nudge (soft); the agent
-#      re-audits and ends again.
-# The subagent's own completion is a SubagentStop event, not Stop, so it does not
-# re-trigger this hook (no recursion).
+#   3. NO dossier -> block (hard) or nudge (soft): the audit was not run.
+#   4. A stale / mismatched / FAIL dossier -> block (hard) or nudge (soft); same path.
+# After a block the agent audits and ends again. The subagent's own completion is a
+# SubagentStop event, not Stop, so it does not re-trigger this hook (no recursion).
 #
 # Wired in .claude/settings.json under hooks.Stop (no matcher — fires every turn end).
 #
 # Design notes
 # ------------
-# * No detection: a Stop hook fires whenever the agent ends a turn, with no
-#   "done vs paused" signal. Rather than guess from changed files (which misses any
-#   verdict that touches no files — an ops check, a factual answer, "no issues") or
-#   parse the message, we let the AGENT decide: it self-invokes the auditor when it
-#   made a verdict. No dossier => nothing to prove.
+# * No detection, default-deny: a Stop hook fires whenever the agent ends a turn, with
+#   no "done vs paused" signal. Rather than guess a verdict from changed files (which
+#   misses any verdict that touches no files — an ops check, a factual answer, "no
+#   issues") or parse the message, the hook requires a dossier on EVERY turn and lets
+#   the AUDITOR classify it (a trivial PASS when there is nothing to prove). A missing
+#   dossier is a skipped audit, not a license to skip — closing the hole where a verdict
+#   slipped through simply by never invoking the auditor.
 #
 # * Tree-hash binding (present-dossier only): at stop time the work is usually
 #   UNCOMMITTED (HEAD has not moved), so HEAD alone can't tell "audited" from
 #   "changed since audit". We bind the dossier to a content-addressed hash of the
 #   full working tree, computed via a throwaway index + `git write-tree`
 #   (deterministic; no timestamps; never touches the real index). The verdict-auditor
-#   computes it the SAME way. Computed only when a dossier exists — the common
-#   no-dossier turn does no git work.
+#   computes it the SAME way. Computed only when a dossier exists — the no-dossier
+#   block does no git tree work.
 #
 # * Loop-safety: the block is satisfiable — a fresh PASS or IN_PROGRESS dossier
 #   always lets the turn end — so we never depend on the (undocumented) stop_hook_active.
+#   A turn that genuinely cannot run the auditor is trapped only in hard mode; soft mode
+#   (the default) nudges and lets it through.
 #
 # * One-shot consumption: the dossier is `rm -f`'d on the allow path so the next
-#   verdict re-audits. Mirrors the trade-off in preflight-commit-push.sh.
+#   turn re-audits. Mirrors the trade-off in preflight-commit-push.sh.
+#
+# * Deny -> audit -> retry (like preflight-commit-push.sh): on a missing / stale / FAIL
+#   dossier the hook blocks (hard) or nudges (soft) with an instruction to invoke the
+#   verdict-auditor; the agent audits, then ends again and the hook re-checks. The auditor
+#   is async, so in hard mode this is end -> block -> audit -> wait -> end. That block-then-
+#   wait is the accepted cost of proof-on-every-turn — there is no async-grace shortcut.
+#
+# Threat model & accepted limitations (this gate catches HONEST mistakes, not a malicious
+# parent — the parent and the auditor share one filesystem + toolset):
+#   - NOT forge-resistant: the parent can write the dossier itself. Real tamper-evidence
+#     needs a signer the parent cannot impersonate (a harness-level capability) — a shell
+#     hook cannot provide it. Out of scope by design.
+#   - NOT content-bound: the dossier binds to working-TREE state + verdict, not to the
+#     turn's specific claims, so one un-consumed PASS can authorize a same-tree turn whose
+#     claims differ. Bounded by one-shot consumption + per-turn re-audit; per-message
+#     binding is incompatible with the async model (the auditor audits a mid-turn message,
+#     not the final one).
 #
 # Tests: bash .claude/hooks/preflight-verdict-check.test.sh
 set -uo pipefail
@@ -80,18 +101,10 @@ compute_tree_hash() {
   rm -f "$idx"
 }
 
-# ── No dossier → the agent self-declared nothing to prove → allow ────────────
-# This is the heart of self-declared gating: absence is the agent's decision, not a
-# gap to punish. Gating is opt-in; the agent invokes the auditor (per CLAUDE.md) only
-# when it made a verdict. Cheap: the common turn does no git work and reads no file.
-if [[ ! -r "$verdict_file" ]]; then
-  allow
-fi
-
-# ── Validate the self-declared dossier ───────────────────────────────────────
+# ── Shared re-audit instruction (used by every block path) ───────────────────
 # ─────────────────────────────────────────────────────────────────────────────
-# The block `reason` below is the gate's UX + anti-cheating contract — what Claude
-# reads when a present dossier is stale / mismatched / FAIL. Invariants to preserve:
+# The block `reason`s below are the gate's UX + anti-cheating contract — what Claude
+# reads when a dossier is missing, stale / mismatched, or FAIL. Invariants to preserve:
 #   • Direct Claude to invoke the verdict-auditor subagent (Task tool), passing the
 #     transcript path so the auditor can read the very claim it must check.
 #   • The AUDITOR — not Claude — writes ${verdict_file}. Claude must not write or
@@ -116,6 +129,20 @@ if a claim genuinely cannot be proven here, it can mark that proof 'blocked' wit
 residual risk. Then end your turn again."
 # ─────────────────────────────────────────────────────────────────────────────
 
+# ── No dossier → audit was not run → block (default-deny) ────────────────────
+# The heart of default-deny: every turn-end must produce a dossier, so a missing one is a
+# skipped audit, not a license to skip. The auditor records a trivial PASS for turns that
+# assert nothing — so complying is cheap, and the only thing this rejects is ending WITHOUT
+# auditing. Deny -> audit -> retry, like preflight-commit-push.sh: invoke the auditor, then
+# end again once the dossier exists (in hard mode that is end -> block -> audit -> end).
+if [[ ! -r "$verdict_file" ]]; then
+  block "No verdict dossier for this turn — the verdict-auditor was not run.
+Every turn must end with a fresh dossier at ${verdict_file}. If this turn asserts
+nothing verifiable, the auditor still records a one-line PASS (empty proof) — cheap.
+${verdict_instruction}"
+fi
+
+# ── Validate the present dossier ─────────────────────────────────────────────
 v_branch="$(jq -r '.branch // ""'    "$verdict_file" 2>/dev/null || echo '')"
 v_head="$(jq -r '.head // ""'        "$verdict_file" 2>/dev/null || echo '')"
 v_tree="$(jq -r '.tree_hash // ""'   "$verdict_file" 2>/dev/null || echo '')"

--- a/.claude/hooks/preflight-verdict-check.test.sh
+++ b/.claude/hooks/preflight-verdict-check.test.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Tests for .claude/hooks/preflight-verdict-check.sh (the Stop-stage verdict gate).
 #
-# This hook is a VALIDATOR of a self-declared dossier (.claude/.last-verdict.json):
-#   - no dossier                                -> allow (agent declared nothing to prove)
+# This hook REQUIRES a dossier (.claude/.last-verdict.json) on every turn-end (default-deny):
+#   - no dossier                                -> block (hard) or nudge (soft): audit not run
 #   - present, PASS/IN_PROGRESS, matching+fresh -> allow (PASS is consumed)
 #   - present, stale / mismatched / FAIL        -> block (hard) or nudge (soft)
 # Each case builds a throwaway git repo, optionally writes a dossier, and runs the
@@ -14,6 +14,12 @@
 # Run with:  bash .claude/hooks/preflight-verdict-check.test.sh
 # Exits non-zero on any failure.
 set -uo pipefail
+
+# Hermetic baseline: neutralize any ambient VERDICT_GATE_HARD_BLOCK so the soft-mode
+# cases below see it absent regardless of the caller's environment (a session or CI that
+# exports it to hard-block would otherwise turn their nudges into blocks). Hard-mode
+# cases set it explicitly in decide().
+unset VERDICT_GATE_HARD_BLOCK
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 HOOK="$REPO_ROOT/.claude/hooks/preflight-verdict-check.sh"
@@ -92,17 +98,17 @@ check_consumed() {  # desc  repo
   fi
 }
 
-echo "## No dossier → allow (the agent self-declared nothing to prove)"
-R="$(setup)";                                    check "clean tree, no dossier → allow"   "$R" "allow"; rm -rf "$R"
-# The key inversion: a production change is NOT force-gated; gating is agent-declared.
-R="$(setup)"; printf 'fix\n' >> "$R/src/lib.rs"; check "prod change, no dossier → allow"  "$R" "allow"; rm -rf "$R"
+echo "## No dossier → block (default-deny: every turn must produce an audited dossier)"
+R="$(setup)";                                    check "clean tree, no dossier → block"   "$R" "block"; rm -rf "$R"
+# The whole point: a turn cannot end simply by never invoking the auditor.
+R="$(setup)"; printf 'fix\n' >> "$R/src/lib.rs"; check "prod change, no dossier → block"  "$R" "block"; rm -rf "$R"
 
 echo
 echo "## Present dossier → validate verdict"
 R="$(setup)"; printf 'fix\n' >> "$R/src/lib.rs"; write_verdict "$R" "PASS" "[]"
 check "code change + matching PASS → allow"      "$R" "allow"
 check_consumed "PASS dossier consumed on allow"  "$R"
-check "after consume (no dossier) → allow"       "$R" "allow"; rm -rf "$R"
+check "after consume (no dossier) → block"       "$R" "block"; rm -rf "$R"
 
 # A verdict with NO file change (ops / investigation) still validates against the
 # clean-tree hash — this is the whole point of covering non-code verdicts.
@@ -145,6 +151,15 @@ if printf '%s' "$soft_out" | jq -e '(.decision // "") != "block" and .continue =
   pass=$((pass + 1)); printf '  PASS  %s\n' "FAIL dossier → nudge (continue:true + systemMessage), not block"
 else
   fail=$((fail + 1)); printf '  FAIL  %s  (out=%s)\n' "soft-mode nudge" "$soft_out"
+fi
+rm -rf "$R"
+
+R="$(setup)"  # no dossier at all → soft mode must nudge, not block
+soft_nodossier="$(printf '%s' "$PAYLOAD" | ( cd "$R" && CLAUDE_PROJECT_DIR="$R" bash "$HOOK" ) 2>/dev/null)"
+if printf '%s' "$soft_nodossier" | jq -e '(.decision // "") != "block" and .continue == true and (.systemMessage | type) == "string"' >/dev/null 2>&1; then
+  pass=$((pass + 1)); printf '  PASS  %s\n' "no dossier → nudge (continue:true + systemMessage), not block"
+else
+  fail=$((fail + 1)); printf '  FAIL  %s  (out=%s)\n' "soft-mode no-dossier nudge" "$soft_nodossier"
 fi
 rm -rf "$R"
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,7 @@
 {
+  "env": {
+    "VERDICT_GATE_HARD_BLOCK": "1"
+  },
   "hooks": {
     "PreToolUse": [
       {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ Every change goes: understand → research → design → implement → test →
 
 - Run the smallest relevant verification first (`make test`, package-scoped test), then broaden if risk justifies.
 - Don't claim tests passed unless they actually ran. If verification can't run, state the blocker and the residual risk.
-- Self-declare verdicts: when you end a turn asserting anything as established — a fix that works, tests that pass, a root cause, an ops/infra finding, "no issues", a factual answer — invoke the `verdict-auditor` subagent (Task) to attach proof before ending. You decide when a turn carries a verdict; a turn with nothing verifiable needs no audit. The auditor — not you — writes the dossier (`.claude/.last-verdict.json`); never hand-write it.
+- Attach a verdict before ending: every turn ends by invoking the `verdict-auditor` subagent (Task), which writes the dossier (`.claude/.last-verdict.json`) — never hand-write it. Claims like a fix that works, tests that pass, a root cause, an ops/infra finding, "no issues", or a factual answer must carry concrete proof; a turn that asserts nothing verifiable still gets a one-line PASS (empty proof). The Stop gate is default-deny: a missing dossier blocks the turn-end (hard mode) or nudges (soft, the default), so the audit cannot be skipped by simply not invoking it. The auditor is async, so in hard mode ending a turn is deny -> audit -> wait -> end (like the commit-push gate); that block-then-wait is the accepted cost of proof on every turn.
 
 **Cross-cutting** (apply at every phase)
 


### PR DESCRIPTION
## Summary
Harden the Stop-stage verdict gate. It was self-declared (#885), so a turn
could end unproven by simply never invoking the auditor. Make it default-deny
(a missing dossier blocks/nudges) and always-on.

## Changes
- Hook: no dossier -> block (hard) / nudge (soft); deny -> audit -> retry,
  mirroring preflight-commit-push.sh. No async-grace shortcut.
- settings: VERDICT_GATE_HARD_BLOCK=1 (always-on).
- Tests: no-dossier cases inverted; hermetic baseline (unset ambient var); 15/15.
- Docs: hook-header threat model — the gate catches honest mistakes, not a
  malicious parent (forge-resistance + content-binding are out of scope, by design).

## How to verify
- `bash .claude/hooks/preflight-verdict-check.test.sh` -> 15/15
- also green with `VERDICT_GATE_HARD_BLOCK=1` and with `env -u VERDICT_GATE_HARD_BLOCK`
- sibling gates unaffected: preflight-commit-push 19/19, preflight-pr-review 29/29

## Risks
Always-on hard mode adds an auditor run per turn-end (deny -> audit -> wait -> end).
The gate is not forge-resistant or content-bound (documented); it targets honest
mistakes, not a malicious parent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened end-of-turn verification so missing or stale proof now triggers a re-check instead of being accepted.
  * Improved handling for empty-proof turns by allowing a simple PASS record when nothing needs verification.
  * Updated the default behavior to block until validation completes in stricter mode, with clearer guidance when a check is required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->