### PR TITLE
Fix dashboard email verification refresh

### DIFF
--- a/apps/api/src/auth/jwt.strategy.spec.ts
+++ b/apps/api/src/auth/jwt.strategy.spec.ts
@@ -55,3 +55,37 @@ describe('JwtStrategy.validate — auto-created user', () => {
     )
   })
 })
+
+describe('JwtStrategy.validate — email verification sync', () => {
+  it('updates an existing unverified user from the trusted JWT claim', async () => {
+    const { strategy, userService } = buildStrategy()
+    const request = { get: jest.fn().mockReturnValue(undefined) } as unknown as Request
+    ;(userService.findOne as jest.Mock).mockResolvedValueOnce({
+      id: 'user-1',
+      role: 'user',
+      email: 'new@boxlite.dev',
+      emailVerified: false,
+    })
+
+    await strategy.validate(request, { sub: 'user-1', email: 'new@boxlite.dev', email_verified: true })
+
+    expect(userService.update).toHaveBeenCalledWith('user-1', { emailVerified: true })
+    expect(userService.create).not.toHaveBeenCalled()
+  })
+
+  it('does not emit another verification update for an already verified user', async () => {
+    const { strategy, userService } = buildStrategy()
+    const request = { get: jest.fn().mockReturnValue(undefined) } as unknown as Request
+    ;(userService.findOne as jest.Mock).mockResolvedValueOnce({
+      id: 'user-1',
+      role: 'user',
+      email: 'new@boxlite.dev',
+      emailVerified: true,
+    })
+
+    await strategy.validate(request, { sub: 'user-1', email: 'new@boxlite.dev', email_verified: true })
+
+    expect(userService.update).not.toHaveBeenCalledWith('user-1', { emailVerified: true })
+    expect(userService.create).not.toHaveBeenCalled()
+  })
+})

