### PR TITLE
fix(runner): support raw file uploads

### DIFF
--- a/apps/runner/README.md
+++ b/apps/runner/README.md
@@ -409,8 +409,10 @@ a feature.
 
 Tar framing is used for directory-shaped transfers so a single endpoint can
 move files, directories, and symlinks uniformly. `application/octet-stream`
-is accepted for clients that need to upload one file verbatim. Temp files live
-under `os.TempDir()` and are cleaned up before the response returns.
+is accepted for clients that need to upload one file verbatim; raw uploads are
+streamed through a guest-side command so tmpfs destinations such as `/tmp` are
+written to the live mount. Temp files live under `os.TempDir()` and are cleaned
+up before the response returns.
 
 ### 5. Per-box metrics
 

--- a/apps/runner/README.md
+++ b/apps/runner/README.md
@@ -404,12 +404,13 @@ a feature.
 
 | Method | Path | Controller | Purpose |
 | --- | --- | --- | --- |
-| `PUT` | `/v1/boxes/:boxId/files?path=<dest>` | `BoxliteFileUpload` | Stream tar body → temp file → `CopyInto(box, tmp, dest)` |
+| `PUT` | `/v1/boxes/:boxId/files?path=<dest>` | `BoxliteFileUpload` | `application/x-tar` extracts before `CopyInto`; `application/octet-stream` copies the raw body as one file |
 | `GET` | `/v1/boxes/:boxId/files?path=<src>` | `BoxliteFileDownload` | `CopyOut(box, src, tmpDir)` → walk dir, write `application/x-tar` |
 
-Tar framing is used in both directions so a single endpoint can move
-files, directories, and symlinks uniformly. Temp files live under
-`os.TempDir()` and are cleaned up before the response returns.
+Tar framing is used for directory-shaped transfers so a single endpoint can
+move files, directories, and symlinks uniformly. `application/octet-stream`
+is accepted for clients that need to upload one file verbatim. Temp files live
+under `os.TempDir()` and are cleaned up before the response returns.
 
 ### 5. Per-box metrics
 
@@ -572,7 +573,7 @@ the Swagger UI (development only).
 | `GET` | `/v1/boxes/:boxId/executions/:execId/attach` | WebSocket stdio + control |
 | `POST` | `/v1/boxes/:boxId/executions/:execId/signal` | Cooperative signal (whitelist) |
 | `POST` | `/v1/boxes/:boxId/executions/:execId/resize` | Resize TTY |
-| `PUT` | `/v1/boxes/:boxId/files?path=<dest>` | Upload tar |
+| `PUT` | `/v1/boxes/:boxId/files?path=<dest>` | Upload tar or raw file |
 | `GET` | `/v1/boxes/:boxId/files?path=<src>` | Download tar |
 | `GET` | `/v1/boxes/:boxId/metrics` | Per-box metrics |
 

--- a/apps/runner/pkg/api/controllers/boxlite_files.go
+++ b/apps/runner/pkg/api/controllers/boxlite_files.go
@@ -37,11 +37,12 @@ func BoxliteFileUpload(ctx *gin.Context) {
 
 	src := stagingDir
 	if uploadUsesRawBody(ctx.GetHeader("Content-Type")) {
-		src, err = stageRawUploadBody(ctx.Request.Body, stagingDir)
-		if err != nil {
-			ctx.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to stage raw upload: %s", err)})
+		if err := r.Boxlite.WriteFileFromReader(ctx.Request.Context(), boxId, destPath, ctx.Request.Body); err != nil {
+			ctx.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("raw upload failed: %s", err)})
 			return
 		}
+		ctx.Status(http.StatusNoContent)
+		return
 	} else {
 		// The SDK uploads a tar archive (Content-Type: application/x-tar) so
 		// that copy_in(host_dir, ...) can move trees in a single request.
@@ -79,20 +80,6 @@ func uploadUsesRawBody(contentType string) bool {
 		mediaType = contentType
 	}
 	return strings.EqualFold(mediaType, "application/octet-stream")
-}
-
-func stageRawUploadBody(r io.Reader, destDir string) (string, error) {
-	target := filepath.Join(destDir, "boxlite-upload-raw")
-	f, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
-	if err != nil {
-		return "", fmt.Errorf("create %s: %w", target, err)
-	}
-	defer f.Close()
-
-	if _, err := io.Copy(f, r); err != nil {
-		return "", fmt.Errorf("write %s: %w", target, err)
-	}
-	return target, nil
 }
 
 // extractTarToDir reads a tar archive from r and writes every entry into

