### PR TITLE
test(usage): cover box usage period ledger and its crash paths

### DIFF
--- a/apps/api/src/usage/usage.crash-recovery.integration.spec.ts
+++ b/apps/api/src/usage/usage.crash-recovery.integration.spec.ts
@@ -1,0 +1,556 @@
+/*
+ * Copyright 2025 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { RedisModule, getRedisConnectionToken } from '@nestjs-modules/ioredis'
+import { EventEmitterModule } from '@nestjs/event-emitter'
+import { Test, TestingModule } from '@nestjs/testing'
+import { TypeOrmModule } from '@nestjs/typeorm'
+import type { Redis } from 'ioredis'
+import { setTimeout as sleep } from 'timers/promises'
+import { DataSource, IsNull, Repository } from 'typeorm'
+import { RedisLockProvider } from '../box/common/redis-lock.provider'
+import { BoxLastActivity } from '../box/entities/box-last-activity.entity'
+import { Box } from '../box/entities/box.entity'
+import { BoxDesiredState } from '../box/enums/box-desired-state.enum'
+import { BoxState } from '../box/enums/box-state.enum'
+import { BoxRepository } from '../box/repositories/box.repository'
+import { CustomNamingStrategy } from '../common/utils/naming-strategy.util'
+import { AddBoxUsagePeriods1785250000000 } from '../migrations/pre-deploy/1785250000000-add-box-usage-periods-migration'
+import { BoxUsagePeriod } from './entities/box-usage-period.entity'
+import { BoxUsagePeriodArchive } from './entities/box-usage-period-archive.entity'
+import { UsageService } from './services/usage.service'
+import { UsageModule } from './usage.module'
+
+// usage.lifecycle.integration.spec.ts covers the happy path: every transition
+// reaches its handler and the ledger tracks the box. This spec covers what
+// happens when it does not.
+//
+// BoxRepository commits the box row and only then calls emitUpdateEvents(),
+// which is an in-process EventEmitter2 emit — not awaited, not persisted, not
+// retried. Between that commit and UsageService finishing its write there is a
+// window in which the box table and the ledger disagree, and anything that ends
+// the process in that window (SIGKILL, a crash, a restart whose 5s grace
+// expires while a handler is parked on its Redis lock) drops the pending work
+// with no record that it was ever owed.
+//
+// The question these tests answer is not "is there a window" — that is plain in
+// the code — but "what does the system do about it afterwards": which drifts the
+// daily roll-over corrects, which wait for the box's next real transition, and
+// which nothing corrects at all. No path is retroactive, so in every case the
+// span mis-billed while the drift stood stays mis-billed.
+//
+// Two of the groups below — an unreachable Redis losing the write, and the
+// shutdown drain returning early — were found by the process-killing harness in
+// apps/scripts/usage-period-chaos (its S5 and S7) and are pinned here so they
+// are covered by an ordinary test run. That harness still owns anything that
+// needs a real process to die; see apps/infra-local/scripts/README.md for which
+// tool covers what.
+//
+// Runs only when a Postgres and a Redis are reachable; skipped otherwise.
+// DB_DATABASE is named too: it is only the database this spec connects to in
+// order to create its own, but unset it would silently build
+// `undefined_...` rather than skipping.
+const describeIfDatabase =
+  process.env.DB_HOST && process.env.REDIS_HOST && process.env.DB_DATABASE ? describe : describe.skip
+
+// Its own database and Redis db index, for the same reason the lifecycle spec
+// has its own: Jest runs spec files concurrently and these all drop the same
+// ledger tables and take the same global cron locks.
+const SCENARIO_DATABASE = `${process.env.DB_DATABASE}_box_usage_crash`
+const SCENARIO_REDIS_DB = 14
+
+const DAY_MS = 24 * 60 * 60 * 1000
+const ALL_TABLES = ['box_usage_periods', 'box_usage_periods_archive', 'box_last_activity', 'box']
+  .map((table) => `"${table}"`)
+  .join(', ')
+
+const BOX_RESOURCES = { cpu: 2, gpu: 1, mem: 4, disk: 10 }
+const compute = (overrides = {}) => expect.objectContaining({ ...BOX_RESOURCES, ...overrides })
+const diskOnly = expect.objectContaining({ cpu: 0, gpu: 0, mem: 0, disk: BOX_RESOURCES.disk })
+
+const ORGANIZATION_ID = '3f2b1c94-0000-4000-8000-000000000002'
+const REGION = 'us'
+
+describeIfDatabase('box usage periods when a handler is lost (integration, live stack)', () => {
+  let moduleRef: TestingModule
+  let dataSource: DataSource
+  let boxRepository: BoxRepository
+  let usageService: UsageService
+  let redisLock: RedisLockProvider
+  let periods: Repository<BoxUsagePeriod>
+  let archives: Repository<BoxUsagePeriodArchive>
+  let ownsDatabase = false
+
+  // ---------------------------------------------------------------- helpers
+
+  const openPeriods = (boxId: string) => periods.find({ where: { boxId, endAt: IsNull() } })
+
+  const ledger = async (boxId: string): Promise<Array<BoxUsagePeriod | BoxUsagePeriodArchive>> => {
+    const [live, archived] = await Promise.all([
+      periods.find({ where: { boxId } }),
+      archives.find({ where: { boxId } }),
+    ])
+    return [...live, ...archived].sort((a, b) => a.startAt.getTime() - b.startAt.getTime())
+  }
+
+  const readBox = (boxId: string) => dataSource.getRepository(Box).findOneByOrFail({ id: boxId })
+
+  const createBox = async (overrides: Partial<Box> = {}): Promise<Box> => {
+    const box = new Box(REGION)
+    box.organizationId = ORGANIZATION_ID
+    box.osUser = 'boxlite'
+    box.state = BoxState.CREATING
+    box.desiredState = BoxDesiredState.STARTED
+    Object.assign(box, BOX_RESOURCES)
+    box.autoPause = 0
+    box.autoDelete = 0
+    Object.assign(box, overrides)
+
+    await boxRepository.insert(box)
+    return box
+  }
+
+  const waitUntil = async (condition: () => boolean | Promise<boolean>, what: string, timeoutMs = 10_000) => {
+    const deadline = Date.now() + timeoutMs
+    while (!(await condition())) {
+      if (Date.now() > deadline) {
+        throw new Error(`timed out after ${timeoutMs}ms waiting for ${what}`)
+      }
+      await sleep(5)
+    }
+  }
+
+  // Sound only because the scenarios below drive one transition at a time; see
+  // the shutdown-drain tests for why activeJobs cannot be trusted under
+  // concurrency.
+  const settle = () => waitUntil(() => usageService.activeJobs.size === 0, 'usage handlers to finish')
+
+  /** A transition whose handler ran to completion — the healthy path. */
+  const drive = async (box: Box, updateData: Partial<Box>): Promise<Box> => {
+    const updated = await boxRepository.update(box.id, { updateData })
+    await settle()
+    return updated
+  }
+
+  /**
+   * A transition whose handler never wrote anything.
+   *
+   * The raw update commits the box row and skips emitUpdateEvents entirely,
+   * which leaves the database in exactly the state a process killed between the
+   * commit and the handler's write leaves behind: box row moved, ledger
+   * untouched, and no in-flight work anywhere to finish it. Reproducing that by
+   * actually killing a process would test Node's signal handling; this tests
+   * what the system does with the result.
+   */
+  const crashAfterCommit = async (box: Box, updateData: Partial<Box>): Promise<Box> => {
+    await boxRepository.update(box.id, { updateData }, true)
+    expect(usageService.activeJobs.size).toBe(0)
+    return readBox(box.id)
+  }
+
+  /** Backdates the box's open period so the roll-over cron considers it stale. */
+  const ageOpenPeriod = async (boxId: string, by = DAY_MS + 60_000) => {
+    await periods.update({ boxId, endAt: IsNull() }, { startAt: new Date(Date.now() - by) })
+  }
+
+  /** Everything a restarted API does to the ledger on its own, without a further transition. */
+  const runReconciliation = async () => {
+    await usageService.closeAndReopenUsagePeriods()
+    await usageService.archiveUsagePeriods()
+  }
+
+  // ------------------------------------------------------------------ setup
+
+  const connection = {
+    type: 'postgres' as const,
+    host: process.env.DB_HOST,
+    port: Number(process.env.DB_PORT || 5432),
+    username: process.env.DB_USERNAME,
+    password: process.env.DB_PASSWORD,
+    namingStrategy: new CustomNamingStrategy(),
+  }
+
+  const withAdminConnection = async (run: (admin: DataSource) => Promise<void>) => {
+    const admin = await new DataSource({ ...connection, database: process.env.DB_DATABASE }).initialize()
+    try {
+      await run(admin)
+    } finally {
+      await admin.destroy()
+    }
+  }
+
+  /** Boots the shipped UsageModule against the scenario database — one API process. */
+  const bootApi = async () => {
+    moduleRef = await Test.createTestingModule({
+      imports: [
+        EventEmitterModule.forRoot(),
+        RedisModule.forRoot({
+          type: 'single',
+          options: {
+            host: process.env.REDIS_HOST,
+            port: Number(process.env.REDIS_PORT || 6379),
+            db: SCENARIO_REDIS_DB,
+            maxRetriesPerRequest: 2,
+          },
+        }),
+        TypeOrmModule.forRoot({
+          ...connection,
+          database: SCENARIO_DATABASE,
+          entities: [Box, BoxLastActivity, BoxUsagePeriod, BoxUsagePeriodArchive],
+          synchronize: false,
+        }),
+        UsageModule,
+      ],
+    }).compile()
+    await moduleRef.init()
+
+    dataSource = moduleRef.get(DataSource)
+    boxRepository = moduleRef.get(BoxRepository)
+    usageService = moduleRef.get(UsageService)
+    redisLock = moduleRef.get(RedisLockProvider)
+    periods = dataSource.getRepository(BoxUsagePeriod)
+    archives = dataSource.getRepository(BoxUsagePeriodArchive)
+  }
+
+  /**
+   * A full API restart: the module graph, the connection pool, the event
+   * emitter and every listener registered on it are torn down and rebuilt. Any
+   * event that had been emitted but not yet handled is gone — there is no
+   * queue, journal or outbox behind emitUpdateEvents to replay it from.
+   */
+  const restartApi = async () => {
+    await moduleRef.close()
+    await bootApi()
+  }
+
+  beforeAll(async () => {
+    await withAdminConnection(async (admin) => {
+      await admin.query(`DROP DATABASE IF EXISTS "${SCENARIO_DATABASE}" WITH (FORCE)`)
+      await admin.query(`CREATE DATABASE "${SCENARIO_DATABASE}"`)
+    })
+    ownsDatabase = true
+
+    const schemaSource = await new DataSource({
+      ...connection,
+      database: SCENARIO_DATABASE,
+      entities: [Box, BoxLastActivity],
+      synchronize: true,
+    }).initialize()
+    await schemaSource.query(`CREATE EXTENSION IF NOT EXISTS "uuid-ossp"`)
+    const queryRunner = schemaSource.createQueryRunner()
+    try {
+      await new AddBoxUsagePeriods1785250000000().up(queryRunner)
+    } finally {
+      await queryRunner.release()
+      await schemaSource.destroy()
+    }
+
+    await bootApi()
+  }, 60_000)
+
+  afterAll(async () => {
+    await moduleRef?.close()
+    if (ownsDatabase) {
+      await withAdminConnection((admin) => admin.query(`DROP DATABASE IF EXISTS "${SCENARIO_DATABASE}" WITH (FORCE)`))
+    }
+  })
+
+  beforeEach(async () => {
+    await dataSource.query(`TRUNCATE ${ALL_TABLES}`)
+  })
+
+  // ------------------------------------------------- the window itself
+
+  describe('the window between the committed box row and the ledger write', () => {
+    it('leaves a started box unbilled for as long as its handler has not finished', async () => {
+      const box = await createBox()
+      // Production's own per-box lock, taken before the transition, parks the
+      // handler at its first await (UsageService.waitForLock) and holds the
+      // window open for as long as this test needs it. The key is UsageService's
+      // private convention; parking it from outside is the only way to observe
+      // the handler mid-flight.
+      const lockKey = `usage-period-${box.id}`
+      expect(await redisLock.lock(lockKey, 60)).toBe(true)
+
+      await boxRepository.update(box.id, { updateData: { state: BoxState.STARTED } })
+
+      // The row is committed and the box is billable, but nothing bills it yet.
+      // A process that dies here takes the pending handler with it.
+      expect((await readBox(box.id)).state).toBe(BoxState.STARTED)
+      expect(await ledger(box.id)).toEqual([])
+      expect(usageService.activeJobs.size).toBeGreaterThan(0)
+
+      await redisLock.unlock(lockKey)
+      await settle()
+
+      expect(await openPeriods(box.id)).toEqual([compute({ endAt: null })])
+    })
+  })
+
+  // ------------------------------------ the handler failing, not the process
+
+  describe('when the handler fails instead of the process', () => {
+    it('loses the write to a log line when Redis is unreachable, and nothing upstream notices', async () => {
+      const box = await createBox()
+      const redis = moduleRef.get<Redis>(getRedisConnectionToken())
+      // Cuts only this client off; the Redis server and every other client stay
+      // up. RedisLockProvider.lock() awaits redis.set(), which rejects on a
+      // closed connection, so the handler throws at its very first statement.
+      redis.disconnect()
+
+      try {
+        // @nestjs/event-emitter wraps every @OnEvent listener in a try/catch
+        // whose `suppressErrors` defaults to true
+        // (event-subscribers.loader.js: `options?.suppressErrors ?? true`), and
+        // UsageService's decorators pass no options. So the throw never reaches
+        // the emitter's caller: update() resolves, the client gets its 200, and
+        // the only trace is one logger.error line.
+        await expect(boxRepository.update(box.id, { updateData: { state: BoxState.STARTED } })).resolves.toBeDefined()
+        expect((await readBox(box.id)).state).toBe(BoxState.STARTED)
+
+        await waitUntil(() => usageService.activeJobs.size === 0, 'the failed handler to unwind')
+        expect(await ledger(box.id)).toEqual([])
+      } finally {
+        await redis.connect()
+      }
+    })
+  })
+
+  // ------------------------------------------------- the shutdown drain
+
+  describe('the graceful-shutdown drain', () => {
+    // main.ts calls enableShutdownHooks(), so a SIGTERM reaches
+    // UsageService.onApplicationShutdown, which spins until activeJobs empties.
+    // These two tests are a pair: the first shows the barrier working, which is
+    // what makes the second one's failure a bug rather than a missing feature.
+    it('holds the process open while a single handler is still in flight', async () => {
+      const box = await createBox()
+      const lockKey = `usage-period-${box.id}`
+      expect(await redisLock.lock(lockKey, 60)).toBe(true)
+      await boxRepository.update(box.id, { updateData: { state: BoxState.STARTED } })
+
+      let drained = false
+      const shutdown = usageService.onApplicationShutdown().then(() => {
+        drained = true
+      })
+
+      // The drain polls once a second, so this waits out more than one poll.
+      // Asserting that something has *not* happened needs a bounded wait; there
+      // is no event to await for a promise staying pending.
+      await sleep(1_500)
+      expect(drained).toBe(false)
+
+      await redisLock.unlock(lockKey)
+      await shutdown
+
+      expect(await openPeriods(box.id)).toEqual([compute({ endAt: null })])
+    })
+
+    it('reports all clear with a handler still parked, because activeJobs is keyed by method name', async () => {
+      const parked = await createBox()
+      const unobstructed = await createBox()
+      const lockKey = `usage-period-${parked.id}`
+      expect(await redisLock.lock(lockKey, 60)).toBe(true)
+
+      await boxRepository.update(parked.id, { updateData: { state: BoxState.STARTED } })
+      await boxRepository.update(unobstructed.id, { updateData: { state: BoxState.STARTED } })
+
+      // @TrackJobExecution does activeJobs.add(propertyKey) / .delete(propertyKey)
+      // — one entry per *method*, not per invocation. Both handlers are the same
+      // method, so the unobstructed one deletes the entry the parked one is
+      // still relying on, and the set empties while a write is outstanding.
+      await waitUntil(() => usageService.activeJobs.size === 0, 'the shared activeJobs entry to be deleted')
+      expect(await openPeriods(parked.id)).toEqual([])
+
+      const startedAt = Date.now()
+      await usageService.onApplicationShutdown()
+      // Returns on its first check rather than waiting out the parked handler:
+      // a SIGTERM here exits the process with that box unbilled.
+      expect(Date.now() - startedAt).toBeLessThan(1_000)
+      expect(await openPeriods(parked.id)).toEqual([])
+
+      await redisLock.unlock(lockKey)
+      await settle()
+    })
+  })
+
+  // --------------------------------------------- a lost START (under-billing)
+
+  describe('a box that reached STARTED while the API was down', () => {
+    it('runs with nothing billing it', async () => {
+      const box = await createBox()
+
+      const crashed = await crashAfterCommit(box, { state: BoxState.STARTED })
+
+      expect(crashed.state).toBe(BoxState.STARTED)
+      expect(await ledger(box.id)).toEqual([])
+    })
+
+    it('is still unbilled after the API restarts and runs its reconciliation', async () => {
+      const box = await createBox()
+      await crashAfterCommit(box, { state: BoxState.STARTED })
+
+      await restartApi()
+      await runReconciliation()
+
+      expect(await ledger(box.id)).toEqual([])
+    })
+
+    it('is still unbilled a week later, because the roll-over only visits periods that already exist', async () => {
+      const box = await createBox()
+      await crashAfterCommit(box, { state: BoxState.STARTED })
+
+      // The roll-over selects FROM box_usage_periods; a box with no row is
+      // invisible to it no matter how long it runs. Nothing else writes the
+      // ledger, so there is no other repair path to wait for.
+      for (let day = 0; day < 7; day += 1) {
+        await usageService.closeAndReopenUsagePeriods()
+      }
+
+      expect(await ledger(box.id)).toEqual([])
+    })
+
+    it('starts billing again only at its next transition, and the compute it ran is gone for good', async () => {
+      const box = await createBox()
+      await crashAfterCommit(box, { state: BoxState.STARTED })
+
+      await drive(box, { desiredState: BoxDesiredState.STOPPED, state: BoxState.STOPPING })
+
+      // One disk-only period, opened by the stop. The entire started span before
+      // it was never billed and there is nothing left to reconstruct it from.
+      expect(await ledger(box.id)).toEqual([diskOnly])
+    })
+
+    it('cannot be repaired by starting it again, because the row already says started', async () => {
+      const box = await createBox()
+      await crashAfterCommit(box, { state: BoxState.STARTED })
+
+      await drive(box, { desiredState: BoxDesiredState.STARTED, state: BoxState.STARTED })
+
+      // emitUpdateEvents only fires on a *change*, so re-asserting the state the
+      // row already holds emits nothing. This closes the last door: sync-states
+      // skips the box for the same reason (it selects desiredState <> state), so
+      // no operator action short of a real stop/start reaches the ledger.
+      expect(await ledger(box.id)).toEqual([])
+    })
+  })
+
+  // ------------------------------------------- a lost STOP (over-billing)
+
+  describe('a box that reached STOPPED while the API was down', () => {
+    it('keeps billing full compute while it sits stopped', async () => {
+      const box = await createBox()
+      await drive(box, { state: BoxState.STARTED })
+
+      const crashed = await crashAfterCommit(box, { desiredState: BoxDesiredState.STOPPED, state: BoxState.STOPPED })
+
+      expect(crashed.state).toBe(BoxState.STOPPED)
+      expect(await openPeriods(box.id)).toEqual([compute({ endAt: null })])
+    })
+
+    it('keeps billing compute across an API restart and its reconciliation', async () => {
+      const box = await createBox()
+      await drive(box, { state: BoxState.STARTED })
+      await crashAfterCommit(box, { desiredState: BoxDesiredState.STOPPED, state: BoxState.STOPPED })
+
+      await restartApi()
+      await runReconciliation()
+
+      expect(await openPeriods(box.id)).toEqual([compute({ endAt: null })])
+    })
+
+    it('is corrected by the roll-over, but only once the period is a day old', async () => {
+      const box = await createBox()
+      await drive(box, { state: BoxState.STARTED })
+      await crashAfterCommit(box, { desiredState: BoxDesiredState.STOPPED, state: BoxState.STOPPED })
+      await ageOpenPeriod(box.id)
+
+      await usageService.closeAndReopenUsagePeriods()
+
+      // The correction is not retroactive: the day it spent stopped was billed
+      // at full compute and stays billed that way.
+      const billed = await ledger(box.id)
+      expect(billed[0]).toEqual(compute({ endAt: expect.any(Date) }))
+      expect(await openPeriods(box.id)).toEqual([diskOnly])
+    })
+
+    it('is corrected immediately if the box is started and stopped again', async () => {
+      const box = await createBox()
+      await drive(box, { state: BoxState.STARTED })
+      await crashAfterCommit(box, { desiredState: BoxDesiredState.STOPPED, state: BoxState.STOPPED })
+
+      await drive(box, { desiredState: BoxDesiredState.STARTED, state: BoxState.STARTED })
+
+      expect(await openPeriods(box.id)).toEqual([compute({ endAt: null })])
+    })
+  })
+
+  // --------------------------------------- a lost DESTROY (over-billing)
+
+  describe('a box that was deleted while the API was down', () => {
+    it('keeps billing a box that no longer exists to the customer', async () => {
+      const box = await createBox()
+      await drive(box, { state: BoxState.STARTED })
+
+      await crashAfterCommit(box, { desiredState: BoxDesiredState.DESTROYED, state: BoxState.DESTROYED })
+
+      expect(await openPeriods(box.id)).toEqual([compute({ endAt: null })])
+    })
+
+    it('stops billing a day later, when the roll-over sees the box is destroyed', async () => {
+      const box = await createBox()
+      await drive(box, { state: BoxState.STARTED })
+      await crashAfterCommit(box, { desiredState: BoxDesiredState.DESTROYED, state: BoxState.DESTROYED })
+      await ageOpenPeriod(box.id)
+
+      await usageService.closeAndReopenUsagePeriods()
+
+      expect(await openPeriods(box.id)).toEqual([])
+    })
+
+    it('is still closed a day later even after cleanup has deleted the box row', async () => {
+      const box = await createBox()
+      await drive(box, { state: BoxState.STARTED })
+      await crashAfterCommit(box, { desiredState: BoxDesiredState.DESTROYED, state: BoxState.DESTROYED })
+      await ageOpenPeriod(box.id)
+      // cleanup-destroyed-boxes deletes destroyed rows 24h after they settle,
+      // which is the same horizon the roll-over waits for — so the box row can
+      // be gone before the ledger is repaired. No foreign key ties them.
+      await dataSource.getRepository(Box).delete({ id: box.id })
+
+      await usageService.closeAndReopenUsagePeriods()
+
+      expect(await openPeriods(box.id)).toEqual([])
+    })
+  })
+
+  // ------------------------------------------------------- a lost resize
+
+  describe('a box that was resized while the API was down', () => {
+    it('keeps billing the old size until the next transition', async () => {
+      const box = await createBox()
+      await drive(box, { state: BoxState.STARTED })
+      await drive(box, { state: BoxState.RESIZING })
+
+      await crashAfterCommit(box, { state: BoxState.STARTED, cpu: 8, mem: 16, disk: 40 })
+
+      expect(await openPeriods(box.id)).toEqual([compute({ endAt: null })])
+    })
+
+    it('keeps billing the old size through the roll-over, which copies the period it found', async () => {
+      const box = await createBox()
+      await drive(box, { state: BoxState.STARTED })
+      await drive(box, { state: BoxState.RESIZING })
+      await crashAfterCommit(box, { state: BoxState.STARTED, cpu: 8, mem: 16, disk: 40 })
+      await ageOpenPeriod(box.id)
+
+      await usageService.closeAndReopenUsagePeriods()
+
+      // fromUsagePeriod carries the old resources forward; the roll-over never
+      // re-reads the box's current size, so this drift outlives every tick.
+      expect(await openPeriods(box.id)).toEqual([compute({ endAt: null })])
+    })
+  })
+})

