### PR TITLE
feat(volumes): support single-file volume mounts

### DIFF
--- a/src/boxlite/src/jailer/mod.rs
+++ b/src/boxlite/src/jailer/mod.rs
@@ -170,6 +170,7 @@ pub trait Jail: Send + Sync {
 
 use crate::disk::read_backing_chain;
 use crate::runtime::layout::BoxFilesystemLayout;
+use crate::volumes::{VolumeShare, classify_volume_share};
 use std::path::PathBuf;
 
 // ============================================================================
@@ -320,12 +321,14 @@ fn build_path_access(layout: &BoxFilesystemLayout, volumes: &[VolumeSpec]) -> Ve
         }
     }
 
-    // User volumes
+    // User volumes. Directories are shared directly, so grant the VMM access.
+    // Single files are staged under shared_dir (granted above), so they need no
+    // grant here — this also keeps the file's host siblings out of the sandbox.
     for vol in volumes {
         let p = PathBuf::from(&vol.host_path);
-        if p.exists() {
+        if let Some(VolumeShare::Dir(dir)) = classify_volume_share(&p) {
             paths.push(PathAccess {
-                path: p,
+                path: dir,
                 writable: !vol.read_only,
             });
         }
@@ -856,6 +859,32 @@ mod tests {
         assert!(
             paths.iter().all(|p| p.path != Path::new("/does/not/exist")),
             "Nonexistent volume should be skipped"
+        );
+    }
+
+    #[test]
+    fn test_build_path_access_single_file_grants_no_host_dir() {
+        let dir = tempdir().unwrap();
+        let layout = test_layout(dir.path().to_path_buf());
+
+        let parent = dir.path().join("cfg");
+        std::fs::create_dir_all(&parent).unwrap();
+        let file = parent.join("app.conf");
+        std::fs::write(&file, "k=v\n").unwrap();
+
+        let volumes = vec![VolumeSpec {
+            host_path: file.to_string_lossy().to_string(),
+            guest_path: "/etc/app.conf".to_string(),
+            read_only: true,
+        }];
+
+        let paths = build_path_access(&layout, &volumes);
+
+        // A single file is staged under shared_dir, so it must not widen path
+        // access to the file or its parent (which would expose host siblings).
+        assert!(
+            paths.iter().all(|p| p.path != file && p.path != parent),
+            "single-file volume must not grant its host file or parent dir"
         );
     }
 

--- a/src/boxlite/src/litebox/init/tasks/vmm_spawn.rs
+++ b/src/boxlite/src/litebox/init/tasks/vmm_spawn.rs
@@ -20,7 +20,9 @@ use crate::runtime::types::ContainerID;
 use crate::util::find_binary;
 use crate::vmm::controller::{ShimController, VmmController, VmmHandler};
 use crate::vmm::{Entrypoint, InstanceSpec, VmmKind};
-use crate::volumes::{ContainerMount, ContainerVolumeManager, GuestVolumeManager};
+use crate::volumes::{
+    ContainerMount, ContainerVolumeManager, GuestVolumeManager, stage_single_file,
+};
 use async_trait::async_trait;
 use boxlite_shared::Transport;
 use boxlite_shared::errors::{BoxliteError, BoxliteResult};
@@ -174,15 +176,27 @@ async fn build_config(
     // Add user volumes via ContainerVolumeManager
     let mut container_mgr = ContainerVolumeManager::new(&mut volume_mgr);
     for vol in &user_volumes {
+        // Single-file volume: stage the file into a dedicated dir under the box's
+        // shared tree (already granted to the VMM sandbox) and share that dir, so
+        // virtio-fs never exposes the file's host siblings. Directories share as-is.
+        let share_dir = match &vol.subpath {
+            None => vol.host_path.clone(),
+            Some(file_name) => {
+                let staging_dir = layout.shared_dir().join("user-volumes").join(&vol.tag);
+                stage_single_file(&staging_dir, &vol.host_path, file_name, vol.read_only)?;
+                staging_dir
+            }
+        };
         container_mgr.add_volume(
             container_id.as_str(),
             &vol.tag,
             &vol.tag,
-            vol.host_path.clone(),
+            share_dir,
             &vol.guest_path,
             vol.read_only,
             vol.owner_uid,
             vol.owner_gid,
+            vol.subpath.clone(),
         );
     }
     let container_mounts = container_mgr.build_container_mounts();

--- a/src/boxlite/src/litebox/init/types.rs
+++ b/src/boxlite/src/litebox/init/types.rs
@@ -12,7 +12,7 @@ use crate::runtime::layout::BoxFilesystemLayout;
 use crate::runtime::options::VolumeSpec;
 use crate::runtime::rt_impl::SharedRuntimeImpl;
 use crate::vmm::controller::VmmHandler;
-use crate::volumes::{ContainerMount, GuestVolumeManager};
+use crate::volumes::{ContainerMount, GuestVolumeManager, VolumeShare, classify_volume_share};
 use boxlite_shared::errors::{BoxliteError, BoxliteResult};
 use std::path::PathBuf;
 use std::sync::atomic::Ordering;
@@ -41,6 +41,9 @@ pub struct ResolvedVolume {
     pub owner_uid: u32,
     /// Owner GID of host directory (for auto-idmap in guest).
     pub owner_gid: u32,
+    /// For a single-file mount, the file's name (staged and bind-mounted on its
+    /// own); `None` for a whole-directory mount.
+    pub subpath: Option<String>,
 }
 
 pub fn resolve_user_volumes(volumes: &[VolumeSpec]) -> BoxliteResult<Vec<ResolvedVolume>> {
@@ -63,16 +66,23 @@ pub fn resolve_user_volumes(volumes: &[VolumeSpec]) -> BoxliteResult<Vec<Resolve
             ))
         })?;
 
