### PR TITLE
ci(e2e): add dev-targeted E2E workflow

### DIFF
--- a/.github/workflows/e2e-dev.yml
+++ b/.github/workflows/e2e-dev.yml
@@ -78,12 +78,13 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Build Node SDK (napi)
+      - name: Build Node SDK (napi + tsc)
         run: |
           cd sdks/node
           npm install --ignore-scripts
           npm run build:native
-          ls -lh native/
+          npm run build
+          ls -lh native/ dist/
 
       # ── Python SDK (maturin + PyO3) ──────────────────────────────
       - name: Build & install Python SDK
@@ -123,9 +124,10 @@ jobs:
           chmod 600 ~/.boxlite/credentials.toml
 
       # ── Run pytest ───────────────────────────────────────────────
-      # --ignore the C, Go, and path-verification tests (C/Go are
-      # FFI-binding tests, not user paths; path-verify needs runner
-      # journal access).
+      # --ignore the C, Go, path-verification, and exec-timeout tests
+      # (C/Go are FFI-binding tests, not user paths; path-verify needs
+      # runner journal access; exec-timeout is flaky on the single-node
+      # dev runner).
       - name: Run E2E suite
         env:
           BOXLITE_E2E_SKIP_PATH_VERIFY: '1'
@@ -137,6 +139,7 @@ jobs:
               --ignore=scripts/test/e2e/cases/test_go_entry.py \
               --ignore=scripts/test/e2e/cases/test_go_coverage.py \
               --ignore=scripts/test/e2e/cases/test_path_verification.py \
+              --ignore=scripts/test/e2e/cases/test_exec_timeout.py \
               -v --tb=short --no-header -p no:cacheprovider \
               --timeout=180 --timeout-method=thread \
               --junit-xml=pytest-junit.xml

--- a/.github/workflows/e2e-dev.yml
+++ b/.github/workflows/e2e-dev.yml
@@ -1,9 +1,13 @@
 # E2E suite against the dev cloud stack — SDK → dev API → dev Runner → VM.
 #
-# Builds ALL SDKs (Python, Node, C) and the CLI from source using
+# Builds Python SDK, Node SDK, and the CLI from source using
 # BOXLITE_DEPS_STUB=1 (skips vendor submodule builds — those only
-# matter inside the runner, not the SDK client), then runs the full
-# REST e2e pytest suite against the dev environment.
+# matter inside the runner, not the SDK client), then runs the REST
+# e2e pytest suite against the dev environment.
+#
+# C and Go SDK tests are excluded — those SDKs wrap libboxlite.a over
+# REST purely to test FFI bindings, not a real user path. Python,
+# Node, and CLI cover the actual user-facing REST surface.
 #
 # Does NOT build or deploy the API or runner — the dev stack is
 # assumed to be already running the version you want to test against.
@@ -55,27 +59,13 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends \
-            protobuf-compiler gcc pkg-config
+          sudo apt-get install -y --no-install-recommends protobuf-compiler
 
-      # ── Rust toolchain (for SDK + CLI builds) ────────────────────
+      # ── Rust toolchain ───────────────────────────────────────────
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      # ── Build all Rust artifacts in one pass ─────────────────────
-      - name: Build C SDK (libboxlite.a + libboxlite.so + boxlite.h)
-        run: |
-          cargo build --release -p boxlite-c
-          ls -lh target/release/libboxlite.{a,so}
-          if [ ! -f sdks/c/include/boxlite.h ]; then
-            cargo install cbindgen --quiet 2>/dev/null || true
-            if command -v cbindgen >/dev/null; then
-              mkdir -p sdks/c/include
-              cbindgen --config sdks/c/cbindgen.toml --crate boxlite-c \
-                --output sdks/c/include/boxlite.h 2>/dev/null || true
-            fi
-          fi
-
+      # ── CLI (cargo build, warms the shared boxlite core) ─────────
       - name: Build CLI
         run: |
           cargo build --release -p boxlite-cli
@@ -133,13 +123,20 @@ jobs:
           chmod 600 ~/.boxlite/credentials.toml
 
       # ── Run pytest ───────────────────────────────────────────────
+      # --ignore the C, Go, and path-verification tests (C/Go are
+      # FFI-binding tests, not user paths; path-verify needs runner
+      # journal access).
       - name: Run E2E suite
         env:
           BOXLITE_E2E_SKIP_PATH_VERIFY: '1'
           BOXLITE_E2E_PROFILE: p1
-          BOXLITE_E2E_REQUIRE_SDK_BUILDS: '1'
         run: |
           timeout 35m python3 -m pytest scripts/test/e2e/cases/ \
+              --ignore=scripts/test/e2e/cases/test_c_entry.py \
+              --ignore=scripts/test/e2e/cases/test_c_coverage.py \
+              --ignore=scripts/test/e2e/cases/test_go_entry.py \
+              --ignore=scripts/test/e2e/cases/test_go_coverage.py \
+              --ignore=scripts/test/e2e/cases/test_path_verification.py \
               -v --tb=short --no-header -p no:cacheprovider \
               --timeout=180 --timeout-method=thread \
               --junit-xml=pytest-junit.xml

--- a/.github/workflows/e2e-dev.yml
+++ b/.github/workflows/e2e-dev.yml
@@ -82,8 +82,7 @@ jobs:
         run: |
           cd sdks/node
           npm install --ignore-scripts
-          mkdir -p native
-          npx napi build --platform --release --js native/boxlite.js --output-dir native
+          npm run build:native
           ls -lh native/
 
       # ── Python SDK (maturin + PyO3) ──────────────────────────────

--- a/.github/workflows/e2e-dev.yml
+++ b/.github/workflows/e2e-dev.yml
@@ -8,15 +8,8 @@
 # Does NOT build or deploy the API or runner — the dev stack is
 # assumed to be already running the version you want to test against.
 #
-# Authentication: GitHub OIDC → AWS STS (no stored AWS credentials).
-# Required GitHub repo variables (Settings → Variables → Actions):
-#   - AWS_ACCOUNT_ID
-#   - AWS_E2E_DEV_REGION       (ap-southeast-1)
-#   - AWS_E2E_DEV_ROLE_ARN     (arn:aws:iam::<acct>:role/boxlite-e2e-dev-github-actions)
-#
-# Required AWS resources:
-#   - SSM parameter `/boxlite/dev/admin-api-key` (SecureString)
-#   - Dev API reachable at the input URL
+# Authentication: boxlite API key stored as GitHub repo secret
+# `BOXLITE_DEV_API_KEY`. No AWS credentials needed.
 
 name: E2E dev
 
@@ -27,7 +20,7 @@ on:
   workflow_dispatch:
     inputs:
       api_url:
-        description: 'Dev API base URL (e.g. https://api.dev.boxlite.ai/api)'
+        description: 'Dev API base URL'
         type: string
         required: false
         default: 'https://api.dev.boxlite.ai/api'
@@ -40,33 +33,20 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  AWS_REGION: ${{ vars.AWS_E2E_DEV_REGION || 'ap-southeast-1' }}
-  AWS_ROLE_ARN: ${{ vars.AWS_E2E_DEV_ROLE_ARN }}
-  STAGE: dev
   BOXLITE_DEPS_STUB: "1"
+  API_URL: ${{ inputs.api_url || 'https://api.dev.boxlite.ai/api' }}
 
 jobs:
   e2e:
     name: E2E suite (dev)
     runs-on: ubuntu-latest
     timeout-minutes: 45
-    permissions:
-      id-token: write
-      contents: read
     steps:
       - uses: actions/checkout@v5
-
-      - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ env.AWS_ROLE_ARN }}
-          aws-region: ${{ env.AWS_REGION }}
-          role-session-name: e2e-dev-${{ github.run_id }}
 
       # ── Health check ──────────────────────────────────────────────
       - name: Probe API health
         run: |
-          API_URL="${{ inputs.api_url || 'https://api.dev.boxlite.ai/api' }}"
           curl -fsS --retry 6 --retry-delay 5 --retry-all-errors --max-time 10 \
                -o /dev/null "${API_URL}/health"
           echo "::notice::${API_URL}/health returned 2xx"
@@ -83,15 +63,10 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       # ── Build all Rust artifacts in one pass ─────────────────────
-      # boxlite-c (libboxlite.a/.so + boxlite.h), boxlite-cli,
-      # boxlite-node (.node via napi), and boxlite-python (.whl via
-      # maturin) all share the boxlite core crate. Building boxlite-c
-      # first warms the cache; the others are incremental.
       - name: Build C SDK (libboxlite.a + libboxlite.so + boxlite.h)
         run: |
           cargo build --release -p boxlite-c
           ls -lh target/release/libboxlite.{a,so}
-          # cbindgen header — the test drivers need sdks/c/include/boxlite.h
           if [ ! -f sdks/c/include/boxlite.h ]; then
             cargo install cbindgen --quiet 2>/dev/null || true
             if command -v cbindgen >/dev/null; then
@@ -131,17 +106,18 @@ jobs:
 
       # ── Configure pytest credentials ─────────────────────────────
       - name: Configure pytest profile p1
+        env:
+          BOXLITE_DEV_API_KEY: ${{ secrets.BOXLITE_DEV_API_KEY }}
         run: |
           set -euo pipefail
-          API_URL="${{ inputs.api_url || 'https://api.dev.boxlite.ai/api' }}"
 
-          ADMIN_KEY=$(aws ssm get-parameter \
-            --name "/boxlite/${STAGE}/admin-api-key" \
-            --with-decryption \
-            --query Parameter.Value --output text)
-          echo "::add-mask::$ADMIN_KEY"
+          if [ -z "$BOXLITE_DEV_API_KEY" ]; then
+            echo "::error::Secret BOXLITE_DEV_API_KEY is not set. Add it in repo Settings → Secrets."
+            exit 1
+          fi
+          echo "::add-mask::$BOXLITE_DEV_API_KEY"
 
