### PR TITLE
feat(billing): settle rated usage into wallet ledger (Phase 3 Wallet)

### DIFF
--- a/apps/api/src/billing/billing.module.ts
+++ b/apps/api/src/billing/billing.module.ts
@@ -5,14 +5,28 @@
 
 import { Module } from '@nestjs/common'
 import { TypeOrmModule } from '@nestjs/typeorm'
+import { Organization } from '../organization/entities/organization.entity'
 import { BoxUsagePeriodArchive } from '../usage/entities/box-usage-period-archive.entity'
 import { PricingPlan } from './entities/pricing-plan.entity'
 import { RatedPeriod } from './entities/rated-period.entity'
+import { WalletTransaction } from './entities/wallet-transaction.entity'
+import { Wallet } from './entities/wallet.entity'
 import { RatingService } from './rating/rating.service'
+import { SettlementService } from './settlement.service'
+import { WalletService } from './wallet.service'
 
 @Module({
-  imports: [TypeOrmModule.forFeature([BoxUsagePeriodArchive, PricingPlan, RatedPeriod])],
-  providers: [RatingService],
-  exports: [RatingService],
+  imports: [
+    TypeOrmModule.forFeature([
+      BoxUsagePeriodArchive,
+      PricingPlan,
+      RatedPeriod,
+      Wallet,
+      WalletTransaction,
+      Organization,
+    ]),
+  ],
+  providers: [RatingService, WalletService, SettlementService],
+  exports: [RatingService, WalletService, SettlementService],
 })
 export class BillingModule {}

--- a/apps/api/src/billing/entities/wallet-transaction.entity.ts
+++ b/apps/api/src/billing/entities/wallet-transaction.entity.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn } from 'typeorm'
+
+export type WalletTransactionKind = 'free_grant' | 'usage_debit' | 'adjustment'
+
+@Entity('wallet_transaction')
+@Index('wallet_transaction_wallet_created_idx', ['walletId', 'createdAt'])
+@Index('wallet_transaction_org_created_idx', ['organizationId', 'createdAt'])
+@Index('wallet_transaction_rated_period_idx', ['ratedPeriodId'], { unique: true })
+export class WalletTransaction {
+  @PrimaryGeneratedColumn('uuid')
+  id: string
+
+  @Column({ type: 'uuid' })
+  walletId: string
+
+  @Column({ type: 'uuid' })
+  organizationId: string
+
+  @Column({ type: 'character varying' })
+  kind: WalletTransactionKind
+
+  @Column({ type: 'bigint' })
+  amountCents: string
+
+  @Column({ type: 'character varying' })
+  source: string
+
+  @Column({ type: 'uuid', nullable: true })
+  ratedPeriodId: string | null
+
+  @Column({ type: 'jsonb', nullable: true })
+  metadata: Record<string, unknown> | null
+
+  @CreateDateColumn({ type: 'timestamp with time zone' })
+  createdAt: Date
+}

--- a/apps/api/src/billing/entities/wallet.entity.ts
+++ b/apps/api/src/billing/entities/wallet.entity.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Check, Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm'
+
+export type BillingStatus = 'trial' | 'active' | 'zero_balance'
+
+@Entity('wallet')
+@Index('wallet_organization_idx', ['organizationId'], { unique: true })
+@Check('wallet_free_balance_non_negative', '"freeBalanceCents" >= 0')
+@Check('wallet_remainder_range', '"settlementRemainderCents" >= 0 AND "settlementRemainderCents" < 1')
+export class Wallet {
+  @PrimaryGeneratedColumn('uuid')
+  id: string
+
+  @Column({ type: 'uuid' })
+  organizationId: string
+
+  @Column({ type: 'bigint', default: 0 })
+  freeBalanceCents: string
+
+  @Column({ type: 'bigint', default: 0 })
+  paidBalanceCents: string
+
+  @Column({ type: 'numeric', precision: 38, scale: 18, default: 0 })
+  settlementRemainderCents: string
+
+  @Column({ type: 'timestamp with time zone', nullable: true })
+  freeExpiresAt: Date | null
+
+  @Column({ type: 'character varying', default: 'trial' })
+  billingStatus: BillingStatus
+
+  @CreateDateColumn({ type: 'timestamp with time zone' })
+  createdAt: Date
+
+  @UpdateDateColumn({ type: 'timestamp with time zone' })
+  updatedAt: Date
+}

--- a/apps/api/src/billing/rating/rating.service.ts
+++ b/apps/api/src/billing/rating/rating.service.ts
@@ -3,8 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { Injectable, Logger } from '@nestjs/common'
-import { Cron, CronExpression } from '@nestjs/schedule'
+import { Injectable } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
 import { QueryFailedError, Repository } from 'typeorm'
 import { BoxUsagePeriodArchive } from '../../usage/entities/box-usage-period-archive.entity'
