### PR TITLE
feat(api): add org-scoped box images

### DIFF
--- a/apps/api/src/box/box.module.ts
+++ b/apps/api/src/box/box.module.ts
@@ -49,13 +49,15 @@ import { EventEmitter2 } from '@nestjs/event-emitter'
 import { BoxLastActivity } from './entities/box-last-activity.entity'
 import { BoxActivityService } from './services/box-activity.service'
 import { BoxStateWaiterService } from './services/box-state-waiter.service'
+import { OrgBoxImage } from './entities/org-box-image.entity'
+import { OrgBoxImageService } from './services/org-box-image.service'
 
 @Module({
   imports: [
     UserModule,
     OrganizationModule,
     RegionModule,
-    TypeOrmModule.forFeature([Box, Runner, WarmPool, Volume, SshAccess, Region, Job, BoxLastActivity]),
+    TypeOrmModule.forFeature([Box, Runner, WarmPool, Volume, SshAccess, Region, Job, BoxLastActivity, OrgBoxImage]),
   ],
   controllers: [BoxController, RunnerController, PreviewController, VolumeController, JobController],
   providers: [
@@ -77,6 +79,7 @@ import { BoxStateWaiterService } from './services/box-state-waiter.service'
     JobStateHandlerService,
     BoxActivityService,
     BoxStateWaiterService,
+    OrgBoxImageService,
     BoxAccessGuard,
     RunnerAccessGuard,
     RegionRunnerAccessGuard,
@@ -103,6 +106,7 @@ import { BoxStateWaiterService } from './services/box-state-waiter.service'
     RunnerAdapterFactory,
     BoxActivityService,
     BoxStateWaiterService,
+    OrgBoxImageService,
   ],
 })
 export class BoxModule {}

--- a/apps/api/src/box/controllers/box.controller.ts
+++ b/apps/api/src/box/controllers/box.controller.ts
@@ -67,6 +67,8 @@ import { InjectRedis } from '@nestjs-modules/ioredis'
 import { Redis } from 'ioredis'
 import { BOX_EVENT_CHANNEL } from '../../common/constants/constants'
 import { RegionBoxAccessGuard } from '../guards/region-box-access.guard'
+import { CreateOrgBoxImageDto, BoxImageDto } from '../dto/org-box-image.dto'
+import { OrgBoxImageService } from '../services/org-box-image.service'
 
 @ApiTags('box')
 @Controller('box')