--- a/apps/api/src/usage/usage.lifecycle.integration.spec.ts
+++ b/apps/api/src/usage/usage.lifecycle.integration.spec.ts
@@ -1,0 +1,599 @@
+/*
+ * Copyright 2025 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { RedisModule } from '@nestjs-modules/ioredis'
+import { EventEmitterModule } from '@nestjs/event-emitter'
+import { Test, TestingModule } from '@nestjs/testing'
+import { TypeOrmModule } from '@nestjs/typeorm'
+import { setTimeout as sleep } from 'timers/promises'
+import { DataSource, IsNull, Repository } from 'typeorm'
+import { BOX_WARM_POOL_UNASSIGNED_ORGANIZATION } from '../box/constants/box.constants'
+import { BoxLastActivity } from '../box/entities/box-last-activity.entity'
+import { Box } from '../box/entities/box.entity'
+import { BoxDesiredState } from '../box/enums/box-desired-state.enum'
+import { BoxState } from '../box/enums/box-state.enum'
+import { BoxRepository } from '../box/repositories/box.repository'
+import { generateBoxId } from '../box/utils/box-id.util'
+import { CustomNamingStrategy } from '../common/utils/naming-strategy.util'
+import { AddBoxUsagePeriods1785250000000 } from '../migrations/pre-deploy/1785250000000-add-box-usage-periods-migration'
+import { BoxUsagePeriod } from './entities/box-usage-period.entity'
+import { BoxUsagePeriodArchive } from './entities/box-usage-period-archive.entity'
+import { UsageService } from './services/usage.service'
+import { UsageModule } from './usage.module'
+
+// The service specs drive UsageService directly: they hand it events they built
+// themselves and a stubbed box repository. That proves the handler bodies, not
+// that a box moving through its states ever produces those events, nor that the
+// real UsageModule can be wired against a real database. This spec closes that
+// gap — every transition below goes through the production BoxRepository, whose
+// own emit is the only thing that reaches the handlers, and the module graph is
+// the shipped UsageModule on a real Postgres and Redis.
+//
+// Runs only when a Postgres and a Redis are reachable; skipped otherwise.
+// DB_DATABASE is named too: it is only the database this spec connects to in
+// order to create its own, but unset it would silently build
+// `undefined_...` rather than skipping.
+const describeIfDatabase =
+  process.env.DB_HOST && process.env.REDIS_HOST && process.env.DB_DATABASE ? describe : describe.skip
+
+// Jest runs spec files concurrently, and usage.service.integration.spec.ts drops
+// the same ledger tables and takes the same global cron locks — sharing either
+// would make whichever file lost the race silently assert against the other's
+// state. So this spec owns a database it creates and drops itself, and a Redis
+// db index of its own.
+const SCENARIO_DATABASE = `${process.env.DB_DATABASE}_box_usage_scenarios`
+const SCENARIO_REDIS_DB = 15
+
+const DAY_MS = 24 * 60 * 60 * 1000
+const LEDGER_TABLES = ['box_usage_periods', 'box_usage_periods_archive']
+const BOX_TABLES = ['box_last_activity', 'box']
+const ALL_TABLES = [...LEDGER_TABLES, ...BOX_TABLES].map((table) => `"${table}"`).join(', ')
+
+// A box only bills for what it consumes, so every assertion below is about one
+// of two shapes: a compute period (the box's real cpu/gpu/mem) or a disk-only
+// period (a stopped box still occupies its disk).
+const BOX_RESOURCES = { cpu: 2, gpu: 1, mem: 4, disk: 10 }
+const compute = (overrides = {}) => expect.objectContaining({ ...BOX_RESOURCES, ...overrides })
+const diskOnly = expect.objectContaining({ cpu: 0, gpu: 0, mem: 0, disk: BOX_RESOURCES.disk })
+
+const ORGANIZATION_ID = '3f2b1c94-0000-4000-8000-000000000001'
+const REGION = 'us'
+
+describeIfDatabase('box usage periods (integration, live stack)', () => {
+  let moduleRef: TestingModule
+  let dataSource: DataSource
+  let boxRepository: BoxRepository
+  let usageService: UsageService
+  let periods: Repository<BoxUsagePeriod>
+  let archives: Repository<BoxUsagePeriodArchive>
+  // Set once this spec has created its database; until then there is nothing of
+  // its own to drop, and it must not drop anybody else's.
+  let ownsDatabase = false
+
+  // ---------------------------------------------------------------- helpers
+
+  const openPeriods = (boxId: string) => periods.find({ where: { boxId, endAt: IsNull() } })
+
+  // The archive cron moves closed periods out of box_usage_periods, so the
+  // billed history of a box is the union of both tables — reading either alone
+  // would make an assertion depend on whether the cron happened to have run.
+  const ledger = async (boxId: string): Promise<Array<BoxUsagePeriod | BoxUsagePeriodArchive>> => {
+    const [live, archived] = await Promise.all([
+      periods.find({ where: { boxId } }),
+      archives.find({ where: { boxId } }),
+    ])
+    return [...live, ...archived].sort((a, b) => a.startAt.getTime() - b.startAt.getTime())
+  }
+
+  const createBox = async (overrides: Partial<Box> = {}): Promise<Box> => {
+    const box = new Box(REGION)
+    box.organizationId = ORGANIZATION_ID
+    box.osUser = 'boxlite'
+    box.state = BoxState.CREATING
+    box.desiredState = BoxDesiredState.STARTED
+    Object.assign(box, BOX_RESOURCES)
+    // The manager's auto-stop and auto-delete sweeps key off these; a scenario
+    // box must be inert to everything except the transitions it is driven through.
+    box.autoPause = 0
+    box.autoDelete = 0
+    Object.assign(box, overrides)
+
+    await boxRepository.insert(box)
+    return box
+  }
+
+  // BoxRepository.update() emits synchronously, so by the time it resolves the
+  // handler has already registered itself in activeJobs — production's own
+  // shutdown barrier doubles as this spec's settle point, with no sleep-for-a-
+  // guessed-duration anywhere.
+  const settle = async () => {
+    const deadline = Date.now() + 10_000
+    while (usageService.activeJobs.size > 0) {
+      if (Date.now() > deadline) {
+        throw new Error(`usage handlers still running after 10s: ${[...usageService.activeJobs].join(', ')}`)
+      }
+      await sleep(5)
+    }
+  }
+
+  const drive = async (box: Box, updateData: Partial<Box>): Promise<Box> => {
+    const updated = await boxRepository.update(box.id, { updateData })
+    await settle()
+    return updated
+  }
+
+  /** Backdates the box's open period so the roll-over cron considers it stale. */
+  const ageOpenPeriod = async (boxId: string, by = DAY_MS + 60_000) => {
+    await periods.update({ boxId, endAt: IsNull() }, { startAt: new Date(Date.now() - by) })
+  }
+
+  const insertOpenPeriod = (overrides: Partial<BoxUsagePeriod> = {}) =>
+    periods.save(
+      periods.create({
+        boxId: generateBoxId(),
+        organizationId: ORGANIZATION_ID,
+        region: REGION,
+        ...BOX_RESOURCES,
+        startAt: new Date(),
+        endAt: null,
+        ...overrides,
+      }),
+    )
+
+  /**
+   * A box's periods must tile its lifetime: each one ends before the next
+   * starts (an overlap is billed twice) and leaves no hole behind it (a gap is
+   * billed to nobody). Closing and reopening take two `new Date()` calls, so
+   * the seam is a few milliseconds wide rather than exact.
+   */
+  const assertContiguous = (chain: Array<{ startAt: Date; endAt: Date | null }>, maxGapMs = 1_000) => {
+    for (let i = 1; i < chain.length; i += 1) {
+      const previousEnd = chain[i - 1].endAt
+      if (previousEnd === null) {
+        throw new Error(`period ${i - 1} of ${chain.length} is still open, so period ${i} overlaps it`)
+      }
+      const gapMs = chain[i].startAt.getTime() - previousEnd.getTime()
+      expect(gapMs).toBeGreaterThanOrEqual(0)
+      expect(gapMs).toBeLessThan(maxGapMs)
+    }
+  }
+
+  // ------------------------------------------------------------------ setup
+
+  const connection = {
+    type: 'postgres' as const,
+    host: process.env.DB_HOST,
+    port: Number(process.env.DB_PORT || 5432),
+    username: process.env.DB_USERNAME,
+    password: process.env.DB_PASSWORD,
+    namingStrategy: new CustomNamingStrategy(),
+  }
+
+  /** Connects to the database the environment points at, only to create or drop this spec's own. */
+  const withAdminConnection = async (run: (admin: DataSource) => Promise<void>) => {
+    const admin = await new DataSource({ ...connection, database: process.env.DB_DATABASE }).initialize()
+    try {
+      await run(admin)
+    } finally {
+      await admin.destroy()
+    }
+  }
+
+  beforeAll(async () => {
+    await withAdminConnection(async (admin) => {
+      await admin.query(`DROP DATABASE IF EXISTS "${SCENARIO_DATABASE}" WITH (FORCE)`)
+      await admin.query(`CREATE DATABASE "${SCENARIO_DATABASE}"`)
+    })
+    ownsDatabase = true
+
+    // `box` comes from its entity — its schema is not this module's contract —
+    // while the ledger tables are built by running the migration that ships, so
+    // the partial unique index under test is the one production will have.
+    const schemaSource = await new DataSource({
+      ...connection,
+      database: SCENARIO_DATABASE,
+      entities: [Box, BoxLastActivity],
+      synchronize: true,
+    }).initialize()
+    await schemaSource.query(`CREATE EXTENSION IF NOT EXISTS "uuid-ossp"`)
+    const queryRunner = schemaSource.createQueryRunner()
+    try {
+      await new AddBoxUsagePeriods1785250000000().up(queryRunner)
+    } finally {
+      await queryRunner.release()
+      await schemaSource.destroy()
+    }
+
+    // ScheduleModule is deliberately absent: the crons are invoked explicitly so
+    // a scenario never races a background tick.
+    moduleRef = await Test.createTestingModule({
+      imports: [
+        EventEmitterModule.forRoot(),
+        RedisModule.forRoot({
+          type: 'single',
+          options: {
+            host: process.env.REDIS_HOST,
+            port: Number(process.env.REDIS_PORT || 6379),
+            db: SCENARIO_REDIS_DB,
+            maxRetriesPerRequest: 2,
+          },
+        }),
+        TypeOrmModule.forRoot({
+          ...connection,
+          database: SCENARIO_DATABASE,
+          entities: [Box, BoxLastActivity, BoxUsagePeriod, BoxUsagePeriodArchive],
+          synchronize: false,
+        }),
+        UsageModule,
+      ],
+    }).compile()
+    await moduleRef.init()
+
+    dataSource = moduleRef.get(DataSource)
+    boxRepository = moduleRef.get(BoxRepository)
+    usageService = moduleRef.get(UsageService)
+    periods = dataSource.getRepository(BoxUsagePeriod)
+    archives = dataSource.getRepository(BoxUsagePeriodArchive)
+  }, 60_000)
+
+  afterAll(async () => {
+    await moduleRef?.close()
+    if (ownsDatabase) {
+      await withAdminConnection((admin) => admin.query(`DROP DATABASE IF EXISTS "${SCENARIO_DATABASE}" WITH (FORCE)`))
+    }
+  })
+
+  beforeEach(async () => {
+    await dataSource.query(`TRUNCATE ${ALL_TABLES}`)
+  })
+
+  // ------------------------------------------- a box moving through its states
+
+  describe('a box moving through its states', () => {
+    it('opens one compute period when the box reaches STARTED', async () => {
+      const box = await createBox()
+
+      await drive(box, { state: BoxState.STARTED })
+
+      const billed = await ledger(box.id)
+      expect(billed).toEqual([compute({ endAt: null, organizationId: ORGANIZATION_ID, region: REGION })])
+      expect(Date.now() - billed[0].startAt.getTime()).toBeLessThan(10_000)
+    })
+
+    it('bills nothing for a box that never starts', async () => {
+      const box = await createBox()
+
+      await drive(box, { state: BoxState.ERROR })
+
+      expect(await ledger(box.id)).toEqual([])
+    })
+
+    it('switches to disk-only billing the moment a stop is requested', async () => {
+      const box = await createBox()
+      await drive(box, { state: BoxState.STARTED })
+
+      await drive(box, { desiredState: BoxDesiredState.STOPPED, state: BoxState.STOPPING })
+
+      const [computePeriod, diskPeriod] = await ledger(box.id)
+      expect(computePeriod).toEqual(compute({ endAt: expect.any(Date) }))
+      expect(diskPeriod).toEqual(diskOnly)
+      expect(diskPeriod.endAt).toBeNull()
+    })
+
+    it('adds no row when the box lands in STOPPED after STOPPING', async () => {
+      const box = await createBox()
+      await drive(box, { state: BoxState.STARTED })
+      await drive(box, { desiredState: BoxDesiredState.STOPPED, state: BoxState.STOPPING })
+
+      await drive(box, { state: BoxState.STOPPED })
+
+      expect(await ledger(box.id)).toHaveLength(2)
+      expect(await openPeriods(box.id)).toEqual([diskOnly])
+    })
+
+    it('stops charging compute when the box lands in STOPPED without passing through STOPPING', async () => {
+      const box = await createBox()
+      await drive(box, { state: BoxState.STARTED })
+
+      await drive(box, { desiredState: BoxDesiredState.STOPPED, state: BoxState.STOPPED })
+
+      const [computePeriod, diskPeriod] = await ledger(box.id)
+      expect(computePeriod).toEqual(compute({ endAt: expect.any(Date) }))
+      expect(diskPeriod).toEqual(diskOnly)
+      expect(diskPeriod.endAt).toBeNull()
+    })
+
+    it('resumes compute billing when a stopped box starts again', async () => {
+      const box = await createBox()
+      await drive(box, { state: BoxState.STARTED })
+      await drive(box, { desiredState: BoxDesiredState.STOPPED, state: BoxState.STOPPED })
+
+      await drive(box, { desiredState: BoxDesiredState.STARTED, state: BoxState.STARTED })
+
+      const billed = await ledger(box.id)
+      expect(billed).toHaveLength(3)
+      expect(billed[1]).toEqual(expect.objectContaining({ cpu: 0, endAt: expect.any(Date) }))
+      expect(billed[2]).toEqual(compute({ endAt: null }))
+    })
+
+    it('bills the new size after a resize, not the old one', async () => {
+      const box = await createBox()
+      await drive(box, { state: BoxState.STARTED })
+
+      await drive(box, { state: BoxState.RESIZING })
+      await drive(box, { state: BoxState.STARTED, cpu: 8, mem: 16, disk: 40 })
+
+      const billed = await ledger(box.id)
+      expect(billed).toHaveLength(2)
+      expect(billed[0]).toEqual(compute({ endAt: expect.any(Date) }))
+      expect(billed[1]).toEqual(expect.objectContaining({ cpu: 8, mem: 16, disk: 40, endAt: null }))
+    })
+
+    it('stops billing when deletion is requested, not when the box is finally gone', async () => {
+      const box = await createBox()
+      await drive(box, { state: BoxState.STARTED })
+
+      await drive(box, { desiredState: BoxDesiredState.DESTROYED })
+
+      expect(await openPeriods(box.id)).toEqual([])
+      expect(await ledger(box.id)).toEqual([compute({ endAt: expect.any(Date) })])
+    })
+
+    it('neither reopens nor re-closes as a deleted box walks DESTROYING to DESTROYED', async () => {
+      const box = await createBox()
+      await drive(box, { state: BoxState.STARTED })
+      await drive(box, { desiredState: BoxDesiredState.DESTROYED })
+      const [closedAtDeleteRequest] = await ledger(box.id)
+
+      await drive(box, { state: BoxState.DESTROYING })
+      await drive(box, { state: BoxState.DESTROYED })
+
+      const billed = await ledger(box.id)
+      expect(billed).toHaveLength(1)
+      expect(billed[0].endAt).toEqual(closedAtDeleteRequest.endAt)
+    })
+
+    it('closes the period when a running box errors', async () => {
+      const box = await createBox()
+      await drive(box, { state: BoxState.STARTED })
+
+      await drive(box, { state: BoxState.ERROR })
+
+      expect(await openPeriods(box.id)).toEqual([])
+      expect(await ledger(box.id)).toEqual([compute({ endAt: expect.any(Date) })])
+    })
+
+    it.each([
+      ['STARTING', BoxState.STARTING],
+      ['RESTORING', BoxState.RESTORING],
+      ['RESIZING', BoxState.RESIZING],
+    ])('leaves the ledger alone while the box passes through %s', async (_label, state) => {
+      const box = await createBox()
+      await drive(box, { state: BoxState.STARTED })
+      const [opened] = await ledger(box.id)
+
+      await drive(box, { state })
+
+      const billed = await ledger(box.id)
+      expect(billed).toHaveLength(1)
+      expect(billed[0].id).toEqual(opened.id)
+      expect(billed[0].endAt).toBeNull()
+    })
+
+    it('keeps two boxes independent', async () => {
+      const stopped = await createBox()
+      const running = await createBox()
+      await drive(stopped, { state: BoxState.STARTED })
+      await drive(running, { state: BoxState.STARTED })
+
+      await drive(stopped, { desiredState: BoxDesiredState.STOPPED, state: BoxState.STOPPING })
+
+      expect(await openPeriods(running.id)).toEqual([compute({ endAt: null })])
+      expect(await openPeriods(stopped.id)).toEqual([diskOnly])
+    })
+
+    it('bills a full start/stop/start/delete lifecycle as one unbroken, non-overlapping chain', async () => {
+      const box = await createBox()
+
+      await drive(box, { state: BoxState.STARTED })
+      await drive(box, { desiredState: BoxDesiredState.STOPPED, state: BoxState.STOPPING })
+      await drive(box, { state: BoxState.STOPPED })
+      await drive(box, { desiredState: BoxDesiredState.STARTED, state: BoxState.STARTED })
+      await drive(box, { desiredState: BoxDesiredState.DESTROYED })
+      await drive(box, { state: BoxState.DESTROYED })
+
+      const billed = await ledger(box.id)
+      expect(billed.map((period) => period.cpu)).toEqual([BOX_RESOURCES.cpu, 0, BOX_RESOURCES.cpu])
+      expect(billed.every((period) => period.endAt !== null)).toBe(true)
+      assertContiguous(billed)
+    })
+  })
+
+  // ---------------------------------------------------------- roll-over cron
+
+  describe('the daily roll-over', () => {
+    it('carries a running box into a fresh period that starts exactly where the old one ended', async () => {
+      const box = await createBox()
+      await drive(box, { state: BoxState.STARTED })
+      await ageOpenPeriod(box.id)
+
+      await usageService.closeAndReopenUsagePeriods()
+
+      const [closed, reopened] = await ledger(box.id)
+      expect(reopened).toEqual(compute({ endAt: null, organizationId: ORGANIZATION_ID, region: REGION }))
+      expect(reopened.startAt).toEqual(closed.endAt)
+    })
+
+    it('zeroes compute for a box that is already stopped', async () => {
+      const box = await createBox()
+      await drive(box, { state: BoxState.STARTED })
+      // A raw update changes the row without emitting, which is what a crashed
+      // or missed handler leaves behind: a stopped box still carrying an open
+      // compute period. Without the zeroing branch the roll-over would re-bill
+      // that box a full cpu every day, forever.
+      await boxRepository.update(box.id, { updateData: { state: BoxState.STOPPED } }, true)
+      await ageOpenPeriod(box.id)
+
+      await usageService.closeAndReopenUsagePeriods()
+
+      expect(await openPeriods(box.id)).toEqual([diskOnly])
+    })
+
+    it('keeps billing disk for a box still stopping', async () => {
+      const box = await createBox()
+      await drive(box, { state: BoxState.STARTED })
+      await drive(box, { desiredState: BoxDesiredState.STOPPED, state: BoxState.STOPPING })
+      await ageOpenPeriod(box.id)
+
+      await usageService.closeAndReopenUsagePeriods()
+
+      expect(await openPeriods(box.id)).toEqual([diskOnly])
+    })
+
+    it('closes without reopening once the box is destroyed', async () => {
+      const box = await createBox()
+      await drive(box, { state: BoxState.STARTED })
+      // Raw, so the destroy never reaches the handlers — the roll-over is the
+      // last line of defence against a period left open on a dead box.
+      await boxRepository.update(
+        box.id,
+        { updateData: { desiredState: BoxDesiredState.DESTROYED, state: BoxState.DESTROYED } },
+        true,
+      )
+      await ageOpenPeriod(box.id)
+
+      await usageService.closeAndReopenUsagePeriods()
+
+      expect(await openPeriods(box.id)).toEqual([])
+      expect(await ledger(box.id)).toEqual([compute({ endAt: expect.any(Date) })])
+    })
+
+    it('closes without reopening when the box row is gone', async () => {
+      const orphan = await insertOpenPeriod({ startAt: new Date(Date.now() - DAY_MS - 60_000) })
+
+      await usageService.closeAndReopenUsagePeriods()
+
+      expect(await openPeriods(orphan.boxId)).toEqual([])
+      expect(await ledger(orphan.boxId)).toEqual([expect.objectContaining({ endAt: expect.any(Date) })])
+    })
+
+    it('leaves a period younger than a day alone', async () => {
+      const box = await createBox()
+      await drive(box, { state: BoxState.STARTED })
+      await ageOpenPeriod(box.id, DAY_MS - 60_000)
+
+      await usageService.closeAndReopenUsagePeriods()
+
+      expect(await ledger(box.id)).toHaveLength(1)
+      expect(await openPeriods(box.id)).toHaveLength(1)
+    })
+
+    it('leaves warm-pool periods alone, since no organization owns them yet', async () => {
+      const warmPool = await insertOpenPeriod({
+        organizationId: BOX_WARM_POOL_UNASSIGNED_ORGANIZATION,
+        startAt: new Date(Date.now() - DAY_MS - 60_000),
+      })
+
+      await usageService.closeAndReopenUsagePeriods()
+
+      expect(await openPeriods(warmPool.boxId)).toHaveLength(1)
+    })
+
+    it('leaves exactly one open period per box behind', async () => {
+      const box = await createBox()
+      await drive(box, { state: BoxState.STARTED })
+      await ageOpenPeriod(box.id)
+
+      await usageService.closeAndReopenUsagePeriods()
+
+      expect(await openPeriods(box.id)).toHaveLength(1)
+    })
+
+    it('caps a single run at 100 periods, leaving the rest for the next tick', async () => {
+      const stale = new Date(Date.now() - DAY_MS - 60_000)
+      for (let i = 0; i < 101; i += 1) {
+        await insertOpenPeriod({ startAt: new Date(stale.getTime() + i) })
+      }
+
+      await usageService.closeAndReopenUsagePeriods()
+
+      expect(await periods.count({ where: { endAt: IsNull() } })).toBe(1)
+    })
+  })
+
+  // ------------------------------------------------------------ archive cron
+
+  describe('the archive sweep', () => {
+    it('moves every closed period across with its billed fields intact', async () => {
+      const box = await createBox()
+      await drive(box, { state: BoxState.STARTED })
+      await drive(box, { desiredState: BoxDesiredState.STOPPED, state: BoxState.STOPPING })
+      const [closed] = await periods.find({ where: { boxId: box.id } })
+
+      await usageService.archiveUsagePeriods()
+
+      expect(await archives.find({ where: { boxId: box.id } })).toEqual([
+        compute({
+          boxId: box.id,
+          organizationId: ORGANIZATION_ID,
+          region: REGION,
+          startAt: closed.startAt,
+          endAt: closed.endAt,
+        }),
+      ])
+    })
+
+    it('leaves the still-accruing period where billing can find it', async () => {
+      const box = await createBox()
+      await drive(box, { state: BoxState.STARTED })
+      await drive(box, { desiredState: BoxDesiredState.STOPPED, state: BoxState.STOPPING })
+
+      await usageService.archiveUsagePeriods()
+
+      expect(await periods.find({ where: { boxId: box.id } })).toEqual([diskOnly])
+      expect(await ledger(box.id)).toHaveLength(2)
+    })
+
+    it('is a no-op once there is nothing closed left to move', async () => {
+      const box = await createBox()
+      await drive(box, { state: BoxState.STARTED })
+      await drive(box, { desiredState: BoxDesiredState.STOPPED, state: BoxState.STOPPING })
+      await usageService.archiveUsagePeriods()
+      const afterFirstSweep = await ledger(box.id)
+
+      await usageService.archiveUsagePeriods()
+
+      expect(await ledger(box.id)).toEqual(afterFirstSweep)
+    })
+  })
+
+  // ------------------------------------------------------------- concurrency
+
+  describe('under concurrency', () => {
+    it('still leaves one open period when a stop races the roll-over', async () => {
+      const box = await createBox()
+      await drive(box, { state: BoxState.STARTED })
+      await ageOpenPeriod(box.id)
+
+      await Promise.all([
+        usageService.closeAndReopenUsagePeriods(),
+        boxRepository.update(box.id, {
+          updateData: { desiredState: BoxDesiredState.STOPPED, state: BoxState.STOPPING },
+        }),
+      ])
+      await settle()
+
+      expect(await openPeriods(box.id)).toHaveLength(1)
+      assertContiguous(await ledger(box.id))
+    })
+
+    it('refuses a second open period for the same box', async () => {
+      const box = await createBox()
+      await drive(box, { state: BoxState.STARTED })
+
+      await expect(insertOpenPeriod({ boxId: box.id })).rejects.toThrow(/box_usage_periods_one_open_period_per_box_idx/)
+    })
+  })
+})