@@ -24,8 +23,6 @@ function isUniqueViolation(error: unknown): boolean {
 
 @Injectable()
 export class RatingService {
-  private readonly logger = new Logger(RatingService.name)
-
   constructor(
     @InjectRepository(BoxUsagePeriodArchive)
     private readonly usageArchives: Repository<BoxUsagePeriodArchive>,
@@ -34,14 +31,6 @@ export class RatingService {
     @InjectRepository(PricingPlan)
     private readonly pricingPlans: Repository<PricingPlan>,
   ) {}
-
-  @Cron(CronExpression.EVERY_5_MINUTES, { name: 'rate-usage-periods' })
-  async scheduledSweep(): Promise<void> {
-    const result = await this.rateClosedPeriods()
-    if (result.rated || result.skipped) {
-      this.logger.log(`rating sweep: rated ${result.rated}, skipped ${result.skipped}`)
-    }
-  }
 
   async rateClosedPeriods(limit = RATING_BATCH_SIZE): Promise<{ rated: number; skipped: number }> {
     const periods = await this.findUnratedArchivedPeriods(limit)

--- a/apps/api/src/billing/settlement.service.spec.ts
+++ b/apps/api/src/billing/settlement.service.spec.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { SettlementService } from './settlement.service'
+
+describe('SettlementService', () => {
+  it('rates archived usage before debiting rated periods', async () => {
+    const order: string[] = []
+    const ratingService = {
+      async rateClosedPeriods() {
+        order.push('rating')
+        return { rated: 2, skipped: 1 }
+      },
+    }
+    const walletService = {
+      async debitRatedPeriods() {
+        order.push('wallet')
+        return { debited: 2, skipped: 0 }
+      },
+    }
+    const service = new SettlementService(ratingService as never, walletService as never)
+
+    await expect(service.settleClosedPeriods()).resolves.toEqual({
+      rated: 2,
+      ratingSkipped: 1,
+      debited: 2,
+      debitSkipped: 0,
+    })
+    expect(order).toEqual(['rating', 'wallet'])
+  })
+
+  it('does not debit when rating fails', async () => {
+    const walletService = { debitRatedPeriods: jest.fn() }
+    const service = new SettlementService(
+      { rateClosedPeriods: jest.fn().mockRejectedValue(new Error('rating unavailable')) } as never,
+      walletService as never,
+    )
+
+    await expect(service.settleClosedPeriods()).rejects.toThrow('rating unavailable')
+    expect(walletService.debitRatedPeriods).not.toHaveBeenCalled()
+  })
+})

--- a/apps/api/src/billing/settlement.service.ts
+++ b/apps/api/src/billing/settlement.service.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Injectable, Logger } from '@nestjs/common'
+import { Cron, CronExpression } from '@nestjs/schedule'
+import { RatingService } from './rating/rating.service'
+import { WalletService } from './wallet.service'
+
+@Injectable()
+export class SettlementService {
+  private readonly logger = new Logger(SettlementService.name)
+
+  constructor(
+    private readonly ratingService: RatingService,
+    private readonly walletService: WalletService,
+  ) {}
+
+  @Cron(CronExpression.EVERY_MINUTE, { name: 'settle-billing-periods' })
+  async scheduledSweep(): Promise<void> {
+    const result = await this.settleClosedPeriods()
+    if (result.rated || result.ratingSkipped || result.debited || result.debitSkipped) {
+      this.logger.log(
+        `settlement sweep: rated ${result.rated}, rating skipped ${result.ratingSkipped}, ` +
+          `debited ${result.debited}, debit skipped ${result.debitSkipped}`,
+      )
+    }
+  }
+
+  async settleClosedPeriods(): Promise<{
+    rated: number
+    ratingSkipped: number
+    debited: number
+    debitSkipped: number
+  }> {
+    const rating = await this.ratingService.rateClosedPeriods()
+    const debit = await this.walletService.debitRatedPeriods()
+    return {
+      rated: rating.rated,
+      ratingSkipped: rating.skipped,
+      debited: debit.debited,
+      debitSkipped: debit.skipped,
+    }
+  }
+}

--- a/apps/api/src/billing/wallet.service.spec.ts
+++ b/apps/api/src/billing/wallet.service.spec.ts
@@ -1,0 +1,292 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Organization } from '../organization/entities/organization.entity'
+import { RatedPeriod } from './entities/rated-period.entity'
+import { WalletTransaction } from './entities/wallet-transaction.entity'
+import { Wallet } from './entities/wallet.entity'
+import { WalletService } from './wallet.service'
+
+interface RepositoryWithRows {
+  rows: unknown[]
+}
+
+class FakeEntityManager {
+  readonly repositories = new Map<unknown, RepositoryWithRows>()
+
+  getRepository<T>(entity: unknown): T {
+    const repository = this.repositories.get(entity)
+    if (!repository) {
+      throw new Error(`missing fake repository for ${String(entity)}`)
+    }
+    return repository as T
+  }
+
+  async transaction<T>(work: (manager: FakeEntityManager) => Promise<T>): Promise<T> {
+    const snapshots = new Map<RepositoryWithRows, unknown[]>()
+    for (const repository of this.repositories.values()) {
+      snapshots.set(repository, structuredClone(repository.rows))
+    }
+
+    try {
+      return await work(this)
+    } catch (error) {
+      for (const [repository, rows] of snapshots) {
+        repository.rows.splice(0, repository.rows.length, ...rows)
+      }
+      throw error
+    }
+  }
+}
+
+class FakeWalletRepository implements RepositoryWithRows {
+  rows: Wallet[] = []
+  manager: FakeEntityManager
+  lockModes: string[] = []
+
+  create(input: Partial<Wallet>): Wallet {
+    return input as Wallet
+  }
+
+  async findOne(options: { where: Partial<Wallet>; lock?: { mode: string } }): Promise<Wallet | null> {
+    if (options.lock) {
+      this.lockModes.push(options.lock.mode)
+    }
+    return this.rows.find((row) => row.organizationId === options.where.organizationId) ?? null
+  }
+
+  async save(wallet: Wallet): Promise<Wallet> {
+    if (!wallet.id) {
+      wallet.id = `wallet-${this.rows.length + 1}`
+      wallet.createdAt = new Date()
+    }
+    wallet.updatedAt = new Date()
+    const index = this.rows.findIndex((row) => row.id === wallet.id)
+    if (index === -1) {
+      this.rows.push(wallet)
+    } else {
+      this.rows[index] = wallet
+    }
+    return wallet
+  }
+}
+
+class FakeWalletTransactionRepository implements RepositoryWithRows {
+  rows: WalletTransaction[] = []
+  saveError: Error | null = null
+
+  create(input: Partial<WalletTransaction>): WalletTransaction {
+    return input as WalletTransaction
+  }
+
+  async findOne(options: { where: Partial<WalletTransaction> }): Promise<WalletTransaction | null> {
+    return (
+      this.rows.find(
+        (row) =>
+          options.where.ratedPeriodId !== undefined && row.ratedPeriodId === options.where.ratedPeriodId,
+      ) ?? null
+    )
+  }
+
+  async save(transaction: WalletTransaction): Promise<WalletTransaction> {
+    if (this.saveError) {
+      throw this.saveError
+    }
+    transaction.id = transaction.id ?? `transaction-${this.rows.length + 1}`
+    transaction.createdAt = transaction.createdAt ?? new Date()
+    this.rows.push(transaction)
+    return transaction
+  }
+}
+
+class FakeRatedPeriodRepository implements RepositoryWithRows {
+  rows: RatedPeriod[] = []
+
+  createQueryBuilder() {
+    const builder = {
+      leftJoin: () => builder,
+      where: () => builder,
+      orderBy: () => builder,
+      take: () => builder,
+      getMany: async () => this.rows,
+    }
+    return builder
+  }
+}
+
+class FakeOrganizationRepository implements RepositoryWithRows {
+  rows: Organization[] = []
+  lockModes: string[] = []
+
+  async findOne(options: { where: Partial<Organization>; lock?: { mode: string } }): Promise<Organization | null> {
+    if (options.lock) {
+      this.lockModes.push(options.lock.mode)
+    }
+    return this.rows.find((row) => row.id === options.where.id) ?? null
+  }
+}
+
+class FakeBillingConfig {
+  get(key: string): number {
+    if (key === 'billing.trialGrantCents') {
+      return 10000
+    }
+    if (key === 'billing.trialDurationDays') {
+      return 30
+    }
+    throw new Error(`unexpected config key ${key}`)
+  }
+}
+
+function ratedPeriod(overrides: Partial<RatedPeriod> = {}): RatedPeriod {
+  return {
+    id: 'rated-1',
+    usagePeriodArchiveId: 'e2591ad4-2a0e-48b9-b414-75a45f56d3cc',
+    organizationId: 'f5de33a9-4eb2-4279-a8de-9f02d63cc4f0',
+    boxId: 'box-1',
+    pricingSegments: [],
+    usageTotals: { cpuSeconds: '0', memGibSeconds: '0', diskGibSeconds: '0', gpuSeconds: '0' },
+    billedSeconds: '1',
+    preciseCents: '1',
+    ratedCents: '1',
+    ratedAt: new Date('2026-07-10T00:00:00Z'),
+    ...overrides,
+  }
+}
+
+function createService() {
+  const manager = new FakeEntityManager()
+  const wallets = new FakeWalletRepository()
+  const transactions = new FakeWalletTransactionRepository()
+  const ratedPeriods = new FakeRatedPeriodRepository()
+  const organizations = new FakeOrganizationRepository()
+  wallets.manager = manager
+  organizations.rows.push({ id: 'f5de33a9-4eb2-4279-a8de-9f02d63cc4f0' } as Organization)
+  manager.repositories.set(Wallet, wallets)
+  manager.repositories.set(WalletTransaction, transactions)
+  manager.repositories.set(RatedPeriod, ratedPeriods)
+  manager.repositories.set(Organization, organizations)
+  const service = new WalletService(
+    wallets as never,
+    ratedPeriods as never,
+    new FakeBillingConfig() as never,
+  )
+  return { service, wallets, transactions, ratedPeriods, organizations }
+}
+
+describe('WalletService', () => {
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-07-10T00:00:00Z'))
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('creates one wallet with a configurable 30-day free grant', async () => {
+    const { service, wallets, transactions, organizations } = createService()
+
+    const first = await service.getOrCreateWallet('f5de33a9-4eb2-4279-a8de-9f02d63cc4f0')
+    const second = await service.getOrCreateWallet('f5de33a9-4eb2-4279-a8de-9f02d63cc4f0')
+
+    expect(first).toBe(second)
+    expect(wallets.rows).toHaveLength(1)
+    expect(wallets.rows[0]).toMatchObject({
+      freeBalanceCents: '10000',
+      paidBalanceCents: '0',
+      settlementRemainderCents: '0',
+      freeExpiresAt: new Date('2026-08-09T00:00:00Z'),
+      billingStatus: 'trial',
+    })
+    expect(transactions.rows).toHaveLength(1)
+    expect(transactions.rows[0]).toMatchObject({ kind: 'free_grant', amountCents: '10000' })
+    expect(organizations.lockModes).toContain('pessimistic_write')
+  })
+
+  it('carries sub-cent usage and debits only whole cents from the wallet', async () => {
+    const { service, wallets, transactions } = createService()
+    await service.debitRatedPeriod(ratedPeriod({ id: 'rated-1', preciseCents: '0.6', ratedCents: '1' }))
+    await service.debitRatedPeriod(ratedPeriod({ id: 'rated-2', preciseCents: '0.6', ratedCents: '1' }))
+
+    expect(wallets.rows[0]).toMatchObject({ freeBalanceCents: '9999', settlementRemainderCents: '0.2' })
+    expect(transactions.rows.filter((row) => row.kind === 'usage_debit').map((row) => row.amountCents)).toEqual([
+      '0',
+      '-1',
+    ])
+  })
+
+  it('spends free balance before paid balance', async () => {
+    const { service, wallets } = createService()
+    const wallet = await service.getOrCreateWallet('f5de33a9-4eb2-4279-a8de-9f02d63cc4f0')
+    wallet.freeBalanceCents = '100'
+    wallet.paidBalanceCents = '100'
+
+    await service.debitRatedPeriod(ratedPeriod({ preciseCents: '150', ratedCents: '150' }))
+
+    expect(wallets.rows[0]).toMatchObject({ freeBalanceCents: '0', paidBalanceCents: '50' })
+  })
+
+  it('preserves the usage debt as a negative paid balance', async () => {
+    const { service, wallets } = createService()
+    const wallet = await service.getOrCreateWallet('f5de33a9-4eb2-4279-a8de-9f02d63cc4f0')
+    wallet.freeBalanceCents = '0'
+    wallet.paidBalanceCents = '0'
+
+    await service.debitRatedPeriod(ratedPeriod({ preciseCents: '25', ratedCents: '25' }))
+
+    expect(wallets.rows[0]).toMatchObject({ paidBalanceCents: '-25', billingStatus: 'zero_balance' })
+  })
+
+  it('does not debit the same rated period twice and locks the wallet row', async () => {
+    const { service, wallets, transactions } = createService()
+    const period = ratedPeriod()
+
+    expect(await service.debitRatedPeriod(period)).not.toBeNull()
+    expect(await service.debitRatedPeriod(period)).toBeNull()
+
+    expect(transactions.rows.filter((row) => row.ratedPeriodId === period.id)).toHaveLength(1)
+    expect(wallets.lockModes).toContain('pessimistic_write')
+  })
+
+  it('rolls back the wallet mutation when the ledger insert fails', async () => {
+    const { service, wallets, transactions } = createService()
+    const wallet = await service.getOrCreateWallet('f5de33a9-4eb2-4279-a8de-9f02d63cc4f0')
+    wallet.freeBalanceCents = '100'
+    transactions.saveError = new Error('ledger unavailable')
+
+    await expect(service.debitRatedPeriod(ratedPeriod({ preciseCents: '10', ratedCents: '10' }))).rejects.toThrow(
+      'ledger unavailable',
+    )
+
+    expect(wallets.rows[0].freeBalanceCents).toBe('100')
+    expect(transactions.rows.filter((row) => row.kind === 'usage_debit')).toHaveLength(0)
+  })
+
+  it('expires unused trial funds before charging new usage', async () => {
+    const { service, wallets, transactions } = createService()
+    const wallet = await service.getOrCreateWallet('f5de33a9-4eb2-4279-a8de-9f02d63cc4f0')
+    wallet.freeBalanceCents = '100'
+    wallet.freeExpiresAt = new Date('2026-07-09T00:00:00Z')
+
+    await service.debitRatedPeriod(ratedPeriod())
+
+    expect(wallets.rows[0]).toMatchObject({ freeBalanceCents: '0', paidBalanceCents: '-1' })
+    expect(transactions.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: 'adjustment', source: 'trial_expired', amountCents: '-100' }),
+        expect.objectContaining({ kind: 'usage_debit', amountCents: '-1' }),
+      ]),
+    )
+  })
+
+  it('sweeps each unrated wallet debit once', async () => {
+    const { service, ratedPeriods, transactions } = createService()
+    ratedPeriods.rows.push(ratedPeriod({ id: 'rated-1' }), ratedPeriod({ id: 'rated-2' }))
+
+    expect(await service.debitRatedPeriods()).toEqual({ debited: 2, skipped: 0 })
+    expect(await service.debitRatedPeriods()).toEqual({ debited: 0, skipped: 2 })
+    expect(transactions.rows.filter((row) => row.kind === 'usage_debit')).toHaveLength(2)
+  })
+})