--- a/apps/runner/pkg/api/controllers/boxlite_files.go
+++ b/apps/runner/pkg/api/controllers/boxlite_files.go
@@ -4,9 +4,11 @@ import (
 	"archive/tar"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/boxlite-ai/runner/pkg/runner"
 	"github.com/gin-gonic/gin"
@@ -26,13 +28,6 @@ func BoxliteFileUpload(ctx *gin.Context) {
 		return
 	}
 
-	// The SDK uploads a tar archive (Content-Type: application/x-tar) so
-	// that copy_in(host_dir, ...) can move trees in a single request.
-	// We MUST extract the archive into a staging dir on the runner host
-	// before handing it to the Go SDK's CopyInto — that lower-level call
-	// expects a *real path*, not a tar file, and would otherwise dump the
-	// entire .tar blob into the guest as a single binary file (which
-	// silently breaks both single-file and directory uploads).
 	stagingDir, err := os.MkdirTemp("", "boxlite-upload-stage-*")
 	if err != nil {
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create staging dir"})
@@ -40,19 +35,34 @@ func BoxliteFileUpload(ctx *gin.Context) {
 	}
 	defer os.RemoveAll(stagingDir)
 
-	stagedPath, isSingleFile, err := extractTarToDir(ctx.Request.Body, stagingDir)
-	if err != nil {
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("failed to extract upload tar: %s", err)})
-		return
-	}
-
-	// If the archive contained exactly one regular file, CopyInto its
-	// extracted path (a real file) so the guest sees the file at destPath.
-	// Otherwise CopyInto the staging dir as a whole — the Go SDK's
-	// recursive copy handles directories natively.
 	src := stagingDir
-	if isSingleFile {
-		src = stagedPath
+	if uploadUsesRawBody(ctx.GetHeader("Content-Type")) {
+		src, err = stageRawUploadBody(ctx.Request.Body, stagingDir)
+		if err != nil {
+			ctx.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to stage raw upload: %s", err)})
+			return
+		}
+	} else {
+		// The SDK uploads a tar archive (Content-Type: application/x-tar) so
+		// that copy_in(host_dir, ...) can move trees in a single request.
+		// We MUST extract the archive into a staging dir on the runner host
+		// before handing it to the Go SDK's CopyInto — that lower-level call
+		// expects a *real path*, not a tar file, and would otherwise dump the
+		// entire .tar blob into the guest as a single binary file (which
+		// silently breaks both single-file and directory uploads).
+		stagedPath, isSingleFile, err := extractTarToDir(ctx.Request.Body, stagingDir)
+		if err != nil {
+			ctx.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("failed to extract upload tar: %s", err)})
+			return
+		}
+
+		// If the archive contained exactly one regular file, CopyInto its
+		// extracted path (a real file) so the guest sees the file at destPath.
+		// Otherwise CopyInto the staging dir as a whole — the Go SDK's
+		// recursive copy handles directories natively.
+		if isSingleFile {
+			src = stagedPath
+		}
 	}
 
 	if err := r.Boxlite.CopyInto(ctx.Request.Context(), boxId, src, destPath); err != nil {
@@ -61,6 +71,28 @@ func BoxliteFileUpload(ctx *gin.Context) {
 	}
 
 	ctx.Status(http.StatusNoContent)
+}
+
+func uploadUsesRawBody(contentType string) bool {
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		mediaType = contentType
+	}
+	return strings.EqualFold(mediaType, "application/octet-stream")
+}
+
+func stageRawUploadBody(r io.Reader, destDir string) (string, error) {
+	target := filepath.Join(destDir, "boxlite-upload-raw")
+	f, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return "", fmt.Errorf("create %s: %w", target, err)
+	}
+	defer f.Close()
+
+	if _, err := io.Copy(f, r); err != nil {
+		return "", fmt.Errorf("write %s: %w", target, err)
+	}
+	return target, nil
 }
 
 // extractTarToDir reads a tar archive from r and writes every entry into

--- a/apps/runner/pkg/api/controllers/boxlite_files_test.go
+++ b/apps/runner/pkg/api/controllers/boxlite_files_test.go
@@ -29,27 +29,6 @@ func TestUploadUsesRawBodyOnlyForOctetStream(t *testing.T) {
 	}
 }
 