--- a/apps/infra-local/README.md
+++ b/apps/infra-local/README.md
@@ -78,6 +78,9 @@ runner path against a separate Docker stack. The direct-SDK capability this stac
 relies on — read-write host volumes + host port mapping — is pinned by
 `sdks/python/tests/test_volume_port_persistence.py`.
 
+For fault injection against a live stack — killing the API mid-transition to see
+what the box usage ledger does about it — see [`scripts/README.md`](./scripts/README.md).
+
 ## Troubleshooting
 
 | Symptom | Cause | Fix |
@@ -96,7 +99,7 @@ relies on — read-write host volumes + host port mapping — is pinned by
 
 ## Layout
 
-Everything is the `compose` package + four root files (no `scripts/`, no `configs/`):
+Everything is the `compose` package + four root files (no `configs/`):
 
 ```text
 apps/infra-local/
@@ -104,6 +107,7 @@ apps/infra-local/
 ├── README.md
 ├── pyproject.toml
 ├── api.env           # API .env template (copied to apps/api/.env on first `up`)
+├── scripts/          # fault-injection + audit tooling (see scripts/README.md)
 └── compose/
     ├── __main__.py   # the `python -m compose` CLI (up/down/status/logs/restart/reset/nuke)
     ├── config.py     # InfraConfig (single source of truth)

--- a/apps/infra-local/scripts/README.md
+++ b/apps/infra-local/scripts/README.md
@@ -1,0 +1,168 @@
+# Usage-ledger drift scenarios
+
+Tools for answering one question: **can a box be running with no usage period
+open, or stopped with one still open?**
+
+Yes, both. This directory reproduces it, and audits for it.
+
+## Why it happens
+
+`box_usage_periods` has exactly one writer, `UsageService`
+(`apps/api/src/usage/services/usage.service.ts`), and it is driven entirely by
+in-process events:
+
+```
+BoxRepository.update()
+  └─ transaction { UPDATE box … }            COMMIT   ← box row is now authoritative
+  └─ emitUpdateEvents()                               ← EventEmitter2, not awaited
+       └─ UsageService.handleBoxStateUpdate()         ← the only ledger write
+            └─ waitForLock(`usage-period-<boxId>`)    ← first await; can park here
+            └─ closeUsagePeriod() / createUsagePeriod()
+```
+
+The commit and the ledger write are not atomic, and the event between them is
+neither persisted nor retried. Anything that ends the process in that window —
+SIGKILL, a crash, an OOM, or a graceful restart whose 5s grace expires while a
+handler is parked on its lock — drops the pending write with nothing recording
+that it was owed.
+
+What happens next is asymmetric:
+
+| Lost transition | Ledger says | Effect | Repaired by |
+|---|---|---|---|
+| → STARTED | nothing open, or the previous disk-only period still open | box runs **unbilled** | neither cron; only the box's next real transition |
+| → STOPPING / STOPPED | compute period still open | box **billed compute while stopped** | `closeAndReopenUsagePeriods` once the period is ≥24h old, or the next real transition, whichever comes first |
+| → DESTROYED | period still open on a deleted box | box **billed after deletion** | the 24h roll-over — a destroyed box has no next transition |
+| → STARTED after a resize | old size still open | billed at the **old size** | neither cron; the roll-over copies the stale size forward via `fromUsagePeriod`, so it outlives every tick |
+
+No repair is retroactive. Every path above fixes what happens *from now on*; the
+span that was mis-billed while the drift stood is never restated.
+
+Nothing self-heals quickly because the two crons in `UsageService` both start
+from `box_usage_periods`: the roll-over iterates periods that already exist (so
+a box with no row is invisible to it), and the archive sweep only moves closed
+rows. `BoxManager.syncStates` — the one job that re-drives a box — selects
+`desiredState <> state`, so a box that settled *before* the crash is skipped.
+Re-issuing `start` on it emits nothing either, because `emitUpdateEvents` fires
+only on a change.
+
+## Where each tool lives
+
+| Job | Tool |
+|---|---|
+| Catch a regression in CI | `apps/api/src/usage/usage.crash-recovery.integration.spec.ts` |
+| Measure what a real process kill does (S1–S8) | `apps/scripts/usage-period-chaos/run.mjs` |
+| Inject the fault into the running local stack, on a real box | `usage-crash-scenario.sh` (here) |
+| Find drift in any live ledger | `usage-ledger-audit.sql` (here) |
+
+The chaos harness in `apps/scripts/usage-period-chaos/` came first and covers
+ground this directory does not: it kills a real process holding the real
+`UsageModule` graph and times the shutdown drain. Its two handler-level findings
+— an unreachable Redis losing the write to a log line, and the graceful drain
+returning early — are pinned as CI tests in the spec below. Detection lives here
+and only here: `usage-ledger-audit.sql` is the one detector, so there is nothing
+to drift against.
+
+## The two tiers
+
+### 1. Deterministic — `usage.crash-recovery.integration.spec.ts`
+
+Lives with the code it tests (`apps/api/src/usage/`). Needs a Postgres and a
+Redis; it creates and drops its own database, so it is safe next to a running
+stack.
+
+Point it at the **Docker** Postgres and Redis, not infra-local's:
+
+```bash
+cd apps
+DB_HOST=127.0.0.1 DB_PORT=55432 DB_USERNAME=postgres DB_PASSWORD=postgres \
+DB_DATABASE=postgres REDIS_HOST=127.0.0.1 REDIS_PORT=6379 \
+npx nx test api --testPathPatterns='usage.crash-recovery' --runInBand
+```
+
+infra-local's Postgres (`25432`) is an L1 microVM with `max_files_per_process`
+1000, and `CREATE DATABASE` on it currently PANICs with `could not close file …:
+No file descriptors available` — which is the first thing this spec's `beforeAll`
+does. The server recovers on its own in about a second and loses nothing, but the
+run dies. `--runInBand` is needed for the same budget: the full parallel suite
+exhausts it too.
+
+`DB_DATABASE` is only the database the spec connects to in order to create its
+own (`<DB_DATABASE>_box_usage_crash`), so any existing database works — but never
+name one holding real usage: the sibling `usage.service.integration.spec.ts`
+drops the ledger tables outright, and its own guard will refuse to run if they
+hold rows.
+
+18 scenarios: the window itself (a committed STARTED that is provably unbilled
+while its handler is parked), then a lost START / STOP / DESTROY / resize, each
+followed through an API restart, the roll-over cron, and the next real
+transition.
+
+Its sibling `usage.lifecycle.integration.spec.ts` covers the healthy path.
+
+### 2. End-to-end — `usage-crash-scenario.sh`
+
+Drives a real box on the running stack and really SIGKILLs the API.
+
+```bash
+cd apps/infra-local
+./scripts/usage-crash-scenario.sh lost-start <box>   # box must be stopped
+./scripts/usage-crash-scenario.sh lost-stop  <box>   # box must be started
+./scripts/usage-crash-scenario.sh audit              # drift report only
+./scripts/usage-crash-scenario.sh cleanup            # revoke the scenario API key
+```
+
+Each run: takes `UsageService`'s own per-box Redis lock so the handler parks
+instead of writing → calls `POST /api/v1/boxes/<id>/{start,stop}` → waits for the
+box row to commit the new state → `kill -9` on the API process group → releases
+the lock → `make restart COMPONENTS=api` → audits immediately, then again after
+two `sync-states` ticks.
+
+The lock is what makes this deterministic, and it is worth being precise about
+what that does and does not show. Unaided, the window is a Redis round-trip
+(`waitForLock`) plus one to three Postgres queries — the `SELECT` for the open
+period, its `UPDATE`, and the `INSERT` — so the script *holds it open* rather
+than waiting to catch a spontaneous race. That proves the window is reachable and
+that nothing repairs what falls into it. It says nothing about how often
+production lands there.
+
+It mints itself an API key directly in the database (cached in
+`.apps-local/usage-crash-scenario.key`) and kills a process by pid file — local
+stack only, never a shared environment.
+
+**Leave the box alone while it runs.** The drift is only observable while the
+box sits in the state it crashed into; the next transition overwrites the ledger
+with something self-consistent and the mis-billed span becomes invisible. A
+dashboard tab left open, or the API's watch mode reloading because a file under
+`apps/api/src` changed, is enough to mask it. The script warns and stops if the
+box moved.
+
+To repair a box the scenario left drifted, stop and start it for real — the next
+transition rewrites its open period correctly.
+
+## The auditor — `usage-ledger-audit.sql`
+
+Read-only, no infra-local assumptions; point it at any environment.
+
+```bash
+psql "postgresql://boxlite:boxlite@127.0.0.1:25432/boxlite" -f scripts/usage-ledger-audit.sql
+```
+
+One row per disagreement between `box` and the ledger, worst first:
+
+| Finding | Meaning |
+|---|---|
+| `MISSING_OPEN` | started box with no open period — unbilled |
+| `MISSING_OPEN_DISK` | stopped box with no open period — disk unbilled |
+| `UNDERBILLED_COMPUTE` | started box whose open period bills `cpu=0` |
+| `OVERBILLED_COMPUTE` | stopped box whose open period still bills compute |
+| `STALE_OPEN` | destroyed / errored box still billing |
+| `ORPHAN_OPEN` | open period whose box row is gone |
+| `WRONG_SIZE` | open period bills a size the box no longer has |
+| `MULTI_OPEN` | more than one period open for a box |
+| `OVERLAP` / `GAP` | the period chain double-bills or skips time |
+
+It is a **point-in-time** check. It catches a box that is *currently* drifted; it
+cannot see a span that was mis-billed and then papered over by a later
+transition. That blind spot is the reason the lost-START case is the serious one:
+by the time anyone looks, the evidence is gone.

--- a/apps/infra-local/scripts/usage-crash-scenario.sh
+++ b/apps/infra-local/scripts/usage-crash-scenario.sh
@@ -1,0 +1,286 @@
+#!/usr/bin/env bash
+#
+# Reproduce, on the running infra-local stack, the two ways the box usage ledger
+# can drift away from the box table:
+#
+#   lost-start <box>   the API dies after the box row commits STARTED but before
+#                      UsageService opens the period  -> the box runs unbilled
+#   lost-stop  <box>   the API dies after the box row commits STOPPED but before
+#                      UsageService closes the period -> the box bills compute
+#                      while stopped
+#
+# Both are the same window. BoxRepository commits the row and only then calls
+# emitUpdateEvents(), an in-process EventEmitter2 emit that is not awaited, not
+# persisted and not retried; UsageService is the only listener that writes the
+# ledger. The scenario holds that window open on purpose — it takes
+# UsageService's own per-box Redis lock first, which parks the handler at its
+# first await — and then SIGKILLs the API while the handler sits there.
+#
+# Usage:
+#   ./usage-crash-scenario.sh audit                 # just report ledger drift
+#   ./usage-crash-scenario.sh lost-start <box>      # box must be stopped
+#   ./usage-crash-scenario.sh lost-stop  <box>      # box must be started
+#   ./usage-crash-scenario.sh key                   # print the scenario API key
+#   ./usage-crash-scenario.sh cleanup               # revoke that key
+#
+# <box> is a box name or id in the local database.
+#
+# Leave the box alone for the duration: the drift is only observable while the
+# box sits in the state it crashed into, so a dashboard tab that stops it, or
+# the API's watch mode reloading because a file under apps/api/src changed, will
+# quietly repair it before the audit runs.
+#
+# Local stack only: it mints an API key straight into the database and SIGKILLs
+# a process by pid file. Never point it at a shared environment.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+INFRA_LOCAL="$(dirname -- "$SCRIPT_DIR")"
+REPO_ROOT="$(cd -- "$INFRA_LOCAL/../.." && pwd)"
+STATE_DIR="$REPO_ROOT/.apps-local"
+API_PID_FILE="$STATE_DIR/logs/api.pid"
+KEY_FILE="$STATE_DIR/usage-crash-scenario.key"
+AUDIT_SQL="$SCRIPT_DIR/usage-ledger-audit.sql"
+
+PGHOST=127.0.0.1 PGPORT=25432 PGUSER=boxlite PGPASSWORD=boxlite PGDATABASE=boxlite
+export PGHOST PGPORT PGUSER PGPASSWORD PGDATABASE
+REDIS_HOST=127.0.0.1 REDIS_PORT=26379
+export REDIS_HOST REDIS_PORT   # the node Redis client below reads them from its environment
+API_URL=http://localhost:3001
+
+# UsageService.aquireLock builds this key; parking it from outside is what holds
+# the window open. Keep in step with usage.service.ts if that name ever changes.
+usage_lock_key() { echo "usage-period-$1"; }
+
+log()  { printf '\033[1;36m==>\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m[warn]\033[0m %s\n' "$*"; }
+die()  { printf '\033[1;31m[fail]\033[0m %s\n' "$*" >&2; exit 1; }
+
+q() { psql -qtAX -c "$1"; }
+
+# Minimal Redis client — the host has no redis-cli, and the local Redis runs
+# inside an L1 microVM rather than a container we could exec into.
+redis() {
+  node -e '
+    const net = require("net")
+    const args = process.argv.slice(1)
+    const cmd = "*" + args.length + "\r\n" + args.map((a) => "$" + Buffer.byteLength(a) + "\r\n" + a + "\r\n").join("")
+    const socket = net.createConnection(Number(process.env.REDIS_PORT), process.env.REDIS_HOST)
+    socket.on("connect", () => socket.write(cmd))
+    socket.on("data", (chunk) => { process.stdout.write(chunk.toString().trim()); socket.end() })
+    socket.on("error", (err) => { console.error(err.message); process.exit(1) })
+  ' "$@"
+}
+
+require_tools() {
+  for tool in psql node curl; do
+    command -v "$tool" >/dev/null || die "$tool not found on PATH"
+  done
+  q 'SELECT 1' >/dev/null 2>&1 || die "no Postgres at $PGHOST:$PGPORT — is the stack up? (make status)"
+  [ "$(redis PING)" = "+PONG" ] || die "no Redis at $REDIS_HOST:$REDIS_PORT"
+}
+
+# ---------------------------------------------------------------- API key
+
+# Mints a key for the organization that owns the target box, so the REST call
+# passes the organization guard. Cached in the gitignored state dir; re-minted
+# whenever the cache is missing or the row no longer matches.
+ensure_api_key() {
+  local org="$1" user token hash
+  user="$(q "SELECT \"userId\" FROM organization_user WHERE \"organizationId\" = '$org' AND role = 'owner' LIMIT 1")"
+  [ -n "$user" ] || die "organization $org has no owner to mint a key for"
+
+  if [ -f "$KEY_FILE" ]; then
+    token="$(cat "$KEY_FILE")"
+    hash="$(printf '%s' "$token" | shasum -a 256 | cut -d' ' -f1)"
+    if [ "$(q "SELECT count(*) FROM api_key WHERE \"keyHash\" = '$hash' AND \"organizationId\" = '$org'")" = "1" ]; then
+      echo "$token"
+      return
+    fi
+  fi
+
+  token="blk_test_$(node -e 'process.stdout.write(require("crypto").randomBytes(32).toString("hex"))')"
+  hash="$(printf '%s' "$token" | shasum -a 256 | cut -d' ' -f1)"
+  q "INSERT INTO api_key (\"organizationId\", \"userId\", name, \"keyHash\", \"keyPrefix\", \"keySuffix\", permissions, \"createdAt\")
+     SELECT '$org', '$user', 'usage-crash-scenario', '$hash', 'blk_test_', '${token: -4}',
+            enum_range(NULL::api_key_permissions_enum), now()
+     ON CONFLICT (\"organizationId\", \"userId\", name)
+     DO UPDATE SET \"keyHash\" = EXCLUDED.\"keyHash\", \"keySuffix\" = EXCLUDED.\"keySuffix\"" >/dev/null
+  umask 077 && printf '%s' "$token" > "$KEY_FILE"
+  echo "$token"
+}
+
+# ---------------------------------------------------------------- box state
+
+resolve_box() {
+  local ref="$1" id
+  id="$(q "SELECT id FROM box WHERE id = '$ref' OR name = '$ref' ORDER BY \"createdAt\" DESC LIMIT 1")"
+  [ -n "$id" ] || die "no box named or id'd '$ref' in the local database"
+  echo "$id"
+}
+
+box_field() { q "SELECT \"$2\" FROM box WHERE id = '$1'"; }
+
+# Polls the box row, which is the only signal that the transition has committed
+# — and committing is precisely what opens the window this scenario needs.
+wait_for_state() {
+  local id="$1" want="$2" timeout="${3:-180}"
+  # Separate declaration: under `set -u` a later initializer in the same `local`
+  # cannot read an earlier one (bash 3.2, which is what macOS ships).
+  local deadline=$((SECONDS + timeout)) seen
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    seen="$(box_field "$id" state)"
+    [ "$seen" = "$want" ] && return 0
+    [ "$seen" = "error" ] && die "box $id went to error: $(box_field "$id" errorReason)"
+    sleep 1
+  done
+  die "box $id still '$(box_field "$id" state)' after ${timeout}s, wanted '$want'"
+}
+
+open_period_summary() {
+  q "SELECT coalesce(string_agg(format('cpu=%s mem=%s disk=%s since %s', cpu, mem, disk, \"startAt\"), '; '), '(none)')
+     FROM box_usage_periods WHERE \"boxId\" = '$1' AND \"endAt\" IS NULL"
+}
+
+# ---------------------------------------------------------------- the crash
+
+kill_api() {
+  [ -f "$API_PID_FILE" ] || die "no API pid file at $API_PID_FILE — is the API running?"
+  local pid pgid
+  pid="$(cat "$API_PID_FILE")"
+  kill -0 "$pid" 2>/dev/null || die "API pid $pid is not alive"
+  pgid="$(ps -o pgid= -p "$pid" | tr -d ' ')"
+  log "SIGKILL the API process group ($pgid) — no shutdown hooks, no draining"
+  kill -9 -"$pgid" 2>/dev/null || true
+  while kill -0 "$pid" 2>/dev/null; do sleep 0.2; done
+}
+
+restart_api() {
+  log "restarting the API"
+  make -C "$INFRA_LOCAL" restart COMPONENTS=api >/dev/null
+  local deadline=$((SECONDS + 180))
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    [ "$(curl -s -o /dev/null -w '%{http_code}' "$API_URL/api/health" || true)" = "200" ] && { log "API healthy again"; return 0; }
+    sleep 2
+  done
+  die "API did not become healthy within 180s"
+}
+
+# Reports, then exits non-zero if anything was found, so this doubles as a cron
+# check or a CI gate. The audit file carries no psql directives precisely so the
+# same query can be rendered for a human and counted for a status code.
+audit() {
+  local findings
+  log "auditing the ledger against the box table${1:+ — $1}"
+  psql --pset=border=2 -f "$AUDIT_SQL"
+  findings="$(psql -qtAX -f "$AUDIT_SQL" | grep -c '[^[:space:]]' || true)"
+  [ "$findings" -eq 0 ]
+}
+
+# The drift is only visible while the box sits in the state it crashed into: the
+# next transition overwrites the ledger with a shape that looks self-consistent
+# again, leaving the mis-billed span with nothing to point at it. So report the
+# box's own state alongside every audit, and treat a box that moved on as an
+# inconclusive run rather than a clean one.
+assert_undisturbed() {
+  local id="$1" want="$2" seen
+  seen="$(box_field "$id" state)"
+  [ "$seen" = "$want" ] && return 0
+  warn "box $id is '$seen', not the '$want' it crashed into — something moved it"
+  warn "(a dashboard tab left open, or the API's watch mode reloading on a source edit)"
+  warn "the drift this scenario creates is no longer observable; re-run without touching the box"
+  return 1
+}
+
+# ---------------------------------------------------------------- scenarios
+
+# from_state: the state the box must be in to start the scenario
+# action:     the REST call that drives the transition
+# to_state:   the state whose commit opens the window we kill in
+run_scenario() {
+  local name="$1" ref="$2" from_state="$3" action="$4" to_state="$5"
+  local id org token lock
+
+  id="$(resolve_box "$ref")"
+  org="$(box_field "$id" organizationId)"
+  [ "$(box_field "$id" state)" = "$from_state" ] ||
+    die "scenario '$name' needs a box in '$from_state'; $id is '$(box_field "$id" state)'"
+
+  token="$(ensure_api_key "$org")"
+  lock="$(usage_lock_key "$id")"
+
+  log "box $id ($(box_field "$id" name)) — open period before: $(open_period_summary "$id")"
+
+  log "taking UsageService's lock '$lock' so its handler parks instead of writing"
+  [ "$(redis SET "$lock" scenario EX 600 NX)" = "+OK" ] ||
+    die "lock $lock is already held — a handler may be mid-flight; retry in a minute"
+
+  log "POST /api/v1/boxes/$id/$action"
+  curl -fsS -X POST -H "Authorization: Bearer $token" "$API_URL/api/v1/boxes/$id/$action" >/dev/null ||
+    { redis DEL "$lock" >/dev/null; die "$action call failed"; }
+
+  log "waiting for the box row to commit '$to_state' (the ledger write is parked behind the lock)"
+  wait_for_state "$id" "$to_state"
+  log "row committed, ledger still shows: $(open_period_summary "$id")"
+
+  kill_api
+
+  log "releasing the lock so the restarted API is not blocked by it"
+  redis DEL "$lock" >/dev/null
+
+  restart_api
+
+  log "box is '$(box_field "$id" state)' / desired '$(box_field "$id" desiredState)'"
+  log "open period after the restart: $(open_period_summary "$id")"
+  assert_undisturbed "$id" "$to_state" || return 1
+  # A finding here is the scenario succeeding, so its non-zero status is not a
+  # failure of this run — only of the ledger.
+  audit "immediately after the restart" || true
+
+  # sync-states runs every 10s and is the only thing that re-drives a box, but
+  # it selects boxes whose desiredState differs from their state — a box that
+  # settled before the crash is invisible to it. 20s is two full ticks.
+  log "waiting 20s for two sync-states ticks"
+  sleep 20
+
+  log "open period after two sync-states ticks: $(open_period_summary "$id")"
+  assert_undisturbed "$id" "$to_state" || return 1
+  audit "after two sync-states ticks" || true
+}
+
+main() {
+  local cmd="${1:-}"
+  case "$cmd" in
+    audit)
+      require_tools
+      audit
+      ;;
+    key)
+      require_tools
+      ensure_api_key "$(q "SELECT \"organizationId\" FROM organization_user WHERE role = 'owner' ORDER BY \"createdAt\" LIMIT 1")"
+      ;;
+    cleanup)
+      require_tools
+      q "DELETE FROM api_key WHERE name = 'usage-crash-scenario'" >/dev/null
+      rm -f "$KEY_FILE"
+      log "scenario API key revoked"
+      ;;
+    lost-start)
+      [ $# -eq 2 ] || die "usage: $0 lost-start <box-name-or-id>"
+      require_tools
+      run_scenario lost-start "$2" stopped start started
+      ;;
+    lost-stop)
+      [ $# -eq 2 ] || die "usage: $0 lost-stop <box-name-or-id>"
+      require_tools
+      run_scenario lost-stop "$2" started stop stopped
+      ;;
+    *)
+      sed -n '2,30p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      exit 2
+      ;;
+  esac
+}
+
+main "$@"

--- a/apps/infra-local/scripts/usage-ledger-audit.sql
+++ b/apps/infra-local/scripts/usage-ledger-audit.sql
@@ -1,0 +1,160 @@
+-- Audit the box usage ledger against the box table. Read-only; safe on any
+-- environment (local / dev / prod).
+--
+--   psql "postgresql://boxlite:boxlite@127.0.0.1:25432/boxlite" \
+--     --pset=border=2 -f usage-ledger-audit.sql
+--
+-- Deliberately one bare statement with no psql directives, so the same file can
+-- be read as a report or counted for an exit code:
+--
+--   psql … -qtAX -f usage-ledger-audit.sql | grep -c '[^[:space:]]'
+--
+-- `usage-crash-scenario.sh audit` does both, and exits non-zero on any finding
+-- so it can run as a cron check or a CI gate.
+--
+-- Every rule below mirrors one branch of UsageService
+-- (apps/api/src/usage/services/usage.service.ts), which is the only writer of
+-- box_usage_periods. It reacts to in-process events emitted by
+-- BoxRepository.emitUpdateEvents() *after* the box row has already committed,
+-- so any interruption in that window (crash, SIGKILL, restart, a handler that
+-- threw) leaves the box table and the ledger disagreeing. That disagreement is
+-- what this file names.
+--
+-- Expected open period, per box.state:
+--   started                              -> exactly 1, cpu = box.cpu   (compute)
+--   stopping | stopped                   -> exactly 1, cpu = 0         (disk only)
+--   error|archived|destroying|destroyed  -> none
+--   desiredState = destroyed             -> none  (closed on the intent, not the outcome)
+--   creating|starting|restoring|resizing -> transitional; not asserted
+--
+-- A finding is a billing error, not a style nit: MISSING_* under-bills the
+-- customer, STALE_OPEN / OVERBILLED_COMPUTE over-bills them.
+
+WITH ledger AS (
+  -- The archive cron moves closed periods out of box_usage_periods, so a box's
+  -- billed history is the union of both tables; reading either alone makes the
+  -- answer depend on whether that cron happened to have run.
+  SELECT "boxId", "startAt", "endAt", cpu, gpu, mem, disk FROM box_usage_periods
+  UNION ALL
+  SELECT "boxId", "startAt", "endAt", cpu, gpu, mem, disk FROM box_usage_periods_archive
+),
+open_period AS (
+  SELECT
+    "boxId",
+    count(*)          AS open_count,
+    max(cpu)          AS cpu,
+    max(disk)         AS disk,
+    min("startAt")    AS since
+  FROM ledger
+  WHERE "endAt" IS NULL
+  GROUP BY "boxId"
+),
+b AS (
+  SELECT
+    id,
+    name,
+    state::text          AS state,
+    "desiredState"::text AS desired_state,
+    cpu,
+    disk,
+    "updatedAt"
+  FROM box
+),
+-- Periods must tile a box's lifetime: each ends before the next starts (an
+-- overlap bills twice) and leaves no hole behind it (a gap bills nobody).
+-- Close-then-reopen is two separate `new Date()` calls, so the seam is a few
+-- milliseconds wide rather than exact.
+chain AS (
+  SELECT
+    "boxId",
+    "startAt",
+    "endAt",
+    lag("endAt")  OVER (PARTITION BY "boxId" ORDER BY "startAt") AS prev_end,
+    lag("startAt") OVER (PARTITION BY "boxId" ORDER BY "startAt") AS prev_start
+  FROM ledger
+),
+findings AS (
+  -- ---- under-billing: the box is consuming, the ledger is not counting -----
+  SELECT 1 AS severity, 'MISSING_OPEN' AS finding, b.id, b.name, b.state, b.desired_state,
+         format('box is started but has no open period (never billed since the handler was lost)') AS detail
+  FROM b LEFT JOIN open_period o ON o."boxId" = b.id
+  WHERE b.state = 'started' AND b.desired_state <> 'destroyed' AND o."boxId" IS NULL
+
+  UNION ALL
+  SELECT 1, 'MISSING_OPEN_DISK', b.id, b.name, b.state, b.desired_state,
+         format('box is %s but has no open period; its disk is not being billed', b.state)
+  FROM b LEFT JOIN open_period o ON o."boxId" = b.id
+  WHERE b.state IN ('stopping', 'stopped') AND b.desired_state <> 'destroyed' AND o."boxId" IS NULL
+
+  -- Same revenue impact as MISSING_OPEN — a running box billed as if parked —
+  -- and it is what a lost STARTED leaves behind when the box already had a
+  -- disk-only period open, so it is graded the same.
+  UNION ALL
+  SELECT 1, 'UNDERBILLED_COMPUTE', b.id, b.name, b.state, b.desired_state,
+         format('box is started (cpu=%s) but its open period bills cpu=0 (disk only)', b.cpu)
+  FROM b JOIN open_period o ON o."boxId" = b.id
+  WHERE b.state = 'started' AND b.desired_state <> 'destroyed' AND o.cpu = 0
+
+  -- ---- over-billing: the ledger is counting, the box is not consuming ------
+  UNION ALL
+  SELECT 1, 'STALE_OPEN', b.id, b.name, b.state, b.desired_state,
+         format('box reached %s / desired %s but a period is still open since %s',
+                b.state, b.desired_state, to_char(o.since, 'YYYY-MM-DD HH24:MI:SS'))
+  FROM b JOIN open_period o ON o."boxId" = b.id
+  WHERE b.state IN ('error', 'archived', 'destroying', 'destroyed') OR b.desired_state = 'destroyed'
+
+  UNION ALL
+  SELECT 1, 'OVERBILLED_COMPUTE', b.id, b.name, b.state, b.desired_state,
+         format('box is %s but its open period still bills cpu=%s (should be 0)', b.state, o.cpu)
+  FROM b JOIN open_period o ON o."boxId" = b.id
+  WHERE b.state IN ('stopping', 'stopped') AND b.desired_state <> 'destroyed' AND o.cpu > 0
+
+  UNION ALL
+  SELECT 1, 'ORPHAN_OPEN', o."boxId", NULL, NULL, NULL,
+         format('open period since %s but the box row is gone',
+                to_char(o.since, 'YYYY-MM-DD HH24:MI:SS'))
+  FROM open_period o LEFT JOIN b ON b.id = o."boxId"
+  WHERE b.id IS NULL
+
+  -- ---- wrong amount --------------------------------------------------------
+  UNION ALL
+  SELECT 2, 'WRONG_SIZE', b.id, b.name, b.state, b.desired_state,
+         format('box is cpu=%s disk=%s but the open period bills cpu=%s disk=%s (a resize was lost)',
+                b.cpu, b.disk, o.cpu, o.disk)
+  FROM b JOIN open_period o ON o."boxId" = b.id
+  WHERE b.state = 'started' AND o.cpu > 0 AND (o.cpu <> b.cpu OR o.disk <> b.disk)
+
+  -- ---- structural ----------------------------------------------------------
+  UNION ALL
+  SELECT 1, 'MULTI_OPEN', o."boxId", b.name, b.state, b.desired_state,
+         format('%s periods are open at once', o.open_count)
+  FROM open_period o LEFT JOIN b ON b.id = o."boxId"
+  WHERE o.open_count > 1
+
+  UNION ALL
+  SELECT 2, 'OVERLAP', c."boxId", b.name, b.state, b.desired_state,
+         format('period starting %s overlaps the previous one (prev end %s)',
+                to_char(c."startAt", 'YYYY-MM-DD HH24:MI:SS.MS'),
+                coalesce(to_char(c.prev_end, 'YYYY-MM-DD HH24:MI:SS.MS'), 'still open'))
+  FROM chain c LEFT JOIN b ON b.id = c."boxId"
+  WHERE c.prev_start IS NOT NULL AND (c.prev_end IS NULL OR c."startAt" < c.prev_end)
+
+  UNION ALL
+  SELECT 2, 'GAP', c."boxId", b.name, b.state, b.desired_state,
+         format('%s unbilled between %s and %s',
+                justify_interval(c."startAt" - c.prev_end),
+                to_char(c.prev_end, 'YYYY-MM-DD HH24:MI:SS.MS'),
+                to_char(c."startAt", 'YYYY-MM-DD HH24:MI:SS.MS'))
+  FROM chain c LEFT JOIN b ON b.id = c."boxId"
+  WHERE c.prev_end IS NOT NULL AND c."startAt" - c.prev_end > interval '2 seconds'
+)
+SELECT
+  CASE severity WHEN 1 THEN 'HIGH' ELSE 'MED' END AS sev,
+  finding,
+  id   AS box_id,
+  name AS box_name,
+  state,
+  desired_state,
+  detail
+FROM findings
+ORDER BY severity, finding, id;

--- a/apps/scripts/usage-period-chaos/README.md
+++ b/apps/scripts/usage-period-chaos/README.md
@@ -1,0 +1,185 @@
+# Box usage-period failure injection
+
+Answers one question: **can a box end up running with nothing billing it, or
+finished with a period still open?**
+
+Yes, in both directions, and one of them is permanent.
+
+## Why the window exists
+
+`BoxRepository.update()` commits the box row inside a transaction, then emits
+the state event _outside_ it:
+
+| Step                                                   | Where                                                                             |
+| ------------------------------------------------------ | --------------------------------------------------------------------------------- |
+| box row committed                                      | [`box.repository.ts:106-126`](../../api/src/box/repositories/box.repository.ts)   |
+| event emitted (synchronous, nobody awaits the handler) | [`box.repository.ts:128`](../../api/src/box/repositories/box.repository.ts)       |
+| handler takes a Redis lock, _then_ writes the ledger   | [`usage.service.ts:51,70,118-151`](../../api/src/usage/services/usage.service.ts) |
+
+So `update()` resolves — and the API answers the client — while the ledger write
+is still in flight. There is no outbox, no retry, and no queue: the intent to
+bill exists only in that process's memory. Anything that kills the process in
+that window loses the write silently.
+
+Two things make it worse:
+
+- `@nestjs/event-emitter` wraps every `@OnEvent` listener in a try/catch whose
+  `suppressErrors` defaults to `true`
+  ([`event-subscribers.loader.js:106-118`](../../node_modules/@nestjs/event-emitter/dist/event-subscribers.loader.js)).
+  `UsageService`'s decorators pass no options, so a handler that throws is
+  downgraded to one `[Event]` log line. No crash, no alert, no retry.
+- The only self-healing is `closeAndReopenUsagePeriods`, and it only looks at
+  periods already older than 24h ([`usage.service.ts:162-173`](../../api/src/usage/services/usage.service.ts)).
+  Nothing anywhere looks for a _missing_ period.
+
+## Results
+
+Measured against a real Postgres + Redis, killing a real process holding the
+real `UsageModule` graph. `apps/api` is not modified by any of this.
+
+|     | Scenario                                                                              | Outcome                                                                                  |
+| --- | ------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| S1  | box reaches `STARTED`, API `SIGKILL`ed before the ledger write                        | **divergence** — box runs, ledger empty                                                  |
+| S2  | box reaches `DESTROYED`, API `SIGKILL`ed before the close                             | **divergence** — period stays open; closed only once it ages past 24h                    |
+| S3  | box reaches `STOPPING`, API `SIGKILL`ed between closing compute and opening disk-only | **divergence** — stopped box's disk billed to nobody, permanently                        |
+| S4  | same window, graceful `SIGTERM`                                                       | consistent — shutdown blocked 2.0s until the write landed                                |
+| S5  | Redis unreachable when the event fires                                                | **divergence** — box row commits, ledger write lost as a log line, process stays healthy |
+| S6  | per-box lock left by a dead process (TTL 5s)                                          | consistent — write landed 5.0s late                                                      |
+| S7  | graceful `SIGTERM` with **two** handlers in flight                                    | **divergence** — drain reported empty, shutdown took 21ms, parked box never billed       |
+| S8  | 3 more rounds of both crons over the S1 box                                           | **divergence persists** — nothing repairs a missing period                               |
+
+S1/S3/S5/S7 never heal. S2 heals after up to 24h of over-billing.
+
+A graceful `SIGTERM` is safe **only while exactly one handler is in flight**.
+`main.ts:173` calls `enableShutdownHooks()` and
+`UsageService.onApplicationShutdown` ([`usage.service.ts:40-46`](../../api/src/usage/services/usage.service.ts))
+drains `activeJobs` first — but `@TrackJobExecution` keys that Set by _method
+name_, not by invocation
+([`track-job-execution.decorator.ts:20-25`](../../api/src/common/decorators/track-job-execution.decorator.ts)).
+Two concurrent `handleBoxStateUpdate` calls therefore share a single entry, and
+whichever finishes first deletes it out from under the other. S7 measures the
+consequence: the drain returned in 21ms and the process exited with a handler
+still mid-write, so that box was never billed. In S4, with a single handler in
+flight, the same shutdown was still blocked 1.5s later and the period did land.
+
+The regime, not the odds: **once two handlers overlap, the drain guarantees
+nothing**, because `activeJobs` cannot tell one invocation from another. How
+often a restart lands on such an overlap depends on traffic and is not something
+this suite measures — S7 manufactures the overlap with a held lock.
+
+Note also that an unreachable Redis **loses** the write rather than wedging it:
+`RedisLockProvider.lock()` awaits `redis.set(...)`, which rejects on a closed
+connection, so the handler throws into the suppressed catch (S5). The unbounded
+`while (activeJobs.size > 0)` drain only wedges on a lock that is _held_ with a
+long TTL, where `waitForLock` spins instead of failing.
+
+These scenarios prove the window is **reachable**, not how often production hits
+it. S1/S2/S4/S6/S7 hold the window open by taking the per-box Redis lock the
+handler waits on, and S3 by a `BEFORE INSERT` `pg_sleep`; unaided, the window is
+however long the lock plus one INSERT takes. Read the results as "this can
+happen and nothing detects it", not as a frequency estimate.
+
+## Running it
+
+S5 and S7 — the two findings that are about a _handler_ failing rather than the
+process dying — are also pinned as CI tests in
+`apps/api/src/usage/usage.crash-recovery.integration.spec.ts`
+("when the handler fails instead of the process" and "the graceful-shutdown
+drain"), so a regression is caught without running this harness. What only this
+harness can do is kill a real process and measure the drain, which is why S1–S8
+stay here.
+
+Automated — creates and drops its own `boxlite_usage_chaos` database and uses
+Redis db 14, so it touches nothing live:
+
+```bash
+cd apps && node scripts/usage-period-chaos/run.mjs
+```
+
+Defaults to the Docker stack (Postgres `55432` / Redis `6379`). Override with
+`CHAOS_DB_HOST/PORT/USER/PASSWORD`, `CHAOS_REDIS_HOST/PORT/DB`, `CHAOS_ADMIN_DB`.
+The infra-local Postgres (`25432`) works but is a microVM and drops connections
+under this load.
+
+How the windows are opened, without touching production code:
+
+- **Redis lock** — the handler's first act is `waitForLock(boxId)`. Holding
+  `usage-period-<boxId>` parks it indefinitely, leaving exactly the
+  committed-box / unwritten-ledger state.
+- **`BEFORE INSERT` trigger** — a `pg_sleep` on `box_usage_periods` parks the
+  handler _between_ closing the old period and opening the new one, which is
+  otherwise sub-millisecond.
+
+## Reproducing S1 against the real API
+
+> The steps below are automated end-to-end by
+> `apps/infra-local/scripts/usage-crash-scenario.sh lost-start <box>` (and
+> `lost-stop` for the other direction), which also mints its own API key,
+> restarts the API through `make restart COMPONENTS=api`, and audits before and
+> after the `sync-states` window. Prefer it; the manual sequence is kept because
+> it is what the script encodes, step for step.
+
+```bash
+# 1. the API process and a box that is currently stopped
+lsof -nP -iTCP:3001 -sTCP:LISTEN -t
+BOX=<boxId>
+
+# 2. park that box's usage handler (infra-local Redis; use --port 6379 for the Docker stack)
+node apps/scripts/usage-period-chaos/park-handler.mjs hold $BOX --port 26379 --ttl 600
+
+# 3. start the box — the API commits state=started and returns; the handler blocks
+curl -X POST -H "Authorization: Bearer $BOXLITE_API_KEY" \
+  http://localhost:3001/api/v1/boxes/$BOX/start
+
+# 4. confirm the box moved but the ledger did not
+psql -h 127.0.0.1 -p 25432 -U boxlite -d boxlite \
+  -c "select state from box where id='$BOX'" \
+  -c "select count(*) from box_usage_periods where \"boxId\"='$BOX'"
+
+# 5. hard-kill the API
+kill -9 $(lsof -nP -iTCP:3001 -sTCP:LISTEN -t)
+
+# 6. release the lock, then restart the API
+#    (nx serve waits for a file change, so touch a source file to trigger it)
+node apps/scripts/usage-period-chaos/park-handler.mjs release $BOX --port 26379
+touch apps/api/src/main.ts
+
+# 7. the box is running and unbilled — and stays that way
+apps/infra-local/scripts/usage-crash-scenario.sh audit
+```
+
+For S2, park the handler and issue `DELETE /api/v1/boxes/$BOX` at step 3 instead;
+the period stays open on a destroyed box.
+
+## Detecting divergence in a live ledger
+
+`apps/infra-local/scripts/usage-ledger-audit.sql` is the detector — read-only,
+safe against production, run with an exit code via
+`apps/infra-local/scripts/usage-crash-scenario.sh audit`. Ten finding classes
+(`MISSING_OPEN`, `MISSING_OPEN_DISK`, `UNDERBILLED_COMPUTE`, `STALE_OPEN`,
+`OVERBILLED_COMPUTE`, `ORPHAN_OPEN`, `WRONG_SIZE`, `MULTI_OPEN`, `OVERLAP`,
+`GAP`) covering both billing directions plus the period chain.
+
+Detection deliberately lives in one place. This directory injects faults and
+measures what the ledger does; it does not carry a second detector, because the
+weaker of two eventually gets trusted.
+
+## What would actually close the gap
+
+In rough order of cost:
+
+1. **Run `usage-ledger-audit.sql` on a schedule.** Cheapest by far, and it turns
+   silent revenue loss into an alert. It does not fix anything.
+2. **`suppressErrors: false`** on `UsageService`'s two `@OnEvent` decorators, so
+   a failed ledger write is at least loud instead of one log line among many.
+3. **Make `activeJobs` count invocations, not method names** — a counter, or a
+   Set of unique ids. One line, and it turns every S7 back into an S4, which is
+   the difference between a rolling restart being safe and being safe only when
+   the fleet happens to be idle.
+4. **Extend the roll-over into a reconciler.** It already walks open periods
+   every minute with the box row in hand; the missing half is the other
+   direction — billable boxes with no open period — plus dropping the 24h floor
+   for boxes that are already terminal.
+5. **Write the ledger in the same transaction as the box row**, or via an
+   outbox drained by the existing cron. This is the only option that actually
+   removes the window rather than shrinking it.

--- a/apps/scripts/usage-period-chaos/check-audit-classes.mjs
+++ b/apps/scripts/usage-period-chaos/check-audit-classes.mjs
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2025 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+/*
+ * Guards the finding-class table in
+ * `docs/investigations/box-usage-period-ledger.md` against the SQL it
+ * describes, `apps/infra-local/scripts/usage-ledger-audit.sql`.
+ *
+ * A doc that restates another file's contents drifts from it silently: a class
+ * added to the SQL, or a severity changed there, leaves the table quietly
+ * wrong. Nothing about that table can be trusted unless something re-reads
+ * both — this is that something.
+ *
+ *   node apps/scripts/usage-period-chaos/check-audit-classes.mjs
+ *
+ * Exits non-zero on any drift, so it works as a pre-commit or CI check.
+ */
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..')
+const SQL = path.join(REPO, 'apps/infra-local/scripts/usage-ledger-audit.sql')
+const DOC = path.join(REPO, 'docs/investigations/box-usage-period-ledger.md')
+
+// Every findings branch is `SELECT <severity>, '<CLASS>'`; the first one spells
+// out `AS severity` / `AS finding`. No length bound on the class name — a
+// bounded one is what hid `GAP` — and `\s` rather than a literal space, so a
+// branch wrapped across lines is still seen instead of silently skipped.
+const SQL_ROW = /SELECT\s+(\d+)(?:\s+AS\s+severity)?,\s*'([A-Z_]+)'/g
+// `| HIGH | 多计费 | `STALE_OPEN` | …`
+const DOC_ROW = /^\| (HIGH|MED)\s*\|[^|]*\| `([A-Z_]+)`/gm
+
+// Mirrors `CASE severity WHEN 1 THEN 'HIGH' ELSE 'MED' END` in the SQL, but
+// refuses to guess: a severity the SQL grows later must be an error here rather
+// than quietly landing in MED, which is the silent-default this check exists to
+// stop making.
+const SEVERITY_LABELS = { 1: 'HIGH', 2: 'MED' }
+
+const collect = (text, pattern, toEntry) => new Map([...text.matchAll(pattern)].map(toEntry))
+
+const inSql = collect(readFileSync(SQL, 'utf8'), SQL_ROW, (m) => [m[2], m[1]])
+const inDoc = collect(readFileSync(DOC, 'utf8'), DOC_ROW, (m) => [m[2], m[1]])
+
+const problems = []
+for (const [cls, raw] of inSql) {
+  if (!SEVERITY_LABELS[raw]) {
+    problems.push(`${cls} has severity ${raw}, which this check does not know how to label — teach it, or fix the SQL`)
+  }
+  inSql.set(cls, SEVERITY_LABELS[raw] ?? `severity ${raw}`)
+}
+for (const [cls, severity] of inSql) {
+  if (!inDoc.has(cls)) {
+    problems.push(`${cls} is emitted by the SQL (${severity}) but missing from the doc table`)
+  } else if (inDoc.get(cls) !== severity) {
+    problems.push(`${cls} is ${severity} in the SQL but documented as ${inDoc.get(cls)}`)
+  }
+}
+for (const cls of inDoc.keys()) {
+  if (!inSql.has(cls)) {
+    problems.push(`${cls} is in the doc table but the SQL never emits it`)
+  }
+}
+
+const counts = [...inSql.values()].reduce((acc, s) => ({ ...acc, [s]: (acc[s] ?? 0) + 1 }), {})
+console.log(
+  `usage-ledger-audit.sql emits ${inSql.size} classes (${counts.HIGH ?? 0} HIGH, ${counts.MED ?? 0} MED); ` +
+    `the doc table lists ${inDoc.size}`,
+)
+
+if (problems.length > 0) {
+  console.error(`\n${problems.length} drift(s):`)
+  for (const problem of problems) {
+    console.error(`  - ${problem}`)
+  }
+  process.exit(1)
+}
+console.log('doc table matches the SQL')

--- a/apps/scripts/usage-period-chaos/park-handler.mjs
+++ b/apps/scripts/usage-period-chaos/park-handler.mjs
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2025 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+/*
+ * Holds (or releases) the per-box usage lock so the ledger write for one box
+ * parks while its box row commits — the window a crashing API dies in. Uses the
+ * key UsageService itself waits on (`usage-period-<boxId>`), so nothing about
+ * the API's behaviour is faked.
+ *
+ *   node apps/scripts/usage-period-chaos/park-handler.mjs hold <boxId> [--ttl 600] [--port 26379]
+ *   node apps/scripts/usage-period-chaos/park-handler.mjs release <boxId>
+ */
+import Redis from 'ioredis'
+
+const [action, boxId] = process.argv.slice(2)
+const arg = (name, fallback) => {
+  const index = process.argv.indexOf(`--${name}`)
+  return index > -1 ? process.argv[index + 1] : fallback
+}
+
+if (!['hold', 'release'].includes(action) || !boxId) {
+  console.error('usage: park-handler.mjs <hold|release> <boxId> [--ttl 600] [--host 127.0.0.1] [--port 26379] [--db 0]')
+  process.exit(2)
+}
+
+const redis = new Redis({
+  host: arg('host', '127.0.0.1'),
+  port: Number(arg('port', 26379)),
+  db: Number(arg('db', 0)),
+})
+const key = `usage-period-${boxId}`
+
+try {
+  if (action === 'hold') {
+    const ttl = Number(arg('ttl', 600))
+    await redis.set(key, 'parked-by-chaos-runbook', 'EX', ttl)
+    console.log(`held ${key} for ${ttl}s — the usage handler for ${boxId} will block at its first await`)
+  } else {
+    await redis.del(key)
+    console.log(`released ${key}`)
+  }
+} finally {
+  await redis.quit()
+}

--- a/apps/scripts/usage-period-chaos/run.mjs
+++ b/apps/scripts/usage-period-chaos/run.mjs
@@ -1,0 +1,478 @@
+/*
+ * Failure-injection runner for the box usage-period ledger.
+ *
+ * Question it answers: can a box end up running with no usage period open, or
+ * finished with one still open, when the API dies between committing the box
+ * row and writing the ledger?
+ *
+ * How the window is opened (no production code is modified):
+ *  - Redis lock:   UsageService's first act is waitForLock(boxId). Holding that
+ *                  key parks the handler indefinitely while the box row is
+ *                  already committed — the exact post-commit/pre-ledger state.
+ *  - INSERT trigger: a BEFORE INSERT pg_sleep on box_usage_periods parks the
+ *                  handler *between* closing the old period and opening the
+ *                  new one, which is otherwise a sub-millisecond window.
+ * The kill is a real SIGKILL of a real process; the restart is a real boot.
+ */
+import { spawn } from 'node:child_process'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { randomUUID } from 'node:crypto'
+import { setTimeout as sleep } from 'node:timers/promises'
+import Redis from 'ioredis'
+import pg from 'pg'
+
+const HERE = path.dirname(fileURLToPath(import.meta.url))
+const API_DIR = path.resolve(HERE, '../../api')
+const WORKER = path.join(HERE, 'worker.ts')
+const TS_NODE = path.resolve(HERE, '../../node_modules/.bin/ts-node')
+
+const DB = {
+  host: process.env.CHAOS_DB_HOST || '127.0.0.1',
+  port: Number(process.env.CHAOS_DB_PORT || 55432),
+  user: process.env.CHAOS_DB_USER || 'postgres',
+  password: process.env.CHAOS_DB_PASSWORD || 'postgres',
+}
+const ADMIN_DB = process.env.CHAOS_ADMIN_DB || 'boxlite'
+const CHAOS_DB = 'boxlite_usage_chaos'
+const REDIS = {
+  host: process.env.CHAOS_REDIS_HOST || '127.0.0.1',
+  port: Number(process.env.CHAOS_REDIS_PORT || 6379),
+  db: Number(process.env.CHAOS_REDIS_DB || 14),
+}
+
+const workerEnv = {
+  ...process.env,
+  DB_HOST: String(DB.host),
+  DB_PORT: String(DB.port),
+  DB_USERNAME: DB.user,
+  DB_PASSWORD: DB.password,
+  DB_DATABASE: CHAOS_DB,
+  REDIS_HOST: String(REDIS.host),
+  REDIS_PORT: String(REDIS.port),
+  REDIS_DB: String(REDIS.db),
+}
+
+// ------------------------------------------------------------------ plumbing
+
+let sql
+let redis
+const q = (text, values) => sql.query(text, values).then((r) => r.rows)
+
+// A scenario that throws between start() and its signal() would otherwise leave
+// a ts-node child alive holding Postgres and Redis connections. Every live
+// worker is tracked so the top-level finally can reap it.
+const liveWorkers = new Set()
+
+class Worker {
+  constructor() {
+    this.seq = 0
+    this.pending = new Map()
+    this.events = []
+    this.logs = []
+    this.exited = null
+  }
+
+  async start() {
+    this.child = spawn(TS_NODE, ['-P', './tsconfig.json', '--transpile-only', WORKER], {
+      cwd: API_DIR,
+      env: workerEnv,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    })
+    this.child.stderr.on('data', (chunk) => this.logs.push(...String(chunk).split('\n').filter(Boolean)))
+    let buffer = ''
+    const ready = new Promise((resolve) => {
+      this.child.stdout.on('data', (chunk) => {
+        buffer += chunk
+        let index
+        while ((index = buffer.indexOf('\n')) >= 0) {
+          const line = buffer.slice(0, index).trim()
+          buffer = buffer.slice(index + 1)
+          if (!line.startsWith('{')) {
+            this.logs.push(line)
+            continue
+          }
+          const message = JSON.parse(line)
+          if (message.event === 'ready') resolve(message)
+          else if (message.event) this.events.push(message)
+          else this.pending.get(message.id)?.(message)
+        }
+      })
+    })
+    liveWorkers.add(this)
+    this.child.on('exit', (code, signal) => {
+      this.exited = { code, signal }
+      liveWorkers.delete(this)
+      for (const resolve of this.pending.values()) resolve({ ok: false, error: 'worker died' })
+      this.pending.clear()
+    })
+    // unref'd, or every worker ever started keeps the runner alive for two more
+    // minutes after the summary prints
+    const bootTimeout = new Promise((_resolve, reject) => {
+      setTimeout(() => reject(new Error('worker boot timeout')), 120_000).unref()
+    })
+    const info = await Promise.race([ready, bootTimeout])
+    this.pid = info.pid
+    return info
+  }
+
+  send(op, extra = {}) {
+    const id = ++this.seq
+    const reply = new Promise((resolve) => this.pending.set(id, resolve))
+    this.child.stdin.write(`${JSON.stringify({ id, op, ...extra })}\n`)
+    return reply
+  }
+
+  async call(op, extra = {}) {
+    const reply = await this.send(op, extra)
+    if (!reply.ok) throw new Error(`${op} failed: ${reply.error}`)
+    return reply
+  }
+
+  async signal(name, graceMs = 30_000) {
+    if (this.exited) return this.exited
+    this.child.kill(name)
+    const deadline = Date.now() + graceMs
+    while (!this.exited && Date.now() < deadline) await sleep(20)
+    if (!this.exited) {
+      this.child.kill('SIGKILL')
+      while (!this.exited) await sleep(20)
+    }
+    return this.exited
+  }
+}
+
+async function setupSchema() {
+  const admin = new pg.Client({ ...DB, database: ADMIN_DB })
+  await admin.connect()
+  await admin.query(`DROP DATABASE IF EXISTS "${CHAOS_DB}" WITH (FORCE)`)
+  await admin.query(`CREATE DATABASE "${CHAOS_DB}"`)
+  await admin.end()
+
+  await new Promise((resolve, reject) => {
+    const setup = spawn(TS_NODE, ['-P', './tsconfig.json', '--transpile-only', WORKER, '--setup'], {
+      cwd: API_DIR,
+      env: workerEnv,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    let out = ''
+    setup.stdout.on('data', (c) => (out += c))
+    setup.stderr.on('data', (c) => (out += c))
+    setup.on('exit', (code) =>
+      code === 0 && out.includes('setup-done') ? resolve() : reject(new Error(`setup failed: ${out}`)),
+    )
+  })
+}
+
+const lockKey = (boxId) => `usage-period-${boxId}`
+const holdLock = (boxId, ttl = 600) => redis.set(lockKey(boxId), 'chaos', 'EX', ttl)
+const releaseLock = (boxId) => redis.del(lockKey(boxId))
+
+/** Widens the gap between closing a period and opening the next one. */
+const delayInserts = (seconds) =>
+  q(`CREATE OR REPLACE FUNCTION chaos_delay_insert() RETURNS trigger AS $$
+       BEGIN PERFORM pg_sleep(${seconds}); RETURN NEW; END $$ LANGUAGE plpgsql`).then(() =>
+    q(`CREATE TRIGGER chaos_delay BEFORE INSERT ON box_usage_periods
+       FOR EACH ROW EXECUTE FUNCTION chaos_delay_insert()`),
+  )
+const stopDelayingInserts = () => q(`DROP TRIGGER IF EXISTS chaos_delay ON box_usage_periods`)
+
+const ledger = async (boxId) => {
+  const live = await q(`SELECT "startAt","endAt",cpu,gpu,mem,disk FROM box_usage_periods WHERE "boxId"=$1`, [boxId])
+  const archived = await q(
+    `SELECT "startAt","endAt",cpu,gpu,mem,disk FROM box_usage_periods_archive WHERE "boxId"=$1`,
+    [boxId],
+  )
+  return [...live, ...archived].sort((a, b) => a.startAt - b.startAt)
+}
+const openCount = async (boxId) =>
+  Number((await q(`SELECT count(*)::int n FROM box_usage_periods WHERE "boxId"=$1 AND "endAt" IS NULL`, [boxId]))[0].n)
+const boxState = async (boxId) => (await q(`SELECT state FROM box WHERE id=$1`, [boxId]))[0]?.state
+
+const results = []
+const report = (id, title, diverged, detail) => {
+  results.push({ id, title, diverged, detail })
+  console.log(`\n[${id}] ${title}\n     ${diverged ? '>>> DIVERGENCE' : '    consistent'}: ${detail}`)
+}
+
+const backdate = (boxId, hours = 25) =>
+  q(`UPDATE box_usage_periods SET "startAt" = now() - interval '${hours} hours' WHERE "boxId"=$1 AND "endAt" IS NULL`, [
+    boxId,
+  ])
+
+// ----------------------------------------------------------------- scenarios
+
+async function s1_killBeforeOpen() {
+  const worker = new Worker()
+  await worker.start()
+  const { boxId } = await worker.call('createBox', { organizationId: randomUUID() })
+
+  await holdLock(boxId) //                        park the handler at its first await
+  await worker.call('transition', { boxId, updateData: { state: 'started' } })
+  const stateAtKill = await boxState(boxId)
+  const openAtKill = await openCount(boxId)
+  await worker.signal('SIGKILL') //               API dies after the box row, before the ledger
+
+  await releaseLock(boxId)
+  const restarted = new Worker()
+  await restarted.start()
+  await restarted.call('cron', { name: 'rollover' })
+  await restarted.call('cron', { name: 'archive' })
+  const after = { state: await boxState(boxId), open: await openCount(boxId), rows: (await ledger(boxId)).length }
+  await restarted.signal('SIGTERM')
+
+  report(
+    'S1',
+    'box reaches STARTED, API SIGKILLed before the ledger write',
+    after.state === 'started' && after.rows === 0,
+    `at kill: box=${stateAtKill} open=${openAtKill}; after restart + both crons: box=${after.state}, ledger rows=${after.rows}, open=${after.open}`,
+  )
+  return boxId
+}
+
+async function s2_killBeforeClose() {
+  const worker = new Worker()
+  await worker.start()
+  const { boxId } = await worker.call('createBox', { organizationId: randomUUID() })
+  await worker.call('transition', { boxId, updateData: { state: 'started' } })
+  await worker.call('settle')
+
+  await holdLock(boxId)
+  await worker.call('transition', { boxId, updateData: { desiredState: 'destroyed', state: 'destroyed' } })
+  await worker.signal('SIGKILL')
+
+  await releaseLock(boxId)
+  const restarted = new Worker()
+  await restarted.start()
+  await restarted.call('cron', { name: 'rollover' })
+  const openAfterRestart = await openCount(boxId)
+
+  // ... and how long the over-billing lasts: the roll-over only looks at
+  // periods older than a day.
+  await backdate(boxId)
+  await restarted.call('cron', { name: 'rollover' })
+  const openAfterADay = await openCount(boxId)
+  await restarted.signal('SIGTERM')
+
+  report(
+    'S2',
+    'box reaches DESTROYED, API SIGKILLed before the period is closed',
+    openAfterRestart > 0,
+    `box=destroyed; open period after restart + roll-over: ${openAfterRestart}; after the period ages past 24h: ${openAfterADay} (so it self-heals, but only after up to a day of over-billing)`,
+  )
+}
+
+async function s3_killBetweenCloseAndOpen() {
+  const worker = new Worker()
+  await worker.start()
+  const { boxId } = await worker.call('createBox', { organizationId: randomUUID() })
+  await worker.call('transition', { boxId, updateData: { state: 'started' } })
+  await worker.call('settle')
+
+  await delayInserts(30) //                       park the handler inside the INSERT
+  worker.send('transition', { boxId, updateData: { desiredState: 'stopped', state: 'stopping' } })
+  // wait until the compute period is closed but the disk-only one is not in yet
+  const deadline = Date.now() + 30_000
+  let closedButNotReopened = false
+  while (Date.now() < deadline && !closedButNotReopened) {
+    const rows = await ledger(boxId)
+    closedButNotReopened = rows.length === 1 && rows[0].endAt !== null
+    if (!closedButNotReopened) await sleep(50)
+  }
+  await worker.signal('SIGKILL')
+  await stopDelayingInserts()
+
+  const restarted = new Worker()
+  await restarted.start()
+  await restarted.call('cron', { name: 'rollover' })
+  await restarted.call('cron', { name: 'archive' })
+  const rows = await ledger(boxId)
+  await restarted.signal('SIGTERM')
+
+  report(
+    'S3',
+    'box reaches STOPPING, API SIGKILLed between closing the compute period and opening the disk-only one',
+    closedButNotReopened && (await openCount(boxId)) === 0,
+    `caught mid-handler: ${closedButNotReopened}; after restart + both crons: ${rows.length} period(s), open=${await openCount(boxId)} — the stopped box's disk is billed to nobody`,
+  )
+}
+
+async function s4_gracefulRestart() {
+  const worker = new Worker()
+  await worker.start()
+  const { boxId } = await worker.call('createBox', { organizationId: randomUUID() })
+
+  await holdLock(boxId)
+  await worker.call('transition', { boxId, updateData: { state: 'started' } })
+  const openBeforeSigterm = await openCount(boxId)
+
+  const startedAt = Date.now()
+  worker.child.kill('SIGTERM')
+  await sleep(1500)
+  const stillAliveWhileBlocked = worker.exited === null
+  await releaseLock(boxId) //                     let the in-flight handler finish
+  while (!worker.exited && Date.now() - startedAt < 30_000) await sleep(20)
+  const drainMs = Date.now() - startedAt
+
+  const open = await openCount(boxId)
+  report(
+    'S4',
+    'same window, but a graceful SIGTERM instead of SIGKILL',
+    open === 0,
+    `open period before SIGTERM: ${openBeforeSigterm}; shutdown still blocked 1.5s later: ${stillAliveWhileBlocked}; drained in ${drainMs}ms; open period after exit: ${open}`,
+  )
+}
+
+async function s5_redisGone() {
+  const worker = new Worker()
+  await worker.start()
+  const { boxId } = await worker.call('createBox', { organizationId: randomUUID() })
+
+  await worker.call('killRedis')
+  const reply = await worker.send('transition', { boxId, updateData: { state: 'started' } })
+  await sleep(3000)
+  const open = await openCount(boxId)
+  const survived = worker.exited === null
+  const rejections = worker.events.filter((event) => event.event === 'unhandledRejection')
+  const alive = survived ? await worker.send('ping') : { ok: false }
+  // Did the handler fail, or is it still parked? A handler that never returns
+  // holds its activeJobs slot, which is what onApplicationShutdown waits on.
+  const stuck = survived ? (reply.inFlight ?? []).length > 0 : null
+  // @nestjs/event-emitter wraps every @OnEvent listener in a try/catch whose
+  // `suppressErrors` defaults to true, so a handler that throws is downgraded
+  // to a log line. Confirm that is where the failure went.
+  const swallowed = worker.logs.filter((line) => /Connection is closed|\[Event\]|ERROR/.test(line))
+  const settled = survived
+    ? await Promise.race([worker.send('settle'), sleep(8000).then(() => ({ ok: 'timeout' }))])
+    : {}
+  await worker.signal('SIGKILL')
+
+  report(
+    'S5',
+    'Redis unreachable when the state event fires',
+    open === 0,
+    `transition itself ${reply.ok ? 'succeeded' : 'failed'} (the box row commits either way); periods written: ${open}; ` +
+      `process survived: ${survived}; still serving other requests: ${alive.ok}; unhandled rejections: ${rejections.length}; ` +
+      `handler still holding a job slot at reply time: ${stuck}; drained within 8s: ${settled.ok === 'timeout' ? 'no' : 'yes'}; ` +
+      `error surfaced only as a log line (suppressErrors default): ${swallowed.length > 0}` +
+      (swallowed[0] ? ` -> ${swallowed[0].replace(/\s+/g, ' ').slice(0, 120)}` : ''),
+  )
+}
+
+async function s6_staleLock() {
+  const worker = new Worker()
+  await worker.start()
+  const { boxId } = await worker.call('createBox', { organizationId: randomUUID() })
+
+  await holdLock(boxId, 5) //                     a lock left behind by a process that died
+  const startedAt = Date.now()
+  await worker.call('transition', { boxId, updateData: { state: 'started' } })
+  await worker.call('settle')
+  const waitedMs = Date.now() - startedAt
+  const open = await openCount(boxId)
+  await worker.signal('SIGTERM')
+
+  report(
+    'S6',
+    'per-box lock left behind by a dead process (TTL 5s)',
+    open !== 1,
+    `ledger write landed after ${waitedMs}ms (blocked until the lock TTL expired); open periods: ${open}`,
+  )
+}
+
+// S4 shows the graceful drain protecting ONE in-flight handler. @TrackJobExecution
+// keys activeJobs by method name, not by invocation, so two concurrent
+// handleBoxStateUpdate calls share a single Set entry — and the first to finish
+// deletes it out from under the second.
+async function s7_concurrentDrain() {
+  const worker = new Worker()
+  await worker.start()
+  const parked = (await worker.call('createBox', { organizationId: randomUUID() })).boxId
+  const quick = (await worker.call('createBox', { organizationId: randomUUID() })).boxId
+
+  await holdLock(parked)
+  await worker.call('transition', { boxId: parked, updateData: { state: 'started' } })
+  // second invocation of the same handler, this one unobstructed
+  await worker.call('transition', { boxId: quick, updateData: { state: 'started' } })
+  // if activeJobs tracked invocations this would still report one in flight
+  const drainedWhileParked = (await worker.call('settle', {})) && true
+
+  const startedAt = Date.now()
+  await worker.signal('SIGTERM')
+  const shutdownMs = Date.now() - startedAt
+
+  await releaseLock(parked) //                     nothing left alive to act on it
+  await sleep(1000)
+  const parkedOpen = await openCount(parked)
+  const quickOpen = await openCount(quick)
+
+  report(
+    'S7',
+    'graceful SIGTERM while two handlers are in flight (activeJobs is keyed by method, not invocation)',
+    parkedOpen === 0,
+    `drain reported empty with a handler still parked: ${drainedWhileParked}; shutdown took ${shutdownMs}ms ` +
+      `(vs ~2000ms in S4, where it correctly waited); periods after exit — parked box: ${parkedOpen}, unobstructed box: ${quickOpen}`,
+  )
+}
+
+async function s8_reconciliationCoverage(strandedBoxId) {
+  const worker = new Worker()
+  await worker.start()
+  for (let i = 0; i < 3; i += 1) {
+    await worker.call('cron', { name: 'rollover' })
+    await worker.call('cron', { name: 'archive' })
+  }
+  const open = await openCount(strandedBoxId)
+  const rows = (await ledger(strandedBoxId)).length
+  const state = await boxState(strandedBoxId)
+  await worker.signal('SIGTERM')
+
+  report(
+    'S8',
+    'does anything ever repair the S1 box? (3 more rounds of both crons)',
+    rows === 0,
+    `box is still ${state} with ${rows} ledger row(s) and ${open} open period(s) — no sweep exists that opens a missing period, so this box runs free forever`,
+  )
+}
+
+// ---------------------------------------------------------------------- main
+
+async function main() {
+  await setupSchema()
+  sql = new pg.Client({ ...DB, database: CHAOS_DB })
+  await sql.connect()
+  redis = new Redis.default({ host: REDIS.host, port: REDIS.port, db: REDIS.db })
+
+  console.log(
+    `chaos database: ${CHAOS_DB} on ${DB.host}:${DB.port}; redis db ${REDIS.db} on ${REDIS.host}:${REDIS.port}`,
+  )
+
+  try {
+    const strandedBoxId = await s1_killBeforeOpen()
+    await s2_killBeforeClose()
+    await s3_killBetweenCloseAndOpen()
+    await s4_gracefulRestart()
+    await s5_redisGone()
+    await s6_staleLock()
+    await s7_concurrentDrain()
+    await s8_reconciliationCoverage(strandedBoxId)
+  } finally {
+    for (const worker of liveWorkers) {
+      worker.child.kill('SIGKILL')
+    }
+    await redis.flushdb().catch(() => {})
+    await redis.quit().catch(() => {})
+    await sql.end().catch(() => {})
+    const admin = new pg.Client({ ...DB, database: ADMIN_DB })
+    await admin.connect()
+    await admin.query(`DROP DATABASE IF EXISTS "${CHAOS_DB}" WITH (FORCE)`)
+    await admin.end()
+  }
+
+  const diverged = results.filter((r) => r.diverged)
+  console.log(`\n${'='.repeat(78)}`)
+  console.log(`${diverged.length} of ${results.length} scenarios end with a ledger that does not match reality:`)
+  for (const r of results) console.log(`  ${r.diverged ? 'DIVERGENCE' : 'consistent '}  ${r.id}  ${r.title}`)
+}
+
+await main()

