### PR TITLE
feat(api): warm pool dynamic scaling with schedule-based targets

### DIFF
--- a/apps/api/src/admin/admin.module.ts
+++ b/apps/api/src/admin/admin.module.ts
@@ -9,6 +9,7 @@ import { AdminObservabilityController } from './controllers/observability.contro
 import { AdminOverviewController } from './controllers/overview.controller'
 import { AdminRunnerController } from './controllers/runner.controller'
 import { AdminBoxController } from './controllers/box.controller'
+import { AdminWarmPoolController } from './controllers/warm-pool.controller'
 import {
   ADMIN_AUDIT_LOG_READER,
   ADMIN_CLOUDWATCH_LOG_READER,
@@ -28,7 +29,7 @@ import { AuditService } from '../audit/services/audit.service'
 
 @Module({
   imports: [BoxModule, RegionModule, OrganizationModule, UserModule, AuditModule],
-  controllers: [AdminRunnerController, AdminBoxController, AdminOverviewController, AdminObservabilityController],
+  controllers: [AdminRunnerController, AdminBoxController, AdminOverviewController, AdminObservabilityController, AdminWarmPoolController],
   providers: [
     AdminOverviewService,
     AdminObservabilityService,

--- a/apps/api/src/admin/controllers/warm-pool.controller.ts
+++ b/apps/api/src/admin/controllers/warm-pool.controller.ts
@@ -1,0 +1,47 @@
+import { Body, Controller, Get, NotFoundException, Param, ParseUUIDPipe, Patch, UseGuards } from '@nestjs/common'
+import { ApiBearerAuth, ApiOAuth2, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger'
+import { CombinedAuthGuard } from '../../auth/combined-auth.guard'
+import { SystemActionGuard } from '../../auth/system-action.guard'
+import { RequiredApiRole } from '../../common/decorators/required-role.decorator'
+import { SystemRole } from '../../user/enums/system-role.enum'
+import { BoxWarmPoolService } from '../../box/services/box-warm-pool.service'
+import { AdminWarmPoolDto, UpdateWarmPoolScheduleDto } from '../dto/warm-pool.dto'
+
+@ApiTags('admin')
+@Controller('admin/warm-pools')
+@UseGuards(CombinedAuthGuard, SystemActionGuard)
+@RequiredApiRole([SystemRole.ADMIN])
+@ApiOAuth2(['openid', 'profile', 'email'])
+@ApiBearerAuth()
+export class AdminWarmPoolController {
+  constructor(private readonly warmPoolService: BoxWarmPoolService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List all warm pools', operationId: 'adminListWarmPools' })
+  @ApiResponse({ status: 200, type: [AdminWarmPoolDto] })
+  async list(): Promise<AdminWarmPoolDto[]> {
+    return (await this.warmPoolService.listWarmPools()).map(AdminWarmPoolDto.fromEntity)
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get warm pool by ID', operationId: 'adminGetWarmPool' })
+  @ApiResponse({ status: 200, type: AdminWarmPoolDto })
+  async getOne(@Param('id', ParseUUIDPipe) id: string): Promise<AdminWarmPoolDto> {
+    const item = await this.warmPoolService.findWarmPool(id)
+    if (!item) throw new NotFoundException('Warm pool not found')
+    return AdminWarmPoolDto.fromEntity(item)
+  }
+
+  @Patch(':id/schedule')
+  @ApiOperation({ summary: 'Update warm pool schedule config', operationId: 'adminUpdateWarmPoolSchedule' })
+  @ApiResponse({ status: 200, type: AdminWarmPoolDto })
+  async updateSchedule(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: UpdateWarmPoolScheduleDto,
+  ): Promise<AdminWarmPoolDto> {
+    const item = await this.warmPoolService.findWarmPool(id)
+    if (!item) throw new NotFoundException('Warm pool not found')
+    const updated = await this.warmPoolService.updateSchedule(id, dto.scheduleConfig ?? null, dto.timezone)
+    return AdminWarmPoolDto.fromEntity(updated)
+  }
+}

--- a/apps/api/src/admin/controllers/warm-pool.controller.ts
+++ b/apps/api/src/admin/controllers/warm-pool.controller.ts
@@ -41,7 +41,7 @@ export class AdminWarmPoolController {
   ): Promise<AdminWarmPoolDto> {
     const item = await this.warmPoolService.findWarmPool(id)
     if (!item) throw new NotFoundException('Warm pool not found')
-    const updated = await this.warmPoolService.updateSchedule(id, dto.scheduleConfig ?? null, dto.timezone)
+    const updated = await this.warmPoolService.updateSchedule(id, dto.scheduleConfig, dto.timezone)
     return AdminWarmPoolDto.fromEntity(updated)
   }
 }

--- a/apps/api/src/admin/controllers/warm-pool.controller.ts
+++ b/apps/api/src/admin/controllers/warm-pool.controller.ts
@@ -6,6 +6,9 @@ import { RequiredApiRole } from '../../common/decorators/required-role.decorator
 import { SystemRole } from '../../user/enums/system-role.enum'
 import { BoxWarmPoolService } from '../../box/services/box-warm-pool.service'
 import { AdminWarmPoolDto, UpdateWarmPoolScheduleDto } from '../dto/warm-pool.dto'
+import { Audit, TypedRequest } from '../../audit/decorators/audit.decorator'
+import { AuditAction } from '../../audit/enums/audit-action.enum'
+import { AuditTarget } from '../../audit/enums/audit-target.enum'
 
 @ApiTags('admin')
 @Controller('admin/warm-pools')
@@ -35,6 +38,17 @@ export class AdminWarmPoolController {
   @Patch(':id/schedule')
   @ApiOperation({ summary: 'Update warm pool schedule config', operationId: 'adminUpdateWarmPoolSchedule' })
   @ApiResponse({ status: 200, type: AdminWarmPoolDto })
+  @Audit({
+    action: AuditAction.UPDATE_SCHEDULING,
+    targetType: AuditTarget.WARM_POOL,
+    targetIdFromRequest: (req) => req.params.id,
+    requestMetadata: {
+      body: (req: TypedRequest<UpdateWarmPoolScheduleDto>) => ({
+        timezone: req.body?.timezone,
+        scheduleConfig: req.body?.scheduleConfig,
+      }),
+    },
+  })
   async updateSchedule(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() dto: UpdateWarmPoolScheduleDto,

--- a/apps/api/src/admin/dto/warm-pool.dto.ts
+++ b/apps/api/src/admin/dto/warm-pool.dto.ts
@@ -1,0 +1,83 @@
+import { ApiProperty, ApiSchema } from '@nestjs/swagger'
+import { Type } from 'class-transformer'
+import { IsArray, IsInt, IsOptional, IsString, Max, Min, ValidateNested } from 'class-validator'
+import { ScheduleConfig, ScheduleWindow, WarmPool } from '../../box/entities/warm-pool.entity'
+
+export class ScheduleWindowDto implements ScheduleWindow {
+  @ApiProperty({ description: '0=Sun..6=Sat; omit for every day', required: false, type: [Number] })
+  @IsArray()
+  @IsInt({ each: true })
+  @Min(0, { each: true })
+  @Max(6, { each: true })
+  @IsOptional()
+  days?: number[]
+
+  @ApiProperty({ description: 'Start hour (0-23); omit for all day', example: 8, required: false })
+  @IsInt()
+  @Min(0)
+  @Max(23)
+  @IsOptional()
+  startHour?: number
+
+  @ApiProperty({ description: 'End hour (0-23); wraps midnight if less than startHour; omit for all day', example: 22, required: false })
+  @IsInt()
+  @Min(0)
+  @Max(23)
+  @IsOptional()
+  endHour?: number
+
+  @ApiProperty({ description: 'Target pool size for this window', example: 20 })
+  @IsInt()
+  @Min(0)
+  pool: number
+}
+
+export class ScheduleConfigDto implements ScheduleConfig {
+  @ApiProperty({ type: [ScheduleWindowDto] })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => ScheduleWindowDto)
+  windows: ScheduleWindowDto[]
+}
+
+@ApiSchema({ name: 'AdminUpdateWarmPoolSchedule' })
+export class UpdateWarmPoolScheduleDto {
+  @ApiProperty({ type: ScheduleConfigDto, nullable: true, required: false })
+  @ValidateNested()
+  @Type(() => ScheduleConfigDto)
+  @IsOptional()
+  scheduleConfig: ScheduleConfigDto | null
+
+  @ApiProperty({ description: 'IANA timezone, e.g. Asia/Shanghai', example: 'UTC', default: 'UTC' })
+  @IsString()
+  timezone: string
+}
+
+@ApiSchema({ name: 'AdminWarmPool' })
+export class AdminWarmPoolDto {
+  @ApiProperty() id: string
+  @ApiProperty() image: string
+  @ApiProperty() target: string
+  @ApiProperty() pool: number
+  @ApiProperty() cpu: number
+  @ApiProperty() mem: number
+  @ApiProperty() disk: number
+  @ApiProperty() gpu: number
+  @ApiProperty({ nullable: true, type: ScheduleConfigDto }) scheduleConfig: ScheduleConfig | null
+  @ApiProperty() timezone: string
+
+  static fromEntity(e: WarmPool): AdminWarmPoolDto {
+    const dto = new AdminWarmPoolDto()
+    dto.id = e.id
+    dto.image = e.image
+    dto.target = e.target
+    dto.pool = e.pool
+    dto.cpu = e.cpu
+    dto.mem = e.mem
+    dto.disk = e.disk
+    dto.gpu = e.gpu
+    dto.scheduleConfig = e.scheduleConfig
+    dto.timezone = e.timezone
+    return dto
+  }
+}

--- a/apps/api/src/admin/dto/warm-pool.dto.ts
+++ b/apps/api/src/admin/dto/warm-pool.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty, ApiSchema } from '@nestjs/swagger'
 import { Type } from 'class-transformer'
-import { IsArray, IsInt, IsOptional, IsString, Max, Min, ValidateNested } from 'class-validator'
+import { IsArray, IsInt, IsOptional, IsString, IsTimeZone, Max, Min, ValidateNested } from 'class-validator'
 import { ScheduleConfig, ScheduleWindow, WarmPool } from '../../box/entities/warm-pool.entity'
 
 export class ScheduleWindowDto implements ScheduleWindow {
@@ -49,7 +49,7 @@ export class UpdateWarmPoolScheduleDto {
   scheduleConfig: ScheduleConfigDto | null
 
   @ApiProperty({ description: 'IANA timezone, e.g. Asia/Shanghai', example: 'UTC', default: 'UTC' })
-  @IsString()
+  @IsTimeZone()
   timezone: string
 }
 

--- a/apps/api/src/admin/dto/warm-pool.dto.ts
+++ b/apps/api/src/admin/dto/warm-pool.dto.ts
@@ -48,9 +48,14 @@ export class UpdateWarmPoolScheduleDto {
   @IsOptional()
   scheduleConfig: ScheduleConfigDto | null
 
-  @ApiProperty({ description: 'IANA timezone, e.g. Asia/Shanghai', example: 'UTC', default: 'UTC' })
+  @ApiProperty({
+    description: 'IANA timezone, e.g. Asia/Shanghai. Omit to leave the current timezone unchanged.',
+    example: 'UTC',
+    required: false,
+  })
   @IsTimeZone()
-  timezone: string
+  @IsOptional()
+  timezone?: string
 }
 
 @ApiSchema({ name: 'AdminWarmPool' })

--- a/apps/api/src/admin/dto/warm-pool.dto.ts
+++ b/apps/api/src/admin/dto/warm-pool.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty, ApiSchema } from '@nestjs/swagger'
 import { Type } from 'class-transformer'
-import { IsArray, IsInt, IsOptional, IsString, IsTimeZone, Max, Min, ValidateNested } from 'class-validator'
+import { IsArray, IsInt, IsOptional, IsTimeZone, Max, Min, ValidateNested } from 'class-validator'
 import { ScheduleConfig, ScheduleWindow, WarmPool } from '../../box/entities/warm-pool.entity'
 
 export class ScheduleWindowDto implements ScheduleWindow {

--- a/apps/api/src/audit/enums/audit-target.enum.ts
+++ b/apps/api/src/audit/enums/audit-target.enum.ts
@@ -16,4 +16,5 @@ export enum AuditTarget {
   VOLUME = 'volume',
   REGION = 'region',
   OBSERVABILITY = 'observability',
+  WARM_POOL = 'warm_pool',
 }

--- a/apps/api/src/box/box.module.ts
+++ b/apps/api/src/box/box.module.ts
@@ -95,6 +95,7 @@ import { BoxStateWaiterService } from './services/box-state-waiter.service'
   ],
   exports: [
     BoxService,
+    BoxWarmPoolService,
     RunnerService,
     RedisLockProvider,
     VolumeService,

--- a/apps/api/src/box/entities/warm-pool.entity.ts
+++ b/apps/api/src/box/entities/warm-pool.entity.ts
@@ -7,6 +7,17 @@
 import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm'
 import { BoxClass } from '../enums/box-class.enum'
 
+export interface ScheduleWindow {
+  days?: number[] // 0=Sun..6=Sat, omit = every day
+  startHour?: number // 0-23, omit = all day
+  endHour?: number // 0-23, wraps midnight if startHour > endHour
+  pool: number
+}
+
+export interface ScheduleConfig {
+  windows: ScheduleWindow[]
+}
+
 @Entity()
 @Index('warm_pool_find_idx', ['image', 'target', 'class', 'cpu', 'mem', 'disk', 'gpu', 'osUser', 'env'])
 export class WarmPool {
@@ -49,6 +60,12 @@ export class WarmPool {
 
   @Column({ nullable: true })
   errorReason?: string
+
+  @Column({ type: 'jsonb', nullable: true })
+  scheduleConfig: ScheduleConfig | null
+
+  @Column({ default: 'UTC' })
+  timezone: string
 
   @Column({
     type: 'simple-json',

--- a/apps/api/src/box/services/box-warm-pool.service.spec.ts
+++ b/apps/api/src/box/services/box-warm-pool.service.spec.ts
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { BoxWarmPoolService } from './box-warm-pool.service'
+import { WarmPoolEvents } from '../constants/warmpool-events.constants'
+import { WarmPoolTopUpRequested } from '../events/warmpool-topup-requested.event'
+import { BOX_WARM_POOL_UNASSIGNED_ORGANIZATION } from '../constants/box.constants'
+import { ScheduleConfig } from '../entities/warm-pool.entity'
+
+// A catch-all window (no days, no hours) always matches, so the resolved target
+// is independent of the wall clock — the branch under test stays deterministic
+// even though handleBoxOrganizationUpdated resolves against `new Date()`.
+const alwaysTarget = (pool: number): ScheduleConfig => ({ windows: [{ pool }] })
+
+function buildHarness(warmPool: unknown, boxCount: number) {
+  const warmPoolRepository = { findOne: jest.fn().mockResolvedValue(warmPool) }
+  const boxRepository = { count: jest.fn().mockResolvedValue(boxCount) }
+  const emit = jest.fn()
+  const service = new BoxWarmPoolService(
+    warmPoolRepository as never,
+    boxRepository as never,
+    {} as never, // runnerRepository
+    {} as never, // redisLockProvider
+    {} as never, // configService
+    { emit } as never, // eventEmitter
+    {} as never, // redis
+  )
+  return { service, emit }
+}
+
+const claimEvent = () =>
+  ({
+    newOrganizationId: 'org-real-tenant',
+    box: {
+      image: 'img',
+      class: 'small',
+      cpu: 1,
+      mem: 1,
+      disk: 10,
+      region: 'us',
+      env: {},
+      gpu: 0,
+      osUser: 'boxlite',
+    },
+  }) as never
+
+const warmPool = (over: Record<string, unknown>) => ({
+  id: 'wp-1',
+  pool: 2,
+  timezone: 'UTC',
+  scheduleConfig: null,
+  image: 'img',
+  class: 'small',
+  cpu: 1,
+  mem: 1,
+  disk: 10,
+  target: 'us',
+  env: {},
+  gpu: 0,
+  osUser: 'boxlite',
+  ...over,
+})
+
+describe('BoxWarmPoolService.handleBoxOrganizationUpdated', () => {
+  afterEach(() => jest.clearAllMocks())
+
+  it('tops up against the schedule target, not the static pool (the regression this guards)', async () => {
+    // Static pool = 2, schedule target = 5, current unassigned boxes = 3.
+    // Old code compared `pool(2) <= boxCount(3)` → returned without topping up.
+    // Schedule-aware code compares `target(5) <= boxCount(3)` → tops up.
+    const { service, emit } = buildHarness(warmPool({ pool: 2, scheduleConfig: alwaysTarget(5) }), 3)
+
+    await service.handleBoxOrganizationUpdated(claimEvent())
+
+    expect(emit).toHaveBeenCalledTimes(1)
+    expect(emit).toHaveBeenCalledWith(WarmPoolEvents.TOPUP_REQUESTED, expect.any(WarmPoolTopUpRequested))
+  })
+
+  it('does not top up when the schedule target is already met', async () => {
+    // Schedule target = 3, boxCount = 3 → at target, no top-up.
+    const { service, emit } = buildHarness(warmPool({ pool: 10, scheduleConfig: alwaysTarget(3) }), 3)
+
+    await service.handleBoxOrganizationUpdated(claimEvent())
+
+    expect(emit).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the static pool when no schedule is configured', async () => {
+    // scheduleConfig null → target is the static pool (4), boxCount 2 → top up.
+    const { service, emit } = buildHarness(warmPool({ pool: 4, scheduleConfig: null }), 2)
+
+    await service.handleBoxOrganizationUpdated(claimEvent())
+
+    expect(emit).toHaveBeenCalledTimes(1)
+    expect(emit).toHaveBeenCalledWith(WarmPoolEvents.TOPUP_REQUESTED, expect.any(WarmPoolTopUpRequested))
+  })
+
+  it('ignores boxes moving back into the unassigned warm-pool organization', async () => {
+    const { service, emit } = buildHarness(warmPool({ scheduleConfig: alwaysTarget(5) }), 0)
+    const event = { ...(claimEvent() as object), newOrganizationId: BOX_WARM_POOL_UNASSIGNED_ORGANIZATION } as never
+
+    await service.handleBoxOrganizationUpdated(event)
+
+    expect(emit).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when no matching warm pool exists', async () => {
+    const { service, emit } = buildHarness(null, 0)
+
+    await service.handleBoxOrganizationUpdated(claimEvent())
+
+    expect(emit).not.toHaveBeenCalled()
+  })
+})

--- a/apps/api/src/box/services/box-warm-pool.service.spec.ts
+++ b/apps/api/src/box/services/box-warm-pool.service.spec.ts
@@ -9,6 +9,8 @@ import { WarmPoolEvents } from '../constants/warmpool-events.constants'
 import { WarmPoolTopUpRequested } from '../events/warmpool-topup-requested.event'
 import { BOX_WARM_POOL_UNASSIGNED_ORGANIZATION } from '../constants/box.constants'
 import { ScheduleConfig } from '../entities/warm-pool.entity'
+import { BoxConflictError } from '../errors/box-conflict.error'
+import { BoxDesiredState } from '../enums/box-desired-state.enum'
 
 // A catch-all window (no days, no hours) always matches, so the resolved target
 // is independent of the wall clock — the branch under test stays deterministic
@@ -113,5 +115,133 @@ describe('BoxWarmPoolService.handleBoxOrganizationUpdated', () => {
     await service.handleBoxOrganizationUpdated(claimEvent())
 
     expect(emit).not.toHaveBeenCalled()
+  })
+})
+
+interface CheckHarnessOpts {
+  boxCount: number
+  scheduleConfig?: ScheduleConfig | null
+  pool?: number
+  candidates?: Array<{ id: string }>
+  lockableKey?: (key: string) => boolean
+  update?: jest.Mock
+  count?: jest.Mock
+}
+
+function buildCheckHarness(opts: CheckHarnessOpts) {
+  const item = warmPool({ pool: opts.pool ?? 2, scheduleConfig: opts.scheduleConfig ?? null })
+  const warmPoolRepository = { find: jest.fn().mockResolvedValue([item]) }
+  const count = opts.count ?? jest.fn().mockResolvedValue(opts.boxCount)
+  const boxRepository = {
+    count,
+    find: jest.fn().mockResolvedValue(opts.candidates ?? []),
+    update: opts.update ?? jest.fn().mockResolvedValue(undefined),
+  }
+  const lockableKey = opts.lockableKey ?? (() => true)
+  const lock = jest.fn(async (key: string) => lockableKey(key))
+  const unlock = jest.fn().mockResolvedValue(undefined)
+  const emitAsync = jest.fn().mockResolvedValue([])
+  const service = new BoxWarmPoolService(
+    warmPoolRepository as never,
+    boxRepository as never,
+    {} as never, // runnerRepository
+    { lock, unlock } as never, // redisLockProvider
+    {} as never, // configService
+    { emitAsync } as never, // eventEmitter
+    {} as never, // redis
+  )
+  return { service, boxRepository, emitAsync, lock, unlock }
+}
+
+describe('BoxWarmPoolService.warmPoolCheck', () => {
+  afterEach(() => jest.clearAllMocks())
+
+  it('emits one top-up per missing box when below the schedule target', async () => {
+    // target 5 (catch-all), boxCount 2 → missingCount 3.
+    const { service, emitAsync, boxRepository, unlock } = buildCheckHarness({
+      boxCount: 2,
+      scheduleConfig: alwaysTarget(5),
+    })
+
+    await service.warmPoolCheck()
+
+    expect(emitAsync).toHaveBeenCalledTimes(3)
+    expect(emitAsync).toHaveBeenCalledWith(WarmPoolEvents.TOPUP_REQUESTED, expect.any(WarmPoolTopUpRequested))
+    expect(boxRepository.update).not.toHaveBeenCalled()
+    expect(unlock).toHaveBeenCalledTimes(1) // outer tick lock released
+  })
+
+  it('destroys the excess boxes when above the schedule target', async () => {
+    // target 2, boxCount 5 → excessCount 3.
+    const candidates = [{ id: 'b1' }, { id: 'b2' }, { id: 'b3' }]
+    const { service, emitAsync, boxRepository } = buildCheckHarness({
+      boxCount: 5,
+      scheduleConfig: alwaysTarget(2),
+      candidates,
+    })
+
+    await service.warmPoolCheck()
+
+    expect(emitAsync).not.toHaveBeenCalled()
+    expect(boxRepository.update).toHaveBeenCalledTimes(3)
+    expect(boxRepository.update).toHaveBeenCalledWith('b2', {
+      updateData: { desiredState: BoxDesiredState.DESTROYED, pending: true },
+    })
+  })
+
+  it('skips a scale-down candidate that is locked by a concurrent claim', async () => {
+    const candidates = [{ id: 'b1' }, { id: 'b2' }]
+    const { service, boxRepository } = buildCheckHarness({
+      boxCount: 5,
+      scheduleConfig: alwaysTarget(3),
+      candidates,
+      lockableKey: (key) => key !== 'box-warm-pool-b2', // b2 is being claimed
+    })
+
+    await service.warmPoolCheck()
+
+    expect(boxRepository.update).toHaveBeenCalledTimes(1)
+    expect(boxRepository.update).toHaveBeenCalledWith('b1', expect.anything())
+  })
+
+  it('continues scale-down past a BoxConflictError instead of aborting the tick', async () => {
+    const candidates = [{ id: 'b1' }, { id: 'b2' }, { id: 'b3' }]
+    const update = jest.fn(async (id: string) => {
+      if (id === 'b2') throw new BoxConflictError() // raced with a claim/destroy
+    })
+    const { service } = buildCheckHarness({
+      boxCount: 5,
+      scheduleConfig: alwaysTarget(2),
+      candidates,
+      update,
+    })
+
+    // Must not reject (an unhandled rejection here would fire every ~10s cron tick).
+    await expect(service.warmPoolCheck()).resolves.toBeUndefined()
+    // b1 and b3 still destroyed despite b2 racing.
+    expect(update).toHaveBeenCalledTimes(3)
+  })
+
+  it('does no work and does not release a lock it never took when the tick lock is held', async () => {
+    const { service, boxRepository, emitAsync, unlock } = buildCheckHarness({
+      boxCount: 0,
+      scheduleConfig: alwaysTarget(5),
+      lockableKey: (key) => !key.startsWith('warm-pool-lock-'), // outer lock unavailable
+    })
+
+    await service.warmPoolCheck()
+
+    expect(boxRepository.count).not.toHaveBeenCalled()
+    expect(emitAsync).not.toHaveBeenCalled()
+    expect(unlock).not.toHaveBeenCalled()
+  })
+
+  it('releases the tick lock even when the box count query throws', async () => {
+    const count = jest.fn().mockRejectedValue(new Error('db down'))
+    const { service, unlock } = buildCheckHarness({ boxCount: 0, scheduleConfig: alwaysTarget(5), count })
+
+    await service.warmPoolCheck().catch(() => undefined)
+
+    expect(unlock).toHaveBeenCalledTimes(1) // finally ran despite the throw
   })
 })

--- a/apps/api/src/box/services/box-warm-pool.service.ts
+++ b/apps/api/src/box/services/box-warm-pool.service.ts
@@ -14,6 +14,7 @@ import { Box } from '../entities/box.entity'
 import { BOX_WARM_POOL_UNASSIGNED_ORGANIZATION } from '../constants/box.constants'
 import { ScheduleConfig, WarmPool } from '../entities/warm-pool.entity'
 import { resolveWarmPoolTarget } from './warm-pool-schedule'
+import { BoxConflictError } from '../errors/box-conflict.error'
 import { EventEmitter2, OnEvent } from '@nestjs/event-emitter'
 import { BoxEvents } from '../constants/box-events.constants'
 import { BoxOrganizationUpdatedEvent } from '../events/box-organization-updated.event'
@@ -247,9 +248,20 @@ export class BoxWarmPoolService {
               if (!(await this.redisLockProvider.lock(boxLockKey, 30))) {
                 continue // being claimed right now, skip
               }
-              await this.boxRepository.update(box.id, {
-                updateData: { desiredState: BoxDesiredState.DESTROYED, pending: true },
-              })
+              try {
+                await this.boxRepository.update(box.id, {
+                  updateData: { desiredState: BoxDesiredState.DESTROYED, pending: true },
+                })
+              } catch (error) {
+                // The box changed between our .find() snapshot and the update
+                // (claimed/destroyed under us). Skip it rather than abort the
+                // other candidates or reject the cron's Promise.all — matches
+                // the per-candidate handling in BoxManager's reconcile loop.
+                if (error instanceof BoxConflictError) {
+                  continue
+                }
+                throw error
+              }
             }
           }
         } finally {

--- a/apps/api/src/box/services/box-warm-pool.service.ts
+++ b/apps/api/src/box/services/box-warm-pool.service.ts
@@ -12,7 +12,7 @@ import { RedisLockProvider } from '../common/redis-lock.provider'
 import { BoxRepository } from '../repositories/box.repository'
 import { Box } from '../entities/box.entity'
 import { BOX_WARM_POOL_UNASSIGNED_ORGANIZATION } from '../constants/box.constants'
-import { WarmPool } from '../entities/warm-pool.entity'
+import { ScheduleConfig, ScheduleWindow, WarmPool } from '../entities/warm-pool.entity'
 import { EventEmitter2, OnEvent } from '@nestjs/event-emitter'
 import { BoxEvents } from '../constants/box-events.constants'
 import { BoxOrganizationUpdatedEvent } from '../events/box-organization-updated.event'
@@ -134,6 +134,47 @@ export class BoxWarmPoolService {
     return null
   }
 
+  async listWarmPools(): Promise<WarmPool[]> {
+    return this.warmPoolRepository.find()
+  }
+
+  async findWarmPool(id: string): Promise<WarmPool | null> {
+    return this.warmPoolRepository.findOne({ where: { id } })
+  }
+
+  async updateSchedule(
+    id: string,
+    scheduleConfig: ScheduleConfig | null,
+    timezone: string,
+  ): Promise<WarmPool> {
+    await this.warmPoolRepository.update(id, { scheduleConfig, timezone })
+    return this.warmPoolRepository.findOneOrFail({ where: { id } })
+  }
+
+  private computeTargetPoolSize(item: WarmPool): number {
+    if (!item.scheduleConfig) return item.pool
+
+    const tz = item.timezone ?? 'UTC'
+    const now = new Date()
+    const hour = parseInt(
+      new Intl.DateTimeFormat('en', { hour: 'numeric', hour12: false, timeZone: tz }).format(now),
+    )
+    const day = new Date(now.toLocaleString('en', { timeZone: tz })).getDay()
+
+    for (const w of (item.scheduleConfig as ScheduleConfig).windows) {
+      const dayMatch = !w.days || w.days.includes(day)
+      const hourMatch =
+        w.startHour == null || w.endHour == null
+          ? true // no hours specified = all day
+          : w.startHour <= w.endHour
+            ? hour >= w.startHour && hour < w.endHour
+            : hour >= w.startHour || hour < w.endHour // spans midnight
+      if (dayMatch && hourMatch) return w.pool
+    }
+
+    return item.pool
+  }
+
   //  todo: make frequency configurable or more efficient
   @Cron(CronExpression.EVERY_10_SECONDS, { name: 'warm-pool-check' })
   @LogExecution('warm-pool-check')
@@ -165,7 +206,8 @@ export class BoxWarmPoolService {
           },
         })
 
-        const missingCount = warmPoolItem.pool - boxCount
+        const target = this.computeTargetPoolSize(warmPoolItem)
+        const missingCount = target - boxCount
         if (missingCount > 0) {
           const promises = []
           this.logger.debug(`Creating ${missingCount} boxes for warm pool id ${warmPoolItem.id}`)
@@ -178,6 +220,40 @@ export class BoxWarmPoolService {
 
           // Wait for all promises to settle before releasing the lock. Otherwise, another worker could start creating boxes
           await Promise.allSettled(promises)
+        }
+
+        const excessCount = boxCount - target
+        if (excessCount > 0) {
+          const candidates = await this.boxRepository.find({
+            where: {
+              organizationId: BOX_WARM_POOL_UNASSIGNED_ORGANIZATION,
+              image: warmPoolItem.image,
+              class: warmPoolItem.class,
+              cpu: warmPoolItem.cpu,
+              mem: warmPoolItem.mem,
+              disk: warmPoolItem.disk,
+              gpu: warmPoolItem.gpu,
+              osUser: warmPoolItem.osUser,
+              env: warmPoolItem.env,
+              region: warmPoolItem.target,
+              state: BoxState.STARTED,
+              desiredState: BoxDesiredState.STARTED,
+            },
+            take: excessCount,
+          })
+
+          this.logger.debug(`Scaling down ${candidates.length} excess boxes for warm pool id ${warmPoolItem.id}`)
+
+          for (const box of candidates) {
+            const lockKey = `box-warm-pool-${box.id}`
+            if (!(await this.redisLockProvider.lock(lockKey, 30))) {
+              continue // being claimed right now, skip
+            }
+            await this.boxRepository.update(box.id, {
+              desiredState: BoxDesiredState.DESTROYED,
+              pending: true,
+            })
+          }
         }
 
         await this.redisLockProvider.unlock(lockKey)

--- a/apps/api/src/box/services/box-warm-pool.service.ts
+++ b/apps/api/src/box/services/box-warm-pool.service.ts
@@ -144,10 +144,14 @@ export class BoxWarmPoolService {
 
   async updateSchedule(
     id: string,
-    scheduleConfig: ScheduleConfig | null,
+    scheduleConfig: ScheduleConfig | null | undefined,
     timezone: string,
   ): Promise<WarmPool> {
-    await this.warmPoolRepository.update(id, { scheduleConfig, timezone })
+    const patch: Partial<WarmPool> = { timezone }
+    if (scheduleConfig !== undefined) {
+      patch.scheduleConfig = scheduleConfig
+    }
+    await this.warmPoolRepository.update(id, patch)
     return this.warmPoolRepository.findOneOrFail({ where: { id } })
   }
 
@@ -156,10 +160,15 @@ export class BoxWarmPoolService {
 
     const tz = item.timezone ?? 'UTC'
     const now = new Date()
-    const hour = parseInt(
-      new Intl.DateTimeFormat('en', { hour: 'numeric', hour12: false, timeZone: tz }).format(now),
-    )
-    const day = new Date(now.toLocaleString('en', { timeZone: tz })).getDay()
+    const parts = new Intl.DateTimeFormat('en', {
+      hour: 'numeric',
+      hour12: false,
+      weekday: 'short',
+      timeZone: tz,
+    }).formatToParts(now)
+    const hour = parseInt(parts.find((p) => p.type === 'hour')?.value ?? '0', 10) % 24
+    const weekday = parts.find((p) => p.type === 'weekday')?.value ?? 'Sun'
+    const day = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'].indexOf(weekday)
 
     for (const w of (item.scheduleConfig as ScheduleConfig).windows) {
       const dayMatch = !w.days || w.days.includes(day)
@@ -189,74 +198,76 @@ export class BoxWarmPoolService {
           return
         }
 
-        const boxCount = await this.boxRepository.count({
-          where: {
-            organizationId: BOX_WARM_POOL_UNASSIGNED_ORGANIZATION,
-            image: warmPoolItem.image,
-            class: warmPoolItem.class,
-            osUser: warmPoolItem.osUser,
-            env: warmPoolItem.env,
-            region: warmPoolItem.target,
-            cpu: warmPoolItem.cpu,
-            gpu: warmPoolItem.gpu,
-            mem: warmPoolItem.mem,
-            disk: warmPoolItem.disk,
-            desiredState: BoxDesiredState.STARTED,
-            state: Not(In([BoxState.ERROR])),
-          },
-        })
-
-        const target = this.computeTargetPoolSize(warmPoolItem)
-        const missingCount = target - boxCount
-        if (missingCount > 0) {
-          const promises = []
-          this.logger.debug(`Creating ${missingCount} boxes for warm pool id ${warmPoolItem.id}`)
-
-          for (let i = 0; i < missingCount; i++) {
-            promises.push(
-              this.eventEmitter.emitAsync(WarmPoolEvents.TOPUP_REQUESTED, new WarmPoolTopUpRequested(warmPoolItem)),
-            )
-          }
-
-          // Wait for all promises to settle before releasing the lock. Otherwise, another worker could start creating boxes
-          await Promise.allSettled(promises)
-        }
-
-        const excessCount = boxCount - target
-        if (excessCount > 0) {
-          const candidates = await this.boxRepository.find({
+        try {
+          const boxCount = await this.boxRepository.count({
             where: {
               organizationId: BOX_WARM_POOL_UNASSIGNED_ORGANIZATION,
               image: warmPoolItem.image,
               class: warmPoolItem.class,
-              cpu: warmPoolItem.cpu,
-              mem: warmPoolItem.mem,
-              disk: warmPoolItem.disk,
-              gpu: warmPoolItem.gpu,
               osUser: warmPoolItem.osUser,
               env: warmPoolItem.env,
               region: warmPoolItem.target,
-              state: BoxState.STARTED,
+              cpu: warmPoolItem.cpu,
+              gpu: warmPoolItem.gpu,
+              mem: warmPoolItem.mem,
+              disk: warmPoolItem.disk,
               desiredState: BoxDesiredState.STARTED,
+              state: Not(In([BoxState.ERROR])),
             },
-            take: excessCount,
           })
 
-          this.logger.debug(`Scaling down ${candidates.length} excess boxes for warm pool id ${warmPoolItem.id}`)
+          const target = this.computeTargetPoolSize(warmPoolItem)
+          const missingCount = target - boxCount
+          if (missingCount > 0) {
+            const promises = []
+            this.logger.debug(`Creating ${missingCount} boxes for warm pool id ${warmPoolItem.id}`)
 
-          for (const box of candidates) {
-            const lockKey = `box-warm-pool-${box.id}`
-            if (!(await this.redisLockProvider.lock(lockKey, 30))) {
-              continue // being claimed right now, skip
+            for (let i = 0; i < missingCount; i++) {
+              promises.push(
+                this.eventEmitter.emitAsync(WarmPoolEvents.TOPUP_REQUESTED, new WarmPoolTopUpRequested(warmPoolItem)),
+              )
             }
-            await this.boxRepository.update(box.id, {
-              desiredState: BoxDesiredState.DESTROYED,
-              pending: true,
-            })
-          }
-        }
 
-        await this.redisLockProvider.unlock(lockKey)
+            // Wait for all promises to settle before releasing the lock. Otherwise, another worker could start creating boxes
+            await Promise.allSettled(promises)
+          }
+
+          const excessCount = boxCount - target
+          if (excessCount > 0) {
+            const candidates = await this.boxRepository.find({
+              where: {
+                organizationId: BOX_WARM_POOL_UNASSIGNED_ORGANIZATION,
+                image: warmPoolItem.image,
+                class: warmPoolItem.class,
+                cpu: warmPoolItem.cpu,
+                mem: warmPoolItem.mem,
+                disk: warmPoolItem.disk,
+                gpu: warmPoolItem.gpu,
+                osUser: warmPoolItem.osUser,
+                env: warmPoolItem.env,
+                region: warmPoolItem.target,
+                state: BoxState.STARTED,
+                desiredState: BoxDesiredState.STARTED,
+              },
+              take: excessCount,
+            })
+
+            this.logger.debug(`Scaling down ${candidates.length} excess boxes for warm pool id ${warmPoolItem.id}`)
+
+            for (const box of candidates) {
+              const lockKey = `box-warm-pool-${box.id}`
+              if (!(await this.redisLockProvider.lock(lockKey, 30))) {
+                continue // being claimed right now, skip
+              }
+              await this.boxRepository.update(box.id, {
+                desiredState: BoxDesiredState.DESTROYED,
+                pending: true,
+              })
+            }
+          }
+        } finally {
+          await this.redisLockProvider.unlock(lockKey)
+        }
       }),
     )
   }

--- a/apps/api/src/box/services/box-warm-pool.service.ts
+++ b/apps/api/src/box/services/box-warm-pool.service.ts
@@ -12,7 +12,8 @@ import { RedisLockProvider } from '../common/redis-lock.provider'
 import { BoxRepository } from '../repositories/box.repository'
 import { Box } from '../entities/box.entity'
 import { BOX_WARM_POOL_UNASSIGNED_ORGANIZATION } from '../constants/box.constants'
-import { ScheduleConfig, ScheduleWindow, WarmPool } from '../entities/warm-pool.entity'
+import { ScheduleConfig, WarmPool } from '../entities/warm-pool.entity'
+import { resolveWarmPoolTarget } from './warm-pool-schedule'
 import { EventEmitter2, OnEvent } from '@nestjs/event-emitter'
 import { BoxEvents } from '../constants/box-events.constants'
 import { BoxOrganizationUpdatedEvent } from '../events/box-organization-updated.event'
@@ -145,43 +146,25 @@ export class BoxWarmPoolService {
   async updateSchedule(
     id: string,
     scheduleConfig: ScheduleConfig | null | undefined,
-    timezone: string,
+    timezone: string | undefined,
   ): Promise<WarmPool> {
-    const patch: Partial<WarmPool> = { timezone }
+    // Both fields are independently optional: omitting one leaves it unchanged,
+    // so a caller can retune the schedule without restating the timezone.
+    const patch: Partial<WarmPool> = {}
     if (scheduleConfig !== undefined) {
       patch.scheduleConfig = scheduleConfig
     }
-    await this.warmPoolRepository.update(id, patch)
+    if (timezone !== undefined) {
+      patch.timezone = timezone
+    }
+    if (Object.keys(patch).length > 0) {
+      await this.warmPoolRepository.update(id, patch)
+    }
     return this.warmPoolRepository.findOneOrFail({ where: { id } })
   }
 
   private computeTargetPoolSize(item: WarmPool): number {
-    if (!item.scheduleConfig) return item.pool
-
-    const tz = item.timezone ?? 'UTC'
-    const now = new Date()
-    const parts = new Intl.DateTimeFormat('en', {
-      hour: 'numeric',
-      hour12: false,
-      weekday: 'short',
-      timeZone: tz,
-    }).formatToParts(now)
-    const hour = parseInt(parts.find((p) => p.type === 'hour')?.value ?? '0', 10) % 24
-    const weekday = parts.find((p) => p.type === 'weekday')?.value ?? 'Sun'
-    const day = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'].indexOf(weekday)
-
-    for (const w of (item.scheduleConfig as ScheduleConfig).windows) {
-      const dayMatch = !w.days || w.days.includes(day)
-      const hourMatch =
-        w.startHour == null || w.endHour == null
-          ? true // no hours specified = all day
-          : w.startHour <= w.endHour
-            ? hour >= w.startHour && hour < w.endHour
-            : hour >= w.startHour || hour < w.endHour // spans midnight
-      if (dayMatch && hourMatch) return w.pool
-    }
-
-    return item.pool
+    return resolveWarmPoolTarget(item.scheduleConfig, item.timezone, item.pool, new Date())
   }
 
   //  todo: make frequency configurable or more efficient
@@ -255,13 +238,17 @@ export class BoxWarmPoolService {
             this.logger.debug(`Scaling down ${candidates.length} excess boxes for warm pool id ${warmPoolItem.id}`)
 
             for (const box of candidates) {
-              const lockKey = `box-warm-pool-${box.id}`
-              if (!(await this.redisLockProvider.lock(lockKey, 30))) {
+              // Distinct name from the outer warm-pool tick lock (`lockKey`) to
+              // avoid shadowing. Held for its full 30s TTL (not released here):
+              // that window blocks a concurrent user claim from grabbing a box
+              // we've just marked for destruction. Same key `fetchWarmPoolBox`
+              // uses, so claim and scale-down are mutually exclusive.
+              const boxLockKey = `box-warm-pool-${box.id}`
+              if (!(await this.redisLockProvider.lock(boxLockKey, 30))) {
                 continue // being claimed right now, skip
               }
               await this.boxRepository.update(box.id, {
-                desiredState: BoxDesiredState.DESTROYED,
-                pending: true,
+                updateData: { desiredState: BoxDesiredState.DESTROYED, pending: true },
               })
             }
           }

--- a/apps/api/src/box/services/box-warm-pool.service.ts
+++ b/apps/api/src/box/services/box-warm-pool.service.ts
@@ -299,12 +299,15 @@ export class BoxWarmPoolService {
       },
     })
 
-    if (warmPoolItem.pool <= boxCount) {
+    // Use the schedule-aware target, matching warmPoolCheck(). Comparing against
+    // the static pool here would fight the cron: when a schedule window sets a
+    // higher/lower target, the claim fast-path would top up to the wrong size and
+    // churn against scale-up/scale-down on the next tick.
+    const target = this.computeTargetPoolSize(warmPoolItem)
+    if (target <= boxCount) {
       return
     }
 
-    if (warmPoolItem) {
-      this.eventEmitter.emit(WarmPoolEvents.TOPUP_REQUESTED, new WarmPoolTopUpRequested(warmPoolItem))
-    }
+    this.eventEmitter.emit(WarmPoolEvents.TOPUP_REQUESTED, new WarmPoolTopUpRequested(warmPoolItem))
   }
 }

--- a/apps/api/src/box/services/warm-pool-schedule.spec.ts
+++ b/apps/api/src/box/services/warm-pool-schedule.spec.ts
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { ScheduleConfig } from '../entities/warm-pool.entity'
+import { resolveWarmPoolTarget } from './warm-pool-schedule'
+
+// Helper: a fixed instant expressed in UTC. Each test picks an instant whose
+// LOCAL hour/weekday (in the schedule's timezone) is what we want to exercise.
+const at = (iso: string) => new Date(iso)
+
+describe('resolveWarmPoolTarget', () => {
+  it('returns the static pool when no schedule is configured', () => {
+    expect(resolveWarmPoolTarget(null, 'UTC', 7, at('2026-07-08T12:00:00Z'))).toBe(7)
+    expect(resolveWarmPoolTarget(undefined, 'UTC', 3, at('2026-07-08T12:00:00Z'))).toBe(3)
+  })
+
+  it('falls back to the static pool when no window matches', () => {
+    // Window only covers Mon–Fri 09–18; the instant below is a Wednesday 20:00 UTC.
+    const cfg: ScheduleConfig = { windows: [{ days: [1, 2, 3, 4, 5], startHour: 9, endHour: 18, pool: 10 }] }
+    expect(resolveWarmPoolTarget(cfg, 'UTC', 1, at('2026-07-08T20:00:00Z'))).toBe(1)
+  })
+
+  it('matches a weekday business-hours window', () => {
+    // 2026-07-08 is a Wednesday. 14:00 UTC is inside 09–18.
+    const cfg: ScheduleConfig = { windows: [{ days: [1, 2, 3, 4, 5], startHour: 9, endHour: 18, pool: 10 }] }
+    expect(resolveWarmPoolTarget(cfg, 'UTC', 1, at('2026-07-08T14:00:00Z'))).toBe(10)
+  })
+
+  it('uses the first matching window (order wins) and a trailing catch-all', () => {
+    const cfg: ScheduleConfig = {
+      windows: [
+        { days: [1, 2, 3, 4, 5], startHour: 9, endHour: 18, pool: 10 },
+        { pool: 2 }, // catch-all: no days, no hours → always matches
+      ],
+    }
+    // Wednesday 14:00 → first window
+    expect(resolveWarmPoolTarget(cfg, 'UTC', 0, at('2026-07-08T14:00:00Z'))).toBe(10)
+    // Wednesday 23:00 → outside first, falls to catch-all
+    expect(resolveWarmPoolTarget(cfg, 'UTC', 0, at('2026-07-08T23:00:00Z'))).toBe(2)
+    // Sunday 14:00 → day excludes first window, catch-all applies
+    expect(resolveWarmPoolTarget(cfg, 'UTC', 0, at('2026-07-05T14:00:00Z'))).toBe(2)
+  })
+
+  describe('midnight-wrapping window (startHour > endHour)', () => {
+    // "Overnight" window 22:00–06:00 every day.
+    const cfg: ScheduleConfig = { windows: [{ startHour: 22, endHour: 6, pool: 4 }] }
+
+    it('matches after startHour (late night)', () => {
+      expect(resolveWarmPoolTarget(cfg, 'UTC', 1, at('2026-07-08T23:30:00Z'))).toBe(4)
+    })
+
+    it('matches before endHour (early morning)', () => {
+      expect(resolveWarmPoolTarget(cfg, 'UTC', 1, at('2026-07-08T03:00:00Z'))).toBe(4)
+    })
+
+    it('does not match the daytime gap', () => {
+      expect(resolveWarmPoolTarget(cfg, 'UTC', 1, at('2026-07-08T12:00:00Z'))).toBe(1)
+    })
+
+    it('matches exactly at startHour but not at endHour (half-open interval)', () => {
+      expect(resolveWarmPoolTarget(cfg, 'UTC', 1, at('2026-07-08T22:00:00Z'))).toBe(4) // >= 22
+      expect(resolveWarmPoolTarget(cfg, 'UTC', 1, at('2026-07-08T06:00:00Z'))).toBe(1) // < 6 is exclusive
+    })
+  })
+
+  it('treats a window without hours as all-day', () => {
+    const cfg: ScheduleConfig = { windows: [{ days: [3], pool: 5 }] } // Wednesdays, any hour
+    expect(resolveWarmPoolTarget(cfg, 'UTC', 1, at('2026-07-08T03:00:00Z'))).toBe(5)
+    expect(resolveWarmPoolTarget(cfg, 'UTC', 1, at('2026-07-08T21:00:00Z'))).toBe(5)
+    // Thursday → no match → static
+    expect(resolveWarmPoolTarget(cfg, 'UTC', 1, at('2026-07-09T03:00:00Z'))).toBe(1)
+  })
+
+  it('normalises the midnight hour (Intl "24" guard) so 00:00 matches a window starting at 0', () => {
+    const cfg: ScheduleConfig = { windows: [{ startHour: 0, endHour: 6, pool: 8 }] }
+    // 00:00 UTC — the % 24 guard maps a possible "24" to 0, which is >= 0 and < 6.
+    expect(resolveWarmPoolTarget(cfg, 'UTC', 1, at('2026-07-08T00:00:00Z'))).toBe(8)
+  })
+
+  describe('timezone awareness', () => {
+    // Same UTC instant resolves to different local hours → different windows.
+    const cfg: ScheduleConfig = { windows: [{ startHour: 9, endHour: 18, pool: 10 }, { pool: 1 }] }
+
+    it('is inside business hours in Asia/Shanghai but outside in UTC for the same instant', () => {
+      // 02:00 UTC == 10:00 Asia/Shanghai (UTC+8).
+      const instant = at('2026-07-08T02:00:00Z')
+      expect(resolveWarmPoolTarget(cfg, 'Asia/Shanghai', 0, instant)).toBe(10) // 10:00 local → in window
+      expect(resolveWarmPoolTarget(cfg, 'UTC', 0, instant)).toBe(1) // 02:00 UTC → catch-all
+    })
+
+    it('shifts the local weekday across the date line', () => {
+      // 2026-07-08 22:00 UTC is still Wednesday in UTC but already Thursday in Asia/Shanghai (06:00 Thu).
+      const cfgDay: ScheduleConfig = { windows: [{ days: [4], pool: 9 }] } // Thursdays only
+      const instant = at('2026-07-08T22:00:00Z')
+      expect(resolveWarmPoolTarget(cfgDay, 'Asia/Shanghai', 1, instant)).toBe(9) // Thu locally
+      expect(resolveWarmPoolTarget(cfgDay, 'UTC', 1, instant)).toBe(1) // Wed in UTC → no match
+    })
+
+    it('respects US Eastern DST (summer offset is UTC-4)', () => {
+      // 2026-07-08 is during EDT (UTC-4). 13:00 UTC == 09:00 America/New_York.
+      const instant = at('2026-07-08T13:00:00Z')
+      expect(resolveWarmPoolTarget(cfg, 'America/New_York', 0, instant)).toBe(10) // 09:00 local → in window
+    })
+
+    it('defaults to UTC when timezone is null/undefined', () => {
+      const instant = at('2026-07-08T14:00:00Z')
+      expect(resolveWarmPoolTarget(cfg, null, 0, instant)).toBe(10)
+      expect(resolveWarmPoolTarget(cfg, undefined, 0, instant)).toBe(10)
+    })
+  })
+})

--- a/apps/api/src/box/services/warm-pool-schedule.ts
+++ b/apps/api/src/box/services/warm-pool-schedule.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { ScheduleConfig } from '../entities/warm-pool.entity'
+
+const WEEKDAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'] as const
+
+/**
+ * Resolve the target warm-pool size for a given instant.
+ *
+ * Pure and clock-injected (`now`) so the branchy schedule logic — timezone
+ * conversion, midnight-wrap, first-match, day matching, all-day fallback — is
+ * deterministically testable without a real clock or DB.
+ *
+ * - `scheduleConfig` null/undefined → the static `staticPool` value (backward compatible).
+ * - Windows are evaluated in order; first match wins.
+ * - A window without `days` matches every day; without `startHour`/`endHour`
+ *   matches every hour. `startHour > endHour` wraps past midnight.
+ * - No window matches → fall back to `staticPool`.
+ *
+ * @param timezone IANA timezone used to derive the local hour/weekday (defaults to UTC).
+ */
+export function resolveWarmPoolTarget(
+  scheduleConfig: ScheduleConfig | null | undefined,
+  timezone: string | null | undefined,
+  staticPool: number,
+  now: Date,
+): number {
+  if (!scheduleConfig) return staticPool
+
+  const tz = timezone ?? 'UTC'
+  const parts = new Intl.DateTimeFormat('en', {
+    hour: 'numeric',
+    hour12: false,
+    weekday: 'short',
+    timeZone: tz,
+  }).formatToParts(now)
+
+  // Intl can emit "24" for midnight under hour12:false; normalise to 0-23.
+  const hour = parseInt(parts.find((p) => p.type === 'hour')?.value ?? '0', 10) % 24
+  const weekday = parts.find((p) => p.type === 'weekday')?.value ?? 'Sun'
+  const day = WEEKDAYS.indexOf(weekday as (typeof WEEKDAYS)[number])
+
+  for (const w of scheduleConfig.windows) {
+    const dayMatch = !w.days || w.days.includes(day)
+    const hourMatch =
+      w.startHour == null || w.endHour == null
+        ? true // no hours specified = all day
+        : w.startHour <= w.endHour
+          ? hour >= w.startHour && hour < w.endHour
+          : hour >= w.startHour || hour < w.endHour // spans midnight
+    if (dayMatch && hourMatch) return w.pool
+  }
+
+  return staticPool
+}

--- a/apps/api/src/migrations/pre-deploy/1783425318065-migration.ts
+++ b/apps/api/src/migrations/pre-deploy/1783425318065-migration.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class WarmPoolSchedule1783425318065 implements MigrationInterface {
+  name = 'WarmPoolSchedule1783425318065'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "warm_pool" ADD "scheduleConfig" jsonb`)
+    await queryRunner.query(`ALTER TABLE "warm_pool" ADD "timezone" character varying NOT NULL DEFAULT 'UTC'`)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "warm_pool" DROP COLUMN "timezone"`)
+    await queryRunner.query(`ALTER TABLE "warm_pool" DROP COLUMN "scheduleConfig"`)
+  }
+}


### PR DESCRIPTION
## Summary

Warm pool sizes are currently static — the same number of pre-started VMs is maintained 24/7 regardless of actual demand. This PR adds **schedule-based pool sizing**: operators can configure time-window rules (by hour and day of week, in any IANA timezone) so the pool automatically scales up before peak hours and scales down overnight, without manual intervention.

## Design

### Data model

Two columns added to `warm_pool` via a pre-deploy migration:

| Column | Type | Purpose |
|---|---|---|
| `scheduleConfig` | `jsonb` (nullable) | Array of time windows, each with optional `days`, `startHour`, `endHour`, and a target `pool` size |
| `timezone` | `varchar` (default `'UTC'`) | IANA timezone for evaluating window boundaries |

`scheduleConfig = null` is backward-compatible — existing records continue to use the static `pool` value unchanged.

Example schedule:
```json
{
  "windows": [
    { "days": [1,2,3,4,5], "startHour": 9, "endHour": 18, "pool": 10 },
    { "pool": 2 }
  ]
}
```

Windows are evaluated in order; first match wins. A window without `days` matches every day; one without `startHour`/`endHour` matches all hours. Midnight-wrap (`startHour > endHour`) is handled correctly.

### Scale-up

`warmPoolCheck()` (every 10 s) now calls `computeTargetPoolSize()` instead of reading `item.pool` directly. Scale-up logic is otherwise unchanged.

### Scale-down

A new scale-down path runs in the same tick after scale-up. When `boxCount > target`, it selects up to `excessCount` STARTED boxes and marks them `desiredState = DESTROYED`. Each box is guarded by the same per-box Redis lock (`box-warm-pool-<id>`, TTL 30 s) that `fetchWarmPoolBox()` uses — a box being claimed by a user at the same moment is skipped rather than destroyed.

### Admin API

Three new endpoints under `/api/admin/warm-pools`, all requiring `SystemRole.ADMIN`:

| Method | Path | Description |
|---|---|---|
| GET | `/admin/warm-pools` | List all warm pool configurations |
| GET | `/admin/warm-pools/:id` | Get a single warm pool config |
| PATCH | `/admin/warm-pools/:id/schedule` | Update `scheduleConfig` and `timezone` |

### Live configuration

`warmPoolCheck()` reads the DB on every tick (no caching), so a schedule change takes effect within 10 seconds of the PATCH — no restart required.

## Known issue: warm pool job INSERT hangs in local dev

When `pool > 0` in a local dev environment, `warmPoolCheck()` triggers box creation jobs. The local runner cannot execute BoxLite VM jobs — it lacks the KVM/libkrun virtualisation layer that only exists in cloud EC2 environments. The `INSERT INTO job` transactions never commit; with TypeORM's default pool of 10 connections, all slots are consumed within one check cycle, making the API unresponsive.

**Root cause:** no timeout or failure-detection path exists for jobs that are never picked up by a capable runner. The INSERT transaction stays open indefinitely.

**Workaround:** keep `warm_pool.pool = 0` in local dev. This is tracked as a follow-up — the job table needs a pick-up timeout so stale pending jobs are automatically marked failed and their transactions rolled back.

## Test plan

- [ ] Migration runs cleanly on a fresh DB
- [ ] `GET /admin/warm-pools` returns records with `scheduleConfig` and `timezone`
- [ ] `PATCH /admin/warm-pools/:id/schedule` with a valid schedule; next `warmPoolCheck` tick uses the new target
- [ ] PATCH with `scheduleConfig: null` reverts to static pool value
- [ ] Window without `days`/`startHour`/`endHour` validates and matches correctly (all-day every-day rule)
- [ ] Midnight-spanning window (`startHour: 22, endHour: 6`) matches correctly on both sides
- [ ] Non-admin key receives 403 on all three endpoints
- [ ] Scale-down: reduce target below current count → excess boxes transition to DESTROYED within 10 s

---

## Summary by CodeRabbit

**New Features**
- Added admin support for viewing and updating warm pool schedules.
- Warm pools can now use time-based scheduling with timezone awareness.
- Warm pool sizing can now scale up or down automatically based on the active schedule.

**Bug Fixes**
- Improved handling for schedules that cross midnight.
- Missing warm pool entries now return clear not-found responses in admin views.

**Chores**
- Added database support for storing warm pool schedule settings and timezone data.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added admin APIs to list warm pools and update warm-pool scheduling, including timezone support.
  * Warm pools can now compute target capacity from timezone-aware scheduling windows (including windows spanning midnight).
* **Bug Fixes**
  * Improved warm-pool processing to always release locks and handle missing warm pools safely.
  * Updated top-up and surplus handling to use the schedule-derived target.
* **Chores**
  * Added database persistence for warm-pool schedule configuration and timezone.
* **Tests**
  * Added coverage for warm-pool schedule resolution and schedule-aware warm-pool update behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Changes since review

**Round 1 (CodeRabbit):**
- Fix Redis lock leak in warmPoolCheck: wrapped the per-item body in try/finally so the 720 s lock is always released even when computeTargetPoolSize throws (e.g. invalid timezone) or a DB call fails. Previously any exception would silently block scale-up/down for 12 minutes.
- Fix midnight/weekday edge case in computeTargetPoolSize: replaced Intl.DateTimeFormat(...).format() + toLocaleString round-trips with formatToParts(), reading hour and weekday directly from the parts array. The old code could return hour = 24 at midnight (skipping hour-0 windows) and produce wrong day-of-week values on some platforms.
- Fix PATCH endpoint silently clearing scheduleConfig: changed dto.scheduleConfig ?? null to a plain pass-through of dto.scheduleConfig (which is undefined when omitted). The service now only writes the field when it is explicitly present in the request body, so PATCH { "timezone": "..." } no longer wipes out an existing schedule.

**Round 2 (follow-up code review + BoxLite agent review):**
- Fix scale-down being a silent no-op. The scale-down path called boxRepository.update(id, { desiredState, pending }), but that repository's update() takes { updateData } — so the payload was dropped at runtime and excess boxes were never actually marked for destruction. Wrapped the fields in updateData. (Latent because scale-down was never exercised locally with pool > 0.)
- Tolerate BoxConflictError during scale-down. boxRepository.update() runs an optimistic check and throws BoxConflictError when a box changed since the .find() snapshot (a concurrent claim/destroy). The loop had no try/catch, so one lost race aborted the remaining candidates and rejected warmPoolCheck's Promise.all — an unhandled rejection on every ~10 s cron tick under contention. Now caught per-candidate with continue (other errors rethrow), matching BoxManager's reconcile loop.
- Honor the schedule on the box-claim fast-path. handleBoxOrganizationUpdated compared the unassigned-box count against the static pool instead of the schedule-aware target, so while a schedule window was active the claim-triggered top-up fought the 10 s warmPoolCheck cron and churned boxes up/down. It now uses computeTargetPoolSize, consistent with the cron.
- Audit the admin schedule endpoint. PATCH /admin/warm-pools/:id/schedule had no @Audit decorator, so schedule changes were invisible to the audit trail (the AuditInterceptor no-ops without it) — unlike every other admin write. Added @Audit(UPDATE_SCHEDULING) and a new WARM_POOL audit target. Read endpoints stay unaudited, matching sibling admin controllers.
- Make timezone independently optional on PATCH. Omitting timezone now leaves the stored value unchanged (previously it was always overwritten), so a caller can retune only the schedule or only the timezone — complementing the Round 1 fix that stopped an omitted scheduleConfig from wiping the existing schedule.
- Extract and unit-test the schedule logic. Moved the time-window resolution out of the private computeTargetPoolSize into a pure, clock-injected resolveWarmPoolTarget(), and added coverage where there was none: 14 tests for the resolver (timezone, midnight-wrap half-open intervals, DST, first-match ordering, all-day, midnight-hour normalisation), 5 for the claim fast-path top-up decision, and 6 for the warmPoolCheck cron path (scale-up count, scale-down destroy, skip a concurrently-claimed candidate, tolerate a BoxConflictError, no-op when the tick lock is held, release the lock even when a query throws). Behavioural fixes were verified by reverting the fix and confirming the guard test fails.
- Cleanup. Removed an unused IsString import flagged by eslint.