### PR TITLE
feat(deploy): add runner artifact build and SSM rollout path

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -3,7 +3,7 @@
 FROM node:24-slim AS base
 ENV CI=true
 
-RUN apt-get update && apt-get install -y --no-install-recommends bash curl && \
+RUN apt-get update && apt-get install -y --no-install-recommends bash curl python3 make g++ && \
   rm -rf /var/lib/apt/lists/*
 RUN npm install -g corepack && corepack enable
 

--- a/apps/infra/scripts/sst-with-cloudflare.mjs
+++ b/apps/infra/scripts/sst-with-cloudflare.mjs
@@ -8,7 +8,9 @@
  * `run()` exists — so its credentials can't be `sst.Secret` like the app
  * secrets. They live in AWS SSM Parameter Store (SecureString) instead, keyed
  * per stage, and this wrapper fetches + exports them just before invoking sst.
- * App secrets are NOT handled here; sst resolves those from its own store.
+ * App secrets are normally resolved by SST from its own store. For self-hosted
+ * deploys, set BOXLITE_ENV_SOURCE=ssm to sync /boxlite/<stage>/env/* into this
+ * app's .env and load the subset that SST models as sst.Secret.
  *
  * Wired into the dev/deploy/remove npm scripts, plus a passthrough:
  *   npm run deploy -- --stage dev      → node sst-with-cloudflare.mjs deploy --stage dev
@@ -18,9 +20,9 @@
  * same credentials fetch the Cloudflare token from SSM — nothing extra to share.
  *
  * Seed the parameters once per stage:
- *   aws ssm put-parameter --region ap-southeast-1 --type SecureString \
+ *   aws ssm put-parameter --region <stage-region> --type SecureString \
  *     --name /boxlite/<stage>/cloudflare-api-token   --value "<token>"
- *   aws ssm put-parameter --region ap-southeast-1 --type SecureString \
+ *   aws ssm put-parameter --region <stage-region> --type SecureString \
  *     --name /boxlite/<stage>/cloudflare-account-id  --value "<account-id>"
  *
  * A credential already in the environment is used as-is (works offline / before
@@ -30,13 +32,33 @@
  */
 
 import { execFileSync, spawnSync } from 'node:child_process'
