### PR TITLE
fix(python-sdk): clean up ruff lint baseline and pin ruff version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -167,7 +167,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install ruff
-        run: pip install ruff
+        run: pip install ruff==0.16.0
 
       - name: Run Python lint
         run: make lint:python

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -30,6 +30,7 @@ Requires Python 3.10 or later.
 
 ```python
 import boxlite
+
 print(boxlite.__version__)  # Prints installed package version
 ```
 
@@ -54,12 +55,14 @@ ls -l /dev/kvm                    # Should exist and be accessible
 import asyncio
 import boxlite
 
+
 async def main():
     # Create a box and run a command
     async with boxlite.SimpleBox(image="python:slim") as box:
         result = await box.exec("python", "-c", "print('Hello from BoxLite!')")
         print(result.stdout)
         # Output: Hello from BoxLite!
+
 
 asyncio.run(main())
 ```
@@ -69,6 +72,7 @@ asyncio.run(main())
 ```python
 import asyncio
 import boxlite
+
 
 async def main():
     # Execute untrusted Python code safely
@@ -82,6 +86,7 @@ print(response.text)
         # CodeBox automatically installs packages
         result = await codebox.run(code)
         print(result)
+
 
 asyncio.run(main())
 ```
@@ -124,15 +129,17 @@ runtime = boxlite.Boxlite.default()
 runtime = boxlite.Boxlite(boxlite.Options(home_dir="/custom/path"))
 
 # Custom registry host with basic auth
-runtime = boxlite.Boxlite(boxlite.Options(
-    image_registries=[
-        boxlite.ImageRegistry(
-            host="registry.example.com",
-            username="user",
-            password="password",
-        )
-    ]
-))
+runtime = boxlite.Boxlite(
+    boxlite.Options(
+        image_registries=[
+            boxlite.ImageRegistry(
+                host="registry.example.com",
+                username="user",
+                password="password",
+            )
+        ]
+    )
+)
 
 # Create a box
 box = runtime.create(boxlite.BoxOptions(image="alpine:latest"))
@@ -167,10 +174,12 @@ implementation of the `Credential` ABC.
 ```python
 from boxlite import Boxlite, BoxliteRestOptions, ApiKeyCredential
 
-rt = Boxlite.rest(BoxliteRestOptions(
-    url="http://localhost:8100",
-    credential=ApiKeyCredential("your-api-key"),
-))
+rt = Boxlite.rest(
+    BoxliteRestOptions(
+        url="http://localhost:8100",
+        credential=ApiKeyCredential("your-api-key"),
+    )
+)
 boxes = await rt.list_info()
 
 # Env discovery — returns None when BOXLITE_API_KEY is unset:
@@ -195,11 +204,13 @@ id; another deployment may use a workspace name, a region+team
 pair, or any other multi-segment value such as `us-east/team-42`.
 
 ```python
-rt = Boxlite.rest(BoxliteRestOptions(
-    url="https://api.boxlite.ai/api",
-    credential=ApiKeyCredential("blk_live_…"),
-    path_prefix="acme",   # → requests hit /v1/acme/boxes
-))
+rt = Boxlite.rest(
+    BoxliteRestOptions(
+        url="https://api.boxlite.ai/api",
+        credential=ApiKeyCredential("blk_live_…"),
+        path_prefix="acme",  # → requests hit /v1/acme/boxes
+    )
+)
 ```
 
 When `path_prefix` is unset or empty, the client builds URLs
@@ -581,7 +592,7 @@ boxlite.BoxOptions(image="123456.dkr.ecr.us-east-1.amazonaws.com/repo:tag")
 
 ```python
 boxlite.BoxOptions(
-    cpus=4,           # 4 CPU cores
+    cpus=4,  # 4 CPU cores
     memory_mib=2048,  # 2 GB RAM
 )
 ```
