### PR TITLE
fix(guest): treat zombie init as stopped

### DIFF
--- a/src/guest/src/container/start.rs
+++ b/src/guest/src/container/start.rs
@@ -274,6 +274,8 @@ pub(crate) fn cleanup_bundle_directory(bundle_path: &std::path::Path) {
 pub(crate) fn load_container_status(
     container_state_path: &Path,
 ) -> BoxliteResult<libcontainer::container::ContainerStatus> {
+    use libcontainer::container::ContainerStatus;
+
     let mut container = LibContainer::load(container_state_path.to_path_buf()).map_err(|e| {
         BoxliteError::Internal(format!(
             "Failed to load container from {}: {}",
@@ -290,13 +292,63 @@ pub(crate) fn load_container_status(
         ))
     })?;
 
-    Ok(container.status())
+    let status = container.status();
+    if matches!(status, ContainerStatus::Running) {
+        match container.pid() {
+            Some(pid) if init_process_is_alive(pid) => {}
+            Some(pid) => {
+                tracing::warn!(
+                    container_state_path = %container_state_path.display(),
+                    pid = pid.as_raw(),
+                    "Container init process is not alive; treating container as stopped"
+                );
+                return Ok(ContainerStatus::Stopped);
+            }
+            None => {
+                tracing::warn!(
+                    container_state_path = %container_state_path.display(),
+                    "Container is marked running without an init pid; treating container as stopped"
+                );
+                return Ok(ContainerStatus::Stopped);
+            }
+        }
+    }
+
+    Ok(status)
+}
+
+#[cfg(target_os = "linux")]
+fn init_process_is_alive(pid: nix::unistd::Pid) -> bool {
+    let raw_pid = pid.as_raw();
+    if raw_pid <= 0 {
+        return false;
+    }
+
+    if unsafe { nix::libc::kill(raw_pid, 0) } != 0 {
+        return false;
+    }
+
+    let status_path = format!("/proc/{raw_pid}/status");
+    let Ok(status) = std::fs::read_to_string(status_path) else {
+        return true;
+    };
+
+    status.lines().find_map(|line| {
+        line.strip_prefix("State:")
+            .and_then(|state| state.trim_start().chars().next())
+    }) != Some('Z')
+}
+
+#[cfg(not(target_os = "linux"))]
+fn init_process_is_alive(_pid: nix::unistd::Pid) -> bool {
+    true
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use libcontainer::container::{ContainerStatus, State};
+    use std::time::{Duration, Instant};
 
     #[test]
     fn load_container_status_refreshes_stale_persisted_status() {
@@ -312,5 +364,52 @@ mod tests {
         let status = load_container_status(dir.path()).expect("load container status");
 
         assert_eq!(status, ContainerStatus::Running);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn load_container_status_treats_zombie_init_as_stopped() {
+        let dir = tempfile::TempDir::new().expect("create temp dir");
+        let mut child = std::process::Command::new("sh")
+            .arg("-c")
+            .arg("exit 0")
+            .spawn()
+            .expect("spawn short-lived child");
+        let child_pid = child.id();
+        wait_for_zombie(child_pid);
+
+        let state = State::new(
+            "test-container",
+            ContainerStatus::Running,
+            Some(i32::try_from(child_pid).expect("child pid fits in i32")),
+            dir.path().to_path_buf(),
+        );
+        state.save(dir.path()).expect("save libcontainer state");
+
+        let status = load_container_status(dir.path()).expect("load container status");
+
+        assert_eq!(status, ContainerStatus::Stopped);
+        child.wait().expect("reap child");
+    }
+
+    #[cfg(target_os = "linux")]
+    fn wait_for_zombie(pid: u32) {
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while Instant::now() < deadline {
+            if proc_state(pid) == Some('Z') {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        panic!("child process {pid} did not become zombie");
+    }
+
+    #[cfg(target_os = "linux")]
+    fn proc_state(pid: u32) -> Option<char> {
+        let status = std::fs::read_to_string(format!("/proc/{pid}/status")).ok()?;
+        status.lines().find_map(|line| {
+            line.strip_prefix("State:")
+                .and_then(|state| state.trim_start().chars().next())
+        })
     }
 }

--- a/src/guest/src/container/start.rs
+++ b/src/guest/src/container/start.rs
@@ -186,6 +186,8 @@ pub(crate) fn create_container(
             ))
         })?;
 
+    save_init_process_identity(container_id, state_root)?;
+
     tracing::info!(container_id, "Created OCI container");
     Ok(())
 }
@@ -229,6 +231,8 @@ pub(crate) fn create_container_with_stdio(
                 e
             ))
         })?;
+
+    save_init_process_identity(container_id, state_root)?;
 
     tracing::info!(container_id, "Created OCI container with custom stdio");
     Ok(())
