### PR TITLE
fix(python): clarify Boxlite context manager

### DIFF
--- a/sdks/python/src/runtime.rs
+++ b/sdks/python/src/runtime.rs
@@ -237,8 +237,29 @@ impl PyBoxlite {
         })
     }
 
-    fn __enter__(slf: PyRef<'_, Self>) -> PyResult<PyRef<'_, Self>> {
-        Ok(slf)
+    fn __aenter__<'py>(slf: Py<Self>, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        pyo3_async_runtimes::tokio::future_into_py(py, async move { Ok(slf) })
+    }
+
+    fn __aexit__<'py>(
+        &self,
+        py: Python<'py>,
+        _exc_type: Py<PyAny>,
+        _exc_val: Py<PyAny>,
+        _exc_tb: Py<PyAny>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let runtime = Arc::clone(&self.runtime);
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            runtime.shutdown(None).await.map_err(map_err)?;
+            Ok(false)
+        })
+    }
+
+    fn __enter__(&self) -> PyResult<()> {
+        Err(pyo3::exceptions::PyRuntimeError::new_err(
+            "Boxlite is an async runtime; use 'async with boxlite.Boxlite(...)' \
+             or use 'with boxlite.SyncBoxlite(...)' for the synchronous API",
+        ))
     }
 
     fn __exit__(

--- a/sdks/python/tests/test_box_management_mock.py
+++ b/sdks/python/tests/test_box_management_mock.py
@@ -137,6 +137,21 @@ class TestBoxliteManagementMethods:
     def test_method_exists(self, cls, method):
         assert hasattr(cls, method), f"Boxlite missing method: {method}"
 
+    def test_sync_context_manager_points_to_sync_api(self, tmp_path):
+        runtime = boxlite.Boxlite(boxlite.Options(home_dir=str(tmp_path)))
+        with pytest.raises(RuntimeError, match="SyncBoxlite"):
+            with runtime:
+                pass
+
+    @pytest.mark.asyncio
+    async def test_async_context_manager(self, tmp_path):
+        runtime = boxlite.Boxlite(boxlite.Options(home_dir=str(tmp_path)))
+        async with runtime as entered:
+            assert entered is runtime
+
+        with pytest.raises(RuntimeError, match="runtime has been shut down"):
+            await runtime.create(boxlite.BoxOptions(image="alpine:latest"))
+
     def test_rest_runtime_images_unsupported(self):
         runtime = boxlite.Boxlite.rest(
             boxlite.BoxliteRestOptions(url="http://localhost:1")


### PR DESCRIPTION
Make native Boxlite support async context management and reject sync context-manager usage with a SyncBoxlite hint.

Test plan:
- [x] cargo fmt --all
- [x] sdks/python/.venv/bin/python -m py_compile sdks/python/tests/test_box_management_mock.py
- [x] BOXLITE_DEPS_STUB=1 cargo check -p boxlite-python
- [ ] Not rerun on debug host after splitting; the same context-manager paths passed on debug host before the split in #954

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added async context-manager support for the Python runtime via `async with`.
  * Async context managers now shut down the underlying runtime automatically on exit.

* **Bug Fixes**
  * Using the async context manager with `with` now raises a clear error directing users to the correct synchronous API.
  * Attempting to use the runtime after exiting the async context now raises an informative error.

* **Tests**
  * Added pytest coverage for both sync-misuse and async lifecycle/shutdown behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->