### PR TITLE
feat(billing): add payment recovery and operations(Phase 7 Reconcile + Ops)

### DIFF
--- a/apps/api/src/admin/admin.module.ts
+++ b/apps/api/src/admin/admin.module.ts
@@ -6,6 +6,7 @@
 
 import { Module } from '@nestjs/common'
 import { AdminObservabilityController } from './controllers/observability.controller'
+import { AdminBillingController } from './controllers/billing.controller'
 import { AdminOverviewController } from './controllers/overview.controller'
 import { AdminRunnerController } from './controllers/runner.controller'
 import { AdminBoxController } from './controllers/box.controller'
@@ -25,10 +26,17 @@ import { OrganizationModule } from '../organization/organization.module'
 import { UserModule } from '../user/user.module'
 import { AuditModule } from '../audit/audit.module'
 import { AuditService } from '../audit/services/audit.service'
+import { BillingModule } from '../billing/billing.module'
 
 @Module({
-  imports: [BoxModule, RegionModule, OrganizationModule, UserModule, AuditModule],
-  controllers: [AdminRunnerController, AdminBoxController, AdminOverviewController, AdminObservabilityController],
+  imports: [BoxModule, RegionModule, OrganizationModule, UserModule, AuditModule, BillingModule],
+  controllers: [
+    AdminRunnerController,
+    AdminBoxController,
+    AdminOverviewController,
+    AdminObservabilityController,
+    AdminBillingController,
+  ],
   providers: [
     AdminOverviewService,
     AdminObservabilityService,

--- a/apps/api/src/admin/controllers/billing.controller.spec.ts
+++ b/apps/api/src/admin/controllers/billing.controller.spec.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { GUARDS_METADATA } from '@nestjs/common/constants'
+import { Request } from 'express'
+import { AUDIT_CONTEXT_KEY, AuditContext } from '../../audit/decorators/audit.decorator'
+import { AuditAction } from '../../audit/enums/audit-action.enum'
+import { AuditTarget } from '../../audit/enums/audit-target.enum'
+import { CombinedAuthGuard } from '../../auth/combined-auth.guard'
+import { SystemActionGuard } from '../../auth/system-action.guard'
+import { RequiredApiRole } from '../../common/decorators/required-role.decorator'
+import { SystemRole } from '../../user/enums/system-role.enum'
+import { AdminBillingController } from './billing.controller'
+
+describe('AdminBillingController', () => {
+  const health = { collectHealth: jest.fn() }
+  const payments = {
+    scheduledPaymentRecovery: jest.fn(),
+    reconcileTopUp: jest.fn(),
+    reconcilePaymentSetup: jest.fn(),
+  }
+  const controller = new AdminBillingController(health as never, payments as never)
+
+  beforeEach(() => jest.clearAllMocks())
+
+  it('requires authenticated Admin API access', () => {
+    expect(Reflect.getMetadata(GUARDS_METADATA, AdminBillingController)).toEqual([CombinedAuthGuard, SystemActionGuard])
+    expect(Reflect.getMetadata(RequiredApiRole.KEY, AdminBillingController)).toEqual([SystemRole.ADMIN])
+  })
+
+  it('audits targeted top-up reconciliation without exposing provider secrets', async () => {
+    payments.reconcileTopUp.mockResolvedValue(true)
+    await expect(controller.reconcileTopUp('top-up-1')).resolves.toEqual({ claimed: true })
+    expect(payments.reconcileTopUp).toHaveBeenCalledWith('top-up-1', expect.any(Date), true)
+
+    const context = Reflect.getMetadata(
+      AUDIT_CONTEXT_KEY,
+      AdminBillingController.prototype.reconcileTopUp,
+    ) as AuditContext
+    expect(context).toMatchObject({ action: AuditAction.UPDATE, targetType: AuditTarget.OBSERVABILITY })
+    expect(context.targetIdFromRequest?.({ params: { topUpId: 'top-up-1' } } as unknown as Request)).toBe(
+      'billing:top-up:top-up-1',
+    )
+  })
+})

--- a/apps/api/src/admin/controllers/billing.controller.ts
+++ b/apps/api/src/admin/controllers/billing.controller.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Controller, Get, HttpCode, Param, ParseUUIDPipe, Post, UseGuards } from '@nestjs/common'
+import { ApiBearerAuth, ApiOAuth2, ApiOperation, ApiTags } from '@nestjs/swagger'
+import { Audit } from '../../audit/decorators/audit.decorator'
+import { AuditAction } from '../../audit/enums/audit-action.enum'
+import { AuditTarget } from '../../audit/enums/audit-target.enum'
+import { CombinedAuthGuard } from '../../auth/combined-auth.guard'
+import { SystemActionGuard } from '../../auth/system-action.guard'
+import { BillingOpsService } from '../../billing/billing-ops.service'
+import { PaymentService } from '../../billing/payment/payment.service'
+import { RequiredApiRole } from '../../common/decorators/required-role.decorator'
+import { SystemRole } from '../../user/enums/system-role.enum'
+
+@ApiTags('admin')
+@Controller('admin/billing')
+@UseGuards(CombinedAuthGuard, SystemActionGuard)
+@RequiredApiRole([SystemRole.ADMIN])
+@ApiOAuth2(['openid', 'profile', 'email'])
+@ApiBearerAuth()
+export class AdminBillingController {
+  constructor(
+    private readonly billingOps: BillingOpsService,
+    private readonly payments: PaymentService,
+  ) {}
+
+  @Get('health')
+  @HttpCode(200)
+  @ApiOperation({ summary: 'Get Billing recovery and ledger health', operationId: 'adminGetBillingHealth' })
+  @Audit({
+    action: AuditAction.READ,
+    targetType: AuditTarget.OBSERVABILITY,
+    targetIdFromRequest: () => 'billing:health',
+  })
+  health() {
+    return this.billingOps.collectHealth()
+  }
+
+  @Post('reconcile')
+  @HttpCode(200)
+  @ApiOperation({ summary: 'Run due Billing recovery work', operationId: 'adminReconcileBilling' })
+  @Audit({
+    action: AuditAction.UPDATE,
+    targetType: AuditTarget.OBSERVABILITY,
+    targetIdFromRequest: () => 'billing:reconcile',
+  })
+  async reconcile() {
+    await this.payments.scheduledPaymentRecovery()
+    return this.billingOps.collectHealth()
+  }
+
+  @Post('reconcile/top-up/:topUpId')
+  @HttpCode(200)
+  @ApiOperation({ summary: 'Force provider reconciliation for one top-up', operationId: 'adminReconcileTopUp' })
+  @Audit({
+    action: AuditAction.UPDATE,
+    targetType: AuditTarget.OBSERVABILITY,
+    targetIdFromRequest: (request) => `billing:top-up:${request.params.topUpId}`,
+  })
+  async reconcileTopUp(@Param('topUpId', ParseUUIDPipe) topUpId: string) {
+    return { claimed: await this.payments.reconcileTopUp(topUpId, new Date(), true) }
+  }
+
+  @Post('reconcile/setup/:organizationId')
+  @HttpCode(200)
+  @ApiOperation({ summary: 'Force provider reconciliation for one payment setup', operationId: 'adminReconcileSetup' })
+  @Audit({
+    action: AuditAction.UPDATE,
+    targetType: AuditTarget.OBSERVABILITY,
+    targetIdFromRequest: (request) => `billing:setup:${request.params.organizationId}`,
+  })
+  async reconcileSetup(@Param('organizationId', ParseUUIDPipe) organizationId: string) {
+    return { claimed: await this.payments.reconcilePaymentSetup(organizationId, new Date(), true) }
+  }
+}

--- a/apps/api/src/billing/billing-edge-cases.integration.spec.ts
+++ b/apps/api/src/billing/billing-edge-cases.integration.spec.ts
@@ -9,6 +9,7 @@ import { randomUUID } from 'node:crypto'
 import { DataSource } from 'typeorm'
 import { BoxUsagePeriodArchive } from '../usage/entities/box-usage-period-archive.entity'
 import { PaymentProviderEvent } from './entities/payment-provider-event.entity'
+import { BillingOpsService } from './billing-ops.service'
 import { PricingPlan } from './entities/pricing-plan.entity'
 import { RatedPeriod } from './entities/rated-period.entity'
 import { TopUpRecord } from './entities/top-up-record.entity'
@@ -17,6 +18,8 @@ import { Wallet } from './entities/wallet.entity'
 import { FakePaymentProvider } from './payment/fake-payment.provider'
 import type {
   PaymentProvider,
+  PaymentReconcileInput,
+  PaymentReconcileResult,
   ProviderWebhookEvent,
   TopUpPaymentInput,
   TopUpPaymentResult,
@@ -53,6 +56,36 @@ class TestWebhookPaymentProvider extends FakePaymentProvider {
   override async parseWebhook(payload: Buffer, signature: string): Promise<ProviderWebhookEvent> {
     void signature
     return JSON.parse(payload.toString('utf8')) as ProviderWebhookEvent
+  }
+}
+
+class ReconciledProvider extends FakePaymentProvider {
+  readonly payments = new Map<string, TopUpPaymentInput>()
+  readonly reconcileCalls: PaymentReconcileInput[] = []
+
+  override async createManualTopUp(input: TopUpPaymentInput): Promise<TopUpPaymentResult> {
+    const providerReference = `pi_reconcile_${input.topUpId}`
+    this.payments.set(providerReference, input)
+    return { status: 'pending', checkoutUrl: null, providerReference, receiptUrl: null }
+  }
+
+  override async reconcile(input: PaymentReconcileInput): Promise<PaymentReconcileResult> {
+    this.reconcileCalls.push(input)
+    const payment = this.payments.get(input.providerReference)
+    if (!payment) throw new Error(`missing provider payment ${input.providerReference}`)
+    return {
+      status: 'resolved',
+      event: {
+        kind: 'top_up_paid',
+        providerEventId: `reconcile:${input.providerReference}:paid`,
+        providerReference: input.providerReference,
+        topUpId: payment.topUpId,
+        organizationId: payment.organizationId,
+        amountCents: payment.amountCents,
+        currency: 'usd',
+        receiptUrl: 'https://receipt.test/reconciled',
+      },
+    }
   }
 }
 
@@ -480,5 +513,244 @@ describeWithDatabase('Billing common edge cases with PostgreSQL', () => {
     await expect(
       billingDataSource.getRepository(WalletTransaction).countBy({ organizationId, kind: 'top_up' }),
     ).resolves.toBe(1)
+  })
+
+  it('lets only one API instance claim and reconcile a stale pending top-up', async () => {
+    const organizationId = randomUUID()
+    await createWallet(organizationId, {
+      paidBalanceCents: '0',
+      paymentProviderCustomerId: 'edge-customer',
+      paymentProviderMethodId: 'edge-method',
+      paymentMethodBrand: 'visa',
+      paymentMethodLast4: '4242',
+    })
+    const provider = new ReconciledProvider()
+    const first = paymentService(walletService(), provider)
+    const second = paymentService(walletService(), provider)
+    const topUp = await first.createManualTopUp(organizationId, '2500', `edge-${randomUUID()}`)
+    const reconcileAt = new Date(Date.now() + 10 * 60 * 1000)
+
+    const claims = await Promise.all([
+      first.reconcileTopUp(topUp.id, reconcileAt),
+      second.reconcileTopUp(topUp.id, reconcileAt),
+    ])
+
+    expect(claims.filter(Boolean)).toHaveLength(1)
+    expect(provider.reconcileCalls).toHaveLength(1)
+    await expect(billingDataSource.getRepository(Wallet).findOneByOrFail({ organizationId })).resolves.toMatchObject({
+      paidBalanceCents: '2500',
+    })
+    await expect(
+      billingDataSource.getRepository(WalletTransaction).countBy({ organizationId, kind: 'top_up' }),
+    ).resolves.toBe(1)
+  })
+
+  it('deduplicates concurrent refund events and restores with one immutable counter-entry', async () => {
+    const organizationId = randomUUID()
+    await createWallet(organizationId, {
+      paidBalanceCents: '0',
+      paymentProviderCustomerId: 'edge-customer',
+      paymentProviderMethodId: 'edge-method',
+      paymentMethodBrand: 'visa',
+      paymentMethodLast4: '4242',
+    })
+    const payments = paymentService(walletService(), new TestWebhookPaymentProvider())
+    const topUp = await payments.createManualTopUp(organizationId, '2500', `edge-${randomUUID()}`)
+    await payments.handleWebhook(
+      Buffer.from(
+        JSON.stringify({
+          kind: 'top_up_paid',
+          providerEventId: `edge:${randomUUID()}`,
+          providerReference: `edge-payment-${topUp.id}`,
+          topUpId: topUp.id,
+          organizationId,
+          amountCents: '2500',
+          currency: 'usd',
+          receiptUrl: null,
+        }),
+      ),
+      'test',
+    )
+    const refund = (providerEventId: string, direction: 'debit' | 'restore') =>
+      Buffer.from(
+        JSON.stringify({
+          kind: 'top_up_adjusted',
+          providerEventId,
+          providerReference: 're_concurrent',
+          topUpId: topUp.id,
+          organizationId,
+          amountCents: '500',
+          currency: 'usd',
+          adjustment: 'refund',
+          direction,
+        }),
+      )
+
+    await Promise.all([
+      payments.handleWebhook(refund(`edge:${randomUUID()}`, 'debit'), 'test'),
+      payments.handleWebhook(refund(`edge:${randomUUID()}`, 'debit'), 'test'),
+    ])
+    await payments.handleWebhook(refund(`edge:${randomUUID()}`, 'restore'), 'test')
+
+    await expect(billingDataSource.getRepository(Wallet).findOneByOrFail({ organizationId })).resolves.toMatchObject({
+      paidBalanceCents: '2500',
+    })
+    await expect(billingDataSource.getRepository(TopUpRecord).findOneByOrFail({ id: topUp.id })).resolves.toMatchObject(
+      {
+        refundedCents: '0',
+      },
+    )
+    await expect(
+      billingDataSource.getRepository(WalletTransaction).countBy({ organizationId, kind: 'adjustment' }),
+    ).resolves.toBe(2)
+  })
+
+  it('persists a failed webhook and retries it after the business transaction rolls back', async () => {
+    const organizationId = randomUUID()
+    await createWallet(organizationId, {
+      paidBalanceCents: '0',
+      paymentProviderCustomerId: 'edge-customer',
+      paymentProviderMethodId: 'edge-method',
+      paymentMethodBrand: 'visa',
+      paymentMethodLast4: '4242',
+    })
+    const payments = paymentService(walletService(), new TestWebhookPaymentProvider())
+    const topUp = await payments.createManualTopUp(organizationId, '2500', `edge-${randomUUID()}`)
+    await payments.handleWebhook(
+      Buffer.from(
+        JSON.stringify({
+          kind: 'top_up_paid',
+          providerEventId: `edge:${randomUUID()}`,
+          providerReference: `edge-payment-${topUp.id}`,
+          topUpId: topUp.id,
+          organizationId,
+          amountCents: '2500',
+          currency: 'usd',
+          receiptUrl: null,
+        }),
+      ),
+      'test',
+    )
+    const failedEventId = `edge:${randomUUID()}`
+    const refundEvent = Buffer.from(
+      JSON.stringify({
+        kind: 'top_up_adjusted',
+        providerEventId: failedEventId,
+        providerReference: 're_retry',
+        topUpId: topUp.id,
+        organizationId,
+        amountCents: '500',
+        currency: 'usd',
+        adjustment: 'refund',
+        direction: 'debit',
+      }),
+    )
+    await controlDataSource.query(`
+      CREATE FUNCTION "${schemaName}".fail_billing_adjustment() RETURNS trigger AS $$
+      BEGIN
+        IF NEW.kind = 'adjustment' THEN RAISE EXCEPTION 'adjustment write unavailable'; END IF;
+        RETURN NEW;
+      END;
+      $$ LANGUAGE plpgsql;
+      CREATE TRIGGER fail_billing_adjustment
+      BEFORE INSERT ON "${schemaName}"."wallet_transaction"
+      FOR EACH ROW EXECUTE FUNCTION "${schemaName}".fail_billing_adjustment();
+    `)
+    try {
+      await expect(payments.handleWebhook(refundEvent, 'test')).rejects.toThrow('adjustment write unavailable')
+    } finally {
+      await controlDataSource.query(`
+        DROP TRIGGER IF EXISTS fail_billing_adjustment ON "${schemaName}"."wallet_transaction";
+        DROP FUNCTION IF EXISTS "${schemaName}".fail_billing_adjustment();
+      `)
+    }
+
+    const eventRepository = billingDataSource.getRepository(PaymentProviderEvent)
+    await expect(eventRepository.findOneByOrFail({ providerEventId: failedEventId })).resolves.toMatchObject({
+      status: 'failed',
+      attempts: 1,
+      payload: expect.objectContaining({ providerReference: 're_retry' }),
+    })
+    await eventRepository.update({ providerEventId: failedEventId }, { nextAttemptAt: new Date(0) })
+    await payments.scheduledPaymentRecovery(new Date())
+
+    await expect(eventRepository.findOneByOrFail({ providerEventId: failedEventId })).resolves.toMatchObject({
+      status: 'processed',
+      nextAttemptAt: null,
+      lastError: null,
+    })
+    await expect(billingDataSource.getRepository(Wallet).findOneByOrFail({ organizationId })).resolves.toMatchObject({
+      paidBalanceCents: '2000',
+    })
+    await expect(
+      billingDataSource.getRepository(WalletTransaction).countBy({ organizationId, kind: 'adjustment' }),
+    ).resolves.toBe(1)
+  })
+
+  it('identifies the exact organization, top-up, provider reference, and failed webhook in health output', async () => {
+    const organizationId = randomUUID()
+    const wallet = await createWallet(organizationId, { paidBalanceCents: '-250' })
+    const topUp = await billingDataSource.getRepository(TopUpRecord).save(
+      billingDataSource.getRepository(TopUpRecord).create({
+        walletId: wallet.id,
+        organizationId,
+        amountCents: '500',
+        source: 'manual',
+        status: 'pending',
+        idempotencyKey: `health:${randomUUID()}`,
+        providerReference: 'pi_health_pending',
+        checkoutUrl: null,
+        receiptUrl: null,
+        failureCode: null,
+        failureMessage: null,
+        reconcileAttempts: 2,
+        nextReconcileAt: new Date('1900-01-01T00:00:00.000Z'),
+        lastReconciledAt: new Date('1900-01-01T00:00:00.000Z'),
+        reconcileLastError: 'provider timeout',
+        refundedCents: '0',
+        disputedCents: '0',
+        completedAt: null,
+        createdAt: new Date('1900-01-01T00:00:00.000Z'),
+      }),
+    )
+    await billingDataSource.getRepository(PaymentProviderEvent).save(
+      billingDataSource.getRepository(PaymentProviderEvent).create({
+        providerEventId: 'evt_health_failed',
+        eventType: 'top_up_paid',
+        providerReference: 'pi_health_pending',
+        status: 'failed',
+        payload: { organizationId, topUpId: topUp.id },
+        attempts: 3,
+        nextAttemptAt: new Date('1900-01-01T00:00:00.000Z'),
+        lastError: 'wallet transaction unavailable',
+        createdAt: new Date('1900-01-01T00:00:00.000Z'),
+        updatedAt: new Date('1900-01-01T00:00:00.000Z'),
+      }),
+    )
+
+    const queryRunner = billingDataSource.createQueryRunner()
+    await queryRunner.connect()
+    try {
+      await queryRunner.query(`SET search_path TO "${schemaName}"`)
+      const health = await new BillingOpsService({ manager: queryRunner.manager } as never).collectHealth()
+
+      expect(health.pendingPayment).toEqual({
+        topUpId: topUp.id,
+        organizationId,
+        providerReference: 'pi_health_pending',
+        lastError: 'provider timeout',
+      })
+      expect(health.failedWebhook).toEqual({
+        providerEventId: 'evt_health_failed',
+        eventType: 'top_up_paid',
+        organizationId,
+        topUpId: topUp.id,
+        providerReference: 'pi_health_pending',
+        lastError: 'wallet transaction unavailable',
+      })
+      expect(health.negativeWallet).toEqual({ organizationId, balanceCents: '-250' })
+    } finally {
+      await queryRunner.release()
+    }
   })
 })

--- a/apps/api/src/billing/billing-ops.service.spec.ts
+++ b/apps/api/src/billing/billing-ops.service.spec.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { billingHealthAlerts, BillingHealthSnapshot } from './billing-ops.service'
+
+const healthy: BillingHealthSnapshot = {
+  pendingPaymentCount: 0,
+  pendingPaymentOldestSeconds: 0,
+  failedWebhookCount: 0,
+  failedWebhookOldestSeconds: 0,
+  negativeWalletCount: 0,
+  lowestWalletBalanceCents: '0',
+  unratedPeriodCount: 0,
+  unratedPeriodOldestSeconds: 0,
+  unsettledPeriodCount: 0,
+  unsettledPeriodOldestSeconds: 0,
+  pendingPayment: null,
+  failedWebhook: null,
+  negativeWallet: null,
+  unratedPeriod: null,
+  unsettledPeriod: null,
+}
+
+describe('billingHealthAlerts', () => {
+  it('stays quiet when payment and settlement pipelines are healthy', () => {
+    expect(billingHealthAlerts(healthy)).toEqual([])
+  })
+
+  it('emits actionable codes for common payment and ledger failures', () => {
+    expect(
+      billingHealthAlerts({
+        ...healthy,
+        pendingPaymentCount: 3,
+        pendingPaymentOldestSeconds: 901,
+        failedWebhookCount: 2,
+        failedWebhookOldestSeconds: 61,
+        negativeWalletCount: 1,
+        lowestWalletBalanceCents: '-250',
+        unratedPeriodCount: 4,
+        unratedPeriodOldestSeconds: 301,
+        unsettledPeriodCount: 5,
+        unsettledPeriodOldestSeconds: 302,
+      }).map((alert) => alert.code),
+    ).toEqual([
+      'stale_pending_payment',
+      'failed_payment_webhook',
+      'negative_wallet_balance',
+      'rating_lag',
+      'settlement_lag',
+    ])
+  })
+})

--- a/apps/api/src/billing/billing-ops.service.ts
+++ b/apps/api/src/billing/billing-ops.service.ts
@@ -1,0 +1,163 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Injectable, Logger } from '@nestjs/common'
+import { Cron, CronExpression } from '@nestjs/schedule'
+import { InjectRepository } from '@nestjs/typeorm'
+import { Repository } from 'typeorm'
+import { WithInstrumentation } from '../common/decorators/otel.decorator'
+import { Wallet } from './entities/wallet.entity'
+
+const STALE_PAYMENT_SECONDS = 15 * 60
+const BILLING_PIPELINE_LAG_SECONDS = 5 * 60
+
+export interface BillingHealthSnapshot {
+  pendingPaymentCount: number
+  pendingPaymentOldestSeconds: number
+  failedWebhookCount: number
+  failedWebhookOldestSeconds: number
+  negativeWalletCount: number
+  lowestWalletBalanceCents: string
+  unratedPeriodCount: number
+  unratedPeriodOldestSeconds: number
+  unsettledPeriodCount: number
+  unsettledPeriodOldestSeconds: number
+  pendingPayment: {
+    topUpId: string
+    organizationId: string
+    providerReference: string | null
+    lastError: string | null
+  } | null
+  failedWebhook: {
+    providerEventId: string
+    eventType: string
+    organizationId: string | null
+    topUpId: string | null
+    providerReference: string | null
+    lastError: string | null
+  } | null
+  negativeWallet: { organizationId: string; balanceCents: string } | null
+  unratedPeriod: { usagePeriodArchiveId: string; organizationId: string; boxId: string } | null
+  unsettledPeriod: { ratedPeriodId: string; organizationId: string; boxId: string } | null
+}
+
+export interface BillingHealthAlert {
+  code: 'stale_pending_payment' | 'failed_payment_webhook' | 'negative_wallet_balance' | 'rating_lag' | 'settlement_lag'
+  severity: 'warning' | 'error'
+}
+
+export function billingHealthAlerts(snapshot: BillingHealthSnapshot): BillingHealthAlert[] {
+  const alerts: BillingHealthAlert[] = []
+  if (snapshot.pendingPaymentCount > 0 && snapshot.pendingPaymentOldestSeconds > STALE_PAYMENT_SECONDS) {
+    alerts.push({ code: 'stale_pending_payment', severity: 'warning' })
+  }
+  if (snapshot.failedWebhookCount > 0) alerts.push({ code: 'failed_payment_webhook', severity: 'error' })
+  if (snapshot.negativeWalletCount > 0) alerts.push({ code: 'negative_wallet_balance', severity: 'error' })
+  if (snapshot.unratedPeriodCount > 0 && snapshot.unratedPeriodOldestSeconds > BILLING_PIPELINE_LAG_SECONDS) {
+    alerts.push({ code: 'rating_lag', severity: 'warning' })
+  }
+  if (snapshot.unsettledPeriodCount > 0 && snapshot.unsettledPeriodOldestSeconds > BILLING_PIPELINE_LAG_SECONDS) {
+    alerts.push({ code: 'settlement_lag', severity: 'warning' })
+  }
+  return alerts
+}
+
+@Injectable()
+export class BillingOpsService {
+  private readonly logger = new Logger(BillingOpsService.name)
+
+  constructor(@InjectRepository(Wallet) private readonly wallets: Repository<Wallet>) {}
+
+  @Cron(CronExpression.EVERY_MINUTE, { name: 'billing-health-check', waitForCompletion: true })
+  @WithInstrumentation('billing_health_check')
+  async scheduledHealthCheck(): Promise<void> {
+    const snapshot = await this.collectHealth()
+    for (const alert of billingHealthAlerts(snapshot)) {
+      this.logger[alert.severity === 'error' ? 'error' : 'warn'](
+        `[billing_alert] ${JSON.stringify({ code: alert.code, ...snapshot })}`,
+      )
+    }
+  }
+
+  async collectHealth(now = new Date()): Promise<BillingHealthSnapshot> {
+    const [row] = await this.wallets.manager.query(
+      `SELECT
+        (SELECT COUNT(*)::int FROM top_up_record WHERE status = 'pending') AS "pendingPaymentCount",
+        COALESCE((SELECT GREATEST(0, EXTRACT(EPOCH FROM ($1::timestamptz - MIN("createdAt"))))
+                    FROM top_up_record WHERE status = 'pending'), 0)::float8 AS "pendingPaymentOldestSeconds",
+        (SELECT COUNT(*)::int FROM payment_provider_event WHERE status = 'failed') AS "failedWebhookCount",
+        COALESCE((SELECT GREATEST(0, EXTRACT(EPOCH FROM ($1::timestamptz - MIN("updatedAt"))))
+                    FROM payment_provider_event WHERE status = 'failed'), 0)::float8 AS "failedWebhookOldestSeconds",
+        (SELECT COUNT(*)::int FROM wallet WHERE ("freeBalanceCents" + "paidBalanceCents") < 0)
+          AS "negativeWalletCount",
+        COALESCE((SELECT MIN("freeBalanceCents" + "paidBalanceCents")::text FROM wallet), '0')
+          AS "lowestWalletBalanceCents",
+        (SELECT COUNT(*)::int FROM box_usage_period_archive a
+          LEFT JOIN rated_period r ON r."usagePeriodArchiveId" = a.id WHERE r.id IS NULL) AS "unratedPeriodCount",
+        COALESCE((SELECT GREATEST(0, EXTRACT(EPOCH FROM ($1::timestamptz - MIN(a."endAt"))))
+          FROM box_usage_period_archive a
+          LEFT JOIN rated_period r ON r."usagePeriodArchiveId" = a.id WHERE r.id IS NULL), 0)::float8
+          AS "unratedPeriodOldestSeconds",
+        (SELECT COUNT(*)::int FROM rated_period r
+          LEFT JOIN wallet_transaction wt ON wt."ratedPeriodId" = r.id WHERE wt.id IS NULL) AS "unsettledPeriodCount",
+        COALESCE((SELECT GREATEST(0, EXTRACT(EPOCH FROM ($1::timestamptz - MIN(r."ratedAt"))))
+          FROM rated_period r
+          LEFT JOIN wallet_transaction wt ON wt."ratedPeriodId" = r.id WHERE wt.id IS NULL), 0)::float8
+          AS "unsettledPeriodOldestSeconds",
+        (SELECT jsonb_build_object(
+            'topUpId', id,
+            'organizationId', "organizationId",
+            'providerReference', "providerReference",
+            'lastError', "reconcileLastError")
+          FROM top_up_record WHERE status = 'pending' ORDER BY "createdAt", id LIMIT 1) AS "pendingPayment",
+        (SELECT jsonb_build_object(
+            'providerEventId', "providerEventId",
+            'eventType', "eventType",
+            'organizationId', payload->>'organizationId',
+            'topUpId', payload->>'topUpId',
+            'providerReference', "providerReference",
+            'lastError', "lastError")
+          FROM payment_provider_event WHERE status = 'failed' ORDER BY "updatedAt", id LIMIT 1)
+          AS "failedWebhook",
+        (SELECT jsonb_build_object(
+            'organizationId', "organizationId",
+            'balanceCents', ("freeBalanceCents" + "paidBalanceCents")::text)
+          FROM wallet WHERE ("freeBalanceCents" + "paidBalanceCents") < 0
+          ORDER BY ("freeBalanceCents" + "paidBalanceCents"), id LIMIT 1) AS "negativeWallet",
+        (SELECT jsonb_build_object(
+            'usagePeriodArchiveId', a.id,
+            'organizationId', a."organizationId",
+            'boxId', a."boxId")
+          FROM box_usage_period_archive a
+          LEFT JOIN rated_period r ON r."usagePeriodArchiveId" = a.id
+          WHERE r.id IS NULL ORDER BY a."endAt", a.id LIMIT 1) AS "unratedPeriod",
+        (SELECT jsonb_build_object(
+            'ratedPeriodId', r.id,
+            'organizationId', r."organizationId",
+            'boxId', r."boxId")
+          FROM rated_period r
+          LEFT JOIN wallet_transaction wt ON wt."ratedPeriodId" = r.id
+          WHERE wt.id IS NULL ORDER BY r."ratedAt", r.id LIMIT 1) AS "unsettledPeriod"`,
+      [now],
+    )
+    return {
+      pendingPaymentCount: Number(row.pendingPaymentCount),
+      pendingPaymentOldestSeconds: Number(row.pendingPaymentOldestSeconds),
+      failedWebhookCount: Number(row.failedWebhookCount),
+      failedWebhookOldestSeconds: Number(row.failedWebhookOldestSeconds),
+      negativeWalletCount: Number(row.negativeWalletCount),
+      lowestWalletBalanceCents: String(row.lowestWalletBalanceCents),
+      unratedPeriodCount: Number(row.unratedPeriodCount),
+      unratedPeriodOldestSeconds: Number(row.unratedPeriodOldestSeconds),
+      unsettledPeriodCount: Number(row.unsettledPeriodCount),
+      unsettledPeriodOldestSeconds: Number(row.unsettledPeriodOldestSeconds),
+      pendingPayment: row.pendingPayment ?? null,
+      failedWebhook: row.failedWebhook ?? null,
+      negativeWallet: row.negativeWallet ?? null,
+      unratedPeriod: row.unratedPeriod ?? null,
+      unsettledPeriod: row.unsettledPeriod ?? null,
+    }
+  }
+}

