### PR TITLE
fix(lifecycle): correct create-time box option validation

### DIFF
--- a/src/boxlite/src/rest/runtime.rs
+++ b/src/boxlite/src/rest/runtime.rs
@@ -81,8 +81,12 @@ fn litebox_from_rest(rest_box: Arc<RestBox>) -> LiteBox {
 #[async_trait::async_trait]
 impl RuntimeBackend for RestRuntime {
     async fn create(&self, options: BoxOptions, name: Option<String>) -> BoxliteResult<LiteBox> {
+        // Validate only the caller's requested policy. An unset auto_pause means
+        // "no auto-pause", so it must not borrow the server's default here —
+        // otherwise a plain remove-on-stop box (`--rm` → auto_delete=1) is
+        // wrongly rejected by the ordering check before the request is even sent.
         crate::runtime::types::BoxLifecyclePolicy {
-            auto_pause: options.auto_pause.unwrap_or(900),
+            auto_pause: options.auto_pause.unwrap_or(0),
             auto_delete: options.auto_delete.unwrap_or(0),
             auto_resume: options.auto_resume.unwrap_or(true),
         }
@@ -240,5 +244,31 @@ mod tests {
 
         // Should fail trying to reach the server for capability check
         assert!(result.is_err(), "Expected error when server is unreachable");
+    }
+
+    #[tokio::test]
+    async fn create_allows_remove_on_stop_without_autopause() {
+        // `run --rm` maps to auto_delete=1 with no auto_pause. The client must
+        // validate only the caller's requested policy — not the server's auto_pause
+        // default — so a remove-on-stop box is not rejected before the request is
+        // sent. With the server unreachable, a passing validation surfaces as a
+        // connection error, never the lifecycle-ordering error.
+        let options = BoxliteRestOptions::new("http://localhost:1"); // unreachable port
+        let runtime = RestRuntime::new(&options).expect("failed to create REST runtime");
+
+        let opts = BoxOptions {
+            auto_delete: Some(1),
+            ..Default::default()
+        };
+        let err = RuntimeBackend::create(&runtime, opts, None)
+            .await
+            .err()
+            .expect("unreachable server must yield an error");
+
+        assert!(
+            !err.to_string()
+                .contains("auto_delete must be greater than auto_pause"),
+            "remove-on-stop without auto_pause must pass client validation; got: {err}"
+        );
     }
 }

--- a/src/boxlite/src/runtime/core.rs
+++ b/src/boxlite/src/runtime/core.rs
@@ -278,6 +278,9 @@ impl BoxliteRuntime {
         options: BoxOptions,
         name: Option<String>,
     ) -> BoxliteResult<LiteBox> {
+        // Reject incompatible option combinations at the create boundary (fail
+        // here, not at start), uniformly for the local and REST backends.
+        options.sanitize()?;
         self.backend.create(options, name).await
     }
 
@@ -291,6 +294,7 @@ impl BoxliteRuntime {
         options: BoxOptions,
         name: Option<String>,
     ) -> BoxliteResult<(LiteBox, bool)> {
+        options.sanitize()?;
         self.backend.get_or_create(options, name).await
     }
 
@@ -523,3 +527,44 @@ const _: () = {
     const fn assert_send_sync<T: Send + Sync>() {}
     let _ = assert_send_sync::<BoxliteRuntime>;
 };
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn local_runtime() -> (BoxliteRuntime, TempDir) {
+        let temp_dir = TempDir::new_in("/tmp").expect("temp dir");
+        let runtime = BoxliteRuntime::new(BoxliteOptions {
+            home_dir: temp_dir.path().to_path_buf(),
+            image_registries: vec![],
+        })
+        .expect("local runtime");
+        (runtime, temp_dir)
+    }
+
+    #[tokio::test]
+    async fn create_rejects_detached_remove_on_stop() {
+        // Remove-on-stop (auto_delete>0) with detach=true is contradictory. The
+        // create boundary must reject it up front rather than deferring to start().
+        let (runtime, _dir) = local_runtime();
+        let opts = BoxOptions {
+            auto_delete: Some(1),
+            detach: true,
+            ..Default::default()
+        };
+        let err = runtime
+            .create(opts, None)
+            .await
+            .err()
+            .expect("detached remove-on-stop must be rejected at create");
+        assert!(
+            matches!(err, BoxliteError::Config(_)),
+            "expected a Config error, got: {err:?}"
+        );
+        assert!(
+            err.to_string().contains("remove-on-stop is incompatible"),
+            "unexpected message: {err}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the two e2e integration failures caused by #1009's create-time lifecycle
options. Both bugs are in the box-creation validation path and were surfaced by
the E2E Integration Tests job.

## Bugs

**1. `run --rm` over REST rejected (`run_over_rest_streams_output_and_propagates_exit_code`)**

`RestRuntime::create` fabricated the server's `auto_pause` default (900) when
checking the ordering rule `auto_delete <= auto_pause`. `run --rm` maps to
`auto_delete=1`, so a plain remove-on-stop box was rejected client-side
(`auto_delete must be greater than auto_pause`) before the request was ever
sent. Now the client validates only the caller's requested policy — an unset
`auto_pause` is `0`, matching the default used elsewhere (`types.rs`).

**2. `auto_remove + detach` not rejected at create (`test_auto_remove_true_detach_true_rejected`)**

`create()` persisted a box without running `BoxOptions::sanitize()`, so an
incompatible combination (remove-on-stop + detach) was only caught later at
`start()`. `sanitize()` now runs at the `BoxliteRuntime` create boundary,
uniformly for the local and REST backends.

## Changes

- `src/boxlite/src/rest/runtime.rs` — validate the requested lifecycle policy with `auto_pause` defaulting to `0`, not `900`.
- `src/boxlite/src/runtime/core.rs` — call `sanitize()` in `create` and `get_or_create` before delegating to the backend.
- Unit reproducers for both; each fails with the exact symptom when its fix is reverted.

## How to verify

```bash
cargo test -p boxlite --lib create_rejects_detached_remove_on_stop create_allows_remove_on_stop_without_autopause
```

The two e2e tests above run in the E2E Integration Tests job.

https://claude.ai/code/session_01TKsDvm6v2jB7ZKDVCSUzMA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed lifecycle validation so remove-on-stop configurations work when automatic pausing is not enabled.
  * Added consistent validation when creating or retrieving runtime instances.
  * Improved error reporting for incompatible remove-on-stop and detached execution settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->