### PR TITLE
fix(ci): deploy stack without Runner

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -161,10 +161,16 @@ is enabled. The workflow is dormant until repository variable
 
 ### `deploy-dev-api.yml`
 
-Manually deploys only the dev `Api` component from `main` on a native AMD64
-GitHub runner. The job is serialized, uses the protected `dev` Environment, and
-authenticates to AWS with short-lived OIDC credentials. Docker runs entirely in
-CI; no developer machine or public SSH builder participates.
+Previews or deploys the full dev stack from `main` on a native AMD64 GitHub
+runner. Deployment safety tests first enforce the Runner lifecycle options.
+Dispatch defaults to preview-only; `apply=true` repeats the full structured
+preview and deploys only when the Runner safety gate accepts the plan. Routine
+control-plane deployment rejects every Runner create, delete, replacement, or
+protected-property change; the routine workflow does not provision Runners.
+The job rejects partial `--target`/`--exclude` deploys so provider changes and
+resources reconcile together. It is serialized, uses the protected `dev`
+Environment, and authenticates to AWS with short-lived OIDC credentials. Docker
+runs entirely in CI; no developer machine or public SSH builder participates.
 
 Required `dev` Environment configuration:
 

--- a/.github/workflows/deploy-dev-api.yml
+++ b/.github/workflows/deploy-dev-api.yml
@@ -1,19 +1,25 @@
-name: Deploy dev API
+name: Deploy dev stack
 
 on:
   workflow_dispatch:
+    inputs:
+      apply:
+        description: Preview again, then deploy the full stack
+        required: true
+        default: false
+        type: boolean
 
 permissions:
   contents: read
   id-token: write
 
 concurrency:
-  group: deploy-dev-api
+  group: deploy-dev-stack
   cancel-in-progress: false
 
 jobs:
   deploy:
-    name: Deploy API
+    name: Deploy dev stack
     if: github.ref == 'refs/heads/main'
     environment: dev
     runs-on: ubuntu-24.04
@@ -41,7 +47,7 @@ jobs:
         with:
           role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