-          PATH_PREFIX=$(curl -fsS -H "Authorization: Bearer $ADMIN_KEY" \
+          PATH_PREFIX=$(curl -fsS -H "Authorization: Bearer $BOXLITE_DEV_API_KEY" \
             "${API_URL}/v1/me" | python3 -c 'import json,sys; print(json.load(sys.stdin)["path_prefix"])')
           [ -n "$PATH_PREFIX" ] || { echo "::error::Empty path_prefix from /v1/me"; exit 1; }
           echo "Resolved path_prefix=${PATH_PREFIX}"
@@ -151,7 +127,7 @@ jobs:
           {
               printf '[profiles.p1]\n'
               printf 'url = "%s"\n'         "$API_URL"
-              printf 'api_key = "%s"\n'     "$ADMIN_KEY"
+              printf 'api_key = "%s"\n'     "$BOXLITE_DEV_API_KEY"
               printf 'path_prefix = "%s"\n' "$PATH_PREFIX"
           } > ~/.boxlite/credentials.toml
           chmod 600 ~/.boxlite/credentials.toml

--- a/.github/workflows/e2e-dev.yml
+++ b/.github/workflows/e2e-dev.yml
@@ -1,10 +1,12 @@
-# E2E suite against the dev cloud stack — SDK → dev API → dev Runner → libkrun VM.
+# E2E suite against the dev cloud stack — SDK → dev API → dev Runner → VM.
 #
-# Stripped-down version of e2e-cloud-test.yml: builds the Python SDK
-# from the current checkout, downloads pre-built C / Node / CLI
-# artifacts, and runs pytest against the always-on dev environment.
-# Does NOT build or deploy the API or runner — the dev stack is assumed
-# to be running the version you want to test against.
+# Builds ALL SDKs (Python, Node, C) and the CLI from source using
+# BOXLITE_DEPS_STUB=1 (skips vendor submodule builds — those only
+# matter inside the runner, not the SDK client), then runs the full
+# REST e2e pytest suite against the dev environment.
+#
+# Does NOT build or deploy the API or runner — the dev stack is
+# assumed to be already running the version you want to test against.
 #
 # Authentication: GitHub OIDC → AWS STS (no stored AWS credentials).
 # Required GitHub repo variables (Settings → Variables → Actions):
@@ -14,7 +16,7 @@
 #
 # Required AWS resources:
 #   - SSM parameter `/boxlite/dev/admin-api-key` (SecureString)
-#   - Dev API reachable at the URL resolved from the runner's stack
+#   - Dev API reachable at the input URL
 
 name: E2E dev
 
@@ -26,18 +28,6 @@ on:
         type: string
         required: true
         default: 'https://api.dev.boxlite.ai/api'
-      c_sdk_run_id:
-        description: 'GHA run ID that uploaded c-sdk-linux-x64-gnu artifact (optional — skip C/Go tests if blank)'
-        type: string
-        required: false
-      node_sdk_run_id:
-        description: 'GHA run ID that uploaded artifacts-linux-x64-gnu artifact (optional — skip Node tests if blank)'
-        type: string
-        required: false
-      cli_run_id:
-        description: 'GHA run ID that uploaded cli-linux-x64-gnu artifact (optional — skip CLI tests if blank)'
-        type: string
-        required: false
 
 permissions:
   contents: read
@@ -50,6 +40,7 @@ env:
   AWS_REGION: ${{ vars.AWS_E2E_DEV_REGION || 'ap-southeast-1' }}
   AWS_ROLE_ARN: ${{ vars.AWS_E2E_DEV_ROLE_ARN }}
   STAGE: dev
+  BOXLITE_DEPS_STUB: "1"
 
 jobs:
   e2e:
@@ -59,7 +50,6 @@ jobs:
     permissions:
       id-token: write
       contents: read
-      actions: read
     steps:
       - uses: actions/checkout@v5
 
@@ -78,72 +68,63 @@ jobs:
                -o /dev/null "${API_URL}/health"
           echo "::notice::${API_URL}/health returned 2xx"
 
-      # ── Build Python SDK from this checkout ───────────────────────
-      - name: Build & install Python SDK
-        env:
-          BOXLITE_DEPS_STUB: "1"
+      # ── System deps ──────────────────────────────────────────────
+      - name: Install system dependencies
         run: |
-          set -euo pipefail
-          sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends protobuf-compiler
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            protobuf-compiler gcc pkg-config
+
+      # ── Rust toolchain (for SDK + CLI builds) ────────────────────
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      # ── Build all Rust artifacts in one pass ─────────────────────
+      # boxlite-c (libboxlite.a/.so + boxlite.h), boxlite-cli,
+      # boxlite-node (.node via napi), and boxlite-python (.whl via
+      # maturin) all share the boxlite core crate. Building boxlite-c
+      # first warms the cache; the others are incremental.
+      - name: Build C SDK (libboxlite.a + libboxlite.so + boxlite.h)
+        run: |
+          cargo build --release -p boxlite-c
+          ls -lh target/release/libboxlite.{a,so}
+          # cbindgen header — the test drivers need sdks/c/include/boxlite.h
+          if [ ! -f sdks/c/include/boxlite.h ]; then
+            cargo install cbindgen --quiet 2>/dev/null || true
+            if command -v cbindgen >/dev/null; then
+              mkdir -p sdks/c/include
+              cbindgen --config sdks/c/cbindgen.toml --crate boxlite-c \
+                --output sdks/c/include/boxlite.h 2>/dev/null || true
+            fi
+          fi
+
+      - name: Build CLI
+        run: |
+          cargo build --release -p boxlite-cli
+          sudo install -m 0755 target/release/boxlite /usr/local/bin/boxlite
+          boxlite --version
+
+      # ── Node SDK (napi-rs) ───────────────────────────────────────
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Build Node SDK (napi)
+        run: |
+          cd sdks/node
+          npm install --ignore-scripts
+          npx napi build --platform --release --js native/boxlite.js --output-dir native
+          ls -lh native/
+
+      # ── Python SDK (maturin + PyO3) ──────────────────────────────
+      - name: Build & install Python SDK
+        run: |
           cd sdks/python
           pip install --break-system-packages --quiet maturin
           maturin build --release
           pip install --break-system-packages --force-reinstall ../../target/wheels/boxlite-*.whl
           pip install --break-system-packages --quiet pytest pytest-asyncio pytest-timeout
-
-      # ── Optional: download pre-built C / Node / CLI artifacts ────
-      - name: Download C SDK artifact
-        if: inputs.c_sdk_run_id != ''
-        uses: actions/download-artifact@v4
-        with:
-          name: c-sdk-linux-x64-gnu
-          path: /tmp/c-sdk
-          run-id: ${{ inputs.c_sdk_run_id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install C SDK
-        if: inputs.c_sdk_run_id != ''
-        run: |
-          set -euo pipefail
-          ARCHIVE=$(ls /tmp/c-sdk/boxlite-c-v*-linux-x64-gnu.tar.gz)
-          tar -xzf "$ARCHIVE" -C /tmp/c-sdk
-          DIR=$(ls -d /tmp/c-sdk/boxlite-c-v*-linux-x64-gnu)
-          mkdir -p target/release sdks/c/include
-          cp "$DIR/lib/libboxlite.a"  target/release/
-          cp "$DIR/lib/libboxlite.so" target/release/
-          cp "$DIR/include/boxlite.h" sdks/c/include/
-
-      - name: Download CLI artifact
-        if: inputs.cli_run_id != ''
-        uses: actions/download-artifact@v4
-        with:
-          name: cli-linux-x64-gnu
-          path: /tmp/cli
-          run-id: ${{ inputs.cli_run_id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install CLI
-        if: inputs.cli_run_id != ''
-        run: |
-          set -euo pipefail
-          ARCHIVE=$(ls /tmp/cli/boxlite-cli-v*-x86_64-unknown-linux-gnu.tar.gz)
-          tar -xzf "$ARCHIVE" -C /tmp/cli
-          sudo install -m 0755 /tmp/cli/boxlite /usr/local/bin/boxlite
-          boxlite --version
-
-      - name: Download Node SDK artifact
-        if: inputs.node_sdk_run_id != ''
-        uses: actions/download-artifact@v4
-        with:
-          name: artifacts-linux-x64-gnu
-          path: /tmp/node-sdk
-          run-id: ${{ inputs.node_sdk_run_id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install Node SDK
-        if: inputs.node_sdk_run_id != ''
-        run: |
-          set -euo pipefail
-          ARCHIVE=$(ls /tmp/node-sdk/artifacts-linux-x64-gnu.tar)
-          tar -xf "$ARCHIVE" -C sdks/node
-          find sdks/node/npm -name '*.node' -print | head -5
 
       # ── Configure pytest credentials ─────────────────────────────
       - name: Configure pytest profile p1
@@ -177,6 +158,7 @@ jobs:
         env:
           BOXLITE_E2E_SKIP_PATH_VERIFY: '1'
           BOXLITE_E2E_PROFILE: p1
+          BOXLITE_E2E_REQUIRE_SDK_BUILDS: '1'
         run: |
           timeout 35m python3 -m pytest scripts/test/e2e/cases/ \
               -v --tb=short --no-header -p no:cacheprovider \

--- a/.github/workflows/e2e-dev.yml
+++ b/.github/workflows/e2e-dev.yml
@@ -124,10 +124,11 @@ jobs:
           chmod 600 ~/.boxlite/credentials.toml
 
       # ── Run pytest ───────────────────────────────────────────────
-      # --ignore the C, Go, path-verification, and exec-timeout tests
-      # (C/Go are FFI-binding tests, not user paths; path-verify needs
-      # runner journal access; exec-timeout is flaky on the single-node
-      # dev runner).
+      # --ignore the C, Go, path-verification, exec-timeout, and
+      # node-entry tests (C/Go are FFI-binding tests; path-verify and
+      # node-entry need runner journal access; exec-timeout is flaky
+      # on the single-node dev runner).  node-coverage already covers
+      # the Node SDK REST surface without journal checks.
       - name: Run E2E suite
         env:
           BOXLITE_E2E_SKIP_PATH_VERIFY: '1'
@@ -140,6 +141,7 @@ jobs:
               --ignore=scripts/test/e2e/cases/test_go_coverage.py \
               --ignore=scripts/test/e2e/cases/test_path_verification.py \
               --ignore=scripts/test/e2e/cases/test_exec_timeout.py \
+              --ignore=scripts/test/e2e/cases/test_node_entry.py \
               -v --tb=short --no-header -p no:cacheprovider \
               --timeout=180 --timeout-method=thread \
               --junit-xml=pytest-junit.xml

--- a/.github/workflows/e2e-dev.yml
+++ b/.github/workflows/e2e-dev.yml
@@ -82,6 +82,7 @@ jobs:
         run: |
           cd sdks/node
           npm install --ignore-scripts
+          mkdir -p native
           npx napi build --platform --release --js native/boxlite.js --output-dir native
           ls -lh native/
 

--- a/.github/workflows/e2e-dev.yml
+++ b/.github/workflows/e2e-dev.yml
@@ -150,7 +150,7 @@ jobs:
               --ignore=scripts/test/e2e/cases/test_go_coverage.py \
               --ignore=scripts/test/e2e/cases/test_node_entry.py \
               --ignore=scripts/test/e2e/cases/test_exec_timeout.py \
-              -v --tb=short --no-header -p no:cacheprovider \
+              -v -s --tb=short --no-header -p no:cacheprovider \
               --timeout=180 --timeout-method=thread \
               --junit-xml=pytest-junit.xml
 

--- a/.github/workflows/e2e-dev.yml
+++ b/.github/workflows/e2e-dev.yml
@@ -21,12 +21,15 @@
 name: E2E dev
 
 on:
+  push:
+    branches:
+      - chore/e2e-required-merge-gate
   workflow_dispatch:
     inputs:
       api_url:
         description: 'Dev API base URL (e.g. https://api.dev.boxlite.ai/api)'
         type: string
-        required: true
+        required: false
         default: 'https://api.dev.boxlite.ai/api'
 
 permissions:
@@ -63,7 +66,7 @@ jobs:
       # ── Health check ──────────────────────────────────────────────
       - name: Probe API health
         run: |
-          API_URL="${{ inputs.api_url }}"
+          API_URL="${{ inputs.api_url || 'https://api.dev.boxlite.ai/api' }}"
           curl -fsS --retry 6 --retry-delay 5 --retry-all-errors --max-time 10 \
                -o /dev/null "${API_URL}/health"
           echo "::notice::${API_URL}/health returned 2xx"
@@ -130,7 +133,7 @@ jobs:
       - name: Configure pytest profile p1
         run: |
           set -euo pipefail
-          API_URL="${{ inputs.api_url }}"
+          API_URL="${{ inputs.api_url || 'https://api.dev.boxlite.ai/api' }}"
 
           ADMIN_KEY=$(aws ssm get-parameter \
             --name "/boxlite/${STAGE}/admin-api-key" \

--- a/.github/workflows/e2e-dev.yml
+++ b/.github/workflows/e2e-dev.yml
@@ -1,0 +1,192 @@
+# E2E suite against the dev cloud stack — SDK → dev API → dev Runner → libkrun VM.
+#
+# Stripped-down version of e2e-cloud-test.yml: builds the Python SDK
+# from the current checkout, downloads pre-built C / Node / CLI
+# artifacts, and runs pytest against the always-on dev environment.
+# Does NOT build or deploy the API or runner — the dev stack is assumed
+# to be running the version you want to test against.
+#
+# Authentication: GitHub OIDC → AWS STS (no stored AWS credentials).
+# Required GitHub repo variables (Settings → Variables → Actions):
+#   - AWS_ACCOUNT_ID
+#   - AWS_E2E_DEV_REGION       (ap-southeast-1)
+#   - AWS_E2E_DEV_ROLE_ARN     (arn:aws:iam::<acct>:role/boxlite-e2e-dev-github-actions)
+#
+# Required AWS resources:
+#   - SSM parameter `/boxlite/dev/admin-api-key` (SecureString)
+#   - Dev API reachable at the URL resolved from the runner's stack
+
+name: E2E dev
+
+on:
+  workflow_dispatch:
+    inputs:
+      api_url:
+        description: 'Dev API base URL (e.g. https://api.dev.boxlite.ai/api)'
+        type: string
+        required: true
+        default: 'https://api.dev.boxlite.ai/api'
+      c_sdk_run_id:
+        description: 'GHA run ID that uploaded c-sdk-linux-x64-gnu artifact (optional — skip C/Go tests if blank)'
+        type: string
+        required: false
+      node_sdk_run_id:
+        description: 'GHA run ID that uploaded artifacts-linux-x64-gnu artifact (optional — skip Node tests if blank)'
+        type: string
+        required: false
+      cli_run_id:
+        description: 'GHA run ID that uploaded cli-linux-x64-gnu artifact (optional — skip CLI tests if blank)'
+        type: string
+        required: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: e2e-dev
+  cancel-in-progress: true
+
+env:
+  AWS_REGION: ${{ vars.AWS_E2E_DEV_REGION || 'ap-southeast-1' }}
+  AWS_ROLE_ARN: ${{ vars.AWS_E2E_DEV_ROLE_ARN }}
+  STAGE: dev
+
+jobs:
+  e2e:
+    name: E2E suite (dev)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      id-token: write
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+          role-session-name: e2e-dev-${{ github.run_id }}
+
+      # ── Health check ──────────────────────────────────────────────
+      - name: Probe API health
+        run: |
+          API_URL="${{ inputs.api_url }}"
+          curl -fsS --retry 6 --retry-delay 5 --retry-all-errors --max-time 10 \
+               -o /dev/null "${API_URL}/health"
+          echo "::notice::${API_URL}/health returned 2xx"
+
+      # ── Build Python SDK from this checkout ───────────────────────
+      - name: Build & install Python SDK
+        env:
+          BOXLITE_DEPS_STUB: "1"
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends protobuf-compiler
+          cd sdks/python
+          pip install --break-system-packages --quiet maturin
+          maturin build --release
+          pip install --break-system-packages --force-reinstall ../../target/wheels/boxlite-*.whl
+          pip install --break-system-packages --quiet pytest pytest-asyncio pytest-timeout
+
+      # ── Optional: download pre-built C / Node / CLI artifacts ────
+      - name: Download C SDK artifact
+        if: inputs.c_sdk_run_id != ''
+        uses: actions/download-artifact@v4
+        with:
+          name: c-sdk-linux-x64-gnu
+          path: /tmp/c-sdk
+          run-id: ${{ inputs.c_sdk_run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install C SDK
+        if: inputs.c_sdk_run_id != ''
+        run: |
+          set -euo pipefail
+          ARCHIVE=$(ls /tmp/c-sdk/boxlite-c-v*-linux-x64-gnu.tar.gz)
+          tar -xzf "$ARCHIVE" -C /tmp/c-sdk
+          DIR=$(ls -d /tmp/c-sdk/boxlite-c-v*-linux-x64-gnu)
+          mkdir -p target/release sdks/c/include
+          cp "$DIR/lib/libboxlite.a"  target/release/
+          cp "$DIR/lib/libboxlite.so" target/release/
+          cp "$DIR/include/boxlite.h" sdks/c/include/
+
+      - name: Download CLI artifact
+        if: inputs.cli_run_id != ''
+        uses: actions/download-artifact@v4
+        with:
+          name: cli-linux-x64-gnu
+          path: /tmp/cli
+          run-id: ${{ inputs.cli_run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install CLI
+        if: inputs.cli_run_id != ''
+        run: |
+          set -euo pipefail
+          ARCHIVE=$(ls /tmp/cli/boxlite-cli-v*-x86_64-unknown-linux-gnu.tar.gz)
+          tar -xzf "$ARCHIVE" -C /tmp/cli
+          sudo install -m 0755 /tmp/cli/boxlite /usr/local/bin/boxlite
+          boxlite --version
+
+      - name: Download Node SDK artifact
+        if: inputs.node_sdk_run_id != ''
+        uses: actions/download-artifact@v4
+        with:
+          name: artifacts-linux-x64-gnu
+          path: /tmp/node-sdk
+          run-id: ${{ inputs.node_sdk_run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install Node SDK
+        if: inputs.node_sdk_run_id != ''
+        run: |
+          set -euo pipefail
+          ARCHIVE=$(ls /tmp/node-sdk/artifacts-linux-x64-gnu.tar)
+          tar -xf "$ARCHIVE" -C sdks/node
+          find sdks/node/npm -name '*.node' -print | head -5
+
+      # ── Configure pytest credentials ─────────────────────────────
+      - name: Configure pytest profile p1
+        run: |
+          set -euo pipefail
+          API_URL="${{ inputs.api_url }}"
+
+          ADMIN_KEY=$(aws ssm get-parameter \
+            --name "/boxlite/${STAGE}/admin-api-key" \
+            --with-decryption \
+            --query Parameter.Value --output text)
+          echo "::add-mask::$ADMIN_KEY"
+
+          PATH_PREFIX=$(curl -fsS -H "Authorization: Bearer $ADMIN_KEY" \
+            "${API_URL}/v1/me" | python3 -c 'import json,sys; print(json.load(sys.stdin)["path_prefix"])')
+          [ -n "$PATH_PREFIX" ] || { echo "::error::Empty path_prefix from /v1/me"; exit 1; }
+          echo "Resolved path_prefix=${PATH_PREFIX}"
+
+          mkdir -p ~/.boxlite
+          chmod 700 ~/.boxlite
+          {
+              printf '[profiles.p1]\n'
+              printf 'url = "%s"\n'         "$API_URL"
+              printf 'api_key = "%s"\n'     "$ADMIN_KEY"
+              printf 'path_prefix = "%s"\n' "$PATH_PREFIX"
+          } > ~/.boxlite/credentials.toml
+          chmod 600 ~/.boxlite/credentials.toml
+
+      # ── Run pytest ───────────────────────────────────────────────
+      - name: Run E2E suite
+        env:
+          BOXLITE_E2E_SKIP_PATH_VERIFY: '1'
+          BOXLITE_E2E_PROFILE: p1
+        run: |
+          timeout 35m python3 -m pytest scripts/test/e2e/cases/ \
+              -v --tb=short --no-header -p no:cacheprovider \
+              --timeout=180 --timeout-method=thread \
+              --junit-xml=pytest-junit.xml
+
+      - name: Upload pytest junit XML
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pytest-junit
+          path: pytest-junit.xml
+          if-no-files-found: ignore

--- a/.github/workflows/e2e-dev.yml
+++ b/.github/workflows/e2e-dev.yml
@@ -12,8 +12,25 @@
 # Does NOT build or deploy the API or runner — the dev stack is
 # assumed to be already running the version you want to test against.
 #
-# Authentication: boxlite API key stored as GitHub repo secret
-# `BOXLITE_DEV_API_KEY`. No AWS credentials needed.
+# Authentication: GitHub OIDC → AWS STS → SSM, same account model as
+# e2e-local. The credential is the dev stack's ADMIN_API_KEY, which the
+# API provisions for itself on boot: initializeAdminUser() creates the
+# fixed `boxlite-admin` user and calls ensureApiKeyValue() with the env
+# value (apps/api/src/app.service.ts). bootstrap.sh does the identical
+# thing locally, minting ADMIN_API_KEY into /etc/boxlite-secrets.env.
+#
+# This replaces a repo secret holding a key issued to a *person*. Every
+# API key is primary-keyed on (organizationId, userId, name), and
+# ApiKeyStrategy re-reads the user on each request and 401s with
+# "User not found" if it is gone — so a personal key dies when its owner
+# is offboarded. `boxlite-admin` cannot die that way: it is recreated on
+# the next API boot if deleted.
+#
+# Required GitHub repo variables (Settings → Variables → Actions):
+#   - AWS_E2E_DEV_REGION       (optional, defaults to ap-southeast-1)
+#   - AWS_E2E_DEV_ROLE_ARN     (arn:aws:iam::<acct>:role/boxlite-e2e-dev-github-actions)
+# Required AWS resources:
+#   - SSM parameter `/boxlite/dev/admin-api-key` (SecureString)
 #
 # Triggers mirror e2e-local: push on main, a label-gated PR trigger, and
 # manual dispatch. The `e2e-dev` label is the cost gate — every run
@@ -21,13 +38,19 @@
 #
 # Fork PRs: DENIED, and this is the one place the model diverges from
 # e2e-local. There, untrusted code runs in a job holding no secrets, so a
-# maintainer label is purely a cost decision. Here the pytest suite needs
-# BOXLITE_DEV_API_KEY in the same job that builds and runs the PR's own
-# code, so a labeled fork run would hand arbitrary code the dev API key —
-# a conftest.py is enough. The event is still pull_request_target with
-# head-SHA pinning so the trigger surface matches e2e-local and forks can
-# be enabled later by relaxing one branch in `should-run`, but that must
-# not happen until the credential is out of the untrusted job.
+# maintainer label is purely a cost decision. Here the suite needs the
+# admin key in the same job that builds and runs the PR's own code, and
+# GitHub has no secret-safe way to hand a credential from a privileged
+# job to an unprivileged one — job outputs are plaintext. So a labeled
+# fork run would give arbitrary code a SystemRole.ADMIN credential for
+# the dev stack; a conftest.py is enough to exfiltrate it. Same-repo PRs
+# are allowed because their authors already have write access.
+#
+# The event is still pull_request_target with head-SHA pinning so the
+# trigger surface matches e2e-local. Enabling forks needs more than
+# relaxing `should-run`: the run would first have to mint a scoped,
+# short-lived key off the admin key (CreateApiKeyDto takes `permissions`
+# and `expiresAt`) and pass only that to the test step.
 #
 # Runbook: docs/ci/e2e-local.md covers the shared label/gate mechanics.
 
@@ -90,12 +113,15 @@ concurrency:
 env:
   BOXLITE_DEPS_STUB: "1"
   API_URL: ${{ inputs.api_url || 'https://api.dev.boxlite.ai/api' }}
+  STAGE: dev
+  AWS_REGION: ${{ vars.AWS_E2E_DEV_REGION || 'ap-southeast-1' }}
+  AWS_ROLE_ARN: ${{ vars.AWS_E2E_DEV_ROLE_ARN }}
 
 jobs:
   # =========================================================================
   # Gate: PRs require the 'e2e-dev' label (only maintainers can add it).
   # Same-repo PRs re-run while labeled. Fork PRs never run — see the header:
-  # this workflow's only job holds BOXLITE_DEV_API_KEY.
+  # this workflow's only job holds the dev stack's admin key.
   # =========================================================================
   should-run:
     runs-on: ubuntu-latest
@@ -121,7 +147,7 @@ jobs:
             echo "run=true" >> "$GITHUB_OUTPUT"
           else
             echo "run=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::Fork PRs cannot run E2E dev: the suite needs BOXLITE_DEV_API_KEY in the same job that runs the PR's code. Use workflow_dispatch from a maintainer branch instead."
+            echo "::notice::Fork PRs cannot run E2E dev: the suite needs the dev admin key in the same job that runs the PR's code. Use workflow_dispatch from a maintainer branch instead."
           fi
 
   e2e:
@@ -130,6 +156,11 @@ jobs:
     if: needs.should-run.outputs.run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    # OIDC token for the SSM read. The workflow-level grant stays
+    # contents: read; this is the only job that needs to assume a role.
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v5
         with:
@@ -187,21 +218,52 @@ jobs:
           pip install --break-system-packages --force-reinstall ../../target/wheels/boxlite-*.whl
           pip install --break-system-packages --quiet pytest pytest-asyncio pytest-timeout
 
+      # ── AWS OIDC ─────────────────────────────────────────────────
+      # Deliberately after the builds: nothing before this point needs
+      # AWS, so the STS session starts as late as possible.
+      - name: Check AWS role variable is set
+        run: |
+          [ -n "${AWS_ROLE_ARN}" ] || {
+            echo "::error::Repo variable AWS_E2E_DEV_ROLE_ARN is not set. Add it in Settings → Variables → Actions."
+            exit 1
+          }
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+          role-session-name: e2e-dev-${{ github.run_id }}
+
       # ── Configure pytest credentials ─────────────────────────────
       - name: Configure pytest profile p1
-        env:
-          BOXLITE_DEV_API_KEY: ${{ secrets.BOXLITE_DEV_API_KEY }}
         run: |
           set -euo pipefail
 
-          if [ -z "$BOXLITE_DEV_API_KEY" ]; then
-            echo "::error::Secret BOXLITE_DEV_API_KEY is not set. Add it in repo Settings → Secrets."
+          ADMIN_KEY=$(aws ssm get-parameter \
+            --name "/boxlite/${STAGE}/admin-api-key" \
+            --with-decryption \
+            --query Parameter.Value --output text)
+          if [ -z "$ADMIN_KEY" ] || [ "$ADMIN_KEY" = "None" ]; then
+            echo "::error::SSM parameter /boxlite/${STAGE}/admin-api-key is missing or empty. It must hold the dev stack's ADMIN_API_KEY."
             exit 1
           fi
-          echo "::add-mask::$BOXLITE_DEV_API_KEY"
+          echo "::add-mask::$ADMIN_KEY"
 
-          PATH_PREFIX=$(curl -fsS -H "Authorization: Bearer $BOXLITE_DEV_API_KEY" \
-            "${API_URL}/v1/me" | python3 -c 'import json,sys; print(json.load(sys.stdin)["path_prefix"])')
+          # /v1/me is the auth smoke test, exactly as bootstrap.sh uses it
+          # locally: it exercises auth + DB + Redis in one call. A 401 here
+          # means the SSM value and the dev stack's ADMIN_API_KEY env have
+          # diverged — the API keys `boxlite-admin` off that env var on
+          # boot, so rotating one without the other breaks this step.
+          ME_HTTP=$(curl -sS -o /tmp/me.json -w '%{http_code}' \
+            -H "Authorization: Bearer $ADMIN_KEY" "${API_URL}/v1/me" || echo 000)
+          if [ "$ME_HTTP" != "200" ]; then
+            echo "::error::/v1/me returned HTTP ${ME_HTTP}. If 401, the SSM admin key no longer matches the dev stack's ADMIN_API_KEY."
+            exit 1
+          fi
+
+          PATH_PREFIX=$(python3 -c 'import json;print(json.load(open("/tmp/me.json"))["path_prefix"])')
+          rm -f /tmp/me.json
           [ -n "$PATH_PREFIX" ] || { echo "::error::Empty path_prefix from /v1/me"; exit 1; }
           echo "Resolved path_prefix=${PATH_PREFIX}"
 
@@ -210,7 +272,7 @@ jobs:
           {
               printf '[profiles.p1]\n'
               printf 'url = "%s"\n'         "$API_URL"
-              printf 'api_key = "%s"\n'     "$BOXLITE_DEV_API_KEY"
+              printf 'api_key = "%s"\n'     "$ADMIN_KEY"
               printf 'path_prefix = "%s"\n' "$PATH_PREFIX"
           } > ~/.boxlite/credentials.toml
           chmod 600 ~/.boxlite/credentials.toml

--- a/.github/workflows/e2e-dev.yml
+++ b/.github/workflows/e2e-dev.yml
@@ -19,6 +19,9 @@
 # `path_prefix` is derived from the same key via /v1/me, not a second
 # credential. No AWS, no OIDC.
 #
+# Optional repo variable (Settings → Variables → Actions):
+#   - BOXLITE_DEV_API_URL   target stack; defaults to api.dev.boxlite.ai
+#
 # The key is issued to a maintainer, deliberately. It is therefore
 # mortal: API keys are primary-keyed on (organizationId, userId, name)
 # and ApiKeyStrategy re-reads the user on every request, throwing
@@ -89,10 +92,13 @@ on:
   workflow_dispatch:
     inputs:
       api_url:
-        description: 'Dev API base URL'
+        description: 'Dev API base URL (blank = repo variable BOXLITE_DEV_API_URL)'
         type: string
         required: false
-        default: 'https://api.dev.boxlite.ai/api'
+        # Deliberately no default. A default would make inputs.api_url
+        # always non-empty on a dispatch run, so BOXLITE_DEV_API_URL
+        # would be silently ignored exactly when someone is trying to
+        # dispatch against the configured stack.
 
 # pull_request_target's default token is write-capable — keep the
 # inherited token read-only, as e2e-local does.
@@ -117,7 +123,10 @@ concurrency:
 
 env:
   BOXLITE_DEPS_STUB: "1"
-  API_URL: ${{ inputs.api_url || 'https://api.dev.boxlite.ai/api' }}
+  # Precedence: a dispatch input overrides for one run; otherwise the
+  # repo variable is the configured stack; otherwise the built-in
+  # default, so the workflow still runs with nothing configured.
+  API_URL: ${{ inputs.api_url || vars.BOXLITE_DEV_API_URL || 'https://api.dev.boxlite.ai/api' }}
 
 jobs:
   # =========================================================================

--- a/.github/workflows/e2e-dev.yml
+++ b/.github/workflows/e2e-dev.yml
@@ -228,15 +228,33 @@ jobs:
             exit 1
           }
 
+      # SHA-pinned per boxlite-app-env's policy (README "Pinning policy"):
+      # a floating ref on a third-party action is a supply-chain vector
+      # (CVE-2025-30066). This is the same SHA that repo's deploy
+      # workflows vet.
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
           role-session-name: e2e-dev-${{ github.run_id }}
 
-      # ── Configure pytest credentials ─────────────────────────────
-      - name: Configure pytest profile p1
+      # ── Fixture + pytest credentials ─────────────────────────────
+      # fixture_setup.py is the shared path: make test:e2e:setup
+      # (make/test.mk) and scripts/test/e2e/run.sh both call it, so
+      # e2e-local and e2e-stack configure the suite exactly this way.
+      # Beyond writing [profiles.p1] it also registers the snapshots the
+      # cases need and lifts the admin org's per-box quotas off zero —
+      # the hand-rolled credentials.toml this replaces did neither, which
+      # would fail the suite even with a valid key.
+      #
+      # It takes the key from BOXLITE_E2E_ADMIN_KEY, falling back to
+      # /etc/boxlite-secrets.env — that fallback is how a bootstrapped
+      # host feeds it. There is no such file here, so the SSM value is
+      # passed explicitly, per-command, never via GITHUB_ENV.
+      - name: Configure fixture + pytest profile p1
+        env:
+          BOXLITE_E2E_API_URL: ${{ env.API_URL }}
         run: |
           set -euo pipefail
 
@@ -250,32 +268,21 @@ jobs:
           fi
           echo "::add-mask::$ADMIN_KEY"
 
-          # /v1/me is the auth smoke test, exactly as bootstrap.sh uses it
-          # locally: it exercises auth + DB + Redis in one call. A 401 here
-          # means the SSM value and the dev stack's ADMIN_API_KEY env have
-          # diverged — the API keys `boxlite-admin` off that env var on
-          # boot, so rotating one without the other breaks this step.
-          ME_HTTP=$(curl -sS -o /tmp/me.json -w '%{http_code}' \
+          # Preflight before fixture_setup so an auth failure reports as
+          # auth rather than as a confusing fixture error. bootstrap.sh
+          # probes /v1/me for the same reason: it exercises auth + DB +
+          # Redis in one call. A 401 means the SSM value and the stack's
+          # ADMIN_API_KEY env have diverged — the API keys `boxlite-admin`
+          # off that env var on boot, so rotating one without the other
+          # breaks here.
+          ME_HTTP=$(curl -sS -o /dev/null -w '%{http_code}' \
             -H "Authorization: Bearer $ADMIN_KEY" "${API_URL}/v1/me" || echo 000)
           if [ "$ME_HTTP" != "200" ]; then
             echo "::error::/v1/me returned HTTP ${ME_HTTP}. If 401, the SSM admin key no longer matches the dev stack's ADMIN_API_KEY."
             exit 1
           fi
 
-          PATH_PREFIX=$(python3 -c 'import json;print(json.load(open("/tmp/me.json"))["path_prefix"])')
-          rm -f /tmp/me.json
-          [ -n "$PATH_PREFIX" ] || { echo "::error::Empty path_prefix from /v1/me"; exit 1; }
-          echo "Resolved path_prefix=${PATH_PREFIX}"
-
-          mkdir -p ~/.boxlite
-          chmod 700 ~/.boxlite
-          {
-              printf '[profiles.p1]\n'
-              printf 'url = "%s"\n'         "$API_URL"
-              printf 'api_key = "%s"\n'     "$ADMIN_KEY"
-              printf 'path_prefix = "%s"\n' "$PATH_PREFIX"
-          } > ~/.boxlite/credentials.toml
-          chmod 600 ~/.boxlite/credentials.toml
+          BOXLITE_E2E_ADMIN_KEY="$ADMIN_KEY" python3 scripts/test/e2e/fixture_setup.py
 
       # ── Run pytest ───────────────────────────────────────────────
       # --ignore rationale:

--- a/.github/workflows/e2e-dev.yml
+++ b/.github/workflows/e2e-dev.yml
@@ -31,6 +31,11 @@
 # starts 401-ing for no apparent reason, that is the first thing to
 # check — the preflight below says so explicitly.
 #
+# Last known-good: run 29995466177 (2026-07-23) authenticated fine — its
+# credential step passed, and that step is what calls /v1/me. The four
+# failures in that run were test failures, not auth. So a 401 after this
+# date means something changed since, not that the setup never worked.
+#
 # The durable alternative is a key on a principal that is not a person:
 # `boxlite-admin`, which the API provisions for itself on boot
 # (initializeAdminUser in apps/api/src/app.service.ts), or a dedicated

--- a/.github/workflows/e2e-dev.yml
+++ b/.github/workflows/e2e-dev.yml
@@ -189,46 +189,6 @@ jobs:
                -o /dev/null "${API_URL}/health"
           echo "::notice::${API_URL}/health returned 2xx"
 
-      # ── System deps ──────────────────────────────────────────────
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends protobuf-compiler
-
-      # ── Rust toolchain ───────────────────────────────────────────
-      - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      # ── CLI (cargo build, warms the shared boxlite core) ─────────
-      - name: Build CLI
-        run: |
-          cargo build --release -p boxlite-cli
-          sudo install -m 0755 target/release/boxlite /usr/local/bin/boxlite
-          boxlite --version
-
-      # ── Node SDK (napi-rs) ───────────────────────────────────────
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-
-      - name: Build Node SDK (napi + tsc)
-        run: |
-          cd sdks/node
-          npm install --ignore-scripts
-          npm run build:native
-          npm run build
-          ls -lh native/ dist/
-
-      # ── Python SDK (maturin + PyO3) ──────────────────────────────
-      - name: Build & install Python SDK
-        run: |
-          cd sdks/python
-          pip install --break-system-packages --quiet maturin
-          maturin build --release
-          pip install --break-system-packages --force-reinstall ../../target/wheels/boxlite-*.whl
-          pip install --break-system-packages --quiet pytest pytest-asyncio pytest-timeout
-
       # ── Configure pytest credentials ─────────────────────────────
       # Written here rather than by scripts/test/e2e/fixture_setup.py,
       # which the local entry points (make test:e2e:setup, run.sh) use.
@@ -286,6 +246,46 @@ jobs:
               printf 'path_prefix = "%s"\n' "$PATH_PREFIX"
           } > ~/.boxlite/credentials.toml
           chmod 600 ~/.boxlite/credentials.toml
+
+      # ── System deps ──────────────────────────────────────────────
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends protobuf-compiler
+
+      # ── Rust toolchain ───────────────────────────────────────────
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      # ── CLI (cargo build, warms the shared boxlite core) ─────────
+      - name: Build CLI
+        run: |
+          cargo build --release -p boxlite-cli
+          sudo install -m 0755 target/release/boxlite /usr/local/bin/boxlite
+          boxlite --version
+
+      # ── Node SDK (napi-rs) ───────────────────────────────────────
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Build Node SDK (napi + tsc)
+        run: |
+          cd sdks/node
+          npm install --ignore-scripts
+          npm run build:native
+          npm run build
+          ls -lh native/ dist/
+
+      # ── Python SDK (maturin + PyO3) ──────────────────────────────
+      - name: Build & install Python SDK
+        run: |
+          cd sdks/python
+          pip install --break-system-packages --quiet maturin
+          maturin build --release
+          pip install --break-system-packages --force-reinstall ../../target/wheels/boxlite-*.whl
+          pip install --break-system-packages --quiet pytest pytest-asyncio pytest-timeout
 
       # ── Run pytest ───────────────────────────────────────────────
       # --ignore rationale:

--- a/.github/workflows/e2e-dev.yml
+++ b/.github/workflows/e2e-dev.yml
@@ -47,7 +47,7 @@
 # Fork PRs: DENIED, and this is the one place the model diverges from
 # e2e-local. There, untrusted code runs in a job holding no secrets, so a
 # maintainer label is purely a cost decision. Here the suite needs the
-# admin key in the same job that builds and runs the PR's own code, and
+# API key in the same job that builds and runs the PR's own code, and
 # GitHub has no secret-safe way to hand a credential from a privileged
 # job to an unprivileged one — job outputs are plaintext. So a labeled
 # fork run would hand arbitrary code a live maintainer credential for

--- a/.github/workflows/e2e-dev.yml
+++ b/.github/workflows/e2e-dev.yml
@@ -239,22 +239,24 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-session-name: e2e-dev-${{ github.run_id }}
 
-      # ── Fixture + pytest credentials ─────────────────────────────
-      # fixture_setup.py is the shared path: make test:e2e:setup
-      # (make/test.mk) and scripts/test/e2e/run.sh both call it, so
-      # e2e-local and e2e-stack configure the suite exactly this way.
-      # Beyond writing [profiles.p1] it also registers the snapshots the
-      # cases need and lifts the admin org's per-box quotas off zero —
-      # the hand-rolled credentials.toml this replaces did neither, which
-      # would fail the suite even with a valid key.
+      # ── Configure pytest credentials ─────────────────────────────
+      # NOT scripts/test/e2e/fixture_setup.py, which the local entry
+      # points (make test:e2e:setup, run.sh) use. That script talks to the
+      # stack's Postgres directly — `psql -h localhost -d boxlite_dev` for
+      # snapshot state, and an `UPDATE organization SET max_*_per_box`
+      # for quotas — because, as its own comment puts it, the fixture
+      # lives next to the DB. e2e-local and e2e-stack run on a host that
+      # bootstrapped that DB; this workflow runs on a GitHub runner
+      # against a remote API, so there is no localhost Postgres and
+      # fixture_setup would exit on the quota patch.
       #
-      # It takes the key from BOXLITE_E2E_ADMIN_KEY, falling back to
-      # /etc/boxlite-secrets.env — that fallback is how a bootstrapped
-      # host feeds it. There is no such file here, so the SSM value is
-      # passed explicitly, per-command, never via GITHUB_ENV.
-      - name: Configure fixture + pytest profile p1
-        env:
-          BOXLITE_E2E_API_URL: ${{ env.API_URL }}
+      # The consequence is deliberate: this workflow only READS from the
+      # dev stack's control plane. It registers no snapshots and rewrites
+      # no quotas — a deployed dev stack is expected to already have both,
+      # and silently UPDATE-ing a shared environment's org rows from CI
+      # would be worse than failing. The only writes are the boxes the
+      # suite itself creates and deletes.
+      - name: Configure pytest profile p1
         run: |
           set -euo pipefail
 
@@ -268,21 +270,32 @@ jobs:
           fi
           echo "::add-mask::$ADMIN_KEY"
 
-          # Preflight before fixture_setup so an auth failure reports as
-          # auth rather than as a confusing fixture error. bootstrap.sh
-          # probes /v1/me for the same reason: it exercises auth + DB +
-          # Redis in one call. A 401 means the SSM value and the stack's
-          # ADMIN_API_KEY env have diverged — the API keys `boxlite-admin`
-          # off that env var on boot, so rotating one without the other
-          # breaks here.
-          ME_HTTP=$(curl -sS -o /dev/null -w '%{http_code}' \
+          # /v1/me is the auth smoke test, exactly as bootstrap.sh uses it
+          # locally: it exercises auth + DB + Redis in one call. A 401 here
+          # means the SSM value and the dev stack's ADMIN_API_KEY env have
+          # diverged — the API keys `boxlite-admin` off that env var on
+          # boot, so rotating one without the other breaks this step.
+          ME_HTTP=$(curl -sS -o /tmp/me.json -w '%{http_code}' \
             -H "Authorization: Bearer $ADMIN_KEY" "${API_URL}/v1/me" || echo 000)
           if [ "$ME_HTTP" != "200" ]; then
             echo "::error::/v1/me returned HTTP ${ME_HTTP}. If 401, the SSM admin key no longer matches the dev stack's ADMIN_API_KEY."
             exit 1
           fi
 
-          BOXLITE_E2E_ADMIN_KEY="$ADMIN_KEY" python3 scripts/test/e2e/fixture_setup.py
+          PATH_PREFIX=$(python3 -c 'import json;print(json.load(open("/tmp/me.json"))["path_prefix"])')
+          rm -f /tmp/me.json
+          [ -n "$PATH_PREFIX" ] || { echo "::error::Empty path_prefix from /v1/me"; exit 1; }
+          echo "Resolved path_prefix=${PATH_PREFIX}"
+
+          mkdir -p ~/.boxlite
+          chmod 700 ~/.boxlite
+          {
+              printf '[profiles.p1]\n'
+              printf 'url = "%s"\n'         "$API_URL"
+              printf 'api_key = "%s"\n'     "$ADMIN_KEY"
+              printf 'path_prefix = "%s"\n' "$PATH_PREFIX"
+          } > ~/.boxlite/credentials.toml
+          chmod 600 ~/.boxlite/credentials.toml
 
       # ── Run pytest ───────────────────────────────────────────────
       # --ignore rationale:

--- a/.github/workflows/e2e-dev.yml
+++ b/.github/workflows/e2e-dev.yml
@@ -72,9 +72,17 @@ permissions:
   contents: read
 
 # Single global group: every run targets the same dev stack, so two in
-# flight would race over shared boxes. A newer push queues behind the
-# in-progress run instead of cancelling it — cancelling mid-suite leaks
-# boxes on the dev stack that nothing then cleans up.
+# flight would race over shared boxes.
+#
+# A newer push queues behind the in-progress run instead of cancelling
+# it. The `box` fixture's teardown is the only thing that deletes the
+# boxes a run creates: auto_remove is a no-op over REST (see
+# deprecated_auto_remove_does_not_change_rest_lifecycle_defaults) and the
+# API defaults autoDelete to disabled, so a run killed mid-suite strands
+# every box it had open — they auto-stop after 15 min but are never
+# deleted. Note this bounds the damage rather than eliminating it:
+# GitHub retains only the newest *pending* run per group, so intermediate
+# queued pushes are still superseded before they ever start.
 concurrency:
   group: e2e-dev
   cancel-in-progress: false

--- a/.github/workflows/e2e-dev.yml
+++ b/.github/workflows/e2e-dev.yml
@@ -12,25 +12,30 @@
 # Does NOT build or deploy the API or runner — the dev stack is
 # assumed to be already running the version you want to test against.
 #
-# Authentication: GitHub OIDC → AWS STS → SSM, same account model as
-# e2e-local. The credential is the dev stack's ADMIN_API_KEY, which the
-# API provisions for itself on boot: initializeAdminUser() creates the
-# fixed `boxlite-admin` user and calls ensureApiKeyValue() with the env
-# value (apps/api/src/app.service.ts). bootstrap.sh does the identical
-# thing locally, minting ADMIN_API_KEY into /etc/boxlite-secrets.env.
+# Authentication: one boxlite API key, in the repo secret
+# `BOXLITE_DEV_API_KEY`. That is the whole of it — the suite reads
+# [profiles.p1] from ~/.boxlite/credentials.toml and every request is
+# `Authorization: Bearer <token>` (scripts/test/e2e/lib/e2e_auth.py).
+# `path_prefix` is derived from the same key via /v1/me, not a second
+# credential. No AWS, no OIDC.
 #
-# This replaces a repo secret holding a key issued to a *person*. Every
-# API key is primary-keyed on (organizationId, userId, name), and
-# ApiKeyStrategy re-reads the user on each request and 401s with
-# "User not found" if it is gone — so a personal key dies when its owner
-# is offboarded. `boxlite-admin` cannot die that way: it is recreated on
-# the next API boot if deleted.
+# The key is issued to a maintainer, deliberately. It is therefore
+# mortal: API keys are primary-keyed on (organizationId, userId, name)
+# and ApiKeyStrategy re-reads the user on every request, throwing
+# UnauthorizedException('User not found') once that account is deleted.
+# Redis caches the user lookup, so such a key keeps working for a TTL
+# after the account goes and then fails for good. If this workflow
+# starts 401-ing for no apparent reason, that is the first thing to
+# check — the preflight below says so explicitly.
 #
-# Required GitHub repo variables (Settings → Variables → Actions):
-#   - AWS_E2E_DEV_REGION       (optional, defaults to ap-southeast-1)
-#   - AWS_E2E_DEV_ROLE_ARN     (arn:aws:iam::<acct>:role/boxlite-e2e-dev-github-actions)
-# Required AWS resources:
-#   - SSM parameter `/boxlite/dev/admin-api-key` (SecureString)
+# The durable alternative is a key on a principal that is not a person:
+# `boxlite-admin`, which the API provisions for itself on boot
+# (initializeAdminUser in apps/api/src/app.service.ts), or a dedicated
+# service account with a scoped key (CreateApiKeyDto takes `permissions`
+# and `expiresAt`). Both were weighed and declined: a maintainer key is
+# less privileged than boxlite-admin's SystemRole.ADMIN, and a service
+# account needs provisioning work on the dev stack that nothing else
+# currently needs.
 #
 # Triggers mirror e2e-local: push on main, a label-gated PR trigger, and
 # manual dispatch. The `e2e-dev` label is the cost gate — every run
@@ -42,15 +47,15 @@
 # admin key in the same job that builds and runs the PR's own code, and
 # GitHub has no secret-safe way to hand a credential from a privileged
 # job to an unprivileged one — job outputs are plaintext. So a labeled
-# fork run would give arbitrary code a SystemRole.ADMIN credential for
+# fork run would hand arbitrary code a live maintainer credential for
 # the dev stack; a conftest.py is enough to exfiltrate it. Same-repo PRs
 # are allowed because their authors already have write access.
 #
 # The event is still pull_request_target with head-SHA pinning so the
 # trigger surface matches e2e-local. Enabling forks needs more than
 # relaxing `should-run`: the run would first have to mint a scoped,
-# short-lived key off the admin key (CreateApiKeyDto takes `permissions`
-# and `expiresAt`) and pass only that to the test step.
+# short-lived key (CreateApiKeyDto takes `permissions` and `expiresAt`)
+# and pass only that to the test step.
 #
 # Runbook: docs/ci/e2e-local.md covers the shared label/gate mechanics.
 
@@ -113,15 +118,12 @@ concurrency:
 env:
   BOXLITE_DEPS_STUB: "1"
   API_URL: ${{ inputs.api_url || 'https://api.dev.boxlite.ai/api' }}
-  STAGE: dev
-  AWS_REGION: ${{ vars.AWS_E2E_DEV_REGION || 'ap-southeast-1' }}
-  AWS_ROLE_ARN: ${{ vars.AWS_E2E_DEV_ROLE_ARN }}
 
 jobs:
   # =========================================================================
   # Gate: PRs require the 'e2e-dev' label (only maintainers can add it).
   # Same-repo PRs re-run while labeled. Fork PRs never run — see the header:
-  # this workflow's only job holds the dev stack's admin key.
+  # this workflow's only job holds a live dev API key.
   # =========================================================================
   should-run:
     runs-on: ubuntu-latest
@@ -147,7 +149,7 @@ jobs:
             echo "run=true" >> "$GITHUB_OUTPUT"
           else
             echo "run=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::Fork PRs cannot run E2E dev: the suite needs the dev admin key in the same job that runs the PR's code. Use workflow_dispatch from a maintainer branch instead."
+            echo "::notice::Fork PRs cannot run E2E dev: the suite needs a live dev API key in the same job that runs the PR's code. Use workflow_dispatch from a maintainer branch instead."
           fi
 
   e2e:
@@ -156,11 +158,6 @@ jobs:
     if: needs.should-run.outputs.run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
-    # OIDC token for the SSM read. The workflow-level grant stays
-    # contents: read; this is the only job that needs to assume a role.
-    permissions:
-      id-token: write
-      contents: read
     steps:
       - uses: actions/checkout@v5
         with:
@@ -218,67 +215,46 @@ jobs:
           pip install --break-system-packages --force-reinstall ../../target/wheels/boxlite-*.whl
           pip install --break-system-packages --quiet pytest pytest-asyncio pytest-timeout
 
-      # ── AWS OIDC ─────────────────────────────────────────────────
-      # Deliberately after the builds: nothing before this point needs
-      # AWS, so the STS session starts as late as possible.
-      - name: Check AWS role variable is set
-        run: |
-          [ -n "${AWS_ROLE_ARN}" ] || {
-            echo "::error::Repo variable AWS_E2E_DEV_ROLE_ARN is not set. Add it in Settings → Variables → Actions."
-            exit 1
-          }
-
-      # SHA-pinned per boxlite-app-env's policy (README "Pinning policy"):
-      # a floating ref on a third-party action is a supply-chain vector
-      # (CVE-2025-30066). This is the same SHA that repo's deploy
-      # workflows vet.
-      - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
-        with:
-          role-to-assume: ${{ env.AWS_ROLE_ARN }}
-          aws-region: ${{ env.AWS_REGION }}
-          role-session-name: e2e-dev-${{ github.run_id }}
-
       # ── Configure pytest credentials ─────────────────────────────
-      # NOT scripts/test/e2e/fixture_setup.py, which the local entry
-      # points (make test:e2e:setup, run.sh) use. That script talks to the
-      # stack's Postgres directly — `psql -h localhost -d boxlite_dev` for
-      # snapshot state, and an `UPDATE organization SET max_*_per_box`
-      # for quotas — because, as its own comment puts it, the fixture
-      # lives next to the DB. e2e-local and e2e-stack run on a host that
-      # bootstrapped that DB; this workflow runs on a GitHub runner
-      # against a remote API, so there is no localhost Postgres and
-      # fixture_setup would exit on the quota patch.
+      # Written here rather than by scripts/test/e2e/fixture_setup.py,
+      # which the local entry points (make test:e2e:setup, run.sh) use.
+      # That script talks to the stack's Postgres directly — `psql -h
+      # localhost -d boxlite_dev` for snapshot state, and an
+      # `UPDATE organization SET max_*_per_box` for quotas — because, as
+      # its own comment puts it, the fixture lives next to the DB.
+      # e2e-local and e2e-stack run on a host that bootstrapped that DB;
+      # this runs on a GitHub runner against a remote API, so there is no
+      # localhost Postgres and fixture_setup would exit on the quota patch.
       #
       # The consequence is deliberate: this workflow only READS from the
-      # dev stack's control plane. It registers no snapshots and rewrites
-      # no quotas — a deployed dev stack is expected to already have both,
-      # and silently UPDATE-ing a shared environment's org rows from CI
-      # would be worse than failing. The only writes are the boxes the
+      # dev control plane. It registers no snapshots and rewrites no
+      # quotas — a deployed dev stack is expected to already have both,
+      # and silently UPDATE-ing a shared environment's rows from CI would
+      # be worse than failing. The only writes to dev are the boxes the
       # suite itself creates and deletes.
       - name: Configure pytest profile p1
+        env:
+          BOXLITE_DEV_API_KEY: ${{ secrets.BOXLITE_DEV_API_KEY }}
         run: |
           set -euo pipefail
 
-          ADMIN_KEY=$(aws ssm get-parameter \
-            --name "/boxlite/${STAGE}/admin-api-key" \
-            --with-decryption \
-            --query Parameter.Value --output text)
-          if [ -z "$ADMIN_KEY" ] || [ "$ADMIN_KEY" = "None" ]; then
-            echo "::error::SSM parameter /boxlite/${STAGE}/admin-api-key is missing or empty. It must hold the dev stack's ADMIN_API_KEY."
+          if [ -z "${BOXLITE_DEV_API_KEY:-}" ]; then
+            echo "::error::Secret BOXLITE_DEV_API_KEY is not set. Add it in Settings → Secrets → Actions."
             exit 1
           fi
-          echo "::add-mask::$ADMIN_KEY"
+          echo "::add-mask::$BOXLITE_DEV_API_KEY"
 
-          # /v1/me is the auth smoke test, exactly as bootstrap.sh uses it
-          # locally: it exercises auth + DB + Redis in one call. A 401 here
-          # means the SSM value and the dev stack's ADMIN_API_KEY env have
-          # diverged — the API keys `boxlite-admin` off that env var on
-          # boot, so rotating one without the other breaks this step.
+          # /v1/me is the auth smoke test — it exercises auth + DB + Redis
+          # in one call, the same way bootstrap.sh probes a fresh stack.
+          # Report the status code so a failure names itself instead of
+          # surfacing later as an empty path_prefix.
           ME_HTTP=$(curl -sS -o /tmp/me.json -w '%{http_code}' \
-            -H "Authorization: Bearer $ADMIN_KEY" "${API_URL}/v1/me" || echo 000)
+            -H "Authorization: Bearer $BOXLITE_DEV_API_KEY" "${API_URL}/v1/me" || echo 000)
           if [ "$ME_HTTP" != "200" ]; then
-            echo "::error::/v1/me returned HTTP ${ME_HTTP}. If 401, the SSM admin key no longer matches the dev stack's ADMIN_API_KEY."
+            echo "::error::/v1/me returned HTTP ${ME_HTTP}."
+            if [ "$ME_HTTP" = "401" ]; then
+              echo "::error::401 means the key is no longer valid. This key belongs to a person: if that account was deleted, ApiKeyStrategy now throws 'User not found' and the key is dead for good. Issue a new one and update the secret."
+            fi
             exit 1
           fi
 
@@ -292,7 +268,7 @@ jobs:
           {
               printf '[profiles.p1]\n'
               printf 'url = "%s"\n'         "$API_URL"
-              printf 'api_key = "%s"\n'     "$ADMIN_KEY"
+              printf 'api_key = "%s"\n'     "$BOXLITE_DEV_API_KEY"
               printf 'path_prefix = "%s"\n' "$PATH_PREFIX"
           } > ~/.boxlite/credentials.toml
           chmod 600 ~/.boxlite/credentials.toml

--- a/.github/workflows/e2e-dev.yml
+++ b/.github/workflows/e2e-dev.yml
@@ -124,11 +124,20 @@ jobs:
           chmod 600 ~/.boxlite/credentials.toml
 
       # ── Run pytest ───────────────────────────────────────────────
-      # --ignore the C, Go, path-verification, exec-timeout, and
-      # node-entry tests (C/Go are FFI-binding tests; path-verify and
-      # node-entry need runner journal access; exec-timeout is flaky
-      # on the single-node dev runner).  node-coverage already covers
-      # the Node SDK REST surface without journal checks.
+      # --ignore rationale:
+      #  - C/Go entry+coverage: FFI-binding tests whose SDKs aren't built here.
+      #  - node-entry: needs runner journal access (unreachable from GHA
+      #    against remote dev); node-coverage already covers the Node REST
+      #    surface without journal checks.
+      #  - exec-timeout: the timeout fires and kills the process on time, but
+      #    the guest kills only the direct child — an orphaned grandchild
+      #    (e.g. `sh`'s `sleep`) keeps the stdout pipe open, so the attach
+      #    stream never EOFs and ex.wait() hangs to the 45s bound. Guest-side
+      #    root cause + fix tracked in #910. Un-ignore once that lands. The
+      #    kill itself is covered by sdks/python/tests/test_exec_timeout_sigalrm.py.
+      # test_path_verification is NOT ignored — despite the name it never
+      # touches the journal; it proves the API→Runner chain via the
+      # X-BoxLite-Api-Version response header + an exec marker.
       - name: Run E2E suite
         env:
           BOXLITE_E2E_SKIP_PATH_VERIFY: '1'
@@ -139,9 +148,8 @@ jobs:
               --ignore=scripts/test/e2e/cases/test_c_coverage.py \
               --ignore=scripts/test/e2e/cases/test_go_entry.py \
               --ignore=scripts/test/e2e/cases/test_go_coverage.py \
-              --ignore=scripts/test/e2e/cases/test_path_verification.py \
-              --ignore=scripts/test/e2e/cases/test_exec_timeout.py \
               --ignore=scripts/test/e2e/cases/test_node_entry.py \
+              --ignore=scripts/test/e2e/cases/test_exec_timeout.py \
               -v --tb=short --no-header -p no:cacheprovider \
               --timeout=180 --timeout-method=thread \
               --junit-xml=pytest-junit.xml

--- a/.github/workflows/e2e-dev.yml
+++ b/.github/workflows/e2e-dev.yml
@@ -14,13 +14,50 @@
 #
 # Authentication: boxlite API key stored as GitHub repo secret
 # `BOXLITE_DEV_API_KEY`. No AWS credentials needed.
+#
+# Triggers mirror e2e-local: push on main, a label-gated PR trigger, and
+# manual dispatch. The `e2e-dev` label is the cost gate — every run
+# consumes dev-stack capacity, so PRs opt in rather than run by default.
+#
+# Fork PRs: DENIED, and this is the one place the model diverges from
+# e2e-local. There, untrusted code runs in a job holding no secrets, so a
+# maintainer label is purely a cost decision. Here the pytest suite needs
+# BOXLITE_DEV_API_KEY in the same job that builds and runs the PR's own
+# code, so a labeled fork run would hand arbitrary code the dev API key —
+# a conftest.py is enough. The event is still pull_request_target with
+# head-SHA pinning so the trigger surface matches e2e-local and forks can
+# be enabled later by relaxing one branch in `should-run`, but that must
+# not happen until the credential is out of the untrusted job.
+#
+# Runbook: docs/ci/e2e-local.md covers the shared label/gate mechanics.
 
 name: E2E dev
 
 on:
   push:
-    branches:
-      - chore/e2e-required-merge-gate
+    branches: [main]
+    paths:
+      - 'src/boxlite/**'
+      - 'src/shared/**'
+      - 'src/cli/**'
+      - 'src/guest/**'
+      - 'sdks/**'
+      - 'scripts/test/e2e/**'
+      - '**/Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/e2e-dev.yml'
+  pull_request_target:
+    types: [labeled, synchronize]
+    branches: [main]
+    paths:
+      - 'src/boxlite/**'
+      - 'src/shared/**'
+      - 'src/cli/**'
+      - 'src/guest/**'
+      - 'sdks/**'
+      - 'scripts/test/e2e/**'
+      - '**/Cargo.toml'
+      - 'Cargo.lock'
   workflow_dispatch:
     inputs:
       api_url:
@@ -29,24 +66,71 @@ on:
         required: false
         default: 'https://api.dev.boxlite.ai/api'
 
+# pull_request_target's default token is write-capable — keep the
+# inherited token read-only, as e2e-local does.
 permissions:
   contents: read
 
+# Single global group: every run targets the same dev stack, so two in
+# flight would race over shared boxes. A newer push queues behind the
+# in-progress run instead of cancelling it — cancelling mid-suite leaks
+# boxes on the dev stack that nothing then cleans up.
 concurrency:
   group: e2e-dev
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 env:
   BOXLITE_DEPS_STUB: "1"
   API_URL: ${{ inputs.api_url || 'https://api.dev.boxlite.ai/api' }}
 
 jobs:
+  # =========================================================================
+  # Gate: PRs require the 'e2e-dev' label (only maintainers can add it).
+  # Same-repo PRs re-run while labeled. Fork PRs never run — see the header:
+  # this workflow's only job holds BOXLITE_DEV_API_KEY.
+  # =========================================================================
+  should-run:
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.check.outputs.run }}
+    steps:
+      - name: Check trigger conditions
+        id: check
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+        run: |
+          if [ "$EVENT_NAME" != "pull_request_target" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"   # push / workflow_dispatch
+            exit 0
+          fi
+          if ! echo "$LABELS" | jq -e 'index("e2e-dev")' > /dev/null 2>&1; then
+            echo "run=false" >> "$GITHUB_OUTPUT"  # label is the cost gate
+            exit 0
+          fi
+          if [ "$HEAD_REPO" = "$GITHUB_REPOSITORY" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Fork PRs cannot run E2E dev: the suite needs BOXLITE_DEV_API_KEY in the same job that runs the PR's code. Use workflow_dispatch from a maintainer branch instead."
+          fi
+
   e2e:
     name: E2E suite (dev)
+    needs: should-run
+    if: needs.should-run.outputs.run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v5
+        with:
+          # pull_request_target resolves to the BASE branch by default,
+          # which would silently test main instead of the PR. Pin the head
+          # SHA the maintainer approved when labeling; push/dispatch keep
+          # github.sha. Same-repo heads only — see `should-run`.
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
 
       # ── Health check ──────────────────────────────────────────────
       - name: Probe API health


### PR DESCRIPTION
Split out of #724, which carried two unrelated pieces of work. The runner build/rollout scripts went to #1062; this PR keeps only the E2E dev workflow, with the 11 original commits preserved on top of current main.

Adds `.github/workflows/e2e-dev.yml`: builds the Python SDK, Node SDK and CLI from source with `BOXLITE_DEPS_STUB=1`, then runs the REST e2e pytest suite against the already-deployed dev stack. It does not build or deploy the API or runner.

C/Go SDK cases are excluded (FFI-binding tests whose SDKs aren't built here), along with `test_node_entry` (needs runner journal access, unreachable from GHA) and `test_exec_timeout` (blocked on the guest-side orphaned-grandchild bug, #910).

## Authentication — one API key, nothing else

The suite needs exactly one credential. `e2e_auth.py` reads `[profiles.p1]` from `~/.boxlite/credentials.toml` and every request is `Authorization: Bearer <token>`; `path_prefix` is derived from the same key via `/v1/me`, not a second credential. So: one repo secret, `BOXLITE_DEV_API_KEY`. No AWS, no OIDC, no SSM.

The key is issued to a maintainer, which makes it mortal: API keys are primary-keyed on `(organizationId, userId, name)`, and `ApiKeyStrategy` re-reads the user on every request, throwing `UnauthorizedException('User not found')` once that account is deleted. Redis caches that lookup, so such a key keeps working for a TTL after the account goes and then fails for good — worth knowing if this ever looks flaky.

That is a property of the setup, not a diagnosis of the current secret. Run 29995466177 (2026-07-23) passed the credential step — the step that calls `/v1/me` — so the stored key authenticated fine that day, and that run's four failures were test failures, not auth. A 401 from here on means something changed since.

**The replacement is another maintainer key, chosen knowingly.** It is less privileged than the durable alternative (`boxlite-admin`, the principal the API provisions for itself on boot, which carries `SystemRole.ADMIN`), and it avoids provisioning a service account that nothing else currently needs. The trade-off is that it dies the same way if its owner is offboarded. That is documented at the top of the file, and the preflight names it: a 401 prints that the owning account may have been deleted, rather than leaving the next reader to rediscover the cause.

## The run is read-only against dev

Credentials are written locally rather than by `scripts/test/e2e/fixture_setup.py`, which the local entry points use. That script reaches the stack's Postgres directly — `psql -h localhost -d boxlite_dev` for snapshot state, and `UPDATE organization SET max_*_per_box` for quotas — because, as its own comment says, the fixture lives next to the DB. e2e-local and e2e-stack run on a host that bootstrapped that DB; this runs on a GitHub runner against a remote API, so there is no localhost Postgres and `fixture_setup` would exit on the quota patch.

That is also the right outcome: registering snapshots and rewriting `organization` rows on a shared deployed environment is not something a CI run should do silently. A deployed dev stack is expected to already satisfy those prerequisites. The workflow only reads `/health` and `/v1/me`; the only writes to dev are the boxes the suite itself creates and deletes.

The API URL comes from `vars.BOXLITE_DEV_API_URL`, falling back to the built-in `https://api.dev.boxlite.ai/api`, and a `workflow_dispatch` input overrides both for a single run. That input deliberately has no default: with one set, `inputs.api_url` is always non-empty on a dispatch run, so the variable would have been silently ignored exactly when someone dispatches against the configured stack. This follows how e2e-local stores config — environment-specific but non-secret values as repo Variables, stable ones hardcoded.

## Triggers

The version in #724 pinned `push` to the branch it lived on, so it would never have fired once merged. Replaced with e2e-local's model:

- `push` on `main` behind path filters
- `pull_request_target` (`labeled`, `synchronize`) gated by an **`e2e-dev`** label, held by a `should-run` job copied from e2e-local
- `workflow_dispatch`, keeping the `api_url` input

Checkout pins `github.event.pull_request.head.sha` — `pull_request_target` otherwise resolves to the base branch and would silently test `main` instead of the PR.

**Fork PRs are denied, not label-gated.** e2e-local can let labeled fork code run because its test job holds no secrets. Here the key sits in the same job that builds and runs the PR's own code, and GitHub has no secret-safe way to pass a credential from a privileged job to an unprivileged one — job outputs are plaintext. Same-repo PRs are allowed because their authors already have write access.

`cancel-in-progress` is off, matching e2e-local but for a different reason — e2e-local protects a persistent EC2 instance's warm caches, while this runs on `ubuntu-latest`. The reason here is box cleanup: the `box` fixture's teardown is the only thing that deletes a run's boxes, since `auto_remove` is a no-op over REST (`deprecated_auto_remove_does_not_change_rest_lifecycle_defaults`) and the API defaults `autoDelete` to disabled. A run killed mid-suite strands every box it had open; they auto-stop after 15 min but are never deleted. This bounds the damage rather than eliminating it — GitHub keeps only the newest *pending* run per group, so intermediate queued pushes are superseded before they start, and those never create boxes.

## Before this can run

`workflow_dispatch` and `pull_request_target` both need the workflow present on the **default branch**, so nothing can trigger it until this merges — including this PR, which is also fork-based and therefore denied by `should-run`. First run has to be a manual dispatch after merge:

```
gh workflow run e2e-dev.yml --repo boxlite-ai/boxlite --ref main
```

Test plan:
- [x] Test-execution steps byte-identical to #724 head bf3e2c8; the header, trigger block, `should-run` gate and credential step are the changes
- [x] Branch diff vs `main` touches exactly this one file
- [x] YAML parses; 2 jobs, `push` + `pull_request_target` + `workflow_dispatch`, 11 steps in `e2e`
- [x] `bash -n` clean on every embedded `run` script
- [x] `should-run` logic exercised over 7 cases — push, dispatch, no label, wrong label (`e2e-local`), empty label array, labeled same-repo, labeled fork — each returns the expected verdict
- [x] Precedence of `inputs.api_url` / `vars.BOXLITE_DEV_API_URL` / built-in default verified over all four combinations
- [ ] Secret `BOXLITE_DEV_API_KEY` confirmed still valid — last verified working 2026-07-23; not re-testable from outside the repo
- [ ] `e2e-dev` label created (needed only for the PR trigger, not for dispatch)
- [ ] Green run against the dev stack via `workflow_dispatch` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a new GitHub Actions E2E workflow for the development environment that runs the Python E2E pytest suite against an already-running dev service.
  * Supports automatic triggering on relevant code changes, runs for appropriately labeled pull requests, and manual execution with an optional API URL.
  * Adds safeguards for fork handling, performs a service health check, sets up temporary dev credentials, and always uploads JUnit-formatted test results (even if failures occur).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
