### PR TITLE
fix(c): port example_common.h to callback API + add port-forwarding example and VM-free option test

### DIFF
--- a/examples/c/06_port_forwarding.c
+++ b/examples/c/06_port_forwarding.c
@@ -1,0 +1,65 @@
+/**
+ * BoxLite C SDK - Example 6: host->guest port forwarding + read-only volume.
+ *
+ * Demonstrates the previously-uncovered option API:
+ *   - boxlite_options_add_port (host:8080 -> guest:80, TCP, bind 127.0.0.1)
+ *   - boxlite_options_add_volume (/tmp/host_share -> /shared, read-only)
+ *
+ * Uses example_common.h, which is ported to the post-and-drain callback API.
+ * Needs a real BoxLite VM (macOS Hypervisor.framework / Linux KVM).
+ *
+ * Build & run:
+ *   cd examples/c && mkdir -p build && cd build && cmake .. && make && ./06_port_forwarding
+ */
+
+#include "example_common.h"
+#include <stdio.h>
+
+static void on_output(const char *text, int is_stderr, void *user_data) {
+  (void)user_data;
+  fputs(text, is_stderr ? stderr : stdout);
+}
+
+int main(void) {
+  printf("=== BoxLite Example: Port Forwarding + Volume ===\n\n");
+
+  CBoxliteRuntime *runtime = create_runtime_or_exit();
+  if (runtime == NULL) return 1;
+
+  // new_alpine_options_or_exit() already enables networking + auto_remove=0.
+  CBoxliteOptions *opts = new_alpine_options_or_exit();
+  if (opts == NULL) { boxlite_runtime_free(runtime); return 1; }
+
+  // Forward host 127.0.0.1:8080 -> guest :80 (TCP). host_port 0 would auto-pick.
+  BoxliteErrorCode code = boxlite_options_add_port(
+      opts, /*host*/ 8080, /*guest*/ 80, BoxlitePortProtocolTcp, "127.0.0.1");
+  if (code != Ok) {
+    fprintf(stderr, "add_port failed (code %d)\n", code);
+    boxlite_options_free(opts);
+    boxlite_runtime_free(runtime);
+    return 1;
+  }
+
+  // Read-only host directory mounted at /shared inside the guest.
+  boxlite_options_add_volume(opts, "/tmp/host_share", "/shared", /*read_only*/ 1);
+
+  // create_box_with_options_or_exit consumes `opts`.
+  CBoxHandle *box = create_box_with_options_or_exit(runtime, opts);
+  if (box == NULL) { boxlite_runtime_free(runtime); return 1; }
+
+  char *box_id = boxlite_box_id(box);
+  printf("Box %s: host 127.0.0.1:8080 -> guest:80, /shared (ro)\n\n",
+         box_id ? box_id : "?");
+
+  int exit_code = 0;
+  CBoxliteError error = {0};
+  code = execute_and_wait(box, "/bin/hostname", NULL, 0, on_output, NULL,
+                          &exit_code, &error);
+  if (code != Ok) { print_error("hostname", &error); boxlite_error_free(&error); }
+  printf("\n[exit %d]\n", exit_code);
+
+  boxlite_free_string(box_id);
+  boxlite_runtime_free(runtime);  // auto-frees the box
+  printf("\n=== Done ===\n");
+  return 0;
+}

--- a/examples/c/example_common.h
+++ b/examples/c/example_common.h
@@ -1,8 +1,14 @@
 #ifndef BOXLITE_EXAMPLE_COMMON_H
 #define BOXLITE_EXAMPLE_COMMON_H
 
+// NOTE: this is the version ported to the post-and-drain callback API.
+// It replaces the repo's examples/c/example_common.h, which used the old
+// direct out-param signatures (boxlite_create_box(runtime,opts,&box,&err) and
+// boxlite_execute(...)) that no longer exist in boxlite.h.
+
 #include "boxlite.h"
 #include <stdio.h>
