### PR TITLE
fix(exec): validate floating timeout seconds

### DIFF
--- a/sdks/c/src/exec/command.rs
+++ b/sdks/c/src/exec/command.rs
@@ -53,8 +53,8 @@ pub(super) unsafe fn parse_boxlite_command(
             box_cmd = box_cmd.user(c_str_to_string(cmd.user)?);
         }
 
-        if cmd.timeout_secs > 0.0 {
-            box_cmd = box_cmd.timeout(std::time::Duration::from_secs_f64(cmd.timeout_secs));
+        if cmd.timeout_secs != 0.0 {
+            box_cmd = box_cmd.timeout_seconds(cmd.timeout_secs)?;
         }
 
         if cmd.tty != 0 {
@@ -62,5 +62,39 @@ pub(super) unsafe fn parse_boxlite_command(
         }
 
         Ok(box_cmd)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::CString;
+    use std::ptr;
+
+    use super::*;
+
+    #[test]
+    fn parse_boxlite_command_rejects_invalid_timeout_secs() {
+        let command = CString::new("true").expect("command cstring");
+
+        for timeout_secs in [-1.0, f64::NAN, f64::INFINITY] {
+            let cmd = BoxliteCommand {
+                command: command.as_ptr(),
+                args: ptr::null(),
+                argc: 0,
+                env_pairs: ptr::null(),
+                env_count: 0,
+                workdir: ptr::null(),
+                user: ptr::null(),
+                timeout_secs,
+                tty: 0,
+            };
+
+            let err =
+                unsafe { parse_boxlite_command(&cmd) }.expect_err("invalid timeout should fail");
+            assert!(
+                matches!(err, BoxliteError::InvalidArgument(ref msg) if msg.contains("timeout_seconds")),
+                "unexpected error for {timeout_secs:?}: {err}"
+            );
+        }
     }
 }

--- a/sdks/node/src/box_handle.rs
+++ b/sdks/node/src/box_handle.rs
@@ -88,7 +88,7 @@ impl JsBox {
         }
 
         if let Some(secs) = timeout_secs {
-            cmd = cmd.timeout(std::time::Duration::from_secs_f64(secs));
+            cmd = cmd.timeout_seconds(secs).map_err(map_err)?;
         }
 
         if let Some(dir) = working_dir {

--- a/sdks/python/src/box_handle.rs
+++ b/sdks/python/src/box_handle.rs
@@ -72,7 +72,7 @@ impl PyBox {
                 cmd = cmd.user(user);
             }
             if let Some(secs) = timeout_secs {
-                cmd = cmd.timeout(std::time::Duration::from_secs_f64(secs));
+                cmd = cmd.timeout_seconds(secs).map_err(map_err)?;
             }
             if let Some(cwd) = cwd {
                 cmd = cmd.working_dir(cwd);

--- a/src/boxlite/src/litebox/exec.rs
+++ b/src/boxlite/src/litebox/exec.rs
@@ -3,6 +3,7 @@
 //! Type definitions for executing commands in a box.
 //! The actual execution logic is in BoxImpl::exec().
 
+use crate::BoxliteError;
 use crate::runtime::backend::ExecBackend;
 use boxlite_shared::errors::BoxliteResult;
 use futures::Stream;
@@ -79,6 +80,16 @@ impl BoxCommand {
     pub fn timeout(mut self, timeout: Duration) -> Self {
         self.timeout = Some(timeout);
         self
+    }
+
+    /// Set execution timeout from API-facing seconds.
+    pub fn timeout_seconds(self, seconds: f64) -> BoxliteResult<Self> {
+        let timeout = Duration::try_from_secs_f64(seconds).map_err(|_| {
+            BoxliteError::InvalidArgument(
+                "timeout_seconds must be a non-negative finite number".to_string(),
+            )
+        })?;
+        Ok(self.timeout(timeout))
     }
 
     /// Set working directory.
@@ -461,6 +472,29 @@ mod tests {
     fn test_box_command_user_whitespace_only_becomes_none() {
         let cmd = BoxCommand::new("id").user("  ");
         assert_eq!(cmd.user, None);
+    }
+
+    #[test]
+    fn timeout_seconds_rejects_negative_and_non_finite_values() {
+        for seconds in [-1.0, f64::NAN, f64::INFINITY] {
+            let err = BoxCommand::new("true")
+                .timeout_seconds(seconds)
+                .expect_err("invalid timeout should fail");
+
+            assert!(
+                matches!(err, BoxliteError::InvalidArgument(ref msg) if msg.contains("timeout_seconds")),
+                "unexpected error for {seconds:?}: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn timeout_seconds_accepts_positive_finite_values() {
+        let cmd = BoxCommand::new("true")
+            .timeout_seconds(1.5)
+            .expect("positive finite timeout should be accepted");
+
+        assert_eq!(cmd.timeout, Some(Duration::from_millis(1500)));
     }
 
     // ─── wait must not block kill ─────────────────────────────────────

--- a/src/cli/src/commands/serve/handlers/executions.rs
+++ b/src/cli/src/commands/serve/handlers/executions.rs
@@ -28,7 +28,10 @@ pub(in crate::commands::serve) async fn start_execution(
     };
 
     let stdin_data = req.stdin.clone();
-    let cmd = build_box_command(&req);
+    let cmd = match build_box_command(&req) {
+        Ok(cmd) => cmd,
+        Err(e) => return error_from_boxlite(&e),
+    };
 
     let mut execution = match litebox.exec(cmd).await {
         Ok(e) => e,

--- a/src/cli/src/commands/serve/mod.rs
+++ b/src/cli/src/commands/serve/mod.rs
@@ -680,7 +680,7 @@ fn build_box_options(req: &CreateBoxRequest) -> Result<BoxOptions, boxlite::Boxl
     })
 }
 
-fn build_box_command(req: &ExecRequest) -> BoxCommand {
+fn build_box_command(req: &ExecRequest) -> Result<BoxCommand, boxlite::BoxliteError> {
     let mut cmd = BoxCommand::new(&req.command).args(req.args.iter().map(String::as_str));
 
     if let Some(ref env_map) = req.env {
@@ -695,9 +695,9 @@ fn build_box_command(req: &ExecRequest) -> BoxCommand {
         cmd = cmd.tty(true);
     }
     if let Some(secs) = req.timeout_seconds {
-        cmd = cmd.timeout(std::time::Duration::from_secs_f64(secs));
+        cmd = cmd.timeout_seconds(secs)?;
     }
-    cmd
+    Ok(cmd)
 }
 
 // ============================================================================
@@ -1022,6 +1022,27 @@ mod tests {
         assert!(!constant_time_eq(b"abc", b"abd"));
         assert!(!constant_time_eq(b"abc", b"abcd"));
         assert!(constant_time_eq(b"", b""));
+    }
+
+    #[test]
+    fn build_box_command_rejects_invalid_timeout_seconds() {
+        for seconds in [-1.0, f64::NAN, f64::INFINITY] {
+            let req = ExecRequest {
+                command: "true".to_string(),
+                args: Vec::new(),
+                stdin: None,
+                env: None,
+                timeout_seconds: Some(seconds),
+                working_dir: None,
+                tty: false,
+            };
+
+            let err = build_box_command(&req).expect_err("invalid timeout should fail");
+            assert!(
+                matches!(err, boxlite::BoxliteError::InvalidArgument(ref msg) if msg.contains("timeout_seconds")),
+                "unexpected error for {seconds:?}: {err}"
+            );
+        }
     }
 
     // ============================================================


### PR DESCRIPTION
## Summary
Validate API-facing exec timeout seconds before converting them to `Duration`, so invalid floating-point inputs return `InvalidArgument` instead of panicking.

Fixes #1011.

## Changes
- Add `BoxCommand::timeout_seconds` as the shared validation point for user-provided timeout seconds.
- Route REST, Python, Node, and C exec entry points through the shared helper.
- Add unit coverage for negative, `NaN`, and `Infinity` timeout values at core, REST, and C parser boundaries.

## How to verify
- `cargo test -p boxlite timeout_seconds -- --nocapture`
- `cargo test -p boxlite-cli --bin boxlite build_box_command_rejects_invalid_timeout_seconds -- --nocapture`
- `cargo check -p boxlite-python -p boxlite-node`
- `CARGO_NET_OFFLINE=true cargo test -p boxlite-c parse_boxlite_command_rejects_invalid_timeout_secs -- --nocapture`
- `CARGO_NET_OFFLINE=true make test:unit:c`

## Risks / rollout
Low. This only changes invalid timeout inputs from panic-prone conversions to normal validation errors; the C API still treats `0.0` as no timeout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout handling across command execution interfaces.
  * Invalid timeout values, including negative, non-finite, or undefined values, now return clear validation errors instead of being accepted.
  * REST execution requests now report invalid timeout settings as HTTP errors.
  * Valid finite timeout values continue to be applied correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->