--- a/apps/scripts/usage-period-chaos/worker.ts
+++ b/apps/scripts/usage-period-chaos/worker.ts
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2025 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+/*
+ * Chaos worker — a real, killable process holding the same object graph the API
+ * holds: EventEmitter2 -> BoxRepository -> UsageModule -> UsageService, over a
+ * real Postgres and Redis. run.mjs drives it over stdin and kills it mid-flight;
+ * nothing here simulates a crash, the process really dies.
+ *
+ * Protocol: one JSON command per stdin line, one JSON reply per stdout line.
+ */
+// Reaches into apps/api on purpose: the point of this harness is to hold the
+// API's own object graph in a process it can kill, so a published boundary
+// would defeat it. Dev tooling only — nothing here ships.
+/* eslint-disable @nx/enforce-module-boundaries */
+import { RedisModule, getRedisConnectionToken } from '@nestjs-modules/ioredis'
+import { EventEmitterModule } from '@nestjs/event-emitter'
+import { Test } from '@nestjs/testing'
+import { TypeOrmModule } from '@nestjs/typeorm'
+import type { Redis } from 'ioredis'
+import * as readline from 'readline'
+import { DataSource } from 'typeorm'
+import { BoxLastActivity } from '../../api/src/box/entities/box-last-activity.entity'
+import { Box } from '../../api/src/box/entities/box.entity'
+import { BoxDesiredState } from '../../api/src/box/enums/box-desired-state.enum'
+import { BoxState } from '../../api/src/box/enums/box-state.enum'
+import { BoxRepository } from '../../api/src/box/repositories/box.repository'
+import { CustomNamingStrategy } from '../../api/src/common/utils/naming-strategy.util'
+import { AddBoxUsagePeriods1785250000000 } from '../../api/src/migrations/pre-deploy/1785250000000-add-box-usage-periods-migration'
+import { BoxUsagePeriod } from '../../api/src/usage/entities/box-usage-period.entity'
+import { BoxUsagePeriodArchive } from '../../api/src/usage/entities/box-usage-period-archive.entity'
+import { UsageService } from '../../api/src/usage/services/usage.service'
+import { UsageModule } from '../../api/src/usage/usage.module'
+
+const connection = {
+  type: 'postgres' as const,
+  host: process.env.DB_HOST,
+  port: Number(process.env.DB_PORT),
+  username: process.env.DB_USERNAME,
+  password: process.env.DB_PASSWORD,
+  database: process.env.DB_DATABASE,
+  namingStrategy: new CustomNamingStrategy(),
+}
+
+const say = (payload: Record<string, unknown>) => process.stdout.write(`${JSON.stringify(payload)}\n`)
+
+// Surfaces what an unhandled rejection would otherwise do silently inside the
+// API: an event handler that throws has no owner to catch it.
+process.on('unhandledRejection', (reason) => {
+  say({ event: 'unhandledRejection', reason: String(reason) })
+})
+
+async function setup() {
+  const source = await new DataSource({
+    ...connection,
+    entities: [Box, BoxLastActivity],
+    synchronize: true,
+  }).initialize()
+  await source.query(`CREATE EXTENSION IF NOT EXISTS "uuid-ossp"`)
+  await source.query(`DROP TABLE IF EXISTS "box_usage_periods", "box_usage_periods_archive"`)
+  const runner = source.createQueryRunner()
+  try {
+    await new AddBoxUsagePeriods1785250000000().up(runner)
+  } finally {
+    await runner.release()
+    await source.destroy()
+  }
+  say({ event: 'setup-done' })
+}
+
+async function serve() {
+  const moduleRef = await Test.createTestingModule({
+    imports: [
+      EventEmitterModule.forRoot({ maxListeners: 100 }),
+      RedisModule.forRoot({
+        type: 'single',
+        options: {
+          host: process.env.REDIS_HOST,
+          port: Number(process.env.REDIS_PORT),
+          db: Number(process.env.REDIS_DB),
+          maxRetriesPerRequest: 2,
+        },
+      }),
+      TypeOrmModule.forRoot({
+        ...connection,
+        entities: [Box, BoxLastActivity, BoxUsagePeriod, BoxUsagePeriodArchive],
+        synchronize: false,
+      }),
+      UsageModule,
+    ],
+  }).compile()
+  await moduleRef.init()
+
+  // main.ts calls app.enableShutdownHooks(), so a real SIGTERM reaches
+  // UsageService.onApplicationShutdown and drains in-flight handlers. The same
+  // path is taken here, closed explicitly rather than through Nest's signal
+  // listener only because stdin holds this process's event loop open, so it
+  // would never actually exit afterwards.
+  let closing = false
+  process.on('SIGTERM', () => {
+    if (closing) {
+      return
+    }
+    closing = true
+    const startedAt = Date.now()
+    moduleRef
+      .close()
+      .then(() => {
+        say({ event: 'closed', drainMs: Date.now() - startedAt })
+        process.exit(0)
+      })
+      .catch((error) => {
+        say({ event: 'close-failed', error: String(error) })
+        process.exit(1)
+      })
+  })
+
+  const boxRepository = moduleRef.get(BoxRepository)
+  const usageService = moduleRef.get(UsageService)
+  const redis: Redis = moduleRef.get(getRedisConnectionToken())
+
+  const ops: Record<string, (cmd: any) => Promise<unknown>> = {
+    ping: async () => ({ pid: process.pid }),
+
+    createBox: async (cmd) => {
+      const box = new Box('us')
+      box.organizationId = cmd.organizationId
+      box.osUser = 'boxlite'
+      box.state = BoxState.CREATING
+      box.desiredState = BoxDesiredState.STARTED
+      box.cpu = cmd.cpu ?? 2
+      box.gpu = cmd.gpu ?? 1
+      box.mem = cmd.mem ?? 4
+      box.disk = cmd.disk ?? 10
+      box.autoPause = 0
+      box.autoDelete = 0
+      await boxRepository.insert(box)
+      return { boxId: box.id }
+    },
+
+    // Resolves as soon as BoxRepository.update() does — the box row is
+    // committed and the event emitted, but the usage handler may still be in
+    // flight. That is precisely the window run.mjs kills in.
+    transition: async (cmd) => {
+      await boxRepository.update(cmd.boxId, { updateData: cmd.updateData })
+      return { inFlight: [...usageService.activeJobs] }
+    },
+
+    settle: async () => {
+      const deadline = Date.now() + 30_000
+      while (usageService.activeJobs.size > 0) {
+        if (Date.now() > deadline) {
+          throw new Error('handlers did not settle in 30s')
+        }
+        await new Promise((resolve) => setTimeout(resolve, 10))
+      }
+      return {}
+    },
+
+    cron: async (cmd) => {
+      if (cmd.name === 'rollover') {
+        await usageService.closeAndReopenUsagePeriods()
+      } else if (cmd.name === 'archive') {
+        await usageService.archiveUsagePeriods()
+      } else {
+        throw new Error(`unknown cron ${cmd.name}`)
+      }
+      return {}
+    },
+
+    // Cuts this process off from Redis without touching the shared server, so
+    // other clients (the live API) keep working.
+    killRedis: async () => {
+      redis.disconnect()
+      return {}
+    },
+  }
+
+  readline.createInterface({ input: process.stdin }).on('line', (line) => {
+    if (!line.trim()) {
+      return
+    }
+    const cmd = JSON.parse(line)
+    Promise.resolve()
+      .then(() => ops[cmd.op](cmd))
+      .then((result) => say({ id: cmd.id, ok: true, ...(result as object) }))
+      .catch((error) => say({ id: cmd.id, ok: false, error: String(error?.message ?? error) }))
+  })
+
+  say({ event: 'ready', pid: process.pid })
+}
+
+const main = process.argv.includes('--setup') ? setup : serve
+main().catch((error) => {
+  say({ event: 'fatal', error: String(error?.stack ?? error) })
+  process.exit(1)
+})

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,10 @@
 
 - [E2E Local CI runbook](./ci/e2e-local.md) — VM-based integration tests on a self-hosted EC2 runner
 
