### PR TITLE
ci(e2e-local): queue runs behind in-progress instead of cancelling

### DIFF
--- a/.github/workflows/e2e-local.yml
+++ b/.github/workflows/e2e-local.yml
@@ -10,7 +10,7 @@
 #     Wait for runner online           50-min timeout               if: always()
 #
 # Concurrency: only ONE e2e run at a time (single persistent instance).
-# Queued runs wait; in-progress runs are cancelled by newer pushes.
+# A newer push queues behind the in-progress run instead of cancelling it.
 #
 # Cost: c8i.4xlarge on-demand rate only while running + ~$4/mo EBS storage.
 # Subsequent runs skip setup/compilation (cached) → ~5-10 min → ~$0.03/run.
@@ -63,11 +63,14 @@ on:
         type: boolean
         default: false
 
-# Single global concurrency group — only one e2e run at a time.
-# The persistent instance can only serve one job. Newer pushes cancel older runs.
+# Single global concurrency group — only one e2e run at a time (the
+# persistent instance can only serve one job). A newer push queues behind
+# the in-progress run instead of cancelling it, so an in-flight run keeps
+# its VM work and the earlier commit still gets a result. GitHub keeps only
+# the newest pending run, so intermediate queued pushes are superseded.
 concurrency:
   group: e2e-runner
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 # pull_request_target's default token is write-capable and e2e-tests runs
 # labeled fork code — keep the inherited token read-only. start-runner and


### PR DESCRIPTION
## Summary
The e2e-local CI runner is a single persistent EC2 instance behind one global concurrency group, so `cancel-in-progress: true` let a push on any branch kill an in-flight run mid-way. This flips it to `false` so a newer run queues behind the in-progress one instead.

## Changes
- `e2e-local.yml`: `concurrency.cancel-in-progress: true → false` — a newer push now waits for the in-progress e2e run to finish rather than cancelling it.
- Rewrote the two concurrency comments to describe the queue-behind behavior and the "newest pending only" coalescing.

## How to verify
- `python3 -c "import yaml; print(yaml.safe_load(open('.github/workflows/e2e-local.yml'))['concurrency'])"` → `{'group': 'e2e-runner', 'cancel-in-progress': False}`.
- Behavioral (needs two overlapping runs): the second run stays `queued` until the first finishes instead of cancelling it — same pattern `publish-boxlite-cloud-images.yml` already uses.

## Risks / rollout
- A new push now waits up to a full run behind an in-progress one, and intermediate queued pushes are superseded (GitHub retains only the newest pending). Latest code still runs; only the wait changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated end-to-end test workflow scheduling so new runs wait for the current run to finish instead of cancelling it.
  * Clarified workflow documentation to reflect the revised queueing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->