### PR TITLE
fix(runtime): make missing box id remove idempotent

### DIFF
--- a/src/boxlite/src/runtime/rt_impl.rs
+++ b/src/boxlite/src/runtime/rt_impl.rs
@@ -27,6 +27,10 @@ fn litebox_from_impl(box_impl: SharedBoxImpl) -> LiteBox {
     LiteBox::new(box_backend, snapshot_backend)
 }
 
+fn looks_like_local_box_id(value: &str) -> bool {
+    value.len() == 12 && value.bytes().all(|b| b.is_ascii_alphanumeric())
+}
+
 /// Archive the active exit file as `exit.previous`, freeing the canonical
 /// slot for the next crash. Single-slot rotation — any prior `exit.previous`
 /// is overwritten. NotFound on source is tolerated.
@@ -491,7 +495,17 @@ impl RuntimeImpl {
 
     /// Remove a box completely by ID or name.
     pub fn remove(&self, id_or_name: &str, force: bool) -> BoxliteResult<()> {
-        let box_id = self.resolve_id(id_or_name)?;
+        let box_id = match self.resolve_id(id_or_name) {
+            Ok(box_id) => box_id,
+            Err(BoxliteError::NotFound(_)) if looks_like_local_box_id(id_or_name) => {
+                tracing::debug!(
+                    box_id = %id_or_name,
+                    "Remove called for an already-missing local box id; treating as cleanup success"
+                );
+                return Ok(());
+            }
+            Err(err) => return Err(err),
+        };
         self.remove_box(&box_id, force)
     }
 

--- a/src/boxlite/tests/lifecycle.rs
+++ b/src/boxlite/tests/lifecycle.rs
@@ -249,6 +249,25 @@ async fn remove_nonexistent_returns_not_found() {
 }
 
 #[tokio::test]
+async fn remove_auto_removed_local_box_id_is_idempotent() {
+    let home = boxlite_test_utils::home::PerTestBoxHome::isolated();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+    let handle = runtime
+        .create(common::alpine_opts_auto(), None)
+        .await
+        .unwrap();
+    let box_id = handle.id().clone();
+
+    handle.stop().await.unwrap();
+    assert!(runtime.get_info(box_id.as_str()).await.unwrap().is_none());
+    runtime.remove(box_id.as_str(), false).await.unwrap();
+}
+
+#[tokio::test]
 async fn remove_stopped_box_succeeds() {
     let home = boxlite_test_utils::home::PerTestBoxHome::isolated();
     let runtime = BoxliteRuntime::new(BoxliteOptions {


### PR DESCRIPTION
Treat remove by already-missing local box id as cleanup success while preserving NotFound for names and invalid ids.

Test plan:
- [x] cargo fmt --all
- [x] BOXLITE_DEPS_STUB=1 cargo test -p boxlite --test lifecycle remove_auto_removed_local_box_id_is_idempotent -- --nocapture
- [x] BOXLITE_DEPS_STUB=1 cargo test -p boxlite --test lifecycle remove_nonexistent_returns_not_found -- --nocapture

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removing an already auto-removed local box now completes successfully instead of returning a “not found” error.
  * Other removal errors continue to be reported normally.

* **Tests**
  * Added coverage confirming repeated removal of an auto-removed box is safe and idempotent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->