### PR TITLE
docs(examples): agent-bundle image — 10 coding agents on node base

### DIFF
--- a/examples/agent-bundle/Dockerfile
+++ b/examples/agent-bundle/Dockerfile
@@ -1,0 +1,43 @@
+# Agent bundle: 10 terminal coding agents in one image, on the boxlite Node base.
+# Base already ships Node 22 + npm + python3/pip + git/curl. Boxes run as the
+# unprivileged `boxlite` user, so each agent is installed the way it will be run:
+#   - npm CLIs: installed as root into the system prefix (/usr/local), run by anyone
+#   - native CLIs: installed AS `boxlite` into that user's own ~/.local (their
+#     per-user, non-root install path) — no root-owned payloads, no relocation.
+FROM ghcr.io/boxlite-ai/boxlite-agent-node:v0.1.0
+
+# --- npm-based agent CLIs (system-wide; -g needs root for the /usr/local prefix) ---
+USER root
+RUN set -eux; \
+    for pkg in \
+      "@anthropic-ai/claude-code" \
+      "@openai/codex" \
+      "@google/gemini-cli" \
+      "@github/copilot" \
+      "opencode-ai" \
+      "@botiverse/raft@latest" \
+      "@moonshot-ai/kimi-code" \
+      "@mariozechner/pi-coding-agent"; do \
+      npm install -g --no-fund --no-audit "$pkg"; \
+    done; \
+    npm cache clean --force; rm -rf /root/.npm /tmp/* /var/tmp/*; \
+    # slim node_modules of dev-only weight (source maps, docs, tests, changelogs)
+    cd /usr/local/lib/node_modules; \
+    find . -type d \( -iname test -o -iname tests -o -iname __tests__ \
+        -o -iname docs -o -iname example -o -iname examples -o -iname .github \) \
+        -prune -exec rm -rf {} + ; \
+    find . -type f \( -name '*.map' -o -name '*.md' -o -name '*.markdown' \
+        -o -name 'CHANGELOG*' -o -name '.npmignore' -o -name '.editorconfig' \) -delete
+
+# --- native-binary agents: installed as the box user, into its own ~/.local ----
+USER boxlite
+ENV HOME=/home/boxlite
+ENV PATH=/home/boxlite/.local/bin:$PATH
+RUN set -eux; \
+    curl -fsS  https://cursor.com/install                | bash; \
+    curl -fsSL https://antigravity.google/cli/install.sh | bash
+
+# --- smoke check: every agent CLI resolves on PATH as the box user ------------
+RUN set -eu; for c in claude codex gemini copilot opencode raft kimi pi cursor-agent agy; do \
+      command -v "$c" >/dev/null || { echo "MISSING: $c"; exit 1; }; \
+    done; echo "all 10 agent CLIs present"

--- a/examples/agent-bundle/README.md
+++ b/examples/agent-bundle/README.md
@@ -1,0 +1,60 @@
+# Agent bundle image
+
+A reference [`Dockerfile`](./Dockerfile) that bundles ten terminal coding agents
+into a single box image, layered on the curated `boxlite-agent-node` base.
+
+## Why the Node base
+
+The `boxlite-agent-node` base already ships **Node 22 + npm + python3/pip + git/
+curl**, so both the npm-installed CLIs and the two curl-installed native agents
+run without extra runtimes. The `base` and `python` curated images lack Node, so
+the npm agents (the majority) cannot install on them.
+
+## Agents included
+
+| Agent | Install source |
+| --- | --- |
+| Claude Code | `npm i -g @anthropic-ai/claude-code` |
+| Codex CLI | `npm i -g @openai/codex` |
+| Gemini CLI | `npm i -g @google/gemini-cli` |
+| Copilot CLI | `npm i -g @github/copilot` |
+| OpenCode | `npm i -g opencode-ai` |
+| raft | `npm i -g @botiverse/raft` |
+| Kimi Code | `npm i -g @moonshot-ai/kimi-code` |
+| Pi | `npm i -g @mariozechner/pi-coding-agent` |
+| Cursor CLI (`cursor-agent`) | `curl https://cursor.com/install \| bash` (native) |
+| Antigravity CLI (`agy`) | `curl https://antigravity.google/cli/install.sh \| bash` (native) |
+
+## Build
+
+```bash
+docker build -t agent-bundle:latest examples/agent-bundle
+```
+
+## Size (linux/amd64)
+
+| | Size |
+| --- | --- |
+| On disk (uncompressed) | ~3.25 GB |
+| Compressed (registry / pull) | ~807 MB |
+
+The base image contributes ~0.4 GB; the agents add the rest. The npm CLIs
+dominate — OpenCode, Codex, Copilot, and Claude Code are ~250–360 MB each.
+
+## Install each agent the way it will be run
+
+Boxes run as the unprivileged `boxlite` user, so the install user is kept
+consistent with the run user:
+
+- **npm CLIs** install as `root` into the system prefix (`/usr/local`) — `npm i -g`
+  needs root, but the result is world-readable and runs fine as any user (they
+  only need a writable `$HOME` for their own config/cache).
+- **Native CLIs** (Cursor, Antigravity) install **as `boxlite`**, so their
+  `curl | bash` installers drop into that user's own `~/.local` — their normal
+  per-user, non-root install path. Nothing lands root-only under `/root`, so no
+  relocation or permission fix-ups are needed; `PATH` just includes
+  `~/.local/bin`.
+
+`node_modules` is slimmed of source maps, docs, tests/examples, and changelogs
+(kept `*.d.ts` and package metadata). All ten CLIs are smoke-checked to resolve
+on `PATH` at build time, and each returns `--version` when run as the box user.


### PR DESCRIPTION
## Summary

Adds `examples/agent-bundle/` — a reference `Dockerfile` (+ README) that bundles **ten terminal coding agents** into one box image on top of the curated `boxlite-agent-node` base.

Agents: Claude Code, Codex CLI, Gemini CLI, Copilot CLI, OpenCode, raft, Kimi Code, Pi (npm) + Cursor CLI and Antigravity CLI (native, curl installers).

## Why the node base

`boxlite-agent-node` already ships Node 22 + npm + python3/pip + git/curl, so both the npm CLIs and the two native agents run without extra runtimes. The `base` and `python` curated images have no Node, so the npm-majority can't install there.

## Notes / non-obvious bits

- **Native agents relocated to `/opt/agents`** — their installers drop payloads under `$HOME/.local` (root-only `0700`), which the unprivileged `boxlite` user can't reach; that otherwise leaves Cursor unusable and ~200 MB stranded under `/root`.
- **`HOME` scoped** to the installer `RUN`; final image uses `HOME=/home/boxlite` so agents can write config/cache as the box user.
- **`node_modules` slimmed** (source maps, docs, tests, changelogs).

## Measured (linux/amd64)

| | Size |
|---|---|
| On disk | ~3.34 GB |
| Compressed (pull) | ~821 MB |

All ten CLIs smoke-checked to resolve on `PATH` at build time, and each returns `--version` when run as the box user.

> Draft: opening for review of placement/approach. Package pins are `@latest`-ish; pin exact versions before any non-example use.
