### PR TITLE
feat(githooks): agent-agnostic gate layer at the git boundary

### DIFF
--- a/.claude/agents/commit-push-auditor.md
+++ b/.claude/agents/commit-push-auditor.md
@@ -4,7 +4,7 @@ description: Independent auditor that judges a pending git commit or push agains
 tools: Read, Bash, Write
 ---
 
-You are the CLAUDE.md compliance auditor for the boxlite3 repository.
+You are the CLAUDE.md compliance auditor for the boxlite repository.
 
 The parent agent must tell you the exact git command they are about to retry
 (e.g. `git commit -m "..."` or `git push origin <branch>`). Treat that as the

--- a/.claude/hooks/preflight-commit-push.sh
+++ b/.claude/hooks/preflight-commit-push.sh
@@ -64,6 +64,27 @@ else
 fi
 
 repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+# Delegate to the git-level gate when installed: with core.hooksPath pointing at
+# .githooks, the same contract is enforced by .githooks/pre-commit|pre-push for
+# EVERY process (any agent, any harness — and humans stay exempt there), so this
+# PreToolUse layer steps aside to keep the audit artifact single-consumer.
+# GITHOOK_DELEGATED marks the call coming FROM that git-level gate — the one
+# caller that must not be deferred, or the two layers would defer to each other
+# and everything would silently pass.
+# Defer ONLY when the delegate hook actually exists at this checkout: git skips
+# missing hooks silently, so hooksPath-configured + delegate-absent (old ref,
+# broken install) would otherwise stand BOTH layers down — a silent bypass.
+# Closed-over-open: when in doubt, gate here.
+if [[ -z "${GITHOOK_DELEGATED:-}" ]]; then
+  hooks_path="$(git config core.hooksPath 2>/dev/null || true)"
+  if [[ "$hooks_path" == *".githooks" ]]; then
+    [[ "$hooks_path" != /* ]] && hooks_path="$repo_root/$hooks_path"
+    if [[ -x "$hooks_path/pre-$kind" ]]; then
+      exit 0
+    fi
+  fi
+fi
 project_dir="${CLAUDE_PROJECT_DIR:-$repo_root}"
 branch="$(git -C "$repo_root" branch --show-current 2>/dev/null || echo '?')"
 head="$(git -C "$repo_root" rev-parse HEAD 2>/dev/null || echo '?')"

--- a/.githooks/githooks.test.sh
+++ b/.githooks/githooks.test.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# Tests for the agent-agnostic git-hook gate layer (.githooks/pre-commit,
+# .githooks/pre-push) and the PreToolUse delegation guard in
+# .claude/hooks/preflight-commit-push.sh.
+#
+# Contract under test:
+#   - agent marker present (CLAUDECODE / CODEX_SANDBOX / AGENT_GATED) + no audit -> commit/push rejected
+#   - agent marker + fresh matching PASS audit                              -> allowed, audit consumed
+#   - no agent marker (human)                                              -> allowed, ungated
+#   - framework hook in .git/hooks is chained after the gate (prek keeps running)
+#   - PreToolUse script defers when core.hooksPath -> .githooks (single consumer),
+#     EXCEPT when called BY the git-level gate (GITHOOK_DELEGATED)
+#
+# Run with:  bash .githooks/githooks.test.sh
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+pass=0
+fail=0
+
+check_eq() {  # desc  got  want
+  local desc="$1" got="$2" want="$3"
+  if [[ "$got" == "$want" ]]; then
+    pass=$((pass + 1)); printf '  PASS  %s\n' "$desc"
+  else
+    fail=$((fail + 1)); printf '  FAIL  %s  (got=%s want=%s)\n' "$desc" "$got" "$want"
+  fi
+}
+
+# Fixture repo with the real gate scripts copied in and hooksPath pointed at
+# its own .githooks (absolute, so hook execution is location-independent).
+setup() {
+  local d; d="$(mktemp -d)"
+  git -C "$d" init -q
+  git -C "$d" config user.email t@t.test
+  git -C "$d" config user.name tester
+  mkdir -p "$d/.githooks" "$d/.claude/hooks"
+  cp "$REPO_ROOT/.githooks/pre-commit" "$REPO_ROOT/.githooks/pre-push" "$d/.githooks/"
+  cp "$REPO_ROOT/.claude/hooks/preflight-commit-push.sh" "$d/.claude/hooks/"
+  printf 'x\n' > "$d/f"
+  git -C "$d" add -A
+  git -C "$d" commit -qm base
+  git -C "$d" config core.hooksPath "$d/.githooks"
+  printf '%s' "$d"
+}
+
+# Fresh PASS audit bound to the fixture's current state.
+write_audit() {  # repo kind
+  local repo="$1" kind="$2" br hd
+  br="$(git -C "$repo" branch --show-current)"; hd="$(git -C "$repo" rev-parse HEAD)"
+  jq -nc --arg b "$br" --arg h "$hd" --arg k "$kind" \
+    '{branch:$b, head:$h, command_kind:$k, verdict:"PASS", findings:[]}' \
+    > "$repo/.claude/.last-audit.json"
+}
+
+# Run `git commit` in the fixture as agent or human; echo the exit code.
+# env -i gives a hermetic environment: the ambient session's own harness markers
+# (CLAUDECODE, CLAUDE_PROJECT_DIR, plugin CODEX_COMPANION_*) must not leak into
+# the fixture's gate decision.
+try_commit() {  # repo  agent|human
+  local repo="$1" who="$2"
+  printf 'y\n' >> "$repo/f"; git -C "$repo" add -A
+  if [[ "$who" == "agent" ]]; then
+    ( cd "$repo" && env -i PATH="$PATH" HOME="$HOME" CLAUDECODE=1 git commit -qm change >/dev/null 2>"$repo/err.txt" )
+  else
+    ( cd "$repo" && env -i PATH="$PATH" HOME="$HOME" git commit -qm change >/dev/null 2>"$repo/err.txt" )
+  fi
+  echo $?
+}
+
+echo "## pre-commit: agent gated, human exempt"
+R="$(setup)"
+check_eq "agent + no audit → commit rejected"       "$(try_commit "$R" agent)" 1
+grep -q 'commit-push-auditor' "$R/err.txt" && names=yes || names=no
+check_eq "rejection names commit-push-auditor"      "$names" "yes"
+rm -rf "$R"
+
+R="$(setup)"; write_audit "$R" commit
+check_eq "agent + PASS audit → commit allowed"      "$(try_commit "$R" agent)" 0
+[[ -e "$R/.claude/.last-audit.json" ]] && consumed=no || consumed=yes
+check_eq "audit consumed by the git-level gate"     "$consumed" "yes"
+rm -rf "$R"
+
+R="$(setup)"
+check_eq "human (no marker) → commit allowed"       "$(try_commit "$R" human)" 0
+rm -rf "$R"
+
+echo
+echo "## chaining: the framework hook in .git/hooks still runs"
+R="$(setup)"
+# --git-common-dir: --git-path hooks would resolve through core.hooksPath and
+# point back at the adapter itself (the exact recursion the adapters guard).
+# Absolutize from inside the fixture — the raw output is cwd-relative (".git").
+hooks_dir="$(cd "$R" && cd "$(git rev-parse --git-common-dir)" && pwd)/hooks"
+mkdir -p "$hooks_dir"
+printf '#!/bin/sh\ntouch "%s/chained.ran"\n' "$R" > "$hooks_dir/pre-commit"
+chmod +x "$hooks_dir/pre-commit"
+try_commit "$R" human >/dev/null
+[[ -e "$R/chained.ran" ]] && chained=yes || chained=no
+check_eq "chained .git/hooks/pre-commit executed"   "$chained" "yes"
+rm -rf "$R"
+
+echo
+echo "## pre-push: same contract at the push boundary"
+R="$(setup)"
+B="$(mktemp -d)"; git init -q --bare "$B"; git -C "$R" remote add origin "$B"
+( cd "$R" && env -i PATH="$PATH" HOME="$HOME" CLAUDECODE=1 git push -q origin HEAD >/dev/null 2>"$R/err.txt" )
+check_eq "agent + no audit → push rejected"         "$?" 1
+rm -rf "$R" "$B"
+
+R="$(setup)"
+B="$(mktemp -d)"; git init -q --bare "$B"; git -C "$R" remote add origin "$B"
+write_audit "$R" push
+( cd "$R" && env -i PATH="$PATH" HOME="$HOME" CLAUDECODE=1 git push -q origin HEAD >/dev/null 2>"$R/err.txt" )
+check_eq "agent + PASS audit → push allowed"        "$?" 0
+rm -rf "$R" "$B"
+
+R="$(setup)"
+B="$(mktemp -d)"; git init -q --bare "$B"; git -C "$R" remote add origin "$B"
+( cd "$R" && env -i PATH="$PATH" HOME="$HOME" git push -q origin HEAD >/dev/null 2>"$R/err.txt" )
+check_eq "human → push allowed, ungated"            "$?" 0
+rm -rf "$R" "$B"
+
+echo
+echo "## delegation guard: exactly one consumer of the audit artifact"
+# With hooksPath installed, the PreToolUse layer must step aside (exit 0,
+# no deny) even when a commit would otherwise be rejected...
+R="$(setup)"
+out="$(printf '{"tool_input":{"command":"git commit -m x"}}' \
+      | ( cd "$R" && CLAUDE_PROJECT_DIR="$R" bash "$R/.claude/hooks/preflight-commit-push.sh" ) 2>/dev/null)"
+check_eq "PreToolUse defers when .githooks installed"  "${out:-EMPTY}" "EMPTY"
+# ...but the call coming FROM the git-level gate must still be judged.
+out="$(printf '{"tool_input":{"command":"git commit -m x"}}' \
+      | ( cd "$R" && CLAUDE_PROJECT_DIR="$R" GITHOOK_DELEGATED=1 bash "$R/.claude/hooks/preflight-commit-push.sh" ) 2>/dev/null)"
+printf '%s' "$out" | jq -e '.hookSpecificOutput.permissionDecision == "deny"' >/dev/null 2>&1 && denied=yes || denied=no
+check_eq "GITHOOK_DELEGATED call still judged (deny)"  "$denied" "yes"
+rm -rf "$R"
+
+# hooksPath configured but the delegate hook ABSENT (old ref, broken install):
+# git silently skips missing hooks, so deferring here would stand BOTH layers
+# down — the PreToolUse layer must gate itself (fail closed).
+R="$(setup)"; rm "$R/.githooks/pre-commit"
+out="$(printf '{"tool_input":{"command":"git commit -m x"}}' \
+      | ( cd "$R" && CLAUDE_PROJECT_DIR="$R" bash "$R/.claude/hooks/preflight-commit-push.sh" ) 2>/dev/null)"
+printf '%s' "$out" | jq -e '.hookSpecificOutput.permissionDecision == "deny"' >/dev/null 2>&1 && denied=yes || denied=no
+check_eq "hooksPath set, delegate missing → fail closed (deny)" "$denied" "yes"
+rm -rf "$R"
+
+# Without hooksPath, the PreToolUse layer gates as before (no regression).
+R="$(setup)"; git -C "$R" config --unset core.hooksPath
+out="$(printf '{"tool_input":{"command":"git commit -m x"}}' \
+      | ( cd "$R" && CLAUDE_PROJECT_DIR="$R" bash "$R/.claude/hooks/preflight-commit-push.sh" ) 2>/dev/null)"
+printf '%s' "$out" | jq -e '.hookSpecificOutput.permissionDecision == "deny"' >/dev/null 2>&1 && denied=yes || denied=no
+check_eq "no hooksPath → PreToolUse still gates"       "$denied" "yes"
+rm -rf "$R"
+
+echo
+echo "RESULT: $pass passed, $fail failed"
+exit $(( fail > 0 ? 1 : 0 ))

--- a/.githooks/install.sh
+++ b/.githooks/install.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Point this clone's git hooks at .githooks/ — the agent-agnostic gate layer.
+# Per-clone config (run once per clone/worktree checkout):
+#   bash .githooks/install.sh
+# The framework-managed hooks in .git/hooks (prek fmt/lint, test matrix) keep
+# running: .githooks/* chain to them after the gate.
+set -euo pipefail
+git config core.hooksPath .githooks
+echo "core.hooksPath -> .githooks (agent-agnostic gate active; framework hooks chained)"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Universal (agent-agnostic) commit gate: enforces the same audited-dossier
+# contract as .claude/hooks/preflight-commit-push.sh, but from git's own hook
+# interface — it fires for ANY process that runs `git commit`, whichever coding
+# agent drives it, including agents with no hook system of their own. Install:
+# .githooks/install.sh (sets core.hooksPath). The PreToolUse gate detects the
+# installation and delegates, so the audit artifact keeps exactly one consumer.
+#
+# Humans are not gated: enforcement binds only when a harness marker is present
+# in the environment — CLAUDECODE (Claude Code shells), CODEX_SANDBOX (Codex
+# exec shells), or explicit AGENT_GATED=1 (any other agent: one env line in its
+# wiring). Named markers, not prefix wildcards: plugin artifacts like
+# CODEX_COMPANION_* must not gate a session that is not Codex-driven. An agent
+# could unset its marker — same honest-mistakes threat model as the rest of the
+# gate stack. git's native --no-verify bypass also applies (existing repo
+# culture: allowed with evidence).
+#
+# After the gate, chains to the framework-managed hook (prek installs into
+# .git/hooks/pre-commit) so fmt/lint still run.
+#
+# Tests: bash .githooks/githooks.test.sh
+set -uo pipefail
+
+is_agent=0
+[[ -n "${CLAUDECODE:-}" || -n "${CODEX_SANDBOX:-}" || -n "${AGENT_GATED:-}" ]] && is_agent=1
+
+if [[ "$is_agent" == 1 ]]; then
+  repo_root="$(git rev-parse --show-toplevel)"
+  # GITHOOK_DELEGATED tells the PreToolUse script this call IS the git-level
+  # gate — without it the script's delegation guard would defer right back to
+  # us and everything would silently pass.
+  out="$(printf '{"tool_input":{"command":"git commit"}}' \
+        | GITHOOK_DELEGATED=1 bash "$repo_root/.claude/hooks/preflight-commit-push.sh" 2>/dev/null || true)"
+  if printf '%s' "$out" | jq -e '.hookSpecificOutput.permissionDecision == "deny"' >/dev/null 2>&1; then
+    printf '%s' "$out" | jq -r '.hookSpecificOutput.permissionDecisionReason' >&2
+    exit 1
+  fi
+fi
+
+# Chain via --git-common-dir, NOT --git-path: --git-path honors core.hooksPath
+# and would resolve to THIS script — self-exec recursion (infinite for humans,
+# double-consume for agents). The framework (prek) installs into the common
+# hooks dir, which is also what all worktrees share. realpath guard as a belt.
+chained="$(git rev-parse --git-common-dir)/hooks/pre-commit"
+if [[ -x "$chained" && "$(realpath "$chained" 2>/dev/null)" != "$(realpath "$0" 2>/dev/null)" ]]; then
+  exec "$chained" "$@"
+fi
+exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Universal (agent-agnostic) push gate — pre-commit's sibling for `git push`.
+# See .githooks/pre-commit for the design. git feeds the ref list on stdin;
+# nothing here reads it (the gate call pipes its own payload), so it flows
+# byte-exact to the chained framework hook (prek's test matrix needs it).
+#
+# Tests: bash .githooks/githooks.test.sh
+set -uo pipefail
+
+# Named harness markers only — see pre-commit for why no prefix wildcards.
+is_agent=0
+[[ -n "${CLAUDECODE:-}" || -n "${CODEX_SANDBOX:-}" || -n "${AGENT_GATED:-}" ]] && is_agent=1
+
+if [[ "$is_agent" == 1 ]]; then
+  repo_root="$(git rev-parse --show-toplevel)"
+  out="$(printf '{"tool_input":{"command":"git push"}}' \
+        | GITHOOK_DELEGATED=1 bash "$repo_root/.claude/hooks/preflight-commit-push.sh" 2>/dev/null || true)"
+  if printf '%s' "$out" | jq -e '.hookSpecificOutput.permissionDecision == "deny"' >/dev/null 2>&1; then
+    printf '%s' "$out" | jq -r '.hookSpecificOutput.permissionDecisionReason' >&2
+    exit 1
+  fi
+fi
+
+# --git-common-dir, not --git-path: see pre-commit (self-exec recursion).
+chained="$(git rev-parse --git-common-dir)/hooks/pre-push"
+if [[ -x "$chained" && "$(realpath "$chained" 2>/dev/null)" != "$(realpath "$0" 2>/dev/null)" ]]; then
+  exec "$chained" "$@"
+fi
+exit 0


### PR DESCRIPTION
## Problem

The gate stack (commit/push audits, verdict gate) enforces only through harness hooks — Claude Code's PreToolUse, Codex's mirror. An agent with no hook system, or one we haven't wired, commits unaudited. Per-harness wiring also means every new coding agent is an integration project.

## Change

Native git hooks are the one interception point every agent shares — they fire for any process that runs `git`, forever.

- `.githooks/pre-commit` / `pre-push`: thin adapters over the existing `preflight-commit-push.sh` — synthesize its PreToolUse payload, translate its `permissionDecision` JSON into hook exit codes, then chain to the framework-managed hooks (prek fmt/lint, test matrix) via `--git-common-dir`. Policy stays single-sourced; the adapters carry zero judgment.
- **Humans stay ungated**: enforcement binds to named harness markers only — `CLAUDECODE`, `CODEX_SANDBOX`, or `AGENT_GATED=1` for any future agent (one env line in its wiring, zero code here). Named markers, not prefix wildcards: plugin artifacts like `CODEX_COMPANION_*` must not gate a session that isn't Codex-driven.
- **Single consumer**: with the layer installed, the PreToolUse gate defers — but only when the delegate hook actually exists at the checkout (a missing delegate would stand both layers down; closed over open). `GITHOOK_DELEGATED` marks the git layer's own call so the layers can't defer to each other.
- Install once per clone: `bash .githooks/install.sh` (sets `core.hooksPath`). The native `--no-verify` flag remains the documented human bypass.

Two defects were found and pinned during development: `--git-path hooks/<name>` honors `core.hooksPath` and resolved the "chained" hook to the adapter itself (self-exec recursion — infinite for humans, double-consume for agents; chaining now uses `--git-common-dir` + a realpath guard), and the original delegation guard failed open when the delegate was absent.

## Tests

`bash .githooks/githooks.test.sh` — 13/13 in hermetic (`env -i`) fixture repos driving real commit/push flows: agent gated / human exempt / audit consumed / framework chaining / both delegation directions / delegate-missing fail-closed. Regression: `preflight-commit-push.test.sh` 21/21 (guard inert without hooksPath), `preflight-pr-review` 30/30. shellcheck clean.

Also fixes a stale repo name in `commit-push-auditor.md`.

https://claude.ai/code/session_01EMbe2xhLRF7BpSoDKxkexi


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Git hook-based checks for commits and pushes, helping prevent actions that don’t meet the required audit flow.
  * Added an installer to enable the new Git hooks path with a confirmation message.
  * Updated the auditor label to match the current repository name.

* **Bug Fixes**
  * Improved hook chaining so existing Git hook behavior still runs after the new checks.
  * Added safeguards to avoid repeated hook execution and to keep behavior consistent across commit and push flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->