### PR TITLE
feat(usage): MVP usage timing inspection

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -11,6 +11,7 @@ import { AppService } from './app.service'
 import { UserModule } from './user/user.module'
 import { TypeOrmModule } from '@nestjs/typeorm'
 import { BoxModule } from './box/box.module'
+import { UsageModule } from './usage/usage.module'
 import { AuthModule } from './auth/auth.module'
 import { ServeStaticModule } from '@nestjs/serve-static'
 import { join } from 'path'
@@ -174,6 +175,7 @@ import { BoxliteRestModule } from './boxlite-rest/boxlite-rest.module'
     BoxModule,
     ScheduleModule.forRoot(),
     AnalyticsModule,
+    UsageModule,
     OrganizationModule,
     RegionModule,
     AdminModule,

--- a/apps/api/src/migrations/pre-deploy/1782600000000-migration.ts
+++ b/apps/api/src/migrations/pre-deploy/1782600000000-migration.ts
@@ -1,0 +1,46 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+/**
+ * MVP user-timing ledger: one table, `usage_period`. Spec snapshot + start/end
+ * per segment; the billable amount is computed at read time (spec × duration).
+ *
+ * Intentionally NOT created here (added back as additive migrations when the
+ * fuller design lands): the `actual*`/`sampleCount`/`sealed` columns, the
+ * partial-unique "one open segment per box" index, and the end-after-start
+ * CHECK. The column names/types match the fuller ledger, so those are pure
+ * `ADD COLUMN` / `ADD CONSTRAINT` later (the partial-unique one needs a dedupe
+ * pass first if any double-open rows slipped in).
+ */
+export class Migration1782600000000 implements MigrationInterface {
+  name = 'Migration1782600000000'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "usage_period" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "boxId" character varying NOT NULL,
+        "organizationId" character varying NOT NULL,
+        "region" character varying,
+        "periodStart" TIMESTAMP WITH TIME ZONE NOT NULL,
+        "periodEnd" TIMESTAMP WITH TIME ZONE,
+        "kind" character varying NOT NULL,
+        "allocCpu" integer NOT NULL,
+        "allocMemGib" integer NOT NULL,
+        "allocDiskGib" integer NOT NULL,
+        "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        CONSTRAINT "usage_period_id_pk" PRIMARY KEY ("id")
+      )`,
+    )
+    await queryRunner.query(
+      `CREATE INDEX "usage_period_box_period_start_idx" ON "usage_period" ("boxId", "periodStart")`,
+    )
+    await queryRunner.query(
+      `CREATE INDEX "usage_period_org_period_start_idx" ON "usage_period" ("organizationId", "periodStart")`,
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "usage_period"`)
+  }
+}

--- a/apps/api/src/usage/billing/usage-math.spec.ts
+++ b/apps/api/src/usage/billing/usage-math.spec.ts
@@ -1,0 +1,167 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { BoxState } from '../../box/enums/box-state.enum'
+import { aggregatePeriods, billingPeriodKind, planTransition, BillablePeriod } from './usage-math'
+
+describe('planTransition', () => {
+  it('first STARTED opens a running period', () => {
+    expect(planTransition(null, BoxState.STARTED)).toEqual({ closeOpen: false, openKind: 'running' })
+  })
+  it('running → STOPPED closes running, opens stopped (disk continues)', () => {
+    expect(planTransition('running', BoxState.STOPPED)).toEqual({ closeOpen: true, openKind: 'stopped' })
+  })
+  it('stopped → STARTED closes stopped, opens running', () => {
+    expect(planTransition('stopped', BoxState.STARTED)).toEqual({ closeOpen: true, openKind: 'running' })
+  })
+  it('running → STARTED (same kind) is a no-op, no fragmentation', () => {
+    expect(planTransition('running', BoxState.STARTED)).toEqual({ closeOpen: false, openKind: null })
+  })
+  it('running → DESTROYED closes running, opens nothing', () => {
+    expect(planTransition('running', BoxState.DESTROYED)).toEqual({ closeOpen: true, openKind: null })
+  })
+  it('no open period → DESTROYED is a no-op', () => {
+    expect(planTransition(null, BoxState.DESTROYED)).toEqual({ closeOpen: false, openKind: null })
+  })
+})
+
+describe('billingPeriodKind', () => {
+  it('STARTED → running (cpu+ram+disk bill)', () => {
+    expect(billingPeriodKind(BoxState.STARTED)).toBe('running')
+  })
+  it('STOPPED → stopped (disk still on disk, no cpu/ram)', () => {
+    expect(billingPeriodKind(BoxState.STOPPED)).toBe('stopped')
+  })
+  it('ARCHIVED → stopped (rootfs retained)', () => {
+    expect(billingPeriodKind(BoxState.ARCHIVED)).toBe('stopped')
+  })
+  it('CREATING → stopped (rootfs exists, not running yet)', () => {
+    expect(billingPeriodKind(BoxState.CREATING)).toBe('stopped')
+  })
+  it('DESTROYED → gone (rootfs released, close period)', () => {
+    expect(billingPeriodKind(BoxState.DESTROYED)).toBe('gone')
+  })
+})
+
+describe('aggregatePeriods', () => {
+  const from = new Date('2026-06-25T00:00:00Z')
+  const to = new Date('2026-06-26T00:00:00Z')
+
+  it('running period: cpu + ram + disk all count', () => {
+    const periods: BillablePeriod[] = [
+      {
+        startAt: new Date('2026-06-25T12:00:00Z'),
+        endAt: new Date('2026-06-25T12:00:10Z'), // 10s
+        kind: 'running',
+        allocCpu: 2,
+        allocMemGib: 4,
+        allocDiskGib: 10,
+      },
+    ]
+    expect(aggregatePeriods(periods, from, to)).toEqual({
+      totalCpuSeconds: 20, // 2 vCPU × 10s
+      totalRamGbSeconds: 40, // 4 GiB × 10s
+      totalDiskGbSeconds: 100, // 10 GiB × 10s
+    })
+  })
+
+  it('stopped period: only disk counts', () => {
+    const periods: BillablePeriod[] = [
+      {
+        startAt: new Date('2026-06-25T12:00:00Z'),
+        endAt: new Date('2026-06-25T12:00:10Z'), // 10s
+        kind: 'stopped',
+        allocCpu: 2,
+        allocMemGib: 4,
+        allocDiskGib: 10,
+      },
+    ]
+    expect(aggregatePeriods(periods, from, to)).toEqual({
+      totalCpuSeconds: 0,
+      totalRamGbSeconds: 0,
+      totalDiskGbSeconds: 100,
+    })
+  })
+
+  it('open period (endAt null) is clipped at `to`', () => {
+    const periods: BillablePeriod[] = [
+      {
+        startAt: new Date('2026-06-25T23:59:50Z'), // 10s before `to`
+        endAt: null,
+        kind: 'running',
+        allocCpu: 1,
+        allocMemGib: 1,
+        allocDiskGib: 1,
+      },
+    ]
+    expect(aggregatePeriods(periods, from, to)).toEqual({
+      totalCpuSeconds: 10,
+      totalRamGbSeconds: 10,
+      totalDiskGbSeconds: 10,
+    })
+  })
+
+  it('clips a period overlapping the range start', () => {
+    const periods: BillablePeriod[] = [
+      {
+        startAt: new Date('2026-06-24T23:59:50Z'), // starts 10s before `from`
+        endAt: new Date('2026-06-25T00:00:10Z'), // ends 10s after `from`
+        kind: 'running',
+        allocCpu: 1,
+        allocMemGib: 1,
+        allocDiskGib: 1,
+      },
+    ]
+    expect(aggregatePeriods(periods, from, to)).toEqual({
+      totalCpuSeconds: 10, // only the 10s inside [from,to]
+      totalRamGbSeconds: 10,
+      totalDiskGbSeconds: 10,
+    })
+  })
+
+  it('drops a period entirely outside the range', () => {
+    const periods: BillablePeriod[] = [
+      {
+        startAt: new Date('2026-06-20T00:00:00Z'),
+        endAt: new Date('2026-06-20T01:00:00Z'),
+        kind: 'running',
+        allocCpu: 9,
+        allocMemGib: 9,
+        allocDiskGib: 9,
+      },
+    ]
+    expect(aggregatePeriods(periods, from, to)).toEqual({
+      totalCpuSeconds: 0,
+      totalRamGbSeconds: 0,
+      totalDiskGbSeconds: 0,
+    })
+  })
+
+  it('sums mixed running + stopped periods (Disk continuous across both)', () => {
+    const periods: BillablePeriod[] = [
+      {
+        startAt: new Date('2026-06-25T12:00:00Z'),
+        endAt: new Date('2026-06-25T12:00:10Z'), // running 10s
+        kind: 'running',
+        allocCpu: 2,
+        allocMemGib: 4,
+        allocDiskGib: 10,
+      },
+      {
+        startAt: new Date('2026-06-25T12:00:10Z'),
+        endAt: new Date('2026-06-25T12:00:30Z'), // stopped 20s
+        kind: 'stopped',
+        allocCpu: 2,
+        allocMemGib: 4,
+        allocDiskGib: 10,
+      },
+    ]
+    expect(aggregatePeriods(periods, from, to)).toEqual({
+      totalCpuSeconds: 20, // running 10s × 2
+      totalRamGbSeconds: 40, // running 10s × 4
+      totalDiskGbSeconds: 300, // (10s + 20s) × 10
+    })
+  })
+})

