### PR TITLE
fix(api): stop auto-retrying errored boxes

### DIFF
--- a/apps/api/src/box/managers/box-actions/box-start.action.spec.ts
+++ b/apps/api/src/box/managers/box-actions/box-start.action.spec.ts
@@ -215,3 +215,55 @@ describe('BoxStartAction.handleRunnerBoxUnknownStateOnDesiredStateStart', () => 
     expect(updatedFields.some((u) => u.state === BoxState.ERROR)).toBe(true)
   })
 })
+
+describe('BoxStartAction.handleRunnerBoxStartedStateCheck', () => {
+  it('moves a timed-out starting box to ERROR and withdraws the start intent', async () => {
+    const runnerId = 'runner-start-timeout-1'
+
+    const box = new Box('region-1', 'starting-box')
+    box.runnerId = runnerId
+    box.state = BoxState.STARTING
+    box.desiredState = BoxDesiredState.STARTED
+    box.pending = true
+
+    const runner = { id: runnerId, state: RunnerState.READY } as Runner
+    const runnerService = { findOneOrFail: jest.fn(async () => runner) }
+    const runnerAdapterFactory = {
+      create: jest.fn(async () => ({ boxInfo: jest.fn(async () => ({ state: BoxState.STARTING })) }) as any),
+    }
+
+    const lockCode = new LockCode('lock-start-timeout-1')
+    const updatedFields: Partial<Box>[] = []
+    const boxRepository = {
+      update: jest.fn(async (_id: string, opts: { updateData: Partial<Box> }) => {
+        updatedFields.push(opts.updateData)
+        return box
+      }),
+    }
+    const redisLockProvider = { getCode: jest.fn(async () => lockCode) }
+    const organizationService = { findOne: jest.fn(async () => ({ boxMetadata: {} })) }
+    const boxActivityService = {
+      getLastActivityAt: jest.fn(async () => new Date(Date.now() - 6 * 60 * 1000)),
+    }
+
+    const action = new BoxStartAction(
+      runnerService as any,
+      runnerAdapterFactory as any,
+      boxRepository as any,
+      organizationService as any,
+      {} as any,
+      redisLockProvider as any,
+      boxActivityService as any,
+    )
+
+    await (action as BoxAction).run(box, lockCode)
+
+    expect(updatedFields).toContainEqual(
+      expect.objectContaining({
+        state: BoxState.ERROR,
+        desiredState: BoxDesiredState.STOPPED,
+        recoverable: false,
+      }),
+    )
+  })
+})

--- a/apps/api/src/box/managers/box-actions/box-start.action.ts
+++ b/apps/api/src/box/managers/box-actions/box-start.action.ts
@@ -7,6 +7,7 @@
 import { Injectable, Logger } from '@nestjs/common'
 import { BoxRepository } from '../../repositories/box.repository'
 import { Box } from '../../entities/box.entity'
+import { BoxDesiredState } from '../../enums/box-desired-state.enum'
 import { BoxState } from '../../enums/box-state.enum'
 import { DONT_SYNC_AGAIN, BoxAction, SYNC_AGAIN, SyncState } from './box.action'
 import { RunnerState } from '../../enums/runner-state.enum'