+## Investigations
+
+- [Box usage-period ledger](./investigations/box-usage-period-ledger.md) — how the billing ledger drifts when the API dies between committing a box row and writing the period, and how to detect it
+
 ## Contributing
 
 ## Legal

--- a/docs/investigations/box-usage-period-ledger.md
+++ b/docs/investigations/box-usage-period-ledger.md
@@ -1,0 +1,218 @@
+# Box usage-period ledger: healthy-path verification and crash-path failure analysis
+
+**Date:** 2026-07-29
+**Status:** Verified; no fix implemented
+**Scope:** `apps/api/src/usage/` (`UsageService` + `box_usage_periods` / `box_usage_periods_archive`)
+
+---
+
+## Summary
+
+On the healthy path the ledger is correct: 29 lifecycle scenarios pass, and all 10 mutations of the production code are caught by them.
+
+On the crash path the ledger drifts away from reality, and **most of that drift never heals**. Six of eight failure-injection scenarios end with a ledger that disagrees with the box table:
+
+- **A box is running but nothing is billing it** — permanent revenue loss; no sweep detects or repairs it.
+- **A box is finished but its period is still open** — continued over-billing, closed at best by the daily roll-over up to 24h later.
+
+The root cause is one unprotected write window: the box row commits in a transaction that does not include the ledger write, and between them sits neither an outbox, nor a retry, nor a queue.
+
+---
+
+## 1. How the ledger is meant to work
+
+A box bills against at most one open period (`endAt IS NULL`) at a time, enforced by the Postgres partial unique index `box_usage_periods_one_open_period_per_box_idx`.
+
+The billing semantics are two event handlers and two cron jobs in `UsageService`:
+
+| Trigger                                           | Behaviour                                                                                                                                        |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `STARTED`                                         | Close the previous period, open a new one at the box's cpu/gpu/mem/disk                                                                          |
+| `STOPPING`                                        | Close the compute period, open a **disk-only** one (cpu/gpu/mem = 0)                                                                             |
+| `STOPPED` (having skipped `STOPPING`)             | Safeguard: if a period is still open with cpu ≠ 0, close it and reopen disk-only                                                                 |
+| `desiredState → DESTROYED`                        | Close immediately — billing stops when **deletion is requested**, not when the box is actually gone                                              |
+| `ERROR` / `ARCHIVED` / `DESTROYING` / `DESTROYED` | Close the period                                                                                                                                 |
+| `close-and-reopen-usage-periods` (every minute)   | Roll a period open longer than 24h; zero the compute if the box is already `STOPPED`; close without reopening if the box is destroyed or missing |
+| `archive-usage-periods` (every minute)            | Move closed periods to the archive table                                                                                                         |
+
+One asymmetry is deliberate and needs a pricing decision before anyone "fixes" it (`usage.service.ts:79-83` says so in a comment): **billing** stops charging compute the moment a stop is requested, while **quota** keeps counting `STOPPING` as compute, because the runner has not released cpu/memory yet.
+
+---
+
+## 2. Healthy-path verification
+
+`apps/api/src/usage/usage.lifecycle.integration.spec.ts`, 29 scenarios.
+
+How it differs from the two existing usage.service specs: the unit spec (`usage.service.spec.ts`) builds event objects itself and calls the handlers directly; the integration spec (`usage.service.integration.spec.ts`) stubs the box repository and calls the crons directly. Both verify function bodies. In this suite **every state transition goes through the production `BoxRepository.update()`**, whose own emit is the only thing that reaches the handlers, against the real `UsageModule` on a real Postgres and Redis. That closes the gap neither existing spec covers: whether a box changing state produces those events at all.
+
+Coverage:
+
+- **Lifecycle (15)** — start opens a period; a box that never starts bills nothing; stopping switches to disk-only; `STOPPING → STOPPED` adds no redundant row; the safeguard for `STOPPED` reached without `STOPPING`; restart resumes compute billing; **a resize bills at the new size**; a delete request stops billing; `DESTROYING → DESTROYED` neither reopens nor re-closes; a running box that errors gets closed; intermediate states (`STARTING`/`RESTORING`/`RESIZING`) leave the ledger alone; two boxes stay independent; a full lifecycle tiles end-to-end with no overlap and no gap.
+- **Daily roll-over (9)** — a running box is carried into a fresh period starting exactly where the old one ended; a stopped box has its compute zeroed; a stopping box keeps its disk; a destroyed box, or one whose row is gone, is closed without reopening; periods younger than a day are untouched; warm-pool periods are untouched; exactly one open period remains; a single run is capped at 100.
+- **Archive (3)** — closed periods move across with their billed fields intact; the open one stays; a second sweep is a no-op.
+- **Concurrency (2)** — a stop racing the roll-over still leaves one open period; the database refuses a second open period for the same box.
+
+**Do the tests have teeth?** Ten separate behaviour-breaking edits were applied to the production code one at a time, re-running the suite each time and restoring afterwards: drop the `STOPPING` branch; drop the `STOPPED` safeguard; move billing's stop back to `DESTROYED`; skip zeroing compute on roll-over; start the reopened period at `now()`; drop the warm-pool filter; lift the 100-row cap; reopen for a box that is gone; archive the open period too; delete the unique index. **All 10 were caught.**
+
+One mutation initially survived, which showed that the "zeroes compute for a stopped box" test was not exercising the branch it named — by the time the roll-over ran, its period was already disk-only. Rewriting it to use a raw update (which emits nothing) to produce a stopped box still carrying compute made the mutation fail the suite. That state is exactly what a crash leaves behind in the data.
+
+### Incidental observations
+
+- **The `ARCHIVED` branch is currently unreachable** — nothing in `apps/api/src` ever assigns `ARCHIVING`/`ARCHIVED`, so only the unit spec covers it.
+- **A box stuck in `STOPPING` is re-billed compute by the roll-over** — the roll-over zeroes compute only when the box is `STOPPED`, not `STOPPING`. A box wedged in `STOPPING` (a lost runner, say) whose open period still carries compute is **re-opened at full compute every day**. That contradicts the policy stated at `usage.service.ts:79-83`, and it is the same bug class #1083 hardened for `STOPPED`.
+- **One update that moves both `state` and `desiredState` serialises for ~500ms** — the two handlers contend on the same per-box Redis lock, and `waitForLock` polls on a fixed 500ms sleep (`usage.service.ts:257-261`). Latency only; correctness is unaffected.
+
+---
+
+## 3. The crash path: an unprotected write window
+
+### 3.1 Where the window is
+
+| Step                                                                           | Location                                                     |
+| ------------------------------------------------------------------------------ | ------------------------------------------------------------ |
+| Box row commits inside a transaction                                           | `apps/api/src/box/repositories/box.repository.ts:106-126`    |
+| Event emitted **outside** it (synchronous emit, but nobody awaits the handler) | `box.repository.ts:128`                                      |
+| Handler takes a Redis lock, **then** writes the ledger                         | `apps/api/src/usage/services/usage.service.ts:51,70,118-151` |
+
+So `update()` resolves — and the API answers the client — while the ledger write is still in flight. No outbox, no retry, no queue: the intent to bill exists only in that process's memory. Anything that kills the process inside that window loses the write silently.
+
+Two things make the consequences worse:
+
+- **Failure is invisible.** `@nestjs/event-emitter@3.1.0` wraps every `@OnEvent` listener in a try/catch whose `suppressErrors` defaults to `true` (`apps/node_modules/@nestjs/event-emitter/dist/event-subscribers.loader.js:106-118`). `UsageService`'s decorators pass no options, so a handler that throws is downgraded to a single `[Event]` log line: no crash, no alert, no retry.
+- **The only self-healing looks at periods that already exist.** `closeAndReopenUsagePeriods` selects periods whose `startAt` is older than 24 hours (`usage.service.ts:162-173`). Nothing anywhere looks for a period that is **missing**.
+
+### 3.2 Failure-injection results
+
+A real `SIGKILL` of a real process holding the same `UsageModule` / `BoxRepository` / `EventEmitter` graph the API holds, on a real Postgres and Redis. `apps/api` is not modified by any of it.
+
+|     | Scenario                                                                        | Outcome                                                                           |
+| --- | ------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| S1  | Box reaches `STARTED`, `SIGKILL` before the ledger write                        | **drift** — box runs, ledger empty, **permanent**                                 |
+| S2  | Box reaches `DESTROYED`, `SIGKILL` before the close                             | **drift** — period stays open until it ages past 24h                              |
+| S3  | Box reaches `STOPPING`, `SIGKILL` between closing compute and opening disk-only | **drift** — the stopped box's disk is billed to nobody, **permanent**             |
+| S4  | Same window, graceful `SIGTERM` (one handler in flight)                         | consistent — shutdown blocks until the write lands                                |
+| S5  | Redis unreachable when the event fires                                          | **drift** — the box row commits, the ledger write is lost as a log line           |
+| S6  | Per-box lock left behind by a dead process (TTL 5s)                             | consistent — the write lands ~5.0s late                                           |
+| S7  | Graceful `SIGTERM` with **two** handlers in flight                              | **drift** — the drain reports empty, exit in 21ms, the parked box is never billed |
+| S8  | Three more rounds of both crons over the S1 box                                 | **drift persists** — nothing reopens a missing period                             |
+
+S5 and S7 are the two findings about a _handler_ failing rather than the process dying, so they do not need a process kill to reproduce. Both are pinned deterministically in `apps/api/src/usage/usage.crash-recovery.integration.spec.ts`, alongside the four lost-transition shapes (START / STOP / DESTROY / resize) followed through an API restart, the roll-over, and the box's next real transition — 18 scenarios that run in CI without this harness.
+
+**These scenarios prove the window is reachable, not how often production lands in it.** S1/S2/S4/S6/S7 hold the window open by taking the per-box Redis lock the handler waits on; S3 uses a `BEFORE INSERT pg_sleep` trigger on `box_usage_periods`. Unaided, the window is as wide as one lock acquisition plus one INSERT. Read the results as "this happens and nothing notices", not as a frequency estimate.
+
+### 3.3 A graceful restart is not the safe path it looks like
+
+`main.ts:173` does call `app.enableShutdownHooks()`, and `UsageService.onApplicationShutdown` (`usage.service.ts:40-46`) does drain `activeJobs` first. But `@TrackJobExecution` keys that Set by **method name**, not by invocation (`apps/api/src/common/decorators/track-job-execution.decorator.ts:20-25`):
+
+```ts
+this.activeJobs.add(propertyKey) // ... finally: this.activeJobs.delete(propertyKey)
+```
+
+Two concurrent `handleBoxStateUpdate` calls therefore share a single entry, and whichever finishes first deletes it out from under the other. S7 measures the consequence: the drain returned in 21ms and the process exited with a handler still mid-write, so that box was never billed. In S4, with a single handler in flight, the same shutdown was still blocked 1.5s later and the period did land.
+
+**The regime, not the odds: once two handlers overlap, the drain guarantees nothing**, because `activeJobs` cannot tell one invocation from another. How often a restart lands on such an overlap depends on traffic and was not measured — S7 manufactures the overlap with a held lock.
+
+Note also that an unreachable Redis **loses** the write rather than wedging it: `RedisLockProvider.lock()` awaits `redis.set(...)`, which rejects on a closed connection, so the handler throws into the suppressed catch (measured in S5). The unbounded `while (activeJobs.size > 0)` drain only wedges on a lock that is _held_ with a long TTL, where `waitForLock` spins instead of failing.
+
+> **Staleness note.** This section assumes `track-job-execution.decorator.ts` still keys by method name. If recommendation #3 in section 5 (key by invocation) lands, this section's conclusion inverts — S7 becomes "consistent", and the assertion pinning the early drain in `usage.crash-recovery.integration.spec.ts` turns red by design. Update this section when you touch that decorator.
+
+---
+
+## 4. Scripts and procedures
+
+The tooling lives in two places, split by what it attacks:
+
+| Directory                          | Role                                                                                                                          |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `apps/infra-local/scripts/`        | End-to-end injection against the **real API** (`usage-crash-scenario.sh`) and live ledger auditing (`usage-ledger-audit.sql`) |
+| `apps/scripts/usage-period-chaos/` | Windows the real API cannot reach, on a **throwaway database** (`run.mjs` + `worker.ts`); see that directory's `README.md`    |
+
+They are complementary. The first kills the live process, which covers the commit-then-crash shape of S1/S2. The second can hold open S3 (between close and reopen), S5 (Redis unreachable), S6 (stale lock), S7 (concurrent drain) and S8 (reconciliation coverage) — each of which needs either a fault injected inside the process or a database it is free to dirty.
+
+### 4.1 Run the whole injection suite
+
+```bash
+cd apps && node scripts/usage-period-chaos/run.mjs
+```
+
+About 47 seconds. Creates and drops its own `boxlite_usage_chaos` database and uses Redis db 14, so it **touches nothing live**. Defaults to the Docker stack (Postgres `55432` / Redis `6379`); override with `CHAOS_DB_HOST/PORT/USER/PASSWORD`, `CHAOS_REDIS_HOST/PORT/DB`, `CHAOS_ADMIN_DB`. The infra-local Postgres (`25432`) works too, but it runs in a microVM and drops connections under this load.
+
+### 4.2 Reproduce S1 / S2 against the real API
+
+```bash
+# box is up but nothing started billing it
+apps/infra-local/scripts/usage-crash-scenario.sh lost-start <box-name-or-id>
+
+# box stopped but its period never closed
+apps/infra-local/scripts/usage-crash-scenario.sh lost-stop <box-name-or-id>
+```
+
+The script runs the whole sequence itself: take the `usage-period-<boxId>` lock so the handler parks → issue the real REST call → wait for the box row to commit the target state → `kill -9` the real API → **release the lock before restarting** (otherwise the restarted API blocks on it) → audit once after the restart and again after two full `sync-states` ticks. It also mints the API key it needs (`usage-crash-scenario.sh key` / `cleanup`).
+
+To drive the sequence by hand, `apps/scripts/usage-period-chaos/park-handler.mjs hold|release <boxId>` takes and releases that lock on its own.
+
+### 4.3 Auditing a live ledger
+
+`apps/infra-local/scripts/usage-ledger-audit.sql` is the reconciliation the API does not have: pure SQL, read-only, safe against production. Run it with an exit code via `usage-crash-scenario.sh audit`, which makes it usable as a cron check or a CI gate.
+
+Ten finding classes; severity comes from the first column of each `SELECT` in the SQL (1 → `HIGH`, 2 → `MED`). The table below restates the SQL and can drift from it, so a check guards it — run this after changing `usage-ledger-audit.sql`:
+
+```bash
+node apps/scripts/usage-period-chaos/check-audit-classes.mjs
+```
+
+| Severity | Group         | Finding               | Fires when                                                                                                       |
+| -------- | ------------- | --------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| HIGH     | under-billing | `MISSING_OPEN`        | Box is `started` (and not pending deletion) with no open period                                                  |
+| HIGH     | under-billing | `MISSING_OPEN_DISK`   | Box is `stopping`/`stopped` with no open period — its disk is billed to nobody                                   |
+| HIGH     | under-billing | `UNDERBILLED_COMPUTE` | Box is `started` but its open period bills `cpu=0`                                                               |
+| HIGH     | over-billing  | `STALE_OPEN`          | Box reached `error`/`archived`/`destroying`/`destroyed`, or `desiredState=destroyed`, and a period is still open |
+| HIGH     | over-billing  | `OVERBILLED_COMPUTE`  | Box is `stopping`/`stopped` but its open period still bills `cpu>0`                                              |
+| HIGH     | over-billing  | `ORPHAN_OPEN`         | A period is open but the box row is gone                                                                         |
+| HIGH     | structural    | `MULTI_OPEN`          | One box has several periods open at once — active double billing, hence graded with the billing classes          |
+| MED      | wrong amount  | `WRONG_SIZE`          | Box is `started` with compute billing, but the period's cpu or disk disagrees with the box — a lost resize       |
+| MED      | structural    | `OVERLAP`             | Two adjacent periods in the chain overlap (double billing)                                                       |
+| MED      | structural    | `GAP`                 | Two adjacent periods leave more than 2 seconds unbilled                                                          |
+
+Two points worth calling out:
+
+- `OVERBILLED_COMPUTE` covers the section 2 observation about a box stuck in `STOPPING` being re-billed compute by the roll-over. If that box has also been marked for deletion it falls to `STALE_OPEN` instead, so there is no hole between them.
+- `WRONG_SIZE` compares cpu and disk only — **not mem** (`usage-ledger-audit.sql:121-125`). A memory-only resize whose ledger write was lost is invisible to this audit.
+
+### 4.4 Measured against the local environment
+
+- **infra-local (25432)** — one HIGH `MISSING_OPEN_DISK`: `smoke0000001`, stopped with no open period, disk unbilled. It is **not** a crash artifact: `authToken='tok-smoke-1'` (not the shape of a `nanoid(32)`), `createdAt` exactly equal to `updatedAt`, and no `box_last_activity` row — which `BoxRepository.insert()` always writes. So it was inserted directly with SQL.
+- **Docker stack (55432)** — all ten classes clean (0 rows).
+
+In other words the local environment holds no genuine ledger drift today; that one hit shows the audit also catches hand-seeded rows.
+
+---
+
+## 5. Recommendations
+
+Cheapest first:
+
+1. **Put `usage-ledger-audit.sql` on a schedule.** By far the cheapest, and it converts silent revenue loss into an alert. It fixes nothing.
+2. **Set `suppressErrors: false`** on `UsageService`'s two `@OnEvent` decorators, so a failed ledger write is at least loud rather than one log line among many.
+3. **Make `activeJobs` track invocations rather than method names** (a counter, or a set of unique ids). A one-line change that turns every S7 back into an S4 — the difference between a rolling restart being safe and being safe only when the fleet happens to be idle. S7 is already the reproducer.
+4. **Grow the roll-over into a real reconciler.** It already walks open periods every minute with the box row in hand; what is missing is the other direction — billable boxes with no open period — plus dropping the 24h floor for boxes already in a terminal state.
+5. **Write the ledger in the box row's transaction, or via an outbox drained by the existing cron.** The only option that removes the window rather than narrowing it.
+
+The `STOPPING` roll-over problem from the end of section 2 lives in the same code as item 4 and is worth fixing in the same pass.
+
+---
+
+## Appendix: related files
+
+| File                                                            | Role                                                                                              |
+| --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `apps/api/src/usage/usage.lifecycle.integration.spec.ts`        | 29 healthy-path scenarios                                                                         |
+| `apps/api/src/usage/usage.crash-recovery.integration.spec.ts`   | 18 crash-path scenarios: the lost-transition shapes, plus S5 and S7 pinned deterministically      |
+| `apps/api/src/usage/services/usage.service.integration.spec.ts` | Existing cron + index-invariant specs                                                             |
+| `apps/api/src/usage/services/usage.service.spec.ts`             | Existing handler unit tests                                                                       |
+| `apps/scripts/usage-period-chaos/run.mjs`                       | 8 failure-injection scenarios (throwaway database)                                                |
+| `apps/scripts/usage-period-chaos/worker.ts`                     | The killable real Nest process carrying the real module graph                                     |
+| `apps/scripts/usage-period-chaos/park-handler.mjs`              | Take / release the per-box usage lock                                                             |
+| `apps/scripts/usage-period-chaos/check-audit-classes.mjs`       | Guards section 4.3's table against the SQL it restates                                            |
+| `apps/infra-local/scripts/usage-crash-scenario.sh`              | End-to-end injection against the real API (`lost-start` / `lost-stop`) plus the audit entry point |
+| `apps/infra-local/scripts/usage-ledger-audit.sql`               | Live ledger reconciliation (ten finding classes)                                                  |


