### PR TITLE
fix(guest): kill exec process group on timeout so orphans don't hang the exec

### DIFF
--- a/src/guest/src/service/exec/exec_handle.rs
+++ b/src/guest/src/service/exec/exec_handle.rs
@@ -342,4 +342,39 @@ impl ExecHandle {
             ))
         })
     }
+
+    /// Send `signal` to the execution's whole process group when the
+    /// process leads its own group, so descendants that outlive the direct
+    /// child — e.g. a shell that forked a long-running command — are also
+    /// terminated.
+    ///
+    /// Why this matters: an orphaned grandchild keeps the stdout/stderr
+    /// pipe write-end open. The attach forwarding tasks then never observe
+    /// EOF, the drain-folded `Execution.Wait` (see PR #563) never returns,
+    /// and the exec appears to "run" forever even though the tracked child
+    /// is dead. This is exactly the exec-timeout hang: the timeout watcher
+    /// SIGKILLs the shell, but its `sleep` child survives holding the pipe.
+    ///
+    /// Falls back to a single-pid kill when the process is NOT a group
+    /// leader, preserving today's behaviour (no regression) until every
+    /// spawn path isolates the exec into its own group.
+    pub fn kill_process_group(&self, signal: Signal) -> BoxliteResult<()> {
+        use nix::sys::signal::killpg;
+        use nix::unistd::getpgid;
+
+        // Only broadcast to the group when the process is its own group
+        // leader (pgid == pid). Otherwise a group-kill could hit unrelated
+        // execs / the guest service sharing the group, so fall back.
+        if let Ok(pgid) = getpgid(Some(self.pid)) {
+            if pgid == self.pid {
+                return killpg(pgid, signal).map_err(|e| {
+                    BoxliteError::Internal(format!(
+                        "Failed to send signal {} to process group {}: {}",
+                        signal, pgid, e
+                    ))
+                });
+            }
+        }
+        self.kill(signal)
+    }
 }

--- a/src/guest/src/service/exec/executor.rs
+++ b/src/guest/src/service/exec/executor.rs
@@ -150,6 +150,22 @@ fn spawn_with_pipes(req: &ExecRequest) -> BoxliteResult<ExecHandle> {
         cmd.stderr(std::process::Stdio::from_raw_fd(stderr_write.into_raw_fd()));
     }
 
+    // Put the child in its own session/process group (it becomes the group
+    // leader, so pgid == pid). This lets the timeout watcher / kill path
+    // signal the whole tree via killpg — otherwise a forked grandchild
+    // (e.g. `sh -c "sleep 300"`) outlives a single-pid kill, keeps the
+    // stdout/stderr pipe open, and hangs the exec's completion forever.
+    {
+        use std::os::unix::process::CommandExt;
+        unsafe {
+            cmd.pre_exec(|| {
+                nix::unistd::setsid()
+                    .map(|_| ())
+                    .map_err(std::io::Error::other)
+            });
+        }
+    }
+
     let child = cmd
         .spawn()
         .map_err(|e| BoxliteError::Internal(format!("Failed to spawn '{}': {}", req.program, e)))?;

--- a/src/guest/src/service/exec/executor.rs
+++ b/src/guest/src/service/exec/executor.rs
@@ -281,3 +281,68 @@ fn spawn_with_pty(req: &ExecRequest, config: PtyConfig) -> BoxliteResult<ExecHan
 
     Ok(handle)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::StreamExt;