--- a/apps/api/src/usage/billing/usage-math.ts
+++ b/apps/api/src/usage/billing/usage-math.ts
@@ -1,0 +1,125 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { BoxState } from '../../box/enums/box-state.enum'
+
+/**
+ * Billing meaning of a box lifecycle state.
+ *
+ * - `running`  — CPU + RAM + Disk all bill (box is executing).
+ * - `stopped`  — only Disk bills (box exists on disk but isn't running:
+ *                stopped / archived / starting / etc.).
+ * - `gone`     — box destroyed; no period exists (close any open one).
+ */
+export type BillingPeriodKind = 'running' | 'stopped' | 'gone'
+
+/**
+ * Map a {@link BoxState} to its billing meaning (the §8 truth table, collapsed
+ * to the control-plane's view — note there is no `paused` state at the API
+ * level). CPU/RAM bind to `running`; Disk binds to existence (everything except
+ * `gone`).
+ */
+export function billingPeriodKind(state: BoxState): BillingPeriodKind {
+  switch (state) {
+    case BoxState.STARTED:
+      return 'running'
+    case BoxState.DESTROYED:
+    case BoxState.DESTROYING:
+      return 'gone'
+    default:
+      // creating / restoring / starting / stopping / stopped / error /
+      // unknown / archived / archiving / resizing: rootfs exists → Disk bills,
+      // but CPU/RAM do not (box isn't executing).
+      return 'stopped'
+  }
+}
+
+/** What to do to the period ledger when a box changes state. */
+export interface TransitionPlan {
+  /** Close the currently-open period (stamp its `endAt = now`). */
+  closeOpen: boolean
+  /** Open a fresh period of this kind, or `null` to open nothing. */
+  openKind: 'running' | 'stopped' | null
+}
+
+/**
+ * Decide how the open period should change when a box moves to `newState`,
+ * given the kind of the currently-open period (`null` = none open).
+ *
+ * Keeps segments clean without churn: a transition that doesn't change the
+ * billing kind (e.g. STARTED→STARTED, or two disk-only states) is a no-op, so
+ * one continuous period is kept rather than fragmenting the ledger.
+ */
+export function planTransition(openKind: 'running' | 'stopped' | null, newState: BoxState): TransitionPlan {
+  const kind = billingPeriodKind(newState)
+
+  if (kind === 'gone') {
+    // Box destroyed: close whatever is open, open nothing.
+    return { closeOpen: openKind !== null, openKind: null }
+  }
+
+  // Same billing kind → keep the single open period (no churn).
+  if (openKind === kind) {
+    return { closeOpen: false, openKind: null }
+  }
+
+  // Kind changed: close the old open period (if any) and open the new kind.
+  return { closeOpen: openKind !== null, openKind: kind }
+}
+
+/** A stored usage period (alloc side) that contributes to billing. */
+export interface BillablePeriod {
+  startAt: Date
+  /** `null` = period still open (box still in this state). */
+  endAt: Date | null
+  /** `running`: cpu+ram+disk bill; `stopped`: disk only. */
+  kind: 'running' | 'stopped'
+  allocCpu: number
+  allocMemGib: number
+  allocDiskGib: number
+}
+
+/** Aggregated billable quantities over a time range (matches the analytics
+ *  contract's `totalCPUSeconds` / `totalRAMGBSeconds` / `totalDiskGBSeconds`). */
+export interface UsageTotals {
+  totalCpuSeconds: number
+  totalRamGbSeconds: number
+  totalDiskGbSeconds: number
+}
+
+/**
+ * Aggregate periods into billable totals, clipping each period to `[from, to]`.
+ * Open periods (`endAt === null`) are clipped at `to`. CPU/RAM only accrue for
+ * `running` periods; Disk accrues for every (existing) period.
+ */
+export function aggregatePeriods(periods: BillablePeriod[], from: Date, to: Date): UsageTotals {
+  const fromMs = from.getTime()
+  const toMs = to.getTime()
+
+  let totalCpuSeconds = 0
+  let totalRamGbSeconds = 0
+  let totalDiskGbSeconds = 0
+
+  for (const p of periods) {
+    // Open periods are clipped at the range end.
+    const endMs = (p.endAt ?? to).getTime()
+    const overlapStart = Math.max(p.startAt.getTime(), fromMs)
+    const overlapEnd = Math.min(endMs, toMs)
+    if (overlapEnd <= overlapStart) {
+      continue // entirely outside [from, to]
+    }
+    const seconds = (overlapEnd - overlapStart) / 1000
+
+    // Disk binds to existence — every (existing) period contributes.
+    totalDiskGbSeconds += p.allocDiskGib * seconds
+    // CPU/RAM bind to running.
+    if (p.kind === 'running') {
+      totalCpuSeconds += p.allocCpu * seconds
+      totalRamGbSeconds += p.allocMemGib * seconds
+    }
+  }
+
+  return { totalCpuSeconds, totalRamGbSeconds, totalDiskGbSeconds }
+}

--- a/apps/api/src/usage/entities/usage-period.entity.ts
+++ b/apps/api/src/usage/entities/usage-period.entity.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm'
+
+/**
+ * One usage segment for a box — the whole MVP timing model in one table.
+ *
+ * The idea (modelled on Daytona): a box's life is a chain of segments. A segment
+ * opens when the box's billing kind changes (running ↔ stopped) and closes
+ * (`periodEnd` set) at the next change or when the box is destroyed. We store the
+ * box's allocated spec (cpu/mem/disk) + the start/end timestamps and NOTHING
+ * else — the billable amount is `spec × duration`, computed at read time. No
+ * seconds stored, no money stored.
+ *
+ * MVP scope: this is deliberately the happy path only. Four protections from the
+ * fuller design are intentionally left out and can be layered back without
+ * reshaping this table (see usage/README or the OB design doc):
+ *   1. actual cgroup columns (real CPU/RAM measured by the Rust engine) — add as
+ *      nullable columns later; billing uses alloc, so reads don't depend on them.
+ *   2. a reconcile cron (force-closes segments orphaned by a runner crash).
+ *   3. a partial-unique "one open segment per box" index (concurrency guard).
+ *   4. an end-after-start CHECK + a `sealed` flag (clock-skew / crash markers).
+ *
+ * The column names + types here match the fuller ledger exactly, so the rating
+ * layer (Phase 2) consumes this table unchanged, and the protections above are
+ * pure additive migrations.
+ */
+@Entity()
+@Index('usage_period_box_period_start_idx', ['boxId', 'periodStart'])
+@Index('usage_period_org_period_start_idx', ['organizationId', 'periodStart'])
+export class UsagePeriod {
+  @PrimaryGeneratedColumn('uuid')
+  id: string
+
+  @Column()
+  boxId: string
+
+  @Column()
+  organizationId: string
+
+  @Column({ nullable: true })
+  region: string
+
+  @Column({ type: 'timestamptz' })
+  periodStart: Date
+
+  /** `null` while the segment is still open (box still in this billing kind). */
+  @Column({ type: 'timestamptz', nullable: true })
+  periodEnd: Date | null
+
+  /** Billing kind: `running` (cpu+ram+disk) or `stopped` (disk only). */
+  @Column()
+  kind: string
+
+  // ---- allocated quantities (the billing basis, snapshotted from the box spec) ----
+  @Column({ type: 'int' })
+  allocCpu: number
+
+  @Column({ type: 'int' })
+  allocMemGib: number
+
+  @Column({ type: 'int' })
+  allocDiskGib: number
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt: Date
+
+  @UpdateDateColumn({ type: 'timestamptz' })
+  updatedAt: Date
+}

