### PR TITLE
fix(gvproxy)!: apply allow_net to UDP egress

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -156,6 +156,14 @@ Structured network configuration for outbound connectivity.
 - `"enabled"` gives the guest outbound connectivity.
 - `"disabled"` removes the guest network interface entirely.
 - Empty or omitted `allow_net` means full outbound access.
+- A non-empty `allow_net` restricts both TCP and UDP egress. IP and CIDR rules
+  match the destination address and apply to both. Hostname rules are enforced
+  by inspecting TLS SNI / HTTP Host, which only TCP carries, so an `allow_net`
+  holding **only** hostnames denies all UDP egress — otherwise a guest could
+  sidestep the rule by addressing the resolved IP directly. QUIC/HTTP3 to such
+  a host falls back to TCP; add the IP or CIDR to keep UDP open.
+- The gateway's DNS resolver and DHCP are internal services and stay reachable
+  regardless of `allow_net`.
 - `host.boxlite.internal` is always available as a built-in hostname for
   reaching host loopback services and is not governed by `allow_net`.
 - Security: when networking is enabled, any service bound to host loopback can

--- a/docs/reference/rust/README.md
+++ b/docs/reference/rust/README.md
@@ -699,7 +699,7 @@ pub enum NetworkSpec {
 }
 ```
 
-`allow_net` supports exact hosts, wildcard hosts, IPs, and CIDRs. `Disabled` removes the guest network interface entirely.
+`allow_net` supports exact hosts, wildcard hosts, IPs, and CIDRs, and restricts both TCP and UDP egress. Hostname rules rely on TLS SNI / HTTP Host inspection, which only TCP carries, so an `allow_net` holding only hostnames denies all UDP egress — add the IP or CIDR to keep UDP open. `Disabled` removes the guest network interface entirely.
 
 ### Secret
 

--- a/sdks/c/include/boxlite.h
+++ b/sdks/c/include/boxlite.h
@@ -747,6 +747,13 @@ void boxlite_options_set_network_enabled(CBoxliteOptions *opts);
 
 void boxlite_options_set_network_disabled(CBoxliteOptions *opts);
 
+// Adds one entry to the outbound allowlist. Patterns: exact host,
+// "*.example.com", IP, or CIDR.
+//
+// A non-empty allowlist restricts both TCP and UDP egress. Hostname entries
+// are enforced by TLS SNI / HTTP Host inspection, which only TCP carries, so
+// an allowlist holding only hostnames denies all UDP egress — add the IP or
+// CIDR to keep UDP open.
 void boxlite_options_add_network_allow(CBoxliteOptions *opts, const char *host);
 
 void boxlite_options_add_secret(CBoxliteOptions *opts,

--- a/sdks/c/src/options.rs
+++ b/sdks/c/src/options.rs
@@ -117,6 +117,13 @@ pub unsafe extern "C" fn boxlite_options_set_network_disabled(opts: *mut CBoxlit
     options_set_network_disabled(opts)
 }
 
+/// Adds one entry to the outbound allowlist. Patterns: exact host,
+/// "*.example.com", IP, or CIDR.
+///
+/// A non-empty allowlist restricts both TCP and UDP egress. Hostname entries
+/// are enforced by TLS SNI / HTTP Host inspection, which only TCP carries, so
+/// an allowlist holding only hostnames denies all UDP egress — add the IP or
+/// CIDR to keep UDP open.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn boxlite_options_add_network_allow(
     opts: *mut CBoxliteOptions,

--- a/sdks/go/options.go
+++ b/sdks/go/options.go
@@ -69,6 +69,10 @@ const (
 	NetworkModeDisabled NetworkMode = "disabled"
 )
 
+// NetworkSpec configures guest networking. A non-empty AllowNet restricts
+// both TCP and UDP egress. Hostname entries are enforced by TLS SNI / HTTP
+// Host inspection, which only TCP carries, so a hostname-only AllowNet denies
+// all UDP egress — add the IP or CIDR to keep UDP open.
 type NetworkSpec struct {
 	Mode     NetworkMode
 	AllowNet []string

--- a/sdks/node/src/options.rs
+++ b/sdks/node/src/options.rs
@@ -325,7 +325,10 @@ pub struct JsNetworkSpec {
     /// Network mode: "enabled" or "disabled".
     pub mode: String,
 
-    /// Outbound allowlist when network is enabled.
+    /// Outbound allowlist when network is enabled. Restricts both TCP and UDP.
+    /// Hostname entries rely on TLS SNI / HTTP Host inspection, which only TCP
+    /// carries, so a hostname-only list denies all UDP egress — add the IP or
+    /// CIDR to keep UDP open.
     #[napi(js_name = "allowNet")]
     pub allow_net: Option<Vec<String>>,
 }

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -257,6 +257,11 @@ Configuration options for creating a box.
 - `mode: str` - `"enabled"` or `"disabled"`
 - `allow_net: List[str]` - Optional outbound allowlist when `mode="enabled"`
 
+`allow_net` restricts both TCP and UDP egress. Hostname entries are enforced by
+inspecting TLS SNI / HTTP Host, which only TCP carries, so an `allow_net`
+holding only hostnames denies all UDP egress — add the IP or CIDR to keep UDP
+open.
+
 `mode="disabled"` removes the guest network interface entirely.
 
 **Example:**

--- a/src/boxlite/src/runtime/options.rs
+++ b/src/boxlite/src/runtime/options.rs
@@ -718,6 +718,20 @@ impl From<&NetworkSpec> for NetworkConfig {
 /// - `"*.example.com"` — wildcard subdomain
 /// - `"192.168.1.1"` — exact IP
 /// - `"10.0.0.0/8"` — CIDR range
+///
+/// A non-empty `allow_net` restricts both TCP and UDP egress. The two
+/// transports enforce it differently:
+/// - IP and CIDR rules are matched against the destination address, so they
+///   apply to TCP and UDP alike.
+/// - Hostname rules are enforced by inspecting the TLS SNI or HTTP Host
+///   header, which only TCP carries. UDP has no equivalent, so an
+///   `allow_net` holding **only** hostnames denies all UDP egress —
+///   otherwise a guest could sidestep the rule by addressing the resolved IP
+///   directly. QUIC/HTTP3 to such a host falls back to TCP; add the IP or
+///   CIDR to `allow_net` to keep UDP open.
+///
+/// The gateway's DNS resolver and DHCP are unaffected: they are internal
+/// services, not egress.
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub enum NetworkSpec {
     /// Network enabled. Empty `allow_net` = full access.

--- a/src/boxlite/tests/network_spec.rs
+++ b/src/boxlite/tests/network_spec.rs
@@ -7,7 +7,7 @@ use boxlite::runtime::options::{BoxOptions, BoxliteOptions, NetworkSpec};
 use boxlite::{BoxCommand, BoxliteRuntime};
 use futures::StreamExt;
 use std::io::{Read, Write};
-use std::net::TcpListener;
+use std::net::{Ipv4Addr, SocketAddr, TcpListener, UdpSocket};
 use std::sync::mpsc;
 use std::thread;
 use std::time::{Duration, Instant};
@@ -174,6 +174,80 @@ async fn run_exit_code(litebox: &boxlite::LiteBox, cmd: &str, args: &[&str]) -> 
 
 fn wget_url_command(url: &str) -> String {
     format!("wget -O- --timeout=5 {url} 2>&1; printf '\\nEXIT:%s\\n' $?")
+}
+
+const UDP_PROBE_MARKER: &str = "boxlite-udp-allow-net-probe";
+const UDP_PROBE_EXIT_PREFIX: &str = "UDP_PROBE_EXIT:";
+
+/// The probe reports its own exit status, because `run_stdout` drops it. A
+/// missing or failing `nc` otherwise produces the same silence as a blocked
+/// datagram, letting the negative test pass without ever sending one.
+fn nc_udp_command(host: &str, port: u16) -> String {
+    format!(
+        "printf %s {UDP_PROBE_MARKER} | nc -u -w 2 {host} {port}; \
+         printf '\\n{UDP_PROBE_EXIT_PREFIX}%s\\n' $?"
+    )
+}
+
+/// BusyBox `nc -u -w` exits 0 once the wait elapses, whether or not anything
+/// answered, so a nonzero status means the probe never ran (127 = no `nc`).
+fn assert_udp_probe_ran(output: &str) {
+    assert!(
+        output.contains(&format!("{UDP_PROBE_EXIT_PREFIX}0")),
+        "UDP probe did not run in the guest: {output}"
+    );
+}
+
+/// Binds a loopback-or-wildcard UDP socket and hands the first datagram to the
+/// returned channel. The reader thread exits on the first packet or after
+/// `listen_for`, so callers waiting for "nothing arrives" still terminate.
+fn start_host_udp_receiver(
+    bind_addr: &str,
+    listen_for: Duration,
+) -> (u16, mpsc::Receiver<Vec<u8>>, thread::JoinHandle<()>) {
+    let socket = UdpSocket::bind(bind_addr).expect("bind host udp receiver");
+    let port = socket.local_addr().expect("host udp receiver addr").port();
+    socket
+        .set_read_timeout(Some(listen_for))
+        .expect("set host udp receiver timeout");
+
+    let (tx, rx) = mpsc::channel();
+    let handle = thread::spawn(move || {
+        let mut buf = [0_u8; 2048];
+        if let Ok((len, _)) = socket.recv_from(&mut buf) {
+            let _ = tx.send(buf[..len].to_vec());
+        }
+    });
+
+    (port, rx, handle)
+}
+
+/// The host's outward-facing IPv4, discovered without sending anything: a
+/// connected UDP socket only records the route the kernel would pick. Tests
+/// need an address that is reachable from gvproxy yet outside both allow_net
+/// and the always-allowed internal IPs, which the 192.168.127.0/24 aliases
+/// cannot provide.
+fn host_routable_ipv4() -> Option<Ipv4Addr> {
+    let socket = UdpSocket::bind("0.0.0.0:0").ok()?;
+    socket.connect("8.8.8.8:80").ok()?;
+    match socket.local_addr().ok()? {
+        SocketAddr::V4(addr) if !addr.ip().is_loopback() => Some(*addr.ip()),
+        _ => None,
+    }
+}
+
+const REQUIRE_EGRESS_ENV: &str = "BOXLITE_TEST_REQUIRE_EGRESS";
+
+/// Handles a host that cannot supply an egress precondition. Skipping keeps the
+/// suite usable on developer machines and in routeless sandboxes; a runner that
+/// is supposed to have egress sets `BOXLITE_TEST_REQUIRE_EGRESS=1` so the skip
+/// becomes a failure instead of a green test that exercised no allowlist at all.
+fn skip_missing_egress(test: &str, reason: &str) {
+    assert!(
+        std::env::var_os(REQUIRE_EGRESS_ENV).is_none(),
+        "{test}: {reason}; {REQUIRE_EGRESS_ENV} is set, so this host must provide egress"
+    );
+    eprintln!("SKIP {test}: {reason}");
 }
 
 fn start_host_http_server(response_body: &'static str) -> (u16, thread::JoinHandle<()>) {
@@ -372,6 +446,87 @@ async fn tcp_filter_blocks_direct_ip_connection() {
         "direct IP should be blocked by TCP filter, got: {out}"
     );
 
+    litebox.stop().await.unwrap();
+}
+
+/// The UDP twin of `tcp_filter_blocks_direct_ip_connection`. A hostname-only
+/// allowlist cannot be enforced for UDP by inspection, so datagrams to an
+/// address outside the allowlist must be dropped rather than forwarded.
+#[tokio::test]
+async fn udp_filter_blocks_direct_ip_datagram() {
+    let Some(host_ip) = host_routable_ipv4() else {
+        skip_missing_egress(
+            "udp_filter_blocks_direct_ip_datagram",
+            "no routable host IPv4 to use as an unlisted destination",
+        );
+        return;
+    };
+
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .unwrap();
+
+    let opts = BoxOptions {
+        network: NetworkSpec::Enabled {
+            allow_net: vec!["example.com".into()],
+        },
+        ..common::alpine_opts()
+    };
+
+    let litebox = runtime.create(opts, None).await.unwrap();
+    litebox.start().await.unwrap();
+
+    let (port, received, receiver) = start_host_udp_receiver("0.0.0.0:0", Duration::from_secs(8));
+    let command = nc_udp_command(&host_ip.to_string(), port);
+    let probe = run_stdout(&litebox, "sh", &["-c", &command]).await;
+    assert_udp_probe_ran(&probe);
+
+    let leaked = received.recv_timeout(Duration::from_secs(5));
+    assert!(
+        leaked.is_err(),
+        "UDP to unlisted {host_ip} escaped the allowlist: {:?}",
+        leaked.map(|bytes| String::from_utf8_lossy(&bytes).into_owned())
+    );
+
+    receiver.join().unwrap();
+    litebox.stop().await.unwrap();
+}
+
+/// The UDP twin of `host_alias_reaches_host_loopback_service_with_restrictive_allowlist`:
+/// tightening UDP must not cut the host alias, which is always allowed.
+#[tokio::test]
+async fn udp_reaches_host_alias_with_restrictive_allowlist() {
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .unwrap();
+
+    let opts = BoxOptions {
+        network: NetworkSpec::Enabled {
+            allow_net: vec!["example.com".into()],
+        },
+        ..common::alpine_opts()
+    };
+
+    let litebox = runtime.create(opts, None).await.unwrap();
+    litebox.start().await.unwrap();
+
+    // The host alias NATs to loopback, so bind where the datagram lands.
+    let (port, received, receiver) = start_host_udp_receiver("127.0.0.1:0", Duration::from_secs(8));
+    let command = nc_udp_command(HOST_IP, port);
+    let _ = run_stdout(&litebox, "sh", &["-c", &command]).await;
+
+    let payload = received
+        .recv_timeout(Duration::from_secs(5))
+        .expect("host alias UDP should still be delivered under a restrictive allowlist");
+    assert_eq!(String::from_utf8_lossy(&payload), UDP_PROBE_MARKER);
+
+    receiver.join().unwrap();
     litebox.stop().await.unwrap();
 }
 

--- a/src/cli/src/cli.rs
+++ b/src/cli/src/cli.rs
@@ -628,9 +628,12 @@ pub struct NetworkFlags {
     #[arg(long = "network", value_name = "MODE")]
     pub network: Option<String>,
 
-    /// Restrict egress to the listed hosts/IPs (repeatable); everything else
-    /// is DNS-sinkholed. Implies network=enabled. Patterns: exact host,
-    /// "*.example.com", IP, or CIDR. Incompatible with `--network disabled`.
+    /// Restrict TCP and UDP egress to the listed hosts/IPs (repeatable);
+    /// everything else is DNS-sinkholed and dropped. Implies network=enabled.
+    /// Patterns: exact host, "*.example.com", IP, or CIDR. Hostname rules need
+    /// TLS SNI / HTTP Host inspection, so a hostname-only list denies all UDP;
+    /// add the IP or CIDR to keep UDP open. Incompatible with `--network
+    /// disabled`.
     #[arg(long = "allow-net", value_name = "HOST")]
     pub allow_net: Vec<String>,
 }

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/allow_net_filter.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/allow_net_filter.go
@@ -1,10 +1,12 @@
 package main
 
