### PR TITLE
feat(rest): expose S3 managed volumes

### DIFF
--- a/sdks/node/lib/native-contracts.ts
+++ b/sdks/node/lib/native-contracts.ts
@@ -77,7 +77,29 @@ export interface JsEnvVar {
   value: string;
 }
 
-export interface JsVolumeSpec {
+export type JsVolumeSpec =
+  | {
+      /** Scheme-qualified managed volume source, e.g. volume://vol_123. */
+      source: string;
+      guestPath: string;
+      readOnly?: boolean;
+    }
+  | {
+      /** Path on the local host for host-path mounts. */
+      hostPath: string;
+      guestPath: string;
+      readOnly?: boolean;
+    };
+
+export interface JsVolumeSourceSpec {
+  /** Scheme-qualified managed volume source, e.g. volume://vol_123. */
+  source: string;
+  guestPath: string;
+  readOnly?: boolean;
+}
+
+export interface JsHostPathVolumeSpec {
+  /** Path on the local host for host-path mounts. */
   hostPath: string;
   guestPath: string;
   readOnly?: boolean;

--- a/sdks/node/lib/simplebox.ts
+++ b/sdks/node/lib/simplebox.ts
@@ -15,6 +15,7 @@ import type {
   JsBox,
   JsBoxInfo,
   JsBoxOptions,
+  JsVolumeSpec,
   NativeBoxConnection,
   NativeBoxTunnel,
   JsExecStderr,
@@ -211,12 +212,8 @@ export interface SimpleBoxOptions {
   /** Environment variables */
   env?: Record<string, string>;
 
-  /** Volume mounts */
-  volumes?: Array<{
-    hostPath: string;
-    guestPath: string;
-    readOnly?: boolean;
-  }>;
+  /** Volume mounts: local hostPath or managed source such as volume://vol_123. */
+  volumes?: JsVolumeSpec[];
 
   /** Port mappings */
   ports?: Array<{

--- a/sdks/node/src/options.rs
+++ b/sdks/node/src/options.rs
@@ -259,8 +259,11 @@ pub struct JsEnvVar {
 #[napi(object)]
 #[derive(Clone, Debug)]
 pub struct JsVolumeSpec {
-    /// Path on host machine
-    pub host_path: String,
+    /// Scheme-qualified source such as `volume://vol_123`.
+    pub source: Option<String>,
+
+    /// Path on host machine for local host-path mounts.
+    pub host_path: Option<String>,
 
     /// Path inside container
     pub guest_path: String,
@@ -269,13 +272,32 @@ pub struct JsVolumeSpec {
     pub read_only: Option<bool>,
 }
 
-impl From<JsVolumeSpec> for VolumeSpec {
-    fn from(v: JsVolumeSpec) -> Self {
-        VolumeSpec {
-            host_path: v.host_path,
+impl TryFrom<JsVolumeSpec> for VolumeSpec {
+    type Error = boxlite_shared::errors::BoxliteError;
+
+    fn try_from(v: JsVolumeSpec) -> Result<Self, Self::Error> {
+        let host_path = match (v.source, v.host_path) {
+            (Some(source), _) => {
+                if !source.starts_with("volume://") {
+                    return Err(Self::Error::InvalidArgument(
+                        "volume source must use the volume:// scheme".into(),
+                    ));
+                }
+                source
+            }
+            (None, Some(host_path)) => host_path,
+            (None, None) => {
+                return Err(Self::Error::InvalidArgument(
+                    "volume source or hostPath is required".into(),
+                ));
+            }
+        };
+
+        Ok(VolumeSpec {
+            host_path,
             guest_path: v.guest_path,
             read_only: v.read_only.unwrap_or(false),
-        }
+        })
     }
 }
 
@@ -389,8 +411,8 @@ impl TryFrom<JsBoxOptions> for BoxOptions {
             .volumes
             .unwrap_or_default()
             .into_iter()
-            .map(VolumeSpec::from)
-            .collect();
+            .map(VolumeSpec::try_from)
+            .collect::<Result<Vec<_>, _>>()?;
 
         // Convert network spec
         let network = match js_opts.network {
@@ -694,6 +716,41 @@ mod tests {
         for registry in cases {
             assert!(js_image_registry_into_core(registry).is_err());
         }
+    }
+
+    #[test]
+    fn js_volume_source_requires_volume_scheme() {
+        let volume = VolumeSpec::try_from(JsVolumeSpec {
+            source: Some("volume://vol_123".into()),
+            host_path: None,
+            guest_path: "/data".into(),
+            read_only: None,
+        })
+        .unwrap();
+
+        assert_eq!(volume.host_path, "volume://vol_123");
+        assert_eq!(volume.guest_path, "/data");
+        assert!(!volume.read_only);
+
+        let err = VolumeSpec::try_from(JsVolumeSpec {
+            source: Some("vol_123".into()),
+            host_path: None,
+            guest_path: "/data".into(),
+            read_only: None,
+        })
+        .unwrap_err();
+
+        assert!(err.to_string().contains("volume:// scheme"));
+
+        let err = VolumeSpec::try_from(JsVolumeSpec {
+            source: None,
+            host_path: None,
+            guest_path: "/data".into(),
+            read_only: None,
+        })
+        .unwrap_err();
+
+        assert!(err.to_string().contains("source or hostPath is required"));
     }
 
     #[test]

--- a/sdks/node/tests/options.test.ts
+++ b/sdks/node/tests/options.test.ts
@@ -190,6 +190,18 @@ describe("SimpleBoxOptions", () => {
     expect(opts.network?.mode).toBe("disabled");
   });
 
+  test("accepts managed volume source mounts", async () => {
+    const { SimpleBox } = await import("../lib/simplebox.js");
+    const box = new SimpleBox({
+      volumes: [{ source: "volume://vol_123", guestPath: "/data" }],
+    });
+    const nativeOptions = (box as any)._boxOpts;
+
+    expect(nativeOptions.volumes).toEqual([
+      { source: "volume://vol_123", guestPath: "/data" },
+    ]);
+  });
+
   test("accepts secrets", () => {
     const secret: Secret = {
       name: "openai",

--- a/sdks/python/src/options.rs
+++ b/sdks/python/src/options.rs
@@ -638,13 +638,21 @@ impl<'a, 'py> pyo3::FromPyObject<'a, 'py> for PyVolumeSpec {
         }
 
         if let Ok(d) = obj.cast::<PyDict>() {
-            let host: String = if let Ok(Some(v)) = d.get_item("host") {
+            let host: String = if let Ok(Some(v)) = d.get_item("source") {
+                let source: String = v.extract()?;
+                if !source.starts_with("volume://") {
+                    return Err(PyRuntimeError::new_err(
+                        "volume source must use the volume:// scheme",
+                    ));
+                }
+                source
+            } else if let Ok(Some(v)) = d.get_item("host") {
                 v.extract()?
             } else if let Ok(Some(v)) = d.get_item("host_path") {
                 v.extract()?
             } else {
                 return Err(PyRuntimeError::new_err(
-                    "volume dict missing host/host_path",
+                    "volume dict missing source/host/host_path",
                 ));
             };
 
@@ -951,5 +959,30 @@ impl From<PyBoxliteRestOptions> for BoxliteRestOptions {
             opts = opts.with_path_prefix(path_prefix);
         }
         opts
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn py_volume_source_requires_volume_scheme() {
+        Python::attach(|py| {
+            let valid = PyDict::new(py);
+            valid.set_item("source", "volume://vol_123").unwrap();
+            valid.set_item("guest_path", "/data").unwrap();
+
+            let volume = valid.extract::<PyVolumeSpec>().unwrap();
+            assert_eq!(volume.host, "volume://vol_123");
+            assert_eq!(volume.guest, "/data");
+            assert!(!volume.read_only);
+
+            let invalid = PyDict::new(py);
+            invalid.set_item("source", "vol_123").unwrap();
+            invalid.set_item("guest_path", "/data").unwrap();
+
+            let err = invalid.extract::<PyVolumeSpec>().unwrap_err();
+            assert!(err.to_string().contains("volume:// scheme"));
+        });
     }
 }

--- a/src/cli/src/cli.rs
+++ b/src/cli/src/cli.rs
@@ -314,6 +314,14 @@ impl GlobalFlags {
         }
     }
 
+    pub fn resolves_rest_runtime(&self) -> bool {
+        let stored = crate::credentials::load_named(&self.resolved_profile())
+            .ok()
+            .flatten();
+        let env_api_key = std::env::var("BOXLITE_API_KEY").ok();
+        self.resolve_rest_options(stored, env_api_key).is_some()
+    }
+
     /// Build REST connection options from the selected credential profile and
     /// the ambient `BOXLITE_API_KEY`. Returns `None` when no URL is configured
     /// (the caller then falls back to the local runtime). Pure — takes the
@@ -749,6 +757,10 @@ pub struct VolumeFlags {
     /// Mount a volume (format: hostPath:boxPath[:options], or boxPath for anonymous volume, e.g. /data:/app/data, /data:ro)
     #[arg(short = 'v', long = "volume", value_name = "VOLUME")]
     pub volume: Vec<String>,
+
+    /// Mount a source into the box (e.g. src=volume://vol_123,target=/data)
+    #[arg(long = "mount", value_name = "MOUNT")]
+    pub mount: Vec<String>,
 }
 
 /// True if the segment is a single ASCII letter (Windows drive, e.g. "C" in "C:\path").
@@ -920,6 +932,71 @@ impl VolumeFlags {
         }
         Ok(())
     }
+
+    /// Apply managed volume id mounts. These are only meaningful for REST runtimes,
+    /// where the server resolves the id to backing object storage before creating the box.
+    pub fn apply_managed_to(&self, opts: &mut BoxOptions) -> anyhow::Result<()> {
+        for s in self.mount.iter() {
+            let (volume_id, guest_path) = parse_managed_mount_spec(s)?;
+            if volume_id.is_empty() {
+                anyhow::bail!("managed volume id must be non-empty");
+            }
+            if guest_path.is_empty() || !guest_path.starts_with('/') {
+                anyhow::bail!("managed volume box path must be absolute (e.g. vol_123:/data)");
+            }
+            opts.volumes.push(VolumeSpec {
+                host_path: volume_id.to_string(),
+                guest_path: guest_path.to_string(),
+                read_only: false,
+            });
+        }
+        Ok(())
+    }
+
+    pub fn has_managed_volumes(&self) -> bool {
+        !self.mount.is_empty()
+    }
+}
+
+fn parse_managed_mount_spec(s: &str) -> anyhow::Result<(String, String)> {
+    let mut source: Option<String> = None;
+    let mut target: Option<String> = None;
+
+    for part in s.split(',') {
+        let (key, value) = part
+            .split_once('=')
+            .ok_or_else(|| anyhow::anyhow!("mount options must use key=value pairs"))?;
+        let key = key.trim();
+        let value = value.trim();
+        match key {
+            "type" => anyhow::bail!("mount type is inferred from the source scheme"),
+            "src" | "source" => source = Some(value.to_string()),
+            "dst" | "destination" | "target" => target = Some(value.to_string()),
+            "volume" => {
+                anyhow::bail!("use source=volume://<volume_id> instead of the volume= shorthand")
+            }
+            "readonly" | "ro" => {
+                if value.eq_ignore_ascii_case("true") || value == "1" {
+                    anyhow::bail!("managed volume mounts are read-write only for now");
+                }
+            }
+            other => anyhow::bail!("unsupported mount option {other:?}"),
+        }
+    }
+
+    let volume_source = source
+        .ok_or_else(|| anyhow::anyhow!("mount volume source is required (src=volume://vol_123)"))?;
+    let volume_id = normalize_managed_volume_source(&volume_source)?;
+    let guest_path =
+        target.ok_or_else(|| anyhow::anyhow!("mount target is required (target=/data)"))?;
+    Ok((volume_id, guest_path))
+}
+
+fn normalize_managed_volume_source(source: &str) -> anyhow::Result<String> {
+    if let Some(volume_id) = source.strip_prefix("volume://") {
+        return Ok(volume_id.to_string());
+    }
+    anyhow::bail!("managed volume source must use the volume:// scheme")
 }
 
 // ============================================================================
@@ -1632,6 +1709,7 @@ mod tests {
                 "/host/data:/guest/data".to_string(),
                 "/readonly:/ro:ro".to_string(),
             ],
+            mount: vec![],
         };
         let mut opts = BoxOptions::default();
         flags.apply_to(&mut opts, None).unwrap();
@@ -1651,6 +1729,7 @@ mod tests {
                 r"C:\host\data:/guest/data".to_string(),
                 r"D:\readonly:/ro:ro".to_string(),
             ],
+            mount: vec![],
         };
         let mut opts = BoxOptions::default();
         flags.apply_to(&mut opts, None).unwrap();
@@ -1668,6 +1747,7 @@ mod tests {
         let base = std::env::temp_dir();
         let flags = VolumeFlags {
             volume: vec!["/data".to_string(), "/cache:ro".to_string()],
+            mount: vec![],
         };
         let mut opts = BoxOptions::default();
         flags.apply_to(&mut opts, Some(&base)).unwrap();
@@ -1682,6 +1762,143 @@ mod tests {
         assert_eq!(opts.volumes[1].guest_path, "/cache");
         assert!(opts.volumes[1].read_only);
         assert!(opts.volumes[1].host_path.contains("anonymous"));
+    }
+
+    #[test]
+    fn test_volume_flags_managed_volume_rejects_bare_id() {
+        let flags = VolumeFlags {
+            volume: vec![],
+            mount: vec!["src=vol_123,target=/data".to_string()],
+        };
+        let mut opts = BoxOptions::default();
+        let err = flags
+            .apply_managed_to(&mut opts)
+            .expect_err("bare volume ids must use the volume:// scheme");
+
+        assert!(
+            err.to_string().contains("volume:// scheme"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_volume_flags_managed_volume_source_scheme() {
+        let flags = VolumeFlags {
+            volume: vec![],
+            mount: vec!["src=volume://vol_123,target=/data".to_string()],
+        };
+        let mut opts = BoxOptions::default();
+        flags.apply_managed_to(&mut opts).unwrap();
+
+        assert_eq!(opts.volumes[0].host_path, "vol_123");
+        assert_eq!(opts.volumes[0].guest_path, "/data");
+    }
+
+    #[test]
+    fn test_volume_flags_managed_volume_rejects_host_scheme() {
+        let flags = VolumeFlags {
+            volume: vec![],
+            mount: vec!["src=host:///tmp/data,target=/data".to_string()],
+        };
+        let mut opts = BoxOptions::default();
+        let err = flags
+            .apply_managed_to(&mut opts)
+            .expect_err("host scheme must be rejected for managed volume mounts");
+
+        assert!(
+            err.to_string().contains("volume:// scheme"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_volume_flags_managed_volume_rejects_missing_id() {
+        let flags = VolumeFlags {
+            volume: vec![],
+            // Must carry the `volume://` prefix so parsing reaches the
+            // empty-id check (`apply_managed_to`) instead of failing earlier
+            // at the scheme check (`normalize_managed_volume_source`).
+            mount: vec!["src=volume://,target=/data".to_string()],
+        };
+        let mut opts = BoxOptions::default();
+        let err = flags
+            .apply_managed_to(&mut opts)
+            .expect_err("managed volume id must be rejected when empty");
+
+        assert!(
+            err.to_string().contains("id must be non-empty"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_volume_flags_managed_volume_rejects_relative_box_path() {
+        let flags = VolumeFlags {
+            volume: vec![],
+            mount: vec!["src=volume://vol_123,target=data".to_string()],
+        };
+        let mut opts = BoxOptions::default();
+        let err = flags
+            .apply_managed_to(&mut opts)
+            .expect_err("managed volume guest path must be absolute");
+
+        assert!(
+            err.to_string().contains("box path must be absolute"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_volume_flags_managed_volume_rejects_shorthand() {
+        let flags = VolumeFlags {
+            volume: vec![],
+            mount: vec!["volume=vol_123,target=/data".to_string()],
+        };
+        let mut opts = BoxOptions::default();
+        let err = flags
+            .apply_managed_to(&mut opts)
+            .expect_err("volume= shorthand must be rejected");
+
+        assert!(
+            err.to_string().contains("source=volume://"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_volume_flags_managed_volume_rejects_type_option() {
+        let flags = VolumeFlags {
+            volume: vec![],
+            mount: vec!["type=volume,src=volume://vol_123,target=/data".to_string()],
+        };
+        let mut opts = BoxOptions::default();
+        let err = flags
+            .apply_managed_to(&mut opts)
+            .expect_err("mount type option must be inferred from source scheme");
+
+        assert!(
+            err.to_string()
+                .contains("type is inferred from the source scheme"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_run_parses_managed_mount_flag() {
+        let cli = Cli::try_parse_from([
+            "boxlite",
+            "run",
+            "--mount",
+            "src=volume://vol_123,target=/data",
+            "alpine",
+        ])
+        .expect("run --mount should parse");
+        let Commands::Run(args) = cli.command else {
+            panic!("expected run command");
+        };
+
+        assert_eq!(args.volume.mount, vec!["src=volume://vol_123,target=/data"]);
+        assert!(args.volume.volume.is_empty());
     }
 
     // ─── auth subcommand parse tests ───────────────────────────────────────

--- a/src/cli/src/commands/create.rs
+++ b/src/cli/src/commands/create.rs
@@ -78,6 +78,10 @@ impl CreateArgs {
         self.management.apply_to(&mut options)?;
         self.publish.apply_to(&mut options)?;
         self.volume.apply_to(&mut options, global.home.as_deref())?;
+        if self.volume.has_managed_volumes() && !global.resolves_rest_runtime() {
+            anyhow::bail!("managed volume mounts require a REST runtime");
+        }
+        self.volume.apply_managed_to(&mut options)?;
         self.network.apply_to(&mut options)?;
 
         // A `create`d box is a background box: `create` then `start`/`exec` runs

--- a/src/cli/src/commands/run.rs
+++ b/src/cli/src/commands/run.rs
@@ -55,6 +55,9 @@ pub async fn execute(args: RunArgs, global: &GlobalFlags) -> anyhow::Result<i32>
     args.boot.require_enabled(global.experimental_features())?;
     args.management
         .require_enabled(global.experimental_features())?;
+    if args.volume.has_managed_volumes() && !global.resolves_rest_runtime() {
+        anyhow::bail!("managed volume mounts require a REST runtime");
+    }
     let (rootfs, command_args) = args.rootfs_and_command()?;
     let command_args = command_args.to_vec();
     let mut runner = BoxRunner::new(args, global)?;
@@ -137,6 +140,7 @@ impl BoxRunner {
         self.args
             .volume
             .apply_to(&mut options, self.home.as_deref())?;
+        self.args.volume.apply_managed_to(&mut options)?;
         self.args.network.apply_to(&mut options)?;
         self.args.process.apply_to(&mut options)?;
 


### PR DESCRIPTION
~~Expose existing S3 managed volumes through the BoxLite REST API and carry volume mounts into REST-created boxes.~~

**Rebuilt on top of main** now that this PR's backend content has been split out and merged separately:
- #1191 — volume REST CRUD (`/v1/volumes` create/list/get/delete)
- #1192 — REST box-create volume mount wiring (`VolumeSpec.source`)
- (follow-up, still open) #1196 — makes `create` return immediately instead of blocking, adds client-side `wait_until_ready`

What's left here is the remaining, still-unmerged piece: **CLI + Node/Python SDK support for attaching a managed volume to a box**, on top of the server-side contract #1191/#1192 already shipped.

- CLI: `--mount src=volume://<id>,target=<path>` on `create`/`run`
- Node/Python SDKs: accept a scheme-qualified volume source (`volume://<id>`) alongside the existing host-path volume option

Test plan:
- `cargo build -p boxlite-cli` / `cargo test -p boxlite-cli --bin boxlite volume` — 30 tests, all pass
- `cargo check -p boxlite-node` / `cargo check -p boxlite-python` — clean
- `cargo fmt --all -- --check` — clean
- Fixed a pre-existing test bug found during verification: `test_volume_flags_managed_volume_rejects_missing_id`'s fixture never reached the code path it meant to exercise (see commit message for detail)