### PR TITLE
fix(ci): run e2e-local on labeled fork PRs via pull_request_target

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -165,7 +165,8 @@ Runs VM-based integration tests on a persistent, self-hosted AWS EC2 runner — 
 runners can't expose `/dev/kvm`, which BoxLite's libkrun microVMs need. The instance is
 started before a run and stopped (not terminated) after, so caches persist. AWS auth is
 GitHub OIDC → STS; runner registration is a GitHub App. A pull request must carry the
-`e2e-local` label (the cost gate) to run.
+`e2e-local` label (the cost gate) to run; fork PRs run via `pull_request_target` and only
+the labeled head commit — re-label after new pushes.
 
 See the **[E2E Local CI runbook](../../docs/ci/e2e-local.md)** for the jobs, the instance,
 one-time provisioning (`scripts/ci/setup-ci-runner.sh`), and troubleshooting.

--- a/.github/workflows/e2e-local.yml
+++ b/.github/workflows/e2e-local.yml
@@ -19,6 +19,16 @@
 #   AWS: GitHub OIDC → AWS STS (no stored AWS credentials)
 #   GitHub: GitHub App → short-lived installation token (no PAT)
 #
+# Fork PRs: plain `pull_request` withholds secrets AND repo variables from
+# fork runs, so start-runner cannot authenticate. The PR trigger is
+# therefore `pull_request_target` (base context: secrets available, workflow
+# definition always from main), gated by the maintainer-applied `e2e-local`
+# label. For forks the approval is per-push: only the labeling event runs,
+# pinned to the head SHA the maintainer approved — a new push needs a
+# re-label. Untrusted code runs only in e2e-tests, which holds no secrets
+# and a read-only token; the runner's instance profile can only terminate
+# the runner itself (see scripts/ci/setup-ci-runner.sh).
+#
 # Setup:   ./scripts/ci/setup-ci-runner.sh
 # Runbook: docs/ci/e2e-local.md
 name: E2E local
@@ -35,7 +45,7 @@ on:
       - '**/Cargo.toml'
       - 'Cargo.lock'
       - '.github/workflows/e2e-local.yml'
-  pull_request:
+  pull_request_target:
     types: [labeled, synchronize]
     branches: [main]
     paths:
@@ -59,6 +69,12 @@ concurrency:
   group: e2e-runner
   cancel-in-progress: true
 
+# pull_request_target's default token is write-capable and e2e-tests runs
+# labeled fork code — keep the inherited token read-only. start-runner and
+# stop-runner declare their own id-token permissions.
+permissions:
+  contents: read
+
 env:
   AWS_REGION: us-east-1
   AWS_ROLE_ARN: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/boxlite-e2e-github-actions
@@ -72,7 +88,9 @@ env:
 
 jobs:
   # =========================================================================
-  # Gate: PRs require 'e2e-local' label (only maintainers can add it)
+  # Gate: PRs require 'e2e-local' label (only maintainers can add it).
+  # Same-repo PRs re-run while labeled; fork PRs run only on the labeling
+  # event itself, so every new fork push needs a fresh maintainer re-label.
   # =========================================================================
   should-run:
     runs-on: ubuntu-latest