@@ -605,7 +616,6 @@ boxlite.BoxOptions(
     volumes=[
         # Read-only mount
         ("/host/config", "/etc/app/config", "ro"),
-
         # Read-write mount
         ("/host/data", "/mnt/data", "rw"),
     ]
@@ -617,10 +627,10 @@ boxlite.BoxOptions(
 ```python
 boxlite.BoxOptions(
     ports=[
-        (8080, 80, "tcp"),      # HTTP
-        (8443, 443, "tcp"),     # HTTPS
-        (5432, 5432, "tcp"),    # PostgreSQL
-        (53, 53, "udp"),        # DNS
+        (8080, 80, "tcp"),  # HTTP
+        (8443, 443, "tcp"),  # HTTPS
+        (5432, 5432, "tcp"),  # PostgreSQL
+        (53, 53, "udp"),  # DNS
     ]
 )
 ```
@@ -784,6 +794,7 @@ from boxlite import BoxliteError, ExecError, TimeoutError, ParseError
 ```python
 import boxlite
 
+
 async def safe_execution():
     try:
         async with boxlite.SimpleBox(image="python:slim") as box:
@@ -852,8 +863,8 @@ sudo usermod -aG kvm $USER
 ```python
 # Increase resource limits
 boxlite.BoxOptions(
-    cpus=4,          # More CPUs
-    memory_mib=4096, # More memory
+    cpus=4,  # More CPUs
+    memory_mib=4096,  # More memory
 )
 
 # Check metrics

--- a/sdks/python/boxlite/__init__.py
+++ b/sdks/python/boxlite/__init__.py
@@ -25,14 +25,14 @@ try:
         Execution,
         ExportOptions,
         HealthCheckOptions,
+        HealthState,
+        HealthStatus,
         ImageHandle,
         ImageInfo,
         ImagePullResult,
-        HealthState,
-        HealthStatus,
-        NetworkSpec,
-        NetworkHandle,
         ImageRegistry,
+        NetworkHandle,
+        NetworkSpec,
         Options,
         RuntimeMetrics,
         Secret,
@@ -44,7 +44,7 @@ try:
         VolumeInfo,
     )
 
-    __all__ = [
+    __all__ = [  # noqa: RUF022 - grouped by API area, not alphabetical
         # Core Rust API
         "Options",
         "ImageRegistry",
@@ -96,7 +96,7 @@ try:
     from .simplebox import SimpleBox  # noqa: F401
 
     __all__.extend(
-        [
+        [  # noqa: RUF022 - grouped by API area, not alphabetical
             # Python convenience wrappers
             "SimpleBox",
             "CodeBox",
@@ -144,7 +144,7 @@ except ImportError:
 try:
     from .orchestration import BoxGroup, BoxRuntime, ManagedBox  # noqa: F401
 
-    __all__.extend(["BoxRuntime", "ManagedBox", "BoxGroup"])
+    __all__.extend(["BoxGroup", "BoxRuntime", "ManagedBox"])
 except ImportError:
     pass
 
@@ -166,15 +166,15 @@ try:
 
     __all__.extend(
         [
-            "SyncBoxlite",
             "SyncBox",
+            "SyncBoxlite",
+            "SyncCodeBox",
+            "SyncExecStderr",
+            "SyncExecStdout",
+            "SyncExecution",
             "SyncImageHandle",
             "SyncNetworkHandle",
-            "SyncExecution",
-            "SyncExecStdout",
-            "SyncExecStderr",
             "SyncSimpleBox",
-            "SyncCodeBox",
             "SyncSkillBox",
         ]
     )

--- a/sdks/python/boxlite/browserbox.py
+++ b/sdks/python/boxlite/browserbox.py
@@ -27,15 +27,18 @@ These modes are MUTUALLY EXCLUSIVE - use one or the other per instance.
 """
 
 import asyncio
+import logging
 import time
 from dataclasses import dataclass
-from typing import Optional, TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Optional
 
 from . import constants as const
 from .simplebox import SimpleBox
 
 if TYPE_CHECKING:
     from .boxlite import Boxlite
+
+logger = logging.getLogger("boxlite.browserbox")
 
 __all__ = ["BrowserBox", "BrowserBoxOptions"]
 
@@ -93,8 +96,8 @@ class BrowserBoxOptions:
     browser: str = "chromium"  # chromium, firefox, or webkit
     memory: int = 2048  # Memory in MiB
     cpu: int = 2  # Number of CPU cores
-    port: Optional[int] = None  # Host port for Playwright Server (default: 3000)
-    cdp_port: Optional[int] = None  # Host port for CDP/Puppeteer (default: 9222)
+    port: int | None = None  # Host port for Playwright Server (default: 3000)
+    cdp_port: int | None = None  # Host port for CDP/Puppeteer (default: 9222)
 
 
 class BrowserBox(SimpleBox):
@@ -132,7 +135,7 @@ class BrowserBox(SimpleBox):
 
     def __init__(
         self,
-        options: Optional[BrowserBoxOptions] = None,
+        options: BrowserBoxOptions | None = None,
         runtime: Optional["Boxlite"] = None,
         **kwargs,
     ):
@@ -225,8 +228,8 @@ class BrowserBox(SimpleBox):
                 "sh", "-c", f"cat {log_path} 2>/dev/null || echo 'No log'"
             )
             log_content = log_result.stdout.strip()
-        except Exception:
-            pass
+        except Exception as e:  # noqa: BLE001 - best-effort log fetch, must not mask the TimeoutError below
+            logger.debug(f"Failed to fetch log for {service_name}: {e}")
 
         raise TimeoutError(
             f"{service_name} did not start within {timeout}s. Log: {log_content[:500]}"

--- a/sdks/python/boxlite/codebox.py
+++ b/sdks/python/boxlite/codebox.py
@@ -4,12 +4,18 @@ CodeBox - Secure Python code execution container.
 Provides a simple, secure environment for running untrusted Python code.
 """
 
-from typing import Optional, TYPE_CHECKING
+import asyncio
+from typing import TYPE_CHECKING, Optional
 
 from .simplebox import SimpleBox
 
 if TYPE_CHECKING:
     from .boxlite import Boxlite
+
+
+def _read_text_file(path: str) -> str:
+    with open(path) as f:
+        return f.read()
 
 
 class CodeBox(SimpleBox):
@@ -27,8 +33,8 @@ class CodeBox(SimpleBox):
     def __init__(
         self,
         image: str = "python:slim",
-        memory_mib: Optional[int] = None,
-        cpus: Optional[int] = None,
+        memory_mib: int | None = None,
+        cpus: int | None = None,
         runtime: Optional["Boxlite"] = None,
         **kwargs,
     ):
@@ -46,7 +52,7 @@ class CodeBox(SimpleBox):
             image=image, memory_mib=memory_mib, cpus=cpus, runtime=runtime, **kwargs
         )
 
-    async def run(self, code: str, timeout: Optional[int] = None) -> str:
+    async def run(self, code: str, timeout: int | None = None) -> str:
         """
         Execute Python code in the secure container.
 
@@ -83,8 +89,7 @@ class CodeBox(SimpleBox):
         Returns:
             Execution stdout as a string
         """
-        with open(script_path, "r") as f:
-            code = f.read()
+        code = await asyncio.to_thread(_read_text_file, script_path)
         return await self.run(code)
 
     async def install_package(self, package: str) -> str:

--- a/sdks/python/boxlite/computerbox.py
+++ b/sdks/python/boxlite/computerbox.py
@@ -7,10 +7,10 @@ that can be viewed from a browser, with full GUI automation support.
 
 import asyncio
 import logging
-from typing import Optional, Tuple, TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from . import constants as const
-from .errors import ExecError, TimeoutError, ParseError
+from .errors import ExecError, ParseError, TimeoutError
 from .simplebox import SimpleBox
 
 if TYPE_CHECKING:
@@ -229,7 +229,7 @@ print(base64.b64encode(buffer.getvalue()).decode("utf-8"))
                 "left_click_drag()", exec_result.exit_code, exec_result.stderr
             )
 
-    async def cursor_position(self) -> Tuple[int, int]:
+    async def cursor_position(self) -> tuple[int, int]:
         """Get the current mouse cursor position. Returns (x, y) tuple."""
         exec_result = await self.exec("xdotool", "getmouselocation", "--shell")
         if exec_result.exit_code != 0:
@@ -288,7 +288,7 @@ print(base64.b64encode(buffer.getvalue()).decode("utf-8"))
         if exec_result.exit_code != 0:
             raise ExecError("scroll()", exec_result.exit_code, exec_result.stderr)
 
-    async def get_screen_size(self) -> Tuple[int, int]:
+    async def get_screen_size(self) -> tuple[int, int]:
         """Get the screen resolution. Returns (width, height) tuple."""
         exec_result = await self.exec("xdotool", "getdisplaygeometry")
         if exec_result.exit_code != 0:

--- a/sdks/python/boxlite/credential.py
+++ b/sdks/python/boxlite/credential.py
@@ -28,4 +28,4 @@ class Credential(ABC):
 # hierarchy without inheritance.
 Credential.register(ApiKeyCredential)
 
-__all__ = ["Credential", "AccessToken", "ApiKeyCredential"]
+__all__ = ["AccessToken", "ApiKeyCredential", "Credential"]

--- a/sdks/python/boxlite/errors.py
+++ b/sdks/python/boxlite/errors.py
@@ -4,13 +4,11 @@ BoxLite error types.
 Provides a hierarchy of exceptions for different failure modes.
 """
 
-__all__ = ["BoxliteError", "ExecError", "TimeoutError", "ParseError"]
+__all__ = ["BoxliteError", "ExecError", "ParseError", "TimeoutError"]
 
 
 class BoxliteError(Exception):
     """Base exception for all boxlite errors."""
-
-    pass
 
 
 class ExecError(BoxliteError):
@@ -35,10 +33,6 @@ class ExecError(BoxliteError):
 class TimeoutError(BoxliteError):
     """Raised when an operation times out."""
 
-    pass
-
 
 class ParseError(BoxliteError):
     """Raised when output parsing fails."""
-
-    pass

--- a/sdks/python/boxlite/interactivebox.py
+++ b/sdks/python/boxlite/interactivebox.py
@@ -10,7 +10,7 @@ import os
 import sys
 import termios
 import tty
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from .simplebox import SimpleBox
 
@@ -44,11 +44,11 @@ class InteractiveBox(SimpleBox):
         self,
         image: str,
         shell: str = "/bin/sh",
-        tty: Optional[bool] = None,
-        memory_mib: Optional[int] = None,
-        cpus: Optional[int] = None,
+        tty: bool | None = None,
+        memory_mib: int | None = None,
+        cpus: int | None = None,
         runtime: Optional["Boxlite"] = None,
-        name: Optional[str] = None,
+        name: str | None = None,
         auto_remove: bool = True,
         **kwargs,
     ):
@@ -145,7 +145,7 @@ class InteractiveBox(SimpleBox):
                 termios.tcsetattr(
                     sys.stdin.fileno(), termios.TCSADRAIN, self._old_tty_settings
                 )
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - terminal restore must not raise during exit
                 logger.error(f"Caught exception on TTY settings: {e}")
 
         """Exit interactive session and restore terminal."""
@@ -159,8 +159,7 @@ class InteractiveBox(SimpleBox):
             except asyncio.TimeoutError:
                 # If it doesn't finish, that's ok - box is shutting down anyway
                 logger.error("Timeout waiting for I/O tasks to finish, cancelling...")
-            except Exception as e:
-                # Ignore other exceptions during cleanup
+            except Exception as e:  # noqa: BLE001 - exit path must not raise on cleanup failure
                 logger.error(f"Caught exception on exit: {e}")
 
         # Print diagnostic after terminal is restored (clean output guaranteed)
@@ -235,7 +234,7 @@ class InteractiveBox(SimpleBox):
 
         except asyncio.CancelledError:
             logger.info("Cancelling interactive shell (stdin forwarding).")
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - background forwarder task must not crash silently
             logger.error(f"Caught exception on stdin: {e}")
 
     async def _forward_output(self):
@@ -257,7 +256,7 @@ class InteractiveBox(SimpleBox):
 
         except asyncio.CancelledError:
             logger.error("Cancelling interactive shell (stdout forwarding).")
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - background forwarder task must not crash silently
             logger.error(f"\nError forwarding output: {e}", file=sys.stderr)
 
     async def _forward_stderr(self):
@@ -279,7 +278,7 @@ class InteractiveBox(SimpleBox):
 
         except asyncio.CancelledError:
             logger.error("Cancelling interactive shell (stderr forwarding).")
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - background forwarder task must not crash silently
             logger.error(f"\nError forwarding stderr: {e}", file=sys.stderr)
 
     async def _wait_for_exit(self):
@@ -288,8 +287,8 @@ class InteractiveBox(SimpleBox):
             result = await self._execution.wait()
             if result.error_message:
                 self._error_message = result.error_message
-        except Exception:
-            pass  # Ignore errors, cleanup will happen in __aexit__
+        except Exception as e:  # noqa: BLE001 - cleanup will happen in __aexit__ regardless
+            logger.debug(f"Error waiting for exit: {e}")
         finally:
             # Signal other tasks to stop
             if self._exited:

--- a/sdks/python/boxlite/orchestration/box_runtime.py
+++ b/sdks/python/boxlite/orchestration/box_runtime.py
@@ -5,12 +5,16 @@ BoxRuntime - Multi-box orchestration with Ray-style decorator API.
 import asyncio
 import base64
 import json
+import logging
 import sys
-from typing import Any, Callable, Optional
+from collections.abc import Callable
+from typing import Any
 
 import cloudpickle
 
 from ..simplebox import SimpleBox
+
+logger = logging.getLogger("boxlite.orchestration")
 
 __all__ = ["BoxRuntime", "ManagedBox"]
 
@@ -22,13 +26,13 @@ class ManagedBox:
         self._runtime = runtime
         self._name = name
         self._kwargs = kwargs
-        self._box: Optional[SimpleBox] = None
+        self._box: SimpleBox | None = None
         self._execution = None
         self._stdin = None
         self._stdout = None
-        self._pump_task: Optional[asyncio.Task] = None
+        self._pump_task: asyncio.Task | None = None
         self._pending: dict[str, asyncio.Future] = {}
-        self._task_func: Optional[Callable] = None
+        self._task_func: Callable | None = None
         self._message_handlers: list[Callable] = []
         self._event_handlers: dict[str, list[Callable]] = {}
 
@@ -49,7 +53,7 @@ class ManagedBox:
         return self
 
     async def _inject_sdk(self) -> None:
-        from importlib.resources import files, as_file
+        from importlib.resources import as_file, files
 
         result = await self._box.exec("pip", "install", "-q", "cloudpickle")
         if result.exit_code != 0:
@@ -80,7 +84,7 @@ class ManagedBox:
 
         return decorator
 
-    async def run(self, env: Optional[dict[str, str]] = None) -> None:
+    async def run(self, env: dict[str, str] | None = None) -> None:
         """Run with registered task and/or handlers."""
         if (
             not self._task_func
@@ -160,7 +164,7 @@ if _d["message_handlers"] or _d["event_handlers"]: run_forever()
                 raise ValueError("Cannot send to self")
             result = await target_box._deliver_message(self._name, data)
             response = {"request_id": request_id, "result": result}
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - RPC boundary: report failure to sender instead of crashing the pump loop
             response = {"request_id": request_id, "error": str(e)}
         await self._send(response)
 
@@ -170,8 +174,8 @@ if _d["message_handlers"] or _d["event_handlers"]: run_forever()
             if name != self._name and box._execution:
                 try:
                     await box._send({"type": "event", "event": event, "data": data})
-                except Exception:
-                    pass
+                except Exception as e:  # noqa: BLE001 - one box's failure must not stop the broadcast to others
+                    logger.debug(f"Failed to publish event to {name}: {e}")
 
     def _handle_response(self, msg: dict) -> None:
         request_id = msg.get("request_id")
@@ -226,14 +230,14 @@ if _d["message_handlers"] or _d["event_handlers"]: run_forever()
         if self._execution:
             try:
                 await self._send({"type": "shutdown"})
-            except Exception:
-                pass
+            except Exception as e:  # noqa: BLE001 - best-effort shutdown notice; kill() below is the real teardown
+                logger.debug(f"Failed to send shutdown message to {self._name}: {e}")
             if self._pump_task:
                 self._pump_task.cancel()
             try:
                 await self._execution.kill()
-            except Exception:
-                pass
+            except Exception as e:  # noqa: BLE001 - stop() must not raise; box is already going away
+                logger.debug(f"Failed to kill execution for {self._name}: {e}")
         self._execution = None
         if self._box:
             await self._box._box.stop()
@@ -248,7 +252,7 @@ class BoxRuntime:
         self._python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
         self._image = f"python:{self._python_version}-slim"
 
-    async def __aenter__(self) -> "BoxRuntime":
+    async def __aenter__(self) -> "BoxRuntime":  # noqa: PYI034 - typing.Self needs 3.11+; project supports 3.10+
         return self
 
     async def __aexit__(self, *_):
@@ -269,7 +273,7 @@ class BoxRuntime:
         """Get list of all box names."""
         return list(self._boxes.keys())
 
-    async def wait_all(self, timeout: float = None) -> list[int]:
+    async def wait_all(self, timeout: float | None = None) -> list[int]:
         if not self._boxes:
             return []
         tasks = [box.wait() for box in self._boxes.values()]

--- a/sdks/python/boxlite/orchestration/guest/boxlite_runtime.py
+++ b/sdks/python/boxlite/orchestration/guest/boxlite_runtime.py
@@ -14,20 +14,21 @@ Protocol (JSON over stdin/stdout):
         {"type": "shutdown"}
 """
 
-import sys
 import json
 import os
+import sys
 import uuid
-from typing import Callable, Any
+from collections.abc import Callable
+from typing import Any
 
 __all__ = [
-    "send_message",
-    "publish_event",
-    "on_message",
-    "on_event",
-    "run_forever",
-    "stop",
     "BOX_NAME",
+    "on_event",
+    "on_message",
+    "publish_event",
+    "run_forever",
+    "send_message",
+    "stop",
 ]
 
 _message_handlers: list[Callable] = []
@@ -114,7 +115,7 @@ def run_forever():
                     try:
                         result = handler(sender, data)
                         break
-                    except Exception as e:
+                    except Exception as e:  # noqa: BLE001 - RPC boundary: report failure to sender instead of crashing the loop
                         error = str(e)
                 if error:
                     print(
@@ -144,13 +145,15 @@ def run_forever():
                 for handler in _event_handlers.get(event, []):
                     try:
                         handler(data)
-                    except Exception:
-                        pass
+                    except Exception as e:  # noqa: BLE001 - one handler's failure must not stop the others
+                        print(
+                            f"event handler for {event!r} failed: {e}", file=sys.stderr
+                        )
 
             elif msg_type == "shutdown":
                 break
 
         except json.JSONDecodeError:
             pass
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - top-level loop guard: report failure via protocol instead of crashing
             print(json.dumps({"type": "error", "error": str(e)}), flush=True)

--- a/sdks/python/boxlite/simplebox.py
+++ b/sdks/python/boxlite/simplebox.py
@@ -7,7 +7,7 @@ Provides common functionality for all specialized boxes (CodeBox, BrowserBox, et
 import asyncio
 import logging
 from enum import IntEnum
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from .exec import ExecResult
 
@@ -73,12 +73,12 @@ class SimpleBox:
 
     def __init__(
         self,
-        image: Optional[str] = None,
-        rootfs_path: Optional[str] = None,
-        memory_mib: Optional[int] = None,
-        cpus: Optional[int] = None,
+        image: str | None = None,
+        rootfs_path: str | None = None,
+        memory_mib: int | None = None,
+        cpus: int | None = None,
         runtime: Optional["Boxlite"] = None,
-        name: Optional[str] = None,
+        name: str | None = None,
         auto_remove: bool = True,
         reuse_existing: bool = False,
         **kwargs,
@@ -133,7 +133,7 @@ class SimpleBox:
         self._reuse_existing = reuse_existing
         self._box = None
         self._started = False
-        self._created: Optional[bool] = None
+        self._created: bool | None = None
         self._network = NetworkHandle(self)
 
     async def _create_tunnel(self, port: int):
@@ -205,7 +205,7 @@ class SimpleBox:
         return self._box.info()
 
     @property
-    def created(self) -> Optional[bool]:
+    def created(self) -> bool | None:
         """Whether this box was newly created (True) or an existing box was reused (False).
 
         Returns None if the box hasn't been started yet.
@@ -223,10 +223,10 @@ class SimpleBox:
         self,
         cmd: str,
         *args: str,
-        env: Optional[dict[str, str]] = None,
-        user: Optional[str] = None,
-        timeout: Optional[float] = None,
-        cwd: Optional[str] = None,
+        env: dict[str, str] | None = None,
+        user: str | None = None,
+        timeout: float | None = None,
+        cwd: str | None = None,
     ) -> ExecResult:
         """
         Execute a command in the box and return the result.
@@ -274,13 +274,13 @@ class SimpleBox:
         # Get streams from Rust execution
         try:
             stdout = execution.stdout()
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - native binding call; fall back to no stdout stream
             logger.error(f"take stdout err: {e}")
             stdout = None
 
         try:
             stderr = execution.stderr()
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - native binding call; fall back to no stderr stream
             logger.error(f"take stderr err: {e}")
             stderr = None
 
@@ -300,7 +300,7 @@ class SimpleBox:
                         stdout_lines.append(line.decode("utf-8", errors="replace"))
                     else:
                         stdout_lines.append(line)
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - stream collection must not crash exec(); partial output is acceptable
                 logger.error(f"collecting stdout err: {e}")
 
         async def collect_stderr():
@@ -313,7 +313,7 @@ class SimpleBox:
                         stderr_lines.append(line.decode("utf-8", errors="replace"))
                     else:
                         stderr_lines.append(line)
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - stream collection must not crash exec(); partial output is acceptable
                 logger.error(f"collecting stderr err: {e}")
 
         await asyncio.gather(collect_stdout(), collect_stderr())
@@ -326,7 +326,7 @@ class SimpleBox:
             exec_result = await execution.wait()
             exit_code = exec_result.exit_code
             error_message = exec_result.error_message
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - native binding call; report failure via exit_code instead of raising
             logger.error(f"failed to wait execution: {e}")
             exit_code = -1
 

--- a/sdks/python/boxlite/skillbox.py
+++ b/sdks/python/boxlite/skillbox.py
@@ -13,7 +13,7 @@ import os
 import random
 import socket
 import time
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from . import constants as const
 from .errors import TimeoutError
@@ -94,7 +94,7 @@ class SkillBox(SimpleBox):
         gui_http_port: int = 0,
         gui_https_port: int = 0,
         auto_remove: bool = True,
-        runtime: Optional["Boxlite"] = None,
+        runtime: Boxlite | None = None,
         **kwargs,
     ):
         """
@@ -175,13 +175,13 @@ class SkillBox(SimpleBox):
         )
 
         # Runtime state for Claude CLI process
-        self._process: Optional["Execution"] = None
+        self._process: Execution | None = None
         self._stdin = None
         self._stdout = None
         self._session_id: str = "default"
         self._setup_complete: bool = False
 
-    async def __aenter__(self) -> "SkillBox":
+    async def __aenter__(self) -> SkillBox:  # noqa: PYI034 - typing.Self needs 3.11+; project supports 3.10+
         """Enter context - creates/reuses box but defers setup to first call()."""
         if not self._oauth_token:
             raise ValueError(
@@ -444,14 +444,14 @@ class SkillBox(SimpleBox):
         if self._stdin:
             try:
                 await self._stdin.close()
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - teardown must not raise if the process already died
                 logger.debug("Error closing stdin: %s", e)
             self._stdin = None
 
         if self._process:
             try:
                 await self._process.wait()
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - teardown must not raise if the process already died
                 logger.debug("Error waiting for process: %s", e)
             self._process = None
 

--- a/sdks/python/boxlite/sync_api/__init__.py
+++ b/sdks/python/boxlite/sync_api/__init__.py
@@ -41,17 +41,17 @@ Note:
     Use the async API (CodeBox, SimpleBox) in those cases.
 """
 
-from ._boxlite import SyncBoxlite
-from ._sync_base import SyncBase, SyncContextManager
 from ._box import SyncBox
+from ._boxlite import SyncBoxlite
+from ._codebox import SyncCodeBox
+from ._execution import SyncExecStderr, SyncExecStdout, SyncExecution
 from ._images import SyncImageHandle
 from ._network import SyncNetworkHandle
-from ._execution import SyncExecution, SyncExecStdout, SyncExecStderr
 from ._simplebox import SyncSimpleBox
-from ._codebox import SyncCodeBox
 from ._skillbox import SyncSkillBox
+from ._sync_base import SyncBase, SyncContextManager
 
-__all__ = [
+__all__ = [  # noqa: RUF022 - grouped by API area, not alphabetical
     # Entry point
     "SyncBoxlite",
     # Base classes

--- a/sdks/python/boxlite/sync_api/_box.py
+++ b/sdks/python/boxlite/sync_api/_box.py
@@ -4,13 +4,13 @@ SyncBox - Synchronous wrapper for Box.
 Mirrors the native Box API exactly, but with synchronous methods.
 """
 
-from typing import TYPE_CHECKING, List, Optional, Tuple
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from ..boxlite import Box, BoxInfo, BoxMetrics
     from ._boxlite import SyncBoxlite
     from ._execution import SyncExecution
     from ._network import SyncNetworkHandle
-    from ..boxlite import Box, BoxInfo, BoxMetrics
 
 __all__ = ["SyncBox"]
 
@@ -70,7 +70,7 @@ class SyncBox:
         return self._box.id
 
     @property
-    def name(self) -> Optional[str]:
+    def name(self) -> str | None:
         """Get the box name (if set)."""
         return self._box.name
 
@@ -93,8 +93,8 @@ class SyncBox:
     def exec(
         self,
         cmd: str,
-        args: Optional[List[str]] = None,
-        env: Optional[List[Tuple[str, str]]] = None,
+        args: list[str] | None = None,
+        env: list[tuple[str, str]] | None = None,
         tty: bool = False,
     ) -> "SyncExecution":
         """
@@ -144,7 +144,7 @@ class SyncBox:
         return self.network.tunnel(port)
 
     # Context manager support
-    def __enter__(self) -> "SyncBox":
+    def __enter__(self) -> "SyncBox":  # noqa: PYI034 - typing.Self needs 3.11+; project supports 3.10+
         """Enter context - starts the box."""
         self._sync(self._box.__aenter__())
         return self

--- a/sdks/python/boxlite/sync_api/_boxlite.py
+++ b/sdks/python/boxlite/sync_api/_boxlite.py
@@ -6,14 +6,17 @@ for the synchronous BoxLite API.
 """
 
 import asyncio
-from typing import TYPE_CHECKING, List, Optional
+import logging
+from typing import TYPE_CHECKING, Optional
 
 from greenlet import greenlet
 
 if TYPE_CHECKING:
+    from ..boxlite import BoxInfo, Boxlite, BoxOptions, Options, RuntimeMetrics
     from ._box import SyncBox
     from ._images import SyncImageHandle
-    from ..boxlite import Boxlite, BoxOptions, BoxInfo, RuntimeMetrics, Options
+
+logger = logging.getLogger("boxlite.sync_boxlite")
 
 __all__ = ["SyncBoxlite"]
 
@@ -70,7 +73,7 @@ class SyncBoxlite:
         self._sync_helper = None
         self._started = False
 
-    def __enter__(self) -> "SyncBoxlite":
+    def __enter__(self) -> "SyncBoxlite":  # noqa: PYI034 - typing.Self needs 3.11+; project supports 3.10+
         """
         Start the sync runtime and enter context.
 
@@ -144,8 +147,8 @@ class SyncBoxlite:
                 for t in [t for t in tasks if not (t.done() or t.cancelled())]:
                     t.cancel()
                 self._loop.run_until_complete(self._loop.shutdown_asyncgens())
-            except Exception:
-                pass  # Ignore errors during cleanup
+            except Exception as e:  # noqa: BLE001 - loop is shutting down regardless; must not raise
+                logger.debug(f"Error during event loop cleanup: {e}")
             finally:
                 self._loop.close()
 
@@ -254,7 +257,7 @@ class SyncBoxlite:
     def create(
         self,
         options: "BoxOptions",
-        name: Optional[str] = None,
+        name: str | None = None,
     ) -> "SyncBox":
         """
         Create a new box.
@@ -279,7 +282,7 @@ class SyncBoxlite:
     def get_or_create(
         self,
         options: "BoxOptions",
-        name: Optional[str] = None,
+        name: str | None = None,
     ) -> tuple["SyncBox", bool]:
         """
         Get an existing box by name, or create a new one.
@@ -317,7 +320,7 @@ class SyncBoxlite:
             return None
         return SyncBox(self, native_box)
 
-    def list_info(self) -> List["BoxInfo"]:
+    def list_info(self) -> list["BoxInfo"]:
         """
         List all boxes.
 
@@ -368,7 +371,7 @@ class SyncBoxlite:
         """
         self._sync(self._boxlite.remove(id_or_name, force))
 
-    def shutdown(self, timeout: Optional[int] = None) -> None:
+    def shutdown(self, timeout: int | None = None) -> None:
         """
         Gracefully shutdown all boxes in this runtime.
 

--- a/sdks/python/boxlite/sync_api/_codebox.py
+++ b/sdks/python/boxlite/sync_api/_codebox.py
@@ -38,10 +38,10 @@ class SyncCodeBox(SyncSimpleBox):
     def __init__(
         self,
         image: str = "python:slim",
-        memory_mib: Optional[int] = None,
-        cpus: Optional[int] = None,
+        memory_mib: int | None = None,
+        cpus: int | None = None,
         runtime: Optional["SyncBoxlite"] = None,
-        name: Optional[str] = None,
+        name: str | None = None,
         auto_remove: bool = True,
         **kwargs,
     ):
@@ -67,7 +67,7 @@ class SyncCodeBox(SyncSimpleBox):
             **kwargs,
         )
 
-    def run(self, code: str, timeout: Optional[int] = None) -> str:
+    def run(self, code: str, timeout: int | None = None) -> str:
         """
         Execute Python code synchronously.
 

--- a/sdks/python/boxlite/sync_api/_execution.py
+++ b/sdks/python/boxlite/sync_api/_execution.py
@@ -4,13 +4,13 @@ SyncExecution - Synchronous wrapper for Execution.
 Mirrors the native Execution API exactly, but with synchronous methods.
 """
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from ._boxlite import SyncBoxlite
     from ..boxlite import Execution
+    from ._boxlite import SyncBoxlite
 
-__all__ = ["SyncExecution", "SyncExecStdin", "SyncExecStdout", "SyncExecStderr"]
+__all__ = ["SyncExecStderr", "SyncExecStdin", "SyncExecStdout", "SyncExecution"]
 
 
 class SyncExecStdin:
@@ -184,7 +184,7 @@ class SyncExecution:
         """Get the execution ID."""
         return self._execution.id
 
-    def stdin(self) -> Optional[SyncExecStdin]:
+    def stdin(self) -> SyncExecStdin | None:
         """
         Get synchronous stdin writer.
 
@@ -202,7 +202,7 @@ class SyncExecution:
             return None
         return SyncExecStdin(self._ctx, async_stdin)
 
-    def stdout(self) -> Optional[SyncExecStdout]:
+    def stdout(self) -> SyncExecStdout | None:
         """
         Get synchronous stdout iterator.
 
@@ -220,7 +220,7 @@ class SyncExecution:
             return None
         return SyncExecStdout(self._ctx, async_stdout)
 
-    def stderr(self) -> Optional[SyncExecStderr]:
+    def stderr(self) -> SyncExecStderr | None:
         """
         Get synchronous stderr iterator.
 

--- a/sdks/python/boxlite/sync_api/_images.py
+++ b/sdks/python/boxlite/sync_api/_images.py
@@ -2,11 +2,11 @@
 SyncImageHandle - Synchronous wrapper for runtime image operations.
 """
 
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from ._boxlite import SyncBoxlite
     from ..boxlite import ImageHandle, ImageInfo, ImagePullResult
+    from ._boxlite import SyncBoxlite
 
 __all__ = ["SyncImageHandle"]
 
@@ -31,5 +31,5 @@ class SyncImageHandle:
     def pull(self, reference: str) -> "ImagePullResult":
         return self._sync(self._handle.pull(reference))
 
-    def list(self) -> List["ImageInfo"]:
+    def list(self) -> list["ImageInfo"]:
         return self._sync(self._handle.list())

--- a/sdks/python/boxlite/sync_api/_simplebox.py
+++ b/sdks/python/boxlite/sync_api/_simplebox.py
@@ -7,13 +7,13 @@ API mirrors async SimpleBox exactly.
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING, Dict, Optional
+from typing import TYPE_CHECKING, Optional
 
 from ..exec import ExecResult
 
 if TYPE_CHECKING:
-    from ._boxlite import SyncBoxlite
     from ._box import SyncBox
+    from ._boxlite import SyncBoxlite
 
 logger = logging.getLogger("boxlite.sync_simplebox")
 
@@ -42,12 +42,12 @@ class SyncSimpleBox:
 
     def __init__(
         self,
-        image: Optional[str] = None,
-        rootfs_path: Optional[str] = None,
-        memory_mib: Optional[int] = None,
-        cpus: Optional[int] = None,
+        image: str | None = None,
+        rootfs_path: str | None = None,
+        memory_mib: int | None = None,
+        cpus: int | None = None,
         runtime: Optional["SyncBoxlite"] = None,
-        name: Optional[str] = None,
+        name: str | None = None,
         auto_remove: bool = True,
         reuse_existing: bool = False,
         **kwargs,
@@ -72,8 +72,8 @@ class SyncSimpleBox:
         if not image and not rootfs_path:
             raise ValueError("Either 'image' or 'rootfs_path' must be provided")
 
-        from ._boxlite import SyncBoxlite
         from ..boxlite import BoxOptions
+        from ._boxlite import SyncBoxlite
 
         # Handle optional runtime
         if runtime is None:
@@ -97,10 +97,10 @@ class SyncSimpleBox:
         # Store for lazy creation in __enter__
         self._name = name
         self._reuse_existing = reuse_existing
-        self._box: Optional["SyncBox"] = None
-        self._created: Optional[bool] = None
+        self._box: SyncBox | None = None
+        self._created: bool | None = None
 
-    def __enter__(self) -> "SyncSimpleBox":
+    def __enter__(self) -> "SyncSimpleBox":  # noqa: PYI034 - typing.Self needs 3.11+; project supports 3.10+
         """Enter context - starts runtime if owned, then creates or reuses box.
 
         When a name is provided, attempts to get an existing box first.
@@ -136,12 +136,12 @@ class SyncSimpleBox:
         return self._box.id
 
     @property
-    def name(self) -> Optional[str]:
+    def name(self) -> str | None:
         """Get the box name (if set)."""
         return self._box.name
 
     @property
-    def created(self) -> Optional[bool]:
+    def created(self) -> bool | None:
         """Whether this box was newly created (True) or an existing box was reused (False).
 
         Returns None if the box hasn't been started yet.
@@ -156,10 +156,10 @@ class SyncSimpleBox:
         self,
         cmd: str,
         *args: str,
-        env: Optional[Dict[str, str]] = None,
-        user: Optional[str] = None,
-        timeout: Optional[float] = None,
-        cwd: Optional[str] = None,
+        env: dict[str, str] | None = None,
+        user: str | None = None,
+        timeout: float | None = None,
+        cwd: str | None = None,
     ) -> ExecResult:
         """
         Execute a command in the box synchronously.
@@ -201,13 +201,13 @@ class SyncSimpleBox:
 
             try:
                 stdout_stream = execution.stdout()
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - native binding call; fall back to no stdout stream
                 logger.error(f"take stdout err: {e}")
                 stdout_stream = None
 
             try:
                 stderr_stream = execution.stderr()
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - native binding call; fall back to no stderr stream
                 logger.error(f"take stderr err: {e}")
                 stderr_stream = None
 
@@ -220,7 +220,7 @@ class SyncSimpleBox:
                             stdout_lines.append(line.decode("utf-8", errors="replace"))
                         else:
                             stdout_lines.append(line)
-                except Exception as e:
+                except Exception as e:  # noqa: BLE001 - stream collection must not crash exec(); partial output is acceptable
                     logger.error(f"collecting stdout err: {e}")
 
             async def collect_stderr():
@@ -232,7 +232,7 @@ class SyncSimpleBox:
                             stderr_lines.append(line.decode("utf-8", errors="replace"))
                         else:
                             stderr_lines.append(line)
-                except Exception as e:
+                except Exception as e:  # noqa: BLE001 - stream collection must not crash exec(); partial output is acceptable
                     logger.error(f"collecting stderr err: {e}")
 
             await asyncio.gather(collect_stdout(), collect_stderr())
@@ -242,7 +242,7 @@ class SyncSimpleBox:
                 exec_result = await execution.wait()
                 exit_code = exec_result.exit_code
                 error_message = exec_result.error_message
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - native binding call; report failure via exit_code instead of raising
                 logger.error(f"failed to wait execution: {e}")
                 exit_code = -1
 

--- a/sdks/python/boxlite/sync_api/_skillbox.py
+++ b/sdks/python/boxlite/sync_api/_skillbox.py
@@ -153,7 +153,7 @@ class SyncSkillBox(SyncSimpleBox):
         self._session_id: str = "default"
         self._setup_complete: bool = False
 
-    def __enter__(self) -> "SyncSkillBox":
+    def __enter__(self) -> "SyncSkillBox":  # noqa: PYI034 - typing.Self needs 3.11+; project supports 3.10+
         """Enter context - validates token and creates/reuses box."""
         if not self._oauth_token:
             raise ValueError(
@@ -383,14 +383,14 @@ class SyncSkillBox(SyncSimpleBox):
         if self._stdin:
             try:
                 self._stdin.close()
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - teardown must not raise if the process already died
                 logger.debug("Error closing stdin: %s", e)
             self._stdin = None
 
         if self._process:
             try:
                 self._process.wait()
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - teardown must not raise if the process already died
                 logger.debug("Error waiting for process: %s", e)
             self._process = None
 

--- a/sdks/python/boxlite/sync_api/_sync_base.py
+++ b/sdks/python/boxlite/sync_api/_sync_base.py
@@ -8,7 +8,8 @@ execute async operations using greenlet fiber switching.
 import asyncio
 import inspect
 import traceback
-from typing import Any, Awaitable, Coroutine, TypeVar, Union
+from collections.abc import Awaitable, Coroutine
+from typing import Any, TypeVar
 
 from greenlet import greenlet
 
@@ -54,7 +55,7 @@ class SyncBase:
 
     def _sync(
         self,
-        coro: Union[Coroutine[Any, Any, T], Awaitable[T]],
+        coro: Coroutine[Any, Any, T] | Awaitable[T],
     ) -> T:
         """
         Run async coroutine synchronously using greenlet fiber switching.
@@ -94,8 +95,8 @@ class SyncBase:
         task: asyncio.Task = asyncio.ensure_future(coro, loop=self._loop)
 
         # 3. Attach debug info for better stack traces
-        setattr(task, "__boxlite_stack__", inspect.stack(0))
-        setattr(task, "__boxlite_stack_trace__", traceback.extract_stack(limit=10))
+        task.__boxlite_stack__ = inspect.stack(0)
+        task.__boxlite_stack_trace__ = traceback.extract_stack(limit=10)
 
         # 4. When task completes, switch back to us
         task.add_done_callback(lambda _: g_self.switch())
@@ -120,7 +121,7 @@ class SyncContextManager(SyncBase):
     Subclasses should override close() for cleanup logic.
     """
 
-    def __enter__(self) -> "SyncContextManager":
+    def __enter__(self) -> "SyncContextManager":  # noqa: PYI034 - typing.Self needs 3.11+; project supports 3.10+
         """Enter context manager."""
         return self
 
@@ -134,4 +135,3 @@ class SyncContextManager(SyncBase):
 
         Override in subclasses to implement cleanup logic.
         """
-        pass

--- a/sdks/python/tests/test_box_management.py
+++ b/sdks/python/tests/test_box_management.py
@@ -8,10 +8,14 @@ These tests exercise the new runtime-oriented API that lives on the
 
 from __future__ import annotations
 
+import logging
 import time
 
-import boxlite
 import pytest
+
+import boxlite
+
+logger = logging.getLogger(__name__)
 
 pytestmark = pytest.mark.integration
 
@@ -76,12 +80,12 @@ def runtime(shared_sync_runtime):
         for box in list(harness._boxes):
             try:
                 box.stop()
-            except Exception:
-                pass
+            except Exception as e:  # noqa: BLE001 - teardown must clean up remaining boxes even if one fails
+                logger.debug(f"Error stopping box {box.id}: {e}")
             try:
                 harness.remove(box.id)
-            except Exception:
-                pass
+            except Exception as e:  # noqa: BLE001 - teardown must clean up remaining boxes even if one fails
+                logger.debug(f"Error removing box {box.id}: {e}")
 
 
 class TestBoxManagement:

--- a/sdks/python/tests/test_box_management_mock.py
+++ b/sdks/python/tests/test_box_management_mock.py
@@ -6,8 +6,11 @@ exported and structured without requiring a working libkrun/VM setup.
 Requires the native Rust extension to be compiled (maturin develop).
 """
 
-import boxlite
+from typing import ClassVar
+
 import pytest
+
+import boxlite
 
 # Native extension types are only available when the Rust extension is compiled.
 # In CI unit-test jobs the extension is not built, so skip gracefully.
@@ -167,7 +170,7 @@ class TestModuleMetadata:
     """Test module-level metadata (always available, even without native ext)."""
 
     # Override the module-level skip — version is always available.
-    pytestmark = []
+    pytestmark: ClassVar = []
 
     def test_version_exists(self):
         assert hasattr(boxlite, "__version__")

--- a/sdks/python/tests/test_credential.py
+++ b/sdks/python/tests/test_credential.py
@@ -12,8 +12,9 @@ integration job (same convention as test_options.py / test_images.py).
 
 from __future__ import annotations
 
-import boxlite
 import pytest
+
+import boxlite
 
 pytestmark = pytest.mark.integration
 
@@ -79,5 +80,5 @@ def test_rest_options_from_env(monkeypatch):
 
 def test_rest_options_from_env_requires_url(monkeypatch):
     monkeypatch.delenv("BOXLITE_REST_URL", raising=False)
-    with pytest.raises(Exception):
+    with pytest.raises(RuntimeError):
         boxlite.BoxliteRestOptions.from_env()

--- a/sdks/python/tests/test_dev_tunnel_e2e.py
+++ b/sdks/python/tests/test_dev_tunnel_e2e.py
@@ -10,7 +10,6 @@ import pytest
 
 import boxlite
 
-
 pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
 
 LOCAL_IMAGE = "python:3-alpine"

--- a/sdks/python/tests/test_errors.py
+++ b/sdks/python/tests/test_errors.py
@@ -5,7 +5,8 @@ Tests the error hierarchy and exception behavior.
 """
 
 import pytest
-from boxlite.errors import BoxliteError, ExecError, TimeoutError, ParseError
+
+from boxlite.errors import BoxliteError, ExecError, ParseError, TimeoutError
 
 
 class TestBoxliteError:
@@ -150,7 +151,7 @@ class TestErrorExports:
 
     def test_errors_from_errors_module(self):
         """Test that errors can be imported from errors module."""
-        from boxlite.errors import BoxliteError, ExecError, TimeoutError, ParseError
+        from boxlite.errors import BoxliteError, ExecError, ParseError, TimeoutError
 
         assert BoxliteError is not None
         assert ExecError is not None

--- a/sdks/python/tests/test_exec.py
+++ b/sdks/python/tests/test_exec.py
@@ -4,8 +4,9 @@ Unit tests for ExecResult dataclass (no VM required).
 Tests the ExecResult structure and behavior.
 """
 
-import pytest
 from dataclasses import is_dataclass
+
+import pytest
 
 import boxlite
 from boxlite.exec import ExecResult
@@ -209,7 +210,7 @@ class TestSyncExecutionAPIExports:
             from boxlite.sync_api._execution import SyncExecution
 
             assert hasattr(SyncExecution, "resize_tty")
-            assert callable(getattr(SyncExecution, "resize_tty"))
+            assert callable(SyncExecution.resize_tty)
         except ImportError:
             pytest.skip("sync API not available")
 

--- a/sdks/python/tests/test_options.py
+++ b/sdks/python/tests/test_options.py
@@ -8,8 +8,9 @@ These tests verify the behavior of:
 
 from __future__ import annotations
 
-import boxlite
 import pytest
+
+import boxlite
 
 pytestmark = pytest.mark.integration
 

--- a/sdks/python/tests/test_readonly_volume_remount.py
+++ b/sdks/python/tests/test_readonly_volume_remount.py
@@ -66,7 +66,7 @@ class TestReadonlyVolumeRemountBypass:
         try:
             # The share is exposed read-only to the guest.
             _, mounts = _sh(sandbox, "cat /proc/mounts | grep sensitive")
-            assert " ro," in mounts, "volume not mounted read-only: %r" % (mounts,)
+            assert " ro," in mounts, f"volume not mounted read-only: {mounts!r}"
 
             # A direct write is rejected (client-side MS_RDONLY active).
             write_exit, _ = _sh(
@@ -84,11 +84,9 @@ class TestReadonlyVolumeRemountBypass:
 
             # The mount must still be read-only after the remount attempt.
             _, after = _sh(sandbox, "cat /proc/mounts | grep sensitive")
-            assert " ro," in after, "volume became writable after remount: %r" % (
-                after,
-            )
-            assert " rw," not in after, "volume became writable after remount: %r" % (
-                after,
+            assert " ro," in after, f"volume became writable after remount: {after!r}"
+            assert " rw," not in after, (
+                f"volume became writable after remount: {after!r}"
             )
 
             # A post-attack write must still fail, and the guest-visible
@@ -104,7 +102,7 @@ class TestReadonlyVolumeRemountBypass:
             assert write2_exit != 0, "write after remount bypass should still fail"
 
             _, guest_view = _sh(sandbox, "cat " + GUEST_MOUNT + "/read_only.txt")
-            assert guest_view == ORIGINAL, "guest modified the file: %r" % (guest_view,)
+            assert guest_view == ORIGINAL, f"guest modified the file: {guest_view!r}"
 
             # HOST VERIFICATION - the advisory's own exploit oracle: if the
             # host file now reads ATTACK_PAYLOAD the sandbox was escaped.
@@ -112,7 +110,7 @@ class TestReadonlyVolumeRemountBypass:
                 host_content = f.read()
             assert host_content == ORIGINAL, (
                 "read-only volume bypass: host file was modified from inside "
-                "the sandbox (got %r)" % (host_content,)
+                f"the sandbox (got {host_content!r})"
             )
         finally:
             sandbox.stop()

--- a/sdks/python/tests/test_resize_tty.py
+++ b/sdks/python/tests/test_resize_tty.py
@@ -7,8 +7,9 @@ These tests require a working VM/libkrun setup.
 
 from __future__ import annotations
 
-import boxlite
 import pytest
+
+import boxlite
 
 pytestmark = pytest.mark.integration
 
@@ -32,7 +33,7 @@ class TestResizeTtySync:
         box = shared_sync_runtime.create(boxlite.BoxOptions(image="alpine:latest"))
         try:
             execution = box.exec("echo", ["hello"])
-            with pytest.raises(Exception):
+            with pytest.raises(RuntimeError):
                 execution.resize_tty(40, 120)
             execution.wait()
         finally:

--- a/sdks/python/tests/test_shutdown.py
+++ b/sdks/python/tests/test_shutdown.py
@@ -13,8 +13,9 @@ from __future__ import annotations
 
 import tempfile
 
-import boxlite
 import pytest
+
+import boxlite
 
 pytestmark = pytest.mark.integration
 

--- a/sdks/python/tests/test_skillbox.py
+++ b/sdks/python/tests/test_skillbox.py
@@ -12,8 +12,9 @@ from __future__ import annotations
 
 import os
 
-import boxlite
 import pytest
+
+import boxlite
 
 # Try to import sync API - skip if greenlet not installed
 try:
@@ -257,9 +258,8 @@ class TestSkillBoxValidation:
         original = os.environ.pop("CLAUDE_CODE_OAUTH_TOKEN", None)
         try:
             box = SyncSkillBox(oauth_token="", runtime=shared_sync_runtime)
-            with pytest.raises(ValueError, match="OAuth token required"):
-                with box:
-                    pass
+            with pytest.raises(ValueError, match="OAuth token required"), box:
+                pass
         finally:
             if original:
                 os.environ["CLAUDE_CODE_OAUTH_TOKEN"] = original

--- a/sdks/python/tests/test_symlink_escape.py
+++ b/sdks/python/tests/test_symlink_escape.py
@@ -175,15 +175,18 @@ async def main(runtime=None):
 
     # [2] Show crafted tar entries
     print("\n[2] Malicious layer tar entries:")
-    with open(os.path.join(OCI_LAYOUT_DIR, "index.json")) as f:
+    with open(os.path.join(OCI_LAYOUT_DIR, "index.json")) as f:  # noqa: ASYNC230 - local PoC setup, not a hot path
         idx = json.load(f)
     mf_dgst = idx["manifests"][0]["digest"].split(":")[1]
-    with open(os.path.join(OCI_LAYOUT_DIR, "blobs", "sha256", mf_dgst)) as f:
+    with open(  # noqa: ASYNC230 - local PoC setup, not a hot path
+        os.path.join(OCI_LAYOUT_DIR, "blobs", "sha256", mf_dgst)
+    ) as f:
         mf = json.load(f)
     lyr_dgst = mf["layers"][0]["digest"].split(":")[1]
-    lyr_data = open(
+    with open(  # noqa: ASYNC230 - local PoC setup, not a hot path
         os.path.join(OCI_LAYOUT_DIR, "blobs", "sha256", lyr_dgst), "rb"
-    ).read()
+    ) as f:
+        lyr_data = f.read()
     with tarfile.open(fileobj=io.BytesIO(lyr_data)) as tf:
         for m in tf.getmembers():
             tstr = {
@@ -206,7 +209,7 @@ async def main(runtime=None):
         ) as box:
             r = await box.exec("sh", "-c", "echo ok")
             print(f"    VM stdout: {r.stdout.strip()}")
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 - box startup can fail in many ways; all are expected here
         # Box may fail to start (incomplete rootfs) — that's fine;
         # the symlink escape occurs during layer extraction, before VM launch.
         print(f"    Box error (expected): {type(e).__name__}: {e}")
@@ -216,7 +219,8 @@ async def main(runtime=None):
     if os.path.exists(TARGET_FILE):
         print("\n  VULNERABLE — host file written successfully!")
         print(f"  Path: {TARGET_FILE}")
-        print(open(TARGET_FILE).read())
+        with open(TARGET_FILE) as f:  # noqa: ASYNC230 - local PoC verification, not a hot path
+            print(f.read())
     else:
         print("\n  NOT VULNERABLE (or already patched)")
 

--- a/sdks/python/tests/test_sync_api.py
+++ b/sdks/python/tests/test_sync_api.py
@@ -217,7 +217,7 @@ class TestSyncExecution:
         box = shared_sync_runtime.create(boxlite.BoxOptions(image="alpine:latest"))
         execution = box.exec("echo", ["hello"])
 
-        with pytest.raises(Exception):
+        with pytest.raises(RuntimeError):
             execution.resize_tty(40, 120)
 
         execution.wait()
@@ -319,7 +319,7 @@ class TestSyncAPIEdgeCases:
             boxes.append(box)
 
         assert len(boxes) == 3
-        assert len(set(b.id for b in boxes)) == 3  # All unique IDs
+        assert len({b.id for b in boxes}) == 3  # All unique IDs
 
         for box in boxes:
             box.stop()

--- a/sdks/python/tests/test_sync_simplebox.py
+++ b/sdks/python/tests/test_sync_simplebox.py
@@ -235,10 +235,12 @@ class TestSyncSimpleBoxReuseExisting:
         ) as box1:
             assert box1.created is True
 
-            with pytest.raises(Exception):
-                with SyncSimpleBox(
+            with (
+                pytest.raises(RuntimeError),
+                SyncSimpleBox(
                     image="alpine:latest",
                     name=name,
                     runtime=shared_sync_runtime,
-                ) as _box2:
-                    pass
+                ) as _box2,
+            ):
+                pass

--- a/sdks/python/tests/test_sync_skillbox.py
+++ b/sdks/python/tests/test_sync_skillbox.py
@@ -200,8 +200,8 @@ class TestSyncSkillBoxExports:
     @pytest.mark.skipif(not SYNC_AVAILABLE, reason="greenlet not installed")
     def test_sync_skillbox_from_sync_api_module(self):
         """Test that SyncSkillBox can be imported from sync_api module."""
-        from boxlite.sync_api import SyncSkillBox as SyncSkillBoxFromModule
         import boxlite
+        from boxlite.sync_api import SyncSkillBox as SyncSkillBoxFromModule
 
         assert SyncSkillBoxFromModule is boxlite.SyncSkillBox
 
@@ -234,9 +234,8 @@ class TestSyncSkillBoxValidation:
         original = os.environ.pop("CLAUDE_CODE_OAUTH_TOKEN", None)
         try:
             box = SyncSkillBox(oauth_token="", runtime=shared_sync_runtime)
-            with pytest.raises(ValueError, match="OAuth token required"):
-                with box:
-                    pass
+            with pytest.raises(ValueError, match="OAuth token required"), box:
+                pass
         finally:
             if original:
                 os.environ["CLAUDE_CODE_OAUTH_TOKEN"] = original

--- a/sdks/python/tests/test_tcp_filter.py
+++ b/sdks/python/tests/test_tcp_filter.py
@@ -7,9 +7,9 @@ runtime so they don't depend on stale hard-coded IPs.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 import ipaddress
 import socket
+from dataclasses import dataclass
 
 import pytest
 

--- a/sdks/python/tests/test_volume_port_persistence.py
+++ b/sdks/python/tests/test_volume_port_persistence.py
@@ -26,6 +26,7 @@ Requirements:
 from __future__ import annotations
 
 import http.client
+import logging
 import os
 import shutil
 import socket
@@ -35,6 +36,8 @@ import time
 import pytest
 
 import boxlite
+
+logger = logging.getLogger(__name__)
 
 GUEST_MOUNT = "/data"
 GUEST_PORT = 8000
@@ -117,15 +120,16 @@ class TestVolumePortPersistence:
                 try:
                     box.start()
                     return box, port
-                except Exception as e:
+                except Exception as e:  # noqa: BLE001 - port bind races can raise different exception types
                     # most likely the host port was taken between pick + bind
                     last_err = e
                     try:
                         box.stop()
-                    except Exception:
-                        # Best-effort cleanup: if start() failed, stop() may also fail;
+                    except Exception as stop_err:  # noqa: BLE001 - best-effort cleanup: if start() failed, stop() may also fail
                         # ignore and continue retrying with a new port.
-                        pass
+                        logger.debug(
+                            f"Error stopping box after failed start: {stop_err}"
+                        )
             raise AssertionError(
                 f"could not start a server box on a free host port: {last_err!r}"
             )


### PR DESCRIPTION
## Summary
- sdks/python has no `[tool.ruff]` config, so `ruff check .` runs on ruff's own default rule set. CI's Python lint job passed on 2026-07-22 with ruff 0.15.22 installed unpinned via `pip install ruff`. ruff 0.16.0 changed its default rule set, and installing it unpinned surfaced 192 previously-undetected violations across ~35 files in boxlite/ and tests/, plus unformatted code fences in README.md.
- Fixes the backlog and pins `ruff==0.16.0` in CI so a future ruff release with a different default rule set can't silently reintroduce this drift.

## Changes
- Mechanical fixes (import sorting, PEP 604 type annotations, README.md code-fence formatting) via `ruff check --fix` / `ruff format`.
- Per-site manual review of BLE001/S110 (broad exception handling) — narrowed where possible, otherwise logged with a justified `# noqa` comment explaining why the broad catch is intentional (cleanup/teardown/RPC-boundary paths).
- ASYNC230 (blocking file I/O in async functions): one production fix in `boxlite/codebox.py` (moved to `asyncio.to_thread`); noqa'd in a test file that's an intentionally-preserved security PoC script.
- B017 (overly broad `assertRaises(Exception)`/`pytest.raises(Exception)`): narrowed to `RuntimeError` in 4 test files, based on the Rust binding's `map_err` (`sdks/python/src/util.rs`) which wraps all `BoxliteError` variants into `PyRuntimeError`.
- Remaining rules (PYI034, RUF022, RUF012/013, UP031, SIM115/117, C401) fixed or justified with a noqa comment per site.
- Pinned `pip install ruff` to `ruff==0.16.0` in `.github/workflows/lint.yml`.

## How to verify
- `cd sdks/python && ruff check . && ruff format --check .` → both clean.
- `cd sdks/python && python -m pytest tests/ -m "not integration"` → 58 passed, 47 skipped (native extension not built), 0 failed.

## Risks / rollout
- The B017 `RuntimeError` narrowing in 4 `integration`-marked tests wasn't run against a compiled native extension in this environment (requires `make dev:python` + a VM runtime); it's backed by reading the Rust source but not empirically confirmed by CI locally. CI's `test:integration:python` job will exercise it.