### PR TITLE
fix(dashboard): refresh terminal signed URL on reconnect

### DIFF
--- a/apps/dashboard/src/hooks/queries/useTerminalSessionQuery.test.tsx
+++ b/apps/dashboard/src/hooks/queries/useTerminalSessionQuery.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+/*
+ * Modified by BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useTerminalSessionQuery } from './useTerminalSessionQuery'
+
+const mocks = vi.hoisted(() => ({
+  getSignedPortPreviewUrl: vi.fn(),
+}))
+
+vi.mock('@/hooks/useApi', () => ({
+  useApi: () => ({
+    boxApi: {
+      getSignedPortPreviewUrl: mocks.getSignedPortPreviewUrl,
+    },
+  }),
+}))
+
+vi.mock('@/hooks/useSelectedOrganization', () => ({
+  useSelectedOrganization: () => ({
+    selectedOrganization: { id: 'org-1' },
+  }),
+}))
+
+function TerminalSessionProbe({ enabled }: { enabled: boolean }) {
+  const { data } = useTerminalSessionQuery('box-1', enabled)
+  return <div data-testid="terminal-session-url">{data?.url ?? 'none'}</div>
+}
+
+async function flushReactWork() {
+  for (let i = 0; i < 3; i += 1) {
+    await act(async () => {
+      await Promise.resolve()
+      vi.advanceTimersByTime(0)
+    })
+  }
+}
+
+describe('useTerminalSessionQuery', () => {
+  let root: Root | null = null
+  let queryClient: QueryClient
+
+  beforeAll(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+  })
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-06T00:00:00.000Z'))
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    })
+    mocks.getSignedPortPreviewUrl
+      .mockResolvedValueOnce({ data: { url: 'https://terminal.example/session-1' } })
+      .mockResolvedValueOnce({ data: { url: 'https://terminal.example/session-2' } })
+  })
+
+  afterEach(() => {
+    act(() => {
+      root?.unmount()
+    })
+    root = null
+    queryClient.clear()
+    document.body.innerHTML = ''
+    vi.useRealTimers()
+    vi.clearAllMocks()
+  })
+
+  async function renderProbe(enabled: boolean) {
+    if (!root) {
+      const host = document.createElement('div')
+      document.body.appendChild(host)
+      root = createRoot(host)
+    }
+
+    await act(async () => {
+      root?.render(
+        <QueryClientProvider client={queryClient}>
+          <TerminalSessionProbe enabled={enabled} />
+        </QueryClientProvider>,
+      )
+    })
+    await flushReactWork()
+  }
+
+  it('keeps the active terminal URL stable across rerenders and refreshes it when re-enabled', async () => {
+    await renderProbe(true)
+
+    expect(mocks.getSignedPortPreviewUrl).toHaveBeenCalledTimes(1)
+    expect(document.querySelector('[data-testid="terminal-session-url"]')?.textContent).toBe(
+      'https://terminal.example/session-1',
+    )
+
+    await renderProbe(true)
+    await flushReactWork()
+
+    expect(mocks.getSignedPortPreviewUrl).toHaveBeenCalledTimes(1)
+    expect(document.querySelector('[data-testid="terminal-session-url"]')?.textContent).toBe(
+      'https://terminal.example/session-1',
+    )
+
+    await renderProbe(false)
+    await renderProbe(true)
+    await flushReactWork()
+
+    expect(mocks.getSignedPortPreviewUrl).toHaveBeenCalledTimes(2)
+    expect(document.querySelector('[data-testid="terminal-session-url"]')?.textContent).toBe(
+      'https://terminal.example/session-2',
+    )
+  })
+})

--- a/apps/dashboard/src/hooks/queries/useTerminalSessionQuery.ts
+++ b/apps/dashboard/src/hooks/queries/useTerminalSessionQuery.ts
@@ -31,7 +31,10 @@ export const useTerminalSessionQuery = (boxId: string, enabled: boolean) => {
       return { url, expiresAt: Date.now() + SESSION_DURATION_SECONDS * 1000 }
     },
     enabled: enabled && !!boxId && !!selectedOrganization?.id,
-    staleTime: Infinity,
+    staleTime: 0,
+    gcTime: 0,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
   })
 
   const existingSession = queryClient.getQueryData<TerminalSession>(queryKey)


### PR DESCRIPTION
## Summary
- refresh signed terminal preview URLs whenever the terminal query is re-enabled
- avoid retaining expired terminal session URLs in React Query cache
- add a focused hook regression test for disable/re-enable behavior

## Verification
- npx vitest run dashboard/src/components/boxes/BoxDetails.test.tsx dashboard/src/hooks/queries/useTerminalSessionQuery.test.tsx --config dashboard/vite.config.mts
- npx eslint dashboard/src/hooks/queries/useTerminalSessionQuery.ts dashboard/src/hooks/queries/useTerminalSessionQuery.test.tsx
- npx prettier --check dashboard/src/hooks/queries/useTerminalSessionQuery.ts dashboard/src/hooks/queries/useTerminalSessionQuery.test.tsx --config ../.prettierrc
- git diff --check --cached

## Notes
- src/cli/README.md was already dirty locally and is not included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal session preview behavior so refreshing and re-opening the view now fetches a fresh link when needed, while keeping the link stable during normal use.
  * Reduced unexpected background refreshes for the terminal session preview to make its behavior more predictable.
* **Tests**
  * Added coverage for terminal session preview loading, caching, and re-fetch behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->