--- a/apps/api/src/billing/billing.module.ts
+++ b/apps/api/src/billing/billing.module.ts
@@ -10,6 +10,7 @@ import { Organization } from '../organization/entities/organization.entity'
 import { OrganizationModule } from '../organization/organization.module'
 import { BoxUsagePeriodArchive } from '../usage/entities/box-usage-period-archive.entity'
 import { BillingController } from './billing.controller'
+import { BillingOpsService } from './billing-ops.service'
 import { BillingReadService } from './billing-read.service'
 import { PaymentProviderEvent } from './entities/payment-provider-event.entity'
 import { PricingPlan } from './entities/pricing-plan.entity'
@@ -45,6 +46,7 @@ import { WalletService } from './wallet.service'
     WalletService,
     SettlementService,
     BillingReadService,
+    BillingOpsService,
     PaymentService,
     {
       provide: PAYMENT_PROVIDER,
@@ -52,6 +54,6 @@ import { WalletService } from './wallet.service'
       useFactory: createPaymentProvider,
     },
   ],
-  exports: [RatingService, WalletService, SettlementService, BillingReadService],
+  exports: [RatingService, WalletService, SettlementService, BillingReadService, BillingOpsService, PaymentService],
 })
 export class BillingModule {}

--- a/apps/api/src/billing/entities/payment-provider-event.entity.ts
+++ b/apps/api/src/billing/entities/payment-provider-event.entity.ts
@@ -3,10 +3,15 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn } from 'typeorm'
+import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm'
+
+export type PaymentProviderEventStatus = 'processed' | 'failed'
 
 @Entity('payment_provider_event')
 @Index('payment_provider_event_provider_id_idx', ['providerEventId'], { unique: true })
+@Index('payment_provider_event_retry_due_idx', ['nextAttemptAt'], {
+  where: '"status" = \'failed\' AND "nextAttemptAt" IS NOT NULL',
+})
 export class PaymentProviderEvent {
   @PrimaryGeneratedColumn('uuid')
   id: string
@@ -17,6 +22,27 @@ export class PaymentProviderEvent {
   @Column({ type: 'character varying' })
   eventType: string
 
+  @Column({ type: 'character varying', nullable: true })
+  providerReference: string | null
+
+  @Column({ type: 'character varying', default: 'processed' })
+  status: PaymentProviderEventStatus
+
+  @Column({ type: 'jsonb', nullable: true })
+  payload: Record<string, unknown> | null
+
+  @Column({ type: 'integer', default: 1 })
+  attempts: number
+
+  @Column({ type: 'timestamp with time zone', nullable: true })
+  nextAttemptAt: Date | null
+
+  @Column({ type: 'text', nullable: true })
+  lastError: string | null
+
   @CreateDateColumn({ type: 'timestamp with time zone' })
   createdAt: Date
+
+  @UpdateDateColumn({ type: 'timestamp with time zone' })
+  updatedAt: Date
 }

--- a/apps/api/src/billing/entities/top-up-record.entity.ts
+++ b/apps/api/src/billing/entities/top-up-record.entity.ts
@@ -15,6 +15,9 @@ export type TopUpStatus = 'pending' | 'paid' | 'failed'
   unique: true,
   where: '"providerReference" IS NOT NULL',
 })
