### PR TITLE
fix(ci): pin ruff below 0.16 to stop unpinned lint drift

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -167,7 +167,9 @@ jobs:
           python-version: '3.12'
 
       - name: Install ruff
-        run: pip install ruff
+        # Pinned: an unpinned install silently upgrades to a new ruff whose newly
+        # stabilized rules can red the lint on unchanged code (0.16.0 did exactly this).
+        run: pip install ruff==0.15.4
 
       - name: Run Python lint
         run: make lint:python

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -38,7 +38,7 @@ Issues = "https://github.com/boxlite-ai/boxlite/issues"
 dev = [
     "pytest>=7.0",
     "pytest-asyncio>=0.21",
-    "ruff>=0.4",
+    "ruff>=0.15,<0.16",
     "tomli>=2.0; python_version < '3.11'",
 ]
 sync = ["greenlet>=3.0.0"]
@@ -48,7 +48,7 @@ orchestration = ["cloudpickle>=3.0"]
 dev = [
     "pytest>=7.0",
     "pytest-asyncio>=0.21",
-    "ruff>=0.4",
+    "ruff>=0.15,<0.16",
     "tomli>=2.0; python_version < '3.11'",
 ]
 sync = ["greenlet>=3.0.0"]


### PR DESCRIPTION
The lint workflow installed ruff unpinned (`pip install ruff`), so the `0.16.0` release — which stabilizes `UP045`/`RUF022` and changes isort output — began failing the Python lint on **unchanged, previously-clean** code (it reds every open PR, e.g. #1028).

Pins ruff to `0.15.4` in `lint.yml` and bounds it to `<0.16` in `sdks/python/pyproject.toml`, so an external ruff release can't spontaneously red the gate again. **No Python code changes** — `sdks/python` passes `ruff 0.15.4` check + `format --check`.

Root cause: the unpinned `pip install ruff` was added in `d27bfa63` (#106); the trigger was the external ruff `0.16.0` release, not any repo commit.

https://claude.ai/code/session_01Y7tNejVgFCQMQhkMvYPKhT


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized the Ruff tooling version used in automated checks and Python development environments.
  * Improved linting consistency and stability across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->