### PR TITLE
fix(warm-pool): prevent job hang when no capable runner is available

### DIFF
--- a/apps/api/src/box/services/box-warm-pool.service.ts
+++ b/apps/api/src/box/services/box-warm-pool.service.ts
@@ -7,7 +7,7 @@
 import { Inject, Injectable, Logger } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
 import { Cron, CronExpression } from '@nestjs/schedule'
-import { In, MoreThan, Not, Repository } from 'typeorm'
+import { In, MoreThan, MoreThanOrEqual, Not, Repository } from 'typeorm'
 import { RedisLockProvider } from '../common/redis-lock.provider'
 import { BoxRepository } from '../repositories/box.repository'
 import { Box } from '../entities/box.entity'
@@ -19,6 +19,7 @@ import { BoxOrganizationUpdatedEvent } from '../events/box-organization-updated.
 import { ConfigService } from '@nestjs/config'
 import { BoxClass } from '../enums/box-class.enum'
 import { BoxState } from '../enums/box-state.enum'
+import { RunnerState } from '../enums/runner-state.enum'
 import { Runner } from '../entities/runner.entity'
 import { WarmPoolTopUpRequested } from '../events/warmpool-topup-requested.event'
 import { WarmPoolEvents } from '../constants/warmpool-events.constants'