-func TestStageRawUploadBodyDoesNotExtractTar(t *testing.T) {
-	payload := tarBytes(t, "skills/main.py", "print('hello')\n")
-	destDir := t.TempDir()
-
-	stagedPath, err := stageRawUploadBody(bytes.NewReader(payload), destDir)
-	if err != nil {
-		t.Fatalf("stageRawUploadBody: %v", err)
-	}
-
-	got, err := os.ReadFile(stagedPath)
-	if err != nil {
-		t.Fatalf("read staged raw upload: %v", err)
-	}
-	if !bytes.Equal(got, payload) {
-		t.Fatalf("raw upload was modified")
-	}
-	if _, err := os.Stat(filepath.Join(destDir, "skills")); !os.IsNotExist(err) {
-		t.Fatalf("raw upload unexpectedly extracted tar entry, stat err=%v", err)
-	}
-}
-
 func TestExtractTarToDirStillExtractsTar(t *testing.T) {
 	destDir := t.TempDir()
 

--- a/apps/runner/pkg/api/controllers/boxlite_files_test.go
+++ b/apps/runner/pkg/api/controllers/boxlite_files_test.go
@@ -1,0 +1,94 @@
+package controllers
+
+import (
+	"archive/tar"
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestUploadUsesRawBodyOnlyForOctetStream(t *testing.T) {
+	tests := []struct {
+		name        string
+		contentType string
+		want        bool
+	}{
+		{name: "octet stream", contentType: "application/octet-stream", want: true},
+		{name: "octet stream with params", contentType: "application/octet-stream; charset=binary", want: true},
+		{name: "tar archive", contentType: "application/x-tar", want: false},
+		{name: "empty defaults to tar archive", contentType: "", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := uploadUsesRawBody(tt.contentType); got != tt.want {
+				t.Fatalf("uploadUsesRawBody(%q) = %v, want %v", tt.contentType, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStageRawUploadBodyDoesNotExtractTar(t *testing.T) {
+	payload := tarBytes(t, "skills/main.py", "print('hello')\n")
+	destDir := t.TempDir()
+
+	stagedPath, err := stageRawUploadBody(bytes.NewReader(payload), destDir)
+	if err != nil {
+		t.Fatalf("stageRawUploadBody: %v", err)
+	}
+
+	got, err := os.ReadFile(stagedPath)
+	if err != nil {
+		t.Fatalf("read staged raw upload: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("raw upload was modified")
+	}
+	if _, err := os.Stat(filepath.Join(destDir, "skills")); !os.IsNotExist(err) {
+		t.Fatalf("raw upload unexpectedly extracted tar entry, stat err=%v", err)
+	}
+}
+
+func TestExtractTarToDirStillExtractsTar(t *testing.T) {
+	destDir := t.TempDir()
+
+	stagedPath, isSingleFile, err := extractTarToDir(bytes.NewReader(tarBytes(t, "skills/main.py", "print('hello')\n")), destDir)
+	if err != nil {
+		t.Fatalf("extractTarToDir: %v", err)
+	}
+	if !isSingleFile {
+		t.Fatalf("isSingleFile = false, want true")
+	}
+	if stagedPath != filepath.Join(destDir, "skills", "main.py") {
+		t.Fatalf("stagedPath = %q, want extracted file path", stagedPath)
+	}
+	got, err := os.ReadFile(stagedPath)
+	if err != nil {
+		t.Fatalf("read extracted file: %v", err)
+	}
+	if string(got) != "print('hello')\n" {
+		t.Fatalf("extracted content = %q", got)
+	}
+}
+
+func tarBytes(t *testing.T, name, content string) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	if err := tw.WriteHeader(&tar.Header{
+		Name: name,
+		Mode: 0o644,
+		Size: int64(len(content)),
+	}); err != nil {
+		t.Fatalf("write tar header: %v", err)
+	}
+	if _, err := tw.Write([]byte(content)); err != nil {
+		t.Fatalf("write tar body: %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar: %v", err)
+	}
+	return buf.Bytes()
+}

--- a/apps/runner/pkg/boxlite/client.go
+++ b/apps/runner/pkg/boxlite/client.go
@@ -7,10 +7,12 @@
 package boxlite
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
 	"log/slog"
+	pathpkg "path"
 	"strings"
 	"sync"
 	"time"
@@ -426,6 +428,72 @@ func (c *Client) CopyInto(ctx context.Context, boxId string, hostSrc, guestDst s
 		return err
 	}
 	return bx.CopyInto(ctx, hostSrc, guestDst)
+}
+
+// WriteFileFromReader streams a raw upload into a guest file from inside the
+// guest so tmpfs destinations such as /tmp are written to the live mount.
+func (c *Client) WriteFileFromReader(ctx context.Context, boxId string, guestDst string, r io.Reader) error {
+	bx, err := c.getOrFetchBox(ctx, boxId)
+	if err != nil {
+		return err
+	}
+	command, args, err := rawUploadCommand(guestDst)
+	if err != nil {
+		return err
+	}
+
+	var stdout, stderr bytes.Buffer
+	execution, err := bx.StartExecution(ctx, command, args, &boxlite.ExecutionOptions{
+		Stdout: &stdout,
+		Stderr: &stderr,
+	})
+	if err != nil {
+		return err
+	}
+
+	copyErr := func() error {
+		if execution.Stdin == nil {
+			return fmt.Errorf("execution stdin is closed")
+		}
+		if _, err := io.Copy(execution.Stdin, r); err != nil {
+			_ = execution.Kill(ctx)
+			_ = execution.Stdin.Close()
+			return err
+		}
+		return execution.Stdin.Close()
+	}()
+
+	exitCode, waitErr := execution.Wait(ctx)
+	output := strings.TrimSpace(stdout.String() + stderr.String())
+	if copyErr != nil {
+		return fmt.Errorf("raw upload stdin failed: %w", copyErr)
+	}
+	if waitErr != nil {
+		if output != "" {
+			return fmt.Errorf("raw upload wait failed: %w: %s", waitErr, output)
+		}
+		return fmt.Errorf("raw upload wait failed: %w", waitErr)
+	}
+	if exitCode != 0 {
+		if output == "" {
+			output = fmt.Sprintf("exit code %d", exitCode)
+		}
+		return fmt.Errorf("raw upload command failed: %s", output)
+	}
+	return nil
+}
+
+func rawUploadCommand(guestDst string) (string, []string, error) {
+	if guestDst == "" {
+		return "", nil, fmt.Errorf("guest destination path required")
+	}
+	return "sh", []string{
+		"-c",
+		`mkdir -p "$1" && cat > "$2"`,
+		"boxlite-raw-upload",
+		pathpkg.Dir(guestDst),
+		guestDst,
+	}, nil
 }
 
 // CopyOut copies a file from a box to the host.

--- a/apps/runner/pkg/boxlite/client_raw_upload_test.go
+++ b/apps/runner/pkg/boxlite/client_raw_upload_test.go
@@ -1,0 +1,34 @@
+package boxlite
+
+import "testing"
+
+func TestRawUploadCommandWritesRequestedGuestPath(t *testing.T) {
+	command, args, err := rawUploadCommand("/tmp/fc-hydrate.tar")
+	if err != nil {
+		t.Fatalf("rawUploadCommand: %v", err)
+	}
+	if command != "sh" {
+		t.Fatalf("command = %q, want sh", command)
+	}
+	want := []string{
+		"-c",
+		`mkdir -p "$1" && cat > "$2"`,
+		"boxlite-raw-upload",
+		"/tmp",
+		"/tmp/fc-hydrate.tar",
+	}
+	if len(args) != len(want) {
+		t.Fatalf("args len = %d, want %d: %#v", len(args), len(want), args)
+	}
+	for i := range want {
+		if args[i] != want[i] {
+			t.Fatalf("args[%d] = %q, want %q", i, args[i], want[i])
+		}
+	}
+}
+
+func TestRawUploadCommandRejectsEmptyDestination(t *testing.T) {
+	if _, _, err := rawUploadCommand(""); err == nil {
+		t.Fatalf("rawUploadCommand accepted empty destination")
+	}
+}


### PR DESCRIPTION
Support raw `application/octet-stream` file uploads by streaming them through the guest while keeping tar archive uploads unchanged.

Test plan:
- [x] `go test ./pkg/api/controllers ./pkg/boxlite` from `apps/runner` using the locally built `sdks/go/libboxlite.a` symlink
- [x] Dev API repro: `application/octet-stream` upload to `/tmp/fc-hydrate.tar` reproduced the old invisibility with CopyInto, while `/root/fc-hydrate.tar` was visible and tar-readable
- [x] `git diff --cached --check`