### PR TITLE
fix(api): use the correct cloud API endpoint

### DIFF
--- a/apps/dashboard/src/lib/environment.test.ts
+++ b/apps/dashboard/src/lib/environment.test.ts
@@ -25,9 +25,9 @@ describe('getRestApiUrl', () => {
 
   it('uses a pinned URL for environments that define one', () => {
     expect(getRestApiUrl(fallback, 'dev.boxlite.ai')).toBe('https://dev.boxlite.ai/api')
-    expect(getRestApiUrl(fallback, 'app.boxlite.ai')).toBe('https://api.boxlite.ai/api')
+    expect(getRestApiUrl(fallback, 'app.boxlite.ai')).toBe('https://app.boxlite.ai/api')
     expect(getRestApiUrl(fallback, 'localhost', 'https://auth.dev.boxlite.ai')).toBe('https://dev.boxlite.ai/api')
-    expect(getRestApiUrl(fallback, 'localhost', 'https://auth.boxlite.ai')).toBe('https://api.boxlite.ai/api')
+    expect(getRestApiUrl(fallback, 'localhost', 'https://auth.boxlite.ai')).toBe('https://app.boxlite.ai/api')
   })
 
   it('falls back when the environment has no pinned URL (e.g. local)', () => {

--- a/apps/dashboard/src/lib/environment.ts
+++ b/apps/dashboard/src/lib/environment.ts
@@ -23,7 +23,7 @@ export type AppEnvironment = 'local' | 'development' | 'production'
 // `local` is intentionally omitted: it falls back to the dashboard's own /api.
 const REST_API_URL_BY_ENV: Partial<Record<AppEnvironment, string>> = {
   development: 'https://dev.boxlite.ai/api',
-  production: 'https://api.boxlite.ai/api',
+  production: 'https://app.boxlite.ai/api',
 }
 
 /** Resolve the current environment from the API issuer and browser hostname. */

--- a/apps/scripts/start-dashboard.mjs
+++ b/apps/scripts/start-dashboard.mjs
@@ -18,7 +18,7 @@ const appsBinPath = path.join(appsRoot, 'node_modules', '.bin')
 const API_TARGETS = {
   local: 'http://localhost:3001',
   dev: 'https://dev.boxlite.ai',
-  // prod: 'https://api.boxlite.ai', // placeholder — set the real prod API origin and
+  // prod: 'https://app.boxlite.ai', // placeholder — set the real prod API origin and
   //                                  // uncomment once the prod stage exists. Prod is
   //                                  // also guarded below (needs --yes-prod).
 }

--- a/openapi/box.openapi.yaml
+++ b/openapi/box.openapi.yaml
@@ -99,12 +99,12 @@ servers:
         default: https
         enum: [https, http]
       host:
-        default: api.boxlite.ai
+        default: app.boxlite.ai
       basePath:
         description: |
           Deployment-defined hostpath prefix. Empty for local servers
           (`boxlite serve` at `http://localhost:8100/v1/…`); typically
-          `/api` for cloud deployments (`https://api.boxlite.ai/api/v1/…`).
+          `/api` for cloud deployments (`https://app.boxlite.ai/api/v1/…`).
         default: ""
 
 # ---------------------------------------------------------------------------

--- a/sdks/node/README.md
+++ b/sdks/node/README.md
@@ -130,7 +130,7 @@ pair, or any other multi-segment value such as `us-east/team-42`.
 import { JsBoxlite, BoxliteRestOptions, ApiKeyCredential } from '@boxlite-ai/boxlite';
 
 const rt = JsBoxlite.rest(new BoxliteRestOptions({
-  url: 'https://api.boxlite.ai/api',
+  url: 'https://app.boxlite.ai/api',
   credential: new ApiKeyCredential('blk_live_…'),
   pathPrefix: 'acme',   // → requests hit /v1/acme/boxes
 }));

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -206,7 +206,7 @@ pair, or any other multi-segment value such as `us-east/team-42`.
 ```python
 rt = Boxlite.rest(
     BoxliteRestOptions(
-        url="https://api.boxlite.ai/api",
+        url="https://app.boxlite.ai/api",
         credential=ApiKeyCredential("blk_live_…"),
         path_prefix="acme",  # → requests hit /v1/acme/boxes
     )

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -266,7 +266,7 @@ Credential:      API key (from ~/.boxlite/credentials.toml [local])
 **Example output (OIDC session):**
 
 ```
-Logged in to:    https://api.boxlite.ai/api
+Logged in to:    https://app.boxlite.ai/api
 Credential:      OIDC bearer token (from ~/.boxlite/credentials.toml [cloud])
 Expires:         2026-05-21T15:42:00+00:00
 ```
@@ -288,7 +288,7 @@ Logged in as:    dev@acme.test
 Name:            Dev McAcme
 Principal:       auth0|abc123 (user)
 Organization:    acme
-Server:          https://api.boxlite.ai/api
+Server:          https://app.boxlite.ai/api
 Scopes:          box:read, box:write, box:exec, image:read, snapshot:read
 ```
 

--- a/src/cli/src/commands/auth/oidc/discovery.rs
+++ b/src/cli/src/commands/auth/oidc/discovery.rs
@@ -54,7 +54,7 @@ struct ServerOidcConfig {
 ///   matching the Go CLI's build-info defaults.
 ///
 /// `server_url` is expected to be the same value passed to `--url` (e.g.
-/// `https://api.boxlite.ai/api`). When the server lookup fails (offline,
+/// `https://app.boxlite.ai/api`). When the server lookup fails (offline,
 /// older boxlite serve that doesn't expose `/config`) we silently fall
 /// through to env vars; if nothing supplies an issuer the caller gets an
 /// `anyhow::Error` with the list of sources we tried.
@@ -195,7 +195,7 @@ async fn fetch_server_oidc(server_url: &str, http: &reqwest::Client) -> Option<S
 }
 
 /// Compute the `/config` URL from a server base URL, preserving any prefix
-/// (e.g. `https://api.boxlite.ai/api/config`). `reqwest::Url::join` would
+/// (e.g. `https://app.boxlite.ai/api/config`). `reqwest::Url::join` would
 /// strip the trailing path segment when the base lacks a trailing slash, so
 /// we append explicitly.
 fn join_config_url(server_url: &str) -> Result<url::Url> {
@@ -256,14 +256,14 @@ mod tests {
 
     #[test]
     fn join_config_url_appends_to_prefix() {
-        let u = join_config_url("https://api.boxlite.ai/api").unwrap();
-        assert_eq!(u.as_str(), "https://api.boxlite.ai/api/config");
+        let u = join_config_url("https://app.boxlite.ai/api").unwrap();
+        assert_eq!(u.as_str(), "https://app.boxlite.ai/api/config");
     }
 
     #[test]
     fn join_config_url_strips_trailing_slash() {
-        let u = join_config_url("https://api.boxlite.ai/api/").unwrap();
-        assert_eq!(u.as_str(), "https://api.boxlite.ai/api/config");
+        let u = join_config_url("https://app.boxlite.ai/api/").unwrap();
+        assert_eq!(u.as_str(), "https://app.boxlite.ai/api/config");
     }
 
     /// Toggle is an involution — runs once to add, again to remove.

--- a/src/cli/src/commands/auth/oidc/refresh.rs
+++ b/src/cli/src/commands/auth/oidc/refresh.rs
@@ -164,7 +164,7 @@ mod tests {
 
     fn oidc_profile_with_expiry(expires_at: chrono::DateTime<Utc>) -> Profile {
         Profile {
-            url: "https://api.boxlite.ai/api".to_string(),
+            url: "https://app.boxlite.ai/api".to_string(),
             access_token: Some(SecretString::from("at".to_string())),
             refresh_token: Some(SecretString::from("rt".to_string())),
             expires_at: Some(expires_at),
@@ -213,7 +213,7 @@ mod tests {
     fn clear_oidc_session_keeps_url_and_method() {
         let mut p = oidc_profile_with_expiry(Utc::now());
         clear_oidc_session(&mut p);
-        assert_eq!(p.url, "https://api.boxlite.ai/api");
+        assert_eq!(p.url, "https://app.boxlite.ai/api");
         assert!(p.access_token.is_none());
         assert!(p.refresh_token.is_none());
         assert!(p.oidc_issuer.is_none());
@@ -225,7 +225,7 @@ mod tests {
     #[test]
     fn apply_tokens_populates_all_oidc_fields() {
         let mut p = Profile {
-            url: "https://api.boxlite.ai/api".to_string(),
+            url: "https://app.boxlite.ai/api".to_string(),
             ..Profile::default()
         };
         let cfg = OidcConfig {

--- a/src/cli/src/credentials.rs
+++ b/src/cli/src/credentials.rs
@@ -370,7 +370,7 @@ mod tests {
 
     fn sample_oidc_profile() -> Profile {
         Profile {
-            url: "https://api.boxlite.ai/api".to_string(),
+            url: "https://app.boxlite.ai/api".to_string(),
             access_token: Some(SecretString::from("at-abc".to_string())),
             refresh_token: Some(SecretString::from("rt-xyz".to_string())),
             id_token: Some(SecretString::from("eyJhbGciOi...".to_string())),
@@ -489,7 +489,7 @@ mod tests {
     #[tokio::test]
     async fn into_rest_options_propagates_path_prefix() {
         let profile = Profile {
-            url: "https://api.boxlite.ai/api".to_string(),
+            url: "https://app.boxlite.ai/api".to_string(),
             api_key: Some(SecretString::from("blk_live_x".to_string())),
             path_prefix: Some("acme".to_string()),
             ..Profile::default()
@@ -664,7 +664,7 @@ mod tests {
     #[tokio::test]
     async fn into_rest_options_oidc_uses_access_token() {
         let profile = Profile {
-            url: "https://api.boxlite.ai/api".to_string(),
+            url: "https://app.boxlite.ai/api".to_string(),
             api_key: Some(SecretString::from("should-not-be-used".to_string())),
             access_token: Some(SecretString::from("oidc-at".to_string())),
             auth_method: AuthMethod::Oidc,


### PR DESCRIPTION
## Summary

Replace the unavailable `https://api.boxlite.ai/api` cloud REST endpoint with `https://app.boxlite.ai/api`.

This aligns the Dashboard production configuration, OpenAPI contract, SDK documentation, CLI examples, and related tests with the deployed cloud endpoint.

Closes [#<issue-number>](https://github.com/boxlite-ai/boxlite/issues/1067)

## Changes

- Update the Dashboard production REST API URL and its regression test.
- Update the OpenAPI default cloud server and example route.
- Align Python and Node.js SDK documentation with the deployed endpoint.
- Update CLI documentation, OIDC examples, and test fixtures.
- Update the Dashboard production API target example.
- Remove all remaining `api.boxlite.ai` references from the repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Updated production API routing to use `https://app.boxlite.ai/api`.
  * Updated cloud API documentation, SDK examples, CLI examples, and authentication references to reflect the new URL.
  * Aligned environment handling and authentication test scenarios with the updated production endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->