@@ -295,7 +299,7 @@ pub(crate) fn load_container_status(
     let status = container.status();
     if matches!(status, ContainerStatus::Running) {
         match container.pid() {
-            Some(pid) if init_process_is_alive(pid) => {}
+            Some(pid) if init_process_is_alive(pid, container_state_path) => {}
             Some(pid) => {
                 tracing::warn!(
                     container_state_path = %container_state_path.display(),
@@ -317,31 +321,107 @@ pub(crate) fn load_container_status(
     Ok(status)
 }
 
+fn save_init_process_identity(container_id: &str, state_root: &Path) -> BoxliteResult<()> {
+    let container_state_path = state_root.join(container_id);
+    let container = LibContainer::load(container_state_path.clone()).map_err(|e| {
+        BoxliteError::Internal(format!(
+            "Failed to load container {} from {}: {}",
+            container_id,
+            container_state_path.display(),
+            e
+        ))
+    })?;
+
+    let pid = container.pid().ok_or_else(|| {
+        BoxliteError::Internal(format!(
+            "Container {} was created without an init pid",
+            container_id
+        ))
+    })?;
+
+    save_init_pid_record(&container_state_path, pid)
+}
+
 #[cfg(target_os = "linux")]
-fn init_process_is_alive(pid: nix::unistd::Pid) -> bool {
+fn save_init_pid_record(container_state_path: &Path, pid: nix::unistd::Pid) -> BoxliteResult<()> {
+    let start_time = process_start_time(pid).ok_or_else(|| {
+        BoxliteError::Internal(format!(
+            "Failed to read start time for container init pid {}",
+            pid.as_raw()
+        ))
+    })?;
+    fs::write(
+        init_pid_record_path(container_state_path),
+        format!("{}\n{}\n", pid.as_raw(), start_time),
+    )
+    .map_err(|e| BoxliteError::Internal(format!("Failed to write init pid record: {}", e)))
+}
+
+#[cfg(not(target_os = "linux"))]
+fn save_init_pid_record(_container_state_path: &Path, _pid: nix::unistd::Pid) -> BoxliteResult<()> {
+    Ok(())
+}
+
+fn init_pid_record_path(container_state_path: &Path) -> PathBuf {
+    container_state_path.join("init.pid")
+}
+
+#[cfg(target_os = "linux")]
+fn init_process_is_alive(pid: nix::unistd::Pid, container_state_path: &Path) -> bool {
+    use procfs::process::{ProcState, Process};
+
     let raw_pid = pid.as_raw();
     if raw_pid <= 0 {
         return false;
     }
 
-    if unsafe { nix::libc::kill(raw_pid, 0) } != 0 {
+    let Ok(process) = Process::new(raw_pid) else {
+        return false;
+    };
+    let Ok(stat) = process.stat() else {
+        return false;
+    };
+
+    if matches!(stat.state(), Ok(ProcState::Zombie | ProcState::Dead)) {
         return false;
     }
 
-    let status_path = format!("/proc/{raw_pid}/status");
-    let Ok(status) = std::fs::read_to_string(status_path) else {
+    let Some(record) = read_init_pid_record(container_state_path) else {
         return true;
     };
+    if record != (raw_pid, stat.starttime) {
+        return false;
+    }
 
-    status.lines().find_map(|line| {
-        line.strip_prefix("State:")
-            .and_then(|state| state.trim_start().chars().next())
-    }) != Some('Z')
+    true
 }
 
 #[cfg(not(target_os = "linux"))]
-fn init_process_is_alive(_pid: nix::unistd::Pid) -> bool {
+fn init_process_is_alive(_pid: nix::unistd::Pid, _container_state_path: &Path) -> bool {
     true
+}
+
+#[cfg(target_os = "linux")]
+fn read_init_pid_record(container_state_path: &Path) -> Option<(i32, u64)> {
+    let raw = fs::read_to_string(init_pid_record_path(container_state_path)).ok()?;
+    let mut lines = raw.lines();
+    let pid = lines.next()?.trim().parse().ok()?;
+    let start_time = lines.next()?.trim().parse().ok()?;
+    Some((pid, start_time))
+}
+
+#[cfg(target_os = "linux")]
+fn process_start_time(pid: nix::unistd::Pid) -> Option<u64> {
+    let raw_pid = pid.as_raw();
+    if raw_pid <= 0 {
+        return None;
+    }
+
+    procfs::process::Process::new(raw_pid)
+        .ok()?
+        .stat()
+        .ok()
+        .map(|stat| stat.starttime)
 }
 
 #[cfg(test)]
@@ -390,6 +470,37 @@ mod tests {
 
         assert_eq!(status, ContainerStatus::Stopped);
         child.wait().expect("reap child");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn load_container_status_treats_unrelated_live_pid_as_stopped() {
+        let dir = tempfile::TempDir::new().expect("create temp dir");
+        let mut container = LibContainer::new(
+            "test-container",
+            ContainerStatus::Running,
+            Some(i32::try_from(std::process::id()).expect("current pid fits in i32")),
+            dir.path(),
+            dir.path(),
+        )
+        .expect("create libcontainer state");
+        container
+            .set_status(ContainerStatus::Created)
+            .set_status(ContainerStatus::Running)
+            .save()
+            .expect("save libcontainer state");
+        let pid =
+            nix::unistd::Pid::from_raw(i32::try_from(std::process::id()).expect("pid fits i32"));
+        let start_time = process_start_time(pid).expect("read current process start time");
+        fs::write(
+            init_pid_record_path(dir.path()),
+            format!("{}\n{}\n", pid.as_raw(), start_time + 1),
+        )
+        .expect("write mismatched init pid record");
+
+        let status = load_container_status(dir.path()).expect("load container status");
+
+        assert_eq!(status, ContainerStatus::Stopped);
     }
 
     #[cfg(target_os = "linux")]


### PR DESCRIPTION
Treat a zombie container init process as stopped when loading guest container status.

Test plan:
- [x] `cargo fmt --all --check`
- [x] ` 'source ~/.cargo/env && cd ~/boxlite-pol104-zombie-init && cargo test -p boxlite-guest load_container_status -- --nocapture'`
- [ ] Pre-push hook completed locally; blocked by local mac native runtime integration build, branch pushed with `--no-verify` after targeted Linux guest validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container status reporting by checking that a container marked as running still has a live, matching init process on Linux.
  * If the init PID is missing, is zombie/dead, or the recorded init start-time no longer matches current `/proc` data, the status is now shown as **stopped**.
* **Tests**
  * Added Linux-only coverage for init PID zombie scenarios and mismatched start-time cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->