### PR TITLE
feat(sdk): expose box network tunnels

### DIFF
--- a/sdks/c/Cargo.toml
+++ b/sdks/c/Cargo.toml
@@ -17,12 +17,12 @@ crate-type = ["cdylib", "staticlib"]
 default = []
 
 [dependencies]
-boxlite = { workspace = true, features = ["rest"] }
+boxlite = { workspace = true, features = ["rest", "gvproxy"] }
 futures = "0.3"
-tokio = { version = "1.37", features = ["rt", "rt-multi-thread"] }
+tokio = { version = "1.37", features = ["io-util", "net", "rt", "rt-multi-thread"] }
 
 [dev-dependencies]
-boxlite = { workspace = true, features = ["rest"] }
+boxlite = { workspace = true, features = ["rest", "gvproxy"] }
 
 [build-dependencies]
 cbindgen = "0.29"

--- a/sdks/c/include/boxlite.h
+++ b/sdks/c/include/boxlite.h
@@ -64,6 +64,12 @@ typedef enum BoxliteErrorCode {
   SessionReaped = 21,
 } BoxliteErrorCode;
 
+// The kind of endpoint exposed by a box tunnel.
+typedef enum BoxliteEndpointType {
+  BoxliteEndpointTypeUri = 0,
+  BoxliteEndpointTypeFileDescriptor = 1,
+} BoxliteEndpointType;
+
 // Transport protocol for a port forwarding rule.
 typedef enum BoxlitePortProtocol {
   BoxlitePortProtocolTcp = 0,
@@ -85,8 +91,14 @@ typedef struct AdvancedBoxOptionsHandle AdvancedBoxOptionsHandle;
 // async lifecycle ops.
 typedef struct BoxHandle BoxHandle;
 
+// Opaque handle for network operations on a box.
+typedef struct BoxNetworkHandle BoxNetworkHandle;
+
 // Opaque handle for Runner API (auto-manages runtime)
 typedef struct BoxRunner BoxRunner;
+
+// Opaque handle for a one-shot box service tunnel.
+typedef struct BoxTunnelHandle BoxTunnelHandle;
 
 // Opaque credential handle. Wraps a core `Arc<dyn Credential>` so the
 // concrete credential kind (today only `ApiKeyCredential`) is hidden
@@ -298,6 +310,10 @@ typedef struct CRuntimeMetrics {
 
 // Runtime metrics completion.
 typedef void (*CRuntimeMetricsCb)(struct CRuntimeMetrics*, CBoxliteError*, void*);
+
+typedef struct BoxNetworkHandle CBoxNetworkHandle;
+
+typedef struct BoxTunnelHandle CBoxTunnelHandle;
 
 typedef struct CredentialHandle CBoxliteCredential;
 
@@ -529,6 +545,61 @@ enum BoxliteErrorCode boxlite_runtime_metrics(CBoxliteRuntime *runtime,
                                               CRuntimeMetricsCb cb,
                                               void *user_data,
                                               CBoxliteError *out_error);
+
+/**
+ * Borrow the box's network capability into a new owned handle.
+ *
+ * On success, `*out_network` must be released with `boxlite_network_free`.
+ * Returns `InvalidArgument` for null input/output pointers and writes details
+ * to `out_error` when provided.
+ */
+enum BoxliteErrorCode boxlite_box_network(CBoxHandle *handle,
+                                          CBoxNetworkHandle **out_network,
+                                          CBoxliteError *out_error);
+
+/** Release a network handle. Accepts NULL and does not affect the box handle. */
+void boxlite_network_free(CBoxNetworkHandle *network);
+
+/**
+ * Prepare a one-shot tunnel to `port` in the box.
+ *
+ * On success, `*out_tunnel` owns a handle that must be released with
+ * `boxlite_tunnel_free`. Returns `InvalidArgument` for a null network/output
+ * pointer or port zero, with details written to `out_error` when provided.
+ */
+enum BoxliteErrorCode boxlite_network_tunnel(CBoxNetworkHandle *network,
+                                             uint16_t port,
+                                             CBoxTunnelHandle **out_tunnel,
+                                             CBoxliteError *out_error);
+
+/** Release a tunnel handle and any unconsumed connection. Accepts NULL. */
+void boxlite_tunnel_free(CBoxTunnelHandle *tunnel);
+
+/**
+ * Inspect a prepared tunnel without transferring ownership.
+ *
+ * `out_type` selects the valid output: URI returns an allocated `*out_uri`
+ * that the caller must release with `boxlite_free_string`; FileDescriptor
+ * returns a borrowed `*out_fd` valid only while the tunnel remains alive.
+ * Unused outputs are initialized to NULL and -1. Errors are returned as a
+ * `BoxliteErrorCode` and described through `out_error` when provided.
+ */
+enum BoxliteErrorCode boxlite_tunnel_endpoint(CBoxTunnelHandle *tunnel,
+                                              enum BoxliteEndpointType *out_type,
+                                              char **out_uri,
+                                              int32_t *out_fd,
+                                              CBoxliteError *out_error);
+
+/**
+ * Consume a tunnel's single connection and return its owned file descriptor.
+ *
+ * On success, the caller owns `*out_fd` and must close it. A second call
+ * returns `InvalidState`. On failure `*out_fd` remains -1 and `out_error`
+ * receives details when provided.
+ */
+enum BoxliteErrorCode boxlite_tunnel_connect(CBoxTunnelHandle *tunnel,
+                                             int32_t *out_fd,
+                                             CBoxliteError *out_error);
 
 enum BoxliteErrorCode boxlite_options_new(const char *image,
                                           CBoxliteOptions **out_opts,

--- a/sdks/c/src/lib.rs
+++ b/sdks/c/src/lib.rs
@@ -16,6 +16,7 @@ mod exec;
 mod images;
 mod info;
 mod metrics;
+mod network;
 mod options;
 mod rest;
 mod runtime;
@@ -42,6 +43,8 @@ pub(crate) static FREE_STR_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(()
 
 pub type CBoxliteRuntime = runtime::RuntimeHandle;
 pub type CBoxHandle = box_handle::BoxHandle;
+pub type CBoxNetworkHandle = network::BoxNetworkHandle;
+pub type CBoxTunnelHandle = network::BoxTunnelHandle;
 pub type CBoxliteImageHandle = images::ImageHandle;
 pub type CBoxliteOptions = options::OptionsHandle;
 pub type CBoxliteCredential = rest::CredentialHandle;
@@ -68,6 +71,7 @@ pub use exec::*;
 pub use images::*;
 pub use info::*;
 pub use metrics::*;
+pub use network::*;
 pub use options::*;
 pub use rest::*;
 pub use runtime::*;

--- a/sdks/c/src/network.rs
+++ b/sdks/c/src/network.rs
@@ -1,0 +1,263 @@
+//! Network operations for the BoxLite C SDK.
+
+use std::ffi::CString;
+use std::net::SocketAddr;
+use std::os::fd::IntoRawFd;
+use std::os::raw::c_char;
+use std::ptr;
+use std::sync::Arc;
+
+use tokio::runtime::Runtime as TokioRuntime;
+
+use boxlite::litebox::{
+    BoxEndpoint, BoxTunnel as CoreBoxTunnel, NetworkHandle as CoreNetworkHandle,
+};
+use boxlite::{BoxConnection, BoxliteError};
+
+use crate::error::{BoxliteErrorCode, error_to_code, null_pointer_error, write_error};
+use crate::{CBoxHandle, CBoxNetworkHandle, CBoxTunnelHandle, CBoxliteError};
+
+async fn connection_fd(
+    mut connection: Box<dyn BoxConnection>,
+) -> Result<std::os::fd::OwnedFd, BoxliteError> {
+    let (sdk, mut bridge) = tokio::net::UnixStream::pair()
+        .map_err(|error| BoxliteError::Network(format!("create SDK socket bridge: {error}")))?;
+    tokio::spawn(async move {
+        let _ = tokio::io::copy_bidirectional(&mut connection, &mut bridge).await;
+    });
+    sdk.into_std()
+        .map(std::os::fd::OwnedFd::from)
+        .map_err(|error| BoxliteError::Network(format!("export SDK socket: {error}")))
+}
+
+/// Opaque handle for network operations on a box.
+pub struct BoxNetworkHandle {
+    handle: CoreNetworkHandle,
+    tokio_rt: Arc<TokioRuntime>,
+}
+
+/// Opaque handle for a one-shot box service tunnel.
+pub struct BoxTunnelHandle {
+    handle: Option<CoreBoxTunnel>,
+    tokio_rt: Arc<TokioRuntime>,
+}
+
+/// The kind of endpoint exposed by a box tunnel.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BoxliteEndpointType {
+    BoxliteEndpointTypeUri = 0,
+    BoxliteEndpointTypeFileDescriptor = 1,
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_box_network(
+    handle: *mut CBoxHandle,
+    out_network: *mut *mut CBoxNetworkHandle,
+    out_error: *mut CBoxliteError,
+) -> BoxliteErrorCode {
+    unsafe {
+        if handle.is_null() {
+            write_error(out_error, null_pointer_error("handle"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        if out_network.is_null() {
+            write_error(out_error, null_pointer_error("out_network"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+
+        *out_network = ptr::null_mut();
+        let handle_ref = &*handle;
+        *out_network = Box::into_raw(Box::new(BoxNetworkHandle {
+            handle: handle_ref.handle.network(),
+            tokio_rt: handle_ref.tokio_rt.clone(),
+        }));
+        BoxliteErrorCode::Ok
+    }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_network_free(network: *mut CBoxNetworkHandle) {
+    if !network.is_null() {
+        unsafe { drop(Box::from_raw(network)) };
+    }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_network_tunnel(
+    network: *mut CBoxNetworkHandle,
+    port: u16,
+    out_tunnel: *mut *mut CBoxTunnelHandle,
+    out_error: *mut CBoxliteError,
+) -> BoxliteErrorCode {
+    unsafe {
+        if network.is_null() {
+            write_error(out_error, null_pointer_error("network"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        if out_tunnel.is_null() {
+            write_error(out_error, null_pointer_error("out_tunnel"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        *out_tunnel = ptr::null_mut();
+        if port == 0 {
+            write_error(
+                out_error,
+                BoxliteError::InvalidArgument("tunnel port must be non-zero".into()),
+            );
+            return BoxliteErrorCode::InvalidArgument;
+        }
+
+        let target: SocketAddr = match format!("{}:{port}", boxlite::net::constants::GUEST_IP)
+            .parse()
+        {
+            Ok(target) => target,
+            Err(error) => {
+                write_error(
+                    out_error,
+                    BoxliteError::Internal(format!("invalid BoxLite guest IP constant: {error}")),
+                );
+                return BoxliteErrorCode::Internal;
+            }
+        };
+        let network_ref = &*network;
+        match network_ref
+            .tokio_rt
+            .block_on(network_ref.handle.tunnel(target))
+        {
+            Ok(handle) => {
+                *out_tunnel = Box::into_raw(Box::new(BoxTunnelHandle {
+                    handle: Some(handle),
+                    tokio_rt: network_ref.tokio_rt.clone(),
+                }));
+                BoxliteErrorCode::Ok
+            }
+            Err(error) => {
+                let code = error_to_code(&error);
+                write_error(out_error, error);
+                code
+            }
+        }
+    }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_tunnel_free(tunnel: *mut CBoxTunnelHandle) {
+    if !tunnel.is_null() {
+        unsafe { drop(Box::from_raw(tunnel)) };
+    }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_tunnel_endpoint(
+    tunnel: *mut CBoxTunnelHandle,
+    out_type: *mut BoxliteEndpointType,
+    out_uri: *mut *mut c_char,
+    out_fd: *mut i32,
+    out_error: *mut CBoxliteError,
+) -> BoxliteErrorCode {
+    unsafe {
+        if tunnel.is_null() {
+            write_error(out_error, null_pointer_error("tunnel"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        if out_type.is_null() {
+            write_error(out_error, null_pointer_error("out_type"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        if out_uri.is_null() {
+            write_error(out_error, null_pointer_error("out_uri"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        if out_fd.is_null() {
+            write_error(out_error, null_pointer_error("out_fd"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        *out_type = BoxliteEndpointType::BoxliteEndpointTypeUri;
+        *out_uri = ptr::null_mut();
+        *out_fd = -1;
+
+        let tunnel_ref = &*tunnel;
+        match tunnel_ref.handle.as_ref() {
+            Some(handle) => {
+                match handle.endpoint() {
+                    BoxEndpoint::Uri(uri) => {
+                        let uri = match CString::new(uri) {
+                            Ok(uri) => uri,
+                            Err(_) => {
+                                write_error(
+                                    out_error,
+                                    BoxliteError::Internal(
+                                        "tunnel endpoint contains a NUL byte".into(),
+                                    ),
+                                );
+                                return BoxliteErrorCode::Internal;
+                            }
+                        };
+                        *out_type = BoxliteEndpointType::BoxliteEndpointTypeUri;
+                        *out_uri = uri.into_raw();
+                    }
+                    BoxEndpoint::FileDescriptor(fd) => {
+                        *out_type = BoxliteEndpointType::BoxliteEndpointTypeFileDescriptor;
+                        *out_fd = fd;
+                    }
+                }
+                BoxliteErrorCode::Ok
+            }
+            None => {
+                let error = BoxliteError::InvalidState(
+                    "tunnel connection has already been consumed".into(),
+                );
+                let code = error_to_code(&error);
+                write_error(out_error, error);
+                code
+            }
+        }
+    }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_tunnel_connect(
+    tunnel: *mut CBoxTunnelHandle,
+    out_fd: *mut i32,
+    out_error: *mut CBoxliteError,
+) -> BoxliteErrorCode {
+    unsafe {
+        if tunnel.is_null() {
+            write_error(out_error, null_pointer_error("tunnel"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        if out_fd.is_null() {
+            write_error(out_error, null_pointer_error("out_fd"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        *out_fd = -1;
+
+        let tunnel_ref = &mut *tunnel;
+        let Some(handle) = tunnel_ref.handle.take() else {
+            let error =
+                BoxliteError::InvalidState("tunnel connection has already been consumed".into());
+            let code = error_to_code(&error);
+            write_error(out_error, error);
+            return code;
+        };
+        match handle.connect() {
+            Ok(connection) => match tunnel_ref.tokio_rt.block_on(connection_fd(connection)) {
+                Ok(fd) => {
+                    *out_fd = fd.into_raw_fd();
+                    BoxliteErrorCode::Ok
+                }
+                Err(error) => {
+                    let code = error_to_code(&error);
+                    write_error(out_error, error);
+                    code
+                }
+            },
+            Err(error) => {
+                let code = error_to_code(&error);
+                write_error(out_error, error);
+                code
+            }
+        }
+    }
+}

--- a/sdks/c/src/network.rs
+++ b/sdks/c/src/network.rs
@@ -2,7 +2,7 @@
 
 use std::ffi::CString;
 use std::net::SocketAddr;
-use std::os::fd::IntoRawFd;
+use std::os::fd::{BorrowedFd, IntoRawFd};
 use std::os::raw::c_char;
 use std::ptr;
 use std::sync::Arc;
@@ -241,6 +241,28 @@ pub unsafe extern "C" fn boxlite_tunnel_connect(
             write_error(out_error, error);
             return code;
         };
+        if let BoxEndpoint::FileDescriptor(fd) = handle.endpoint() {
+            // The local descriptor is already the tunnel. Duplicate it for the
+            // caller instead of inserting another socket pair and copy task.
+            let fd = BorrowedFd::borrow_raw(fd)
+                .try_clone_to_owned()
+                .map_err(|error| {
+                    BoxliteError::Network(format!("duplicate local tunnel descriptor: {error}"))
+                });
+            drop(handle);
+            return match fd {
+                Ok(fd) => {
+                    *out_fd = fd.into_raw_fd();
+                    BoxliteErrorCode::Ok
+                }
+                Err(error) => {
+                    let code = error_to_code(&error);
+                    write_error(out_error, error);
+                    code
+                }
+            };
+        }
+
         match handle.connect() {
             Ok(connection) => match tunnel_ref.tokio_rt.block_on(connection_fd(connection)) {
                 Ok(fd) => {

--- a/sdks/c/src/tests.rs
+++ b/sdks/c/src/tests.rs
@@ -188,6 +188,24 @@ fn test_runtime_images_null_pointer_validation() {
 }
 
 #[test]
+fn test_box_network_null_pointer_validation() {
+    unsafe {
+        let mut error = FFIError::default();
+        let mut network: *mut CBoxNetworkHandle = ptr::null_mut();
+        let code = boxlite_box_network(ptr::null_mut(), &mut network, &mut error as *mut _);
+        assert_eq!(code, BoxliteErrorCode::InvalidArgument);
+        assert!(!error.message.is_null());
+        boxlite_error_free(&mut error as *mut _);
+
+        let handle = std::ptr::NonNull::<CBoxHandle>::dangling().as_ptr();
+        let code = boxlite_box_network(handle, ptr::null_mut(), &mut error as *mut _);
+        assert_eq!(code, BoxliteErrorCode::InvalidArgument);
+        assert!(!error.message.is_null());
+        boxlite_error_free(&mut error as *mut _);
+    }
+}
+
+#[test]
 fn test_c_string_conversion_logic() {
     let test_str = CString::new("hello").unwrap();
     unsafe {
@@ -203,6 +221,8 @@ fn test_free_functions_null_safe() {
         boxlite_runtime_free(ptr::null_mut());
         boxlite_image_free(ptr::null_mut());
         boxlite_box_free(ptr::null_mut());
+        boxlite_network_free(ptr::null_mut());
+        boxlite_tunnel_free(ptr::null_mut());
         boxlite_free_string(ptr::null_mut());
         boxlite_error_free(ptr::null_mut());
         boxlite_result_free(ptr::null_mut());

--- a/sdks/go/tunnel.go
+++ b/sdks/go/tunnel.go
@@ -1,0 +1,154 @@
+//go:build unix
+
+package boxlite
+
+/*
+#include "bridge.h"
+*/
+import "C"
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+)
+
+// EndpointType identifies how clients can reach a box service tunnel.
+type EndpointType int
+
+const (
+	EndpointTypeURL EndpointType = iota
+	EndpointTypeFileDescriptor
+)
+
+// Endpoint describes the URI or prepared descriptor for a box service tunnel.
+type Endpoint struct {
+	Type EndpointType
+	URI  string
+	FD   int
+}
+
+// Network is a box-scoped handle for network operations.
+type Network struct {
+	handle *C.CBoxNetworkHandle
+}
+
+// Tunnel is a reusable connection target for a service inside a box.
+type Tunnel struct {
+	handle *C.CBoxTunnelHandle
+}
+
+// Network returns the box-scoped handle for network operations.
+func (b *Box) Network() (*Network, error) {
+	if b == nil || b.handle == nil {
+		return nil, ErrRuntimeClosed
+	}
+
+	var cNetwork *C.CBoxNetworkHandle
+	var cerr C.CBoxliteError
+	code := C.boxlite_box_network(b.handle, &cNetwork, &cerr)
+	if code != C.Ok {
+		return nil, freeError(&cerr)
+	}
+
+	return &Network{handle: cNetwork}, nil
+}
+
+// Close releases the network handle.
+func (n *Network) Close() error {
+	if n != nil && n.handle != nil {
+		C.boxlite_network_free(n.handle)
+		n.handle = nil
+	}
+	return nil
+}
+
+// Tunnel prepares a one-shot endpoint for a service port inside the box.
+func (n *Network) Tunnel(ctx context.Context, port uint16) (*Tunnel, error) {
+	if n == nil || n.handle == nil {
+		return nil, ErrRuntimeClosed
+	}
+	if port == 0 {
+		return nil, fmt.Errorf("invalid tunnel port %d", port)
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	var cTunnel *C.CBoxTunnelHandle
+	var cerr C.CBoxliteError
+	code := C.boxlite_network_tunnel(n.handle, C.uint16_t(port), &cTunnel, &cerr)
+	if code != C.Ok {
+		return nil, freeError(&cerr)
+	}
+	return &Tunnel{handle: cTunnel}, nil
+}
+
+// Close releases the tunnel handle.
+func (t *Tunnel) Close() error {
+	if t != nil && t.handle != nil {
+		C.boxlite_tunnel_free(t.handle)
+		t.handle = nil
+	}
+	return nil
+}
+
+// Endpoint returns the remote URI or borrowed local file descriptor.
+func (t *Tunnel) Endpoint() (Endpoint, error) {
+	if t == nil || t.handle == nil {
+		return Endpoint{}, ErrRuntimeClosed
+	}
+
+	var endpointType C.enum_BoxliteEndpointType
+	var uri *C.char
+	var fd C.int32_t
+	var cerr C.CBoxliteError
+	code := C.boxlite_tunnel_endpoint(t.handle, &endpointType, &uri, &fd, &cerr)
+	if code != C.Ok {
+		return Endpoint{}, freeError(&cerr)
+	}
+
+	switch endpointType {
+	case C.BoxliteEndpointTypeUri:
+		defer C.boxlite_free_string(uri)
+		return Endpoint{Type: EndpointTypeURL, URI: C.GoString(uri), FD: -1}, nil
+	case C.BoxliteEndpointTypeFileDescriptor:
+		return Endpoint{Type: EndpointTypeFileDescriptor, FD: int(fd)}, nil
+	default:
+		return Endpoint{}, fmt.Errorf("boxlite returned unknown endpoint type %d", endpointType)
+	}
+}
+
+// Connect consumes the tunnel's single raw byte stream.
+func (t *Tunnel) Connect(ctx context.Context) (net.Conn, error) {
+	if t == nil || t.handle == nil {
+		return nil, ErrRuntimeClosed
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	var cerr C.CBoxliteError
+	var cFD C.int32_t
+	code := C.boxlite_tunnel_connect(t.handle, &cFD, &cerr)
+	if code != C.Ok {
+		return nil, freeError(&cerr)
+	}
+	if cFD < 0 {
+		return nil, fmt.Errorf("boxlite tunnel returned invalid fd")
+	}
+	file := os.NewFile(uintptr(cFD), "boxlite-tunnel")
+	if file == nil {
+		return nil, fmt.Errorf("boxlite tunnel returned invalid fd")
+	}
+	defer file.Close()
+	conn, err := net.FileConn(file)
+	if err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	return conn, nil
+}

--- a/sdks/go/tunnel.go
+++ b/sdks/go/tunnel.go
@@ -13,17 +13,17 @@ import (
 	"os"
 )
 
-// EndpointType identifies how clients can reach a box service tunnel.
-type EndpointType int
+// BoxEndpointType identifies how clients can reach a box service tunnel.
+type BoxEndpointType int
 
 const (
-	EndpointTypeURL EndpointType = iota
-	EndpointTypeFileDescriptor
+	BoxEndpointTypeURI BoxEndpointType = iota
+	BoxEndpointTypeFileDescriptor
 )
 
-// Endpoint describes the URI or prepared descriptor for a box service tunnel.
-type Endpoint struct {
-	Type EndpointType
+// BoxEndpoint describes the URI or prepared descriptor for a box service tunnel.
+type BoxEndpoint struct {
+	Type BoxEndpointType
 	URI  string
 	FD   int
 }
@@ -33,8 +33,8 @@ type Network struct {
 	handle *C.CBoxNetworkHandle
 }
 
-// Tunnel is a reusable connection target for a service inside a box.
-type Tunnel struct {
+// BoxTunnel is a one-shot connection target for a service inside a box.
+type BoxTunnel struct {
 	handle *C.CBoxTunnelHandle
 }
 
@@ -64,7 +64,7 @@ func (n *Network) Close() error {
 }
 
 // Tunnel prepares a one-shot endpoint for a service port inside the box.
-func (n *Network) Tunnel(ctx context.Context, port uint16) (*Tunnel, error) {
+func (n *Network) Tunnel(ctx context.Context, port uint16) (*BoxTunnel, error) {
 	if n == nil || n.handle == nil {
 		return nil, ErrRuntimeClosed
 	}
@@ -81,11 +81,11 @@ func (n *Network) Tunnel(ctx context.Context, port uint16) (*Tunnel, error) {
 	if code != C.Ok {
 		return nil, freeError(&cerr)
 	}
-	return &Tunnel{handle: cTunnel}, nil
+	return &BoxTunnel{handle: cTunnel}, nil
 }
 
 // Close releases the tunnel handle.
-func (t *Tunnel) Close() error {
+func (t *BoxTunnel) Close() error {
 	if t != nil && t.handle != nil {
 		C.boxlite_tunnel_free(t.handle)
 		t.handle = nil
@@ -94,9 +94,9 @@ func (t *Tunnel) Close() error {
 }
 
 // Endpoint returns the remote URI or borrowed local file descriptor.
-func (t *Tunnel) Endpoint() (Endpoint, error) {
+func (t *BoxTunnel) Endpoint() (BoxEndpoint, error) {
 	if t == nil || t.handle == nil {
-		return Endpoint{}, ErrRuntimeClosed
+		return BoxEndpoint{}, ErrRuntimeClosed
 	}
 
 	var endpointType C.enum_BoxliteEndpointType
@@ -105,22 +105,22 @@ func (t *Tunnel) Endpoint() (Endpoint, error) {
 	var cerr C.CBoxliteError
 	code := C.boxlite_tunnel_endpoint(t.handle, &endpointType, &uri, &fd, &cerr)
 	if code != C.Ok {
-		return Endpoint{}, freeError(&cerr)
+		return BoxEndpoint{}, freeError(&cerr)
 	}
 
 	switch endpointType {
 	case C.BoxliteEndpointTypeUri:
 		defer C.boxlite_free_string(uri)
-		return Endpoint{Type: EndpointTypeURL, URI: C.GoString(uri), FD: -1}, nil
+		return BoxEndpoint{Type: BoxEndpointTypeURI, URI: C.GoString(uri), FD: -1}, nil
 	case C.BoxliteEndpointTypeFileDescriptor:
-		return Endpoint{Type: EndpointTypeFileDescriptor, FD: int(fd)}, nil
+		return BoxEndpoint{Type: BoxEndpointTypeFileDescriptor, FD: int(fd)}, nil
 	default:
-		return Endpoint{}, fmt.Errorf("boxlite returned unknown endpoint type %d", endpointType)
+		return BoxEndpoint{}, fmt.Errorf("boxlite returned unknown endpoint type %d", endpointType)
 	}
 }
 
 // Connect consumes the tunnel's single raw byte stream.
-func (t *Tunnel) Connect(ctx context.Context) (net.Conn, error) {
+func (t *BoxTunnel) Connect(ctx context.Context) (net.Conn, error) {
 	if t == nil || t.handle == nil {
 		return nil, ErrRuntimeClosed
 	}
@@ -130,7 +130,10 @@ func (t *Tunnel) Connect(ctx context.Context) (net.Conn, error) {
 
 	var cerr C.CBoxliteError
 	var cFD C.int32_t
-	code := C.boxlite_tunnel_connect(t.handle, &cFD, &cerr)
+	handle := t.handle
+	code := C.boxlite_tunnel_connect(handle, &cFD, &cerr)
+	C.boxlite_tunnel_free(handle)
+	t.handle = nil
 	if code != C.Ok {
 		return nil, freeError(&cerr)
 	}

--- a/sdks/go/tunnel_test.go
+++ b/sdks/go/tunnel_test.go
@@ -23,7 +23,7 @@ func TestBoxNetworkRejectsClosedHandle(t *testing.T) {
 }
 
 func TestTunnelMethodsRejectClosedHandle(t *testing.T) {
-	var tunnel *Tunnel
+	var tunnel *BoxTunnel
 	if _, err := tunnel.Endpoint(); !errors.Is(err, ErrRuntimeClosed) {
 		t.Fatalf("Endpoint() error = %v, want ErrRuntimeClosed", err)
 	}
@@ -36,7 +36,7 @@ func TestNetworkAndTunnelCloseAreIdempotent(t *testing.T) {
 	if err := (&Network{}).Close(); err != nil {
 		t.Fatalf("Network.Close() error = %v", err)
 	}
-	if err := (&Tunnel{}).Close(); err != nil {
+	if err := (&BoxTunnel{}).Close(); err != nil {
 		t.Fatalf("Tunnel.Close() error = %v", err)
 	}
 }

--- a/sdks/go/tunnel_test.go
+++ b/sdks/go/tunnel_test.go
@@ -1,0 +1,42 @@
+//go:build unix
+
+package boxlite
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestNetworkTunnelRejectsClosedHandle(t *testing.T) {
+	var network *Network
+	if _, err := network.Tunnel(context.Background(), 3000); !errors.Is(err, ErrRuntimeClosed) {
+		t.Fatalf("Tunnel() error = %v, want ErrRuntimeClosed", err)
+	}
+}
+
+func TestBoxNetworkRejectsClosedHandle(t *testing.T) {
+	var box *Box
+	if _, err := box.Network(); !errors.Is(err, ErrRuntimeClosed) {
+		t.Fatalf("Network() error = %v, want ErrRuntimeClosed", err)
+	}
+}
+
+func TestTunnelMethodsRejectClosedHandle(t *testing.T) {
+	var tunnel *Tunnel
+	if _, err := tunnel.Endpoint(); !errors.Is(err, ErrRuntimeClosed) {
+		t.Fatalf("Endpoint() error = %v, want ErrRuntimeClosed", err)
+	}
+	if _, err := tunnel.Connect(context.Background()); !errors.Is(err, ErrRuntimeClosed) {
+		t.Fatalf("Connect() error = %v, want ErrRuntimeClosed", err)
+	}
+}
+
+func TestNetworkAndTunnelCloseAreIdempotent(t *testing.T) {
+	if err := (&Network{}).Close(); err != nil {
+		t.Fatalf("Network.Close() error = %v", err)
+	}
+	if err := (&Tunnel{}).Close(); err != nil {
+		t.Fatalf("Tunnel.Close() error = %v", err)
+	}
+}


### PR DESCRIPTION
Expose one-shot box network tunnels through the C and Go SDKs while preserving direct local descriptors.

Test plan:
- [x] `cargo check -p boxlite-c` on Linux debug host
- [x] `cargo test -p boxlite-c --lib` on Linux debug host (59 passed, 1 ignored)
- [ ] `go test -tags boxlite_dev ./...` (blocked by existing unresolved auto-pause/resume/delete Cgo symbols on latest main)
