### PR TITLE
fix(cli): render table correctly when box list is empty

### DIFF
--- a/src/cli/src/formatter.rs
+++ b/src/cli/src/formatter.rs
@@ -236,8 +236,16 @@ where
 
 /// Create a standard table with Boxlite styling.
 pub fn create_table<T: Tabled>(data: impl IntoIterator<Item = T>) -> Table {
-    let mut table = Table::new(data);
-    table.with(Style::sharp());
+    let mut rows = data.into_iter().peekable();
+    let is_empty = rows.peek().is_none();
+    let mut table = Table::new(rows);
+
+    if is_empty {
+        table.with(Style::sharp().remove_horizontals());
+    } else {
+        table.with(Style::sharp());
+    }
+
     table
 }
 
@@ -251,6 +259,28 @@ mod tests {
     struct TestData {
         name: String,
         value: i32,
+    }
+
+    #[derive(Tabled)]
+    struct TestRow {
+        #[tabled(rename = "NAME")]
+        name: String,
+        #[tabled(rename = "VALUE")]
+        value: i32,
+    }
+
+    #[test]
+    fn test_create_table_closes_empty_table() {
+        let rows: Vec<TestRow> = Vec::new();
+
+        assert_eq!(
+            create_table(rows).to_string(),
+            concat!(
+                "┌──────┬───────┐\n",
+                "│ NAME │ VALUE │\n",
+                "└──────┴───────┘"
+            )
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fix empty-table rendering in the shared `formatter::create_table` so CLI commands display a complete bottom border when there are no data rows.

This closes https://github.com/boxlite-ai/boxlite/issues/1057

## Changes

* Apply the table style conditionally when the table contains only headers.
* Fix empty-table output for all commands using the shared formatter, including `list`, `images`, `volume ls`, and `stats`.
* Add regression coverage for the empty-table case.

## How to verify

* Run a table-based command with no matching data, for example:

```bash
./target/debug/boxlite list -a
```

* Verify the table ends with a bottom border (`└...┘`) instead of a header separator (`├...┤`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the visual rendering of empty tables in the CLI.
  * Empty tables now display with a cleaner, closed layout while populated tables retain their existing formatting.
* **Tests**
  * Added coverage to verify the expected rendering of empty tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->