@@ -81,6 +83,7 @@ export class BoxController {
   constructor(
     private readonly runnerService: RunnerService,
     private readonly boxService: BoxService,
+    private readonly orgBoxImageService: OrgBoxImageService,
     @InjectRedis() private readonly redis: Redis,
   ) {
     this.redisSubscriber = this.redis.duplicate()
@@ -251,6 +254,41 @@ export class BoxController {
     const boxes = await this.boxService.findByRunnerId(runnerContext.runnerId, stateArray, skip)
 
     return this.boxService.toBoxDtos(boxes)
+  }
+
+  @Get('supported-images')
+  @ApiOperation({
+    summary: 'List box images available to the current organization',
+    operationId: 'listSupportedBoxImages',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'System images plus organization-scoped images',
+    type: [BoxImageDto],
+  })
+  async listSupportedBoxImages(@AuthContext() authContext: OrganizationAuthContext): Promise<BoxImageDto[]> {
+    return await this.orgBoxImageService.listAvailable(authContext.organizationId)
+  }
+
+  @Post('org-images')
+  @HttpCode(200)
+  @UseInterceptors(ContentTypeInterceptor)
+  @ApiOperation({
+    summary: 'Register a box image for the current organization',
+    operationId: 'createOrgBoxImage',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'The organization image has been registered.',
+    type: BoxImageDto,
+  })
+  @RequiredOrganizationResourcePermissions([OrganizationResourcePermission.WRITE_BOXES])
+  async createOrgBoxImage(
+    @AuthContext() authContext: OrganizationAuthContext,
+    @Body() dto: CreateOrgBoxImageDto,
+  ): Promise<BoxImageDto> {
+    const image = await this.orgBoxImageService.create(authContext.organizationId, dto, authContext.userId)
+    return BoxImageDto.fromOrgImage(image)
   }
 
   @Get(':boxIdOrName')

--- a/apps/api/src/box/dto/org-box-image.dto.ts
+++ b/apps/api/src/box/dto/org-box-image.dto.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { ApiProperty } from '@nestjs/swagger'
+import { IsString, Matches, MaxLength, MinLength } from 'class-validator'
+import { OrgBoxImage } from '../entities/org-box-image.entity'
+import { OrgBoxImageStatus } from '../enums/org-box-image-status.enum'
+
+export class CreateOrgBoxImageDto {
+  @ApiProperty({
+    description: 'Short image selector unique within the organization',
+    example: 'hermes',
+  })
+  @IsString()
+  @MinLength(1)
+  @MaxLength(64)
+  @Matches(/^[a-z0-9][a-z0-9._-]*$/)
+  name: string
+
+  @ApiProperty({
+    description: 'OCI image reference to allow for this organization',
+    example: 'sam2026go/hermes-agent:boxlite',
+  })
+  @IsString()
+  @MinLength(1)
+  @MaxLength(512)
+  ref: string
+}
+
+export class BoxImageDto {
+  @ApiProperty({ example: 'hermes' })
+  name: string
+
+  @ApiProperty({ example: 'sam2026go/hermes-agent:boxlite' })
+  ref: string
+
+  @ApiProperty({ enum: ['system', 'organization'] })
+  source: 'system' | 'organization'
+
+  @ApiProperty({ enum: OrgBoxImageStatus, required: false })
+  status?: OrgBoxImageStatus
+
+  static fromOrgImage(image: OrgBoxImage): BoxImageDto {
+    return {
+      name: image.name,
+      ref: image.ref,
+      source: 'organization',
+      status: image.status,
+    }
+  }
+}

--- a/apps/api/src/box/entities/org-box-image.entity.ts
+++ b/apps/api/src/box/entities/org-box-image.entity.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn, Unique, UpdateDateColumn } from 'typeorm'
+import { OrgBoxImageStatus } from '../enums/org-box-image-status.enum'
+
+@Entity('org_box_image')
+@Unique(['organizationId', 'name'])
+@Unique(['organizationId', 'ref'])
+@Index('org_box_image_organizationid_idx', ['organizationId'])
+@Index('org_box_image_status_idx', ['status'])
+export class OrgBoxImage {
+  @PrimaryGeneratedColumn('uuid')
+  id: string
+
+  @Column({ type: 'uuid' })
+  organizationId: string
+
+  @Column()
+  name: string
+
+  @Column()
+  ref: string
+
+  @Column({
+    type: 'enum',
+    enum: OrgBoxImageStatus,
+    default: OrgBoxImageStatus.ACTIVE,
+  })
+  status = OrgBoxImageStatus.ACTIVE
+
+  @Column({ nullable: true })
+  createdBy?: string
+
+  @CreateDateColumn({ type: 'timestamp with time zone' })
+  createdAt: Date
+
+  @UpdateDateColumn({ type: 'timestamp with time zone' })
+  updatedAt: Date
+}

--- a/apps/api/src/box/enums/org-box-image-status.enum.ts
+++ b/apps/api/src/box/enums/org-box-image-status.enum.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+export enum OrgBoxImageStatus {
+  ACTIVE = 'active',
+  BLOCKED = 'blocked',
+  DELETED = 'deleted',
+}

--- a/apps/api/src/box/services/box.service.spec.ts
+++ b/apps/api/src/box/services/box.service.spec.ts
@@ -51,6 +51,7 @@ function makeService() {
     noop, // regionService
     noop, // boxLookupCacheInvalidationService
     noop, // boxActivityService
+    noop, // orgBoxImageService
   )
   return { service, boxRepository, eventEmitter, organizationService, organizationUsageService }
 }