--- a/apps/dashboard/src/components/Banner.tsx
+++ b/apps/dashboard/src/components/Banner.tsx
@@ -55,6 +55,7 @@ const bannerVariants = cva('relative overflow-hidden backdrop-blur-xl border-y w
 interface BannerAction {
   label: string
   onClick: () => void
+  disabled?: boolean
 }
 
 interface BannerNotification {
@@ -191,6 +192,7 @@ export const Banner = ({
             <button
               type="button"
               onClick={action.onClick}
+              disabled={action.disabled}
               className="text-sm font-medium underline-offset-4 underline row-[2] sm:row-[1] col-[2] sm:col-[3] justify-self-start"
             >
               {action.label}

--- a/apps/dashboard/src/components/PageLayout.test.tsx
+++ b/apps/dashboard/src/components/PageLayout.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+import React from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it } from 'vitest'
+import { BannerProvider } from './Banner'
+import { DashboardBannerSlot, PageContent } from './PageLayout'
+
+async function render(element: React.ReactElement) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  root.render(element)
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  return { container, root }
+}
+
+const notification = {
+  id: 'verify-email',
+  title: 'Verification Required',
+  description: 'Please verify your email address to access all features.',
+}
+
+describe('dashboard banner placement', () => {
+  const roots: Root[] = []
+
+  afterEach(() => {
+    roots.splice(0).forEach((root) => root.unmount())
+    document.body.replaceChildren()
+  })
+
+  it('renders dashboard banners from the shell slot', async () => {
+    const { container, root } = await render(
+      <BannerProvider defaultNotifications={[notification]}>
+        <DashboardBannerSlot />
+      </BannerProvider>,
+    )
+    roots.push(root)
+
+    expect(container.textContent).toContain('Verification Required')
+  })
+
+  it('does not render a second banner from PageContent', async () => {
+    const { container, root } = await render(
+      <BannerProvider defaultNotifications={[notification]}>
+        <DashboardBannerSlot />
+        <PageContent>Boxes</PageContent>
+      </BannerProvider>,
+    )
+    roots.push(root)
+
+    expect(container.textContent?.match(/Verification Required/g)).toHaveLength(1)
+  })
+})

--- a/apps/dashboard/src/components/PageLayout.tsx
+++ b/apps/dashboard/src/components/PageLayout.tsx
@@ -65,26 +65,29 @@ function PageBanner({ className, children, ...props }: ComponentProps<'div'>) {
   )
 }
 
-function PageContent({ className, size = 'default', ...props }: ComponentProps<'main'> & { size?: PageSize }) {
+function DashboardBannerSlot() {
   return (
-    <>
-      <PageBanner>
-        <BannerStack bannerClassName={cn({ 'max-w-5xl mx-auto': size === 'default' })} />
-      </PageBanner>
-      <main
-        className={cn(
-          'flex w-full flex-col gap-4 px-4 pb-8 sm:px-5 2xl:px-0',
-          {
-            'mx-auto max-w-[960px]': size === 'default',
-            'mx-auto max-w-[1040px]': size === 'content',
-            'mx-auto max-w-[1440px]': size === 'full',
-          },
-          className,
-        )}
-        {...props}
-      />
-    </>
+    <PageBanner>
+      <BannerStack />
+    </PageBanner>
   )
 }
 
-export { PageContent, PageDescription, PageHeader, PageLayout, PageTitle }
+function PageContent({ className, size = 'default', ...props }: ComponentProps<'main'> & { size?: PageSize }) {
+  return (
+    <main
+      className={cn(
+        'flex w-full flex-col gap-4 px-4 pb-8 sm:px-5 2xl:px-0',
+        {
+          'mx-auto max-w-[960px]': size === 'default',
+          'mx-auto max-w-[1040px]': size === 'content',
+          'mx-auto max-w-[1440px]': size === 'full',
+        },
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+export { DashboardBannerSlot, PageContent, PageDescription, PageHeader, PageLayout, PageTitle }

--- a/apps/dashboard/src/contexts/SelectedOrganizationContext.tsx
+++ b/apps/dashboard/src/contexts/SelectedOrganizationContext.tsx
@@ -11,7 +11,7 @@ import { createContext } from 'react'
 export interface ISelectedOrganizationContext {
   selectedOrganization: Organization | null
   organizationMembers: OrganizationUser[]
-  refreshOrganizationMembers: () => Promise<OrganizationUser[]>
+  refreshOrganizationMembers: (organizationId?: string) => Promise<OrganizationUser[]>
   authenticatedUserOrganizationMember: OrganizationUser | null
   authenticatedUserHasPermission: (permission: OrganizationRolePermissionsEnum) => boolean
   onSelectOrganization: (organizationId: string) => Promise<boolean>

--- a/apps/dashboard/src/hooks/useSuspensionBanner.test.tsx
+++ b/apps/dashboard/src/hooks/useSuspensionBanner.test.tsx
@@ -1,0 +1,178 @@
+// @vitest-environment jsdom
+import React from 'react'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useSuspensionBanner } from './useSuspensionBanner'
+
+const mocks = vi.hoisted(() => ({
+  addBanner: vi.fn(),
+  removeBanner: vi.fn(),
+  signinSilent: vi.fn(),
+  removeUser: vi.fn(),
+  signinRedirect: vi.fn(),
+  getAuthenticatedUser: vi.fn(),
+  refreshOrganizations: vi.fn(),
+  refreshOrganizationMembers: vi.fn(),
+  toastError: vi.fn(),
+  apiClientConstructor: vi.fn(),
+}))
+
+vi.mock('@/components/Banner', () => ({
+  useBanner: () => ({ addBanner: mocks.addBanner, removeBanner: mocks.removeBanner }),
+}))
+
+vi.mock('react-oidc-context', () => ({
+  useAuth: () => ({
+    signinSilent: mocks.signinSilent,
+    removeUser: mocks.removeUser,
+    signinRedirect: mocks.signinRedirect,
+  }),
+}))
+
+vi.mock('@/api/apiClient', () => ({
+  ApiClient: vi.fn().mockImplementation(function (...args) {
+    mocks.apiClientConstructor(...args)
+    return {
+      userApi: {
+        getAuthenticatedUser: mocks.getAuthenticatedUser,
+      },
+    }
+  }),
+}))
+
+vi.mock('@/hooks/useConfig', () => ({
+  useConfig: () => ({ apiUrl: 'https://api.boxlite.test' }),
+}))
+
+vi.mock('@/hooks/useOrganizations', () => ({
+  useOrganizations: () => ({ refreshOrganizations: mocks.refreshOrganizations }),
+}))
+
+vi.mock('@/hooks/useSelectedOrganization', () => ({
+  useSelectedOrganization: () => ({
+    selectedOrganization: { id: 'org-1' },
+    refreshOrganizationMembers: mocks.refreshOrganizationMembers,
+  }),
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: mocks.toastError,
+  },
+}))
+
+function Harness() {
+  useSuspensionBanner({
+    suspended: true,
+    suspensionReason: 'Please verify your email address',
+    suspendedAt: new Date('2026-07-07T00:00:00.000Z'),
+    suspensionCleanupGracePeriodHours: 24,
+  })
+  return null
+}
+
+async function renderHookAt(path = '/dashboard/boxes?filter=active') {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  await act(async () => {
+    root.render(
+      <MemoryRouter initialEntries={[path]}>
+        <Harness />
+      </MemoryRouter>,
+    )
+  })
+  return root
+}
+
+function latestBannerAction() {
+  const notification = mocks.addBanner.mock.calls.at(-1)?.[0]
+  expect(notification).toMatchObject({
+    title: 'Verification Required',
+    action: expect.objectContaining({ label: 'I verified my email' }),
+  })
+  return notification.action as { label: string; onClick: () => Promise<void> | void }
+}
+
+describe('useSuspensionBanner verify-email recovery', () => {
+  const roots: Root[] = []
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.signinSilent.mockResolvedValue({
+      access_token: 'fresh-token',
+      profile: { email_verified: true },
+    })
+    mocks.getAuthenticatedUser.mockResolvedValue({ data: { id: 'user-1', emailVerified: true } })
+    mocks.refreshOrganizations.mockResolvedValue(undefined)
+    mocks.refreshOrganizationMembers.mockResolvedValue([])
+    mocks.removeUser.mockResolvedValue(undefined)
+    mocks.signinRedirect.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    roots.splice(0).forEach((root) => root.unmount())
+    document.body.replaceChildren()
+  })
+
+  it('adds a CTA to the verify-email suspension banner', async () => {
+    const root = await renderHookAt()
+    roots.push(root)
+
+    expect(latestBannerAction().label).toBe('I verified my email')
+  })
+
+  it('syncs the backend identity and refreshes org state when silent refresh confirms verification', async () => {
+    const root = await renderHookAt()
+    roots.push(root)
+
+    await act(async () => {
+      await latestBannerAction().onClick()
+    })
+
+    expect(mocks.signinSilent).toHaveBeenCalledTimes(1)
+    expect(mocks.apiClientConstructor).toHaveBeenCalledWith({ apiUrl: 'https://api.boxlite.test' }, 'fresh-token')
+    expect(mocks.getAuthenticatedUser).toHaveBeenCalledTimes(1)
+    expect(mocks.refreshOrganizations).toHaveBeenCalledWith('org-1')
+    expect(mocks.refreshOrganizationMembers).toHaveBeenCalledTimes(1)
+    expect(mocks.removeUser).not.toHaveBeenCalled()
+    expect(mocks.signinRedirect).not.toHaveBeenCalled()
+  })
+
+  it('falls back to redirect login with returnTo when silent refresh fails', async () => {
+    mocks.signinSilent.mockRejectedValueOnce(new Error('login_required'))
+    const root = await renderHookAt('/dashboard/boxes?page=2')
+    roots.push(root)
+
+    await act(async () => {
+      await latestBannerAction().onClick()
+    })
+
+    expect(mocks.removeUser).toHaveBeenCalledTimes(1)
+    expect(mocks.signinRedirect).toHaveBeenCalledWith({
+      state: { returnTo: '/dashboard/boxes?page=2' },
+    })
+  })
+
+  it('falls back to redirect login when the refreshed profile is still not verified', async () => {
+    mocks.signinSilent.mockResolvedValueOnce({
+      access_token: 'fresh-token',
+      profile: { email_verified: false },
+    })
+    const root = await renderHookAt('/dashboard/boxes?onboarding=1')
+    roots.push(root)
+
+    await act(async () => {
+      await latestBannerAction().onClick()
+    })
+
+    expect(mocks.getAuthenticatedUser).not.toHaveBeenCalled()
+    expect(mocks.toastError).toHaveBeenCalledWith('We could not confirm verification yet. Try again in a moment.')
+    expect(mocks.removeUser).toHaveBeenCalledTimes(1)
+    expect(mocks.signinRedirect).toHaveBeenCalledWith({
+      state: { returnTo: '/dashboard/boxes?onboarding=1' },
+    })
+  })
+})

--- a/apps/dashboard/src/hooks/useSuspensionBanner.tsx
+++ b/apps/dashboard/src/hooks/useSuspensionBanner.tsx
@@ -6,11 +6,17 @@
 
 import { useBanner } from '@/components/Banner'
 import { RoutePath } from '@/enums/RoutePath'
+import { ApiClient } from '@/api/apiClient'
+import { useConfig } from '@/hooks/useConfig'
+import { useOrganizations } from '@/hooks/useOrganizations'
+import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
 import { Organization } from '@boxlite-ai/api-client'
 import { addHours, formatDistanceToNow } from 'date-fns'
 import { CreditCardIcon, MailIcon } from '@/components/ui/icon'
-import { useEffect, useRef } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useAuth } from 'react-oidc-context'
 import { useLocation, useNavigate } from 'react-router-dom'
+import { toast } from 'sonner'
 
 const SUSPENSION_BANNER_ID = 'suspension-banner'
 
@@ -36,8 +42,62 @@ export function useSuspensionBanner(suspension?: Suspension | null) {
   const { addBanner, removeBanner } = useBanner()
   const navigate = useNavigate()
   const location = useLocation()
+  const config = useConfig()
+  const { signinSilent, removeUser, signinRedirect } = useAuth()
+  const { refreshOrganizations } = useOrganizations()
+  const { selectedOrganization, refreshOrganizationMembers } = useSelectedOrganization()
   const path = location?.pathname
   const previousSuspendedRef = useRef<boolean | undefined>(undefined)
+  const [isCheckingVerification, setIsCheckingVerification] = useState(false)
+
+  const redirectToFreshLogin = useCallback(async () => {
+    await removeUser()
+    await signinRedirect({
+      state: {
+        returnTo: `${location.pathname}${location.search}`,
+      },
+    })
+  }, [location.pathname, location.search, removeUser, signinRedirect])
+
+  const handleVerifyEmailRefresh = useCallback(async () => {
+    if (isCheckingVerification) {
+      return
+    }
+
+    setIsCheckingVerification(true)
+    try {
+      let freshUser
+      try {
+        freshUser = await signinSilent()
+      } catch {
+        await redirectToFreshLogin()
+        return
+      }
+
+      if (!freshUser?.access_token || freshUser.profile.email_verified !== true) {
+        toast.error('We could not confirm verification yet. Try again in a moment.')
+        await redirectToFreshLogin()
+        return
+      }
+
+      const api = new ApiClient(config, freshUser.access_token)
+      await api.userApi.getAuthenticatedUser()
+      await refreshOrganizations(selectedOrganization?.id)
+      await refreshOrganizationMembers()
+    } catch {
+      toast.error('We could not refresh your account. Try again in a moment.')
+    } finally {
+      setIsCheckingVerification(false)
+    }
+  }, [
+    config,
+    isCheckingVerification,
+    redirectToFreshLogin,
+    refreshOrganizationMembers,
+    refreshOrganizations,
+    selectedOrganization?.id,
+    signinSilent,
+  ])
 
   useEffect(() => {
     const wasSuspended = previousSuspendedRef.current
@@ -81,6 +141,11 @@ export function useSuspensionBanner(suspension?: Suspension | null) {
           title: 'Verification Required',
           description: 'Please verify your email address to access all features.',
           icon: <MailIcon className="h-4 w-4 flex-shrink-0 text-current" />,
+          action: {
+            label: isCheckingVerification ? 'Checking...' : 'I verified my email',
+            onClick: handleVerifyEmailRefresh,
+            disabled: isCheckingVerification,
+          },
           isDismissible: false,
         })
       }
@@ -137,5 +202,5 @@ export function useSuspensionBanner(suspension?: Suspension | null) {
       description: reason ? `${reason}. ${cleanupText}` : cleanupText,
       isDismissible: false,
     })
-  }, [suspension, addBanner, removeBanner, navigate, path])
+  }, [suspension, addBanner, handleVerifyEmailRefresh, isCheckingVerification, removeBanner, navigate, path])
 }

