### PR TITLE
fix(python): raise TimeoutError for exec timeouts

### DIFF
--- a/apps/runner/pkg/api/controllers/boxlite_exec.go
+++ b/apps/runner/pkg/api/controllers/boxlite_exec.go
@@ -185,9 +185,8 @@ func BoxliteGetExecution(ctx *gin.Context) {
 // ExecutionInfoResponse describes an execution's current state.
 // Field names match the OpenAPI ExecutionInfo schema:
 // execution_id, status, exit_code, error_message. Statuses are
-// running | completed | killed | timed_out per spec; today we only
-// emit running and completed (the latter covers any non-running state
-// the kernel surfaced — exit-code semantics distinguish them).
+// running | completed | killed | timed_out per spec; today killed falls
+// back to completed with signal-shaped exit-code semantics.
 // exit_code and error_message are populated only after Done fires so
 // callers can distinguish "still running" from "exited cleanly with
 // code 0".
@@ -202,7 +201,11 @@ func executionInfoFromManagedExec(exec *boxlite.ManagedExec) ExecutionInfoRespon
 	resp := ExecutionInfoResponse{ExecutionID: exec.ID}
 	select {
 	case <-exec.Done:
-		resp.Status = "completed"
+		if exec.TimedOut {
+			resp.Status = "timed_out"
+		} else {
+			resp.Status = "completed"
+		}
 		code := exec.ExitCode
 		resp.ExitCode = &code
 		if exec.Err != nil {

--- a/apps/runner/pkg/api/controllers/boxlite_exec_attach.go
+++ b/apps/runner/pkg/api/controllers/boxlite_exec_attach.go
@@ -68,6 +68,7 @@ type attachExec interface {
 	WriteStdin(data []byte) (int, error)
 	DoneCh() <-chan struct{}
 	ExitCodeValue() int
+	TimedOutValue() bool
 	IsTTY() bool
 	Resize(rows, cols int) error
 	Signal(sig int) error
@@ -289,6 +290,7 @@ func runAttachLoop(parentCtx context.Context, conn *websocket.Conn, exec attachE
 			_ = writeJSONFrame(conn, &writeMu, map[string]any{
 				"type":      "exit",
 				"exit_code": exec.ExitCodeValue(),
+				"timed_out": exec.TimedOutValue(),
 			})
 			closeWS(websocket.CloseNormalClosure, "")
 		} else {
@@ -486,6 +488,7 @@ func (m managedExecAttach) Subscribe(bufSize int) (stdout, stderr <-chan []byte,
 func (m managedExecAttach) WriteStdin(data []byte) (int, error) { return m.me.AttachWriteStdin(data) }
 func (m managedExecAttach) DoneCh() <-chan struct{}             { return m.me.Done }
 func (m managedExecAttach) ExitCodeValue() int                  { return m.me.ExitCode }
+func (m managedExecAttach) TimedOutValue() bool                 { return m.me.TimedOut }
 func (m managedExecAttach) IsTTY() bool                         { return m.me.TTY }
 func (m managedExecAttach) Resize(rows, cols int) error         { return m.me.AttachResize(rows, cols) }
 func (m managedExecAttach) Signal(sig int) error                { return m.me.AttachSignal(sig) }

--- a/apps/runner/pkg/api/controllers/boxlite_exec_attach_test.go
+++ b/apps/runner/pkg/api/controllers/boxlite_exec_attach_test.go
@@ -31,6 +31,7 @@ type stubAttachExec struct {
 	stdinW     *io.PipeWriter
 	done       chan struct{}
 	exitCode   int
+	timedOut   bool
 	tty        bool
 	connected  atomic.Bool
 	disconnect atomic.Int32
@@ -147,6 +148,7 @@ func (s *stubAttachExec) WriteStdin(data []byte) (int, error) {
 }
 func (s *stubAttachExec) DoneCh() <-chan struct{} { return s.done }
 func (s *stubAttachExec) ExitCodeValue() int      { return s.exitCode }
+func (s *stubAttachExec) TimedOutValue() bool     { return s.timedOut }
 func (s *stubAttachExec) IsTTY() bool             { return s.tty }
 func (s *stubAttachExec) Resize(rows, cols int) error {
 	s.mu.Lock()
@@ -227,6 +229,7 @@ func readNextDataFrame(t *testing.T, conn *websocket.Conn, deadline time.Duratio
 func TestBoxliteExecAttach_StdinAndExit(t *testing.T) {
 	stub := newStubAttachExec()
 	stub.exitCode = 42
+	stub.timedOut = true
 	cleanup := withStubExec(t, "exec-1", stub)
 	defer cleanup()
 
@@ -301,6 +304,9 @@ func TestBoxliteExecAttach_StdinAndExit(t *testing.T) {
 			if ev["type"] == "exit" {
 				if got, want := int(ev["exit_code"].(float64)), 42; got != want {
 					t.Fatalf("expected exit_code %d, got %d", want, got)
+				}
+				if got, want := ev["timed_out"].(bool), true; got != want {
+					t.Fatalf("expected timed_out %v, got %v", want, got)
 				}
 				gotExit = true
 				continue

--- a/apps/runner/pkg/api/controllers/boxlite_exec_test.go
+++ b/apps/runner/pkg/api/controllers/boxlite_exec_test.go
@@ -135,6 +135,33 @@ func TestBoxliteGetExecutionReturnsRunningThenExited(t *testing.T) {
 	}
 }
 
+func TestBoxliteGetExecutionReportsTimedOut(t *testing.T) {
+	mgr := withFreshExecManager(t)
+	exec := seedManagedExec(mgr, "exec-timeout", &signalCapturingExec{})
+	exec.ExitCode = -15
+	exec.TimedOut = true
+	close(exec.Done)
+
+	w := runHandler(http.MethodGet,
+		"/v1/boxes/:boxId/executions/:execId",
+		"/v1/boxes/box/executions/exec-timeout",
+		nil, BoxliteGetExecution)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	var info ExecutionInfoResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &info); err != nil {
+		t.Fatalf("unmarshal failed: %v body=%s", err, w.Body.String())
+	}
+	if info.Status != "timed_out" {
+		t.Fatalf("expected status=timed_out, got %+v", info)
+	}
+	if info.ExitCode == nil || *info.ExitCode != -15 {
+		t.Fatalf("expected exit_code=-15, got %+v", info)
+	}
+}
+
 // Phase 2.1: missing exec id returns 404 instead of 200/empty body.
 func TestBoxliteGetExecutionNotFound(t *testing.T) {
 	withFreshExecManager(t)

--- a/apps/runner/pkg/boxlite/exec_manager.go
+++ b/apps/runner/pkg/boxlite/exec_manager.go
@@ -70,6 +70,9 @@ func (s sdkExec) ResizeTTY(ctx context.Context, rows, cols int) error {
 }
 func (s sdkExec) Close() error                          { return s.inner.Close() }
 func (s sdkExec) Wait(ctx context.Context) (int, error) { return s.inner.Wait(ctx) }
+func (s sdkExec) WaitResult(ctx context.Context) (*boxlite.ExecutionWaitResult, error) {
+	return s.inner.WaitResult(ctx)
+}
 
 type ExecManager struct {
 	mu    sync.RWMutex
@@ -95,6 +98,7 @@ type ManagedExec struct {
 	execution execHandle
 	Done      chan struct{}
 	ExitCode  int
+	TimedOut  bool
 	Err       error
 	TTY       bool
 	created   time.Time
@@ -395,8 +399,11 @@ func (m *ExecManager) Start(ctx context.Context, bx *boxlite.Box, boxID string, 
 			exec.handleMu.Unlock()
 		}()
 
-		exitCode, err := handle.Wait(context.Background())
-		exec.ExitCode = exitCode
+		result, err := handle.WaitResult(context.Background())
+		if result != nil {
+			exec.ExitCode = result.ExitCode
+			exec.TimedOut = result.TimedOut
+		}
 		exec.Err = err
 	}()
 

--- a/apps/runner/pkg/boxlite/exec_manager_integration_test.go
+++ b/apps/runner/pkg/boxlite/exec_manager_integration_test.go
@@ -1,0 +1,86 @@
+//go:build boxlite_dev
+
+package boxlite
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	sdk "github.com/boxlite-ai/boxlite/sdks/go"
+)
+
+func TestIntegrationExecManagerRecordsTimedOut(t *testing.T) {
+	ctx := context.Background()
+	homeDir, err := os.MkdirTemp("/tmp", "boxlite-runner-timeout-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(homeDir) })
+
+	rt, err := sdk.NewRuntime(sdk.WithHomeDir(homeDir))
+	if err != nil {
+		var sdkErr *sdk.Error
+		if errors.As(err, &sdkErr) && (sdkErr.Code == sdk.ErrUnsupported || sdkErr.Code == sdk.ErrUnsupportedEngine) {
+			t.Skipf("runtime not available: %v", err)
+		}
+		t.Fatalf("NewRuntime: %v", err)
+	}
+	t.Cleanup(func() { _ = rt.Close() })
+
+	box, err := rt.Create(ctx, "alpine:latest", sdk.WithAutoRemove(false))
+	if err != nil {
+		skipInfraError(t, "Create", err)
+		t.Fatalf("Create: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = box.Stop(ctx)
+		_ = rt.ForceRemove(ctx, box.ID())
+		_ = box.Close()
+	})
+	if err := box.Start(ctx); err != nil {
+		skipInfraError(t, "Start", err)
+		t.Fatalf("Start: %v", err)
+	}
+
+	mgr := NewExecManager()
+	mgr.Stop()
+	id, err := mgr.Start(ctx, box, box.ID(), StartOptions{
+		Command: "sleep",
+		Args:    []string{"20"},
+		Timeout: 2 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("ExecManager.Start: %v", err)
+	}
+	t.Cleanup(func() { _ = mgr.Kill(id) })
+
+	exec, ok := mgr.Get(id)
+	if !ok {
+		t.Fatalf("exec %s not registered", id)
+	}
+	select {
+	case <-exec.Done:
+	case <-time.After(15 * time.Second):
+		t.Fatalf("timed exec did not complete within 15s")
+	}
+	if exec.Err != nil {
+		t.Fatalf("wait returned error: %v", exec.Err)
+	}
+	if !exec.TimedOut {
+		t.Fatalf("expected TimedOut=true, got exit_code=%d", exec.ExitCode)
+	}
+	if exec.ExitCode == 0 {
+		t.Fatalf("expected non-zero timeout exit code")
+	}
+}
+
+func skipInfraError(t *testing.T, op string, err error) {
+	t.Helper()
+	var sdkErr *sdk.Error
+	if errors.As(err, &sdkErr) && (sdkErr.Code == sdk.ErrStorage || sdkErr.Code == sdk.ErrImage || sdkErr.Code == sdk.ErrNetwork) {
+		t.Skipf("%s infrastructure prerequisite unavailable (code=%d): %v", op, sdkErr.Code, err)
+	}
+}

--- a/apps/runner/pkg/boxlite/exec_manager_integration_test.go
+++ b/apps/runner/pkg/boxlite/exec_manager_integration_test.go
@@ -46,7 +46,7 @@ func TestIntegrationExecManagerRecordsTimedOut(t *testing.T) {
 	}
 
 	mgr := NewExecManager()
-	mgr.Stop()
+	t.Cleanup(func() { mgr.Stop() })
 	id, err := mgr.Start(ctx, box, box.ID(), StartOptions{
 		Command: "sleep",
 		Args:    []string{"20"},

--- a/sdks/c/include/boxlite.h
+++ b/sdks/c/include/boxlite.h
@@ -212,6 +212,9 @@ typedef void (*CBoxExitCb)(int, void*);
 // Execution wait completion (carries exit code on success).
 typedef void (*CExecutionWaitCb)(int, CBoxliteError*, void*);
 
+// Execution wait completion with structured result metadata.
+typedef void (*CExecutionWaitResultCb)(int, bool, CBoxliteError*, void*);
+
 // Execution kill completion.
 typedef void (*CExecutionKillCb)(CBoxliteError*, void*);
 
@@ -510,6 +513,11 @@ enum BoxliteErrorCode boxlite_execution_wait(CExecutionHandle *execution,
                                              CExecutionWaitCb cb,
                                              void *user_data,
                                              CBoxliteError *out_error);
+
+enum BoxliteErrorCode boxlite_execution_wait_result(CExecutionHandle *execution,
+                                                    CExecutionWaitResultCb cb,
+                                                    void *user_data,
+                                                    CBoxliteError *out_error);
 
 enum BoxliteErrorCode boxlite_execution_kill(CExecutionHandle *execution,
                                              CExecutionKillCb cb,

--- a/sdks/c/include/boxlite.h
+++ b/sdks/c/include/boxlite.h
@@ -514,6 +514,16 @@ enum BoxliteErrorCode boxlite_execution_wait(CExecutionHandle *execution,
                                              void *user_data,
                                              CBoxliteError *out_error);
 
+// Schedules an asynchronous wait and invokes `cb` with the exit code and
+// timeout status, passing `user_data` through unchanged.
+//
+// Returns immediately with a validation or scheduling status. When non-null,
+// `out_error` receives details for synchronous failures.
+//
+// # Safety
+//
+// `execution` must be a valid handle, `cb` must be callable for the duration
+// of the asynchronous operation, and `out_error` must be null or writable.
 enum BoxliteErrorCode boxlite_execution_wait_result(CExecutionHandle *execution,
                                                     CExecutionWaitResultCb cb,
                                                     void *user_data,

--- a/sdks/c/src/event_queue.rs
+++ b/sdks/c/src/event_queue.rs
@@ -181,6 +181,12 @@ pub(crate) type CRuntimeShutdownFn = extern "C" fn(*mut crate::CBoxliteError, *m
 pub type CExecutionWaitCb = Option<extern "C" fn(c_int, *mut crate::CBoxliteError, *mut c_void)>;
 pub(crate) type CExecutionWaitFn = extern "C" fn(c_int, *mut crate::CBoxliteError, *mut c_void);
 
+/// Execution wait completion with structured result metadata.
+pub type CExecutionWaitResultCb =
+    Option<extern "C" fn(c_int, bool, *mut crate::CBoxliteError, *mut c_void)>;
+pub(crate) type CExecutionWaitResultFn =
+    extern "C" fn(c_int, bool, *mut crate::CBoxliteError, *mut c_void);
+
 /// Execution kill completion.
 pub type CExecutionKillCb = Option<extern "C" fn(*mut crate::CBoxliteError, *mut c_void)>;
 pub(crate) type CExecutionKillFn = extern "C" fn(*mut crate::CBoxliteError, *mut c_void);
@@ -402,6 +408,11 @@ pub enum RuntimeEvent {
         cb: CExecutionWaitFn,
         user_data: usize,
         result: Result<i32, BoxliteError>,
+    },
+    WaitResult {
+        cb: CExecutionWaitResultFn,
+        user_data: usize,
+        result: Result<(i32, bool), BoxliteError>,
     },
     Kill {
         cb: CExecutionKillFn,

--- a/sdks/c/src/exec/execution.rs
+++ b/sdks/c/src/exec/execution.rs
@@ -38,8 +38,8 @@ use crate::box_handle::BoxHandle;
 use crate::error::{BoxliteErrorCode, FFIError, error_to_code, null_pointer_error, write_error};
 use crate::event_queue::{
     CBoxExitCb, CBoxExitFn, CBoxStderrCb, CBoxStderrFn, CBoxStdoutCb, CBoxStdoutFn,
-    CExecutionKillCb, CExecutionResizeCb, CExecutionSignalCb, CExecutionWaitCb, EventQueue,
-    RuntimeEvent, push_event,
+    CExecutionKillCb, CExecutionResizeCb, CExecutionSignalCb, CExecutionWaitCb,
+    CExecutionWaitResultCb, EventQueue, RuntimeEvent, push_event,
 };
 use crate::{CBoxHandle, CBoxliteError, CExecutionHandle};
 
@@ -166,6 +166,16 @@ pub unsafe extern "C" fn boxlite_execution_wait(
     out_error: *mut CBoxliteError,
 ) -> BoxliteErrorCode {
     execution_wait(execution, cb, user_data, out_error)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_execution_wait_result(
+    execution: *mut CExecutionHandle,
+    cb: CExecutionWaitResultCb,
+    user_data: *mut c_void,
+    out_error: *mut CBoxliteError,
+) -> BoxliteErrorCode {
+    execution_wait_result(execution, cb, user_data, out_error)
 }
 
 #[unsafe(no_mangle)]
@@ -503,6 +513,45 @@ unsafe fn execution_wait(
     }
 }
 
+unsafe fn execution_wait_result(
+    execution: *mut ExecutionHandle,
+    cb: CExecutionWaitResultCb,
+    user_data: *mut c_void,
+    out_error: *mut FFIError,
+) -> BoxliteErrorCode {
+    unsafe {
+        if execution.is_null() {
+            write_error(out_error, null_pointer_error("execution"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        let cb = crate::unwrap_cb_or_return!(cb, out_error);
+
+        let exec_ref = &*execution;
+        let exec_arc = exec_ref.execution.clone();
+        let queue = exec_ref.queue.clone();
+        let user_data_addr = user_data as usize;
+        let process_completed = exec_ref.process_completed.clone();
+
+        exec_ref.tokio_rt.spawn(async move {
+            let result = wait_result_on_clone(&exec_arc).await;
+            if result.is_ok() {
+                process_completed.store(true, Ordering::Release);
+            }
+            push_event(
+                &queue,
+                RuntimeEvent::WaitResult {
+                    cb,
+                    user_data: user_data_addr,
+                    result,
+                },
+            )
+            .await;
+        });
+
+        BoxliteErrorCode::Ok
+    }
+}
+
 unsafe fn execution_kill(
     execution: *mut ExecutionHandle,
     cb: CExecutionKillCb,
@@ -822,6 +871,16 @@ fn snapshot_execution(slot: &Mutex<Option<Execution>>) -> Result<Execution, Boxl
 async fn wait_on_clone(slot: &Mutex<Option<Execution>>) -> Result<i32, BoxliteError> {
     let clone = snapshot_execution(slot)?;
     clone.wait().await.map(|status| status.exit_code)
+}
+
+async fn wait_result_on_clone(
+    slot: &Mutex<Option<Execution>>,
+) -> Result<(i32, bool), BoxliteError> {
+    let clone = snapshot_execution(slot)?;
+    clone
+        .wait()
+        .await
+        .map(|status| (status.exit_code, status.timed_out))
 }
 
 async fn kill_on_clone(slot: &Mutex<Option<Execution>>) -> Result<(), BoxliteError> {

--- a/sdks/c/src/exec/execution.rs
+++ b/sdks/c/src/exec/execution.rs
@@ -168,6 +168,16 @@ pub unsafe extern "C" fn boxlite_execution_wait(
     execution_wait(execution, cb, user_data, out_error)
 }
 
+/// Schedules an asynchronous wait and invokes `cb` with the exit code and
+/// timeout status, passing `user_data` through unchanged.
+///
+/// Returns immediately with a validation or scheduling status. When non-null,
+/// `out_error` receives details for synchronous failures.
+///
+/// # Safety
+///
+/// `execution` must be a valid handle, `cb` must be callable for the duration
+/// of the asynchronous operation, and `out_error` must be null or writable.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn boxlite_execution_wait_result(
     execution: *mut CExecutionHandle,

--- a/sdks/c/src/runtime.rs
+++ b/sdks/c/src/runtime.rs
@@ -649,6 +649,24 @@ unsafe fn dispatch_event(event: RuntimeEvent) {
                     crate::boxlite_error_free(&mut err);
                 }
             }
+            RuntimeEvent::WaitResult {
+                cb,
+                user_data,
+                result,
+            } => {
+                let mut err = FFIError::default();
+                let (exit_code, timed_out) = match result {
+                    Ok((code, timed_out)) => (code, timed_out),
+                    Err(e) => {
+                        err = crate::error::error_to_c_error(e);
+                        (-1, false)
+                    }
+                };
+                cb(exit_code, timed_out, &mut err, user_data as *mut c_void);
+                if !err.message.is_null() {
+                    crate::boxlite_error_free(&mut err);
+                }
+            }
             RuntimeEvent::Kill {
                 cb,
                 user_data,

--- a/sdks/go/bridge.c
+++ b/sdks/go/bridge.c
@@ -36,6 +36,7 @@ extern void goBoxliteOnRuntimeMetrics(CRuntimeMetrics *m, CBoxliteError *err, vo
 extern void goBoxliteOnRuntimeShutdown(CBoxliteError *err, void *ud);
 
 extern void goBoxliteOnExecutionWait(int exit_code, CBoxliteError *err, void *ud);
+extern void goBoxliteOnExecutionWaitResult(int exit_code, bool timed_out, CBoxliteError *err, void *ud);
 extern void goBoxliteOnExecutionKill(CBoxliteError *err, void *ud);
 extern void goBoxliteOnExecutionSignal(CBoxliteError *err, void *ud);
 extern void goBoxliteOnExecutionResize(CBoxliteError *err, void *ud);
@@ -71,6 +72,7 @@ CRuntimeMetricsCb cbRuntimeMetrics(void) { return (CRuntimeMetricsCb)goBoxliteOn
 CRuntimeShutdownCb cbRuntimeShutdown(void) { return (CRuntimeShutdownCb)goBoxliteOnRuntimeShutdown; }
 
 CExecutionWaitCb cbExecutionWait(void) { return (CExecutionWaitCb)goBoxliteOnExecutionWait; }
+CExecutionWaitResultCb cbExecutionWaitResult(void) { return (CExecutionWaitResultCb)goBoxliteOnExecutionWaitResult; }
 CExecutionKillCb cbExecutionKill(void) { return (CExecutionKillCb)goBoxliteOnExecutionKill; }
 CExecutionSignalCb cbExecutionSignal(void) { return (CExecutionSignalCb)goBoxliteOnExecutionSignal; }
 CExecutionResizeCb cbExecutionResize(void) { return (CExecutionResizeCb)goBoxliteOnExecutionResize; }

--- a/sdks/go/bridge.h
+++ b/sdks/go/bridge.h
@@ -36,6 +36,7 @@ extern CRuntimeMetricsCb cbRuntimeMetrics(void);
 extern CRuntimeShutdownCb cbRuntimeShutdown(void);
 
 extern CExecutionWaitCb cbExecutionWait(void);
+extern CExecutionWaitResultCb cbExecutionWaitResult(void);
 extern CExecutionKillCb cbExecutionKill(void);
 extern CExecutionSignalCb cbExecutionSignal(void);
 extern CExecutionResizeCb cbExecutionResize(void);

--- a/sdks/go/bridge_callback.go
+++ b/sdks/go/bridge_callback.go
@@ -453,6 +453,27 @@ func goBoxliteOnExecutionWait(exitCode C.int, errPtr *C.CBoxliteError, userData 
 	}
 }
 
+//export goBoxliteOnExecutionWaitResult
+func goBoxliteOnExecutionWaitResult(exitCode C.int, timedOut C.bool, errPtr *C.CBoxliteError, userData unsafe.Pointer) {
+	h := ptrToHandle(userData)
+	if h == 0 {
+		return
+	}
+	if !claimHandleForDispatch(h) {
+		return
+	}
+	defer h.Delete()
+	ch, ok := h.Value().(chan executionWaitResult)
+	if !ok {
+		return
+	}
+	ch <- executionWaitResult{
+		exitCode: int(exitCode),
+		timedOut: bool(timedOut),
+		err:      errorFromCError(errPtr),
+	}
+}
+
 //export goBoxliteOnExecutionKill
 func goBoxliteOnExecutionKill(errPtr *C.CBoxliteError, userData unsafe.Pointer) {
 	deliverUnitResult(userData, errPtr)
@@ -582,5 +603,6 @@ type runtimeMetricsResult struct {
 
 type executionWaitResult struct {
 	exitCode int
+	timedOut bool
 	err      error
 }

--- a/sdks/go/exec.go
+++ b/sdks/go/exec.go
@@ -24,6 +24,12 @@ type ExecResult struct {
 	Stderr   string
 }
 
+// ExecutionWaitResult is the structured result returned by Execution.WaitResult.
+type ExecutionWaitResult struct {
+	ExitCode int
+	TimedOut bool
+}
+
 // envMapToFlatPairs flattens an env map into a [k0, v0, k1, v1, ...]
 // slice sorted by key. Sorting makes the C call deterministic across
 // runs, which matters for test reproducibility and for any downstream
@@ -299,46 +305,48 @@ func (e *Execution) Write(p []byte) (int, error) {
 	return e.Stdin.Write(p)
 }
 
-// Wait blocks until the process has exited AND every stdout/stderr
+// WaitResult blocks until the process has exited AND every stdout/stderr
 // callback for this execution has been dispatched, then returns the
-// exit code. Mirrors os/exec.Cmd's Wait for the io.Writer case —
+// structured exit result. Mirrors os/exec.Cmd's Wait for the io.Writer case —
 // every BoxLite execution IS the io.Writer case (streams are pushed
 // to a user-supplied Writer / callback; there is no StdoutPipe-style
-// user-read pipe), so Wait is the single terminal and must guarantee
+// user-read pipe), so waiting is the single terminal and must guarantee
 // output completeness on return.
 //
 // The post-exit-code drain is non-cancelable by ctx (parity with
 // os/exec's awaitGoroutines); only runtime shutdown breaks it, in
 // which case the process's exit code is preserved and err is
 // overwritten only if the wait had none.
-func (e *Execution) Wait(ctx context.Context) (int, error) {
+func (e *Execution) WaitResult(ctx context.Context) (*ExecutionWaitResult, error) {
 	if e.handle == nil {
-		return 0, &Error{Code: ErrInvalidState, Message: "execution is closed"}
+		return nil, &Error{Code: ErrInvalidState, Message: "execution is closed"}
 	}
 
 	ch := make(chan executionWaitResult, 1)
 	h := registerHandleForDispatch(cgo.NewHandle(ch))
 
 	var cerr C.CBoxliteError
-	if rc := C.boxlite_execution_wait(e.handle, C.cbExecutionWait(), handleToPtr(h), &cerr); rc != C.Ok {
+	if rc := C.boxlite_execution_wait_result(e.handle, C.cbExecutionWaitResult(), handleToPtr(h), &cerr); rc != C.Ok {
 		deleteHandleForDispatch(h)
-		return 0, freeError(&cerr)
+		return nil, freeError(&cerr)
 	}
 
-	var code int
+	result := &ExecutionWaitResult{}
 	var err error
 	select {
 	case res := <-ch:
-		code, err = res.exitCode, res.err
+		result.ExitCode = res.exitCode
+		result.TimedOut = res.timedOut
+		err = res.err
 	case <-ctx.Done():
 		// ctx cancel before the process reports exit: skip the
 		// drain barrier (consistent with os/exec's behavior on
 		// Process.Wait cancellation).
 		drainAndDelete(ch, h, e.closing)
-		return 0, ctx.Err()
+		return nil, ctx.Err()
 	case <-e.closing:
 		drainAndDelete(ch, h, e.closing)
-		return 0, ErrRuntimeClosed
+		return nil, ErrRuntimeClosed
 	}
 
 	// Drain barrier: wait for stream pumps to flush before returning,
@@ -353,7 +361,19 @@ func (e *Execution) Wait(ctx context.Context) (int, error) {
 			err = ErrRuntimeClosed
 		}
 	}
-	return code, err
+	return result, err
+}
+
+// Wait blocks until the process has exited AND every stdout/stderr
+// callback for this execution has been dispatched, then returns the
+// exit code. See WaitResult for the structured variant that also reports
+// whether the configured execution timeout terminated the process.
+func (e *Execution) Wait(ctx context.Context) (int, error) {
+	result, err := e.WaitResult(ctx)
+	if err != nil {
+		return 0, err
+	}
+	return result.ExitCode, nil
 }
 
 // Kill terminates the running command.

--- a/sdks/python/boxlite/exec.py
+++ b/sdks/python/boxlite/exec.py
@@ -20,6 +20,7 @@ class ExecResult:
         exit_code: Exit code from the command (negative if terminated by signal)
         stdout: Standard output as string
         stderr: Standard error as string
+        timed_out: True if the configured execution timeout terminated the command.
         error_message: Diagnostic message when process died unexpectedly
             (e.g., container init death). None if normal exit.
     """
@@ -27,4 +28,5 @@ class ExecResult:
     exit_code: int
     stdout: str
     stderr: str
+    timed_out: bool = False
     error_message: str | None = None

--- a/sdks/python/boxlite/simplebox.py
+++ b/sdks/python/boxlite/simplebox.py
@@ -9,6 +9,7 @@ import logging
 from enum import IntEnum
 from typing import Optional, TYPE_CHECKING
 
+from .errors import TimeoutError
 from .exec import ExecResult
 
 if TYPE_CHECKING:
@@ -266,6 +267,8 @@ class SimpleBox:
         # Convert env dict to list of tuples if provided
         env_list = list(env.items()) if env else None
 
+        command_display = " ".join([cmd, *args])
+
         # Execute via Rust (returns PyExecution)
         execution = await self._box.exec(
             cmd, arg_list, env_list, user=user, timeout_secs=timeout, cwd=cwd
@@ -322,9 +325,11 @@ class SimpleBox:
         stderr = "".join(stderr_lines)
 
         error_message = None
+        timed_out = False
         try:
             exec_result = await execution.wait()
             exit_code = exec_result.exit_code
+            timed_out = exec_result.timed_out
             error_message = exec_result.error_message
         except Exception as e:
             logger.error(f"failed to wait execution: {e}")
@@ -332,10 +337,16 @@ class SimpleBox:
 
         logger.debug(f"exec finish, exit_code: {exit_code}")
 
+        if timed_out:
+            raise TimeoutError(
+                f"Command '{command_display}' timed out after {timeout:g} seconds"
+            )
+
         return ExecResult(
             exit_code=exit_code,
             stdout=stdout,
             stderr=stderr,
+            timed_out=timed_out,
             error_message=error_message,
         )
 

--- a/sdks/python/boxlite/simplebox.py
+++ b/sdks/python/boxlite/simplebox.py
@@ -338,9 +338,10 @@ class SimpleBox:
         logger.debug(f"exec finish, exit_code: {exit_code}")
 
         if timed_out:
-            raise TimeoutError(
-                f"Command '{command_display}' timed out after {timeout:g} seconds"
+            timeout_detail = (
+                f" after {timeout:g} seconds" if timeout is not None else ""
             )
+            raise TimeoutError(f"Command '{command_display}' timed out{timeout_detail}")
 
         return ExecResult(
             exit_code=exit_code,

--- a/sdks/python/boxlite/sync_api/_simplebox.py
+++ b/sdks/python/boxlite/sync_api/_simplebox.py
@@ -9,6 +9,7 @@ import asyncio
 import logging
 from typing import TYPE_CHECKING, Dict, Optional
 
+from ..errors import TimeoutError
 from ..exec import ExecResult
 
 if TYPE_CHECKING:
@@ -190,6 +191,7 @@ class SyncSimpleBox:
 
         # Access the underlying async Box directly
         async_box = self._box._box
+        command_display = " ".join([cmd, *args])
 
         async def _exec_and_collect():
             execution = await async_box.exec(
@@ -238,18 +240,27 @@ class SyncSimpleBox:
             await asyncio.gather(collect_stdout(), collect_stderr())
 
             error_message = None
+            timed_out = False
             try:
                 exec_result = await execution.wait()
                 exit_code = exec_result.exit_code
+                timed_out = exec_result.timed_out
                 error_message = exec_result.error_message
             except Exception as e:
                 logger.error(f"failed to wait execution: {e}")
                 exit_code = -1
+                error_message = None
+
+            if timed_out:
+                raise TimeoutError(
+                    f"Command '{command_display}' timed out after {timeout:g} seconds"
+                )
 
             return ExecResult(
                 exit_code=exit_code,
                 stdout="".join(stdout_lines),
                 stderr="".join(stderr_lines),
+                timed_out=timed_out,
                 error_message=error_message,
             )
 

--- a/sdks/python/boxlite/sync_api/_simplebox.py
+++ b/sdks/python/boxlite/sync_api/_simplebox.py
@@ -252,8 +252,11 @@ class SyncSimpleBox:
                 error_message = None
 
             if timed_out:
+                timeout_detail = (
+                    f" after {timeout:g} seconds" if timeout is not None else ""
+                )
                 raise TimeoutError(
-                    f"Command '{command_display}' timed out after {timeout:g} seconds"
+                    f"Command '{command_display}' timed out{timeout_detail}"
                 )
 
             return ExecResult(

--- a/sdks/python/src/exec.rs
+++ b/sdks/python/src/exec.rs
@@ -115,6 +115,8 @@ pub(crate) struct PyExecResult {
     #[pyo3(get, set)]
     pub(crate) exit_code: i32,
     #[pyo3(get, set)]
+    pub(crate) timed_out: bool,
+    #[pyo3(get, set)]
     pub(crate) error_message: Option<String>,
 }
 
@@ -172,6 +174,7 @@ impl PyExecution {
             let exec_result = execution.wait().await.map_err(map_err)?;
             Ok(PyExecResult {
                 exit_code: exec_result.exit_code,
+                timed_out: exec_result.timed_out,
                 error_message: exec_result.error_message,
             })
         })

--- a/sdks/python/tests/test_exec_timeout_sigalrm.py
+++ b/sdks/python/tests/test_exec_timeout_sigalrm.py
@@ -7,11 +7,9 @@ timeout watcher must use SIGKILL (signal 9, uncatchable). If it sends SIGALRM
 completion, and ``ExecResult.exit_code`` comes back as 0 — the deadline is
 bypassed.
 
-The Python SDK does NOT raise ``boxlite.TimeoutError`` on exec timeout; it
-returns an ``ExecResult`` whose ``exit_code`` reflects how the process died
-(non-zero / signal). The PoC at ``boxlite_poc/poc_sigalrm_bypass.py``
-confirms this: it inspects ``exit_code`` and elapsed wall-time, never an
-exception.
+The Python convenience SDK raises ``boxlite.TimeoutError`` on exec timeout.
+This test still checks elapsed wall-time so timeout signaling regressions do
+not hide behind the typed exception.
 
 Requirements:
   - make dev:python  (build the Python SDK with native extension)
@@ -66,9 +64,9 @@ async def test_exec_timeout_kills_sigalrm_ignoring_process(shared_runtime):
 
     Two-pronged assertion — both must hold:
 
-    1) ``exit_code != 0`` — the workload must NOT have completed normally.
-       With the SIGALRM bug, SIG_IGN absorbs the timeout signal, the loop
-       finishes, and Python exits cleanly with 0.
+    1) ``TimeoutError`` is raised — the workload must NOT have completed
+       normally. With the SIGALRM bug, SIG_IGN absorbs the timeout signal,
+       the loop finishes, and Python exits cleanly with 0.
 
     2) ``elapsed < TIMEOUT_S + 2.0`` — termination must happen near the
        configured deadline, not at the workload's natural end. Even if
@@ -82,26 +80,38 @@ async def test_exec_timeout_kills_sigalrm_ignoring_process(shared_runtime):
         image="python:3-alpine", runtime=shared_runtime
     ) as box:
         t0 = time.time()
-        result = await box.exec(
-            "python3",
-            "-c",
-            IGNORE_SIGALRM,
-            str(WORKLOAD_S),
-            timeout=TIMEOUT_S,
-        )
+        with pytest.raises(boxlite.TimeoutError):
+            await box.exec(
+                "python3",
+                "-c",
+                IGNORE_SIGALRM,
+                str(WORKLOAD_S),
+                timeout=TIMEOUT_S,
+            )
         elapsed = time.time() - t0
 
-        assert result.exit_code != 0, (
-            f"exec returned exit_code=0 after {elapsed:.2f}s — the {WORKLOAD_S}s "
-            f"workload completed normally despite timeout={TIMEOUT_S}s. The "
-            f"guest's timeout watcher is sending a catchable signal that the "
-            f"workload absorbs via SIG_IGN; the kill must use SIGKILL."
-        )
         assert elapsed < TIMEOUT_S + 2.0, (
-            f"exec returned after {elapsed:.2f}s with exit_code={result.exit_code} "
+            f"exec returned after {elapsed:.2f}s "
             f"— expected termination near {TIMEOUT_S}s. The timeout watcher "
             f"is not killing the process promptly."
         )
+
+
+async def test_execution_wait_reports_timed_out(shared_runtime):
+    """Low-level wait result carries an explicit timed_out flag."""
+    box = await shared_runtime.create(
+        boxlite.BoxOptions(image="python:3-alpine", auto_remove=True)
+    )
+    async with box:
+        execution = await box.exec(
+            "python3",
+            ["-c", IGNORE_SIGALRM, str(WORKLOAD_S)],
+            timeout_secs=TIMEOUT_S,
+        )
+        result = await execution.wait()
+
+    assert result.timed_out is True
+    assert result.exit_code != 0
 
 
 async def test_exec_timeout_sigkill_fallback_when_sigterm_ignored(shared_runtime):
@@ -125,22 +135,16 @@ async def test_exec_timeout_sigkill_fallback_when_sigterm_ignored(shared_runtime
         image="python:3-alpine", runtime=shared_runtime
     ) as box:
         t0 = time.time()
-        result = await box.exec(
-            "python3",
-            "-c",
-            IGNORE_TERM_AND_ALRM,
-            str(WORKLOAD_S),
-            timeout=TIMEOUT_S,
-        )
+        with pytest.raises(boxlite.TimeoutError):
+            await box.exec(
+                "python3",
+                "-c",
+                IGNORE_TERM_AND_ALRM,
+                str(WORKLOAD_S),
+                timeout=TIMEOUT_S,
+            )
         elapsed = time.time() - t0
 
-        assert result.exit_code != 0, (
-            f"stage-3 SIGKILL fallback broken: exec returned exit_code=0 "
-            f"after {elapsed:.2f}s. The workload ignores SIGTERM AND was not "
-            f"SIGKILL'd by the watcher — either grace expired without sending "
-            f"SIGKILL, or stage-3 escalation was removed from "
-            f"src/guest/src/service/exec/timeout.rs."
-        )
         # Expected ~ TIMEOUT_S + GRACE_S = 5.0s. Allow +2.0s headroom for VM
         # / SDK overhead. If elapsed approaches WORKLOAD_S, the watcher is
         # not enforcing the deadline at all.

--- a/sdks/python/tests/test_sync_simplebox.py
+++ b/sdks/python/tests/test_sync_simplebox.py
@@ -9,11 +9,9 @@ from __future__ import annotations
 
 import pytest
 
-import boxlite
-
 # Try to import sync API - skip if greenlet not installed
 try:
-    from boxlite import SyncSimpleBox
+    from boxlite import SyncSimpleBox, TimeoutError as BoxliteTimeoutError
 
     SYNC_AVAILABLE = True
 except ImportError:
@@ -119,7 +117,7 @@ class TestSyncSimpleBox:
     def test_exec_with_timeout(self, shared_sync_runtime):
         """Per-exec timeout raises a typed TimeoutError."""
         with SyncSimpleBox(image="alpine:latest", runtime=shared_sync_runtime) as box:
-            with pytest.raises(boxlite.TimeoutError):
+            with pytest.raises(BoxliteTimeoutError):
                 box.exec("sleep", "60", timeout=2)
 
     def test_exec_combined_options(self, shared_sync_runtime):

--- a/sdks/python/tests/test_sync_simplebox.py
+++ b/sdks/python/tests/test_sync_simplebox.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import pytest
 
+import boxlite
+
 # Try to import sync API - skip if greenlet not installed
 try:
     from boxlite import SyncSimpleBox
@@ -115,10 +117,10 @@ class TestSyncSimpleBox:
             assert "nobody" in result.stdout
 
     def test_exec_with_timeout(self, shared_sync_runtime):
-        """Per-exec timeout kills long-running commands."""
+        """Per-exec timeout raises a typed TimeoutError."""
         with SyncSimpleBox(image="alpine:latest", runtime=shared_sync_runtime) as box:
-            result = box.exec("sleep", "60", timeout=2)
-            assert result.exit_code != 0
+            with pytest.raises(boxlite.TimeoutError):
+                box.exec("sleep", "60", timeout=2)
 
     def test_exec_combined_options(self, shared_sync_runtime):
         """Per-exec cwd and user can be combined."""

--- a/src/boxlite/src/litebox/exec.rs
+++ b/src/boxlite/src/litebox/exec.rs
@@ -345,6 +345,8 @@ impl Execution {
 pub struct ExecResult {
     /// Exit code (0 = success). If terminated by signal, code is negative signal number.
     pub exit_code: i32,
+    /// Whether the configured execution timeout terminated this process.
+    pub timed_out: bool,
     /// Diagnostic message when process died unexpectedly
     /// (e.g., container init death causing PID namespace teardown).
     /// None if the process exited normally.

--- a/src/boxlite/src/portal/interfaces/exec.rs
+++ b/src/boxlite/src/portal/interfaces/exec.rs
@@ -293,6 +293,7 @@ impl ExecProtocol {
         };
         ExecResult {
             exit_code: code,
+            timed_out: resp.timed_out,
             error_message,
         }
     }
@@ -433,7 +434,11 @@ impl ExecProtocol {
                     tracing::debug!(execution_id = %execution_id, "Wait cancelled during shutdown");
                     // Send a special result indicating cancellation
                     // Using exit code -1 to indicate abnormal termination
-                    let _ = result_tx.send(ExecResult { exit_code: -1, error_message: None });
+                    let _ = result_tx.send(ExecResult {
+                        exit_code: -1,
+                        timed_out: false,
+                        error_message: None,
+                    });
                     return;
                 }
                 result = client.wait(request) => result,
@@ -452,6 +457,7 @@ impl ExecProtocol {
                     );
                     let _ = result_tx.send(ExecResult {
                         exit_code: -1,
+                        timed_out: false,
                         error_message: None,
                     });
                 }
@@ -852,7 +858,11 @@ mod tests {
             tokio::select! {
                 biased;
                 _ = token_clone.cancelled() => {
-                    let _ = result_tx.send(ExecResult { exit_code: -1, error_message: None });
+                    let _ = result_tx.send(ExecResult {
+                        exit_code: -1,
+                        timed_out: false,
+                        error_message: None,
+                    });
                 }
                 _ = tokio::time::sleep(Duration::from_secs(3600)) => {
                     // Would normally wait for gRPC response

--- a/src/boxlite/src/rest/litebox.rs
+++ b/src/boxlite/src/rest/litebox.rs
@@ -601,7 +601,7 @@ const WS_CLIENT_PING_INTERVAL: std::time::Duration = std::time::Duration::from_m
 ///   control (`resize`, `signal`, `stdin_eof`).
 /// - Server → Client: binary frames have a 1-byte channel prefix
 ///   (`0x01` = stdout, `0x02` = stderr); text JSON frames are
-///   `{"type":"exit","exit_code":N}` (terminal) or
+///   `{"type":"exit","exit_code":N,"timed_out":bool}` (terminal) or
 ///   `{"type":"error","message":"..."}` (informational, connection stays open).
 ///
 /// Always emits exactly one `ExecResult` to `result_tx` before returning,
@@ -812,11 +812,14 @@ async fn attach_ws_pump(
                             }
                         }
                         Message::Text(text) => match parse_control_frame(&text) {
-                            ControlFrame::Exit { exit_code } => {
-                                tracing::debug!(exit_code, "WS attach: exit control frame");
+                            ControlFrame::Exit {
+                                exit_code,
+                                timed_out,
+                            } => {
+                                tracing::debug!(exit_code, timed_out, "WS attach: exit control frame");
                                 let _ = result_tx.send(ExecResult {
                                     exit_code,
-                                    timed_out: false,
+                                    timed_out,
                                     error_message: None,
                                 });
                                 return;
@@ -959,7 +962,7 @@ async fn probe_execution_status(
 
 /// Decoded form of a Server→Client text-JSON frame.
 enum ControlFrame {
-    Exit { exit_code: i32 },
+    Exit { exit_code: i32, timed_out: bool },
     Error { message: String },
     Unknown,
 }
@@ -974,7 +977,14 @@ fn parse_control_frame(text: &str) -> ControlFrame {
                 .get("exit_code")
                 .and_then(|v| v.as_i64())
                 .unwrap_or(-1) as i32;
-            ControlFrame::Exit { exit_code }
+            let timed_out = value
+                .get("timed_out")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            ControlFrame::Exit {
+                exit_code,
+                timed_out,
+            }
         }
         Some("error") => {
             let message = value
@@ -1462,8 +1472,8 @@ mod tests {
     // ─── ws_clean_exit_emits_result ───────────────────────────────────────
     //
     // Server sends one stdout binary frame, one exit text frame, then
-    // closes. Client must observe `ExecResult { exit_code: 7 }`, the
-    // stdout payload, and stdin bytes must round-trip back as binary.
+    // closes. Client must observe `ExecResult { exit_code: 7, timed_out: true }`,
+    // the stdout payload, and stdin bytes must round-trip back as binary.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn ws_clean_exit_emits_result() {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -1483,9 +1493,11 @@ mod tests {
                 ws.send(Message::Binary(vec![0x01, b'h', b'i']))
                     .await
                     .unwrap();
-                ws.send(Message::Text(r#"{"type":"exit","exit_code":7}"#.into()))
-                    .await
-                    .unwrap();
+                ws.send(Message::Text(
+                    r#"{"type":"exit","exit_code":7,"timed_out":true}"#.into(),
+                ))
+                .await
+                .unwrap();
                 let _ = ws.close(None).await;
             })
             .await;
@@ -1513,6 +1525,7 @@ mod tests {
             .expect("result channel timed out")
             .expect("result channel closed without value");
         assert_eq!(res.exit_code, 7);
+        assert!(res.timed_out);
         assert!(res.error_message.is_none());
 
         let out = tokio::time::timeout(Duration::from_secs(1), stdout_rx.recv())

--- a/src/boxlite/src/rest/litebox.rs
+++ b/src/boxlite/src/rest/litebox.rs
@@ -816,6 +816,7 @@ async fn attach_ws_pump(
                                 tracing::debug!(exit_code, "WS attach: exit control frame");
                                 let _ = result_tx.send(ExecResult {
                                     exit_code,
+                                    timed_out: false,
                                     error_message: None,
                                 });
                                 return;
@@ -937,13 +938,17 @@ async fn probe_execution_status(
         client.get::<ExecutionStatusResponse>(&status_path),
     );
     match status_probe.await {
-        Ok(Ok(info)) => match info.status.as_str() {
-            "completed" | "killed" | "timed_out" => ProbeResult::Terminal(ExecResult {
-                exit_code: info.exit_code.unwrap_or(-1),
-                error_message: None,
-            }),
-            _ => ProbeResult::StillRunning,
-        },
+        Ok(Ok(info)) => {
+            let timed_out = info.status == "timed_out";
+            match info.status.as_str() {
+                "completed" | "killed" | "timed_out" => ProbeResult::Terminal(ExecResult {
+                    exit_code: info.exit_code.unwrap_or(-1),
+                    timed_out,
+                    error_message: None,
+                }),
+                _ => ProbeResult::StillRunning,
+            }
+        }
         // A definitive 404 means the box or exec genuinely does not
         // exist — distinct from a transient probe failure. Don't loop
         // the reconnect budget against something that isn't there.
@@ -1012,6 +1017,7 @@ async fn emit_or_fallback(
                 // lost the output". The real exit code is still preserved.
                 let _ = result_tx.send(ExecResult {
                     exit_code: info.exit_code.unwrap_or(-1),
+                    timed_out: info.status == "timed_out",
                     error_message: Some(cause.clone()),
                 });
                 return;
@@ -1024,6 +1030,7 @@ async fn emit_or_fallback(
     }
     let _ = result_tx.send(ExecResult {
         exit_code: -1,
+        timed_out: false,
         error_message: Some(cause),
     });
 }

--- a/src/cli/src/commands/serve/mod.rs
+++ b/src/cli/src/commands/serve/mod.rs
@@ -1682,6 +1682,7 @@ mod tests {
         result_tx
             .send(boxlite::ExecResult {
                 exit_code: 0,
+                timed_out: false,
                 error_message: None,
             })
             .unwrap();
@@ -1725,6 +1726,7 @@ mod tests {
         result_tx
             .send(boxlite::ExecResult {
                 exit_code: 42,
+                timed_out: false,
                 error_message: None,
             })
             .unwrap();

--- a/src/cli/src/commands/serve/mod.rs
+++ b/src/cli/src/commands/serve/mod.rs
@@ -1784,6 +1784,7 @@ mod tests {
         result_tx
             .send(boxlite::ExecResult {
                 exit_code: 0,
+                timed_out: false,
                 error_message: None,
             })
             .unwrap();

--- a/src/cli/src/terminal/mod.rs
+++ b/src/cli/src/terminal/mod.rs
@@ -434,6 +434,7 @@ mod tests {
                     tokio::time::sleep(Duration::from_millis(150)).await;
                     let _ = result_tx.send(boxlite::ExecResult {
                         exit_code: 0,
+                        timed_out: false,
                         error_message: None,
                     });
                     drop(stdout_tx);
@@ -490,6 +491,7 @@ mod tests {
             tokio::spawn(async move {
                 let _ = result_tx.send(boxlite::ExecResult {
                     exit_code: 0,
+                    timed_out: false,
                     error_message: Some(
                         "WS connect failed: WS auth rejected (401 Unauthorized)".to_string(),
                     ),

--- a/src/guest/src/reaper.rs
+++ b/src/guest/src/reaper.rs
@@ -85,6 +85,11 @@ pub(crate) type ExitAction = Box<dyn FnOnce(ExitStatus) + Send>;
 pub(crate) struct ExitSlot(watch::Receiver<Option<ExitStatus>>);
 
 impl ExitSlot {
+    /// Return the exit status without waiting when the reaper has settled it.
+    pub(crate) fn try_get(&self) -> Option<ExitStatus> {
+        *self.0.borrow()
+    }
+
     /// The pid's exit status, awaiting it if it has not exited yet.
     pub(crate) async fn get(&self) -> ExitStatus {
         let mut rx = self.0.clone();

--- a/src/guest/src/service/exec/mod.rs
+++ b/src/guest/src/service/exec/mod.rs
@@ -139,6 +139,7 @@ impl Execution for GuestServer {
 
         // Wait for process to exit
         let exit_status = state.wait_process().await;
+        let timed_out = state.was_timed_out().await;
 
         let (exit_code, signal, error_message) = match exit_status {
             ExitStatus::Code(code) => {
@@ -178,7 +179,7 @@ impl Execution for GuestServer {
         Ok(Response::new(WaitResponse {
             exit_code,
             signal,
-            timed_out: false,
+            timed_out,
             duration_ms: 0,
             error_message,
         }))

--- a/src/guest/src/service/exec/state.rs
+++ b/src/guest/src/service/exec/state.rs
@@ -294,6 +294,10 @@ impl ExecutionState {
     pub async fn kill_for_timeout(&self, signal: nix::sys::signal::Signal) -> bool {
         let mut inner = self.inner.lock().await;
 
+        if self.exit.try_get().is_some() {
+            return false;
+        }
+
         if let Some(ref handle) = inner.handle {
             let sent = handle.kill(signal).is_ok();
             if sent {

--- a/src/guest/src/service/exec/state.rs
+++ b/src/guest/src/service/exec/state.rs
@@ -191,11 +191,6 @@ impl ExecutionState {
         self.exit.get().await
     }
 
-    pub async fn mark_timed_out(&self) {
-        let mut inner = self.inner.lock().await;
-        inner.timed_out = true;
-    }
-
     pub async fn was_timed_out(&self) -> bool {
         let inner = self.inner.lock().await;
         inner.timed_out
@@ -289,6 +284,22 @@ impl ExecutionState {
 
         if let Some(ref handle) = inner.handle {
             handle.kill(signal).is_ok()
+        } else {
+            false
+        }
+    }
+
+    /// Kill process for timeout handling and record the timeout under the
+    /// same lock so wait cannot observe a signal-caused exit as completed.
+    pub async fn kill_for_timeout(&self, signal: nix::sys::signal::Signal) -> bool {
+        let mut inner = self.inner.lock().await;
+
+        if let Some(ref handle) = inner.handle {
+            let sent = handle.kill(signal).is_ok();
+            if sent {
+                inner.timed_out = true;
+            }
+            sent
         } else {
             false
         }

--- a/src/guest/src/service/exec/state.rs
+++ b/src/guest/src/service/exec/state.rs
@@ -27,8 +27,7 @@ struct Inner {
     handle: Option<ExecHandle>,
     /// Stdout/stderr forwarding tasks (set on attach)
     output_tasks: Vec<JoinHandle<()>>,
-    /// Timeout flag
-    #[allow(dead_code)] // Will be used for timeout handling
+    /// Set once the execution timeout watcher has signaled this process.
     timed_out: bool,
     /// Optional init health checker for the container this exec runs in.
     /// Used to detect container init death when exec gets SIGKILL.
@@ -190,6 +189,16 @@ impl ExecutionState {
     /// concurrent callers and any number of later ones all read the same status.
     pub async fn wait_process(&self) -> crate::service::exec::exec_handle::ExitStatus {
         self.exit.get().await
+    }
+
+    pub async fn mark_timed_out(&self) {
+        let mut inner = self.inner.lock().await;
+        inner.timed_out = true;
+    }
+
+    pub async fn was_timed_out(&self) -> bool {
+        let inner = self.inner.lock().await;
+        inner.timed_out
     }
 
     /// Attach to execution output.

--- a/src/guest/src/service/exec/timeout.rs
+++ b/src/guest/src/service/exec/timeout.rs
@@ -38,6 +38,7 @@ pub(super) fn start_timeout_watcher(
             // Process already exited on its own; nothing more to do.
             return;
         }
+        exec_state.mark_timed_out().await;
         info!(
             execution_id = %exec_id,
             grace_ms = TIMEOUT_GRACE.as_millis() as u64,

--- a/src/guest/src/service/exec/timeout.rs
+++ b/src/guest/src/service/exec/timeout.rs
@@ -44,14 +44,13 @@ pub(super) fn start_timeout_watcher(
             "SIGTERM on timeout; grace before SIGKILL"
         );
 
-        // Stage 2: wait for the grace window. `exec_state.kill` already
-        // returns false once the process is reaped, so we do not need to
-        // poll — we just sleep the full grace then ask for SIGKILL.
+        // Stage 2: wait for the grace window. We do not need to poll; before
+        // SIGKILL, kill_for_timeout rechecks whether the process was reaped.
         tokio::time::sleep(TIMEOUT_GRACE).await;
 
         // Stage 3: SIGKILL fallback. Returns false if SIGTERM was honored
         // during the grace window (clean exit, no escalation needed).
-        if exec_state.kill(Signal::SIGKILL).await {
+        if exec_state.kill_for_timeout(Signal::SIGKILL).await {
             warn!(
                 execution_id = %exec_id,
                 "SIGKILL after grace expired; workload did not exit on SIGTERM"

--- a/src/guest/src/service/exec/timeout.rs
+++ b/src/guest/src/service/exec/timeout.rs
@@ -34,11 +34,10 @@ pub(super) fn start_timeout_watcher(
         use nix::sys::signal::Signal;
 
         // Stage 1: SIGTERM — polite termination request.
-        if !exec_state.kill(Signal::SIGTERM).await {
+        if !exec_state.kill_for_timeout(Signal::SIGTERM).await {
             // Process already exited on its own; nothing more to do.
             return;
         }
-        exec_state.mark_timed_out().await;
         info!(
             execution_id = %exec_id,
             grace_ms = TIMEOUT_GRACE.as_millis() as u64,


### PR DESCRIPTION
Raise TimeoutError from Python convenience exec APIs using an explicit timeout signal propagated through local and cloud execution paths.

Test plan:
- [x] cargo fmt --all
- [x] cargo fmt --all --check
- [x] python3 -m py_compile sdks/python/boxlite/exec.py sdks/python/boxlite/simplebox.py sdks/python/boxlite/sync_api/_simplebox.py sdks/python/tests/test_exec_timeout_sigalrm.py sdks/python/tests/test_sync_simplebox.py
- [x] BOXLITE_DEPS_STUB=1 cargo check -p boxlite-c -p boxlite -p boxlite-cli -p boxlite-python
- [x] BOXLITE_DEPS_STUB=1 cargo check -p boxlite
- [x] BOXLITE_DEPS_STUB=1 cargo test -p boxlite --features rest ws_clean_exit_emits_result -- --nocapture
- [x] cargo check -p boxlite-guest --target aarch64-unknown-linux-musl
- [x] git diff --check
- [x] ssh ngolo@54.169.172.226 'bash -lc "cd ~/boxlite-pr959-timeout && BOXLITE_DEPS_STUB=1 cargo check -p boxlite-guest"'
- [x] ssh ngolo@54.169.172.226 'bash -lc "cd ~/boxlite-pr959-cloud-check && BOXLITE_DEPS_STUB=1 cargo check -p boxlite-c"'
- [x] ssh ngolo@54.169.172.226 'bash -lc "cd ~/boxlite-pr959-cloud-check && BOXLITE_DEPS_STUB=1 cargo build -p boxlite-c && cd apps/runner && go test -tags boxlite_dev ./pkg/api/controllers ./pkg/boxlite"'
- [x] ssh ngolo@54.169.172.226 'bash -lc "cd ~/boxlite-pr959-attach-check/apps/runner && go test -tags boxlite_dev ./pkg/api/controllers -count=1"'
- [x] ssh ngolo@54.169.172.226 'bash -lc "cd ~/boxlite-pr959-realvm-check && cargo build -p boxlite-guest --target x86_64-unknown-linux-musl && cargo rustc -p boxlite-c --lib --crate-type staticlib && cd apps && go test -tags boxlite_dev ./runner/pkg/boxlite -run TestIntegrationExecManagerRecordsTimedOut -count=1 -v"'
- [ ] Live dev rollout not run; current deployed dev runner was only used to confirm the pre-fix cloud API reports timed-out execs as completed/-15


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Execution wait results now include a `timed_out` flag (alongside exit code) across APIs and SDKs.
  * REST and WebSocket execution reporting now distinguish `timed_out` terminal outcomes.
  * C and Go SDKs add structured “wait result” support (exit code + timeout flag); Python and CLI/SDK results expose `timed_out`.
* **Bug Fixes**
  * Timeout state is now consistently mapped into execution status, callbacks, and response payloads (including WebSocket/REST and guest wait reporting).
* **Tests**
  * Added unit/integration coverage for `timed_out` responses and updated Python tests to expect timeout exceptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->