### PR TITLE
fix(activity): keep long-lived connections active

### DIFF
--- a/apps/api/src/boxlite-rest/boxlite-ws-proxy.service.spec.ts
+++ b/apps/api/src/boxlite-rest/boxlite-ws-proxy.service.spec.ts
@@ -5,7 +5,9 @@
  */
 
 import { createProxyMiddleware } from 'http-proxy-middleware'
+import { EventEmitter } from 'events'
 import type { IncomingMessage } from 'http'
+import type { Socket } from 'net'
 import { BoxliteWsProxyService } from './boxlite-ws-proxy.service'
 
 jest.mock('http-proxy-middleware', () => ({
@@ -112,5 +114,52 @@ describe('BoxliteWsProxyService', () => {
 
     await expect(service.authenticate(authRequest(jwt), 'org-1')).resolves.toBeNull()
     expect(organizationUserService.findOne).toHaveBeenCalledWith('org-1', 'user-1')
+  })
+
+  it('keeps websocket boxes active until the client socket closes', async () => {
+    jest.useFakeTimers()
+
+    try {
+      const apiKeyService = {
+        getApiKeyByValue: jest.fn().mockResolvedValue({
+          organizationId: 'org-1',
+          userId: 'user-1',
+          expiresAt: null,
+        }),
+      }
+      const organizationUserService = {
+        findOne: jest.fn().mockResolvedValue({ organizationId: 'org-1', userId: 'user-1' }),
+      }
+      const boxService = {
+        findOneByIdOrName: jest.fn().mockResolvedValue({ id: 'box-uuid', runnerId: 'runner-1' }),
+        updateLastActivityAt: jest.fn().mockResolvedValue(undefined),
+      }
+      const runnerService = {
+        findOne: jest.fn().mockResolvedValue({ apiUrl: 'http://runner.test', apiKey: 'runner-key' }),
+      }
+      const service = new BoxliteWsProxyService(
+        apiKeyService as never,
+        organizationUserService as never,
+        boxService as never,
+        runnerService as never,
+        {} as never,
+      )
+      const socket = new EventEmitter() as unknown as Socket
+
+      await service.upgrade(authRequest('blk_live_test'), socket, Buffer.alloc(0))
+      await Promise.resolve()
+
+      expect(boxService.updateLastActivityAt).toHaveBeenCalledTimes(1)
+
+      await jest.advanceTimersByTimeAsync(45_000)
+      expect(boxService.updateLastActivityAt).toHaveBeenCalledTimes(2)
+
+      socket.emit('close')
+      await jest.advanceTimersByTimeAsync(45_000)
+      expect(boxService.updateLastActivityAt).toHaveBeenCalledTimes(2)
+    } finally {
+      jest.clearAllTimers()
+      jest.useRealTimers()
+    }
   })
 })

--- a/apps/api/src/boxlite-rest/boxlite-ws-proxy.service.ts
+++ b/apps/api/src/boxlite-rest/boxlite-ws-proxy.service.ts
@@ -24,6 +24,8 @@ type RunnerUpgradeRequest = IncomingMessage & {
 // Named groups: `tenant` (optional org id / path prefix) and `boxId`.
 const ATTACH_PATH = /^\/api\/v1\/(?:(?<tenant>[^/]+)\/)?boxes\/(?<boxId>[^/]+)\/executions\/[^/]+\/attach(?:\?.*)?$/
 
+const WS_ACTIVITY_KEEPALIVE_INTERVAL_MS = 45_000
+
 /**
  * Singleton WebSocket proxy for `/attach` upgrades.
  *
@@ -114,12 +116,6 @@ export class BoxliteWsProxyService {
         this.respondAndClose(socket, 404, 'Not Found')
         return
       }
-      // Mirror legacy toolbox path — opening a WS attach is user activity,
-      // so the autostop cron does not reap a session that's still connected.
-      // Best-effort: do not fail the upgrade if this errors.
-      this.boxService
-        .updateLastActivityAt(box.id, new Date())
-        .catch((err) => this.logger.warn(`updateLastActivityAt failed for ${box.id}: ${err}`))
       const runner = await this.runnerService.findOne(box.runnerId)
       if (!runner) {
         this.respondAndClose(socket, 404, 'Not Found')
@@ -127,15 +123,54 @@ export class BoxliteWsProxyService {
       }
       ;(req as RunnerUpgradeRequest).__boxliteRunner = runner
       ;(req as RunnerUpgradeRequest).__boxliteRunnerBoxId = box.id
-      ;(
-        this.proxy as unknown as {
-          upgrade: (req: IncomingMessage, socket: Socket, head: Buffer) => void
-        }
-      ).upgrade(req, socket, head)
+      const stopActivityKeepalive = this.startActivityKeepalive(box.id, socket)
+      try {
+        ;(
+          this.proxy as unknown as {
+            upgrade: (req: IncomingMessage, socket: Socket, head: Buffer) => void
+          }
+        ).upgrade(req, socket, head)
+      } catch (err) {
+        stopActivityKeepalive()
+        throw err
+      }
     } catch (err) {
       this.logger.warn(`upgrade failed for ${req.url}: ${(err as Error).message}`)
       this.respondAndClose(socket, 404, 'Not Found')
     }
+  }
+
+  private startActivityKeepalive(boxId: string, socket: Socket): () => void {
+    let stopped = false
+    let updateInFlight = false
+
+    const update = () => {
+      if (stopped || updateInFlight) return
+
+      updateInFlight = true
+      void this.boxService
+        .updateLastActivityAt(boxId, new Date())
+        .catch((err) => this.logger.warn(`updateLastActivityAt failed for ${boxId}: ${err}`))
+        .finally(() => {
+          updateInFlight = false
+        })
+    }
+
+    const interval = setInterval(update, WS_ACTIVITY_KEEPALIVE_INTERVAL_MS)
+    interval.unref()
+
+    const stop = () => {
+      if (stopped) return
+
+      stopped = true
+      clearInterval(interval)
+      socket.off('close', stop)
+    }
+
+    socket.once('close', stop)
+    update()
+
+    return stop
   }
 
   /**

--- a/apps/proxy/pkg/proxy/get_box_target.go
+++ b/apps/proxy/pkg/proxy/get_box_target.go
@@ -22,6 +22,11 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const (
+	activityPollInterval  = 50 * time.Second
+	activityUpdateTimeout = 10 * time.Second
+)
+
 func (p *Proxy) GetProxyTarget(ctx *gin.Context) (*url.URL, map[string]string, error) {
 	var targetPort, targetPath, boxIdOrSignedToken string
 
@@ -292,38 +297,11 @@ func (p *Proxy) parseHost(host string) (targetPort string, boxIdOrSignedToken st
 // updateLastActivity updates the last activity timestamp for a box.
 // If shouldPollUpdate is true, it starts a goroutine that updates every 50 seconds.
 func (p *Proxy) updateLastActivity(ctx context.Context, boxId string, shouldPollUpdate bool, doneCh chan struct{}) {
-	// Prevent frequent updates by caching the last update
-	cached, err := p.boxLastActivityUpdateCache.Has(ctx, boxId)
-	if err != nil {
-		// If cache doesn't work, skip the update to avoid spamming the API
-		log.Errorf("failed to check last activity update cache for box %s: %v", boxId, err)
-		return
-	}
-
-	// Poll interval is 50 seconds to avoid spamming the API which will also cache updates for 45 seconds
-	pollInterval := 50 * time.Second
-
-	if !cached {
-		_, err := p.apiclient.BoxAPI.UpdateLastActivity(ctx, boxId).Execute()
-		if err != nil {
-			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-				return
-			}
-			log.Errorf("failed to update last activity for box %s", boxId)
-			return
-		}
-
-		// Expire a bit before the poll interval to avoid skipping one interval
-		err = p.boxLastActivityUpdateCache.Set(ctx, boxId, true, pollInterval-5*time.Second)
-		if err != nil {
-			log.Errorf("failed to set last activity update cache for box %s: %v", boxId, err)
-		}
-	}
-
 	if shouldPollUpdate {
-		// Update keep alive every pollInterval until stopped
+		// Keep retrying while the proxied connection remains open, even if the
+		// initial activity update encounters a transient API or cache failure.
 		go func() {
-			ticker := time.NewTicker(pollInterval)
+			ticker := time.NewTicker(activityPollInterval)
 			defer ticker.Stop()
 
 			for {
@@ -335,5 +313,35 @@ func (p *Proxy) updateLastActivity(ctx context.Context, boxId string, shouldPoll
 				}
 			}
 		}()
+	}
+
+	updateCtx, cancel := context.WithTimeout(ctx, activityUpdateTimeout)
+	defer cancel()
+
+	// Prevent frequent updates by caching the last update
+	cached, err := p.boxLastActivityUpdateCache.Has(updateCtx, boxId)
+	if err != nil {
+		// If cache doesn't work, skip the update to avoid spamming the API
+		log.Errorf("failed to check last activity update cache for box %s: %v", boxId, err)
+		return
+	}
+
+	if !cached {
+		_, err := p.apiclient.BoxAPI.UpdateLastActivity(updateCtx, boxId).Execute()
+		if err != nil {
+			log.Errorf("failed to update last activity for box %s: %v", boxId, err)
+			return
+		}
+
+		// Expire a bit before the poll interval to avoid skipping one interval
+		err = p.boxLastActivityUpdateCache.Set(
+			updateCtx,
+			boxId,
+			true,
+			activityPollInterval-5*time.Second,
+		)
+		if err != nil {
+			log.Errorf("failed to set last activity update cache for box %s: %v", boxId, err)
+		}
 	}
 }


### PR DESCRIPTION
Keep long-lived connections active by refreshing WebSocket activity and retaining proxy retries after an initial activity update failure.

Test plan:
- [x] `cd apps && go test ./proxy/pkg/proxy`
- [x] `cd apps && yarn nx test api --runInBand --testPathPatterns=boxlite-ws-proxy.service.spec.ts`
- [x] `cd apps && yarn eslint api/src/boxlite-rest/boxlite-ws-proxy.service.ts api/src/boxlite-rest/boxlite-ws-proxy.service.spec.ts`
- [x] `cd apps && yarn tsc -p api/tsconfig.spec.json --noEmit`
- [x] `make lint:fix`
- [ ] `cd apps && yarn nx test api --runInBand` (blocked by the existing Jest ESM parsing issue in `boxlite-rest-routing.spec.ts`)