### PR TITLE
fix(proxy): preserve preview activity updates

### DIFF
--- a/apps/proxy/pkg/proxy/get_box_target.go
+++ b/apps/proxy/pkg/proxy/get_box_target.go
@@ -22,6 +22,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const activityUpdateTimeout = 10 * time.Second
+
 func (p *Proxy) GetProxyTarget(ctx *gin.Context) (*url.URL, map[string]string, error) {
 	var targetPort, targetPath, boxIdOrSignedToken string
 
@@ -78,7 +80,8 @@ func (p *Proxy) GetProxyTarget(ctx *gin.Context) (*url.URL, map[string]string, e
 	// Skip last activity update if header is set
 	if ctx.Request.Header.Get(SKIP_LAST_ACTIVITY_UPDATE_HEADER) != "true" {
 		doneCh := make(chan struct{})
-		go p.updateLastActivity(ctx.Request.Context(), boxId, true, doneCh)
+		activityCtx := context.WithoutCancel(ctx.Request.Context())
+		go p.updateLastActivity(activityCtx, boxId, true, doneCh)
 		ctx.Request.Header.Del(SKIP_LAST_ACTIVITY_UPDATE_HEADER)
 		ctx.Set(ACTIVITY_POLL_STOP_KEY, func() {
 			close(doneCh)
@@ -292,8 +295,11 @@ func (p *Proxy) parseHost(host string) (targetPort string, boxIdOrSignedToken st
 // updateLastActivity updates the last activity timestamp for a box.
 // If shouldPollUpdate is true, it starts a goroutine that updates every 50 seconds.
 func (p *Proxy) updateLastActivity(ctx context.Context, boxId string, shouldPollUpdate bool, doneCh chan struct{}) {
+	updateCtx, cancel := context.WithTimeout(ctx, activityUpdateTimeout)
+	defer cancel()
+
 	// Prevent frequent updates by caching the last update
-	cached, err := p.boxLastActivityUpdateCache.Has(ctx, boxId)
+	cached, err := p.boxLastActivityUpdateCache.Has(updateCtx, boxId)
 	if err != nil {
 		// If cache doesn't work, skip the update to avoid spamming the API
 		log.Errorf("failed to check last activity update cache for box %s: %v", boxId, err)
@@ -304,7 +310,7 @@ func (p *Proxy) updateLastActivity(ctx context.Context, boxId string, shouldPoll
 	pollInterval := 50 * time.Second
 
 	if !cached {
-		_, err := p.apiclient.BoxAPI.UpdateLastActivity(ctx, boxId).Execute()
+		_, err := p.apiclient.BoxAPI.UpdateLastActivity(updateCtx, boxId).Execute()
 		if err != nil {
 			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 				return
@@ -314,7 +320,7 @@ func (p *Proxy) updateLastActivity(ctx context.Context, boxId string, shouldPoll
 		}
 
 		// Expire a bit before the poll interval to avoid skipping one interval
-		err = p.boxLastActivityUpdateCache.Set(ctx, boxId, true, pollInterval-5*time.Second)
+		err = p.boxLastActivityUpdateCache.Set(updateCtx, boxId, true, pollInterval-5*time.Second)
 		if err != nil {
 			log.Errorf("failed to set last activity update cache for box %s: %v", boxId, err)
 		}

--- a/apps/proxy/pkg/proxy/get_box_target_test.go
+++ b/apps/proxy/pkg/proxy/get_box_target_test.go
@@ -1,0 +1,135 @@
+// Copyright 2025 BoxLite AI (originally Daytona Platforms Inc.
+// Modified by BoxLite AI, 2025-2026
+// SPDX-License-Identifier: AGPL-3.0
+
+package proxy
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	apiclient "github.com/boxlite-ai/boxlite/libs/api-client-go"
+	common_cache "github.com/boxlite-ai/common-go/pkg/cache"
+	"github.com/gin-gonic/gin"
+)
+
+type blockingActivityCache struct {
+	entered  chan struct{}
+	release  chan struct{}
+	deadline chan time.Time
+	once     sync.Once
+}
+
+func (c *blockingActivityCache) Get(context.Context, string) (*bool, error) {
+	return nil, errors.New("key not found")
+}
+
+func (c *blockingActivityCache) Set(context.Context, string, bool, time.Duration) error {
+	return nil
+}
+
+func (c *blockingActivityCache) Delete(context.Context, string) error {
+	return nil
+}
+
+func (c *blockingActivityCache) Has(ctx context.Context, _ string) (bool, error) {
+	c.once.Do(func() {
+		deadline, _ := ctx.Deadline()
+		c.deadline <- deadline
+		close(c.entered)
+	})
+
+	select {
+	case <-c.release:
+		if err := ctx.Err(); err != nil {
+			return false, err
+		}
+		return false, nil
+	case <-ctx.Done():
+		return false, ctx.Err()
+	}
+}
+
+func TestGetProxyTargetUpdatesActivityAfterRequestCancellation(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	activityRequests := make(chan string, 1)
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		activityRequests <- r.URL.Path
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer apiServer.Close()
+
+	apiConfig := apiclient.NewConfiguration()
+	apiConfig.Servers = apiclient.ServerConfigurations{{URL: apiServer.URL}}
+
+	cacheCtx, cancelCaches := context.WithCancel(context.Background())
+	defer cancelCaches()
+
+	publicCache := common_cache.NewMapCache[bool](cacheCtx)
+	runnerCache := common_cache.NewMapCache[RunnerInfo](cacheCtx)
+	if err := publicCache.Set(cacheCtx, "box-1", true, time.Minute); err != nil {
+		t.Fatalf("set public cache: %v", err)
+	}
+	if err := runnerCache.Set(cacheCtx, "box-1", RunnerInfo{
+		ApiUrl: "http://runner.test",
+		ApiKey: "runner-key",
+	}, time.Minute); err != nil {
+		t.Fatalf("set runner cache: %v", err)
+	}
+
+	activityCache := &blockingActivityCache{
+		entered:  make(chan struct{}),
+		release:  make(chan struct{}),
+		deadline: make(chan time.Time, 1),
+	}
+	proxy := &Proxy{
+		apiclient:                  apiclient.NewAPIClient(apiConfig),
+		boxPublicCache:             publicCache,
+		boxRunnerCache:             runnerCache,
+		boxLastActivityUpdateCache: activityCache,
+	}
+
+	requestCtx, cancelRequest := context.WithCancel(context.Background())
+	request := httptest.NewRequest(http.MethodGet, "http://8000-box-1.proxy.test/", nil).WithContext(requestCtx)
+	request.Host = "8000-box-1.proxy.test"
+
+	ginCtx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	ginCtx.Request = request
+	ginCtx.Params = gin.Params{{Key: "path", Value: "/"}}
+
+	if _, _, err := proxy.GetProxyTarget(ginCtx); err != nil {
+		t.Fatalf("get proxy target: %v", err)
+	}
+	defer stopActivityPoll(ginCtx)
+
+	select {
+	case <-activityCache.entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("activity update did not start")
+	}
+	deadline := <-activityCache.deadline
+	remaining := time.Until(deadline)
+	if deadline.IsZero() || remaining <= 0 || remaining > activityUpdateTimeout {
+		t.Fatalf("unexpected activity update deadline: %v", deadline)
+	}
+
+	// Reproduce a short proxy response ending while its asynchronous activity
+	// update is still in flight.
+	cancelRequest()
+	close(activityCache.release)
+
+	select {
+	case path := <-activityRequests:
+		if path != "/box/box-1/last-activity" {
+			t.Fatalf("unexpected activity endpoint: %s", path)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("request cancellation prevented the activity update")
+	}
+}


### PR DESCRIPTION
Preserve preview activity updates after request completion while bounding each detached update attempt to 10 seconds.

Test plan:
- [x] `cd apps && go test ./proxy/pkg/proxy`
- [x] `cd apps && go test -race ./proxy/pkg/proxy`
- [x] `make lint:fix`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Last-activity updates now continue when a proxy request is canceled.
  * Updates are bounded by a timeout to prevent them from running indefinitely.
* **Tests**
  * Added coverage confirming activity updates are sent after request cancellation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->