### PR TITLE
fix(ci): use one SST deployment selector

### DIFF
--- a/.github/workflows/deploy-dev-api.yml
+++ b/.github/workflows/deploy-dev-api.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Deploy the API only
         working-directory: apps/infra
-        run: npm run deploy -- --stage dev --target Api --exclude Runner
+        run: npm run deploy -- --stage dev --target Api
 
       - name: Remove materialized configuration
         if: always()

--- a/apps/infra/README.md
+++ b/apps/infra/README.md
@@ -76,10 +76,11 @@ GitHub `dev` Environment. GitHub OIDC supplies short-lived AWS credentials; no
 AWS access keys are stored in GitHub. `DEPLOY_ENV` materializes the stage's
 gitignored `.env` only for the job and is deleted even if deployment fails.
 
-The current workflow deliberately targets only `Api` and excludes `Runner`:
+The current workflow deliberately targets only `Api`; selecting only the API
+also skips the Runner release-asset preflight:
 
 ```bash
-npm run deploy -- --stage dev --target Api --exclude Runner
+npm run deploy -- --stage dev --target Api
 ```
 
 The role template grants only the AWS control-plane actions used by this SST
@@ -378,12 +379,13 @@ capability-gated two-phase rollout:
    requests to Runners at the required version, and each upgraded Runner only
    becomes schedulable after the control plane reports that exact version.
 
-An explicit `--exclude Runner` deployment is the operator escape hatch for a
-control-plane-only rollout. It skips the Runner release-asset preflight and
-leaves the EC2 resource, binary, and identity tag untouched. Detached requests
-that use legacy Runner capabilities remain available; requests needing the new
-Runner version fail explicitly until a later full rollout applies the metadata
-and upgrades the binary.
+An API-only `--target Api` deployment, or a broader deployment with an explicit
+`--exclude Runner`, is the operator escape hatch for a control-plane-only
+rollout. Either form skips the Runner release-asset preflight and leaves the EC2
+resource, binary, and identity tag untouched. Detached requests that use legacy
+Runner capabilities remain available; requests needing the new Runner version
+fail explicitly until a later full rollout applies the metadata and upgrades
+the binary.
 
 This bounded compatibility window is intentional: silently discarding a
 requested command or foreground lifecycle would be data loss, while sending it