-          role-session-name: deploy-dev-api-${{ github.run_id }}
+          role-session-name: deploy-dev-stack-${{ github.run_id }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -54,6 +60,10 @@ jobs:
         working-directory: apps/infra
         run: npm ci
 
+      - name: Run deployment safety tests
+        working-directory: apps/infra
+        run: npm test
+
       - name: Materialize stage configuration
         shell: bash
         env:
@@ -63,14 +73,24 @@ jobs:
           test -n "$DEPLOY_ENV"
           umask 077
           printf '%s\n' "$DEPLOY_ENV" > apps/infra/.env
-          if grep -Eq '^(AWS_PROFILE|AWS_ACCESS_KEY_ID|AWS_SECRET_ACCESS_KEY|AWS_SESSION_TOKEN|BUILDX_BUILDER)=' apps/infra/.env; then
-            echo "DEPLOY_ENV must rely on workflow OIDC and the native CI builder" >&2
-            exit 1
-          fi
+          node apps/infra/scripts/deploy-environment-validation.mjs apps/infra/.env
 
-      - name: Deploy the API only
+      - name: Install SST providers
         working-directory: apps/infra
-        run: npm run deploy -- --stage dev --target Api
+        run: npm run --silent sst -- install --stage dev
+
+      - name: Preview the full stack
+        shell: bash
+        working-directory: apps/infra
+        run: |
+          set -euo pipefail
+          npm run --silent sst -- diff --stage dev --policy . --json |
+            node scripts/deployment-preview.mjs
+
+      - name: Deploy the full stack
+        if: ${{ inputs.apply }}
+        working-directory: apps/infra
+        run: npm run deploy -- --stage dev --policy .
 
       - name: Remove materialized configuration
         if: always()

--- a/apps/infra/.env.example
+++ b/apps/infra/.env.example
@@ -1,7 +1,7 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # BoxLite Infra — .env
 #
-# Copy to .env and fill in the non-secret deployment values before first deploy.
+# Copy to .env and fill in the non-secret values before deploying an existing stack.
 # SST application secrets are stage-scoped. Set them separately with the
 # `npm run sst -- secret set` command; putting those names here does not
 # configure the deployed app.
@@ -13,7 +13,8 @@
 #   [optional]            safe to leave unset
 #
 # Sections 1–2 contain the required local configuration. Section 3 describes
-# the optional runner; section 4 holds optional local overrides.
+# the optional Runner inventory configuration; section 4 holds optional local
+# overrides.
 # ─────────────────────────────────────────────────────────────────────────────
 
 # ─── 1. Domain + DNS ─────────────────────────────────────────────────────────
@@ -72,17 +73,18 @@ OIDC_ISSUER_BASE_URL=https://your-tenant.auth0.com/
 # domain. Leave unset when the public and internal issuer are the same.
 PUBLIC_OIDC_DOMAIN=https://auth.dev.example.com/
 # [required SST secret] Set the SPA client ID in the stage's SST secret store;
-# it is deliberately not read from this local deployment environment:
-#   npm run sst -- secret set OIDC_CLIENT_ID "<spa-client-id>" --stage <stage>
+# it is deliberately not read from this local deployment environment. Use the
+# non-echoing stdin procedure in README.md; never put the value in process argv:
+#   printf '%s' "$secret_value" | npm run sst -- secret set OIDC_CLIENT_ID --stage <stage>
 # [required] Non-secret API audience:
 OIDC_AUDIENCE=https://dev.example.com/api
 
 # ─── 3. Runner ───────────────────────────────────────────────────────────────
-# [optional] Total number of runners (the default runner is #1). Set >1 to add
-# more: each extra gets its own EC2 + token and is auto-registered with the
-# control plane during `sst deploy` (admin API). Unset = 1 (default only).
+# [optional] Expected current runner total from 1 to 100 (the default runner is
+# #1). Routine deploys require an exact match with SST state and cannot create,
+# recover, or remove runners. Unset = 1 (default only).
 # v2 runners self-report their address via healthcheck, so no IP wiring is needed.
-#   RUNNERS=3
+#   RUNNERS=3  # only when state already contains default + runner-2 + runner-3
 #
 # [required for private box images] ghcr pull credential. Runners pull box images
 # straight from private ghcr.io, so set BOTH to enable: the token is stored in
@@ -93,18 +95,19 @@ OIDC_AUDIENCE=https://dev.example.com/api
 #   GHCR_TOKEN=ghp_xxx
 
 # ─── 4. Optional overrides ───────────────────────────────────────────────────
-# Everything below is [optional] — safe auto-generated or derived defaults.
-# Uncomment to pin.
+# Everything below is [optional]. Entries marked local-only must remain unset in
+# the GitHub `DEPLOY_ENV` secret; the workflow rejects local credential context.
 
 # 4a. AWS / deploy
 # AWS region used by both SST and the post-deploy verifier.
 # AWS_REGION=ap-southeast-1
 # API release reported by /api/config. Defaults to Cargo.toml's workspace version.
 # VERSION=0.9.8
-# AWS profile used by SST. Leave unset to use "default".
+# Local CLI only: AWS profile used by SST. Remove it before uploading this file
+# as `DEPLOY_ENV`; GitHub CI uses OIDC and rejects AWS_PROFILE.
 # AWS_PROFILE=my-aws-profile
-# Optional absolute AWS CLI path. The deploy wrapper also searches PATH and
-# standard Homebrew/system locations before starting a deployment.
+# Local CLI only: optional absolute AWS CLI path. Remove it before uploading
+# this file as `DEPLOY_ENV`; CI selects the native Ubuntu AWS CLI from PATH.
 # AWS_CLI_PATH=/opt/homebrew/bin/aws
 # 4b. Secrets & keys — auto-generated per stack; pin only to rotate or to share
 # a value across stacks.
@@ -125,8 +128,10 @@ OIDC_AUDIENCE=https://dev.example.com/api
 # DASHBOARD_BASE_API_URL=https://api.dev.example.com
 # APP_URL=
 
-# 4d. Default runner name (rarely changed). v2 runners self-report their
-# address, so there are no domain/url knobs to pin.
+# 4d. Provisioning-time Runner identity. It is immutable for an existing stack:
+# routine deployment rejects a rename. Use 2-255 letters, numbers, underscores,
+# periods, or hyphens; it must not equal an extra runner name such as runner-2.
+# v2 runners self-report their address, so there are no domain/url knobs to pin.
 # DEFAULT_RUNNER_NAME=default
 
 # 4e. Auth0 Management API (account linking).

--- a/apps/infra/PulumiPolicy.yaml
+++ b/apps/infra/PulumiPolicy.yaml
@@ -1,0 +1,3 @@
+runtime: nodejs
+main: policies/runner/index.js
+description: Mandatory BoxLite Runner lifecycle and identity policy

--- a/apps/infra/README.md
+++ b/apps/infra/README.md
@@ -6,12 +6,13 @@
 > See the project root `LICENSE` file and individual source file headers for
 > full license terms.
 
-One-command deploy of the BoxLite control plane: ECS Fargate services, an
-EC2 runner with nested KVM, RDS Postgres, ElastiCache Redis, S3, CloudFront.
+Guarded deployment of an existing BoxLite control-plane stack: ECS Fargate
+services, an EC2 Runner with nested KVM, RDS Postgres, ElastiCache Redis, S3,
+and CloudFront.
 
 - **Region:** `AWS_REGION` (defaults to `ap-southeast-1`)
 - **IaC:** SST v4 (Pulumi under the hood)
-- **Cost at rest:** ~$570/month always-on — Runner + load balancers dominate (tear down with one command)
+- **Cost at rest:** ~$570/month always-on — Runner + load balancers dominate
 
 ## Prerequisites
 
@@ -19,24 +20,39 @@ EC2 runner with nested KVM, RDS Postgres, ElastiCache Redis, S3, CloudFront.
 - An **Auth0 tenant** (or any OIDC provider — see `.env.example` for setup steps)
 - A protected GitHub **`dev` Environment** with required reviewers
 - An AWS GitHub OIDC provider and the deployment role described below
+- An existing SST stack whose Runner inventory exactly matches `RUNNERS`
 - **AWS CLI** and **GitHub CLI** for one-time CI bootstrap only
 
-## Quick start
+## Deploy an existing stack
+
+This workflow cannot create the first Runner or recover a missing one. Complete
+a separately reviewed Runner provisioning operation before using it for a new
+stage; that operation is not implemented in this repository yet.
 
 ```bash
 cd apps/infra
 npm install
 cp .env.example .env        # stage config: STACK_DOMAIN, OIDC_ISSUER_BASE_URL, OIDC_AUDIENCE
 
-# Cloudflare provider credentials live in SSM (per stage) — see "Secrets & credentials":
-aws ssm put-parameter --region ap-southeast-1 --type SecureString \
-  --name /boxlite/dev/cloudflare-api-token  --value "<token>"
-aws ssm put-parameter --region ap-southeast-1 --type SecureString \
-  --name /boxlite/dev/cloudflare-account-id --value "<account-id>"
+# Cloudflare provider credentials live in SSM (per stage). Read each value
+# without terminal echo, then pass it through stdin instead of process argv:
+printf 'Cloudflare API token: ' >&2
+IFS= read -rs secret_value; printf '\n' >&2
+printf '%s' "$secret_value" | aws ssm put-parameter --region ap-southeast-1 \
+  --type SecureString --name /boxlite/dev/cloudflare-api-token --value file:///dev/stdin
+unset secret_value
+printf 'Cloudflare account ID: ' >&2
+IFS= read -rs secret_value; printf '\n' >&2
+printf '%s' "$secret_value" | aws ssm put-parameter --region ap-southeast-1 \
+  --type SecureString --name /boxlite/dev/cloudflare-account-id --value file:///dev/stdin
+unset secret_value
 
 # Required application secret. There is no placeholder fallback because a wrong
-# client ID makes every interactive login fail.
-npm run sst -- secret set OIDC_CLIENT_ID "<spa-client-id>" --stage dev
+# client ID makes every interactive login fail. SST reads an omitted value from stdin.
+printf 'OIDC client ID: ' >&2
+IFS= read -rs secret_value; printf '\n' >&2
+printf '%s' "$secret_value" | npm run sst -- secret set OIDC_CLIENT_ID --stage dev
+unset secret_value
 
 # Bootstrap the short-lived GitHub OIDC role. The account's GitHub OIDC provider
 # already exists when the E2E CI setup has been run.
@@ -51,15 +67,18 @@ aws cloudformation deploy --region ap-southeast-1 \
 #   secret   DEPLOY_ENV          = the contents of this .env file
 gh secret set DEPLOY_ENV --env dev < .env
 
-# The workflow is manual and accepts deployments only from main.
-gh workflow run deploy-dev-api.yml --ref main
+# The workflow is manual and accepts runs only from main. It updates an existing
+# stack; initial Runner provisioning is intentionally a separate operation.
+gh workflow run deploy-dev-api.yml --ref main -f apply=false
+gh workflow run deploy-dev-api.yml --ref main -f apply=true
 ```
 
 `OIDC_CLIENT_ID` is required. Other app secrets (SSH keys, Auth0 Management API,
 Svix, PostHog) are optional and set per-stage in the SST secret store — see
 [Secrets & credentials](#secrets--credentials).
 
-First deploy: 10–15 minutes. Output prints service URLs + CloudFront domain.
+A full reconciliation typically takes 10–15 minutes. Output prints service URLs
+and the CloudFront domain.
 
 If a build fails on a transient registry or package-mirror error, rerun the
 workflow — SST resumes from the failed step.
@@ -76,12 +95,27 @@ GitHub `dev` Environment. GitHub OIDC supplies short-lived AWS credentials; no
 AWS access keys are stored in GitHub. `DEPLOY_ENV` materializes the stage's
 gitignored `.env` only for the job and is deleted even if deployment fails.
 
-The current workflow deliberately targets only `Api`; selecting only the API
-also skips the Runner release-asset preflight:
+The workflow first runs deployment safety tests that require every Runner to
+retain `protect: true` and the AMI/user-data ignore rules. It then runs a full
+`sst diff --json` and passes the structured plan through
+`scripts/deployment-preview.mjs`. The gate rejects creating, replacing, or
+deleting a Runner instance and any in-place Runner change other than provider
+association or tags. Workflow dispatch defaults to a preview-only run; set
+`apply=true` only after reviewing it. An apply run repeats the same guarded
+preview before the full-stack deploy:
 
 ```bash
-npm run deploy -- --stage dev --target Api
+npm run deploy -- --stage dev
 ```
+
+Both commands deliberately avoid `--target` and `--exclude`. Pulumi treats both
+as partial updates, which cannot safely migrate a provider while omitted
+resources still reference the old provider. Full reconciliation also avoids
+silently accumulating stack drift. The deployment wrapper rejects partial
+deploy selectors; targeted `diff` remains available for read-only inspection.
+The Runner EC2 identity and binary remain stable through the lifecycle controls
+under [Runner lifecycle](#runner-lifecycle), and the matching release-asset
+preflight always runs before deployment.
 
 The role template grants only the AWS control-plane actions used by this SST
 stack. IAM mutation is limited to `boxlite-*` roles, policies, and instance
@@ -98,20 +132,30 @@ they differ. Keep required reviewers enabled on that Environment.
 Three homes, one access gate — **AWS IAM**. Nothing secret lives in git or a
 single laptop's `.env`:
 
-| What                                                                                                                              | Where                                                                        | Set with                                                                         |
-| --------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| **App secrets** — SSH host/private keys, Auth0 Management API id + secret, `SVIX_AUTH_TOKEN`, `POSTHOG_API_KEY`, `OIDC_CLIENT_ID` | SST secret store (encrypted in SST state, per stage)                         | `npm run sst -- secret set <NAME> "<value>" --stage <stage>`                     |
-| **Cloudflare provider creds** — `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_DEFAULT_ACCOUNT_ID`                                           | AWS SSM (`SecureString`, per stage)                                          | `aws ssm put-parameter --type SecureString --name /boxlite/<stage>/cloudflare-…` |
-| **Stage config** — `STACK_DOMAIN`, `OIDC_ISSUER_BASE_URL`, `OIDC_AUDIENCE`, toggles                                               | GitHub Environment secret `DEPLOY_ENV`; local `.env` is the bootstrap source | `gh secret set DEPLOY_ENV --env dev < .env`                                      |
+| What                                                                                                                              | Where                                                                        | Set with                                                         |
+| --------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| **App secrets** — SSH host/private keys, Auth0 Management API id + secret, `SVIX_AUTH_TOKEN`, `POSTHOG_API_KEY`, `OIDC_CLIENT_ID` | SST secret store (encrypted in SST state, per stage)                         | Non-echoing prompt + SST stdin procedure below                   |
+| **Cloudflare provider creds** — `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_DEFAULT_ACCOUNT_ID`                                           | AWS SSM (`SecureString`, per stage)                                          | Non-echoing prompt + AWS CLI `file:///dev/stdin` procedure above |
+| **Stage config** — `STACK_DOMAIN`, `OIDC_ISSUER_BASE_URL`, `OIDC_AUDIENCE`, toggles                                               | GitHub Environment secret `DEPLOY_ENV`; local `.env` is the bootstrap source | `gh secret set DEPLOY_ENV --env dev < .env`                      |
+
+Grant each API token only the permissions and resources required for its
+documented use; the Cloudflare token needs `Zone:Read` and `DNS:Edit` for the
+managed zone. Rotate tokens regularly and immediately after suspected
+disclosure, updating the value in SSM or the SST secret store. Never put token
+values in command arguments, echo them, enable shell tracing around
+secret-handling commands, or copy secret-bearing logs or workflow output into
+issues.
 
 `VERSION` is optional; it controls the release reported by `/api/config` and
 defaults to the canonical workspace version in `Cargo.toml`.
 
 The Cloudflare creds can't be `sst.Secret`: the provider initializes in `app()`
 before `run()` (where secrets exist), so it reads them from the environment.
-`scripts/sst-with-cloudflare.mjs` — wired into `npm run dev`/`deploy`/`remove`,
+`scripts/sst-with-cloudflare.mjs` — wired into `npm run deploy`/`remove`,
 `npm run secrets`, and `npm run sst` — fetches them from SSM and exports them
-before invoking sst.
+before invoking sst. `sst dev` is disabled for this stateful stack because a
+long-running process cannot refresh the Runner state baseline before every
+update.
 **Run sst through these npm scripts**, not bare `npx sst`, so the creds load.
 SST 4.6.11 exposes no supported deploy option to disable or redact this event
 stream, so the wrapper removes Pulumi's transient
@@ -124,9 +168,12 @@ the stale event log.
 ### App secrets
 
 ```bash
-npm run sst -- secret set SVIX_AUTH_TOKEN "<value>" --stage dev  # set one
-npm run sst -- secret load .env.secrets --stage dev              # bulk-load an ignored secret dotenv
-npm run secrets -- --stage dev                                   # list what's set
+printf 'SVIX auth token: ' >&2
+IFS= read -rs secret_value; printf '\n' >&2
+printf '%s' "$secret_value" | npm run sst -- secret set SVIX_AUTH_TOKEN --stage dev
+unset secret_value
+npm run sst -- secret load .env.secrets --stage dev # bulk-load an ignored secret dotenv
+npm run secrets -- --stage dev                      # list what's set
 ```
 
 Secret names match the env keys the services expect, but values in the ordinary
@@ -141,30 +188,35 @@ Access is **AWS IAM only**: anyone who can deploy (read SST state + SSM, run
 offboard by revoking it. There's no secret file or vault to hand over. Secret
 values and the SSM params are **per-stage** — seed each stage you run.
 
-## After first deploy
+## After deployment
 
-Nothing needs to be fed back into `.env`. The runner EC2 self-registers with the
-API on boot — v2 runners report their address via healthcheck — so boxes
-work as soon as the runner reaches `READY` (~30–60s), visible in the dashboard
-Runner table or `GET /admin/runners`.
+Nothing needs to be fed back into `.env`. Existing Runner EC2 instances
+self-report their addresses through healthchecks and remain visible in the
+dashboard Runner table or `GET /admin/runners`.
 
-### Adding a runner
+### Runner inventory
 
-The default runner is auto-seeded by the API at boot. To run more, set the total
-count and redeploy:
+The default runner is auto-seeded by the API at boot. `RUNNERS` records the
+expected total (1-100), including the default Runner:
 
 ```bash
-echo "RUNNERS=3" >> .env     # default runner (#1) + runner-2 + runner-3
-npm run deploy -- --stage dev
+# Existing inventory: default (#1) + runner-2 + runner-3.
+echo "RUNNERS=3" >> .env
 ```
+
+Routine control-plane deployment requires this inventory to match the current
+SST checkpoint exactly. It will not create a first Runner, scale out, or replace
+a missing Runner. A separately designed and reviewed provisioning operation is
+required so unknown preview-time secrets and network IDs cannot bypass the
+control-plane safety gate; none is implemented in this repository yet.
 
 Each extra runner gets its own EC2 + minted token. Because the API only
 auto-seeds the single default, the extras are registered with the control plane
 by a post-deploy step (`RegisterExtraRunners` in `sst.config.ts`, which runs
 `scripts/register-runners.mjs` against the admin API once the API is healthy).
-It's idempotent — re-running `sst deploy` won't duplicate rows. Scaling **down**
-is the deliberate decommission ceremony under [Runner lifecycle](#runner-lifecycle),
-applied per runner.
+It's idempotent — re-running `sst deploy` won't duplicate rows. Scaling down is
+also excluded from routine deployment; see
+[Runner decommission and recovery](#runner-decommission-and-recovery).
 
 ### Custom system images
 
@@ -188,12 +240,12 @@ URLs must use HTTPS; an HTTP fallback is accepted only on a loopback host.
 
 Four public DNS names, three different fronting layers:
 
-| Hostname                 | Fronted by           | Purpose                                                           |
-| ------------------------ | -------------------- | ----------------------------------------------------------------- |
-| `<STACK_DOMAIN>`         | CloudFront Router    | Dashboard SPA + static assets (cache-friendly, edge-served)       |
-| `api.<STACK_DOMAIN>`     | Api ALB (direct)     | REST API, WebSocket `/attach`, build-log streaming, file transfer |
-| `proxy.<STACK_DOMAIN>`   | Proxy NLB (TLS)      | Port-preview wildcard `<port>-<boxId>.proxy.<domain>`             |
-| `*.proxy.<STACK_DOMAIN>` | Proxy NLB (TLS)      | Wildcard alias of the above (per-box preview hosts)               |
+| Hostname                 | Fronted by        | Purpose                                                           |
+| ------------------------ | ----------------- | ----------------------------------------------------------------- |
+| `<STACK_DOMAIN>`         | CloudFront Router | Dashboard SPA + static assets (cache-friendly, edge-served)       |
+| `api.<STACK_DOMAIN>`     | Api ALB (direct)  | REST API, WebSocket `/attach`, build-log streaming, file transfer |
+| `proxy.<STACK_DOMAIN>`   | Proxy NLB (TLS)   | Port-preview wildcard `<port>-<boxId>.proxy.<domain>`             |
+| `*.proxy.<STACK_DOMAIN>` | Proxy NLB (TLS)   | Wildcard alias of the above (per-box preview hosts)               |
 
 **Why `/api/*` bypasses CloudFront.** CloudFront imposes a non-configurable
 10-minute idle cap on WebSocket connections — even with WS Ping frames and
@@ -333,22 +385,41 @@ For Auth0 specifically:
 | **ClickHouse Cloud** | Managed OTel storage                  | external service; configured by env                                      |
 | **ClickStack**       | Logs/traces/metrics explorer          | external ClickHouse Cloud UI                                             |
 
-Run the `Deploy dev API` workflow again to redeploy the API. See
+Run the `Deploy dev stack` workflow again to redeploy. See
 [Public hostnames](#public-hostnames) below for the rationale behind the
 dashboard-vs-API split.
 
 ## Common commands
 
 ```bash
-gh workflow run deploy-dev-api.yml --ref main # native AMD64 API deployment
+# Preview the protected GitHub deployment environment without mutation.
+gh workflow run deploy-dev-api.yml --ref main -f apply=false
+
+# After the preview passes review, evaluate again and apply the full stack.
+gh workflow run deploy-dev-api.yml --ref main -f apply=true
+
 npm run sst -- diff --stage dev     # preview changes
 npm run sst -- unlock --stage dev   # recover from "concurrent update detected"
 npm run sst -- shell --stage dev    # open shell with SST-linked env vars
-npm run remove -- --stage dev       # requires the Proxy/Runner unprotect procedures
 ```
 
 > The workflow routes deployment through `scripts/sst-with-cloudflare.mjs` so
 > Cloudflare credentials load from SSM. Bare `npx sst …` skips that integration.
+> The wrapper also requires the repository's mandatory Runner policy for every
+> `diff` and `deploy`, and requires the SST subcommand to be the first argument.
+> `sst dev` is disabled.
+> Before each diff or deploy it exports the encrypted SST checkpoint, keeps
+> only a non-secret hash of every non-default Runner input except the four
+> deliberately mutable fields (AMI, user data, declared tags, and
+> provider-expanded tags),
+> and compares current state with desired Runner properties. The current SST
+> CLI cannot save and later apply one exact preview plan, so apply performs a
+> fresh state export and evaluation. The policy blocks every Runner create,
+> unsafe property change, changed protection, or changed identity even if the
+> human-readable preview stream is incomplete. A separate actor can still
+> change backend state between that export and Pulumi acquiring its update lock;
+> the protected Environment
+> and serialized workflow reduce this residual window but cannot eliminate it.
 
 ## Runner lifecycle
 
@@ -380,38 +451,18 @@ capability-gated two-phase rollout:
    requests to Runners at the required version, and each upgraded Runner only
    becomes schedulable after the control plane reports that exact version.
 
-An API-only `--target Api` deployment, or a broader deployment with an explicit
-`--exclude Runner`, is the operator escape hatch for a control-plane-only
-rollout. Either form skips the Runner release-asset preflight and leaves the EC2
-resource and its identity tag untouched. Detached requests that use legacy
-Runner capabilities remain available; requests needing the new Runner version
-fail explicitly until a later full rollout applies the metadata and upgrades
-the binary.
+Routine infrastructure deploys reconcile the full stack. They may update the
+Runner's provider association or tags in place, but the preview gate rejects
+creation, replacement, deletion, or other instance changes. The mandatory
+policy also requires the exact current inventory and identity, `protect: true`,
+only the two intended `ignoreChanges` properties, and equality of all other
+non-default inputs during preview and apply. The EC2 stays in place; a version
+change is delivered during the full deployment by the sequential
+`UpgradeRunnerBinary-*` SSM commands described below.
 
-> Of the two, only `--target Api` also leaves the **binary** alone, because it
-> deploys the API and nothing else. `--exclude Runner` drops just the `Runner`
-> component; the upgrade commands below are separate ones
-> (`UpgradeRunnerBinary-default`, and one per extra Runner), so they still run
-> while the preflight is skipped. That fails closed rather than dangerously — a
-> missing asset stops the download before the unit is touched — but it turns an
-> intentionally Runner-free rollout into a failed deploy. `--target` and
-> `--exclude` cannot be combined, so with that form every generated upgrade
-> command has to be named — one per Runner, not just the default:
->
-> ```bash
-> # RUNNERS=1
-> npm run deploy -- --stage dev --exclude Runner \
->   --exclude UpgradeRunnerBinary-default
->
-> # RUNNERS=3 — extras are UpgradeRunnerBinary-runner-2, -runner-3, … up to RUNNERS
-> npm run deploy -- --stage dev --exclude Runner \
->   --exclude UpgradeRunnerBinary-default \
->   --exclude UpgradeRunnerBinary-runner-2 \
->   --exclude UpgradeRunnerBinary-runner-3
-> ```
->
-> Prefer `--target Api` when you can: it creates no upgrade command at all, so
-> there is no per-Runner bookkeeping to get wrong.
+Detached requests that use legacy Runner capabilities remain available during
+the compatibility window; requests needing the new Runner version fail
+explicitly until the rolling binary upgrade reaches that Runner.
 
 This bounded compatibility window is intentional: silently discarding a
 requested command or foreground lifecycle would be data loss, while sending it
@@ -454,7 +505,7 @@ hand-install. Version ordering understands prereleases: `0.9.10` outranks
 `0.9.9`, and `0.9.8-alpha` is treated as older than `0.9.8`, so promoting a
 prerelease host to the matching release is an upgrade, not a refused downgrade.
 
-To upgrade out of band — after a partial roll, or to pin a version without
+To upgrade out of band — after an interrupted roll, or to pin a version without
 deploying:
 
 ```bash
@@ -472,42 +523,14 @@ ALLOW_DOWNGRADE=1 npm run runner:update -- 0.9.5   # deliberate rollback
 > the deploy path has — so treat any Runner upgrade as disruptive and drain it
 > yourself when that matters.
 
-### Deliberate decommission (multi-step ceremony)
+### Runner decommission and recovery
 
-When you actually need to replace the Runner (failed disk, security incident,
-major version upgrade with on-disk format change), it is a multi-edit
-operation by design:
-
-1. Make the Runner unschedulable first — `PATCH /runners/:id/scheduling` with
-   `unschedulable: true`. Order matters: it is the only flag both placement
-   paths honour, so without it a box can be assigned between the check below
-   and the destroy. `draining` alone will not do, because the warm pool does
-   not consult it.
-2. Verify no `running` boxes are pinned to this Runner (DB query against
-   `box.runnerId`), and leave it unschedulable for the rest of the ceremony.
-3. Edit `sst.config.ts`: change `protect: true` to `protect: false` on the
-   Runner resource. Run `npm run deploy -- --stage <stage>`. This only updates
-   the resource metadata; the EC2 is not yet touched.
-4. Destroy the EC2:
-
-   ```bash
-   npx pulumi destroy --target 'urn:pulumi:<stage>::boxlite::aws:ec2/instance:Instance::Runner'
-   ```
-
-5. Edit `sst.config.ts`: change `protect: false` back to `protect: true`. Run
-   `npm run deploy -- --stage <stage>` again — a new Runner is created with
-   fresh state.
-
-This is deliberate by construction: a cordon, two config edits, two deploys. Around
-that ceremony the control plane offers two independent flags, and they are not
-equivalent. `unschedulable` keeps a Runner out of both placement paths — the
-`findAvailableRunners` filter and the warm-pool candidate query. `draining` is
-narrower: it excludes the Runner from `findAvailableRunners` and sweeps it
-toward decommissioning once its boxes are gone, but the warm-pool query does
-not consult it, so a pre-warmed box can still be assigned there. Nothing sets
-either flag automatically, and the binary upgrade above does not drain the
-Runner it restarts. Neither flag removes the explicit Pulumi protection steps
-required to replace the EC2 resource.
+The routine workflow intentionally does not provision, decommission, or recover
+Runner EC2 instances. Do not change `protect: true` or edit SST state as part of
+a normal deployment. A separate reviewed runbook must cover control-plane
+draining, pinned-box checks, the exact cloud and SST-state operations, and
+post-operation verification before any Runner is removed or recreated. That
+break-glass operation is not implemented in this repository yet.
 
 ## Architecture
 
@@ -617,6 +640,7 @@ service, and the dashboard's configured API base URL.
 | **Total**                             | **~$570** |
 
 Figures are approximate (ap-southeast-1 on-demand). The **Runner and the load
-balancers dominate** — the NAT is ~$16, not a headline cost. Stack removal
-requires the Proxy and Runner unprotect procedures above; S3 buckets and RDS
-snapshots are retained in production (`--stage production`) per SST's default.
+balancers dominate** — the NAT is ~$16, not a headline cost. Whole-stack removal
+requires a separate reviewed Proxy and Runner decommission runbook, which is not
+implemented here. S3 buckets and RDS snapshots are retained in production
+(`--stage production`) per SST's default.

--- a/apps/infra/package-lock.json
+++ b/apps/infra/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@pulumi/aws": "^7.24.0",
+        "@pulumi/policy": "1.21.0",
         "js-yaml": "^4.1.0",
         "sst": "^4.6.11"
       }
@@ -706,6 +707,18 @@
       "dependencies": {
         "@pulumi/pulumi": "^3.142.0",
         "mime": "^2.0.0"
+      }
+    },
+    "node_modules/@pulumi/policy": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@pulumi/policy/-/policy-1.21.0.tgz",
+      "integrity": "sha512-tLczMS7S2UUpc1qO9xvGY54GumUShTNxm/BY/T1fb0Hp/ILScxXzrmLpkbt4KUGZAcX/EdGLVuMGHyhreqbfvg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.10.1",
+        "@pulumi/pulumi": "^3.204.0",
+        "google-protobuf": "^3.21.4"
       }
     },
     "node_modules/@pulumi/pulumi": {

--- a/apps/infra/package.json
+++ b/apps/infra/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "private": true,
   "type": "module",
+  "main": "policies/runner/index.js",
   "scripts": {
-    "dev": "node scripts/sst-with-cloudflare.mjs dev",
     "deploy": "node scripts/sst-with-cloudflare.mjs deploy",
     "remove": "node scripts/sst-with-cloudflare.mjs remove",
     "test": "node --test scripts/*.test.mjs",
@@ -14,6 +14,7 @@
   },
   "devDependencies": {
     "@pulumi/aws": "^7.24.0",
+    "@pulumi/policy": "1.21.0",
     "js-yaml": "^4.1.0",
     "sst": "^4.6.11"
   },

--- a/apps/infra/policies/runner/definitions.cjs
+++ b/apps/infra/policies/runner/definitions.cjs
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+const { resolveRunnerInventory } = require('../../scripts/runner-inventory.cjs')
+const { validateRunnerResource, validateRunnerStack } = require('./validate.cjs')
+
+function reportViolations(violations, reportViolation) {
+  for (const violation of violations) reportViolation(violation)
+}
+
+function createRunnerPolicies(inventory, baseline) {
+  inventory ??= resolveRunnerInventory(process.env)
+  if (!baseline || typeof baseline !== 'object' || Array.isArray(baseline)) {
+    throw new Error('Runner state baseline is required to create Runner policies')
+  }
+  return [
+    {
+      name: 'runner-instance-contract',
+      description: 'Protects every declared Runner instance and preserves its control-plane identity.',
+      enforcementLevel: 'mandatory',
+      validateResource(resource, reportViolation) {
+        reportViolations(validateRunnerResource(resource, inventory, baseline), reportViolation)
+      },
+    },
+    {
+      name: 'runner-inventory-complete',
+      description: 'Requires the previewed stack to contain every declared Runner exactly once.',
+      enforcementLevel: 'mandatory',
+      validateStack(stack, reportViolation) {
+        reportViolations(validateRunnerStack(stack.resources, inventory, baseline), reportViolation)
+      },
+    },
+  ]
+}
+
+module.exports = { createRunnerPolicies }

--- a/apps/infra/policies/runner/index.js
+++ b/apps/infra/policies/runner/index.js
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+import policy from '@pulumi/policy'
+
+import runnerInventoryModule from '../../scripts/runner-inventory.cjs'
+import runnerStateBaselineModule from '../../scripts/runner-state-baseline.cjs'
+import runnerPolicyDefinitions from './definitions.cjs'
+
+const { PolicyPack } = policy
+const { resolveRunnerInventory } = runnerInventoryModule
+const { parseRunnerStateBaseline } = runnerStateBaselineModule
+const { createRunnerPolicies } = runnerPolicyDefinitions
+
+const runnerInventory = resolveRunnerInventory(process.env)
+const serializedRunnerStateBaseline = process.env.BOXLITE_RUNNER_STATE_BASELINE
+if (!serializedRunnerStateBaseline) {
+  throw new Error('BOXLITE_RUNNER_STATE_BASELINE is required')
+}
+const runnerStateBaseline = parseRunnerStateBaseline(serializedRunnerStateBaseline)
+
+new PolicyPack('boxlite-runner-safety', {
+  policies: createRunnerPolicies(runnerInventory, runnerStateBaseline),
+})

--- a/apps/infra/policies/runner/validate.cjs
+++ b/apps/infra/policies/runner/validate.cjs
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+const {
+  CONTROL_PLANE_NAME_TAG,
+  RUNNER_RESOURCE_TYPE,
+  isRunnerLikeResource,
+  resolveRunnerInventory,
+} = require('../../scripts/runner-inventory.cjs')
+const {
+  createRunnerIdentityFingerprint,
+  createRunnerSafetyFingerprint,
+  hasExactIgnoredProperties,
+} = require('../../scripts/runner-state-baseline.cjs')
+
+function readTags(resource) {
+  try {
+    return resource.props?.tags
+  } catch {
+    return undefined
+  }
+}
+
+function readTagsAll(resource) {
+  try {
+    return resource.props?.tagsAll
+  } catch {
+    return undefined
+  }
+}
+
+function readTagValue(tags, key) {
+  try {
+    return tags[key]
+  } catch {
+    return undefined
+  }
+}
+
+function isRunnerCandidate(resource, expectedByResourceName) {
+  return isRunnerLikeResource(
+    {
+      name: resource.name,
+      type: resource.type,
+      properties: { tags: readTags(resource), tagsAll: readTagsAll(resource) },
+    },
+    new Set(expectedByResourceName.keys()),
+  )
+}
+
+function validateRunnerResource(resource, inventory, baseline) {
+  inventory ??= resolveRunnerInventory()
+  const expectedByResourceName = new Map(inventory.map((runner) => [runner.resourceName, runner]))
+  if (!isRunnerCandidate(resource, expectedByResourceName)) return []
+
+  const expected = expectedByResourceName.get(resource.name)
+  if (!expected) {
+    return ['Runner identity is not declared by the deployment inventory.']
+  }
+
+  const violations = []
+  if (resource.type !== RUNNER_RESOURCE_TYPE) {
+    violations.push('Runner resources must remain EC2 instances.')
+  }
+
+  const tags = readTags(resource)
+  const hasExpectedIdentity =
+    tags &&
+    typeof tags === 'object' &&
+    !Array.isArray(tags) &&
+    readTagValue(tags, 'Name') === expected.nameTag &&
+    readTagValue(tags, CONTROL_PLANE_NAME_TAG) === expected.controlPlaneRunnerName
+  if (!hasExpectedIdentity) {
+    violations.push('Runner identity tags must match the deployment inventory.')
+  }
+
+  if (resource.opts?.protect !== true) {
+    violations.push('Runner resources must keep deletion protection enabled.')
+  }
+  if (!hasExactIgnoredProperties(resource.opts?.ignoreChanges)) {
+    violations.push('Runner resources must ignore only AMI and user-data changes.')
+  }
+
+  const currentProperties = baseline?.resources?.[resource.name]
+  if (currentProperties === undefined) {
+    violations.push('Routine deployment must not create a Runner resource.')
+  } else {
+    try {
+      const desiredFingerprint = createRunnerSafetyFingerprint(resource.props)
+      if (desiredFingerprint !== currentProperties.inputFingerprint) {
+        violations.push('Runner protected properties must match the current deployment state.')
+      }
+    } catch {
+      violations.push('Runner protected properties could not be resolved for comparison.')
+    }
+    if (hasExpectedIdentity) {
+      try {
+        const desiredIdentityFingerprint = createRunnerIdentityFingerprint(resource.props, resource.name)
+        if (desiredIdentityFingerprint !== currentProperties.identityFingerprint) {
+          violations.push('Runner identity tags must match the current deployment state.')
+        }
+      } catch {
+        violations.push('Runner identity tags could not be resolved for comparison.')
+      }
+    }
+  }
+
+  return violations
+}
+
+function validateRunnerStack(resources, inventory, baseline) {
+  inventory ??= resolveRunnerInventory()
+  const expectedByResourceName = new Map(inventory.map((runner) => [runner.resourceName, runner]))
+  const resourceCounts = new Map(inventory.map((runner) => [runner.resourceName, 0]))
+  let undeclaredRunnerCount = 0
+
+  for (const resource of resources) {
+    if (!isRunnerCandidate(resource, expectedByResourceName)) continue
+
+    if (resourceCounts.has(resource.name)) {
+      resourceCounts.set(resource.name, resourceCounts.get(resource.name) + 1)
+    } else {
+      undeclaredRunnerCount += 1
+    }
+  }
+
+  const violations = []
+  for (const resourceCount of resourceCounts.values()) {
+    if (resourceCount === 0) violations.push('Runner inventory is missing a declared resource.')
+    if (resourceCount > 1) violations.push('Runner inventory contains a duplicate declared resource.')
+  }
+  if (undeclaredRunnerCount > 0) {
+    violations.push('Runner inventory contains an undeclared resource.')
+  }
+
+  const currentResourceNames = new Set(Object.keys(baseline?.resources ?? {}))
+  const inventoryDiffersFromState =
+    inventory.some((runner) => !currentResourceNames.has(runner.resourceName)) ||
+    [...currentResourceNames].some((name) => !expectedByResourceName.has(name))
+  if (inventoryDiffersFromState) {
+    violations.push('Runner inventory differs from the current deployment state.')
+  }
+
+  return violations
+}
+
+module.exports = { validateRunnerResource, validateRunnerStack }

--- a/apps/infra/scripts/deploy-environment-validation.mjs
+++ b/apps/infra/scripts/deploy-environment-validation.mjs
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+import { readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+
+import { parse } from 'dotenv'
+
+const FORBIDDEN_DEPLOYMENT_KEYS = new Set([
+  'AWS_ACCESS_KEY_ID',
+  'AWS_CLI_PATH',
+  'AWS_CONFIG_FILE',
+  'AWS_CONTAINER_CREDENTIALS_FULL_URI',
+  'AWS_CONTAINER_CREDENTIALS_RELATIVE_URI',
+  'AWS_DEFAULT_PROFILE',
+  'AWS_ENDPOINT_URL',
+  'AWS_PROFILE',
+  'AWS_ROLE_ARN',
+  'AWS_SECRET_ACCESS_KEY',
+  'AWS_SHARED_CREDENTIALS_FILE',
+  'AWS_SESSION_TOKEN',
+  'AWS_WEB_IDENTITY_TOKEN_FILE',
+  'BUILDX_BUILDER',
+  'RUNNER_CREATE_ALLOWLIST',
+  'SST_BIN_PATH',
+])
+
+export function validateDeployEnvironment(source) {
+  for (const [index, rawLine] of source.split(/\r?\n/).entries()) {
+    const line = rawLine.trim()
+    if (line === '' || line.startsWith('#')) continue
+    if (!/^[A-Za-z_][A-Za-z0-9_]*=/.test(line)) {
+      throw new Error(`DEPLOY_ENV contains invalid assignment syntax on line ${index + 1}; expected KEY=value`)
+    }
+  }
+
+  const configuredKeys = Object.keys(parse(source))
+  const forbiddenKeys = configuredKeys
+    .filter((key) => FORBIDDEN_DEPLOYMENT_KEYS.has(key) || key.startsWith('AWS_ENDPOINT_URL_'))
+    .sort()
+  if (forbiddenKeys.length > 0) {
+    throw new Error(
+      `DEPLOY_ENV must rely on workflow OIDC and the native CI builder, and must not define: ${forbiddenKeys.join(', ')}`,
+    )
+  }
+}
+
+async function main(args) {
+  if (args.length !== 1) throw new Error('expected exactly one DEPLOY_ENV file path')
+  validateDeployEnvironment(await readFile(args[0], 'utf8'))
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main(process.argv.slice(2)).catch((error) => {
+    console.error(`deploy-environment-validation: ${error.message}`)
+    process.exitCode = 1
+  })
+}

--- a/apps/infra/scripts/deploy-environment-validation.test.mjs
+++ b/apps/infra/scripts/deploy-environment-validation.test.mjs
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { validateDeployEnvironment } from './deploy-environment-validation.mjs'
+
+test('accepts ordinary dotenv deployment configuration', () => {
+  assert.doesNotThrow(() =>
+    validateDeployEnvironment(`
+STACK_DOMAIN=dev.boxlite.ai
+OIDC_AUDIENCE=https://dev.boxlite.ai/api
+RUNNERS=1
+`),
+  )
+})
+
+test('rejects every forbidden workflow override', () => {
+  const forbiddenAssignments = [
+    'AWS_PROFILE=developer',
+    'AWS_ACCESS_KEY_ID=synthetic-access-key',
+    'AWS_CONFIG_FILE=/tmp/synthetic-aws-config',
+    'AWS_CONTAINER_CREDENTIALS_FULL_URI=https://credentials.invalid',
+    'AWS_CONTAINER_CREDENTIALS_RELATIVE_URI=/synthetic-credentials',
+    'AWS_DEFAULT_PROFILE=developer',
+    'AWS_ENDPOINT_URL=https://aws.invalid',
+    'AWS_ENDPOINT_URL_S3=https://s3.invalid',
+    'AWS_ROLE_ARN=arn:aws:iam::123456789012:role/synthetic',
+    'AWS_SECRET_ACCESS_KEY=synthetic-secret-key',
+    'AWS_SHARED_CREDENTIALS_FILE=/tmp/synthetic-aws-credentials',
+    'AWS_SESSION_TOKEN="synthetic-session-token"',
+    'AWS_WEB_IDENTITY_TOKEN_FILE=/tmp/synthetic-web-identity-token',
+    'AWS_CLI_PATH=/opt/local/bin/aws',
+    'BUILDX_BUILDER=laptop-builder',
+    'RUNNER_CREATE_ALLOWLIST=Runner',
+    'SST_BIN_PATH=/tmp/synthetic-sst',
+  ]
+
+  for (const assignment of forbiddenAssignments) {
+    const secretValue = assignment.split('=', 2)[1].replaceAll('"', '')
+    assert.throws(
+      () => validateDeployEnvironment(assignment),
+      (error) => {
+        assert.match(error.message, /DEPLOY_ENV must rely on workflow OIDC/)
+        assert.equal(error.message.includes(secretValue), false)
+        return true
+      },
+    )
+  }
+})
+
+test('rejects non-canonical dotenv assignments before parsing', () => {
+  const invalidAssignments = [
+    'export AWS_SECRET_ACCESS_KEY:synthetic-secret-key',
+    'export AWS_SECRET_ACCESS_KEY = synthetic-secret-key',
+    'AWS_ACCESS_KEY_ID: synthetic-access-key',
+    'AWS_PROFILE : developer',
+  ]
+
+  for (const assignment of invalidAssignments) {
+    const secretValue = assignment.split(/\s*(?:=|:)\s*/, 2)[1]
+    assert.throws(
+      () => validateDeployEnvironment(assignment),
+      (error) => {
+        assert.match(error.message, /DEPLOY_ENV contains invalid assignment syntax on line 1/)
+        assert.equal(error.message.includes(secretValue), false)
+        return true
+      },
+    )
+  }
+})

--- a/apps/infra/scripts/deployment-preview.mjs
+++ b/apps/infra/scripts/deployment-preview.mjs
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+import { fileURLToPath } from 'node:url'
+import { resolve } from 'node:path'
+
+import runnerInventory from './runner-inventory.cjs'
+
+const { isRunnerLikeResource } = runnerInventory
+
+const MAX_PREVIEW_BYTES = 32 * 1024 * 1024
+
+function resourceName(urn) {
+  return urn.slice(urn.lastIndexOf('::') + 2)
+}
+
+function isAllowedRunnerUpdatePath(path) {
+  return (
+    path === '__provider' ||
+    path === 'tags' ||
+    path.startsWith('tags.') ||
+    path.startsWith('tags[') ||
+    path === 'tagsAll' ||
+    path.startsWith('tagsAll.') ||
+    path.startsWith('tagsAll[')
+  )
+}
+
+export function validateDeploymentPreview(rawPreview) {
+  let changes
+  try {
+    changes = JSON.parse(rawPreview)
+  } catch (error) {
+    throw new Error(`SST deployment preview is not valid JSON: ${error.message}`)
+  }
+  if (!Array.isArray(changes)) throw new Error('SST deployment preview must be a JSON array')
+
+  const runnerUpdates = []
+  const unsafeRunnerChanges = []
+
+  for (const [index, change] of changes.entries()) {
+    if (
+      !change ||
+      typeof change !== 'object' ||
+      typeof change.op !== 'string' ||
+      typeof change.urn !== 'string' ||
+      typeof change.type !== 'string'
+    ) {
+      throw new Error(`SST deployment preview entry ${index} is not a valid resource change`)
+    }
+
+    const name = resourceName(change.urn)
+    const isRunner =
+      isRunnerLikeResource({ name, type: change.type, properties: change.old?.inputs }) ||
+      isRunnerLikeResource({ name, type: change.type, properties: change.new?.inputs })
+    if (!isRunner) continue
+
+    const paths = Object.keys(change.detailedDiff ?? {})
+    const isSafeUpdate =
+      change.op === 'update' &&
+      change.new?.protect === true &&
+      paths.length > 0 &&
+      paths.every(isAllowedRunnerUpdatePath)
+
+    if (!isSafeUpdate) {
+      unsafeRunnerChanges.push(`${name}: ${change.op} (${paths.join(', ') || 'no detailed diff'})`)
+      continue
+    }
+    runnerUpdates.push({ name, paths })
+  }
+
+  if (unsafeRunnerChanges.length > 0) {
+    throw new Error(`unsafe Runner deployment plan: ${unsafeRunnerChanges.join('; ')}`)
+  }
+
+  return { changeCount: changes.length, runnerUpdates }
+}
+
+async function readPreviewFromStdin() {
+  process.stdin.setEncoding('utf8')
+  let rawPreview = ''
+  let previewBytes = 0
+
+  for await (const chunk of process.stdin) {
+    previewBytes += Buffer.byteLength(chunk)
+    if (previewBytes > MAX_PREVIEW_BYTES) {
+      throw new Error(`SST deployment preview exceeds ${MAX_PREVIEW_BYTES} bytes`)
+    }
+    rawPreview += chunk
+  }
+  return rawPreview
+}
+
+async function main() {
+  const preview = validateDeploymentPreview(await readPreviewFromStdin())
+  console.log(`deployment-preview: ${preview.changeCount} planned resource change(s) passed the Runner safety gate`)
+  for (const update of preview.runnerUpdates) {
+    console.log(`deployment-preview: ${update.name} has a safe in-place update (${update.paths.join(', ')})`)
+  }
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    await main()
+  } catch (error) {
+    console.error(`deployment-preview: ${error.message}`)
+    process.exitCode = 1
+  }
+}

--- a/apps/infra/scripts/deployment-preview.test.mjs
+++ b/apps/infra/scripts/deployment-preview.test.mjs
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { validateDeploymentPreview } from './deployment-preview.mjs'
+
+const runnerChange = ({
+  name = 'Runner',
+  op = 'update',
+  detailedDiff = { __provider: { diffKind: 'update', inputDiff: true } },
+  protect = true,
+} = {}) => ({
+  op,
+  urn: `urn:pulumi:dev::boxlite::aws:ec2/instance:Instance::${name}`,
+  type: 'aws:ec2/instance:Instance',
+  old: { protect: true },
+  new: { protect },
+  detailedDiff,
+})
+
+test('accepts provider and tag-only updates to protected Runner instances', () => {
+  const preview = [
+    {
+      op: 'replace',
+      urn: 'urn:pulumi:dev::boxlite::aws:ecs/service:Service::ApiService',
+      type: 'aws:ecs/service:Service',
+      old: { protect: false },
+      new: { protect: false },
+      detailedDiff: {},
+    },
+    runnerChange({
+      detailedDiff: {
+        __provider: { diffKind: 'update', inputDiff: true },
+        'tags["boxlite:control-plane-runner-name"]': { diffKind: 'add', inputDiff: true },
+        'tagsAll["boxlite:control-plane-runner-name"]': { diffKind: 'add', inputDiff: false },
+      },
+    }),
+    runnerChange({ name: 'Runner-runner-2', detailedDiff: { tags: { diffKind: 'update', inputDiff: true } } }),
+  ]
+
+  assert.deepEqual(validateDeploymentPreview(JSON.stringify(preview)), {
+    changeCount: 3,
+    runnerUpdates: [
+      {
+        name: 'Runner',
+        paths: [
+          '__provider',
+          'tags["boxlite:control-plane-runner-name"]',
+          'tagsAll["boxlite:control-plane-runner-name"]',
+        ],
+      },
+      { name: 'Runner-runner-2', paths: ['tags'] },
+    ],
+  })
+})
+
+test('rejects Runner creates even when they are protected', () => {
+  const create = runnerChange({ name: 'Runner-runner-2', op: 'create' })
+
+  assert.throws(() => validateDeploymentPreview(JSON.stringify([create])), /unsafe Runner deployment plan/)
+  assert.throws(
+    () => validateDeploymentPreview(JSON.stringify([{ ...create, new: { protect: false } }])),
+    /unsafe Runner deployment plan/,
+  )
+})
+
+test('rejects disruptive or unexplained Runner operations', () => {
+  const unsafeChanges = [
+    runnerChange({ op: 'replace' }),
+    runnerChange({ op: 'delete', protect: false }),
+    runnerChange({ name: 'Runner-runner-2', op: 'create' }),
+    { ...runnerChange({ op: 'replace' }), type: 'aws:ec2/launchTemplate:LaunchTemplate' },
+    {
+      ...runnerChange({ name: 'Canary', op: 'create' }),
+      new: { protect: true, inputs: { tags: { Name: 'boxlite-runner-3' } } },
+    },
+    runnerChange({ detailedDiff: { instanceType: { diffKind: 'update', inputDiff: true } } }),
+    runnerChange({ detailedDiff: {} }),
+  ]
+
+  for (const change of unsafeChanges) {
+    assert.throws(() => validateDeploymentPreview(JSON.stringify([change])), /unsafe Runner deployment plan/)
+  }
+})
+
+test('rejects malformed SST diff output', () => {
+  assert.throws(() => validateDeploymentPreview('not JSON'), /valid JSON/)
+  assert.throws(() => validateDeploymentPreview('{}'), /JSON array/)
+  assert.throws(() => validateDeploymentPreview('[{"op":"update"}]'), /valid resource change/)
+})

--- a/apps/infra/scripts/deployment-scope.mjs
+++ b/apps/infra/scripts/deployment-scope.mjs
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const PARTIAL_DEPLOY_SELECTOR = /^--(?:target|exclude)(?:=|$)/
+const RUNNER_POLICY_ROOT = resolve(fileURLToPath(new URL('..', import.meta.url)))
+const RUNNER_POLICY_SUBCOMMANDS = new Set(['diff', 'deploy'])
+
+export function requireSstSubcommandFirst(args) {
+  if (!args[0] || args[0].startsWith('-')) {
+    throw new Error('the SST subcommand must be the first argument so deployment safety checks cannot be bypassed')
+  }
+  if (args[0] === 'dev') {
+    throw new Error('sst dev is disabled for this stateful stack; use a fresh guarded diff and deploy instead')
+  }
+  if (RUNNER_POLICY_SUBCOMMANDS.has(args[0]) && args.includes('--')) {
+    throw new Error('the -- argument delimiter is disabled for guarded SST diff and deploy commands')
+  }
+}
+
+export function requireFullStackDeploy(args) {
+  if (args[0] !== 'deploy') return
+
+  const selector = args.find((argument) => PARTIAL_DEPLOY_SELECTOR.test(argument))
+  if (selector) {
+    throw new Error(
+      `partial SST deploys are disabled (${selector}); run a full deploy so provider state and resources reconcile together`,
+    )
+  }
+}
+
+export function withRequiredRunnerPolicy(args, workingDirectory = process.cwd()) {
+  if (!RUNNER_POLICY_SUBCOMMANDS.has(args[0])) return [...args]
+
+  const policyArguments = []
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index]
+    if (argument === '--policy') {
+      const value = args[index + 1]
+      const hasValue = value !== undefined && !value.startsWith('--')
+      policyArguments.push({ index, valueIndex: hasValue ? index + 1 : undefined, value: hasValue ? value : undefined })
+      if (hasValue) index += 1
+    } else if (argument.startsWith('--policy=')) {
+      policyArguments.push({ index, value: argument.slice('--policy='.length) })
+    }
+  }
+
+  if (policyArguments.length > 1) {
+    throw new Error('the Runner policy must be specified exactly once')
+  }
+  if (policyArguments.length === 0) {
+    return [...args, '--policy', RUNNER_POLICY_ROOT]
+  }
+
+  const [policyArgument] = policyArguments
+  if (!policyArgument.value || resolve(workingDirectory, policyArgument.value) !== RUNNER_POLICY_ROOT) {
+    throw new Error(`the Runner policy path must be ${RUNNER_POLICY_ROOT}`)
+  }
+
+  const normalizedArgs = [...args]
+  if (policyArgument.valueIndex === undefined) {
+    normalizedArgs[policyArgument.index] = `--policy=${RUNNER_POLICY_ROOT}`
+  } else {
+    normalizedArgs[policyArgument.valueIndex] = RUNNER_POLICY_ROOT
+  }
+  return normalizedArgs
+}

--- a/apps/infra/scripts/deployment-scope.test.mjs
+++ b/apps/infra/scripts/deployment-scope.test.mjs
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+import assert from 'node:assert/strict'
+import { resolve } from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+import { requireFullStackDeploy, requireSstSubcommandFirst, withRequiredRunnerPolicy } from './deployment-scope.mjs'
+
+const RUNNER_POLICY_ROOT = resolve(fileURLToPath(new URL('..', import.meta.url)))
+
+test('always injects the repository Runner policy root', () => {
+  assert.deepEqual(withRequiredRunnerPolicy(['deploy', '--stage', 'dev'], '/untrusted/working-directory'), [
+    'deploy',
+    '--stage',
+    'dev',
+    '--policy',
+    RUNNER_POLICY_ROOT,
+  ])
+})
+
+test('rejects flag-first SST syntax so deployment guards cannot be bypassed', () => {
+  assert.doesNotThrow(() => requireSstSubcommandFirst(['deploy', '--stage', 'dev']))
+  assert.throws(
+    () => requireSstSubcommandFirst(['--stage', 'dev', 'deploy', '--target', 'Api']),
+    /subcommand must be the first argument/,
+  )
+  assert.throws(() => requireSstSubcommandFirst(['dev']), /sst dev is disabled/)
+  assert.throws(() => requireSstSubcommandFirst(['dev', '--', 'next', 'dev']), /sst dev is disabled/)
+  assert.throws(() => requireSstSubcommandFirst(['diff', '--stage', 'dev', '--']), /argument delimiter is disabled/)
+  assert.throws(() => requireSstSubcommandFirst(['deploy', '--', '--policy', '.']), /argument delimiter is disabled/)
+})
+
+test('accepts full-stack deploys and read-only targeted diffs', () => {
+  assert.doesNotThrow(() => requireFullStackDeploy(['deploy', '--stage', 'dev']))
+  assert.doesNotThrow(() => requireFullStackDeploy(['diff', '--stage', 'dev', '--target', 'Api']))
+})
+
+test('rejects every partial deploy selector form before SST runs', () => {
+  for (const args of [
+    ['deploy', '--stage', 'dev', '--target', 'Api'],
+    ['deploy', '--stage', 'dev', '--target=Api'],
+    ['deploy', '--stage', 'dev', '--exclude', 'Runner'],
+    ['deploy', '--stage', 'dev', '--exclude=Runner'],
+  ]) {
+    assert.throws(() => requireFullStackDeploy(args), /partial SST deploys are disabled/)
+  }
+})
+
+test('requires the repository Runner policy for every preview and deploy', () => {
+  assert.deepEqual(withRequiredRunnerPolicy(['diff', '--stage', 'dev'], RUNNER_POLICY_ROOT), [
+    'diff',
+    '--stage',
+    'dev',
+    '--policy',
+    RUNNER_POLICY_ROOT,
+  ])
+  assert.deepEqual(withRequiredRunnerPolicy(['deploy', '--stage', 'dev', '--policy=.'], RUNNER_POLICY_ROOT), [
+    'deploy',
+    '--stage',
+    'dev',
+    `--policy=${RUNNER_POLICY_ROOT}`,
+  ])
+  assert.deepEqual(withRequiredRunnerPolicy(['state', 'export', '--stage', 'dev'], RUNNER_POLICY_ROOT), [
+    'state',
+    'export',
+    '--stage',
+    'dev',
+  ])
+
+  assert.throws(
+    () => withRequiredRunnerPolicy(['deploy', '--stage', 'dev', '--policy', '../other-policy'], RUNNER_POLICY_ROOT),
+    /Runner policy.*must be/,
+  )
+  assert.throws(
+    () => withRequiredRunnerPolicy(['diff', '--policy', '.', '--policy=.'], RUNNER_POLICY_ROOT),
+    /Runner policy.*exactly once/,
+  )
+
+  for (const args of [
+    ['diff', '--policy'],
+    ['diff', '--policy='],
+    ['deploy', '--policy', '.', '--policy', '.'],
+  ]) {
+    assert.throws(() => withRequiredRunnerPolicy(args, RUNNER_POLICY_ROOT), /Runner policy/)
+  }
+})
+
+test('resolves relative Runner policy paths from the supplied working directory', () => {
+  const workingDirectory = resolve(RUNNER_POLICY_ROOT, 'scripts')
+
+  assert.deepEqual(withRequiredRunnerPolicy(['deploy', '--stage', 'dev', '--policy', '..'], workingDirectory), [
+    'deploy',
+    '--stage',
+    'dev',
+    '--policy',
+    RUNNER_POLICY_ROOT,
+  ])
+})

--- a/apps/infra/scripts/release-deployment-safety.test.mjs
+++ b/apps/infra/scripts/release-deployment-safety.test.mjs
@@ -145,11 +145,25 @@ test('manual dev deployment previews and reconciles the full stack in guarded Gi
   assert.ok(installStep, 'the SST provider installation step is missing')
   assert.equal(installStep.run, 'npm run --silent sst -- install --stage dev')
   assert.ok(previewStep, 'the full-stack preview step is missing')
-  assert.match(previewStep.run, /npm run --silent sst -- diff --stage dev --policy \. --json/)
-  assert.match(previewStep.run, /node scripts\/deployment-preview\.mjs/)
+  assert.equal(previewStep.if, undefined, 'Preview validation must not be conditional')
+  assert.equal(previewStep['continue-on-error'], undefined, 'Preview failures must stop deployment')
+  assert.equal(previewStep.shell, 'bash')
+  assert.equal(
+    previewStep.run,
+    [
+      'set -euo pipefail',
+      'npm run --silent sst -- diff --stage dev --policy . --json |',
+      '  node scripts/deployment-preview.mjs',
+      '',
+    ].join('\n'),
+  )
   assert.ok(deployStep, 'the full-stack deployment step is missing')
   assert.equal(deployStep.if, '${{ inputs.apply }}')
   assert.equal(deployStep.run, 'npm run deploy -- --stage dev --policy .')
+  assert.ok(
+    workflow.jobs.deploy.steps.indexOf(previewStep) < workflow.jobs.deploy.steps.indexOf(deployStep),
+    'Preview validation must complete before deployment',
+  )
   assert.ok(
     workflow.jobs.deploy.steps.indexOf(safetyTestStep) < workflow.jobs.deploy.steps.indexOf(previewStep),
     'Runner lifecycle contracts must be tested before the deployment preview',

--- a/apps/infra/scripts/release-deployment-safety.test.mjs
+++ b/apps/infra/scripts/release-deployment-safety.test.mjs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 BoxLite AI
 
 import assert from 'node:assert/strict'
+import { createRequire } from 'node:module'
 import { existsSync, readFileSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -10,7 +11,10 @@ import { DEFAULT_SCHEMA, Type, load } from 'js-yaml'
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..')
 const SST_WRAPPER = join(REPO_ROOT, 'apps/infra/scripts/sst-with-cloudflare.mjs')
-const DEV_API_DEPLOY_WORKFLOW = join(REPO_ROOT, '.github/workflows/deploy-dev-api.yml')
+const RUNNER_POLICY_PROJECT = join(REPO_ROOT, 'apps/infra/PulumiPolicy.yaml')
+const RUNNER_POLICY_ENTRY = join(REPO_ROOT, 'apps/infra/policies/runner/index.js')
+const RUNNER_POLICY_DEFINITIONS = join(REPO_ROOT, 'apps/infra/policies/runner/definitions.cjs')
+const DEV_DEPLOY_WORKFLOW = join(REPO_ROOT, '.github/workflows/deploy-dev-api.yml')
 const LINT_WORKFLOW = join(REPO_ROOT, '.github/workflows/lint.yml')
 const DEV_DEPLOY_ROLE = join(REPO_ROOT, 'apps/infra/ci/github-deploy-role.yaml')
 const CLOUDFORMATION_SCHEMA = DEFAULT_SCHEMA.extend([
@@ -27,6 +31,7 @@ const CLOUDFORMATION_SCHEMA = DEFAULT_SCHEMA.extend([
     construct: (value) => value,
   }),
 ])
+const requireFromTest = createRequire(import.meta.url)
 
 function readRuntimeBoundaryStatements() {
   const template = load(readFileSync(DEV_DEPLOY_ROLE, 'utf8'), { schema: CLOUDFORMATION_SCHEMA })
@@ -48,6 +53,37 @@ test('SST deploy verifies Runner release assets before invoking SST', () => {
   assert.notEqual(preflightIndex, -1, 'the Runner release preflight is missing')
   assert.notEqual(sstIndex, -1, 'the guarded SST invocation is missing')
   assert.ok(preflightIndex < sstIndex, 'SST may run before Runner release availability is known')
+  assert.doesNotMatch(source, /isSstComponentExcluded/)
+  assert.match(source, /requireFullStackDeploy\(sstArgs\)/)
+  assert.match(source, /withRequiredRunnerPolicy\(sstArgs\)/)
+  assert.doesNotMatch(source, /RUNNER_POLICY_ROOT/)
+})
+
+test('preview and deploy use the mandatory local Runner policy', () => {
+  assert.ok(existsSync(RUNNER_POLICY_PROJECT), 'PulumiPolicy.yaml is missing')
+  assert.ok(existsSync(RUNNER_POLICY_ENTRY), 'the Runner policy entry point is missing')
+  assert.ok(existsSync(RUNNER_POLICY_DEFINITIONS), 'the Runner policy definitions are missing')
+  assert.deepEqual(load(readFileSync(RUNNER_POLICY_PROJECT, 'utf8')), {
+    runtime: 'nodejs',
+    main: 'policies/runner/index.js',
+    description: 'Mandatory BoxLite Runner lifecycle and identity policy',
+  })
+
+  const policySource = readFileSync(RUNNER_POLICY_ENTRY, 'utf8')
+  const policyDefinitions = readFileSync(RUNNER_POLICY_DEFINITIONS, 'utf8')
+  assert.match(policySource, /new PolicyPack\('boxlite-runner-safety'/)
+  assert.match(policySource, /serializedRunnerStateBaseline = process\.env\.BOXLITE_RUNNER_STATE_BASELINE/)
+  assert.match(policySource, /parseRunnerStateBaseline\(serializedRunnerStateBaseline\)/)
+  assert.match(policySource, /policies: createRunnerPolicies\(runnerInventory, runnerStateBaseline\)/)
+  assert.equal(policyDefinitions.match(/enforcementLevel: 'mandatory'/g)?.length, 2)
+
+  const packageJson = JSON.parse(readFileSync(join(REPO_ROOT, 'apps/infra/package.json'), 'utf8'))
+  const packageLock = JSON.parse(readFileSync(join(REPO_ROOT, 'apps/infra/package-lock.json'), 'utf8'))
+  assert.equal(packageJson.main, 'policies/runner/index.js')
+  assert.ok(existsSync(join(REPO_ROOT, 'apps/infra', packageJson.main)), 'the Node policy entry point is missing')
+  assert.equal(requireFromTest.resolve(join(REPO_ROOT, 'apps/infra')), RUNNER_POLICY_ENTRY)
+  assert.equal(packageJson.devDependencies['@pulumi/policy'], '1.21.0')
+  assert.equal(packageLock.packages[''].devDependencies['@pulumi/policy'], '1.21.0')
 })
 
 test('SST deploy does not depend on a laptop-managed remote builder', () => {
@@ -67,13 +103,24 @@ test('SST deploy does not depend on a laptop-managed remote builder', () => {
   }
 })
 
-test('manual dev API deployment runs natively in guarded GitHub CI', () => {
-  assert.ok(existsSync(DEV_API_DEPLOY_WORKFLOW), 'the dev API deployment workflow is missing')
-  const source = readFileSync(DEV_API_DEPLOY_WORKFLOW, 'utf8')
+test('manual dev deployment previews and reconciles the full stack in guarded GitHub CI', () => {
+  assert.ok(existsSync(DEV_DEPLOY_WORKFLOW), 'the dev stack deployment workflow is missing')
+  const source = readFileSync(DEV_DEPLOY_WORKFLOW, 'utf8')
   const workflow = load(source)
-  const deployStep = workflow.jobs.deploy.steps.find((step) => step.name === 'Deploy the API only')
+  const safetyTestStep = workflow.jobs.deploy.steps.find((step) => step.name === 'Run deployment safety tests')
+  const materializeStep = workflow.jobs.deploy.steps.find((step) => step.name === 'Materialize stage configuration')
+  const installStep = workflow.jobs.deploy.steps.find((step) => step.name === 'Install SST providers')
+  const previewStep = workflow.jobs.deploy.steps.find((step) => step.name === 'Preview the full stack')
+  const deployStep = workflow.jobs.deploy.steps.find((step) => step.name === 'Deploy the full stack')
 
   assert.match(source, /workflow_dispatch:/)
+  assert.deepEqual(workflow.on.workflow_dispatch.inputs.apply, {
+    description: 'Preview again, then deploy the full stack',
+    required: true,
+    default: false,
+    type: 'boolean',
+  })
+  assert.equal(workflow.on.workflow_dispatch.inputs.runner_create_allowlist, undefined)
   assert.match(source, /if: github\.ref == 'refs\/heads\/main'/)
   assert.match(source, /environment: dev/)
   assert.match(source, /id-token: write/)
@@ -83,15 +130,52 @@ test('manual dev API deployment runs natively in guarded GitHub CI', () => {
   assert.match(source, /aws-actions\/configure-aws-credentials@/)
   assert.match(source, /role-to-assume: \$\{\{ vars\.AWS_DEPLOY_ROLE_ARN \}\}/)
   assert.match(source, /secrets\.DEPLOY_ENV/)
-  assert.match(source, /AWS_ACCESS_KEY_ID[\s\S]*native CI builder/)
-  assert.ok(deployStep, 'the API deployment step is missing')
-  assert.equal(deployStep.run, 'npm run deploy -- --stage dev --target Api')
+  assert.equal(workflow.jobs.deploy.env.RUNNER_CREATE_ALLOWLIST, undefined)
+  assert.match(source, /node apps\/infra\/scripts\/deploy-environment-validation\.mjs apps\/infra\/\.env/)
+  assert.doesNotMatch(materializeStep.run, /grep/)
+  assert.ok(safetyTestStep, 'the deployment safety test step is missing')
+  assert.equal(safetyTestStep.run, 'npm test')
+  assert.ok(materializeStep, 'the stage configuration step is missing')
+  const materializeConfigIndex = materializeStep.run.indexOf('printf \'%s\\n\' "$DEPLOY_ENV" > apps/infra/.env')
+  const validateConfigIndex = materializeStep.run.indexOf(
+    'node apps/infra/scripts/deploy-environment-validation.mjs apps/infra/.env',
+  )
+  assert.notEqual(materializeConfigIndex, -1, 'the stage configuration is not materialized')
+  assert.ok(validateConfigIndex > materializeConfigIndex, 'DEPLOY_ENV must be validated after it is materialized')
+  assert.ok(installStep, 'the SST provider installation step is missing')
+  assert.equal(installStep.run, 'npm run --silent sst -- install --stage dev')
+  assert.ok(previewStep, 'the full-stack preview step is missing')
+  assert.match(previewStep.run, /npm run --silent sst -- diff --stage dev --policy \. --json/)
+  assert.match(previewStep.run, /node scripts\/deployment-preview\.mjs/)
+  assert.ok(deployStep, 'the full-stack deployment step is missing')
+  assert.equal(deployStep.if, '${{ inputs.apply }}')
+  assert.equal(deployStep.run, 'npm run deploy -- --stage dev --policy .')
+  assert.ok(
+    workflow.jobs.deploy.steps.indexOf(safetyTestStep) < workflow.jobs.deploy.steps.indexOf(previewStep),
+    'Runner lifecycle contracts must be tested before the deployment preview',
+  )
+  assert.ok(
+    workflow.jobs.deploy.steps.indexOf(materializeStep) < workflow.jobs.deploy.steps.indexOf(installStep) &&
+      workflow.jobs.deploy.steps.indexOf(installStep) < workflow.jobs.deploy.steps.indexOf(previewStep),
+    'SST providers must be installed after stage config and before the deployment preview',
+  )
+  assert.doesNotMatch(`${previewStep.run}\n${deployStep.run}`, /--(?:target|exclude)(?:[=\s]|$)/)
   assert.doesNotMatch(source, /setup-qemu/)
+})
+
+test('package scripts disable long-running SST dev for the stateful stack', () => {
+  const packageJson = JSON.parse(readFileSync(join(REPO_ROOT, 'apps/infra/package.json'), 'utf8'))
+
+  assert.equal(packageJson.scripts.dev, undefined)
 })
 
 test('infrastructure tests cannot persist or write with the workflow token', () => {
   const source = readFileSync(LINT_WORKFLOW, 'utf8')
-  const infraJob = source.slice(source.indexOf('\n  infra:\n'), source.indexOf('  # Single required status check'))
+  const infraJobStart = source.indexOf('\n  infra:\n')
+  const infraJobEnd = source.indexOf('  # Single required status check', infraJobStart)
+  assert.notEqual(infraJobStart, -1, 'infra job marker is missing from lint.yml')
+  assert.notEqual(infraJobEnd, -1, 'required-status marker is missing from lint.yml')
+  const infraJob = source.slice(infraJobStart, infraJobEnd)
 
   assert.match(infraJob, /permissions:\s+contents: read/)
   assert.match(infraJob, /uses: actions\/checkout@v5\s+with:\s+persist-credentials: false/)
@@ -150,13 +234,7 @@ test('dev deploy role trusts only the repository GitHub Environment identity', (
   assert.deepEqual(findStatement(statements, 'BoxLiteBucketObjects'), {
     Sid: 'BoxLiteBucketObjects',
     Effect: 'Allow',
-    Action: [
-      's3:AbortMultipartUpload',
-      's3:DeleteObject',
-      's3:DeleteObjectVersion',
-      's3:GetObject',
-      's3:PutObject',
-    ],
+    Action: ['s3:AbortMultipartUpload', 's3:DeleteObject', 's3:DeleteObjectVersion', 's3:GetObject', 's3:PutObject'],
     Resource: [
       'arn:${AWS::Partition}:s3:::boxlite-${GitHubEnvironment}-*/*',
       'arn:${AWS::Partition}:s3:::boxlite-volume-*/*',
@@ -169,6 +247,9 @@ test('SST preflights the workspace Runner artifact even when VERSION overrides t
 
   assert.match(source, /const workspaceVersion = readWorkspaceVersion\(\)/)
   assert.match(source, /resolvePublicDeploymentConfig\(process\.env, workspaceVersion\)/)
-  assert.match(source, /await verifyRunnerReleaseAssets\(workspaceVersion\)/)
+  assert.match(
+    source,
+    /await verifyRunnerReleaseAssets\(workspaceVersion, \{ signal: runnerReleasePreflightAbortController\.signal \}\)/,
+  )
   assert.doesNotMatch(source, /verifyRunnerReleaseAssets\(publicDeploymentConfig\.releaseVersion\)/)
 })

--- a/apps/infra/scripts/runner-inventory.cjs
+++ b/apps/infra/scripts/runner-inventory.cjs
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+const MAX_RUNNER_COUNT = 100
+const RUNNER_NAME_PATTERN = /^[a-zA-Z0-9_.-]+$/
+const RUNNER_RESOURCE_TYPE = 'aws:ec2/instance:Instance'
+const RUNNER_RESOURCE_NAME_PATTERN = /^Runner(?:-runner-[1-9][0-9]*)?$/
+const RUNNER_RESOURCE_CANDIDATE_PATTERN = /^Runner(?:-|$)/
+const CONTROL_PLANE_NAME_TAG = 'boxlite:control-plane-runner-name'
+
+function hasRunnerIdentityTags(properties) {
+  for (const tags of [properties?.tags, properties?.tagsAll]) {
+    if (!tags || typeof tags !== 'object' || Array.isArray(tags)) continue
+    if (typeof tags.Name === 'string' && tags.Name.startsWith('boxlite-runner-')) return true
+    if (Object.prototype.hasOwnProperty.call(tags, CONTROL_PLANE_NAME_TAG)) return true
+  }
+  return false
+}
+
+function isRunnerLikeResource({ name, type, properties }, expectedResourceNames = new Set()) {
+  if (expectedResourceNames.has(name) || RUNNER_RESOURCE_CANDIDATE_PATTERN.test(name || '')) return true
+  return type === RUNNER_RESOURCE_TYPE && hasRunnerIdentityTags(properties)
+}
+
+function resolveRunnerCount(configuredCount) {
+  const runnerCount = configuredCount || '1'
+  if (!/^[1-9][0-9]*$/.test(runnerCount)) {
+    throw new Error(`RUNNERS must be an integer between 1 and ${MAX_RUNNER_COUNT}`)
+  }
+
+  const parsedCount = Number(runnerCount)
+  if (!Number.isSafeInteger(parsedCount) || parsedCount > MAX_RUNNER_COUNT) {
+    throw new Error(`RUNNERS must be an integer between 1 and ${MAX_RUNNER_COUNT}`)
+  }
+  return parsedCount
+}
+
+function requireValidRunnerName(name) {
+  if (name.length < 2 || name.length > 255 || !RUNNER_NAME_PATTERN.test(name)) {
+    throw new Error(
+      'DEFAULT_RUNNER_NAME must be 2-255 characters containing only letters, numbers, underscores, periods, and hyphens',
+    )
+  }
+}
+
+function resolveRunnerInventory(environment = process.env) {
+  const totalRunners = resolveRunnerCount(environment.RUNNERS)
+  const defaultRunnerName = environment.DEFAULT_RUNNER_NAME || 'default'
+  requireValidRunnerName(defaultRunnerName)
+
+  const inventory = Array.from({ length: totalRunners }, (_, offset) => {
+    const index = offset + 1
+    if (index === 1) {
+      return {
+        resourceName: 'Runner',
+        nameTag: 'boxlite-runner-default',
+        controlPlaneRunnerName: defaultRunnerName,
+      }
+    }
+
+    return {
+      resourceName: `Runner-runner-${index}`,
+      nameTag: `boxlite-runner-${index}`,
+      controlPlaneRunnerName: `runner-${index}`,
+    }
+  })
+
+  const runnerNames = new Set(inventory.map((runner) => runner.controlPlaneRunnerName))
+  if (runnerNames.size !== inventory.length) {
+    throw new Error('Runner names must be unique within the deployment inventory')
+  }
+
+  return inventory
+}
+
+module.exports = {
+  CONTROL_PLANE_NAME_TAG,
+  RUNNER_RESOURCE_CANDIDATE_PATTERN,
+  RUNNER_RESOURCE_NAME_PATTERN,
+  RUNNER_RESOURCE_TYPE,
+  hasRunnerIdentityTags,
+  isRunnerLikeResource,
+  resolveRunnerInventory,
+}

--- a/apps/infra/scripts/runner-inventory.test.mjs
+++ b/apps/infra/scripts/runner-inventory.test.mjs
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import runnerInventory from './runner-inventory.cjs'
+
+const { resolveRunnerInventory } = runnerInventory
+
+test('resolves the exact default and extra Runner identities from deployment config', () => {
+  assert.deepEqual(resolveRunnerInventory({}), [
+    {
+      resourceName: 'Runner',
+      nameTag: 'boxlite-runner-default',
+      controlPlaneRunnerName: 'default',
+    },
+  ])
+  assert.deepEqual(resolveRunnerInventory({ RUNNERS: '3', DEFAULT_RUNNER_NAME: 'primary' }), [
+    {
+      resourceName: 'Runner',
+      nameTag: 'boxlite-runner-default',
+      controlPlaneRunnerName: 'primary',
+    },
+    {
+      resourceName: 'Runner-runner-2',
+      nameTag: 'boxlite-runner-2',
+      controlPlaneRunnerName: 'runner-2',
+    },
+    {
+      resourceName: 'Runner-runner-3',
+      nameTag: 'boxlite-runner-3',
+      controlPlaneRunnerName: 'runner-3',
+    },
+  ])
+})
+
+test('rejects malformed or unsafe Runner counts at the deployment boundary', () => {
+  assert.equal(resolveRunnerInventory({ RUNNERS: '' }).length, 1)
+  assert.equal(resolveRunnerInventory({ RUNNERS: '100' }).length, 100)
+
+  for (const runners of ['0', '-2', '3-extra', '1.5', ' 3', '101']) {
+    assert.throws(() => resolveRunnerInventory({ RUNNERS: runners }), /RUNNERS must be an integer between 1 and 100/)
+  }
+})
+
+test('rejects invalid or duplicate control-plane Runner identities', () => {
+  for (const defaultRunnerName of ['a', 'runner name', 'x'.repeat(256)]) {
+    assert.throws(
+      () => resolveRunnerInventory({ DEFAULT_RUNNER_NAME: defaultRunnerName }),
+      /DEFAULT_RUNNER_NAME must be/,
+    )
+  }
+
+  assert.throws(
+    () => resolveRunnerInventory({ RUNNERS: '2', DEFAULT_RUNNER_NAME: 'runner-2' }),
+    /Runner names must be unique/,
+  )
+})

--- a/apps/infra/scripts/runner-policy-baseline.mjs
+++ b/apps/infra/scripts/runner-policy-baseline.mjs
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+import { spawn } from 'node:child_process'
+
+import runnerStateBaseline from './runner-state-baseline.cjs'
+
+const { createRunnerStateBaseline } = runnerStateBaseline
+const MAX_STATE_EXPORT_BYTES = 64 * 1024 * 1024
+const STATE_EXPORT_TIMEOUT_MS = 5 * 60_000
+const STATE_EXPORT_KILL_GRACE_MS = 5_000
+const MAX_SERIALIZED_RUNNER_BASELINE_BYTES = 32 * 1024
+const STATE_NOT_FOUND_LOG = /\berr="state not found"(?:\s|$)/
+
+function signalProcessGroup(child, signal) {
+  if (process.platform !== 'win32' && child.pid) {
+    try {
+      process.kill(-child.pid, signal)
+      return
+    } catch {}
+  }
+  child.kill(signal)
+}
+
+function abortedExecutionError(signal, stdout, stderr) {
+  const error = new Error('The operation was aborted', { cause: signal.reason })
+  error.name = 'AbortError'
+  error.stdout = stdout
+  error.stderr = stderr
+  return error
+}
+
+export function executeStateExportProcess(command, args, options) {
+  const {
+    encoding = 'utf8',
+    killGraceMs = STATE_EXPORT_KILL_GRACE_MS,
+    maxBuffer = MAX_STATE_EXPORT_BYTES,
+    signal,
+    timeout,
+    ...childOptions
+  } = options
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(abortedExecutionError(signal, '', ''))
+      return
+    }
+
+    const stdoutChunks = []
+    const stderrChunks = []
+    let stdoutBytes = 0
+    let stderrBytes = 0
+    let terminationReason
+    let killTimer
+    let timeoutTimer
+    let spawnError
+    const child = spawn(command, args, {
+      ...childOptions,
+      detached: process.platform !== 'win32',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+
+    function terminateReadOnlyExport(reason) {
+      if (terminationReason) return
+      terminationReason = reason
+      signalProcessGroup(child, 'SIGINT')
+      killTimer = setTimeout(() => signalProcessGroup(child, 'SIGKILL'), killGraceMs)
+      killTimer.unref()
+    }
+
+    function abort() {
+      terminateReadOnlyExport('aborted')
+    }
+
+    function collectOutput(chunks, chunk, streamBytes) {
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk, encoding)
+      if (streamBytes + buffer.length > maxBuffer) {
+        terminateReadOnlyExport('maxBuffer')
+        return streamBytes
+      }
+      chunks.push(buffer)
+      return streamBytes + buffer.length
+    }
+
+    child.stdout.on('data', (chunk) => {
+      stdoutBytes = collectOutput(stdoutChunks, chunk, stdoutBytes)
+    })
+    child.stderr.on('data', (chunk) => {
+      stderrBytes = collectOutput(stderrChunks, chunk, stderrBytes)
+    })
+    child.on('error', (error) => {
+      spawnError = error
+    })
+    child.on('close', (code, childSignal) => {
+      if (timeoutTimer) clearTimeout(timeoutTimer)
+      if (killTimer) clearTimeout(killTimer)
+      signal?.removeEventListener('abort', abort)
+
+      const stdout = Buffer.concat(stdoutChunks).toString(encoding)
+      const stderr = Buffer.concat(stderrChunks).toString(encoding)
+      if (terminationReason === 'aborted') {
+        reject(abortedExecutionError(signal, stdout, stderr))
+      } else if (terminationReason === 'timeout') {
+        const error = new Error('The operation timed out')
+        error.killed = true
+        error.stdout = stdout
+        error.stderr = stderr
+        reject(error)
+      } else if (terminationReason === 'maxBuffer') {
+        const error = new Error('State export output exceeded the configured buffer limit')
+        error.code = 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER'
+        error.killed = true
+        error.stdout = stdout
+        error.stderr = stderr
+        reject(error)
+      } else if (spawnError) {
+        spawnError.stdout = stdout
+        spawnError.stderr = stderr
+        reject(spawnError)
+      } else if (code !== 0) {
+        const error = new Error(`State export process exited with status ${code ?? `signal ${childSignal}`}`)
+        error.code = code
+        error.signal = childSignal
+        error.stdout = stdout
+        error.stderr = stderr
+        reject(error)
+      } else {
+        resolve({ stdout, stderr })
+      }
+    })
+
+    signal?.addEventListener('abort', abort, { once: true })
+    if (signal?.aborted) abort()
+
+    if (timeout > 0) {
+      timeoutTimer = setTimeout(() => {
+        terminateReadOnlyExport('timeout')
+      }, timeout)
+      timeoutTimer.unref()
+    }
+  })
+}
+
+function forwardedConfigArguments(sstArgs) {
+  const configArguments = []
+  for (let index = 1; index < sstArgs.length; index += 1) {
+    const argument = sstArgs[index]
+    if (argument === '--config') {
+      const value = sstArgs[index + 1]
+      if (!value || value.startsWith('--')) throw new Error('SST --config requires a path')
+      configArguments.push('--config', value)
+      index += 1
+    } else if (argument.startsWith('--config=')) {
+      const value = argument.slice('--config='.length)
+      if (!value) throw new Error('SST --config requires a path')
+      configArguments.push('--config', value)
+    }
+  }
+  if (configArguments.length > 2) throw new Error('SST --config must be specified exactly once')
+  return configArguments
+}
+
+function stateExportFailureReason(error) {
+  if (error?.code === 'ENOENT') return 'the sst executable was not found on PATH'
+  if (error?.name === 'AbortError') return 'the state export was interrupted'
+  if (error instanceof SyntaxError) return 'sst returned invalid checkpoint JSON'
+  if (error?.code === 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER') {
+    return `sst exceeded the ${MAX_STATE_EXPORT_BYTES / (1024 * 1024)} MiB output limit`
+  }
+  if (error?.killed) return `sst exceeded the ${STATE_EXPORT_TIMEOUT_MS / 1_000}-second timeout`
+  if (Number.isInteger(error?.code)) return `sst exited with status ${error.code}`
+  return 'sst did not complete successfully'
+}
+
+function isMissingStateExport(error) {
+  const wasInterrupted =
+    error?.name === 'AbortError' ||
+    error?.killed === true ||
+    error?.code === 'ETIMEDOUT' ||
+    error?.code === 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER' ||
+    typeof error?.signal === 'string'
+  return (
+    !wasInterrupted &&
+    Number.isInteger(error?.code) &&
+    error.code !== 0 &&
+    typeof error?.stderr === 'string' &&
+    STATE_NOT_FOUND_LOG.test(error.stderr)
+  )
+}
+
+export async function readRunnerStateBaseline({
+  stage,
+  sstPath = 'sst',
+  sstArgs,
+  environment = process.env,
+  signal,
+  execute = executeStateExportProcess,
+}) {
+  let exportedState
+  try {
+    const result = await execute(
+      sstPath,
+      ['state', 'export', '--stage', stage, '--print-logs', ...forwardedConfigArguments(sstArgs)],
+      {
+        encoding: 'utf8',
+        env: environment,
+        signal,
+        timeout: STATE_EXPORT_TIMEOUT_MS,
+        // The native SST process gets a grace period to cancel and await its
+        // detached Pulumi child. State export is read-only, so a stuck export
+        // is force-stopped after that grace period.
+        killGraceMs: STATE_EXPORT_KILL_GRACE_MS,
+        maxBuffer: MAX_STATE_EXPORT_BYTES,
+      },
+    )
+    exportedState = JSON.parse(typeof result === 'string' ? result : result.stdout)
+  } catch (error) {
+    if (isMissingStateExport(error)) {
+      exportedState = { latest: { resources: [] } }
+    } else {
+      throw new Error(`failed to export the current SST state: ${stateExportFailureReason(error)}`, { cause: error })
+    }
+  }
+
+  let serializedBaseline
+  try {
+    serializedBaseline = JSON.stringify(createRunnerStateBaseline(exportedState))
+  } catch (error) {
+    throw new Error(`failed to create the Runner state baseline: ${error.message}`, { cause: error })
+  }
+  if (Buffer.byteLength(serializedBaseline, 'utf8') > MAX_SERIALIZED_RUNNER_BASELINE_BYTES) {
+    throw new Error('Runner state baseline exceeds the 32 KiB environment handoff limit')
+  }
+  return serializedBaseline
+}

--- a/apps/infra/scripts/runner-policy-baseline.test.mjs
+++ b/apps/infra/scripts/runner-policy-baseline.test.mjs
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { executeStateExportProcess, readRunnerStateBaseline } from './runner-policy-baseline.mjs'
+import runnerInventory from './runner-inventory.cjs'
+
+const { CONTROL_PLANE_NAME_TAG } = runnerInventory
+const SAFE_BASELINE_HANDOFF_BYTES = 32 * 1024
+
+function runnerStateResource(index) {
+  const isDefaultRunner = index === 1
+  const resourceName = isDefaultRunner ? 'Runner' : `Runner-runner-${index}`
+  const nameTag = isDefaultRunner ? 'boxlite-runner-default' : `boxlite-runner-${index}`
+  const controlPlaneRunnerName = isDefaultRunner ? 'default' : `runner-${index}`
+  return {
+    urn: `urn:pulumi:dev::boxlite::aws:ec2/instance:Instance::${resourceName}`,
+    type: 'aws:ec2/instance:Instance',
+    custom: true,
+    id: `i-runner-${index}`,
+    inputs: {
+      instanceType: 'c8i.2xlarge',
+      tags: {
+        Name: nameTag,
+        [CONTROL_PLANE_NAME_TAG]: controlPlaneRunnerName,
+      },
+    },
+    provider: 'urn:pulumi:dev::boxlite::pulumi:providers:aws::AwsProvider::provider-id',
+    protect: true,
+    ignoreChanges: ['ami', 'userDataBase64'],
+  }
+}
+
+test('exports the matching SST checkpoint with bounded, cancellable execution', async () => {
+  const calls = []
+  const controller = new AbortController()
+  const environment = { PATH: '/synthetic/bin' }
+  const baseline = await readRunnerStateBaseline({
+    stage: 'dev',
+    sstArgs: ['diff', '--stage', 'dev', '--config=infra/sst.config.ts'],
+    environment,
+    signal: controller.signal,
+    async execute(command, args, options) {
+      calls.push({ command, args, options })
+      return { stdout: JSON.stringify({ stack: 'dev', latest: { resources: [] } }), stderr: '' }
+    },
+  })
+
+  assert.deepEqual(JSON.parse(baseline), { version: 3, resources: {} })
+  assert.equal(calls.length, 1)
+  assert.equal(calls[0].command, 'sst')
+  assert.deepEqual(calls[0].args, [
+    'state',
+    'export',
+    '--stage',
+    'dev',
+    '--print-logs',
+    '--config',
+    'infra/sst.config.ts',
+  ])
+  assert.equal(calls[0].options.env, environment)
+  assert.equal(calls[0].options.signal, controller.signal)
+  assert.equal(calls[0].options.timeout, 300_000)
+  assert.equal(calls[0].options.maxBuffer, 64 * 1024 * 1024)
+})
+
+test('represents an explicitly missing SST stage as an empty Runner baseline', async () => {
+  const baseline = await readRunnerStateBaseline({
+    stage: 'new-stage',
+    sstArgs: ['diff', '--stage', 'new-stage'],
+    async execute() {
+      throw Object.assign(new Error('synthetic missing state'), {
+        code: 1,
+        stderr: 'time=synthetic level=ERROR msg="exited with error" err="state not found"\n',
+      })
+    },
+  })
+
+  assert.deepEqual(JSON.parse(baseline), { version: 3, resources: {} })
+})
+
+test('keeps the maximum supported Runner inventory within the safe environment handoff size', async () => {
+  const resources = Array.from({ length: 100 }, (_, offset) => runnerStateResource(offset + 1))
+  const baseline = await readRunnerStateBaseline({
+    stage: 'dev',
+    sstArgs: ['diff', '--stage', 'dev'],
+    async execute() {
+      return { stdout: JSON.stringify({ latest: { resources } }), stderr: '' }
+    },
+  })
+
+  assert.equal(JSON.parse(baseline).version, 3)
+  assert.equal(Object.keys(JSON.parse(baseline).resources).length, 100)
+  assert.ok(Buffer.byteLength(baseline, 'utf8') < SAFE_BASELINE_HANDOFF_BYTES)
+})
+
+test('rejects an oversized Runner baseline before the environment handoff', async () => {
+  const resources = Array.from({ length: 400 }, (_, offset) => runnerStateResource(offset + 1))
+
+  await assert.rejects(
+    readRunnerStateBaseline({
+      stage: 'dev',
+      sstArgs: ['diff', '--stage', 'dev'],
+      async execute() {
+        return { stdout: JSON.stringify({ latest: { resources } }), stderr: '' }
+      },
+    }),
+    /Runner state baseline exceeds the 32 KiB environment handoff limit/,
+  )
+})
+
+for (const [name, failure] of [
+  [
+    'aborted',
+    Object.assign(new Error('synthetic abort'), {
+      name: 'AbortError',
+    }),
+  ],
+  [
+    'killed',
+    Object.assign(new Error('synthetic kill'), {
+      killed: true,
+      signal: 'SIGKILL',
+    }),
+  ],
+  [
+    'timed-out',
+    Object.assign(new Error('synthetic timeout'), {
+      code: 'ETIMEDOUT',
+    }),
+  ],
+  [
+    'maxBuffer-terminated',
+    Object.assign(new Error('synthetic maxBuffer failure'), {
+      code: 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER',
+    }),
+  ],
+  [
+    'signal-terminated',
+    Object.assign(new Error('synthetic signal termination'), {
+      signal: 'SIGTERM',
+    }),
+  ],
+]) {
+  test(`does not treat ${name} state export failure as a missing SST stage`, async () => {
+    failure.stderr = 'time=synthetic level=ERROR msg="exited with error" err="state not found"\n'
+
+    await assert.rejects(
+      readRunnerStateBaseline({
+        stage: 'dev',
+        sstArgs: ['diff', '--stage', 'dev'],
+        async execute() {
+          throw failure
+        },
+      }),
+      /failed to export the current SST state/,
+    )
+  })
+}
+
+test('interrupts a state export that exceeds its timeout', async () => {
+  await assert.rejects(
+    executeStateExportProcess(process.execPath, ['-e', 'setInterval(() => {}, 1_000)'], {
+      encoding: 'utf8',
+      env: process.env,
+      timeout: 50,
+      maxBuffer: 1024 * 1024,
+    }),
+    (error) => {
+      assert.equal(error.killed, true)
+      return true
+    },
+  )
+})
+
+test(
+  'force-stops a read-only state export that ignores the graceful interrupt',
+  { skip: process.platform === 'win32' },
+  async () => {
+    const startedAt = Date.now()
+
+    await assert.rejects(
+      executeStateExportProcess('/bin/sh', ['-c', "trap '' INT; sleep 3"], {
+        encoding: 'utf8',
+        env: process.env,
+        timeout: 100,
+        killGraceMs: 50,
+        maxBuffer: 1024 * 1024,
+      }),
+      (error) => {
+        assert.equal(error.killed, true)
+        return true
+      },
+    )
+
+    assert.ok(Date.now() - startedAt < 1_000, 'state export waited for a child that ignored SIGINT')
+  },
+)
+
+test('reports state-export failures without exposing captured checkpoint data', async () => {
+  const sensitiveValue = 'sentinel-state-secret'
+  const failure = Object.assign(new Error('synthetic failure'), {
+    code: 1,
+    stdout: sensitiveValue,
+    stderr: sensitiveValue,
+  })
+
+  await assert.rejects(
+    readRunnerStateBaseline({
+      stage: 'dev',
+      sstArgs: ['diff', '--stage', 'dev'],
+      async execute() {
+        throw failure
+      },
+    }),
+    (error) => {
+      assert.match(error.message, /failed to export the current SST state: sst exited with status 1/)
+      assert.doesNotMatch(error.message, new RegExp(sensitiveValue))
+      return true
+    },
+  )
+})

--- a/apps/infra/scripts/runner-policy.test.mjs
+++ b/apps/infra/scripts/runner-policy.test.mjs
@@ -1,0 +1,374 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import test from 'node:test'
+
+import runnerInventory from './runner-inventory.cjs'
+import runnerStateBaseline from './runner-state-baseline.cjs'
+import runnerPolicyDefinitions from '../policies/runner/definitions.cjs'
+import runnerPolicy from '../policies/runner/validate.cjs'
+
+const { CONTROL_PLANE_NAME_TAG, resolveRunnerInventory } = runnerInventory
+const { createRunnerIdentityFingerprint, createRunnerSafetyFingerprint } = runnerStateBaseline
+const { createRunnerPolicies } = runnerPolicyDefinitions
+const { validateRunnerResource, validateRunnerStack } = runnerPolicy
+const RUNNER_TYPE = 'aws:ec2/instance:Instance'
+const SAFE_OPTIONS = { protect: true, ignoreChanges: ['ami', 'userDataBase64'] }
+const SENSITIVE_PROPERTY_VALUE = 'sentinel-sensitive-user-data'
+const RUNNER_POLICY_ENTRY = fileURLToPath(new URL('../policies/runner/index.js', import.meta.url))
+const SAFE_RUNNER_PROPERTIES = {
+  associatePublicIpAddress: true,
+  cpuOptions: { nestedVirtualization: 'enabled' },
+  iamInstanceProfile: 'boxlite-dev-runner-profile',
+  instanceType: 'c8i.2xlarge',
+  metadataOptions: { httpEndpoint: 'enabled', httpPutResponseHopLimit: 1, httpTokens: 'required' },
+  rootBlockDevice: { volumeSize: 100 },
+  subnetId: 'subnet-123',
+  vpcSecurityGroupIds: ['sg-456'],
+}
+
+function runnerResource(spec, overrides = {}) {
+  return {
+    type: RUNNER_TYPE,
+    name: spec.resourceName,
+    props: {
+      ...SAFE_RUNNER_PROPERTIES,
+      userDataBase64: SENSITIVE_PROPERTY_VALUE,
+      tags: {
+        Name: spec.nameTag,
+        [CONTROL_PLANE_NAME_TAG]: spec.controlPlaneRunnerName,
+      },
+    },
+    opts: SAFE_OPTIONS,
+    ...overrides,
+  }
+}
+
+function runnerBaseline(inventory, includedInventory = inventory) {
+  const includedNames = new Set(includedInventory.map((runner) => runner.resourceName))
+  return {
+    version: 3,
+    resources: Object.fromEntries(
+      inventory
+        .filter((runner) => includedNames.has(runner.resourceName))
+        .map((runner) => [
+          runner.resourceName,
+          {
+            inputFingerprint: createRunnerSafetyFingerprint(runnerResource(runner).props),
+            identityFingerprint: createRunnerIdentityFingerprint(runnerResource(runner).props, runner.resourceName),
+          },
+        ]),
+    ),
+  }
+}
+
+function collectViolations(validate) {
+  const violations = []
+  validate((message) => violations.push(message))
+  return violations
+}
+
+test('requires the serialized Runner state baseline before loading the policy pack', () => {
+  const environment = { ...process.env }
+  delete environment.DEFAULT_RUNNER_NAME
+  delete environment.BOXLITE_RUNNER_STATE_BASELINE
+  delete environment.RUNNERS
+
+  const result = spawnSync(process.execPath, [RUNNER_POLICY_ENTRY], {
+    encoding: 'utf8',
+    env: environment,
+    maxBuffer: 1024 * 1024,
+    timeout: 5_000,
+  })
+
+  assert.notEqual(result.status, 0)
+  assert.match(result.stderr, /BOXLITE_RUNNER_STATE_BASELINE is required/)
+})
+
+test('requires a Runner state baseline when creating policy definitions', () => {
+  assert.throws(() => createRunnerPolicies(resolveRunnerInventory({})), /Runner state baseline is required/)
+})
+
+test('accepts protected Runner resources with exact lifecycle, identity, and state', () => {
+  const inventory = resolveRunnerInventory({ RUNNERS: '2', DEFAULT_RUNNER_NAME: 'primary' })
+  const baseline = runnerBaseline(inventory)
+
+  for (const spec of inventory) {
+    assert.deepEqual(validateRunnerResource(runnerResource(spec), inventory, baseline), [])
+    assert.deepEqual(
+      validateRunnerResource(
+        runnerResource(spec, { opts: { protect: true, ignoreChanges: ['userDataBase64', 'ami'] } }),
+        inventory,
+        baseline,
+      ),
+      [],
+    )
+  }
+  assert.deepEqual(
+    validateRunnerResource(
+      {
+        type: RUNNER_TYPE,
+        name: 'Worker',
+        props: { tags: { Name: 'unrelated-instance' } },
+        opts: {},
+      },
+      inventory,
+      baseline,
+    ),
+    [],
+  )
+})
+
+test('rejects unsafe Runner lifecycle options without reporting property values', () => {
+  const inventory = resolveRunnerInventory({})
+  const baseline = runnerBaseline(inventory)
+  const [spec] = inventory
+  const cases = [
+    {
+      resource: runnerResource(spec, { opts: { ...SAFE_OPTIONS, protect: false } }),
+      expected: ['Runner resources must keep deletion protection enabled.'],
+    },
+    {
+      resource: runnerResource(spec, { opts: { protect: true, ignoreChanges: ['ami'] } }),
+      expected: ['Runner resources must ignore only AMI and user-data changes.'],
+    },
+    {
+      resource: runnerResource(spec, {
+        opts: { protect: true, ignoreChanges: [...SAFE_OPTIONS.ignoreChanges, 'instanceType'] },
+      }),
+      expected: ['Runner resources must ignore only AMI and user-data changes.'],
+    },
+    {
+      resource: runnerResource(spec, {
+        opts: { protect: true, ignoreChanges: ['ami', 'userDataBase64', 'userDataBase64'] },
+      }),
+      expected: ['Runner resources must ignore only AMI and user-data changes.'],
+    },
+  ]
+
+  for (const { resource, expected } of cases) {
+    const violations = validateRunnerResource(resource, inventory, baseline)
+    assert.deepEqual(violations, expected)
+    assert.doesNotMatch(violations.join('\n'), new RegExp(SENSITIVE_PROPERTY_VALUE))
+  }
+})
+
+test('rejects missing, mismatched, or unexpected Runner identities', () => {
+  const inventory = resolveRunnerInventory({ RUNNERS: '2', DEFAULT_RUNNER_NAME: 'primary' })
+  const baseline = runnerBaseline(inventory)
+  const [defaultRunner, extraRunner] = inventory
+  const missingIdentityTag = runnerResource(defaultRunner)
+  delete missingIdentityTag.props.tags[CONTROL_PLANE_NAME_TAG]
+  const mismatchedNameTag = runnerResource(extraRunner)
+  mismatchedNameTag.props.tags.Name = 'boxlite-runner-9'
+  const cases = [
+    missingIdentityTag,
+    mismatchedNameTag,
+    runnerResource(defaultRunner, { type: 'aws:ec2/launchTemplate:LaunchTemplate' }),
+    {
+      type: RUNNER_TYPE,
+      name: 'Canary',
+      props: { tags: { Name: 'boxlite-runner-canary' } },
+      opts: SAFE_OPTIONS,
+    },
+    {
+      type: RUNNER_TYPE,
+      name: 'Runner-runner-3',
+      props: { tags: {} },
+      opts: SAFE_OPTIONS,
+    },
+  ]
+
+  assert.deepEqual(validateRunnerResource(cases[0], inventory, baseline), [
+    'Runner identity tags must match the deployment inventory.',
+  ])
+  assert.deepEqual(validateRunnerResource(cases[1], inventory, baseline), [
+    'Runner identity tags must match the deployment inventory.',
+  ])
+  assert.deepEqual(validateRunnerResource(cases[2], inventory, baseline), [
+    'Runner resources must remain EC2 instances.',
+  ])
+  assert.deepEqual(validateRunnerResource(cases[3], inventory, baseline), [
+    'Runner identity is not declared by the deployment inventory.',
+  ])
+  assert.deepEqual(validateRunnerResource(cases[4], inventory, baseline), [
+    'Runner identity is not declared by the deployment inventory.',
+  ])
+})
+
+test('rejects a deployment-config rename of an existing Runner identity', () => {
+  const currentInventory = resolveRunnerInventory({ DEFAULT_RUNNER_NAME: 'current-name' })
+  const desiredInventory = resolveRunnerInventory({ DEFAULT_RUNNER_NAME: 'renamed' })
+  const baseline = runnerBaseline(currentInventory)
+
+  assert.ok(
+    validateRunnerResource(runnerResource(desiredInventory[0]), desiredInventory, baseline).includes(
+      'Runner identity tags must match the current deployment state.',
+    ),
+  )
+})
+
+test('rejects incomplete or ambiguous Runner stacks', () => {
+  const inventory = resolveRunnerInventory({ RUNNERS: '2', DEFAULT_RUNNER_NAME: 'primary' })
+  const baseline = runnerBaseline(inventory)
+  const resources = inventory.map((spec) => runnerResource(spec))
+
+  assert.deepEqual(validateRunnerStack(resources, inventory, baseline), [])
+  assert.deepEqual(validateRunnerStack(resources.slice(0, 1), inventory, baseline), [
+    'Runner inventory is missing a declared resource.',
+  ])
+  assert.deepEqual(validateRunnerStack([...resources, runnerResource(inventory[1])], inventory, baseline), [
+    'Runner inventory contains a duplicate declared resource.',
+  ])
+  assert.deepEqual(
+    validateRunnerStack(
+      [
+        ...resources,
+        {
+          type: RUNNER_TYPE,
+          name: 'Canary',
+          props: { tags: { Name: 'boxlite-runner-canary' } },
+          opts: SAFE_OPTIONS,
+        },
+      ],
+      inventory,
+      baseline,
+    ),
+    ['Runner inventory contains an undeclared resource.'],
+  )
+})
+
+test('ignores unresolved properties on unrelated resources without weakening inventory checks', () => {
+  const inventory = resolveRunnerInventory({ RUNNERS: '2' })
+  const baseline = runnerBaseline(inventory)
+  const unrelatedResource = {
+    type: RUNNER_TYPE,
+    name: 'VpcNatInstance',
+    props: new Proxy(
+      {},
+      {
+        get() {
+          throw new Error('property value is unknown during preview')
+        },
+      },
+    ),
+    opts: {},
+  }
+
+  assert.deepEqual(validateRunnerResource(unrelatedResource, inventory, baseline), [])
+  assert.deepEqual(validateRunnerStack([runnerResource(inventory[0]), unrelatedResource], inventory, baseline), [
+    'Runner inventory is missing a declared resource.',
+  ])
+})
+
+test('rejects protected Runner property drift even when no preview event is available', () => {
+  const inventory = resolveRunnerInventory({})
+  const baseline = runnerBaseline(inventory)
+  const [spec] = inventory
+
+  for (const changedProperties of [
+    { instanceType: 'c8i.4xlarge' },
+    { subnetId: 'subnet-other' },
+    { vpcSecurityGroupIds: ['sg-other'] },
+    { iamInstanceProfile: 'other-profile' },
+    { rootBlockDevice: { volumeSize: 200 } },
+    { metadataOptions: { httpEndpoint: 'enabled', httpPutResponseHopLimit: 2, httpTokens: 'required' } },
+    { cpuOptions: { nestedVirtualization: 'disabled' } },
+    { associatePublicIpAddress: false },
+    { rootBlockDevice: { volumeSize: 100, encrypted: false } },
+    { disableApiTermination: true },
+  ]) {
+    const resource = runnerResource(spec)
+    resource.props = { ...resource.props, ...changedProperties }
+    assert.ok(
+      validateRunnerResource(resource, inventory, baseline).includes(
+        'Runner protected properties must match the current deployment state.',
+      ),
+    )
+  }
+})
+
+test('rejects a currently missing Runner in routine deployments', () => {
+  const inventory = resolveRunnerInventory({ RUNNERS: '2' })
+  const baseline = runnerBaseline(inventory, inventory.slice(0, 1))
+  const resources = inventory.map((spec) => runnerResource(spec))
+
+  assert.ok(
+    validateRunnerResource(resources[1], inventory, baseline).includes(
+      'Routine deployment must not create a Runner resource.',
+    ),
+  )
+  assert.ok(
+    validateRunnerStack(resources, inventory, baseline).includes(
+      'Runner inventory differs from the current deployment state.',
+    ),
+  )
+})
+
+test('rejects Runner properties that cannot be resolved during preview', () => {
+  const inventory = resolveRunnerInventory({})
+  const baseline = runnerBaseline(inventory)
+  const resource = runnerResource(inventory[0])
+  resource.props.subnetId = new Proxy(
+    {},
+    {
+      get() {
+        throw new Error('property value is unknown during preview')
+      },
+    },
+  )
+
+  assert.ok(
+    validateRunnerResource(resource, inventory, baseline).includes(
+      'Runner protected properties could not be resolved for comparison.',
+    ),
+  )
+})
+
+test('reports unresolved Runner identity-tag properties as policy violations', () => {
+  const inventory = resolveRunnerInventory({})
+  const baseline = runnerBaseline(inventory)
+  const resource = runnerResource(inventory[0])
+  resource.props.tags = new Proxy(resource.props.tags, {
+    get() {
+      throw new Error('tag value is unknown during preview')
+    },
+  })
+
+  const violations = validateRunnerResource(resource, inventory, baseline)
+  assert.ok(violations.includes('Runner identity tags must match the deployment inventory.'))
+})
+
+test('wires mandatory resource and stack validators to policy reports', () => {
+  const inventory = resolveRunnerInventory({ RUNNERS: '2' })
+  const baseline = runnerBaseline(inventory)
+  const policies = createRunnerPolicies(inventory, baseline)
+  assert.deepEqual(
+    policies.map(({ name, enforcementLevel }) => ({ name, enforcementLevel })),
+    [
+      { name: 'runner-instance-contract', enforcementLevel: 'mandatory' },
+      { name: 'runner-inventory-complete', enforcementLevel: 'mandatory' },
+    ],
+  )
+
+  const resourcePolicy = policies[0]
+  const stackPolicy = policies[1]
+  assert.deepEqual(
+    collectViolations((reportViolation) =>
+      resourcePolicy.validateResource(
+        runnerResource(inventory[0], { opts: { ...SAFE_OPTIONS, protect: false } }),
+        reportViolation,
+      ),
+    ),
+    ['Runner resources must keep deletion protection enabled.'],
+  )
+  assert.deepEqual(
+    collectViolations((reportViolation) =>
+      stackPolicy.validateStack({ resources: [runnerResource(inventory[0])] }, reportViolation),
+    ),
+    ['Runner inventory is missing a declared resource.'],
+  )
+})

--- a/apps/infra/scripts/runner-release-assets.mjs
+++ b/apps/infra/scripts/runner-release-assets.mjs
@@ -5,8 +5,78 @@ import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
 
 const RELEASE_DOWNLOAD_ROOT = 'https://github.com/boxlite-ai/boxlite/releases/download'
+const RELEASE_REQUEST_KILL_GRACE_MS = 1_000
+const RELEASE_REQUEST_MAX_BUFFER = 1024 * 1024
 const STABLE_VERSION = /^[0-9]+\.[0-9]+\.[0-9]+$/
 const execFileAsync = promisify(execFile)
+
+function signalProcessGroup(child, signal) {
+  if (process.platform !== 'win32' && child.pid) {
+    try {
+      process.kill(-child.pid, signal)
+      return
+    } catch {}
+  }
+  if (child.exitCode === null && child.signalCode === null) child.kill(signal)
+}
+
+function releaseRequestTerminationError(reason, signal, executionError) {
+  const error =
+    reason === 'aborted'
+      ? Object.assign(new Error('The operation was aborted', { cause: signal.reason }), {
+          code: 'ABORT_ERR',
+          name: 'AbortError',
+        })
+      : Object.assign(new Error('The operation timed out'), { code: 'ETIMEDOUT', killed: true })
+  error.stdout = executionError?.stdout ?? ''
+  error.stderr = executionError?.stderr ?? ''
+  return error
+}
+
+async function executeReleaseRequest(command, args, { encoding, environment, maxBuffer, signal, timeoutMs }) {
+  if (signal?.aborted) throw releaseRequestTerminationError('aborted', signal)
+
+  // AbortSignal makes execFile reject before its child emits close. Own the
+  // cancellation so the deploy wrapper waits until the request child is reaped.
+  const execution = execFileAsync(command, args, {
+    detached: process.platform !== 'win32',
+    encoding,
+    env: environment,
+    maxBuffer,
+  })
+  const child = execution.child
+  let executionError
+  let killTimer
+  let terminationReason
+
+  const terminate = (reason) => {
+    if (terminationReason) return
+    terminationReason = reason
+    signalProcessGroup(child, 'SIGTERM')
+    killTimer = setTimeout(() => signalProcessGroup(child, 'SIGKILL'), RELEASE_REQUEST_KILL_GRACE_MS)
+    killTimer.unref()
+  }
+  const abort = () => terminate('aborted')
+  const timeoutTimer = setTimeout(() => terminate('timeout'), timeoutMs)
+  timeoutTimer.unref()
+  signal?.addEventListener('abort', abort, { once: true })
+  if (signal?.aborted) abort()
+
+  let result
+  try {
+    result = await execution
+  } catch (error) {
+    executionError = error
+  } finally {
+    clearTimeout(timeoutTimer)
+    if (killTimer) clearTimeout(killTimer)
+    signal?.removeEventListener('abort', abort)
+  }
+
+  if (terminationReason) throw releaseRequestTerminationError(terminationReason, signal, executionError)
+  if (executionError) throw executionError
+  return result
+}
 
 export function resolveRunnerReleaseAssets(version) {
   if (!STABLE_VERSION.test(version)) {
@@ -24,11 +94,11 @@ export function resolveRunnerReleaseAssets(version) {
   }
 }
 
-async function curlReleaseAsset(curlPath, url, extraArguments, environment, timeoutMs, description) {
+async function curlReleaseAsset(curlPath, url, extraArguments, environment, signal, timeoutMs, description) {
   const timeoutSeconds = Math.max(1, Math.ceil(timeoutMs / 1_000))
   const connectTimeoutSeconds = Math.min(10, timeoutSeconds)
   try {
-    const { stdout } = await execFileAsync(
+    const { stdout } = await executeReleaseRequest(
       curlPath,
       [
         '--fail',
@@ -48,10 +118,10 @@ async function curlReleaseAsset(curlPath, url, extraArguments, environment, time
       ],
       {
         encoding: 'utf8',
-        env: environment,
-        killSignal: 'SIGTERM',
-        maxBuffer: 1024 * 1024,
-        timeout: timeoutMs,
+        environment,
+        maxBuffer: RELEASE_REQUEST_MAX_BUFFER,
+        signal,
+        timeoutMs,
       },
     )
     return stdout
@@ -69,7 +139,7 @@ function remainingTimeoutMs(deadline) {
 
 export async function verifyRunnerReleaseAssets(
   version,
-  { curlPath = 'curl', environment = process.env, timeoutMs = 15_000 } = {},
+  { curlPath = 'curl', environment = process.env, signal, timeoutMs = 15_000 } = {},
 ) {
   if (typeof curlPath !== 'string' || curlPath.trim() === '') {
     throw new Error('Runner release preflight requires a curl executable')
@@ -84,7 +154,15 @@ export async function verifyRunnerReleaseAssets(
   // curl honors HTTPS_PROXY/NO_PROXY by default. Node's bare fetch does not,
   // which made valid releases unreachable from proxied deployment hosts.
   const checksumContents = (
-    await curlReleaseAsset(curlPath, assets.checksumUrl, [], environment, remainingTimeoutMs(deadline), 'checksum')
+    await curlReleaseAsset(
+      curlPath,
+      assets.checksumUrl,
+      [],
+      environment,
+      signal,
+      remainingTimeoutMs(deadline),
+      'checksum',
+    )
   ).trim()
   const checksum = checksumContents.match(/^([0-9a-f]{64})[ \t]+\*?([^\r\n]+)$/i)
   if (!checksum || checksum[2] !== assets.tarballName) {
@@ -96,6 +174,7 @@ export async function verifyRunnerReleaseAssets(
     assets.tarballUrl,
     ['--head', '--output', '/dev/null'],
     environment,
+    signal,
     remainingTimeoutMs(deadline),
     'tarball',
   )

--- a/apps/infra/scripts/runner-release-assets.test.mjs
+++ b/apps/infra/scripts/runner-release-assets.test.mjs
@@ -23,6 +23,7 @@ function createFakeCurl(
     checksum = `${DIGEST}  ${TARBALL}\n`,
     checksumExit = 0,
     expectedProxy = process.env.HTTPS_PROXY ?? '',
+    delaySeconds = 0,
     tarballExit = 0,
   } = {},
 ) {
@@ -36,6 +37,7 @@ function createFakeCurl(
     `#!/usr/bin/env bash
 set -euo pipefail
 [[ "\${HTTPS_PROXY:-}" == ${shellQuote(expectedProxy)} ]] || { echo 'HTTPS_PROXY was not forwarded' >&2; exit 90; }
+sleep ${delaySeconds}
 printf '%s\\n' "$*" >> ${shellQuote(logPath)}
 case "$*" in
   *${TARBALL}.sha256*)
@@ -80,19 +82,32 @@ test('uses bounded curl requests so deployment honors the host proxy environment
 test('rejects a missing or mismatched Runner release before deployment', async (t) => {
   const missing = createFakeCurl(t, { checksumExit: 22 })
   await assert.rejects(
-    verifyRunnerReleaseAssets(VERSION, { curlPath: missing.curlPath, timeoutMs: 1_000 }),
+    verifyRunnerReleaseAssets(VERSION, { curlPath: missing.curlPath, timeoutMs: 5_000 }),
     /checksum request failed/i,
   )
 
   const mismatched = createFakeCurl(t, { checksum: `${DIGEST}  another-file.tar.gz\n` })
   await assert.rejects(
-    verifyRunnerReleaseAssets(VERSION, { curlPath: mismatched.curlPath, timeoutMs: 1_000 }),
+    verifyRunnerReleaseAssets(VERSION, { curlPath: mismatched.curlPath, timeoutMs: 5_000 }),
     /checksum manifest.*exactly/i,
   )
 
   const missingTarball = createFakeCurl(t, { tarballExit: 22 })
   await assert.rejects(
-    verifyRunnerReleaseAssets(VERSION, { curlPath: missingTarball.curlPath, timeoutMs: 1_000 }),
+    verifyRunnerReleaseAssets(VERSION, { curlPath: missingTarball.curlPath, timeoutMs: 5_000 }),
     /tarball request failed/i,
   )
+})
+
+test('aborts a pending Runner release preflight', async (t) => {
+  const fixture = createFakeCurl(t, { delaySeconds: 10 })
+  const controller = new AbortController()
+  const verification = verifyRunnerReleaseAssets(VERSION, {
+    curlPath: fixture.curlPath,
+    signal: controller.signal,
+    timeoutMs: 15_000,
+  })
+
+  controller.abort(new Error('synthetic interruption'))
+  await assert.rejects(verification, /checksum request failed/i)
 })

--- a/apps/infra/scripts/runner-state-baseline.cjs
+++ b/apps/infra/scripts/runner-state-baseline.cjs
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+const { createHash } = require('node:crypto')
+
+const {
+  CONTROL_PLANE_NAME_TAG,
+  RUNNER_RESOURCE_NAME_PATTERN,
+  RUNNER_RESOURCE_TYPE,
+  isRunnerLikeResource,
+} = require('./runner-inventory.cjs')
+
+const ALLOWED_MUTABLE_INPUTS = new Set(['ami', 'tags', 'tagsAll', 'userDataBase64'])
+const REQUIRED_IGNORED_PROPERTIES = ['ami', 'userDataBase64']
+const RUNNER_FINGERPRINT_PATTERN = /^sha256:[0-9a-f]{64}$/
+const UNORDERED_ARRAY_PATHS = new Set(['vpcSecurityGroupIds'])
+const AUDITED_PROVIDER_DEFAULTS = new Map([
+  ['forceDestroy', false],
+  ['getPasswordData', false],
+  ['sourceDestCheck', true],
+  ['userDataReplaceOnChange', false],
+  ['metadataOptions.httpProtocolIpv6', 'disabled'],
+  ['rootBlockDevice.deleteOnTermination', true],
+])
+
+function resourceName(urn) {
+  return typeof urn === 'string' ? urn.slice(urn.lastIndexOf('::') + 2) : ''
+}
+
+function canonicalize(value, path = []) {
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') return value
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) throw new Error('invalid Runner input')
+    return value
+  }
+  if (Array.isArray(value)) {
+    const canonicalValues = value.map((entry) => canonicalize(entry, [...path, '[]']))
+    if (!UNORDERED_ARRAY_PATHS.has(path.join('.'))) return canonicalValues
+    return canonicalValues.sort((left, right) => {
+      const serializedLeft = JSON.stringify(left)
+      const serializedRight = JSON.stringify(right)
+      if (serializedLeft === serializedRight) return 0
+      return serializedLeft < serializedRight ? -1 : 1
+    })
+  }
+  if (!value || typeof value !== 'object') throw new Error('invalid Runner input')
+
+  const defaultKeys = value.__defaults === undefined ? [] : value.__defaults
+  if (!Array.isArray(defaultKeys) || defaultKeys.some((key) => typeof key !== 'string')) {
+    throw new Error('invalid Runner defaults metadata')
+  }
+  const providerDefaults = new Set(defaultKeys)
+  for (const key of providerDefaults) {
+    const propertyPath = [...path, key].join('.')
+    if (!AUDITED_PROVIDER_DEFAULTS.has(propertyPath) || value[key] !== AUDITED_PROVIDER_DEFAULTS.get(propertyPath)) {
+      throw new Error('unrecognized Runner provider default')
+    }
+  }
+  const canonical = {}
+  for (const key of Object.keys(value).sort()) {
+    const propertyPath = [...path, key].join('.')
+    const isAuditedProviderDefault =
+      AUDITED_PROVIDER_DEFAULTS.has(propertyPath) && value[key] === AUDITED_PROVIDER_DEFAULTS.get(propertyPath)
+    if (key === '__defaults' || isAuditedProviderDefault || value[key] === undefined) continue
+    canonical[key] = canonicalize(value[key], [...path, key])
+  }
+  return canonical
+}
+
+function normalizeRunnerProtectedInputs(properties) {
+  if (!properties || typeof properties !== 'object' || Array.isArray(properties)) {
+    throw new Error('invalid Runner inputs')
+  }
+
+  const protectedInputs = {}
+  for (const key of Object.keys(properties)) {
+    if (ALLOWED_MUTABLE_INPUTS.has(key) || properties[key] === undefined) continue
+    protectedInputs[key] = properties[key]
+  }
+  if (Array.isArray(protectedInputs.__defaults)) {
+    protectedInputs.__defaults = protectedInputs.__defaults.filter((key) => !ALLOWED_MUTABLE_INPUTS.has(key))
+  }
+  return canonicalize(protectedInputs)
+}
+
+function createRunnerSafetyFingerprint(properties) {
+  const serializedInputs = JSON.stringify(normalizeRunnerProtectedInputs(properties))
+  return `sha256:${createHash('sha256').update(serializedInputs).digest('hex')}`
+}
+
+function readConsistentIdentityTag(properties, key) {
+  const values = []
+  for (const tags of [properties?.tags, properties?.tagsAll]) {
+    if (!tags || typeof tags !== 'object' || Array.isArray(tags)) continue
+    if (!Object.prototype.hasOwnProperty.call(tags, key)) continue
+    if (typeof tags[key] !== 'string' || tags[key].length === 0) throw new Error('invalid Runner identity tag')
+    values.push(tags[key])
+  }
+  const uniqueValues = new Set(values)
+  if (uniqueValues.size > 1) throw new Error('conflicting Runner identity tags')
+  return values[0]
+}
+
+function legacyControlPlaneRunnerName(resourceName, nameTag) {
+  if (resourceName === 'Runner' && nameTag === 'boxlite-runner-default') return 'default'
+
+  const extraRunner = resourceName.match(/^Runner-runner-([1-9][0-9]*)$/)
+  if (extraRunner && nameTag === `boxlite-runner-${extraRunner[1]}`) return `runner-${extraRunner[1]}`
+  throw new Error('Runner state is missing its control-plane identity tag')
+}
+
+function createRunnerIdentityFingerprint(properties, resourceName, { allowLegacyFallback = false } = {}) {
+  const nameTag = readConsistentIdentityTag(properties, 'Name')
+  if (!nameTag) throw new Error('Runner state is missing its Name identity tag')
+
+  let controlPlaneRunnerName = readConsistentIdentityTag(properties, CONTROL_PLANE_NAME_TAG)
+  if (!controlPlaneRunnerName && allowLegacyFallback) {
+    controlPlaneRunnerName = legacyControlPlaneRunnerName(resourceName, nameTag)
+  }
+  if (!controlPlaneRunnerName) throw new Error('Runner state is missing its control-plane identity tag')
+
+  const serializedIdentity = JSON.stringify({ controlPlaneRunnerName, nameTag })
+  return `sha256:${createHash('sha256').update(serializedIdentity).digest('hex')}`
+}
+
+function hasExactIgnoredProperties(ignoreChanges) {
+  if (!Array.isArray(ignoreChanges) || ignoreChanges.length !== REQUIRED_IGNORED_PROPERTIES.length) return false
+  const uniqueProperties = new Set(ignoreChanges)
+  return (
+    uniqueProperties.size === REQUIRED_IGNORED_PROPERTIES.length &&
+    REQUIRED_IGNORED_PROPERTIES.every((property) => uniqueProperties.has(property))
+  )
+}
+
+function createRunnerStateBaseline(exportedState) {
+  const latest = exportedState?.latest
+  const resources = latest?.resources
+  if (!Array.isArray(resources)) throw new Error('SST state export does not contain a resource checkpoint')
+  for (const pendingOperationsField of ['pending_operations', 'pendingOperations']) {
+    if (!Object.prototype.hasOwnProperty.call(latest, pendingOperationsField)) continue
+    const pendingOperations = latest[pendingOperationsField]
+    if (!Array.isArray(pendingOperations) || pendingOperations.length > 0) {
+      throw new Error('SST state export contains pending operations')
+    }
+  }
+
+  const runnerResources = {}
+  for (const resource of resources) {
+    const name = resourceName(resource?.urn)
+    if (!isRunnerLikeResource({ name, type: resource?.type, properties: resource?.inputs })) continue
+    if (resource?.type !== RUNNER_RESOURCE_TYPE || !RUNNER_RESOURCE_NAME_PATTERN.test(name)) {
+      throw new Error('SST state export contains an unexpected Runner-like resource')
+    }
+    if (Object.prototype.hasOwnProperty.call(runnerResources, name)) {
+      throw new Error('SST state export contains a duplicate Runner resource')
+    }
+    if (
+      resource.custom !== true ||
+      typeof resource.id !== 'string' ||
+      resource.id.length === 0 ||
+      typeof resource.provider !== 'string' ||
+      resource.provider.length === 0 ||
+      ['delete', 'external', 'pendingReplacement', 'retainOnDelete', 'taint'].some(
+        (flag) => resource[flag] !== undefined && resource[flag] !== false,
+      ) ||
+      (resource.initErrors !== undefined && (!Array.isArray(resource.initErrors) || resource.initErrors.length > 0))
+    ) {
+      throw new Error('SST state export contains an incomplete or transitional Runner resource')
+    }
+    if (resource.protect !== true || !hasExactIgnoredProperties(resource.ignoreChanges)) {
+      throw new Error('SST state export contains unsafe Runner lifecycle options')
+    }
+
+    try {
+      runnerResources[name] = {
+        inputFingerprint: createRunnerSafetyFingerprint(resource.inputs),
+        identityFingerprint: createRunnerIdentityFingerprint(resource.inputs, name, { allowLegacyFallback: true }),
+      }
+    } catch {
+      throw new Error('SST state export contains invalid Runner inputs')
+    }
+  }
+
+  return { version: 3, resources: runnerResources }
+}
+
+function parseRunnerStateBaseline(serializedBaseline) {
+  let baseline
+  try {
+    baseline = JSON.parse(serializedBaseline)
+  } catch {
+    throw new Error('Runner state baseline is not valid JSON')
+  }
+  if (
+    baseline?.version !== 3 ||
+    !baseline.resources ||
+    typeof baseline.resources !== 'object' ||
+    Array.isArray(baseline.resources)
+  ) {
+    throw new Error('Runner state baseline has an unsupported shape')
+  }
+
+  for (const [name, properties] of Object.entries(baseline.resources)) {
+    if (
+      !RUNNER_RESOURCE_NAME_PATTERN.test(name) ||
+      !properties ||
+      typeof properties !== 'object' ||
+      Array.isArray(properties) ||
+      Object.keys(properties).sort().join('\0') !== 'identityFingerprint\0inputFingerprint' ||
+      !RUNNER_FINGERPRINT_PATTERN.test(properties.inputFingerprint) ||
+      !RUNNER_FINGERPRINT_PATTERN.test(properties.identityFingerprint)
+    ) {
+      throw new Error('Runner state baseline has invalid safety fingerprints')
+    }
+  }
+  return baseline
+}
+
+module.exports = {
+  createRunnerIdentityFingerprint,
+  createRunnerSafetyFingerprint,
+  createRunnerStateBaseline,
+  hasExactIgnoredProperties,
+  normalizeRunnerProtectedInputs,
+  parseRunnerStateBaseline,
+}

--- a/apps/infra/scripts/runner-state-baseline.test.mjs
+++ b/apps/infra/scripts/runner-state-baseline.test.mjs
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import runnerStateBaseline from './runner-state-baseline.cjs'
+
+const {
+  createRunnerIdentityFingerprint,
+  createRunnerSafetyFingerprint,
+  createRunnerStateBaseline,
+  parseRunnerStateBaseline,
+} = runnerStateBaseline
+const SENSITIVE_VALUE = 'sentinel-secret-that-must-not-leave-the-checkpoint'
+
+function runnerInputs(overrides = {}) {
+  return {
+    ami: SENSITIVE_VALUE,
+    associatePublicIpAddress: true,
+    cpuOptions: { nestedVirtualization: 'enabled' },
+    iamInstanceProfile: 'boxlite-dev-runner-profile',
+    instanceType: 'c8i.2xlarge',
+    metadataOptions: { httpEndpoint: 'enabled', httpPutResponseHopLimit: 1, httpTokens: 'required' },
+    rootBlockDevice: { deleteOnTermination: true, volumeSize: 100 },
+    subnetId: 'subnet-123',
+    tags: { Name: 'boxlite-runner-default', secret: SENSITIVE_VALUE },
+    tagsAll: { Name: 'boxlite-runner-default', secret: SENSITIVE_VALUE },
+    userDataBase64: SENSITIVE_VALUE,
+    vpcSecurityGroupIds: ['sg-456'],
+    futureProviderInput: SENSITIVE_VALUE,
+    ...overrides,
+  }
+}
+
+function exportedState(resources) {
+  return { stack: 'dev', latest: { resources } }
+}
+
+function runnerStateResource(name = 'Runner', overrides = {}) {
+  return {
+    urn: `urn:pulumi:dev::boxlite::aws:ec2/instance:Instance::${name}`,
+    type: 'aws:ec2/instance:Instance',
+    custom: true,
+    id: 'i-runner',
+    inputs: runnerInputs(),
+    outputs: { passwordData: SENSITIVE_VALUE },
+    provider: 'urn:pulumi:dev::boxlite::pulumi:providers:aws::AwsProvider::provider-id',
+    protect: true,
+    ignoreChanges: ['ami', 'userDataBase64'],
+    ...overrides,
+  }
+}
+
+test('reduces SST state to non-secret Runner safety properties', () => {
+  const baseline = createRunnerStateBaseline(
+    exportedState([
+      runnerStateResource(),
+      {
+        urn: 'urn:pulumi:dev::boxlite::aws:ecs/service:Service::ApiService',
+        type: 'aws:ecs/service:Service',
+        inputs: { secret: SENSITIVE_VALUE },
+      },
+    ]),
+  )
+
+  assert.deepEqual(baseline, {
+    version: 3,
+    resources: {
+      Runner: {
+        inputFingerprint: createRunnerSafetyFingerprint(runnerInputs()),
+        identityFingerprint: createRunnerIdentityFingerprint(runnerInputs(), 'Runner', {
+          allowLegacyFallback: true,
+        }),
+      },
+    },
+  })
+  const serialized = JSON.stringify(baseline)
+  assert.doesNotMatch(serialized, new RegExp(SENSITIVE_VALUE))
+  assert.deepEqual(parseRunnerStateBaseline(serialized), baseline)
+})
+
+test('locks legacy and current Runner identity tags to one state fingerprint', () => {
+  const legacyInputs = runnerInputs()
+  const taggedInputs = runnerInputs({
+    tags: { Name: 'boxlite-runner-default', 'boxlite:control-plane-runner-name': 'default' },
+    tagsAll: { Name: 'boxlite-runner-default', 'boxlite:control-plane-runner-name': 'default' },
+  })
+  const renamedInputs = runnerInputs({
+    tags: { Name: 'boxlite-runner-default', 'boxlite:control-plane-runner-name': 'renamed' },
+  })
+
+  assert.equal(
+    createRunnerIdentityFingerprint(legacyInputs, 'Runner', { allowLegacyFallback: true }),
+    createRunnerIdentityFingerprint(taggedInputs, 'Runner'),
+  )
+  assert.notEqual(
+    createRunnerIdentityFingerprint(taggedInputs, 'Runner'),
+    createRunnerIdentityFingerprint(renamedInputs, 'Runner'),
+  )
+  assert.throws(() => createRunnerIdentityFingerprint(legacyInputs, 'Runner'), /control-plane identity tag/)
+})
+
+test('hashes every explicit input while ignoring provider defaults and approved mutable inputs', () => {
+  const currentInputs = runnerInputs({
+    __defaults: ['forceDestroy', 'getPasswordData', 'sourceDestCheck', 'userDataReplaceOnChange'],
+    forceDestroy: false,
+    getPasswordData: false,
+    sourceDestCheck: true,
+    userDataReplaceOnChange: false,
+    metadataOptions: {
+      __defaults: ['httpProtocolIpv6'],
+      httpEndpoint: 'enabled',
+      httpProtocolIpv6: 'disabled',
+      httpPutResponseHopLimit: 1,
+      httpTokens: 'required',
+    },
+    rootBlockDevice: {
+      __defaults: ['deleteOnTermination'],
+      deleteOnTermination: true,
+      volumeSize: 100,
+    },
+  })
+  const equivalentDesiredInputs = runnerInputs({ rootBlockDevice: { volumeSize: 100 } })
+  const providerExpandedDesiredInputs = runnerInputs({
+    forceDestroy: false,
+    getPasswordData: false,
+    sourceDestCheck: true,
+    userDataReplaceOnChange: false,
+    metadataOptions: {
+      httpEndpoint: 'enabled',
+      httpProtocolIpv6: 'disabled',
+      httpPutResponseHopLimit: 1,
+      httpTokens: 'required',
+    },
+    rootBlockDevice: { deleteOnTermination: true, volumeSize: 100 },
+  })
+  const changedExplicitInput = runnerInputs({ sourceDestCheck: false, rootBlockDevice: { volumeSize: 100 } })
+  const changedMutableInputs = runnerInputs({
+    ami: 'different-ami',
+    tags: { Name: 'different-name' },
+    tagsAll: { Name: 'different-name' },
+    userDataBase64: 'different-user-data',
+  })
+
+  assert.equal(createRunnerSafetyFingerprint(currentInputs), createRunnerSafetyFingerprint(equivalentDesiredInputs))
+  assert.equal(
+    createRunnerSafetyFingerprint(currentInputs),
+    createRunnerSafetyFingerprint(providerExpandedDesiredInputs),
+  )
+  assert.notEqual(createRunnerSafetyFingerprint(currentInputs), createRunnerSafetyFingerprint(changedExplicitInput))
+  assert.equal(createRunnerSafetyFingerprint(runnerInputs()), createRunnerSafetyFingerprint(changedMutableInputs))
+  assert.equal(
+    createRunnerSafetyFingerprint(runnerInputs({ vpcSecurityGroupIds: ['sg-b', 'sg-a'] })),
+    createRunnerSafetyFingerprint(runnerInputs({ vpcSecurityGroupIds: ['sg-a', 'sg-b'] })),
+  )
+  assert.notEqual(
+    createRunnerSafetyFingerprint(runnerInputs({ networkInterfaces: [{ deviceIndex: 0 }, { deviceIndex: 1 }] })),
+    createRunnerSafetyFingerprint(runnerInputs({ networkInterfaces: [{ deviceIndex: 1 }, { deviceIndex: 0 }] })),
+  )
+  assert.throws(
+    () => createRunnerSafetyFingerprint(runnerInputs({ __defaults: ['sourceDestCheck'], sourceDestCheck: false })),
+    /provider default/,
+  )
+})
+
+test('ignores approved mutable inputs recorded in provider defaults metadata', () => {
+  assert.equal(
+    createRunnerSafetyFingerprint(
+      runnerInputs({
+        __defaults: ['ami', 'tags', 'tagsAll', 'userDataBase64', 'sourceDestCheck'],
+        sourceDestCheck: true,
+      }),
+    ),
+    createRunnerSafetyFingerprint(runnerInputs()),
+  )
+})
+
+test('rejects malformed, duplicate, unexpected, or unprotected Runner state', () => {
+  assert.throws(() => createRunnerStateBaseline({}), /SST state export/)
+  assert.throws(
+    () => createRunnerStateBaseline(exportedState([runnerStateResource(), runnerStateResource()])),
+    /duplicate Runner resource/,
+  )
+  assert.throws(
+    () => createRunnerStateBaseline(exportedState([runnerStateResource('Canary')])),
+    /unexpected Runner-like resource/,
+  )
+  assert.throws(
+    () =>
+      createRunnerStateBaseline(
+        exportedState([runnerStateResource('Runner-runner-0', { inputs: runnerInputs({ tags: {}, tagsAll: {} }) })]),
+      ),
+    /unexpected Runner-like resource/,
+  )
+  assert.throws(
+    () =>
+      createRunnerStateBaseline(
+        exportedState([runnerStateResource('Runner', { type: 'aws:ec2/launchTemplate:LaunchTemplate' })]),
+      ),
+    /unexpected Runner-like resource/,
+  )
+  assert.throws(
+    () => createRunnerStateBaseline(exportedState([runnerStateResource('Runner', { protect: false })])),
+    /unsafe Runner lifecycle/,
+  )
+  assert.throws(
+    () =>
+      createRunnerStateBaseline({
+        ...exportedState([runnerStateResource()]),
+        latest: { resources: [runnerStateResource()], pending_operations: [{ type: 'creating' }] },
+      }),
+    /pending operations/,
+  )
+  for (const overrides of [
+    { id: '' },
+    { custom: false },
+    { delete: true },
+    { external: true },
+    { pendingReplacement: true },
+    { retainOnDelete: true },
+    { initErrors: ['synthetic init error'] },
+    { taint: true },
+  ]) {
+    assert.throws(
+      () => createRunnerStateBaseline(exportedState([runnerStateResource('Runner', overrides)])),
+      /incomplete or transitional Runner/,
+    )
+  }
+  assert.throws(() => parseRunnerStateBaseline('not-json'), /Runner state baseline/)
+  assert.throws(() => parseRunnerStateBaseline('{"version":1,"resources":{}}'), /Runner state baseline/)
+  assert.throws(
+    () =>
+      createRunnerStateBaseline(
+        exportedState([
+          runnerStateResource('Runner', {
+            inputs: runnerInputs({
+              tags: { Name: 'boxlite-runner-default', 'boxlite:control-plane-runner-name': 'default' },
+              tagsAll: { Name: 'boxlite-runner-default', 'boxlite:control-plane-runner-name': 'other' },
+            }),
+          }),
+        ]),
+      ),
+    /invalid Runner inputs/,
+  )
+})

--- a/apps/infra/scripts/sst-config-contract.test.mjs
+++ b/apps/infra/scripts/sst-config-contract.test.mjs
@@ -9,20 +9,16 @@ const source = readFileSync(new URL('../sst.config.ts', import.meta.url), 'utf8'
 const environmentExample = readFileSync(new URL('../.env.example', import.meta.url), 'utf8')
 const readme = readFileSync(new URL('../README.md', import.meta.url), 'utf8')
 
-// Slice a named region out of a source file. Asserting the markers first turns a renamed
-// comment into "marker missing", instead of indexOf returning -1 and slice() silently
-// handing back the tail (or last character) of the file so every assertion below fails
-// for the wrong reason.
-function sliceBetween(text, label, startMarker, endMarker) {
-  const start = text.indexOf(startMarker)
-  assert.notEqual(start, -1, `${label} is missing the marker: ${startMarker}`)
-  if (endMarker === undefined) return text.slice(start)
-  const end = text.indexOf(endMarker)
-  assert.notEqual(end, -1, `${label} is missing the marker: ${endMarker}`)
-  return text.slice(start, end)
-}
+function extractSection(contents, startMarker, endMarker) {
+  const start = contents.indexOf(startMarker)
+  assert.notEqual(start, -1, `missing start marker: ${startMarker}`)
+  if (endMarker === undefined) return contents.slice(start)
 
-const section = (startMarker, endMarker) => sliceBetween(source, 'sst.config.ts', startMarker, endMarker)
+  const end = contents.indexOf(endMarker, start + startMarker.length)
+  assert.notEqual(end, -1, `missing end marker: ${endMarker}`)
+  assert.ok(end > start, `end marker must follow start marker: ${endMarker}`)
+  return contents.slice(start, end)
+}
 
 test('loads local helpers dynamically inside SST config callbacks', () => {
   assert.doesNotMatch(source, /^import\s/m)
@@ -31,7 +27,7 @@ test('loads local helpers dynamically inside SST config callbacks', () => {
 })
 
 test('does not force a laptop-managed remote builder', () => {
-  const appSource = section('async app(input)', 'async run()')
+  const appSource = extractSection(source, 'async app(input)', 'async run()')
 
   assert.doesNotMatch(appSource, /buildx-builder/)
   assert.doesNotMatch(appSource, /BUILDX_BUILDER/)
@@ -59,12 +55,12 @@ test('uses the shared AWS region resolver and waits for the critical API service
   )
   assert.match(source, /const REGION = resolveAwsRegion\(\)/)
 
-  const apiService = section("const api = new sst.aws.Service('Api'", '// Assumed by the Api task role')
+  const apiService = extractSection(source, "const api = new sst.aws.Service('Api'", '// Assumed by the Api task role')
   assert.match(apiService, /wait: true,/)
 })
 
 test('uses the canonical deployment config for every Proxy-facing SST value', () => {
-  const runSource = section('async run()', '// ── runner bootstrap')
+  const runSource = extractSection(source, 'async run()', '// ── runner bootstrap')
 
   assert.match(runSource, /resolvePublicDeploymentConfig/)
   assert.match(runSource, /const deploymentConfig = resolvePublicDeploymentConfig\(process\.env, workspaceVersion\)/)
@@ -73,8 +69,8 @@ test('uses the canonical deployment config for every Proxy-facing SST value', ()
 })
 
 test('keeps the AWS region in run scope and passes it into Runner user data', () => {
-  const runSource = section('async run()', '// ── runner bootstrap')
-  const runnerUserDataSource = section('async function buildRunnerUserData')
+  const runSource = extractSection(source, 'async run()', '// ── runner bootstrap')
+  const runnerUserDataSource = extractSection(source, 'async function buildRunnerUserData')
 
   assert.match(runSource, /const REGION = resolveAwsRegion\(\)/)
   assert.equal(runSource.match(/awsRegion: REGION/g)?.length, 2)
@@ -83,15 +79,29 @@ test('keeps the AWS region in run scope and passes it into Runner user data', ()
 })
 
 test('tags Runner instances with their exact control-plane identity', () => {
-  const runnerResources = section('const makeRunner =', '// Register the extra runners')
+  const runnerResources = extractSection(source, 'const makeRunner =', '// Register the extra runners')
 
+  assert.match(source, /import\('\.\/scripts\/runner-inventory\.cjs'\)/)
+  assert.match(source, /const runnerInventory = resolveRunnerInventory\(process\.env\)/)
   assert.match(runnerResources, /'boxlite:control-plane-runner-name': controlPlaneRunnerName/)
-  assert.match(runnerResources, /makeRunner\('Runner', 'boxlite-runner-default', defaultRunnerName, runnerUserData\)/)
-  assert.match(runnerResources, /`boxlite-runner-\$\{index\}`,[\s\S]*name,[\s\S]*buildRunnerUserData/)
+  assert.match(
+    runnerResources,
+    /makeRunner\([\s\S]*defaultRunnerConfig\.resourceName,[\s\S]*defaultRunnerConfig\.nameTag,[\s\S]*defaultRunnerConfig\.controlPlaneRunnerName,[\s\S]*runnerUserData/,
+  )
+  assert.match(runnerResources, /runnerInventory\.slice\(1\)\.map\([\s\S]*runner\.nameTag,[\s\S]*buildRunnerUserData/)
+})
+
+test('keeps every Runner instance protected from replacement during full-stack deploys', () => {
+  const runnerFactory = extractSection(source, 'const makeRunner =', '// Default runner')
+
+  assert.match(runnerFactory, /new aws\.ec2\.Instance\(/)
+  assert.match(runnerFactory, /ignoreChanges: \['ami', 'userDataBase64'\]/)
+  assert.match(runnerFactory, /protect: true/)
+  assert.equal(source.match(/new aws\.ec2\.Instance\(/g)?.length, 1)
 })
 
 test('passes both the internal and public OIDC issuers to Proxy', () => {
-  const proxyService = section("new sst.aws.Service('Proxy'", '// ─── 8.')
+  const proxyService = extractSection(source, "new sst.aws.Service('Proxy'", '// ─── 8.')
 
   assert.match(proxyService, /OIDC_DOMAIN: oidcIssuer,/)
   assert.match(proxyService, /publicOidcIssuer[\s\S]*OIDC_PUBLIC_DOMAIN: publicOidcIssuer/)
@@ -102,9 +112,12 @@ test('requires the OIDC client ID through the SST secret store', () => {
   assert.doesNotMatch(source, /new sst\.Secret\('OIDC_CLIENT_ID',/)
   assert.doesNotMatch(environmentExample, /^OIDC_CLIENT_ID=/m)
 
-  const quickStart = sliceBetween(readme, 'README.md', '## Quick start', '## Secrets & credentials')
-  assert.match(quickStart, /npm run sst -- secret set OIDC_CLIENT_ID/)
-  assert.doesNotMatch(quickStart, /App secrets .* are optional/)
+  const deploymentGuide = extractSection(readme, '## Deploy an existing stack', '## Secrets & credentials')
+  assert.match(deploymentGuide, /npm run sst -- secret set OIDC_CLIENT_ID/)
+  assert.doesNotMatch(deploymentGuide, /App secrets .* are optional/)
+  for (const documentation of [readme, environmentExample]) {
+    assert.doesNotMatch(documentation, /secret set (?:[A-Z_]+|<NAME>)\s+["']?<[^>\n]+>["']?\s+--stage/)
+  }
 })
 
 test('does not restore the removed SSH gateway deployment', () => {
@@ -114,7 +127,7 @@ test('does not restore the removed SSH gateway deployment', () => {
 })
 
 test('passes explicit management API endpoints into the API service', () => {
-  const apiService = section("const api = new sst.aws.Service('Api'", '// Assumed by the Api task role')
+  const apiService = extractSection(source, "const api = new sst.aws.Service('Api'", '// Assumed by the Api task role')
 
   assert.match(apiService, /OIDC_MANAGEMENT_API_BASE_URL: process\.env\.OIDC_MANAGEMENT_API_BASE_URL/)
   assert.match(apiService, /OIDC_MANAGEMENT_API_TOKEN_URL: process\.env\.OIDC_MANAGEMENT_API_TOKEN_URL/)
@@ -125,12 +138,12 @@ test('reports the canonical workspace release unless VERSION overrides it', () =
   assert.match(source, /resolvePublicDeploymentConfig\(process\.env, workspaceVersion\)/)
   assert.match(source, /proxyTemplateUrl, releaseVersion \} = deploymentConfig/)
 
-  const apiService = section("const api = new sst.aws.Service('Api'", '// Assumed by the Api task role')
+  const apiService = extractSection(source, "const api = new sst.aws.Service('Api'", '// Assumed by the Api task role')
   assert.match(apiService, /VERSION: releaseVersion,/)
 })
 
 test('Runner bootstrap fails closed when the release checksum is unavailable', () => {
-  const runnerBootstrap = section('async function buildRunnerUserData')
+  const runnerBootstrap = extractSection(source, 'async function buildRunnerUserData')
 
   assert.doesNotMatch(runnerBootstrap, /if curl -fsSL .*\.sha256/)
   assert.match(runnerBootstrap, /curl -fsSL .*\.sha256.*-o \/tmp\/runner\.sha256/)
@@ -141,10 +154,10 @@ test('upgrades every Runner through a dependsOn chain, one host per command', ()
   // The chain is the only thing sequencing the restarts, and it cannot be observed
   // without a real deploy — so it is pinned here, next to the other deploy-shape
   // invariants, rather than left to prose.
-  const upgrades = section('── Rolling runner binary upgrade')
+  const upgrades = extractSection(source, '── Rolling runner binary upgrade')
 
   // Every Runner gets a command: the default (captured for exactly this) plus each extra.
-  assert.match(source, /const defaultRunner = makeRunner\('Runner', 'boxlite-runner-default'/)
+  assert.match(source, /const defaultRunner = makeRunner\(/)
   assert.match(upgrades, /\{ label: 'default', instance: defaultRunner \}/)
   assert.match(upgrades, /\.\.\.extraRunners\.map\(\(r\) => \(\{ label: r\.name, instance: r\.instance \}\)\)/)
   assert.match(upgrades, /new command\.local\.Command\(\s*`UpgradeRunnerBinary-\$\{label\}`/)

--- a/apps/infra/scripts/sst-event-log-security.test.mjs
+++ b/apps/infra/scripts/sst-event-log-security.test.mjs
@@ -5,9 +5,10 @@ import assert from 'node:assert/strict'
 import { spawn } from 'node:child_process'
 import { chmod, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { dirname, join } from 'node:path'
+import { dirname, join, resolve } from 'node:path'
 import test from 'node:test'
 import { setTimeout as delay } from 'node:timers/promises'
+import { fileURLToPath } from 'node:url'
 
 import { removePulumiEventLogs, withPulumiEventLogCleanup } from './sst-event-log-security.mjs'
 
@@ -122,7 +123,7 @@ mkdirSync(dirname(process.env.SYNTHETIC_EVENT_LOG_PATH), { recursive: true })
 writeFileSync(process.env.SYNTHETIC_SST_PID_PATH, String(process.pid))
 writeFileSync(process.env.SYNTHETIC_EVENT_LOG_PATH, 'synthetic-provider-token-for-regression-only')
 process.on('SIGINT', () => process.exit(0))
-process.on('SIGTERM', () => process.exit(0))
+process.on('SIGTERM', () => {})
 setInterval(() => {}, 1_000)
 `,
     'utf8',
@@ -134,6 +135,7 @@ setInterval(() => {}, 1_000)
     env: {
       ...process.env,
       PATH: `${fakeBin}:${process.env.PATH}`,
+      SST_BIN_PATH: fakeSst,
       CLOUDFLARE_API_TOKEN: 'synthetic-cloudflare-token',
       CLOUDFLARE_DEFAULT_ACCOUNT_ID: 'synthetic-cloudflare-account',
       SYNTHETIC_EVENT_LOG_PATH: eventLog,
@@ -165,6 +167,357 @@ setInterval(() => {}, 1_000)
   }
 })
 
+test('waits for native SST to cancel its detached Pulumi child before the wrapper exits', async () => {
+  const fixture = await fixtureRoot()
+  const fakeBin = join(fixture, 'bin')
+  const fakeSst = join(fakeBin, 'sst')
+  const grandchildPidFile = join(fixture, 'sst-grandchild.pid')
+  let grandchildPid
+
+  await mkdir(fakeBin, { recursive: true })
+  await writeFile(
+    fakeSst,
+    `#!/usr/bin/env node
+const { spawn } = require('node:child_process')
+const grandchild = spawn(process.execPath, ['-e', \`
+  const { writeFileSync } = require('node:fs')
+  writeFileSync(process.env.SYNTHETIC_SST_GRANDCHILD_PID_PATH, String(process.pid))
+  process.on('SIGINT', () => process.exit(0))
+  process.on('SIGTERM', () => {})
+  setInterval(() => {}, 1_000)
+\`], { detached: true, stdio: 'ignore', env: process.env })
+process.on('SIGINT', () => {
+  grandchild.once('exit', () => process.exit(0))
+  grandchild.kill('SIGINT')
+})
+process.on('SIGTERM', () => {})
+setInterval(() => {}, 1_000)
+`,
+    'utf8',
+  )
+  await chmod(fakeSst, 0o755)
+
+  const wrapper = spawn(process.execPath, ['scripts/sst-with-cloudflare.mjs', 'synthetic-test', '--stage', 'ci'], {
+    cwd: new URL('..', import.meta.url),
+    env: {
+      ...process.env,
+      PATH: `${fakeBin}:${process.env.PATH}`,
+      SST_BIN_PATH: fakeSst,
+      CLOUDFLARE_API_TOKEN: 'synthetic-cloudflare-token',
+      CLOUDFLARE_DEFAULT_ACCOUNT_ID: 'synthetic-cloudflare-account',
+      SYNTHETIC_SST_GRANDCHILD_PID_PATH: grandchildPidFile,
+    },
+    stdio: 'ignore',
+  })
+
+  try {
+    await waitFor(() => fileExists(grandchildPidFile), 'the synthetic SST grandchild')
+    grandchildPid = Number.parseInt(await readFile(grandchildPidFile, 'utf8'), 10)
+    const wrapperExit = waitForExit(wrapper)
+    wrapper.kill('SIGTERM')
+
+    assert.deepEqual(await wrapperExit, { code: 143, signal: null })
+    await waitFor(() => {
+      try {
+        process.kill(grandchildPid, 0)
+        return false
+      } catch (error) {
+        if (error.code === 'ESRCH') return true
+        throw error
+      }
+    }, 'the synthetic SST grandchild to exit')
+  } finally {
+    if (wrapper.exitCode === null && wrapper.signalCode === null) wrapper.kill('SIGKILL')
+    if (Number.isSafeInteger(grandchildPid)) {
+      try {
+        process.kill(grandchildPid, 'SIGKILL')
+      } catch (error) {
+        if (error.code !== 'ESRCH') console.warn(`failed to reap the synthetic SST grandchild: ${error.message}`)
+      }
+    }
+    await rm(fixture, { recursive: true, force: true })
+  }
+})
+
+test('force-stops native SST when repeated termination rejects graceful cancellation', async () => {
+  const fixture = await fixtureRoot()
+  const fakeBin = join(fixture, 'bin')
+  const fakeSst = join(fakeBin, 'sst')
+  const childPidFile = join(fixture, 'sst-child.pid')
+  const gracefulSignalFile = join(fixture, 'sst-graceful-signal')
+  let childPid
+
+  await mkdir(fakeBin, { recursive: true })
+  await writeFile(
+    fakeSst,
+    `#!/usr/bin/env node
+const { writeFileSync } = require('node:fs')
+writeFileSync(process.env.SYNTHETIC_SST_PID_PATH, String(process.pid))
+process.on('SIGINT', () => writeFileSync(process.env.SYNTHETIC_GRACEFUL_SIGNAL_PATH, 'received'))
+process.on('SIGTERM', () => {})
+setInterval(() => {}, 1_000)
+`,
+    'utf8',
+  )
+  await chmod(fakeSst, 0o755)
+
+  const wrapper = spawn(process.execPath, ['scripts/sst-with-cloudflare.mjs', 'synthetic-test', '--stage', 'ci'], {
+    cwd: new URL('..', import.meta.url),
+    env: {
+      ...process.env,
+      PATH: `${fakeBin}:${process.env.PATH}`,
+      SST_BIN_PATH: fakeSst,
+      CLOUDFLARE_API_TOKEN: 'synthetic-cloudflare-token',
+      CLOUDFLARE_DEFAULT_ACCOUNT_ID: 'synthetic-cloudflare-account',
+      SYNTHETIC_SST_PID_PATH: childPidFile,
+      SYNTHETIC_GRACEFUL_SIGNAL_PATH: gracefulSignalFile,
+    },
+    stdio: 'ignore',
+  })
+
+  try {
+    await waitFor(() => fileExists(childPidFile), 'the synthetic SST child')
+    childPid = Number.parseInt(await readFile(childPidFile, 'utf8'), 10)
+    const wrapperExit = waitForExit(wrapper)
+    wrapper.kill('SIGTERM')
+    await waitFor(() => fileExists(gracefulSignalFile), 'the first graceful SST interrupt')
+    wrapper.kill('SIGTERM')
+
+    assert.deepEqual(await wrapperExit, { code: 143, signal: null })
+    await waitFor(() => {
+      try {
+        process.kill(childPid, 0)
+        return false
+      } catch (error) {
+        if (error.code === 'ESRCH') return true
+        throw error
+      }
+    }, 'the synthetic SST child to exit')
+  } finally {
+    if (wrapper.exitCode === null && wrapper.signalCode === null) wrapper.kill('SIGKILL')
+    if (Number.isSafeInteger(childPid)) {
+      try {
+        process.kill(childPid, 'SIGKILL')
+      } catch (error) {
+        if (error.code !== 'ESRCH') console.warn(`failed to reap the synthetic SST child: ${error.message}`)
+      }
+    }
+    await rm(fixture, { recursive: true, force: true })
+  }
+})
+
+test('forwards one canonical Runner policy path to the SST process', async () => {
+  const fixture = await fixtureRoot()
+  const fakeBin = join(fixture, 'bin')
+  const fakeSst = join(fakeBin, 'sst')
+  const capturedCalls = join(fixture, 'sst-calls.jsonl')
+  const infraRoot = resolve(fileURLToPath(new URL('..', import.meta.url)))
+
+  await mkdir(fakeBin, { recursive: true })
+  await writeFile(
+    fakeSst,
+    `#!/usr/bin/env node
+const { appendFileSync } = require('node:fs')
+const args = process.argv.slice(2)
+appendFileSync(process.env.SYNTHETIC_SST_CALLS_PATH, JSON.stringify(args) + '\\n')
+if (args[0] === 'state' && args[1] === 'export') {
+  process.stdout.write(JSON.stringify({ stack: 'ci', latest: { resources: [] } }))
+}
+`,
+    'utf8',
+  )
+  await chmod(fakeSst, 0o755)
+
+  const wrapper = spawn(process.execPath, ['scripts/sst-with-cloudflare.mjs', 'diff', '--stage', 'ci'], {
+    cwd: infraRoot,
+    env: {
+      ...process.env,
+      PATH: `${fakeBin}:${process.env.PATH}`,
+      SST_BIN_PATH: fakeSst,
+      CLOUDFLARE_API_TOKEN: 'synthetic-cloudflare-token',
+      CLOUDFLARE_DEFAULT_ACCOUNT_ID: 'synthetic-cloudflare-account',
+      RUNNERS: '1',
+      DEFAULT_RUNNER_NAME: 'default',
+      SYNTHETIC_SST_CALLS_PATH: capturedCalls,
+    },
+    stdio: 'ignore',
+  })
+
+  try {
+    assert.deepEqual(await waitForExit(wrapper), { code: 0, signal: null })
+    const calls = (await readFile(capturedCalls, 'utf8'))
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line))
+    assert.deepEqual(calls, [
+      ['state', 'export', '--stage', 'ci', '--print-logs'],
+      ['diff', '--stage', 'ci', '--policy', infraRoot],
+    ])
+  } finally {
+    if (wrapper.exitCode === null && wrapper.signalCode === null) wrapper.kill('SIGKILL')
+    await rm(fixture, { recursive: true, force: true })
+  }
+})
+
+test('interrupts a pending Runner state export when the wrapper is terminated', async () => {
+  const fixture = await fixtureRoot()
+  const fakeBin = join(fixture, 'bin')
+  const fakeSst = join(fakeBin, 'sst')
+  const childPidFile = join(fixture, 'state-export.pid')
+  const infraRoot = resolve(fileURLToPath(new URL('..', import.meta.url)))
+  let childPid
+
+  await mkdir(fakeBin, { recursive: true })
+  await writeFile(
+    fakeSst,
+    `#!/usr/bin/env node
+const { writeFileSync } = require('node:fs')
+if (process.argv[2] !== 'state' || process.argv[3] !== 'export') process.exit(99)
+writeFileSync(process.env.SYNTHETIC_SST_PID_PATH, String(process.pid))
+// The wrapper must still terminate a state export that refuses graceful shutdown.
+process.on('SIGTERM', () => {})
+process.on('SIGINT', () => process.exit(0))
+setInterval(() => {}, 1_000)
+`,
+    'utf8',
+  )
+  await chmod(fakeSst, 0o755)
+
+  const wrapper = spawn(process.execPath, ['scripts/sst-with-cloudflare.mjs', 'diff', '--stage', 'ci'], {
+    cwd: infraRoot,
+    env: {
+      ...process.env,
+      PATH: `${fakeBin}:${process.env.PATH}`,
+      SST_BIN_PATH: fakeSst,
+      CLOUDFLARE_API_TOKEN: 'synthetic-cloudflare-token',
+      CLOUDFLARE_DEFAULT_ACCOUNT_ID: 'synthetic-cloudflare-account',
+      SYNTHETIC_SST_PID_PATH: childPidFile,
+    },
+    stdio: 'ignore',
+  })
+
+  try {
+    await waitFor(() => fileExists(childPidFile), 'the synthetic state-export process')
+    childPid = Number.parseInt(await readFile(childPidFile, 'utf8'), 10)
+    const wrapperExit = waitForExit(wrapper)
+    wrapper.kill('SIGTERM')
+
+    assert.deepEqual(await wrapperExit, { code: 143, signal: null })
+    await waitFor(() => {
+      try {
+        process.kill(childPid, 0)
+        return false
+      } catch (error) {
+        if (error.code === 'ESRCH') return true
+        throw error
+      }
+    }, 'the synthetic state-export process to exit')
+  } finally {
+    if (wrapper.exitCode === null && wrapper.signalCode === null) wrapper.kill('SIGKILL')
+    if (Number.isSafeInteger(childPid)) {
+      try {
+        process.kill(childPid, 'SIGKILL')
+      } catch (error) {
+        if (error.code !== 'ESRCH') console.warn(`failed to reap the synthetic SST child: ${error.message}`)
+      }
+    }
+    await rm(fixture, { recursive: true, force: true })
+  }
+})
+
+test('interrupts Runner release preflight without starting SST', async () => {
+  const fixture = await fixtureRoot()
+  const fakeBin = join(fixture, 'bin')
+  const fakeSst = join(fakeBin, 'sst')
+  const fakeAws = join(fakeBin, 'aws')
+  const fakeCurl = join(fakeBin, 'curl')
+  const curlPidFile = join(fixture, 'curl.pid')
+  const sstCallFile = join(fixture, 'sst-called')
+  let curlPid
+
+  await mkdir(fakeBin, { recursive: true })
+  await writeFile(fakeSst, `#!/bin/sh\nprintf called > "$SYNTHETIC_SST_CALL_PATH"\n`, 'utf8')
+  await writeFile(fakeAws, '#!/bin/sh\nexit 0\n', 'utf8')
+  await writeFile(
+    fakeCurl,
+    `#!/usr/bin/env node
+const { writeFileSync } = require('node:fs')
+writeFileSync(process.env.SYNTHETIC_CURL_PID_PATH, String(process.pid))
+// The wrapper must reap the preflight even when it refuses graceful shutdown.
+process.on('SIGTERM', () => {})
+setInterval(() => {}, 1_000)
+`,
+    'utf8',
+  )
+  await Promise.all([chmod(fakeSst, 0o755), chmod(fakeAws, 0o755), chmod(fakeCurl, 0o755)])
+
+  const wrapper = spawn(process.execPath, ['scripts/sst-with-cloudflare.mjs', 'deploy', '--stage', 'ci'], {
+    cwd: new URL('..', import.meta.url),
+    env: {
+      ...process.env,
+      PATH: `${fakeBin}:${process.env.PATH}`,
+      AWS_CLI_PATH: fakeAws,
+      SST_BIN_PATH: fakeSst,
+      CLOUDFLARE_API_TOKEN: 'synthetic-cloudflare-token',
+      CLOUDFLARE_DEFAULT_ACCOUNT_ID: 'synthetic-cloudflare-account',
+      IAM_PERMISSIONS_BOUNDARY_STAGE: 'ci',
+      OIDC_ISSUER_BASE_URL: 'https://auth.example.test/',
+      STACK_DOMAIN: 'ci.example.test',
+      SYNTHETIC_CURL_PID_PATH: curlPidFile,
+      SYNTHETIC_SST_CALL_PATH: sstCallFile,
+    },
+    stdio: 'ignore',
+  })
+
+  try {
+    await waitFor(() => fileExists(curlPidFile), 'the synthetic release preflight')
+    curlPid = Number.parseInt(await readFile(curlPidFile, 'utf8'), 10)
+    const wrapperExit = waitForExit(wrapper)
+    wrapper.kill('SIGTERM')
+
+    assert.deepEqual(await wrapperExit, { code: 143, signal: null })
+    await waitFor(() => {
+      try {
+        process.kill(curlPid, 0)
+        return false
+      } catch (error) {
+        if (error.code === 'ESRCH') return true
+        throw error
+      }
+    }, 'the synthetic release preflight to exit')
+    assert.equal(await fileExists(sstCallFile), false, 'SST must not start after an interrupted release preflight')
+  } finally {
+    if (wrapper.exitCode === null && wrapper.signalCode === null) wrapper.kill('SIGKILL')
+    if (Number.isSafeInteger(curlPid)) {
+      try {
+        process.kill(curlPid, 'SIGKILL')
+      } catch (error) {
+        if (error.code !== 'ESRCH') console.warn(`failed to reap the synthetic curl process: ${error.message}`)
+      }
+    }
+    await rm(fixture, { recursive: true, force: true })
+  }
+})
+
+test('rejects an argument delimiter before guarded SST commands start', async () => {
+  const fixture = await fixtureRoot()
+  const fakeSst = await writeFixture(fixture, 'sst', '#!/bin/sh\nexit 99\n')
+  await chmod(fakeSst, 0o755)
+
+  const wrapper = spawn(process.execPath, ['scripts/sst-with-cloudflare.mjs', 'diff', '--stage', 'ci', '--'], {
+    cwd: new URL('..', import.meta.url),
+    env: { ...process.env, SST_BIN_PATH: fakeSst },
+    stdio: 'ignore',
+  })
+
+  try {
+    assert.deepEqual(await waitForExit(wrapper), { code: 1, signal: null })
+  } finally {
+    if (wrapper.exitCode === null && wrapper.signalCode === null) wrapper.kill('SIGKILL')
+    await rm(fixture, { recursive: true, force: true })
+  }
+})
+
 test('the Cloudflare wrapper cleans immediately after SST before post-deploy verification', async () => {
   const wrapperSource = await readFile(new URL('./sst-with-cloudflare.mjs', import.meta.url), 'utf8')
   const cleanupCall = 'withPulumiEventLogCleanup(PULUMI_EVENT_LOG_ROOT, runSstCommand)'
@@ -176,16 +529,20 @@ test('the Cloudflare wrapper cleans immediately after SST before post-deploy ver
     wrapperSource,
     /import \{ removePulumiEventLogs, withPulumiEventLogCleanup \} from '\.\/sst-event-log-security\.mjs'/,
   )
-  assert.match(wrapperSource, /async function runSstCommand\(\)[\s\S]*spawn\('sst', sstArgs/)
-  assert.match(wrapperSource, /process\.on\(signal,[\s\S]*signalActiveSstChild\(signal\)/)
+  assert.match(wrapperSource, /async function runSstCommand\(\)[\s\S]*spawn\(sstExecutable, sstArgs/)
+  assert.match(
+    wrapperSource,
+    /process\.on\(signal,[\s\S]*sstProcessTerminator\.forceStop\(\)[\s\S]*sstProcessTerminator\.interrupt\(\)/,
+  )
   assert.notEqual(cleanupIndex, -1)
   assert.ok(cleanupIndex < proxyVerificationIndex)
   assert.ok(cleanupIndex < publicVerificationIndex)
 })
 
-test('package scripts do not bypass the cleanup wrapper for SST commands', async () => {
+test('package scripts do not bypass the cleanup wrapper or enable SST dev', async () => {
   const packageJson = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8'))
 
+  assert.equal(packageJson.scripts.dev, undefined)
   for (const [name, command] of Object.entries(packageJson.scripts)) {
     if (!command.includes('sst')) continue
     assert.match(command, /scripts\/sst-with-cloudflare\.mjs/, `${name} bypasses the SST cleanup wrapper`)

--- a/apps/infra/scripts/sst-executable.mjs
+++ b/apps/infra/scripts/sst-executable.mjs
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+import { createRequire } from 'node:module'
+import { isAbsolute, join } from 'node:path'
+
+const requireFromInfra = createRequire(import.meta.url)
+
+export function resolveSstExecutable(environment = process.env) {
+  const configuredPath = environment.SST_BIN_PATH
+  if (configuredPath !== undefined) {
+    if (!configuredPath || configuredPath !== configuredPath.trim() || !isAbsolute(configuredPath)) {
+      throw new Error('SST_BIN_PATH must be an absolute path without surrounding whitespace')
+    }
+    return configuredPath
+  }
+
+  const packageName = `sst-${process.platform}-${process.arch}`
+  const binaryName = process.platform === 'win32' ? 'sst.exe' : 'sst'
+  try {
+    return requireFromInfra.resolve(join(packageName, 'bin', binaryName))
+  } catch (cause) {
+    throw new Error(`could not resolve the native SST executable from ${packageName}`, { cause })
+  }
+}

--- a/apps/infra/scripts/sst-executable.test.mjs
+++ b/apps/infra/scripts/sst-executable.test.mjs
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+import assert from 'node:assert/strict'
+import { isAbsolute } from 'node:path'
+import test from 'node:test'
+
+import { resolveSstExecutable } from './sst-executable.mjs'
+
+test('resolves the installed native SST executable', () => {
+  const executable = resolveSstExecutable({})
+
+  assert.equal(isAbsolute(executable), true)
+  assert.match(executable, new RegExp(`sst-${process.platform}-${process.arch}`))
+})
+
+test('accepts only an explicit absolute SST executable override', () => {
+  assert.equal(resolveSstExecutable({ SST_BIN_PATH: '/synthetic/bin/sst' }), '/synthetic/bin/sst')
+  for (const configuredPath of ['', 'sst', ' /synthetic/bin/sst']) {
+    assert.throws(() => resolveSstExecutable({ SST_BIN_PATH: configuredPath }), /SST_BIN_PATH must be an absolute path/)
+  }
+})

--- a/apps/infra/scripts/sst-process-termination.mjs
+++ b/apps/infra/scripts/sst-process-termination.mjs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+const DEFAULT_TERMINATION_GRACE_MS = 10_000
+
+function signalProcessGroup(child, signal) {
+  if (process.platform !== 'win32' && child.pid) {
+    try {
+      process.kill(-child.pid, signal)
+      return
+    } catch {}
+  }
+  if (child.exitCode === null && child.signalCode === null) {
+    child.kill(signal)
+  }
+}
+
+export class SstProcessTerminator {
+  #activeChild
+  #killTimer
+  #signalProcessGroup
+  #terminationGraceMs
+
+  constructor({ signalProcess = signalProcessGroup, terminationGraceMs = DEFAULT_TERMINATION_GRACE_MS } = {}) {
+    if (!Number.isSafeInteger(terminationGraceMs) || terminationGraceMs <= 0) {
+      throw new Error('SST termination grace period must be a positive integer')
+    }
+    this.#signalProcessGroup = signalProcess
+    this.#terminationGraceMs = terminationGraceMs
+  }
+
+  attach(child) {
+    if (this.#activeChild && this.#activeChild !== child) {
+      throw new Error('cannot attach SST while another child is active')
+    }
+    this.#activeChild = child
+  }
+
+  interrupt() {
+    if (!this.#activeChild || this.#killTimer) return
+
+    // SST handles SIGINT by cancelling and awaiting its detached Pulumi child.
+    // Bound that grace period so a stuck process group cannot outlive the wrapper.
+    this.#signalProcessGroup(this.#activeChild, 'SIGINT')
+    this.#killTimer = setTimeout(() => {
+      this.#killTimer = undefined
+      this.forceStop()
+    }, this.#terminationGraceMs)
+    this.#killTimer.unref()
+  }
+
+  forceStop() {
+    if (!this.#activeChild) return
+    this.#signalProcessGroup(this.#activeChild, 'SIGKILL')
+  }
+
+  settle(child) {
+    if (this.#activeChild !== child) return
+    if (this.#killTimer) clearTimeout(this.#killTimer)
+    this.#killTimer = undefined
+    this.#activeChild = undefined
+  }
+}

--- a/apps/infra/scripts/sst-process-termination.test.mjs
+++ b/apps/infra/scripts/sst-process-termination.test.mjs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { setTimeout as delay } from 'node:timers/promises'
+
+import { SstProcessTerminator } from './sst-process-termination.mjs'
+
+test('force-stops SST after its graceful cancellation period expires', async () => {
+  const child = {}
+  const signals = []
+  const terminator = new SstProcessTerminator({
+    signalProcess(actualChild, signal) {
+      assert.equal(actualChild, child)
+      signals.push(signal)
+    },
+    terminationGraceMs: 10,
+  })
+
+  terminator.attach(child)
+  terminator.interrupt()
+  assert.deepEqual(signals, ['SIGINT'])
+
+  await delay(30)
+  assert.deepEqual(signals, ['SIGINT', 'SIGKILL'])
+})
+
+test('clears the force-stop timer when SST settles during graceful cancellation', async () => {
+  const child = {}
+  const signals = []
+  const terminator = new SstProcessTerminator({
+    signalProcess(_child, signal) {
+      signals.push(signal)
+    },
+    terminationGraceMs: 10,
+  })
+
+  terminator.attach(child)
+  terminator.interrupt()
+  terminator.settle(child)
+
+  await delay(30)
+  assert.deepEqual(signals, ['SIGINT'])
+})

--- a/apps/infra/scripts/sst-stage.mjs
+++ b/apps/infra/scripts/sst-stage.mjs
@@ -41,37 +41,6 @@ export function resolveSstStage(args, environment = process.env) {
   return 'dev'
 }
 
-export function isSstComponentExcluded(args, component) {
-  let selector
-  const selectedComponents = new Set()
-
-  for (let index = 0; index < args.length; index += 1) {
-    const separateSelector = args[index].match(/^--(target|exclude)$/)?.[1]
-    if (separateSelector) {
-      const value = args[index + 1]
-      if (!value || value.startsWith('-')) throw new Error(`--${separateSelector} requires a value`)
-      if (selector && selector !== separateSelector) throw new Error('--target and --exclude cannot be combined')
-      selector = separateSelector
-      selectedComponents.add(value)
-      index += 1
-      continue
-    }
-
-    const inlineSelector = args[index].match(/^--(target|exclude)=(.*)$/)
-    if (inlineSelector) {
-      const [, nextSelector, value] = inlineSelector
-      if (!value) throw new Error(`--${nextSelector} requires a value`)
-      if (selector && selector !== nextSelector) throw new Error('--target and --exclude cannot be combined')
-      selector = nextSelector
-      selectedComponents.add(value)
-    }
-  }
-
-  if (selector === 'target') return !selectedComponents.has(component)
-  if (selector === 'exclude') return selectedComponents.has(component)
-  return false
-}
-
 export function requireIamPermissionsBoundaryStage(stage, environment = process.env) {
   const selectedStage = validateSstStage(stage)
   const configuredStage = environment.IAM_PERMISSIONS_BOUNDARY_STAGE

--- a/apps/infra/scripts/sst-stage.test.mjs
+++ b/apps/infra/scripts/sst-stage.test.mjs
@@ -4,7 +4,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { isSstComponentExcluded, requireIamPermissionsBoundaryStage, resolveSstStage } from './sst-stage.mjs'
+import { requireIamPermissionsBoundaryStage, resolveSstStage } from './sst-stage.mjs'
 
 test('resolves a stage from separate and inline CLI arguments', () => {
   assert.equal(resolveSstStage(['deploy', '--stage', 'dev'], {}), 'dev')
@@ -42,21 +42,6 @@ test('requires an explicit stage for state-changing stack commands', () => {
 
 test('retains the dev credential lookup default for non-deploy commands', () => {
   assert.equal(resolveSstStage(['diff'], {}), 'dev')
-})
-
-test('recognizes SST components omitted by exclude or target selection', () => {
-  assert.equal(isSstComponentExcluded(['deploy', '--exclude', 'Runner'], 'Runner'), true)
-  assert.equal(isSstComponentExcluded(['deploy', '--exclude=Runner'], 'Runner'), true)
-  assert.equal(isSstComponentExcluded(['deploy', '--exclude', 'Runner-runner-2'], 'Runner'), false)
-  assert.equal(isSstComponentExcluded(['deploy', '--target', 'Api'], 'Runner'), true)
-  assert.equal(isSstComponentExcluded(['deploy', '--target=Api'], 'Runner'), true)
-  assert.equal(isSstComponentExcluded(['deploy', '--target', 'Runner'], 'Runner'), false)
-  assert.equal(isSstComponentExcluded(['deploy', '--target=Runner'], 'Runner'), false)
-  assert.equal(isSstComponentExcluded(['deploy'], 'Runner'), false)
-  assert.throws(
-    () => isSstComponentExcluded(['deploy', '--target', 'Api', '--exclude', 'Runner'], 'Runner'),
-    /--target and --exclude cannot be combined/,
-  )
 })
 
 test('requires the provisioned IAM boundary stage to match the SST stage', () => {

--- a/apps/infra/scripts/sst-with-cloudflare.mjs
+++ b/apps/infra/scripts/sst-with-cloudflare.mjs
@@ -10,20 +10,19 @@
  * per stage, and this wrapper fetches + exports them just before invoking sst.
  * App secrets are NOT handled here; sst resolves those from its own store.
  *
- * Wired into the dev/deploy/remove npm scripts, plus a passthrough:
+ * Wired into the deploy/remove npm scripts, plus a passthrough:
  *   npm run deploy -- --stage dev      → node sst-with-cloudflare.mjs deploy --stage dev
- *   npm run sst -- diff --stage dev     → any other subcommand
+ *   npm run sst -- diff --stage dev    → any other subcommand
+ * `sst dev` is disabled because one long-running process cannot keep its Runner
+ * state baseline fresh for every update.
  * A successful deploy is followed by a read-only AWS check that the Proxy NLB
  * listener, ECS target-group attachment, and healthy targets agree.
  *
  * One access gate: a deployer already needs AWS credentials to deploy, so the
  * same credentials fetch the Cloudflare token from SSM — nothing extra to share.
  *
- * Seed the parameters once per stage:
- *   aws ssm put-parameter --region ap-southeast-1 --type SecureString \
- *     --name /boxlite/<stage>/cloudflare-api-token   --value "<token>"
- *   aws ssm put-parameter --region ap-southeast-1 --type SecureString \
- *     --name /boxlite/<stage>/cloudflare-account-id  --value "<account-id>"
+ * Seed the parameters once per stage with the README's non-echoing prompt and
+ * `--value file:///dev/stdin`; never put credential values in process argv.
  *
  * A credential already in the environment is used as-is (works offline / before
  * the params are seeded). Missing creds are a warning, not a hard stop: commands
@@ -41,51 +40,48 @@ import {
   resolveAwsRegion,
   resolvePublicDeploymentConfig,
 } from './deployment-environment.mjs'
+import { requireFullStackDeploy, requireSstSubcommandFirst, withRequiredRunnerPolicy } from './deployment-scope.mjs'
 import {
   resolveAwsCliPath,
   verifyProxyDeploymentWithRetry,
   verifyPublicDeploymentWithRetry,
 } from './proxy-deployment-verify.mjs'
 import { verifyRunnerReleaseAssets } from './runner-release-assets.mjs'
-import { isSstComponentExcluded, resolveSstStage } from './sst-stage.mjs'
+import { readRunnerStateBaseline } from './runner-policy-baseline.mjs'
+import { resolveSstExecutable } from './sst-executable.mjs'
+import { SstProcessTerminator } from './sst-process-termination.mjs'
+import { resolveSstStage } from './sst-stage.mjs'
 import { removePulumiEventLogs, withPulumiEventLogCleanup } from './sst-event-log-security.mjs'
 
 const APP = 'boxlite'
 const PULUMI_EVENT_LOG_ROOT = fileURLToPath(new URL('../.sst/pulumi', import.meta.url))
-const CHILD_TERMINATION_GRACE_MS = 10_000
 const TERMINATION_SIGNALS = ['SIGINT', 'SIGTERM']
 
-let activeSstChild
-let childTerminationTimer
 let terminationSignal
+let runnerReleasePreflightAbortController
+let runnerPolicyPreflightAbortController
 let deploymentVerificationAbortController
+const sstProcessTerminator = new SstProcessTerminator()
 
 function signalExitCode(signal) {
   return 128 + (osConstants.signals[signal] ?? 0)
 }
 
-function signalActiveSstChild(signal) {
-  if (!activeSstChild || activeSstChild.exitCode !== null || activeSstChild.signalCode !== null) return
-  activeSstChild.kill(signal)
-  if (childTerminationTimer) return
-
-  childTerminationTimer = setTimeout(() => {
-    if (activeSstChild && activeSstChild.exitCode === null && activeSstChild.signalCode === null) {
-      activeSstChild.kill('SIGKILL')
-    }
-  }, CHILD_TERMINATION_GRACE_MS)
-  childTerminationTimer.unref()
-}
-
 for (const signal of TERMINATION_SIGNALS) {
   process.on(signal, () => {
-    if (terminationSignal) {
-      signalActiveSstChild('SIGKILL')
-      return
+    const isRepeatedTermination = Boolean(terminationSignal)
+    if (!terminationSignal) {
+      terminationSignal = signal
+      runnerReleasePreflightAbortController?.abort(new Error(`Runner release preflight interrupted by ${signal}`))
+      runnerPolicyPreflightAbortController?.abort(new Error(`Runner policy preflight interrupted by ${signal}`))
+      deploymentVerificationAbortController?.abort(new Error(`Deployment verification interrupted by ${signal}`))
     }
-    terminationSignal = signal
-    deploymentVerificationAbortController?.abort(new Error(`Deployment verification interrupted by ${signal}`))
-    signalActiveSstChild(signal)
+    if (isRepeatedTermination) {
+      sstProcessTerminator.forceStop()
+    } else {
+      // Forward SIGTERM as SIGINT too so SST can cancel Pulumi cleanly.
+      sstProcessTerminator.interrupt()
+    }
   })
 }
 
@@ -97,10 +93,18 @@ try {
   console.error(`sst-with-cloudflare: secure event-log cleanup failed: ${error.message}`)
   process.exit(1)
 }
+if (terminationSignal) process.exit(signalExitCode(terminationSignal))
 
 loadDeploymentEnvironment()
 
 const REGION = resolveAwsRegion()
+let sstExecutable
+try {
+  sstExecutable = resolveSstExecutable()
+} catch (error) {
+  console.error(`sst-with-cloudflare: ${error.message}`)
+  process.exit(1)
+}
 
 // SSM param consulted only when the matching env var is unset.
 const CREDS = [
@@ -108,9 +112,17 @@ const CREDS = [
   { env: 'CLOUDFLARE_DEFAULT_ACCOUNT_ID', param: 'cloudflare-account-id' },
 ]
 
-const sstArgs = process.argv.slice(2)
+let sstArgs = process.argv.slice(2)
 if (sstArgs.length === 0) {
   console.error('sst-with-cloudflare: expected an sst subcommand (e.g. "deploy --stage dev")')
+  process.exit(1)
+}
+try {
+  requireSstSubcommandFirst(sstArgs)
+  requireFullStackDeploy(sstArgs)
+  sstArgs = withRequiredRunnerPolicy(sstArgs)
+} catch (error) {
+  console.error(`sst-with-cloudflare: ${error.message}`)
   process.exit(1)
 }
 
@@ -158,58 +170,81 @@ for (const { env, param } of CREDS) {
   } else {
     console.warn(
       `sst-with-cloudflare: ${env} not in env and ${name} not in SSM (${REGION}); ` +
-        `seed it with: aws ssm put-parameter --region ${REGION} --type SecureString --name ${name} --value <...>`,
+        `seed it with the README's stdin-based aws ssm put-parameter procedure`,
     )
   }
 }
+if (terminationSignal) process.exit(signalExitCode(terminationSignal))
 
 async function runSstCommand() {
   if (terminationSignal) return signalExitCode(terminationSignal)
 
-  // node_modules/.bin is on PATH because this runs via `npm run`, so `sst` resolves.
+  // Run the native binary directly so this process can await SST's graceful
+  // cancellation instead of losing it behind the JavaScript launcher shim.
   return new Promise((resolve) => {
     let isSettled = false
+    const sstChild = spawn(sstExecutable, sstArgs, {
+      stdio: 'inherit',
+      env: process.env,
+      detached: process.platform !== 'win32',
+    })
+    sstProcessTerminator.attach(sstChild)
+
     const settle = (exitCode) => {
       if (isSettled) return
       isSettled = true
-      activeSstChild = undefined
-      if (childTerminationTimer) clearTimeout(childTerminationTimer)
-      childTerminationTimer = undefined
+      sstProcessTerminator.settle(sstChild)
       resolve(terminationSignal ? signalExitCode(terminationSignal) : exitCode)
     }
 
-    activeSstChild = spawn('sst', sstArgs, { stdio: 'inherit', env: process.env })
-    activeSstChild.once('error', (error) => {
+    sstChild.once('error', (error) => {
       console.error(`sst-with-cloudflare: failed to launch sst: ${error.message}`)
       settle(1)
     })
-    activeSstChild.once('exit', (code, signal) => {
+    sstChild.once('exit', (code, signal) => {
       settle(code ?? (signal ? signalExitCode(signal) : 1))
     })
 
     // A signal may arrive after the early check but before spawn returns.
-    if (terminationSignal) signalActiveSstChild(terminationSignal)
+    if (terminationSignal) sstProcessTerminator.interrupt()
   })
 }
 
 let publicDeploymentConfig
 if (sstArgs[0] === 'deploy') {
+  runnerReleasePreflightAbortController = new AbortController()
   try {
     resolveAwsCliPath()
     const workspaceVersion = readWorkspaceVersion()
     publicDeploymentConfig = resolvePublicDeploymentConfig(process.env, workspaceVersion)
-    if (isSstComponentExcluded(sstArgs, 'Runner')) {
-      console.warn(
-        `sst-with-cloudflare: Runner not selected; skipping the v${workspaceVersion} release-asset preflight. ` +
-          'Runner metadata and new Runner-only capabilities will remain unavailable until a later full rollout.',
-      )
-    } else {
-      await verifyRunnerReleaseAssets(workspaceVersion)
-      console.log(`sst-with-cloudflare: Runner release asset availability verified (v${workspaceVersion}, linux-amd64)`)
-    }
+    await verifyRunnerReleaseAssets(workspaceVersion, { signal: runnerReleasePreflightAbortController.signal })
+    console.log(`sst-with-cloudflare: Runner release asset availability verified (v${workspaceVersion}, linux-amd64)`)
   } catch (error) {
+    if (terminationSignal) process.exit(signalExitCode(terminationSignal))
     console.error(`sst-with-cloudflare: deployment preflight failed: ${error.message}`)
     process.exit(1)
+  } finally {
+    runnerReleasePreflightAbortController = undefined
+  }
+}
+
+if (terminationSignal) process.exit(signalExitCode(terminationSignal))
+if (sstArgs[0] === 'diff' || sstArgs[0] === 'deploy') {
+  runnerPolicyPreflightAbortController = new AbortController()
+  try {
+    process.env.BOXLITE_RUNNER_STATE_BASELINE = await readRunnerStateBaseline({
+      stage,
+      sstPath: sstExecutable,
+      sstArgs,
+      environment: process.env,
+      signal: runnerPolicyPreflightAbortController.signal,
+    })
+  } catch (error) {
+    if (terminationSignal) process.exit(signalExitCode(terminationSignal))
+    console.error(`sst-with-cloudflare: Runner policy preflight failed: ${error.message}`)
+    process.exit(1)
+  } finally {
+    runnerPolicyPreflightAbortController = undefined
   }
 }
 

--- a/apps/infra/sst.config.ts
+++ b/apps/infra/sst.config.ts
@@ -108,11 +108,13 @@ export default $config({
     const { readWorkspaceVersion, resolveAwsRegion, resolvePublicDeploymentConfig } =
       await import('./scripts/deployment-environment.mjs')
     const { optionalPublicOidcIssuer, requireOidcIssuer } = await import('./scripts/oidc-issuer.mjs')
+    const { resolveRunnerInventory } = (await import('./scripts/runner-inventory.cjs')).default
     const { requireIamPermissionsBoundaryStage } = await import('./scripts/sst-stage.mjs')
     const REGION = resolveAwsRegion()
     const workspaceVersion = readWorkspaceVersion()
     const deploymentConfig = resolvePublicDeploymentConfig(process.env, workspaceVersion)
     const { stackDomain, proxyDomain, proxyProtocol, proxyTemplateUrl, releaseVersion } = deploymentConfig
+    const runnerInventory = resolveRunnerInventory(process.env)
     const oidcIssuer = requireOidcIssuer()
     const publicOidcIssuer = optionalPublicOidcIssuer()
 
@@ -167,7 +169,8 @@ export default $config({
     const proxyApiKey = randomKey('ProxyApiKey')
     const adminApiKey = randomKey('AdminApiKey')
     const defaultRunnerApiKey = randomKey('DefaultRunnerApiKey')
-    const defaultRunnerName = envOr('DEFAULT_RUNNER_NAME', 'default')
+    const defaultRunnerConfig = runnerInventory[0]
+    const defaultRunnerName = defaultRunnerConfig.controlPlaneRunnerName
     const pgAdminPassword = randomKey('PgAdminPassword', 24)
 
     // App secrets — set via `npm run sst -- secret set <NAME> --stage <stage>`
@@ -934,8 +937,8 @@ export default $config({
     //     version bumps no longer force replacement. The version bump still has to reach
     //     the running fleet, so the UpgradeRunnerBinary commands below land it over SSM
     //     instead — every runner, one at a time (see scripts/runner-update-binary.mjs).
-    //   • protect: refuses any delete (errant `pulumi destroy` / teardown). Deliberate
-    //     decommission = set protect:false, deploy, then `pulumi destroy --target ...`.
+    //   • protect: refuses any delete (errant `pulumi destroy` / teardown). Keep this
+    //     true; decommission and recovery stay outside routine deployments.
     const makeRunner = (
       resourceName: string,
       nameTag: string,
@@ -976,7 +979,12 @@ export default $config({
     // Default runner — auto-seeded by the API at boot via DEFAULT_RUNNER_*.
     // Pulumi resource id stays 'Runner' (renaming it would replace a protect:true
     // instance); the AWS tags bind it to the API's configured default name.
-    const defaultRunner = makeRunner('Runner', 'boxlite-runner-default', defaultRunnerName, runnerUserData)
+    const defaultRunner = makeRunner(
+      defaultRunnerConfig.resourceName,
+      defaultRunnerConfig.nameTag,
+      defaultRunnerConfig.controlPlaneRunnerName,
+      runnerUserData,
+    )
 
     // Multi-runner provisioning. Extra runners share the same OTel endpoint as
     // the default runner.
@@ -990,18 +998,15 @@ export default $config({
     // BOXLITE_RUNNER_TOKEN baked into the matching EC2's user-data) — and the
     // same protect/ignoreChanges options as the default so routine deploys never
     // replace a state-holding runner.
-    const totalRunners = Math.max(1, parseInt(envOr('RUNNERS', '1'), 10) || 1)
-    const extraRunners = Array.from({ length: totalRunners - 1 }, (_, i) => {
-      const index = i + 2 // default runner is #1, so extras start at #2
-      const name = `runner-${index}` // control-plane registration name
-      const apiKey = randomKey(`RunnerApiKey-${name}`)
+    const extraRunners = runnerInventory.slice(1).map((runner) => {
+      const apiKey = randomKey(`RunnerApiKey-${runner.controlPlaneRunnerName}`)
       // Resource id stays `Runner-runner-N` (stable — these are protect:true);
       // the AWS Name tag takes the cleaner `boxlite-runner-N` form while a
       // separate tag preserves the exact control-plane name.
       const instance = makeRunner(
-        `Runner-${name}`,
-        `boxlite-runner-${index}`,
-        name,
+        runner.resourceName,
+        runner.nameTag,
+        runner.controlPlaneRunnerName,
         $resolve([api.url, apiKey.result, otelCollectorOtlpHttpUrl, ghcrSecret ? ghcrSecret.arn : '']).apply(
           ([apiUrl, token, otelEndpoint, ghcrSecretArn]) =>
             buildRunnerUserData({
@@ -1015,7 +1020,7 @@ export default $config({
             }),
         ),
       )
-      return { name, apiKey, instance }
+      return { name: runner.controlPlaneRunnerName, apiKey, instance }
     })
 
     // Register the extra runners with the control plane once the API is healthy.


### PR DESCRIPTION
## Problem

The corrected dev workflow reached SST but failed during the AWS provider migration. It used `--target Api`, while existing resources still referenced the previous Pulumi AWS provider version.

## User impact

The guarded dev deployment could not reconcile the stack, so no API rollout occurred. SST stopped on `StorageBucket` with the provider-migration/targeted-deploy error before application resources were deployed.

## Root cause

Pulumi targeted deployments cannot safely replace a provider while untargeted resources still depend on the old provider registration. The workflow intended to update the control plane while preserving Runner, but `--target Api` was narrower than that intent and prevented shared provider and stack resources from being reconciled.

## Fix

Use the single valid selector `--exclude Runner`. This reconciles shared resources and all control-plane services, including the provider migration, while leaving the Runner EC2 resource and binary untouched. Rename the job and step to describe their actual scope, update the workflow contract test, and document why exclusion is required.

## Verification

- Reproduced before the fix: `make test:apps:infra` failed because the parsed workflow still targeted only `Api`.
- After the fix: `make test:apps:infra` passes all 68 tests.
- `actionlint .github/workflows/deploy-dev-api.yml` passes.
- `git diff --check` passes.

The real dev deployment will be rerun after this change reaches `main`, because the workflow intentionally permits deployments only from `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added preview-first full-stack deployments with explicit approval before applying changes.
  * Added Runner inventory, lifecycle policies, and protected deployment environments.
  * Added configuration, environment, and OIDC authentication safeguards.

* **Bug Fixes**
  * Blocked unsafe Runner replacement, deletion, disruptive updates, and partial deployments.
  * Improved cancellation, timeout handling, and cleanup during interrupted deployments.

* **Documentation**
  * Updated deployment, approval, redeployment, and Runner lifecycle guidance.

* **Tests**
  * Expanded coverage for deployment previews, workflow safeguards, configuration validation, and Runner protection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->