### PR TITLE
fix(hooks): stop turn-end verdict gate from re-auditing every turn

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,4 @@
 {
-  "env": {
-    "VERDICT_GATE_HARD_BLOCK": "1"
-  },
   "hooks": {
     "PreToolUse": [
       {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,17 +14,6 @@
           }
         ]
       }
-    ],
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/preflight-verdict-check.sh",
-            "timeout": 60
-          }
-        ]
-      }
     ]
   }
 }

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -16,18 +16,6 @@
           }
         ]
       }
-    ],
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "/usr/bin/env bash \"$(git rev-parse --show-toplevel)/.claude/hooks/preflight-verdict-check.sh\"",
-            "statusMessage": "Checking verdict proof",
-            "timeout": 60
-          }
-        ]
-      }
     ]
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ Every change goes: understand → research → design → implement → test →
 
 - Run the smallest relevant verification first (`make test`, package-scoped test), then broaden if risk justifies.
 - Don't claim tests passed unless they actually ran. If verification can't run, state the blocker and the residual risk.
-- Attach a verdict before ending: every turn ends by invoking the `verdict-auditor` subagent (Task), which writes the dossier (`.claude/.last-verdict.json`) — never hand-write it. Claims like a fix that works, tests that pass, a root cause, an ops/infra finding, "no issues", or a factual answer must carry concrete proof; a turn that asserts nothing verifiable still gets a one-line PASS (empty proof). The Stop gate is default-deny: a missing dossier blocks the turn-end (hard mode) or nudges (soft, the default), so the audit cannot be skipped by simply not invoking it. The auditor is async, so in hard mode ending a turn is deny -> audit -> wait -> end (like the commit-push gate); that block-then-wait is the accepted cost of proof on every turn.
+- Attach a verdict once at task close when the change is ready for commit, push, PR review, or another explicit handoff. Use the `verdict-auditor` subagent (Task) for that final verification pass and let it write `.claude/.last-verdict.json` — never hand-write it. Do not launch the auditor on every conversational turn, for ordinary explanations, or while iterating locally. Do not use a subagent for review unless the user explicitly asks for one. Claims like a fix that works, tests that pass, a root cause, an ops/infra finding, or "no issues" still need concrete proof from commands, file refs, or the single final verdict.
 
 **Cross-cutting** (apply at every phase)
 


### PR DESCRIPTION
## Problem
The turn-end verdict gate forces a verdict-auditor run on **every** agent turn — in both harnesses, but by different paths:

- **Claude Code**: #892 set `VERDICT_GATE_HARD_BLOCK=1` in `.claude/settings.json`, hard-blocking each turn-end (deny → audit → wait → end). The agent keeps waking itself to re-audit.
- **Codex**: never reads settings.json, so the env toggle can't reach it. Every agent turn-end still fires the Stop hook, whose nudge text drives the codex agent to run the auditor anyway. With 10+ subagents that's one forced audit per subagent turn.

## Changes
1. **`.claude/settings.json`** — remove the `env` block. The hook falls back to its soft default (`${VERDICT_GATE_HARD_BLOCK:-0}`): a non-blocking nudge, no self-wake.
2. **`.codex/hooks.json`** — drop the `Stop` verdict block entirely (codex has no soft/hard lever, so removal is the only way to stop the per-turn audit).

## Kept intact
- `preflight-commit-push.sh` and `preflight-pr-review.sh` (PreToolUse) — the real proof boundaries, unchanged in **both** harnesses.
- Claude users can still opt back into hard mode locally via `VERDICT_GATE_HARD_BLOCK=1`.

## Verify
```
verdict-check  15/15    commit-push  19/19    pr-review  29/29
```
Tests are hermetic (set `VERDICT_GATE_HARD_BLOCK` per-case, don't read settings.json), so both changes leave them green. `.codex/hooks.json` validated with jq; PreToolUse gates confirmed present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed a previously enforced environment gating setting from the project.
  * Disabled the automated pre-stop verification that ran during the “Stop” phase (including its timeout behavior).
* **Documentation**
  * Updated workflow guidance to run verdict auditing only at explicit handoff/close points, rather than on ordinary conversational turns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->