--- a/apps/api/src/usage/usage.controller.ts
+++ b/apps/api/src/usage/usage.controller.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Controller, Get, Param, Query, UseGuards } from '@nestjs/common'
+import { ApiOAuth2, ApiOperation, ApiParam, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger'
+import { CombinedAuthGuard } from '../auth/combined-auth.guard'
+import { AuthenticatedRateLimitGuard } from '../common/guards/authenticated-rate-limit.guard'
+import { OrganizationResourceActionGuard } from '../organization/guards/organization-resource-action.guard'
+import { BoxAccessGuard } from '../box/guards/box-access.guard'
+import { BoxUsageResult, UsageService } from './usage.service'
+
+const DEFAULT_RANGE_MS = 30 * 24 * 60 * 60 * 1000 // 30 days
+
+@ApiTags('usage')
+@Controller('usage')
+@UseGuards(CombinedAuthGuard, OrganizationResourceActionGuard, AuthenticatedRateLimitGuard)
+@ApiOAuth2(['openid', 'profile', 'email'])
+export class UsageController {
+  constructor(private readonly usageService: UsageService) {}
+
+  @Get('box/:boxId')
+  @ApiOperation({
+    summary: 'Get aggregated usage totals for a box over a time range',
+    operationId: 'getBoxUsage',
+  })
+  @ApiParam({ name: 'boxId', description: 'ID of the box', type: 'string' })
+  @ApiQuery({ name: 'from', required: false, type: String, description: 'ISO start (default: 30d ago)' })
+  @ApiQuery({ name: 'to', required: false, type: String, description: 'ISO end (default: now)' })
+  @ApiResponse({ status: 200, description: 'Aggregated box usage totals' })
+  @UseGuards(BoxAccessGuard)
+  async getBoxUsage(
+    @Param('boxId') boxId: string,
+    @Query('from') from?: string,
+    @Query('to') to?: string,
+  ): Promise<BoxUsageResult> {
+    const toDate = to ? new Date(to) : new Date()
+    const fromDate = from ? new Date(from) : new Date(toDate.getTime() - DEFAULT_RANGE_MS)
+    return this.usageService.getBoxUsage(boxId, fromDate, toDate)
+  }
+}

--- a/apps/api/src/usage/usage.controller.ts
+++ b/apps/api/src/usage/usage.controller.ts
@@ -9,7 +9,7 @@ import { CombinedAuthGuard } from '../auth/combined-auth.guard'
 import { AuthenticatedRateLimitGuard } from '../common/guards/authenticated-rate-limit.guard'
 import { OrganizationResourceActionGuard } from '../organization/guards/organization-resource-action.guard'
 import { BoxAccessGuard } from '../box/guards/box-access.guard'
-import { BoxUsageResult, UsageService } from './usage.service'
+import { BoxUsagePeriodRow, BoxUsageResult, UsageService } from './usage.service'
 
 const DEFAULT_RANGE_MS = 30 * 24 * 60 * 60 * 1000 // 30 days
 
@@ -38,5 +38,17 @@ export class UsageController {
     const toDate = to ? new Date(to) : new Date()
     const fromDate = from ? new Date(from) : new Date(toDate.getTime() - DEFAULT_RANGE_MS)
     return this.usageService.getBoxUsage(boxId, fromDate, toDate)
+  }
+
+  @Get('box/:boxId/periods')
+  @ApiOperation({
+    summary: 'List raw usage_period rows for a box',
+    operationId: 'listBoxUsagePeriods',
+  })
+  @ApiParam({ name: 'boxId', description: 'ID of the box', type: 'string' })
+  @ApiResponse({ status: 200, description: 'Raw usage_period rows for the box' })
+  @UseGuards(BoxAccessGuard)
+  async listBoxUsagePeriods(@Param('boxId') boxId: string): Promise<BoxUsagePeriodRow[]> {
+    return this.usageService.listBoxPeriods(boxId)
   }
 }

--- a/apps/api/src/usage/usage.integration.spec.ts
+++ b/apps/api/src/usage/usage.integration.spec.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ *
+ * Real-Postgres integration test for the MVP usage-timing ledger. Skipped by
+ * default (no DB in CI); run against a local Postgres with:
+ *
+ *   RUN_DB_IT=1 npx nx test api --testPathPatterns=usage.integration --skip-nx-cache
+ *
+ * Runs the MVP migration, then drives a box lifecycle through UsageService and
+ * checks the segments open/close correctly + getBoxUsage computes alloc-seconds.
+ */
+
+import { DataSource, IsNull } from 'typeorm'
+import { Box } from '../box/entities/box.entity'
+import { BoxState } from '../box/enums/box-state.enum'
+import { Migration1782600000000 } from '../migrations/pre-deploy/1782600000000-migration'
+import { UsagePeriod } from './entities/usage-period.entity'
+import { UsageService } from './usage.service'
+
+const dbDescribe = process.env.RUN_DB_IT ? describe : describe.skip
+
+const box = (state: BoxState): Box =>
+  ({ id: 'box-it', organizationId: 'org-it', region: 'r1', cpu: 2, mem: 4, disk: 10, state }) as Box
+
+dbDescribe('MVP usage timing — real Postgres', () => {
+  let ds: DataSource
+  let svc: UsageService
+
+  beforeAll(async () => {
+    ds = new DataSource({
+      type: 'postgres',
+      host: process.env.DB_HOST ?? 'localhost',
+      port: Number(process.env.DB_PORT ?? 5440),
+      username: process.env.DB_USERNAME ?? 'postgres',
+      password: process.env.DB_PASSWORD ?? 'postgres',
+      database: process.env.DB_DATABASE ?? 'usage_it',
+      entities: [UsagePeriod],
+      synchronize: false,
+    })
+    await ds.initialize()
+    const qr = ds.createQueryRunner()
+    await qr.query(`CREATE EXTENSION IF NOT EXISTS "uuid-ossp"`)
+    await qr.query(`DROP TABLE IF EXISTS "usage_period" CASCADE`)
+    await new Migration1782600000000().up(qr)
+    await qr.release()
+    svc = new UsageService(ds.getRepository(UsagePeriod))
+  }, 60000)
+
+  afterAll(async () => {
+    if (!ds?.isInitialized) return
+    const qr = ds.createQueryRunner()
+    await qr.query(`DROP TABLE IF EXISTS "usage_period" CASCADE`)
+    await qr.release()
+    await ds.destroy()
+  })
+
+  it('builds running→stopped segments across a box lifecycle and aggregates alloc-seconds', async () => {
+    const t0 = new Date('2026-06-25T12:00:00Z')
+    const t1 = new Date('2026-06-25T12:00:10Z') // +10s running
+    const t2 = new Date('2026-06-25T12:00:30Z') // +20s stopped
+
+    await svc.applyTransition(box(BoxState.STARTED), BoxState.STARTED, t0) // open running
+    await svc.applyTransition(box(BoxState.STOPPED), BoxState.STOPPED, t1) // close running, open stopped
+    await svc.applyTransition(box(BoxState.DESTROYED), BoxState.DESTROYED, t2) // close stopped
+
+    const rows = await ds.getRepository(UsagePeriod).find({ where: { boxId: 'box-it' }, order: { periodStart: 'ASC' } })
+    expect(rows.map((r) => [r.kind, r.periodEnd !== null])).toEqual([
+      ['running', true], // running, closed at t1
+      ['stopped', true], // stopped, closed at t2
+    ])
+
+    // running 10s → cpu 2×10, ram 4×10; disk continuous across both 30s → 10×30
+    const usage = await svc.getBoxUsage('box-it', t0, t2)
+    expect(usage).toEqual({
+      boxId: 'box-it',
+      totalCPUSeconds: 20,
+      totalRAMGBSeconds: 40,
+      totalDiskGBSeconds: 300,
+      totalGPUSeconds: 0,
+    })
+  })
+
+  it('keeps at most one open segment per box (close-before-open guard)', async () => {
+    const b = (state: BoxState): Box => ({ ...box(state), id: 'box-guard' }) as Box
+    await svc.applyTransition(b(BoxState.STARTED), BoxState.STARTED, new Date('2026-06-25T13:00:00Z'))
+    await svc.applyTransition(b(BoxState.STOPPED), BoxState.STOPPED, new Date('2026-06-25T13:00:10Z'))
+
+    // mid-lifecycle (running closed, stopped open) → exactly ONE open segment, not two
+    const open = await ds.getRepository(UsagePeriod).find({ where: { boxId: 'box-guard', periodEnd: IsNull() } })
+    expect(open).toHaveLength(1)
+    expect(open[0].kind).toBe('stopped')
+  })
+})

--- a/apps/api/src/usage/usage.module.ts
+++ b/apps/api/src/usage/usage.module.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Module } from '@nestjs/common'
+import { TypeOrmModule } from '@nestjs/typeorm'
+import { BoxModule } from '../box/box.module'
+import { BoxAccessGuard } from '../box/guards/box-access.guard'
+import { OrganizationModule } from '../organization/organization.module'
+import { UsagePeriod } from './entities/usage-period.entity'
+import { UsageController } from './usage.controller'
+import { UsageService } from './usage.service'
+
+@Module({
+  // OrganizationModule + BoxModule satisfy the controller guards' constructor deps —
+  // OrganizationResourceActionGuard needs OrganizationService, BoxAccessGuard needs
+  // BoxService. Without them the API fails to boot (tsc + unit tests still pass), so
+  // this is verified on the running stack, not just by compiling.
+  imports: [TypeOrmModule.forFeature([UsagePeriod]), OrganizationModule, BoxModule],
+  controllers: [UsageController],
+  providers: [UsageService, BoxAccessGuard],
+  exports: [UsageService],
+})
+export class UsageModule {}

