### PR TITLE
fix(libkrun-sys): let a static shim dlopen libkrunfw

### DIFF
--- a/scripts/build/build-shim.sh
+++ b/scripts/build/build-shim.sh
@@ -85,6 +85,9 @@ build_shim_binary() {
 
     if [ "$OS" = "linux" ]; then
         # Go c-archive crashes with musl TLS; use glibc + crt-static instead.
+        # crt-static only works because libkrun-sys gives libkrunfw a libc
+        # DT_NEEDED (LibFixup::ensure_libc_dependency); without it a static
+        # binary cannot dlopen it on aarch64.
         # relocation-model=static avoids static-pie which is incompatible with Go c-archive relocations.
         # --target is required so RUSTFLAGS (crt-static, relocation-model) don't leak into
         # proc-macro compilation — proc-macros are dylibs and can't use crt-static.

--- a/src/deps/libkrun-sys/build.rs
+++ b/src/deps/libkrun-sys/build.rs
@@ -440,6 +440,45 @@ impl LibFixup {
         run_command(&mut cmd, &format!("fix install name for {}", lib_name));
     }
 
+    /// Gives a library that does not already depend on libc a `DT_NEEDED`
+    /// entry for it.
+    ///
+    /// libkrunfw is a kernel blob linked `-nostdlib`, so it declares no
+    /// dependencies at all. A `+crt-static` shim cannot dlopen such a library
+    /// on aarch64: glibc's static-dlopen path resolves `_dl_var_init` through
+    /// the loaded object's own scope, and with no dependency chain `ld.so` —
+    /// the only place that symbol exists — is never reached. The load then
+    /// fails as `undefined symbol: _dl_var_init`, naming the library, which
+    /// does not reference it. Depending on libc pulls `ld.so` into scope.
+    ///
+    /// Libraries that already link libc are left alone, so this only ever
+    /// touches one that would otherwise be unloadable from a static binary.
+    ///
+    /// Gated on a glibc host: `libc.so.6` is glibc's soname, and build scripts
+    /// compile for the host, so a musl host would otherwise be stamped with a
+    /// dependency it cannot resolve.
+    #[cfg(all(target_os = "linux", target_env = "gnu"))]
+    fn ensure_libc_dependency(lib_path: &Path) {
+        const LIBC: &str = "libc.so.6";
+        let lib_path_str = lib_path.to_str().expect("Invalid library path");
+
+        let needed = Command::new("patchelf")
+            .args(["--print-needed", lib_path_str])
+            .output()
+            .unwrap_or_else(|e| panic!("Failed to read DT_NEEDED of {}: {}", lib_path_str, e));
+        if String::from_utf8_lossy(&needed.stdout)
+            .lines()
+            .any(|entry| entry.trim() == LIBC)
+        {
+            return;
+        }
+
+        let mut cmd = Command::new("patchelf");
+        cmd.args(["--add-needed", LIBC, lib_path_str]);
+        run_command(&mut cmd, &format!("add {} dependency", LIBC));
+        println!("cargo:warning=Added {} dependency to {}", LIBC, lib_path_str);
+    }
+
     /// Extract SONAME from versioned library filename.
     /// e.g., libkrunfw.so.4.9.0 -> Some("libkrunfw.so.4")
     #[cfg(target_os = "linux")]
@@ -488,12 +527,16 @@ impl LibFixup {
                                 .map_err(|e| format!("Failed to rename file: {}", e))?;
                             println!("cargo:warning=Renamed {} to {}", filename, soname);
                             Self::fix_install_name(&soname, &new_path);
+                            #[cfg(target_env = "gnu")]
+                            Self::ensure_libc_dependency(&new_path);
                             continue;
                         }
                     }
                 }
 
                 Self::fix_install_name(&filename, &path);
+                #[cfg(all(target_os = "linux", target_env = "gnu"))]
+                Self::ensure_libc_dependency(&path);
 
                 // macOS: re-sign after modifying
                 #[cfg(target_os = "macos")]


### PR DESCRIPTION
libkrunfw is a kernel blob linked -nostdlib, so it ships with no DT_NEEDED entries. On aarch64 glibc 2.28 a +crt-static caller cannot dlopen it: the static-dlopen path resolves _dl_var_init through the loaded object's own scope, and with no dependency chain ld.so — the only place that symbol exists — is never reached. The load fails as "undefined symbol: _dl_var_init", naming a library that does not reference it.

Give it a libc dependency in LibFixup, beside the patchelf --set-soname this build script already runs, so it covers both the downloaded prebuilt and the BOXLITE_BUILD_LIBKRUNFW path and applies to the renamed soname that ships. The guard skips a library that already links libc, so repeated builds do not accumulate DT_NEEDED entries. Gated on a glibc host because build scripts compile for the host and libc.so.6 does not exist on musl.

Record the coupling at the crt-static flag itself, which had nothing to warn a reader that the flag depends on a fixup in another crate.

Claude-Session: https://claude.ai/code/session_01YL9HKQHBrZR9u1qY7FDyKd

## Summary
<!-- 1-2 sentences: what this changes and why. -->

## Changes
- <!-- notable change — what changed, not a restatement of the diff -->

## How to verify
- <!-- a command or step a reviewer can run -->

## Risks / rollout
- <!-- only if any; delete this section otherwise -->

<!-- Describe the change, not the process: no pasted logs, no AI/conversation
     narrative, no secrets. Keep it tight and delete sections that don't apply. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux compatibility for builds using dynamically loaded system libraries.
  * Ensured required libc dependency information is retained in relevant Linux binaries, improving runtime loading reliability on aarch64 systems.

* **Documentation**
  * Added clarifying comments explaining Linux static-linking and dynamic-loading behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->