-// tcp_filter.go — AllowNet matcher for TCP-level filtering.
+// allow_net_filter.go — AllowNet matcher shared by the TCP and UDP paths.
 //
 // Supports: exact IP, CIDR, exact hostname, wildcard hostname (*.example.com).
-// IP/CIDR rules are checked directly against destination IPs.
-// Hostname rules are checked via SNI/Host header inspection (see forked_tcp.go).
+// IP/CIDR rules are checked directly against destination IPs, so they apply to
+// both transports. Hostname rules need SNI/Host inspection (forked_tcp.go),
+// which only TCP can do — UDP therefore denies hostname-only allowlists
+// (forked_udp.go).
 
 import (
 	"net"
@@ -13,9 +15,9 @@ import (
 	logrus "github.com/sirupsen/logrus"
 )
 
-// TCPFilter checks outbound TCP connections against an allowlist.
+// AllowNetFilter checks outbound traffic against an allowlist.
 // nil filter means no filtering (all traffic allowed).
-type TCPFilter struct {
+type AllowNetFilter struct {
 	exactIPs         map[[4]byte]bool
 	cidrs            []*net.IPNet
 	alwaysAllow      map[[4]byte]bool // internal IPs that should never be filtered
@@ -24,14 +26,14 @@ type TCPFilter struct {
 	hasHostnameRules bool
 }
 
-// NewTCPFilter parses allow_net rules into IP/CIDR and hostname categories.
+// NewAllowNetFilter parses allow_net rules into IP/CIDR and hostname categories.
 // Returns nil if rules is empty (zero overhead fast path).
-func NewTCPFilter(rules []string, internalIPs ...string) *TCPFilter {
+func NewAllowNetFilter(rules []string, internalIPs ...string) *AllowNetFilter {
 	if len(rules) == 0 {
 		return nil
 	}
 
-	f := &TCPFilter{
+	f := &AllowNetFilter{
 		exactIPs:    make(map[[4]byte]bool),
 		alwaysAllow: make(map[[4]byte]bool),
 		exactHosts:  make(map[string]bool),
@@ -59,7 +61,7 @@ func NewTCPFilter(rules []string, internalIPs ...string) *TCPFilter {
 		if ip := net.ParseIP(rule); ip != nil {
 			if ip4 := ip.To4(); ip4 != nil {
 				f.exactIPs[toIPv4Key(ip4)] = true
-				logrus.WithField("ip", rule).Debug("allowNet TCP: added exact IP")
+				logrus.WithField("ip", rule).Debug("allowNet: added exact IP")
 			}
 			continue
 		}
@@ -67,7 +69,7 @@ func NewTCPFilter(rules []string, internalIPs ...string) *TCPFilter {
 		// CIDR: "10.0.0.0/8"
 		if _, cidr, err := net.ParseCIDR(rule); err == nil {
 			f.cidrs = append(f.cidrs, cidr)
-			logrus.WithField("cidr", rule).Debug("allowNet TCP: added CIDR")
+			logrus.WithField("cidr", rule).Debug("allowNet: added CIDR")
 			continue
 		}
 
@@ -82,14 +84,14 @@ func NewTCPFilter(rules []string, internalIPs ...string) *TCPFilter {
 			suffix := strings.ToLower(host[1:]) // ".example.com"
 			f.wildcardSuffixes = append(f.wildcardSuffixes, suffix)
 			f.hasHostnameRules = true
-			logrus.WithField("wildcard", host).Debug("allowNet TCP: added wildcard")
+			logrus.WithField("wildcard", host).Debug("allowNet: added wildcard")
 			continue
 		}
 
 		// Exact hostname
 		f.exactHosts[strings.ToLower(host)] = true
 		f.hasHostnameRules = true
-		logrus.WithField("hostname", host).Debug("allowNet TCP: added hostname")
+		logrus.WithField("hostname", host).Debug("allowNet: added hostname")
 	}
 
 	logrus.WithFields(logrus.Fields{
@@ -97,13 +99,13 @@ func NewTCPFilter(rules []string, internalIPs ...string) *TCPFilter {
 		"cidrs":     len(f.cidrs),
 		"hostnames": len(f.exactHosts),
 		"wildcards": len(f.wildcardSuffixes),
-	}).Info("allowNet TCP: filter initialized")
+	}).Info("allowNet: filter initialized")
 
 	return f
 }
 
 // MatchesIP checks if destIP is allowed by IP/CIDR rules or always-allow.
-func (f *TCPFilter) MatchesIP(destIP net.IP) bool {
+func (f *AllowNetFilter) MatchesIP(destIP net.IP) bool {
 	ip4 := destIP.To4()
 	if ip4 == nil {
 		return false
@@ -124,7 +126,7 @@ func (f *TCPFilter) MatchesIP(destIP net.IP) bool {
 }
 
 // MatchesHostname checks if hostname is allowed by hostname rules.
-func (f *TCPFilter) MatchesHostname(hostname string) bool {
+func (f *AllowNetFilter) MatchesHostname(hostname string) bool {
 	hostname = strings.ToLower(strings.TrimSuffix(hostname, "."))
 	if hostname == "" {
 		return false
@@ -141,7 +143,7 @@ func (f *TCPFilter) MatchesHostname(hostname string) bool {
 }
 
 // HasHostnameRules returns true if any hostname/wildcard rules exist.
-func (f *TCPFilter) HasHostnameRules() bool {
+func (f *AllowNetFilter) HasHostnameRules() bool {
 	return f.hasHostnameRules
 }
 

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/allow_net_filter_test.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/allow_net_filter_test.go
@@ -8,36 +8,36 @@ import (
 	"gvisor.dev/gvisor/pkg/tcpip"
 )
 
-func TestTCPFilter_ExactIP(t *testing.T) {
-	f := NewTCPFilter([]string{"1.2.3.4", "5.6.7.8"}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
+func TestAllowNetFilter_ExactIP(t *testing.T) {
+	f := NewAllowNetFilter([]string{"1.2.3.4", "5.6.7.8"}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
 	assertTrue(t, f.MatchesIP(net.ParseIP("1.2.3.4")), "1.2.3.4 allowed")
 	assertTrue(t, f.MatchesIP(net.ParseIP("5.6.7.8")), "5.6.7.8 allowed")
 	assertFalse(t, f.MatchesIP(net.ParseIP("9.9.9.9")), "9.9.9.9 blocked")
 }
 
-func TestTCPFilter_CIDR(t *testing.T) {
-	f := NewTCPFilter([]string{"10.0.0.0/8"}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
+func TestAllowNetFilter_CIDR(t *testing.T) {
+	f := NewAllowNetFilter([]string{"10.0.0.0/8"}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
 	assertTrue(t, f.MatchesIP(net.ParseIP("10.1.2.3")), "in range")
 	assertTrue(t, f.MatchesIP(net.ParseIP("10.255.255.255")), "end of range")
 	assertFalse(t, f.MatchesIP(net.ParseIP("11.0.0.1")), "out of range")
 }
 
-func TestTCPFilter_InternalIPsAlwaysAllowed(t *testing.T) {
-	f := NewTCPFilter([]string{"1.2.3.4"}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
+func TestAllowNetFilter_InternalIPsAlwaysAllowed(t *testing.T) {
+	f := NewAllowNetFilter([]string{"1.2.3.4"}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
 	assertTrue(t, f.MatchesIP(net.ParseIP("192.168.127.1")), "gateway always allowed")
 	assertTrue(t, f.MatchesIP(net.ParseIP("192.168.127.2")), "guest always allowed")
 	assertTrue(t, f.MatchesIP(net.ParseIP("192.168.127.254")), "host alias IP always allowed")
 }
 
-func TestTCPFilter_NilWhenEmpty(t *testing.T) {
-	f := NewTCPFilter([]string{}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
+func TestAllowNetFilter_NilWhenEmpty(t *testing.T) {
+	f := NewAllowNetFilter([]string{}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
 	if f != nil {
 		t.Error("empty rules should return nil filter")
 	}
 }
 
-func TestTCPFilter_ExactHostname(t *testing.T) {
-	f := NewTCPFilter([]string{"api.openai.com"}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
+func TestAllowNetFilter_ExactHostname(t *testing.T) {
+	f := NewAllowNetFilter([]string{"api.openai.com"}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
 	assertTrue(t, f.MatchesHostname("api.openai.com"), "exact match")
 	assertTrue(t, f.MatchesHostname("API.OPENAI.COM"), "case insensitive")
 	assertFalse(t, f.MatchesHostname("evil.com"), "not in list")
@@ -45,21 +45,21 @@ func TestTCPFilter_ExactHostname(t *testing.T) {
 	assertTrue(t, f.HasHostnameRules(), "should have hostname rules")
 }
 
-func TestTCPFilter_Wildcard(t *testing.T) {
-	f := NewTCPFilter([]string{"*.example.com"}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
+func TestAllowNetFilter_Wildcard(t *testing.T) {
+	f := NewAllowNetFilter([]string{"*.example.com"}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
 	assertTrue(t, f.MatchesHostname("api.example.com"), "subdomain matched")
 	assertTrue(t, f.MatchesHostname("deep.sub.example.com"), "deep subdomain matched")
 	assertFalse(t, f.MatchesHostname("example.com"), "base domain not matched by wildcard")
 	assertFalse(t, f.MatchesHostname("notexample.com"), "different domain not matched")
 }
 
-func TestTCPFilter_IPOnlyNoHostnameRules(t *testing.T) {
-	f := NewTCPFilter([]string{"1.2.3.4", "10.0.0.0/8"}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
+func TestAllowNetFilter_IPOnlyNoHostnameRules(t *testing.T) {
+	f := NewAllowNetFilter([]string{"1.2.3.4", "10.0.0.0/8"}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
 	assertFalse(t, f.HasHostnameRules(), "IP-only rules have no hostname rules")
 }
 
-func TestTCPFilter_MixedRules(t *testing.T) {
-	f := NewTCPFilter([]string{
+func TestAllowNetFilter_MixedRules(t *testing.T) {
+	f := NewAllowNetFilter([]string{
 		"1.2.3.4",
 		"10.0.0.0/8",
 		"api.openai.com",
@@ -72,24 +72,24 @@ func TestTCPFilter_MixedRules(t *testing.T) {
 	assertTrue(t, f.HasHostnameRules(), "has hostname rules")
 }
 
-func TestTCPFilter_TrailingDotStripped(t *testing.T) {
-	f := NewTCPFilter([]string{"api.openai.com"}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
+func TestAllowNetFilter_TrailingDotStripped(t *testing.T) {
+	f := NewAllowNetFilter([]string{"api.openai.com"}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
 	assertTrue(t, f.MatchesHostname("api.openai.com."), "trailing dot stripped")
 }
 
-func TestTCPFilter_HostWithPort(t *testing.T) {
-	f := NewTCPFilter([]string{"api.openai.com:443"}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
+func TestAllowNetFilter_HostWithPort(t *testing.T) {
+	f := NewAllowNetFilter([]string{"api.openai.com:443"}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
 	assertTrue(t, f.MatchesHostname("api.openai.com"), "port stripped from rule")
 	assertTrue(t, f.HasHostnameRules(), "should have hostname rules")
 }
 
-func TestTCPFilter_EmptyHostname(t *testing.T) {
-	f := NewTCPFilter([]string{"api.openai.com"}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
+func TestAllowNetFilter_EmptyHostname(t *testing.T) {
+	f := NewAllowNetFilter([]string{"api.openai.com"}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
 	assertFalse(t, f.MatchesHostname(""), "empty hostname never matches")
 }
 
 func TestDecideTCPRoute_CIDRUsesStandardForward(t *testing.T) {
-	f := NewTCPFilter([]string{"104.18.26.0/24"}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
+	f := NewAllowNetFilter([]string{"104.18.26.0/24"}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
 
 	inRange := net.IP([]byte{104, 18, 26, 120})
 	if got := decideTCPRoute(inRange, 80, f, nil); got != tcpRouteStandardForward {
@@ -103,7 +103,7 @@ func TestDecideTCPRoute_CIDRUsesStandardForward(t *testing.T) {
 }
 
 func TestResolveTCPDestination_HostAliasUsesPreNATIPForPolicy(t *testing.T) {
-	filter := NewTCPFilter([]string{"example.com"}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
+	filter := NewAllowNetFilter([]string{"example.com"}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
 	hostAlias := tcpip.AddrFrom4Slice(net.ParseIP("192.168.127.254").To4())
 	loopback := tcpip.AddrFrom4Slice(net.ParseIP("127.0.0.1").To4())
 	nat := map[tcpip.Address]tcpip.Address{

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/forked_network.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/forked_network.go
@@ -30,7 +30,7 @@ func OverrideTCPHandler(
 	vn *virtualnetwork.VirtualNetwork,
 	config *types.Configuration,
 	ec2MetadataAccess bool,
-	filter *TCPFilter,
+	filter *AllowNetFilter,
 	ca *BoxCA,
 	secretMatcher *SecretHostMatcher,
 ) error {

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/forked_network.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/forked_network.go
@@ -1,9 +1,12 @@
 package main
 
-// forked_network.go — Override gvproxy's TCP handler after creation.
+// forked_network.go — Install BoxLite's filtered transport handlers on an
+// existing VirtualNetwork.
 //
-// After virtualnetwork.New() creates the network stack with the default
-// TCP forwarder, we replace it with our filtered version.
+// virtualnetwork.New() registers upstream's unfiltered TCP and UDP forwarders
+// (gvisor-tap-vsock services.go:27-30). installAllowNetHandlers replaces both
+// from one place, so a transport cannot be quietly left on the unfiltered
+// default — that gap is what made allow_net a TCP-only control.
 //
 // stack.SetTransportProtocolHandler() is a public gVisor API.
 // The only use of reflect+unsafe is to access VirtualNetwork's private
@@ -22,11 +25,15 @@ import (
 	"gvisor.dev/gvisor/pkg/tcpip"
 	"gvisor.dev/gvisor/pkg/tcpip/stack"
 	"gvisor.dev/gvisor/pkg/tcpip/transport/tcp"
+	"gvisor.dev/gvisor/pkg/tcpip/transport/udp"
 )
 
-// OverrideTCPHandler replaces the default TCP protocol handler on an
-// existing VirtualNetwork with our filtered version.
-func OverrideTCPHandler(
+// installAllowNetHandlers replaces the default TCP and UDP protocol handlers
+// with BoxLite's filtered versions.
+//
+// A returned error must be fatal to box creation: the handlers left in place
+// are upstream's, which forward every destination.
+func installAllowNetHandlers(
 	vn *virtualnetwork.VirtualNetwork,
 	config *types.Configuration,
 	ec2MetadataAccess bool,
@@ -34,28 +41,46 @@ func OverrideTCPHandler(
 	ca *BoxCA,
 	secretMatcher *SecretHostMatcher,
 ) error {
-	// Access private stack field via reflect
+	s, err := stackOf(vn)
+	if err != nil {
+		return err
+	}
+
+	// One NAT table and one lock shared by both transports, matching
+	// upstream's addServices (services.go:23-30).
+	nat := natTable(config)
+	var natLock sync.Mutex
+
+	tcpFwd := TCPWithFilter(s, nat, &natLock, ec2MetadataAccess, filter, ca, secretMatcher)
+	s.SetTransportProtocolHandler(tcp.ProtocolNumber, tcpFwd.HandlePacket)
+	logrus.Info("allowNet TCP: handler overridden with SNI-inspecting forwarder")
+
+	s.SetTransportProtocolHandler(udp.ProtocolNumber, UDPWithFilter(s, nat, &natLock, filter))
+	logrus.Info("allowNet UDP: handler overridden with allowlist-checking forwarder")
+
+	return nil
+}
+
+// stackOf reaches VirtualNetwork's unexported gVisor stack, the only handle
+// that allows replacing transport handlers after construction.
+func stackOf(vn *virtualnetwork.VirtualNetwork) (*stack.Stack, error) {
 	v := reflect.ValueOf(vn).Elem()
 	stackField := v.FieldByName("stack")
 	if !stackField.IsValid() {
-		return fmt.Errorf("VirtualNetwork has no 'stack' field (gvisor-tap-vsock API changed?)")
+		return nil, fmt.Errorf("VirtualNetwork has no 'stack' field (gvisor-tap-vsock API changed?)")
 	}
 
-	// #nosec G103 — accessing private field to override TCP handler
-	s := (*stack.Stack)(unsafe.Pointer(stackField.Pointer()))
+	// #nosec G103 — accessing private field to override transport handlers
+	return (*stack.Stack)(unsafe.Pointer(stackField.Pointer())), nil
+}
 
-	// Rebuild NAT table (same logic as upstream parseNATTable in services.go)
+// natTable rebuilds gvproxy's address translation map (same logic as upstream
+// parseNATTable in services.go).
+func natTable(config *types.Configuration) map[tcpip.Address]tcpip.Address {
 	nat := make(map[tcpip.Address]tcpip.Address)
 	for source, destination := range config.NAT {
 		nat[tcpip.AddrFrom4Slice(net.ParseIP(source).To4())] =
 			tcpip.AddrFrom4Slice(net.ParseIP(destination).To4())
 	}
-
-	// Replace TCP handler with our filtered version
-	var natLock sync.Mutex
-	tcpFwd := TCPWithFilter(s, nat, &natLock, ec2MetadataAccess, filter, ca, secretMatcher)
-	s.SetTransportProtocolHandler(tcp.ProtocolNumber, tcpFwd.HandlePacket)
-
-	logrus.Info("allowNet TCP: handler overridden with SNI-inspecting forwarder")
-	return nil
+	return nat
 }

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/forked_network_test.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/forked_network_test.go
@@ -10,7 +10,7 @@ import (
 
 // TestStackFieldExists validates that VirtualNetwork has a "stack" field.
 // If gvisor-tap-vsock renames or removes this field, this test fails fast
-// instead of a silent runtime panic in OverrideTCPHandler.
+// instead of a silent runtime panic in installAllowNetHandlers.
 func TestStackFieldExists(t *testing.T) {
 	config := &types.Configuration{
 		Subnet:            "192.168.127.0/24",

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/forked_tcp.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/forked_tcp.go
@@ -55,7 +55,7 @@ func init() {
 	}
 }
 
-func decideTCPRoute(destIP net.IP, destPort uint16, filter *TCPFilter, secretMatcher *SecretHostMatcher) tcpRoute {
+func decideTCPRoute(destIP net.IP, destPort uint16, filter *AllowNetFilter, secretMatcher *SecretHostMatcher) tcpRoute {
 	if filter == nil {
 		if secretMatcher != nil && destPort == 443 {
 			return tcpRouteInspect
@@ -96,7 +96,7 @@ func resolveTCPDestination(localAddress tcpip.Address, nat map[tcpip.Address]tcp
 }
 
 func TCPWithFilter(s *stack.Stack, nat map[tcpip.Address]tcpip.Address,
-	natLock *sync.Mutex, ec2MetadataAccess bool, filter *TCPFilter,
+	natLock *sync.Mutex, ec2MetadataAccess bool, filter *AllowNetFilter,
 	ca *BoxCA, secretMatcher *SecretHostMatcher) *tcp.Forwarder {
 
 	return tcp.NewForwarder(s, 0, 10, func(r *tcp.ForwarderRequest) {
@@ -164,7 +164,7 @@ func standardForward(r *tcp.ForwarderRequest, destAddr string) {
 // inspectAndForward: Accept → Peek SNI/Host → check allowlist → Dial → relay.
 // The flow is reversed from upstream because we need to read from the guest
 // before deciding whether to connect to the upstream server.
-func inspectAndForward(r *tcp.ForwarderRequest, destAddr string, destPort uint16, filter *TCPFilter, ca *BoxCA, secretMatcher *SecretHostMatcher) {
+func inspectAndForward(r *tcp.ForwarderRequest, destAddr string, destPort uint16, filter *AllowNetFilter, ca *BoxCA, secretMatcher *SecretHostMatcher) {
 	// Step 1: Accept TCP from guest first (reversed from upstream)
 	var wq waiter.Queue
 	ep, tcpErr := r.CreateEndpoint(&wq)

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/forked_tcp_test.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/forked_tcp_test.go
@@ -133,7 +133,7 @@ func TestMitmRouting_AllowlistAndSecrets_MitmPriority(t *testing.T) {
 	matcher := NewSecretHostMatcher(secrets)
 
 	// Also create an allowlist filter that includes the same host
-	filter := NewTCPFilter([]string{"api.example.com"}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
+	filter := NewAllowNetFilter([]string{"api.example.com"}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
 
 	// Both should match
 	if !matcher.Matches("api.example.com") {

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/forked_udp.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/forked_udp.go
@@ -1,0 +1,125 @@
+package main
+
+// forked_udp.go — UDP forwarding gated by the allow_net allowlist.
+//
+// Unlike the TCP path, this is not a fork of upstream's forwarder. The policy
+// check runs at the protocol-handler level, before upstream's forwarder
+// creates an endpoint, and allowed datagrams are handed to that forwarder
+// untouched — same shape as Tailscale's wrapUDPProtocolHandler.
+//
+// Traffic that never reaches here: the gateway DNS resolver (bound to
+// GatewayIP:53, services.go:62) and DHCP (bound to :67, dhcp.go:93) are
+// registered endpoints, and gVisor's demuxer matches those before falling
+// back to this default handler (gvisor stack/nic.go:863-871). Internal
+// services therefore need no allowlist exemption.
+
+import (
+	"net"
+	"sync"
+
+	"github.com/containers/gvisor-tap-vsock/pkg/services/forwarder"
+	logrus "github.com/sirupsen/logrus"
+	"gvisor.dev/gvisor/pkg/tcpip"
+	"gvisor.dev/gvisor/pkg/tcpip/header"
+	"gvisor.dev/gvisor/pkg/tcpip/stack"
+)
+
+// UDPWithFilter returns a UDP protocol handler that drops datagrams whose
+// destination is outside the allowlist and forwards the rest through
+// upstream's forwarder. A nil filter forwards everything.
+func UDPWithFilter(s *stack.Stack, nat map[tcpip.Address]tcpip.Address,
+	natLock *sync.Mutex, filter *AllowNetFilter) func(stack.TransportEndpointID, *stack.PacketBuffer) bool {
+
+	upstream := forwarder.UDP(s, nat, natLock)
+	if filter == nil {
+		return upstream.HandlePacket
+	}
+
+	blocked := newBlockedDestinationLog()
+	return func(id stack.TransportEndpointID, pkt *stack.PacketBuffer) bool {
+		// Policy sees the pre-NAT destination, matching the TCP path
+		// (resolveTCPDestination, forked_tcp.go:83). Upstream applies NAT
+		// itself once the datagram is allowed through.
+		if !udpDestinationAllowed(id.LocalAddress, filter) {
+			blocked.note(id.LocalAddress, id.LocalPort)
+			// Consumed: a silent drop. Returning false would make gVisor
+			// emit ICMP port-unreachable, handing the guest a probe oracle.
+			return true
+		}
+		return upstream.HandlePacket(id, pkt)
+	}
+}
+
+// udpDestinationAllowed applies the same link-local and broadcast guards as
+// upstream (forwarder/udp.go:21) and then the allowlist.
+//
+// Hostname rules cannot be evaluated here — UDP carries no SNI or Host header
+// to peek at — so an allowlist holding only hostnames denies all UDP egress.
+// A guest must not be able to sidestep a hostname rule by addressing the
+// resolved IP directly.
+func udpDestinationAllowed(dest tcpip.Address, filter *AllowNetFilter) bool {
+	// Link-local stays denied even when ec2MetadataAccess is on: IMDS speaks
+	// HTTP over TCP, so opening UDP to 169.254.0.0/16 would only add egress.
+	if linkLocalSubnet.Contains(dest) || dest == header.IPv4Broadcast {
+		return false
+	}
+	addr4 := dest.As4()
+	return filter.MatchesIP(net.IP(addr4[:]))
+}
+
+// maxLoggedDestinations bounds the distinct destinations that earn their own
+// log line. Chosen to cover a realistic misconfiguration (a handful of
+// endpoints) without letting a port scan size the map.
+const maxLoggedDestinations = 256
+
+type udpDestination struct {
+	addr tcpip.Address
+	port uint16
+}
+
+// blockedDestinationLog keeps drop logging bounded. UDP is connectionless and
+// a guest can emit thousands of denied datagrams per second, so logging every
+// drop the way the TCP path logs every blocked connection would let the guest
+// flood the log. Output is capped at one line per distinct destination plus
+// one per order-of-magnitude of total drops.
+type blockedDestinationLog struct {
+	mu            sync.Mutex
+	seen          map[udpDestination]bool
+	dropped       uint64
+	nextMilestone uint64
+}
+
+func newBlockedDestinationLog() *blockedDestinationLog {
+	return &blockedDestinationLog{
+		seen:          make(map[udpDestination]bool),
+		nextMilestone: 1,
+	}
+}
+
+func (b *blockedDestinationLog) note(addr tcpip.Address, port uint16) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.dropped++
+
+	key := udpDestination{addr: addr, port: port}
+	newDestination := !b.seen[key] && len(b.seen) < maxLoggedDestinations
+	if newDestination {
+		b.seen[key] = true
+	}
+
+	milestone := b.dropped >= b.nextMilestone
+	if milestone {
+		b.nextMilestone *= 10
+	}
+
+	if !newDestination && !milestone {
+		return
+	}
+
+	logrus.WithFields(logrus.Fields{
+		"dst_ip":        addr,
+		"dst_port":      port,
+		"dropped_total": b.dropped,
+	}).Info("allowNet UDP: blocked (no matching rule)")
+}

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/forked_udp_test.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/forked_udp_test.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"net"
+	"testing"
+
+	logrus "github.com/sirupsen/logrus"
+	logrustest "github.com/sirupsen/logrus/hooks/test"
+	"gvisor.dev/gvisor/pkg/tcpip"
+	"gvisor.dev/gvisor/pkg/tcpip/header"
+)
+
+func ipv4Addr(t *testing.T, s string) tcpip.Address {
+	t.Helper()
+	ip := net.ParseIP(s).To4()
+	if ip == nil {
+		t.Fatalf("not an IPv4 address: %q", s)
+	}
+	return tcpip.AddrFrom4Slice(ip)
+}
+
+func TestUDPDestinationAllowed_IPAndCIDRRules(t *testing.T) {
+	filter := NewAllowNetFilter(
+		[]string{"1.2.3.4", "10.0.0.0/8"},
+		"192.168.127.1", "192.168.127.2", "192.168.127.254",
+	)
+
+	cases := []struct {
+		dest string
+		want bool
+		why  string
+	}{
+		{"1.2.3.4", true, "exact IP rule"},
+		{"10.1.2.3", true, "inside CIDR rule"},
+		{"11.1.2.3", false, "outside every rule"},
+		{"8.8.8.8", false, "unapproved resolver"},
+		{"192.168.127.1", true, "gateway is always allowed"},
+		{"192.168.127.254", true, "host alias is always allowed"},
+	}
+
+	for _, tc := range cases {
+		if got := udpDestinationAllowed(ipv4Addr(t, tc.dest), filter); got != tc.want {
+			t.Errorf("udpDestinationAllowed(%s) = %v, want %v (%s)", tc.dest, got, tc.want, tc.why)
+		}
+	}
+}
+
+// Hostname rules need SNI/Host inspection, which UDP cannot provide. A
+// hostname-only allowlist must therefore deny UDP outright — otherwise a
+// guest bypasses the rule by addressing the resolved IP directly.
+func TestUDPDestinationAllowed_HostnameOnlyRulesDenyEverything(t *testing.T) {
+	filter := NewAllowNetFilter(
+		[]string{"api.openai.com", "*.example.com"},
+		"192.168.127.1", "192.168.127.2", "192.168.127.254",
+	)
+
+	for _, dest := range []string{"1.2.3.4", "93.184.216.34", "8.8.8.8"} {
+		if udpDestinationAllowed(ipv4Addr(t, dest), filter) {
+			t.Errorf("udpDestinationAllowed(%s) = true, want false for a hostname-only allowlist", dest)
+		}
+	}
+
+	// Internal addresses stay reachable so the box can still boot and resolve.
+	if !udpDestinationAllowed(ipv4Addr(t, "192.168.127.1"), filter) {
+		t.Error("gateway must stay reachable under a hostname-only allowlist")
+	}
+}
+
+// Link-local is denied regardless of the allowlist: ec2MetadataAccess opens
+// IMDS over TCP only, so a UDP hole there would be pure added egress.
+func TestUDPDestinationAllowed_LinkLocalAndBroadcastDenied(t *testing.T) {
+	filter := NewAllowNetFilter(
+		[]string{"169.254.0.0/16", "255.255.255.255"},
+		"192.168.127.1", "192.168.127.2", "192.168.127.254",
+	)
+
+	if udpDestinationAllowed(ipv4Addr(t, "169.254.169.254"), filter) {
+		t.Error("link-local must be denied even when a CIDR rule covers it")
+	}
+	if udpDestinationAllowed(header.IPv4Broadcast, filter) {
+		t.Error("broadcast must be denied even when an exact rule covers it")
+	}
+}
+
+func TestBlockedDestinationLog_OneLinePerDestination(t *testing.T) {
+	hook := logrustest.NewLocal(logrus.StandardLogger())
+	defer hook.Reset()
+
+	blocked := newBlockedDestinationLog()
+	dest := ipv4Addr(t, "1.2.3.4")
+
+	// Drops 2..9 are neither a new destination nor an order-of-magnitude
+	// milestone, so they must stay silent.
+	for i := 0; i < 5; i++ {
+		blocked.note(dest, 53)
+	}
+
+	if got := len(hook.Entries); got != 1 {
+		t.Fatalf("5 drops to one destination produced %d log lines, want 1", got)
+	}
+	if blocked.dropped != 5 {
+		t.Errorf("dropped counter = %d, want 5", blocked.dropped)
+	}
+}
+
+func TestBlockedDestinationLog_LogsEachNewDestination(t *testing.T) {
+	hook := logrustest.NewLocal(logrus.StandardLogger())
+	defer hook.Reset()
+
+	blocked := newBlockedDestinationLog()
+	blocked.note(ipv4Addr(t, "1.2.3.4"), 53)
+	blocked.note(ipv4Addr(t, "1.2.3.4"), 443) // same IP, different port
+	blocked.note(ipv4Addr(t, "5.6.7.8"), 53)
+
+	if got := len(hook.Entries); got != 3 {
+		t.Fatalf("3 distinct destinations produced %d log lines, want 3", got)
+	}
+}
+
+func TestBlockedDestinationLog_BoundedByDestinationCap(t *testing.T) {
+	hook := logrustest.NewLocal(logrus.StandardLogger())
+	defer hook.Reset()
+
+	blocked := newBlockedDestinationLog()
+	// One drop per distinct port, past the cap. The milestone lines (drops
+	// 1, 10, 100) coincide with new destinations, so they add no extra
+	// entries; every drop past the cap must be silent.
+	for port := 0; port < maxLoggedDestinations+64; port++ {
+		blocked.note(ipv4Addr(t, "1.2.3.4"), uint16(port))
+	}
+
+	if got := len(hook.Entries); got != maxLoggedDestinations {
+		t.Fatalf("logged %d lines for %d destinations, want the %d cap",
+			got, maxLoggedDestinations+64, maxLoggedDestinations)
+	}
+	if blocked.dropped != uint64(maxLoggedDestinations+64) {
+		t.Errorf("dropped counter = %d, want %d", blocked.dropped, maxLoggedDestinations+64)
+	}
+}
+
+func TestBlockedDestinationLog_MilestoneKeepsFloodVisible(t *testing.T) {
+	hook := logrustest.NewLocal(logrus.StandardLogger())
+	defer hook.Reset()
+
+	blocked := newBlockedDestinationLog()
+	dest := ipv4Addr(t, "1.2.3.4")
+	for i := 0; i < 100; i++ {
+		blocked.note(dest, 53)
+	}
+
+	// Drops 1, 10 and 100 to a single destination: first-seen plus two
+	// order-of-magnitude milestones.
+	if got := len(hook.Entries); got != 3 {
+		t.Fatalf("100 drops to one destination produced %d log lines, want 3", got)
+	}
+	if last := hook.LastEntry().Data["dropped_total"]; last != uint64(100) {
+		t.Errorf("last line reported dropped_total=%v, want 100", last)
+	}
+}

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/main.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/main.go
@@ -434,8 +434,13 @@ func gvproxy_create(configJSON *C.char, errOut **C.char) C.longlong {
 			if len(config.AllowNet) > 0 {
 				allowNetFilter = NewAllowNetFilter(config.AllowNet, config.GatewayIP, config.GuestIP, config.HostIP)
 			}
+			// Fatal on purpose: the handlers left behind are upstream's
+			// unfiltered forwarders, so a box that starts anyway would carry
+			// an allow_net the caller believes in and the network ignores.
 			if err := installAllowNetHandlers(vn, tapConfig, tapConfig.Ec2MetadataAccess, allowNetFilter, instance.ca, instance.secretMatcher); err != nil {
-				logrus.WithError(err).Error("allowNet: failed to install transport handlers")
+				logrus.WithFields(logrus.Fields{"error": err, "id": id}).Error("allowNet: failed to install transport handlers")
+				initErr <- fmt.Errorf("failed to install allow_net transport handlers: %w", err)
+				return
 			}
 		}
 

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/main.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/main.go
@@ -427,14 +427,15 @@ func gvproxy_create(configJSON *C.char, errOut **C.char) C.longlong {
 			return
 		}
 
-		// Override TCP handler with AllowNet filter and/or MITM secret substitution
+		// Override the TCP and UDP handlers with the AllowNet filter and/or
+		// MITM secret substitution
 		if len(config.AllowNet) > 0 || instance.secretMatcher != nil {
 			var allowNetFilter *AllowNetFilter
 			if len(config.AllowNet) > 0 {
 				allowNetFilter = NewAllowNetFilter(config.AllowNet, config.GatewayIP, config.GuestIP, config.HostIP)
 			}
-			if err := OverrideTCPHandler(vn, tapConfig, tapConfig.Ec2MetadataAccess, allowNetFilter, instance.ca, instance.secretMatcher); err != nil {
-				logrus.WithError(err).Error("TCP: failed to override handler")
+			if err := installAllowNetHandlers(vn, tapConfig, tapConfig.Ec2MetadataAccess, allowNetFilter, instance.ca, instance.secretMatcher); err != nil {
+				logrus.WithError(err).Error("allowNet: failed to install transport handlers")
 			}
 		}
 

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/main.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/main.go
@@ -429,11 +429,11 @@ func gvproxy_create(configJSON *C.char, errOut **C.char) C.longlong {
 
 		// Override TCP handler with AllowNet filter and/or MITM secret substitution
 		if len(config.AllowNet) > 0 || instance.secretMatcher != nil {
-			var tcpFilter *TCPFilter
+			var allowNetFilter *AllowNetFilter
 			if len(config.AllowNet) > 0 {
-				tcpFilter = NewTCPFilter(config.AllowNet, config.GatewayIP, config.GuestIP, config.HostIP)
+				allowNetFilter = NewAllowNetFilter(config.AllowNet, config.GatewayIP, config.GuestIP, config.HostIP)
 			}
-			if err := OverrideTCPHandler(vn, tapConfig, tapConfig.Ec2MetadataAccess, tcpFilter, instance.ca, instance.secretMatcher); err != nil {
+			if err := OverrideTCPHandler(vn, tapConfig, tapConfig.Ec2MetadataAccess, allowNetFilter, instance.ca, instance.secretMatcher); err != nil {
 				logrus.WithError(err).Error("TCP: failed to override handler")
 			}
 		}

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/udp_filter_test.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/udp_filter_test.go
@@ -1,0 +1,498 @@
+package main
+
+// udp_filter_test.go — allow_net must apply to UDP, not only TCP.
+//
+// These tests drive the real virtual network the way a guest does: raw
+// Ethernet frames over the qemu stream protocol into vn.AcceptQemu. Nothing
+// is stubbed — the packets traverse the same gVisor stack, the same NAT
+// table, and the same transport handlers a running box uses.
+//
+// The unlisted destination is a TEST-NET address (198.51.100.9) that the
+// config NAT-maps to loopback, so the forwarder's net.Dial lands on a
+// test-owned listener instead of the internet. Policy is evaluated on the
+// pre-NAT address (forked_tcp.go:83), so 198.51.100.9 is what the allowlist
+// sees, exactly as it would for a real public IP.
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/containers/gvisor-tap-vsock/pkg/types"
+	"github.com/containers/gvisor-tap-vsock/pkg/virtualnetwork"
+	"gvisor.dev/gvisor/pkg/tcpip"
+	"gvisor.dev/gvisor/pkg/tcpip/checksum"
+	"gvisor.dev/gvisor/pkg/tcpip/header"
+	"gvisor.dev/gvisor/pkg/tcpip/transport/tcp"
+	"gvisor.dev/gvisor/pkg/tcpip/transport/udp"
+)
+
+const (
+	unlistedIP   = "198.51.100.9"
+	allowedCIDR  = "198.51.100.1/32"
+	guestSrcPort = 41234
+	probePayload = "BOXLITE_UDP_ALLOW_NET_PROBE"
+	// A forwarded datagram reaches loopback in microseconds; this only has to
+	// outlast scheduler noise before we conclude the packet was dropped.
+	forwardWindow = 2 * time.Second
+)
+
+// guestTap is the test's end of the virtual link: write frames to inject
+// guest traffic, read frames the gateway sends back.
+type guestTap struct {
+	conn   net.Conn
+	frames chan []byte
+}
+
+// startNetwork builds the same virtual network gvproxy_create builds
+// (buildTapConfig → virtualnetwork.New → installAllowNetHandlers) and
+// attaches a test-driven guest link to it.
+func startNetwork(t *testing.T, allowNet []string) *guestTap {
+	t.Helper()
+
+	cfg := testGvproxyConfig()
+	cfg.AllowNet = allowNet
+	tapConfig := buildTapConfig(cfg, types.QemuProtocol)
+	// Route the unlisted TEST-NET destination to a test-owned loopback
+	// listener. The forwarders dial the NAT-translated address; the allowlist
+	// still sees 198.51.100.9.
+	tapConfig.NAT[unlistedIP] = "127.0.0.1"
+
+	vn, err := virtualnetwork.New(tapConfig)
+	if err != nil {
+		t.Fatalf("virtualnetwork.New: %v", err)
+	}
+
+	if len(cfg.AllowNet) > 0 {
+		filter := NewAllowNetFilter(cfg.AllowNet, cfg.GatewayIP, cfg.GuestIP, cfg.HostIP)
+		if err := installAllowNetHandlers(vn, tapConfig, tapConfig.Ec2MetadataAccess, filter, nil, nil); err != nil {
+			t.Fatalf("installAllowNetHandlers: %v", err)
+		}
+	}
+
+	guestSide, stackSide := net.Pipe()
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() { _ = vn.AcceptQemu(ctx, stackSide) }()
+	t.Cleanup(func() {
+		cancel()
+		_ = guestSide.Close()
+	})
+
+	tap := &guestTap{conn: guestSide, frames: make(chan []byte, 64)}
+	// Drain the gateway→guest direction: the switch writes ARP requests and
+	// replies synchronously over net.Pipe and would block without a reader.
+	go tap.readLoop()
+	return tap
+}
+
+func (g *guestTap) readLoop() {
+	var size [4]byte
+	for {
+		if _, err := readFull(g.conn, size[:]); err != nil {
+			return
+		}
+		frame := make([]byte, binary.BigEndian.Uint32(size[:]))
+		if _, err := readFull(g.conn, frame); err != nil {
+			return
+		}
+		if g.answerARP(frame) {
+			continue
+		}
+		select {
+		case g.frames <- frame:
+		default: // capture buffer full: the tests only inspect DNS replies
+		}
+	}
+}
+
+// answerARP replies to the gateway's ARP request for the guest IP. Without
+// it the stack has no link address for the guest and never delivers a reply
+// packet, which a real guest's kernel would handle.
+func (g *guestTap) answerARP(frame []byte) bool {
+	if len(frame) < header.EthernetMinimumSize+header.ARPSize {
+		return false
+	}
+	eth := header.Ethernet(frame)
+	if eth.Type() != header.ARPProtocolNumber {
+		return false
+	}
+	req := header.ARP(frame[header.EthernetMinimumSize:])
+	if !req.IsValid() || req.Op() != header.ARPRequest {
+		return false
+	}
+	cfg := testGvproxyConfig()
+	guestIP := net.ParseIP(cfg.GuestIP).To4()
+	if !net.IP(req.ProtocolAddressTarget()).Equal(guestIP) {
+		return false
+	}
+	guestMAC, err := net.ParseMAC(cfg.GuestMac)
+	if err != nil {
+		return false
+	}
+
+	reply := make([]byte, header.EthernetMinimumSize+header.ARPSize)
+	header.Ethernet(reply).Encode(&header.EthernetFields{
+		SrcAddr: tcpip.LinkAddress(guestMAC),
+		DstAddr: eth.SourceAddress(),
+		Type:    header.ARPProtocolNumber,
+	})
+	arp := header.ARP(reply[header.EthernetMinimumSize:])
+	arp.SetIPv4OverEthernet()
+	arp.SetOp(header.ARPReply)
+	copy(arp.HardwareAddressSender(), guestMAC)
+	copy(arp.ProtocolAddressSender(), guestIP)
+	copy(arp.HardwareAddressTarget(), req.HardwareAddressSender())
+	copy(arp.ProtocolAddressTarget(), req.ProtocolAddressSender())
+
+	var size [4]byte
+	binary.BigEndian.PutUint32(size[:], uint32(len(reply)))
+	_ = g.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+	_, _ = g.conn.Write(append(size[:], reply...))
+	return true
+}
+
+// awaitUDPPayload returns the payload of the next UDP datagram the gateway
+// sends to the guest from srcIP:srcPort.
+func (g *guestTap) awaitUDPPayload(t *testing.T, srcIP string, srcPort uint16) []byte {
+	t.Helper()
+	deadline := time.After(forwardWindow)
+	for {
+		select {
+		case frame := <-g.frames:
+			payload, ok := parseUDPPayload(frame, srcIP, srcPort)
+			if ok {
+				return payload
+			}
+		case <-deadline:
+			t.Fatalf("no UDP datagram from %s:%d reached the guest", srcIP, srcPort)
+		}
+	}
+}
+
+func parseUDPPayload(frame []byte, srcIP string, srcPort uint16) ([]byte, bool) {
+	if len(frame) < header.EthernetMinimumSize+header.IPv4MinimumSize {
+		return nil, false
+	}
+	if header.Ethernet(frame).Type() != header.IPv4ProtocolNumber {
+		return nil, false
+	}
+	ip := header.IPv4(frame[header.EthernetMinimumSize:])
+	if !ip.IsValid(len(ip)) || tcpip.TransportProtocolNumber(ip.Protocol()) != udp.ProtocolNumber {
+		return nil, false
+	}
+	if net.IP(ip.SourceAddressSlice()).String() != srcIP {
+		return nil, false
+	}
+	segment := header.UDP(ip.Payload())
+	if len(segment) < header.UDPMinimumSize || segment.SourcePort() != srcPort {
+		return nil, false
+	}
+	return segment.Payload(), true
+}
+
+func readFull(conn net.Conn, buf []byte) (int, error) {
+	read := 0
+	for read < len(buf) {
+		n, err := conn.Read(buf[read:])
+		read += n
+		if err != nil {
+			return read, err
+		}
+	}
+	return read, nil
+}
+
+func (g *guestTap) send(t *testing.T, frame []byte) {
+	t.Helper()
+	var size [4]byte
+	binary.BigEndian.PutUint32(size[:], uint32(len(frame)))
+	if err := g.conn.SetWriteDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatalf("SetWriteDeadline: %v", err)
+	}
+	if _, err := g.conn.Write(append(size[:], frame...)); err != nil {
+		t.Fatalf("write frame: %v", err)
+	}
+}
+
+// --- frame construction -----------------------------------------------------
+
+func mac(t *testing.T, s string) tcpip.LinkAddress {
+	t.Helper()
+	parsed, err := net.ParseMAC(s)
+	if err != nil {
+		t.Fatalf("ParseMAC(%q): %v", s, err)
+	}
+	return tcpip.LinkAddress(parsed)
+}
+
+func addr(t *testing.T, s string) tcpip.Address {
+	t.Helper()
+	ip := net.ParseIP(s).To4()
+	if ip == nil {
+		t.Fatalf("not an IPv4 address: %q", s)
+	}
+	return tcpip.AddrFrom4Slice(ip)
+}
+
+// ipv4Frame wraps an already-checksummed transport segment in IPv4 +
+// Ethernet, addressed to the gateway MAC so the switch delivers it to the
+// stack (switch.go:281).
+func ipv4Frame(t *testing.T, src, dst tcpip.Address, proto tcpip.TransportProtocolNumber, segment []byte) []byte {
+	t.Helper()
+	cfg := testGvproxyConfig()
+
+	total := header.IPv4MinimumSize + len(segment)
+	ip := header.IPv4(make([]byte, total))
+	ip.Encode(&header.IPv4Fields{
+		TotalLength: uint16(total),
+		TTL:         64,
+		Protocol:    uint8(proto),
+		SrcAddr:     src,
+		DstAddr:     dst,
+	})
+	ip.SetChecksum(^ip.CalculateChecksum())
+	copy(ip[header.IPv4MinimumSize:], segment)
+
+	frame := make([]byte, header.EthernetMinimumSize+total)
+	header.Ethernet(frame).Encode(&header.EthernetFields{
+		SrcAddr: mac(t, cfg.GuestMac),
+		DstAddr: mac(t, cfg.GatewayMac),
+		Type:    header.IPv4ProtocolNumber,
+	})
+	copy(frame[header.EthernetMinimumSize:], ip)
+	return frame
+}
+
+func udpFrame(t *testing.T, dstIP string, dstPort uint16, payload []byte) []byte {
+	t.Helper()
+	cfg := testGvproxyConfig()
+	src, dst := addr(t, cfg.GuestIP), addr(t, dstIP)
+
+	length := header.UDPMinimumSize + len(payload)
+	segment := header.UDP(make([]byte, length))
+	segment.Encode(&header.UDPFields{
+		SrcPort: guestSrcPort,
+		DstPort: dstPort,
+		Length:  uint16(length),
+	})
+	copy(segment.Payload(), payload)
+
+	xsum := header.PseudoHeaderChecksum(udp.ProtocolNumber, src, dst, uint16(length))
+	xsum = checksum.Checksum(payload, xsum)
+	segment.SetChecksum(^segment.CalculateChecksum(xsum))
+
+	return ipv4Frame(t, src, dst, udp.ProtocolNumber, segment)
+}
+
+func tcpSynFrame(t *testing.T, dstIP string, dstPort uint16) []byte {
+	t.Helper()
+	cfg := testGvproxyConfig()
+	src, dst := addr(t, cfg.GuestIP), addr(t, dstIP)
+
+	segment := header.TCP(make([]byte, header.TCPMinimumSize))
+	segment.Encode(&header.TCPFields{
+		SrcPort:    guestSrcPort,
+		DstPort:    dstPort,
+		SeqNum:     1000,
+		DataOffset: header.TCPMinimumSize,
+		Flags:      header.TCPFlagSyn,
+		WindowSize: 65535,
+	})
+	xsum := header.PseudoHeaderChecksum(tcp.ProtocolNumber, src, dst, header.TCPMinimumSize)
+	segment.SetChecksum(^segment.CalculateChecksum(xsum))
+
+	return ipv4Frame(t, src, dst, tcp.ProtocolNumber, segment)
+}
+
+// --- minimal DNS wire format ------------------------------------------------
+//
+// Hand-rolled rather than pulled from miekg/dns, which is only an indirect
+// dependency here.
+
+func dnsQueryA(txnID uint16, name string) []byte {
+	query := make([]byte, 12, 32)
+	binary.BigEndian.PutUint16(query[0:], txnID)
+	binary.BigEndian.PutUint16(query[2:], 0x0100) // standard query, recursion desired
+	binary.BigEndian.PutUint16(query[4:], 1)      // QDCOUNT
+
+	for _, label := range strings.Split(name, ".") {
+		query = append(query, byte(len(label)))
+		query = append(query, label...)
+	}
+	query = append(query, 0)          // root label
+	query = append(query, 0, 1, 0, 1) // QTYPE=A, QCLASS=IN
+	return query
+}
+
+// parseSingleAResponse extracts the address from a reply carrying exactly one
+// A record. The rdata is the final four bytes of such a message, so the
+// answer section needs no name-compression handling.
+func parseSingleAResponse(msg []byte, txnID uint16) (net.IP, error) {
+	if len(msg) < 16 {
+		return nil, fmt.Errorf("reply too short: %d bytes", len(msg))
+	}
+	if got := binary.BigEndian.Uint16(msg[0:]); got != txnID {
+		return nil, fmt.Errorf("transaction id %#04x, want %#04x", got, txnID)
+	}
+	if answers := binary.BigEndian.Uint16(msg[6:]); answers != 1 {
+		return nil, fmt.Errorf("ANCOUNT %d, want exactly 1", answers)
+	}
+	return net.IP(msg[len(msg)-4:]).To4(), nil
+}
+
+// --- host-side receivers ----------------------------------------------------
+
+func listenUDP(t *testing.T) (*net.UDPConn, uint16) {
+	t.Helper()
+	conn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatalf("ListenUDP: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	return conn, uint16(conn.LocalAddr().(*net.UDPAddr).Port)
+}
+
+func listenTCP(t *testing.T) (net.Listener, uint16) {
+	t.Helper()
+	ln, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	return ln, uint16(ln.Addr().(*net.TCPAddr).Port)
+}
+
+// --- tests ------------------------------------------------------------------
+
+// TestAllowNetBlocksUnlistedTCP is the control: it proves the allowlist is
+// active and rejecting 198.51.100.9 on the transport that IS filtered.
+// Without it, a UDP result could just mean a broken allow_net config.
+func TestAllowNetBlocksUnlistedTCP(t *testing.T) {
+	ln, port := listenTCP(t)
+	tap := startNetwork(t, []string{allowedCIDR})
+
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err == nil {
+			accepted <- conn
+		}
+	}()
+
+	tap.send(t, tcpSynFrame(t, unlistedIP, port))
+
+	select {
+	case conn := <-accepted:
+		_ = conn.Close()
+		t.Fatalf("allow_net=%v: TCP to unlisted %s was forwarded to the host listener", allowedCIDR, unlistedIP)
+	case <-time.After(forwardWindow):
+	}
+}
+
+// TestAllowNetBlocksUnlistedUDP is the reproducer for the reported bypass:
+// the same allowlist, the same unlisted destination, UDP instead of TCP.
+func TestAllowNetBlocksUnlistedUDP(t *testing.T) {
+	conn, port := listenUDP(t)
+	tap := startNetwork(t, []string{allowedCIDR})
+
+	tap.send(t, udpFrame(t, unlistedIP, port, []byte(probePayload)))
+
+	if err := conn.SetReadDeadline(time.Now().Add(forwardWindow)); err != nil {
+		t.Fatalf("SetReadDeadline: %v", err)
+	}
+	buf := make([]byte, 2048)
+	n, from, err := conn.ReadFrom(buf)
+	if err != nil {
+		return // timed out: the datagram was dropped, which is the contract
+	}
+	t.Fatalf("allow_net=%v: UDP to unlisted %s reached the host listener from %s: %q",
+		allowedCIDR, unlistedIP, from, buf[:n])
+}
+
+// TestAllowNetHostnameRulesAlsoBindUDP covers the hostname-only allowlist,
+// where TCP policy comes from SNI/Host inspection that UDP has no analogue
+// for. Half the test proves the DNS sinkhole is engaged; the other half
+// sends UDP straight to a hard-coded IP, which is how a guest sidesteps it.
+func TestAllowNetHostnameRulesAlsoBindUDP(t *testing.T) {
+	cfg := testGvproxyConfig()
+	conn, port := listenUDP(t)
+	tap := startNetwork(t, []string{"example.com"})
+
+	// The gateway resolver must sinkhole a name outside the allowlist,
+	// otherwise the rest of this test proves nothing about policy being on.
+	const txnID = 0xbe11
+	tap.send(t, udpFrame(t, cfg.GatewayIP, 53, dnsQueryA(txnID, "blocked.test")))
+	answer := tap.awaitUDPPayload(t, cfg.GatewayIP, 53)
+	sinkholed, err := parseSingleAResponse(answer, txnID)
+	if err != nil {
+		t.Fatalf("gateway DNS reply: %v", err)
+	}
+	if !sinkholed.Equal(net.IPv4zero) {
+		t.Fatalf("expected DNS sinkhole 0.0.0.0 for blocked.test, got %s", sinkholed)
+	}
+
+	// Same box, same policy: a datagram to a hard-coded IP never consults it.
+	tap.send(t, udpFrame(t, unlistedIP, port, []byte(probePayload)))
+	if err := conn.SetReadDeadline(time.Now().Add(forwardWindow)); err != nil {
+		t.Fatalf("SetReadDeadline: %v", err)
+	}
+	buf := make([]byte, 2048)
+	n, from, err := conn.ReadFrom(buf)
+	if err != nil {
+		return // dropped, as a hostname-only allowlist should
+	}
+	t.Fatalf("allow_net=[example.com]: UDP to hard-coded %s reached the host listener from %s: %q",
+		unlistedIP, from, buf[:n])
+}
+
+// TestEmptyAllowlistForwardsUDP guards the other direction: an empty
+// allow_net is documented as full internet access, so the new UDP handler
+// must not turn the default configuration into a blackhole.
+func TestEmptyAllowlistForwardsUDP(t *testing.T) {
+	conn, port := listenUDP(t)
+	tap := startNetwork(t, nil)
+
+	tap.send(t, udpFrame(t, unlistedIP, port, []byte(probePayload)))
+
+	if err := conn.SetReadDeadline(time.Now().Add(forwardWindow)); err != nil {
+		t.Fatalf("SetReadDeadline: %v", err)
+	}
+	buf := make([]byte, 2048)
+	n, _, err := conn.ReadFrom(buf)
+	if err != nil {
+		t.Fatalf("empty allow_net must forward UDP, but the datagram was dropped: %v", err)
+	}
+	if string(buf[:n]) != probePayload {
+		t.Fatalf("forwarded payload = %q, want %q", buf[:n], probePayload)
+	}
+}
+
+// TestUnfilteredNetworkForwardsUnlistedTCP pins the consequence of
+// main.go:437 logging an OverrideTCPHandler failure and continuing: the box
+// keeps the upstream default handler, which forwards everything. It is the
+// same network minus the override, so a failed override is a fully open box.
+func TestUnfilteredNetworkForwardsUnlistedTCP(t *testing.T) {
+	ln, port := listenTCP(t)
+	tap := startNetwork(t, nil) // no allow_net → no OverrideTCPHandler call
+
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err == nil {
+			accepted <- conn
+		}
+	}()
+
+	tap.send(t, tcpSynFrame(t, unlistedIP, port))
+
+	select {
+	case conn := <-accepted:
+		_ = conn.Close()
+	case <-time.After(forwardWindow):
+		t.Fatal("default handler did not forward TCP — harness is not delivering frames to the stack")
+	}
+}


### PR DESCRIPTION
## Problem

A non-empty `NetworkSpec.allow_net` replaced only the TCP protocol handler, leaving upstream gvisor-tap-vsock's unfiltered UDP forwarder in place. Datagrams to any reachable address were forwarded regardless of the allowlist, while the equivalent TCP connection was blocked.

Three defects, same root:

1. `SetTransportProtocolHandler` was called for `tcp.ProtocolNumber` only — `udp.ProtocolNumber` kept upstream's forwarder, which dials the guest-chosen destination without consulting any policy.
2. A failed handler override was logged and startup continued, leaving the box on the *unfiltered* defaults — more open than the same box with no allowlist configured.
3. The DNS sinkhole only governs queries sent to the gateway resolver, so a datagram addressed straight to another resolver's IP bypassed it. Corollary of (1).

## Changes

- `installAllowNetHandlers` replaces both transports from one call site, so a protocol cannot be left on the unfiltered default.
- `UDPWithFilter` checks the pre-NAT destination against the allowlist the TCP path already consults, at the protocol-handler level — before upstream's forwarder creates an endpoint. Allowed datagrams are handed to that forwarder untouched, so its NAT, session, and teardown semantics are reused rather than forked.
- Denied datagrams are dropped silently. Returning "unhandled" would make gVisor emit ICMP port-unreachable, giving a guest a probe oracle.
- Drop logging is bounded — one line per distinct destination up to a cap, plus one per order-of-magnitude of total drops — because a guest can emit denied datagrams far faster than the TCP path produces blocked connections.
- Handler installation failure is now fatal to box creation, reusing the existing teardown path.
- `TCPFilter` → `AllowNetFilter`: the type is the policy source for every transport, and the TCP-scoped name is how the gap stayed invisible.

Internal traffic needs no exemption: the gateway resolver and DHCP are registered endpoints, and gVisor's demuxer matches those before the default handler runs.

ICMP was checked for the same failure shape and is not affected — no forwarder is installed, and echo requests are answered locally without leaving the host.

## Behaviour

| Destination | empty `allow_net` | IP/CIDR match | no match | hostname-only rules |
|---|---|---|---|---|
| external UDP | forward | forward | **drop (new)** | **drop (new)** |
| external TCP | forward | forward | RST | SNI/Host decides |
| gateway DNS `:53`, DHCP `:67` | forward | forward | forward | forward |
| host alias `.254` | forward | forward | forward | forward |
| link-local `169.254/16` | drop | drop | drop | drop |

## Breaking change

UDP to a hostname-only `allow_net` entry is now denied. Hostname rules are enforced by SNI/Host inspection, which UDP cannot provide, and permitting the resolved IP would let a guest bypass the rule by addressing it directly. QUIC/HTTP3 to an allowlisted hostname falls back to TCP; add the IP or CIDR to keep UDP reachable.

## Testing

Go bridge suite: 127 pass. The reproducers drive the real virtual network — raw Ethernet frames over the qemu protocol into `vn.AcceptQemu`, through the same gVisor stack, NAT table, and handlers a running box uses.

Two-side verified: with every production change reverted, `TestAllowNetBlocksUnlistedUDP` and `TestAllowNetHostnameRulesAlsoBindUDP` fail with the payload arriving at the host listener, while the TCP control and the empty-allowlist case still pass. Restored, all pass.

Two gaps, stated plainly:

- The VM-level cases in `network_spec.rs` are `#[ignore]` and were **not executed** — `libkrun`/`libkrunfw` submodules could not be fetched in this environment. They compile and are formatted; they need `make test` on a machine with full dependencies.
- The fail-closed branch in `main.go` has no direct test: its only trigger is gvisor-tap-vsock dropping `VirtualNetwork`'s unexported `stack` field, which cannot be constructed from a test. `TestStackFieldExists` guards that trigger.

Pre-existing and unrelated: `TestBuildAllowNetDNSZones_PerTLDZonesHaveSinkholeDefaultIP` fails without outbound DNS. Confirmed failing on `053e3817` in a separate worktree.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Network allowlists now restrict both TCP and UDP outbound traffic.
  * Hostname-based allow rules are enforced via TCP-only hostname inspection, so hostname-only entries do not permit UDP.
  * QUIC/HTTP3 may fall back to TCP for hostname matches unless the destination IP/CIDR is explicitly allowed.
* **Documentation**
  * Expanded reference and SDK/CLI docs to clarify allowlist pattern formats and UDP limitations, including notes about gateway DNS/DHCP access.
* **Tests**
  * Added UDP-focused integration coverage for allow/deny behavior and bounded blocked-destination logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->