### PR TITLE
feat(usage): MVP alloc usage timing

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -11,6 +11,7 @@ import { AppService } from './app.service'
 import { UserModule } from './user/user.module'
 import { TypeOrmModule } from '@nestjs/typeorm'
 import { BoxModule } from './box/box.module'
+import { UsageModule } from './usage/usage.module'
 import { AuthModule } from './auth/auth.module'
 import { ServeStaticModule } from '@nestjs/serve-static'
 import { join } from 'path'
@@ -174,6 +175,7 @@ import { BoxliteRestModule } from './boxlite-rest/boxlite-rest.module'
     BoxModule,
     ScheduleModule.forRoot(),
     AnalyticsModule,
+    UsageModule,
     OrganizationModule,
     RegionModule,
     AdminModule,

--- a/apps/api/src/migrations/pre-deploy/1782600000000-migration.ts
+++ b/apps/api/src/migrations/pre-deploy/1782600000000-migration.ts
@@ -1,0 +1,46 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+/**
+ * MVP user-timing ledger: one table, `usage_period`. Spec snapshot + start/end
+ * per segment; the billable amount is computed at read time (spec × duration).
+ *
+ * Intentionally NOT created here (added back as additive migrations when the
+ * fuller design lands): the `actual*`/`sampleCount`/`sealed` columns, the
+ * partial-unique "one open segment per box" index, and the end-after-start
+ * CHECK. The column names/types match the fuller ledger, so those are pure
+ * `ADD COLUMN` / `ADD CONSTRAINT` later (the partial-unique one needs a dedupe
+ * pass first if any double-open rows slipped in).
+ */
+export class Migration1782600000000 implements MigrationInterface {
+  name = 'Migration1782600000000'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "usage_period" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "boxId" character varying NOT NULL,
+        "organizationId" character varying NOT NULL,
+        "region" character varying,
+        "periodStart" TIMESTAMP WITH TIME ZONE NOT NULL,
+        "periodEnd" TIMESTAMP WITH TIME ZONE,
+        "kind" character varying NOT NULL,
+        "allocCpu" integer NOT NULL,
+        "allocMemGib" integer NOT NULL,
+        "allocDiskGib" integer NOT NULL,
+        "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        CONSTRAINT "usage_period_id_pk" PRIMARY KEY ("id")
+      )`,
+    )
+    await queryRunner.query(
+      `CREATE INDEX "usage_period_box_period_start_idx" ON "usage_period" ("boxId", "periodStart")`,
+    )
+    await queryRunner.query(
+      `CREATE INDEX "usage_period_org_period_start_idx" ON "usage_period" ("organizationId", "periodStart")`,
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "usage_period"`)
+  }
+}

