### PR TITLE
fix(infra): harden SST deployments

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -172,8 +172,10 @@ Required `dev` Environment configuration:
 - Variable `AWS_REGION` (defaults to `ap-southeast-1`)
 - Secret `DEPLOY_ENV` containing the stage's dotenv configuration
 
-Bootstrap the role with `apps/infra/ci/github-deploy-role.yaml`, then require
-reviewers on the GitHub Environment before enabling deployments.
+Bootstrap the scoped role and runtime permissions boundary with
+`apps/infra/ci/github-deploy-role.yaml`, then require reviewers on the GitHub
+Environment before enabling deployments. Redeploy that CloudFormation stack
+when its policy changes.
 
 ### `e2e-local.yml`
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -159,6 +159,22 @@ is enabled. The workflow is dormant until repository variable
 4. Trigger a new push, pull request update, or manual dispatch and verify CodeQL analysis uploads successfully.
 5. Roll back by setting `CODEQL_ADVANCED_SETUP_ENABLED=false` and re-enabling default setup.
 
+### `deploy-dev-api.yml`
+
+Manually deploys only the dev `Api` component from `main` on a native AMD64
+GitHub runner. The job is serialized, uses the protected `dev` Environment, and
+authenticates to AWS with short-lived OIDC credentials. Docker runs entirely in
+CI; no developer machine or public SSH builder participates.
+
+Required `dev` Environment configuration:
+
+- Variable `AWS_DEPLOY_ROLE_ARN`
+- Variable `AWS_REGION` (defaults to `ap-southeast-1`)
+- Secret `DEPLOY_ENV` containing the stage's dotenv configuration
+
+Bootstrap the role with `apps/infra/ci/github-deploy-role.yaml`, then require
+reviewers on the GitHub Environment before enabling deployments.
+
 ### `e2e-local.yml`
 
 Runs VM-based integration tests on a persistent, self-hosted AWS EC2 runner — GitHub-hosted

--- a/.github/workflows/deploy-dev-api.yml
+++ b/.github/workflows/deploy-dev-api.yml
@@ -21,6 +21,7 @@ jobs:
     env:
       AWS_REGION: ${{ vars.AWS_REGION || 'ap-southeast-1' }}
       AWS_DEFAULT_REGION: ${{ vars.AWS_REGION || 'ap-southeast-1' }}
+      IAM_PERMISSIONS_BOUNDARY_STAGE: dev
 
     steps:
       - name: Checkout main

