### PR TITLE
fix(apps): secure network tunnels

### DIFF
--- a/apps/api/src/box/dto/create-box.dto.ts
+++ b/apps/api/src/box/dto/create-box.dto.ts
@@ -58,7 +58,7 @@ export class CreateBoxDto {
 
   @ApiPropertyOptional({
     description: 'Whether the box http preview is publicly accessible',
-    default: true,
+    default: false,
     example: true,
   })
   @IsOptional()

--- a/apps/api/src/box/services/box.service.spec.ts
+++ b/apps/api/src/box/services/box.service.spec.ts
@@ -217,6 +217,7 @@ function makeNetworkTunnelService() {
       throw new Error(`unexpected config key ${key}`)
     }),
   } as any
+  const redis = { setex: jest.fn(), get: jest.fn() } as any
   const regionService = { findOne: jest.fn().mockResolvedValue(null) } as any
   const noop = {} as any
   const service = new BoxService(
@@ -231,7 +232,7 @@ function makeNetworkTunnelService() {
     noop,
     noop,
     noop,
-    noop,
+    redis,
     regionService,
     noop,
     noop,
@@ -240,16 +241,38 @@ function makeNetworkTunnelService() {
     id: 'MixedCaseBox',
     region: 'region-1',
   } as any)
-  return service
+  return { service, redis }
 }
 
 describe('BoxService network tunnel URLs', () => {
-  it('creates a case-safe endpoint for an SDK tunnel', async () => {
-    const service = makeNetworkTunnelService()
+  it('mints a short-lived capability bound to the tenant-owned box and guest port', async () => {
+    const { service, redis } = makeNetworkTunnelService()
 
     const result = await service.getNetworkTunnelUrl('MixedCaseBox', 'org-1', 3000)
 
-    expect(result).toBe('https://3000-d-4d6978656443617365426f78.proxy.example.test')
+    const token = result.match(/^https:\/\/3000-(t-[a-z0-9]{32})\.proxy\.example\.test$/)?.[1]
+    expect(token).toBeDefined()
+    expect(service.findOneByIdOrName).toHaveBeenCalledWith('MixedCaseBox', 'org-1')
+    expect(redis.setex).toHaveBeenCalledWith(`box:network-tunnel-token:3000:${token}`, 60, 'MixedCaseBox')
+  })
+
+  it.each([0, 65536])('rejects out-of-range guest port %s before looking up a box', async (port) => {
+    const { service } = makeNetworkTunnelService()
+
+    await expect(service.getNetworkTunnelUrl('MixedCaseBox', 'org-1', port)).rejects.toThrow('Invalid port')
+
+    expect(service.findOneByIdOrName).not.toHaveBeenCalled()
+  })
+
+  it('resolves a capability only from its port-bound tunnel key', async () => {
+    const { service, redis } = makeNetworkTunnelService()
+    const token = 't-0123456789abcdef0123456789abcdef'
+    redis.get.mockImplementation(async (key: string) =>
+      key === `box:network-tunnel-token:3000:${token}` ? 'MixedCaseBox' : null,
+    )
+
+    await expect(service.getBoxIdFromSignedPreviewUrlToken(token, 3000)).resolves.toBe('MixedCaseBox')
+    await expect(service.getBoxIdFromSignedPreviewUrlToken(token, 3001)).rejects.toThrow('Invalid or expired token')
   })
 })
 
@@ -271,8 +294,9 @@ describe('BoxService public defaults', () => {
   }
 
   it.each([
-    [undefined, true],
+    [undefined, false],
     [false, false],
+    [true, true],
   ])('defaults a fresh box to public=%s', async (requestedPublic, expectedPublic) => {
     const { service, boxRepository } = makeCreateService()
 
@@ -282,8 +306,9 @@ describe('BoxService public defaults', () => {
   })
 
   it.each([
-    [undefined, true],
+    [undefined, false],
     [false, false],
+    [true, true],
   ])('defaults an assigned warm-pool box to public=%s', async (requestedPublic, expectedPublic) => {
     const warmPoolBox = { id: 'warm-box', runnerId: 'runner-1', name: 'warm-box' } as any
     const update = jest.fn().mockResolvedValue(warmPoolBox)

--- a/apps/api/src/box/services/box.service.ts
+++ b/apps/api/src/box/services/box.service.ts
@@ -90,6 +90,9 @@ const DEFAULT_BOX_MEM = 1
 const DEFAULT_BOX_DISK = 10
 const DEFAULT_BOX_GPU = 0
 const TERMINAL_PREVIEW_PORT = 22222
+const NETWORK_TUNNEL_TOKEN_PREFIX = 't-'
+const NETWORK_TUNNEL_TOKEN_LENGTH = 32
+const NETWORK_TUNNEL_TOKEN_TTL_SECONDS = 60
 
 @Injectable()
 export class BoxService {
@@ -226,7 +229,7 @@ export class BoxService {
       box.mem = mem
       box.disk = disk
 
-      box.public = createBoxDto.public ?? true
+      box.public = createBoxDto.public ?? false
 
       if (createBoxDto.networkBlockAll !== undefined) {
         box.networkBlockAll = createBoxDto.networkBlockAll
@@ -287,7 +290,7 @@ export class BoxService {
   ): Promise<BoxDto> {
     const now = new Date()
     const updateData: Partial<Box> = {
-      public: createBoxDto.public ?? true,
+      public: createBoxDto.public ?? false,
       labels: createBoxDto.labels || {},
       organizationId: organization.id,
       createdAt: now,
@@ -716,12 +719,15 @@ export class BoxService {
     const proxyDomain = this.configService.getOrThrow('proxy.domain')
     const proxyProtocol = this.configService.getOrThrow('proxy.protocol')
     const box = await this.findOneByIdOrName(boxIdOrName, organizationId)
-    const endpointId = encodeDirectPreviewBoxId(box.id)
+    const token =
+      NETWORK_TUNNEL_TOKEN_PREFIX +
+      customNanoid(urlAlphabet.replace('_', '').replace('-', ''))(NETWORK_TUNNEL_TOKEN_LENGTH).toLowerCase()
+    await this.redis.setex(networkTunnelTokenKey(port, token), NETWORK_TUNNEL_TOKEN_TTL_SECONDS, box.id)
 
-    let url = `${proxyProtocol}://${port}-${endpointId}.${proxyDomain}`
+    let url = `${proxyProtocol}://${port}-${token}.${proxyDomain}`
     const region = await this.regionService.findOne(box.region, true)
     if (region?.proxyUrl) {
-      url = region.proxyUrl.replace(/(https?:\/)(\/)/, `$1/${port}-${endpointId}.`)
+      url = region.proxyUrl.replace(/(https?:\/)(\/)/, `$1/${port}-${token}.`)
     }
     return url
   }
@@ -770,7 +776,9 @@ export class BoxService {
   }
 
   async getBoxIdFromSignedPreviewUrlToken(token: string, port: number): Promise<string> {
-    const lockKey = `box:signed-preview-url-token:${port}:${token}`
+    const lockKey = token.startsWith(NETWORK_TUNNEL_TOKEN_PREFIX)
+      ? networkTunnelTokenKey(port, token)
+      : `box:signed-preview-url-token:${port}:${token}`
     const boxId = await this.redis.get(lockKey)
     if (!boxId) {
       throw new ForbiddenException('Invalid or expired token')
@@ -1562,6 +1570,10 @@ export class BoxService {
 
     return { valid: true, boxId: sshAccess.box.id }
   }
+}
+
+function networkTunnelTokenKey(port: number, token: string): string {
+  return `box:network-tunnel-token:${port}:${token}`
 }
 
 function encodeDirectPreviewBoxId(boxId: string): string {

--- a/apps/api/src/boxlite-rest/boxlite-network-tunnel.integration.spec.ts
+++ b/apps/api/src/boxlite-rest/boxlite-network-tunnel.integration.spec.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import type { ExecutionContext } from '@nestjs/common'
+import { Reflector } from '@nestjs/core'
+import { OrganizationMemberRole } from '../organization/enums/organization-member-role.enum'
+import { OrganizationResourcePermission } from '../organization/enums/organization-resource-permission.enum'
+import { OrganizationResourceActionGuard } from '../organization/guards/organization-resource-action.guard'
+import { BoxliteProxyController } from './boxlite-proxy.controller'
+
+jest.mock('http-proxy-middleware', () => ({
+  createProxyMiddleware: jest.fn(),
+  fixRequestBody: jest.fn(),
+}))
+jest.mock('uuid', () => ({
+  v4: jest.fn(() => 'mock-uuid'),
+  validate: jest.fn(() => true),
+}))
+
+describe('BoxLite network tunnel authorization integration', () => {
+  const boxService = {
+    getNetworkTunnelUrl: jest.fn().mockResolvedValue('https://3000-t-capability.proxy.test'),
+  }
+  const controller = new BoxliteProxyController(boxService as never, {} as never, {} as never)
+  const guard = new OrganizationResourceActionGuard(
+    { findOne: jest.fn().mockResolvedValue({ id: 'org-1' }) } as never,
+    {
+      findOne: jest.fn().mockResolvedValue({
+        role: OrganizationMemberRole.MEMBER,
+        assignedRoles: [],
+      }),
+    } as never,
+    new Reflector(),
+  )
+
+  beforeAll(() => {
+    ;(guard as any).redis = {
+      get: jest.fn().mockResolvedValue(null),
+      set: jest.fn().mockResolvedValue('OK'),
+    }
+  })
+
+  beforeEach(() => {
+    boxService.getNetworkTunnelUrl.mockClear()
+  })
+
+  it('rejects tunnel minting when the API key lacks write:boxes', async () => {
+    const request = apiKeyRequest([OrganizationResourcePermission.READ_VOLUMES])
+
+    await expect(guard.canActivate(tunnelContext(request))).resolves.toBe(false)
+
+    expect(boxService.getNetworkTunnelUrl).not.toHaveBeenCalled()
+  })
+
+  it('mints a tenant-scoped tunnel capability for an authorized API key', async () => {
+    const request = apiKeyRequest([OrganizationResourcePermission.WRITE_BOXES])
+
+    await expect(guard.canActivate(tunnelContext(request))).resolves.toBe(true)
+    await expect(controller.proxyNetworkTunnel(request.user as never, 'tenant-box', 3000)).resolves.toEqual({
+      uri: 'https://3000-t-capability.proxy.test',
+    })
+    expect(boxService.getNetworkTunnelUrl).toHaveBeenCalledWith('tenant-box', 'org-1', 3000)
+  })
+
+  function apiKeyRequest(permissions: OrganizationResourcePermission[]) {
+    return {
+      params: {},
+      user: {
+        role: 'user',
+        userId: 'user-1',
+        email: 'user@example.test',
+        organizationId: 'org-1',
+        apiKey: {
+          organizationId: 'org-1',
+          permissions,
+        },
+      },
+    }
+  }
+
+  function tunnelContext(request: ReturnType<typeof apiKeyRequest>): ExecutionContext {
+    return {
+      getClass: () => BoxliteProxyController,
+      getHandler: () => BoxliteProxyController.prototype.proxyNetworkTunnel,
+      switchToHttp: () => ({
+        getRequest: () => request,
+      }),
+    } as unknown as ExecutionContext
+  }
+})

--- a/apps/api/src/boxlite-rest/boxlite-proxy.controller.spec.ts
+++ b/apps/api/src/boxlite-rest/boxlite-proxy.controller.spec.ts
@@ -5,7 +5,10 @@
  */
 
 import { ForbiddenException } from '@nestjs/common'
+import { Reflector } from '@nestjs/core'
 import { createProxyMiddleware } from 'http-proxy-middleware'
+import { RequiredOrganizationResourcePermissions } from '../organization/decorators/required-organization-resource-permissions.decorator'
+import { OrganizationResourcePermission } from '../organization/enums/organization-resource-permission.enum'
 import { BoxliteProxyController } from './boxlite-proxy.controller'
 
 jest.mock('http-proxy-middleware', () => ({
@@ -60,6 +63,14 @@ describe('BoxliteProxyController', () => {
 
     expect(boxService.getNetworkTunnelUrl).toHaveBeenCalledWith('public-box', 'org-1', 3000)
     expect(result).toEqual({ uri: 'https://3000-box.proxy.test' })
+  })
+
+  it('requires write:boxes permission to mint a network tunnel capability', () => {
+    const reflector = new Reflector()
+
+    expect(
+      reflector.get(RequiredOrganizationResourcePermissions, BoxliteProxyController.prototype.proxyNetworkTunnel),
+    ).toEqual([OrganizationResourcePermission.WRITE_BOXES])
   })
 
   it('auto-resumes exec and files but treats metrics as observation-only', async () => {

--- a/apps/api/src/boxlite-rest/boxlite-proxy.controller.ts
+++ b/apps/api/src/boxlite-rest/boxlite-proxy.controller.ts
@@ -32,6 +32,8 @@ import { AuthContext } from '../common/decorators/auth-context.decorator'
 import { OrganizationAuthContext } from '../common/interfaces/auth-context.interface'
 import { BoxService } from '../box/services/box.service'
 import { RunnerService } from '../box/services/runner.service'
+import { RequiredOrganizationResourcePermissions } from '../organization/decorators/required-organization-resource-permissions.decorator'
+import { OrganizationResourcePermission } from '../organization/enums/organization-resource-permission.enum'
 import { BoxAutoResumeService } from './box-auto-resume.service'
 
 type ProxyActivityPolicy = { activity: boolean; autoResume: boolean }
@@ -200,6 +202,7 @@ export class BoxliteProxyController {
 
   @Post(':boxId/network/tunnel')
   @HttpCode(HttpStatus.OK)
+  @RequiredOrganizationResourcePermissions([OrganizationResourcePermission.WRITE_BOXES])
   async proxyNetworkTunnel(
     @AuthContext() authContext: OrganizationAuthContext,
     @Param('boxId') boxId: string,

--- a/apps/proxy/pkg/proxy/tunnel.go
+++ b/apps/proxy/pkg/proxy/tunnel.go
@@ -8,7 +8,7 @@ import (
 	"bufio"
 	"context"
 	"crypto/tls"
-	"encoding/hex"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -17,31 +17,38 @@ import (
 	"strings"
 	"time"
 
+	common_errors "github.com/boxlite-ai/common-go/pkg/errors"
 	common_proxy "github.com/boxlite-ai/common-go/pkg/proxy"
+	"github.com/boxlite-ai/common-go/pkg/utils"
 	log "github.com/sirupsen/logrus"
 )
 
 const runnerTunnelSetupTimeout = 10 * time.Second
 
-const tunnelBoxIDPrefix = "d-"
+const (
+	networkTunnelTokenPrefix       = "t-"
+	networkTunnelTokenRandomLength = 32
+)
+
+var errInvalidNetworkTunnelToken = errors.New("invalid or expired network tunnel capability")
 
 func (p *Proxy) handleTunnelConnect(writer http.ResponseWriter, request *http.Request) {
 	if request.Method != http.MethodConnect {
 		http.Error(writer, "CONNECT required", http.StatusMethodNotAllowed)
 		return
 	}
-	boxID, port, err := p.tunnelTarget(request)
+	token, port, err := p.tunnelTarget(request)
 	if err != nil {
 		http.Error(writer, err.Error(), http.StatusBadRequest)
 		return
 	}
-	isPublic, err := p.getBoxPublic(request.Context(), boxID)
+	boxID, err := p.resolveNetworkTunnelToken(request.Context(), token, port)
 	if err != nil {
-		http.Error(writer, "box visibility unavailable", http.StatusBadGateway)
-		return
-	}
-	if !*isPublic {
-		http.Error(writer, "box is not public", http.StatusForbidden)
+		if errors.Is(err, errInvalidNetworkTunnelToken) {
+			http.Error(writer, "invalid or expired network tunnel capability", http.StatusForbidden)
+		} else {
+			http.Error(writer, "network tunnel authorization unavailable", http.StatusBadGateway)
+		}
 		return
 	}
 	runnerInfo, err := p.getBoxRunnerInfo(request.Context(), boxID)
@@ -69,39 +76,70 @@ func (p *Proxy) handleTunnelConnect(writer http.ResponseWriter, request *http.Re
 }
 
 func (p *Proxy) tunnelTarget(request *http.Request) (string, uint16, error) {
-	port, boxID, _, err := p.parseHost(request.Host)
-	if err != nil || boxID == "" {
+	port, token, _, err := p.parseHost(request.Host)
+	if err != nil || !isNetworkTunnelToken(token) {
 		return "", 0, fmt.Errorf("invalid tunnel host")
-	}
-	if decoded, ok, decodeErr := decodeTunnelBoxID(boxID); decodeErr != nil {
-		return "", 0, decodeErr
-	} else if ok {
-		boxID = decoded
 	}
 	value, err := strconv.ParseUint(port, 10, 16)
 	if err != nil || value == 0 {
 		return "", 0, fmt.Errorf("invalid tunnel port")
 	}
-	return boxID, uint16(value), nil
+	return token, uint16(value), nil
 }
 
-func decodeTunnelBoxID(value string) (string, bool, error) {
-	encoded, ok := strings.CutPrefix(value, tunnelBoxIDPrefix)
-	if !ok {
-		return value, false, nil
+func isNetworkTunnelToken(token string) bool {
+	if len(token) != len(networkTunnelTokenPrefix)+networkTunnelTokenRandomLength ||
+		!strings.HasPrefix(token, networkTunnelTokenPrefix) {
+		return false
 	}
-	decoded, err := hex.DecodeString(encoded)
-	if err != nil || len(decoded) != 12 {
-		return "", true, fmt.Errorf("invalid tunnel box ID")
-	}
-	boxID := string(decoded)
-	for _, ch := range boxID {
-		if (ch >= '0' && ch <= '9') || (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z') {
+	for _, ch := range token[len(networkTunnelTokenPrefix):] {
+		if (ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'z') {
 			continue
 		}
-		return "", true, fmt.Errorf("invalid tunnel box ID")
+		return false
 	}
-	return boxID, true, nil
+	return true
+}
+
+func (p *Proxy) resolveNetworkTunnelToken(ctx context.Context, token string, port uint16) (string, error) {
+	var boxID string
+	err := utils.RetryWithExponentialBackoff(
+		ctx,
+		"resolve network tunnel capability",
+		proxyMaxRetries,
+		proxyBaseDelay,
+		proxyMaxDelay,
+		func() error {
+			resolvedBoxID, response, err := p.apiclient.PreviewAPI.
+				GetBoxIdFromSignedPreviewUrlToken(ctx, token, float32(port)).
+				Execute()
+			if err == nil {
+				if resolvedBoxID == "" {
+					return &utils.NonRetryableError{Err: errInvalidNetworkTunnelToken}
+				}
+				boxID = resolvedBoxID
+				return nil
+			}
+
+			if response != nil &&
+				response.StatusCode >= http.StatusBadRequest &&
+				response.StatusCode < http.StatusInternalServerError &&
+				response.StatusCode != http.StatusRequestTimeout &&
+				response.StatusCode != http.StatusTooManyRequests {
+				return &utils.NonRetryableError{Err: errInvalidNetworkTunnelToken}
+			}
+
+			openapiErr := common_errors.ConvertOpenAPIError(err)
+			if openapiErr != nil && !common_errors.IsRetryableOpenAPIError(openapiErr) {
+				return &utils.NonRetryableError{Err: openapiErr}
+			}
+			return openapiErr
+		},
+	)
+	if err != nil {
+		return "", err
+	}
+	return boxID, nil
 }
 
 func dialRunnerTunnel(ctx context.Context, runnerInfo *RunnerInfo, boxID string, port uint16) (net.Conn, error) {

--- a/apps/proxy/pkg/proxy/tunnel_integration_test.go
+++ b/apps/proxy/pkg/proxy/tunnel_integration_test.go
@@ -1,0 +1,111 @@
+// Copyright 2026 BoxLite AI
+// SPDX-License-Identifier: AGPL-3.0
+
+package proxy
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	apiclient "github.com/boxlite-ai/boxlite/libs/api-client-go"
+	common_cache "github.com/boxlite-ai/common-go/pkg/cache"
+)
+
+func TestTunnelCapabilityIntegrationResolvesControlPlaneBeforeRunner(t *testing.T) {
+	const (
+		boxID = "AbCdEf123456"
+		token = "t-0123456789abcdef0123456789abcdef"
+	)
+	requests := make(chan *http.Request, 1)
+	proxy := tunnelIntegrationProxy(t, func(request *http.Request) (*http.Response, error) {
+		requests <- request
+		if request.URL.Path != "/preview/"+token+"/3000/box-id" {
+			return tunnelIntegrationResponse(request, http.StatusNotFound, "not found"), nil
+		}
+		return tunnelIntegrationResponse(request, http.StatusOK, boxID), nil
+	})
+	ctx := context.Background()
+	if err := proxy.boxRunnerCache.Set(
+		ctx,
+		boxID,
+		RunnerInfo{ApiUrl: "://invalid-runner", ApiKey: "runner-key"},
+		time.Minute,
+	); err != nil {
+		t.Fatal(err)
+	}
+	request := httptest.NewRequest(http.MethodConnect, "http://proxy.test", nil)
+	request.Host = "3000-" + token + ".proxy.test:443"
+	response := httptest.NewRecorder()
+
+	proxy.handleTunnelConnect(response, request)
+
+	if response.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want runner failure after capability resolution", response.Code)
+	}
+	select {
+	case controlPlaneRequest := <-requests:
+		if controlPlaneRequest.URL.Path != "/preview/"+token+"/3000/box-id" {
+			t.Fatalf("control-plane path = %q", controlPlaneRequest.URL.Path)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("control plane did not resolve tunnel capability")
+	}
+}
+
+func TestTunnelCapabilityIntegrationRejectsExpiredTokenBeforeRunnerLookup(t *testing.T) {
+	const token = "t-0123456789abcdef0123456789abcdef"
+	var controlPlanePaths []string
+	proxy := tunnelIntegrationProxy(t, func(request *http.Request) (*http.Response, error) {
+		controlPlanePaths = append(controlPlanePaths, request.URL.Path)
+		if request.URL.Path != "/preview/"+token+"/3000/box-id" {
+			return tunnelIntegrationResponse(request, http.StatusNotFound, "not found"), nil
+		}
+		return tunnelIntegrationResponse(request, http.StatusForbidden, "expired"), nil
+	})
+	request := httptest.NewRequest(http.MethodConnect, "http://proxy.test", nil)
+	request.Host = "3000-" + token + ".proxy.test:443"
+	response := httptest.NewRecorder()
+
+	proxy.handleTunnelConnect(response, request)
+
+	if response.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want expired capability rejection", response.Code)
+	}
+	if len(controlPlanePaths) != 1 || controlPlanePaths[0] != "/preview/"+token+"/3000/box-id" {
+		t.Fatalf("control-plane requests = %q, want only the capability lookup", controlPlanePaths)
+	}
+}
+
+type tunnelIntegrationRoundTripper func(*http.Request) (*http.Response, error)
+
+func (roundTrip tunnelIntegrationRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	return roundTrip(request)
+}
+
+func tunnelIntegrationProxy(t *testing.T, roundTrip tunnelIntegrationRoundTripper) *Proxy {
+	t.Helper()
+	config := apiclient.NewConfiguration()
+	config.Servers = apiclient.ServerConfigurations{{URL: "http://control-plane.test"}}
+	config.HTTPClient = &http.Client{Transport: roundTrip}
+	ctx := context.Background()
+	return &Proxy{
+		apiclient:      apiclient.NewAPIClient(config),
+		boxRunnerCache: common_cache.NewMapCache[RunnerInfo](ctx),
+		boxPublicCache: common_cache.NewMapCache[bool](ctx),
+	}
+}
+
+func tunnelIntegrationResponse(request *http.Request, status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Status:     http.StatusText(status),
+		Header:     http.Header{"Content-Type": []string{"text/plain"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Request:    request,
+	}
+}

--- a/apps/proxy/pkg/proxy/tunnel_test.go
+++ b/apps/proxy/pkg/proxy/tunnel_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	apiclient "github.com/boxlite-ai/boxlite/libs/api-client-go"
 	common_cache "github.com/boxlite-ai/common-go/pkg/cache"
 	common_proxy "github.com/boxlite-ai/common-go/pkg/proxy"
 )
@@ -84,18 +85,18 @@ func TestConnectHandlerTracksTunnelForShutdown(t *testing.T) {
 
 func TestTunnelTargetUsesPreviewAuthority(t *testing.T) {
 	request := httptest.NewRequest(http.MethodConnect, "http://proxy.test", nil)
-	request.Host = "3000-d-416243644566313233343536.proxy.test:443"
+	request.Host = "3000-t-0123456789abcdef0123456789abcdef.proxy.test:443"
 
-	boxID, port, err := (&Proxy{}).tunnelTarget(request)
+	token, port, err := (&Proxy{}).tunnelTarget(request)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if boxID != "AbCdEf123456" || port != 3000 {
-		t.Fatalf("unexpected tunnel target: %s:%d", boxID, port)
+	if token != "t-0123456789abcdef0123456789abcdef" || port != 3000 {
+		t.Fatalf("unexpected tunnel target: %s:%d", token, port)
 	}
 }
 
-func TestTunnelConnectRejectsPrivateBoxBeforeRunnerDial(t *testing.T) {
+func TestTunnelConnectRejectsDirectBoxIDBeforeRunnerDial(t *testing.T) {
 	ctx := context.Background()
 	publicCache := common_cache.NewMapCache[bool](ctx)
 	if err := publicCache.Set(ctx, "AbCdEf123456", false, time.Minute); err != nil {
@@ -108,8 +109,58 @@ func TestTunnelConnectRejectsPrivateBoxBeforeRunnerDial(t *testing.T) {
 
 	proxy.handleTunnelConnect(response, request)
 
-	if response.Code != http.StatusForbidden {
-		t.Fatalf("status = %d, want %d", response.Code, http.StatusForbidden)
+	if response.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusBadRequest)
+	}
+}
+
+func TestTunnelConnectResolvesCapabilityBeforeRunnerDial(t *testing.T) {
+	const token = "t-0123456789abcdef0123456789abcdef"
+	requestPath := make(chan string, 1)
+	apiServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path == "/preview/"+token+"/3000/box-id" {
+			requestPath <- request.URL.Path
+			writer.Header().Set("Content-Type", "text/plain")
+			_, _ = writer.Write([]byte("AbCdEf123456"))
+			return
+		}
+		http.NotFound(writer, request)
+	}))
+	defer apiServer.Close()
+
+	clientConfig := apiclient.NewConfiguration()
+	clientConfig.Servers = apiclient.ServerConfigurations{{URL: apiServer.URL}}
+	ctx := context.Background()
+	runnerCache := common_cache.NewMapCache[RunnerInfo](ctx)
+	if err := runnerCache.Set(
+		ctx,
+		"AbCdEf123456",
+		RunnerInfo{ApiUrl: "http://127.0.0.1:1", ApiKey: "runner-key"},
+		time.Minute,
+	); err != nil {
+		t.Fatal(err)
+	}
+	proxy := &Proxy{
+		apiclient:      apiclient.NewAPIClient(clientConfig),
+		boxRunnerCache: runnerCache,
+		boxPublicCache: common_cache.NewMapCache[bool](ctx),
+	}
+	request := httptest.NewRequest(http.MethodConnect, "http://proxy.test", nil)
+	request.Host = "3000-" + token + ".proxy.test:443"
+	response := httptest.NewRecorder()
+
+	proxy.handleTunnelConnect(response, request)
+
+	if response.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want %d after capability resolution", response.Code, http.StatusBadGateway)
+	}
+	select {
+	case got := <-requestPath:
+		if got != "/preview/"+token+"/3000/box-id" {
+			t.Fatalf("capability lookup path = %q", got)
+		}
+	default:
+		t.Fatal("capability was not resolved through the control plane")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Default newly created and warm-pool-assigned Apps boxes to private unless callers explicitly request public access.
- Require `write:boxes` and tenant-scoped box lookup before minting a guest-port tunnel.
- Replace direct box IDs in tunnel authorities with random, port-bound capabilities that expire after 60 seconds.
- Restrict proxy CONNECT handling to those capabilities, resolve them through the control plane, and preserve authenticated runner CONNECT with bounded setup.
- Add unit and integration coverage across the API authorization boundary and proxy/control-plane path.

## Why

Apps REST previously defaulted boxes to public and embedded a reversible box ID in guest-port tunnel hostnames. The tunnel route also lacked an explicit Box write permission. This let possession of a predictable authority reach exposure behavior without a short-lived, tenant-authorized capability.

## Impact

Apps-created boxes are private by default. Callers that intentionally need public previews must opt in. Guest-port tunnels now require an authenticated API request with `write:boxes`, tenant ownership, and a fresh port-specific capability. Existing terminal preview behavior is unchanged.

## Validation

- Full production-revert red/green replay with:
  `NX_DAEMON=false NX_ISOLATE_PLUGINS=false NX_SKIP_NX_CACHE=true make test:apps SETUP_DONE=1 FILTER='public defaults|network tunnel authorization integration|network tunnel URLs|TunnelCapabilityIntegration|DirectBoxID' PYTHON=/usr/bin/python3`
- Red: API 5 failed / 7 passed; proxy exposed legacy public/direct-ID resolution behavior.
- Green: all six Apps projects passed; API 12/12 selected tests passed; proxy unit and integration suites passed.
- `make fmt:apps`
- `make lint:apps` — 0 errors; 31 pre-existing warnings.
- `git diff --check`
