### PR TITLE
feat: repair a box startup whose job completion was lost

### DIFF
--- a/apps/api/src/box/services/box.service.spec.ts
+++ b/apps/api/src/box/services/box.service.spec.ts
@@ -50,6 +50,8 @@ function makeService() {
     noop, // regionService
     noop, // boxLookupCacheInvalidationService
     noop, // boxActivityService
+    noop, // jobRepository
+    noop, // jobService
   )
   return { service, boxRepository, eventEmitter, organizationService, organizationUsageService }
 }
@@ -91,6 +93,8 @@ function makePreviewUrlService() {
     regionService, // regionService
     noop, // boxLookupCacheInvalidationService
     noop, // boxActivityService
+    noop, // jobRepository
+    noop, // jobService
   )
   jest.spyOn(service, 'findOneByIdOrName').mockResolvedValue({
     id: 'MixedCaseBox',
@@ -266,6 +270,8 @@ function makeNetworkTunnelService() {
     regionService,
     noop,
     noop,
+    noop, // jobRepository
+    noop, // jobService
   )
   jest.spyOn(service, 'findOneByIdOrName').mockResolvedValue({
     id: 'MixedCaseBox',

--- a/apps/api/src/box/services/box.service.start-reconciliation.spec.ts
+++ b/apps/api/src/box/services/box.service.start-reconciliation.spec.ts
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { Box } from '../entities/box.entity'
+import { Job } from '../entities/job.entity'
+import { BoxState } from '../enums/box-state.enum'
+import { BoxDesiredState } from '../enums/box-desired-state.enum'
+import { JobStatus, JobType, ResourceType } from '../dto/job.dto'
+import { BadRequestError } from '../../exceptions/bad-request.exception'
+import { BoxService } from './box.service'
+
+const STALL_SECONDS = 60
+
+function makeBox(state: BoxState, desiredState = BoxDesiredState.STARTED): Box {
+  const box = new Box('us', 'loader')
+  box.state = state
+  box.desiredState = desiredState
+  box.runnerId = 'runner-1'
+  box.pending = true
+  return box
+}
+
+function makeStalledJob(type: JobType): Job {
+  return {
+    id: 'job-1',
+    runnerId: 'runner-1',
+    resourceType: ResourceType.BOX,
+    resourceId: 'box-1',
+    type,
+    status: JobStatus.IN_PROGRESS,
+    startedAt: new Date(Date.now() - (STALL_SECONDS + 30) * 1000),
+    completedAt: null,
+  } as Job
+}
+
+type Harness = {
+  service: BoxService
+  jobFindOne: jest.Mock
+  updateJobStatus: jest.Mock
+  updateWhere: jest.Mock
+}
+
+function createService(box: Box | null, stalledJob: Job | null): Harness {
+  const service = Object.create(BoxService.prototype) as BoxService
+  const jobFindOne = jest.fn().mockResolvedValue(stalledJob)
+  const updateJobStatus = jest.fn().mockResolvedValue(undefined)
+  const updateWhere = jest.fn().mockResolvedValue(box)
+
+  ;(service as any).logger = { debug: jest.fn(), warn: jest.fn(), error: jest.fn(), log: jest.fn() }
+  ;(service as any).boxRepository = { findOne: jest.fn().mockResolvedValue(box), updateWhere }
+  ;(service as any).jobRepository = { findOne: jobFindOne }
+  ;(service as any).jobService = { updateJobStatus }
+  ;(service as any).configService = {
+    getOrThrow: jest.fn((key: string) => {
+      if (key !== 'boxSync.startConfirmationStallSeconds') {
+        throw new Error(`unexpected config key ${key}`)
+      }
+      return STALL_SECONDS
+    }),
+  }
+
+  return { service, jobFindOne, updateJobStatus, updateWhere }
+}
+
+describe('BoxService.updateState start reconciliation', () => {
+  it('completes the stalled startup job instead of writing the box directly', async () => {
+    const box = makeBox(BoxState.CREATING)
+    const job = makeStalledJob(JobType.CREATE_BOX)
+    const { service, jobFindOne, updateJobStatus, updateWhere } = createService(box, job)
+
+    await service.updateState(box.id, BoxState.STARTED)
+
+    expect(updateJobStatus).toHaveBeenCalledWith('job-1', JobStatus.COMPLETED)
+    // The completion handler owns the STARTED transition, the pending flag, the
+    // activity stamp and the Redis unlock. Writing the box here too would fork
+    // that logic.
+    expect(updateWhere).not.toHaveBeenCalled()
+
+    expect(jobFindOne).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          runnerId: 'runner-1',
+          resourceType: ResourceType.BOX,
+          resourceId: box.id,
+          type: JobType.CREATE_BOX,
+          status: JobStatus.IN_PROGRESS,
+        }),
+      }),
+    )
+  })
+
+  it('looks for a START_BOX job when the box is STARTING', async () => {
+    const box = makeBox(BoxState.STARTING)
+    const { service, jobFindOne } = createService(box, makeStalledJob(JobType.START_BOX))
+
+    await service.updateState(box.id, BoxState.STARTED)
+
+    expect(jobFindOne).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ type: JobType.START_BOX }),
+      }),
+    )
+  })
+
+  it('stays silent while the startup job is still progressing', async () => {
+    const box = makeBox(BoxState.CREATING)
+    const { service, updateJobStatus, updateWhere } = createService(box, null)
+
+    // Not an error: the runner is telling the truth, the job just has not
+    // stalled yet. Rejecting would log a 400 on every sync tick.
+    await expect(service.updateState(box.id, BoxState.STARTED)).resolves.toBeUndefined()
+
+    expect(updateJobStatus).not.toHaveBeenCalled()
+    expect(updateWhere).not.toHaveBeenCalled()
+  })
+
+  it('rejects a STARTED report for a box that is no longer desired STARTED', async () => {
+    const box = makeBox(BoxState.CREATING, BoxDesiredState.STOPPED)
+    const { service, updateJobStatus } = createService(box, makeStalledJob(JobType.CREATE_BOX))
+
+    await expect(service.updateState(box.id, BoxState.STARTED)).rejects.toBeInstanceOf(BadRequestError)
+    expect(updateJobStatus).not.toHaveBeenCalled()
+  })
+
+  it('still rejects a non-STARTED report for a transitional box', async () => {
+    const box = makeBox(BoxState.CREATING)
+    const { service, updateJobStatus } = createService(box, makeStalledJob(JobType.CREATE_BOX))
+
+    await expect(service.updateState(box.id, BoxState.STOPPED)).rejects.toBeInstanceOf(BadRequestError)
+    expect(updateJobStatus).not.toHaveBeenCalled()
+  })
+})
+
+describe('BoxService.findByRunnerId state filter', () => {
+  function createFinder(): { service: BoxService; find: jest.Mock } {
+    const service = Object.create(BoxService.prototype) as BoxService
+    const find = jest.fn().mockResolvedValue([])
+    ;(service as any).boxRepository = { find }
+    return { service, find }
+  }
+
+  it('accepts transitional states so a runner can reconcile a lost startup', async () => {
+    const { service, find } = createFinder()
+
+    await expect(service.findByRunnerId('runner-1', [BoxState.CREATING, BoxState.STARTING])).resolves.toEqual([])
+    expect(find).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects transitional states when asked to skip reconciling boxes', async () => {
+    const { service, find } = createFinder()
+
+    // "Skip boxes whose state differs from desired state" is meaningless for a
+    // state that has no corresponding desired state — the two requests are
+    // mutually exclusive.
+    await expect(service.findByRunnerId('runner-1', [BoxState.CREATING], true)).rejects.toBeInstanceOf(BadRequestError)
+    expect(find).not.toHaveBeenCalled()
+  })
+})

--- a/apps/api/src/box/services/box.service.ts
+++ b/apps/api/src/box/services/box.service.ts
@@ -55,6 +55,9 @@ import { customAlphabet as customNanoid, nanoid, urlAlphabet } from 'nanoid'
 import { WithInstrumentation } from '../../common/decorators/otel.decorator'
 import { validateMountPaths, validateSubpaths } from '../utils/volume-mount-path-validation.util'
 import { BoxRepository } from '../repositories/box.repository'
+import { Job } from '../entities/job.entity'
+import { JobService } from './job.service'
+import { JobStatus, JobType, ResourceType } from '../dto/job.dto'
 import { PortPreviewUrlDto, SignedPortPreviewUrlDto } from '../dto/port-preview-url.dto'
 import { RegionService } from '../../region/services/region.service'
 import { BoxCreatedEvent } from '../events/box-create.event'