--- a/.github/workflows/deploy-dev-api.yml
+++ b/.github/workflows/deploy-dev-api.yml
@@ -1,0 +1,76 @@
+name: Deploy dev API
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: deploy-dev-api
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy API
+    if: github.ref == 'refs/heads/main'
+    environment: dev
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    env:
+      AWS_REGION: ${{ vars.AWS_REGION || 'ap-southeast-1' }}
+      AWS_DEFAULT_REGION: ${{ vars.AWS_REGION || 'ap-southeast-1' }}
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Verify native AMD64 Docker
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(uname -m)" = "x86_64"
+          test "$(docker info --format '{{.Architecture}}')" = "x86_64"
+
+      - name: Configure AWS credentials through OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+          role-session-name: deploy-dev-api-${{ github.run_id }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: apps/infra/package-lock.json
+
+      - name: Install deployment dependencies
+        working-directory: apps/infra
+        run: npm ci
+
+      - name: Materialize stage configuration
+        shell: bash
+        env:
+          DEPLOY_ENV: ${{ secrets.DEPLOY_ENV }}
+        run: |
+          set -euo pipefail
+          test -n "$DEPLOY_ENV"
+          umask 077
+          printf '%s\n' "$DEPLOY_ENV" > apps/infra/.env
+          if grep -Eq '^(AWS_PROFILE|AWS_ACCESS_KEY_ID|AWS_SECRET_ACCESS_KEY|AWS_SESSION_TOKEN|BUILDX_BUILDER)=' apps/infra/.env; then
+            echo "DEPLOY_ENV must rely on workflow OIDC and the native CI builder" >&2
+            exit 1
+          fi
+
+      - name: Deploy the API only
+        working-directory: apps/infra
+        run: npm run deploy -- --stage dev --target Api --exclude Runner
+
+      - name: Remove materialized configuration
+        if: always()
+        run: rm -f apps/infra/.env

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -322,6 +322,9 @@ jobs:
           cache: npm
           cache-dependency-path: apps/infra/package-lock.json
 
+      - name: Enable Corepack
+        run: corepack enable
+
       - name: Run infrastructure deployment tests
         run: make test:apps:infra
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -308,12 +308,16 @@ jobs:
 
   infra:
     name: SST deployment tests
+    permissions:
+      contents: read
     needs: changes
     if: ${{ needs.changes.outputs.infra == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,6 +23,8 @@ on:
       - '.github/workflows/lint.yml'
       - '.github/workflows/config.yml'
       - '.github/workflows/build-runtime.yml'
+      - '.github/workflows/deploy-dev-api.yml'
+      - 'apps/infra/**'
       - 'scripts/release/**'
   # No path filter on pull_request: the `Lint (conclusion)` job is a required
   # status check, so this workflow must run on EVERY PR and report it. A
@@ -47,6 +49,7 @@ jobs:
       c: ${{ steps.filter.outputs.c }}
       go: ${{ steps.filter.outputs.go }}
       quality: ${{ steps.filter.outputs.quality }}
+      infra: ${{ steps.filter.outputs.infra }}
       install_script: ${{ steps.filter.outputs.install_script }}
     steps:
       - uses: actions/checkout@v5
@@ -80,6 +83,10 @@ jobs:
               - 'make/quality.mk'
               - '.pre-commit-config.yaml'
               - '.github/workflows/lint.yml'
+            infra:
+              - 'apps/infra/**'
+              - '.github/workflows/deploy-dev-api.yml'
+              - 'make/test.mk'
             install_script:
               - 'scripts/release/**'
               - '.github/workflows/build-runtime.yml'
@@ -299,6 +306,28 @@ jobs:
       - name: Run installer script smoke test
         run: make test:install-script
 
+  infra:
+    name: SST deployment tests
+    needs: changes
+    if: ${{ needs.changes.outputs.infra == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: apps/infra/package-lock.json
+
+      - name: Run infrastructure deployment tests
+        run: make test:apps:infra
+
+      - name: Install and type-check the SST deployment config
+        run: make test:apps:infra-config
+
   # Single required status check for branch protection / merge queue.
   # Passes only if every job above succeeded or was skipped (path-filtered).
   # `if: !cancelled()` is required: without it a failed dependency would skip
@@ -306,7 +335,7 @@ jobs:
   # NOTE: keep `needs` in sync with the jobs above when adding/removing jobs.
   lint-conclusion:
     name: Lint (conclusion)
-    needs: [config, changes, rustfmt, clippy, python, node, c, go, install_script]
+    needs: [config, changes, rustfmt, clippy, python, node, c, go, install_script, infra]
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     permissions: {}

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ node_modules/
 package-lock.json
 yarn.lock
 !/apps/yarn.lock
+!/apps/infra/package-lock.json
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/apps/infra/.env.example
+++ b/apps/infra/.env.example
@@ -1,7 +1,10 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # BoxLite Infra — .env
 #
-# Copy to .env and fill in required values before first deploy.
+# Copy to .env and fill in the non-secret deployment values before first deploy.
+# SST application secrets are stage-scoped. Set them separately with the
+# `npm run sst -- secret set` command; putting those names here does not
+# configure the deployed app.
 #
 # Tier legend (what happens if you leave a var unset):
 #   [required]            deploy fails — the config throws or a provider errors
@@ -9,8 +12,8 @@
 #                         (the code silently falls back to a non-working default)
 #   [optional]            safe to leave unset
 #
-# Sections 1–3 are what you must set to stand up a working stack; section 4
-# holds every optional override.
+# Sections 1–2 contain the required local configuration. Section 3 describes
+# the optional runner; section 4 holds optional local overrides.
 # ─────────────────────────────────────────────────────────────────────────────
 
 # ─── 1. Domain + DNS ─────────────────────────────────────────────────────────
@@ -56,14 +59,17 @@ CLOUDFLARE_API_TOKEN=
 #      Auth0's still-alive session cookie. Default-on for tenants created on
 #      or after 14 November 2023; older tenants must flip it manually.
 #
-# [required] Issuer URL (no trailing slash) — deploy throws if unset:
-OIDC_ISSUER_BASE_URL=https://your-tenant.auth0.com
-# Optional public issuer shown to browser clients, usually an Auth0 custom domain.
-# Leave unset when the public and internal issuer are the same.
-PUBLIC_OIDC_DOMAIN=https://auth.dev.example.com
-# [required at runtime] These silently default to "boxlite" if unset, which
-# deploys a broken auth config rather than failing. Always set both:
-OIDC_CLIENT_ID=your-spa-client-id
+# [required] Exact issuer URL from the provider's discovery document.
+# Auth0 includes the trailing slash shown below; other providers may not.
+# Do not add or remove a slash because OIDC issuer matching is byte-for-byte.
+OIDC_ISSUER_BASE_URL=https://your-tenant.auth0.com/
+# Optional exact public issuer shown to browser clients, usually an Auth0 custom
+# domain. Leave unset when the public and internal issuer are the same.
+PUBLIC_OIDC_DOMAIN=https://auth.dev.example.com/
+# [required SST secret] Set the SPA client ID in the stage's SST secret store;
+# it is deliberately not read from this local deployment environment:
+#   npm run sst -- secret set OIDC_CLIENT_ID "<spa-client-id>" --stage <stage>
+# [required] Non-secret API audience:
 OIDC_AUDIENCE=https://dev.example.com/api
 
 # ─── 3. Runner ───────────────────────────────────────────────────────────────
@@ -86,9 +92,15 @@ OIDC_AUDIENCE=https://dev.example.com/api
 # Uncomment to pin.
 
 # 4a. AWS / deploy
+# AWS region used by both SST and the post-deploy verifier.
+# AWS_REGION=ap-southeast-1
+# API release reported by /api/config. Defaults to Cargo.toml's workspace version.
+# VERSION=0.9.8
 # AWS profile used by SST. Leave unset to use "default".
 # AWS_PROFILE=my-aws-profile
-
+# Optional absolute AWS CLI path. The deploy wrapper also searches PATH and
+# standard Homebrew/system locations before starting a deployment.
+# AWS_CLI_PATH=/opt/homebrew/bin/aws
 # 4b. Secrets & keys — auto-generated per stack; pin only to rotate or to share
 # a value across stacks.
 # ENCRYPTION_KEY=
@@ -98,7 +110,8 @@ OIDC_AUDIENCE=https://dev.example.com/api
 # DEFAULT_RUNNER_API_KEY=
 
 # 4c. Endpoints & URLs — auto-derived from STACK_DOMAIN; pin for custom DNS /
-# topology.
+# topology. PROXY_DOMAIN configures the public hostname, certificate, and
+# wildcard alias on SST's TLS NLB listener; keep the URL values aligned with it.
 # PROXY_DOMAIN=proxy.dev.example.com
 # PROXY_PROTOCOL=https
 # PROXY_TEMPLATE_URL=https://proxy.dev.example.com
@@ -117,8 +130,14 @@ OIDC_AUDIENCE=https://dev.example.com/api
 # Management API with permissions: read:users, update:users, read:connections,
 # create:guardian_enrollment_tickets, read:connections_options.
 # OIDC_MANAGEMENT_API_ENABLED=true
-# OIDC_MANAGEMENT_API_CLIENT_ID=
-# OIDC_MANAGEMENT_API_CLIENT_SECRET=
+# Optional for a root issuer; required for a path-based issuer. This is the
+# exact API prefix before endpoints such as `connections` and `users/...`.
+# OIDC_MANAGEMENT_API_BASE_URL=https://your-tenant.auth0.com/api/v2/
+# Optional for a root issuer; required for a path-based issuer because the OIDC
+# client-credentials endpoint cannot be derived safely from an issuer path.
+# OIDC_MANAGEMENT_API_TOKEN_URL=https://your-tenant.auth0.com/oauth/token
+# Set OIDC_MANAGEMENT_API_CLIENT_ID and OIDC_MANAGEMENT_API_CLIENT_SECRET through
+# `npm run sst -- secret set`, not in this file.
 # OIDC_MANAGEMENT_API_AUDIENCE=https://your-tenant.auth0.com/api/v2/
 
 # 4f. OIDC logout overrides.
@@ -162,13 +181,13 @@ OIDC_AUDIENCE=https://dev.example.com/api
 # dashboard's feature flags. Without POSTHOG_API_KEY the DASHBOARD_CREATE_BOX
 # flag can't resolve, so the "Create Box" button stays disabled, and API
 # request metrics stop recording.
-# POSTHOG_API_KEY=
+# Set POSTHOG_API_KEY through `npm run sst -- secret set`, not in this file.
 # POSTHOG_HOST=https://us.posthog.com
 
 # 4j. Webhooks (Svix) — outbound event delivery (box/snapshot/volume events).
 # Without SVIX_AUTH_TOKEN the dashboard logs cosmetic errors. SVIX_SERVER_URL
 # pins a self-hosted Svix instance (defaults to Svix cloud).
-# SVIX_AUTH_TOKEN=
+# Set SVIX_AUTH_TOKEN through `npm run sst -- secret set`, not in this file.
 # SVIX_SERVER_URL=
 
 # 4k. Observability backend — ClickHouse (trace/metric/log storage). All [optional];
@@ -219,11 +238,15 @@ OIDC_AUDIENCE=https://dev.example.com/api
 # OTEL_EXPORTER_OTLP_HEADERS=                               # e.g. authorization=Bearer xxx
 # OTEL_COLLECTOR_API_KEY=                                   # collector→API key; default: ADMIN_API_KEY
 
-# 4n. System box images. The live images are the three digest-pinned refs in
-# sst.config.ts (BOXLITE_SYSTEM_{BASE,PYTHON,NODE}_IMAGE), pulled from ghcr.io with the
-# runner's GHCR_TOKEN. The vars below are currently INERT — no code reads them (Daytona-
-# port residue, see apps/api configuration.ts); setting them has no effect. Documented
-# only as reserved names for a future source-registry path.
+# 4n. System box images. The built-ins are the three pinned refs in sst.config.ts
+# (BOXLITE_SYSTEM_{BASE,PYTHON,NODE}_IMAGE), pulled with the runner's registry
+# credentials. Add supported images as comma-separated `name=ref` entries:
+# BOXLITE_SYSTEM_IMAGES=sandbaseai-hermes=sam2026go/hermes-agent:boxlite-noexpose-20260726
+# Runners cache exact image refs. Roll out changed image bytes with a new immutable
+# tag or digest; do not repush a mutable tag and expect existing caches to refresh.
+#
+# The vars below are currently INERT — no code reads them (Daytona-port residue,
+# see apps/api configuration.ts). They are reserved for a future registry path.
 # BOXLITE_SYSTEM_IMAGE_TAG=20260605-p0-r3
 # BOXLITE_SYSTEM_SOURCE_REGISTRY_URL=
 # BOXLITE_SYSTEM_SOURCE_REGISTRY_USERNAME=

--- a/apps/infra/.env.example
+++ b/apps/infra/.env.example
@@ -17,6 +17,11 @@
 # ─────────────────────────────────────────────────────────────────────────────
 
 # ─── 1. Domain + DNS ─────────────────────────────────────────────────────────
+# [required] Must match both `--stage` and the GitHubEnvironment used to deploy
+# ci/github-deploy-role.yaml. This prevents SST from naming a boundary that was
+# never provisioned.
+IAM_PERMISSIONS_BOUNDARY_STAGE=dev
+
 # [required] A Cloudflare-managed domain. SST creates ACM certs + DNS records
 # automatically via the Cloudflare API. Deploy throws without STACK_DOMAIN, and
 # the Cloudflare provider fails without the two credentials.

--- a/apps/infra/README.md
+++ b/apps/infra/README.md
@@ -9,7 +9,7 @@
 One-command deploy of the BoxLite control plane: ECS Fargate services, an
 EC2 runner with nested KVM, RDS Postgres, ElastiCache Redis, S3, CloudFront.
 
-- **Region:** `ap-southeast-1`
+- **Region:** `AWS_REGION` (defaults to `ap-southeast-1`)
 - **IaC:** SST v4 (Pulumi under the hood)
 - **Cost at rest:** ~$570/month always-on — Runner + load balancers dominate (tear down with one command)
 
@@ -17,15 +17,16 @@ EC2 runner with nested KVM, RDS Postgres, ElastiCache Redis, S3, CloudFront.
 
 - A **Cloudflare-managed domain** (SST creates ACM certs + DNS records automatically)
 - An **Auth0 tenant** (or any OIDC provider — see `.env.example` for setup steps)
-- **Docker Desktop** running locally (SST builds container images)
-- **AWS CLI** configured with a profile that has admin access
+- A protected GitHub **`dev` Environment** with required reviewers
+- An AWS GitHub OIDC provider and the deployment role described below
+- **AWS CLI** and **GitHub CLI** for one-time CI bootstrap only
 
 ## Quick start
 
 ```bash
 cd apps/infra
 npm install
-cp .env.example .env        # non-secret config: STACK_DOMAIN, OIDC_ISSUER_BASE_URL, OIDC_AUDIENCE
+cp .env.example .env        # stage config: STACK_DOMAIN, OIDC_ISSUER_BASE_URL, OIDC_AUDIENCE
 
 # Cloudflare provider credentials live in SSM (per stage) — see "Secrets & credentials":
 aws ssm put-parameter --region ap-southeast-1 --type SecureString \
@@ -33,46 +34,100 @@ aws ssm put-parameter --region ap-southeast-1 --type SecureString \
 aws ssm put-parameter --region ap-southeast-1 --type SecureString \
   --name /boxlite/dev/cloudflare-account-id --value "<account-id>"
 
-npm run deploy -- --stage dev   # the wrapper loads the Cloudflare creds, then runs sst deploy
+# Required application secret. There is no placeholder fallback because a wrong
+# client ID makes every interactive login fail.
+npm run sst -- secret set OIDC_CLIENT_ID "<spa-client-id>" --stage dev
+
+# Bootstrap the short-lived GitHub OIDC role. The account's GitHub OIDC provider
+# already exists when the E2E CI setup has been run.
+aws cloudformation deploy --region ap-southeast-1 \
+  --stack-name boxlite-dev-github-deploy \
+  --template-file ci/github-deploy-role.yaml \
+  --capabilities CAPABILITY_NAMED_IAM
+
+# In the protected GitHub `dev` Environment, configure:
+#   variable AWS_DEPLOY_ROLE_ARN = the stack's RoleArn output
+#   variable AWS_REGION          = ap-southeast-1
+#   secret   DEPLOY_ENV          = the contents of this .env file
+gh secret set DEPLOY_ENV --env dev < .env
+
+# The workflow is manual and accepts deployments only from main.
+gh workflow run deploy-dev-api.yml --ref main
 ```
 
-App secrets (Auth0 Management API, Svix, PostHog) are optional and set
-per-stage in the SST secret store — see [Secrets & credentials](#secrets--credentials).
+`OIDC_CLIENT_ID` is required. Other app secrets (SSH keys, Auth0 Management API,
+Svix, PostHog) are optional and set per-stage in the SST secret store — see
+[Secrets & credentials](#secrets--credentials).
 
 First deploy: 10–15 minutes. Output prints service URLs + CloudFront domain.
 
-If the build fails with a transient `auth.docker.io` EOF or Debian mirror
-`502 Bad Gateway`, just rerun `npm run deploy -- --stage dev` — SST resumes
-from the failed step.
+If a build fails on a transient registry or package-mirror error, rerun the
+workflow — SST resumes from the failed step.
+
+## Native AMD64 CI deployment
+
+`.github/workflows/deploy-dev-api.yml` runs the deployment on GitHub's native
+`ubuntu-24.04` AMD64 runner. Docker, Buildx, image compilation, and the daemon all
+run in CI; a developer Mac needs neither Docker Desktop nor the Docker CLI. The
+workflow checks both the kernel and Docker engine architecture before SST runs.
+
+The job is manual, serialized, restricted to `main`, and bound to the protected
+GitHub `dev` Environment. GitHub OIDC supplies short-lived AWS credentials; no
+AWS access keys are stored in GitHub. `DEPLOY_ENV` materializes the stage's
+gitignored `.env` only for the job and is deleted even if deployment fails.
+
+The current workflow deliberately targets only `Api` and excludes `Runner`:
+
+```bash
+npm run deploy -- --stage dev --target Api --exclude Runner
+```
+
+The role template grants `AdministratorAccess` because this SST app creates IAM
+roles and many AWS resource types. Its trust policy accepts only OIDC tokens for
+`boxlite-ai/boxlite` using the `dev` Environment. Keep required reviewers enabled
+and use a separate AWS account for dev; narrow the policy later from CloudTrail
+with IAM Access Analyzer.
 
 ## Secrets & credentials
 
 Three homes, one access gate — **AWS IAM**. Nothing secret lives in git or a
 single laptop's `.env`:
 
-| What | Where | Set with |
-|---|---|---|
-| **App secrets** — Auth0 Management API id + secret, `SVIX_AUTH_TOKEN`, `POSTHOG_API_KEY`, `OIDC_CLIENT_ID` | SST secret store (encrypted in SST state, per stage) | `sst secret set <NAME> "<value>" --stage <stage>` |
-| **Cloudflare provider creds** — `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_DEFAULT_ACCOUNT_ID` | AWS SSM (`SecureString`, per stage) | `aws ssm put-parameter --type SecureString --name /boxlite/<stage>/cloudflare-…` |
-| **Non-secret config** — `STACK_DOMAIN`, `OIDC_ISSUER_BASE_URL`, `OIDC_AUDIENCE`, toggles | local `.env` (gitignored) | edit `.env` |
+| What                                                                                                                              | Where                                                                        | Set with                                                                         |
+| --------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| **App secrets** — SSH host/private keys, Auth0 Management API id + secret, `SVIX_AUTH_TOKEN`, `POSTHOG_API_KEY`, `OIDC_CLIENT_ID` | SST secret store (encrypted in SST state, per stage)                         | `npm run sst -- secret set <NAME> "<value>" --stage <stage>`                     |
+| **Cloudflare provider creds** — `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_DEFAULT_ACCOUNT_ID`                                           | AWS SSM (`SecureString`, per stage)                                          | `aws ssm put-parameter --type SecureString --name /boxlite/<stage>/cloudflare-…` |
+| **Stage config** — `STACK_DOMAIN`, `OIDC_ISSUER_BASE_URL`, `OIDC_AUDIENCE`, toggles                                               | GitHub Environment secret `DEPLOY_ENV`; local `.env` is the bootstrap source | `gh secret set DEPLOY_ENV --env dev < .env`                                      |
+
+`VERSION` is optional; it controls the release reported by `/api/config` and
+defaults to the canonical workspace version in `Cargo.toml`.
 
 The Cloudflare creds can't be `sst.Secret`: the provider initializes in `app()`
 before `run()` (where secrets exist), so it reads them from the environment.
-`scripts/sst-with-cloudflare.mjs` — wired into `npm run dev`/`deploy`/`remove`
-and `npm run sst` — fetches them from SSM and exports them before invoking sst.
+`scripts/sst-with-cloudflare.mjs` — wired into `npm run dev`/`deploy`/`remove`,
+`npm run secrets`, and `npm run sst` — fetches them from SSM and exports them
+before invoking sst.
 **Run sst through these npm scripts**, not bare `npx sst`, so the creds load.
+SST 4.6.11 exposes no supported deploy option to disable or redact this event
+stream, so the wrapper removes Pulumi's transient
+`.sst/pulumi/**/eventlog.json` before and after every wrapped SST command. These event
+streams can contain provider credentials; SST state and non-secret diagnostics
+are left in place. If an existing event log is ever found to contain a provider
+token, rotate that token immediately, then run any wrapped SST command to remove
+the stale event log.
 
 ### App secrets
 
 ```bash
-sst secret set SVIX_AUTH_TOKEN "<value>" --stage dev   # set one
-sst secret load .env --stage dev                       # bulk-load a dotenv (names match 1:1)
-npm run secrets -- --stage dev                          # list what's set
+npm run sst -- secret set SVIX_AUTH_TOKEN "<value>" --stage dev  # set one
+npm run sst -- secret load .env.secrets --stage dev              # bulk-load an ignored secret dotenv
+npm run secrets -- --stage dev                                   # list what's set
 ```
 
-Secret names match the env keys the services expect. Unset optional secrets
-resolve to empty (feature off); `OIDC_CLIENT_ID` defaults to `boxlite`. A changed
-value takes effect on the next `npm run deploy`.
+Secret names match the env keys the services expect, but values in the ordinary
+deployment `.env` are not consumed as SST application secrets. `OIDC_CLIENT_ID`
+has no fallback and must exist before deploy. Unset optional secrets resolve to
+empty (feature off). A changed value takes effect on the next `npm run deploy`.
 
 ### Onboarding / offboarding
 
@@ -106,22 +161,34 @@ It's idempotent — re-running `sst deploy` won't duplicate rows. Scaling **down
 is the deliberate decommission ceremony under [Runner lifecycle](#runner-lifecycle),
 applied per runner.
 
+### Custom system images
+
+Add supported images through `BOXLITE_SYSTEM_IMAGES` as documented in
+`.env.example`, for example
+`sandbaseai-hermes=sam2026go/hermes-agent:boxlite-noexpose-20260726`. Runners
+cache exact image refs, so publish updated bytes under a new immutable tag or
+digest; do not repush a mutable tag and expect an existing cache to refresh.
+
 > **Note:** `CLOUDFRONT_DOMAIN` is no longer needed — SST Router resolves
 > it automatically via your `STACK_DOMAIN`. The dashboard's API base URL
 > is likewise derived: `DASHBOARD_BASE_API_URL` defaults to
 > `https://api.<STACK_DOMAIN>` and is substituted into the bundled JS at
 > container start (see `apps/api/src/main.ts`).
 
+The dashboard derives one canonical `/api` URL from that injected value and
+uses it for both runtime requests and every generated SDK/CLI example. Remote
+URLs must use HTTPS; an HTTP fallback is accepted only on a loopback host.
+
 ## Public hostnames
 
 Four public DNS names, three different fronting layers:
 
-| Hostname                       | Fronted by             | Purpose                                                           |
-|--------------------------------|------------------------|-------------------------------------------------------------------|
-| `<STACK_DOMAIN>`               | CloudFront Router      | Dashboard SPA + static assets (cache-friendly, edge-served)       |
-| `api.<STACK_DOMAIN>`           | Api ALB (direct)       | REST API, WebSocket `/attach`, build-log streaming, file transfer |
-| `proxy.<STACK_DOMAIN>`         | Proxy ALB (direct)     | Port-preview wildcard `<port>-<boxId>.proxy.<domain>`         |
-| `*.proxy.<STACK_DOMAIN>`       | Proxy ALB (direct)     | Wildcard alias of the above (per-box preview hosts)           |
+| Hostname                 | Fronted by           | Purpose                                                           |
+| ------------------------ | -------------------- | ----------------------------------------------------------------- |
+| `<STACK_DOMAIN>`         | CloudFront Router    | Dashboard SPA + static assets (cache-friendly, edge-served)       |
+| `api.<STACK_DOMAIN>`     | Api ALB (direct)     | REST API, WebSocket `/attach`, build-log streaming, file transfer |
+| `proxy.<STACK_DOMAIN>`   | Proxy NLB (TLS)      | Port-preview wildcard `<port>-<boxId>.proxy.<domain>`             |
+| `*.proxy.<STACK_DOMAIN>` | Proxy NLB (TLS)      | Wildcard alias of the above (per-box preview hosts)               |
 
 **Why `/api/*` bypasses CloudFront.** CloudFront imposes a non-configurable
 10-minute idle cap on WebSocket connections — even with WS Ping frames and
@@ -135,16 +202,44 @@ CF-fronted. The dashboard's bundled JS picks up
 `apps/api/src/main.ts::replaceInDirectory`) so all its `/api/*` fetches go
 direct to the Api ALB.
 
-**SDK base URL.** Long-lived SDK sessions (`exec`, `attach`) should target
-`https://api.<STACK_DOMAIN>` directly, not `https://<STACK_DOMAIN>/api`. The
-CloudFront-routed path works for short request/response calls but caps
-WebSockets at 10 minutes.
+**SDK and CLI base URL.** Use `https://api.<STACK_DOMAIN>/api` for SDK and CLI
+profiles, especially for long-lived operations (`exec`, `attach`, SSE, and
+uploads). The CloudFront-routed `https://<STACK_DOMAIN>/api` path is only for
+short request/response calls; WebSocket execution attach is not a supported
+CloudFront path.
+
+## Proxy deployment safety
+
+The Proxy NLB, TLS listener, and target group are protected Pulumi resources.
+An immutable topology change therefore fails instead of silently replacing a
+target group during a partial deploy. Proxy and API task updates use ECS rolling
+deployments and wait for steady state. Proxy targets must pass `GET /health`.
+
+After every successful `npm run deploy`, `scripts/sst-with-cloudflare.mjs`
+queries AWS and verifies that the NLB listener forwards to the target group
+attached to the Proxy ECS service and that the group has at least the desired
+number of healthy targets. It then probes `/health` through both the base Proxy
+hostname and a deliberately invalid `deployment-probe.<PROXY_DOMAIN>` wildcard
+hostname, which verifies the wildcard DNS record and TLS certificate without a
+live box. The API `/api/config` probe also checks the exact OIDC issuer, release
+version, and Proxy template host. A failed check makes the deploy command exit nonzero; it reports the
+mismatch but does not mutate or roll back AWS resources.
+Deploys and removals require `--stage <stage>` (or `SST_STAGE`) so SST, the
+verifier, and destructive operations cannot target different stages.
+
+A deliberate NLB or target-group migration must be performed as a separate
+operation. First set all three Proxy transform `opts.protect` values to `false`
+and deploy that metadata-only change without changing topology. Then carry out
+the separately reviewed migration or `sst remove`; restore protection afterward
+if the stack remains. This prevents a topology replacement from being mixed
+into the same deploy that disables protection.
 
 ## WebSocket session length
 
-Api and Proxy ALBs have `idle_timeout: 3600` (1 hour) via the SST
-`transform.loadBalancer` hook in `sst.config.ts`. This pairs with three
-layers per AWS's "WebSocket through ALB" guidance:
+The Api ALB has `idle_timeout: 3600` (1 hour) via the SST
+`transform.loadBalancer` hook in `sst.config.ts`. Proxy traffic uses the TLS
+NLB described above. The API setting pairs with three layers per AWS's
+"WebSocket through ALB" guidance:
 
 - **App-layer WS Ping every 15s** sent by the runner
   (`apps/runner/pkg/api/controllers/{boxlite_exec_attach,proxy}.go`). The
@@ -187,6 +282,7 @@ For Auth0 specifically:
      `--callback-port` flag, add the matching URL here too.
 
    Set **Allowed Logout URLs** to `https://<STACK_DOMAIN>`.
+
 2. **Custom API** — identifier becomes `OIDC_AUDIENCE` (e.g. `https://dev.boxlite.ai/api`)
 3. **Post-Login Action** — Auth0 access_tokens don't include `email_verified` by default;
    without it BoxLite suspends the user's organization. Use
@@ -203,7 +299,11 @@ For Auth0 specifically:
    BoxLite fallback. ([Auth0 docs](https://auth0.com/docs/authenticate/login/logout/log-users-out-of-auth0))
 5. **Machine-to-Machine app** (optional, for account linking) — authorize for Auth0 Management API
    with permissions: `read:users`, `update:users`, `read:connections`,
-   `create:guardian_enrollment_tickets`, `read:connections_options`.
+   `create:guardian_enrollment_tickets`, `read:connections_options`. A root
+   issuer safely derives Auth0's `/api/v2/` prefix and `/oauth/token` endpoint.
+   If the provider issuer has a path, set `OIDC_MANAGEMENT_API_BASE_URL` and
+   `OIDC_MANAGEMENT_API_TOKEN_URL` to the provider's exact endpoints; the API
+   refuses to guess either value from the issuer path.
 6. **`OIDC_ISSUER_BASE_URL` env var** — set to Auth0's canonical issuer
    **with the trailing slash** (e.g. `https://dev-xxxxx.us.auth0.com/`).
    Auth0's discovery doc reports `issuer` with a trailing slash, and
@@ -216,34 +316,34 @@ For Auth0 specifically:
 
 ## Service URLs
 
-| Service             | Purpose                              | Exposure                                     |
-|---------------------|--------------------------------------|----------------------------------------------|
-| **Dashboard SPA**   | Browser UI (static assets via CDN)   | `https://<STACK_DOMAIN>` (CloudFront)        |
-| **Api**             | REST API + WebSocket `/attach`       | `https://api.<STACK_DOMAIN>` (public ALB)    |
-| **Proxy**           | `<port>-<id>.proxy.<domain>` previews | `https://*.proxy.<STACK_DOMAIN>` (public ALB) |
-| **Jaeger**          | Trace viewer (no auth)               | internal ALB (set `JAEGER_PUBLIC=true` to expose) |
-| **OtelCollector**   | OTLP ingest + health                 | internal ALB (in-VPC emitters only)          |
-| **PgAdmin**         | Postgres admin UI                    | internal ALB (set `PGADMIN_PUBLIC=true` to expose) |
-| **MailDev**         | Mock SMTP + web UI (no auth)         | internal ALB only — no public option (`MAILDEV_PUBLIC=true` is rejected) |
-| **ClickHouse Cloud** | Managed OTel storage                 | external service; configured by env         |
-| **ClickStack**      | Logs/traces/metrics explorer         | external ClickHouse Cloud UI                |
+| Service              | Purpose                               | Exposure                                                                 |
+| -------------------- | ------------------------------------- | ------------------------------------------------------------------------ |
+| **Dashboard SPA**    | Browser UI (static assets via CDN)    | `https://<STACK_DOMAIN>` (CloudFront)                                    |
+| **Api**              | REST API + WebSocket `/attach`        | `https://api.<STACK_DOMAIN>` (public ALB)                                |
+| **Proxy**            | `<port>-<id>.proxy.<domain>` previews | `https://*.proxy.<STACK_DOMAIN>` (public TLS NLB)                        |
+| **Jaeger**           | Trace viewer (no auth)                | internal ALB (set `JAEGER_PUBLIC=true` to expose)                        |
+| **OtelCollector**    | OTLP ingest + health                  | internal ALB (in-VPC emitters only)                                      |
+| **PgAdmin**          | Postgres admin UI                     | internal ALB (set `PGADMIN_PUBLIC=true` to expose)                       |
+| **MailDev**          | Mock SMTP + web UI (no auth)          | internal ALB only — no public option (`MAILDEV_PUBLIC=true` is rejected) |
+| **ClickHouse Cloud** | Managed OTel storage                  | external service; configured by env                                      |
+| **ClickStack**       | Logs/traces/metrics explorer          | external ClickHouse Cloud UI                                             |
 
-Run `npm run deploy -- --stage dev` without changes to reprint all URLs. See
+Run the `Deploy dev API` workflow again to redeploy the API. See
 [Public hostnames](#public-hostnames) below for the rationale behind the
 dashboard-vs-API split.
 
 ## Common commands
 
 ```bash
-npm run deploy -- --stage dev       # deploy / update
+gh workflow run deploy-dev-api.yml --ref main # native AMD64 API deployment
 npm run sst -- diff --stage dev     # preview changes
 npm run sst -- unlock --stage dev   # recover from "concurrent update detected"
 npm run sst -- shell --stage dev    # open shell with SST-linked env vars
-npm run remove -- --stage dev       # destroy everything
+npm run remove -- --stage dev       # requires the Proxy/Runner unprotect procedures
 ```
 
-> These route through `scripts/sst-with-cloudflare.mjs` so the Cloudflare provider
-> creds load from SSM. Bare `npx sst …` skips that and can't reach Cloudflare.
+> The workflow routes deployment through `scripts/sst-with-cloudflare.mjs` so
+> Cloudflare credentials load from SSM. Bare `npx sst …` skips that integration.
 
 ## Runner lifecycle
 
@@ -262,20 +362,75 @@ resource options on `sst.config.ts`'s Runner enforce that:
 ### Upgrading the runner binary
 
 The Runner binary version is pinned to `Cargo.toml`'s `version` field at the
-repo root. To deliver a new runner build without recreating the EC2:
+repo root. Treat a release that changes the API-to-Runner protocol as a
+capability-gated two-phase rollout:
+
+1. Publish the matching Runner tarball and checksum, then deploy the API and
+   infrastructure. The deploy preflight refuses to mutate SST when those
+   assets are absent. Existing detached box creates remain routable to older
+   Runners; requests that need the new foreground/command session capability
+   fail explicitly until a compatible Runner is available.
+2. Upgrade Runners one at a time with the command below. The API filters those
+   requests to Runners at the required version, and each upgraded Runner only
+   becomes schedulable after the control plane reports that exact version.
+
+An explicit `--exclude Runner` deployment is the operator escape hatch for a
+control-plane-only rollout. It skips the Runner release-asset preflight and
+leaves the EC2 resource, binary, and identity tag untouched. Detached requests
+that use legacy Runner capabilities remain available; requests needing the new
+Runner version fail explicitly until a later full rollout applies the metadata
+and upgrades the binary.
+
+This bounded compatibility window is intentional: silently discarding a
+requested command or foreground lifecycle would be data loss, while sending it
+to an older Runner would be a protocol error. To deliver a new runner build
+without recreating the EC2:
 
 ```bash
-# Uses the version in Cargo.toml by default; pass an explicit arg to override.
-scripts/deploy/runner-update-binary.sh           # latest from Cargo.toml
-scripts/deploy/runner-update-binary.sh 0.9.5     # explicit
+# Supply an admin API token from the operator's secret manager. Do not commit it
+# or put it in the SST deployment environment.
+CONTROL_PLANE_API_URL=https://api.dev.boxlite.ai/api \
+CONTROL_PLANE_API_KEY="$OPERATOR_API_KEY" \
+CONTROL_PLANE_RUNNER_ID=00000000-0000-4000-8000-000000000001 \
+CONTROL_PLANE_RUNNER_NAME=default \
+STAGE=dev scripts/deploy/runner-update-binary.sh \
+  --allow-disruptive-restart 0.9.8
+
+# Update additional runners one at a time. Each Runner has its own control-plane
+# UUID even when the AWS Name tag follows the same naming convention.
+CONTROL_PLANE_API_URL=https://api.boxlite.ai/api \
+CONTROL_PLANE_API_KEY="$OPERATOR_API_KEY" \
+CONTROL_PLANE_RUNNER_ID=00000000-0000-4000-8000-000000000002 \
+CONTROL_PLANE_RUNNER_NAME=runner-2 \
+STAGE=production RUNNER_NAME=boxlite-runner-2 \
+  scripts/deploy/runner-update-binary.sh --allow-disruptive-restart 0.9.8
 ```
 
-The script uses AWS SSM Run Command to download the release tarball from
-GitHub Releases and verify its SHA-256 *before* stopping the systemd unit — so
-a failed or corrupt fetch never takes the runner down — then backs up the live
-binary, swaps `/usr/local/bin/boxlite-runner`, and restarts. If the new binary
-fails to come up, it performs a rollback to the backup. Box state under
-`/var/lib/boxlite` is untouched.
+The AWS `Name` and control-plane Runner names are intentionally different, so
+both must be supplied. Before touching AWS, the script resolves
+`CONTROL_PLANE_RUNNER_ID` through the admin API and requires its exact name to
+equal `CONTROL_PLANE_RUNNER_NAME`. It then selects exactly one running EC2 using
+the SST app, explicit stage, AWS `RUNNER_NAME`, and the
+`boxlite:control-plane-runner-name` mapping tag. Only after those checks does it
+start a persistent `restart` drain. That transaction makes the Runner
+unschedulable; new box assignments, warm-pool claims, and pending starts are
+fenced while the script polls the control plane until the active-box count
+reaches zero.
+
+Only then does AWS SSM Run Command download the release tarball, require its
+SHA-256 sidecar, and confirm the candidate's exact version before stopping the
+systemd unit. It backs up the live binary, swaps it, and requires both the local
+`--version` output and Runner HTTP health response to report the requested
+version. It then waits for the control plane to see the restarted Runner as
+drained with zero active boxes and to report the requested `appVersion`; only
+then does the updater clear the restart drain. On success, the control plane
+restores the scheduling state that existed before the drain. On any drain, SSM,
+rollback, readiness, or version-observation failure, the Runner remains drained
+for operator inspection; do not manually re-enable it until the failed command
+is understood. Files under
+`/var/lib/boxlite` remain on disk, but that does not make an active-VM restart
+non-disruptive, so the explicit `--allow-disruptive-restart` acknowledgement
+remains required.
 
 ### Deliberate decommission (three-step ceremony)
 
@@ -295,19 +450,15 @@ operation by design:
    ```
 
 4. Edit `sst.config.ts`: change `protect: false` back to `protect: true`. Run
-   `npm run deploy` again — a new Runner is created with fresh state.
+   `npm run deploy -- --stage <stage>` again — a new Runner is created with
+   fresh state.
 
-This is deliberate by construction: three code edits across two deploys. If
-you find yourself doing this often, look at the future drain API (tracked
-separately) instead of streamlining the ceremony.
-
-### Future: control-plane drain (`runner.state` enum)
-
-The current state is single-Runner with manual decommission. A future phase
-will add a `runner.state` enum (`initializing`, `ready`, `disabled`,
-`decommissioned`, `unresponsive`) and admin endpoints to drain a Runner via
-the API, mirroring the upstream Daytona model. Multi-Runner Pulumi shape
-follows that. Not yet implemented.
+This is deliberate by construction: three code edits across two deploys. The
+control plane now provides two drain modes around this ceremony: ordinary
+decommission drains remain eligible for the decommission worker, while the
+admin updater uses a restart drain that keeps the Runner protected and
+unschedulable until its in-place binary update succeeds. Neither mode removes
+the explicit Pulumi protection steps required to replace the EC2 resource.
 
 ## Architecture
 
@@ -321,9 +472,9 @@ follows that. Not yet implemented.
                                      api.<STACK_DOMAIN>
                                      idle_timeout=1h  (for long WS sessions)
 
-  Browser ───▶ Proxy ALB ───▶ box port (toolbox + user-app previews)
+  Browser ───▶ Proxy NLB ───▶ Proxy ECS ───▶ box port (toolbox + user-app previews)
                 proxy.<STACK_DOMAIN> + *.proxy.<STACK_DOMAIN>
-                idle_timeout=1h
+                TLS:443 → TCP:4000
 
                           ┌───────┬────────┬────────┐
                           │  RDS  │ Redis  │   S3   │  Api → DB/Redis (linked);
@@ -352,7 +503,7 @@ is fine; ignore it.
 **Api crashes with `Failed to fetch OpenID configuration`** — the API can't
 reach `<OIDC_ISSUER_BASE_URL>/.well-known/openid-configuration`. Check network
 egress from the API container to the IdP, and confirm `OIDC_ISSUER_BASE_URL`
-points at a working host. apps/api strips a trailing slash *only* when composing
+points at a working host. apps/api strips a trailing slash _only_ when composing
 its own internal discovery URL; the value is exposed to clients via `/api/config`
 verbatim — see the next two entries.
 
@@ -361,7 +512,7 @@ verbatim — see the next two entries.
 under `issuer`. Auth0 always reports the issuer with a trailing slash; spec-
 compliant OIDC clients (including the Rust CLI's `openidconnect` crate)
 demand byte-for-byte match. Fix: set `OIDC_ISSUER_BASE_URL` to the form your
-IdP returns (Auth0: `https://dev-xxxxx.us.auth0.com/` *with* slash). See
+IdP returns (Auth0: `https://dev-xxxxx.us.auth0.com/` _with_ slash). See
 the OIDC setup section above. The Rust CLI tolerates this with a one-shot
 retry that toggles the trailing slash, so the user-visible failure here is
 typically the web dashboard, not the CLI — but treat any `unexpected issuer
@@ -392,24 +543,31 @@ missing `email_verified` claim. Deploy the Post-Login Action described above.
 systemd logs (`aws ssm start-session` → `journalctl -u boxlite-runner`) for auth
 or connectivity errors to the API.
 
-**Box preview URL returns 503** — Proxy service may need a force-redeploy after
-initial setup: `aws ecs update-service --force-new-deployment --service Proxy`.
+**Box preview cannot connect** — verify that the NLB listener target group
+matches the Proxy ECS service attachment and has a registered target. Do not
+switch the listener to a replacement target group until its Proxy target passes
+`/health`.
+
+**Dashboard terminal cannot connect** — the terminal uses the direct API host,
+not the Proxy NLB. Verify `https://api.<STACK_DOMAIN>/api/config`, the API ECS
+service, and the dashboard's configured API base URL.
 
 **Docker build fails with "broken pipe"** — transient ECR push failure. Retry deploy.
 
 ## Cost (ap-southeast-1, always-on)
 
-| Resource                              | Monthly |
-|---------------------------------------|---------|
-| EC2 c8i.2xlarge (Runner)              | ~$325   |
-| Load balancers (6 ALB + 1 NLB)        | ~$115   |
-| 7x Fargate 0.25 vCPU / 0.5 GB         | ~$65    |
-| 2x NAT EC2 (`t4g.nano`) + public IPv4 | ~$16    |
-| RDS `t4g.micro` Postgres              | ~$15    |
-| ElastiCache Redis                     | ~$15    |
-| CloudFront + S3 + CloudWatch Logs     | ~$20    |
+| Resource                              | Monthly   |
+| ------------------------------------- | --------- |
+| EC2 c8i.2xlarge (Runner)              | ~$325     |
+| Load balancers (5 ALB + 2 NLB)        | ~$115     |
+| 7x Fargate 0.25 vCPU / 0.5 GB         | ~$65      |
+| 2x NAT EC2 (`t4g.nano`) + public IPv4 | ~$16      |
+| RDS `t4g.micro` Postgres              | ~$15      |
+| ElastiCache Redis                     | ~$15      |
+| CloudFront + S3 + CloudWatch Logs     | ~$20      |
 | **Total**                             | **~$570** |
 
 Figures are approximate (ap-southeast-1 on-demand). The **Runner and the load
-balancers dominate** — the NAT is ~$16, not a headline cost. `npm run remove -- --stage dev` tears it all down; S3 buckets and RDS snapshots are retained in
-production stage (`--stage production`) per SST's default.
+balancers dominate** — the NAT is ~$16, not a headline cost. Stack removal
+requires the Proxy and Runner unprotect procedures above; S3 buckets and RDS
+snapshots are retained in production (`--stage production`) per SST's default.

--- a/apps/infra/README.md
+++ b/apps/infra/README.md
@@ -88,7 +88,9 @@ profiles. Every role created by SST must carry the stage's runtime permissions
 boundary, which excludes IAM mutation and limits workloads to the data-plane APIs
 they need. Its trust policy accepts only OIDC tokens for `boxlite-ai/boxlite`
 using the `dev` Environment. Redeploy the bootstrap stack whenever this policy or
-boundary changes, and keep required reviewers enabled on that Environment.
+boundary changes. `IAM_PERMISSIONS_BOUNDARY_STAGE` must match both the SST stage
+and the template's `GitHubEnvironment`; deployment fails before creating roles if
+they differ. Keep required reviewers enabled on that Environment.
 
 ## Secrets & credentials
 

--- a/apps/infra/README.md
+++ b/apps/infra/README.md
@@ -82,11 +82,13 @@ The current workflow deliberately targets only `Api` and excludes `Runner`:
 npm run deploy -- --stage dev --target Api --exclude Runner
 ```
 
-The role template grants `AdministratorAccess` because this SST app creates IAM
-roles and many AWS resource types. Its trust policy accepts only OIDC tokens for
-`boxlite-ai/boxlite` using the `dev` Environment. Keep required reviewers enabled
-and use a separate AWS account for dev; narrow the policy later from CloudTrail
-with IAM Access Analyzer.
+The role template grants only the AWS control-plane actions used by this SST
+stack. IAM mutation is limited to `boxlite-*` roles, policies, and instance
+profiles. Every role created by SST must carry the stage's runtime permissions
+boundary, which excludes IAM mutation and limits workloads to the data-plane APIs
+they need. Its trust policy accepts only OIDC tokens for `boxlite-ai/boxlite`
+using the `dev` Environment. Redeploy the bootstrap stack whenever this policy or
+boundary changes, and keep required reviewers enabled on that Environment.
 
 ## Secrets & credentials
 

--- a/apps/infra/ci/github-deploy-role.yaml
+++ b/apps/infra/ci/github-deploy-role.yaml
@@ -20,33 +20,19 @@ Resources:
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
-          - Sid: RuntimeDataPlane
+          - Sid: RuntimeAccountWideControlChannels
             Effect: Allow
             Action:
               - ecr:GetAuthorizationToken
               - ecr:BatchCheckLayerAvailability
               - ecr:BatchGetImage
               - ecr:GetDownloadUrlForLayer
-              - kms:Decrypt
               - logs:CreateLogGroup
               - logs:CreateLogStream
               - logs:DescribeLogGroups
               - logs:DescribeLogStreams
               - logs:FilterLogEvents
               - logs:PutLogEvents
-              - s3:AbortMultipartUpload
-              - s3:CreateBucket
-              - s3:DeleteBucket
-              - s3:DeleteObject
-              - s3:DeleteObjectVersion
-              - s3:GetBucketLocation
-              - s3:GetObject
-              - s3:ListBucket
-              - s3:ListBucketVersions
-              - s3:PutBucketTagging
-              - s3:PutObject
-              - secretsmanager:DescribeSecret
-              - secretsmanager:GetSecretValue
               - ssm:DescribeAssociation
               - ssm:GetDeployablePatchSnapshotForInstance
               - ssm:GetDocument
@@ -72,6 +58,42 @@ Resources:
               - ec2messages:GetMessages
               - ec2messages:SendReply
             Resource: '*'
+          - Sid: BoxLiteStageSecrets
+            Effect: Allow
+            Action:
+              - secretsmanager:DescribeSecret
+              - secretsmanager:GetSecretValue
+            Resource: !Sub arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:boxlite-${GitHubEnvironment}-*
+          - Sid: BoxLiteStageKmsKeys
+            Effect: Allow
+            Action: kms:Decrypt
+            Resource: !Sub arn:${AWS::Partition}:kms:${AWS::Region}:${AWS::AccountId}:key/*
+            Condition:
+              ForAnyValue:StringLike:
+                kms:ResourceAliases: !Sub alias/boxlite-${GitHubEnvironment}-*
+          - Sid: BoxLiteBuckets
+            Effect: Allow
+            Action:
+              - s3:CreateBucket
+              - s3:DeleteBucket
+              - s3:GetBucketLocation
+              - s3:ListBucket
+              - s3:ListBucketVersions
+              - s3:PutBucketTagging
+            Resource:
+              - !Sub arn:${AWS::Partition}:s3:::boxlite-${GitHubEnvironment}-*
+              - !Sub arn:${AWS::Partition}:s3:::boxlite-volume-*
+          - Sid: BoxLiteBucketObjects
+            Effect: Allow
+            Action:
+              - s3:AbortMultipartUpload
+              - s3:DeleteObject
+              - s3:DeleteObjectVersion
+              - s3:GetObject
+              - s3:PutObject
+            Resource:
+              - !Sub arn:${AWS::Partition}:s3:::boxlite-${GitHubEnvironment}-*/*
+              - !Sub arn:${AWS::Partition}:s3:::boxlite-volume-*/*
           - Sid: AssumeBoxLiteRuntimeRoles
             Effect: Allow
             Action: sts:AssumeRole

--- a/apps/infra/ci/github-deploy-role.yaml
+++ b/apps/infra/ci/github-deploy-role.yaml
@@ -1,0 +1,39 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: GitHub Actions OIDC role for BoxLite SST deployments
+
+Parameters:
+  GitHubRepository:
+    Type: String
+    Default: boxlite-ai/boxlite
+    AllowedPattern: '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$'
+  GitHubEnvironment:
+    Type: String
+    Default: dev
+    AllowedPattern: '^[A-Za-z0-9_.-]+$'
+
+Resources:
+  GitHubDeployRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub boxlite-${GitHubEnvironment}-github-deploy
+      Description: Short-lived role used only by the guarded BoxLite GitHub deployment environment
+      MaxSessionDuration: 7200
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Federated: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:oidc-provider/token.actions.githubusercontent.com
+            Action: sts:AssumeRoleWithWebIdentity
+            Condition:
+              StringEquals:
+                token.actions.githubusercontent.com:aud: sts.amazonaws.com
+                token.actions.githubusercontent.com:sub: !Sub repo:${GitHubRepository}:environment:${GitHubEnvironment}
+      ManagedPolicyArns:
+        # SST can create IAM and arbitrary AWS resources declared by the app.
+        # The OIDC trust boundary and protected GitHub Environment are the gate.
+        - arn:aws:iam::aws:policy/AdministratorAccess
+
+Outputs:
+  RoleArn:
+    Value: !GetAtt GitHubDeployRole.Arn

--- a/apps/infra/ci/github-deploy-role.yaml
+++ b/apps/infra/ci/github-deploy-role.yaml
@@ -12,6 +12,71 @@ Parameters:
     AllowedPattern: '^[A-Za-z0-9_.-]+$'
 
 Resources:
+  BoxLiteRuntimePermissionsBoundary:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: !Sub boxlite-${GitHubEnvironment}-runtime-boundary
+      Description: Maximum data-plane permissions for roles created by the BoxLite SST stack
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: RuntimeDataPlane
+            Effect: Allow
+            Action:
+              - ecr:GetAuthorizationToken
+              - ecr:BatchCheckLayerAvailability
+              - ecr:BatchGetImage
+              - ecr:GetDownloadUrlForLayer
+              - kms:Decrypt
+              - logs:CreateLogGroup
+              - logs:CreateLogStream
+              - logs:DescribeLogGroups
+              - logs:DescribeLogStreams
+              - logs:FilterLogEvents
+              - logs:PutLogEvents
+              - s3:AbortMultipartUpload
+              - s3:CreateBucket
+              - s3:DeleteBucket
+              - s3:DeleteObject
+              - s3:DeleteObjectVersion
+              - s3:GetBucketLocation
+              - s3:GetObject
+              - s3:ListBucket
+              - s3:ListBucketVersions
+              - s3:PutBucketTagging
+              - s3:PutObject
+              - secretsmanager:DescribeSecret
+              - secretsmanager:GetSecretValue
+              - ssm:DescribeAssociation
+              - ssm:GetDeployablePatchSnapshotForInstance
+              - ssm:GetDocument
+              - ssm:GetManifest
+              - ssm:GetParameter
+              - ssm:GetParameters
+              - ssm:ListAssociations
+              - ssm:ListInstanceAssociations
+              - ssm:PutComplianceItems
+              - ssm:PutConfigurePackageResult
+              - ssm:PutInventory
+              - ssm:UpdateAssociationStatus
+              - ssm:UpdateInstanceAssociationStatus
+              - ssm:UpdateInstanceInformation
+              - ssmmessages:CreateControlChannel
+              - ssmmessages:CreateDataChannel
+              - ssmmessages:OpenControlChannel
+              - ssmmessages:OpenDataChannel
+              - ec2messages:AcknowledgeMessage
+              - ec2messages:DeleteMessage
+              - ec2messages:FailMessage
+              - ec2messages:GetEndpoint
+              - ec2messages:GetMessages
+              - ec2messages:SendReply
+            Resource: '*'
+          - Sid: AssumeBoxLiteRuntimeRoles
+            Effect: Allow
+            Action: sts:AssumeRole
+            Resource: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/boxlite-*
+
   GitHubDeployRole:
     Type: AWS::IAM::Role
     Properties:
@@ -29,11 +94,113 @@ Resources:
               StringEquals:
                 token.actions.githubusercontent.com:aud: sts.amazonaws.com
                 token.actions.githubusercontent.com:sub: !Sub repo:${GitHubRepository}:environment:${GitHubEnvironment}
-      ManagedPolicyArns:
-        # SST can create IAM and arbitrary AWS resources declared by the app.
-        # The OIDC trust boundary and protected GitHub Environment are the gate.
-        - arn:aws:iam::aws:policy/AdministratorAccess
+      Policies:
+        - PolicyName: boxlite-sst-deploy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: BoxLiteAwsControlPlane
+                Effect: Allow
+                Action:
+                  - acm:*
+                  - application-autoscaling:*
+                  - autoscaling:*
+                  - cloudfront:*
+                  - cloudwatch:*
+                  - ec2:*
+                  - ecr:*
+                  - ecs:*
+                  - elasticache:*
+                  - elasticloadbalancing:*
+                  - kms:DescribeKey
+                  - lambda:*
+                  - logs:*
+                  - rds:*
+                  - s3:*
+                  - secretsmanager:*
+                  - servicediscovery:*
+                  - ssm:*
+                  - tag:GetResources
+                  - tag:GetTagKeys
+                  - tag:GetTagValues
+                Resource: '*'
+              - Sid: ReadIamAndAccountMetadata
+                Effect: Allow
+                Action:
+                  - iam:GetInstanceProfile
+                  - iam:GetPolicy
+                  - iam:GetPolicyVersion
+                  - iam:GetRole
+                  - iam:GetRolePolicy
+                  - iam:ListAttachedRolePolicies
+                  - iam:ListInstanceProfilesForRole
+                  - iam:ListPolicyVersions
+                  - iam:ListRolePolicies
+                  - iam:ListRoleTags
+                  - sts:GetCallerIdentity
+                Resource: '*'
+              - Sid: CreateBoundedBoxLiteRoles
+                Effect: Allow
+                Action: iam:CreateRole
+                Resource: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/boxlite-*
+                Condition:
+                  StringEquals:
+                    iam:PermissionsBoundary: !Ref BoxLiteRuntimePermissionsBoundary
+              - Sid: ManageBoxLiteRoles
+                Effect: Allow
+                Action:
+                  - iam:AttachRolePolicy
+                  - iam:CreateInstanceProfile
+                  - iam:DeleteInstanceProfile
+                  - iam:DeleteRole
+                  - iam:DeleteRolePolicy
+                  - iam:DetachRolePolicy
+                  - iam:PassRole
+                  - iam:PutRolePolicy
+                  - iam:RemoveRoleFromInstanceProfile
+                  - iam:AddRoleToInstanceProfile
+                  - iam:TagInstanceProfile
+                  - iam:TagRole
+                  - iam:UntagInstanceProfile
+                  - iam:UntagRole
+                  - iam:UpdateAssumeRolePolicy
+                  - iam:UpdateRole
+                  - iam:UpdateRoleDescription
+                Resource:
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/boxlite-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/boxlite-*
+              - Sid: SetBoxLiteRoleBoundary
+                Effect: Allow
+                Action: iam:PutRolePermissionsBoundary
+                Resource: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/boxlite-*
+                Condition:
+                  StringEquals:
+                    iam:PermissionsBoundary: !Ref BoxLiteRuntimePermissionsBoundary
+              - Sid: ManageBoxLitePolicies
+                Effect: Allow
+                Action:
+                  - iam:CreatePolicy
+                  - iam:CreatePolicyVersion
+                  - iam:DeletePolicy
+                  - iam:DeletePolicyVersion
+                  - iam:SetDefaultPolicyVersion
+                  - iam:TagPolicy
+                  - iam:UntagPolicy
+                Resource: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/boxlite-*
+              - Sid: CreateRequiredServiceLinkedRoles
+                Effect: Allow
+                Action: iam:CreateServiceLinkedRole
+                Resource: !Sub arn:${AWS::Partition}:iam::*:role/aws-service-role/*
+                Condition:
+                  StringEquals:
+                    iam:AWSServiceName:
+                      - autoscaling.amazonaws.com
+                      - ecs.amazonaws.com
+                      - elasticloadbalancing.amazonaws.com
+                      - rds.amazonaws.com
 
 Outputs:
   RoleArn:
     Value: !GetAtt GitHubDeployRole.Arn
+  RuntimePermissionsBoundaryArn:
+    Value: !Ref BoxLiteRuntimePermissionsBoundary

--- a/apps/infra/package-lock.json
+++ b/apps/infra/package-lock.json
@@ -1,0 +1,3230 @@
+{
+  "name": "@boxlite/infra",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@boxlite/infra",
+      "version": "0.0.1",
+      "dependencies": {
+        "@pulumi/random": "^4.19.2",
+        "dotenv": "^17.4.0"
+      },
+      "devDependencies": {
+        "@pulumi/aws": "^7.24.0",
+        "sst": "^4.6.11"
+      }
+    },
+    "node_modules/@gar/promise-retry": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@gar/promise-retry/-/promise-retry-1.0.3.tgz",
+      "integrity": "sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
+      "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.0.tgz",
+      "integrity": "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.3",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@isaacs/string-locale-compare": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/string-locale-compare/-/string-locale-compare-1.1.0.tgz",
+      "integrity": "sha512-SQ7Kzhh9+D+ZW9MA0zkYv3VXhIDNx+LzM6EJ+/65I3QY+enU6Itte7E5XX7EWrqLW2FN4n06GWzBnPoC3th2aQ==",
+      "license": "ISC"
+    },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/@logdna/tail-file": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@logdna/tail-file/-/tail-file-2.2.0.tgz",
+      "integrity": "sha512-XGSsWDweP80Fks16lwkAUIr54ICyBs6PsI4mpfTLQaWgEJRtY9xEV+PeyDpJ+sJEGZxqINlpmAwe/6tS1pP8Ng==",
+      "license": "SEE LICENSE IN LICENSE",
+      "engines": {
+        "node": ">=10.3.0"
+      }
+    },
+    "node_modules/@npmcli/agent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-4.0.0.tgz",
+      "integrity": "sha512-kAQTcEN9E8ERLVg5AsGwLNoFb+oEG6engbqAU2P43gD4JEIkNGMHdVQ096FsOAAYpZPB0RSt0zgInKIAS1l5QA==",
+      "license": "ISC",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "lru-cache": "^11.2.1",
+        "socks-proxy-agent": "^8.0.3"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/arborist": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/arborist/-/arborist-9.4.2.tgz",
+      "integrity": "sha512-omJgPyzt11cEGrxzgrECoOyxAunmPMgBFTcAB/FbaB+9iOYhGmRdsQqySV8o0LWQ/l2kTeASUIMR4xJufVwmtw==",
+      "license": "ISC",
+      "dependencies": {
+        "@gar/promise-retry": "^1.0.0",
+        "@isaacs/string-locale-compare": "^1.1.0",
+        "@npmcli/fs": "^5.0.0",
+        "@npmcli/installed-package-contents": "^4.0.0",
+        "@npmcli/map-workspaces": "^5.0.0",
+        "@npmcli/metavuln-calculator": "^9.0.2",
+        "@npmcli/name-from-folder": "^4.0.0",
+        "@npmcli/node-gyp": "^5.0.0",
+        "@npmcli/package-json": "^7.0.0",
+        "@npmcli/query": "^5.0.0",
+        "@npmcli/redact": "^4.0.0",
+        "@npmcli/run-script": "^10.0.0",
+        "bin-links": "^6.0.0",
+        "cacache": "^20.0.1",
+        "common-ancestor-path": "^2.0.0",
+        "hosted-git-info": "^9.0.0",
+        "json-stringify-nice": "^1.1.4",
+        "lru-cache": "^11.2.1",
+        "minimatch": "^10.0.3",
+        "nopt": "^9.0.0",
+        "npm-install-checks": "^8.0.0",
+        "npm-package-arg": "^13.0.0",
+        "npm-pick-manifest": "^11.0.1",
+        "npm-registry-fetch": "^19.0.0",
+        "pacote": "^21.0.2",
+        "parse-conflict-json": "^5.0.1",
+        "proc-log": "^6.0.0",
+        "proggy": "^4.0.0",
+        "promise-all-reject-late": "^1.0.0",
+        "promise-call-limit": "^3.0.1",
+        "semver": "^7.3.7",
+        "ssri": "^13.0.0",
+        "treeverse": "^3.0.0",
+        "walk-up-path": "^4.0.0"
+      },
+      "bin": {
+        "arborist": "bin/index.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/fs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-5.0.0.tgz",
+      "integrity": "sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==",
+      "license": "ISC",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/git": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-7.0.2.tgz",
+      "integrity": "sha512-oeolHDjExNAJAnlYP2qzNjMX/Xi9bmu78C9dIGr4xjobrSKbuMYCph8lTzn4vnW3NjIqVmw/f8BCfouqyJXlRg==",
+      "license": "ISC",
+      "dependencies": {
+        "@gar/promise-retry": "^1.0.0",
+        "@npmcli/promise-spawn": "^9.0.0",
+        "ini": "^6.0.0",
+        "lru-cache": "^11.2.1",
+        "npm-pick-manifest": "^11.0.1",
+        "proc-log": "^6.0.0",
+        "semver": "^7.3.5",
+        "which": "^6.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/git/node_modules/ini": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
+      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/installed-package-contents": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/installed-package-contents/-/installed-package-contents-4.0.0.tgz",
+      "integrity": "sha512-yNyAdkBxB72gtZ4GrwXCM0ZUedo9nIbOMKfGjt6Cu6DXf0p8y1PViZAKDC8q8kv/fufx0WTjRBdSlyrvnP7hmA==",
+      "license": "ISC",
+      "dependencies": {
+        "npm-bundled": "^5.0.0",
+        "npm-normalize-package-bin": "^5.0.0"
+      },
+      "bin": {
+        "installed-package-contents": "bin/index.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/map-workspaces": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@npmcli/map-workspaces/-/map-workspaces-5.0.3.tgz",
+      "integrity": "sha512-o2grssXo1e774E5OtEwwrgoszYRh0lqkJH+Pb9r78UcqdGJRDRfhpM8DvZPjzNLLNYeD/rNbjOKM3Ss5UABROw==",
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/name-from-folder": "^4.0.0",
+        "@npmcli/package-json": "^7.0.0",
+        "glob": "^13.0.0",
+        "minimatch": "^10.0.3"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/metavuln-calculator": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@npmcli/metavuln-calculator/-/metavuln-calculator-9.0.3.tgz",
+      "integrity": "sha512-94GLSYhLXF2t2LAC7pDwLaM4uCARzxShyAQKsirmlNcpidH89VA4/+K1LbJmRMgz5gy65E/QBBWQdUvGLe2Frg==",
+      "license": "ISC",
+      "dependencies": {
+        "cacache": "^20.0.0",
+        "json-parse-even-better-errors": "^5.0.0",
+        "pacote": "^21.0.0",
+        "proc-log": "^6.0.0",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/name-from-folder": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/name-from-folder/-/name-from-folder-4.0.0.tgz",
+      "integrity": "sha512-qfrhVlOSqmKM8i6rkNdZzABj8MKEITGFAY+4teqBziksCQAOLutiAxM1wY2BKEd8KjUSpWmWCYxvXr0y4VTlPg==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/node-gyp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/node-gyp/-/node-gyp-5.0.0.tgz",
+      "integrity": "sha512-uuG5HZFXLfyFKqg8QypsmgLQW7smiRjVc45bqD/ofZZcR/uxEjgQU8qDPv0s9TEeMUiAAU/GC5bR6++UdTirIQ==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/package-json": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-7.0.5.tgz",
+      "integrity": "sha512-iVuTlG3ORq2iaVa1IWUxAO/jIp77tUKBhoMjuzYW2kL4MLN1bi/ofqkZ7D7OOwh8coAx1/S2ge0rMdGv8sLSOQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/git": "^7.0.0",
+        "glob": "^13.0.0",
+        "hosted-git-info": "^9.0.0",
+        "json-parse-even-better-errors": "^5.0.0",
+        "proc-log": "^6.0.0",
+        "semver": "^7.5.3",
+        "spdx-expression-parse": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/promise-spawn": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-9.0.1.tgz",
+      "integrity": "sha512-OLUaoqBuyxeTqUvjA3FZFiXUfYC1alp3Sa99gW3EUDz3tZ3CbXDdcZ7qWKBzicrJleIgucoWamWH1saAmH/l2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "which": "^6.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/query": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/query/-/query-5.0.0.tgz",
+      "integrity": "sha512-8TZWfTQOsODpLqo9SVhVjHovmKXNpevHU0gO9e+y4V4fRIOneiXy0u0sMP9LmS71XivrEWfZWg50ReH4WRT4aQ==",
+      "license": "ISC",
+      "dependencies": {
+        "postcss-selector-parser": "^7.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/redact": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/redact/-/redact-4.0.0.tgz",
+      "integrity": "sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/run-script": {
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-10.0.4.tgz",
+      "integrity": "sha512-mGUWr1uMnf0le2TwfOZY4SFxZGXGfm4Jtay/nwAa2FLNAKXUoUwaGwBMNH36UHPtinWfTSJ3nqFQr0091CxVGg==",
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/node-gyp": "^5.0.0",
+        "@npmcli/package-json": "^7.0.0",
+        "@npmcli/promise-spawn": "^9.0.0",
+        "node-gyp": "^12.1.0",
+        "proc-log": "^6.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+      "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/context-async-hooks": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.1.tgz",
+      "integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
+      "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.57.2.tgz",
+      "integrity": "sha512-gHU1vA3JnHbNxEXg5iysqCWxN9j83d7/epTYBZflqQnTyCC4N7yZXn/dMM+bEmyhQPGjhCkNZLx4vZuChH1PYw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.7.1",
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/otlp-exporter-base": "0.57.2",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.57.2",
+        "@opentelemetry/otlp-transformer": "0.57.2",
+        "@opentelemetry/resources": "1.30.1",
+        "@opentelemetry/sdk-trace-base": "1.30.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-zipkin": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.30.1.tgz",
+      "integrity": "sha512-6S2QIMJahIquvFaaxmcwpvQQRD/YFaMTNoIxrfPIPOeITN+a8lfEcPDxNxn8JDAaxkg+4EnXhz8upVDYenoQjA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/resources": "1.30.1",
+        "@opentelemetry/sdk-trace-base": "1.30.1",
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
+      "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.57.2",
+        "@types/shimmer": "^1.2.0",
+        "import-in-the-middle": "^1.8.1",
+        "require-in-the-middle": "^7.1.1",
+        "semver": "^7.5.2",
+        "shimmer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-grpc": {
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.57.2.tgz",
+      "integrity": "sha512-TR6YQA67cLSZzdxbf2SrbADJy2Y8eBW1+9mF15P0VK2MYcpdoUSmQTF1oMkBwa3B9NwqDFA2fq7wYTTutFQqaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "0.57.2",
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.57.2.tgz",
+      "integrity": "sha512-XdxEzL23Urhidyebg5E6jZoaiW5ygP/mRjxLHixogbqwDy2Faduzb5N0o/Oi+XTIJu+iyxXdVORjXax+Qgfxag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/otlp-transformer": "0.57.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-grpc-exporter-base": {
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.57.2.tgz",
+      "integrity": "sha512-USn173KTWy0saqqRB5yU9xUZ2xdgb1Rdu5IosJnm9aV4hMTuFFRTUsQxbgc24QxpCHeoKzzCSnS/JzdV0oM2iQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.7.1",
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/otlp-exporter-base": "0.57.2",
+        "@opentelemetry/otlp-transformer": "0.57.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.57.2.tgz",
+      "integrity": "sha512-48IIRj49gbQVK52jYsw70+Jv+JbahT8BqT2Th7C4H7RCM9d0gZ5sgNPoMpWldmfjvIsSgiGJtjfk9MeZvjhoig==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.57.2",
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/resources": "1.30.1",
+        "@opentelemetry/sdk-logs": "0.57.2",
+        "@opentelemetry/sdk-metrics": "1.30.1",
+        "@opentelemetry/sdk-trace-base": "1.30.1",
+        "protobufjs": "^7.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/propagator-b3": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.30.1.tgz",
+      "integrity": "sha512-oATwWWDIJzybAZ4pO76ATN5N6FFbOA1otibAVlS8v90B4S1wClnhRUk7K+2CHAwN1JKYuj4jh/lpCEG5BAqFuQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.30.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/propagator-jaeger": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.30.1.tgz",
+      "integrity": "sha512-Pj/BfnYEKIOImirH76M4hDaBSx6HyZ2CXUqk+Kj02m6BB80c/yo4BdWkn/1gDFfU+YPY+bPR2U0DKBfdxCKwmg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.30.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
+      "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.57.2.tgz",
+      "integrity": "sha512-TXFHJ5c+BKggWbdEQ/inpgIzEmS2BGQowLE9UhsMd7YYlUfBQJ4uax0VF/B5NYigdM/75OoJGhAV3upEhK+3gg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.57.2",
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/resources": "1.30.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.30.1.tgz",
+      "integrity": "sha512-q9zcZ0Okl8jRgmy7eNW3Ku1XSgg3sDLa5evHZpCwjspw7E8Is4K/haRPDJrBcX3YSn/Y7gUvFnByNYEKQNbNog==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/resources": "1.30.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
+      "integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/resources": "1.30.1",
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.30.1.tgz",
+      "integrity": "sha512-cBjYOINt1JxXdpw1e5MlHmFRc5fgj4GW/86vsKFxJCJ8AL4PdVtYH41gWwl4qd4uQjqEL1oJVrXkSy5cnduAnQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/context-async-hooks": "1.30.1",
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/propagator-b3": "1.30.1",
+        "@opentelemetry/propagator-jaeger": "1.30.1",
+        "@opentelemetry/sdk-trace-base": "1.30.1",
+        "semver": "^7.5.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@pulumi/aws": {
+      "version": "7.24.0",
+      "resolved": "https://registry.npmjs.org/@pulumi/aws/-/aws-7.24.0.tgz",
+      "integrity": "sha512-Y+zV+uU3Mr+5kUaqsFbF0/lf9yc8TU1Kx1cgcqMbyUQTRBRyfpXb6lR3sBwC88z1DX/WFMrBCD+1bbwnS2fBbw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@pulumi/pulumi": "^3.142.0",
+        "mime": "^2.0.0"
+      }
+    },
+    "node_modules/@pulumi/pulumi": {
+      "version": "3.229.0",
+      "resolved": "https://registry.npmjs.org/@pulumi/pulumi/-/pulumi-3.229.0.tgz",
+      "integrity": "sha512-SoGAonHOrGP/NQQivq3gMz0nlebVUYOf6TgpsPHqvFARsHz4JIR+/fpFm/8JW+Ev5o6tvb6g04a+STmpdxoaOg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.10.1",
+        "@logdna/tail-file": "^2.0.6",
+        "@npmcli/arborist": "^9.0.0",
+        "@opentelemetry/api": "^1.9",
+        "@opentelemetry/exporter-trace-otlp-grpc": "^0.57",
+        "@opentelemetry/exporter-zipkin": "^1.30",
+        "@opentelemetry/instrumentation": "^0.57",
+        "@opentelemetry/instrumentation-grpc": "^0.57",
+        "@opentelemetry/resources": "^1.30",
+        "@opentelemetry/sdk-trace-base": "^1.30",
+        "@opentelemetry/sdk-trace-node": "^1.30",
+        "@types/google-protobuf": "^3.15.5",
+        "@types/semver": "^7.5.6",
+        "@types/tmp": "^0.2.6",
+        "execa": "^5.1.0",
+        "fdir": "^6.5.0",
+        "google-protobuf": "^3.21.4",
+        "got": "^11.8.6",
+        "ini": "^2.0.0",
+        "js-yaml": "^3.14.2",
+        "minimist": "^1.2.6",
+        "normalize-package-data": "^6.0.0",
+        "package-directory": "^8.1.0",
+        "picomatch": "^4.0.0",
+        "require-from-string": "^2.0.1",
+        "semver": "^7.5.2",
+        "source-map-support": "^0.5.6",
+        "tmp": "^0.2.4",
+        "upath": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "ts-node": ">= 7.0.1 < 12",
+        "typescript": ">= 3.8.3 < 7"
+      },
+      "peerDependenciesMeta": {
+        "ts-node": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@pulumi/random": {
+      "version": "4.19.2",
+      "resolved": "https://registry.npmjs.org/@pulumi/random/-/random-4.19.2.tgz",
+      "integrity": "sha512-ee77eUIfPMekYi9x7/3iDVIhqUcZrvXQpC8YNTRN8XKfRDuuWio4xu2CvoHeEBDOov84FumMafFqn+xSf+XlDQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@pulumi/pulumi": "^3.142.0"
+      }
+    },
+    "node_modules/@sigstore/bundle": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-4.0.0.tgz",
+      "integrity": "sha512-NwCl5Y0V6Di0NexvkTqdoVfmjTaQwoLM236r89KEojGmq/jMls8S+zb7yOwAPdXvbwfKDlP+lmXgAL4vKSQT+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/protobuf-specs": "^0.5.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@sigstore/core": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@sigstore/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-kxHrDQ9YgfrWUSXU0cjsQGv8JykOFZQ9ErNKbFPWzk3Hgpwu8x2hHrQ9IdA8yl+j9RTLTC3sAF3Tdq1IQCP4oA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@sigstore/protobuf-specs": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@sigstore/protobuf-specs/-/protobuf-specs-0.5.0.tgz",
+      "integrity": "sha512-MM8XIwUjN2bwvCg1QvrMtbBmpcSHrkhFSCu1D11NyPvDQ25HEc4oG5/OcQfd/Tlf/OxmKWERDj0zGE23jQaMwA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/@sigstore/sign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@sigstore/sign/-/sign-4.1.1.tgz",
+      "integrity": "sha512-Hf4xglukg0XXQ2RiD5vSoLjdPe8OBUPA8XeVjUObheuDcWdYWrnH/BNmxZCzkAy68MzmNCxXLeurJvs6hcP2OQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@gar/promise-retry": "^1.0.2",
+        "@sigstore/bundle": "^4.0.0",
+        "@sigstore/core": "^3.2.0",
+        "@sigstore/protobuf-specs": "^0.5.0",
+        "make-fetch-happen": "^15.0.4",
+        "proc-log": "^6.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@sigstore/tuf": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@sigstore/tuf/-/tuf-4.0.2.tgz",
+      "integrity": "sha512-TCAzTy0xzdP79EnxSjq9KQ3eaR7+FmudLC6eRKknVKZbV7ZNlGLClAAQb/HMNJ5n2OBNk2GT1tEmU0xuPr+SLQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/protobuf-specs": "^0.5.0",
+        "tuf-js": "^4.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@sigstore/verify": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@sigstore/verify/-/verify-3.1.0.tgz",
+      "integrity": "sha512-mNe0Iigql08YupSOGv197YdHpPPr+EzDZmfCgMc7RPNaZTw5aLN01nBl6CHJOh3BGtnMIj83EeN4butBchc8Ag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/bundle": "^4.0.0",
+        "@sigstore/core": "^3.1.0",
+        "@sigstore/protobuf-specs": "^0.5.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@szmarczak/http-timer": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "license": "MIT",
+      "dependencies": {
+        "defer-to-connect": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@tufjs/canonical-json": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tufjs/canonical-json/-/canonical-json-2.0.0.tgz",
+      "integrity": "sha512-yVtV8zsdo8qFHe+/3kw81dSLyF7D576A5cCFCi4X7B39tWT7SekaEFUnvnWJHz+9qO7qJTah1JbrDjWKqFtdWA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@tufjs/models": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@tufjs/models/-/models-4.1.0.tgz",
+      "integrity": "sha512-Y8cK9aggNRsqJVaKUlEYs4s7CvQ1b1ta2DVPyAimb0I2qhzjNk+A+mxvll/klL0RlfuIUei8BF7YWiua4kQqww==",
+      "license": "MIT",
+      "dependencies": {
+        "@tufjs/canonical-json": "2.0.0",
+        "minimatch": "^10.1.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@types/cacheable-request": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "^3.1.4",
+        "@types/node": "*",
+        "@types/responselike": "^1.0.0"
+      }
+    },
+    "node_modules/@types/google-protobuf": {
+      "version": "3.15.12",
+      "resolved": "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.15.12.tgz",
+      "integrity": "sha512-40um9QqwHjRS92qnOaDpL7RmDK15NuZYo9HihiJRbYkMQZlWnuH8AdvbMy8/o6lgLmKbDUKa+OALCltHdbOTpQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/keyv": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.5.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.1.tgz",
+      "integrity": "sha512-lgrR3HRNQdTEeeXBnLURFO4JIIbpcVcMlLM9IG0jsNRTRNSbMkm9S2hyhxhnokke1NM25Dr9QghgeB5PQKolrw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/responselike": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/shimmer": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
+      "integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/tmp": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.6.tgz",
+      "integrity": "sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==",
+      "license": "MIT"
+    },
+    "node_modules/abbrev": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
+      "integrity": "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/aws4fetch": {
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/aws4fetch/-/aws4fetch-1.0.18.tgz",
+      "integrity": "sha512-3Cf+YaUl07p24MoQ46rFwulAmiyCwH2+1zw1ZyPAX5OtJ34Hh185DwB8y/qRLb6cYYYtSFJ9pthyLc0MD4e8sQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/bin-links": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bin-links/-/bin-links-6.0.0.tgz",
+      "integrity": "sha512-X4CiKlcV2GjnCMwnKAfbVWpHa++65th9TuzAEYtZoATiOE2DQKhSp4CJlyLoTqdhBKlXjpXjCTYPNNFS33Fi6w==",
+      "license": "ISC",
+      "dependencies": {
+        "cmd-shim": "^8.0.0",
+        "npm-normalize-package-bin": "^5.0.0",
+        "proc-log": "^6.0.0",
+        "read-cmd-shim": "^6.0.0",
+        "write-file-atomic": "^7.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/cacache": {
+      "version": "20.0.4",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-20.0.4.tgz",
+      "integrity": "sha512-M3Lab8NPYlZU2exsL3bMVvMrMqgwCnMWfdZbK28bn3pK6APT/Te/I8hjRPNu1uwORY9a1eEQoifXbKPQMfMTOA==",
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/fs": "^5.0.0",
+        "fs-minipass": "^3.0.0",
+        "glob": "^13.0.0",
+        "lru-cache": "^11.1.0",
+        "minipass": "^7.0.3",
+        "minipass-collect": "^2.0.1",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "p-map": "^7.0.2",
+        "ssri": "^13.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/cacheable-lookup": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.6.0"
+      }
+    },
+    "node_modules/cacheable-request": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+      "license": "MIT",
+      "dependencies": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^4.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^6.0.1",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cacheable-request/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "license": "MIT"
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/clone-response": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cmd-shim": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-8.0.0.tgz",
+      "integrity": "sha512-Jk/BK6NCapZ58BKUxlSI+ouKRbjH1NLZCgJkYoab+vEHUY3f6OzpNBN9u7HFSv9J6TRDGs4PLOHezoKGaFRSCA==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/common-ancestor-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-2.0.0.tgz",
+      "integrity": "sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cross-spawn/node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/cross-spawn/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decompress-response/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.0.tgz",
+      "integrity": "sha512-kCKF62fwtzwYm0IGBNjRUjtJgMfGapII+FslMHIjMR5KTnwEmBmWLDRSnc3XSNP8bNy34tekgQyDT0hr7pERRQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/exponential-backoff": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
+      "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/find-up-simple": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.1.tgz",
+      "integrity": "sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fs-minipass": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
+      "integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/google-protobuf": {
+      "version": "3.21.4",
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.4.tgz",
+      "integrity": "sha512-MnG7N936zcKTco4Jd2PX2U96Kf9PxygAPKBug+74LHzmHXmceN16MmRcdgZv+DGef/S9YvQAfRsNCn4cjf9yyQ==",
+      "license": "(BSD-3-Clause AND Apache-2.0)"
+    },
+    "node_modules/got": {
+      "version": "11.8.6",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^4.0.0",
+        "@szmarczak/http-timer": "^4.0.5",
+        "@types/cacheable-request": "^6.0.1",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
+        "cacheable-request": "^7.0.2",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
+        "lowercase-keys": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hosted-git-info": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
+      "integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^11.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/http2-wrapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "license": "MIT",
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ignore-walk": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-8.0.0.tgz",
+      "integrity": "sha512-FCeMZT4NiRQGh+YkeKMtWrOmBgWjHjMJ26WQWrRQyoyzqevdaGSakUaJW5xQYmjLlUVk2qUnCjYVBax9EKKg8A==",
+      "license": "ISC",
+      "dependencies": {
+        "minimatch": "^10.0.3"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/import-in-the-middle": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.15.0.tgz",
+      "integrity": "sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.14.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^1.2.2",
+        "module-details-from-path": "^1.0.3"
+      }
+    },
+    "node_modules/ini": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
+      "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jose": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.2.3.tgz",
+      "integrity": "sha512-KUXdbctm1uHVL8BYhnyHkgp3zDX5KW8ZhAKVFEfUbU2P8Alpzjb+48hHvjOdQIyPshoblhzsuqOwEEAbtHVirA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "license": "MIT"
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-5.0.0.tgz",
+      "integrity": "sha512-ZF1nxZ28VhQouRWhUcVlUIN3qwSgPuswK05s/HIaoetAoE/9tngVmCHjSxmSQPav1nd+lPtTL0YZ/2AFdR/iYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/json-stringify-nice": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/json-stringify-nice/-/json-stringify-nice-1.1.4.tgz",
+      "integrity": "sha512-5Z5RFW63yxReJ7vANgW6eZFGWaQvnPE3WNmZoOJrSkGju2etKA2L5rrOa1sm877TVTFt57A80BH1bArcmlLfPw==",
+      "license": "ISC",
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
+      "engines": [
+        "node >= 0.2.0"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/just-diff": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/just-diff/-/just-diff-6.0.2.tgz",
+      "integrity": "sha512-S59eriX5u3/QhMNq3v/gm8Kd0w8OS6Tz2FS1NG4blv+z0MuQcBRJyFWjdovM0Rad4/P4aUPFtnkNjMjyMlMSYA==",
+      "license": "MIT"
+    },
+    "node_modules/just-diff-apply": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/just-diff-apply/-/just-diff-apply-5.5.0.tgz",
+      "integrity": "sha512-OYTthRfSh55WOItVqwpefPtNt2VdKsq5AnAK6apdtR6yCH8pr0CmSr710J0Mf+WdQy7K/OzMy7K2MgAfdQURDw==",
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/make-fetch-happen": {
+      "version": "15.0.5",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-15.0.5.tgz",
+      "integrity": "sha512-uCbIa8jWWmQZt4dSnEStkVC6gdakiinAm4PiGsywIkguF0eWMdcjDz0ECYhUolFU3pFLOev9VNPCEygydXnddg==",
+      "license": "ISC",
+      "dependencies": {
+        "@gar/promise-retry": "^1.0.0",
+        "@npmcli/agent": "^4.0.0",
+        "@npmcli/redact": "^4.0.0",
+        "cacache": "^20.0.1",
+        "http-cache-semantics": "^4.1.1",
+        "minipass": "^7.0.2",
+        "minipass-fetch": "^5.0.0",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "negotiator": "^1.0.0",
+        "proc-log": "^6.0.0",
+        "ssri": "^13.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "license": "MIT"
+    },
+    "node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minipass-collect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-2.0.1.tgz",
+      "integrity": "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minipass-fetch": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-5.0.2.tgz",
+      "integrity": "sha512-2d0q2a8eCi2IRg/IGubCNRJoYbA1+YPXAzQVRFmB45gdGZafyivnZ5YSEfo3JikbjGxOdntGFvBQGqaSMXlAFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.0.3",
+        "minipass-sized": "^2.0.0",
+        "minizlib": "^3.0.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      },
+      "optionalDependencies": {
+        "iconv-lite": "^0.7.2"
+      }
+    },
+    "node_modules/minipass-flush": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
+      "integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minipass-flush/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-flush/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
+    "node_modules/minipass-pipeline": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+      "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-pipeline/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-pipeline/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
+    "node_modules/minipass-sized": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-2.0.0.tgz",
+      "integrity": "sha512-zSsHhto5BcUVM2m1LurnXY6M//cGhVaegT71OfOXoprxT6o780GZd792ea6FfrQkuU4usHZIUczAQMRUE2plzA==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-gyp": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.2.0.tgz",
+      "integrity": "sha512-q23WdzrQv48KozXlr0U1v9dwO/k59NHeSzn6loGcasyf0UnSrtzs8kRxM+mfwJSf0DkX0s43hcqgnSO4/VNthQ==",
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "exponential-backoff": "^3.1.1",
+        "graceful-fs": "^4.2.6",
+        "make-fetch-happen": "^15.0.0",
+        "nopt": "^9.0.0",
+        "proc-log": "^6.0.0",
+        "semver": "^7.3.5",
+        "tar": "^7.5.4",
+        "tinyglobby": "^0.2.12",
+        "which": "^6.0.0"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/nopt": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
+      "integrity": "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==",
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^4.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/normalize-package-data": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
+      "integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^7.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-license": "^3.0.4"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/normalize-package-data/node_modules/hosted-git-info": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+      "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^10.0.1"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/normalize-package-data/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/normalize-url": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-bundled": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-5.0.0.tgz",
+      "integrity": "sha512-JLSpbzh6UUXIEoqPsYBvVNVmyrjVZ1fzEFbqxKkTJQkWBO3xFzFT+KDnSKQWwOQNbuWRwt5LSD6HOTLGIWzfrw==",
+      "license": "ISC",
+      "dependencies": {
+        "npm-normalize-package-bin": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm-install-checks": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-8.0.0.tgz",
+      "integrity": "sha512-ScAUdMpyzkbpxoNekQ3tNRdFI8SJ86wgKZSQZdUxT+bj0wVFpsEMWnkXP0twVe1gJyNF5apBWDJhhIbgrIViRA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "semver": "^7.1.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm-normalize-package-bin": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-5.0.0.tgz",
+      "integrity": "sha512-CJi3OS4JLsNMmr2u07OJlhcrPxCeOeP/4xq67aWNai6TNWWbTrlNDgl8NcFKVlcBKp18GPj+EzbNIgrBfZhsag==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm-package-arg": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-13.0.2.tgz",
+      "integrity": "sha512-IciCE3SY3uE84Ld8WZU23gAPPV9rIYod4F+rc+vJ7h7cwAJt9Vk6TVsK60ry7Uj3SRS3bqRRIGuTp9YVlk6WNA==",
+      "license": "ISC",
+      "dependencies": {
+        "hosted-git-info": "^9.0.0",
+        "proc-log": "^6.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-name": "^7.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm-packlist": {
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-10.0.4.tgz",
+      "integrity": "sha512-uMW73iajD8hiH4ZBxEV3HC+eTnppIqwakjOYuvgddnalIw2lJguKviK1pcUJDlIWm1wSJkchpDZDSVVsZEYRng==",
+      "license": "ISC",
+      "dependencies": {
+        "ignore-walk": "^8.0.0",
+        "proc-log": "^6.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm-pick-manifest": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-11.0.3.tgz",
+      "integrity": "sha512-buzyCfeoGY/PxKqmBqn1IUJrZnUi1VVJTdSSRPGI60tJdUhUoSQFhs0zycJokDdOznQentgrpf8LayEHyyYlqQ==",
+      "license": "ISC",
+      "dependencies": {
+        "npm-install-checks": "^8.0.0",
+        "npm-normalize-package-bin": "^5.0.0",
+        "npm-package-arg": "^13.0.0",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm-registry-fetch": {
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-19.1.1.tgz",
+      "integrity": "sha512-TakBap6OM1w0H73VZVDf44iFXsOS3h+L4wVMXmbWOQroZgFhMch0juN6XSzBNlD965yIKvWg2dfu7NSiaYLxtw==",
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/redact": "^4.0.0",
+        "jsonparse": "^1.3.1",
+        "make-fetch-happen": "^15.0.0",
+        "minipass": "^7.0.2",
+        "minipass-fetch": "^5.0.0",
+        "minizlib": "^3.0.1",
+        "npm-package-arg": "^13.0.0",
+        "proc-log": "^6.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/oidc-token-hash": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.2.0.tgz",
+      "integrity": "sha512-6gj2m8cJZ+iSW8bm0FXdGF0YhIQbKrfP4yWTNzxc31U6MOjfEmB1rHvlYvxI1B7t7BCi1F2vYTT6YhtQRG4hxw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^10.13.0 || >=12.0.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openid-client": {
+      "version": "5.6.4",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.6.4.tgz",
+      "integrity": "sha512-T1h3B10BRPKfcObdBklX639tVz+xh34O7GjofqrqiAQdm7eHsQ00ih18x6wuJ/E6FxdtS2u3FmUGPDeEcMwzNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jose": "^4.15.4",
+        "lru-cache": "^6.0.0",
+        "object-hash": "^2.2.0",
+        "oidc-token-hash": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/openid-client/node_modules/jose": {
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/openid-client/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/openid-client/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
+      "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/package-directory": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/package-directory/-/package-directory-8.2.0.tgz",
+      "integrity": "sha512-qJSu5Mo6tHmRxCy2KCYYKYgcfBdUpy9dwReaZD/xwf608AUk/MoRtIOWzgDtUeGeC7n/55yC3MI1Q+MbSoektw==",
+      "license": "MIT",
+      "dependencies": {
+        "find-up-simple": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pacote": {
+      "version": "21.5.0",
+      "resolved": "https://registry.npmjs.org/pacote/-/pacote-21.5.0.tgz",
+      "integrity": "sha512-VtZ0SB8mb5Tzw3dXDfVAIjhyVKUHZkS/ZH9/5mpKenwC9sFOXNI0JI7kEF7IMkwOnsWMFrvAZHzx1T5fmrp9FQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@gar/promise-retry": "^1.0.0",
+        "@npmcli/git": "^7.0.0",
+        "@npmcli/installed-package-contents": "^4.0.0",
+        "@npmcli/package-json": "^7.0.0",
+        "@npmcli/promise-spawn": "^9.0.0",
+        "@npmcli/run-script": "^10.0.0",
+        "cacache": "^20.0.0",
+        "fs-minipass": "^3.0.0",
+        "minipass": "^7.0.2",
+        "npm-package-arg": "^13.0.0",
+        "npm-packlist": "^10.0.1",
+        "npm-pick-manifest": "^11.0.1",
+        "npm-registry-fetch": "^19.0.0",
+        "proc-log": "^6.0.0",
+        "sigstore": "^4.0.0",
+        "ssri": "^13.0.0",
+        "tar": "^7.4.3"
+      },
+      "bin": {
+        "pacote": "bin/index.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/parse-conflict-json": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/parse-conflict-json/-/parse-conflict-json-5.0.1.tgz",
+      "integrity": "sha512-ZHEmNKMq1wyJXNwLxyHnluPfRAFSIliBvbK/UiOceROt4Xh9Pz0fq49NytIaeaCUf5VR86hwQ/34FCcNU5/LKQ==",
+      "license": "ISC",
+      "dependencies": {
+        "json-parse-even-better-errors": "^5.0.0",
+        "just-diff": "^6.0.0",
+        "just-diff-apply": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
+      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/proc-log": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/proggy": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/proggy/-/proggy-4.0.0.tgz",
+      "integrity": "sha512-MbA4R+WQT76ZBm/5JUpV9yqcJt92175+Y0Bodg3HgiXzrmKu7Ggq+bpn6y6wHH+gN9NcyKn3yg1+d47VaKwNAQ==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/promise-all-reject-late": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/promise-all-reject-late/-/promise-all-reject-late-1.0.1.tgz",
+      "integrity": "sha512-vuf0Lf0lOxyQREH7GDIOUMLS7kz+gs8i6B+Yi8dC68a2sychGrHTJYghMBD6k7eUcH0H5P73EckCA48xijWqXw==",
+      "license": "ISC",
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/promise-call-limit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/promise-call-limit/-/promise-call-limit-3.0.2.tgz",
+      "integrity": "sha512-mRPQO2T1QQVw11E7+UdCJu7S61eJVWknzml9sC1heAdj1jxl0fWMBypIt9ZOcLFf8FkG995ZD7RnVk7HH72fZw==",
+      "license": "ISC",
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-cmd-shim": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-6.0.0.tgz",
+      "integrity": "sha512-1zM5HuOfagXCBWMN83fuFI/x+T/UhZ7k+KIzhrHXcQoeX5+7gmaDYjELQHmmzIodumBHeByBJT4QYS7ufAgs7A==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-in-the-middle": {
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.5.2.tgz",
+      "integrity": "sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3",
+        "resolve": "^1.22.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "license": "MIT"
+    },
+    "node_modules/responselike": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "license": "MIT",
+      "dependencies": {
+        "lowercase-keys": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shimmer": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/sigstore": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/sigstore/-/sigstore-4.1.0.tgz",
+      "integrity": "sha512-/fUgUhYghuLzVT/gaJoeVehLCgZiUxPCPMcyVNY0lIf/cTCz58K/WTI7PefDarXxp9nUKpEwg1yyz3eSBMTtgA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/bundle": "^4.0.0",
+        "@sigstore/core": "^3.1.0",
+        "@sigstore/protobuf-specs": "^0.5.0",
+        "@sigstore/sign": "^4.1.0",
+        "@sigstore/tuf": "^4.0.1",
+        "@sigstore/verify": "^3.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.0.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/spdx-correct": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+      "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-correct/node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
+      "integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+      "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/ssri": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-13.0.1.tgz",
+      "integrity": "sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/sst": {
+      "version": "4.6.11",
+      "resolved": "https://registry.npmjs.org/sst/-/sst-4.6.11.tgz",
+      "integrity": "sha512-fepz1Xb8boDegv4mcgvZRmXQ7vObl09cX2e4cKrQiosZD3GeOC1MnMt08yyQcfOv12LcOI77/5+Hki9w2+6qGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aws4fetch": "1.0.18",
+        "jose": "5.2.3",
+        "openid-client": "5.6.4"
+      },
+      "bin": {
+        "sst": "bin/sst.mjs"
+      },
+      "optionalDependencies": {
+        "sst-darwin-arm64": "4.6.11",
+        "sst-darwin-x64": "4.6.11",
+        "sst-linux-arm64": "4.6.11",
+        "sst-linux-x64": "4.6.11",
+        "sst-linux-x86": "4.6.11",
+        "sst-win32-arm64": "4.6.11",
+        "sst-win32-x64": "4.6.11",
+        "sst-win32-x86": "4.6.11"
+      }
+    },
+    "node_modules/sst-darwin-arm64": {
+      "version": "4.6.11",
+      "resolved": "https://registry.npmjs.org/sst-darwin-arm64/-/sst-darwin-arm64-4.6.11.tgz",
+      "integrity": "sha512-FUnvogAL7iQYjcfF9Ne3YT9Ku0a8f3dd+5N/I4FP6PaqHYdHsOvS/tMU2xyokLuiZdbQ8kzh8JYZTCtZfbGe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/sst-darwin-x64": {
+      "version": "4.6.11",
+      "resolved": "https://registry.npmjs.org/sst-darwin-x64/-/sst-darwin-x64-4.6.11.tgz",
+      "integrity": "sha512-T3wmeYKjsggcHDD9eE17pf4mP5J+u6OlZSIJNSPJaEmx8UiJJMiqWK7o0c0EbmPngTOGDtkceNxLKBhj2TsCeQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/sst-linux-arm64": {
+      "version": "4.6.11",
+      "resolved": "https://registry.npmjs.org/sst-linux-arm64/-/sst-linux-arm64-4.6.11.tgz",
+      "integrity": "sha512-1ACzUFRFIu5bW2ncIm+AtPAEggYoXBSNDMs/cgiWkQ5D2m2MzcYRf99D6cankEXFMxv2qCkXouYo9WfWNlpDvQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/sst-linux-x64": {
+      "version": "4.6.11",
+      "resolved": "https://registry.npmjs.org/sst-linux-x64/-/sst-linux-x64-4.6.11.tgz",
+      "integrity": "sha512-8pbmkApHWBkw4Wuj7V5XyIOTDYpDK9Vw13nq/4hoxv+C2UDheLix3ribOycAIH2JtdpwAhyMsztFrXO0zclseg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/sst-linux-x86": {
+      "version": "4.6.11",
+      "resolved": "https://registry.npmjs.org/sst-linux-x86/-/sst-linux-x86-4.6.11.tgz",
+      "integrity": "sha512-vO2RgtsuPy+4ee0RqAtYWvrguH4xPjl7XHsyqYOyt+dzOmCWiP/27AmYTWFt/yLay5leatYma/qqyZwe8avMHg==",
+      "cpu": [
+        "x86"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/sst-win32-arm64": {
+      "version": "4.6.11",
+      "resolved": "https://registry.npmjs.org/sst-win32-arm64/-/sst-win32-arm64-4.6.11.tgz",
+      "integrity": "sha512-2NulfXFSCOXSLfSYGeHOH27T3pWhsu/GDM6wlya12wSb2taOtXkVIXBnPNxxRIMPIeMweKNTsxeMZSBI2PfTWw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/sst-win32-x64": {
+      "version": "4.6.11",
+      "resolved": "https://registry.npmjs.org/sst-win32-x64/-/sst-win32-x64-4.6.11.tgz",
+      "integrity": "sha512-yAEKwpPv0qeE1mx6KHvg81uN5ZxCqzfmDansxpiTFvnyRm3+p7mDc2YrP3nXvqO17sbawPKibaJwM4V3C98OXg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/sst-win32-x86": {
+      "version": "4.6.11",
+      "resolved": "https://registry.npmjs.org/sst-win32-x86/-/sst-win32-x86-4.6.11.tgz",
+      "integrity": "sha512-xeRxuI+GdWBEjP9SvO3IdIcSGzhhnDcmsUfMkiHmIJDAXzAOQbrNhoYfPGeFzPPDeCJZSYWF623NSL+OUiCLFQ==",
+      "cpu": [
+        "x86"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
+      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/treeverse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/treeverse/-/treeverse-3.0.0.tgz",
+      "integrity": "sha512-gcANaAnd2QDZFmHFEOF4k7uc1J/6a6z3DJMd/QwEyxLoKGiptJRwid582r7QIsFlFMIZ3SnxfS52S4hm2DHkuQ==",
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/tuf-js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/tuf-js/-/tuf-js-4.1.0.tgz",
+      "integrity": "sha512-50QV99kCKH5P/Vs4E2Gzp7BopNV+KzTXqWeaxrfu5IQJBOULRsTIS9seSsOVT8ZnGXzCyx55nYWAi4qJzpZKEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tufjs/models": "4.1.0",
+        "debug": "^4.4.3",
+        "make-fetch-happen": "^15.0.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "license": "MIT"
+    },
+    "node_modules/upath": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
+      "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4",
+        "yarn": "*"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/validate-npm-package-license/node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/validate-npm-package-name": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
+      "integrity": "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/walk-up-path": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-4.0.0.tgz",
+      "integrity": "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==",
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/which": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+      "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^4.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/write-file-atomic": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-7.0.1.tgz",
+      "integrity": "sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==",
+      "license": "ISC",
+      "dependencies": {
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/write-file-atomic/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    }
+  }
+}

--- a/apps/infra/package-lock.json
+++ b/apps/infra/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@pulumi/aws": "^7.24.0",
+        "js-yaml": "^4.1.0",
         "sst": "^4.6.11"
       }
     },
@@ -759,6 +760,28 @@
         }
       }
     },
+    "node_modules/@pulumi/pulumi/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/@pulumi/pulumi/node_modules/js-yaml": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/@pulumi/random": {
       "version": "4.19.2",
       "resolved": "https://registry.npmjs.org/@pulumi/random/-/random-4.19.2.tgz",
@@ -1021,13 +1044,11 @@
       }
     },
     "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/aws4fetch": {
       "version": "1.0.18",
@@ -1724,13 +1745,23 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"

--- a/apps/infra/package.json
+++ b/apps/infra/package.json
@@ -7,8 +7,9 @@
     "dev": "node scripts/sst-with-cloudflare.mjs dev",
     "deploy": "node scripts/sst-with-cloudflare.mjs deploy",
     "remove": "node scripts/sst-with-cloudflare.mjs remove",
+    "test": "node --test scripts/*.test.mjs",
     "sst": "node scripts/sst-with-cloudflare.mjs",
-    "secrets": "sst secret list"
+    "secrets": "node scripts/sst-with-cloudflare.mjs secret list"
   },
   "devDependencies": {
     "@pulumi/aws": "^7.24.0",

--- a/apps/infra/package.json
+++ b/apps/infra/package.json
@@ -13,6 +13,7 @@
   },
   "devDependencies": {
     "@pulumi/aws": "^7.24.0",
+    "js-yaml": "^4.1.0",
     "sst": "^4.6.11"
   },
   "dependencies": {

--- a/apps/infra/scripts/deployment-environment.mjs
+++ b/apps/infra/scripts/deployment-environment.mjs
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+import { config as loadDotenv } from 'dotenv'
+import { readFileSync, statSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { optionalPublicOidcIssuer, requireOidcIssuer } from './oidc-issuer.mjs'
+
+const DEFAULT_AWS_REGION = 'ap-southeast-1'
+const STABLE_SEMVER_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/
+const DEFAULT_MODULE_DIRECTORY = dirname(fileURLToPath(import.meta.url))
+
+export function loadDeploymentEnvironment({ path, environment = process.env } = {}) {
+  return loadDotenv({
+    ...(path ? { path } : {}),
+    processEnv: environment,
+    quiet: true,
+  })
+}
+
+export function resolveAwsRegion(environment = process.env) {
+  return environment.AWS_REGION?.trim() || DEFAULT_AWS_REGION
+}
+
+export function resolveReleaseVersion(workspaceVersion, environment = process.env) {
+  if (typeof workspaceVersion !== 'string' || workspaceVersion.trim() === '') {
+    throw new Error('The workspace release version is missing')
+  }
+  if (workspaceVersion !== workspaceVersion.trim() || !STABLE_SEMVER_PATTERN.test(workspaceVersion)) {
+    throw new Error(
+      `The workspace release version '${workspaceVersion}' is not a stable semantic version (expected X.Y.Z)`,
+    )
+  }
+
+  const configuredVersion = environment.VERSION
+  if (configuredVersion === undefined || configuredVersion === '') return workspaceVersion
+  if (configuredVersion !== configuredVersion.trim() || !STABLE_SEMVER_PATTERN.test(configuredVersion)) {
+    throw new Error(`VERSION '${configuredVersion}' is not a stable semantic version (expected X.Y.Z)`)
+  }
+  return configuredVersion
+}
+
+function isFile(path) {
+  try {
+    return statSync(path).isFile()
+  } catch {
+    return false
+  }
+}
+
+function findRepositoryRoot(moduleDirectory) {
+  if (typeof moduleDirectory !== 'string' || moduleDirectory === '') {
+    throw new Error('moduleDirectory must be a non-empty filesystem path')
+  }
+
+  const startingDirectory = resolve(moduleDirectory)
+  let candidateDirectory = startingDirectory
+
+  while (true) {
+    const cargoTomlPath = join(candidateDirectory, 'Cargo.toml')
+    const infraPackagePath = join(candidateDirectory, 'apps', 'infra', 'package.json')
+    if (isFile(cargoTomlPath) && isFile(infraPackagePath)) return candidateDirectory
+
+    const parentDirectory = dirname(candidateDirectory)
+    if (parentDirectory === candidateDirectory) break
+    candidateDirectory = parentDirectory
+  }
+
+  throw new Error(
+    `could not find the BoxLite repository root from '${startingDirectory}' ` +
+      '(expected one ancestor containing both Cargo.toml and apps/infra/package.json)',
+  )
+}
+
+export function readWorkspaceVersion({ moduleDirectory = DEFAULT_MODULE_DIRECTORY } = {}) {
+  const repositoryRoot = findRepositoryRoot(moduleDirectory)
+  const cargoTomlPath = join(repositoryRoot, 'Cargo.toml')
+  let cargoToml
+  try {
+    cargoToml = readFileSync(cargoTomlPath, 'utf8')
+  } catch (cause) {
+    throw new Error(`could not read workspace release version from '${cargoTomlPath}'`, { cause })
+  }
+  const version = cargoToml.match(/^version\s*=\s*"(.+?)"/m)?.[1]
+  if (!version) {
+    throw new Error(
+      `could not parse release version from '${cargoTomlPath}' (expected a top-level \`version = "X.Y.Z"\`)`,
+    )
+  }
+  return version
+}
+
+function requireHostname(name, value) {
+  if (!value || value !== value.trim()) {
+    throw new Error(`${name} must be a hostname without whitespace`)
+  }
+
+  let url
+  try {
+    url = new URL(`https://${value}`)
+  } catch {
+    throw new Error(`${name} must be a valid hostname`)
+  }
+  if (
+    url.hostname !== value.toLowerCase() ||
+    url.port ||
+    url.username ||
+    url.password ||
+    url.pathname !== '/' ||
+    url.search ||
+    url.hash
+  ) {
+    throw new Error(`${name} must be a hostname without a scheme, port, path, credentials, query, or fragment`)
+  }
+  return url.hostname
+}
+
+function parseExpectedSupportedImages(rawImages) {
+  return (rawImages ?? '')
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .map((entry) => {
+      const separator = entry.indexOf('=')
+      const name = separator > 0 ? entry.slice(0, separator).trim() : ''
+      const ref = separator > 0 ? entry.slice(separator + 1).trim() : ''
+      if (!name || !ref) {
+        throw new Error(`Invalid BOXLITE_SYSTEM_IMAGES entry '${entry}', expected 'name=ref'`)
+      }
+      return { name, ref }
+    })
+}
+
+export function resolvePublicDeploymentConfig(environment = process.env, workspaceVersion = readWorkspaceVersion()) {
+  const stackDomain = requireHostname('STACK_DOMAIN', environment.STACK_DOMAIN)
+
+  const proxyDomain = requireHostname('PROXY_DOMAIN', environment.PROXY_DOMAIN?.trim() || `proxy.${stackDomain}`)
+  const proxyProtocol = environment.PROXY_PROTOCOL?.trim() || 'https'
+  if (proxyProtocol !== 'https') {
+    throw new Error(`PROXY_PROTOCOL must be https for the provisioned TLS NLB, received ${proxyProtocol}`)
+  }
+  const expectedProxyTemplateUrl = environment.PROXY_TEMPLATE_URL?.trim() || `${proxyProtocol}://${proxyDomain}`
+  let proxyTemplateUrl
+  try {
+    proxyTemplateUrl = new URL(expectedProxyTemplateUrl)
+  } catch {
+    throw new Error('PROXY_TEMPLATE_URL must be a valid absolute HTTPS URL')
+  }
+  if (
+    proxyTemplateUrl.protocol !== 'https:' ||
+    proxyTemplateUrl.username ||
+    proxyTemplateUrl.password ||
+    proxyTemplateUrl.port ||
+    proxyTemplateUrl.pathname !== '/' ||
+    proxyTemplateUrl.search ||
+    proxyTemplateUrl.hash
+  ) {
+    throw new Error('PROXY_TEMPLATE_URL must be an HTTPS origin without credentials, port, path, query, or fragment')
+  }
+  if (proxyTemplateUrl.hostname !== proxyDomain) {
+    throw new Error(`PROXY_TEMPLATE_URL host ${proxyTemplateUrl.hostname} does not match PROXY_DOMAIN ${proxyDomain}`)
+  }
+  const expectedOidcIssuer = optionalPublicOidcIssuer(environment) ?? requireOidcIssuer(environment)
+  const proxyTemplateOrigin = proxyTemplateUrl.origin
+  const releaseVersion = resolveReleaseVersion(workspaceVersion, environment)
+  const expectedSupportedImages = parseExpectedSupportedImages(environment.BOXLITE_SYSTEM_IMAGES)
+
+  return {
+    stackDomain,
+    proxyDomain,
+    proxyProtocol,
+    proxyTemplateUrl: proxyTemplateOrigin,
+    releaseVersion,
+    proxyHealthUrl: `${proxyProtocol}://${proxyDomain}/health`,
+    proxyWildcardHealthUrl: `${proxyProtocol}://deployment-probe.${proxyDomain}/health`,
+    apiConfigUrl: `https://api.${stackDomain}/api/config`,
+    expectedOidcIssuer,
+    expectedProxyTemplateUrl: proxyTemplateOrigin,
+    expectedVersion: releaseVersion,
+    expectedSupportedImages,
+  }
+}

--- a/apps/infra/scripts/deployment-environment.test.mjs
+++ b/apps/infra/scripts/deployment-environment.test.mjs
@@ -2,7 +2,7 @@
 // Copyright (c) 2026 BoxLite AI
 
 import assert from 'node:assert/strict'
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import test from 'node:test'

--- a/apps/infra/scripts/deployment-environment.test.mjs
+++ b/apps/infra/scripts/deployment-environment.test.mjs
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+import assert from 'node:assert/strict'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+
+import {
+  loadDeploymentEnvironment,
+  readWorkspaceVersion,
+  resolveAwsRegion,
+  resolvePublicDeploymentConfig,
+  resolveReleaseVersion,
+} from './deployment-environment.mjs'
+
+test('loads the deployment dotenv before resolving wrapper-side AWS settings', () => {
+  const directory = mkdtempSync(join(tmpdir(), 'boxlite-deployment-environment-'))
+  const dotenvPath = join(directory, '.env')
+  const environment = { AWS_REGION: 'eu-west-1' }
+  writeFileSync(dotenvPath, 'AWS_REGION=ap-southeast-2\nAWS_CLI_PATH=/custom/bin/aws\nSST_STAGE=staging\n')
+
+  try {
+    loadDeploymentEnvironment({ path: dotenvPath, environment })
+
+    assert.equal(resolveAwsRegion(environment), 'eu-west-1', 'the shell environment must override .env')
+    assert.equal(environment.AWS_CLI_PATH, '/custom/bin/aws')
+    assert.equal(environment.SST_STAGE, 'staging')
+  } finally {
+    rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+test('uses one AWS region resolver for the wrapper and SST config', () => {
+  assert.equal(resolveAwsRegion({}), 'ap-southeast-1')
+  assert.equal(resolveAwsRegion({ AWS_REGION: ' us-east-2 ' }), 'us-east-2')
+})
+
+test('finds the workspace version when SST runs a bundle below .sst/platform', () => {
+  const repositoryRoot = mkdtempSync(join(tmpdir(), 'boxlite-bundled-sst-'))
+  const bundledModuleDirectory = join(repositoryRoot, 'apps', 'infra', '.sst', 'platform')
+
+  try {
+    mkdirSync(bundledModuleDirectory, { recursive: true })
+    writeFileSync(join(repositoryRoot, 'Cargo.toml'), '[workspace.package]\nversion = "1.2.3"\n')
+    writeFileSync(join(repositoryRoot, 'apps', 'Cargo.toml'), '[workspace.package]\nversion = "9.9.9"\n')
+    writeFileSync(
+      join(repositoryRoot, 'apps', 'infra', 'package.json'),
+      JSON.stringify({ name: '@boxlite/infra', private: true }),
+    )
+
+    assert.equal(readWorkspaceVersion({ moduleDirectory: bundledModuleDirectory }), '1.2.3')
+  } finally {
+    rmSync(repositoryRoot, { recursive: true, force: true })
+  }
+})
+
+test('fails explicitly when no ancestor contains both repository markers', () => {
+  const incompleteRepository = mkdtempSync(join(tmpdir(), 'boxlite-incomplete-repository-'))
+  const moduleDirectory = join(incompleteRepository, '.sst', 'platform')
+
+  try {
+    mkdirSync(moduleDirectory, { recursive: true })
+    writeFileSync(join(incompleteRepository, 'Cargo.toml'), '[workspace.package]\nversion = "1.2.3"\n')
+
+    assert.throws(
+      () => readWorkspaceVersion({ moduleDirectory }),
+      /could not find the BoxLite repository root.*Cargo\.toml.*apps\/infra\/package\.json/,
+    )
+  } finally {
+    rmSync(incompleteRepository, { recursive: true, force: true })
+  }
+})
+
+test('uses a stable workspace release as the API version unless explicitly overridden', () => {
+  assert.equal(resolveReleaseVersion('0.9.7', {}), '0.9.7')
+  assert.equal(resolveReleaseVersion('0.9.7', { VERSION: '0.9.8' }), '0.9.8')
+  assert.throws(() => resolveReleaseVersion('  ', {}), /workspace release version is missing/)
+})
+
+test('rejects non-stable or whitespace-normalized release identities', () => {
+  for (const workspaceVersion of [' 0.9.7 ', 'v0.9.7', '0.9', '0.9.7-rc.1', '01.2.3']) {
+    assert.throws(() => resolveReleaseVersion(workspaceVersion, {}), /stable semantic version/)
+  }
+  for (const version of [' 0.9.8 ', 'latest', '0.9.8+build.1', '0.9.8-rc.1', '1.02.3']) {
+    assert.throws(() => resolveReleaseVersion('0.9.7', { VERSION: version }), /stable semantic version/)
+  }
+})
+
+test('derives the public deployment probes from the same deployment environment', () => {
+  assert.deepEqual(
+    resolvePublicDeploymentConfig(
+      {
+        STACK_DOMAIN: 'dev.boxlite.ai',
+        PROXY_DOMAIN: 'preview.dev.boxlite.ai',
+        PROXY_PROTOCOL: 'https',
+        PROXY_TEMPLATE_URL: 'https://preview.dev.boxlite.ai',
+        OIDC_ISSUER_BASE_URL: 'https://tenant.auth0.com/',
+        PUBLIC_OIDC_DOMAIN: 'https://auth.dev.boxlite.ai/',
+        BOXLITE_SYSTEM_IMAGES:
+          'sandbaseai-hermes=sam2026go/hermes-agent:boxlite-noexpose-20260726,tools=example.test/tools:1',
+      },
+      '0.9.7',
+    ),
+    {
+      stackDomain: 'dev.boxlite.ai',
+      proxyDomain: 'preview.dev.boxlite.ai',
+      proxyProtocol: 'https',
+      proxyTemplateUrl: 'https://preview.dev.boxlite.ai',
+      releaseVersion: '0.9.7',
+      proxyHealthUrl: 'https://preview.dev.boxlite.ai/health',
+      proxyWildcardHealthUrl: 'https://deployment-probe.preview.dev.boxlite.ai/health',
+      apiConfigUrl: 'https://api.dev.boxlite.ai/api/config',
+      expectedOidcIssuer: 'https://auth.dev.boxlite.ai/',
+      expectedProxyTemplateUrl: 'https://preview.dev.boxlite.ai',
+      expectedVersion: '0.9.7',
+      expectedSupportedImages: [
+        { name: 'sandbaseai-hermes', ref: 'sam2026go/hermes-agent:boxlite-noexpose-20260726' },
+        { name: 'tools', ref: 'example.test/tools:1' },
+      ],
+    },
+  )
+})
+
+test('rejects malformed deployment image additions before SST can mutate the stack', () => {
+  const baseEnvironment = {
+    STACK_DOMAIN: 'dev.boxlite.ai',
+    OIDC_ISSUER_BASE_URL: 'https://tenant.auth0.com/',
+  }
+
+  for (const configuredImages of ['missing-ref=', '=missing-name', 'missing-separator']) {
+    assert.throws(
+      () =>
+        resolvePublicDeploymentConfig(
+          {
+            ...baseEnvironment,
+            BOXLITE_SYSTEM_IMAGES: configuredImages,
+          },
+          '0.9.7',
+        ),
+      /Invalid BOXLITE_SYSTEM_IMAGES entry.*expected 'name=ref'/,
+    )
+  }
+})
+
+test('returns canonical Proxy settings for SST and the public verifier', () => {
+  const config = resolvePublicDeploymentConfig(
+    {
+      STACK_DOMAIN: 'DEV.BOXLITE.AI',
+      PROXY_DOMAIN: ' Preview.Dev.BoxLite.AI ',
+      PROXY_PROTOCOL: ' https ',
+      PROXY_TEMPLATE_URL: ' https://Preview.Dev.BoxLite.AI/ ',
+      OIDC_ISSUER_BASE_URL: 'https://tenant.auth0.com/',
+    },
+    '0.9.7',
+  )
+
+  assert.equal(config.stackDomain, 'dev.boxlite.ai')
+  assert.equal(config.proxyDomain, 'preview.dev.boxlite.ai')
+  assert.equal(config.proxyProtocol, 'https')
+  assert.equal(config.proxyTemplateUrl, 'https://preview.dev.boxlite.ai')
+  assert.equal(config.proxyHealthUrl, 'https://preview.dev.boxlite.ai/health')
+  assert.equal(config.proxyWildcardHealthUrl, 'https://deployment-probe.preview.dev.boxlite.ai/health')
+})
+
+test('rejects Proxy settings that disagree with the provisioned TLS NLB', () => {
+  const baseEnvironment = {
+    STACK_DOMAIN: 'dev.boxlite.ai',
+    OIDC_ISSUER_BASE_URL: 'https://tenant.auth0.com/',
+  }
+
+  assert.throws(
+    () =>
+      resolvePublicDeploymentConfig(
+        {
+          ...baseEnvironment,
+          PROXY_PROTOCOL: 'http',
+        },
+        '0.9.7',
+      ),
+    /PROXY_PROTOCOL must be https/,
+  )
+  assert.throws(
+    () =>
+      resolvePublicDeploymentConfig(
+        {
+          ...baseEnvironment,
+          PROXY_DOMAIN: 'proxy.dev.boxlite.ai',
+          PROXY_TEMPLATE_URL: 'https://detached.dev.boxlite.ai',
+        },
+        '0.9.7',
+      ),
+    /PROXY_TEMPLATE_URL host detached\.dev\.boxlite\.ai does not match PROXY_DOMAIN proxy\.dev\.boxlite\.ai/,
+  )
+})

--- a/apps/infra/scripts/oidc-issuer.mjs
+++ b/apps/infra/scripts/oidc-issuer.mjs
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+function validateOidcIssuer(name, value) {
+  if (value !== value.trim()) {
+    throw new Error(`${name} must not contain leading or trailing whitespace`)
+  }
+
+  let issuer
+  try {
+    issuer = new URL(value)
+  } catch {
+    throw new Error(`${name} must be a valid absolute HTTPS URL`)
+  }
+
+  if (issuer.protocol !== 'https:') {
+    throw new Error(`${name} must use HTTPS`)
+  }
+  if (issuer.username || issuer.password) {
+    throw new Error(`${name} must not include credentials`)
+  }
+  if (issuer.search || issuer.hash) {
+    throw new Error(`${name} must not include a query string or fragment`)
+  }
+
+  return value
+}
+
+export function requireOidcIssuer(environment = process.env) {
+  const value = environment.OIDC_ISSUER_BASE_URL
+  if (!value) {
+    throw new Error('OIDC_ISSUER_BASE_URL is required (e.g. https://<tenant>.auth0.com/)')
+  }
+  return validateOidcIssuer('OIDC_ISSUER_BASE_URL', value)
+}
+
+export function optionalPublicOidcIssuer(environment = process.env) {
+  const value = environment.PUBLIC_OIDC_DOMAIN
+  if (value === undefined || value === '') return undefined
+  return validateOidcIssuer('PUBLIC_OIDC_DOMAIN', value)
+}

--- a/apps/infra/scripts/oidc-issuer.test.mjs
+++ b/apps/infra/scripts/oidc-issuer.test.mjs
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { optionalPublicOidcIssuer, requireOidcIssuer } from './oidc-issuer.mjs'
+
+test('preserves each provider-defined HTTPS issuer exactly', () => {
+  assert.equal(requireOidcIssuer({ OIDC_ISSUER_BASE_URL: 'https://tenant.auth0.com/' }), 'https://tenant.auth0.com/')
+  assert.equal(
+    requireOidcIssuer({ OIDC_ISSUER_BASE_URL: 'https://tenant.okta.com/oauth2/default' }),
+    'https://tenant.okta.com/oauth2/default',
+  )
+  assert.equal(
+    optionalPublicOidcIssuer({ PUBLIC_OIDC_DOMAIN: 'https://auth.dev.example.com/tenant' }),
+    'https://auth.dev.example.com/tenant',
+  )
+})
+
+test('requires the internal issuer and treats an empty public issuer as unset', () => {
+  assert.throws(() => requireOidcIssuer({}), /OIDC_ISSUER_BASE_URL is required/)
+  assert.equal(optionalPublicOidcIssuer({}), undefined)
+  assert.equal(optionalPublicOidcIssuer({ PUBLIC_OIDC_DOMAIN: '' }), undefined)
+})
+
+test('rejects malformed or unsafe issuer URLs', () => {
+  for (const value of [
+    'tenant.auth0.com/',
+    'http://tenant.auth0.com/',
+    'https://user:password@tenant.auth0.com/',
+    'https://tenant.auth0.com/?tenant=dev',
+    'https://tenant.auth0.com/#issuer',
+  ]) {
+    assert.throws(() => requireOidcIssuer({ OIDC_ISSUER_BASE_URL: value }), /OIDC_ISSUER_BASE_URL/)
+  }
+})

--- a/apps/infra/scripts/proxy-deployment-verify.mjs
+++ b/apps/infra/scripts/proxy-deployment-verify.mjs
@@ -1,0 +1,410 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+import { execFileSync } from 'node:child_process'
+import { accessSync, constants } from 'node:fs'
+import { delimiter, join } from 'node:path'
+
+const PROXY_SERVICE_NAME = 'Proxy'
+const PROXY_CONTAINER_PORT = 4000
+const PROXY_LISTENER_PORT = 443
+const STANDARD_AWS_CLI_DIRECTORIES = ['/opt/homebrew/bin', '/usr/local/bin', '/usr/bin', '/bin']
+
+function exactlyOne(values, label) {
+  if (!Array.isArray(values) || values.length !== 1) {
+    throw new Error(`${label}: expected exactly one, found ${values?.length ?? 0}`)
+  }
+  return values[0]
+}
+
+function activeListenerTargetGroups(listener) {
+  const targetGroupArns = new Set()
+
+  for (const action of listener.DefaultActions ?? []) {
+    if (action.Type !== 'forward') continue
+
+    const configuredGroups = action.ForwardConfig?.TargetGroups ?? []
+    for (const group of configuredGroups) {
+      if ((group.Weight ?? 1) > 0 && group.TargetGroupArn) {
+        targetGroupArns.add(group.TargetGroupArn)
+      }
+    }
+
+    if (configuredGroups.length === 0 && action.TargetGroupArn) {
+      targetGroupArns.add(action.TargetGroupArn)
+    }
+  }
+
+  return [...targetGroupArns]
+}
+
+export function resolveAwsCliPath(environment = process.env) {
+  const configuredPath = environment.AWS_CLI_PATH?.trim()
+  const candidates = configuredPath
+    ? [configuredPath]
+    : [
+        ...(environment.PATH ?? '')
+          .split(delimiter)
+          .filter(Boolean)
+          .map((directory) => join(directory, 'aws')),
+        ...STANDARD_AWS_CLI_DIRECTORIES.map((directory) => join(directory, 'aws')),
+      ]
+
+  for (const candidate of new Set(candidates)) {
+    try {
+      accessSync(candidate, constants.X_OK)
+      return candidate
+    } catch {
+      // Continue through PATH and standard package-manager locations.
+    }
+  }
+
+  const detail = configuredPath ? `AWS_CLI_PATH=${configuredPath}` : 'PATH and standard install locations'
+  const error = new Error(`AWS CLI not found via ${detail}`)
+  error.code = 'ENOENT'
+  throw error
+}
+
+export function runAwsJson(args, region) {
+  let output
+  try {
+    const awsCliPath = resolveAwsCliPath()
+    output = execFileSync(awsCliPath, [...args, '--region', region, '--output', 'json', '--no-cli-pager'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 15_000,
+      killSignal: 'SIGTERM',
+    })
+  } catch (error) {
+    const detail = error.stderr?.toString().trim() || error.message
+    throw new Error(`AWS ${args[0]} ${args[1]} failed: ${detail}`, { cause: error })
+  }
+
+  try {
+    return JSON.parse(output)
+  } catch (error) {
+    throw new Error(`AWS ${args[0]} ${args[1]} returned invalid JSON`, { cause: error })
+  }
+}
+
+export function verifyProxyDeployment({ app, stage, region, awsJson }) {
+  if (!app?.trim()) throw new Error('Proxy verification requires an app name')
+  if (!stage?.trim()) throw new Error('Proxy verification requires an SST stage')
+  if (!region?.trim()) throw new Error('Proxy verification requires an AWS region')
+
+  const queryAws = awsJson ?? ((args) => runAwsJson(args, region))
+  const taggedClusters = queryAws([
+    'resourcegroupstaggingapi',
+    'get-resources',
+    '--resource-type-filters',
+    'ecs:cluster',
+    '--tag-filters',
+    `Key=sst:app,Values=${app}`,
+    `Key=sst:stage,Values=${stage}`,
+  ])
+  const clusterArn = exactlyOne(
+    taggedClusters.ResourceTagMappingList?.map((resource) => resource.ResourceARN),
+    `ECS cluster tagged sst:app=${app}, sst:stage=${stage}`,
+  )
+
+  const describedServices = queryAws([
+    'ecs',
+    'describe-services',
+    '--cluster',
+    clusterArn,
+    '--services',
+    PROXY_SERVICE_NAME,
+  ])
+  if (describedServices.failures?.length) {
+    throw new Error(`Proxy ECS service lookup failed: ${JSON.stringify(describedServices.failures)}`)
+  }
+  const service = exactlyOne(describedServices.services, 'Proxy ECS service')
+  if (service.status !== 'ACTIVE') {
+    throw new Error(`Proxy ECS service is ${service.status ?? 'missing'}, expected ACTIVE`)
+  }
+  if (!Number.isInteger(service.desiredCount) || service.desiredCount < 1) {
+    throw new Error(`Proxy ECS service desired count is ${service.desiredCount ?? 'missing'}, expected at least 1`)
+  }
+  if (service.runningCount < service.desiredCount) {
+    throw new Error(
+      `Proxy ECS service has ${service.runningCount ?? 0} running tasks; expected ${service.desiredCount}`,
+    )
+  }
+
+  const serviceLoadBalancer = exactlyOne(service.loadBalancers, 'Proxy ECS load-balancer attachment')
+  if (
+    serviceLoadBalancer.containerName !== PROXY_SERVICE_NAME ||
+    serviceLoadBalancer.containerPort !== PROXY_CONTAINER_PORT
+  ) {
+    throw new Error(
+      `Proxy ECS load-balancer attachment points to ${serviceLoadBalancer.containerName}:` +
+        `${serviceLoadBalancer.containerPort}, expected ${PROXY_SERVICE_NAME}:${PROXY_CONTAINER_PORT}`,
+    )
+  }
+  const targetGroupArn = serviceLoadBalancer.targetGroupArn
+  if (!targetGroupArn) throw new Error('Proxy ECS load-balancer attachment has no target group ARN')
+
+  const taggedLoadBalancers = queryAws([
+    'resourcegroupstaggingapi',
+    'get-resources',
+    '--resource-type-filters',
+    'elasticloadbalancing:loadbalancer',
+    '--tag-filters',
+    `Key=sst:app,Values=${app}`,
+    `Key=sst:stage,Values=${stage}`,
+  ])
+  const taggedNetworkLoadBalancerArns = (taggedLoadBalancers.ResourceTagMappingList ?? [])
+    .map((resource) => resource.ResourceARN)
+    .filter((resourceArn) => resourceArn.includes(':loadbalancer/net/'))
+  const tlsListeners = taggedNetworkLoadBalancerArns.flatMap((loadBalancerArn) => {
+    const describedListeners = queryAws(['elbv2', 'describe-listeners', '--load-balancer-arn', loadBalancerArn])
+    return (describedListeners.Listeners ?? [])
+      .filter((candidate) => candidate.Port === PROXY_LISTENER_PORT && candidate.Protocol === 'TLS')
+      .map((listener) => ({ listener, loadBalancerArn }))
+  })
+  const { listener, loadBalancerArn } = exactlyOne(tlsListeners, `SST-tagged Proxy TLS:${PROXY_LISTENER_PORT} listener`)
+  const listenerTargetGroupArn = exactlyOne(
+    activeListenerTargetGroups(listener),
+    `Proxy TLS:${PROXY_LISTENER_PORT} active listener target group`,
+  )
+  if (listenerTargetGroupArn !== targetGroupArn) {
+    throw new Error(
+      `Proxy listener target group ${listenerTargetGroupArn} does not match the Proxy ECS target group ${targetGroupArn}`,
+    )
+  }
+
+  const describedTargetGroups = queryAws(['elbv2', 'describe-target-groups', '--target-group-arns', targetGroupArn])
+  const targetGroup = exactlyOne(describedTargetGroups.TargetGroups, 'Proxy target group')
+  if (targetGroup.Port !== PROXY_CONTAINER_PORT || targetGroup.Protocol !== 'TCP' || targetGroup.TargetType !== 'ip') {
+    throw new Error(
+      `Proxy target group is ${targetGroup.Protocol}:${targetGroup.Port}/${targetGroup.TargetType}; ` +
+        `expected TCP:${PROXY_CONTAINER_PORT}/ip`,
+    )
+  }
+  if (targetGroup.HealthCheckProtocol !== 'HTTP' || targetGroup.HealthCheckPath !== '/health') {
+    throw new Error(
+      `Proxy target-group health check is ${targetGroup.HealthCheckProtocol ?? 'missing'}:` +
+        `${targetGroup.HealthCheckPath ?? 'missing'}, expected HTTP:/health`,
+    )
+  }
+  if (!(targetGroup.LoadBalancerArns ?? []).includes(loadBalancerArn)) {
+    throw new Error(
+      `Proxy target group ${targetGroupArn} is not attached to the SST-tagged load balancer ${loadBalancerArn}`,
+    )
+  }
+
+  const describedTargetHealth = queryAws(['elbv2', 'describe-target-health', '--target-group-arn', targetGroupArn])
+  const healthyTargetCount = (describedTargetHealth.TargetHealthDescriptions ?? []).filter(
+    (target) => target.TargetHealth?.State === 'healthy',
+  ).length
+  if (healthyTargetCount < service.desiredCount) {
+    throw new Error(
+      `Proxy target group has ${healthyTargetCount} healthy target${healthyTargetCount === 1 ? '' : 's'}; ` +
+        `expected at least ${service.desiredCount}`,
+    )
+  }
+
+  return {
+    clusterArn,
+    serviceArn: service.serviceArn,
+    listenerArn: listener.ListenerArn,
+    targetGroupArn,
+    desiredCount: service.desiredCount,
+    healthyTargetCount,
+  }
+}
+
+function parseAbsoluteHttpsUrl(value, label) {
+  let url
+  try {
+    url = new URL(value)
+  } catch {
+    throw new Error(`${label} must be a valid absolute HTTPS URL`)
+  }
+  if (url.protocol !== 'https:') throw new Error(`${label} must use HTTPS`)
+  if (url.username || url.password) throw new Error(`${label} must not include credentials`)
+  if (url.search || url.hash) throw new Error(`${label} must not include a query string or fragment`)
+  return url
+}
+
+async function fetchJson(fetchImpl, url, label, requestTimeoutMs) {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), requestTimeoutMs)
+
+  try {
+    const response = await fetchImpl(url, {
+      headers: { accept: 'application/json' },
+      signal: controller.signal,
+    })
+    if (!response?.ok) {
+      throw new Error(`${label} returned HTTP ${response?.status ?? 'unknown'}`)
+    }
+    try {
+      return await response.json()
+    } catch (error) {
+      throw new Error(`${label} returned invalid JSON`, { cause: error })
+    }
+  } catch (error) {
+    if (controller.signal.aborted) {
+      throw new Error(`${label} timed out after ${requestTimeoutMs}ms`, { cause: error })
+    }
+    throw error
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+export async function verifyPublicDeployment({
+  proxyHealthUrl,
+  proxyWildcardHealthUrl,
+  apiConfigUrl,
+  expectedOidcIssuer,
+  expectedProxyTemplateUrl,
+  expectedVersion,
+  expectedSupportedImages = [],
+  fetchImpl = globalThis.fetch,
+  requestTimeoutMs = 15_000,
+}) {
+  if (typeof fetchImpl !== 'function') throw new Error('Public deployment verification requires fetch')
+  if (!Number.isFinite(requestTimeoutMs) || requestTimeoutMs <= 0) {
+    throw new Error(`Public deployment request timeout must be positive, received ${requestTimeoutMs}`)
+  }
+
+  const proxyHealthEndpoint = parseAbsoluteHttpsUrl(proxyHealthUrl, 'Proxy health URL')
+  const proxyWildcardHealth = parseAbsoluteHttpsUrl(proxyWildcardHealthUrl, 'Proxy wildcard health URL')
+  if (proxyWildcardHealth.hostname !== `deployment-probe.${proxyHealthEndpoint.hostname}`) {
+    throw new Error(
+      `Proxy wildcard health host ${proxyWildcardHealth.hostname} does not match ` +
+        `deployment-probe.${proxyHealthEndpoint.hostname}`,
+    )
+  }
+  parseAbsoluteHttpsUrl(apiConfigUrl, 'API config URL')
+  parseAbsoluteHttpsUrl(expectedOidcIssuer, 'Expected OIDC issuer')
+  const expectedProxyTemplate = parseAbsoluteHttpsUrl(expectedProxyTemplateUrl, 'Expected Proxy template URL')
+  if (typeof expectedVersion !== 'string' || expectedVersion.trim() === '') {
+    throw new Error('Expected API version is required')
+  }
+  if (!Array.isArray(expectedSupportedImages)) {
+    throw new Error('Expected supported images must be an array')
+  }
+  for (const image of expectedSupportedImages) {
+    if (
+      !image ||
+      typeof image !== 'object' ||
+      Array.isArray(image) ||
+      typeof image.name !== 'string' ||
+      image.name === '' ||
+      typeof image.ref !== 'string' ||
+      image.ref === ''
+    ) {
+      throw new Error('Each expected supported image must contain a non-empty name and ref')
+    }
+  }
+
+  const proxyHealth = await fetchJson(fetchImpl, proxyHealthUrl, 'Public Proxy health check', requestTimeoutMs)
+  if (proxyHealth?.status !== 'ok') {
+    throw new Error(`Public Proxy health check returned status ${JSON.stringify(proxyHealth?.status ?? null)}`)
+  }
+
+  const proxyWildcardHealthResponse = await fetchJson(
+    fetchImpl,
+    proxyWildcardHealthUrl,
+    'Public Proxy wildcard health check',
+    requestTimeoutMs,
+  )
+  if (proxyWildcardHealthResponse?.status !== 'ok') {
+    throw new Error(
+      `Public Proxy wildcard health check returned status ` +
+        `${JSON.stringify(proxyWildcardHealthResponse?.status ?? null)}`,
+    )
+  }
+
+  const apiConfig = await fetchJson(fetchImpl, apiConfigUrl, 'Public API config check', requestTimeoutMs)
+  const actualOidcIssuer = apiConfig?.oidc?.issuer
+  if (typeof actualOidcIssuer !== 'string') {
+    throw new Error(`Public API OIDC issuer ${JSON.stringify(actualOidcIssuer ?? null)} is missing`)
+  }
+  parseAbsoluteHttpsUrl(actualOidcIssuer, 'Public API OIDC issuer')
+  if (actualOidcIssuer !== expectedOidcIssuer) {
+    throw new Error(`Public API OIDC issuer ${actualOidcIssuer} does not match expected ${expectedOidcIssuer}`)
+  }
+
+  const actualProxyTemplate = parseAbsoluteHttpsUrl(apiConfig?.proxyTemplateUrl, 'Public API Proxy template URL')
+  if (actualProxyTemplate.host !== expectedProxyTemplate.host) {
+    throw new Error(
+      `Public API Proxy template host ${actualProxyTemplate.host} does not match ${expectedProxyTemplate.host}`,
+    )
+  }
+  if (actualProxyTemplate.href !== expectedProxyTemplate.href) {
+    throw new Error(
+      `Public API Proxy template URL ${actualProxyTemplate.href} does not match expected ${expectedProxyTemplate.href}`,
+    )
+  }
+
+  const actualVersion = apiConfig?.version
+  if (actualVersion !== expectedVersion) {
+    throw new Error(`Public API version ${actualVersion ?? 'missing'} does not match expected ${expectedVersion}`)
+  }
+
+  if (expectedSupportedImages.length > 0) {
+    const actualSupportedImages = apiConfig?.supportedImages
+    if (!Array.isArray(actualSupportedImages)) {
+      const expectedNames = expectedSupportedImages.map(({ name }) => name).join(', ')
+      throw new Error(`Public API supported images ${expectedNames} are missing`)
+    }
+    for (const expectedImage of expectedSupportedImages) {
+      const actualImage = actualSupportedImages.find((image) => image?.name === expectedImage.name)
+      if (!actualImage) {
+        throw new Error(`Public API supported images are missing ${expectedImage.name}`)
+      }
+      if (actualImage.ref !== expectedImage.ref) {
+        throw new Error(
+          `Public API image ${expectedImage.name} ref ${actualImage.ref ?? 'missing'} does not match expected ${expectedImage.ref}`,
+        )
+      }
+    }
+  }
+
+  return {
+    proxyHealthUrl,
+    proxyWildcardHealthUrl,
+    apiConfigUrl,
+    oidcIssuer: actualOidcIssuer,
+    proxyTemplateHost: actualProxyTemplate.host,
+    version: actualVersion,
+  }
+}
+
+function wait(delayMs) {
+  return new Promise((resolve) => setTimeout(resolve, delayMs))
+}
+
+async function verifyWithRetry(options, retryOptions, defaultVerify) {
+  const { attempts = 7, delayMs = 10_000, verify = defaultVerify, sleep = wait, onRetry = () => {} } = retryOptions
+  if (!Number.isInteger(attempts) || attempts < 1) {
+    throw new Error(`Deployment verification retry attempts must be a positive integer, received ${attempts}`)
+  }
+  if (!Number.isFinite(delayMs) || delayMs < 0) {
+    throw new Error(`Deployment verification retry delay must be non-negative, received ${delayMs}`)
+  }
+
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      return await verify(options)
+    } catch (error) {
+      if (attempt === attempts) throw error
+      onRetry({ error, attempt, nextAttempt: attempt + 1, attempts, delayMs })
+      await sleep(delayMs)
+    }
+  }
+
+  throw new Error('Deployment verification exhausted its retry loop')
+}
+
+export async function verifyProxyDeploymentWithRetry(options, retryOptions = {}) {
+  return verifyWithRetry(options, retryOptions, verifyProxyDeployment)
+}
+
+export async function verifyPublicDeploymentWithRetry(options, retryOptions = {}) {
+  return verifyWithRetry(options, retryOptions, verifyPublicDeployment)
+}

--- a/apps/infra/scripts/proxy-deployment-verify.mjs
+++ b/apps/infra/scripts/proxy-deployment-verify.mjs
@@ -125,10 +125,13 @@ export function verifyProxyDeployment({ app, stage, region, awsJson }) {
   if (!Number.isInteger(service.desiredCount) || service.desiredCount < 1) {
     throw new Error(`Proxy ECS service desired count is ${service.desiredCount ?? 'missing'}, expected at least 1`)
   }
-  if (service.runningCount < service.desiredCount) {
+  if (!Number.isInteger(service.runningCount) || service.runningCount < 0) {
     throw new Error(
-      `Proxy ECS service has ${service.runningCount ?? 0} running tasks; expected ${service.desiredCount}`,
+      `Proxy ECS service running task count is ${service.runningCount ?? 'missing'}, expected a non-negative integer`,
     )
+  }
+  if (service.runningCount < service.desiredCount) {
+    throw new Error(`Proxy ECS service has ${service.runningCount} running tasks; expected ${service.desiredCount}`)
   }
 
   const serviceLoadBalancer = exactlyOne(service.loadBalancers, 'Proxy ECS load-balancer attachment')
@@ -375,12 +378,36 @@ export async function verifyPublicDeployment({
   }
 }
 
-function wait(delayMs) {
-  return new Promise((resolve) => setTimeout(resolve, delayMs))
+function abortReason(signal) {
+  return signal.reason instanceof Error ? signal.reason : new Error('Deployment verification interrupted')
+}
+
+function wait(delayMs, signal) {
+  if (!signal) return new Promise((resolve) => setTimeout(resolve, delayMs))
+  if (signal.aborted) return Promise.reject(abortReason(signal))
+
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort)
+      resolve()
+    }, delayMs)
+    const onAbort = () => {
+      clearTimeout(timer)
+      reject(abortReason(signal))
+    }
+    signal.addEventListener('abort', onAbort, { once: true })
+  })
 }
 
 async function verifyWithRetry(options, retryOptions, defaultVerify) {
-  const { attempts = 7, delayMs = 10_000, verify = defaultVerify, sleep = wait, onRetry = () => {} } = retryOptions
+  const {
+    attempts = 7,
+    delayMs = 10_000,
+    verify = defaultVerify,
+    sleep = wait,
+    onRetry = () => {},
+    signal,
+  } = retryOptions
   if (!Number.isInteger(attempts) || attempts < 1) {
     throw new Error(`Deployment verification retry attempts must be a positive integer, received ${attempts}`)
   }
@@ -389,12 +416,14 @@ async function verifyWithRetry(options, retryOptions, defaultVerify) {
   }
 
   for (let attempt = 1; attempt <= attempts; attempt++) {
+    if (signal?.aborted) throw abortReason(signal)
     try {
       return await verify(options)
     } catch (error) {
+      if (signal?.aborted) throw abortReason(signal)
       if (attempt === attempts) throw error
       onRetry({ error, attempt, nextAttempt: attempt + 1, attempts, delayMs })
-      await sleep(delayMs)
+      await sleep(delayMs, signal)
     }
   }
 

--- a/apps/infra/scripts/proxy-deployment-verify.test.mjs
+++ b/apps/infra/scripts/proxy-deployment-verify.test.mjs
@@ -145,6 +145,39 @@ test('verifies the listener, ECS attachment, and healthy Proxy targets', () => {
   assert.equal(fixture.calls.length, 6)
 })
 
+test('rejects a Proxy service response without a running task count', () => {
+  const fixture = createAwsFixture({
+    'ecs describe-services': {
+      failures: [],
+      services: [
+        {
+          serviceArn: SERVICE_ARN,
+          status: 'ACTIVE',
+          desiredCount: 1,
+          loadBalancers: [
+            {
+              targetGroupArn: TARGET_GROUP_ARN,
+              containerName: 'Proxy',
+              containerPort: 4000,
+            },
+          ],
+        },
+      ],
+    },
+  })
+
+  assert.throws(
+    () =>
+      verifyProxyDeployment({
+        app: 'boxlite',
+        stage: 'dev',
+        region: 'ap-southeast-1',
+        awsJson: fixture.awsJson,
+      }),
+    /running task count is missing, expected a non-negative integer/,
+  )
+})
+
 test('rejects a listener that forwards to a target group not attached to Proxy', () => {
   const fixture = createAwsFixture({
     [`elbv2 describe-listeners ${LOAD_BALANCER_ARN}`]: {
@@ -345,6 +378,27 @@ test('returns the last verification error after the retry limit', async () => {
     expectedError,
   )
   assert.equal(verificationAttempts, 2)
+})
+
+test('aborts a pending verification retry delay', async () => {
+  const controller = new AbortController()
+  const interrupted = new Error('deployment verification interrupted')
+  const startedAt = Date.now()
+  const verification = verifyProxyDeploymentWithRetry(
+    { app: 'boxlite', stage: 'dev', region: 'ap-southeast-1' },
+    {
+      attempts: 2,
+      delayMs: 250,
+      signal: controller.signal,
+      verify() {
+        throw new Error('target is still registering')
+      },
+    },
+  )
+
+  controller.abort(interrupted)
+  await assert.rejects(verification, interrupted)
+  assert.ok(Date.now() - startedAt < 200, 'abort must not wait for the retry delay')
 })
 
 test('the default retry window covers two 30-second target health checks', async () => {

--- a/apps/infra/scripts/proxy-deployment-verify.test.mjs
+++ b/apps/infra/scripts/proxy-deployment-verify.test.mjs
@@ -1,0 +1,577 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+import assert from 'node:assert/strict'
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+
+import {
+  runAwsJson,
+  verifyProxyDeployment,
+  verifyProxyDeploymentWithRetry,
+  verifyPublicDeployment,
+  verifyPublicDeploymentWithRetry,
+} from './proxy-deployment-verify.mjs'
+
+const CLUSTER_ARN = 'arn:aws:ecs:ap-southeast-1:123456789012:cluster/boxlite-dev-cluster'
+const SERVICE_ARN = `${CLUSTER_ARN.replace(':cluster/', ':service/')}/Proxy`
+const TARGET_GROUP_ARN = 'arn:aws:elasticloadbalancing:ap-southeast-1:123456789012:targetgroup/proxy/primary'
+const LOAD_BALANCER_ARN = 'arn:aws:elasticloadbalancing:ap-southeast-1:123456789012:loadbalancer/net/proxy/lb'
+const LISTENER_ARN = 'arn:aws:elasticloadbalancing:ap-southeast-1:123456789012:listener/net/proxy/lb/listener'
+
+test('runs the configured AWS CLI when PATH does not contain aws', () => {
+  const directory = mkdtempSync(join(tmpdir(), 'boxlite-infra-aws-cli-'))
+  const awsCliPath = join(directory, 'aws-cli')
+  const previousAwsCliPath = process.env.AWS_CLI_PATH
+  const previousPath = process.env.PATH
+
+  writeFileSync(awsCliPath, '#!/bin/sh\nprintf \'%s\\n\' \'{"Account":"123456789012"}\'\n')
+  chmodSync(awsCliPath, 0o755)
+  process.env.AWS_CLI_PATH = awsCliPath
+  process.env.PATH = directory
+
+  try {
+    assert.deepEqual(runAwsJson(['sts', 'get-caller-identity'], 'ap-southeast-1'), {
+      Account: '123456789012',
+    })
+  } finally {
+    if (previousAwsCliPath === undefined) delete process.env.AWS_CLI_PATH
+    else process.env.AWS_CLI_PATH = previousAwsCliPath
+    if (previousPath === undefined) delete process.env.PATH
+    else process.env.PATH = previousPath
+    rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+function awsCallKey(args) {
+  const operation = args.slice(0, 2).join(' ')
+  if (operation === 'resourcegroupstaggingapi get-resources') {
+    const filterIndex = args.indexOf('--resource-type-filters')
+    return `${operation} ${args[filterIndex + 1]}`
+  }
+  if (operation === 'elbv2 describe-listeners') {
+    const loadBalancerIndex = args.indexOf('--load-balancer-arn')
+    return `${operation} ${args[loadBalancerIndex + 1]}`
+  }
+  return operation
+}
+
+function createAwsFixture(overrides = {}) {
+  const responses = {
+    'resourcegroupstaggingapi get-resources ecs:cluster': {
+      ResourceTagMappingList: [{ ResourceARN: CLUSTER_ARN }],
+    },
+    'resourcegroupstaggingapi get-resources elasticloadbalancing:loadbalancer': {
+      ResourceTagMappingList: [{ ResourceARN: LOAD_BALANCER_ARN }],
+    },
+    'ecs describe-services': {
+      failures: [],
+      services: [
+        {
+          serviceArn: SERVICE_ARN,
+          status: 'ACTIVE',
+          desiredCount: 1,
+          runningCount: 1,
+          loadBalancers: [
+            {
+              targetGroupArn: TARGET_GROUP_ARN,
+              containerName: 'Proxy',
+              containerPort: 4000,
+            },
+          ],
+        },
+      ],
+    },
+    'elbv2 describe-target-groups': {
+      TargetGroups: [
+        {
+          TargetGroupArn: TARGET_GROUP_ARN,
+          LoadBalancerArns: [LOAD_BALANCER_ARN],
+          Port: 4000,
+          Protocol: 'TCP',
+          TargetType: 'ip',
+          HealthCheckProtocol: 'HTTP',
+          HealthCheckPath: '/health',
+        },
+      ],
+    },
+    [`elbv2 describe-listeners ${LOAD_BALANCER_ARN}`]: {
+      Listeners: [
+        {
+          ListenerArn: LISTENER_ARN,
+          Port: 443,
+          Protocol: 'TLS',
+          DefaultActions: [{ Type: 'forward', TargetGroupArn: TARGET_GROUP_ARN }],
+        },
+      ],
+    },
+    'elbv2 describe-target-health': {
+      TargetHealthDescriptions: [{ Target: { Id: '10.0.1.23', Port: 4000 }, TargetHealth: { State: 'healthy' } }],
+    },
+    ...overrides,
+  }
+  const calls = []
+  return {
+    calls,
+    awsJson(args) {
+      calls.push(args)
+      const key = awsCallKey(args)
+      if (!(key in responses)) throw new Error(`unexpected AWS call: ${args.join(' ')}`)
+      return responses[key]
+    },
+  }
+}
+
+test('verifies the listener, ECS attachment, and healthy Proxy targets', () => {
+  const fixture = createAwsFixture()
+
+  const result = verifyProxyDeployment({
+    app: 'boxlite',
+    stage: 'dev',
+    region: 'ap-southeast-1',
+    awsJson: fixture.awsJson,
+  })
+
+  assert.deepEqual(result, {
+    clusterArn: CLUSTER_ARN,
+    serviceArn: SERVICE_ARN,
+    listenerArn: LISTENER_ARN,
+    targetGroupArn: TARGET_GROUP_ARN,
+    desiredCount: 1,
+    healthyTargetCount: 1,
+  })
+  assert.equal(fixture.calls.length, 6)
+})
+
+test('rejects a listener that forwards to a target group not attached to Proxy', () => {
+  const fixture = createAwsFixture({
+    [`elbv2 describe-listeners ${LOAD_BALANCER_ARN}`]: {
+      Listeners: [
+        {
+          ListenerArn: LISTENER_ARN,
+          Port: 443,
+          Protocol: 'TLS',
+          DefaultActions: [
+            {
+              Type: 'forward',
+              TargetGroupArn: 'arn:aws:elasticloadbalancing:ap-southeast-1:123456789012:targetgroup/proxy/detached',
+            },
+          ],
+        },
+      ],
+    },
+  })
+
+  assert.throws(
+    () =>
+      verifyProxyDeployment({
+        app: 'boxlite',
+        stage: 'dev',
+        region: 'ap-southeast-1',
+        awsJson: fixture.awsJson,
+      }),
+    /does not match the Proxy ECS target group/,
+  )
+})
+
+test('rejects an internally healthy legacy attachment when the SST NLB forwards elsewhere', () => {
+  const legacyTargetGroupArn = 'arn:aws:elasticloadbalancing:ap-southeast-1:123456789012:targetgroup/proxy/legacy'
+  const legacyLoadBalancerArn = 'arn:aws:elasticloadbalancing:ap-southeast-1:123456789012:loadbalancer/net/proxy/legacy'
+  const fixture = createAwsFixture({
+    'ecs describe-services': {
+      failures: [],
+      services: [
+        {
+          serviceArn: SERVICE_ARN,
+          status: 'ACTIVE',
+          desiredCount: 1,
+          runningCount: 1,
+          loadBalancers: [
+            {
+              targetGroupArn: legacyTargetGroupArn,
+              containerName: 'Proxy',
+              containerPort: 4000,
+            },
+          ],
+        },
+      ],
+    },
+    'elbv2 describe-target-groups': {
+      TargetGroups: [
+        {
+          TargetGroupArn: legacyTargetGroupArn,
+          LoadBalancerArns: [legacyLoadBalancerArn],
+          Port: 4000,
+          Protocol: 'TCP',
+          TargetType: 'ip',
+          HealthCheckProtocol: 'HTTP',
+          HealthCheckPath: '/health',
+        },
+      ],
+    },
+    [`elbv2 describe-listeners ${legacyLoadBalancerArn}`]: {
+      Listeners: [
+        {
+          ListenerArn: `${legacyLoadBalancerArn}/listener`,
+          Port: 443,
+          Protocol: 'TLS',
+          DefaultActions: [{ Type: 'forward', TargetGroupArn: legacyTargetGroupArn }],
+        },
+      ],
+    },
+  })
+
+  assert.throws(
+    () =>
+      verifyProxyDeployment({
+        app: 'boxlite',
+        stage: 'dev',
+        region: 'ap-southeast-1',
+        awsJson: fixture.awsJson,
+      }),
+    /does not match the Proxy ECS target group/,
+  )
+})
+
+test('rejects a target group that does not use the Proxy HTTP health check', () => {
+  const fixture = createAwsFixture({
+    'elbv2 describe-target-groups': {
+      TargetGroups: [
+        {
+          TargetGroupArn: TARGET_GROUP_ARN,
+          LoadBalancerArns: [LOAD_BALANCER_ARN],
+          Port: 4000,
+          Protocol: 'TCP',
+          TargetType: 'ip',
+          HealthCheckProtocol: 'TCP',
+        },
+      ],
+    },
+  })
+
+  assert.throws(
+    () =>
+      verifyProxyDeployment({
+        app: 'boxlite',
+        stage: 'dev',
+        region: 'ap-southeast-1',
+        awsJson: fixture.awsJson,
+      }),
+    /health check is TCP:missing, expected HTTP:\/health/,
+  )
+})
+
+test('rejects a target group without enough healthy targets for the service', () => {
+  const fixture = createAwsFixture({
+    'ecs describe-services': {
+      failures: [],
+      services: [
+        {
+          serviceArn: SERVICE_ARN,
+          status: 'ACTIVE',
+          desiredCount: 2,
+          runningCount: 2,
+          loadBalancers: [
+            {
+              targetGroupArn: TARGET_GROUP_ARN,
+              containerName: 'Proxy',
+              containerPort: 4000,
+            },
+          ],
+        },
+      ],
+    },
+  })
+
+  assert.throws(
+    () =>
+      verifyProxyDeployment({
+        app: 'boxlite',
+        stage: 'dev',
+        region: 'ap-southeast-1',
+        awsJson: fixture.awsJson,
+      }),
+    /has 1 healthy target; expected at least 2/,
+  )
+})
+
+test('retries a bounded number of times while AWS deployment state converges', async () => {
+  let verificationAttempts = 0
+  const retryDelays = []
+
+  const result = await verifyProxyDeploymentWithRetry(
+    { app: 'boxlite', stage: 'dev', region: 'ap-southeast-1' },
+    {
+      attempts: 3,
+      delayMs: 25,
+      verify() {
+        verificationAttempts += 1
+        if (verificationAttempts < 3) throw new Error('target is still registering')
+        return { healthyTargetCount: 1 }
+      },
+      sleep(delayMs) {
+        retryDelays.push(delayMs)
+        return Promise.resolve()
+      },
+    },
+  )
+
+  assert.deepEqual(result, { healthyTargetCount: 1 })
+  assert.equal(verificationAttempts, 3)
+  assert.deepEqual(retryDelays, [25, 25])
+})
+
+test('returns the last verification error after the retry limit', async () => {
+  let verificationAttempts = 0
+  const expectedError = new Error('target never became healthy')
+
+  await assert.rejects(
+    verifyProxyDeploymentWithRetry(
+      { app: 'boxlite', stage: 'dev', region: 'ap-southeast-1' },
+      {
+        attempts: 2,
+        delayMs: 0,
+        verify() {
+          verificationAttempts += 1
+          throw expectedError
+        },
+        sleep() {
+          return Promise.resolve()
+        },
+      },
+    ),
+    expectedError,
+  )
+  assert.equal(verificationAttempts, 2)
+})
+
+test('the default retry window covers two 30-second target health checks', async () => {
+  let verificationAttempts = 0
+  const retryDelays = []
+  const expectedError = new Error('target health is still converging')
+
+  await assert.rejects(
+    verifyProxyDeploymentWithRetry(
+      { app: 'boxlite', stage: 'dev', region: 'ap-southeast-1' },
+      {
+        verify() {
+          verificationAttempts += 1
+          throw expectedError
+        },
+        sleep(delayMs) {
+          retryDelays.push(delayMs)
+          return Promise.resolve()
+        },
+      },
+    ),
+    expectedError,
+  )
+
+  assert.equal(verificationAttempts, 7)
+  assert.deepEqual(retryDelays, [10_000, 10_000, 10_000, 10_000, 10_000, 10_000])
+})
+
+function jsonResponse(status, body) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    async json() {
+      return body
+    },
+  }
+}
+
+function publicDeploymentOptions(fetchImpl) {
+  return {
+    proxyHealthUrl: 'https://proxy.dev.boxlite.ai/health',
+    proxyWildcardHealthUrl: 'https://deployment-probe.proxy.dev.boxlite.ai/health',
+    apiConfigUrl: 'https://api.dev.boxlite.ai/api/config',
+    expectedOidcIssuer: 'https://auth.dev.boxlite.ai/',
+    expectedProxyTemplateUrl: 'https://proxy.dev.boxlite.ai',
+    expectedVersion: '0.9.7',
+    fetchImpl,
+  }
+}
+
+test('verifies the public Proxy health and API deployment config with an injected fetch', async () => {
+  const calls = []
+  const result = await verifyPublicDeployment(
+    publicDeploymentOptions(async (url) => {
+      calls.push(url)
+      if (url === 'https://proxy.dev.boxlite.ai/health') {
+        return jsonResponse(200, { status: 'ok', version: '0.0.1' })
+      }
+      if (url === 'https://deployment-probe.proxy.dev.boxlite.ai/health') {
+        return jsonResponse(200, { status: 'ok', version: '0.0.1' })
+      }
+      if (url === 'https://api.dev.boxlite.ai/api/config') {
+        return jsonResponse(200, {
+          version: '0.9.7',
+          oidc: { issuer: 'https://auth.dev.boxlite.ai/' },
+          proxyTemplateUrl: 'https://proxy.dev.boxlite.ai',
+        })
+      }
+      throw new Error(`unexpected URL: ${url}`)
+    }),
+  )
+
+  assert.deepEqual(calls, [
+    'https://proxy.dev.boxlite.ai/health',
+    'https://deployment-probe.proxy.dev.boxlite.ai/health',
+    'https://api.dev.boxlite.ai/api/config',
+  ])
+  assert.deepEqual(result, {
+    proxyHealthUrl: 'https://proxy.dev.boxlite.ai/health',
+    proxyWildcardHealthUrl: 'https://deployment-probe.proxy.dev.boxlite.ai/health',
+    apiConfigUrl: 'https://api.dev.boxlite.ai/api/config',
+    oidcIssuer: 'https://auth.dev.boxlite.ai/',
+    proxyTemplateHost: 'proxy.dev.boxlite.ai',
+    version: '0.9.7',
+  })
+})
+
+test('rejects a deployment whose base Proxy works but wildcard DNS or TLS does not', async () => {
+  await assert.rejects(
+    verifyPublicDeployment(
+      publicDeploymentOptions(async (url) => {
+        if (url === 'https://proxy.dev.boxlite.ai/health') {
+          return jsonResponse(200, { status: 'ok' })
+        }
+        if (url === 'https://deployment-probe.proxy.dev.boxlite.ai/health') {
+          return jsonResponse(502, { status: 'unavailable' })
+        }
+        return jsonResponse(200, {
+          version: '0.9.7',
+          oidc: { issuer: 'https://auth.dev.boxlite.ai/' },
+          proxyTemplateUrl: 'https://proxy.dev.boxlite.ai',
+        })
+      }),
+    ),
+    /Public Proxy wildcard health check returned HTTP 502/,
+  )
+})
+
+test('rejects a public API config with a different issuer or the wrong Proxy host', async () => {
+  await assert.rejects(
+    verifyPublicDeployment(
+      publicDeploymentOptions(async (url) =>
+        url.includes('/health')
+          ? jsonResponse(200, { status: 'ok' })
+          : jsonResponse(200, {
+              version: '0.9.7',
+              oidc: { issuer: 'https://auth.dev.boxlite.ai' },
+              proxyTemplateUrl: 'https://proxy.dev.boxlite.ai',
+            }),
+      ),
+    ),
+    /does not match expected https:\/\/auth\.dev\.boxlite\.ai\//,
+  )
+
+  await assert.rejects(
+    verifyPublicDeployment(
+      publicDeploymentOptions(async (url) =>
+        url.includes('/health')
+          ? jsonResponse(200, { status: 'ok' })
+          : jsonResponse(200, {
+              version: '0.9.7',
+              oidc: { issuer: 'https://auth.dev.boxlite.ai/' },
+              proxyTemplateUrl: 'https://detached.dev.boxlite.ai',
+            }),
+      ),
+    ),
+    /Proxy template host detached\.dev\.boxlite\.ai does not match proxy\.dev\.boxlite\.ai/,
+  )
+
+  await assert.rejects(
+    verifyPublicDeployment(
+      publicDeploymentOptions(async (url) =>
+        url.includes('/health')
+          ? jsonResponse(200, { status: 'ok' })
+          : jsonResponse(200, {
+              version: '0.9.7',
+              oidc: { issuer: 'https://auth.dev.boxlite.ai/' },
+              proxyTemplateUrl: 'https://proxy.dev.boxlite.ai/wrong-path',
+            }),
+      ),
+    ),
+    /Proxy template URL https:\/\/proxy\.dev\.boxlite\.ai\/wrong-path does not match expected/,
+  )
+})
+
+test('rejects a public API config from a stale release', async () => {
+  await assert.rejects(
+    verifyPublicDeployment(
+      publicDeploymentOptions(async (url) =>
+        url.includes('/health')
+          ? jsonResponse(200, { status: 'ok' })
+          : jsonResponse(200, {
+              version: '0.9.6',
+              oidc: { issuer: 'https://auth.dev.boxlite.ai/' },
+              proxyTemplateUrl: 'https://proxy.dev.boxlite.ai',
+            }),
+      ),
+    ),
+    /API version 0\.9\.6 does not match expected 0\.9\.7/,
+  )
+})
+
+test('rejects a public API config that omits or changes a configured image', async () => {
+  const expectedSupportedImages = [
+    { name: 'sandbaseai-hermes', ref: 'sam2026go/hermes-agent:boxlite-noexpose-20260726' },
+  ]
+  const apiConfig = (supportedImages) => ({
+    version: '0.9.7',
+    oidc: { issuer: 'https://auth.dev.boxlite.ai/' },
+    proxyTemplateUrl: 'https://proxy.dev.boxlite.ai',
+    ...(supportedImages === undefined ? {} : { supportedImages }),
+  })
+  const verifyImages = (supportedImages) =>
+    verifyPublicDeployment({
+      ...publicDeploymentOptions(async (url) =>
+        url.includes('/health') ? jsonResponse(200, { status: 'ok' }) : jsonResponse(200, apiConfig(supportedImages)),
+      ),
+      expectedSupportedImages,
+    })
+
+  await assert.rejects(verifyImages(undefined), /supported images.*sandbaseai-hermes.*missing/i)
+  await assert.rejects(
+    verifyImages([{ name: 'sandbaseai-hermes', ref: 'sam2026go/hermes-agent:old' }]),
+    /image sandbaseai-hermes.*sam2026go\/hermes-agent:old.*boxlite-noexpose-20260726/i,
+  )
+})
+
+test('retries public deployment probes a bounded number of times', async () => {
+  let proxyAttempts = 0
+  const retryDelays = []
+
+  const result = await verifyPublicDeploymentWithRetry(
+    publicDeploymentOptions(async (url) => {
+      if (url === 'https://proxy.dev.boxlite.ai/health') {
+        proxyAttempts += 1
+        return proxyAttempts < 3 ? jsonResponse(503, { status: 'starting' }) : jsonResponse(200, { status: 'ok' })
+      }
+      if (url === 'https://deployment-probe.proxy.dev.boxlite.ai/health') {
+        return jsonResponse(200, { status: 'ok' })
+      }
+      return jsonResponse(200, {
+        version: '0.9.7',
+        oidc: { issuer: 'https://auth.dev.boxlite.ai/' },
+        proxyTemplateUrl: 'https://proxy.dev.boxlite.ai',
+      })
+    }),
+    {
+      attempts: 3,
+      delayMs: 25,
+      sleep(delayMs) {
+        retryDelays.push(delayMs)
+        return Promise.resolve()
+      },
+    },
+  )
+
+  assert.equal(result.proxyTemplateHost, 'proxy.dev.boxlite.ai')
+  assert.equal(proxyAttempts, 3)
+  assert.deepEqual(retryDelays, [25, 25])
+})

--- a/apps/infra/scripts/release-deployment-safety.test.mjs
+++ b/apps/infra/scripts/release-deployment-safety.test.mjs
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+import assert from 'node:assert/strict'
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import test from 'node:test'
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..')
+const SST_WRAPPER = join(REPO_ROOT, 'apps/infra/scripts/sst-with-cloudflare.mjs')
+const DEV_API_DEPLOY_WORKFLOW = join(REPO_ROOT, '.github/workflows/deploy-dev-api.yml')
+const DEV_DEPLOY_ROLE = join(REPO_ROOT, 'apps/infra/ci/github-deploy-role.yaml')
+
+test('SST deploy verifies Runner release assets before invoking SST', () => {
+  const source = readFileSync(SST_WRAPPER, 'utf8')
+  const preflightIndex = source.indexOf('await verifyRunnerReleaseAssets(')
+  const sstIndex = source.indexOf('await withPulumiEventLogCleanup(')
+
+  assert.match(source, /import \{ verifyRunnerReleaseAssets \} from '\.\/runner-release-assets\.mjs'/)
+  assert.notEqual(preflightIndex, -1, 'the Runner release preflight is missing')
+  assert.notEqual(sstIndex, -1, 'the guarded SST invocation is missing')
+  assert.ok(preflightIndex < sstIndex, 'SST may run before Runner release availability is known')
+})
+
+test('SST deploy does not depend on a laptop-managed remote builder', () => {
+  const source = readFileSync(SST_WRAPPER, 'utf8')
+  const packageSource = readFileSync(join(REPO_ROOT, 'apps/infra/package.json'), 'utf8')
+
+  assert.doesNotMatch(source, /RemoteAmd64Builder/)
+  assert.doesNotMatch(source, /BUILDX_BUILDER/)
+  assert.doesNotMatch(packageSource, /builder:(?:provision|start|status|stop)/)
+  for (const legacyPath of [
+    'apps/infra/scripts/buildx-builder.mjs',
+    'apps/infra/scripts/buildx-builder-cli.mjs',
+    'apps/infra/buildkit/amd64-builder.yaml',
+    'apps/infra/buildkit/buildkitd.toml',
+  ]) {
+    assert.equal(existsSync(join(REPO_ROOT, legacyPath)), false, `${legacyPath} must be removed`)
+  }
+})
+
+test('manual dev API deployment runs natively in guarded GitHub CI', () => {
+  assert.ok(existsSync(DEV_API_DEPLOY_WORKFLOW), 'the dev API deployment workflow is missing')
+  const source = readFileSync(DEV_API_DEPLOY_WORKFLOW, 'utf8')
+
+  assert.match(source, /workflow_dispatch:/)
+  assert.match(source, /if: github\.ref == 'refs\/heads\/main'/)
+  assert.match(source, /environment: dev/)
+  assert.match(source, /id-token: write/)
+  assert.match(source, /runs-on: ubuntu-24\.04/)
+  assert.match(source, /uname -m[\s\S]*x86_64/)
+  assert.match(source, /docker info[\s\S]*x86_64/)
+  assert.match(source, /aws-actions\/configure-aws-credentials@/)
+  assert.match(source, /role-to-assume: \$\{\{ vars\.AWS_DEPLOY_ROLE_ARN \}\}/)
+  assert.match(source, /secrets\.DEPLOY_ENV/)
+  assert.match(source, /AWS_ACCESS_KEY_ID[\s\S]*native CI builder/)
+  assert.match(source, /npm run deploy -- --stage dev --target Api --exclude Runner/)
+  assert.doesNotMatch(source, /setup-qemu/)
+})
+
+test('dev deploy role trusts only the repository GitHub Environment identity', () => {
+  assert.ok(existsSync(DEV_DEPLOY_ROLE), 'the GitHub deployment role template is missing')
+  const source = readFileSync(DEV_DEPLOY_ROLE, 'utf8')
+
+  assert.match(source, /oidc-provider\/token\.actions\.githubusercontent\.com/)
+  assert.match(source, /token\.actions\.githubusercontent\.com:aud: sts\.amazonaws\.com/)
+  assert.match(
+    source,
+    /token\.actions\.githubusercontent\.com:sub: !Sub repo:\$\{GitHubRepository\}:environment:\$\{GitHubEnvironment\}/,
+  )
+})
+
+test('SST preflights the workspace Runner artifact even when VERSION overrides the public API version', () => {
+  const source = readFileSync(SST_WRAPPER, 'utf8')
+
+  assert.match(source, /const workspaceVersion = readWorkspaceVersion\(\)/)
+  assert.match(source, /resolvePublicDeploymentConfig\(process\.env, workspaceVersion\)/)
+  assert.match(source, /await verifyRunnerReleaseAssets\(workspaceVersion\)/)
+  assert.doesNotMatch(source, /verifyRunnerReleaseAssets\(publicDeploymentConfig\.releaseVersion\)/)
+})

--- a/apps/infra/scripts/release-deployment-safety.test.mjs
+++ b/apps/infra/scripts/release-deployment-safety.test.mjs
@@ -6,12 +6,38 @@ import { existsSync, readFileSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import test from 'node:test'
+import { DEFAULT_SCHEMA, Type, load } from 'js-yaml'
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..')
 const SST_WRAPPER = join(REPO_ROOT, 'apps/infra/scripts/sst-with-cloudflare.mjs')
 const DEV_API_DEPLOY_WORKFLOW = join(REPO_ROOT, '.github/workflows/deploy-dev-api.yml')
 const LINT_WORKFLOW = join(REPO_ROOT, '.github/workflows/lint.yml')
 const DEV_DEPLOY_ROLE = join(REPO_ROOT, 'apps/infra/ci/github-deploy-role.yaml')
+const CLOUDFORMATION_SCHEMA = DEFAULT_SCHEMA.extend([
+  new Type('!Sub', {
+    kind: 'scalar',
+    construct: (value) => value,
+  }),
+  new Type('!Ref', {
+    kind: 'scalar',
+    construct: (value) => value,
+  }),
+  new Type('!GetAtt', {
+    kind: 'scalar',
+    construct: (value) => value,
+  }),
+])
+
+function readRuntimeBoundaryStatements() {
+  const template = load(readFileSync(DEV_DEPLOY_ROLE, 'utf8'), { schema: CLOUDFORMATION_SCHEMA })
+  return template.Resources.BoxLiteRuntimePermissionsBoundary.Properties.PolicyDocument.Statement
+}
+
+function findStatement(statements, sid) {
+  const statement = statements.find((candidate) => candidate.Sid === sid)
+  assert.ok(statement, `missing ${sid} statement`)
+  return statement
+}
 
 test('SST deploy verifies Runner release assets before invoking SST', () => {
   const source = readFileSync(SST_WRAPPER, 'utf8')
@@ -71,6 +97,7 @@ test('infrastructure tests cannot persist or write with the workflow token', () 
 test('dev deploy role trusts only the repository GitHub Environment identity', () => {
   assert.ok(existsSync(DEV_DEPLOY_ROLE), 'the GitHub deployment role template is missing')
   const source = readFileSync(DEV_DEPLOY_ROLE, 'utf8')
+  const statements = readRuntimeBoundaryStatements()
 
   assert.match(source, /oidc-provider\/token\.actions\.githubusercontent\.com/)
   assert.match(source, /token\.actions\.githubusercontent\.com:aud: sts\.amazonaws\.com/)
@@ -82,9 +109,56 @@ test('dev deploy role trusts only the repository GitHub Environment identity', (
   assert.match(source, /BoxLiteRuntimePermissionsBoundary:/)
   assert.match(source, /iam:PermissionsBoundary/)
   assert.match(source, /PolicyName: boxlite-sst-deploy/)
-  assert.match(source, /secret:boxlite-\$\{GitHubEnvironment\}-\*/)
-  assert.match(source, /arn:\$\{AWS::Partition\}:s3:::boxlite-\$\{GitHubEnvironment\}-\*/)
-  assert.match(source, /kms:ResourceAliases:/)
+
+  assert.deepEqual(findStatement(statements, 'BoxLiteStageSecrets'), {
+    Sid: 'BoxLiteStageSecrets',
+    Effect: 'Allow',
+    Action: ['secretsmanager:DescribeSecret', 'secretsmanager:GetSecretValue'],
+    Resource:
+      'arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:boxlite-${GitHubEnvironment}-*',
+  })
+  assert.deepEqual(findStatement(statements, 'BoxLiteStageKmsKeys'), {
+    Sid: 'BoxLiteStageKmsKeys',
+    Effect: 'Allow',
+    Action: 'kms:Decrypt',
+    Resource: 'arn:${AWS::Partition}:kms:${AWS::Region}:${AWS::AccountId}:key/*',
+    Condition: {
+      'ForAnyValue:StringLike': {
+        'kms:ResourceAliases': 'alias/boxlite-${GitHubEnvironment}-*',
+      },
+    },
+  })
+  assert.deepEqual(findStatement(statements, 'BoxLiteBuckets'), {
+    Sid: 'BoxLiteBuckets',
+    Effect: 'Allow',
+    Action: [
+      's3:CreateBucket',
+      's3:DeleteBucket',
+      's3:GetBucketLocation',
+      's3:ListBucket',
+      's3:ListBucketVersions',
+      's3:PutBucketTagging',
+    ],
+    Resource: [
+      'arn:${AWS::Partition}:s3:::boxlite-${GitHubEnvironment}-*',
+      'arn:${AWS::Partition}:s3:::boxlite-volume-*',
+    ],
+  })
+  assert.deepEqual(findStatement(statements, 'BoxLiteBucketObjects'), {
+    Sid: 'BoxLiteBucketObjects',
+    Effect: 'Allow',
+    Action: [
+      's3:AbortMultipartUpload',
+      's3:DeleteObject',
+      's3:DeleteObjectVersion',
+      's3:GetObject',
+      's3:PutObject',
+    ],
+    Resource: [
+      'arn:${AWS::Partition}:s3:::boxlite-${GitHubEnvironment}-*/*',
+      'arn:${AWS::Partition}:s3:::boxlite-volume-*/*',
+    ],
+  })
 })
 
 test('SST preflights the workspace Runner artifact even when VERSION overrides the public API version', () => {

--- a/apps/infra/scripts/release-deployment-safety.test.mjs
+++ b/apps/infra/scripts/release-deployment-safety.test.mjs
@@ -82,6 +82,9 @@ test('dev deploy role trusts only the repository GitHub Environment identity', (
   assert.match(source, /BoxLiteRuntimePermissionsBoundary:/)
   assert.match(source, /iam:PermissionsBoundary/)
   assert.match(source, /PolicyName: boxlite-sst-deploy/)
+  assert.match(source, /secret:boxlite-\$\{GitHubEnvironment\}-\*/)
+  assert.match(source, /arn:\$\{AWS::Partition\}:s3:::boxlite-\$\{GitHubEnvironment\}-\*/)
+  assert.match(source, /kms:ResourceAliases:/)
 })
 
 test('SST preflights the workspace Runner artifact even when VERSION overrides the public API version', () => {

--- a/apps/infra/scripts/release-deployment-safety.test.mjs
+++ b/apps/infra/scripts/release-deployment-safety.test.mjs
@@ -10,6 +10,7 @@ import test from 'node:test'
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..')
 const SST_WRAPPER = join(REPO_ROOT, 'apps/infra/scripts/sst-with-cloudflare.mjs')
 const DEV_API_DEPLOY_WORKFLOW = join(REPO_ROOT, '.github/workflows/deploy-dev-api.yml')
+const LINT_WORKFLOW = join(REPO_ROOT, '.github/workflows/lint.yml')
 const DEV_DEPLOY_ROLE = join(REPO_ROOT, 'apps/infra/ci/github-deploy-role.yaml')
 
 test('SST deploy verifies Runner release assets before invoking SST', () => {
@@ -59,6 +60,14 @@ test('manual dev API deployment runs natively in guarded GitHub CI', () => {
   assert.doesNotMatch(source, /setup-qemu/)
 })
 
+test('infrastructure tests cannot persist or write with the workflow token', () => {
+  const source = readFileSync(LINT_WORKFLOW, 'utf8')
+  const infraJob = source.slice(source.indexOf('\n  infra:\n'), source.indexOf('  # Single required status check'))
+
+  assert.match(infraJob, /permissions:\s+contents: read/)
+  assert.match(infraJob, /uses: actions\/checkout@v5\s+with:\s+persist-credentials: false/)
+})
+
 test('dev deploy role trusts only the repository GitHub Environment identity', () => {
   assert.ok(existsSync(DEV_DEPLOY_ROLE), 'the GitHub deployment role template is missing')
   const source = readFileSync(DEV_DEPLOY_ROLE, 'utf8')
@@ -69,6 +78,10 @@ test('dev deploy role trusts only the repository GitHub Environment identity', (
     source,
     /token\.actions\.githubusercontent\.com:sub: !Sub repo:\$\{GitHubRepository\}:environment:\$\{GitHubEnvironment\}/,
   )
+  assert.doesNotMatch(source, /AdministratorAccess/)
+  assert.match(source, /BoxLiteRuntimePermissionsBoundary:/)
+  assert.match(source, /iam:PermissionsBoundary/)
+  assert.match(source, /PolicyName: boxlite-sst-deploy/)
 })
 
 test('SST preflights the workspace Runner artifact even when VERSION overrides the public API version', () => {

--- a/apps/infra/scripts/runner-release-assets.mjs
+++ b/apps/infra/scripts/runner-release-assets.mjs
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+
+const RELEASE_DOWNLOAD_ROOT = 'https://github.com/boxlite-ai/boxlite/releases/download'
+const STABLE_VERSION = /^[0-9]+\.[0-9]+\.[0-9]+$/
+const execFileAsync = promisify(execFile)
+
+export function resolveRunnerReleaseAssets(version) {
+  if (!STABLE_VERSION.test(version)) {
+    throw new Error(`Runner release version '${version}' is not a stable semantic version (expected X.Y.Z)`)
+  }
+
+  const tarballName = `boxlite-runner-v${version}-linux-amd64.tar.gz`
+  const checksumName = `${tarballName}.sha256`
+  const releaseUrl = `${RELEASE_DOWNLOAD_ROOT}/v${version}`
+  return {
+    tarballName,
+    checksumName,
+    tarballUrl: `${releaseUrl}/${tarballName}`,
+    checksumUrl: `${releaseUrl}/${checksumName}`,
+  }
+}
+
+async function curlReleaseAsset(curlPath, url, extraArguments, environment, timeoutMs, description) {
+  const timeoutSeconds = Math.max(1, Math.ceil(timeoutMs / 1_000))
+  const connectTimeoutSeconds = Math.min(10, timeoutSeconds)
+  try {
+    const { stdout } = await execFileAsync(
+      curlPath,
+      [
+        '--fail',
+        '--silent',
+        '--show-error',
+        '--location',
+        '--proto',
+        '=https',
+        '--proto-redir',
+        '=https',
+        '--connect-timeout',
+        String(connectTimeoutSeconds),
+        '--max-time',
+        String(timeoutSeconds),
+        ...extraArguments,
+        url,
+      ],
+      {
+        encoding: 'utf8',
+        env: environment,
+        killSignal: 'SIGTERM',
+        maxBuffer: 1024 * 1024,
+        timeout: timeoutMs,
+      },
+    )
+    return stdout
+  } catch (error) {
+    const detail = error.stderr?.trim() || error.message
+    throw new Error(`Runner release ${description} request failed for ${url}: ${detail}`, { cause: error })
+  }
+}
+
+function remainingTimeoutMs(deadline) {
+  const remaining = deadline - Date.now()
+  if (remaining <= 0) throw new Error('Runner release preflight exceeded its timeout')
+  return remaining
+}
+
+export async function verifyRunnerReleaseAssets(
+  version,
+  { curlPath = 'curl', environment = process.env, timeoutMs = 15_000 } = {},
+) {
+  if (typeof curlPath !== 'string' || curlPath.trim() === '') {
+    throw new Error('Runner release preflight requires a curl executable')
+  }
+  if (!Number.isInteger(timeoutMs) || timeoutMs <= 0) {
+    throw new Error('Runner release preflight timeout must be a positive integer')
+  }
+
+  const assets = resolveRunnerReleaseAssets(version)
+  const deadline = Date.now() + timeoutMs
+
+  // curl honors HTTPS_PROXY/NO_PROXY by default. Node's bare fetch does not,
+  // which made valid releases unreachable from proxied deployment hosts.
+  const checksumContents = (
+    await curlReleaseAsset(curlPath, assets.checksumUrl, [], environment, remainingTimeoutMs(deadline), 'checksum')
+  ).trim()
+  const checksum = checksumContents.match(/^([0-9a-f]{64})[ \t]+\*?([^\r\n]+)$/i)
+  if (!checksum || checksum[2] !== assets.tarballName) {
+    throw new Error(`Runner release checksum manifest must name exactly '${assets.tarballName}'`)
+  }
+
+  await curlReleaseAsset(
+    curlPath,
+    assets.tarballUrl,
+    ['--head', '--output', '/dev/null'],
+    environment,
+    remainingTimeoutMs(deadline),
+    'tarball',
+  )
+  return assets
+}

--- a/apps/infra/scripts/runner-release-assets.test.mjs
+++ b/apps/infra/scripts/runner-release-assets.test.mjs
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+import assert from 'node:assert/strict'
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+
+import { resolveRunnerReleaseAssets, verifyRunnerReleaseAssets } from './runner-release-assets.mjs'
+
+const VERSION = '1.2.3'
+const TARBALL = `boxlite-runner-v${VERSION}-linux-amd64.tar.gz`
+const DIGEST = 'a'.repeat(64)
+
+function shellQuote(value) {
+  return `'${value.replaceAll("'", `'"'"'`)}'`
+}
+
+function createFakeCurl(
+  t,
+  {
+    checksum = `${DIGEST}  ${TARBALL}\n`,
+    checksumExit = 0,
+    expectedProxy = process.env.HTTPS_PROXY ?? '',
+    tarballExit = 0,
+  } = {},
+) {
+  const directory = mkdtempSync(join(tmpdir(), 'boxlite-runner-release-curl-'))
+  const curlPath = join(directory, 'curl')
+  const logPath = join(directory, 'curl.log')
+  t.after(() => rmSync(directory, { recursive: true, force: true }))
+
+  writeFileSync(
+    curlPath,
+    `#!/usr/bin/env bash
+set -euo pipefail
+[[ "\${HTTPS_PROXY:-}" == ${shellQuote(expectedProxy)} ]] || { echo 'HTTPS_PROXY was not forwarded' >&2; exit 90; }
+printf '%s\\n' "$*" >> ${shellQuote(logPath)}
+case "$*" in
+  *${TARBALL}.sha256*)
+    [[ ${checksumExit} -eq 0 ]] || exit ${checksumExit}
+    printf '%s' ${shellQuote(checksum)}
+    ;;
+  *${TARBALL}*) exit ${tarballExit} ;;
+  *) exit 2 ;;
+esac
+`,
+  )
+  chmodSync(curlPath, 0o755)
+  return { curlPath, logPath }
+}
+
+test('resolves the exact Linux Runner release artifacts for a stable version', () => {
+  assert.deepEqual(resolveRunnerReleaseAssets(VERSION), {
+    tarballName: TARBALL,
+    checksumName: `${TARBALL}.sha256`,
+    tarballUrl: `https://github.com/boxlite-ai/boxlite/releases/download/v${VERSION}/${TARBALL}`,
+    checksumUrl: `https://github.com/boxlite-ai/boxlite/releases/download/v${VERSION}/${TARBALL}.sha256`,
+  })
+})
+
+test('uses bounded curl requests so deployment honors the host proxy environment', async (t) => {
+  const expectedProxy = 'http://deployment-proxy.test:8080'
+  const fixture = createFakeCurl(t, { expectedProxy })
+  const assets = await verifyRunnerReleaseAssets(VERSION, {
+    curlPath: fixture.curlPath,
+    environment: { ...process.env, HTTPS_PROXY: expectedProxy },
+    timeoutMs: 1_000,
+  })
+
+  assert.equal(assets.tarballName, TARBALL)
+  const requests = readFileSync(fixture.logPath, 'utf8').trim().split('\n')
+  assert.equal(requests.length, 2)
+  assert.match(requests[0], new RegExp(`--max-time 1 .*${TARBALL}\\.sha256$`))
+  assert.doesNotMatch(requests[0], /--head/)
+  assert.match(requests[1], new RegExp(`--max-time 1 .*--head .*${TARBALL}$`))
+})
+
+test('rejects a missing or mismatched Runner release before deployment', async (t) => {
+  const missing = createFakeCurl(t, { checksumExit: 22 })
+  await assert.rejects(
+    verifyRunnerReleaseAssets(VERSION, { curlPath: missing.curlPath, timeoutMs: 1_000 }),
+    /checksum request failed/i,
+  )
+
+  const mismatched = createFakeCurl(t, { checksum: `${DIGEST}  another-file.tar.gz\n` })
+  await assert.rejects(
+    verifyRunnerReleaseAssets(VERSION, { curlPath: mismatched.curlPath, timeoutMs: 1_000 }),
+    /checksum manifest.*exactly/i,
+  )
+
+  const missingTarball = createFakeCurl(t, { tarballExit: 22 })
+  await assert.rejects(
+    verifyRunnerReleaseAssets(VERSION, { curlPath: missingTarball.curlPath, timeoutMs: 1_000 }),
+    /tarball request failed/i,
+  )
+})

--- a/apps/infra/scripts/runner-release-assets.test.mjs
+++ b/apps/infra/scripts/runner-release-assets.test.mjs
@@ -66,15 +66,15 @@ test('uses bounded curl requests so deployment honors the host proxy environment
   const assets = await verifyRunnerReleaseAssets(VERSION, {
     curlPath: fixture.curlPath,
     environment: { ...process.env, HTTPS_PROXY: expectedProxy },
-    timeoutMs: 1_000,
+    timeoutMs: 5_000,
   })
 
   assert.equal(assets.tarballName, TARBALL)
   const requests = readFileSync(fixture.logPath, 'utf8').trim().split('\n')
   assert.equal(requests.length, 2)
-  assert.match(requests[0], new RegExp(`--max-time 1 .*${TARBALL}\\.sha256$`))
+  assert.match(requests[0], new RegExp(`--max-time 5 .*${TARBALL}\\.sha256$`))
   assert.doesNotMatch(requests[0], /--head/)
-  assert.match(requests[1], new RegExp(`--max-time 1 .*--head .*${TARBALL}$`))
+  assert.match(requests[1], new RegExp(`--max-time [1-5] .*--head .*${TARBALL}$`))
 })
 
 test('rejects a missing or mismatched Runner release before deployment', async (t) => {

--- a/apps/infra/scripts/sst-config-contract.test.mjs
+++ b/apps/infra/scripts/sst-config-contract.test.mjs
@@ -29,6 +29,8 @@ test('pins the AWS provider used by the deployed stack', () => {
 
 test('applies the deployment permissions boundary to every SST-created IAM role', () => {
   assert.match(source, /const runtimePermissionsBoundaryArn =/)
+  assert.match(source, /requireIamPermissionsBoundaryStage\(\$app\.stage\)/)
+  assert.match(environmentExample, /^IAM_PERMISSIONS_BOUNDARY_STAGE=dev$/m)
   assert.match(
     source,
     /\$transform\(aws\.iam\.Role,[\s\S]*args\.permissionsBoundary \?\?= runtimePermissionsBoundaryArn/,

--- a/apps/infra/scripts/sst-config-contract.test.mjs
+++ b/apps/infra/scripts/sst-config-contract.test.mjs
@@ -24,7 +24,15 @@ test('does not force a laptop-managed remote builder', () => {
 })
 
 test('pins the AWS provider used by the deployed stack', () => {
-  assert.match(source, /aws: \{ version: '7\.20\.0', region: REGION,/)
+  assert.match(source, /aws:\s*\{\s*version: '7\.24\.0',\s*region: REGION,/)
+})
+
+test('applies the deployment permissions boundary to every SST-created IAM role', () => {
+  assert.match(source, /const runtimePermissionsBoundaryArn =/)
+  assert.match(
+    source,
+    /\$transform\(aws\.iam\.Role,[\s\S]*args\.permissionsBoundary \?\?= runtimePermissionsBoundaryArn/,
+  )
 })
 
 test('uses the shared AWS region resolver and waits for the critical API service', () => {

--- a/apps/infra/scripts/sst-config-contract.test.mjs
+++ b/apps/infra/scripts/sst-config-contract.test.mjs
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+const source = readFileSync(new URL('../sst.config.ts', import.meta.url), 'utf8')
+const environmentExample = readFileSync(new URL('../.env.example', import.meta.url), 'utf8')
+const readme = readFileSync(new URL('../README.md', import.meta.url), 'utf8')
+
+test('loads local helpers dynamically inside SST config callbacks', () => {
+  assert.doesNotMatch(source, /^import\s/m)
+  assert.match(source, /async app\(input\)/)
+  assert.match(source, /await import\('\.\/scripts\/deployment-environment\.mjs'\)/)
+})
+
+test('does not force a laptop-managed remote builder', () => {
+  const appSource = source.slice(source.indexOf('async app(input)'), source.indexOf('async run()'))
+
+  assert.doesNotMatch(appSource, /buildx-builder/)
+  assert.doesNotMatch(appSource, /BUILDX_BUILDER/)
+  assert.doesNotMatch(environmentExample, /^BUILDX_BUILDER_/m)
+})
+
+test('pins the AWS provider used by the deployed stack', () => {
+  assert.match(source, /aws: \{ version: '7\.20\.0', region: REGION,/)
+})
+
+test('uses the shared AWS region resolver and waits for the critical API service', () => {
+  assert.match(
+    source,
+    /const \{[^}]*resolveAwsRegion[^}]*\} = await import\('\.\/scripts\/deployment-environment\.mjs'\)/,
+  )
+  assert.match(source, /const REGION = resolveAwsRegion\(\)/)
+
+  const apiService = source.slice(
+    source.indexOf("const api = new sst.aws.Service('Api'"),
+    source.indexOf('// Assumed by the Api task role'),
+  )
+  assert.match(apiService, /wait: true,/)
+})
+
+test('uses the canonical deployment config for every Proxy-facing SST value', () => {
+  const runSource = source.slice(source.indexOf('async run()'), source.indexOf('// ── runner bootstrap'))
+
+  assert.match(runSource, /resolvePublicDeploymentConfig/)
+  assert.match(runSource, /const deploymentConfig = resolvePublicDeploymentConfig\(process\.env, workspaceVersion\)/)
+  assert.match(runSource, /const \{ stackDomain, proxyDomain, proxyProtocol, proxyTemplateUrl, releaseVersion \}/)
+  assert.doesNotMatch(runSource, /envOr\('PROXY_(?:DOMAIN|PROTOCOL|TEMPLATE_URL)'/)
+})
+
+test('keeps the AWS region in run scope and passes it into Runner user data', () => {
+  const runSource = source.slice(source.indexOf('async run()'), source.indexOf('// ── runner bootstrap'))
+  const runnerUserDataSource = source.slice(source.indexOf('async function buildRunnerUserData'))
+
+  assert.match(runSource, /const REGION = resolveAwsRegion\(\)/)
+  assert.equal(runSource.match(/awsRegion: REGION/g)?.length, 2)
+  assert.match(runnerUserDataSource, /awsRegion: string/)
+  assert.match(runnerUserDataSource, /Environment=AWS_REGION=\$\{input\.awsRegion\}/)
+})
+
+test('tags Runner instances with their exact control-plane identity', () => {
+  const runnerResources = source.slice(
+    source.indexOf('const makeRunner ='),
+    source.indexOf('// Register the extra runners'),
+  )
+
+  assert.match(runnerResources, /'boxlite:control-plane-runner-name': controlPlaneRunnerName/)
+  assert.match(runnerResources, /makeRunner\('Runner', 'boxlite-runner-default', defaultRunnerName, runnerUserData\)/)
+  assert.match(runnerResources, /`boxlite-runner-\$\{index\}`,[\s\S]*name,[\s\S]*buildRunnerUserData/)
+})
+
+test('passes both the internal and public OIDC issuers to Proxy', () => {
+  const proxyService = source.slice(source.indexOf("new sst.aws.Service('Proxy'"), source.indexOf('// ─── 8.'))
+
+  assert.match(proxyService, /OIDC_DOMAIN: oidcIssuer,/)
+  assert.match(proxyService, /publicOidcIssuer[\s\S]*OIDC_PUBLIC_DOMAIN: publicOidcIssuer/)
+})
+
+test('requires the OIDC client ID through the SST secret store', () => {
+  assert.match(source, /new sst\.Secret\('OIDC_CLIENT_ID'\)/)
+  assert.doesNotMatch(source, /new sst\.Secret\('OIDC_CLIENT_ID',/)
+  assert.doesNotMatch(environmentExample, /^OIDC_CLIENT_ID=/m)
+
+  const quickStart = readme.slice(readme.indexOf('## Quick start'), readme.indexOf('## Secrets & credentials'))
+  assert.match(quickStart, /npm run sst -- secret set OIDC_CLIENT_ID/)
+  assert.doesNotMatch(quickStart, /App secrets .* are optional/)
+})
+
+test('does not restore the removed SSH gateway deployment', () => {
+  assert.doesNotMatch(source, /SshGateway|SSH_GATEWAY|SSH_PRIVATE_KEY_B64|SSH_HOST_KEY_B64/)
+  assert.doesNotMatch(environmentExample, /SSH_GATEWAY|SSH_PRIVATE_KEY_B64|SSH_HOST_KEY_B64/)
+  assert.doesNotMatch(readme, /SshGateway|SSH_GATEWAY|SSH_PRIVATE_KEY_B64|SSH_HOST_KEY_B64/)
+})
+
+test('passes explicit management API endpoints into the API service', () => {
+  const apiService = source.slice(
+    source.indexOf("const api = new sst.aws.Service('Api'"),
+    source.indexOf('// Assumed by the Api task role'),
+  )
+
+  assert.match(apiService, /OIDC_MANAGEMENT_API_BASE_URL: process\.env\.OIDC_MANAGEMENT_API_BASE_URL/)
+  assert.match(apiService, /OIDC_MANAGEMENT_API_TOKEN_URL: process\.env\.OIDC_MANAGEMENT_API_TOKEN_URL/)
+})
+
+test('reports the canonical workspace release unless VERSION overrides it', () => {
+  assert.match(source, /const workspaceVersion = readWorkspaceVersion\(\)/)
+  assert.match(source, /resolvePublicDeploymentConfig\(process\.env, workspaceVersion\)/)
+  assert.match(source, /proxyTemplateUrl, releaseVersion \} = deploymentConfig/)
+
+  const apiService = source.slice(
+    source.indexOf("const api = new sst.aws.Service('Api'"),
+    source.indexOf('// Assumed by the Api task role'),
+  )
+  assert.match(apiService, /VERSION: releaseVersion,/)
+})
+
+test('Runner bootstrap fails closed when the release checksum is unavailable', () => {
+  const runnerBootstrap = source.slice(source.indexOf('async function buildRunnerUserData'))
+
+  assert.doesNotMatch(runnerBootstrap, /if curl -fsSL .*\.sha256/)
+  assert.match(runnerBootstrap, /curl -fsSL .*\.sha256.*-o \/tmp\/runner\.sha256/)
+  assert.match(runnerBootstrap, /runner checksum mismatch/)
+})

--- a/apps/infra/scripts/sst-event-log-security.mjs
+++ b/apps/infra/scripts/sst-event-log-security.mjs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+import { readdir, unlink } from 'node:fs/promises'
+import { join } from 'node:path'
+
+const PULUMI_EVENT_LOG_NAME = 'eventlog.json'
+
+/**
+ * Remove only Pulumi's transient Automation API event stream files.
+ *
+ * SST state, checkpoints, and other diagnostics are deliberately retained.
+ * Directory symlinks are not followed, so cleanup cannot escape the caller's
+ * fixed `.sst/pulumi` root.
+ */
+export async function removePulumiEventLogs(pulumiRoot) {
+  let removedCount = 0
+
+  async function visit(directory) {
+    let entries
+    try {
+      entries = await readdir(directory, { withFileTypes: true })
+    } catch (error) {
+      if (error.code === 'ENOENT') return
+      throw new Error('Unable to inspect Pulumi event logs; refusing to run SST', { cause: error })
+    }
+
+    for (const entry of entries) {
+      const entryPath = join(directory, entry.name)
+      if (entry.isDirectory()) {
+        await visit(entryPath)
+        continue
+      }
+      if (entry.name !== PULUMI_EVENT_LOG_NAME) continue
+
+      try {
+        await unlink(entryPath)
+        removedCount += 1
+      } catch (error) {
+        if (error.code === 'ENOENT') continue
+        throw new Error('Unable to remove a Pulumi event log; refusing to persist provider credentials', {
+          cause: error,
+        })
+      }
+    }
+  }
+
+  await visit(pulumiRoot)
+  return removedCount
+}
+
+/**
+ * Clear stale event streams before invoking SST, then clean again regardless
+ * of command success. Cleanup errors intentionally fail closed.
+ */
+export async function withPulumiEventLogCleanup(pulumiRoot, runSstCommand) {
+  await removePulumiEventLogs(pulumiRoot)
+  try {
+    return await runSstCommand()
+  } finally {
+    await removePulumiEventLogs(pulumiRoot)
+  }
+}

--- a/apps/infra/scripts/sst-event-log-security.test.mjs
+++ b/apps/infra/scripts/sst-event-log-security.test.mjs
@@ -157,7 +157,7 @@ setInterval(() => {}, 1_000)
       try {
         process.kill(childPid, 'SIGKILL')
       } catch (error) {
-        if (error.code !== 'ESRCH') throw error
+        if (error.code !== 'ESRCH') console.warn(`failed to reap the synthetic SST child: ${error.message}`)
       }
     }
     await rm(dirname(eventLog), { recursive: true, force: true })

--- a/apps/infra/scripts/sst-event-log-security.test.mjs
+++ b/apps/infra/scripts/sst-event-log-security.test.mjs
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+import assert from 'node:assert/strict'
+import { spawn } from 'node:child_process'
+import { chmod, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import test from 'node:test'
+import { setTimeout as delay } from 'node:timers/promises'
+
+import { removePulumiEventLogs, withPulumiEventLogCleanup } from './sst-event-log-security.mjs'
+
+const SYNTHETIC_PROVIDER_TOKEN = 'synthetic-provider-token-for-regression-only'
+
+async function fixtureRoot() {
+  return mkdtemp(join(tmpdir(), 'boxlite-sst-event-log-security-'))
+}
+
+async function writeFixture(root, relativePath, content) {
+  const filePath = join(root, relativePath)
+  await mkdir(join(filePath, '..'), { recursive: true })
+  await writeFile(filePath, content, 'utf8')
+  return filePath
+}
+
+async function fileExists(filePath) {
+  try {
+    await readFile(filePath)
+    return true
+  } catch (error) {
+    if (error.code === 'ENOENT') return false
+    throw error
+  }
+}
+
+async function waitFor(predicate, description, timeoutMs = 5_000) {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (await predicate()) return
+    await delay(10)
+  }
+  throw new Error(`Timed out waiting for ${description}`)
+}
+
+function waitForExit(child, timeoutMs = 5_000) {
+  return Promise.race([
+    new Promise((resolve, reject) => {
+      child.once('error', reject)
+      child.once('exit', (code, signal) => resolve({ code, signal }))
+    }),
+    delay(timeoutMs).then(() => {
+      throw new Error('Timed out waiting for the SST wrapper to exit')
+    }),
+  ])
+}
+
+test('removes nested Pulumi event logs without reading or deleting non-secret diagnostics', async () => {
+  const root = await fixtureRoot()
+  const eventLog = await writeFixture(
+    root,
+    'stage/update/eventlog.json',
+    JSON.stringify({ provider: { apiToken: SYNTHETIC_PROVIDER_TOKEN } }),
+  )
+  const diagnostics = await writeFixture(root, 'stage/update/diagnostics.json', '{"status":"failed"}')
+  const state = await writeFixture(root, 'stage/checkpoint/state.json', '{"resources":[]}')
+
+  const removedCount = await removePulumiEventLogs(root)
+
+  assert.equal(removedCount, 1)
+  assert.equal(await fileExists(eventLog), false)
+  assert.equal(await readFile(diagnostics, 'utf8'), '{"status":"failed"}')
+  assert.equal(await readFile(state, 'utf8'), '{"resources":[]}')
+})
+
+test('cleans stale logs before a command and newly written logs after it succeeds', async () => {
+  const root = await fixtureRoot()
+  const staleLog = await writeFixture(root, 'old/eventlog.json', SYNTHETIC_PROVIDER_TOKEN)
+  const generatedLog = join(root, 'new', 'eventlog.json')
+
+  const result = await withPulumiEventLogCleanup(root, async () => {
+    assert.equal(await fileExists(staleLog), false)
+    await writeFixture(root, 'new/eventlog.json', SYNTHETIC_PROVIDER_TOKEN)
+    return 23
+  })
+
+  assert.equal(result, 23)
+  assert.equal(await fileExists(generatedLog), false)
+})
+
+test('cleans a generated event log when the wrapped command fails', async () => {
+  const root = await fixtureRoot()
+  const generatedLog = join(root, 'failed', 'eventlog.json')
+
+  await assert.rejects(
+    withPulumiEventLogCleanup(root, async () => {
+      await writeFixture(root, 'failed/eventlog.json', SYNTHETIC_PROVIDER_TOKEN)
+      throw new Error('synthetic command failure')
+    }),
+    /synthetic command failure/,
+  )
+
+  assert.equal(await fileExists(generatedLog), false)
+})
+
+test('cleans a generated event log before exiting after SIGTERM', async () => {
+  const fixture = await fixtureRoot()
+  const fakeBin = join(fixture, 'bin')
+  const fakeSst = join(fakeBin, 'sst')
+  const pulumiRoot = new URL('../.sst/pulumi/', import.meta.url)
+  const eventLog = join(pulumiRoot.pathname, `signal-test-${process.pid}-${Date.now()}`, 'eventlog.json')
+  const childPidFile = join(fixture, 'sst-child.pid')
+  let childPid
+
+  await mkdir(fakeBin, { recursive: true })
+  await writeFile(
+    fakeSst,
+    `#!/usr/bin/env node
+const { mkdirSync, writeFileSync } = require('node:fs')
+const { dirname } = require('node:path')
+mkdirSync(dirname(process.env.SYNTHETIC_EVENT_LOG_PATH), { recursive: true })
+writeFileSync(process.env.SYNTHETIC_SST_PID_PATH, String(process.pid))
+writeFileSync(process.env.SYNTHETIC_EVENT_LOG_PATH, 'synthetic-provider-token-for-regression-only')
+process.on('SIGINT', () => process.exit(0))
+process.on('SIGTERM', () => process.exit(0))
+setInterval(() => {}, 1_000)
+`,
+    'utf8',
+  )
+  await chmod(fakeSst, 0o755)
+
+  const wrapper = spawn(process.execPath, ['scripts/sst-with-cloudflare.mjs', 'synthetic-test', '--stage', 'ci'], {
+    cwd: new URL('..', import.meta.url),
+    env: {
+      ...process.env,
+      PATH: `${fakeBin}:${process.env.PATH}`,
+      CLOUDFLARE_API_TOKEN: 'synthetic-cloudflare-token',
+      CLOUDFLARE_DEFAULT_ACCOUNT_ID: 'synthetic-cloudflare-account',
+      SYNTHETIC_EVENT_LOG_PATH: eventLog,
+      SYNTHETIC_SST_PID_PATH: childPidFile,
+    },
+    stdio: 'ignore',
+  })
+
+  try {
+    await waitFor(() => fileExists(eventLog), 'the synthetic SST event log')
+    childPid = Number.parseInt(await readFile(childPidFile, 'utf8'), 10)
+    const wrapperExit = waitForExit(wrapper)
+    wrapper.kill('SIGTERM')
+    const result = await wrapperExit
+
+    assert.equal(await fileExists(eventLog), false, 'SIGTERM must not leave the Pulumi event log behind')
+    assert.deepEqual(result, { code: 143, signal: null })
+  } finally {
+    if (wrapper.exitCode === null && wrapper.signalCode === null) wrapper.kill('SIGKILL')
+    if (Number.isSafeInteger(childPid)) {
+      try {
+        process.kill(childPid, 'SIGKILL')
+      } catch (error) {
+        if (error.code !== 'ESRCH') throw error
+      }
+    }
+    await rm(dirname(eventLog), { recursive: true, force: true })
+    await rm(fixture, { recursive: true, force: true })
+  }
+})
+
+test('the Cloudflare wrapper cleans immediately after SST before post-deploy verification', async () => {
+  const wrapperSource = await readFile(new URL('./sst-with-cloudflare.mjs', import.meta.url), 'utf8')
+  const cleanupCall = 'withPulumiEventLogCleanup(PULUMI_EVENT_LOG_ROOT, runSstCommand)'
+  const cleanupIndex = wrapperSource.indexOf(cleanupCall)
+  const proxyVerificationIndex = wrapperSource.indexOf('await verifyProxyDeploymentWithRetry(')
+  const publicVerificationIndex = wrapperSource.indexOf('await verifyPublicDeploymentWithRetry(')
+
+  assert.match(
+    wrapperSource,
+    /import \{ removePulumiEventLogs, withPulumiEventLogCleanup \} from '\.\/sst-event-log-security\.mjs'/,
+  )
+  assert.match(wrapperSource, /async function runSstCommand\(\)[\s\S]*spawn\('sst', sstArgs/)
+  assert.match(wrapperSource, /process\.on\(signal,[\s\S]*signalActiveSstChild\(signal\)/)
+  assert.notEqual(cleanupIndex, -1)
+  assert.ok(cleanupIndex < proxyVerificationIndex)
+  assert.ok(cleanupIndex < publicVerificationIndex)
+})
+
+test('package scripts do not bypass the cleanup wrapper for SST commands', async () => {
+  const packageJson = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8'))
+
+  for (const [name, command] of Object.entries(packageJson.scripts)) {
+    if (!command.includes('sst')) continue
+    assert.match(command, /scripts\/sst-with-cloudflare\.mjs/, `${name} bypasses the SST cleanup wrapper`)
+  }
+})
+
+test('the infrastructure config check does not invoke SST outside the cleanup wrapper', async () => {
+  const makeTargets = await readFile(new URL('../../../make/test.mk', import.meta.url), 'utf8')
+
+  assert.doesNotMatch(makeTargets, /npm exec -- sst/)
+  assert.match(makeTargets, /npm run sst -- install --stage ci/)
+})

--- a/apps/infra/scripts/sst-event-log-security.test.mjs
+++ b/apps/infra/scripts/sst-event-log-security.test.mjs
@@ -196,5 +196,5 @@ test('the infrastructure config check does not invoke SST outside the cleanup wr
   const makeTargets = await readFile(new URL('../../../make/test.mk', import.meta.url), 'utf8')
 
   assert.doesNotMatch(makeTargets, /npm exec -- sst/)
-  assert.match(makeTargets, /npm run sst -- install --stage ci/)
+  assert.match(makeTargets, /IAM_PERMISSIONS_BOUNDARY_STAGE=ci npm run sst -- install --stage ci/)
 })

--- a/apps/infra/scripts/sst-stage.mjs
+++ b/apps/infra/scripts/sst-stage.mjs
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+const SST_STAGE_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]*$/
+
+function validateSstStage(stage) {
+  if (!SST_STAGE_PATTERN.test(stage)) {
+    throw new Error(`invalid SST stage '${stage}' (expected letters, numbers, underscores, or hyphens)`)
+  }
+  return stage
+}
+
+export function resolveSstStage(args, environment = process.env) {
+  let configuredStage
+
+  for (let index = 0; index < args.length; index++) {
+    if (args[index] === '--stage') {
+      const stage = args[index + 1]
+      if (!stage || stage.startsWith('-')) throw new Error('--stage requires a value')
+      if (configuredStage !== undefined) throw new Error('--stage may be specified only once')
+      configuredStage = stage
+      index += 1
+      continue
+    }
+
+    const inlineStage = args[index].match(/^--stage=(.*)$/)?.[1]
+    if (inlineStage !== undefined) {
+      if (!inlineStage) throw new Error('--stage requires a value')
+      if (configuredStage !== undefined) throw new Error('--stage may be specified only once')
+      configuredStage = inlineStage
+    }
+  }
+
+  if (configuredStage !== undefined) return validateSstStage(configuredStage)
+  if (environment.SST_STAGE !== undefined && environment.SST_STAGE !== '') {
+    return validateSstStage(environment.SST_STAGE)
+  }
+  if (args[0] === 'deploy' || args[0] === 'remove') {
+    throw new Error(`${args[0]} requires an explicit --stage or SST_STAGE`)
+  }
+  return 'dev'
+}
+
+export function isSstComponentExcluded(args, component) {
+  for (let index = 0; index < args.length; index += 1) {
+    if (args[index] === '--exclude') {
+      if (args[index + 1] === component) return true
+      index += 1
+      continue
+    }
+
+    if (args[index] === `--exclude=${component}`) return true
+  }
+  return false
+}

--- a/apps/infra/scripts/sst-stage.mjs
+++ b/apps/infra/scripts/sst-stage.mjs
@@ -53,3 +53,17 @@ export function isSstComponentExcluded(args, component) {
   }
   return false
 }
+
+export function requireIamPermissionsBoundaryStage(stage, environment = process.env) {
+  const selectedStage = validateSstStage(stage)
+  const configuredStage = environment.IAM_PERMISSIONS_BOUNDARY_STAGE
+  if (!configuredStage) {
+    throw new Error('IAM_PERMISSIONS_BOUNDARY_STAGE is required to identify the provisioned runtime boundary')
+  }
+
+  const boundaryStage = validateSstStage(configuredStage)
+  if (boundaryStage !== selectedStage) {
+    throw new Error(`IAM permissions boundary stage ${boundaryStage} does not match SST stage ${selectedStage}`)
+  }
+  return boundaryStage
+}

--- a/apps/infra/scripts/sst-stage.test.mjs
+++ b/apps/infra/scripts/sst-stage.test.mjs
@@ -4,7 +4,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { isSstComponentExcluded, resolveSstStage } from './sst-stage.mjs'
+import { isSstComponentExcluded, requireIamPermissionsBoundaryStage, resolveSstStage } from './sst-stage.mjs'
 
 test('resolves a stage from separate and inline CLI arguments', () => {
   assert.equal(resolveSstStage(['deploy', '--stage', 'dev'], {}), 'dev')
@@ -49,4 +49,13 @@ test('recognizes only an explicitly excluded SST component', () => {
   assert.equal(isSstComponentExcluded(['deploy', '--exclude=Runner'], 'Runner'), true)
   assert.equal(isSstComponentExcluded(['deploy', '--exclude', 'Runner-runner-2'], 'Runner'), false)
   assert.equal(isSstComponentExcluded(['deploy', '--target', 'Runner'], 'Runner'), false)
+})
+
+test('requires the provisioned IAM boundary stage to match the SST stage', () => {
+  assert.equal(requireIamPermissionsBoundaryStage('dev', { IAM_PERMISSIONS_BOUNDARY_STAGE: 'dev' }), 'dev')
+  assert.throws(
+    () => requireIamPermissionsBoundaryStage('production', { IAM_PERMISSIONS_BOUNDARY_STAGE: 'dev' }),
+    /IAM permissions boundary stage dev does not match SST stage production/,
+  )
+  assert.throws(() => requireIamPermissionsBoundaryStage('dev', {}), /IAM_PERMISSIONS_BOUNDARY_STAGE is required/)
 })

--- a/apps/infra/scripts/sst-stage.test.mjs
+++ b/apps/infra/scripts/sst-stage.test.mjs
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { isSstComponentExcluded, resolveSstStage } from './sst-stage.mjs'
+
+test('resolves a stage from separate and inline CLI arguments', () => {
+  assert.equal(resolveSstStage(['deploy', '--stage', 'dev'], {}), 'dev')
+  assert.equal(resolveSstStage(['deploy', '--stage=production'], {}), 'production')
+})
+
+test('resolves an explicitly configured SST_STAGE', () => {
+  assert.equal(resolveSstStage(['deploy'], { SST_STAGE: 'staging' }), 'staging')
+})
+
+test('rejects duplicate stage options instead of guessing which one SST will use', () => {
+  assert.throws(
+    () => resolveSstStage(['deploy', '--stage', 'dev', '--stage=production'], {}),
+    /--stage may be specified only once/,
+  )
+})
+
+test('rejects unsafe CLI and environment stage values', () => {
+  for (const stage of ['dev/production', ' dev', 'dev ', '--production', '']) {
+    if (stage === '') {
+      assert.throws(() => resolveSstStage(['deploy', '--stage='], {}), /--stage requires a value/)
+      continue
+    }
+    assert.throws(() => resolveSstStage(['deploy', `--stage=${stage}`], {}), /invalid SST stage/)
+  }
+
+  assert.throws(() => resolveSstStage(['deploy'], { SST_STAGE: 'dev/production' }), /invalid SST stage/)
+  assert.equal(resolveSstStage(['deploy', '--stage', 'feature_42-test'], {}), 'feature_42-test')
+})
+
+test('requires an explicit stage for state-changing stack commands', () => {
+  assert.throws(() => resolveSstStage(['deploy'], {}), /deploy requires an explicit --stage or SST_STAGE/)
+  assert.throws(() => resolveSstStage(['remove'], {}), /remove requires an explicit --stage or SST_STAGE/)
+})
+
+test('retains the dev credential lookup default for non-deploy commands', () => {
+  assert.equal(resolveSstStage(['diff'], {}), 'dev')
+})
+
+test('recognizes only an explicitly excluded SST component', () => {
+  assert.equal(isSstComponentExcluded(['deploy', '--exclude', 'Runner'], 'Runner'), true)
+  assert.equal(isSstComponentExcluded(['deploy', '--exclude=Runner'], 'Runner'), true)
+  assert.equal(isSstComponentExcluded(['deploy', '--exclude', 'Runner-runner-2'], 'Runner'), false)
+  assert.equal(isSstComponentExcluded(['deploy', '--target', 'Runner'], 'Runner'), false)
+})

--- a/apps/infra/scripts/sst-with-cloudflare.mjs
+++ b/apps/infra/scripts/sst-with-cloudflare.mjs
@@ -13,6 +13,8 @@
  * Wired into the dev/deploy/remove npm scripts, plus a passthrough:
  *   npm run deploy -- --stage dev      → node sst-with-cloudflare.mjs deploy --stage dev
  *   npm run sst -- diff --stage dev     → any other subcommand
+ * A successful deploy is followed by a read-only AWS check that the Proxy NLB
+ * listener, ECS target-group attachment, and healthy targets agree.
  *
  * One access gate: a deployer already needs AWS credentials to deploy, so the
  * same credentials fetch the Cloudflare token from SSM — nothing extra to share.
@@ -29,9 +31,74 @@
  * error for one that does.
  */
 
-import { execFileSync, spawnSync } from 'node:child_process'
+import { execFileSync, spawn } from 'node:child_process'
+import { constants as osConstants } from 'node:os'
+import { fileURLToPath } from 'node:url'
 
-const REGION = process.env.AWS_REGION || 'ap-southeast-1'
+import {
+  loadDeploymentEnvironment,
+  readWorkspaceVersion,
+  resolveAwsRegion,
+  resolvePublicDeploymentConfig,
+} from './deployment-environment.mjs'
+import {
+  resolveAwsCliPath,
+  verifyProxyDeploymentWithRetry,
+  verifyPublicDeploymentWithRetry,
+} from './proxy-deployment-verify.mjs'
+import { verifyRunnerReleaseAssets } from './runner-release-assets.mjs'
+import { isSstComponentExcluded, resolveSstStage } from './sst-stage.mjs'
+import { removePulumiEventLogs, withPulumiEventLogCleanup } from './sst-event-log-security.mjs'
+
+const APP = 'boxlite'
+const PULUMI_EVENT_LOG_ROOT = fileURLToPath(new URL('../.sst/pulumi', import.meta.url))
+const CHILD_TERMINATION_GRACE_MS = 10_000
+const TERMINATION_SIGNALS = ['SIGINT', 'SIGTERM']
+
+let activeSstChild
+let childTerminationTimer
+let terminationSignal
+
+function signalExitCode(signal) {
+  return 128 + (osConstants.signals[signal] ?? 0)
+}
+
+function signalActiveSstChild(signal) {
+  if (!activeSstChild || activeSstChild.exitCode !== null || activeSstChild.signalCode !== null) return
+  activeSstChild.kill(signal)
+  if (childTerminationTimer) return
+
+  childTerminationTimer = setTimeout(() => {
+    if (activeSstChild && activeSstChild.exitCode === null && activeSstChild.signalCode === null) {
+      activeSstChild.kill('SIGKILL')
+    }
+  }, CHILD_TERMINATION_GRACE_MS)
+  childTerminationTimer.unref()
+}
+
+for (const signal of TERMINATION_SIGNALS) {
+  process.on(signal, () => {
+    if (terminationSignal) {
+      signalActiveSstChild('SIGKILL')
+      return
+    }
+    terminationSignal = signal
+    signalActiveSstChild(signal)
+  })
+}
+
+// Delete stale streams before any blocking credential lookup. Signal handlers
+// are already installed, so later cleanup cannot be bypassed by SIGINT/SIGTERM.
+try {
+  await removePulumiEventLogs(PULUMI_EVENT_LOG_ROOT)
+} catch (error) {
+  console.error(`sst-with-cloudflare: secure event-log cleanup failed: ${error.message}`)
+  process.exit(1)
+}
+
+loadDeploymentEnvironment()
+
+const REGION = resolveAwsRegion()
 
 // SSM param consulted only when the matching env var is unset.
 const CREDS = [
@@ -45,23 +112,25 @@ if (sstArgs.length === 0) {
   process.exit(1)
 }
 
-// Resolve the stage from the sst args (--stage x or --stage=x); the SSM path is
-// per-stage. Falls back to SST_STAGE then "dev".
-function resolveStage(args) {
-  for (let i = 0; i < args.length; i++) {
-    if (args[i] === '--stage' && args[i + 1]) return args[i + 1]
-    const m = args[i].match(/^--stage=(.+)$/)
-    if (m) return m[1]
-  }
-  return process.env.SST_STAGE || 'dev'
-}
-
 function fetchFromSsm(name) {
   try {
+    const awsCliPath = resolveAwsCliPath()
     const out = execFileSync(
-      'aws',
-      ['ssm', 'get-parameter', '--region', REGION, '--name', name, '--with-decryption', '--query', 'Parameter.Value', '--output', 'text'],
-      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
+      awsCliPath,
+      [
+        'ssm',
+        'get-parameter',
+        '--region',
+        REGION,
+        '--name',
+        name,
+        '--with-decryption',
+        '--query',
+        'Parameter.Value',
+        '--output',
+        'text',
+      ],
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 15_000, killSignal: 'SIGTERM' },
     ).trim()
     return out && out !== 'None' ? out : null
   } catch (err) {
@@ -70,7 +139,13 @@ function fetchFromSsm(name) {
   }
 }
 
-const stage = resolveStage(sstArgs)
+let stage
+try {
+  stage = resolveSstStage(sstArgs)
+} catch (error) {
+  console.error(`sst-with-cloudflare: ${error.message}`)
+  process.exit(1)
+}
 
 for (const { env, param } of CREDS) {
   if (process.env[env]) continue // already provided — don't touch
@@ -86,10 +161,102 @@ for (const { env, param } of CREDS) {
   }
 }
 
-// node_modules/.bin is on PATH because this runs via `npm run`, so `sst` resolves.
-const result = spawnSync('sst', sstArgs, { stdio: 'inherit', env: process.env })
-if (result.error) {
-  console.error(`sst-with-cloudflare: failed to launch sst: ${result.error.message}`)
-  process.exit(1)
+async function runSstCommand() {
+  if (terminationSignal) return signalExitCode(terminationSignal)
+
+  // node_modules/.bin is on PATH because this runs via `npm run`, so `sst` resolves.
+  return new Promise((resolve) => {
+    let isSettled = false
+    const settle = (exitCode) => {
+      if (isSettled) return
+      isSettled = true
+      activeSstChild = undefined
+      if (childTerminationTimer) clearTimeout(childTerminationTimer)
+      childTerminationTimer = undefined
+      resolve(terminationSignal ? signalExitCode(terminationSignal) : exitCode)
+    }
+
+    activeSstChild = spawn('sst', sstArgs, { stdio: 'inherit', env: process.env })
+    activeSstChild.once('error', (error) => {
+      console.error(`sst-with-cloudflare: failed to launch sst: ${error.message}`)
+      settle(1)
+    })
+    activeSstChild.once('exit', (code, signal) => {
+      settle(code ?? (signal ? signalExitCode(signal) : 1))
+    })
+
+    // A signal may arrive after the early check but before spawn returns.
+    if (terminationSignal) signalActiveSstChild(terminationSignal)
+  })
 }
-process.exit(result.status ?? 1)
+
+let publicDeploymentConfig
+if (sstArgs[0] === 'deploy') {
+  try {
+    resolveAwsCliPath()
+    const workspaceVersion = readWorkspaceVersion()
+    publicDeploymentConfig = resolvePublicDeploymentConfig(process.env, workspaceVersion)
+    if (isSstComponentExcluded(sstArgs, 'Runner')) {
+      console.warn(
+        `sst-with-cloudflare: Runner excluded; skipping the v${workspaceVersion} release-asset preflight. ` +
+          'Runner metadata and new Runner-only capabilities will remain unavailable until a later full rollout.',
+      )
+    } else {
+      await verifyRunnerReleaseAssets(workspaceVersion)
+      console.log(`sst-with-cloudflare: Runner release assets verified (v${workspaceVersion}, linux-amd64)`)
+    }
+  } catch (error) {
+    console.error(`sst-with-cloudflare: deployment preflight failed: ${error.message}`)
+    process.exit(1)
+  }
+}
+
+let exitCode
+try {
+  exitCode = await withPulumiEventLogCleanup(PULUMI_EVENT_LOG_ROOT, runSstCommand)
+} catch (error) {
+  console.error(`sst-with-cloudflare: secure event-log cleanup failed: ${error.message}`)
+  exitCode = 1
+}
+
+if (exitCode === 0 && !terminationSignal && sstArgs[0] === 'deploy') {
+  try {
+    const verification = await verifyProxyDeploymentWithRetry(
+      { app: APP, stage, region: REGION },
+      {
+        onRetry({ error, nextAttempt, attempts, delayMs }) {
+          console.warn(
+            `sst-with-cloudflare: Proxy routing is not ready (${error.message}); ` +
+              `retrying ${nextAttempt}/${attempts} in ${delayMs / 1_000}s`,
+          )
+        },
+      },
+    )
+    console.log(
+      `sst-with-cloudflare: Proxy routing verified ` +
+        `(${verification.healthyTargetCount}/${verification.desiredCount} healthy, ` +
+        `listener → ${verification.targetGroupArn})`,
+    )
+
+    const publicVerification = await verifyPublicDeploymentWithRetry(publicDeploymentConfig, {
+      onRetry({ error, nextAttempt, attempts, delayMs }) {
+        console.warn(
+          `sst-with-cloudflare: public deployment is not ready (${error.message}); ` +
+            `retrying ${nextAttempt}/${attempts} in ${delayMs / 1_000}s`,
+        )
+      },
+    })
+    console.log(
+      `sst-with-cloudflare: public deployment verified ` +
+        `(Proxy ${publicVerification.proxyHealthUrl}, wildcard ${publicVerification.proxyWildcardHealthUrl}, ` +
+        `API ${publicVerification.apiConfigUrl}, ` +
+        `version ${publicVerification.version}, issuer ${publicVerification.oidcIssuer})`,
+    )
+  } catch (error) {
+    console.error(`sst-with-cloudflare: SST deploy completed, but deployment verification failed: ${error.message}`)
+    exitCode = 1
+  }
+}
+
+if (terminationSignal) exitCode = signalExitCode(terminationSignal)
+process.exit(exitCode)

--- a/apps/infra/scripts/sst-with-cloudflare.mjs
+++ b/apps/infra/scripts/sst-with-cloudflare.mjs
@@ -58,6 +58,7 @@ const TERMINATION_SIGNALS = ['SIGINT', 'SIGTERM']
 let activeSstChild
 let childTerminationTimer
 let terminationSignal
+let deploymentVerificationAbortController
 
 function signalExitCode(signal) {
   return 128 + (osConstants.signals[signal] ?? 0)
@@ -83,6 +84,7 @@ for (const signal of TERMINATION_SIGNALS) {
       return
     }
     terminationSignal = signal
+    deploymentVerificationAbortController?.abort(new Error(`Deployment verification interrupted by ${signal}`))
     signalActiveSstChild(signal)
   })
 }
@@ -203,7 +205,7 @@ if (sstArgs[0] === 'deploy') {
       )
     } else {
       await verifyRunnerReleaseAssets(workspaceVersion)
-      console.log(`sst-with-cloudflare: Runner release assets verified (v${workspaceVersion}, linux-amd64)`)
+      console.log(`sst-with-cloudflare: Runner release asset availability verified (v${workspaceVersion}, linux-amd64)`)
     }
   } catch (error) {
     console.error(`sst-with-cloudflare: deployment preflight failed: ${error.message}`)
@@ -220,10 +222,12 @@ try {
 }
 
 if (exitCode === 0 && !terminationSignal && sstArgs[0] === 'deploy') {
+  deploymentVerificationAbortController = new AbortController()
   try {
     const verification = await verifyProxyDeploymentWithRetry(
       { app: APP, stage, region: REGION },
       {
+        signal: deploymentVerificationAbortController.signal,
         onRetry({ error, nextAttempt, attempts, delayMs }) {
           console.warn(
             `sst-with-cloudflare: Proxy routing is not ready (${error.message}); ` +
@@ -239,6 +243,7 @@ if (exitCode === 0 && !terminationSignal && sstArgs[0] === 'deploy') {
     )
 
     const publicVerification = await verifyPublicDeploymentWithRetry(publicDeploymentConfig, {
+      signal: deploymentVerificationAbortController.signal,
       onRetry({ error, nextAttempt, attempts, delayMs }) {
         console.warn(
           `sst-with-cloudflare: public deployment is not ready (${error.message}); ` +
@@ -253,8 +258,12 @@ if (exitCode === 0 && !terminationSignal && sstArgs[0] === 'deploy') {
         `version ${publicVerification.version}, issuer ${publicVerification.oidcIssuer})`,
     )
   } catch (error) {
-    console.error(`sst-with-cloudflare: SST deploy completed, but deployment verification failed: ${error.message}`)
+    if (!terminationSignal) {
+      console.error(`sst-with-cloudflare: SST deploy completed, but deployment verification failed: ${error.message}`)
+    }
     exitCode = 1
+  } finally {
+    deploymentVerificationAbortController = undefined
   }
 }
 

--- a/apps/infra/sst.config.ts
+++ b/apps/infra/sst.config.ts
@@ -108,6 +108,7 @@ export default $config({
     const { readWorkspaceVersion, resolveAwsRegion, resolvePublicDeploymentConfig } =
       await import('./scripts/deployment-environment.mjs')
     const { optionalPublicOidcIssuer, requireOidcIssuer } = await import('./scripts/oidc-issuer.mjs')
+    const { requireIamPermissionsBoundaryStage } = await import('./scripts/sst-stage.mjs')
     const REGION = resolveAwsRegion()
     const workspaceVersion = readWorkspaceVersion()
     const deploymentConfig = resolvePublicDeploymentConfig(process.env, workspaceVersion)
@@ -118,6 +119,7 @@ export default $config({
     // Every role created by this stack must stay inside the boundary provisioned
     // with the GitHub deployment role. The raw-resource transform also covers IAM
     // roles created internally by SST components, not only the roles declared here.
+    requireIamPermissionsBoundaryStage($app.stage)
     const runtimePermissionsBoundaryArn = $interpolate`arn:aws:iam::${aws.getCallerIdentityOutput().accountId}:policy/${$app.name}-${$app.stage}-runtime-boundary`
     $transform(aws.iam.Role, (args) => {
       args.permissionsBoundary ??= runtimePermissionsBoundaryArn

--- a/apps/infra/sst.config.ts
+++ b/apps/infra/sst.config.ts
@@ -674,6 +674,23 @@ export default $config({
         rules: [{ listen: '443/tls', forward: `${PORTS.PROXY}/tcp` }],
         health: { [`${PORTS.PROXY}/tcp`]: {} },
       },
+      // Keep the NLB's health check on the Proxy HTTP endpoint. Letting SST
+      // infer a TCP probe while the existing target group retains an HTTP
+      // matcher produces an invalid AWS target-group update.
+      transform: {
+        target: (targetArgs) => {
+          targetArgs.healthCheck = {
+            protocol: 'HTTP',
+            port: 'traffic-port',
+            path: '/health',
+            matcher: '200-399',
+            interval: 30,
+            timeout: 5,
+            healthyThreshold: 2,
+            unhealthyThreshold: 3,
+          }
+        },
+      },
       environment: {
         PROXY_PORT: String(PORTS.PROXY),
         PROXY_PROTOCOL: envOr('PROXY_PROTOCOL', 'https'),

--- a/apps/infra/sst.config.ts
+++ b/apps/infra/sst.config.ts
@@ -90,7 +90,11 @@ export default $config({
       removal: input?.stage === 'production' ? 'retain' : 'remove',
       home: 'aws',
       providers: {
-        aws: { version: '7.20.0', region: REGION, ...(process.env.AWS_PROFILE ? { profile: process.env.AWS_PROFILE } : {}) },
+        aws: {
+          version: '7.24.0',
+          region: REGION,
+          ...(process.env.AWS_PROFILE ? { profile: process.env.AWS_PROFILE } : {}),
+        },
         cloudflare: '6.15.0',
         random: '4.16.6',
         // command provider: multi-runner post-deploy registration
@@ -110,6 +114,14 @@ export default $config({
     const { stackDomain, proxyDomain, proxyProtocol, proxyTemplateUrl, releaseVersion } = deploymentConfig
     const oidcIssuer = requireOidcIssuer()
     const publicOidcIssuer = optionalPublicOidcIssuer()
+
+    // Every role created by this stack must stay inside the boundary provisioned
+    // with the GitHub deployment role. The raw-resource transform also covers IAM
+    // roles created internally by SST components, not only the roles declared here.
+    const runtimePermissionsBoundaryArn = $interpolate`arn:aws:iam::${aws.getCallerIdentityOutput().accountId}:policy/${$app.name}-${$app.stage}-runtime-boundary`
+    $transform(aws.iam.Role, (args) => {
+      args.permissionsBoundary ??= runtimePermissionsBoundaryArn
+    })
 
     // Strip trailing slash from service.url so path concat produces clean URLs
     // (api.url = "https://api.dev.boxlite.ai/" → apiBase = "https://api.dev.boxlite.ai").

--- a/apps/infra/sst.config.ts
+++ b/apps/infra/sst.config.ts
@@ -6,7 +6,7 @@
 /// <reference path="./.sst/platform/config.d.ts" />
 
 // ─────────────────────────────────────────────────────────────────────────────
-// BoxLite control plane on AWS (ap-southeast-1).
+// BoxLite control plane on AWS (AWS_REGION, default ap-southeast-1).
 //
 // Top of file: constants + helpers + the runner user-data builder.
 // Inside `run()`, resources are created in deploy order:
@@ -17,8 +17,6 @@
 //   4. auth (external OIDC)         9. CDN (CloudFront)
 //   5. observability               10. runner (EC2 + nested KVM)
 // ─────────────────────────────────────────────────────────────────────────────
-
-const REGION = 'ap-southeast-1'
 
 // Container ports each service listens on internally
 const PORTS = {
@@ -67,13 +65,6 @@ const httpHealth = (path: string, overrides: Partial<{ successCodes: string }> =
   ...overrides,
 })
 
-// OIDC issuer URL — must be set (Auth0, Okta, etc.). No default.
-const requireOidcIssuer = () => {
-  const v = process.env.OIDC_ISSUER_BASE_URL
-  if (!v) throw new Error('OIDC_ISSUER_BASE_URL is required (e.g. https://<tenant>.auth0.com/)')
-  return v
-}
-
 // Required env var, with the reason it's needed (for vars that become mandatory
 // only under a feature flag). Throws a clear error at deploy time instead of
 // silently shipping the TS non-null assertion's `undefined` into the container.
@@ -85,18 +76,21 @@ const requireEnv = (key: string, why: string) => {
 
 // Runner endpoint default — localhost. v2 runners self-report their address via
 // healthcheck, so the DEFAULT_RUNNER_* override is rarely needed.
-const runnerEndpoint = (override: string, port: number, scheme: string) =>
-  envOr(override, `${scheme}localhost:${port}`)
+const runnerEndpoint = (override: string, port: number, scheme: string) => envOr(override, `${scheme}localhost:${port}`)
 
 // ── app config ───────────────────────────────────────────────────────────────
 export default $config({
-  app(input) {
+  async app(input) {
+    const { loadDeploymentEnvironment, resolveAwsRegion } = await import('./scripts/deployment-environment.mjs')
+    loadDeploymentEnvironment()
+    const REGION = resolveAwsRegion()
+
     return {
       name: 'boxlite',
       removal: input?.stage === 'production' ? 'retain' : 'remove',
       home: 'aws',
       providers: {
-        aws: { region: REGION, ...(process.env.AWS_PROFILE ? { profile: process.env.AWS_PROFILE } : {}) },
+        aws: { version: '7.20.0', region: REGION, ...(process.env.AWS_PROFILE ? { profile: process.env.AWS_PROFILE } : {}) },
         cloudflare: '6.15.0',
         random: '4.16.6',
         // command provider: multi-runner post-deploy registration
@@ -107,9 +101,15 @@ export default $config({
   },
 
   async run() {
-    // Load .env overrides (anything unset falls back to auto-generated values)
-    const { config } = await import('dotenv')
-    config()
+    const { readWorkspaceVersion, resolveAwsRegion, resolvePublicDeploymentConfig } =
+      await import('./scripts/deployment-environment.mjs')
+    const { optionalPublicOidcIssuer, requireOidcIssuer } = await import('./scripts/oidc-issuer.mjs')
+    const REGION = resolveAwsRegion()
+    const workspaceVersion = readWorkspaceVersion()
+    const deploymentConfig = resolvePublicDeploymentConfig(process.env, workspaceVersion)
+    const { stackDomain, proxyDomain, proxyProtocol, proxyTemplateUrl, releaseVersion } = deploymentConfig
+    const oidcIssuer = requireOidcIssuer()
+    const publicOidcIssuer = optionalPublicOidcIssuer()
 
     // Strip trailing slash from service.url so path concat produces clean URLs
     // (api.url = "https://api.dev.boxlite.ai/" → apiBase = "https://api.dev.boxlite.ai").
@@ -122,10 +122,14 @@ export default $config({
     const clickHouseReaderHost = process.env.CLICKHOUSE_READER_HOST || process.env.CLICKHOUSE_HOST
     const clickHouseExporterEnabled = process.env.CLICKHOUSE_EXPORTER_ENABLED === 'true'
     if (clickHouseExporterEnabled && !clickHouseWriterEndpoint) {
-      throw new Error('CLICKHOUSE_WRITER_ENDPOINT or CLICKHOUSE_ENDPOINT is required when CLICKHOUSE_EXPORTER_ENABLED=true')
+      throw new Error(
+        'CLICKHOUSE_WRITER_ENDPOINT or CLICKHOUSE_ENDPOINT is required when CLICKHOUSE_EXPORTER_ENABLED=true',
+      )
     }
     if (clickHouseExporterEnabled && !clickHouseWriterPassword) {
-      throw new Error('CLICKHOUSE_WRITER_PASSWORD or CLICKHOUSE_PASSWORD is required when CLICKHOUSE_EXPORTER_ENABLED=true')
+      throw new Error(
+        'CLICKHOUSE_WRITER_PASSWORD or CLICKHOUSE_PASSWORD is required when CLICKHOUSE_EXPORTER_ENABLED=true',
+      )
     }
     const collectorExporters = clickHouseExporterEnabled ? '[boxlite_exporter,clickhouse]' : '[boxlite_exporter]'
 
@@ -134,10 +138,6 @@ export default $config({
     // port-80-only ALB → 502). We side-step that by giving Api and Dex ALBs
     // HTTPS listeners with a wildcard ACM cert, so Router routes to https://
     // origins and the non-buggy branch runs.
-    const stackDomain = process.env.STACK_DOMAIN
-    if (!stackDomain) {
-      throw new Error('STACK_DOMAIN is required (Cloudflare-managed subdomain, e.g. dev.boxlite.ai)')
-    }
     const cloudflareDns = sst.cloudflare.dns()
     const serviceDomain = (name: string) => ({
       name: `${name}.${stackDomain}`,
@@ -153,17 +153,19 @@ export default $config({
     const proxyApiKey = randomKey('ProxyApiKey')
     const adminApiKey = randomKey('AdminApiKey')
     const defaultRunnerApiKey = randomKey('DefaultRunnerApiKey')
+    const defaultRunnerName = envOr('DEFAULT_RUNNER_NAME', 'default')
     const pgAdminPassword = randomKey('PgAdminPassword', 24)
 
-    // App secrets — set via `sst secret set <NAME> --stage <stage>` (or bulk
-    // `sst secret load <dotenv>`); stored encrypted in SST state and shared
-    // per-stage by anyone with deploy access. Names match the env keys so a
-    // dotenv `sst secret load` maps 1:1. Optional ones carry an empty-string
-    // placeholder, so "unset" reads as '' — an "empty = off" contract.
-    // NB: the Cloudflare provider creds can't live
-    // here (the provider initializes in app() before run() exists); they're
-    // injected from SSM by scripts/sst-with-cloudflare.mjs.
-    const oidcClientId = new sst.Secret('OIDC_CLIENT_ID', 'boxlite')
+    // App secrets — set via `npm run sst -- secret set <NAME> --stage <stage>`
+    // (or bulk `npm run sst -- secret load <dotenv>`); stored encrypted in SST
+    // state and shared per-stage by anyone with deploy access. OIDC_CLIENT_ID is
+    // required and has no deployable fallback: a placeholder would let the stack
+    // become healthy while every interactive login fails. Optional secrets carry
+    // an empty-string fallback, where empty means that the feature is disabled.
+    // NB: the Cloudflare provider creds can't live here (the provider initializes
+    // in app() before run() exists); scripts/sst-with-cloudflare.mjs injects them
+    // from SSM instead.
+    const oidcClientId = new sst.Secret('OIDC_CLIENT_ID')
     const oidcMgmtClientId = new sst.Secret('OIDC_MANAGEMENT_API_CLIENT_ID')
     const oidcMgmtClientSecret = new sst.Secret('OIDC_MANAGEMENT_API_CLIENT_SECRET')
     const posthogApiKey = new sst.Secret('POSTHOG_API_KEY', '')
@@ -367,6 +369,7 @@ export default $config({
     // ─── 6. API (NestJS control plane) ───────────────────────────────────────
     const api = new sst.aws.Service('Api', {
       cluster,
+      wait: true,
       image: {
         context: '../..',
         dockerfile: 'apps/api/Dockerfile',
@@ -402,9 +405,7 @@ export default $config({
           // observability reader defaults to this region
           // (ADMIN_OBSERVABILITY_CLOUDWATCH_REGION).
           actions: ['logs:DescribeLogGroups'],
-          resources: [
-            $interpolate`arn:aws:logs:${REGION}:${aws.getCallerIdentityOutput().accountId}:log-group:*`,
-          ],
+          resources: [$interpolate`arn:aws:logs:${REGION}:${aws.getCallerIdentityOutput().accountId}:log-group:*`],
         },
         {
           // Admin observability S3 reader + VolumeManager boot probe are
@@ -449,7 +450,7 @@ export default $config({
         PORT: String(PORTS.API),
         ENVIRONMENT: 'production',
         RUN_MIGRATIONS: 'true',
-        VERSION: '0.1.0',
+        VERSION: releaseVersion,
         DEFAULT_REGION_ENFORCE_QUOTAS: 'false',
         DEFAULT_TEMPLATE: envOr('DEFAULT_TEMPLATE', 'boxlite/base'),
         // Box base images: the three *_IMAGE refs below are the built-in curated set the API
@@ -503,20 +504,29 @@ export default $config({
         // OIDC — external provider (Auth0/Okta/etc.)
         OIDC_CLIENT_ID: oidcClientId.value,
         OIDC_AUDIENCE: envOr('OIDC_AUDIENCE', 'boxlite'),
-        OIDC_ISSUER_BASE_URL: requireOidcIssuer(),
-        ...(process.env.PUBLIC_OIDC_DOMAIN && {
-          PUBLIC_OIDC_DOMAIN: process.env.PUBLIC_OIDC_DOMAIN,
+        OIDC_ISSUER_BASE_URL: oidcIssuer,
+        ...(publicOidcIssuer && {
+          PUBLIC_OIDC_DOMAIN: publicOidcIssuer,
         }),
         // Optional: Auth0 Management API (enables account linking etc.)
         ...(process.env.OIDC_MANAGEMENT_API_ENABLED === 'true' && {
           OIDC_MANAGEMENT_API_ENABLED: 'true',
+          ...(process.env.OIDC_MANAGEMENT_API_BASE_URL && {
+            OIDC_MANAGEMENT_API_BASE_URL: process.env.OIDC_MANAGEMENT_API_BASE_URL,
+          }),
+          ...(process.env.OIDC_MANAGEMENT_API_TOKEN_URL && {
+            OIDC_MANAGEMENT_API_TOKEN_URL: process.env.OIDC_MANAGEMENT_API_TOKEN_URL,
+          }),
           // Client id/secret come from the SST secret store now. If the feature
           // is enabled but a secret is unset, the value resolves to '' and the
           // Api errors at runtime — instead of the old deploy-time requireEnv
           // throw (Output values can't be guarded at config-build time).
           OIDC_MANAGEMENT_API_CLIENT_ID: oidcMgmtClientId.value,
           OIDC_MANAGEMENT_API_CLIENT_SECRET: oidcMgmtClientSecret.value,
-          OIDC_MANAGEMENT_API_AUDIENCE: requireEnv('OIDC_MANAGEMENT_API_AUDIENCE', 'when OIDC_MANAGEMENT_API_ENABLED=true'),
+          OIDC_MANAGEMENT_API_AUDIENCE: requireEnv(
+            'OIDC_MANAGEMENT_API_AUDIENCE',
+            'when OIDC_MANAGEMENT_API_ENABLED=true',
+          ),
         }),
         // RP-initiated logout fallback. Safe to set unconditionally: the API
         // probes the IdP's discovery doc at startup and only exposes this URL
@@ -540,10 +550,10 @@ export default $config({
         S3_ROLE_NAME: s3AccessRoleName,
 
         // Proxy
-        PROXY_DOMAIN: envOr('PROXY_DOMAIN', `proxy.${stackDomain}`),
-        PROXY_PROTOCOL: envOr('PROXY_PROTOCOL', 'https'),
+        PROXY_DOMAIN: proxyDomain,
+        PROXY_PROTOCOL: proxyProtocol,
         PROXY_API_KEY: envOr('PROXY_API_KEY', proxyApiKey.result),
-        PROXY_TEMPLATE_URL: envOr('PROXY_TEMPLATE_URL', `https://proxy.${stackDomain}`),
+        PROXY_TEMPLATE_URL: proxyTemplateUrl,
 
         // Admin
         ADMIN_API_KEY: envOr('ADMIN_API_KEY', adminApiKey.result),
@@ -615,7 +625,7 @@ export default $config({
         DASHBOARD_BASE_API_URL: envOr('DASHBOARD_BASE_API_URL', `https://api.${stackDomain}`),
 
         // Default runner — the API auto-seeds it at boot; v2 runners self-report
-        DEFAULT_RUNNER_NAME: envOr('DEFAULT_RUNNER_NAME', 'default'),
+        DEFAULT_RUNNER_NAME: defaultRunnerName,
         DEFAULT_RUNNER_API_KEY: envOr('DEFAULT_RUNNER_API_KEY', defaultRunnerApiKey.result),
         DEFAULT_RUNNER_DOMAIN: runnerEndpoint('DEFAULT_RUNNER_DOMAIN', PORTS.RUNNER, ''),
         DEFAULT_RUNNER_API_URL: runnerEndpoint('DEFAULT_RUNNER_API_URL', PORTS.RUNNER, 'http://'),
@@ -659,12 +669,17 @@ export default $config({
     })
 
     // ─── 7. EDGE SERVICES ────────────────────────────────────────────────────
-    // Proxy: routes `<port>-<boxid>.proxy.<stack>` to the box port.
-    // Wildcard cert covers *.proxy.<stack>; Cloudflare serves wildcard DNS.
-    const proxyDomain = `proxy.${stackDomain}`
+    // Proxy: routes `<port>-<boxid>.<proxyDomain>` to the box port.
+    // SST terminates TLS on the NLB listener and manages the proxy + wildcard
+    // Cloudflare records from the same env-driven domain exposed by the API.
+    // Protect the NLB topology so an immutable replacement fails instead of
+    // partially switching the listener to a target group that ECS has not
+    // attached. Routine task revisions continue to use ECS rolling deployments.
+
     new sst.aws.Service('Proxy', {
       cluster,
       image: { context: '../..', dockerfile: 'apps/proxy/Dockerfile', cache: false },
+      wait: true,
       loadBalancer: {
         domain: {
           name: proxyDomain,
@@ -672,34 +687,41 @@ export default $config({
           dns: cloudflareDns,
         },
         rules: [{ listen: '443/tls', forward: `${PORTS.PROXY}/tcp` }],
-        health: { [`${PORTS.PROXY}/tcp`]: {} },
       },
-      // Keep the NLB's health check on the Proxy HTTP endpoint. Letting SST
-      // infer a TCP probe while the existing target group retains an HTTP
-      // matcher produces an invalid AWS target-group update.
+      environment: {
+        PROXY_PORT: String(PORTS.PROXY),
+        PROXY_PROTOCOL: proxyProtocol,
+        PROXY_API_KEY: envOr('PROXY_API_KEY', proxyApiKey.result),
+        // api-client-go appends paths like "/config" directly → include /api suffix
+        BOXLITE_API_URL: $interpolate`${stripTrailingSlash(api.url)}/api`,
+        OIDC_CLIENT_ID: oidcClientId.value,
+        OIDC_AUDIENCE: envOr('OIDC_AUDIENCE', 'boxlite'),
+        OIDC_DOMAIN: oidcIssuer,
+        ...(publicOidcIssuer && {
+          OIDC_PUBLIC_DOMAIN: publicOidcIssuer,
+        }),
+      },
       transform: {
-        target: (targetArgs) => {
-          targetArgs.healthCheck = {
+        loadBalancer: (_args, opts) => {
+          opts.protect = true
+        },
+        listener: (_args, opts) => {
+          opts.protect = true
+        },
+        target: (args, opts) => {
+          args.healthCheck = {
+            enabled: true,
             protocol: 'HTTP',
-            port: 'traffic-port',
             path: '/health',
+            port: 'traffic-port',
             matcher: '200-399',
             interval: 30,
             timeout: 5,
             healthyThreshold: 2,
             unhealthyThreshold: 3,
           }
+          opts.protect = true
         },
-      },
-      environment: {
-        PROXY_PORT: String(PORTS.PROXY),
-        PROXY_PROTOCOL: envOr('PROXY_PROTOCOL', 'https'),
-        PROXY_API_KEY: envOr('PROXY_API_KEY', proxyApiKey.result),
-        // api-client-go appends paths like "/config" directly → include /api suffix
-        BOXLITE_API_URL: $interpolate`${stripTrailingSlash(api.url)}/api`,
-        OIDC_CLIENT_ID: oidcClientId.value,
-        OIDC_AUDIENCE: envOr('OIDC_AUDIENCE', 'boxlite'),
-        OIDC_DOMAIN: requireOidcIssuer(),
       },
     })
 
@@ -811,8 +833,8 @@ export default $config({
     // Dedicated runner security group (least-privilege, explicit in IaC).
     // Without it the runner falls back to the VPC's shared default SG, which
     // allows ALL ports from the whole VPC CIDR. The runner multiplexes its
-    // control-plane API and box proxy onto a single port (API_PORT =
-    // PORTS.RUNNER); box ports are served INSIDE the runner and
+    // control-plane API, box proxy, and (when enabled) ssh-gateway onto a single
+    // port (API_PORT = PORTS.RUNNER); box ports are served INSIDE the runner and
     // never bound on the host NIC. So one inbound port — reachable only from
     // inside the VPC — is the complete surface. Combined with the public-subnet
     // placement (the runner egresses via the Internet Gateway, not the NAT that
@@ -827,7 +849,7 @@ export default $config({
           fromPort: PORTS.RUNNER,
           toPort: PORTS.RUNNER,
           cidrBlocks: [vpc.nodes.vpc.cidrBlock],
-          description: 'control-plane API + box proxy (multiplexed on the runner API port)',
+          description: 'control-plane API + box proxy + ssh-gateway (multiplexed on the runner API port)',
         },
       ],
       egress: [
@@ -879,20 +901,33 @@ export default $config({
       otelCollectorOtlpHttpUrl,
       ghcrSecret ? ghcrSecret.arn : '',
     ]).apply(([apiUrl, token, otelEndpoint, ghcrSecretArn]) =>
-      buildRunnerUserData({ apiUrl, token, otelEndpoint, ghcrSecretArn: ghcrSecretArn || undefined, ghcrUsername }),
+      buildRunnerUserData({
+        apiUrl,
+        token,
+        otelEndpoint,
+        awsRegion: REGION,
+        runnerVersion: workspaceVersion,
+        ghcrSecretArn: ghcrSecretArn || undefined,
+        ghcrUsername,
+      }),
     )
 
     // Runners hold load-bearing box state (/var/lib/boxlite + in-memory libkrun VMs).
     // The default runner and every extra runner are identical except for resource
-    // name, Name tag, and per-runner user-data, so they share one factory. Two Pulumi
+    // name, identity tags, and per-runner user-data, so they share one factory. Two Pulumi
     // options keep a runner persistent across routine deploys:
     //   • ignoreChanges ['ami','userDataBase64']: monthly Ubuntu AMIs and Cargo.toml
     //     version bumps no longer force replacement; a new binary lands out-of-band via
     //     SSM instead of recreating the EC2 — scripts/deploy/runner-update-binary.sh
-    //     upgrades the DEFAULT runner (matches its tag only); extra runners separately.
+    //     upgrades one Runner selected by both its AWS and control-plane identity tags.
     //   • protect: refuses any delete (errant `pulumi destroy` / teardown). Deliberate
     //     decommission = set protect:false, deploy, then `pulumi destroy --target ...`.
-    const makeRunner = (resourceName: string, nameTag: string, userData: $util.Input<string>) =>
+    const makeRunner = (
+      resourceName: string,
+      nameTag: string,
+      controlPlaneRunnerName: string,
+      userData: $util.Input<string>,
+    ) =>
       new aws.ec2.Instance(
         resourceName,
         {
@@ -913,7 +948,10 @@ export default $config({
           metadataOptions: { httpEndpoint: 'enabled', httpTokens: 'required', httpPutResponseHopLimit: 1 },
           userDataBase64: userData,
           rootBlockDevice: { volumeSize: RUNNER.rootDiskGB },
-          tags: { Name: nameTag },
+          tags: {
+            Name: nameTag,
+            'boxlite:control-plane-runner-name': controlPlaneRunnerName,
+          },
         },
         {
           ignoreChanges: ['ami', 'userDataBase64'],
@@ -923,8 +961,8 @@ export default $config({
 
     // Default runner — auto-seeded by the API at boot via DEFAULT_RUNNER_*.
     // Pulumi resource id stays 'Runner' (renaming it would replace a protect:true
-    // instance); only the AWS Name tag carries the explicit `-default` suffix.
-    makeRunner('Runner', 'boxlite-runner-default', runnerUserData)
+    // instance); the AWS tags bind it to the API's configured default name.
+    makeRunner('Runner', 'boxlite-runner-default', defaultRunnerName, runnerUserData)
 
     // Multi-runner provisioning. Extra runners share the same OTel endpoint as
     // the default runner.
@@ -944,13 +982,23 @@ export default $config({
       const name = `runner-${index}` // control-plane registration name
       const apiKey = randomKey(`RunnerApiKey-${name}`)
       // Resource id stays `Runner-runner-N` (stable — these are protect:true);
-      // only the AWS Name tag takes the cleaner `boxlite-runner-N` form.
+      // the AWS Name tag takes the cleaner `boxlite-runner-N` form while a
+      // separate tag preserves the exact control-plane name.
       const instance = makeRunner(
         `Runner-${name}`,
         `boxlite-runner-${index}`,
+        name,
         $resolve([api.url, apiKey.result, otelCollectorOtlpHttpUrl, ghcrSecret ? ghcrSecret.arn : '']).apply(
           ([apiUrl, token, otelEndpoint, ghcrSecretArn]) =>
-            buildRunnerUserData({ apiUrl, token, otelEndpoint, ghcrSecretArn: ghcrSecretArn || undefined, ghcrUsername }),
+            buildRunnerUserData({
+              apiUrl,
+              token,
+              otelEndpoint,
+              awsRegion: REGION,
+              runnerVersion: workspaceVersion,
+              ghcrSecretArn: ghcrSecretArn || undefined,
+              ghcrUsername,
+            }),
         ),
       )
       return { name, apiKey, instance }
@@ -989,19 +1037,12 @@ async function buildRunnerUserData(input: {
   apiUrl: string
   token: string
   otelEndpoint: string
+  awsRegion: string
+  runnerVersion: string
   ghcrSecretArn?: string
   ghcrUsername?: string
 }): Promise<string> {
-  const { readFileSync } = await import('fs')
-  const { resolve } = await import('path')
-
-  // SST invokes from apps/infra/ as cwd; Cargo.toml lives at repo root.
-  const cargoToml = readFileSync(resolve(process.cwd(), '../../Cargo.toml'), 'utf-8')
-  const versionMatch = cargoToml.match(/^version\s*=\s*"(.+?)"/m)
-  if (!versionMatch) {
-    throw new Error('could not parse runner version from ../../Cargo.toml (expected a top-level `version = "X.Y.Z"`)')
-  }
-  const RUNNER_VERSION = versionMatch[1]
+  const RUNNER_VERSION = input.runnerVersion
 
   // ghcr pull credential delivery (option B, rotation-capable): install AWS CLI v2
   // and write a start-wrapper that re-fetches the TOKEN from Secrets Manager on
@@ -1064,19 +1105,16 @@ rm -f /tmp/mount-s3.deb
 
 # Download the prebuilt runner binary, then verify its SHA-256 against the
 # checksum published next to the release asset before installing (it runs as
-# root). Best-effort for backward compatibility: a release with no .sha256 asset
-# warns and proceeds; a present-but-mismatched checksum is fatal (fail-closed).
+# root). A missing, malformed, or mismatched checksum is fatal.
 RUNNER_BASE="https://github.com/boxlite-ai/boxlite/releases/download/v${RUNNER_VERSION}"
 RUNNER_TARBALL="boxlite-runner-v${RUNNER_VERSION}-linux-amd64.tar.gz"
 curl -fsSL "\${RUNNER_BASE}/\${RUNNER_TARBALL}" -o "/tmp/\${RUNNER_TARBALL}"
-if curl -fsSL "\${RUNNER_BASE}/\${RUNNER_TARBALL}.sha256" -o /tmp/runner.sha256; then
-  EXPECTED=\$(awk '{print \$1}' /tmp/runner.sha256)
-  ACTUAL=\$(sha256sum "/tmp/\${RUNNER_TARBALL}" | awk '{print \$1}')
-  [ "\$EXPECTED" = "\$ACTUAL" ] || { echo "FATAL: runner checksum mismatch (want \$EXPECTED got \$ACTUAL)" >&2; exit 1; }
-  echo "runner tarball checksum verified (\$ACTUAL)"
-else
-  echo "WARNING: no .sha256 published for v${RUNNER_VERSION}; installing without integrity verification" >&2
-fi
+curl -fsSL "\${RUNNER_BASE}/\${RUNNER_TARBALL}.sha256" -o /tmp/runner.sha256
+EXPECTED=\$(awk 'NR == 1 {print \$1}' /tmp/runner.sha256)
+[[ "\$EXPECTED" =~ ^[0-9a-f]{64}\$ ]] || { echo "FATAL: invalid runner checksum file" >&2; exit 1; }
+ACTUAL=\$(sha256sum "/tmp/\${RUNNER_TARBALL}" | awk '{print \$1}')
+[ "\$EXPECTED" = "\$ACTUAL" ] || { echo "FATAL: runner checksum mismatch (want \$EXPECTED got \$ACTUAL)" >&2; exit 1; }
+echo "runner tarball checksum verified (\$ACTUAL)"
 tar -xzf "/tmp/\${RUNNER_TARBALL}" -C /usr/local/bin/
 rm -f "/tmp/\${RUNNER_TARBALL}" /tmp/runner.sha256
 chmod +x /usr/local/bin/boxlite-runner
@@ -1106,13 +1144,17 @@ Environment=API_VERSION=2
 Environment=API_PORT=${PORTS.RUNNER}
 Environment=RUNNER_DOMAIN=\$HOST_IP
 Environment=BOXLITE_HOME_DIR=/var/lib/boxlite
-Environment=AWS_REGION=${REGION}
+Environment=AWS_REGION=${input.awsRegion}
 Environment=OTEL_LOGGING_ENABLED=true
 Environment=OTEL_TRACING_ENABLED=true
-Environment=OTEL_EXPORTER_OTLP_ENDPOINT=${input.otelEndpoint}${input.ghcrSecretArn ? `
+Environment=OTEL_EXPORTER_OTLP_ENDPOINT=${input.otelEndpoint}${
+    input.ghcrSecretArn
+      ? `
 # ghcr: username + secret ARN are non-secret; the start-wrapper fetches the TOKEN at runtime.
 Environment=GHCR_USERNAME=${input.ghcrUsername ?? ''}
-Environment=GHCR_SECRET_ARN=${input.ghcrSecretArn}` : ''}
+Environment=GHCR_SECRET_ARN=${input.ghcrSecretArn}`
+      : ''
+  }
 
 [Install]
 WantedBy=multi-user.target

--- a/make/test.mk
+++ b/make/test.mk
@@ -1,4 +1,4 @@
-PHONY_TARGETS += test test\:unit\:guest test\:apps\:infra test\:apps\:infra-config
+PHONY_TARGETS += test test\:unit\:guest _ensure-infra-deps test\:apps\:infra test\:apps\:infra-config
 
 # Mirrors GitHub Actions strategy.fail-fast. Default false: aggregator
 # targets run every sub-suite even if an earlier one fails, then exit
@@ -362,13 +362,18 @@ test\:all\:go:
 # Without the tag, `go test` uses bridge_cgo_prebuilt.go, which needs the
 # downloaded sdks/go/{libboxlite.a,include} bundle (absent on dev checkouts)
 # and fails #579. Same pattern as test:unit:go above.
-test\:apps\:infra:
+_ensure-infra-deps:
+	@if [ ! -d apps/infra/node_modules ]; then \
+		echo "📦 Installing SST deployment dependencies..."; \
+		cd apps/infra && npm ci --no-audit --no-fund; \
+	fi
+
+test\:apps\:infra: _ensure-infra-deps
 	@echo "🧪 Running infrastructure script tests..."
 	@cd apps/infra && npm test
 
-test\:apps\:infra-config: _ensure-apps-deps
+test\:apps\:infra-config: _ensure-apps-deps _ensure-infra-deps
 	@echo "🧪 Installing and type-checking the SST deployment config..."
-	@cd apps/infra && npm ci --no-audit --no-fund
 	@cd apps/infra && npm run sst -- install --stage ci
 	@cd apps/infra && ../node_modules/.bin/tsc --noEmit --allowJs --checkJs false \
 		--module NodeNext --moduleResolution NodeNext --target ES2022 --skipLibCheck sst.config.ts

--- a/make/test.mk
+++ b/make/test.mk
@@ -374,7 +374,7 @@ test\:apps\:infra: _ensure-infra-deps
 
 test\:apps\:infra-config: _ensure-apps-deps _ensure-infra-deps
 	@echo "🧪 Installing and type-checking the SST deployment config..."
-	@cd apps/infra && npm run sst -- install --stage ci
+	@cd apps/infra && IAM_PERMISSIONS_BOUNDARY_STAGE=ci npm run sst -- install --stage ci
 	@cd apps/infra && ../node_modules/.bin/tsc --noEmit --allowJs --checkJs false \
 		--module NodeNext --moduleResolution NodeNext --target ES2022 --skipLibCheck sst.config.ts
 

--- a/make/test.mk
+++ b/make/test.mk
@@ -1,4 +1,4 @@
-PHONY_TARGETS += test test\:unit\:guest
+PHONY_TARGETS += test test\:unit\:guest test\:apps\:infra test\:apps\:infra-config
 
 # Mirrors GitHub Actions strategy.fail-fast. Default false: aggregator
 # targets run every sub-suite even if an earlier one fails, then exit
@@ -362,8 +362,20 @@ test\:all\:go:
 # Without the tag, `go test` uses bridge_cgo_prebuilt.go, which needs the
 # downloaded sdks/go/{libboxlite.a,include} bundle (absent on dev checkouts)
 # and fails #579. Same pattern as test:unit:go above.
+test\:apps\:infra:
+	@echo "🧪 Running infrastructure script tests..."
+	@cd apps/infra && npm test
+
+test\:apps\:infra-config: _ensure-apps-deps
+	@echo "🧪 Installing and type-checking the SST deployment config..."
+	@cd apps/infra && npm ci --no-audit --no-fund
+	@cd apps/infra && npm run sst -- install --stage ci
+	@cd apps/infra && ../node_modules/.bin/tsc --noEmit --allowJs --checkJs false \
+		--module NodeNext --moduleResolution NodeNext --target ES2022 --skipLibCheck sst.config.ts
+
 test\:apps: _ensure-apps-deps dev\:go
 	@echo "🧪 Running apps workspace test matrix..."
+	@$(MAKE) test:apps:infra
 	@cd apps && GOFLAGS=-tags=boxlite_dev yarn nx run-many --target=test --all --parallel=$$(getconf _NPROCESSORS_ONLN) $(if $(FILTER),-- --testNamePattern '$(FILTER)',)
 
 test\:rest\:inventory: _ensure-apps-deps


### PR DESCRIPTION
## What changed

- Run guarded dev API deployments on a native AMD64 GitHub runner with short-lived AWS OIDC credentials.
- Centralize SST stage, region, release, Proxy domain, image, and OIDC issuer validation.
- Keep Proxy NLB resources protected, pin the HTTP `/health` target-group check, wait for ECS steady state, and verify listener attachment, healthy targets, wildcard TLS/DNS, and public API configuration after deployment.
- Remove Pulumi event logs before and after every wrapped SST command because they can contain provider credentials.
- Verify required Runner release artifacts before a full SST deployment and fail closed on missing or mismatched checksums.
- Pin infra dependencies and run the SST helper/config checks through Make and CI.
- Document stage-scoped secrets, CI bootstrap, deployment recovery, and Proxy topology.

## Why

The Proxy outage happened after a new SST NLB target group had no Proxy ECS task IPs attached. The live repair reattached the ECS service manually, but the deployment path did not verify that SST's listener target group was the same group ECS maintained or that it had enough healthy targets.

SST also inferred a TCP health check while the existing target group retained an HTTP matcher, which AWS rejects as an invalid target-group update. The deployment wrapper previously stopped after SST returned success, so either condition could escape into production.

## Impact

Future deployments use one validated configuration, preserve the Proxy HTTP health check, wait for critical ECS services, and fail when the public routing path or ECS target registration is not ready. Dev API deployment no longer depends on a developer Mac or a laptop-managed remote Docker builder.

The branch is based on current `main` and preserves the newer SSH-gateway removal.

## Validation

- `make test:apps:infra` — 63 tests passed
- TypeScript compile of `apps/infra/sst.config.ts` against generated SST platform types
- Prettier check for all added/changed infra JavaScript and the dev deployment workflow
- `actionlint` for `deploy-dev-api.yml`; `lint.yml` validates with its pre-existing SC2046 warning ignored
- `git diff --check`

A fresh local `sst install --stage ci` stalled inside SST's internal `bun install` through the local network proxy after six minutes. CI runs that fresh install/type-check on Linux.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manual, branch-gated workflow for deploying only the dev API.
  * Stronger deployment verification for proxy routing, health checks, API config/version, and supported images (with retry + abort).
  * Enforced runner release asset checksum validation (deployment fails if missing/mismatched).
* **Documentation**
  * Expanded infrastructure/bootstrapping, OIDC issuer formatting, and permissions-boundary setup requirements.
* **Bug Fixes**
  * Tightened environment/stage validation and improved “fail closed” guardrails during deployment verification.
* **Tests**
  * Added/expanded suites for deployment-environment resolution, OIDC handling, proxy verification, deployment safety, and runner asset checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->