### PR DESCRIPTION
## Summary

The box usage ledger is written by in-process event handlers with no outbox and no retry, so a box row and its usage period can disagree whenever the API dies between committing one and writing the other. Nothing currently detects that, and most of the resulting drift never heals. This adds verification for the healthy path and for that crash window, plus the reconciliation query the API lacks.

## Changes

- `usage.lifecycle.integration.spec.ts` — 29 scenarios driving every transition through the production `BoxRepository.update()`, so the handlers consume the events a real box produces rather than hand-built ones. Covers start / stop / restart / resize / delete, the daily roll-over, the archive sweep, and the one-open-period invariant.
- `usage.crash-recovery.integration.spec.ts` — 18 scenarios pinning the four lost-transition shapes (START / STOP / DESTROY / resize) through an API restart, the roll-over, and the box's next real transition, plus two handler-level failures: a lost write surfacing only as a log line, and the graceful-shutdown drain returning while a handler is still writing.
- `apps/scripts/usage-period-chaos/` — failure injection that kills a real process holding the real `UsageModule` graph, against a database it creates and drops itself.
- `apps/infra-local/scripts/` — the same faults injected into a running local stack on a real box, and `usage-ledger-audit.sql`: ten finding classes across both billing directions and the period chain, with an exit code so it can run as a cron check or a CI gate.
- `docs/investigations/box-usage-period-ledger.md` — where the window is, what each scenario measured, and the options for closing it.