@@ -93,6 +94,7 @@ function makePreviewUrlService() {
     regionService, // regionService
     noop, // boxLookupCacheInvalidationService
     noop, // boxActivityService
+    noop, // orgBoxImageService
   )
   jest.spyOn(service, 'findOneByIdOrName').mockResolvedValue({
     id: 'MixedCaseBox',
@@ -269,6 +271,7 @@ function makeNetworkTunnelService() {
     regionService,
     noop,
     noop,
+    noop,
   )
   jest.spyOn(service, 'findOneByIdOrName').mockResolvedValue({
     id: 'MixedCaseBox',
@@ -301,6 +304,7 @@ describe('BoxService public defaults', () => {
       },
       redis: { exists: jest.fn().mockResolvedValue(1) },
       runnerService: { getRandomAvailableRunner: jest.fn().mockResolvedValue({ id: 'runner-1' }) },
+      orgBoxImageService: { resolveImage: jest.fn().mockResolvedValue('base-ref') },
       boxRepository,
       eventEmitter: { emitAsync: jest.fn().mockResolvedValue(undefined) },
       toBoxDto: jest.fn((box) => box),

--- a/apps/api/src/box/services/box.service.ts
+++ b/apps/api/src/box/services/box.service.ts
@@ -18,7 +18,6 @@ import { BoxError } from '../../exceptions/box-error.exception'
 import { BadRequestError } from '../../exceptions/bad-request.exception'
 import { Cron, CronExpression } from '@nestjs/schedule'
 import { BOX_WARM_POOL_UNASSIGNED_ORGANIZATION } from '../constants/box.constants'
-import { assertSupportedImage } from '../constants/curated-images.constant'
 import { BoxWarmPoolService } from './box-warm-pool.service'
 import { EventEmitter2, OnEvent } from '@nestjs/event-emitter'
 import { WarmPoolEvents } from '../constants/warmpool-events.constants'
@@ -76,6 +75,7 @@ import { BoxLookupCacheInvalidationService } from './box-lookup-cache-invalidati
 import { Region } from '../../region/entities/region.entity'
 import { BoxActivityService } from './box-activity.service'
 import { assertWithinPerBoxLimits } from './per-box-limits'
+import { OrgBoxImageService } from './org-box-image.service'
 import {
   AUTO_DELETE_DISABLED,
   AUTO_PAUSE_DISABLED,
@@ -114,6 +114,7 @@ export class BoxService {
     private readonly regionService: RegionService,
     private readonly boxLookupCacheInvalidationService: BoxLookupCacheInvalidationService,
     private readonly boxActivityService: BoxActivityService,
+    private readonly orgBoxImageService: OrgBoxImageService,
   ) {}
 
   protected getLockKey(id: string): string {
@@ -175,9 +176,9 @@ export class BoxService {
       // Reject over-limit requests at the boundary (the "security option"
       // per-box ceilings) rather than persisting out-of-range values.
       assertWithinPerBoxLimits(cpu, mem, disk, organization)
-      // Restrict box creation to the supported pinned images; reject anything else
-      // at the request boundary (defaults undefined -> base image).
-      const image = assertSupportedImage(createBoxDto.image)
+      // Restrict box creation to system images or images registered to this org.
+      // Undefined defaults to the system base image.
+      const image = await this.orgBoxImageService.resolveImage(organization.id, createBoxDto.image)
 
       this.organizationService.assertOrganizationIsNotSuspended(organization)
 

--- a/apps/api/src/box/services/org-box-image.service.spec.ts
+++ b/apps/api/src/box/services/org-box-image.service.spec.ts
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { BadRequestError } from '../../exceptions/bad-request.exception'
+import { OrgBoxImageStatus } from '../enums/org-box-image-status.enum'
+import { OrgBoxImageService } from './org-box-image.service'
+
+const BASE_REF = 'ghcr.io/boxlite-ai/boxlite-agent-base:20260605-p0-r3'
+
+describe('OrgBoxImageService', () => {
+  const ENV_KEYS = [
+    'BOXLITE_SYSTEM_BASE_IMAGE',
+    'BOXLITE_SYSTEM_PYTHON_IMAGE',
+    'BOXLITE_SYSTEM_NODE_IMAGE',
+    'BOXLITE_SYSTEM_IMAGES',
+  ]
+  const saved: Record<string, string | undefined> = {}
+  let repo: {
+    create: jest.Mock
+    save: jest.Mock
+    find: jest.Mock
+    findOne: jest.Mock
+  }
+  let service: OrgBoxImageService
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) {
+      saved[k] = process.env[k]
+      delete process.env[k]
+    }
+
+    repo = {
+      create: jest.fn((value) => value),
+      save: jest.fn(async (value) => ({ id: 'img_1', ...value })),
+      find: jest.fn(async () => []),
+      findOne: jest.fn(async () => null),
+    }
+    service = new OrgBoxImageService(repo as any)
+  })
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k]
+      else process.env[k] = saved[k]
+    }
+  })
+
+  it('defaults to the system base image', async () => {
+    await expect(service.resolveImage('org_1', undefined)).resolves.toBe(BASE_REF)
+    expect(repo.findOne).not.toHaveBeenCalled()
+  })
+
+  it('resolves system images before querying organization images', async () => {
+    await expect(service.resolveImage('org_1', 'base')).resolves.toBe(BASE_REF)
+    expect(repo.findOne).not.toHaveBeenCalled()
+  })
+
+  it('resolves active organization images by name or ref within the organization', async () => {
+    repo.findOne.mockResolvedValueOnce({
+      organizationId: 'org_1',
+      name: 'hermes',
+      ref: 'sam2026go/hermes-agent:boxlite',
+      status: OrgBoxImageStatus.ACTIVE,
+    })
+
+    await expect(service.resolveImage('org_1', 'hermes')).resolves.toBe('sam2026go/hermes-agent:boxlite')
+    expect(repo.findOne).toHaveBeenCalledWith({
+      where: [
+        { organizationId: 'org_1', status: OrgBoxImageStatus.ACTIVE, name: 'hermes' },
+        { organizationId: 'org_1', status: OrgBoxImageStatus.ACTIVE, ref: 'hermes' },
+      ],
+    })
+  })
+
+  it('does not resolve another organization image with the same selector', async () => {
+    repo.findOne.mockImplementation(async ({ where }) => {
+      const scopedName = where[0]
+      if (scopedName.organizationId === 'org_2' && scopedName.name === 'hermes') {
+        return {
+          organizationId: 'org_2',
+          name: 'hermes',
+          ref: 'sam2026go/hermes-agent:boxlite',
+          status: OrgBoxImageStatus.ACTIVE,
+        }
+      }
+      return null
+    })
+    repo.find.mockResolvedValueOnce([])
+
+    await expect(service.resolveImage('org_1', 'hermes')).rejects.toThrow(BadRequestError)
+    await expect(service.resolveImage('org_2', 'hermes')).resolves.toBe('sam2026go/hermes-agent:boxlite')
+  })
+
+  it('rejects images outside the system and organization scopes', async () => {
+    repo.find.mockResolvedValueOnce([])
+    await expect(service.resolveImage('org_1', 'alpine:3.23')).rejects.toThrow(BadRequestError)
+  })
+
+  it('lists system images before organization images', async () => {
+    repo.find.mockResolvedValueOnce([
+      {
+        name: 'hermes',
+        ref: 'sam2026go/hermes-agent:boxlite',
+        status: OrgBoxImageStatus.ACTIVE,
+      },
+    ])
+
+    await expect(service.listAvailable('org_1')).resolves.toEqual(
+      expect.arrayContaining([
+        { name: 'base', ref: BASE_REF, source: 'system' },
+        {
+          name: 'hermes',
+          ref: 'sam2026go/hermes-agent:boxlite',
+          source: 'organization',
+          status: OrgBoxImageStatus.ACTIVE,
+        },
+      ]),
+    )
+  })
+
+  it('validates refs when registering an organization image', async () => {
+    await expect(service.create('org_1', { name: 'bad', ref: 'https://example.com/image' }, 'user_1')).rejects.toThrow(
+      BadRequestError,
+    )
+
+    await service.create('org_1', { name: 'hermes', ref: 'sam2026go/hermes-agent:boxlite' }, 'user_1')
+    expect(repo.create).toHaveBeenCalledWith({
+      organizationId: 'org_1',
+      name: 'hermes',
+      ref: 'sam2026go/hermes-agent:boxlite',
+      status: OrgBoxImageStatus.ACTIVE,
+      createdBy: 'user_1',
+    })
+  })
+})

--- a/apps/api/src/box/services/org-box-image.service.ts
+++ b/apps/api/src/box/services/org-box-image.service.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Injectable } from '@nestjs/common'
+import { InjectRepository } from '@nestjs/typeorm'
+import { Repository } from 'typeorm'
+import { BadRequestError } from '../../exceptions/bad-request.exception'
+import { supportedImages } from '../constants/curated-images.constant'
+import { CreateOrgBoxImageDto, BoxImageDto } from '../dto/org-box-image.dto'
+import { OrgBoxImage } from '../entities/org-box-image.entity'
+import { OrgBoxImageStatus } from '../enums/org-box-image-status.enum'
+
+@Injectable()
+export class OrgBoxImageService {
+  constructor(
+    @InjectRepository(OrgBoxImage)
+    private readonly orgBoxImageRepository: Repository<OrgBoxImage>,
+  ) {}
+
+  async create(organizationId: string, dto: CreateOrgBoxImageDto, userId?: string): Promise<OrgBoxImage> {
+    this.assertImageRef(dto.ref)
+
+    const image = this.orgBoxImageRepository.create({
+      organizationId,
+      name: dto.name,
+      ref: dto.ref,
+      status: OrgBoxImageStatus.ACTIVE,
+      createdBy: userId,
+    })
+    return await this.orgBoxImageRepository.save(image)
+  }
+
+  async listAvailable(organizationId: string): Promise<BoxImageDto[]> {
+    const orgImages = await this.orgBoxImageRepository.find({
+      where: { organizationId, status: OrgBoxImageStatus.ACTIVE },
+      order: { createdAt: 'ASC' },
+    })
+
+    return [
+      ...supportedImages().map((image) => ({ ...image, source: 'system' as const })),
+      ...orgImages.map(BoxImageDto.fromOrgImage),
+    ]
+  }
+
+  async resolveImage(organizationId: string, image: string | undefined): Promise<string> {
+    const systemImages = supportedImages()
+
+    if (image === undefined) {
+      return systemImages[0].ref
+    }
+
+    const systemMatch = systemImages.find(({ name, ref }) => image === name || image === ref)
+    if (systemMatch) {
+      return systemMatch.ref
+    }
+
+    const orgMatch = await this.orgBoxImageRepository.findOne({
+      where: [
+        { organizationId, status: OrgBoxImageStatus.ACTIVE, name: image },
+        { organizationId, status: OrgBoxImageStatus.ACTIVE, ref: image },
+      ],
+    })
+    if (orgMatch) {
+      return orgMatch.ref
+    }
+
+    const options = (await this.listAvailable(organizationId)).map(({ name, ref }) => `${name} (${ref})`).join(', ')
+    throw new BadRequestError(`Unsupported image '${image}'. Supported images: ${options}`)
+  }
+
+  private assertImageRef(ref: string): void {
+    if (/^\s|\s$|\s/.test(ref)) {
+      throw new BadRequestError('Image ref must not contain whitespace')
+    }
+    if (ref.includes('://')) {
+      throw new BadRequestError('Image ref must be an OCI image reference, not a URL')
+    }
+  }
+}

