### PR TITLE
fix(hooks): read mtime via GNU stat -c first across preflight hooks

### DIFF
--- a/.claude/hooks/preflight-commit-push.sh
+++ b/.claude/hooks/preflight-commit-push.sh
@@ -140,7 +140,8 @@ valid_handoff_command_hash() {
   handoff_kind="$(jq -r '.command_kind // ""' "$handoff_file" 2>/dev/null || echo '')"
   handoff_diff_hash="$(jq -r '.diff_hash // ""' "$handoff_file" 2>/dev/null || echo '')"
   handoff_command_hash="$(jq -r '.command_hash // ""' "$handoff_file" 2>/dev/null || echo '')"
-  handoff_mtime="$(stat -f '%m' "$handoff_file" 2>/dev/null || stat -c '%Y' "$handoff_file" 2>/dev/null || echo 0)"
+  handoff_mtime="$(stat -c '%Y' "$handoff_file" 2>/dev/null || stat -f '%m' "$handoff_file" 2>/dev/null || echo 0)"
+  [[ "$handoff_mtime" =~ ^[0-9]+$ ]] || handoff_mtime=0
   now_epoch="$(date +%s)"
   handoff_age=$(( now_epoch - handoff_mtime ))
 
@@ -199,9 +200,12 @@ ${invoke_instruction}"
 Retry the push through the git-level pre-push gate so it can produce the exact ref-update audit command."
   fi
 
-  # File mtime as freshness signal: portable across BSD (stat -f %m) and GNU
-  # (stat -c %Y) without parsing self-reported timestamps.
-  audit_mtime="$(stat -f '%m' "$audit_file" 2>/dev/null || stat -c '%Y' "$audit_file" 2>/dev/null || echo 0)"
+  # File mtime as freshness signal, without parsing self-reported timestamps.
+  # GNU (stat -c %Y) first: on GNU/uutils, BSD's `stat -f` is --file-system and
+  # exits nonzero while printing an FS block to stdout, which the `||` would
+  # concatenate with the epoch. Real BSD lacks -c, so it falls through to -f.
+  audit_mtime="$(stat -c '%Y' "$audit_file" 2>/dev/null || stat -f '%m' "$audit_file" 2>/dev/null || echo 0)"
+  [[ "$audit_mtime" =~ ^[0-9]+$ ]] || audit_mtime=0
   now_epoch="$(date +%s)"
   age=$(( now_epoch - audit_mtime ))
 

--- a/.claude/hooks/preflight-pr-review.sh
+++ b/.claude/hooks/preflight-pr-review.sh
@@ -183,7 +183,8 @@ marker_branch="$(jq -r '.branch // ""' "$marker_file" 2>/dev/null || echo '')"
 marker_head="$(jq -r '.head // ""' "$marker_file" 2>/dev/null || echo '')"
 marker_message="$(jq -r '.message // ""' "$marker_file" 2>/dev/null || echo '')"
 
-marker_mtime="$(stat -f '%m' "$marker_file" 2>/dev/null || stat -c '%Y' "$marker_file" 2>/dev/null || echo 0)"
+marker_mtime="$(stat -c '%Y' "$marker_file" 2>/dev/null || stat -f '%m' "$marker_file" 2>/dev/null || echo 0)"
+[[ "$marker_mtime" =~ ^[0-9]+$ ]] || marker_mtime=0
 now_epoch="$(date +%s)"
 age=$(( now_epoch - marker_mtime ))
 

--- a/.claude/hooks/preflight-verdict-check.sh
+++ b/.claude/hooks/preflight-verdict-check.sh
@@ -301,8 +301,14 @@ if [[ -r "$verdict_file" ]]; then
   v_tree="$(jq -r '.tree_hash // ""'   "$verdict_file" 2>/dev/null || echo '')"
   v_verdict="$(jq -r '.verdict // ""'  "$verdict_file" 2>/dev/null || echo '')"
 
-  # mtime as freshness signal — portable across BSD (stat -f %m) and GNU (stat -c %Y).
-  v_mtime="$(stat -f '%m' "$verdict_file" 2>/dev/null || stat -c '%Y' "$verdict_file" 2>/dev/null || echo 0)"
+  # mtime as freshness signal. Try GNU (stat -c %Y) FIRST. On GNU/uutils, BSD's
+  # `stat -f %m` reads as --file-system with %m and the file as two operands: %m
+  # errors to stderr (swallowed), the file's FS block prints to *stdout* (not
+  # swallowed), and it exits 1 — so the `||` also runs -c %Y, concatenating the
+  # FS block and the epoch into v_mtime and poisoning the arithmetic below.
+  # GNU `-c` genuinely fails on real BSD, so BSD still falls through to -f.
+  v_mtime="$(stat -c '%Y' "$verdict_file" 2>/dev/null || stat -f '%m' "$verdict_file" 2>/dev/null || echo 0)"
+  [[ "$v_mtime" =~ ^[0-9]+$ ]] || v_mtime=0
   now_epoch="$(date +%s)"
   age=$(( now_epoch - v_mtime ))
 

--- a/.claude/hooks/run-commit-push-audit.sh
+++ b/.claude/hooks/run-commit-push-audit.sh
@@ -113,7 +113,8 @@ valid_push_audit_context() {
   ctx_command_hash="$(jq -r '.command_hash // ""' "$push_context_meta_file" 2>/dev/null || echo '')"
   ctx_pushed_diff_hash="$(jq -r '.pushed_diff_hash // ""' "$push_context_meta_file" 2>/dev/null || echo '')"
   actual_diff_hash="$(hash_file "$push_context_diff_file")"
-  ctx_mtime="$(stat -f '%m' "$push_context_meta_file" 2>/dev/null || stat -c '%Y' "$push_context_meta_file" 2>/dev/null || echo 0)"
+  ctx_mtime="$(stat -c '%Y' "$push_context_meta_file" 2>/dev/null || stat -f '%m' "$push_context_meta_file" 2>/dev/null || echo 0)"
+  [[ "$ctx_mtime" =~ ^[0-9]+$ ]] || ctx_mtime=0
   now_epoch="$(date +%s)"
   age=$(( now_epoch - ctx_mtime ))
 

--- a/.claude/hooks/run-verdict-audit.sh
+++ b/.claude/hooks/run-verdict-audit.sh
@@ -43,7 +43,8 @@ turn that asserts nothing verifiable is a PASS. Follow your procedure and write 
 dossier to ${verdict_file}. transcript_path: ${transcript_path}"
 
 # The audit must be attributable to a fresh run, not a leftover dossier.
-before_mtime="$(stat -f '%m' "$verdict_file" 2>/dev/null || stat -c '%Y' "$verdict_file" 2>/dev/null || echo 0)"
+before_mtime="$(stat -c '%Y' "$verdict_file" 2>/dev/null || stat -f '%m' "$verdict_file" 2>/dev/null || echo 0)"
+[[ "$before_mtime" =~ ^[0-9]+$ ]] || before_mtime=0
 
 if [[ -n "${VERDICT_AUDITOR_CMD:-}" ]]; then
   printf '%s' "$audit_prompt" | bash -c "$VERDICT_AUDITOR_CMD" || true
@@ -69,7 +70,8 @@ EOF
   exit 2
 fi
 
-after_mtime="$(stat -f '%m' "$verdict_file" 2>/dev/null || stat -c '%Y' "$verdict_file" 2>/dev/null || echo 0)"
+after_mtime="$(stat -c '%Y' "$verdict_file" 2>/dev/null || stat -f '%m' "$verdict_file" 2>/dev/null || echo 0)"
+[[ "$after_mtime" =~ ^[0-9]+$ ]] || after_mtime=0
 if [[ -r "$verdict_file" && "$after_mtime" != "$before_mtime" ]] \
    && jq -e '.verdict and .branch and .tree_hash' "$verdict_file" >/dev/null 2>&1; then
   echo "audit complete: $(jq -r '.verdict' "$verdict_file") → $verdict_file"


### PR DESCRIPTION
## Problem

The preflight hooks read a file's mtime via a BSD-first chain:
`stat -f '%m' … || stat -c '%Y' …`. On GNU/uutils, `stat -f` means
`--file-system`: the format and the file become two operands, the format
errors to stderr (swallowed) while the file's FS block prints to **stdout**
(not swallowed) and it exits 1 — so the `||` also runs `-c %Y`, and the mtime
variable captures the FS block **plus** the epoch. Under `set -u` that
concatenation crashed the Stop hook with `File: unbound variable` in the
`$((now - mtime))` arithmetic.

## Fix

Reorder every site to GNU `-c %Y` first (real BSD lacks `-c` and still falls
through to `-f`), and guard each mtime to digits so non-numeric `stat` output
can no longer crash the arithmetic. All 7 occurrences across 5 hooks:
`preflight-verdict-check`, `preflight-pr-review`, `preflight-commit-push` (×2),
`run-verdict-audit` (×2), `run-commit-push-audit`.

## Verification

- Red→green: old order → `File: unbound variable`; patched → numeric epoch,
  arithmetic succeeds.
- `bash -n` clean on all 5 hooks; grep confirms no BSD-first `stat -f '%m'` remains.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility across Linux, macOS, and BSD environments when checking file timestamps.
  * Prevented invalid timestamp values from disrupting freshness, expiration, and audit validation checks.
  * Ensured stale or malformed validation markers are handled safely and require renewed verification when necessary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->