+    use nix::sys::signal::killpg;
+    use nix::sys::signal::Signal;
+    use nix::sys::wait::waitpid;
+    use nix::unistd::getpgid;
+    use std::time::Duration;
+
+    fn shell_request(script: &str) -> ExecRequest {
+        ExecRequest {
+            program: "/bin/sh".to_string(),
+            args: vec!["-c".to_string(), script.to_string()],
+            ..Default::default()
+        }
+    }
+
+    fn sleep_request(seconds: u64) -> ExecRequest {
+        ExecRequest {
+            program: "/bin/sleep".to_string(),
+            args: vec![seconds.to_string()],
+            ..Default::default()
+        }
+    }
+
+    fn reap(handle: &ExecHandle) {
+        let _ = waitpid(handle.pid(), None);
+    }
+
+    #[test]
+    fn spawn_with_pipes_starts_process_group_leader() {
+        let req = sleep_request(60);
+        let handle = spawn_with_pipes(&req).expect("spawn shell");
+
+        let pgid = getpgid(Some(handle.pid())).expect("child process group");
+        handle.kill(Signal::SIGKILL).expect("kill process");
+        reap(&handle);
+
+        assert_eq!(pgid, handle.pid());
+    }
+
+    #[tokio::test]
+    async fn kill_process_group_closes_pipes_held_by_descendants() {
+        let req = shell_request("sleep 2");
+        let mut handle = spawn_with_pipes(&req).expect("spawn shell");
+        let mut stdout = handle.stdout().expect("stdout stream");
+        let pgid = getpgid(Some(handle.pid())).expect("child process group");
+
+        if pgid == handle.pid() {
+            killpg(pgid, Signal::SIGKILL).expect("kill process group");
+        } else {
+            handle.kill(Signal::SIGKILL).expect("kill process");
+        }
+        reap(&handle);
+
+        assert_eq!(pgid, handle.pid());
+
+        let next = tokio::time::timeout(Duration::from_secs(1), stdout.next())
+            .await
+            .expect("stdout should reach EOF after group kill");
+        assert!(next.is_none());
+    }
+}

--- a/src/guest/src/service/exec/state.rs
+++ b/src/guest/src/service/exec/state.rs
@@ -332,6 +332,20 @@ impl ExecutionState {
         }
     }
 
+    /// Like [`kill`](Self::kill), but targets the exec's whole process
+    /// group when it leads one, so descendants (e.g. a shell's forked
+    /// child) are terminated too. Used by the timeout watcher; see
+    /// [`ExecHandle::kill_process_group`] for the rationale.
+    pub async fn kill_group(&self, signal: nix::sys::signal::Signal) -> bool {
+        let inner = self.inner.lock().await;
+
+        if let Some(ref handle) = inner.handle {
+            handle.kill_process_group(signal).is_ok()
+        } else {
+            false
+        }
+    }
+
     /// Resize PTY window.
     pub async fn resize_pty(
         &self,

--- a/src/guest/src/service/exec/timeout.rs
+++ b/src/guest/src/service/exec/timeout.rs
@@ -34,7 +34,14 @@ pub(super) fn start_timeout_watcher(
         use nix::sys::signal::Signal;
 
         // Stage 1: SIGTERM — polite termination request.
-        if !exec_state.kill(Signal::SIGTERM).await {
+        //
+        // Signal the whole process GROUP, not just the direct child. A
+        // shell like `sh -c "sleep 300"` forks a `sleep` grandchild that
+        // survives a kill of the shell alone and keeps the stdout/stderr
+        // pipe write-end open. That hangs the attach forwarding tasks (they
+        // never see EOF), the drain-folded Execution.Wait never returns, and
+        // the exec appears to run forever. See ExecHandle::kill_process_group.
+        if !exec_state.kill_group(Signal::SIGTERM).await {
             // Process already exited on its own; nothing more to do.
             return;
         }
@@ -51,7 +58,7 @@ pub(super) fn start_timeout_watcher(
 
         // Stage 3: SIGKILL fallback. Returns false if SIGTERM was honored
         // during the grace window (clean exit, no escalation needed).
-        if exec_state.kill(Signal::SIGKILL).await {
+        if exec_state.kill_group(Signal::SIGKILL).await {
             warn!(
                 execution_id = %exec_id,
                 "SIGKILL after grace expired; workload did not exit on SIGTERM"


### PR DESCRIPTION
Kill exec process groups on timeout so shell-spawned descendants cannot keep stdout/stderr pipes open and hang completion.

Test plan:
- [x] cargo fmt --check
- [x] git diff --check
- [x] Before fix on Linux: `cargo test -p boxlite-guest service::exec::executor::tests` failed 0 passed / 2 failed on `5c51bd7b` plus the test commit
- [x] After fix on Linux: `cargo test -p boxlite-guest service::exec::executor::tests` passed 2 passed / 0 failed on `1dc49841`
