### PR TITLE
fix(api): restore box usage period ledger

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -295,8 +295,9 @@ jobs:
     # build scripts, Nx/Jest), so it must not carry write scopes.
     permissions:
       contents: read
-    # Redis lets the quota engine's real-Lua integration spec run (it self-skips
-    # without REDIS_HOST); the rest of the api suite is pure/mocked.
+    # Redis lets the quota engine's real-Lua integration spec run and Postgres
+    # lets the usage ledger's spec run (each self-skips without its env vars);
+    # the rest of the api suite is pure/mocked.
     services:
       redis:
         image: redis:7
@@ -309,8 +310,25 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: boxlite
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     env:
       REDIS_HOST: localhost
+      DB_HOST: localhost
+      DB_PORT: 5432
+      DB_USERNAME: postgres
+      DB_PASSWORD: postgres
+      DB_DATABASE: boxlite
     defaults:
       run:
         working-directory: apps

--- a/apps/api/src/app.module.spec.ts
+++ b/apps/api/src/app.module.spec.ts
@@ -1,0 +1,26 @@
+// http-proxy-middleware is ESM-only and sits in AppModule's import graph via
+// the boxlite-rest proxy controller; nothing here exercises it.
+jest.mock('http-proxy-middleware', () => ({
+  createProxyMiddleware: () => () => undefined,
+  fixRequestBody: () => undefined,
+}))
+
+/*
+ * Copyright 2025 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { MODULE_METADATA } from '@nestjs/common/constants'
+import { AppModule } from './app.module'
+import { UsageModule } from './usage/usage.module'
+
+// The usage ledger is driven entirely by events and cron jobs — nothing imports
+// it and no request path touches it — so dropping this registration disables
+// billing silently. It was in fact lost once in a convergence merge (#715).
+describe('AppModule registrations', () => {
+  it('registers the usage ledger', () => {
+    const imports = Reflect.getMetadata(MODULE_METADATA.IMPORTS, AppModule) as Array<unknown>
+
+    expect(imports).toContain(UsageModule)
+  })
+})

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -20,6 +20,7 @@ import { seconds, ThrottlerModule } from '@nestjs/throttler'
 import { RedisModule, getRedisConnectionToken } from '@nestjs-modules/ioredis'
 import { ScheduleModule } from '@nestjs/schedule'
 import { EventEmitterModule } from '@nestjs/event-emitter'
+import { UsageModule } from './usage/usage.module'
 import { AnalyticsModule } from './analytics/analytics.module'
 import { OrganizationModule } from './organization/organization.module'
 import { EmailModule } from './email/email.module'
@@ -173,6 +174,7 @@ import { BoxliteRestModule } from './boxlite-rest/boxlite-rest.module'
     UserModule,
     BoxModule,
     ScheduleModule.forRoot(),
+    UsageModule,
     AnalyticsModule,
     OrganizationModule,
     RegionModule,

--- a/apps/api/src/migrations/pre-deploy/1785250000000-add-box-usage-periods-migration.ts
+++ b/apps/api/src/migrations/pre-deploy/1785250000000-add-box-usage-periods-migration.ts
@@ -1,0 +1,49 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddBoxUsagePeriods1785250000000 implements MigrationInterface {
+  name = 'AddBoxUsagePeriods1785250000000'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "box_usage_periods" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "boxId" character varying NOT NULL,
+        "organizationId" character varying NOT NULL,
+        "startAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+        "endAt" TIMESTAMP WITH TIME ZONE,
+        "cpu" double precision NOT NULL,
+        "gpu" double precision NOT NULL,
+        "mem" double precision NOT NULL,
+        "disk" double precision NOT NULL,
+        "region" character varying NOT NULL,
+        CONSTRAINT "box_usage_periods_id_pk" PRIMARY KEY ("id")
+      )`,
+    )
+    await queryRunner.query(`CREATE INDEX "idx_box_usage_periods_box_end" ON "box_usage_periods" ("boxId", "endAt")`)
+    // Enforces the at-most-one-open-period-per-box invariant that the advisory
+    // Redis lock alone cannot guarantee; see box-usage-period.entity.ts.
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "box_usage_periods_one_open_period_per_box_idx" ON "box_usage_periods" ("boxId") WHERE "endAt" IS NULL`,
+    )
+    await queryRunner.query(
+      `CREATE TABLE "box_usage_periods_archive" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "boxId" character varying NOT NULL,
+        "organizationId" character varying NOT NULL,
+        "startAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+        "endAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+        "cpu" double precision NOT NULL,
+        "gpu" double precision NOT NULL,
+        "mem" double precision NOT NULL,
+        "disk" double precision NOT NULL,
+        "region" character varying NOT NULL,
+        CONSTRAINT "box_usage_periods_archive_id_pk" PRIMARY KEY ("id")
+      )`,
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "box_usage_periods_archive"`)
+    await queryRunner.query(`DROP TABLE "box_usage_periods"`)
+  }
+}

--- a/apps/api/src/usage/entities/box-usage-period-archive.entity.ts
+++ b/apps/api/src/usage/entities/box-usage-period-archive.entity.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm'
+import { BoxUsagePeriod } from './box-usage-period.entity'
+
+// Duplicate of BoxUsagePeriod
+// Used to archive usage periods and keep the original table lightweight
+// Will only contain closed usage periods
+@Entity('box_usage_periods_archive')
+export class BoxUsagePeriodArchive {
+  @PrimaryGeneratedColumn('uuid')
+  id: string
+
+  @Column({ name: 'boxId' })
+  boxId: string
+
+  @Column()
+  // Redundant property to optimize billing queries
+  organizationId: string
+
+  @Column({ type: 'timestamp with time zone' })
+  startAt: Date
+
+  @Column({ type: 'timestamp with time zone' })
+  endAt: Date
+
+  @Column({ type: 'float' })
+  cpu: number
+
+  @Column({ type: 'float' })
+  gpu: number
+
+  @Column({ type: 'float' })
+  mem: number
+
+  @Column({ type: 'float' })
+  disk: number
+
+  @Column()
+  region: string
+
+  public static fromUsagePeriod(usagePeriod: BoxUsagePeriod) {
+    const usagePeriodEntity = new BoxUsagePeriodArchive()
+    usagePeriodEntity.boxId = usagePeriod.boxId
+    usagePeriodEntity.organizationId = usagePeriod.organizationId
+    usagePeriodEntity.startAt = usagePeriod.startAt
+    usagePeriodEntity.endAt = usagePeriod.endAt
+    usagePeriodEntity.cpu = usagePeriod.cpu
+    usagePeriodEntity.gpu = usagePeriod.gpu
+    usagePeriodEntity.mem = usagePeriod.mem
+    usagePeriodEntity.disk = usagePeriod.disk
+    usagePeriodEntity.region = usagePeriod.region
+    return usagePeriodEntity
+  }
+}

--- a/apps/api/src/usage/entities/box-usage-period.entity.ts
+++ b/apps/api/src/usage/entities/box-usage-period.entity.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Column, Entity, Index, PrimaryGeneratedColumn } from 'typeorm'
+
+@Entity('box_usage_periods')
+@Index('idx_box_usage_periods_box_end', ['boxId', 'endAt'])
+// A box bills against exactly one open period at a time. The per-box Redis lock
+// is advisory and expires, so the invariant is enforced in the database: two
+// interleaved handlers closing and reopening the same period would otherwise
+// leave two open rows and double-count the overlap.
+@Index('box_usage_periods_one_open_period_per_box_idx', ['boxId'], {
+  unique: true,
+  where: '"endAt" IS NULL',
+})
+export class BoxUsagePeriod {
+  @PrimaryGeneratedColumn('uuid')
+  id: string
+
+  @Column({ name: 'boxId' })
+  boxId: string
+
+  @Column()
+  // Redundant property to optimize billing queries
+  organizationId: string
+
+  @Column({ type: 'timestamp with time zone' })
+  startAt: Date
+
+  @Column({ type: 'timestamp with time zone', nullable: true })
+  endAt: Date | null
+
+  @Column({ type: 'float' })
+  cpu: number
+
+  @Column({ type: 'float' })
+  gpu: number
+
+  @Column({ type: 'float' })
+  mem: number
+
+  @Column({ type: 'float' })
+  disk: number
+
+  @Column()
+  region: string
+
+  public static fromUsagePeriod(usagePeriod: BoxUsagePeriod) {
+    const usagePeriodEntity = new BoxUsagePeriod()
+    usagePeriodEntity.boxId = usagePeriod.boxId
+    usagePeriodEntity.organizationId = usagePeriod.organizationId
+    usagePeriodEntity.startAt = usagePeriod.startAt
+    usagePeriodEntity.endAt = usagePeriod.endAt
+    usagePeriodEntity.cpu = usagePeriod.cpu
+    usagePeriodEntity.gpu = usagePeriod.gpu
+    usagePeriodEntity.mem = usagePeriod.mem
+    usagePeriodEntity.disk = usagePeriod.disk
+    usagePeriodEntity.region = usagePeriod.region
+    return usagePeriodEntity
+  }
+}

--- a/apps/api/src/usage/services/usage.service.integration.spec.ts
+++ b/apps/api/src/usage/services/usage.service.integration.spec.ts
@@ -1,0 +1,249 @@
+/*
+ * Copyright 2025 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Redis } from 'ioredis'
+import { DataSource, Repository } from 'typeorm'
+import { BoxState } from '../../box/enums/box-state.enum'
+import { BOX_WARM_POOL_UNASSIGNED_ORGANIZATION } from '../../box/constants/box.constants'
+import { RedisLockProvider } from '../../box/common/redis-lock.provider'
+import { CustomNamingStrategy } from '../../common/utils/naming-strategy.util'
+import { AddBoxUsagePeriods1785250000000 } from '../../migrations/pre-deploy/1785250000000-add-box-usage-periods-migration'
+import { BoxUsagePeriod } from '../entities/box-usage-period.entity'
+import { BoxUsagePeriodArchive } from '../entities/box-usage-period-archive.entity'
+import { UsageService } from './usage.service'
+
+// The two cron jobs are a destructive archive transaction and a roll-over that
+// rewrites resources — neither is observable without a real database, and the
+// at-most-one-open-period invariant lives in a Postgres partial index whose
+// WHERE clause no schema differ compares. The schema here is built by running
+// the migration, so these tests exercise the DDL that actually ships. Runs only
+// when a Postgres and a Redis are reachable; skipped otherwise.
+const describeIfDatabase = process.env.DB_HOST && process.env.REDIS_HOST ? describe : describe.skip
+
+const DAY_MS = 24 * 60 * 60 * 1000
+const TABLES = ['box_usage_periods', 'box_usage_periods_archive']
+
+describeIfDatabase('UsageService (integration, real Postgres + Redis)', () => {
+  let dataSource: DataSource
+  let redis: Redis
+  let periods: Repository<BoxUsagePeriod>
+  let archives: Repository<BoxUsagePeriodArchive>
+  // Set only once this spec has built the tables itself. Until then the rows in
+  // them belong to somebody else and nothing here may write or clear them.
+  let ownsTables = false
+
+  const box = { id: 'box-int-1', organizationId: 'org-int-1', region: 'us', cpu: 2, gpu: 1, mem: 4, disk: 10 }
+
+  // The service's own lock keys — cleared individually so a parallel spec
+  // sharing this Redis keeps its state.
+  const lockKeys = [`usage-period-${box.id}`, 'close-and-reopen-usage-periods', 'archive-usage-periods']
+
+  const openPeriod = (overrides: Partial<BoxUsagePeriod> = {}) =>
+    periods.save(
+      periods.create({
+        boxId: box.id,
+        organizationId: box.organizationId,
+        region: box.region,
+        cpu: box.cpu,
+        gpu: box.gpu,
+        mem: box.mem,
+        disk: box.disk,
+        startAt: new Date(),
+        endAt: null,
+        ...overrides,
+      }),
+    )
+
+  const serviceForBoxState = (state: BoxState) =>
+    new UsageService(periods, new RedisLockProvider(redis), {
+      findOne: async () => ({ id: box.id, state }),
+    } as any)
+
+  const quoted = TABLES.map((table) => `"${table}"`).join(', ')
+  const dropTables = () => dataSource.query(`DROP TABLE IF EXISTS ${quoted}`)
+  const truncateTables = () => dataSource.query(`TRUNCATE ${quoted}`)
+
+  // This spec owns the ledger tables outright — it drops and rebuilds them from
+  // the migration — so it must never be pointed at a database holding real
+  // usage. Each table is checked on its own: one populated table is enough to
+  // refuse, even if the other is missing.
+  const assertDisposableDatabase = async () => {
+    const existing: string[] = (
+      await dataSource.query(`SELECT table_name FROM information_schema.tables WHERE table_name = ANY($1)`, [TABLES])
+    ).map((row: { table_name: string }) => row.table_name)
+
+    for (const table of existing) {
+      const [{ rows }] = await dataSource.query(`SELECT count(*)::int AS rows FROM "${table}"`)
+      if (rows > 0) {
+        throw new Error(
+          `refusing to run: "${table}" in database "${process.env.DB_DATABASE}" already holds rows — point DB_* at a disposable database`,
+        )
+      }
+    }
+  }
+
+  beforeAll(async () => {
+    dataSource = await new DataSource({
+      type: 'postgres',
+      host: process.env.DB_HOST,
+      port: Number(process.env.DB_PORT || 5432),
+      username: process.env.DB_USERNAME,
+      password: process.env.DB_PASSWORD,
+      database: process.env.DB_DATABASE,
+      entities: [BoxUsagePeriod, BoxUsagePeriodArchive],
+      namingStrategy: new CustomNamingStrategy(),
+      synchronize: false,
+    }).initialize()
+
+    // Rebuild the schema from the migration every run, so these tests exercise
+    // the DDL that ships rather than whatever an earlier run happened to leave.
+    await assertDisposableDatabase()
+    await dropTables()
+    await dataSource.query(`CREATE EXTENSION IF NOT EXISTS "uuid-ossp"`)
+    const queryRunner = dataSource.createQueryRunner()
+    try {
+      await new AddBoxUsagePeriods1785250000000().up(queryRunner)
+      ownsTables = true
+    } finally {
+      await queryRunner.release()
+    }
+
+    redis = new Redis({
+      host: process.env.REDIS_HOST,
+      port: Number(process.env.REDIS_PORT || 6379),
+      maxRetriesPerRequest: 2,
+    })
+    periods = dataSource.getRepository(BoxUsagePeriod)
+    archives = dataSource.getRepository(BoxUsagePeriodArchive)
+  })
+
+  // Setup can throw (the disposable-database guard), so nothing here may assume
+  // it ran to completion.
+  afterAll(async () => {
+    if (redis) {
+      await redis.del(...lockKeys)
+      await redis.quit()
+    }
+    if (dataSource?.isInitialized) {
+      if (ownsTables) {
+        // leave the schema in place but carrying nothing, so a later run finds
+        // the database exactly as disposable as it expects
+        await truncateTables().catch(() => undefined)
+      }
+      await dataSource.destroy()
+    }
+  })
+
+  beforeEach(async () => {
+    await periods.clear()
+    await archives.clear()
+    await redis.del(...lockKeys)
+  })
+
+  it('archives closed periods and leaves the open one in place', async () => {
+    await openPeriod({ startAt: new Date(Date.now() - 2 * DAY_MS), endAt: new Date(Date.now() - DAY_MS) })
+    const stillOpen = await openPeriod()
+
+    await serviceForBoxState(BoxState.STARTED).archiveUsagePeriods()
+
+    expect(await periods.find()).toEqual([expect.objectContaining({ id: stillOpen.id })])
+    expect(await archives.find()).toEqual([
+      expect.objectContaining({ boxId: box.id, organizationId: box.organizationId, cpu: box.cpu }),
+    ])
+  })
+
+  it('rolls a day-old period over, carrying the resources of a running box', async () => {
+    await openPeriod({ startAt: new Date(Date.now() - DAY_MS - 60_000) })
+
+    await serviceForBoxState(BoxState.STARTED).closeAndReopenUsagePeriods()
+
+    const [closed, reopened] = await periods.find({ order: { startAt: 'ASC' } })
+    expect(closed.endAt).toBeInstanceOf(Date)
+    expect(reopened).toEqual(expect.objectContaining({ endAt: null, cpu: 2, gpu: 1, mem: 4, disk: 10 }))
+  })
+
+  it('stops charging compute when it rolls over a period whose box is already stopped', async () => {
+    // a box that reached STOPPED without passing through STOPPING keeps a
+    // full-resource period open; the roll-over must not re-bill its cpu forever
+    await openPeriod({ startAt: new Date(Date.now() - DAY_MS - 60_000) })
+
+    await serviceForBoxState(BoxState.STOPPED).closeAndReopenUsagePeriods()
+
+    const [, reopened] = await periods.find({ order: { startAt: 'ASC' } })
+    expect(reopened).toEqual(expect.objectContaining({ endAt: null, cpu: 0, gpu: 0, mem: 0, disk: 10 }))
+  })
+
+  it('leaves a period younger than a day alone', async () => {
+    const fresh = await openPeriod({ startAt: new Date(Date.now() - 60 * 60 * 1000) })
+
+    await serviceForBoxState(BoxState.STARTED).closeAndReopenUsagePeriods()
+
+    expect(await periods.find()).toEqual([expect.objectContaining({ id: fresh.id, endAt: null })])
+  })
+
+  it('leaves warm-pool periods alone, since no organization owns them yet', async () => {
+    const warmPool = await openPeriod({
+      organizationId: BOX_WARM_POOL_UNASSIGNED_ORGANIZATION,
+      startAt: new Date(Date.now() - DAY_MS - 60_000),
+    })
+
+    await serviceForBoxState(BoxState.STARTED).closeAndReopenUsagePeriods()
+
+    expect(await periods.find()).toEqual([expect.objectContaining({ id: warmPool.id, endAt: null })])
+  })
+
+  it('starts the reopened period exactly where the closed one ended, with the same attribution', async () => {
+    await openPeriod({ startAt: new Date(Date.now() - DAY_MS - 60_000) })
+
+    await serviceForBoxState(BoxState.STOPPING).closeAndReopenUsagePeriods()
+
+    const [closed, reopened] = await periods.find({ order: { startAt: 'ASC' } })
+    // no gap and no overlap: an inherited startAt would bill the elapsed day twice
+    expect(reopened.startAt).toEqual(closed.endAt)
+    expect(reopened).toEqual(
+      expect.objectContaining({ organizationId: box.organizationId, region: box.region, endAt: null }),
+    )
+  })
+
+  it('closes without reopening when the box row no longer exists', async () => {
+    await openPeriod({ startAt: new Date(Date.now() - DAY_MS - 60_000) })
+    const serviceWithoutBox = new UsageService(periods, new RedisLockProvider(redis), {
+      findOne: async () => null,
+    } as any)
+
+    await serviceWithoutBox.closeAndReopenUsagePeriods()
+
+    // a missing box must not throw inside the transaction — that would roll the
+    // close back and leave the period accruing forever
+    const remaining = await periods.find()
+    expect(remaining).toHaveLength(1)
+    expect(remaining[0].endAt).toBeInstanceOf(Date)
+  })
+
+  it('does not reopen a period for a box that is already gone', async () => {
+    await openPeriod({ startAt: new Date(Date.now() - DAY_MS - 60_000) })
+
+    await serviceForBoxState(BoxState.DESTROYED).closeAndReopenUsagePeriods()
+
+    const remaining = await periods.find()
+    expect(remaining).toHaveLength(1)
+    expect(remaining[0].endAt).toBeInstanceOf(Date)
+  })
+
+  it('declares the open-period invariant on the entity as well as in the migration', () => {
+    const index = dataSource
+      .getMetadata(BoxUsagePeriod)
+      .indices.find((candidate) => candidate.name === 'box_usage_periods_one_open_period_per_box_idx')
+
+    expect(index).toMatchObject({ isUnique: true, where: '"endAt" IS NULL' })
+    expect(index?.columns.map((column) => column.propertyName)).toEqual(['boxId'])
+  })
+
+  it('refuses a second open period for the same box', async () => {
+    await openPeriod()
+
+    await expect(openPeriod()).rejects.toThrow(/box_usage_periods_one_open_period_per_box_idx/)
+  })
+})

--- a/apps/api/src/usage/services/usage.service.spec.ts
+++ b/apps/api/src/usage/services/usage.service.spec.ts
@@ -1,0 +1,274 @@
+/*
+ * Copyright 2025 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { EVENT_LISTENER_METADATA } from '@nestjs/event-emitter/dist/constants'
+import { FindOperator } from 'typeorm'
+import { BoxEvents } from '../../box/constants/box-events.constants'
+import { Box } from '../../box/entities/box.entity'
+import { BoxDesiredState } from '../../box/enums/box-desired-state.enum'
+import { BoxState } from '../../box/enums/box-state.enum'
+import { BoxDesiredStateUpdatedEvent } from '../../box/events/box-desired-state-updated.event'
+import { BoxStateUpdatedEvent } from '../../box/events/box-state-updated.event'
+import { BoxUsagePeriod } from '../entities/box-usage-period.entity'
+import { UsageService } from './usage.service'
+
+const box = {
+  id: 'box-1',
+  organizationId: 'org-1',
+  region: 'us',
+  cpu: 2,
+  gpu: 1,
+  mem: 4,
+  disk: 10,
+} as Box
+
+const event = (newState: BoxState) => new BoxStateUpdatedEvent(box, BoxState.UNKNOWN, newState)
+
+// Evaluates the operators the service actually queries with, so a changed
+// predicate changes what the fake returns. Anything else throws rather than
+// quietly matching — a silent default would let a query drift past these tests.
+const satisfies = (actual: unknown, condition: unknown): boolean => {
+  if (condition instanceof FindOperator) {
+    switch (condition.type) {
+      case 'isNull':
+        return actual === null
+      case 'not':
+        return !satisfies(actual, condition.child ?? condition.value)
+      default:
+        throw new Error(`usage.service.spec: unsupported find operator "${condition.type}"`)
+    }
+  }
+  return actual === condition
+}
+
+const makeService = (stored: BoxUsagePeriod[] = []) => {
+  const usagePeriodRepository = {
+    findOne: jest.fn(async ({ where }: any) =>
+      stored.find((period) =>
+        Object.entries(where).every(([column, condition]) => satisfies((period as any)[column], condition)),
+      ),
+    ),
+    save: jest.fn().mockImplementation(async (period) => period),
+  }
+  const redisLockProvider = {
+    lock: jest.fn().mockResolvedValue(true),
+    unlock: jest.fn().mockResolvedValue(undefined),
+  }
+  const boxRepository = { findOne: jest.fn() }
+
+  const service = new UsageService(usagePeriodRepository as any, redisLockProvider as any, boxRepository as any)
+
+  return { service, usagePeriodRepository, redisLockProvider }
+}
+
+const OTHER_BOX_ID = 'box-2'
+
+const openPeriod = (cpu = box.cpu, boxId = box.id) => ({ boxId, cpu, endAt: null }) as unknown as BoxUsagePeriod
+const closedPeriod = (cpu = box.cpu, boxId = box.id) => ({ boxId, cpu, endAt: new Date() }) as unknown as BoxUsagePeriod
+
+// Every handler below is reached only through an @OnEvent subscription; calling
+// them directly proves the body, not that anything ever calls it.
+describe('UsageService event subscriptions', () => {
+  it.each([
+    ['handleBoxStateUpdate', BoxEvents.STATE_UPDATED],
+    ['handleBoxDesiredStateUpdate', BoxEvents.DESIRED_STATE_UPDATED],
+  ])('subscribes %s to %s', (handler, expectedEvent) => {
+    const subscriptions = Reflect.getMetadata(EVENT_LISTENER_METADATA, (UsageService.prototype as any)[handler])
+
+    expect(subscriptions).toEqual([expect.objectContaining({ event: expectedEvent })])
+  })
+})
+
+describe('UsageService.handleBoxStateUpdate', () => {
+  it('opens a full-resource period when the box starts', async () => {
+    const { service, usagePeriodRepository } = makeService()
+
+    await service.handleBoxStateUpdate(event(BoxState.STARTED))
+
+    expect(usagePeriodRepository.save).toHaveBeenCalledTimes(1)
+    expect(usagePeriodRepository.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        boxId: 'box-1',
+        organizationId: 'org-1',
+        region: 'us',
+        cpu: 2,
+        gpu: 1,
+        mem: 4,
+        disk: 10,
+        endAt: null,
+      }),
+    )
+    // billing starts now, not at some inherited timestamp
+    const [[opened]] = usagePeriodRepository.save.mock.calls
+    expect(opened.startAt).toBeInstanceOf(Date)
+    expect(Date.now() - opened.startAt.getTime()).toBeLessThan(5_000)
+  })
+
+  it('closes the previous period before opening a new one when the box starts', async () => {
+    const stale = openPeriod()
+    const { service, usagePeriodRepository } = makeService([stale])
+
+    await service.handleBoxStateUpdate(event(BoxState.STARTED))
+
+    const [closed, opened] = usagePeriodRepository.save.mock.calls.map(([period]) => period)
+    expect(closed).toBe(stale)
+    expect(stale.endAt).toBeInstanceOf(Date)
+    expect(opened).toEqual(expect.objectContaining({ cpu: 2, endAt: null }))
+  })
+
+  it('never closes a period belonging to a different box', async () => {
+    const otherBoxPeriod = openPeriod(box.cpu, OTHER_BOX_ID)
+    const { service, usagePeriodRepository } = makeService([otherBoxPeriod])
+
+    await service.handleBoxStateUpdate(event(BoxState.STARTED))
+
+    // only the newly opened period is written; the other box keeps accruing
+    expect(usagePeriodRepository.save).toHaveBeenCalledTimes(1)
+    expect(otherBoxPeriod.endAt).toBeNull()
+  })
+
+  it('ignores a still-billing period owned by another box when this box lands in STOPPED', async () => {
+    const otherBoxPeriod = openPeriod(box.cpu, OTHER_BOX_ID)
+    const { service, usagePeriodRepository } = makeService([otherBoxPeriod])
+
+    await service.handleBoxStateUpdate(event(BoxState.STOPPED))
+
+    expect(usagePeriodRepository.save).not.toHaveBeenCalled()
+    expect(otherBoxPeriod.endAt).toBeNull()
+  })
+
+  it('does not re-close an already closed period when the box is destroyed', async () => {
+    const alreadyClosed = closedPeriod()
+    const closedAt = alreadyClosed.endAt
+    const { service, usagePeriodRepository } = makeService([alreadyClosed])
+
+    await service.handleBoxStateUpdate(event(BoxState.DESTROYED))
+
+    expect(usagePeriodRepository.save).not.toHaveBeenCalled()
+    expect(alreadyClosed.endAt).toBe(closedAt)
+  })
+
+  it('closes the open period and reopens it disk-only when the box stops', async () => {
+    const open = openPeriod()
+    const { service, usagePeriodRepository } = makeService([open])
+
+    await service.handleBoxStateUpdate(event(BoxState.STOPPING))
+
+    const [closed, reopened] = usagePeriodRepository.save.mock.calls.map(([period]) => period)
+    expect(closed).toBe(open)
+    expect(closed.endAt).toBeInstanceOf(Date)
+    // a stopped box keeps paying for disk, but not for cpu/gpu/mem
+    expect(reopened).toEqual(expect.objectContaining({ cpu: 0, gpu: 0, mem: 0, disk: 10, endAt: null }))
+  })
+
+  it('closes the open period without reopening when the box is destroyed', async () => {
+    const open = openPeriod()
+    const { service, usagePeriodRepository } = makeService([open])
+
+    await service.handleBoxStateUpdate(event(BoxState.DESTROYED))
+
+    expect(usagePeriodRepository.save).toHaveBeenCalledTimes(1)
+    expect(usagePeriodRepository.save).toHaveBeenCalledWith(open)
+    expect(open.endAt).toBeInstanceOf(Date)
+  })
+
+  it('closes a still-billing period when the box lands in STOPPED without passing through STOPPING', async () => {
+    const open = openPeriod()
+    const { service, usagePeriodRepository } = makeService([open])
+
+    await service.handleBoxStateUpdate(event(BoxState.STOPPED))
+
+    const [closed, reopened] = usagePeriodRepository.save.mock.calls.map(([period]) => period)
+    expect(closed).toBe(open)
+    expect(closed.endAt).toBeInstanceOf(Date)
+    expect(reopened).toEqual(expect.objectContaining({ cpu: 0, gpu: 0, mem: 0, disk: 10, endAt: null }))
+  })
+
+  it('leaves an already disk-only period alone when the box lands in STOPPED', async () => {
+    // the box passed through STOPPING normally, so its open period already
+    // charges no compute — reopening it would only add a spurious row
+    const { service, usagePeriodRepository } = makeService([openPeriod(0)])
+
+    await service.handleBoxStateUpdate(event(BoxState.STOPPED))
+
+    expect(usagePeriodRepository.save).not.toHaveBeenCalled()
+  })
+
+  it('ignores a compute period that is already closed when the box lands in STOPPED', async () => {
+    // only open periods are still accruing; a closed one must not be reopened
+    const { service, usagePeriodRepository } = makeService([closedPeriod()])
+
+    await service.handleBoxStateUpdate(event(BoxState.STOPPED))
+
+    expect(usagePeriodRepository.save).not.toHaveBeenCalled()
+  })
+
+  it('closes the period when the box is destroyed but has not reached DESTROYED yet', async () => {
+    const open = openPeriod()
+    const { service, usagePeriodRepository } = makeService([open])
+
+    await service.handleBoxStateUpdate(event(BoxState.DESTROYING))
+
+    expect(usagePeriodRepository.save).toHaveBeenCalledTimes(1)
+    expect(open.endAt).toBeInstanceOf(Date)
+  })
+
+  it.each([
+    ['ERROR', BoxState.ERROR],
+    ['ARCHIVED', BoxState.ARCHIVED],
+    ['DESTROYED', BoxState.DESTROYED],
+    ['DESTROYING', BoxState.DESTROYING],
+  ])('stops billing when the box reaches %s', async (_label, state) => {
+    const open = openPeriod()
+    const { service, usagePeriodRepository } = makeService([open])
+
+    await service.handleBoxStateUpdate(event(state))
+
+    expect(usagePeriodRepository.save).toHaveBeenCalledTimes(1)
+    expect(open.endAt).toBeInstanceOf(Date)
+  })
+
+  it('releases the per-box lock even when the transition is not billable', async () => {
+    const { service, redisLockProvider } = makeService()
+
+    await service.handleBoxStateUpdate(event(BoxState.STARTING))
+
+    expect(redisLockProvider.unlock).toHaveBeenCalledWith(`usage-period-${box.id}`)
+  })
+})
+
+describe('UsageService.handleBoxDesiredStateUpdate', () => {
+  it('stops billing as soon as deletion is requested', async () => {
+    const open = openPeriod()
+    const { service, usagePeriodRepository } = makeService([open])
+
+    await service.handleBoxDesiredStateUpdate(
+      new BoxDesiredStateUpdatedEvent(box, BoxDesiredState.STARTED, BoxDesiredState.DESTROYED),
+    )
+
+    expect(usagePeriodRepository.save).toHaveBeenCalledWith(open)
+    expect(open.endAt).toBeInstanceOf(Date)
+  })
+
+  it('keeps billing for a desired state that is not deletion', async () => {
+    const { service, usagePeriodRepository } = makeService([openPeriod()])
+
+    await service.handleBoxDesiredStateUpdate(
+      new BoxDesiredStateUpdatedEvent(box, BoxDesiredState.STARTED, BoxDesiredState.STOPPED),
+    )
+
+    expect(usagePeriodRepository.save).not.toHaveBeenCalled()
+  })
+
+  it('releases the per-box lock it took', async () => {
+    const { service, redisLockProvider } = makeService([openPeriod()])
+
+    await service.handleBoxDesiredStateUpdate(
+      new BoxDesiredStateUpdatedEvent(box, BoxDesiredState.STARTED, BoxDesiredState.DESTROYED),
+    )
+
+    expect(redisLockProvider.unlock).toHaveBeenCalledWith(`usage-period-${box.id}`)
+  })
+})

--- a/apps/api/src/usage/services/usage.service.ts
+++ b/apps/api/src/usage/services/usage.service.ts
@@ -1,0 +1,270 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Injectable, Logger, OnApplicationShutdown } from '@nestjs/common'
+import { InjectRepository } from '@nestjs/typeorm'
+import { IsNull, LessThan, Not, Repository } from 'typeorm'
+import { BoxUsagePeriod } from '../entities/box-usage-period.entity'
+import { OnEvent } from '@nestjs/event-emitter'
+import { BoxStateUpdatedEvent } from '../../box/events/box-state-updated.event'
+import { BoxDesiredStateUpdatedEvent } from '../../box/events/box-desired-state-updated.event'
+import { BoxState } from '../../box/enums/box-state.enum'
+import { BoxDesiredState } from '../../box/enums/box-desired-state.enum'
+import { BoxEvents } from './../../box/constants/box-events.constants'
+import { Cron, CronExpression } from '@nestjs/schedule'
+import { RedisLockProvider } from '../../box/common/redis-lock.provider'
+import { BOX_WARM_POOL_UNASSIGNED_ORGANIZATION } from '../../box/constants/box.constants'
+import { BoxUsagePeriodArchive } from '../entities/box-usage-period-archive.entity'
+import { TrackableJobExecutions } from '../../common/interfaces/trackable-job-executions'
+import { TrackJobExecution } from '../../common/decorators/track-job-execution.decorator'
+import { setTimeout as sleep } from 'timers/promises'
+import { LogExecution } from '../../common/decorators/log-execution.decorator'
+import { WithInstrumentation } from '../../common/decorators/otel.decorator'
+import { BoxRepository } from '../../box/repositories/box.repository'
+
+@Injectable()
+export class UsageService implements TrackableJobExecutions, OnApplicationShutdown {
+  activeJobs = new Set<string>()
+  private readonly logger = new Logger(UsageService.name)
+
+  constructor(
+    @InjectRepository(BoxUsagePeriod)
+    private boxUsagePeriodRepository: Repository<BoxUsagePeriod>,
+    private readonly redisLockProvider: RedisLockProvider,
+    private readonly boxRepository: BoxRepository,
+  ) {}
+
+  async onApplicationShutdown() {
+    //  wait for all active jobs to finish
+    while (this.activeJobs.size > 0) {
+      this.logger.log(`Waiting for ${this.activeJobs.size} active jobs to finish`)
+      await sleep(1000)
+    }
+  }
+
+  @OnEvent(BoxEvents.DESIRED_STATE_UPDATED)
+  @TrackJobExecution()
+  async handleBoxDesiredStateUpdate(event: BoxDesiredStateUpdatedEvent) {
+    await this.waitForLock(event.box.id)
+
+    try {
+      switch (event.newDesiredState) {
+        case BoxDesiredState.DESTROYED: {
+          await this.closeUsagePeriod(event.box.id)
+          break
+        }
+      }
+    } finally {
+      this.releaseLock(event.box.id).catch((error) => {
+        this.logger.error(`Error releasing lock for box ${event.box.id}`, error)
+      })
+    }
+  }
+
+  @OnEvent(BoxEvents.STATE_UPDATED)
+  @TrackJobExecution()
+  async handleBoxStateUpdate(event: BoxStateUpdatedEvent) {
+    await this.waitForLock(event.box.id)
+
+    try {
+      switch (event.newState) {
+        case BoxState.STARTED: {
+          await this.closeUsagePeriod(event.box.id)
+          await this.createUsagePeriod(event)
+          break
+        }
+        // Billing stops charging compute the moment a stop is requested, while
+        // quota keeps counting it (BOX_STATES_CONSUMING_COMPUTE includes
+        // STOPPING) because the runner has not released cpu/memory yet. The two
+        // answer different questions; do not "reconcile" them without a pricing
+        // decision.
+        case BoxState.STOPPING:
+          await this.closeUsagePeriod(event.box.id)
+          await this.createUsagePeriod(event, true)
+          break
+        // Safeguards if STOPPING state is skipped
+        case BoxState.STOPPED: {
+          const cpuUsagePeriod = await this.boxUsagePeriodRepository.findOne({
+            where: {
+              boxId: event.box.id,
+              endAt: IsNull(),
+              cpu: Not(0),
+            },
+          })
+          if (cpuUsagePeriod) {
+            await this.closeUsagePeriod(event.box.id)
+            await this.createUsagePeriod(event, true)
+          }
+          break
+        }
+        case BoxState.ERROR:
+        case BoxState.ARCHIVED:
+        case BoxState.DESTROYING:
+        case BoxState.DESTROYED: {
+          await this.closeUsagePeriod(event.box.id)
+          break
+        }
+      }
+    } finally {
+      this.releaseLock(event.box.id).catch((error) => {
+        this.logger.error(`Error releasing lock for box ${event.box.id}`, error)
+      })
+    }
+  }
+
+  private async createUsagePeriod(event: BoxStateUpdatedEvent, diskOnly = false) {
+    const usagePeriod = new BoxUsagePeriod()
+    usagePeriod.boxId = event.box.id
+    usagePeriod.startAt = new Date()
+    usagePeriod.endAt = null
+    if (!diskOnly) {
+      usagePeriod.cpu = event.box.cpu
+      usagePeriod.gpu = event.box.gpu
+      usagePeriod.mem = event.box.mem
+    } else {
+      usagePeriod.cpu = 0
+      usagePeriod.gpu = 0
+      usagePeriod.mem = 0
+    }
+    usagePeriod.disk = event.box.disk
+    usagePeriod.organizationId = event.box.organizationId
+    usagePeriod.region = event.box.region
+
+    await this.boxUsagePeriodRepository.save(usagePeriod)
+  }
+
+  private async closeUsagePeriod(boxId: string) {
+    const lastUsagePeriod = await this.boxUsagePeriodRepository.findOne({
+      where: {
+        boxId,
+        endAt: IsNull(),
+      },
+    })
+
+    if (lastUsagePeriod) {
+      lastUsagePeriod.endAt = new Date()
+      await this.boxUsagePeriodRepository.save(lastUsagePeriod)
+    }
+  }
+
+  @Cron(CronExpression.EVERY_MINUTE, { name: 'close-and-reopen-usage-periods' })
+  @TrackJobExecution()
+  @LogExecution('close-and-reopen-usage-periods')
+  @WithInstrumentation()
+  async closeAndReopenUsagePeriods() {
+    if (!(await this.redisLockProvider.lock('close-and-reopen-usage-periods', 60))) {
+      return
+    }
+
+    const usagePeriods = await this.boxUsagePeriodRepository.find({
+      where: {
+        endAt: IsNull(),
+        // 1 day ago
+        startAt: LessThan(new Date(Date.now() - 1000 * 60 * 60 * 24)),
+        organizationId: Not(BOX_WARM_POOL_UNASSIGNED_ORGANIZATION),
+      },
+      order: {
+        startAt: 'ASC',
+      },
+      take: 100,
+    })
+
+    for (const usagePeriod of usagePeriods) {
+      if (!(await this.aquireLock(usagePeriod.boxId))) {
+        continue
+      }
+
+      // validate that the usage period should remain active just in case
+      try {
+        const box = await this.boxRepository.findOne({
+          where: {
+            id: usagePeriod.boxId,
+          },
+        })
+
+        await this.boxUsagePeriodRepository.manager.transaction(async (transactionalEntityManager) => {
+          // Close usage period
+          const closeTime = new Date()
+          usagePeriod.endAt = closeTime
+          await transactionalEntityManager.save(usagePeriod)
+
+          if (
+            box &&
+            (box.state === BoxState.STARTED || box.state === BoxState.STOPPED || box.state === BoxState.STOPPING)
+          ) {
+            // Create new usage period
+            const newUsagePeriod = BoxUsagePeriod.fromUsagePeriod(usagePeriod)
+            newUsagePeriod.startAt = closeTime
+            newUsagePeriod.endAt = null
+            if (box.state === BoxState.STOPPED) {
+              newUsagePeriod.cpu = 0
+              newUsagePeriod.gpu = 0
+              newUsagePeriod.mem = 0
+            }
+            await transactionalEntityManager.save(newUsagePeriod)
+          }
+        })
+      } catch (error) {
+        this.logger.error(`Error closing and reopening usage period ${usagePeriod.boxId}`, error)
+      } finally {
+        await this.releaseLock(usagePeriod.boxId)
+      }
+    }
+
+    await this.redisLockProvider.unlock('close-and-reopen-usage-periods')
+  }
+
+  @Cron(CronExpression.EVERY_MINUTE, { name: 'archive-usage-periods' })
+  @TrackJobExecution()
+  @LogExecution('archive-usage-periods')
+  @WithInstrumentation()
+  async archiveUsagePeriods() {
+    const lockKey = 'archive-usage-periods'
+    if (!(await this.redisLockProvider.lock(lockKey, 60))) {
+      return
+    }
+
+    await this.boxUsagePeriodRepository.manager.transaction(async (transactionalEntityManager) => {
+      const usagePeriods = await transactionalEntityManager.find(BoxUsagePeriod, {
+        where: {
+          endAt: Not(IsNull()),
+        },
+        order: {
+          startAt: 'ASC',
+        },
+        take: 1000,
+      })
+
+      if (usagePeriods.length === 0) {
+        return
+      }
+
+      this.logger.debug(`Found ${usagePeriods.length} usage periods to archive`)
+
+      await transactionalEntityManager.delete(
+        BoxUsagePeriod,
+        usagePeriods.map((usagePeriod) => usagePeriod.id),
+      )
+      await transactionalEntityManager.save(usagePeriods.map(BoxUsagePeriodArchive.fromUsagePeriod))
+    })
+
+    await this.redisLockProvider.unlock(lockKey)
+  }
+
+  private async waitForLock(boxId: string) {
+    while (!(await this.aquireLock(boxId))) {
+      await new Promise((resolve) => setTimeout(resolve, 500))
+    }
+  }
+
+  private async aquireLock(boxId: string): Promise<boolean> {
+    return await this.redisLockProvider.lock(`usage-period-${boxId}`, 60)
+  }
+
+  private async releaseLock(boxId: string) {
+    await this.redisLockProvider.unlock(`usage-period-${boxId}`)
+  }
+}

--- a/apps/api/src/usage/usage.module.spec.ts
+++ b/apps/api/src/usage/usage.module.spec.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { MODULE_METADATA } from '@nestjs/common/constants'
+import { EventEmitter2 } from '@nestjs/event-emitter'
+import { Test } from '@nestjs/testing'
+import { getRepositoryToken } from '@nestjs/typeorm'
+import { DataSource } from 'typeorm'
+import { Box } from '../box/entities/box.entity'
+import { BoxRepository } from '../box/repositories/box.repository'
+import { BoxLookupCacheInvalidationService } from '../box/services/box-lookup-cache-invalidation.service'
+import { RedisLockProvider } from '../box/common/redis-lock.provider'
+import { BoxUsagePeriod } from './entities/box-usage-period.entity'
+import { BoxUsagePeriodArchive } from './entities/box-usage-period-archive.entity'
+import { UsageService } from './services/usage.service'
+import { UsageModule } from './usage.module'
+
+// Everything the module reaches for outside its own providers — the DataSource,
+// the ioredis connection — is stubbed, and useMocker fills in any token the
+// module forgot to provide. So a compile proves the wiring it *does* declare is
+// constructible, not that the declarations are complete; the metadata tests
+// below cover what it would otherwise let through.
+// The DataSource shape is what @nestjs/typeorm's repository factory and
+// BaseRepository read while wiring up.
+const externalStub = () => ({
+  entityMetadatas: [],
+  options: { type: 'postgres' },
+  getRepository: () => ({}),
+})
+
+describe('UsageModule', () => {
+  it('resolves UsageService and builds BoxRepository through its factory', async () => {
+    const moduleRef = await Test.createTestingModule({ imports: [UsageModule] })
+      .useMocker(externalStub)
+      .compile()
+
+    expect(moduleRef.get(UsageService)).toBeInstanceOf(UsageService)
+    expect(moduleRef.get(RedisLockProvider)).toBeInstanceOf(RedisLockProvider)
+    expect(moduleRef.get(BoxRepository)).toBeInstanceOf(BoxRepository)
+  })
+
+  it('registers every entity repository and provider its service resolves through', () => {
+    const imports = Reflect.getMetadata(MODULE_METADATA.IMPORTS, UsageModule) as Array<any>
+    const providers = Reflect.getMetadata(MODULE_METADATA.PROVIDERS, UsageModule) as Array<any>
+    const importedTokens = imports.flatMap((imported) => imported?.providers ?? []).map((provider) => provider?.provide)
+
+    expect(importedTokens).toEqual(
+      expect.arrayContaining([
+        getRepositoryToken(BoxUsagePeriod),
+        getRepositoryToken(BoxUsagePeriodArchive),
+        getRepositoryToken(Box),
+      ]),
+    )
+    expect(providers).toContain(BoxLookupCacheInvalidationService)
+  })
+
+  // This module hand-rolls its own BoxRepository factory instead of importing
+  // BoxModule, so a dependency added, dropped or reordered in the constructor
+  // would silently arrive as `undefined` or in the wrong slot — Nest checks
+  // neither the arity nor the order of a useFactory's inject list.
+  it('injects exactly the BoxRepository constructor parameters, in order', () => {
+    const providers = Reflect.getMetadata(MODULE_METADATA.PROVIDERS, UsageModule) as Array<any>
+    const boxRepositoryProvider = providers.find((provider) => provider?.provide === BoxRepository)
+
+    expect(boxRepositoryProvider.inject).toEqual([DataSource, EventEmitter2, BoxLookupCacheInvalidationService])
+    expect(boxRepositoryProvider.inject).toHaveLength(BoxRepository.length)
+  })
+})

--- a/apps/api/src/usage/usage.module.ts
+++ b/apps/api/src/usage/usage.module.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Module } from '@nestjs/common'
+import { TypeOrmModule } from '@nestjs/typeorm'
+import { DataSource } from 'typeorm'
+import { EventEmitter2 } from '@nestjs/event-emitter'
+import { BoxUsagePeriod } from './entities/box-usage-period.entity'
+import { UsageService } from './services/usage.service'
+import { RedisLockProvider } from '../box/common/redis-lock.provider'
+import { BoxUsagePeriodArchive } from './entities/box-usage-period-archive.entity'
+import { BoxRepository } from '../box/repositories/box.repository'
+import { BoxLookupCacheInvalidationService } from '../box/services/box-lookup-cache-invalidation.service'
+import { Box } from '../box/entities/box.entity'
+
+@Module({
+  imports: [TypeOrmModule.forFeature([BoxUsagePeriod, Box, BoxUsagePeriodArchive])],
+  providers: [
+    UsageService,
+    RedisLockProvider,
+    BoxLookupCacheInvalidationService,
+    {
+      provide: BoxRepository,
+      inject: [DataSource, EventEmitter2, BoxLookupCacheInvalidationService],
+      useFactory: (
+        dataSource: DataSource,
+        eventEmitter: EventEmitter2,
+        boxLookupCacheInvalidationService: BoxLookupCacheInvalidationService,
+      ) => new BoxRepository(dataSource, eventEmitter, boxLookupCacheInvalidationService),
+    },
+  ],
+  exports: [UsageService],
+})
+export class UsageModule {}


### PR DESCRIPTION
## Summary

The `usage` module was dropped from `apps/api` during the #715 convergence merge — it
was not among that PR's stated deletions — so no box usage periods have been recorded
since. This restores the module and the two tables it writes to.

## Changes

- Restore `apps/api/src/usage` (module, `BoxUsagePeriod` + `BoxUsagePeriodArchive`
  entities, `UsageService`) from the pre-deletion tree, and re-register `UsageModule`
  in `app.module.ts`. `BoxState.BUILD_FAILED` is dropped from the switch because that
  enum member no longer exists.
- Carry the upstream hardening our port base predates, which moves where charging
  stops: billing ends when deletion is *requested* rather than when the box reaches
  `DESTROYED`; a box landing in `STOPPED` or `DESTROYING` without passing through
  `STOPPING` no longer keeps a compute-charging period open; and the daily roll-over
  reopens a stopped box's period with its compute zeroed. Without these, a box that
  skipped `STOPPING` kept a full-CPU period that the cron re-billed every day forever.
- Add a partial unique index (`box_usage_periods_one_open_period_per_box_idx`) so at
  most one open period exists per box. The per-box Redis lock is advisory and expires,
  so two interleaved handlers could otherwise leave two open rows and double-count the
  overlap.
- Add a pre-deploy migration creating `box_usage_periods`, `box_usage_periods_archive`
  and both indexes. The #736 baseline squash ran *after* the deletion, so the tables
  are absent from the baseline.
- Add unit, module-wiring and Postgres-backed integration specs, and give the apps CI
  job a Postgres service so the integration spec runs instead of self-skipping.

## How to verify

- From `apps/`: `npx jest --config api/jest.config.ts --rootDir api --testPathPatterns usage`
- With a scratch Postgres and Redis reachable (`DB_*`, `REDIS_*` set), the same command
  additionally runs the integration spec, which builds its schema by executing the
  shipped migration. It refuses to run against a database whose ledger tables hold rows.

## Risks / rollout

- The migration is additive and lives in `pre-deploy/`, so it must run before the API
  rolls. The ordering itself is enforced by deploy code outside this repo.
- The ledger is write-only in this repo: rows accumulate and the archive cron rotates
  them, but nothing here reads them yet.
- Divergences from upstream `v0.190.0` are only states and columns our model lacks
  (`PAUSED`/`PAUSING`, `BUILD_FAILED`, `gpuType`, `regionType`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added usage tracking for compute, GPU, memory, and disk resources throughout box lifecycles.
  * Usage periods now start, pause, resume, and end automatically as box states change.
  * Added daily rollover handling for long-running usage periods.
  * Added archival of completed usage records to support ongoing history management.
  * Improved handling for deleted, destroyed, stopped, and disk-only boxes to ensure accurate billing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->