+@Index('top_up_record_reconcile_due_idx', ['nextReconcileAt'], {
+  where: '"status" = \'pending\' AND "nextReconcileAt" IS NOT NULL',
+})
 @Check('top_up_record_positive_amount', '"amountCents" > 0')
 export class TopUpRecord {
   @PrimaryGeneratedColumn('uuid')
@@ -52,6 +55,24 @@ export class TopUpRecord {
 
   @Column({ type: 'text', nullable: true })
   failureMessage: string | null
+
+  @Column({ type: 'integer', default: 0 })
+  reconcileAttempts: number
+
+  @Column({ type: 'timestamp with time zone', nullable: true })
+  nextReconcileAt: Date | null
+
+  @Column({ type: 'timestamp with time zone', nullable: true })
+  lastReconciledAt: Date | null
+
+  @Column({ type: 'text', nullable: true })
+  reconcileLastError: string | null
+
+  @Column({ type: 'bigint', default: 0 })
+  refundedCents: string
+
+  @Column({ type: 'bigint', default: 0 })
+  disputedCents: string
 
   @Column({ type: 'timestamp with time zone', nullable: true })
   completedAt: Date | null

--- a/apps/api/src/billing/entities/wallet-transaction.entity.ts
+++ b/apps/api/src/billing/entities/wallet-transaction.entity.ts
@@ -11,6 +11,10 @@ export type WalletTransactionKind = 'free_grant' | 'usage_debit' | 'adjustment' 
 @Index('wallet_transaction_wallet_created_idx', ['walletId', 'createdAt'])
 @Index('wallet_transaction_org_created_idx', ['organizationId', 'createdAt'])
 @Index('wallet_transaction_rated_period_idx', ['ratedPeriodId'], { unique: true })
+@Index('wallet_transaction_provider_action_idx', ['providerActionId'], {
+  unique: true,
+  where: '"providerActionId" IS NOT NULL',
+})
 export class WalletTransaction {
   @PrimaryGeneratedColumn('uuid')
   id: string
@@ -32,6 +36,9 @@ export class WalletTransaction {
 
   @Column({ type: 'uuid', nullable: true })
   ratedPeriodId: string | null
+
+  @Column({ type: 'character varying', nullable: true })
+  providerActionId: string | null
 
   @Column({ type: 'jsonb', nullable: true })
   metadata: Record<string, unknown> | null

--- a/apps/api/src/billing/entities/wallet.entity.ts
+++ b/apps/api/src/billing/entities/wallet.entity.ts
@@ -9,6 +9,9 @@ export type BillingStatus = 'trial' | 'active' | 'zero_balance'
 
 @Entity('wallet')
 @Index('wallet_organization_idx', ['organizationId'], { unique: true })
+@Index('wallet_payment_setup_reconcile_due_idx', ['paymentSetupNextReconcileAt'], {
+  where: '"paymentSetupAttemptId" IS NOT NULL AND "paymentSetupNextReconcileAt" IS NOT NULL',
+})
 @Check('wallet_free_balance_non_negative', '"freeBalanceCents" >= 0')
 @Check('wallet_remainder_range', '"settlementRemainderCents" >= 0 AND "settlementRemainderCents" < 1')
 export class Wallet {
@@ -44,6 +47,21 @@ export class Wallet {
 
   @Column({ type: 'character varying', nullable: true })
   paymentMethodLast4: string | null
+
+  @Column({ type: 'character varying', nullable: true })
+  paymentSetupAttemptId: string | null
+
+  @Column({ type: 'character varying', nullable: true })
+  paymentSetupProviderReference: string | null
+
+  @Column({ type: 'timestamp with time zone', nullable: true })
+  paymentSetupNextReconcileAt: Date | null
+
+  @Column({ type: 'integer', default: 0 })
+  paymentSetupReconcileAttempts: number
+
+  @Column({ type: 'text', nullable: true })
+  paymentSetupLastError: string | null
 
   @Column({ type: 'boolean', default: false })
   autoReloadEnabled: boolean

--- a/apps/api/src/billing/payment/fake-payment.provider.ts
+++ b/apps/api/src/billing/payment/fake-payment.provider.ts
@@ -6,6 +6,8 @@
 import { BadRequestException } from '@nestjs/common'
 import {
   PaymentProvider,
+  PaymentReconcileInput,
+  PaymentReconcileResult,
   PaymentSetupInput,
   PaymentSetupResult,
   ProviderWebhookEvent,
@@ -32,6 +34,11 @@ export class FakePaymentProvider implements PaymentProvider {
 
   async chargeSavedMethod(input: TopUpPaymentInput): Promise<TopUpPaymentResult> {
     return this.paidResult(input)
+  }
+
+  async reconcile(input: PaymentReconcileInput): Promise<PaymentReconcileResult> {
+    void input
+    return { status: 'pending' }
   }
 
   async parseWebhook(payload: Buffer, signature: string): Promise<ProviderWebhookEvent | null> {

--- a/apps/api/src/billing/payment/payment-provider.factory.ts
+++ b/apps/api/src/billing/payment/payment-provider.factory.ts
@@ -15,8 +15,9 @@ export function createPaymentProvider(configService: TypedConfigService): Paymen
 
   const secretKey = configService.get('billing.stripe.secretKey')
   const webhookSecret = configService.get('billing.stripe.webhookSecret')
+  const previousWebhookSecret = configService.get('billing.stripe.previousWebhookSecret')
   if (!secretKey || !webhookSecret) {
     throw new Error('Stripe payment provider requires STRIPE_SECRET_KEY and STRIPE_WEBHOOK_SECRET')
   }
-  return new StripePaymentProvider(secretKey, webhookSecret)
+  return new StripePaymentProvider(secretKey, webhookSecret, undefined, previousWebhookSecret)
 }

--- a/apps/api/src/billing/payment/payment-provider.spec.ts
+++ b/apps/api/src/billing/payment/payment-provider.spec.ts
@@ -89,7 +89,12 @@ describe('PaymentProvider implementations', () => {
       expect.objectContaining({
         mode: 'setup',
         customer: 'cus_1',
-        metadata: { organizationId: 'org-1', walletId: 'wallet-1', operation: 'setup' },
+        metadata: {
+          organizationId: 'org-1',
+          walletId: 'wallet-1',
+          setupAttemptId: 'attempt-1',
+          operation: 'setup',
+        },
       }),
       { idempotencyKey: 'wallet-setup:wallet-1:attempt-1' },
     )
@@ -213,6 +218,40 @@ describe('PaymentProvider implementations', () => {
     expect(constructEvent).toHaveBeenCalledWith(payload, 'stripe-signature', 'whsec_test')
   })
 
+  it('accepts the previous webhook secret only during a controlled secret rotation', async () => {
+    const payload = Buffer.from('{"id":"evt_rotated"}')
+    const signatureError = Object.assign(new Error('signature does not match'), {
+      type: 'StripeSignatureVerificationError',
+    })
+    const constructEvent = jest
+      .fn()
+      .mockImplementationOnce(() => {
+        throw signatureError
+      })
+      .mockReturnValueOnce({
+        id: 'evt_rotated',
+        type: 'payment_intent.succeeded',
+        data: {
+          object: {
+            id: 'pi_rotated',
+            amount_received: 2500,
+            currency: 'usd',
+            latest_charge: null,
+            metadata: { operation: 'auto_reload', topUpId: 'top-up-1', organizationId: 'org-1' },
+          },
+        },
+      })
+    const stripe = { webhooks: { constructEvent } } as unknown as Stripe
+    const provider = new StripePaymentProvider('sk_test_secret', 'whsec_current', stripe, 'whsec_previous')
+
+    await expect(provider.parseWebhook(payload, 'stripe-signature')).resolves.toMatchObject({
+      providerEventId: 'evt_rotated',
+      providerReference: 'pi_rotated',
+    })
+    expect(constructEvent).toHaveBeenNthCalledWith(1, payload, 'stripe-signature', 'whsec_current')
+    expect(constructEvent).toHaveBeenNthCalledWith(2, payload, 'stripe-signature', 'whsec_previous')
+  })
+
   it('reserves PaymentIntent webhooks for saved-card auto-reloads', async () => {
     const payload = Buffer.from('{"id":"evt_payment_intent"}')
     const constructEvent = jest
@@ -253,6 +292,131 @@ describe('PaymentProvider implementations', () => {
       providerReference: 'pi_auto',
       topUpId: 'top-up-2',
       receiptUrl: 'https://receipt.test/auto',
+    })
+  })
+
+  it('reconciles a lost Checkout webhook from the provider source of truth', async () => {
+    const sessionsRetrieve = jest.fn().mockResolvedValue({
+      id: 'cs_reconcile',
+      mode: 'payment',
+      status: 'complete',
+      payment_status: 'paid',
+      amount_total: 2500,
+      currency: 'usd',
+      metadata: { operation: 'top_up', topUpId: 'top-up-1', organizationId: 'org-1' },
+      payment_intent: null,
+    })
+    const stripe = { checkout: { sessions: { retrieve: sessionsRetrieve } } } as unknown as Stripe
+    const provider = new StripePaymentProvider('sk_test_secret', 'whsec_test', stripe)
+
+    await expect(provider.reconcile({ operation: 'top_up', providerReference: 'cs_reconcile' })).resolves.toEqual({
+      status: 'resolved',
+      event: {
+        kind: 'top_up_paid',
+        providerEventId: 'reconcile:cs_reconcile:paid',
+        providerReference: 'cs_reconcile',
+        topUpId: 'top-up-1',
+        organizationId: 'org-1',
+        amountCents: '2500',
+        currency: 'usd',
+        receiptUrl: null,
+      },
+    })
+    expect(sessionsRetrieve).toHaveBeenCalledWith('cs_reconcile', { expand: ['payment_intent.latest_charge'] })
+  })
+
+  it('keeps processing payments pending and resolves terminal PaymentIntent failures', async () => {
+    const paymentIntentsRetrieve = jest
+      .fn()
+      .mockResolvedValueOnce({
+        id: 'pi_processing',
+        status: 'processing',
+        metadata: { operation: 'auto_reload', topUpId: 'top-up-1', organizationId: 'org-1' },
+      })
+      .mockResolvedValueOnce({
+        id: 'pi_failed',
+        status: 'requires_payment_method',
+        last_payment_error: { code: 'card_declined', message: 'declined' },
+        metadata: { operation: 'auto_reload', topUpId: 'top-up-2', organizationId: 'org-1' },
+      })
+    const stripe = { paymentIntents: { retrieve: paymentIntentsRetrieve } } as unknown as Stripe
+    const provider = new StripePaymentProvider('sk_test_secret', 'whsec_test', stripe)
+
+    await expect(provider.reconcile({ operation: 'top_up', providerReference: 'pi_processing' })).resolves.toEqual({
+      status: 'pending',
+    })
+    await expect(provider.reconcile({ operation: 'top_up', providerReference: 'pi_failed' })).resolves.toEqual({
+      status: 'resolved',
+      event: expect.objectContaining({
+        kind: 'top_up_failed',
+        providerEventId: 'reconcile:pi_failed:requires_payment_method',
+        failureCode: 'card_declined',
+      }),
+    })
+  })
+
+  it('normalizes refunds and disputes into auditable wallet adjustments', async () => {
+    const payload = Buffer.from('{"id":"evt_adjustment"}')
+    const constructEvent = jest
+      .fn()
+      .mockReturnValueOnce({
+        id: 'evt_refund',
+        type: 'refund.created',
+        data: {
+          object: {
+            id: 're_1',
+            amount: 500,
+            currency: 'usd',
+            status: 'succeeded',
+            payment_intent: 'pi_topup',
+            charge: null,
+          },
+        },
+      })
+      .mockReturnValueOnce({
+        id: 'evt_dispute_restored',
+        type: 'charge.dispute.funds_reinstated',
+        data: {
+          object: {
+            id: 'du_1',
+            amount: 700,
+            currency: 'usd',
+            payment_intent: 'pi_topup',
+            charge: 'ch_1',
+          },
+        },
+      })
+    const paymentIntentsRetrieve = jest.fn().mockResolvedValue({
+      id: 'pi_topup',
+      metadata: { topUpId: 'top-up-1', organizationId: 'org-1' },
+    })
+    const stripe = {
+      webhooks: { constructEvent },
+      paymentIntents: { retrieve: paymentIntentsRetrieve },
+    } as unknown as Stripe
+    const provider = new StripePaymentProvider('sk_test_secret', 'whsec_test', stripe)
+
+    await expect(provider.parseWebhook(payload, 'stripe-signature')).resolves.toEqual({
+      kind: 'top_up_adjusted',
+      providerEventId: 'evt_refund',
+      providerReference: 're_1',
+      topUpId: 'top-up-1',
+      organizationId: 'org-1',
+      amountCents: '500',
+      currency: 'usd',
+      adjustment: 'refund',
+      direction: 'debit',
+    })
+    await expect(provider.parseWebhook(payload, 'stripe-signature')).resolves.toEqual({
+      kind: 'top_up_adjusted',
+      providerEventId: 'evt_dispute_restored',
+      providerReference: 'du_1',
+      topUpId: 'top-up-1',
+      organizationId: 'org-1',
+      amountCents: '700',
+      currency: 'usd',
+      adjustment: 'dispute',
+      direction: 'restore',
     })
   })
 

--- a/apps/api/src/billing/payment/payment-provider.ts
+++ b/apps/api/src/billing/payment/payment-provider.ts
@@ -45,14 +45,31 @@ export interface TopUpPaymentResult {
   failureMessage?: string
 }
 
+export interface PaymentReconcileInput {
+  operation: 'setup' | 'top_up'
+  providerReference: string
+}
+
+export type PaymentReconcileResult = { status: 'pending' } | { status: 'resolved'; event: ProviderWebhookEvent }
+
 export type ProviderWebhookEvent =
   | {
       kind: 'setup_succeeded'
       providerEventId: string
       providerReference: string
       organizationId: string
+      setupAttemptId: string
       providerCustomerId: string
       paymentMethod: PaymentMethodView
+    }
+  | {
+      kind: 'setup_failed'
+      providerEventId: string
+      providerReference: string
+      organizationId: string
+      setupAttemptId: string
+      failureCode: string
+      failureMessage: string
     }
   | {
       kind: 'top_up_paid'
@@ -73,12 +90,24 @@ export type ProviderWebhookEvent =
       failureCode: string | null
       failureMessage: string | null
     }
+  | {
+      kind: 'top_up_adjusted'
+      providerEventId: string
+      providerReference: string
+      topUpId: string
+      organizationId: string
+      amountCents: string
+      currency: string
+      adjustment: 'refund' | 'dispute'
+      direction: 'debit' | 'restore'
+    }
 
 export interface PaymentProvider {
   readonly mode: 'fake' | 'stripe'
   createSetup(input: PaymentSetupInput): Promise<PaymentSetupResult>
   createManualTopUp(input: TopUpPaymentInput): Promise<TopUpPaymentResult>
   chargeSavedMethod(input: TopUpPaymentInput): Promise<TopUpPaymentResult>
+  reconcile(input: PaymentReconcileInput): Promise<PaymentReconcileResult>
   parseWebhook(payload: Buffer, signature: string): Promise<ProviderWebhookEvent | null>
 }
 

--- a/apps/api/src/billing/payment/payment.service.spec.ts
+++ b/apps/api/src/billing/payment/payment.service.spec.ts
@@ -9,7 +9,16 @@ import { TopUpRecord } from '../entities/top-up-record.entity'
 import { WalletTransaction } from '../entities/wallet-transaction.entity'
 import { Wallet } from '../entities/wallet.entity'
 import { FakePaymentProvider } from './fake-payment.provider'
-import { PaymentProvider, ProviderWebhookEvent, TopUpPaymentInput, TopUpPaymentResult } from './payment-provider'
+import {
+  PaymentProvider,
+  PaymentReconcileInput,
+  PaymentReconcileResult,
+  PaymentSetupInput,
+  PaymentSetupResult,
+  ProviderWebhookEvent,
+  TopUpPaymentInput,
+  TopUpPaymentResult,
+} from './payment-provider'
 import { PaymentService } from './payment.service'
 
 const ORG_ID = 'f5de33a9-4eb2-4279-a8de-9f02d63cc4f0'
@@ -97,6 +106,37 @@ class AmbiguousThenSuccessfulPaymentProvider extends FakePaymentProvider {
   }
 }
 
+class AmbiguousThenSuccessfulSetupProvider extends FakePaymentProvider {
+  setupCalls: PaymentSetupInput[] = []
+
+  override async createSetup(input: PaymentSetupInput): Promise<PaymentSetupResult> {
+    this.setupCalls.push(input)
+    if (this.setupCalls.length === 1) throw new Error('setup provider response was lost')
+    return super.createSetup(input)
+  }
+}
+
+class ReconciledPaymentProvider extends PendingPaymentProvider {
+  reconcileCalls: PaymentReconcileInput[] = []
+
+  override async reconcile(input: PaymentReconcileInput): Promise<PaymentReconcileResult> {
+    this.reconcileCalls.push(input)
+    return {
+      status: 'resolved',
+      event: {
+        kind: 'top_up_paid',
+        providerEventId: `reconcile:${input.providerReference}:paid`,
+        providerReference: input.providerReference,
+        topUpId: 'top-up-1',
+        organizationId: ORG_ID,
+        amountCents: '2500',
+        currency: 'usd',
+        receiptUrl: 'https://receipt.test/reconciled',
+      },
+    }
+  }
+}
+
 function wallet(overrides: Partial<Wallet> = {}): Wallet {
   return {
     id: 'wallet-1',
@@ -110,6 +150,11 @@ function wallet(overrides: Partial<Wallet> = {}): Wallet {
     paymentProviderMethodId: null,
     paymentMethodBrand: null,
     paymentMethodLast4: null,
+    paymentSetupAttemptId: null,
+    paymentSetupProviderReference: null,
+    paymentSetupNextReconcileAt: null,
+    paymentSetupReconcileAttempts: 0,
+    paymentSetupLastError: null,
     autoReloadEnabled: false,
     autoReloadThresholdCents: null,
     autoReloadTargetCents: null,
@@ -201,6 +246,12 @@ describe('PaymentService', () => {
       receiptUrl: null,
       failureCode: null,
       failureMessage: null,
+      reconcileAttempts: 0,
+      nextReconcileAt: null,
+      lastReconciledAt: null,
+      reconcileLastError: null,
+      refundedCents: '0',
+      disputedCents: '0',
       completedAt: null,
       createdAt: new Date('2026-07-10T00:00:00Z'),
       updatedAt: new Date('2026-07-10T00:00:00Z'),
@@ -260,6 +311,150 @@ describe('PaymentService', () => {
     expect(provider.manualTopUpCalls[0].topUpId).toBe(provider.manualTopUpCalls[1].topUpId)
     expect(currentWallet.paidBalanceCents).toBe('2500')
     expect(transactions.rows).toHaveLength(1)
+  })
+
+  it('reuses one durable setup attempt after the provider response is lost', async () => {
+    const provider = new AmbiguousThenSuccessfulSetupProvider()
+    const { service, currentWallet } = createService(provider)
+
+    await expect(service.setupPaymentMethod(ORG_ID)).rejects.toThrow('payment provider request failed')
+    const setupAttemptId = currentWallet.paymentSetupAttemptId
+    expect(setupAttemptId).toEqual(expect.any(String))
+    expect(currentWallet.paymentSetupNextReconcileAt).toBeInstanceOf(Date)
+
+    await expect(service.setupPaymentMethod(ORG_ID)).resolves.toEqual({ status: 'ready', checkoutUrl: null })
+    expect(provider.setupCalls.map((call) => call.setupAttemptId)).toEqual([setupAttemptId, setupAttemptId])
+    expect(currentWallet.paymentSetupAttemptId).toBeNull()
+  })
+
+  it('reconciles one pending top-up and credits the wallet exactly once', async () => {
+    const provider = new ReconciledPaymentProvider()
+    const { service, currentWallet, topUps, transactions } = createService(provider, {
+      paymentProviderCustomerId: 'cus-1',
+      paymentProviderMethodId: 'pm-1',
+    })
+    const topUp = await service.createManualTopUp(ORG_ID, '2500', 'request-reconcile')
+    const reconcileAt = new Date(Date.now() + 10 * 60 * 1000)
+
+    await expect(service.reconcileTopUp(topUp.id, reconcileAt)).resolves.toBe(true)
+    await expect(service.reconcileTopUp(topUp.id, new Date(reconcileAt.getTime() + 60_000))).resolves.toBe(false)
+
+    expect(provider.reconcileCalls).toEqual([{ operation: 'top_up', providerReference: 'checkout-pending' }])
+    expect(topUps.rows[0]).toMatchObject({
+      status: 'paid',
+      reconcileAttempts: 1,
+      nextReconcileAt: null,
+      reconcileLastError: null,
+    })
+    expect(currentWallet.paidBalanceCents).toBe('2500')
+    expect(transactions.rows.filter((row) => row.kind === 'top_up')).toHaveLength(1)
+  })
+
+  it('uses immutable adjustments for refund debit and restoration without double-changing balance', async () => {
+    const { service, currentWallet, topUps, transactions } = createService(new TestWebhookPaymentProvider(), {
+      paymentProviderCustomerId: 'cus-1',
+      paymentProviderMethodId: 'pm-1',
+    })
+    const topUp = await service.createManualTopUp(ORG_ID, '2500', 'request-refund')
+    await service.handleWebhook(
+      Buffer.from(
+        JSON.stringify({
+          kind: 'top_up_paid',
+          providerEventId: 'evt-paid-for-refund',
+          providerReference: 'checkout-pending',
+          topUpId: topUp.id,
+          organizationId: ORG_ID,
+          amountCents: '2500',
+          currency: 'usd',
+          receiptUrl: null,
+        }),
+      ),
+      'test',
+    )
+
+    const refundDebit = {
+      kind: 'top_up_adjusted',
+      providerEventId: 'evt-refund-created',
+      providerReference: 're_1',
+      topUpId: topUp.id,
+      organizationId: ORG_ID,
+      amountCents: '500',
+      currency: 'usd',
+      adjustment: 'refund',
+      direction: 'debit',
+    }
+    await service.handleWebhook(Buffer.from(JSON.stringify(refundDebit)), 'test')
+    await service.handleWebhook(
+      Buffer.from(JSON.stringify({ ...refundDebit, providerEventId: 'evt-refund-updated' })),
+      'test',
+    )
+    await service.handleWebhook(
+      Buffer.from(
+        JSON.stringify({
+          ...refundDebit,
+          providerEventId: 'evt-refund-failed',
+          direction: 'restore',
+        }),
+      ),
+      'test',
+    )
+
+    expect(currentWallet.paidBalanceCents).toBe('2500')
+    expect(topUps.rows[0]).toMatchObject({ refundedCents: '0' })
+    expect(transactions.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ providerActionId: 'refund:re_1:debit', amountCents: '-500' }),
+        expect.objectContaining({ providerActionId: 'refund:re_1:restore', amountCents: '500' }),
+      ]),
+    )
+    expect(transactions.rows.filter((row) => row.kind === 'adjustment')).toHaveLength(2)
+  })
+
+  it('does not debit a refund when its terminal failure arrives first', async () => {
+    const { service, currentWallet, transactions } = createService(new TestWebhookPaymentProvider(), {
+      paidBalanceCents: '2500',
+      paymentProviderCustomerId: 'cus-1',
+      paymentProviderMethodId: 'pm-1',
+    })
+    const topUp = await service.createManualTopUp(ORG_ID, '2500', 'request-refund-out-of-order')
+    await service.handleWebhook(
+      Buffer.from(
+        JSON.stringify({
+          kind: 'top_up_paid',
+          providerEventId: 'evt-paid-before-out-of-order-refund',
+          providerReference: 'checkout-pending',
+          topUpId: topUp.id,
+          organizationId: ORG_ID,
+          amountCents: '2500',
+          currency: 'usd',
+          receiptUrl: null,
+        }),
+      ),
+      'test',
+    )
+
+    const event = {
+      kind: 'top_up_adjusted',
+      providerReference: 're_out_of_order',
+      topUpId: topUp.id,
+      organizationId: ORG_ID,
+      amountCents: '500',
+      currency: 'usd',
+      adjustment: 'refund',
+    }
+    await service.handleWebhook(
+      Buffer.from(JSON.stringify({ ...event, providerEventId: 'evt-failed-first', direction: 'restore' })),
+      'test',
+    )
+    await service.handleWebhook(
+      Buffer.from(JSON.stringify({ ...event, providerEventId: 'evt-created-late', direction: 'debit' })),
+      'test',
+    )
+
+    expect(currentWallet.paidBalanceCents).toBe('5000')
+    expect(transactions.rows.filter((row) => row.kind === 'adjustment')).toEqual([
+      expect.objectContaining({ providerActionId: 'refund:re_out_of_order:restore', amountCents: '0' }),
+    ])
   })
 
   it('converges failed then paid webhooks, ignores later failure, and never double-credits', async () => {

--- a/apps/api/src/billing/payment/payment.service.ts
+++ b/apps/api/src/billing/payment/payment.service.ts
@@ -7,7 +7,7 @@ import { BadRequestException, Inject, Injectable, Logger, ServiceUnavailableExce
 import { Cron, CronExpression } from '@nestjs/schedule'
 import { InjectRepository } from '@nestjs/typeorm'
 import { randomUUID } from 'node:crypto'
-import { EntityManager, QueryFailedError, Repository } from 'typeorm'
+import { EntityManager, LessThanOrEqual, QueryFailedError, Repository } from 'typeorm'
 import { TypedConfigService } from '../../config/typed-config.service'
 import { PaymentProviderEvent } from '../entities/payment-provider-event.entity'
 import { TopUpRecord } from '../entities/top-up-record.entity'
@@ -17,6 +17,7 @@ import { WalletService } from '../wallet.service'
 import {
   PAYMENT_PROVIDER,
   PaymentProvider,
+  PaymentSetupResult,
   ProviderWebhookEvent,
   TopUpPaymentInput,
   TopUpPaymentResult,
@@ -25,6 +26,9 @@ import {
 const MIN_TOP_UP_CENTS = 500n
 const MIN_AUTO_RELOAD_SPREAD_CENTS = 1000n
 const AUTO_RELOAD_RETRY_MILLISECONDS = 15 * 60 * 1000
+const INITIAL_RECONCILE_DELAY_MILLISECONDS = 60 * 1000
+const MAX_RECONCILE_DELAY_MILLISECONDS = 60 * 60 * 1000
+const RECOVERY_BATCH_SIZE = 100
 const PG_UNIQUE_VIOLATION = '23505'
 
 export interface AutoReloadInput {
@@ -76,37 +80,9 @@ export class PaymentService {
   async setupPaymentMethod(
     organizationId: string,
   ): Promise<{ status: 'ready' | 'pending'; checkoutUrl: string | null }> {
-    const wallet = await this.walletService.getOrCreateWallet(organizationId)
-    const result = await this.provider.createSetup({
-      organizationId,
-      walletId: wallet.id,
-      setupAttemptId: randomUUID(),
-      providerCustomerId: wallet.paymentProviderCustomerId,
-      ...this.returnUrls(),
-    })
-
-    await this.wallets.manager.transaction(async (manager) => {
-      const lockedWallet = await manager.getRepository(Wallet).findOne({
-        where: { organizationId },
-        lock: { mode: 'pessimistic_write' },
-      })
-      if (!lockedWallet) throw new BadRequestException('wallet not found')
-      lockedWallet.paymentProviderCustomerId = result.providerCustomerId
-      await manager.getRepository(Wallet).save(lockedWallet)
-    })
-
-    if (result.status === 'ready' && result.paymentMethod) {
-      await this.applyProviderEvent({
-        kind: 'setup_succeeded',
-        providerEventId: `direct:${result.providerReference}`,
-        providerReference: result.providerReference,
-        organizationId,
-        providerCustomerId: result.providerCustomerId,
-        paymentMethod: result.paymentMethod,
-      })
-    }
-
-    return { status: result.status, checkoutUrl: result.checkoutUrl }
+    await this.walletService.getOrCreateWallet(organizationId)
+    const setup = await this.claimPaymentSetup(organizationId)
+    return this.dispatchPaymentSetup(setup)
   }
 
   async setAutoReload(organizationId: string, input: AutoReloadInput): Promise<void> {
@@ -171,7 +147,7 @@ export class PaymentService {
 
   async handleWebhook(payload: Buffer, signature: string): Promise<void> {
     const event = await this.provider.parseWebhook(payload, signature)
-    if (event) await this.applyProviderEvent(event)
+    if (event) await this.processProviderEvent(event)
   }
 
   async runAutoReloadForOrganization(organizationId: string, now = new Date()): Promise<boolean> {
@@ -181,7 +157,7 @@ export class PaymentService {
     return true
   }
 
-  @Cron(CronExpression.EVERY_MINUTE, { name: 'billing-auto-reload' })
+  @Cron(CronExpression.EVERY_MINUTE, { name: 'billing-auto-reload', waitForCompletion: true })
   async scheduledAutoReload(): Promise<void> {
     const candidates = await this.wallets
       .createQueryBuilder('wallet')
@@ -201,6 +177,38 @@ export class PaymentService {
       } catch (error) {
         this.logger.error(`auto-reload failed for organization ${candidate.organizationId}`, error)
       }
+    }
+  }
+
+  @Cron(CronExpression.EVERY_MINUTE, { name: 'billing-payment-recovery', waitForCompletion: true })
+  async scheduledPaymentRecovery(now = new Date()): Promise<void> {
+    const [topUps, setupWallets, providerEvents] = await Promise.all([
+      this.topUps.find({
+        select: { id: true },
+        where: { status: 'pending', nextReconcileAt: LessThanOrEqual(now) },
+        order: { nextReconcileAt: 'ASC', id: 'ASC' },
+        take: RECOVERY_BATCH_SIZE,
+      }),
+      this.wallets.find({
+        select: { organizationId: true },
+        where: { paymentSetupNextReconcileAt: LessThanOrEqual(now) },
+        order: { paymentSetupNextReconcileAt: 'ASC', id: 'ASC' },
+        take: RECOVERY_BATCH_SIZE,
+      }),
+      this.wallets.manager.getRepository(PaymentProviderEvent).find({
+        select: { id: true },
+        where: { status: 'failed', nextAttemptAt: LessThanOrEqual(now) },
+        order: { nextAttemptAt: 'ASC', id: 'ASC' },
+        take: RECOVERY_BATCH_SIZE,
+      }),
+    ])
+
+    for (const topUp of topUps) await this.recover('top_up', topUp.id, () => this.reconcileTopUp(topUp.id, now))
+    for (const wallet of setupWallets) {
+      await this.recover('setup', wallet.organizationId, () => this.reconcilePaymentSetup(wallet.organizationId, now))
+    }
+    for (const event of providerEvents) {
+      await this.recover('webhook', event.id, () => this.retryProviderEvent(event.id, now))
     }
   }
 
@@ -242,6 +250,248 @@ export class PaymentService {
     }
   }
 
+  async reconcileTopUp(topUpId: string, now = new Date(), force = false): Promise<boolean> {
+    const topUp = await this.claimTopUpReconciliation(topUpId, now, force)
+    if (!topUp) return false
+
+    try {
+      if (!topUp.providerReference) {
+        await this.dispatchTopUp(topUp, topUp.source === 'auto_reload')
+        return true
+      }
+
+      const result = await this.provider.reconcile({
+        operation: 'top_up',
+        providerReference: topUp.providerReference,
+      })
+      if (result.status === 'resolved') {
+        await this.processProviderEvent(result.event)
+      } else {
+        await this.markTopUpPending(topUp.id, topUp.reconcileAttempts, now)
+      }
+      return true
+    } catch (error) {
+      await this.markTopUpReconcileFailure(topUp.id, topUp.reconcileAttempts, error, now)
+      throw error
+    }
+  }
+
+  async reconcilePaymentSetup(organizationId: string, now = new Date(), force = false): Promise<boolean> {
+    const setup = await this.claimPaymentSetupReconciliation(organizationId, now, force)
+    if (!setup) return false
+
+    try {
+      if (!setup.paymentSetupProviderReference) {
+        await this.dispatchPaymentSetup(setup)
+        return true
+      }
+
+      const result = await this.provider.reconcile({
+        operation: 'setup',
+        providerReference: setup.paymentSetupProviderReference,
+      })
+      if (result.status === 'resolved') {
+        await this.processProviderEvent(result.event)
+      } else {
+        await this.markPaymentSetupPending(organizationId, setup.paymentSetupReconcileAttempts, now)
+      }
+      return true
+    } catch (error) {
+      await this.markPaymentSetupFailure(
+        organizationId,
+        setup.paymentSetupAttemptId,
+        setup.paymentSetupReconcileAttempts,
+        error,
+        now,
+      )
+      throw error
+    }
+  }
+
+  private async claimPaymentSetup(organizationId: string): Promise<Wallet> {
+    return this.wallets.manager.transaction(async (manager) => {
+      const repository = manager.getRepository(Wallet)
+      const wallet = await repository.findOne({
+        where: { organizationId },
+        lock: { mode: 'pessimistic_write' },
+      })
+      if (!wallet) throw new BadRequestException('wallet not found')
+      if (!wallet.paymentSetupAttemptId) {
+        wallet.paymentSetupAttemptId = randomUUID()
+        wallet.paymentSetupProviderReference = null
+        wallet.paymentSetupNextReconcileAt = new Date()
+        wallet.paymentSetupReconcileAttempts = 0
+        wallet.paymentSetupLastError = null
+        await repository.save(wallet)
+      }
+      return { ...wallet }
+    })
+  }
+
+  private async dispatchPaymentSetup(
+    setup: Wallet,
+  ): Promise<{ status: 'ready' | 'pending'; checkoutUrl: string | null }> {
+    if (!setup.paymentSetupAttemptId) throw new Error('payment setup attempt is missing')
+
+    let result: PaymentSetupResult
+    try {
+      result = await this.provider.createSetup({
+        organizationId: setup.organizationId,
+        walletId: setup.id,
+        setupAttemptId: setup.paymentSetupAttemptId,
+        providerCustomerId: setup.paymentProviderCustomerId,
+        ...this.returnUrls(),
+      })
+    } catch (error) {
+      await this.markPaymentSetupFailure(
+        setup.organizationId,
+        setup.paymentSetupAttemptId,
+        setup.paymentSetupReconcileAttempts,
+        error,
+        new Date(),
+      )
+      throw new ServiceUnavailableException('payment provider request failed', { cause: error })
+    }
+
+    await this.persistPaymentSetupResult(setup.organizationId, setup.paymentSetupAttemptId, result)
+    if (result.status === 'ready' && result.paymentMethod) {
+      await this.processProviderEvent({
+        kind: 'setup_succeeded',
+        providerEventId: `direct:${result.providerReference}`,
+        providerReference: result.providerReference,
+        organizationId: setup.organizationId,
+        setupAttemptId: setup.paymentSetupAttemptId,
+        providerCustomerId: result.providerCustomerId,
+        paymentMethod: result.paymentMethod,
+      })
+    }
+    return { status: result.status, checkoutUrl: result.checkoutUrl }
+  }
+
+  private async persistPaymentSetupResult(
+    organizationId: string,
+    setupAttemptId: string,
+    result: PaymentSetupResult,
+  ): Promise<void> {
+    await this.wallets.manager.transaction(async (manager) => {
+      const repository = manager.getRepository(Wallet)
+      const wallet = await repository.findOne({
+        where: { organizationId },
+        lock: { mode: 'pessimistic_write' },
+      })
+      if (!wallet) throw new BadRequestException('wallet not found')
+      if (wallet.paymentSetupAttemptId !== setupAttemptId) return
+      wallet.paymentProviderCustomerId = result.providerCustomerId
+      wallet.paymentSetupProviderReference = result.providerReference
+      wallet.paymentSetupNextReconcileAt = new Date(Date.now() + INITIAL_RECONCILE_DELAY_MILLISECONDS)
+      wallet.paymentSetupLastError = null
+      await repository.save(wallet)
+    })
+  }
+
+  private claimPaymentSetupReconciliation(organizationId: string, now: Date, force: boolean): Promise<Wallet | null> {
+    return this.wallets.manager.transaction(async (manager) => {
+      const repository = manager.getRepository(Wallet)
+      const wallet = await repository.findOne({
+        where: { organizationId },
+        lock: { mode: 'pessimistic_write' },
+      })
+      if (
+        !wallet?.paymentSetupAttemptId ||
+        !wallet.paymentSetupNextReconcileAt ||
+        (!force && wallet.paymentSetupNextReconcileAt > now)
+      ) {
+        return null
+      }
+      wallet.paymentSetupReconcileAttempts += 1
+      wallet.paymentSetupNextReconcileAt = new Date(
+        now.getTime() + this.reconcileDelayMilliseconds(wallet.paymentSetupReconcileAttempts),
+      )
+      await repository.save(wallet)
+      return { ...wallet }
+    })
+  }
+
+  private async markPaymentSetupPending(organizationId: string, attempts: number, now: Date): Promise<void> {
+    await this.wallets.manager.transaction(async (manager) => {
+      const repository = manager.getRepository(Wallet)
+      const wallet = await repository.findOne({
+        where: { organizationId },
+        lock: { mode: 'pessimistic_write' },
+      })
+      if (!wallet?.paymentSetupAttemptId) return
+      wallet.paymentSetupNextReconcileAt = new Date(now.getTime() + this.reconcileDelayMilliseconds(attempts))
+      wallet.paymentSetupLastError = null
+      await repository.save(wallet)
+    })
+  }
+
+  private async markPaymentSetupFailure(
+    organizationId: string,
+    setupAttemptId: string | null,
+    attempts: number,
+    error: unknown,
+    now: Date,
+  ): Promise<void> {
+    await this.wallets.manager.transaction(async (manager) => {
+      const repository = manager.getRepository(Wallet)
+      const wallet = await repository.findOne({
+        where: { organizationId },
+        lock: { mode: 'pessimistic_write' },
+      })
+      if (!wallet || wallet.paymentSetupAttemptId !== setupAttemptId) return
+      wallet.paymentSetupLastError = this.errorMessage(error)
+      wallet.paymentSetupNextReconcileAt = new Date(now.getTime() + this.reconcileDelayMilliseconds(attempts + 1))
+      await repository.save(wallet)
+    })
+  }
+
+  private claimTopUpReconciliation(topUpId: string, now: Date, force: boolean): Promise<TopUpRecord | null> {
+    return this.wallets.manager.transaction(async (manager) => {
+      const repository = manager.getRepository(TopUpRecord)
+      const topUp = await repository.findOne({
+        where: { id: topUpId },
+        lock: { mode: 'pessimistic_write' },
+      })
+      if (!topUp || topUp.status !== 'pending' || (!force && topUp.nextReconcileAt && topUp.nextReconcileAt > now)) {
+        return null
+      }
+      topUp.reconcileAttempts += 1
+      topUp.lastReconciledAt = now
+      topUp.nextReconcileAt = new Date(now.getTime() + this.reconcileDelayMilliseconds(topUp.reconcileAttempts))
+      await repository.save(topUp)
+      return { ...topUp }
+    })
+  }
+
+  private async markTopUpPending(topUpId: string, attempts: number, now: Date): Promise<void> {
+    await this.wallets.manager.transaction(async (manager) => {
+      const repository = manager.getRepository(TopUpRecord)
+      const topUp = await repository.findOne({
+        where: { id: topUpId },
+        lock: { mode: 'pessimistic_write' },
+      })
+      if (!topUp || topUp.status !== 'pending') return
+      topUp.nextReconcileAt = new Date(now.getTime() + this.reconcileDelayMilliseconds(attempts))
+      topUp.reconcileLastError = null
+      await repository.save(topUp)
+    })
+  }
+
+  private async markTopUpReconcileFailure(topUpId: string, attempts: number, error: unknown, now: Date): Promise<void> {
+    await this.wallets.manager.transaction(async (manager) => {
+      const repository = manager.getRepository(TopUpRecord)
+      const topUp = await repository.findOne({
+        where: { id: topUpId },
+        lock: { mode: 'pessimistic_write' },
+      })
+      if (!topUp || topUp.status !== 'pending') return
+      topUp.reconcileLastError = this.errorMessage(error)
+      topUp.nextReconcileAt = new Date(now.getTime() + this.reconcileDelayMilliseconds(attempts + 1))
+      await repository.save(topUp)
+    })
+  }
+
   private async claimManualTopUp(organizationId: string, amountCents: bigint, idempotencyKey: string) {
     try {
       return await this.wallets.manager.transaction(async (manager) => {
@@ -271,6 +521,12 @@ export class PaymentService {
             receiptUrl: null,
             failureCode: null,
             failureMessage: null,
+            reconcileAttempts: 0,
+            nextReconcileAt: new Date(Date.now() + INITIAL_RECONCILE_DELAY_MILLISECONDS),
+            lastReconciledAt: null,
+            reconcileLastError: null,
+            refundedCents: '0',
+            disputedCents: '0',
             completedAt: null,
           }),
         )
@@ -328,6 +584,12 @@ export class PaymentService {
           receiptUrl: null,
           failureCode: null,
           failureMessage: null,
+          reconcileAttempts: 0,
+          nextReconcileAt: new Date(Date.now() + INITIAL_RECONCILE_DELAY_MILLISECONDS),
+          lastReconciledAt: null,
+          reconcileLastError: null,
+          refundedCents: '0',
+          disputedCents: '0',
           completedAt: null,
         }),
       )
@@ -352,6 +614,7 @@ export class PaymentService {
     try {
       result = savedMethod ? await this.provider.chargeSavedMethod(input) : await this.provider.createManualTopUp(input)
     } catch (error) {
+      await this.markTopUpReconcileFailure(topUp.id, topUp.reconcileAttempts, error, new Date())
       throw new ServiceUnavailableException('payment provider request failed', { cause: error })
     }
 
@@ -359,12 +622,23 @@ export class PaymentService {
   }
 
   private async applyPaymentResult(topUp: TopUpRecord, result: TopUpPaymentResult): Promise<void> {
-    topUp.providerReference = result.providerReference
-    topUp.checkoutUrl = result.checkoutUrl
-    await this.topUps.save(topUp)
+    await this.wallets.manager.transaction(async (manager) => {
+      const repository = manager.getRepository(TopUpRecord)
+      const current = await repository.findOne({
+        where: { id: topUp.id },
+        lock: { mode: 'pessimistic_write' },
+      })
+      if (!current || current.status !== 'pending') return
+      current.providerReference = result.providerReference
+      current.checkoutUrl = result.checkoutUrl
+      current.nextReconcileAt =
+        result.status === 'pending' ? new Date(Date.now() + INITIAL_RECONCILE_DELAY_MILLISECONDS) : null
+      current.reconcileLastError = null
+      await repository.save(current)
+    })
 
     if (result.status === 'paid') {
-      await this.applyProviderEvent({
+      await this.processProviderEvent({
         kind: 'top_up_paid',
         providerEventId: `direct:${result.providerReference}`,
         providerReference: result.providerReference,
@@ -375,7 +649,7 @@ export class PaymentService {
         receiptUrl: result.receiptUrl,
       })
     } else if (result.status === 'failed') {
-      await this.applyProviderEvent({
+      await this.processProviderEvent({
         kind: 'top_up_failed',
         providerEventId: `direct:${result.providerReference}`,
         providerReference: result.providerReference,
@@ -387,39 +661,135 @@ export class PaymentService {
     }
   }
 
+  private async processProviderEvent(event: ProviderWebhookEvent): Promise<void> {
+    try {
+      await this.applyProviderEvent(event)
+    } catch (error) {
+      await this.recordProviderEventFailure(event, error)
+      this.logger.error(
+        `[billing_payment] stage=webhook_apply event=${event.providerEventId} reference=${event.providerReference} error=${this.errorMessage(error)}`,
+      )
+      throw error
+    }
+  }
+
   private async applyProviderEvent(event: ProviderWebhookEvent): Promise<void> {
     try {
       await this.wallets.manager.transaction(async (manager) => {
         const eventRepository = manager.getRepository(PaymentProviderEvent)
-        if (await eventRepository.findOne({ where: { providerEventId: event.providerEventId } })) return
+        const existing = await eventRepository.findOne({
+          where: { providerEventId: event.providerEventId },
+          lock: { mode: 'pessimistic_write' },
+        })
+        if (existing?.status === 'processed') return
 
-        if (event.kind === 'setup_succeeded') {
-          const wallet = await manager.getRepository(Wallet).findOne({
-            where: { organizationId: event.organizationId },
-            lock: { mode: 'pessimistic_write' },
-          })
-          if (!wallet) throw new BadRequestException('wallet not found')
-          wallet.paymentProviderCustomerId = event.providerCustomerId
-          wallet.paymentProviderMethodId = event.paymentMethod.id
-          wallet.paymentMethodBrand = event.paymentMethod.brand
-          wallet.paymentMethodLast4 = event.paymentMethod.last4
-          await manager.getRepository(Wallet).save(wallet)
+        if (event.kind === 'setup_succeeded' || event.kind === 'setup_failed') {
+          await this.applySetupEvent(manager, event)
+        } else if (event.kind === 'top_up_adjusted') {
+          await this.applyTopUpAdjustment(manager, event)
         } else {
           await this.applyTopUpEvent(manager, event)
         }
 
-        await eventRepository.save(
-          eventRepository.create({ providerEventId: event.providerEventId, eventType: event.kind }),
-        )
+        const record =
+          existing ??
+          eventRepository.create({
+            providerEventId: event.providerEventId,
+            createdAt: new Date(),
+            attempts: 1,
+          })
+        record.eventType = this.providerEventType(event)
+        record.providerReference = event.providerReference
+        record.status = 'processed'
+        record.payload = event as unknown as Record<string, unknown>
+        record.nextAttemptAt = null
+        record.lastError = null
+        await eventRepository.save(record)
       })
     } catch (error) {
       if (!this.isUniqueViolation(error)) throw error
     }
   }
 
+  private async recordProviderEventFailure(event: ProviderWebhookEvent, error: unknown): Promise<void> {
+    try {
+      await this.wallets.manager.transaction(async (manager) => {
+        const repository = manager.getRepository(PaymentProviderEvent)
+        const existing = await repository.findOne({
+          where: { providerEventId: event.providerEventId },
+          lock: { mode: 'pessimistic_write' },
+        })
+        if (existing?.status === 'processed') return
+        const record =
+          existing ??
+          repository.create({
+            providerEventId: event.providerEventId,
+            createdAt: new Date(),
+            attempts: 0,
+          })
+        record.eventType = this.providerEventType(event)
+        record.providerReference = event.providerReference
+        record.status = 'failed'
+        record.payload = event as unknown as Record<string, unknown>
+        record.attempts += 1
+        record.nextAttemptAt = new Date(Date.now() + this.reconcileDelayMilliseconds(record.attempts))
+        record.lastError = this.errorMessage(error)
+        await repository.save(record)
+      })
+    } catch (failure) {
+      if (!this.isUniqueViolation(failure)) throw failure
+    }
+  }
+
+  private async retryProviderEvent(providerEventId: string, now: Date): Promise<boolean> {
+    const event = await this.wallets.manager.transaction(async (manager) => {
+      const repository = manager.getRepository(PaymentProviderEvent)
+      const record = await repository.findOne({
+        where: { id: providerEventId },
+        lock: { mode: 'pessimistic_write' },
+      })
+      if (record?.status !== 'failed' || !record.payload || (record.nextAttemptAt && record.nextAttemptAt > now)) {
+        return null
+      }
+      record.nextAttemptAt = new Date(now.getTime() + this.reconcileDelayMilliseconds(record.attempts + 1))
+      await repository.save(record)
+      return record.payload as unknown as ProviderWebhookEvent
+    })
+    if (!event) return false
+    await this.processProviderEvent(event)
+    return true
+  }
+
+  private async applySetupEvent(
+    manager: EntityManager,
+    event: Extract<ProviderWebhookEvent, { kind: 'setup_succeeded' | 'setup_failed' }>,
+  ): Promise<void> {
+    const repository = manager.getRepository(Wallet)
+    const wallet = await repository.findOne({
+      where: { organizationId: event.organizationId },
+      lock: { mode: 'pessimistic_write' },
+    })
+    if (!wallet) throw new BadRequestException('wallet not found')
+    if (wallet.paymentSetupAttemptId !== event.setupAttemptId) return
+
+    if (event.kind === 'setup_succeeded') {
+      wallet.paymentProviderCustomerId = event.providerCustomerId
+      wallet.paymentProviderMethodId = event.paymentMethod.id
+      wallet.paymentMethodBrand = event.paymentMethod.brand
+      wallet.paymentMethodLast4 = event.paymentMethod.last4
+      wallet.paymentSetupLastError = null
+    } else {
+      wallet.paymentSetupLastError = `${event.failureCode}: ${event.failureMessage}`
+    }
+    wallet.paymentSetupAttemptId = null
+    wallet.paymentSetupProviderReference = null
+    wallet.paymentSetupNextReconcileAt = null
+    await repository.save(wallet)
+  }
+
   private async applyTopUpEvent(
     manager: EntityManager,
-    event: Exclude<ProviderWebhookEvent, { kind: 'setup_succeeded' }>,
+    event: Extract<ProviderWebhookEvent, { kind: 'top_up_paid' | 'top_up_failed' }>,
   ): Promise<void> {
     const topUpRepository = manager.getRepository(TopUpRecord)
     const topUp = await topUpRepository.findOne({
@@ -435,6 +805,8 @@ export class PaymentService {
       topUp.status = 'failed'
       topUp.failureCode = event.failureCode
       topUp.failureMessage = event.failureMessage
+      topUp.nextReconcileAt = null
+      topUp.reconcileLastError = null
       topUp.completedAt = new Date()
       await topUpRepository.save(topUp)
       if (topUp.source === 'auto_reload') {
@@ -469,6 +841,8 @@ export class PaymentService {
     topUp.receiptUrl = event.receiptUrl
     topUp.failureCode = null
     topUp.failureMessage = null
+    topUp.nextReconcileAt = null
+    topUp.reconcileLastError = null
     topUp.completedAt = new Date()
     await topUpRepository.save(topUp)
     const transactionRepository = manager.getRepository(WalletTransaction)
@@ -480,7 +854,82 @@ export class PaymentService {
         amountCents: topUp.amountCents,
         source: topUp.source === 'auto_reload' ? 'auto_reload' : 'manual_top_up',
         ratedPeriodId: null,
+        providerActionId: null,
         metadata: { topUpId: topUp.id, providerReference: event.providerReference },
+      }),
+    )
+  }
+
+  private async applyTopUpAdjustment(
+    manager: EntityManager,
+    event: Extract<ProviderWebhookEvent, { kind: 'top_up_adjusted' }>,
+  ): Promise<void> {
+    const amount = this.positiveCents(event.amountCents, 'provider adjustment amount')
+    if (event.currency.toLowerCase() !== 'usd') throw new BadRequestException('provider adjustment must use USD')
+
+    const topUpRepository = manager.getRepository(TopUpRecord)
+    const topUp = await topUpRepository.findOne({
+      where: { id: event.topUpId },
+      lock: { mode: 'pessimistic_write' },
+    })
+    if (!topUp || topUp.organizationId !== event.organizationId || topUp.status !== 'paid') {
+      throw new BadRequestException('provider adjustment does not match a paid top-up')
+    }
+    if (amount > BigInt(topUp.amountCents)) throw new BadRequestException('provider adjustment exceeds top-up')
+
+    const walletRepository = manager.getRepository(Wallet)
+    const wallet = await walletRepository.findOne({
+      where: { id: topUp.walletId },
+      lock: { mode: 'pessimistic_write' },
+    })
+    if (!wallet) throw new BadRequestException('wallet not found')
+
+    const transactionRepository = manager.getRepository(WalletTransaction)
+    const actionPrefix = `${event.adjustment}:${event.providerReference}`
+    const debitActionId = `${actionPrefix}:debit`
+    const restoreActionId = `${actionPrefix}:restore`
+    const debit = await transactionRepository.findOne({ where: { providerActionId: debitActionId } })
+    const restore = await transactionRepository.findOne({ where: { providerActionId: restoreActionId } })
+    if (event.direction === 'debit' && (debit || restore)) return
+    if (event.direction === 'restore' && restore) return
+
+    const counter = event.adjustment === 'refund' ? 'refundedCents' : 'disputedCents'
+    let ledgerAmount = 0n
+    if (event.direction === 'debit') {
+      ledgerAmount = -amount
+      wallet.paidBalanceCents = (BigInt(wallet.paidBalanceCents) - amount).toString()
+      topUp[counter] = (BigInt(topUp[counter]) + amount).toString()
+    } else if (debit) {
+      if (BigInt(debit.amountCents) !== -amount) {
+        throw new BadRequestException('provider adjustment restoration amount does not match debit')
+      }
+      const currentAdjusted = BigInt(topUp[counter])
+      if (currentAdjusted < amount) throw new BadRequestException('provider adjustment restoration exceeds debit')
+      ledgerAmount = amount
+      wallet.paidBalanceCents = (BigInt(wallet.paidBalanceCents) + amount).toString()
+      topUp[counter] = (currentAdjusted - amount).toString()
+    }
+
+    wallet.billingStatus = this.statusForWallet(wallet)
+    if (ledgerAmount !== 0n) {
+      await walletRepository.save(wallet)
+      await topUpRepository.save(topUp)
+    }
+    await transactionRepository.save(
+      transactionRepository.create({
+        walletId: wallet.id,
+        organizationId: wallet.organizationId,
+        kind: 'adjustment',
+        amountCents: ledgerAmount.toString(),
+        source: `stripe_${event.adjustment}_${event.direction}`,
+        ratedPeriodId: null,
+        providerActionId: event.direction === 'debit' ? debitActionId : restoreActionId,
+        metadata: {
+          topUpId: topUp.id,
+          providerReference: event.providerReference,
+          adjustment: event.adjustment,
+          direction: event.direction,
+        },
       }),
     )
   }
@@ -500,6 +949,27 @@ export class PaymentService {
   private assertIdempotentAmount(topUp: TopUpRecord, amountCents: bigint): void {
     if (topUp.amountCents !== amountCents.toString()) {
       throw new BadRequestException('idempotency key was already used with a different amount')
+    }
+  }
+
+  private providerEventType(event: ProviderWebhookEvent): string {
+    return event.kind === 'top_up_adjusted' ? `${event.kind}:${event.adjustment}:${event.direction}` : event.kind
+  }
+
+  private reconcileDelayMilliseconds(attempts: number): number {
+    const exponent = Math.max(0, Math.min(6, attempts - 1))
+    return Math.min(INITIAL_RECONCILE_DELAY_MILLISECONDS * 2 ** exponent, MAX_RECONCILE_DELAY_MILLISECONDS)
+  }
+
+  private errorMessage(error: unknown): string {
+    return (error instanceof Error ? error.message : String(error)).slice(0, 500)
+  }
+
+  private async recover(stage: 'setup' | 'top_up' | 'webhook', id: string, work: () => Promise<unknown>) {
+    try {
+      await work()
+    } catch (error) {
+      this.logger.warn(`[billing_payment] stage=${stage}_reconcile id=${id} error=${this.errorMessage(error)}`)
     }
   }
 

--- a/apps/api/src/billing/payment/stripe-payment.provider.ts
+++ b/apps/api/src/billing/payment/stripe-payment.provider.ts
@@ -7,6 +7,8 @@ import Stripe from 'stripe'
 import {
   PaymentMethodView,
   PaymentProvider,
+  PaymentReconcileInput,
+  PaymentReconcileResult,
   PaymentSetupInput,
   PaymentSetupResult,
   ProviderWebhookEvent,
@@ -21,6 +23,7 @@ export class StripePaymentProvider implements PaymentProvider {
     secretKey: string,
     private readonly webhookSecret: string,
     private readonly stripe = new Stripe(secretKey),
+    private readonly previousWebhookSecret?: string,
   ) {}
 
   async createSetup(input: PaymentSetupInput): Promise<PaymentSetupResult> {
@@ -35,6 +38,7 @@ export class StripePaymentProvider implements PaymentProvider {
         metadata: {
           organizationId: input.organizationId,
           walletId: input.walletId,
+          setupAttemptId: input.setupAttemptId,
           operation: 'setup',
         },
       },
@@ -139,8 +143,37 @@ export class StripePaymentProvider implements PaymentProvider {
     }
   }
 
+  async reconcile(input: PaymentReconcileInput): Promise<PaymentReconcileResult> {
+    if (input.providerReference.startsWith('cs_')) {
+      const session = await this.stripe.checkout.sessions.retrieve(input.providerReference, {
+        expand: ['payment_intent.latest_charge'],
+      })
+      if (input.operation === 'setup') return this.reconcileSetupSession(session)
+      return this.reconcileTopUpSession(session)
+    }
+
+    if (input.operation === 'top_up' && input.providerReference.startsWith('pi_')) {
+      const intent = await this.stripe.paymentIntents.retrieve(input.providerReference, {
+        expand: ['latest_charge'],
+      })
+      if (intent.status === 'processing') return { status: 'pending' }
+      if (intent.status === 'succeeded') {
+        return {
+          status: 'resolved',
+          event: this.paymentIntentPaidEvent(`reconcile:${intent.id}:succeeded`, intent),
+        }
+      }
+      return {
+        status: 'resolved',
+        event: this.paymentIntentFailedEvent(`reconcile:${intent.id}:${intent.status}`, intent),
+      }
+    }
+
+    throw new Error(`Unsupported ${input.operation} provider reference ${input.providerReference}`)
+  }
+
   async parseWebhook(payload: Buffer, signature: string): Promise<ProviderWebhookEvent | null> {
-    const event = this.stripe.webhooks.constructEvent(payload, signature, this.webhookSecret)
+    const event = this.constructWebhookEvent(payload, signature)
 
     if (event.type === 'checkout.session.completed') {
       const session = event.data.object
@@ -156,6 +189,12 @@ export class StripePaymentProvider implements PaymentProvider {
       return this.checkoutFailedEvent(event.id, event.data.object)
     }
 
+    if (event.type === 'checkout.session.expired') {
+      return event.data.object.mode === 'setup'
+        ? this.setupFailedEvent(event.id, event.data.object)
+        : this.checkoutFailedEvent(event.id, event.data.object, 'checkout_expired')
+    }
+
     if (event.type === 'payment_intent.succeeded' && event.data.object.metadata?.operation === 'auto_reload') {
       return this.paymentIntentPaidEvent(event.id, event.data.object)
     }
@@ -164,7 +203,35 @@ export class StripePaymentProvider implements PaymentProvider {
       return this.paymentIntentFailedEvent(event.id, event.data.object)
     }
 
+    if (event.type === 'refund.created' || event.type === 'refund.updated' || event.type === 'refund.failed') {
+      return this.refundEvent(event.id, event.data.object)
+    }
+
+    if (
+      event.type === 'charge.dispute.created' ||
+      event.type === 'charge.dispute.funds_withdrawn' ||
+      event.type === 'charge.dispute.funds_reinstated'
+    ) {
+      return this.disputeEvent(event.id, event.type, event.data.object)
+    }
+
     return null
+  }
+
+  private constructWebhookEvent(payload: Buffer, signature: string): Stripe.Event {
+    try {
+      return this.stripe.webhooks.constructEvent(payload, signature, this.webhookSecret)
+    } catch (error) {
+      if (!this.previousWebhookSecret || !this.isSignatureVerificationError(error)) throw error
+      return this.stripe.webhooks.constructEvent(payload, signature, this.previousWebhookSecret)
+    }
+  }
+
+  private isSignatureVerificationError(error: unknown): boolean {
+    return (
+      error instanceof Stripe.errors.StripeSignatureVerificationError ||
+      (error as { type?: string } | null)?.type === 'StripeSignatureVerificationError'
+    )
   }
 
   private createCustomer(input: PaymentSetupInput) {
@@ -196,8 +263,55 @@ export class StripePaymentProvider implements PaymentProvider {
       providerEventId,
       providerReference: session.id,
       organizationId,
+      setupAttemptId: this.requiredMetadata(session, 'setupAttemptId'),
       providerCustomerId: customerId,
       paymentMethod: this.paymentMethodView(paymentMethod),
+    }
+  }
+
+  private async reconcileSetupSession(session: Stripe.Checkout.Session): Promise<PaymentReconcileResult> {
+    if (session.mode !== 'setup') throw new Error(`Stripe Checkout session ${session.id} is not a setup session`)
+    if (session.status === 'complete') {
+      return {
+        status: 'resolved',
+        event: await this.setupEvent(`reconcile:${session.id}:setup_succeeded`, session),
+      }
+    }
+    if (session.status === 'expired') {
+      return {
+        status: 'resolved',
+        event: this.setupFailedEvent(`reconcile:${session.id}:expired`, session),
+      }
+    }
+    return { status: 'pending' }
+  }
+
+  private async reconcileTopUpSession(session: Stripe.Checkout.Session): Promise<PaymentReconcileResult> {
+    if (session.mode !== 'payment') throw new Error(`Stripe Checkout session ${session.id} is not a payment session`)
+    if (session.payment_status === 'paid') {
+      return {
+        status: 'resolved',
+        event: await this.checkoutPaidEvent(`reconcile:${session.id}:paid`, session),
+      }
+    }
+    if (session.status === 'expired') {
+      return {
+        status: 'resolved',
+        event: this.checkoutFailedEvent(`reconcile:${session.id}:expired`, session, 'checkout_expired'),
+      }
+    }
+    return { status: 'pending' }
+  }
+
+  private setupFailedEvent(providerEventId: string, session: Stripe.Checkout.Session): ProviderWebhookEvent {
+    return {
+      kind: 'setup_failed',
+      providerEventId,
+      providerReference: session.id,
+      organizationId: this.requiredMetadata(session, 'organizationId'),
+      setupAttemptId: this.requiredMetadata(session, 'setupAttemptId'),
+      failureCode: 'checkout_expired',
+      failureMessage: 'Stripe payment setup expired before completion',
     }
   }
 
@@ -218,16 +332,70 @@ export class StripePaymentProvider implements PaymentProvider {
     }
   }
 
-  private checkoutFailedEvent(providerEventId: string, session: Stripe.Checkout.Session): ProviderWebhookEvent {
+  private checkoutFailedEvent(
+    providerEventId: string,
+    session: Stripe.Checkout.Session,
+    failureCode = 'async_payment_failed',
+  ): ProviderWebhookEvent {
     return {
       kind: 'top_up_failed',
       providerEventId,
       providerReference: session.id,
       topUpId: this.requiredMetadata(session, 'topUpId'),
       organizationId: this.requiredMetadata(session, 'organizationId'),
-      failureCode: 'async_payment_failed',
-      failureMessage: 'Stripe Checkout payment failed',
+      failureCode,
+      failureMessage:
+        failureCode === 'checkout_expired' ? 'Stripe Checkout session expired' : 'Stripe Checkout payment failed',
     }
+  }
+
+  private async refundEvent(providerEventId: string, refund: Stripe.Refund): Promise<ProviderWebhookEvent> {
+    const intent = await this.paymentIntentForAdjustment(refund.payment_intent, refund.charge)
+    return {
+      kind: 'top_up_adjusted',
+      providerEventId,
+      providerReference: refund.id,
+      topUpId: this.requiredMetadata(intent, 'topUpId'),
+      organizationId: this.requiredMetadata(intent, 'organizationId'),
+      amountCents: String(refund.amount),
+      currency: refund.currency,
+      adjustment: 'refund',
+      direction: refund.status === 'failed' || refund.status === 'canceled' ? 'restore' : 'debit',
+    }
+  }
+
+  private async disputeEvent(
+    providerEventId: string,
+    eventType: 'charge.dispute.created' | 'charge.dispute.funds_withdrawn' | 'charge.dispute.funds_reinstated',
+    dispute: Stripe.Dispute,
+  ): Promise<ProviderWebhookEvent> {
+    const intent = await this.paymentIntentForAdjustment(dispute.payment_intent, dispute.charge)
+    return {
+      kind: 'top_up_adjusted',
+      providerEventId,
+      providerReference: dispute.id,
+      topUpId: this.requiredMetadata(intent, 'topUpId'),
+      organizationId: this.requiredMetadata(intent, 'organizationId'),
+      amountCents: String(dispute.amount),
+      currency: dispute.currency,
+      adjustment: 'dispute',
+      direction: eventType === 'charge.dispute.funds_reinstated' ? 'restore' : 'debit',
+    }
+  }
+
+  private async paymentIntentForAdjustment(
+    paymentIntent: string | Stripe.PaymentIntent | null,
+    charge: string | Stripe.Charge | null,
+  ): Promise<Stripe.PaymentIntent> {
+    if (typeof paymentIntent === 'string') return this.stripe.paymentIntents.retrieve(paymentIntent)
+    if (paymentIntent) return paymentIntent
+
+    const resolvedCharge = typeof charge === 'string' ? await this.stripe.charges.retrieve(charge) : charge
+    if (typeof resolvedCharge?.payment_intent === 'string') {
+      return this.stripe.paymentIntents.retrieve(resolvedCharge.payment_intent)
+    }
+    if (resolvedCharge?.payment_intent) return resolvedCharge.payment_intent
+    throw new Error('Stripe adjustment has no PaymentIntent')
   }
 
   private paymentIntentPaidEvent(providerEventId: string, intent: Stripe.PaymentIntent): ProviderWebhookEvent {

--- a/apps/api/src/config/configuration.ts
+++ b/apps/api/src/config/configuration.ts
@@ -175,6 +175,7 @@ const configuration = {
     stripe: {
       secretKey: process.env.STRIPE_SECRET_KEY,
       webhookSecret: process.env.STRIPE_WEBHOOK_SECRET,
+      previousWebhookSecret: process.env.STRIPE_WEBHOOK_SECRET_PREVIOUS,
     },
   },
   analyticsApiUrl: process.env.ANALYTICS_API_URL,

--- a/apps/api/src/migrations/pre-deploy/1782700400000-migration.spec.ts
+++ b/apps/api/src/migrations/pre-deploy/1782700400000-migration.spec.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import type { QueryRunner } from 'typeorm'
+import { Migration1782700400000 } from './1782700400000-migration'
+
+class RecordingQueryRunner {
+  readonly queries: string[] = []
+
+  async query(sql: string): Promise<void> {
+    this.queries.push(sql.replace(/\s+/g, ' ').trim())
+  }
+}
+
+describe('Migration1782700400000', () => {
+  it('adds durable payment recovery and immutable provider adjustments without a new table', async () => {
+    const runner = new RecordingQueryRunner()
+
+    await new Migration1782700400000().up(runner as unknown as QueryRunner)
+
+    const sql = runner.queries.join('\n')
+    expect(sql).toContain('ALTER TABLE "wallet" ADD "paymentSetupAttemptId"')
+    expect(sql).toContain('ALTER TABLE "wallet" ADD "paymentSetupNextReconcileAt"')
+    expect(sql).toContain('ALTER TABLE "top_up_record" ADD "reconcileAttempts" integer NOT NULL DEFAULT 0')
+    expect(sql).toContain('ALTER TABLE "top_up_record" ADD "refundedCents" bigint NOT NULL DEFAULT 0')
+    expect(sql).toContain('ALTER TABLE "top_up_record" ADD "disputedCents" bigint NOT NULL DEFAULT 0')
+    expect(sql).toContain(
+      'ALTER TABLE "payment_provider_event" ADD "status" character varying NOT NULL DEFAULT \'processed\'',
+    )
+    expect(sql).toContain('ALTER TABLE "payment_provider_event" ADD "payload" jsonb')
+    expect(sql).toContain('ALTER TABLE "wallet_transaction" ADD "providerActionId" character varying')
+    expect(sql).toContain('CREATE INDEX "top_up_record_reconcile_due_idx"')
+    expect(sql).toContain('CREATE INDEX "payment_provider_event_retry_due_idx"')
+    expect(sql).toContain('CREATE UNIQUE INDEX "wallet_transaction_provider_action_idx"')
+    expect(sql).not.toContain('CREATE TABLE')
+  })
+
+  it('drops recovery indexes before their columns', async () => {
+    const runner = new RecordingQueryRunner()
+
+    await new Migration1782700400000().down(runner as unknown as QueryRunner)
+
+    expect(runner.queries.slice(0, 4)).toEqual([
+      'DROP INDEX "wallet_transaction_provider_action_idx"',
+      'DROP INDEX "payment_provider_event_retry_due_idx"',
+      'DROP INDEX "wallet_payment_setup_reconcile_due_idx"',
+      'DROP INDEX "top_up_record_reconcile_due_idx"',
+    ])
+    expect(runner.queries.at(-1)).toBe('ALTER TABLE "wallet" DROP COLUMN "paymentSetupAttemptId"')
+  })
+})

--- a/apps/api/src/migrations/pre-deploy/1782700400000-migration.ts
+++ b/apps/api/src/migrations/pre-deploy/1782700400000-migration.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class Migration1782700400000 implements MigrationInterface {
+  name = 'Migration1782700400000'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "wallet" ADD "paymentSetupAttemptId" character varying`)
+    await queryRunner.query(`ALTER TABLE "wallet" ADD "paymentSetupProviderReference" character varying`)
+    await queryRunner.query(`ALTER TABLE "wallet" ADD "paymentSetupNextReconcileAt" TIMESTAMP WITH TIME ZONE`)
+    await queryRunner.query(`ALTER TABLE "wallet" ADD "paymentSetupReconcileAttempts" integer NOT NULL DEFAULT 0`)
+    await queryRunner.query(`ALTER TABLE "wallet" ADD "paymentSetupLastError" text`)
+
+    await queryRunner.query(`ALTER TABLE "top_up_record" ADD "reconcileAttempts" integer NOT NULL DEFAULT 0`)
+    await queryRunner.query(`ALTER TABLE "top_up_record" ADD "nextReconcileAt" TIMESTAMP WITH TIME ZONE`)
+    await queryRunner.query(`ALTER TABLE "top_up_record" ADD "lastReconciledAt" TIMESTAMP WITH TIME ZONE`)
+    await queryRunner.query(`ALTER TABLE "top_up_record" ADD "reconcileLastError" text`)
+    await queryRunner.query(`ALTER TABLE "top_up_record" ADD "refundedCents" bigint NOT NULL DEFAULT 0`)
+    await queryRunner.query(`ALTER TABLE "top_up_record" ADD "disputedCents" bigint NOT NULL DEFAULT 0`)
+    await queryRunner.query(
+      `ALTER TABLE "top_up_record" ADD CONSTRAINT "top_up_record_reversal_non_negative"
+       CHECK ("refundedCents" >= 0 AND "disputedCents" >= 0)`,
+    )
+
+    await queryRunner.query(`ALTER TABLE "payment_provider_event" ADD "providerReference" character varying`)
+    await queryRunner.query(
+      `ALTER TABLE "payment_provider_event" ADD "status" character varying NOT NULL DEFAULT 'processed'`,
+    )
+    await queryRunner.query(`ALTER TABLE "payment_provider_event" ADD "payload" jsonb`)
+    await queryRunner.query(`ALTER TABLE "payment_provider_event" ADD "attempts" integer NOT NULL DEFAULT 1`)
+    await queryRunner.query(`ALTER TABLE "payment_provider_event" ADD "nextAttemptAt" TIMESTAMP WITH TIME ZONE`)
+    await queryRunner.query(`ALTER TABLE "payment_provider_event" ADD "lastError" text`)
+    await queryRunner.query(
+      `ALTER TABLE "payment_provider_event" ADD "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()`,
+    )
+
+    await queryRunner.query(`ALTER TABLE "wallet_transaction" ADD "providerActionId" character varying`)
+
+    await queryRunner.query(`UPDATE "top_up_record" SET "nextReconcileAt" = "updatedAt" WHERE "status" = 'pending'`)
+
+    await queryRunner.query(
+      `CREATE INDEX "top_up_record_reconcile_due_idx"
+       ON "top_up_record" ("nextReconcileAt")
+       WHERE "status" = 'pending' AND "nextReconcileAt" IS NOT NULL`,
+    )
+    await queryRunner.query(
+      `CREATE INDEX "wallet_payment_setup_reconcile_due_idx"
+       ON "wallet" ("paymentSetupNextReconcileAt")
+       WHERE "paymentSetupAttemptId" IS NOT NULL AND "paymentSetupNextReconcileAt" IS NOT NULL`,
+    )
+    await queryRunner.query(
+      `CREATE INDEX "payment_provider_event_retry_due_idx"
+       ON "payment_provider_event" ("nextAttemptAt")
+       WHERE "status" = 'failed' AND "nextAttemptAt" IS NOT NULL`,
+    )
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "wallet_transaction_provider_action_idx"
+       ON "wallet_transaction" ("providerActionId") WHERE "providerActionId" IS NOT NULL`,
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "wallet_transaction_provider_action_idx"`)
+    await queryRunner.query(`DROP INDEX "payment_provider_event_retry_due_idx"`)
+    await queryRunner.query(`DROP INDEX "wallet_payment_setup_reconcile_due_idx"`)
+    await queryRunner.query(`DROP INDEX "top_up_record_reconcile_due_idx"`)
+
+    await queryRunner.query(`ALTER TABLE "wallet_transaction" DROP COLUMN "providerActionId"`)
+
+    await queryRunner.query(`ALTER TABLE "payment_provider_event" DROP COLUMN "updatedAt"`)
+    await queryRunner.query(`ALTER TABLE "payment_provider_event" DROP COLUMN "lastError"`)
+    await queryRunner.query(`ALTER TABLE "payment_provider_event" DROP COLUMN "nextAttemptAt"`)
+    await queryRunner.query(`ALTER TABLE "payment_provider_event" DROP COLUMN "attempts"`)
+    await queryRunner.query(`ALTER TABLE "payment_provider_event" DROP COLUMN "payload"`)
+    await queryRunner.query(`ALTER TABLE "payment_provider_event" DROP COLUMN "status"`)
+    await queryRunner.query(`ALTER TABLE "payment_provider_event" DROP COLUMN "providerReference"`)
+
+    await queryRunner.query(`ALTER TABLE "top_up_record" DROP CONSTRAINT "top_up_record_reversal_non_negative"`)
+    await queryRunner.query(`ALTER TABLE "top_up_record" DROP COLUMN "disputedCents"`)
+    await queryRunner.query(`ALTER TABLE "top_up_record" DROP COLUMN "refundedCents"`)
+    await queryRunner.query(`ALTER TABLE "top_up_record" DROP COLUMN "reconcileLastError"`)
+    await queryRunner.query(`ALTER TABLE "top_up_record" DROP COLUMN "lastReconciledAt"`)
+    await queryRunner.query(`ALTER TABLE "top_up_record" DROP COLUMN "nextReconcileAt"`)
+    await queryRunner.query(`ALTER TABLE "top_up_record" DROP COLUMN "reconcileAttempts"`)
+
+    await queryRunner.query(`ALTER TABLE "wallet" DROP COLUMN "paymentSetupLastError"`)
+    await queryRunner.query(`ALTER TABLE "wallet" DROP COLUMN "paymentSetupReconcileAttempts"`)
+    await queryRunner.query(`ALTER TABLE "wallet" DROP COLUMN "paymentSetupNextReconcileAt"`)
+    await queryRunner.query(`ALTER TABLE "wallet" DROP COLUMN "paymentSetupProviderReference"`)
+    await queryRunner.query(`ALTER TABLE "wallet" DROP COLUMN "paymentSetupAttemptId"`)
+  }
+}

--- a/apps/infra/BILLING_PAYMENT_RUNBOOK.md
+++ b/apps/infra/BILLING_PAYMENT_RUNBOOK.md
@@ -1,0 +1,131 @@
+# Billing Payment Runbook
+
+This runbook covers Stripe payment recovery and Billing pipeline health. It does not cover
+zero-balance enforcement; PR7 remains suitable only for a monitored, allow-listed beta.
+
+## Recovery Model
+
+- Stripe webhooks are the low-latency path.
+- `billing-payment-recovery` runs every minute and claims only due rows from PostgreSQL.
+- Provider reads happen outside database transactions. Results are applied in row-locked,
+  idempotent transactions.
+- Setup and top-up retries reuse the original attempt, provider reference, and Stripe
+  idempotency key.
+- Failed webhook application is persisted in `payment_provider_event` and retried with
+  exponential backoff from 1 minute to 1 hour.
+- Refunds and disputes append immutable `adjustment` ledger entries. Historical transactions
+  are never edited.
+
+## Release Checklist
+
+1. Run pre-deploy migrations before deploying the API.
+2. Set stage-scoped SST secrets. Never place their values in Git or logs.
+3. Set `BILLING_PAYMENT_PROVIDER=stripe` explicitly for the target stage.
+4. Configure the Stripe endpoint at `/billing/webhooks/payment` with these events:
+   - `checkout.session.completed`
+   - `checkout.session.expired`
+   - `checkout.session.async_payment_failed`
+   - `payment_intent.succeeded`
+   - `payment_intent.payment_failed`
+   - `refund.created`
+   - `refund.updated`
+   - `refund.failed`
+   - `charge.dispute.created`
+   - `charge.dispute.funds_withdrawn`
+   - `charge.dispute.funds_reinstated`
+5. Deploy the API, then verify `GET /admin/billing/health` as an administrator.
+6. Run the Stripe Sandbox E2E and confirm one paid top-up maps to one wallet credit.
+
+Local verification:
+
+```bash
+cd apps
+yarn test:billing:ops
+yarn e2e:billing:stripe
+```
+
+Run the PostgreSQL edge suite against a dedicated test database. If the local API shares the
+512 MiB local PostgreSQL Box, stop the API before `test:billing:ops`; otherwise the API pool,
+scheduled jobs, and concurrent fault tests can exhaust the test database process budget.
+
+Fault exercises use the same browser flow:
+
+```bash
+# Pauses after card setup. Stop the listener, then press Enter to prove provider reconciliation.
+BILLING_STRIPE_E2E_EXPECT_RECONCILE=1 BILLING_STRIPE_E2E_TIMEOUT_MS=180000 yarn e2e:billing:stripe
+
+# Creates a real test-mode refund and requires one immutable -$5 wallet adjustment.
+BILLING_STRIPE_E2E_REFUND=1 BILLING_STRIPE_E2E_TIMEOUT_MS=120000 yarn e2e:billing:stripe
+```
+
+AWS identity check before stage work:
+
+```bash
+AWS_PROFILE=boxlite-sso aws sts get-caller-identity
+```
+
+## Health and Alerts
+
+`GET /admin/billing/health` returns counts, oldest age, and the oldest affected resource for:
+
+| Alert                     | Trigger                                      | First action                                             |
+| ------------------------- | -------------------------------------------- | -------------------------------------------------------- |
+| `stale_pending_payment`   | Pending top-up older than 15 minutes         | Reconcile the returned top-up ID                         |
+| `failed_payment_webhook`  | A normalized event failed to apply           | Inspect `lastError`, then run due recovery               |
+| `negative_wallet_balance` | Wallet total is below zero                   | Verify settlement and payment recovery before adjustment |
+| `rating_lag`              | Archived Usage is unrated for over 5 minutes | Check Rating cron and database health                    |
+| `settlement_lag`          | Rated Usage is unsettled for over 5 minutes  | Check Settlement cron and wallet lock failures           |
+
+Structured log prefixes:
+
+- `[billing_alert]`: health threshold crossed; includes the health snapshot and resource locators.
+- `[billing_payment]`: payment apply or reconcile failure; includes stage, local ID, provider reference,
+  and the sanitized error.
+
+## Manual Recovery
+
+All recovery endpoints require the existing admin role and emit an audit record.
+
+```text
+POST /admin/billing/reconcile
+POST /admin/billing/reconcile/top-up/:topUpId
+POST /admin/billing/reconcile/setup/:organizationId
+```
+
+Use the narrow top-up or setup endpoint first. The broad endpoint processes only currently due
+rows and is safe to repeat. Do not create a replacement top-up for an ambiguous Stripe response;
+reconcile the existing row so the stable idempotency key remains effective.
+
+For a missed Stripe delivery, inspect the event in Stripe, resend it to the endpoint, and then run
+Billing recovery. Repeated and out-of-order events are deduplicated by provider event and provider
+action IDs.
+
+## Webhook Secret Rotation
+
+The API accepts one current and one previous signing secret during a controlled overlap.
+
+1. Set `STRIPE_WEBHOOK_SECRET_PREVIOUS` to the currently deployed secret.
+2. Roll the endpoint secret in Stripe with a grace period.
+3. Set `STRIPE_WEBHOOK_SECRET` to the new secret and deploy.
+4. Confirm new deliveries succeed and signature failures remain at zero.
+5. After the Stripe grace period has expired, clear `STRIPE_WEBHOOK_SECRET_PREVIOUS` and deploy again.
+
+Keep `STRIPE_SECRET_KEY` rotation separate from webhook signing-secret rotation so failures have a
+single cause.
+
+## Rollback
+
+- Roll back the API image first. The PR7 migration is additive, so the previous API can ignore the
+  new columns.
+- Do not drop recovery columns or indexes during an incident.
+- Keep Stripe webhooks enabled; Stripe retries failed live deliveries for a bounded period.
+- If provider calls are unhealthy, leave rows pending. Never mark a payment paid from operator
+  judgment alone.
+- After recovery, deploy the fixed image and run `POST /admin/billing/reconcile`.
+
+## Incident Acceptance Boundary
+
+A Stripe outage can delay wallet credit but must not duplicate it. An API or database outage can
+delay webhook application, but the failed-event queue and provider reconciliation recover after
+service restoration. PR7 does not stop Box create/start or running resources at zero balance; use
+strict organization quotas and active monitoring until Enforcement is implemented.

--- a/apps/infra/README.md
+++ b/apps/infra/README.md
@@ -71,11 +71,12 @@ npm run secrets -- --stage dev                          # list what's set
 ```
 
 Billing with Stripe also requires stage-scoped `STRIPE_SECRET_KEY` and
-`STRIPE_WEBHOOK_SECRET`. Use a Stripe test key for non-production stages and
-register only the four events consumed by the API: `checkout.session.completed`,
-`checkout.session.async_payment_failed`, `payment_intent.succeeded`, and
-`payment_intent.payment_failed`. Set `BILLING_PAYMENT_PROVIDER=stripe` in the
-deploy environment; the API fails closed when either secret is absent.
+`STRIPE_WEBHOOK_SECRET`. `STRIPE_WEBHOOK_SECRET_PREVIOUS` is optional and is used
+only during a controlled signing-secret rotation. Use a Stripe test key for
+non-production stages and register only the events listed in
+[BILLING_PAYMENT_RUNBOOK.md](./BILLING_PAYMENT_RUNBOOK.md). Set
+`BILLING_PAYMENT_PROVIDER=stripe` in the deploy environment; the API fails closed
+when either required secret is absent.
 
 Secret names match the env keys the services expect. Unset optional secrets
 resolve to empty (feature off); `OIDC_CLIENT_ID` defaults to `boxlite`. A changed

--- a/apps/infra/sst-billing-config.test.mjs
+++ b/apps/infra/sst-billing-config.test.mjs
@@ -7,9 +7,11 @@ const source = await readFile(new URL('./sst.config.ts', import.meta.url), 'utf8
 test('stores Stripe credentials in stage-scoped SST secrets', () => {
   assert.match(source, /const stripeSecretKey = new sst\.Secret\('STRIPE_SECRET_KEY', ''\)/)
   assert.match(source, /const stripeWebhookSecret = new sst\.Secret\('STRIPE_WEBHOOK_SECRET', ''\)/)
+  assert.match(source, /const stripePreviousWebhookSecret = new sst\.Secret\('STRIPE_WEBHOOK_SECRET_PREVIOUS', ''\)/)
 })
 
 test('injects Stripe credentials into the API service from SST secret values', () => {
   assert.match(source, /STRIPE_SECRET_KEY: stripeSecretKey\.value/)
   assert.match(source, /STRIPE_WEBHOOK_SECRET: stripeWebhookSecret\.value/)
+  assert.match(source, /STRIPE_WEBHOOK_SECRET_PREVIOUS: stripePreviousWebhookSecret\.value/)
 })

--- a/apps/infra/sst.config.ts
+++ b/apps/infra/sst.config.ts
@@ -174,6 +174,7 @@ export default $config({
     const sshHostKey = new sst.Secret('SSH_HOST_KEY_B64', '')
     const stripeSecretKey = new sst.Secret('STRIPE_SECRET_KEY', '')
     const stripeWebhookSecret = new sst.Secret('STRIPE_WEBHOOK_SECRET', '')
+    const stripePreviousWebhookSecret = new sst.Secret('STRIPE_WEBHOOK_SECRET_PREVIOUS', '')
 
     // ─── 2. PLATFORM ─────────────────────────────────────────────────────────
     // Network model + rationale (subnets / NAT / egress-only public IP, AWS citations): ./NETWORKING.md
@@ -465,6 +466,7 @@ export default $config({
           : envOr('BILLING_PAYMENT_PROVIDER', 'fake'),
         STRIPE_SECRET_KEY: stripeSecretKey.value,
         STRIPE_WEBHOOK_SECRET: stripeWebhookSecret.value,
+        STRIPE_WEBHOOK_SECRET_PREVIOUS: stripePreviousWebhookSecret.value,
         // Box base images: only the three digest-pinned *_IMAGE refs below are live — the
         // API gates box creation to that curated set (apps/api curated-images.constant.ts)
         // and the runner pulls them straight from ghcr.io with its GHCR_TOKEN. IMAGE_TAG and

--- a/apps/package.json
+++ b/apps/package.json
@@ -29,6 +29,7 @@
     "test:billing:wallet": "node scripts/billing-test-suite.mjs wallet",
     "test:billing:payment": "node scripts/billing-test-suite.mjs payment",
     "test:billing:stripe": "node --test scripts/billing-stripe-sandbox-config.test.mjs infra/sst-billing-config.test.mjs",
+    "test:billing:ops": "node scripts/billing-test-suite.mjs ops",
     "test:billing:read": "node scripts/billing-test-suite.mjs read",
     "test:billing:ui": "node scripts/billing-test-suite.mjs ui",
     "test:billing:db": "node scripts/billing-test-suite.mjs db",

--- a/apps/scripts/billing-stripe-sandbox-config.mjs
+++ b/apps/scripts/billing-stripe-sandbox-config.mjs
@@ -1,8 +1,15 @@
 export const STRIPE_BILLING_EVENTS = [
   'checkout.session.completed',
+  'checkout.session.expired',
   'checkout.session.async_payment_failed',
   'payment_intent.succeeded',
   'payment_intent.payment_failed',
+  'refund.created',
+  'refund.updated',
+  'refund.failed',
+  'charge.dispute.created',
+  'charge.dispute.funds_withdrawn',
+  'charge.dispute.funds_reinstated',
 ]
 
 export function assertStripeSandboxSecrets(secretKey, webhookSecret) {
@@ -76,5 +83,29 @@ export function assertStripeE2EEvidence(evidence) {
   }
   if (BigInt(evidence.paidBalanceAfterCents) - BigInt(evidence.paidBalanceBeforeCents) !== 500n) {
     throw new Error('Stripe E2E paid balance must increase by 500 cents')
+  }
+}
+
+export function assertStripeReconcileEvidence(evidence) {
+  const expectedEventId = `reconcile:${evidence.topUp.providerReference}:paid`
+  const recovered = evidence.providerEvents.filter(
+    (event) =>
+      event.eventType === 'top_up_paid' &&
+      event.providerReference === evidence.topUp.providerReference &&
+      event.providerEventId === expectedEventId,
+  )
+  if (recovered.length !== 1) {
+    throw new Error('Stripe E2E requires exactly one reconciliation event for the lost webhook')
+  }
+}
+
+export function assertStripeRefundEvidence(evidence) {
+  if (
+    evidence.matchingLedgerRows !== 1 ||
+    evidence.amountCents !== '-500' ||
+    evidence.refundedCents !== '500' ||
+    BigInt(evidence.paidBalanceAfterCents) !== BigInt(evidence.paidBalanceBeforeCents) - 500n
+  ) {
+    throw new Error('Stripe E2E requires exactly one immutable $5 refund debit')
   }
 }

--- a/apps/scripts/billing-stripe-sandbox-config.test.mjs
+++ b/apps/scripts/billing-stripe-sandbox-config.test.mjs
@@ -5,6 +5,8 @@ import {
   assertLocalStripeDatabase,
   assertMatchingStripeAccounts,
   assertMatchingWebhookSecrets,
+  assertStripeReconcileEvidence,
+  assertStripeRefundEvidence,
   assertStripeE2EEvidence,
   assertStripeSandboxSecrets,
   redactStripeSecrets,
@@ -22,7 +24,7 @@ test('listens only for payment events consumed by the API', () => {
     'listen',
     '--skip-update',
     '--events',
-    'checkout.session.completed,checkout.session.async_payment_failed,payment_intent.succeeded,payment_intent.payment_failed',
+    'checkout.session.completed,checkout.session.expired,checkout.session.async_payment_failed,payment_intent.succeeded,payment_intent.payment_failed,refund.created,refund.updated,refund.failed,charge.dispute.created,charge.dispute.funds_withdrawn,charge.dispute.funds_reinstated',
     '--forward-to',
     'http://localhost:3001/api/billing/webhooks/payment',
   ])
@@ -78,4 +80,50 @@ test('requires the API key and Stripe CLI to use the same account', () => {
 test('requires the API and listener to use the same webhook secret', () => {
   assert.doesNotThrow(() => assertMatchingWebhookSecrets('whsec_same', 'whsec_same'))
   assert.throws(() => assertMatchingWebhookSecrets('whsec_api', 'whsec_cli'), /same webhook signing secret/)
+})
+
+test('requires a lost webhook to be recovered from the Stripe source of truth', () => {
+  assert.doesNotThrow(() =>
+    assertStripeReconcileEvidence({
+      topUp: { id: 'top-up-1', providerReference: 'cs_recovered' },
+      providerEvents: [
+        {
+          providerEventId: 'reconcile:cs_recovered:paid',
+          eventType: 'top_up_paid',
+          providerReference: 'cs_recovered',
+        },
+      ],
+    }),
+  )
+  assert.throws(
+    () =>
+      assertStripeReconcileEvidence({
+        topUp: { id: 'top-up-1', providerReference: 'cs_webhook' },
+        providerEvents: [{ providerEventId: 'evt_webhook', eventType: 'top_up_paid', providerReference: 'cs_webhook' }],
+      }),
+    /reconciliation event/,
+  )
+})
+
+test('requires one immutable debit for a Stripe refund', () => {
+  assert.doesNotThrow(() =>
+    assertStripeRefundEvidence({
+      paidBalanceBeforeCents: '8502',
+      paidBalanceAfterCents: '8002',
+      amountCents: '-500',
+      refundedCents: '500',
+      matchingLedgerRows: 1,
+    }),
+  )
+  assert.throws(
+    () =>
+      assertStripeRefundEvidence({
+        paidBalanceBeforeCents: '8502',
+        paidBalanceAfterCents: '7502',
+        amountCents: '-500',
+        refundedCents: '500',
+        matchingLedgerRows: 2,
+      }),
+    /exactly one immutable/,
+  )
 })

--- a/apps/scripts/billing-stripe-sandbox-e2e.mjs
+++ b/apps/scripts/billing-stripe-sandbox-e2e.mjs
@@ -1,20 +1,31 @@
 #!/usr/bin/env node
 
 import fs from 'node:fs/promises'
+import { execFile } from 'node:child_process'
 import path from 'node:path'
 import process from 'node:process'
+import { createInterface } from 'node:readline/promises'
+import { promisify } from 'node:util'
 import { fileURLToPath } from 'node:url'
 import pg from 'pg'
 import { chromium } from 'playwright-core'
-import { assertLocalStripeDatabase, assertStripeE2EEvidence } from './billing-stripe-sandbox-config.mjs'
+import {
+  assertLocalStripeDatabase,
+  assertStripeE2EEvidence,
+  assertStripeReconcileEvidence,
+  assertStripeRefundEvidence,
+} from './billing-stripe-sandbox-config.mjs'
 
 const { Client } = pg
+const execFileAsync = promisify(execFile)
 const scriptsRoot = path.dirname(fileURLToPath(import.meta.url))
 const repoRoot = path.resolve(scriptsRoot, '..', '..')
 const dashboardUrl = stripTrailingSlash(process.env.BOXLITE_E2E_BASE_URL || 'http://localhost:3000')
 const loginEmail = process.env.BOXLITE_E2E_LOGIN_EMAIL || 'admin@boxlite.dev'
 const loginPassword = process.env.BOXLITE_E2E_LOGIN_PASSWORD || 'password'
 const timeoutMs = Number(process.env.BILLING_STRIPE_E2E_TIMEOUT_MS || 60_000)
+const expectReconcile = process.env.BILLING_STRIPE_E2E_EXPECT_RECONCILE === '1'
+const exerciseRefund = process.env.BILLING_STRIPE_E2E_REFUND === '1'
 const chromeExecutablePath =
   process.env.CHROME_EXECUTABLE_PATH || '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
 const database = {
@@ -94,6 +105,7 @@ try {
     return wallet.paymentProviderCustomerId?.startsWith('cus_') && wallet.paymentProviderMethodId?.startsWith('pm_')
   }, 'Stripe setup webhook')
   await page.screenshot({ path: path.join(artifactsDir, 'stripe-setup-complete.png'), fullPage: true })
+  if (expectReconcile) await pauseAfterSetup()
 
   await page.getByRole('button', { name: 'Add funds', exact: true }).click()
   await page.getByRole('textbox', { name: 'Custom top-up amount', exact: true }).fill('5.00')
@@ -103,10 +115,19 @@ try {
   await page.getByRole('button', { name: 'Pay', exact: true }).click()
   await page.waitForURL(`${dashboardUrl}/dashboard/billing?payment=success`)
 
+  if (expectReconcile) {
+    const pendingTopUp = await waitFor(() => loadLatestTopUp(organizationId), 'pending Stripe top-up')
+    if (pendingTopUp.status !== 'pending') {
+      throw new Error('Lost-webhook exercise expected the top-up to remain pending before reconciliation')
+    }
+    await db.query(`UPDATE top_up_record SET "nextReconcileAt" = clock_timestamp() WHERE id = $1`, [pendingTopUp.id])
+  }
+
   const topUp = await waitFor(() => loadPaidTopUp(organizationId), 'paid Stripe top-up')
   const walletAfter = await loadWallet(organizationId)
   const ledgerTopUpIds = await loadLedgerTopUpIds(topUp.id)
-  const providerEventTypes = await loadProviderEventTypes()
+  const providerEvents = await loadProviderEvents()
+  const providerEventTypes = providerEvents.map((event) => event.eventType)
   const evidence = {
     paidBalanceBeforeCents: walletBefore.paidBalanceCents,
     paidBalanceAfterCents: walletAfter.paidBalanceCents,
@@ -116,11 +137,18 @@ try {
     providerEventTypes,
   }
   assertStripeE2EEvidence(evidence)
+  if (expectReconcile) assertStripeReconcileEvidence({ topUp, providerEvents })
   assertNoLocalHttpErrors()
 
   await page.getByRole('tab', { name: 'Billing', exact: true }).click()
   await page.getByRole('heading', { name: '▸ Receipts', exact: true }).waitFor()
   await page.screenshot({ path: path.join(artifactsDir, 'stripe-top-up-complete.png'), fullPage: true })
+  const refund = exerciseRefund ? await refundTopUp(topUp, walletAfter.paidBalanceCents) : null
+  if (refund) {
+    await page.reload({ waitUntil: 'domcontentloaded' })
+    await page.getByRole('heading', { name: 'Billing', exact: true }).waitFor()
+    await page.screenshot({ path: path.join(artifactsDir, 'stripe-refund-complete.png'), fullPage: true })
+  }
   console.log(
     JSON.stringify(
       {
@@ -132,6 +160,8 @@ try {
         providerReferenceType: topUp.providerReference.slice(0, 3),
         ledgerCredits: ledgerTopUpIds.length,
         providerEventTypes,
+        recoveredWithoutWebhook: expectReconcile,
+        refund,
         artifactsDir,
       },
       null,
@@ -218,6 +248,11 @@ async function resetLocalPaymentProvider(targetOrganizationId) {
 }
 
 async function loadPaidTopUp(targetOrganizationId) {
+  const topUp = await loadLatestTopUp(targetOrganizationId)
+  return topUp?.status === 'paid' ? topUp : null
+}
+
+async function loadLatestTopUp(targetOrganizationId) {
   const result = await db.query(
     `SELECT id, status, "amountCents", "providerReference", "receiptUrl"
        FROM top_up_record
@@ -225,8 +260,7 @@ async function loadPaidTopUp(targetOrganizationId) {
       ORDER BY "createdAt" DESC LIMIT 1`,
     [targetOrganizationId, runStartedAt],
   )
-  const topUp = result.rows[0]
-  return topUp?.status === 'paid' ? topUp : null
+  return result.rows[0] ?? null
 }
 
 async function loadLedgerTopUpIds(topUpId) {
@@ -239,12 +273,65 @@ async function loadLedgerTopUpIds(topUpId) {
   return result.rows.map((row) => row.topUpId)
 }
 
-async function loadProviderEventTypes() {
+async function loadProviderEvents() {
   const result = await db.query(
-    `SELECT "eventType" FROM payment_provider_event WHERE "createdAt" >= $1 ORDER BY "createdAt"`,
+    `SELECT "providerEventId", "eventType", "providerReference"
+       FROM payment_provider_event WHERE "createdAt" >= $1 ORDER BY "createdAt"`,
     [runStartedAt],
   )
-  return result.rows.map((row) => row.eventType)
+  return result.rows
+}
+
+async function pauseAfterSetup() {
+  const prompt = createInterface({ input: process.stdin, output: process.stdout })
+  try {
+    await prompt.question('[billing-stripe-e2e] Setup complete. Stop the Stripe listener, then press Enter.\n')
+  } finally {
+    prompt.close()
+  }
+}
+
+async function refundTopUp(topUp, paidBalanceBeforeCents) {
+  const { stdout: sessionOutput } = await execFileAsync(
+    'stripe',
+    ['get', `/v1/checkout/sessions/${topUp.providerReference}`, '--color', 'off'],
+    { maxBuffer: 1024 * 1024 },
+  )
+  const session = JSON.parse(sessionOutput)
+  if (typeof session.payment_intent !== 'string') {
+    throw new Error(`Stripe Checkout session ${topUp.providerReference} has no PaymentIntent`)
+  }
+  const { stdout: refundOutput } = await execFileAsync(
+    'stripe',
+    ['post', '/v1/refunds', '-d', `payment_intent=${session.payment_intent}`, '-d', 'amount=500', '--color', 'off'],
+    { maxBuffer: 1024 * 1024 },
+  )
+  const providerRefund = JSON.parse(refundOutput)
+  const evidence = await waitFor(() => loadRefundEvidence(topUp.id, providerRefund.id), 'Stripe refund adjustment')
+  assertStripeRefundEvidence({ paidBalanceBeforeCents, ...evidence })
+  return {
+    providerReferenceType: providerRefund.id.slice(0, 3),
+    matchingLedgerRows: evidence.matchingLedgerRows,
+    ledgerAmountCents: evidence.amountCents,
+    paidBalanceBeforeCents,
+    paidBalanceAfterCents: evidence.paidBalanceAfterCents,
+    refundedCents: evidence.refundedCents,
+  }
+}
+
+async function loadRefundEvidence(topUpId, refundId) {
+  const result = await db.query(
+    `SELECT wt."amountCents",
+            w."paidBalanceCents" AS "paidBalanceAfterCents",
+            tur."refundedCents",
+            COUNT(*) OVER ()::int AS "matchingLedgerRows"
+       FROM wallet_transaction wt
+       JOIN wallet w ON w.id = wt."walletId"
+       JOIN top_up_record tur ON tur.id::text = wt.metadata->>'topUpId'
+      WHERE wt.metadata->>'topUpId' = $1 AND wt."providerActionId" = $2`,
+    [topUpId, `refund:${refundId}:debit`],
+  )
+  return result.rowCount === 1 ? result.rows[0] : null
 }
 
 async function waitFor(check, label) {

--- a/apps/scripts/billing-test-suite.mjs
+++ b/apps/scripts/billing-test-suite.mjs
@@ -10,6 +10,8 @@ const appsRoot = path.resolve(scriptsRoot, '..')
 const yarn = process.platform === 'win32' ? 'yarn.cmd' : 'yarn'
 
 const apiSpecs = [
+  'api/src/admin/controllers/billing.controller.spec.ts',
+  'api/src/billing/billing-ops.service.spec.ts',
   'api/src/usage/usage.service.spec.ts',
   'api/src/billing/billing-read.service.spec.ts',
   'api/src/billing/billing.controller.spec.ts',
@@ -20,6 +22,7 @@ const apiSpecs = [
   'api/src/billing/rating/rating.service.spec.ts',
   'api/src/billing/settlement.service.spec.ts',
   'api/src/billing/wallet.service.spec.ts',
+  'api/src/migrations/pre-deploy/1782700400000-migration.spec.ts',
 ]
 
 const prerequisiteSpecs = ['api/src/organization/services/organization.service.regions.spec.ts']
@@ -54,6 +57,13 @@ const stages = {
     'api/src/billing/payment/payment.controller.spec.ts',
     'api/src/billing/payment/payment.service.spec.ts',
   ]),
+  ops: jest('Payment recovery and operations', [
+    'api/src/admin/controllers/billing.controller.spec.ts',
+    'api/src/billing/billing-ops.service.spec.ts',
+    'api/src/billing/payment/payment-provider.spec.ts',
+    'api/src/billing/payment/payment.service.spec.ts',
+    'api/src/migrations/pre-deploy/1782700400000-migration.spec.ts',
+  ]),
   stripe: {
     label: 'Stripe Sandbox configuration',
     args: ['test:billing:stripe'],
@@ -76,6 +86,10 @@ const stages = {
       'eslint',
       'api/src/usage',
       'api/src/billing',
+      'api/src/admin/controllers/billing.controller.ts',
+      'api/src/admin/controllers/billing.controller.spec.ts',
+      'api/src/migrations/pre-deploy/1782700400000-migration.ts',
+      'api/src/migrations/pre-deploy/1782700400000-migration.spec.ts',
       'dashboard/src/pages/Billing.tsx',
       'dashboard/src/components/billing',
       'dashboard/src/components/Box/CreateBoxDialog.tsx',
@@ -106,6 +120,10 @@ const suites = {
   wallet: { description: 'PR3 wallet and settlement', stages: [stages.wallet] },
   payment: { description: 'PR5 providers, webhooks, and top-ups', stages: [stages.payment, stages.stripe] },
   stripe: { description: 'PR6 Stripe Sandbox configuration', stages: [stages.stripe] },
+  ops: {
+    description: 'PR7 payment recovery, PostgreSQL edge cases, and operations',
+    stages: [stages.ops, stages.stripe, stages.db],
+  },
   read: { description: 'PR4 billing read API', stages: [stages.read] },
   ui: { description: 'PR4/PR5 dashboard behavior', stages: [stages.ui] },
   db: { description: 'Real PostgreSQL concurrency and recovery', stages: [stages.db] },


### PR DESCRIPTION
## Summary

Adds the recovery and operations layer for Stripe-backed Billing. Webhooks remain the real-time path; PostgreSQL-backed reconciliation recovers setup and top-up rows when a provider response or webhook is lost.

```text
Stripe webhook ────────────────┐
                               ▼
Pending setup/top-up ── due claim ── Stripe retrieve
                               │
                               ▼
                     row-locked idempotent apply
                               │
             ┌─────────────────┼──────────────────┐
             ▼                 ▼                  ▼
           Wallet       immutable ledger   provider event log
                                                    │
                                                    ▼
                                      retry queue + Admin health
```

## What changed

- Reconciles pending Setup and Top-up attempts every minute with exponential backoff.
- Reuses stable local attempts, provider references, and Stripe idempotency keys.
- Persists failed normalized webhook application and retries it from PostgreSQL.
- Handles refund and dispute debits/restores with immutable adjustment transactions.
- Adds current/previous webhook signing secrets for controlled rotation.
- Adds Billing health alerts and Admin-only audited health/recovery endpoints.
- Adds a pre-deploy migration with recovery fields and indexes; no new tables.
- Adds release, rollback, secret rotation, alert, and incident runbook.

## Recovery endpoints

- `GET /admin/billing/health`
- `POST /admin/billing/reconcile`
- `POST /admin/billing/reconcile/top-up/:topUpId`
- `POST /admin/billing/reconcile/setup/:organizationId`

## Verification

- `yarn test:billing:verify`
  - API and migration: 77 passed
  - Stripe configuration: 11 passed
  - PostgreSQL edge cases: 11 passed
  - Dashboard: 39 passed
  - scoped ESLint, API build, Dashboard build passed
- Real Stripe test-mode browser E2E:
  - normal Setup + $5 Checkout + webhook: one credit
  - listener stopped after Setup: pending payment recovered from Stripe with one `reconcile:` event and one credit
  - real $5 refund: two provider notifications, one immutable `-500` adjustment, final balance restored
- `AWS_PROFILE=boxlite-sso aws sts get-caller-identity` passed.

## Scope boundary

This enables a monitored allow-listed beta. It does not block Box create/start or stop running resources at zero balance; prepaid enforcement remains a separate change.
