### PR TITLE
Enforce strict Apps REST create contract

### DIFF
--- a/apps/api/src/boxlite-rest/boxlite-box.controller.ts
+++ b/apps/api/src/boxlite-rest/boxlite-box.controller.ts
@@ -17,6 +17,7 @@ import {
   UseGuards,
   Logger,
   Res,
+  ValidationPipe,
 } from '@nestjs/common'
 import { ApiTags, ApiBearerAuth, ApiResponse, ApiExcludeController } from '@nestjs/swagger'
 import { Response } from 'express'
@@ -72,10 +73,6 @@ export class BoxliteBoxController {
         cpus: req.body?.cpus,
         memory_mib: req.body?.memory_mib,
         disk_size_gb: req.body?.disk_size_gb,
-        working_dir: req.body?.working_dir,
-        entrypoint: req.body?.entrypoint,
-        cmd: req.body?.cmd,
-        detach: req.body?.detach,
         auto_pause: req.body?.auto_pause,
         auto_delete: req.body?.auto_delete,
         auto_resume: req.body?.auto_resume,
@@ -84,7 +81,14 @@ export class BoxliteBoxController {
   })
   async createBox(
     @AuthContext() authContext: OrganizationAuthContext,
-    @Body() dto: CreateBoxDto,
+    @Body(
+      new ValidationPipe({
+        transform: true,
+        whitelist: true,
+        forbidNonWhitelisted: true,
+      }),
+    )
+    dto: CreateBoxDto,
   ): Promise<BoxResponseDto> {
     const organization = authContext.organization
     const createBoxDto = createBoxToCreateBox(dto)

--- a/apps/api/src/boxlite-rest/boxlite-rest-contract.spec.ts
+++ b/apps/api/src/boxlite-rest/boxlite-rest-contract.spec.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2025 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { parse } from 'yaml'
+
+type OpenApiSchema = {
+  description?: string
+  additionalProperties?: boolean | OpenApiSchema
+  minimum?: number
+  properties?: Record<string, OpenApiSchema>
+}
+
+type OpenApiDocument = {
+  components: {
+    schemas: Record<string, OpenApiSchema>
+  }
+}
+
+const specPath = resolve(__dirname, '../../../../openapi/box.openapi.yaml')
+const document = parse(readFileSync(specPath, 'utf8')) as OpenApiDocument
+const schemas = document.components.schemas
+
+describe('published Apps REST contract', () => {
+  it('publishes the exact implemented create allowlist as a closed object', () => {
+    const create = schemas.CreateBoxRequest
+
+    expect(create.additionalProperties).toBe(false)
+    expect(Object.keys(create.properties ?? {}).sort()).toEqual(
+      [
+        'name',
+        'image',
+        'cpus',
+        'memory_mib',
+        'disk_size_gb',
+        'env',
+        'user',
+        'network',
+        'auto_pause',
+        'auto_delete',
+        'auto_resume',
+      ].sort(),
+    )
+    expect(create.description).not.toContain('BoxOptions')
+    expect(create.properties?.memory_mib.minimum).toBe(256)
+  })
+
+  it.each(['VolumeSpec', 'PortSpec', 'SecretSpec', 'SecurityPreset'])(
+    'does not publish host/runtime create component %s',
+    (schemaName) => {
+      expect(schemas).not.toHaveProperty(schemaName)
+    },
+  )
+
+  it('does not publish runner-host process details in Box responses', () => {
+    const box = schemas.Box
+
+    expect(box.properties).not.toHaveProperty('pid')
+    expect(box.description).not.toContain('BoxInfo')
+    expect(box.properties?.image.description).not.toMatch(/rootfs|host path/i)
+  })
+})

--- a/apps/api/src/boxlite-rest/boxlite-rest-routing.spec.ts
+++ b/apps/api/src/boxlite-rest/boxlite-rest-routing.spec.ts
@@ -12,6 +12,7 @@ import { CombinedAuthGuard } from '../auth/combined-auth.guard'
 import { OrganizationResourceActionGuard } from '../organization/guards/organization-resource-action.guard'
 import { BoxService } from '../box/services/box.service'
 import { BoxStateWaiterService } from '../box/services/box-state-waiter.service'
+import { BoxState } from '../box/enums/box-state.enum'
 import { BoxliteBoxController } from './boxlite-box.controller'
 import { BoxliteProxyController } from './boxlite-proxy.controller'
 import { BoxliteWsProxyService } from './boxlite-ws-proxy.service'
@@ -27,6 +28,18 @@ jest.mock('uuid', () => ({
 
 describe('BoxLite REST routing', () => {
   let app: INestApplication
+  const createBox = jest.fn().mockResolvedValue({
+    id: 'box-created',
+    name: 'created-box',
+    state: BoxState.STARTED,
+    createdAt: new Date('2026-07-25T00:00:00.000Z'),
+    updatedAt: new Date('2026-07-25T00:00:01.000Z'),
+    image: 'ghcr.io/boxlite-ai/boxlite-agent-base:20260605-p0-r3',
+    cpu: 1,
+    memory: 1,
+    labels: {},
+    pid: 4321,
+  })
 
   async function startRoutingTestApp() {
     const moduleRef = await Test.createTestingModule({
@@ -35,6 +48,7 @@ describe('BoxLite REST routing', () => {
         {
           provide: BoxService,
           useValue: {
+            create: createBox,
             findAllDeprecated: jest.fn().mockResolvedValue([]),
             toBoxDtos: jest.fn().mockResolvedValue([]),
           },
@@ -64,13 +78,26 @@ describe('BoxLite REST routing', () => {
     await app.listen(0)
   }
 
-  async function get(path: string): Promise<Response> {
+  async function request(path: string, init?: RequestInit): Promise<Response> {
     const address = app.getHttpServer().address() as AddressInfo
-    return fetch(`http://127.0.0.1:${address.port}${path}`)
+    return fetch(`http://127.0.0.1:${address.port}${path}`, init)
+  }
+
+  async function get(path: string): Promise<Response> {
+    return request(path)
+  }
+
+  async function post(path: string, body: Record<string, unknown>): Promise<Response> {
+    return request(path, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    })
   }
 
   afterEach(async () => {
     await app?.close()
+    createBox.mockClear()
   })
 
   it('mounts box controllers at canonical and legacy default-prefix routes', () => {
@@ -88,6 +115,105 @@ describe('BoxLite REST routing', () => {
     expect(await canonical.json()).toEqual({ boxes: [] })
     expect(legacy.status).toBe(200)
     expect(await legacy.json()).toEqual({ boxes: [] })
+  })
+
+  it.each([
+    ['rootfs_path', '/srv/runner/rootfs'],
+    ['working_dir', '/workspace'],
+    ['entrypoint', ['/bin/sh']],
+    ['cmd', ['-lc', 'id']],
+    ['volumes', [{ host_path: '/etc', guest_path: '/host' }]],
+    ['ports', [{ host_port: 22, guest_port: 22, host_ip: '127.0.0.1' }]],
+    ['secrets', [{ name: 'token', value: 'not-a-real-secret' }]],
+    ['security', 'development'],
+    ['advanced', { new_pid_ns: false }],
+    ['runtime', { home_dir: '/srv/boxlite' }],
+    ['auto_remove', true],
+    ['health_check', { command: ['true'] }],
+    ['tty', true],
+  ])('rejects unsupported create field %s at the Apps HTTP boundary', async (field, value) => {
+    await startRoutingTestApp()
+
+    const response = await post('/api/v1/boxes', { image: 'base', [field]: value })
+
+    expect(response.status).toBe(400)
+    expect(createBox).not.toHaveBeenCalled()
+  })
+
+  it('rejects unknown nested network fields at the Apps HTTP boundary', async () => {
+    await startRoutingTestApp()
+
+    const response = await post('/api/v1/boxes', {
+      image: 'base',
+      network: { mode: 'enabled', allow_net: ['api.openai.com'], host_ip: '127.0.0.1' },
+    })
+
+    expect(response.status).toBe(400)
+    expect(createBox).not.toHaveBeenCalled()
+  })
+
+  it('applies the strict create allowlist to the legacy prefixed route', async () => {
+    await startRoutingTestApp()
+
+    const response = await post('/api/v1/default/boxes', {
+      image: 'base',
+      rootfs_path: '/srv/runner/rootfs',
+    })
+
+    expect(response.status).toBe(400)
+    expect(createBox).not.toHaveBeenCalled()
+  })
+
+  it('rejects invalid values in otherwise allowlisted fields before creation', async () => {
+    await startRoutingTestApp()
+
+    const response = await post('/api/v1/boxes', {
+      image: 'base',
+      env: { RETRIES: 3 },
+    })
+
+    expect(response.status).toBe(400)
+    expect(createBox).not.toHaveBeenCalled()
+  })
+
+  it('accepts the implemented create allowlist and tolerates legacy detach without mapping it', async () => {
+    await startRoutingTestApp()
+
+    const response = await post('/api/v1/boxes', {
+      name: 'worker',
+      image: 'base',
+      cpus: 1,
+      memory_mib: 256,
+      disk_size_gb: 1,
+      env: { MODE: 'worker' },
+      user: 'boxlite',
+      network: { mode: 'enabled', allow_net: ['api.openai.com'] },
+      auto_pause: 900,
+      auto_delete: 3600,
+      auto_resume: false,
+      detach: true,
+    })
+
+    expect(response.status).toBe(201)
+    expect(createBox).toHaveBeenCalledTimes(1)
+    const [mapped] = createBox.mock.calls[0]
+    expect(mapped).toMatchObject({
+      name: 'worker',
+      image: 'base',
+      cpu: 1,
+      memory: 1,
+      disk: 1,
+      env: { MODE: 'worker' },
+      user: 'boxlite',
+      networkBlockAll: false,
+      networkAllowList: 'api.openai.com',
+      autoPause: 900,
+      autoDelete: 3600,
+      autoResume: false,
+    })
+    expect(mapped).not.toHaveProperty('detach')
+    const body = (await response.json()) as Record<string, unknown>
+    expect(body).not.toHaveProperty('pid')
   })
 
   it('matches websocket attach upgrades with or without a routing prefix', () => {

--- a/apps/api/src/boxlite-rest/dto/box-response.dto.ts
+++ b/apps/api/src/boxlite-rest/dto/box-response.dto.ts
@@ -38,12 +38,6 @@ export class BoxResponseDto {
   })
   updated_at: string
 
-  @ApiPropertyOptional({
-    description: 'Runtime process ID when available',
-    example: 12345,
-  })
-  pid?: number
-
   @ApiProperty({
     description: 'Approved image used for the box',
     example: 'boxlite/base',

--- a/apps/api/src/boxlite-rest/dto/create-box.dto.spec.ts
+++ b/apps/api/src/boxlite-rest/dto/create-box.dto.spec.ts
@@ -40,6 +40,23 @@ describe('CreateBoxDto resource minimums', () => {
   })
 })
 
+describe('CreateBoxDto environment validation', () => {
+  it('accepts a string-to-string environment map', async () => {
+    const errors = await validate(plainToInstance(CreateBoxDto, { env: { MODE: 'worker', RETRIES: '3' } }))
+
+    expect(errors).toHaveLength(0)
+  })
+
+  it.each([{ RETRIES: 3 }, { DEBUG: true }, { EMPTY: null }])(
+    'rejects non-string environment values in %j',
+    async (env) => {
+      const errors = await validate(plainToInstance(CreateBoxDto, { env }))
+
+      expect(errors.find((error) => error.property === 'env')).toBeDefined()
+    },
+  )
+})
+
 describe('CreateBoxDto lifecycle policy', () => {
   it('accepts second-based lifecycle fields', async () => {
     const errors = await validate(

--- a/apps/api/src/boxlite-rest/dto/create-box.dto.ts
+++ b/apps/api/src/boxlite-rest/dto/create-box.dto.ts
@@ -11,7 +11,6 @@ import {
   IsString,
   IsNumber,
   IsBoolean,
-  IsObject,
   IsArray,
   Min,
   IsIn,
@@ -30,6 +29,22 @@ class IsNetworkAllowEntryConstraint implements ValidatorConstraintInterface {
 
   defaultMessage(): string {
     return 'each allow_net entry must be an IPv4 address, IPv4 CIDR, hostname, or wildcard hostname'
+  }
+}
+
+@ValidatorConstraint({ name: 'isStringRecord', async: false })
+class IsStringRecordConstraint implements ValidatorConstraintInterface {
+  validate(value: unknown): boolean {
+    return (
+      typeof value === 'object' &&
+      value !== null &&
+      !Array.isArray(value) &&
+      Object.values(value).every((entry) => typeof entry === 'string')
+    )
+  }
+
+  defaultMessage(): string {
+    return 'env must be an object whose values are strings'
   }
 }
 
@@ -73,25 +88,16 @@ export class CreateBoxDto {
   disk_size_gb?: number
 
   @IsOptional()
-  @IsString()
-  working_dir?: string
-
-  @IsOptional()
-  @IsObject()
+  @Validate(IsStringRecordConstraint)
   env?: Record<string, string>
-
-  @IsOptional()
-  @IsArray()
-  entrypoint?: string[]
-
-  @IsOptional()
-  @IsArray()
-  cmd?: string[]
 
   @IsOptional()
   @IsString()
   user?: string
 
+  // Released Rust REST clients send detach on every create. Apps boxes are
+  // control-plane owned, so accept this legacy field as a validated no-op but
+  // keep it out of the published contract and downstream mapper.
   @IsOptional()
   @IsBoolean()
   detach?: boolean

--- a/apps/api/src/boxlite-rest/mappers/box-to-box.mapper.spec.ts
+++ b/apps/api/src/boxlite-rest/mappers/box-to-box.mapper.spec.ts
@@ -6,6 +6,52 @@
 import { BoxState } from '../../box/enums/box-state.enum'
 import { boxToBoxResponse, createBoxToCreateBox } from './box-to-box.mapper'
 
+describe('BoxLite Apps create allowlist mapper', () => {
+  it('maps every implemented create field into the control-plane DTO', () => {
+    const mapped = createBoxToCreateBox(
+      {
+        name: 'worker',
+        image: 'base',
+        cpus: 2,
+        memory_mib: 1536,
+        disk_size_gb: 8,
+        env: { MODE: 'worker' },
+        user: 'boxlite',
+        network: {
+          mode: 'enabled',
+          allow_net: [' api.openai.com ', '10.0.0.0/8'],
+        },
+        auto_pause: 900,
+        auto_delete: 3600,
+        auto_resume: false,
+      },
+      'region-1',
+    )
+
+    expect(mapped).toEqual({
+      name: 'worker',
+      image: 'base',
+      cpu: 2,
+      memory: 2,
+      disk: 8,
+      env: { MODE: 'worker' },
+      user: 'boxlite',
+      target: 'region-1',
+      networkBlockAll: false,
+      networkAllowList: 'api.openai.com,10.0.0.0/8',
+      autoPause: 900,
+      autoDelete: 3600,
+      autoResume: false,
+    })
+  })
+
+  it('does not map the unpublished detach compatibility field', () => {
+    const mapped = createBoxToCreateBox({ image: 'base', detach: true })
+
+    expect(mapped).not.toHaveProperty('detach')
+  })
+})
+
 describe('BoxLite lifecycle policy mapper', () => {
   it('maps second-based create fields into the control-plane DTO', () => {
     const mapped = createBoxToCreateBox({
@@ -44,5 +90,17 @@ describe('BoxLite lifecycle policy mapper', () => {
     } as any)
 
     expect(response.auto_resume).toBe(true)
+  })
+
+  it('does not expose a runner-host PID in the Apps response', () => {
+    const response = boxToBoxResponse({
+      id: 'box-1',
+      name: 'demo',
+      state: BoxState.STARTED,
+      labels: {},
+      pid: 4321,
+    } as any)
+
+    expect(response).not.toHaveProperty('pid')
   })
 })

--- a/openapi/box.openapi.yaml
+++ b/openapi/box.openapi.yaml
@@ -1486,7 +1486,7 @@ components:
     # =======================================================================
     Box:
       type: object
-      description: Box metadata (maps to BoxInfo)
+      description: Tenant-safe Box metadata
       required: [box_id, status, created_at, updated_at, image, cpus, memory_mib]
       properties:
         box_id:
@@ -1517,14 +1517,10 @@ components:
           type: string
           format: date-time
           description: Last state change timestamp (UTC)
-        pid:
-          type: integer
-          nullable: true
-          description: VMM subprocess PID (null if not running)
         image:
           type: string
-          description: OCI image reference or rootfs path
-          example: python:3.11-slim
+          description: Operator-approved image selected for the box
+          example: python
         cpus:
           type: integer
           minimum: 1
@@ -1576,7 +1572,8 @@ components:
 
     CreateBoxRequest:
       type: object
-      description: Configuration for creating a new box (maps to BoxOptions)
+      description: Tenant-safe configuration for creating a BoxLite Apps box
+      additionalProperties: false
       properties:
         name:
           type: string
@@ -1587,32 +1584,26 @@ components:
           example: dev-box
         image:
           type: string
-          description: OCI image reference
-          default: "alpine:latest"
-          example: python:3.11-slim
-        rootfs_path:
-          type: string
           description: |
-            Path to a pre-built rootfs (alternative to `image`).
-            Mutually exclusive with `image`.
+            Operator-approved image name or exact approved reference.
+            Arbitrary image pulls are not supported.
+          default: base
+          example: python
         cpus:
           type: integer
           minimum: 1
           maximum: 32
-          description: Number of vCPUs to allocate
+          description: Number of vCPUs to allocate, subject to organization limits
           example: 2
         memory_mib:
           type: integer
-          minimum: 128
-          description: Memory in MiB to allocate
+          minimum: 256
+          description: Memory in MiB to allocate, subject to organization limits
           example: 512
         disk_size_gb:
           type: integer
           minimum: 1
-          description: Disk size in GB (sparse, grows as needed)
-        working_dir:
-          type: string
-          description: Default working directory inside the container
+          description: Disk size in GB, subject to organization limits
         env:
           type: object
           additionalProperties:
@@ -1621,41 +1612,12 @@ components:
           example:
             PYTHONPATH: /app
             DEBUG: "1"
-        entrypoint:
-          type: array
-          items:
-            type: string
-          description: Override image ENTRYPOINT
-        cmd:
-          type: array
-          items:
-            type: string
-          description: Override image CMD
         user:
           type: string
           description: "User to run as (format: <name|uid>[:<group|gid>])"
           example: "1000:1000"
-        volumes:
-          type: array
-          items:
-            $ref: "#/components/schemas/VolumeSpec"
-        ports:
-          type: array
-          items:
-            $ref: "#/components/schemas/PortSpec"
         network:
           $ref: "#/components/schemas/NetworkSpec"
-        secrets:
-          type: array
-          items:
-            $ref: "#/components/schemas/SecretSpec"
-          description: |
-            Secret placeholder rules for outbound HTTP(S) requests.
-            Matching requests replace `placeholder` with `value` on the host side.
-        detach:
-          type: boolean
-          description: Box survives parent process exit
-          default: false
         auto_pause:
           type: integer
           minimum: 0
@@ -1670,23 +1632,6 @@ components:
           type: boolean
           default: true
           description: Whether the box automatically resumes when accessed after AutoPause
-        security:
-          $ref: "#/components/schemas/SecurityPreset"
-
-    VolumeSpec:
-      type: object
-      description: Host-to-guest filesystem mount
-      required: [host_path, guest_path]
-      properties:
-        host_path:
-          type: string
-          description: Path on the host filesystem
-        guest_path:
-          type: string
-          description: Mount point inside the container
-        read_only:
-          type: boolean
-          default: false
 
     NetworkSpec:
       type: object
@@ -1707,64 +1652,6 @@ components:
             Optional outbound allowlist used only when `mode=enabled`.
             Empty or omitted means full outbound access.
             Supports hostnames, wildcard hostnames, IPs, and CIDRs.
-
-    PortSpec:
-      type: object
-      description: Port forwarding rule (host → guest)
-      required: [guest_port]
-      properties:
-        host_port:
-          type: integer
-          minimum: 0
-          maximum: 65535
-          description: Host port (0 or omit for dynamic assignment)
-        guest_port:
-          type: integer
-          minimum: 1
-          maximum: 65535
-          description: Container port to expose
-        protocol:
-          type: string
-          enum: [tcp, udp]
-          default: tcp
-        host_ip:
-          type: string
-          description: Host IP to bind (defaults to 0.0.0.0)
-
-    SecretSpec:
-      type: object
-      description: Outbound HTTP(S) secret substitution rule
-      required: [name, value]
-      properties:
-        name:
-          type: string
-          description: Human-readable secret name
-        value:
-          type: string
-          description: Real secret value. Never enters the guest VM.
-        hosts:
-          type: array
-          items:
-            type: string
-          description: Matching hosts for this secret. Empty means no host restriction.
-        placeholder:
-          type: string
-          description: |
-            Placeholder string visible inside the guest.
-            Defaults to `<BOXLITE_SECRET:{name}>` when omitted.
-
-    SecurityPreset:
-      type: string
-      description: |
-        Security isolation preset:
-        - `development`: Minimal isolation for debugging
-        - `standard`: Recommended for most use cases (jailer + seccomp on Linux)
-        - `maximum`: All isolation features enabled (untrusted workloads)
-      enum:
-        - development
-        - standard
-        - maximum
-      default: standard
 
     Snapshot:
       type: object

--- a/scripts/test/stress/api-create-box.k6.js
+++ b/scripts/test/stress/api-create-box.k6.js
@@ -96,7 +96,6 @@ export default function (cfg) {
     cpus: Number(__ENV.BOXLITE_STRESS_CPUS || 1),
     memory_mib: Number(__ENV.BOXLITE_STRESS_MEMORY_MIB || 256),
     disk_size_gb: Number(__ENV.BOXLITE_STRESS_DISK_SIZE_GB || 1),
-    detach: true,
   })
 
   const create = http.post(`${cfg.baseUrl}/v1/${cfg.prefix}/boxes`, body, cfg.auth)

--- a/scripts/test/stress/api-vm-lifecycle.k6.js
+++ b/scripts/test/stress/api-vm-lifecycle.k6.js
@@ -114,7 +114,6 @@ export default function (cfg) {
       cpus: Number(__ENV.BOXLITE_STRESS_CPUS || 1),
       memory_mib: Number(__ENV.BOXLITE_STRESS_MEMORY_MIB || 256),
       disk_size_gb: Number(__ENV.BOXLITE_STRESS_DISK_SIZE_GB || 1),
-      detach: true,
     })
 
     const create = http.post(`${cfg.baseUrl}/v1/${cfg.prefix}/boxes`, body, authParams())


### PR DESCRIPTION
## Summary

- enforce an endpoint-scoped positive allowlist for Apps box creation
- remove host-only and unsupported controls plus runner-host PID details from the published contract
- retain `detach` as an unpublished, validated compatibility no-op for released REST clients
- add static contract, DTO, mapper unit, and live Nest HTTP integration coverage

## Why

The Apps API previously described local-owner BoxOptions and accepted unsupported fields that the mapper ignored. That made the multi-tenant contract misleading and exposed host/runtime controls as if they were supported.

## Impact

Unknown or unsupported top-level and nested create fields now return HTTP 400 before `BoxService.create`. The published schema contains only implemented tenant-safe fields. Existing released clients remain compatible because boolean `detach` is accepted but ignored.

## Validation

- focused Apps REST contract run: 30 tests passed across four suites
- `make lint:apps`: passed (31 existing warnings)
- `make test:rest:inventory`: passed (32 spec operations; createBox candidate coverage)
- full Apps test matrix: 214/218 passed; four assertions failed in three untouched AutoResume/proxy suites
- Apps API compilation passed; the full workspace build remains blocked at runner link because `sdks/go/libboxlite.a` is absent