@@ -81,16 +99,28 @@ jobs:
     steps:
       - name: Check trigger conditions
         id: check
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_ACTION: ${{ github.event.action }}
+          ADDED_LABEL: ${{ github.event.label.name }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            LABELS='${{ toJson(github.event.pull_request.labels.*.name) }}'
-            if echo "$LABELS" | jq -e 'index("e2e-local")' > /dev/null 2>&1; then
-              echo "run=true" >> "$GITHUB_OUTPUT"
-            else
-              echo "run=false" >> "$GITHUB_OUTPUT"
-            fi
-          else
+          if [ "$EVENT_NAME" != "pull_request_target" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"   # push / workflow_dispatch
+            exit 0
+          fi
+          if ! echo "$LABELS" | jq -e 'index("e2e-local")' > /dev/null 2>&1; then
+            echo "run=false" >> "$GITHUB_OUTPUT"  # label is the cost gate
+            exit 0
+          fi
+          if [ "$HEAD_REPO" = "$GITHUB_REPOSITORY" ]; then
             echo "run=true" >> "$GITHUB_OUTPUT"
+          elif [ "$EVENT_ACTION" = "labeled" ] && [ "$ADDED_LABEL" = "e2e-local" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Fork PR changed since its e2e-local approval. Remove and re-add the label to re-run e2e."
           fi
 
   # =========================================================================
@@ -364,6 +394,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
         with:
+          # pull_request_target resolves to the BASE branch by default, which
+          # would silently test main instead of the PR. Pin the head SHA the
+          # maintainer approved when labeling; push/dispatch keep github.sha.
+          # No credentials persist on the runner: fork code runs after this.
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
           submodules: recursive
           clean: false
 

--- a/docs/ci/e2e-local.md
+++ b/docs/ci/e2e-local.md
@@ -37,7 +37,10 @@ flowchart LR
 - Push to `main` touching runtime code (`src/boxlite`, `src/shared`, `src/cli`, `src/guest`,
   `sdks/**`, any `Cargo.toml`, `Cargo.lock`, or the workflow file itself).
 - A pull request labeled `e2e-local` — the label is the cost gate, and only maintainers can
-  add it.
+  add it. The trigger is `pull_request_target`, so fork PRs get the credentials a plain
+  `pull_request` run would be denied. Same-repo PRs re-run on every push while labeled; a
+  fork PR runs only the head commit that was labeled — after new pushes, remove and re-add
+  the label to approve the new code.
 - Manual `workflow_dispatch`, with an optional `debug` input that opens an SSH session if the
   tests fail.
 
@@ -110,6 +113,7 @@ gh workflow run e2e-local.yml
 | `e2e-tests` fails on low disk | `target/` build artifacts filled the volume | the job evicts caches at 80% use and refuses below 20 GB free; if it still fails, free space on the instance manually |
 | A run can't find the instance, or targets the wrong one | `EC2_E2E_INSTANCE_ID` is stale | it self-heals via the `Name=boxlite-e2e` tag; clear the variable to force rediscovery |
 | A pull request doesn't trigger the workflow | the `e2e-local` label is missing | a maintainer adds the label (it is the cost gate) |
+| A labeled fork PR doesn't re-run after a push | fork approval is per-commit | remove and re-add the `e2e-local` label to approve the new head |
 
 For an interactive session, dispatch the workflow with `debug: true`; on failure it opens a
 tmate SSH session and leaves the instance running (it auto-stops after 30 minutes idle).


### PR DESCRIPTION
## Summary

[Run 29324915498](https://github.com/boxlite-ai/boxlite/actions/runs/29324915498/job/87061427258) failed on fork PR #982: GitHub withholds secrets **and** repository variables from fork `pull_request` runs (`Secret source: None`), so the maintainer-applied `e2e-local` label sent the run into `start-runner`, where `create-github-app-token` failed with "Input required and not supplied: app-id". The label contract ("label ⇒ e2e runs") was implemented on an event type that structurally cannot honor it for forks.

Switch the PR trigger to label-gated `pull_request_target` (base context: credentials available, workflow definition always from `main`), hardened per the standard pattern (protobuf `test_runner.yml`, GitHub security-hardening guidance):

- **Per-push fork approval** — a fork PR runs only on the `e2e-local` labeling event, pinned to the labeled head SHA; pushes after approval are skipped with a notice until a maintainer re-labels. Same-repo PRs keep today's behavior (re-run on every push while labeled).
- **Checkout pins `head.sha`** — `pull_request_target` resolves to the base branch by default, which would silently test `main`; `persist-credentials: false` so no token remains on the persistent runner when fork code runs.
- **Read-only default token** — top-level `permissions: contents: read` (the `pull_request_target` default is write-capable); `should-run` gate inputs move from inline `${{ }}` interpolation into `env:`.

Blast radius of an approved-then-malicious fork run stays contained: secrets exist only in `start-runner`/`stop-runner` (GitHub-hosted, never execute PR code), and the runner's instance profile allows only self-termination (`scripts/ci/setup-ci-runner.sh`).

## Verification

- `actionlint`: identical 2 pre-existing findings as HEAD's version — zero new findings
- Gate behavior: the `should-run` script extracted from the YAML and executed across 9 event scenarios passes 9/9 (push/dispatch run; same-repo labeled runs on label+synchronize; fork runs only on the `e2e-local` labeling event; stale/unapproved fork events skip)
- Regression side: HEAD's gate script, given the failing run's exact inputs (`pull_request`, fork, `e2e-local` present), returns `run=true` — the path into the credential-less crash

After merge: remove and re-add `e2e-local` on #982 to run e2e against its current head.

https://claude.ai/code/session_01HkVMvjNbCKPrbwxps95jTp


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI Improvements**
  * Updated end-to-end test workflows to run securely for forked pull requests.
  * Tests now run only when the `e2e-local` label is applied, using the labeled commit.
  * After new changes are pushed to a forked pull request, remove and re-add the label to run tests again.

* **Documentation**
  * Clarified labeling behavior, permissions, and troubleshooting guidance for local end-to-end tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->