@@ -196,6 +197,7 @@ export class BoxStartAction extends BoxAction {
     if (lastActivityAt && lastActivityAt.getTime() < Date.now() - 1000 * 60 * timeoutMinutes) {
       const updateData: Partial<Box> = {
         state: BoxState.ERROR,
+        desiredState: BoxDesiredState.STOPPED,
         errorReason,
         recoverable: false,
       }

--- a/apps/api/src/box/managers/box-actions/box.action.ts
+++ b/apps/api/src/box/managers/box-actions/box.action.ts
@@ -10,6 +10,7 @@ import { RunnerAdapterFactory } from '../../runner-adapter/runnerAdapter'
 import { Box } from '../../entities/box.entity'
 import { BoxRepository } from '../../repositories/box.repository'
 import { BoxState } from '../../enums/box-state.enum'
+import { BoxDesiredState } from '../../enums/box-desired-state.enum'
 import { getStateChangeLockKey } from '../../utils/lock-key.util'
 import { LockCode, RedisLockProvider } from '../../common/redis-lock.provider'
 
@@ -65,6 +66,10 @@ export abstract class BoxAction {
 
     const updateData: Partial<Box> = {
       state,
+    }
+
+    if (state === BoxState.ERROR && box.desiredState === BoxDesiredState.STARTED) {
+      updateData.desiredState = BoxDesiredState.STOPPED
     }
 
     if (runnerId !== undefined) {

--- a/apps/api/src/box/managers/box.manager.sync-error.spec.ts
+++ b/apps/api/src/box/managers/box.manager.sync-error.spec.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { BoxManager } from './box.manager'
+import { BoxDesiredState } from '../enums/box-desired-state.enum'
+import { BoxState } from '../enums/box-state.enum'
+
+function buildHarness(box: { state: BoxState; desiredState: BoxDesiredState }) {
+  const updateWhere = jest.fn().mockResolvedValue(undefined)
+  const boxRepository: any = {
+    findOneOrFail: jest.fn().mockResolvedValue({ id: 'box-1', runnerId: 'runner-1', ...box }),
+    updateWhere,
+  }
+  const runnerService: any = {
+    getRunnerApiVersion: jest.fn().mockResolvedValue('2'),
+  }
+  const redisLockProvider: any = {
+    lock: jest.fn().mockResolvedValue(true),
+    unlock: jest.fn().mockResolvedValue(undefined),
+  }
+  const thrower = jest.fn().mockRejectedValue(new Error('runner unreachable'))
+  const manager = new BoxManager(
+    boxRepository,
+    runnerService,
+    redisLockProvider,
+    { run: box.desiredState === BoxDesiredState.STARTED ? thrower : jest.fn() } as any,
+    { run: box.desiredState === BoxDesiredState.STOPPED ? thrower : jest.fn() } as any,
+    { run: jest.fn() } as any,
+  )
+  return { manager, updateWhere }
+}
+
+describe('BoxManager.syncInstanceState error handling', () => {
+  afterEach(() => jest.clearAllMocks())
+
+  it('withdraws STARTED intent when start sync fails before a job completes', async () => {
+    const { manager, updateWhere } = buildHarness({
+      state: BoxState.STOPPED,
+      desiredState: BoxDesiredState.STARTED,
+    })
+
+    await manager.syncInstanceState('box-1')
+
+    expect(updateWhere).toHaveBeenCalledTimes(1)
+    expect(updateWhere.mock.calls[0][1].updateData).toMatchObject({
+      state: BoxState.ERROR,
+      desiredState: BoxDesiredState.STOPPED,
+    })
+  })
+
+  it('does not overwrite STOPPED intent when stop sync fails', async () => {
+    const { manager, updateWhere } = buildHarness({
+      state: BoxState.STARTED,
+      desiredState: BoxDesiredState.STOPPED,
+    })
+
+    await manager.syncInstanceState('box-1')
+
+    expect(updateWhere).toHaveBeenCalledTimes(1)
+    expect(updateWhere.mock.calls[0][1].updateData).toMatchObject({
+      state: BoxState.ERROR,
+    })
+    expect(updateWhere.mock.calls[0][1].updateData.desiredState).toBeUndefined()
+  })
+})

--- a/apps/api/src/box/managers/box.manager.ts
+++ b/apps/api/src/box/managers/box.manager.ts
@@ -365,6 +365,9 @@ export class BoxManager implements TrackableJobExecutions, OnApplicationShutdown
             errorReason,
             recoverable,
           }
+          if (box.desiredState === BoxDesiredState.STARTED) {
+            updateData.desiredState = BoxDesiredState.STOPPED
+          }
 
           // Update box to error state without safeguards
           await this.boxRepository.updateWhere(boxId, { updateData, whereCondition: {} })

--- a/apps/api/src/box/services/box.service.spec.ts
+++ b/apps/api/src/box/services/box.service.spec.ts
@@ -13,8 +13,10 @@ import { BoxEvents } from '../constants/box-events.constants'
 // organizationService; every other injected dependency is irrelevant.
 function makeService() {
   const boxRepository = {
+    findOne: jest.fn(),
     findOneByIdOrName: jest.fn(),
     conditionalStartForProxy: jest.fn(),
+    updateWhere: jest.fn(),
   } as any
   const eventEmitter = { emit: jest.fn(), emitAsync: jest.fn() } as any
   // assertOrganizationIsNotSuspended mirrors the real implementation: throw
@@ -149,5 +151,35 @@ describe('BoxService.ensureStartedForProxy', () => {
     await expect(service.ensureStartedForProxy('box-1', activeOrg)).resolves.toBeUndefined()
     expect(eventEmitter.emit).not.toHaveBeenCalled()
     expect(warn).toHaveBeenCalled()
+  })
+})
+
+describe('BoxService.updateState', () => {
+  afterEach(() => jest.clearAllMocks())
+
+  it('withdraws STARTED intent when the runner reports ERROR', async () => {
+    const { service, boxRepository } = makeService()
+    boxRepository.findOne.mockResolvedValue({
+      id: 'box-1',
+      state: BoxState.STARTED,
+      desiredState: BoxDesiredState.STARTED,
+    })
+    boxRepository.updateWhere.mockResolvedValue(undefined)
+
+    await service.updateState('box-1', BoxState.ERROR, false, 'runner reported error')
+
+    expect(boxRepository.updateWhere).toHaveBeenCalledWith('box-1', {
+      updateData: {
+        state: BoxState.ERROR,
+        recoverable: false,
+        errorReason: 'runner reported error',
+        desiredState: BoxDesiredState.STOPPED,
+      },
+      whereCondition: {
+        pending: false,
+        state: BoxState.STARTED,
+        desiredState: BoxDesiredState.STARTED,
+      },
+    })
   })
 })

--- a/apps/api/src/box/services/box.service.ts
+++ b/apps/api/src/box/services/box.service.ts
@@ -1400,6 +1400,8 @@ export class BoxService {
     const desiredState = this.getExpectedDesiredStateForState(newState)
     if (desiredState) {
       updateData.desiredState = desiredState
+    } else if (newState === BoxState.ERROR && box.desiredState === BoxDesiredState.STARTED) {
+      updateData.desiredState = BoxDesiredState.STOPPED
     }
 
     await this.boxRepository.updateWhere(box.id, {

--- a/apps/api/src/box/services/job-state-handler.service.spec.ts
+++ b/apps/api/src/box/services/job-state-handler.service.spec.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { JobStateHandlerService } from './job-state-handler.service'
+import { BoxDesiredState } from '../enums/box-desired-state.enum'
+import { BoxState } from '../enums/box-state.enum'
+import { JobStatus } from '../enums/job-status.enum'
+import { JobType } from '../enums/job-type.enum'
+
+function buildHarness(state: BoxState) {
+  const box = { id: 'box-1', state, desiredState: BoxDesiredState.STARTED }
+  const updates: Array<Record<string, unknown>> = []
+  const boxRepository: any = {
+    findOne: jest.fn().mockResolvedValue(box),
+    update: jest.fn(async (_id: string, opts: { updateData: Record<string, unknown> }) => {
+      updates.push(opts.updateData)
+    }),
+  }
+  return { service: new JobStateHandlerService(boxRepository, {} as any), updates }
+}
+
+function failedJob(type: JobType, errorMessage: string) {
+  return {
+    id: 'job-1',
+    type,
+    status: JobStatus.FAILED,
+    resourceId: 'box-1',
+    errorMessage,
+  } as any
+}
+
+describe('JobStateHandlerService failed start-intent jobs', () => {
+  afterEach(() => jest.clearAllMocks())
+
+  it.each([
+    [JobType.CREATE_BOX, BoxState.CREATING, 'Failed to create box'],
+    [JobType.START_BOX, BoxState.STARTING, 'Failed to start box'],
+    [JobType.RECOVER_BOX, BoxState.ERROR, 'Failed to recover box'],
+  ])('marks failed %s as ERROR and withdraws STARTED intent', async (jobType, state, fallbackReason) => {
+    const { service, updates } = buildHarness(state)
+
+    await service.handleJobCompletion(failedJob(jobType, fallbackReason))
+
+    expect(updates).toHaveLength(1)
+    expect(updates[0]).toMatchObject({
+      state: BoxState.ERROR,
+      desiredState: BoxDesiredState.STOPPED,
+    })
+  })
+})

--- a/apps/api/src/box/services/job-state-handler.service.ts
+++ b/apps/api/src/box/services/job-state-handler.service.ts
@@ -266,6 +266,7 @@ export class JobStateHandlerService {
       } else if (job.status === JobStatus.FAILED) {
         this.logger.error(`RECOVER_BOX job ${job.id} failed for box ${boxId}: ${job.errorMessage}`)
         updateData.state = BoxState.ERROR
+        updateData.desiredState = BoxDesiredState.STOPPED
         updateData.errorReason = job.errorMessage || 'Failed to recover box'
       }
 

--- a/apps/api/src/box/services/job-state-handler.service.ts
+++ b/apps/api/src/box/services/job-state-handler.service.ts
@@ -154,6 +154,7 @@ export class JobStateHandlerService {
       } else if (job.status === JobStatus.FAILED) {
         this.logger.error(`START_BOX job ${job.id} failed for box ${boxId}: ${job.errorMessage}`)
         updateData.state = BoxState.ERROR
+        updateData.desiredState = BoxDesiredState.STOPPED
         const { recoverable, errorReason } = sanitizeBoxError(job.errorMessage)
         updateData.errorReason = errorReason || 'Failed to start box'
         updateData.recoverable = recoverable

--- a/apps/api/src/box/services/job-state-handler.service.ts
+++ b/apps/api/src/box/services/job-state-handler.service.ts
@@ -112,6 +112,7 @@ export class JobStateHandlerService {
       } else if (job.status === JobStatus.FAILED) {
         this.logger.error(`CREATE_BOX job ${job.id} failed for box ${boxId}: ${job.errorMessage}`)
         updateData.state = BoxState.ERROR
+        updateData.desiredState = BoxDesiredState.STOPPED
         const { recoverable, errorReason } = sanitizeBoxError(job.errorMessage)
         updateData.errorReason = errorReason || 'Failed to create box'
         updateData.recoverable = recoverable


### PR DESCRIPTION
Reset boxes that enter ERROR during create/start/recover or runner-reported failure paths back to desiredState=STOPPED so failed boxes do not auto-retry until the user starts them again.

Test plan:
- [x] `cd apps && NX_DAEMON=false NX_CACHE_DIRECTORY=/tmp/nx-cache-pr917-rebase-job corepack yarn nx test api --testPathPatterns=job-state-handler.service --runInBand --skip-nx-cache`
- [x] `cd apps && NX_DAEMON=false NX_CACHE_DIRECTORY=/tmp/nx-cache-pr917-rebase-sync corepack yarn nx test api --testPathPatterns=box.manager.sync-error --runInBand --skip-nx-cache`
- [x] `cd apps && NX_DAEMON=false NX_CACHE_DIRECTORY=/tmp/nx-cache-pr917-rebase-start corepack yarn nx test api --testPathPatterns=box-start.action --runInBand --skip-nx-cache`
- [x] `cd apps && NX_DAEMON=false NX_CACHE_DIRECTORY=/tmp/nx-cache-pr917-rebase-service corepack yarn nx test api --testPathPatterns=box.service --runInBand --skip-nx-cache`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved box failure handling so boxes that error during start, create, recover, or sync now clear the requested start intent and move to a stopped desired state.
  * Timed-out starting boxes are now marked as errored, non-recoverable, and no longer left in a started desired state.
  * Updated state transitions to keep box status and requested state aligned when startup-related operations fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->