+import { chmodSync, mkdirSync, mkdtempSync, renameSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
 
-const REGION = process.env.AWS_REGION || 'ap-southeast-1'
+const DEFAULT_REGION = 'ap-southeast-1'
+const STAGE_REGIONS = {
+  dev: 'ap-southeast-1',
+  prod: 'us-west-2',
+  production: 'us-west-2',
+}
 
 // SSM param consulted only when the matching env var is unset.
 const CREDS = [
   { env: 'CLOUDFLARE_API_TOKEN', param: 'cloudflare-api-token' },
   { env: 'CLOUDFLARE_DEFAULT_ACCOUNT_ID', param: 'cloudflare-account-id' },
+]
+
+const CONFIG_COMMANDS = new Set(['deploy', 'dev', 'diff', 'remove'])
+const DEFAULT_PRODUCT_ENV_PREFIX_TEMPLATE = '/boxlite/{stage}/env'
+const DEFAULT_SST_SECRET_KEYS = [
+  'OIDC_CLIENT_ID',
+  'OIDC_MANAGEMENT_API_CLIENT_ID',
+  'OIDC_MANAGEMENT_API_CLIENT_SECRET',
+  'POSTHOG_API_KEY',
+  'SVIX_AUTH_TOKEN',
+  'SSH_PRIVATE_KEY_B64',
+  'SSH_HOST_KEY_B64',
 ]
 
 const sstArgs = process.argv.slice(2)
@@ -56,12 +78,20 @@ function resolveStage(args) {
   return process.env.SST_STAGE || 'dev'
 }
 
+function runAws(args, options = {}) {
+  return execFileSync('aws', args, {
+    encoding: 'utf8',
+    env: { ...process.env, AWS_REGION: REGION },
+    maxBuffer: 10 * 1024 * 1024,
+    ...options,
+  })
+}
+
 function fetchFromSsm(name) {
   try {
-    const out = execFileSync(
-      'aws',
+    const out = runAws(
       ['ssm', 'get-parameter', '--region', REGION, '--name', name, '--with-decryption', '--query', 'Parameter.Value', '--output', 'text'],
-      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
+      { stdio: ['ignore', 'pipe', 'pipe'] },
     ).trim()
     return out && out !== 'None' ? out : null
   } catch (err) {
@@ -70,7 +100,115 @@ function fetchFromSsm(name) {
   }
 }
 
+function dotenvLine(key, value) {
+  return `${key}=${JSON.stringify(value)}`
+}
+
+function writeAtomically(file, body) {
+  mkdirSync(dirname(file), { recursive: true })
+  const tmp = `${file}.tmp-${process.pid}`
+  writeFileSync(tmp, body, { mode: 0o600 })
+  renameSync(tmp, file)
+  chmodSync(file, 0o600)
+}
+
+function envPrefixForStage() {
+  const explicit = process.env.BOXLITE_ENV_SSM_PREFIX || process.env.OPS_PRODUCT_ENV_SSM_PREFIX
+  const template =
+    process.env.BOXLITE_ENV_SSM_PREFIX_TEMPLATE ||
+    process.env.OPS_PRODUCT_ENV_SSM_PREFIX_TEMPLATE ||
+    DEFAULT_PRODUCT_ENV_PREFIX_TEMPLATE
+  const source = explicit || template
+  return source.replaceAll('{stage}', stage)
+}
+
+function sstSecretKeys() {
+  return new Set(
+    (process.env.BOXLITE_SST_SECRET_KEYS || process.env.OPS_PRODUCT_SST_SECRET_KEYS || DEFAULT_SST_SECRET_KEYS.join(','))
+      .split(',')
+      .map((key) => key.trim())
+      .filter(Boolean),
+  )
+}
+
+function syncProductEnvFromSsm() {
+  const source = process.env.BOXLITE_ENV_SOURCE || process.env.SST_ENV_SOURCE || 'local'
+  if (source !== 'ssm' || !CONFIG_COMMANDS.has(sstArgs[0])) return
+
+  const prefix = envPrefixForStage()
+  const outFile = process.env.BOXLITE_ENV_FILE || process.env.OPS_PRODUCT_ENV_FILE || join(process.cwd(), '.env')
+  let params
+  try {
+    const stdout = runAws([
+      'ssm',
+      'get-parameters-by-path',
+      '--region',
+      REGION,
+      '--path',
+      prefix,
+      '--recursive',
+      '--with-decryption',
+      '--query',
+      'Parameters[].{Name:Name,Value:Value,Version:Version}',
+      '--output',
+      'json',
+    ])
+    params = JSON.parse(stdout || '[]')
+  } catch (err) {
+    const detail = err.stderr ? String(err.stderr).trim() : err.message
+    console.error(`sst-env-sync: failed to read ${prefix} from SSM (${REGION}): ${detail}`)
+    process.exit(1)
+  }
+
+  const records = params
+    .map((param) => ({
+      key: String(param.Name || '').split('/').filter(Boolean).pop(),
+      value: String(param.Value ?? ''),
+      version: Number(param.Version || 0),
+    }))
+    .filter((param) => param.key)
+    .sort((a, b) => a.key.localeCompare(b.key))
+
+  if (records.length === 0) {
+    console.error(`sst-env-sync: no parameters found under ${prefix} in ${REGION}; seed SSM before running SST with BOXLITE_ENV_SOURCE=ssm`)
+    process.exit(1)
+  }
+
+  writeAtomically(outFile, `${records.map((param) => dotenvLine(param.key, param.value)).join('\n')}\n`)
+
+  const secretKeys = sstSecretKeys()
+  const secretLines = records
+    .filter((param) => secretKeys.has(param.key) && param.value)
+    .map((param) => dotenvLine(param.key, param.value))
+
+  if (secretLines.length) {
+    const tempDir = mkdtempSync(join(tmpdir(), 'boxlite-sst-secrets-'))
+    const secretFile = join(tempDir, '.sst-secrets.env')
+    try {
+      writeFileSync(secretFile, `${secretLines.join('\n')}\n`, { mode: 0o600 })
+      console.log(`sst-env-sync: wrote ${outFile} (${records.length} key(s) from ${prefix}); loading ${secretLines.length} SST secret(s)`)
+      execFileSync('sst', ['secret', 'load', secretFile, '--stage', stage], { stdio: 'inherit', env: process.env })
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  } else {
+    console.log(`sst-env-sync: wrote ${outFile} (${records.length} key(s) from ${prefix}); no SST secrets matched`)
+  }
+
+  console.log(
+    `::ops-audit::${JSON.stringify({
+      phase: 'env-sync',
+      stage,
+      region: REGION,
+      prefix,
+      keyVersions: records.map((param) => ({ key: param.key, version: param.version })),
+      sstSecretKeys: records.filter((param) => secretKeys.has(param.key) && param.value).map((param) => param.key),
+    })}`,
+  )
+}
+
 const stage = resolveStage(sstArgs)
+const REGION = process.env.BOXLITE_AWS_REGION || process.env.AWS_REGION || STAGE_REGIONS[stage] || DEFAULT_REGION
 
 for (const { env, param } of CREDS) {
   if (process.env[env]) continue // already provided — don't touch
@@ -85,6 +223,8 @@ for (const { env, param } of CREDS) {
     )
   }
 }
+
+syncProductEnvFromSsm()
 
 // node_modules/.bin is on PATH because this runs via `npm run`, so `sst` resolves.
 const result = spawnSync('sst', sstArgs, { stdio: 'inherit', env: process.env })

--- a/apps/infra/sst.config.ts
+++ b/apps/infra/sst.config.ts
@@ -6,7 +6,9 @@
 /// <reference path="./.sst/platform/config.d.ts" />
 
 // ─────────────────────────────────────────────────────────────────────────────
-// BoxLite control plane on AWS (ap-southeast-1).
+// BoxLite control plane on AWS. Region is stage-scoped: dev stays in
+// ap-southeast-1, prod/production stays in us-west-2 unless explicitly
+// overridden by AWS_REGION/BOXLITE_AWS_REGION.
 //
 // Top of file: constants + helpers + the runner user-data builder.
 // Inside `run()`, resources are created in deploy order:
@@ -18,7 +20,14 @@
 //   5. observability               10. runner (EC2 + nested KVM)
 // ─────────────────────────────────────────────────────────────────────────────
 
-const REGION = 'ap-southeast-1'
+const DEFAULT_REGION = 'ap-southeast-1'
+const STAGE_REGIONS: Record<string, string> = {
+  dev: 'ap-southeast-1',
+  prod: 'us-west-2',
+  production: 'us-west-2',
+}
+const regionForStage = (stage = 'dev') => process.env.BOXLITE_AWS_REGION || process.env.AWS_REGION || STAGE_REGIONS[stage] || DEFAULT_REGION
+const isProductionStage = (stage = '') => stage === 'prod' || stage === 'production'
 const ACCOUNT_ID = '064212132677'
 const IAM_ROLE_BOUNDARY_ARN = `arn:aws:iam::${ACCOUNT_ID}:policy/boxlite-role-boundary`
 
@@ -94,12 +103,13 @@ const runnerEndpoint = (override: string, port: number, scheme: string) =>
 // ── app config ───────────────────────────────────────────────────────────────
 export default $config({
   app(input) {
+    const region = regionForStage(input?.stage)
     return {
       name: 'boxlite',
-      removal: input?.stage === 'production' ? 'retain' : 'remove',
+      removal: isProductionStage(input?.stage) ? 'retain' : 'remove',
       home: 'aws',
       providers: {
-        aws: { region: REGION, ...(process.env.AWS_PROFILE ? { profile: process.env.AWS_PROFILE } : {}) },
+        aws: { region, ...(process.env.AWS_PROFILE ? { profile: process.env.AWS_PROFILE } : {}) },
         cloudflare: '6.15.0',
         random: '4.16.6',
         // command provider: multi-runner post-deploy registration
@@ -113,6 +123,7 @@ export default $config({
     // Load .env overrides (anything unset falls back to auto-generated values)
     const { config } = await import('dotenv')
     config()
+    const region = regionForStage($app.stage)
 
     // BoxLite AWS guardrail: every managed IAM role must keep the account's
     // permissions boundary. If this is omitted, Pulumi treats the boundary as
@@ -223,7 +234,7 @@ export default $config({
     // S3 versioning is on in every stage: cheap, and the only guard against an
     // object-level overwrite/delete (which `removal` never covers). Redis is a
     // transient cache, so it needs neither.
-    const isProd = $app.stage === 'production'
+    const isProd = isProductionStage($app.stage)
     const serviceImageCache = envOr(
       'SERVICE_IMAGE_CACHE',
       $app.stage === 'prod' || $app.stage === 'production' ? 'false' : 'true',
@@ -272,7 +283,7 @@ export default $config({
     // removes the single largest by-volume consumer of fck-nat egress.
     new aws.ec2.VpcEndpoint('S3Gateway', {
       vpcId: vpc.nodes.vpc.id,
-      serviceName: `com.amazonaws.${REGION}.s3`,
+      serviceName: `com.amazonaws.${region}.s3`,
       vpcEndpointType: 'Gateway',
       routeTableIds: vpc.nodes.privateRouteTables.apply((tables) => tables.map((t) => t.id)),
     })
@@ -422,7 +433,7 @@ export default $config({
           // (ADMIN_OBSERVABILITY_CLOUDWATCH_REGION).
           actions: ['logs:DescribeLogGroups'],
           resources: [
-            $interpolate`arn:aws:logs:${REGION}:${aws.getCallerIdentityOutput().accountId}:log-group:*`,
+            $interpolate`arn:aws:logs:${region}:${aws.getCallerIdentityOutput().accountId}:log-group:*`,
           ],
         },
         {
@@ -434,8 +445,8 @@ export default $config({
         {
           actions: ['logs:FilterLogEvents'],
           resources: [
-            $interpolate`arn:aws:logs:${REGION}:${aws.getCallerIdentityOutput().accountId}:log-group:/sst/cluster/${cluster.nodes.cluster.name}/*`,
-            $interpolate`arn:aws:logs:${REGION}:${aws.getCallerIdentityOutput().accountId}:log-group:/sst/cluster/${cluster.nodes.cluster.name}/*:*`,
+            $interpolate`arn:aws:logs:${region}:${aws.getCallerIdentityOutput().accountId}:log-group:/sst/cluster/${cluster.nodes.cluster.name}/*`,
+            $interpolate`arn:aws:logs:${region}:${aws.getCallerIdentityOutput().accountId}:log-group:/sst/cluster/${cluster.nodes.cluster.name}/*:*`,
           ],
         },
         {
@@ -551,7 +562,7 @@ export default $config({
         // supported only for S3-compatible deployments (MinIO).
         S3_ENDPOINT: $interpolate`https://s3.${aws.getRegionOutput().name}.amazonaws.com`,
         S3_STS_ENDPOINT: $interpolate`https://sts.${aws.getRegionOutput().name}.amazonaws.com`,
-        S3_REGION: REGION,
+        S3_REGION: region,
         S3_DEFAULT_BUCKET: storage.name,
         S3_ACCOUNT_ID: aws.getCallerIdentityOutput().accountId,
         S3_ROLE_NAME: s3AccessRoleName,
@@ -598,7 +609,7 @@ export default $config({
           'BOX_OTEL_ENDPOINT_URL',
           envOr('OTEL_EXPORTER_OTLP_ENDPOINT', otelCollectorOtlpHttpUrl),
         ),
-        ADMIN_OBSERVABILITY_CLOUDWATCH_REGION: envOr('ADMIN_OBSERVABILITY_CLOUDWATCH_REGION', REGION),
+        ADMIN_OBSERVABILITY_CLOUDWATCH_REGION: envOr('ADMIN_OBSERVABILITY_CLOUDWATCH_REGION', region),
         ADMIN_OBSERVABILITY_CLOUDWATCH_LOG_GROUPS: envOr('ADMIN_OBSERVABILITY_CLOUDWATCH_LOG_GROUPS', ''),
         ADMIN_OBSERVABILITY_CLOUDWATCH_LOG_GROUP_PREFIX: envOr(
           'ADMIN_OBSERVABILITY_CLOUDWATCH_LOG_GROUP_PREFIX',
@@ -606,7 +617,7 @@ export default $config({
         ),
         ADMIN_OBSERVABILITY_CLOUDWATCH_LIMIT_PER_GROUP: envOr('ADMIN_OBSERVABILITY_CLOUDWATCH_LIMIT_PER_GROUP', '25'),
         ADMIN_OBSERVABILITY_CLOUDWATCH_MAX_LOG_GROUPS: envOr('ADMIN_OBSERVABILITY_CLOUDWATCH_MAX_LOG_GROUPS', '20'),
-        ADMIN_OBSERVABILITY_S3_REGION: envOr('ADMIN_OBSERVABILITY_S3_REGION', REGION),
+        ADMIN_OBSERVABILITY_S3_REGION: envOr('ADMIN_OBSERVABILITY_S3_REGION', region),
         ADMIN_OBSERVABILITY_S3_BUCKETS: envOr('ADMIN_OBSERVABILITY_S3_BUCKETS', storage.name),
         ADMIN_OBSERVABILITY_S3_MAX_OBJECTS: envOr('ADMIN_OBSERVABILITY_S3_MAX_OBJECTS', '25'),
         ...(process.env.ADMIN_OBSERVABILITY_CLICKSTACK_URL && {
@@ -921,7 +932,7 @@ export default $config({
       otelCollectorOtlpHttpUrl,
       ghcrSecret ? ghcrSecret.arn : '',
     ]).apply(([apiUrl, token, otelEndpoint, ghcrSecretArn]) =>
-      buildRunnerUserData({ apiUrl, token, otelEndpoint, ghcrSecretArn: ghcrSecretArn || undefined, ghcrUsername }),
+      buildRunnerUserData({ apiUrl, token, otelEndpoint, ghcrSecretArn: ghcrSecretArn || undefined, ghcrUsername, region }),
     )
 
     // Runners hold load-bearing box state (/var/lib/boxlite + in-memory libkrun VMs).
@@ -992,7 +1003,7 @@ export default $config({
         `boxlite-runner-${index}`,
         $resolve([api.url, apiKey.result, otelCollectorOtlpHttpUrl, ghcrSecret ? ghcrSecret.arn : '']).apply(
           ([apiUrl, token, otelEndpoint, ghcrSecretArn]) =>
-            buildRunnerUserData({ apiUrl, token, otelEndpoint, ghcrSecretArn: ghcrSecretArn || undefined, ghcrUsername }),
+            buildRunnerUserData({ apiUrl, token, otelEndpoint, ghcrSecretArn: ghcrSecretArn || undefined, ghcrUsername, region }),
         ),
       )
       return { name, apiKey, instance }
@@ -1033,6 +1044,7 @@ async function buildRunnerUserData(input: {
   otelEndpoint: string
   ghcrSecretArn?: string
   ghcrUsername?: string
+  region: string
 }): Promise<string> {
   const { readFileSync } = await import('fs')
   const { resolve } = await import('path')
@@ -1148,7 +1160,7 @@ Environment=API_VERSION=2
 Environment=API_PORT=${PORTS.RUNNER}
 Environment=RUNNER_DOMAIN=\$HOST_IP
 Environment=BOXLITE_HOME_DIR=/var/lib/boxlite
-Environment=AWS_REGION=${REGION}
+Environment=AWS_REGION=${input.region}
 Environment=OTEL_LOGGING_ENABLED=true
 Environment=OTEL_TRACING_ENABLED=true
 Environment=OTEL_EXPORTER_OTLP_ENDPOINT=${input.otelEndpoint}${input.ghcrSecretArn ? `

--- a/apps/infra/sst.config.ts
+++ b/apps/infra/sst.config.ts
@@ -19,6 +19,8 @@
 // ─────────────────────────────────────────────────────────────────────────────
 
 const REGION = 'ap-southeast-1'
+const ACCOUNT_ID = '064212132677'
+const IAM_ROLE_BOUNDARY_ARN = `arn:aws:iam::${ACCOUNT_ID}:policy/boxlite-role-boundary`
 
 // Container ports each service listens on internally
 const PORTS = {
@@ -111,6 +113,14 @@ export default $config({
     // Load .env overrides (anything unset falls back to auto-generated values)
     const { config } = await import('dotenv')
     config()
+
+    // BoxLite AWS guardrail: every managed IAM role must keep the account's
+    // permissions boundary. If this is omitted, Pulumi treats the boundary as
+    // drift and tries DeleteRolePermissionsBoundary, which the account policy
+    // explicitly denies.
+    $transform(aws.iam.Role, (args) => {
+      args.permissionsBoundary ??= IAM_ROLE_BOUNDARY_ARN
+    })
 
     // Strip trailing slash from service.url so path concat produces clean URLs
     // (api.url = "https://api.dev.boxlite.ai/" → apiBase = "https://api.dev.boxlite.ai").
@@ -214,6 +224,10 @@ export default $config({
     // object-level overwrite/delete (which `removal` never covers). Redis is a
     // transient cache, so it needs neither.
     const isProd = $app.stage === 'production'
+    const serviceImageCache = envOr(
+      'SERVICE_IMAGE_CACHE',
+      $app.stage === 'prod' || $app.stage === 'production' ? 'false' : 'true',
+    ) === 'true'
     // Unique-but-stable suffix for the DB final snapshot: a fixed name would collide
     // with the snapshot a prior teardown of the same stage already created (RDS requires
     // unique final-snapshot ids). RandomId is stable across deploys (no drift) and is
@@ -323,7 +337,7 @@ export default $config({
 
     const otelCollector = new sst.aws.Service('OtelCollector', {
       cluster,
-      image: { context: '../..', dockerfile: 'apps/otel-collector/Dockerfile', cache: false },
+      image: { context: '../..', dockerfile: 'apps/otel-collector/Dockerfile', cache: serviceImageCache },
       command: [
         '--config',
         '/otelcol/collector-config.yaml',
@@ -374,6 +388,7 @@ export default $config({
       image: {
         context: '../..',
         dockerfile: 'apps/api/Dockerfile',
+        cache: serviceImageCache,
       },
       loadBalancer: {
         domain: serviceDomain('api'),
@@ -671,7 +686,7 @@ export default $config({
     const proxyDomain = `proxy.${stackDomain}`
     new sst.aws.Service('Proxy', {
       cluster,
-      image: { context: '../..', dockerfile: 'apps/proxy/Dockerfile', cache: false },
+      image: { context: '../..', dockerfile: 'apps/proxy/Dockerfile', cache: serviceImageCache },
       loadBalancer: {
         domain: {
           name: proxyDomain,
@@ -707,7 +722,7 @@ export default $config({
     // get a stable, memorable hostname instead of the auto-generated NLB DNS name.
     const sshGateway = new sst.aws.Service('SshGateway', {
       cluster,
-      image: { context: '../..', dockerfile: 'apps/ssh-gateway/Dockerfile', cache: false },
+      image: { context: '../..', dockerfile: 'apps/ssh-gateway/Dockerfile', cache: serviceImageCache },
       loadBalancer: { rules: [{ listen: `${PORTS.SSH_GATEWAY}/tcp`, forward: `${PORTS.SSH_GATEWAY}/tcp` }] },
       environment: {
         // api-client-go composes paths like "/box/ssh-access/validate" directly.

--- a/apps/otel-collector/Dockerfile
+++ b/apps/otel-collector/Dockerfile
@@ -8,7 +8,7 @@ COPY --from=golang:1.25.4-alpine /usr/local/go/ /usr/local/go/
 
 ENV PATH="/usr/local/go/bin:${PATH}"
 
-RUN apk add --no-cache git
+RUN apk add --no-cache git build-base python3
 
 WORKDIR /boxlite/apps
 

--- a/apps/proxy/Dockerfile
+++ b/apps/proxy/Dockerfile
@@ -8,7 +8,7 @@ COPY --from=golang:1.25.4-alpine /usr/local/go/ /usr/local/go/
 
 ENV PATH="/usr/local/go/bin:${PATH}"
 
-RUN apk add --no-cache git
+RUN apk add --no-cache git build-base python3
 
 WORKDIR /boxlite/apps
 

--- a/apps/ssh-gateway/Dockerfile
+++ b/apps/ssh-gateway/Dockerfile
@@ -8,7 +8,7 @@ COPY --from=golang:1.25.4-alpine /usr/local/go/ /usr/local/go/
 
 ENV PATH="/usr/local/go/bin:${PATH}"
 
-RUN apk add --no-cache git
+RUN apk add --no-cache git build-base python3
 
 WORKDIR /boxlite/apps
 

--- a/scripts/deploy/build-runner-binary.sh
+++ b/scripts/deploy/build-runner-binary.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# Build the Linux amd64 boxlite-runner tarball without GitHub Actions.
+#
+# Run this from the checkout you want to deploy. To deploy latest main to dev:
+#   git checkout main
+#   git pull --ff-only origin main
+#   scripts/deploy/build-runner-binary.sh --output-dir dist
+# The generated tarball is intentionally named
+# `v{VERSION}-dev-{BUILD_SEQUENCE}-{GUEST_HASH}`. This script is for
+# non-published builds, so the embedded runtime cache must not share the
+# official release directory `v{VERSION}`.
+#
+# The runner is a cgo binary that links libboxlite.a. Build the embedded runtime
+# inputs first (boxlite-shim + boxlite-guest), force boxlite's build.rs to rerun
+# so those binaries are embedded, then build/stage the C SDK archive for Go.
+#
+# Usage:
+#   scripts/deploy/build-runner-binary.sh
+#   scripts/deploy/build-runner-binary.sh --output-dir /tmp
+#   BOXLITE_RUNNER_BUILD_NUMBER=123 scripts/deploy/build-runner-binary.sh
+#   scripts/deploy/build-runner-binary.sh --skip-setup
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUTPUT_DIR="$ROOT_DIR/dist"
+RUN_SETUP=1
+BUILD_SEQUENCE="${BOXLITE_RUNNER_BUILD_NUMBER:-${GITHUB_RUN_NUMBER:-}}"
+
+usage() {
+  sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+  cat <<'EOF'
+Options:
+  --output-dir DIR   Directory for the runner tarball. Default: ./dist
+  --build-number ID  Ordered dev build sequence. Default: BOXLITE_RUNNER_BUILD_NUMBER,
+                     GITHUB_RUN_NUMBER, or current UTC timestamp.
+  --skip-setup       Skip `make setup:build`.
+  -h, --help         Show this help.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-dir)
+      [[ $# -ge 2 ]] || { echo "error: --output-dir requires a value" >&2; exit 1; }
+      OUTPUT_DIR="$2"
+      shift 2
+      ;;
+    --build-number)
+      [[ $# -ge 2 ]] || { echo "error: --build-number requires a value" >&2; exit 1; }
+      BUILD_SEQUENCE="$2"
+      shift 2
+      ;;
+    --skip-setup)
+      RUN_SETUP=0
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+cd "$ROOT_DIR"
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || { echo "error: required command not found: $1" >&2; exit 1; }
+}
+
+require_cmd cargo
+require_cmd go
+require_cmd make
+require_cmd sha256sum
+require_cmd tar
+
+if [[ "$(uname -s)" != "Linux" || "$(uname -m)" != "x86_64" ]]; then
+  echo "error: runner tarball build currently requires a Linux x86_64 builder" >&2
+  exit 1
+fi
+
+VERSION="$(grep -m 1 '^version' "$ROOT_DIR/Cargo.toml" | sed -E 's/^version *= *"([^"]+)".*/\1/')"
+if [[ -z "$VERSION" ]]; then
+  echo "error: could not read version from Cargo.toml" >&2
+  exit 1
+fi
+
+if [[ -z "$BUILD_SEQUENCE" ]]; then
+  BUILD_SEQUENCE="$(date -u +%Y%m%d%H%M%S)"
+fi
+BUILD_SEQUENCE="$(printf '%s' "$BUILD_SEQUENCE" | tr -c 'A-Za-z0-9._-' '-')"
+BUILD_SEQUENCE="${BUILD_SEQUENCE#v}"
+[[ -n "$BUILD_SEQUENCE" ]] || { echo "error: build sequence cannot be empty" >&2; exit 1; }
+
+TMP_DIR="$(mktemp -d)"
+GO_WORK_BACKUP="$TMP_DIR/go.work.backup"
+GO_WORK_SUM_BACKUP="$TMP_DIR/go.work.sum.backup"
+HAD_GO_WORK=0
+HAD_GO_WORK_SUM=0
+
+restore_go_work() {
+  if [[ "$HAD_GO_WORK" -eq 1 ]]; then
+    cp "$GO_WORK_BACKUP" "$ROOT_DIR/apps/go.work"
+  else
+    rm -f "$ROOT_DIR/apps/go.work"
+  fi
+
+  if [[ "$HAD_GO_WORK_SUM" -eq 1 ]]; then
+    cp "$GO_WORK_SUM_BACKUP" "$ROOT_DIR/apps/go.work.sum"
+  else
+    rm -f "$ROOT_DIR/apps/go.work.sum"
+  fi
+
+  rm -rf "$TMP_DIR"
+}
+trap restore_go_work EXIT
+
+if [[ -f "$ROOT_DIR/apps/go.work" ]]; then
+  HAD_GO_WORK=1
+  cp "$ROOT_DIR/apps/go.work" "$GO_WORK_BACKUP"
+fi
+if [[ -f "$ROOT_DIR/apps/go.work.sum" ]]; then
+  HAD_GO_WORK_SUM=1
+  cp "$ROOT_DIR/apps/go.work.sum" "$GO_WORK_SUM_BACKUP"
+fi
+
+GO_VERSION="$(awk '/^go / { print $2; exit }' "$ROOT_DIR/apps/runner/go.mod")"
+if [[ -z "$GO_VERSION" ]]; then
+  echo "error: could not read Go version from apps/runner/go.mod" >&2
+  exit 1
+fi
+
+cat > "$ROOT_DIR/apps/go.work" <<EOF
+go $GO_VERSION
+
+use (
+	./runner
+	./common-go
+	./api-client-go
+	../sdks/go
+)
+EOF
+
+echo "==> Building boxlite-runner from package v$VERSION at $(git rev-parse --short HEAD)"
+echo "==> Non-release artifact version prefix: v${VERSION}-dev-${BUILD_SEQUENCE}"
+
+echo "==> Cleaning runner build artifacts"
+cargo clean -p boxlite -p boxlite-c -p boxlite-shim -p boxlite-guest
+rm -f \
+  "$ROOT_DIR/sdks/go/libboxlite.a" \
+  "$ROOT_DIR/target/release/libboxlite.a" \
+  "$ROOT_DIR/target/release/libboxlite.so" \
+  "$ROOT_DIR/target/release/boxlite-shim"
+rm -f "$ROOT_DIR/target/x86_64-unknown-linux-gnu/release/boxlite-shim"
+rm -f "$ROOT_DIR/target/x86_64-unknown-linux-musl/release/boxlite-guest"
+rm -rf "$ROOT_DIR/sdks/c/dist"
+
+if [[ "$RUN_SETUP" -eq 1 ]]; then
+  make setup:build
+fi
+
+scripts/build/build-shim.sh --profile release
+scripts/build/build-guest.sh --profile release
+GUEST_BIN="$ROOT_DIR/target/x86_64-unknown-linux-musl/release/boxlite-guest"
+[[ -x "$GUEST_BIN" ]] || { echo "error: guest binary not found after build: $GUEST_BIN" >&2; exit 1; }
+GUEST_SHA256="$(sha256sum "$GUEST_BIN" | awk '{print $1}')"
+RUNTIME_SUFFIX="${GUEST_SHA256:0:12}"
+RUNTIME_CACHE_SUFFIX="dev-${BUILD_SEQUENCE}-${RUNTIME_SUFFIX}"
+RUNNER_VERSION="${VERSION}-${RUNTIME_CACHE_SUFFIX}"
+
+echo "==> Building libboxlite with runtime cache key v${RUNNER_VERSION}"
+BOXLITE_RUNTIME_CACHE_VERSION="$VERSION" \
+  BOXLITE_RUNTIME_CACHE_SUFFIX="$RUNTIME_CACHE_SUFFIX" \
+  make dist:c
+cp "$ROOT_DIR/target/release/libboxlite.a" "$ROOT_DIR/sdks/go/libboxlite.a"
+
+go -C apps/runner mod download
+go -C apps/common-go mod download
+go -C apps/api-client-go mod download
+
+RUNNER_BIN="$TMP_DIR/boxlite-runner"
+CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -C apps \
+  -ldflags "-X github.com/boxlite-ai/runner/internal.Version=${RUNNER_VERSION}" \
+  -o "$RUNNER_BIN" ./runner/cmd/runner
+printf '%s  boxlite-guest\n' "$GUEST_SHA256" > "$TMP_DIR/boxlite-runner.guest.sha256"
+echo "==> Wrote guest hash sidecar ${GUEST_SHA256:0:12}"
+printf '%s\n' "$RUNTIME_CACHE_SUFFIX" > "$TMP_DIR/boxlite-runner.runtime-suffix"
+echo "==> Runtime cache directory: v${RUNNER_VERSION}"
+
+mkdir -p "$OUTPUT_DIR"
+TARBALL="$OUTPUT_DIR/boxlite-runner-v${RUNNER_VERSION}-linux-amd64.tar.gz"
+tar czf "$TARBALL" -C "$TMP_DIR" \
+  boxlite-runner \
+  boxlite-runner.guest.sha256 \
+  boxlite-runner.runtime-suffix
+
+if command -v sha256sum >/dev/null 2>&1; then
+  sha256sum "$TARBALL" > "$TARBALL.sha256"
+else
+  shasum -a 256 "$TARBALL" > "$TARBALL.sha256"
+fi
+
+echo "==> Wrote $TARBALL"
+echo "==> Wrote $TARBALL.sha256"

--- a/scripts/deploy/runner-update-binary.sh
+++ b/scripts/deploy/runner-update-binary.sh
@@ -1,9 +1,13 @@
 #!/usr/bin/env bash
 # Upgrade the boxlite-runner binary on the live Runner EC2 in-place.
 #
-# Replaces /usr/local/bin/boxlite-runner with a freshly downloaded release
-# binary and restarts the systemd unit. The EC2 instance itself is not
-# replaced; box state under /var/lib/boxlite is preserved.
+# Installs the new binary into a versioned release directory, points
+# /usr/local/bin/boxlite-runner at it, restarts the systemd unit, and verifies
+# that detached box shims that were alive before the restart are still alive and
+# can be re-attached by the new runner. The EC2 instance itself is not replaced;
+# box state under /var/lib/boxlite is preserved. It uploads the locally built
+# runner tarball to a temporary S3 location, then asks SSM to install it on the
+# target runner.
 #
 # Pair with the `ignoreChanges: ["ami", "userDataBase64"]` setting on the
 # Runner resource in apps/infra/sst.config.ts — that prevents `sst deploy`
@@ -12,19 +16,92 @@
 #
 # Usage:
 #   scripts/deploy/runner-update-binary.sh                  # version from Cargo.toml
-#   scripts/deploy/runner-update-binary.sh 0.9.5            # explicit version
+#   scripts/deploy/runner-update-binary.sh 0.9.7-dev-123-58d8f01bcd02
+#   scripts/deploy/runner-update-binary.sh --output-dir /tmp/dist 0.9.7-dev-123-58d8f01bcd02
 #   AWS_REGION=us-west-2 scripts/deploy/runner-update-binary.sh
 #   STAGE=production scripts/deploy/runner-update-binary.sh
+#   RUNNER_INSTANCE_ID=i-0123456789abcdef0 scripts/deploy/runner-update-binary.sh
+#   PROD_RUNNER_INSTANCE_ID=i-0123456789abcdef0 STAGE=production scripts/deploy/runner-update-binary.sh
 
 set -euo pipefail
 
-AWS_REGION="${AWS_REGION:-ap-southeast-1}"
 STAGE="${STAGE:-dev}"
+DEV_AWS_REGION="${DEV_AWS_REGION:-ap-southeast-1}"
+DEV_RUNNER_INSTANCE_NAME="${DEV_RUNNER_INSTANCE_NAME:-boxlite-dev-runner-default}"
+DEV_RUNNER_INSTANCE_ID="${DEV_RUNNER_INSTANCE_ID:-}"
+PROD_AWS_REGION="${PROD_AWS_REGION:-us-west-2}"
+PROD_RUNNER_INSTANCE_NAME="${PROD_RUNNER_INSTANCE_NAME:-boxlite-prod-runner-default}"
+PROD_RUNNER_INSTANCE_ID="${PROD_RUNNER_INSTANCE_ID:-}"
+AWS_REGION="${AWS_REGION:-}"
+RUNNER_INSTANCE_NAME="${RUNNER_INSTANCE_NAME:-}"
+RUNNER_INSTANCE_ID="${RUNNER_INSTANCE_ID:-}"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ARTIFACT_DIR="${RUNNER_ARTIFACT_DIR:-$REPO_ROOT/dist}"
+RUNNER_ARTIFACT_S3_URI="${RUNNER_ARTIFACT_S3_URI:-}"
+VERSION=""
 
-if [[ $# -ge 1 ]]; then
-  VERSION="$1"
-else
+usage() {
+  sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-dir|--artifact-dir)
+      [[ $# -ge 2 ]] || { echo "error: $1 requires a value" >&2; exit 1; }
+      ARTIFACT_DIR="$2"
+      shift 2
+      ;;
+    --version)
+      [[ $# -ge 2 ]] || { echo "error: --version requires a value" >&2; exit 1; }
+      VERSION="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    -*)
+      echo "error: unknown option $1" >&2
+      usage >&2
+      exit 1
+      ;;
+    *)
+      if [[ -n "$VERSION" ]]; then
+        echo "error: unexpected extra argument $1" >&2
+        usage >&2
+        exit 1
+      fi
+      VERSION="$1"
+      shift
+      ;;
+  esac
+done
+
+command -v aws >/dev/null 2>&1 || { echo "error: required command not found: aws" >&2; exit 1; }
+
+case "$STAGE" in
+  dev|production) ;;
+  prod) STAGE="production" ;;
+  *)
+    echo "error: STAGE must be dev or production (got: $STAGE)" >&2
+    exit 1
+    ;;
+esac
+
+case "$STAGE" in
+  dev)
+    AWS_REGION="${AWS_REGION:-$DEV_AWS_REGION}"
+    RUNNER_INSTANCE_ID="${RUNNER_INSTANCE_ID:-$DEV_RUNNER_INSTANCE_ID}"
+    RUNNER_INSTANCE_NAME="${RUNNER_INSTANCE_NAME:-$DEV_RUNNER_INSTANCE_NAME}"
+    ;;
+  production)
+    AWS_REGION="${AWS_REGION:-$PROD_AWS_REGION}"
+    RUNNER_INSTANCE_ID="${RUNNER_INSTANCE_ID:-$PROD_RUNNER_INSTANCE_ID}"
+    RUNNER_INSTANCE_NAME="${RUNNER_INSTANCE_NAME:-$PROD_RUNNER_INSTANCE_NAME}"
+    ;;
+esac
+
+if [[ -z "$VERSION" ]]; then
   VERSION=$(grep -m 1 '^version' "$REPO_ROOT/Cargo.toml" | sed -E 's/^version *= *"([^"]+)".*/\1/')
   if [[ -z "$VERSION" ]]; then
     echo "error: could not read version from Cargo.toml at $REPO_ROOT/Cargo.toml" >&2
@@ -32,66 +109,415 @@ else
   fi
 fi
 
-echo "==> Upgrading boxlite-runner to v$VERSION on stage=$STAGE region=$AWS_REGION"
+ASSET_TARBALL="boxlite-runner-v${VERSION}-linux-amd64.tar.gz"
+LOCAL_TARBALL="$ARTIFACT_DIR/$ASSET_TARBALL"
+LOCAL_SHA="$LOCAL_TARBALL.sha256"
+RUNTIME_CACHE_VERSION="${VERSION%%-dev-*}"
 
-INSTANCE_ID=$(aws ec2 describe-instances --region "$AWS_REGION" \
-  --filters "Name=tag:Name,Values=boxlite-runner-default" "Name=instance-state-name,Values=running" \
-  --query 'Reservations[].Instances[].InstanceId' --output text)
-
-if [[ -z "$INSTANCE_ID" || "$INSTANCE_ID" == "None" ]]; then
-  echo "error: no running boxlite-runner-default instance found in region $AWS_REGION" >&2
+if [[ ! -f "$LOCAL_TARBALL" ]]; then
+  echo "error: local runner tarball not found: $LOCAL_TARBALL" >&2
+  echo "       run scripts/deploy/build-runner-binary.sh first, or set --output-dir/RUNNER_ARTIFACT_DIR" >&2
   exit 1
+fi
+if [[ ! -f "$LOCAL_SHA" ]]; then
+  echo "error: local runner checksum not found: $LOCAL_SHA" >&2
+  echo "       run scripts/deploy/build-runner-binary.sh first" >&2
+  exit 1
+fi
+
+echo "==> Upgrading boxlite-runner from local artifact v$VERSION on stage=$STAGE region=$AWS_REGION"
+
+if [[ -n "$RUNNER_INSTANCE_ID" ]]; then
+  INSTANCE_ID="$RUNNER_INSTANCE_ID"
+else
+  INSTANCE_FILTERS=(
+    "Name=tag:Name,Values=${RUNNER_INSTANCE_NAME}"
+    "Name=instance-state-name,Values=running"
+  )
+  INSTANCE_IDS=()
+  while IFS= read -r instance_id; do
+    INSTANCE_IDS+=("$instance_id")
+  done < <(aws ec2 describe-instances --region "$AWS_REGION" \
+    --filters "${INSTANCE_FILTERS[@]}" \
+    --query 'Reservations[].Instances[].InstanceId' --output text | tr '\t' '\n' | sed '/^$/d')
+
+  if [[ "${#INSTANCE_IDS[@]}" -ne 1 ]]; then
+    echo "error: expected exactly one running runner instance, found ${#INSTANCE_IDS[@]}" >&2
+    echo "       region=$AWS_REGION stage=$STAGE name=$RUNNER_INSTANCE_NAME" >&2
+    if [[ "${#INSTANCE_IDS[@]}" -gt 0 ]]; then
+      printf '       matches: %s\n' "${INSTANCE_IDS[*]}" >&2
+    fi
+    echo "       set RUNNER_INSTANCE_ID=i-... to target an instance explicitly" >&2
+    exit 1
+  fi
+  INSTANCE_ID="${INSTANCE_IDS[0]}"
 fi
 echo "    instance: $INSTANCE_ID"
 
-ASSET_BASE="https://github.com/boxlite-ai/boxlite/releases/download/v${VERSION}"
-ASSET_TARBALL="boxlite-runner-v${VERSION}-linux-amd64.tar.gz"
+if [[ -z "$RUNNER_ARTIFACT_S3_URI" ]]; then
+  ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+  RUNNER_ARTIFACT_S3_URI="s3://boxlite-${STAGE}-runner-builds/tmp/runner-rollouts/${ACCOUNT_ID}/${VERSION}/$(date -u +%Y%m%dT%H%M%SZ)"
+fi
+REMOTE_TARBALL_URL="${RUNNER_ARTIFACT_S3_URI%/}/$ASSET_TARBALL"
+REMOTE_SHA_URL="$REMOTE_TARBALL_URL.sha256"
+echo "==> Uploading local artifact to $RUNNER_ARTIFACT_S3_URI"
+aws s3 cp --region "$AWS_REGION" "$LOCAL_TARBALL" "$REMOTE_TARBALL_URL"
+aws s3 cp --region "$AWS_REGION" "$LOCAL_SHA" "$REMOTE_SHA_URL"
+PRESIGNED_TARBALL_URL=$(aws s3 presign --region "$AWS_REGION" "$REMOTE_TARBALL_URL" --expires-in 3600)
+PRESIGNED_SHA_URL=$(aws s3 presign --region "$AWS_REGION" "$REMOTE_SHA_URL" --expires-in 3600)
 
 # Remote upgrade script. Mirrors the boot user-data's integrity policy and adds a
 # rollback: download + checksum-verify BEFORE stopping the unit (so a failed or
-# corrupt fetch never takes the runner down), back up the live binary, swap it in,
-# and restore the backup if the new binary fails to come up.
+# corrupt fetch never takes the runner down), install the new binary into a
+# versioned release directory, switch the live symlink, and switch back if the
+# new binary fails to come up.
 read -r -d '' SCRIPT <<EOF || true
 set -euo pipefail
-echo "current version:"
-/usr/local/bin/boxlite-runner --version || true
+SERVICE=boxlite-runner
+RUNNER_BIN=/usr/local/bin/boxlite-runner
+RELEASES_DIR=/usr/local/lib/boxlite-runner/releases
+KEEP_RELEASES=\${RUNNER_KEEP_RELEASES:-5}
+HOT_SNAPSHOT=\$(mktemp)
+
+load_runner_env() {
+  API_PORT=8080
+  BOXLITE_HOME_DIR=/var/lib/boxlite
+  BOXLITE_RUNNER_TOKEN=
+  ENABLE_TLS=false
+  while IFS= read -r kv; do
+    case "\$kv" in
+      API_PORT=*) API_PORT="\${kv#API_PORT=}" ;;
+      BOXLITE_HOME_DIR=*) BOXLITE_HOME_DIR="\${kv#BOXLITE_HOME_DIR=}" ;;
+      BOXLITE_RUNNER_TOKEN=*) BOXLITE_RUNNER_TOKEN="\${kv#BOXLITE_RUNNER_TOKEN=}" ;;
+      API_TOKEN=*) [ -n "\$BOXLITE_RUNNER_TOKEN" ] || BOXLITE_RUNNER_TOKEN="\${kv#API_TOKEN=}" ;;
+      ENABLE_TLS=*) ENABLE_TLS="\${kv#ENABLE_TLS=}" ;;
+    esac
+  done < <(systemctl show "\$SERVICE" --property=Environment --value | tr ' ' '\n')
+  if [ -z "\$BOXLITE_RUNNER_TOKEN" ]; then
+    echo "FATAL: could not read BOXLITE_RUNNER_TOKEN/API_TOKEN from \$SERVICE environment" >&2
+    exit 1
+  fi
+  if [ "\$ENABLE_TLS" = true ]; then
+    RUNNER_BASE_URL="https://127.0.0.1:\$API_PORT"
+    CURL_TLS=(-k)
+  else
+    RUNNER_BASE_URL="http://127.0.0.1:\$API_PORT"
+    CURL_TLS=()
+  fi
+}
+
+proc_start_time() {
+  awk '{print \$22}' "/proc/\$1/stat" 2>/dev/null || true
+}
+
+proc_state() {
+  awk '{print \$3}' "/proc/\$1/stat" 2>/dev/null || true
+}
+
+pid_alive() {
+  local pid="\$1"
+  [ -n "\$pid" ] || return 1
+  kill -0 "\$pid" 2>/dev/null || return 1
+  [ "\$(proc_state "\$pid")" != Z ]
+}
+
+snapshot_live_detached_shims() {
+  : > "\$HOT_SNAPSHOT"
+  local boxes_dir="\$BOXLITE_HOME_DIR/boxes"
+  [ -d "\$boxes_dir" ] || return 0
+  while IFS= read -r pid_file; do
+    local box_id pid start actual_start
+    box_id="\$(basename "\$(dirname "\$pid_file")")"
+    pid="\$(sed -n '1p' "\$pid_file" 2>/dev/null | tr -dc '0-9')"
+    start="\$(sed -n '2p' "\$pid_file" 2>/dev/null | tr -dc '0-9')"
+    pid_alive "\$pid" || continue
+    if [ -n "\$start" ]; then
+      actual_start="\$(proc_start_time "\$pid")"
+      [ "\$actual_start" = "\$start" ] || continue
+    fi
+    printf '%s %s %s\n' "\$box_id" "\$pid" "\$start" >> "\$HOT_SNAPSHOT"
+  done < <(find "\$boxes_dir" -mindepth 2 -maxdepth 2 -name shim.pid -type f 2>/dev/null | sort)
+}
+
+wait_runner_ready() {
+  local i
+  for i in \$(seq 1 30); do
+    if curl -fsS "\${CURL_TLS[@]}" "\$RUNNER_BASE_URL/" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "FATAL: runner API did not become ready at \$RUNNER_BASE_URL" >&2
+  return 1
+}
+
+verify_runner_health_samples() {
+  local i
+  for i in 1 2; do
+    curl -fsS "\${CURL_TLS[@]}" \
+      -H "Authorization: Bearer \$BOXLITE_RUNNER_TOKEN" \
+      "\$RUNNER_BASE_URL/info" >/dev/null || {
+        echo "FATAL: runner health sample \$i failed at \$RUNNER_BASE_URL/info" >&2
+        return 1
+      }
+    echo "runner health sample \$i: ok"
+    [ "\$i" -eq 2 ] || sleep 2
+  done
+}
+
+runtime_cache_dirs() {
+  local version_dir="\${RUNTIME_CACHE_DIR_NAME:-v${RUNTIME_CACHE_VERSION}}"
+  local -a data_roots=()
+  local svc_user svc_home env_value
+
+  svc_user=\$(systemctl show "\$SERVICE" --property=User --value 2>/dev/null || true)
+  if [ -z "\$svc_user" ]; then
+    svc_user=root
+  fi
+
+  svc_home=\$(getent passwd "\$svc_user" 2>/dev/null | cut -d: -f6 || true)
+  [ -n "\$svc_home" ] && data_roots+=("\$svc_home/.local/share")
+
+  while IFS= read -r env_value; do
+    case "\$env_value" in
+      XDG_DATA_HOME=*) data_roots+=("\${env_value#XDG_DATA_HOME=}") ;;
+      HOME=*) data_roots+=("\${env_value#HOME=}/.local/share") ;;
+    esac
+  done < <(systemctl show "\$SERVICE" --property=Environment --value | tr ' ' '\n')
+
+  data_roots+=("/root/.local/share")
+  for home in /home/*; do
+    [ -d "\$home" ] && data_roots+=("\$home/.local/share")
+  done
+
+  local seen=" "
+  local root cache_dir
+  for root in "\${data_roots[@]}"; do
+    [ -n "\$root" ] || continue
+    case "\$seen" in *" \$root "*) continue ;; esac
+    seen="\$seen\$root "
+    cache_dir="\$root/boxlite/runtimes/\$version_dir"
+    [ -d "\$cache_dir" ] && printf '%s\n' "\$cache_dir"
+  done
+}
+
+verify_embedded_runtime_hash() {
+  local checked=0
+  local cache_dir guest_hash
+
+  if [ -z "\${GUEST_EXPECTED:-}" ]; then
+    echo "embedded runtime guest hash verification skipped: no expected guest hash sidecar"
+    return 0
+  fi
+
+  while IFS= read -r cache_dir; do
+    [ -n "\$cache_dir" ] || continue
+    if [ ! -f "\$cache_dir/boxlite-guest" ]; then
+      continue
+    fi
+    checked=\$((checked + 1))
+    guest_hash=\$(sha256sum "\$cache_dir/boxlite-guest" | awk '{print \$1}')
+    if [ "\$guest_hash" != "\$GUEST_EXPECTED" ]; then
+      echo "FATAL: embedded runtime guest hash mismatch in \$cache_dir (expected=\${GUEST_EXPECTED:0:12} actual=\${guest_hash:0:12})" >&2
+      return 1
+    fi
+    echo "embedded runtime guest hash verified: \${guest_hash:0:12} (\$cache_dir)"
+  done < <(runtime_cache_dirs)
+
+  if [ "\$checked" -eq 0 ]; then
+    echo "embedded runtime guest hash verification deferred: runtime cache not extracted yet for \$RUNTIME_CACHE_DIR_NAME"
+  fi
+}
+
+verify_hot_adopted_shims() {
+  local count=0
+  if [ ! -s "\$HOT_SNAPSHOT" ]; then
+    echo "hot rollout: no live detached shims to adopt"
+    return 0
+  fi
+
+  while read -r box_id before_pid before_start; do
+    [ -n "\$box_id" ] || continue
+    count=\$((count + 1))
+    local pid_file now_pid now_start
+    pid_file="\$BOXLITE_HOME_DIR/boxes/\$box_id/shim.pid"
+    now_pid="\$(sed -n '1p' "\$pid_file" 2>/dev/null | tr -dc '0-9')"
+    now_start="\$(sed -n '2p' "\$pid_file" 2>/dev/null | tr -dc '0-9')"
+    [ "\$now_pid" = "\$before_pid" ] || {
+      echo "FATAL: box \$box_id shim pid changed across rollout (before=\$before_pid after=\$now_pid)" >&2
+      return 1
+    }
+    pid_alive "\$now_pid" || {
+      echo "FATAL: box \$box_id shim pid \$now_pid is not alive after rollout" >&2
+      return 1
+    }
+    if [ -n "\$before_start" ]; then
+      [ "\$now_start" = "\$before_start" ] || {
+        echo "FATAL: box \$box_id shim start-time changed across rollout" >&2
+        return 1
+      }
+      [ "\$(proc_start_time "\$now_pid")" = "\$before_start" ] || {
+        echo "FATAL: box \$box_id shim pid \$now_pid failed start-time verification" >&2
+        return 1
+      }
+    fi
+
+    # This forces the new runner process through getOrFetchBox -> runtime.Get ->
+    # vmm_attach for boxes that only existed in the previous runner's memory.
+    curl -fsS "\${CURL_TLS[@]}" \
+      -H "Authorization: Bearer \$BOXLITE_RUNNER_TOKEN" \
+      "\$RUNNER_BASE_URL/v1/boxes/\$box_id/metrics" >/dev/null || {
+        echo "FATAL: new runner failed to attach/probe detached box \$box_id" >&2
+        return 1
+      }
+    echo "hot rollout: adopted \$box_id pid=\$now_pid"
+  done < "\$HOT_SNAPSHOT"
+
+  echo "hot rollout: adopted \$count detached box(es)"
+}
+
+prepare_release_target() {
+  local source_binary="\$1"
+  local release_id="\$2"
+  local release_dir="\$RELEASES_DIR/\$release_id"
+  mkdir -p "\$release_dir"
+  install -m 0755 "\$source_binary" "\$release_dir/boxlite-runner"
+  sha256sum "\$release_dir/boxlite-runner" | awk '{print \$1}' > "\$release_dir/boxlite-runner.sha256"
+  printf '%s\n' "\$release_dir/boxlite-runner"
+}
+
+verify_release_target() {
+  local target="\$1"
+  local label="\$2"
+  local expected actual sha_file
+
+  if [ ! -x "\$target" ]; then
+    echo "FATAL: \$label runner target is not executable: \$target" >&2
+    return 1
+  fi
+
+  sha_file="\$(dirname "\$target")/boxlite-runner.sha256"
+  actual=\$(sha256sum "\$target" | awk '{print \$1}')
+  if [ -f "\$sha_file" ]; then
+    expected=\$(awk '{print \$1}' "\$sha_file")
+    if [ "\$expected" != "\$actual" ]; then
+      echo "FATAL: \$label runner target hash mismatch: \$target (expected=\${expected:0:12} actual=\${actual:0:12})" >&2
+      return 1
+    fi
+  else
+    echo "\$actual" > "\$sha_file"
+    echo "WARNING: \$label runner target had no hash sidecar; recorded current hash \${actual:0:12}" >&2
+  fi
+
+  echo "\$label runner target verified: \${actual:0:12} (\$target)"
+}
+
+current_runner_target() {
+  if [ -L "\$RUNNER_BIN" ]; then
+    readlink -f "\$RUNNER_BIN" 2>/dev/null || true
+  elif [ -x "\$RUNNER_BIN" ]; then
+    local legacy_dir="\$RELEASES_DIR/legacy-\$(date +%Y%m%d%H%M%S)"
+    mkdir -p "\$legacy_dir"
+    cp -a "\$RUNNER_BIN" "\$legacy_dir/boxlite-runner"
+    sha256sum "\$legacy_dir/boxlite-runner" | awk '{print \$1}' > "\$legacy_dir/boxlite-runner.sha256"
+    printf '%s\n' "\$legacy_dir/boxlite-runner"
+  fi
+}
+
+activate_runner_target() {
+  local target="\$1"
+  ln -sfn "\$target" "\$RUNNER_BIN"
+}
+
+prune_old_releases() {
+  [ "\$KEEP_RELEASES" -gt 0 ] 2>/dev/null || return 0
+  [ -d "\$RELEASES_DIR" ] || return 0
+  find "\$RELEASES_DIR" -mindepth 1 -maxdepth 1 -type d -printf '%T@ %p\n' \
+    | sort -rn \
+    | awk -v keep="\$KEEP_RELEASES" 'NR > keep { sub(/^[^ ]+ /, ""); print }' \
+    | while IFS= read -r old_dir; do
+        rm -rf "\$old_dir"
+      done
+}
+
+restart_with_target() {
+  local target="\$1"
+  systemctl stop "\$SERVICE" || true
+  activate_runner_target "\$target" || return 1
+  systemctl start "\$SERVICE" || return 1
+  sleep 2
+  systemctl is-active --quiet "\$SERVICE" || return 1
+  wait_runner_ready || return 1
+  verify_runner_health_samples || return 1
+  verify_embedded_runtime_hash || return 1
+  verify_hot_adopted_shims || return 1
+}
+
+load_runner_env
+snapshot_live_detached_shims
+echo "hot rollout: captured \$(wc -l < "\$HOT_SNAPSHOT" | tr -d ' ') live detached shim(s)"
 
 WORK=\$(mktemp -d)
-trap 'rm -rf "\$WORK"' EXIT
-curl -fsSL "${ASSET_BASE}/${ASSET_TARBALL}" -o "\$WORK/runner.tar.gz"
-if curl -fsSL "${ASSET_BASE}/${ASSET_TARBALL}.sha256" -o "\$WORK/runner.sha256"; then
+trap 'rm -rf "\$WORK"; rm -f "\$HOT_SNAPSHOT"' EXIT
+curl -fsSL "${PRESIGNED_TARBALL_URL}" -o "\$WORK/runner.tar.gz"
+if curl -fsSL "${PRESIGNED_SHA_URL}" -o "\$WORK/runner.sha256"; then
   EXPECTED=\$(awk '{print \$1}' "\$WORK/runner.sha256")
   ACTUAL=\$(sha256sum "\$WORK/runner.tar.gz" | awk '{print \$1}')
   [ "\$EXPECTED" = "\$ACTUAL" ] || { echo "FATAL: checksum mismatch (want \$EXPECTED got \$ACTUAL)" >&2; exit 1; }
   echo "checksum verified (\$ACTUAL)"
 else
-  echo "WARNING: no .sha256 published for v${VERSION}; installing without integrity verification" >&2
+  echo "WARNING: no checksum available for runner tarball; installing without integrity verification" >&2
 fi
 tar -xzf "\$WORK/runner.tar.gz" -C "\$WORK"
 test -x "\$WORK/boxlite-runner" || { echo "FATAL: tarball has no boxlite-runner binary" >&2; exit 1; }
-
-# Back up the live binary (if any) so a failed swap or start can roll back.
-HAD_PREVIOUS=false
-if [ -x /usr/local/bin/boxlite-runner ]; then
-  cp -a /usr/local/bin/boxlite-runner /usr/local/bin/boxlite-runner.bak
-  HAD_PREVIOUS=true
+if [ -f "\$WORK/boxlite-runner.guest.sha256" ]; then
+  GUEST_EXPECTED=\$(awk '{print \$1}' "\$WORK/boxlite-runner.guest.sha256")
+  echo "runner expected guest hash: \${GUEST_EXPECTED:0:12}"
+else
+  GUEST_EXPECTED=""
+  echo "WARNING: tarball has no guest hash sidecar; skipping pre-install guest hash verification" >&2
 fi
-systemctl stop boxlite-runner || true
+if [ -f "\$WORK/boxlite-runner.runtime-suffix" ]; then
+  RUNTIME_SUFFIX=\$(tr -dc 'A-Za-z0-9._-' < "\$WORK/boxlite-runner.runtime-suffix")
+  if [ -n "\$RUNTIME_SUFFIX" ]; then
+    RUNTIME_CACHE_DIR_NAME="v${RUNTIME_CACHE_VERSION}-\$RUNTIME_SUFFIX"
+    echo "runner runtime cache key: \$RUNTIME_CACHE_DIR_NAME"
+  else
+    RUNTIME_CACHE_DIR_NAME="v${RUNTIME_CACHE_VERSION}"
+    echo "WARNING: runtime suffix sidecar is empty; using \$RUNTIME_CACHE_DIR_NAME" >&2
+  fi
+else
+  RUNTIME_CACHE_DIR_NAME="v${RUNTIME_CACHE_VERSION}"
+  echo "runner runtime cache key: \$RUNTIME_CACHE_DIR_NAME"
+fi
+
+CURRENT_TARGET=\$(current_runner_target)
+NEW_TARGET=\$(prepare_release_target "\$WORK/boxlite-runner" "v${VERSION}")
+verify_release_target "\$NEW_TARGET" "new" || exit 1
+echo "install target: \$NEW_TARGET"
+if [ -n "\$CURRENT_TARGET" ]; then
+  verify_release_target "\$CURRENT_TARGET" "rollback" || exit 1
+  echo "rollback target: \$CURRENT_TARGET"
+else
+  echo "rollback target: none"
+fi
+
 # Swap + start + health as one guarded condition: a failing step here (install error,
 # start failure, or an unhealthy unit) routes to the rollback branch instead of aborting
 # the script under set -e — commands in an if-condition are exempt from set -e.
-if install -m 0755 "\$WORK/boxlite-runner" /usr/local/bin/boxlite-runner && systemctl start boxlite-runner && sleep 2 && systemctl is-active --quiet boxlite-runner; then
-  [ "\$HAD_PREVIOUS" = true ] && rm -f /usr/local/bin/boxlite-runner.bak
+if restart_with_target "\$NEW_TARGET"; then
+  prune_old_releases
   echo "systemd unit: active"
-  echo "new version:"
-  /usr/local/bin/boxlite-runner --version
 else
-  echo "upgrade failed; rolling back" >&2
-  if [ "\$HAD_PREVIOUS" = true ]; then
-    mv -f /usr/local/bin/boxlite-runner.bak /usr/local/bin/boxlite-runner
-    systemctl restart boxlite-runner || true
+  echo "upgrade failed or detached-box adoption failed; rolling back" >&2
+  if [ -n "\$CURRENT_TARGET" ]; then
+    if restart_with_target "\$CURRENT_TARGET"; then
+      echo "rollback complete"
+    else
+      echo "rollback failed" >&2
+    fi
   fi
-  journalctl -u boxlite-runner --no-pager -n 50 || true
+  journalctl -u "\$SERVICE" --no-pager -n 50 || true
   exit 1
 fi
 EOF


### PR DESCRIPTION
## Summary

Draft PR for the EC2 dev smoke runner rollout path.

This branch stages the product-side pieces that Ops Console currently needs for runner rollout testing:

- add `scripts/deploy/build-runner-binary.sh` to produce runner tarball + sha256 artifacts
- extend `scripts/deploy/runner-update-binary.sh` for release/dev artifacts, S3 staging, checksum verification, SSM install, systemd verification, and rollback target handling
- extend `apps/infra/scripts/sst-with-cloudflare.mjs` so self-host deploys can sync product env from SSM into `.env` and load selected SST secrets
- adjust `apps/infra/sst.config.ts` for the related deploy/runner artifact path

## EC2 smoke evidence

Tested through Ops Console UI against dev runner `i-0ee6bc569d5a1e9ef`:

- UI-triggered runner upgrade dispatched and completed
- runner artifact was built on the Ops EC2 buildbox
- artifact uploaded to `s3://boxlite-dev-runner-builds/...`
- SSM update completed successfully on the target runner
- checksum verified
- runner systemd was active after update
- hot rollout adopted 2 detached boxes during upgrade
- UI-triggered rollback to `0.9.7` completed successfully
- runner symlink returned to `/usr/local/lib/boxlite-runner/releases/v0.9.7/boxlite-runner`

## Known issues / why draft

- This branch is currently based on an older product commit and should be reviewed/rebased before merge.
- The tested dev-build runner installed successfully, but post-update `START_BOX` failed with `Guest binary hash mismatch`; rollback restored `v0.9.7`.
- Rollback input currently expects `0.9.7`, not `v0.9.7`; entering `v0.9.7` produced `vv0.9.7` and a 404.
- After rollback, runner systemd is active, but the runner still has a lower-level `libkrun status=-22` START_BOX failure that is outside this PR's rollout mechanics.

## Test plan

- [x] Ops Console UI -> runner upgrade -> target dev runner
- [x] Build runner artifact on EC2 buildbox
- [x] Upload artifact to S3
- [x] SSM install/swap on runner
- [x] UI-triggered rollback to release `0.9.7`
- [ ] Rebase/clean branch against latest `main`
- [ ] Fix release version input normalization (`v0.9.7` vs `0.9.7`)
- [ ] Resolve runner runtime `START_BOX` health failures before marking production-ready