-        if !resolved_path.is_dir() {
-            return Err(BoxliteError::Config(format!(
-                "Volume host path is not a directory: {}",
-                vol.host_path
-            )));
-        }
+        // A directory is shared as-is; a single file keeps its own path here and
+        // is staged into a dedicated share dir later (see vmm_spawn), so virtio-fs
+        // never exposes the file's host siblings.
+        let (source_path, subpath) = match classify_volume_share(&resolved_path) {
+            Some(VolumeShare::Dir(dir)) => (dir, None),
+            Some(VolumeShare::File(name)) => (resolved_path.clone(), Some(name)),
+            None => {
+                return Err(BoxliteError::Config(format!(
+                    "Volume host path is not a file or directory: {}",
+                    vol.host_path
+                )));
+            }
+        };
 
         let tag = format!("uservol{}", i);
 
-        // Stat host path to get owner UID/GID for auto-idmap in guest
+        // Owner comes from the mount target itself (file or dir) for guest idmap.
         let (owner_uid, owner_gid) = {
             use std::os::unix::fs::MetadataExt;
             let meta = std::fs::metadata(&resolved_path).map_err(|e| {
@@ -87,7 +97,8 @@ pub fn resolve_user_volumes(volumes: &[VolumeSpec]) -> BoxliteResult<Vec<Resolve
 
         tracing::debug!(
             tag = %tag,
-            host_path = %resolved_path.display(),
+            host_path = %source_path.display(),
+            subpath = ?subpath,
             guest_path = %vol.guest_path,
             read_only = vol.read_only,
             owner_uid,
@@ -97,11 +108,12 @@ pub fn resolve_user_volumes(volumes: &[VolumeSpec]) -> BoxliteResult<Vec<Resolve
 
         resolved.push(ResolvedVolume {
             tag,
-            host_path: resolved_path,
+            host_path: source_path,
             guest_path: vol.guest_path.clone(),
             read_only: vol.read_only,
             owner_uid,
             owner_gid,
+            subpath,
         });
     }
 
@@ -348,6 +360,7 @@ mod tests {
         assert_eq!(resolved[0].owner_uid, expected_uid);
         assert_eq!(resolved[0].owner_gid, expected_gid);
         assert_eq!(resolved[0].tag, "uservol0");
+        assert_eq!(resolved[0].subpath, None);
     }
 
     #[test]
@@ -363,17 +376,23 @@ mod tests {
     }
 
     #[test]
-    fn resolve_volume_file_not_dir_errors() {
-        let tmp = tempfile::NamedTempFile::new().unwrap();
+    fn resolve_single_file_volume_records_source_and_name() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file_path = tmp.path().join("app.conf");
+        std::fs::write(&file_path, "key=value\n").unwrap();
+
         let volumes = vec![VolumeSpec {
-            host_path: tmp.path().to_str().unwrap().to_string(),
-            guest_path: "/data".to_string(),
-            read_only: false,
+            host_path: file_path.to_str().unwrap().to_string(),
+            guest_path: "/etc/app.conf".to_string(),
+            read_only: true,
         }];
 
-        let result = resolve_user_volumes(&volumes);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("not a directory"));
+        let resolved = resolve_user_volumes(&volumes).unwrap();
+        assert_eq!(resolved.len(), 1);
+        // Keeps the file's own path (staged into a share dir later) plus its name.
+        assert_eq!(resolved[0].host_path, file_path.canonicalize().unwrap());
+        assert_eq!(resolved[0].subpath, Some("app.conf".to_string()));
+        assert_eq!(resolved[0].guest_path, "/etc/app.conf");
     }
 
     /// Reverting Drop to call `remove_box` (the pre-fix behavior) flips this red:

--- a/src/boxlite/src/portal/interfaces/container.rs
+++ b/src/boxlite/src/portal/interfaces/container.rs
@@ -117,6 +117,7 @@ impl ContainerInterface {
                 read_only: m.read_only,
                 owner_uid: m.owner_uid,
                 owner_gid: m.owner_gid,
+                subpath: m.subpath.unwrap_or_default(),
             })
             .collect();
 

--- a/src/boxlite/src/volumes/container_volume.rs
+++ b/src/boxlite/src/volumes/container_volume.rs
@@ -27,6 +27,9 @@ pub struct ContainerMount {
     pub owner_uid: u32,
     /// Owner GID of host directory (for auto-idmap in guest)
     pub owner_gid: u32,
+    /// For a single-file mount, the file name to bind-mount from the staged
+    /// share dir; `None` for a whole-directory mount.
+    pub subpath: Option<String>,
 }
 
 /// Manages container-level volume configuration.
@@ -76,6 +79,7 @@ impl<'a> ContainerVolumeManager<'a> {
         read_only: bool,
         owner_uid: u32,
         owner_gid: u32,
+        subpath: Option<String>,
     ) {
         // Add virtiofs share to guest with container_id
         // Guest will mount at convention path: /run/boxlite/shared/containers/{container_id}/volumes/{tag}
@@ -94,6 +98,7 @@ impl<'a> ContainerVolumeManager<'a> {
             read_only,
             owner_uid,
             owner_gid,
+            subpath,
         });
     }
 
