### PR TITLE
feat(quickstart): Add C, CLI, and REST quickstart entries

### DIFF
--- a/apps/dashboard/src/components/CodeBlock.tsx
+++ b/apps/dashboard/src/components/CodeBlock.tsx
@@ -6,7 +6,7 @@
 
 import { useTheme } from '@/contexts/ThemeContext'
 import { cn } from '@/lib/utils'
-import { Highlight, themes, type PrismTheme, type Token } from 'prism-react-renderer'
+import { Highlight, Prism, themes, type PrismTheme, type Token } from 'prism-react-renderer'
 import type { Key } from 'react'
 import { CopyButton } from './CopyButton'
 
@@ -41,8 +41,73 @@ const oneLight = {
   },
 }
 
+const languageAliases: Record<string, string> = {
+  sh: 'bash',
+  shell: 'bash',
+}
+
+function registerBashGrammar() {
+  const languages = Prism.languages as typeof Prism.languages & {
+    bash?: unknown
+    sh?: unknown
+    shell?: unknown
+  }
+  if (languages.bash) {
+    return
+  }
+
+  languages.bash = {
+    shebang: {
+      pattern: /^#!\s*\/.*/,
+      alias: 'important',
+    },
+    comment: {
+      pattern: /(^|[^"{\\$])#.*/,
+      lookbehind: true,
+    },
+    string: [
+      {
+        pattern: /"(?:\\[\s\S]|\$\([^)]+\)|\$(?!\()|`[^`]+`|[^"\\`$])*"/,
+        greedy: true,
+        inside: {
+          variable: /\$(?:\w+|[#?*!@$]|\{[^}]+\})/,
+        },
+      },
+      {
+        pattern: /'[^']*'/,
+        greedy: true,
+      },
+    ],
+    variable: /\$(?:\w+|[#?*!@$]|\{[^}]+\})/,
+    function: {
+      pattern: /(^|[\s;|&])(?:bash|boxlite|cc|command|curl|date|echo|jq|mv|printf|read|stty|tar)(?=$|[\s;|&])/,
+      lookbehind: true,
+    },
+    keyword: {
+      pattern: /(^|[\s;|&])(?:case|do|done|elif|else|esac|fi|for|function|if|in|select|then|until|while)(?=$|[\s;|&])/,
+      lookbehind: true,
+    },
+    builtin: {
+      pattern: /(^|[\s;|&])(?:export|set|test|trap|type)(?=$|[\s;|&])/,
+      lookbehind: true,
+      alias: 'class-name',
+    },
+    boolean: {
+      pattern: /(^|[\s;|&])(?:false|true)(?=$|[\s;|&])/,
+      lookbehind: true,
+    },
+    operator: /\d?<>|>\||\+=|=[=~]?|!=?|<<[<-]?|[&\d]?>>|\d[<>]&?|[<>][&=]?|&[>&]?|\|[&|]?/,
+    punctuation: /\$?\(\(?|\)\)?|\.\.|[{}[\];\\]/,
+  }
+  languages.sh = languages.bash
+  languages.shell = languages.bash
+}
+
+registerBashGrammar()
+
 const CodeBlock: React.FC<CodeBlockProps> = ({ code, language, showCopy = true, codeAreaClassName, className }) => {
   const { resolvedTheme } = useTheme()
+  const highlightLanguage = languageAliases[language] ?? language
 
   return (
     <div
@@ -54,11 +119,14 @@ const CodeBlock: React.FC<CodeBlockProps> = ({ code, language, showCopy = true, 
       <Highlight
         theme={(resolvedTheme === 'dark' ? oneDark : oneLight) as PrismTheme}
         code={code.trim()}
-        language={language}
+        language={highlightLanguage}
       >
         {({ style, tokens, getLineProps, getTokenProps }: HighlightProps) => (
           <pre
-            className={cn('overflow-x-auto rounded-lg p-4 pr-12 text-[13px] leading-6', codeAreaClassName)}
+            className={cn(
+              'scrollbar-elevated overflow-x-auto rounded-lg p-4 pr-12 text-[13px] leading-6',
+              codeAreaClassName,
+            )}
             style={style}
           >
             {tokens.map((line, i) => {

--- a/apps/dashboard/src/components/OnboardingGuideDialog.tsx
+++ b/apps/dashboard/src/components/OnboardingGuideDialog.tsx
@@ -9,12 +9,13 @@ import pythonIcon from '@/assets/python.svg'
 import rustIcon from '@/assets/rust.svg'
 import typescriptIcon from '@/assets/typescript.svg'
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Server, Terminal } from '@/components/ui/icon'
 import { useApi } from '@/hooks/useApi'
 import { useConfig } from '@/hooks/useConfig'
 import { getRestApiUrl } from '@/lib/environment'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
 import { handleApiError } from '@/lib/error-handling'
-import { getOnboardingCodeExamples, type OnboardingLanguage } from '@/lib/onboarding-code-examples'
+import { getOnboardingCodeExamples, type OnboardingInterface } from '@/lib/onboarding-code-examples'
 import { setLocalStorageItem } from '@/lib/local-storage'
 import { cn } from '@/lib/utils'
 import type { OnboardingProgress } from '@/lib/onboarding-progress'
@@ -40,7 +41,7 @@ interface OnboardingGuideDialogProps {
 
 const STAGES = [
   { tag: 'STEP 01', label: 'Create a key' },
-  { tag: 'STEP 02', label: 'Install the SDK' },
+  { tag: 'STEP 02', label: 'Install SDK/CLI' },
   { tag: 'STEP 03', label: 'Execute code in box' },
 ] as const
 
@@ -52,17 +53,27 @@ const SCENARIOS = [
     tag: 'Box',
     title: 'Box as your untrusted code container',
     description:
-      'Run AI-generated or untrusted code in an isolated, disposable Box. Create a key, install the SDK, then execute code safely inside a box.',
+      'Run AI-generated or untrusted code in an isolated, disposable Box. Create a key, choose an interface, then execute code safely inside a box.',
   },
 ] as const
 
 type ScenarioId = (typeof SCENARIOS)[number]['id']
 
-const LANGS: { value: OnboardingLanguage; label: string; iconSrc: string }[] = [
+const LANGS: {
+  value: OnboardingInterface
+  label: string
+  ariaLabel?: string
+  iconSrc?: string
+  badge?: string
+  Icon?: React.ComponentType<{ className?: string }>
+}[] = [
   { value: 'python', label: 'Python', iconSrc: pythonIcon },
   { value: 'typescript', label: 'Node', iconSrc: typescriptIcon },
   { value: 'go', label: 'Go', iconSrc: goIcon },
   { value: 'rust', label: 'Rust', iconSrc: rustIcon },
+  { value: 'c', label: 'SDK', ariaLabel: 'C SDK', badge: 'C' },
+  { value: 'cli', label: 'CLI', Icon: Terminal },
+  { value: 'rest', label: 'REST', Icon: Server },
 ]
 
 function PrimaryBtn({ children, onClick }: { children: React.ReactNode; onClick: () => void }) {
@@ -77,7 +88,7 @@ function PrimaryBtn({ children, onClick }: { children: React.ReactNode; onClick:
   )
 }
 
-export function OnboardingGuideDialog({ open, onOpenChange, onProgressChange, progress }: OnboardingGuideDialogProps) {
+export function OnboardingGuideDialog({ open, onOpenChange, onProgressChange }: OnboardingGuideDialogProps) {
   const { apiKeyApi } = useApi()
   const { apiUrl } = useConfig()
   const restApiUrl = getRestApiUrl(apiUrl)
@@ -87,17 +98,41 @@ export function OnboardingGuideDialog({ open, onOpenChange, onProgressChange, pr
   const [scenario, setScenario] = useState<ScenarioId | null>(null)
   const [step, setStep] = useState(0)
   const [done, setDone] = useState<[boolean, boolean, boolean]>([false, false, false])
-  const [language, setLanguage] = useState<OnboardingLanguage>('python')
+  const [language, setLanguage] = useState<OnboardingInterface>('python')
   const [createdKey, setCreatedKey] = useState<ApiKeyResponse | null>(null)
   const [creating, setCreating] = useState(false)
   const [copied, setCopied] = useState(false)
 
   const codeExamples = getOnboardingCodeExamples()
   const activeExample = codeExamples[language]
+  const activeInterface = LANGS.find((l) => l.value === language)
   const renderedExample = useMemo(
     () => activeExample.example.replaceAll('your-api-url', restApiUrl),
     [activeExample.example, restApiUrl],
   )
+  const executionDescription =
+    language === 'c' ? (
+      <>
+        What it does: compiles a C program that reads your <span className="text-foreground">BOXLITE_API_KEY</span>,
+        creates a Box, runs a command inside it, prints stdout, then removes the Box.
+      </>
+    ) : language === 'cli' ? (
+      <>
+        What it does: reads your <span className="text-foreground">BOXLITE_API_KEY</span> and{' '}
+        <span className="text-foreground">BOXLITE_REST_URL</span>, runs one command in a disposable Box, then removes
+        it.
+      </>
+    ) : language === 'rest' ? (
+      <>
+        What it does: reads your <span className="text-foreground">BOXLITE_API_KEY</span>, calls the REST API to create
+        and start a Box, executes a command, prints execution status, then removes the Box.
+      </>
+    ) : (
+      <>
+        What it does: reads your <span className="text-foreground">BOXLITE_API_KEY</span> from the environment, creates
+        a Box, runs a command inside it, prints the output, then removes the Box.
+      </>
+    )
 
   const apiKeyPermissions = useMemo(() => {
     if (!canCreateApiKey) return []
@@ -202,7 +237,7 @@ export function OnboardingGuideDialog({ open, onOpenChange, onProgressChange, pr
                   >
                     <div className="text-[13px] font-semibold leading-snug">{sc.title}</div>
                     <div className="mt-[6px] font-mono text-[10px] uppercase tracking-[1px] text-muted-foreground">
-                      3 steps · sdk
+                      3 steps · sdk/api
                     </div>
                     <div className="mt-auto flex items-center gap-[7px] pt-4 font-mono text-[11px] uppercase tracking-[1.5px]">
                       Start
@@ -278,7 +313,7 @@ export function OnboardingGuideDialog({ open, onOpenChange, onProgressChange, pr
                       </span>
                       <span
                         className={cn(
-                          'whitespace-nowrap text-[12px]',
+                          'hidden whitespace-nowrap text-[12px] sm:inline',
                           active
                             ? 'font-semibold text-foreground'
                             : isDone
@@ -366,40 +401,59 @@ export function OnboardingGuideDialog({ open, onOpenChange, onProgressChange, pr
 
               {step === 1 && (
                 <div className="px-5 py-[18px]" style={{ animation: 'stat-in .25s ease' }}>
-                  <div className="mb-[14px] flex border-b border-border">
+                  <div className="mb-[14px] grid grid-cols-2 gap-2 sm:grid-cols-4">
                     {LANGS.map((l) => {
                       const on = language === l.value
+                      const Icon = l.Icon
                       return (
                         <button
                           key={l.value}
                           type="button"
+                          aria-label={l.ariaLabel}
                           onClick={() => setLanguage(l.value)}
                           className={cn(
-                            '-mb-px flex items-center gap-2 border-b-2 px-[14px] py-[7px] text-[12px] transition-colors',
+                            'flex min-h-[34px] items-center justify-center gap-2 border px-[10px] py-[7px] text-[12px] transition-colors',
                             on
-                              ? 'border-brand font-semibold text-foreground'
-                              : 'border-transparent text-muted-foreground',
+                              ? 'border-brand bg-[hsl(var(--brand)/0.12)] font-semibold text-brand'
+                              : 'border-border text-muted-foreground hover:border-brand/70 hover:text-foreground',
                           )}
                         >
-                          <img src={l.iconSrc} alt="" className="size-3.5" />
+                          {l.iconSrc ? (
+                            <img src={l.iconSrc} alt="" className="size-3.5" />
+                          ) : Icon ? (
+                            <Icon className="size-3.5" />
+                          ) : (
+                            <span
+                              aria-hidden="true"
+                              className="flex size-3.5 items-center justify-center border border-current text-[9px] leading-none"
+                            >
+                              {l.badge}
+                            </span>
+                          )}
                           {l.label}
                         </button>
                       )
                     })}
                   </div>
                   <div className="mb-[9px] text-[9px] uppercase tracking-[1.5px] text-muted-foreground">
-                    Run in your local terminal
+                    {activeExample.setupLabel ?? 'Run in your local terminal'}
                   </div>
-                  <div className="flex items-center gap-3 border border-border bg-[hsl(var(--code-background))] px-[14px] py-3">
-                    <span className="flex-none text-success">$</span>
-                    <span className="flex-1 break-all text-[13px]">{activeExample.install}</span>
+                  <div className="flex items-start gap-3 border border-border bg-[hsl(var(--code-background))] px-[14px] py-3">
+                    <span className="flex-none pt-[1px] text-success">$</span>
+                    <pre className="min-w-0 flex-1 whitespace-pre-wrap break-words text-[13px] leading-relaxed text-foreground">
+                      {activeExample.install}
+                    </pre>
                   </div>
                   <div className="mt-[11px] flex items-start gap-2 text-[11.5px] leading-relaxed text-muted-foreground">
                     <span className="flex-none text-brand">ⓘ</span>
                     <span>
-                      Run this command in your <span className="text-foreground">local development environment</span> to
-                      install the {LANGS.find((l) => l.value === language)?.label} library. Continue once the install
-                      finishes.
+                      {activeExample.setupDescription ?? (
+                        <>
+                          Run this command in your{' '}
+                          <span className="text-foreground">local development environment</span> to install the{' '}
+                          {activeInterface?.label} library. Continue once the install finishes.
+                        </>
+                      )}
                     </span>
                   </div>
                   <div className="mt-4 flex justify-end">
@@ -433,9 +487,7 @@ export function OnboardingGuideDialog({ open, onOpenChange, onProgressChange, pr
                   <div className="mt-[12px] flex items-start gap-2 text-[11.5px] leading-relaxed text-muted-foreground">
                     <span className="flex-none text-brand">ⓘ</span>
                     <span>
-                      What it does: reads your <span className="text-foreground">BOXLITE_API_KEY</span> from the
-                      environment, creates a Box, runs a command inside it, prints the output, then removes the Box. Run
-                      it in your terminal with the install command from the previous step.
+                      {executionDescription} Run it in your terminal with the install command from the previous step.
                     </span>
                   </div>
                   <div className="mt-4 flex items-center justify-end">

--- a/apps/dashboard/src/components/OnboardingGuideDialog.tsx
+++ b/apps/dashboard/src/components/OnboardingGuideDialog.tsx
@@ -9,13 +9,18 @@ import pythonIcon from '@/assets/python.svg'
 import rustIcon from '@/assets/rust.svg'
 import typescriptIcon from '@/assets/typescript.svg'
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
-import { Server, Terminal } from '@/components/ui/icon'
+import { KeyRound, Server, Terminal } from '@/components/ui/icon'
 import { useApi } from '@/hooks/useApi'
 import { useConfig } from '@/hooks/useConfig'
 import { getRestApiUrl } from '@/lib/environment'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
 import { handleApiError } from '@/lib/error-handling'
-import { getOnboardingCodeExamples, type OnboardingInterface } from '@/lib/onboarding-code-examples'
+import { createApiKeyWithFallbackName, DEFAULT_QUICKSTART_API_KEY_NAME } from '@/lib/quickstart-api-key'
+import {
+  getOnboardingCodeExamples,
+  renderOnboardingCodeExample,
+  type OnboardingInterface,
+} from '@/lib/onboarding-code-examples'
 import { setLocalStorageItem } from '@/lib/local-storage'
 import { cn } from '@/lib/utils'
 import type { OnboardingProgress } from '@/lib/onboarding-progress'
@@ -88,10 +93,12 @@ function PrimaryBtn({ children, onClick }: { children: React.ReactNode; onClick:
   )
 }
 
+type CopyTarget = 'api-key' | 'install'
+
 export function OnboardingGuideDialog({ open, onOpenChange, onProgressChange }: OnboardingGuideDialogProps) {
   const { apiKeyApi } = useApi()
-  const { apiUrl } = useConfig()
-  const restApiUrl = getRestApiUrl(apiUrl)
+  const config = useConfig()
+  const restApiUrl = getRestApiUrl(config.apiUrl, undefined, config.oidc.issuer)
   const { selectedOrganization, authenticatedUserHasPermission } = useSelectedOrganization()
   const canCreateApiKey = authenticatedUserHasPermission(OrganizationRolePermissionsEnum.WRITE_BOXES)
 
@@ -100,15 +107,16 @@ export function OnboardingGuideDialog({ open, onOpenChange, onProgressChange }: 
   const [done, setDone] = useState<[boolean, boolean, boolean]>([false, false, false])
   const [language, setLanguage] = useState<OnboardingInterface>('python')
   const [createdKey, setCreatedKey] = useState<ApiKeyResponse | null>(null)
+  const [keyName, setKeyName] = useState('')
   const [creating, setCreating] = useState(false)
-  const [copied, setCopied] = useState(false)
+  const [copiedTarget, setCopiedTarget] = useState<CopyTarget | null>(null)
 
   const codeExamples = getOnboardingCodeExamples()
   const activeExample = codeExamples[language]
   const activeInterface = LANGS.find((l) => l.value === language)
   const renderedExample = useMemo(
-    () => activeExample.example.replaceAll('your-api-url', restApiUrl),
-    [activeExample.example, restApiUrl],
+    () => renderOnboardingCodeExample(language, { apiKey: createdKey?.value, restApiUrl }),
+    [createdKey?.value, language, restApiUrl],
   )
   const executionDescription =
     language === 'c' ? (
@@ -149,7 +157,8 @@ export function OnboardingGuideDialog({ open, onOpenChange, onProgressChange }: 
       setStep(0)
       setDone([false, false, false])
       setCreatedKey(null)
-      setCopied(false)
+      setKeyName('')
+      setCopiedTarget(null)
     }
   }, [open])
 
@@ -159,13 +168,15 @@ export function OnboardingGuideDialog({ open, onOpenChange, onProgressChange }: 
     setStep(0)
     setDone([false, false, false])
     setCreatedKey(null)
-    setCopied(false)
+    setKeyName('')
+    setCopiedTarget(null)
   }
   const backToScenarios = () => {
     setScenario(null)
     setStep(0)
     setDone([false, false, false])
     setCreatedKey(null)
+    setKeyName('')
   }
 
   const finished = done.every(Boolean)
@@ -191,9 +202,9 @@ export function OnboardingGuideDialog({ open, onOpenChange, onProgressChange }: 
     setCreating(true)
     try {
       const key = (
-        await apiKeyApi.createApiKey(
-          { name: 'sdk-quickstart', permissions: apiKeyPermissions },
-          selectedOrganization.id,
+        await createApiKeyWithFallbackName<{ data: ApiKeyResponse }>(
+          (name) => apiKeyApi.createApiKey({ name, permissions: apiKeyPermissions }, selectedOrganization.id),
+          { baseName: keyName },
         )
       ).data
       setCreatedKey(key)
@@ -205,14 +216,14 @@ export function OnboardingGuideDialog({ open, onOpenChange, onProgressChange }: 
     }
   }
 
-  const copyKey = (value: string) => {
+  const copyText = (value: string, target: CopyTarget) => {
     try {
       navigator.clipboard?.writeText(value)
     } catch {
       /* clipboard may be unavailable */
     }
-    setCopied(true)
-    setTimeout(() => setCopied(false), 1400)
+    setCopiedTarget(target)
+    setTimeout(() => setCopiedTarget(null), 1400)
   }
 
   return (
@@ -340,32 +351,49 @@ export function OnboardingGuideDialog({ open, onOpenChange, onProgressChange }: 
               {step === 0 && (
                 <div className="px-5 py-[18px]" style={{ animation: 'stat-in .25s ease' }}>
                   <div className="mb-[9px] text-[9px] uppercase tracking-[1.5px] text-muted-foreground">
-                    {createdKey ? 'Your API key  ·  shown once' : 'Create a key to authenticate'}
+                    {createdKey ? 'Your API key' : 'Key name'}
                   </div>
-                  <div className="flex items-center gap-[10px] border border-border bg-[hsl(var(--code-background))] px-[14px] py-3">
-                    <span
-                      className={cn(
-                        'flex-1 break-all text-[13px] tracking-[0.5px]',
-                        createdKey ? 'text-foreground' : 'text-muted-foreground',
-                      )}
-                    >
-                      {createdKey ? createdKey.value : 'Click “Create key” to generate a secret'}
-                    </span>
-                    {createdKey && (
+                  <div className="flex items-center gap-[10px] border border-border bg-[hsl(var(--code-background))] px-[14px] py-3 focus-within:border-brand">
+                    <KeyRound className={cn('size-4 flex-none', createdKey ? 'text-brand' : 'text-muted-foreground')} />
+                    {createdKey ? (
+                      <span className="flex-1 break-all text-[11.5px] leading-relaxed text-foreground">
+                        {createdKey.value}
+                      </span>
+                    ) : (
+                      <input
+                        value={keyName}
+                        onChange={(e) => setKeyName(e.target.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter' && !creating) {
+                            void handleCreateKey()
+                          }
+                        }}
+                        placeholder={`${DEFAULT_QUICKSTART_API_KEY_NAME} (default)`}
+                        aria-label="Quickstart API key name"
+                        disabled={creating}
+                        className="min-w-0 flex-1 bg-transparent text-[13px] tracking-[0.5px] text-foreground outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-60"
+                      />
+                    )}
+                    {createdKey ? (
                       <button
                         type="button"
-                        onClick={() => copyKey(createdKey.value)}
+                        onClick={() => copyText(createdKey.value, 'api-key')}
                         className={cn(
                           'flex-none border px-[11px] py-[6px] text-[10px] uppercase tracking-[1px] transition-colors',
-                          copied
+                          copiedTarget === 'api-key'
                             ? 'border-success text-success'
                             : 'border-border text-muted-foreground hover:text-foreground',
                         )}
                       >
-                        {copied ? '✓ Copied' : 'Copy'}
+                        {copiedTarget === 'api-key' ? '✓ Copied' : 'Copy'}
                       </button>
-                    )}
+                    ) : null}
                   </div>
+                  {!createdKey && (
+                    <div className="mt-[9px] text-[11.5px] leading-relaxed text-muted-foreground">
+                      Leave blank to use <span className="text-foreground">{DEFAULT_QUICKSTART_API_KEY_NAME}</span>.
+                    </div>
+                  )}
                   {createdKey && (
                     <div className="mt-[11px] flex items-start gap-2 text-[11.5px] leading-relaxed text-muted-foreground">
                       <span className="flex-none text-brand">ⓘ</span>
@@ -443,6 +471,18 @@ export function OnboardingGuideDialog({ open, onOpenChange, onProgressChange }: 
                     <pre className="min-w-0 flex-1 whitespace-pre-wrap break-words text-[13px] leading-relaxed text-foreground">
                       {activeExample.install}
                     </pre>
+                    <button
+                      type="button"
+                      onClick={() => copyText(activeExample.install, 'install')}
+                      className={cn(
+                        'flex-none border px-[11px] py-[6px] text-[10px] uppercase tracking-[1px] transition-colors',
+                        copiedTarget === 'install'
+                          ? 'border-success text-success'
+                          : 'border-border text-muted-foreground hover:text-foreground',
+                      )}
+                    >
+                      {copiedTarget === 'install' ? '✓ Copied' : 'Copy'}
+                    </button>
                   </div>
                   <div className="mt-[11px] flex items-start gap-2 text-[11.5px] leading-relaxed text-muted-foreground">
                     <span className="flex-none text-brand">ⓘ</span>
@@ -466,6 +506,40 @@ export function OnboardingGuideDialog({ open, onOpenChange, onProgressChange }: 
 
               {step === 2 && (
                 <div className="px-5 py-[18px]" style={{ animation: 'stat-in .25s ease' }}>
+                  <div className="mb-[14px] grid grid-cols-2 gap-2 sm:grid-cols-4">
+                    {LANGS.map((l) => {
+                      const on = language === l.value
+                      const Icon = l.Icon
+                      return (
+                        <button
+                          key={l.value}
+                          type="button"
+                          aria-label={l.ariaLabel}
+                          onClick={() => setLanguage(l.value)}
+                          className={cn(
+                            'flex min-h-[34px] items-center justify-center gap-2 border px-[10px] py-[7px] text-[12px] transition-colors',
+                            on
+                              ? 'border-brand bg-[hsl(var(--brand)/0.12)] font-semibold text-brand'
+                              : 'border-border text-muted-foreground hover:border-brand/70 hover:text-foreground',
+                          )}
+                        >
+                          {l.iconSrc ? (
+                            <img src={l.iconSrc} alt="" className="size-3.5" />
+                          ) : Icon ? (
+                            <Icon className="size-3.5" />
+                          ) : (
+                            <span
+                              aria-hidden="true"
+                              className="flex size-3.5 items-center justify-center border border-current text-[9px] leading-none"
+                            >
+                              {l.badge}
+                            </span>
+                          )}
+                          {l.label}
+                        </button>
+                      )
+                    })}
+                  </div>
                   <div className="mb-[9px] text-[9px] uppercase tracking-[1.5px] text-muted-foreground">
                     Run this from your local machine
                   </div>

--- a/apps/dashboard/src/components/OnboardingGuideDialog.tsx
+++ b/apps/dashboard/src/components/OnboardingGuideDialog.tsx
@@ -8,7 +8,6 @@ import goIcon from '@/assets/go.svg'
 import pythonIcon from '@/assets/python.svg'
 import rustIcon from '@/assets/rust.svg'
 import typescriptIcon from '@/assets/typescript.svg'
-import { CopyButton } from '@/components/CopyButton'
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { KeyRound, Server, Terminal } from '@/components/ui/icon'
 import { useApi } from '@/hooks/useApi'
@@ -111,7 +110,36 @@ function PrimaryBtn({ children, onClick }: { children: React.ReactNode; onClick:
   )
 }
 
-type CopyTarget = 'install'
+function QuickstartCopyButton({
+  copied,
+  onClick,
+  className,
+}: {
+  copied: boolean
+  onClick: () => void
+  className?: string
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      style={{
+        boxShadow: copied ? '3px 3px 0 hsl(var(--success) / 0.35)' : '3px 3px 0 hsl(var(--border))',
+      }}
+      className={cn(
+        'flex h-7 min-w-[76px] flex-none items-center justify-center border-2 bg-[hsl(var(--code-background))] px-[10px] text-[10px] font-semibold uppercase tracking-[1px] transition-[color,border-color,background-color,transform,box-shadow] active:translate-x-px active:translate-y-px active:shadow-none',
+        copied
+          ? 'border-success bg-[hsl(var(--success)/0.14)] text-success'
+          : 'border-border text-muted-foreground hover:border-brand hover:text-foreground',
+        className,
+      )}
+    >
+      {copied ? '✓ Copied' : 'Copy'}
+    </button>
+  )
+}
+
+type CopyTarget = 'api-key' | 'install' | 'code'
 
 export function OnboardingGuideDialog({ open, onOpenChange, onProgressChange }: OnboardingGuideDialogProps) {
   const { apiKeyApi } = useApi()
@@ -379,10 +407,9 @@ export function OnboardingGuideDialog({ open, onOpenChange, onProgressChange }: 
                       />
                     )}
                     {createdKey ? (
-                      <CopyButton
-                        value={createdKey.value}
-                        variant="ghost"
-                        className="flex-none bg-background/80 p-2 text-muted-foreground shadow-sm ring-1 ring-border/70 backdrop-blur hover:bg-muted hover:text-foreground"
+                      <QuickstartCopyButton
+                        copied={copiedTarget === 'api-key'}
+                        onClick={() => copyText(createdKey.value, 'api-key')}
                       />
                     ) : null}
                   </div>
@@ -456,18 +483,10 @@ export function OnboardingGuideDialog({ open, onOpenChange, onProgressChange }: 
                     <pre className="scrollbar-elevated min-w-0 flex-1 overflow-x-auto whitespace-pre text-[13px] leading-relaxed text-foreground">
                       {activeExample.install}
                     </pre>
-                    <button
-                      type="button"
+                    <QuickstartCopyButton
+                      copied={copiedTarget === 'install'}
                       onClick={() => copyText(activeExample.install, 'install')}
-                      className={cn(
-                        'flex-none border px-[11px] py-[6px] text-[10px] uppercase tracking-[1px] transition-colors',
-                        copiedTarget === 'install'
-                          ? 'border-success text-success'
-                          : 'border-border text-muted-foreground hover:text-foreground',
-                      )}
-                    >
-                      {copiedTarget === 'install' ? '✓ Copied' : 'Copy'}
-                    </button>
+                    />
                   </div>
                   <div className="mt-[11px] flex items-start gap-2 text-[11.5px] leading-relaxed text-muted-foreground">
                     <span className="flex-none text-brand">ⓘ</span>
@@ -516,10 +535,10 @@ export function OnboardingGuideDialog({ open, onOpenChange, onProgressChange }: 
                   <div className="mb-[9px] text-[9px] uppercase tracking-[1.5px] text-muted-foreground">
                     Run this from your local machine
                   </div>
-                  <div className="min-h-0 flex-1">
+                  <div className="relative min-h-0 flex-1">
                     <Suspense
                       fallback={
-                        <pre className="scrollbar-elevated h-full overflow-auto whitespace-pre rounded-none p-3 text-[11.5px] leading-relaxed">
+                        <pre className="scrollbar-elevated h-full overflow-auto whitespace-pre rounded-none p-3 pr-24 text-[11.5px] leading-relaxed">
                           {renderedExample}
                         </pre>
                       }
@@ -527,11 +546,16 @@ export function OnboardingGuideDialog({ open, onOpenChange, onProgressChange }: 
                       <CodeBlock
                         code={renderedExample}
                         language={activeExample.codeLanguage}
-                        showCopy
+                        showCopy={false}
                         className="h-full rounded-none"
-                        codeAreaClassName="h-full overflow-auto whitespace-pre text-[11.5px] leading-relaxed"
+                        codeAreaClassName="h-full overflow-auto whitespace-pre pr-24 text-[11.5px] leading-relaxed"
                       />
                     </Suspense>
+                    <QuickstartCopyButton
+                      copied={copiedTarget === 'code'}
+                      onClick={() => copyText(renderedExample, 'code')}
+                      className="absolute right-2 top-2.5"
+                    />
                   </div>
                   <div className="mt-[12px] flex items-start gap-2 text-[11.5px] leading-relaxed text-muted-foreground">
                     <span className="flex-none text-brand">ⓘ</span>

--- a/apps/dashboard/src/components/OnboardingGuideDialog.tsx
+++ b/apps/dashboard/src/components/OnboardingGuideDialog.tsx
@@ -18,9 +18,11 @@ import { handleApiError } from '@/lib/error-handling'
 import { createApiKeyWithFallbackName, DEFAULT_QUICKSTART_API_KEY_NAME } from '@/lib/quickstart-api-key'
 import {
   getOnboardingCodeExamples,
+  getOnboardingInterfaces,
   renderOnboardingCodeExample,
   type OnboardingInterface,
 } from '@/lib/onboarding-code-examples'
+import type { QuickstartIconName, QuickstartInterfaceDefinition } from '@/lib/quickstart/types'
 import { setLocalStorageItem } from '@/lib/local-storage'
 import { cn } from '@/lib/utils'
 import type { OnboardingProgress } from '@/lib/onboarding-progress'
@@ -64,22 +66,37 @@ const SCENARIOS = [
 
 type ScenarioId = (typeof SCENARIOS)[number]['id']
 
-const LANGS: {
-  value: OnboardingInterface
-  label: string
-  ariaLabel?: string
-  iconSrc?: string
-  badge?: string
-  Icon?: React.ComponentType<{ className?: string }>
-}[] = [
-  { value: 'python', label: 'Python', iconSrc: pythonIcon },
-  { value: 'typescript', label: 'Node', iconSrc: typescriptIcon },
-  { value: 'go', label: 'Go', iconSrc: goIcon },
-  { value: 'rust', label: 'Rust', iconSrc: rustIcon },
-  { value: 'c', label: 'SDK', ariaLabel: 'C SDK', badge: 'C' },
-  { value: 'cli', label: 'CLI', Icon: Terminal },
-  { value: 'rest', label: 'REST', Icon: Server },
-]
+const QUICKSTART_INTERFACES = getOnboardingInterfaces()
+const DEFAULT_INTERFACE = QUICKSTART_INTERFACES[0]?.id ?? 'python'
+const ICON_ASSETS: Partial<Record<QuickstartIconName, string>> = {
+  go: goIcon,
+  python: pythonIcon,
+  rust: rustIcon,
+  typescript: typescriptIcon,
+}
+const ICON_COMPONENTS: Partial<Record<QuickstartIconName, React.ComponentType<{ className?: string }>>> = {
+  server: Server,
+  terminal: Terminal,
+}
+
+function QuickstartInterfaceIcon({ item }: { item: QuickstartInterfaceDefinition }) {
+  const iconSrc = ICON_ASSETS[item.icon]
+  const Icon = ICON_COMPONENTS[item.icon]
+  if (iconSrc) {
+    return <img src={iconSrc} alt="" className="size-3.5" />
+  }
+  if (Icon) {
+    return <Icon className="size-3.5" />
+  }
+  return (
+    <span
+      aria-hidden="true"
+      className="flex size-3.5 items-center justify-center border border-current text-[9px] leading-none"
+    >
+      {item.badge}
+    </span>
+  )
+}
 
 function PrimaryBtn({ children, onClick }: { children: React.ReactNode; onClick: () => void }) {
   return (
@@ -105,43 +122,19 @@ export function OnboardingGuideDialog({ open, onOpenChange, onProgressChange }: 
   const [scenario, setScenario] = useState<ScenarioId | null>(null)
   const [step, setStep] = useState(0)
   const [done, setDone] = useState<[boolean, boolean, boolean]>([false, false, false])
-  const [language, setLanguage] = useState<OnboardingInterface>('python')
+  const [language, setLanguage] = useState<OnboardingInterface>(DEFAULT_INTERFACE)
   const [createdKey, setCreatedKey] = useState<ApiKeyResponse | null>(null)
   const [keyName, setKeyName] = useState('')
   const [creating, setCreating] = useState(false)
   const [copiedTarget, setCopiedTarget] = useState<CopyTarget | null>(null)
 
   const codeExamples = getOnboardingCodeExamples()
-  const activeExample = codeExamples[language]
-  const activeInterface = LANGS.find((l) => l.value === language)
+  const activeExample = codeExamples[language] ?? codeExamples[DEFAULT_INTERFACE]
+  const activeInterface = QUICKSTART_INTERFACES.find((item) => item.id === language) ?? QUICKSTART_INTERFACES[0]
   const renderedExample = useMemo(
     () => renderOnboardingCodeExample(language, { apiKey: createdKey?.value, restApiUrl }),
     [createdKey?.value, language, restApiUrl],
   )
-  const executionDescription =
-    language === 'c' ? (
-      <>
-        What it does: compiles a C program that reads your <span className="text-foreground">BOXLITE_API_KEY</span>,
-        creates a Box, runs a command inside it, prints stdout, then removes the Box.
-      </>
-    ) : language === 'cli' ? (
-      <>
-        What it does: reads your <span className="text-foreground">BOXLITE_API_KEY</span> and{' '}
-        <span className="text-foreground">BOXLITE_REST_URL</span>, runs one command in a disposable Box, then removes
-        it.
-      </>
-    ) : language === 'rest' ? (
-      <>
-        What it does: reads your <span className="text-foreground">BOXLITE_API_KEY</span>, calls the REST API to create
-        and start a Box, executes a command, prints execution status, then removes the Box.
-      </>
-    ) : (
-      <>
-        What it does: reads your <span className="text-foreground">BOXLITE_API_KEY</span> from the environment, creates
-        a Box, runs a command inside it, prints the output, then removes the Box.
-      </>
-    )
-
   const apiKeyPermissions = useMemo(() => {
     if (!canCreateApiKey) return []
     const permissions: CreateApiKeyPermissionsEnum[] = [CreateApiKeyPermissionsEnum.WRITE_BOXES]
@@ -228,7 +221,12 @@ export function OnboardingGuideDialog({ open, onOpenChange, onProgressChange }: 
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="flex max-h-[88vh] flex-col gap-0 overflow-hidden p-0 font-mono sm:max-w-[620px]">
+      <DialogContent
+        className={cn(
+          'flex max-h-[88vh] flex-col gap-0 overflow-hidden p-0 font-mono sm:max-w-[860px]',
+          scenario !== null && step === 2 && 'h-[88vh]',
+        )}
+      >
         {scenario === null ? (
           <>
             <DialogHeader className="shrink-0 px-5 pb-2 pt-[18px]">
@@ -237,7 +235,7 @@ export function OnboardingGuideDialog({ open, onOpenChange, onProgressChange }: 
                 {SCENARIOS.length} scenario{SCENARIOS.length === 1 ? '' : 's'} available
               </DialogDescription>
             </DialogHeader>
-            <div className="min-h-0 flex-1 overflow-y-auto border-t border-border px-5 pb-3 pt-[24px] scrollbar-thin scrollbar-thumb-border scrollbar-track-transparent">
+            <div className="scrollbar-elevated min-h-0 flex-1 overflow-y-auto border-t border-border px-5 pb-3 pt-[24px]">
               <div className="grid grid-cols-2 gap-[20px]">
                 {SCENARIOS.map((sc) => (
                   <button
@@ -347,7 +345,12 @@ export function OnboardingGuideDialog({ open, onOpenChange, onProgressChange }: 
             </div>
 
             {/* body */}
-            <div className="min-h-0 flex-1 overflow-y-auto border-t border-border scrollbar-thin scrollbar-thumb-border scrollbar-track-transparent">
+            <div
+              className={cn(
+                'scrollbar-elevated min-h-0 flex-1 border-t border-border',
+                step === 2 ? 'overflow-hidden' : 'overflow-y-auto',
+              )}
+            >
               {step === 0 && (
                 <div className="px-5 py-[18px]" style={{ animation: 'stat-in .25s ease' }}>
                   <div className="mb-[9px] text-[9px] uppercase tracking-[1.5px] text-muted-foreground">
@@ -430,15 +433,14 @@ export function OnboardingGuideDialog({ open, onOpenChange, onProgressChange }: 
               {step === 1 && (
                 <div className="px-5 py-[18px]" style={{ animation: 'stat-in .25s ease' }}>
                   <div className="mb-[14px] grid grid-cols-2 gap-2 sm:grid-cols-4">
-                    {LANGS.map((l) => {
-                      const on = language === l.value
-                      const Icon = l.Icon
+                    {QUICKSTART_INTERFACES.map((item) => {
+                      const on = language === item.id
                       return (
                         <button
-                          key={l.value}
+                          key={item.id}
                           type="button"
-                          aria-label={l.ariaLabel}
-                          onClick={() => setLanguage(l.value)}
+                          aria-label={item.ariaLabel}
+                          onClick={() => setLanguage(item.id)}
                           className={cn(
                             'flex min-h-[34px] items-center justify-center gap-2 border px-[10px] py-[7px] text-[12px] transition-colors',
                             on
@@ -446,19 +448,8 @@ export function OnboardingGuideDialog({ open, onOpenChange, onProgressChange }: 
                               : 'border-border text-muted-foreground hover:border-brand/70 hover:text-foreground',
                           )}
                         >
-                          {l.iconSrc ? (
-                            <img src={l.iconSrc} alt="" className="size-3.5" />
-                          ) : Icon ? (
-                            <Icon className="size-3.5" />
-                          ) : (
-                            <span
-                              aria-hidden="true"
-                              className="flex size-3.5 items-center justify-center border border-current text-[9px] leading-none"
-                            >
-                              {l.badge}
-                            </span>
-                          )}
-                          {l.label}
+                          <QuickstartInterfaceIcon item={item} />
+                          {item.label}
                         </button>
                       )
                     })}
@@ -468,7 +459,7 @@ export function OnboardingGuideDialog({ open, onOpenChange, onProgressChange }: 
                   </div>
                   <div className="flex items-start gap-3 border border-border bg-[hsl(var(--code-background))] px-[14px] py-3">
                     <span className="flex-none pt-[1px] text-success">$</span>
-                    <pre className="min-w-0 flex-1 whitespace-pre-wrap break-words text-[13px] leading-relaxed text-foreground">
+                    <pre className="scrollbar-elevated min-w-0 flex-1 overflow-x-auto whitespace-pre text-[13px] leading-relaxed text-foreground">
                       {activeExample.install}
                     </pre>
                     <button
@@ -505,17 +496,16 @@ export function OnboardingGuideDialog({ open, onOpenChange, onProgressChange }: 
               )}
 
               {step === 2 && (
-                <div className="px-5 py-[18px]" style={{ animation: 'stat-in .25s ease' }}>
+                <div className="flex h-full min-h-0 flex-col px-5 py-[18px]" style={{ animation: 'stat-in .25s ease' }}>
                   <div className="mb-[14px] grid grid-cols-2 gap-2 sm:grid-cols-4">
-                    {LANGS.map((l) => {
-                      const on = language === l.value
-                      const Icon = l.Icon
+                    {QUICKSTART_INTERFACES.map((item) => {
+                      const on = language === item.id
                       return (
                         <button
-                          key={l.value}
+                          key={item.id}
                           type="button"
-                          aria-label={l.ariaLabel}
-                          onClick={() => setLanguage(l.value)}
+                          aria-label={item.ariaLabel}
+                          onClick={() => setLanguage(item.id)}
                           className={cn(
                             'flex min-h-[34px] items-center justify-center gap-2 border px-[10px] py-[7px] text-[12px] transition-colors',
                             on
@@ -523,19 +513,8 @@ export function OnboardingGuideDialog({ open, onOpenChange, onProgressChange }: 
                               : 'border-border text-muted-foreground hover:border-brand/70 hover:text-foreground',
                           )}
                         >
-                          {l.iconSrc ? (
-                            <img src={l.iconSrc} alt="" className="size-3.5" />
-                          ) : Icon ? (
-                            <Icon className="size-3.5" />
-                          ) : (
-                            <span
-                              aria-hidden="true"
-                              className="flex size-3.5 items-center justify-center border border-current text-[9px] leading-none"
-                            >
-                              {l.badge}
-                            </span>
-                          )}
-                          {l.label}
+                          <QuickstartInterfaceIcon item={item} />
+                          {item.label}
                         </button>
                       )
                     })}
@@ -543,25 +522,28 @@ export function OnboardingGuideDialog({ open, onOpenChange, onProgressChange }: 
                   <div className="mb-[9px] text-[9px] uppercase tracking-[1.5px] text-muted-foreground">
                     Run this from your local machine
                   </div>
-                  <Suspense
-                    fallback={
-                      <pre className="overflow-auto whitespace-pre-wrap break-words rounded-none p-3 text-[11.5px] leading-relaxed">
-                        {renderedExample}
-                      </pre>
-                    }
-                  >
-                    <CodeBlock
-                      code={renderedExample}
-                      language={activeExample.codeLanguage}
-                      showCopy
-                      className="rounded-none"
-                      codeAreaClassName="whitespace-pre-wrap break-words text-[11.5px] leading-relaxed"
-                    />
-                  </Suspense>
+                  <div className="min-h-0 flex-1">
+                    <Suspense
+                      fallback={
+                        <pre className="scrollbar-elevated h-full overflow-auto whitespace-pre rounded-none p-3 text-[11.5px] leading-relaxed">
+                          {renderedExample}
+                        </pre>
+                      }
+                    >
+                      <CodeBlock
+                        code={renderedExample}
+                        language={activeExample.codeLanguage}
+                        showCopy
+                        className="h-full rounded-none"
+                        codeAreaClassName="h-full overflow-auto whitespace-pre text-[11.5px] leading-relaxed"
+                      />
+                    </Suspense>
+                  </div>
                   <div className="mt-[12px] flex items-start gap-2 text-[11.5px] leading-relaxed text-muted-foreground">
                     <span className="flex-none text-brand">ⓘ</span>
                     <span>
-                      {executionDescription} Run it in your terminal with the install command from the previous step.
+                      {activeExample.executionDescription} Run it in your terminal with the install command from the
+                      previous step.
                     </span>
                   </div>
                   <div className="mt-4 flex items-center justify-end">

--- a/apps/dashboard/src/components/OnboardingGuideDialog.tsx
+++ b/apps/dashboard/src/components/OnboardingGuideDialog.tsx
@@ -8,6 +8,7 @@ import goIcon from '@/assets/go.svg'
 import pythonIcon from '@/assets/python.svg'
 import rustIcon from '@/assets/rust.svg'
 import typescriptIcon from '@/assets/typescript.svg'
+import { CopyButton } from '@/components/CopyButton'
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { KeyRound, Server, Terminal } from '@/components/ui/icon'
 import { useApi } from '@/hooks/useApi'
@@ -110,7 +111,7 @@ function PrimaryBtn({ children, onClick }: { children: React.ReactNode; onClick:
   )
 }
 
-type CopyTarget = 'api-key' | 'install'
+type CopyTarget = 'install'
 
 export function OnboardingGuideDialog({ open, onOpenChange, onProgressChange }: OnboardingGuideDialogProps) {
   const { apiKeyApi } = useApi()
@@ -378,18 +379,11 @@ export function OnboardingGuideDialog({ open, onOpenChange, onProgressChange }: 
                       />
                     )}
                     {createdKey ? (
-                      <button
-                        type="button"
-                        onClick={() => copyText(createdKey.value, 'api-key')}
-                        className={cn(
-                          'flex-none border px-[11px] py-[6px] text-[10px] uppercase tracking-[1px] transition-colors',
-                          copiedTarget === 'api-key'
-                            ? 'border-success text-success'
-                            : 'border-border text-muted-foreground hover:text-foreground',
-                        )}
-                      >
-                        {copiedTarget === 'api-key' ? '✓ Copied' : 'Copy'}
-                      </button>
+                      <CopyButton
+                        value={createdKey.value}
+                        variant="ghost"
+                        className="flex-none bg-background/80 p-2 text-muted-foreground shadow-sm ring-1 ring-border/70 backdrop-blur hover:bg-muted hover:text-foreground"
+                      />
                     ) : null}
                   </div>
                   {!createdKey && (

--- a/apps/dashboard/src/index.css
+++ b/apps/dashboard/src/index.css
@@ -294,8 +294,79 @@ body {
   }
 }
 
+* {
+  scrollbar-width: thin;
+  scrollbar-color: hsl(var(--muted-foreground) / 0.28) transparent;
+}
+
+*::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+*::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+*::-webkit-scrollbar-thumb {
+  min-height: 36px;
+  border: 3px solid transparent;
+  border-radius: 999px;
+  background-color: hsl(var(--muted-foreground) / 0.24);
+  background-clip: content-box;
+}
+
+*::-webkit-scrollbar-thumb:hover {
+  background-color: hsl(var(--muted-foreground) / 0.42);
+}
+
+*::-webkit-scrollbar-corner {
+  background: transparent;
+}
+
+.scrollbar-elevated {
+  scrollbar-gutter: stable;
+  scrollbar-color: hsl(var(--muted-foreground) / 0.36) transparent;
+}
+
+.scrollbar-elevated::-webkit-scrollbar-thumb {
+  border-width: 3px;
+  background-color: hsl(var(--muted-foreground) / 0.3);
+}
+
+.scrollbar-elevated::-webkit-scrollbar-thumb:hover {
+  background-color: hsl(var(--brand) / 0.55);
+}
+
+.scrollbar-thin,
 .scrollbar-sm {
-  @apply scrollbar-thin scrollbar-thumb-neutral-300 dark:scrollbar-thumb-neutral-700 scrollbar-track-background;
+  scrollbar-width: thin;
+  scrollbar-color: hsl(var(--muted-foreground) / 0.28) transparent;
+}
+
+.scrollbar-thin::-webkit-scrollbar,
+.scrollbar-sm::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+.scrollbar-thumb-border::-webkit-scrollbar-thumb,
+.scrollbar-sm::-webkit-scrollbar-thumb {
+  border: 3px solid transparent;
+  border-radius: 999px;
+  background-color: hsl(var(--muted-foreground) / 0.24);
+  background-clip: content-box;
+}
+
+.scrollbar-thumb-border::-webkit-scrollbar-thumb:hover,
+.scrollbar-sm::-webkit-scrollbar-thumb:hover {
+  background-color: hsl(var(--muted-foreground) / 0.42);
+}
+
+.scrollbar-track-background::-webkit-scrollbar-track,
+.scrollbar-track-transparent::-webkit-scrollbar-track,
+.scrollbar-sm::-webkit-scrollbar-track {
+  background: transparent;
 }
 
 @keyframes skeleton-shimmer {

--- a/apps/dashboard/src/lib/environment.test.ts
+++ b/apps/dashboard/src/lib/environment.test.ts
@@ -9,6 +9,12 @@ describe('resolveEnvironment', () => {
     expect(resolveEnvironment('app.boxlite.ai')).toBe('production')
   })
 
+  it('uses the OIDC issuer before the browser hostname', () => {
+    expect(resolveEnvironment('localhost', 'https://auth.dev.boxlite.ai')).toBe('development')
+    expect(resolveEnvironment('localhost', 'https://auth.boxlite.ai')).toBe('production')
+    expect(resolveEnvironment('localhost', 'http://localhost:25556/dex')).toBe('local')
+  })
+
   it('defaults unrecognised hosts to production', () => {
     expect(resolveEnvironment('something.example.com')).toBe('production')
   })
@@ -20,6 +26,8 @@ describe('getRestApiUrl', () => {
   it('uses a pinned URL for environments that define one', () => {
     expect(getRestApiUrl(fallback, 'dev.boxlite.ai')).toBe('https://dev.boxlite.ai/api')
     expect(getRestApiUrl(fallback, 'app.boxlite.ai')).toBe('https://api.boxlite.ai/api')
+    expect(getRestApiUrl(fallback, 'localhost', 'https://auth.dev.boxlite.ai')).toBe('https://dev.boxlite.ai/api')
+    expect(getRestApiUrl(fallback, 'localhost', 'https://auth.boxlite.ai')).toBe('https://api.boxlite.ai/api')
   })
 
   it('falls back when the environment has no pinned URL (e.g. local)', () => {

--- a/apps/dashboard/src/lib/environment.ts
+++ b/apps/dashboard/src/lib/environment.ts
@@ -11,10 +11,11 @@
  * without a backend change. The long-term fix is to read a server-provided
  * `restApiUrl` from /api/config; until then this file is the single place to edit.
  *
- * Detection uses the hostname, NOT `config.environment`: the dev stage reports
- * `environment: "production"` (it's a production *build* of the dev stage), so
- * that field cannot tell dev from prod. The hostname is the reliable signal.
- * URLs below were verified against the live /api/config endpoints.
+ * Detection uses the OIDC issuer first, then the hostname. `config.environment`
+ * cannot distinguish dev from prod because the dev stage reports
+ * `environment: "production"` (it's a production build of the dev stage). The
+ * issuer keeps local dashboard + dev/prod API proxy runs honest, where the
+ * browser hostname is just `localhost`.
  */
 export type AppEnvironment = 'local' | 'development' | 'production'
 
@@ -25,16 +26,21 @@ const REST_API_URL_BY_ENV: Partial<Record<AppEnvironment, string>> = {
   production: 'https://api.boxlite.ai/api',
 }
 
-/** Resolve the current environment from the hostname. */
+/** Resolve the current environment from the API issuer and browser hostname. */
 export function resolveEnvironment(
   hostname: string = typeof window !== 'undefined' ? window.location.hostname : '',
+  oidcIssuer = '',
 ): AppEnvironment {
+  const issuer = oidcIssuer.toLowerCase()
+  if (issuer.includes('auth.dev.boxlite.ai') || issuer.includes('.dev.')) return 'development'
+  if (issuer.includes('auth.boxlite.ai')) return 'production'
+
   if (hostname === 'localhost' || hostname === '127.0.0.1') return 'local'
   if (hostname === 'dev.boxlite.ai' || hostname.includes('.dev.')) return 'development'
   return 'production'
 }
 
 /** The public REST API URL to show in SDK/CLI snippets for the current environment. */
-export function getRestApiUrl(fallback: string, hostname?: string): string {
-  return REST_API_URL_BY_ENV[resolveEnvironment(hostname)] ?? fallback
+export function getRestApiUrl(fallback: string, hostname?: string, oidcIssuer?: string): string {
+  return REST_API_URL_BY_ENV[resolveEnvironment(hostname, oidcIssuer)] ?? fallback
 }

--- a/apps/dashboard/src/lib/onboarding-code-examples.test.ts
+++ b/apps/dashboard/src/lib/onboarding-code-examples.test.ts
@@ -37,13 +37,28 @@ describe('onboarding code examples', () => {
     expect(examples.c.example).toContain('boxlite_box_exec')
     expect(examples.c.example).toContain('boxlite_remove')
 
-    expect(examples.cli.example).toContain('boxlite run --rm --name sdk-quickstart')
+    expect(examples.cli.example).toContain('boxlite run --rm --name "sdk-quickstart-cli-$(date +%s)"')
     expect(examples.cli.example).toContain('echo "Hello from BoxLite CLI"')
+    expect(examples.cli.example).toContain('Paste your BoxLite API key from Step 1')
 
+    expect(examples.rest.example).toContain('Paste your BoxLite API key from Step 1')
+    expect(examples.rest.example).toContain('name="sdk-quickstart-rest-$(date +%s)"')
+    expect(examples.rest.example).not.toContain('"name":"sdk-quickstart"')
     expect(examples.rest.example).toContain('${BOXLITE_REST_URL}/v1/boxes')
     expect(examples.rest.example).toContain('/start')
     expect(examples.rest.example).toContain('/exec')
     expect(examples.rest.example).toContain('/executions/${exec_id}')
     expect(examples.rest.example).toContain('-X DELETE')
+  })
+
+  it('keeps REST setup focused on required local tools', () => {
+    const examples = getOnboardingCodeExamples()
+
+    expect(examples.rest.install).toBe(`command -v curl
+command -v jq`)
+    expect(examples.rest.install).not.toContain('box.openapi.yaml')
+    expect(examples.rest.setupLabel).toBe('Check REST tools')
+    expect(examples.rest.setupDescription).toContain('REST does not require an SDK install')
+    expect(examples.rest.setupDescription).toContain('OpenAPI is available')
   })
 })

--- a/apps/dashboard/src/lib/onboarding-code-examples.test.ts
+++ b/apps/dashboard/src/lib/onboarding-code-examples.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { getOnboardingCodeExamples } from './onboarding-code-examples'
+import {
+  getOnboardingCodeExamples,
+  renderOnboardingCodeExample,
+  type OnboardingInterface,
+} from './onboarding-code-examples'
 
 describe('onboarding code examples', () => {
   it('includes SDK, CLI, and REST entrypoints', () => {
@@ -35,7 +39,20 @@ describe('onboarding code examples', () => {
     expect(examples.c.example).toContain('boxlite_create_box')
     expect(examples.c.example).toContain('boxlite_start_box')
     expect(examples.c.example).toContain('boxlite_box_exec')
+    expect(examples.c.example).toContain('pthread_create')
+    expect(examples.c.example).toContain('boxlite_runtime_drain(loop->runtime, 100')
+    expect(examples.c.example).not.toContain('boxlite_runtime_drain(qs->runtime, -1')
+    expect(examples.c.example).toContain('boxlite_execution_stdin_close')
     expect(examples.c.example).toContain('boxlite_remove')
+    expect(examples.c.example).not.toContain('boxlite_options_free(box_options)')
+    expect(examples.c.run).toContain('-pthread')
+
+    expect(examples.python.example).toContain('sdk-quickstart-python-')
+    expect(examples.typescript.example).toContain('sdk-quickstart-node-')
+    expect(examples.go.example).toContain('sdk-quickstart-go-')
+    expect(examples.rust.example).toContain('sdk-quickstart-rust-')
+    expect(examples.rust.example).toContain('let mut exec =')
+    expect(examples.c.example).toContain('sdk-quickstart-c-')
 
     expect(examples.cli.example).toContain('boxlite run --rm --name "sdk-quickstart-cli-$(date +%s)"')
     expect(examples.cli.example).toContain('echo "Hello from BoxLite CLI"')
@@ -60,5 +77,23 @@ command -v jq`)
     expect(examples.rest.setupLabel).toBe('Check REST tools')
     expect(examples.rest.setupDescription).toContain('REST does not require an SDK install')
     expect(examples.rest.setupDescription).toContain('OpenAPI is available')
+  })
+
+  it('injects the generated API key into rendered quickstart examples', () => {
+    const apiKey = 'blk_test_generated_key'
+    const interfaces: OnboardingInterface[] = ['python', 'typescript', 'go', 'rust', 'c', 'cli', 'rest']
+
+    for (const selectedInterface of interfaces) {
+      expect(
+        renderOnboardingCodeExample(selectedInterface, { apiKey, restApiUrl: 'https://dev.boxlite.ai/api' }),
+      ).toContain(apiKey)
+    }
+
+    expect(renderOnboardingCodeExample('cli', { apiKey, restApiUrl: 'https://dev.boxlite.ai/api' })).not.toContain(
+      'Paste your BoxLite API key from Step 1',
+    )
+    expect(renderOnboardingCodeExample('rest', { apiKey, restApiUrl: 'https://dev.boxlite.ai/api' })).not.toContain(
+      'Paste your BoxLite API key from Step 1',
+    )
   })
 })

--- a/apps/dashboard/src/lib/onboarding-code-examples.test.ts
+++ b/apps/dashboard/src/lib/onboarding-code-examples.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import {
   getOnboardingCodeExamples,
+  getOnboardingInterfaces,
   renderOnboardingCodeExample,
-  type OnboardingInterface,
 } from './onboarding-code-examples'
 
 describe('onboarding code examples', () => {
@@ -10,6 +10,24 @@ describe('onboarding code examples', () => {
     const examples = getOnboardingCodeExamples()
 
     expect(Object.keys(examples).sort()).toEqual(['c', 'cli', 'go', 'python', 'rest', 'rust', 'typescript'])
+  })
+
+  it('is driven by registry entries that all render templates', () => {
+    const interfaces = getOnboardingInterfaces()
+    const examples = getOnboardingCodeExamples()
+
+    expect(interfaces.map((item) => item.id)).toEqual(['python', 'typescript', 'go', 'rust', 'c', 'cli', 'rest'])
+
+    for (const item of interfaces) {
+      const example = examples[item.id]
+      expect(example).toBeDefined()
+      expect(example.id).toBe(item.id)
+      expect(example.label).toBe(item.label)
+      expect(example.install).not.toContain('{{')
+      expect(example.run).not.toContain('{{')
+      expect(example.example).not.toContain('{{')
+      expect(example.executionDescription.length).toBeGreaterThan(20)
+    }
   })
 
   it('reads API keys from environment variables instead of interactive prompts', () => {
@@ -81,7 +99,7 @@ command -v jq`)
 
   it('injects the generated API key into rendered quickstart examples', () => {
     const apiKey = 'blk_test_generated_key'
-    const interfaces: OnboardingInterface[] = ['python', 'typescript', 'go', 'rust', 'c', 'cli', 'rest']
+    const interfaces = getOnboardingInterfaces().map((item) => item.id)
 
     for (const selectedInterface of interfaces) {
       expect(

--- a/apps/dashboard/src/lib/onboarding-code-examples.test.ts
+++ b/apps/dashboard/src/lib/onboarding-code-examples.test.ts
@@ -2,6 +2,12 @@ import { describe, expect, it } from 'vitest'
 import { getOnboardingCodeExamples } from './onboarding-code-examples'
 
 describe('onboarding code examples', () => {
+  it('includes SDK, CLI, and REST entrypoints', () => {
+    const examples = getOnboardingCodeExamples()
+
+    expect(Object.keys(examples).sort()).toEqual(['c', 'cli', 'go', 'python', 'rest', 'rust', 'typescript'])
+  })
+
   it('reads API keys from environment variables instead of interactive prompts', () => {
     const examples = getOnboardingCodeExamples()
 
@@ -20,5 +26,24 @@ describe('onboarding code examples', () => {
     expect(examples.rust.example).toContain('std::env::var("BOXLITE_API_KEY")')
     expect(examples.rust.example).not.toContain('stdin()')
     expect(examples.rust.example).not.toContain('read_line')
+  })
+
+  it('executes code in a box for the added entrypoints', () => {
+    const examples = getOnboardingCodeExamples()
+
+    expect(examples.c.example).toContain('getenv("BOXLITE_API_KEY")')
+    expect(examples.c.example).toContain('boxlite_create_box')
+    expect(examples.c.example).toContain('boxlite_start_box')
+    expect(examples.c.example).toContain('boxlite_box_exec')
+    expect(examples.c.example).toContain('boxlite_remove')
+
+    expect(examples.cli.example).toContain('boxlite run --rm --name sdk-quickstart')
+    expect(examples.cli.example).toContain('echo "Hello from BoxLite CLI"')
+
+    expect(examples.rest.example).toContain('${BOXLITE_REST_URL}/v1/boxes')
+    expect(examples.rest.example).toContain('/start')
+    expect(examples.rest.example).toContain('/exec')
+    expect(examples.rest.example).toContain('/executions/${exec_id}')
+    expect(examples.rest.example).toContain('-X DELETE')
   })
 })

--- a/apps/dashboard/src/lib/onboarding-code-examples.ts
+++ b/apps/dashboard/src/lib/onboarding-code-examples.ts
@@ -9,6 +9,19 @@ export interface OnboardingCodeExample {
   setupDescription?: string
 }
 
+interface RenderOnboardingCodeExampleOptions {
+  apiKey?: string
+  restApiUrl: string
+}
+
+function doubleQuoted(value: string): string {
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n')}"`
+}
+
+function shellSingleQuoted(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`
+}
+
 const codeExamples: Record<OnboardingInterface, OnboardingCodeExample> = {
   typescript: {
     install: 'npm install @boxlite-ai/boxlite tsx',
@@ -26,7 +39,8 @@ const rt = JsBoxlite.rest(new BoxliteRestOptions({
   credential: new ApiKeyCredential(apiKey),
 }))
 
-const box = await rt.create({ image: 'ghcr.io/boxlite-ai/boxlite-agent-base:20260605-p0-r3' }, 'sdk-quickstart')
+const boxName = \`sdk-quickstart-node-\${Date.now()}\`
+const box = await rt.create({ image: 'ghcr.io/boxlite-ai/boxlite-agent-base:20260605-p0-r3' }, boxName)
 await box.start()
 
 const exec = await box.exec('echo', ['Hello from BoxLite SDK'])
@@ -48,6 +62,7 @@ await rt.remove(box.id, true)`,
     codeLanguage: 'python',
     example: `import asyncio
 import os
+import time
 from boxlite import ApiKeyCredential, Boxlite, BoxliteRestOptions, BoxOptions
 
 async def main():
@@ -56,7 +71,8 @@ async def main():
         credential=ApiKeyCredential(os.environ["BOXLITE_API_KEY"]),
     ))
 
-    box = await rt.create(BoxOptions(image="ghcr.io/boxlite-ai/boxlite-agent-base:20260605-p0-r3"), name="sdk-quickstart")
+    box_name = f"sdk-quickstart-python-{int(time.time())}"
+    box = await rt.create(BoxOptions(image="ghcr.io/boxlite-ai/boxlite-agent-base:20260605-p0-r3"), name=box_name)
     await box.start()
 
     execution = await box.exec("echo", args=["Hello from BoxLite SDK"])
@@ -80,8 +96,10 @@ go run github.com/boxlite-ai/boxlite/sdks/go/cmd/setup`,
 
 import (
     "context"
+    "fmt"
     "log"
     "os"
+    "time"
 
     boxlite "github.com/boxlite-ai/boxlite/sdks/go"
 )
@@ -107,7 +125,8 @@ func main() {
     }
     defer rt.Close()
 
-    box, err := rt.Create(ctx, "ghcr.io/boxlite-ai/boxlite-agent-base:20260605-p0-r3", boxlite.WithName("sdk-quickstart"))
+    boxName := fmt.Sprintf("sdk-quickstart-go-%d", time.Now().Unix())
+    box, err := rt.Create(ctx, "ghcr.io/boxlite-ai/boxlite-agent-base:20260605-p0-r3", boxlite.WithName(boxName))
     if err != nil {
         log.Fatal(err)
     }
@@ -148,10 +167,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         rootfs: RootfsSpec::Image("ghcr.io/boxlite-ai/boxlite-agent-base:20260605-p0-r3".into()),
         ..Default::default()
     };
-    let box_handle = rt.create(options, Some("sdk-quickstart".into())).await?;
+    let suffix = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)?
+        .as_secs();
+    let name = format!("sdk-quickstart-rust-{suffix}");
+    let box_handle = rt.create(options, Some(name)).await?;
     box_handle.start().await?;
 
-    let exec = box_handle
+    let mut exec = box_handle
         .exec(BoxCommand::new("echo").arg("Hello from BoxLite SDK"))
         .await?;
     let mut stdout = exec.stdout().expect("stdout stream should be available");
@@ -174,7 +197,7 @@ PLATFORM=darwin-arm64
 curl -fsSL "https://github.com/boxlite-ai/boxlite/releases/download/\${VERSION}/boxlite-c-\${VERSION}-\${PLATFORM}.tar.gz" \\
   | tar xz
 mv "boxlite-c-\${VERSION}-\${PLATFORM}" boxlite-c-sdk`,
-    run: `cc main.c -Iboxlite-c-sdk/include -Lboxlite-c-sdk/lib -lboxlite \\
+    run: `cc main.c -Iboxlite-c-sdk/include -Lboxlite-c-sdk/lib -lboxlite -pthread \\
   -Wl,-rpath,"$PWD/boxlite-c-sdk/lib" -o quickstart
 BOXLITE_API_KEY=$KEY BOXLITE_REST_URL=your-api-url ./quickstart`,
     codeLanguage: 'c',
@@ -182,18 +205,27 @@ BOXLITE_API_KEY=$KEY BOXLITE_REST_URL=your-api-url ./quickstart`,
     setupDescription:
       'Downloads the prebuilt C header and native library. The next step includes boxlite.h and links libboxlite.',
     example: `#include "boxlite.h"
+#include <pthread.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <time.h>
 
 typedef struct {
     CBoxliteRuntime *runtime;
     CBoxHandle *box;
     CExecutionHandle *exec;
+    pthread_mutex_t mutex;
+    pthread_cond_t cond;
     int done;
     int failed;
     int exit_code;
 } Quickstart;
+
+typedef struct {
+    CBoxliteRuntime *runtime;
+    volatile int stop;
+} DrainLoop;
 
 static int has_error(const CBoxliteError *error) {
     return error && error->code != Ok;
@@ -213,8 +245,42 @@ static void require_ok(BoxliteErrorCode code, const char *op, CBoxliteError *err
     }
 }
 
+static void *drain_loop(void *user_data) {
+    DrainLoop *loop = (DrainLoop *)user_data;
+    CBoxliteError error = {0};
+
+    while (!loop->stop) {
+        if (boxlite_runtime_drain(loop->runtime, 100, &error) < 0) {
+            print_error("drain", &error);
+            error = (CBoxliteError){0};
+        }
+    }
+    return NULL;
+}
+
+static void prepare_wait(Quickstart *qs) {
+    pthread_mutex_lock(&qs->mutex);
+    qs->done = 0;
+    qs->failed = 0;
+    pthread_mutex_unlock(&qs->mutex);
+}
+
+static void wait_until_done(Quickstart *qs) {
+    pthread_mutex_lock(&qs->mutex);
+    while (!qs->done) {
+        pthread_cond_wait(&qs->cond, &qs->mutex);
+    }
+    int failed = qs->failed;
+    pthread_mutex_unlock(&qs->mutex);
+
+    if (failed) {
+        exit(1);
+    }
+}
+
 static void on_create(CBoxHandle *box, CBoxliteError *error, void *user_data) {
     Quickstart *qs = (Quickstart *)user_data;
+    pthread_mutex_lock(&qs->mutex);
     if (has_error(error)) {
         print_error("create box", error);
         qs->failed = 1;
@@ -222,44 +288,38 @@ static void on_create(CBoxHandle *box, CBoxliteError *error, void *user_data) {
         qs->box = box;
     }
     qs->done = 1;
+    pthread_cond_signal(&qs->cond);
+    pthread_mutex_unlock(&qs->mutex);
 }
 
 static void on_done(CBoxliteError *error, void *user_data) {
     Quickstart *qs = (Quickstart *)user_data;
+    pthread_mutex_lock(&qs->mutex);
     if (has_error(error)) {
         print_error("operation", error);
         qs->failed = 1;
     }
     qs->done = 1;
+    pthread_cond_signal(&qs->cond);
+    pthread_mutex_unlock(&qs->mutex);
 }
 
 static void on_wait(int exit_code, CBoxliteError *error, void *user_data) {
     Quickstart *qs = (Quickstart *)user_data;
+    pthread_mutex_lock(&qs->mutex);
     if (has_error(error)) {
         print_error("wait", error);
         qs->failed = 1;
     }
     qs->exit_code = exit_code;
     qs->done = 1;
+    pthread_cond_signal(&qs->cond);
+    pthread_mutex_unlock(&qs->mutex);
 }
 
 static void on_stdout(const uint8_t *data, size_t len, void *user_data) {
     (void)user_data;
     fwrite(data, 1, len, stdout);
-}
-
-static void drain_until_done(Quickstart *qs) {
-    CBoxliteError error = {0};
-    while (!qs->done) {
-        if (boxlite_runtime_drain(qs->runtime, -1, &error) < 0) {
-            print_error("drain", &error);
-            exit(1);
-        }
-    }
-    if (qs->failed) {
-        exit(1);
-    }
-    qs->done = 0;
 }
 
 int main(void) {
@@ -278,43 +338,58 @@ int main(void) {
     CBoxliteRestOptions *rest = NULL;
     CBoxliteOptions *box_options = NULL;
     Quickstart qs = {0};
+    pthread_mutex_init(&qs.mutex, NULL);
+    pthread_cond_init(&qs.cond, NULL);
 
     require_ok(boxlite_api_key_credential_new(api_key, &credential, &error), "credential", &error);
     require_ok(boxlite_rest_options_new(api_url, &rest, &error), "rest options", &error);
     boxlite_rest_options_set_credential(rest, credential);
     require_ok(boxlite_rest_runtime_new_with_options(rest, &qs.runtime, &error), "rest runtime", &error);
+    DrainLoop loop = {.runtime = qs.runtime, .stop = 0};
+    pthread_t drain_thread;
+    pthread_create(&drain_thread, NULL, drain_loop, &loop);
 
     require_ok(
         boxlite_options_new("ghcr.io/boxlite-ai/boxlite-agent-base:20260605-p0-r3", &box_options, &error),
         "box options",
         &error
     );
-    boxlite_options_set_name(box_options, "sdk-quickstart");
+    char box_name[64];
+    snprintf(box_name, sizeof(box_name), "sdk-quickstart-c-%ld", (long)time(NULL));
+    boxlite_options_set_name(box_options, box_name);
+    prepare_wait(&qs);
     require_ok(boxlite_create_box(qs.runtime, box_options, on_create, &qs, &error), "create box", &error);
-    drain_until_done(&qs);
+    wait_until_done(&qs);
 
+    prepare_wait(&qs);
     require_ok(boxlite_start_box(qs.box, on_done, &qs, &error), "start box", &error);
-    drain_until_done(&qs);
+    wait_until_done(&qs);
 
     const char *args[] = {"Hello from BoxLite C SDK"};
     BoxliteCommand cmd = {.command = "echo", .args = args, .argc = 1};
     require_ok(boxlite_box_exec(qs.box, &cmd, &qs.exec, &error), "exec", &error);
     require_ok(boxlite_execution_on_stdout(qs.exec, on_stdout, NULL, &error), "stdout", &error);
+    require_ok(boxlite_execution_stdin_close(qs.exec, &error), "stdin close", &error);
+    prepare_wait(&qs);
     require_ok(boxlite_execution_wait(qs.exec, on_wait, &qs, &error), "wait", &error);
-    drain_until_done(&qs);
+    wait_until_done(&qs);
     printf("Exit code: %d\\n", qs.exit_code);
 
     char *box_id = boxlite_box_id(qs.box);
+    prepare_wait(&qs);
     require_ok(boxlite_remove(qs.runtime, box_id, 1, on_done, &qs, &error), "remove box", &error);
-    drain_until_done(&qs);
+    wait_until_done(&qs);
     boxlite_free_string(box_id);
 
+    loop.stop = 1;
+    pthread_join(drain_thread, NULL);
     boxlite_execution_free(qs.exec);
     boxlite_box_free(qs.box);
-    boxlite_options_free(box_options);
     boxlite_rest_options_free(rest);
     boxlite_credential_free(credential);
     boxlite_runtime_free(qs.runtime);
+    pthread_mutex_destroy(&qs.mutex);
+    pthread_cond_destroy(&qs.cond);
     return qs.exit_code;
 }`,
   },
@@ -388,4 +463,76 @@ curl -fsS "\${BOXLITE_REST_URL}/v1/boxes/\${box_id}/executions/\${exec_id}" "\${
 
 export function getOnboardingCodeExamples(): Record<OnboardingInterface, OnboardingCodeExample> {
   return codeExamples
+}
+
+export function renderOnboardingCodeExample(
+  selectedInterface: OnboardingInterface,
+  options: RenderOnboardingCodeExampleOptions,
+): string {
+  const example = codeExamples[selectedInterface].example.replaceAll('your-api-url', options.restApiUrl)
+  const apiKey = options.apiKey
+  if (!apiKey) {
+    return example
+  }
+
+  const quotedApiKey = doubleQuoted(apiKey)
+  const shellQuotedApiKey = shellSingleQuoted(apiKey)
+  switch (selectedInterface) {
+    case 'typescript':
+      return example.replace(
+        `const apiKey = process.env.BOXLITE_API_KEY
+if (!apiKey) {
+  throw new Error('Set BOXLITE_API_KEY before running this script')
+}`,
+        `const apiKey = ${quotedApiKey}`,
+      )
+    case 'python':
+      return example.replace(
+        'credential=ApiKeyCredential(os.environ["BOXLITE_API_KEY"]),',
+        `credential=ApiKeyCredential(${quotedApiKey}),`,
+      )
+    case 'go':
+      return example.replace(
+        `apiKey := os.Getenv("BOXLITE_API_KEY")
+    if apiKey == "" {
+        log.Fatal("Set BOXLITE_API_KEY before running this program")
+    }`,
+        `apiKey := ${quotedApiKey}`,
+      )
+    case 'rust':
+      return example.replace(
+        'let api_key = std::env::var("BOXLITE_API_KEY")?;',
+        `let api_key = ${quotedApiKey}.to_owned();`,
+      )
+    case 'c':
+      return example.replace(
+        'const char *api_key = getenv("BOXLITE_API_KEY");',
+        `const char *api_key = ${quotedApiKey};`,
+      )
+    case 'cli':
+      return example.replace(
+        `if [ -z "\${BOXLITE_API_KEY:-}" ]; then
+  printf "Paste your BoxLite API key from Step 1: " >&2
+  stty -echo
+  IFS= read -r BOXLITE_API_KEY
+  stty echo
+  printf "\\n" >&2
+fi
+export BOXLITE_API_KEY`,
+        `export BOXLITE_API_KEY=${shellQuotedApiKey}`,
+      )
+    case 'rest':
+      return example.replace(
+        `if [ -z "\${BOXLITE_API_KEY:-}" ]; then
+  printf "Paste your BoxLite API key from Step 1: " >&2
+  stty -echo
+  IFS= read -r BOXLITE_API_KEY
+  stty echo
+  printf "\\n" >&2
+fi
+export BOXLITE_API_KEY`,
+        `BOXLITE_API_KEY=${shellQuotedApiKey}
+export BOXLITE_API_KEY`,
+      )
+  }
 }

--- a/apps/dashboard/src/lib/onboarding-code-examples.ts
+++ b/apps/dashboard/src/lib/onboarding-code-examples.ts
@@ -1,13 +1,15 @@
-export type OnboardingLanguage = 'python' | 'typescript' | 'go' | 'rust'
+export type OnboardingInterface = 'python' | 'typescript' | 'go' | 'rust' | 'c' | 'cli' | 'rest'
 
 export interface OnboardingCodeExample {
   install: string
   run: string
   example: string
   codeLanguage: string
+  setupLabel?: string
+  setupDescription?: string
 }
 
-const codeExamples: Record<OnboardingLanguage, OnboardingCodeExample> = {
+const codeExamples: Record<OnboardingInterface, OnboardingCodeExample> = {
   typescript: {
     install: 'npm install @boxlite-ai/boxlite tsx',
     run: 'BOXLITE_API_KEY=$KEY npx tsx index.mts',
@@ -165,8 +167,212 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }`,
   },
+  c: {
+    install: `VERSION=v0.9.5
+PLATFORM=darwin-arm64
+# Linux: PLATFORM=linux-x64-gnu or linux-arm64-gnu
+curl -fsSL "https://github.com/boxlite-ai/boxlite/releases/download/\${VERSION}/boxlite-c-\${VERSION}-\${PLATFORM}.tar.gz" \\
+  | tar xz
+mv "boxlite-c-\${VERSION}-\${PLATFORM}" boxlite-c-sdk`,
+    run: `cc main.c -Iboxlite-c-sdk/include -Lboxlite-c-sdk/lib -lboxlite \\
+  -Wl,-rpath,"$PWD/boxlite-c-sdk/lib" -o quickstart
+BOXLITE_API_KEY=$KEY BOXLITE_REST_URL=your-api-url ./quickstart`,
+    codeLanguage: 'c',
+    setupLabel: 'Download C SDK',
+    setupDescription:
+      'Downloads the prebuilt C header and native library. The next step includes boxlite.h and links libboxlite.',
+    example: `#include "boxlite.h"
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+typedef struct {
+    CBoxliteRuntime *runtime;
+    CBoxHandle *box;
+    CExecutionHandle *exec;
+    int done;
+    int failed;
+    int exit_code;
+} Quickstart;
+
+static int has_error(const CBoxliteError *error) {
+    return error && error->code != Ok;
 }
 
-export function getOnboardingCodeExamples(): Record<OnboardingLanguage, OnboardingCodeExample> {
+static void print_error(const char *op, CBoxliteError *error) {
+    fprintf(stderr, "%s failed: %s\\n", op, error && error->message ? error->message : "unknown");
+    if (error) {
+        boxlite_error_free(error);
+    }
+}
+
+static void require_ok(BoxliteErrorCode code, const char *op, CBoxliteError *error) {
+    if (code != Ok) {
+        print_error(op, error);
+        exit(1);
+    }
+}
+
+static void on_create(CBoxHandle *box, CBoxliteError *error, void *user_data) {
+    Quickstart *qs = (Quickstart *)user_data;
+    if (has_error(error)) {
+        print_error("create box", error);
+        qs->failed = 1;
+    } else {
+        qs->box = box;
+    }
+    qs->done = 1;
+}
+
+static void on_done(CBoxliteError *error, void *user_data) {
+    Quickstart *qs = (Quickstart *)user_data;
+    if (has_error(error)) {
+        print_error("operation", error);
+        qs->failed = 1;
+    }
+    qs->done = 1;
+}
+
+static void on_wait(int exit_code, CBoxliteError *error, void *user_data) {
+    Quickstart *qs = (Quickstart *)user_data;
+    if (has_error(error)) {
+        print_error("wait", error);
+        qs->failed = 1;
+    }
+    qs->exit_code = exit_code;
+    qs->done = 1;
+}
+
+static void on_stdout(const uint8_t *data, size_t len, void *user_data) {
+    (void)user_data;
+    fwrite(data, 1, len, stdout);
+}
+
+static void drain_until_done(Quickstart *qs) {
+    CBoxliteError error = {0};
+    while (!qs->done) {
+        if (boxlite_runtime_drain(qs->runtime, -1, &error) < 0) {
+            print_error("drain", &error);
+            exit(1);
+        }
+    }
+    if (qs->failed) {
+        exit(1);
+    }
+    qs->done = 0;
+}
+
+int main(void) {
+    const char *api_key = getenv("BOXLITE_API_KEY");
+    const char *api_url = getenv("BOXLITE_REST_URL");
+    if (!api_key) {
+        fprintf(stderr, "Set BOXLITE_API_KEY before running this program\\n");
+        return 1;
+    }
+    if (!api_url) {
+        api_url = "your-api-url";
+    }
+
+    CBoxliteError error = {0};
+    CBoxliteCredential *credential = NULL;
+    CBoxliteRestOptions *rest = NULL;
+    CBoxliteOptions *box_options = NULL;
+    Quickstart qs = {0};
+
+    require_ok(boxlite_api_key_credential_new(api_key, &credential, &error), "credential", &error);
+    require_ok(boxlite_rest_options_new(api_url, &rest, &error), "rest options", &error);
+    boxlite_rest_options_set_credential(rest, credential);
+    require_ok(boxlite_rest_runtime_new_with_options(rest, &qs.runtime, &error), "rest runtime", &error);
+
+    require_ok(
+        boxlite_options_new("ghcr.io/boxlite-ai/boxlite-agent-base:20260605-p0-r3", &box_options, &error),
+        "box options",
+        &error
+    );
+    boxlite_options_set_name(box_options, "sdk-quickstart");
+    require_ok(boxlite_create_box(qs.runtime, box_options, on_create, &qs, &error), "create box", &error);
+    drain_until_done(&qs);
+
+    require_ok(boxlite_start_box(qs.box, on_done, &qs, &error), "start box", &error);
+    drain_until_done(&qs);
+
+    const char *args[] = {"Hello from BoxLite C SDK"};
+    BoxliteCommand cmd = {.command = "echo", .args = args, .argc = 1};
+    require_ok(boxlite_box_exec(qs.box, &cmd, &qs.exec, &error), "exec", &error);
+    require_ok(boxlite_execution_on_stdout(qs.exec, on_stdout, NULL, &error), "stdout", &error);
+    require_ok(boxlite_execution_wait(qs.exec, on_wait, &qs, &error), "wait", &error);
+    drain_until_done(&qs);
+    printf("Exit code: %d\\n", qs.exit_code);
+
+    char *box_id = boxlite_box_id(qs.box);
+    require_ok(boxlite_remove(qs.runtime, box_id, 1, on_done, &qs, &error), "remove box", &error);
+    drain_until_done(&qs);
+    boxlite_free_string(box_id);
+
+    boxlite_execution_free(qs.exec);
+    boxlite_box_free(qs.box);
+    boxlite_options_free(box_options);
+    boxlite_rest_options_free(rest);
+    boxlite_credential_free(credential);
+    boxlite_runtime_free(qs.runtime);
+    return qs.exit_code;
+}`,
+  },
+  cli: {
+    install: 'curl -fsSL https://sh.boxlite.ai | sh',
+    run: `BOXLITE_API_KEY=$KEY BOXLITE_REST_URL=your-api-url boxlite run --rm --name sdk-quickstart \\
+  ghcr.io/boxlite-ai/boxlite-agent-base:20260605-p0-r3 \\
+  echo "Hello from BoxLite CLI"`,
+    codeLanguage: 'bash',
+    setupLabel: 'Install CLI',
+    setupDescription:
+      'Installs the boxlite command. The next step uses it directly with BOXLITE_API_KEY and BOXLITE_REST_URL.',
+    example: `export BOXLITE_API_KEY="\${BOXLITE_API_KEY:?Set BOXLITE_API_KEY}"
+export BOXLITE_REST_URL="your-api-url"
+
+boxlite run --rm --name sdk-quickstart \\
+  ghcr.io/boxlite-ai/boxlite-agent-base:20260605-p0-r3 \\
+  echo "Hello from BoxLite CLI"`,
+  },
+  rest: {
+    install: `command -v curl
+command -v jq
+curl -fsSL https://raw.githubusercontent.com/boxlite-ai/boxlite/main/openapi/box.openapi.yaml \\
+  -o boxlite.openapi.yaml`,
+    run: 'BOXLITE_API_KEY=$KEY BOXLITE_REST_URL=your-api-url bash quickstart-rest.sh',
+    codeLanguage: 'bash',
+    setupLabel: 'Get API contract',
+    setupDescription:
+      'Downloads the OpenAPI contract for agents and API tools. The next step can use curl, Postman, or a generated client against the documented endpoints.',
+    example: `#!/usr/bin/env bash
+set -euo pipefail
+
+: "\${BOXLITE_API_KEY:?Set BOXLITE_API_KEY}"
+BOXLITE_REST_URL="\${BOXLITE_REST_URL:-your-api-url}"
+auth=(-H "Authorization: Bearer \${BOXLITE_API_KEY}")
+json=(-H "Content-Type: application/json")
+
+box_id="$(
+  curl -fsS -X POST "\${BOXLITE_REST_URL}/v1/boxes" \\
+    "\${auth[@]}" "\${json[@]}" \\
+    -d '{"name":"sdk-quickstart","image":"ghcr.io/boxlite-ai/boxlite-agent-base:20260605-p0-r3"}' \\
+    | jq -r '.box_id'
+)"
+trap 'curl -fsS -X DELETE "\${BOXLITE_REST_URL}/v1/boxes/\${box_id}?force=true" "\${auth[@]}" >/dev/null || true' EXIT
+
+curl -fsS -X POST "\${BOXLITE_REST_URL}/v1/boxes/\${box_id}/start" "\${auth[@]}" >/dev/null
+
+exec_id="$(
+  curl -fsS -X POST "\${BOXLITE_REST_URL}/v1/boxes/\${box_id}/exec" \\
+    "\${auth[@]}" "\${json[@]}" \\
+    -d '{"command":"echo","args":["Hello from BoxLite REST"]}' \\
+    | jq -r '.execution_id'
+)"
+
+curl -fsS "\${BOXLITE_REST_URL}/v1/boxes/\${box_id}/executions/\${exec_id}" "\${auth[@]}" | jq`,
+  },
+}
+
+export function getOnboardingCodeExamples(): Record<OnboardingInterface, OnboardingCodeExample> {
   return codeExamples
 }

--- a/apps/dashboard/src/lib/onboarding-code-examples.ts
+++ b/apps/dashboard/src/lib/onboarding-code-examples.ts
@@ -320,42 +320,55 @@ int main(void) {
   },
   cli: {
     install: 'curl -fsSL https://sh.boxlite.ai | sh',
-    run: `BOXLITE_API_KEY=$KEY BOXLITE_REST_URL=your-api-url boxlite run --rm --name sdk-quickstart \\
+    run: `BOXLITE_API_KEY=$KEY BOXLITE_REST_URL=your-api-url boxlite run --rm --name "sdk-quickstart-cli-$(date +%s)" \\
   ghcr.io/boxlite-ai/boxlite-agent-base:20260605-p0-r3 \\
   echo "Hello from BoxLite CLI"`,
     codeLanguage: 'bash',
     setupLabel: 'Install CLI',
     setupDescription:
       'Installs the boxlite command. The next step uses it directly with BOXLITE_API_KEY and BOXLITE_REST_URL.',
-    example: `export BOXLITE_API_KEY="\${BOXLITE_API_KEY:?Set BOXLITE_API_KEY}"
+    example: `if [ -z "\${BOXLITE_API_KEY:-}" ]; then
+  printf "Paste your BoxLite API key from Step 1: " >&2
+  stty -echo
+  IFS= read -r BOXLITE_API_KEY
+  stty echo
+  printf "\\n" >&2
+fi
+export BOXLITE_API_KEY
 export BOXLITE_REST_URL="your-api-url"
 
-boxlite run --rm --name sdk-quickstart \\
+boxlite run --rm --name "sdk-quickstart-cli-$(date +%s)" \\
   ghcr.io/boxlite-ai/boxlite-agent-base:20260605-p0-r3 \\
   echo "Hello from BoxLite CLI"`,
   },
   rest: {
     install: `command -v curl
-command -v jq
-curl -fsSL https://raw.githubusercontent.com/boxlite-ai/boxlite/main/openapi/box.openapi.yaml \\
-  -o boxlite.openapi.yaml`,
+command -v jq`,
     run: 'BOXLITE_API_KEY=$KEY BOXLITE_REST_URL=your-api-url bash quickstart-rest.sh',
     codeLanguage: 'bash',
-    setupLabel: 'Get API contract',
+    setupLabel: 'Check REST tools',
     setupDescription:
-      'Downloads the OpenAPI contract for agents and API tools. The next step can use curl, Postman, or a generated client against the documented endpoints.',
+      'REST does not require an SDK install. The next step uses curl and jq to create a Box and execute a command. OpenAPI is available for full endpoint reference and generated clients.',
     example: `#!/usr/bin/env bash
 set -euo pipefail
 
-: "\${BOXLITE_API_KEY:?Set BOXLITE_API_KEY}"
+if [ -z "\${BOXLITE_API_KEY:-}" ]; then
+  printf "Paste your BoxLite API key from Step 1: " >&2
+  stty -echo
+  IFS= read -r BOXLITE_API_KEY
+  stty echo
+  printf "\\n" >&2
+fi
+export BOXLITE_API_KEY
 BOXLITE_REST_URL="\${BOXLITE_REST_URL:-your-api-url}"
 auth=(-H "Authorization: Bearer \${BOXLITE_API_KEY}")
 json=(-H "Content-Type: application/json")
+name="sdk-quickstart-rest-$(date +%s)"
 
 box_id="$(
   curl -fsS -X POST "\${BOXLITE_REST_URL}/v1/boxes" \\
     "\${auth[@]}" "\${json[@]}" \\
-    -d '{"name":"sdk-quickstart","image":"ghcr.io/boxlite-ai/boxlite-agent-base:20260605-p0-r3"}' \\
+    -d "{\\"name\\":\\"\${name}\\",\\"image\\":\\"ghcr.io/boxlite-ai/boxlite-agent-base:20260605-p0-r3\\"}" \\
     | jq -r '.box_id'
 )"
 trap 'curl -fsS -X DELETE "\${BOXLITE_REST_URL}/v1/boxes/\${box_id}?force=true" "\${auth[@]}" >/dev/null || true' EXIT

--- a/apps/dashboard/src/lib/onboarding-code-examples.ts
+++ b/apps/dashboard/src/lib/onboarding-code-examples.ts
@@ -1,18 +1,33 @@
-export type OnboardingInterface = 'python' | 'typescript' | 'go' | 'rust' | 'c' | 'cli' | 'rest'
+import definitions from './quickstart/interfaces.json'
+import cTemplate from './quickstart/templates/c.c?raw'
+import cliTemplate from './quickstart/templates/cli.sh?raw'
+import goTemplate from './quickstart/templates/go.go?raw'
+import pythonTemplate from './quickstart/templates/python.py?raw'
+import restTemplate from './quickstart/templates/rest.sh?raw'
+import rustTemplate from './quickstart/templates/rust.rs?raw'
+import typescriptTemplate from './quickstart/templates/typescript.mts?raw'
+import type {
+  OnboardingCodeExample,
+  QuickstartInterfaceDefinition,
+  RenderOnboardingCodeExampleOptions,
+} from './quickstart/types'
 
-export interface OnboardingCodeExample {
-  install: string
-  run: string
-  example: string
-  codeLanguage: string
-  setupLabel?: string
-  setupDescription?: string
+export type OnboardingInterface = string
+export type { OnboardingCodeExample, QuickstartInterfaceDefinition }
+
+type TemplateValues = Record<string, string>
+
+const templateMap: Record<string, string> = {
+  c: cTemplate,
+  cli: cliTemplate,
+  go: goTemplate,
+  python: pythonTemplate,
+  rest: restTemplate,
+  rust: rustTemplate,
+  typescript: typescriptTemplate,
 }
 
-interface RenderOnboardingCodeExampleOptions {
-  apiKey?: string
-  restApiUrl: string
-}
+const quickstartDefinitions = definitions as QuickstartInterfaceDefinition[]
 
 function doubleQuoted(value: string): string {
   return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n')}"`
@@ -22,517 +37,92 @@ function shellSingleQuoted(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`
 }
 
-const codeExamples: Record<OnboardingInterface, OnboardingCodeExample> = {
-  typescript: {
-    install: 'npm install @boxlite-ai/boxlite tsx',
-    run: 'BOXLITE_API_KEY=$KEY npx tsx index.mts',
-    codeLanguage: 'typescript',
-    example: `import { ApiKeyCredential, BoxliteRestOptions, JsBoxlite } from '@boxlite-ai/boxlite'
+function shellApiKeyBlock(apiKey?: string): string {
+  if (apiKey) {
+    return `BOXLITE_API_KEY=${shellSingleQuoted(apiKey)}
+export BOXLITE_API_KEY`
+  }
 
-const apiKey = process.env.BOXLITE_API_KEY
-if (!apiKey) {
-  throw new Error('Set BOXLITE_API_KEY before running this script')
-}
-
-const rt = JsBoxlite.rest(new BoxliteRestOptions({
-  url: process.env.BOXLITE_REST_URL ?? 'your-api-url',
-  credential: new ApiKeyCredential(apiKey),
-}))
-
-const boxName = \`sdk-quickstart-node-\${Date.now()}\`
-const box = await rt.create({ image: 'ghcr.io/boxlite-ai/boxlite-agent-base:20260605-p0-r3' }, boxName)
-await box.start()
-
-const exec = await box.exec('echo', ['Hello from BoxLite SDK'])
-const stdout = await exec.stdout()
-let output = ''
-let chunk: string | null
-while ((chunk = await stdout.next()) !== null) {
-  output += chunk
-}
-const result = await exec.wait()
-console.log('Exit code:', result.exitCode)
-console.log(output)
-
-await rt.remove(box.id, true)`,
-  },
-  python: {
-    install: 'pip install boxlite',
-    run: 'BOXLITE_API_KEY=$KEY python main.py',
-    codeLanguage: 'python',
-    example: `import asyncio
-import os
-import time
-from boxlite import ApiKeyCredential, Boxlite, BoxliteRestOptions, BoxOptions
-
-async def main():
-    rt = Boxlite.rest(BoxliteRestOptions(
-        url=os.environ.get("BOXLITE_REST_URL", "your-api-url"),
-        credential=ApiKeyCredential(os.environ["BOXLITE_API_KEY"]),
-    ))
-
-    box_name = f"sdk-quickstart-python-{int(time.time())}"
-    box = await rt.create(BoxOptions(image="ghcr.io/boxlite-ai/boxlite-agent-base:20260605-p0-r3"), name=box_name)
-    await box.start()
-
-    execution = await box.exec("echo", args=["Hello from BoxLite SDK"])
-    output = ""
-    async for line in execution.stdout():
-        output += line
-    result = await execution.wait()
-    print(f"Exit code: {result.exit_code}")
-    print(output)
-
-    await rt.remove(box.id, force=True)
-
-asyncio.run(main())`,
-  },
-  go: {
-    install: `go get github.com/boxlite-ai/boxlite/sdks/go
-go run github.com/boxlite-ai/boxlite/sdks/go/cmd/setup`,
-    run: 'BOXLITE_API_KEY=$KEY go run .',
-    codeLanguage: 'go',
-    example: `package main
-
-import (
-    "context"
-    "fmt"
-    "log"
-    "os"
-    "time"
-
-    boxlite "github.com/boxlite-ai/boxlite/sdks/go"
-)
-
-func main() {
-    ctx := context.Background()
-    apiKey := os.Getenv("BOXLITE_API_KEY")
-    if apiKey == "" {
-        log.Fatal("Set BOXLITE_API_KEY before running this program")
-    }
-
-    apiURL := os.Getenv("BOXLITE_REST_URL")
-    if apiURL == "" {
-        apiURL = "your-api-url"
-    }
-
-    rt, err := boxlite.NewRest(boxlite.BoxliteRestOptions{
-        URL:        apiURL,
-        Credential: boxlite.NewApiKeyCredential(apiKey),
-    })
-    if err != nil {
-        log.Fatal(err)
-    }
-    defer rt.Close()
-
-    boxName := fmt.Sprintf("sdk-quickstart-go-%d", time.Now().Unix())
-    box, err := rt.Create(ctx, "ghcr.io/boxlite-ai/boxlite-agent-base:20260605-p0-r3", boxlite.WithName(boxName))
-    if err != nil {
-        log.Fatal(err)
-    }
-    if err := box.Start(ctx); err != nil {
-        log.Fatal(err)
-    }
-
-    result, err := box.Exec(ctx, "echo", "Hello from BoxLite SDK")
-    if err != nil {
-        log.Fatal(err)
-    }
-    log.Println("Exit code:", result.ExitCode)
-    log.Print(result.Stdout)
-
-    if err := rt.ForceRemove(ctx, box.ID()); err != nil {
-        log.Fatal(err)
-    }
-}`,
-  },
-  rust: {
-    install: `cargo add boxlite --features rest
-cargo add tokio --features macros,rt-multi-thread
-cargo add futures`,
-    run: 'BOXLITE_API_KEY=$KEY cargo run',
-    codeLanguage: 'rust',
-    example: `use boxlite::{BoxCommand, BoxOptions, BoxliteRestOptions, BoxliteRuntime, RootfsSpec};
-use futures::StreamExt;
-
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let api_key = std::env::var("BOXLITE_API_KEY")?;
-    let api_url = std::env::var("BOXLITE_REST_URL").unwrap_or_else(|_| "your-api-url".to_owned());
-    let rt = BoxliteRuntime::rest(
-        BoxliteRestOptions::new(api_url).with_api_key(api_key),
-    )?;
-
-    let options = BoxOptions {
-        rootfs: RootfsSpec::Image("ghcr.io/boxlite-ai/boxlite-agent-base:20260605-p0-r3".into()),
-        ..Default::default()
-    };
-    let suffix = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)?
-        .as_secs();
-    let name = format!("sdk-quickstart-rust-{suffix}");
-    let box_handle = rt.create(options, Some(name)).await?;
-    box_handle.start().await?;
-
-    let mut exec = box_handle
-        .exec(BoxCommand::new("echo").arg("Hello from BoxLite SDK"))
-        .await?;
-    let mut stdout = exec.stdout().expect("stdout stream should be available");
-    let mut output = String::new();
-    while let Some(line) = stdout.next().await {
-        output.push_str(&line);
-    }
-    let result = exec.wait().await?;
-    println!("Exit code: {}", result.exit_code);
-    print!("{output}");
-
-    rt.remove(&box_handle.id().to_string(), true).await?;
-    Ok(())
-}`,
-  },
-  c: {
-    install: `VERSION=v0.9.5
-PLATFORM=darwin-arm64
-# Linux: PLATFORM=linux-x64-gnu or linux-arm64-gnu
-curl -fsSL "https://github.com/boxlite-ai/boxlite/releases/download/\${VERSION}/boxlite-c-\${VERSION}-\${PLATFORM}.tar.gz" \\
-  | tar xz
-mv "boxlite-c-\${VERSION}-\${PLATFORM}" boxlite-c-sdk`,
-    run: `cc main.c -Iboxlite-c-sdk/include -Lboxlite-c-sdk/lib -lboxlite -pthread \\
-  -Wl,-rpath,"$PWD/boxlite-c-sdk/lib" -o quickstart
-BOXLITE_API_KEY=$KEY BOXLITE_REST_URL=your-api-url ./quickstart`,
-    codeLanguage: 'c',
-    setupLabel: 'Download C SDK',
-    setupDescription:
-      'Downloads the prebuilt C header and native library. The next step includes boxlite.h and links libboxlite.',
-    example: `#include "boxlite.h"
-#include <pthread.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <time.h>
-
-typedef struct {
-    CBoxliteRuntime *runtime;
-    CBoxHandle *box;
-    CExecutionHandle *exec;
-    pthread_mutex_t mutex;
-    pthread_cond_t cond;
-    int done;
-    int failed;
-    int exit_code;
-} Quickstart;
-
-typedef struct {
-    CBoxliteRuntime *runtime;
-    volatile int stop;
-} DrainLoop;
-
-static int has_error(const CBoxliteError *error) {
-    return error && error->code != Ok;
-}
-
-static void print_error(const char *op, CBoxliteError *error) {
-    fprintf(stderr, "%s failed: %s\\n", op, error && error->message ? error->message : "unknown");
-    if (error) {
-        boxlite_error_free(error);
-    }
-}
-
-static void require_ok(BoxliteErrorCode code, const char *op, CBoxliteError *error) {
-    if (code != Ok) {
-        print_error(op, error);
-        exit(1);
-    }
-}
-
-static void *drain_loop(void *user_data) {
-    DrainLoop *loop = (DrainLoop *)user_data;
-    CBoxliteError error = {0};
-
-    while (!loop->stop) {
-        if (boxlite_runtime_drain(loop->runtime, 100, &error) < 0) {
-            print_error("drain", &error);
-            error = (CBoxliteError){0};
-        }
-    }
-    return NULL;
-}
-
-static void prepare_wait(Quickstart *qs) {
-    pthread_mutex_lock(&qs->mutex);
-    qs->done = 0;
-    qs->failed = 0;
-    pthread_mutex_unlock(&qs->mutex);
-}
-
-static void wait_until_done(Quickstart *qs) {
-    pthread_mutex_lock(&qs->mutex);
-    while (!qs->done) {
-        pthread_cond_wait(&qs->cond, &qs->mutex);
-    }
-    int failed = qs->failed;
-    pthread_mutex_unlock(&qs->mutex);
-
-    if (failed) {
-        exit(1);
-    }
-}
-
-static void on_create(CBoxHandle *box, CBoxliteError *error, void *user_data) {
-    Quickstart *qs = (Quickstart *)user_data;
-    pthread_mutex_lock(&qs->mutex);
-    if (has_error(error)) {
-        print_error("create box", error);
-        qs->failed = 1;
-    } else {
-        qs->box = box;
-    }
-    qs->done = 1;
-    pthread_cond_signal(&qs->cond);
-    pthread_mutex_unlock(&qs->mutex);
-}
-
-static void on_done(CBoxliteError *error, void *user_data) {
-    Quickstart *qs = (Quickstart *)user_data;
-    pthread_mutex_lock(&qs->mutex);
-    if (has_error(error)) {
-        print_error("operation", error);
-        qs->failed = 1;
-    }
-    qs->done = 1;
-    pthread_cond_signal(&qs->cond);
-    pthread_mutex_unlock(&qs->mutex);
-}
-
-static void on_wait(int exit_code, CBoxliteError *error, void *user_data) {
-    Quickstart *qs = (Quickstart *)user_data;
-    pthread_mutex_lock(&qs->mutex);
-    if (has_error(error)) {
-        print_error("wait", error);
-        qs->failed = 1;
-    }
-    qs->exit_code = exit_code;
-    qs->done = 1;
-    pthread_cond_signal(&qs->cond);
-    pthread_mutex_unlock(&qs->mutex);
-}
-
-static void on_stdout(const uint8_t *data, size_t len, void *user_data) {
-    (void)user_data;
-    fwrite(data, 1, len, stdout);
-}
-
-int main(void) {
-    const char *api_key = getenv("BOXLITE_API_KEY");
-    const char *api_url = getenv("BOXLITE_REST_URL");
-    if (!api_key) {
-        fprintf(stderr, "Set BOXLITE_API_KEY before running this program\\n");
-        return 1;
-    }
-    if (!api_url) {
-        api_url = "your-api-url";
-    }
-
-    CBoxliteError error = {0};
-    CBoxliteCredential *credential = NULL;
-    CBoxliteRestOptions *rest = NULL;
-    CBoxliteOptions *box_options = NULL;
-    Quickstart qs = {0};
-    pthread_mutex_init(&qs.mutex, NULL);
-    pthread_cond_init(&qs.cond, NULL);
-
-    require_ok(boxlite_api_key_credential_new(api_key, &credential, &error), "credential", &error);
-    require_ok(boxlite_rest_options_new(api_url, &rest, &error), "rest options", &error);
-    boxlite_rest_options_set_credential(rest, credential);
-    require_ok(boxlite_rest_runtime_new_with_options(rest, &qs.runtime, &error), "rest runtime", &error);
-    DrainLoop loop = {.runtime = qs.runtime, .stop = 0};
-    pthread_t drain_thread;
-    pthread_create(&drain_thread, NULL, drain_loop, &loop);
-
-    require_ok(
-        boxlite_options_new("ghcr.io/boxlite-ai/boxlite-agent-base:20260605-p0-r3", &box_options, &error),
-        "box options",
-        &error
-    );
-    char box_name[64];
-    snprintf(box_name, sizeof(box_name), "sdk-quickstart-c-%ld", (long)time(NULL));
-    boxlite_options_set_name(box_options, box_name);
-    prepare_wait(&qs);
-    require_ok(boxlite_create_box(qs.runtime, box_options, on_create, &qs, &error), "create box", &error);
-    wait_until_done(&qs);
-
-    prepare_wait(&qs);
-    require_ok(boxlite_start_box(qs.box, on_done, &qs, &error), "start box", &error);
-    wait_until_done(&qs);
-
-    const char *args[] = {"Hello from BoxLite C SDK"};
-    BoxliteCommand cmd = {.command = "echo", .args = args, .argc = 1};
-    require_ok(boxlite_box_exec(qs.box, &cmd, &qs.exec, &error), "exec", &error);
-    require_ok(boxlite_execution_on_stdout(qs.exec, on_stdout, NULL, &error), "stdout", &error);
-    require_ok(boxlite_execution_stdin_close(qs.exec, &error), "stdin close", &error);
-    prepare_wait(&qs);
-    require_ok(boxlite_execution_wait(qs.exec, on_wait, &qs, &error), "wait", &error);
-    wait_until_done(&qs);
-    printf("Exit code: %d\\n", qs.exit_code);
-
-    char *box_id = boxlite_box_id(qs.box);
-    prepare_wait(&qs);
-    require_ok(boxlite_remove(qs.runtime, box_id, 1, on_done, &qs, &error), "remove box", &error);
-    wait_until_done(&qs);
-    boxlite_free_string(box_id);
-
-    loop.stop = 1;
-    pthread_join(drain_thread, NULL);
-    boxlite_execution_free(qs.exec);
-    boxlite_box_free(qs.box);
-    boxlite_rest_options_free(rest);
-    boxlite_credential_free(credential);
-    boxlite_runtime_free(qs.runtime);
-    pthread_mutex_destroy(&qs.mutex);
-    pthread_cond_destroy(&qs.cond);
-    return qs.exit_code;
-}`,
-  },
-  cli: {
-    install: 'curl -fsSL https://sh.boxlite.ai | sh',
-    run: `BOXLITE_API_KEY=$KEY BOXLITE_REST_URL=your-api-url boxlite run --rm --name "sdk-quickstart-cli-$(date +%s)" \\
-  ghcr.io/boxlite-ai/boxlite-agent-base:20260605-p0-r3 \\
-  echo "Hello from BoxLite CLI"`,
-    codeLanguage: 'bash',
-    setupLabel: 'Install CLI',
-    setupDescription:
-      'Installs the boxlite command. The next step uses it directly with BOXLITE_API_KEY and BOXLITE_REST_URL.',
-    example: `if [ -z "\${BOXLITE_API_KEY:-}" ]; then
+  return `if [ -z "\${BOXLITE_API_KEY:-}" ]; then
   printf "Paste your BoxLite API key from Step 1: " >&2
   stty -echo
   IFS= read -r BOXLITE_API_KEY
   stty echo
   printf "\\n" >&2
 fi
-export BOXLITE_API_KEY
-export BOXLITE_REST_URL="your-api-url"
+export BOXLITE_API_KEY`
+}
 
-boxlite run --rm --name "sdk-quickstart-cli-$(date +%s)" \\
-  ghcr.io/boxlite-ai/boxlite-agent-base:20260605-p0-r3 \\
-  echo "Hello from BoxLite CLI"`,
-  },
-  rest: {
-    install: `command -v curl
-command -v jq`,
-    run: 'BOXLITE_API_KEY=$KEY BOXLITE_REST_URL=your-api-url bash quickstart-rest.sh',
-    codeLanguage: 'bash',
-    setupLabel: 'Check REST tools',
-    setupDescription:
-      'REST does not require an SDK install. The next step uses curl and jq to create a Box and execute a command. OpenAPI is available for full endpoint reference and generated clients.',
-    example: `#!/usr/bin/env bash
-set -euo pipefail
+function buildTemplateValues(options: RenderOnboardingCodeExampleOptions): TemplateValues {
+  const apiKey = options.apiKey
+  return {
+    API_KEY_C: apiKey ? doubleQuoted(apiKey) : 'getenv("BOXLITE_API_KEY")',
+    API_KEY_GO: apiKey ? doubleQuoted(apiKey) : 'os.Getenv("BOXLITE_API_KEY")',
+    API_KEY_PY: apiKey ? doubleQuoted(apiKey) : 'os.environ["BOXLITE_API_KEY"]',
+    API_KEY_RS: apiKey ? `${doubleQuoted(apiKey)}.to_owned()` : 'std::env::var("BOXLITE_API_KEY")?',
+    API_KEY_SH: shellApiKeyBlock(apiKey),
+    API_KEY_TS: apiKey ? doubleQuoted(apiKey) : 'process.env.BOXLITE_API_KEY',
+    REST_API_URL: options.restApiUrl,
+  }
+}
 
-if [ -z "\${BOXLITE_API_KEY:-}" ]; then
-  printf "Paste your BoxLite API key from Step 1: " >&2
-  stty -echo
-  IFS= read -r BOXLITE_API_KEY
-  stty echo
-  printf "\\n" >&2
-fi
-export BOXLITE_API_KEY
-BOXLITE_REST_URL="\${BOXLITE_REST_URL:-your-api-url}"
-auth=(-H "Authorization: Bearer \${BOXLITE_API_KEY}")
-json=(-H "Content-Type: application/json")
-name="sdk-quickstart-rest-$(date +%s)"
+function renderTemplate(template: string, values: TemplateValues): string {
+  const rendered = template.replace(/\{\{([A-Z0-9_]+)\}\}/g, (match, key: string) => {
+    const value = values[key]
+    if (value === undefined) {
+      throw new Error(`Missing quickstart template value: ${key}`)
+    }
+    return value
+  })
 
-box_id="$(
-  curl -fsS -X POST "\${BOXLITE_REST_URL}/v1/boxes" \\
-    "\${auth[@]}" "\${json[@]}" \\
-    -d "{\\"name\\":\\"\${name}\\",\\"image\\":\\"ghcr.io/boxlite-ai/boxlite-agent-base:20260605-p0-r3\\"}" \\
-    | jq -r '.box_id'
-)"
-trap 'curl -fsS -X DELETE "\${BOXLITE_REST_URL}/v1/boxes/\${box_id}?force=true" "\${auth[@]}" >/dev/null || true' EXIT
+  const unresolved = rendered.match(/\{\{[^}]+}}/)
+  if (unresolved) {
+    throw new Error(`Unresolved quickstart template token: ${unresolved[0]}`)
+  }
 
-curl -fsS -X POST "\${BOXLITE_REST_URL}/v1/boxes/\${box_id}/start" "\${auth[@]}" >/dev/null
+  return rendered.trimEnd()
+}
 
-exec_id="$(
-  curl -fsS -X POST "\${BOXLITE_REST_URL}/v1/boxes/\${box_id}/exec" \\
-    "\${auth[@]}" "\${json[@]}" \\
-    -d '{"command":"echo","args":["Hello from BoxLite REST"]}' \\
-    | jq -r '.execution_id'
-)"
+function renderCommand(command: string, values: TemplateValues): string {
+  return renderTemplate(command, values)
+}
 
-curl -fsS "\${BOXLITE_REST_URL}/v1/boxes/\${box_id}/executions/\${exec_id}" "\${auth[@]}" | jq`,
-  },
+function getDefinition(id: OnboardingInterface): QuickstartInterfaceDefinition {
+  const definition = quickstartDefinitions.find((item) => item.id === id)
+  if (!definition) {
+    throw new Error(`Unknown quickstart interface: ${id}`)
+  }
+  return definition
+}
+
+function renderExample(definition: QuickstartInterfaceDefinition, values: TemplateValues): OnboardingCodeExample {
+  const template = templateMap[definition.template]
+  if (!template) {
+    throw new Error(`Missing quickstart template: ${definition.template}`)
+  }
+
+  return {
+    ...definition,
+    install: renderCommand(definition.install, values),
+    run: renderCommand(definition.run, values),
+    example: renderTemplate(template, values),
+  }
+}
+
+export function getOnboardingInterfaces(): QuickstartInterfaceDefinition[] {
+  return quickstartDefinitions
 }
 
 export function getOnboardingCodeExamples(): Record<OnboardingInterface, OnboardingCodeExample> {
-  return codeExamples
+  const values = buildTemplateValues({ restApiUrl: 'your-api-url' })
+  return Object.fromEntries(
+    quickstartDefinitions.map((definition) => [definition.id, renderExample(definition, values)]),
+  )
 }
 
 export function renderOnboardingCodeExample(
   selectedInterface: OnboardingInterface,
   options: RenderOnboardingCodeExampleOptions,
 ): string {
-  const example = codeExamples[selectedInterface].example.replaceAll('your-api-url', options.restApiUrl)
-  const apiKey = options.apiKey
-  if (!apiKey) {
-    return example
-  }
-
-  const quotedApiKey = doubleQuoted(apiKey)
-  const shellQuotedApiKey = shellSingleQuoted(apiKey)
-  switch (selectedInterface) {
-    case 'typescript':
-      return example.replace(
-        `const apiKey = process.env.BOXLITE_API_KEY
-if (!apiKey) {
-  throw new Error('Set BOXLITE_API_KEY before running this script')
-}`,
-        `const apiKey = ${quotedApiKey}`,
-      )
-    case 'python':
-      return example.replace(
-        'credential=ApiKeyCredential(os.environ["BOXLITE_API_KEY"]),',
-        `credential=ApiKeyCredential(${quotedApiKey}),`,
-      )
-    case 'go':
-      return example.replace(
-        `apiKey := os.Getenv("BOXLITE_API_KEY")
-    if apiKey == "" {
-        log.Fatal("Set BOXLITE_API_KEY before running this program")
-    }`,
-        `apiKey := ${quotedApiKey}`,
-      )
-    case 'rust':
-      return example.replace(
-        'let api_key = std::env::var("BOXLITE_API_KEY")?;',
-        `let api_key = ${quotedApiKey}.to_owned();`,
-      )
-    case 'c':
-      return example.replace(
-        'const char *api_key = getenv("BOXLITE_API_KEY");',
-        `const char *api_key = ${quotedApiKey};`,
-      )
-    case 'cli':
-      return example.replace(
-        `if [ -z "\${BOXLITE_API_KEY:-}" ]; then
-  printf "Paste your BoxLite API key from Step 1: " >&2
-  stty -echo
-  IFS= read -r BOXLITE_API_KEY
-  stty echo
-  printf "\\n" >&2
-fi
-export BOXLITE_API_KEY`,
-        `export BOXLITE_API_KEY=${shellQuotedApiKey}`,
-      )
-    case 'rest':
-      return example.replace(
-        `if [ -z "\${BOXLITE_API_KEY:-}" ]; then
-  printf "Paste your BoxLite API key from Step 1: " >&2
-  stty -echo
-  IFS= read -r BOXLITE_API_KEY
-  stty echo
-  printf "\\n" >&2
-fi
-export BOXLITE_API_KEY`,
-        `BOXLITE_API_KEY=${shellQuotedApiKey}
-export BOXLITE_API_KEY`,
-      )
-  }
+  return renderExample(getDefinition(selectedInterface), buildTemplateValues(options)).example
 }

--- a/apps/dashboard/src/lib/quickstart-api-key.test.ts
+++ b/apps/dashboard/src/lib/quickstart-api-key.test.ts
@@ -29,9 +29,9 @@ describe('buildQuickstartApiKeyName', () => {
     expect(buildQuickstartApiKeyName(0, 'demo')).toBe('demo')
   })
 
-  it('appends an incrementing suffix on later attempts', () => {
-    expect(buildQuickstartApiKeyName(1)).toBe('sdk-quickstart-2')
-    expect(buildQuickstartApiKeyName(2, 'demo')).toBe('demo-3')
+  it('appends a short random suffix on later attempts', () => {
+    expect(buildQuickstartApiKeyName(1)).toMatch(/^sdk-quickstart-[0-9a-z]{4}$/)
+    expect(buildQuickstartApiKeyName(2, 'demo')).toMatch(/^demo-[0-9a-z]{4}$/)
   })
 })
 
@@ -69,19 +69,20 @@ describe('createApiKeyWithFallbackName', () => {
     expect(create).toHaveBeenCalledTimes(1)
   })
 
-  it('retries with a suffix on duplicate-name conflicts', async () => {
+  it('retries with a random suffix on duplicate-name conflicts', async () => {
     const seen: string[] = []
     const create = vi.fn(async (name: string) => {
       seen.push(name)
-      if (name === 'demo-key' || name === 'demo-key-2') {
+      if (name === 'demo-key') {
         throw { cause: { response: { status: 409 } } }
       }
       return { name }
     })
 
     const result = await createApiKeyWithFallbackName(create, { baseName: 'demo-key' })
-    expect(seen).toEqual(['demo-key', 'demo-key-2', 'demo-key-3'])
-    expect(result).toEqual({ name: 'demo-key-3' })
+    expect(seen[0]).toBe('demo-key')
+    expect(seen[1]).toMatch(/^demo-key-[0-9a-z]{4}$/)
+    expect(result).toEqual({ name: seen[1] })
   })
 
   it('propagates a non-conflict error without retrying', async () => {

--- a/apps/dashboard/src/lib/quickstart-api-key.test.ts
+++ b/apps/dashboard/src/lib/quickstart-api-key.test.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+import {
+  DEFAULT_QUICKSTART_API_KEY_NAME,
+  buildQuickstartApiKeyName,
+  createApiKeyWithFallbackName,
+  isApiKeyNameConflict,
+  resolveQuickstartApiKeyBaseName,
+} from './quickstart-api-key'
+
+describe('resolveQuickstartApiKeyBaseName', () => {
+  it('uses the default quickstart name when the input is blank', () => {
+    expect(resolveQuickstartApiKeyBaseName('')).toBe(DEFAULT_QUICKSTART_API_KEY_NAME)
+    expect(resolveQuickstartApiKeyBaseName('   ')).toBe(DEFAULT_QUICKSTART_API_KEY_NAME)
+  })
+
+  it('trims a custom key name', () => {
+    expect(resolveQuickstartApiKeyBaseName(' demo key ')).toBe('demo key')
+  })
+})
+
+describe('buildQuickstartApiKeyName', () => {
+  it('uses the base name on the first attempt', () => {
+    expect(buildQuickstartApiKeyName()).toBe(DEFAULT_QUICKSTART_API_KEY_NAME)
+    expect(buildQuickstartApiKeyName(0, 'demo')).toBe('demo')
+  })
+
+  it('appends an incrementing suffix on later attempts', () => {
+    expect(buildQuickstartApiKeyName(1)).toBe('sdk-quickstart-2')
+    expect(buildQuickstartApiKeyName(2, 'demo')).toBe('demo-3')
+  })
+})
+
+describe('isApiKeyNameConflict', () => {
+  it('detects a 409 wrapped by the axios interceptor', () => {
+    expect(isApiKeyNameConflict({ cause: { response: { status: 409 } } })).toBe(true)
+  })
+
+  it('detects a raw 409 and the backend duplicate-name message', () => {
+    expect(isApiKeyNameConflict({ response: { status: 409 } })).toBe(true)
+    expect(isApiKeyNameConflict(new Error('API key with this name already exists'))).toBe(true)
+  })
+
+  it('ignores unrelated errors', () => {
+    expect(isApiKeyNameConflict(new Error('network down'))).toBe(false)
+    expect(isApiKeyNameConflict({ cause: { response: { status: 500 } } })).toBe(false)
+    expect(isApiKeyNameConflict(null)).toBe(false)
+  })
+})
+
+describe('createApiKeyWithFallbackName', () => {
+  it('uses the default name when no custom name is provided', async () => {
+    const create = vi.fn(async (name: string) => ({ name }))
+    const result = await createApiKeyWithFallbackName(create)
+
+    expect(result).toEqual({ name: DEFAULT_QUICKSTART_API_KEY_NAME })
+    expect(create).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses the custom base name when provided', async () => {
+    const create = vi.fn(async (name: string) => ({ name }))
+    const result = await createApiKeyWithFallbackName(create, { baseName: 'demo-key' })
+
+    expect(result).toEqual({ name: 'demo-key' })
+    expect(create).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries with a suffix on duplicate-name conflicts', async () => {
+    const seen: string[] = []
+    const create = vi.fn(async (name: string) => {
+      seen.push(name)
+      if (name === 'demo-key' || name === 'demo-key-2') {
+        throw { cause: { response: { status: 409 } } }
+      }
+      return { name }
+    })
+
+    const result = await createApiKeyWithFallbackName(create, { baseName: 'demo-key' })
+    expect(seen).toEqual(['demo-key', 'demo-key-2', 'demo-key-3'])
+    expect(result).toEqual({ name: 'demo-key-3' })
+  })
+
+  it('propagates a non-conflict error without retrying', async () => {
+    const create = vi.fn(async () => {
+      throw new Error('boom')
+    })
+
+    await expect(createApiKeyWithFallbackName(create)).rejects.toThrow('boom')
+    expect(create).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/dashboard/src/lib/quickstart-api-key.ts
+++ b/apps/dashboard/src/lib/quickstart-api-key.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+export const DEFAULT_QUICKSTART_API_KEY_NAME = 'sdk-quickstart'
+
+export function resolveQuickstartApiKeyBaseName(value: string): string {
+  const trimmed = value.trim()
+  return trimmed === '' ? DEFAULT_QUICKSTART_API_KEY_NAME : trimmed
+}
+
+export function buildQuickstartApiKeyName(attempt = 0, baseName = DEFAULT_QUICKSTART_API_KEY_NAME): string {
+  return attempt <= 0 ? baseName : `${baseName}-${attempt + 1}`
+}
+
+export function isApiKeyNameConflict(error: unknown): boolean {
+  const err = error as { cause?: { response?: { status?: number } }; response?: { status?: number }; message?: string }
+  const status = err?.cause?.response?.status ?? err?.response?.status
+  if (status === 409) return true
+  return typeof err?.message === 'string' && err.message.includes('already exists')
+}
+
+export async function createApiKeyWithFallbackName<T>(
+  create: (name: string) => Promise<T>,
+  options: { baseName?: string; maxAttempts?: number } = {},
+): Promise<T> {
+  const baseName = resolveQuickstartApiKeyBaseName(options.baseName ?? '')
+  const maxAttempts = options.maxAttempts ?? 5
+  let lastError: unknown
+
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    try {
+      return await create(buildQuickstartApiKeyName(attempt, baseName))
+    } catch (error) {
+      if (!isApiKeyNameConflict(error)) throw error
+      lastError = error
+    }
+  }
+
+  throw lastError
+}

--- a/apps/dashboard/src/lib/quickstart-api-key.ts
+++ b/apps/dashboard/src/lib/quickstart-api-key.ts
@@ -11,7 +11,15 @@ export function resolveQuickstartApiKeyBaseName(value: string): string {
 }
 
 export function buildQuickstartApiKeyName(attempt = 0, baseName = DEFAULT_QUICKSTART_API_KEY_NAME): string {
-  return attempt <= 0 ? baseName : `${baseName}-${attempt + 1}`
+  return attempt <= 0 ? baseName : `${baseName}-${randomUuidSuffix()}`
+}
+
+function randomUuidSuffix(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID().replace(/-/g, '').slice(0, 4)
+  }
+
+  return Math.random().toString(36).slice(2, 6).padEnd(4, '0')
 }
 
 export function isApiKeyNameConflict(error: unknown): boolean {

--- a/apps/dashboard/src/lib/quickstart/interfaces.json
+++ b/apps/dashboard/src/lib/quickstart/interfaces.json
@@ -1,0 +1,88 @@
+[
+  {
+    "id": "python",
+    "label": "Python",
+    "icon": "python",
+    "install": "pip install boxlite",
+    "run": "BOXLITE_API_KEY=$KEY python main.py",
+    "codeLanguage": "python",
+    "setupLabel": "Run in your local terminal",
+    "setupDescription": "Run this command in your local development environment to install the Python library. Continue once the install finishes.",
+    "executionDescription": "What it does: uses your API key from Step 1, creates a Box, runs a command inside it, prints the output, then removes the Box.",
+    "template": "python"
+  },
+  {
+    "id": "typescript",
+    "label": "Node",
+    "icon": "typescript",
+    "install": "npm install @boxlite-ai/boxlite tsx",
+    "run": "BOXLITE_API_KEY=$KEY npx tsx index.mts",
+    "codeLanguage": "typescript",
+    "setupLabel": "Run in your local terminal",
+    "setupDescription": "Run this command in your local development environment to install the Node library. Continue once the install finishes.",
+    "executionDescription": "What it does: uses your API key from Step 1, creates a Box, runs a command inside it, prints the output, then removes the Box.",
+    "template": "typescript"
+  },
+  {
+    "id": "go",
+    "label": "Go",
+    "icon": "go",
+    "install": "go get github.com/boxlite-ai/boxlite/sdks/go\ngo run github.com/boxlite-ai/boxlite/sdks/go/cmd/setup",
+    "run": "BOXLITE_API_KEY=$KEY go run .",
+    "codeLanguage": "go",
+    "setupLabel": "Run in your local terminal",
+    "setupDescription": "Run this command in your local development environment to install the Go library. Continue once the install finishes.",
+    "executionDescription": "What it does: uses your API key from Step 1, creates a Box, runs a command inside it, prints the output, then removes the Box.",
+    "template": "go"
+  },
+  {
+    "id": "rust",
+    "label": "Rust",
+    "icon": "rust",
+    "install": "cargo add boxlite --features rest\ncargo add tokio --features macros,rt-multi-thread\ncargo add futures",
+    "run": "BOXLITE_API_KEY=$KEY cargo run",
+    "codeLanguage": "rust",
+    "setupLabel": "Run in your local terminal",
+    "setupDescription": "Run this command in your local development environment to install the Rust library. Continue once the install finishes.",
+    "executionDescription": "What it does: uses your API key from Step 1, creates a Box, runs a command inside it, prints the output, then removes the Box.",
+    "template": "rust"
+  },
+  {
+    "id": "c",
+    "label": "SDK",
+    "ariaLabel": "C SDK",
+    "icon": "badge",
+    "badge": "C",
+    "install": "VERSION=v0.9.5\nPLATFORM=darwin-arm64\n# Linux: PLATFORM=linux-x64-gnu or linux-arm64-gnu\ncurl -fsSL \"https://github.com/boxlite-ai/boxlite/releases/download/${VERSION}/boxlite-c-${VERSION}-${PLATFORM}.tar.gz\" \\\n  | tar xz\nmv \"boxlite-c-${VERSION}-${PLATFORM}\" boxlite-c-sdk",
+    "run": "cc main.c -Iboxlite-c-sdk/include -Lboxlite-c-sdk/lib -lboxlite -pthread \\\n  -Wl,-rpath,\"$PWD/boxlite-c-sdk/lib\" -o quickstart\nBOXLITE_API_KEY=$KEY BOXLITE_REST_URL={{REST_API_URL}} ./quickstart",
+    "codeLanguage": "c",
+    "setupLabel": "Download C SDK",
+    "setupDescription": "Downloads the prebuilt C header and native library. The next step includes boxlite.h and links libboxlite.",
+    "executionDescription": "What it does: compiles a C program that uses your API key from Step 1, creates a Box, runs a command inside it, prints stdout, then removes the Box.",
+    "template": "c"
+  },
+  {
+    "id": "cli",
+    "label": "CLI",
+    "icon": "terminal",
+    "install": "curl -fsSL https://sh.boxlite.ai | sh",
+    "run": "BOXLITE_API_KEY=$KEY BOXLITE_REST_URL={{REST_API_URL}} boxlite run --rm --name \"sdk-quickstart-cli-$(date +%s)\" \\\n  ghcr.io/boxlite-ai/boxlite-agent-base:20260605-p0-r3 \\\n  echo \"Hello from BoxLite CLI\"",
+    "codeLanguage": "bash",
+    "setupLabel": "Install CLI",
+    "setupDescription": "Installs the boxlite command. The next step uses it directly with BOXLITE_API_KEY and BOXLITE_REST_URL.",
+    "executionDescription": "What it does: sets the API key and REST URL for one boxlite run, runs a command in a disposable Box, then removes it.",
+    "template": "cli"
+  },
+  {
+    "id": "rest",
+    "label": "REST",
+    "icon": "server",
+    "install": "command -v curl\ncommand -v jq",
+    "run": "BOXLITE_API_KEY=$KEY BOXLITE_REST_URL={{REST_API_URL}} bash quickstart-rest.sh",
+    "codeLanguage": "bash",
+    "setupLabel": "Check REST tools",
+    "setupDescription": "REST does not require an SDK install. The next step uses curl and jq to create a Box and execute a command.",
+    "executionDescription": "What it does: uses your API key from Step 1, calls the REST API to create and start a Box, executes a command, prints execution status, then removes the Box.",
+    "template": "rest"
+  }
+]

--- a/apps/dashboard/src/lib/quickstart/templates/c.c
+++ b/apps/dashboard/src/lib/quickstart/templates/c.c
@@ -1,0 +1,212 @@
+#include "boxlite.h"
+#include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+typedef struct {
+    CBoxliteRuntime *runtime;
+    CBoxHandle *box;
+    CExecutionHandle *exec;
+    pthread_mutex_t mutex;
+    pthread_cond_t cond;
+    int done;
+    int failed;
+    int exit_code;
+} Quickstart;
+
+typedef struct {
+    CBoxliteRuntime *runtime;
+    volatile int stop;
+} DrainLoop;
+
+static int has_error(const CBoxliteError *error) {
+    return error && error->code != Ok;
+}
+
+static void print_error(const char *op, CBoxliteError *error) {
+    fprintf(stderr, "%s failed: %s\n", op, error && error->message ? error->message : "unknown");
+    if (error) {
+        boxlite_error_free(error);
+    }
+}
+
+static void require_ok(BoxliteErrorCode code, const char *op, CBoxliteError *error) {
+    if (code != Ok) {
+        print_error(op, error);
+        exit(1);
+    }
+}
+
+static void *drain_loop(void *user_data) {
+    DrainLoop *loop = (DrainLoop *)user_data;
+    CBoxliteError error = {0};
+
+    while (!loop->stop) {
+        if (boxlite_runtime_drain(loop->runtime, 100, &error) < 0) {
+            print_error("drain", &error);
+            error = (CBoxliteError){0};
+        }
+    }
+    return NULL;
+}
+
+static void prepare_wait(Quickstart *qs) {
+    pthread_mutex_lock(&qs->mutex);
+    qs->done = 0;
+    qs->failed = 0;
+    pthread_mutex_unlock(&qs->mutex);
+}
+
+static void wait_until_done(Quickstart *qs) {
+    pthread_mutex_lock(&qs->mutex);
+    while (!qs->done) {
+        pthread_cond_wait(&qs->cond, &qs->mutex);
+    }
+    int failed = qs->failed;
+    pthread_mutex_unlock(&qs->mutex);
+
+    if (failed) {
+        exit(1);
+    }
+}
+
+static void on_create(CBoxHandle *box, CBoxliteError *error, void *user_data) {
+    Quickstart *qs = (Quickstart *)user_data;
+    pthread_mutex_lock(&qs->mutex);
+    if (has_error(error)) {
+        print_error("create box", error);
+        qs->failed = 1;
+    } else {
+        qs->box = box;
+    }
+    qs->done = 1;
+    pthread_cond_signal(&qs->cond);
+    pthread_mutex_unlock(&qs->mutex);
+}
+
+static void on_done(CBoxliteError *error, void *user_data) {
+    Quickstart *qs = (Quickstart *)user_data;
+    pthread_mutex_lock(&qs->mutex);
+    if (has_error(error)) {
+        print_error("operation", error);
+        qs->failed = 1;
+    }
+    qs->done = 1;
+    pthread_cond_signal(&qs->cond);
+    pthread_mutex_unlock(&qs->mutex);
+}
+
+static void on_wait(int exit_code, CBoxliteError *error, void *user_data) {
+    Quickstart *qs = (Quickstart *)user_data;
+    pthread_mutex_lock(&qs->mutex);
+    if (has_error(error)) {
+        print_error("wait", error);
+        qs->failed = 1;
+    }
+    qs->exit_code = exit_code;
+    qs->done = 1;
+    pthread_cond_signal(&qs->cond);
+    pthread_mutex_unlock(&qs->mutex);
+}
+
+static void on_stdout(const uint8_t *data, size_t len, void *user_data) {
+    (void)user_data;
+    fwrite(data, 1, len, stdout);
+}
+
+int main(void) {
+    const char *api_key = {{API_KEY_C}};
+    const char *api_url = getenv("BOXLITE_REST_URL");
+    if (!api_key) {
+        fprintf(stderr, "Set BOXLITE_API_KEY before running this program\n");
+        return 1;
+    }
+    if (!api_url) {
+        api_url = "{{REST_API_URL}}";
+    }
+
+    CBoxliteError error = {0};
+    CBoxliteCredential *credential = NULL;
+    CBoxliteRestOptions *rest = NULL;
+    CBoxliteOptions *box_options = NULL;
+    Quickstart qs = {0};
+    pthread_mutex_init(&qs.mutex, NULL);
+    pthread_cond_init(&qs.cond, NULL);
+
+    require_ok(
+        boxlite_api_key_credential_new(api_key, &credential, &error),
+        "credential",
+        &error
+    );
+    require_ok(boxlite_rest_options_new(api_url, &rest, &error), "rest options", &error);
+    boxlite_rest_options_set_credential(rest, credential);
+    require_ok(
+        boxlite_rest_runtime_new_with_options(rest, &qs.runtime, &error),
+        "rest runtime",
+        &error
+    );
+    DrainLoop loop = {.runtime = qs.runtime, .stop = 0};
+    pthread_t drain_thread;
+    pthread_create(&drain_thread, NULL, drain_loop, &loop);
+
+    require_ok(
+        boxlite_options_new(
+            "ghcr.io/boxlite-ai/boxlite-agent-base:20260605-p0-r3",
+            &box_options,
+            &error
+        ),
+        "box options",
+        &error
+    );
+    char box_name[64];
+    snprintf(box_name, sizeof(box_name), "sdk-quickstart-c-%ld", (long)time(NULL));
+    boxlite_options_set_name(box_options, box_name);
+    prepare_wait(&qs);
+    require_ok(
+        boxlite_create_box(qs.runtime, box_options, on_create, &qs, &error),
+        "create box",
+        &error
+    );
+    wait_until_done(&qs);
+
+    prepare_wait(&qs);
+    require_ok(boxlite_start_box(qs.box, on_done, &qs, &error), "start box", &error);
+    wait_until_done(&qs);
+
+    const char *args[] = {"Hello from BoxLite C SDK"};
+    BoxliteCommand cmd = {.command = "echo", .args = args, .argc = 1};
+    require_ok(boxlite_box_exec(qs.box, &cmd, &qs.exec, &error), "exec", &error);
+    require_ok(
+        boxlite_execution_on_stdout(qs.exec, on_stdout, NULL, &error),
+        "stdout",
+        &error
+    );
+    require_ok(boxlite_execution_stdin_close(qs.exec, &error), "stdin close", &error);
+    prepare_wait(&qs);
+    require_ok(boxlite_execution_wait(qs.exec, on_wait, &qs, &error), "wait", &error);
+    wait_until_done(&qs);
+    printf("Exit code: %d\n", qs.exit_code);
+
+    char *box_id = boxlite_box_id(qs.box);
+    prepare_wait(&qs);
+    require_ok(
+        boxlite_remove(qs.runtime, box_id, 1, on_done, &qs, &error),
+        "remove box",
+        &error
+    );
+    wait_until_done(&qs);
+    boxlite_free_string(box_id);
+
+    loop.stop = 1;
+    pthread_join(drain_thread, NULL);
+    boxlite_execution_free(qs.exec);
+    boxlite_box_free(qs.box);
+    boxlite_rest_options_free(rest);
+    boxlite_credential_free(credential);
+    boxlite_runtime_free(qs.runtime);
+    pthread_mutex_destroy(&qs.mutex);
+    pthread_cond_destroy(&qs.cond);
+    return qs.exit_code;
+}

--- a/apps/dashboard/src/lib/quickstart/templates/cli.sh
+++ b/apps/dashboard/src/lib/quickstart/templates/cli.sh
@@ -1,0 +1,6 @@
+{{API_KEY_SH}}
+export BOXLITE_REST_URL="{{REST_API_URL}}"
+
+boxlite run --rm --name "sdk-quickstart-cli-$(date +%s)" \
+  ghcr.io/boxlite-ai/boxlite-agent-base:20260605-p0-r3 \
+  echo "Hello from BoxLite CLI"

--- a/apps/dashboard/src/lib/quickstart/templates/go.go
+++ b/apps/dashboard/src/lib/quickstart/templates/go.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+    "context"
+    "fmt"
+    "log"
+    "os"
+    "time"
+
+    boxlite "github.com/boxlite-ai/boxlite/sdks/go"
+)
+
+func main() {
+    ctx := context.Background()
+    apiKey := {{API_KEY_GO}}
+    if apiKey == "" {
+        log.Fatal("Set BOXLITE_API_KEY before running this program")
+    }
+
+    apiURL := os.Getenv("BOXLITE_REST_URL")
+    if apiURL == "" {
+        apiURL = "{{REST_API_URL}}"
+    }
+
+    rt, err := boxlite.NewRest(boxlite.BoxliteRestOptions{
+        URL:        apiURL,
+        Credential: boxlite.NewApiKeyCredential(apiKey),
+    })
+    if err != nil {
+        log.Fatal(err)
+    }
+    defer rt.Close()
+
+    boxName := fmt.Sprintf("sdk-quickstart-go-%d", time.Now().Unix())
+    box, err := rt.Create(
+        ctx,
+        "ghcr.io/boxlite-ai/boxlite-agent-base:20260605-p0-r3",
+        boxlite.WithName(boxName),
+    )
+    if err != nil {
+        log.Fatal(err)
+    }
+    if err := box.Start(ctx); err != nil {
+        log.Fatal(err)
+    }
+
+    result, err := box.Exec(ctx, "echo", "Hello from BoxLite SDK")
+    if err != nil {
+        log.Fatal(err)
+    }
+    log.Println("Exit code:", result.ExitCode)
+    log.Print(result.Stdout)
+
+    if err := rt.ForceRemove(ctx, box.ID()); err != nil {
+        log.Fatal(err)
+    }
+}

--- a/apps/dashboard/src/lib/quickstart/templates/python.py
+++ b/apps/dashboard/src/lib/quickstart/templates/python.py
@@ -1,0 +1,37 @@
+import asyncio
+import os
+import time
+
+from boxlite import (
+    ApiKeyCredential,
+    Boxlite,
+    BoxliteRestOptions,
+    BoxOptions,
+)
+
+async def main():
+    rt = Boxlite.rest(BoxliteRestOptions(
+        url=os.environ.get("BOXLITE_REST_URL", "{{REST_API_URL}}"),
+        credential=ApiKeyCredential({{API_KEY_PY}}),
+    ))
+
+    box_name = f"sdk-quickstart-python-{int(time.time())}"
+    box = await rt.create(
+        BoxOptions(
+            image="ghcr.io/boxlite-ai/boxlite-agent-base:20260605-p0-r3",
+        ),
+        name=box_name,
+    )
+    await box.start()
+
+    execution = await box.exec("echo", args=["Hello from BoxLite SDK"])
+    output = ""
+    async for line in execution.stdout():
+        output += line
+    result = await execution.wait()
+    print(f"Exit code: {result.exit_code}")
+    print(output)
+
+    await rt.remove(box.id, force=True)
+
+asyncio.run(main())

--- a/apps/dashboard/src/lib/quickstart/templates/rest.sh
+++ b/apps/dashboard/src/lib/quickstart/templates/rest.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+{{API_KEY_SH}}
+BOXLITE_REST_URL="${BOXLITE_REST_URL:-{{REST_API_URL}}}"
+auth=(-H "Authorization: Bearer ${BOXLITE_API_KEY}")
+json=(-H "Content-Type: application/json")
+name="sdk-quickstart-rest-$(date +%s)"
+
+box_id="$(
+  curl -fsS -X POST "${BOXLITE_REST_URL}/v1/boxes" \
+    "${auth[@]}" "${json[@]}" \
+    -d "{\"name\":\"${name}\",\"image\":\"ghcr.io/boxlite-ai/boxlite-agent-base:20260605-p0-r3\"}" \
+    | jq -r '.box_id'
+)"
+trap 'curl -fsS -X DELETE "${BOXLITE_REST_URL}/v1/boxes/${box_id}?force=true" "${auth[@]}" >/dev/null || true' EXIT
+
+curl -fsS -X POST "${BOXLITE_REST_URL}/v1/boxes/${box_id}/start" "${auth[@]}" >/dev/null
+
+exec_id="$(
+  curl -fsS -X POST "${BOXLITE_REST_URL}/v1/boxes/${box_id}/exec" \
+    "${auth[@]}" "${json[@]}" \
+    -d '{"command":"echo","args":["Hello from BoxLite REST"]}' \
+    | jq -r '.execution_id'
+)"
+
+curl -fsS "${BOXLITE_REST_URL}/v1/boxes/${box_id}/executions/${exec_id}" "${auth[@]}" | jq

--- a/apps/dashboard/src/lib/quickstart/templates/rust.rs
+++ b/apps/dashboard/src/lib/quickstart/templates/rust.rs
@@ -1,0 +1,39 @@
+use boxlite::{BoxCommand, BoxOptions, BoxliteRestOptions, BoxliteRuntime, RootfsSpec};
+use futures::StreamExt;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key = {{API_KEY_RS}};
+    let api_url = std::env::var("BOXLITE_REST_URL").unwrap_or_else(|_| "{{REST_API_URL}}".to_owned());
+    let rt = BoxliteRuntime::rest(
+        BoxliteRestOptions::new(api_url).with_api_key(api_key),
+    )?;
+
+    let options = BoxOptions {
+        rootfs: RootfsSpec::Image(
+            "ghcr.io/boxlite-ai/boxlite-agent-base:20260605-p0-r3".into(),
+        ),
+        ..Default::default()
+    };
+    let suffix = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)?
+        .as_secs();
+    let name = format!("sdk-quickstart-rust-{suffix}");
+    let box_handle = rt.create(options, Some(name)).await?;
+    box_handle.start().await?;
+
+    let mut exec = box_handle
+        .exec(BoxCommand::new("echo").arg("Hello from BoxLite SDK"))
+        .await?;
+    let mut stdout = exec.stdout().expect("stdout stream should be available");
+    let mut output = String::new();
+    while let Some(line) = stdout.next().await {
+        output.push_str(&line);
+    }
+    let result = exec.wait().await?;
+    println!("Exit code: {}", result.exit_code);
+    print!("{output}");
+
+    rt.remove(&box_handle.id().to_string(), true).await?;
+    Ok(())
+}

--- a/apps/dashboard/src/lib/quickstart/templates/typescript.mts
+++ b/apps/dashboard/src/lib/quickstart/templates/typescript.mts
@@ -1,0 +1,35 @@
+import { ApiKeyCredential, BoxliteRestOptions, JsBoxlite } from '@boxlite-ai/boxlite'
+
+const apiKey = {{API_KEY_TS}}
+if (!apiKey) {
+  throw new Error('Set BOXLITE_API_KEY before running this script')
+}
+
+const rt = JsBoxlite.rest(
+  new BoxliteRestOptions({
+    url: process.env.BOXLITE_REST_URL ?? '{{REST_API_URL}}',
+    credential: new ApiKeyCredential(apiKey),
+  }),
+)
+
+const boxName = `sdk-quickstart-node-${Date.now()}`
+const box = await rt.create(
+  {
+    image: 'ghcr.io/boxlite-ai/boxlite-agent-base:20260605-p0-r3',
+  },
+  boxName,
+)
+await box.start()
+
+const exec = await box.exec('echo', ['Hello from BoxLite SDK'])
+const stdout = await exec.stdout()
+let output = ''
+let chunk: string | null
+while ((chunk = await stdout.next()) !== null) {
+  output += chunk
+}
+const result = await exec.wait()
+console.log('Exit code:', result.exitCode)
+console.log(output)
+
+await rt.remove(box.id, true)

--- a/apps/dashboard/src/lib/quickstart/types.ts
+++ b/apps/dashboard/src/lib/quickstart/types.ts
@@ -1,0 +1,25 @@
+export type QuickstartIconName = 'python' | 'typescript' | 'go' | 'rust' | 'terminal' | 'server' | 'badge'
+
+export interface QuickstartInterfaceDefinition {
+  id: string
+  label: string
+  ariaLabel?: string
+  icon: QuickstartIconName
+  badge?: string
+  install: string
+  run: string
+  codeLanguage: string
+  setupLabel?: string
+  setupDescription?: string
+  executionDescription: string
+  template: string
+}
+
+export interface OnboardingCodeExample extends QuickstartInterfaceDefinition {
+  example: string
+}
+
+export interface RenderOnboardingCodeExampleOptions {
+  apiKey?: string
+  restApiUrl: string
+}


### PR DESCRIPTION
## Summary

- add C SDK, CLI, and REST entries to the dashboard onboarding quickstart
- update the onboarding UI to show SDK/API entrypoints, setup guidance, file labels, and runnable commands
- add coverage for the new entrypoints, REST OpenAPI contract guidance, C prebuilt archive install path, and CLI REST env-var flow

## Validation

- `corepack yarn vitest run dashboard/src/lib/onboarding-code-examples.test.ts`
- `git diff --check`
- `make lint:apps` (0 errors, 38 warnings)
- `curl -fsSI 'http://127.0.0.1:3002/dashboard/boxes?onboarding=1'`
- in-app browser check for onboarding REST step structure: `Create quickstart-rest.sh` before `Run quickstart-rest.sh`, script and command present, no Vite overlay or console errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded onboarding guide and generated code examples to cover C SDK, CLI, and REST alongside existing targets.
  * Updated the interface selection UI to an icon-button grid and made step guidance use interface-specific install/run copy.
  * Improved API key creation/copy behavior with interface-aware setup label/description.
* **Bug Fixes**
  * Environment and REST URL resolution now prioritizes OIDC issuer information over browser hostname.
* **Tests**
  * Added/expanded coverage for onboarding entrypoints/snippet generation, quickstart API key conflict/retry behavior, and environment resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->