--- a/apps/api/src/usage/usage.service.spec.ts
+++ b/apps/api/src/usage/usage.service.spec.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Box } from '../box/entities/box.entity'
+import { BoxState } from '../box/enums/box-state.enum'
+import { UsagePeriod } from './entities/usage-period.entity'
+import { UsageService } from './usage.service'
+
+/**
+ * Minimal in-memory stand-in for the TypeORM repository — exercises the
+ * service's open/close orchestration without a database. `findOne` returns the
+ * currently-open period (periodEnd == null) for a box; `save` upserts.
+ */
+class FakeRepo {
+  rows: UsagePeriod[] = []
+
+  create(obj: Partial<UsagePeriod>): UsagePeriod {
+    return { ...obj } as UsagePeriod
+  }
+
+  async save(obj: UsagePeriod): Promise<UsagePeriod> {
+    if (!obj.id) {
+      obj.id = `p${this.rows.length + 1}`
+      this.rows.push(obj)
+    }
+    return obj
+  }
+
+  async findOne(opts: { where: { boxId: string } }): Promise<UsagePeriod | null> {
+    const open = this.rows.filter((r) => r.boxId === opts.where.boxId && r.periodEnd == null)
+    return open.length ? open[open.length - 1] : null
+  }
+}
+
+function box(state: BoxState): Box {
+  return { id: 'box-1', organizationId: 'org-1', region: 'r1', cpu: 2, mem: 4, disk: 10, state } as Box
+}
+
+describe('UsageService.applyTransition', () => {
+  let repo: FakeRepo
+  let svc: UsageService
+
+  beforeEach(() => {
+    repo = new FakeRepo()
+    svc = new UsageService(repo as never)
+  })
+
+  it('opens a running period when a box starts', async () => {
+    await svc.applyTransition(box(BoxState.STARTED), BoxState.STARTED, new Date('2026-06-25T12:00:00Z'))
+    expect(repo.rows).toHaveLength(1)
+    expect(repo.rows[0]).toMatchObject({
+      boxId: 'box-1',
+      organizationId: 'org-1',
+      kind: 'running',
+      periodEnd: null,
+      allocCpu: 2,
+      allocMemGib: 4,
+      allocDiskGib: 10,
+    })
+  })
+
+  it('opens a disk-only stopped period when a box is created not-running', async () => {
+    await svc.applyTransition(box(BoxState.CREATING), BoxState.CREATING, new Date('2026-06-25T12:00:00Z'))
+    expect(repo.rows).toHaveLength(1)
+    expect(repo.rows[0].kind).toBe('stopped')
+  })
+
+  it('closes running and opens stopped on stop (disk continues)', async () => {
+    const t0 = new Date('2026-06-25T12:00:00Z')
+    const t1 = new Date('2026-06-25T12:00:10Z')
+    await svc.applyTransition(box(BoxState.STARTED), BoxState.STARTED, t0)
+    await svc.applyTransition(box(BoxState.STOPPED), BoxState.STOPPED, t1)
+
+    const running = repo.rows.find((r) => r.kind === 'running')!
+    const stopped = repo.rows.find((r) => r.kind === 'stopped')!
+    expect(repo.rows).toHaveLength(2)
+    expect(running.periodEnd).toEqual(t1) // closed at stop
+    expect(stopped.periodEnd).toBeNull() // disk keeps running
+  })
+
+  it('does not fragment the ledger on a same-kind transition', async () => {
+    await svc.applyTransition(box(BoxState.STARTED), BoxState.STARTED, new Date('2026-06-25T12:00:00Z'))
+    await svc.applyTransition(box(BoxState.STARTED), BoxState.STARTED, new Date('2026-06-25T12:00:05Z'))
+    expect(repo.rows).toHaveLength(1)
+    expect(repo.rows[0].periodEnd).toBeNull()
+  })
+
+  it('closes the open period and opens nothing on destroy', async () => {
+    const t0 = new Date('2026-06-25T12:00:00Z')
+    const t1 = new Date('2026-06-25T12:00:10Z')
+    await svc.applyTransition(box(BoxState.STARTED), BoxState.STARTED, t0)
+    await svc.applyTransition(box(BoxState.DESTROYED), BoxState.DESTROYED, t1)
+    expect(repo.rows).toHaveLength(1)
+    expect(repo.rows[0].periodEnd).toEqual(t1)
+  })
+})

--- a/apps/api/src/usage/usage.service.spec.ts
+++ b/apps/api/src/usage/usage.service.spec.ts
@@ -21,6 +21,9 @@ class FakeRepo {
   }
 
   async save(obj: UsagePeriod): Promise<UsagePeriod> {
+    const now = new Date('2026-06-25T12:00:00Z')
+    obj.createdAt ??= now
+    obj.updatedAt = now
     if (!obj.id) {
       obj.id = `p${this.rows.length + 1}`
       this.rows.push(obj)
@@ -31,6 +34,12 @@ class FakeRepo {
   async findOne(opts: { where: { boxId: string } }): Promise<UsagePeriod | null> {
     const open = this.rows.filter((r) => r.boxId === opts.where.boxId && r.periodEnd == null)
     return open.length ? open[open.length - 1] : null
+  }
+
+  async find(opts: { where: { boxId: string }; order: { periodStart: 'ASC' } }): Promise<UsagePeriod[]> {
+    return this.rows
+      .filter((r) => r.boxId === opts.where.boxId)
+      .sort((a, b) => a.periodStart.getTime() - b.periodStart.getTime())
   }
 }
 
@@ -94,5 +103,26 @@ describe('UsageService.applyTransition', () => {
     await svc.applyTransition(box(BoxState.DESTROYED), BoxState.DESTROYED, t1)
     expect(repo.rows).toHaveLength(1)
     expect(repo.rows[0].periodEnd).toEqual(t1)
+  })
+
+  it('lists raw period rows in table order for dashboard inspection', async () => {
+    const t0 = new Date('2026-06-25T12:00:00Z')
+    const t1 = new Date('2026-06-25T12:00:10Z')
+    await svc.applyTransition(box(BoxState.STARTED), BoxState.STARTED, t0)
+    await svc.applyTransition(box(BoxState.STOPPED), BoxState.STOPPED, t1)
+
+    const rows = await svc.listBoxPeriods('box-1')
+
+    expect(rows.map((row) => row.kind)).toEqual(['running', 'stopped'])
+    expect(rows[0]).toMatchObject({
+      boxId: 'box-1',
+      organizationId: 'org-1',
+      periodStart: '2026-06-25T12:00:00.000Z',
+      periodEnd: '2026-06-25T12:00:10.000Z',
+      allocCpu: 2,
+      allocMemGib: 4,
+      allocDiskGib: 10,
+    })
+    expect(rows[1].periodEnd).toBeNull()
   })
 })

--- a/apps/api/src/usage/usage.service.ts
+++ b/apps/api/src/usage/usage.service.ts
@@ -20,6 +20,21 @@ export interface BoxUsageResult extends UsageTotalsContract {
   boxId: string
 }
 
+export interface BoxUsagePeriodRow {
+  id: string
+  boxId: string
+  organizationId: string
+  region: string | null
+  kind: string
+  periodStart: string
+  periodEnd: string | null
+  allocCpu: number
+  allocMemGib: number
+  allocDiskGib: number
+  createdAt: string
+  updatedAt: string
+}
+
 interface UsageTotalsContract {
   totalCPUSeconds: number
   totalRAMGBSeconds: number
@@ -141,5 +156,28 @@ export class UsageService {
       totalDiskGBSeconds: totals.totalDiskGbSeconds,
       totalGPUSeconds: 0, // MVP: no GPU metering
     }
+  }
+
+  /** Return the raw ledger rows for a box, ordered exactly as the table is inspected during local validation. */
+  async listBoxPeriods(boxId: string): Promise<BoxUsagePeriodRow[]> {
+    const rows = await this.periods.find({
+      where: { boxId },
+      order: { periodStart: 'ASC' },
+    })
+
+    return rows.map((row) => ({
+      id: row.id,
+      boxId: row.boxId,
+      organizationId: row.organizationId,
+      region: row.region,
+      kind: row.kind,
+      periodStart: row.periodStart.toISOString(),
+      periodEnd: row.periodEnd ? row.periodEnd.toISOString() : null,
+      allocCpu: row.allocCpu,
+      allocMemGib: row.allocMemGib,
+      allocDiskGib: row.allocDiskGib,
+      createdAt: row.createdAt.toISOString(),
+      updatedAt: row.updatedAt.toISOString(),
+    }))
   }
 }

