### PR TITLE
fix(hooks): gitignore .pr-reviewed.json to keep verdict dossiers valid

### DIFF
--- a/.claude/hooks/preflight-verdict-check.test.sh
+++ b/.claude/hooks/preflight-verdict-check.test.sh
@@ -173,6 +173,30 @@ check_gone() {  # desc  repo
   fi
 }
 
+# ── Real-repo invariant: every gate-written .claude/ state file is gitignored ──
+# compute_tree_hash() folds the whole working tree into the dossier binding via
+# `git add -A`, which SKIPS gitignored paths. So every file the gates write under
+# .claude/ MUST be gitignored — otherwise writing it perturbs the very tree hash
+# the dossier is keyed to and self-invalidates a just-passed audit (the class of
+# bug that hit .pr-reviewed.json: a fresh PASS discarded as "stale" the instant
+# the PR-review ack was written). setup() emulates this per synthetic repo (only
+# .last-verdict.json); this case guards the REAL .gitignore for the whole class,
+# so a new marker added without a matching ignore line fails here.
+echo "## Invariant: gate state files are gitignored (never enter the tree hash)"
+for f in \
+  .claude/.last-audit.json \
+  .claude/.last-verdict.json \
+  .claude/.pr-reviewed.json \
+  .claude/.verdict-last-uuid \
+  .claude/.verdict-decisions.log; do
+  if git -C "$REPO_ROOT" check-ignore -q "$f"; then
+    pass=$((pass + 1)); printf '  PASS  %s gitignored\n' "$f"
+  else
+    fail=$((fail + 1)); printf '  FAIL  %s NOT gitignored → would perturb compute_tree_hash\n' "$f"
+  fi
+done
+
+echo
 echo "## Detection: no dossier → the turn text decides"
 R="$(setup)"; write_transcript "$R" "The root cause is a race between gvproxy startup and the socket bind."
 check "'root cause is X' → block (verdict asserted, unaudited)"   "$R" "block"; rm -rf "$R"

--- a/.gitignore
+++ b/.gitignore
@@ -180,6 +180,7 @@ Cargo.lock
 .claude/worktrees/
 .claude/.last-audit.json
 .claude/.last-verdict.json
+.claude/.pr-reviewed.json
 .claude/.verdict-last-uuid
 .claude/.verdict-decisions.log
 


### PR DESCRIPTION
## Summary

The turn-end verdict gate binds its audit dossier to a content hash of the
working tree (`compute_tree_hash`, built with `git add -A`). That snapshot
skips git-ignored paths but captures non-ignored untracked ones. Four of the
five gate-written `.claude/` state files were git-ignored; the PR-review
marker `.claude/.pr-reviewed.json` was not — so writing the acknowledgment
moved the tree hash a fresh audit was keyed to, and the dossier was discarded
as "stale", re-blocking the turn.

## Changes

- `.gitignore`: ignore `.claude/.pr-reviewed.json` alongside its four siblings,
  so no gate-written state can perturb the tree-hash binding (and the ephemeral
  marker can never be committed).
- `preflight-verdict-check.test.sh`: add a real-repo invariant test asserting
  every gate-written `.claude/` file is `git check-ignore`'d. The prior tests
  only encoded this in a synthetic repo they construct, so they could not catch
  a real omission.

## How to verify

```
bash .claude/hooks/preflight-verdict-check.test.sh   # 53 passed, 0 failed
git check-ignore -v .claude/.pr-reviewed.json        # -> .gitignore:183
```

Two-side: reverting the `.gitignore` line turns the suite red (52 passed, 1
failed, pointing at `.pr-reviewed.json`); restoring it is green.

## Risks

Low. One `.gitignore` line plus a test. No hook logic changes; the marker was
already ephemeral and one-shot-consumed, never intended to be tracked.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a check to ensure key local Claude state files remain ignored in the real repository.
  * Expanded validation coverage for the preflight test flow.

* **Chores**
  * Updated ignore rules so an additional local Claude state file is excluded from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->