+#include <string.h>
 
 static void print_error(const char *context, const CBoxliteError *error) {
   fprintf(stderr, "%s failed (code %d): %s\n", context, error->code,
@@ -35,21 +41,59 @@ static CBoxliteOptions *new_alpine_options_or_exit(void) {
   return opts;
 }
 
-static CBoxHandle *create_alpine_box_or_exit(CBoxliteRuntime *runtime) {
-  CBoxliteOptions *opts = new_alpine_options_or_exit();
-  if (opts == NULL) {
-    return NULL;
-  }
+// The post-and-drain API delivers the new handle via a callback.
+typedef struct { CBoxHandle *box; } CreateBoxCtx;
+static void on_box_created(CBoxHandle *box, CBoxliteError *err, void *ud) {
+  (void)err;  // failures are also reported through boxlite_create_box's out_error
+  ((CreateBoxCtx *)ud)->box = box;
+}
 
-  CBoxHandle *box = NULL;
+// Create a box from already-built options. Takes ownership of `opts`.
+static CBoxHandle *create_box_with_options_or_exit(CBoxliteRuntime *runtime,
+                                                    CBoxliteOptions *opts) {
+  CreateBoxCtx ctx = {0};
   CBoxliteError error = {0};
-  BoxliteErrorCode code = boxlite_create_box(runtime, opts, &box, &error);
-  if (code != Ok) {
+  BoxliteErrorCode code =
+      boxlite_create_box(runtime, opts, on_box_created, &ctx, &error);
+  boxlite_options_free(opts);
+  if (code != Ok || ctx.box == NULL) {
     print_error("box creation", &error);
     boxlite_error_free(&error);
     return NULL;
   }
-  return box;
+  return ctx.box;
+}
+
+static CBoxHandle *create_alpine_box_or_exit(CBoxliteRuntime *runtime) {
+  CBoxliteOptions *opts = new_alpine_options_or_exit();
+  if (opts == NULL) return NULL;
+  return create_box_with_options_or_exit(runtime, opts);
+}
+
+// Bridge the new byte-stream callbacks to the examples' (text, is_stderr, ud) contract.
+typedef struct {
+  void (*cb)(const char *, int, void *);
+  void *user_data;
+  int exit_code;
+} ExecCtx;
+
+static void forward(const uint8_t *data, size_t len, int is_stderr, ExecCtx *c) {
+  if (c->cb == NULL || len == 0) return;
+  char buf[4096];
+  size_t n = len < sizeof(buf) - 1 ? len : sizeof(buf) - 1;
+  memcpy(buf, data, n);
+  buf[n] = '\0';
+  c->cb(buf, is_stderr, c->user_data);
+}
+static void on_stdout_chunk(const uint8_t *data, size_t len, void *ud) {
+  forward(data, len, 0, (ExecCtx *)ud);
+}
+static void on_stderr_chunk(const uint8_t *data, size_t len, void *ud) {
+  forward(data, len, 1, (ExecCtx *)ud);
+}
+static void on_wait_done(int exit_code, CBoxliteError *err, void *ud) {
+  (void)err;
+  ((ExecCtx *)ud)->exit_code = exit_code;
 }
 
 static BoxliteErrorCode
@@ -57,24 +101,26 @@ execute_and_wait(CBoxHandle *box, const char *command,
                  const char *const *args, int argc,
                  void (*callback)(const char *, int, void *), void *user_data,
                  int *out_exit_code, CBoxliteError *error) {
-  BoxliteCommand cmd = {.command = command,
-                        .args = args,
-                        .argc = argc,
-                        .env_pairs = NULL,
-                        .env_count = 0,
-                        .workdir = NULL,
-                        .user = NULL,
-                        .timeout_secs = 0.0,
-                        .tty = 0};
+  BoxliteCommand cmd = {.command = command, .args = args, .argc = argc,
+                        .env_pairs = NULL, .env_count = 0,
+                        .workdir = NULL, .user = NULL,
+                        .timeout_secs = 0.0, .tty = 0};
+  ExecCtx ctx = {.cb = callback, .user_data = user_data, .exit_code = 0};
+
   CExecutionHandle *execution = NULL;
-  BoxliteErrorCode code =
-      boxlite_execute(box, &cmd, callback, user_data, &execution, error);
-  if (code != Ok) {
-    return code;
+  BoxliteErrorCode code = boxlite_box_exec(box, &cmd, &execution, error);
+  if (code != Ok) return code;
+
+  if (callback != NULL) {
+    code = boxlite_execution_on_stdout(execution, on_stdout_chunk, &ctx, error);
+    if (code != Ok) { boxlite_execution_free(execution); return code; }
+    code = boxlite_execution_on_stderr(execution, on_stderr_chunk, &ctx, error);
+    if (code != Ok) { boxlite_execution_free(execution); return code; }
   }
 
-  code = boxlite_execution_wait(execution, out_exit_code, error);
+  code = boxlite_execution_wait(execution, on_wait_done, &ctx, error);
   boxlite_execution_free(execution);
+  if (code == Ok && out_exit_code != NULL) *out_exit_code = ctx.exit_code;
   return code;
 }
 

--- a/sdks/c/README.md
+++ b/sdks/c/README.md
@@ -43,13 +43,13 @@ The C SDK provides two API styles:
    - Advanced features (volumes, networking, etc.)
 
 Both APIs support:
-- ‚úÖ Structured error handling (error codes + messages)
-- ‚úÖ OCI container images
-- ‚úÖ Hardware-accelerated VMs (KVM/Hypervisor.framework)
-- ‚úÖ Command execution with streaming output
-- ‚úÖ Box lifecycle management
-- ‚úÖ Performance metrics
-- ‚úÖ Multi-box management
+- ‚ú?Structured error handling (error codes + messages)
+- ‚ú?OCI container images
+- ‚ú?Hardware-accelerated VMs (KVM/Hypervisor.framework)
+- ‚ú?Command execution with streaming output
+- ‚ú?Box lifecycle management
+- ‚ú?Performance metrics
+- ‚ú?Multi-box management
 
 ---
 
@@ -90,7 +90,7 @@ Both APIs support:
 
 ```bash
 # From repository root
-git clone https://github.com/boxlite/boxlite.git
+git clone https://github.com/boxlite-ai/boxlite.git
 cd boxlite
 
 # Initialize submodules (REQUIRED!)
@@ -314,16 +314,16 @@ void boxlite_simple_free(CBoxliteSimple* box);
 ```
 
 #### When to Use Simple API
-- ‚úÖ Quick prototypes and scripts
-- ‚úÖ Single-box applications
-- ‚úÖ Buffered output is acceptable
-- ‚úÖ Standard resource limits (2 CPUs, 512 MB)
+- ‚ú?Quick prototypes and scripts
+- ‚ú?Single-box applications
+- ‚ú?Buffered output is acceptable
+- ‚ú?Standard resource limits (2 CPUs, 512 MB)
 
 #### When to Use Native API Instead
-- ‚ùå Need streaming output callbacks
-- ‚ùå Custom volumes or networking
-- ‚ùå Multi-box orchestration
-- ‚ùå Advanced configuration (custom box options)
+- ‚ù?Need streaming output callbacks
+- ‚ù?Custom volumes or networking
+- ‚ù?Multi-box orchestration
+- ‚ù?Advanced configuration (custom box options)
 
 ### Native API
 
@@ -653,22 +653,22 @@ make
 ### Rules
 
 1. **All allocated strings must be freed**
-   - `boxlite_box_id()` ‚Üí `boxlite_free_string()`
+   - `boxlite_box_id()` ‚Ü?`boxlite_free_string()`
 
 2. **Error structs must be freed**
-   - `CBoxliteError` ‚Üí `boxlite_error_free()`
+   - `CBoxliteError` ‚Ü?`boxlite_error_free()`
 
 3. **Results must be freed**
-   - `CBoxliteExecResult` ‚Üí `boxlite_result_free()`
-   - `CBoxInfo` ‚Üí `boxlite_free_box_info()`
-   - `CBoxInfoList` ‚Üí `boxlite_free_box_info_list()`
-   - `CImagePullResult` ‚Üí `boxlite_free_image_pull_result()`
-   - `CImageInfoList` ‚Üí `boxlite_free_image_info_list()`
+   - `CBoxliteExecResult` ‚Ü?`boxlite_result_free()`
+   - `CBoxInfo` ‚Ü?`boxlite_free_box_info()`
+   - `CBoxInfoList` ‚Ü?`boxlite_free_box_info_list()`
+   - `CImagePullResult` ‚Ü?`boxlite_free_image_pull_result()`
+   - `CImageInfoList` ‚Ü?`boxlite_free_image_info_list()`
 
 4. **Handles have specific free functions**
-   - `CBoxliteRuntime` ‚Üí `boxlite_runtime_free()` (auto-frees all boxes)
-   - `CBoxHandle` ‚Üí `boxlite_box_free()`
-   - `CBoxliteSimple` ‚Üí `boxlite_simple_free()`
+   - `CBoxliteRuntime` ‚Ü?`boxlite_runtime_free()` (auto-frees all boxes)
+   - `CBoxHandle` ‚Ü?`boxlite_box_free()`
+   - `CBoxliteSimple` ‚Ü?`boxlite_simple_free()`
 
 5. **All cleanup functions are NULL-safe**
 
@@ -717,7 +717,7 @@ leaks -atExit -- ./my_app
 
 ### Thread Safety
 
-- ‚úÖ **`CBoxliteRuntime` is thread-safe** - Multiple threads can call runtime functions concurrently
+- ‚ú?**`CBoxliteRuntime` is thread-safe** - Multiple threads can call runtime functions concurrently
 - ‚ö†Ô∏è **`CBoxHandle` is NOT thread-safe** - Don't share box handles across threads
 - ‚ö†Ô∏è **`CBoxliteSimple` is NOT thread-safe** - Don't share simple boxes across threads
 
@@ -791,11 +791,11 @@ Callbacks are invoked on the **calling thread**. Do not block in callbacks.
 
 | Platform | Architecture | Status | Requirements |
 |----------|-------------|--------|--------------|
-| macOS    | ARM64 (Apple Silicon) | ‚úÖ Full support | macOS 11.0+, Hypervisor.framework |
-| macOS    | x86_64 (Intel) | ‚ùå Not supported | N/A |
-| Linux    | x86_64 | ‚úÖ Full support | KVM enabled |
-| Linux    | ARM64 (aarch64) | ‚úÖ Full support | KVM enabled |
-| Windows  | Any | ‚ùå Not supported | Use WSL2 |
+| macOS    | ARM64 (Apple Silicon) | ‚ú?Full support | macOS 11.0+, Hypervisor.framework |
+| macOS    | x86_64 (Intel) | ‚ù?Not supported | N/A |
+| Linux    | x86_64 | ‚ú?Full support | KVM enabled |
+| Linux    | ARM64 (aarch64) | ‚ú?Full support | KVM enabled |
+| Windows  | Any | ‚ù?Not supported | Use WSL2 |
 
 ### Platform-Specific Notes
 
@@ -846,7 +846,7 @@ boxlite_options_add_port(opts, 8080, 80, BoxlitePortProtocolTcp, NULL);  /* host
 
 **Recommended migrations:**
 
-**1. Simple use cases ‚Üí Simple API**
+**1. Simple use cases ‚Ü?Simple API**
 
 Before (0.1.x):
 ```c
@@ -871,7 +871,7 @@ boxlite_result_free(result);
 boxlite_simple_free(box);
 ```
 
-**2. Error handling ‚Üí Structured errors**
+**2. Error handling ‚Ü?Structured errors**
 
 Before:
 ```c
@@ -999,7 +999,7 @@ The C SDK is a thin wrapper around the Rust `boxlite` crate:
 
 ```
 sdks/c/src/lib.rs
-  ‚Üì (exports C ABI)
+  ‚Ü?(exports C ABI)
 sdks/c/src/runtime.rs    (runtime management)
 sdks/c/src/box_handle.rs (box lifecycle)
 sdks/c/src/exec.rs       (command execution)
@@ -1007,7 +1007,7 @@ sdks/c/src/images.rs     (image operations)
 sdks/c/src/info.rs       (box info)
 sdks/c/src/metrics.rs    (metrics)
 sdks/c/src/copy.rs       (file copy)
-  ‚Üì (wraps)
+  ‚Ü?(wraps)
 boxlite/src/runtime/
 ```
 

--- a/sdks/c/tests/CMakeLists.txt
+++ b/sdks/c/tests/CMakeLists.txt
@@ -38,6 +38,7 @@ set(TEST_TARGETS
     test_simple_api
     test_null_callback
     test_rest
+    test_options_port
 )
 
 foreach(TARGET ${TEST_TARGETS})
@@ -75,6 +76,10 @@ set_tests_properties(test_null_callback PROPERTIES LABELS "ffi")
 # REST runtime construction does no I/O (lazy connect), so it is a
 # true unit test — runs under `make test:unit:c` (ctest -L unit).
 set_tests_properties(test_rest PROPERTIES LABELS "unit")
+
+# Like test_null_callback: only exercises option-builder FFI validation,
+# no VM is required.
+set_tests_properties(test_options_port PROPERTIES LABELS "ffi")
 
 message(STATUS "BoxLite C Tests Configuration:")
 message(STATUS "  Include dir: ${BOXLITE_INCLUDE_DIR}")

--- a/sdks/c/tests/test_options_port.c
+++ b/sdks/c/tests/test_options_port.c
@@ -1,0 +1,78 @@
+// VM-free FFI test for `boxlite_options_add_port` argument validation.
+//
+// Mirrors `test_null_callback`: it exercises ONLY the option-builder path —
+// no runtime/box is created and no KVM is required — so it runs under
+// `ctest -L ffi` without a real VM.
+//
+// Build & run (after `make dev:c`):
+//   cd sdks/c/tests && mkdir -p build && cd build && cmake .. && make && ctest -L ffi -V
+
+#include <stdio.h>
+#include "boxlite.h"
+
+static int failures = 0;
+
+#define CHECK(cond, msg) do {                                     \
+    if (!(cond)) { fprintf(stderr, "FAIL: %s\n", (msg)); failures++; } \
+    else          { printf("ok  : %s\n", (msg)); }                  \
+} while (0)
+
+// Free `err` only when a call failed; matches the README convention and keeps
+// the test free of double-free concerns across successive assertions.
+#define FREE_IF_ERR(code, err) do { if ((code) != Ok) boxlite_error_free(&(err)); } while (0)
+
+int main(void) {
+    CBoxliteOptions *opts = NULL;
+    CBoxliteError err = {0};
+
+    // Build an options object — no runtime, no VM, no I/O.
+    BoxliteErrorCode c = boxlite_options_new("alpine:3.19", &opts, &err);
+    CHECK(c == Ok, "boxlite_options_new succeeds");
+    if (c != Ok) { boxlite_error_free(&err); return 1; }
+
+    // host_port = 0 means "same as guest_port" (per boxlite.h) — valid.
+    err = (CBoxliteError){0};
+    c = boxlite_options_add_port(opts, /*host_port*/ 0, /*guest_port*/ 8080,
+                                 BoxlitePortProtocolTcp, /*host_ip*/ NULL);
+    CHECK(c == Ok, "add_port(host=0, guest=8080, Tcp, NULL) -> Ok");
+    FREE_IF_ERR(c, err);
+
+    // Explicit host bind + UDP — valid.
+    err = (CBoxliteError){0};
+    c = boxlite_options_add_port(opts, 9090, 90, BoxlitePortProtocolUdp, "127.0.0.1");
+    CHECK(c == Ok, "add_port(9090, 90, Udp, 127.0.0.1) -> Ok");
+    FREE_IF_ERR(c, err);
+
+    // guest_port == 0 is invalid (guest_port required, 1..65535).
+    err = (CBoxliteError){0};
+    c = boxlite_options_add_port(opts, 0, 0, BoxlitePortProtocolTcp, NULL);
+    CHECK(c == InvalidArgument, "add_port guest_port=0 -> InvalidArgument");
+    FREE_IF_ERR(c, err);
+
+    // NULL opts must be rejected, not crash.
+    err = (CBoxliteError){0};
+    c = boxlite_options_add_port(NULL, 8080, 80, BoxlitePortProtocolTcp, NULL);
+    CHECK(c == InvalidArgument, "add_port NULL opts -> InvalidArgument");
+    FREE_IF_ERR(c, err);
+
+    // Non-UTF-8 host_ip must be rejected (header contract).
+    const char bad_utf8[] = { (char)0xff, (char)0xfe, 0 };
+    err = (CBoxliteError){0};
+    c = boxlite_options_add_port(opts, 8080, 80, BoxlitePortProtocolTcp, bad_utf8);
+    CHECK(c == InvalidArgument, "add_port non-UTF-8 host_ip -> InvalidArgument");
+    FREE_IF_ERR(c, err);
+
+    // boxlite_options_add_volume returns void; just must not crash on valid input.
+    boxlite_options_add_volume(opts, "/tmp/host_share", "/shared", /*read_only*/ 1);
+    CHECK(1, "add_volume valid input does not crash");
+
+    boxlite_options_free(opts);
+    // `err` is already cleaned up on every failing branch above.
+
+    if (failures) {
+        fprintf(stderr, "%d check(s) failed\n", failures);
+        return 1;
+    }
+    printf("all checks passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

Closes #1002.

1. **`examples/c/example_common.h`** — ported to the post-and-drain callback API. `boxlite_create_box` now receives the handle via a `CBoxCreateBoxCb`; exec uses `boxlite_box_exec` + `on_stdout`/`on_stderr` + `execution_wait` (exit code via `CExecutionWaitCb`). The public helper signatures (`create_alpine_box_or_exit`, `execute_and_wait`) are unchanged, so existing examples that use them still call the same way. Added a new `create_box_with_options_or_exit(runtime, opts)` helper for examples that need custom options.
2. **`examples/c/06_port_forwarding.c`** *(new)* — demonstrates the previously-uncovered `boxlite_options_add_port` (host 127.0.0.1:8080 → guest 80) and `boxlite_options_add_volume` (read-only mount), using the fixed helper.
3. **`sdks/c/tests/test_options_port.c`** *(new)* — VM-free FFI test (CTest label `ffi`) pinning `boxlite_options_add_port`'s contract: `Ok` for valid args; `InvalidArgument` for `guest_port == 0`, `NULL opts`, and non-UTF-8 `host_ip`; plus a smoke call of `boxlite_options_add_volume`.
4. **`sdks/c/README.md`** — fix the clone URL (`github.com/boxlite/boxlite` → `github.com/boxlite-ai/boxlite`).

## Why

The C SDK migrated box creation / exec / lifecycle to a callback API, but `example_common.h` was not updated, so the examples stopped compiling (see #1002 for the gcc repro). The `add_port`/`add_volume` option API also had no coverage despite a recent breaking change. This PR fixes the shared helper and adds coverage.

The test is deliberately VM-free (label `ffi`, like `test_null_callback`) so it runs in CI without a KVM runner.

## Test plan

- [ ] `gcc -fsyntax-only -Wall -Wextra -I examples/c -I sdks/c/include examples/c/06_port_forwarding.c` → clean
- [ ] `make dev:c`
- [ ] `cd sdks/c/tests && mkdir -p build && cd build && cmake .. && make`
- [ ] `ctest -L ffi -V` → `test_options_port` passes (**no VM required**)
- [ ] `grep -rn "boxlite_options_add_port\|boxlite_options_add_volume" examples/c sdks/c/tests` → the new files are the only hits
- [ ] `06_port_forwarding.c` is intentionally **not** wired into `examples/c/CMakeLists.txt`: that `make` is already broken on `main` because the sibling examples (`01_lifecycle`, …) call the old direct lifecycle signatures (tracked separately). It is verified by the `gcc -fsyntax-only` step above and will be wired into the build once those siblings are migrated.

> Note: the remaining examples (`01_lifecycle`, `02_list_boxes`, …) also call lifecycle functions (`stop_box`/`get`/`start_box`/`remove`) with the old direct signatures and still need the same callback migration — tracked separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a C example demonstrating TCP host-to-guest port forwarding and read-only directory sharing.
* **Documentation**
  * Updated C SDK guidance, architecture details, supported platforms, and migration notes.
* **Bug Fixes**
  * Improved C SDK option and execution handling, including callback-based output streaming and completion reporting.
* **Tests**
  * Added validation coverage for port forwarding options, including invalid arguments, UDP configuration, and volume settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->