### PR TITLE
ci(e2e): rename e2e-dev workflow to e2e-cloud

### DIFF
--- a/.github/workflows/e2e-cloud.yml
+++ b/.github/workflows/e2e-cloud.yml
@@ -46,7 +46,7 @@
 # currently needs.
 #
 # Triggers mirror e2e-local: push on main, a label-gated PR trigger, and
-# manual dispatch. The `e2e-dev` label is the cost gate — every run
+# manual dispatch. The `e2e-cloud` label is the cost gate — every run
 # consumes dev-stack capacity, so PRs opt in rather than run by default.
 #
 # Fork PRs: DENIED, and this is the one place the model diverges from
@@ -67,7 +67,7 @@
 #
 # Runbook: docs/ci/e2e-local.md covers the shared label/gate mechanics.
 
-name: E2E dev
+name: E2E cloud
 
 on:
   push:
@@ -81,7 +81,7 @@ on:
       - 'scripts/test/e2e/**'
       - '**/Cargo.toml'
       - 'Cargo.lock'
-      - '.github/workflows/e2e-dev.yml'
+      - '.github/workflows/e2e-cloud.yml'
   pull_request_target:
     types: [labeled, synchronize]
     branches: [main]
@@ -123,7 +123,7 @@ permissions:
 # GitHub retains only the newest *pending* run per group, so intermediate
 # queued pushes are still superseded before they ever start.
 concurrency:
-  group: e2e-dev
+  group: e2e-cloud
   cancel-in-progress: false
 
 env:
@@ -135,7 +135,7 @@ env:
 
 jobs:
   # =========================================================================
-  # Gate: PRs require the 'e2e-dev' label (only maintainers can add it).
+  # Gate: PRs require the 'e2e-cloud' label (only maintainers can add it).
   # Same-repo PRs re-run while labeled. Fork PRs never run — see the header:
   # this workflow's only job holds a live dev API key.
   # =========================================================================
@@ -155,7 +155,7 @@ jobs:
             echo "run=true" >> "$GITHUB_OUTPUT"   # push / workflow_dispatch
             exit 0
           fi
-          if ! echo "$LABELS" | jq -e 'index("e2e-dev")' > /dev/null 2>&1; then
+          if ! echo "$LABELS" | jq -e 'index("e2e-cloud")' > /dev/null 2>&1; then
             echo "run=false" >> "$GITHUB_OUTPUT"  # label is the cost gate
             exit 0
           fi
@@ -163,11 +163,11 @@ jobs:
             echo "run=true" >> "$GITHUB_OUTPUT"
           else
             echo "run=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::Fork PRs cannot run E2E dev: the suite needs a live dev API key in the same job that runs the PR's code. Use workflow_dispatch from a maintainer branch instead."
+            echo "::notice::Fork PRs cannot run E2E cloud: the suite needs a live dev API key in the same job that runs the PR's code. Use workflow_dispatch from a maintainer branch instead."
           fi
 
   e2e:
-    name: E2E suite (dev)
+    name: E2E suite (cloud)
     needs: should-run
     if: needs.should-run.outputs.run == 'true'
     runs-on: ubuntu-latest


### PR DESCRIPTION
Renames the E2E workflow added in #1063 from `e2e-dev` to `e2e-cloud`.

The old name described the environment it defaults to; the new one describes the surface it tests — a deployed cloud stack — which gives a local/cloud axis alongside `e2e-local.yml`. The environment stays a parameter (`API_URL`), so the workflow can point at any deployed stack without the name going stale.

## What changed

Single `git mv` plus 8 identity tokens:

| Line | Before | After |
| --- | --- | --- |
| 70 | `name: E2E dev` | `name: E2E cloud` |
| 84 | push path filter `e2e-dev.yml` | `e2e-cloud.yml` |
| 126 | `concurrency.group: e2e-dev` | `e2e-cloud` |
| 158 | `jq -e 'index("e2e-dev")'` | `index("e2e-cloud")` |
| 170 | `name: E2E suite (dev)` | `E2E suite (cloud)` |
| 49, 138, 166 | comment / `::notice::` mentions | updated |

## What deliberately did not change

`BOXLITE_DEV_API_KEY`, `BOXLITE_DEV_API_URL`, and the `api.dev.boxlite.ai` default name the *target environment*, not the workflow. Renaming the secret and variable would need a lockstep repo-settings change to keep the workflow working, and would misname what they point at. Line 1 already reads "the dev cloud stack", so both axes stay coherent: identity = cloud, environment = dev.

`apps/package.json`'s `e2e:dev` → `apps/scripts/e2e-dev-smoke.mjs` is an unrelated dashboard smoke script and is untouched.

## Repo settings — order matters

1. **Create the `e2e-cloud` label only after this merges.** `pull_request_target` evaluates the *base branch's* workflow definition, so `main` keeps gating on `e2e-dev` until then; renaming the label early would break triggering for every other open PR. Creating `e2e-cloud` alongside `e2e-dev` and deleting the old one after merge also works.
2. **Required status checks** move from `E2E dev` / `E2E suite (dev)` to the cloud variants.
3. **Don't merge with a run in flight** — the old and new concurrency groups don't serialize against each other, and that group exists to keep two suites off the shared dev stack. Self-healing after the first run.

Renaming the file also makes Actions treat this as a new workflow: prior run history stays under the old entry, and `workflow_dispatch` for the new name appears once it is on the default branch.

## Test plan

No test suite covers workflow YAML, and this changes no behavior beyond the literal the label gate compares, so verification is structural and behavioral rather than a reproducer:

- [x] YAML parses — `name: E2E cloud`, 3 triggers, `concurrency.group: e2e-cloud`, 2 jobs, job `E2E suite (cloud)`, 11 steps, push path filter self-reference updated
- [x] `bash -n` clean on the `should-run` gate script extracted from the YAML
- [x] Gate exercised over 7 cases against the live file — push ✅, `workflow_dispatch` ✅, no label ❌, wrong label `e2e-local` ❌, **old label `e2e-dev` ❌**, new label `e2e-cloud` ✅, fork + new label ❌
- [x] Repo-wide sweep for `e2e-dev` / `E2E dev` / `E2E suite (dev)` / `e2e_dev` / `e2e:dev` — one hit, the unrelated `apps/package.json` smoke script
- [x] No labeler config, CODEOWNERS entry, issue template, or `workflow_call` names this workflow
- [ ] Green `workflow_dispatch` run after merge (`gh workflow run e2e-cloud.yml --repo boxlite-ai/boxlite --ref main`) — the workflow has never run under either name; `pull_request_target.paths` has no `.github/workflows/**` entry, so this PR cannot trigger it even when labeled

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7HcbzZ34qjfzUv4pALQme


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated end-to-end cloud testing workflow naming and configuration.
  * Improved labeling and messaging used to control when cloud end-to-end tests run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->