--- a/apps/api/src/billing/wallet.service.ts
+++ b/apps/api/src/billing/wallet.service.ts
@@ -1,0 +1,230 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Injectable, NotFoundException } from '@nestjs/common'
+import { InjectRepository } from '@nestjs/typeorm'
+import Decimal from 'decimal.js'
+import { EntityManager, QueryFailedError, Repository } from 'typeorm'
+import { TypedConfigService } from '../config/typed-config.service'
+import { Organization } from '../organization/entities/organization.entity'
+import { RatedPeriod } from './entities/rated-period.entity'
+import { WalletTransaction } from './entities/wallet-transaction.entity'
+import { BillingStatus, Wallet } from './entities/wallet.entity'
+
+const PG_UNIQUE_VIOLATION = '23505'
+const WALLET_DEBIT_BATCH_SIZE = 100
+const DAY_MILLISECONDS = 24 * 60 * 60 * 1000
+
+function isUniqueViolation(error: unknown): boolean {
+  return (
+    error instanceof QueryFailedError &&
+    (error.driverError as { code?: string } | undefined)?.code === PG_UNIQUE_VIOLATION
+  )
+}
+
+function nonNegativeBigInt(value: string): bigint {
+  const parsed = BigInt(value)
+  return parsed > 0n ? parsed : 0n
+}
+
+@Injectable()
+export class WalletService {
+  constructor(
+    @InjectRepository(Wallet)
+    private readonly wallets: Repository<Wallet>,
+    @InjectRepository(RatedPeriod)
+    private readonly ratedPeriods: Repository<RatedPeriod>,
+    private readonly configService: TypedConfigService,
+  ) {}
+
+  getOrCreateWallet(organizationId: string): Promise<Wallet> {
+    return this.wallets.manager.transaction((manager) => this.findWalletForUpdate(manager, organizationId))
+  }
+
+  async debitRatedPeriods(limit = WALLET_DEBIT_BATCH_SIZE): Promise<{ debited: number; skipped: number }> {
+    const periods = await this.findUndebitedRatedPeriods(limit)
+    let debited = 0
+    let skipped = 0
+
+    for (const period of periods) {
+      if (await this.debitRatedPeriod(period)) {
+        debited++
+      } else {
+        skipped++
+      }
+    }
+
+    return { debited, skipped }
+  }
+
+  async debitRatedPeriod(period: RatedPeriod): Promise<WalletTransaction | null> {
+    try {
+      return await this.wallets.manager.transaction(async (manager) => {
+        const wallet = await this.findWalletForUpdate(manager, period.organizationId)
+        const transactionRepository = manager.getRepository(WalletTransaction)
+        const existing = await transactionRepository.findOne({ where: { ratedPeriodId: period.id } })
+        if (existing) {
+          return null
+        }
+
+        const preciseCents = new Decimal(period.preciseCents)
+        if (preciseCents.isNegative()) {
+          throw new Error(`rated period ${period.id} has a negative charge`)
+        }
+        const remainderBefore = new Decimal(wallet.settlementRemainderCents)
+        const unsettledCents = remainderBefore.plus(preciseCents)
+        const debitCents = BigInt(unsettledCents.toDecimalPlaces(0, Decimal.ROUND_FLOOR).toFixed(0))
+        const freeBefore = BigInt(wallet.freeBalanceCents)
+        const paidBefore = BigInt(wallet.paidBalanceCents)
+        const freeDebitCents = debitCents < nonNegativeBigInt(wallet.freeBalanceCents)
+          ? debitCents
+          : nonNegativeBigInt(wallet.freeBalanceCents)
+        const paidDebitCents = debitCents - freeDebitCents
+
+        wallet.freeBalanceCents = (freeBefore - freeDebitCents).toString()
+        wallet.paidBalanceCents = (paidBefore - paidDebitCents).toString()
+        wallet.settlementRemainderCents = unsettledCents.minus(debitCents.toString()).toString()
+        wallet.billingStatus = this.statusForWallet(wallet)
+        await manager.getRepository(Wallet).save(wallet)
+
+        return transactionRepository.save(
+          transactionRepository.create({
+            walletId: wallet.id,
+            organizationId: wallet.organizationId,
+            kind: 'usage_debit',
+            amountCents: (-debitCents).toString(),
+            source: 'rated_period',
+            ratedPeriodId: period.id,
+            metadata: {
+              preciseCents: period.preciseCents,
+              remainderBeforeCents: remainderBefore.toString(),
+              remainderAfterCents: wallet.settlementRemainderCents,
+              freeDebitCents: freeDebitCents.toString(),
+              paidDebitCents: paidDebitCents.toString(),
+            },
+          }),
+        )
+      })
+    } catch (error) {
+      if (isUniqueViolation(error)) {
+        return null
+      }
+      throw error
+    }
+  }
+
+  private findUndebitedRatedPeriods(limit: number): Promise<RatedPeriod[]> {
+    return this.ratedPeriods
+      .createQueryBuilder('rp')
+      .leftJoin(WalletTransaction, 'wt', 'wt."ratedPeriodId" = rp.id')
+      .where('wt.id IS NULL')
+      .orderBy('rp.ratedAt', 'ASC')
+      .take(Math.max(1, Math.min(1000, Math.trunc(limit))))
+      .getMany()
+  }
+
+  private async findWalletForUpdate(manager: EntityManager, organizationId: string): Promise<Wallet> {
+    const walletRepository = manager.getRepository(Wallet)
+    let wallet = await walletRepository.findOne({
+      where: { organizationId },
+      lock: { mode: 'pessimistic_write' },
+    })
+
+    if (!wallet) {
+      const organization = await manager.getRepository(Organization).findOne({
+        where: { id: organizationId },
+        lock: { mode: 'pessimistic_write' },
+      })
+      if (!organization) {
+        throw new NotFoundException(`organization ${organizationId} not found`)
+      }
+
+      wallet = await walletRepository.findOne({
+        where: { organizationId },
+        lock: { mode: 'pessimistic_write' },
+      })
+      if (!wallet) {
+        wallet = await this.createWallet(manager, organizationId)
+      }
+    }
+
+    await this.expireFreeBalance(manager, wallet)
+    return wallet
+  }
+
+  private async createWallet(manager: EntityManager, organizationId: string): Promise<Wallet> {
+    const walletRepository = manager.getRepository(Wallet)
+    const grantCents = this.configService.get('billing.trialGrantCents')
+    const durationDays = this.configService.get('billing.trialDurationDays')
+    if (!Number.isSafeInteger(grantCents) || grantCents < 0) {
+      throw new Error('billing trial grant cents must be a non-negative safe integer')
+    }
+    if (!Number.isSafeInteger(durationDays) || durationDays <= 0) {
+      throw new Error('billing trial duration days must be a positive safe integer')
+    }
+
+    const wallet = await walletRepository.save(
+      walletRepository.create({
+        organizationId,
+        freeBalanceCents: String(grantCents),
+        paidBalanceCents: '0',
+        settlementRemainderCents: '0',
+        freeExpiresAt: grantCents > 0 ? new Date(Date.now() + durationDays * DAY_MILLISECONDS) : null,
+        billingStatus: grantCents > 0 ? 'trial' : 'zero_balance',
+      }),
+    )
+
+    if (grantCents > 0) {
+      const transactionRepository = manager.getRepository(WalletTransaction)
+      await transactionRepository.save(
+        transactionRepository.create({
+          walletId: wallet.id,
+          organizationId,
+          kind: 'free_grant',
+          amountCents: String(grantCents),
+          source: 'default_trial_grant',
+          ratedPeriodId: null,
+          metadata: { expiresAt: wallet.freeExpiresAt?.toISOString() },
+        }),
+      )
+    }
+
+    return wallet
+  }
+
+  private async expireFreeBalance(manager: EntityManager, wallet: Wallet): Promise<void> {
+    if (!wallet.freeExpiresAt || wallet.freeExpiresAt.getTime() > Date.now()) {
+      return
+    }
+
+    const expiredCents = nonNegativeBigInt(wallet.freeBalanceCents)
+    if (expiredCents === 0n) {
+      return
+    }
+
+    wallet.freeBalanceCents = '0'
+    wallet.billingStatus = this.statusForWallet(wallet)
+    await manager.getRepository(Wallet).save(wallet)
+    const transactionRepository = manager.getRepository(WalletTransaction)
+    await transactionRepository.save(
+      transactionRepository.create({
+        walletId: wallet.id,
+        organizationId: wallet.organizationId,
+        kind: 'adjustment',
+        amountCents: (-expiredCents).toString(),
+        source: 'trial_expired',
+        ratedPeriodId: null,
+        metadata: { expiredAt: wallet.freeExpiresAt.toISOString() },
+      }),
+    )
+  }
+
+  private statusForWallet(wallet: Wallet): BillingStatus {
+    if (BigInt(wallet.freeBalanceCents) + BigInt(wallet.paidBalanceCents) <= 0n) {
+      return 'zero_balance'
+    }
+    return BigInt(wallet.freeBalanceCents) > 0n ? 'trial' : 'active'
+  }
+}

