### PR TITLE
fix(python): add async SimpleBox metrics

### DIFF
--- a/sdks/python/boxlite/simplebox.py
+++ b/sdks/python/boxlite/simplebox.py
@@ -292,6 +292,15 @@ class SimpleBox:
             error_message=error_message,
         )
 
+    async def metrics(self):
+        """Get box metrics (CPU, memory usage)."""
+        if not self._started:
+            raise RuntimeError(
+                "Box not started. Use 'async with SimpleBox(...) as box:' "
+                "or call 'await box.start()' first."
+            )
+        return await self._box.metrics()
+
     async def stop(self):
         """
         Stop the box and release resources.

--- a/sdks/python/tests/test_simplebox.py
+++ b/sdks/python/tests/test_simplebox.py
@@ -1,0 +1,20 @@
+"""Integration tests for the async SimpleBox convenience wrapper."""
+
+from __future__ import annotations
+
+import pytest
+
+import boxlite
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+
+
+async def test_simplebox_metrics(shared_runtime):
+    """Async SimpleBox exposes box metrics like SyncSimpleBox."""
+    async with boxlite.SimpleBox(
+        image="alpine:latest", runtime=shared_runtime
+    ) as box:
+        await box.exec("echo", "test")
+        metrics = await box.metrics()
+        assert metrics is not None
+        assert metrics.commands_executed_total >= 1

--- a/sdks/python/tests/test_simplebox.py
+++ b/sdks/python/tests/test_simplebox.py
@@ -11,9 +11,7 @@ pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
 
 async def test_simplebox_metrics(shared_runtime):
     """Async SimpleBox exposes box metrics like SyncSimpleBox."""
-    async with boxlite.SimpleBox(
-        image="alpine:latest", runtime=shared_runtime
-    ) as box:
+    async with boxlite.SimpleBox(image="alpine:latest", runtime=shared_runtime) as box:
         await box.exec("echo", "test")
         metrics = await box.metrics()
         assert metrics is not None


### PR DESCRIPTION
Add metrics() to async SimpleBox so it matches the synchronous convenience API.

Test plan:
- [x] cargo fmt --all
- [x] sdks/python/.venv/bin/python -m py_compile sdks/python/boxlite/simplebox.py sdks/python/tests/test_simplebox.py
- [x] BOXLITE_DEPS_STUB=1 cargo check -p boxlite-python
- [ ] Not rerun on debug host after splitting; the same SimpleBox metrics path passed on debug host before the split in #954

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an async `metrics()` capability to `SimpleBox` to retrieve resource usage (CPU/memory) for a box that has been started.
  * Enforces the same started/ready-state requirement as other `SimpleBox` actions.
* **Tests**
  * Added an integration test that starts a `SimpleBox`, runs a command, retrieves `box.metrics()`, and verifies metrics are returned and include a non-zero `commands_executed_total`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->