### PR TITLE
fix(api): harden BoxLite v1 routes and throttling

### DIFF
--- a/apps/api-client-go/api/openapi.yaml
+++ b/apps/api-client-go/api/openapi.yaml
@@ -5249,8 +5249,8 @@ components:
       example:
         name: My API Key
         permissions:
-        - write:registries
-        - write:registries
+        - write:boxes
+        - write:boxes
         expiresAt: 2025-06-09T12:00:00Z
       properties:
         name:
@@ -5262,21 +5262,8 @@ components:
             to the API key
           items:
             enum:
-            - write:registries
-            - delete:registries
-            - write:templates
-            - delete:templates
             - write:boxes
             - delete:boxes
-            - read:volumes
-            - write:volumes
-            - delete:volumes
-            - write:regions
-            - delete:regions
-            - read:runners
-            - write:runners
-            - delete:runners
-            - read:audit_logs
             type: string
           type: array
         expiresAt:
@@ -5810,8 +5797,8 @@ components:
         name: Maintainer
         description: Can manage all resources
         permissions:
-        - write:registries
-        - write:registries
+        - write:boxes
+        - write:boxes
       properties:
         name:
           description: The name of the role
@@ -5825,21 +5812,8 @@ components:
           description: The list of permissions assigned to the role
           items:
             enum:
-            - write:registries
-            - delete:registries
-            - write:templates
-            - delete:templates
             - write:boxes
             - delete:boxes
-            - read:volumes
-            - write:volumes
-            - delete:volumes
-            - write:regions
-            - delete:regions
-            - read:runners
-            - write:runners
-            - delete:runners
-            - read:audit_logs
             type: string
           type: array
       required:
@@ -5852,8 +5826,8 @@ components:
         name: Maintainer
         description: Can manage all resources
         permissions:
-        - write:registries
-        - write:registries
+        - write:boxes
+        - write:boxes
       properties:
         name:
           description: The name of the role
@@ -5867,21 +5841,8 @@ components:
           description: The list of permissions assigned to the role
           items:
             enum:
-            - write:registries
-            - delete:registries
-            - write:templates
-            - delete:templates
             - write:boxes
             - delete:boxes
-            - read:volumes
-            - write:volumes
-            - delete:volumes
-            - write:regions
-            - delete:regions
-            - read:runners
-            - write:runners
-            - delete:runners
-            - read:audit_logs
             type: string
           type: array
       required:

--- a/apps/api/src/api-key/dto/create-api-key.dto.ts
+++ b/apps/api/src/api-key/dto/create-api-key.dto.ts
@@ -4,9 +4,12 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { IsArray, IsDate, IsEnum, IsNotEmpty, IsOptional, IsString } from 'class-validator'
+import { IsArray, IsDate, IsIn, IsNotEmpty, IsOptional, IsString } from 'class-validator'
 import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger'
-import { OrganizationResourcePermission } from '../../organization/enums/organization-resource-permission.enum'
+import {
+  ASSIGNABLE_ORGANIZATION_RESOURCE_PERMISSIONS,
+  OrganizationResourcePermission,
+} from '../../organization/enums/organization-resource-permission.enum'
 import { Type } from 'class-transformer'
 
 @ApiSchema({ name: 'CreateApiKey' })
