### PR TITLE
fix(sdk): remove REST tunnel bridge copy

### DIFF
--- a/scripts/test/e2e/cases/test_node_tunnel.py
+++ b/scripts/test/e2e/cases/test_node_tunnel.py
@@ -78,10 +78,9 @@ def test_node_sdk_tunnel_rejects_stopped_box(node_tunnel_env):
     env.pop("BOXLITE_E2E_SKIP_STOPPED_BOX")
     _assert_node_tunnel_passes(_run_node_tunnel(env))
 
-
 @pytest.mark.xfail(
     strict=True,
-    reason="TCP half-close currently drops the guest response",
+    reason="cloud tunnel path through NLB TLS termination does not guarantee TCP half-close",
 )
 def test_node_sdk_tunnel_preserves_tcp_half_close(node_tunnel_env):
     env = {**node_tunnel_env}

--- a/scripts/test/e2e/cases/test_sdk_tunnel.py
+++ b/scripts/test/e2e/cases/test_sdk_tunnel.py
@@ -224,10 +224,9 @@ async def test_python_sdk_tunnel_rejects_stopped_box(rt, image):
         return
     assert SERVICES[0][1] not in stopped_response
 
-
 @pytest.mark.xfail(
     strict=True,
-    reason="TCP half-close currently drops the guest response",
+    reason="cloud tunnel path through NLB TLS termination does not guarantee TCP half-close",
 )
 @pytest.mark.asyncio
 async def test_python_sdk_tunnel_preserves_tcp_half_close(rt, image):

--- a/src/boxlite/src/rest/client.rs
+++ b/src/boxlite/src/rest/client.rs
@@ -358,7 +358,7 @@ impl ApiClient {
     pub(crate) async fn connect_box_network_tunnel(
         &self,
         uri: &str,
-    ) -> BoxliteResult<tokio::io::DuplexStream> {
+    ) -> BoxliteResult<hyper_util::rt::TokioIo<hyper::upgrade::Upgraded>> {
         use http_body_util::Empty;
         use hyper::{Method, Request, Uri};
         use hyper_util::rt::TokioIo;
@@ -399,12 +399,7 @@ impl ApiClient {
         let upgraded = hyper::upgrade::on(response)
             .await
             .map_err(|e| BoxliteError::Network(format!("CONNECT upgrade failed: {e}")))?;
-        let (local, mut pump_end) = tokio::io::duplex(64 * 1024);
-        let mut remote = TokioIo::new(upgraded);
-        tokio::spawn(async move {
-            let _ = tokio::io::copy_bidirectional(&mut pump_end, &mut remote).await;
-        });
-        Ok(local)
+        Ok(TokioIo::new(upgraded))
     }
 
     /// Prepare a box service tunnel and return its public descriptor.
@@ -677,19 +672,25 @@ mod tests {
             let mut payload = [0; 4];
             socket.read_exact(&mut payload).await.unwrap();
             assert_eq!(&payload, b"ping");
-            socket.write_all(&payload).await.unwrap();
+            assert_eq!(
+                socket.read_u8().await.unwrap_err().kind(),
+                std::io::ErrorKind::UnexpectedEof
+            );
+            socket.write_all(b"pong").await.unwrap();
         });
 
         let client =
             ApiClient::new(&BoxliteRestOptions::new(format!("http://127.0.0.1:{port}"))).unwrap();
-        let mut stream = client
+        let stream = client
             .connect_box_network_tunnel(&format!("http://127.0.0.1:{port}"))
             .await
             .unwrap();
-        stream.write_all(b"ping").await.unwrap();
+        let (mut reader, mut writer) = tokio::io::split(stream);
+        writer.write_all(b"ping").await.unwrap();
+        writer.shutdown().await.unwrap();
         let mut response = [0; 4];
-        stream.read_exact(&mut response).await.unwrap();
-        assert_eq!(&response, b"ping");
+        reader.read_exact(&mut response).await.unwrap();
+        assert_eq!(&response, b"pong");
         server.await.unwrap();
     }
 


### PR DESCRIPTION
Return the REST CONNECT upgraded stream directly from the Rust SDK instead of inserting an internal duplex copy bridge.

Test plan:
- [x] `PATH="$HOME/.cargo/bin:$PATH" cargo test -p boxlite --lib connect_box_network_tunnel_uses_connect_and_streams_both_directions --features rest -- --nocapture`
- [x] `python3 -m py_compile scripts/test/e2e/cases/test_sdk_tunnel.py scripts/test/e2e/cases/test_node_tunnel.py`
- [x] `git diff --check`
- [x] `python -m pytest sdks/python/tests/test_tunnel.py -q`
- [x] `go test ./pkg/proxy -run TestProxyBidirectionalStreamPreservesHalfCloseResponse -v` from `apps/common-go`
- [x] `go test ./pkg/proxy -run "TestBufferedConnForwardsCloseWrite|TestTunnelTarget" -v` from `apps/proxy`
- [x] Manual TLS and hyper-rustls CONNECT half-close probes passed on the debug host
- [ ] Cloud Python/Node half-close E2E remains strict xfail because the NLB TLS termination path does not guarantee TCP half-close semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated network tunnel handling so callers receive the upgraded tunnel stream directly, improving how tunnel traffic is read and written.
  - Adjusted tunnel streaming behavior to align with bidirectional usage expectations.

- **Tests**
  - Updated the tunnel unit test to validate request/response in both directions using the new returned stream API.
  - Refreshed E2E test xfail explanations for TCP half-close behavior to reflect the current tunnel path characteristics (tests remain xfailed).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->