### PR TITLE
fix(ci): allow fork-PR checkout in label-gated e2e workflow

### DIFF
--- a/.github/workflows/e2e-local.yml
+++ b/.github/workflows/e2e-local.yml
@@ -402,6 +402,11 @@ jobs:
           persist-credentials: false
           submodules: recursive
           clean: false
+          # checkout v5.1.0+ refuses fork-PR checkouts under
+          # pull_request_target unless opted in. Safe here: the run is
+          # label-gated to the maintainer-approved head SHA, this job holds
+          # no secrets, and the token is read-only and not persisted.
+          allow-unsafe-pr-checkout: true
 
       - name: Verify KVM access
         run: |


### PR DESCRIPTION
## Why

actions/checkout v5.1.0 (2026-07-20) refuses to fetch fork PR code in `pull_request_target` workflows unless the step opts in via `allow-unsafe-pr-checkout: true`. Every fork PR now fails e2e at the Checkout step (first hit: #1016, run 29919073197):

> Refusing to check out fork pull request code from a 'pull_request_target' workflow. … set 'allow-unsafe-pr-checkout: true' on the actions/checkout step.

## What

Opt the e2e-tests Checkout step in. The mitigations the gate asks for already exist in this workflow: fork runs are gated on the maintainer-applied `e2e-local` label pinned to the approved head SHA (re-label per push), the job holds no secrets, and the token is `contents: read` with `persist-credentials: false`.

Note: actionlint ≤1.7.11 flags the input as unknown — stale bundled schema; the input is defined in action.yml at the SHA `v5` resolves to.

**After merge:** remove and re-add the `e2e-local` label on #1016 to re-run e2e against the fixed workflow definition (pull_request_target reads the workflow from main, so the fix takes effect only once merged).

https://claude.ai/code/session_019NzYgutK3RsJupnSe16M1w

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end test workflow configuration to support approved fork-based pull requests.
  * Added safety documentation clarifying the workflow’s restricted execution and permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->