--- a/apps/api/src/migrations/pre-deploy/1785143000000-add-org-box-images-migration.ts
+++ b/apps/api/src/migrations/pre-deploy/1785143000000-add-org-box-images-migration.ts
@@ -1,0 +1,34 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddOrgBoxImages1785143000000 implements MigrationInterface {
+  name = 'AddOrgBoxImages1785143000000'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`CREATE TYPE "public"."org_box_image_status_enum" AS ENUM('active', 'blocked', 'deleted')`)
+    await queryRunner.query(
+      `CREATE TABLE "org_box_image" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "organizationId" uuid NOT NULL,
+        "name" character varying NOT NULL,
+        "ref" character varying NOT NULL,
+        "status" "public"."org_box_image_status_enum" NOT NULL DEFAULT 'active',
+        "createdBy" character varying,
+        "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        CONSTRAINT "org_box_image_organizationId_name_key" UNIQUE ("organizationId", "name"),
+        CONSTRAINT "org_box_image_organizationId_ref_key" UNIQUE ("organizationId", "ref"),
+        CONSTRAINT "org_box_image_pk" PRIMARY KEY ("id"),
+        CONSTRAINT "org_box_image_organizationId_fk" FOREIGN KEY ("organizationId") REFERENCES "organization"("id") ON DELETE CASCADE ON UPDATE NO ACTION
+      )`,
+    )
+    await queryRunner.query(`CREATE INDEX "org_box_image_organizationid_idx" ON "org_box_image" ("organizationId")`)
+    await queryRunner.query(`CREATE INDEX "org_box_image_status_idx" ON "org_box_image" ("status")`)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "public"."org_box_image_status_idx"`)
+    await queryRunner.query(`DROP INDEX "public"."org_box_image_organizationid_idx"`)
+    await queryRunner.query(`DROP TABLE "org_box_image"`)
+    await queryRunner.query(`DROP TYPE "public"."org_box_image_status_enum"`)
+  }
+}


### PR DESCRIPTION
Add organization-scoped box image registration and resolution on top of the existing system image allowlist.

Test plan:
- [x] cd apps && ./node_modules/.bin/jest --config api/jest.config.ts api/src/box/services/org-box-image.service.spec.ts api/src/box/constants/curated-images.constant.spec.ts api/src/box/services/box.service.spec.ts --runInBand
- [x] cd apps && ./node_modules/.bin/tsc --noEmit -p api/tsconfig.app.json
- [x] cd apps && ./node_modules/.bin/eslint api/src/box/box.module.ts api/src/box/controllers/box.controller.ts api/src/box/services/box.service.ts api/src/box/services/box.service.spec.ts api/src/box/dto/org-box-image.dto.ts api/src/box/entities/org-box-image.entity.ts api/src/box/enums/org-box-image-status.enum.ts api/src/box/services/org-box-image.service.ts api/src/box/services/org-box-image.service.spec.ts api/src/migrations/pre-deploy/1785143000000-add-org-box-images-migration.ts
