### PR TITLE
feat(rust-sdk): expose box network tunnels

### DIFF
--- a/src/boxlite/src/lib.rs
+++ b/src/boxlite/src/lib.rs
@@ -32,7 +32,7 @@ mod rest;
 mod rootfs;
 mod volumes;
 
-pub use litebox::{BoxTunnel, LiteBox};
+pub use litebox::{BoxConnection, BoxTunnel, LiteBox};
 pub use portal::GuestSession;
 pub use runtime::{AuthHandle, BoxliteRuntime, ImageHandle, Principal};
 

--- a/src/boxlite/src/lib.rs
+++ b/src/boxlite/src/lib.rs
@@ -32,7 +32,7 @@ mod rest;
 mod rootfs;
 mod volumes;
 
-pub use litebox::LiteBox;
+pub use litebox::{BoxTunnel, LiteBox};
 pub use portal::GuestSession;
 pub use runtime::{AuthHandle, BoxliteRuntime, ImageHandle, Principal};
 

--- a/src/boxlite/src/litebox/box_impl.rs
+++ b/src/boxlite/src/litebox/box_impl.rs
@@ -1187,7 +1187,7 @@ impl crate::runtime::backend::BoxNetworkBackend for BoxImpl {
             None,
             Arc::new(move || {
                 let network = Arc::clone(&network);
-                Box::pin(async move { Ok(network.tunnel(target).await?.into_stream()) })
+                Box::pin(async move { network.tunnel(target).await })
             }),
         ))
     }

--- a/src/boxlite/src/litebox/box_impl.rs
+++ b/src/boxlite/src/litebox/box_impl.rs
@@ -4,6 +4,7 @@
 // IMPORTS
 // ============================================================================
 
+use std::net::SocketAddr;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
 use std::time::{Duration, Instant};
@@ -23,6 +24,7 @@ use crate::disk::Disk;
 use crate::event_listener::EventListener;
 #[cfg(target_os = "linux")]
 use crate::fs::BindMountHandle;
+use crate::litebox::BoxTunnel;
 use crate::litebox::copy::CopyOptions;
 use crate::lock::LockGuard;
 use crate::metrics::{BoxMetrics, BoxMetricsStorage};