@@ -108,11 +113,38 @@ impl<'a> ContainerVolumeManager<'a> {
             read_only,
             owner_uid: 0,
             owner_gid: 0,
+            subpath: None,
         });
     }
 
     /// Build container mount configuration.
     pub fn build_container_mounts(&self) -> Vec<ContainerMount> {
         self.container_mounts.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn add_volume_carries_subpath_for_single_file() {
+        let mut guest = GuestVolumeManager::new();
+        let mut mgr = ContainerVolumeManager::new(&mut guest);
+        mgr.add_volume(
+            "cid",
+            "uservol0",
+            "uservol0",
+            PathBuf::from("/host/parent"),
+            "/etc/app.conf",
+            true,
+            0,
+            0,
+            Some("app.conf".to_string()),
+        );
+
+        let mounts = mgr.build_container_mounts();
+        assert_eq!(mounts.len(), 1);
+        assert_eq!(mounts[0].subpath, Some("app.conf".to_string()));
     }
 }

--- a/src/boxlite/src/volumes/mod.rs
+++ b/src/boxlite/src/volumes/mod.rs
@@ -6,6 +6,10 @@
 
 mod container_volume;
 mod guest_volume;
+mod share;
+mod staging;
 
 pub use container_volume::{ContainerMount, ContainerVolumeManager};
 pub use guest_volume::GuestVolumeManager;