--- a/apps/api/src/config/configuration.ts
+++ b/apps/api/src/config/configuration.ts
@@ -166,6 +166,10 @@ const configuration = {
   organizationBoxDefaultLimitedNetworkEgress: process.env.ORGANIZATION_BOX_DEFAULT_LIMITED_NETWORK_EGRESS === 'true',
   pylonAppId: process.env.PYLON_APP_ID,
   billingApiUrl: process.env.BILLING_API_URL,
+  billing: {
+    trialGrantCents: parseInt(process.env.BILLING_TRIAL_GRANT_CENTS || '10000', 10),
+    trialDurationDays: parseInt(process.env.BILLING_TRIAL_DURATION_DAYS || '30', 10),
+  },
   analyticsApiUrl: process.env.ANALYTICS_API_URL,
   defaultRunner: {
     domain: process.env.DEFAULT_RUNNER_DOMAIN,

--- a/apps/api/src/migrations/pre-deploy/1782700200000-migration.spec.ts
+++ b/apps/api/src/migrations/pre-deploy/1782700200000-migration.spec.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import type { QueryRunner } from 'typeorm'
+import { Migration1782700200000 } from './1782700200000-migration'
+
+class RecordingQueryRunner {
+  readonly queries: string[] = []
+
+  async query(sql: string): Promise<void> {
+    this.queries.push(sql.replace(/\s+/g, ' ').trim())
+  }
+}
+
+describe('Migration1782700200000', () => {
+  it('creates the wallet state and an immutable idempotent transaction ledger', async () => {
+    const runner = new RecordingQueryRunner()
+
+    await new Migration1782700200000().up(runner as unknown as QueryRunner)
+
+    const sql = runner.queries.join('\n')
+    expect(sql).toContain('CREATE TABLE "wallet"')
+    expect(sql).toContain('"settlementRemainderCents" numeric(38,18)')
+    expect(sql).toContain('"freeExpiresAt" TIMESTAMP WITH TIME ZONE')
+    expect(sql).toContain('CONSTRAINT "wallet_free_balance_non_negative" CHECK')
+    expect(sql).toContain('CONSTRAINT "wallet_remainder_range" CHECK')
+    expect(sql).toContain('CREATE UNIQUE INDEX "wallet_organization_idx"')
+    expect(sql).toContain('CREATE TABLE "wallet_transaction"')
+    expect(sql).toContain('CREATE UNIQUE INDEX "wallet_transaction_rated_period_idx"')
+    expect(sql).toContain('CREATE TRIGGER "wallet_transaction_immutable"')
+    expect(sql).not.toContain('top_up_record')
+    expect(sql).not.toContain('providerEventId')
+  })
+
+  it('drops the ledger before wallet state and then removes its trigger function', async () => {
+    const runner = new RecordingQueryRunner()
+
+    await new Migration1782700200000().down(runner as unknown as QueryRunner)
+
+    expect(runner.queries).toEqual([
+      'DROP TABLE "wallet_transaction"',
+      'DROP TABLE "wallet"',
+      'DROP FUNCTION "reject_wallet_transaction_mutation"()',
+    ])
+  })
+})

--- a/apps/api/src/migrations/pre-deploy/1782700200000-migration.ts
+++ b/apps/api/src/migrations/pre-deploy/1782700200000-migration.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class Migration1782700200000 implements MigrationInterface {
+  name = 'Migration1782700200000'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "wallet" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "organizationId" uuid NOT NULL,
+        "freeBalanceCents" bigint NOT NULL DEFAULT 0,
+        "paidBalanceCents" bigint NOT NULL DEFAULT 0,
+        "settlementRemainderCents" numeric(38,18) NOT NULL DEFAULT 0,
+        "freeExpiresAt" TIMESTAMP WITH TIME ZONE,
+        "billingStatus" character varying NOT NULL DEFAULT 'trial',
+        "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        CONSTRAINT "wallet_free_balance_non_negative" CHECK ("freeBalanceCents" >= 0),
+        CONSTRAINT "wallet_remainder_range" CHECK (
+          "settlementRemainderCents" >= 0 AND "settlementRemainderCents" < 1
+        ),
+        CONSTRAINT "wallet_id_pk" PRIMARY KEY ("id")
+      )`,
+    )
+    await queryRunner.query(`CREATE UNIQUE INDEX "wallet_organization_idx" ON "wallet" ("organizationId")`)
+
+    await queryRunner.query(
+      `CREATE TABLE "wallet_transaction" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "walletId" uuid NOT NULL,
+        "organizationId" uuid NOT NULL,
+        "kind" character varying NOT NULL,
+        "amountCents" bigint NOT NULL,
+        "source" character varying NOT NULL,
+        "ratedPeriodId" uuid,
+        "metadata" jsonb,
+        "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        CONSTRAINT "wallet_transaction_wallet_fk" FOREIGN KEY ("walletId")
+          REFERENCES "wallet"("id") ON DELETE RESTRICT ON UPDATE NO ACTION,
+        CONSTRAINT "wallet_transaction_rated_period_fk" FOREIGN KEY ("ratedPeriodId")
+          REFERENCES "rated_period"("id") ON DELETE RESTRICT ON UPDATE NO ACTION,
+        CONSTRAINT "wallet_transaction_id_pk" PRIMARY KEY ("id")
+      )`,
+    )
+    await queryRunner.query(
+      `CREATE INDEX "wallet_transaction_wallet_created_idx" ON "wallet_transaction" ("walletId", "createdAt")`,
+    )
+    await queryRunner.query(
+      `CREATE INDEX "wallet_transaction_org_created_idx" ON "wallet_transaction" ("organizationId", "createdAt")`,
+    )
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "wallet_transaction_rated_period_idx" ON "wallet_transaction" ("ratedPeriodId")`,
+    )
+    await queryRunner.query(
+      `CREATE FUNCTION "reject_wallet_transaction_mutation"() RETURNS trigger AS $$
+      BEGIN
+        RAISE EXCEPTION 'wallet transactions are immutable';
+      END;
+      $$ LANGUAGE plpgsql`,
+    )
+    await queryRunner.query(
+      `CREATE TRIGGER "wallet_transaction_immutable"
+      BEFORE UPDATE OR DELETE ON "wallet_transaction"
+      FOR EACH ROW EXECUTE FUNCTION "reject_wallet_transaction_mutation"()`,
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "wallet_transaction"`)
+    await queryRunner.query(`DROP TABLE "wallet"`)
+    await queryRunner.query(`DROP FUNCTION "reject_wallet_transaction_mutation"()`)
+  }
+}


### PR DESCRIPTION
## Summary

- add one wallet per organization with free and paid balances
- grant a configurable $100 trial balance with a 30-day default lifetime
- settle rated periods through an immutable, idempotent wallet ledger
- lock wallet updates to protect concurrent settlement

## Stack

- Depends on #972
- Next layer: Billing read API and dashboard

## Validation

- Wallet and settlement focused tests: 12/12 passed

## Review

Review only the diff against `codex/billing-v3-pr2-rating`.