--- a/apps/api/src/usage/billing/usage-math.spec.ts
+++ b/apps/api/src/usage/billing/usage-math.spec.ts
@@ -25,6 +25,12 @@ describe('planTransition', () => {
   it('no open period → DESTROYED is a no-op', () => {
     expect(planTransition(null, BoxState.DESTROYED)).toEqual({ closeOpen: false, openKind: null })
   })
+  it('RESIZING is transient: a hot resize keeps the running period open (no cpu/ram gap)', () => {
+    expect(planTransition('running', BoxState.RESIZING)).toEqual({ closeOpen: false, openKind: null })
+  })
+  it('RESIZING is transient: a disk resize on a stopped box stays disk-only (no cpu/ram billing)', () => {
+    expect(planTransition('stopped', BoxState.RESIZING)).toEqual({ closeOpen: false, openKind: null })
+  })
 })
 
 describe('billingPeriodKind', () => {

--- a/apps/api/src/usage/billing/usage-math.spec.ts
+++ b/apps/api/src/usage/billing/usage-math.spec.ts
@@ -1,0 +1,167 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { BoxState } from '../../box/enums/box-state.enum'
+import { aggregatePeriods, billingPeriodKind, planTransition, BillablePeriod } from './usage-math'
+
+describe('planTransition', () => {
+  it('first STARTED opens a running period', () => {
+    expect(planTransition(null, BoxState.STARTED)).toEqual({ closeOpen: false, openKind: 'running' })
+  })
+  it('running → STOPPED closes running, opens stopped (disk continues)', () => {
+    expect(planTransition('running', BoxState.STOPPED)).toEqual({ closeOpen: true, openKind: 'stopped' })
+  })
+  it('stopped → STARTED closes stopped, opens running', () => {
+    expect(planTransition('stopped', BoxState.STARTED)).toEqual({ closeOpen: true, openKind: 'running' })
+  })
+  it('running → STARTED (same kind) is a no-op, no fragmentation', () => {
+    expect(planTransition('running', BoxState.STARTED)).toEqual({ closeOpen: false, openKind: null })
+  })
+  it('running → DESTROYED closes running, opens nothing', () => {
+    expect(planTransition('running', BoxState.DESTROYED)).toEqual({ closeOpen: true, openKind: null })
+  })
+  it('no open period → DESTROYED is a no-op', () => {
+    expect(planTransition(null, BoxState.DESTROYED)).toEqual({ closeOpen: false, openKind: null })
+  })
+})
+
+describe('billingPeriodKind', () => {
+  it('STARTED → running (cpu+ram+disk bill)', () => {
+    expect(billingPeriodKind(BoxState.STARTED)).toBe('running')
+  })
+  it('STOPPED → stopped (disk still on disk, no cpu/ram)', () => {
+    expect(billingPeriodKind(BoxState.STOPPED)).toBe('stopped')
+  })
+  it('ARCHIVED → stopped (rootfs retained)', () => {
+    expect(billingPeriodKind(BoxState.ARCHIVED)).toBe('stopped')
+  })
+  it('CREATING → stopped (rootfs exists, not running yet)', () => {
+    expect(billingPeriodKind(BoxState.CREATING)).toBe('stopped')
+  })
+  it('DESTROYED → gone (rootfs released, close period)', () => {
+    expect(billingPeriodKind(BoxState.DESTROYED)).toBe('gone')
+  })
+})
+
+describe('aggregatePeriods', () => {
+  const from = new Date('2026-06-25T00:00:00Z')
+  const to = new Date('2026-06-26T00:00:00Z')
+
+  it('running period: cpu + ram + disk all count', () => {
+    const periods: BillablePeriod[] = [
+      {
+        startAt: new Date('2026-06-25T12:00:00Z'),
+        endAt: new Date('2026-06-25T12:00:10Z'), // 10s
+        kind: 'running',
+        allocCpu: 2,
+        allocMemGib: 4,
+        allocDiskGib: 10,
+      },
+    ]
+    expect(aggregatePeriods(periods, from, to)).toEqual({
+      totalCpuSeconds: 20, // 2 vCPU × 10s
+      totalRamGbSeconds: 40, // 4 GiB × 10s
+      totalDiskGbSeconds: 100, // 10 GiB × 10s
+    })
+  })
+
+  it('stopped period: only disk counts', () => {
+    const periods: BillablePeriod[] = [
+      {
+        startAt: new Date('2026-06-25T12:00:00Z'),
+        endAt: new Date('2026-06-25T12:00:10Z'), // 10s
+        kind: 'stopped',
+        allocCpu: 2,
+        allocMemGib: 4,
+        allocDiskGib: 10,
+      },
+    ]
+    expect(aggregatePeriods(periods, from, to)).toEqual({
+      totalCpuSeconds: 0,
+      totalRamGbSeconds: 0,
+      totalDiskGbSeconds: 100,
+    })
+  })
+
+  it('open period (endAt null) is clipped at `to`', () => {
+    const periods: BillablePeriod[] = [
+      {
+        startAt: new Date('2026-06-25T23:59:50Z'), // 10s before `to`
+        endAt: null,
+        kind: 'running',
+        allocCpu: 1,
+        allocMemGib: 1,
+        allocDiskGib: 1,
+      },
+    ]
+    expect(aggregatePeriods(periods, from, to)).toEqual({
+      totalCpuSeconds: 10,
+      totalRamGbSeconds: 10,
+      totalDiskGbSeconds: 10,
+    })
+  })
+
+  it('clips a period overlapping the range start', () => {
+    const periods: BillablePeriod[] = [
+      {
+        startAt: new Date('2026-06-24T23:59:50Z'), // starts 10s before `from`
+        endAt: new Date('2026-06-25T00:00:10Z'), // ends 10s after `from`
+        kind: 'running',
+        allocCpu: 1,
+        allocMemGib: 1,
+        allocDiskGib: 1,
+      },
+    ]
+    expect(aggregatePeriods(periods, from, to)).toEqual({
+      totalCpuSeconds: 10, // only the 10s inside [from,to]
+      totalRamGbSeconds: 10,
+      totalDiskGbSeconds: 10,
+    })
+  })
+
+  it('drops a period entirely outside the range', () => {
+    const periods: BillablePeriod[] = [
+      {
+        startAt: new Date('2026-06-20T00:00:00Z'),
+        endAt: new Date('2026-06-20T01:00:00Z'),
+        kind: 'running',
+        allocCpu: 9,
+        allocMemGib: 9,
+        allocDiskGib: 9,
+      },
+    ]
+    expect(aggregatePeriods(periods, from, to)).toEqual({
+      totalCpuSeconds: 0,
+      totalRamGbSeconds: 0,
+      totalDiskGbSeconds: 0,
+    })
+  })
+
+  it('sums mixed running + stopped periods (Disk continuous across both)', () => {
+    const periods: BillablePeriod[] = [
+      {
+        startAt: new Date('2026-06-25T12:00:00Z'),
+        endAt: new Date('2026-06-25T12:00:10Z'), // running 10s
+        kind: 'running',
+        allocCpu: 2,
+        allocMemGib: 4,
+        allocDiskGib: 10,
+      },
+      {
+        startAt: new Date('2026-06-25T12:00:10Z'),
+        endAt: new Date('2026-06-25T12:00:30Z'), // stopped 20s
+        kind: 'stopped',
+        allocCpu: 2,
+        allocMemGib: 4,
+        allocDiskGib: 10,
+      },
+    ]
+    expect(aggregatePeriods(periods, from, to)).toEqual({
+      totalCpuSeconds: 20, // running 10s × 2
+      totalRamGbSeconds: 40, // running 10s × 4
+      totalDiskGbSeconds: 300, // (10s + 20s) × 10
+    })
+  })
+})

--- a/apps/api/src/usage/billing/usage-math.ts
+++ b/apps/api/src/usage/billing/usage-math.ts
@@ -30,7 +30,7 @@ export function billingPeriodKind(state: BoxState): BillingPeriodKind {
       return 'gone'
     default:
       // creating / restoring / starting / stopping / stopped / error /
-      // unknown / archived / archiving / resizing: rootfs exists → Disk bills,
+      // unknown / archived / archiving: rootfs exists → Disk bills,
       // but CPU/RAM do not (box isn't executing).
       return 'stopped'
   }
@@ -53,6 +53,15 @@ export interface TransitionPlan {
  * one continuous period is kept rather than fragmenting the ledger.
  */
 export function planTransition(openKind: 'running' | 'stopped' | null, newState: BoxState): TransitionPlan {
+  // RESIZING is a transient in-place state: a resize can start from STARTED
+  // (hot — workload keeps executing) or STOPPED (disk resize), and the box
+  // returns to that state when it completes. Mapping it to either kind would
+  // mis-bill one of the two cases (close a still-running period, or bill
+  // CPU/RAM for a stopped box), so the ledger simply keeps the open period.
+  if (newState === BoxState.RESIZING) {
+    return { closeOpen: false, openKind: null }
+  }
+
   const kind = billingPeriodKind(newState)
 
   if (kind === 'gone') {

--- a/apps/api/src/usage/billing/usage-math.ts
+++ b/apps/api/src/usage/billing/usage-math.ts
@@ -1,0 +1,125 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { BoxState } from '../../box/enums/box-state.enum'
+
+/**
+ * Billing meaning of a box lifecycle state.
+ *
+ * - `running`  — CPU + RAM + Disk all bill (box is executing).
+ * - `stopped`  — only Disk bills (box exists on disk but isn't running:
+ *                stopped / archived / starting / etc.).
+ * - `gone`     — box destroyed; no period exists (close any open one).
+ */
+export type BillingPeriodKind = 'running' | 'stopped' | 'gone'
+
+/**
+ * Map a {@link BoxState} to its billing meaning (the §8 truth table, collapsed
+ * to the control-plane's view — note there is no `paused` state at the API
+ * level). CPU/RAM bind to `running`; Disk binds to existence (everything except
+ * `gone`).
+ */
+export function billingPeriodKind(state: BoxState): BillingPeriodKind {
+  switch (state) {
+    case BoxState.STARTED:
+      return 'running'
+    case BoxState.DESTROYED:
+    case BoxState.DESTROYING:
+      return 'gone'
+    default:
+      // creating / restoring / starting / stopping / stopped / error /
+      // unknown / archived / archiving / resizing: rootfs exists → Disk bills,
+      // but CPU/RAM do not (box isn't executing).
+      return 'stopped'
+  }
+}
+
+/** What to do to the period ledger when a box changes state. */
+export interface TransitionPlan {
+  /** Close the currently-open period (stamp its `endAt = now`). */
+  closeOpen: boolean
+  /** Open a fresh period of this kind, or `null` to open nothing. */
+  openKind: 'running' | 'stopped' | null
+}
+
+/**
+ * Decide how the open period should change when a box moves to `newState`,
+ * given the kind of the currently-open period (`null` = none open).
+ *
+ * Keeps segments clean without churn: a transition that doesn't change the
+ * billing kind (e.g. STARTED→STARTED, or two disk-only states) is a no-op, so
+ * one continuous period is kept rather than fragmenting the ledger.
+ */
+export function planTransition(openKind: 'running' | 'stopped' | null, newState: BoxState): TransitionPlan {
+  const kind = billingPeriodKind(newState)
+
+  if (kind === 'gone') {
+    // Box destroyed: close whatever is open, open nothing.
+    return { closeOpen: openKind !== null, openKind: null }
+  }
+
+  // Same billing kind → keep the single open period (no churn).
+  if (openKind === kind) {
+    return { closeOpen: false, openKind: null }
+  }
+
+  // Kind changed: close the old open period (if any) and open the new kind.
+  return { closeOpen: openKind !== null, openKind: kind }
+}
+
+/** A stored usage period (alloc side) that contributes to billing. */
+export interface BillablePeriod {
+  startAt: Date
+  /** `null` = period still open (box still in this state). */
+  endAt: Date | null
+  /** `running`: cpu+ram+disk bill; `stopped`: disk only. */
+  kind: 'running' | 'stopped'
+  allocCpu: number
+  allocMemGib: number
+  allocDiskGib: number
+}
+
+/** Aggregated billable quantities over a time range (matches the analytics
+ *  contract's `totalCPUSeconds` / `totalRAMGBSeconds` / `totalDiskGBSeconds`). */
+export interface UsageTotals {
+  totalCpuSeconds: number
+  totalRamGbSeconds: number
+  totalDiskGbSeconds: number
+}
+
+/**
+ * Aggregate periods into billable totals, clipping each period to `[from, to]`.
+ * Open periods (`endAt === null`) are clipped at `to`. CPU/RAM only accrue for
+ * `running` periods; Disk accrues for every (existing) period.
+ */
+export function aggregatePeriods(periods: BillablePeriod[], from: Date, to: Date): UsageTotals {
+  const fromMs = from.getTime()
+  const toMs = to.getTime()
+
+  let totalCpuSeconds = 0
+  let totalRamGbSeconds = 0
+  let totalDiskGbSeconds = 0
+
+  for (const p of periods) {
+    // Open periods are clipped at the range end.
+    const endMs = (p.endAt ?? to).getTime()
+    const overlapStart = Math.max(p.startAt.getTime(), fromMs)
+    const overlapEnd = Math.min(endMs, toMs)
+    if (overlapEnd <= overlapStart) {
+      continue // entirely outside [from, to]
+    }
+    const seconds = (overlapEnd - overlapStart) / 1000
+
+    // Disk binds to existence — every (existing) period contributes.
+    totalDiskGbSeconds += p.allocDiskGib * seconds
+    // CPU/RAM bind to running.
+    if (p.kind === 'running') {
+      totalCpuSeconds += p.allocCpu * seconds
+      totalRamGbSeconds += p.allocMemGib * seconds
+    }
+  }
+
+  return { totalCpuSeconds, totalRamGbSeconds, totalDiskGbSeconds }
+}

--- a/apps/api/src/usage/entities/usage-period.entity.ts
+++ b/apps/api/src/usage/entities/usage-period.entity.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm'
+
+/**
+ * One usage segment for a box — the whole MVP timing model in one table.
+ *
+ * The idea (modelled on Daytona): a box's life is a chain of segments. A segment
+ * opens when the box's billing kind changes (running ↔ stopped) and closes
+ * (`periodEnd` set) at the next change or when the box is destroyed. We store the
+ * box's allocated spec (cpu/mem/disk) + the start/end timestamps and NOTHING
+ * else — the billable amount is `spec × duration`, computed at read time. No
+ * seconds stored, no money stored.
+ *
+ * MVP scope: this is deliberately the happy path only. Four protections from the
+ * fuller design are intentionally left out and can be layered back without
+ * reshaping this table (see usage/README or the OB design doc):
+ *   1. actual cgroup columns (real CPU/RAM measured by the Rust engine) — add as
+ *      nullable columns later; billing uses alloc, so reads don't depend on them.
+ *   2. a reconcile cron (force-closes segments orphaned by a runner crash).
+ *   3. a partial-unique "one open segment per box" index (concurrency guard).
+ *   4. an end-after-start CHECK + a `sealed` flag (clock-skew / crash markers).
+ *
+ * The column names + types here match the fuller ledger exactly, so the rating
+ * layer (Phase 2) consumes this table unchanged, and the protections above are
+ * pure additive migrations.
+ */
+@Entity()
+@Index('usage_period_box_period_start_idx', ['boxId', 'periodStart'])
+@Index('usage_period_org_period_start_idx', ['organizationId', 'periodStart'])
+export class UsagePeriod {
+  @PrimaryGeneratedColumn('uuid')
+  id: string
+
+  @Column()
+  boxId: string
+
+  @Column()
+  organizationId: string
+
+  @Column({ nullable: true })
+  region: string
+
+  @Column({ type: 'timestamptz' })
+  periodStart: Date
+
+  /** `null` while the segment is still open (box still in this billing kind). */
+  @Column({ type: 'timestamptz', nullable: true })
+  periodEnd: Date | null
+
+  /** Billing kind: `running` (cpu+ram+disk) or `stopped` (disk only). */
+  @Column()
+  kind: string
+
+  // ---- allocated quantities (the billing basis, snapshotted from the box spec) ----
+  @Column({ type: 'int' })
+  allocCpu: number
+
+  @Column({ type: 'int' })
+  allocMemGib: number
+
+  @Column({ type: 'int' })
+  allocDiskGib: number
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt: Date
+
+  @UpdateDateColumn({ type: 'timestamptz' })
+  updatedAt: Date
+}

--- a/apps/api/src/usage/entities/usage-period.entity.ts
+++ b/apps/api/src/usage/entities/usage-period.entity.ts
@@ -42,7 +42,7 @@ export class UsagePeriod {
   organizationId: string
 
   @Column({ nullable: true })
-  region: string
+  region: string | null
 
   @Column({ type: 'timestamptz' })
   periodStart: Date
@@ -51,9 +51,13 @@ export class UsagePeriod {
   @Column({ type: 'timestamptz', nullable: true })
   periodEnd: Date | null
 
-  /** Billing kind: `running` (cpu+ram+disk) or `stopped` (disk only). */
+  /**
+   * Billing kind: `running` (cpu+ram+disk) or `stopped` (disk only). Stored as
+   * a plain varchar holding these literal strings — downstream rating compares
+   * `kind === 'running'` literally, so the persisted values must never change.
+   */
   @Column()
-  kind: string
+  kind: 'running' | 'stopped'
 
   // ---- allocated quantities (the billing basis, snapshotted from the box spec) ----
   @Column({ type: 'int' })

--- a/apps/api/src/usage/usage.controller.spec.ts
+++ b/apps/api/src/usage/usage.controller.spec.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { BadRequestException } from '@nestjs/common'
+import { UsageController } from './usage.controller'
+import { BoxUsageResult, UsageService } from './usage.service'
+
+const RESULT: BoxUsageResult = {
+  boxId: 'box-1',
+  totalCPUSeconds: 0,
+  totalRAMGBSeconds: 0,
+  totalDiskGBSeconds: 0,
+  totalGPUSeconds: 0,
+}
+
+describe('UsageController.getBoxUsage query-range validation', () => {
+  let getBoxUsage: jest.Mock
+  let ctrl: UsageController
+
+  beforeEach(() => {
+    getBoxUsage = jest.fn(async () => RESULT)
+    ctrl = new UsageController({ getBoxUsage } as unknown as UsageService)
+  })
+
+  it('rejects an unparsable from/to with 400 instead of passing Invalid Date downstream', async () => {
+    await expect(ctrl.getBoxUsage('box-1', 'not-a-date', undefined)).rejects.toBeInstanceOf(BadRequestException)
+    await expect(ctrl.getBoxUsage('box-1', undefined, 'also-bad')).rejects.toBeInstanceOf(BadRequestException)
+    expect(getBoxUsage).not.toHaveBeenCalled()
+  })
+
+  it('rejects an inverted range (from after to)', async () => {
+    await expect(
+      ctrl.getBoxUsage('box-1', '2026-06-25T12:00:00Z', '2026-06-25T11:00:00Z'),
+    ).rejects.toBeInstanceOf(BadRequestException)
+    expect(getBoxUsage).not.toHaveBeenCalled()
+  })
+
+  it('passes parsed dates through for a valid range', async () => {
+    await expect(ctrl.getBoxUsage('box-1', '2026-06-25T11:00:00Z', '2026-06-25T12:00:00Z')).resolves.toEqual(RESULT)
+    expect(getBoxUsage).toHaveBeenCalledWith(
+      'box-1',
+      new Date('2026-06-25T11:00:00Z'),
+      new Date('2026-06-25T12:00:00Z'),
+    )
+  })
+})

--- a/apps/api/src/usage/usage.controller.ts
+++ b/apps/api/src/usage/usage.controller.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { Controller, Get, Param, Query, UseGuards } from '@nestjs/common'
+import { BadRequestException, Controller, Get, Param, Query, UseGuards } from '@nestjs/common'
 import { ApiOAuth2, ApiOperation, ApiParam, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger'
 import { CombinedAuthGuard } from '../auth/combined-auth.guard'
 import { AuthenticatedRateLimitGuard } from '../common/guards/authenticated-rate-limit.guard'
@@ -37,6 +37,14 @@ export class UsageController {
   ): Promise<BoxUsageResult> {
     const toDate = to ? new Date(to) : new Date()
     const fromDate = from ? new Date(from) : new Date(toDate.getTime() - DEFAULT_RANGE_MS)
+    // Fail fast at the boundary: an unparsable ISO string becomes Invalid Date,
+    // which would otherwise surface as an opaque DB error or silently-zero totals.
+    if (isNaN(fromDate.getTime()) || isNaN(toDate.getTime())) {
+      throw new BadRequestException('from/to must be valid ISO-8601 timestamps')
+    }
+    if (fromDate > toDate) {
+      throw new BadRequestException('from must not be after to')
+    }
     return this.usageService.getBoxUsage(boxId, fromDate, toDate)
   }
 }

--- a/apps/api/src/usage/usage.controller.ts
+++ b/apps/api/src/usage/usage.controller.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Controller, Get, Param, Query, UseGuards } from '@nestjs/common'
+import { ApiOAuth2, ApiOperation, ApiParam, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger'
+import { CombinedAuthGuard } from '../auth/combined-auth.guard'
+import { AuthenticatedRateLimitGuard } from '../common/guards/authenticated-rate-limit.guard'
+import { OrganizationResourceActionGuard } from '../organization/guards/organization-resource-action.guard'
+import { BoxAccessGuard } from '../box/guards/box-access.guard'
+import { BoxUsageResult, UsageService } from './usage.service'
+
+const DEFAULT_RANGE_MS = 30 * 24 * 60 * 60 * 1000 // 30 days
+
+@ApiTags('usage')
+@Controller('usage')
+@UseGuards(CombinedAuthGuard, OrganizationResourceActionGuard, AuthenticatedRateLimitGuard)
+@ApiOAuth2(['openid', 'profile', 'email'])
+export class UsageController {
+  constructor(private readonly usageService: UsageService) {}
+
+  @Get('box/:boxId')
+  @ApiOperation({
+    summary: 'Get aggregated usage totals for a box over a time range',
+    operationId: 'getBoxUsage',
+  })
+  @ApiParam({ name: 'boxId', description: 'ID of the box', type: 'string' })
+  @ApiQuery({ name: 'from', required: false, type: String, description: 'ISO start (default: 30d ago)' })
+  @ApiQuery({ name: 'to', required: false, type: String, description: 'ISO end (default: now)' })
+  @ApiResponse({ status: 200, description: 'Aggregated box usage totals' })
+  @UseGuards(BoxAccessGuard)
+  async getBoxUsage(
+    @Param('boxId') boxId: string,
+    @Query('from') from?: string,
+    @Query('to') to?: string,
+  ): Promise<BoxUsageResult> {
+    const toDate = to ? new Date(to) : new Date()
+    const fromDate = from ? new Date(from) : new Date(toDate.getTime() - DEFAULT_RANGE_MS)
+    return this.usageService.getBoxUsage(boxId, fromDate, toDate)
+  }
+}

--- a/apps/api/src/usage/usage.integration.spec.ts
+++ b/apps/api/src/usage/usage.integration.spec.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ *
+ * Real-Postgres integration test for the MVP usage-timing ledger. Skipped by
+ * default (no DB in CI); run against a local Postgres with:
+ *
+ *   RUN_DB_IT=1 npx nx test api --testPathPatterns=usage.integration --skip-nx-cache
+ *
+ * Runs the MVP migration, then drives a box lifecycle through UsageService and
+ * checks the segments open/close correctly + getBoxUsage computes alloc-seconds.
+ */
+
+import { DataSource, IsNull } from 'typeorm'
+import { Box } from '../box/entities/box.entity'
+import { BoxState } from '../box/enums/box-state.enum'
+import { Migration1782600000000 } from '../migrations/pre-deploy/1782600000000-migration'
+import { UsagePeriod } from './entities/usage-period.entity'
+import { UsageService } from './usage.service'
+
+const dbDescribe = process.env.RUN_DB_IT ? describe : describe.skip
+
+const box = (state: BoxState): Box =>
+  ({ id: 'box-it', organizationId: 'org-it', region: 'r1', cpu: 2, mem: 4, disk: 10, state }) as Box
+
+dbDescribe('MVP usage timing — real Postgres', () => {
+  let ds: DataSource
+  let svc: UsageService
+
+  beforeAll(async () => {
+    ds = new DataSource({
+      type: 'postgres',
+      host: process.env.DB_HOST ?? 'localhost',
+      port: Number(process.env.DB_PORT ?? 5440),
+      username: process.env.DB_USERNAME ?? 'postgres',
+      password: process.env.DB_PASSWORD ?? 'postgres',
+      database: process.env.DB_DATABASE ?? 'usage_it',
+      entities: [UsagePeriod],
+      synchronize: false,
+    })
+    await ds.initialize()
+    const qr = ds.createQueryRunner()
+    await qr.query(`CREATE EXTENSION IF NOT EXISTS "uuid-ossp"`)
+    await qr.query(`DROP TABLE IF EXISTS "usage_period" CASCADE`)
+    await new Migration1782600000000().up(qr)
+    await qr.release()
+    svc = new UsageService(ds.getRepository(UsagePeriod))
+  }, 60000)
+
+  afterAll(async () => {
+    if (!ds?.isInitialized) return
+    const qr = ds.createQueryRunner()
+    await qr.query(`DROP TABLE IF EXISTS "usage_period" CASCADE`)
+    await qr.release()
+    await ds.destroy()
+  })
+
+  it('builds running→stopped segments across a box lifecycle and aggregates alloc-seconds', async () => {
+    const t0 = new Date('2026-06-25T12:00:00Z')
+    const t1 = new Date('2026-06-25T12:00:10Z') // +10s running
+    const t2 = new Date('2026-06-25T12:00:30Z') // +20s stopped
+
+    await svc.applyTransition(box(BoxState.STARTED), BoxState.STARTED, t0) // open running
+    await svc.applyTransition(box(BoxState.STOPPED), BoxState.STOPPED, t1) // close running, open stopped
+    await svc.applyTransition(box(BoxState.DESTROYED), BoxState.DESTROYED, t2) // close stopped
+
+    const rows = await ds.getRepository(UsagePeriod).find({ where: { boxId: 'box-it' }, order: { periodStart: 'ASC' } })
+    expect(rows.map((r) => [r.kind, r.periodEnd !== null])).toEqual([
+      ['running', true], // running, closed at t1
+      ['stopped', true], // stopped, closed at t2
+    ])
+
+    // running 10s → cpu 2×10, ram 4×10; disk continuous across both 30s → 10×30
+    const usage = await svc.getBoxUsage('box-it', t0, t2)
+    expect(usage).toEqual({
+      boxId: 'box-it',
+      totalCPUSeconds: 20,
+      totalRAMGBSeconds: 40,
+      totalDiskGBSeconds: 300,
+      totalGPUSeconds: 0,
+    })
+  })
+
+  it('keeps at most one open segment per box (close-before-open guard)', async () => {
+    const b = (state: BoxState): Box => ({ ...box(state), id: 'box-guard' }) as Box
+    await svc.applyTransition(b(BoxState.STARTED), BoxState.STARTED, new Date('2026-06-25T13:00:00Z'))
+    await svc.applyTransition(b(BoxState.STOPPED), BoxState.STOPPED, new Date('2026-06-25T13:00:10Z'))
+
+    // mid-lifecycle (running closed, stopped open) → exactly ONE open segment, not two
+    const open = await ds.getRepository(UsagePeriod).find({ where: { boxId: 'box-guard', periodEnd: IsNull() } })
+    expect(open).toHaveLength(1)
+    expect(open[0].kind).toBe('stopped')
+  })
+})

--- a/apps/api/src/usage/usage.module.ts
+++ b/apps/api/src/usage/usage.module.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Module } from '@nestjs/common'
+import { TypeOrmModule } from '@nestjs/typeorm'
+import { BoxModule } from '../box/box.module'
+import { BoxAccessGuard } from '../box/guards/box-access.guard'
+import { OrganizationModule } from '../organization/organization.module'
+import { UsagePeriod } from './entities/usage-period.entity'
+import { UsageController } from './usage.controller'
+import { UsageService } from './usage.service'
+
+@Module({
+  // OrganizationModule + BoxModule satisfy the controller guards' constructor deps —
+  // OrganizationResourceActionGuard needs OrganizationService, BoxAccessGuard needs
+  // BoxService. Without them the API fails to boot (tsc + unit tests still pass), so
+  // this is verified on the running stack, not just by compiling.
+  imports: [TypeOrmModule.forFeature([UsagePeriod]), OrganizationModule, BoxModule],
+  controllers: [UsageController],
+  providers: [UsageService, BoxAccessGuard],
+  exports: [UsageService],
+})
+export class UsageModule {}

--- a/apps/api/src/usage/usage.service.spec.ts
+++ b/apps/api/src/usage/usage.service.spec.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Box } from '../box/entities/box.entity'
+import { BoxState } from '../box/enums/box-state.enum'
+import { UsagePeriod } from './entities/usage-period.entity'
+import { UsageService } from './usage.service'
+
+/**
+ * Minimal in-memory stand-in for the TypeORM repository — exercises the
+ * service's open/close orchestration without a database. `findOne` returns the
+ * currently-open period (periodEnd == null) for a box; `save` upserts.
+ */
+class FakeRepo {
+  rows: UsagePeriod[] = []
+
+  create(obj: Partial<UsagePeriod>): UsagePeriod {
+    return { ...obj } as UsagePeriod
+  }
+
+  async save(obj: UsagePeriod): Promise<UsagePeriod> {
+    if (!obj.id) {
+      obj.id = `p${this.rows.length + 1}`
+      this.rows.push(obj)
+    }
+    return obj
+  }
+
+  async findOne(opts: { where: { boxId: string } }): Promise<UsagePeriod | null> {
+    const open = this.rows.filter((r) => r.boxId === opts.where.boxId && r.periodEnd == null)
+    return open.length ? open[open.length - 1] : null
+  }
+}
+
+function box(state: BoxState): Box {
+  return { id: 'box-1', organizationId: 'org-1', region: 'r1', cpu: 2, mem: 4, disk: 10, state } as Box
+}
+
+describe('UsageService.applyTransition', () => {
+  let repo: FakeRepo
+  let svc: UsageService
+
+  beforeEach(() => {
+    repo = new FakeRepo()
+    svc = new UsageService(repo as never)
+  })
+
+  it('opens a running period when a box starts', async () => {
+    await svc.applyTransition(box(BoxState.STARTED), BoxState.STARTED, new Date('2026-06-25T12:00:00Z'))
+    expect(repo.rows).toHaveLength(1)
+    expect(repo.rows[0]).toMatchObject({
+      boxId: 'box-1',
+      organizationId: 'org-1',
+      kind: 'running',
+      periodEnd: null,
+      allocCpu: 2,
+      allocMemGib: 4,
+      allocDiskGib: 10,
+    })
+  })
+
+  it('opens a disk-only stopped period when a box is created not-running', async () => {
+    await svc.applyTransition(box(BoxState.CREATING), BoxState.CREATING, new Date('2026-06-25T12:00:00Z'))
+    expect(repo.rows).toHaveLength(1)
+    expect(repo.rows[0].kind).toBe('stopped')
+  })
+
+  it('closes running and opens stopped on stop (disk continues)', async () => {
+    const t0 = new Date('2026-06-25T12:00:00Z')
+    const t1 = new Date('2026-06-25T12:00:10Z')
+    await svc.applyTransition(box(BoxState.STARTED), BoxState.STARTED, t0)
+    await svc.applyTransition(box(BoxState.STOPPED), BoxState.STOPPED, t1)
+
+    const running = repo.rows.find((r) => r.kind === 'running')!
+    const stopped = repo.rows.find((r) => r.kind === 'stopped')!
+    expect(repo.rows).toHaveLength(2)
+    expect(running.periodEnd).toEqual(t1) // closed at stop
+    expect(stopped.periodEnd).toBeNull() // disk keeps running
+  })
+
+  it('does not fragment the ledger on a same-kind transition', async () => {
+    await svc.applyTransition(box(BoxState.STARTED), BoxState.STARTED, new Date('2026-06-25T12:00:00Z'))
+    await svc.applyTransition(box(BoxState.STARTED), BoxState.STARTED, new Date('2026-06-25T12:00:05Z'))
+    expect(repo.rows).toHaveLength(1)
+    expect(repo.rows[0].periodEnd).toBeNull()
+  })
+
+  it('closes the open period and opens nothing on destroy', async () => {
+    const t0 = new Date('2026-06-25T12:00:00Z')
+    const t1 = new Date('2026-06-25T12:00:10Z')
+    await svc.applyTransition(box(BoxState.STARTED), BoxState.STARTED, t0)
+    await svc.applyTransition(box(BoxState.DESTROYED), BoxState.DESTROYED, t1)
+    expect(repo.rows).toHaveLength(1)
+    expect(repo.rows[0].periodEnd).toEqual(t1)
+  })
+})

--- a/apps/api/src/usage/usage.service.spec.ts
+++ b/apps/api/src/usage/usage.service.spec.ts
@@ -32,6 +32,10 @@ class FakeRepo {
     const open = this.rows.filter((r) => r.boxId === opts.where.boxId && r.periodEnd == null)
     return open.length ? open[open.length - 1] : null
   }
+
+  async count(opts: { where: { boxId: string } }): Promise<number> {
+    return this.rows.filter((r) => r.boxId === opts.where.boxId).length
+  }
 }
 
 function box(state: BoxState): Box {
@@ -94,5 +98,34 @@ describe('UsageService.applyTransition', () => {
     await svc.applyTransition(box(BoxState.DESTROYED), BoxState.DESTROYED, t1)
     expect(repo.rows).toHaveLength(1)
     expect(repo.rows[0].periodEnd).toEqual(t1)
+  })
+})
+
+describe('UsageService.handleBoxCreated', () => {
+  let repo: FakeRepo
+  let svc: UsageService
+
+  beforeEach(() => {
+    repo = new FakeRepo()
+    svc = new UsageService(repo as never)
+  })
+
+  it('opens the first period from the CREATED snapshot when the ledger is empty', async () => {
+    await svc.handleBoxCreated({ box: box(BoxState.STARTED) } as never)
+    expect(repo.rows).toHaveLength(1)
+    expect(repo.rows[0].kind).toBe('running')
+  })
+
+  it('ignores a stale CREATED snapshot when a racing STATE_UPDATED already ledgered the box', async () => {
+    // STATE_UPDATED won the race: the box is already ledgered as running.
+    await svc.applyTransition(box(BoxState.STARTED), BoxState.STARTED, new Date('2026-06-25T12:00:00Z'))
+
+    // CREATED arrives late with its insert-time snapshot (CREATING → stopped);
+    // applying it would close the live running period and flip it to stopped.
+    await svc.handleBoxCreated({ box: box(BoxState.CREATING) } as never)
+
+    expect(repo.rows).toHaveLength(1)
+    expect(repo.rows[0].kind).toBe('running')
+    expect(repo.rows[0].periodEnd).toBeNull()
   })
 })

--- a/apps/api/src/usage/usage.service.ts
+++ b/apps/api/src/usage/usage.service.ts
@@ -48,6 +48,15 @@ export class UsageService {
     // the initial period here, or the running time before the first transition
     // is lost.
     try {
+      // CREATED's only job is the very first segment. Its payload is a snapshot
+      // taken at insert time, and the emitter doesn't await this listener — so a
+      // racing STATE_UPDATED may have ledgered a fresher state already. If any
+      // segment exists, applying the stale snapshot would flip the ledger
+      // backwards (e.g. close a live running period); skip instead.
+      const alreadyLedgered = await this.periods.count({ where: { boxId: event.box.id } })
+      if (alreadyLedgered > 0) {
+        return
+      }
       await this.applyTransition(event.box, event.box.state, new Date())
     } catch (err) {
       // Metering must never break the box state machine — the CREATED emitter
@@ -91,7 +100,7 @@ export class UsageService {
       where: { boxId: box.id, periodEnd: IsNull() },
       order: { periodStart: 'DESC' },
     })
-    const openKind = open ? (open.kind as 'running' | 'stopped') : null
+    const openKind = open ? open.kind : null
     const plan = planTransition(openKind, newState)
 
     if (plan.closeOpen && open) {
@@ -127,7 +136,7 @@ export class UsageService {
     const billable: BillablePeriod[] = rows.map((r) => ({
       startAt: r.periodStart,
       endAt: r.periodEnd,
-      kind: r.kind as 'running' | 'stopped',
+      kind: r.kind,
       allocCpu: r.allocCpu,
       allocMemGib: r.allocMemGib,
       allocDiskGib: r.allocDiskGib,

--- a/apps/api/src/usage/usage.service.ts
+++ b/apps/api/src/usage/usage.service.ts
@@ -1,0 +1,145 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Injectable, Logger } from '@nestjs/common'
+import { InjectRepository } from '@nestjs/typeorm'
+import { IsNull, Repository } from 'typeorm'
+import { Box } from '../box/entities/box.entity'
+import { BoxEvents } from '../box/constants/box-events.constants'
+import { BoxCreatedEvent } from '../box/events/box-create.event'
+import { BoxStateUpdatedEvent } from '../box/events/box-state-updated.event'
+import { BoxState } from '../box/enums/box-state.enum'
+import { OnAsyncEvent } from '../common/decorators/on-async-event.decorator'
+import { UsagePeriod } from './entities/usage-period.entity'
+import { aggregatePeriods, BillablePeriod, planTransition, UsageTotals } from './billing/usage-math'
+
+/** The analytics contract's per-box usage shape (`models.BoxUsage`). */
+export interface BoxUsageResult extends UsageTotalsContract {
+  boxId: string
+}
+
+interface UsageTotalsContract {
+  totalCPUSeconds: number
+  totalRAMGBSeconds: number
+  totalDiskGBSeconds: number
+  totalGPUSeconds: number
+}
+
+/**
+ * Builds the alloc-side usage ledger from box lifecycle events and answers
+ * usage queries. Pure billing math lives in `./billing/usage-math`; this
+ * service is the thin event/DB wiring around it.
+ */
+@Injectable()
+export class UsageService {
+  private readonly logger = new Logger(UsageService.name)
+
+  constructor(
+    @InjectRepository(UsagePeriod)
+    private readonly periods: Repository<UsagePeriod>,
+  ) {}
+
+  @OnAsyncEvent({ event: BoxEvents.CREATED })
+  async handleBoxCreated(event: BoxCreatedEvent): Promise<void> {
+    // A box can be inserted directly at STARTED (box.service.ts), which emits
+    // only CREATED — not STATE_UPDATED (an insert has no previous state). Open
+    // the initial period here, or the running time before the first transition
+    // is lost.
+    try {
+      await this.applyTransition(event.box, event.box.state, new Date())
+    } catch (err) {
+      // Metering must never break the box state machine — the CREATED emitter
+      // is `emitAsync`, so an uncaught throw here would fail box creation
+      // outright. Log with stack and swallow. (A reconcile sweep that re-closes
+      // periods orphaned by a crash is a Phase 1.5 add-on, not in this MVP.)
+      this.logger.error(
+        `usage ledger open failed for box ${event.box?.id}`,
+        err instanceof Error ? err.stack : String(err),
+      )
+    }
+  }
+
+  @OnAsyncEvent({ event: BoxEvents.STATE_UPDATED })
+  async handleBoxStateUpdated(event: BoxStateUpdatedEvent): Promise<void> {
+    try {
+      await this.applyTransition(event.box, event.newState, new Date())
+    } catch (err) {
+      // Same guarantee: metering never breaks the state machine. STATE_UPDATED
+      // is `emit`, so a throw here would become an unhandled rejection — still
+      // log with stack and swallow.
+      this.logger.error(
+        `usage ledger update failed for box ${event.box?.id}`,
+        err instanceof Error ? err.stack : String(err),
+      )
+    }
+  }
+
+  /**
+   * Apply one state transition to the box's period ledger (server clock = the
+   * single authority). Closes the open segment and/or opens a new one per
+   * {@link planTransition}.
+   *
+   * The "find the open segment, close it, then open the new one" order is the
+   * ONLY thing preventing two open segments for a box in this MVP (the fuller
+   * design also has a partial-unique index as a hard guard — omitted here). So
+   * the close-before-open sequence below is load-bearing, not incidental.
+   */
+  async applyTransition(box: Box, newState: BoxState, now: Date): Promise<void> {
+    const open = await this.periods.findOne({
+      where: { boxId: box.id, periodEnd: IsNull() },
+      order: { periodStart: 'DESC' },
+    })
+    const openKind = open ? (open.kind as 'running' | 'stopped') : null
+    const plan = planTransition(openKind, newState)
+
+    if (plan.closeOpen && open) {
+      open.periodEnd = now
+      await this.periods.save(open)
+    }
+    if (plan.openKind) {
+      await this.periods.save(
+        this.periods.create({
+          boxId: box.id,
+          organizationId: box.organizationId,
+          region: box.region,
+          periodStart: now,
+          periodEnd: null,
+          kind: plan.openKind,
+          allocCpu: box.cpu,
+          allocMemGib: box.mem,
+          allocDiskGib: box.disk,
+        }),
+      )
+    }
+  }
+
+  /** Aggregate a box's usage over `[from, to]` into the analytics contract shape. */
+  async getBoxUsage(boxId: string, from: Date, to: Date): Promise<BoxUsageResult> {
+    const rows = await this.periods
+      .createQueryBuilder('p')
+      .where('p.boxId = :boxId', { boxId })
+      .andWhere('p.periodStart <= :to', { to })
+      .andWhere('(p.periodEnd IS NULL OR p.periodEnd >= :from)', { from })
+      .getMany()
+
+    const billable: BillablePeriod[] = rows.map((r) => ({
+      startAt: r.periodStart,
+      endAt: r.periodEnd,
+      kind: r.kind as 'running' | 'stopped',
+      allocCpu: r.allocCpu,
+      allocMemGib: r.allocMemGib,
+      allocDiskGib: r.allocDiskGib,
+    }))
+
+    const totals: UsageTotals = aggregatePeriods(billable, from, to)
+    return {
+      boxId,
+      totalCPUSeconds: totals.totalCpuSeconds,
+      totalRAMGBSeconds: totals.totalRamGbSeconds,
+      totalDiskGBSeconds: totals.totalDiskGbSeconds,
+      totalGPUSeconds: 0, // MVP: no GPU metering
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a `usage_period` ledger for box lifecycle timing
- record running/stopped usage periods from box lifecycle transitions
- expose `GET /api/usage/box/:boxId` aggregate alloc-seconds
- add focused usage math/service tests plus a real-Postgres integration spec

## Verification
- `npx tsc --noEmit -p api/tsconfig.app.json`
- `npx nx test api --testPathPatterns='usage' --skip-nx-cache`

## Notes
- Local dashboard usage inspection tooling is intentionally not included in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a box usage summary endpoint with `from`/`to` query support, returning aggregated CPU, RAM, and disk totals (GPU totals are included as zero for the MVP).
  * Introduced a usage ledger that records lifecycle-based billing segments in the database.
  * Added supporting billing computation for aggregating usage over clipped time ranges.

* **Bug Fixes**
  * Improved lifecycle transitions to keep usage segments consistent and prevent fragmented ledger records.
  * Ensured metering failures don’t block box state processing.

* **Tests**
  * Added unit tests for usage calculations and service behavior, plus an optional Postgres integration test and controller validation tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->