+pub use share::{VolumeShare, classify_volume_share};
+pub use staging::stage_single_file;

--- a/src/boxlite/src/volumes/share.rs
+++ b/src/boxlite/src/volumes/share.rs
@@ -1,0 +1,59 @@
+//! How a volume host path maps onto a virtio-fs share.
+
+use std::path::{Path, PathBuf};
+
+/// How a volume host path is exposed over virtio-fs.
+///
+/// virtio-fs can only share a directory, so a single file is staged into a
+/// dedicated directory and bind-mounted by name inside the guest.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VolumeShare {
+    /// Share the whole directory as-is.
+    Dir(PathBuf),
+    /// A single file; the value is its file name.
+    File(String),
+}
+
+/// Classify a volume host path for virtio-fs sharing. Returns `None` when the
+/// path is neither a file nor a directory (or a file without a usable name),
+/// leaving the error to the caller.
+pub fn classify_volume_share(host_path: &Path) -> Option<VolumeShare> {
+    if host_path.is_dir() {
+        Some(VolumeShare::Dir(host_path.to_path_buf()))
+    } else if host_path.is_file() {
+        let name = host_path.file_name()?.to_str()?.to_string();
+        Some(VolumeShare::File(name))
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifies_directory_as_whole_dir_share() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert_eq!(
+            classify_volume_share(tmp.path()),
+            Some(VolumeShare::Dir(tmp.path().to_path_buf()))
+        );
+    }
+
+    #[test]
+    fn classifies_file_as_its_name() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("app.conf");
+        std::fs::write(&file, "x").unwrap();
+        assert_eq!(
+            classify_volume_share(&file),
+            Some(VolumeShare::File("app.conf".to_string()))
+        );
+    }
+
+    #[test]
+    fn classifies_nonexistent_path_as_none() {
+        assert_eq!(classify_volume_share(Path::new("/no/such/path/xyz")), None);
+    }
+}

