### PR TITLE
fix(codeowners): reference the existing reviewer team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,8 +2,8 @@
 # Order matters: the LAST matching pattern for a path wins.
 # Referenced teams must have explicit repo access or the rule is ignored by GitHub.
 
-# All code is owned by the reviewers team.
-*                          @boxlite-ai/reviewers
+# All code is owned by the reviewer team.
+*                          @boxlite-ai/reviewer
 
 # Legal and contributor policy changes require project owner review.
 /CONTRIBUTING.md           @DorianZheng


### PR DESCRIPTION
## Summary

`.github/CODEOWNERS` assigns all paths to `@boxlite-ai/reviewers`. That team does not exist — the org team is `reviewer`. GitHub ignores a CODEOWNERS rule naming a nonexistent team, so the active `main` ruleset's `require_code_owner_review` has no owners to request.

GitHub's own validator against the current default branch:

```
$ gh api repos/boxlite-ai/boxlite/codeowners/errors
Unknown owner on line 6: make sure the team @boxlite-ai/reviewers exists,
is publicly visible, and has write access to the repository
```

## Follow-up required

This rename satisfies two of the validator's three conditions — the team exists, and `reviewer.privacy` is `closed` rather than `secret`, so it is publicly visible. It does not satisfy the third: `reviewer` has no access to this repository today (`contributors` = triage, `maintainers` = admin). Granting the team write access is a repository settings change and is not part of this PR.

https://claude.ai/code/session_01Sg4N93Wo287KvCoQywWUAX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository code ownership configuration to route reviews to the current reviewer team.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->