### PR TITLE
fix(hooks): make mtime checks portable

### DIFF
--- a/.claude/hooks/preflight-commit-push.sh
+++ b/.claude/hooks/preflight-commit-push.sh
@@ -70,6 +70,19 @@ branch="$(git -C "$repo_root" branch --show-current 2>/dev/null || echo '?')"
 head="$(git -C "$repo_root" rev-parse HEAD 2>/dev/null || echo '?')"
 max_age_seconds=600
 
+file_mtime_epoch() {
+  local path="$1" mtime
+  if mtime="$(stat -c '%Y' "$path" 2>/dev/null)" && [[ "$mtime" =~ ^[0-9]+$ ]]; then
+    printf '%s' "$mtime"
+    return
+  fi
+  if mtime="$(stat -f '%m' "$path" 2>/dev/null)" && [[ "$mtime" =~ ^[0-9]+$ ]]; then
+    printf '%s' "$mtime"
+    return
+  fi
+  printf '0'
+}
+
 hash_stdin() {
   shasum -a 256 | awk '{print $1}'
 }
@@ -140,7 +153,7 @@ valid_handoff_command_hash() {
   handoff_kind="$(jq -r '.command_kind // ""' "$handoff_file" 2>/dev/null || echo '')"
   handoff_diff_hash="$(jq -r '.diff_hash // ""' "$handoff_file" 2>/dev/null || echo '')"
   handoff_command_hash="$(jq -r '.command_hash // ""' "$handoff_file" 2>/dev/null || echo '')"
-  handoff_mtime="$(stat -f '%m' "$handoff_file" 2>/dev/null || stat -c '%Y' "$handoff_file" 2>/dev/null || echo 0)"
+  handoff_mtime="$(file_mtime_epoch "$handoff_file")"
   now_epoch="$(date +%s)"
   handoff_age=$(( now_epoch - handoff_mtime ))
 
@@ -199,9 +212,8 @@ ${invoke_instruction}"
 Retry the push through the git-level pre-push gate so it can produce the exact ref-update audit command."
   fi
 
-  # File mtime as freshness signal: portable across BSD (stat -f %m) and GNU
-  # (stat -c %Y) without parsing self-reported timestamps.
-  audit_mtime="$(stat -f '%m' "$audit_file" 2>/dev/null || stat -c '%Y' "$audit_file" 2>/dev/null || echo 0)"
+  # Keep failed platform probes from contaminating the successful command's output.
+  audit_mtime="$(file_mtime_epoch "$audit_file")"
   now_epoch="$(date +%s)"
   age=$(( now_epoch - audit_mtime ))
 

--- a/.claude/hooks/preflight-pr-review.sh
+++ b/.claude/hooks/preflight-pr-review.sh
@@ -67,6 +67,19 @@ head="$(git -C "$repo_root" rev-parse HEAD 2>/dev/null || echo '?')"
 marker_file="$project_dir/.claude/.pr-reviewed.json"
 max_age_seconds=600
 
+file_mtime_epoch() {
+  local path="$1" mtime
+  if mtime="$(stat -c '%Y' "$path" 2>/dev/null)" && [[ "$mtime" =~ ^[0-9]+$ ]]; then
+    printf '%s' "$mtime"
+    return
+  fi
+  if mtime="$(stat -f '%m' "$path" 2>/dev/null)" && [[ "$mtime" =~ ^[0-9]+$ ]]; then
+    printf '%s' "$mtime"
+    return
+  fi
+  printf '0'
+}
+
 deny() {
   jq -nc --arg r "$1" '{
     hookSpecificOutput: {
@@ -183,7 +196,7 @@ marker_branch="$(jq -r '.branch // ""' "$marker_file" 2>/dev/null || echo '')"
 marker_head="$(jq -r '.head // ""' "$marker_file" 2>/dev/null || echo '')"
 marker_message="$(jq -r '.message // ""' "$marker_file" 2>/dev/null || echo '')"
 
-marker_mtime="$(stat -f '%m' "$marker_file" 2>/dev/null || stat -c '%Y' "$marker_file" 2>/dev/null || echo 0)"
+marker_mtime="$(file_mtime_epoch "$marker_file")"
 now_epoch="$(date +%s)"
 age=$(( now_epoch - marker_mtime ))
 

--- a/.claude/hooks/preflight-verdict-check.sh
+++ b/.claude/hooks/preflight-verdict-check.sh
@@ -89,6 +89,19 @@
 # Tests: bash .claude/hooks/preflight-verdict-check.test.sh
 set -uo pipefail
 
+file_mtime_epoch() {
+  local path="$1" mtime
+  if mtime="$(stat -c '%Y' "$path" 2>/dev/null)" && [[ "$mtime" =~ ^[0-9]+$ ]]; then
+    printf '%s' "$mtime"
+    return
+  fi
+  if mtime="$(stat -f '%m' "$path" 2>/dev/null)" && [[ "$mtime" =~ ^[0-9]+$ ]]; then
+    printf '%s' "$mtime"
+    return
+  fi
+  printf '0'
+}
+
 payload="$(cat)"
 transcript_path="$(printf '%s' "$payload" | jq -r '.transcript_path // ""' 2>/dev/null || echo '')"
 
@@ -301,8 +314,8 @@ if [[ -r "$verdict_file" ]]; then
   v_tree="$(jq -r '.tree_hash // ""'   "$verdict_file" 2>/dev/null || echo '')"
   v_verdict="$(jq -r '.verdict // ""'  "$verdict_file" 2>/dev/null || echo '')"
 
-  # mtime as freshness signal — portable across BSD (stat -f %m) and GNU (stat -c %Y).
-  v_mtime="$(stat -f '%m' "$verdict_file" 2>/dev/null || stat -c '%Y' "$verdict_file" 2>/dev/null || echo 0)"
+  # Keep failed platform probes from contaminating the successful command's output.
+  v_mtime="$(file_mtime_epoch "$verdict_file")"
   now_epoch="$(date +%s)"
   age=$(( now_epoch - v_mtime ))
 

--- a/.claude/hooks/run-commit-push-audit.sh
+++ b/.claude/hooks/run-commit-push-audit.sh
@@ -20,6 +20,19 @@ branch="$(git -C "$repo_root" branch --show-current 2>/dev/null || echo '?')"
 head="$(git -C "$repo_root" rev-parse HEAD 2>/dev/null || echo '?')"
 findings=()
 
+file_mtime_epoch() {
+  local path="$1" mtime
+  if mtime="$(stat -c '%Y' "$path" 2>/dev/null)" && [[ "$mtime" =~ ^[0-9]+$ ]]; then
+    printf '%s' "$mtime"
+    return
+  fi
+  if mtime="$(stat -f '%m' "$path" 2>/dev/null)" && [[ "$mtime" =~ ^[0-9]+$ ]]; then
+    printf '%s' "$mtime"
+    return
+  fi
+  printf '0'
+}
+
 hash_stdin() {
   shasum -a 256 | awk '{print $1}'
 }
@@ -113,7 +126,7 @@ valid_push_audit_context() {
   ctx_command_hash="$(jq -r '.command_hash // ""' "$push_context_meta_file" 2>/dev/null || echo '')"
   ctx_pushed_diff_hash="$(jq -r '.pushed_diff_hash // ""' "$push_context_meta_file" 2>/dev/null || echo '')"
   actual_diff_hash="$(hash_file "$push_context_diff_file")"
-  ctx_mtime="$(stat -f '%m' "$push_context_meta_file" 2>/dev/null || stat -c '%Y' "$push_context_meta_file" 2>/dev/null || echo 0)"
+  ctx_mtime="$(file_mtime_epoch "$push_context_meta_file")"
   now_epoch="$(date +%s)"
   age=$(( now_epoch - ctx_mtime ))
 

--- a/.claude/hooks/run-verdict-audit.sh
+++ b/.claude/hooks/run-verdict-audit.sh
@@ -21,6 +21,19 @@
 # Exit codes: 0 dossier written · 1 audit ran but no dossier · 2 no runner available.
 set -uo pipefail
 
+file_mtime_epoch() {
+  local path="$1" mtime
+  if mtime="$(stat -c '%Y' "$path" 2>/dev/null)" && [[ "$mtime" =~ ^[0-9]+$ ]]; then
+    printf '%s' "$mtime"
+    return
+  fi
+  if mtime="$(stat -f '%m' "$path" 2>/dev/null)" && [[ "$mtime" =~ ^[0-9]+$ ]]; then
+    printf '%s' "$mtime"
+    return
+  fi
+  printf '0'
+}
+
 transcript_path="${1:-}"
 if [[ -z "$transcript_path" ]]; then
   echo "usage: run-verdict-audit.sh <transcript_path>" >&2
@@ -43,7 +56,7 @@ turn that asserts nothing verifiable is a PASS. Follow your procedure and write 
 dossier to ${verdict_file}. transcript_path: ${transcript_path}"
 
 # The audit must be attributable to a fresh run, not a leftover dossier.
-before_mtime="$(stat -f '%m' "$verdict_file" 2>/dev/null || stat -c '%Y' "$verdict_file" 2>/dev/null || echo 0)"
+before_mtime="$(file_mtime_epoch "$verdict_file")"
 
 if [[ -n "${VERDICT_AUDITOR_CMD:-}" ]]; then
   printf '%s' "$audit_prompt" | bash -c "$VERDICT_AUDITOR_CMD" || true
@@ -69,7 +82,7 @@ EOF
   exit 2
 fi
 
-after_mtime="$(stat -f '%m' "$verdict_file" 2>/dev/null || stat -c '%Y' "$verdict_file" 2>/dev/null || echo 0)"
+after_mtime="$(file_mtime_epoch "$verdict_file")"
 if [[ -r "$verdict_file" && "$after_mtime" != "$before_mtime" ]] \
    && jq -e '.verdict and .branch and .tree_hash' "$verdict_file" >/dev/null 2>&1; then
   echo "audit complete: $(jq -r '.verdict' "$verdict_file") → $verdict_file"


### PR DESCRIPTION

 ## Summary

  Fixes hook failures on GNU/Linux caused by combining BSD and GNU `stat` probes in one
  fallback chain. Hooks now accept only numeric file modification times.

  ## Changes

  - Probe GNU and BSD `stat` formats independently.
  - Apply the portable mtime helper to verdict, commit/push, and PR audit hooks.
  - Fall back to zero when neither probe returns a numeric timestamp.

  ## How to verify

  - `bash .claude/hooks/preflight-verdict-check.test.sh`
  - `bash .claude/hooks/preflight-commit-push.test.sh`
  - `bash .claude/hooks/preflight-pr-review.test.sh`
  - `bash .claude/hooks/run-verdict-audit.test.sh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when checking file timestamps across GNU/Linux and BSD/macOS environments.
  * Prevented failed timestamp checks from interfering with successful freshness validation.
  * Preserved existing audit, verdict, and preflight validation behavior while making timestamp handling more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->