--- a/src/boxlite/src/volumes/staging.rs
+++ b/src/boxlite/src/volumes/staging.rs
@@ -1,0 +1,158 @@
+//! Host-side staging for single-file volume mounts.
+
+use std::path::{Path, PathBuf};
+
+use boxlite_shared::errors::{BoxliteError, BoxliteResult};
+
+/// Stage a single file into `staging_dir` so virtio-fs can share a directory
+/// that contains only that file (never the file's host siblings).
+///
+/// A read-write mount is hard-linked so guest edits flow back to the host file.
+/// It cannot cross filesystems (`EXDEV`), so a rw source on a different
+/// filesystem than the staging dir is a hard error — a copy would silently drop
+/// the guest's writes at teardown.
+///
+/// A read-only mount is copied: the staged file is a separate inode, so the host
+/// source can never be modified through the mount. That makes it a boot-time
+/// snapshot (host edits afterward don't reach the guest), which is fine for
+/// read-only config. Idempotent — re-staging replaces any existing entry.
+pub fn stage_single_file(
+    staging_dir: &Path,
+    source: &Path,
+    file_name: &str,
+    read_only: bool,
+) -> BoxliteResult<PathBuf> {
+    std::fs::create_dir_all(staging_dir).map_err(|e| {
+        BoxliteError::Config(format!(
+            "Failed to create volume staging dir '{}': {}",
+            staging_dir.display(),
+            e
+        ))
+    })?;
+
+    let staged = staging_dir.join(file_name);
+
+    if read_only {
+        tracing::warn!(
+            source = %source.display(),
+            "read-only single-file volume is staged as a boot-time snapshot; \
+             host edits after box start won't reach the guest"
+        );
+        return copy_into_staging(source, &staged);
+    }
+
+    if staged.exists() {
+        std::fs::remove_file(&staged).map_err(|e| {
+            BoxliteError::Config(format!(
+                "Failed to clear staged volume file '{}': {}",
+                staged.display(),
+                e
+            ))
+        })?;
+    }
+
+    match std::fs::hard_link(source, &staged) {
+        Ok(()) => Ok(staged),
+        Err(e) if e.raw_os_error() == Some(libc::EXDEV) => Err(BoxliteError::Config(format!(
+            "Cannot mount read-write single file '{}': it is on a different filesystem than \
+             the box storage, so it cannot be hard-linked and a copy would silently drop the \
+             guest's writes. Mount its parent directory instead, or place the file on the same \
+             filesystem as the box home.",
+            source.display()
+        ))),
+        Err(e) => Err(BoxliteError::Config(format!(
+            "Failed to stage volume file '{}': {}",
+            source.display(),
+            e
+        ))),
+    }
+}
+
+/// Copy `source` to `staged` via a temp file + atomic rename, so a box reading
+/// the staged path mid-copy can never see a half-written file.
+fn copy_into_staging(source: &Path, staged: &Path) -> BoxliteResult<PathBuf> {
+    let tmp = staged.with_file_name(format!(
+        "{}.staging-tmp",
+        staged.file_name().and_then(|n| n.to_str()).unwrap_or("vol")
+    ));
+    std::fs::copy(source, &tmp).map_err(|e| {
+        BoxliteError::Config(format!(
+            "Failed to copy volume file '{}' into staging: {}",
+            source.display(),
+            e
+        ))
+    })?;
+    std::fs::rename(&tmp, staged).map_err(|e| {
+        BoxliteError::Config(format!(
+            "Failed to publish staged volume file '{}': {}",
+            staged.display(),
+            e
+        ))
+    })?;
+    Ok(staged.to_path_buf())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::MetadataExt;
+
+    #[test]
+    fn read_write_file_is_hardlinked_into_staging_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("app.conf");
+        std::fs::write(&source, "key=value\n").unwrap();
+        let staging = tmp.path().join("staging").join("uservol0");
+
+        let staged = stage_single_file(&staging, &source, "app.conf", false).unwrap();
+
+        assert_eq!(staged, staging.join("app.conf"));
+        assert_eq!(std::fs::read_to_string(&staged).unwrap(), "key=value\n");
+        // Read-write => hard link => same inode => edits flow both ways.
+        assert_eq!(
+            std::fs::metadata(&staged).unwrap().ino(),
+            std::fs::metadata(&source).unwrap().ino()
+        );
+    }
+
+    #[test]
+    fn read_only_file_is_copied_so_writes_never_reach_source() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("secret.conf");
+        std::fs::write(&source, "sensitive=true\n").unwrap();
+        let staging = tmp.path().join("staging");
+
+        let staged = stage_single_file(&staging, &source, "app.conf", true).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(&staged).unwrap(),
+            "sensitive=true\n"
+        );
+        // Separate inode: a write to the staged file must not reach the source.
+        assert_ne!(
+            std::fs::metadata(&staged).unwrap().ino(),
+            std::fs::metadata(&source).unwrap().ino()
+        );
+        std::fs::write(&staged, "TAMPERED\n").unwrap();
+        assert_eq!(
+            std::fs::read_to_string(&source).unwrap(),
+            "sensitive=true\n"
+        );
+    }
+
+    #[test]
+    fn re_staging_replaces_existing_entry() {
+        let tmp = tempfile::tempdir().unwrap();
+        let staging = tmp.path().join("staging");
+
+        let first = tmp.path().join("first.conf");
+        std::fs::write(&first, "one").unwrap();
+        stage_single_file(&staging, &first, "app.conf", false).unwrap();
+
+        let second = tmp.path().join("second.conf");
+        std::fs::write(&second, "two").unwrap();
+        let staged = stage_single_file(&staging, &second, "app.conf", false).unwrap();
+
+        assert_eq!(std::fs::read_to_string(&staged).unwrap(), "two");
+    }
+}

