### PR TITLE
feat(api): env-configurable box image allowlist

### DIFF
--- a/apps/api/src/box/constants/curated-images.constant.spec.ts
+++ b/apps/api/src/box/constants/curated-images.constant.spec.ts
@@ -7,8 +7,17 @@
 import { BadRequestError } from '../../exceptions/bad-request.exception'
 import { assertSupportedImage, supportedImages } from './curated-images.constant'
 
+const BASE_REF = 'ghcr.io/boxlite-ai/boxlite-agent-base:20260605-p0-r3'
+const PYTHON_REF = 'ghcr.io/boxlite-ai/boxlite-agent-python:20260605-p0-r3'
+const NODE_REF = 'ghcr.io/boxlite-ai/boxlite-agent-node:20260605-p0-r3'
+
 describe('supported image allowlist', () => {
-  const ENV_KEYS = ['BOXLITE_SYSTEM_BASE_IMAGE', 'BOXLITE_SYSTEM_PYTHON_IMAGE', 'BOXLITE_SYSTEM_NODE_IMAGE']
+  const ENV_KEYS = [
+    'BOXLITE_SYSTEM_BASE_IMAGE',
+    'BOXLITE_SYSTEM_PYTHON_IMAGE',
+    'BOXLITE_SYSTEM_NODE_IMAGE',
+    'BOXLITE_SYSTEM_IMAGES',
+  ]
   const saved: Record<string, string | undefined> = {}
 
   beforeEach(() => {
@@ -26,37 +35,68 @@ describe('supported image allowlist', () => {
     }
   })
 
-  it('exposes the three curated ghcr refs, base first (the default)', () => {
-    const supported = supportedImages()
-    expect(supported).toEqual([
-      'ghcr.io/boxlite-ai/boxlite-agent-base:20260605-p0-r3',
-      'ghcr.io/boxlite-ai/boxlite-agent-python:20260605-p0-r3',
-      'ghcr.io/boxlite-ai/boxlite-agent-node:20260605-p0-r3',
+  it('exposes the three built-ins as name/ref pairs, base first (the default)', () => {
+    expect(supportedImages()).toEqual([
+      { name: 'base', ref: BASE_REF },
+      { name: 'python', ref: PYTHON_REF },
+      { name: 'node', ref: NODE_REF },
     ])
   })
 
-  it('accepts each supported ref verbatim', () => {
-    for (const ref of supportedImages()) {
+  it('resolves a built-in name to its ref', () => {
+    expect(assertSupportedImage('base')).toBe(BASE_REF)
+    expect(assertSupportedImage('python')).toBe(PYTHON_REF)
+    expect(assertSupportedImage('node')).toBe(NODE_REF)
+  })
+
+  it('accepts a full ref verbatim and returns it', () => {
+    for (const { ref } of supportedImages()) {
       expect(assertSupportedImage(ref)).toBe(ref)
     }
   })
 
   it('defaults to the base ref when no image is supplied', () => {
-    expect(assertSupportedImage(undefined)).toBe(supportedImages()[0])
+    expect(assertSupportedImage(undefined)).toBe(BASE_REF)
   })
 
   it('prefers the env-configured ref over the curated fallback', () => {
     process.env.BOXLITE_SYSTEM_PYTHON_IMAGE = 'ghcr.io/boxlite-ai/override@sha256:deadbeef'
-    expect(assertSupportedImage('ghcr.io/boxlite-ai/override@sha256:deadbeef')).toBe(
-      'ghcr.io/boxlite-ai/override@sha256:deadbeef',
-    )
+    expect(assertSupportedImage('python')).toBe('ghcr.io/boxlite-ai/override@sha256:deadbeef')
   })
 
-  it('rejects anything outside the allowlist, naming the supported refs', () => {
+  it('appends BOXLITE_SYSTEM_IMAGES additions, resolvable by name or ref', () => {
+    process.env.BOXLITE_SYSTEM_IMAGES = 'hermes=sam2026go/hermes-agent:boxlite'
+
+    expect(supportedImages()).toEqual([
+      { name: 'base', ref: BASE_REF },
+      { name: 'python', ref: PYTHON_REF },
+      { name: 'node', ref: NODE_REF },
+      { name: 'hermes', ref: 'sam2026go/hermes-agent:boxlite' },
+    ])
+    expect(assertSupportedImage('hermes')).toBe('sam2026go/hermes-agent:boxlite')
+    expect(assertSupportedImage('sam2026go/hermes-agent:boxlite')).toBe('sam2026go/hermes-agent:boxlite')
+  })
+
+  it('parses a multi-entry list, trimming whitespace and dropping empty entries', () => {
+    process.env.BOXLITE_SYSTEM_IMAGES = ' hermes = sam2026go/hermes-agent:boxlite , , foo=ghcr.io/acme/foo:1 '
+    expect(supportedImages().slice(3)).toEqual([
+      { name: 'hermes', ref: 'sam2026go/hermes-agent:boxlite' },
+      { name: 'foo', ref: 'ghcr.io/acme/foo:1' },
+    ])
+  })
+
+  it('throws on a malformed BOXLITE_SYSTEM_IMAGES entry (missing name or ref)', () => {
+    process.env.BOXLITE_SYSTEM_IMAGES = 'sam2026go/hermes-agent:boxlite'
+    expect(() => supportedImages()).toThrow(/Invalid BOXLITE_SYSTEM_IMAGES entry/)
+
+    process.env.BOXLITE_SYSTEM_IMAGES = 'hermes='
+    expect(() => supportedImages()).toThrow(/Invalid BOXLITE_SYSTEM_IMAGES entry/)
+  })
+
+  it('rejects a selector outside the set, naming the supported names and refs', () => {
     expect(() => assertSupportedImage('alpine:3.23')).toThrow(BadRequestError)
     expect(() => assertSupportedImage('ghcr.io/evil/image:latest')).toThrow(BadRequestError)
-    // legacy curated keys are no longer accepted -- only full refs are
-    expect(() => assertSupportedImage('python')).toThrow(BadRequestError)
-    expect(() => assertSupportedImage('nope')).toThrow(/Supported images: .*boxlite-agent-base/)
+    // an added image is unreachable once its env entry is gone
+    expect(() => assertSupportedImage('hermes')).toThrow(/Supported images: base \(.*boxlite-agent-base/)
   })
 })

--- a/apps/api/src/box/constants/curated-images.constant.ts
+++ b/apps/api/src/box/constants/curated-images.constant.ts
@@ -7,54 +7,99 @@
 import { BadRequestError } from '../../exceptions/bad-request.exception'
 
 /**
- * Temporary curated-image gate: boxes may only boot from this fixed set of curated OCI
- * refs, because the runner pulls with its own private-registry token and must never be
- * handed an arbitrary user-supplied image. The gate is deliberately thin and sits only
- * at the request boundary (BoxService create / warm-pool); everything downstream treats
- * `image` as an opaque OCI ref. When per-org custom images land, delete this file and
- * its call sites — no other layer knows the curated set exists.
+ * Curated-image gate: boxes may only boot from a fixed, operator-controlled set of images,
+ * because the runner pulls with its own private-registry token and must never be handed an
+ * arbitrary user-supplied image. The gate is deliberately thin and sits only at the request
+ * boundary (BoxService create / warm-pool); everything downstream treats the resolved ref as
+ * an opaque OCI ref. When per-org custom images land, delete this file and its call sites --
+ * no other layer knows the curated set exists.
  *
- * Env overrides (set on the Api service in apps/infra/sst.config.ts) allow ref
- * rotation without a code deploy; the fallbacks cover local/dev runs.
+ * Each image has a short `name` and an OCI `ref`; a caller may select either (undefined picks
+ * the default -- the first entry, `base`). The set is the three built-ins plus any operator
+ * additions, both configured via env so refs rotate and images are added without a code deploy:
+ *   BOXLITE_SYSTEM_{BASE,PYTHON,NODE}_IMAGE  -- rotate a built-in's ref
+ *   BOXLITE_SYSTEM_IMAGES                     -- add images, comma-separated `name=ref`
+ *                                                e.g. "hermes=sam2026go/hermes-agent:boxlite"
  */
-type SupportedImageSource = {
+export type SupportedImage = {
+  name: string
+  ref: string
+}
+
+type BuiltinImageSource = {
+  name: string
   envVar: string
   fallbackRef: string
 }
 
-const SUPPORTED_IMAGE_SOURCES: SupportedImageSource[] = [
+const BUILTIN_IMAGE_SOURCES: BuiltinImageSource[] = [
   {
+    name: 'base',
     envVar: 'BOXLITE_SYSTEM_BASE_IMAGE',
     fallbackRef: 'ghcr.io/boxlite-ai/boxlite-agent-base:20260605-p0-r3',
   },
   {
+    name: 'python',
     envVar: 'BOXLITE_SYSTEM_PYTHON_IMAGE',
     fallbackRef: 'ghcr.io/boxlite-ai/boxlite-agent-python:20260605-p0-r3',
   },
   {
+    name: 'node',
     envVar: 'BOXLITE_SYSTEM_NODE_IMAGE',
     fallbackRef: 'ghcr.io/boxlite-ai/boxlite-agent-node:20260605-p0-r3',
   },
 ]
 
-/** Curated OCI refs a box may boot from. The first entry is the default image. */
-export function supportedImages(): string[] {
-  return SUPPORTED_IMAGE_SOURCES.map(({ envVar, fallbackRef }) => process.env[envVar] || fallbackRef)
+/** Env var carrying operator-added images as comma-separated `name=ref` pairs. */
+const EXTRA_IMAGES_ENV = 'BOXLITE_SYSTEM_IMAGES'
+
+/**
+ * Parse `name=ref,name=ref` into images. A malformed entry throws (operator config, not user
+ * input) so a typo surfaces loudly at the boundary instead of silently dropping an image.
+ */
+function parseExtraImages(raw: string | undefined): SupportedImage[] {
+  return (raw ?? '')
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .map((entry) => {
+      const separator = entry.indexOf('=')
+      const name = separator > 0 ? entry.slice(0, separator).trim() : ''
+      const ref = separator > 0 ? entry.slice(separator + 1).trim() : ''
+      if (!name || !ref) {
+        throw new Error(`Invalid ${EXTRA_IMAGES_ENV} entry '${entry}', expected 'name=ref'`)
+      }
+      return { name, ref }
+    })
 }
 
 /**
- * Validate a user-supplied OCI ref at the request boundary. Undefined selects the
- * default image; anything outside the supported set is rejected with the full list so
- * callers can self-correct.
+ * Curated images a box may boot from: the built-in three (each ref env-overridable) followed
+ * by any BOXLITE_SYSTEM_IMAGES additions. The first entry (`base`) is the default image.
+ */
+export function supportedImages(): SupportedImage[] {
+  const builtins = BUILTIN_IMAGE_SOURCES.map(({ name, envVar, fallbackRef }) => ({
+    name,
+    ref: process.env[envVar] || fallbackRef,
+  }))
+  return [...builtins, ...parseExtraImages(process.env[EXTRA_IMAGES_ENV])]
+}
+
+/**
+ * Resolve a user-supplied selector to its OCI ref at the request boundary. Undefined selects
+ * the default image; a value matching a supported name or ref resolves to that ref; anything
+ * else is rejected with the full list so callers can self-correct.
  */
 export function assertSupportedImage(image: string | undefined): string {
   const supported = supportedImages()
 
   if (image === undefined) {
-    return supported[0]
+    return supported[0].ref
   }
-  if (!supported.includes(image)) {
-    throw new BadRequestError(`Unsupported image '${image}'. Supported images: ${supported.join(', ')}`)
+  const match = supported.find(({ name, ref }) => image === name || image === ref)
+  if (!match) {
+    const options = supported.map(({ name, ref }) => `${name} (${ref})`).join(', ')
+    throw new BadRequestError(`Unsupported image '${image}'. Supported images: ${options}`)
   }
-  return image
+  return match.ref
 }

--- a/apps/api/src/box/dto/create-box.dto.ts
+++ b/apps/api/src/box/dto/create-box.dto.ts
@@ -20,8 +20,9 @@ export class CreateBoxDto {
   name?: string
 
   @ApiPropertyOptional({
-    description: 'The image to use for the box',
-    example: 'boxlite/base',
+    description:
+      'Image to boot the box from: a supported image name (e.g. "base") or its full OCI ref. Omit for the default.',
+    example: 'base',
   })
   @IsOptional()
   @IsString()

--- a/apps/infra/sst.config.ts
+++ b/apps/infra/sst.config.ts
@@ -456,11 +456,12 @@ export default $config({
         VERSION: '0.1.0',
         DEFAULT_REGION_ENFORCE_QUOTAS: 'false',
         DEFAULT_TEMPLATE: envOr('DEFAULT_TEMPLATE', 'boxlite/base'),
-        // Box base images: only the three digest-pinned *_IMAGE refs below are live — the
-        // API gates box creation to that curated set (apps/api curated-images.constant.ts)
-        // and the runner pulls them straight from ghcr.io with its GHCR_TOKEN. IMAGE_TAG and
-        // the SOURCE_REGISTRY_* block are inert Daytona-port residue (no consumer — see
-        // apps/api configuration.ts), kept only as reserved names for a future registry path.
+        // Box base images: the three *_IMAGE refs below are the built-in curated set the API
+        // gates box creation to (apps/api curated-images.constant.ts); the runner pulls them
+        // straight from ghcr.io with its GHCR_TOKEN. BOXLITE_SYSTEM_IMAGES appends more images
+        // (comma-separated `name=ref`) without a code deploy — empty means built-ins only.
+        // IMAGE_TAG and the SOURCE_REGISTRY_* block are inert Daytona-port residue (no consumer
+        // — see apps/api configuration.ts), kept only as reserved names for a future registry path.
         BOXLITE_SYSTEM_IMAGE_TAG: envOr('BOXLITE_SYSTEM_IMAGE_TAG', '20260605-p0-r3'),
         BOXLITE_SYSTEM_BASE_IMAGE: envOr(
           'BOXLITE_SYSTEM_BASE_IMAGE',
@@ -474,6 +475,7 @@ export default $config({
           'BOXLITE_SYSTEM_NODE_IMAGE',
           'ghcr.io/boxlite-ai/boxlite-agent-node:20260605-p0-r3',
         ),
+        BOXLITE_SYSTEM_IMAGES: envOr('BOXLITE_SYSTEM_IMAGES', ''),
         ...(process.env.BOXLITE_SYSTEM_SOURCE_REGISTRY_URL && {
           BOXLITE_SYSTEM_SOURCE_REGISTRY_NAME: envOr(
             'BOXLITE_SYSTEM_SOURCE_REGISTRY_NAME',


### PR DESCRIPTION
## What

Make the box-image allowlist configurable from env so images can be added
without a code deploy.

- `BOXLITE_SYSTEM_IMAGES` (comma-separated `name=ref`) appends images to the
  built-in `base`/`python`/`node` set; `base` stays the default.
- Images are `{ name, ref }`; a create-time selector resolves by name or full
  OCI ref to the ref, so persist / warm-pool / runner stay on opaque refs.
- A malformed `name=ref` entry throws at the request boundary (operator config).

## Verification

- Unit spec 9/9, incl. two-side A/B (old `string[]` code fails the new spec).
- `tsc --noEmit` on the api app source clean; sole consumer `box.service.ts:175`
  keeps the same `string` return.
- Live local-infra run (`POST /api/v1/boxes`): `hermes` accepted by name and by
  full ref (persisted as the resolved ref), unknowns rejected with the full
  supported list, omitted image defaults to base.

Note: actually booting `sam2026go/hermes-agent:boxlite` needs a linux/arm64
image build (currently amd64-only) — out of scope for this allowlist change.

https://claude.ai/code/session_01YFLhjZmRUvDUFtwBp9wELy


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Select system images by built-in names or full OCI references when creating a box.
  * Add custom supported images through `BOXLITE_SYSTEM_IMAGES` using `name=ref` entries.
  * Configure image overrides through environment settings.

* **Bug Fixes**
  * Improved validation and error messages for unsupported or malformed image selections.

* **Documentation**
  * Updated image configuration guidance and API examples, including the default `base` image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->