--- a/apps/dashboard/src/pages/Dashboard.tsx
+++ b/apps/dashboard/src/pages/Dashboard.tsx
@@ -25,6 +25,7 @@ import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
 import { useSuspensionBanner } from '@/hooks/useSuspensionBanner'
 import { cn } from '@/lib/utils'
 import { BookOpen, BookSearchIcon, MessageCircle, SunMoon } from '@/components/ui/icon'
+import { DashboardBannerSlot } from '@/components/PageLayout'
 
 function useDashboardCommands() {
   const { theme, setTheme } = useTheme()
@@ -140,6 +141,7 @@ const Dashboard: React.FC = () => {
       <SidebarProvider isBannerVisible={false} defaultOpen={true} className="flex-col">
         <Sidebar isBannerVisible={isBannerVisible} billingEnabled={!!config.billingApiUrl} version={config.version} />
         <SidebarInset className="min-h-0 overflow-visible">
+          <DashboardBannerSlot />
           <div className="w-full min-h-[var(--app-content-height,calc(100svh_-_60px))] overscroll-none">
             {/* Lazy route components (Admin/Billing/Settings/box-details) suspend
                 here so only the content area shows a fallback — the sidebar/shell


### PR DESCRIPTION
## Summary

Fixes the dashboard flow where a user remains blocked after verifying their email until they log out and back in.

- Moves org suspension banners to the dashboard shell so `/dashboard/boxes` can show the verify-email banner.
- Adds an `I verified my email` CTA that silently refreshes the OIDC user, syncs the trusted JWT claim through `/users/me`, and refetches organization/member state.
- Falls back to a fresh redirect login with `returnTo` when silent refresh fails or the provider has not reflected verification yet.

## User Journey Diff

```text
BEFORE ❌
┌──────────────┐
│ ① Sign up    │
│ email signup │
└──────┬───────┘
       ▼
┌──────────────┐
│ ② Verify     │
│ email link   │
└──────┬───────┘
       ▼
┌──────────────┐
│ ③ Refresh    │
│ /boxes page  │
└──────┬───────┘
       ▼
┌──────────────────────────────┐
│ ④ Still blocked              │
│ stale sessionStorage user    │
│ org still looks suspended    │
│ banner may be missing        │
└──────┬───────────────────────┘
       ▼
┌──────────────┐
│ ⑤ Logout     │
└──────┬───────┘
       ▼
┌──────────────┐
│ ⑥ Login      │
│ fresh token  │
└──────┬───────┘
       ▼
┌──────────────┐
│ ✅ Create Box │
└──────────────┘

AFTER ✅
┌──────────────┐
│ ① Sign up    │
│ email signup │
└──────┬───────┘
       ▼
┌──────────────┐
│ ② Verify     │
│ email link   │
└──────┬───────┘
       ▼
┌──────────────────────────────┐
│ ③ Back to /dashboard/boxes   │
│ shell banner is visible      │
└──────┬───────────────────────┘
       ▼
┌──────────────────────────────┐
│ ④ Click CTA                  │
│ “I verified my email”        │
└──────┬───────────────────────┘
       ▼
┌──────────────────────────────┐
│ ⑤ Silent refresh             │
│ fresh token/profile          │
└──────┬───────────────────────┘
       ▼
┌──────────────────────────────┐
│ ⑥ Backend sync               │
│ fresh JWT → /users/me        │
│ emailVerified=true           │
│ org unsuspended              │
└──────┬───────────────────────┘
       ▼
┌──────────────┐
│ ✅ Create Box │
│ no logout     │
└──────────────┘
```

## Fixed Flow

```text
┌────────────────────────────────────────┐
│ User clicks banner CTA                 │
│ “I verified my email”                  │
└──────────────────┬─────────────────────┘
                   ▼
          ┌────────────────┐
          │ signinSilent() │
          │ refresh OIDC   │
          └───────┬────────┘
                  │
      ┌───────────┴────────────────────┐
      ▼                                ▼
┌──────────────────────┐       ┌──────────────────────────┐
│ ❌ failed / not true  │       │ ✅ email_verified=true    │
│ provider not ready   │       │ fresh token/profile       │
└──────────┬───────────┘       └─────────────┬────────────┘
           ▼                                 ▼
┌──────────────────────┐       ┌──────────────────────────┐
│ show try-again msg   │       │ GET /users/me            │
└──────────┬───────────┘       │ with fresh JWT           │
           ▼                   └─────────────┬────────────┘
┌──────────────────────┐                     ▼
│ removeUser()         │       ┌──────────────────────────┐
│ signinRedirect()     │       │ JWT strategy trusts JWT  │
│ keep returnTo        │       │ updates emailVerified    │
└──────────────────────┘       └─────────────┬────────────┘
                                             ▼
                               ┌──────────────────────────┐
                               │ EMAIL_VERIFIED event     │
                               │ default org unsuspended  │
                               └─────────────┬────────────┘
                                             ▼
                               ┌──────────────────────────┐
                               │ refetch orgs + members   │
                               │ banner disappears        │
                               └─────────────┬────────────┘
                                             ▼
                               ┌──────────────────────────┐
                               │ ✅ Create Box             │
                               └──────────────────────────┘
```

## Validation

- Two-sided frontend verification: tests fail with all production changes reverted, then pass after restoring them.
- `yarn --cwd apps vitest run src/components/PageLayout.test.tsx src/hooks/useSuspensionBanner.test.tsx --config dashboard/vite.config.mts`
- `yarn --cwd apps vitest run --config dashboard/vite.config.mts`
- `cd apps && yarn nx run api:test --testPathPatterns=api/src/auth/jwt.strategy.spec.ts --runInBand`
- `make lint:apps`
- `cd apps && yarn nx run dashboard:build --configuration=development`
- `git diff --check`