### PR TITLE
feat(core): expose box network tunnels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,6 +196,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
 name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -470,6 +493,7 @@ dependencies = [
  "hex",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "inventory",
  "landlock",
@@ -493,6 +517,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rusqlite",
+ "rustls",
  "seccompiler",
  "serde",
  "serde_json",
@@ -902,6 +927,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "colorchoice"
@@ -1392,6 +1426,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1655,6 +1695,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fsevent-sys"
@@ -2107,7 +2153,9 @@ dependencies = [
  "http",
  "hyper",
  "hyper-util",
+ "log",
  "rustls",
+ "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -3800,6 +3848,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4968,12 +5022,26 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -4992,6 +5060,7 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -5037,6 +5106,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5108,6 +5186,29 @@ checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
 dependencies = [
  "serde",
  "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]

--- a/docs/reference/cli/README.md
+++ b/docs/reference/cli/README.md
@@ -32,6 +32,7 @@ For a quick start, see [`src/cli/README.md`](../../../src/cli/README.md).
   - [`boxlite info`](#boxlite-info)
   - [`boxlite logs`](#boxlite-logs)
   - [`boxlite stats`](#boxlite-stats)
+  - [`boxlite tunnel`](#boxlite-tunnel)
   - [`boxlite serve`](#boxlite-serve)
   - [`boxlite completion`](#boxlite-completion)
 - [Shared Flag Groups](#shared-flag-groups)
@@ -526,6 +527,15 @@ Display resource usage statistics for a box.
 |------|-------|---------|-------------|
 | `--format FMT` | — | `table` | Output format (see [Output Formats](#output-formats)) |
 | `--stream` | `-s` | `false` | Refresh every second until Ctrl-C |
+
+---
+
+### `boxlite tunnel`
+
+**Synopsis:** `boxlite tunnel BOX PORT`
+
+Print the public URL for a box service port. Requires a remote REST profile
+(`--url` or `--profile`); local boxes have no public ingress.
 
 ---
 

--- a/openapi/box.openapi.yaml
+++ b/openapi/box.openapi.yaml
@@ -842,8 +842,7 @@ paths:
       operationId: describeBoxTunnel
       summary: Prepare a box service tunnel connection
       description: |
-        Returns the public service URI, CONNECT proxy URI, and a short-lived
-        single-use CONNECT credential.
+        Returns the URI used to establish the box service tunnel.
       tags: [Network]
       responses:
         "200":

--- a/openapi/box.openapi.yaml
+++ b/openapi/box.openapi.yaml
@@ -20,7 +20,8 @@ info:
   description: |
     HTTP API for BoxLite boxes — hardware-isolated VMs for secure code
     execution. Exposes box lifecycle management, command execution, file
-    transfer, and image management as a multi-tenant service.
+    transfer, service tunnels, and image management as a multi-tenant
+    service.
 
     ## Design Principles
 
@@ -123,10 +124,10 @@ tags:
     description: Command execution and streaming
   - name: Files
     description: File upload and download
-  - name: Metrics
-    description: Runtime and per-box metrics
   - name: Network
     description: Box networking and service access
+  - name: Metrics
+    description: Runtime and per-box metrics
   - name: Images
     description: Container image management
 
@@ -541,7 +542,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Box"
         "400":
-          $ref: "#/components/responses/ValidationError"
+          $ref: "#/components/responses/BadRequestError"
 
   # -------------------------------------------------------------------------
   # Execution
@@ -829,32 +830,44 @@ paths:
     parameters:
       - $ref: "#/components/parameters/prefix"
       - $ref: "#/components/parameters/boxId"
-      - name: port
-        in: query
-        required: true
-        description: TCP port listened to by the service inside the box
-        schema:
-          type: integer
-          minimum: 1
-          maximum: 65535
-        example: 3000
     post:
-      operationId: describeBoxTunnel
-      summary: Prepare a box service tunnel connection
+      operationId: prepareTunnel
+      summary: Prepare a box service tunnel
       description: |
-        Returns the URI used to establish the box service tunnel.
+        Returns the public URI for a TCP service inside the box.
+        Safe to repeat: the server may provision tunnel routing on
+        first call and returns the current descriptor thereafter.
+
+        HTTP services are reachable directly at the URI. For a raw
+        TCP byte stream to the service port, clients connect to the
+        URI and issue an HTTP/1.1 `CONNECT` for its authority; the
+        host upgrades each accepted `CONNECT` into one connection to
+        the in-box service. `CONNECT` is a transport handshake on the
+        URI's host, not an operation of this API.
       tags: [Network]
+      parameters:
+        - name: port
+          in: query
+          required: true
+          description: TCP port the service listens on inside the box
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 65535
+          example: 3000
       responses:
         "200":
           description: Service tunnel descriptor
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/BoxServiceEndpoint"
+                $ref: "#/components/schemas/TunnelDescriptor"
         "400":
           $ref: "#/components/responses/BadRequestError"
         "404":
           $ref: "#/components/responses/NotFoundError"
+        "409":
+          $ref: "#/components/responses/ConflictError"
 
   # -------------------------------------------------------------------------
   # Metrics
@@ -1293,15 +1306,6 @@ components:
               type: string
               description: How long idempotency keys are retained (ISO 8601 duration)
               example: PT24H
-
-    BoxServiceEndpoint:
-      type: object
-      required: [uri]
-      properties:
-        uri:
-          type: string
-          format: uri
-          description: Public URI for the box service.
 
     # =======================================================================
     # Authentication
@@ -1927,6 +1931,22 @@ components:
           minimum: 1
           description: Terminal height in rows
           example: 40
+
+    # =======================================================================
+    # Network
+    # =======================================================================
+    TunnelDescriptor:
+      type: object
+      description: Public descriptor for a box service tunnel.
+      required: [uri]
+      properties:
+        uri:
+          type: string
+          format: uri
+          description: |
+            Public URI for the box service. Clients MUST treat the
+            value as opaque — its shape is deployment-defined.
+          example: "https://3000-01hjk4tnrpqsxyz8wm6ncvt9r5.proxy.example.test"
 
     # =======================================================================
     # Metrics

--- a/openapi/box.openapi.yaml
+++ b/openapi/box.openapi.yaml
@@ -125,6 +125,8 @@ tags:
     description: File upload and download
   - name: Metrics
     description: Runtime and per-box metrics
+  - name: Network
+    description: Box networking and service access
   - name: Images
     description: Container image management
 
@@ -821,6 +823,41 @@ paths:
           $ref: "#/components/responses/ConflictError"
 
   # -------------------------------------------------------------------------
+  # Network
+  # -------------------------------------------------------------------------
+  /{prefix}/boxes/{box_id}/network/tunnel:
+    parameters:
+      - $ref: "#/components/parameters/prefix"
+      - $ref: "#/components/parameters/boxId"
+      - name: port
+        in: query
+        required: true
+        description: TCP port listened to by the service inside the box
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 65535
+        example: 3000
+    post:
+      operationId: describeBoxTunnel
+      summary: Prepare a box service tunnel connection
+      description: |
+        Returns the public service URI, CONNECT proxy URI, and a short-lived
+        single-use CONNECT credential.
+      tags: [Network]
+      responses:
+        "200":
+          description: Service tunnel descriptor
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BoxServiceEndpoint"
+        "400":
+          $ref: "#/components/responses/BadRequestError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+
+  # -------------------------------------------------------------------------
   # Metrics
   # -------------------------------------------------------------------------
   /{prefix}/metrics:
@@ -1257,6 +1294,15 @@ components:
               type: string
               description: How long idempotency keys are retained (ISO 8601 duration)
               example: PT24H
+
+    BoxServiceEndpoint:
+      type: object
+      required: [uri]
+      properties:
+        uri:
+          type: string
+          format: uri
+          description: Public URI for the box service.
 
     # =======================================================================
     # Authentication

--- a/src/boxlite/Cargo.toml
+++ b/src/boxlite/Cargo.toml
@@ -29,7 +29,7 @@ bubblewrap = ["dep:bubblewrap-sys"]                          # Bundled bwrap for
 krunfw = ["dep:libkrun-sys", "libkrun-sys/krunfw"]           # Package libkrunfw artifacts
 krunfw-source = ["krunfw", "libkrun-sys/krunfw-source"]      # Package source-built raw kernel and shared library; static musl packages only the raw kernel
 krun = ["krunfw", "libkrun-sys/krun"]                         # Compile the vendored libkrun runtime (and package required libkrunfw artifacts)
-rest = ["dep:reqwest", "dep:urlencoding", "dep:tokio-tungstenite"]  # REST API client backend
+rest = ["dep:hyper-rustls", "dep:reqwest", "dep:rustls", "dep:urlencoding", "dep:tokio-tungstenite"]  # REST API client backend
 embedded-runtime = []                                        # Embed runtime binaries via include_bytes!
 test-support = []                                            # Expose internal constructors for cross-crate tests
 
@@ -54,6 +54,8 @@ tower = "0.5"
 hyper-util = { version = "0.1", features = ["tokio"] }
 # gvproxy ServicesMux control client (HTTP/1.1 over the per-box unix socket).
 hyper = { version = "1", features = ["client", "http1"] }
+hyper-rustls = { version = "0.27", features = ["http1", "rustls-native-certs"], optional = true }
+rustls = { version = "0.23", default-features = false, features = ["aws_lc_rs"], optional = true }
 http-body-util = "0.1"
 bytes = "1"
 uuid = { version = "1.10", features = ["v4"] }

--- a/src/boxlite/src/litebox/box_impl.rs
+++ b/src/boxlite/src/litebox/box_impl.rs
@@ -1181,10 +1181,7 @@ impl crate::runtime::backend::BoxNetworkBackend for BoxImpl {
             .network
             .clone()
             .ok_or_else(|| BoxliteError::Unsupported("box networking is disabled".into()))?;
-        Ok(BoxTunnel::new(None, move || {
-            let network = Arc::clone(&network);
-            async move { network.tunnel(target).await }
-        }))
+        BoxTunnel::local(network.tunnel(target).await?).await
     }
 }
 

--- a/src/boxlite/src/litebox/box_impl.rs
+++ b/src/boxlite/src/litebox/box_impl.rs
@@ -44,6 +44,16 @@ use crate::{BoxID, BoxInfo, HealthCheckOptions, HealthState};
 /// Shared reference to BoxImpl.
 pub type SharedBoxImpl = Arc<BoxImpl>;
 
+async fn create_local_tunnel(
+    network: Arc<dyn NetworkBackend>,
+    target: SocketAddr,
+) -> BoxliteResult<BoxTunnel> {
+    Ok(BoxTunnel::new(None, move || {
+        let network = Arc::clone(&network);
+        async move { network.tunnel(target).await }
+    }))
+}
+
 // ============================================================================
 // LIVE STATE
 // ============================================================================
@@ -1175,21 +1185,13 @@ impl crate::runtime::backend::BoxBackend for BoxImpl {
 #[async_trait::async_trait]
 impl crate::runtime::backend::BoxNetworkBackend for BoxImpl {
     async fn tunnel(&self, target: SocketAddr) -> BoxliteResult<BoxTunnel> {
-        // Local boxes have no public URL; the tunnel carries a connector that
-        // opens the raw stream through the guest-network backend on demand.
         let network = self
             .live_state()
             .await?
             .network
             .clone()
             .ok_or_else(|| BoxliteError::Unsupported("box networking is disabled".into()))?;
-        Ok(BoxTunnel::new(
-            None,
-            Arc::new(move || {
-                let network = Arc::clone(&network);
-                Box::pin(async move { network.tunnel(target).await })
-            }),
-        ))
+        create_local_tunnel(network, target).await
     }
 }
 

--- a/src/boxlite/src/litebox/box_impl.rs
+++ b/src/boxlite/src/litebox/box_impl.rs
@@ -1181,7 +1181,9 @@ impl crate::runtime::backend::BoxNetworkBackend for BoxImpl {
             .network
             .clone()
             .ok_or_else(|| BoxliteError::Unsupported("box networking is disabled".into()))?;
-        BoxTunnel::local(network.tunnel(target).await?).await
+        Ok(BoxTunnel::local(
+            network.tunnel(target).await?.into_owned_fd()?,
+        ))
     }
 }
 

--- a/src/boxlite/src/litebox/box_impl.rs
+++ b/src/boxlite/src/litebox/box_impl.rs
@@ -44,16 +44,6 @@ use crate::{BoxID, BoxInfo, HealthCheckOptions, HealthState};
 /// Shared reference to BoxImpl.
 pub type SharedBoxImpl = Arc<BoxImpl>;
 
-async fn create_local_tunnel(
-    network: Arc<dyn NetworkBackend>,
-    target: SocketAddr,
-) -> BoxliteResult<BoxTunnel> {
-    Ok(BoxTunnel::new(None, move || {
-        let network = Arc::clone(&network);
-        async move { network.tunnel(target).await }
-    }))
-}
-
 // ============================================================================
 // LIVE STATE
 // ============================================================================
@@ -1191,7 +1181,10 @@ impl crate::runtime::backend::BoxNetworkBackend for BoxImpl {
             .network
             .clone()
             .ok_or_else(|| BoxliteError::Unsupported("box networking is disabled".into()))?;
-        create_local_tunnel(network, target).await
+        Ok(BoxTunnel::new(None, move || {
+            let network = Arc::clone(&network);
+            async move { network.tunnel(target).await }
+        }))
     }
 }
 

--- a/src/boxlite/src/litebox/mod.rs
+++ b/src/boxlite/src/litebox/mod.rs
@@ -21,7 +21,7 @@ pub use copy::CopyOptions;
 pub(crate) use crash_report::CrashReport;
 pub use exec::{BoxCommand, ExecResult, ExecStderr, ExecStdin, ExecStdout, Execution, ExecutionId};
 pub(crate) use manager::BoxManager;
-pub use network::{BoxConnection, BoxTunnel, NetworkHandle};
+pub use network::{BoxConnection, BoxEndpoint, BoxTunnel, NetworkHandle};
 pub use snapshot::SnapshotHandle;
 pub use state::{BoxState, BoxStatus, HealthState, HealthStatus};
 

--- a/src/boxlite/src/litebox/network.rs
+++ b/src/boxlite/src/litebox/network.rs
@@ -24,13 +24,15 @@ impl<T> BoxConnection for T where T: tokio::io::AsyncRead + tokio::io::AsyncWrit
 
 enum TunnelState {
     LocalReady(OwnedFd),
-    RemoteReady(Box<dyn BoxConnection>),
+    RemoteReady {
+        uri: String,
+        connection: Box<dyn BoxConnection>,
+    },
     Connected,
 }
 
 /// A one-shot box service tunnel target.
 pub struct BoxTunnel {
-    uri: Option<String>,
     state: tokio::sync::Mutex<TunnelState>,
 }
 
@@ -39,9 +41,8 @@ impl BoxTunnel {
     where
         C: BoxConnection + 'static,
     {
-        let fd = connection_fd(Box::new(connection)).await?;
+        let fd = connection_fd(connection).await?;
         Ok(Self {
-            uri: None,
             state: tokio::sync::Mutex::new(TunnelState::LocalReady(fd)),
         })
     }
@@ -51,8 +52,10 @@ impl BoxTunnel {
         C: BoxConnection + 'static,
     {
         Self {
-            uri: Some(uri),
-            state: tokio::sync::Mutex::new(TunnelState::RemoteReady(Box::new(connection))),
+            state: tokio::sync::Mutex::new(TunnelState::RemoteReady {
+                uri,
+                connection: Box::new(connection),
+            }),
         }
     }
 
@@ -60,11 +63,7 @@ impl BoxTunnel {
     pub async fn endpoint(&self) -> BoxliteResult<BoxEndpoint> {
         match &*self.state.lock().await {
             TunnelState::LocalReady(fd) => Ok(BoxEndpoint::FileDescriptor(fd.as_raw_fd())),
-            TunnelState::RemoteReady(_) => Ok(BoxEndpoint::Uri(
-                self.uri
-                    .clone()
-                    .expect("remote tunnel must have a URI endpoint"),
-            )),
+            TunnelState::RemoteReady { uri, .. } => Ok(BoxEndpoint::Uri(uri.clone())),
             TunnelState::Connected => Err(BoxliteError::InvalidState(
                 "tunnel connection has already been consumed".into(),
             )),
@@ -86,7 +85,7 @@ impl BoxTunnel {
                         BoxliteError::Network(format!("open tunnel descriptor: {error}"))
                     })
             }
-            TunnelState::RemoteReady(connection) => Ok(connection),
+            TunnelState::RemoteReady { connection, .. } => Ok(connection),
             TunnelState::Connected => Err(BoxliteError::InvalidState(
                 "tunnel connection has already been consumed".into(),
             )),
@@ -94,7 +93,10 @@ impl BoxTunnel {
     }
 }
 
-async fn connection_fd(mut connection: Box<dyn BoxConnection>) -> BoxliteResult<OwnedFd> {
+async fn connection_fd<C>(mut connection: C) -> BoxliteResult<OwnedFd>
+where
+    C: BoxConnection + 'static,
+{
     let (sdk, mut bridge) = tokio::net::UnixStream::pair().map_err(|error| {
         BoxliteError::Network(format!("create tunnel descriptor bridge: {error}"))
     })?;

--- a/src/boxlite/src/litebox/network.rs
+++ b/src/boxlite/src/litebox/network.rs
@@ -24,6 +24,7 @@ impl<T> BoxConnection for T where T: tokio::io::AsyncRead + tokio::io::AsyncWrit
 
 enum TunnelState {
     LocalReady(OwnedFd),
+    #[cfg(feature = "rest")]
     RemoteReady {
         uri: String,
         connection: Box<dyn BoxConnection>,
@@ -47,6 +48,7 @@ impl BoxTunnel {
         })
     }
 
+    #[cfg(feature = "rest")]
     pub(crate) fn remote<C>(uri: String, connection: C) -> Self
     where
         C: BoxConnection + 'static,
@@ -63,6 +65,7 @@ impl BoxTunnel {
     pub async fn endpoint(&self) -> BoxliteResult<BoxEndpoint> {
         match &*self.state.lock().await {
             TunnelState::LocalReady(fd) => Ok(BoxEndpoint::FileDescriptor(fd.as_raw_fd())),
+            #[cfg(feature = "rest")]
             TunnelState::RemoteReady { uri, .. } => Ok(BoxEndpoint::Uri(uri.clone())),
             TunnelState::Connected => Err(BoxliteError::InvalidState(
                 "tunnel connection has already been consumed".into(),
@@ -85,6 +88,7 @@ impl BoxTunnel {
                         BoxliteError::Network(format!("open tunnel descriptor: {error}"))
                     })
             }
+            #[cfg(feature = "rest")]
             TunnelState::RemoteReady { connection, .. } => Ok(connection),
             TunnelState::Connected => Err(BoxliteError::InvalidState(
                 "tunnel connection has already been consumed".into(),
@@ -135,6 +139,7 @@ mod tests {
 
     use super::*;
 
+    #[cfg(feature = "rest")]
     #[tokio::test]
     async fn remote_tunnel_exposes_and_consumes_prepared_connection() {
         let (stream, mut peer) = UnixStream::pair().unwrap();

--- a/src/boxlite/src/litebox/network.rs
+++ b/src/boxlite/src/litebox/network.rs
@@ -38,14 +38,12 @@ pub struct BoxTunnel {
 }
 
 impl BoxTunnel {
-    pub(crate) async fn local<C>(connection: C) -> BoxliteResult<Self>
-    where
-        C: BoxConnection + 'static,
-    {
-        let fd = connection_fd(connection).await?;
-        Ok(Self {
+    /// Wrap an owned transport descriptor. The fd *is* the tunnel — no bridge
+    /// copy in between: `endpoint()` lends it out, `connect()` consumes it.
+    pub(crate) fn local(fd: OwnedFd) -> Self {
+        Self {
             state: tokio::sync::Mutex::new(TunnelState::LocalReady(fd)),
-        })
+        }
     }
 
     #[cfg(feature = "rest")]
@@ -95,21 +93,6 @@ impl BoxTunnel {
             )),
         }
     }
-}
-
-async fn connection_fd<C>(mut connection: C) -> BoxliteResult<OwnedFd>
-where
-    C: BoxConnection + 'static,
-{
-    let (sdk, mut bridge) = tokio::net::UnixStream::pair().map_err(|error| {
-        BoxliteError::Network(format!("create tunnel descriptor bridge: {error}"))
-    })?;
-    tokio::spawn(async move {
-        let _ = tokio::io::copy_bidirectional(&mut connection, &mut bridge).await;
-    });
-    sdk.into_std()
-        .map(OwnedFd::from)
-        .map_err(|error| BoxliteError::Network(format!("export tunnel descriptor: {error}")))
 }
 
 /// Handle for network operations on a LiteBox.
@@ -162,12 +145,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn local_tunnel_exposes_fd_and_consumes_prepared_connection() {
+    async fn local_tunnel_hands_back_the_transport_fd() {
         let (stream, mut peer) = UnixStream::pair().unwrap();
-        let tunnel = BoxTunnel::local(stream).await.unwrap();
+        let fd = OwnedFd::from(stream.into_std().unwrap());
+        let transport_fd = fd.as_raw_fd();
+        let tunnel = BoxTunnel::local(fd);
 
+        // Zero-copy contract: the endpoint IS the transport fd, not a bridge.
         let endpoint = tunnel.endpoint().await.unwrap();
-        assert!(matches!(endpoint, BoxEndpoint::FileDescriptor(fd) if fd >= 0));
+        assert_eq!(endpoint, BoxEndpoint::FileDescriptor(transport_fd));
         let same_endpoint = tunnel.endpoint().await.unwrap();
         assert_eq!(endpoint, same_endpoint);
 

--- a/src/boxlite/src/litebox/network.rs
+++ b/src/boxlite/src/litebox/network.rs
@@ -1,9 +1,7 @@
 //! Network sub-resource on LiteBox.
 
-use std::future::Future;
 use std::net::SocketAddr;
 use std::os::fd::{AsRawFd, OwnedFd};
-use std::pin::Pin;
 use std::sync::Arc;
 
 use boxlite_shared::errors::{BoxliteError, BoxliteResult};
@@ -24,81 +22,59 @@ pub trait BoxConnection: tokio::io::AsyncRead + tokio::io::AsyncWrite + Send + U
 
 impl<T> BoxConnection for T where T: tokio::io::AsyncRead + tokio::io::AsyncWrite + Send + Unpin {}
 
-type ConnectFuture = Pin<Box<dyn Future<Output = BoxliteResult<Box<dyn BoxConnection>>> + Send>>;
-type Connector = Arc<dyn Fn() -> ConnectFuture + Send + Sync>;
-
 enum TunnelState {
-    Pending,
     LocalReady(OwnedFd),
+    RemoteReady(Box<dyn BoxConnection>),
     Connected,
 }
 
 /// A one-shot box service tunnel target.
 pub struct BoxTunnel {
     uri: Option<String>,
-    connector: Connector,
     state: tokio::sync::Mutex<TunnelState>,
 }
 
 impl BoxTunnel {
-    pub(crate) fn new<F, Fut, C>(uri: Option<String>, connect: F) -> Self
+    pub(crate) async fn local<C>(connection: C) -> BoxliteResult<Self>
     where
-        F: Fn() -> Fut + Send + Sync + 'static,
-        Fut: Future<Output = BoxliteResult<C>> + Send + 'static,
         C: BoxConnection + 'static,
     {
-        let connector = Arc::new(move || {
-            let future = connect();
-            Box::pin(async move {
-                future
-                    .await
-                    .map(|stream| Box::new(stream) as Box<dyn BoxConnection>)
-            }) as ConnectFuture
-        });
+        let fd = connection_fd(Box::new(connection)).await?;
+        Ok(Self {
+            uri: None,
+            state: tokio::sync::Mutex::new(TunnelState::LocalReady(fd)),
+        })
+    }
+
+    pub(crate) fn remote<C>(uri: String, connection: C) -> Self
+    where
+        C: BoxConnection + 'static,
+    {
         Self {
-            uri,
-            connector,
-            state: tokio::sync::Mutex::new(TunnelState::Pending),
+            uri: Some(uri),
+            state: tokio::sync::Mutex::new(TunnelState::RemoteReady(Box::new(connection))),
         }
     }
 
-    /// Return the remote URI or prepare and borrow the local connection descriptor.
+    /// Describe the prepared tunnel without opening another connection.
     pub async fn endpoint(&self) -> BoxliteResult<BoxEndpoint> {
-        if let Some(uri) = &self.uri {
-            return Ok(BoxEndpoint::Uri(uri.clone()));
+        match &*self.state.lock().await {
+            TunnelState::LocalReady(fd) => Ok(BoxEndpoint::FileDescriptor(fd.as_raw_fd())),
+            TunnelState::RemoteReady(_) => Ok(BoxEndpoint::Uri(
+                self.uri
+                    .clone()
+                    .expect("remote tunnel must have a URI endpoint"),
+            )),
+            TunnelState::Connected => Err(BoxliteError::InvalidState(
+                "tunnel connection has already been consumed".into(),
+            )),
         }
-
-        let mut state = self.state.lock().await;
-        match &*state {
-            TunnelState::LocalReady(fd) => {
-                return Ok(BoxEndpoint::FileDescriptor(fd.as_raw_fd()));
-            }
-            TunnelState::Connected => {
-                return Err(BoxliteError::InvalidState(
-                    "tunnel connection has already been consumed".into(),
-                ));
-            }
-            TunnelState::Pending => {}
-        }
-
-        let connection = (self.connector)().await?;
-        let fd = connection_fd(connection).await?;
-        let raw_fd = fd.as_raw_fd();
-        *state = TunnelState::LocalReady(fd);
-        Ok(BoxEndpoint::FileDescriptor(raw_fd))
     }
 
     /// Consume this tunnel's single connection.
     pub async fn connect(&self) -> BoxliteResult<Box<dyn BoxConnection>> {
         let mut state = self.state.lock().await;
         match std::mem::replace(&mut *state, TunnelState::Connected) {
-            TunnelState::Pending => match (self.connector)().await {
-                Ok(connection) => Ok(connection),
-                Err(error) => {
-                    *state = TunnelState::Pending;
-                    Err(error)
-                }
-            },
             TunnelState::LocalReady(fd) => {
                 let stream = std::os::unix::net::UnixStream::from(fd);
                 stream.set_nonblocking(true).map_err(|error| {
@@ -110,6 +86,7 @@ impl BoxTunnel {
                         BoxliteError::Network(format!("open tunnel descriptor: {error}"))
                     })
             }
+            TunnelState::RemoteReady(connection) => Ok(connection),
             TunnelState::Connected => Err(BoxliteError::InvalidState(
                 "tunnel connection has already been consumed".into(),
             )),
@@ -142,7 +119,7 @@ impl NetworkHandle {
         Self { network_backend }
     }
 
-    /// Prepare a one-shot tunnel endpoint without opening a data connection.
+    /// Establish a one-shot tunnel and return its prepared endpoint and connection.
     pub async fn tunnel(&self, target: SocketAddr) -> BoxliteResult<BoxTunnel> {
         self.network_backend.tunnel(target).await
     }
@@ -157,31 +134,17 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn remote_tunnel_connects_once_lazily() {
-        let (peer_tx, mut peer_rx) = tokio::sync::mpsc::unbounded_channel();
-        let tunnel = BoxTunnel::new(
-            Some("https://3000-box.proxy.example.test".to_string()),
-            move || {
-                let peer_tx = peer_tx.clone();
-                async move {
-                    let (stream, peer) = UnixStream::pair().map_err(|error| {
-                        BoxliteError::Network(format!("test socket pair failed: {error}"))
-                    })?;
-                    peer_tx.send(peer).unwrap();
-                    Ok(stream)
-                }
-            },
-        );
+    async fn remote_tunnel_exposes_and_consumes_prepared_connection() {
+        let (stream, mut peer) = UnixStream::pair().unwrap();
+        let tunnel = BoxTunnel::remote("https://3000-box.proxy.example.test".to_string(), stream);
 
         assert_eq!(
             tunnel.endpoint().await.unwrap(),
             BoxEndpoint::Uri("https://3000-box.proxy.example.test".to_string())
         );
-        assert!(peer_rx.try_recv().is_err(), "tunnel() must not connect");
 
         let mut first = tunnel.connect().await.unwrap();
-        let mut first_peer = peer_rx.recv().await.unwrap();
-        first_peer.write_all(b"one").await.unwrap();
+        peer.write_all(b"one").await.unwrap();
         let mut first_response = [0; 3];
         first.read_exact(&mut first_response).await.unwrap();
         assert_eq!(&first_response, b"one");
@@ -192,18 +155,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn local_endpoint_prepares_fd_consumed_by_connect() {
-        let (peer_tx, mut peer_rx) = tokio::sync::mpsc::unbounded_channel();
-        let tunnel = BoxTunnel::new(None, move || {
-            let peer_tx = peer_tx.clone();
-            async move {
-                let (stream, peer) = UnixStream::pair().map_err(|error| {
-                    BoxliteError::Network(format!("test socket pair failed: {error}"))
-                })?;
-                peer_tx.send(peer).unwrap();
-                Ok(stream)
-            }
-        });
+    async fn local_tunnel_exposes_fd_and_consumes_prepared_connection() {
+        let (stream, mut peer) = UnixStream::pair().unwrap();
+        let tunnel = BoxTunnel::local(stream).await.unwrap();
 
         let endpoint = tunnel.endpoint().await.unwrap();
         assert!(matches!(endpoint, BoxEndpoint::FileDescriptor(fd) if fd >= 0));
@@ -211,8 +165,7 @@ mod tests {
         assert_eq!(endpoint, same_endpoint);
 
         let mut first = tunnel.connect().await.unwrap();
-        let mut first_peer = peer_rx.recv().await.unwrap();
-        first_peer.write_all(b"one").await.unwrap();
+        peer.write_all(b"one").await.unwrap();
         let mut first_response = [0; 3];
         first.read_exact(&mut first_response).await.unwrap();
         assert_eq!(&first_response, b"one");

--- a/src/boxlite/src/litebox/network.rs
+++ b/src/boxlite/src/litebox/network.rs
@@ -22,27 +22,34 @@ pub trait BoxConnection: tokio::io::AsyncRead + tokio::io::AsyncWrite + Send + U
 
 impl<T> BoxConnection for T where T: tokio::io::AsyncRead + tokio::io::AsyncWrite + Send + Unpin {}
 
-enum TunnelState {
-    LocalReady(OwnedFd),
+/// The transport a [`BoxTunnel`] was built over — fixed at construction,
+/// never transitions. Not a state machine.
+enum TunnelTransport {
+    /// Owned descriptor for the local transport; the fd *is* the tunnel.
+    Local(OwnedFd),
+    /// Live remote stream plus the public URI it was opened against.
     #[cfg(feature = "rest")]
-    RemoteReady {
+    Remote {
         uri: String,
         connection: Box<dyn BoxConnection>,
     },
-    Connected,
 }
 
 /// A one-shot box service tunnel target.
+///
+/// [`endpoint`](Self::endpoint) lends the descriptor; [`connect`](Self::connect)
+/// consumes the tunnel, so a second connect is a move error at compile time
+/// rather than a runtime state check.
 pub struct BoxTunnel {
-    state: tokio::sync::Mutex<TunnelState>,
+    transport: TunnelTransport,
 }
 
 impl BoxTunnel {
     /// Wrap an owned transport descriptor. The fd *is* the tunnel — no bridge
-    /// copy in between: `endpoint()` lends it out, `connect()` consumes it.
+    /// copy in between.
     pub(crate) fn local(fd: OwnedFd) -> Self {
         Self {
-            state: tokio::sync::Mutex::new(TunnelState::LocalReady(fd)),
+            transport: TunnelTransport::Local(fd),
         }
     }
 
@@ -52,30 +59,29 @@ impl BoxTunnel {
         C: BoxConnection + 'static,
     {
         Self {
-            state: tokio::sync::Mutex::new(TunnelState::RemoteReady {
+            transport: TunnelTransport::Remote {
                 uri,
                 connection: Box::new(connection),
-            }),
+            },
         }
     }
 
     /// Describe the prepared tunnel without opening another connection.
-    pub async fn endpoint(&self) -> BoxliteResult<BoxEndpoint> {
-        match &*self.state.lock().await {
-            TunnelState::LocalReady(fd) => Ok(BoxEndpoint::FileDescriptor(fd.as_raw_fd())),
+    pub fn endpoint(&self) -> BoxEndpoint {
+        match &self.transport {
+            TunnelTransport::Local(fd) => BoxEndpoint::FileDescriptor(fd.as_raw_fd()),
             #[cfg(feature = "rest")]
-            TunnelState::RemoteReady { uri, .. } => Ok(BoxEndpoint::Uri(uri.clone())),
-            TunnelState::Connected => Err(BoxliteError::InvalidState(
-                "tunnel connection has already been consumed".into(),
-            )),
+            TunnelTransport::Remote { uri, .. } => BoxEndpoint::Uri(uri.clone()),
         }
     }
 
-    /// Consume this tunnel's single connection.
-    pub async fn connect(&self) -> BoxliteResult<Box<dyn BoxConnection>> {
-        let mut state = self.state.lock().await;
-        match std::mem::replace(&mut *state, TunnelState::Connected) {
-            TunnelState::LocalReady(fd) => {
+    /// Consume this tunnel into its single connection.
+    ///
+    /// Must run inside a tokio runtime — the local descriptor is registered
+    /// with the reactor here.
+    pub fn connect(self) -> BoxliteResult<Box<dyn BoxConnection>> {
+        match self.transport {
+            TunnelTransport::Local(fd) => {
                 let stream = std::os::unix::net::UnixStream::from(fd);
                 stream.set_nonblocking(true).map_err(|error| {
                     BoxliteError::Network(format!("configure tunnel descriptor: {error}"))
@@ -87,10 +93,7 @@ impl BoxTunnel {
                     })
             }
             #[cfg(feature = "rest")]
-            TunnelState::RemoteReady { connection, .. } => Ok(connection),
-            TunnelState::Connected => Err(BoxliteError::InvalidState(
-                "tunnel connection has already been consumed".into(),
-            )),
+            TunnelTransport::Remote { connection, .. } => Ok(connection),
         }
     }
 }
@@ -116,32 +119,30 @@ impl NetworkHandle {
 
 #[cfg(test)]
 mod tests {
-    use boxlite_shared::errors::BoxliteError;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::UnixStream;
 
     use super::*;
 
+    // Double-connect and endpoint-after-connect need no runtime tests: connect()
+    // takes `self`, so both are move errors at compile time.
+
     #[cfg(feature = "rest")]
     #[tokio::test]
-    async fn remote_tunnel_exposes_and_consumes_prepared_connection() {
+    async fn remote_tunnel_exposes_uri_and_yields_its_connection() {
         let (stream, mut peer) = UnixStream::pair().unwrap();
         let tunnel = BoxTunnel::remote("https://3000-box.proxy.example.test".to_string(), stream);
 
         assert_eq!(
-            tunnel.endpoint().await.unwrap(),
+            tunnel.endpoint(),
             BoxEndpoint::Uri("https://3000-box.proxy.example.test".to_string())
         );
 
-        let mut first = tunnel.connect().await.unwrap();
+        let mut connection = tunnel.connect().unwrap();
         peer.write_all(b"one").await.unwrap();
-        let mut first_response = [0; 3];
-        first.read_exact(&mut first_response).await.unwrap();
-        assert_eq!(&first_response, b"one");
-        assert!(matches!(
-            tunnel.connect().await,
-            Err(BoxliteError::InvalidState(_))
-        ));
+        let mut response = [0; 3];
+        connection.read_exact(&mut response).await.unwrap();
+        assert_eq!(&response, b"one");
     }
 
     #[tokio::test]
@@ -152,23 +153,13 @@ mod tests {
         let tunnel = BoxTunnel::local(fd);
 
         // Zero-copy contract: the endpoint IS the transport fd, not a bridge.
-        let endpoint = tunnel.endpoint().await.unwrap();
-        assert_eq!(endpoint, BoxEndpoint::FileDescriptor(transport_fd));
-        let same_endpoint = tunnel.endpoint().await.unwrap();
-        assert_eq!(endpoint, same_endpoint);
+        assert_eq!(tunnel.endpoint(), BoxEndpoint::FileDescriptor(transport_fd));
+        assert_eq!(tunnel.endpoint(), BoxEndpoint::FileDescriptor(transport_fd));
 
-        let mut first = tunnel.connect().await.unwrap();
+        let mut connection = tunnel.connect().unwrap();
         peer.write_all(b"one").await.unwrap();
-        let mut first_response = [0; 3];
-        first.read_exact(&mut first_response).await.unwrap();
-        assert_eq!(&first_response, b"one");
-        assert!(matches!(
-            tunnel.connect().await,
-            Err(BoxliteError::InvalidState(_))
-        ));
-        assert!(matches!(
-            tunnel.endpoint().await,
-            Err(BoxliteError::InvalidState(_))
-        ));
+        let mut response = [0; 3];
+        connection.read_exact(&mut response).await.unwrap();
+        assert_eq!(&response, b"one");
     }
 }

--- a/src/boxlite/src/litebox/network.rs
+++ b/src/boxlite/src/litebox/network.rs
@@ -2,69 +2,131 @@
 
 use std::future::Future;
 use std::net::SocketAddr;
+use std::os::fd::{AsRawFd, OwnedFd};
 use std::pin::Pin;
 use std::sync::Arc;
 
-use boxlite_shared::errors::BoxliteResult;
+use boxlite_shared::errors::{BoxliteError, BoxliteResult};
 
-use crate::net::BoxInternalTunnel;
 use crate::runtime::backend::BoxNetworkBackend;
 
-/// Lazily opens the raw byte stream backing a [`BoxTunnel`]. Each backend
-/// builds one inside its [`BoxNetworkBackend::tunnel`] impl, capturing whatever
-/// it needs (a REST client, a gvproxy handle) so the tunnel stays self-contained
-/// and the backend only has to expose `tunnel`.
-pub(crate) type TunnelConnector = Arc<
-    dyn Fn() -> Pin<Box<dyn Future<Output = BoxliteResult<BoxInternalTunnel>> + Send>>
-        + Send
-        + Sync,
->;
+/// A descriptor for a box service tunnel.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum BoxEndpoint {
+    /// A URI clients can use to reach a remote box service.
+    Uri(String),
+    /// A borrowed descriptor for the prepared local connection.
+    FileDescriptor(i32),
+}
 
 /// Public byte-stream capability for a box service connection.
 pub trait BoxConnection: tokio::io::AsyncRead + tokio::io::AsyncWrite + Send + Unpin {}
 
 impl<T> BoxConnection for T where T: tokio::io::AsyncRead + tokio::io::AsyncWrite + Send + Unpin {}
 
-/// A box service tunnel target. Call [`endpoint`](Self::endpoint) first, then
-/// [`connect`](Self::connect) on this handle.
+type ConnectFuture = Pin<Box<dyn Future<Output = BoxliteResult<Box<dyn BoxConnection>>> + Send>>;
+type Connector = Arc<dyn Fn() -> ConnectFuture + Send + Sync>;
+
+enum TunnelState {
+    Pending,
+    LocalReady(OwnedFd),
+    Connected,
+}
+
+/// A one-shot box service tunnel target.
 pub struct BoxTunnel {
-    endpoint: Option<String>,
-    connector: TunnelConnector,
-    stream: Arc<tokio::sync::Mutex<Option<BoxInternalTunnel>>>,
+    uri: Option<String>,
+    connector: Connector,
+    state: tokio::sync::Mutex<TunnelState>,
 }
 
 impl BoxTunnel {
-    pub(crate) fn new(endpoint: Option<String>, connector: TunnelConnector) -> Self {
+    pub(crate) fn new<F, Fut, C>(uri: Option<String>, connect: F) -> Self
+    where
+        F: Fn() -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = BoxliteResult<C>> + Send + 'static,
+        C: BoxConnection + 'static,
+    {
+        let connector = Arc::new(move || {
+            let future = connect();
+            Box::pin(async move {
+                future
+                    .await
+                    .map(|stream| Box::new(stream) as Box<dyn BoxConnection>)
+            }) as ConnectFuture
+        });
         Self {
-            endpoint,
+            uri,
             connector,
-            stream: Arc::new(tokio::sync::Mutex::new(None)),
+            state: tokio::sync::Mutex::new(TunnelState::Pending),
         }
     }
 
-    /// Resolve the endpoint, fetching a URL remotely or preparing a local stream.
-    pub async fn endpoint(&self) -> BoxliteResult<Option<String>> {
-        match &self.endpoint {
-            Some(endpoint) => Ok(Some(endpoint.clone())),
-            None => {
-                let mut stream = self.stream.lock().await;
-                if stream.is_none() {
-                    *stream = Some((self.connector)().await?);
-                }
-                Ok(None)
+    /// Return the remote URI or prepare and borrow the local connection descriptor.
+    pub async fn endpoint(&self) -> BoxliteResult<BoxEndpoint> {
+        if let Some(uri) = &self.uri {
+            return Ok(BoxEndpoint::Uri(uri.clone()));
+        }
+
+        let mut state = self.state.lock().await;
+        match &*state {
+            TunnelState::LocalReady(fd) => {
+                return Ok(BoxEndpoint::FileDescriptor(fd.as_raw_fd()));
             }
+            TunnelState::Connected => {
+                return Err(BoxliteError::InvalidState(
+                    "tunnel connection has already been consumed".into(),
+                ));
+            }
+            TunnelState::Pending => {}
         }
+
+        let connection = (self.connector)().await?;
+        let fd = connection_fd(connection).await?;
+        let raw_fd = fd.as_raw_fd();
+        *state = TunnelState::LocalReady(fd);
+        Ok(BoxEndpoint::FileDescriptor(raw_fd))
     }
 
-    /// Consume the prepared local stream or establish the remote stream once.
+    /// Consume this tunnel's single connection.
     pub async fn connect(&self) -> BoxliteResult<Box<dyn BoxConnection>> {
-        let mut stream = self.stream.lock().await;
-        if let Some(stream) = stream.take() {
-            return Ok(Box::new(stream));
+        let mut state = self.state.lock().await;
+        match std::mem::replace(&mut *state, TunnelState::Connected) {
+            TunnelState::Pending => match (self.connector)().await {
+                Ok(connection) => Ok(connection),
+                Err(error) => {
+                    *state = TunnelState::Pending;
+                    Err(error)
+                }
+            },
+            TunnelState::LocalReady(fd) => {
+                let stream = std::os::unix::net::UnixStream::from(fd);
+                stream.set_nonblocking(true).map_err(|error| {
+                    BoxliteError::Network(format!("configure tunnel descriptor: {error}"))
+                })?;
+                tokio::net::UnixStream::from_std(stream)
+                    .map(|stream| Box::new(stream) as Box<dyn BoxConnection>)
+                    .map_err(|error| {
+                        BoxliteError::Network(format!("open tunnel descriptor: {error}"))
+                    })
+            }
+            TunnelState::Connected => Err(BoxliteError::InvalidState(
+                "tunnel connection has already been consumed".into(),
+            )),
         }
-        drop(stream);
-        Ok(Box::new((self.connector)().await?))
     }
+}
+
+async fn connection_fd(mut connection: Box<dyn BoxConnection>) -> BoxliteResult<OwnedFd> {
+    let (sdk, mut bridge) = tokio::net::UnixStream::pair().map_err(|error| {
+        BoxliteError::Network(format!("create tunnel descriptor bridge: {error}"))
+    })?;
+    tokio::spawn(async move {
+        let _ = tokio::io::copy_bidirectional(&mut connection, &mut bridge).await;
+    });
+    sdk.into_std()
+        .map(OwnedFd::from)
+        .map_err(|error| BoxliteError::Network(format!("export tunnel descriptor: {error}")))
 }
 
 /// Handle for network operations on a LiteBox.
@@ -80,11 +142,7 @@ impl NetworkHandle {
         Self { network_backend }
     }
 
-    /// Describe a tunnel target, returning a [`BoxTunnel`] with endpoint and
-    /// connection operations for both local and remote boxes.
-    ///
-    /// This is the single tunnel entry point: callers that only want the raw
-    /// stream use the SDK-specific `connect()` wrapper.
+    /// Prepare a one-shot tunnel endpoint without opening a data connection.
     pub async fn tunnel(&self, target: SocketAddr) -> BoxliteResult<BoxTunnel> {
         self.network_backend.tunnel(target).await
     }
@@ -92,103 +150,79 @@ impl NetworkHandle {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::{AtomicUsize, Ordering};
-
     use boxlite_shared::errors::BoxliteError;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::UnixStream;
 
     use super::*;
 
-    #[derive(Default)]
-    struct TestBackend {
-        connected: Arc<AtomicUsize>,
-    }
-
-    #[async_trait::async_trait]
-    impl BoxNetworkBackend for TestBackend {
-        async fn tunnel(&self, _target: SocketAddr) -> BoxliteResult<BoxTunnel> {
-            let connected = Arc::clone(&self.connected);
-            Ok(BoxTunnel::new(
-                Some("https://3000-box.proxy.example.test".to_string()),
-                Arc::new(move || {
-                    let connected = Arc::clone(&connected);
-                    Box::pin(async move {
-                        connected.fetch_add(1, Ordering::Relaxed);
-                        Err(BoxliteError::Unsupported("test tunnel".to_string()))
-                    })
-                }),
-            ))
-        }
-    }
-
     #[tokio::test]
-    async fn box_tunnel_fetches_url_and_connects_lazily() {
-        let backend = Arc::new(TestBackend::default());
-        let network = NetworkHandle::new(backend.clone());
-        let target = "192.168.127.2:3000".parse().unwrap();
-
-        // Obtaining the tunnel does no work — no connect.
-        let tunnel = network.tunnel(target).await.unwrap();
-        assert_eq!(backend.connected.load(Ordering::Relaxed), 0);
-
-        // endpoint() returns the already-resolved URL; connect() remains separate.
-        let endpoint = tunnel.endpoint().await.unwrap();
-        assert_eq!(
-            endpoint.as_deref(),
-            Some("https://3000-box.proxy.example.test")
+    async fn remote_tunnel_connects_once_lazily() {
+        let (peer_tx, mut peer_rx) = tokio::sync::mpsc::unbounded_channel();
+        let tunnel = BoxTunnel::new(
+            Some("https://3000-box.proxy.example.test".to_string()),
+            move || {
+                let peer_tx = peer_tx.clone();
+                async move {
+                    let (stream, peer) = UnixStream::pair().map_err(|error| {
+                        BoxliteError::Network(format!("test socket pair failed: {error}"))
+                    })?;
+                    peer_tx.send(peer).unwrap();
+                    Ok(stream)
+                }
+            },
         );
-        assert_eq!(backend.connected.load(Ordering::Relaxed), 0);
 
-        // Connecting the tunnel triggers exactly one connect.
-        assert!(tunnel.connect().await.is_err());
-        assert_eq!(backend.connected.load(Ordering::Relaxed), 1);
-    }
+        assert_eq!(
+            tunnel.endpoint().await.unwrap(),
+            BoxEndpoint::Uri("https://3000-box.proxy.example.test".to_string())
+        );
+        assert!(peer_rx.try_recv().is_err(), "tunnel() must not connect");
 
-    struct LocalBackend {
-        peer: Arc<tokio::sync::Mutex<Option<UnixStream>>>,
-    }
-
-    #[async_trait::async_trait]
-    impl BoxNetworkBackend for LocalBackend {
-        async fn tunnel(&self, _target: SocketAddr) -> BoxliteResult<BoxTunnel> {
-            let peer = Arc::clone(&self.peer);
-            Ok(BoxTunnel::new(
-                None,
-                Arc::new(move || {
-                    let peer = Arc::clone(&peer);
-                    Box::pin(async move {
-                        let (stream, other) = UnixStream::pair().map_err(|error| {
-                            BoxliteError::Network(format!("test socket pair failed: {error}"))
-                        })?;
-                        *peer.lock().await = Some(other);
-                        Ok(BoxInternalTunnel::from_local(
-                            stream,
-                            "192.168.127.2:3000".parse().unwrap(),
-                        ))
-                    })
-                }),
-            ))
-        }
+        let mut first = tunnel.connect().await.unwrap();
+        let mut first_peer = peer_rx.recv().await.unwrap();
+        first_peer.write_all(b"one").await.unwrap();
+        let mut first_response = [0; 3];
+        first.read_exact(&mut first_response).await.unwrap();
+        assert_eq!(&first_response, b"one");
+        assert!(matches!(
+            tunnel.connect().await,
+            Err(BoxliteError::InvalidState(_))
+        ));
     }
 
     #[tokio::test]
-    async fn local_box_uses_the_same_endpoint_then_connect_flow() {
-        let peer = Arc::new(tokio::sync::Mutex::new(None));
-        let network = NetworkHandle::new(Arc::new(LocalBackend {
-            peer: Arc::clone(&peer),
-        }));
-        let target = "192.168.127.2:3000".parse().unwrap();
+    async fn local_endpoint_prepares_fd_consumed_by_connect() {
+        let (peer_tx, mut peer_rx) = tokio::sync::mpsc::unbounded_channel();
+        let tunnel = BoxTunnel::new(None, move || {
+            let peer_tx = peer_tx.clone();
+            async move {
+                let (stream, peer) = UnixStream::pair().map_err(|error| {
+                    BoxliteError::Network(format!("test socket pair failed: {error}"))
+                })?;
+                peer_tx.send(peer).unwrap();
+                Ok(stream)
+            }
+        });
 
-        let tunnel = network.tunnel(target).await.unwrap();
         let endpoint = tunnel.endpoint().await.unwrap();
-        assert_eq!(endpoint, None);
-        let mut stream = tunnel.connect().await.unwrap();
-        let mut peer = peer.lock().await.take().unwrap();
+        assert!(matches!(endpoint, BoxEndpoint::FileDescriptor(fd) if fd >= 0));
+        let same_endpoint = tunnel.endpoint().await.unwrap();
+        assert_eq!(endpoint, same_endpoint);
 
-        peer.write_all(b"local").await.unwrap();
-        let mut response = [0; 5];
-        stream.read_exact(&mut response).await.unwrap();
-        assert_eq!(&response, b"local");
+        let mut first = tunnel.connect().await.unwrap();
+        let mut first_peer = peer_rx.recv().await.unwrap();
+        first_peer.write_all(b"one").await.unwrap();
+        let mut first_response = [0; 3];
+        first.read_exact(&mut first_response).await.unwrap();
+        assert_eq!(&first_response, b"one");
+        assert!(matches!(
+            tunnel.connect().await,
+            Err(BoxliteError::InvalidState(_))
+        ));
+        assert!(matches!(
+            tunnel.endpoint().await,
+            Err(BoxliteError::InvalidState(_))
+        ));
     }
 }

--- a/src/boxlite/src/net/gvproxy/services.rs
+++ b/src/boxlite/src/net/gvproxy/services.rs
@@ -1065,6 +1065,5 @@ mod tests {
         let tunnel = backend.tunnel(target).await.expect("tunnel handshake");
         assert_eq!(tunnel.peer_addr(), target);
         // The owned OS fd is recoverable for an SDK handoff.
-        assert!(tunnel.into_fd().is_some());
     }
 }

--- a/src/boxlite/src/net/mod.rs
+++ b/src/boxlite/src/net/mod.rs
@@ -13,6 +13,7 @@ use boxlite_shared::errors::{BoxliteError, BoxliteResult};
 use serde_json::Value;
 use std::io;
 use std::net::SocketAddr;
+use std::os::fd::OwnedFd;
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -255,6 +256,19 @@ impl BoxInternalTunnel {
     /// The guest `ip:port` this tunnel targets.
     pub fn peer_addr(&self) -> SocketAddr {
         self.peer
+    }
+
+    /// Recover the transport's owned OS fd — the fd *is* the tunnel, so the
+    /// consumer holds the real socket with no bridge in between.
+    ///
+    /// tokio → std deregisters the socket from the reactor before the fd
+    /// changes hands.
+    pub(crate) fn into_owned_fd(self) -> BoxliteResult<OwnedFd> {
+        match self.stream {
+            TunnelStream::Local(stream) => stream.into_std().map(OwnedFd::from).map_err(|error| {
+                BoxliteError::Network(format!("detach tunnel socket for handoff: {error}"))
+            }),
+        }
     }
 }
 

--- a/src/boxlite/src/net/mod.rs
+++ b/src/boxlite/src/net/mod.rs
@@ -13,7 +13,6 @@ use boxlite_shared::errors::{BoxliteError, BoxliteResult};
 use serde_json::Value;
 use std::io;
 use std::net::SocketAddr;
-use std::os::fd::OwnedFd;
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -238,8 +237,7 @@ pub(crate) enum TunnelStream {
 /// it for concurrent read+write. The transport is swappable behind [`TunnelStream`]
 /// so the same type carries a local unix pipe now and a cloud stream later without
 /// touching [`NetworkBackend::tunnel`]'s signature. `peer_addr()` is the guest
-/// target; [`into_fd`](Self::into_fd) recovers the tunnel's owned OS fd — the
-/// transport-agnostic handle an SDK wraps as a native socket.
+/// target.
 pub struct BoxInternalTunnel {
     stream: TunnelStream,
     peer: SocketAddr,
@@ -257,18 +255,6 @@ impl BoxInternalTunnel {
     /// The guest `ip:port` this tunnel targets.
     pub fn peer_addr(&self) -> SocketAddr {
         self.peer
-    }
-
-    /// Recover the tunnel's owned OS file descriptor — the transport-agnostic
-    /// handle an SDK wraps as a native socket (the glue does `.into_raw_fd()`,
-    /// then e.g. Python `socket.socket(fileno=fd)`). `None` for a transport with
-    /// no single host fd (a cloud stream), where callers fall back to a
-    /// local-listener bridge. This is the FFI-handoff shape libtailscale uses.
-    pub fn into_fd(self) -> Option<OwnedFd> {
-        match self.stream {
-            // tokio → std deregisters from the reactor; the std socket owns the fd.
-            TunnelStream::Local(stream) => stream.into_std().ok().map(OwnedFd::from),
-        }
     }
 }
 
@@ -684,6 +670,5 @@ mod tests {
         assert_eq!(&back, b"pong");
 
         // the owned OS fd is recoverable with no unsafe downcast (SDK handoff)
-        assert!(tunnel.into_fd().is_some());
     }
 }

--- a/src/boxlite/src/rest/client.rs
+++ b/src/boxlite/src/rest/client.rs
@@ -382,8 +382,8 @@ impl ApiClient {
         Ok(local)
     }
 
-    /// Request the public descriptor for a box service tunnel.
-    pub(crate) async fn describe_box_tunnel(
+    /// Prepare a box service tunnel and return its public descriptor.
+    pub(crate) async fn prepare_box_tunnel(
         &self,
         box_id: impl AsRef<str>,
         port: u16,

--- a/src/boxlite/src/rest/client.rs
+++ b/src/boxlite/src/rest/client.rs
@@ -20,6 +20,9 @@ use crate::runtime::auth::Principal;
 const REFRESH_LEEWAY: Duration = Duration::from_secs(60);
 const TUNNEL_SETUP_TIMEOUT: Duration = Duration::from_secs(30);
 
+type TunnelConnector =
+    hyper_rustls::HttpsConnector<hyper_util::client::legacy::connect::HttpConnector>;
+
 /// HTTP client for the BoxLite REST API.
 ///
 /// Handles base URL construction, bearer auth (any [`Credential`] impl),
@@ -27,6 +30,7 @@ const TUNNEL_SETUP_TIMEOUT: Duration = Duration::from_secs(30);
 #[derive(Clone)]
 pub(crate) struct ApiClient {
     http: Client,
+    tunnel_connector: TunnelConnector,
     base_url: String,
     /// Routing-slot value substituted into the `{prefix}` URL segment
     /// on box-scoped requests. `None` or empty → URL skips the segment
@@ -50,12 +54,19 @@ impl ApiClient {
             .timeout(std::time::Duration::from_secs(300))
             .build()
             .map_err(|e| BoxliteError::Config(format!("failed to create HTTP client: {}", e)))?;
+        let tunnel_connector = hyper_rustls::HttpsConnectorBuilder::new()
+            .with_native_roots()
+            .map_err(|e| BoxliteError::Config(format!("failed to load TLS roots: {e}")))?
+            .https_or_http()
+            .enable_http1()
+            .build();
 
         let base_url = config.url.trim_end_matches('/').to_string();
         let path_prefix = config.path_prefix.clone();
 
         Ok(Self {
             http,
+            tunnel_connector,
             base_url,
             path_prefix,
             credential: config.credential.clone(),
@@ -325,7 +336,6 @@ impl ApiClient {
     ) -> BoxliteResult<tokio::io::DuplexStream> {
         use http_body_util::Empty;
         use hyper::{Method, Request, Uri};
-        use hyper_rustls::HttpsConnectorBuilder;
         use hyper_util::rt::TokioIo;
         use tower::Service;
 
@@ -336,12 +346,7 @@ impl ApiClient {
             .authority()
             .ok_or_else(|| BoxliteError::Config("CONNECT URI has no authority".into()))?
             .clone();
-        let mut connector = HttpsConnectorBuilder::new()
-            .with_native_roots()
-            .map_err(|e| BoxliteError::Config(format!("failed to load TLS roots: {e}")))?
-            .https_or_http()
-            .enable_http1()
-            .build();
+        let mut connector = self.tunnel_connector.clone();
         let io = tokio::time::timeout(TUNNEL_SETUP_TIMEOUT, connector.call(uri.clone()))
             .await
             .map_err(|_| BoxliteError::Network("CONNECT socket setup timed out".into()))?

--- a/src/boxlite/src/rest/client.rs
+++ b/src/boxlite/src/rest/client.rs
@@ -18,6 +18,7 @@ use crate::runtime::auth::Principal;
 
 /// Re-request a token once it is within this leeway of `expires_at`.
 const REFRESH_LEEWAY: Duration = Duration::from_secs(60);
+const TUNNEL_SETUP_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// HTTP client for the BoxLite REST API.
 ///
@@ -44,6 +45,7 @@ pub(crate) struct ApiClient {
 
 impl ApiClient {
     pub fn new(config: &BoxliteRestOptions) -> BoxliteResult<Self> {
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
         let http = Client::builder()
             .timeout(std::time::Duration::from_secs(300))
             .build()
@@ -317,6 +319,97 @@ impl ApiClient {
         Ok(stream)
     }
 
+    pub(crate) async fn connect_box_network_tunnel(
+        &self,
+        uri: &str,
+    ) -> BoxliteResult<tokio::io::DuplexStream> {
+        use http_body_util::Empty;
+        use hyper::{Method, Request, Uri};
+        use hyper_rustls::HttpsConnectorBuilder;
+        use hyper_util::rt::TokioIo;
+        use tower::Service;
+
+        let uri: Uri = uri
+            .parse()
+            .map_err(|e| BoxliteError::Config(format!("invalid CONNECT URI: {e}")))?;
+        let authority = uri
+            .authority()
+            .ok_or_else(|| BoxliteError::Config("CONNECT URI has no authority".into()))?
+            .clone();
+        let mut connector = HttpsConnectorBuilder::new()
+            .with_native_roots()
+            .map_err(|e| BoxliteError::Config(format!("failed to load TLS roots: {e}")))?
+            .https_or_http()
+            .enable_http1()
+            .build();
+        let io = tokio::time::timeout(TUNNEL_SETUP_TIMEOUT, connector.call(uri.clone()))
+            .await
+            .map_err(|_| BoxliteError::Network("CONNECT socket setup timed out".into()))?
+            .map_err(|e| BoxliteError::Network(format!("CONNECT socket setup failed: {e}")))?;
+        let (mut sender, connection) = hyper::client::conn::http1::handshake(io)
+            .await
+            .map_err(|e| BoxliteError::Network(format!("CONNECT handshake failed: {e}")))?;
+        tokio::spawn(async move {
+            let _ = connection.with_upgrades().await;
+        });
+        let request = Request::builder()
+            .method(Method::CONNECT)
+            .uri(authority.as_str())
+            .header("Host", authority.as_str())
+            .body(Empty::<bytes::Bytes>::new())
+            .map_err(|e| BoxliteError::Internal(format!("CONNECT request build failed: {e}")))?;
+        let response = tokio::time::timeout(TUNNEL_SETUP_TIMEOUT, sender.send_request(request))
+            .await
+            .map_err(|_| BoxliteError::Network("CONNECT response timed out".into()))?
+            .map_err(|e| BoxliteError::Network(format!("CONNECT request failed: {e}")))?;
+        let status = response.status();
+        if !status.is_success() {
+            return Err(map_http_status(status, "CONNECT proxy rejected tunnel"));
+        }
+        let upgraded = hyper::upgrade::on(response)
+            .await
+            .map_err(|e| BoxliteError::Network(format!("CONNECT upgrade failed: {e}")))?;
+        let (local, mut pump_end) = tokio::io::duplex(64 * 1024);
+        let mut remote = TokioIo::new(upgraded);
+        tokio::spawn(async move {
+            let _ = tokio::io::copy_bidirectional(&mut pump_end, &mut remote).await;
+        });
+        Ok(local)
+    }
+
+    /// Request the public descriptor for a box service tunnel.
+    pub(crate) async fn describe_box_tunnel(
+        &self,
+        box_id: impl AsRef<str>,
+        port: u16,
+    ) -> BoxliteResult<String> {
+        #[derive(serde::Deserialize)]
+        struct TunnelDescriptor {
+            uri: String,
+        }
+        let path = format!("/boxes/{}/network/tunnel?port={port}", box_id.as_ref());
+        let request = self
+            .authorize(
+                self.http
+                    .post(self.url(&path))
+                    .header(reqwest::header::ACCEPT, "application/json"),
+            )
+            .await?;
+        let response = request
+            .send()
+            .await
+            .map_err(|e| BoxliteError::Network(e.to_string()))?;
+        let status = response.status();
+        if !status.is_success() {
+            return self.handle_error(status, response).await;
+        }
+        let descriptor: TunnelDescriptor = response
+            .json()
+            .await
+            .map_err(|e| BoxliteError::Internal(format!("invalid tunnel descriptor: {e}")))?;
+        Ok(descriptor.uri)
+    }
+
     /// Build an authorized request (for custom operations like file upload/download).
     pub async fn authorized_request(
         &self,
@@ -500,6 +593,8 @@ mod tests {
     use async_trait::async_trait;
     use boxlite_shared::errors::BoxliteError;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
 
     /// Rotating credential with a finite expiry already in the past, so
     /// `current_bearer` must re-request on every call. Proves the cache
@@ -529,6 +624,43 @@ mod tests {
     fn client_with(cred: Arc<dyn Credential>) -> ApiClient {
         let opts = BoxliteRestOptions::new("http://localhost:1").with_credential(cred);
         ApiClient::new(&opts).expect("client")
+    }
+
+    #[tokio::test]
+    #[allow(clippy::result_large_err)]
+    async fn connect_box_network_tunnel_uses_connect_and_streams_both_directions() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut headers = Vec::new();
+            while !headers.ends_with(b"\r\n\r\n") {
+                headers.push(socket.read_u8().await.unwrap());
+            }
+            let headers = String::from_utf8(headers).unwrap();
+            assert!(headers.starts_with(&format!("CONNECT 127.0.0.1:{port} HTTP/1.1")));
+            socket
+                .write_all(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+                .await
+                .unwrap();
+
+            let mut payload = [0; 4];
+            socket.read_exact(&mut payload).await.unwrap();
+            assert_eq!(&payload, b"ping");
+            socket.write_all(&payload).await.unwrap();
+        });
+
+        let client =
+            ApiClient::new(&BoxliteRestOptions::new(format!("http://127.0.0.1:{port}"))).unwrap();
+        let mut stream = client
+            .connect_box_network_tunnel(&format!("http://127.0.0.1:{port}"))
+            .await
+            .unwrap();
+        stream.write_all(b"ping").await.unwrap();
+        let mut response = [0; 4];
+        stream.read_exact(&mut response).await.unwrap();
+        assert_eq!(&response, b"ping");
+        server.await.unwrap();
     }
 
     #[tokio::test]

--- a/src/boxlite/src/rest/litebox.rs
+++ b/src/boxlite/src/rest/litebox.rs
@@ -396,12 +396,8 @@ impl BoxNetworkBackend for RestBox {
         let port = target.port();
         let box_id = self.box_id_str();
         let endpoint = self.client.describe_box_tunnel(&box_id, port).await?;
-        let client = self.client.clone();
-        Ok(BoxTunnel::new(Some(endpoint.clone()), move || {
-            let client = client.clone();
-            let endpoint = endpoint.clone();
-            async move { client.connect_box_network_tunnel(&endpoint).await }
-        }))
+        let connection = self.client.connect_box_network_tunnel(&endpoint).await?;
+        Ok(BoxTunnel::remote(endpoint, connection))
     }
 }
 

--- a/src/boxlite/src/rest/litebox.rs
+++ b/src/boxlite/src/rest/litebox.rs
@@ -395,7 +395,7 @@ impl BoxNetworkBackend for RestBox {
 
         let port = target.port();
         let box_id = self.box_id_str();
-        let endpoint = self.client.describe_box_tunnel(&box_id, port).await?;
+        let endpoint = self.client.prepare_box_tunnel(&box_id, port).await?;
         let connection = self.client.connect_box_network_tunnel(&endpoint).await?;
         Ok(BoxTunnel::remote(endpoint, connection))
     }

--- a/src/boxlite/src/rest/litebox.rs
+++ b/src/boxlite/src/rest/litebox.rs
@@ -1,5 +1,6 @@
 //! RestBox — implements BoxBackend for the REST API.
 
+use std::net::SocketAddr;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -13,7 +14,9 @@ use boxlite_shared::errors::{BoxliteError, BoxliteResult};
 use crate::BoxInfo;
 use crate::litebox::copy::CopyOptions;
 use crate::litebox::snapshot_mgr::SnapshotInfo;
-use crate::litebox::{BoxCommand, ExecResult, ExecStderr, ExecStdin, ExecStdout, Execution};
+use crate::litebox::{
+    BoxCommand, BoxTunnel, ExecResult, ExecStderr, ExecStdin, ExecStdout, Execution,
+};
 use crate::metrics::BoxMetrics;
 use crate::runtime::backend::{BoxBackend, BoxNetworkBackend, SnapshotBackend};
 use crate::runtime::id::BoxID;
@@ -316,9 +319,8 @@ impl BoxBackend for RestBox {
         let info = resp.to_box_info()?;
         let rest_box = Arc::new(RestBox::new(self.client.clone(), info));
         let box_backend: Arc<dyn BoxBackend> = rest_box.clone();
+        let network_backend: Arc<dyn BoxNetworkBackend> = rest_box.clone();
         let snapshot_backend: Arc<dyn SnapshotBackend> = rest_box;
-        let network_backend: Arc<dyn BoxNetworkBackend> =
-            Arc::new(crate::runtime::backend::UnsupportedNetworkBackend);
         Ok(crate::LiteBox::new(
             box_backend,
             network_backend,
@@ -379,6 +381,27 @@ impl BoxBackend for RestBox {
         })?;
 
         Ok(crate::runtime::options::BoxArchive::new(output_path))
+    }
+}
+
+#[async_trait]
+impl BoxNetworkBackend for RestBox {
+    async fn tunnel(&self, target: SocketAddr) -> BoxliteResult<BoxTunnel> {
+        if target.ip().to_string() != crate::net::constants::GUEST_IP {
+            return Err(BoxliteError::Unsupported(
+                "REST box tunnels only support service ports on the guest IP".into(),
+            ));
+        }
+
+        let port = target.port();
+        let box_id = self.box_id_str();
+        let endpoint = self.client.describe_box_tunnel(&box_id, port).await?;
+        let client = self.client.clone();
+        Ok(BoxTunnel::new(Some(endpoint.clone()), move || {
+            let client = client.clone();
+            let endpoint = endpoint.clone();
+            async move { client.connect_box_network_tunnel(&endpoint).await }
+        }))
     }
 }
 

--- a/src/boxlite/src/rest/runtime.rs
+++ b/src/boxlite/src/rest/runtime.rs
@@ -35,9 +35,8 @@ impl AuthBackend for RestRuntime {
 
 fn litebox_from_rest(rest_box: Arc<RestBox>) -> LiteBox {
     let box_backend: Arc<dyn crate::runtime::backend::BoxBackend> = rest_box.clone();
+    let network_backend: Arc<dyn crate::runtime::backend::BoxNetworkBackend> = rest_box.clone();
     let snapshot_backend: Arc<dyn crate::runtime::backend::SnapshotBackend> = rest_box;
-    let network_backend: Arc<dyn crate::runtime::backend::BoxNetworkBackend> =
-        Arc::new(crate::runtime::backend::UnsupportedNetworkBackend);
     LiteBox::new(box_backend, network_backend, snapshot_backend)
 }
 

--- a/src/boxlite/src/runtime/backend.rs
+++ b/src/boxlite/src/runtime/backend.rs
@@ -133,24 +133,9 @@ pub(crate) trait BoxBackend: Send + Sync {
 /// network data-plane capabilities directly.
 #[async_trait]
 pub(crate) trait BoxNetworkBackend: Send + Sync {
-    /// Describe a tunnel target, returning a self-contained [`BoxTunnel`]:
-    /// remote backends attach a public URL, and either kind can lazily open
-    /// the raw byte stream via [`BoxTunnel::connect`].
+    /// Prepare a reusable tunnel target without opening a data connection.
+    /// Remote backends attach a public URL; local backends attach a Unix socket.
     async fn tunnel(&self, target: SocketAddr) -> BoxliteResult<BoxTunnel>;
-}
-
-/// Network backend used when the current runtime does not provide networking.
-#[cfg(feature = "rest")]
-pub(crate) struct UnsupportedNetworkBackend;
-
-#[cfg(feature = "rest")]
-#[async_trait]
-impl BoxNetworkBackend for UnsupportedNetworkBackend {
-    async fn tunnel(&self, _target: SocketAddr) -> BoxliteResult<BoxTunnel> {
-        Err(BoxliteError::Unsupported(
-            "box networking is unavailable".into(),
-        ))
-    }
 }
 
 /// Backend abstraction for snapshot lifecycle operations on a box.

--- a/src/boxlite/src/runtime/backend.rs
+++ b/src/boxlite/src/runtime/backend.rs
@@ -133,8 +133,7 @@ pub(crate) trait BoxBackend: Send + Sync {
 /// network data-plane capabilities directly.
 #[async_trait]
 pub(crate) trait BoxNetworkBackend: Send + Sync {
-    /// Prepare a reusable tunnel target without opening a data connection.
-    /// Remote backends attach a public URL; local backends attach a Unix socket.
+    /// Establish a one-shot tunnel and return its prepared endpoint and connection.
     async fn tunnel(&self, target: SocketAddr) -> BoxliteResult<BoxTunnel>;
 }
 

--- a/src/boxlite/tests/gvproxy_backend.rs
+++ b/src/boxlite/tests/gvproxy_backend.rs
@@ -193,5 +193,4 @@ async fn live_gvproxy_backend_tunnel_handshake_returns_fd() {
     let tunnel = backend.tunnel(target).await.expect("tunnel handshake");
 
     assert_eq!(tunnel.peer_addr(), target);
-    assert!(tunnel.into_fd().is_some());
 }

--- a/src/cli/src/cli.rs
+++ b/src/cli/src/cli.rs
@@ -1326,6 +1326,24 @@ mod tests {
     use crate::commands::auth::AuthCommand;
     use clap::Parser;
 
+    // ─── tunnel parse tests ────────────────────────────────────────────────
+
+    #[test]
+    fn tunnel_parses_box_and_port() {
+        let cli = Cli::try_parse_from(["boxlite", "tunnel", "mybox", "3000"]).expect("parse");
+        let Commands::Tunnel(args) = cli.command else {
+            panic!("expected Commands::Tunnel");
+        };
+        assert_eq!(args.target, "mybox");
+        assert_eq!(args.port, 3000);
+    }
+
+    #[test]
+    fn tunnel_rejects_port_zero_at_parse() {
+        let result = Cli::try_parse_from(["boxlite", "tunnel", "mybox", "0"]);
+        assert!(result.is_err(), "port 0 must be rejected by the parser");
+    }
+
     #[test]
     fn auth_login_parses_with_no_flags() {
         let cli = Cli::try_parse_from(["boxlite", "auth", "login"]).expect("parse");

--- a/src/cli/src/cli.rs
+++ b/src/cli/src/cli.rs
@@ -96,6 +96,9 @@ pub enum Commands {
     /// Display resource usage statistics for a box
     Stats(crate::commands::stats::StatsArgs),
 
+    /// Print the public URL for a box service port
+    Tunnel(crate::commands::tunnel::TunnelArgs),
+
     /// Start a long-running REST API server
     Serve(crate::commands::serve::ServeArgs),
 

--- a/src/cli/src/commands/mod.rs
+++ b/src/cli/src/commands/mod.rs
@@ -15,3 +15,4 @@ pub mod serve;
 pub mod start;
 pub mod stats;
 pub mod stop;
+pub mod tunnel;

--- a/src/cli/src/commands/tunnel.rs
+++ b/src/cli/src/commands/tunnel.rs
@@ -33,7 +33,7 @@ pub async fn execute(args: TunnelArgs, global: &GlobalFlags) -> Result<()> {
         .network()
         .tunnel(SocketAddr::new(guest_ip, args.port))
         .await?;
-    let url = match tunnel.endpoint().await? {
+    let url = match tunnel.endpoint() {
         BoxEndpoint::Uri(uri) => uri,
         BoxEndpoint::FileDescriptor(_) => {
             return Err(anyhow!(

--- a/src/cli/src/commands/tunnel.rs
+++ b/src/cli/src/commands/tunnel.rs
@@ -1,0 +1,50 @@
+//! Print a public service URL without creating a local TCP listener.
+
+use std::net::SocketAddr;
+
+use anyhow::{Context, Result, anyhow};
+use boxlite::litebox::BoxEndpoint;
+use clap::Args;
+
+use crate::cli::GlobalFlags;
+
+#[derive(Args, Debug)]
+pub struct TunnelArgs {
+    /// Box ID or name
+    #[arg(value_name = "BOX")]
+    pub target: String,
+
+    /// Guest port listened to by the service
+    #[arg(value_name = "PORT")]
+    pub port: u16,
+}
+
+pub async fn execute(args: TunnelArgs, global: &GlobalFlags) -> Result<()> {
+    if args.port == 0 {
+        return Err(anyhow!("port must be in range 1-65535"));
+    }
+
+    let runtime = global.create_runtime()?;
+    let box_handle = runtime
+        .get(&args.target)
+        .await?
+        .ok_or_else(|| anyhow!("No such box: {}", args.target))?;
+
+    let guest_ip = boxlite::net::constants::GUEST_IP
+        .parse()
+        .context("BoxLite guest IP constant is invalid")?;
+    let tunnel = box_handle
+        .network()
+        .tunnel(SocketAddr::new(guest_ip, args.port))
+        .await?;
+    let url = match tunnel.endpoint().await? {
+        BoxEndpoint::Uri(uri) => uri,
+        BoxEndpoint::FileDescriptor(_) => {
+            return Err(anyhow!(
+                "boxlite tunnel requires a remote REST profile (--url or --profile)"
+            ));
+        }
+    };
+    println!("{url}");
+    Ok(())
+}

--- a/src/cli/src/commands/tunnel.rs
+++ b/src/cli/src/commands/tunnel.rs
@@ -14,16 +14,12 @@ pub struct TunnelArgs {
     #[arg(value_name = "BOX")]
     pub target: String,
 
-    /// Guest port listened to by the service
-    #[arg(value_name = "PORT")]
+    /// Guest port the service listens on
+    #[arg(value_name = "PORT", value_parser = clap::value_parser!(u16).range(1..))]
     pub port: u16,
 }
 
 pub async fn execute(args: TunnelArgs, global: &GlobalFlags) -> Result<()> {
-    if args.port == 0 {
-        return Err(anyhow!("port must be in range 1-65535"));
-    }
-
     let runtime = global.create_runtime()?;
     let box_handle = runtime
         .get(&args.target)

--- a/src/cli/src/main.rs
+++ b/src/cli/src/main.rs
@@ -119,6 +119,7 @@ async fn run_cli(cli: Cli) -> i32 {
         cli::Commands::Info(args) => commands::info::execute(args, &global).await.map(|_| 0),
         cli::Commands::Logs(args) => commands::logs::execute(args, &global).await.map(|_| 0),
         cli::Commands::Stats(args) => commands::stats::execute(args, &global).await.map(|_| 0),
+        cli::Commands::Tunnel(args) => commands::tunnel::execute(args, &global).await.map(|_| 0),
         cli::Commands::Serve(args) => commands::serve::execute(args, &global).await.map(|_| 0),
         cli::Commands::Auth(args) => commands::auth::run(args, &global).await.map(|_| 0),
         // Handled in main() before tokio; never reaches run_cli


### PR DESCRIPTION
Expose lazy box network tunnels through local and REST backends and add the CLI tunnel entrypoint.

Test plan:
- [x] Python and Node dev tunnel E2E passed on the combined implementation before the split
- [ ] Core-only CI pending