### PR TITLE
feat: add embedded SSH server

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -136,6 +136,20 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install protobuf
 
+      # Only the macOS branch of `make clippy` cross-compiles boxlite-guest to
+      # linux-musl, and the guest links C since russh brought in ring. This is
+      # the same bottled toolchain and cross-linker config that
+      # scripts/setup/setup-macos.sh gives developers.
+      - name: Install guest cross toolchain (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew install FiloSottile/musl-cross/musl-cross
+          mkdir -p "$HOME/.cargo"
+          {
+            printf '\n[target.x86_64-unknown-linux-musl]\nlinker = "x86_64-linux-musl-gcc"\n'
+            printf '\n[target.aarch64-unknown-linux-musl]\nlinker = "aarch64-linux-musl-gcc"\n'
+          } >> "$HOME/.cargo/config.toml"
+
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
         continue-on-error: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout",
+]
+
+[[package]]
+name = "aes"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
+dependencies = [
+ "cipher",
+ "cpubits",
+ "cpufeatures 0.3.0",
+ "zeroize",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdf011db2e21ce0d575593d749db5554b47fed37aff429e4dc50bc91ac93a028"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,6 +132,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "argon2"
+version = "0.6.0-rc.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7af50940b73bf4e16c15c448a2b121c63f2d68e3e54b6a8731673cb4aa0cdff5"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures 0.3.0",
+ "password-hash",
 ]
 
 [[package]]
@@ -256,7 +305,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sha1",
+ "sha1 0.10.6",
  "sync_wrapper",
  "tokio",
  "tokio-tungstenite 0.29.0",
@@ -323,6 +372,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -345,6 +400,17 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bcrypt-pbkdf"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "144e573728da132683b9488acd528274c790e07fc06ff81ee29f9d8f8b1041e0"
+dependencies = [
+ "blowfish",
+ "pbkdf2",
+ "sha2 0.11.0",
+]
 
 [[package]]
 name = "bincode"
@@ -401,6 +467,18 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "blake2"
+version = "0.11.0-rc.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061f1a09225e328e1ffbb378d2d49923c0ca5fee19fb5ac1cc9c1e9d52b93690"
+dependencies = [
+ "digest 0.11.3",
+]
 
 [[package]]
 name = "block-buffer"
@@ -408,7 +486,36 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+ "zeroize",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "blowfish"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62ce3946557b35e71d1bbe07ec385073ce9eda05043f95de134eb578fcf1a298"
+dependencies = [
+ "byteorder",
+ "cipher",
 ]
 
 [[package]]
@@ -466,7 +573,7 @@ dependencies = [
  "seccompiler",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "signal-hook",
  "sysinfo",
  "tar",
@@ -556,6 +663,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "boxlite-shared",
+ "bytes",
  "clap",
  "futures",
  "libcontainer",
@@ -564,6 +672,8 @@ dependencies = [
  "procfs",
  "rayon",
  "rtnetlink",
+ "russh",
+ "russh-sftp",
  "serde",
  "serde_json",
  "tar",
@@ -710,6 +820,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2dc9ee5f88d11e0beb842c88b33c8a5cf0d1329c4b19494af42b07dbfe8896"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cbindgen"
 version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -753,6 +872,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+ "zeroize",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -764,6 +896,18 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
+ "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -834,6 +978,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -878,6 +1028,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "const_format"
@@ -926,10 +1082,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -1006,8 +1177,25 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
  "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
+dependencies = [
+ "cpubits",
+ "ctutils",
+ "getrandom 0.4.2",
+ "hybrid-array",
+ "num-traits",
+ "rand_core 0.10.1",
+ "serdect",
  "subtle",
  "zeroize",
 ]
@@ -1018,8 +1206,29 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "getrandom 0.4.2",
+ "hybrid-array",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "crypto-primes"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3633a51a39c69ebbaa4feaa694bd83d241e4093901c84a0963b19d9bb3f0cf8f"
+dependencies = [
+ "crypto-bigint 0.7.5",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1029,16 +1238,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "400a21f1014a968ec518c7ccdf9b4a4ed0cac8c56ccb6d604f8b91f00110501e"
 
 [[package]]
+name = "ctr"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+ "subtle",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
- "fiat-crypto",
+ "digest 0.10.7",
+ "fiat-crypto 0.2.9",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "curve25519-dalek-derive",
+ "digest 0.11.3",
+ "fiat-crypto 0.3.0",
+ "rand_core 0.10.1",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -1125,10 +1370,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "delegate"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "780eb241654bf097afb00fc5f054a09b687dad862e485fdcf8399bb056565370"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "der"
@@ -1136,8 +1406,19 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
- "pem-rfc7468",
+ "const-oid 0.9.6",
+ "pem-rfc7468 0.7.0",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
+dependencies = [
+ "const-oid 0.10.2",
+ "pem-rfc7468 1.0.0",
  "zeroize",
 ]
 
@@ -1183,6 +1464,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "des"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "916a94e407b54f9034d71dd748234cd1e516ced6284009906ae246f177eafe5a"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "dialoguer"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1207,10 +1497,22 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -1300,12 +1602,27 @@ version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der",
- "digest",
- "elliptic-curve",
- "rfc6979",
- "signature",
- "spki",
+ "der 0.7.10",
+ "digest 0.10.7",
+ "elliptic-curve 0.13.8",
+ "rfc6979 0.4.0",
+ "signature 2.2.0",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0681a4fc24c767085329728d8dfba959af91228aa4610cca4f8ce317ba46ae0"
+dependencies = [
+ "der 0.8.1",
+ "digest 0.11.3",
+ "elliptic-curve 0.14.1",
+ "rfc6979 0.6.0",
+ "signature 3.0.0",
+ "spki 0.8.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -1314,8 +1631,18 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8",
- "signature",
+ "pkcs8 0.10.2",
+ "signature 2.2.0",
+]
+
+[[package]]
+name = "ed25519"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
+dependencies = [
+ "pkcs8 0.11.0",
+ "signature 3.0.0",
 ]
 
 [[package]]
@@ -1324,10 +1651,26 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
- "curve25519-dalek",
- "ed25519",
+ "curve25519-dalek 4.1.3",
+ "ed25519 2.2.3",
  "serde",
- "sha2",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
+dependencies = [
+ "curve25519-dalek 5.0.0",
+ "ed25519 3.0.0",
+ "rand_core 0.10.1",
+ "serde",
+ "sha2 0.11.0",
+ "signature 3.0.0",
  "subtle",
  "zeroize",
 ]
@@ -1344,17 +1687,39 @@ version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "base16ct",
- "crypto-bigint",
- "digest",
- "ff",
- "generic-array",
- "group",
- "hkdf",
- "pem-rfc7468",
- "pkcs8",
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.5",
+ "digest 0.10.7",
+ "ff 0.13.1",
+ "generic-array 0.14.7",
+ "group 0.13.0",
+ "hkdf 0.12.4",
+ "pem-rfc7468 0.7.0",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
- "sec1",
+ "sec1 0.7.3",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d65aa39b3a5c1c9c1b745c9a019234bb7a21b77abcb4f4d266d706e2d577d65"
+dependencies = [
+ "base16ct 1.0.0",
+ "crypto-bigint 0.7.5",
+ "crypto-common 0.2.2",
+ "digest 0.11.3",
+ "ff 0.14.0",
+ "group 0.14.0",
+ "hkdf 0.13.0",
+ "hybrid-array",
+ "pem-rfc7468 1.0.0",
+ "pkcs8 0.11.0",
+ "rand_core 0.10.1",
+ "sec1 0.8.1",
  "subtle",
  "zeroize",
 ]
@@ -1370,6 +1735,18 @@ name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
+name = "enum_dispatch"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "enumflags2"
@@ -1449,10 +1826,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ff"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1f686ab92a9fb0eaf188f6c6c87b89490baa6fdb0db4544ba4dc47f7942489f"
+dependencies = [
+ "rand_core 0.10.1",
+ "subtle",
+]
+
+[[package]]
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "filetime"
@@ -1675,6 +2068,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb130435a959a8d525e6bca66ff6c40981a300ee96d70e3ef56f046556d614a3"
+dependencies = [
+ "generic-array 0.14.7",
+ "rustversion",
+ "typenum",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1708,10 +2112,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1727,10 +2134,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
+dependencies = [
+ "polyval",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "gloo-timers"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "482ce8a491a501da4cd806bd190275363d674f2845005c6ddbd5d3e1dd54495d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "group"
@@ -1738,8 +2166,19 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff",
+ "ff 0.13.1",
  "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "group"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd1a1c7a5206c5b7a3f5a0d7ccd3ff85d0c8f5133d62a02680255b0004af5f4"
+dependencies = [
+ "ff 0.14.0",
+ "rand_core 0.10.1",
  "subtle",
 ]
 
@@ -1790,6 +2229,12 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -1858,12 +2303,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hex-literal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
+
+[[package]]
 name = "hkdf"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
+dependencies = [
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -1872,7 +2332,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1943,6 +2412,18 @@ name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "ctutils",
+ "subtle",
+ "typenum",
+ "zeroize",
+]
 
 [[package]]
 name = "hyper"
@@ -2212,6 +2693,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "block-padding",
+ "hybrid-array",
+]
+
+[[package]]
+name = "internal-russh-num-bigint"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae8e22120c32fb4d19ec55fba35015f57095cd95a2e3b732e44457f5915b2ee8"
+dependencies = [
+ "num-integer",
+ "num-traits",
+ "rand 0.10.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "inventory"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2337,13 +2840,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -2354,12 +2856,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6204285f77fe7d9784db3fdc449ecce1a0114927a51d5a41c4c7a292011c015f"
 dependencies = [
  "base64 0.13.1",
- "crypto-common",
- "digest",
- "hmac",
+ "crypto-common 0.1.7",
+ "digest 0.10.7",
+ "hmac 0.12.1",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "kem"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01737161ba802849cfd486b5bd209d38ba4943494c249a8126005170c7621edd"
+dependencies = [
+ "crypto-common 0.2.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2613,6 +3135,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "md5"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ebb8d8732c6a6df3d8f032a82911cfc747e00efb95cc46e8d0acd5b5b88570c"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2691,6 +3219,31 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ml-kem"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e15f3e5b957493873e396a66914e83e616b6afe335cdef7efe5c6e1216aba66"
+dependencies = [
+ "hybrid-array",
+ "kem",
+ "module-lattice",
+ "pkcs8 0.11.0",
+ "rand_core 0.10.1",
+ "sha3 0.11.0",
+]
+
+[[package]]
+name = "module-lattice"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c61b87c9683ab7cb1c6871d261ad5479b6b10ceb52c4352aaca3b5d35a8febe"
+dependencies = [
+ "ctutils",
+ "hybrid-array",
+ "num-traits",
 ]
 
 [[package]]
@@ -2999,6 +3552,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint-dig"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3075,7 +3638,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_path_to_error",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "url",
 ]
@@ -3124,7 +3687,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3212,23 +3775,23 @@ dependencies = [
  "base64 0.21.7",
  "chrono",
  "dyn-clone",
- "ed25519-dalek",
- "hmac",
+ "ed25519-dalek 2.2.0",
+ "hmac 0.12.1",
  "http",
  "itertools 0.10.5",
  "log",
  "oauth2",
- "p256",
- "p384",
+ "p256 0.13.2",
+ "p384 0.13.1",
  "rand 0.8.6",
- "rsa",
+ "rsa 0.9.10",
  "serde",
  "serde-value",
  "serde_json",
  "serde_path_to_error",
  "serde_plain",
  "serde_with",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "thiserror 1.0.69",
  "url",
@@ -3261,10 +3824,23 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
+ "primeorder 0.13.6",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "p256"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c9239b2dbc807adbbe147e8cf72ea7450c3a0aabe62cb8e75ff4ec22e1f72a"
+dependencies = [
+ "ecdsa 0.17.0",
+ "elliptic-curve 0.14.1",
+ "primefield",
+ "primeorder 0.14.0",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -3273,10 +3849,58 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
 dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
+ "primeorder 0.13.6",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "p384"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d17b851e6b3e378ab4ecb07fa2ed23f4d15f075735f8fec9fa1e7bdce5f8301f"
+dependencies = [
+ "ecdsa 0.17.0",
+ "elliptic-curve 0.14.1",
+ "fiat-crypto 0.3.0",
+ "primefield",
+ "primeorder 0.14.0",
+ "sha2 0.11.0",
+]
+
+[[package]]
+name = "p521"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ad64cc32c2dc466317c12ee5853e61f159f9eab1fe7efade0395dc2e7b43449"
+dependencies = [
+ "base16ct 1.0.0",
+ "ecdsa 0.17.0",
+ "elliptic-curve 0.14.1",
+ "primefield",
+ "primeorder 0.14.0",
+ "sha2 0.11.0",
+]
+
+[[package]]
+name = "pageant"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f3a5ae18f65a85c67a77d18d42d3606c07948e3c17c1e5f74852b26589e88a5"
+dependencies = [
+ "base16ct 1.0.0",
+ "byteorder",
+ "bytes",
+ "delegate",
+ "futures",
+ "log",
+ "rand 0.10.2",
+ "sha2 0.11.0",
+ "thiserror 2.0.18",
+ "tokio",
+ "windows 0.62.2",
+ "windows-strings",
 ]
 
 [[package]]
@@ -3314,6 +3938,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aab41826031698d6ffcd9cff78ef56ef998e39dc7e5067cdfebe373842d4723b"
+dependencies = [
+ "phc",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3338,6 +3971,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pbkdf2"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
+dependencies = [
+ "digest 0.11.3",
+ "hmac 0.13.0",
+]
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3357,6 +4000,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3370,6 +4022,16 @@ checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
  "indexmap 2.14.0",
+]
+
+[[package]]
+name = "phc"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44dc769b75f93afdddd8c7fa12d685292ddeff1e66f7f0f3a234cf1818afe892"
+dependencies = [
+ "base64ct",
+ "ctutils",
 ]
 
 [[package]]
@@ -3410,9 +4072,36 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der",
- "pkcs8",
- "spki",
+ "der 0.7.10",
+ "pkcs8 0.10.2",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs1"
+version = "0.8.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986d2e952779af96ea048f160fd9194e1751b4faea78bcf3ceb456efe008088e"
+dependencies = [
+ "der 0.8.1",
+ "spki 0.8.0",
+]
+
+[[package]]
+name = "pkcs5"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63d440a804ec8d6fafbb6b84471e013286658d373248927692ab3366686220ca"
+dependencies = [
+ "aes",
+ "aes-gcm",
+ "cbc",
+ "der 0.8.1",
+ "pbkdf2",
+ "rand_core 0.10.1",
+ "scrypt",
+ "sha2 0.11.0",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -3421,8 +4110,20 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.10",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
+dependencies = [
+ "der 0.8.1",
+ "pkcs5",
+ "rand_core 0.10.1",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -3436,6 +4137,28 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "poly1305"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2d0073b297041425c7c3df6eb4792d598a15323fe63346852b092eca02904c"
+dependencies = [
+ "cpufeatures 0.3.0",
+ "universal-hash",
+ "zeroize",
+]
+
+[[package]]
+name = "polyval"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0fa31d631f2b2cb2a544d0aa321ce847a94764d701ca2becc411138b93d49cd"
+dependencies = [
+ "cpubits",
+ "cpufeatures 0.3.0",
+ "universal-hash",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -3518,12 +4241,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "primefield"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c555a6e4eb7d4e158fcb028c835c3b8642206ddc279b5c6b202ef9a8bdb592f4"
+dependencies = [
+ "crypto-bigint 0.7.5",
+ "crypto-common 0.2.2",
+ "ff 0.14.0",
+ "rand_core 0.10.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
- "elliptic-curve",
+ "elliptic-curve 0.13.8",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c9f42978c78a00e3d68f69fc03e57a234debae69da4020a4fb588fcdcd07b06"
+dependencies = [
+ "elliptic-curve 0.14.1",
+ "once_cell",
+ "primefield",
+ "serdect",
+ "wnaf",
 ]
 
 [[package]]
@@ -3927,6 +4677,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3963,6 +4724,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_xorshift"
@@ -4160,8 +4927,18 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a459cddafb3fe76b31fd8f1108007566c40301feb64dc7b54656eb7388172b"
+dependencies = [
+ "crypto-bigint 0.7.5",
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -4195,17 +4972,36 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
- "pkcs1",
- "pkcs8",
+ "pkcs1 0.7.5",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
- "signature",
- "spki",
+ "signature 2.2.0",
+ "spki 0.7.3",
  "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rsa"
+version = "0.10.0-rc.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b2aa4ba0d89f73d1e332df05be0eeab8840351c36ca5654341dfdb57bb3caf"
+dependencies = [
+ "const-oid 0.10.2",
+ "crypto-bigint 0.7.5",
+ "crypto-primes",
+ "digest 0.11.3",
+ "pkcs1 0.8.0-rc.4",
+ "pkcs8 0.11.0",
+ "rand_core 0.10.1",
+ "sha2 0.11.0",
+ "signature 3.0.0",
+ "spki 0.8.0",
  "zeroize",
 ]
 
@@ -4290,6 +5086,122 @@ dependencies = [
  "libsqlite3-sys",
  "smallvec",
  "sqlite-wasm-rs",
+]
+
+[[package]]
+name = "russh"
+version = "0.62.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8b67b5a0d8068c89dcbe9d95df986af7a851d1f3c604525274c37468e60464f"
+dependencies = [
+ "aes",
+ "bitflags 2.11.1",
+ "block-padding",
+ "byteorder",
+ "bytes",
+ "cbc",
+ "cipher",
+ "crypto-bigint 0.7.5",
+ "ctr",
+ "curve25519-dalek 5.0.0",
+ "data-encoding",
+ "delegate",
+ "der 0.8.1",
+ "digest 0.11.3",
+ "ecdsa 0.17.0",
+ "ed25519-dalek 3.0.0",
+ "elliptic-curve 0.14.1",
+ "enum_dispatch",
+ "flate2",
+ "futures",
+ "generic-array 1.4.2",
+ "getrandom 0.4.2",
+ "ghash",
+ "hex-literal",
+ "hmac 0.13.0",
+ "inout",
+ "internal-russh-num-bigint",
+ "keccak",
+ "log",
+ "md5",
+ "ml-kem",
+ "module-lattice",
+ "num-bigint",
+ "p256 0.14.0",
+ "p384 0.14.0",
+ "p521",
+ "pageant",
+ "pbkdf2",
+ "pkcs1 0.8.0-rc.4",
+ "pkcs5",
+ "pkcs8 0.11.0",
+ "polyval",
+ "rand 0.10.2",
+ "rand_core 0.10.1",
+ "ring",
+ "rsa 0.10.0-rc.18",
+ "russh-cryptovec",
+ "russh-util",
+ "salsa20",
+ "scrypt",
+ "sec1 0.8.1",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
+ "sha3 0.12.0",
+ "signature 3.0.0",
+ "spki 0.8.0",
+ "ssh-encoding",
+ "ssh-key",
+ "subtle",
+ "thiserror 2.0.18",
+ "tokio",
+ "typenum",
+ "universal-hash",
+ "zeroize",
+]
+
+[[package]]
+name = "russh-cryptovec"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3aec6cb630dbe85d72ffd7bcd95f07e1bd69f9f270ee8adfa1afe443a6331438"
+dependencies = [
+ "log",
+ "nix 0.31.2",
+ "ssh-encoding",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "russh-sftp"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed8949eca4163c18a8f59ff96d32cf61e9c13b9735e21ef32b3907f4aafa1a9"
+dependencies = [
+ "bitflags 2.11.1",
+ "bytes",
+ "chrono",
+ "dashmap",
+ "gloo-timers",
+ "log",
+ "serde",
+ "serde_bytes",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "russh-util"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668424a5dde0bcb45b55ba7de8476b93831b4aa2fa6947e145f3b053e22c60b6"
+dependencies = [
+ "chrono",
+ "tokio",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -4429,6 +5341,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "salsa20"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f874456e72520ff1375a06c588eaf074b0f01f9e9e1aada45bd9b7954a6e42c"
+dependencies = [
+ "cfg-if",
+ "cipher",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4483,15 +5405,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scrypt"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87af57419b594aa23fa95f09f0e06d80d84ba01c26148c43844cad6ff4485f0"
+dependencies = [
+ "cfg-if",
+ "pbkdf2",
+ "salsa20",
+ "sha2 0.11.0",
+]
+
+[[package]]
 name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct",
- "der",
- "generic-array",
- "pkcs8",
+ "base16ct 0.2.0",
+ "der 0.7.10",
+ "generic-array 0.14.7",
+ "pkcs8 0.10.2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
+dependencies = [
+ "base16ct 1.0.0",
+ "ctutils",
+ "der 0.8.1",
+ "hybrid-array",
  "subtle",
  "zeroize",
 ]
@@ -4564,6 +5512,16 @@ checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
  "ordered-float",
  "serde",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -4695,14 +5653,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "serdect"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
+dependencies = [
+ "base16ct 1.0.0",
+ "serde",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4712,8 +5691,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest 0.11.3",
+ "keccak",
+]
+
+[[package]]
+name = "sha3"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc9bad02c26382724b2d2692c6f179285e4b54eeecd7968f52a50059c3c11759"
+dependencies = [
+ "digest 0.11.3",
+ "keccak",
+ "sponge-cursor",
 ]
 
 [[package]]
@@ -4763,8 +5774,18 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "signature"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
+dependencies = [
+ "digest 0.11.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4844,8 +5865,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
 ]
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der 0.8.1",
+]
+
+[[package]]
+name = "sponge-cursor"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620"
 
 [[package]]
 name = "sqlite-wasm-rs"
@@ -4857,6 +5894,65 @@ dependencies = [
  "js-sys",
  "rsqlite-vfs",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "ssh-cipher"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d801accda99469cde6d73da741422610fdf6508a72d9a69d1b55cb241c720597"
+dependencies = [
+ "aead",
+ "aes",
+ "aes-gcm",
+ "chacha20",
+ "cipher",
+ "ctutils",
+ "des",
+ "poly1305",
+ "ssh-encoding",
+ "zeroize",
+]
+
+[[package]]
+name = "ssh-encoding"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b54d0ed0498daf3f78d82e00e28c8eec9d75a067c4cfbcc7a0f7d0f4077749e"
+dependencies = [
+ "base64ct",
+ "bytes",
+ "crypto-bigint 0.7.5",
+ "ctutils",
+ "digest 0.11.3",
+ "pem-rfc7468 1.0.0",
+ "zeroize",
+]
+
+[[package]]
+name = "ssh-key"
+version = "0.7.0-rc.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9a32fae177b74a22aa9c5b01bf7e68b33545be32d9e381e248058d2adc15ce3"
+dependencies = [
+ "argon2",
+ "bcrypt-pbkdf",
+ "ctutils",
+ "ed25519-dalek 3.0.0",
+ "hex",
+ "hmac 0.13.0",
+ "p256 0.14.0",
+ "p384 0.14.0",
+ "p521",
+ "rand_core 0.10.1",
+ "rsa 0.10.0-rc.18",
+ "sec1 0.8.1",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
+ "signature 3.0.0",
+ "ssh-cipher",
+ "ssh-encoding",
+ "zeroize",
 ]
 
 [[package]]
@@ -5267,6 +6363,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]
@@ -5608,7 +6705,7 @@ dependencies = [
  "rand 0.8.6",
  "rustls",
  "rustls-pki-types",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 1.0.69",
  "utf-8",
 ]
@@ -5625,7 +6722,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.4",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 2.0.18",
 ]
 
@@ -5695,6 +6792,16 @@ name = "unindent"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
+
+[[package]]
+name = "universal-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
+dependencies = [
+ "crypto-common 0.2.2",
+ "ctutils",
+]
 
 [[package]]
 name = "unsafe-libyaml"
@@ -5871,9 +6978,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5884,9 +6991,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.70"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5894,9 +7001,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5904,9 +7011,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5917,9 +7024,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
@@ -5973,9 +7080,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.97"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6541,6 +7648,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "wnaf"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab12e7090f27e2ffd9322651492942d50c2926094af30601e1964337db39daf1"
+dependencies = [
+ "ff 0.14.0",
+ "group 0.14.0",
+ "hybrid-array",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6631,9 +7749,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/make/test.mk
+++ b/make/test.mk
@@ -208,8 +208,10 @@ test\:unit\:rust:
 
 # Guest crate unit tests. Linux-only (the crate does not build elsewhere) and
 # excluded from test:unit:rust because the zygote suite forks real processes.
-# Runs the pure-logic modules, which is where capability resolution and OCI
-# spec construction live — otherwise nothing exercises them.
+# nextest's process-per-test isolation is what makes the whole crate runnable:
+# several suites assert on process-global state (raw fd numbers, waitpid), so
+# they can interfere under a shared process. The cargo fallback has no such
+# isolation, so it stays on the two modules that are pure logic.
 test\:unit\:guest:
 	@if [ "$$(uname)" != "Linux" ]; then \
 		echo "⏭️  Guest unit tests require Linux"; \
@@ -217,7 +219,7 @@ test\:unit\:guest:
 	fi; \
 	echo "🧪 Running guest unit tests..."; \
 	if command -v cargo-nextest >/dev/null 2>&1; then \
-		cargo nextest run --no-tests=fail -p boxlite-guest -E 'test(~capabilit) + test(~spec::tests)'; \
+		cargo nextest run --no-tests=fail -p boxlite-guest; \
 	else \
 		cargo test -p boxlite-guest --bins -- --test-threads=1 capabilit spec::tests; \
 	fi

--- a/src/boxlite/src/portal/interfaces/exec.rs
+++ b/src/boxlite/src/portal/interfaces/exec.rs
@@ -169,6 +169,9 @@ impl ExecutionInterface {
         let request = KillRequest {
             execution_id: execution_id.to_string(),
             signal,
+            // Host signals address the execution's leader; process-group
+            // teardown is an in-guest policy (see the SSH bridge).
+            process_group: false,
         };
 
         let response = self.client.kill(request).await?.into_inner();
@@ -272,6 +275,8 @@ impl ExecProtocol {
                     cols,
                     x_pixels: 0,
                     y_pixels: 0,
+                    // The host CLI sends no RFC 4254 modes; SSH sessions do.
+                    modes: Vec::new(),
                 })
             } else {
                 None

--- a/src/boxlite/tests/resize_tty.rs
+++ b/src/boxlite/tests/resize_tty.rs
@@ -1,0 +1,68 @@
+//! `resize_tty` must reach the guest PTY, not merely return success.
+//!
+//! kill/signal already have host coverage in the Node and Python SDK suites,
+//! and `zygote_integration` covers stdin. Resize is the gap: every existing
+//! test asserts only that the call returned, so a resize that never reaches
+//! the terminal would pass all of them.
+
+mod common;
+
+use std::time::Duration;
+
+use boxlite::BoxCommand;
+use tokio_stream::StreamExt;
+
+/// `resize_tty` changes the window the process actually sees.
+#[tokio::test]
+async fn resize_tty_changes_the_window_the_process_sees() {
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = boxlite::BoxliteRuntime::new(boxlite::runtime::options::BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+    let handle = runtime.create(common::alpine_opts(), None).await.unwrap();
+    handle.start().await.unwrap();
+
+    // The shell announces it is ready, then blocks on stdin. That handshake is
+    // what orders the resize before `stty` runs — a sleep would race exec setup
+    // on a cold pull or a loaded machine.
+    let mut execution = handle
+        .exec(
+            BoxCommand::new("sh")
+                .args(["-c", "echo ready; read _ack; stty size"])
+                .tty(true),
+        )
+        .await
+        .expect("exec failed");
+
+    let mut stream = execution.stdout().expect("stdout should be available once");
+    let mut stdout = String::new();
+    while !stdout.contains("ready") {
+        let chunk = tokio::time::timeout(Duration::from_secs(30), stream.next())
+            .await
+            .expect("shell should announce readiness")
+            .expect("stdout closed before the shell was ready");
+        stdout.push_str(&chunk);
+    }
+
+    execution.resize_tty(40, 100).await.expect("resize failed");
+
+    let mut stdin = execution.stdin().expect("stdin should be available once");
+    stdin.write_all(b"\n").await.expect("stdin write failed");
+    stdin.close();
+
+    while let Some(chunk) = stream.next().await {
+        stdout.push_str(&chunk);
+    }
+    let _ = tokio::time::timeout(Duration::from_secs(30), execution.wait()).await;
+
+    assert!(
+        stdout.contains("40 100"),
+        "resize did not reach the guest pty, stty reported: {stdout:?}"
+    );
+
+    handle.stop().await.unwrap();
+    let _ = runtime.remove(handle.id().as_str(), true).await;
+    let _ = runtime.shutdown(Some(common::TEST_SHUTDOWN_TIMEOUT)).await;
+}

--- a/src/boxlite/tests/security_enforcement.rs
+++ b/src/boxlite/tests/security_enforcement.rs
@@ -100,6 +100,8 @@ async fn virtiofs_readonly_and_capabilities() {
     readonly_volume_blocks_write(&bx).await;
     readonly_volume_blocks_remount(&bx).await;
     rw_volume_allows_write(&bx).await;
+    guest_root_is_sealed_read_only(&bx).await;
+    sealed_root_leaves_container_rootfs_writable(&bx).await;
     capabilities_exclude_sys_admin(&bx).await;
     capabilities_match_docker_defaults(&bx).await;
 
@@ -146,6 +148,49 @@ async fn readonly_volume_blocks_remount(bx: &LiteBox) {
             || output.contains("Read-only"),
         "error should indicate permission/readonly denial, got: {output}"
     );
+}
+
+/// Run a shell script on the guest VM itself rather than inside the container.
+///
+/// `LiteBox::exec` only injects the container executor when the caller has not
+/// already chosen one, so setting it here reaches the guest's own mount
+/// namespace — the only vantage point from which the guest root is visible.
+fn guest_sh(script: &str) -> BoxCommand {
+    BoxCommand::new("sh")
+        .args(["-c", script])
+        .env("BOXLITE_EXECUTOR", "guest")
+}
+
+/// The guest agent remounts its own root read-only at boot
+/// (`mounts::seal_root_readonly`). That is what stops a container process from
+/// reopening the agent binary through the `/proc/<pid>/exe` a forked-not-exec'd
+/// SSH workload leaves behind, so the guest root must reject writes.
+async fn guest_root_is_sealed_read_only(bx: &LiteBox) {
+    // Positive control: /tmp is tmpfs, so a failure below is the seal and not a
+    // broken guest-executor path.
+    let writable = exec_exit_code(bx, guest_sh("echo probe > /tmp/boxlite-seal-probe")).await;
+    assert_eq!(writable, 0, "guest tmpfs should still accept writes");
+
+    // Assert on the file, not on the shell's exit code: a full guest rootfs
+    // fails the write with ENOSPC after `creat` has already made the entry, so
+    // a non-zero exit does not distinguish a sealed root from a full one.
+    let _ = exec_exit_code(bx, guest_sh("echo probe > /boxlite-seal-probe 2>&1")).await;
+    let exists = exec_exit_code(bx, guest_sh("test -e /boxlite-seal-probe")).await;
+    assert_ne!(exists, 0, "probe file should not exist on the sealed root");
+}
+
+/// The seal covers the guest's root superblock only. Container rootfs writes
+/// outside the tmpfs mounts must keep working.
+async fn sealed_root_leaves_container_rootfs_writable(bx: &LiteBox) {
+    let exit = exec_exit_code(
+        bx,
+        BoxCommand::new("sh").args(["-c", "echo ok > /usr/boxlite-seal-probe 2>&1"]),
+    )
+    .await;
+    assert_eq!(exit, 0, "container rootfs should stay writable");
+
+    let content = exec_stdout(bx, BoxCommand::new("cat").arg("/usr/boxlite-seal-probe")).await;
+    assert_eq!(content.trim(), "ok");
 }
 
 /// Sanity check: writable volume does accept writes.

--- a/src/guest/Cargo.toml
+++ b/src/guest/Cargo.toml
@@ -20,7 +20,7 @@ base64 = "0.22"
 bytes = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-nix = { version = "0.29", features = ["mount", "process", "fs", "sched", "socket", "poll"] }
+nix = { version = "0.29", features = ["mount", "process", "fs", "sched", "socket", "poll", "user"] }
 async-trait = "0.1"
 uuid = { version = "1.10", features = ["v4"] }
 tonic = "0.12"

--- a/src/guest/Cargo.toml
+++ b/src/guest/Cargo.toml
@@ -13,10 +13,11 @@ path = "src/main.rs"
 
 [dependencies]
 boxlite-shared.workspace = true
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "io-util", "net", "fs", "time", "signal"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "io-util", "net", "fs", "time", "signal", "process"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 base64 = "0.22"
+bytes = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 nix = { version = "0.29", features = ["mount", "process", "fs", "sched", "socket", "poll"] }
@@ -29,6 +30,8 @@ async-stream = "0.3"
 clap = { version = "4.5", features = ["derive"] }
 rayon = "1.10"
 tar = "0.4"
+russh = { version = "0.62.4", default-features = false, features = ["ring", "flate2", "rsa"] }
+russh-sftp = "2.3.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = "0.18.0"

--- a/src/guest/src/container/command.rs
+++ b/src/guest/src/container/command.rs
@@ -69,6 +69,10 @@ pub struct ContainerCommand {
 
     /// PTY configuration (set via with_pty())
     pty_config: Option<PtyConfig>,
+
+    /// Trusted in-process workload selection. Public exec arguments never set
+    /// this field, even if argv[0] matches the internal placeholder.
+    ssh_workload: Option<crate::service::ssh::SshWorkload>,
 }
 
 impl ContainerCommand {
@@ -95,6 +99,7 @@ impl ContainerCommand {
             cwd: None,
             console_socket: None,
             pty_config: None,
+            ssh_workload: None,
             id,
             state_root,
         }
@@ -116,6 +121,14 @@ impl ContainerCommand {
     /// Resolved at spawn time from the container's /etc/passwd.
     pub fn with_user(mut self, user: String) -> Self {
         self.user_override = Some(user);
+        self
+    }
+
+    pub(crate) fn with_ssh_workload(mut self, workload: crate::service::ssh::SshWorkload) -> Self {
+        let (program, args) = workload.placeholder();
+        self.program = Some(program);
+        self.args = args;
+        self.ssh_workload = Some(workload);
         self
     }
 
@@ -366,6 +379,16 @@ impl ContainerCommand {
         let program = self.program.clone().unwrap_or_default();
         let mut container_args = vec![program.clone()];
         container_args.extend_from_slice(self.args.as_slice());
+        let ssh_workload = self.ssh_workload.clone();
+        if self.console_socket.is_some()
+            && ssh_workload
+                .as_ref()
+                .is_some_and(|workload| !workload.supports_pty())
+        {
+            return Err(BoxliteError::Config(
+                "this internal SSH workload does not support a PTY".into(),
+            ));
+        }
 
         let (uid, gid) = self.resolve_exec_user()?;
 
@@ -390,6 +413,7 @@ impl ContainerCommand {
             cwd: self.cwd.clone().unwrap_or_else(|| "/".to_string()).into(),
             env: self.env.clone(),
             args: container_args.clone(),
+            ssh_workload,
             uid,
             gid,
             capabilities: self.capabilities.clone(),
@@ -487,6 +511,7 @@ pub(crate) fn create_pty_child(
     config: PtyConfig,
 ) -> BoxliteResult<ExecHandle> {
     set_pty_window_size(&pty_master, &config)?;
+    crate::service::exec::tty::apply_modes(&pty_master, &config.modes)?;
     let (stdin, stdout) = reconcile_pty_fds(&pty_master)?;
 
     // PTY mode: stderr is None (merged into stdout)
@@ -638,6 +663,7 @@ mod tests {
             cols: 80,
             x_pixels: 0,
             y_pixels: 0,
+            modes: Vec::new(),
         };
         let cmd = make_cmd().with_pty(config);
         let pty = cmd.pty_config.unwrap();
@@ -661,6 +687,27 @@ mod tests {
         assert_eq!(cmd.env.get("BAZ"), Some(&"qux".to_string()));
         assert_eq!(cmd.cwd, Some("/tmp".to_string()));
         assert_eq!(cmd.user_override, Some("nobody".to_string()));
+    }
+
+    #[test]
+    fn public_command_arguments_do_not_select_the_ssh_executor() {
+        let (program, args) = crate::service::ssh::SshWorkload::Sftp.placeholder();
+        let cmd = make_cmd().program(program).args(args);
+
+        assert_eq!(cmd.ssh_workload, None);
+    }
+
+    #[test]
+    fn trusted_ssh_workload_sets_typed_state_and_placeholder() {
+        let workload = crate::service::ssh::SshWorkload::DirectStreamlocal {
+            socket_path: "/run/service.sock".into(),
+        };
+        let (expected_program, expected_args) = workload.placeholder();
+        let cmd = make_cmd().with_ssh_workload(workload.clone());
+
+        assert_eq!(cmd.ssh_workload, Some(workload));
+        assert_eq!(cmd.program, Some(expected_program));
+        assert_eq!(cmd.args, expected_args);
     }
 
     // ========================================================================

--- a/src/guest/src/container/lifecycle.rs
+++ b/src/guest/src/container/lifecycle.rs
@@ -29,6 +29,7 @@ const DEFAULT_INIT_PTY: PtyConfig = PtyConfig {
     cols: 80,
     x_pixels: 0,
     y_pixels: 0,
+    modes: Vec::new(),
 };
 
 /// OCI container
@@ -74,6 +75,12 @@ pub struct Container {
 }
 
 impl Container {
+    /// Resolve the root account's home and login shell from this container's
+    /// mounted rootfs. Invalid or unavailable fields use conservative defaults.
+    pub(crate) fn root_session_profile(&self) -> super::user_profile::RootSessionProfile {
+        super::user_profile::root_session_profile(&self.bundle_path.join("rootfs"))
+    }
+
     /// Create and start an OCI container
     ///
     /// Creates a container with the specified rootfs and starts the init process.

--- a/src/guest/src/container/lifecycle.rs
+++ b/src/guest/src/container/lifecycle.rs
@@ -75,12 +75,6 @@ pub struct Container {
 }
 
 impl Container {
-    /// Resolve the root account's home and login shell from this container's
-    /// mounted rootfs. Invalid or unavailable fields use conservative defaults.
-    pub(crate) fn root_session_profile(&self) -> super::user_profile::RootSessionProfile {
-        super::user_profile::root_session_profile(&self.bundle_path.join("rootfs"))
-    }
-
     /// Create and start an OCI container
     ///
     /// Creates a container with the specified rootfs and starts the init process.

--- a/src/guest/src/container/mod.rs
+++ b/src/guest/src/container/mod.rs
@@ -74,6 +74,8 @@ mod start;
 #[cfg(target_os = "linux")]
 mod stdio;
 #[cfg(target_os = "linux")]
+pub(crate) mod user_profile;
+#[cfg(target_os = "linux")]
 pub(crate) mod zygote;
 
 #[cfg(target_os = "linux")]

--- a/src/guest/src/container/user_profile.rs
+++ b/src/guest/src/container/user_profile.rs
@@ -1,0 +1,272 @@
+//! Container user profile resolution for login-style sessions.
+
+use std::collections::VecDeque;
+use std::ffi::OsString;
+use std::fs;
+use std::io::Read as _;
+use std::os::unix::fs::PermissionsExt as _;
+use std::path::{Component, Path, PathBuf};
+
+const MAX_PASSWD_BYTES: u64 = 1024 * 1024;
+const FALLBACK_SHELLS: [&str; 6] = [
+    "/bin/bash",
+    "/bin/ash",
+    "/bin/sh",
+    "/usr/bin/bash",
+    "/usr/bin/ash",
+    "/usr/bin/sh",
+];
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct RootSessionProfile {
+    pub(crate) home_dir: String,
+    pub(crate) login_shell: String,
+}
+
+/// Resolve root's login profile relative to a container root filesystem.
+///
+/// Both returned values are container paths. A missing, malformed, or unusable
+/// passwd home falls back to `/`; an unusable passwd shell falls through a
+/// fixed list of common absolute shell paths. Resolution never follows a
+/// container symlink outside `rootfs` in the guest mount namespace.
+pub(crate) fn root_session_profile(rootfs: &Path) -> RootSessionProfile {
+    let passwd = read_passwd(rootfs);
+    let configured = passwd.as_deref().and_then(root_fields);
+    let home_dir = configured
+        .and_then(|(home, _)| usable_directory(rootfs, home).then_some(home))
+        .unwrap_or("/")
+        .to_string();
+    let login_shell = configured
+        .and_then(|(_, shell)| usable_executable(rootfs, shell).then_some(shell))
+        .or_else(|| {
+            FALLBACK_SHELLS
+                .into_iter()
+                .find(|shell| usable_executable(rootfs, shell))
+        })
+        // Preserve the conventional failure mode when an image has no shell:
+        // exec reports `/bin/sh` missing instead of inventing a guest path.
+        .unwrap_or("/bin/sh")
+        .to_string();
+
+    RootSessionProfile {
+        home_dir,
+        login_shell,
+    }
+}
+
+fn read_passwd(rootfs: &Path) -> Option<String> {
+    let passwd = safely_resolved(rootfs, "/etc/passwd")?;
+    let mut file = fs::File::open(passwd).ok()?;
+    let mut bytes = Vec::new();
+    file.by_ref()
+        .take(MAX_PASSWD_BYTES + 1)
+        .read_to_end(&mut bytes)
+        .ok()?;
+    if bytes.len() as u64 > MAX_PASSWD_BYTES {
+        return None;
+    }
+    String::from_utf8(bytes).ok()
+}
+
+fn root_fields(passwd: &str) -> Option<(&str, &str)> {
+    passwd.lines().find_map(|line| {
+        let mut fields = line.split(':');
+        let name = fields.next()?;
+        let _password = fields.next()?;
+        let _uid = fields.next()?;
+        let _gid = fields.next()?;
+        let _gecos = fields.next()?;
+        let home = fields.next()?;
+        let shell = fields.next()?;
+        (name == "root").then_some((home, shell))
+    })
+}
+
+fn usable_directory(rootfs: &Path, container_path: &str) -> bool {
+    safely_resolved(rootfs, container_path).is_some_and(|path| path.is_dir())
+}
+
+fn usable_executable(rootfs: &Path, container_path: &str) -> bool {
+    safely_resolved(rootfs, container_path).is_some_and(|path| {
+        fs::metadata(path)
+            .is_ok_and(|metadata| metadata.is_file() && metadata.permissions().mode() & 0o111 != 0)
+    })
+}
+
+fn safely_resolved(rootfs: &Path, container_path: &str) -> Option<PathBuf> {
+    let container_path = Path::new(container_path);
+    if !container_path.is_absolute()
+        || container_path
+            .components()
+            .any(|component| !matches!(component, Component::RootDir | Component::Normal(_)))
+    {
+        return None;
+    }
+    let rootfs = fs::canonicalize(rootfs).ok()?;
+    let mut pending = owned_components(container_path.strip_prefix("/").ok()?);
+    let mut relative = PathBuf::new();
+    let mut followed_symlinks = 0_u8;
+
+    while let Some(component) = pending.pop_front() {
+        match component {
+            OwnedComponent::Current => {}
+            OwnedComponent::Parent => {
+                // A chroot clamps `..` at its root; mirror that behavior while
+                // resolving against the guest-visible rootfs tree.
+                relative.pop();
+            }
+            OwnedComponent::Normal(name) => {
+                let candidate = rootfs.join(&relative).join(&name);
+                let metadata = fs::symlink_metadata(&candidate).ok()?;
+                if metadata.file_type().is_symlink() {
+                    followed_symlinks = followed_symlinks.checked_add(1)?;
+                    if followed_symlinks > 40 {
+                        return None;
+                    }
+                    let target = fs::read_link(candidate).ok()?;
+                    if target.is_absolute() {
+                        relative.clear();
+                    }
+                    let mut target_components = owned_components(&target);
+                    target_components.append(&mut pending);
+                    pending = target_components;
+                } else {
+                    relative.push(name);
+                }
+            }
+        }
+    }
+
+    Some(rootfs.join(relative))
+}
+
+enum OwnedComponent {
+    Current,
+    Parent,
+    Normal(OsString),
+}
+
+fn owned_components(path: &Path) -> VecDeque<OwnedComponent> {
+    path.components()
+        .filter_map(|component| match component {
+            Component::RootDir => None,
+            Component::CurDir => Some(OwnedComponent::Current),
+            Component::ParentDir => Some(OwnedComponent::Parent),
+            Component::Normal(name) => Some(OwnedComponent::Normal(name.to_os_string())),
+            Component::Prefix(_) => None,
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_executable(path: &Path) {
+        fs::write(path, "#!/bin/sh\n").unwrap();
+        let mut permissions = fs::metadata(path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(path, permissions).unwrap();
+    }
+
+    #[test]
+    fn configured_root_home_and_executable_shell_are_selected() {
+        let rootfs = tempfile::tempdir().unwrap();
+        fs::create_dir_all(rootfs.path().join("etc")).unwrap();
+        fs::create_dir_all(rootfs.path().join("home/root")).unwrap();
+        fs::create_dir_all(rootfs.path().join("opt/bin")).unwrap();
+        write_executable(&rootfs.path().join("opt/bin/zsh"));
+        fs::write(
+            rootfs.path().join("etc/passwd"),
+            "root:x:0:0:root:/home/root:/opt/bin/zsh\n",
+        )
+        .unwrap();
+
+        assert_eq!(
+            root_session_profile(rootfs.path()),
+            RootSessionProfile {
+                home_dir: "/home/root".into(),
+                login_shell: "/opt/bin/zsh".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn missing_home_and_unusable_shell_use_safe_fallbacks() {
+        let rootfs = tempfile::tempdir().unwrap();
+        fs::create_dir_all(rootfs.path().join("etc")).unwrap();
+        fs::create_dir_all(rootfs.path().join("bin")).unwrap();
+        write_executable(&rootfs.path().join("bin/ash"));
+        fs::write(
+            rootfs.path().join("etc/passwd"),
+            "root:x:0:0:root:/missing:/missing/shell\n",
+        )
+        .unwrap();
+
+        assert_eq!(
+            root_session_profile(rootfs.path()),
+            RootSessionProfile {
+                home_dir: "/".into(),
+                login_shell: "/bin/ash".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn absolute_symlink_cannot_escape_the_container_rootfs() {
+        use std::os::unix::fs::symlink;
+
+        let rootfs = tempfile::tempdir().unwrap();
+        fs::create_dir_all(rootfs.path().join("etc")).unwrap();
+        fs::create_dir_all(rootfs.path().join("bin")).unwrap();
+        write_executable(&rootfs.path().join("bin/sh"));
+        symlink("/tmp", rootfs.path().join("escape")).unwrap();
+        fs::write(
+            rootfs.path().join("etc/passwd"),
+            "root:x:0:0:root:/escape:/escape/sh\n",
+        )
+        .unwrap();
+
+        let profile = root_session_profile(rootfs.path());
+        assert_eq!(profile.home_dir, "/");
+        assert_eq!(profile.login_shell, "/bin/sh");
+    }
+
+    #[test]
+    fn absolute_shell_symlink_is_resolved_from_the_container_root() {
+        use std::os::unix::fs::symlink;
+
+        let rootfs = tempfile::tempdir().unwrap();
+        fs::create_dir_all(rootfs.path().join("etc")).unwrap();
+        fs::create_dir_all(rootfs.path().join("bin")).unwrap();
+        fs::create_dir_all(rootfs.path().join("usr/bin")).unwrap();
+        write_executable(&rootfs.path().join("usr/bin/ash"));
+        symlink("/usr/bin/ash", rootfs.path().join("bin/sh")).unwrap();
+        fs::write(
+            rootfs.path().join("etc/passwd"),
+            "root:x:0:0:root:/:/bin/sh\n",
+        )
+        .unwrap();
+
+        assert_eq!(root_session_profile(rootfs.path()).login_shell, "/bin/sh");
+    }
+
+    #[test]
+    fn symlink_loop_is_rejected_and_uses_a_fallback_shell() {
+        use std::os::unix::fs::symlink;
+
+        let rootfs = tempfile::tempdir().unwrap();
+        fs::create_dir_all(rootfs.path().join("etc")).unwrap();
+        fs::create_dir_all(rootfs.path().join("bin")).unwrap();
+        write_executable(&rootfs.path().join("bin/ash"));
+        symlink("/loop-b", rootfs.path().join("loop-a")).unwrap();
+        symlink("/loop-a", rootfs.path().join("loop-b")).unwrap();
+        fs::write(
+            rootfs.path().join("etc/passwd"),
+            "root:x:0:0:root:/:/loop-a\n",
+        )
+        .unwrap();
+
+        assert_eq!(root_session_profile(rootfs.path()).login_shell, "/bin/ash");
+    }
+}

--- a/src/guest/src/container/user_profile.rs
+++ b/src/guest/src/container/user_profile.rs
@@ -1,21 +1,10 @@
 //! Container user profile resolution for login-style sessions.
 
-use std::collections::VecDeque;
-use std::ffi::OsString;
-use std::fs;
-use std::io::Read as _;
-use std::os::unix::fs::PermissionsExt as _;
-use std::path::{Component, Path, PathBuf};
+use nix::unistd::{Uid, User};
 
-const MAX_PASSWD_BYTES: u64 = 1024 * 1024;
-const FALLBACK_SHELLS: [&str; 6] = [
-    "/bin/bash",
-    "/bin/ash",
-    "/bin/sh",
-    "/usr/bin/bash",
-    "/usr/bin/ash",
-    "/usr/bin/sh",
-];
+/// OpenSSH substitutes `_PATH_BSHELL` when a passwd entry carries no shell
+/// (`session.c`, `do_child`); this is that path on Linux.
+const DEFAULT_SHELL: &str = "/bin/sh";
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct RootSessionProfile {
@@ -23,167 +12,44 @@ pub(crate) struct RootSessionProfile {
     pub(crate) login_shell: String,
 }
 
-/// Resolve root's login profile relative to a container root filesystem.
+/// Resolve root's login profile from the passwd database.
 ///
-/// Both returned values are container paths. A missing, malformed, or unusable
-/// passwd home falls back to `/`; an unusable passwd shell falls through a
-/// fixed list of common absolute shell paths. Resolution never follows a
-/// container symlink outside `rootfs` in the guest mount namespace.
-pub(crate) fn root_session_profile(rootfs: &Path) -> RootSessionProfile {
-    let passwd = read_passwd(rootfs);
-    let configured = passwd.as_deref().and_then(root_fields);
-    let home_dir = configured
-        .and_then(|(home, _)| usable_directory(rootfs, home).then_some(home))
-        .unwrap_or("/")
-        .to_string();
-    let login_shell = configured
-        .and_then(|(_, shell)| usable_executable(rootfs, shell).then_some(shell))
-        .or_else(|| {
-            FALLBACK_SHELLS
-                .into_iter()
-                .find(|shell| usable_executable(rootfs, shell))
-        })
-        // Preserve the conventional failure mode when an image has no shell:
-        // exec reports `/bin/sh` missing instead of inventing a guest path.
-        .unwrap_or("/bin/sh")
-        .to_string();
+/// `getpwuid_r` reads the passwd file of the *calling* process's mount
+/// namespace, so this is only meaningful once the container has been entered.
+/// It is the same lookup libcontainer uses to seed `HOME` (`utils::get_user_home`).
+///
+/// The passwd shell is used verbatim and only an absent or empty field falls
+/// back to `/bin/sh`, matching OpenSSH. An image carrying no passwd entry for
+/// root has no OpenSSH analogue — sshd refuses the login — so the same default
+/// stands in rather than failing a session the box exists to serve.
+pub(crate) fn root_session_profile() -> RootSessionProfile {
+    let root = User::from_uid(Uid::from_raw(0)).ok().flatten();
+    profile_from_passwd(
+        root.as_ref().and_then(|user| user.dir.to_str()),
+        root.as_ref().and_then(|user| user.shell.to_str()),
+    )
+}
 
+fn profile_from_passwd(dir: Option<&str>, shell: Option<&str>) -> RootSessionProfile {
     RootSessionProfile {
-        home_dir,
-        login_shell,
+        home_dir: non_empty(dir).unwrap_or("/").to_string(),
+        login_shell: non_empty(shell).unwrap_or(DEFAULT_SHELL).to_string(),
     }
 }
 
-fn read_passwd(rootfs: &Path) -> Option<String> {
-    let passwd = safely_resolved(rootfs, "/etc/passwd")?;
-    let mut file = fs::File::open(passwd).ok()?;
-    let mut bytes = Vec::new();
-    file.by_ref()
-        .take(MAX_PASSWD_BYTES + 1)
-        .read_to_end(&mut bytes)
-        .ok()?;
-    if bytes.len() as u64 > MAX_PASSWD_BYTES {
-        return None;
-    }
-    String::from_utf8(bytes).ok()
-}
-
-fn root_fields(passwd: &str) -> Option<(&str, &str)> {
-    passwd.lines().find_map(|line| {
-        let mut fields = line.split(':');
-        let name = fields.next()?;
-        let _password = fields.next()?;
-        let _uid = fields.next()?;
-        let _gid = fields.next()?;
-        let _gecos = fields.next()?;
-        let home = fields.next()?;
-        let shell = fields.next()?;
-        (name == "root").then_some((home, shell))
-    })
-}
-
-fn usable_directory(rootfs: &Path, container_path: &str) -> bool {
-    safely_resolved(rootfs, container_path).is_some_and(|path| path.is_dir())
-}
-
-fn usable_executable(rootfs: &Path, container_path: &str) -> bool {
-    safely_resolved(rootfs, container_path).is_some_and(|path| {
-        fs::metadata(path)
-            .is_ok_and(|metadata| metadata.is_file() && metadata.permissions().mode() & 0o111 != 0)
-    })
-}
-
-fn safely_resolved(rootfs: &Path, container_path: &str) -> Option<PathBuf> {
-    let container_path = Path::new(container_path);
-    if !container_path.is_absolute()
-        || container_path
-            .components()
-            .any(|component| !matches!(component, Component::RootDir | Component::Normal(_)))
-    {
-        return None;
-    }
-    let rootfs = fs::canonicalize(rootfs).ok()?;
-    let mut pending = owned_components(container_path.strip_prefix("/").ok()?);
-    let mut relative = PathBuf::new();
-    let mut followed_symlinks = 0_u8;
-
-    while let Some(component) = pending.pop_front() {
-        match component {
-            OwnedComponent::Current => {}
-            OwnedComponent::Parent => {
-                // A chroot clamps `..` at its root; mirror that behavior while
-                // resolving against the guest-visible rootfs tree.
-                relative.pop();
-            }
-            OwnedComponent::Normal(name) => {
-                let candidate = rootfs.join(&relative).join(&name);
-                let metadata = fs::symlink_metadata(&candidate).ok()?;
-                if metadata.file_type().is_symlink() {
-                    followed_symlinks = followed_symlinks.checked_add(1)?;
-                    if followed_symlinks > 40 {
-                        return None;
-                    }
-                    let target = fs::read_link(candidate).ok()?;
-                    if target.is_absolute() {
-                        relative.clear();
-                    }
-                    let mut target_components = owned_components(&target);
-                    target_components.append(&mut pending);
-                    pending = target_components;
-                } else {
-                    relative.push(name);
-                }
-            }
-        }
-    }
-
-    Some(rootfs.join(relative))
-}
-
-enum OwnedComponent {
-    Current,
-    Parent,
-    Normal(OsString),
-}
-
-fn owned_components(path: &Path) -> VecDeque<OwnedComponent> {
-    path.components()
-        .filter_map(|component| match component {
-            Component::RootDir => None,
-            Component::CurDir => Some(OwnedComponent::Current),
-            Component::ParentDir => Some(OwnedComponent::Parent),
-            Component::Normal(name) => Some(OwnedComponent::Normal(name.to_os_string())),
-            Component::Prefix(_) => None,
-        })
-        .collect()
+fn non_empty(field: Option<&str>) -> Option<&str> {
+    field.filter(|value| !value.is_empty())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    fn write_executable(path: &Path) {
-        fs::write(path, "#!/bin/sh\n").unwrap();
-        let mut permissions = fs::metadata(path).unwrap().permissions();
-        permissions.set_mode(0o755);
-        fs::set_permissions(path, permissions).unwrap();
-    }
+    use std::path::Path;
 
     #[test]
-    fn configured_root_home_and_executable_shell_are_selected() {
-        let rootfs = tempfile::tempdir().unwrap();
-        fs::create_dir_all(rootfs.path().join("etc")).unwrap();
-        fs::create_dir_all(rootfs.path().join("home/root")).unwrap();
-        fs::create_dir_all(rootfs.path().join("opt/bin")).unwrap();
-        write_executable(&rootfs.path().join("opt/bin/zsh"));
-        fs::write(
-            rootfs.path().join("etc/passwd"),
-            "root:x:0:0:root:/home/root:/opt/bin/zsh\n",
-        )
-        .unwrap();
-
+    fn configured_passwd_fields_are_used_verbatim() {
         assert_eq!(
-            root_session_profile(rootfs.path()),
+            profile_from_passwd(Some("/home/root"), Some("/opt/bin/zsh")),
             RootSessionProfile {
                 home_dir: "/home/root".into(),
                 login_shell: "/opt/bin/zsh".into(),
@@ -191,82 +57,42 @@ mod tests {
         );
     }
 
+    /// A shell the image does not ship is still used verbatim: OpenSSH execs it
+    /// and reports the failure rather than silently choosing another shell.
     #[test]
-    fn missing_home_and_unusable_shell_use_safe_fallbacks() {
-        let rootfs = tempfile::tempdir().unwrap();
-        fs::create_dir_all(rootfs.path().join("etc")).unwrap();
-        fs::create_dir_all(rootfs.path().join("bin")).unwrap();
-        write_executable(&rootfs.path().join("bin/ash"));
-        fs::write(
-            rootfs.path().join("etc/passwd"),
-            "root:x:0:0:root:/missing:/missing/shell\n",
-        )
-        .unwrap();
-
+    fn a_missing_shell_is_not_substituted() {
         assert_eq!(
-            root_session_profile(rootfs.path()),
+            profile_from_passwd(Some("/root"), Some("/does/not/exist")).login_shell,
+            "/does/not/exist"
+        );
+    }
+
+    #[test]
+    fn empty_passwd_fields_fall_back() {
+        assert_eq!(
+            profile_from_passwd(Some(""), Some("")),
             RootSessionProfile {
                 home_dir: "/".into(),
-                login_shell: "/bin/ash".into(),
+                login_shell: "/bin/sh".into(),
             }
         );
     }
 
     #[test]
-    fn absolute_symlink_cannot_escape_the_container_rootfs() {
-        use std::os::unix::fs::symlink;
-
-        let rootfs = tempfile::tempdir().unwrap();
-        fs::create_dir_all(rootfs.path().join("etc")).unwrap();
-        fs::create_dir_all(rootfs.path().join("bin")).unwrap();
-        write_executable(&rootfs.path().join("bin/sh"));
-        symlink("/tmp", rootfs.path().join("escape")).unwrap();
-        fs::write(
-            rootfs.path().join("etc/passwd"),
-            "root:x:0:0:root:/escape:/escape/sh\n",
-        )
-        .unwrap();
-
-        let profile = root_session_profile(rootfs.path());
-        assert_eq!(profile.home_dir, "/");
-        assert_eq!(profile.login_shell, "/bin/sh");
+    fn an_absent_passwd_entry_falls_back() {
+        assert_eq!(
+            profile_from_passwd(None, None),
+            RootSessionProfile {
+                home_dir: "/".into(),
+                login_shell: "/bin/sh".into(),
+            }
+        );
     }
 
     #[test]
-    fn absolute_shell_symlink_is_resolved_from_the_container_root() {
-        use std::os::unix::fs::symlink;
-
-        let rootfs = tempfile::tempdir().unwrap();
-        fs::create_dir_all(rootfs.path().join("etc")).unwrap();
-        fs::create_dir_all(rootfs.path().join("bin")).unwrap();
-        fs::create_dir_all(rootfs.path().join("usr/bin")).unwrap();
-        write_executable(&rootfs.path().join("usr/bin/ash"));
-        symlink("/usr/bin/ash", rootfs.path().join("bin/sh")).unwrap();
-        fs::write(
-            rootfs.path().join("etc/passwd"),
-            "root:x:0:0:root:/:/bin/sh\n",
-        )
-        .unwrap();
-
-        assert_eq!(root_session_profile(rootfs.path()).login_shell, "/bin/sh");
-    }
-
-    #[test]
-    fn symlink_loop_is_rejected_and_uses_a_fallback_shell() {
-        use std::os::unix::fs::symlink;
-
-        let rootfs = tempfile::tempdir().unwrap();
-        fs::create_dir_all(rootfs.path().join("etc")).unwrap();
-        fs::create_dir_all(rootfs.path().join("bin")).unwrap();
-        write_executable(&rootfs.path().join("bin/ash"));
-        symlink("/loop-b", rootfs.path().join("loop-a")).unwrap();
-        symlink("/loop-a", rootfs.path().join("loop-b")).unwrap();
-        fs::write(
-            rootfs.path().join("etc/passwd"),
-            "root:x:0:0:root:/:/loop-a\n",
-        )
-        .unwrap();
-
-        assert_eq!(root_session_profile(rootfs.path()).login_shell, "/bin/ash");
+    fn the_passwd_database_yields_absolute_paths() {
+        let profile = root_session_profile();
+        assert!(Path::new(&profile.home_dir).is_absolute());
+        assert!(Path::new(&profile.login_shell).is_absolute());
     }
 }

--- a/src/guest/src/container/zygote.rs
+++ b/src/guest/src/container/zygote.rs
@@ -56,6 +56,7 @@ pub(crate) struct BuildSpec {
     pub cwd: PathBuf,
     pub env: HashMap<String, String>,
     pub args: Vec<String>,
+    pub ssh_workload: Option<crate::service::ssh::SshWorkload>,
     pub uid: u32,
     pub gid: u32,
     pub capabilities: CapabilitySet,
@@ -93,6 +94,8 @@ enum ZygoteRequest {
     Build(BuildSpec),
     /// Build a container's init process. Same fd-passing contract as `Build`.
     BuildInit(InitBuildSpec),
+    #[cfg(test)]
+    InspectAmbientRuntimeEnvironment,
 }
 
 /// Tagged IPC response from zygote to parent, matched 1:1 with requests.
@@ -105,6 +108,8 @@ enum ZygoteRequest {
 enum ZygoteResponse {
     Build(BuildResult),
     BuildInit(BuildResult),
+    #[cfg(test)]
+    AmbientRuntimeEnvironment(Vec<String>),
 }
 
 impl Zygote {
@@ -127,6 +132,7 @@ impl Zygote {
             Ok(ForkResult::Child) => {
                 // Child: close parent's end, enter serve loop (never returns)
                 drop(parent_sock);
+                sanitize_ambient_runtime_environment();
                 serve(child_sock);
             }
             Ok(ForkResult::Parent { child }) => {
@@ -181,6 +187,19 @@ impl Zygote {
             ))),
         }
     }
+
+    #[cfg(test)]
+    fn inspect_ambient_runtime_environment(&self) -> BoxliteResult<Vec<String>> {
+        let sock = self.sock.lock().unwrap();
+        let fd = sock.as_raw_fd();
+        send_request(fd, &ZygoteRequest::InspectAmbientRuntimeEnvironment, None)?;
+        match recv_response(fd)? {
+            ZygoteResponse::AmbientRuntimeEnvironment(variables) => Ok(variables),
+            other => Err(BoxliteError::Internal(format!(
+                "zygote protocol violation: environment probe answered with {other:?}"
+            ))),
+        }
+    }
 }
 
 // ============================================================================
@@ -207,6 +226,15 @@ fn serve(sock: OwnedFd) -> ! {
                     ZygoteRequest::BuildInit(spec) => {
                         ZygoteResponse::BuildInit(do_build_init(spec, fds))
                     }
+                    #[cfg(test)]
+                    ZygoteRequest::InspectAmbientRuntimeEnvironment => {
+                        let retained = ["LISTEN_FDS", "LISTEN_PID", "LISTEN_FDNAMES"]
+                            .into_iter()
+                            .filter(|variable| std::env::var_os(variable).is_some())
+                            .map(str::to_owned)
+                            .collect();
+                        ZygoteResponse::AmbientRuntimeEnvironment(retained)
+                    }
                 };
                 if let Err(e) = send_response(fd, &response) {
                     eprintln!("[zygote] send_response failed: {e}");
@@ -220,6 +248,20 @@ fn serve(sock: OwnedFd) -> ! {
                 std::process::exit(0);
             }
         }
+    }
+}
+
+/// Remove process-launch variables that libcontainer interprets as runtime
+/// control rather than target environment.
+///
+/// Box image and caller environment is inherited by the guest process. Youki
+/// reads ambient `LISTEN_FDS` when deciding which zygote descriptors survive a
+/// tenant exec, so accepting it here could leak the zygote control socket into
+/// the container. The requested target environment is carried independently in
+/// [`BuildSpec`] and remains untouched.
+fn sanitize_ambient_runtime_environment() {
+    for variable in ["LISTEN_FDS", "LISTEN_PID", "LISTEN_FDNAMES"] {
+        std::env::remove_var(variable);
     }
 }
 
@@ -247,6 +289,14 @@ fn do_build(spec: BuildSpec, fds: Option<[RawFd; 3]>) -> BuildResult {
             .with_console_socket(spec.console_socket.clone())
             .validate_id()
             .map_err(|e| format!("Invalid container ID: {e}"))?;
+
+        // The image entrypoint and ordinary exec requests retain Youki's
+        // default executor. Only a typed internal SSH workload installs the
+        // direct BoxLite dispatcher in the final tenant child.
+        if let Some(workload) = spec.ssh_workload.clone() {
+            builder =
+                builder.with_executor(crate::service::ssh::BoxliteWorkloadExecutor::new(workload));
+        }
 
         if let Some((stdin, stdout, stderr)) = owned_fds {
             builder = builder
@@ -563,6 +613,11 @@ fn recv_response(sock: RawFd) -> BoxliteResult<ZygoteResponse> {
 mod tests {
     use super::*;
     use crate::container::capabilities::CapabilitySet;
+    use std::process::Command;
+
+    const AMBIENT_ENV_PROBE: &str = "BOXLITE_ZYGOTE_AMBIENT_ENV_PROBE";
+    const AMBIENT_ENV_TEST: &str =
+        "container::zygote::tests::zygote_removes_ambient_runtime_control_environment";
 
     // ========================================================================
     // Serialization tests (pure logic, no fork needed)
@@ -584,6 +639,7 @@ mod tests {
                 "-c".to_string(),
                 "echo hello world".to_string(),
             ],
+            ssh_workload: None,
             uid: 1000,
             gid: 1000,
             capabilities: CapabilitySet::default(),
@@ -596,6 +652,18 @@ mod tests {
         let json = serde_json::to_vec(&spec).unwrap();
         let decoded: BuildSpec = serde_json::from_slice(&json).unwrap();
         assert_eq!(spec, decoded);
+    }
+
+    #[test]
+    fn build_spec_preserves_a_typed_ssh_workload() {
+        let mut spec = sample_spec();
+        spec.ssh_workload = Some(crate::service::ssh::SshWorkload::ReverseStreamlocal {
+            socket_path: "/run/service.sock".into(),
+            ingress: "127.0.0.1:32000".parse().unwrap(),
+        });
+        let json = serde_json::to_vec(&spec).unwrap();
+        let decoded: BuildSpec = serde_json::from_slice(&json).unwrap();
+        assert_eq!(decoded, spec);
     }
 
     #[test]
@@ -640,6 +708,7 @@ mod tests {
             cwd: PathBuf::from("/"),
             env: HashMap::new(),
             args: vec![],
+            ssh_workload: None,
             uid: 0,
             gid: 0,
             capabilities: CapabilitySet::default(),
@@ -798,6 +867,7 @@ mod tests {
             cwd: PathBuf::from("/workspace/project/subdir"),
             env,
             args,
+            ssh_workload: None,
             uid: 65534,
             gid: 65534,
             capabilities: CapabilitySet::default(),
@@ -828,6 +898,7 @@ mod tests {
             cwd: PathBuf::from("/"),
             env,
             args: vec![],
+            ssh_workload: None,
             uid: 0,
             gid: 0,
             capabilities: CapabilitySet::default(),
@@ -887,6 +958,48 @@ mod tests {
 
         // Drop releases the OwnedFd, closing the socket.
         // The zygote child will exit on recv error.
+    }
+
+    #[test]
+    fn zygote_removes_ambient_runtime_control_environment() {
+        if std::env::var_os(AMBIENT_ENV_PROBE).is_none() {
+            let output = Command::new(std::env::current_exe().unwrap())
+                .args(["--exact", AMBIENT_ENV_TEST, "--test-threads=1"])
+                .env(AMBIENT_ENV_PROBE, "1")
+                .env("LISTEN_FDS", "8")
+                .env("LISTEN_PID", "1")
+                .env("LISTEN_FDNAMES", "boxlite-control")
+                .output()
+                .expect("run isolated zygote environment probe");
+            assert!(
+                output.status.success(),
+                "isolated zygote environment probe failed:\nstdout:\n{}\nstderr:\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            return;
+        }
+
+        let zygote = Zygote::start().expect("zygote should start");
+        let retained = zygote
+            .inspect_ambient_runtime_environment()
+            .expect("inspect zygote environment");
+
+        let children_path = format!("/proc/self/task/{}/children", nix::unistd::gettid());
+        let children = std::fs::read_to_string(children_path).expect("read probe child list");
+        let child_pids: Vec<i32> = children
+            .split_whitespace()
+            .map(|pid| pid.parse().expect("child pid must be numeric"))
+            .collect();
+        assert_eq!(child_pids.len(), 1, "probe must have exactly one child");
+        let zygote_pid = Pid::from_raw(child_pids[0]);
+
+        drop(zygote);
+        nix::sys::wait::waitpid(zygote_pid, None).expect("reap environment probe zygote");
+        assert!(
+            retained.is_empty(),
+            "zygote retained runtime control variables: {retained:?}"
+        );
     }
 
     #[test]
@@ -978,6 +1091,7 @@ mod tests {
                     cwd: PathBuf::from("/"),
                     env: HashMap::new(),
                     args: vec!["echo".to_string()],
+                    ssh_workload: None,
                     uid: 0,
                     gid: 0,
                     capabilities: CapabilitySet::default(),
@@ -1019,6 +1133,7 @@ mod tests {
             cwd: PathBuf::from("/"),
             env: HashMap::new(),
             args: vec!["true".to_string()],
+            ssh_workload: None,
             uid: 0,
             gid: 0,
             capabilities: CapabilitySet::default(),
@@ -1128,6 +1243,9 @@ mod tests {
                             .parse()
                             .expect("init id carries its index");
                         ZygoteResponse::BuildInit(BuildResult::Spawned { pid: 3000 + i })
+                    }
+                    ZygoteRequest::InspectAmbientRuntimeEnvironment => {
+                        panic!("unexpected environment probe")
                     }
                 };
                 send_response(child_fd, &response).unwrap();
@@ -1362,6 +1480,7 @@ mod tests {
                 cwd: PathBuf::from("/"),
                 env: HashMap::new(),
                 args: vec!["true".to_string()],
+                ssh_workload: None,
                 uid: 0,
                 gid: 0,
                 capabilities: CapabilitySet::default(),

--- a/src/guest/src/main.rs
+++ b/src/guest/src/main.rs
@@ -123,6 +123,19 @@ async fn async_main() -> BoxliteResult<()> {
     mounts::mount_essential_tmpfs()?;
     eprintln!("[guest] T+{}ms: tmpfs mounted", boot_elapsed_ms());
 
+    // Seal the root before any container — and therefore any tenant process —
+    // can exist, so a workload that enters the container by fork cannot have
+    // its inherited /proc/self/exe reopened for write. The host key is created
+    // first because it is the one guest-root write that outlives startup; a
+    // failure here is not fatal to the box, it only leaves SSH unable to start
+    // later, which is the same outcome the lazy path already reported through
+    // `SshStartError::HostKey`.
+    if let Err(error) = service::ssh::provision_host_key() {
+        tracing::warn!(%error, "SSH host key not provisioned; SSH cannot start on this boot");
+    }
+    mounts::seal_root_readonly()?;
+    eprintln!("[guest] T+{}ms: root sealed read-only", boot_elapsed_ms());
+
     // Install the child-reaper before serving: one waitpid(-1) loop reaps the
     // container init, exec tenants (both reparent to us via as_sibling), and
     // guest processes, so a finished command is observed and the box stops

--- a/src/guest/src/mounts.rs
+++ b/src/guest/src/mounts.rs
@@ -95,6 +95,36 @@ fn mount_tmpfs(cfg: &TmpfsMount) -> BoxliteResult<()> {
     Ok(())
 }
 
+/// Remount the guest's own root filesystem read-only.
+///
+/// Direct tenant workloads (SFTP, socket forwarding) enter the container by
+/// fork without execve, so their `/proc/<pid>/exe` still names this agent's
+/// binary. Any container process in the same pid namespace can take an `O_PATH`
+/// handle to it, wait for that process to exit, and reopen the handle for write
+/// — CVE-2019-5736. `MS_REMOUNT` is what closes that: it flips `MNT_READONLY`
+/// on the *existing* mount rather than stacking a new one, so handles already
+/// derived from it are covered as well. A bind mount would not be — it creates
+/// a separate mount that older handles never reference.
+///
+/// Every runtime write target lives on another mount: `/tmp`, `/var/tmp` and
+/// `/run` are tmpfs (see [`mount_essential_tmpfs`]), and container rootfs trees
+/// live under `/run/boxlite/shared` on virtio-fs. Call this only once those are
+/// in place and nothing on the root is still open for write, or the kernel
+/// rejects the remount with `EBUSY`.
+pub fn seal_root_readonly() -> BoxliteResult<()> {
+    mount(
+        None::<&str>,
+        "/",
+        None::<&str>,
+        MsFlags::MS_REMOUNT | MsFlags::MS_RDONLY,
+        None::<&str>,
+    )
+    .map_err(|e| BoxliteError::Internal(format!("Failed to remount / read-only: {}", e)))?;
+
+    tracing::info!("Remounted / read-only");
+    Ok(())
+}
+
 fn is_tmpfs(path: &Path) -> BoxliteResult<bool> {
     let mounts = match fs::read_to_string("/proc/mounts") {
         Ok(content) => content,

--- a/src/guest/src/reaper.rs
+++ b/src/guest/src/reaper.rs
@@ -105,6 +105,18 @@ impl ExitSlot {
             }
         }
     }
+
+    #[cfg(test)]
+    pub(crate) fn settled_for_test(status: ExitStatus) -> Self {
+        let (_tx, rx) = watch::channel(Some(status));
+        Self(rx)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn pending_for_test() -> (Self, watch::Sender<Option<ExitStatus>>) {
+        let (tx, rx) = watch::channel(None);
+        (Self(rx), tx)
+    }
 }
 
 #[derive(Default)]

--- a/src/guest/src/service/exec/error.rs
+++ b/src/guest/src/service/exec/error.rs
@@ -1,0 +1,74 @@
+//! Errors the execution core reports to any caller, transport or in-process.
+//!
+//! The core deals in these; `impl Execution for GuestServer` is the only place
+//! that turns one into a `tonic::Status`. Keeping the discriminant typed is what
+//! lets an in-process caller — the SSH server — branch on the reason without
+//! matching on a rendered string.
+
+use std::fmt;
+
+#[derive(Debug)]
+pub(crate) enum ExecutionError {
+    /// No execution is registered under this id.
+    NotFound(String),
+    /// The execution exists but its process handle is already gone.
+    HandleUnavailable,
+    /// stdin was already taken by an earlier `send_input`.
+    StdinTaken,
+    /// stdout/stderr were already taken by an earlier `attach`.
+    AlreadyAttached,
+    /// The execution was not started with a PTY.
+    NotAPty,
+    /// Caller supplied a value the core cannot act on (bad signal, bad size).
+    InvalidArgument(String),
+    /// I/O against the process failed.
+    Io(String),
+    /// The caller's own input stream ended in error.
+    ///
+    /// Carries that error verbatim so the RPC adapter returns the peer's
+    /// original status rather than flattening every stream failure to
+    /// `Internal`. Only a transport-backed caller can produce this — the
+    /// in-process path feeds an infallible stream and never constructs it.
+    Input(Box<tonic::Status>),
+}
+
+impl fmt::Display for ExecutionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotFound(id) => write!(f, "execution not found: {id}"),
+            Self::HandleUnavailable => write!(f, "execution handle is no longer available"),
+            Self::StdinTaken => write!(f, "execution stdin was already taken"),
+            Self::AlreadyAttached => write!(f, "execution output is already attached"),
+            Self::NotAPty => write!(f, "execution was not started with a PTY"),
+            Self::InvalidArgument(detail) => write!(f, "invalid argument: {detail}"),
+            Self::Io(detail) => write!(f, "execution I/O failed: {detail}"),
+            Self::Input(status) => write!(f, "execution input stream failed: {status}"),
+        }
+    }
+}
+
+impl std::error::Error for ExecutionError {}
+
+impl From<ExecutionError> for tonic::Status {
+    fn from(error: ExecutionError) -> Self {
+        // The caller's own stream error goes back unchanged — re-coding it would
+        // hide why the peer gave up.
+        if let ExecutionError::Input(status) = error {
+            return *status;
+        }
+        let message = error.to_string();
+        match error {
+            ExecutionError::NotFound(_) => tonic::Status::not_found(message),
+            ExecutionError::HandleUnavailable | ExecutionError::NotAPty => {
+                tonic::Status::failed_precondition(message)
+            }
+            ExecutionError::StdinTaken | ExecutionError::AlreadyAttached => {
+                tonic::Status::already_exists(message)
+            }
+            ExecutionError::InvalidArgument(_) => tonic::Status::invalid_argument(message),
+            ExecutionError::Io(_) => tonic::Status::internal(message),
+            // Returned verbatim above; this arm is unreachable.
+            ExecutionError::Input(status) => *status,
+        }
+    }
+}

--- a/src/guest/src/service/exec/exec_handle.rs
+++ b/src/guest/src/service/exec/exec_handle.rs
@@ -184,6 +184,14 @@ pub struct PtyConfig {
     pub cols: u16,
     pub x_pixels: u16,
     pub y_pixels: u16,
+    pub modes: Vec<PtyMode>,
+}
+
+/// One RFC 4254 terminal-mode opcode and value.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PtyMode {
+    pub opcode: u8,
+    pub value: u32,
 }
 
 /// Handle to a running process
@@ -352,5 +360,147 @@ impl ExecHandle {
                 signal, self.pid, e
             ))
         })
+    }
+
+    /// Signal the execution's process group after proving the tracked process
+    /// is still that group's leader. This check prevents a negative-PID kill
+    /// from targeting a different group when used on an execution that did not
+    /// create its own session.
+    pub fn kill_process_group(&self, signal: Signal) -> BoxliteResult<()> {
+        use nix::sys::signal::kill;
+        use nix::unistd::getpgid;
+
+        let process_group = getpgid(Some(self.pid)).map_err(|error| {
+            BoxliteError::Internal(format!(
+                "Failed to resolve process group for {}: {}",
+                self.pid, error
+            ))
+        })?;
+        let target = checked_process_group_target(self.pid, process_group)?;
+        kill(target, signal).map_err(|error| {
+            BoxliteError::Internal(format!(
+                "Failed to send signal {} to process group {}: {}",
+                signal, process_group, error
+            ))
+        })
+    }
+}
+
+fn checked_process_group_target(pid: Pid, process_group: Pid) -> BoxliteResult<Pid> {
+    let pid_raw = pid.as_raw();
+    if pid_raw <= 0 || process_group != pid {
+        return Err(BoxliteError::Internal(format!(
+            "Refusing process-group signal: execution pid {pid} is not group leader {process_group}"
+        )));
+    }
+    Ok(Pid::from_raw(-pid_raw))
+}
+
+#[cfg(test)]
+mod process_group_tests {
+    use super::*;
+    use std::io::BufRead as _;
+    use std::os::unix::process::CommandExt as _;
+    use std::process::{Child, Command, Stdio};
+    use std::time::{Duration, Instant};
+
+    struct ChildGroup {
+        child: Child,
+        process_group: Pid,
+    }
+
+    impl Drop for ChildGroup {
+        fn drop(&mut self) {
+            let _ = nix::sys::signal::kill(
+                Pid::from_raw(-self.process_group.as_raw()),
+                Signal::SIGKILL,
+            );
+            let _ = self.child.wait();
+        }
+    }
+
+    fn is_gone_or_zombie(pid: Pid) -> bool {
+        let stat = match std::fs::read_to_string(format!("/proc/{pid}/stat")) {
+            Ok(stat) => stat,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return true,
+            Err(_) => return false,
+        };
+        stat.rsplit_once(") ")
+            .and_then(|(_, fields)| fields.chars().next())
+            == Some('Z')
+    }
+
+    #[test]
+    fn negative_kill_target_requires_the_execution_to_be_group_leader() {
+        let pid = Pid::from_raw(4242);
+        assert_eq!(
+            checked_process_group_target(pid, pid).unwrap(),
+            Pid::from_raw(-4242)
+        );
+
+        let error = checked_process_group_target(pid, Pid::from_raw(4000)).unwrap_err();
+        assert!(error.to_string().contains("is not group leader"));
+        assert!(checked_process_group_target(Pid::from_raw(0), Pid::from_raw(0)).is_err());
+    }
+
+    #[test]
+    fn process_group_kill_reaches_a_background_descendant() {
+        let mut command = Command::new("/bin/sh");
+        command
+            .arg("-c")
+            .arg("trap '' HUP TERM; sleep 30 & echo $!; wait")
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null());
+        // SAFETY: setsid is async-signal-safe and this closure performs no
+        // allocation or other work between fork and exec.
+        unsafe {
+            command.pre_exec(|| {
+                if nix::libc::setsid() == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+        let mut group = ChildGroup {
+            child: command.spawn().unwrap(),
+            process_group: Pid::from_raw(0),
+        };
+        let leader = Pid::from_raw(group.child.id() as i32);
+        group.process_group = leader;
+        assert_eq!(nix::unistd::getpgid(Some(leader)).unwrap(), leader);
+
+        let stdout = group.child.stdout.take().unwrap();
+        let mut line = String::new();
+        std::io::BufReader::new(stdout)
+            .read_line(&mut line)
+            .unwrap();
+        let descendant = Pid::from_raw(line.trim().parse::<i32>().unwrap());
+        assert_eq!(nix::unistd::getpgid(Some(descendant)).unwrap(), leader);
+
+        let (_stdin_peer, stdin) = nix::unistd::pipe().unwrap();
+        let (stdout, _stdout_peer) = nix::unistd::pipe().unwrap();
+        let (stderr, _stderr_peer) = nix::unistd::pipe().unwrap();
+        let handle = ExecHandle::new(leader, stdin, stdout, Some(stderr));
+
+        handle.kill_process_group(Signal::SIGTERM).unwrap();
+        std::thread::sleep(Duration::from_millis(25));
+        assert!(group.child.try_wait().unwrap().is_none());
+
+        handle.kill_process_group(Signal::SIGKILL).unwrap();
+        let status = group.child.wait().unwrap();
+        assert_eq!(
+            std::os::unix::process::ExitStatusExt::signal(&status),
+            Some(9)
+        );
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while !is_gone_or_zombie(descendant) && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(
+            is_gone_or_zombie(descendant),
+            "background descendant survived process-group SIGKILL"
+        );
     }
 }

--- a/src/guest/src/service/exec/executor.rs
+++ b/src/guest/src/service/exec/executor.rs
@@ -33,14 +33,24 @@ impl ContainerExecutor {
     pub fn container_ref(&self) -> Arc<Mutex<Container>> {
         self.container.clone()
     }
-}
 
-#[async_trait]
-impl Executor for ContainerExecutor {
-    async fn spawn(&self, req: &ExecRequest) -> BoxliteResult<ExecHandle> {
+    pub(crate) async fn spawn_ssh_workload(
+        &self,
+        req: &ExecRequest,
+        workload: crate::service::ssh::SshWorkload,
+    ) -> BoxliteResult<ExecHandle> {
+        self.spawn_request(req, Some(workload)).await
+    }
+
+    async fn spawn_request(
+        &self,
+        req: &ExecRequest,
+        ssh_workload: Option<crate::service::ssh::SshWorkload>,
+    ) -> BoxliteResult<ExecHandle> {
         use crate::container::SpawnResult;
 
         let start = std::time::Instant::now();
+        let pty_config = req.tty.as_ref().map(PtyConfig::try_from).transpose()?;
 
         // Phase 1 (mutex held): build command + zygote IPC.
         //
@@ -57,17 +67,16 @@ impl Executor for ContainerExecutor {
                 .args(&req.args)
                 .envs(req.env.iter().map(|(k, v)| (k.as_str(), v.as_str())));
 
+            if let Some(workload) = ssh_workload {
+                cmd = cmd.with_ssh_workload(workload);
+            }
+
             if !req.workdir.is_empty() {
                 cmd = cmd.current_dir(&req.workdir);
             }
 
-            if let Some(tty) = &req.tty {
-                cmd = cmd.with_pty(PtyConfig {
-                    rows: tty.rows as u16,
-                    cols: tty.cols as u16,
-                    x_pixels: tty.x_pixels as u16,
-                    y_pixels: tty.y_pixels as u16,
-                });
+            if let Some(tty) = pty_config {
+                cmd = cmd.with_pty(tty);
             }
 
             if let Some(ref user) = req.user {
@@ -97,6 +106,13 @@ impl Executor for ContainerExecutor {
     }
 }
 
+#[async_trait]
+impl Executor for ContainerExecutor {
+    async fn spawn(&self, req: &ExecRequest) -> BoxliteResult<ExecHandle> {
+        self.spawn_request(req, None).await
+    }
+}
+
 /// Executes commands directly on guest (no container).
 pub struct GuestExecutor;
 
@@ -104,12 +120,7 @@ pub struct GuestExecutor;
 impl Executor for GuestExecutor {
     async fn spawn(&self, req: &ExecRequest) -> BoxliteResult<ExecHandle> {
         if let Some(tty) = &req.tty {
-            let config = PtyConfig {
-                rows: tty.rows as u16,
-                cols: tty.cols as u16,
-                x_pixels: tty.x_pixels as u16,
-                y_pixels: tty.y_pixels as u16,
-            };
+            let config = PtyConfig::try_from(tty)?;
             spawn_with_pty(req, config)
         } else {
             spawn_with_pipes(req)
@@ -183,6 +194,7 @@ fn spawn_with_pty(req: &ExecRequest, config: PtyConfig) -> BoxliteResult<ExecHan
 
     let OpenptyResult { master, slave } = openpty(Some(&winsize), None)
         .map_err(|e| BoxliteError::Internal(format!("Failed to create PTY: {}", e)))?;
+    crate::service::exec::tty::apply_modes(&slave, &config.modes)?;
 
     // Get raw FD for use in pre_exec closure
     let slave_raw_fd = slave.as_raw_fd();

--- a/src/guest/src/service/exec/mod.rs
+++ b/src/guest/src/service/exec/mod.rs
@@ -16,53 +16,173 @@
 //!
 //! Each file has a single, clear responsibility.
 
+pub(in crate::service) mod error;
 #[cfg(target_os = "linux")]
 pub mod exec_handle;
 pub(in crate::service) mod executor;
 pub(in crate::service) mod registry;
 pub(in crate::service) mod state;
 mod timeout;
+pub(crate) mod tty;
 
 // Re-export trait so container module can implement it
 pub(crate) use state::InitHealthCheck;
 
+use crate::service::exec::error::ExecutionError;
 use crate::service::exec::executor::{ContainerExecutor, GuestExecutor};
+use crate::service::exec::state::{ExecutionExit, ExecutionState};
 use crate::service::server::GuestServer;
 use boxlite_shared::{
     constants::executor as executor_const, AttachRequest, ExecError, ExecOutput, ExecRequest,
     ExecResponse, ExecStdin, Execution, KillRequest, KillResponse, ResizeTtyRequest,
     ResizeTtyResponse, SendInputAck, WaitRequest, WaitResponse,
 };
-use futures::stream::Stream;
+use futures::stream::{Stream, StreamExt as _};
 use std::pin::Pin;
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Request, Response, Status, Streaming};
-use tracing::{debug, info, warn};
+use tracing::{debug, info};
+
+/// The execution core, addressed in native types.
+///
+/// This is the whole contract for driving a running execution, and it is
+/// transport-free on purpose: `impl Execution for GuestServer` below is one
+/// adapter over it, and the in-process SSH server is another. Neither is
+/// privileged, and neither can drift from the other, because the behaviour
+/// lives here rather than in either adapter.
+impl GuestServer {
+    async fn execution(&self, exec_id: &str) -> Result<ExecutionState, ExecutionError> {
+        self.registry
+            .get(exec_id)
+            .await
+            .ok_or_else(|| ExecutionError::NotFound(exec_id.to_string()))
+    }
+
+    /// Stream a running execution's stdout/stderr. One attach per execution.
+    pub(crate) async fn attach_execution(
+        &self,
+        exec_id: &str,
+    ) -> Result<mpsc::Receiver<ExecOutput>, ExecutionError> {
+        info!(execution_id = %exec_id, "attach request");
+        self.execution(exec_id).await?.attach(exec_id).await
+    }
+
+    /// Forward `first` and then everything `stream` yields to the execution's
+    /// stdin. The returned task completes when the stream ends or stdin closes.
+    pub(crate) async fn send_execution_input(
+        &self,
+        first: ExecStdin,
+        stream: impl Stream<Item = Result<ExecStdin, ExecutionError>> + Send + Unpin + 'static,
+    ) -> Result<JoinHandle<Result<(), ExecutionError>>, ExecutionError> {
+        if first.execution_id.is_empty() {
+            return Err(ExecutionError::InvalidArgument(
+                "execution_id is required".into(),
+            ));
+        }
+        let exec_id = first.execution_id.clone();
+        self.execution(&exec_id)
+            .await?
+            .send_input(first, stream)
+            .await
+    }
+
+    /// Wait for exit, already classified — see [`ExecutionState::wait_exit`].
+    pub(crate) async fn wait_execution(
+        &self,
+        exec_id: &str,
+    ) -> Result<ExecutionExit, ExecutionError> {
+        debug!(execution_id = %exec_id, "wait request");
+        Ok(self.execution(exec_id).await?.wait_exit(exec_id).await)
+    }
+
+    /// Signal the execution. `false` means the process had already exited.
+    pub(crate) async fn kill_execution(
+        &self,
+        exec_id: &str,
+        signal: i32,
+        process_group: bool,
+    ) -> Result<bool, ExecutionError> {
+        info!(execution_id = %exec_id, signal, process_group, "kill request");
+        // Resolve before parsing: signal 0 is the conventional liveness probe and
+        // is not a `Signal`, so parsing first would report an unknown execution
+        // as an invalid argument.
+        let state = self.execution(exec_id).await?;
+        let parsed = nix::sys::signal::Signal::try_from(signal)
+            .map_err(|_| ExecutionError::InvalidArgument(format!("signal number {signal}")))?;
+        let sent = state.kill(parsed, process_group).await;
+        if sent {
+            info!(execution_id = %exec_id, signal, "signal sent");
+        } else {
+            info!(execution_id = %exec_id, "failed to send signal");
+        }
+        Ok(sent)
+    }
+
+    /// Resize the execution's PTY.
+    ///
+    /// A device-level refusal — no handle, no PTY, failed ioctl — is an outcome
+    /// rather than an error, because that is what the wire contract reports
+    /// (`success: false` on an otherwise successful call). `Err` is reserved for
+    /// a caller mistake: an out-of-range dimension or an unknown execution.
+    pub(crate) async fn resize_execution_tty(
+        &self,
+        exec_id: &str,
+        rows: u32,
+        cols: u32,
+        x_pixels: u32,
+        y_pixels: u32,
+    ) -> Result<TtyResize, ExecutionError> {
+        // Unwrap the inner detail rather than the rendered `BoxliteError`: both
+        // types render an "invalid argument: " prefix, and nesting them stutters.
+        let dimension = |name, value| {
+            tty::dimension(name, value).map_err(|error| match error {
+                boxlite_shared::errors::BoxliteError::InvalidArgument(detail) => {
+                    ExecutionError::InvalidArgument(detail)
+                }
+                other => ExecutionError::InvalidArgument(other.to_string()),
+            })
+        };
+        let rows = dimension("rows", rows)?;
+        let cols = dimension("cols", cols)?;
+        let x_pixels = dimension("x_pixels", x_pixels)?;
+        let y_pixels = dimension("y_pixels", y_pixels)?;
+
+        info!(execution_id = %exec_id, rows, cols, "resize_tty request");
+        Ok(
+            match self
+                .execution(exec_id)
+                .await?
+                .resize_pty(rows, cols, x_pixels, y_pixels)
+                .await
+            {
+                Ok(()) => {
+                    info!(execution_id = %exec_id, rows, cols, "tty resized");
+                    TtyResize::Resized
+                }
+                Err(error) => {
+                    info!(execution_id = %exec_id, %error, "failed to resize tty");
+                    TtyResize::Rejected(error)
+                }
+            },
+        )
+    }
+}
+
+/// What a resize did, for callers that must distinguish "the terminal refused"
+/// from "you asked for something impossible".
+#[derive(Debug)]
+pub(crate) enum TtyResize {
+    Resized,
+    Rejected(ExecutionError),
+}
 
 #[tonic::async_trait]
 impl Execution for GuestServer {
     async fn exec(&self, request: Request<ExecRequest>) -> Result<Response<ExecResponse>, Status> {
         let req = request.into_inner();
-        let execution_id = req
-            .execution_id
-            .clone()
-            .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
-
-        // Validate: execution doesn't already exist
-        if self.registry.exists(&execution_id).await {
-            return Ok(Response::new(error_response(
-                execution_id,
-                "execution_exists",
-                "Execution already exists",
-            )));
-        }
-
-        // Spawn execution
-        let result = spawn_execution(self, execution_id.clone(), req).await;
-        match result {
-            Ok(resp) => Ok(Response::new(resp)),
-            Err(err_resp) => Ok(Response::new(err_resp)),
-        }
+        Ok(Response::new(start_execution(self, req, None).await))
     }
 
     type AttachStream = Pin<Box<dyn Stream<Item = Result<ExecOutput, Status>> + Send + 'static>>;
@@ -71,22 +191,11 @@ impl Execution for GuestServer {
         &self,
         request: Request<AttachRequest>,
     ) -> Result<Response<Self::AttachStream>, Status> {
-        let exec_id = request.into_inner().execution_id;
-        info!(execution_id = %exec_id, "attach request");
-
-        // Get state from registry
-        let state = self
-            .registry
-            .get(&exec_id)
-            .await
-            .ok_or_else(|| Status::not_found(format!("Execution not found: {}", exec_id)))?;
-
-        // Call state directly
-        let rx = state.attach(&exec_id).await?;
-
-        Ok(Response::new(
-            Box::pin(ReceiverStream::new(rx)) as Self::AttachStream
-        ))
+        let rx = self
+            .attach_execution(&request.into_inner().execution_id)
+            .await?;
+        let stream = ReceiverStream::new(rx).map(Ok);
+        Ok(Response::new(Box::pin(stream) as Self::AttachStream))
     }
 
     async fn send_input(
@@ -95,139 +204,44 @@ impl Execution for GuestServer {
     ) -> Result<Response<SendInputAck>, Status> {
         let mut stream = request.into_inner();
 
-        // First message must carry execution_id
+        // First message must carry execution_id.
         let first = stream
             .message()
             .await?
             .ok_or_else(|| Status::invalid_argument("Empty stdin stream"))?;
 
-        let exec_id = first.execution_id.clone();
-        if exec_id.is_empty() {
-            return Err(Status::invalid_argument("execution_id is required"));
-        }
+        let rest = stream.map(|msg| msg.map_err(|status| ExecutionError::Input(Box::new(status))));
+        let task = self.send_execution_input(first, Box::pin(rest)).await?;
 
-        // Get state from registry
-        let state = self
-            .registry
-            .get(&exec_id)
-            .await
-            .ok_or_else(|| Status::not_found(format!("Execution not found: {}", exec_id)))?;
-
-        // Call state directly
-        let task = state.send_input(first, stream).await?;
-
-        // Wait for task to complete
         match task.await {
             Ok(Ok(())) => Ok(Response::new(SendInputAck {})),
-            Ok(Err(e)) => Err(e),
-            Err(e) => Err(Status::internal(format!("Stdin task panicked: {}", e))),
+            Ok(Err(error)) => Err(error.into()),
+            Err(error) => Err(Status::internal(format!("Stdin task panicked: {error}"))),
         }
     }
 
     async fn wait(&self, request: Request<WaitRequest>) -> Result<Response<WaitResponse>, Status> {
-        use exec_handle::ExitStatus;
-
-        let exec_id = request.into_inner().execution_id;
-        debug!(execution_id = %exec_id, "wait request");
-
-        // Get state from registry
-        let state = self
-            .registry
-            .get(&exec_id)
-            .await
-            .ok_or_else(|| Status::not_found(format!("Execution not found: {}", exec_id)))?;
-
-        // Wait for process to exit
-        let exit_status = state.wait_process().await;
-
-        let (exit_code, signal, error_message) = match exit_status {
-            ExitStatus::Code(code) => {
-                debug!(
-                    execution_id = %exec_id,
-                    exit_code = code,
-                    "Process exited with code"
-                );
-                (code, 0, String::new())
-            }
-            ExitStatus::Signal(sig) => {
-                let mut error_msg = String::new();
-                // When a process gets SIGKILL, check if container init died.
-                // PID namespace teardown sends SIGKILL to all processes when init exits.
-                if sig == nix::sys::signal::Signal::SIGKILL {
-                    if let Some(diagnosis) = state.check_container_death().await {
-                        warn!(
-                            execution_id = %exec_id,
-                            signal = sig as i32,
-                            diagnosis = %diagnosis,
-                            "Process killed by container init death (PID namespace teardown). \
-                             The container's init process exited, causing all exec'd processes \
-                             to receive SIGKILL."
-                        );
-                        error_msg = diagnosis;
-                    }
-                }
-                debug!(
-                    execution_id = %exec_id,
-                    signal = sig as i32,
-                    "Process exited due to signal"
-                );
-                (0, sig as i32, error_msg)
-            }
-        };
-
+        let exit = self
+            .wait_execution(&request.into_inner().execution_id)
+            .await?;
         Ok(Response::new(WaitResponse {
-            exit_code,
-            signal,
+            exit_code: exit.exit_code,
+            signal: exit.signal,
             timed_out: false,
             duration_ms: 0,
-            error_message,
+            error_message: exit.error_message,
         }))
     }
 
     async fn kill(&self, request: Request<KillRequest>) -> Result<Response<KillResponse>, Status> {
-        use nix::sys::signal::Signal;
-
         let req = request.into_inner();
-        info!(
-            execution_id = %req.execution_id,
-            signal = req.signal,
-            "kill request"
-        );
-
-        // Get state from registry
-        let state = self.registry.get(&req.execution_id).await.ok_or_else(|| {
-            Status::not_found(format!("Execution not found: {}", req.execution_id))
-        })?;
-
-        // Parse signal
-        let signal = Signal::try_from(req.signal).map_err(|_| {
-            Status::invalid_argument(format!("Invalid signal number: {}", req.signal))
-        })?;
-
-        // Send signal
-        match state.kill(signal).await {
-            true => {
-                info!(
-                    execution_id = %req.execution_id,
-                    signal = req.signal,
-                    "signal sent"
-                );
-                Ok(Response::new(KillResponse {
-                    success: true,
-                    error: None,
-                }))
-            }
-            false => {
-                info!(
-                    execution_id = %req.execution_id,
-                    "failed to send signal"
-                );
-                Ok(Response::new(KillResponse {
-                    success: false,
-                    error: Some("Failed to send signal".to_string()),
-                }))
-            }
-        }
+        let sent = self
+            .kill_execution(&req.execution_id, req.signal, req.process_group)
+            .await?;
+        Ok(Response::new(KillResponse {
+            success: sent,
+            error: (!sent).then(|| "Failed to send signal".to_string()),
+        }))
     }
 
     async fn resize_tty(
@@ -235,53 +249,54 @@ impl Execution for GuestServer {
         request: Request<ResizeTtyRequest>,
     ) -> Result<Response<ResizeTtyResponse>, Status> {
         let req = request.into_inner();
-
-        info!(
-            execution_id = %req.execution_id,
-            rows = req.rows,
-            cols = req.cols,
-            "resize_tty request"
-        );
-
-        // Get state from registry
-        let state = self.registry.get(&req.execution_id).await.ok_or_else(|| {
-            Status::not_found(format!("Execution not found: {}", req.execution_id))
-        })?;
-
-        // Call state directly
-        match state
-            .resize_pty(
-                req.rows as u16,
-                req.cols as u16,
-                req.x_pixels as u16,
-                req.y_pixels as u16,
+        let outcome = self
+            .resize_execution_tty(
+                &req.execution_id,
+                req.rows,
+                req.cols,
+                req.x_pixels,
+                req.y_pixels,
             )
-            .await
-        {
-            Ok(()) => {
-                info!(
-                    execution_id = %req.execution_id,
-                    rows = req.rows,
-                    cols = req.cols,
-                    "tty resized"
-                );
-                Ok(Response::new(ResizeTtyResponse {
-                    success: true,
-                    error: None,
-                }))
-            }
-            Err(e) => {
-                info!(
-                    execution_id = %req.execution_id,
-                    error = %e,
-                    "failed to resize tty"
-                );
-                Ok(Response::new(ResizeTtyResponse {
-                    success: false,
-                    error: Some(e.to_string()),
-                }))
-            }
-        }
+            .await?;
+        Ok(Response::new(match outcome {
+            TtyResize::Resized => ResizeTtyResponse {
+                success: true,
+                error: None,
+            },
+            TtyResize::Rejected(reason) => ResizeTtyResponse {
+                success: false,
+                error: Some(reason.to_string()),
+            },
+        }))
+    }
+}
+
+/// Start a typed workload selected by the in-process SSH server. This entry
+/// point is intentionally outside the public Execution RPC contract.
+pub(crate) async fn start_ssh_execution(
+    server: &GuestServer,
+    req: ExecRequest,
+    workload: crate::service::ssh::SshWorkload,
+) -> ExecResponse {
+    start_execution(server, req, Some(workload)).await
+}
+
+async fn start_execution(
+    server: &GuestServer,
+    req: ExecRequest,
+    ssh_workload: Option<crate::service::ssh::SshWorkload>,
+) -> ExecResponse {
+    let execution_id = req
+        .execution_id
+        .clone()
+        .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+
+    if server.registry.exists(&execution_id).await {
+        return error_response(execution_id, "execution_exists", "Execution already exists");
+    }
+
+    match spawn_execution(server, execution_id, req, ssh_workload).await {
+        Ok(response) | Err(response) => response,
     }
 }
 
@@ -290,6 +305,7 @@ async fn spawn_execution(
     server: &GuestServer,
     execution_id: String,
     req: ExecRequest,
+    ssh_workload: Option<crate::service::ssh::SshWorkload>,
 ) -> Result<ExecResponse, ExecResponse> {
     let started_at_ms = now_ms();
 
@@ -300,7 +316,8 @@ async fn spawn_execution(
     let spawned_at = std::time::Instant::now();
 
     // Step 1: Spawn process using executor selected by BOXLITE_EXECUTOR env var
-    let (child, container_ref) = spawn_with_executor(server, &req, &execution_id).await?;
+    let (child, container_ref) =
+        spawn_with_executor(server, &req, &execution_id, ssh_workload).await?;
 
     let pid = child.pid().as_raw() as u32;
 
@@ -389,6 +406,7 @@ async fn spawn_with_executor(
     server: &GuestServer,
     req: &ExecRequest,
     execution_id: &str,
+    ssh_workload: Option<crate::service::ssh::SshWorkload>,
 ) -> Result<
     (
         exec_handle::ExecHandle,
@@ -402,6 +420,12 @@ async fn spawn_with_executor(
 
     match executor_value {
         Some(executor_const::GUEST) | None | Some("") => {
+            if ssh_workload.is_some() {
+                return Err(spawn_error(
+                    execution_id,
+                    "internal SSH workloads require a container executor".into(),
+                ));
+            }
             // Guest executor (explicit or default)
             debug!(execution_id = %execution_id, "Using GuestExecutor");
             let handle = GuestExecutor
@@ -471,7 +495,11 @@ async fn spawn_with_executor(
             };
             let executor = ContainerExecutor::new(container_arc);
             let container_ref = executor.container_ref();
-            let handle = match executor.spawn(req).await {
+            let spawn = match ssh_workload {
+                Some(workload) => executor.spawn_ssh_workload(req, workload).await,
+                None => executor.spawn(req).await,
+            };
+            let handle = match spawn {
                 Ok(h) => h,
                 Err(e) => {
                     // Check if container init died — provide actionable diagnostics

--- a/src/guest/src/service/exec/registry.rs
+++ b/src/guest/src/service/exec/registry.rs
@@ -51,6 +51,23 @@ impl ExecutionRegistry {
         self.executions.lock().await.insert(exec_id, state);
     }
 
+    /// Release one explicitly ephemeral execution.
+    ///
+    /// SSH calls this only after its output stream and terminal wait complete.
+    /// Retained SDK executions and container-init sessions are never released by
+    /// their normal wait paths, preserving repeatable waits for those callers.
+    pub async fn release_ephemeral(&self, exec_id: &str) -> bool {
+        let state = {
+            let mut executions = self.executions.lock().await;
+            executions.remove(exec_id)
+        };
+        let Some(state) = state else {
+            return false;
+        };
+        state.release_resources().await;
+        true
+    }
+
     /// Gracefully shutdown all running executions.
     ///
     /// Sends SIGTERM first, waits for exit with timeout, then SIGKILL if needed.
@@ -105,5 +122,69 @@ impl ExecutionRegistry {
                 let _ = kill(Pid::from_raw(*pid), Signal::SIGKILL);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod release_tests {
+    use super::*;
+    use crate::reaper::ExitSlot;
+    use crate::service::exec::exec_handle::{ExecHandle, ExitStatus};
+    use nix::unistd::{pipe, Pid};
+
+    fn settled_state(pid: i32, is_init: bool) -> ExecutionState {
+        let (_stdin_peer, stdin) = pipe().unwrap();
+        let (stdout, _stdout_peer) = pipe().unwrap();
+        let (stderr, _stderr_peer) = pipe().unwrap();
+        let handle = ExecHandle::new(Pid::from_raw(pid), stdin, stdout, Some(stderr));
+        let exit = ExitSlot::settled_for_test(ExitStatus::Code(7));
+        if is_init {
+            ExecutionState::new_init_session(handle, exit)
+        } else {
+            ExecutionState::new(handle, exit)
+        }
+    }
+
+    #[tokio::test]
+    async fn release_is_scoped_and_preserves_retained_waits_and_init_sessions() {
+        let registry = ExecutionRegistry::new();
+        registry
+            .register("sdk-exec".into(), settled_state(11_001, false))
+            .await;
+        registry
+            .register("init-exec".into(), settled_state(11_002, true))
+            .await;
+        registry
+            .register("ssh-exec".into(), settled_state(11_003, false))
+            .await;
+
+        let sdk_state = registry.get("sdk-exec").await.unwrap();
+        assert_eq!(sdk_state.wait_process().await.code(), 7);
+        assert_eq!(sdk_state.wait_process().await.code(), 7);
+
+        assert!(registry.release_ephemeral("ssh-exec").await);
+        assert!(!registry.release_ephemeral("ssh-exec").await);
+        assert!(!registry.exists("ssh-exec").await);
+        assert!(registry.exists("sdk-exec").await);
+        assert!(registry.exists("init-exec").await);
+    }
+
+    #[tokio::test]
+    async fn sequential_ssh_releases_do_not_accumulate_registry_entries() {
+        let registry = ExecutionRegistry::new();
+        registry
+            .register("retained".into(), settled_state(12_000, false))
+            .await;
+
+        for index in 0..128 {
+            let execution_id = format!("ssh-{index}");
+            registry
+                .register(execution_id.clone(), settled_state(12_001 + index, false))
+                .await;
+            assert!(registry.release_ephemeral(&execution_id).await);
+            assert!(!registry.exists(&execution_id).await);
+        }
+
+        assert!(registry.exists("retained").await);
     }
 }

--- a/src/guest/src/service/exec/state.rs
+++ b/src/guest/src/service/exec/state.rs
@@ -1,10 +1,11 @@
+use crate::service::exec::error::ExecutionError;
 use crate::service::exec::exec_handle::ExecHandle;
 use boxlite_shared::ExecOutput;
+use futures::Stream;
 use std::os::unix::io::AsRawFd;
 use std::sync::Arc;
 use tokio::sync::{mpsc, Mutex};
-use tokio::task::JoinHandle;
-use tonic::Status;
+use tokio::task::{AbortHandle, JoinHandle};
 use tracing::info;
 
 /// Abstraction for checking container init health.
@@ -25,14 +26,29 @@ pub(crate) trait InitHealthCheck: Send + Sync {
 struct Inner {
     /// The process handle (owns pid, pty_controller, stdin, stdout, stderr)
     handle: Option<ExecHandle>,
+    /// Abort handles for stdin forwarding tasks that may own the taken stdin FD.
+    input_tasks: Vec<AbortHandle>,
     /// Stdout/stderr forwarding tasks (set on attach)
     output_tasks: Vec<JoinHandle<()>>,
+    /// Set once ephemeral callers explicitly release this execution's resources.
+    released: bool,
     /// Timeout flag
     #[allow(dead_code)] // Will be used for timeout handling
     timed_out: bool,
     /// Optional init health checker for the container this exec runs in.
     /// Used to detect container init death when exec gets SIGKILL.
     init_health: Option<Arc<Mutex<dyn InitHealthCheck>>>,
+}
+
+/// How an execution ended, already classified.
+///
+/// `error_message` carries the container-death diagnosis when pid-namespace
+/// teardown is what killed the process; it is empty otherwise.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ExecutionExit {
+    pub exit_code: i32,
+    pub signal: i32,
+    pub error_message: String,
 }
 
 /// Execution state.
@@ -61,12 +77,22 @@ impl ExecutionState {
         Self::from_inner(
             Inner {
                 handle: Some(handle),
+                input_tasks: Vec::new(),
                 output_tasks: Vec::new(),
+                released: false,
                 timed_out: false,
                 init_health: None,
             },
             exit,
         )
+    }
+
+    #[cfg(test)]
+    pub(in crate::service) fn new_for_test(
+        handle: ExecHandle,
+        exit: crate::reaper::ExitSlot,
+    ) -> Self {
+        Self::new(handle, exit)
     }
 
     /// Create execution state with an init health checker.
@@ -81,7 +107,9 @@ impl ExecutionState {
         Self::from_inner(
             Inner {
                 handle: Some(handle),
+                input_tasks: Vec::new(),
                 output_tasks: Vec::new(),
+                released: false,
                 timed_out: false,
                 init_health: Some(init_health),
             },
@@ -98,7 +126,9 @@ impl ExecutionState {
         Self::from_inner(
             Inner {
                 handle: Some(handle),
+                input_tasks: Vec::new(),
                 output_tasks: Vec::new(),
+                released: false,
                 timed_out: false,
                 init_health: None,
             },
@@ -133,41 +163,46 @@ impl ExecutionState {
     pub async fn send_input(
         &self,
         first: boxlite_shared::ExecStdin,
-        mut stream: tonic::Streaming<boxlite_shared::ExecStdin>,
-    ) -> Result<JoinHandle<Result<(), Status>>, Status> {
+        stream: impl Stream<Item = Result<boxlite_shared::ExecStdin, ExecutionError>>
+            + Send
+            + Unpin
+            + 'static,
+    ) -> Result<JoinHandle<Result<(), ExecutionError>>, ExecutionError> {
+        use futures::StreamExt as _;
+
         // Take stdin from handle
         let mut stdin = {
             let mut inner = self.inner.lock().await;
             let handle = inner
                 .handle
                 .as_mut()
-                .ok_or_else(|| Status::failed_precondition("Handle not available"))?;
+                .ok_or(ExecutionError::HandleUnavailable)?;
 
-            handle
-                .stdin()
-                .ok_or_else(|| Status::already_exists("Stdin already taken"))?
+            handle.stdin().ok_or(ExecutionError::StdinTaken)?
         };
 
         // Spawn forwarding task
+        let mut stream = stream;
         let task = tokio::spawn(async move {
             // Write first message data
             if !first.data.is_empty() {
                 stdin
                     .write_all(&first.data)
                     .await
-                    .map_err(|e| Status::internal(format!("Stdin write failed: {}", e)))?;
+                    .map_err(|e| ExecutionError::Io(e.to_string()))?;
             }
             if first.close {
                 return Ok(());
             }
 
             // Forward remaining messages
-            while let Some(msg) = stream.message().await? {
+            while let Some(msg) = stream.next().await {
+                let msg = msg?;
                 if !msg.data.is_empty() {
                     stdin
                         .write_all(&msg.data)
                         .await
-                        .map_err(|e| Status::internal(format!("Stdin write failed: {}", e)))?;
+                        .map_err(|e| ExecutionError::Io(e.to_string()))?;
                 }
                 if msg.close {
                     break;
@@ -175,8 +210,22 @@ impl ExecutionState {
             }
             Ok(())
         });
+        self.track_input_task(task.abort_handle()).await;
 
         Ok(task)
+    }
+
+    /// Track a task that owns stdin after it has been taken from the handle.
+    ///
+    /// Release can race with task creation. A task registered after release is
+    /// aborted immediately instead of escaping the execution's lifetime.
+    async fn track_input_task(&self, task: AbortHandle) {
+        let mut inner = self.inner.lock().await;
+        if inner.released {
+            task.abort();
+        } else {
+            inner.input_tasks.push(task);
+        }
     }
 
     /// Wait for process to exit.
@@ -192,6 +241,52 @@ impl ExecutionState {
         self.exit.get().await
     }
 
+    /// Wait for exit and classify it.
+    ///
+    /// The SIGKILL diagnosis lives here rather than in a caller because
+    /// [`Self::check_container_death`] is private to the exec module: every
+    /// consumer — the RPC adapter and the in-process SSH bridge alike — must get
+    /// the same answer, including the reason a tenant was killed by pid-namespace
+    /// teardown rather than by its own exit.
+    pub(crate) async fn wait_exit(&self, exec_id: &str) -> ExecutionExit {
+        use crate::service::exec::exec_handle::ExitStatus;
+
+        match self.wait_process().await {
+            ExitStatus::Code(code) => {
+                tracing::debug!(execution_id = %exec_id, exit_code = code, "Process exited with code");
+                ExecutionExit {
+                    exit_code: code,
+                    signal: 0,
+                    error_message: String::new(),
+                }
+            }
+            ExitStatus::Signal(signal) => {
+                let mut error_message = String::new();
+                // PID namespace teardown SIGKILLs every process when init exits,
+                // so a bare SIGKILL is ambiguous without asking the container.
+                if signal == nix::sys::signal::Signal::SIGKILL {
+                    if let Some(diagnosis) = self.check_container_death().await {
+                        tracing::warn!(
+                            execution_id = %exec_id,
+                            signal = signal as i32,
+                            diagnosis = %diagnosis,
+                            "Process killed by container init death (PID namespace teardown). \
+                             The container's init process exited, causing all exec'd processes \
+                             to receive SIGKILL."
+                        );
+                        error_message = diagnosis;
+                    }
+                }
+                tracing::debug!(execution_id = %exec_id, signal = signal as i32, "Process exited due to signal");
+                ExecutionExit {
+                    exit_code: 0,
+                    signal: signal as i32,
+                    error_message,
+                }
+            }
+        }
+    }
+
     /// Attach to execution output.
     ///
     /// Takes stdout/stderr from handle and starts forwarding tasks.
@@ -199,7 +294,7 @@ impl ExecutionState {
     pub async fn attach(
         &self,
         exec_id: &str,
-    ) -> Result<mpsc::Receiver<Result<ExecOutput, Status>>, Status> {
+    ) -> Result<mpsc::Receiver<ExecOutput>, ExecutionError> {
         use boxlite_shared::{exec_output, Stderr, Stdout};
         use futures::StreamExt;
 
@@ -210,13 +305,13 @@ impl ExecutionState {
             let mut inner = self.inner.lock().await;
 
             if !inner.output_tasks.is_empty() {
-                return Err(Status::already_exists("Already attached"));
+                return Err(ExecutionError::AlreadyAttached);
             }
 
             let handle = inner
                 .handle
                 .as_mut()
-                .ok_or_else(|| Status::failed_precondition("Handle not available"))?;
+                .ok_or(ExecutionError::HandleUnavailable)?;
 
             let stdout = handle.stdout();
             let stderr = handle.stderr();
@@ -236,7 +331,7 @@ impl ExecutionState {
                     let msg = ExecOutput {
                         event: Some(exec_output::Event::Stdout(Stdout { data: chunk })),
                     };
-                    if tx.send(Ok(msg)).await.is_err() {
+                    if tx.send(msg).await.is_err() {
                         break;
                     }
                 }
@@ -254,7 +349,7 @@ impl ExecutionState {
                     let msg = ExecOutput {
                         event: Some(exec_output::Event::Stderr(Stderr { data: chunk })),
                     };
-                    if tx.send(Ok(msg)).await.is_err() {
+                    if tx.send(msg).await.is_err() {
                         break;
                     }
                 }
@@ -266,20 +361,55 @@ impl ExecutionState {
         // Store tasks
         {
             let mut inner = self.inner.lock().await;
-            inner.output_tasks = tasks;
+            if inner.released {
+                for task in tasks {
+                    task.abort();
+                }
+            } else {
+                inner.output_tasks = tasks;
+            }
         }
 
         Ok(rx)
     }
 
+    /// Drop every resource owned by an explicitly ephemeral execution.
+    ///
+    /// Ordinary SDK executions never call this method, so their repeatable wait
+    /// contract remains unchanged. Taking the handle closes any retained stdin,
+    /// stdout/stderr, and PTY controller descriptors even when another state
+    /// clone still exists. Forwarders are aborted because stdin may already have
+    /// moved out of the handle into one of those tasks.
+    pub(super) async fn release_resources(&self) -> bool {
+        let mut inner = self.inner.lock().await;
+        if inner.released {
+            return false;
+        }
+        inner.released = true;
+
+        for task in inner.input_tasks.drain(..) {
+            task.abort();
+        }
+        for task in inner.output_tasks.drain(..) {
+            task.abort();
+        }
+        drop(inner.handle.take());
+        drop(inner.init_health.take());
+        true
+    }
+
     /// Kill process with signal.
     ///
     /// Returns true if signal was sent, false if already exited.
-    pub async fn kill(&self, signal: nix::sys::signal::Signal) -> bool {
+    pub async fn kill(&self, signal: nix::sys::signal::Signal, process_group: bool) -> bool {
         let inner = self.inner.lock().await;
 
         if let Some(ref handle) = inner.handle {
-            handle.kill(signal).is_ok()
+            if process_group {
+                handle.kill_process_group(signal).is_ok()
+            } else {
+                handle.kill(signal).is_ok()
+            }
         } else {
             false
         }
@@ -292,7 +422,7 @@ impl ExecutionState {
         cols: u16,
         x_pixels: u16,
         y_pixels: u16,
-    ) -> Result<(), Status> {
+    ) -> Result<(), ExecutionError> {
         use nix::libc::TIOCSWINSZ;
         use nix::pty::Winsize;
 
@@ -301,11 +431,9 @@ impl ExecutionState {
         let handle = inner
             .handle
             .as_ref()
-            .ok_or_else(|| Status::failed_precondition("handle already consumed"))?;
+            .ok_or(ExecutionError::HandleUnavailable)?;
 
-        let controller = handle
-            .pty_controller()
-            .ok_or_else(|| Status::failed_precondition("not a PTY"))?;
+        let controller = handle.pty_controller().ok_or(ExecutionError::NotAPty)?;
 
         let winsize = Winsize {
             ws_row: rows,
@@ -317,10 +445,101 @@ impl ExecutionState {
         // Send TIOCSWINSZ ioctl
         unsafe {
             if nix::libc::ioctl(controller.as_raw_fd(), TIOCSWINSZ, &winsize as *const _) == -1 {
-                return Err(Status::internal("ioctl TIOCSWINSZ failed"));
+                return Err(ExecutionError::Io("ioctl TIOCSWINSZ failed".into()));
             }
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod release_tests {
+    use super::*;
+    use crate::reaper::ExitSlot;
+    use crate::service::exec::exec_handle::{ExitStatus, PtyConfig};
+    use nix::unistd::{pipe, Pid};
+    use std::os::fd::{AsRawFd, OwnedFd, RawFd};
+
+    fn fd_is_open(fd: RawFd) -> bool {
+        (unsafe { nix::libc::fcntl(fd, nix::libc::F_GETFD) }) != -1
+    }
+
+    fn state_with_tracked_handle() -> (ExecutionState, [RawFd; 4], Vec<OwnedFd>) {
+        let (stdin_peer, stdin) = pipe().unwrap();
+        let (stdout, stdout_peer) = pipe().unwrap();
+        let (stderr, stderr_peer) = pipe().unwrap();
+        let (pty_controller, pty_peer) = pipe().unwrap();
+        let tracked = [
+            stdin.as_raw_fd(),
+            stdout.as_raw_fd(),
+            stderr.as_raw_fd(),
+            pty_controller.as_raw_fd(),
+        ];
+
+        let mut handle = ExecHandle::new(Pid::from_raw(42_424), stdin, stdout, Some(stderr));
+        handle.set_pty(
+            std::fs::File::from(pty_controller),
+            PtyConfig {
+                rows: 24,
+                cols: 80,
+                x_pixels: 0,
+                y_pixels: 0,
+                modes: Vec::new(),
+            },
+        );
+        let state = ExecutionState::new(handle, ExitSlot::settled_for_test(ExitStatus::Code(0)));
+        (
+            state,
+            tracked,
+            vec![stdin_peer, stdout_peer, stderr_peer, pty_peer],
+        )
+    }
+
+    #[tokio::test]
+    async fn release_closes_handle_fds_and_aborts_forwarders_idempotently() {
+        let (state, tracked_fds, _peers) = state_with_tracked_handle();
+        let retained_clone = state.clone();
+        let (task_fd, task_peer) = pipe().unwrap();
+        let task_raw_fd = task_fd.as_raw_fd();
+        let task = tokio::spawn(async move {
+            let _task_fd = task_fd;
+            std::future::pending::<()>().await;
+        });
+        state.track_input_task(task.abort_handle()).await;
+
+        assert!(tracked_fds.into_iter().all(fd_is_open));
+        assert!(fd_is_open(task_raw_fd));
+        assert!(state.release_resources().await);
+        assert!(!state.release_resources().await);
+
+        assert!(tracked_fds.into_iter().all(|fd| !fd_is_open(fd)));
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_secs(1), task)
+                .await
+                .expect("aborted input task must finish")
+                .expect_err("input task must be cancelled")
+                .is_cancelled()
+        );
+        assert!(!fd_is_open(task_raw_fd));
+        assert!(retained_clone.get_pid().await.is_none());
+        drop(task_peer);
+    }
+
+    #[tokio::test]
+    async fn a_forwarder_registered_after_release_is_aborted() {
+        let (state, _tracked_fds, _peers) = state_with_tracked_handle();
+        assert!(state.release_resources().await);
+
+        let task = tokio::spawn(std::future::pending::<()>());
+        state.track_input_task(task.abort_handle()).await;
+
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_secs(1), task)
+                .await
+                .expect("late forwarder must finish")
+                .expect_err("late forwarder must be cancelled")
+                .is_cancelled()
+        );
     }
 }

--- a/src/guest/src/service/exec/timeout.rs
+++ b/src/guest/src/service/exec/timeout.rs
@@ -34,7 +34,7 @@ pub(super) fn start_timeout_watcher(
         use nix::sys::signal::Signal;
 
         // Stage 1: SIGTERM — polite termination request.
-        if !exec_state.kill(Signal::SIGTERM).await {
+        if !exec_state.kill(Signal::SIGTERM, false).await {
             // Process already exited on its own; nothing more to do.
             return;
         }
@@ -51,7 +51,7 @@ pub(super) fn start_timeout_watcher(
 
         // Stage 3: SIGKILL fallback. Returns false if SIGTERM was honored
         // during the grace window (clean exit, no escalation needed).
-        if exec_state.kill(Signal::SIGKILL).await {
+        if exec_state.kill(Signal::SIGKILL, false).await {
             warn!(
                 execution_id = %exec_id,
                 "SIGKILL after grace expired; workload did not exit on SIGTERM"

--- a/src/guest/src/service/exec/tty.rs
+++ b/src/guest/src/service/exec/tty.rs
@@ -1,0 +1,363 @@
+//! Validation and Linux termios application for execution PTYs.
+
+use super::exec_handle::{PtyConfig, PtyMode};
+use boxlite_shared::errors::{BoxliteError, BoxliteResult};
+use nix::libc;
+use std::os::fd::AsRawFd;
+
+const MAX_TERMINAL_MODES: usize = 256;
+
+impl TryFrom<&boxlite_shared::TtyConfig> for PtyConfig {
+    type Error = BoxliteError;
+
+    fn try_from(config: &boxlite_shared::TtyConfig) -> Result<Self, Self::Error> {
+        if config.modes.len() > MAX_TERMINAL_MODES {
+            return Err(BoxliteError::InvalidArgument(format!(
+                "TTY has {} terminal modes; maximum is {MAX_TERMINAL_MODES}",
+                config.modes.len()
+            )));
+        }
+
+        let modes = config
+            .modes
+            .iter()
+            .map(|mode| {
+                let opcode = u8::try_from(mode.opcode).map_err(|_| {
+                    BoxliteError::InvalidArgument(format!(
+                        "TTY mode opcode {} exceeds the RFC 4254 byte range",
+                        mode.opcode
+                    ))
+                })?;
+                if is_control_character(opcode) && mode.value > u8::MAX as u32 {
+                    return Err(BoxliteError::InvalidArgument(format!(
+                        "TTY control-character mode {opcode} has value {} outside the byte range",
+                        mode.value
+                    )));
+                }
+                Ok(PtyMode {
+                    opcode,
+                    value: mode.value,
+                })
+            })
+            .collect::<BoxliteResult<Vec<_>>>()?;
+
+        Ok(Self {
+            rows: dimension("rows", config.rows)?,
+            cols: dimension("cols", config.cols)?,
+            x_pixels: dimension("x_pixels", config.x_pixels)?,
+            y_pixels: dimension("y_pixels", config.y_pixels)?,
+            modes,
+        })
+    }
+}
+
+pub(crate) fn dimension(name: &str, value: u32) -> BoxliteResult<u16> {
+    u16::try_from(value).map_err(|_| {
+        BoxliteError::InvalidArgument(format!(
+            "TTY {name} value {value} exceeds the kernel u16 limit"
+        ))
+    })
+}
+
+/// Apply RFC 4254 terminal modes to an already-open Linux PTY endpoint.
+///
+/// Setting attributes through either the slave (direct guest execution) or
+/// the master (container console-socket execution) updates the shared PTY.
+pub(crate) fn apply_modes(fd: &impl AsRawFd, modes: &[PtyMode]) -> BoxliteResult<()> {
+    if modes.is_empty() {
+        return Ok(());
+    }
+
+    let raw_fd = fd.as_raw_fd();
+    let mut termios = read_termios(raw_fd)?;
+    for mode in modes {
+        apply_mode(&mut termios, mode)?;
+    }
+    write_termios(raw_fd, &termios)
+}
+
+fn read_termios(fd: libc::c_int) -> BoxliteResult<libc::termios> {
+    let mut termios = std::mem::MaybeUninit::<libc::termios>::uninit();
+    if unsafe { libc::tcgetattr(fd, termios.as_mut_ptr()) } == -1 {
+        return Err(BoxliteError::Internal(format!(
+            "Failed to read PTY terminal modes: {}",
+            std::io::Error::last_os_error()
+        )));
+    }
+    Ok(unsafe { termios.assume_init() })
+}
+
+fn write_termios(fd: libc::c_int, termios: &libc::termios) -> BoxliteResult<()> {
+    if unsafe { libc::tcsetattr(fd, libc::TCSANOW, termios) } == -1 {
+        return Err(BoxliteError::Internal(format!(
+            "Failed to apply PTY terminal modes: {}",
+            std::io::Error::last_os_error()
+        )));
+    }
+    Ok(())
+}
+
+fn apply_mode(termios: &mut libc::termios, mode: &PtyMode) -> BoxliteResult<()> {
+    let enabled = mode.value != 0;
+    match mode.opcode {
+        1 => set_control_character(termios, libc::VINTR, mode.value),
+        2 => set_control_character(termios, libc::VQUIT, mode.value),
+        3 => set_control_character(termios, libc::VERASE, mode.value),
+        4 => set_control_character(termios, libc::VKILL, mode.value),
+        5 => set_control_character(termios, libc::VEOF, mode.value),
+        6 => set_control_character(termios, libc::VEOL, mode.value),
+        7 => set_control_character(termios, libc::VEOL2, mode.value),
+        8 => set_control_character(termios, libc::VSTART, mode.value),
+        9 => set_control_character(termios, libc::VSTOP, mode.value),
+        10 => set_control_character(termios, libc::VSUSP, mode.value),
+        12 => set_control_character(termios, libc::VREPRINT, mode.value),
+        13 => set_control_character(termios, libc::VWERASE, mode.value),
+        14 => set_control_character(termios, libc::VLNEXT, mode.value),
+        16 => set_control_character(termios, libc::VSWTC, mode.value),
+        18 => set_control_character(termios, libc::VDISCARD, mode.value),
+
+        30 => set_flag(&mut termios.c_iflag, libc::IGNPAR, enabled),
+        31 => set_flag(&mut termios.c_iflag, libc::PARMRK, enabled),
+        32 => set_flag(&mut termios.c_iflag, libc::INPCK, enabled),
+        33 => set_flag(&mut termios.c_iflag, libc::ISTRIP, enabled),
+        34 => set_flag(&mut termios.c_iflag, libc::INLCR, enabled),
+        35 => set_flag(&mut termios.c_iflag, libc::IGNCR, enabled),
+        36 => set_flag(&mut termios.c_iflag, libc::ICRNL, enabled),
+        37 => set_flag(&mut termios.c_iflag, libc::IUCLC, enabled),
+        38 => set_flag(&mut termios.c_iflag, libc::IXON, enabled),
+        39 => set_flag(&mut termios.c_iflag, libc::IXANY, enabled),
+        40 => set_flag(&mut termios.c_iflag, libc::IXOFF, enabled),
+        41 => set_flag(&mut termios.c_iflag, libc::IMAXBEL, enabled),
+        42 => set_flag(&mut termios.c_iflag, libc::IUTF8, enabled),
+
+        50 => set_flag(&mut termios.c_lflag, libc::ISIG, enabled),
+        51 => set_flag(&mut termios.c_lflag, libc::ICANON, enabled),
+        52 => set_flag(&mut termios.c_lflag, libc::XCASE, enabled),
+        53 => set_flag(&mut termios.c_lflag, libc::ECHO, enabled),
+        54 => set_flag(&mut termios.c_lflag, libc::ECHOE, enabled),
+        55 => set_flag(&mut termios.c_lflag, libc::ECHOK, enabled),
+        56 => set_flag(&mut termios.c_lflag, libc::ECHONL, enabled),
+        57 => set_flag(&mut termios.c_lflag, libc::NOFLSH, enabled),
+        58 => set_flag(&mut termios.c_lflag, libc::TOSTOP, enabled),
+        59 => set_flag(&mut termios.c_lflag, libc::IEXTEN, enabled),
+        60 => set_flag(&mut termios.c_lflag, libc::ECHOCTL, enabled),
+        61 => set_flag(&mut termios.c_lflag, libc::ECHOKE, enabled),
+        62 => set_flag(&mut termios.c_lflag, libc::PENDIN, enabled),
+
+        70 => set_flag(&mut termios.c_oflag, libc::OPOST, enabled),
+        71 => set_flag(&mut termios.c_oflag, libc::OLCUC, enabled),
+        72 => set_flag(&mut termios.c_oflag, libc::ONLCR, enabled),
+        73 => set_flag(&mut termios.c_oflag, libc::OCRNL, enabled),
+        74 => set_flag(&mut termios.c_oflag, libc::ONOCR, enabled),
+        75 => set_flag(&mut termios.c_oflag, libc::ONLRET, enabled),
+
+        90 => set_character_size(termios, libc::CS7, enabled),
+        91 => set_character_size(termios, libc::CS8, enabled),
+        92 => set_flag(&mut termios.c_cflag, libc::PARENB, enabled),
+        93 => set_flag(&mut termios.c_cflag, libc::PARODD, enabled),
+
+        128 => set_speed(termios, mode.value, true)?,
+        129 => set_speed(termios, mode.value, false)?,
+        _ => {}
+    }
+    Ok(())
+}
+
+fn set_control_character(termios: &mut libc::termios, index: usize, value: u32) {
+    termios.c_cc[index] = if value == u8::MAX as u32 {
+        libc::_POSIX_VDISABLE
+    } else {
+        value as libc::cc_t
+    };
+}
+
+fn set_flag(flags: &mut libc::tcflag_t, flag: libc::tcflag_t, enabled: bool) {
+    if enabled {
+        *flags |= flag;
+    } else {
+        *flags &= !flag;
+    }
+}
+
+fn set_character_size(termios: &mut libc::termios, size: libc::tcflag_t, enabled: bool) {
+    let current_size = termios.c_cflag & libc::CSIZE;
+    if enabled {
+        termios.c_cflag = (termios.c_cflag & !libc::CSIZE) | size;
+    } else if current_size == size {
+        termios.c_cflag &= !libc::CSIZE;
+    }
+}
+
+fn set_speed(termios: &mut libc::termios, baud: u32, is_input: bool) -> BoxliteResult<()> {
+    let Some(speed) = baud_rate(baud) else {
+        // A PTY does not transmit over a physical line. Preserve its current
+        // speed when a platform cannot represent the client's baud rate.
+        return Ok(());
+    };
+    let result = if is_input {
+        unsafe { libc::cfsetispeed(termios, speed) }
+    } else {
+        unsafe { libc::cfsetospeed(termios, speed) }
+    };
+    if result == -1 {
+        return Err(BoxliteError::Internal(format!(
+            "Failed to set PTY baud rate {baud}: {}",
+            std::io::Error::last_os_error()
+        )));
+    }
+    Ok(())
+}
+
+fn baud_rate(baud: u32) -> Option<libc::speed_t> {
+    Some(match baud {
+        0 => libc::B0,
+        50 => libc::B50,
+        75 => libc::B75,
+        110 => libc::B110,
+        134 => libc::B134,
+        150 => libc::B150,
+        200 => libc::B200,
+        300 => libc::B300,
+        600 => libc::B600,
+        1_200 => libc::B1200,
+        1_800 => libc::B1800,
+        2_400 => libc::B2400,
+        4_800 => libc::B4800,
+        9_600 => libc::B9600,
+        19_200 => libc::B19200,
+        38_400 => libc::B38400,
+        57_600 => libc::B57600,
+        115_200 => libc::B115200,
+        230_400 => libc::B230400,
+        460_800 => libc::B460800,
+        500_000 => libc::B500000,
+        576_000 => libc::B576000,
+        921_600 => libc::B921600,
+        1_000_000 => libc::B1000000,
+        1_152_000 => libc::B1152000,
+        1_500_000 => libc::B1500000,
+        2_000_000 => libc::B2000000,
+        2_500_000 => libc::B2500000,
+        3_000_000 => libc::B3000000,
+        3_500_000 => libc::B3500000,
+        4_000_000 => libc::B4000000,
+        _ => return None,
+    })
+}
+
+fn is_control_character(opcode: u8) -> bool {
+    matches!(opcode, 1..=18)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nix::pty::{openpty, OpenptyResult};
+
+    fn wire_tty(rows: u32, modes: Vec<boxlite_shared::TtyMode>) -> boxlite_shared::TtyConfig {
+        boxlite_shared::TtyConfig {
+            rows,
+            cols: 80,
+            x_pixels: 0,
+            y_pixels: 0,
+            modes,
+        }
+    }
+
+    #[test]
+    fn validates_wire_dimensions_and_terminal_modes_without_truncation() {
+        let config = PtyConfig::try_from(&wire_tty(
+            24,
+            vec![boxlite_shared::TtyMode {
+                opcode: 53,
+                value: 0,
+            }],
+        ))
+        .unwrap();
+        assert_eq!(config.rows, 24);
+        assert_eq!(
+            config.modes[0],
+            PtyMode {
+                opcode: 53,
+                value: 0
+            }
+        );
+
+        let error = PtyConfig::try_from(&wire_tty(u16::MAX as u32 + 1, Vec::new())).unwrap_err();
+        assert!(error.to_string().contains("kernel u16 limit"));
+
+        let error = PtyConfig::try_from(&wire_tty(
+            24,
+            vec![boxlite_shared::TtyMode {
+                opcode: 1,
+                value: u8::MAX as u32 + 1,
+            }],
+        ))
+        .unwrap_err();
+        assert!(error.to_string().contains("outside the byte range"));
+
+        let error = PtyConfig::try_from(&wire_tty(
+            24,
+            vec![boxlite_shared::TtyMode {
+                opcode: u8::MAX as u32 + 1,
+                value: 0,
+            }],
+        ))
+        .unwrap_err();
+        assert!(error.to_string().contains("opcode"));
+    }
+
+    #[test]
+    fn applies_modes_through_both_pty_endpoints() {
+        let OpenptyResult { master, slave } = openpty(None, None).unwrap();
+        apply_modes(
+            &slave,
+            &[
+                PtyMode {
+                    opcode: 1,
+                    value: 3,
+                },
+                PtyMode {
+                    opcode: 2,
+                    value: u8::MAX as u32,
+                },
+                PtyMode {
+                    opcode: 36,
+                    value: 0,
+                },
+                PtyMode {
+                    opcode: 53,
+                    value: 0,
+                },
+                PtyMode {
+                    opcode: 128,
+                    value: 9_600,
+                },
+                PtyMode {
+                    opcode: 129,
+                    value: 9_600,
+                },
+            ],
+        )
+        .unwrap();
+
+        let termios = read_termios(master.as_raw_fd()).unwrap();
+        assert_eq!(termios.c_cc[libc::VINTR], 3);
+        assert_eq!(termios.c_cc[libc::VQUIT], libc::_POSIX_VDISABLE);
+        assert_eq!(termios.c_iflag & libc::ICRNL, 0);
+        assert_eq!(termios.c_lflag & libc::ECHO, 0);
+        assert_eq!(unsafe { libc::cfgetispeed(&termios) }, libc::B9600);
+        assert_eq!(unsafe { libc::cfgetospeed(&termios) }, libc::B9600);
+
+        apply_modes(
+            &master,
+            &[PtyMode {
+                opcode: 53,
+                value: 1,
+            }],
+        )
+        .unwrap();
+        let termios = read_termios(slave.as_raw_fd()).unwrap();
+        assert_ne!(termios.c_lflag & libc::ECHO, 0);
+    }
+}

--- a/src/guest/src/service/guest.rs
+++ b/src/guest/src/service/guest.rs
@@ -100,12 +100,13 @@ impl GuestService for GuestServer {
         // Stop accepts, close established transports, and wait until their
         // handlers can no longer register new executions before snapshotting
         // the execution registry below.
-        self.ssh_manager.shutdown().await.map_err(|error| {
-            error!(%error, "SSH sessions did not quiesce during guest shutdown");
-            Status::deadline_exceeded(format!(
-                "guest shutdown stopped before execution teardown: {error}"
-            ))
-        })?;
+        // Best-effort: the quiesce only buys ordering, so a stuck session must
+        // not strand containers or skip the filesystem sync below, which COW
+        // disk consistency on restart depends on. `shutting_down` is already
+        // set, so nothing else would finish the teardown if this returned.
+        let quiesce = self.ssh_manager.shutdown().await.inspect_err(|error| {
+            error!(%error, "SSH sessions did not quiesce; continuing guest teardown");
+        });
 
         // Step 1: Gracefully shutdown all running executions
         info!("Stopping running executions...");
@@ -166,6 +167,14 @@ impl GuestService for GuestServer {
             nix::libc::sync();
         }
 
+        // Report the degraded quiesce only now that containers are stopped,
+        // exit records are written and the filesystems are synced.
+        if let Err(error) = quiesce {
+            return Err(Status::deadline_exceeded(format!(
+                "guest teardown completed but SSH sessions did not quiesce: {error}"
+            )));
+        }
+
         info!("Graceful shutdown complete");
         Ok(Response::new(ShutdownResponse {}))
     }
@@ -201,5 +210,38 @@ impl GuestService for GuestServer {
         stored.clear();
 
         Ok(Response::new(ThawResponse { thawed_count }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::layout::GuestLayout;
+    use crate::reaper::ExitSlot;
+    use crate::service::exec::exec_handle::ExitStatus;
+
+    /// A quiesce that fails must not strand the rest of the teardown: the exit
+    /// record still reaches disk, and the failure is reported afterwards.
+    #[tokio::test]
+    async fn shutdown_writes_exit_records_when_ssh_fails_to_quiesce() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let server = GuestServer::new(GuestLayout::with_base(root.path()));
+        let exit_file = server.layout.shared().container("c1").exit_file();
+        std::fs::create_dir_all(exit_file.parent().expect("container root"))
+            .expect("container dir");
+        server.init_exits.lock().await.insert(
+            "c1".to_string(),
+            ExitSlot::settled_for_test(ExitStatus::Code(7)),
+        );
+
+        server.ssh_manager.close_connection_budget_for_test();
+        let status = server
+            .shutdown(Request::new(ShutdownRequest {}))
+            .await
+            .expect_err("a failed quiesce is reported to the host");
+
+        assert_eq!(status.code(), tonic::Code::DeadlineExceeded);
+        let written = boxlite_shared::layout::ExitRecord::read(&exit_file);
+        assert_eq!(written.map(|record| record.exit_code), Some(7));
     }
 }

--- a/src/guest/src/service/guest.rs
+++ b/src/guest/src/service/guest.rs
@@ -97,6 +97,16 @@ impl GuestService for GuestServer {
         self.shutting_down
             .store(true, std::sync::atomic::Ordering::SeqCst);
 
+        // Stop accepts, close established transports, and wait until their
+        // handlers can no longer register new executions before snapshotting
+        // the execution registry below.
+        self.ssh_manager.shutdown().await.map_err(|error| {
+            error!(%error, "SSH sessions did not quiesce during guest shutdown");
+            Status::deadline_exceeded(format!(
+                "guest shutdown stopped before execution teardown: {error}"
+            ))
+        })?;
+
         // Step 1: Gracefully shutdown all running executions
         info!("Stopping running executions...");
         self.registry

--- a/src/guest/src/service/mod.rs
+++ b/src/guest/src/service/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! This module contains the gRPC server and service implementations:
 //! - `guest`: Guest initialization and management (Init, Ping, Shutdown RPCs)
+//! - `ssh`: Live configure/status/disable control plus the SSH data plane
 //! - `container`: Container lifecycle (Init RPC)
 //! - `execution`: Command execution (Exec, Wait, Kill RPCs)
 
@@ -10,3 +11,4 @@ pub(crate) mod exec;
 pub(crate) mod files;
 mod guest;
 pub(crate) mod server;
+pub(crate) mod ssh;

--- a/src/guest/src/service/server.rs
+++ b/src/guest/src/service/server.rs
@@ -20,10 +20,12 @@ pub(crate) struct GuestInitState {
 
 /// Guest agent server.
 ///
-/// Implements three gRPC services:
+/// Implements the guest's gRPC services:
 /// - Guest: Agent initialization and management
+/// - Ssh: Live embedded-SSH listener control
 /// - Container: OCI container lifecycle
 /// - Execution: Command execution with bidirectional streaming
+/// - Files: Container-rootfs file transfer
 pub(crate) struct GuestServer {
     /// Guest filesystem layout
     pub layout: GuestLayout,
@@ -36,6 +38,9 @@ pub(crate) struct GuestServer {
 
     /// Execution registry for tracking running executions
     pub registry: ExecutionRegistry,
+
+    /// Independently reconfigurable embedded SSH listener.
+    pub ssh_manager: crate::service::ssh::SshManager,
 
     /// Mount points frozen by Quiesce RPC, thawed by Thaw RPC.
     pub frozen_mounts: Mutex<Vec<PathBuf>>,
@@ -68,6 +73,7 @@ impl GuestServer {
             init_state: Arc::new(Mutex::new(GuestInitState::default())),
             containers: Arc::new(Mutex::new(HashMap::new())),
             registry: ExecutionRegistry::new(),
+            ssh_manager: crate::service::ssh::SshManager::default(),
             frozen_mounts: Mutex::new(Vec::new()),
             shutting_down: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             init_exits: Arc::new(Mutex::new(HashMap::new())),
@@ -77,7 +83,7 @@ impl GuestServer {
     /// Run the tonic server listening on the specified transport.
     ///
     /// Binds to the specified transport (Unix, TCP, or Vsock) and serves
-    /// all three gRPC services on a single port.
+    /// all guest gRPC services on a single port.
     ///
     /// If `notify_uri` is provided, connects to that URI after the server
     /// is ready to serve, signaling readiness to the host.
@@ -96,15 +102,18 @@ impl GuestServer {
 
         // Wrap self in Arc for sharing across services
         let server = Arc::new(self);
+        server.ssh_manager.attach_guest(&server);
 
         let server_builder = Server::builder()
             .add_service(boxlite_shared::ContainerServer::from_arc(server.clone()))
             .add_service(boxlite_shared::GuestServer::from_arc(server.clone()))
+            .add_service(boxlite_shared::SshServer::from_arc(server.clone()))
             .add_service(boxlite_shared::ExecutionServer::from_arc(server.clone()))
             .add_service(boxlite_shared::FilesServer::from_arc(server.clone()));
 
         match transport {
             BoxTransport::Vsock { port } => {
+                use tokio_stream::StreamExt as _;
                 use tokio_vsock::{VsockAddr, VsockListener, VMADDR_CID_ANY};
 
                 info!("Binding to vsock port {}", port);
@@ -122,7 +131,26 @@ impl GuestServer {
                     port
                 );
 
-                let incoming = listener.incoming();
+                // AF_VSOCK is not a trust boundary by itself: a tenant process
+                // can make a loopback vsock connection from inside the VM. All
+                // guest RPCs are host control-plane operations, so reject every
+                // peer CID except the well-known host CID before tonic sees it.
+                let incoming = listener
+                    .incoming()
+                    .filter_map(|connection| match connection {
+                        Ok(stream) => match stream.peer_addr() {
+                            Ok(peer) if is_host_vsock_peer(peer) => Some(Ok(stream)),
+                            Ok(peer) => {
+                                warn!(peer_cid = peer.cid(), "Rejected non-host guest RPC peer");
+                                None
+                            }
+                            Err(error) => {
+                                warn!(%error, "Rejected guest RPC peer with no vsock address");
+                                None
+                            }
+                        },
+                        Err(error) => Some(Err(error)),
+                    });
 
                 tokio::spawn(async move {
                     if let Err(e) = notify_host_ready(notify_uri).await {
@@ -293,4 +321,21 @@ async fn notify_host_ready(notify_uri: Option<String>) -> BoxliteResult<()> {
     }
 
     Ok(())
+}
+
+fn is_host_vsock_peer(peer: tokio_vsock::VsockAddr) -> bool {
+    peer.cid() == tokio_vsock::VMADDR_CID_HOST
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio_vsock::{VsockAddr, VMADDR_CID_HOST, VMADDR_CID_LOCAL};
+
+    #[test]
+    fn guest_control_vsock_accepts_only_the_host_cid() {
+        assert!(is_host_vsock_peer(VsockAddr::new(VMADDR_CID_HOST, 1234)));
+        assert!(!is_host_vsock_peer(VsockAddr::new(VMADDR_CID_LOCAL, 1234)));
+        assert!(!is_host_vsock_peer(VsockAddr::new(42, 1234)));
+    }
 }

--- a/src/guest/src/service/ssh/auth.rs
+++ b/src/guest/src/service/ssh/auth.rs
@@ -1,0 +1,342 @@
+//! OpenSSH user-certificate authorization for the embedded server.
+
+use russh::keys::ssh_key::certificate::CertType;
+use russh::keys::{Algorithm, Certificate, HashAlg, PublicKey};
+
+pub(crate) const SSH_USER: &str = "root";
+
+#[derive(Debug)]
+pub(crate) enum AuthorizerError {
+    InvalidCaKey(String),
+    UnsupportedCaAlgorithm(Algorithm),
+    InvalidPrincipal,
+}
+
+impl std::fmt::Display for AuthorizerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidCaKey(error) => write!(f, "invalid SSH CA public key: {error}"),
+            Self::UnsupportedCaAlgorithm(algorithm) => write!(
+                f,
+                "unsupported SSH CA algorithm {algorithm}; only Ed25519 is enabled"
+            ),
+            Self::InvalidPrincipal => write!(
+                f,
+                "SSH certificate principal must be a non-empty URL-safe identifier"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for AuthorizerError {}
+
+#[derive(Clone)]
+pub(crate) struct CertificateAuthorizer {
+    ca_fingerprint: russh::keys::ssh_key::Fingerprint,
+    principal: String,
+}
+
+/// Capabilities granted by the authenticated OpenSSH user certificate.
+///
+/// OpenSSH certificates are deny-by-default: a capability is available only
+/// when its `permit-*` extension is present. Server-wide policy is applied on
+/// top of this identity at the request handler.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct CertificatePermissions {
+    pub(crate) pty: bool,
+    pub(crate) port_forwarding: bool,
+    pub(crate) agent_forwarding: bool,
+    pub(crate) x11_forwarding: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct AuthorizedIdentity {
+    pub(crate) permissions: CertificatePermissions,
+}
+
+impl CertificateAuthorizer {
+    pub(crate) fn new(
+        ca_public_key: &str,
+        principal: impl Into<String>,
+    ) -> Result<Self, AuthorizerError> {
+        let principal = principal.into();
+        if !is_valid_principal(&principal) {
+            return Err(AuthorizerError::InvalidPrincipal);
+        }
+
+        let ca_public_key = PublicKey::from_openssh(ca_public_key.trim())
+            .map_err(|error| AuthorizerError::InvalidCaKey(error.to_string()))?;
+        if ca_public_key.algorithm() != Algorithm::Ed25519 {
+            return Err(AuthorizerError::UnsupportedCaAlgorithm(
+                ca_public_key.algorithm(),
+            ));
+        }
+
+        Ok(Self {
+            ca_fingerprint: ca_public_key.fingerprint(HashAlg::Sha256),
+            principal,
+        })
+    }
+
+    /// Validate every security-relevant certificate field that russh leaves
+    /// to the application after it verifies proof of possession.
+    pub(crate) fn authorize(
+        &self,
+        user: &str,
+        certificate: &Certificate,
+    ) -> Option<AuthorizedIdentity> {
+        if user != SSH_USER
+            || certificate.cert_type() != CertType::User
+            || certificate.validate([&self.ca_fingerprint]).is_err()
+            || !certificate
+                .valid_principals()
+                .iter()
+                .any(|principal| principal == &self.principal)
+            || !certificate.critical_options().is_empty()
+        {
+            return None;
+        }
+
+        let extensions = certificate.extensions();
+        Some(AuthorizedIdentity {
+            permissions: CertificatePermissions {
+                pty: extensions.contains_key("permit-pty"),
+                port_forwarding: extensions.contains_key("permit-port-forwarding"),
+                agent_forwarding: extensions.contains_key("permit-agent-forwarding"),
+                x11_forwarding: extensions.contains_key("permit-X11-forwarding"),
+            },
+        })
+    }
+
+    #[cfg(test)]
+    fn is_authorized(&self, user: &str, certificate: &Certificate) -> bool {
+        self.authorize(user, certificate).is_some()
+    }
+}
+
+fn is_valid_principal(principal: &str) -> bool {
+    !principal.is_empty()
+        && principal.len() <= 128
+        && principal
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-' || byte == b'_')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use russh::keys::ssh_key::certificate::Builder;
+    use russh::keys::{Algorithm, EcdsaCurve, PrivateKey};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn private_key() -> PrivateKey {
+        let mut rng = russh::keys::key::safe_rng();
+        PrivateKey::random(&mut rng, Algorithm::Ed25519).unwrap()
+    }
+
+    fn public_key() -> String {
+        private_key().public_key().to_openssh().unwrap()
+    }
+
+    fn certificate(
+        ca_key: &PrivateKey,
+        principal: &str,
+        cert_type: CertType,
+        critical_option: bool,
+        valid_after: u64,
+        valid_before: u64,
+    ) -> Certificate {
+        let subject_key = private_key();
+        let mut rng = russh::keys::key::safe_rng();
+        let mut builder = Builder::new_with_random_nonce(
+            &mut rng,
+            subject_key.public_key(),
+            valid_after,
+            valid_before,
+        )
+        .unwrap();
+        builder.cert_type(cert_type).unwrap();
+        builder.valid_principal(principal).unwrap();
+        if critical_option {
+            builder
+                .critical_option("force-command", "echo unsafe")
+                .unwrap();
+        }
+        builder.sign(ca_key).unwrap()
+    }
+
+    #[test]
+    fn parses_a_ca_public_key_without_retaining_its_body() {
+        let authorizer = CertificateAuthorizer::new(&public_key(), "box_123").unwrap();
+        assert_eq!(authorizer.principal, "box_123");
+    }
+
+    #[test]
+    fn rejects_invalid_ca_and_unscoped_principal() {
+        assert!(matches!(
+            CertificateAuthorizer::new("not a key", "box_123"),
+            Err(AuthorizerError::InvalidCaKey(_))
+        ));
+        assert!(matches!(
+            CertificateAuthorizer::new(&public_key(), ""),
+            Err(AuthorizerError::InvalidPrincipal)
+        ));
+        assert!(matches!(
+            CertificateAuthorizer::new(&public_key(), "../other-box"),
+            Err(AuthorizerError::InvalidPrincipal)
+        ));
+
+        let mut rng = russh::keys::key::safe_rng();
+        let ecdsa_ca = PrivateKey::random(
+            &mut rng,
+            Algorithm::Ecdsa {
+                curve: EcdsaCurve::NistP256,
+            },
+        )
+        .unwrap()
+        .public_key()
+        .to_openssh()
+        .unwrap();
+        assert!(matches!(
+            CertificateAuthorizer::new(&ecdsa_ca, "box_123"),
+            Err(AuthorizerError::UnsupportedCaAlgorithm(_))
+        ));
+    }
+
+    #[test]
+    fn accepts_only_current_user_certificates_for_the_box_principal() {
+        let ca_key = private_key();
+        let other_ca = private_key();
+        let ca_public_key = ca_key.public_key().to_openssh().unwrap();
+        let authorizer = CertificateAuthorizer::new(&ca_public_key, "box_123").unwrap();
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+
+        let valid = certificate(
+            &ca_key,
+            "box_123",
+            CertType::User,
+            false,
+            now - 60,
+            now + 60,
+        );
+        assert!(authorizer.is_authorized("root", &valid));
+        assert!(!authorizer.is_authorized("nobody", &valid));
+
+        let wrong_ca = certificate(
+            &other_ca,
+            "box_123",
+            CertType::User,
+            false,
+            now - 60,
+            now + 60,
+        );
+        assert!(!authorizer.is_authorized("root", &wrong_ca));
+
+        let wrong_principal = certificate(
+            &ca_key,
+            "box_456",
+            CertType::User,
+            false,
+            now - 60,
+            now + 60,
+        );
+        assert!(!authorizer.is_authorized("root", &wrong_principal));
+
+        let host_certificate = certificate(
+            &ca_key,
+            "box_123",
+            CertType::Host,
+            false,
+            now - 60,
+            now + 60,
+        );
+        assert!(!authorizer.is_authorized("root", &host_certificate));
+    }
+
+    #[test]
+    fn rejects_expired_certificates_and_unknown_critical_options() {
+        let ca_key = private_key();
+        let ca_public_key = ca_key.public_key().to_openssh().unwrap();
+        let authorizer = CertificateAuthorizer::new(&ca_public_key, "box_123").unwrap();
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+
+        let expired = certificate(
+            &ca_key,
+            "box_123",
+            CertType::User,
+            false,
+            now - 120,
+            now - 60,
+        );
+        assert!(!authorizer.is_authorized("root", &expired));
+
+        let critical = certificate(&ca_key, "box_123", CertType::User, true, now - 60, now + 60);
+        assert!(!authorizer.is_authorized("root", &critical));
+    }
+
+    #[test]
+    fn certificate_extensions_grant_only_named_capabilities() {
+        let ca_key = private_key();
+        let authorizer =
+            CertificateAuthorizer::new(&ca_key.public_key().to_openssh().unwrap(), "box_123")
+                .unwrap();
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let subject_key = private_key();
+        let mut rng = russh::keys::key::safe_rng();
+        let mut builder =
+            Builder::new_with_random_nonce(&mut rng, subject_key.public_key(), now - 60, now + 60)
+                .unwrap();
+        builder.valid_principal("box_123").unwrap();
+        builder.extension("permit-pty", "").unwrap();
+        builder.extension("permit-port-forwarding", "").unwrap();
+        builder.extension("unknown-future-extension", "").unwrap();
+        let certificate = builder.sign(&ca_key).unwrap();
+
+        let identity = authorizer.authorize("root", &certificate).unwrap();
+        assert_eq!(
+            identity.permissions,
+            CertificatePermissions {
+                pty: true,
+                port_forwarding: true,
+                agent_forwarding: false,
+                x11_forwarding: false,
+            }
+        );
+    }
+
+    #[test]
+    fn accepts_an_rsa_subject_certificate_signed_by_the_ed25519_ca() {
+        let ca_key = private_key();
+        let authorizer =
+            CertificateAuthorizer::new(&ca_key.public_key().to_openssh().unwrap(), "box_123")
+                .unwrap();
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let mut rng = russh::keys::key::safe_rng();
+        let subject_key = PrivateKey::random(
+            &mut rng,
+            Algorithm::Rsa {
+                hash: Some(HashAlg::Sha512),
+            },
+        )
+        .unwrap();
+        let mut builder =
+            Builder::new_with_random_nonce(&mut rng, subject_key.public_key(), now - 60, now + 60)
+                .unwrap();
+        builder.valid_principal("box_123").unwrap();
+        let certificate = builder.sign(&ca_key).unwrap();
+
+        assert!(authorizer.is_authorized("root", &certificate));
+    }
+}

--- a/src/guest/src/service/ssh/backoff.rs
+++ b/src/guest/src/service/ssh/backoff.rs
@@ -1,0 +1,48 @@
+//! Bounded retry delay for transient TCP accept failures.
+
+use std::time::Duration;
+
+const INITIAL: Duration = Duration::from_millis(10);
+const MAX: Duration = Duration::from_secs(1);
+
+pub(crate) struct Backoff {
+    current: Duration,
+}
+
+impl Backoff {
+    pub(crate) fn new() -> Self {
+        Self { current: INITIAL }
+    }
+
+    pub(crate) fn reset(&mut self) {
+        self.current = INITIAL;
+    }
+
+    pub(crate) async fn wait(&mut self) {
+        tokio::time::sleep(self.current).await;
+        self.advance();
+    }
+
+    fn advance(&mut self) {
+        self.current = (self.current * 2).min(MAX);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn retry_delay_is_capped_and_resettable() {
+        let mut backoff = Backoff::new();
+        assert_eq!(backoff.current, INITIAL);
+
+        for _ in 0..16 {
+            backoff.advance();
+        }
+        assert_eq!(backoff.current, MAX);
+
+        backoff.reset();
+        assert_eq!(backoff.current, INITIAL);
+    }
+}

--- a/src/guest/src/service/ssh/bridge.rs
+++ b/src/guest/src/service/ssh/bridge.rs
@@ -21,6 +21,12 @@ use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinHandle;
 use tracing::{debug, warn};
 
+/// Starting directory for a session helper. The helper chdirs to the passwd
+/// home itself once it is inside the container (`session::enter_root_home`),
+/// which is the only place that directory can be read, so the request just
+/// needs a directory every image is guaranteed to have.
+const SESSION_WORKDIR: &str = "/";
+
 const GRACEFUL_TERMINATION_SIGNALS: [i32; 2] = [1, 15]; // SIGHUP, SIGTERM
 const FORCED_TERMINATION_SIGNAL: i32 = 9; // SIGKILL
 
@@ -118,8 +124,8 @@ impl ChannelBridge {
         channel_id: ChannelId,
         session_handle: SessionHandle,
     ) -> Result<Self, BridgeError> {
-        let (container_id, profile) = resolve_single_container_profile(&server).await?;
-        let launch = execution_launch(command, tty, env, &container_id, &profile);
+        let container_id = resolve_single_container(&server).await?;
+        let launch = execution_launch(command, tty, env, &container_id);
         let completion = launch.completion;
 
         let response = tokio::time::timeout(
@@ -326,18 +332,9 @@ impl Drop for ChannelBridge {
     }
 }
 
-pub(super) async fn resolve_single_container_profile(
-    server: &GuestServer,
-) -> Result<(String, crate::container::user_profile::RootSessionProfile), BridgeError> {
+pub(super) async fn resolve_single_container(server: &GuestServer) -> Result<String, BridgeError> {
     let containers = server.containers.lock().await;
-    let container_id = select_single_container_id(containers.keys())?;
-    let container = containers
-        .get(&container_id)
-        .expect("selected container remains registered while map is locked")
-        .clone();
-    drop(containers);
-    let profile = container.lock().await.root_session_profile();
-    Ok((container_id, profile))
+    select_single_container_id(containers.keys())
 }
 
 fn select_single_container_id<'a>(
@@ -374,12 +371,18 @@ fn container_exec_env(
 pub(super) fn session_exec_env(
     mut env: HashMap<String, String>,
     container_id: &str,
-    profile: &crate::container::user_profile::RootSessionProfile,
 ) -> HashMap<String, String> {
-    // Account identity is server-owned. Insert it after client-provided env so
-    // AcceptEnv cannot move a root login away from its passwd profile.
-    env.insert("HOME".into(), profile.home_dir.clone());
-    env.insert("SHELL".into(), profile.login_shell.clone());
+    // Account identity is server-owned. Apply it after client-provided env so
+    // an env request cannot rename a root login or point it at another home.
+    //
+    // HOME and SHELL are dropped rather than overwritten: neither is knowable
+    // out here, so there is no correct value to send. The session sets both
+    // once it is inside the container, from the passwd entry it can finally
+    // read, and libcontainer seeds HOME ahead of it when absent. Dropping is
+    // belt-and-braces against a future path that forwards client env without
+    // reaching that session — it is not what makes the account values win.
+    env.remove("HOME");
+    env.remove("SHELL");
     env.insert("USER".into(), SSH_USER.into());
     env.insert("LOGNAME".into(), SSH_USER.into());
     container_exec_env(env, container_id)
@@ -401,16 +404,15 @@ fn execution_launch(
     tty: Option<TtyConfig>,
     env: HashMap<String, String>,
     container_id: &str,
-    profile: &crate::container::user_profile::RootSessionProfile,
 ) -> ExecutionLaunch {
     match command {
         Command::Shell => {
-            let helper = session_launch(container_id, profile, env, SshWorkload::Shell);
+            let helper = session_launch(container_id, env, SshWorkload::Shell);
             ExecutionLaunch {
                 program: helper.program,
                 args: helper.args,
                 env: helper.env,
-                workdir: profile.home_dir.clone(),
+                workdir: SESSION_WORKDIR.into(),
                 tty,
                 user: helper.user,
                 completion: ChannelCompletion::Session,
@@ -418,12 +420,12 @@ fn execution_launch(
             }
         }
         Command::Exec(command) => {
-            let helper = session_launch(container_id, profile, env, SshWorkload::Exec { command });
+            let helper = session_launch(container_id, env, SshWorkload::Exec { command });
             ExecutionLaunch {
                 program: helper.program,
                 args: helper.args,
                 env: helper.env,
-                workdir: profile.home_dir.clone(),
+                workdir: SESSION_WORKDIR.into(),
                 tty,
                 user: helper.user,
                 completion: ChannelCompletion::Session,
@@ -431,12 +433,12 @@ fn execution_launch(
             }
         }
         Command::Sftp => {
-            let helper = sftp_launch(container_id, profile);
+            let helper = sftp_launch(container_id);
             ExecutionLaunch {
                 program: helper.program,
                 args: helper.args,
                 env: helper.env,
-                workdir: profile.home_dir.clone(),
+                workdir: SESSION_WORKDIR.into(),
                 tty: None,
                 user: helper.user,
                 completion: ChannelCompletion::Session,
@@ -444,7 +446,7 @@ fn execution_launch(
             }
         }
         Command::Streamlocal(socket_path) => {
-            let helper = streamlocal_launch(container_id, profile, socket_path);
+            let helper = streamlocal_launch(container_id, socket_path);
             ExecutionLaunch {
                 program: helper.program,
                 args: helper.args,
@@ -470,7 +472,6 @@ struct InternalHelperLaunch {
 
 fn internal_helper_launch(
     container_id: &str,
-    profile: &crate::container::user_profile::RootSessionProfile,
     workload: SshWorkload,
     env: HashMap<String, String>,
 ) -> InternalHelperLaunch {
@@ -481,7 +482,7 @@ fn internal_helper_launch(
         // requiring a helper executable in the container image.
         program,
         args,
-        env: session_exec_env(env, container_id, profile),
+        env: session_exec_env(env, container_id),
         // Server-owned SSH work always runs as container root. A numeric
         // identity works in scratch images that deliberately omit passwd.
         user: Some("0:0".to_string()),
@@ -491,28 +492,19 @@ fn internal_helper_launch(
 
 fn session_launch(
     container_id: &str,
-    profile: &crate::container::user_profile::RootSessionProfile,
     env: HashMap<String, String>,
     workload: SshWorkload,
 ) -> InternalHelperLaunch {
-    internal_helper_launch(container_id, profile, workload, env)
+    internal_helper_launch(container_id, workload, env)
 }
 
-fn sftp_launch(
-    container_id: &str,
-    profile: &crate::container::user_profile::RootSessionProfile,
-) -> InternalHelperLaunch {
-    internal_helper_launch(container_id, profile, SshWorkload::Sftp, HashMap::new())
+fn sftp_launch(container_id: &str) -> InternalHelperLaunch {
+    internal_helper_launch(container_id, SshWorkload::Sftp, HashMap::new())
 }
 
-fn streamlocal_launch(
-    container_id: &str,
-    profile: &crate::container::user_profile::RootSessionProfile,
-    socket_path: String,
-) -> InternalHelperLaunch {
+fn streamlocal_launch(container_id: &str, socket_path: String) -> InternalHelperLaunch {
     internal_helper_launch(
         container_id,
-        profile,
         SshWorkload::DirectStreamlocal { socket_path },
         HashMap::new(),
     )
@@ -885,13 +877,6 @@ mod tests {
     use crate::service::exec::state::ExecutionState;
     use nix::unistd::{pipe, Pid};
 
-    fn root_profile() -> crate::container::user_profile::RootSessionProfile {
-        crate::container::user_profile::RootSessionProfile {
-            home_dir: "/root".into(),
-            login_shell: "/bin/bash".into(),
-        }
-    }
-
     async fn pending_execution(
         registry: &ExecutionRegistry,
         execution_id: &str,
@@ -940,8 +925,7 @@ mod tests {
     }
 
     #[test]
-    fn shell_launch_uses_the_container_profile_and_protects_account_environment() {
-        let profile = root_profile();
+    fn shell_launch_protects_account_environment() {
         let mut env = HashMap::from([
             ("HOME".to_string(), "/attacker".to_string()),
             ("SHELL".to_string(), "/tmp/shell".to_string()),
@@ -951,7 +935,7 @@ mod tests {
         ]);
         env.insert(executor_const::ENV_VAR.to_string(), "guest".into());
 
-        let launch = execution_launch(Command::Shell, None, env, "container-1", &profile);
+        let launch = execution_launch(Command::Shell, None, env, "container-1");
 
         assert_eq!(
             launch.program,
@@ -961,12 +945,11 @@ mod tests {
             launch.args,
             [crate::service::ssh::session::INTERNAL_SESSION_ARG, "shell"]
         );
-        assert_eq!(launch.workdir, "/root");
-        assert_eq!(launch.env.get("HOME").map(String::as_str), Some("/root"));
-        assert_eq!(
-            launch.env.get("SHELL").map(String::as_str),
-            Some("/bin/bash")
-        );
+        assert_eq!(launch.workdir, "/");
+        // Not overwritten — removed, so libcontainer and the in-container
+        // session can supply the real account values.
+        assert!(!launch.env.contains_key("HOME"));
+        assert!(!launch.env.contains_key("SHELL"));
         assert_eq!(launch.env.get("USER").map(String::as_str), Some("root"));
         assert_eq!(launch.env.get("LOGNAME").map(String::as_str), Some("root"));
         assert_eq!(
@@ -987,7 +970,6 @@ mod tests {
             None,
             HashMap::new(),
             "container-1",
-            &root_profile(),
         );
 
         assert_eq!(
@@ -998,11 +980,11 @@ mod tests {
                 command
             ]
         );
-        assert_eq!(launch.workdir, "/root");
+        assert_eq!(launch.workdir, "/");
     }
 
     #[test]
-    fn sftp_launch_uses_root_home_without_a_tty_or_client_environment() {
+    fn sftp_launch_drops_the_tty_and_client_environment() {
         let mut env = HashMap::new();
         env.insert("LC_ALL".into(), "client-controlled".into());
         let launch = execution_launch(
@@ -1010,18 +992,16 @@ mod tests {
             Some(TtyConfig::default()),
             env,
             "container-1",
-            &root_profile(),
         );
 
-        assert_eq!(launch.workdir, "/root");
+        assert_eq!(launch.workdir, "/");
         assert!(launch.tty.is_none());
         assert!(!launch.env.contains_key("LC_ALL"));
-        assert_eq!(launch.env.get("HOME").map(String::as_str), Some("/root"));
     }
 
     #[test]
     fn sftp_uses_the_internal_container_workload() {
-        let launch = sftp_launch("container-1", &root_profile());
+        let launch = sftp_launch("container-1");
 
         assert_eq!(
             launch.program,
@@ -1029,8 +1009,7 @@ mod tests {
         );
         assert_eq!(launch.args, [crate::service::ssh::sftp::INTERNAL_SFTP_ARG]);
         assert_eq!(launch.user.as_deref(), Some("0:0"));
-        assert_eq!(launch.env.len(), 5);
-        assert_eq!(launch.env.get("HOME").map(String::as_str), Some("/root"));
+        assert_eq!(launch.env.len(), 3);
         assert_eq!(
             launch.env.get(executor_const::ENV_VAR).map(String::as_str),
             Some("container=container-1")
@@ -1039,7 +1018,7 @@ mod tests {
 
     #[test]
     fn streamlocal_uses_the_internal_container_workload() {
-        let launch = streamlocal_launch("container-1", &root_profile(), "/run/service.sock".into());
+        let launch = streamlocal_launch("container-1", "/run/service.sock".into());
 
         assert_eq!(
             launch.program,
@@ -1053,8 +1032,7 @@ mod tests {
             ]
         );
         assert_eq!(launch.user.as_deref(), Some("0:0"));
-        assert_eq!(launch.env.len(), 5);
-        assert_eq!(launch.env.get("HOME").map(String::as_str), Some("/root"));
+        assert_eq!(launch.env.len(), 3);
         assert_eq!(
             launch.env.get(executor_const::ENV_VAR).map(String::as_str),
             Some("container=container-1")

--- a/src/guest/src/service/ssh/bridge.rs
+++ b/src/guest/src/service/ssh/bridge.rs
@@ -1,0 +1,1226 @@
+//! Bridge one SSH channel to the guest's existing execution lifecycle.
+
+use crate::service::exec::error::ExecutionError;
+use crate::service::exec::registry::ExecutionRegistry;
+use crate::service::exec::TtyResize;
+use crate::service::server::GuestServer;
+use crate::service::ssh::auth::SSH_USER;
+use crate::service::ssh::limits::{
+    CONTROL_CALL_TIMEOUT, FORWARD_CONNECT_TIMEOUT, PROCESS_TERMINATION_GRACE, STDIN_QUEUE_DEPTH,
+};
+use crate::service::ssh::SshWorkload;
+use boxlite_shared::{
+    constants::executor as executor_const, ExecOutput, ExecRequest, ExecStdin, TtyConfig,
+};
+use futures::StreamExt as _;
+use russh::server::Handle as SessionHandle;
+use russh::{ChannelId, Sig};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::{mpsc, oneshot};
+use tokio::task::JoinHandle;
+use tracing::{debug, warn};
+
+const GRACEFUL_TERMINATION_SIGNALS: [i32; 2] = [1, 15]; // SIGHUP, SIGTERM
+const FORCED_TERMINATION_SIGNAL: i32 = 9; // SIGKILL
+
+/// SSH-owned signals address the execution's whole process group, never just
+/// its leader: a shell that has forked children must take them down with it.
+/// Every SSH kill site passes this rather than a literal, so the policy has one
+/// place to be read, changed, and asserted.
+pub(super) const SIGNAL_TARGETS_PROCESS_GROUP: bool = true;
+
+#[derive(Debug)]
+pub(crate) enum BridgeError {
+    Target(String),
+    Exec(String),
+    StdinClosed,
+}
+
+impl std::fmt::Display for BridgeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Target(error) => write!(f, "SSH execution target unavailable: {error}"),
+            Self::Exec(error) => write!(f, "SSH execution failed: {error}"),
+            Self::StdinClosed => write!(f, "SSH execution stdin is closed"),
+        }
+    }
+}
+
+impl std::error::Error for BridgeError {}
+
+impl From<ExecutionError> for BridgeError {
+    fn from(error: ExecutionError) -> Self {
+        Self::Exec(error.to_string())
+    }
+}
+
+pub(crate) enum Command {
+    Shell,
+    Exec(String),
+    Sftp,
+    Streamlocal(String),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ChannelCompletion {
+    Session,
+    Forwarding,
+}
+
+impl ChannelCompletion {
+    fn sends_exit_notification(self) -> bool {
+        matches!(self, Self::Session)
+    }
+}
+
+#[derive(Clone)]
+struct StdinForwarder {
+    execution_id: String,
+    sender: mpsc::Sender<ExecStdin>,
+}
+
+impl StdinForwarder {
+    async fn data(&self, data: Vec<u8>) -> Result<(), BridgeError> {
+        self.send(data, false).await
+    }
+
+    async fn eof(&self) -> Result<(), BridgeError> {
+        self.send(Vec::new(), true).await
+    }
+
+    async fn send(&self, data: Vec<u8>, close: bool) -> Result<(), BridgeError> {
+        self.sender
+            .send(ExecStdin {
+                execution_id: self.execution_id.clone(),
+                data,
+                close,
+            })
+            .await
+            .map_err(|_| BridgeError::StdinClosed)
+    }
+}
+
+pub(crate) struct ChannelBridge {
+    server: Arc<GuestServer>,
+    execution_id: String,
+    stdin: StdinForwarder,
+    output_activate: Option<oneshot::Sender<()>>,
+    output_cancel: Option<oneshot::Sender<()>>,
+}
+
+impl ChannelBridge {
+    pub(crate) async fn start(
+        server: Arc<GuestServer>,
+        command: Command,
+        tty: Option<TtyConfig>,
+        env: HashMap<String, String>,
+        channel_id: ChannelId,
+        session_handle: SessionHandle,
+    ) -> Result<Self, BridgeError> {
+        let (container_id, profile) = resolve_single_container_profile(&server).await?;
+        let launch = execution_launch(command, tty, env, &container_id, &profile);
+        let completion = launch.completion;
+
+        let response = tokio::time::timeout(
+            CONTROL_CALL_TIMEOUT,
+            crate::service::exec::start_ssh_execution(
+                &server,
+                ExecRequest {
+                    execution_id: None,
+                    program: launch.program,
+                    args: launch.args,
+                    env: launch.env,
+                    workdir: launch.workdir,
+                    timeout_ms: 0,
+                    tty: launch.tty,
+                    user: launch.user,
+                },
+                launch.workload,
+            ),
+        )
+        .await
+        .map_err(|_| BridgeError::Exec("exec timed out".into()))?;
+
+        if let Some(error) = response.error {
+            return Err(BridgeError::Exec(format!(
+                "{}: {}",
+                error.reason, error.detail
+            )));
+        }
+        let execution_id = response.execution_id;
+
+        // The core takes the execution id from the first frame, so open the
+        // stream with an empty one; an empty payload writes nothing.
+        let (stdin_tx, stdin_rx) = mpsc::channel::<ExecStdin>(STDIN_QUEUE_DEPTH);
+        let opening = ExecStdin {
+            execution_id: execution_id.clone(),
+            data: Vec::new(),
+            close: false,
+        };
+        let input_task = match server
+            .send_execution_input(
+                opening,
+                Box::pin(tokio_stream::wrappers::ReceiverStream::new(stdin_rx).map(Ok)),
+            )
+            .await
+        {
+            Ok(task) => task,
+            // The execution is already registered and running, so this failure
+            // path owes the same teardown every sibling below performs.
+            Err(error) => {
+                cleanup_failed_execution_start(server.clone(), execution_id);
+                return Err(error.into());
+            }
+        };
+        tokio::spawn(async move {
+            if let Ok(Err(error)) = input_task.await {
+                warn!(%error, "SSH stdin forwarding ended with an error");
+            }
+        });
+
+        let (output_start, output_activate) = if completion == ChannelCompletion::Forwarding {
+            let ready = match await_streamlocal_ready(&server, &execution_id).await {
+                Ok(ready) => ready,
+                Err(error) => {
+                    cleanup_failed_execution_start(server.clone(), execution_id);
+                    return Err(error);
+                }
+            };
+            let (activate_tx, activate_rx) = oneshot::channel();
+            (
+                OutputPumpStart::AwaitActivation {
+                    output: ready.output,
+                    buffered_stdout: ready.buffered_stdout,
+                    activate_rx,
+                },
+                Some(activate_tx),
+            )
+        } else {
+            (OutputPumpStart::Attach, None)
+        };
+
+        let (cancel_tx, cancel_rx) = oneshot::channel();
+        let output_task = spawn_output_pump(
+            server.clone(),
+            execution_id.clone(),
+            channel_id,
+            session_handle,
+            completion,
+            output_start,
+            cancel_rx,
+        );
+        spawn_execution_cleanup(server.registry.clone(), execution_id.clone(), output_task);
+
+        Ok(Self {
+            server,
+            execution_id: execution_id.clone(),
+            stdin: StdinForwarder {
+                execution_id,
+                sender: stdin_tx,
+            },
+            output_activate,
+            output_cancel: Some(cancel_tx),
+        })
+    }
+
+    /// Allow a prepared forwarding pump to emit buffered socket data only
+    /// after the SSH channel-open confirmation has been queued.
+    pub(crate) fn activate_output(&mut self) {
+        if let Some(activate) = self.output_activate.take() {
+            let _ = activate.send(());
+        }
+    }
+
+    pub(crate) async fn stdin(&self, data: Vec<u8>) -> Result<(), BridgeError> {
+        self.stdin.data(data).await
+    }
+
+    pub(crate) async fn stdin_eof(&self) -> Result<(), BridgeError> {
+        self.stdin.eof().await
+    }
+
+    pub(crate) async fn resize(
+        &self,
+        rows: u32,
+        cols: u32,
+        x_pixels: u32,
+        y_pixels: u32,
+    ) -> Result<(), BridgeError> {
+        let outcome = tokio::time::timeout(
+            CONTROL_CALL_TIMEOUT,
+            self.server
+                .resize_execution_tty(&self.execution_id, rows, cols, x_pixels, y_pixels),
+        )
+        .await
+        .map_err(|_| BridgeError::Exec("resize_tty timed out".into()))??;
+        match outcome {
+            TtyResize::Resized => Ok(()),
+            TtyResize::Rejected(reason) => Err(reason.into()),
+        }
+    }
+
+    pub(crate) async fn signal(&self, signal: i32) -> Result<(), BridgeError> {
+        send_group_signal(&self.server, &self.execution_id, signal).await
+    }
+
+    pub(crate) fn terminate_running(&mut self) {
+        let execution_id = self.execution_id.clone();
+        let server = self.server.clone();
+        tokio::spawn(terminate_process_group(server, execution_id));
+        if let Some(cancel) = self.output_cancel.take() {
+            let _ = cancel.send(());
+        }
+    }
+}
+
+async fn send_group_signal(
+    server: &GuestServer,
+    execution_id: &str,
+    signal: i32,
+) -> Result<(), BridgeError> {
+    let sent = tokio::time::timeout(
+        CONTROL_CALL_TIMEOUT,
+        server.kill_execution(execution_id, signal, SIGNAL_TARGETS_PROCESS_GROUP),
+    )
+    .await
+    .map_err(|_| BridgeError::Exec("kill timed out".into()))??;
+    if sent {
+        Ok(())
+    } else {
+        Err(BridgeError::Exec("kill rejected the signal".into()))
+    }
+}
+
+async fn terminate_process_group(server: Arc<GuestServer>, execution_id: String) {
+    // Give normal shell traps and cleanup handlers one fixed grace window.
+    // `timeout_at` prevents a stuck control call from postponing SIGKILL past
+    // the deadline.
+    let deadline = tokio::time::Instant::now() + PROCESS_TERMINATION_GRACE;
+    for signal in GRACEFUL_TERMINATION_SIGNALS {
+        match tokio::time::timeout_at(deadline, send_group_signal(&server, &execution_id, signal))
+            .await
+        {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => {
+                debug!(%error, %execution_id, signal, "SSH graceful group signal was not delivered");
+            }
+            Err(_) => break,
+        }
+    }
+    tokio::time::sleep_until(deadline).await;
+    if let Err(error) = send_group_signal(&server, &execution_id, FORCED_TERMINATION_SIGNAL).await {
+        debug!(%error, %execution_id, "SSH forced group signal was not delivered");
+    }
+}
+
+impl Drop for ChannelBridge {
+    fn drop(&mut self) {
+        // Transport loss may drop the russh handler without delivering a
+        // channel-close callback. Keep SSH-owned processes tied to the channel
+        // in that path as well; terminate_running takes the cancel sender so a
+        // normal channel-close does not start teardown twice.
+        if self.output_cancel.is_some() {
+            self.terminate_running();
+        }
+    }
+}
+
+pub(super) async fn resolve_single_container_profile(
+    server: &GuestServer,
+) -> Result<(String, crate::container::user_profile::RootSessionProfile), BridgeError> {
+    let containers = server.containers.lock().await;
+    let container_id = select_single_container_id(containers.keys())?;
+    let container = containers
+        .get(&container_id)
+        .expect("selected container remains registered while map is locked")
+        .clone();
+    drop(containers);
+    let profile = container.lock().await.root_session_profile();
+    Ok((container_id, profile))
+}
+
+fn select_single_container_id<'a>(
+    mut container_ids: impl Iterator<Item = &'a String>,
+) -> Result<String, BridgeError> {
+    let Some(container_id) = container_ids.next() else {
+        return Err(BridgeError::Target(
+            "no running container is registered".into(),
+        ));
+    };
+    let Some(_second_container_id) = container_ids.next() else {
+        return Ok(container_id.clone());
+    };
+
+    let count = 2 + container_ids.count();
+    Err(BridgeError::Target(format!(
+        "exactly one running container is required, found {count}"
+    )))
+}
+
+fn container_exec_env(
+    mut env: HashMap<String, String>,
+    container_id: &str,
+) -> HashMap<String, String> {
+    // Insert this after caller-provided variables so an SSH client cannot
+    // select the guest executor or a different container.
+    env.insert(
+        executor_const::ENV_VAR.to_string(),
+        format!("{}={container_id}", executor_const::CONTAINER_KEY),
+    );
+    env
+}
+
+pub(super) fn session_exec_env(
+    mut env: HashMap<String, String>,
+    container_id: &str,
+    profile: &crate::container::user_profile::RootSessionProfile,
+) -> HashMap<String, String> {
+    // Account identity is server-owned. Insert it after client-provided env so
+    // AcceptEnv cannot move a root login away from its passwd profile.
+    env.insert("HOME".into(), profile.home_dir.clone());
+    env.insert("SHELL".into(), profile.login_shell.clone());
+    env.insert("USER".into(), SSH_USER.into());
+    env.insert("LOGNAME".into(), SSH_USER.into());
+    container_exec_env(env, container_id)
+}
+
+struct ExecutionLaunch {
+    program: String,
+    args: Vec<String>,
+    env: HashMap<String, String>,
+    workdir: String,
+    tty: Option<TtyConfig>,
+    user: Option<String>,
+    completion: ChannelCompletion,
+    workload: SshWorkload,
+}
+
+fn execution_launch(
+    command: Command,
+    tty: Option<TtyConfig>,
+    env: HashMap<String, String>,
+    container_id: &str,
+    profile: &crate::container::user_profile::RootSessionProfile,
+) -> ExecutionLaunch {
+    match command {
+        Command::Shell => {
+            let helper = session_launch(container_id, profile, env, SshWorkload::Shell);
+            ExecutionLaunch {
+                program: helper.program,
+                args: helper.args,
+                env: helper.env,
+                workdir: profile.home_dir.clone(),
+                tty,
+                user: helper.user,
+                completion: ChannelCompletion::Session,
+                workload: helper.workload,
+            }
+        }
+        Command::Exec(command) => {
+            let helper = session_launch(container_id, profile, env, SshWorkload::Exec { command });
+            ExecutionLaunch {
+                program: helper.program,
+                args: helper.args,
+                env: helper.env,
+                workdir: profile.home_dir.clone(),
+                tty,
+                user: helper.user,
+                completion: ChannelCompletion::Session,
+                workload: helper.workload,
+            }
+        }
+        Command::Sftp => {
+            let helper = sftp_launch(container_id, profile);
+            ExecutionLaunch {
+                program: helper.program,
+                args: helper.args,
+                env: helper.env,
+                workdir: profile.home_dir.clone(),
+                tty: None,
+                user: helper.user,
+                completion: ChannelCompletion::Session,
+                workload: helper.workload,
+            }
+        }
+        Command::Streamlocal(socket_path) => {
+            let helper = streamlocal_launch(container_id, profile, socket_path);
+            ExecutionLaunch {
+                program: helper.program,
+                args: helper.args,
+                env: helper.env,
+                workdir: String::new(),
+                tty: None,
+                user: helper.user,
+                completion: ChannelCompletion::Forwarding,
+                workload: helper.workload,
+            }
+        }
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct InternalHelperLaunch {
+    program: String,
+    args: Vec<String>,
+    env: HashMap<String, String>,
+    user: Option<String>,
+    workload: SshWorkload,
+}
+
+fn internal_helper_launch(
+    container_id: &str,
+    profile: &crate::container::user_profile::RootSessionProfile,
+    workload: SshWorkload,
+    env: HashMap<String, String>,
+) -> InternalHelperLaunch {
+    let (program, args) = workload.placeholder();
+    InternalHelperLaunch {
+        // The zygote installs BoxliteWorkloadExecutor for tenant builds. This
+        // reserved argv[0] selects its narrow SSH workload surface without
+        // requiring a helper executable in the container image.
+        program,
+        args,
+        env: session_exec_env(env, container_id, profile),
+        // Server-owned SSH work always runs as container root. A numeric
+        // identity works in scratch images that deliberately omit passwd.
+        user: Some("0:0".to_string()),
+        workload,
+    }
+}
+
+fn session_launch(
+    container_id: &str,
+    profile: &crate::container::user_profile::RootSessionProfile,
+    env: HashMap<String, String>,
+    workload: SshWorkload,
+) -> InternalHelperLaunch {
+    internal_helper_launch(container_id, profile, workload, env)
+}
+
+fn sftp_launch(
+    container_id: &str,
+    profile: &crate::container::user_profile::RootSessionProfile,
+) -> InternalHelperLaunch {
+    internal_helper_launch(container_id, profile, SshWorkload::Sftp, HashMap::new())
+}
+
+fn streamlocal_launch(
+    container_id: &str,
+    profile: &crate::container::user_profile::RootSessionProfile,
+    socket_path: String,
+) -> InternalHelperLaunch {
+    internal_helper_launch(
+        container_id,
+        profile,
+        SshWorkload::DirectStreamlocal { socket_path },
+        HashMap::new(),
+    )
+}
+
+struct PreparedStreamlocalOutput {
+    output: mpsc::Receiver<ExecOutput>,
+    buffered_stdout: Vec<u8>,
+}
+
+enum OutputPumpStart {
+    Attach,
+    AwaitActivation {
+        output: mpsc::Receiver<ExecOutput>,
+        buffered_stdout: Vec<u8>,
+        activate_rx: oneshot::Receiver<()>,
+    },
+}
+
+#[derive(Default)]
+struct StreamlocalReadyParser {
+    matched: usize,
+}
+
+impl StreamlocalReadyParser {
+    fn push_stdout(&mut self, data: &[u8]) -> Result<Option<Vec<u8>>, BridgeError> {
+        let magic = crate::service::ssh::streamlocal::STREAMLOCAL_READY_MAGIC;
+        let prefix_bytes = (magic.len() - self.matched).min(data.len());
+        if data[..prefix_bytes] != magic[self.matched..self.matched + prefix_bytes] {
+            return Err(BridgeError::Exec(
+                "streamlocal helper returned an invalid readiness prefix".into(),
+            ));
+        }
+        self.matched += prefix_bytes;
+        if self.matched == magic.len() {
+            Ok(Some(data[prefix_bytes..].to_vec()))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+async fn await_streamlocal_ready(
+    server: &GuestServer,
+    execution_id: &str,
+) -> Result<PreparedStreamlocalOutput, BridgeError> {
+    tokio::time::timeout(FORWARD_CONNECT_TIMEOUT, async {
+        let mut output = server
+            .attach_execution(execution_id)
+            .await
+            .map_err(|error| BridgeError::Exec(format!("streamlocal attach failed: {error}")))?;
+        let mut parser = StreamlocalReadyParser::default();
+
+        loop {
+            let message = output.recv().await.ok_or_else(|| {
+                BridgeError::Exec("streamlocal helper exited before readiness".into())
+            })?;
+            match message.event {
+                Some(boxlite_shared::exec_output::Event::Stdout(stdout)) => {
+                    if let Some(buffered_stdout) = parser.push_stdout(&stdout.data)? {
+                        return Ok(PreparedStreamlocalOutput {
+                            output,
+                            buffered_stdout,
+                        });
+                    }
+                }
+                Some(boxlite_shared::exec_output::Event::Stderr(stderr)) => {
+                    debug!(
+                        bytes = stderr.data.len(),
+                        %execution_id,
+                        "streamlocal helper stderr before readiness"
+                    );
+                }
+                None => {}
+            }
+        }
+    })
+    .await
+    .map_err(|_| BridgeError::Exec("streamlocal readiness timed out".into()))?
+}
+
+const INDETERMINATE_EXIT_STATUS: u32 = 255;
+
+#[derive(Debug, Eq, PartialEq)]
+enum ExitNotification {
+    Status(u32),
+    Signal { number: i32, message: String },
+}
+
+fn spawn_output_pump(
+    server: Arc<GuestServer>,
+    execution_id: String,
+    channel_id: ChannelId,
+    session_handle: SessionHandle,
+    completion: ChannelCompletion,
+    output_start: OutputPumpStart,
+    mut cancel_rx: oneshot::Receiver<()>,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let (mut output, buffered_stdout) = match output_start {
+            OutputPumpStart::Attach => {
+                let attached = tokio::select! {
+                    _ = &mut cancel_rx => return,
+                    attached = tokio::time::timeout(
+                        CONTROL_CALL_TIMEOUT,
+                        server.attach_execution(&execution_id),
+                    ) => attached,
+                };
+                // Flatten first so each outcome is one arm and the compiler,
+                // not a panic, proves the match is exhaustive.
+                let attached = match attached {
+                    Ok(inner) => inner,
+                    Err(_) => Err(ExecutionError::Io("attach timed out".into())),
+                };
+                match attached {
+                    Ok(output) => (output, Vec::new()),
+                    Err(error) => {
+                        warn!(%error, %execution_id, "SSH attach failed");
+                        terminate_process_group(server.clone(), execution_id.clone()).await;
+                        finish_channel(
+                            &session_handle,
+                            channel_id,
+                            completion,
+                            ExitNotification::Status(INDETERMINATE_EXIT_STATUS),
+                        )
+                        .await;
+                        return;
+                    }
+                }
+            }
+            OutputPumpStart::AwaitActivation {
+                output,
+                buffered_stdout,
+                mut activate_rx,
+            } => {
+                let activated = tokio::select! {
+                    _ = &mut cancel_rx => return,
+                    activated = &mut activate_rx => activated,
+                };
+                if activated.is_err() {
+                    return;
+                }
+                (output, buffered_stdout)
+            }
+        };
+
+        if !buffered_stdout.is_empty() {
+            let _ = session_handle.data(channel_id, buffered_stdout).await;
+        }
+
+        loop {
+            tokio::select! {
+                // A resolved oneshot receiver must not be polled again by the
+                // wait select below. Cancellation means the channel lifecycle
+                // owner is already terminating the process group, so the
+                // output task can finish immediately.
+                _ = &mut cancel_rx => return,
+                message = output.recv() => {
+                    match message {
+                        Some(message) => match message.event {
+                            Some(boxlite_shared::exec_output::Event::Stdout(stdout)) => {
+                                let _ = session_handle.data(channel_id, stdout.data).await;
+                            }
+                            Some(boxlite_shared::exec_output::Event::Stderr(stderr)) => {
+                                let _ = session_handle.extended_data(channel_id, 1, stderr.data).await;
+                            }
+                            None => {}
+                        },
+                        None => break,
+                    }
+                }
+            }
+        }
+
+        // Output EOF and process exit are distinct. Programs may close stdout
+        // and stderr while continuing useful work, so the wait remains
+        // outstanding for their actual lifetime. Channel cancellation is the
+        // bounded escape path and triggers process-group teardown through
+        // ChannelBridge.
+        let exit = tokio::select! {
+            _ = &mut cancel_rx => return,
+            exit = server.wait_execution(&execution_id) => exit,
+        };
+
+        let notification = match exit {
+            Ok(exit) => exit_notification(exit.exit_code, exit.signal, exit.error_message),
+            Err(error) => {
+                warn!(%error, %execution_id, "SSH wait failed");
+                terminate_process_group(server, execution_id.clone()).await;
+                ExitNotification::Status(INDETERMINATE_EXIT_STATUS)
+            }
+        };
+
+        finish_channel(&session_handle, channel_id, completion, notification).await;
+    })
+}
+
+/// Keep one lifecycle owner for every SSH-created execution.
+///
+/// The output task may finish early because Attach failed or the SSH channel
+/// was cancelled. The cleanup task still waits for a confirmed process exit.
+/// Conversely, a process may exit before its buffered output is drained, so
+/// release waits for both before closing descriptors and removing the registry
+/// entry.
+fn spawn_execution_cleanup(
+    registry: ExecutionRegistry,
+    execution_id: String,
+    output_task: JoinHandle<()>,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let Some(state) = registry.get(&execution_id).await else {
+            return;
+        };
+
+        state.wait_process().await;
+        if let Err(error) = output_task.await {
+            warn!(%error, %execution_id, "SSH output task ended unexpectedly");
+        }
+
+        if !registry.release_ephemeral(&execution_id).await {
+            debug!(%execution_id, "SSH execution was already released");
+        }
+    })
+}
+
+fn cleanup_failed_execution_start(server: Arc<GuestServer>, execution_id: String) {
+    let cleanup_execution_id = execution_id.clone();
+    let output_task = tokio::spawn(async {});
+    spawn_execution_cleanup(server.registry.clone(), cleanup_execution_id, output_task);
+    tokio::spawn(terminate_process_group(server, execution_id));
+}
+
+fn exit_notification(exit_code: i32, signal: i32, error_message: String) -> ExitNotification {
+    if signal == 0 {
+        ExitNotification::Status(exit_code as u32)
+    } else {
+        ExitNotification::Signal {
+            number: signal,
+            message: error_message,
+        }
+    }
+}
+
+async fn finish_channel(
+    handle: &SessionHandle,
+    channel_id: ChannelId,
+    completion: ChannelCompletion,
+    notification: ExitNotification,
+) {
+    if completion.sends_exit_notification() {
+        match notification {
+            ExitNotification::Status(status) => {
+                let _ = handle.exit_status_request(channel_id, status).await;
+            }
+            ExitNotification::Signal { number, message } => {
+                let _ = handle
+                    .exit_signal_request(
+                        channel_id,
+                        ssh_signal(number),
+                        false,
+                        message,
+                        String::new(),
+                    )
+                    .await;
+            }
+        }
+    }
+    let _ = handle.eof(channel_id).await;
+    let _ = handle.close(channel_id).await;
+}
+
+pub(crate) fn signal_number(signal: &Sig) -> Option<i32> {
+    Some(match signal {
+        Sig::ABRT => 6,
+        Sig::ALRM => 14,
+        Sig::FPE => 8,
+        Sig::HUP => 1,
+        Sig::ILL => 4,
+        Sig::INT => 2,
+        Sig::KILL => 9,
+        Sig::PIPE => 13,
+        Sig::QUIT => 3,
+        Sig::SEGV => 11,
+        Sig::TERM => 15,
+        Sig::USR1 => 10,
+        Sig::Custom(name) => custom_signal_number(name)?,
+    })
+}
+
+fn custom_signal_number(name: &str) -> Option<i32> {
+    let name = name.strip_prefix("SIG").unwrap_or(name);
+    Some(match name {
+        "HUP" => 1,
+        "INT" => 2,
+        "QUIT" => 3,
+        "ILL" => 4,
+        "TRAP" => 5,
+        "ABRT" | "IOT" => 6,
+        "BUS" => 7,
+        "FPE" => 8,
+        "KILL" => 9,
+        "USR1" => 10,
+        "SEGV" => 11,
+        "USR2" => 12,
+        "PIPE" => 13,
+        "ALRM" => 14,
+        "TERM" => 15,
+        "STKFLT" => 16,
+        "CHLD" | "CLD" => 17,
+        "CONT" => 18,
+        "STOP" => 19,
+        "TSTP" => 20,
+        "TTIN" => 21,
+        "TTOU" => 22,
+        "URG" => 23,
+        "XCPU" => 24,
+        "XFSZ" => 25,
+        "VTALRM" => 26,
+        "PROF" => 27,
+        "WINCH" => 28,
+        "IO" | "POLL" => 29,
+        "PWR" => 30,
+        "SYS" => 31,
+        _ => return None,
+    })
+}
+
+fn ssh_signal(signal: i32) -> Sig {
+    match signal {
+        1 => Sig::HUP,
+        2 => Sig::INT,
+        3 => Sig::QUIT,
+        4 => Sig::ILL,
+        6 => Sig::ABRT,
+        8 => Sig::FPE,
+        9 => Sig::KILL,
+        10 => Sig::USR1,
+        11 => Sig::SEGV,
+        13 => Sig::PIPE,
+        14 => Sig::ALRM,
+        15 => Sig::TERM,
+        16 => Sig::Custom("STKFLT".into()),
+        5 => Sig::Custom("TRAP".into()),
+        7 => Sig::Custom("BUS".into()),
+        12 => Sig::Custom("USR2".into()),
+        17 => Sig::Custom("CHLD".into()),
+        18 => Sig::Custom("CONT".into()),
+        19 => Sig::Custom("STOP".into()),
+        20 => Sig::Custom("TSTP".into()),
+        21 => Sig::Custom("TTIN".into()),
+        22 => Sig::Custom("TTOU".into()),
+        23 => Sig::Custom("URG".into()),
+        24 => Sig::Custom("XCPU".into()),
+        25 => Sig::Custom("XFSZ".into()),
+        26 => Sig::Custom("VTALRM".into()),
+        27 => Sig::Custom("PROF".into()),
+        28 => Sig::Custom("WINCH".into()),
+        29 => Sig::Custom("IO".into()),
+        30 => Sig::Custom("PWR".into()),
+        31 => Sig::Custom("SYS".into()),
+        other => Sig::Custom(format!("SIGNAL-{other}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::reaper::ExitSlot;
+    use crate::service::exec::exec_handle::{ExecHandle, ExitStatus};
+    use crate::service::exec::state::ExecutionState;
+    use nix::unistd::{pipe, Pid};
+
+    fn root_profile() -> crate::container::user_profile::RootSessionProfile {
+        crate::container::user_profile::RootSessionProfile {
+            home_dir: "/root".into(),
+            login_shell: "/bin/bash".into(),
+        }
+    }
+
+    async fn pending_execution(
+        registry: &ExecutionRegistry,
+        execution_id: &str,
+        pid: i32,
+    ) -> tokio::sync::watch::Sender<Option<ExitStatus>> {
+        let (_stdin_peer, stdin) = pipe().unwrap();
+        let (stdout, _stdout_peer) = pipe().unwrap();
+        let (stderr, _stderr_peer) = pipe().unwrap();
+        let handle = ExecHandle::new(Pid::from_raw(pid), stdin, stdout, Some(stderr));
+        let (exit, exit_tx) = ExitSlot::pending_for_test();
+        let state = ExecutionState::new_for_test(handle, exit);
+        registry.register(execution_id.into(), state).await;
+        exit_tx
+    }
+
+    #[test]
+    fn execution_requires_exactly_one_container() {
+        let none = Vec::<String>::new();
+        assert!(matches!(
+            select_single_container_id(none.iter()),
+            Err(BridgeError::Target(_))
+        ));
+
+        let one = ["container-1".to_string()];
+        assert_eq!(
+            select_single_container_id(one.iter()).unwrap(),
+            "container-1"
+        );
+
+        let many = ["container-1".to_string(), "container-2".to_string()];
+        let error = select_single_container_id(many.iter()).unwrap_err();
+        assert!(error.to_string().contains("found 2"));
+    }
+
+    #[test]
+    fn caller_cannot_override_the_container_executor() {
+        let mut env = HashMap::new();
+        env.insert(executor_const::ENV_VAR.to_string(), "guest".to_string());
+
+        let env = container_exec_env(env, "container-1");
+
+        assert_eq!(
+            env.get(executor_const::ENV_VAR).map(String::as_str),
+            Some("container=container-1")
+        );
+    }
+
+    #[test]
+    fn shell_launch_uses_the_container_profile_and_protects_account_environment() {
+        let profile = root_profile();
+        let mut env = HashMap::from([
+            ("HOME".to_string(), "/attacker".to_string()),
+            ("SHELL".to_string(), "/tmp/shell".to_string()),
+            ("USER".to_string(), "somebody".to_string()),
+            ("LOGNAME".to_string(), "somebody".to_string()),
+            ("TERM".to_string(), "xterm-256color".to_string()),
+        ]);
+        env.insert(executor_const::ENV_VAR.to_string(), "guest".into());
+
+        let launch = execution_launch(Command::Shell, None, env, "container-1", &profile);
+
+        assert_eq!(
+            launch.program,
+            crate::service::ssh::workload::INTERNAL_PROGRAM
+        );
+        assert_eq!(
+            launch.args,
+            [crate::service::ssh::session::INTERNAL_SESSION_ARG, "shell"]
+        );
+        assert_eq!(launch.workdir, "/root");
+        assert_eq!(launch.env.get("HOME").map(String::as_str), Some("/root"));
+        assert_eq!(
+            launch.env.get("SHELL").map(String::as_str),
+            Some("/bin/bash")
+        );
+        assert_eq!(launch.env.get("USER").map(String::as_str), Some("root"));
+        assert_eq!(launch.env.get("LOGNAME").map(String::as_str), Some("root"));
+        assert_eq!(
+            launch.env.get("TERM").map(String::as_str),
+            Some("xterm-256color")
+        );
+        assert_eq!(
+            launch.env.get(executor_const::ENV_VAR).map(String::as_str),
+            Some("container=container-1")
+        );
+    }
+
+    #[test]
+    fn exec_launch_preserves_the_complete_command_as_one_argument() {
+        let command = "printf '%s' 'spaces ; $(still shell data)'";
+        let launch = execution_launch(
+            Command::Exec(command.into()),
+            None,
+            HashMap::new(),
+            "container-1",
+            &root_profile(),
+        );
+
+        assert_eq!(
+            launch.args,
+            [
+                crate::service::ssh::session::INTERNAL_SESSION_ARG,
+                "exec",
+                command
+            ]
+        );
+        assert_eq!(launch.workdir, "/root");
+    }
+
+    #[test]
+    fn sftp_launch_uses_root_home_without_a_tty_or_client_environment() {
+        let mut env = HashMap::new();
+        env.insert("LC_ALL".into(), "client-controlled".into());
+        let launch = execution_launch(
+            Command::Sftp,
+            Some(TtyConfig::default()),
+            env,
+            "container-1",
+            &root_profile(),
+        );
+
+        assert_eq!(launch.workdir, "/root");
+        assert!(launch.tty.is_none());
+        assert!(!launch.env.contains_key("LC_ALL"));
+        assert_eq!(launch.env.get("HOME").map(String::as_str), Some("/root"));
+    }
+
+    #[test]
+    fn sftp_uses_the_internal_container_workload() {
+        let launch = sftp_launch("container-1", &root_profile());
+
+        assert_eq!(
+            launch.program,
+            crate::service::ssh::workload::INTERNAL_PROGRAM
+        );
+        assert_eq!(launch.args, [crate::service::ssh::sftp::INTERNAL_SFTP_ARG]);
+        assert_eq!(launch.user.as_deref(), Some("0:0"));
+        assert_eq!(launch.env.len(), 5);
+        assert_eq!(launch.env.get("HOME").map(String::as_str), Some("/root"));
+        assert_eq!(
+            launch.env.get(executor_const::ENV_VAR).map(String::as_str),
+            Some("container=container-1")
+        );
+    }
+
+    #[test]
+    fn streamlocal_uses_the_internal_container_workload() {
+        let launch = streamlocal_launch("container-1", &root_profile(), "/run/service.sock".into());
+
+        assert_eq!(
+            launch.program,
+            crate::service::ssh::workload::INTERNAL_PROGRAM
+        );
+        assert_eq!(
+            launch.args,
+            [
+                crate::service::ssh::streamlocal::INTERNAL_STREAMLOCAL_ARG,
+                "/run/service.sock"
+            ]
+        );
+        assert_eq!(launch.user.as_deref(), Some("0:0"));
+        assert_eq!(launch.env.len(), 5);
+        assert_eq!(launch.env.get("HOME").map(String::as_str), Some("/root"));
+        assert_eq!(
+            launch.env.get(executor_const::ENV_VAR).map(String::as_str),
+            Some("container=container-1")
+        );
+    }
+
+    #[test]
+    fn forwarding_completion_is_distinct_from_session_exit_notification() {
+        assert!(ChannelCompletion::Session.sends_exit_notification());
+        assert!(!ChannelCompletion::Forwarding.sends_exit_notification());
+    }
+
+    #[test]
+    fn streamlocal_readiness_prefix_can_be_fragmented() {
+        let magic = crate::service::ssh::streamlocal::STREAMLOCAL_READY_MAGIC;
+        let mut parser = StreamlocalReadyParser::default();
+
+        assert_eq!(parser.push_stdout(&magic[..3]).unwrap(), None);
+        assert_eq!(parser.push_stdout(&magic[3..11]).unwrap(), None);
+        assert_eq!(parser.push_stdout(&magic[11..]).unwrap(), Some(Vec::new()));
+    }
+
+    #[test]
+    fn streamlocal_readiness_preserves_coalesced_socket_payload() {
+        let magic = crate::service::ssh::streamlocal::STREAMLOCAL_READY_MAGIC;
+        let mut frame = magic.to_vec();
+        frame.extend_from_slice(b"socket payload");
+
+        let mut parser = StreamlocalReadyParser::default();
+        assert_eq!(
+            parser.push_stdout(&frame).unwrap(),
+            Some(b"socket payload".to_vec())
+        );
+    }
+
+    #[test]
+    fn streamlocal_readiness_rejects_non_helper_output() {
+        let mut parser = StreamlocalReadyParser::default();
+        assert!(parser.push_stdout(b"not readiness").is_err());
+    }
+
+    #[test]
+    fn ssh_teardown_escalates_hup_and_term_to_kill() {
+        assert_eq!(GRACEFUL_TERMINATION_SIGNALS, [1, 15]);
+        assert_eq!(FORCED_TERMINATION_SIGNAL, 9);
+        assert!(!PROCESS_TERMINATION_GRACE.is_zero());
+        // A shell that forked children must take them down with it, so the
+        // final signal addresses the group rather than the leader.
+        assert_eq!(
+            (FORCED_TERMINATION_SIGNAL, SIGNAL_TARGETS_PROCESS_GROUP),
+            (9, true)
+        );
+    }
+
+    #[test]
+    fn preserves_signal_termination_as_an_ssh_exit_signal() {
+        assert_eq!(
+            exit_notification(0, 15, "container init exited".into()),
+            ExitNotification::Signal {
+                number: 15,
+                message: "container init exited".into()
+            }
+        );
+        assert_eq!(
+            exit_notification(23, 0, String::new()),
+            ExitNotification::Status(23)
+        );
+        assert_eq!(signal_number(&Sig::TERM), Some(15));
+        assert_eq!(signal_number(&Sig::Custom("USR2".into())), Some(12));
+        assert_eq!(signal_number(&Sig::Custom("UNKNOWN".into())), None);
+    }
+
+    #[tokio::test]
+    async fn stdin_backpressure_preserves_more_than_one_queue_of_frames() {
+        let (sender, mut receiver) = mpsc::channel(STDIN_QUEUE_DEPTH);
+        let forwarder = StdinForwarder {
+            execution_id: "exec-1".into(),
+            sender,
+        };
+        let expected: Vec<Vec<u8>> = (0..(STDIN_QUEUE_DEPTH * 3))
+            .map(|index| vec![index as u8; 257])
+            .collect();
+        let sent = expected.clone();
+
+        let producer = tokio::spawn(async move {
+            for frame in sent {
+                forwarder.data(frame).await.unwrap();
+            }
+            forwarder.eof().await.unwrap();
+        });
+
+        let mut observed = Vec::new();
+        while let Some(message) = receiver.recv().await {
+            assert_eq!(message.execution_id, "exec-1");
+            if message.close {
+                break;
+            }
+            observed.push(message.data);
+        }
+        producer.await.unwrap();
+
+        assert_eq!(observed, expected);
+    }
+
+    #[tokio::test]
+    async fn attach_failure_still_releases_after_terminal_exit() {
+        let registry = ExecutionRegistry::new();
+        let exit_tx = pending_execution(&registry, "attach-failed", 31_001).await;
+        let output_task = tokio::spawn(async {});
+        let cleanup =
+            spawn_execution_cleanup(registry.clone(), "attach-failed".into(), output_task);
+
+        tokio::task::yield_now().await;
+        assert!(registry.exists("attach-failed").await);
+        exit_tx.send(Some(ExitStatus::Code(255))).unwrap();
+        tokio::time::timeout(CONTROL_CALL_TIMEOUT, cleanup)
+            .await
+            .expect("cleanup must finish after exit")
+            .unwrap();
+
+        assert!(!registry.exists("attach-failed").await);
+    }
+
+    #[tokio::test]
+    async fn cancelled_output_waiter_survives_until_teardown_reaps_process() {
+        let registry = ExecutionRegistry::new();
+        let exit_tx = pending_execution(&registry, "cancelled", 31_002).await;
+        let (cancel_tx, cancel_rx) = oneshot::channel::<()>();
+        let output_task = tokio::spawn(async move {
+            let _ = cancel_rx.await;
+        });
+        let cleanup = spawn_execution_cleanup(registry.clone(), "cancelled".into(), output_task);
+
+        cancel_tx.send(()).unwrap();
+        tokio::task::yield_now().await;
+        assert!(registry.exists("cancelled").await);
+
+        exit_tx
+            .send(Some(ExitStatus::Signal(nix::sys::signal::Signal::SIGKILL)))
+            .unwrap();
+        tokio::time::timeout(CONTROL_CALL_TIMEOUT, cleanup)
+            .await
+            .expect("cleanup must finish after teardown exit")
+            .unwrap();
+        assert!(!registry.exists("cancelled").await);
+    }
+
+    #[tokio::test]
+    async fn terminal_execution_is_retained_until_output_is_drained() {
+        let registry = ExecutionRegistry::new();
+        let exit_tx = pending_execution(&registry, "draining", 31_003).await;
+        let (drained_tx, drained_rx) = oneshot::channel::<()>();
+        let output_task = tokio::spawn(async move {
+            let _ = drained_rx.await;
+        });
+        let cleanup = spawn_execution_cleanup(registry.clone(), "draining".into(), output_task);
+
+        exit_tx.send(Some(ExitStatus::Code(0))).unwrap();
+        tokio::task::yield_now().await;
+        assert!(registry.exists("draining").await);
+
+        drained_tx.send(()).unwrap();
+        tokio::time::timeout(CONTROL_CALL_TIMEOUT, cleanup)
+            .await
+            .expect("cleanup must finish after output drains")
+            .unwrap();
+        assert!(!registry.exists("draining").await);
+    }
+}

--- a/src/guest/src/service/ssh/control.rs
+++ b/src/guest/src/service/ssh/control.rs
@@ -1,0 +1,79 @@
+use crate::service::server::GuestServer;
+use crate::service::ssh::{SshConfig, SshRuntimeStatus, SshStartError};
+use boxlite_shared::{
+    Ssh as SshService, SshConfigureRequest, SshConfigureResponse, SshDisableRequest,
+    SshDisableResponse, SshStatus, SshStatusRequest, SshStatusResponse,
+};
+use std::net::SocketAddr;
+use tonic::{Request, Response, Status};
+
+#[tonic::async_trait]
+impl SshService for GuestServer {
+    async fn configure(
+        &self,
+        request: Request<SshConfigureRequest>,
+    ) -> Result<Response<SshConfigureResponse>, Status> {
+        if !self.init_state.lock().await.initialized {
+            return Err(Status::failed_precondition(
+                "Guest.Init must complete before SSH is configured",
+            ));
+        }
+
+        let request = request.into_inner();
+        let listen_addr: SocketAddr = request.listen_address.parse().map_err(|error| {
+            Status::invalid_argument(format!("invalid SSH listen address: {error}"))
+        })?;
+        let config = SshConfig::new(listen_addr, request.ca_public_key, request.principal)
+            .map_err(|error| Status::invalid_argument(error.to_string()))?;
+        let status = self
+            .ssh_manager
+            .configure(config)
+            .await
+            .map_err(start_error_status)?;
+        Ok(Response::new(SshConfigureResponse {
+            status: Some(status.into()),
+        }))
+    }
+
+    async fn status(
+        &self,
+        _request: Request<SshStatusRequest>,
+    ) -> Result<Response<SshStatusResponse>, Status> {
+        Ok(Response::new(SshStatusResponse {
+            status: Some(self.ssh_manager.status().await.into()),
+        }))
+    }
+
+    async fn disable(
+        &self,
+        _request: Request<SshDisableRequest>,
+    ) -> Result<Response<SshDisableResponse>, Status> {
+        Ok(Response::new(SshDisableResponse {
+            status: Some(self.ssh_manager.disable().await.into()),
+        }))
+    }
+}
+
+impl From<SshRuntimeStatus> for SshStatus {
+    fn from(status: SshRuntimeStatus) -> Self {
+        Self {
+            enabled: status.enabled,
+            listen_address: status
+                .listen_addr
+                .map(|address| address.to_string())
+                .unwrap_or_default(),
+            generation: status.generation,
+            host_key_fingerprint: status.host_key_fingerprint.unwrap_or_default(),
+        }
+    }
+}
+
+fn start_error_status(error: SshStartError) -> Status {
+    match error {
+        SshStartError::ShuttingDown => Status::failed_precondition(error.to_string()),
+        SshStartError::Bind(error) => {
+            Status::unavailable(format!("failed to bind SSH listener: {error}"))
+        }
+        other => Status::internal(other.to_string()),
+    }
+}

--- a/src/guest/src/service/ssh/forward.rs
+++ b/src/guest/src/service/ssh/forward.rs
@@ -1,0 +1,490 @@
+//! TCP forwarding owned by one authenticated SSH connection.
+
+use crate::service::ssh::limits::{
+    FORWARD_CONNECT_TIMEOUT, MAX_FORWARD_CONNECTIONS, MAX_FORWARD_HOST_BYTES,
+    MAX_REMOTE_FORWARD_LISTENERS,
+};
+use russh::server::{ChannelOpenHandle, Handle as SessionHandle, Msg};
+use russh::{Channel, ChannelOpenFailure};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, MutexGuard};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::{oneshot, Semaphore};
+use tokio::task::JoinSet;
+use tracing::{debug, warn};
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct ForwardKey {
+    address: String,
+    port: u16,
+}
+
+struct ReverseListenerEntry {
+    identity: Arc<()>,
+    cancel: oneshot::Sender<()>,
+    stopped: oneshot::Receiver<()>,
+}
+
+/// Shared registration state lets a listener remove itself after an accept
+/// failure without awaiting or dropping its own task handle.
+#[derive(Clone, Default)]
+struct ReverseListenerRegistry {
+    entries: Arc<Mutex<HashMap<ForwardKey, ReverseListenerEntry>>>,
+}
+
+impl ReverseListenerRegistry {
+    fn register(
+        &self,
+        key: ForwardKey,
+        max_listeners: usize,
+    ) -> Option<ReverseListenerRegistration> {
+        let mut entries = self.lock();
+        if entries.len() >= max_listeners || entries.contains_key(&key) {
+            return None;
+        }
+
+        let identity = Arc::new(());
+        let (cancel_tx, cancel_rx) = oneshot::channel();
+        let (stopped_tx, stopped_rx) = oneshot::channel();
+        entries.insert(
+            key.clone(),
+            ReverseListenerEntry {
+                identity: identity.clone(),
+                cancel: cancel_tx,
+                stopped: stopped_rx,
+            },
+        );
+        Some(ReverseListenerRegistration {
+            registry: self.clone(),
+            key,
+            identity,
+            cancel: cancel_rx,
+            stopped: Some(stopped_tx),
+        })
+    }
+
+    async fn cancel(&self, key: &ForwardKey) -> bool {
+        let entry = self.lock().remove(key);
+        let Some(entry) = entry else {
+            return false;
+        };
+
+        let _ = entry.cancel.send(());
+        // Closing this receiver also counts as completion: it means the
+        // registration guard was dropped while its listener task unwound.
+        let _ = entry.stopped.await;
+        true
+    }
+
+    fn cancel_all(&self) {
+        let entries = self
+            .lock()
+            .drain()
+            .map(|(_, entry)| entry)
+            .collect::<Vec<_>>();
+        for entry in entries {
+            let _ = entry.cancel.send(());
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.lock().len()
+    }
+
+    fn lock(&self) -> MutexGuard<'_, HashMap<ForwardKey, ReverseListenerEntry>> {
+        self.entries
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+}
+
+struct ReverseListenerRegistration {
+    registry: ReverseListenerRegistry,
+    key: ForwardKey,
+    identity: Arc<()>,
+    cancel: oneshot::Receiver<()>,
+    stopped: Option<oneshot::Sender<()>>,
+}
+
+impl ReverseListenerRegistration {
+    async fn cancelled(&mut self) {
+        let _ = (&mut self.cancel).await;
+    }
+}
+
+impl Drop for ReverseListenerRegistration {
+    fn drop(&mut self) {
+        let mut entries = self.registry.lock();
+        let owns_entry = entries
+            .get(&self.key)
+            .is_some_and(|entry| Arc::ptr_eq(&entry.identity, &self.identity));
+        if owns_entry {
+            entries.remove(&self.key);
+        }
+        drop(entries);
+
+        if let Some(stopped) = self.stopped.take() {
+            let _ = stopped.send(());
+        }
+    }
+}
+
+/// Owns the socket relays and reverse listeners created by one SSH client.
+///
+/// TCP sockets can be opened by the guest because BoxLite containers share the
+/// guest network namespace. Filesystem-backed forwarding lives elsewhere: a
+/// guest path is not a container path once the mount namespace is created.
+pub(crate) struct ForwardingManager {
+    connection_permits: Arc<Semaphore>,
+    reverse_listeners: ReverseListenerRegistry,
+}
+
+impl ForwardingManager {
+    pub(crate) fn new() -> Self {
+        Self {
+            connection_permits: Arc::new(Semaphore::new(MAX_FORWARD_CONNECTIONS)),
+            reverse_listeners: ReverseListenerRegistry::default(),
+        }
+    }
+
+    /// Connect a client-opened `direct-tcpip` channel to its requested target.
+    pub(crate) async fn open_direct_tcpip(
+        &self,
+        channel: Channel<Msg>,
+        host: &str,
+        port: u32,
+        reply: ChannelOpenHandle,
+    ) {
+        let Some(port) = valid_target(host, port) else {
+            reply
+                .reject(ChannelOpenFailure::AdministrativelyProhibited)
+                .await;
+            return;
+        };
+
+        let Ok(permit) = self.connection_permits.clone().try_acquire_owned() else {
+            reply.reject(ChannelOpenFailure::ResourceShortage).await;
+            return;
+        };
+
+        let stream =
+            match tokio::time::timeout(FORWARD_CONNECT_TIMEOUT, TcpStream::connect((host, port)))
+                .await
+            {
+                Ok(Ok(stream)) => stream,
+                Ok(Err(error)) => {
+                    debug!(host, port, %error, "SSH direct TCP connect failed");
+                    reply.reject(ChannelOpenFailure::ConnectFailed).await;
+                    return;
+                }
+                Err(_) => {
+                    debug!(host, port, "SSH direct TCP connect timed out");
+                    reply.reject(ChannelOpenFailure::ConnectFailed).await;
+                    return;
+                }
+            };
+
+        reply.accept().await;
+        spawn_relay(channel, stream, permit);
+    }
+
+    /// Bind a loopback-only reverse forwarding listener.
+    pub(crate) async fn listen_tcpip(
+        &mut self,
+        requested_address: &str,
+        requested_port: &mut u32,
+        session_handle: SessionHandle,
+    ) -> bool {
+        if self.reverse_listeners.len() >= MAX_REMOTE_FORWARD_LISTENERS {
+            return false;
+        }
+        let Some(address) = loopback_bind_address(requested_address) else {
+            return false;
+        };
+        let Ok(port) = u16::try_from(*requested_port) else {
+            return false;
+        };
+
+        let listener = match TcpListener::bind((address.as_str(), port)).await {
+            Ok(listener) => listener,
+            Err(error) => {
+                debug!(%address, port, %error, "SSH reverse TCP bind failed");
+                return false;
+            }
+        };
+        let Ok(bound_addr) = listener.local_addr() else {
+            return false;
+        };
+        let bound_port = bound_addr.port();
+        let key = ForwardKey {
+            address: address.clone(),
+            port: bound_port,
+        };
+        let Some(registration) = self
+            .reverse_listeners
+            .register(key, MAX_REMOTE_FORWARD_LISTENERS)
+        else {
+            return false;
+        };
+
+        *requested_port = u32::from(bound_port);
+        spawn_reverse_listener(
+            listener,
+            address,
+            bound_port,
+            session_handle,
+            self.connection_permits.clone(),
+            registration,
+        );
+        true
+    }
+
+    pub(crate) async fn cancel_tcpip(&mut self, requested_address: &str, port: u32) -> bool {
+        let Some(address) = loopback_bind_address(requested_address) else {
+            return false;
+        };
+        let Ok(port) = u16::try_from(port) else {
+            return false;
+        };
+        let key = ForwardKey { address, port };
+        self.reverse_listeners.cancel(&key).await
+    }
+}
+
+impl Drop for ForwardingManager {
+    fn drop(&mut self) {
+        self.reverse_listeners.cancel_all();
+    }
+}
+
+fn valid_target(host: &str, port: u32) -> Option<u16> {
+    if host.is_empty()
+        || host.len() > MAX_FORWARD_HOST_BYTES
+        || host.bytes().any(|byte| byte.is_ascii_control())
+    {
+        return None;
+    }
+    let port = u16::try_from(port).ok()?;
+    (port != 0).then_some(port)
+}
+
+/// `GatewayPorts no`: remote forwards may listen only on guest loopback.
+fn loopback_bind_address(requested: &str) -> Option<String> {
+    match requested {
+        "" | "localhost" | "127.0.0.1" => Some("127.0.0.1".to_string()),
+        "::1" => Some("::1".to_string()),
+        _ => None,
+    }
+}
+
+fn spawn_relay(
+    channel: Channel<Msg>,
+    mut stream: TcpStream,
+    _permit: tokio::sync::OwnedSemaphorePermit,
+) {
+    tokio::spawn(async move {
+        let mut channel = channel.into_stream();
+        if let Err(error) = tokio::io::copy_bidirectional(&mut channel, &mut stream).await {
+            debug!(%error, "SSH TCP relay ended with an error");
+        }
+        let _ = tokio::io::AsyncWriteExt::shutdown(&mut channel).await;
+        let _ = tokio::io::AsyncWriteExt::shutdown(&mut stream).await;
+    });
+}
+
+fn spawn_reverse_listener(
+    listener: TcpListener,
+    connected_address: String,
+    connected_port: u16,
+    session_handle: SessionHandle,
+    permits: Arc<Semaphore>,
+    mut registration: ReverseListenerRegistration,
+) {
+    tokio::spawn(async move {
+        let mut pending_opens = JoinSet::new();
+        loop {
+            tokio::select! {
+                biased;
+                _ = registration.cancelled() => break,
+                completed = pending_opens.join_next(), if !pending_opens.is_empty() => {
+                    if let Some(Err(error)) = completed {
+                        warn!(%error, "SSH reverse TCP channel task failed");
+                    }
+                }
+                accepted = listener.accept() => {
+                    let (stream, originator) = match accepted {
+                        Ok(accepted) => accepted,
+                        Err(error) => {
+                            warn!(%error, "SSH reverse TCP listener failed");
+                            break;
+                        }
+                    };
+                    let Ok(permit) = permits.clone().try_acquire_owned() else {
+                        debug!(%originator, "SSH forwarding connection limit reached");
+                        continue;
+                    };
+
+                    let handle = session_handle.clone();
+                    let address = connected_address.clone();
+                    pending_opens.spawn(async move {
+                        let channel = tokio::time::timeout(
+                            FORWARD_CONNECT_TIMEOUT,
+                            handle.channel_open_forwarded_tcpip(
+                                address,
+                                u32::from(connected_port),
+                                originator.ip().to_string(),
+                                u32::from(originator.port()),
+                            ),
+                        )
+                        .await;
+                        match channel {
+                            Ok(Ok(channel)) => spawn_relay(channel, stream, permit),
+                            Ok(Err(error)) => {
+                                debug!(%error, "SSH client rejected reverse TCP channel")
+                            }
+                            Err(_) => {
+                                debug!(%originator, "SSH reverse TCP channel request timed out")
+                            }
+                        }
+                    });
+                }
+            }
+        }
+
+        finish_reverse_listener(listener, pending_opens, registration).await;
+    });
+}
+
+async fn finish_reverse_listener(
+    listener: TcpListener,
+    mut pending_opens: JoinSet<()>,
+    registration: ReverseListenerRegistration,
+) {
+    // Stop accepting first, then wait for every already-accepted channel open
+    // to resolve. Cancellation cannot report success while one of those tasks
+    // could still open a forwarded channel afterward.
+    drop(listener);
+    while let Some(completed) = pending_opens.join_next().await {
+        if let Err(error) = completed {
+            warn!(%error, "SSH reverse TCP channel task failed");
+        }
+    }
+    drop(registration);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn direct_targets_are_bounded_and_require_a_real_port() {
+        assert_eq!(valid_target("localhost", 22), Some(22));
+        assert_eq!(valid_target("::1", 65_535), Some(65_535));
+        assert_eq!(valid_target("localhost", 0), None);
+        assert_eq!(valid_target("localhost", 65_536), None);
+        assert_eq!(valid_target("bad\nhost", 22), None);
+        assert_eq!(
+            valid_target(&"a".repeat(MAX_FORWARD_HOST_BYTES + 1), 22),
+            None
+        );
+    }
+
+    #[test]
+    fn reverse_forwarding_enforces_gateway_ports_no() {
+        assert_eq!(loopback_bind_address(""), Some("127.0.0.1".into()));
+        assert_eq!(loopback_bind_address("localhost"), Some("127.0.0.1".into()));
+        assert_eq!(loopback_bind_address("::1"), Some("::1".into()));
+        assert_eq!(loopback_bind_address("0.0.0.0"), None);
+        assert_eq!(loopback_bind_address("192.0.2.10"), None);
+    }
+
+    #[tokio::test]
+    async fn cancel_waits_for_the_listener_socket_and_pending_opens() {
+        let registry = ReverseListenerRegistry::default();
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let bound_address = listener.local_addr().unwrap();
+        let key = ForwardKey {
+            address: "127.0.0.1".into(),
+            port: bound_address.port(),
+        };
+        let registration = registry.register(key.clone(), 1).unwrap();
+        let (finish_tx, finish_rx) = oneshot::channel::<()>();
+        let mut pending_opens = JoinSet::new();
+        pending_opens.spawn(async move {
+            let _ = finish_rx.await;
+        });
+
+        let registry_for_cancel = registry.clone();
+        let cancel_task = tokio::spawn(async move { registry_for_cancel.cancel(&key).await });
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while registry.len() != 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("cancel must claim the registration");
+
+        let listener_task = tokio::spawn(finish_reverse_listener(
+            listener,
+            pending_opens,
+            registration,
+        ));
+        let replacement_listener = tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                if let Ok(listener) = TcpListener::bind(bound_address).await {
+                    break listener;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("cancel must close the listening socket");
+        assert!(!cancel_task.is_finished());
+
+        finish_tx.send(()).unwrap();
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_secs(1), cancel_task)
+                .await
+                .expect("cancel must finish at the listener boundary")
+                .unwrap()
+        );
+        listener_task.await.unwrap();
+        assert_eq!(registry.len(), 0);
+        drop(replacement_listener);
+        assert!(TcpStream::connect(bound_address).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn spontaneous_listener_exit_removes_only_its_registration() {
+        let registry = ReverseListenerRegistry::default();
+        let key = ForwardKey {
+            address: "127.0.0.1".into(),
+            port: 32_002,
+        };
+        let registration = registry.register(key.clone(), 1).unwrap();
+        assert_eq!(registry.len(), 1);
+
+        drop(registration);
+
+        assert_eq!(registry.len(), 0);
+        assert!(!registry.cancel(&key).await);
+    }
+
+    #[test]
+    fn an_old_listener_exit_cannot_remove_a_replacement_registration() {
+        let registry = ReverseListenerRegistry::default();
+        let key = ForwardKey {
+            address: "127.0.0.1".into(),
+            port: 32_003,
+        };
+        let old_registration = registry.register(key.clone(), 1).unwrap();
+        registry.cancel_all();
+        let replacement = registry.register(key, 1).unwrap();
+
+        drop(old_registration);
+        assert_eq!(registry.len(), 1);
+
+        drop(replacement);
+        assert_eq!(registry.len(), 0);
+    }
+}

--- a/src/guest/src/service/ssh/host_key.rs
+++ b/src/guest/src/service/ssh/host_key.rs
@@ -1,0 +1,181 @@
+//! Persistent Ed25519 host identity for the embedded SSH server.
+
+use russh::keys::{Algorithm, PrivateKey};
+use std::path::{Path, PathBuf};
+
+pub(crate) const DEFAULT_HOST_KEY_PATH: &str = "/var/lib/boxlite/ssh/ssh_host_ed25519_key";
+
+#[derive(Debug)]
+pub(crate) enum HostKeyError {
+    Io(std::io::Error),
+    InvalidFile(String),
+    Parse(String),
+}
+
+impl std::fmt::Display for HostKeyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(error) => write!(f, "host key I/O error: {error}"),
+            Self::InvalidFile(error) => write!(f, "invalid host key file: {error}"),
+            Self::Parse(error) => write!(f, "host key parse error: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for HostKeyError {}
+
+pub(crate) fn default_path() -> PathBuf {
+    PathBuf::from(DEFAULT_HOST_KEY_PATH)
+}
+
+/// Load the stable host key, or create it atomically on first boot.
+pub(crate) fn load_or_create(path: &Path) -> Result<PrivateKey, HostKeyError> {
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) => load_existing(path, &metadata),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => create_atomic(path),
+        Err(error) => Err(HostKeyError::Io(error)),
+    }
+}
+
+fn load_existing(path: &Path, metadata: &std::fs::Metadata) -> Result<PrivateKey, HostKeyError> {
+    use std::os::unix::fs::PermissionsExt;
+
+    if !metadata.file_type().is_file() {
+        return Err(HostKeyError::InvalidFile(
+            "path must be a regular file".into(),
+        ));
+    }
+    if metadata.permissions().mode() & 0o077 != 0 {
+        return Err(HostKeyError::InvalidFile(
+            "group or other permissions are not allowed".into(),
+        ));
+    }
+
+    let encoded = std::fs::read(path).map_err(HostKeyError::Io)?;
+    let key = PrivateKey::from_openssh(&encoded)
+        .map_err(|error| HostKeyError::Parse(error.to_string()))?;
+    if key.algorithm() != Algorithm::Ed25519 {
+        return Err(HostKeyError::InvalidFile(format!(
+            "unsupported algorithm {}; expected Ed25519",
+            key.algorithm()
+        )));
+    }
+    Ok(key)
+}
+
+fn create_atomic(path: &Path) -> Result<PrivateKey, HostKeyError> {
+    use std::io::Write;
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let parent = path.parent().ok_or_else(|| {
+        HostKeyError::InvalidFile("host key path must have a parent directory".into())
+    })?;
+    std::fs::create_dir_all(parent).map_err(HostKeyError::Io)?;
+
+    let mut rng = russh::keys::key::safe_rng();
+    let key = PrivateKey::random(&mut rng, Algorithm::Ed25519)
+        .map_err(|error| HostKeyError::Parse(error.to_string()))?;
+    let encoded = key
+        .to_openssh(russh::keys::ssh_key::LineEnding::LF)
+        .map_err(|error| HostKeyError::Parse(error.to_string()))?;
+
+    let temp_path = path.with_extension(format!("tmp-{}", uuid::Uuid::new_v4()));
+    let write_result = (|| {
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&temp_path)
+            .map_err(HostKeyError::Io)?;
+        file.write_all(encoded.as_bytes())
+            .map_err(HostKeyError::Io)?;
+        file.sync_all().map_err(HostKeyError::Io)?;
+        std::fs::rename(&temp_path, path).map_err(HostKeyError::Io)?;
+        std::fs::File::open(parent)
+            .and_then(|directory| directory.sync_all())
+            .map_err(HostKeyError::Io)?;
+        Ok::<(), HostKeyError>(())
+    })();
+
+    if write_result.is_err() {
+        let _ = std::fs::remove_file(&temp_path);
+    }
+    write_result?;
+
+    Ok(key)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn creates_a_private_ed25519_key_and_reuses_it() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("ssh").join("host_key");
+
+        let first = load_or_create(&path).unwrap();
+        let second = load_or_create(&path).unwrap();
+
+        assert_eq!(first.algorithm(), Algorithm::Ed25519);
+        assert_eq!(
+            first.public_key().to_openssh().unwrap(),
+            second.public_key().to_openssh().unwrap()
+        );
+
+        use std::os::unix::fs::PermissionsExt;
+        let mode = std::fs::metadata(path).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o600);
+    }
+
+    #[test]
+    fn rejects_corrupt_or_overexposed_existing_keys() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("host_key");
+        std::fs::write(&path, b"not an openssh private key").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
+        assert!(matches!(load_or_create(&path), Err(HostKeyError::Parse(_))));
+
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        assert!(matches!(
+            load_or_create(&path),
+            Err(HostKeyError::InvalidFile(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_a_non_ed25519_existing_host_key() {
+        use russh::keys::EcdsaCurve;
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("host_key");
+        let mut rng = russh::keys::key::safe_rng();
+        let key = PrivateKey::random(
+            &mut rng,
+            Algorithm::Ecdsa {
+                curve: EcdsaCurve::NistP256,
+            },
+        )
+        .unwrap();
+        std::fs::write(
+            &path,
+            key.to_openssh(russh::keys::ssh_key::LineEnding::LF)
+                .unwrap(),
+        )
+        .unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
+
+        assert!(matches!(
+            load_or_create(&path),
+            Err(HostKeyError::InvalidFile(_))
+        ));
+    }
+
+    #[test]
+    fn production_key_is_not_under_the_late_mounted_runtime_tree() {
+        assert!(!default_path().starts_with("/run/boxlite"));
+    }
+}

--- a/src/guest/src/service/ssh/limits.rs
+++ b/src/guest/src/service/ssh/limits.rs
@@ -1,0 +1,25 @@
+//! Resource bounds for the guest SSH listener.
+
+use std::time::Duration;
+
+pub(crate) const MAX_CONNECTIONS: usize = 128;
+pub(crate) const MAX_CHANNELS_PER_CONNECTION: usize = 16;
+pub(crate) const MAX_ENV_VARS: usize = 32;
+pub(crate) const MAX_ENV_NAME_BYTES: usize = 256;
+pub(crate) const MAX_ENV_VALUE_BYTES: usize = 4096;
+pub(crate) const MAX_TERM_BYTES: usize = 256;
+pub(crate) const MAX_COMMAND_BYTES: usize = 64 * 1024;
+pub(crate) const MAX_FORWARD_HOST_BYTES: usize = 253;
+// Linux sockaddr_un::sun_path is 108 bytes including its trailing NUL.
+pub(crate) const MAX_STREAMLOCAL_PATH_BYTES: usize = 107;
+pub(crate) const MAX_REMOTE_FORWARD_LISTENERS: usize = 16;
+pub(crate) const MAX_FORWARD_CONNECTIONS: usize = 64;
+pub(crate) const MAX_SFTP_HANDLES: usize = 256;
+pub(crate) const MAX_SFTP_READ_BYTES: usize = 256 * 1024;
+pub(crate) const MAX_SFTP_DIRECTORY_ENTRIES: usize = 128;
+pub(crate) const STDIN_QUEUE_DEPTH: usize = 32;
+pub(crate) const CONTROL_CALL_TIMEOUT: Duration = Duration::from_secs(10);
+pub(crate) const PROCESS_TERMINATION_GRACE: Duration = Duration::from_secs(1);
+pub(crate) const FORWARD_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+pub(crate) const AUTHENTICATION_TIMEOUT: Duration = Duration::from_secs(30);
+pub(crate) const DISCONNECT_GRACE_TIMEOUT: Duration = Duration::from_secs(1);

--- a/src/guest/src/service/ssh/mod.rs
+++ b/src/guest/src/service/ssh/mod.rs
@@ -1,0 +1,1247 @@
+#![cfg(target_os = "linux")]
+//! CA-authenticated SSH server embedded in `boxlite-guest`.
+//!
+//! The listener is opt-in and is reached through BoxLite's existing direct
+//! TCP tunnel. Session processes and the OCI-contained SFTP helper are
+//! delegated through the existing guest Execution service; TCP forwarding
+//! uses the network namespace shared by the guest and its one container.
+
+mod auth;
+mod backoff;
+mod bridge;
+mod control;
+mod forward;
+mod host_key;
+mod limits;
+mod reverse_streamlocal;
+mod server;
+mod session;
+mod sftp;
+mod streamlocal;
+mod workload;
+
+pub(crate) use workload::{BoxliteWorkloadExecutor, SshWorkload};
+
+use crate::service::server::GuestServer;
+use auth::CertificateAuthorizer;
+use backoff::Backoff;
+use boxlite_shared::errors::{BoxliteError, BoxliteResult};
+use russh::keys::HashAlg;
+use std::net::{Shutdown, SocketAddr};
+use std::path::PathBuf;
+use std::sync::{Arc, OnceLock, Weak};
+use tokio::net::TcpListener;
+use tokio::sync::{oneshot, watch, Mutex};
+use tokio::task::JoinHandle;
+use tracing::{debug, info, warn};
+
+/// Materialize the persistent SSH host key while the guest root is still
+/// writable.
+///
+/// A listener is configured later over RPC, long after
+/// [`crate::mounts::seal_root_readonly`] has run, and the key lives on the
+/// guest root rather than on one of the tmpfs mounts because clients pin it in
+/// `known_hosts` and it must survive a box restart. Creating it here keeps that
+/// storage unchanged: by the time a listener starts, `load_or_create` only ever
+/// reads.
+pub(crate) fn provision_host_key() -> BoxliteResult<()> {
+    host_key::load_or_create(&host_key::default_path())
+        .map(|_| ())
+        .map_err(|error| {
+            BoxliteError::Internal(format!("failed to provision SSH host key: {error}"))
+        })
+}
+
+#[derive(Clone)]
+pub(crate) struct SshConfig {
+    listen_addr: SocketAddr,
+    authorizer: Arc<CertificateAuthorizer>,
+    host_key_path: PathBuf,
+}
+
+impl SshConfig {
+    pub(crate) fn new(
+        listen_addr: SocketAddr,
+        ca_public_key: impl AsRef<str>,
+        principal: impl Into<String>,
+    ) -> BoxliteResult<Self> {
+        let authorizer = CertificateAuthorizer::new(ca_public_key.as_ref(), principal)
+            .map_err(|error| BoxliteError::Config(error.to_string()))?;
+        Ok(Self {
+            listen_addr,
+            authorizer: Arc::new(authorizer),
+            host_key_path: host_key::default_path(),
+        })
+    }
+
+    #[cfg(test)]
+    fn with_host_key_path(mut self, host_key_path: PathBuf) -> Self {
+        self.host_key_path = host_key_path;
+        self
+    }
+}
+
+/// Public state returned by the SSH control plane.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct SshRuntimeStatus {
+    pub enabled: bool,
+    pub listen_addr: Option<SocketAddr>,
+    pub generation: u64,
+    pub host_key_fingerprint: Option<String>,
+}
+
+/// Owns the live SSH listener independently from guest initialization.
+///
+/// The accept loop receives policy epochs through a watch channel. Policy is
+/// committed when authentication succeeds: rotation closes earlier transports
+/// that are still unauthenticated, while authenticated sessions retain their
+/// identity snapshot.
+pub(crate) struct SshManager {
+    guest: OnceLock<Weak<GuestServer>>,
+    state: Mutex<ManagerState>,
+    /// Authentication epoch shared by every listener generation. Updating it
+    /// wakes pre-authentication transports so revoked credentials cannot be
+    /// used through a connection opened before rotation or disable.
+    policy_tx: watch::Sender<Option<Arc<CertificateAuthorizer>>>,
+    /// One connection budget spans live listener rebinds. Existing sessions
+    /// may drain across a rebind without multiplying the configured bound.
+    connection_permits: Arc<tokio::sync::Semaphore>,
+    /// Guest shutdown is terminal and closes established transports; ordinary
+    /// Disable intentionally leaves authenticated connections draining.
+    shutdown_tx: watch::Sender<bool>,
+}
+
+impl Default for SshManager {
+    fn default() -> Self {
+        let (policy_tx, _) = watch::channel(None);
+        let (shutdown_tx, _) = watch::channel(false);
+        Self {
+            guest: OnceLock::new(),
+            state: Mutex::new(ManagerState::default()),
+            policy_tx,
+            connection_permits: Arc::new(tokio::sync::Semaphore::new(limits::MAX_CONNECTIONS)),
+            shutdown_tx,
+        }
+    }
+}
+
+#[derive(Default)]
+struct ManagerState {
+    generation: u64,
+    listener: Option<RunningListener>,
+}
+
+struct RunningListener {
+    requested_addr: SocketAddr,
+    bound_addr: SocketAddr,
+    host_key_fingerprint: String,
+    config: Arc<russh::server::Config>,
+    authorizer: Arc<CertificateAuthorizer>,
+    shutdown_tx: Option<oneshot::Sender<()>>,
+    task: JoinHandle<()>,
+}
+
+impl RunningListener {
+    async fn stop(mut self) -> StoppedListener {
+        if let Some(shutdown_tx) = self.shutdown_tx.take() {
+            let _ = shutdown_tx.send(());
+        }
+        if let Err(error) = self.task.await {
+            warn!(%error, "SSH listener task failed while stopping");
+        }
+        StoppedListener {
+            requested_addr: self.requested_addr,
+            host_key_fingerprint: self.host_key_fingerprint,
+            config: self.config,
+            authorizer: self.authorizer,
+        }
+    }
+}
+
+struct StoppedListener {
+    requested_addr: SocketAddr,
+    host_key_fingerprint: String,
+    config: Arc<russh::server::Config>,
+    authorizer: Arc<CertificateAuthorizer>,
+}
+
+struct PreparedListener {
+    config: Arc<russh::server::Config>,
+    host_key_fingerprint: String,
+}
+
+#[derive(Clone)]
+struct ConnectionContext {
+    guest: Arc<GuestServer>,
+    policy_rx: watch::Receiver<Option<Arc<CertificateAuthorizer>>>,
+    permits: Arc<tokio::sync::Semaphore>,
+    guest_shutdown_rx: watch::Receiver<bool>,
+}
+
+#[derive(Debug)]
+pub(crate) enum SshStartError {
+    NotAttached,
+    ShuttingDown,
+    HostKey(host_key::HostKeyError),
+    Bind(std::io::Error),
+    Rebind {
+        replacement: std::io::Error,
+        rollback: std::io::Error,
+    },
+}
+
+impl std::fmt::Display for SshStartError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotAttached => write!(f, "SSH manager is not attached to the guest server"),
+            Self::ShuttingDown => write!(f, "guest shutdown has started; SSH cannot be configured"),
+            Self::HostKey(error) => write!(f, "{error}"),
+            Self::Bind(error) => write!(f, "failed to bind SSH listener: {error}"),
+            Self::Rebind {
+                replacement,
+                rollback,
+            } => write!(
+                f,
+                "failed to bind replacement SSH listener ({replacement}) and restore the previous listener ({rollback})"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for SshStartError {}
+
+#[derive(Debug)]
+pub(crate) enum SshShutdownError {
+    ConnectionBudgetClosed,
+    TimedOut,
+}
+
+impl std::fmt::Display for SshShutdownError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ConnectionBudgetClosed => {
+                write!(f, "SSH connection budget closed during guest shutdown")
+            }
+            Self::TimedOut => write!(f, "timed out waiting for SSH sessions to stop"),
+        }
+    }
+}
+
+impl std::error::Error for SshShutdownError {}
+
+impl SshManager {
+    /// Attach the manager after `GuestServer` has been wrapped in its serving
+    /// `Arc`. The weak reference avoids a server/manager ownership cycle.
+    pub(crate) fn attach_guest(&self, guest: &Arc<GuestServer>) {
+        let _ = self.guest.set(Arc::downgrade(guest));
+    }
+
+    pub(crate) async fn configure(
+        &self,
+        ssh: SshConfig,
+    ) -> Result<SshRuntimeStatus, SshStartError> {
+        let guest = self
+            .guest
+            .get()
+            .and_then(Weak::upgrade)
+            .ok_or(SshStartError::NotAttached)?;
+        let mut state = self.state.lock().await;
+
+        // This check shares the listener-state critical section with every
+        // mutation. A Configure queued behind shutdown therefore cannot reopen
+        // the listener after teardown has disabled it.
+        if *self.shutdown_tx.borrow()
+            || guest
+                .shutting_down
+                .load(std::sync::atomic::Ordering::SeqCst)
+        {
+            return Err(SshStartError::ShuttingDown);
+        }
+
+        // Updating policy on the same fixed socket does not disrupt the
+        // listener. Pre-authentication connections observe the new epoch and
+        // are closed; authenticated connections keep their established policy.
+        let can_update_in_place = ssh.listen_addr.port() != 0
+            && state
+                .listener
+                .as_ref()
+                .is_some_and(|listener| listener.requested_addr == ssh.listen_addr);
+        if can_update_in_place {
+            state.generation = state.generation.saturating_add(1);
+            let listener = state.listener.as_mut().expect("listener checked above");
+            listener.authorizer = ssh.authorizer.clone();
+            self.policy_tx.send_replace(Some(ssh.authorizer));
+            info!(
+                listen_addr = %ssh.listen_addr,
+                generation = state.generation,
+                "embedded SSH authentication policy updated"
+            );
+            return Ok(runtime_status(&state));
+        }
+
+        let prepared = prepare_listener(&ssh).await?;
+        let mut listener_result = TcpListener::bind(ssh.listen_addr).await;
+        let mut stopped_listener = None;
+
+        // Switching between overlapping wildcard/specific bindings on the
+        // same port cannot be prepared concurrently. Stop our old listener and
+        // retry once; other bind failures leave the old listener untouched.
+        if listener_result
+            .as_ref()
+            .is_err_and(|error| error.kind() == std::io::ErrorKind::AddrInUse)
+            && state.listener.as_ref().is_some_and(|listener| {
+                listen_addresses_overlap(listener.bound_addr, ssh.listen_addr)
+            })
+        {
+            if let Some(listener) = state.listener.take() {
+                stopped_listener = Some(listener.stop().await);
+            }
+            listener_result = TcpListener::bind(ssh.listen_addr).await;
+        }
+
+        let listener = match listener_result {
+            Ok(listener) => listener,
+            Err(replacement) => {
+                let Some(previous) = stopped_listener else {
+                    return Err(SshStartError::Bind(replacement));
+                };
+                match restart_listener(
+                    previous,
+                    self.policy_tx.subscribe(),
+                    self.connection_permits.clone(),
+                    self.shutdown_tx.subscribe(),
+                    guest.clone(),
+                )
+                .await
+                {
+                    Ok(restored) => {
+                        state.listener = Some(restored);
+                        return Err(SshStartError::Bind(replacement));
+                    }
+                    Err(rollback) => {
+                        // No listener remains to own the old policy. Revoke it
+                        // explicitly so transports accepted by the stopped
+                        // generation cannot authenticate against stale state.
+                        self.policy_tx.send_replace(None);
+                        state.generation = state.generation.saturating_add(1);
+                        return Err(SshStartError::Rebind {
+                            replacement,
+                            rollback,
+                        });
+                    }
+                }
+            }
+        };
+        let previous_authorizer = state
+            .listener
+            .as_ref()
+            .map(|listener| listener.authorizer.clone())
+            .or_else(|| {
+                stopped_listener
+                    .as_ref()
+                    .map(|listener| listener.authorizer.clone())
+            });
+        let next_authorizer = ssh.authorizer;
+        self.policy_tx.send_replace(Some(next_authorizer.clone()));
+        let running = match start_listener(
+            listener,
+            ssh.listen_addr,
+            prepared.config,
+            prepared.host_key_fingerprint,
+            next_authorizer,
+            ConnectionContext {
+                guest,
+                policy_rx: self.policy_tx.subscribe(),
+                permits: self.connection_permits.clone(),
+                guest_shutdown_rx: self.shutdown_tx.subscribe(),
+            },
+        ) {
+            Ok(running) => running,
+            Err(replacement) => {
+                self.policy_tx.send_replace(previous_authorizer);
+                let Some(previous) = stopped_listener else {
+                    return Err(SshStartError::Bind(replacement));
+                };
+                match restart_listener(
+                    previous,
+                    self.policy_tx.subscribe(),
+                    self.connection_permits.clone(),
+                    self.shutdown_tx.subscribe(),
+                    self.guest
+                        .get()
+                        .and_then(Weak::upgrade)
+                        .ok_or(SshStartError::NotAttached)?,
+                )
+                .await
+                {
+                    Ok(restored) => {
+                        state.listener = Some(restored);
+                        return Err(SshStartError::Bind(replacement));
+                    }
+                    Err(rollback) => {
+                        self.policy_tx.send_replace(None);
+                        state.generation = state.generation.saturating_add(1);
+                        return Err(SshStartError::Rebind {
+                            replacement,
+                            rollback,
+                        });
+                    }
+                }
+            }
+        };
+        let bound_addr = running.bound_addr;
+        let fingerprint = running.host_key_fingerprint.clone();
+
+        let previous = state.listener.replace(running);
+        state.generation = state.generation.saturating_add(1);
+        if let Some(previous) = previous {
+            let _ = previous.stop().await;
+        }
+        info!(
+            %bound_addr,
+            fingerprint = %fingerprint,
+            generation = state.generation,
+            "embedded SSH listener ready"
+        );
+        Ok(runtime_status(&state))
+    }
+
+    pub(crate) async fn status(&self) -> SshRuntimeStatus {
+        let state = self.state.lock().await;
+        runtime_status(&state)
+    }
+
+    pub(crate) async fn disable(&self) -> SshRuntimeStatus {
+        let mut state = self.state.lock().await;
+        // This is unconditional because a failed listener rollback can leave
+        // accepted pre-authentication transports even though no listener is
+        // present in ManagerState.
+        self.policy_tx.send_replace(None);
+        if let Some(listener) = state.listener.take() {
+            let _ = listener.stop().await;
+            state.generation = state.generation.saturating_add(1);
+            info!(
+                generation = state.generation,
+                "embedded SSH listener disabled"
+            );
+        }
+        runtime_status(&state)
+    }
+
+    /// Terminal guest teardown: stop accepts, revoke pre-auth transports, close
+    /// authenticated sessions, and wait for their handlers to release the
+    /// shared connection budget before the execution registry is snapshotted.
+    pub(crate) async fn shutdown(&self) -> Result<SshRuntimeStatus, SshShutdownError> {
+        self.shutdown_tx.send_replace(true);
+        let status = self.disable().await;
+        let all_connections = self
+            .connection_permits
+            .clone()
+            .acquire_many_owned(limits::MAX_CONNECTIONS as u32);
+        match tokio::time::timeout(limits::CONTROL_CALL_TIMEOUT, all_connections).await {
+            Ok(Ok(_permit)) => Ok(status),
+            Ok(Err(_)) => Err(SshShutdownError::ConnectionBudgetClosed),
+            Err(_) => Err(SshShutdownError::TimedOut),
+        }
+    }
+}
+
+fn start_listener(
+    listener: TcpListener,
+    requested_addr: SocketAddr,
+    config: Arc<russh::server::Config>,
+    host_key_fingerprint: String,
+    authorizer: Arc<CertificateAuthorizer>,
+    context: ConnectionContext,
+) -> std::io::Result<RunningListener> {
+    let bound_addr = listener.local_addr()?;
+    let (shutdown_tx, listener_shutdown_rx) = oneshot::channel();
+    let task = tokio::spawn(accept_loop(
+        listener,
+        config.clone(),
+        context,
+        listener_shutdown_rx,
+    ));
+    Ok(RunningListener {
+        requested_addr,
+        bound_addr,
+        host_key_fingerprint,
+        config,
+        authorizer,
+        shutdown_tx: Some(shutdown_tx),
+        task,
+    })
+}
+
+async fn restart_listener(
+    previous: StoppedListener,
+    policy_rx: watch::Receiver<Option<Arc<CertificateAuthorizer>>>,
+    connection_permits: Arc<tokio::sync::Semaphore>,
+    guest_shutdown_rx: watch::Receiver<bool>,
+    guest: Arc<GuestServer>,
+) -> std::io::Result<RunningListener> {
+    let listener = TcpListener::bind(previous.requested_addr).await?;
+    let context = ConnectionContext {
+        guest,
+        policy_rx,
+        permits: connection_permits,
+        guest_shutdown_rx,
+    };
+    start_listener(
+        listener,
+        previous.requested_addr,
+        previous.config,
+        previous.host_key_fingerprint,
+        previous.authorizer,
+        context,
+    )
+}
+
+fn runtime_status(state: &ManagerState) -> SshRuntimeStatus {
+    match &state.listener {
+        Some(listener) => SshRuntimeStatus {
+            enabled: true,
+            listen_addr: Some(listener.bound_addr),
+            generation: state.generation,
+            host_key_fingerprint: Some(listener.host_key_fingerprint.clone()),
+        },
+        None => SshRuntimeStatus {
+            enabled: false,
+            listen_addr: None,
+            generation: state.generation,
+            host_key_fingerprint: None,
+        },
+    }
+}
+
+fn listen_addresses_overlap(current: SocketAddr, next: SocketAddr) -> bool {
+    current.port() == next.port()
+        && (current.ip() == next.ip()
+            || current.ip().is_unspecified()
+            || next.ip().is_unspecified())
+}
+
+async fn prepare_listener(ssh: &SshConfig) -> Result<PreparedListener, SshStartError> {
+    let host_key = host_key::load_or_create(&ssh.host_key_path).map_err(SshStartError::HostKey)?;
+    let host_key_fingerprint = host_key
+        .public_key()
+        .fingerprint(HashAlg::Sha256)
+        .to_string();
+    let config = Arc::new(server::build_config(host_key));
+    Ok(PreparedListener {
+        config,
+        host_key_fingerprint,
+    })
+}
+
+async fn accept_loop(
+    listener: TcpListener,
+    config: Arc<russh::server::Config>,
+    context: ConnectionContext,
+    mut listener_shutdown_rx: oneshot::Receiver<()>,
+) {
+    let ConnectionContext {
+        guest,
+        policy_rx,
+        permits,
+        mut guest_shutdown_rx,
+    } = context;
+    let mut backoff = Backoff::new();
+
+    loop {
+        let accepted = tokio::select! {
+            _ = &mut listener_shutdown_rx => break,
+            _ = wait_for_shutdown(&mut guest_shutdown_rx) => break,
+            accepted = listener.accept() => accepted,
+        };
+        match accepted {
+            Ok((socket, peer_addr)) => {
+                backoff.reset();
+                if let Err(error) = socket.set_nodelay(true) {
+                    debug!(%peer_addr, %error, "failed to enable TCP_NODELAY for SSH connection");
+                }
+                let (socket, shutdown_socket) = match socket_with_shutdown_handle(socket) {
+                    Ok(sockets) => sockets,
+                    Err(error) => {
+                        warn!(%peer_addr, %error, "failed to prepare SSH connection socket");
+                        continue;
+                    }
+                };
+                let permit = match permits.clone().try_acquire_owned() {
+                    Ok(permit) => permit,
+                    Err(_) => {
+                        warn!(%peer_addr, "SSH connection limit reached");
+                        continue;
+                    }
+                };
+
+                let (authenticated_tx, authenticated_rx) = tokio::sync::oneshot::channel();
+                let mut connection_policy_rx = policy_rx.clone();
+                let authorizer = connection_policy_rx.borrow_and_update().clone();
+                let Some(authorizer) = authorizer else {
+                    debug!(%peer_addr, "SSH connection rejected while listener policy is disabled");
+                    continue;
+                };
+                let handler = server::SshConnection::new(
+                    guest.clone(),
+                    authorizer,
+                    connection_policy_rx.clone(),
+                    authenticated_tx,
+                );
+                let config = config.clone();
+                let mut connection_shutdown_rx = guest_shutdown_rx.clone();
+                tokio::spawn(async move {
+                    let _permit = permit;
+                    let handshake = tokio::time::timeout(
+                        limits::AUTHENTICATION_TIMEOUT,
+                        russh::server::run_stream(config, socket, handler),
+                    );
+                    tokio::pin!(handshake);
+                    let handshake_result = tokio::select! {
+                        biased;
+                        _ = wait_for_shutdown(&mut connection_shutdown_rx) => {
+                            let _ = shutdown_socket.shutdown(Shutdown::Both);
+                            return;
+                        }
+                        _ = connection_policy_rx.changed() => {
+                            // This transport has not authenticated yet. Any
+                            // policy epoch change revokes its accepted snapshot.
+                            let _ = shutdown_socket.shutdown(Shutdown::Both);
+                            return;
+                        }
+                        result = &mut handshake => result,
+                    };
+                    match handshake_result {
+                        Ok(Ok(running)) => {
+                            monitor_session(
+                                running,
+                                authenticated_rx,
+                                connection_policy_rx,
+                                connection_shutdown_rx,
+                                shutdown_socket,
+                                peer_addr,
+                            )
+                            .await;
+                        }
+                        Ok(Err(error)) => {
+                            debug!(%peer_addr, %error, "SSH handshake failed");
+                        }
+                        Err(_) => warn!(%peer_addr, "SSH identification exchange timed out"),
+                    }
+                });
+            }
+            Err(error) => {
+                warn!(%error, "SSH accept failed");
+                tokio::select! {
+                    _ = &mut listener_shutdown_rx => break,
+                    _ = wait_for_shutdown(&mut guest_shutdown_rx) => break,
+                    _ = backoff.wait() => {}
+                }
+            }
+        }
+    }
+    debug!("embedded SSH accept loop stopped");
+}
+
+async fn monitor_session(
+    mut running: russh::server::RunningSession<server::SshConnection>,
+    mut authenticated: tokio::sync::oneshot::Receiver<()>,
+    mut policy_rx: watch::Receiver<Option<Arc<CertificateAuthorizer>>>,
+    mut shutdown_rx: watch::Receiver<bool>,
+    shutdown_socket: std::net::TcpStream,
+    peer_addr: SocketAddr,
+) {
+    let handle = running.handle();
+    tokio::select! {
+        biased;
+        result = &mut running => {
+            if let Err(error) = result {
+                debug!(%peer_addr, %error, "SSH session ended");
+            }
+        }
+        result = &mut authenticated => {
+            if result.is_err() {
+                debug!(%peer_addr, "SSH session ended before authentication completed");
+                if let Err(error) = running.await {
+                    debug!(%peer_addr, %error, "SSH session ended");
+                }
+                return;
+            }
+
+            // The certificate callback sent this signal while holding the
+            // current policy epoch's read lock. Authentication is now the
+            // snapshot boundary: later credential rotation does not revoke
+            // this identity, while guest shutdown still closes the transport.
+            tokio::select! {
+                result = &mut running => {
+                    if let Err(error) = result {
+                        debug!(%peer_addr, %error, "SSH session ended");
+                    }
+                }
+                _ = wait_for_shutdown(&mut shutdown_rx) => {
+                    disconnect_transport(&handle, &shutdown_socket, "guest shutdown").await;
+                    if let Err(error) = running.await {
+                        debug!(%peer_addr, %error, "SSH session ended during guest shutdown");
+                    }
+                }
+            }
+        }
+        _ = policy_rx.changed() => {
+            disconnect_transport(&handle, &shutdown_socket, "SSH authentication policy changed").await;
+            if let Err(error) = running.await {
+                debug!(%peer_addr, %error, "pre-authentication SSH session ended after policy change");
+            }
+        }
+        _ = wait_for_shutdown(&mut shutdown_rx) => {
+            disconnect_transport(&handle, &shutdown_socket, "guest shutdown").await;
+            if let Err(error) = running.await {
+                debug!(%peer_addr, %error, "pre-authentication SSH session ended during shutdown");
+            }
+        }
+        _ = tokio::time::sleep(limits::AUTHENTICATION_TIMEOUT) => {
+            warn!(%peer_addr, "SSH authentication timed out");
+            disconnect_transport(&handle, &shutdown_socket, "authentication timeout").await;
+            if let Err(error) = running.await {
+                debug!(%peer_addr, %error, "SSH session ended after authentication timeout");
+            }
+        }
+    }
+}
+
+/// Lock the connection's accepted policy epoch for an atomic authentication
+/// commit. `Ref::has_changed` detects replacement even when rollback restores
+/// the same `Arc`, while retaining the guard orders a later policy publication
+/// after the caller's commit signal.
+pub(super) fn authentication_policy_guard<'a>(
+    policy_rx: &'a watch::Receiver<Option<Arc<CertificateAuthorizer>>>,
+    accepted_authorizer: &Arc<CertificateAuthorizer>,
+) -> Option<watch::Ref<'a, Option<Arc<CertificateAuthorizer>>>> {
+    let current = policy_rx.borrow();
+    if current.has_changed()
+        || !current
+            .as_ref()
+            .is_some_and(|authorizer| Arc::ptr_eq(authorizer, accepted_authorizer))
+    {
+        None
+    } else {
+        Some(current)
+    }
+}
+
+#[cfg(test)]
+fn authentication_policy_is_current(
+    policy_rx: &mut watch::Receiver<Option<Arc<CertificateAuthorizer>>>,
+    accepted_authorizer: &Arc<CertificateAuthorizer>,
+) -> bool {
+    authentication_policy_guard(policy_rx, accepted_authorizer).is_some()
+}
+
+async fn wait_for_shutdown(shutdown_rx: &mut watch::Receiver<bool>) {
+    if *shutdown_rx.borrow() {
+        return;
+    }
+    while shutdown_rx.changed().await.is_ok() {
+        if *shutdown_rx.borrow() {
+            return;
+        }
+    }
+}
+
+async fn disconnect_transport(
+    handle: &russh::server::Handle,
+    shutdown_socket: &std::net::TcpStream,
+    reason: &'static str,
+) {
+    let disconnect = handle.disconnect(
+        russh::Disconnect::ByApplication,
+        reason.into(),
+        String::new(),
+    );
+    let _ = tokio::time::timeout(limits::DISCONNECT_GRACE_TIMEOUT, disconnect).await;
+    if let Err(error) = shutdown_socket.shutdown(Shutdown::Both) {
+        debug!(%error, reason, "failed to shut down SSH transport");
+    }
+}
+
+fn socket_with_shutdown_handle(
+    socket: tokio::net::TcpStream,
+) -> std::io::Result<(tokio::net::TcpStream, std::net::TcpStream)> {
+    let socket = socket.into_std()?;
+    let shutdown_socket = socket.try_clone()?;
+    let socket = tokio::net::TcpStream::from_std(socket)?;
+    Ok((socket, shutdown_socket))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::layout::GuestLayout;
+    use russh::keys::ssh_key::certificate::{Builder, CertType};
+    use russh::keys::{Algorithm, Certificate, PrivateKey, PrivateKeyWithHashAlg, PublicKey};
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+    use tokio::io::AsyncReadExt;
+
+    fn private_key() -> PrivateKey {
+        let mut rng = russh::keys::key::safe_rng();
+        PrivateKey::random(&mut rng, Algorithm::Ed25519).unwrap()
+    }
+
+    fn ca_public_key() -> String {
+        private_key().public_key().to_openssh().unwrap()
+    }
+
+    fn user_certificate(ca_key: &PrivateKey, principal: &str) -> (Arc<PrivateKey>, Certificate) {
+        let subject_key = Arc::new(private_key());
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let mut rng = russh::keys::key::safe_rng();
+        let mut builder = Builder::new_with_random_nonce(
+            &mut rng,
+            subject_key.public_key(),
+            now.saturating_sub(60),
+            now.saturating_add(60),
+        )
+        .unwrap();
+        builder.cert_type(CertType::User).unwrap();
+        builder.key_id("boxlite-test").unwrap();
+        builder.valid_principal(principal).unwrap();
+        builder.extension("permit-pty", "").unwrap();
+        builder.extension("permit-port-forwarding", "").unwrap();
+        (subject_key, builder.sign(ca_key).unwrap())
+    }
+
+    #[derive(Clone)]
+    struct TrustTestHostKey;
+
+    impl russh::client::Handler for TrustTestHostKey {
+        type Error = russh::Error;
+
+        async fn check_server_key(
+            &mut self,
+            _server_public_key: &PublicKey,
+        ) -> Result<bool, Self::Error> {
+            Ok(true)
+        }
+    }
+
+    async fn connect_test_client(address: SocketAddr) -> russh::client::Handle<TrustTestHostKey> {
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            russh::client::connect(
+                Arc::new(russh::client::Config::default()),
+                address,
+                TrustTestHostKey,
+            ),
+        )
+        .await
+        .expect("SSH handshake timed out")
+        .expect("SSH handshake failed")
+    }
+
+    async fn wait_for_available_connection_permits(manager: &SshManager, expected: usize) {
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                if manager.connection_permits.available_permits() == expected {
+                    return;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap_or_else(|_| {
+            panic!(
+                "timed out waiting for {expected} available SSH connection permits; found {}",
+                manager.connection_permits.available_permits()
+            )
+        });
+    }
+
+    #[test]
+    fn ssh_config_is_disabled_by_absence_and_rejects_bad_auth_inputs() {
+        let address = "127.0.0.1:0".parse().unwrap();
+        assert!(SshConfig::new(address, "not a key", "box_123").is_err());
+        assert!(SshConfig::new(address, ca_public_key(), "../box").is_err());
+    }
+
+    #[test]
+    fn tests_can_redirect_the_host_key_without_changing_production_default() {
+        let address = "127.0.0.1:0".parse().unwrap();
+        let path = PathBuf::from("/tmp/test-host-key");
+        let config = SshConfig::new(address, ca_public_key(), "box_123")
+            .unwrap()
+            .with_host_key_path(path.clone());
+        assert_eq!(config.host_key_path, path);
+        assert_eq!(
+            host_key::default_path(),
+            PathBuf::from(host_key::DEFAULT_HOST_KEY_PATH)
+        );
+    }
+
+    #[test]
+    fn authentication_commit_rejects_a_replaced_or_disabled_policy_epoch() {
+        let accepted = Arc::new(CertificateAuthorizer::new(&ca_public_key(), "box_123").unwrap());
+        let (policy_tx, mut policy_rx) = watch::channel(Some(accepted.clone()));
+        assert!(authentication_policy_is_current(&mut policy_rx, &accepted));
+
+        let replacement =
+            Arc::new(CertificateAuthorizer::new(&ca_public_key(), "box_456").unwrap());
+        policy_tx.send_replace(Some(replacement));
+        assert!(!authentication_policy_is_current(&mut policy_rx, &accepted));
+
+        policy_tx.send_replace(None);
+        assert!(!authentication_policy_is_current(&mut policy_rx, &accepted));
+
+        let (policy_tx, mut policy_rx) = watch::channel(Some(accepted.clone()));
+        policy_tx.send_replace(Some(Arc::new(
+            CertificateAuthorizer::new(&ca_public_key(), "box_789").unwrap(),
+        )));
+        policy_tx.send_replace(Some(accepted.clone()));
+        assert!(
+            !authentication_policy_is_current(&mut policy_rx, &accepted),
+            "a policy replacement followed by rollback is still a new epoch"
+        );
+    }
+
+    #[tokio::test]
+    async fn disable_revokes_policy_even_without_a_running_listener() {
+        let manager = SshManager::default();
+        let authorizer = Arc::new(CertificateAuthorizer::new(&ca_public_key(), "box_123").unwrap());
+        manager.policy_tx.send_replace(Some(authorizer));
+
+        let status = manager.disable().await;
+
+        assert!(!status.enabled);
+        assert!(manager.policy_tx.borrow().is_none());
+    }
+
+    #[tokio::test]
+    async fn shutdown_handle_forces_a_live_transport_to_finish() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let peer = tokio::net::TcpStream::connect(listener.local_addr().unwrap())
+            .await
+            .unwrap();
+        let (socket, _) = listener.accept().await.unwrap();
+        let (mut socket, shutdown_socket) = socket_with_shutdown_handle(socket).unwrap();
+
+        shutdown_socket.shutdown(Shutdown::Both).unwrap();
+        let mut byte = [0_u8; 1];
+        let read_result =
+            tokio::time::timeout(std::time::Duration::from_secs(1), socket.read(&mut byte)).await;
+
+        assert!(read_result.is_ok(), "local shutdown must unblock the read");
+        drop(peer);
+    }
+
+    #[tokio::test]
+    async fn manager_reconfigures_in_place_and_releases_listener_on_disable() {
+        let port_guard = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = port_guard.local_addr().unwrap();
+        drop(port_guard);
+        let host_key_dir = tempfile::tempdir().unwrap();
+        let host_key_path = host_key_dir.path().join("ssh_host_ed25519_key");
+
+        let guest = Arc::new(GuestServer::new(GuestLayout::new()));
+        guest.ssh_manager.attach_guest(&guest);
+        let first = guest
+            .ssh_manager
+            .configure(
+                SshConfig::new(address, ca_public_key(), "box_123")
+                    .unwrap()
+                    .with_host_key_path(host_key_path),
+            )
+            .await
+            .unwrap();
+        let second = guest
+            .ssh_manager
+            .configure(SshConfig::new(address, ca_public_key(), "box_456").unwrap())
+            .await
+            .unwrap();
+
+        assert!(first.enabled);
+        assert_eq!(first.listen_addr, Some(address));
+        assert_eq!(second.listen_addr, first.listen_addr);
+        assert_eq!(second.generation, first.generation + 1);
+
+        let disabled = guest.ssh_manager.disable().await;
+        assert!(!disabled.enabled);
+        assert_eq!(disabled.generation, second.generation + 1);
+        assert_eq!(guest.ssh_manager.disable().await, disabled);
+        let _rebound = TcpListener::bind(address).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn wire_auth_rotation_disable_and_shutdown_have_distinct_lifecycles() {
+        let port_guard = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = port_guard.local_addr().unwrap();
+        drop(port_guard);
+        let host_key_dir = tempfile::tempdir().unwrap();
+        let host_key_path = host_key_dir.path().join("ssh_host_ed25519_key");
+        let ca_a = private_key();
+        let ca_b = private_key();
+        let (subject_a, certificate_a) = user_certificate(&ca_a, "box_123");
+        let (subject_b, certificate_b) = user_certificate(&ca_b, "box_456");
+
+        let guest = Arc::new(GuestServer::new(GuestLayout::new()));
+        guest.ssh_manager.attach_guest(&guest);
+        guest
+            .ssh_manager
+            .configure(
+                SshConfig::new(address, ca_a.public_key().to_openssh().unwrap(), "box_123")
+                    .unwrap()
+                    .with_host_key_path(host_key_path.clone()),
+            )
+            .await
+            .unwrap();
+
+        let mut authenticated_a = connect_test_client(address).await;
+        let raw_key_result = authenticated_a
+            .authenticate_publickey(
+                "root",
+                PrivateKeyWithHashAlg::new(Arc::new(private_key()), None),
+            )
+            .await
+            .unwrap();
+        assert!(!raw_key_result.success(), "raw user keys must be rejected");
+        assert!(
+            authenticated_a
+                .authenticate_openssh_cert("root", subject_a.clone(), certificate_a.clone())
+                .await
+                .unwrap()
+                .success(),
+            "the configured CA certificate must authenticate"
+        );
+
+        let mut pre_rotation = connect_test_client(address).await;
+        wait_for_available_connection_permits(&guest.ssh_manager, limits::MAX_CONNECTIONS - 2)
+            .await;
+        guest
+            .ssh_manager
+            .configure(
+                SshConfig::new(address, ca_b.public_key().to_openssh().unwrap(), "box_456")
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        wait_for_available_connection_permits(&guest.ssh_manager, limits::MAX_CONNECTIONS - 1)
+            .await;
+
+        let stale_auth = tokio::time::timeout(
+            Duration::from_secs(2),
+            pre_rotation.authenticate_openssh_cert("root", subject_a, certificate_a),
+        )
+        .await
+        .expect("a pre-rotation transport must be closed promptly");
+        assert!(
+            stale_auth.is_err() || !stale_auth.unwrap().success(),
+            "a connection opened under the old CA must not authenticate after rotation"
+        );
+
+        let channel = authenticated_a
+            .channel_open_session()
+            .await
+            .expect("an already-authenticated connection must survive rotation");
+        channel.close().await.unwrap();
+
+        let mut authenticated_b = connect_test_client(address).await;
+        assert!(
+            authenticated_b
+                .authenticate_openssh_cert("root", subject_b.clone(), certificate_b.clone())
+                .await
+                .unwrap()
+                .success(),
+            "new connections must use the rotated CA and principal"
+        );
+
+        let disabled = guest.ssh_manager.disable().await;
+        assert!(!disabled.enabled);
+        let channel = authenticated_b
+            .channel_open_session()
+            .await
+            .expect("Disable must allow authenticated connections to drain");
+        channel.close().await.unwrap();
+        assert!(
+            tokio::net::TcpStream::connect(address).await.is_err(),
+            "Disable must stop new TCP accepts"
+        );
+
+        authenticated_a
+            .disconnect(russh::Disconnect::ByApplication, "test complete", "")
+            .await
+            .unwrap();
+        authenticated_b
+            .disconnect(russh::Disconnect::ByApplication, "test complete", "")
+            .await
+            .unwrap();
+        drop(authenticated_a);
+        drop(authenticated_b);
+        drop(pre_rotation);
+        wait_for_available_connection_permits(&guest.ssh_manager, limits::MAX_CONNECTIONS).await;
+
+        guest
+            .ssh_manager
+            .configure(
+                SshConfig::new(address, ca_b.public_key().to_openssh().unwrap(), "box_456")
+                    .unwrap()
+                    .with_host_key_path(host_key_path),
+            )
+            .await
+            .unwrap();
+        let mut shutdown_client = connect_test_client(address).await;
+        assert!(shutdown_client
+            .authenticate_openssh_cert("root", subject_b, certificate_b)
+            .await
+            .unwrap()
+            .success());
+
+        guest
+            .shutting_down
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        guest.ssh_manager.shutdown().await.unwrap();
+        wait_for_available_connection_permits(&guest.ssh_manager, limits::MAX_CONNECTIONS).await;
+        assert!(shutdown_client.channel_open_session().await.is_err());
+        assert!(matches!(
+            guest
+                .ssh_manager
+                .configure(
+                    SshConfig::new(address, ca_public_key(), "box_789")
+                        .unwrap()
+                        .with_host_key_path(host_key_dir.path().join("other-host-key")),
+                )
+                .await,
+            Err(SshStartError::ShuttingDown)
+        ));
+    }
+
+    #[tokio::test]
+    async fn wire_rejected_session_requests_close_the_accepted_channel() {
+        let port_guard = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = port_guard.local_addr().unwrap();
+        drop(port_guard);
+        let host_key_dir = tempfile::tempdir().unwrap();
+        let ca_key = private_key();
+        let (subject_key, certificate) = user_certificate(&ca_key, "box_123");
+        let guest = Arc::new(GuestServer::new(GuestLayout::new()));
+        guest.ssh_manager.attach_guest(&guest);
+        guest
+            .ssh_manager
+            .configure(
+                SshConfig::new(
+                    address,
+                    ca_key.public_key().to_openssh().unwrap(),
+                    "box_123",
+                )
+                .unwrap()
+                .with_host_key_path(host_key_dir.path().join("ssh_host_ed25519_key")),
+            )
+            .await
+            .unwrap();
+
+        let mut client = connect_test_client(address).await;
+        assert!(client
+            .authenticate_openssh_cert("root", subject_key, certificate)
+            .await
+            .unwrap()
+            .success());
+
+        let mut invalid_exec = client.channel_open_session().await.unwrap();
+        invalid_exec
+            .exec(true, b"bad\0command".to_vec())
+            .await
+            .unwrap();
+        assert!(matches!(
+            tokio::time::timeout(Duration::from_secs(2), invalid_exec.wait())
+                .await
+                .expect("invalid exec must receive a failure reply"),
+            Some(russh::ChannelMsg::Failure)
+        ));
+        assert!(matches!(
+            tokio::time::timeout(Duration::from_secs(2), invalid_exec.wait())
+                .await
+                .expect("invalid exec must close its accepted channel"),
+            Some(russh::ChannelMsg::Close) | None
+        ));
+
+        let mut unsupported_subsystem = client.channel_open_session().await.unwrap();
+        unsupported_subsystem
+            .request_subsystem(true, "not-sftp")
+            .await
+            .unwrap();
+        assert!(matches!(
+            tokio::time::timeout(Duration::from_secs(2), unsupported_subsystem.wait())
+                .await
+                .expect("unsupported subsystem must receive a failure reply"),
+            Some(russh::ChannelMsg::Failure)
+        ));
+        assert!(matches!(
+            tokio::time::timeout(Duration::from_secs(2), unsupported_subsystem.wait())
+                .await
+                .expect("unsupported subsystem must close its accepted channel"),
+            Some(russh::ChannelMsg::Close) | None
+        ));
+
+        client
+            .disconnect(russh::Disconnect::ByApplication, "test complete", "")
+            .await
+            .unwrap();
+        guest.ssh_manager.disable().await;
+    }
+
+    #[tokio::test]
+    async fn failed_overlapping_rebind_preserves_the_previous_listener() {
+        let port_guard = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = port_guard.local_addr().unwrap().port();
+        drop(port_guard);
+
+        // This listener does not conflict with the initial 127.0.0.1 bind,
+        // but it keeps a later wildcard bind failing after the manager stops
+        // its own socket. That makes the rollback path deterministic.
+        let _other_loopback_listener = std::net::TcpListener::bind(("127.0.0.2", port)).unwrap();
+        let old_address: SocketAddr = format!("127.0.0.1:{port}").parse().unwrap();
+        let replacement_address: SocketAddr = format!("0.0.0.0:{port}").parse().unwrap();
+        let host_key_dir = tempfile::tempdir().unwrap();
+        let host_key_path = host_key_dir.path().join("ssh_host_ed25519_key");
+
+        let guest = Arc::new(GuestServer::new(GuestLayout::new()));
+        guest.ssh_manager.attach_guest(&guest);
+        let original = guest
+            .ssh_manager
+            .configure(
+                SshConfig::new(old_address, ca_public_key(), "box_123")
+                    .unwrap()
+                    .with_host_key_path(host_key_path.clone()),
+            )
+            .await
+            .unwrap();
+
+        let replacement = guest
+            .ssh_manager
+            .configure(
+                SshConfig::new(replacement_address, ca_public_key(), "box_456")
+                    .unwrap()
+                    .with_host_key_path(host_key_path),
+            )
+            .await;
+
+        assert!(replacement.is_err());
+        assert_eq!(guest.ssh_manager.status().await, original);
+        assert!(std::net::TcpListener::bind(old_address).is_err());
+        guest.ssh_manager.disable().await;
+    }
+
+    #[test]
+    fn rebind_retry_only_stops_a_listener_that_can_conflict() {
+        let loopback: SocketAddr = "127.0.0.1:2200".parse().unwrap();
+        let wildcard: SocketAddr = "0.0.0.0:2200".parse().unwrap();
+        let other_ip: SocketAddr = "192.0.2.1:2200".parse().unwrap();
+
+        assert!(listen_addresses_overlap(loopback, wildcard));
+        assert!(listen_addresses_overlap(wildcard, other_ip));
+        assert!(!listen_addresses_overlap(loopback, other_ip));
+        assert!(!listen_addresses_overlap(
+            loopback,
+            "127.0.0.1:2201".parse().unwrap()
+        ));
+    }
+}

--- a/src/guest/src/service/ssh/mod.rs
+++ b/src/guest/src/service/ssh/mod.rs
@@ -444,6 +444,13 @@ impl SshManager {
             Err(_) => Err(SshShutdownError::TimedOut),
         }
     }
+
+    /// Force the next `shutdown` to fail without waiting out its timeout, so
+    /// callers can be tested against a degraded quiesce.
+    #[cfg(test)]
+    pub(crate) fn close_connection_budget_for_test(&self) {
+        self.connection_permits.close();
+    }
 }
 
 fn start_listener(

--- a/src/guest/src/service/ssh/reverse_streamlocal.rs
+++ b/src/guest/src/service/ssh/reverse_streamlocal.rs
@@ -89,6 +89,20 @@ pub(crate) fn parse_internal_args(args: &[String]) -> BoxliteResult<InternalArgs
     })
 }
 
+/// Bind a pathname socket that is owner-only from the moment it appears.
+///
+/// `bind` creates the pathname with `0777 & ~umask`, and `connect(2)` on a
+/// pathname socket needs only write permission, so a later chmod still leaves a
+/// window in which any container process could reach the listener. The socket
+/// may sit anywhere the target validator allows, including a world-writable
+/// directory, so the umask has to be narrow across the bind itself.
+fn bind_owner_only(socket_path: impl AsRef<Path>) -> std::io::Result<UnixListener> {
+    let previous_umask = unsafe { nix::libc::umask(0o177) };
+    let listener = UnixListener::bind(socket_path);
+    unsafe { nix::libc::umask(previous_umask) };
+    listener
+}
+
 async fn serve_reverse_streamlocal<R, W>(
     args: InternalArgs,
     mut control: R,
@@ -105,7 +119,7 @@ where
 
     // Deliberately do not pre-unlink. Existing filesystem entries belong to
     // the container and a forwarding request must not destroy them.
-    let listener = UnixListener::bind(&args.socket_path).map_err(|error| {
+    let listener = bind_owner_only(&args.socket_path).map_err(|error| {
         BoxliteError::Execution(format!("reverse streamlocal bind failed: {error}"))
     })?;
     let mut bound_socket = BoundSocket::capture(&args.socket_path).map_err(|error| {
@@ -1134,6 +1148,22 @@ mod tests {
         let mut response = [0; 8];
         unix.read_exact(&mut response).await.unwrap();
         assert_eq!(&response, b"response");
+    }
+
+    /// The pathname must never be reachable by a container process, not even
+    /// for the window between `bind` and the chmod that follows it.
+    #[tokio::test]
+    async fn the_listener_pathname_is_owner_only_before_any_chmod() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let socket_path = dir.path().join("forward.sock");
+
+        let permissive = unsafe { nix::libc::umask(0) };
+        let listener = bind_owner_only(&socket_path);
+        unsafe { nix::libc::umask(permissive) };
+        listener.expect("bind");
+
+        let mode = std::fs::metadata(&socket_path).expect("stat").mode();
+        assert_eq!(mode & 0o777, 0o600, "actual mode {:o}", mode & 0o777);
     }
 
     #[test]

--- a/src/guest/src/service/ssh/reverse_streamlocal.rs
+++ b/src/guest/src/service/ssh/reverse_streamlocal.rs
@@ -524,10 +524,10 @@ impl RunningHelper {
         ingress: SocketAddrV4,
         token: String,
     ) -> Result<Self, String> {
-        let (container_id, profile) = super::bridge::resolve_single_container_profile(&server)
+        let container_id = super::bridge::resolve_single_container(&server)
             .await
             .map_err(|error| error.to_string())?;
-        let launch = helper_execution_launch(&container_id, &profile, socket_path, ingress);
+        let launch = helper_execution_launch(&container_id, socket_path, ingress);
         let response = tokio::time::timeout(
             CONTROL_CALL_TIMEOUT,
             crate::service::exec::start_ssh_execution(&server, launch.request, launch.workload),
@@ -713,7 +713,6 @@ struct HelperExecutionLaunch {
 
 fn helper_execution_launch(
     container_id: &str,
-    profile: &crate::container::user_profile::RootSessionProfile,
     socket_path: &str,
     ingress: SocketAddrV4,
 ) -> HelperExecutionLaunch {
@@ -727,8 +726,9 @@ fn helper_execution_launch(
             execution_id: None,
             program,
             args,
-            env: super::bridge::session_exec_env(HashMap::new(), container_id, profile),
-            workdir: profile.home_dir.clone(),
+            env: super::bridge::session_exec_env(HashMap::new(), container_id),
+            // A socket relay never resolves a path against its cwd.
+            workdir: "/".to_string(),
             timeout_ms: 0,
             tty: None,
             user: Some("0:0".to_string()),
@@ -1195,13 +1195,8 @@ mod tests {
 
     #[test]
     fn helper_launch_keeps_the_token_out_of_logged_argv_and_env() {
-        let profile = crate::container::user_profile::RootSessionProfile {
-            home_dir: "/root".into(),
-            login_shell: "/bin/ash".into(),
-        };
         let launch = helper_execution_launch(
             "container-1",
-            &profile,
             "/run/service.sock",
             SocketAddrV4::new(Ipv4Addr::LOCALHOST, 32_000),
         );
@@ -1221,14 +1216,11 @@ mod tests {
         );
         assert!(request.args.iter().all(|value| !value.contains(TOKEN)));
         assert!(request.env.values().all(|value| !value.contains(TOKEN)));
-        assert_eq!(request.env.get("HOME").map(String::as_str), Some("/root"));
-        assert_eq!(
-            request.env.get("SHELL").map(String::as_str),
-            Some("/bin/ash")
-        );
+        assert!(!request.env.contains_key("HOME"));
+        assert!(!request.env.contains_key("SHELL"));
         assert_eq!(request.env.get("USER").map(String::as_str), Some("root"));
         assert_eq!(request.user.as_deref(), Some("0:0"));
-        assert_eq!(request.workdir, "/root");
+        assert_eq!(request.workdir, "/");
         assert!(matches!(
             launch.workload,
             crate::service::ssh::SshWorkload::ReverseStreamlocal { .. }

--- a/src/guest/src/service/ssh/reverse_streamlocal.rs
+++ b/src/guest/src/service/ssh/reverse_streamlocal.rs
@@ -1,0 +1,1387 @@
+//! Container-scoped OpenSSH reverse streamlocal forwarding.
+//!
+//! The SSH server cannot bind the requested pathname directly: it lives in the
+//! guest mount namespace, while SSH sessions see the OCI container's mount
+//! namespace. A small container-executed helper owns the Unix listener and
+//! relays each accepted connection to a private guest-loopback ingress. The
+//! parent authenticates those ingress connections before opening
+//! `forwarded-streamlocal@openssh.com` channels.
+
+use crate::service::exec::registry::ExecutionRegistry;
+use crate::service::server::GuestServer;
+use crate::service::ssh::limits::{
+    CONTROL_CALL_TIMEOUT, FORWARD_CONNECT_TIMEOUT, MAX_FORWARD_CONNECTIONS,
+    MAX_REMOTE_FORWARD_LISTENERS, PROCESS_TERMINATION_GRACE,
+};
+use boxlite_shared::errors::{BoxliteError, BoxliteResult};
+use boxlite_shared::{exec_output, ExecOutput, ExecRequest, ExecStdin};
+use futures::StreamExt as _;
+use russh::server::{Handle as SessionHandle, Msg};
+use russh::Channel;
+use std::collections::HashMap;
+use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+use std::os::unix::fs::{FileTypeExt, MetadataExt, PermissionsExt};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, MutexGuard};
+use std::time::Duration;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream, UnixListener, UnixStream};
+use tokio::sync::{mpsc, oneshot, Semaphore};
+use tokio::task::{JoinHandle, JoinSet};
+use tokio_stream::wrappers::ReceiverStream;
+use tracing::{debug, warn};
+
+pub(crate) const INTERNAL_REVERSE_STREAMLOCAL_ARG: &str = "--boxlite-internal-reverse-streamlocal";
+pub(crate) const REVERSE_STREAMLOCAL_READY_MAGIC: &[u8] = b"\0boxlite-reverse-streamlocal-ready\0";
+const REVERSE_STREAMLOCAL_STOPPED_MAGIC: &[u8] = b"\0boxlite-reverse-streamlocal-stopped\0";
+const HELPER_RELAY_DRAIN_TIMEOUT: Duration = Duration::from_secs(30);
+const INGRESS_TOKEN_BYTES: usize = 36;
+const HELPER_STDIN_QUEUE_DEPTH: usize = 2;
+
+#[derive(Debug)]
+pub(crate) struct InternalArgs {
+    pub(crate) socket_path: String,
+    pub(crate) ingress: SocketAddrV4,
+}
+
+pub(crate) fn run_internal(args: InternalArgs) -> BoxliteResult<()> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| BoxliteError::Internal(format!("reverse streamlocal runtime: {error}")))?;
+    runtime.block_on(serve_reverse_streamlocal(
+        args,
+        tokio::io::stdin(),
+        tokio::io::stdout(),
+    ))
+}
+
+pub(crate) fn parse_internal_args(args: &[String]) -> BoxliteResult<InternalArgs> {
+    let [socket_path, ingress] = args else {
+        return Err(BoxliteError::Config(
+            "internal reverse streamlocal workload requires socket path and ingress".into(),
+        ));
+    };
+    let socket_path = socket_path.clone();
+    if !super::streamlocal::is_valid_target(&socket_path) {
+        return Err(BoxliteError::Config(
+            "invalid internal reverse streamlocal socket path".into(),
+        ));
+    }
+
+    let ingress = ingress
+        .parse::<SocketAddr>()
+        .map_err(|_| BoxliteError::Config("invalid reverse streamlocal ingress".into()))?;
+    let SocketAddr::V4(ingress) = ingress else {
+        return Err(BoxliteError::Config(
+            "reverse streamlocal ingress must use IPv4 loopback".into(),
+        ));
+    };
+    if *ingress.ip() != Ipv4Addr::LOCALHOST || ingress.port() == 0 {
+        return Err(BoxliteError::Config(
+            "reverse streamlocal ingress must use IPv4 loopback with a nonzero port".into(),
+        ));
+    }
+
+    Ok(InternalArgs {
+        socket_path,
+        ingress,
+    })
+}
+
+async fn serve_reverse_streamlocal<R, W>(
+    args: InternalArgs,
+    mut control: R,
+    mut status: W,
+) -> BoxliteResult<()>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    // The per-listener bearer token uses stdin because execution argv/env are
+    // diagnostic surfaces. Execution's stdin stream is binary and is never
+    // included in process-launch logs.
+    let token = read_ingress_token(&mut control).await?;
+
+    // Deliberately do not pre-unlink. Existing filesystem entries belong to
+    // the container and a forwarding request must not destroy them.
+    let listener = UnixListener::bind(&args.socket_path).map_err(|error| {
+        BoxliteError::Execution(format!("reverse streamlocal bind failed: {error}"))
+    })?;
+    let mut bound_socket = BoundSocket::capture(&args.socket_path).map_err(|error| {
+        BoxliteError::Execution(format!(
+            "reverse streamlocal socket identity failed: {error}"
+        ))
+    })?;
+    std::fs::set_permissions(&args.socket_path, std::fs::Permissions::from_mode(0o600)).map_err(
+        |error| {
+            BoxliteError::Execution(format!(
+                "reverse streamlocal socket permission update failed: {error}"
+            ))
+        },
+    )?;
+
+    // The parent consumes this marker before accepting the SSH global request.
+    // At this point bind, identity capture, and permission hardening have all
+    // succeeded inside the container mount namespace.
+    status
+        .write_all(REVERSE_STREAMLOCAL_READY_MAGIC)
+        .await
+        .map_err(|error| {
+            BoxliteError::Execution(format!(
+                "reverse streamlocal readiness write failed: {error}"
+            ))
+        })?;
+    status.flush().await.map_err(|error| {
+        BoxliteError::Execution(format!(
+            "reverse streamlocal readiness flush failed: {error}"
+        ))
+    })?;
+
+    let permits = Arc::new(Semaphore::new(MAX_FORWARD_CONNECTIONS));
+    let mut relays = JoinSet::new();
+    let mut stop = [0_u8; 16];
+    let listener_result = loop {
+        tokio::select! {
+            biased;
+            control_result = control.read(&mut stop) => {
+                break control_result.map(|_| ());
+            }
+            completed = relays.join_next(), if !relays.is_empty() => {
+                if let Some(Err(error)) = completed {
+                    warn!(%error, "reverse streamlocal helper relay task failed");
+                }
+            }
+            accepted = listener.accept() => {
+                let (stream, _) = match accepted {
+                    Ok(accepted) => accepted,
+                    Err(error) => break Err(error),
+                };
+                let Ok(permit) = permits.clone().try_acquire_owned() else {
+                    debug!("reverse streamlocal helper connection limit reached");
+                    continue;
+                };
+                let ingress = args.ingress;
+                let token = token.clone();
+                relays.spawn(async move {
+                    let _permit = permit;
+                    if let Err(error) = relay_to_ingress(stream, ingress, token.as_bytes()).await {
+                        debug!(%error, "reverse streamlocal helper relay ended");
+                    }
+                });
+            }
+        }
+    };
+
+    drop(listener);
+    bound_socket.cleanup().map_err(|error| {
+        BoxliteError::Execution(format!(
+            "reverse streamlocal socket cleanup failed: {error}"
+        ))
+    })?;
+    status
+        .write_all(REVERSE_STREAMLOCAL_STOPPED_MAGIC)
+        .await
+        .map_err(|error| {
+            BoxliteError::Execution(format!("reverse streamlocal stopped write failed: {error}"))
+        })?;
+    status.flush().await.map_err(|error| {
+        BoxliteError::Execution(format!("reverse streamlocal stopped flush failed: {error}"))
+    })?;
+
+    // Established relays may drain after the listener pathname disappears, but
+    // a peer cannot pin this internal execution forever.
+    if tokio::time::timeout(HELPER_RELAY_DRAIN_TIMEOUT, drain_join_set(&mut relays))
+        .await
+        .is_err()
+    {
+        relays.abort_all();
+        drain_join_set(&mut relays).await;
+    }
+
+    listener_result.map_err(|error| {
+        BoxliteError::Execution(format!("reverse streamlocal accept failed: {error}"))
+    })
+}
+
+async fn read_ingress_token<R>(control: &mut R) -> BoxliteResult<String>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut token = [0_u8; INGRESS_TOKEN_BYTES];
+    tokio::time::timeout(FORWARD_CONNECT_TIMEOUT, control.read_exact(&mut token))
+        .await
+        .map_err(|_| BoxliteError::Execution("reverse streamlocal token read timed out".into()))?
+        .map_err(|error| {
+            BoxliteError::Execution(format!("reverse streamlocal token read failed: {error}"))
+        })?;
+    let token = std::str::from_utf8(&token)
+        .map_err(|_| BoxliteError::Config("reverse streamlocal token is not UTF-8".into()))?;
+    let parsed_token = uuid::Uuid::parse_str(token)
+        .map_err(|_| BoxliteError::Config("invalid reverse streamlocal token".into()))?;
+    if parsed_token.to_string() != token {
+        return Err(BoxliteError::Config(
+            "reverse streamlocal token must use canonical UUID syntax".into(),
+        ));
+    }
+    Ok(token.to_string())
+}
+
+async fn relay_to_ingress(
+    mut unix: UnixStream,
+    ingress: SocketAddrV4,
+    token: &[u8],
+) -> std::io::Result<()> {
+    let mut tcp = tokio::time::timeout(FORWARD_CONNECT_TIMEOUT, TcpStream::connect(ingress))
+        .await
+        .map_err(|_| {
+            std::io::Error::new(std::io::ErrorKind::TimedOut, "ingress connect timed out")
+        })??;
+    tcp.write_all(token).await?;
+    let _ = tokio::io::copy_bidirectional(&mut unix, &mut tcp).await?;
+    let _ = unix.shutdown().await;
+    let _ = tcp.shutdown().await;
+    Ok(())
+}
+
+async fn drain_join_set<T: 'static>(tasks: &mut JoinSet<T>) {
+    while let Some(completed) = tasks.join_next().await {
+        if let Err(error) = completed {
+            warn!(%error, "reverse streamlocal task failed");
+        }
+    }
+}
+
+struct BoundSocket {
+    path: PathBuf,
+    device: u64,
+    inode: u64,
+    cleaned: bool,
+}
+
+impl BoundSocket {
+    fn capture(path: impl AsRef<Path>) -> std::io::Result<Self> {
+        let path = path.as_ref();
+        let metadata = std::fs::symlink_metadata(path)?;
+        if !metadata.file_type().is_socket() {
+            return Err(std::io::Error::other("bound pathname is not a Unix socket"));
+        }
+        Ok(Self {
+            path: path.to_path_buf(),
+            device: metadata.dev(),
+            inode: metadata.ino(),
+            cleaned: false,
+        })
+    }
+
+    fn cleanup(&mut self) -> std::io::Result<()> {
+        if self.cleaned {
+            return Ok(());
+        }
+        self.cleaned = true;
+
+        let metadata = match std::fs::symlink_metadata(&self.path) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(error) => return Err(error),
+        };
+        if metadata.file_type().is_socket()
+            && metadata.dev() == self.device
+            && metadata.ino() == self.inode
+        {
+            std::fs::remove_file(&self.path)?;
+        }
+        Ok(())
+    }
+}
+
+impl Drop for BoundSocket {
+    fn drop(&mut self) {
+        let _ = self.cleanup();
+    }
+}
+
+#[derive(Clone, Default)]
+struct ListenerRegistry {
+    entries: Arc<Mutex<HashMap<String, ListenerEntry>>>,
+}
+
+struct ListenerEntry {
+    identity: Arc<()>,
+    cancel: oneshot::Sender<()>,
+    stopped: oneshot::Receiver<bool>,
+}
+
+impl ListenerRegistry {
+    fn register(&self, socket_path: String, limit: usize) -> Option<ListenerRegistration> {
+        let mut entries = self.lock();
+        if entries.len() >= limit || entries.contains_key(&socket_path) {
+            return None;
+        }
+
+        let identity = Arc::new(());
+        let (cancel_tx, cancel_rx) = oneshot::channel();
+        let (stopped_tx, stopped_rx) = oneshot::channel();
+        entries.insert(
+            socket_path.clone(),
+            ListenerEntry {
+                identity: identity.clone(),
+                cancel: cancel_tx,
+                stopped: stopped_rx,
+            },
+        );
+        Some(ListenerRegistration {
+            registry: self.clone(),
+            socket_path,
+            identity,
+            cancel: cancel_rx,
+            stopped: Some(stopped_tx),
+            stopped_cleanly: false,
+        })
+    }
+
+    async fn cancel(&self, socket_path: &str) -> bool {
+        let entry = self.lock().remove(socket_path);
+        let Some(entry) = entry else {
+            return false;
+        };
+        let _ = entry.cancel.send(());
+        entry.stopped.await.unwrap_or(false)
+    }
+
+    fn cancel_all(&self) {
+        let entries = self
+            .lock()
+            .drain()
+            .map(|(_, entry)| entry)
+            .collect::<Vec<_>>();
+        for entry in entries {
+            let _ = entry.cancel.send(());
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.lock().len()
+    }
+
+    fn lock(&self) -> MutexGuard<'_, HashMap<String, ListenerEntry>> {
+        self.entries
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+}
+
+struct ListenerRegistration {
+    registry: ListenerRegistry,
+    socket_path: String,
+    identity: Arc<()>,
+    cancel: oneshot::Receiver<()>,
+    stopped: Option<oneshot::Sender<bool>>,
+    stopped_cleanly: bool,
+}
+
+impl ListenerRegistration {
+    async fn cancelled(&mut self) {
+        let _ = (&mut self.cancel).await;
+    }
+
+    fn finish_cleanly(&mut self) {
+        self.stopped_cleanly = true;
+    }
+}
+
+impl Drop for ListenerRegistration {
+    fn drop(&mut self) {
+        let mut entries = self.registry.lock();
+        let owns_entry = entries
+            .get(&self.socket_path)
+            .is_some_and(|entry| Arc::ptr_eq(&entry.identity, &self.identity));
+        if owns_entry {
+            entries.remove(&self.socket_path);
+        }
+        drop(entries);
+
+        if let Some(stopped) = self.stopped.take() {
+            let _ = stopped.send(self.stopped_cleanly);
+        }
+    }
+}
+
+/// Owns reverse streamlocal listeners created by one authenticated connection.
+pub(crate) struct ReverseStreamlocalManager {
+    listeners: ListenerRegistry,
+    connection_permits: Arc<Semaphore>,
+}
+
+impl ReverseStreamlocalManager {
+    pub(crate) fn new() -> Self {
+        Self {
+            listeners: ListenerRegistry::default(),
+            connection_permits: Arc::new(Semaphore::new(MAX_FORWARD_CONNECTIONS)),
+        }
+    }
+
+    pub(crate) async fn listen(
+        &self,
+        socket_path: &str,
+        server: Arc<GuestServer>,
+        session_handle: SessionHandle,
+    ) -> bool {
+        if !super::streamlocal::is_valid_target(socket_path)
+            || self.listeners.len() >= MAX_REMOTE_FORWARD_LISTENERS
+        {
+            return false;
+        }
+        let Some(registration) = self
+            .listeners
+            .register(socket_path.to_string(), MAX_REMOTE_FORWARD_LISTENERS)
+        else {
+            return false;
+        };
+
+        let ingress = match TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await {
+            Ok(ingress) => ingress,
+            Err(error) => {
+                debug!(%error, "reverse streamlocal loopback ingress bind failed");
+                return false;
+            }
+        };
+        let SocketAddr::V4(ingress_address) = ingress
+            .local_addr()
+            .ok()
+            .unwrap_or_else(|| SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0)))
+        else {
+            return false;
+        };
+        if *ingress_address.ip() != Ipv4Addr::LOCALHOST || ingress_address.port() == 0 {
+            return false;
+        }
+
+        let token = uuid::Uuid::new_v4().to_string();
+        let helper =
+            match RunningHelper::start(server, socket_path, ingress_address, token.clone()).await {
+                Ok(helper) => helper,
+                Err(error) => {
+                    debug!(%error, socket_path, "reverse streamlocal helper start failed");
+                    return false;
+                }
+            };
+
+        spawn_listener(
+            ingress,
+            socket_path.to_string(),
+            token,
+            session_handle,
+            self.connection_permits.clone(),
+            helper,
+            registration,
+        );
+        true
+    }
+
+    pub(crate) async fn cancel(&self, socket_path: &str) -> bool {
+        if !super::streamlocal::is_valid_target(socket_path) {
+            return false;
+        }
+        self.listeners.cancel(socket_path).await
+    }
+}
+
+impl Drop for ReverseStreamlocalManager {
+    fn drop(&mut self) {
+        self.listeners.cancel_all();
+    }
+}
+
+struct RunningHelper {
+    server: Arc<GuestServer>,
+    registry: ExecutionRegistry,
+    execution_id: String,
+    stdin: mpsc::Sender<ExecStdin>,
+    stdin_task: JoinHandle<()>,
+    output: mpsc::Receiver<ExecOutput>,
+    buffered_stdout: Vec<u8>,
+}
+
+impl RunningHelper {
+    async fn start(
+        server: Arc<GuestServer>,
+        socket_path: &str,
+        ingress: SocketAddrV4,
+        token: String,
+    ) -> Result<Self, String> {
+        let (container_id, profile) = super::bridge::resolve_single_container_profile(&server)
+            .await
+            .map_err(|error| error.to_string())?;
+        let launch = helper_execution_launch(&container_id, &profile, socket_path, ingress);
+        let response = tokio::time::timeout(
+            CONTROL_CALL_TIMEOUT,
+            crate::service::exec::start_ssh_execution(&server, launch.request, launch.workload),
+        )
+        .await
+        .map_err(|_| "reverse streamlocal exec RPC timed out".to_string())?;
+        if let Some(error) = response.error {
+            return Err(format!("{}: {}", error.reason, error.detail));
+        }
+        let execution_id = response.execution_id;
+        let registry = server.registry.clone();
+
+        let (stdin_tx, stdin_rx) = mpsc::channel::<ExecStdin>(HELPER_STDIN_QUEUE_DEPTH);
+        let opening = ExecStdin {
+            execution_id: execution_id.clone(),
+            data: Vec::new(),
+            close: false,
+        };
+        let input = match server
+            .send_execution_input(opening, Box::pin(ReceiverStream::new(stdin_rx).map(Ok)))
+            .await
+        {
+            Ok(task) => task,
+            // Matches every sibling failure below: the execution is registered
+            // and running, so it must be torn down rather than leaked.
+            Err(error) => {
+                spawn_failed_helper_cleanup(server.clone(), registry, execution_id, None, None);
+                return Err(format!("reverse streamlocal stdin setup failed: {error}"));
+            }
+        };
+        let stdin_task = tokio::spawn(async move {
+            if let Ok(Err(error)) = input.await {
+                debug!(%error, "reverse streamlocal helper stdin ended");
+            }
+        });
+        if stdin_tx
+            .send(ExecStdin {
+                execution_id: execution_id.clone(),
+                data: token.into_bytes(),
+                close: false,
+            })
+            .await
+            .is_err()
+        {
+            spawn_failed_helper_cleanup(
+                server.clone(),
+                registry,
+                execution_id,
+                None,
+                Some(stdin_task),
+            );
+            return Err("reverse streamlocal stdin setup failed".into());
+        }
+
+        let attach =
+            tokio::time::timeout(CONTROL_CALL_TIMEOUT, server.attach_execution(&execution_id))
+                .await;
+        let mut output = match attach {
+            Ok(Ok(output)) => output,
+            Ok(Err(error)) => {
+                let _ = stdin_tx
+                    .send(ExecStdin {
+                        execution_id: execution_id.clone(),
+                        data: Vec::new(),
+                        close: true,
+                    })
+                    .await;
+                drop(stdin_tx);
+                spawn_failed_helper_cleanup(
+                    server.clone(),
+                    registry,
+                    execution_id,
+                    None,
+                    Some(stdin_task),
+                );
+                return Err(format!("reverse streamlocal attach failed: {error}"));
+            }
+            Err(_) => {
+                let _ = stdin_tx
+                    .send(ExecStdin {
+                        execution_id: execution_id.clone(),
+                        data: Vec::new(),
+                        close: true,
+                    })
+                    .await;
+                drop(stdin_tx);
+                spawn_failed_helper_cleanup(
+                    server.clone(),
+                    registry,
+                    execution_id,
+                    None,
+                    Some(stdin_task),
+                );
+                return Err("reverse streamlocal attach timed out".into());
+            }
+        };
+
+        let buffered_stdout = match read_marker(
+            &mut output,
+            REVERSE_STREAMLOCAL_READY_MAGIC,
+            Vec::new(),
+            REVERSE_STREAMLOCAL_STOPPED_MAGIC.len(),
+        )
+        .await
+        {
+            Ok(buffered) => buffered,
+            Err(error) => {
+                let _ = stdin_tx
+                    .send(ExecStdin {
+                        execution_id: execution_id.clone(),
+                        data: Vec::new(),
+                        close: true,
+                    })
+                    .await;
+                drop(stdin_tx);
+                spawn_failed_helper_cleanup(
+                    server.clone(),
+                    registry,
+                    execution_id,
+                    Some(output),
+                    Some(stdin_task),
+                );
+                return Err(error);
+            }
+        };
+
+        Ok(Self {
+            server,
+            registry,
+            execution_id,
+            stdin: stdin_tx,
+            stdin_task,
+            output,
+            buffered_stdout,
+        })
+    }
+
+    async fn request_stop(&mut self) -> bool {
+        self.stdin
+            .send(ExecStdin {
+                execution_id: self.execution_id.clone(),
+                data: Vec::new(),
+                close: true,
+            })
+            .await
+            .is_ok()
+    }
+
+    async fn wait_stopped(&mut self) -> bool {
+        let buffered = std::mem::take(&mut self.buffered_stdout);
+        match read_marker(
+            &mut self.output,
+            REVERSE_STREAMLOCAL_STOPPED_MAGIC,
+            buffered,
+            0,
+        )
+        .await
+        {
+            Ok(_) => true,
+            Err(error) => {
+                debug!(%error, "reverse streamlocal helper stop acknowledgement failed");
+                false
+            }
+        }
+    }
+
+    fn spawn_cleanup(self, force_termination: bool) {
+        spawn_execution_cleanup(
+            self.server,
+            self.registry,
+            self.execution_id,
+            Some(self.output),
+            Some(self.stdin_task),
+            force_termination,
+        );
+    }
+}
+
+struct HelperExecutionLaunch {
+    request: ExecRequest,
+    workload: super::SshWorkload,
+}
+
+fn helper_execution_launch(
+    container_id: &str,
+    profile: &crate::container::user_profile::RootSessionProfile,
+    socket_path: &str,
+    ingress: SocketAddrV4,
+) -> HelperExecutionLaunch {
+    let workload = super::SshWorkload::ReverseStreamlocal {
+        socket_path: socket_path.into(),
+        ingress,
+    };
+    let (program, args) = workload.placeholder();
+    HelperExecutionLaunch {
+        request: ExecRequest {
+            execution_id: None,
+            program,
+            args,
+            env: super::bridge::session_exec_env(HashMap::new(), container_id, profile),
+            workdir: profile.home_dir.clone(),
+            timeout_ms: 0,
+            tty: None,
+            user: Some("0:0".to_string()),
+        },
+        workload,
+    }
+}
+
+fn spawn_listener(
+    ingress: TcpListener,
+    socket_path: String,
+    token: String,
+    session_handle: SessionHandle,
+    permits: Arc<Semaphore>,
+    mut helper: RunningHelper,
+    mut registration: ListenerRegistration,
+) {
+    tokio::spawn(async move {
+        enum End {
+            Cancelled,
+            HelperEnded,
+            IngressFailed,
+        }
+
+        let mut pending_opens = JoinSet::new();
+        let end = loop {
+            tokio::select! {
+                biased;
+                _ = registration.cancelled() => break End::Cancelled,
+                completed = pending_opens.join_next(), if !pending_opens.is_empty() => {
+                    if let Some(Err(error)) = completed {
+                        warn!(%error, "reverse streamlocal channel task failed");
+                    }
+                }
+                output = helper.output.recv() => {
+                    match output {
+                        Some(ExecOutput { event: Some(exec_output::Event::Stderr(stderr)) }) => {
+                            debug!(bytes = stderr.data.len(), "reverse streamlocal helper stderr");
+                        }
+                        Some(ExecOutput { event: Some(exec_output::Event::Stdout(stdout)) }) => {
+                            if !append_stopped_marker_prefix(
+                                &mut helper.buffered_stdout,
+                                &stdout.data,
+                            ) {
+                                warn!("reverse streamlocal helper emitted invalid control output");
+                                break End::HelperEnded;
+                            }
+                        }
+                        Some(ExecOutput { event: None }) => {}
+                        None => break End::HelperEnded,
+                    }
+                }
+                accepted = ingress.accept() => {
+                    let (stream, peer) = match accepted {
+                        Ok(accepted) => accepted,
+                        Err(error) => {
+                            warn!(%error, "reverse streamlocal loopback ingress failed");
+                            break End::IngressFailed;
+                        }
+                    };
+                    if !peer.ip().is_loopback() {
+                        continue;
+                    }
+                    let Ok(permit) = permits.clone().try_acquire_owned() else {
+                        debug!("reverse streamlocal forwarding connection limit reached");
+                        continue;
+                    };
+                    let handle = session_handle.clone();
+                    let path = socket_path.clone();
+                    let expected_token = token.clone();
+                    pending_opens.spawn(async move {
+                        let stream = match authenticate_ingress(stream, expected_token.as_bytes()).await {
+                            Ok(stream) => stream,
+                            Err(error) => {
+                                debug!(%error, "reverse streamlocal ingress authentication failed");
+                                return;
+                            }
+                        };
+                        let channel = tokio::time::timeout(
+                            FORWARD_CONNECT_TIMEOUT,
+                            handle.channel_open_forwarded_streamlocal(path),
+                        )
+                        .await;
+                        match channel {
+                            Ok(Ok(channel)) => spawn_relay(channel, stream, permit),
+                            Ok(Err(error)) => {
+                                debug!(%error, "SSH client rejected reverse streamlocal channel")
+                            }
+                            Err(_) => debug!("reverse streamlocal channel request timed out"),
+                        }
+                    });
+                }
+            }
+        };
+
+        // Closing the ingress first prevents a post-cancel helper connection
+        // from starting another SSH channel. Already-open relays own their TCP
+        // streams independently and may continue draining.
+        drop(ingress);
+        let was_cancelled = matches!(end, End::Cancelled);
+        let stop_acknowledged = if matches!(end, End::HelperEnded) {
+            false
+        } else {
+            let requested = helper.request_stop().await;
+            requested
+                && tokio::time::timeout(CONTROL_CALL_TIMEOUT, helper.wait_stopped())
+                    .await
+                    .unwrap_or(false)
+        };
+
+        finish_pending_opens(&mut pending_opens).await;
+        if was_cancelled && stop_acknowledged {
+            registration.finish_cleanly();
+        }
+        drop(registration);
+        helper.spawn_cleanup(!stop_acknowledged && !matches!(end, End::HelperEnded));
+    });
+}
+
+async fn authenticate_ingress(
+    mut stream: TcpStream,
+    expected_token: &[u8],
+) -> std::io::Result<TcpStream> {
+    if expected_token.len() != INGRESS_TOKEN_BYTES {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "invalid expected ingress token length",
+        ));
+    }
+    let mut received = [0_u8; INGRESS_TOKEN_BYTES];
+    tokio::time::timeout(FORWARD_CONNECT_TIMEOUT, stream.read_exact(&mut received))
+        .await
+        .map_err(|_| std::io::Error::new(std::io::ErrorKind::TimedOut, "token read timed out"))??;
+    if received != expected_token {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "ingress token mismatch",
+        ));
+    }
+    Ok(stream)
+}
+
+fn spawn_relay(
+    channel: Channel<Msg>,
+    mut stream: TcpStream,
+    _permit: tokio::sync::OwnedSemaphorePermit,
+) {
+    tokio::spawn(async move {
+        let mut channel = channel.into_stream();
+        if let Err(error) = tokio::io::copy_bidirectional(&mut channel, &mut stream).await {
+            debug!(%error, "SSH reverse streamlocal relay ended with an error");
+        }
+        let _ = channel.shutdown().await;
+        let _ = stream.shutdown().await;
+    });
+}
+
+async fn finish_pending_opens(pending_opens: &mut JoinSet<()>) {
+    while let Some(completed) = pending_opens.join_next().await {
+        if let Err(error) = completed {
+            warn!(%error, "reverse streamlocal channel task failed");
+        }
+    }
+}
+
+#[derive(Default)]
+struct MarkerParser {
+    matched: usize,
+}
+
+impl MarkerParser {
+    fn push(
+        &mut self,
+        marker: &[u8],
+        chunk: &[u8],
+        max_trailing_bytes: usize,
+    ) -> Result<Option<Vec<u8>>, String> {
+        let needed = marker.len().saturating_sub(self.matched);
+        let prefix_len = needed.min(chunk.len());
+        if chunk[..prefix_len] != marker[self.matched..self.matched + prefix_len] {
+            return Err("reverse streamlocal helper returned an invalid control marker".into());
+        }
+        self.matched += prefix_len;
+        if self.matched == marker.len() {
+            if chunk.len() - prefix_len > max_trailing_bytes {
+                return Err("reverse streamlocal helper returned excess control output".into());
+            }
+            return Ok(Some(chunk[prefix_len..].to_vec()));
+        }
+        Ok(None)
+    }
+}
+
+async fn read_marker(
+    output: &mut mpsc::Receiver<ExecOutput>,
+    marker: &[u8],
+    initial_stdout: Vec<u8>,
+    max_trailing_bytes: usize,
+) -> Result<Vec<u8>, String> {
+    tokio::time::timeout(FORWARD_CONNECT_TIMEOUT, async {
+        let mut parser = MarkerParser::default();
+        if !initial_stdout.is_empty() {
+            if let Some(buffered) = parser.push(marker, &initial_stdout, max_trailing_bytes)? {
+                return Ok(buffered);
+            }
+        }
+        loop {
+            let message = output.recv().await.ok_or_else(|| {
+                "reverse streamlocal helper exited before control marker".to_string()
+            })?;
+            match message.event {
+                Some(exec_output::Event::Stdout(stdout)) => {
+                    if let Some(buffered) = parser.push(marker, &stdout.data, max_trailing_bytes)? {
+                        return Ok(buffered);
+                    }
+                }
+                Some(exec_output::Event::Stderr(stderr)) => {
+                    debug!(
+                        bytes = stderr.data.len(),
+                        "reverse streamlocal helper stderr before marker"
+                    );
+                }
+                None => {}
+            }
+        }
+    })
+    .await
+    .map_err(|_| "reverse streamlocal helper control marker timed out".to_string())?
+}
+
+fn append_stopped_marker_prefix(buffer: &mut Vec<u8>, chunk: &[u8]) -> bool {
+    let Some(end) = buffer.len().checked_add(chunk.len()) else {
+        return false;
+    };
+    if end > REVERSE_STREAMLOCAL_STOPPED_MAGIC.len()
+        || chunk != &REVERSE_STREAMLOCAL_STOPPED_MAGIC[buffer.len()..end]
+    {
+        return false;
+    }
+    buffer.extend_from_slice(chunk);
+    true
+}
+
+fn spawn_failed_helper_cleanup(
+    server: Arc<GuestServer>,
+    registry: ExecutionRegistry,
+    execution_id: String,
+    output: Option<mpsc::Receiver<ExecOutput>>,
+    stdin_task: Option<JoinHandle<()>>,
+) {
+    spawn_execution_cleanup(server, registry, execution_id, output, stdin_task, true);
+}
+
+fn spawn_execution_cleanup(
+    server: Arc<GuestServer>,
+    registry: ExecutionRegistry,
+    execution_id: String,
+    output: Option<mpsc::Receiver<ExecOutput>>,
+    stdin_task: Option<JoinHandle<()>>,
+    force_termination: bool,
+) {
+    tokio::spawn(async move {
+        let output_task = output.map(|mut output| {
+            tokio::spawn(async move {
+                while let Some(message) = output.recv().await {
+                    if let Some(exec_output::Event::Stderr(stderr)) = message.event {
+                        debug!(
+                            bytes = stderr.data.len(),
+                            "reverse streamlocal helper stderr"
+                        );
+                    }
+                }
+            })
+        });
+
+        let state = registry.get(&execution_id).await;
+        if force_termination {
+            // A failed start may still have a working stdin control stream.
+            // Give that graceful stop a chance to unlink the socket before
+            // escalating to signals that cannot run the helper's destructor.
+            let exited_gracefully = if let Some(state) = &state {
+                tokio::time::timeout(PROCESS_TERMINATION_GRACE, state.wait_process())
+                    .await
+                    .is_ok()
+            } else {
+                true
+            };
+            if !exited_gracefully {
+                let _ = tokio::time::timeout(
+                    CONTROL_CALL_TIMEOUT,
+                    server.kill_execution(
+                        &execution_id,
+                        15,
+                        super::bridge::SIGNAL_TARGETS_PROCESS_GROUP,
+                    ),
+                )
+                .await;
+                if let Some(state) = &state {
+                    if tokio::time::timeout(PROCESS_TERMINATION_GRACE, state.wait_process())
+                        .await
+                        .is_err()
+                    {
+                        let _ = tokio::time::timeout(
+                            CONTROL_CALL_TIMEOUT,
+                            server.kill_execution(
+                                &execution_id,
+                                9,
+                                super::bridge::SIGNAL_TARGETS_PROCESS_GROUP,
+                            ),
+                        )
+                        .await;
+                    }
+                } else {
+                    let _ = tokio::time::timeout(
+                        CONTROL_CALL_TIMEOUT,
+                        server.kill_execution(
+                            &execution_id,
+                            9,
+                            super::bridge::SIGNAL_TARGETS_PROCESS_GROUP,
+                        ),
+                    )
+                    .await;
+                }
+            }
+        }
+        if let Some(state) = state {
+            state.wait_process().await;
+        }
+        if let Some(task) = output_task {
+            let _ = task.await;
+        }
+        if let Some(task) = stdin_task {
+            let _ = task.await;
+        }
+        if !registry.release_ephemeral(&execution_id).await {
+            debug!(%execution_id, "reverse streamlocal helper was already released");
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TOKEN: &str = "9e3d4f4f-e9e5-4896-a42c-9fe5f53244af";
+
+    struct RunningInternal {
+        control: tokio::io::DuplexStream,
+        status: tokio::io::DuplexStream,
+        task: JoinHandle<BoxliteResult<()>>,
+    }
+
+    async fn start_internal(socket_path: &Path, ingress: SocketAddrV4) -> RunningInternal {
+        let (mut control, workload_control) = tokio::io::duplex(64);
+        let (workload_status, mut status) = tokio::io::duplex(128);
+        let args = InternalArgs {
+            socket_path: socket_path.to_string_lossy().into_owned(),
+            ingress,
+        };
+        let task = tokio::spawn(serve_reverse_streamlocal(
+            args,
+            workload_control,
+            workload_status,
+        ));
+        control.write_all(TOKEN.as_bytes()).await.unwrap();
+
+        let mut ready = vec![0; REVERSE_STREAMLOCAL_READY_MAGIC.len()];
+        tokio::time::timeout(FORWARD_CONNECT_TIMEOUT, status.read_exact(&mut ready))
+            .await
+            .expect("reverse streamlocal readiness timed out")
+            .expect("read reverse streamlocal readiness");
+        assert_eq!(ready, REVERSE_STREAMLOCAL_READY_MAGIC);
+
+        RunningInternal {
+            control,
+            status,
+            task,
+        }
+    }
+
+    async fn stop_internal(mut running: RunningInternal) {
+        running.control.write_all(b"stop").await.unwrap();
+        let mut stopped = vec![0; REVERSE_STREAMLOCAL_STOPPED_MAGIC.len()];
+        tokio::time::timeout(
+            FORWARD_CONNECT_TIMEOUT,
+            running.status.read_exact(&mut stopped),
+        )
+        .await
+        .expect("reverse streamlocal stop timed out")
+        .expect("read reverse streamlocal stopped marker");
+        assert_eq!(stopped, REVERSE_STREAMLOCAL_STOPPED_MAGIC);
+        tokio::time::timeout(FORWARD_CONNECT_TIMEOUT, running.task)
+            .await
+            .expect("reverse streamlocal workload did not exit")
+            .expect("join reverse streamlocal workload")
+            .expect("reverse streamlocal workload failed");
+    }
+
+    async fn assert_internal_round_trip(socket_path: &Path, ingress: &TcpListener, request: &[u8]) {
+        let mut unix = UnixStream::connect(socket_path).await.unwrap();
+        let (mut tcp, peer) = tokio::time::timeout(FORWARD_CONNECT_TIMEOUT, ingress.accept())
+            .await
+            .expect("reverse streamlocal ingress accept timed out")
+            .unwrap();
+        assert!(peer.ip().is_loopback());
+
+        let mut token = [0; INGRESS_TOKEN_BYTES];
+        tcp.read_exact(&mut token).await.unwrap();
+        assert_eq!(&token, TOKEN.as_bytes());
+
+        unix.write_all(request).await.unwrap();
+        let mut received = vec![0; request.len()];
+        tcp.read_exact(&mut received).await.unwrap();
+        assert_eq!(received, request);
+
+        tcp.write_all(b"response").await.unwrap();
+        let mut response = [0; 8];
+        unix.read_exact(&mut response).await.unwrap();
+        assert_eq!(&response, b"response");
+    }
+
+    #[test]
+    fn helper_arguments_require_a_safe_path_and_loopback_ingress() {
+        let parsed =
+            parse_internal_args(&["/run/service.sock".into(), "127.0.0.1:32000".into()]).unwrap();
+        assert_eq!(parsed.socket_path, "/run/service.sock");
+        assert_eq!(parsed.ingress.port(), 32_000);
+
+        assert!(parse_internal_args(&["relative.sock".into(), "127.0.0.1:32000".into(),]).is_err());
+        assert!(
+            parse_internal_args(&["/run/service.sock".into(), "192.0.2.1:32000".into(),]).is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn ingress_token_is_read_only_from_the_binary_control_stream() {
+        let (mut writer, mut reader) = tokio::io::duplex(64);
+        writer.write_all(TOKEN.as_bytes()).await.unwrap();
+        assert_eq!(read_ingress_token(&mut reader).await.unwrap(), TOKEN);
+
+        let (mut writer, mut reader) = tokio::io::duplex(64);
+        writer
+            .write_all(b"00000000-0000-0000-0000-00000000000Z")
+            .await
+            .unwrap();
+        assert!(read_ingress_token(&mut reader).await.is_err());
+    }
+
+    #[test]
+    fn helper_launch_keeps_the_token_out_of_logged_argv_and_env() {
+        let profile = crate::container::user_profile::RootSessionProfile {
+            home_dir: "/root".into(),
+            login_shell: "/bin/ash".into(),
+        };
+        let launch = helper_execution_launch(
+            "container-1",
+            &profile,
+            "/run/service.sock",
+            SocketAddrV4::new(Ipv4Addr::LOCALHOST, 32_000),
+        );
+        let request = launch.request;
+
+        assert_eq!(
+            request.program,
+            crate::service::ssh::workload::INTERNAL_PROGRAM
+        );
+        assert_eq!(
+            request.args,
+            [
+                INTERNAL_REVERSE_STREAMLOCAL_ARG,
+                "/run/service.sock",
+                "127.0.0.1:32000",
+            ]
+        );
+        assert!(request.args.iter().all(|value| !value.contains(TOKEN)));
+        assert!(request.env.values().all(|value| !value.contains(TOKEN)));
+        assert_eq!(request.env.get("HOME").map(String::as_str), Some("/root"));
+        assert_eq!(
+            request.env.get("SHELL").map(String::as_str),
+            Some("/bin/ash")
+        );
+        assert_eq!(request.env.get("USER").map(String::as_str), Some("root"));
+        assert_eq!(request.user.as_deref(), Some("0:0"));
+        assert_eq!(request.workdir, "/root");
+        assert!(matches!(
+            launch.workload,
+            crate::service::ssh::SshWorkload::ReverseStreamlocal { .. }
+        ));
+    }
+
+    #[test]
+    fn ready_and_stopped_markers_support_fragmented_and_coalesced_input() {
+        for marker in [
+            REVERSE_STREAMLOCAL_READY_MAGIC,
+            REVERSE_STREAMLOCAL_STOPPED_MAGIC,
+        ] {
+            let split = marker.len() / 2;
+            let mut parser = MarkerParser::default();
+            assert_eq!(parser.push(marker, &marker[..split], 16).unwrap(), None);
+            assert_eq!(
+                parser
+                    .push(marker, &[&marker[split..], b"after"].concat(), 16)
+                    .unwrap(),
+                Some(b"after".to_vec())
+            );
+
+            let mut parser = MarkerParser::default();
+            assert_eq!(
+                parser
+                    .push(marker, &[marker, b"payload"].concat(), 16)
+                    .unwrap(),
+                Some(b"payload".to_vec())
+            );
+        }
+    }
+
+    #[test]
+    fn helper_control_output_is_prefix_checked_and_bounded() {
+        let mut buffered = Vec::new();
+        let split = REVERSE_STREAMLOCAL_STOPPED_MAGIC.len() / 2;
+        assert!(append_stopped_marker_prefix(
+            &mut buffered,
+            &REVERSE_STREAMLOCAL_STOPPED_MAGIC[..split]
+        ));
+        assert!(append_stopped_marker_prefix(
+            &mut buffered,
+            &REVERSE_STREAMLOCAL_STOPPED_MAGIC[split..]
+        ));
+        assert!(!append_stopped_marker_prefix(&mut buffered, b"extra"));
+
+        let mut parser = MarkerParser::default();
+        assert!(parser
+            .push(
+                REVERSE_STREAMLOCAL_READY_MAGIC,
+                &[REVERSE_STREAMLOCAL_READY_MAGIC, b"too-long"].concat(),
+                1,
+            )
+            .is_err());
+    }
+
+    #[test]
+    fn duplicate_and_listener_limit_registrations_are_rejected() {
+        let registry = ListenerRegistry::default();
+        let first = registry.register("/run/one.sock".into(), 2).unwrap();
+        assert!(registry.register("/run/one.sock".into(), 2).is_none());
+        let second = registry.register("/run/two.sock".into(), 2).unwrap();
+        assert!(registry.register("/run/three.sock".into(), 2).is_none());
+        drop(first);
+        assert!(registry.register("/run/three.sock".into(), 2).is_some());
+        drop(second);
+    }
+
+    #[tokio::test]
+    async fn cancel_waits_for_pending_channel_opens() {
+        let registry = ListenerRegistry::default();
+        let mut registration = registry.register("/run/one.sock".into(), 1).unwrap();
+        let (finish_tx, finish_rx) = oneshot::channel::<()>();
+        let mut pending = JoinSet::new();
+        pending.spawn(async move {
+            let _ = finish_rx.await;
+        });
+
+        let registry_for_cancel = registry.clone();
+        let cancel = tokio::spawn(async move { registry_for_cancel.cancel("/run/one.sock").await });
+        registration.cancelled().await;
+        registration.finish_cleanly();
+        let finish = tokio::spawn(async move {
+            finish_pending_opens(&mut pending).await;
+            drop(registration);
+        });
+        tokio::task::yield_now().await;
+        assert!(!cancel.is_finished());
+
+        finish_tx.send(()).unwrap();
+        finish.await.unwrap();
+        assert!(cancel.await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn wrong_ingress_token_is_rejected_without_consuming_payload() {
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let client = tokio::spawn(async move {
+            let mut client = TcpStream::connect(address).await.unwrap();
+            client
+                .write_all(b"00000000-0000-0000-0000-000000000000payload")
+                .await
+                .unwrap();
+        });
+        let (server, _) = listener.accept().await.unwrap();
+        let error = authenticate_ingress(server, TOKEN.as_bytes())
+            .await
+            .unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::PermissionDenied);
+        client.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn internal_listener_relays_multiple_connections_and_cleans_up() {
+        let directory = tempfile::tempdir().unwrap();
+        let socket_path = directory.path().join("forward.sock");
+        let ingress = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+        let ingress_address = match ingress.local_addr().unwrap() {
+            SocketAddr::V4(address) => address,
+            SocketAddr::V6(_) => unreachable!("IPv4 bind returned IPv6 address"),
+        };
+        let running = start_internal(&socket_path, ingress_address).await;
+
+        assert_internal_round_trip(&socket_path, &ingress, b"first").await;
+        assert_internal_round_trip(&socket_path, &ingress, b"second").await;
+        stop_internal(running).await;
+        assert!(!socket_path.exists());
+    }
+
+    #[tokio::test]
+    async fn internal_listener_preserves_an_existing_path() {
+        let directory = tempfile::tempdir().unwrap();
+        let socket_path = directory.path().join("occupied.sock");
+        let existing = UnixListener::bind(&socket_path).unwrap();
+        let ingress = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+        let ingress_address = match ingress.local_addr().unwrap() {
+            SocketAddr::V4(address) => address,
+            SocketAddr::V6(_) => unreachable!("IPv4 bind returned IPv6 address"),
+        };
+        let (mut control, workload_control) = tokio::io::duplex(64);
+        let (workload_status, _status) = tokio::io::duplex(64);
+        let task = tokio::spawn(serve_reverse_streamlocal(
+            InternalArgs {
+                socket_path: socket_path.to_string_lossy().into_owned(),
+                ingress: ingress_address,
+            },
+            workload_control,
+            workload_status,
+        ));
+        control.write_all(TOKEN.as_bytes()).await.unwrap();
+
+        let result = tokio::time::timeout(FORWARD_CONNECT_TIMEOUT, task)
+            .await
+            .expect("colliding reverse streamlocal workload did not exit")
+            .unwrap();
+        assert!(result.is_err());
+        assert!(socket_path.exists());
+
+        let connect = UnixStream::connect(&socket_path).await.unwrap();
+        let (_accepted, _) = existing.accept().await.unwrap();
+        drop(connect);
+    }
+
+    #[tokio::test]
+    async fn internal_listener_does_not_unlink_a_replacement_socket() {
+        let directory = tempfile::tempdir().unwrap();
+        let socket_path = directory.path().join("forward.sock");
+        let displaced_path = directory.path().join("displaced.sock");
+        let ingress = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+        let ingress_address = match ingress.local_addr().unwrap() {
+            SocketAddr::V4(address) => address,
+            SocketAddr::V6(_) => unreachable!("IPv4 bind returned IPv6 address"),
+        };
+        let running = start_internal(&socket_path, ingress_address).await;
+
+        std::fs::rename(&socket_path, &displaced_path).unwrap();
+        let replacement = UnixListener::bind(&socket_path).unwrap();
+        stop_internal(running).await;
+
+        assert!(socket_path.exists());
+        let connect = UnixStream::connect(&socket_path).await.unwrap();
+        let (_accepted, _) = replacement.accept().await.unwrap();
+        drop(connect);
+    }
+}

--- a/src/guest/src/service/ssh/server.rs
+++ b/src/guest/src/service/ssh/server.rs
@@ -1,0 +1,975 @@
+//! Per-connection russh handler and protocol policy.
+
+use crate::service::server::GuestServer;
+use crate::service::ssh::auth::{CertificateAuthorizer, CertificatePermissions, SSH_USER};
+use crate::service::ssh::bridge::{signal_number, ChannelBridge, Command};
+use crate::service::ssh::forward::ForwardingManager;
+use crate::service::ssh::limits::{
+    MAX_CHANNELS_PER_CONNECTION, MAX_COMMAND_BYTES, MAX_ENV_NAME_BYTES, MAX_ENV_VALUE_BYTES,
+    MAX_ENV_VARS, MAX_TERM_BYTES,
+};
+use crate::service::ssh::reverse_streamlocal::ReverseStreamlocalManager;
+use crate::service::ssh::streamlocal;
+use boxlite_shared::{TtyConfig, TtyMode};
+use russh::keys::{Algorithm, Certificate, EcdsaCurve, HashAlg, PrivateKey, PublicKey};
+use russh::server::{Auth, ChannelOpenHandle, Handle as SessionHandle, Msg, Session};
+use russh::{Channel, ChannelId, MethodKind, MethodSet, Pty, Sig};
+use std::borrow::Cow;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use tokio::sync::{oneshot, watch};
+use tracing::{info, warn};
+
+#[derive(Default)]
+struct PendingChannelState {
+    env: HashMap<String, String>,
+    tty: Option<TtyConfig>,
+    pty_term: Option<String>,
+}
+
+impl PendingChannelState {
+    fn into_execution_env(mut self) -> HashMap<String, String> {
+        if let Some(term) = self.pty_term {
+            self.env.insert("TERM".to_string(), term);
+        }
+        self.env
+    }
+}
+
+pub(crate) struct SshConnection {
+    guest: Arc<GuestServer>,
+    authorizer: Arc<CertificateAuthorizer>,
+    policy_rx: watch::Receiver<Option<Arc<CertificateAuthorizer>>>,
+    pending_channels: HashSet<ChannelId>,
+    pending_state: HashMap<ChannelId, PendingChannelState>,
+    bridges: HashMap<ChannelId, ChannelBridge>,
+    permissions: CertificatePermissions,
+    forwarding: ForwardingManager,
+    reverse_streamlocal: ReverseStreamlocalManager,
+    authenticated: Option<oneshot::Sender<()>>,
+}
+
+impl SshConnection {
+    pub(crate) fn new(
+        guest: Arc<GuestServer>,
+        authorizer: Arc<CertificateAuthorizer>,
+        policy_rx: watch::Receiver<Option<Arc<CertificateAuthorizer>>>,
+        authenticated: oneshot::Sender<()>,
+    ) -> Self {
+        Self {
+            guest,
+            authorizer,
+            policy_rx,
+            pending_channels: HashSet::new(),
+            pending_state: HashMap::new(),
+            bridges: HashMap::new(),
+            permissions: CertificatePermissions::default(),
+            forwarding: ForwardingManager::new(),
+            reverse_streamlocal: ReverseStreamlocalManager::new(),
+            authenticated: Some(authenticated),
+        }
+    }
+
+    fn open_channel_count(&self) -> usize {
+        self.pending_channels.len() + self.bridges.len()
+    }
+
+    fn is_shutting_down(&self) -> bool {
+        self.guest
+            .shutting_down
+            .load(std::sync::atomic::Ordering::SeqCst)
+    }
+
+    async fn start_execution(
+        &mut self,
+        channel_id: ChannelId,
+        command: Command,
+        session_handle: SessionHandle,
+    ) -> Result<(), String> {
+        if self.is_shutting_down() {
+            return Err("guest shutdown has started".into());
+        }
+        let mut state = self.pending_state.remove(&channel_id).unwrap_or_default();
+        let tty = state.tty.take();
+        let env = state.into_execution_env();
+        let bridge = ChannelBridge::start(
+            self.guest.clone(),
+            command,
+            tty,
+            env,
+            channel_id,
+            session_handle,
+        )
+        .await
+        .map_err(|error| error.to_string())?;
+        self.pending_channels.remove(&channel_id);
+        self.bridges.insert(channel_id, bridge);
+        Ok(())
+    }
+
+    fn abandon_pending_channel(&mut self, channel_id: ChannelId) {
+        self.pending_channels.remove(&channel_id);
+        self.pending_state.remove(&channel_id);
+    }
+}
+
+impl russh::server::Handler for SshConnection {
+    type Error = russh::Error;
+
+    async fn auth_none(&mut self, _user: &str) -> Result<Auth, Self::Error> {
+        Ok(Auth::reject())
+    }
+
+    async fn auth_password(&mut self, _user: &str, _password: &str) -> Result<Auth, Self::Error> {
+        Ok(Auth::reject())
+    }
+
+    async fn auth_publickey_offered(
+        &mut self,
+        user: &str,
+        _public_key: &PublicKey,
+    ) -> Result<Auth, Self::Error> {
+        // Certificate authentication uses the publickey wire method. The
+        // actual decision is made only after russh verifies the signature.
+        Ok(if user == SSH_USER {
+            Auth::Accept
+        } else {
+            Auth::reject()
+        })
+    }
+
+    async fn auth_publickey(
+        &mut self,
+        _user: &str,
+        _public_key: &PublicKey,
+    ) -> Result<Auth, Self::Error> {
+        // Raw keys are deliberately unsupported; only CA-signed certificates
+        // can reach the container.
+        Ok(Auth::reject())
+    }
+
+    async fn auth_openssh_certificate(
+        &mut self,
+        user: &str,
+        certificate: &Certificate,
+    ) -> Result<Auth, Self::Error> {
+        let Some(identity) = self.authorizer.authorize(user, certificate) else {
+            self.permissions = CertificatePermissions::default();
+            info!(user, "SSH certificate rejected");
+            return Ok(Auth::reject());
+        };
+
+        let Some(policy_guard) =
+            super::authentication_policy_guard(&self.policy_rx, &self.authorizer)
+        else {
+            self.permissions = CertificatePermissions::default();
+            info!(
+                user,
+                "SSH certificate rejected after authentication policy changed"
+            );
+            return Ok(Auth::reject());
+        };
+
+        self.permissions = identity.permissions;
+        if let Some(authenticated) = self.authenticated.take() {
+            let _ = authenticated.send(());
+        }
+
+        // Keep the policy read lock through the authentication signal. A
+        // concurrent Configure/Disable publication therefore happens either
+        // wholly before this commit (and is rejected above) or wholly after it
+        // (and applies only to later authentication attempts).
+        drop(policy_guard);
+        info!(key_id = certificate.key_id(), "SSH certificate accepted");
+        Ok(Auth::Accept)
+    }
+
+    async fn channel_open_session(
+        &mut self,
+        channel: Channel<Msg>,
+        reply: ChannelOpenHandle,
+        _session: &mut Session,
+    ) -> Result<(), Self::Error> {
+        if self.is_shutting_down() || self.open_channel_count() >= MAX_CHANNELS_PER_CONNECTION {
+            warn!(
+                open_channels = self.open_channel_count(),
+                limit = MAX_CHANNELS_PER_CONNECTION,
+                "SSH channel limit reached"
+            );
+            reply
+                .reject(russh::ChannelOpenFailure::ResourceShortage)
+                .await;
+            return Ok(());
+        }
+
+        let channel_id = channel.id();
+        self.pending_channels.insert(channel_id);
+        self.pending_state
+            .insert(channel_id, PendingChannelState::default());
+        reply.accept().await;
+        Ok(())
+    }
+
+    async fn channel_open_x11(
+        &mut self,
+        _channel: Channel<Msg>,
+        _originator_address: &str,
+        _originator_port: u32,
+        reply: ChannelOpenHandle,
+        _session: &mut Session,
+    ) -> Result<(), Self::Error> {
+        reply
+            .reject(russh::ChannelOpenFailure::AdministrativelyProhibited)
+            .await;
+        Ok(())
+    }
+
+    async fn channel_open_direct_tcpip(
+        &mut self,
+        channel: Channel<Msg>,
+        host_to_connect: &str,
+        port_to_connect: u32,
+        _originator_address: &str,
+        _originator_port: u32,
+        reply: ChannelOpenHandle,
+        _session: &mut Session,
+    ) -> Result<(), Self::Error> {
+        if self.is_shutting_down() || !self.permissions.port_forwarding {
+            reply
+                .reject(russh::ChannelOpenFailure::AdministrativelyProhibited)
+                .await;
+            return Ok(());
+        }
+        self.forwarding
+            .open_direct_tcpip(channel, host_to_connect, port_to_connect, reply)
+            .await;
+        Ok(())
+    }
+
+    async fn channel_open_forwarded_tcpip(
+        &mut self,
+        _channel: Channel<Msg>,
+        _host_to_connect: &str,
+        _port_to_connect: u32,
+        _originator_address: &str,
+        _originator_port: u32,
+        reply: ChannelOpenHandle,
+        _session: &mut Session,
+    ) -> Result<(), Self::Error> {
+        reply
+            .reject(russh::ChannelOpenFailure::AdministrativelyProhibited)
+            .await;
+        Ok(())
+    }
+
+    async fn channel_open_direct_streamlocal(
+        &mut self,
+        channel: Channel<Msg>,
+        socket_path: &str,
+        reply: ChannelOpenHandle,
+        session: &mut Session,
+    ) -> Result<(), Self::Error> {
+        if self.is_shutting_down() {
+            reply
+                .reject(russh::ChannelOpenFailure::AdministrativelyProhibited)
+                .await;
+            return Ok(());
+        }
+        if let Some(reason) = direct_streamlocal_rejection(
+            self.permissions.port_forwarding,
+            self.open_channel_count(),
+            socket_path,
+        ) {
+            reply.reject(reason).await;
+            return Ok(());
+        }
+
+        let channel_id = channel.id();
+        let session_handle = session.handle();
+        match ChannelBridge::start(
+            self.guest.clone(),
+            Command::Streamlocal(socket_path.to_string()),
+            None,
+            HashMap::new(),
+            channel_id,
+            session_handle,
+        )
+        .await
+        {
+            Ok(bridge) => {
+                // `start` has observed the in-container connect handshake, but
+                // its output pump remains gated until confirmation is queued.
+                reply.accept().await;
+                self.bridges.insert(channel_id, bridge);
+                self.bridges
+                    .get_mut(&channel_id)
+                    .expect("streamlocal bridge was just inserted")
+                    .activate_output();
+            }
+            Err(error) => {
+                warn!(%error, "SSH direct streamlocal helper start failed");
+                reply.reject(russh::ChannelOpenFailure::ConnectFailed).await;
+            }
+        }
+        Ok(())
+    }
+
+    async fn env_request(
+        &mut self,
+        channel: ChannelId,
+        variable_name: &str,
+        variable_value: &str,
+        session: &mut Session,
+    ) -> Result<(), Self::Error> {
+        let Some(state) = self.pending_state.get_mut(&channel) else {
+            session.channel_failure(channel)?;
+            return Ok(());
+        };
+        if state.env.len() >= MAX_ENV_VARS
+            || !is_valid_env_name(variable_name)
+            || variable_value.len() > MAX_ENV_VALUE_BYTES
+            || variable_value.contains('\0')
+        {
+            session.channel_failure(channel)?;
+            return Ok(());
+        }
+
+        state
+            .env
+            .insert(variable_name.to_string(), variable_value.to_string());
+        session.channel_success(channel)?;
+        Ok(())
+    }
+
+    async fn pty_request(
+        &mut self,
+        channel: ChannelId,
+        term: &str,
+        col_width: u32,
+        row_height: u32,
+        pix_width: u32,
+        pix_height: u32,
+        modes: &[(Pty, u32)],
+        session: &mut Session,
+    ) -> Result<(), Self::Error> {
+        if !self.permissions.pty {
+            session.channel_failure(channel)?;
+            return Ok(());
+        }
+        let Some(state) = self.pending_state.get_mut(&channel) else {
+            session.channel_failure(channel)?;
+            return Ok(());
+        };
+        if !apply_pty_request(
+            state,
+            term,
+            (row_height, col_width, pix_width, pix_height),
+            modes,
+        ) {
+            session.channel_failure(channel)?;
+            return Ok(());
+        }
+        session.channel_success(channel)?;
+        Ok(())
+    }
+
+    async fn window_change_request(
+        &mut self,
+        channel: ChannelId,
+        col_width: u32,
+        row_height: u32,
+        pix_width: u32,
+        pix_height: u32,
+        session: &mut Session,
+    ) -> Result<(), Self::Error> {
+        let Some(bridge) = self.bridges.get(&channel) else {
+            session.channel_failure(channel)?;
+            return Ok(());
+        };
+        match bridge
+            .resize(row_height, col_width, pix_width, pix_height)
+            .await
+        {
+            Ok(()) => session.channel_success(channel)?,
+            Err(error) => {
+                warn!(%error, "SSH resize request failed");
+                session.channel_failure(channel)?;
+            }
+        }
+        Ok(())
+    }
+
+    async fn shell_request(
+        &mut self,
+        channel: ChannelId,
+        session: &mut Session,
+    ) -> Result<(), Self::Error> {
+        if !self.pending_channels.contains(&channel) {
+            session.channel_failure(channel)?;
+            return Ok(());
+        }
+
+        match self
+            .start_execution(channel, Command::Shell, session.handle())
+            .await
+        {
+            Ok(()) => session.channel_success(channel)?,
+            Err(error) => {
+                warn!(%error, "SSH shell start failed");
+                self.abandon_pending_channel(channel);
+                session.channel_failure(channel)?;
+                session.close(channel)?;
+            }
+        }
+        Ok(())
+    }
+
+    async fn exec_request(
+        &mut self,
+        channel: ChannelId,
+        data: &[u8],
+        session: &mut Session,
+    ) -> Result<(), Self::Error> {
+        if !self.pending_channels.contains(&channel) {
+            self.abandon_pending_channel(channel);
+            session.channel_failure(channel)?;
+            return Ok(());
+        }
+        let Some(command) = valid_exec_command(data).map(str::to_string) else {
+            self.abandon_pending_channel(channel);
+            session.channel_failure(channel)?;
+            session.close(channel)?;
+            return Ok(());
+        };
+
+        info!(channel = ?channel, command_len = command.len(), "SSH exec request");
+        match self
+            .start_execution(channel, Command::Exec(command), session.handle())
+            .await
+        {
+            Ok(()) => session.channel_success(channel)?,
+            Err(error) => {
+                warn!(%error, "SSH exec start failed");
+                self.abandon_pending_channel(channel);
+                session.channel_failure(channel)?;
+                session.close(channel)?;
+            }
+        }
+        Ok(())
+    }
+
+    async fn subsystem_request(
+        &mut self,
+        channel: ChannelId,
+        name: &str,
+        session: &mut Session,
+    ) -> Result<(), Self::Error> {
+        if name != "sftp" || !self.pending_channels.contains(&channel) {
+            let was_pending = self.pending_channels.contains(&channel);
+            self.abandon_pending_channel(channel);
+            session.channel_failure(channel)?;
+            if was_pending {
+                session.close(channel)?;
+            }
+            return Ok(());
+        }
+
+        match self
+            .start_execution(channel, Command::Sftp, session.handle())
+            .await
+        {
+            Ok(()) => session.channel_success(channel)?,
+            Err(error) => {
+                warn!(%error, "SSH SFTP subsystem start failed");
+                self.abandon_pending_channel(channel);
+                session.channel_failure(channel)?;
+                session.close(channel)?;
+            }
+        }
+        Ok(())
+    }
+
+    async fn agent_request(
+        &mut self,
+        channel: ChannelId,
+        session: &mut Session,
+    ) -> Result<bool, Self::Error> {
+        session.channel_failure(channel)?;
+        Ok(false)
+    }
+
+    async fn signal(
+        &mut self,
+        channel: ChannelId,
+        signal: Sig,
+        _session: &mut Session,
+    ) -> Result<(), Self::Error> {
+        let Some(signal) = signal_number(&signal) else {
+            warn!(channel = ?channel, "SSH client requested an unsupported signal");
+            return Ok(());
+        };
+        let Some(bridge) = self.bridges.get(&channel) else {
+            return Ok(());
+        };
+        if let Err(error) = bridge.signal(signal).await {
+            warn!(%error, channel = ?channel, signal, "SSH signal forwarding failed");
+        }
+        Ok(())
+    }
+
+    async fn tcpip_forward(
+        &mut self,
+        address: &str,
+        port: &mut u32,
+        session: &mut Session,
+    ) -> Result<bool, Self::Error> {
+        if self.is_shutting_down() || !self.permissions.port_forwarding {
+            return Ok(false);
+        }
+        Ok(self
+            .forwarding
+            .listen_tcpip(address, port, session.handle())
+            .await)
+    }
+
+    async fn cancel_tcpip_forward(
+        &mut self,
+        address: &str,
+        port: u32,
+        _session: &mut Session,
+    ) -> Result<bool, Self::Error> {
+        if !self.permissions.port_forwarding {
+            return Ok(false);
+        }
+        Ok(self.forwarding.cancel_tcpip(address, port).await)
+    }
+
+    async fn streamlocal_forward(
+        &mut self,
+        socket_path: &str,
+        session: &mut Session,
+    ) -> Result<bool, Self::Error> {
+        if self.is_shutting_down()
+            || !reverse_streamlocal_allowed(self.permissions.port_forwarding, socket_path)
+        {
+            return Ok(false);
+        }
+        Ok(self
+            .reverse_streamlocal
+            .listen(socket_path, self.guest.clone(), session.handle())
+            .await)
+    }
+
+    async fn cancel_streamlocal_forward(
+        &mut self,
+        socket_path: &str,
+        _session: &mut Session,
+    ) -> Result<bool, Self::Error> {
+        if !reverse_streamlocal_allowed(self.permissions.port_forwarding, socket_path) {
+            return Ok(false);
+        }
+        Ok(self.reverse_streamlocal.cancel(socket_path).await)
+    }
+
+    async fn x11_request(
+        &mut self,
+        channel: ChannelId,
+        _single_connection: bool,
+        _x11_auth_protocol: &str,
+        _x11_auth_cookie: &str,
+        _x11_screen_number: u32,
+        session: &mut Session,
+    ) -> Result<(), Self::Error> {
+        session.channel_failure(channel)?;
+        Ok(())
+    }
+
+    async fn data(
+        &mut self,
+        channel: ChannelId,
+        data: &[u8],
+        session: &mut Session,
+    ) -> Result<(), Self::Error> {
+        let send_result = match self.bridges.get(&channel) {
+            Some(bridge) => bridge.stdin(data.to_vec()).await,
+            None => return Ok(()),
+        };
+        if let Err(error) = send_result {
+            warn!(%error, "SSH stdin forwarding failed");
+            if let Some(mut bridge) = self.bridges.remove(&channel) {
+                bridge.terminate_running();
+            }
+            session.close(channel)?;
+        }
+        Ok(())
+    }
+
+    async fn channel_eof(
+        &mut self,
+        channel: ChannelId,
+        session: &mut Session,
+    ) -> Result<(), Self::Error> {
+        let send_result = match self.bridges.get(&channel) {
+            Some(bridge) => bridge.stdin_eof().await,
+            None => return Ok(()),
+        };
+        if let Err(error) = send_result {
+            warn!(%error, "SSH stdin EOF forwarding failed");
+            if let Some(mut bridge) = self.bridges.remove(&channel) {
+                bridge.terminate_running();
+            }
+            session.close(channel)?;
+        }
+        Ok(())
+    }
+
+    async fn channel_close(
+        &mut self,
+        channel: ChannelId,
+        _session: &mut Session,
+    ) -> Result<(), Self::Error> {
+        self.abandon_pending_channel(channel);
+        if let Some(mut bridge) = self.bridges.remove(&channel) {
+            bridge.terminate_running();
+        }
+        Ok(())
+    }
+}
+
+impl Drop for SshConnection {
+    fn drop(&mut self) {
+        for (_, mut bridge) in self.bridges.drain() {
+            bridge.terminate_running();
+        }
+    }
+}
+
+fn is_valid_env_name(name: &str) -> bool {
+    if name.is_empty() || name.len() > MAX_ENV_NAME_BYTES {
+        return false;
+    }
+    let mut bytes = name.bytes();
+    let Some(first) = bytes.next() else {
+        return false;
+    };
+    (first.is_ascii_alphabetic() || first == b'_')
+        && bytes.all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+}
+
+fn valid_exec_command(data: &[u8]) -> Option<&str> {
+    if data.len() > MAX_COMMAND_BYTES || data.contains(&0) {
+        return None;
+    }
+    std::str::from_utf8(data).ok()
+}
+
+fn direct_streamlocal_rejection(
+    can_forward: bool,
+    open_channels: usize,
+    socket_path: &str,
+) -> Option<russh::ChannelOpenFailure> {
+    if !can_forward || !streamlocal::is_valid_target(socket_path) {
+        Some(russh::ChannelOpenFailure::AdministrativelyProhibited)
+    } else if open_channels >= MAX_CHANNELS_PER_CONNECTION {
+        Some(russh::ChannelOpenFailure::ResourceShortage)
+    } else {
+        None
+    }
+}
+
+fn reverse_streamlocal_allowed(can_forward: bool, socket_path: &str) -> bool {
+    can_forward && streamlocal::is_valid_target(socket_path)
+}
+
+fn apply_pty_request(
+    state: &mut PendingChannelState,
+    term: &str,
+    dimensions: (u32, u32, u32, u32),
+    modes: &[(Pty, u32)],
+) -> bool {
+    if term.is_empty()
+        || term.len() > MAX_TERM_BYTES
+        || !term.bytes().all(|byte| byte.is_ascii_graphic())
+        || (state.env.len() >= MAX_ENV_VARS && !state.env.contains_key("TERM"))
+    {
+        return false;
+    }
+
+    let (rows, cols, x_pixels, y_pixels) = dimensions;
+    let tty = TtyConfig {
+        rows,
+        cols,
+        x_pixels,
+        y_pixels,
+        modes: modes
+            .iter()
+            .map(|(opcode, value)| TtyMode {
+                opcode: *opcode as u32,
+                value: *value,
+            })
+            .collect(),
+    };
+    if crate::service::exec::exec_handle::PtyConfig::try_from(&tty).is_err() {
+        return false;
+    }
+
+    // OpenSSH carries the terminal type in the PTY request, not necessarily
+    // in a separate environment request. The PTY value is authoritative.
+    state.env.insert("TERM".to_string(), term.to_string());
+    state.pty_term = Some(term.to_string());
+    state.tty = Some(tty);
+    true
+}
+
+pub(crate) fn build_config(host_key: PrivateKey) -> russh::server::Config {
+    let mut methods = MethodSet::empty();
+    methods.push(MethodKind::PublicKey);
+    let preferred = russh::Preferred {
+        key: Cow::Owned(vec![
+            Algorithm::Ed25519,
+            Algorithm::SkEd25519,
+            Algorithm::Ecdsa {
+                curve: EcdsaCurve::NistP256,
+            },
+            Algorithm::SkEcdsaSha2NistP256,
+            Algorithm::Ecdsa {
+                curve: EcdsaCurve::NistP384,
+            },
+            Algorithm::Ecdsa {
+                curve: EcdsaCurve::NistP521,
+            },
+            Algorithm::Rsa {
+                hash: Some(HashAlg::Sha512),
+            },
+            Algorithm::Rsa {
+                hash: Some(HashAlg::Sha256),
+            },
+        ]),
+        // Immediate zlib exposes the decompressor before authentication.
+        // OpenSSH's delayed variant activates only after auth succeeds.
+        compression: Cow::Owned(vec![
+            russh::compression::NONE,
+            russh::compression::ZLIB_LEGACY,
+        ]),
+        ..Default::default()
+    };
+
+    russh::server::Config {
+        methods,
+        preferred,
+        auth_rejection_time: std::time::Duration::from_millis(500),
+        auth_rejection_time_initial: Some(std::time::Duration::ZERO),
+        keys: vec![host_key],
+        max_auth_attempts: 6,
+        keepalive_interval: Some(std::time::Duration::from_secs(30)),
+        keepalive_max: 3,
+        nodelay: true,
+        ..Default::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::layout::GuestLayout;
+    use russh::keys::ssh_key::certificate::{Builder, CertType};
+    use russh::keys::{Algorithm, PrivateKey};
+    use russh::server::Handler as _;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn user_certificate(ca_key: &PrivateKey, principal: &str) -> Certificate {
+        let mut rng = russh::keys::key::safe_rng();
+        let subject_key = PrivateKey::random(&mut rng, Algorithm::Ed25519).unwrap();
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let mut builder = Builder::new_with_random_nonce(
+            &mut rng,
+            subject_key.public_key(),
+            now.saturating_sub(60),
+            now.saturating_add(60),
+        )
+        .unwrap();
+        builder.cert_type(CertType::User).unwrap();
+        builder.key_id("boxlite-server-test").unwrap();
+        builder.valid_principal(principal).unwrap();
+        builder.extension("permit-pty", "").unwrap();
+        builder.sign(ca_key).unwrap()
+    }
+
+    async fn test_connection(
+        authorizer: Arc<CertificateAuthorizer>,
+        policy_rx: watch::Receiver<Option<Arc<CertificateAuthorizer>>>,
+    ) -> (SshConnection, oneshot::Receiver<()>) {
+        let guest = Arc::new(GuestServer::new(GuestLayout::new()));
+        let (authenticated_tx, authenticated_rx) = oneshot::channel();
+        (
+            SshConnection::new(guest, authorizer, policy_rx, authenticated_tx),
+            authenticated_rx,
+        )
+    }
+
+    #[tokio::test]
+    async fn certificate_authentication_commits_only_the_current_policy_epoch() {
+        let ca_key = {
+            let mut rng = russh::keys::key::safe_rng();
+            PrivateKey::random(&mut rng, Algorithm::Ed25519).unwrap()
+        };
+        let ca_public_key = ca_key.public_key().to_openssh().unwrap();
+        let certificate = user_certificate(&ca_key, "box_123");
+        let accepted = Arc::new(CertificateAuthorizer::new(&ca_public_key, "box_123").unwrap());
+
+        let (_policy_tx, policy_rx) = watch::channel(Some(accepted.clone()));
+        let (mut current, mut committed) = test_connection(accepted.clone(), policy_rx).await;
+        let auth = current
+            .auth_openssh_certificate(SSH_USER, &certificate)
+            .await
+            .unwrap();
+
+        assert_eq!(auth, Auth::Accept);
+        assert!(current.permissions.pty);
+        assert!(matches!(committed.try_recv(), Ok(())));
+
+        let (policy_tx, policy_rx) = watch::channel(Some(accepted.clone()));
+        let (mut stale, mut not_committed) = test_connection(accepted.clone(), policy_rx).await;
+        policy_tx.send_replace(Some(Arc::new(
+            CertificateAuthorizer::new(&ca_public_key, "box_456").unwrap(),
+        )));
+        policy_tx.send_replace(Some(accepted));
+
+        let auth = stale
+            .auth_openssh_certificate(SSH_USER, &certificate)
+            .await
+            .unwrap();
+
+        assert_eq!(auth, Auth::reject());
+        assert_eq!(stale.permissions, CertificatePermissions::default());
+        assert!(matches!(
+            not_committed.try_recv(),
+            Err(oneshot::error::TryRecvError::Empty)
+        ));
+    }
+
+    #[test]
+    fn accepts_only_bounded_portable_environment_names() {
+        for name in ["TERM", "LC_ALL", "_BOX_1"] {
+            assert!(is_valid_env_name(name));
+        }
+        for name in ["", "1PATH", "A=B", "A-B", "A\0B"] {
+            assert!(!is_valid_env_name(name));
+        }
+        assert!(!is_valid_env_name(&"A".repeat(MAX_ENV_NAME_BYTES + 1)));
+    }
+
+    #[test]
+    fn exec_command_must_be_bounded_utf8_without_nul() {
+        assert_eq!(
+            valid_exec_command(b"printf '%s' hello"),
+            Some("printf '%s' hello")
+        );
+        assert_eq!(valid_exec_command(b""), Some(""));
+        assert!(valid_exec_command(b"printf before\0after").is_none());
+        assert!(valid_exec_command(&[0xff]).is_none());
+        assert!(valid_exec_command(&vec![b'x'; MAX_COMMAND_BYTES + 1]).is_none());
+    }
+
+    #[test]
+    fn direct_streamlocal_requires_certificate_permission_path_and_capacity() {
+        assert_eq!(
+            direct_streamlocal_rejection(false, 0, "/run/service.sock"),
+            Some(russh::ChannelOpenFailure::AdministrativelyProhibited)
+        );
+        assert_eq!(
+            direct_streamlocal_rejection(true, 0, "relative.sock"),
+            Some(russh::ChannelOpenFailure::AdministrativelyProhibited)
+        );
+        assert_eq!(
+            direct_streamlocal_rejection(true, MAX_CHANNELS_PER_CONNECTION, "/run/service.sock"),
+            Some(russh::ChannelOpenFailure::ResourceShortage)
+        );
+        assert_eq!(
+            direct_streamlocal_rejection(true, 0, "/run/service.sock"),
+            None
+        );
+    }
+
+    #[test]
+    fn reverse_streamlocal_requires_certificate_permission_and_safe_path() {
+        assert!(!reverse_streamlocal_allowed(false, "/run/service.sock"));
+        assert!(!reverse_streamlocal_allowed(true, "relative.sock"));
+        assert!(reverse_streamlocal_allowed(true, "/run/service.sock"));
+    }
+
+    #[test]
+    fn advertises_only_public_key_authentication() {
+        let mut rng = russh::keys::key::safe_rng();
+        let host_key = PrivateKey::random(&mut rng, Algorithm::Ed25519).unwrap();
+        let config = build_config(host_key);
+
+        assert_eq!(&*config.methods, &[MethodKind::PublicKey]);
+        assert_eq!(config.max_auth_attempts, 6);
+        assert!(config.preferred.key.contains(&Algorithm::Ed25519));
+        assert!(config.preferred.key.contains(&Algorithm::SkEd25519));
+        assert!(config.preferred.key.contains(&Algorithm::Rsa {
+            hash: Some(HashAlg::Sha512),
+        }));
+        assert!(config.preferred.key.contains(&Algorithm::Rsa {
+            hash: Some(HashAlg::Sha256),
+        }));
+        assert!(!config
+            .preferred
+            .key
+            .contains(&Algorithm::Rsa { hash: None }));
+        assert!(!config.preferred.key.contains(&Algorithm::Dsa));
+        assert!(config
+            .preferred
+            .compression
+            .contains(&russh::compression::ZLIB_LEGACY));
+        assert!(!config
+            .preferred
+            .compression
+            .contains(&russh::compression::ZLIB));
+    }
+
+    #[test]
+    fn pty_request_sets_a_bounded_authoritative_term() {
+        let mut state = PendingChannelState::default();
+        state.env.insert("TERM".into(), "caller-value".into());
+        let tty = (24, 80, 0, 0);
+        let modes = [(Pty::VINTR, 3), (Pty::ECHO, 0)];
+
+        assert!(apply_pty_request(&mut state, "xterm-256color", tty, &modes));
+        assert_eq!(
+            state.env.get("TERM").map(String::as_str),
+            Some("xterm-256color")
+        );
+        let requested_tty = state.tty.as_ref().unwrap();
+        assert_eq!((requested_tty.rows, requested_tty.cols), (tty.0, tty.1));
+        assert_eq!(requested_tty.modes[0].opcode, Pty::VINTR as u32);
+        assert_eq!(requested_tty.modes[0].value, 3);
+
+        state.env.insert("TERM".into(), "later-env-value".into());
+        assert_eq!(
+            state.into_execution_env().get("TERM").map(String::as_str),
+            Some("xterm-256color")
+        );
+
+        let mut state = PendingChannelState::default();
+        for invalid in ["", "xterm\nunsafe"] {
+            assert!(!apply_pty_request(&mut state, invalid, tty, &modes));
+        }
+        assert!(!apply_pty_request(
+            &mut state,
+            &"x".repeat(MAX_TERM_BYTES + 1),
+            tty,
+            &modes
+        ));
+        assert!(!apply_pty_request(
+            &mut state,
+            "xterm",
+            (u16::MAX as u32 + 1, 80, 0, 0),
+            &modes
+        ));
+    }
+}

--- a/src/guest/src/service/ssh/session.rs
+++ b/src/guest/src/service/ssh/session.rs
@@ -25,10 +25,15 @@ pub(crate) fn parse_internal_args(args: &[String]) -> BoxliteResult<SessionActio
     }
 }
 
-/// Run after libcontainer has applied the tenant's namespaces and credentials.
+/// Run after libcontainer has applied the tenant's namespaces and credentials,
+/// which is what makes the passwd lookup resolve inside the container.
 pub(crate) fn run_internal(action: SessionAction) -> BoxliteResult<()> {
-    let profile = root_session_profile(Path::new("/"));
+    let profile = root_session_profile();
     enter_root_home(&profile)?;
+    // OpenSSH exports the account's shell alongside HOME (session.c, `do_child`).
+    // libcontainer already seeded HOME from the same passwd entry, and
+    // `enter_root_home` narrows it to the directory actually entered.
+    std::env::set_var("SHELL", &profile.login_shell);
 
     match action {
         SessionAction::Shell => exec_login_shell(&profile),
@@ -38,7 +43,7 @@ pub(crate) fn run_internal(action: SessionAction) -> BoxliteResult<()> {
 
 /// Apply root's home before the SFTP protocol loop starts.
 pub(crate) fn prepare_sftp_home() -> BoxliteResult<()> {
-    enter_root_home(&root_session_profile(Path::new("/")))
+    enter_root_home(&root_session_profile())
 }
 
 fn enter_root_home(profile: &RootSessionProfile) -> BoxliteResult<()> {

--- a/src/guest/src/service/ssh/session.rs
+++ b/src/guest/src/service/ssh/session.rs
@@ -1,0 +1,108 @@
+//! Login-style process setup for SSH shell, exec, and SFTP helpers.
+
+use crate::container::user_profile::{root_session_profile, RootSessionProfile};
+use boxlite_shared::errors::{BoxliteError, BoxliteResult};
+use std::ffi::OsString;
+use std::os::unix::process::CommandExt as _;
+use std::path::Path;
+use std::process::Command;
+
+pub(crate) const INTERNAL_SESSION_ARG: &str = "--boxlite-internal-ssh-session";
+
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) enum SessionAction {
+    Shell,
+    Exec(String),
+}
+
+pub(crate) fn parse_internal_args(args: &[String]) -> BoxliteResult<SessionAction> {
+    match args {
+        [mode] if mode == "shell" => Ok(SessionAction::Shell),
+        [mode, command] if mode == "exec" => Ok(SessionAction::Exec(command.clone())),
+        _ => Err(BoxliteError::Config(
+            "internal SSH session workload expects `shell` or `exec <command>`".into(),
+        )),
+    }
+}
+
+/// Run after libcontainer has applied the tenant's namespaces and credentials.
+pub(crate) fn run_internal(action: SessionAction) -> BoxliteResult<()> {
+    let profile = root_session_profile(Path::new("/"));
+    enter_root_home(&profile)?;
+
+    match action {
+        SessionAction::Shell => exec_login_shell(&profile),
+        SessionAction::Exec(command) => exec_command(&profile, &command),
+    }
+}
+
+/// Apply root's home before the SFTP protocol loop starts.
+pub(crate) fn prepare_sftp_home() -> BoxliteResult<()> {
+    enter_root_home(&root_session_profile(Path::new("/")))
+}
+
+fn enter_root_home(profile: &RootSessionProfile) -> BoxliteResult<()> {
+    std::env::set_current_dir(&profile.home_dir).or_else(|home_error| {
+        std::env::set_current_dir("/").map_err(|fallback_error| {
+            BoxliteError::Execution(format!(
+                "failed to enter SSH root home {} ({home_error}) and fallback / ({fallback_error})",
+                profile.home_dir
+            ))
+        })
+    })?;
+    let effective_home = std::env::current_dir().map_err(|error| {
+        BoxliteError::Execution(format!("failed to resolve SSH session home: {error}"))
+    })?;
+    std::env::set_var("HOME", effective_home);
+    Ok(())
+}
+
+fn exec_login_shell(profile: &RootSessionProfile) -> BoxliteResult<()> {
+    let shell_name = Path::new(&profile.login_shell)
+        .file_name()
+        .ok_or_else(|| BoxliteError::Execution("SSH login shell has no basename".into()))?;
+    let mut login_argv0 = OsString::from("-");
+    login_argv0.push(shell_name);
+    // OpenSSH marks a login shell by prefixing argv[0] with `-`. This is the
+    // portable login-shell convention and does not assume a passwd shell
+    // implements a particular `-l` option.
+    let error = Command::new(&profile.login_shell).arg0(login_argv0).exec();
+    Err(BoxliteError::Execution(format!(
+        "failed to exec SSH login shell {}: {error}",
+        profile.login_shell
+    )))
+}
+
+fn exec_command(profile: &RootSessionProfile, command: &str) -> BoxliteResult<()> {
+    // The SSH payload remains one argv value after `-c`; it is never split or
+    // interpolated by the guest bridge before the account shell receives it.
+    let error = Command::new(&profile.login_shell)
+        .arg("-c")
+        .arg(command)
+        .exec();
+    Err(BoxliteError::Execution(format!(
+        "failed to exec SSH command shell {}: {error}",
+        profile.login_shell
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_ambiguous_internal_session_arguments() {
+        assert!(parse_internal_args(&[]).is_err());
+        assert!(parse_internal_args(&["exec".into()]).is_err());
+        assert!(parse_internal_args(&["shell".into(), "extra".into()]).is_err());
+    }
+
+    #[test]
+    fn preserves_exec_command_as_one_argument() {
+        let command = "printf '%s' 'spaces ; $(still data)'";
+        assert_eq!(
+            parse_internal_args(&["exec".into(), command.into()]).unwrap(),
+            SessionAction::Exec(command.into())
+        );
+    }
+}

--- a/src/guest/src/service/ssh/sftp.rs
+++ b/src/guest/src/service/ssh/sftp.rs
@@ -1,0 +1,1451 @@
+//! Embedded SFTP v3 helper executed through the OCI container boundary.
+
+use crate::service::ssh::limits::{
+    MAX_SFTP_DIRECTORY_ENTRIES, MAX_SFTP_HANDLES, MAX_SFTP_READ_BYTES,
+};
+use boxlite_shared::errors::{BoxliteError, BoxliteResult};
+use russh_sftp::extensions::{
+    FsyncExtension, HardlinkExtension, LimitsExtension, Statvfs, StatvfsExtension, FSYNC, HARDLINK,
+    LIMITS, STATVFS,
+};
+use russh_sftp::protocol::{
+    Attrs, Data, ExtendedReply, File as SftpFile, FileAttributes, Handle, Name, OpenFlags, Packet,
+    Status, StatusCode, Version,
+};
+use russh_sftp::server::StatusReply;
+use std::collections::HashMap;
+use std::ffi::CString;
+use std::fs::{self, File, OpenOptions, ReadDir};
+use std::io::{ErrorKind, Read as _};
+use std::os::fd::AsRawFd;
+use std::os::unix::ffi::OsStrExt;
+use std::os::unix::fs::{FileExt, OpenOptionsExt, PermissionsExt};
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::sync::oneshot;
+
+pub(crate) const INTERNAL_SFTP_ARG: &str = "--boxlite-internal-sftp";
+const EXPAND_PATH: &str = "expand-path@openssh.com";
+const FSTATVFS: &str = "fstatvfs@openssh.com";
+const HOME_DIRECTORY: &str = "home-directory";
+const LSETSTAT: &str = "lsetstat@openssh.com";
+const POSIX_RENAME: &str = "posix-rename@openssh.com";
+const USERS_GROUPS_BY_ID: &str = "users-groups-by-id@openssh.com";
+const MAX_ACCOUNT_DATABASE_BYTES: u64 = 1024 * 1024;
+const MAX_ACCOUNT_NAME_BYTES: usize = 256;
+const MAX_ID_LOOKUPS: usize = 1024;
+
+#[derive(serde::Deserialize, serde::Serialize)]
+struct PosixRenameExtension {
+    oldpath: String,
+    newpath: String,
+}
+
+#[derive(serde::Deserialize, serde::Serialize)]
+struct LsetstatExtension {
+    path: String,
+    attrs: FileAttributes,
+}
+
+#[derive(serde::Deserialize, serde::Serialize)]
+struct UsersGroupsByIdExtension {
+    uids: Vec<u8>,
+    gids: Vec<u8>,
+}
+
+enum OpenHandle {
+    File(File),
+    Directory(ReadDir),
+}
+
+/// A filesystem server isolated by the same tenant namespaces, credentials,
+/// and capability set as container exec. Handles are opaque, connection-local,
+/// and bounded.
+struct SftpSession {
+    handles: HashMap<String, OpenHandle>,
+    next_handle: u64,
+}
+
+/// Makes the detached `russh-sftp` protocol task observable by its helper
+/// process so EOF or a pipe error terminates the execution cleanly.
+struct EofAwareStream<S> {
+    inner: S,
+    finished: Option<oneshot::Sender<()>>,
+}
+
+impl<S> EofAwareStream<S> {
+    fn new(inner: S) -> (Self, oneshot::Receiver<()>) {
+        let (finished_tx, finished_rx) = oneshot::channel();
+        (
+            Self {
+                inner,
+                finished: Some(finished_tx),
+            },
+            finished_rx,
+        )
+    }
+
+    fn finish(&mut self) {
+        if let Some(finished) = self.finished.take() {
+            let _ = finished.send(());
+        }
+    }
+}
+
+impl<S: AsyncRead + Unpin> AsyncRead for EofAwareStream<S> {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        context: &mut Context<'_>,
+        buffer: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        let filled_before = buffer.filled().len();
+        let result = Pin::new(&mut self.inner).poll_read(context, buffer);
+        let is_finished = match &result {
+            Poll::Ready(Err(_)) => true,
+            Poll::Ready(Ok(())) => buffer.filled().len() == filled_before,
+            Poll::Pending => false,
+        };
+        if is_finished {
+            self.finish();
+        }
+        result
+    }
+}
+
+impl<S: AsyncWrite + Unpin> AsyncWrite for EofAwareStream<S> {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        context: &mut Context<'_>,
+        buffer: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        let result = Pin::new(&mut self.inner).poll_write(context, buffer);
+        if matches!(&result, Poll::Ready(Err(_)))
+            || matches!(&result, Poll::Ready(Ok(0)) if !buffer.is_empty())
+        {
+            self.finish();
+        }
+        result
+    }
+
+    fn poll_flush(
+        mut self: Pin<&mut Self>,
+        context: &mut Context<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        let result = Pin::new(&mut self.inner).poll_flush(context);
+        if matches!(&result, Poll::Ready(Err(_))) {
+            self.finish();
+        }
+        result
+    }
+
+    fn poll_shutdown(
+        mut self: Pin<&mut Self>,
+        context: &mut Context<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        let result = Pin::new(&mut self.inner).poll_shutdown(context);
+        if matches!(&result, Poll::Ready(_)) {
+            self.finish();
+        }
+        result
+    }
+}
+
+impl SftpSession {
+    fn new() -> Self {
+        Self {
+            handles: HashMap::new(),
+            next_handle: 1,
+        }
+    }
+
+    fn insert_handle(&mut self, handle: OpenHandle) -> Result<String, StatusReply> {
+        if self.handles.len() >= MAX_SFTP_HANDLES {
+            return Err(StatusCode::Failure.with_message("too many open SFTP handles"));
+        }
+        let id = format!("{:016x}", self.next_handle);
+        self.next_handle = self.next_handle.wrapping_add(1);
+        self.handles.insert(id.clone(), handle);
+        Ok(id)
+    }
+
+    fn file(&self, handle: &str) -> Result<&File, StatusReply> {
+        match self.handles.get(handle) {
+            Some(OpenHandle::File(file)) => Ok(file),
+            Some(OpenHandle::Directory(_)) => {
+                Err(StatusCode::Failure.with_message("handle is a directory"))
+            }
+            None => Err(StatusCode::NoSuchFile.with_message("unknown SFTP handle")),
+        }
+    }
+
+    fn directory(&mut self, handle: &str) -> Result<&mut ReadDir, StatusReply> {
+        match self.handles.get_mut(handle) {
+            Some(OpenHandle::Directory(directory)) => Ok(directory),
+            Some(OpenHandle::File(_)) => {
+                Err(StatusCode::Failure.with_message("handle is not a directory"))
+            }
+            None => Err(StatusCode::NoSuchFile.with_message("unknown SFTP handle")),
+        }
+    }
+}
+
+impl russh_sftp::server::Handler for SftpSession {
+    type Error = StatusReply;
+
+    fn unimplemented(&self) -> Self::Error {
+        StatusCode::OpUnsupported.into()
+    }
+
+    async fn init(
+        &mut self,
+        _version: u32,
+        _extensions: HashMap<String, String>,
+    ) -> Result<Version, Self::Error> {
+        let mut version = Version::new();
+        version
+            .extensions
+            .insert(LIMITS.to_string(), "1".to_string());
+        version
+            .extensions
+            .insert(HARDLINK.to_string(), "1".to_string());
+        version
+            .extensions
+            .insert(FSYNC.to_string(), "1".to_string());
+        version
+            .extensions
+            .insert(STATVFS.to_string(), "2".to_string());
+        version
+            .extensions
+            .insert(FSTATVFS.to_string(), "2".to_string());
+        version
+            .extensions
+            .insert(LSETSTAT.to_string(), "1".to_string());
+        version
+            .extensions
+            .insert(EXPAND_PATH.to_string(), "1".to_string());
+        version
+            .extensions
+            .insert(HOME_DIRECTORY.to_string(), "1".to_string());
+        version
+            .extensions
+            .insert(USERS_GROUPS_BY_ID.to_string(), "1".to_string());
+        version
+            .extensions
+            .insert(POSIX_RENAME.to_string(), "1".to_string());
+        Ok(version)
+    }
+
+    async fn open(
+        &mut self,
+        id: u32,
+        filename: String,
+        pflags: OpenFlags,
+        attrs: FileAttributes,
+    ) -> Result<Handle, Self::Error> {
+        let mut options: OpenOptions = pflags.into();
+        options.mode(attrs.permissions.unwrap_or(0o666) & 0o7777);
+        let file = options.open(&filename).map_err(io_status)?;
+        let handle = self.insert_handle(OpenHandle::File(file))?;
+        Ok(Handle { id, handle })
+    }
+
+    async fn close(&mut self, id: u32, handle: String) -> Result<Status, Self::Error> {
+        self.handles
+            .remove(&handle)
+            .ok_or_else(|| StatusCode::NoSuchFile.with_message("unknown SFTP handle"))?;
+        Ok(ok_status(id))
+    }
+
+    async fn read(
+        &mut self,
+        id: u32,
+        handle: String,
+        offset: u64,
+        len: u32,
+    ) -> Result<Data, Self::Error> {
+        let len = usize::try_from(len)
+            .unwrap_or(usize::MAX)
+            .min(MAX_SFTP_READ_BYTES);
+        let mut data = vec![0; len];
+        let read = self
+            .file(&handle)?
+            .read_at(&mut data, offset)
+            .map_err(io_status)?;
+        if read == 0 {
+            return Err(StatusCode::Eof.into());
+        }
+        data.truncate(read);
+        Ok(Data { id, data })
+    }
+
+    async fn write(
+        &mut self,
+        id: u32,
+        handle: String,
+        offset: u64,
+        data: Vec<u8>,
+    ) -> Result<Status, Self::Error> {
+        if data.len() > MAX_SFTP_READ_BYTES {
+            return Err(StatusCode::Failure.with_message("SFTP write exceeds the size limit"));
+        }
+        offset
+            .checked_add(
+                u64::try_from(data.len()).map_err(|_| {
+                    StatusCode::Failure.with_message("SFTP write length exceeds u64")
+                })?,
+            )
+            .ok_or_else(|| StatusCode::Failure.with_message("SFTP write offset overflow"))?;
+        let file = self.file(&handle)?;
+        let mut written = 0;
+        while written < data.len() {
+            let write_offset = offset
+                .checked_add(u64::try_from(written).map_err(|_| {
+                    StatusCode::Failure.with_message("SFTP write length exceeds u64")
+                })?)
+                .ok_or_else(|| StatusCode::Failure.with_message("SFTP write offset overflow"))?;
+            let count = file
+                .write_at(&data[written..], write_offset)
+                .map_err(io_status)?;
+            if count == 0 {
+                return Err(StatusCode::Failure.with_message("short SFTP write"));
+            }
+            written += count;
+        }
+        Ok(ok_status(id))
+    }
+
+    async fn lstat(&mut self, id: u32, path: String) -> Result<Attrs, Self::Error> {
+        attrs_for(id, fs::symlink_metadata(path).map_err(io_status)?)
+    }
+
+    async fn stat(&mut self, id: u32, path: String) -> Result<Attrs, Self::Error> {
+        attrs_for(id, fs::metadata(path).map_err(io_status)?)
+    }
+
+    async fn fstat(&mut self, id: u32, handle: String) -> Result<Attrs, Self::Error> {
+        attrs_for(id, self.file(&handle)?.metadata().map_err(io_status)?)
+    }
+
+    async fn setstat(
+        &mut self,
+        id: u32,
+        path: String,
+        attrs: FileAttributes,
+    ) -> Result<Status, Self::Error> {
+        apply_path_attributes(Path::new(&path), attrs)?;
+        Ok(ok_status(id))
+    }
+
+    async fn fsetstat(
+        &mut self,
+        id: u32,
+        handle: String,
+        attrs: FileAttributes,
+    ) -> Result<Status, Self::Error> {
+        apply_file_attributes(self.file(&handle)?, attrs)?;
+        Ok(ok_status(id))
+    }
+
+    async fn opendir(&mut self, id: u32, path: String) -> Result<Handle, Self::Error> {
+        let directory = fs::read_dir(path).map_err(io_status)?;
+        let handle = self.insert_handle(OpenHandle::Directory(directory))?;
+        Ok(Handle { id, handle })
+    }
+
+    async fn readdir(&mut self, id: u32, handle: String) -> Result<Name, Self::Error> {
+        let directory = self.directory(&handle)?;
+        let mut files = Vec::new();
+        for entry in directory.take(MAX_SFTP_DIRECTORY_ENTRIES) {
+            let entry = entry.map_err(io_status)?;
+            let metadata = fs::symlink_metadata(entry.path()).map_err(io_status)?;
+            files.push(SftpFile::new(
+                entry.file_name().to_string_lossy(),
+                FileAttributes::from(&metadata),
+            ));
+        }
+        if files.is_empty() {
+            return Err(StatusCode::Eof.into());
+        }
+        Ok(Name { id, files })
+    }
+
+    async fn remove(&mut self, id: u32, filename: String) -> Result<Status, Self::Error> {
+        fs::remove_file(filename).map_err(io_status)?;
+        Ok(ok_status(id))
+    }
+
+    async fn mkdir(
+        &mut self,
+        id: u32,
+        path: String,
+        attrs: FileAttributes,
+    ) -> Result<Status, Self::Error> {
+        fs::create_dir(&path).map_err(io_status)?;
+        if let Some(mode) = attrs.permissions {
+            fs::set_permissions(&path, fs::Permissions::from_mode(mode & 0o7777))
+                .map_err(io_status)?;
+        }
+        Ok(ok_status(id))
+    }
+
+    async fn rmdir(&mut self, id: u32, path: String) -> Result<Status, Self::Error> {
+        fs::remove_dir(path).map_err(io_status)?;
+        Ok(ok_status(id))
+    }
+
+    async fn realpath(&mut self, id: u32, path: String) -> Result<Name, Self::Error> {
+        let path = fs::canonicalize(path).map_err(io_status)?;
+        Ok(Name {
+            id,
+            files: vec![SftpFile::dummy(path.to_string_lossy())],
+        })
+    }
+
+    async fn rename(
+        &mut self,
+        id: u32,
+        oldpath: String,
+        newpath: String,
+    ) -> Result<Status, Self::Error> {
+        rename_without_replace(Path::new(&oldpath), Path::new(&newpath))?;
+        Ok(ok_status(id))
+    }
+
+    async fn readlink(&mut self, id: u32, path: String) -> Result<Name, Self::Error> {
+        let target = fs::read_link(path).map_err(io_status)?;
+        Ok(Name {
+            id,
+            files: vec![SftpFile::dummy(target.to_string_lossy())],
+        })
+    }
+
+    async fn symlink(
+        &mut self,
+        id: u32,
+        linkpath: String,
+        targetpath: String,
+    ) -> Result<Status, Self::Error> {
+        // OpenSSH sends target then link name, opposite the field names in
+        // russh-sftp's v3 decoder. Treat the first value as the target.
+        std::os::unix::fs::symlink(linkpath, targetpath).map_err(io_status)?;
+        Ok(ok_status(id))
+    }
+
+    async fn extended(
+        &mut self,
+        id: u32,
+        request: String,
+        data: Vec<u8>,
+    ) -> Result<Packet, Self::Error> {
+        use bytes::Bytes;
+
+        match request.as_str() {
+            LIMITS => extended_reply(
+                id,
+                &LimitsExtension {
+                    max_packet_len: MAX_SFTP_READ_BYTES as u64 + 1024,
+                    max_read_len: MAX_SFTP_READ_BYTES as u64,
+                    max_write_len: MAX_SFTP_READ_BYTES as u64,
+                    max_open_handles: MAX_SFTP_HANDLES as u64,
+                },
+            ),
+            HARDLINK => {
+                let mut data = Bytes::from(data);
+                let request: HardlinkExtension =
+                    russh_sftp::de::from_bytes(&mut data).map_err(protocol_status)?;
+                fs::hard_link(request.oldpath, request.newpath).map_err(io_status)?;
+                Ok(ok_status(id).into())
+            }
+            FSYNC => {
+                let mut data = Bytes::from(data);
+                let request: FsyncExtension =
+                    russh_sftp::de::from_bytes(&mut data).map_err(protocol_status)?;
+                self.file(&request.handle)?.sync_all().map_err(io_status)?;
+                Ok(ok_status(id).into())
+            }
+            STATVFS => {
+                let mut data = Bytes::from(data);
+                let request: StatvfsExtension =
+                    russh_sftp::de::from_bytes(&mut data).map_err(protocol_status)?;
+                extended_reply(id, &statvfs(Path::new(&request.path))?)
+            }
+            FSTATVFS => {
+                let request: FsyncExtension = decode_extension(data)?;
+                extended_reply(id, &fstatvfs(self.file(&request.handle)?)?)
+            }
+            LSETSTAT => {
+                let request: LsetstatExtension = decode_extension(data)?;
+                apply_symlink_attributes(Path::new(&request.path), request.attrs)?;
+                Ok(ok_status(id).into())
+            }
+            EXPAND_PATH => {
+                let path: String = decode_extension(data)?;
+                Ok(name_packet(id, expand_path(&path)?)?.into())
+            }
+            HOME_DIRECTORY => {
+                let username: String = decode_extension(data)?;
+                let username = (!username.is_empty()).then_some(username.as_str());
+                let home = fs::canonicalize(passwd_home(username)?).map_err(io_status)?;
+                Ok(name_packet(id, home)?.into())
+            }
+            USERS_GROUPS_BY_ID => {
+                let request: UsersGroupsByIdExtension = decode_extension(data)?;
+                let uids = unpack_ids(&request.uids)?;
+                let gids = unpack_ids(&request.gids)?;
+                extended_reply(
+                    id,
+                    &UsersGroupsByIdExtension {
+                        uids: pack_names(account_names(Path::new("/etc/passwd"), &uids, 2)?)?,
+                        gids: pack_names(account_names(Path::new("/etc/group"), &gids, 2)?)?,
+                    },
+                )
+            }
+            POSIX_RENAME => {
+                let mut data = Bytes::from(data);
+                let request: PosixRenameExtension =
+                    russh_sftp::de::from_bytes(&mut data).map_err(protocol_status)?;
+                fs::rename(request.oldpath, request.newpath).map_err(io_status)?;
+                Ok(ok_status(id).into())
+            }
+            _ => Err(StatusCode::OpUnsupported.into()),
+        }
+    }
+}
+
+pub(crate) fn run_internal() -> BoxliteResult<()> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| BoxliteError::Internal(format!("SFTP runtime: {error}")))?;
+    runtime.block_on(async {
+        let stream = tokio::io::join(tokio::io::stdin(), tokio::io::stdout());
+        let (stream, finished) = EofAwareStream::new(stream);
+        russh_sftp::server::run_with_config(
+            stream,
+            SftpSession::new(),
+            russh_sftp::server::Config {
+                // Includes request metadata in addition to the advertised
+                // read/write payload limit.
+                max_client_packet_len: (MAX_SFTP_READ_BYTES + 4096) as u32,
+            },
+        )
+        .await;
+        // `run_with_config` detaches its protocol loop. Wait for that loop's
+        // stream to observe EOF/error before exiting the tenant process.
+        let _ = finished.await;
+    });
+    Ok(())
+}
+
+fn ok_status(id: u32) -> Status {
+    Status {
+        id,
+        status_code: StatusCode::Ok,
+        error_message: "OK".to_string(),
+        language_tag: "en-US".to_string(),
+    }
+}
+
+fn attrs_for(id: u32, metadata: fs::Metadata) -> Result<Attrs, StatusReply> {
+    Ok(Attrs {
+        id,
+        attrs: FileAttributes::from(&metadata),
+    })
+}
+
+fn io_status(error: std::io::Error) -> StatusReply {
+    let code = match error.kind() {
+        std::io::ErrorKind::NotFound => StatusCode::NoSuchFile,
+        std::io::ErrorKind::PermissionDenied => StatusCode::PermissionDenied,
+        std::io::ErrorKind::UnexpectedEof => StatusCode::Eof,
+        _ => StatusCode::Failure,
+    };
+    code.with_message(error.to_string())
+}
+
+fn protocol_status(error: impl std::fmt::Display) -> StatusReply {
+    StatusCode::BadMessage.with_message(error.to_string())
+}
+
+fn rename_without_replace(oldpath: &Path, newpath: &Path) -> Result<(), StatusReply> {
+    let oldpath = c_path(oldpath)?;
+    let newpath = c_path(newpath)?;
+    // SFTP v3 requires SSH_FXP_RENAME to fail when newpath exists. Linux's
+    // renameat2 gives that rule atomic semantics; a metadata pre-check would
+    // allow another process to race us and have its file overwritten.
+    let result = unsafe {
+        nix::libc::syscall(
+            nix::libc::SYS_renameat2,
+            nix::libc::AT_FDCWD,
+            oldpath.as_ptr(),
+            nix::libc::AT_FDCWD,
+            newpath.as_ptr(),
+            nix::libc::RENAME_NOREPLACE,
+        )
+    };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(io_status(std::io::Error::last_os_error()))
+    }
+}
+
+fn extended_reply<T: serde::Serialize>(id: u32, value: &T) -> Result<Packet, StatusReply> {
+    let data = russh_sftp::ser::to_bytes(value)
+        .map_err(protocol_status)?
+        .to_vec();
+    Ok(ExtendedReply { id, data }.into())
+}
+
+fn decode_extension<T: serde::de::DeserializeOwned>(data: Vec<u8>) -> Result<T, StatusReply> {
+    let mut data = bytes::Bytes::from(data);
+    let value = russh_sftp::de::from_bytes(&mut data).map_err(protocol_status)?;
+    if !data.is_empty() {
+        return Err(StatusCode::BadMessage.with_message("trailing extension data"));
+    }
+    Ok(value)
+}
+
+fn name_packet(id: u32, path: PathBuf) -> Result<Name, StatusReply> {
+    let path = path
+        .into_os_string()
+        .into_string()
+        .map_err(|_| StatusCode::Failure.with_message("path is not valid UTF-8"))?;
+    Ok(Name {
+        id,
+        files: vec![SftpFile::dummy(path)],
+    })
+}
+
+fn apply_path_attributes(path: &Path, attrs: FileAttributes) -> Result<(), StatusReply> {
+    if let Some(size) = attrs.size {
+        OpenOptions::new()
+            .write(true)
+            .open(path)
+            .and_then(|file| file.set_len(size))
+            .map_err(io_status)?;
+    }
+    if attrs.uid.is_some() || attrs.gid.is_some() {
+        let path = c_path(path)?;
+        let result = unsafe {
+            nix::libc::chown(
+                path.as_ptr(),
+                attrs.uid.unwrap_or(u32::MAX),
+                attrs.gid.unwrap_or(u32::MAX),
+            )
+        };
+        cvt(result, "chown")?;
+    }
+    if let Some(mode) = attrs.permissions {
+        fs::set_permissions(path, fs::Permissions::from_mode(mode & 0o7777)).map_err(io_status)?;
+    }
+    if attrs.atime.is_some() || attrs.mtime.is_some() {
+        set_path_times(path, attrs.atime, attrs.mtime)?;
+    }
+    Ok(())
+}
+
+fn apply_file_attributes(file: &File, attrs: FileAttributes) -> Result<(), StatusReply> {
+    if let Some(size) = attrs.size {
+        file.set_len(size).map_err(io_status)?;
+    }
+    if attrs.uid.is_some() || attrs.gid.is_some() {
+        let result = unsafe {
+            nix::libc::fchown(
+                file.as_raw_fd(),
+                attrs.uid.unwrap_or(u32::MAX),
+                attrs.gid.unwrap_or(u32::MAX),
+            )
+        };
+        cvt(result, "fchown")?;
+    }
+    if let Some(mode) = attrs.permissions {
+        let result = unsafe { nix::libc::fchmod(file.as_raw_fd(), mode & 0o7777) };
+        cvt(result, "fchmod")?;
+    }
+    if attrs.atime.is_some() || attrs.mtime.is_some() {
+        let times = timespecs(attrs.atime, attrs.mtime);
+        let result = unsafe { nix::libc::futimens(file.as_raw_fd(), times.as_ptr()) };
+        cvt(result, "futimens")?;
+    }
+    Ok(())
+}
+
+fn set_path_times(path: &Path, atime: Option<u32>, mtime: Option<u32>) -> Result<(), StatusReply> {
+    let path = c_path(path)?;
+    let times = timespecs(atime, mtime);
+    let result =
+        unsafe { nix::libc::utimensat(nix::libc::AT_FDCWD, path.as_ptr(), times.as_ptr(), 0) };
+    cvt(result, "utimensat")
+}
+
+fn timespecs(atime: Option<u32>, mtime: Option<u32>) -> [nix::libc::timespec; 2] {
+    [
+        nix::libc::timespec {
+            tv_sec: atime.map_or(0, i64::from),
+            tv_nsec: if atime.is_some() {
+                0
+            } else {
+                nix::libc::UTIME_OMIT
+            },
+        },
+        nix::libc::timespec {
+            tv_sec: mtime.map_or(0, i64::from),
+            tv_nsec: if mtime.is_some() {
+                0
+            } else {
+                nix::libc::UTIME_OMIT
+            },
+        },
+    ]
+}
+
+fn statvfs(path: &Path) -> Result<Statvfs, StatusReply> {
+    let path = c_path(path)?;
+    let mut value = std::mem::MaybeUninit::<nix::libc::statvfs>::zeroed();
+    let result = unsafe { nix::libc::statvfs(path.as_ptr(), value.as_mut_ptr()) };
+    cvt(result, "statvfs")?;
+    Ok(portable_statvfs(unsafe { value.assume_init() }))
+}
+
+fn fstatvfs(file: &File) -> Result<Statvfs, StatusReply> {
+    let mut value = std::mem::MaybeUninit::<nix::libc::statvfs>::zeroed();
+    let result = unsafe { nix::libc::fstatvfs(file.as_raw_fd(), value.as_mut_ptr()) };
+    cvt(result, "fstatvfs")?;
+    Ok(portable_statvfs(unsafe { value.assume_init() }))
+}
+
+fn portable_statvfs(value: nix::libc::statvfs) -> Statvfs {
+    Statvfs {
+        block_size: value.f_bsize,
+        fragment_size: value.f_frsize,
+        blocks: value.f_blocks,
+        blocks_free: value.f_bfree,
+        blocks_avail: value.f_bavail,
+        inodes: value.f_files,
+        inodes_free: value.f_ffree,
+        inodes_avail: value.f_favail,
+        fs_id: value.f_fsid,
+        // OpenSSH's wire format defines only read-only and no-setuid.
+        flags: value.f_flag & 0x3,
+        name_max: value.f_namemax,
+    }
+}
+
+fn expand_path(path: &str) -> Result<PathBuf, StatusReply> {
+    let expanded = if path.is_empty() {
+        PathBuf::from(".")
+    } else if let Some(path) = path.strip_prefix('~') {
+        let (username, suffix) = path.split_once('/').unwrap_or((path, ""));
+        let username = (!username.is_empty()).then_some(username);
+        let mut expanded = passwd_home(username)?;
+        if !suffix.is_empty() {
+            expanded.push(suffix);
+        }
+        expanded
+    } else {
+        PathBuf::from(path)
+    };
+    fs::canonicalize(expanded).map_err(io_status)
+}
+
+fn passwd_home(username: Option<&str>) -> Result<PathBuf, StatusReply> {
+    if username.is_some_and(|username| username.len() > MAX_ACCOUNT_NAME_BYTES) {
+        return Err(StatusCode::BadMessage.with_message("account name is too long"));
+    }
+    let passwd = read_account_database(Path::new("/etc/passwd"))?
+        .ok_or_else(|| StatusCode::Failure.with_message("passwd database is unavailable"))?;
+    let effective_uid = unsafe { nix::libc::geteuid() };
+    for line in passwd.lines() {
+        let fields: Vec<_> = line.split(':').collect();
+        if fields.len() < 7 {
+            continue;
+        }
+        let is_match = match username {
+            Some(username) => fields[0] == username,
+            None => fields[2].parse::<u32>().ok() == Some(effective_uid),
+        };
+        if is_match {
+            let home = PathBuf::from(fields[5]);
+            if !home.is_absolute() {
+                return Err(
+                    StatusCode::Failure.with_message("passwd home directory is not absolute")
+                );
+            }
+            return Ok(home);
+        }
+    }
+    Err(StatusCode::Failure.with_message("account has no passwd entry"))
+}
+
+fn unpack_ids(data: &[u8]) -> Result<Vec<u32>, StatusReply> {
+    if !data.len().is_multiple_of(std::mem::size_of::<u32>()) {
+        return Err(StatusCode::BadMessage.with_message("ID list is not a sequence of uint32"));
+    }
+    let count = data.len() / std::mem::size_of::<u32>();
+    if count > MAX_ID_LOOKUPS {
+        return Err(StatusCode::Failure.with_message("too many account ID lookups"));
+    }
+    Ok(data
+        .chunks_exact(4)
+        .map(|id| u32::from_be_bytes(id.try_into().expect("four-byte chunk")))
+        .collect())
+}
+
+fn account_names(
+    database_path: &Path,
+    ids: &[u32],
+    id_field: usize,
+) -> Result<Vec<String>, StatusReply> {
+    let mut names: HashMap<u32, Option<String>> =
+        ids.iter().copied().map(|id| (id, None)).collect();
+    if let Some(database) = read_account_database(database_path)? {
+        for line in database.lines() {
+            let fields: Vec<_> = line.split(':').collect();
+            let Some(id) = fields.get(id_field).and_then(|id| id.parse::<u32>().ok()) else {
+                continue;
+            };
+            let Some(name) = fields.first() else {
+                continue;
+            };
+            if name.len() > MAX_ACCOUNT_NAME_BYTES {
+                return Err(StatusCode::Failure.with_message("account name is too long"));
+            }
+            if let Some(slot) = names.get_mut(&id) {
+                if slot.is_none() {
+                    *slot = Some((*name).to_string());
+                }
+            }
+        }
+    }
+    Ok(ids
+        .iter()
+        .map(|id| names.get(id).cloned().flatten().unwrap_or_default())
+        .collect())
+}
+
+fn pack_names(names: Vec<String>) -> Result<Vec<u8>, StatusReply> {
+    let mut packed = Vec::new();
+    for name in names {
+        let length = u32::try_from(name.len())
+            .map_err(|_| StatusCode::Failure.with_message("account name is too long"))?;
+        let next_len = packed
+            .len()
+            .checked_add(4)
+            .and_then(|length| length.checked_add(name.len()))
+            .ok_or_else(|| StatusCode::Failure.with_message("account name reply is too large"))?;
+        if next_len > MAX_SFTP_READ_BYTES {
+            return Err(StatusCode::Failure.with_message("account name reply is too large"));
+        }
+        packed.extend_from_slice(&length.to_be_bytes());
+        packed.extend_from_slice(name.as_bytes());
+    }
+    Ok(packed)
+}
+
+fn read_account_database(path: &Path) -> Result<Option<String>, StatusReply> {
+    let mut file = match File::open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(io_status(error)),
+    };
+    let mut bytes = Vec::new();
+    file.by_ref()
+        .take(MAX_ACCOUNT_DATABASE_BYTES + 1)
+        .read_to_end(&mut bytes)
+        .map_err(io_status)?;
+    if bytes.len() as u64 > MAX_ACCOUNT_DATABASE_BYTES {
+        return Err(StatusCode::Failure.with_message("account database is too large"));
+    }
+    String::from_utf8(bytes)
+        .map(Some)
+        .map_err(|_| StatusCode::Failure.with_message("account database is not valid UTF-8"))
+}
+
+fn apply_symlink_attributes(path: &Path, attrs: FileAttributes) -> Result<(), StatusReply> {
+    if attrs.size.is_some() {
+        return Err(StatusCode::BadMessage.with_message("cannot set the size of a symlink"));
+    }
+    let path = c_path(path)?;
+    if let Some(mode) = attrs.permissions {
+        let result = unsafe {
+            nix::libc::fchmodat(
+                nix::libc::AT_FDCWD,
+                path.as_ptr(),
+                mode & 0o7777,
+                nix::libc::AT_SYMLINK_NOFOLLOW,
+            )
+        };
+        cvt(result, "fchmodat")?;
+    }
+    if attrs.atime.is_some() || attrs.mtime.is_some() {
+        let times = timespecs(attrs.atime, attrs.mtime);
+        let result = unsafe {
+            nix::libc::utimensat(
+                nix::libc::AT_FDCWD,
+                path.as_ptr(),
+                times.as_ptr(),
+                nix::libc::AT_SYMLINK_NOFOLLOW,
+            )
+        };
+        cvt(result, "utimensat")?;
+    }
+    if attrs.uid.is_some() || attrs.gid.is_some() {
+        let result = unsafe {
+            nix::libc::fchownat(
+                nix::libc::AT_FDCWD,
+                path.as_ptr(),
+                attrs.uid.unwrap_or(u32::MAX),
+                attrs.gid.unwrap_or(u32::MAX),
+                nix::libc::AT_SYMLINK_NOFOLLOW,
+            )
+        };
+        cvt(result, "fchownat")?;
+    }
+    Ok(())
+}
+
+fn c_path(path: &Path) -> Result<CString, StatusReply> {
+    CString::new(path.as_os_str().as_bytes())
+        .map_err(|_| StatusCode::BadMessage.with_message("path contains NUL"))
+}
+
+fn cvt(result: i32, operation: &str) -> Result<(), StatusReply> {
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(io_status(std::io::Error::last_os_error())
+            .with_message(format!("{operation}: {}", std::io::Error::last_os_error())))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use russh_sftp::server::Handler as _;
+
+    #[derive(serde::Deserialize, serde::Serialize)]
+    struct TestUsersGroupsById {
+        uids: Vec<u8>,
+        gids: Vec<u8>,
+    }
+
+    fn packed_ids(ids: &[u32]) -> Vec<u8> {
+        ids.iter().flat_map(|id| id.to_be_bytes()).collect()
+    }
+
+    fn unpack_names(mut bytes: &[u8]) -> Vec<String> {
+        let mut names = Vec::new();
+        while !bytes.is_empty() {
+            let (length, rest) = bytes.split_at(4);
+            let length = u32::from_be_bytes(length.try_into().unwrap()) as usize;
+            let (name, rest) = rest.split_at(length);
+            names.push(String::from_utf8(name.to_vec()).unwrap());
+            bytes = rest;
+        }
+        names
+    }
+
+    fn current_passwd_identity() -> (String, PathBuf) {
+        let effective_uid = unsafe { nix::libc::geteuid() };
+        fs::read_to_string("/etc/passwd")
+            .unwrap()
+            .lines()
+            .find_map(|line| {
+                let fields: Vec<_> = line.split(':').collect();
+                (fields.len() >= 7 && fields[2].parse::<u32>().ok() == Some(effective_uid))
+                    .then(|| (fields[0].to_string(), PathBuf::from(fields[5])))
+            })
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn sftp_file_handles_support_offset_reads_and_writes() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("file");
+        let mut session = SftpSession::new();
+        let handle = session
+            .open(
+                1,
+                path.to_string_lossy().into_owned(),
+                OpenFlags::WRITE | OpenFlags::CREATE,
+                FileAttributes::empty(),
+            )
+            .await
+            .unwrap()
+            .handle;
+        session
+            .write(2, handle.clone(), 3, b"box".to_vec())
+            .await
+            .unwrap();
+        session.close(3, handle).await.unwrap();
+
+        let handle = session
+            .open(
+                4,
+                path.to_string_lossy().into_owned(),
+                OpenFlags::READ,
+                FileAttributes::empty(),
+            )
+            .await
+            .unwrap()
+            .handle;
+        let data = session.read(5, handle, 3, 3).await.unwrap();
+        assert_eq!(data.data, b"box");
+    }
+
+    #[tokio::test]
+    async fn sftp_write_rejects_an_offset_range_that_overflows_u64() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("file");
+        let mut session = SftpSession::new();
+        let handle = session
+            .open(
+                1,
+                path.to_string_lossy().into_owned(),
+                OpenFlags::WRITE | OpenFlags::CREATE,
+                FileAttributes::empty(),
+            )
+            .await
+            .unwrap()
+            .handle;
+
+        let error = session
+            .write(2, handle, u64::MAX, vec![1, 2])
+            .await
+            .unwrap_err();
+
+        assert_eq!(
+            error.error_message.as_deref(),
+            Some("SFTP write offset overflow")
+        );
+        assert!(fs::read(path).unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn sftp_v3_rename_does_not_replace_an_existing_destination() {
+        let temp = tempfile::tempdir().unwrap();
+        let oldpath = temp.path().join("old");
+        let newpath = temp.path().join("new");
+        fs::write(&oldpath, b"old").unwrap();
+        fs::write(&newpath, b"new").unwrap();
+        let mut session = SftpSession::new();
+
+        let result = session
+            .rename(
+                1,
+                oldpath.to_string_lossy().into_owned(),
+                newpath.to_string_lossy().into_owned(),
+            )
+            .await;
+
+        assert!(result.is_err());
+        assert_eq!(fs::read(oldpath).unwrap(), b"old");
+        assert_eq!(fs::read(newpath).unwrap(), b"new");
+    }
+
+    #[tokio::test]
+    async fn openssh_posix_rename_is_advertised_and_replaces_the_destination() {
+        let temp = tempfile::tempdir().unwrap();
+        let oldpath = temp.path().join("old");
+        let newpath = temp.path().join("new");
+        fs::write(&oldpath, b"replacement").unwrap();
+        fs::write(&newpath, b"original").unwrap();
+        let mut session = SftpSession::new();
+
+        let version = session.init(3, HashMap::new()).await.unwrap();
+        assert_eq!(
+            version.extensions.get(POSIX_RENAME).map(String::as_str),
+            Some("1")
+        );
+
+        let request = PosixRenameExtension {
+            oldpath: oldpath.to_string_lossy().into_owned(),
+            newpath: newpath.to_string_lossy().into_owned(),
+        };
+        let packet = session
+            .extended(
+                1,
+                POSIX_RENAME.to_string(),
+                russh_sftp::ser::to_bytes(&request).unwrap().to_vec(),
+            )
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            packet,
+            Packet::Status(Status {
+                status_code: StatusCode::Ok,
+                ..
+            })
+        ));
+        assert!(!oldpath.exists());
+        assert_eq!(fs::read(newpath).unwrap(), b"replacement");
+    }
+
+    #[tokio::test]
+    async fn openssh_fstatvfs_is_advertised_and_uses_an_open_file_handle() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("file");
+        fs::write(&path, b"boxlite").unwrap();
+        let mut session = SftpSession::new();
+
+        let version = session.init(3, HashMap::new()).await.unwrap();
+        assert_eq!(
+            version
+                .extensions
+                .get("fstatvfs@openssh.com")
+                .map(String::as_str),
+            Some("2")
+        );
+
+        let handle = session
+            .open(
+                1,
+                path.to_string_lossy().into_owned(),
+                OpenFlags::READ,
+                FileAttributes::empty(),
+            )
+            .await
+            .unwrap()
+            .handle;
+        let packet = session
+            .extended(
+                2,
+                "fstatvfs@openssh.com".to_string(),
+                russh_sftp::ser::to_bytes(&handle).unwrap().to_vec(),
+            )
+            .await
+            .unwrap();
+        let Packet::ExtendedReply(reply) = packet else {
+            panic!("fstatvfs returned the wrong SFTP packet type");
+        };
+        let value: Statvfs = russh_sftp::de::from_bytes(&mut reply.data.into()).unwrap();
+        assert!(value.block_size > 0);
+        assert!(value.name_max > 0);
+    }
+
+    #[tokio::test]
+    async fn openssh_statvfs_exposes_only_portable_flag_bits() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut session = SftpSession::new();
+        let request = StatvfsExtension {
+            path: temp.path().to_string_lossy().into_owned(),
+        };
+
+        let packet = session
+            .extended(
+                1,
+                STATVFS.to_string(),
+                russh_sftp::ser::to_bytes(&request).unwrap().to_vec(),
+            )
+            .await
+            .unwrap();
+        let Packet::ExtendedReply(reply) = packet else {
+            panic!("statvfs returned the wrong SFTP packet type");
+        };
+        let value: Statvfs = russh_sftp::de::from_bytes(&mut reply.data.into()).unwrap();
+
+        assert_eq!(value.flags & !0x3, 0);
+    }
+
+    #[tokio::test]
+    async fn openssh_expand_path_is_advertised_and_returns_a_canonical_name() {
+        let temp = tempfile::tempdir().unwrap();
+        let directory = temp.path().join("directory");
+        fs::create_dir(&directory).unwrap();
+        let requested = directory.join("..").join("directory");
+        let mut session = SftpSession::new();
+
+        let version = session.init(3, HashMap::new()).await.unwrap();
+        assert_eq!(
+            version
+                .extensions
+                .get("expand-path@openssh.com")
+                .map(String::as_str),
+            Some("1")
+        );
+
+        let packet = session
+            .extended(
+                1,
+                "expand-path@openssh.com".to_string(),
+                russh_sftp::ser::to_bytes(&requested.to_string_lossy().into_owned())
+                    .unwrap()
+                    .to_vec(),
+            )
+            .await
+            .unwrap();
+        let Packet::Name(name) = packet else {
+            panic!("expand-path returned the wrong SFTP packet type");
+        };
+        assert_eq!(name.files.len(), 1);
+        assert_eq!(
+            Path::new(&name.files[0].filename),
+            fs::canonicalize(directory).unwrap()
+        );
+
+        let (username, home) = current_passwd_identity();
+        for requested in [
+            "~".to_string(),
+            "~/./".to_string(),
+            format!("~{username}"),
+            format!("~{username}/."),
+        ] {
+            let packet = session
+                .extended(
+                    2,
+                    EXPAND_PATH.to_string(),
+                    russh_sftp::ser::to_bytes(&requested).unwrap().to_vec(),
+                )
+                .await
+                .unwrap();
+            let Packet::Name(name) = packet else {
+                panic!("tilde expansion returned the wrong SFTP packet type");
+            };
+            assert_eq!(
+                Path::new(&name.files[0].filename),
+                fs::canonicalize(&home).unwrap()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn home_directory_is_advertised_and_resolves_the_current_user() {
+        let mut session = SftpSession::new();
+        let (username, expected_home) = current_passwd_identity();
+
+        let version = session.init(3, HashMap::new()).await.unwrap();
+        assert_eq!(
+            version.extensions.get("home-directory").map(String::as_str),
+            Some("1")
+        );
+
+        for requested in [String::new(), username] {
+            let packet = session
+                .extended(
+                    1,
+                    HOME_DIRECTORY.to_string(),
+                    russh_sftp::ser::to_bytes(&requested).unwrap().to_vec(),
+                )
+                .await
+                .unwrap();
+            let Packet::Name(name) = packet else {
+                panic!("home-directory returned the wrong SFTP packet type");
+            };
+            assert_eq!(name.files.len(), 1);
+            assert_eq!(
+                Path::new(&name.files[0].filename),
+                fs::canonicalize(&expected_home).unwrap()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn users_groups_by_id_is_advertised_and_preserves_request_order() {
+        let mut session = SftpSession::new();
+        let version = session.init(3, HashMap::new()).await.unwrap();
+        assert_eq!(
+            version
+                .extensions
+                .get("users-groups-by-id@openssh.com")
+                .map(String::as_str),
+            Some("1")
+        );
+
+        let request = TestUsersGroupsById {
+            uids: packed_ids(&[0, u32::MAX]),
+            gids: packed_ids(&[0, u32::MAX]),
+        };
+        let packet = session
+            .extended(
+                1,
+                "users-groups-by-id@openssh.com".to_string(),
+                russh_sftp::ser::to_bytes(&request).unwrap().to_vec(),
+            )
+            .await
+            .unwrap();
+        let Packet::ExtendedReply(reply) = packet else {
+            panic!("users-groups-by-id returned the wrong SFTP packet type");
+        };
+        let reply: TestUsersGroupsById =
+            russh_sftp::de::from_bytes(&mut reply.data.into()).unwrap();
+        assert_eq!(unpack_names(&reply.uids), ["root", ""]);
+        assert_eq!(unpack_names(&reply.gids), ["root", ""]);
+
+        let malformed = TestUsersGroupsById {
+            uids: vec![0, 0, 0],
+            gids: Vec::new(),
+        };
+        let error = session
+            .extended(
+                2,
+                USERS_GROUPS_BY_ID.to_string(),
+                russh_sftp::ser::to_bytes(&malformed).unwrap().to_vec(),
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(error.status_code, StatusCode::BadMessage);
+
+        let too_many = TestUsersGroupsById {
+            uids: vec![0; (MAX_ID_LOOKUPS + 1) * 4],
+            gids: Vec::new(),
+        };
+        let error = session
+            .extended(
+                3,
+                USERS_GROUPS_BY_ID.to_string(),
+                russh_sftp::ser::to_bytes(&too_many).unwrap().to_vec(),
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(error.status_code, StatusCode::Failure);
+    }
+
+    #[tokio::test]
+    async fn openssh_lsetstat_is_advertised_and_changes_the_link_not_its_target() {
+        use std::os::unix::fs::symlink;
+        use std::time::UNIX_EPOCH;
+
+        let temp = tempfile::tempdir().unwrap();
+        let target = temp.path().join("target");
+        let link = temp.path().join("link");
+        fs::write(&target, b"target").unwrap();
+        symlink(&target, &link).unwrap();
+        let target_mtime = fs::metadata(&target).unwrap().modified().unwrap();
+        let mut session = SftpSession::new();
+
+        let version = session.init(3, HashMap::new()).await.unwrap();
+        assert_eq!(
+            version
+                .extensions
+                .get("lsetstat@openssh.com")
+                .map(String::as_str),
+            Some("1")
+        );
+
+        let request = (
+            link.to_string_lossy().into_owned(),
+            FileAttributes {
+                atime: Some(1_600_000_000),
+                mtime: Some(1_600_000_001),
+                ..FileAttributes::empty()
+            },
+        );
+        let packet = session
+            .extended(
+                1,
+                "lsetstat@openssh.com".to_string(),
+                russh_sftp::ser::to_bytes(&request).unwrap().to_vec(),
+            )
+            .await
+            .unwrap();
+        assert!(matches!(
+            packet,
+            Packet::Status(Status {
+                status_code: StatusCode::Ok,
+                ..
+            })
+        ));
+        assert_eq!(
+            fs::symlink_metadata(&link)
+                .unwrap()
+                .modified()
+                .unwrap()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+            1_600_000_001
+        );
+        assert_eq!(
+            fs::metadata(&target).unwrap().modified().unwrap(),
+            target_mtime
+        );
+
+        let size_request = (
+            link.to_string_lossy().into_owned(),
+            FileAttributes {
+                size: Some(0),
+                ..FileAttributes::empty()
+            },
+        );
+        let error = session
+            .extended(
+                2,
+                LSETSTAT.to_string(),
+                russh_sftp::ser::to_bytes(&size_request).unwrap().to_vec(),
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(error.status_code, StatusCode::BadMessage);
+        assert_eq!(fs::read_link(link).unwrap(), target);
+    }
+
+    #[tokio::test]
+    async fn openssh_symlink_wire_order_creates_link_at_the_second_path() {
+        let temp = tempfile::tempdir().unwrap();
+        let linkpath = temp.path().join("link");
+        let mut session = SftpSession::new();
+
+        // russh-sftp calls these fields linkpath/targetpath, but OpenSSH puts
+        // the target first and the link name second on the wire.
+        session
+            .symlink(
+                1,
+                "../target".to_string(),
+                linkpath.to_string_lossy().into_owned(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(fs::read_link(linkpath).unwrap(), Path::new("../target"));
+    }
+
+    #[tokio::test]
+    async fn sftp_handle_table_is_bounded() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("file");
+        fs::write(&path, b"x").unwrap();
+        let mut session = SftpSession::new();
+        for id in 0..MAX_SFTP_HANDLES {
+            session
+                .open(
+                    id as u32,
+                    path.to_string_lossy().into_owned(),
+                    OpenFlags::READ,
+                    FileAttributes::empty(),
+                )
+                .await
+                .unwrap();
+        }
+        assert!(session
+            .open(
+                999,
+                path.to_string_lossy().into_owned(),
+                OpenFlags::READ,
+                FileAttributes::empty(),
+            )
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn eof_aware_stream_reports_input_completion() {
+        use tokio::io::AsyncWriteExt as _;
+
+        let (client, server) = tokio::io::duplex(64);
+        let (mut stream, finished) = EofAwareStream::new(server);
+        drop(client);
+
+        let mut byte = [0_u8; 1];
+        let read = tokio::io::AsyncReadExt::read(&mut stream, &mut byte)
+            .await
+            .unwrap();
+        assert_eq!(read, 0);
+        finished.await.unwrap();
+
+        stream.shutdown().await.unwrap();
+    }
+}

--- a/src/guest/src/service/ssh/streamlocal.rs
+++ b/src/guest/src/service/ssh/streamlocal.rs
@@ -1,0 +1,222 @@
+//! Container-scoped relay for OpenSSH direct streamlocal forwarding.
+
+use crate::service::ssh::limits::{FORWARD_CONNECT_TIMEOUT, MAX_STREAMLOCAL_PATH_BYTES};
+use boxlite_shared::errors::{BoxliteError, BoxliteResult};
+use std::path::Path;
+use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
+use tokio::net::UnixStream;
+
+pub(crate) const INTERNAL_STREAMLOCAL_ARG: &str = "--boxlite-internal-streamlocal";
+pub(crate) const STREAMLOCAL_READY_MAGIC: &[u8] = b"\0boxlite-streamlocal-ready\0";
+
+/// Accept only Linux pathname sockets that can fit in `sockaddr_un::sun_path`.
+///
+/// The path is interpreted only after ContainerExecutor has entered the target
+/// container's mount namespace, so an authorized client never selects a guest
+/// filesystem path.
+pub(crate) fn is_valid_target(path: &str) -> bool {
+    !path.is_empty()
+        && path.len() <= MAX_STREAMLOCAL_PATH_BYTES
+        && !path.contains('\0')
+        && Path::new(path).is_absolute()
+}
+
+pub(crate) fn run_internal(socket_path: String) -> BoxliteResult<()> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| BoxliteError::Internal(format!("streamlocal runtime: {error}")))?;
+    runtime.block_on(relay_streamlocal(
+        &socket_path,
+        tokio::io::stdin(),
+        tokio::io::stdout(),
+    ))
+}
+
+pub(crate) fn parse_internal_args(args: &[String]) -> BoxliteResult<String> {
+    let [socket_path] = args else {
+        return Err(BoxliteError::Config(
+            "internal streamlocal workload requires exactly one socket path".into(),
+        ));
+    };
+    let socket_path = socket_path.clone();
+    if !is_valid_target(&socket_path) {
+        return Err(BoxliteError::Config(
+            "invalid internal streamlocal socket path".into(),
+        ));
+    }
+    Ok(socket_path)
+}
+
+async fn relay_streamlocal<R, W>(
+    socket_path: &str,
+    mut input: R,
+    mut output: W,
+) -> BoxliteResult<()>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    let socket = tokio::time::timeout(FORWARD_CONNECT_TIMEOUT, UnixStream::connect(socket_path))
+        .await
+        .map_err(|_| BoxliteError::Execution("streamlocal connect timed out".into()))?
+        .map_err(|error| BoxliteError::Execution(format!("streamlocal connect failed: {error}")))?;
+
+    // This prefix is consumed by the parent bridge. It proves that pathname
+    // lookup and connect succeeded inside the container mount namespace before
+    // the SSH server confirms the channel open.
+    output
+        .write_all(STREAMLOCAL_READY_MAGIC)
+        .await
+        .map_err(|error| {
+            BoxliteError::Execution(format!("streamlocal readiness write failed: {error}"))
+        })?;
+    output.flush().await.map_err(|error| {
+        BoxliteError::Execution(format!("streamlocal readiness flush failed: {error}"))
+    })?;
+    let (mut socket_reader, mut socket_writer) = socket.into_split();
+
+    let client_to_socket = async {
+        tokio::io::copy(&mut input, &mut socket_writer).await?;
+        socket_writer.shutdown().await
+    };
+    let socket_to_client = async {
+        tokio::io::copy(&mut socket_reader, &mut output).await?;
+        output.shutdown().await
+    };
+    // Both halves have independent lifetimes. In particular, a Unix peer may
+    // shut down its write side after a greeting while continuing to consume a
+    // request, so completion of either pump must not cancel the other.
+    let (uplink, downlink) = tokio::join!(client_to_socket, socket_to_client);
+    uplink
+        .and(downlink)
+        .map_err(|error| BoxliteError::Execution(format!("streamlocal relay failed: {error}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::UnixListener;
+
+    #[test]
+    fn target_must_be_absolute_nul_free_and_fit_linux_sun_path() {
+        assert!(is_valid_target("/run/service.sock"));
+        assert!(!is_valid_target("run/service.sock"));
+        assert!(!is_valid_target("/run/bad\0socket"));
+        assert!(!is_valid_target(&format!(
+            "/{}",
+            "s".repeat(MAX_STREAMLOCAL_PATH_BYTES)
+        )));
+        assert!(is_valid_target(&format!(
+            "/{}",
+            "s".repeat(MAX_STREAMLOCAL_PATH_BYTES - 1)
+        )));
+    }
+
+    #[test]
+    fn helper_requires_exactly_one_valid_target() {
+        assert_eq!(
+            parse_internal_args(&[String::from("/run/service.sock")]).unwrap(),
+            "/run/service.sock"
+        );
+        assert!(parse_internal_args(&[]).is_err());
+        assert!(parse_internal_args(&[String::from("relative.sock")]).is_err());
+        assert!(parse_internal_args(&[
+            String::from("/run/one.sock"),
+            String::from("/run/two.sock")
+        ])
+        .is_err());
+    }
+
+    #[tokio::test]
+    async fn relay_crosses_a_real_unix_socket_and_preserves_half_close() {
+        let directory = tempfile::tempdir().unwrap();
+        let socket_path = directory.path().join("service.sock");
+        let listener = UnixListener::bind(&socket_path).unwrap();
+
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = Vec::new();
+            stream.read_to_end(&mut request).await.unwrap();
+            assert_eq!(request, b"request");
+            stream.write_all(b"response").await.unwrap();
+            stream.shutdown().await.unwrap();
+        });
+
+        let (mut input_writer, input_reader) = tokio::io::duplex(64);
+        let (output_writer, mut output_reader) = tokio::io::duplex(64);
+        let relay_path = socket_path.to_string_lossy().into_owned();
+        let relay = tokio::spawn(async move {
+            relay_streamlocal(&relay_path, input_reader, output_writer).await
+        });
+
+        input_writer.write_all(b"request").await.unwrap();
+        input_writer.shutdown().await.unwrap();
+        let mut response = Vec::new();
+        output_reader.read_to_end(&mut response).await.unwrap();
+
+        relay.await.unwrap().unwrap();
+        server.await.unwrap();
+        assert_eq!(response, [STREAMLOCAL_READY_MAGIC, b"response"].concat());
+    }
+
+    #[tokio::test]
+    async fn socket_write_eof_does_not_cancel_later_client_input() {
+        let directory = tempfile::tempdir().unwrap();
+        let socket_path = directory.path().join("service.sock");
+        let listener = UnixListener::bind(&socket_path).unwrap();
+
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            stream.write_all(b"greeting").await.unwrap();
+            stream.shutdown().await.unwrap();
+            let mut request = Vec::new();
+            stream.read_to_end(&mut request).await.unwrap();
+            request
+        });
+
+        let (mut input_writer, input_reader) = tokio::io::duplex(64);
+        let (output_writer, mut output_reader) = tokio::io::duplex(64);
+        let relay_path = socket_path.to_string_lossy().into_owned();
+        let relay = tokio::spawn(async move {
+            relay_streamlocal(&relay_path, input_reader, output_writer).await
+        });
+
+        let mut greeting = vec![0; STREAMLOCAL_READY_MAGIC.len() + b"greeting".len()];
+        tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            output_reader.read_exact(&mut greeting),
+        )
+        .await
+        .expect("relay must deliver the socket's write side")
+        .unwrap();
+        assert_eq!(greeting, [STREAMLOCAL_READY_MAGIC, b"greeting"].concat());
+
+        input_writer.write_all(b"late request").await.unwrap();
+        input_writer.shutdown().await.unwrap();
+
+        let request = tokio::time::timeout(std::time::Duration::from_secs(1), server)
+            .await
+            .expect("socket reader must survive its write-side EOF")
+            .unwrap();
+        assert_eq!(request, b"late request");
+        relay.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn failed_connect_emits_no_readiness_prefix() {
+        let directory = tempfile::tempdir().unwrap();
+        let socket_path = directory.path().join("missing.sock");
+        let (_input_writer, input_reader) = tokio::io::duplex(64);
+        let (output_writer, mut output_reader) = tokio::io::duplex(64);
+
+        let result =
+            relay_streamlocal(socket_path.to_str().unwrap(), input_reader, output_writer).await;
+        let mut output = Vec::new();
+        output_reader.read_to_end(&mut output).await.unwrap();
+
+        assert!(result.is_err());
+        assert!(output.is_empty());
+    }
+}

--- a/src/guest/src/service/ssh/workload.rs
+++ b/src/guest/src/service/ssh/workload.rs
@@ -293,7 +293,6 @@ mod tests {
     use libcontainer::oci_spec::runtime::{ProcessBuilder, SpecBuilder, UserBuilder};
     use std::fs;
     use std::io::{Read as _, Write as _};
-    use std::os::unix::fs::PermissionsExt as _;
     use std::path::{Path, PathBuf};
     use std::process::{Child, Command, Stdio};
     use std::time::{Duration, Instant};
@@ -537,29 +536,20 @@ mod tests {
         }
     }
 
-    fn is_executable(path: &Path) -> bool {
-        path.is_absolute()
-            && fs::metadata(path).is_ok_and(|metadata| {
-                metadata.is_file() && metadata.permissions().mode() & 0o111 != 0
-            })
-    }
+    /// Values the SSH session never chooses, seeded into the subprocess so an
+    /// assertion on `$HOME`/`$SHELL` cannot be satisfied by what the runner
+    /// happened to export.
+    const INHERITED_HOME_SENTINEL: &str = "/nonexistent/inherited-home";
+    const INHERITED_SHELL_SENTINEL: &str = "/nonexistent/inherited-shell";
 
+    /// Mirror of the production rule: the passwd shell is used verbatim and
+    /// only an empty field becomes `/bin/sh`. A shell the image does not ship
+    /// is *not* substituted, so this oracle must not probe for one either.
     fn selected_shell(configured: PathBuf) -> PathBuf {
-        if is_executable(&configured) {
-            return configured;
+        if configured.as_os_str().is_empty() {
+            return PathBuf::from("/bin/sh");
         }
-        [
-            "/bin/bash",
-            "/bin/ash",
-            "/bin/sh",
-            "/usr/bin/bash",
-            "/usr/bin/ash",
-            "/usr/bin/sh",
-        ]
-        .into_iter()
-        .map(PathBuf::from)
-        .find(|path| is_executable(path))
-        .expect("Linux test environment has a fallback shell")
+        configured
     }
 
     #[test]
@@ -680,10 +670,12 @@ mod tests {
     }
 
     #[test]
-    fn exec_workload_preserves_one_command_argument_and_root_home() {
+    fn exec_workload_preserves_one_command_argument_and_exports_the_account_profile() {
         let inherited_cwd = tempfile::tempdir().unwrap();
-        let expected_home = selected_home(root_record().0);
-        let command = r#"printf '\036%s\0%s\037' "$PWD" 'literal spaces ; $(not reparsed)'"#;
+        let (home, shell) = root_record();
+        let expected_home = selected_home(home);
+        let expected_shell = selected_shell(shell);
+        let command = r#"printf '\036%s\0%s\0%s\0%s\037' "$PWD" "$HOME" "$SHELL" 'literal spaces ; $(not reparsed)'"#;
         let output = Command::new(std::env::current_exe().unwrap())
             .args([
                 "--exact",
@@ -693,6 +685,11 @@ mod tests {
             ])
             .env(SUBPROCESS_CASE, "exec")
             .env(SUBPROCESS_COMMAND, command)
+            // Values the session must overwrite. Inheriting the runner's own
+            // HOME/SHELL would let this pass without the session exporting
+            // anything.
+            .env("HOME", INHERITED_HOME_SENTINEL)
+            .env("SHELL", INHERITED_SHELL_SENTINEL)
             .current_dir(inherited_cwd.path())
             .output()
             .unwrap();
@@ -701,14 +698,21 @@ mod tests {
             "{}",
             String::from_utf8_lossy(&output.stderr)
         );
+        // HOME is exported as the directory actually entered, so it tracks $PWD.
         let expected = format!(
-            "\u{1e}{}\0literal spaces ; $(not reparsed)\u{1f}",
-            expected_home.display()
+            "\u{1e}{}\0{}\0{}\0literal spaces ; $(not reparsed)\u{1f}",
+            expected_home.display(),
+            expected_home.display(),
+            expected_shell.display()
         );
-        assert!(output
-            .stdout
-            .windows(expected.len())
-            .any(|window| window == expected.as_bytes()));
+        assert!(
+            output
+                .stdout
+                .windows(expected.len())
+                .any(|window| window == expected.as_bytes()),
+            "expected {expected:?} in {:?}",
+            String::from_utf8_lossy(&output.stdout)
+        );
     }
 
     #[test]

--- a/src/guest/src/service/ssh/workload.rs
+++ b/src/guest/src/service/ssh/workload.rs
@@ -1,0 +1,737 @@
+//! BoxLite workloads executed by libcontainer after tenant setup.
+
+use super::{limits, reverse_streamlocal, session, sftp, streamlocal};
+use boxlite_shared::errors::{BoxliteError, BoxliteResult};
+use libcontainer::oci_spec::runtime::Spec;
+use libcontainer::workload::{Executor, ExecutorError, ExecutorValidationError};
+use serde::{Deserialize, Serialize};
+use std::net::SocketAddrV4;
+
+/// Reserved OCI argv[0] used to represent a typed workload in the process spec.
+/// It is a validation placeholder, not a selector or container filesystem path.
+pub(crate) const INTERNAL_PROGRAM: &str = "boxlite-internal:ssh";
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub(crate) enum SshWorkload {
+    Shell,
+    Exec {
+        command: String,
+    },
+    Sftp,
+    DirectStreamlocal {
+        socket_path: String,
+    },
+    ReverseStreamlocal {
+        socket_path: String,
+        ingress: SocketAddrV4,
+    },
+}
+
+impl SshWorkload {
+    pub(crate) fn placeholder(&self) -> (String, Vec<String>) {
+        let args = match self {
+            Self::Shell => vec![session::INTERNAL_SESSION_ARG.into(), "shell".into()],
+            Self::Exec { command } => vec![
+                session::INTERNAL_SESSION_ARG.into(),
+                "exec".into(),
+                command.clone(),
+            ],
+            Self::Sftp => vec![sftp::INTERNAL_SFTP_ARG.into()],
+            Self::DirectStreamlocal { socket_path } => vec![
+                streamlocal::INTERNAL_STREAMLOCAL_ARG.into(),
+                socket_path.clone(),
+            ],
+            Self::ReverseStreamlocal {
+                socket_path,
+                ingress,
+            } => vec![
+                reverse_streamlocal::INTERNAL_REVERSE_STREAMLOCAL_ARG.into(),
+                socket_path.clone(),
+                ingress.to_string(),
+            ],
+        };
+        (INTERNAL_PROGRAM.into(), args)
+    }
+
+    /// Parse the reserved argv shape when validating typed zygote state.
+    /// Executor selection never uses this parser: only the private in-process
+    /// SSH launch path can populate `BuildSpec::ssh_workload`.
+    pub(crate) fn from_container_args(args: &[String]) -> BoxliteResult<Option<Self>> {
+        if args.first().map(String::as_str) != Some(INTERNAL_PROGRAM) {
+            return Ok(None);
+        }
+        let [_, selector, workload_args @ ..] = args else {
+            return Err(BoxliteError::Config(
+                "internal SSH workload requires a selector".into(),
+            ));
+        };
+
+        let workload = match selector.as_str() {
+            session::INTERNAL_SESSION_ARG => match session::parse_internal_args(workload_args)? {
+                session::SessionAction::Shell => Self::Shell,
+                session::SessionAction::Exec(command) => {
+                    if command.len() > limits::MAX_COMMAND_BYTES || command.contains('\0') {
+                        return Err(BoxliteError::Config(
+                            "internal SSH command is too large or contains NUL".into(),
+                        ));
+                    }
+                    Self::Exec { command }
+                }
+            },
+            sftp::INTERNAL_SFTP_ARG if workload_args.is_empty() => Self::Sftp,
+            sftp::INTERNAL_SFTP_ARG => {
+                return Err(BoxliteError::Config(
+                    "internal SFTP workload does not accept arguments".into(),
+                ));
+            }
+            streamlocal::INTERNAL_STREAMLOCAL_ARG => Self::DirectStreamlocal {
+                socket_path: streamlocal::parse_internal_args(workload_args)?,
+            },
+            reverse_streamlocal::INTERNAL_REVERSE_STREAMLOCAL_ARG => {
+                let args = reverse_streamlocal::parse_internal_args(workload_args)?;
+                Self::ReverseStreamlocal {
+                    socket_path: args.socket_path,
+                    ingress: args.ingress,
+                }
+            }
+            _ => {
+                return Err(BoxliteError::Config(format!(
+                    "unknown internal SSH workload selector: {selector}"
+                )));
+            }
+        };
+        Ok(Some(workload))
+    }
+
+    pub(crate) fn supports_pty(&self) -> bool {
+        matches!(self, Self::Shell | Self::Exec { .. })
+    }
+
+    fn run(self) -> BoxliteResult<()> {
+        match self {
+            Self::Shell => session::run_internal(session::SessionAction::Shell),
+            Self::Exec { command } => session::run_internal(session::SessionAction::Exec(command)),
+            Self::Sftp => {
+                session::prepare_sftp_home()?;
+                sftp::run_internal()
+            }
+            Self::DirectStreamlocal { socket_path } => streamlocal::run_internal(socket_path),
+            Self::ReverseStreamlocal {
+                socket_path,
+                ingress,
+            } => reverse_streamlocal::run_internal(reverse_streamlocal::InternalArgs {
+                socket_path,
+                ingress,
+            }),
+        }
+    }
+
+    fn is_direct_rust(&self) -> bool {
+        !matches!(self, Self::Shell | Self::Exec { .. })
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct BoxliteWorkloadExecutor {
+    workload: SshWorkload,
+}
+
+impl BoxliteWorkloadExecutor {
+    pub(crate) fn new(workload: SshWorkload) -> Self {
+        Self { workload }
+    }
+
+    fn validate_spec(&self, spec: &Spec) -> BoxliteResult<()> {
+        let process = spec.process().as_ref().ok_or_else(|| {
+            BoxliteError::Config("internal SSH workload requires an OCI process".into())
+        })?;
+        let args = process.args().as_deref().ok_or_else(|| {
+            BoxliteError::Config("internal SSH workload requires process arguments".into())
+        })?;
+        if process.user().uid() != 0 || process.user().gid() != 0 {
+            return Err(BoxliteError::Config(
+                "internal SSH workloads must run as container root".into(),
+            ));
+        }
+        let parsed = SshWorkload::from_container_args(args)?.ok_or_else(|| {
+            BoxliteError::Config("internal SSH workload placeholder is missing".into())
+        })?;
+        if parsed != self.workload {
+            return Err(BoxliteError::Config(
+                "internal SSH workload does not match its OCI placeholder".into(),
+            ));
+        }
+        if process.terminal().unwrap_or(false) && !self.workload.supports_pty() {
+            return Err(BoxliteError::Config(
+                "this internal SSH workload does not support a PTY".into(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl Executor for BoxliteWorkloadExecutor {
+    fn exec(&self, spec: &Spec) -> Result<(), ExecutorError> {
+        self.validate_spec(spec).map_err(executor_error)?;
+        let workload = self.workload.clone();
+        if !workload.is_direct_rust() {
+            return workload.run().map_err(executor_error);
+        }
+
+        install_direct_workload_panic_hook();
+
+        // Youki normally marks these descriptors CLOEXEC and waits for execve
+        // to close its notification pipe. Direct Rust workloads do not exec,
+        // so this real close is both the readiness boundary and leak defense.
+        close_inherited_fds().map_err(executor_error)?;
+
+        match workload.run() {
+            Ok(()) => exit_without_inherited_handlers(0),
+            Err(error) => {
+                eprintln!("[ssh-workload] {error}");
+                use std::io::Write as _;
+                let _ = std::io::stderr().flush();
+                exit_without_inherited_handlers(1);
+            }
+        }
+    }
+
+    fn validate(&self, spec: &Spec) -> Result<(), ExecutorValidationError> {
+        self.validate_spec(spec)
+            .map_err(|error| ExecutorValidationError::ArgValidationError(error.to_string()))
+    }
+}
+
+fn executor_error(error: BoxliteError) -> ExecutorError {
+    ExecutorError::Execution(Box::new(error))
+}
+
+fn close_inherited_fds() -> BoxliteResult<()> {
+    let result = unsafe { nix::libc::syscall(nix::libc::SYS_close_range, 3_u32, u32::MAX, 0_u32) };
+    if result == 0 {
+        return Ok(());
+    }
+
+    let error = std::io::Error::last_os_error();
+    if !matches!(
+        error.raw_os_error(),
+        Some(nix::libc::ENOSYS) | Some(nix::libc::EINVAL) | Some(nix::libc::EPERM)
+    ) {
+        return Err(BoxliteError::Internal(format!(
+            "close inherited SSH workload descriptors: {error}"
+        )));
+    }
+
+    let descriptors = {
+        let mut descriptors = Vec::new();
+        for entry in std::fs::read_dir("/proc/self/fd").map_err(|fallback_error| {
+            BoxliteError::Internal(format!(
+                "enumerate inherited SSH workload descriptors after close_range failed ({error}): {fallback_error}"
+            ))
+        })? {
+            let entry = entry.map_err(|fallback_error| {
+                BoxliteError::Internal(format!(
+                    "read inherited SSH workload descriptor: {fallback_error}"
+                ))
+            })?;
+            let Some(descriptor) = entry
+                .file_name()
+                .to_str()
+                .and_then(|name| name.parse::<i32>().ok())
+            else {
+                continue;
+            };
+            if descriptor >= 3 {
+                descriptors.push(descriptor);
+            }
+        }
+        descriptors
+    };
+
+    let mut close_error = None;
+    for descriptor in descriptors {
+        if unsafe { nix::libc::close(descriptor) } == -1 {
+            let error = std::io::Error::last_os_error();
+            if error.raw_os_error() != Some(nix::libc::EBADF) && close_error.is_none() {
+                close_error = Some((descriptor, error));
+            }
+        }
+    }
+    if let Some((descriptor, error)) = close_error {
+        // Closing any descriptor >= 3 crosses Youki's logical exec boundary:
+        // its parent may already have observed EOF on the exec-notify pipe.
+        // Never return into libcontainer after that point.
+        eprintln!("[ssh-workload] close inherited descriptor {descriptor}: {error}");
+        use std::io::Write as _;
+        let _ = std::io::stderr().flush();
+        exit_without_inherited_handlers(1);
+    }
+    Ok(())
+}
+
+fn install_direct_workload_panic_hook() {
+    std::panic::set_hook(Box::new(|_| {
+        const MESSAGE: &[u8] = b"[ssh-workload] internal workload panicked\n";
+        unsafe {
+            nix::libc::write(
+                nix::libc::STDERR_FILENO,
+                MESSAGE.as_ptr().cast(),
+                MESSAGE.len(),
+            );
+            nix::libc::_exit(101);
+        }
+    }));
+}
+
+fn exit_without_inherited_handlers(status: i32) -> ! {
+    unsafe { nix::libc::_exit(status) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use libcontainer::oci_spec::runtime::{ProcessBuilder, SpecBuilder, UserBuilder};
+    use std::fs;
+    use std::io::{Read as _, Write as _};
+    use std::os::unix::fs::PermissionsExt as _;
+    use std::path::{Path, PathBuf};
+    use std::process::{Child, Command, Stdio};
+    use std::time::{Duration, Instant};
+
+    const SUBPROCESS_CASE: &str = "BOXLITE_SSH_WORKLOAD_SUBPROCESS";
+    const SUBPROCESS_COMMAND: &str = "BOXLITE_SSH_WORKLOAD_COMMAND";
+    const SUBPROCESS_TEST: &str =
+        "service::ssh::workload::tests::internal_workload_subprocess_driver";
+
+    fn spec(args: &[&str], terminal: bool) -> Spec {
+        let user = UserBuilder::default()
+            .uid(0_u32)
+            .gid(0_u32)
+            .build()
+            .unwrap();
+        let process = ProcessBuilder::default()
+            .terminal(terminal)
+            .user(user)
+            .args(
+                args.iter()
+                    .map(|value| (*value).to_string())
+                    .collect::<Vec<_>>(),
+            )
+            .env(vec!["PATH=/bin:/usr/bin".to_string()])
+            .cwd("/")
+            .build()
+            .unwrap();
+        SpecBuilder::default().process(process).build().unwrap()
+    }
+
+    fn parse(args: &[&str]) -> BoxliteResult<Option<SshWorkload>> {
+        SshWorkload::from_container_args(
+            &args
+                .iter()
+                .map(|value| (*value).to_string())
+                .collect::<Vec<_>>(),
+        )
+    }
+
+    #[test]
+    fn ordinary_commands_do_not_select_a_custom_workload() {
+        assert_eq!(parse(&["/bin/true"]).unwrap(), None);
+    }
+
+    #[test]
+    fn every_internal_workload_round_trips_through_zygote_serialization() {
+        let workloads = [
+            SshWorkload::Shell,
+            SshWorkload::Exec {
+                command: "printf '%s' hello".into(),
+            },
+            SshWorkload::Sftp,
+            SshWorkload::DirectStreamlocal {
+                socket_path: "/run/service.sock".into(),
+            },
+            SshWorkload::ReverseStreamlocal {
+                socket_path: "/run/service.sock".into(),
+                ingress: "127.0.0.1:32000".parse().unwrap(),
+            },
+        ];
+        for workload in workloads {
+            let encoded = serde_json::to_vec(&workload).unwrap();
+            let decoded: SshWorkload = serde_json::from_slice(&encoded).unwrap();
+            assert_eq!(decoded, workload);
+        }
+    }
+
+    #[test]
+    fn validates_every_internal_workload_shape() {
+        let cases = [
+            (
+                vec![INTERNAL_PROGRAM, session::INTERNAL_SESSION_ARG, "shell"],
+                false,
+            ),
+            (
+                vec![
+                    INTERNAL_PROGRAM,
+                    session::INTERNAL_SESSION_ARG,
+                    "exec",
+                    "printf '%s' hello",
+                ],
+                true,
+            ),
+            (vec![INTERNAL_PROGRAM, sftp::INTERNAL_SFTP_ARG], false),
+            (
+                vec![
+                    INTERNAL_PROGRAM,
+                    streamlocal::INTERNAL_STREAMLOCAL_ARG,
+                    "/run/service.sock",
+                ],
+                false,
+            ),
+            (
+                vec![
+                    INTERNAL_PROGRAM,
+                    reverse_streamlocal::INTERNAL_REVERSE_STREAMLOCAL_ARG,
+                    "/run/service.sock",
+                    "127.0.0.1:32000",
+                ],
+                false,
+            ),
+        ];
+        for (args, terminal) in cases {
+            let workload = parse(&args).unwrap().unwrap();
+            BoxliteWorkloadExecutor::new(workload)
+                .validate(&spec(&args, terminal))
+                .unwrap();
+        }
+    }
+
+    #[test]
+    fn rejects_unknown_ambiguous_or_mismatched_internal_workloads() {
+        for args in [
+            vec![INTERNAL_PROGRAM],
+            vec![INTERNAL_PROGRAM, "unknown"],
+            vec![INTERNAL_PROGRAM, sftp::INTERNAL_SFTP_ARG, "extra"],
+            vec![INTERNAL_PROGRAM, session::INTERNAL_SESSION_ARG, "exec"],
+            vec![
+                INTERNAL_PROGRAM,
+                streamlocal::INTERNAL_STREAMLOCAL_ARG,
+                "relative.sock",
+            ],
+            vec![
+                INTERNAL_PROGRAM,
+                reverse_streamlocal::INTERNAL_REVERSE_STREAMLOCAL_ARG,
+                "/run/service.sock",
+                "192.0.2.1:32000",
+            ],
+        ] {
+            assert!(parse(&args).is_err(), "accepted {args:?}");
+        }
+
+        let args = [INTERNAL_PROGRAM, session::INTERNAL_SESSION_ARG, "shell"];
+        assert!(BoxliteWorkloadExecutor::new(SshWorkload::Sftp)
+            .validate(&spec(&args, false))
+            .is_err());
+    }
+
+    #[test]
+    fn rejects_a_pty_for_protocol_and_relay_workloads() {
+        let args = [INTERNAL_PROGRAM, sftp::INTERNAL_SFTP_ARG];
+        assert!(BoxliteWorkloadExecutor::new(SshWorkload::Sftp)
+            .validate(&spec(&args, true))
+            .is_err());
+    }
+
+    #[test]
+    fn rejects_non_root_internal_workloads() {
+        let args = [INTERNAL_PROGRAM, sftp::INTERNAL_SFTP_ARG];
+        let process = ProcessBuilder::default()
+            .terminal(false)
+            .user(
+                UserBuilder::default()
+                    .uid(1000_u32)
+                    .gid(1000_u32)
+                    .build()
+                    .unwrap(),
+            )
+            .args(args.map(str::to_owned).to_vec())
+            .env(vec!["PATH=/bin:/usr/bin".to_string()])
+            .cwd("/")
+            .build()
+            .unwrap();
+        let non_root_spec = SpecBuilder::default().process(process).build().unwrap();
+
+        assert!(BoxliteWorkloadExecutor::new(SshWorkload::Sftp)
+            .validate(&non_root_spec)
+            .is_err());
+    }
+
+    fn spawn_subprocess(case: &str, cwd: &Path) -> Child {
+        Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                SUBPROCESS_TEST,
+                "--nocapture",
+                "--test-threads=1",
+            ])
+            .env(SUBPROCESS_CASE, case)
+            .current_dir(cwd)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn isolated SSH workload test")
+    }
+
+    fn wait_for_cwd(child: &mut Child, expected: &Path) {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            if child.try_wait().unwrap().is_some() {
+                let mut stderr = String::new();
+                child
+                    .stderr
+                    .take()
+                    .unwrap()
+                    .read_to_string(&mut stderr)
+                    .unwrap();
+                panic!("workload exited before entering {expected:?}: {stderr}");
+            }
+            if matches!(
+                fs::read_link(format!("/proc/{}/cwd", child.id())),
+                Ok(path) if path == expected
+            ) {
+                return;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "workload never entered {expected:?}"
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        }
+    }
+
+    fn root_record() -> (PathBuf, PathBuf) {
+        let passwd = fs::read_to_string("/etc/passwd").unwrap();
+        let fields = passwd
+            .lines()
+            .find_map(|line| {
+                let fields = line.split(':').collect::<Vec<_>>();
+                (fields.len() >= 7 && fields[0] == "root").then_some(fields)
+            })
+            .expect("Linux test environment has a root passwd entry");
+        (fields[5].into(), fields[6].into())
+    }
+
+    fn selected_home(home: PathBuf) -> PathBuf {
+        if home.is_absolute() && home.is_dir() {
+            home
+        } else {
+            PathBuf::from("/")
+        }
+    }
+
+    fn is_executable(path: &Path) -> bool {
+        path.is_absolute()
+            && fs::metadata(path).is_ok_and(|metadata| {
+                metadata.is_file() && metadata.permissions().mode() & 0o111 != 0
+            })
+    }
+
+    fn selected_shell(configured: PathBuf) -> PathBuf {
+        if is_executable(&configured) {
+            return configured;
+        }
+        [
+            "/bin/bash",
+            "/bin/ash",
+            "/bin/sh",
+            "/usr/bin/bash",
+            "/usr/bin/ash",
+            "/usr/bin/sh",
+        ]
+        .into_iter()
+        .map(PathBuf::from)
+        .find(|path| is_executable(path))
+        .expect("Linux test environment has a fallback shell")
+    }
+
+    #[test]
+    fn internal_workload_subprocess_driver() {
+        let Ok(case) = std::env::var(SUBPROCESS_CASE) else {
+            return;
+        };
+        if case == "close-fds" {
+            let file = fs::File::open("/dev/null").unwrap();
+            const HIGH_FD: i32 = 4096;
+            assert_eq!(
+                unsafe { nix::libc::dup2(std::os::fd::AsRawFd::as_raw_fd(&file), HIGH_FD) },
+                HIGH_FD
+            );
+            close_inherited_fds().unwrap();
+            let high_closed = unsafe { nix::libc::fcntl(HIGH_FD, nix::libc::F_GETFD) } == -1;
+            let stdio_open =
+                (0..=2).all(|fd| unsafe { nix::libc::fcntl(fd, nix::libc::F_GETFD) } != -1);
+            if high_closed && stdio_open {
+                println!("fd-boundary-ok");
+                std::io::stdout().flush().unwrap();
+                exit_without_inherited_handlers(0);
+            }
+            exit_without_inherited_handlers(1);
+        }
+        if case == "panic" {
+            install_direct_workload_panic_hook();
+            panic!("must terminate through the direct-workload panic hook");
+        }
+
+        let args = match case.as_str() {
+            "shell" => vec![
+                INTERNAL_PROGRAM.to_string(),
+                session::INTERNAL_SESSION_ARG.to_string(),
+                "shell".to_string(),
+            ],
+            "exec" => vec![
+                INTERNAL_PROGRAM.to_string(),
+                session::INTERNAL_SESSION_ARG.to_string(),
+                "exec".to_string(),
+                std::env::var(SUBPROCESS_COMMAND).unwrap(),
+            ],
+            "sftp" => vec![
+                INTERNAL_PROGRAM.to_string(),
+                sftp::INTERNAL_SFTP_ARG.to_string(),
+            ],
+            _ => panic!("unknown subprocess case: {case}"),
+        };
+        let workload = SshWorkload::from_container_args(&args).unwrap().unwrap();
+        let arg_refs = args.iter().map(String::as_str).collect::<Vec<_>>();
+        BoxliteWorkloadExecutor::new(workload)
+            .exec(&spec(&arg_refs, false))
+            .unwrap();
+        unreachable!("successful workload execution must not return");
+    }
+
+    #[test]
+    fn shell_workload_enters_root_home_and_uses_login_argv0() {
+        let inherited_cwd = tempfile::tempdir().unwrap();
+        let (home, shell) = root_record();
+        let expected_home = selected_home(home);
+        let expected_shell = fs::canonicalize(selected_shell(shell)).unwrap();
+        let expected_argv0 = format!("-{}", expected_shell.file_name().unwrap().to_string_lossy());
+        let mut child = spawn_subprocess("shell", inherited_cwd.path());
+
+        wait_for_cwd(&mut child, &expected_home);
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            if matches!(
+                fs::read_link(format!("/proc/{}/exe", child.id())),
+                Ok(path) if path == expected_shell
+            ) {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "workload never execed {expected_shell:?}"
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        }
+
+        child
+            .stdin
+            .take()
+            .unwrap()
+            .write_all(b"printf '\\036%s\\037' \"$0\"; exit\n")
+            .unwrap();
+        let output = child.wait_with_output().unwrap();
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let framed = [
+            b"\x1e".as_slice(),
+            expected_argv0.as_bytes(),
+            b"\x1f".as_slice(),
+        ]
+        .concat();
+        assert!(output
+            .stdout
+            .windows(framed.len())
+            .any(|window| window == framed));
+    }
+
+    #[test]
+    fn exec_workload_preserves_one_command_argument_and_root_home() {
+        let inherited_cwd = tempfile::tempdir().unwrap();
+        let expected_home = selected_home(root_record().0);
+        let command = r#"printf '\036%s\0%s\037' "$PWD" 'literal spaces ; $(not reparsed)'"#;
+        let output = Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                SUBPROCESS_TEST,
+                "--nocapture",
+                "--test-threads=1",
+            ])
+            .env(SUBPROCESS_CASE, "exec")
+            .env(SUBPROCESS_COMMAND, command)
+            .current_dir(inherited_cwd.path())
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let expected = format!(
+            "\u{1e}{}\0literal spaces ; $(not reparsed)\u{1f}",
+            expected_home.display()
+        );
+        assert!(output
+            .stdout
+            .windows(expected.len())
+            .any(|window| window == expected.as_bytes()));
+    }
+
+    #[test]
+    fn sftp_workload_enters_root_home() {
+        let inherited_cwd = tempfile::tempdir().unwrap();
+        let expected_home = selected_home(root_record().0);
+        let mut child = spawn_subprocess("sftp", inherited_cwd.path());
+        wait_for_cwd(&mut child, &expected_home);
+        child.kill().unwrap();
+        child.wait().unwrap();
+    }
+
+    #[test]
+    fn direct_workloads_close_high_descriptors_but_keep_stdio() {
+        let output = Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                SUBPROCESS_TEST,
+                "--nocapture",
+                "--test-threads=1",
+            ])
+            .env(SUBPROCESS_CASE, "close-fds")
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(String::from_utf8_lossy(&output.stdout).contains("fd-boundary-ok"));
+    }
+
+    #[test]
+    fn direct_workload_panics_exit_without_unwinding() {
+        let output = Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                SUBPROCESS_TEST,
+                "--nocapture",
+                "--test-threads=1",
+            ])
+            .env(SUBPROCESS_CASE, "panic")
+            .output()
+            .unwrap();
+        assert_eq!(output.status.code(), Some(101));
+        assert!(String::from_utf8_lossy(&output.stderr)
+            .contains("[ssh-workload] internal workload panicked"));
+    }
+}

--- a/src/guest/src/service/ssh/workload.rs
+++ b/src/guest/src/service/ssh/workload.rs
@@ -520,8 +520,17 @@ mod tests {
         (fields[5].into(), fields[6].into())
     }
 
+    /// Mirror the fallback in `session::enter_root_home`.
+    ///
+    /// Existence is not enough: the session chdir's into this directory, so it
+    /// needs search permission. In a container the workload is root and always
+    /// has it; under `cargo test` the runner is whoever invoked it, and root's
+    /// home is typically 0700 — so an unprivileged run legitimately lands on
+    /// `/` and the expectation has to follow.
     fn selected_home(home: PathBuf) -> PathBuf {
-        if home.is_absolute() && home.is_dir() {
+        let traversable =
+            home.is_dir() && nix::unistd::access(&home, nix::unistd::AccessFlags::X_OK).is_ok();
+        if home.is_absolute() && traversable {
             home
         } else {
             PathBuf::from("/")
@@ -560,13 +569,27 @@ mod tests {
         };
         if case == "close-fds" {
             let file = fs::File::open("/dev/null").unwrap();
-            const HIGH_FD: i32 = 4096;
+            // The highest descriptor this process may hold. dup2 rejects a
+            // target at or above RLIMIT_NOFILE with EBADF, so a fixed number
+            // fails before the code under test ever runs wherever the soft
+            // limit is lower.
+            let high_fd = {
+                let mut limit = nix::libc::rlimit {
+                    rlim_cur: 0,
+                    rlim_max: 0,
+                };
+                assert_eq!(
+                    unsafe { nix::libc::getrlimit(nix::libc::RLIMIT_NOFILE, &mut limit) },
+                    0
+                );
+                i32::try_from(limit.rlim_cur.saturating_sub(1).min(4096)).unwrap()
+            };
             assert_eq!(
-                unsafe { nix::libc::dup2(std::os::fd::AsRawFd::as_raw_fd(&file), HIGH_FD) },
-                HIGH_FD
+                unsafe { nix::libc::dup2(std::os::fd::AsRawFd::as_raw_fd(&file), high_fd) },
+                high_fd
             );
             close_inherited_fds().unwrap();
-            let high_closed = unsafe { nix::libc::fcntl(HIGH_FD, nix::libc::F_GETFD) } == -1;
+            let high_closed = unsafe { nix::libc::fcntl(high_fd, nix::libc::F_GETFD) } == -1;
             let stdio_open =
                 (0..=2).all(|fd| unsafe { nix::libc::fcntl(fd, nix::libc::F_GETFD) } != -1);
             if high_closed && stdio_open {

--- a/src/shared/proto/boxlite/v1/service.proto
+++ b/src/shared/proto/boxlite/v1/service.proto
@@ -47,6 +47,21 @@ service Guest {
   rpc Thaw(ThawRequest) returns (ThawResponse);
 }
 
+// Live control for the embedded SSH listener. SSH is deliberately separate
+// from Guest.Init so credentials and listener policy can be rotated without
+// rebuilding or restarting the guest.
+service Ssh {
+  // Enable SSH or replace policy for subsequent authentication attempts.
+  // Pre-auth transports close; authenticated connections retain their snapshot.
+  rpc Configure(SshConfigureRequest) returns (SshConfigureResponse);
+
+  // Return the currently active listener state.
+  rpc Status(SshStatusRequest) returns (SshStatusResponse);
+
+  // Stop accepts and close pre-auth transports. Authenticated sessions may drain.
+  rpc Disable(SshDisableRequest) returns (SshDisableResponse);
+}
+
 // Command execution
 service Execution {
   // Start execution immediately.
@@ -202,6 +217,45 @@ message ThawRequest {}
 message ThawResponse {
   // Number of filesystems successfully thawed
   uint32 thawed_count = 1;
+}
+
+// ============================================================================
+// SSH Service Messages
+// ============================================================================
+
+message SshConfigureRequest {
+  // Guest TCP socket address, for example "0.0.0.0:22".
+  string listen_address = 1;
+  // OpenSSH public key for the CA trusted to sign user certificates.
+  string ca_public_key = 2;
+  // Required certificate principal (normally the host-owned Box ID).
+  string principal = 3;
+}
+
+message SshConfigureResponse {
+  SshStatus status = 1;
+}
+
+message SshStatusRequest {}
+
+message SshStatusResponse {
+  SshStatus status = 1;
+}
+
+message SshDisableRequest {}
+
+message SshDisableResponse {
+  SshStatus status = 1;
+}
+
+message SshStatus {
+  bool enabled = 1;
+  // Actual bound address. Empty while disabled.
+  string listen_address = 2;
+  // Increases when SSH state changes in this guest process; resets on restart.
+  uint64 generation = 3;
+  // SHA-256 fingerprint of the persistent guest host key. Empty while disabled.
+  string host_key_fingerprint = 4;
 }
 
 // ============================================================================
@@ -363,6 +417,13 @@ message TtyConfig {
   uint32 cols = 2;      // Terminal width
   uint32 x_pixels = 3;  // Optional: pixel width
   uint32 y_pixels = 4;  // Optional: pixel height
+  repeated TtyMode modes = 5; // RFC 4254 section 8 terminal modes
+}
+
+// One RFC 4254 terminal mode opcode and its uint32 argument.
+message TtyMode {
+  uint32 opcode = 1;
+  uint32 value = 2;
 }
 
 message ExecResponse {
@@ -423,6 +484,9 @@ message WaitResponse {
 message KillRequest {
   string execution_id = 1;
   int32 signal = 2;  // Signal number (default: 9 = SIGKILL)
+  // Signal the execution's process group. The guest verifies that the tracked
+  // PID is still the group leader before using a negative-PID kill target.
+  bool process_group = 3;
 }
 
 message KillResponse {

--- a/src/shared/src/lib.rs
+++ b/src/shared/src/lib.rs
@@ -26,6 +26,9 @@ pub use generated::container_server::{Container, ContainerServer};
 pub use generated::guest_client::GuestClient;
 pub use generated::guest_server::{Guest, GuestServer};
 
+// SSH control service
+pub use generated::ssh_server::{Ssh, SshServer};
+
 // Execution service
 pub use generated::execution_client::ExecutionClient;
 pub use generated::execution_server::{Execution, ExecutionServer};


### PR DESCRIPTION
## Summary

- embed a `russh` SSH endpoint in `boxlite-guest` with CA-signed certificate authentication
- add live configure/status/disable control outside `Guest.Init`, plus host APIs and a stdio ProxyCommand transport
- support shell/exec, PTY and signals, SFTP, TCP and Unix-socket forwarding, and bounded lifecycle cleanup
- document setup, credential rotation, security boundaries, compatibility, and troubleshooting

## Why

SSH access was coupled to gateway and image assumptions and could not be safely reconfigured at runtime. The guest now owns SSH protocol termination while the host owns mutable policy and credential reconciliation.

## User impact

Standard OpenSSH clients can connect without an `sshd` package in the image. CA credentials can rotate without restarting the guest: existing authenticated sessions drain normally, while terminal shutdown closes all sessions. Password authentication, raw public-key authentication, agent forwarding, and unsafe forwarding modes remain disabled.

## Validation

- `make test:unit:guest` — 210 unit tests plus 7 SSH integration tests passed on Linux
- `BOXLITE_DEPS_STUB=1 make test:unit:rust FILTER=ssh` — 6 tests passed
- `BOXLITE_DEPS_STUB=1 make test:integration:cli FILTER=network_tunnel_accepts_stdio_proxy_mode SETUP_DONE=1`
- `make clippy`
- `make guest`
- `make fmt:check:rust`
- `git diff --check`

A full `make fmt:check` was also attempted, but the apps dependency bootstrap failed while building native sqlite3 before formatting ran.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an embedded certificate-authenticated SSH service with interactive shell/exec, SFTP, and TCP/streamlocal forwarding (including reverse streamlocal).
  * Extended TTY handling with RFC 4254 terminal modes and process-group-aware termination.
  * Added guest-side rootfs sealing (read-only) and root login profile resolution.
* **Bug Fixes**
  * Hardened security by enforcing guest root filesystem sealing while preserving expected writable paths.
  * Restricted guest RPC processing to host-origin vsock peers.
* **Tests**
  * Added/expanded integration coverage for TTY resize, sealed-root security enforcement, and execution/session behavior.
* **Chores**
  * Improved lint workflow for macOS Rust cross-linting to Linux musl.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->