@@ -60,7 +62,7 @@ pub(crate) struct LiveState {
     /// Read via [`BoxImpl::network`]; the first caller lands with the outer
     /// (SDK/CLI) layer — held now so the box owns the abstraction from birth.
     #[allow(dead_code)]
-    network: Option<Box<dyn NetworkBackend>>,
+    network: Option<Arc<dyn NetworkBackend>>,
 
     // Metrics
     metrics: BoxMetricsStorage,
@@ -90,7 +92,7 @@ impl LiveState {
         Self {
             handler: std::sync::Mutex::new(handler),
             guest_session,
-            network,
+            network: network.map(Arc::from),
             metrics,
             _container_rootfs_disk: container_rootfs_disk,
             guest_rootfs_disk,
@@ -1167,6 +1169,27 @@ impl crate::runtime::backend::BoxBackend for BoxImpl {
         dest: &std::path::Path,
     ) -> BoxliteResult<crate::runtime::options::BoxArchive> {
         BoxImpl::export_box(self, options, dest).await
+    }
+}
+
+#[async_trait::async_trait]
+impl crate::runtime::backend::BoxNetworkBackend for BoxImpl {
+    async fn tunnel(&self, target: SocketAddr) -> BoxliteResult<BoxTunnel> {
+        // Local boxes have no public URL; the tunnel carries a connector that
+        // opens the raw stream through the guest-network backend on demand.
+        let network = self
+            .live_state()
+            .await?
+            .network
+            .clone()
+            .ok_or_else(|| BoxliteError::Unsupported("box networking is disabled".into()))?;
+        Ok(BoxTunnel::new(
+            None,
+            Arc::new(move || {
+                let network = Arc::clone(&network);
+                Box::pin(async move { Ok(network.tunnel(target).await?.into_stream()) })
+            }),
+        ))
     }
 }
 

--- a/src/boxlite/src/litebox/mod.rs
+++ b/src/boxlite/src/litebox/mod.rs
@@ -62,17 +62,6 @@ impl LiteBox {
     /// Create a LiteBox from backend implementations.
     pub(crate) fn new(
         box_backend: Arc<dyn BoxBackend>,
-        snapshot_backend: Arc<dyn SnapshotBackend>,
-    ) -> Self {
-        Self::new_with_network(
-            box_backend,
-            Arc::new(crate::litebox::network::UnsupportedNetworkBackend),
-            snapshot_backend,
-        )
-    }
-
-    pub(crate) fn new_with_network(
-        box_backend: Arc<dyn BoxBackend>,
         network_backend: Arc<dyn BoxNetworkBackend>,
         snapshot_backend: Arc<dyn SnapshotBackend>,
     ) -> Self {

--- a/src/boxlite/src/litebox/mod.rs
+++ b/src/boxlite/src/litebox/mod.rs
@@ -21,7 +21,7 @@ pub use copy::CopyOptions;
 pub(crate) use crash_report::CrashReport;
 pub use exec::{BoxCommand, ExecResult, ExecStderr, ExecStdin, ExecStdout, Execution, ExecutionId};
 pub(crate) use manager::BoxManager;
-pub use network::{BoxTunnel, NetworkHandle};
+pub use network::{BoxConnection, BoxTunnel, NetworkHandle};
 pub use snapshot::SnapshotHandle;
 pub use state::{BoxState, BoxStatus, HealthState, HealthStatus};
 

--- a/src/boxlite/src/litebox/mod.rs
+++ b/src/boxlite/src/litebox/mod.rs
@@ -12,6 +12,7 @@ mod exec;
 mod init;
 pub(crate) mod local_snapshot;
 mod manager;
+mod network;
 mod snapshot;
 pub(crate) mod snapshot_mgr;
 mod state;
@@ -20,6 +21,7 @@ pub use copy::CopyOptions;
 pub(crate) use crash_report::CrashReport;
 pub use exec::{BoxCommand, ExecResult, ExecStderr, ExecStdin, ExecStdout, Execution, ExecutionId};
 pub(crate) use manager::BoxManager;
+pub use network::{BoxTunnel, NetworkHandle};
 pub use snapshot::SnapshotHandle;
 pub use state::{BoxState, BoxStatus, HealthState, HealthStatus};
 
@@ -31,7 +33,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use crate::metrics::BoxMetrics;
-use crate::runtime::backend::{BoxBackend, SnapshotBackend};
+use crate::runtime::backend::{BoxBackend, BoxNetworkBackend, SnapshotBackend};
 use crate::runtime::options::{BoxArchive, CloneOptions, ExportOptions};
 use crate::{BoxID, BoxInfo};
 use boxlite_shared::errors::BoxliteResult;
@@ -50,6 +52,8 @@ pub struct LiteBox {
     name: Option<String>,
     /// Backend for lifecycle/exec/file operations.
     box_backend: Arc<dyn BoxBackend>,
+    /// Backend for network operations.
+    network_backend: Arc<dyn BoxNetworkBackend>,
     /// Backend for snapshot lifecycle operations.
     snapshot_backend: Arc<dyn SnapshotBackend>,
 }
@@ -60,12 +64,25 @@ impl LiteBox {
         box_backend: Arc<dyn BoxBackend>,
         snapshot_backend: Arc<dyn SnapshotBackend>,
     ) -> Self {
+        Self::new_with_network(
+            box_backend,
+            Arc::new(crate::litebox::network::UnsupportedNetworkBackend),
+            snapshot_backend,
+        )
+    }
+
+    pub(crate) fn new_with_network(
+        box_backend: Arc<dyn BoxBackend>,
+        network_backend: Arc<dyn BoxNetworkBackend>,
+        snapshot_backend: Arc<dyn SnapshotBackend>,
+    ) -> Self {
         let id = box_backend.id().clone();
         let name = box_backend.name().map(|s| s.to_string());
         Self {
             id,
             name,
             box_backend,
+            network_backend,
             snapshot_backend,
         }
     }
@@ -138,6 +155,11 @@ impl LiteBox {
         self.box_backend
             .copy_out(container_src.as_ref(), host_dst.as_ref(), opts)
             .await
+    }
+
+    /// Get a network handle for raw tunnel operations.
+    pub fn network(&self) -> NetworkHandle {
+        NetworkHandle::new(Arc::clone(&self.network_backend))
     }
 
     /// Get a snapshot handle for snapshot operations.

--- a/src/boxlite/src/litebox/network.rs
+++ b/src/boxlite/src/litebox/network.rs
@@ -5,7 +5,7 @@ use std::net::SocketAddr;
 use std::pin::Pin;
 use std::sync::Arc;
 
-use boxlite_shared::errors::{BoxliteError, BoxliteResult};
+use boxlite_shared::errors::BoxliteResult;
 
 use crate::net::BoxInternalTunnel;
 use crate::runtime::backend::BoxNetworkBackend;
@@ -30,17 +30,6 @@ pub(crate) type TunnelUrlFetch =
 pub trait BoxConnection: tokio::io::AsyncRead + tokio::io::AsyncWrite + Send + Unpin {}
 
 impl<T> BoxConnection for T where T: tokio::io::AsyncRead + tokio::io::AsyncWrite + Send + Unpin {}
-
-pub(crate) struct UnsupportedNetworkBackend;
-
-#[async_trait::async_trait]
-impl BoxNetworkBackend for UnsupportedNetworkBackend {
-    async fn tunnel(&self, _target: SocketAddr) -> BoxliteResult<BoxTunnel> {
-        Err(BoxliteError::Unsupported(
-            "box networking is unavailable".into(),
-        ))
-    }
-}
 
 /// A box service tunnel target. Call [`endpoint`](Self::endpoint) first, then
 /// [`connect`](Self::connect) on this handle.

--- a/src/boxlite/src/litebox/network.rs
+++ b/src/boxlite/src/litebox/network.rs
@@ -20,12 +20,6 @@ pub(crate) type TunnelConnector = Arc<
         + Sync,
 >;
 
-/// Lazily fetches the public endpoint for a [`BoxTunnel`]. Present only for remote
-/// boxes, and invoked on demand so a caller that only connects never pays for
-/// the describe round-trip.
-pub(crate) type TunnelUrlFetch =
-    Box<dyn Fn() -> Pin<Box<dyn Future<Output = BoxliteResult<String>> + Send>> + Send + Sync>;
-
 /// Public byte-stream capability for a box service connection.
 pub trait BoxConnection: tokio::io::AsyncRead + tokio::io::AsyncWrite + Send + Unpin {}
 
@@ -34,15 +28,15 @@ impl<T> BoxConnection for T where T: tokio::io::AsyncRead + tokio::io::AsyncWrit
 /// A box service tunnel target. Call [`endpoint`](Self::endpoint) first, then
 /// [`connect`](Self::connect) on this handle.
 pub struct BoxTunnel {
-    endpoint: Option<TunnelUrlFetch>,
+    endpoint: Option<String>,
     connector: TunnelConnector,
     stream: Arc<tokio::sync::Mutex<Option<BoxInternalTunnel>>>,
 }
 
 impl BoxTunnel {
-    pub(crate) fn new(url: Option<TunnelUrlFetch>, connector: TunnelConnector) -> Self {
+    pub(crate) fn new(endpoint: Option<String>, connector: TunnelConnector) -> Self {
         Self {
-            endpoint: url,
+            endpoint,
             connector,
             stream: Arc::new(tokio::sync::Mutex::new(None)),
         }
@@ -51,7 +45,7 @@ impl BoxTunnel {
     /// Resolve the endpoint, fetching a URL remotely or preparing a local stream.
     pub async fn endpoint(&self) -> BoxliteResult<Option<String>> {
         match &self.endpoint {
-            Some(fetch) => Ok(Some(fetch().await?)),
+            Some(endpoint) => Ok(Some(endpoint.clone())),
             None => {
                 let mut stream = self.stream.lock().await;
                 if stream.is_none() {
@@ -108,23 +102,15 @@ mod tests {
 
     #[derive(Default)]
     struct TestBackend {
-        described: Arc<AtomicUsize>,
         connected: Arc<AtomicUsize>,
     }
 
     #[async_trait::async_trait]
     impl BoxNetworkBackend for TestBackend {
         async fn tunnel(&self, _target: SocketAddr) -> BoxliteResult<BoxTunnel> {
-            let described = Arc::clone(&self.described);
             let connected = Arc::clone(&self.connected);
             Ok(BoxTunnel::new(
-                Some(Box::new(move || {
-                    let described = Arc::clone(&described);
-                    Box::pin(async move {
-                        described.fetch_add(1, Ordering::Relaxed);
-                        Ok("https://3000-box.proxy.example.test".to_string())
-                    })
-                })),
+                Some("https://3000-box.proxy.example.test".to_string()),
                 Arc::new(move || {
                     let connected = Arc::clone(&connected);
                     Box::pin(async move {
@@ -142,24 +128,21 @@ mod tests {
         let network = NetworkHandle::new(backend.clone());
         let target = "192.168.127.2:3000".parse().unwrap();
 
-        // Obtaining the tunnel does no work — no describe, no connect.
+        // Obtaining the tunnel does no work — no connect.
         let tunnel = network.tunnel(target).await.unwrap();
-        assert_eq!(backend.described.load(Ordering::Relaxed), 0);
         assert_eq!(backend.connected.load(Ordering::Relaxed), 0);
 
-        // endpoint() triggers exactly one describe; connect() remains separate.
+        // endpoint() returns the already-resolved URL; connect() remains separate.
         let endpoint = tunnel.endpoint().await.unwrap();
         assert_eq!(
             endpoint.as_deref(),
             Some("https://3000-box.proxy.example.test")
         );
-        assert_eq!(backend.described.load(Ordering::Relaxed), 1);
         assert_eq!(backend.connected.load(Ordering::Relaxed), 0);
 
         // Connecting the tunnel triggers exactly one connect.
         assert!(tunnel.connect().await.is_err());
         assert_eq!(backend.connected.load(Ordering::Relaxed), 1);
-        assert_eq!(backend.described.load(Ordering::Relaxed), 1);
     }
 
     struct LocalBackend {

--- a/src/boxlite/src/litebox/network.rs
+++ b/src/boxlite/src/litebox/network.rs
@@ -95,7 +95,7 @@ impl NetworkHandle {
     ///
     /// This is the single tunnel entry point: callers that only want the raw
     /// stream use the SDK-specific `connect()` wrapper.
-    pub async fn box_tunnel(&self, target: SocketAddr) -> BoxliteResult<BoxTunnel> {
+    pub async fn tunnel(&self, target: SocketAddr) -> BoxliteResult<BoxTunnel> {
         self.network_backend.tunnel(target).await
     }
 }
@@ -147,7 +147,7 @@ mod tests {
         let target = "192.168.127.2:3000".parse().unwrap();
 
         // Obtaining the tunnel does no work — no describe, no connect.
-        let tunnel = network.box_tunnel(target).await.unwrap();
+        let tunnel = network.tunnel(target).await.unwrap();
         assert_eq!(backend.described.load(Ordering::Relaxed), 0);
         assert_eq!(backend.connected.load(Ordering::Relaxed), 0);
 
@@ -198,7 +198,7 @@ mod tests {
         }));
         let target = "192.168.127.2:3000".parse().unwrap();
 
-        let tunnel = network.box_tunnel(target).await.unwrap();
+        let tunnel = network.tunnel(target).await.unwrap();
         let endpoint = tunnel.endpoint().await.unwrap();
         assert_eq!(endpoint, None);
         let TunnelStream::Local(mut stream) = tunnel.connect().await.unwrap();

--- a/src/boxlite/src/litebox/network.rs
+++ b/src/boxlite/src/litebox/network.rs
@@ -201,9 +201,7 @@ mod tests {
         let tunnel = network.box_tunnel(target).await.unwrap();
         let endpoint = tunnel.endpoint().await.unwrap();
         assert_eq!(endpoint, None);
-        let mut stream = match tunnel.connect().await.unwrap() {
-            TunnelStream::Local(stream) => stream,
-        };
+        let TunnelStream::Local(mut stream) = tunnel.connect().await.unwrap();
         let mut peer = peer.lock().await.take().unwrap();
 
         peer.write_all(b"local").await.unwrap();

--- a/src/boxlite/src/litebox/network.rs
+++ b/src/boxlite/src/litebox/network.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use boxlite_shared::errors::{BoxliteError, BoxliteResult};
 
-use crate::net::TunnelStream;
+use crate::net::BoxInternalTunnel;
 use crate::runtime::backend::BoxNetworkBackend;
 
 /// Lazily opens the raw byte stream backing a [`BoxTunnel`]. Each backend
@@ -15,7 +15,9 @@ use crate::runtime::backend::BoxNetworkBackend;
 /// it needs (a REST client, a gvproxy handle) so the tunnel stays self-contained
 /// and the backend only has to expose `tunnel`.
 pub(crate) type TunnelConnector = Arc<
-    dyn Fn() -> Pin<Box<dyn Future<Output = BoxliteResult<TunnelStream>> + Send>> + Send + Sync,
+    dyn Fn() -> Pin<Box<dyn Future<Output = BoxliteResult<BoxInternalTunnel>> + Send>>
+        + Send
+        + Sync,
 >;
 
 /// Lazily fetches the public endpoint for a [`BoxTunnel`]. Present only for remote
@@ -23,6 +25,11 @@ pub(crate) type TunnelConnector = Arc<
 /// the describe round-trip.
 pub(crate) type TunnelUrlFetch =
     Box<dyn Fn() -> Pin<Box<dyn Future<Output = BoxliteResult<String>> + Send>> + Send + Sync>;
+
+/// Public byte-stream capability for a box service connection.
+pub trait BoxConnection: tokio::io::AsyncRead + tokio::io::AsyncWrite + Send + Unpin {}
+
+impl<T> BoxConnection for T where T: tokio::io::AsyncRead + tokio::io::AsyncWrite + Send + Unpin {}
 
 pub(crate) struct UnsupportedNetworkBackend;
 
@@ -40,7 +47,7 @@ impl BoxNetworkBackend for UnsupportedNetworkBackend {
 pub struct BoxTunnel {
     endpoint: Option<TunnelUrlFetch>,
     connector: TunnelConnector,
-    stream: Arc<tokio::sync::Mutex<Option<TunnelStream>>>,
+    stream: Arc<tokio::sync::Mutex<Option<BoxInternalTunnel>>>,
 }
 
 impl BoxTunnel {
@@ -67,13 +74,13 @@ impl BoxTunnel {
     }
 
     /// Consume the prepared local stream or establish the remote stream once.
-    pub async fn connect(&self) -> BoxliteResult<TunnelStream> {
+    pub async fn connect(&self) -> BoxliteResult<Box<dyn BoxConnection>> {
         let mut stream = self.stream.lock().await;
         if let Some(stream) = stream.take() {
-            return Ok(stream);
+            return Ok(Box::new(stream));
         }
         drop(stream);
-        (self.connector)().await
+        Ok(Box::new((self.connector)().await?))
     }
 }
 
@@ -183,7 +190,10 @@ mod tests {
                             BoxliteError::Network(format!("test socket pair failed: {error}"))
                         })?;
                         *peer.lock().await = Some(other);
-                        Ok(TunnelStream::Local(stream))
+                        Ok(BoxInternalTunnel::from_local(
+                            stream,
+                            "192.168.127.2:3000".parse().unwrap(),
+                        ))
                     })
                 }),
             ))
@@ -201,7 +211,7 @@ mod tests {
         let tunnel = network.tunnel(target).await.unwrap();
         let endpoint = tunnel.endpoint().await.unwrap();
         assert_eq!(endpoint, None);
-        let TunnelStream::Local(mut stream) = tunnel.connect().await.unwrap();
+        let mut stream = tunnel.connect().await.unwrap();
         let mut peer = peer.lock().await.take().unwrap();
 
         peer.write_all(b"local").await.unwrap();

--- a/src/boxlite/src/litebox/network.rs
+++ b/src/boxlite/src/litebox/network.rs
@@ -1,0 +1,214 @@
+//! Network sub-resource on LiteBox.
+
+use std::future::Future;
+use std::net::SocketAddr;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use boxlite_shared::errors::{BoxliteError, BoxliteResult};
+
+use crate::net::TunnelStream;
+use crate::runtime::backend::BoxNetworkBackend;
+
+/// Lazily opens the raw byte stream backing a [`BoxTunnel`]. Each backend
+/// builds one inside its [`BoxNetworkBackend::tunnel`] impl, capturing whatever
+/// it needs (a REST client, a gvproxy handle) so the tunnel stays self-contained
+/// and the backend only has to expose `tunnel`.
+pub(crate) type TunnelConnector = Arc<
+    dyn Fn() -> Pin<Box<dyn Future<Output = BoxliteResult<TunnelStream>> + Send>> + Send + Sync,
+>;
+
+/// Lazily fetches the public endpoint for a [`BoxTunnel`]. Present only for remote
+/// boxes, and invoked on demand so a caller that only connects never pays for
+/// the describe round-trip.
+pub(crate) type TunnelUrlFetch =
+    Box<dyn Fn() -> Pin<Box<dyn Future<Output = BoxliteResult<String>> + Send>> + Send + Sync>;
+
+pub(crate) struct UnsupportedNetworkBackend;
+
+#[async_trait::async_trait]
+impl BoxNetworkBackend for UnsupportedNetworkBackend {
+    async fn tunnel(&self, _target: SocketAddr) -> BoxliteResult<BoxTunnel> {
+        Err(BoxliteError::Unsupported(
+            "box networking is unavailable".into(),
+        ))
+    }
+}
+
+/// A box service tunnel target. Call [`endpoint`](Self::endpoint) first, then
+/// [`connect`](Self::connect) on this handle.
+pub struct BoxTunnel {
+    endpoint: Option<TunnelUrlFetch>,
+    connector: TunnelConnector,
+    stream: Arc<tokio::sync::Mutex<Option<TunnelStream>>>,
+}
+
+impl BoxTunnel {
+    pub(crate) fn new(url: Option<TunnelUrlFetch>, connector: TunnelConnector) -> Self {
+        Self {
+            endpoint: url,
+            connector,
+            stream: Arc::new(tokio::sync::Mutex::new(None)),
+        }
+    }
+
+    /// Resolve the endpoint, fetching a URL remotely or preparing a local stream.
+    pub async fn endpoint(&self) -> BoxliteResult<Option<String>> {
+        match &self.endpoint {
+            Some(fetch) => Ok(Some(fetch().await?)),
+            None => {
+                let mut stream = self.stream.lock().await;
+                if stream.is_none() {
+                    *stream = Some((self.connector)().await?);
+                }
+                Ok(None)
+            }
+        }
+    }
+
+    /// Consume the prepared local stream or establish the remote stream once.
+    pub async fn connect(&self) -> BoxliteResult<TunnelStream> {
+        let mut stream = self.stream.lock().await;
+        if let Some(stream) = stream.take() {
+            return Ok(stream);
+        }
+        drop(stream);
+        (self.connector)().await
+    }
+}
+
+/// Handle for network operations on a LiteBox.
+///
+/// Obtained via `litebox.network()`. Owns backend handles and can be used
+/// independently from the originating `LiteBox` borrow.
+pub struct NetworkHandle {
+    network_backend: Arc<dyn BoxNetworkBackend>,
+}
+
+impl NetworkHandle {
+    pub(crate) fn new(network_backend: Arc<dyn BoxNetworkBackend>) -> Self {
+        Self { network_backend }
+    }
+
+    /// Describe a tunnel target, returning a [`BoxTunnel`] with endpoint and
+    /// connection operations for both local and remote boxes.
+    ///
+    /// This is the single tunnel entry point: callers that only want the raw
+    /// stream use the SDK-specific `connect()` wrapper.
+    pub async fn box_tunnel(&self, target: SocketAddr) -> BoxliteResult<BoxTunnel> {
+        self.network_backend.tunnel(target).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use boxlite_shared::errors::BoxliteError;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::UnixStream;
+
+    use super::*;
+
+    #[derive(Default)]
+    struct TestBackend {
+        described: Arc<AtomicUsize>,
+        connected: Arc<AtomicUsize>,
+    }
+
+    #[async_trait::async_trait]
+    impl BoxNetworkBackend for TestBackend {
+        async fn tunnel(&self, _target: SocketAddr) -> BoxliteResult<BoxTunnel> {
+            let described = Arc::clone(&self.described);
+            let connected = Arc::clone(&self.connected);
+            Ok(BoxTunnel::new(
+                Some(Box::new(move || {
+                    let described = Arc::clone(&described);
+                    Box::pin(async move {
+                        described.fetch_add(1, Ordering::Relaxed);
+                        Ok("https://3000-box.proxy.example.test".to_string())
+                    })
+                })),
+                Arc::new(move || {
+                    let connected = Arc::clone(&connected);
+                    Box::pin(async move {
+                        connected.fetch_add(1, Ordering::Relaxed);
+                        Err(BoxliteError::Unsupported("test tunnel".to_string()))
+                    })
+                }),
+            ))
+        }
+    }
+
+    #[tokio::test]
+    async fn box_tunnel_fetches_url_and_connects_lazily() {
+        let backend = Arc::new(TestBackend::default());
+        let network = NetworkHandle::new(backend.clone());
+        let target = "192.168.127.2:3000".parse().unwrap();
+
+        // Obtaining the tunnel does no work — no describe, no connect.
+        let tunnel = network.box_tunnel(target).await.unwrap();
+        assert_eq!(backend.described.load(Ordering::Relaxed), 0);
+        assert_eq!(backend.connected.load(Ordering::Relaxed), 0);
+
+        // endpoint() triggers exactly one describe; connect() remains separate.
+        let endpoint = tunnel.endpoint().await.unwrap();
+        assert_eq!(
+            endpoint.as_deref(),
+            Some("https://3000-box.proxy.example.test")
+        );
+        assert_eq!(backend.described.load(Ordering::Relaxed), 1);
+        assert_eq!(backend.connected.load(Ordering::Relaxed), 0);
+
+        // Connecting the tunnel triggers exactly one connect.
+        assert!(tunnel.connect().await.is_err());
+        assert_eq!(backend.connected.load(Ordering::Relaxed), 1);
+        assert_eq!(backend.described.load(Ordering::Relaxed), 1);
+    }
+
+    struct LocalBackend {
+        peer: Arc<tokio::sync::Mutex<Option<UnixStream>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl BoxNetworkBackend for LocalBackend {
+        async fn tunnel(&self, _target: SocketAddr) -> BoxliteResult<BoxTunnel> {
+            let peer = Arc::clone(&self.peer);
+            Ok(BoxTunnel::new(
+                None,
+                Arc::new(move || {
+                    let peer = Arc::clone(&peer);
+                    Box::pin(async move {
+                        let (stream, other) = UnixStream::pair().map_err(|error| {
+                            BoxliteError::Network(format!("test socket pair failed: {error}"))
+                        })?;
+                        *peer.lock().await = Some(other);
+                        Ok(TunnelStream::Local(stream))
+                    })
+                }),
+            ))
+        }
+    }
+
+    #[tokio::test]
+    async fn local_box_uses_the_same_endpoint_then_connect_flow() {
+        let peer = Arc::new(tokio::sync::Mutex::new(None));
+        let network = NetworkHandle::new(Arc::new(LocalBackend {
+            peer: Arc::clone(&peer),
+        }));
+        let target = "192.168.127.2:3000".parse().unwrap();
+
+        let tunnel = network.box_tunnel(target).await.unwrap();
+        let endpoint = tunnel.endpoint().await.unwrap();
+        assert_eq!(endpoint, None);
+        let mut stream = match tunnel.connect().await.unwrap() {
+            TunnelStream::Local(stream) => stream,
+        };
+        let mut peer = peer.lock().await.take().unwrap();
+
+        peer.write_all(b"local").await.unwrap();
+        let mut response = [0; 5];
+        stream.read_exact(&mut response).await.unwrap();
+        assert_eq!(&response, b"local");
+    }
+}

--- a/src/boxlite/src/net/gvproxy/services.rs
+++ b/src/boxlite/src/net/gvproxy/services.rs
@@ -28,8 +28,8 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::UnixStream;
 
 use crate::net::{
-    BoxTunnel, DnsZoneSpec, Forward, NetworkBackend, NetworkBackendConfig, NetworkBackendSpec,
-    NetworkBackendStats, TransportProtocol,
+    BoxInternalTunnel, DnsZoneSpec, Forward, NetworkBackend, NetworkBackendConfig,
+    NetworkBackendSpec, NetworkBackendStats, TransportProtocol,
 };
 
 /// Upper bound on a single control exchange. A bound-but-unserved socket (the
@@ -252,7 +252,7 @@ impl NetworkBackend for GvproxyBackend {
         parse_stats(&body)
     }
 
-    async fn tunnel(&self, target: SocketAddr) -> BoxliteResult<BoxTunnel> {
+    async fn tunnel(&self, target: SocketAddr) -> BoxliteResult<BoxInternalTunnel> {
         // `/tunnel` hijacks the HTTP connection — no HTTP response is returned —
         // so we speak it raw (not via hyper): send gvproxy's request, read its
         // literal "OK" ack, and the socket becomes a raw pipe to the guest target.
@@ -297,7 +297,7 @@ impl NetworkBackend for GvproxyBackend {
             )));
         }
 
-        Ok(BoxTunnel::from_local(stream, target))
+        Ok(BoxInternalTunnel::from_local(stream, target))
     }
 }
 

--- a/src/boxlite/src/net/mod.rs
+++ b/src/boxlite/src/net/mod.rs
@@ -225,7 +225,7 @@ impl NetworkBackendStats {
 /// erasing to `Box<dyn>`) is deliberate: the local variant can hand its raw OS fd
 /// to an SDK with no unsafe downcast, and split lock-free. Mirrors pingora's
 /// `enum RawStream` and tungstenite's `MaybeTlsStream`.
-pub enum TunnelStream {
+pub(crate) enum TunnelStream {
     /// A raw unix-socket pipe to a same-host backend (gvproxy `/tunnel`).
     Local(UnixStream),
 }
@@ -257,10 +257,6 @@ impl BoxInternalTunnel {
     /// The guest `ip:port` this tunnel targets.
     pub fn peer_addr(&self) -> SocketAddr {
         self.peer
-    }
-
-    pub(crate) fn into_stream(self) -> TunnelStream {
-        self.stream
     }
 
     /// Recover the tunnel's owned OS file descriptor — the transport-agnostic

--- a/src/boxlite/src/net/mod.rs
+++ b/src/boxlite/src/net/mod.rs
@@ -219,13 +219,13 @@ impl NetworkBackendStats {
     }
 }
 
-/// The transport backing a [`BoxTunnel`] — a small, closed set (one variant per
+/// The transport backing a [`BoxInternalTunnel`] — a small, closed set (one variant per
 /// transport). Only the local gvproxy unix socket exists today; a cloud WS/TLS
 /// variant lands with the cloud data plane. Keeping the concrete type (rather than
 /// erasing to `Box<dyn>`) is deliberate: the local variant can hand its raw OS fd
 /// to an SDK with no unsafe downcast, and split lock-free. Mirrors pingora's
 /// `enum RawStream` and tungstenite's `MaybeTlsStream`.
-enum TunnelStream {
+pub enum TunnelStream {
     /// A raw unix-socket pipe to a same-host backend (gvproxy `/tunnel`).
     Local(UnixStream),
 }
@@ -240,12 +240,12 @@ enum TunnelStream {
 /// touching [`NetworkBackend::tunnel`]'s signature. `peer_addr()` is the guest
 /// target; [`into_fd`](Self::into_fd) recovers the tunnel's owned OS fd — the
 /// transport-agnostic handle an SDK wraps as a native socket.
-pub struct BoxTunnel {
+pub struct BoxInternalTunnel {
     stream: TunnelStream,
     peer: SocketAddr,
 }
 
-impl BoxTunnel {
+impl BoxInternalTunnel {
     /// Wrap a same-host unix-socket tunnel already connected to `peer`.
     pub fn from_local(stream: UnixStream, peer: SocketAddr) -> Self {
         Self {
@@ -257,6 +257,10 @@ impl BoxTunnel {
     /// The guest `ip:port` this tunnel targets.
     pub fn peer_addr(&self) -> SocketAddr {
         self.peer
+    }
+
+    pub(crate) fn into_stream(self) -> TunnelStream {
+        self.stream
     }
 
     /// Recover the tunnel's owned OS file descriptor — the transport-agnostic
@@ -272,15 +276,15 @@ impl BoxTunnel {
     }
 }
 
-impl std::fmt::Debug for BoxTunnel {
+impl std::fmt::Debug for BoxInternalTunnel {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("BoxTunnel")
+        f.debug_struct("BoxInternalTunnel")
             .field("peer", &self.peer)
             .finish_non_exhaustive()
     }
 }
 
-impl AsyncRead for BoxTunnel {
+impl AsyncRead for BoxInternalTunnel {
     fn poll_read(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
@@ -292,7 +296,7 @@ impl AsyncRead for BoxTunnel {
     }
 }
 
-impl AsyncWrite for BoxTunnel {
+impl AsyncWrite for BoxInternalTunnel {
     fn poll_write(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
@@ -405,9 +409,9 @@ pub trait NetworkBackend: Send + Sync + std::fmt::Debug {
     }
 
     /// Open a raw byte tunnel to the guest `target` (the data plane, as opposed
-    /// to the control methods above). Returns a [`BoxTunnel`] the caller
+    /// to the control methods above). Returns a [`BoxInternalTunnel`] the caller
     /// reads/writes directly. Backends without a tunnel inherit `Unsupported`.
-    async fn tunnel(&self, _target: SocketAddr) -> BoxliteResult<BoxTunnel> {
+    async fn tunnel(&self, _target: SocketAddr) -> BoxliteResult<BoxInternalTunnel> {
         Err(control_unsupported("tunnel"))
     }
 }
@@ -662,12 +666,12 @@ mod tests {
     async fn box_tunnel_pipes_bytes_and_carries_peer() {
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
-        // A BoxTunnel over a real unix socketpair: bytes must cross its AsyncRead/
+        // A BoxInternalTunnel over a real unix socketpair: bytes must cross its AsyncRead/
         // AsyncWrite dispatch in both directions, the peer is carried out-of-band,
         // and the concrete local stream stays recoverable (the SDK fd-bridge relies on it).
         let (near, mut far) = UnixStream::pair().unwrap();
         let peer: SocketAddr = "192.168.127.2:8080".parse().unwrap();
-        let mut tunnel = BoxTunnel::from_local(near, peer);
+        let mut tunnel = BoxInternalTunnel::from_local(near, peer);
 
         assert_eq!(tunnel.peer_addr(), peer);
 

--- a/src/boxlite/src/rest/litebox.rs
+++ b/src/boxlite/src/rest/litebox.rs
@@ -15,7 +15,7 @@ use crate::litebox::copy::CopyOptions;
 use crate::litebox::snapshot_mgr::SnapshotInfo;
 use crate::litebox::{BoxCommand, ExecResult, ExecStderr, ExecStdin, ExecStdout, Execution};
 use crate::metrics::BoxMetrics;
-use crate::runtime::backend::{BoxBackend, SnapshotBackend};
+use crate::runtime::backend::{BoxBackend, BoxNetworkBackend, SnapshotBackend};
 use crate::runtime::id::BoxID;
 use crate::runtime::options::{CloneOptions, ExportOptions, SnapshotOptions};
 
@@ -317,7 +317,13 @@ impl BoxBackend for RestBox {
         let rest_box = Arc::new(RestBox::new(self.client.clone(), info));
         let box_backend: Arc<dyn BoxBackend> = rest_box.clone();
         let snapshot_backend: Arc<dyn SnapshotBackend> = rest_box;
-        Ok(crate::LiteBox::new(box_backend, snapshot_backend))
+        let network_backend: Arc<dyn BoxNetworkBackend> =
+            Arc::new(crate::runtime::backend::UnsupportedNetworkBackend);
+        Ok(crate::LiteBox::new(
+            box_backend,
+            network_backend,
+            snapshot_backend,
+        ))
     }
 
     async fn clone_boxes(

--- a/src/boxlite/src/rest/runtime.rs
+++ b/src/boxlite/src/rest/runtime.rs
@@ -36,7 +36,9 @@ impl AuthBackend for RestRuntime {
 fn litebox_from_rest(rest_box: Arc<RestBox>) -> LiteBox {
     let box_backend: Arc<dyn crate::runtime::backend::BoxBackend> = rest_box.clone();
     let snapshot_backend: Arc<dyn crate::runtime::backend::SnapshotBackend> = rest_box;
-    LiteBox::new(box_backend, snapshot_backend)
+    let network_backend: Arc<dyn crate::runtime::backend::BoxNetworkBackend> =
+        Arc::new(crate::runtime::backend::UnsupportedNetworkBackend);
+    LiteBox::new(box_backend, network_backend, snapshot_backend)
 }
 
 #[async_trait::async_trait]

--- a/src/boxlite/src/runtime/backend.rs
+++ b/src/boxlite/src/runtime/backend.rs
@@ -139,6 +139,18 @@ pub(crate) trait BoxNetworkBackend: Send + Sync {
     async fn tunnel(&self, target: SocketAddr) -> BoxliteResult<BoxTunnel>;
 }
 
+/// Network backend used when the current runtime does not provide networking.
+pub(crate) struct UnsupportedNetworkBackend;
+
+#[async_trait]
+impl BoxNetworkBackend for UnsupportedNetworkBackend {
+    async fn tunnel(&self, _target: SocketAddr) -> BoxliteResult<BoxTunnel> {
+        Err(BoxliteError::Unsupported(
+            "box networking is unavailable".into(),
+        ))
+    }
+}
+
 /// Backend abstraction for snapshot lifecycle operations on a box.
 ///
 /// Kept separate from `BoxBackend` so lifecycle/exec/file operations can evolve

--- a/src/boxlite/src/runtime/backend.rs
+++ b/src/boxlite/src/runtime/backend.rs
@@ -1,12 +1,13 @@
 //! Runtime backend trait — internal abstraction for local vs REST execution.
 
+use std::net::SocketAddr;
 use std::path::Path;
 
 use async_trait::async_trait;
 
 use crate::litebox::copy::CopyOptions;
 use crate::litebox::snapshot_mgr::SnapshotInfo;
-use crate::litebox::{BoxCommand, Execution, LiteBox};
+use crate::litebox::{BoxCommand, BoxTunnel, Execution, LiteBox};
 use crate::metrics::{BoxMetrics, RuntimeMetrics};
 use crate::runtime::options::{
     BoxArchive, BoxOptions, CloneOptions, ExportOptions, SnapshotOptions,
@@ -124,6 +125,18 @@ pub(crate) trait BoxBackend: Send + Sync {
     ) -> BoxliteResult<Vec<LiteBox>>;
 
     async fn export_box(&self, options: ExportOptions, dest: &Path) -> BoxliteResult<BoxArchive>;
+}
+
+/// Backend abstraction for box network operations.
+///
+/// Kept separate from `BoxBackend` so lifecycle/exec/file operations do not own
+/// network data-plane capabilities directly.
+#[async_trait]
+pub(crate) trait BoxNetworkBackend: Send + Sync {
+    /// Describe a tunnel target, returning a self-contained [`BoxTunnel`]:
+    /// remote backends attach a public URL, and either kind can lazily open
+    /// the raw byte stream via [`BoxTunnel::connect`].
+    async fn tunnel(&self, target: SocketAddr) -> BoxliteResult<BoxTunnel>;
 }
 
 /// Backend abstraction for snapshot lifecycle operations on a box.

--- a/src/boxlite/src/runtime/rt_impl.rs
+++ b/src/boxlite/src/runtime/rt_impl.rs
@@ -25,7 +25,7 @@ fn litebox_from_impl(box_impl: SharedBoxImpl) -> LiteBox {
     let network_backend: Arc<dyn crate::runtime::backend::BoxNetworkBackend> = box_impl.clone();
     let snapshot_backend: Arc<dyn crate::runtime::backend::SnapshotBackend> =
         Arc::new(LocalSnapshotBackend::new(box_impl));
-    LiteBox::new_with_network(box_backend, network_backend, snapshot_backend)
+    LiteBox::new(box_backend, network_backend, snapshot_backend)
 }
 
 /// Archive the active exit file as `exit.previous`, freeing the canonical

--- a/src/boxlite/src/runtime/rt_impl.rs
+++ b/src/boxlite/src/runtime/rt_impl.rs
@@ -22,9 +22,10 @@ use tokio_util::sync::CancellationToken;
 
 fn litebox_from_impl(box_impl: SharedBoxImpl) -> LiteBox {
     let box_backend: Arc<dyn crate::runtime::backend::BoxBackend> = box_impl.clone();
+    let network_backend: Arc<dyn crate::runtime::backend::BoxNetworkBackend> = box_impl.clone();
     let snapshot_backend: Arc<dyn crate::runtime::backend::SnapshotBackend> =
         Arc::new(LocalSnapshotBackend::new(box_impl));
-    LiteBox::new(box_backend, snapshot_backend)
+    LiteBox::new_with_network(box_backend, network_backend, snapshot_backend)
 }
 
 /// Archive the active exit file as `exit.previous`, freeing the canonical


### PR DESCRIPTION
Expose a unified Rust network tunnel handle for local and REST-backed boxes.

Test plan:
- [x] cargo check -p boxlite --features rest --no-default-features

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added box network tunneling with lazy endpoint discovery (public URL vs local stream) and on-demand tunnel connection.
  * Exposed network tunneling via the LiteBox API with a new network handle and tunnel endpoint/connection support.
  * Added REST-based tunneling using HTTP CONNECT.
* **Bug Fixes**
  * Improved WebSocket URL handling, including query parameters and correct scheme mapping.
  * Networking-disabled configurations now return an unsupported-operation error.
* **Tests**
  * Added coverage to ensure endpoint discovery and tunnel connection are performed lazily and separately.
* **Chores**
  * Updated REST HTTP/TLS and connection setup (HTTP/1, native Rustls certificates).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->