--- a/apps/infra/scripts/release-deployment-safety.test.mjs
+++ b/apps/infra/scripts/release-deployment-safety.test.mjs
@@ -70,6 +70,8 @@ test('SST deploy does not depend on a laptop-managed remote builder', () => {
 test('manual dev API deployment runs natively in guarded GitHub CI', () => {
   assert.ok(existsSync(DEV_API_DEPLOY_WORKFLOW), 'the dev API deployment workflow is missing')
   const source = readFileSync(DEV_API_DEPLOY_WORKFLOW, 'utf8')
+  const workflow = load(source)
+  const deployStep = workflow.jobs.deploy.steps.find((step) => step.name === 'Deploy the API only')
 
   assert.match(source, /workflow_dispatch:/)
   assert.match(source, /if: github\.ref == 'refs\/heads\/main'/)
@@ -82,7 +84,8 @@ test('manual dev API deployment runs natively in guarded GitHub CI', () => {
   assert.match(source, /role-to-assume: \$\{\{ vars\.AWS_DEPLOY_ROLE_ARN \}\}/)
   assert.match(source, /secrets\.DEPLOY_ENV/)
   assert.match(source, /AWS_ACCESS_KEY_ID[\s\S]*native CI builder/)
-  assert.match(source, /npm run deploy -- --stage dev --target Api --exclude Runner/)
+  assert.ok(deployStep, 'the API deployment step is missing')
+  assert.equal(deployStep.run, 'npm run deploy -- --stage dev --target Api')
   assert.doesNotMatch(source, /setup-qemu/)
 })
 

--- a/apps/infra/scripts/sst-stage.mjs
+++ b/apps/infra/scripts/sst-stage.mjs
@@ -42,15 +42,33 @@ export function resolveSstStage(args, environment = process.env) {
 }
 
 export function isSstComponentExcluded(args, component) {
+  let selector
+  const selectedComponents = new Set()
+
   for (let index = 0; index < args.length; index += 1) {
-    if (args[index] === '--exclude') {
-      if (args[index + 1] === component) return true
+    const separateSelector = args[index].match(/^--(target|exclude)$/)?.[1]
+    if (separateSelector) {
+      const value = args[index + 1]
+      if (!value || value.startsWith('-')) throw new Error(`--${separateSelector} requires a value`)
+      if (selector && selector !== separateSelector) throw new Error('--target and --exclude cannot be combined')
+      selector = separateSelector
+      selectedComponents.add(value)
       index += 1
       continue
     }
 
-    if (args[index] === `--exclude=${component}`) return true
+    const inlineSelector = args[index].match(/^--(target|exclude)=(.*)$/)
+    if (inlineSelector) {
+      const [, nextSelector, value] = inlineSelector
+      if (!value) throw new Error(`--${nextSelector} requires a value`)
+      if (selector && selector !== nextSelector) throw new Error('--target and --exclude cannot be combined')
+      selector = nextSelector
+      selectedComponents.add(value)
+    }
   }
+
+  if (selector === 'target') return !selectedComponents.has(component)
+  if (selector === 'exclude') return selectedComponents.has(component)
   return false
 }
 

--- a/apps/infra/scripts/sst-stage.test.mjs
+++ b/apps/infra/scripts/sst-stage.test.mjs
@@ -44,11 +44,19 @@ test('retains the dev credential lookup default for non-deploy commands', () => 
   assert.equal(resolveSstStage(['diff'], {}), 'dev')
 })
 
-test('recognizes only an explicitly excluded SST component', () => {
+test('recognizes SST components omitted by exclude or target selection', () => {
   assert.equal(isSstComponentExcluded(['deploy', '--exclude', 'Runner'], 'Runner'), true)
   assert.equal(isSstComponentExcluded(['deploy', '--exclude=Runner'], 'Runner'), true)
   assert.equal(isSstComponentExcluded(['deploy', '--exclude', 'Runner-runner-2'], 'Runner'), false)
+  assert.equal(isSstComponentExcluded(['deploy', '--target', 'Api'], 'Runner'), true)
+  assert.equal(isSstComponentExcluded(['deploy', '--target=Api'], 'Runner'), true)
   assert.equal(isSstComponentExcluded(['deploy', '--target', 'Runner'], 'Runner'), false)
+  assert.equal(isSstComponentExcluded(['deploy', '--target=Runner'], 'Runner'), false)
+  assert.equal(isSstComponentExcluded(['deploy'], 'Runner'), false)
+  assert.throws(
+    () => isSstComponentExcluded(['deploy', '--target', 'Api', '--exclude', 'Runner'], 'Runner'),
+    /--target and --exclude cannot be combined/,
+  )
 })
 
 test('requires the provisioned IAM boundary stage to match the SST stage', () => {

--- a/apps/infra/scripts/sst-with-cloudflare.mjs
+++ b/apps/infra/scripts/sst-with-cloudflare.mjs
@@ -200,7 +200,7 @@ if (sstArgs[0] === 'deploy') {
     publicDeploymentConfig = resolvePublicDeploymentConfig(process.env, workspaceVersion)
     if (isSstComponentExcluded(sstArgs, 'Runner')) {
       console.warn(
-        `sst-with-cloudflare: Runner excluded; skipping the v${workspaceVersion} release-asset preflight. ` +
+        `sst-with-cloudflare: Runner not selected; skipping the v${workspaceVersion} release-asset preflight. ` +
           'Runner metadata and new Runner-only capabilities will remain unavailable until a later full rollout.',
       )
     } else {


### PR DESCRIPTION
## Problem

The manual dev API deployment failed before changing infrastructure. The workflow invoked SST with both `--target Api` and `--exclude Runner`, but SST treats `--target` and `--exclude` as mutually exclusive selector groups.

## User impact

Approving and running the guarded dev deployment always stopped at argument validation, so the API could not be deployed through the new workflow.

## Root cause

The workflow attempted to express “API only” twice. `--target Api` already selects the API component, while adding `--exclude Runner` makes the command invalid in SST 4.6.11.

## Fix

Keep the single `--target Api` selector and remove `--exclude Runner`. Parse the workflow YAML in the deployment safety test and assert the exact API-only command so the incompatible selector combination cannot return unnoticed.

## Verification

- Reproduced before the fix: `make test:apps:infra` failed with the actual command containing both selectors.
- After the fix: `make test:apps:infra` passes all 68 tests.
- `actionlint .github/workflows/deploy-dev-api.yml` passes.
- `git diff --check` passes.

The real dev deployment will be rerun after this change reaches `main` because the workflow intentionally permits deployments only from `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the dev API “API-only” deployment workflow to use the correct command and stage/target settings.
  * Improved component selection parsing to correctly handle `--target/--exclude` (including inline forms) and reject conflicting selector arguments.
  * Updated the preflight warning text when the Runner component isn’t selected.
* **Documentation**
  * Refreshed control-plane-only deployment guidance with the API-only command examples.
* **Tests**
  * Expanded CI/workflow and SST selector tests to assert the exact expected commands and selector behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->