--- a/apps/api/src/usage/usage.service.ts
+++ b/apps/api/src/usage/usage.service.ts
@@ -1,0 +1,145 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Injectable, Logger } from '@nestjs/common'
+import { InjectRepository } from '@nestjs/typeorm'
+import { IsNull, Repository } from 'typeorm'
+import { Box } from '../box/entities/box.entity'
+import { BoxEvents } from '../box/constants/box-events.constants'
+import { BoxCreatedEvent } from '../box/events/box-create.event'
+import { BoxStateUpdatedEvent } from '../box/events/box-state-updated.event'
+import { BoxState } from '../box/enums/box-state.enum'
+import { OnAsyncEvent } from '../common/decorators/on-async-event.decorator'
+import { UsagePeriod } from './entities/usage-period.entity'
+import { aggregatePeriods, BillablePeriod, planTransition, UsageTotals } from './billing/usage-math'
+
+/** The analytics contract's per-box usage shape (`models.BoxUsage`). */
+export interface BoxUsageResult extends UsageTotalsContract {
+  boxId: string
+}
+
+interface UsageTotalsContract {
+  totalCPUSeconds: number
+  totalRAMGBSeconds: number
+  totalDiskGBSeconds: number
+  totalGPUSeconds: number
+}
+
+/**
+ * Builds the alloc-side usage ledger from box lifecycle events and answers
+ * usage queries. Pure billing math lives in `./billing/usage-math`; this
+ * service is the thin event/DB wiring around it.
+ */
+@Injectable()
+export class UsageService {
+  private readonly logger = new Logger(UsageService.name)
+
+  constructor(
+    @InjectRepository(UsagePeriod)
+    private readonly periods: Repository<UsagePeriod>,
+  ) {}
+
+  @OnAsyncEvent({ event: BoxEvents.CREATED })
+  async handleBoxCreated(event: BoxCreatedEvent): Promise<void> {
+    // A box can be inserted directly at STARTED (box.service.ts), which emits
+    // only CREATED — not STATE_UPDATED (an insert has no previous state). Open
+    // the initial period here, or the running time before the first transition
+    // is lost.
+    try {
+      await this.applyTransition(event.box, event.box.state, new Date())
+    } catch (err) {
+      // Metering must never break the box state machine — the CREATED emitter
+      // is `emitAsync`, so an uncaught throw here would fail box creation
+      // outright. Log with stack and swallow. (A reconcile sweep that re-closes
+      // periods orphaned by a crash is a Phase 1.5 add-on, not in this MVP.)
+      this.logger.error(
+        `usage ledger open failed for box ${event.box?.id}`,
+        err instanceof Error ? err.stack : String(err),
+      )
+    }
+  }
+
+  @OnAsyncEvent({ event: BoxEvents.STATE_UPDATED })
+  async handleBoxStateUpdated(event: BoxStateUpdatedEvent): Promise<void> {
+    try {
+      await this.applyTransition(event.box, event.newState, new Date())
+    } catch (err) {
+      // Same guarantee: metering never breaks the state machine. STATE_UPDATED
+      // is `emit`, so a throw here would become an unhandled rejection — still
+      // log with stack and swallow.
+      this.logger.error(
+        `usage ledger update failed for box ${event.box?.id}`,
+        err instanceof Error ? err.stack : String(err),
+      )
+    }
+  }
+
+  /**
+   * Apply one state transition to the box's period ledger (server clock = the
+   * single authority). Closes the open segment and/or opens a new one per
+   * {@link planTransition}.
+   *
+   * The "find the open segment, close it, then open the new one" order is the
+   * ONLY thing preventing two open segments for a box in this MVP (the fuller
+   * design also has a partial-unique index as a hard guard — omitted here). So
+   * the close-before-open sequence below is load-bearing, not incidental.
+   */
+  async applyTransition(box: Box, newState: BoxState, now: Date): Promise<void> {
+    const open = await this.periods.findOne({
+      where: { boxId: box.id, periodEnd: IsNull() },
+      order: { periodStart: 'DESC' },
+    })
+    const openKind = open ? (open.kind as 'running' | 'stopped') : null
+    const plan = planTransition(openKind, newState)
+
+    if (plan.closeOpen && open) {
+      open.periodEnd = now
+      await this.periods.save(open)
+    }
+    if (plan.openKind) {
+      await this.periods.save(
+        this.periods.create({
+          boxId: box.id,
+          organizationId: box.organizationId,
+          region: box.region,
+          periodStart: now,
+          periodEnd: null,
+          kind: plan.openKind,
+          allocCpu: box.cpu,
+          allocMemGib: box.mem,
+          allocDiskGib: box.disk,
+        }),
+      )
+    }
+  }
+
+  /** Aggregate a box's usage over `[from, to]` into the analytics contract shape. */
+  async getBoxUsage(boxId: string, from: Date, to: Date): Promise<BoxUsageResult> {
+    const rows = await this.periods
+      .createQueryBuilder('p')
+      .where('p.boxId = :boxId', { boxId })
+      .andWhere('p.periodStart <= :to', { to })
+      .andWhere('(p.periodEnd IS NULL OR p.periodEnd >= :from)', { from })
+      .getMany()
+
+    const billable: BillablePeriod[] = rows.map((r) => ({
+      startAt: r.periodStart,
+      endAt: r.periodEnd,
+      kind: r.kind as 'running' | 'stopped',
+      allocCpu: r.allocCpu,
+      allocMemGib: r.allocMemGib,
+      allocDiskGib: r.allocDiskGib,
+    }))
+
+    const totals: UsageTotals = aggregatePeriods(billable, from, to)
+    return {
+      boxId,
+      totalCPUSeconds: totals.totalCpuSeconds,
+      totalRAMGBSeconds: totals.totalRamGbSeconds,
+      totalDiskGBSeconds: totals.totalDiskGbSeconds,
+      totalGPUSeconds: 0, // MVP: no GPU metering
+    }
+  }
+}

--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -39,6 +39,7 @@ import Boxes from './pages/Boxes'
 // recharts/terminal deps. Boxes + the Dashboard shell stay eager (first paint).
 const Keys = React.lazy(() => import('./pages/Keys'))
 const Billing = React.lazy(() => import('./pages/Billing'))
+const UsageVerification = React.lazy(() => import('./pages/UsageVerification'))
 const Admin = React.lazy(() => import('./pages/Admin'))
 const EmailVerify = React.lazy(() => import('./pages/EmailVerify'))
 const OrganizationSettings = React.lazy(() => import('@/pages/OrganizationSettings'))
@@ -187,6 +188,7 @@ function App() {
         <Route path={getRouteSubPath(RoutePath.KEYS)} element={<Keys />} />
         <Route path={getRouteSubPath(RoutePath.BOXES)} element={<Boxes />} />
         <Route path={getRouteSubPath(RoutePath.BILLING)} element={<Billing />} />
+        <Route path={getRouteSubPath(RoutePath.USAGE_VERIFICATION)} element={<UsageVerification />} />
         <Route path={getRouteSubPath(RoutePath.PRICING)} element={<Navigate to={RoutePath.BILLING} replace />} />
         <Route path={getRouteSubPath(RoutePath.ADMIN)} element={<Admin />} />
         {/* TODO(image-rewrite): legacy /dashboard/templates route removed with the templates page. */}

--- a/apps/dashboard/src/api/apiClient.test.ts
+++ b/apps/dashboard/src/api/apiClient.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AxiosRequestConfig } from 'axios'
 
 const config = { apiUrl: 'http://api.test/api' } as never
 
@@ -61,5 +62,28 @@ describe('ApiClient 401 -> bounded re-login recovery', () => {
     await expect(api.organizationsApi.listOrganizations()).rejects.toBeTruthy()
     // Marker cleared so a later genuine 401 still gets its one recovery attempt.
     expect(window.sessionStorage.getItem('boxlite.reauth-attempted')).toBeNull()
+  })
+})
+
+describe('ApiClient usage requests', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('sends the selected organization header for usage reads', async () => {
+    vi.resetModules()
+    const axios = (await import('axios')).default
+    const requests: AxiosRequestConfig[] = []
+    axios.defaults.adapter = (async (cfg: AxiosRequestConfig) => {
+      requests.push(cfg)
+      return { data: cfg.url?.endsWith('/periods') ? [] : {}, status: 200, statusText: '', headers: {}, config: cfg }
+    }) as never
+
+    const { ApiClient } = await import('./apiClient')
+    const api = new ApiClient(config, 'tok')
+    await api.getBoxUsage('box-1', 'org-1')
+    await api.getBoxUsagePeriods('box-1', 'org-1')
+
+    expect(requests.map((request) => request.headers?.['X-BoxLite-Organization-ID'])).toEqual(['org-1', 'org-1'])
   })
 })

--- a/apps/dashboard/src/api/apiClient.ts
+++ b/apps/dashboard/src/api/apiClient.ts
@@ -5,6 +5,7 @@
  */
 
 import { BillingApiClient } from '@/billing-api/billingApiClient'
+import type { BoxUsagePeriodRow, BoxUsageTotals } from '@/lib/usage-verification'
 import { DashboardConfig } from '@/types/DashboardConfig'
 import {
   Configuration as AnalyticsConfiguration,
@@ -265,6 +266,22 @@ export class ApiClient {
       url,
       data,
     })
