### PR TITLE
fix(apps): enforce BoxLite REST permissions

### DIFF
--- a/apps/api/src/boxlite-rest/boxlite-box.controller.ts
+++ b/apps/api/src/boxlite-rest/boxlite-box.controller.ts
@@ -22,6 +22,10 @@ import { ApiTags, ApiBearerAuth, ApiResponse, ApiExcludeController } from '@nest
 import { Response } from 'express'
 import { CombinedAuthGuard } from '../auth/combined-auth.guard'
 import { OrganizationResourceActionGuard } from '../organization/guards/organization-resource-action.guard'
+import {
+  FailClosedOnMissingOrganizationResourcePermissions,
+  RequiredOrganizationResourcePermissions,
+} from '../organization/decorators/required-organization-resource-permissions.decorator'
 import { AuthContext } from '../common/decorators/auth-context.decorator'
 import { OrganizationAuthContext } from '../common/interfaces/auth-context.interface'
 import { BoxService } from '../box/services/box.service'
@@ -35,12 +39,18 @@ import { boxToBoxResponse, createBoxToCreateBox } from './mappers/box-to-box.map
 import { Audit, MASKED_AUDIT_VALUE, TypedRequest } from '../audit/decorators/audit.decorator'
 import { AuditAction } from '../audit/enums/audit-action.enum'
 import { AuditTarget } from '../audit/enums/audit-target.enum'
+import {
+  BOXLITE_BOX_DELETE_PERMISSIONS,
+  BOXLITE_BOX_READ_PERMISSIONS,
+  BOXLITE_BOX_WRITE_PERMISSIONS,
+} from './boxlite-permission.policy'
 // Spec-first surface: the contract is openapi/box.openapi.yaml, not the
 // generated product spec (which `:prefix` routes would render invalid).
 @ApiExcludeController()
 @ApiTags('BoxLite REST')
 @Controller(['v1/boxes', 'v1/:prefix/boxes'])
 @UseGuards(CombinedAuthGuard, OrganizationResourceActionGuard)