## How to verify

Both specs need a Postgres and a Redis and create their own databases; they skip when `DB_HOST`, `DB_DATABASE` or `REDIS_HOST` are unset.

```bash
cd apps
DB_HOST=127.0.0.1 DB_PORT=5432 DB_USERNAME=postgres DB_PASSWORD=postgres \
DB_DATABASE=postgres REDIS_HOST=127.0.0.1 REDIS_PORT=6379 \
  npx jest --config api/jest.config.ts --rootDir api --testPathPatterns usage

node scripts/usage-period-chaos/run.mjs            # 8 injection scenarios
node scripts/usage-period-chaos/check-audit-classes.mjs
```

## Risks / rollout

No production code is touched — specs, tooling and docs only.

`usage.crash-recovery.integration.spec.ts` deliberately pins the shutdown drain's current behaviour. Landing the `activeJobs` change that the investigation recommends will turn that assertion red by design; the doc's staleness note flags it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive integration coverage for usage billing lifecycles, rollovers, archiving, concurrency, and crash-recovery/lost-transition scenarios.
* **New Tools**
  * Added local failure-injection and chaos scripts to reproduce interrupted usage-ledger behavior.
  * Added a read-only SQL audit report to detect under-/over-billing, missing/stale periods, structural inconsistencies, and drift.
* **Documentation**
  * Added an investigations guide and local playbook for reproducing, diagnosing, and auditing usage-ledger drift, with links from the docs index.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->