+  }
+
+  public async getBoxUsage(boxId: string, organizationId: string): Promise<BoxUsageTotals> {
+    return (
+      await this.axiosInstance.get<BoxUsageTotals>(`/usage/box/${encodeURIComponent(boxId)}`, {
+        headers: { 'X-BoxLite-Organization-ID': organizationId },
+      })
+    ).data
+  }
+
+  public async getBoxUsagePeriods(boxId: string, organizationId: string): Promise<BoxUsagePeriodRow[]> {
+    return (
+      await this.axiosInstance.get<BoxUsagePeriodRow[]>(`/usage/box/${encodeURIComponent(boxId)}/periods`, {
+        headers: { 'X-BoxLite-Organization-ID': organizationId },
+      })
+    ).data
   }
 
   public get axiosInstance() {

--- a/apps/dashboard/src/components/Box/CreateBoxDialog.tsx
+++ b/apps/dashboard/src/components/Box/CreateBoxDialog.tsx
@@ -7,23 +7,19 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from 
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
 import { RoutePath } from '@/enums/RoutePath'
 import { useCreateBoxMutation } from '@/hooks/mutations/useCreateBoxMutation'
+import { useConfig } from '@/hooks/useConfig'
+import { getBoxImageOptions, getDefaultBoxImage, resolveCreateBoxImageRef } from '@/lib/box-images'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
 import { getBoxRouteId } from '@/lib/box-identity'
 import { handleApiError } from '@/lib/error-handling'
 import { cn } from '@/lib/utils'
 import type { Box } from '@boxlite-ai/api-client'
 import { ChevronDown, Plus } from '@/components/ui/icon'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { generatePath, useNavigate } from 'react-router-dom'
 import { toast } from 'sonner'
 
 const NAME_REGEX = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/
-
-const SUPPORTED_BOX_IMAGES = [
-  { id: 'base', name: 'Base', ref: 'ghcr.io/boxlite-ai/boxlite-agent-base:20260605-p0-r3', isDefault: true },
-  { id: 'python', name: 'Python', ref: 'ghcr.io/boxlite-ai/boxlite-agent-python:20260605-p0-r3', isDefault: false },
-  { id: 'node', name: 'Node.js', ref: 'ghcr.io/boxlite-ai/boxlite-agent-node:20260605-p0-r3', isDefault: false },
-] as const
 
 const DEFAULTS = { cpu: 1, memory: 1, disk: 10 }
 const LIMITS = { cpu: 8, memory: 32, disk: 50 }
@@ -104,13 +100,15 @@ export const CreateBoxDialog = ({
   onCreated?: (box: Box) => void
 }) => {
   const navigate = useNavigate()
+  const config = useConfig()
   const [internalOpen, setInternalOpen] = useState(false)
   const open = controlledOpen ?? internalOpen
   const setOpen = onOpenChange ?? setInternalOpen
 
   const { selectedOrganization } = useSelectedOrganization()
   const createBoxMutation = useCreateBoxMutation()
-  const defaultImage = SUPPORTED_BOX_IMAGES.find((i) => i.isDefault) ?? SUPPORTED_BOX_IMAGES[0]
+  const imageOptions = useMemo(() => getBoxImageOptions(config.environment), [config.environment])
+  const defaultImage = getDefaultBoxImage(imageOptions)
 
   const [name, setName] = useState('')
   const [imageRef, setImageRef] = useState<string>(defaultImage.ref)
@@ -132,7 +130,7 @@ export const CreateBoxDialog = ({
     }
   }, [open, defaultImage.ref])
 
-  const selectedImage = SUPPORTED_BOX_IMAGES.find((i) => i.ref === imageRef) ?? defaultImage
+  const selectedImage = imageOptions.find((i) => i.ref === imageRef) ?? defaultImage
   const nameValid = !name || NAME_REGEX.test(name)
 
   const handleCreate = async () => {
@@ -148,7 +146,7 @@ export const CreateBoxDialog = ({
     try {
       const box = await createBoxMutation.mutateAsync({
         name: name.trim() || undefined,
-        image: imageRef || defaultImage.ref,
+        image: resolveCreateBoxImageRef(imageRef),
         network: { mode: 'enabled' },
         resources: { cpu, memory, disk },
       })
@@ -217,7 +215,7 @@ export const CreateBoxDialog = ({
                 align="start"
                 className="min-w-[var(--radix-dropdown-menu-trigger-width)] font-mono text-[12px]"
               >
-                {SUPPORTED_BOX_IMAGES.map((img) => (
+                {imageOptions.map((img) => (
                   <DropdownMenuItem
                     key={img.id}
                     className={cn('cursor-pointer', img.ref === imageRef && 'text-brand')}

--- a/apps/dashboard/src/components/Sidebar.tsx
+++ b/apps/dashboard/src/components/Sidebar.tsx
@@ -182,6 +182,7 @@ export function Sidebar({ isBannerVisible }: SidebarProps) {
     () => [
       { label: 'Boxes', path: RoutePath.BOXES },
       { label: 'Billing', path: RoutePath.BILLING },
+      { label: 'Usage', path: RoutePath.USAGE_VERIFICATION },
       ...(canViewAdmin ? [{ label: 'Admin', path: RoutePath.ADMIN }] : []),
     ],
     [canViewAdmin],

--- a/apps/dashboard/src/components/boxes/BoxDetails.tsx
+++ b/apps/dashboard/src/components/boxes/BoxDetails.tsx
@@ -48,6 +48,7 @@ import { useAuth } from 'react-oidc-context'
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom'
 import { toast } from 'sonner'
 import { BoxTerminalTab } from './BoxTerminalTab'
+import { BoxUsageLedger } from './BoxUsageLedger'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 
 const STATUS = { running: '#5ad67d', idle: '#e0b341', stopped: '#8C919C', error: '#e0564a', dim: '#5b616e' } as const
@@ -356,15 +357,19 @@ export default function BoxDetails() {
                   <Pause className="size-[13px]" fill="currentColor" /> stop
                 </button>
               )}
-              {writePermitted && isTransitioning(box) && !isRecoverable(box) && !isStartable(box) && !isStoppable(box) && (
-                <button
-                  type="button"
-                  disabled
-                  className="flex min-h-10 items-center gap-2 border border-border px-[15px] py-2 text-[13px] font-medium text-muted-foreground"
-                >
-                  <RefreshCw className="size-[14px] animate-spin" /> working…
-                </button>
-              )}
+              {writePermitted &&
+                isTransitioning(box) &&
+                !isRecoverable(box) &&
+                !isStartable(box) &&
+                !isStoppable(box) && (
+                  <button
+                    type="button"
+                    disabled
+                    className="flex min-h-10 items-center gap-2 border border-border px-[15px] py-2 text-[13px] font-medium text-muted-foreground"
+                  >
+                    <RefreshCw className="size-[14px] animate-spin" /> working…
+                  </button>
+                )}
               {deletePermitted && (
                 <DropdownMenu>
                   <DropdownMenuTrigger
@@ -434,6 +439,8 @@ export default function BoxDetails() {
               <SectionHeader title="timestamps" />
               <SpecRow label="created">{getRelativeTimeString(box.createdAt).relativeTimeString}</SpecRow>
               <SpecRow label="last event">{getRelativeTimeString(box.updatedAt).relativeTimeString}</SpecRow>
+
+              <BoxUsageLedger boxId={box.id} />
 
               {box.errorReason && (
                 <>

--- a/apps/dashboard/src/components/boxes/BoxUsageLedger.tsx
+++ b/apps/dashboard/src/components/boxes/BoxUsageLedger.tsx
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { useBoxUsagePeriodsQuery, useBoxUsageQuery } from '@/hooks/queries/useBoxUsageQuery'
+import { formatUsageSeconds, formatUsageTimestamp } from '@/lib/usage-verification'
+import { RefreshCw } from '@/components/ui/icon'
+
+function errorText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+export function BoxUsageLedger({ boxId }: { boxId: string }) {
+  const periodsQuery = useBoxUsagePeriodsQuery(boxId, true)
+  const usageQuery = useBoxUsageQuery(boxId, true)
+
+  const refresh = () => {
+    periodsQuery.refetch()
+    usageQuery.refetch()
+  }
+
+  return (
+    <div className="mt-4 border border-border bg-card p-3">
+      <div className="flex items-center justify-between gap-3">
+        <div className="font-mono text-[10px] uppercase tracking-[1.2px] text-muted-foreground">usage_period</div>
+        <button
+          type="button"
+          onClick={refresh}
+          title="refresh usage"
+          className="flex size-7 items-center justify-center border border-border transition-colors hover:bg-background"
+        >
+          <RefreshCw
+            className={periodsQuery.isFetching || usageQuery.isFetching ? 'size-3.5 animate-spin' : 'size-3.5'}
+          />
+        </button>
+      </div>
+
+      <div className="mt-3 overflow-x-auto border border-border">
+        <table className="w-full min-w-[720px] border-collapse font-mono text-[11px]">
+          <thead className="bg-background text-muted-foreground">
+            <tr>
+              <th className="border-b border-border px-2 py-2 text-left font-medium">kind</th>
+              <th className="border-b border-border px-2 py-2 text-left font-medium">periodStart</th>
+              <th className="border-b border-border px-2 py-2 text-left font-medium">periodEnd</th>
+              <th className="border-b border-border px-2 py-2 text-right font-medium">cpu</th>
+              <th className="border-b border-border px-2 py-2 text-right font-medium">mem</th>
+              <th className="border-b border-border px-2 py-2 text-right font-medium">disk</th>
+            </tr>
+          </thead>
+          <tbody>
+            {periodsQuery.data?.map((row) => (
+              <tr key={row.id} className="border-b border-border last:border-b-0">
+                <td className="px-2 py-2">{row.kind}</td>
+                <td className="px-2 py-2">{formatUsageTimestamp(row.periodStart)}</td>
+                <td className="px-2 py-2">{formatUsageTimestamp(row.periodEnd)}</td>
+                <td className="px-2 py-2 text-right">{row.allocCpu}</td>
+                <td className="px-2 py-2 text-right">{row.allocMemGib}</td>
+                <td className="px-2 py-2 text-right">{row.allocDiskGib}</td>
+              </tr>
+            ))}
+            {periodsQuery.data?.length === 0 && (
+              <tr>
+                <td colSpan={6} className="px-2 py-6 text-center text-muted-foreground">
+                  No usage_period rows
+                </td>
+              </tr>
+            )}
+            {periodsQuery.isError && (
+              <tr>
+                <td colSpan={6} className="px-2 py-3 text-destructive">
+                  {errorText(periodsQuery.error)}
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="mt-4 font-mono text-[10px] uppercase tracking-[1.2px] text-muted-foreground">
+        GET /api/usage/box/{boxId}
+      </div>
+      <div className="mt-2 grid grid-cols-3 gap-2 font-mono text-[11px]">
+        <div className="border border-border bg-background p-2">
+          <div className="text-muted-foreground">CPU seconds</div>
+          <div className="mt-1 text-foreground">{formatUsageSeconds(usageQuery.data?.totalCPUSeconds)}</div>
+        </div>
+        <div className="border border-border bg-background p-2">
+          <div className="text-muted-foreground">RAM GB seconds</div>
+          <div className="mt-1 text-foreground">{formatUsageSeconds(usageQuery.data?.totalRAMGBSeconds)}</div>
+        </div>
+        <div className="border border-border bg-background p-2">
+          <div className="text-muted-foreground">Disk GB seconds</div>
+          <div className="mt-1 text-foreground">{formatUsageSeconds(usageQuery.data?.totalDiskGBSeconds)}</div>
+        </div>
+      </div>
+      <pre className="mt-2 max-h-[190px] overflow-auto whitespace-pre-wrap break-words border border-border bg-background p-2 font-mono text-[11px]">
+        {usageQuery.isError ? errorText(usageQuery.error) : JSON.stringify(usageQuery.data ?? null, null, 2)}
+      </pre>
+    </div>
+  )
+}

--- a/apps/dashboard/src/enums/RoutePath.ts
+++ b/apps/dashboard/src/enums/RoutePath.ts
@@ -20,6 +20,7 @@ export enum RoutePath {
   KEYS = '/dashboard/keys',
   BOXES = '/dashboard/boxes',
   BILLING = '/dashboard/billing',
+  USAGE_VERIFICATION = '/dashboard/usage-verification',
   PRICING = '/dashboard/pricing',
   ADMIN = '/dashboard/admin',
   IMAGES = '/dashboard/images',

--- a/apps/dashboard/src/hooks/queries/queryKeys.ts
+++ b/apps/dashboard/src/hooks/queries/queryKeys.ts
@@ -80,6 +80,9 @@ export const queryKeys = {
     all: ['boxes'] as const,
     detail: (organizationId: string, boxId: string) =>
       [...queryKeys.boxes.all, organizationId, boxId, 'detail'] as const,
+    usage: (organizationId: string, boxId: string) => [...queryKeys.boxes.all, organizationId, boxId, 'usage'] as const,
+    usagePeriods: (organizationId: string, boxId: string) =>
+      [...queryKeys.boxes.all, organizationId, boxId, 'usage-periods'] as const,
     terminalSession: (boxId: string) => [...queryKeys.boxes.all, boxId, 'terminal-session'] as const,
   },
   telemetry: {

--- a/apps/dashboard/src/hooks/queries/useBoxUsageQuery.ts
+++ b/apps/dashboard/src/hooks/queries/useBoxUsageQuery.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { useApi } from '@/hooks/useApi'
+import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
+import type { BoxUsagePeriodRow, BoxUsageTotals } from '@/lib/usage-verification'
+import { useQuery } from '@tanstack/react-query'
+import { queryKeys } from './queryKeys'
+
+export function useBoxUsageQuery(boxId: string | undefined, autoRefresh: boolean) {
+  const api = useApi()
+  const { selectedOrganization } = useSelectedOrganization()
+
+  return useQuery<BoxUsageTotals>({
+    queryKey: queryKeys.boxes.usage(selectedOrganization?.id ?? '', boxId ?? ''),
+    queryFn: () => api.getBoxUsage(boxId ?? '', selectedOrganization?.id ?? ''),
+    enabled: !!selectedOrganization?.id && !!boxId,
+    refetchInterval: autoRefresh ? 3000 : false,
+    staleTime: 1000,
+    retry: false,
+  })
+}
+
+export function useBoxUsagePeriodsQuery(boxId: string | undefined, autoRefresh: boolean) {
+  const api = useApi()
+  const { selectedOrganization } = useSelectedOrganization()
+
+  return useQuery<BoxUsagePeriodRow[]>({
+    queryKey: queryKeys.boxes.usagePeriods(selectedOrganization?.id ?? '', boxId ?? ''),
+    queryFn: () => api.getBoxUsagePeriods(boxId ?? '', selectedOrganization?.id ?? ''),
+    enabled: !!selectedOrganization?.id && !!boxId,
+    refetchInterval: autoRefresh ? 3000 : false,
+    staleTime: 1000,
+    retry: false,
+  })
+}

--- a/apps/dashboard/src/lib/box-images.test.ts
+++ b/apps/dashboard/src/lib/box-images.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { getBoxImageOptions, getDefaultBoxImage, resolveCreateBoxImageRef } from './box-images'
+
+describe('box image options', () => {
+  it('uses the arm64-capable base v0.1.0 image for local box creation', () => {
+    const images = getBoxImageOptions('local')
+    const defaultImage = getDefaultBoxImage(images)
+
+    expect(images.map((image) => image.ref)).toEqual(['ghcr.io/boxlite-ai/boxlite-agent-base:v0.1.0'])
+    expect(defaultImage.name).toBe('Base')
+    expect(resolveCreateBoxImageRef(defaultImage.ref)).toBe('ghcr.io/boxlite-ai/boxlite-agent-base:v0.1.0')
+  })
+
+  it('keeps curated image refs available outside local', () => {
+    const images = getBoxImageOptions('production')
+    const defaultImage = getDefaultBoxImage(images)
+
+    expect(images.map((image) => image.name)).toEqual(['Base', 'Python', 'Node.js'])
+    expect(resolveCreateBoxImageRef(defaultImage.ref)).toBe('ghcr.io/boxlite-ai/boxlite-agent-base:20260605-p0-r3')
+  })
+
+  it('treats an empty image ref as omitted in the Box API request', () => {
+    expect(resolveCreateBoxImageRef('')).toBeUndefined()
+    expect(resolveCreateBoxImageRef('ghcr.io/boxlite-ai/boxlite-agent-node:20260605-p0-r3')).toBe(
+      'ghcr.io/boxlite-ai/boxlite-agent-node:20260605-p0-r3',
+    )
+  })
+})

--- a/apps/dashboard/src/lib/box-images.ts
+++ b/apps/dashboard/src/lib/box-images.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+export type BoxImageOption = {
+  id: string
+  name: string
+  ref: string
+  isDefault: boolean
+}
+
+const CLOUD_BOX_IMAGES = [
+  { id: 'base', name: 'Base', ref: 'ghcr.io/boxlite-ai/boxlite-agent-base:20260605-p0-r3', isDefault: true },
+  { id: 'python', name: 'Python', ref: 'ghcr.io/boxlite-ai/boxlite-agent-python:20260605-p0-r3', isDefault: false },
+  { id: 'node', name: 'Node.js', ref: 'ghcr.io/boxlite-ai/boxlite-agent-node:20260605-p0-r3', isDefault: false },
+] as const satisfies readonly BoxImageOption[]
+
+const LOCAL_BOX_IMAGES = [
+  { id: 'base', name: 'Base', ref: 'ghcr.io/boxlite-ai/boxlite-agent-base:v0.1.0', isDefault: true },
+] as const satisfies readonly BoxImageOption[]
+
+export function getBoxImageOptions(environment: string | undefined): readonly BoxImageOption[] {
+  return environment === 'local' ? LOCAL_BOX_IMAGES : CLOUD_BOX_IMAGES
+}
+
+export function getDefaultBoxImage(images: readonly BoxImageOption[]): BoxImageOption {
+  return images.find((image) => image.isDefault) ?? images[0]
+}
+
+export function resolveCreateBoxImageRef(imageRef: string): string | undefined {
+  return imageRef || undefined
+}

--- a/apps/dashboard/src/lib/usage-verification.test.ts
+++ b/apps/dashboard/src/lib/usage-verification.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import {
+  calculateUsageDelta,
+  formatUsageSeconds,
+  formatUsageTimestamp,
+  type BoxUsageTotals,
+} from './usage-verification'
+
+describe('usage verification helpers', () => {
+  it('formats usage seconds with useful precision', () => {
+    expect(formatUsageSeconds(undefined)).toBe('-')
+    expect(formatUsageSeconds(90.21)).toBe('90.21')
+    expect(formatUsageSeconds(158.844)).toBe('158.8')
+  })
+
+  it('calculates non-negative deltas between usage samples', () => {
+    const previous: BoxUsageTotals = {
+      boxId: 'box-1',
+      totalCPUSeconds: 10,
+      totalRAMGBSeconds: 12,
+      totalDiskGBSeconds: 20,
+      totalGPUSeconds: 0,
+    }
+    const current: BoxUsageTotals = {
+      boxId: 'box-1',
+      totalCPUSeconds: 17.5,
+      totalRAMGBSeconds: 18,
+      totalDiskGBSeconds: 42,
+      totalGPUSeconds: 0,
+    }
+
+    expect(calculateUsageDelta(current, previous)).toEqual({
+      cpu: 7.5,
+      ram: 6,
+      disk: 22,
+      gpu: 0,
+    })
+    expect(calculateUsageDelta(previous, current).cpu).toBe(0)
+  })
+
+  it('formats raw period timestamps for compact table display', () => {
+    expect(formatUsageTimestamp('2026-06-25T12:00:00.000Z')).toBe('2026-06-25 12:00:00Z')
+    expect(formatUsageTimestamp(null)).toBe('NULL')
+    expect(formatUsageTimestamp('not-a-date')).toBe('not-a-date')
+  })
+})

--- a/apps/dashboard/src/lib/usage-verification.ts
+++ b/apps/dashboard/src/lib/usage-verification.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+export interface BoxUsageTotals {
+  boxId: string
+  totalCPUSeconds: number
+  totalRAMGBSeconds: number
+  totalDiskGBSeconds: number
+  totalGPUSeconds: number
+}
+
+export interface BoxUsagePeriodRow {
+  id: string
+  boxId: string
+  organizationId: string
+  region: string | null
+  kind: string
+  periodStart: string
+  periodEnd: string | null
+  allocCpu: number
+  allocMemGib: number
+  allocDiskGib: number
+  createdAt: string
+  updatedAt: string
+}
+
+export interface UsageDelta {
+  cpu: number
+  ram: number
+  disk: number
+  gpu: number
+}
+
+export function formatUsageSeconds(value: number | undefined): string {
+  if (value === undefined || !Number.isFinite(value)) return '-'
+  if (Math.abs(value) < 100) return value.toFixed(2)
+  return value.toFixed(1)
+}
+
+export function calculateUsageDelta(current?: BoxUsageTotals, previous?: BoxUsageTotals): UsageDelta {
+  return {
+    cpu: Math.max(0, (current?.totalCPUSeconds ?? 0) - (previous?.totalCPUSeconds ?? 0)),
+    ram: Math.max(0, (current?.totalRAMGBSeconds ?? 0) - (previous?.totalRAMGBSeconds ?? 0)),
+    disk: Math.max(0, (current?.totalDiskGBSeconds ?? 0) - (previous?.totalDiskGBSeconds ?? 0)),
+    gpu: Math.max(0, (current?.totalGPUSeconds ?? 0) - (previous?.totalGPUSeconds ?? 0)),
+  }
+}
+
+export function formatUsageTimestamp(value: string | null | undefined): string {
+  if (!value) return 'NULL'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return date.toISOString().replace('T', ' ').replace('.000Z', 'Z')
+}

--- a/apps/dashboard/src/pages/UsageVerification.tsx
+++ b/apps/dashboard/src/pages/UsageVerification.tsx
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { BoxUsageLedger } from '@/components/boxes/BoxUsageLedger'
+import { Button } from '@/components/ui/button'
+import { getBoxesQueryKey, useBoxes } from '@/hooks/useBoxes'
+import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
+import { getBoxDisplayName } from '@/lib/box-identity'
+import { cn } from '@/lib/utils'
+import { ListBoxesPaginatedStatesEnum } from '@boxlite-ai/api-client'
+import { useMemo, useState } from 'react'
+
+const VISIBLE_BOX_STATES = [
+  ListBoxesPaginatedStatesEnum.CREATING,
+  ListBoxesPaginatedStatesEnum.STARTING,
+  ListBoxesPaginatedStatesEnum.STARTED,
+  ListBoxesPaginatedStatesEnum.STOPPING,
+  ListBoxesPaginatedStatesEnum.STOPPED,
+  ListBoxesPaginatedStatesEnum.ERROR,
+  ListBoxesPaginatedStatesEnum.UNKNOWN,
+]
+
+export default function UsageVerification() {
+  const { selectedOrganization } = useSelectedOrganization()
+  const [selectedBoxId, setSelectedBoxId] = useState('')
+  const boxesParams = useMemo(
+    () => ({
+      page: 1,
+      pageSize: 50,
+      filters: {
+        states: VISIBLE_BOX_STATES,
+      },
+    }),
+    [],
+  )
+  const boxesQuery = useBoxes(getBoxesQueryKey(selectedOrganization?.id, boxesParams), boxesParams)
+
+  return (
+    <main className="min-h-[var(--app-content-height,calc(100svh_-_60px))] bg-background p-4 text-foreground sm:p-5">
+      <div className="mx-auto grid w-full max-w-[1320px] gap-4 lg:grid-cols-[360px_minmax(0,1fr)]">
+        <section className="border border-border bg-card p-4">
+          <div className="flex items-center justify-between gap-3 border-b border-border pb-3">
+            <div>
+              <h1 className="text-lg font-semibold tracking-tight">Usage</h1>
+              <div className="mt-1 font-mono text-xs text-muted-foreground">
+                org={selectedOrganization?.id ?? 'none'}
+              </div>
+            </div>
+            <Button variant="secondary" onClick={() => boxesQuery.refetch()}>
+              Refresh
+            </Button>
+          </div>
+          <div className="mt-3 max-h-[calc(100svh-180px)] overflow-auto">
+            {(boxesQuery.data?.items ?? []).map((box) => (
+              <button
+                type="button"
+                key={box.id}
+                onClick={() => setSelectedBoxId(box.id)}
+                className={cn(
+                  'w-full border-b border-border px-2 py-2 text-left last:border-b-0 hover:bg-accent',
+                  selectedBoxId === box.id && 'bg-accent',
+                )}
+              >
+                <div className="truncate text-sm font-medium">{getBoxDisplayName(box)}</div>
+                <div className="mt-1 flex items-center justify-between gap-2 font-mono text-xs text-muted-foreground">
+                  <span className="truncate">{box.id}</span>
+                  <span>{box.state}</span>
+                </div>
+              </button>
+            ))}
+            {boxesQuery.data?.items.length === 0 && (
+              <div className="py-8 text-center text-sm text-muted-foreground">No boxes</div>
+            )}
+          </div>
+        </section>
+
+        <section>
+          {selectedBoxId ? (
+            <BoxUsageLedger boxId={selectedBoxId} />
+          ) : (
+            <div className="border border-dashed border-border p-8 text-center text-sm text-muted-foreground">
+              Select a box to inspect usage_period rows and aggregate usage JSON.
+            </div>
+          )}
+        </section>
+      </div>
+    </main>
+  )
+}

--- a/apps/infra-local/compose/services.py
+++ b/apps/infra-local/compose/services.py
@@ -197,6 +197,7 @@ staticClients:
     redirectURIs:
       - '${REDIRECT_URI}'
       - 'http://localhost:3000'
+      - 'http://localhost:3002'
       - 'http://localhost:5173'
       # `boxlite auth login` (browser/OIDC) loopback callback — RFC 8252 §8.3
       # loopback IP literal on the CLI's fixed default port 5555. The CLI binds


### PR DESCRIPTION
## Summary
- add a dashboard usage inspection panel that shows raw `usage_period` rows and `/api/usage/box/:id` aggregate JSON for an existing box
- expose a read-only `GET /api/usage/box/:boxId/periods` endpoint for local validation/debugging
- make local dashboard box creation use the arm64-capable `ghcr.io/boxlite-ai/boxlite-agent-base:v0.1.0` image
- allow local Dex redirects from `http://localhost:3002`

## Verification
- `npx nx test api --testPathPatterns='usage' --skip-nx-cache`
- `npx vitest run dashboard/src/api/apiClient.test.ts dashboard/src/lib/usage-verification.test.ts dashboard/src/lib/box-images.test.ts --config dashboard/vite.config.mts`
- `npx nx build dashboard`
- infra-local smoke: created a real box with `ghcr.io/boxlite-ai/boxlite-agent-base:v0.1.0`, observed `started`, verified raw `usage_period` rows and aggregate JSON, then deleted test boxes

## Notes
- Draft PR for local-stack MVP validation; branch is still based on the original usage MVP base and is behind current `main`.