--- a/src/guest/src/service/container.rs
+++ b/src/guest/src/service/container.rs
@@ -217,7 +217,13 @@ impl ContainerService for GuestServer {
             .mounts
             .iter()
             .map(|m| {
-                let source = container_layout.volume_dir(&m.volume_name);
+                let volume_dir = container_layout.volume_dir(&m.volume_name);
+                // Single-file mount: bind just the one file within the shared dir.
+                let source = if m.subpath.is_empty() {
+                    volume_dir
+                } else {
+                    volume_dir.join(&m.subpath)
+                };
                 UserMount {
                     source: source.to_string_lossy().to_string(),
                     destination: m.destination.clone(),

--- a/src/shared/proto/boxlite/v1/service.proto
+++ b/src/shared/proto/boxlite/v1/service.proto
@@ -230,6 +230,10 @@ message BindMount {
   // guest applies mount_setattr(MOUNT_ATTR_IDMAP) to remap transparently.
   uint32 owner_uid = 4;
   uint32 owner_gid = 5;
+  // For a single-file mount, the file name within the shared volume dir; the
+  // guest bind-mounts {volume_dir}/{subpath} rather than the whole dir. Empty
+  // for a whole-directory mount.
+  string subpath = 6;
 }
 
 message ContainerInitResponse {


### PR DESCRIPTION
## Summary
Adds support for single-file volume mounts. Previously a volume host path had to be a directory, so a single config file could not be mounted without sharing its whole parent directory or inlining the content via heredocs. Fixes #785.

## Changes
- `resolve_user_volumes`: a single-file host path now shares the file's **parent directory** via virtio-fs and records the file name as `subpath`; directory mounts are unchanged.
- Guest bind-mounts `{volume_dir}/{subpath}` to `guest_path`, so only that one file appears in the container — the rest of the parent dir stays invisible.
- Host jailer grants the VMM sandbox access to the shared **parent dir** (not the file path) so virtio-fs can serve it.
- `subpath` plumbed through `ContainerMount` and the `BindMount` proto (new field `6`; empty = whole-directory mount).

## How to verify
```sh
mkdir -p /tmp/sf && echo key=value > /tmp/sf/app.conf && echo secret > /tmp/sf/other.txt
boxlite run -v /tmp/sf/app.conf:/etc/app.conf:ro alpine \
  sh -c 'cat /etc/app.conf; find / -name other.txt'
# -> prints "key=value"; the sibling other.txt is NOT present in the container
```
Unit tests: `make test:unit:rust` — adds resolver, container-mount, and jailer path-access cases for single-file mounts.

## Risks / rollout
The file's parent directory is shared with the guest VM over virtio-fs (mounted at an internal path); only the requested file is bind-mounted into the container, so the container never sees siblings. A read-write single-file mount makes the shared parent writable at the virtio-fs layer, consistent with how directory mounts already behave.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added single-file mounting within shared volumes via an optional mount subpath, including per-file staging when applicable.
  * Extended the mount/init protocol to target the correct in-guest file location.
* **Bug Fixes**
  * Improved sandbox path-access rules for file-backed volumes to avoid granting access to the file path and its parent directory.
  * Refined volume resolution to reliably distinguish directory mounts from single-file mounts.
* **Tests**
  * Added/updated unit tests for single-file classification, mount initialization, staging behavior, and path-access expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->