@@ -167,6 +168,24 @@ export class BoxWarmPoolService {
 
         const missingCount = warmPoolItem.pool - boxCount
         if (missingCount > 0) {
+          const availabilityScoreThreshold = this.configService.getOrThrow<number>('runnerScore.thresholds.availability')
+          const availableRunnerCount = await this.runnerRepository.count({
+            where: {
+              region: warmPoolItem.target,
+              state: RunnerState.READY,
+              unschedulable: Not(true),
+              draining: Not(true),
+              availabilityScore: MoreThanOrEqual(availabilityScoreThreshold),
+            },
+          })
+          if (availableRunnerCount === 0) {
+            this.logger.debug(
+              `Skipping warm pool top-up for ${warmPoolItem.id}: no available runners in region ${warmPoolItem.target}`,
+            )
+            await this.redisLockProvider.unlock(lockKey)
+            return
+          }
+
           const promises = []
           this.logger.debug(`Creating ${missingCount} boxes for warm pool id ${warmPoolItem.id}`)
 
@@ -229,8 +248,23 @@ export class BoxWarmPoolService {
       return
     }
 
-    if (warmPoolItem) {
-      this.eventEmitter.emit(WarmPoolEvents.TOPUP_REQUESTED, new WarmPoolTopUpRequested(warmPoolItem))
+    const availabilityScoreThreshold = this.configService.getOrThrow<number>('runnerScore.thresholds.availability')
+    const availableRunnerCount = await this.runnerRepository.count({
+      where: {
+        region: warmPoolItem.target,
+        state: RunnerState.READY,
+        unschedulable: Not(true),
+        draining: Not(true),
+        availabilityScore: MoreThanOrEqual(availabilityScoreThreshold),
+      },
+    })
+    if (availableRunnerCount === 0) {
+      this.logger.debug(
+        `Skipping warm pool top-up for ${warmPoolItem.id}: no available runners in region ${warmPoolItem.target}`,
+      )
+      return
     }
+
+    this.eventEmitter.emit(WarmPoolEvents.TOPUP_REQUESTED, new WarmPoolTopUpRequested(warmPoolItem))
   }
 }

--- a/apps/api/src/box/services/box-warm-pool.service.ts
+++ b/apps/api/src/box/services/box-warm-pool.service.ts
@@ -135,6 +135,20 @@ export class BoxWarmPoolService {
     return null
   }
 
+  private async hasAvailableRunnerForRegion(region: string): Promise<boolean> {
+    const availabilityScoreThreshold = this.configService.getOrThrow<number>('runnerScore.thresholds.availability')
+    const count = await this.runnerRepository.count({
+      where: {
+        region,
+        state: RunnerState.READY,
+        unschedulable: Not(true),
+        draining: Not(true),
+        availabilityScore: MoreThanOrEqual(availabilityScoreThreshold),
+      },
+    })
+    return count > 0
+  }
+
   //  todo: make frequency configurable or more efficient
   @Cron(CronExpression.EVERY_10_SECONDS, { name: 'warm-pool-check' })
   @LogExecution('warm-pool-check')
@@ -168,17 +182,7 @@ export class BoxWarmPoolService {
 
         const missingCount = warmPoolItem.pool - boxCount
         if (missingCount > 0) {
-          const availabilityScoreThreshold = this.configService.getOrThrow<number>('runnerScore.thresholds.availability')
-          const availableRunnerCount = await this.runnerRepository.count({
-            where: {
-              region: warmPoolItem.target,
-              state: RunnerState.READY,
-              unschedulable: Not(true),
-              draining: Not(true),
-              availabilityScore: MoreThanOrEqual(availabilityScoreThreshold),
-            },
-          })
-          if (availableRunnerCount === 0) {
+          if (!(await this.hasAvailableRunnerForRegion(warmPoolItem.target))) {
             this.logger.debug(
               `Skipping warm pool top-up for ${warmPoolItem.id}: no available runners in region ${warmPoolItem.target}`,
             )
@@ -248,17 +252,7 @@ export class BoxWarmPoolService {
       return
     }
 
-    const availabilityScoreThreshold = this.configService.getOrThrow<number>('runnerScore.thresholds.availability')
-    const availableRunnerCount = await this.runnerRepository.count({
-      where: {
-        region: warmPoolItem.target,
-        state: RunnerState.READY,
-        unschedulable: Not(true),
-        draining: Not(true),
-        availabilityScore: MoreThanOrEqual(availabilityScoreThreshold),
-      },
-    })
-    if (availableRunnerCount === 0) {
+    if (!(await this.hasAvailableRunnerForRegion(warmPoolItem.target))) {
       this.logger.debug(
         `Skipping warm pool top-up for ${warmPoolItem.id}: no available runners in region ${warmPoolItem.target}`,
       )

--- a/apps/api/src/box/services/job.service.ts
+++ b/apps/api/src/box/services/job.service.ts
@@ -30,6 +30,11 @@ const JOB_STALE_TIMEOUT_MINUTES: Partial<Record<JobType, number>> = {
   [JobType.PULL_ARTIFACT]: 120,
 }
 
+// A PENDING job that has not been claimed within this window will never be
+// claimed — the runner was incapable, lost, or never existed (e.g. local dev).
+// Expire it so the DB connection holding the transaction is released.
+const PENDING_STALE_TIMEOUT_MINUTES = 5
+
 @Injectable()
 export class JobService {
   private readonly logger = new Logger(JobService.name)
@@ -441,6 +446,30 @@ export class JobService {
           } catch (error) {
             this.logger.error(`Error marking job ${job.id} as failed: ${error.message}`, error.stack)
           }
+        }
+      }
+      // Expire PENDING jobs that were never claimed by any runner.
+      const pendingThreshold = new Date(Date.now() - PENDING_STALE_TIMEOUT_MINUTES * 60 * 1000)
+      const stalePendingJobs = await this.jobRepository.find({
+        where: {
+          status: JobStatus.PENDING,
+          createdAt: LessThan(pendingThreshold),
+        },
+        take: 500,
+      })
+
+      for (const job of stalePendingJobs) {
+        try {
+          await this.updateJobStatus(
+            job.id,
+            JobStatus.FAILED,
+            `Job expired — not claimed by any runner within ${PENDING_STALE_TIMEOUT_MINUTES} minutes`,
+          )
+          this.logger.warn(
+            `Expired pending job ${job.id} (type: ${job.type}, resource: ${job.resourceType} ${job.resourceId})`,
+          )
+        } catch (error) {
+          this.logger.error(`Error expiring pending job ${job.id}: ${error.message}`, error.stack)
         }
       }
     } catch (error) {

--- a/apps/api/src/box/services/job.service.ts
+++ b/apps/api/src/box/services/job.service.ts
@@ -460,14 +460,26 @@ export class JobService {
 
       for (const job of stalePendingJobs) {
         try {
-          await this.updateJobStatus(
-            job.id,
-            JobStatus.FAILED,
-            `Job expired — not claimed by any runner within ${PENDING_STALE_TIMEOUT_MINUTES} minutes`,
+          const errorMessage = `Job expired — not claimed by any runner within ${PENDING_STALE_TIMEOUT_MINUTES} minutes`
+          const result = await this.jobRepository.update(
+            { id: job.id, status: JobStatus.PENDING, createdAt: LessThan(pendingThreshold) },
+            { status: JobStatus.FAILED, errorMessage, completedAt: new Date() },
           )
+
+          if (!result.affected) {
+            continue
+          }
+
           this.logger.warn(
             `Expired pending job ${job.id} (type: ${job.type}, resource: ${job.resourceType} ${job.resourceId})`,
           )
+
+          const updatedJob = await this.findOne(job.id)
+          if (updatedJob) {
+            this.jobStateHandlerService.handleJobCompletion(updatedJob).catch((error) => {
+              this.logger.error(`Error handling job completion for job ${job.id}:`, error)
+            })
+          }
         } catch (error) {
           this.logger.error(`Error expiring pending job ${job.id}: ${error.message}`, error.stack)
         }


### PR DESCRIPTION
## Problem

After setting `warm_pool.pool = 10` in a local development environment, the dashboard would get stuck on the BOOTING CONSOLE screen indefinitely after login. The `/api/organizations` request would never resolve, leaving the UI in a permanent loading state.

## Root Cause Analysis

### Discovery

Investigating the network tab showed `/api/organizations` permanently pending while `/api/config` and `/api/auth/token` returned normally. This pointed to a DB-level blockage rather than an auth issue — the API process was up, but requests that touched the database were hanging.

Querying `pg_stat_activity` revealed the cause:

```sql
SELECT pid, state, query, now() - query_start AS duration
FROM pg_stat_activity
WHERE state = 'active';
```

```
 pid | state  |        query           | duration
-----+--------+------------------------+----------
  31 | active | INSERT INTO "job" ...  | 00:07:35
  32 | active | INSERT INTO "job" ...  | 00:07:35
  ...×10
```

10 `INSERT INTO job` transactions had been active for over 7 minutes, consuming all 10 connections in the TypeORM default connection pool (`DB_POOL_MAX` unset → default = 10). Every subsequent DB query — including the one backing `/api/organizations` — queued behind them and never resolved. The dashboard uses `suspend-react` in `OrganizationsProvider`, so a permanently pending promise kept the entire UI in Suspense.

### Why did the jobs hang?

The root cause is a design gap in the warm pool top-up flow:

```
warmPoolCheck() runs every 10s
  → pool=10, current boxes=0 → missingCount=10
  → emits WarmPoolTopUpRequested × 10
  → box service creates 10 jobs (status=PENDING)
  → waits for a runner to claim each job and create a VM
  → local environment has no runner capable of executing VM jobs
     (requires KVM/libkrun — only available on EC2)
  → jobs stay PENDING forever
  → 10 open transactions, 10 connections held indefinitely
  → TypeORM pool exhausted → dashboard stalls
```

Neither `warmPoolCheck()` nor `handleBoxOrganizationUpdated()` checked whether any runner in the target region was actually capable of handling the job before creating it. The existing `handleStaleJobs()` cron only expired `IN_PROGRESS` jobs — `PENDING` jobs had no timeout at all.

## Fix

Two-layer guard to close both the prevention and recovery gaps.

### Layer 1 — Prevention

Both `warmPoolCheck()` and `handleBoxOrganizationUpdated()` now query the runner table before creating a job. *(source text was garbled here — please confirm this reflects the intended wording)* If no runner in the target region is READY, schedulable, and above the availability score threshold, the top-up is skipped and no job is created.

```ts
const availableRunnerCount = await this.runnerRepository.count({
  where: {
    region: warmPoolItem.target,
    state: RunnerState.READY,
    unschedulable: Not(true),
    draining: Not(true),
    availabilityScore: MoreThanOrEqual(availabilityScoreThreshold),
  },
})
if (availableRunnerCount === 0) {
  this.logger.debug(`Skipping warm pool top-up for ${warmPoolItem.id}: no available runners in region ${warmPoolItem.target}`)
  return
}
```

This eliminates the problem at the source in both code paths that emit `WarmPoolTopUpRequested`.

### Layer 2 — Recovery

`handleStaleJobs()` (which already runs every minute) now also expires `PENDING` jobs older than 5 minutes by marking them `FAILED` with a human-readable reason.

This covers the residual race window that Layer 1 cannot eliminate: a runner may pass the availability check, the job gets written, and then the runner goes offline before claiming it. Without Layer 2, that job would also hang indefinitely.

```ts
const PENDING_STALE_TIMEOUT_MINUTES = 5

const stalePendingJobs = await this.jobRepository.find({
  where: { status: JobStatus.PENDING, createdAt: LessThan(pendingThreshold) },
  take: 500,
})
for (const job of stalePendingJobs) {
  await this.updateJobStatus(job.id, JobStatus.FAILED,
    `Job expired — not claimed by any runner within ${PENDING_STALE_TIMEOUT_MINUTES} minutes`)
}
```
*(closing of the template string / for-loop was truncated in the source — please double-check this matches the actual diff)*

## Files Changed

| File | Change |
|---|---|
| `apps/api/src/box/services/box-warm-pool.service.ts` | Add runner availability check in `handleBoxOrganizationUpdated()` before emitting top-up event |
| `apps/api/src/box/services/job.service.ts` | Add PENDING job expiry (5 min timeout) in `handleStaleJobs()` |

## Test Plan

- [ ] Set `warm_pool.pool > 0` in a local environment (no capable runner present) — confirm no new PENDING jobs appear in the job table
- [ ] Confirm dashboard loads normally under the same configuration
- [ ] Manually insert a PENDING job older than 5 minutes — confirm `handleStaleJobs()` marks it FAILED within the next cron cycle
- [ ] In an environment with a READY runner, confirm warm pool top-up still works normally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Warm-pool top-ups now only trigger when there are eligible READY runners available in the target region, reducing unnecessary requests.
  * Unclaimed `PENDING` jobs now expire after a 5-minute window and are automatically marked as failed with an “expired — not claimed” message.
  * Existing handling for `IN_PROGRESS` job timeouts continues to work as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Changes since review

**Round 1 (CodeRabbit):**
- Fix race condition in pending job expiry: replaced updateJobStatus() with a conditional repository.update() that includes status = PENDING in the WHERE clause. Previously a runner could claim the job between the find() and the update(), causing updateJobStatus(IN_PROGRESS → FAILED) to incorrectly fail an actively running job.
- Extract hasAvailableRunnerForRegion() helper: the runner availability count query was duplicated in warmPoolCheck and handleBoxOrganizationUpdated. Extracted into a private helper to prevent future drift between the two gate checks.