### PR TITLE
feat(proxy): route signed service port previews

### DIFF
--- a/apps/infra/sst.config.ts
+++ b/apps/infra/sst.config.ts
@@ -545,7 +545,7 @@ export default $config({
         PROXY_DOMAIN: envOr('PROXY_DOMAIN', `proxy.${stackDomain}`),
         PROXY_PROTOCOL: envOr('PROXY_PROTOCOL', 'https'),
         PROXY_API_KEY: envOr('PROXY_API_KEY', proxyApiKey.result),
-        PROXY_TEMPLATE_URL: envOr('PROXY_TEMPLATE_URL', `https://proxy.${stackDomain}`),
+        PROXY_TEMPLATE_URL: envOr('PROXY_TEMPLATE_URL', `https://{{PORT}}-{{boxId}}.proxy.${stackDomain}`),
 
         // SSH Gateway — friendly hostname `ssh.<stackDomain>` is provisioned
         // as a Cloudflare CNAME pointing at the SshGateway NLB further below.

--- a/apps/proxy/pkg/proxy/get_box_target.go
+++ b/apps/proxy/pkg/proxy/get_box_target.go
@@ -6,8 +6,10 @@ package proxy
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -16,10 +18,16 @@ import (
 
 	apiclient "github.com/boxlite-ai/boxlite/libs/api-client-go"
 	common_errors "github.com/boxlite-ai/common-go/pkg/errors"
+	common_proxy "github.com/boxlite-ai/common-go/pkg/proxy"
 	"github.com/boxlite-ai/common-go/pkg/utils"
 	"github.com/gin-gonic/gin"
 
 	log "github.com/sirupsen/logrus"
+)
+
+const (
+	directPreviewBoxIDLength        = 12
+	encodedDirectPreviewBoxIDLength = 24
 )
 
 func (p *Proxy) GetProxyTarget(ctx *gin.Context) (*url.URL, map[string]string, error) {
@@ -33,7 +41,7 @@ func (p *Proxy) GetProxyTarget(ctx *gin.Context) (*url.URL, map[string]string, e
 		ctx.Error(common_errors.NewBadRequestError(err))
 		return nil, nil, err
 	}
-	targetPath = ctx.Param("path")
+	targetPath = requestEscapedPath(ctx.Request.URL, ctx.Param("path"))
 
 	if targetPort == "" {
 		ctx.Error(common_errors.NewBadRequestError(errors.New("target port is required")))
@@ -46,6 +54,13 @@ func (p *Proxy) GetProxyTarget(ctx *gin.Context) (*url.URL, map[string]string, e
 	}
 
 	boxId := boxIdOrSignedToken
+	if decodedBoxId, ok, decodeErr := decodeDirectPreviewBoxID(boxIdOrSignedToken); decodeErr != nil {
+		ctx.Error(common_errors.NewBadRequestError(decodeErr))
+		return nil, nil, decodeErr
+	} else if ok {
+		boxId = decodedBoxId
+		boxIdOrSignedToken = decodedBoxId
+	}
 
 	isPublic, err := p.getBoxPublic(ctx, boxIdOrSignedToken)
 	if err != nil {
@@ -86,14 +101,7 @@ func (p *Proxy) GetProxyTarget(ctx *gin.Context) (*url.URL, map[string]string, e
 	}
 
 	// Build the target URL
-	targetURL := fmt.Sprintf("%s/boxes/%s/toolbox/proxy/%s", runnerInfo.ApiUrl, boxId, targetPort)
-
-	// Ensure path always has a leading slash but not duplicate slashes
-	if targetPath == "" {
-		targetPath = "/"
-	} else if !strings.HasPrefix(targetPath, "/") {
-		targetPath = "/" + targetPath
-	}
+	targetURL := runnerProxyTargetURL(runnerInfo.ApiUrl, boxId, targetPort)
 
 	// Create the complete target URL with path
 	target, err := url.Parse(fmt.Sprintf("%s%s", targetURL, targetPath))
@@ -102,10 +110,54 @@ func (p *Proxy) GetProxyTarget(ctx *gin.Context) (*url.URL, map[string]string, e
 		return nil, nil, fmt.Errorf("failed to parse target URL: %w", err)
 	}
 
+	forwardedProto := "http"
+	if p.config != nil && p.config.ProxyProtocol != "" {
+		forwardedProto = p.config.ProxyProtocol
+	}
+	forwardedHost := ctx.Request.Host
+	forwardedPort := forwardedPortFromHost(forwardedHost, forwardedProto)
+
 	return target, map[string]string{
 		"X-BoxLite-Authorization": fmt.Sprintf("Bearer %s", runnerInfo.ApiKey),
-		"X-Forwarded-Host":        ctx.Request.Host,
+		"X-Forwarded-Host":        forwardedHost,
+		"X-Forwarded-Proto":       forwardedProto,
+		"X-Forwarded-Port":        forwardedPort,
+		"Forwarded":               common_proxy.FormatForwardedHeader(forwardedHost, forwardedProto),
 	}, nil
+}
+
+func runnerProxyTargetURL(runnerApiURL string, boxId string, targetPort string) string {
+	if targetPort == TERMINAL_PORT {
+		return fmt.Sprintf("%s/boxes/%s/toolbox/proxy/%s", runnerApiURL, boxId, targetPort)
+	}
+	return fmt.Sprintf("%s/v1/boxes/%s/network/proxy/%s", runnerApiURL, boxId, targetPort)
+}
+
+func requestEscapedPath(requestURL *url.URL, fallbackPath string) string {
+	path := fallbackPath
+	if requestURL != nil && requestURL.EscapedPath() != "" {
+		path = requestURL.EscapedPath()
+	}
+	if path == "" {
+		return "/"
+	}
+	if !strings.HasPrefix(path, "/") {
+		return "/" + path
+	}
+	return path
+}
+
+func forwardedPortFromHost(host string, proto string) string {
+	if _, port, err := net.SplitHostPort(host); err == nil {
+		return port
+	}
+	if strings.EqualFold(proto, "https") {
+		return "443"
+	}
+	if strings.EqualFold(proto, "http") {
+		return "80"
+	}
+	return ""
 }
 
 func (p *Proxy) getBoxRunnerInfo(ctx context.Context, boxId string) (*RunnerInfo, error) {
@@ -287,6 +339,40 @@ func (p *Proxy) parseHost(host string) (targetPort string, boxIdOrSignedToken st
 	baseHost = strings.Join(parts[1:], ".")
 
 	return targetPort, boxIdOrSignedToken, baseHost, nil
+}
+
+func decodeDirectPreviewBoxID(value string) (string, bool, error) {
+	if len(value) != encodedDirectPreviewBoxIDLength {
+		return value, false, nil
+	}
+
+	decoded, err := hex.DecodeString(value)
+	if err != nil {
+		return value, false, nil
+	}
+	if len(decoded) == 0 {
+		return "", true, errors.New("invalid direct preview box ID: empty decoded box ID")
+	}
+
+	boxId := string(decoded)
+	if !isValidDirectPreviewBoxID(boxId) {
+		return "", true, errors.New("invalid direct preview box ID")
+	}
+
+	return boxId, true, nil
+}
+
+func isValidDirectPreviewBoxID(value string) bool {
+	if len(value) != directPreviewBoxIDLength {
+		return false
+	}
+	for _, ch := range value {
+		if (ch >= '0' && ch <= '9') || (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z') {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 // updateLastActivity updates the last activity timestamp for a box.

--- a/apps/proxy/pkg/proxy/get_box_target_test.go
+++ b/apps/proxy/pkg/proxy/get_box_target_test.go
@@ -1,0 +1,142 @@
+// Copyright 2026 BoxLite AI
+// SPDX-License-Identifier: AGPL-3.0
+
+package proxy
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	common_proxy "github.com/boxlite-ai/common-go/pkg/proxy"
+)
+
+func TestRequestEscapedPathPreservesEscapedSlash(t *testing.T) {
+	req := httptest.NewRequest("GET", "https://3999-token.proxy.dev.boxlite.ai/files/a%2Fb?download=1", nil)
+
+	got := requestEscapedPath(req.URL, "/files/a/b")
+	want := "/files/a%2Fb"
+	if got != want {
+		t.Fatalf("requestEscapedPath = %q, want %q", got, want)
+	}
+}
+
+func TestRequestEscapedPathUsesFallbackWhenRequestPathIsEmpty(t *testing.T) {
+	got := requestEscapedPath(nil, "health")
+	want := "/health"
+	if got != want {
+		t.Fatalf("requestEscapedPath fallback = %q, want %q", got, want)
+	}
+}
+
+func TestDecodeDirectPreviewBoxID(t *testing.T) {
+	got, ok, err := decodeDirectPreviewBoxID("35334d4f5a336a70355a7531")
+	if err != nil {
+		t.Fatalf("decodeDirectPreviewBoxID returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("decodeDirectPreviewBoxID did not recognize encoded direct box ID")
+	}
+	if got != "53MOZ3jp5Zu1" {
+		t.Fatalf("decodeDirectPreviewBoxID = %q, want %q", got, "53MOZ3jp5Zu1")
+	}
+}
+
+func TestDecodeDirectPreviewBoxIDRejectsDecodedPathCharacters(t *testing.T) {
+	_, ok, err := decodeDirectPreviewBoxID("35334d4f5a336a702f2e2e2f")
+	if err == nil {
+		t.Fatal("decodeDirectPreviewBoxID returned nil error")
+	}
+	if !ok {
+		t.Fatal("decodeDirectPreviewBoxID did not recognize encoded direct box ID")
+	}
+}
+
+func TestDecodeDirectPreviewBoxIDRejectsDecodedWrongLength(t *testing.T) {
+	_, ok, err := decodeDirectPreviewBoxID("35334d4f5a336a70355a75")
+	if err != nil {
+		t.Fatalf("decodeDirectPreviewBoxID returned error for legacy-sized value: %v", err)
+	}
+	if ok {
+		t.Fatal("decodeDirectPreviewBoxID unexpectedly recognized non-encoded value")
+	}
+
+	_, ok, err = decodeDirectPreviewBoxID("35334d4f5a336a70355a7500")
+	if err == nil {
+		t.Fatal("decodeDirectPreviewBoxID returned nil error")
+	}
+	if !ok {
+		t.Fatal("decodeDirectPreviewBoxID did not recognize encoded direct box ID")
+	}
+}
+
+func TestDecodeDirectPreviewBoxIDKeepsLegacyRawValue(t *testing.T) {
+	got, ok, err := decodeDirectPreviewBoxID("legacyboxid")
+	if err != nil {
+		t.Fatalf("decodeDirectPreviewBoxID returned error: %v", err)
+	}
+	if ok {
+		t.Fatal("decodeDirectPreviewBoxID unexpectedly recognized legacy raw value")
+	}
+	if got != "legacyboxid" {
+		t.Fatalf("decodeDirectPreviewBoxID = %q, want %q", got, "legacyboxid")
+	}
+}
+
+func TestDecodeDirectPreviewBoxIDKeepsShortRawValue(t *testing.T) {
+	got, ok, err := decodeDirectPreviewBoxID("abcdef0123456789")
+	if err != nil {
+		t.Fatalf("decodeDirectPreviewBoxID returned error: %v", err)
+	}
+	if ok {
+		t.Fatal("decodeDirectPreviewBoxID unexpectedly recognized short raw value")
+	}
+	if got != "abcdef0123456789" {
+		t.Fatalf("decodeDirectPreviewBoxID = %q, want %q", got, "abcdef0123456789")
+	}
+}
+
+func TestForwardedPortFromHost(t *testing.T) {
+	tests := []struct {
+		name  string
+		host  string
+		proto string
+		want  string
+	}{
+		{name: "explicit port", host: "3999-token.proxy.dev.boxlite.ai:8443", proto: "https", want: "8443"},
+		{name: "https default", host: "3999-token.proxy.dev.boxlite.ai", proto: "https", want: "443"},
+		{name: "http default", host: "3999-token.proxy.dev.boxlite.ai", proto: "http", want: "80"},
+		{name: "unknown proto", host: "3999-token.proxy.dev.boxlite.ai", proto: "tcp", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := forwardedPortFromHost(tt.host, tt.proto); got != tt.want {
+				t.Fatalf("forwardedPortFromHost(%q, %q) = %q, want %q", tt.host, tt.proto, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRunnerProxyTargetURLKeepsTerminalOnToolboxProxy(t *testing.T) {
+	got := runnerProxyTargetURL("http://runner:3003", "box123", TERMINAL_PORT)
+	want := "http://runner:3003/boxes/box123/toolbox/proxy/22222"
+	if got != want {
+		t.Fatalf("runnerProxyTargetURL = %q, want %q", got, want)
+	}
+}
+
+func TestRunnerProxyTargetURLUsesNetworkProxyForServicePorts(t *testing.T) {
+	got := runnerProxyTargetURL("http://runner:3003", "box123", "3000")
+	want := "http://runner:3003/v1/boxes/box123/network/proxy/3000"
+	if got != want {
+		t.Fatalf("runnerProxyTargetURL = %q, want %q", got, want)
+	}
+}
+
+func TestFormatForwardedHeader(t *testing.T) {
+	got := common_proxy.FormatForwardedHeader("3999-token.proxy.dev.boxlite.ai", "https")
+	want := `host="3999-token.proxy.dev.boxlite.ai";proto=https`
+	if got != want {
+		t.Fatalf("formatForwardedHeader = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Decode signed service preview hosts and route their HTTP traffic through the box network API.

Test plan:
- [x] `go test ./pkg/proxy`