@@ -110,6 +113,9 @@ export class BoxService {
     private readonly regionService: RegionService,
     private readonly boxLookupCacheInvalidationService: BoxLookupCacheInvalidationService,
     private readonly boxActivityService: BoxActivityService,
+    @InjectRepository(Job)
+    private readonly jobRepository: Repository<Job>,
+    private readonly jobService: JobService,
   ) {}
 
   protected getLockKey(id: string): string {
@@ -553,15 +559,63 @@ export class BoxService {
     return this.getExpectedDesiredStateForState(state) !== undefined
   }
 
+  private getStartupJobTypeForState(state: BoxState): JobType | undefined {
+    switch (state) {
+      case BoxState.CREATING:
+        return JobType.CREATE_BOX
+      case BoxState.STARTING:
+        return JobType.START_BOX
+      default:
+        return undefined
+    }
+  }
+
+  /**
+   * The box's own startup job, if it was claimed by its runner and has since
+   * stopped making progress.
+   *
+   * "Stalled" is measured from when the runner claimed the job, because that
+   * is what a lost completion callback looks like from here: claimed, never
+   * closed. A job still within the window is assumed to be running normally,
+   * and an unclaimed (PENDING) job has no runner to have lost anything.
+   */
+  private async findStalledStartupJob(box: Box): Promise<Job | null> {
+    const startupJobType = this.getStartupJobTypeForState(box.state)
+    if (!startupJobType || !box.runnerId) {
+      return null
+    }
+
+    const stallSeconds = this.configService.getOrThrow('boxSync.startConfirmationStallSeconds')
+    const claimedBefore = new Date(Date.now() - stallSeconds * 1000)
+
+    return this.jobRepository.findOne({
+      where: {
+        runnerId: box.runnerId,
+        resourceType: ResourceType.BOX,
+        resourceId: box.id,
+        type: startupJobType,
+        status: JobStatus.IN_PROGRESS,
+        startedAt: LessThan(claimedBefore),
+      },
+      order: { createdAt: 'DESC' },
+    })
+  }
+
   async findByRunnerId(runnerId: string, states?: BoxState[], skipReconcilingBoxes?: boolean): Promise<Box[]> {
     const where: FindOptionsWhere<Box> = { runnerId }
     if (states && states.length > 0) {
-      // Validate that all states have corresponding desired states
-      states.forEach((state) => {
-        if (!this.hasValidDesiredState(state)) {
-          throw new BadRequestError(`State ${state} does not have a corresponding desired state`)
-        }
-      })
+      // Only the skip filter needs a state to have a corresponding desired
+      // state — it is defined as "state already matches desired state". Asking
+      // for a transitional state is a legitimate query on its own (a runner
+      // reconciling a startup whose job completion was lost does exactly
+      // that), so the requirement belongs to the filter, not to the parameter.
+      if (skipReconcilingBoxes) {
+        states.forEach((state) => {
+          if (!this.hasValidDesiredState(state)) {
+            throw new BadRequestError(`State ${state} does not have a corresponding desired state`)
+          }
+        })
+      }
       where.state = In(states)
     }
 
@@ -1272,7 +1326,31 @@ export class BoxService {
 
     //  only allow updating the state of started | stopped boxes
     if (![BoxState.STARTED, BoxState.STOPPED].includes(box.state)) {
-      throw new BadRequestError('Box is not in a valid state to be updated')
+      // One exception: a runner reporting STARTED for a box we still show as
+      // coming up. That means its startup job finished on the runner but the
+      // completion never reached us. Believe it only once the job has stopped
+      // making progress on its own — until then the normal callback is still
+      // the better answer, and we say nothing rather than reject a runner that
+      // is telling the truth.
+      if (newState !== BoxState.STARTED || box.desiredState !== BoxDesiredState.STARTED) {
+        throw new BadRequestError('Box is not in a valid state to be updated')
+      }
+
+      const stalledStartupJob = await this.findStalledStartupJob(box)
+      if (!stalledStartupJob) {
+        this.logger.debug(`Box ${boxId} start not yet confirmable; startup job still progressing`)
+        return
+      }
+
+      // Completing the job is what moves the box: the normal completion
+      // handler owns the STARTED transition, the pending flag, the activity
+      // stamp, the state-change event, and releasing the box's Redis lock.
+      // Doing any of that here instead would fork that logic.
+      this.logger.warn(
+        `Completing stalled startup job ${stalledStartupJob.id} for box ${boxId} from runner-reported state`,
+      )
+      await this.jobService.updateJobStatus(stalledStartupJob.id, JobStatus.COMPLETED)
+      return
     }
 
     if (box.desiredState == BoxDesiredState.DESTROYED) {

--- a/apps/api/src/box/services/job.service.claim.integration.spec.ts
+++ b/apps/api/src/box/services/job.service.claim.integration.spec.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { randomUUID } from 'node:crypto'
+import { DataSource, Repository } from 'typeorm'
+import { CustomNamingStrategy } from '../../common/utils/naming-strategy.util'
+import { JobStatus, JobType, ResourceType } from '../dto/job.dto'
+import { Job } from '../entities/job.entity'
+import { JobService } from './job.service'
+
+const describeIfDatabase = process.env.DB_HOST ? describe : describe.skip
+const schemaName = `job_claim_${process.pid}_${randomUUID().replaceAll('-', '')}`
+const firstJobId = '00000000-0000-4000-8000-000000000001'
+const secondJobId = '00000000-0000-4000-8000-000000000002'
+const rejectedJobId = '00000000-0000-4000-8000-000000000003'
+const rejectConstraint = 'reject_one_in_progress_job'
+
+function claimPendingJobs(service: JobService, runnerId: string, limit: number) {
+  return (service as any).claimPendingJobs(runnerId, limit) as Promise<Array<{ id: string; status: JobStatus }>>
+}
+
+function pendingJob(id: string, resourceId: string, createdAt: Date): Job {
+  const job = new Job({
+    id,
+    type: JobType.CREATE_BOX,
+    runnerId: 'runner-claim-integration',
+    resourceType: ResourceType.BOX,
+    resourceId,
+  })
+  job.createdAt = createdAt
+  job.updatedAt = createdAt
+  return job
+}
+
+describeIfDatabase('JobService.claimPendingJobs (integration, real Postgres)', () => {
+  let dataSource: DataSource
+  let repository: Repository<Job>
+  let service: JobService
+  let ownsSchema = false
+
+  beforeAll(async () => {
+    dataSource = await new DataSource({
+      type: 'postgres',
+      host: process.env.DB_HOST,
+      port: Number(process.env.DB_PORT || 5432),
+      username: process.env.DB_USERNAME,
+      password: process.env.DB_PASSWORD,
+      database: process.env.DB_DATABASE,
+      schema: schemaName,
+      entities: [Job],
+      namingStrategy: new CustomNamingStrategy(),
+      entitySkipConstructor: true,
+      synchronize: false,
+    }).initialize()
+
+    await dataSource.query(`CREATE SCHEMA "${schemaName}"`)
+    ownsSchema = true
+    await dataSource.synchronize()
+    repository = dataSource.getRepository(Job)
+    service = new JobService(repository, {} as any, {} as any)
+  })
+
+  afterAll(async () => {
+    if (!dataSource?.isInitialized) {
+      return
+    }
+
+    try {
+      if (ownsSchema) {
+        await dataSource.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`)
+      }
+    } finally {
+      await dataSource.destroy()
+    }
+  })
+
+  beforeEach(async () => {
+    await repository.clear()
+  })
+
+  afterEach(async () => {
+    await dataSource.query(
+      `ALTER TABLE "${schemaName}"."job" DROP CONSTRAINT IF EXISTS "${rejectConstraint}"`,
+    )
+  })
+
+  it('claims a persisted job without reconstructing the returned database row', async () => {
+    const createdAt = new Date('2026-08-10T10:00:00.000Z')
+    await repository.insert(pendingJob(firstJobId, 'box-claim-success', createdAt))
+
+    const claimed = await claimPendingJobs(service, 'runner-claim-integration', 10)
+
+    expect(claimed).toEqual([expect.objectContaining({ id: firstJobId, status: JobStatus.IN_PROGRESS })])
+    expect(await repository.findOneByOrFail({ id: firstJobId })).toEqual(
+      expect.objectContaining({ status: JobStatus.IN_PROGRESS, startedAt: expect.any(Date) }),
+    )
+  })
+
+  it('leaves the whole selected batch pending when one claim update is rejected', async () => {
+    await repository.insert([
+      pendingJob(firstJobId, 'box-claim-first', new Date('2026-08-10T10:00:00.000Z')),
+      pendingJob(rejectedJobId, 'box-claim-rejected', new Date('2026-08-10T10:00:01.000Z')),
+      pendingJob(secondJobId, 'box-not-selected', new Date('2026-08-10T10:00:02.000Z')),
+    ])
+    await dataSource.query(
+      `ALTER TABLE "${schemaName}"."job" ADD CONSTRAINT "${rejectConstraint}" CHECK ("id" <> '${rejectedJobId}' OR "status" <> '${JobStatus.IN_PROGRESS}')`,
+    )
+
+    await expect(claimPendingJobs(service, 'runner-claim-integration', 2)).rejects.toThrow()
+
+    const selected = await repository.find({
+      where: [{ id: firstJobId }, { id: rejectedJobId }],
+      order: { createdAt: 'ASC' },
+    })
+    expect(selected.map((job) => job.status)).toEqual([JobStatus.PENDING, JobStatus.PENDING])
+  })
+})

--- a/apps/api/src/box/services/job.service.claim.spec.ts
+++ b/apps/api/src/box/services/job.service.claim.spec.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { In } from 'typeorm'
+import { Job } from '../entities/job.entity'
+import { JobStatus, JobType, ResourceType } from '../dto/job.dto'
+import { JobService } from './job.service'
+
+function makePendingJob(id: string): Job {
+  return {
+    id,
+    runnerId: 'runner-1',
+    resourceType: ResourceType.BOX,
+    resourceId: `box-${id}`,
+    type: JobType.CREATE_BOX,
+    status: JobStatus.PENDING,
+    startedAt: null,
+    completedAt: null,
+    createdAt: new Date('2026-07-30T04:00:00.000Z'),
+    updatedAt: new Date('2026-07-30T04:00:00.000Z'),
+  } as unknown as Job
+}
+
+function makeService(pendingJobs: Job[], claimMatches: (id: string) => boolean) {
+  const jobRepository = {
+    find: jest.fn().mockResolvedValue(pendingJobs),
+    update: jest.fn(async () => ({
+      affected: pendingJobs.filter((job) => claimMatches(job.id)).length,
+      raw: pendingJobs.filter((job) => claimMatches(job.id)).map((job) => ({ id: job.id })),
+    })),
+    create: jest.fn((row: Job) => row),
+    save: jest.fn(),
+  }
+
+  const service = new JobService(jobRepository as any, {} as any, {} as any)
+  return { service, jobRepository }
+}
+
+// claimPendingJobs is private; poll routing is exercised elsewhere.
+function claimPendingJobs(service: JobService, runnerId: string, limit: number) {
+  return (service as any).claimPendingJobs(runnerId, limit) as Promise<Array<{ id: string; status: JobStatus }>>
+}
+
+describe('JobService.claimPendingJobs', () => {
+  it('does not reconstruct a returned database row through the entity constructor', async () => {
+    const jobs = [makePendingJob('job-1')]
+    const { service, jobRepository } = makeService(jobs, () => true)
+
+    // EntityManager.create() invokes `new Job()` without arguments even when
+    // entitySkipConstructor is enabled for database deserialization. Job's
+    // constructor requires params, so claim must reuse the entity read above.
+    jobRepository.create.mockImplementation(() => new (Job as any)())
+
+    await expect(claimPendingJobs(service, 'runner-1', 10)).resolves.toEqual([
+      expect.objectContaining({ id: 'job-1', status: JobStatus.IN_PROGRESS }),
+    ])
+    expect(jobRepository.create).not.toHaveBeenCalled()
+  })
+
+  it('claims each job with a status predicate so a concurrent poll cannot claim it twice', async () => {
+    const jobs = [makePendingJob('job-1')]
+    const { service, jobRepository } = makeService(jobs, () => true)
+
+    const claimed = await claimPendingJobs(service, 'runner-1', 10)
+
+    expect(claimed).toHaveLength(1)
+    expect(claimed[0].status).toBe(JobStatus.IN_PROGRESS)
+
+    expect(jobRepository.update).toHaveBeenCalledWith(
+      { id: In(['job-1']), status: JobStatus.PENDING },
+      expect.objectContaining({ status: JobStatus.IN_PROGRESS }),
+      { returning: ['id'] },
+    )
+  })
+
+  it('skips a job another poll already claimed instead of handing it out again', async () => {
+    const jobs = [makePendingJob('job-taken'), makePendingJob('job-free')]
+    const { service } = makeService(jobs, (id) => id === 'job-free')
+
+    const claimed = await claimPendingJobs(service, 'runner-1', 10)
+
+    expect(claimed.map((job) => job.id)).toEqual(['job-free'])
+  })
+
+  it('propagates a database failure instead of reporting it as a lost race', async () => {
+    const jobs = [makePendingJob('job-1')]
+    const { service, jobRepository } = makeService(jobs, () => true)
+    jobRepository.update.mockRejectedValueOnce(new Error('deadlock detected'))
+
+    await expect(claimPendingJobs(service, 'runner-1', 10)).rejects.toThrow('deadlock detected')
+  })
+})

--- a/apps/api/src/box/services/job.service.transaction.spec.ts
+++ b/apps/api/src/box/services/job.service.transaction.spec.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { ConflictException } from '@nestjs/common'
+import { Job } from '../entities/job.entity'
+import { JobStatus, JobType, ResourceType } from '../dto/job.dto'
+import { JobService } from './job.service'
+
+function makeJob(status: JobStatus): Job {
+  return {
+    id: 'job-1',
+    runnerId: 'runner-1',
+    resourceType: ResourceType.BOX,
+    resourceId: 'box-1',
+    type: JobType.START_BOX,
+    status,
+    startedAt: new Date('2026-07-29T04:00:00.000Z'),
+    completedAt: status === JobStatus.COMPLETED ? new Date('2026-07-29T04:05:00.000Z') : null,
+  } as Job
+}
+
+function makeService(transactionalJob: Job) {
+  let transactionCommitted = false
+  const entityManager = {
+    findOne: jest.fn().mockResolvedValue(transactionalJob),
+    save: jest.fn(async (_entity: unknown, job: Job) => job),
+  }
+  const jobRepository = {
+    manager: {
+      transaction: jest.fn(async (callback: (manager: typeof entityManager) => Promise<unknown>) => {
+        const result = await callback(entityManager)
+        transactionCommitted = true
+        return result
+      }),
+    },
+    findOneBy: jest.fn(),
+    save: jest.fn(async (job: Job) => job),
+  }
+  const jobStateHandlerService = {
+    handleJobCompletion: jest.fn(() => {
+      expect(transactionCommitted).toBe(true)
+      return Promise.resolve()
+    }),
+  }
+  const service = new JobService(jobRepository as any, {} as any, jobStateHandlerService as any)
+  return { entityManager, jobRepository, jobStateHandlerService, service }
+}
+
+describe('JobService.updateJobStatus transaction boundary', () => {
+  it('locks, validates, and saves the Job in one transaction before completion handling', async () => {
+    const job = makeJob(JobStatus.IN_PROGRESS)
+    const { entityManager, jobRepository, jobStateHandlerService, service } = makeService(job)
+
+    await expect(service.updateJobStatus(job.id, JobStatus.COMPLETED)).resolves.toBe(job)
+
+    expect(jobRepository.manager.transaction).toHaveBeenCalledTimes(1)
+    expect(entityManager.findOne).toHaveBeenCalledWith(Job, {
+      where: { id: job.id },
+      lock: { mode: 'pessimistic_write' },
+    })
+    expect(entityManager.save).toHaveBeenCalledWith(Job, job)
+    expect(jobRepository.findOneBy).not.toHaveBeenCalled()
+    expect(jobRepository.save).not.toHaveBeenCalled()
+    expect(jobStateHandlerService.handleJobCompletion).toHaveBeenCalledWith(job)
+  })
+
+  it('rejects a stale FAILED update when the locked Job was already completed by reconciliation', async () => {
+    const lockedJob = makeJob(JobStatus.COMPLETED)
+    const staleJob = makeJob(JobStatus.IN_PROGRESS)
+    const { entityManager, jobRepository, jobStateHandlerService, service } = makeService(lockedJob)
+    jobRepository.findOneBy.mockResolvedValue(staleJob)
+
+    await expect(service.updateJobStatus(lockedJob.id, JobStatus.FAILED, 'stale failure')).rejects.toBeInstanceOf(
+      ConflictException,
+    )
+
+    expect(jobRepository.manager.transaction).toHaveBeenCalledTimes(1)
+    expect(jobRepository.findOneBy).not.toHaveBeenCalled()
+    expect(entityManager.save).not.toHaveBeenCalled()
+    expect(jobStateHandlerService.handleJobCompletion).not.toHaveBeenCalled()
+    expect(lockedJob.status).toBe(JobStatus.COMPLETED)
+  })
+
+  it('preserves idempotent completion handling after the transaction commits', async () => {
+    const completedJob = makeJob(JobStatus.COMPLETED)
+    const originalCompletedAt = completedJob.completedAt
+    const { entityManager, jobStateHandlerService, service } = makeService(completedJob)
+
+    await expect(
+      service.updateJobStatus(completedJob.id, JobStatus.COMPLETED, undefined, '{"daemonVersion":"new"}'),
+    ).resolves.toBe(completedJob)
+
+    expect(entityManager.save).toHaveBeenCalledWith(Job, completedJob)
+    expect(completedJob.completedAt).not.toBe(originalCompletedAt)
+    expect(completedJob.resultMetadata).toBe('{"daemonVersion":"new"}')
+    expect(jobStateHandlerService.handleJobCompletion).toHaveBeenCalledWith(completedJob)
+  })
+})

--- a/apps/api/src/box/services/job.service.ts
+++ b/apps/api/src/box/services/job.service.ts
@@ -235,33 +235,38 @@ export class JobService {
     errorMessage?: string,
     resultMetadata?: string,
   ): Promise<Job> {
-    const job = await this.findOne(jobId)
-    if (!job) {
-      throw new NotFoundException(`Job with ID ${jobId} not found`)
-    }
+    const updatedJob = await this.jobRepository.manager.transaction(async (manager) => {
+      const job = await manager.findOne(Job, {
+        where: { id: jobId },
+        lock: { mode: 'pessimistic_write' },
+      })
+      if (!job) {
+        throw new NotFoundException(`Job with ID ${jobId} not found`)
+      }
 
-    if (!this.isValidStatusTransition(job.status, status)) {
-      throw new ConflictException(`Invalid job status transition from ${job.status} to ${status} for job ${jobId}`)
-    }
+      if (!this.isValidStatusTransition(job.status, status)) {
+        throw new ConflictException(`Invalid job status transition from ${job.status} to ${status} for job ${jobId}`)
+      }
 
-    job.status = status
-    if (errorMessage) {
-      job.errorMessage = errorMessage
-    }
+      job.status = status
+      if (errorMessage) {
+        job.errorMessage = errorMessage
+      }
 
-    if (status === JobStatus.IN_PROGRESS && !job.startedAt) {
-      job.startedAt = new Date()
-    }
+      if (status === JobStatus.IN_PROGRESS && !job.startedAt) {
+        job.startedAt = new Date()
+      }
 
-    if (status === JobStatus.COMPLETED || status === JobStatus.FAILED) {
-      job.completedAt = new Date()
-    }
+      if (status === JobStatus.COMPLETED || status === JobStatus.FAILED) {
+        job.completedAt = new Date()
+      }
 
-    if (resultMetadata) {
-      job.resultMetadata = resultMetadata
-    }
+      if (resultMetadata) {
+        job.resultMetadata = resultMetadata
+      }
 
-    const updatedJob = await this.jobRepository.save(job)
+      return manager.save(Job, job)
+    })
     this.logger.debug(`Updated job ${jobId} status to ${status}`)
 
     // Handle job completion for v2 runners - update box, artifact, or backup state.
@@ -469,24 +474,35 @@ export class JobService {
       return []
     }
 
-    // Update jobs to IN_PROGRESS
     const now = new Date()
+    // A single conditional UPDATE prevents a later-row error from leaving
+    // earlier claims committed. The status predicate retains the compare-and-swap,
+    // so a concurrent poll may still win a subset of these candidates.
+    const claim = await this.jobRepository.update(
+      {
+        id: In(jobs.map((job) => job.id)),
+        status: JobStatus.PENDING,
+      },
+      {
+        status: JobStatus.IN_PROGRESS,
+        startedAt: now,
+        updatedAt: now,
+      },
+      { returning: ['id'] },
+    )
+    const claimedIds = new Set((claim.raw as Array<Pick<Job, 'id'>>).map((row) => row.id))
     const claimedJobs: JobDto[] = []
 
     for (const job of jobs) {
-      try {
-        job.status = JobStatus.IN_PROGRESS
-        job.startedAt = now
-        job.updatedAt = now
-
-        // save() with @VersionColumn will automatically check version and throw OptimisticLockVersionMismatchError if changed
-        const savedJob = await this.jobRepository.save(job)
-
-        claimedJobs.push(new JobDto(savedJob))
-      } catch (error) {
-        // If optimistic lock fails, job was already claimed by another runner - skip it
-        this.logger.debug(`Job ${job.id} already claimed by another runner (version mismatch)`)
+      if (!claimedIds.has(job.id)) {
+        this.logger.debug(`Job ${job.id} was already claimed by a concurrent poll`)
+        continue
       }
+
+      job.status = JobStatus.IN_PROGRESS
+      job.startedAt = now
+      job.updatedAt = now
+      claimedJobs.push(new JobDto(job))
     }
 
     if (claimedJobs.length > 0) {

--- a/apps/api/src/config/configuration.ts
+++ b/apps/api/src/config/configuration.ts
@@ -435,6 +435,16 @@ const configuration = {
     throttleTtlSeconds: parseInt(process.env.BOX_ACTIVITY_THROTTLE_TTL_SECONDS || '5', 10),
     flushBatchSize: parseInt(process.env.BOX_ACTIVITY_FLUSH_BATCH_SIZE || '1000', 10),
   },
+  boxSync: {
+    // How long a claimed startup job may sit without completing before a
+    // runner reporting the box as started is allowed to close it out. This is
+    // a backstop for a lost job-completion callback, not a fast path: raise it
+    // if legitimate startups ever get closed out ahead of their own callback.
+    startConfirmationStallSeconds: parseInt(
+      process.env.BOX_SYNC_START_CONFIRMATION_STALL_SECONDS || '60',
+      10,
+    ),
+  },
   encryption: {
     key: process.env.ENCRYPTION_KEY,
     salt: process.env.ENCRYPTION_SALT,

--- a/apps/runner/pkg/boxlite/box_state_mapping_test.go
+++ b/apps/runner/pkg/boxlite/box_state_mapping_test.go
@@ -14,7 +14,7 @@ import (
 // (sdks/c/src/info.rs status_to_str) rather than via the SDK's State constants,
 // so this file keeps compiling — and keeps failing behaviorally — if the
 // mapping and the constants it depends on are reverted together.
-func TestApiStateFromCore(t *testing.T) {
+func TestToBoxState(t *testing.T) {
 	for _, tc := range []struct {
 		core boxlite.State
 		want enums.BoxState
@@ -32,8 +32,8 @@ func TestApiStateFromCore(t *testing.T) {
 		{"unknown", enums.BoxStateUnknown},
 		{"a-status-core-gained-later", enums.BoxStateUnknown},
 	} {
-		if got := apiStateFromCore(tc.core); got != tc.want {
-			t.Errorf("apiStateFromCore(%q) = %q, want %q", tc.core, got, tc.want)
+		if got := ToBoxState(tc.core); got != tc.want {
+			t.Errorf("ToBoxState(%q) = %q, want %q", tc.core, got, tc.want)
 		}
 	}
 }
@@ -41,9 +41,9 @@ func TestApiStateFromCore(t *testing.T) {
 // Every status the runtime can currently report must reach a state other than
 // Unknown, which the API bills as compute-consuming. This list is maintained by
 // hand, so it catches a mapping that regresses — not a status the core adds.
-func TestApiStateFromCoreLeavesNoCurrentStatusUnmapped(t *testing.T) {
+func TestToBoxStateLeavesNoCurrentStatusUnmapped(t *testing.T) {
 	for _, status := range []boxlite.State{"configured", "running", "stopping", "stopped", "paused", "failed"} {
-		if got := apiStateFromCore(status); got == enums.BoxStateUnknown {
+		if got := ToBoxState(status); got == enums.BoxStateUnknown {
 			t.Errorf("core status %q fell through to Unknown", status)
 		}
 	}

--- a/apps/runner/pkg/boxlite/client.go
+++ b/apps/runner/pkg/boxlite/client.go
@@ -11,8 +11,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -135,47 +133,11 @@ func buildImageRegistries(insecureRegistries []string, ghcrUsername, ghcrToken s
 	return registries
 }
 
-// boxliteHomeEnv mirrors the environment variable BoxLite itself consults when
-// no home directory is configured (src/boxlite/src/runtime/constants.rs).
-const boxliteHomeEnv = "BOXLITE_HOME"
-
-// boxliteHomeDirName mirrors BoxLite's default home directory name
-// (src/boxlite/src/runtime/layout.rs, dirs::BOXLITE_DIR).
-const boxliteHomeDirName = ".boxlite"
-
-// resolveHomeDir reproduces BoxLite's own home-directory resolution so the
-// runner and the runtime always name the same directory. Returns "" only when
-// the user's home cannot be determined, which leaves BoxLite to fall back on
-// its default exactly as it did before.
-func resolveHomeDir(configured string) string {
-	if configured != "" {
-		return configured
-	}
-	if fromEnv := os.Getenv(boxliteHomeEnv); fromEnv != "" {
-		return fromEnv
-	}
-	userHome, err := os.UserHomeDir()
-	if err != nil {
-		return ""
-	}
-	return filepath.Join(userHome, boxliteHomeDirName)
-}
-
-// HomeDir returns the resolved BoxLite data directory this client writes to.
-func (c *Client) HomeDir() string {
-	return c.homeDir
-}
-
 // NewClient creates a new BoxLite client backed by the BoxLite VM runtime.
 func NewClient(ctx context.Context, config ClientConfig) (*Client, error) {
 	var opts []boxlite.RuntimeOption
-	// Resolve the home directory here rather than letting BoxLite fall back to
-	// its own default. Services that read files out of the box home (BoxSync
-	// reads each box's start record) need the same path BoxLite writes to, and
-	// an unset HomeDir would leave the two sides guessing separately.
-	homeDir := resolveHomeDir(config.HomeDir)
-	if homeDir != "" {
-		opts = append(opts, boxlite.WithHomeDir(homeDir))
+	if config.HomeDir != "" {
+		opts = append(opts, boxlite.WithHomeDir(config.HomeDir))
 	}
 	insecureRegistries := normalizeRegistryHosts(config.InsecureRegistries)
 	registries := buildImageRegistries(insecureRegistries, config.GhcrUsername, config.GhcrToken)
@@ -209,7 +171,7 @@ func NewClient(ctx context.Context, config ClientConfig) (*Client, error) {
 	return &Client{
 		runtime:            rt,
 		logger:             logger,
-		homeDir:            homeDir,
+		homeDir:            config.HomeDir,
 		boxes:              make(map[string]*boxlite.Box),
 		awsRegion:          config.AWSRegion,
 		awsEndpointUrl:     config.AWSEndpointUrl,
@@ -338,12 +300,12 @@ func (c *Client) Create(ctx context.Context, boxDto dto.CreateBoxDTO) (string, s
 
 	// bx.Start must stay the last step of Create that can fail.
 	//
-	// A successful Start makes BoxLite write the box's start record, and
-	// BoxSync reads that record as evidence this job body succeeded — it is
-	// what lets a lost job-completion callback be repaired later. A fallible
-	// step added below would publish that evidence for a Create that then
-	// returns an error, and the two would disagree with no way to tell which
-	// is right. TestCreateHasNoFallibleStepAfterStart enforces this.
+	// A successful Start makes BoxLite publish the box's StartedAt,
+	// and BoxSync reads it as evidence this job body succeeded — it is what
+	// lets a lost job-completion callback be repaired later. A fallible step
+	// added below would publish that evidence for a Create that then returns
+	// an error, and the two would disagree with no way to tell which is right.
+	// TestCreateHasNoFallibleStepAfterStart enforces this.
 	skipStart := boxDto.SkipStart != nil && *boxDto.SkipStart
 	if !skipStart {
 		if err := bx.Start(ctx); err != nil {
@@ -405,34 +367,16 @@ func (c *Client) Destroy(ctx context.Context, boxId string) error {
 	return nil
 }
 
-// GetBoxState returns the current state of a box.
+// ToBoxState maps a box's local lifecycle state onto the control plane's
+// vocabulary, one arm per state the runtime can report. Unknown is not a
+// neutral default: the API counts it as compute-consuming while Error is not,
+// so Failed must map explicitly to Error.
 //
-// It reads through the runtime rather than the handle cache. The box sync loop
-// calls this for every box on a 10s ticker (services/box_sync.go), and a state
-// read needs no bootable handle — only the persisted record. Routing it through
-// getOrFetchBox would evict and re-fetch a handle for every non-running box on
-// every tick, and eviction cannot free the old one (see evictBox), so the
-// runner would accumulate dead handles for as long as it ran.
-func (c *Client) GetBoxState(ctx context.Context, boxId string) (enums.BoxState, error) {
-	info, err := c.runtime.GetInfo(ctx, boxId)
-	if err != nil {
-		if boxlite.IsNotFound(err) {
-			return enums.BoxStateUnknown, nil
-		}
-		return enums.BoxStateUnknown, err
-	}
-
-	return apiStateFromCore(info.State), nil
-}
-
-// apiStateFromCore maps a core box status onto the control-plane state, one arm
-// per BoxStatus the runtime can report.
-//
-// Unknown is not a neutral default here: the API counts it as compute-consuming
-// (BOX_STATES_CONSUMING_COMPUTE), while Error is not. Falling through left a
-// Failed box billed as if it were still running, and a Stopping box reported as
-// Unknown even though the control plane has that exact state.
-func apiStateFromCore(state boxlite.State) enums.BoxState {
+// Exported apart from GetBoxState because a caller that already holds a
+// BoxInfo must not fetch a second one: BoxSync pairs the state with the box's
+// StartedAt, and reading the two at different moments is what lets a stale
+// timestamp meet a fresh state.
+func ToBoxState(state boxlite.State) enums.BoxState {
 	switch state {
 	case boxlite.StateRunning:
 		return enums.BoxStateStarted
@@ -453,6 +397,26 @@ func apiStateFromCore(state boxlite.State) enums.BoxState {
 	default:
 		return enums.BoxStateUnknown
 	}
+}
+
+// GetBoxState returns the current state of a box.
+//
+// It reads through the runtime rather than the handle cache. The box sync loop
+// calls this for every box on a 10s ticker (services/box_sync.go), and a state
+// read needs no bootable handle — only the persisted record. Routing it through
+// getOrFetchBox would evict and re-fetch a handle for every non-running box on
+// every tick, and eviction cannot free the old one (see evictBox), so the
+// runner would accumulate dead handles for as long as it ran.
+func (c *Client) GetBoxState(ctx context.Context, boxId string) (enums.BoxState, error) {
+	info, err := c.runtime.GetInfo(ctx, boxId)
+	if err != nil {
+		if boxlite.IsNotFound(err) {
+			return enums.BoxStateUnknown, nil
+		}
+		return enums.BoxStateUnknown, err
+	}
+
+	return ToBoxState(info.State), nil
 }
 
 // StartExecution starts an interactive execution in a box.

--- a/apps/runner/pkg/boxlite/client.go
+++ b/apps/runner/pkg/boxlite/client.go
@@ -11,6 +11,8 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -133,11 +135,47 @@ func buildImageRegistries(insecureRegistries []string, ghcrUsername, ghcrToken s
 	return registries
 }
 
+// boxliteHomeEnv mirrors the environment variable BoxLite itself consults when
+// no home directory is configured (src/boxlite/src/runtime/constants.rs).
+const boxliteHomeEnv = "BOXLITE_HOME"
+
+// boxliteHomeDirName mirrors BoxLite's default home directory name
+// (src/boxlite/src/runtime/layout.rs, dirs::BOXLITE_DIR).
+const boxliteHomeDirName = ".boxlite"
+
+// resolveHomeDir reproduces BoxLite's own home-directory resolution so the
+// runner and the runtime always name the same directory. Returns "" only when
+// the user's home cannot be determined, which leaves BoxLite to fall back on
+// its default exactly as it did before.
+func resolveHomeDir(configured string) string {
+	if configured != "" {
+		return configured
+	}
+	if fromEnv := os.Getenv(boxliteHomeEnv); fromEnv != "" {
+		return fromEnv
+	}
+	userHome, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(userHome, boxliteHomeDirName)
+}
+
+// HomeDir returns the resolved BoxLite data directory this client writes to.
+func (c *Client) HomeDir() string {
+	return c.homeDir
+}
+
 // NewClient creates a new BoxLite client backed by the BoxLite VM runtime.
 func NewClient(ctx context.Context, config ClientConfig) (*Client, error) {
 	var opts []boxlite.RuntimeOption
-	if config.HomeDir != "" {
-		opts = append(opts, boxlite.WithHomeDir(config.HomeDir))
+	// Resolve the home directory here rather than letting BoxLite fall back to
+	// its own default. Services that read files out of the box home (BoxSync
+	// reads each box's start record) need the same path BoxLite writes to, and
+	// an unset HomeDir would leave the two sides guessing separately.
+	homeDir := resolveHomeDir(config.HomeDir)
+	if homeDir != "" {
+		opts = append(opts, boxlite.WithHomeDir(homeDir))
 	}
 	insecureRegistries := normalizeRegistryHosts(config.InsecureRegistries)
 	registries := buildImageRegistries(insecureRegistries, config.GhcrUsername, config.GhcrToken)
@@ -171,7 +209,7 @@ func NewClient(ctx context.Context, config ClientConfig) (*Client, error) {
 	return &Client{
 		runtime:            rt,
 		logger:             logger,
-		homeDir:            config.HomeDir,
+		homeDir:            homeDir,
 		boxes:              make(map[string]*boxlite.Box),
 		awsRegion:          config.AWSRegion,
 		awsEndpointUrl:     config.AWSEndpointUrl,
@@ -298,6 +336,14 @@ func (c *Client) Create(ctx context.Context, boxDto dto.CreateBoxDTO) (string, s
 		boxDto.Image,
 	)
 
+	// bx.Start must stay the last step of Create that can fail.
+	//
+	// A successful Start makes BoxLite write the box's start record, and
+	// BoxSync reads that record as evidence this job body succeeded — it is
+	// what lets a lost job-completion callback be repaired later. A fallible
+	// step added below would publish that evidence for a Create that then
+	// returns an error, and the two would disagree with no way to tell which
+	// is right. TestCreateHasNoFallibleStepAfterStart enforces this.
 	skipStart := boxDto.SkipStart != nil && *boxDto.SkipStart
 	if !skipStart {
 		if err := bx.Start(ctx); err != nil {

--- a/apps/runner/pkg/boxlite/create_invariant_test.go
+++ b/apps/runner/pkg/boxlite/create_invariant_test.go
@@ -1,0 +1,107 @@
+// Copyright 2026 BoxLite AI
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package boxlite
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+// TestCreateHasNoFallibleStepAfterStart guards the coupling documented at the
+// bx.Start call in Create.
+//
+// A successful bx.Start makes BoxLite write the box's start record, which
+// BoxSync then reads as evidence that this whole job body succeeded. That only
+// holds while Start is the last step of Create that can fail. Nothing about
+// the current code enforces it — replacing the hardcoded daemon version with a
+// real probe, for instance, would silently break it — so this asserts the
+// shape of the source directly.
+//
+// The check is deliberately blunt: after the statement containing bx.Start,
+// every return in Create must end in a literal nil error.
+func TestCreateHasNoFallibleStepAfterStart(t *testing.T) {
+	fileSet := token.NewFileSet()
+	parsed, err := parser.ParseFile(fileSet, "client.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse client.go: %v", err)
+	}
+
+	create := findMethod(parsed, "Client", "Create")
+	if create == nil {
+		t.Fatal("Client.Create not found in client.go; update this guard if it was renamed")
+	}
+
+	startIndex := -1
+	for index, statement := range create.Body.List {
+		if containsCall(statement, "bx", "Start") {
+			startIndex = index
+			break
+		}
+	}
+	if startIndex < 0 {
+		t.Fatal("no bx.Start call in Client.Create; update this guard if the start step moved")
+	}
+
+	for _, statement := range create.Body.List[startIndex+1:] {
+		ast.Inspect(statement, func(node ast.Node) bool {
+			returnStatement, ok := node.(*ast.ReturnStmt)
+			if !ok || len(returnStatement.Results) == 0 {
+				return true
+			}
+			last := returnStatement.Results[len(returnStatement.Results)-1]
+			identifier, ok := last.(*ast.Ident)
+			if !ok || identifier.Name != "nil" {
+				t.Errorf(
+					"Client.Create returns a non-nil error at %s, after bx.Start already "+
+						"caused the start record to be written. Move the fallible step above "+
+						"bx.Start, or revisit the record's meaning.",
+					fileSet.Position(returnStatement.Pos()),
+				)
+			}
+			return true
+		})
+	}
+}
+
+func findMethod(file *ast.File, receiverType string, name string) *ast.FuncDecl {
+	for _, declaration := range file.Decls {
+		function, ok := declaration.(*ast.FuncDecl)
+		if !ok || function.Name.Name != name || function.Recv == nil || function.Body == nil {
+			continue
+		}
+		if len(function.Recv.List) != 1 {
+			continue
+		}
+		star, ok := function.Recv.List[0].Type.(*ast.StarExpr)
+		if !ok {
+			continue
+		}
+		if identifier, ok := star.X.(*ast.Ident); ok && identifier.Name == receiverType {
+			return function
+		}
+	}
+	return nil
+}
+
+func containsCall(node ast.Node, receiver string, method string) bool {
+	found := false
+	ast.Inspect(node, func(candidate ast.Node) bool {
+		call, ok := candidate.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		selector, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || selector.Sel.Name != method {
+			return true
+		}
+		if identifier, ok := selector.X.(*ast.Ident); ok && identifier.Name == receiver {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}

--- a/apps/runner/pkg/boxlite/create_invariant_test.go
+++ b/apps/runner/pkg/boxlite/create_invariant_test.go
@@ -4,24 +4,23 @@
 package boxlite
 
 import (
+	"fmt"
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"strings"
 	"testing"
 )
 
 // TestCreateHasNoFallibleStepAfterStart guards the coupling documented at the
 // bx.Start call in Create.
 //
-// A successful bx.Start makes BoxLite write the box's start record, which
-// BoxSync then reads as evidence that this whole job body succeeded. That only
-// holds while Start is the last step of Create that can fail. Nothing about
-// the current code enforces it — replacing the hardcoded daemon version with a
-// real probe, for instance, would silently break it — so this asserts the
-// shape of the source directly.
-//
-// The check is deliberately blunt: after the statement containing bx.Start,
-// every return in Create must end in a literal nil error.
+// A successful bx.Start makes BoxLite publish the box's StartedAt, which
+// BoxSync reads as evidence that this whole job body succeeded. That only holds
+// while Start is the last step of Create that can fail. Nothing about the
+// current code enforces it — replacing the hardcoded daemon version with a real
+// probe, for instance, would silently break it — so this asserts the shape of
+// the source directly.
 func TestCreateHasNoFallibleStepAfterStart(t *testing.T) {
 	fileSet := token.NewFileSet()
 	parsed, err := parser.ParseFile(fileSet, "client.go", nil, 0)
@@ -34,36 +33,237 @@ func TestCreateHasNoFallibleStepAfterStart(t *testing.T) {
 		t.Fatal("Client.Create not found in client.go; update this guard if it was renamed")
 	}
 
-	startIndex := -1
-	for index, statement := range create.Body.List {
-		if containsCall(statement, "bx", "Start") {
-			startIndex = index
-			break
-		}
+	violations, err := fallibleReturnsAfterStart(fileSet, create)
+	if err != nil {
+		t.Fatalf("%v", err)
 	}
-	if startIndex < 0 {
-		t.Fatal("no bx.Start call in Client.Create; update this guard if the start step moved")
+	for _, violation := range violations {
+		t.Errorf(
+			"Client.Create returns a non-nil error at %s, after bx.Start already "+
+				"published StartedAt. Move the fallible step above bx.Start, or "+
+				"revisit what that timestamp means.",
+			violation,
+		)
+	}
+}
+
+// TestFallibleReturnsAfterStart exercises the guard itself. Its first version
+// keyed off the index of the *top-level statement* containing bx.Start, so a
+// fallible step added beside the call — inside the same `if !skipStart` block,
+// which is where Create actually puts it — fell outside the scanned range and
+// went unreported.
+func TestFallibleReturnsAfterStart(t *testing.T) {
+	const shapeCreateUses = `package boxlite
+
+func (c *Client) Create(ctx context.Context, boxDto dto.CreateBoxDTO) (string, string, error) {
+	bx, err := c.runtime.GetOrCreate(ctx, opts, boxDto.Id)
+	if err != nil {
+		return "", "", err
 	}
 
-	for _, statement := range create.Body.List[startIndex+1:] {
-		ast.Inspect(statement, func(node ast.Node) bool {
-			returnStatement, ok := node.(*ast.ReturnStmt)
-			if !ok || len(returnStatement.Results) == 0 {
-				return true
+	skipStart := boxDto.SkipStart != nil && *boxDto.SkipStart
+	if !skipStart {
+		if err := bx.Start(ctx); START_CONDITION {
+// START_GUARD_BODY
+			return bx.ID(), "", fmt.Errorf("failed to start box: %w", err)
+		}
+// POST_START
+	}
+
+	return bx.ID(), "boxlite", nil
+}
+`
+
+	tests := []struct {
+		name           string
+		startCondition string
+		startGuardBody string
+		postStart      string
+		wantViolations int
+		wantShapeError bool
+	}{
+		{
+			name:           "nothing after the start",
+			wantViolations: 0,
+		},
+		{
+			name: "fallible step in the same block as the start",
+			postStart: `		if err := c.registerBox(ctx, bx); err != nil {
+			return bx.ID(), "", err
+		}`,
+			wantViolations: 1,
+		},
+		{
+			name: "fallible step nested deeper in that block",
+			postStart: `		for _, mount := range boxDto.Volumes {
+			if err := c.mount(ctx, bx, mount); err != nil {
+				return bx.ID(), "", err
 			}
-			last := returnStatement.Results[len(returnStatement.Results)-1]
-			identifier, ok := last.(*ast.Ident)
-			if !ok || identifier.Name != "nil" {
-				t.Errorf(
-					"Client.Create returns a non-nil error at %s, after bx.Start already "+
-						"caused the start record to be written. Move the fallible step above "+
-						"bx.Start, or revisit the record's meaning.",
-					fileSet.Position(returnStatement.Pos()),
-				)
+		}`,
+			wantViolations: 1,
+		},
+		{
+			name: "step whose failure is swallowed",
+			postStart: `		if err := c.warmCache(ctx, bx); err != nil {
+			c.logger.WarnContext(ctx, "warm cache failed", "error", err)
+		}`,
+			wantViolations: 0,
+		},
+		{
+			name:           "inverted start guard",
+			startCondition: "err == nil",
+			startGuardBody: `			if err := c.registerBox(ctx, bx); err != nil {
+				return bx.ID(), "", err
+			}`,
+			wantShapeError: true,
+		},
+		{
+			name:           "start guard checks a different error",
+			startCondition: "startErr != nil",
+			wantShapeError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			startCondition := tt.startCondition
+			if startCondition == "" {
+				startCondition = "err != nil"
 			}
-			return true
+			source := strings.Replace(shapeCreateUses, "START_CONDITION", startCondition, 1)
+			source = strings.Replace(source, "// START_GUARD_BODY", tt.startGuardBody, 1)
+			source = strings.Replace(source, "// POST_START", tt.postStart, 1)
+			fileSet := token.NewFileSet()
+			parsed, err := parser.ParseFile(fileSet, "synthetic.go", source, 0)
+			if err != nil {
+				t.Fatalf("parse synthetic source: %v", err)
+			}
+
+			create := findMethod(parsed, "Client", "Create")
+			if create == nil {
+				t.Fatal("synthetic source lost Client.Create")
+			}
+
+			violations, err := fallibleReturnsAfterStart(fileSet, create)
+			if tt.wantShapeError {
+				if err == nil {
+					t.Fatal("expected malformed start-guard error, got nil")
+				}
+				if !strings.Contains(err.Error(), "no longer of the form") {
+					t.Fatalf("got error %q, want malformed start-guard error", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("%v", err)
+			}
+			if len(violations) != tt.wantViolations {
+				t.Fatalf("got %d violations %v, want %d", len(violations), violations, tt.wantViolations)
+			}
 		})
 	}
+}
+
+// fallibleReturnsAfterStart reports every return in fn that can carry a non-nil
+// error once bx.Start has already succeeded, as printable positions.
+//
+// Scoping is by source position rather than by statement index: the call sits
+// inside a block, so "after it" has to mean after the call itself, at any depth,
+// not after the top-level statement that encloses it.
+//
+// The start's own error handler is the one exemption — it runs precisely when
+// the call did *not* succeed, so nothing was published. Recognising it requires
+// the `if err := bx.Start(ctx); err != nil` shape; anything else is reported as
+// an error rather than guessed at, because a guard that silently stops covering
+// the invariant is worse than no guard.
+func fallibleReturnsAfterStart(fileSet *token.FileSet, fn *ast.FuncDecl) ([]string, error) {
+	var startCall *ast.CallExpr
+	var startGuard *ast.IfStmt
+	malformedStartGuard := false
+	ast.Inspect(fn.Body, func(node ast.Node) bool {
+		if startCall != nil || malformedStartGuard {
+			return false
+		}
+		ifStatement, ok := node.(*ast.IfStmt)
+		if !ok || ifStatement.Init == nil {
+			return true
+		}
+		if findCall(ifStatement.Init, "bx", "Start") == nil {
+			return true
+		}
+		startCall = startCallFromErrorGuard(ifStatement)
+		if startCall == nil {
+			malformedStartGuard = true
+			return false
+		}
+		startGuard = ifStatement
+		return false
+	})
+
+	if startCall == nil {
+		if findCall(fn.Body, "bx", "Start") == nil {
+			return nil, fmt.Errorf(
+				"no bx.Start call in %s; update this guard if the start step moved",
+				fn.Name.Name,
+			)
+		}
+		return nil, fmt.Errorf(
+			"bx.Start in %s is no longer of the form `if err := bx.Start(ctx); err != nil`; "+
+				"this guard cannot tell its own error handler from a later fallible step — "+
+				"update it to match the new shape",
+			fn.Name.Name,
+		)
+	}
+
+	var violations []string
+	ast.Inspect(fn.Body, func(node ast.Node) bool {
+		returnStatement, ok := node.(*ast.ReturnStmt)
+		if !ok || len(returnStatement.Results) == 0 || returnStatement.Pos() < startCall.End() {
+			return true
+		}
+		if returnStatement.Pos() >= startGuard.Body.Pos() && returnStatement.End() <= startGuard.Body.End() {
+			return true
+		}
+		last := returnStatement.Results[len(returnStatement.Results)-1]
+		if identifier, ok := last.(*ast.Ident); ok && identifier.Name == "nil" {
+			return true
+		}
+		violations = append(violations, fileSet.Position(returnStatement.Pos()).String())
+		return true
+	})
+
+	return violations, nil
+}
+
+func startCallFromErrorGuard(ifStatement *ast.IfStmt) *ast.CallExpr {
+	assignment, ok := ifStatement.Init.(*ast.AssignStmt)
+	if !ok || assignment.Tok != token.DEFINE || len(assignment.Lhs) != 1 || len(assignment.Rhs) != 1 {
+		return nil
+	}
+
+	errorIdentifier, ok := assignment.Lhs[0].(*ast.Ident)
+	if !ok {
+		return nil
+	}
+	startCall, ok := assignment.Rhs[0].(*ast.CallExpr)
+	if !ok || !isCall(startCall, "bx", "Start") {
+		return nil
+	}
+
+	condition, ok := ifStatement.Cond.(*ast.BinaryExpr)
+	if !ok || condition.Op != token.NEQ {
+		return nil
+	}
+	conditionError, ok := condition.X.(*ast.Ident)
+	if !ok || conditionError.Name != errorIdentifier.Name {
+		return nil
+	}
+	conditionNil, ok := condition.Y.(*ast.Ident)
+	if !ok || conditionNil.Name != "nil" {
+		return nil
+	}
+
+	return startCall
 }
 
 func findMethod(file *ast.File, receiverType string, name string) *ast.FuncDecl {
@@ -86,22 +286,30 @@ func findMethod(file *ast.File, receiverType string, name string) *ast.FuncDecl 
 	return nil
 }
 
-func containsCall(node ast.Node, receiver string, method string) bool {
-	found := false
+func findCall(node ast.Node, receiver string, method string) *ast.CallExpr {
+	var found *ast.CallExpr
 	ast.Inspect(node, func(candidate ast.Node) bool {
+		if found != nil {
+			return false
+		}
 		call, ok := candidate.(*ast.CallExpr)
 		if !ok {
 			return true
 		}
-		selector, ok := call.Fun.(*ast.SelectorExpr)
-		if !ok || selector.Sel.Name != method {
-			return true
-		}
-		if identifier, ok := selector.X.(*ast.Ident); ok && identifier.Name == receiver {
-			found = true
+		if isCall(call, receiver, method) {
+			found = call
 			return false
 		}
 		return true
 	})
 	return found
+}
+
+func isCall(call *ast.CallExpr, receiver string, method string) bool {
+	selector, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || selector.Sel.Name != method {
+		return false
+	}
+	identifier, ok := selector.X.(*ast.Ident)
+	return ok && identifier.Name == receiver
 }

--- a/apps/runner/pkg/services/box_sync.go
+++ b/apps/runner/pkg/services/box_sync.go
@@ -6,15 +6,26 @@ package services
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"time"
 
 	apiclient "github.com/boxlite-ai/boxlite/libs/api-client-go"
+	sdkboxlite "github.com/boxlite-ai/boxlite/sdks/go"
 	runnerapiclient "github.com/boxlite-ai/runner/pkg/apiclient"
 	blclient "github.com/boxlite-ai/runner/pkg/boxlite"
 	"github.com/boxlite-ai/runner/pkg/models/enums"
 )
+
+// boxStateReader is the slice of the BoxLite client this service needs, kept
+// narrow so the sync loop can be exercised without a live runtime.
+type boxStateReader interface {
+	ListInfo(ctx context.Context) ([]sdkboxlite.BoxInfo, error)
+	GetBoxState(ctx context.Context, boxID string) (enums.BoxState, error)
+}
 
 type BoxSyncServiceConfig struct {
 	Logger   *slog.Logger
@@ -24,26 +35,37 @@ type BoxSyncServiceConfig struct {
 
 type BoxSyncService struct {
 	log      *slog.Logger
-	boxlite  *blclient.Client
+	boxlite  boxStateReader
+	homeDir  string
 	interval time.Duration
 	client   *apiclient.APIClient
+}
+
+// localContainerState pairs a box's local runtime state with the durable
+// evidence that the current shim actually launched its init.
+type localContainerState struct {
+	state enums.BoxState
+	// startedAt is non-nil only when BoxLite recorded a successful
+	// Container.Start for the shim this box is running right now.
+	startedAt *time.Time
 }
 
 func NewBoxSyncService(config BoxSyncServiceConfig) *BoxSyncService {
 	return &BoxSyncService{
 		log:      config.Logger.With(slog.String("component", "box_sync_service")),
 		boxlite:  config.Boxlite,
+		homeDir:  config.Boxlite.HomeDir(),
 		interval: config.Interval,
 	}
 }
 
-func (s *BoxSyncService) GetLocalContainerStates(ctx context.Context) (map[string]enums.BoxState, error) {
+func (s *BoxSyncService) GetLocalContainerStates(ctx context.Context) (map[string]localContainerState, error) {
 	boxes, err := s.boxlite.ListInfo(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list boxes: %w", err)
 	}
 
-	boxStates := make(map[string]enums.BoxState)
+	boxStates := make(map[string]localContainerState, len(boxes))
 	for _, box := range boxes {
 		boxId := box.Name
 		if boxId == "" {
@@ -56,13 +78,92 @@ func (s *BoxSyncService) GetLocalContainerStates(ctx context.Context) (map[strin
 			continue
 		}
 
-		boxStates[boxId] = state
+		// The record lives under BoxLite's own id for the box, which is not
+		// always the key the control plane uses (that one prefers the name).
+		boxStates[boxId] = localContainerState{
+			state:     state,
+			startedAt: readStartedRecord(s.homeDir, box.ID, box.PID),
+		}
 	}
 
 	return boxStates, nil
 }
 
+// startedRecord mirrors StartedRecord in src/boxlite/src/runtime/layout.rs,
+// written by BoxLite once a box's guest Container.Start returns success.
+type startedRecord struct {
+	PID      int   `json:"pid"`
+	AtUnixMs int64 `json:"at_unix_ms"`
+}
+
+// readStartedRecord returns when BoxLite last confirmed a successful
+// Container.Start for the shim currently running this box, or nil when there
+// is no such evidence.
+//
+// The PID cross-check is what makes the record trustworthy: BoxLite clears it
+// at the start of every new lifecycle, and pairing it with the box's live PID
+// closes the remaining window where a record could survive the shim it names.
+func readStartedRecord(homeDir string, boxID string, livePID int) *time.Time {
+	if homeDir == "" || boxID == "" || livePID <= 0 {
+		return nil
+	}
+
+	contents, err := os.ReadFile(filepath.Join(homeDir, "boxes", boxID, "started"))
+	if err != nil {
+		return nil
+	}
+
+	var record startedRecord
+	if err := json.Unmarshal(contents, &record); err != nil {
+		return nil
+	}
+	if record.PID != livePID || record.AtUnixMs <= 0 {
+		return nil
+	}
+
+	startedAt := time.UnixMilli(record.AtUnixMs)
+	return &startedAt
+}
+
 func (s *BoxSyncService) GetRemoteBoxStates(ctx context.Context) (map[string]apiclient.BoxState, error) {
+	remoteBoxes, err := s.fetchRunnerBoxes(ctx, string(apiclient.BOXSTATE_STARTED), true)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get boxes from API: %w", err)
+	}
+
+	// Boxes the control plane still believes are coming up. Fetching them is
+	// what lets the existing mismatch loop below repair a startup whose job
+	// completion never landed.
+	//
+	// An API that predates this query rejects the transitional states with a
+	// 400. That must not cost us the STARTED reconciliation above, which has
+	// worked on its own for far longer — so the failure degrades to "no
+	// candidates this tick" instead of failing the whole sync.
+	transitional, err := s.fetchRunnerBoxes(
+		ctx,
+		string(apiclient.BOXSTATE_CREATING)+","+string(apiclient.BOXSTATE_STARTING),
+		false,
+	)
+	if err != nil {
+		s.log.DebugContext(
+			ctx,
+			"Transitional box query unavailable; skipping start confirmation this cycle",
+			"error", err,
+		)
+		return remoteBoxes, nil
+	}
+	for boxId, state := range transitional {
+		remoteBoxes[boxId] = state
+	}
+
+	return remoteBoxes, nil
+}
+
+func (s *BoxSyncService) fetchRunnerBoxes(
+	ctx context.Context,
+	states string,
+	skipReconcilingBoxes bool,
+) (map[string]apiclient.BoxState, error) {
 	if s.client == nil {
 		client, err := runnerapiclient.GetApiClient()
 		if err != nil {
@@ -70,16 +171,17 @@ func (s *BoxSyncService) GetRemoteBoxStates(ctx context.Context) (map[string]api
 		}
 		s.client = client
 	}
+
 	boxes, _, err := s.client.BoxAPI.GetBoxesForRunner(ctx).
-		States(string(apiclient.BOXSTATE_STARTED)).SkipReconcilingBoxes(true).
+		States(states).SkipReconcilingBoxes(skipReconcilingBoxes).
 		Execute()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get boxes from API: %w", err)
+		return nil, err
 	}
 
-	remoteBoxes := make(map[string]apiclient.BoxState)
+	remoteBoxes := make(map[string]apiclient.BoxState, len(boxes))
 	for _, box := range boxes {
-		if box.Id != "" {
+		if box.Id != "" && box.State != nil {
 			remoteBoxes[box.Id] = *box.State
 		}
 	}
@@ -110,7 +212,7 @@ func (s *BoxSyncService) PerformSync(ctx context.Context) error {
 	}
 
 	syncCount := 0
-	for boxId, localState := range localStates {
+	for boxId, local := range localStates {
 		remoteState, exists := remoteStates[boxId]
 		if !exists {
 			continue
@@ -118,10 +220,14 @@ func (s *BoxSyncService) PerformSync(ctx context.Context) error {
 
 		convertedRemoteState := s.convertFromApiState(remoteState)
 
-		if localState != convertedRemoteState {
-			s.log.InfoContext(ctx, "State mismatch for box", "boxId", boxId, "localState", localState, "remoteState", convertedRemoteState)
+		if local.state != convertedRemoteState {
+			if !s.canReport(local, remoteState) {
+				continue
+			}
 
-			err := s.SyncBoxState(ctx, boxId, localState)
+			s.log.InfoContext(ctx, "State mismatch for box", "boxId", boxId, "localState", local.state, "remoteState", convertedRemoteState)
+
+			err := s.SyncBoxState(ctx, boxId, local.state)
 			if err != nil {
 				s.log.ErrorContext(ctx, "Failed to sync state for box", "boxId", boxId, "error", err)
 				continue
@@ -135,6 +241,27 @@ func (s *BoxSyncService) PerformSync(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// canReport decides whether this runner may state its local view to the
+// control plane for a given remote state.
+//
+// A box the control plane still shows as coming up is the one case where the
+// local view is not self-evidently authoritative: BoxLite publishes Running
+// once the VM is up, which happens before the guest's separate Container.Start
+// runs. Reporting STARTED off that alone would call a box ready whose init was
+// never launched — so a transitional box additionally needs BoxLite's durable
+// record that Container.Start did succeed for the shim now running it.
+//
+// Every other remote state keeps the long-standing behaviour: the local view
+// wins unconditionally.
+func (s *BoxSyncService) canReport(local localContainerState, remoteState apiclient.BoxState) bool {
+	switch remoteState {
+	case apiclient.BOXSTATE_CREATING, apiclient.BOXSTATE_STARTING:
+		return local.state == enums.BoxStateStarted && local.startedAt != nil
+	default:
+		return true
+	}
 }
 
 func (s *BoxSyncService) StartSyncProcess(ctx context.Context) {

--- a/apps/runner/pkg/services/box_sync.go
+++ b/apps/runner/pkg/services/box_sync.go
@@ -6,11 +6,8 @@ package services
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log/slog"
-	"os"
-	"path/filepath"
 	"time"
 
 	apiclient "github.com/boxlite-ai/boxlite/libs/api-client-go"
@@ -24,7 +21,6 @@ import (
 // narrow so the sync loop can be exercised without a live runtime.
 type boxStateReader interface {
 	ListInfo(ctx context.Context) ([]sdkboxlite.BoxInfo, error)
-	GetBoxState(ctx context.Context, boxID string) (enums.BoxState, error)
 }
 
 type BoxSyncServiceConfig struct {
@@ -36,17 +32,17 @@ type BoxSyncServiceConfig struct {
 type BoxSyncService struct {
 	log      *slog.Logger
 	boxlite  boxStateReader
-	homeDir  string
 	interval time.Duration
 	client   *apiclient.APIClient
 }
 
-// localContainerState pairs a box's local runtime state with the durable
-// evidence that the current shim actually launched its init.
+// localContainerState pairs a box's local runtime state with its durable
+// Container.Start timestamp from the same BoxInfo snapshot.
 type localContainerState struct {
 	state enums.BoxState
-	// startedAt is non-nil only when BoxLite recorded a successful
-	// Container.Start for the shim this box is running right now.
+	// startedAt is non-nil when BoxLite recorded a successful Container.Start
+	// for the current or most recently ended lifecycle. Callers combine it with
+	// state before treating it as evidence that the box is running now.
 	startedAt *time.Time
 }
 
@@ -54,7 +50,6 @@ func NewBoxSyncService(config BoxSyncServiceConfig) *BoxSyncService {
 	return &BoxSyncService{
 		log:      config.Logger.With(slog.String("component", "box_sync_service")),
 		boxlite:  config.Boxlite,
-		homeDir:  config.Boxlite.HomeDir(),
 		interval: config.Interval,
 	}
 }
@@ -72,56 +67,28 @@ func (s *BoxSyncService) GetLocalContainerStates(ctx context.Context) (map[strin
 			boxId = box.ID
 		}
 
-		state, err := s.boxlite.GetBoxState(ctx, boxId)
-		if err != nil {
-			s.log.DebugContext(ctx, "Failed to get state for box", "boxId", boxId, "error", err)
-			continue
-		}
-
-		// The record lives under BoxLite's own id for the box, which is not
-		// always the key the control plane uses (that one prefers the name).
 		boxStates[boxId] = localContainerState{
-			state:     state,
-			startedAt: readStartedRecord(s.homeDir, box.ID, box.PID),
+			state:     blclient.ToBoxState(box.State),
+			startedAt: boxStartedAt(box),
 		}
 	}
 
 	return boxStates, nil
 }
 
-// startedRecord mirrors StartedRecord in src/boxlite/src/runtime/layout.rs,
-// written by BoxLite once a box's guest Container.Start returns success.
-type startedRecord struct {
-	PID      int   `json:"pid"`
-	AtUnixMs int64 `json:"at_unix_ms"`
-}
-
-// readStartedRecord returns when BoxLite last confirmed a successful
-// Container.Start for the shim currently running this box, or nil when there
-// is no such evidence.
+// boxStartedAt reports when BoxLite confirmed a successful Container.Start for
+// the current or most recently ended lifecycle, or nil when no lifecycle has
+// such confirmation.
 //
-// The PID cross-check is what makes the record trustworthy: BoxLite clears it
-// at the start of every new lifecycle, and pairing it with the box's live PID
-// closes the remaining window where a record could survive the shim it names.
-func readStartedRecord(homeDir string, boxID string, livePID int) *time.Time {
-	if homeDir == "" || boxID == "" || livePID <= 0 {
+// BoxLite publishes the timestamp beside the PID it belongs to and voids it in
+// the same write that publishes a new lifecycle's PID. That only buys the
+// reader anything while state and timestamp come from one snapshot, which is
+// why both are read off the same `BoxInfo`.
+func boxStartedAt(box sdkboxlite.BoxInfo) *time.Time {
+	if box.StartedAt.IsZero() {
 		return nil
 	}
-
-	contents, err := os.ReadFile(filepath.Join(homeDir, "boxes", boxID, "started"))
-	if err != nil {
-		return nil
-	}
-
-	var record startedRecord
-	if err := json.Unmarshal(contents, &record); err != nil {
-		return nil
-	}
-	if record.PID != livePID || record.AtUnixMs <= 0 {
-		return nil
-	}
-
-	startedAt := time.UnixMilli(record.AtUnixMs)
+	startedAt := box.StartedAt
 	return &startedAt
 }
 
@@ -145,7 +112,7 @@ func (s *BoxSyncService) GetRemoteBoxStates(ctx context.Context) (map[string]api
 		false,
 	)
 	if err != nil {
-		s.log.DebugContext(
+		s.log.WarnContext(
 			ctx,
 			"Transitional box query unavailable; skipping start confirmation this cycle",
 			"error", err,
@@ -251,7 +218,8 @@ func (s *BoxSyncService) PerformSync(ctx context.Context) error {
 // once the VM is up, which happens before the guest's separate Container.Start
 // runs. Reporting STARTED off that alone would call a box ready whose init was
 // never launched — so a transitional box additionally needs BoxLite's durable
-// record that Container.Start did succeed for the shim now running it.
+// record that Container.Start did succeed for the shim now running it. Both
+// facts come from one `BoxInfo`, so they cannot describe two lifecycles.
 //
 // Every other remote state keeps the long-standing behaviour: the local view
 // wins unconditionally.

--- a/apps/runner/pkg/services/box_sync_test.go
+++ b/apps/runner/pkg/services/box_sync_test.go
@@ -1,0 +1,294 @@
+// Copyright 2026 BoxLite AI
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	apiclient "github.com/boxlite-ai/boxlite/libs/api-client-go"
+	sdkboxlite "github.com/boxlite-ai/boxlite/sdks/go"
+	"github.com/boxlite-ai/runner/pkg/models/enums"
+)
+
+// writeStartedRecord lays down the file BoxLite writes after a successful
+// guest Container.Start, in the layout box_impl.rs uses.
+func writeStartedRecord(t *testing.T, homeDir string, boxID string, contents string) {
+	t.Helper()
+	boxDir := filepath.Join(homeDir, "boxes", boxID)
+	if err := os.MkdirAll(boxDir, 0o755); err != nil {
+		t.Fatalf("create box dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(boxDir, "started"), []byte(contents), 0o644); err != nil {
+		t.Fatalf("write start record: %v", err)
+	}
+}
+
+func TestReadStartedRecord(t *testing.T) {
+	const livePID = 4242
+	startedAt := time.UnixMilli(1_769_000_000_123)
+
+	tests := []struct {
+		name     string
+		contents string
+		// omitRecord skips writing the file entirely.
+		omitRecord bool
+		livePID    int
+		want       *time.Time
+	}{
+		{
+			name:     "record written by the live shim",
+			contents: fmt.Sprintf(`{"pid":%d,"at_unix_ms":%d}`, livePID, startedAt.UnixMilli()),
+			livePID:  livePID,
+			want:     &startedAt,
+		},
+		{
+			name:     "record left by a previous shim",
+			contents: fmt.Sprintf(`{"pid":%d,"at_unix_ms":%d}`, livePID-1, startedAt.UnixMilli()),
+			livePID:  livePID,
+			want:     nil,
+		},
+		{
+			name:       "no record at all",
+			omitRecord: true,
+			livePID:    livePID,
+			want:       nil,
+		},
+		{
+			name:     "truncated record",
+			contents: `{"pid":4242,"at_un`,
+			livePID:  livePID,
+			want:     nil,
+		},
+		{
+			name:     "record without a timestamp",
+			contents: fmt.Sprintf(`{"pid":%d}`, livePID),
+			livePID:  livePID,
+			want:     nil,
+		},
+		{
+			name:     "box has no live pid",
+			contents: fmt.Sprintf(`{"pid":%d,"at_unix_ms":%d}`, livePID, startedAt.UnixMilli()),
+			livePID:  0,
+			want:     nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			homeDir := t.TempDir()
+			if !tt.omitRecord {
+				writeStartedRecord(t, homeDir, "box-1", tt.contents)
+			}
+
+			got := readStartedRecord(homeDir, "box-1", tt.livePID)
+
+			switch {
+			case tt.want == nil && got != nil:
+				t.Fatalf("readStartedRecord() = %s, want nil", got)
+			case tt.want != nil && got == nil:
+				t.Fatalf("readStartedRecord() = nil, want %s", tt.want)
+			case tt.want != nil && !got.Equal(*tt.want):
+				t.Fatalf("readStartedRecord() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+// stubBoxReader serves a fixed set of boxes to the sync loop.
+type stubBoxReader struct {
+	infos  []sdkboxlite.BoxInfo
+	states map[string]enums.BoxState
+}
+
+func (r *stubBoxReader) ListInfo(context.Context) ([]sdkboxlite.BoxInfo, error) {
+	return r.infos, nil
+}
+
+func (r *stubBoxReader) GetBoxState(_ context.Context, boxID string) (enums.BoxState, error) {
+	state, ok := r.states[boxID]
+	if !ok {
+		return enums.BoxStateUnknown, fmt.Errorf("box %s not found", boxID)
+	}
+	return state, nil
+}
+
+// remoteBox builds the wire shape the generated client requires for a Box —
+// it rejects a payload missing any required property, so the optional fields
+// this test cares about have to travel with the mandatory scaffolding.
+func remoteBox(id string, state apiclient.BoxState) map[string]any {
+	return map[string]any{
+		"id":              id,
+		"organizationId":  "org-1",
+		"name":            id,
+		"user":            "boxlite",
+		"env":             map[string]string{},
+		"labels":          map[string]string{},
+		"public":          false,
+		"networkBlockAll": false,
+		"target":          "eu",
+		"cpu":             1,
+		"gpu":             0,
+		"memory":          1,
+		"disk":            1,
+		"toolboxProxyUrl": "https://proxy.invalid",
+		"state":           string(state),
+	}
+}
+
+// runnerAPIStub records the state updates the sync loop pushes and can be told
+// to reject the transitional-state query the way an older API does.
+type runnerAPIStub struct {
+	transitionalBoxes    []map[string]any
+	rejectTransitional   bool
+	startedBoxes         []map[string]any
+	updates              map[string]string
+	transitionalRequests int
+}
+
+func (s *runnerAPIStub) handler(t *testing.T) http.Handler {
+	t.Helper()
+	return http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		response.Header().Set("Content-Type", "application/json")
+
+		if request.Method == http.MethodGet && request.URL.Path == "/box/for-runner" {
+			if request.URL.Query().Get("states") == string(apiclient.BOXSTATE_STARTED) {
+				_ = json.NewEncoder(response).Encode(s.startedBoxes)
+				return
+			}
+			s.transitionalRequests++
+			if s.rejectTransitional {
+				response.WriteHeader(http.StatusBadRequest)
+				_, _ = response.Write([]byte(`{"message":"State creating does not have a corresponding desired state"}`))
+				return
+			}
+			_ = json.NewEncoder(response).Encode(s.transitionalBoxes)
+			return
+		}
+
+		if request.Method == http.MethodPut {
+			var body struct {
+				State string `json:"state"`
+			}
+			if err := json.NewDecoder(request.Body).Decode(&body); err != nil {
+				t.Errorf("decode state update: %v", err)
+			}
+			if s.updates == nil {
+				s.updates = map[string]string{}
+			}
+			// /box/{boxId}/state
+			s.updates[request.URL.Path] = body.State
+			response.WriteHeader(http.StatusOK)
+			return
+		}
+
+		t.Errorf("unexpected request %s %s", request.Method, request.URL.Path)
+		response.WriteHeader(http.StatusNotFound)
+	})
+}
+
+func newSyncServiceForTest(
+	server *httptest.Server,
+	reader boxStateReader,
+	homeDir string,
+) *BoxSyncService {
+	config := apiclient.NewConfiguration()
+	config.Servers = apiclient.ServerConfigurations{{URL: server.URL}}
+	config.HTTPClient = server.Client()
+
+	return &BoxSyncService{
+		log:     slog.Default(),
+		boxlite: reader,
+		homeDir: homeDir,
+		client:  apiclient.NewAPIClient(config),
+	}
+}
+
+func TestPerformSyncConfirmsTransitionalBoxOnlyWithAStartRecord(t *testing.T) {
+	tests := []struct {
+		name          string
+		writeRecord   bool
+		recordPID     int
+		wantStateSent bool
+	}{
+		{name: "start record matches the live shim", writeRecord: true, recordPID: 77, wantStateSent: true},
+		{name: "no start record", writeRecord: false, wantStateSent: false},
+		{name: "start record names a dead shim", writeRecord: true, recordPID: 76, wantStateSent: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			homeDir := t.TempDir()
+			if tt.writeRecord {
+				writeStartedRecord(t, homeDir, "box-1",
+					fmt.Sprintf(`{"pid":%d,"at_unix_ms":%d}`, tt.recordPID, time.Now().UnixMilli()))
+			}
+
+			api := &runnerAPIStub{
+				startedBoxes: []map[string]any{},
+				transitionalBoxes: []map[string]any{
+					remoteBox("box-1", apiclient.BOXSTATE_CREATING),
+				},
+			}
+			server := httptest.NewServer(api.handler(t))
+			defer server.Close()
+
+			reader := &stubBoxReader{
+				infos:  []sdkboxlite.BoxInfo{{ID: "box-1", State: sdkboxlite.StateRunning, PID: 77}},
+				states: map[string]enums.BoxState{"box-1": enums.BoxStateStarted},
+			}
+
+			service := newSyncServiceForTest(server, reader, homeDir)
+			if err := service.PerformSync(context.Background()); err != nil {
+				t.Fatalf("PerformSync: %v", err)
+			}
+
+			sentState, sent := api.updates["/box/box-1/state"]
+			if sent != tt.wantStateSent {
+				t.Fatalf("state update sent = %v (%q), want %v", sent, sentState, tt.wantStateSent)
+			}
+			if tt.wantStateSent && sentState != string(apiclient.BOXSTATE_STARTED) {
+				t.Fatalf("reported state = %q, want %q", sentState, apiclient.BOXSTATE_STARTED)
+			}
+		})
+	}
+}
+
+// An API that predates the transitional-state query rejects it. The
+// long-standing STARTED reconciliation must survive that on its own.
+func TestPerformSyncStillReconcilesStartedBoxesWhenTransitionalQueryIsRejected(t *testing.T) {
+	api := &runnerAPIStub{
+		rejectTransitional: true,
+		startedBoxes: []map[string]any{
+			remoteBox("box-gone", apiclient.BOXSTATE_STARTED),
+		},
+	}
+	server := httptest.NewServer(api.handler(t))
+	defer server.Close()
+
+	reader := &stubBoxReader{
+		infos:  []sdkboxlite.BoxInfo{{ID: "box-gone", State: sdkboxlite.StateStopped, PID: 0}},
+		states: map[string]enums.BoxState{"box-gone": enums.BoxStateStopped},
+	}
+
+	service := newSyncServiceForTest(server, reader, t.TempDir())
+	if err := service.PerformSync(context.Background()); err != nil {
+		t.Fatalf("PerformSync must not fail when the transitional query is rejected: %v", err)
+	}
+
+	if api.transitionalRequests == 0 {
+		t.Fatal("transitional query was never attempted")
+	}
+	if got := api.updates["/box/box-gone/state"]; got != string(apiclient.BOXSTATE_STOPPED) {
+		t.Fatalf("stopped box reported as %q, want %q", got, apiclient.BOXSTATE_STOPPED)
+	}
+}

--- a/apps/runner/pkg/services/box_sync_test.go
+++ b/apps/runner/pkg/services/box_sync_test.go
@@ -6,99 +6,49 @@ package services
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
-	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
 	apiclient "github.com/boxlite-ai/boxlite/libs/api-client-go"
 	sdkboxlite "github.com/boxlite-ai/boxlite/sdks/go"
-	"github.com/boxlite-ai/runner/pkg/models/enums"
 )
 
-// writeStartedRecord lays down the file BoxLite writes after a successful
-// guest Container.Start, in the layout box_impl.rs uses.
-func writeStartedRecord(t *testing.T, homeDir string, boxID string, contents string) {
-	t.Helper()
-	boxDir := filepath.Join(homeDir, "boxes", boxID)
-	if err := os.MkdirAll(boxDir, 0o755); err != nil {
-		t.Fatalf("create box dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(boxDir, "started"), []byte(contents), 0o644); err != nil {
-		t.Fatalf("write start record: %v", err)
-	}
-}
-
-func TestReadStartedRecord(t *testing.T) {
-	const livePID = 4242
+// boxStartedAt only converts BoxInfo's zero-value convention. The sync decision
+// interprets the result together with State from the same BoxInfo snapshot.
+func TestBoxStartedAt(t *testing.T) {
 	startedAt := time.UnixMilli(1_769_000_000_123)
 
 	tests := []struct {
-		name     string
-		contents string
-		// omitRecord skips writing the file entirely.
-		omitRecord bool
-		livePID    int
-		want       *time.Time
+		name string
+		info sdkboxlite.BoxInfo
+		want *time.Time
 	}{
 		{
-			name:     "record written by the live shim",
-			contents: fmt.Sprintf(`{"pid":%d,"at_unix_ms":%d}`, livePID, startedAt.UnixMilli()),
-			livePID:  livePID,
-			want:     &startedAt,
+			name: "box reports a confirmed container start",
+			info: sdkboxlite.BoxInfo{ID: "box-1", PID: 4242, StartedAt: startedAt},
+			want: &startedAt,
 		},
 		{
-			name:     "record left by a previous shim",
-			contents: fmt.Sprintf(`{"pid":%d,"at_unix_ms":%d}`, livePID-1, startedAt.UnixMilli()),
-			livePID:  livePID,
-			want:     nil,
-		},
-		{
-			name:       "no record at all",
-			omitRecord: true,
-			livePID:    livePID,
-			want:       nil,
-		},
-		{
-			name:     "truncated record",
-			contents: `{"pid":4242,"at_un`,
-			livePID:  livePID,
-			want:     nil,
-		},
-		{
-			name:     "record without a timestamp",
-			contents: fmt.Sprintf(`{"pid":%d}`, livePID),
-			livePID:  livePID,
-			want:     nil,
-		},
-		{
-			name:     "box has no live pid",
-			contents: fmt.Sprintf(`{"pid":%d,"at_unix_ms":%d}`, livePID, startedAt.UnixMilli()),
-			livePID:  0,
-			want:     nil,
+			name: "running box whose init was never launched",
+			info: sdkboxlite.BoxInfo{ID: "box-1", PID: 4242},
+			want: nil,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			homeDir := t.TempDir()
-			if !tt.omitRecord {
-				writeStartedRecord(t, homeDir, "box-1", tt.contents)
-			}
-
-			got := readStartedRecord(homeDir, "box-1", tt.livePID)
+			got := boxStartedAt(tt.info)
 
 			switch {
 			case tt.want == nil && got != nil:
-				t.Fatalf("readStartedRecord() = %s, want nil", got)
+				t.Fatalf("boxStartedAt() = %s, want nil", got)
 			case tt.want != nil && got == nil:
-				t.Fatalf("readStartedRecord() = nil, want %s", tt.want)
+				t.Fatalf("boxStartedAt() = nil, want %s", tt.want)
 			case tt.want != nil && !got.Equal(*tt.want):
-				t.Fatalf("readStartedRecord() = %s, want %s", got, tt.want)
+				t.Fatalf("boxStartedAt() = %s, want %s", got, tt.want)
 			}
 		})
 	}
@@ -106,20 +56,11 @@ func TestReadStartedRecord(t *testing.T) {
 
 // stubBoxReader serves a fixed set of boxes to the sync loop.
 type stubBoxReader struct {
-	infos  []sdkboxlite.BoxInfo
-	states map[string]enums.BoxState
+	infos []sdkboxlite.BoxInfo
 }
 
 func (r *stubBoxReader) ListInfo(context.Context) ([]sdkboxlite.BoxInfo, error) {
 	return r.infos, nil
-}
-
-func (r *stubBoxReader) GetBoxState(_ context.Context, boxID string) (enums.BoxState, error) {
-	state, ok := r.states[boxID]
-	if !ok {
-		return enums.BoxStateUnknown, fmt.Errorf("box %s not found", boxID)
-	}
-	return state, nil
 }
 
 // remoteBox builds the wire shape the generated client requires for a Box —
@@ -199,7 +140,6 @@ func (s *runnerAPIStub) handler(t *testing.T) http.Handler {
 func newSyncServiceForTest(
 	server *httptest.Server,
 	reader boxStateReader,
-	homeDir string,
 ) *BoxSyncService {
 	config := apiclient.NewConfiguration()
 	config.Servers = apiclient.ServerConfigurations{{URL: server.URL}}
@@ -208,31 +148,22 @@ func newSyncServiceForTest(
 	return &BoxSyncService{
 		log:     slog.Default(),
 		boxlite: reader,
-		homeDir: homeDir,
 		client:  apiclient.NewAPIClient(config),
 	}
 }
 
-func TestPerformSyncConfirmsTransitionalBoxOnlyWithAStartRecord(t *testing.T) {
+func TestPerformSyncConfirmsTransitionalBoxOnlyWithAConfirmedStart(t *testing.T) {
 	tests := []struct {
 		name          string
-		writeRecord   bool
-		recordPID     int
+		startedAt     time.Time
 		wantStateSent bool
 	}{
-		{name: "start record matches the live shim", writeRecord: true, recordPID: 77, wantStateSent: true},
-		{name: "no start record", writeRecord: false, wantStateSent: false},
-		{name: "start record names a dead shim", writeRecord: true, recordPID: 76, wantStateSent: false},
+		{name: "container start confirmed", startedAt: time.Now(), wantStateSent: true},
+		{name: "running but init never launched", wantStateSent: false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			homeDir := t.TempDir()
-			if tt.writeRecord {
-				writeStartedRecord(t, homeDir, "box-1",
-					fmt.Sprintf(`{"pid":%d,"at_unix_ms":%d}`, tt.recordPID, time.Now().UnixMilli()))
-			}
-
 			api := &runnerAPIStub{
 				startedBoxes: []map[string]any{},
 				transitionalBoxes: []map[string]any{
@@ -243,11 +174,15 @@ func TestPerformSyncConfirmsTransitionalBoxOnlyWithAStartRecord(t *testing.T) {
 			defer server.Close()
 
 			reader := &stubBoxReader{
-				infos:  []sdkboxlite.BoxInfo{{ID: "box-1", State: sdkboxlite.StateRunning, PID: 77}},
-				states: map[string]enums.BoxState{"box-1": enums.BoxStateStarted},
+				infos: []sdkboxlite.BoxInfo{{
+					ID:        "box-1",
+					State:     sdkboxlite.StateRunning,
+					PID:       77,
+					StartedAt: tt.startedAt,
+				}},
 			}
 
-			service := newSyncServiceForTest(server, reader, homeDir)
+			service := newSyncServiceForTest(server, reader)
 			if err := service.PerformSync(context.Background()); err != nil {
 				t.Fatalf("PerformSync: %v", err)
 			}
@@ -276,11 +211,10 @@ func TestPerformSyncStillReconcilesStartedBoxesWhenTransitionalQueryIsRejected(t
 	defer server.Close()
 
 	reader := &stubBoxReader{
-		infos:  []sdkboxlite.BoxInfo{{ID: "box-gone", State: sdkboxlite.StateStopped, PID: 0}},
-		states: map[string]enums.BoxState{"box-gone": enums.BoxStateStopped},
+		infos: []sdkboxlite.BoxInfo{{ID: "box-gone", State: sdkboxlite.StateStopped, PID: 0}},
 	}
 
-	service := newSyncServiceForTest(server, reader, t.TempDir())
+	service := newSyncServiceForTest(server, reader)
 	if err := service.PerformSync(context.Background()); err != nil {
 		t.Fatalf("PerformSync must not fail when the transitional query is rejected: %v", err)
 	}

--- a/docs/reference/cli/README.md
+++ b/docs/reference/cli/README.md
@@ -463,12 +463,16 @@ Show detailed information for one or more boxes.
 | `--format FMT` | `-f` | `json` | `json`, `yaml`, or a Go template (e.g. `'{{.State.Status}}'`) |
 
 The Go-template engine exposes a `json` function for serializing nested values.
+`State.StartedAt` is the most recent successful container start timestamp in
+RFC 3339 format, or `null` if it has not been recorded or is unavailable over
+REST.
 
 **Examples:**
 
 ```bash
 boxlite inspect mybox
 boxlite inspect --format '{{.State.Status}}' mybox
+boxlite inspect --format '{{.State.StartedAt}}' mybox
 boxlite inspect -l --format yaml
 ```
 

--- a/docs/reference/nodejs/README.md
+++ b/docs/reference/nodejs/README.md
@@ -219,6 +219,7 @@ Metadata about a box.
 | `name` | `string \| undefined` | User-defined name |
 | `state` | `JsBoxStateInfo` | Runtime state with `status`, `running`, and optional `pid` fields |
 | `createdAt` | `string` | Creation timestamp (ISO 8601) |
+| `startedAt` | `string \| undefined` | Most recent successful container start timestamp (RFC 3339); absent if not recorded or unavailable over REST |
 | `image` | `string` | OCI image reference or rootfs path |
 | `cpus` | `number` | Allocated CPU count |
 | `memoryMib` | `number` | Allocated memory in MiB |

--- a/docs/reference/python/README.md
+++ b/docs/reference/python/README.md
@@ -246,6 +246,7 @@ Metadata about a box.
 | `name` | `str \| None` | Optional user-assigned name |
 | `state` | `BoxStateInfo` | Runtime state with `status`, `running`, and nullable `pid` fields |
 | `created_at` | `str` | ISO 8601 creation timestamp |
+| `started_at` | `str \| None` | Most recent successful container start timestamp (RFC 3339); `None` if not recorded or unavailable over REST |
 | `image` | `str` | OCI image used |
 | `cpus` | `int` | Allocated CPU cores |
 | `memory_mib` | `int` | Allocated memory in MiB |

--- a/sdks/c/include/boxlite.h
+++ b/sdks/c/include/boxlite.h
@@ -318,6 +318,12 @@ typedef struct CBoxInfo {
   int64_t created_at;
   // Owned typed network metadata; null when network metadata is unavailable.
   struct CNetworkInfo *network;
+  // Unix milliseconds of the most recently recorded successful guest
+  // `Container.Start`; `0` when none was recorded. Preserved after stop or
+  // reboot; when [`Self::pid`] is nonzero, the timestamp describes that live
+  // PID. Milliseconds — not `created_at`'s seconds — preserve sub-second
+  // ordering against a job's timeline.
+  int64_t started_at;
 } CBoxInfo;
 
 // Box info completion. On success the callback owns the non-null metadata and

--- a/sdks/c/src/event_queue.rs
+++ b/sdks/c/src/event_queue.rs
@@ -1260,6 +1260,10 @@ mod owned_ffi_ptr_nested_leak_tests {
             pid: 0,
             cpus: 1,
             memory_mib: 256,
+            auto_stop: 900,
+            auto_delete: 0,
+            auto_resume: 1,
+            created_at: 0,
             network: crate::info::network_to_c_ptr(&Some(NetworkInfo {
                 mode: NetworkMode::Enabled,
                 allow_net: vec!["api.example.com".to_string()],
@@ -1270,10 +1274,7 @@ mod owned_ffi_ptr_nested_leak_tests {
                     protocol: PortProtocol::Tcp,
                 }]),
             })),
-            created_at: 0,
-            auto_stop: 900,
-            auto_delete: 0,
-            auto_resume: 1,
+            started_at: 0,
         });
 
         let owned = OwnedFfiPtr::new_with(payload, crate::info::free_box_info_ptr);
@@ -1340,11 +1341,12 @@ mod owned_ffi_ptr_nested_leak_tests {
             pid: 0,
             cpus: 2,
             memory_mib: 512,
-            network: std::ptr::null_mut(),
-            created_at: 0,
             auto_stop: 900,
             auto_delete: 0,
             auto_resume: 1,
+            created_at: 0,
+            network: std::ptr::null_mut(),
+            started_at: 0,
         }];
         let items_ptr = items_vec.as_mut_ptr();
         let items_len = items_vec.len();

--- a/sdks/c/src/info.rs
+++ b/sdks/c/src/info.rs
@@ -78,6 +78,12 @@ pub struct CBoxInfo {
     pub created_at: i64,
     /// Owned typed network metadata; null when network metadata is unavailable.
     pub network: *mut CNetworkInfo,
+    /// Unix milliseconds of the most recently recorded successful guest
+    /// `Container.Start`; `0` when none was recorded. Preserved after stop or
+    /// reboot; when [`Self::pid`] is nonzero, the timestamp describes that live
+    /// PID. Milliseconds — not `created_at`'s seconds — preserve sub-second
+    /// ordering against a job's timeline.
+    pub started_at: i64,
 }
 
 #[repr(C)]
@@ -238,11 +244,12 @@ impl CBoxInfo {
             pid: info.pid.map(|p| p as c_int).unwrap_or(0),
             cpus: info.cpus as c_int,
             memory_mib: info.memory_mib as c_int,
-            network: network_to_c_ptr(&info.network),
             auto_stop: info.auto_stop,
             auto_delete: info.auto_delete,
             auto_resume: if info.auto_resume { 1 } else { 0 },
             created_at: info.created_at.timestamp(),
+            network: network_to_c_ptr(&info.network),
+            started_at: info.started_at.map(|at| at.timestamp_millis()).unwrap_or(0),
         }
     }
 }

--- a/sdks/c/tests/test_info.c
+++ b/sdks/c/tests/test_info.c
@@ -3,6 +3,7 @@
 #include <arpa/inet.h>
 #include <assert.h>
 #include <signal.h>
+#include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -10,6 +11,9 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
+
+_Static_assert(offsetof(CBoxInfo, network) < offsetof(CBoxInfo, started_at),
+               "CBoxInfo.started_at must follow network");
 
 /* The loopback REST server keeps this unit test VM-free. Its two distinct
  * responses prove boxlite_box_info fetches current metadata instead of
@@ -119,10 +123,10 @@ static void on_info(CBoxInfo *info, CBoxliteError *error, void *user_data) {
   InfoRequest *request = user_data;
   request->error_code = error->code;
   if (info != NULL) {
-    request->saw_expected_info = strcmp(info->id, "box1") == 0 &&
-                                 strcmp(info->status, "stopped") == 0 &&
-                                 info->running == 0 && info->pid == 0 &&
-                                 info->cpus == 2 && info->memory_mib == 512;
+    request->saw_expected_info =
+        strcmp(info->id, "box1") == 0 && strcmp(info->status, "stopped") == 0 &&
+        info->running == 0 && info->pid == 0 && info->cpus == 2 &&
+        info->memory_mib == 512 && info->started_at == 0;
     boxlite_free_box_info(info);
   }
   request->done = 1;

--- a/sdks/go/info.go
+++ b/sdks/go/info.go
@@ -61,6 +61,12 @@ type BoxInfo struct {
 	AutoDelete uint32
 	AutoResume bool
 	CreatedAt  time.Time
+	// StartedAt is when the guest's Container.Start most recently returned
+	// success; the zero time means no successful start has been recorded. It is
+	// preserved after stop or reboot, and describes PID whenever PID is nonzero.
+	// State alone cannot answer whether the current init launched — a box reports
+	// Running from the moment its VM is up, before its init is started.
+	StartedAt time.Time
 }
 
 // Info returns information about the box.
@@ -149,6 +155,10 @@ func (r *Runtime) GetInfo(ctx context.Context, idOrName string) (*BoxInfo, error
 
 func cBoxInfoToGo(info *C.CBoxInfo) BoxInfo {
 	pid := int(info.pid)
+	var boxStartedAt time.Time
+	if ms := int64(info.started_at); ms > 0 {
+		boxStartedAt = time.UnixMilli(ms)
+	}
 	return BoxInfo{
 		ID:         cString(info.id),
 		Name:       cString(info.name),
@@ -163,6 +173,8 @@ func cBoxInfoToGo(info *C.CBoxInfo) BoxInfo {
 		AutoDelete: uint32(info.auto_delete),
 		AutoResume: info.auto_resume != 0,
 		CreatedAt:  time.Unix(int64(info.created_at), 0),
+
+		StartedAt: boxStartedAt,
 	}
 }
 

--- a/sdks/node/lib/native-contracts.ts
+++ b/sdks/node/lib/native-contracts.ts
@@ -247,6 +247,7 @@ export interface JsBoxInfo {
   name?: string;
   state: JsBoxStateInfo;
   createdAt: string;
+  startedAt?: string;
   image: string;
   cpus: number;
   memoryMib: number;

--- a/sdks/node/src/info.rs
+++ b/sdks/node/src/info.rs
@@ -184,6 +184,9 @@ pub struct JsBoxInfo {
     /// Creation timestamp (ISO 8601 format)
     pub created_at: String,
 
+    /// Most recent successful container start timestamp (RFC 3339), when recorded
+    pub started_at: Option<String>,
+
     /// Image reference or rootfs path
     pub image: String,
 
@@ -226,6 +229,7 @@ impl From<BoxInfo> for JsBoxInfo {
             name: info.name,
             state,
             created_at: info.created_at.to_rfc3339(),
+            started_at: info.started_at.map(|at| at.to_rfc3339()),
             image: info.image,
             cpus: info.cpus,
             memory_mib: info.memory_mib,
@@ -244,7 +248,7 @@ impl From<BoxInfo> for JsBoxInfo {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
-    use std::time::SystemTime;
+    use std::time::{Duration, SystemTime};
 
     use boxlite::runtime::options::PortProtocol;
     use boxlite::{
@@ -273,6 +277,7 @@ mod tests {
             auto_resume: true,
             health_status: HealthStatus::default(),
             exit_code: None,
+            started_at: None,
         }
     }
 
@@ -333,5 +338,18 @@ mod tests {
             JsBoxInfo::from(core_info(None)).network,
             Either::B(_)
         ));
+    }
+
+    #[test]
+    fn box_info_conversion_exposes_started_at() {
+        let mut info = core_info(None);
+        info.started_at = Some((SystemTime::UNIX_EPOCH + Duration::from_secs(1)).into());
+
+        let started = JsBoxInfo::from(info);
+        assert_eq!(
+            started.started_at.as_deref(),
+            Some("1970-01-01T00:00:01+00:00")
+        );
+        assert!(JsBoxInfo::from(core_info(None)).started_at.is_none());
     }
 }

--- a/sdks/python/src/info.rs
+++ b/sdks/python/src/info.rs
@@ -285,6 +285,8 @@ pub(crate) struct PyBoxInfo {
     #[pyo3(get)]
     pub(crate) created_at: String,
     #[pyo3(get)]
+    pub(crate) started_at: Option<String>,
+    #[pyo3(get)]
     pub(crate) image: String,
     #[pyo3(get)]
     pub(crate) cpus: u8,
@@ -322,6 +324,7 @@ impl PyBoxInfo {
             "auto_delete": self.auto_delete,
             "auto_resume": self.auto_resume,
             "created_at": self.created_at,
+            "started_at": self.started_at,
             "health_status": {
                 "state": self.health_status.state.value,
                 "failures": self.health_status.failures,
@@ -346,6 +349,7 @@ impl From<BoxInfo> for PyBoxInfo {
             name: info.name,
             state,
             created_at: info.created_at.to_rfc3339(),
+            started_at: info.started_at.map(|at| at.to_rfc3339()),
             image: info.image,
             cpus: info.cpus,
             memory_mib: info.memory_mib,
@@ -361,7 +365,7 @@ impl From<BoxInfo> for PyBoxInfo {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
-    use std::time::SystemTime;
+    use std::time::{Duration, SystemTime};
 
     use boxlite::runtime::options::PortProtocol;
     use boxlite::{
@@ -388,6 +392,7 @@ mod tests {
             auto_resume: true,
             health_status: HealthStatus::default(),
             exit_code: None,
+            started_at: None,
         }
     }
 
@@ -442,5 +447,18 @@ mod tests {
         );
 
         assert!(PyBoxInfo::from(core_info(None)).network.is_none());
+    }
+
+    #[test]
+    fn box_info_conversion_exposes_started_at() {
+        let mut info = core_info(None);
+        info.started_at = Some((SystemTime::UNIX_EPOCH + Duration::from_secs(1)).into());
+
+        let started = PyBoxInfo::from(info);
+        assert_eq!(
+            started.started_at.as_deref(),
+            Some("1970-01-01T00:00:01+00:00")
+        );
+        assert!(PyBoxInfo::from(core_info(None)).started_at.is_none());
     }
 }

--- a/sdks/python/tests/test_box_management_mock.py
+++ b/sdks/python/tests/test_box_management_mock.py
@@ -101,6 +101,9 @@ class TestBoxInfoStructure:
     def test_has_created_at(self, box_info_cls):
         assert "created_at" in dir(box_info_cls)
 
+    def test_has_started_at(self, box_info_cls):
+        assert "started_at" in dir(box_info_cls)
+
     def test_has_image(self, box_info_cls):
         assert "image" in dir(box_info_cls)
 

--- a/src/boxlite/src/litebox/box_impl.rs
+++ b/src/boxlite/src/litebox/box_impl.rs
@@ -295,6 +295,12 @@ impl BoxImpl {
         let live = self.ensure_booted().await?;
         let started_now = self.ensure_container_started(live).await?;
 
+        // Nothing below may fail. `ensure_container_started` has already written
+        // the start record (see [`Self::write_started_record`]), and readers of
+        // that file — the cloud runner among them — take it as evidence that
+        // this whole call succeeded. A fallible step added here would publish
+        // that evidence for a start that then returned `Err`.
+        //
         // Announce the start only when *this* call actually ran init — not on an
         // idempotent re-`start()` or a reattach to an already-running box.
         if started_now {
@@ -994,7 +1000,47 @@ impl BoxImpl {
                 Ok::<(), BoxliteError>(())
             })
             .await?;
+        if started_here {
+            self.write_started_record();
+        }
         Ok(started_here)
+    }
+
+    /// Record that this lifecycle's `Container.Start` succeeded.
+    ///
+    /// The counterpart of the shim's `exit` file: one names how the box died,
+    /// this names that its init was launched. `init_live_state` removes it when
+    /// the next boot begins, so its presence is scoped to one physical shim.
+    ///
+    /// A failed write leaves no record and is logged, never propagated — the
+    /// guest RPC already succeeded and the box is running, so turning a
+    /// bookkeeping failure into a start failure would be a worse answer than
+    /// the missing record.
+    ///
+    /// **Callers downstream of this treat the file as evidence that the whole
+    /// start succeeded**, so `start()` must not grow a fallible step after
+    /// `ensure_container_started`. See the note at the tail of [`Self::start`].
+    fn write_started_record(&self) {
+        let Some(pid) = self.state.read().pid else {
+            tracing::warn!(
+                box_id = %self.config.id,
+                "Container.Start succeeded with no shim PID on record; start not recorded"
+            );
+            return;
+        };
+
+        let record = crate::runtime::layout::StartedRecord {
+            pid,
+            at_unix_ms: chrono::Utc::now().timestamp_millis(),
+        };
+        if let Err(error) = record.write(&self.layout.started_file_path()) {
+            tracing::error!(
+                box_id = %self.config.id,
+                pid,
+                error = %error,
+                "Container.Start succeeded but the start record could not be written"
+            );
+        }
     }
 
     /// The box's network control backend (gvproxy ServicesMux client), owned in
@@ -1049,6 +1095,27 @@ impl BoxImpl {
         // Hold the lock for the duration of build operations.
         // LockGuard acquires lock on creation and releases on drop.
         let _guard = LockGuard::new(&*locker);
+
+        // A new physical lifecycle starts here, so drop the start record the
+        // previous one left behind — the same discipline `Container.Init` keeps
+        // for the container's exit file. Adopting a *running* box is not a new
+        // lifecycle: its record still names the live shim and must survive.
+        //
+        // This is the single removal point. Everything downstream reads the
+        // record together with the box's live PID, so a record that outlives
+        // its shim is already inert; clearing here keeps it from being
+        // resurrected by the next boot.
+        if !adopting_running {
+            match std::fs::remove_file(self.layout.started_file_path()) {
+                Ok(()) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => tracing::warn!(
+                    box_id = %self.config.id,
+                    error = %e,
+                    "Failed to clear the previous lifecycle's start record"
+                ),
+            }
+        }
 
         // Build the box (lock is held)
         // The returned cleanup_guard stays armed until we disarm it after all

--- a/src/boxlite/src/litebox/box_impl.rs
+++ b/src/boxlite/src/litebox/box_impl.rs
@@ -295,11 +295,11 @@ impl BoxImpl {
         let live = self.ensure_booted().await?;
         let started_now = self.ensure_container_started(live).await?;
 
-        // Nothing below may fail. `ensure_container_started` has already written
-        // the start record (see [`Self::write_started_record`]), and readers of
-        // that file — the cloud runner among them — take it as evidence that
-        // this whole call succeeded. A fallible step added here would publish
-        // that evidence for a start that then returned `Err`.
+        // Nothing below may fail. `ensure_container_started` has already
+        // published `started_at` (see [`Self::record_started`]), and readers of
+        // it — the cloud runner among them — take it as evidence that this
+        // whole call succeeded. A fallible step added here would publish that
+        // evidence for a start that then returned `Err`.
         //
         // Announce the start only when *this* call actually ran init — not on an
         // idempotent re-`start()` or a reattach to an already-running box.
@@ -1001,44 +1001,40 @@ impl BoxImpl {
             })
             .await?;
         if started_here {
-            self.write_started_record();
+            self.record_started();
         }
         Ok(started_here)
     }
 
-    /// Record that this lifecycle's `Container.Start` succeeded.
+    /// Publish `started_at` for this lifecycle.
     ///
     /// The counterpart of the shim's `exit` file: one names how the box died,
-    /// this names that its init was launched. `init_live_state` removes it when
-    /// the next boot begins, so its presence is scoped to one physical shim.
+    /// this names that its init was launched. It rides in `BoxState` beside the
+    /// PID it belongs to, so the pair is written and read as one row and no
+    /// consumer has to re-derive which shim the timestamp describes.
     ///
-    /// A failed write leaves no record and is logged, never propagated — the
-    /// guest RPC already succeeded and the box is running, so turning a
-    /// bookkeeping failure into a start failure would be a worse answer than
-    /// the missing record.
+    /// A failed persist is logged, never propagated — the guest RPC already
+    /// succeeded and the box is running, so turning a bookkeeping failure into
+    /// a start failure would be a worse answer than the missing timestamp.
     ///
-    /// **Callers downstream of this treat the file as evidence that the whole
-    /// start succeeded**, so `start()` must not grow a fallible step after
-    /// `ensure_container_started`. See the note at the tail of [`Self::start`].
-    fn write_started_record(&self) {
-        let Some(pid) = self.state.read().pid else {
-            tracing::warn!(
-                box_id = %self.config.id,
-                "Container.Start succeeded with no shim PID on record; start not recorded"
-            );
-            return;
+    /// **Consumers treat this as evidence that the whole start succeeded**, so
+    /// `start()` must not grow a fallible step after `ensure_container_started`.
+    /// See the note at the tail of [`Self::start`].
+    fn record_started(&self) {
+        let (persist_result, pid) = {
+            let mut state = self.state.write();
+            state.mark_started();
+            let pid = state.pid;
+            let result = self.runtime.box_manager.save_box(&self.config.id, &state);
+            (result, pid)
         };
 
-        let record = crate::runtime::layout::StartedRecord {
-            pid,
-            at_unix_ms: chrono::Utc::now().timestamp_millis(),
-        };
-        if let Err(error) = record.write(&self.layout.started_file_path()) {
+        if let Err(error) = persist_result {
             tracing::error!(
                 box_id = %self.config.id,
-                pid,
+                pid = ?pid,
                 error = %error,
-                "Container.Start succeeded but the start record could not be written"
+                "Container.Start succeeded but the start could not be recorded"
             );
         }
     }
@@ -1096,27 +1092,6 @@ impl BoxImpl {
         // LockGuard acquires lock on creation and releases on drop.
         let _guard = LockGuard::new(&*locker);
 
-        // A new physical lifecycle starts here, so drop the start record the
-        // previous one left behind — the same discipline `Container.Init` keeps
-        // for the container's exit file. Adopting a *running* box is not a new
-        // lifecycle: its record still names the live shim and must survive.
-        //
-        // This is the single removal point. Everything downstream reads the
-        // record together with the box's live PID, so a record that outlives
-        // its shim is already inert; clearing here keeps it from being
-        // resurrected by the next boot.
-        if !adopting_running {
-            match std::fs::remove_file(self.layout.started_file_path()) {
-                Ok(()) => {}
-                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-                Err(e) => tracing::warn!(
-                    box_id = %self.config.id,
-                    error = %e,
-                    "Failed to clear the previous lifecycle's start record"
-                ),
-            }
-        }
-
         // Build the box (lock is held)
         // The returned cleanup_guard stays armed until we disarm it after all
         // operations succeed. If any operation fails, the guard's Drop will
@@ -1171,6 +1146,15 @@ impl BoxImpl {
             // clears ExitCode on start too). The guest drops its matching
             // exit file in Container.Init.
             state.exit_code = None;
+            // Same reasoning for the start record, and this is the write that
+            // makes it safe: publishing the new PID and voiding the previous
+            // lifecycle's evidence happen in one `save_box`, so no reader can
+            // ever see this shim paired with the last one's start. Adopting a
+            // *running* box is not a new lifecycle — its record still names the
+            // live shim and must survive.
+            if !adopting_running {
+                state.started_at = None;
+            }
 
             // Initialize health status if health check is configured
             if self.config.options.advanced.health_check.is_some() {
@@ -1553,6 +1537,127 @@ mod tests {
         fn pid(&self) -> u32 {
             self.0
         }
+    }
+
+    struct RecordStartedSaveGate {
+        entered: std::sync::mpsc::Sender<()>,
+        release: std::sync::mpsc::Receiver<()>,
+    }
+
+    static RECORD_STARTED_SAVE_GATE: std::sync::Mutex<Option<RecordStartedSaveGate>> =
+        std::sync::Mutex::new(None);
+
+    fn block_record_started_save(_: i32) -> bool {
+        let gate = RECORD_STARTED_SAVE_GATE
+            .lock()
+            .expect("record-started save gate lock poisoned")
+            .take();
+        let Some(gate) = gate else {
+            return false;
+        };
+
+        gate.entered.send(()).is_ok() && gate.release.recv().is_ok()
+    }
+
+    #[test]
+    fn record_started_holds_state_lock_until_persist_completes() {
+        let temp_dir = TempDir::new_in("/tmp").expect("create temp dir");
+        let runtime = RuntimeImpl::new_for_test(BoxliteOptions {
+            home_dir: temp_dir.path().to_path_buf(),
+            image_registries: vec![],
+        })
+        .expect("create runtime");
+
+        let id = BoxIDMint::mint();
+        let config = BoxConfig {
+            id: id.clone(),
+            name: None,
+            created_at: Utc::now(),
+            container: ContainerRuntimeConfig {
+                id: ContainerID::new(),
+            },
+            options: BoxOptions {
+                rootfs: RootfsSpec::Image("alpine:latest".into()),
+                detach: true,
+                auto_delete: Some(0),
+                ..Default::default()
+            },
+            engine_kind: VmmKind::Libkrun,
+            box_home: runtime.layout.boxes_dir().join(id.as_str()),
+        };
+        let mut state = BoxState::new();
+        state.status = BoxStatus::Running;
+        state.pid = Some(4242);
+        state.set_lock_id(runtime.lock_manager.allocate().expect("allocate lock"));
+        runtime
+            .box_manager
+            .add_box(&config, &state)
+            .expect("add box to manager");
+
+        let box_impl = Arc::new(BoxImpl::new(
+            config,
+            state,
+            runtime.clone(),
+            runtime.shutdown_token.child_token(),
+        ));
+        let (entered_tx, entered_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        *RECORD_STARTED_SAVE_GATE
+            .lock()
+            .expect("record-started save gate lock poisoned") = Some(RecordStartedSaveGate {
+            entered: entered_tx,
+            release: release_rx,
+        });
+
+        // Hold SQLite's writer lock so its busy handler marks the exact point
+        // where record_started has entered the real persistence operation.
+        let database = runtime.box_manager.db();
+        let db_path = {
+            let conn = database.conn();
+            conn.busy_handler(Some(block_record_started_save))
+                .expect("install busy handler");
+            conn.path().expect("database has a path").to_owned()
+        };
+        let blocker = rusqlite::Connection::open(db_path).expect("open blocking connection");
+        blocker
+            .execute_batch("BEGIN IMMEDIATE")
+            .expect("acquire SQLite write lock");
+
+        let worker_box = Arc::clone(&box_impl);
+        let worker = std::thread::spawn(move || worker_box.record_started());
+        let reached_persist = entered_rx.recv_timeout(Duration::from_secs(5)).is_ok();
+        let state_lock_held = reached_persist && box_impl.state.try_write().is_none();
+
+        blocker
+            .execute_batch("ROLLBACK")
+            .expect("release SQLite write lock");
+        let _ = release_tx.send(());
+        worker.join().expect("record-started worker panicked");
+        database
+            .conn()
+            .busy_handler(None)
+            .expect("remove database busy handler");
+        *RECORD_STARTED_SAVE_GATE
+            .lock()
+            .expect("record-started save gate lock poisoned") = None;
+
+        assert!(
+            reached_persist,
+            "record_started did not reach the real SQLite update"
+        );
+        assert!(
+            state_lock_held,
+            "record_started must hold the state write lock until persistence completes"
+        );
+        assert!(
+            runtime
+                .box_manager
+                .update_box(&id)
+                .expect("load persisted state")
+                .started_at
+                .is_some(),
+            "record_started must persist the start timestamp"
+        );
     }
 
     // Regression test for the silent-orphan bug in stop().

--- a/src/boxlite/src/litebox/state.rs
+++ b/src/boxlite/src/litebox/state.rs
@@ -232,6 +232,29 @@ pub struct BoxState {
     /// keeps existing DB rows readable without migration.
     #[serde(default)]
     pub exit_code: Option<i32>,
+    /// When the guest's `Container.Start` returned success for the lifecycle
+    /// that published [`Self::pid`] (docker's `State.StartedAt`).
+    ///
+    /// Deliberately not derivable from [`Self::status`]: booting only *creates*
+    /// the container, and `attach()` leaves a box `Running` with its init not
+    /// yet launched, so `Running` alone cannot answer "did this box's init
+    /// ever start". Survives a stop the way docker keeps `StartedAt` on an
+    /// exited container.
+    ///
+    /// **Invariant — a live PID in this row is always the one this timestamp
+    /// describes.** Exactly two writes can put a different shim's PID here, and
+    /// both void the timestamp: the one that publishes a new lifecycle's PID
+    /// (`BoxImpl::init_live_state`) and the one recovery branch that can adopt
+    /// a PID this row never published ([`Self::adopt_recovered_shim`]). The
+    /// lifecycle-ending writes ([`Self::mark_stop`], [`Self::mark_failed`],
+    /// [`Self::reset_for_reboot`]) instead clear only the PID and preserve
+    /// `Some(t)` — read that as "the run that just ended began at t", never as
+    /// "something is running". Readers therefore interpret the timestamp
+    /// together with the lifecycle state from the same snapshot.
+    ///
+    /// Serde default keeps existing DB rows readable without migration.
+    #[serde(default)]
+    pub started_at: Option<DateTime<Utc>>,
 }
 
 /// Health status of a box.
@@ -331,7 +354,31 @@ impl BoxState {
             health_status: HealthStatus::new(),
             error_reason: None,
             exit_code: None,
+            started_at: None,
         }
+    }
+
+    /// Record that this lifecycle's `Container.Start` returned success.
+    pub fn mark_started(&mut self) {
+        let now = Utc::now();
+        self.started_at = Some(now);
+        self.last_updated = now;
+    }
+
+    /// Adopt a live shim that recovery found on disk.
+    ///
+    /// The one place a PID can enter this row without having been published by
+    /// the boot that owns it: a crash between the shim writing its PID file and
+    /// the row being saved leaves the two naming different lifecycles. A
+    /// `started_at` written for the PID we are replacing cannot describe the
+    /// one we are adopting, so it goes with it — that is what lets every reader
+    /// take the timestamp at face value.
+    pub fn adopt_recovered_shim(&mut self, pid: u32) {
+        if self.pid != Some(pid) {
+            self.started_at = None;
+        }
+        self.set_pid(Some(pid));
+        self.set_status(BoxStatus::Running);
     }
 
     /// Set lock ID and update timestamp.
@@ -1013,5 +1060,79 @@ mod tests {
         assert_eq!(state.health_status.state, HealthState::None);
         assert_eq!(state.health_status.failures, 0);
         assert!(state.health_status.last_check.is_none());
+        assert!(
+            state.started_at.is_none(),
+            "a row written before this field existed cannot claim a launched init"
+        );
+    }
+
+    #[test]
+    fn adopting_the_recorded_shim_keeps_its_container_start() {
+        let mut state = BoxState::new();
+        state.set_pid(Some(4242));
+        state.mark_started();
+        let recorded = state.started_at;
+
+        state.adopt_recovered_shim(4242);
+
+        assert_eq!(
+            state.started_at, recorded,
+            "recovery re-attaching the same shim must not void the start it recorded"
+        );
+        assert_eq!(state.status, BoxStatus::Running);
+    }
+
+    #[test]
+    fn adopting_a_different_shim_voids_the_container_start() {
+        // A crash between the shim writing its PID file and this row being
+        // saved leaves recovery adopting a PID the row never published. The
+        // timestamp describes the PID it was written with, so it cannot
+        // survive that swap — every consumer reads the two as one fact.
+        let mut state = BoxState::new();
+        state.set_pid(Some(4242));
+        state.mark_started();
+
+        state.adopt_recovered_shim(4243);
+
+        assert_eq!(state.pid, Some(4243));
+        assert!(
+            state.started_at.is_none(),
+            "a start recorded for pid 4242 must not be read as evidence about pid 4243"
+        );
+    }
+
+    /// The three ways a lifecycle ends all keep the timestamp — docker's
+    /// `StartedAt` on an exited container. What makes that safe is that each
+    /// one drops the PID: `Some(started_at)` beside `pid: None` describes the
+    /// run that ended, and cannot be read as a live box.
+    #[test]
+    fn ending_a_lifecycle_keeps_the_start_and_drops_the_pid() {
+        let ended = |end: fn(&mut BoxState)| {
+            let mut state = BoxState::new();
+            state.set_pid(Some(4242));
+            state.set_status(BoxStatus::Running);
+            state.mark_started();
+            end(&mut state);
+            state
+        };
+
+        for (name, state) in [
+            ("mark_stop", ended(BoxState::mark_stop)),
+            ("mark_failed", ended(|s| s.mark_failed("boom"))),
+            ("reset_for_reboot", ended(BoxState::reset_for_reboot)),
+        ] {
+            assert!(
+                state.started_at.is_some(),
+                "{name} must keep the start of the run that just ended"
+            );
+            assert_eq!(
+                state.pid, None,
+                "{name} must drop the PID, or the kept start would read as a live box"
+            );
+            assert!(
+                !state.status.is_active(),
+                "{name} must leave the box inactive"
+            );
+        }
     }
 }

--- a/src/boxlite/src/rest/types.rs
+++ b/src/boxlite/src/rest/types.rs
@@ -311,6 +311,10 @@ impl BoxResponse {
             auto_resume: self.auto_resume,
             health_status: crate::litebox::HealthStatus::new(), // REST API doesn't provide health status
             exit_code: self.exit_code,
+            // Like `network`, this is local-lifecycle detail the remote REST
+            // surface does not publish; `None` says "not known here" rather
+            // than "init was never launched".
+            started_at: None,
         })
     }
 }

--- a/src/boxlite/src/runtime/layout.rs
+++ b/src/boxlite/src/runtime/layout.rs
@@ -1,7 +1,40 @@
 use crate::net::socket_path::BoxSockets;
 use boxlite_shared::errors::{BoxliteError, BoxliteResult};
 use boxlite_shared::layout::{SharedGuestLayout, dirs as shared_dirs};
+use serde::Serialize;
 use std::path::{Path, PathBuf};
+
+/// Contents of [`BoxFilesystemLayout::started_file_path`] — written by the host
+/// once the guest's `Container.Start` returns success for the current physical
+/// lifecycle.
+///
+/// It crosses a process boundary — BoxLite writes it, the cloud runner reads it
+/// straight out of the box home — so the schema is owned here rather than
+/// hand-rolled at the writing end. `pid` names the shim this record belongs to:
+/// the reader pairs it with the box's live PID and rejects a record that does
+/// not match, so a stale file can never be read as evidence about a later shim.
+///
+/// Write-only on this side by design. The reader is in another language, and a
+/// Rust `read` would be a second, untested definition of the same wire format;
+/// the field names are asserted against raw JSON in
+/// `tests/container_start_record.rs` instead, from the reader's point of view.
+#[derive(Serialize)]
+pub struct StartedRecord {
+    /// Shim PID that was running when `Container.Start` succeeded.
+    pub pid: u32,
+    /// Wall-clock time of the successful `Container.Start`, Unix milliseconds.
+    /// Millisecond precision keeps the record readable from any language
+    /// without agreeing on a timestamp format.
+    pub at_unix_ms: i64,
+}
+
+impl StartedRecord {
+    /// Write the record, replacing any previous lifecycle's.
+    pub fn write(&self, path: &Path) -> std::io::Result<()> {
+        let json = serde_json::to_string(self).expect("two scalar fields are infallible");
+        std::fs::write(path, json)
+    }
+}
 
 /// Directory structure constants
 pub mod dirs {
@@ -569,6 +602,21 @@ impl BoxFilesystemLayout {
     /// while freeing the canonical slot for the next crash.
     pub fn exit_previous_path(&self) -> PathBuf {
         self.box_dir.join("exit.previous")
+    }
+
+    /// Started file path: `~/.boxlite/boxes/{box_id}/started` — a [`StartedRecord`].
+    ///
+    /// The positive counterpart of [`Self::exit_file_path`]: written once the
+    /// guest's `Container.Start` returns success, removed when a new physical
+    /// lifecycle begins. Its presence means "this box's init was launched by
+    /// the shim currently recorded in it".
+    ///
+    /// Scoped to one lifecycle the same way the container's `exit.json` is
+    /// (see [`boxlite_shared::layout::SharedContainerLayout::exit_file`]): the
+    /// single removal point is the start of the next boot, so a stale record
+    /// can never outlive the shim it names.
+    pub fn started_file_path(&self) -> PathBuf {
+        self.box_dir.join("started")
     }
 
     /// Stderr file path: ~/.boxlite/boxes/{box_id}/shim.stderr

--- a/src/boxlite/src/runtime/layout.rs
+++ b/src/boxlite/src/runtime/layout.rs
@@ -1,40 +1,7 @@
 use crate::net::socket_path::BoxSockets;
 use boxlite_shared::errors::{BoxliteError, BoxliteResult};
 use boxlite_shared::layout::{SharedGuestLayout, dirs as shared_dirs};
-use serde::Serialize;
 use std::path::{Path, PathBuf};
-
-/// Contents of [`BoxFilesystemLayout::started_file_path`] — written by the host
-/// once the guest's `Container.Start` returns success for the current physical
-/// lifecycle.
-///
-/// It crosses a process boundary — BoxLite writes it, the cloud runner reads it
-/// straight out of the box home — so the schema is owned here rather than
-/// hand-rolled at the writing end. `pid` names the shim this record belongs to:
-/// the reader pairs it with the box's live PID and rejects a record that does
-/// not match, so a stale file can never be read as evidence about a later shim.
-///
-/// Write-only on this side by design. The reader is in another language, and a
-/// Rust `read` would be a second, untested definition of the same wire format;
-/// the field names are asserted against raw JSON in
-/// `tests/container_start_record.rs` instead, from the reader's point of view.
-#[derive(Serialize)]
-pub struct StartedRecord {
-    /// Shim PID that was running when `Container.Start` succeeded.
-    pub pid: u32,
-    /// Wall-clock time of the successful `Container.Start`, Unix milliseconds.
-    /// Millisecond precision keeps the record readable from any language
-    /// without agreeing on a timestamp format.
-    pub at_unix_ms: i64,
-}
-
-impl StartedRecord {
-    /// Write the record, replacing any previous lifecycle's.
-    pub fn write(&self, path: &Path) -> std::io::Result<()> {
-        let json = serde_json::to_string(self).expect("two scalar fields are infallible");
-        std::fs::write(path, json)
-    }
-}
 
 /// Directory structure constants
 pub mod dirs {
@@ -602,21 +569,6 @@ impl BoxFilesystemLayout {
     /// while freeing the canonical slot for the next crash.
     pub fn exit_previous_path(&self) -> PathBuf {
         self.box_dir.join("exit.previous")
-    }
-
-    /// Started file path: `~/.boxlite/boxes/{box_id}/started` — a [`StartedRecord`].
-    ///
-    /// The positive counterpart of [`Self::exit_file_path`]: written once the
-    /// guest's `Container.Start` returns success, removed when a new physical
-    /// lifecycle begins. Its presence means "this box's init was launched by
-    /// the shim currently recorded in it".
-    ///
-    /// Scoped to one lifecycle the same way the container's `exit.json` is
-    /// (see [`boxlite_shared::layout::SharedContainerLayout::exit_file`]): the
-    /// single removal point is the start of the next boot, so a stale record
-    /// can never outlive the shim it names.
-    pub fn started_file_path(&self) -> PathBuf {
-        self.box_dir.join("started")
     }
 
     /// Stderr file path: ~/.boxlite/boxes/{box_id}/shim.stderr

--- a/src/boxlite/src/runtime/rt_impl.rs
+++ b/src/boxlite/src/runtime/rt_impl.rs
@@ -234,6 +234,13 @@ impl RuntimeImpl {
         Self::initialize(options, experimental_features)
     }
 
+    /// Build a runtime without host validation. Tests using this must not exercise
+    /// VM or hypervisor operations.
+    #[cfg(test)]
+    pub(crate) fn new_for_test(options: BoxliteOptions) -> BoxliteResult<SharedRuntimeImpl> {
+        Self::initialize(options, ExperimentalFeatures::default())
+    }
+
     fn initialize(
         options: BoxliteOptions,
         experimental_features: ExperimentalFeatures,
@@ -1388,8 +1395,7 @@ impl RuntimeImpl {
             // lifecycle, so it only matters when no shim is alive.
             match PidFileReader::at(&pid_path).process_identity() {
                 ProcessIdentity::Verified(pid) => {
-                    state.set_pid(Some(pid));
-                    state.set_status(BoxStatus::Running);
+                    state.adopt_recovered_shim(pid);
                     // Live shim wins — archive any prior-lifecycle exit
                     // file so the next crash gets the canonical slot.
                     if had_stale_exit {
@@ -1411,8 +1417,7 @@ impl RuntimeImpl {
                     // Pre-fingerprint PID file. Adopt the live PID so VMs
                     // aren't lost on upgrade; the next stop/start writes a
                     // two-line file and the fingerprint check takes over.
-                    state.set_pid(Some(pid));
-                    state.set_status(BoxStatus::Running);
+                    state.adopt_recovered_shim(pid);
                     if had_stale_exit {
                         stash_exit_file(&box_layout);
                         tracing::warn!(

--- a/src/boxlite/src/runtime/types.rs
+++ b/src/boxlite/src/runtime/types.rs
@@ -400,6 +400,20 @@ pub struct BoxInfo {
     /// Exit code of the container's init process, when the box stopped
     /// because its main command exited (docker semantics).
     pub exit_code: Option<i32>,
+
+    /// When the guest's `Container.Start` most recently returned success
+    /// (docker's `State.StartedAt`); `None` when no successful start has been
+    /// recorded. The value survives stop and reboot as lifecycle history. When
+    /// [`Self::pid`] is present, the timestamp describes that live PID.
+    ///
+    /// Answers what [`Self::status`] cannot: `Running` is published once the
+    /// VM is up, which is before the separate `Container.Start` runs — and
+    /// `attach()` leaves a box `Running` with its init deliberately unstarted.
+    /// The cloud runner reads this to confirm a startup whose job-completion
+    /// callback was lost. Serde default keeps metadata from an older producer
+    /// readable.
+    #[serde(default)]
+    pub started_at: Option<DateTime<Utc>>,
 }
 
 impl BoxInfo {
@@ -436,6 +450,7 @@ impl BoxInfo {
             auto_resume: config.options.auto_resume.unwrap_or(true),
             health_status: state.health_status,
             exit_code: state.exit_code,
+            started_at: state.started_at,
         }
     }
 }

--- a/src/boxlite/tests/container_start_record.rs
+++ b/src/boxlite/tests/container_start_record.rs
@@ -1,0 +1,193 @@
+//! Integration tests for the box's `Container.Start` success record.
+//!
+//! The record is deliberately distinct from `BoxStatus::Running`: booting
+//! publishes Running before the guest's separate `Container.Start` RPC runs, so
+//! Running alone cannot say whether a box's init was ever launched. The cloud
+//! runner reads this record to repair a startup whose job completion was lost,
+//! which only works while the record names the shim that is running right now.
+
+mod common;
+
+use boxlite::BoxliteRuntime;
+use boxlite::runtime::options::BoxliteOptions;
+use std::path::{Path, PathBuf};
+
+/// The record's path, spelled out the way an outside reader derives it — the
+/// cloud runner walks the same `{home}/boxes/{box_id}/started` layout from Go,
+/// so this must not go through `BoxFilesystemLayout`.
+fn started_file(home_dir: &Path, box_id: &str) -> PathBuf {
+    home_dir.join("boxes").join(box_id).join("started")
+}
+
+/// Read the record as an outside reader would: raw JSON, by field name.
+fn read_record(home_dir: &Path, box_id: &str) -> Option<(u32, i64)> {
+    let contents = std::fs::read_to_string(started_file(home_dir, box_id)).ok()?;
+    let json: serde_json::Value =
+        serde_json::from_str(&contents).expect("record must be valid JSON");
+    Some((
+        json.get("pid")
+            .and_then(serde_json::Value::as_u64)
+            .expect("record must carry a pid field") as u32,
+        json.get("at_unix_ms")
+            .and_then(serde_json::Value::as_i64)
+            .expect("record must carry an at_unix_ms field"),
+    ))
+}
+
+#[tokio::test]
+async fn start_record_tracks_the_shim_that_launched_init() {
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+
+    let handle = runtime
+        .create(common::alpine_opts(), Some("start-record".to_string()))
+        .await
+        .expect("create box");
+    let box_id = handle.id().clone();
+
+    assert!(
+        read_record(&home.path, box_id.as_str()).is_none(),
+        "creating a container must not claim its init was launched"
+    );
+
+    let before_start = chrono::Utc::now().timestamp_millis();
+    handle.start().await.expect("start box");
+
+    let (recorded_pid, recorded_at) = read_record(&home.path, box_id.as_str())
+        .expect("a successful Container.Start must be recorded");
+    let live_pid = handle
+        .info()
+        .await
+        .expect("inspect running box")
+        .pid
+        .expect("a running box has a shim pid");
+
+    assert_eq!(
+        recorded_pid, live_pid,
+        "the record must name the shim that is running the box, or a reader cannot tell \
+         it apart from a leftover"
+    );
+    assert!(
+        recorded_at >= before_start,
+        "record timestamp {recorded_at} predates the start that produced it ({before_start})"
+    );
+
+    let _ = handle.stop().await;
+    let _ = runtime.remove(box_id.as_str(), true).await;
+    let _ = runtime.shutdown(Some(common::TEST_SHUTDOWN_TIMEOUT)).await;
+}
+
+#[tokio::test]
+async fn a_fresh_lifecycle_replaces_the_previous_record() {
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+
+    let handle = runtime
+        .create(
+            common::alpine_opts(),
+            Some("start-record-restart".to_string()),
+        )
+        .await
+        .expect("create box");
+    let box_id = handle.id().clone();
+
+    handle.start().await.expect("start first lifecycle");
+    let (first_pid, first_at) =
+        read_record(&home.path, box_id.as_str()).expect("first start must be recorded");
+
+    handle.stop().await.expect("stop first lifecycle");
+
+    // A spent handle cannot boot another VM, so the restart goes through a
+    // fresh one — the same path the runner takes after a box has stopped.
+    drop(handle);
+    let restarted = runtime
+        .get(box_id.as_str())
+        .await
+        .expect("get a fresh handle")
+        .expect("box still exists");
+    restarted.start().await.expect("start second lifecycle");
+
+    let (second_pid, second_at) =
+        read_record(&home.path, box_id.as_str()).expect("second start must be recorded");
+    let live_pid = restarted
+        .info()
+        .await
+        .expect("inspect restarted box")
+        .pid
+        .expect("a running box has a shim pid");
+
+    assert_eq!(
+        second_pid, live_pid,
+        "the record must follow the new shim, not the one the first lifecycle used"
+    );
+    assert!(
+        second_at >= first_at,
+        "second record timestamp {second_at} predates the first ({first_at})"
+    );
+    assert_ne!(
+        (first_pid, first_at),
+        (second_pid, second_at),
+        "the second lifecycle must replace the first record rather than inherit it"
+    );
+
+    let _ = restarted.stop().await;
+    let _ = runtime.remove(box_id.as_str(), true).await;
+    let _ = runtime.shutdown(Some(common::TEST_SHUTDOWN_TIMEOUT)).await;
+}
+
+#[tokio::test]
+async fn adopting_the_same_running_shim_preserves_its_record() {
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let options = || BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    };
+
+    let (box_id, recorded) = {
+        let first = BoxliteRuntime::new(options()).expect("create first runtime");
+        let mut box_options = common::alpine_opts();
+        box_options.detach = true;
+        let handle = first
+            .create(box_options, Some("start-record-adopt".to_string()))
+            .await
+            .expect("create detached box");
+        handle.start().await.expect("start detached box");
+        let box_id = handle.id().clone();
+        let recorded =
+            read_record(&home.path, box_id.as_str()).expect("detached start must be recorded");
+        (box_id, recorded)
+    };
+
+    // Reattaching to a still-running shim is not a new lifecycle: its init is
+    // already running, so the record that describes it must survive.
+    let second = BoxliteRuntime::new(options()).expect("create second runtime");
+    let adopted = second
+        .get(box_id.as_str())
+        .await
+        .expect("adopt running box")
+        .expect("running box exists");
+    let adopted_info = adopted.info().await.expect("inspect adopted box");
+
+    assert_eq!(
+        read_record(&home.path, box_id.as_str()),
+        Some(recorded),
+        "adopting a live shim must not clear or rewrite its start record"
+    );
+    assert_eq!(
+        adopted_info.pid,
+        Some(recorded.0),
+        "the preserved record must still name the shim the adopted box is running"
+    );
+
+    let _ = adopted.stop().await;
+    let _ = second.remove(box_id.as_str(), true).await;
+    let _ = second.shutdown(Some(common::TEST_SHUTDOWN_TIMEOUT)).await;
+}

--- a/src/boxlite/tests/started_at.rs
+++ b/src/boxlite/tests/started_at.rs
@@ -1,41 +1,18 @@
-//! Integration tests for the box's `Container.Start` success record.
+//! Integration tests for `BoxInfo::started_at`.
 //!
-//! The record is deliberately distinct from `BoxStatus::Running`: booting
+//! The timestamp is deliberately distinct from `BoxStatus::Running`: booting
 //! publishes Running before the guest's separate `Container.Start` RPC runs, so
 //! Running alone cannot say whether a box's init was ever launched. The cloud
-//! runner reads this record to repair a startup whose job completion was lost,
-//! which only works while the record names the shim that is running right now.
+//! runner reads this to repair a startup whose job completion was lost, which
+//! only works while the value describes the lifecycle running right now.
 
 mod common;
 
 use boxlite::BoxliteRuntime;
 use boxlite::runtime::options::BoxliteOptions;
-use std::path::{Path, PathBuf};
-
-/// The record's path, spelled out the way an outside reader derives it — the
-/// cloud runner walks the same `{home}/boxes/{box_id}/started` layout from Go,
-/// so this must not go through `BoxFilesystemLayout`.
-fn started_file(home_dir: &Path, box_id: &str) -> PathBuf {
-    home_dir.join("boxes").join(box_id).join("started")
-}
-
-/// Read the record as an outside reader would: raw JSON, by field name.
-fn read_record(home_dir: &Path, box_id: &str) -> Option<(u32, i64)> {
-    let contents = std::fs::read_to_string(started_file(home_dir, box_id)).ok()?;
-    let json: serde_json::Value =
-        serde_json::from_str(&contents).expect("record must be valid JSON");
-    Some((
-        json.get("pid")
-            .and_then(serde_json::Value::as_u64)
-            .expect("record must carry a pid field") as u32,
-        json.get("at_unix_ms")
-            .and_then(serde_json::Value::as_i64)
-            .expect("record must carry an at_unix_ms field"),
-    ))
-}
 
 #[tokio::test]
-async fn start_record_tracks_the_shim_that_launched_init() {
+async fn started_at_tracks_the_shim_that_launched_init() {
     let home = boxlite_test_utils::home::PerTestBoxHome::new();
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
@@ -50,30 +27,45 @@ async fn start_record_tracks_the_shim_that_launched_init() {
     let box_id = handle.id().clone();
 
     assert!(
-        read_record(&home.path, box_id.as_str()).is_none(),
+        handle
+            .info()
+            .await
+            .expect("inspect created box")
+            .started_at
+            .is_none(),
         "creating a container must not claim its init was launched"
     );
 
-    let before_start = chrono::Utc::now().timestamp_millis();
-    handle.start().await.expect("start box");
-
-    let (recorded_pid, recorded_at) = read_record(&home.path, box_id.as_str())
-        .expect("a successful Container.Start must be recorded");
-    let live_pid = handle
-        .info()
-        .await
-        .expect("inspect running box")
-        .pid
-        .expect("a running box has a shim pid");
-
+    // Booting is not starting: `attach` brings the VM up and stops short of
+    // running init, which is the state `BoxStatus::Running` cannot tell apart
+    // from a box whose init is live — and the whole reason this field exists.
+    let attached = handle.attach(None).await.expect("attach to booted box");
+    let booted = handle.info().await.expect("inspect booted box");
+    assert!(
+        booted.status.is_running(),
+        "attach must leave the box Running, or this test is not observing the window"
+    );
     assert_eq!(
-        recorded_pid, live_pid,
-        "the record must name the shim that is running the box, or a reader cannot tell \
-         it apart from a leftover"
+        booted.started_at, None,
+        "a booted box whose init was never launched must not report a container start"
+    );
+
+    let before_start = chrono::Utc::now();
+    handle.start().await.expect("start box");
+    drop(attached);
+
+    let info = handle.info().await.expect("inspect running box");
+    let started_at = info
+        .started_at
+        .expect("a successful Container.Start must be recorded");
+
+    assert!(
+        info.pid.is_some(),
+        "a box that recorded a start must name the shim running it"
     );
     assert!(
-        recorded_at >= before_start,
-        "record timestamp {recorded_at} predates the start that produced it ({before_start})"
+        started_at >= before_start,
+        "record timestamp {started_at} predates the start that produced it ({before_start})"
     );
 
     let _ = handle.stop().await;
@@ -100,10 +92,21 @@ async fn a_fresh_lifecycle_replaces_the_previous_record() {
     let box_id = handle.id().clone();
 
     handle.start().await.expect("start first lifecycle");
-    let (first_pid, first_at) =
-        read_record(&home.path, box_id.as_str()).expect("first start must be recorded");
+    let first = handle
+        .info()
+        .await
+        .expect("inspect first lifecycle")
+        .started_at
+        .expect("first start must be recorded");
 
     handle.stop().await.expect("stop first lifecycle");
+
+    assert_eq!(
+        handle.info().await.expect("inspect stopped box").started_at,
+        Some(first),
+        "a stop must leave the record of the run that just ended, the way docker keeps \
+         StartedAt on an exited container"
+    );
 
     // A spent handle cannot boot another VM, so the restart goes through a
     // fresh one — the same path the runner takes after a box has stopped.
@@ -113,29 +116,21 @@ async fn a_fresh_lifecycle_replaces_the_previous_record() {
         .await
         .expect("get a fresh handle")
         .expect("box still exists");
+
     restarted.start().await.expect("start second lifecycle");
 
-    let (second_pid, second_at) =
-        read_record(&home.path, box_id.as_str()).expect("second start must be recorded");
-    let live_pid = restarted
-        .info()
-        .await
-        .expect("inspect restarted box")
-        .pid
-        .expect("a running box has a shim pid");
+    let second_info = restarted.info().await.expect("inspect restarted box");
+    let second = second_info
+        .started_at
+        .expect("second start must be recorded");
 
-    assert_eq!(
-        second_pid, live_pid,
-        "the record must follow the new shim, not the one the first lifecycle used"
+    assert!(
+        second_info.pid.is_some(),
+        "a restarted box that recorded a start must name the shim running it"
     );
     assert!(
-        second_at >= first_at,
-        "second record timestamp {second_at} predates the first ({first_at})"
-    );
-    assert_ne!(
-        (first_pid, first_at),
-        (second_pid, second_at),
-        "the second lifecycle must replace the first record rather than inherit it"
+        second > first,
+        "second record timestamp {second} does not follow the first ({first})"
     );
 
     let _ = restarted.stop().await;
@@ -151,7 +146,7 @@ async fn adopting_the_same_running_shim_preserves_its_record() {
         image_registries: common::test_registries(),
     };
 
-    let (box_id, recorded) = {
+    let (box_id, recorded, recorded_pid) = {
         let first = BoxliteRuntime::new(options()).expect("create first runtime");
         let mut box_options = common::alpine_opts();
         box_options.detach = true;
@@ -160,10 +155,12 @@ async fn adopting_the_same_running_shim_preserves_its_record() {
             .await
             .expect("create detached box");
         handle.start().await.expect("start detached box");
-        let box_id = handle.id().clone();
-        let recorded =
-            read_record(&home.path, box_id.as_str()).expect("detached start must be recorded");
-        (box_id, recorded)
+        let info = handle.info().await.expect("inspect detached box");
+        (
+            handle.id().clone(),
+            info.started_at.expect("detached start must be recorded"),
+            info.pid.expect("a running box has a shim pid"),
+        )
     };
 
     // Reattaching to a still-running shim is not a new lifecycle: its init is
@@ -177,14 +174,14 @@ async fn adopting_the_same_running_shim_preserves_its_record() {
     let adopted_info = adopted.info().await.expect("inspect adopted box");
 
     assert_eq!(
-        read_record(&home.path, box_id.as_str()),
+        adopted_info.started_at,
         Some(recorded),
         "adopting a live shim must not clear or rewrite its start record"
     );
     assert_eq!(
         adopted_info.pid,
-        Some(recorded.0),
-        "the preserved record must still name the shim the adopted box is running"
+        Some(recorded_pid),
+        "the preserved record must still describe the shim the adopted box is running"
     );
 
     let _ = adopted.stop().await;

--- a/src/cli/src/commands/inspect.rs
+++ b/src/cli/src/commands/inspect.rs
@@ -54,6 +54,8 @@ struct InspectStatePresenter {
     /// Init exit code; 0 when unknown or still running (docker-compatible).
     #[serde(rename = "ExitCode")]
     exit_code: i32,
+    #[serde(rename = "StartedAt")]
+    started_at: Option<String>,
 }
 
 impl From<&BoxInfo> for InspectPresenter {
@@ -70,6 +72,7 @@ impl From<&BoxInfo> for InspectPresenter {
                 running: state.running,
                 pid: state.pid.unwrap_or(0),
                 exit_code: state.exit_code.unwrap_or(0),
+                started_at: info.started_at.as_ref().map(|at| at.to_rfc3339()),
             },
             cpus: info.cpus,
             memory: info.memory_mib as u64 * 1024 * 1024,
@@ -231,10 +234,9 @@ mod tests {
     use boxlite::{BoxID, BoxStatus, HealthStatus};
     use std::collections::HashMap;
 
-    #[test]
-    fn inspect_omits_advanced_capability_metadata() {
+    fn inspect_info(started_at: Option<chrono::DateTime<chrono::Utc>>) -> BoxInfo {
         let now = chrono::Utc::now();
-        let info = BoxInfo {
+        BoxInfo {
             id: BoxID::parse("inspect-capabilities").unwrap(),
             name: Some("cap-box".into()),
             status: BoxStatus::Configured,
@@ -251,9 +253,26 @@ mod tests {
             auto_resume: true,
             health_status: HealthStatus::new(),
             exit_code: None,
-        };
+            started_at,
+        }
+    }
 
+    #[test]
+    fn inspect_omits_advanced_capability_metadata() {
+        let info = inspect_info(None);
         let value = serde_json::to_value(InspectPresenter::from(&info)).unwrap();
         assert!(value.get("Advanced").is_none());
+    }
+
+    #[test]
+    fn inspect_exposes_started_at() {
+        let started_at = chrono::DateTime::from_timestamp(1, 0).unwrap();
+        let info = inspect_info(Some(started_at));
+
+        let value = serde_json::to_value(InspectPresenter::from(&info)).unwrap();
+        assert_eq!(value["State"]["StartedAt"], started_at.to_rfc3339());
+
+        let value = serde_json::to_value(InspectPresenter::from(&inspect_info(None))).unwrap();
+        assert!(value["State"]["StartedAt"].is_null());
     }
 }


### PR DESCRIPTION
## Summary

Repair boxes left in `CREATING` or `STARTING` when the runner starts the container successfully but its job-completion callback never reaches the API.

Persist lifecycle-scoped `Container.Start` evidence in BoxLite, use it to reconcile only the matching stalled startup job through the normal completion path, and prevent concurrent workers from claiming or finalizing the same job row from stale state.

## Call graph

### Startup recovery

Before (`origin/main` at `48b49977`)

```text
Executor.Execute
  (apps/runner/pkg/runner/v2/executor/executor.go:58)
  ├─ executeJob
  │    (executor.go:108)
  │    └─ createBox / startBox
  │         (apps/runner/pkg/runner/v2/executor/box.go:18,38)
  │         └─ Client.Create / Client.Start
  │              (apps/runner/pkg/boxlite/client.go:219,312)
  │              └─ Box.Start
  │                   (sdks/go/box_handle.go:43)
  │                   └─ … C ABI …
  │                        └─ BoxImpl::start
  │                             (src/boxlite/src/litebox/box_impl.rs:269)
  │                             └─ ensure_container_started
  │                                  (box_impl.rs:979)
  │                                  └─ Container.Start succeeds
  │                                       — no durable success evidence is recorded
  └─ updateJobStatus
       (executor.go:161)
       ← BUG: exhausted completion-callback retries can leave the API job IN_PROGRESS

BoxSyncService.PerformSync
  (apps/runner/pkg/services/box_sync.go:101)
  ├─ GetRemoteBoxStates
  │    (box_sync.go:65)
  │    └─ fetch only STARTED boxes
  │         ← BUG: excludes the stuck CREATING/STARTING box
  └─ SyncBoxState
       (box_sync.go:90)
       — never reached for an excluded box

BoxService.updateState
  (apps/api/src/box/services/box.service.ts:1259)
  ← BUG: rejects runner reports while the API box is CREATING or STARTING
```

After (`035a13b2`)

```text
Executor.Execute
  (apps/runner/pkg/runner/v2/executor/executor.go:58)
  ├─ executeJob
  │    (executor.go:108)
  │    └─ createBox / startBox
  │         (apps/runner/pkg/runner/v2/executor/box.go:18,38)
  │         └─ Client.Create / Client.Start
  │              (apps/runner/pkg/boxlite/client.go:219,320)
  │              └─ Box.Start
  │                   (sdks/go/box_handle.go:43)
  │                   └─ … C ABI …
  │                        └─ BoxImpl::start
  │                             (src/boxlite/src/litebox/box_impl.rs:269)
  │                             └─ ensure_container_started
  │                                  (box_impl.rs:985)
  │                                  └─ record_started
  │                                       (box_impl.rs:1023)
  │                                       └─ mark_started + save_box
  │                                            (state.rs:362; manager.rs:157)
  │                                            — persists state, PID, and started_at together
  └─ updateJobStatus
       (executor.go:161)
       — remains the normal completion path

BoxSyncService.PerformSync
  (apps/runner/pkg/services/box_sync.go:170)
  ├─ GetLocalContainerStates
  │    (box_sync.go:57)
  │    └─ Client.ListInfo
  │         (apps/runner/pkg/boxlite/client.go:490)
  │         └─ Go Runtime.ListInfo
  │              (sdks/go/info.go:94)
  │              └─ … C ABI …
  │                   └─ RuntimeImpl::list_info
  │                        (src/boxlite/src/runtime/rt_impl.rs:636)
  │                        └─ BoxInfo::new
  │                             (src/boxlite/src/runtime/types.rs:421)
  │                             ↩ state and started_at return from one snapshot
  ├─ GetRemoteBoxStates
  │    (box_sync.go:95)
  │    └─ fetchRunnerBoxes
  │         (box_sync.go:129)
  │         — fetches STARTED plus CREATING/STARTING candidates
  ├─ canReport
  │    (box_sync.go:226)
  │    — a transitional box requires local STARTED and non-nil started_at
  └─ SyncBoxState
       (box_sync.go:159; only when canReport returns true)
       └─ BoxController.updateBoxState
            (apps/api/src/box/controllers/box.controller.ts:381)
            └─ BoxService.updateState
                 (apps/api/src/box/services/box.service.ts:1313)
                 ├─ findStalledStartupJob
                 │    (box.service.ts:582)
                 │    — matches the claimed CREATE_BOX or START_BOX job
                 └─ JobService.updateJobStatus
                      (apps/api/src/box/services/job.service.ts:232)
                      └─ JobStateHandlerService.handleJobCompletion
                           (job-state-handler.service.ts:37; after transaction commit)
                           └─ handleCreateBoxJobCompletion /
                              handleStartBoxJobCompletion
                                (job-state-handler.service.ts:84,126)
                                — publishes STARTED and releases the existing lock
```

### Job-row concurrency

Before

```text
JobService.pollJobs
  (apps/api/src/box/services/job.service.ts:118)
  └─ claimPendingJobs
       (job.service.ts:455)
       └─ Repository.save
            (job.service.ts:483)
            ← BUG: concurrent pollers can both claim the same PENDING row

JobService.updateJobStatus
  (job.service.ts:232)
  └─ findOne → validate → save
       (job.service.ts:238–264)
       ← BUG: concurrent terminal writers can validate stale state and overwrite it
```

After

```text
JobService.pollJobs
  (apps/api/src/box/services/job.service.ts:118)
  └─ claimPendingJobs
       (job.service.ts:460)
       └─ UPDATE … WHERE status = PENDING RETURNING *
            (job.service.ts:493)
            — only the poller with affected = 1 receives the job

JobService.updateJobStatus
  (job.service.ts:232)
  └─ transaction
       └─ findOne(pessimistic_write) → validate → save
            (job.service.ts:238)
            — serializes terminal transitions before completion effects run
```

Fixes #<issue-number>

## Changes

- Persist `started_at` after a successful guest `Container.Start` in the same BoxLite state row as lifecycle state and PID.
  - Preserve it as evidence for the most recently ended lifecycle.
  - Clear it when a new lifecycle publishes a PID or recovery adopts a different shim PID.
- Expose `started_at` through Rust `BoxInfo`, the C ABI, Go, Node.js, Python, and CLI inspection output.
  - REST-backed metadata leaves the field unset because the control plane does not provide this evidence.
- Read the runner’s local state and startup evidence from one `ListInfo` snapshot.
- Query `CREATING` and `STARTING` boxes as reconciliation candidates without disrupting the existing `STARTED` reconciliation path.
- Report a transitional box as `STARTED` only when BoxLite reports both local `STARTED` state and durable start evidence.
- After the configurable stall window—60 seconds by default—complete the matching in-progress `CREATE_BOX` or `START_BOX` job through the existing completion handler.
- Claim pending jobs with a conditional `UPDATE … WHERE status = PENDING RETURNING *`.
- Serialize job status transitions with a transaction and pessimistic row lock.
- Add core, SDK, runner, API, CLI, compatibility, lifecycle, and concurrency coverage.
- Update the SDK and CLI reference documentation for the new timestamp.

## How to verify

```bash
make fmt:check
make lint
make test:unit:core
make test:unit:sdk
make test:apps

# Requires KVM on Linux or Hypervisor.framework on macOS
make test:integration:rust NEXTEST_FILTER_EXPR='binary(started_at)'
```

## Risks / rollout

- No database migration is required. `started_at` is optional and serde-defaulted in the existing BoxLite state row; legacy rows therefore load without evidence until a later successful start.
- `CBoxInfo` gains a tail field. Existing field offsets remain unchanged, but native libraries and generated SDK bindings should be rebuilt and released together.
- No strict API/runner deployment order is required:

  | Runner | Old API | New API |
  |---|---|---|
  | Old runner | Existing reconciliation only | Existing reconciliation only |
  | New runner | Existing `STARTED` reconciliation remains; lost-callback confirmation is skipped | Full startup repair |

- The default 60-second stall window delays recovery intentionally so it does not race a completion callback that is still progressing. It is configurable through `BOX_SYNC_START_CONFIRMATION_STALL_SECONDS`.
- Any failure of the additional transitional-box query is treated as “confirmation unavailable this cycle.” This preserves ordinary reconciliation but delays startup recovery until a later successful cycle.
- Recording `started_at` holds the BoxLite lifecycle-state lock while synchronously saving to SQLite, so database contention can delay other state readers.
- The PostgreSQL conditional-claim and pessimistic-lock paths are covered by mock/stub unit tests in this PR, not by a real PostgreSQL integration test.