+@FailClosedOnMissingOrganizationResourcePermissions(true)
 @ApiBearerAuth()
 export class BoxliteBoxController {
   private readonly logger = new Logger(BoxliteBoxController.name)
@@ -51,6 +61,7 @@ export class BoxliteBoxController {
   ) {}
 
   @Post()
+  @RequiredOrganizationResourcePermissions(BOXLITE_BOX_WRITE_PERMISSIONS)
   @HttpCode(201)
   @ApiResponse({
     status: 201,
@@ -97,6 +108,7 @@ export class BoxliteBoxController {
   }
 
   @Get()
+  @RequiredOrganizationResourcePermissions(BOXLITE_BOX_READ_PERMISSIONS)
   @ApiResponse({
     status: 200,
     description: 'List boxes',
@@ -114,6 +126,7 @@ export class BoxliteBoxController {
   }
 
   @Get(':boxId')
+  @RequiredOrganizationResourcePermissions(BOXLITE_BOX_READ_PERMISSIONS)
   @ApiResponse({
     status: 200,
     description: 'Box details',
@@ -129,6 +142,7 @@ export class BoxliteBoxController {
   }
 
   @Head(':boxId')
+  @RequiredOrganizationResourcePermissions(BOXLITE_BOX_READ_PERMISSIONS)
   async headBox(
     @AuthContext() authContext: OrganizationAuthContext,
     @Param('boxId') boxId: string,
@@ -143,6 +157,7 @@ export class BoxliteBoxController {
   }
 
   @Delete(':boxId')
+  @RequiredOrganizationResourcePermissions(BOXLITE_BOX_DELETE_PERMISSIONS)
   @HttpCode(204)
   @Audit({
     action: AuditAction.DELETE,
@@ -154,6 +169,7 @@ export class BoxliteBoxController {
   }
 
   @Post(':boxId/start')
+  @RequiredOrganizationResourcePermissions(BOXLITE_BOX_WRITE_PERMISSIONS)
   @ApiResponse({
     status: 201,
     description: 'Box start requested',
@@ -185,6 +201,7 @@ export class BoxliteBoxController {
   }
 
   @Post(':boxId/stop')
+  @RequiredOrganizationResourcePermissions(BOXLITE_BOX_WRITE_PERMISSIONS)
   @ApiResponse({
     status: 201,
     description: 'Box stop requested',

--- a/apps/api/src/boxlite-rest/boxlite-config.controller.ts
+++ b/apps/api/src/boxlite-rest/boxlite-config.controller.ts
@@ -6,6 +6,8 @@
 
 import { Controller, Get } from '@nestjs/common'
 import { ApiTags, ApiExcludeController } from '@nestjs/swagger'
+import { RequiredOrganizationResourcePermissions } from '../organization/decorators/required-organization-resource-permissions.decorator'
+import { BOXLITE_BOX_READ_PERMISSIONS } from './boxlite-permission.policy'
 
 // Spec-first surface: the contract is openapi/box.openapi.yaml.
 @ApiExcludeController()
@@ -13,6 +15,7 @@ import { ApiTags, ApiExcludeController } from '@nestjs/swagger'
 @Controller('v1')
 export class BoxliteConfigController {
   @Get('config')
+  @RequiredOrganizationResourcePermissions(BOXLITE_BOX_READ_PERMISSIONS)
   getConfig() {
     return {
       capabilities: {

--- a/apps/api/src/boxlite-rest/boxlite-me.controller.spec.ts
+++ b/apps/api/src/boxlite-rest/boxlite-me.controller.spec.ts
@@ -6,23 +6,38 @@
 
 import { ApiKey } from '../api-key/api-key.entity'
 import { AuthContext } from '../common/interfaces/auth-context.interface'
+import { OrganizationMemberRole } from '../organization/enums/organization-member-role.enum'
+import { OrganizationResourcePermission } from '../organization/enums/organization-resource-permission.enum'
 import { OrganizationService } from '../organization/services/organization.service'
+import { SystemRole } from '../user/enums/system-role.enum'
 import { BoxliteMeController } from './boxlite-me.controller'
 
 describe('BoxliteMeController', () => {
-  // resolvePathPrefix only touches OrganizationService on the user-session path;
-  // API-key contexts short-circuit on apiKey.organizationId.
-  function makeController(orgFindByUser: jest.Mock = jest.fn()): BoxliteMeController {
+  function makeController(
+    orgFindByUser: jest.Mock = jest.fn().mockResolvedValue([
+      {
+        organization: { id: '11111111-1111-1111-1111-111111111111' },
+        organizationUser: {
+          organizationId: '11111111-1111-1111-1111-111111111111',
+          userId: 'user-1',
+          role: OrganizationMemberRole.MEMBER,
+          assignedRoles: [],
+        },
+        isDefaultForAuthenticatedUser: true,
+      },
+    ]),
+  ): BoxliteMeController {
     const organizationService = { findByUserWithDefaultFlag: orgFindByUser } as unknown as OrganizationService
     return new BoxliteMeController(organizationService)
   }
 
-  function apiKeyContext(expiresAt?: Date): AuthContext {
+  function apiKeyContext(expiresAt?: Date, permissions: OrganizationResourcePermission[] = []): AuthContext {
     const apiKey = {
       organizationId: '11111111-1111-1111-1111-111111111111',
       userId: 'user-1',
       name: 'key-531',
       expiresAt,
+      permissions,
     } as ApiKey
     return {
       userId: 'user-1',
@@ -60,6 +75,71 @@ describe('BoxliteMeController', () => {
 
       expect(result.principal_type).toBe('user')
       expect(result.expires_at).toBeNull()
+    })
+  })
+
+  describe('GET /v1/me — scopes reflect effective Box permissions', () => {
+    it('does not advertise write, exec, delete, or image scopes to a read-only API key', async () => {
+      const result = await makeController().getMe(apiKeyContext())
+
+      expect(result.scopes).toEqual(['box:read', 'me:read'])
+    })
+
+    it('maps Box write permission to write and exec scopes without advertising delete', async () => {
+      const result = await makeController().getMe(
+        apiKeyContext(undefined, [OrganizationResourcePermission.WRITE_BOXES]),
+      )
+
+      expect(result.scopes).toEqual(['box:read', 'box:write', 'box:exec', 'me:read'])
+    })
+
+    it('does not advertise Box scopes when the API key owner is no longer an organization member', async () => {
+      const result = await makeController(jest.fn().mockResolvedValue([])).getMe(apiKeyContext())
+
+      expect(result.scopes).toEqual(['me:read'])
+    })
+
+    it('does not let a system administrator API key advertise permissions absent from the key', async () => {
+      const context = apiKeyContext()
+      context.role = SystemRole.ADMIN
+
+      const result = await makeController().getMe(context)
+
+      expect(result.scopes).toEqual(['box:read', 'me:read'])
+    })
+
+    it('uses the selected organization membership for an interactive user', async () => {
+      const findByUser = jest.fn().mockResolvedValue([
+        {
+          organization: { id: 'org-2' },
+          isDefaultForAuthenticatedUser: true,
+          organizationUser: {
+            role: OrganizationMemberRole.MEMBER,
+            assignedRoles: [{ permissions: [OrganizationResourcePermission.DELETE_BOXES] }],
+          },
+        },
+      ])
+      const ctx: AuthContext = {
+        userId: 'user-2',
+        email: 'human@example.com',
+        role: 'user' as AuthContext['role'],
+      }
+
+      const result = await makeController(findByUser).getMe(ctx)
+
+      expect(result.scopes).toEqual(['box:read', 'box:delete', 'me:read'])
+    })
+
+    it('does not advertise Box scopes to an interactive user without an organization membership', async () => {
+      const context: AuthContext = {
+        userId: 'user-2',
+        email: 'human@example.com',
+        role: 'user' as AuthContext['role'],
+      }
+
+      const result = await makeController(jest.fn().mockResolvedValue([])).getMe(context)
+
+      expect(result.scopes).toEqual(['me:read'])
     })
   })
 })

--- a/apps/api/src/boxlite-rest/boxlite-me.controller.ts
+++ b/apps/api/src/boxlite-rest/boxlite-me.controller.ts
@@ -9,8 +9,11 @@ import { ApiBearerAuth, ApiTags, ApiExcludeController } from '@nestjs/swagger'
 import { CombinedAuthGuard } from '../auth/combined-auth.guard'
 import { AuthContext } from '../common/decorators/auth-context.decorator'
 import { AuthContext as AuthCtx } from '../common/interfaces/auth-context.interface'
+import type { OrganizationUser } from '../organization/entities/organization-user.entity'
+import { RequiredOrganizationResourcePermissions } from '../organization/decorators/required-organization-resource-permissions.decorator'
 import { OrganizationService } from '../organization/services/organization.service'
 import { PrincipalDto } from './dto/principal.dto'
+import { BOXLITE_BOX_READ_PERMISSIONS, grantedBoxliteScopes } from './boxlite-permission.policy'
 
 /**
  * `GET /v1/me` — identity for the calling credential.
@@ -31,8 +34,9 @@ export class BoxliteMeController {
   constructor(private readonly organizationService: OrganizationService) {}
 
   @Get('me')
+  @RequiredOrganizationResourcePermissions(BOXLITE_BOX_READ_PERMISSIONS)
   async getMe(@AuthContext() ctx: AuthCtx): Promise<PrincipalDto> {
-    const pathPrefix = await this.resolvePathPrefix(ctx)
+    const access = await this.resolveOrganizationAccess(ctx)
 
     const principalType: 'user' | 'service_account' = ctx.apiKey ? 'service_account' : 'user'
 
@@ -41,11 +45,8 @@ export class BoxliteMeController {
       principal_type: principalType,
       email: ctx.email || undefined,
       display_name: undefined,
-      path_prefix: pathPrefix,
-      // TODO: source scopes from ctx.apiKey?.scopes once the ApiKey entity
-      // has a `scopes` column. For now grant the full set used by the OpenAPI
-      // spec's documented scope vocabulary.
-      scopes: ['box:read', 'box:write', 'box:exec', 'box:delete', 'image:read', 'image:write', 'me:read'],
+      path_prefix: access.pathPrefix,
+      scopes: grantedBoxliteScopes(ctx, access.organizationUser),
       // Source of truth for key expiry is ApiKey.expiresAt — the same column the
       // dashboard's `/api-keys` list renders. Returning a hardcoded null here let
       // clients believe a soon-to-expire key was permanent (P1-2). `null` stays
@@ -63,15 +64,28 @@ export class BoxliteMeController {
    * the field stays present in the response envelope with explicit
    * `null` per the OpenAPI contract).
    */
-  private async resolvePathPrefix(ctx: AuthCtx): Promise<string | null> {
-    if (ctx.apiKey?.organizationId) {
-      return ctx.apiKey.organizationId
-    }
+  private async resolveOrganizationAccess(
+    ctx: AuthCtx,
+  ): Promise<{ pathPrefix: string | null; organizationUser?: OrganizationUser }> {
     const memberships = await this.organizationService.findByUserWithDefaultFlag(ctx.userId)
-    if (memberships.length === 0) {
-      return null
+
+    if (ctx.apiKey?.organizationId) {
+      const membership = memberships.find(
+        (candidate) => candidate.organization.id === ctx.apiKey?.organizationId,
+      )
+      return {
+        pathPrefix: ctx.apiKey.organizationId,
+        organizationUser: membership?.organizationUser,
+      }
     }
-    return (memberships.find((membership) => membership.isDefaultForAuthenticatedUser) ?? memberships[0]).organization
-      .id
+
+    if (memberships.length === 0) {
+      return { pathPrefix: null }
+    }
+    const membership = memberships.find((candidate) => candidate.isDefaultForAuthenticatedUser) ?? memberships[0]
+    return {
+      pathPrefix: membership.organization.id,
+      organizationUser: membership.organizationUser,
+    }
   }
 }

--- a/apps/api/src/boxlite-rest/boxlite-permission.policy.spec.ts
+++ b/apps/api/src/boxlite-rest/boxlite-permission.policy.spec.ts
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import type { ApiKey } from '../api-key/api-key.entity'
+import type { AuthContext, OrganizationAuthContext } from '../common/interfaces/auth-context.interface'
+import type { OrganizationUser } from '../organization/entities/organization-user.entity'
+import { OrganizationMemberRole } from '../organization/enums/organization-member-role.enum'
+import { OrganizationResourcePermission } from '../organization/enums/organization-resource-permission.enum'
+import { hasRequiredOrganizationResourcePermissions } from '../organization/guards/organization-resource-action.guard'
+import { SystemRole } from '../user/enums/system-role.enum'
+import {
+  BOXLITE_BOX_READ_PERMISSIONS,
+  BOXLITE_BOX_WRITE_PERMISSIONS,
+  grantedBoxliteScopes,
+} from './boxlite-permission.policy'
+
+function apiKey(permissions: OrganizationResourcePermission[]): ApiKey {
+  return {
+    organizationId: 'org-1',
+    userId: 'user-1',
+    permissions,
+  } as ApiKey
+}
+
+function organizationUser(
+  role: OrganizationMemberRole,
+  permissions: OrganizationResourcePermission[] = [],
+): OrganizationUser {
+  return {
+    organizationId: 'org-1',
+    userId: 'user-1',
+    role,
+    assignedRoles: permissions.length > 0 ? [{ permissions }] : [],
+  } as OrganizationUser
+}
+
+function authContext(options?: {
+  role?: SystemRole
+  keyPermissions?: OrganizationResourcePermission[]
+  memberRole?: OrganizationMemberRole
+  memberPermissions?: OrganizationResourcePermission[]
+}): OrganizationAuthContext {
+  const member = organizationUser(
+    options?.memberRole ?? OrganizationMemberRole.MEMBER,
+    options?.memberPermissions,
+  )
+  return {
+    organizationId: 'org-1',
+    organization: { id: 'org-1' },
+    organizationUser: member,
+    userId: 'user-1',
+    email: 'user@example.com',
+    role: options?.role ?? SystemRole.USER,
+    apiKey: options?.keyPermissions === undefined ? undefined : apiKey(options.keyPermissions),
+  } as OrganizationAuthContext
+}
+
+describe('BoxLite permission policy', () => {
+  describe('hasRequiredOrganizationResourcePermissions', () => {
+    it('allows organization members to use membership-only Box reads', () => {
+      expect(hasRequiredOrganizationResourcePermissions(authContext(), BOXLITE_BOX_READ_PERMISSIONS)).toBe(true)
+    })
+
+    it('allows a member role with Box write permission to mutate boxes', () => {
+      const context = authContext({ memberPermissions: [OrganizationResourcePermission.WRITE_BOXES] })
+
+      expect(hasRequiredOrganizationResourcePermissions(context, BOXLITE_BOX_WRITE_PERMISSIONS)).toBe(true)
+    })
+
+    it('fails closed when assigned-role permissions are unavailable', () => {
+      const context = authContext()
+      const member = context.organizationUser as OrganizationUser
+      member.assignedRoles = undefined as never
+
+      expect(hasRequiredOrganizationResourcePermissions(context, BOXLITE_BOX_WRITE_PERMISSIONS)).toBe(false)
+    })
+
+    it('does not let an owner API key inherit the interactive owner bypass', () => {
+      const context = authContext({
+        memberRole: OrganizationMemberRole.OWNER,
+        keyPermissions: [],
+      })
+
+      expect(hasRequiredOrganizationResourcePermissions(context, BOXLITE_BOX_WRITE_PERMISSIONS)).toBe(false)
+    })
+
+    it('allows an owner API key when the key itself has Box write permission', () => {
+      const context = authContext({
+        memberRole: OrganizationMemberRole.OWNER,
+        keyPermissions: [OrganizationResourcePermission.WRITE_BOXES],
+      })
+
+      expect(hasRequiredOrganizationResourcePermissions(context, BOXLITE_BOX_WRITE_PERMISSIONS)).toBe(true)
+    })
+
+    it('does not let a system administrator API key bypass its own Box permissions', () => {
+      const context = authContext({
+        role: SystemRole.ADMIN,
+        keyPermissions: [],
+      })
+
+      expect(hasRequiredOrganizationResourcePermissions(context, BOXLITE_BOX_WRITE_PERMISSIONS)).toBe(false)
+    })
+
+    it('allows an interactive owner without assigned roles', () => {
+      const context = authContext({ memberRole: OrganizationMemberRole.OWNER })
+
+      expect(hasRequiredOrganizationResourcePermissions(context, BOXLITE_BOX_WRITE_PERMISSIONS)).toBe(true)
+    })
+
+    it('requires an organization membership even for membership-only reads', () => {
+      const context = authContext()
+      context.organizationUser = undefined
+
+      expect(hasRequiredOrganizationResourcePermissions(context, BOXLITE_BOX_READ_PERMISSIONS)).toBe(false)
+    })
+  })
+
+  describe('grantedBoxliteScopes', () => {
+    it('maps an API key with both Box capabilities to the complete Box scope set', () => {
+      const context = authContext({
+        keyPermissions: [
+          OrganizationResourcePermission.WRITE_BOXES,
+          OrganizationResourcePermission.DELETE_BOXES,
+        ],
+      })
+
+      expect(grantedBoxliteScopes(context, context.organizationUser)).toEqual([
+        'box:read',
+        'box:write',
+        'box:exec',
+        'box:delete',
+        'me:read',
+      ])
+    })
+
+    it('keeps an owner API key with no Box permissions read-only', () => {
+      const context = authContext({
+        memberRole: OrganizationMemberRole.OWNER,
+        keyPermissions: [],
+      })
+
+      expect(grantedBoxliteScopes(context, context.organizationUser)).toEqual(['box:read', 'me:read'])
+    })
+
+    it('keeps a system administrator API key constrained by the key permissions', () => {
+      const context = authContext({
+        role: SystemRole.ADMIN,
+        keyPermissions: [],
+      })
+
+      expect(grantedBoxliteScopes(context, context.organizationUser)).toEqual(['box:read', 'me:read'])
+    })
+
+    it('does not advertise Box access without an organization membership', () => {
+      const context = authContext()
+      context.organizationUser = undefined
+
+      expect(grantedBoxliteScopes(context)).toEqual(['me:read'])
+    })
+
+    it('maps an interactive owner to all Box scopes', () => {
+      const context = authContext({ memberRole: OrganizationMemberRole.OWNER })
+
+      expect(grantedBoxliteScopes(context, context.organizationUser)).toEqual([
+        'box:read',
+        'box:write',
+        'box:exec',
+        'box:delete',
+        'me:read',
+      ])
+    })
+
+    it('maps assigned member permissions without advertising image scopes', () => {
+      const context = authContext({ memberPermissions: [OrganizationResourcePermission.DELETE_BOXES] })
+
+      expect(grantedBoxliteScopes(context, context.organizationUser)).toEqual(['box:read', 'box:delete', 'me:read'])
+    })
+
+    it('gives system administrators all Box scopes without an organization membership', () => {
+      const context: AuthContext = {
+        userId: 'admin-1',
+        email: 'admin@example.com',
+        role: SystemRole.ADMIN,
+      }
+
+      expect(grantedBoxliteScopes(context)).toEqual([
+        'box:read',
+        'box:write',
+        'box:exec',
+        'box:delete',
+        'me:read',
+      ])
+    })
+  })
+})

--- a/apps/api/src/boxlite-rest/boxlite-permission.policy.ts
+++ b/apps/api/src/boxlite-rest/boxlite-permission.policy.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import type { AuthContext } from '../common/interfaces/auth-context.interface'
+import type { OrganizationUser } from '../organization/entities/organization-user.entity'
+import { OrganizationMemberRole } from '../organization/enums/organization-member-role.enum'
+import { OrganizationResourcePermission } from '../organization/enums/organization-resource-permission.enum'
+import { SystemRole } from '../user/enums/system-role.enum'
+
+export const BOXLITE_BOX_READ_PERMISSIONS: OrganizationResourcePermission[] = []
+export const BOXLITE_BOX_WRITE_PERMISSIONS = [OrganizationResourcePermission.WRITE_BOXES]
+export const BOXLITE_BOX_DELETE_PERMISSIONS = [OrganizationResourcePermission.DELETE_BOXES]
+
+export function grantedBoxliteScopes(authContext: AuthContext, organizationUser?: OrganizationUser): string[] {
+  if (!hasBoxReadAccess(authContext, organizationUser)) {
+    return ['me:read']
+  }
+
+  const scopes = ['box:read', 'me:read']
+  const permissions = effectiveBoxPermissions(authContext, organizationUser)
+
+  if (permissions.has(OrganizationResourcePermission.WRITE_BOXES)) {
+    scopes.splice(1, 0, 'box:write', 'box:exec')
+  }
+  if (permissions.has(OrganizationResourcePermission.DELETE_BOXES)) {
+    scopes.splice(scopes.length - 1, 0, 'box:delete')
+  }
+
+  return scopes
+}
+
+function hasBoxReadAccess(authContext: AuthContext, organizationUser?: OrganizationUser): boolean {
+  return (authContext.role === SystemRole.ADMIN && !authContext.apiKey) || organizationUser !== undefined
+}
+
+function effectiveBoxPermissions(
+  authContext: AuthContext,
+  organizationUser?: OrganizationUser,
+): Set<OrganizationResourcePermission> {
+  if (authContext.apiKey) {
+    return new Set(authContext.apiKey.permissions ?? [])
+  }
+
+  if (authContext.role === SystemRole.ADMIN) {
+    return new Set(BOXLITE_BOX_WRITE_PERMISSIONS.concat(BOXLITE_BOX_DELETE_PERMISSIONS))
+  }
+
+  if (organizationUser?.role === OrganizationMemberRole.OWNER) {
+    return new Set(BOXLITE_BOX_WRITE_PERMISSIONS.concat(BOXLITE_BOX_DELETE_PERMISSIONS))
+  }
+
+  return new Set(organizationUser?.assignedRoles?.flatMap((role) => role.permissions) ?? [])
+}

--- a/apps/api/src/boxlite-rest/boxlite-permissions.integration.spec.ts
+++ b/apps/api/src/boxlite-rest/boxlite-permissions.integration.spec.ts
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { getRedisConnectionToken } from '@nestjs-modules/ioredis'
+import { Test } from '@nestjs/testing'
+import type { CanActivate, ExecutionContext, INestApplication } from '@nestjs/common'
+import type { AddressInfo } from 'net'
+import { CombinedAuthGuard } from '../auth/combined-auth.guard'
+import { BoxService } from '../box/services/box.service'
+import { BoxStateWaiterService } from '../box/services/box-state-waiter.service'
+import { RunnerService } from '../box/services/runner.service'
+import { OrganizationMemberRole } from '../organization/enums/organization-member-role.enum'
+import { OrganizationResourcePermission } from '../organization/enums/organization-resource-permission.enum'
+import { OrganizationResourceActionGuard } from '../organization/guards/organization-resource-action.guard'
+import { OrganizationService } from '../organization/services/organization.service'
+import { OrganizationUserService } from '../organization/services/organization-user.service'
+import { SystemRole } from '../user/enums/system-role.enum'
+import { BoxAutoResumeService } from './box-auto-resume.service'
+import { BoxliteBoxController } from './boxlite-box.controller'
+import { BoxliteProxyController } from './boxlite-proxy.controller'
+
+jest.mock('http-proxy-middleware', () => ({
+  createProxyMiddleware: jest.fn(),
+  fixRequestBody: jest.fn(),
+}))
+jest.mock('uuid', () => ({
+  v4: jest.fn(() => 'mock-uuid'),
+  validate: jest.fn(() => true),
+}))
+
+const KEY_PERMISSIONS: Record<string, OrganizationResourcePermission[]> = {
+  read: [],
+  'admin-read': [],
+  write: [OrganizationResourcePermission.WRITE_BOXES],
+  delete: [OrganizationResourcePermission.DELETE_BOXES],
+}
+
+describe('BoxLite REST permission integration', () => {
+  let app: INestApplication
+  const organization = { id: 'org-1' }
+  const boxService = {
+    create: jest.fn(),
+    destroy: jest.fn().mockResolvedValue(undefined),
+    findAllDeprecated: jest.fn().mockResolvedValue([]),
+    toBoxDtos: jest.fn().mockResolvedValue([]),
+    getNetworkTunnelUrl: jest.fn().mockResolvedValue('http://127.0.0.1/tunnel'),
+  }
+
+  const authenticationGuard: CanActivate = {
+    canActivate(context: ExecutionContext): boolean {
+      const request = context.switchToHttp().getRequest()
+      const authorization = request.headers.authorization as string | undefined
+      const token = authorization?.replace(/^Bearer\s+/i, '')
+      const permissions = token ? KEY_PERMISSIONS[token] : undefined
+      if (!permissions) {
+        return false
+      }
+
+      request.user = {
+        organizationId: organization.id,
+        userId: 'owner-1',
+        email: 'owner@example.com',
+        role: token === 'admin-read' ? SystemRole.ADMIN : SystemRole.USER,
+        apiKey: {
+          organizationId: organization.id,
+          userId: 'owner-1',
+          name: `${token}-key`,
+          permissions,
+        },
+      }
+      return true
+    },
+  }
+
+  beforeAll(async () => {
+    const redis = {
+      get: jest.fn().mockResolvedValue(null),
+      set: jest.fn().mockResolvedValue('OK'),
+    }
+    const moduleRef = await Test.createTestingModule({
+      controllers: [BoxliteBoxController, BoxliteProxyController],
+      providers: [
+        OrganizationResourceActionGuard,
+        {
+          provide: getRedisConnectionToken(),
+          useValue: redis,
+        },
+        {
+          provide: OrganizationService,
+          useValue: {
+            findOne: jest.fn().mockResolvedValue(organization),
+          },
+        },
+        {
+          provide: OrganizationUserService,
+          useValue: {
+            findOne: jest.fn().mockResolvedValue({
+              organizationId: organization.id,
+              userId: 'owner-1',
+              role: OrganizationMemberRole.OWNER,
+              assignedRoles: [],
+            }),
+          },
+        },
+        {
+          provide: BoxService,
+          useValue: boxService,
+        },
+        {
+          provide: BoxStateWaiterService,
+          useValue: {},
+        },
+        {
+          provide: RunnerService,
+          useValue: {},
+        },
+        {
+          provide: BoxAutoResumeService,
+          useValue: {},
+        },
+      ],
+    })
+      .overrideGuard(CombinedAuthGuard)
+      .useValue(authenticationGuard)
+      .compile()
+
+    app = moduleRef.createNestApplication()
+    app.setGlobalPrefix('api')
+    await app.listen(0)
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  afterAll(async () => {
+    await app.close()
+  })
+
+  async function request(path: string, credential: keyof typeof KEY_PERMISSIONS, init?: RequestInit): Promise<Response> {
+    const address = app.getHttpServer().address() as AddressInfo
+    return fetch(`http://127.0.0.1:${address.port}${path}`, {
+      ...init,
+      headers: {
+        Authorization: `Bearer ${credential}`,
+        'Content-Type': 'application/json',
+        ...init?.headers,
+      },
+    })
+  }
+
+  it('allows an owner API key without mutation permissions to list boxes', async () => {
+    const response = await request('/api/v1/boxes', 'read')
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ boxes: [] })
+    expect(boxService.findAllDeprecated).toHaveBeenCalledWith(organization.id)
+  })
+
+  it('rejects create before invoking BoxService when an owner API key lacks Box write permission', async () => {
+    const response = await request('/api/v1/boxes', 'read', {
+      method: 'POST',
+      body: JSON.stringify({ image: 'ubuntu:24.04' }),
+    })
+
+    expect(response.status).toBe(403)
+    expect(boxService.create).not.toHaveBeenCalled()
+  })
+
+  it('rejects create when a system administrator API key lacks Box write permission', async () => {
+    const response = await request('/api/v1/boxes', 'admin-read', {
+      method: 'POST',
+      body: JSON.stringify({ image: 'ubuntu:24.04' }),
+    })
+
+    expect(response.status).toBe(403)
+    expect(boxService.create).not.toHaveBeenCalled()
+  })
+
+  it('allows a Box write API key to create a network tunnel', async () => {
+    const response = await request('/api/v1/boxes/box-1/network/tunnel?port=3000', 'write', {
+      method: 'POST',
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ uri: 'http://127.0.0.1/tunnel' })
+    expect(boxService.getNetworkTunnelUrl).toHaveBeenCalledWith('box-1', organization.id, 3000)
+  })
+
+  it('does not let Box write permission authorize box destruction', async () => {
+    const response = await request('/api/v1/boxes/box-1', 'write', {
+      method: 'DELETE',
+    })
+
+    expect(response.status).toBe(403)
+    expect(boxService.destroy).not.toHaveBeenCalled()
+  })
+
+  it('allows a Box delete API key to destroy a box', async () => {
+    const response = await request('/api/v1/boxes/box-1', 'delete', {
+      method: 'DELETE',
+    })
+
+    expect(response.status).toBe(204)
+    expect(boxService.destroy).toHaveBeenCalledWith('box-1', organization.id)
+  })
+})

--- a/apps/api/src/boxlite-rest/boxlite-proxy.controller.ts
+++ b/apps/api/src/boxlite-rest/boxlite-proxy.controller.ts
@@ -28,11 +28,16 @@ import { createProxyMiddleware, fixRequestBody, Options } from 'http-proxy-middl
 import { Request, Response, NextFunction } from 'express'
 import { CombinedAuthGuard } from '../auth/combined-auth.guard'
 import { OrganizationResourceActionGuard } from '../organization/guards/organization-resource-action.guard'
+import {
+  FailClosedOnMissingOrganizationResourcePermissions,
+  RequiredOrganizationResourcePermissions,
+} from '../organization/decorators/required-organization-resource-permissions.decorator'
 import { AuthContext } from '../common/decorators/auth-context.decorator'
 import { OrganizationAuthContext } from '../common/interfaces/auth-context.interface'
 import { BoxService } from '../box/services/box.service'
 import { RunnerService } from '../box/services/runner.service'
 import { BoxAutoResumeService } from './box-auto-resume.service'
+import { BOXLITE_BOX_READ_PERMISSIONS, BOXLITE_BOX_WRITE_PERMISSIONS } from './boxlite-permission.policy'
 
 type ProxyActivityPolicy = { activity: boolean; autoResume: boolean }
 const USER_OPERATION: ProxyActivityPolicy = { activity: true, autoResume: true }
@@ -44,6 +49,7 @@ const OBSERVATION_ONLY: ProxyActivityPolicy = { activity: false, autoResume: fal
 @ApiTags('BoxLite REST')
 @Controller(['v1/boxes', 'v1/:prefix/boxes'])
 @UseGuards(CombinedAuthGuard, OrganizationResourceActionGuard)
+@FailClosedOnMissingOrganizationResourcePermissions(true)
 @ApiBearerAuth()
 export class BoxliteProxyController {
   private readonly logger = new Logger(BoxliteProxyController.name)
@@ -55,6 +61,7 @@ export class BoxliteProxyController {
   ) {}
 
   @All(':boxId/exec')
+  @RequiredOrganizationResourcePermissions(BOXLITE_BOX_WRITE_PERMISSIONS)
   async proxyExec(
     @AuthContext() authContext: OrganizationAuthContext,
     @Param('boxId') boxId: string,
@@ -74,6 +81,7 @@ export class BoxliteProxyController {
   }
 
   @All(':boxId/executions/:execId/signal')
+  @RequiredOrganizationResourcePermissions(BOXLITE_BOX_WRITE_PERMISSIONS)
   async proxyExecSignal(
     @AuthContext() authContext: OrganizationAuthContext,
     @Param('boxId') boxId: string,
@@ -94,6 +102,7 @@ export class BoxliteProxyController {
   }
 
   @All(':boxId/executions/:execId/resize')
+  @RequiredOrganizationResourcePermissions(BOXLITE_BOX_WRITE_PERMISSIONS)
   async proxyExecResize(
     @AuthContext() authContext: OrganizationAuthContext,
     @Param('boxId') boxId: string,
@@ -114,6 +123,7 @@ export class BoxliteProxyController {
   }
 
   @Get(':boxId/executions/:execId')
+  @RequiredOrganizationResourcePermissions(BOXLITE_BOX_WRITE_PERMISSIONS)
   async proxyExecStatus(
     @AuthContext() authContext: OrganizationAuthContext,
     @Param('boxId') boxId: string,
@@ -134,6 +144,7 @@ export class BoxliteProxyController {
   }
 
   @Delete(':boxId/executions/:execId')
+  @RequiredOrganizationResourcePermissions(BOXLITE_BOX_WRITE_PERMISSIONS)
   async proxyExecKill(
     @AuthContext() authContext: OrganizationAuthContext,
     @Param('boxId') boxId: string,
@@ -160,6 +171,7 @@ export class BoxliteProxyController {
   // a NestJS 404, which is the correct answer.
 
   @All(':boxId/files')
+  @RequiredOrganizationResourcePermissions(BOXLITE_BOX_WRITE_PERMISSIONS)
   async proxyFiles(
     @AuthContext() authContext: OrganizationAuthContext,
     @Param('boxId') boxId: string,
@@ -180,6 +192,7 @@ export class BoxliteProxyController {
   }
 
   @All(':boxId/metrics')
+  @RequiredOrganizationResourcePermissions(BOXLITE_BOX_READ_PERMISSIONS)
   async proxyMetrics(
     @AuthContext() authContext: OrganizationAuthContext,
     @Param('boxId') boxId: string,
@@ -199,6 +212,7 @@ export class BoxliteProxyController {
   }
 
   @Post(':boxId/network/tunnel')
+  @RequiredOrganizationResourcePermissions(BOXLITE_BOX_WRITE_PERMISSIONS)
   @HttpCode(HttpStatus.OK)
   async proxyNetworkTunnel(
     @AuthContext() authContext: OrganizationAuthContext,

--- a/apps/api/src/boxlite-rest/boxlite-rest-routing.spec.ts
+++ b/apps/api/src/boxlite-rest/boxlite-rest-routing.spec.ts
@@ -5,14 +5,20 @@
  */
 
 import { PATH_METADATA } from '@nestjs/common/constants'
+import { Reflector } from '@nestjs/core'
 import { Test } from '@nestjs/testing'
-import type { INestApplication } from '@nestjs/common'
+import type { ExecutionContext, INestApplication } from '@nestjs/common'
 import type { AddressInfo } from 'net'
 import { CombinedAuthGuard } from '../auth/combined-auth.guard'
 import { OrganizationResourceActionGuard } from '../organization/guards/organization-resource-action.guard'
+import { RequiredOrganizationResourcePermissions } from '../organization/decorators/required-organization-resource-permissions.decorator'
+import { OrganizationResourcePermission } from '../organization/enums/organization-resource-permission.enum'
+import { OrganizationMemberRole } from '../organization/enums/organization-member-role.enum'
 import { BoxService } from '../box/services/box.service'
 import { BoxStateWaiterService } from '../box/services/box-state-waiter.service'
 import { BoxliteBoxController } from './boxlite-box.controller'
+import { BoxliteConfigController } from './boxlite-config.controller'
+import { BoxliteMeController } from './boxlite-me.controller'
 import { BoxliteProxyController } from './boxlite-proxy.controller'
 import { BoxliteWsProxyService } from './boxlite-ws-proxy.service'
 
@@ -99,6 +105,7 @@ describe('BoxLite REST routing', () => {
       {} as any,
       {} as any,
       {} as any,
+      {} as any,
     )
 
     expect(service.matchAttachPath('/api/v1/boxes/box-1/executions/exec-1/attach')).toEqual({ boxId: 'box-1' })
@@ -117,8 +124,125 @@ describe('BoxLite REST routing', () => {
       {} as any,
       {} as any,
       {} as any,
+      {} as any,
     )
 
     expect(service.matchAttachPath('/api/v1/boxes/box-1/network/tunnel?port=3000')).toBeNull()
+  })
+})
+
+describe('BoxLite REST permissions', () => {
+  const READ_BOXES: OrganizationResourcePermission[] = []
+  const WRITE_BOXES = [OrganizationResourcePermission.WRITE_BOXES]
+  const DELETE_BOXES = [OrganizationResourcePermission.DELETE_BOXES]
+
+  const routePermissions: Array<
+    [controller: object, handlerName: string, expectedPermissions: OrganizationResourcePermission[]]
+  > = [
+    [BoxliteConfigController.prototype, 'getConfig', READ_BOXES],
+    [BoxliteMeController.prototype, 'getMe', READ_BOXES],
+    [BoxliteBoxController.prototype, 'createBox', WRITE_BOXES],
+    [BoxliteBoxController.prototype, 'listBoxes', READ_BOXES],
+    [BoxliteBoxController.prototype, 'getBox', READ_BOXES],
+    [BoxliteBoxController.prototype, 'headBox', READ_BOXES],
+    [BoxliteBoxController.prototype, 'removeBox', DELETE_BOXES],
+    [BoxliteBoxController.prototype, 'startBox', WRITE_BOXES],
+    [BoxliteBoxController.prototype, 'stopBox', WRITE_BOXES],
+    [BoxliteProxyController.prototype, 'proxyExec', WRITE_BOXES],
+    [BoxliteProxyController.prototype, 'proxyExecSignal', WRITE_BOXES],
+    [BoxliteProxyController.prototype, 'proxyExecResize', WRITE_BOXES],
+    [BoxliteProxyController.prototype, 'proxyExecStatus', WRITE_BOXES],
+    [BoxliteProxyController.prototype, 'proxyExecKill', WRITE_BOXES],
+    [BoxliteProxyController.prototype, 'proxyFiles', WRITE_BOXES],
+    [BoxliteProxyController.prototype, 'proxyMetrics', READ_BOXES],
+    [BoxliteProxyController.prototype, 'proxyNetworkTunnel', WRITE_BOXES],
+  ]
+
+  it.each(routePermissions)('%s.%s declares its required Box permission', (controller, handlerName, expected) => {
+    const handler = (controller as Record<string, unknown>)[handlerName]
+
+    expect(Reflect.getMetadata(RequiredOrganizationResourcePermissions.KEY, handler)).toEqual(expected)
+  })
+
+  function permissionContext(
+    controller: object,
+    handler: object,
+    apiKeyPermissions?: OrganizationResourcePermission[],
+  ): ExecutionContext {
+    const apiKey =
+      apiKeyPermissions === undefined
+        ? undefined
+        : {
+            organizationId: 'org-123',
+            userId: 'user-1',
+            name: 'owner-key',
+            permissions: apiKeyPermissions,
+          }
+
+    const request = {
+      params: {},
+      user: {
+        organizationId: 'org-123',
+        userId: 'user-1',
+        email: 'owner@example.com',
+        role: 'user',
+        apiKey,
+      },
+    }
+
+    return {
+      getClass: () => controller,
+      getHandler: () => handler,
+      switchToHttp: () => ({
+        getRequest: () => request,
+      }),
+    } as unknown as ExecutionContext
+  }
+
+  function permissionGuard(): OrganizationResourceActionGuard {
+    const organizationService = {
+      findOne: jest.fn().mockResolvedValue({ id: 'org-123' }),
+    }
+    const organizationUserService = {
+      findOne: jest.fn().mockResolvedValue({
+        organizationId: 'org-123',
+        userId: 'user-1',
+        role: OrganizationMemberRole.OWNER,
+        assignedRoles: [],
+      }),
+    }
+    const guard = new OrganizationResourceActionGuard(
+      organizationService as never,
+      organizationUserService as never,
+      new Reflector(),
+    )
+    ;(guard as any).redis = {
+      get: jest.fn().mockResolvedValue(null),
+      set: jest.fn().mockResolvedValue('OK'),
+    }
+    return guard
+  }
+
+  it('keeps an owner API key constrained by its own Box permissions', async () => {
+    const context = permissionContext(BoxliteBoxController, BoxliteBoxController.prototype.createBox, [])
+
+    await expect(permissionGuard().canActivate(context)).resolves.toBe(false)
+  })
+
+  it('lets an interactive owner use Box write routes without an assigned role', async () => {
+    const context = permissionContext(BoxliteBoxController, BoxliteBoxController.prototype.createBox)
+
+    await expect(permissionGuard().canActivate(context)).resolves.toBe(true)
+  })
+
+  it('fails closed when a BoxLite Box route has no permission metadata', async () => {
+    const unclassifiedHandler = function unclassifiedHandler() {}
+    const context = permissionContext(
+      BoxliteBoxController,
+      unclassifiedHandler,
+      Object.values(OrganizationResourcePermission),
+    )
+
+    await expect(permissionGuard().canActivate(context)).resolves.toBe(false)
   })
 })

--- a/apps/api/src/boxlite-rest/boxlite-rest.module.ts
+++ b/apps/api/src/boxlite-rest/boxlite-rest.module.ts
@@ -15,9 +15,10 @@ import { BoxliteBoxController } from './boxlite-box.controller'
 import { BoxliteProxyController } from './boxlite-proxy.controller'
 import { BoxliteWsProxyService } from './boxlite-ws-proxy.service'
 import { BoxAutoResumeService } from './box-auto-resume.service'
+import { UserModule } from '../user/user.module'
 
 @Module({
-  imports: [BoxModule, AuthModule, ApiKeyModule, OrganizationModule],
+  imports: [BoxModule, AuthModule, ApiKeyModule, OrganizationModule, UserModule],
   controllers: [BoxliteMeController, BoxliteConfigController, BoxliteBoxController, BoxliteProxyController],
   providers: [BoxliteWsProxyService, BoxAutoResumeService],
   exports: [BoxliteWsProxyService],

--- a/apps/api/src/boxlite-rest/boxlite-ws-proxy.service.spec.ts
+++ b/apps/api/src/boxlite-rest/boxlite-ws-proxy.service.spec.ts
@@ -6,6 +6,9 @@
 
 import { createProxyMiddleware } from 'http-proxy-middleware'
 import type { IncomingMessage } from 'http'
+import { OrganizationMemberRole } from '../organization/enums/organization-member-role.enum'
+import { OrganizationResourcePermission } from '../organization/enums/organization-resource-permission.enum'
+import { SystemRole } from '../user/enums/system-role.enum'
 import { BoxliteWsProxyService } from './boxlite-ws-proxy.service'
 
 jest.mock('http-proxy-middleware', () => ({
@@ -53,6 +56,13 @@ describe('BoxliteWsProxyService', () => {
     const jwtStrategy = {
       verifyToken: jest.fn(),
     }
+    const userService = {
+      findOne: jest.fn().mockResolvedValue({
+        id: 'user-1',
+        role: SystemRole.USER,
+        email: 'dev@acme.test',
+      }),
+    }
     const service = new BoxliteWsProxyService(
       apiKeyService as never,
       organizationUserService as never,
@@ -61,6 +71,7 @@ describe('BoxliteWsProxyService', () => {
       runnerService as never,
       autoResume as never,
       jwtStrategy as never,
+      userService as never,
     ) as unknown as {
       authenticate: (req: IncomingMessage, urlTenant?: string) => Promise<{ organization: { id: string } } | null>
     }
@@ -74,11 +85,21 @@ describe('BoxliteWsProxyService', () => {
       runnerService,
       autoResume,
       jwtStrategy,
+      userService,
     }
   }
 
   it('rewrites public box ids to internal box ids before proxying attach upgrades to the runner', () => {
-    new BoxliteWsProxyService({} as never, {} as never, {} as never, {} as never, {} as never, {} as never, {} as never)
+    new BoxliteWsProxyService(
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+    )
 
     const proxyOptions = jest.mocked(createProxyMiddleware).mock.calls[0][0]
     const pathRewrite = proxyOptions.pathRewrite as (path: string, req: unknown) => string
@@ -98,8 +119,14 @@ describe('BoxliteWsProxyService', () => {
       organizationId: 'org-1',
       userId: 'user-1',
       expiresAt: null,
+      permissions: [OrganizationResourcePermission.WRITE_BOXES],
     })
-    organizationUserService.findOne.mockResolvedValue({ organizationId: 'org-1', userId: 'user-1' })
+    organizationUserService.findOne.mockResolvedValue({
+      organizationId: 'org-1',
+      userId: 'user-1',
+      role: OrganizationMemberRole.OWNER,
+      assignedRoles: [],
+    })
     autoResume.ensureReady.mockRejectedValue(new Error('start failed'))
     const socket = { write: jest.fn(), destroy: jest.fn() }
     const proxyHandler = jest.mocked(createProxyMiddleware).mock.results.at(-1)?.value
@@ -121,10 +148,16 @@ describe('BoxliteWsProxyService', () => {
       organizationId: 'org-1',
       userId: 'user-1',
       expiresAt: null,
+      permissions: [OrganizationResourcePermission.WRITE_BOXES],
     })
-    organizationUserService.findOne.mockResolvedValue({ organizationId: 'org-1', userId: 'user-1' })
+    organizationUserService.findOne.mockResolvedValue({
+      organizationId: 'org-1',
+      userId: 'user-1',
+      role: OrganizationMemberRole.OWNER,
+      assignedRoles: [],
+    })
 
-    await expect(service.authenticate(authRequest('blk_live_test'))).resolves.toEqual({
+    await expect(service.authenticate(authRequest('blk_live_test'))).resolves.toMatchObject({
       organization: { id: 'org-1', suspended: false },
     })
     expect(organizationUserService.findOne).toHaveBeenCalledWith('org-1', 'user-1')
@@ -137,7 +170,7 @@ describe('BoxliteWsProxyService', () => {
     jwtStrategy.verifyToken.mockResolvedValue({ sub: 'user-1', email: 'dev@acme.test' })
     organizationUserService.findOne.mockResolvedValue({ organizationId: 'org-1', userId: 'user-1' })
 
-    await expect(service.authenticate(authRequest(jwt), 'org-1')).resolves.toEqual({
+    await expect(service.authenticate(authRequest(jwt), 'org-1')).resolves.toMatchObject({
       organization: { id: 'org-1', suspended: false },
     })
     expect(jwtStrategy.verifyToken).toHaveBeenCalledWith(jwt)
@@ -161,5 +194,57 @@ describe('BoxliteWsProxyService', () => {
 
     await expect(service.authenticate(authRequest(jwt), 'org-1')).resolves.toBeNull()
     expect(organizationUserService.findOne).toHaveBeenCalledWith('org-1', 'user-1')
+  })
+
+  it('rejects websocket attach when an owner API key lacks Box write permission', async () => {
+    const { service, apiKeyService, organizationUserService } = buildAuthHarness()
+    apiKeyService.getApiKeyByValue.mockResolvedValue({
+      organizationId: 'org-1',
+      userId: 'user-1',
+      expiresAt: null,
+      permissions: [],
+    })
+    organizationUserService.findOne.mockResolvedValue({
+      organizationId: 'org-1',
+      userId: 'user-1',
+      role: OrganizationMemberRole.OWNER,
+      assignedRoles: [],
+    })
+    const socket = { write: jest.fn(), destroy: jest.fn() }
+    const proxyHandler = jest.mocked(createProxyMiddleware).mock.results.at(-1)?.value
+
+    await (service as unknown as BoxliteWsProxyService).upgrade(
+      authRequest('blk_live_test'),
+      socket as never,
+      Buffer.alloc(0),
+    )
+
+    expect(socket.write).toHaveBeenCalledWith(expect.stringContaining('403 Forbidden'))
+    expect(proxyHandler.upgrade).not.toHaveBeenCalled()
+    expect(socket.destroy).toHaveBeenCalled()
+  })
+
+  it('allows an interactive system administrator to attach without an assigned Box role', async () => {
+    const { service, organizationUserService, jwtStrategy, userService } = buildAuthHarness()
+    const jwt = 'eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJhZG1pbi0xIn0.signature'
+    jwtStrategy.verifyToken.mockResolvedValue({ sub: 'admin-1', email: 'admin@acme.test' })
+    userService.findOne.mockResolvedValue({
+      id: 'admin-1',
+      role: SystemRole.ADMIN,
+      email: 'admin@acme.test',
+    })
+    organizationUserService.findOne.mockResolvedValue({
+      organizationId: 'org-1',
+      userId: 'admin-1',
+      role: OrganizationMemberRole.MEMBER,
+      assignedRoles: [],
+    })
+    const socket = { write: jest.fn(), destroy: jest.fn() }
+    const proxyHandler = jest.mocked(createProxyMiddleware).mock.results.at(-1)?.value
+
+    await (service as unknown as BoxliteWsProxyService).upgrade(authRequest(jwt), socket as never, Buffer.alloc(0))
+
+    expect(proxyHandler.upgrade).toHaveBeenCalled()
+    expect(socket.write).not.toHaveBeenCalledWith(expect.stringContaining('403 Forbidden'))
   })
 })

--- a/apps/api/src/boxlite-rest/boxlite-ws-proxy.service.ts
+++ b/apps/api/src/boxlite-rest/boxlite-ws-proxy.service.ts
@@ -12,14 +12,29 @@ import { JwtStrategy } from '../auth/jwt.strategy'
 import { OrganizationUserService } from '../organization/services/organization-user.service'
 import { OrganizationService } from '../organization/services/organization.service'
 import { Organization } from '../organization/entities/organization.entity'
+import type { OrganizationUser } from '../organization/entities/organization-user.entity'
 import { BoxService } from '../box/services/box.service'
 import { RunnerService } from '../box/services/runner.service'
 import type { Runner } from '../box/entities/runner.entity'
+import type { ApiKey } from '../api-key/api-key.entity'
+import { SystemRole } from '../user/enums/system-role.enum'
+import { UserService } from '../user/user.service'
+import { hasRequiredOrganizationResourcePermissions } from '../organization/guards/organization-resource-action.guard'
 import { BoxAutoResumeService } from './box-auto-resume.service'
+import { BOXLITE_BOX_WRITE_PERMISSIONS } from './boxlite-permission.policy'
 
 type RunnerUpgradeRequest = IncomingMessage & {
   __boxliteRunner?: Runner
   __boxliteRunnerBoxId?: string
+}
+
+type WebSocketAuthContext = {
+  organization: Organization
+  organizationUser?: OrganizationUser
+  userId: string
+  email: string
+  role: SystemRole
+  apiKey?: ApiKey
 }
 
 // Matches /api/v1/boxes/<id>/executions/<id>/attach and the
@@ -53,6 +68,7 @@ export class BoxliteWsProxyService {
     // Exported by AuthModule (already imported here). Resolves to `undefined`
     // when `skipConnections` is set, so the JWT path guards on it.
     @Inject(JwtStrategy) private readonly jwtStrategy: JwtStrategy | undefined,
+    private readonly userService: UserService,
   ) {
     this.proxy = createProxyMiddleware({
       ws: true,
@@ -113,6 +129,20 @@ export class BoxliteWsProxyService {
       return
     }
 
+    const permissionContext = {
+      organizationId: auth.organization.id,
+      organization: auth.organization,
+      organizationUser: auth.organizationUser,
+      userId: auth.userId,
+      email: auth.email,
+      role: auth.role,
+      apiKey: auth.apiKey,
+    }
+    if (!hasRequiredOrganizationResourcePermissions(permissionContext, BOXLITE_BOX_WRITE_PERMISSIONS)) {
+      this.respondAndClose(socket, 403, 'Forbidden')
+      return
+    }
+
     try {
       const box = await this.boxService.findOneByIdOrName(match.boxId, auth.organization.id)
       if (!box?.runnerId) {
@@ -148,8 +178,8 @@ export class BoxliteWsProxyService {
 
   /**
    * Inline authentication for WS upgrades, mirroring the API-key + JWT halves of
-   * CombinedAuthGuard. Membership-only, like the HTTP exec/attach routes
-   * (`BoxliteProxyController`), which carry no resource-permission decorator.
+   * CombinedAuthGuard, then enforcing the same Box write permission required by
+   * the HTTP exec routes.
    * Never throws — any failure resolves to `null` (a 401), so the fire-and-forget
    * `upgrade` caller can't leak a hung socket.
    *
@@ -164,13 +194,15 @@ export class BoxliteWsProxyService {
    * organization is taken from the URL `{prefix}` (`urlTenant`); a request with
    * no tenant (or the legacy `default`) is rejected since the org is ambiguous
    * for a multi-org user. Membership in that org is then required, identically to
-   * the API-key path. `jwtStrategy` is absent when `skipConnections` is set.
+   * the API-key path, except that a database-backed system administrator keeps
+   * the same cross-organization access granted by the HTTP guard. `jwtStrategy`
+   * is absent when `skipConnections` is set.
    *
    * Unlike the HTTP path, this does not consult the Redis cache used by
    * ApiKeyStrategy / OrganizationAccessGuard. Upgrade frequency is low; if
    * upgrade latency becomes a concern, add caching as a follow-up.
    */
-  private async authenticate(req: IncomingMessage, urlTenant?: string): Promise<{ organization: Organization } | null> {
+  private async authenticate(req: IncomingMessage, urlTenant?: string): Promise<WebSocketAuthContext | null> {
     try {
       const header = req.headers['authorization']
       const headerValue = Array.isArray(header) ? header[0] : header
@@ -186,8 +218,19 @@ export class BoxliteWsProxyService {
         if (apiKey.expiresAt && apiKey.expiresAt < new Date()) return null
         const membership = await this.organizationUserService.findOne(apiKey.organizationId, apiKey.userId)
         if (!membership) return null
+        const user = await this.userService.findOne(apiKey.userId)
+        if (!user) return null
         const organization = await this.organizationService.findOne(apiKey.organizationId)
-        return organization ? { organization } : null
+        return organization
+          ? {
+              organization,
+              organizationUser: membership,
+              userId: user.id,
+              email: user.email,
+              role: user.role,
+              apiKey,
+            }
+          : null
       }
 
       // 2. JWT (OIDC) — org comes from the URL tenant; membership required.
@@ -200,10 +243,20 @@ export class BoxliteWsProxyService {
       if (claims.cid && claims.uid) userId = claims.uid
       if (!userId) return null
 
+      const user = await this.userService.findOne(userId)
+      if (!user) return null
       const membership = await this.organizationUserService.findOne(urlTenant, userId)
-      if (!membership) return null
+      if (!membership && user.role !== SystemRole.ADMIN) return null
       const organization = await this.organizationService.findOne(urlTenant)
-      return organization ? { organization } : null
+      return organization
+        ? {
+            organization,
+            organizationUser: membership ?? undefined,
+            userId: user.id,
+            email: user.email,
+            role: user.role,
+          }
+        : null
     } catch {
       // Any failure (invalid JWT signature, a DB error, …) → 401. This single
       // guard is why authenticate never throws — `upgrade` calls it before its

--- a/apps/api/src/organization/decorators/required-organization-resource-permissions.decorator.ts
+++ b/apps/api/src/organization/decorators/required-organization-resource-permissions.decorator.ts
@@ -8,3 +8,5 @@ import { Reflector } from '@nestjs/core'
 import { OrganizationResourcePermission } from '../enums/organization-resource-permission.enum'
 
 export const RequiredOrganizationResourcePermissions = Reflector.createDecorator<OrganizationResourcePermission[]>()
+
+export const FailClosedOnMissingOrganizationResourcePermissions = Reflector.createDecorator<boolean>()

--- a/apps/api/src/organization/guards/organization-access.guard.ts
+++ b/apps/api/src/organization/guards/organization-access.guard.ts
@@ -86,7 +86,7 @@ export class OrganizationAccessGuard implements CanActivate {
     }
     request.user = organizationAuthContext
 
-    if (authContext.role === SystemRole.ADMIN) {
+    if (authContext.role === SystemRole.ADMIN && !authContext.apiKey) {
       return true
     }
 

--- a/apps/api/src/organization/guards/organization-resource-action.guard.ts
+++ b/apps/api/src/organization/guards/organization-resource-action.guard.ts
@@ -8,8 +8,12 @@ import { CanActivate, Injectable, ExecutionContext, Logger, Type } from '@nestjs
 import { GUARDS_METADATA } from '@nestjs/common/constants'
 import { Reflector } from '@nestjs/core'
 import { OrganizationAccessGuard } from './organization-access.guard'
-import { RequiredOrganizationResourcePermissions } from '../decorators/required-organization-resource-permissions.decorator'
+import {
+  FailClosedOnMissingOrganizationResourcePermissions,
+  RequiredOrganizationResourcePermissions,
+} from '../decorators/required-organization-resource-permissions.decorator'
 import { OrganizationMemberRole } from '../enums/organization-member-role.enum'
+import { OrganizationResourcePermission } from '../enums/organization-resource-permission.enum'
 import { OrganizationService } from '../services/organization.service'
 import { OrganizationUserService } from '../services/organization-user.service'
 import { OrganizationAuthContext } from '../../common/interfaces/auth-context.interface'
@@ -19,6 +23,48 @@ import { isRunnerContext } from '../../common/interfaces/runner-context.interfac
 import { OR_GUARD_INNER_GUARDS } from '../../auth/or.guard'
 
 const RUNNER_COMPATIBLE_RESOURCE_GUARD_NAMES = new Set(['RunnerAuthGuard', 'BoxAccessGuard'])
+
+export function hasRequiredOrganizationResourcePermissions(
+  authContext: OrganizationAuthContext,
+  requiredPermissions: OrganizationResourcePermission[],
+): boolean {
+  if (authContext.apiKey) {
+    if (!authContext.organizationUser) {
+      return false
+    }
+    return hasEveryRequiredPermission(authContext.apiKey.permissions, requiredPermissions)
+  }
+
+  if (authContext.role === SystemRole.ADMIN) {
+    return true
+  }
+
+  if (!authContext.organizationUser) {
+    return false
+  }
+
+  if (authContext.organizationUser.role === OrganizationMemberRole.OWNER) {
+    return true
+  }
+
+  const permissions = authContext.organizationUser.assignedRoles?.flatMap((role) => role.permissions)
+  return hasEveryRequiredPermission(permissions, requiredPermissions)
+}
+
+function hasEveryRequiredPermission(
+  permissions: OrganizationResourcePermission[] | undefined,
+  requiredPermissions: OrganizationResourcePermission[],
+): boolean {
+  if (requiredPermissions.length === 0) {
+    return true
+  }
+  if (!Array.isArray(permissions)) {
+    return false
+  }
+
+  const assignedPermissions = new Set(permissions)
+  return requiredPermissions.every((permission) => assignedPermissions.has(permission))
+}
 
 @Injectable()
 export class OrganizationResourceActionGuard extends OrganizationAccessGuard {
@@ -45,7 +91,20 @@ export class OrganizationResourceActionGuard extends OrganizationAccessGuard {
       return false
     }
 
-    if (authContext.role === SystemRole.ADMIN) {
+    const requiredPermissions =
+      this.reflector.get(RequiredOrganizationResourcePermissions, context.getHandler()) ||
+      this.reflector.get(RequiredOrganizationResourcePermissions, context.getClass())
+
+    if (!requiredPermissions) {
+      const failClosed =
+        this.reflector.get(FailClosedOnMissingOrganizationResourcePermissions, context.getHandler()) ||
+        this.reflector.get(FailClosedOnMissingOrganizationResourcePermissions, context.getClass())
+      if (failClosed) {
+        return false
+      }
+    }
+
+    if (authContext.role === SystemRole.ADMIN && !authContext.apiKey) {
       return true
     }
 
@@ -53,27 +112,7 @@ export class OrganizationResourceActionGuard extends OrganizationAccessGuard {
       return false
     }
 
-    if (!authContext.organizationUser) {
-      return false
-    }
-
-    if (authContext.organizationUser.role === OrganizationMemberRole.OWNER && !authContext.apiKey) {
-      return true
-    }
-
-    const requiredPermissions =
-      this.reflector.get(RequiredOrganizationResourcePermissions, context.getHandler()) ||
-      this.reflector.get(RequiredOrganizationResourcePermissions, context.getClass())
-
-    if (!requiredPermissions) {
-      return true
-    }
-
-    const assignedPermissions = authContext.apiKey
-      ? new Set(authContext.apiKey.permissions)
-      : new Set(authContext.organizationUser.assignedRoles.flatMap((role) => role.permissions))
-
-    return requiredPermissions.every((permission) => assignedPermissions.has(permission))
+    return requiredPermissions ? hasRequiredOrganizationResourcePermissions(authContext, requiredPermissions) : true
   }
 
   private handlerAllowsRunnerResourceAccess(context: ExecutionContext): boolean {

--- a/apps/api/src/organization/services/organization.service.ts
+++ b/apps/api/src/organization/services/organization.service.ts
@@ -156,13 +156,18 @@ export class OrganizationService implements OnModuleInit, TrackableJobExecutions
     return this.findDefaultForUserWithEntityManager(this.organizationRepository.manager, userId)
   }
 
-  async findByUserWithDefaultFlag(
-    userId: string,
-  ): Promise<{ organization: Organization; isDefaultForAuthenticatedUser: boolean }[]> {
+  async findByUserWithDefaultFlag(userId: string): Promise<
+    {
+      organization: Organization
+      organizationUser: OrganizationUser
+      isDefaultForAuthenticatedUser: boolean
+    }[]
+  > {
     const memberships = await this.organizationRepository.manager.find(OrganizationUser, {
       where: { userId },
       relations: {
         organization: true,
+        assignedRoles: true,
       },
       order: {
         createdAt: 'ASC',
@@ -171,6 +176,7 @@ export class OrganizationService implements OnModuleInit, TrackableJobExecutions
 
     return memberships.map((membership) => ({
       organization: membership.organization,
+      organizationUser: membership,
       isDefaultForAuthenticatedUser: membership.isDefaultForUser,
     }))
   }


### PR DESCRIPTION
## Summary

- Classify every BoxLite v1 HTTP route as membership-read, Box-write, or Box-delete and fail closed when permission metadata is missing.
- Apply the same Box-write policy to WebSocket attach before any Box or runner lookup.
- Keep API keys constrained by their own organization membership and Box capabilities, including keys owned by organization owners or system administrators.
- Make `/v1/me` scopes reflect the caller's effective membership and Box permissions.
- Add policy unit tests plus live Nest HTTP integration coverage.

## Root cause

BoxLite v1 routes did not have a complete permission boundary. Owner/admin identity could widen API-key authority, WebSocket upgrades bypassed the HTTP guards, and `/v1/me` could advertise scopes the caller could not exercise.

## End-to-end policy

- HTTP: authentication -> organization access -> explicit route capability metadata -> shared Box permission policy -> controller/service.
- WebSocket: authentication -> database-backed role/membership lookup -> shared Box-write policy -> Box/runner lookup -> proxy upgrade.
- Missing capability metadata denies access. Interactive system administrators retain the HTTP guard's existing cross-organization behavior; API keys never inherit that bypass.

## Files

- BoxLite routes and policy: `boxlite-box.controller.ts`, `boxlite-config.controller.ts`, `boxlite-me.controller.ts`, `boxlite-permission.policy.ts`, `boxlite-proxy.controller.ts`, `boxlite-ws-proxy.service.ts`, `boxlite-rest.module.ts`
- Shared organization enforcement: `required-organization-resource-permissions.decorator.ts`, `organization-access.guard.ts`, `organization-resource-action.guard.ts`, `organization.service.ts`
- Unit/integration coverage: `boxlite-me.controller.spec.ts`, `boxlite-permission.policy.spec.ts`, `boxlite-permissions.integration.spec.ts`, `boxlite-rest-routing.spec.ts`, `boxlite-ws-proxy.service.spec.ts`

## Validation

- `NX_DAEMON=false NX_ISOLATE_PLUGINS=false NX_SKIP_NX_CACHE=true make -o 'dev\:go' test:apps SETUP_DONE=1 FILTER='BoxLite REST permissions|rejects websocket attach when an owner API key lacks Box write permission|scopes reflect effective Box permissions|BoxLite permission policy|BoxLite REST permission integration|interactive system administrator'` — 49 passed across 5 suites.
- `NX_DAEMON=false NX_ISOLATE_PLUGINS=false NX_SKIP_NX_CACHE=true make -o 'dev\:go' test:apps SETUP_DONE=1 FILTER='system administrator API key|without an organization membership|no longer an organization member|interactive system administrator'` — 9 focused edge-case tests passed across 4 suites.
- `NX_DAEMON=false NX_ISOLATE_PLUGINS=false make lint:apps` — passed with 0 errors (31 existing warnings).
- `VERSION=0.0.0-dev GOFLAGS=-tags=boxlite_dev NX_DAEMON=false NX_ISOLATE_PLUGINS=false make build:apps` — all 10 Apps projects passed.
- `NX_DAEMON=false NX_ISOLATE_PLUGINS=false make fmt:check:apps` — still reports only the 186 pre-existing generated-client formatting findings; no changed file is listed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Permissions**
  * Added organization-level permission checks across BoxLite box, configuration, proxy, and WebSocket operations.
  * Restricted creation, execution, modification, and deletion actions to appropriate permissions.
  * Improved authorization handling for API keys, administrators, owners, and organization members.
  * `/v1/me` now reports scopes based on the caller’s effective permissions.
* **Bug Fixes**
  * Requests with missing or insufficient authorization metadata now fail safely instead of bypassing checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->