### PR TITLE
feat(cli): support rootfs paths in run and create

### DIFF
--- a/docs/reference/cli/README.md
+++ b/docs/reference/cli/README.md
@@ -231,11 +231,18 @@ Credential:      API key (from BOXLITE_API_KEY env var)
 
 ### `boxlite run`
 
-**Synopsis:** `boxlite run [OPTIONS] IMAGE [COMMAND...]`
+**Synopsis:**
 
-Create a box from an image and run a command. If `COMMAND` is omitted, the box runs `sh` (`src/cli/src/commands/run.rs:138`).
+- `boxlite run [OPTIONS] IMAGE [COMMAND...]`
+- `boxlite run [OPTIONS] --rootfs PATH [COMMAND...]`
 
-**Options:** Uses [`ProcessFlags`](#processflags) + [`ResourceFlags`](#resourceflags) + [`PublishFlags`](#publishflags) + [`VolumeFlags`](#volumeflags) + [`ManagementFlags`](#managementflags).
+Create a box from an image or prepared rootfs and run a command. If `COMMAND` is omitted, the box runs `sh`.
+
+**Options:** Uses [`ProcessFlags`](#processflags) + [`ResourceFlags`](#resourceflags) + [`PublishFlags`](#publishflags) + [`VolumeFlags`](#volumeflags) + [`ManagementFlags`](#managementflags), plus:
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--rootfs PATH` | — | Use a prepared rootfs path instead of pulling/resolving an image |
 
 **Exit behavior:**
 
@@ -251,6 +258,7 @@ boxlite run -it --rm alpine:latest /bin/sh
 boxlite run -d --name web -p 8080:80 nginx:alpine
 boxlite run -v $(pwd):/work -w /work alpine:latest ls -la
 boxlite run --cpus 4 --memory 4096 python:slim python -c "print(2+2)"
+boxlite run --rootfs /path/to/rootfs /bin/sh
 ```
 
 ---
@@ -281,14 +289,18 @@ boxlite exec -e DEBUG=1 -w /app mybox -- pytest tests/
 
 ### `boxlite create`
 
-**Synopsis:** `boxlite create [OPTIONS] IMAGE`
+**Synopsis:**
 
-Create a box without running a command. Prints the new box's ID to stdout.
+- `boxlite create [OPTIONS] IMAGE`
+- `boxlite create [OPTIONS] --rootfs PATH`
+
+Create a box from an image or prepared rootfs without running a command. Prints the new box's ID to stdout.
 
 **Options:**
 
 | Flag | Short | Description |
 |------|-------|-------------|
+| `--rootfs PATH` | — | Use a prepared rootfs path instead of pulling/resolving an image |
 | `--env KEY=VALUE` | `-e` | Set environment variables (repeatable) |
 | `--workdir PATH` | `-w` | Working directory inside the box |
 
@@ -301,6 +313,7 @@ Also uses [`ResourceFlags`](#resourceflags) + [`PublishFlags`](#publishflags) + 
 ```bash
 boxlite create --name mybox alpine:latest
 boxlite create -p 8080:80 -v /data:/app/data --name web nginx:alpine
+boxlite create --rootfs /path/to/rootfs --name local-rootfs
 ```
 
 ---

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -15,8 +15,8 @@ The BoxLite CLI (`boxlite`) lets you create, run, and manage BoxLite boxes from 
 
 ### Key Features
 
-- **Run** — Create a box from an image and run a command (interactive, TTY, or detached); supports `-p` (publish ports) and `-v` (volumes)
-- **Create** — Create a box without running; supports `-p` and `-v`
+- **Run** — Create a box from an image or prepared rootfs and run a command (interactive, TTY, or detached); supports `-p` (publish ports) and `-v` (volumes)
+- **Create** — Create a box from an image or prepared rootfs without running; supports `-p` and `-v`
 - **Lifecycle** — Start, stop, restart, remove boxes
 - **Inspect** — Show detailed box info (JSON, YAML, or Go template)
 - **Exec** — Run commands inside a running box
@@ -296,12 +296,16 @@ Scopes:          box:read, box:write, box:exec, image:read, snapshot:read
 
 ### `boxlite run`
 
-Create a box from an image and run a command.
+Create a box from an image or prepared rootfs and run a command.
 
-**Usage:** `boxlite run [OPTIONS] IMAGE [COMMAND]...`
+**Usage:**
+
+- `boxlite run [OPTIONS] IMAGE [COMMAND]...`
+- `boxlite run [OPTIONS] --rootfs PATH [COMMAND]...`
 
 | Option | Short | Description |
 |--------|-------|-------------|
+| `--rootfs PATH` | | Use a prepared rootfs path instead of pulling/resolving an image |
 | `--interactive` | `-i` | Keep STDIN open |
 | `--tty` | `-t` | Allocate a pseudo-TTY |
 | `--env KEY=VALUE` | `-e` | Set environment variables (repeatable) |
@@ -321,16 +325,21 @@ boxlite run alpine:latest echo "Hello"
 boxlite run -it --rm alpine:latest /bin/sh
 boxlite run -d --name openclaw -p 18789:18789 ghcr.io/openclaw/openclaw:main
 boxlite run -v /host/data:/app/data alpine:latest cat /app/data/hello.txt
+boxlite run --rootfs /path/to/rootfs /bin/sh
 ```
 
 ### `boxlite create`
 
-Create a new box without running a command.
+Create a new box from an image or prepared rootfs without running a command.
 
-**Usage:** `boxlite create [OPTIONS] IMAGE`
+**Usage:**
+
+- `boxlite create [OPTIONS] IMAGE`
+- `boxlite create [OPTIONS] --rootfs PATH`
 
 | Option | Short | Description |
 |--------|-------|-------------|
+| `--rootfs PATH` | | Use a prepared rootfs path instead of pulling/resolving an image |
 | `--name NAME` | | Name the box |
 | `--env KEY=VALUE` | `-e` | Environment variables |
 | `--workdir PATH` | `-w` | Working directory |
@@ -346,6 +355,7 @@ Create a new box without running a command.
 ```bash
 boxlite create --name mybox alpine:latest
 boxlite create -p 18789:18789 -v /data:/app/data --name openclaw ghcr.io/openclaw/openclaw:main
+boxlite create --rootfs /path/to/rootfs --name local-rootfs
 boxlite start mybox
 boxlite start openclaw
 ```

--- a/src/cli/src/commands/create.rs
+++ b/src/cli/src/commands/create.rs
@@ -7,7 +7,11 @@ use clap::Args;
 pub struct CreateArgs {
     /// Image to create from
     #[arg(index = 1)]
-    pub image: String,
+    pub image: Option<String>,
+
+    /// Path to an already prepared rootfs
+    #[arg(long = "rootfs", value_name = "PATH")]
+    pub rootfs: Option<String>,
 
     #[command(flatten)]
     pub management: crate::cli::ManagementFlags,
@@ -39,8 +43,8 @@ pub struct CreateArgs {
 }
 
 pub async fn execute(args: CreateArgs, global: &GlobalFlags) -> anyhow::Result<()> {
-    let rt = global.create_runtime()?;
     let box_options = args.to_box_options(global)?;
+    let rt = global.create_runtime()?;
 
     let litebox = rt.create(box_options, args.management.name.clone()).await?;
     println!("{}", litebox.id());
@@ -61,7 +65,70 @@ impl CreateArgs {
             options.entrypoint = Some(vec![exec.clone()]);
         }
         crate::cli::apply_env_vars(&self.env, &mut options);
-        options.rootfs = RootfsSpec::Image(self.image.clone());
+        options.rootfs = self.rootfs_spec()?;
         Ok(options)
+    }
+
+    fn rootfs_spec(&self) -> anyhow::Result<RootfsSpec> {
+        match (self.image.as_ref(), self.rootfs.as_ref()) {
+            (Some(image), None) => Ok(RootfsSpec::Image(image.clone())),
+            (None, Some(path)) => Ok(RootfsSpec::RootfsPath(path.clone())),
+            (None, None) => anyhow::bail!("provide IMAGE or --rootfs PATH"),
+            (Some(_), Some(_)) => anyhow::bail!("provide either IMAGE or --rootfs PATH, not both"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::{Cli, Commands};
+    use clap::Parser;
+
+    #[test]
+    fn create_rootfs_flag_sets_rootfs_path() {
+        let cli = Cli::try_parse_from(["boxlite", "create", "--rootfs", "/tmp/rootfs"])
+            .expect("create --rootfs should parse");
+        let Commands::Create(args) = cli.command else {
+            panic!("expected create command");
+        };
+
+        let opts = args
+            .to_box_options(&cli.global)
+            .expect("rootfs options should build");
+
+        match opts.rootfs {
+            RootfsSpec::RootfsPath(path) => assert_eq!(path, "/tmp/rootfs"),
+            other => panic!("expected RootfsPath, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn create_requires_image_or_rootfs() {
+        let cli = Cli::try_parse_from(["boxlite", "create"]).expect("create should parse");
+        let Commands::Create(args) = cli.command else {
+            panic!("expected create command");
+        };
+
+        let err = args
+            .to_box_options(&cli.global)
+            .expect_err("missing source must be rejected");
+
+        assert!(err.to_string().contains("IMAGE or --rootfs"));
+    }
+
+    #[test]
+    fn create_rejects_image_and_rootfs_together() {
+        let cli = Cli::try_parse_from(["boxlite", "create", "--rootfs", "/tmp/rootfs", "alpine"])
+            .expect("create image and rootfs should parse");
+        let Commands::Create(args) = cli.command else {
+            panic!("expected create command");
+        };
+
+        let err = args
+            .to_box_options(&cli.global)
+            .expect_err("competing sources must be rejected");
+
+        assert!(err.to_string().contains("either IMAGE or --rootfs"));
     }
 }

--- a/src/cli/src/commands/run.rs
+++ b/src/cli/src/commands/run.rs
@@ -29,12 +29,13 @@ pub struct RunArgs {
     #[command(flatten)]
     pub management: ManagementFlags,
 
-    #[arg(index = 1)]
-    pub image: String,
+    /// Path to an already prepared rootfs
+    #[arg(long = "rootfs", value_name = "PATH")]
+    pub rootfs: Option<String>,
 
-    /// Command to run inside the image
-    #[arg(index = 2, trailing_var_arg = true)]
-    pub command: Vec<String>,
+    /// Image and command, or command only when --rootfs is set
+    #[arg(index = 1, trailing_var_arg = true, value_name = "IMAGE|COMMAND")]
+    pub args: Vec<String>,
 }
 
 /// Entry point.
@@ -46,8 +47,10 @@ pub struct RunArgs {
 /// runs `shutdown_sync()` and stops the box's shim on every return path.
 /// `std::process::exit` would bypass that Drop chain and leak the shim (#622).
 pub async fn execute(args: RunArgs, global: &GlobalFlags) -> anyhow::Result<i32> {
+    let (rootfs, command_args) = args.rootfs_and_command()?;
+    let command_args = command_args.to_vec();
     let mut runner = BoxRunner::new(args, global)?;
-    runner.run().await
+    runner.run(rootfs, command_args).await
 }
 
 struct BoxRunner {
@@ -64,14 +67,14 @@ impl BoxRunner {
         Ok(Self { args, rt, home })
     }
 
-    async fn run(&mut self) -> anyhow::Result<i32> {
+    async fn run(&mut self, rootfs: RootfsSpec, command_args: Vec<String>) -> anyhow::Result<i32> {
         // Validate flags and environment
         self.validate_flags()?;
 
-        let litebox = self.create_box().await?;
+        let litebox = self.create_box(rootfs).await?;
 
         // Start execution
-        let cmd = self.prepare_command();
+        let cmd = self.prepare_command(&command_args);
         let mut execution = litebox.exec(cmd).await?;
 
         // Detach mode: Print ID and exit
@@ -104,7 +107,7 @@ impl BoxRunner {
         Ok(to_shell_exit_code(exit_code))
     }
 
-    async fn create_box(&self) -> anyhow::Result<LiteBox> {
+    async fn create_box(&self, rootfs: RootfsSpec) -> anyhow::Result<LiteBox> {
         let mut options = BoxOptions::default();
         self.args.resource.apply_to(&mut options);
         self.args.management.apply_to(&mut options)?;
@@ -120,7 +123,7 @@ impl BoxRunner {
             options.auto_remove = false;
         }
 
-        options.rootfs = RootfsSpec::Image(self.args.image.clone());
+        options.rootfs = rootfs;
 
         let litebox = self
             .rt
@@ -130,8 +133,8 @@ impl BoxRunner {
         Ok(litebox)
     }
 
-    fn prepare_command(&self) -> BoxCommand {
-        let (program, args) = parse_command_args(&self.args.command);
+    fn prepare_command(&self, command_args: &[String]) -> BoxCommand {
+        let (program, args) = parse_command_args(command_args);
         BoxCommand::new(program)
             .args(args)
             .tty(self.args.process.tty)
@@ -147,6 +150,27 @@ impl BoxRunner {
     }
 }
 
+impl RunArgs {
+    fn rootfs_and_command(&self) -> anyhow::Result<(RootfsSpec, &[String])> {
+        resolve_rootfs_and_command(self.rootfs.as_deref(), &self.args)
+    }
+}
+
+fn resolve_rootfs_and_command<'a>(
+    rootfs: Option<&str>,
+    args: &'a [String],
+) -> anyhow::Result<(RootfsSpec, &'a [String])> {
+    if let Some(path) = rootfs {
+        return Ok((RootfsSpec::RootfsPath(path.to_string()), args));
+    }
+
+    let Some((image, command)) = args.split_first() else {
+        anyhow::bail!("provide IMAGE or --rootfs PATH");
+    };
+
+    Ok((RootfsSpec::Image(image.clone()), command))
+}
+
 fn parse_command_args(input: &[String]) -> (&str, &[String]) {
     if input.is_empty() {
         ("sh", &[])
@@ -158,6 +182,8 @@ fn parse_command_args(input: &[String]) -> (&str, &[String]) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cli::{Cli, Commands};
+    use clap::Parser;
 
     #[test]
     fn test_parse_command_args_defaults() {
@@ -172,5 +198,76 @@ mod tests {
             parse_command_args(&input),
             ("echo", &["hello".to_string()] as &[String])
         );
+    }
+
+    #[test]
+    fn run_rootfs_flag_sets_rootfs_path_and_uses_trailing_command() {
+        let cli = Cli::try_parse_from(["boxlite", "run", "--rootfs", "/tmp/rootfs", "echo", "hi"])
+            .expect("run --rootfs should parse");
+        let Commands::Run(args) = cli.command else {
+            panic!("expected run command");
+        };
+
+        let (rootfs, command) = args
+            .rootfs_and_command()
+            .expect("rootfs command should resolve");
+
+        match rootfs {
+            RootfsSpec::RootfsPath(path) => assert_eq!(path, "/tmp/rootfs"),
+            other => panic!("expected RootfsPath, got {other:?}"),
+        }
+        assert_eq!(command, &["echo".to_string(), "hi".to_string()]);
+    }
+
+    #[test]
+    fn run_rootfs_without_command_defaults_to_shell() {
+        let cli = Cli::try_parse_from(["boxlite", "run", "--rootfs", "/tmp/rootfs"])
+            .expect("run --rootfs should parse");
+        let Commands::Run(args) = cli.command else {
+            panic!("expected run command");
+        };
+
+        let (rootfs, command) = args
+            .rootfs_and_command()
+            .expect("rootfs command should resolve");
+
+        match rootfs {
+            RootfsSpec::RootfsPath(path) => assert_eq!(path, "/tmp/rootfs"),
+            other => panic!("expected RootfsPath, got {other:?}"),
+        }
+        assert_eq!(parse_command_args(command), ("sh", &[] as &[String]));
+    }
+
+    #[test]
+    fn run_without_rootfs_preserves_image_and_command() {
+        let cli = Cli::try_parse_from(["boxlite", "run", "alpine:latest", "echo", "hi"])
+            .expect("run image command should parse");
+        let Commands::Run(args) = cli.command else {
+            panic!("expected run command");
+        };
+
+        let (rootfs, command) = args
+            .rootfs_and_command()
+            .expect("image command should resolve");
+
+        match rootfs {
+            RootfsSpec::Image(image) => assert_eq!(image, "alpine:latest"),
+            other => panic!("expected Image, got {other:?}"),
+        }
+        assert_eq!(command, &["echo".to_string(), "hi".to_string()]);
+    }
+
+    #[test]
+    fn run_requires_image_or_rootfs() {
+        let cli = Cli::try_parse_from(["boxlite", "run"]).expect("run should parse");
+        let Commands::Run(args) = cli.command else {
+            panic!("expected run command");
+        };
+
+        let err = args
+            .rootfs_and_command()
+            .expect_err("missing source must be rejected");
+
+        assert!(err.to_string().contains("IMAGE or --rootfs"));
     }
 }


### PR DESCRIPTION
## Summary
Add CLI support for creating and running boxes from a prepared rootfs path via `--rootfs PATH`, matching the runtime option already exposed internally.

## Changes
- Accept `--rootfs PATH` on `boxlite run` and `boxlite create`.
- Preserve image-based invocation and validate that `create` receives exactly one source.
- Treat trailing `run --rootfs` arguments as the command and keep the default `sh` command when omitted.
- Update CLI quick-reference and reference documentation.

## How to verify
- `cargo test -p boxlite-cli --bin boxlite rootfs -- --nocapture`
- `make test:changed:cli FILTER=rootfs`
- `make fmt:check:rust`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `boxlite run` and `boxlite create` now support using a prepared root filesystem in addition to image-based inputs.
  * `boxlite run` can accept a prepared rootfs path with an optional command, and defaults to `sh` when no command is provided.

* **Documentation**
  * Updated CLI reference and README examples to show the new `--rootfs PATH` usage for both commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->