@@ -22,12 +25,12 @@ export class CreateApiKeyDto {
 
   @ApiProperty({
     description: 'The list of organization resource permissions explicitly assigned to the API key',
-    enum: OrganizationResourcePermission,
+    enum: ASSIGNABLE_ORGANIZATION_RESOURCE_PERMISSIONS,
     isArray: true,
     required: true,
   })
   @IsArray()
-  @IsEnum(OrganizationResourcePermission, { each: true })
+  @IsIn(ASSIGNABLE_ORGANIZATION_RESOURCE_PERMISSIONS, { each: true })
   permissions: OrganizationResourcePermission[]
 
   @ApiPropertyOptional({

--- a/apps/api/src/auth/failed-auth-tracker.service.ts
+++ b/apps/api/src/auth/failed-auth-tracker.service.ts
@@ -10,6 +10,7 @@ import { Redis } from 'ioredis'
 import { Request, Response } from 'express'
 import { ThrottlerException } from '@nestjs/throttler'
 import { TypedConfigService } from '../config/typed-config.service'
+import { getClientIp } from '../common/utils/client-ip.util'
 import { setRateLimitHeaders } from '../common/utils/rate-limit-headers.util'
 
 /**
@@ -27,7 +28,7 @@ export class FailedAuthTrackerService {
 
   async incrementFailedAuth(request: Request, response: Response): Promise<void> {
     try {
-      const ip = request.ips.length ? request.ips[0] : request.ip
+      const ip = getClientIp(request)
       const throttlerName = 'failed-auth'
       const tracker = `${throttlerName}:${ip}`
 

--- a/apps/api/src/boxlite-rest/boxlite-box.controller.ts
+++ b/apps/api/src/boxlite-rest/boxlite-box.controller.ts
@@ -44,12 +44,14 @@ import {
   BOXLITE_BOX_READ_PERMISSIONS,
   BOXLITE_BOX_WRITE_PERMISSIONS,
 } from './boxlite-permission.policy'
+import { AuthenticatedRateLimitGuard } from '../common/guards/authenticated-rate-limit.guard'
+import { ThrottlerScope } from '../common/decorators/throttler-scope.decorator'
 // Spec-first surface: the contract is openapi/box.openapi.yaml, not the
 // generated product spec (which `:prefix` routes would render invalid).
 @ApiExcludeController()
 @ApiTags('BoxLite REST')
 @Controller(['v1/boxes', 'v1/:prefix/boxes'])
-@UseGuards(CombinedAuthGuard, OrganizationResourceActionGuard)
+@UseGuards(CombinedAuthGuard, OrganizationResourceActionGuard, AuthenticatedRateLimitGuard)
 @FailClosedOnMissingOrganizationResourcePermissions(true)
 @ApiBearerAuth()
 export class BoxliteBoxController {
@@ -62,6 +64,7 @@ export class BoxliteBoxController {
 
   @Post()
   @RequiredOrganizationResourcePermissions(BOXLITE_BOX_WRITE_PERMISSIONS)
+  @ThrottlerScope('box-create')
   @HttpCode(201)
   @ApiResponse({
     status: 201,
@@ -158,6 +161,7 @@ export class BoxliteBoxController {
 
   @Delete(':boxId')
   @RequiredOrganizationResourcePermissions(BOXLITE_BOX_DELETE_PERMISSIONS)
+  @ThrottlerScope('box-lifecycle')
   @HttpCode(204)
   @Audit({
     action: AuditAction.DELETE,
@@ -170,6 +174,7 @@ export class BoxliteBoxController {
 
   @Post(':boxId/start')
   @RequiredOrganizationResourcePermissions(BOXLITE_BOX_WRITE_PERMISSIONS)
+  @ThrottlerScope('box-lifecycle')
   @ApiResponse({
     status: 201,
     description: 'Box start requested',
@@ -202,6 +207,7 @@ export class BoxliteBoxController {
 
   @Post(':boxId/stop')
   @RequiredOrganizationResourcePermissions(BOXLITE_BOX_WRITE_PERMISSIONS)
+  @ThrottlerScope('box-lifecycle')
   @ApiResponse({
     status: 201,
     description: 'Box stop requested',

--- a/apps/api/src/boxlite-rest/boxlite-config.controller.ts
+++ b/apps/api/src/boxlite-rest/boxlite-config.controller.ts
@@ -4,15 +4,17 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { Controller, Get } from '@nestjs/common'
+import { Controller, Get, UseGuards } from '@nestjs/common'
 import { ApiTags, ApiExcludeController } from '@nestjs/swagger'
 import { RequiredOrganizationResourcePermissions } from '../organization/decorators/required-organization-resource-permissions.decorator'
 import { BOXLITE_BOX_READ_PERMISSIONS } from './boxlite-permission.policy'
+import { AnonymousRateLimitGuard } from '../common/guards/anonymous-rate-limit.guard'
 
 // Spec-first surface: the contract is openapi/box.openapi.yaml.
 @ApiExcludeController()
 @ApiTags('BoxLite REST')
 @Controller('v1')
+@UseGuards(AnonymousRateLimitGuard)
 export class BoxliteConfigController {
   @Get('config')
   @RequiredOrganizationResourcePermissions(BOXLITE_BOX_READ_PERMISSIONS)

--- a/apps/api/src/boxlite-rest/boxlite-me.controller.ts
+++ b/apps/api/src/boxlite-rest/boxlite-me.controller.ts
@@ -12,6 +12,7 @@ import { AuthContext as AuthCtx } from '../common/interfaces/auth-context.interf
 import type { OrganizationUser } from '../organization/entities/organization-user.entity'
 import { RequiredOrganizationResourcePermissions } from '../organization/decorators/required-organization-resource-permissions.decorator'
 import { OrganizationService } from '../organization/services/organization.service'
+import { AuthenticatedRateLimitGuard } from '../common/guards/authenticated-rate-limit.guard'
 import { PrincipalDto } from './dto/principal.dto'
 import { BOXLITE_BOX_READ_PERMISSIONS, grantedBoxliteScopes } from './boxlite-permission.policy'
 
@@ -28,7 +29,7 @@ import { BOXLITE_BOX_READ_PERMISSIONS, grantedBoxliteScopes } from './boxlite-pe
 @ApiExcludeController()
 @ApiTags('BoxLite REST')
 @Controller('v1')
-@UseGuards(CombinedAuthGuard)
+@UseGuards(CombinedAuthGuard, AuthenticatedRateLimitGuard)
 @ApiBearerAuth()
 export class BoxliteMeController {
   constructor(private readonly organizationService: OrganizationService) {}

--- a/apps/api/src/boxlite-rest/boxlite-permissions.integration.spec.ts
+++ b/apps/api/src/boxlite-rest/boxlite-permissions.integration.spec.ts
@@ -12,6 +12,7 @@ import { CombinedAuthGuard } from '../auth/combined-auth.guard'
 import { BoxService } from '../box/services/box.service'
 import { BoxStateWaiterService } from '../box/services/box-state-waiter.service'
 import { RunnerService } from '../box/services/runner.service'
+import { AuthenticatedRateLimitGuard } from '../common/guards/authenticated-rate-limit.guard'
 import { OrganizationMemberRole } from '../organization/enums/organization-member-role.enum'
 import { OrganizationResourcePermission } from '../organization/enums/organization-resource-permission.enum'
 import { OrganizationResourceActionGuard } from '../organization/guards/organization-resource-action.guard'
@@ -125,6 +126,8 @@ describe('BoxLite REST permission integration', () => {
     })
       .overrideGuard(CombinedAuthGuard)
       .useValue(authenticationGuard)
+      .overrideGuard(AuthenticatedRateLimitGuard)
+      .useValue({ canActivate: () => true })
       .compile()
 
     app = moduleRef.createNestApplication()

--- a/apps/api/src/boxlite-rest/boxlite-proxy.controller.ts
+++ b/apps/api/src/boxlite-rest/boxlite-proxy.controller.ts
@@ -6,8 +6,8 @@
 
 import {
   Controller,
-  All,
   Get,
+  Put,
   Delete,
   Param,
   Req,
@@ -16,7 +16,6 @@ import {
   UseGuards,
   Logger,
   NotFoundException,
-  ForbiddenException,
   HttpCode,
   HttpStatus,
   ParseIntPipe,
@@ -36,6 +35,7 @@ import { AuthContext } from '../common/decorators/auth-context.decorator'
 import { OrganizationAuthContext } from '../common/interfaces/auth-context.interface'
 import { BoxService } from '../box/services/box.service'
 import { RunnerService } from '../box/services/runner.service'
+import { AuthenticatedRateLimitGuard } from '../common/guards/authenticated-rate-limit.guard'
 import { BoxAutoResumeService } from './box-auto-resume.service'
 import { BOXLITE_BOX_READ_PERMISSIONS, BOXLITE_BOX_WRITE_PERMISSIONS } from './boxlite-permission.policy'
 
@@ -43,12 +43,11 @@ type ProxyActivityPolicy = { activity: boolean; autoResume: boolean }
 const USER_OPERATION: ProxyActivityPolicy = { activity: true, autoResume: true }
 const OBSERVATION_ONLY: ProxyActivityPolicy = { activity: false, autoResume: false }
 
-// Spec-first surface (openapi/box.openapi.yaml). Must stay out of the product
-// spec: @All() expands to the SEARCH verb, which OpenAPI 3.0 cannot express.
+// Spec-first surface (openapi/box.openapi.yaml). Must stay out of the product spec.
 @ApiExcludeController()
 @ApiTags('BoxLite REST')
 @Controller(['v1/boxes', 'v1/:prefix/boxes'])
-@UseGuards(CombinedAuthGuard, OrganizationResourceActionGuard)
+@UseGuards(CombinedAuthGuard, OrganizationResourceActionGuard, AuthenticatedRateLimitGuard)
 @FailClosedOnMissingOrganizationResourcePermissions(true)
 @ApiBearerAuth()
 export class BoxliteProxyController {
@@ -60,7 +59,7 @@ export class BoxliteProxyController {
     private readonly autoResume: BoxAutoResumeService,
   ) {}
 
-  @All(':boxId/exec')
+  @Post(':boxId/exec')
   @RequiredOrganizationResourcePermissions(BOXLITE_BOX_WRITE_PERMISSIONS)
   async proxyExec(
     @AuthContext() authContext: OrganizationAuthContext,
@@ -80,7 +79,7 @@ export class BoxliteProxyController {
     )
   }
 
-  @All(':boxId/executions/:execId/signal')
+  @Post(':boxId/executions/:execId/signal')
   @RequiredOrganizationResourcePermissions(BOXLITE_BOX_WRITE_PERMISSIONS)
   async proxyExecSignal(
     @AuthContext() authContext: OrganizationAuthContext,
@@ -101,7 +100,7 @@ export class BoxliteProxyController {
     )
   }
 
-  @All(':boxId/executions/:execId/resize')
+  @Post(':boxId/executions/:execId/resize')
   @RequiredOrganizationResourcePermissions(BOXLITE_BOX_WRITE_PERMISSIONS)
   async proxyExecResize(
     @AuthContext() authContext: OrganizationAuthContext,
@@ -170,7 +169,7 @@ export class BoxliteProxyController {
   // to this path (callers that forgot the Upgrade headers) fall through to
   // a NestJS 404, which is the correct answer.
 
-  @All(':boxId/files')
+  @Get(':boxId/files')
   @RequiredOrganizationResourcePermissions(BOXLITE_BOX_WRITE_PERMISSIONS)
   async proxyFiles(
     @AuthContext() authContext: OrganizationAuthContext,
@@ -178,6 +177,28 @@ export class BoxliteProxyController {
     @Req() req: Request,
     @Res() res: Response,
     @Next() next: NextFunction,
+  ) {
+    return this.proxyFilesRequest(authContext, boxId, req, res, next)
+  }
+
+  @Put(':boxId/files')
+  @RequiredOrganizationResourcePermissions(BOXLITE_BOX_WRITE_PERMISSIONS)
+  async proxyFilesUpload(
+    @AuthContext() authContext: OrganizationAuthContext,
+    @Param('boxId') boxId: string,
+    @Req() req: Request,
+    @Res() res: Response,
+    @Next() next: NextFunction,
+  ) {
+    return this.proxyFilesRequest(authContext, boxId, req, res, next)
+  }
+
+  private proxyFilesRequest(
+    authContext: OrganizationAuthContext,
+    boxId: string,
+    req: Request,
+    res: Response,
+    next: NextFunction,
   ) {
     const query = req.url.includes('?') ? req.url.substring(req.url.indexOf('?')) : ''
     return this.proxyToRunner(
@@ -191,7 +212,7 @@ export class BoxliteProxyController {
     )
   }
 
-  @All(':boxId/metrics')
+  @Get(':boxId/metrics')
   @RequiredOrganizationResourcePermissions(BOXLITE_BOX_READ_PERMISSIONS)
   async proxyMetrics(
     @AuthContext() authContext: OrganizationAuthContext,

--- a/apps/api/src/boxlite-rest/boxlite-request-throttle.service.spec.ts
+++ b/apps/api/src/boxlite-rest/boxlite-request-throttle.service.spec.ts
@@ -1,0 +1,143 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0
+ * Copyright (c) 2025 BoxLite AI
+ */
+
+import type { IncomingMessage } from 'http'
+import type { ThrottlerModuleOptions, ThrottlerStorage } from '@nestjs/throttler'
+import { BoxliteRequestThrottleService } from './boxlite-request-throttle.service'
+
+describe('BoxliteRequestThrottleService', () => {
+  const options: ThrottlerModuleOptions = {
+    throttlers: [
+      { name: 'anonymous', limit: 20, ttl: 60_000 },
+      { name: 'authenticated', limit: 200, ttl: 60_000 },
+    ],
+  }
+
+  function makeHarness(record = { totalHits: 1, timeToExpire: 60, isBlocked: false, timeToBlockExpire: 0 }) {
+    const storage = {
+      increment: jest.fn().mockResolvedValue(record),
+    } as unknown as ThrottlerStorage
+    const organizationService = {
+      findOne: jest.fn().mockResolvedValue({
+        authenticatedRateLimit: 50,
+        authenticatedRateLimitTtlSeconds: 30,
+      }),
+    }
+    const service = new BoxliteRequestThrottleService(options, storage, organizationService as never)
+    return { service, storage, organizationService }
+  }
+
+  it('does not let websocket clients rotate anonymous quota keys with forwarded headers', async () => {
+    const { service, storage } = makeHarness()
+    const firstRequest = {
+      headers: { 'x-forwarded-for': '203.0.113.8, 198.51.100.24' },
+      socket: { remoteAddress: '10.0.0.5' },
+    } as unknown as IncomingMessage
+    const secondRequest = {
+      headers: { 'x-forwarded-for': '192.0.2.9, 198.51.100.24' },
+      socket: { remoteAddress: '10.0.0.5' },
+    } as unknown as IncomingMessage
+
+    await expect(service.consumeAnonymous(firstRequest)).resolves.toEqual({ allowed: true })
+    await expect(service.consumeAnonymous(secondRequest)).resolves.toEqual({ allowed: true })
+    expect(storage.increment).toHaveBeenNthCalledWith(
+      1,
+      'anonymous-anonymous:198.51.100.24',
+      60_000,
+      20,
+      60_000,
+      'anonymous',
+    )
+    expect(storage.increment).toHaveBeenNthCalledWith(
+      2,
+      'anonymous-anonymous:198.51.100.24',
+      60_000,
+      20,
+      60_000,
+      'anonymous',
+    )
+  })
+
+  it('ignores forwarded headers from direct untrusted websocket peers', async () => {
+    const { service, storage } = makeHarness()
+    const request = {
+      headers: { 'x-forwarded-for': '203.0.113.8' },
+      socket: { remoteAddress: '198.51.100.24' },
+    } as unknown as IncomingMessage
+
+    await expect(service.consumeAnonymous(request)).resolves.toEqual({ allowed: true })
+    expect(storage.increment).toHaveBeenCalledWith('anonymous-anonymous:198.51.100.24', 60_000, 20, 60_000, 'anonymous')
+  })
+
+  it('falls back to the socket address when no forwarded client IP is present', async () => {
+    const { service, storage } = makeHarness()
+    const request = {
+      headers: {},
+      socket: { remoteAddress: '198.51.100.24' },
+    } as unknown as IncomingMessage
+
+    await expect(service.consumeAnonymous(request)).resolves.toEqual({ allowed: true })
+    expect(storage.increment).toHaveBeenCalledWith('anonymous-anonymous:198.51.100.24', 60_000, 20, 60_000, 'anonymous')
+  })
+
+  it('shares the authenticated guard keyspace and honors organization overrides', async () => {
+    const { service, storage, organizationService } = makeHarness({
+      totalHits: 51,
+      timeToExpire: 30,
+      isBlocked: true,
+      timeToBlockExpire: 7,
+    })
+
+    await expect(service.consumeAuthenticated('org-1')).resolves.toEqual({
+      allowed: false,
+      retryAfterSeconds: 7,
+    })
+    expect(organizationService.findOne).toHaveBeenCalledWith('org-1')
+    expect(storage.increment).toHaveBeenCalledWith('authenticated-auth:org:org-1', 30_000, 50, 30_000, 'authenticated')
+  })
+
+  it('uses an explicitly configured block duration and clamps Retry-After to one second', async () => {
+    const storage = {
+      increment: jest.fn().mockResolvedValue({
+        totalHits: 21,
+        timeToExpire: 60,
+        isBlocked: true,
+        timeToBlockExpire: 0,
+      }),
+    } as unknown as ThrottlerStorage
+    const service = new BoxliteRequestThrottleService(
+      {
+        throttlers: [{ name: 'anonymous', limit: 20, ttl: 60_000, blockDuration: 5_000 }],
+      },
+      storage,
+      { findOne: jest.fn() } as never,
+    )
+    const request = {
+      headers: {},
+      socket: { remoteAddress: '198.51.100.24' },
+    } as unknown as IncomingMessage
+
+    await expect(service.consumeAnonymous(request)).resolves.toEqual({
+      allowed: false,
+      retryAfterSeconds: 1,
+    })
+    expect(storage.increment).toHaveBeenCalledWith('anonymous-anonymous:198.51.100.24', 60_000, 20, 5_000, 'anonymous')
+  })
+
+  it('does not touch storage or organizations when a limiter is not configured', async () => {
+    const storage = { increment: jest.fn() } as unknown as ThrottlerStorage
+    const organizationService = { findOne: jest.fn() }
+    const service = new BoxliteRequestThrottleService({ throttlers: [] }, storage, organizationService as never)
+    const request = {
+      headers: {},
+      socket: { remoteAddress: '198.51.100.24' },
+    } as unknown as IncomingMessage
+
+    await expect(service.consumeAnonymous(request)).resolves.toEqual({ allowed: true })
+    await expect(service.consumeAuthenticated('org-1')).resolves.toEqual({ allowed: true })
+    expect(storage.increment).not.toHaveBeenCalled()
+    expect(organizationService.findOne).not.toHaveBeenCalled()
+  })
+})

--- a/apps/api/src/boxlite-rest/boxlite-request-throttle.service.ts
+++ b/apps/api/src/boxlite-rest/boxlite-request-throttle.service.ts
@@ -1,0 +1,100 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0
+ * Copyright (c) 2025 BoxLite AI
+ */
+
+import { Injectable } from '@nestjs/common'
+import type { IncomingMessage } from 'http'
+import { InjectThrottlerOptions, InjectThrottlerStorage } from '@nestjs/throttler'
+import type { ThrottlerModuleOptions, ThrottlerOptions, ThrottlerStorage } from '@nestjs/throttler'
+import { OrganizationService } from '../organization/services/organization.service'
+import { getClientIp } from '../common/utils/client-ip.util'
+
+export type BoxliteThrottleDecision = {
+  allowed: boolean
+  retryAfterSeconds?: number
+}
+
+type ResolvedThrottle = {
+  name: string
+  limit: number
+  ttl: number
+  blockDuration: number
+}
+
+/**
+ * Applies the configured Nest throttlers to HTTP-upgrade requests, which
+ * bypass the guards used by normal v1 controller requests.
+ */
+@Injectable()
+export class BoxliteRequestThrottleService {
+  constructor(
+    @InjectThrottlerOptions() private readonly options: ThrottlerModuleOptions,
+    @InjectThrottlerStorage() private readonly storage: ThrottlerStorage,
+    private readonly organizationService: OrganizationService,
+  ) {}
+
+  async consumeAnonymous(request: IncomingMessage): Promise<BoxliteThrottleDecision> {
+    const throttle = this.resolveThrottle('anonymous')
+    if (!throttle) {
+      return { allowed: true }
+    }
+
+    return this.consume(throttle, `anonymous:${getClientIp(request)}`)
+  }
+
+  async consumeAuthenticated(organizationId: string): Promise<BoxliteThrottleDecision> {
+    const throttle = this.resolveThrottle('authenticated')
+    if (!throttle) {
+      return { allowed: true }
+    }
+
+    const organization = await this.organizationService.findOne(organizationId)
+    if (organization?.authenticatedRateLimit != null) {
+      throttle.limit = organization.authenticatedRateLimit
+    }
+    if (organization?.authenticatedRateLimitTtlSeconds != null) {
+      throttle.ttl = organization.authenticatedRateLimitTtlSeconds * 1000
+      throttle.blockDuration = throttle.ttl
+    }
+
+    return this.consume(throttle, `auth:org:${organizationId}`)
+  }
+
+  private async consume(throttle: ResolvedThrottle, tracker: string): Promise<BoxliteThrottleDecision> {
+    const key = `${throttle.name}-${tracker}`
+    const result = await this.storage.increment(
+      key,
+      throttle.ttl,
+      throttle.limit,
+      throttle.blockDuration,
+      throttle.name,
+    )
+
+    return result.isBlocked
+      ? { allowed: false, retryAfterSeconds: Math.max(1, result.timeToBlockExpire) }
+      : { allowed: true }
+  }
+
+  private resolveThrottle(name: string): ResolvedThrottle | null {
+    const throttlers = Array.isArray(this.options) ? this.options : this.options.throttlers
+    const configured = throttlers.find((throttler) => (throttler.name ?? 'default') === name)
+    if (!configured) {
+      return null
+    }
+
+    const limit = this.numericValue(configured, 'limit')
+    const ttl = this.numericValue(configured, 'ttl')
+    const blockDuration = configured.blockDuration === undefined ? ttl : this.numericValue(configured, 'blockDuration')
+
+    return { name, limit, ttl, blockDuration }
+  }
+
+  private numericValue(config: ThrottlerOptions, field: 'limit' | 'ttl' | 'blockDuration'): number {
+    const value = config[field]
+    if (typeof value !== 'number') {
+      throw new Error(`BoxLite WebSocket throttler ${config.name ?? 'default'} ${field} must be numeric`)
+    }
+    return value
+  }
+}

--- a/apps/api/src/boxlite-rest/boxlite-rest-routing.spec.ts
+++ b/apps/api/src/boxlite-rest/boxlite-rest-routing.spec.ts
@@ -4,18 +4,22 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { PATH_METADATA } from '@nestjs/common/constants'
+import { METHOD_METADATA, PATH_METADATA } from '@nestjs/common/constants'
 import { Reflector } from '@nestjs/core'
 import { Test } from '@nestjs/testing'
-import type { ExecutionContext, INestApplication } from '@nestjs/common'
+import { RequestMethod, type ExecutionContext, type INestApplication } from '@nestjs/common'
 import type { AddressInfo } from 'net'
+import { createProxyMiddleware } from 'http-proxy-middleware'
 import { CombinedAuthGuard } from '../auth/combined-auth.guard'
+import { AuthenticatedRateLimitGuard } from '../common/guards/authenticated-rate-limit.guard'
 import { OrganizationResourceActionGuard } from '../organization/guards/organization-resource-action.guard'
 import { RequiredOrganizationResourcePermissions } from '../organization/decorators/required-organization-resource-permissions.decorator'
 import { OrganizationResourcePermission } from '../organization/enums/organization-resource-permission.enum'
 import { OrganizationMemberRole } from '../organization/enums/organization-member-role.enum'
 import { BoxService } from '../box/services/box.service'
+import { RunnerService } from '../box/services/runner.service'
 import { BoxStateWaiterService } from '../box/services/box-state-waiter.service'
+import { BoxAutoResumeService } from './box-auto-resume.service'
 import { BoxliteBoxController } from './boxlite-box.controller'
 import { BoxliteConfigController } from './boxlite-config.controller'
 import { BoxliteMeController } from './boxlite-me.controller'
@@ -63,6 +67,8 @@ describe('BoxLite REST routing', () => {
       })
       .overrideGuard(OrganizationResourceActionGuard)
       .useValue({ canActivate: () => true })
+      .overrideGuard(AuthenticatedRateLimitGuard)
+      .useValue({ canActivate: () => true })
       .compile()
 
     app = moduleRef.createNestApplication()
@@ -70,9 +76,62 @@ describe('BoxLite REST routing', () => {
     await app.listen(0)
   }
 
-  async function get(path: string): Promise<Response> {
+  async function startProxyRoutingTestApp() {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [BoxliteProxyController],
+      providers: [
+        {
+          provide: BoxService,
+          useValue: {
+            findOneByIdOrName: jest.fn().mockResolvedValue({
+              id: 'box-uuid',
+              runnerId: 'runner-1',
+              autoResume: false,
+            }),
+            updateLastActivityAt: jest.fn().mockResolvedValue(undefined),
+          },
+        },
+        {
+          provide: RunnerService,
+          useValue: {
+            findOne: jest.fn().mockResolvedValue({
+              apiUrl: 'http://runner.local',
+              apiKey: 'runner-key',
+            }),
+          },
+        },
+        {
+          provide: BoxAutoResumeService,
+          useValue: {
+            ensureReady: jest.fn().mockResolvedValue(undefined),
+          },
+        },
+      ],
+    })
+      .overrideGuard(CombinedAuthGuard)
+      .useValue({
+        canActivate: (context: any) => {
+          context.switchToHttp().getRequest().user = {
+            organizationId: 'org-123',
+            organization: { id: 'org-123' },
+          }
+          return true
+        },
+      })
+      .overrideGuard(OrganizationResourceActionGuard)
+      .useValue({ canActivate: () => true })
+      .overrideGuard(AuthenticatedRateLimitGuard)
+      .useValue({ canActivate: () => true })
+      .compile()
+
+    app = moduleRef.createNestApplication()
+    app.setGlobalPrefix('api')
+    await app.listen(0)
+  }
+
+  async function request(path: string, method = 'GET'): Promise<Response> {
     const address = app.getHttpServer().address() as AddressInfo
-    return fetch(`http://127.0.0.1:${address.port}${path}`)
+    return fetch(`http://127.0.0.1:${address.port}${path}`, { method })
   }
 
   afterEach(async () => {
@@ -87,8 +146,8 @@ describe('BoxLite REST routing', () => {
   it('registers canonical and legacy default-prefix routes in the Nest HTTP router', async () => {
     await startRoutingTestApp()
 
-    const canonical = await get('/api/v1/boxes')
-    const legacy = await get('/api/v1/default/boxes')
+    const canonical = await request('/api/v1/boxes')
+    const legacy = await request('/api/v1/default/boxes')
 
     expect(canonical.status).toBe(200)
     expect(await canonical.json()).toEqual({ boxes: [] })
@@ -96,8 +155,49 @@ describe('BoxLite REST routing', () => {
     expect(await legacy.json()).toEqual({ boxes: [] })
   })
 
+  it('maps proxy handlers to only the HTTP verbs documented in the v1 contract', () => {
+    const prototype = BoxliteProxyController.prototype as unknown as Record<string, (...args: never[]) => unknown>
+    const method = (handlerName: string) => Reflect.getMetadata(METHOD_METADATA, prototype[handlerName])
+
+    expect(method('proxyExec')).toBe(RequestMethod.POST)
+    expect(method('proxyExecSignal')).toBe(RequestMethod.POST)
+    expect(method('proxyExecResize')).toBe(RequestMethod.POST)
+    expect(method('proxyExecStatus')).toBe(RequestMethod.GET)
+    expect(method('proxyExecKill')).toBe(RequestMethod.DELETE)
+    expect(method('proxyFiles')).toBe(RequestMethod.GET)
+    expect(method('proxyFilesUpload')).toBe(RequestMethod.PUT)
+    expect(method('proxyMetrics')).toBe(RequestMethod.GET)
+  })
+
+  it('rejects undocumented proxy verbs at the HTTP router boundary', async () => {
+    jest
+      .mocked(createProxyMiddleware)
+      .mockReturnValue(((_req: unknown, res: { status: (code: number) => { end: () => void } }) =>
+        res.status(204).end()) as never)
+    await startProxyRoutingTestApp()
+
+    const cases = [
+      ['/api/v1/boxes/box-1/exec', 'POST', 204],
+      ['/api/v1/boxes/box-1/exec', 'GET', 404],
+      ['/api/v1/boxes/box-1/executions/exec-1/signal', 'POST', 204],
+      ['/api/v1/boxes/box-1/executions/exec-1/signal', 'GET', 404],
+      ['/api/v1/boxes/box-1/executions/exec-1/resize', 'POST', 204],
+      ['/api/v1/boxes/box-1/executions/exec-1/resize', 'PATCH', 404],
+      ['/api/v1/boxes/box-1/files?path=/tmp', 'GET', 204],
+      ['/api/v1/boxes/box-1/files?path=/tmp', 'PUT', 204],
+      ['/api/v1/boxes/box-1/files?path=/tmp', 'POST', 404],
+      ['/api/v1/boxes/box-1/metrics', 'GET', 204],
+      ['/api/v1/boxes/box-1/metrics', 'DELETE', 404],
+    ] as const
+
+    for (const [path, method, expectedStatus] of cases) {
+      const response = await request(path, method)
+      expect({ path, method, status: response.status }).toEqual({ path, method, status: expectedStatus })
+    }
+  })
+
   it('matches websocket attach upgrades with or without a routing prefix', () => {
-    const service = new BoxliteWsProxyService(
+    const service = new (BoxliteWsProxyService as any)(
       {} as any,
       {} as any,
       {} as any,
@@ -106,6 +206,10 @@ describe('BoxLite REST routing', () => {
       {} as any,
       {} as any,
       {} as any,
+      {
+        consumeAnonymous: jest.fn().mockResolvedValue({ allowed: true }),
+        consumeAuthenticated: jest.fn().mockResolvedValue({ allowed: true }),
+      },
     )
 
     expect(service.matchAttachPath('/api/v1/boxes/box-1/executions/exec-1/attach')).toEqual({ boxId: 'box-1' })
@@ -116,7 +220,7 @@ describe('BoxLite REST routing', () => {
   })
 
   it('does not route HTTP duplex tunnels through the websocket proxy', () => {
-    const service = new BoxliteWsProxyService(
+    const service = new (BoxliteWsProxyService as any)(
       {} as any,
       {} as any,
       {} as any,
@@ -125,6 +229,10 @@ describe('BoxLite REST routing', () => {
       {} as any,
       {} as any,
       {} as any,
+      {
+        consumeAnonymous: jest.fn().mockResolvedValue({ allowed: true }),
+        consumeAuthenticated: jest.fn().mockResolvedValue({ allowed: true }),
+      },
     )
 
     expect(service.matchAttachPath('/api/v1/boxes/box-1/network/tunnel?port=3000')).toBeNull()
@@ -154,6 +262,7 @@ describe('BoxLite REST permissions', () => {
     [BoxliteProxyController.prototype, 'proxyExecStatus', WRITE_BOXES],
     [BoxliteProxyController.prototype, 'proxyExecKill', WRITE_BOXES],
     [BoxliteProxyController.prototype, 'proxyFiles', WRITE_BOXES],
+    [BoxliteProxyController.prototype, 'proxyFilesUpload', WRITE_BOXES],
     [BoxliteProxyController.prototype, 'proxyMetrics', READ_BOXES],
     [BoxliteProxyController.prototype, 'proxyNetworkTunnel', WRITE_BOXES],
   ]

--- a/apps/api/src/boxlite-rest/boxlite-rest.module.ts
+++ b/apps/api/src/boxlite-rest/boxlite-rest.module.ts
@@ -16,11 +16,12 @@ import { BoxliteProxyController } from './boxlite-proxy.controller'
 import { BoxliteWsProxyService } from './boxlite-ws-proxy.service'
 import { BoxAutoResumeService } from './box-auto-resume.service'
 import { UserModule } from '../user/user.module'
+import { BoxliteRequestThrottleService } from './boxlite-request-throttle.service'
 
 @Module({
   imports: [BoxModule, AuthModule, ApiKeyModule, OrganizationModule, UserModule],
   controllers: [BoxliteMeController, BoxliteConfigController, BoxliteBoxController, BoxliteProxyController],
-  providers: [BoxliteWsProxyService, BoxAutoResumeService],
+  providers: [BoxliteWsProxyService, BoxAutoResumeService, BoxliteRequestThrottleService],
   exports: [BoxliteWsProxyService],
 })
 export class BoxliteRestModule {}

--- a/apps/api/src/boxlite-rest/boxlite-security.integration.spec.ts
+++ b/apps/api/src/boxlite-rest/boxlite-security.integration.spec.ts
@@ -1,0 +1,203 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0
+ * Copyright (c) 2025 BoxLite AI
+ */
+
+import { type CanActivate, type ExecutionContext } from '@nestjs/common'
+import { Reflector } from '@nestjs/core'
+import type { NestExpressApplication } from '@nestjs/platform-express'
+import { Test } from '@nestjs/testing'
+import { ThrottlerStorageService, type ThrottlerModuleOptions } from '@nestjs/throttler'
+import type { Redis } from 'ioredis'
+import type { AddressInfo } from 'net'
+import { CombinedAuthGuard } from '../auth/combined-auth.guard'
+import { AnonymousRateLimitGuard } from '../common/guards/anonymous-rate-limit.guard'
+import { AuthenticatedRateLimitGuard } from '../common/guards/authenticated-rate-limit.guard'
+import type { AuthContext } from '../common/interfaces/auth-context.interface'
+import { OrganizationResourcePermission } from '../organization/enums/organization-resource-permission.enum'
+import { OrganizationMemberRole } from '../organization/enums/organization-member-role.enum'
+import { OrganizationService } from '../organization/services/organization.service'
+import { OrganizationUserService } from '../organization/services/organization-user.service'
+import { BoxliteConfigController } from './boxlite-config.controller'
+import { BoxliteMeController } from './boxlite-me.controller'
+import { BoxliteRequestThrottleService } from './boxlite-request-throttle.service'
+
+describe('BoxLite v1 security integration', () => {
+  let app: NestExpressApplication
+  let storage: ThrottlerStorageService
+  let upgradeThrottle: BoxliteRequestThrottleService
+
+  const authContext: AuthContext = {
+    userId: 'user-1',
+    email: 'svc@example.com',
+    role: 'user' as AuthContext['role'],
+    organizationId: 'org-1',
+    apiKey: {
+      organizationId: 'org-1',
+      userId: 'user-1',
+      permissions: [OrganizationResourcePermission.WRITE_BOXES],
+    } as AuthContext['apiKey'],
+  }
+
+  beforeEach(async () => {
+    const options: ThrottlerModuleOptions = {
+      throttlers: [
+        { name: 'anonymous', limit: 1, ttl: 60_000 },
+        { name: 'authenticated', limit: 1, ttl: 60_000 },
+      ],
+    }
+    storage = new ThrottlerStorageService()
+    const reflector = new Reflector()
+    const organizationService = {
+      findOne: jest.fn().mockResolvedValue({
+        id: 'org-1',
+        authenticatedRateLimit: null,
+        authenticatedRateLimitTtlSeconds: null,
+      }),
+      findByUserWithDefaultFlag: jest.fn().mockResolvedValue([
+        {
+          isDefaultForAuthenticatedUser: true,
+          organization: { id: 'org-1' },
+          organizationUser: {
+            role: OrganizationMemberRole.MEMBER,
+            assignedRoles: [{ permissions: [OrganizationResourcePermission.WRITE_BOXES] }],
+          },
+        },
+      ]),
+    }
+    const organizationUserService = {
+      findOne: jest.fn().mockResolvedValue({
+        role: OrganizationMemberRole.MEMBER,
+        assignedRoles: [],
+      }),
+      getAssignedPermissions: jest.fn().mockReturnValue(new Set([OrganizationResourcePermission.WRITE_BOXES])),
+    }
+    const redis = {
+      get: jest.fn().mockResolvedValue(null),
+      set: jest.fn().mockResolvedValue('OK'),
+    } as unknown as Redis
+
+    const anonymousGuard = new AnonymousRateLimitGuard(options, storage, reflector)
+    const authenticatedGuard = new AuthenticatedRateLimitGuard(
+      options,
+      storage,
+      reflector,
+      redis,
+      organizationService as unknown as OrganizationService,
+    )
+    await anonymousGuard.onModuleInit()
+    await authenticatedGuard.onModuleInit()
+
+    const injectAuthentication: CanActivate = {
+      canActivate(context: ExecutionContext) {
+        const request = context.switchToHttp().getRequest()
+        if (request.headers.authorization === 'Bearer test') {
+          request.user = {
+            userId: authContext.userId,
+            email: authContext.email,
+            role: authContext.role,
+            organizationId: request.headers['x-boxlite-organization-id'],
+          }
+        } else {
+          request.user = authContext
+        }
+        return true
+      },
+    }
+
+    const moduleRef = await Test.createTestingModule({
+      controllers: [BoxliteConfigController, BoxliteMeController],
+      providers: [
+        {
+          provide: OrganizationService,
+          useValue: organizationService,
+        },
+        {
+          provide: OrganizationUserService,
+          useValue: organizationUserService,
+        },
+      ],
+    })
+      .overrideGuard(AnonymousRateLimitGuard)
+      .useValue(anonymousGuard)
+      .overrideGuard(CombinedAuthGuard)
+      .useValue(injectAuthentication)
+      .overrideGuard(AuthenticatedRateLimitGuard)
+      .useValue(authenticatedGuard)
+      .compile()
+
+    app = moduleRef.createNestApplication<NestExpressApplication>()
+    app.setGlobalPrefix('api')
+    app.set('trust proxy', true)
+    upgradeThrottle = new BoxliteRequestThrottleService(options, storage, organizationService as never)
+    await app.listen(0)
+  })
+
+  afterEach(async () => {
+    await app.close()
+    storage.onApplicationShutdown()
+  })
+
+  async function request(path: string, headers?: Record<string, string>): Promise<Response> {
+    const address = app.getHttpServer().address() as AddressInfo
+    return fetch(`http://127.0.0.1:${address.port}${path}`, { headers })
+  }
+
+  it('does not let HTTP clients rotate anonymous quota keys with forwarded headers', async () => {
+    const first = await request('/api/v1/config', {
+      'x-forwarded-for': '203.0.113.8, 198.51.100.24',
+    })
+    const second = await request('/api/v1/config', {
+      'x-forwarded-for': '192.0.2.9, 198.51.100.24',
+    })
+
+    expect(first.status).toBe(200)
+    expect(second.status).toBe(429)
+    expect(second.headers.get('retry-after-anonymous')).toBe('60')
+  })
+
+  it('shares the anonymous quota between HTTP and websocket upgrades', async () => {
+    const headers = { 'x-forwarded-for': '203.0.113.8, 198.51.100.24' }
+    const response = await request('/api/v1/config', headers)
+
+    expect(response.status).toBe(200)
+    await expect(
+      upgradeThrottle.consumeAnonymous({
+        headers,
+        socket: { remoteAddress: '127.0.0.1' },
+      } as unknown as import('http').IncomingMessage),
+    ).resolves.toEqual({
+      allowed: false,
+      retryAfterSeconds: 60,
+    })
+  })
+
+  it('returns effective scopes and enforces the shared authenticated organization quota', async () => {
+    const first = await request('/api/v1/me')
+    const second = await request('/api/v1/me')
+
+    expect(first.status).toBe(200)
+    await expect(first.json()).resolves.toEqual(
+      expect.objectContaining({
+        scopes: ['box:read', 'box:write', 'box:exec', 'me:read'],
+      }),
+    )
+    expect(second.status).toBe(429)
+    expect(second.headers.get('retry-after-authenticated')).toBe('60')
+  })
+
+  it('does not key interactive /v1/me throttling from an unvalidated organization header', async () => {
+    const first = await request('/api/v1/me', {
+      authorization: 'Bearer test',
+      'x-boxlite-organization-id': 'attacker-org-1',
+    })
+    const second = await request('/api/v1/me', {
+      authorization: 'Bearer test',
+      'x-boxlite-organization-id': 'attacker-org-2',
+    })
+
+    expect(first.status).toBe(200)
+    expect(second.status).toBe(429)
+    expect(second.headers.get('retry-after-authenticated')).toBe('60')
+  })
+})

--- a/apps/api/src/boxlite-rest/boxlite-throttling.spec.ts
+++ b/apps/api/src/boxlite-rest/boxlite-throttling.spec.ts
@@ -1,0 +1,57 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0
+ * Copyright (c) 2025 BoxLite AI
+ */
+
+import { GUARDS_METADATA } from '@nestjs/common/constants'
+import { CombinedAuthGuard } from '../auth/combined-auth.guard'
+import { AuthenticatedRateLimitGuard } from '../common/guards/authenticated-rate-limit.guard'
+import { AnonymousRateLimitGuard } from '../common/guards/anonymous-rate-limit.guard'
+import { THROTTLER_SCOPE_KEY } from '../common/decorators/throttler-scope.decorator'
+import { OrganizationResourceActionGuard } from '../organization/guards/organization-resource-action.guard'
+import { BoxliteBoxController } from './boxlite-box.controller'
+import { BoxliteConfigController } from './boxlite-config.controller'
+import { BoxliteMeController } from './boxlite-me.controller'
+import { BoxliteProxyController } from './boxlite-proxy.controller'
+
+jest.mock('http-proxy-middleware', () => ({
+  createProxyMiddleware: jest.fn(),
+  fixRequestBody: jest.fn(),
+}))
+jest.mock('uuid', () => ({
+  v4: jest.fn(() => 'mock-uuid'),
+  validate: jest.fn(() => true),
+}))
+
+function guardsFor(controller: object): unknown[] {
+  return Reflect.getMetadata(GUARDS_METADATA, controller) ?? []
+}
+
+describe('BoxLite v1 throttling metadata', () => {
+  it('applies the anonymous limiter to public v1 discovery', () => {
+    expect(guardsFor(BoxliteConfigController)).toEqual(expect.arrayContaining([AnonymousRateLimitGuard]))
+  })
+
+  it('applies the authenticated limiter after authentication and organization access', () => {
+    expect(guardsFor(BoxliteMeController)).toEqual([CombinedAuthGuard, AuthenticatedRateLimitGuard])
+    expect(guardsFor(BoxliteBoxController)).toEqual([
+      CombinedAuthGuard,
+      OrganizationResourceActionGuard,
+      AuthenticatedRateLimitGuard,
+    ])
+    expect(guardsFor(BoxliteProxyController)).toEqual([
+      CombinedAuthGuard,
+      OrganizationResourceActionGuard,
+      AuthenticatedRateLimitGuard,
+    ])
+  })
+
+  it('uses the existing box-create and lifecycle quota scopes for expensive mutations', () => {
+    expect(Reflect.getMetadata(THROTTLER_SCOPE_KEY, BoxliteBoxController.prototype.createBox)).toEqual(['box-create'])
+    expect(Reflect.getMetadata(THROTTLER_SCOPE_KEY, BoxliteBoxController.prototype.startBox)).toEqual(['box-lifecycle'])
+    expect(Reflect.getMetadata(THROTTLER_SCOPE_KEY, BoxliteBoxController.prototype.stopBox)).toEqual(['box-lifecycle'])
+    expect(Reflect.getMetadata(THROTTLER_SCOPE_KEY, BoxliteBoxController.prototype.removeBox)).toEqual([
+      'box-lifecycle',
+    ])
+  })
+})

--- a/apps/api/src/boxlite-rest/boxlite-ws-proxy.service.spec.ts
+++ b/apps/api/src/boxlite-rest/boxlite-ws-proxy.service.spec.ts
@@ -46,7 +46,7 @@ describe('BoxliteWsProxyService', () => {
       findOne: jest.fn().mockImplementation(async (id) => ({ id, suspended: false })),
     }
     const boxService = {
-      findOneByIdOrName: jest.fn().mockResolvedValue({ id: 'box-uuid', runnerId: 'runner-1' }),
+      findOneByIdOrName: jest.fn().mockResolvedValue({ id: 'box-uuid', runnerId: 'runner-1', autoResume: true }),
       updateLastActivityAt: jest.fn().mockResolvedValue(undefined),
     }
     const runnerService = {
@@ -63,6 +63,10 @@ describe('BoxliteWsProxyService', () => {
         email: 'dev@acme.test',
       }),
     }
+    const requestThrottle = {
+      consumeAnonymous: jest.fn().mockResolvedValue({ allowed: true }),
+      consumeAuthenticated: jest.fn().mockResolvedValue({ allowed: true }),
+    }
     const service = new BoxliteWsProxyService(
       apiKeyService as never,
       organizationUserService as never,
@@ -72,6 +76,7 @@ describe('BoxliteWsProxyService', () => {
       autoResume as never,
       jwtStrategy as never,
       userService as never,
+      requestThrottle as never,
     ) as unknown as {
       authenticate: (req: IncomingMessage, urlTenant?: string) => Promise<{ organization: { id: string } } | null>
     }
@@ -86,11 +91,13 @@ describe('BoxliteWsProxyService', () => {
       autoResume,
       jwtStrategy,
       userService,
+      requestThrottle,
     }
   }
 
   it('rewrites public box ids to internal box ids before proxying attach upgrades to the runner', () => {
     new BoxliteWsProxyService(
+      {} as never,
       {} as never,
       {} as never,
       {} as never,
@@ -139,6 +146,97 @@ describe('BoxliteWsProxyService', () => {
 
     expect(autoResume.ensureReady).toHaveBeenCalledWith('box-uuid', expect.objectContaining({ id: 'org-1' }))
     expect(proxyHandler.upgrade).not.toHaveBeenCalled()
+    expect(socket.destroy).toHaveBeenCalled()
+  })
+
+  it('rejects websocket upgrades when the anonymous pre-auth quota is exhausted', async () => {
+    const { service, apiKeyService, requestThrottle } = buildAuthHarness()
+    requestThrottle.consumeAnonymous.mockResolvedValue({ allowed: false, retryAfterSeconds: 12 })
+    const socket = { write: jest.fn(), destroy: jest.fn() }
+
+    await (service as unknown as BoxliteWsProxyService).upgrade(
+      authRequest('blk_live_test'),
+      socket as never,
+      Buffer.alloc(0),
+    )
+
+    expect(requestThrottle.consumeAnonymous).toHaveBeenCalledWith(expect.objectContaining({ url: expect.any(String) }))
+    expect(apiKeyService.getApiKeyByValue).not.toHaveBeenCalled()
+    expect(socket.write).toHaveBeenCalledWith(expect.stringContaining('HTTP/1.1 429 Too Many Requests'))
+    expect(socket.write).toHaveBeenCalledWith(expect.stringContaining('Retry-After: 12'))
+    expect(socket.destroy).toHaveBeenCalled()
+  })
+
+  it('rejects authenticated websocket upgrades when the organization quota is exhausted', async () => {
+    const { service, apiKeyService, organizationUserService, boxService, requestThrottle } = buildAuthHarness()
+    apiKeyService.getApiKeyByValue.mockResolvedValue({
+      organizationId: 'org-1',
+      userId: 'user-1',
+      expiresAt: null,
+      permissions: [OrganizationResourcePermission.WRITE_BOXES],
+    })
+    organizationUserService.findOne.mockResolvedValue({
+      organizationId: 'org-1',
+      userId: 'user-1',
+      role: OrganizationMemberRole.MEMBER,
+      assignedRoles: [],
+    })
+    requestThrottle.consumeAuthenticated.mockResolvedValue({ allowed: false, retryAfterSeconds: 7 })
+    const socket = { write: jest.fn(), destroy: jest.fn() }
+
+    await (service as unknown as BoxliteWsProxyService).upgrade(
+      authRequest('blk_live_test'),
+      socket as never,
+      Buffer.alloc(0),
+    )
+
+    expect(requestThrottle.consumeAuthenticated).toHaveBeenCalledWith('org-1')
+    expect(boxService.findOneByIdOrName).not.toHaveBeenCalled()
+    expect(socket.write).toHaveBeenCalledWith(expect.stringContaining('HTTP/1.1 429 Too Many Requests'))
+    expect(socket.write).toHaveBeenCalledWith(expect.stringContaining('Retry-After: 7'))
+  })
+
+  it('fails closed when the anonymous websocket limiter is unavailable', async () => {
+    const { service, apiKeyService, requestThrottle } = buildAuthHarness()
+    requestThrottle.consumeAnonymous.mockRejectedValue(new Error('storage unavailable'))
+    const socket = { write: jest.fn(), destroy: jest.fn() }
+
+    await (service as unknown as BoxliteWsProxyService).upgrade(
+      authRequest('blk_live_test'),
+      socket as never,
+      Buffer.alloc(0),
+    )
+
+    expect(apiKeyService.getApiKeyByValue).not.toHaveBeenCalled()
+    expect(socket.write).toHaveBeenCalledWith(expect.stringContaining('HTTP/1.1 503 Service Unavailable'))
+    expect(socket.destroy).toHaveBeenCalled()
+  })
+
+  it('fails closed when the authenticated websocket limiter is unavailable', async () => {
+    const { service, apiKeyService, organizationUserService, boxService, requestThrottle } = buildAuthHarness()
+    apiKeyService.getApiKeyByValue.mockResolvedValue({
+      organizationId: 'org-1',
+      userId: 'user-1',
+      expiresAt: null,
+      permissions: [OrganizationResourcePermission.WRITE_BOXES],
+    })
+    organizationUserService.findOne.mockResolvedValue({
+      organizationId: 'org-1',
+      userId: 'user-1',
+      role: OrganizationMemberRole.MEMBER,
+      assignedRoles: [],
+    })
+    requestThrottle.consumeAuthenticated.mockRejectedValue(new Error('storage unavailable'))
+    const socket = { write: jest.fn(), destroy: jest.fn() }
+
+    await (service as unknown as BoxliteWsProxyService).upgrade(
+      authRequest('blk_live_test'),
+      socket as never,
+      Buffer.alloc(0),
+    )
+
+    expect(boxService.findOneByIdOrName).not.toHaveBeenCalled()
+    expect(socket.write).toHaveBeenCalledWith(expect.stringContaining('HTTP/1.1 503 Service Unavailable'))
     expect(socket.destroy).toHaveBeenCalled()
   })
 

--- a/apps/api/src/boxlite-rest/boxlite-ws-proxy.service.ts
+++ b/apps/api/src/boxlite-rest/boxlite-ws-proxy.service.ts
@@ -22,6 +22,7 @@ import { UserService } from '../user/user.service'
 import { hasRequiredOrganizationResourcePermissions } from '../organization/guards/organization-resource-action.guard'
 import { BoxAutoResumeService } from './box-auto-resume.service'
 import { BOXLITE_BOX_WRITE_PERMISSIONS } from './boxlite-permission.policy'
+import { BoxliteRequestThrottleService } from './boxlite-request-throttle.service'
 
 type RunnerUpgradeRequest = IncomingMessage & {
   __boxliteRunner?: Runner
@@ -69,6 +70,7 @@ export class BoxliteWsProxyService {
     // when `skipConnections` is set, so the JWT path guards on it.
     @Inject(JwtStrategy) private readonly jwtStrategy: JwtStrategy | undefined,
     private readonly userService: UserService,
+    private readonly requestThrottle: BoxliteRequestThrottleService,
   ) {
     this.proxy = createProxyMiddleware({
       ws: true,
@@ -123,6 +125,19 @@ export class BoxliteWsProxyService {
       return
     }
 
+    let anonymousThrottle
+    try {
+      anonymousThrottle = await this.requestThrottle.consumeAnonymous(req)
+    } catch (err) {
+      this.logger.warn(`anonymous upgrade throttle failed for ${req.url}: ${(err as Error).message}`)
+      this.respondAndClose(socket, 503, 'Service Unavailable')
+      return
+    }
+    if (!anonymousThrottle.allowed) {
+      this.respondRateLimited(socket, anonymousThrottle.retryAfterSeconds)
+      return
+    }
+
     const auth = await this.authenticate(req, match.tenant)
     if (!auth) {
       this.respondAndClose(socket, 401, 'Unauthorized')
@@ -140,6 +155,19 @@ export class BoxliteWsProxyService {
     }
     if (!hasRequiredOrganizationResourcePermissions(permissionContext, BOXLITE_BOX_WRITE_PERMISSIONS)) {
       this.respondAndClose(socket, 403, 'Forbidden')
+      return
+    }
+
+    let authenticatedThrottle
+    try {
+      authenticatedThrottle = await this.requestThrottle.consumeAuthenticated(auth.organization.id)
+    } catch (err) {
+      this.logger.warn(`authenticated upgrade throttle failed for ${req.url}: ${(err as Error).message}`)
+      this.respondAndClose(socket, 503, 'Service Unavailable')
+      return
+    }
+    if (!authenticatedThrottle.allowed) {
+      this.respondRateLimited(socket, authenticatedThrottle.retryAfterSeconds)
       return
     }
 
@@ -269,6 +297,17 @@ export class BoxliteWsProxyService {
   private respondAndClose(socket: Socket, status: number, reason: string): void {
     try {
       socket.write(`HTTP/1.1 ${status} ${reason}\r\nConnection: close\r\nContent-Length: 0\r\n\r\n`)
+    } catch {
+      // Socket may already be torn down — ignore.
+    }
+    socket.destroy()
+  }
+
+  private respondRateLimited(socket: Socket, retryAfterSeconds = 1): void {
+    try {
+      socket.write(
+        `HTTP/1.1 429 Too Many Requests\r\nConnection: close\r\nRetry-After: ${retryAfterSeconds}\r\nContent-Length: 0\r\n\r\n`,
+      )
     } catch {
       // Socket may already be torn down — ignore.
     }

--- a/apps/api/src/common/guards/anonymous-rate-limit.guard.ts
+++ b/apps/api/src/common/guards/anonymous-rate-limit.guard.ts
@@ -8,6 +8,7 @@ import { Injectable, ExecutionContext } from '@nestjs/common'
 import { Reflector } from '@nestjs/core'
 import { ThrottlerGuard, ThrottlerModuleOptions, ThrottlerRequest, ThrottlerStorage } from '@nestjs/throttler'
 import { Request } from 'express'
+import { getClientIp } from '../utils/client-ip.util'
 
 @Injectable()
 export class AnonymousRateLimitGuard extends ThrottlerGuard {
@@ -17,8 +18,7 @@ export class AnonymousRateLimitGuard extends ThrottlerGuard {
 
   protected async getTracker(req: Request): Promise<string> {
     // For anonymous requests, use IP address as tracker
-    const ip = req.ips.length ? req.ips[0] : req.ip
-    return `anonymous:${ip}`
+    return `anonymous:${getClientIp(req)}`
   }
 
   protected generateKey(context: ExecutionContext, suffix: string, name: string): string {

--- a/apps/api/src/common/guards/authenticated-rate-limit.guard.ts
+++ b/apps/api/src/common/guards/authenticated-rate-limit.guard.ts
@@ -13,8 +13,13 @@ import { Redis } from 'ioredis'
 import { OrganizationService } from '../../organization/services/organization.service'
 import { THROTTLER_SCOPE_KEY } from '../decorators/throttler-scope.decorator'
 import { AuthContextType } from '../interfaces/auth-context.interface'
+import { getClientIp } from '../utils/client-ip.util'
 
 type RateLimitAuthContext = AuthContextType & {
+  apiKey?: {
+    organizationId?: string
+  }
+  organization?: unknown
   organizationId?: string
   userId?: string
 }
@@ -39,10 +44,11 @@ export class AuthenticatedRateLimitGuard extends ThrottlerGuard {
 
   protected async getTracker(req: Request): Promise<string> {
     const user = (req as AuthenticatedRequest).user
+    const organizationId = this.getTrustedOrganizationId(user)
 
     // Track by organization ID when available (shared quota per org)
-    if (user?.organizationId) {
-      return `auth:org:${user.organizationId}`
+    if (organizationId) {
+      return `auth:org:${organizationId}`
     }
 
     // Fallback to user ID for non-org routes (e.g., /users/me)
@@ -51,8 +57,7 @@ export class AuthenticatedRateLimitGuard extends ThrottlerGuard {
     }
 
     // Ultimate fallback (shouldn't happen in normal flow)
-    const ip = req.ips.length ? req.ips[0] : req.ip
-    return `fallback:${ip}`
+    return `fallback:${getClientIp(req)}`
   }
 
   protected generateKey(context: ExecutionContext, suffix: string, name: string): string {
@@ -104,7 +109,7 @@ export class AuthenticatedRateLimitGuard extends ThrottlerGuard {
         }
 
         const user = request.user
-        const orgId = user?.organizationId
+        const orgId = this.getTrustedOrganizationId(user)
         if (orgId) {
           const orgLimits = await this.getCachedOrganizationRateLimits(orgId)
           if (orgLimits) {
@@ -158,6 +163,16 @@ export class AuthenticatedRateLimitGuard extends ThrottlerGuard {
   private isSystemRole(user: RateLimitAuthContext | undefined): boolean {
     // Skip rate limiting for M2M system roles (proxy, runner, ssh-gateway)
     return user?.role === 'ssh-gateway' || user?.role === 'proxy' || user?.role === 'runner'
+  }
+
+  private getTrustedOrganizationId(user: RateLimitAuthContext | undefined): string | undefined {
+    if (user?.apiKey?.organizationId) {
+      return user.apiKey.organizationId
+    }
+    if (user?.organization && user.organizationId) {
+      return user.organizationId
+    }
+    return undefined
   }
 
   private async getCachedOrganizationRateLimits(organizationId: string): Promise<{

--- a/apps/api/src/common/middleware/failed-auth-rate-limit.middleware.ts
+++ b/apps/api/src/common/middleware/failed-auth-rate-limit.middleware.ts
@@ -10,6 +10,7 @@ import { ThrottlerException } from '@nestjs/throttler'
 import { getRedisConnectionToken } from '@nestjs-modules/ioredis'
 import { Redis } from 'ioredis'
 import { TypedConfigService } from '../../config/typed-config.service'
+import { getClientIp } from '../utils/client-ip.util'
 import { setRateLimitHeaders } from '../utils/rate-limit-headers.util'
 
 /**
@@ -32,7 +33,7 @@ export class FailedAuthRateLimitMiddleware implements NestMiddleware {
   ) {}
 
   async use(req: Request, res: Response, next: NextFunction) {
-    const ip = req.ips.length ? req.ips[0] : req.ip
+    const ip = getClientIp(req)
     const throttlerName = 'failed-auth'
     const tracker = `${throttlerName}:${ip}`
 

--- a/apps/api/src/common/utils/client-ip.util.ts
+++ b/apps/api/src/common/utils/client-ip.util.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import type { IncomingMessage } from 'http'
+import { BlockList, isIP } from 'net'
+
+const trustedIngressAddresses = new BlockList()
+trustedIngressAddresses.addSubnet('10.0.0.0', 8, 'ipv4')
+trustedIngressAddresses.addSubnet('172.16.0.0', 12, 'ipv4')
+trustedIngressAddresses.addSubnet('192.168.0.0', 16, 'ipv4')
+trustedIngressAddresses.addSubnet('127.0.0.0', 8, 'ipv4')
+trustedIngressAddresses.addSubnet('169.254.0.0', 16, 'ipv4')
+trustedIngressAddresses.addAddress('::1', 'ipv6')
+trustedIngressAddresses.addSubnet('fc00::', 7, 'ipv6')
+trustedIngressAddresses.addSubnet('fe80::', 10, 'ipv6')
+
+type ParsedIpAddress = {
+  address: string
+  family: 'ipv4' | 'ipv6'
+}
+
+/**
+ * Resolve the client address behind the single private ingress hop used by
+ * the API deployment. The ingress appends the transport client address to
+ * X-Forwarded-For, so caller-supplied entries to its left are never trusted.
+ */
+export function getClientIp(request: Pick<IncomingMessage, 'headers' | 'socket'>): string {
+  const peer = parseIpAddress(request.socket.remoteAddress)
+  if (!peer || !trustedIngressAddresses.check(peer.address, peer.family)) {
+    return peer?.address ?? 'unknown'
+  }
+
+  const forwarded = request.headers['x-forwarded-for']
+  const forwardedValue = Array.isArray(forwarded) ? forwarded.join(',') : forwarded
+  const ingressClient = forwardedValue?.split(',').at(-1)
+  return parseIpAddress(ingressClient)?.address ?? peer.address
+}
+
+/**
+ * Express invokes this from the application outwards. Only the direct,
+ * private transport peer is accepted as an ingress proxy.
+ */
+export function trustPrivateIngress(address: string, hop: number): boolean {
+  const peer = parseIpAddress(address)
+  return hop === 0 && Boolean(peer && trustedIngressAddresses.check(peer.address, peer.family))
+}
+
+function parseIpAddress(value: string | undefined): ParsedIpAddress | null {
+  if (!value) {
+    return null
+  }
+
+  let address = value.trim()
+  const bracketedIpv6 = address.match(/^\[([^\]]+)\](?::\d+)?$/)
+  if (bracketedIpv6) {
+    address = bracketedIpv6[1]
+  } else {
+    const ipv4WithPort = address.match(/^(\d+\.\d+\.\d+\.\d+):\d+$/)
+    if (ipv4WithPort) {
+      address = ipv4WithPort[1]
+    }
+  }
+
+  address = address.replace(/%.+$/, '')
+  const mappedIpv4 = address.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/i)
+  if (mappedIpv4) {
+    address = mappedIpv4[1]
+  }
+
+  const version = isIP(address)
+  if (version === 4) {
+    return { address, family: 'ipv4' }
+  }
+  if (version === 6) {
+    return { address, family: 'ipv6' }
+  }
+  return null
+}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -16,6 +16,7 @@ import { MetricsInterceptor } from './interceptors/metrics.interceptor'
 import { HttpsOptions } from '@nestjs/common/interfaces/external/https-options.interface'
 import { TypedConfigService } from './config/typed-config.service'
 import { FailedAuthTrackerService } from './auth/failed-auth-tracker.service'
+import { trustPrivateIngress } from './common/utils/client-ip.util'
 import { DataSource, MigrationExecutor } from 'typeorm'
 import { getOpenApiConfig } from './openapi.config'
 import { AuditInterceptor } from './audit/interceptors/audit.interceptor'
@@ -82,7 +83,7 @@ async function bootstrap() {
 
   const configService = app.get(TypedConfigService)
   const failedAuthTracker = app.get(FailedAuthTrackerService)
-  app.set('trust proxy', true)
+  app.set('trust proxy', trustPrivateIngress)
   app.useGlobalFilters(new AllExceptionsFilter(failedAuthTracker))
   app.useGlobalInterceptors(new LoggerErrorInterceptor())
   app.useGlobalInterceptors(new ObservabilityContextInterceptor())

--- a/apps/api/src/organization/dto/assignable-organization-resource-permissions.spec.ts
+++ b/apps/api/src/organization/dto/assignable-organization-resource-permissions.spec.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import 'reflect-metadata'
+import { plainToInstance } from 'class-transformer'
+import { validate } from 'class-validator'
+import { CreateApiKeyDto } from '../../api-key/dto/create-api-key.dto'
+import { CreateOrganizationRoleDto } from './create-organization-role.dto'
+import { UpdateOrganizationRoleDto } from './update-organization-role.dto'
+
+const supportedPermissions = ['write:boxes', 'delete:boxes']
+
+const unsupportedPermissions = [
+  'write:registries',
+  'delete:registries',
+  'write:templates',
+  'delete:templates',
+  'write:regions',
+  'delete:regions',
+  'read:runners',
+  'write:runners',
+  'delete:runners',
+  'read:volumes',
+  'write:volumes',
+  'delete:volumes',
+  'read:audit_logs',
+]
+
+const assignmentRequests = [
+  {
+    name: 'API key creation',
+    dto: CreateApiKeyDto,
+    body: { name: 'automation' },
+  },
+  {
+    name: 'organization role creation',
+    dto: CreateOrganizationRoleDto,
+    body: { name: 'Maintainer', description: 'Maintains supported resources' },
+  },
+  {
+    name: 'organization role update',
+    dto: UpdateOrganizationRoleDto,
+    body: { name: 'Maintainer', description: 'Maintains supported resources' },
+  },
+]
+
+describe('Assignable organization resource permission DTOs', () => {
+  it.each(assignmentRequests)('accepts every supported permission for $name', async ({ dto, body }) => {
+    const errors = await validate(plainToInstance(dto, { ...body, permissions: supportedPermissions }))
+
+    expect(errors).toHaveLength(0)
+  })
+
+  it.each(
+    assignmentRequests.flatMap((request) => unsupportedPermissions.map((permission) => ({ ...request, permission }))),
+  )('rejects $permission during $name', async ({ dto, body, permission }) => {
+    const errors = await validate(plainToInstance(dto, { ...body, permissions: [permission] }))
+
+    expect(errors.find((error) => error.property === 'permissions')?.constraints).toHaveProperty('isIn')
+  })
+})

--- a/apps/api/src/organization/dto/create-organization-role.dto.ts
+++ b/apps/api/src/organization/dto/create-organization-role.dto.ts
@@ -5,8 +5,11 @@
  */
 
 import { ApiProperty, ApiSchema } from '@nestjs/swagger'
-import { ArrayNotEmpty, IsArray, IsEnum, IsString } from 'class-validator'
-import { OrganizationResourcePermission } from '../enums/organization-resource-permission.enum'
+import { ArrayNotEmpty, IsArray, IsIn, IsString } from 'class-validator'
+import {
+  ASSIGNABLE_ORGANIZATION_RESOURCE_PERMISSIONS,
+  OrganizationResourcePermission,
+} from '../enums/organization-resource-permission.enum'
 
 @ApiSchema({ name: 'CreateOrganizationRole' })
 export class CreateOrganizationRoleDto {
@@ -27,12 +30,12 @@ export class CreateOrganizationRoleDto {
 
   @ApiProperty({
     description: 'The list of permissions assigned to the role',
-    enum: OrganizationResourcePermission,
+    enum: ASSIGNABLE_ORGANIZATION_RESOURCE_PERMISSIONS,
     isArray: true,
     required: true,
   })
   @IsArray()
   @ArrayNotEmpty()
-  @IsEnum(OrganizationResourcePermission, { each: true })
+  @IsIn(ASSIGNABLE_ORGANIZATION_RESOURCE_PERMISSIONS, { each: true })
   permissions: OrganizationResourcePermission[]
 }

--- a/apps/api/src/organization/dto/update-organization-role.dto.ts
+++ b/apps/api/src/organization/dto/update-organization-role.dto.ts
@@ -5,8 +5,11 @@
  */
 
 import { ApiProperty, ApiSchema } from '@nestjs/swagger'
-import { ArrayNotEmpty, IsArray, IsEnum, IsString } from 'class-validator'
-import { OrganizationResourcePermission } from '../enums/organization-resource-permission.enum'
+import { ArrayNotEmpty, IsArray, IsIn, IsString } from 'class-validator'
+import {
+  ASSIGNABLE_ORGANIZATION_RESOURCE_PERMISSIONS,
+  OrganizationResourcePermission,
+} from '../enums/organization-resource-permission.enum'
 
 @ApiSchema({ name: 'UpdateOrganizationRole' })
 export class UpdateOrganizationRoleDto {
@@ -27,12 +30,12 @@ export class UpdateOrganizationRoleDto {
 
   @ApiProperty({
     description: 'The list of permissions assigned to the role',
-    enum: OrganizationResourcePermission,
+    enum: ASSIGNABLE_ORGANIZATION_RESOURCE_PERMISSIONS,
     isArray: true,
     required: true,
   })
   @IsArray()
   @ArrayNotEmpty()
-  @IsEnum(OrganizationResourcePermission, { each: true })
+  @IsIn(ASSIGNABLE_ORGANIZATION_RESOURCE_PERMISSIONS, { each: true })
   permissions: OrganizationResourcePermission[]
 }

--- a/apps/api/src/organization/enums/organization-resource-permission.enum.ts
+++ b/apps/api/src/organization/enums/organization-resource-permission.enum.ts
@@ -5,7 +5,8 @@
  */
 
 /*
-  IMPORTANT: When adding a new permission, make sure to update apps/dashboard/src/constants/CreateApiKeyPermissionsGroups.ts accordingly
+  When exposing a permission in a dashboard workflow, update that workflow's
+  permission group.
 */
 export enum OrganizationResourcePermission {
   // docker registries
@@ -37,3 +38,11 @@ export enum OrganizationResourcePermission {
   // audit
   READ_AUDIT_LOGS = 'read:audit_logs',
 }
+
+// Keep legacy permission values in the internal enum while stored roles, API keys,
+// and active route guards can still reference them. This list is the public
+// boundary for new assignments and can grow as those capabilities ship.
+export const ASSIGNABLE_ORGANIZATION_RESOURCE_PERMISSIONS = [
+  OrganizationResourcePermission.WRITE_BOXES,
+  OrganizationResourcePermission.DELETE_BOXES,
+] as const satisfies readonly OrganizationResourcePermission[]

--- a/apps/api/src/organization/organization-permission-assignment.integration.spec.ts
+++ b/apps/api/src/organization/organization-permission-assignment.integration.spec.ts
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { type CanActivate, type ExecutionContext, ValidationPipe } from '@nestjs/common'
+import { SwaggerModule } from '@nestjs/swagger'
+import { Test } from '@nestjs/testing'
+import type { INestApplication } from '@nestjs/common'
+import { AuthGuard } from '@nestjs/passport'
+import type { AddressInfo } from 'node:net'
+import { ApiKeyController } from '../api-key/api-key.controller'
+import { ApiKeyService } from '../api-key/api-key.service'
+import { CombinedAuthGuard } from '../auth/combined-auth.guard'
+import { AuthenticatedRateLimitGuard } from '../common/guards/authenticated-rate-limit.guard'
+import { SystemRole } from '../user/enums/system-role.enum'
+import { OrganizationRoleController } from './controllers/organization-role.controller'
+import { OrganizationActionGuard } from './guards/organization-action.guard'
+import { OrganizationResourceActionGuard } from './guards/organization-resource-action.guard'
+import { OrganizationRoleService } from './services/organization-role.service'
+
+const supportedPermissions = ['write:boxes', 'delete:boxes']
+
+const unsupportedPermissions = [
+  'write:registries',
+  'delete:registries',
+  'write:templates',
+  'delete:templates',
+  'write:regions',
+  'delete:regions',
+  'read:runners',
+  'write:runners',
+  'delete:runners',
+  'read:volumes',
+  'write:volumes',
+  'delete:volumes',
+  'read:audit_logs',
+]
+
+describe('Organization permission assignment integration', () => {
+  let app: INestApplication
+  let baseUrl: string
+  const apiKeyService = {
+    createApiKey: jest.fn(),
+  }
+  const organizationRoleService = {
+    create: jest.fn(),
+    update: jest.fn(),
+  }
+
+  beforeAll(async () => {
+    const injectAdmin: CanActivate = {
+      canActivate(context: ExecutionContext): boolean {
+        context.switchToHttp().getRequest().user = {
+          organizationId: 'org-1',
+          userId: 'admin-1',
+          role: SystemRole.ADMIN,
+        }
+        return true
+      },
+    }
+    const allow: CanActivate = { canActivate: () => true }
+    const moduleRef = await Test.createTestingModule({
+      controllers: [ApiKeyController, OrganizationRoleController],
+      providers: [
+        { provide: ApiKeyService, useValue: apiKeyService },
+        { provide: OrganizationRoleService, useValue: organizationRoleService },
+      ],
+    })
+      .overrideGuard(CombinedAuthGuard)
+      .useValue(injectAdmin)
+      .overrideGuard(AuthGuard('jwt'))
+      .useValue(injectAdmin)
+      .overrideGuard(AuthenticatedRateLimitGuard)
+      .useValue(allow)
+      .overrideGuard(OrganizationActionGuard)
+      .useValue(allow)
+      .overrideGuard(OrganizationResourceActionGuard)
+      .useValue(allow)
+      .compile()
+
+    app = moduleRef.createNestApplication()
+    app.useGlobalPipes(new ValidationPipe({ transform: true }))
+    await app.listen(0)
+    const address = app.getHttpServer().address() as AddressInfo
+    baseUrl = `http://127.0.0.1:${address.port}`
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    apiKeyService.createApiKey.mockImplementation(async (_organizationId, _userId, name, permissions, expiresAt) => ({
+      apiKey: {
+        name,
+        permissions,
+        expiresAt,
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      },
+      value: 'boxlite_test_key',
+    }))
+    organizationRoleService.create.mockImplementation(async (organizationId, role) => ({
+      ...role,
+      id: 'role-1',
+      organizationId,
+      isGlobal: false,
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    }))
+    organizationRoleService.update.mockImplementation(async (roleId, role) => ({
+      ...role,
+      id: roleId,
+      organizationId: 'org-1',
+      isGlobal: false,
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    }))
+  })
+
+  afterAll(async () => {
+    await app.close()
+  })
+
+  async function post(path: string, body: object): Promise<Response> {
+    return fetch(`${baseUrl}${path}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+  }
+
+  async function put(path: string, body: object): Promise<Response> {
+    return fetch(`${baseUrl}${path}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+  }
+
+  it.each(unsupportedPermissions)(
+    'rejects unsupported API-key permission %s at the HTTP boundary',
+    async (permission) => {
+      const response = await post('/api-keys', { name: 'automation', permissions: [permission] })
+
+      expect(response.status).toBe(400)
+      expect(apiKeyService.createApiKey).not.toHaveBeenCalled()
+    },
+  )
+
+  it.each(unsupportedPermissions)('rejects unsupported role permission %s at the HTTP boundary', async (permission) => {
+    const response = await post('/organizations/org-1/roles', {
+      name: 'Maintainer',
+      description: 'Maintains supported resources',
+      permissions: [permission],
+    })
+
+    expect(response.status).toBe(400)
+    expect(organizationRoleService.create).not.toHaveBeenCalled()
+  })
+
+  it.each(unsupportedPermissions)(
+    'rejects unsupported role update permission %s at the HTTP boundary',
+    async (permission) => {
+      const response = await put('/organizations/org-1/roles/role-1', {
+        name: 'Maintainer',
+        description: 'Maintains supported resources',
+        permissions: [permission],
+      })
+
+      expect(response.status).toBe(400)
+      expect(organizationRoleService.update).not.toHaveBeenCalled()
+    },
+  )
+
+  it('allows every supported permission through all assignment endpoints', async () => {
+    const apiKeyResponse = await post('/api-keys', { name: 'automation', permissions: supportedPermissions })
+    const roleResponse = await post('/organizations/org-1/roles', {
+      name: 'Maintainer',
+      description: 'Maintains supported resources',
+      permissions: supportedPermissions,
+    })
+    const roleUpdateResponse = await put('/organizations/org-1/roles/role-1', {
+      name: 'Maintainer',
+      description: 'Maintains supported resources',
+      permissions: supportedPermissions,
+    })
+
+    expect(apiKeyResponse.status).toBe(201)
+    expect(roleResponse.status).toBe(201)
+    expect(roleUpdateResponse.status).toBe(200)
+    expect(apiKeyService.createApiKey).toHaveBeenCalledTimes(1)
+    expect(organizationRoleService.create).toHaveBeenCalledTimes(1)
+    expect(organizationRoleService.update).toHaveBeenCalledTimes(1)
+  })
+
+  it.each(['CreateApiKey', 'CreateOrganizationRole', 'UpdateOrganizationRole'])(
+    'documents only supported values in the %s request schema',
+    (schemaName) => {
+      const document = SwaggerModule.createDocument(app, {
+        openapi: '3.0.0',
+        info: { title: 'permission assignment test', version: '1' },
+      })
+      const schema = document.components?.schemas?.[schemaName] as
+        | { properties?: { permissions?: { items?: { enum?: string[] } } } }
+        | undefined
+
+      expect(schema?.properties?.permissions?.items?.enum).toEqual(supportedPermissions)
+    },
+  )
+})

--- a/apps/dashboard/src/components/OrganizationMembers/ViewerOrganizationRoleCheckbox.tsx
+++ b/apps/dashboard/src/components/OrganizationMembers/ViewerOrganizationRoleCheckbox.tsx
@@ -16,7 +16,7 @@ export const ViewerOrganizationRoleCheckbox: React.FC = () => {
         <Label htmlFor="role-viewer" className="font-normal">
           Viewer
         </Label>
-        <p className="text-sm text-gray-500">Grants read access to boxes, images, and registries in the organization</p>
+        <p className="text-sm text-gray-500">Grants read access to supported resources in the organization</p>
       </div>
     </div>
   )

--- a/apps/dashboard/src/constants/OrganizationPermissionsGroups.test.ts
+++ b/apps/dashboard/src/constants/OrganizationPermissionsGroups.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+import { ORGANIZATION_ROLE_PERMISSIONS_GROUPS } from './OrganizationPermissionsGroups'
+
+describe('Organization role permission catalog', () => {
+  it('offers only currently supported resource groups', () => {
+    expect(ORGANIZATION_ROLE_PERMISSIONS_GROUPS).toEqual([
+      {
+        name: 'Boxes',
+        permissions: ['write:boxes', 'delete:boxes'],
+      },
+    ])
+  })
+})

--- a/apps/dashboard/src/constants/OrganizationPermissionsGroups.ts
+++ b/apps/dashboard/src/constants/OrganizationPermissionsGroups.ts
@@ -12,23 +12,4 @@ export const ORGANIZATION_ROLE_PERMISSIONS_GROUPS: { name: string; permissions: 
       name: 'Boxes',
       permissions: [OrganizationRolePermissionsEnum.WRITE_BOXES, OrganizationRolePermissionsEnum.DELETE_BOXES],
     },
-    {
-      name: 'Images',
-      permissions: [OrganizationRolePermissionsEnum.WRITE_TEMPLATES, OrganizationRolePermissionsEnum.DELETE_TEMPLATES],
-    },
-    {
-      name: 'Registries',
-      permissions: [
-        OrganizationRolePermissionsEnum.WRITE_REGISTRIES,
-        OrganizationRolePermissionsEnum.DELETE_REGISTRIES,
-      ],
-    },
-    {
-      name: 'Volumes',
-      permissions: [
-        OrganizationRolePermissionsEnum.READ_VOLUMES,
-        OrganizationRolePermissionsEnum.WRITE_VOLUMES,
-        OrganizationRolePermissionsEnum.DELETE_VOLUMES,
-      ],
-    },
   ]

--- a/apps/dashboard/src/pages/OrganizationRoles.tsx
+++ b/apps/dashboard/src/pages/OrganizationRoles.tsx
@@ -11,9 +11,24 @@ import { useApi } from '@/hooks/useApi'
 import { useOrganizationRoles } from '@/hooks/useOrganizationRoles'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
 import { handleApiError } from '@/lib/error-handling'
-import { OrganizationRolePermissionsEnum } from '@boxlite-ai/api-client'
+import { CreateOrganizationRolePermissionsEnum, OrganizationRolePermissionsEnum } from '@boxlite-ai/api-client'
 import React, { useState } from 'react'
 import { toast } from 'sonner'
+
+type AssignableOrganizationRolePermission = Exclude<
+  CreateOrganizationRolePermissionsEnum,
+  typeof CreateOrganizationRolePermissionsEnum.UNKNOWN_DEFAULT_OPEN_API
+>
+
+const assignableOrganizationRolePermissions = new Set<string>(
+  Object.values(CreateOrganizationRolePermissionsEnum).filter(
+    (permission) => permission !== CreateOrganizationRolePermissionsEnum.UNKNOWN_DEFAULT_OPEN_API,
+  ),
+)
+
+const isAssignableOrganizationRolePermission = (
+  permission: OrganizationRolePermissionsEnum,
+): permission is AssignableOrganizationRolePermission => assignableOrganizationRolePermissions.has(permission)
 
 const OrganizationRoles: React.FC = () => {
   const { organizationsApi } = useApi()
@@ -35,7 +50,7 @@ const OrganizationRoles: React.FC = () => {
       await organizationsApi.createOrganizationRole(selectedOrganization.id, {
         name: name.trim(),
         description: description?.trim(),
-        permissions,
+        permissions: permissions.filter(isAssignableOrganizationRolePermission),
       })
       toast.success('Role created successfully')
       await refreshRoles(false)
@@ -60,7 +75,7 @@ const OrganizationRoles: React.FC = () => {
       await organizationsApi.updateOrganizationRole(selectedOrganization.id, roleId, {
         name: name.trim(),
         description: description?.trim(),
-        permissions,
+        permissions: permissions.filter(isAssignableOrganizationRolePermission),
       })
       toast.success('Role updated successfully')
       await refreshRoles(false)

--- a/apps/libs/api-client/src/models/create-api-key.ts
+++ b/apps/libs/api-client/src/models/create-api-key.ts
@@ -30,24 +30,9 @@ export interface CreateApiKey {
 }
 
 export const CreateApiKeyPermissionsEnum = {
-    WRITE_REGISTRIES: 'write:registries',
-    DELETE_REGISTRIES: 'delete:registries',
-    WRITE_TEMPLATES: 'write:templates',
-    DELETE_TEMPLATES: 'delete:templates',
     WRITE_BOXES: 'write:boxes',
     DELETE_BOXES: 'delete:boxes',
-    READ_VOLUMES: 'read:volumes',
-    WRITE_VOLUMES: 'write:volumes',
-    DELETE_VOLUMES: 'delete:volumes',
-    WRITE_REGIONS: 'write:regions',
-    DELETE_REGIONS: 'delete:regions',
-    READ_RUNNERS: 'read:runners',
-    WRITE_RUNNERS: 'write:runners',
-    DELETE_RUNNERS: 'delete:runners',
-    READ_AUDIT_LOGS: 'read:audit_logs',
     UNKNOWN_DEFAULT_OPEN_API: '11184809',
 } as const;
 
 export type CreateApiKeyPermissionsEnum = typeof CreateApiKeyPermissionsEnum[keyof typeof CreateApiKeyPermissionsEnum];
-
-

--- a/apps/libs/api-client/src/models/create-organization-role.ts
+++ b/apps/libs/api-client/src/models/create-organization-role.ts
@@ -30,24 +30,9 @@ export interface CreateOrganizationRole {
 }
 
 export const CreateOrganizationRolePermissionsEnum = {
-    WRITE_REGISTRIES: 'write:registries',
-    DELETE_REGISTRIES: 'delete:registries',
-    WRITE_TEMPLATES: 'write:templates',
-    DELETE_TEMPLATES: 'delete:templates',
     WRITE_BOXES: 'write:boxes',
     DELETE_BOXES: 'delete:boxes',
-    READ_VOLUMES: 'read:volumes',
-    WRITE_VOLUMES: 'write:volumes',
-    DELETE_VOLUMES: 'delete:volumes',
-    WRITE_REGIONS: 'write:regions',
-    DELETE_REGIONS: 'delete:regions',
-    READ_RUNNERS: 'read:runners',
-    WRITE_RUNNERS: 'write:runners',
-    DELETE_RUNNERS: 'delete:runners',
-    READ_AUDIT_LOGS: 'read:audit_logs',
     UNKNOWN_DEFAULT_OPEN_API: '11184809',
 } as const;
 
 export type CreateOrganizationRolePermissionsEnum = typeof CreateOrganizationRolePermissionsEnum[keyof typeof CreateOrganizationRolePermissionsEnum];
-
-

--- a/apps/libs/api-client/src/models/update-organization-role.ts
+++ b/apps/libs/api-client/src/models/update-organization-role.ts
@@ -30,24 +30,9 @@ export interface UpdateOrganizationRole {
 }
 
 export const UpdateOrganizationRolePermissionsEnum = {
-    WRITE_REGISTRIES: 'write:registries',
-    DELETE_REGISTRIES: 'delete:registries',
-    WRITE_TEMPLATES: 'write:templates',
-    DELETE_TEMPLATES: 'delete:templates',
     WRITE_BOXES: 'write:boxes',
     DELETE_BOXES: 'delete:boxes',
-    READ_VOLUMES: 'read:volumes',
-    WRITE_VOLUMES: 'write:volumes',
-    DELETE_VOLUMES: 'delete:volumes',
-    WRITE_REGIONS: 'write:regions',
-    DELETE_REGIONS: 'delete:regions',
-    READ_RUNNERS: 'read:runners',
-    WRITE_RUNNERS: 'write:runners',
-    DELETE_RUNNERS: 'delete:runners',
-    READ_AUDIT_LOGS: 'read:audit_logs',
     UNKNOWN_DEFAULT_OPEN_API: '11184809',
 } as const;
 
 export type UpdateOrganizationRolePermissionsEnum = typeof UpdateOrganizationRolePermissionsEnum[keyof typeof UpdateOrganizationRolePermissionsEnum];
-
-


### PR DESCRIPTION
## Summary

- replace broad BoxLite v1 proxy mappings with the exact documented HTTP verbs
- apply shared anonymous/authenticated throttling to HTTP routes and WebSocket upgrades, with consistent trusted-ingress client addressing
- report only effective BoxLite `/v1/me` scopes and reuse the shared permission policy from #1034
- add route-metadata, HTTP integration, scope, limiter, and WebSocket unit coverage

## Why

`@All` exposed undocumented methods, WebSocket upgrades bypassed Nest guards, forwarded headers and raw organization context could rotate limiter keys, and `/v1/me` advertised permissions the principal did not actually hold.

## Impact

Undocumented verbs now return 404, v1 callers share the configured quota across supported paths and upgrade traffic, and clients receive scopes that match effective Box permissions. Limiter storage failures on upgrades fail closed with 503.

This is stacked on #1034 so authorization continues to use the existing organization permission services without duplicating RBAC.

## Verification

- complete production-revert red/green proof for the new regression tests
- `NX_DAEMON=false NX_ISOLATE_PLUGINS=false SETUP_DONE=1 make test:apps FILTER='[Bb]ox[Ll]ite'` — 12 suites, 94 tests passed
- `NX_DAEMON=false NX_ISOLATE_PLUGINS=false SETUP_DONE=1 make lint:apps` — 0 errors (30 existing warnings)
- `VERSION=0.0.0-dev GOFLAGS=-tags=boxlite_dev NX_DAEMON=false NX_ISOLATE_PLUGINS=false SETUP_DONE=1 make build:apps` — 10 Apps projects passed