### PR TITLE
fix(rootfs): key guest rootfs cache on the resolved guest binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,7 +573,7 @@ dependencies = [
  "seccompiler",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "signal-hook",
  "sysinfo",
  "tar",

--- a/src/boxlite/Cargo.toml
+++ b/src/boxlite/Cargo.toml
@@ -74,7 +74,10 @@ oci-client = { version = "0.15", default-features = false, features = ["rustls-t
 oci-spec = "0.8.3"
 tar = "0.4"
 flate2 = "1.0"
-sha2 = "0.10"
+# 0.11 picks the CPU's SHA extensions at runtime via cpufeatures; 0.10's portable
+# fallback costs ~36 ms release / ~690 ms debug on the 18 MB guest binary, which is
+# what forced the old compile-time BOXLITE_GUEST_HASH proxy.
+sha2 = "0.11"
 xattr = "1.0"
 walkdir = "2.5"
 filetime = "0.2"
@@ -112,7 +115,8 @@ pathrs = "0.2"      # openat2(RESOLVE_IN_ROOT) safe path resolution for OCI extr
 [build-dependencies]
 pkg-config = "0.3"
 regex = "1"
-sha2 = "0.10"
+sha2 = "0.11"
+hex = "0.4.3"
 
 [target.'cfg(target_os = "linux")'.build-dependencies]
 cc = "1"  # Compile C helpers (KVM smoke test)

--- a/src/boxlite/build.rs
+++ b/src/boxlite/build.rs
@@ -4,7 +4,6 @@ use std::cell::OnceCell;
 use std::env;
 use std::fs;
 use std::io;
-use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -797,7 +796,7 @@ impl EmbeddedManifest {
                 .unwrap_or_else(|e| panic!("Failed to read {} for hashing: {}", path.display(), e));
             hasher.update(&content);
         }
-        let hash = format!("{:x}", hasher.finalize());
+        let hash = hex::encode(hasher.finalize());
         let prefix = &hash[..12];
         println!("cargo:rustc-env=BOXLITE_MANIFEST_HASH={}", prefix);
         println!(
@@ -1097,99 +1096,6 @@ fn sign_shim_with_entitlements(binary: &Path) {
         }
     }
 }
-/// Computes and embeds the `boxlite-guest` binary hash.
-///
-/// Search order:
-/// 1. Direct build output: `target/{target-triple}/{profile}/boxlite-guest`
-/// 2. `runtime_dir` (OUT_DIR/runtime/ — for prebuilt mode)
-///
-/// IMPORTANT: The source binary (direct build output) must be checked FIRST because
-/// this runs before embedded manifest generation in main(). The OUT_DIR/runtime/ copy
-/// may be from a previous build and stale when the guest binary was rebuilt.
-///
-/// If the binary isn't found, silently skips — runtime will compute the hash as fallback.
-struct GuestBinaryHash<'a> {
-    runtime_dir: &'a Path,
-    mode: &'a DepsMode,
-    cargo: &'a CargoBuildContext,
-}
-
-impl<'a> GuestBinaryHash<'a> {
-    /// Create a guest binary hash emitter.
-    fn new(runtime_dir: &'a Path, mode: &'a DepsMode, cargo: &'a CargoBuildContext) -> Self {
-        Self {
-            runtime_dir,
-            mode,
-            cargo,
-        }
-    }
-
-    /// Emit BOXLITE_GUEST_HASH when a guest binary is available.
-    fn emit(&self) {
-        let Some(guest_path) = self.guest_path() else {
-            println!("cargo:warning=boxlite-guest not found, skipping compile-time hash");
-            return;
-        };
-
-        match Self::sha256_file(&guest_path) {
-            Ok(hash) => {
-                println!("cargo:rustc-env=BOXLITE_GUEST_HASH={}", hash);
-                println!("cargo:rerun-if-changed={}", guest_path.display());
-                println!(
-                    "cargo:warning=Embedded guest hash: {}... (from {})",
-                    &hash[..12],
-                    guest_path.display()
-                );
-            }
-            Err(e) => {
-                println!(
-                    "cargo:warning=Failed to hash boxlite-guest at {}: {}",
-                    guest_path.display(),
-                    e
-                );
-            }
-        }
-    }
-
-    /// Pick the best available guest binary for hashing.
-    fn guest_path(&self) -> Option<PathBuf> {
-        let profile = env::var("PROFILE").unwrap_or_else(|_| "debug".to_string());
-        self.source_guest_path(&profile)
-            .or_else(|| self.runtime_guest_path())
-    }
-
-    /// Find the workspace-built guest binary in source builds.
-    fn source_guest_path(&self, profile: &str) -> Option<PathBuf> {
-        if !matches!(self.mode, DepsMode::Source) {
-            return None;
-        }
-
-        let workspace_root = self.cargo.workspace_root()?;
-        EmbeddedManifest::find_prebuilt_guest(workspace_root, profile)
-    }
-
-    /// Find the guest binary already copied into OUT_DIR/runtime.
-    fn runtime_guest_path(&self) -> Option<PathBuf> {
-        let path = self.runtime_dir.join("boxlite-guest");
-        path.is_file().then_some(path)
-    }
-
-    /// Compute SHA256 hex digest of a file.
-    fn sha256_file(path: &Path) -> io::Result<String> {
-        let mut file = fs::File::open(path)?;
-        let mut hasher = Sha256::new();
-        let mut buffer = vec![0u8; 64 * 1024];
-        loop {
-            let n = file.read(&mut buffer)?;
-            if n == 0 {
-                break;
-            }
-            hasher.update(&buffer[..n]);
-        }
-        Ok(format!("{:x}", hasher.finalize()))
-    }
-}
-
 /// Collects all FFI dependencies into a single runtime directory.
 /// This directory can be used by downstream crates (e.g., Python SDK) to
 /// bundle all required libraries and binaries together.
@@ -1287,10 +1193,6 @@ fn main() {
 
     // Expose the runtime directory to downstream crates (e.g., Python SDK)
     println!("cargo:runtime_dir={}", runtime_dir.display());
-
-    // Compute and embed guest binary hash at compile time (best-effort).
-    // Falls back to runtime computation if the binary isn't available yet.
-    GuestBinaryHash::new(&runtime_dir, &mode, &cargo).emit();
 
     // Generate embedded runtime manifest (include_bytes! for self-contained SDKs)
     EmbeddedManifest::new(&runtime_dir).generate(&mode, &cargo);

--- a/src/boxlite/src/disk/base_disk.rs
+++ b/src/boxlite/src/disk/base_disk.rs
@@ -16,7 +16,10 @@
 //! dependents. If none exist, the base is deleted and GC cascades to the
 //! parent base disk.
 
+use std::collections::HashSet;
+use std::fs;
 use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
 
 use boxlite_shared::errors::BoxliteResult;
 use serde::{Deserialize, Serialize};
@@ -78,6 +81,10 @@ pub(crate) struct BaseDiskManager {
 }
 
 impl BaseDiskManager {
+    /// How long a base file must sit untouched before the orphan sweep may
+    /// consider it. Covers the window between `install`'s rename and its insert.
+    const ORPHAN_GRACE: Duration = Duration::from_secs(300);
+
     pub(crate) fn new(bases_dir: PathBuf, store: BaseDiskStore) -> Self {
         // Canonicalize once at construction so all path comparisons are consistent
         // with the canonical backing paths written by write_cow_child_header().
@@ -96,6 +103,189 @@ impl BaseDiskManager {
     #[allow(dead_code)] // used in tests
     pub(crate) fn bases_dir(&self) -> &Path {
         &self.bases_dir
+    }
+
+    /// Every base file something still depends on, following chains to the end.
+    ///
+    /// Three dimensions have to be covered or live data becomes reachable:
+    /// - **Both** overlays a box owns — `disk.qcow2`, backed by a clone base or
+    ///   snapshot, and `guest-rootfs.qcow2`, backed by a rootfs base. Reading one
+    ///   makes live bases of the other kind look unclaimed.
+    /// - The **full** chain, not just the immediate backing file, since clone
+    ///   bases nest (see `find_parent_base` and `try_gc_base`'s parent cascade).
+    /// - Chains rooted at the **bases themselves**, not only at box overlays. A
+    ///   clone base points at its parent (`test_create_base_disk_tracks_ancestry`
+    ///   builds exactly that), so a parent whose row went missing would otherwise
+    ///   be deleted out from under a child that still has one.
+    ///
+    /// Over-reporting is the safe direction: if a whole chain is orphaned, the
+    /// leaf is collected on this pass and its parent on the next, so the sweep
+    /// still converges.
+    ///
+    /// `read_backing_chain` returns partial results on a read error and caps at
+    /// `MAX_BACKING_CHAIN_DEPTH`, so this can under-report. It is one of two
+    /// independent guards in [`Self::gc_orphans`], never the sole authority.
+    pub(crate) fn referenced_backing_paths(&self, boxes_dir: &Path) -> HashSet<PathBuf> {
+        let mut referenced = HashSet::new();
+
+        match fs::read_dir(boxes_dir) {
+            Ok(entries) => {
+                for entry in entries.flatten() {
+                    let disks_dir = entry.path().join("disks");
+                    for overlay in [
+                        disk_filenames::CONTAINER_DISK,
+                        disk_filenames::GUEST_ROOTFS_DISK,
+                    ] {
+                        let overlay_path = disks_dir.join(overlay);
+                        if overlay_path.exists() {
+                            referenced.extend(super::read_backing_chain(&overlay_path));
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                if boxes_dir.exists() {
+                    tracing::warn!(
+                        "GC: failed to read boxes dir {}: {}",
+                        boxes_dir.display(),
+                        e
+                    );
+                }
+            }
+        }
+
+        // Ancestry between bases themselves.
+        match fs::read_dir(&self.bases_dir) {
+            Ok(entries) => {
+                for entry in entries.flatten() {
+                    referenced.extend(super::read_backing_chain(&entry.path()));
+                }
+            }
+            Err(e) => {
+                if self.bases_dir.exists() {
+                    tracing::warn!(
+                        "GC: failed to read bases dir {}: {}",
+                        self.bases_dir.display(),
+                        e
+                    );
+                }
+            }
+        }
+
+        referenced
+    }
+
+    /// Delete base files that nothing claims.
+    ///
+    /// The per-kind collectors work from DB records, so a file whose row is gone
+    /// — a crash between the rename and the insert, a hand-edited database, a
+    /// schema reset — becomes permanently invisible to them and is never
+    /// reclaimed. This sweep starts from the filesystem instead.
+    ///
+    /// A file is deleted only when **both** hold, because snapshots are user data
+    /// that no collector may remove:
+    /// - no `base_disk` row of *any* kind names it, and
+    /// - nothing backs onto it — see [`Self::referenced_backing_paths`], which
+    ///   covers box overlays and base-to-base ancestry alike.
+    ///
+    /// The two guards are independent on purpose: each can miss (a lost row, an
+    /// unreadable qcow2 header, a chain deeper than the walk), so a file has to
+    /// look unclaimed to *both* before it is removed.
+    ///
+    /// Files younger than [`Self::ORPHAN_GRACE`] are skipped: `install` renames a
+    /// file into place before inserting its row, so a fresh entry looks unclaimed
+    /// for a moment. `RuntimeLock` already excludes a concurrent installer; the
+    /// grace period costs nothing and removes the reliance on that.
+    pub(crate) fn gc_orphans(&self, boxes_dir: &Path) -> BoxliteResult<usize> {
+        let entries = match fs::read_dir(&self.bases_dir) {
+            Ok(entries) => entries,
+            Err(e) => {
+                if self.bases_dir.exists() {
+                    tracing::warn!(
+                        "GC: failed to read bases dir {}: {}",
+                        self.bases_dir.display(),
+                        e
+                    );
+                }
+                return Ok(0);
+            }
+        };
+        let referenced = self.referenced_backing_paths(boxes_dir);
+        let now = SystemTime::now();
+
+        let mut removed = 0;
+        let mut reclaimed_bytes = 0u64;
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let Some(extension) = path.extension().and_then(|e| e.to_str()) else {
+                continue;
+            };
+            // Only the two shapes this manager creates; never touch anything else
+            // that happens to sit in the directory.
+            if !matches!(extension, "ext4" | "qcow2") {
+                continue;
+            }
+
+            let Ok(metadata) = entry.metadata() else {
+                continue;
+            };
+            if !metadata.is_file() {
+                continue;
+            }
+
+            let settled = metadata
+                .modified()
+                .ok()
+                .and_then(|mtime| now.duration_since(mtime).ok())
+                .is_some_and(|age| age >= Self::ORPHAN_GRACE);
+            if !settled {
+                continue;
+            }
+
+            if referenced.contains(&path) {
+                continue;
+            }
+            // Fail closed, as `try_gc_base` does: a DB error must never read as
+            // "unclaimed". One SQLITE_BUSY during `recover_boxes` would otherwise
+            // sweep every settled file here, snapshots included.
+            let claimed = match self.store.find_by_base_path(&path.to_string_lossy()) {
+                Ok(record) => record.is_some(),
+                Err(e) => {
+                    tracing::warn!(
+                        path = %path.display(),
+                        "GC: cannot determine whether a base disk is claimed, keeping it: {}",
+                        e
+                    );
+                    true
+                }
+            };
+            if claimed {
+                continue;
+            }
+
+            tracing::info!(
+                path = %path.display(),
+                size_mb = metadata.len() / (1024 * 1024),
+                "GC: removing orphaned base disk (no DB record, no overlay reference)"
+            );
+            match fs::remove_file(&path) {
+                Ok(()) => {
+                    removed += 1;
+                    reclaimed_bytes += metadata.len();
+                }
+                Err(e) => tracing::warn!("GC: failed to remove {}: {}", path.display(), e),
+            }
+        }
+
+        if removed > 0 {
+            tracing::info!(
+                removed,
+                reclaimed_mb = reclaimed_bytes / (1024 * 1024),
+                "GC: reclaimed orphaned base disks"
+            );
+        }
+        Ok(removed)
     }
 
     /// Core operation: create a base disk from a box's live container disk.
@@ -606,5 +796,208 @@ mod tests {
             "Base should be deleted (no more dependents)"
         );
         assert!(!base_file.exists());
+    }
+
+    /// Backdate past `ORPHAN_GRACE` so the sweep will consider the file.
+    fn age(path: &Path) {
+        let old = filetime::FileTime::from_system_time(
+            SystemTime::now() - BaseDiskManager::ORPHAN_GRACE * 2,
+        );
+        filetime::set_file_mtime(path, old).unwrap();
+    }
+
+    fn insert_row(mgr: &BaseDiskManager, id: &str, kind: BaseDiskKind, path: &Path) {
+        mgr.store()
+            .insert(&BaseDisk {
+                id: base_id(id),
+                source_box_id: "__global__".to_string(),
+                name: Some(id.to_string()),
+                kind,
+                disk_info: DiskInfo {
+                    base_path: path.to_string_lossy().to_string(),
+                    container_disk_bytes: 0,
+                    size_bytes: 0,
+                },
+                created_at: 0,
+            })
+            .unwrap();
+    }
+
+    /// Only a file that *nothing* claims may be deleted.
+    ///
+    /// The per-kind collectors iterate DB records, so a file whose row is gone is
+    /// invisible to them and accumulates forever. This sweep starts from the
+    /// filesystem — which means it must not mistake a snapshot, a clone base, or
+    /// an overlay's backing file for garbage.
+    #[test]
+    fn gc_orphans_removes_only_unclaimed_files() {
+        let (dir, mgr) = setup();
+        let boxes_dir = dir.path().join("boxes");
+
+        // 1. Unclaimed — no DB row, no overlay. The only legitimate target.
+        let orphan = mgr.bases_dir.join("orphan01.ext4");
+        std::fs::write(&orphan, b"unclaimed").unwrap();
+        age(&orphan);
+
+        // 2. Claimed by a DB row, and a Snapshot at that — user data.
+        let snapshot = mgr.bases_dir.join("snapshot.qcow2");
+        std::fs::write(&snapshot, b"user snapshot").unwrap();
+        age(&snapshot);
+        insert_row(&mgr, "snapshot", BaseDiskKind::Snapshot, &snapshot);
+
+        // 3. No DB row, but a live box's guest-rootfs overlay backs onto it.
+        let backed = mgr.bases_dir.join("backed001.ext4");
+        std::fs::write(&backed, b"still in use").unwrap();
+        age(&backed);
+        let box_disks = boxes_dir.join("box-1").join("disks");
+        std::fs::create_dir_all(&box_disks).unwrap();
+        write_qcow2_with_backing(
+            &box_disks.join(disk_filenames::GUEST_ROOTFS_DISK),
+            Some(&backed.to_string_lossy()),
+        );
+
+        // 4. No DB row, but a container overlay backs onto it. Scanning only
+        //    guest-rootfs.qcow2 would delete this one.
+        let clone_base = mgr.bases_dir.join("clonebas.qcow2");
+        std::fs::write(&clone_base, b"clone base").unwrap();
+        age(&clone_base);
+        let box2_disks = boxes_dir.join("box-2").join("disks");
+        std::fs::create_dir_all(&box2_disks).unwrap();
+        write_qcow2_with_backing(
+            &box2_disks.join(disk_filenames::CONTAINER_DISK),
+            Some(&clone_base.to_string_lossy()),
+        );
+
+        let removed = mgr.gc_orphans(&boxes_dir).unwrap();
+
+        assert_eq!(removed, 1, "exactly one file was unclaimed");
+        assert!(!orphan.exists(), "unclaimed file should be reclaimed");
+        assert!(snapshot.exists(), "a snapshot must never be auto-deleted");
+        assert!(
+            backed.exists(),
+            "guest-rootfs overlay still backs onto this"
+        );
+        assert!(
+            clone_base.exists(),
+            "container overlay still backs onto this"
+        );
+    }
+
+    /// Clone bases nest, and a mid-chain base with no DB row is precisely what
+    /// this sweep exists to handle — so it must not be reachable by deleting it.
+    #[test]
+    fn gc_orphans_follows_the_whole_backing_chain() {
+        let (dir, mgr) = setup();
+        let boxes_dir = dir.path().join("boxes");
+
+        // bd1 <- bd2 <- overlay. Neither base has a DB row.
+        let bd1 = mgr.bases_dir.join("chain001.qcow2");
+        write_qcow2_with_backing(&bd1, None);
+        age(&bd1);
+        let bd2 = mgr.bases_dir.join("chain002.qcow2");
+        write_qcow2_with_backing(&bd2, Some(&bd1.to_string_lossy()));
+        age(&bd2);
+
+        let box_disks = boxes_dir.join("box-1").join("disks");
+        std::fs::create_dir_all(&box_disks).unwrap();
+        write_qcow2_with_backing(
+            &box_disks.join(disk_filenames::CONTAINER_DISK),
+            Some(&bd2.to_string_lossy()),
+        );
+
+        let removed = mgr.gc_orphans(&boxes_dir).unwrap();
+
+        assert_eq!(removed, 0, "every link in a live chain is in use");
+        assert!(bd2.exists(), "immediate backing file");
+        assert!(
+            bd1.exists(),
+            "grandparent — reachable only by walking the chain"
+        );
+    }
+
+    /// A base's parent may be reachable only through the child, never through a
+    /// box overlay — `create_base_disk` chains bases directly.
+    ///
+    /// If the parent's row is the one that went missing, scanning only box
+    /// overlays would delete it out from under a child that is still tracked.
+    #[test]
+    fn gc_orphans_follows_ancestry_between_bases() {
+        let (dir, mgr) = setup();
+
+        // bd1 <- bd2, no box overlay anywhere. Only bd2 keeps a DB row.
+        let bd1 = mgr.bases_dir.join("parent01.qcow2");
+        write_qcow2_with_backing(&bd1, None);
+        age(&bd1);
+        let bd2 = mgr.bases_dir.join("child001.qcow2");
+        write_qcow2_with_backing(&bd2, Some(&bd1.to_string_lossy()));
+        age(&bd2);
+        insert_row(&mgr, "child001", BaseDiskKind::CloneBase, &bd2);
+
+        let removed = mgr.gc_orphans(&dir.path().join("boxes")).unwrap();
+
+        assert_eq!(removed, 0, "a tracked child still needs its parent");
+        assert!(bd2.exists(), "claimed by its DB row");
+        assert!(bd1.exists(), "claimed only by its child's backing chain");
+    }
+
+    /// A database error must never read as "unclaimed".
+    ///
+    /// `try_gc_base` already fails closed (`has_dependents(..).unwrap_or(true)`).
+    /// This sweep deletes, so failing open here would let one transient error
+    /// during `recover_boxes` take out every settled file, snapshots included.
+    #[test]
+    fn gc_orphans_keeps_files_when_the_db_cannot_be_read() {
+        let dir = TempDir::new().unwrap();
+        let db = Database::open(&dir.path().join("db").join("test.db")).unwrap();
+        let bases_dir = dir.path().join("bases");
+        std::fs::create_dir_all(&bases_dir).unwrap();
+        let mgr = BaseDiskManager::new(bases_dir, BaseDiskStore::new(db.clone()));
+
+        let base = mgr.bases_dir.join("atrisk01.ext4");
+        std::fs::write(&base, b"unclaimed as far as a broken DB can tell").unwrap();
+        age(&base);
+
+        // Make every `find_by_base_path` return Err rather than Ok(None).
+        // Dropping the table is what a query error looks like from the caller's
+        // side, without depending on page-cache behaviour.
+        db.conn().execute("DROP TABLE base_disk", []).unwrap();
+
+        let removed = mgr.gc_orphans(&dir.path().join("boxes")).unwrap();
+
+        assert_eq!(removed, 0, "an unreadable DB must not authorise deletion");
+        assert!(base.exists(), "files must survive a DB error");
+    }
+
+    /// A file installed moments ago has not had its DB row written yet.
+    #[test]
+    fn gc_orphans_spares_freshly_written_files() {
+        let (dir, mgr) = setup();
+
+        let fresh = mgr.bases_dir.join("fresh001.ext4");
+        std::fs::write(&fresh, b"just renamed into place").unwrap();
+
+        let removed = mgr.gc_orphans(&dir.path().join("boxes")).unwrap();
+
+        assert_eq!(removed, 0);
+        assert!(
+            fresh.exists(),
+            "a file inside the grace window must survive"
+        );
+    }
+
+    /// The sweep owns two filename shapes; anything else in the directory is
+    /// not its to delete.
+    #[test]
+    fn gc_orphans_ignores_unrecognized_files() {
+        let (dir, mgr) = setup();
+
+        let stray = mgr.bases_dir.join("notes.txt");
+        std::fs::write(&stray, b"not ours").unwrap();
+        age(&stray);
+
+        let removed = mgr.gc_orphans(&dir.path().join("boxes")).unwrap();
+
+        assert_eq!(removed, 0);
+        assert!(stray.exists());
     }
 }

--- a/src/boxlite/src/images/archive/verifier.rs
+++ b/src/boxlite/src/images/archive/verifier.rs
@@ -61,7 +61,7 @@ impl LayerVerifier {
             }
             hasher.update(&buffer[..n]);
         }
-        let computed = format!("{:x}", hasher.finalize());
+        let computed = hex::encode(hasher.finalize());
         if computed != self.expected_hash {
             tracing::error!(
                 "DiffID mismatch for {}: expected sha256:{}, computed sha256:{}",
@@ -93,7 +93,7 @@ mod tests {
     fn accepts_matching_in_memory_stream() {
         use sha2::Digest;
         let payload = b"boxlite layer verifier test bytes";
-        let expected = format!("sha256:{:x}", sha2::Sha256::digest(payload));
+        let expected = format!("sha256:{}", hex::encode(sha2::Sha256::digest(payload)));
         let verifier = LayerVerifier::new(&expected).unwrap();
         assert!(verifier.verify_reader(&payload[..], None).unwrap());
     }
@@ -113,7 +113,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
 
         let tar_data = b"fake-tar-bytes-for-hashing";
-        let expected = format!("sha256:{:x}", sha2::Sha256::digest(tar_data));
+        let expected = format!("sha256:{}", hex::encode(sha2::Sha256::digest(tar_data)));
 
         let mut gz = GzEncoder::new(Vec::new(), Compression::default());
         gz.write_all(tar_data).unwrap();
@@ -132,7 +132,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
 
         let tar_data = b"uncompressed-tar-bytes";
-        let expected = format!("sha256:{:x}", sha2::Sha256::digest(tar_data));
+        let expected = format!("sha256:{}", hex::encode(sha2::Sha256::digest(tar_data)));
 
         let path = tmp.path().join("layer.tar");
         std::fs::write(&path, tar_data).unwrap();

--- a/src/boxlite/src/images/object.rs
+++ b/src/boxlite/src/images/object.rs
@@ -288,7 +288,7 @@ impl ImageObject {
         for layer in &self.manifest.layers {
             hasher.update(layer.digest.as_bytes());
         }
-        format!("sha256:{:x}", hasher.finalize())
+        format!("sha256:{}", hex::encode(hasher.finalize()))
     }
 
     // ========================================================================

--- a/src/boxlite/src/images/storage.rs
+++ b/src/boxlite/src/images/storage.rs
@@ -155,7 +155,7 @@ impl ImageStorage {
 
         let mut hasher = Sha256::new();
         hasher.update(&file_data);
-        let computed_hash = format!("sha256:{:x}", hasher.finalize());
+        let computed_hash = format!("sha256:{}", hex::encode(hasher.finalize()));
 
         if computed_hash != digest {
             tracing::error!(
@@ -485,7 +485,7 @@ impl<W> HashingWriter<W> {
     /// Consume the writer and return (inner_writer, hex_hash, bytes_written).
     pub fn finalize(self) -> (W, String, u64) {
         use sha2::Digest;
-        let hash = format!("{:x}", self.hasher.finalize());
+        let hash = hex::encode(self.hasher.finalize());
         (self.inner, hash, self.bytes_written)
     }
 }
@@ -812,7 +812,7 @@ mod tests {
         use tokio::io::AsyncWriteExt;
 
         let data = b"hello world - hashing writer test";
-        let expected_hash = format!("{:x}", sha2::Sha256::digest(data));
+        let expected_hash = hex::encode(sha2::Sha256::digest(data));
 
         let buf = Vec::new();
         let mut writer = HashingWriter::new(buf);
@@ -834,7 +834,7 @@ mod tests {
         use sha2::Digest;
         use tokio::io::AsyncWriteExt;
 
-        let hash = format!("{:x}", sha2::Sha256::digest(content));
+        let hash = hex::encode(sha2::Sha256::digest(content));
         let digest = format!("sha256:{}", hash);
         let mut staged = store
             .stage_layer_download(&digest, expected_size)

--- a/src/boxlite/src/images/store.rs
+++ b/src/boxlite/src/images/store.rs
@@ -536,7 +536,7 @@ impl ImageStore {
         // path never re-downloads — so re-verify the bytes here before trusting
         // their DiffIDs. Otherwise a corrupted / tampered cached config could
         // supply attacker-chosen rootfs.diff_ids and defeat layer verification.
-        let computed = format!("sha256:{:x}", Sha256::digest(&config_bytes));
+        let computed = format!("sha256:{}", hex::encode(Sha256::digest(&config_bytes)));
         if computed != config_digest {
             return Err(BoxliteError::Storage(format!(
                 "image config digest mismatch: expected {}, computed {} ({} bytes)",
@@ -1696,7 +1696,7 @@ mod tests {
     /// `load_diff_ids_from_config`'s digest check passes.
     fn write_config_blob(inner: &ImageStoreInner, bytes: &[u8]) -> String {
         use sha2::{Digest, Sha256};
-        let digest = format!("sha256:{:x}", Sha256::digest(bytes));
+        let digest = format!("sha256:{}", hex::encode(Sha256::digest(bytes)));
         let path = inner.storage.config_path(&digest);
         std::fs::create_dir_all(path.parent().unwrap()).unwrap();
         std::fs::write(&path, bytes).unwrap();

--- a/src/boxlite/src/litebox/archive.rs
+++ b/src/boxlite/src/litebox/archive.rs
@@ -260,7 +260,7 @@ pub(crate) fn sha256_file(path: &Path) -> BoxliteResult<String> {
         hasher.update(&buf[..n]);
     }
 
-    Ok(format!("sha256:{:x}", hasher.finalize()))
+    Ok(format!("sha256:{}", hex::encode(hasher.finalize())))
 }
 
 #[cfg(test)]

--- a/src/boxlite/src/rootfs/guest.rs
+++ b/src/boxlite/src/rootfs/guest.rs
@@ -1,21 +1,18 @@
 //! Guest rootfs types and metadata.
 
-use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::sync::OnceLock;
 
 use boxlite_shared::errors::{BoxliteError, BoxliteResult};
 
 use crate::disk::{
     BaseDisk, BaseDiskKind, BaseDiskManager, Disk, DiskFormat, inject_file_into_ext4,
-    read_backing_file_path,
 };
 use crate::images::{ImageDiskManager, ImageObject};
 #[cfg(test)]
 use crate::runtime::id::BaseDiskID;
 use crate::runtime::id::BaseDiskIDMint;
-use crate::util;
+use crate::vmm::guest_binary::GuestBinary;
 
 /// A fully resolved and ready-to-use guest rootfs.
 ///
@@ -262,7 +259,6 @@ impl GuestRootfs {
 pub struct GuestRootfsManager {
     base_disk_mgr: BaseDiskManager,
     temp_dir: PathBuf,
-    guest_hash: OnceLock<Result<String, String>>,
 }
 
 /// Sentinel source_box_id for global rootfs cache entries.
@@ -273,18 +269,6 @@ impl GuestRootfsManager {
         Self {
             base_disk_mgr,
             temp_dir,
-            guest_hash: OnceLock::new(),
-        }
-    }
-
-    /// Get the cached guest binary hash, computing it once on first access.
-    fn cached_guest_hash(&self) -> BoxliteResult<&str> {
-        let cached = self
-            .guest_hash
-            .get_or_init(|| Self::guest_binary_hash().map_err(|e| e.to_string()));
-        match cached {
-            Ok(hash) => Ok(hash.as_str()),
-            Err(msg) => Err(BoxliteError::Storage(msg.clone())),
         }
     }
 
@@ -312,17 +296,13 @@ impl GuestRootfsManager {
 
         // Stage 2: versioned guest rootfs
         let digest = image.compute_image_digest();
-        let hash_start = std::time::Instant::now();
-        let guest_hash = self.cached_guest_hash()?;
-        tracing::info!(
-            elapsed_ms = hash_start.elapsed().as_millis() as u64,
-            "get_or_create: cached_guest_hash done"
-        );
-        let version_key = Self::version_key(&digest, guest_hash);
+        let guest = GuestBinary::get()?;
+        let version_key = Self::version_key(&digest, guest.id());
 
         if let Some(disk) = self.find(&version_key) {
             tracing::info!(
                 version_key = %version_key,
+                commit = boxlite_shared::GIT_COMMIT.unwrap_or("unknown"),
                 total_ms = total_start.elapsed().as_millis() as u64,
                 "get_or_create: CACHE HIT"
             );
@@ -333,9 +313,7 @@ impl GuestRootfsManager {
             version_key = %version_key,
             "get_or_create: CACHE MISS — building guest rootfs"
         );
-        let disk = self
-            .build_and_install(&image_disk, &digest, &version_key)
-            .await?;
+        let disk = self.build_and_install(&image_disk, &version_key).await?;
 
         tracing::info!(
             total_ms = total_start.elapsed().as_millis() as u64,
@@ -389,14 +367,9 @@ impl GuestRootfsManager {
 
     /// Build guest rootfs from image disk and atomically install.
     ///
-    /// Verifies the actual guest binary hash against the expected version key.
-    /// If the compile-time hash is stale, uses the actual hash for the version key.
-    async fn build_and_install(
-        &self,
-        image_disk: &Disk,
-        digest: &str,
-        expected_version_key: &str,
-    ) -> BoxliteResult<Disk> {
+    /// Injects the same [`GuestBinary`] the caller keyed `version_key` on, so
+    /// what is cached always matches what the key names.
+    async fn build_and_install(&self, image_disk: &Disk, version_key: &str) -> BoxliteResult<Disk> {
         let build_start = std::time::Instant::now();
 
         // Stage: copy image disk to temp, inject guest binary there
@@ -424,54 +397,25 @@ impl GuestRootfsManager {
             "build_and_install: copy image disk done"
         );
 
-        // Inject guest binary into staged disk via debugfs
+        // Inject the guest binary the version key was derived from. Resolution
+        // and validation already happened in `GuestBinary::get`, so there is no
+        // second lookup that could pick a different file.
         let inject_start = std::time::Instant::now();
-        let guest_bin = util::find_binary("boxlite-guest")?;
+        let guest = GuestBinary::get()?;
 
-        // Pre-flight: validate guest binary is a valid ELF for this architecture
-        crate::vmm::guest_check::validate_guest_binary(&guest_bin)?;
-
-        // Verify the actual guest binary hash matches what we expected.
-        // The compile-time hash (from build.rs) may be stale if the guest
-        // binary was rebuilt after boxlite was compiled.
-        let actual_hash = Self::sha256_file(&guest_bin)?;
-        let actual_version_key = Self::version_key(digest, &actual_hash);
-
-        if actual_version_key != expected_version_key {
-            if option_env!("BOXLITE_GUEST_HASH").is_some() {
-                // Compile-time hash exists but doesn't match the actual binary.
-                // This means boxlite was compiled against a different guest binary
-                // than what's found at runtime — an inconsistent build.
-                return Err(BoxliteError::Internal(format!(
-                    "Guest binary hash mismatch: compile-time key {} but actual key {}. \
-                     Rebuild boxlite to fix.",
-                    expected_version_key, actual_version_key
-                )));
-            }
-            // No compile-time hash (fallback mode) — use actual hash
-            tracing::info!(
-                expected = %expected_version_key,
-                actual = %actual_version_key,
-                "No compile-time hash, using actual guest hash"
-            );
-            // Check cache with actual key — might already exist
-            if let Some(disk) = self.find(&actual_version_key) {
-                return Ok(disk);
-            }
-        }
-
-        inject_file_into_ext4(&staged_path, &guest_bin, "boxlite/bin/boxlite-guest")?;
+        inject_file_into_ext4(&staged_path, guest.path(), "boxlite/bin/boxlite-guest")?;
         tracing::info!(
             elapsed_ms = inject_start.elapsed().as_millis() as u64,
             "build_and_install: inject guest binary done"
         );
 
-        // Atomic install: use the actual version key (may differ from expected)
         let staged_disk = Disk::new(staged_path, DiskFormat::Ext4, false);
-        let result = self.install(&actual_version_key, staged_disk);
+        let result = self.install(version_key, staged_disk);
 
         tracing::info!(
-            version_key = %actual_version_key,
+            version_key = %version_key,
+            commit = boxlite_shared::GIT_COMMIT.unwrap_or("unknown"),
+            guest_id = %guest.id(),
             total_ms = build_start.elapsed().as_millis() as u64,
             "build_and_install: completed"
         );
@@ -564,16 +508,12 @@ impl GuestRootfsManager {
     pub fn gc(&self, boxes_dir: &Path) -> BoxliteResult<usize> {
         let gc_start = std::time::Instant::now();
 
-        // Compute current guest hash prefix to identify current-version entries.
         // Version keys are "{image_12}-{guest_12}", so entries whose name ends
-        // with the current guest hash suffix are still valid for future boxes.
-        let current_guest_suffix = match self.cached_guest_hash() {
-            Ok(hash) => {
-                let g = &hash[..12.min(hash.len())];
-                format!("-{}", g)
-            }
+        // with the current guest id are still valid for future boxes.
+        let current_guest_suffix = match GuestBinary::get() {
+            Ok(guest) => format!("-{}", guest.id()),
             Err(e) => {
-                tracing::warn!("GC: cannot determine current guest hash, skipping: {}", e);
+                tracing::warn!("GC: cannot resolve the guest binary, skipping: {}", e);
                 return Ok(0);
             }
         };
@@ -593,7 +533,9 @@ impl GuestRootfsManager {
     ///
     /// Queries the DB for all rootfs entries, then determines which to keep:
     /// - Entries whose version key (name) ends with `current_guest_suffix`
-    /// - Entries whose base_path is referenced by a box's `disks/guest-rootfs.qcow2`
+    /// - Entries whose base_path any box overlay backs onto (see
+    ///   [`BaseDiskManager::referenced_backing_paths`], which covers both
+    ///   `disk.qcow2` and `disks/guest-rootfs.qcow2`)
     fn gc_inner(&self, boxes_dir: &Path, current_guest_suffix: &str) -> BoxliteResult<usize> {
         let records = self
             .base_disk_mgr
@@ -605,7 +547,7 @@ impl GuestRootfsManager {
         }
 
         // Collect all referenced backing file paths from box qcow2 overlays.
-        let referenced = Self::collect_referenced_rootfs_paths(boxes_dir);
+        let referenced = self.base_disk_mgr.referenced_backing_paths(boxes_dir);
 
         tracing::info!(
             referenced_count = referenced.len(),
@@ -667,106 +609,7 @@ impl GuestRootfsManager {
         Ok(removed)
     }
 
-    /// Collect all backing file paths referenced by boxes' guest-rootfs.qcow2 overlays.
-    fn collect_referenced_rootfs_paths(boxes_dir: &Path) -> HashSet<PathBuf> {
-        let mut referenced = HashSet::new();
-
-        if !boxes_dir.exists() {
-            return referenced;
-        }
-
-        let entries = match fs::read_dir(boxes_dir) {
-            Ok(e) => e,
-            Err(e) => {
-                tracing::warn!(
-                    "GC: failed to read boxes dir {}: {}",
-                    boxes_dir.display(),
-                    e
-                );
-                return referenced;
-            }
-        };
-
-        for entry in entries.flatten() {
-            // Correct path: boxes/{box_id}/disks/guest-rootfs.qcow2
-            let qcow2_path = entry.path().join("disks").join("guest-rootfs.qcow2");
-            if !qcow2_path.exists() {
-                continue;
-            }
-
-            match read_backing_file_path(&qcow2_path) {
-                Ok(Some(backing_path)) => {
-                    referenced.insert(PathBuf::from(backing_path));
-                }
-                Ok(None) => {}
-                Err(e) => {
-                    tracing::warn!(
-                        "Failed to read backing file from {}: {}",
-                        qcow2_path.display(),
-                        e
-                    );
-                }
-            }
-        }
-
-        referenced
-    }
-
-    /// Compute SHA256 hash of the boxlite-guest binary.
-    ///
-    /// Uses compile-time hash (embedded by build.rs) when available,
-    /// falling back to runtime computation.
-    fn guest_binary_hash() -> BoxliteResult<String> {
-        // Fast path: use compile-time hash embedded by build.rs
-        if let Some(hash) = option_env!("BOXLITE_GUEST_HASH") {
-            tracing::info!(
-                hash_prefix = &hash[..12.min(hash.len())],
-                "guest_binary_hash: using compile-time hash"
-            );
-            return Ok(hash.to_string());
-        }
-
-        let guest_bin = util::find_binary("boxlite-guest")?;
-        Self::sha256_file(&guest_bin)
-    }
-
-    /// Compute SHA256 hex digest of a file.
-    fn sha256_file(path: &Path) -> BoxliteResult<String> {
-        use sha2::{Digest, Sha256};
-        use std::io::Read;
-
-        let start = std::time::Instant::now();
-        let mut file = fs::File::open(path).map_err(|e| {
-            BoxliteError::Storage(format!("Failed to open {}: {}", path.display(), e))
-        })?;
-
-        let file_size = file.metadata().map(|m| m.len()).unwrap_or(0);
-
-        let mut hasher = Sha256::new();
-        let mut buffer = vec![0u8; 64 * 1024];
-        loop {
-            let n = file.read(&mut buffer).map_err(|e| {
-                BoxliteError::Storage(format!("Failed to read {}: {}", path.display(), e))
-            })?;
-            if n == 0 {
-                break;
-            }
-            hasher.update(&buffer[..n]);
-        }
-
-        let hash = format!("{:x}", hasher.finalize());
-        tracing::info!(
-            path = %path.display(),
-            size_mb = file_size / (1024 * 1024),
-            elapsed_ms = start.elapsed().as_millis() as u64,
-            hash_prefix = &hash[..12.min(hash.len())],
-            "sha256_file computed"
-        );
-
-        Ok(hash)
-    }
-
-    /// Compute the version key from image digest and guest binary hash.
+    /// Compute the version key from image digest and guest binary id.
     fn version_key(digest: &str, guest_hash: &str) -> String {
         let d = digest.strip_prefix("sha256:").unwrap_or(digest);
         let d = &d[..12.min(d.len())];
@@ -834,6 +677,56 @@ mod tests {
     fn test_version_key_short_inputs() {
         let key = GuestRootfsManager::version_key("abc", "def");
         assert_eq!(key, "abc-def");
+    }
+
+    /// Rebuilding the guest must move the cache key, so an existing entry is not
+    /// reused for a different binary.
+    ///
+    /// Same verification caveat as `guest_binary::id_tracks_the_bytes_on_disk`:
+    /// this composes `GuestBinary::resolve_at`, which the fix introduces, so a
+    /// full production revert stops it compiling instead of failing it. It was
+    /// checked by mutation (digest the path, not the bytes) and by a booted VM.
+    #[test]
+    fn version_key_follows_the_guest_binary_on_disk() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let digest = "sha256:18264223e3ecaaaabbbbccccdddd";
+
+        // One path, rewritten — what `make guest` does. Distinct paths would let
+        // an implementation that keyed on the path alone pass this test.
+        let write_guest = |filler: u8| {
+            let path = dir.path().join("boxlite-guest");
+            let mut elf = vec![0u8; 128];
+            elf[..4].copy_from_slice(&[0x7f, b'E', b'L', b'F']);
+            elf[4] = 2;
+            let machine: u16 = if std::env::consts::ARCH == "x86_64" {
+                0x3E
+            } else {
+                0xB7
+            };
+            elf[18..20].copy_from_slice(&machine.to_le_bytes());
+            elf[64..].fill(filler);
+            std::fs::write(&path, elf).unwrap();
+            path
+        };
+
+        let before = GuestBinary::resolve_at(write_guest(0xAA)).unwrap();
+        let after = GuestBinary::resolve_at(write_guest(0xBB)).unwrap();
+
+        let key_before = GuestRootfsManager::version_key(digest, before.id());
+        let key_after = GuestRootfsManager::version_key(digest, after.id());
+
+        assert_ne!(
+            key_before, key_after,
+            "a rebuilt guest must not reuse the previous rootfs cache entry"
+        );
+        // Same image, so only the guest half may move — otherwise every image
+        // would rebuild whenever the guest changed.
+        assert_eq!(
+            key_before[..12],
+            key_after[..12],
+            "image half must be stable"
+        );
+        assert!(key_after.ends_with(after.id()), "GC matches on this suffix");
     }
 
     #[test]

--- a/src/boxlite/src/runtime/embedded.rs
+++ b/src/boxlite/src/runtime/embedded.rs
@@ -5,9 +5,11 @@
 //! under the platform's local data dir, then serves that directory to
 //! [`RuntimeBinaryFinder`](crate::util::RuntimeBinaryFinder) for binary discovery.
 //!
-//! Every profile uses `~/.local/share/boxlite/runtimes/v{VERSION}-{HASH}/`, where
-//! `{HASH}` is a 12-character SHA256 prefix of all embedded file contents. This
-//! prevents same-version builds with different assets from sharing a stale cache.
+//! Every profile uses `~/.local/share/boxlite/runtimes/v{VERSION}-{COMMIT}-{HASH}/`,
+//! where `{HASH}` is a 12-character SHA256 prefix of all embedded file contents
+//! and `{COMMIT}` the git commit the build came from. The hash prevents
+//! same-version builds with different assets from sharing a stale cache; the
+//! commit lets a cache directory say which checkout produced it.
 
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
@@ -32,7 +34,7 @@ include!(concat!(env!("OUT_DIR"), "/embedded_manifest.rs"));
 ///   └─ extract to {dir}.extracting.{pid}/
 ///      ├─ write all files + .complete stamp
 ///      ├─ atomic rename → dir
-///      ├─ cleanup stale versions (TTL 30d)
+///      ├─ cleanup stale versions (disuse TTL: 7d release, 1h debug)
 ///      └─ Ok(Self { dir })
 /// ```
 pub struct EmbeddedRuntime {
@@ -194,9 +196,11 @@ impl EmbeddedRuntime {
         let data_dir = dirs::data_local_dir()
             .ok_or_else(|| BoxliteError::Storage("No local data directory".into()))?;
 
-        // Include the manifest hash for every profile so rebuilding the same version
-        // with different runtime assets cannot reuse a stale extracted cache.
-        let dir_name = format!("v{}-{}", crate::VERSION, env!("BOXLITE_MANIFEST_HASH"));
+        let dir_name = Self::dir_name(
+            crate::VERSION,
+            boxlite_shared::GIT_COMMIT,
+            env!("BOXLITE_MANIFEST_HASH"),
+        );
 
         let dir = data_dir.join("boxlite").join("runtimes").join(dir_name);
         let parent = dir.parent().ok_or_else(|| {
@@ -208,6 +212,29 @@ impl EmbeddedRuntime {
         std::fs::create_dir_all(parent)
             .map_err(|e| BoxliteError::Storage(format!("mkdir {}: {}", parent.display(), e)))?;
         Ok(dir)
+    }
+
+    /// Cache directory name: `v{version}-{commit}-{manifest_hash}`.
+    ///
+    /// `manifest_hash` is what makes the name *correct* — rebuilding the same
+    /// version with different runtime assets must not reuse a stale extracted
+    /// cache. `commit` makes it *legible*: the directory otherwise cannot say
+    /// which checkout produced it. A build with no commit to report keeps the
+    /// two-segment name rather than carrying a placeholder.
+    ///
+    /// Including it does split the cache for byte-identical assets, which is
+    /// the same cost the guest rootfs key refuses to pay. The trade differs
+    /// because the split is bounded here and unbounded there: [`cleanup_stale`]
+    /// reclaims these directories on a disuse TTL, whereas a rootfs base is
+    /// retained for as long as any box overlay backs onto it, so a per-commit
+    /// split would accumulate for the life of those boxes.
+    ///
+    /// [`cleanup_stale`]: Self::cleanup_stale
+    fn dir_name(version: &str, commit: Option<&str>, manifest_hash: &str) -> String {
+        match commit {
+            Some(commit) => format!("v{}-{}-{}", version, commit, manifest_hash),
+            None => format!("v{}-{}", version, manifest_hash),
+        }
     }
 
     #[cfg(unix)]
@@ -238,17 +265,50 @@ mod tests {
         let dir = EmbeddedRuntime::versioned_dir().unwrap();
         let dir_str = dir.to_string_lossy();
 
-        // Verify path structure: .../boxlite/runtimes/v{VERSION}-{HASH}
+        // Verify path structure: .../boxlite/runtimes/v{VERSION}-[{COMMIT}-]{HASH}
         assert!(
             dir_str.contains("boxlite/runtimes/"),
             "Expected path to contain boxlite/runtimes/, got {}",
             dir.display()
         );
         let dir_name = dir.file_name().unwrap().to_string_lossy();
-        let expected = format!("v{}-{}", crate::VERSION, env!("BOXLITE_MANIFEST_HASH"));
+        assert!(
+            dir_name.starts_with(&format!("v{}-", crate::VERSION)),
+            "Runtime dir should be version-stamped: {dir_name}"
+        );
+        assert!(
+            dir_name.ends_with(env!("BOXLITE_MANIFEST_HASH")),
+            "Runtime dir should include the manifest hash: {dir_name}"
+        );
+        // This checks only that a stamped commit reaches the directory name;
+        // that the build script stamps one at all is guarded by boxlite-shared's
+        // `commit_is_stamped_when_built_from_a_tracked_checkout`.
+        if let Some(commit) = boxlite_shared::GIT_COMMIT {
+            assert!(
+                dir_name.contains(&format!("-{commit}-")),
+                "Runtime dir should name the commit it was built from: {dir_name}"
+            );
+        }
+    }
+
+    #[test]
+    fn dir_name_carries_the_commit() {
         assert_eq!(
-            dir_name, expected,
-            "Runtime dir should include the manifest hash"
+            EmbeddedRuntime::dir_name("0.9.8", Some("ea34a8c4"), "4e5f6a7b8c9d"),
+            "v0.9.8-ea34a8c4-4e5f6a7b8c9d"
+        );
+        assert_ne!(
+            EmbeddedRuntime::dir_name("0.9.8", Some("ea34a8c4"), "4e5f6a7b8c9d"),
+            EmbeddedRuntime::dir_name("0.9.8", Some("8103b2cb"), "4e5f6a7b8c9d"),
+            "byte-identical assets from different commits must not share a cache dir"
+        );
+    }
+
+    #[test]
+    fn dir_name_without_a_commit_keeps_the_two_segment_form() {
+        assert_eq!(
+            EmbeddedRuntime::dir_name("0.9.8", None, "4e5f6a7b8c9d"),
+            "v0.9.8-4e5f6a7b8c9d"
         );
     }
 

--- a/src/boxlite/src/runtime/layout.rs
+++ b/src/boxlite/src/runtime/layout.rs
@@ -681,10 +681,7 @@ impl ImageFilesystemLayout {
         // Hash the bundle path for location identity
         let path_str = bundle_path.to_string_lossy();
         let path_hash = Sha256::digest(path_str.as_bytes());
-        let path_short = format!("{:x}", path_hash)
-            .chars()
-            .take(8)
-            .collect::<String>();
+        let path_short = hex::encode(path_hash).chars().take(8).collect::<String>();
 
         // Extract short manifest digest for content identity
         let manifest_short = manifest_digest

--- a/src/boxlite/src/runtime/rt_impl.rs
+++ b/src/boxlite/src/runtime/rt_impl.rs
@@ -1446,6 +1446,13 @@ impl RuntimeImpl {
             tracing::warn!("Guest rootfs GC failed: {}", e);
         }
 
+        // Then reclaim base files no DB record and no overlay claims — the
+        // per-kind collectors above work from records, so a file whose row is
+        // gone is invisible to them.
+        if let Err(e) = self.base_disk_mgr.gc_orphans(&self.layout.boxes_dir()) {
+            tracing::warn!("Orphaned base disk GC failed: {}", e);
+        }
+
         tracing::info!("Box recovery complete");
         Ok(())
     }

--- a/src/boxlite/src/util/binary_finder.rs
+++ b/src/boxlite/src/util/binary_finder.rs
@@ -4,7 +4,7 @@
 //! bundled with BoxLite. The search follows a priority order:
 //!
 //! 1. `BOXLITE_RUNTIME_DIR` - Explicit override (highest priority)
-//! 2. Embedded runtime cache (e.g., `~/.local/share/boxlite/runtimes/v{VERSION}-{HASH}/`) - Self-contained SDKs
+//! 2. Embedded runtime cache (e.g., `~/.local/share/boxlite/runtimes/v{VERSION}-{COMMIT}-{HASH}/`) - Self-contained SDKs
 //! 3. `DYLD_LIBRARY_PATH` (macOS) / `LD_LIBRARY_PATH` (Linux) - User-specified runtime location
 //! 4. dladdr-based detection - For packaged/installed scenarios
 

--- a/src/boxlite/src/util/mod.rs
+++ b/src/boxlite/src/util/mod.rs
@@ -171,11 +171,14 @@ pub fn register_to_tracing(non_blocking: NonBlocking, env_filter: EnvFilter) {
 pub fn inject_guest_binary(rootfs_path: &std::path::Path) -> BoxliteResult<()> {
     let dest_dir = rootfs_path.join("boxlite/bin");
     let dest_path = dest_dir.join("boxlite-guest");
-    let guest_bin = find_binary("boxlite-guest")?;
+    // Same resolution the disk path uses, so the two can never inject different
+    // binaries. (mtime+size below answers a different question — whether this
+    // destination copy is current — not which binary is authoritative.)
+    let guest_bin = crate::vmm::guest_binary::GuestBinary::get()?.path();
 
     // Check if binary needs update
     if dest_path.exists() {
-        if is_binary_up_to_date(&guest_bin, &dest_path)? {
+        if is_binary_up_to_date(guest_bin, &dest_path)? {
             return Ok(());
         }
         // Remove old binary before copying (it might be read-only 0o555)
@@ -196,7 +199,7 @@ pub fn inject_guest_binary(rootfs_path: &std::path::Path) -> BoxliteResult<()> {
         ))
     })?;
 
-    std::fs::copy(&guest_bin, &dest_path).map_err(|e| {
+    std::fs::copy(guest_bin, &dest_path).map_err(|e| {
         BoxliteError::Storage(format!(
             "Failed to copy guest binary to {}: {}",
             dest_path.display(),

--- a/src/boxlite/src/vmm/guest_binary.rs
+++ b/src/boxlite/src/vmm/guest_binary.rs
@@ -1,0 +1,197 @@
+//! The `boxlite-guest` binary this process injects, resolved once.
+//!
+//! The binary is late-bound: [`find_binary`] searches `BOXLITE_RUNTIME_DIR`
+//! before the embedded runtime cache, so which file gets injected is decided at
+//! run time, not build time. Anything derived from its contents — above all the
+//! guest rootfs cache key — must therefore be derived from the file that was
+//! actually resolved.
+//!
+//! [`GuestBinary`] is the single place that resolution happens. Callers take the
+//! path and the identity from the same value, so "the binary we hashed" and "the
+//! binary we injected" cannot drift apart.
+
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+use boxlite_shared::errors::{BoxliteError, BoxliteResult};
+use sha2::{Digest, Sha256};
+
+use super::guest_check::validate_guest_bytes;
+use crate::util::find_binary;
+
+/// Hex characters of the content digest used as the identity.
+///
+/// Matches the width the guest rootfs cache key has always used, so entries
+/// cached by earlier builds of the same binary still resolve.
+const ID_LEN: usize = 12;
+
+/// The resolved `boxlite-guest` binary and its content identity.
+pub struct GuestBinary {
+    path: PathBuf,
+    id: String,
+}
+
+impl GuestBinary {
+    /// Resolve, validate and identify the guest binary, once per process.
+    ///
+    /// Only success is memoised: [`BoxliteError`] is not `Clone`, and caching a
+    /// rendered string would flatten a "wrong architecture, rebuild with…"
+    /// message into a generic one. A failure here aborts box start anyway, so
+    /// retrying the read costs nothing that matters.
+    pub fn get() -> BoxliteResult<&'static Self> {
+        static INSTANCE: OnceLock<GuestBinary> = OnceLock::new();
+
+        if let Some(binary) = INSTANCE.get() {
+            return Ok(binary);
+        }
+        let resolved = Self::resolve()?;
+        // A concurrent caller may have won the race; both computed the same
+        // value from the same file, so either is correct.
+        Ok(INSTANCE.get_or_init(|| resolved))
+    }
+
+    /// Path to inject into a guest rootfs.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Content identity, for cache keys and log fields.
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    fn resolve() -> BoxliteResult<Self> {
+        Self::resolve_at(find_binary("boxlite-guest")?)
+    }
+
+    /// Identify the binary at `path`.
+    ///
+    /// Split from [`Self::resolve`] so the read-validate-identify step can be
+    /// exercised against a known file, without touching `BOXLITE_RUNTIME_DIR`
+    /// or the process-wide cache.
+    pub(crate) fn resolve_at(path: PathBuf) -> BoxliteResult<Self> {
+        // One read feeds both validation and the digest.
+        let started = std::time::Instant::now();
+        let bytes = std::fs::read(&path).map_err(|e| {
+            BoxliteError::Storage(format!(
+                "Cannot read guest binary {}: {}",
+                path.display(),
+                e
+            ))
+        })?;
+        validate_guest_bytes(&bytes, &path)?;
+        let id = hex::encode(Sha256::digest(&bytes))[..ID_LEN].to_string();
+
+        tracing::info!(
+            path = %path.display(),
+            id = %id,
+            size_mb = bytes.len() / (1024 * 1024),
+            elapsed_ms = started.elapsed().as_millis() as u64,
+            "Resolved guest binary"
+        );
+
+        Ok(Self { path, id })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Smallest byte sequence `validate_guest_bytes` accepts for this host.
+    fn fake_guest(filler: u8) -> Vec<u8> {
+        let mut elf = vec![0u8; 128];
+        elf[..4].copy_from_slice(&[0x7f, b'E', b'L', b'F']);
+        elf[4] = 2; // 64-bit
+        let machine: u16 = match std::env::consts::ARCH {
+            "x86_64" => 0x3E,
+            _ => 0xB7,
+        };
+        elf[18..20].copy_from_slice(&machine.to_le_bytes());
+        elf[64..].fill(filler); // payload the digest must actually cover
+        elf
+    }
+
+    fn write_guest(dir: &tempfile::TempDir, filler: u8) -> PathBuf {
+        let path = dir.path().join("boxlite-guest");
+        std::fs::write(&path, fake_guest(filler)).unwrap();
+        path
+    }
+
+    /// The identity must come from the file's contents.
+    ///
+    /// NOTE ON VERIFICATION: this cannot be a revert-and-watch-it-fail
+    /// reproducer. It calls `resolve_at`, which the fix introduces, so removing
+    /// the production change stops it compiling rather than failing it. What was
+    /// done instead: mutating `resolve_at` to digest the path rather than the
+    /// bytes makes this assertion fire, and a booted VM was shown to rebuild the
+    /// rootfs after the guest binary was swapped underneath an unchanged boxlite.
+    /// Treat the absent red side as a known gap, not as coverage.
+    #[test]
+    fn id_tracks_the_bytes_on_disk() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let before = GuestBinary::resolve_at(write_guest(&dir, 0xAA)).unwrap();
+        let first_id = before.id().to_string();
+
+        // Same path, different contents — as after `make guest`.
+        let after = GuestBinary::resolve_at(write_guest(&dir, 0xBB)).unwrap();
+
+        assert_ne!(
+            first_id,
+            after.id(),
+            "a rebuilt guest binary must not keep the previous identity"
+        );
+        assert_eq!(before.path(), after.path(), "same path, different contents");
+    }
+
+    #[test]
+    fn id_is_stable_for_unchanged_bytes() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_guest(&dir, 0xAA);
+
+        let first = GuestBinary::resolve_at(path.clone()).unwrap();
+        let second = GuestBinary::resolve_at(path).unwrap();
+
+        assert_eq!(
+            first.id(),
+            second.id(),
+            "identical bytes must reuse the cached rootfs, not rebuild it"
+        );
+        assert_eq!(first.id().len(), ID_LEN);
+    }
+
+    /// The read lives here now, so its failure must be named here.
+    #[test]
+    fn a_missing_binary_is_reported_by_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("boxlite-guest");
+
+        let error = GuestBinary::resolve_at(missing.clone())
+            .err()
+            .expect("a missing binary must not resolve");
+
+        assert!(
+            error.to_string().contains("Cannot read")
+                && error.to_string().contains("boxlite-guest"),
+            "error should name the unreadable path: {error}"
+        );
+    }
+
+    /// Resolution must reject a binary the VM could not run, before it is
+    /// injected into a rootfs and cached under a key that looks valid.
+    #[test]
+    fn a_non_elf_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("boxlite-guest");
+        std::fs::write(&path, vec![0u8; 128]).unwrap();
+
+        let error = GuestBinary::resolve_at(path)
+            .err()
+            .expect("bad magic must not resolve");
+        assert!(
+            error.to_string().contains("ELF"),
+            "error should name the problem: {error}"
+        );
+    }
+}

--- a/src/boxlite/src/vmm/guest_check.rs
+++ b/src/boxlite/src/vmm/guest_check.rs
@@ -17,22 +17,19 @@ const EM_AARCH64: u16 = 0xB7;
 /// ELF program header type for interpreter (PT_INTERP).
 const PT_INTERP: u32 = 3;
 
-/// Validate that a guest binary is a valid ELF for the current host architecture.
+/// Validate that guest binary contents are a runnable ELF for this host.
 ///
 /// Checks:
-/// 1. File exists and is non-empty
+/// 1. Non-empty and large enough to hold an ELF header
 /// 2. Valid ELF magic bytes
 /// 3. Machine type matches host architecture
 /// 4. Binary is statically linked (no PT_INTERP program header)
-pub fn validate_guest_binary(path: &Path) -> BoxliteResult<()> {
-    let data = std::fs::read(path).map_err(|e| {
-        BoxliteError::Internal(format!(
-            "Cannot read guest binary {}: {}",
-            path.display(),
-            e
-        ))
-    })?;
-
+///
+/// Takes bytes rather than a path because the only caller
+/// ([`GuestBinary`](crate::vmm::guest_binary::GuestBinary)) has already read the
+/// ~18 MB file to digest it; reading it a second time to validate is waste.
+/// `path` names the binary in error messages only.
+pub fn validate_guest_bytes(data: &[u8], path: &Path) -> BoxliteResult<()> {
     if data.len() < 64 {
         return Err(BoxliteError::Internal(format!(
             "Guest binary {} is too small ({} bytes) — not a valid ELF",
@@ -88,7 +85,7 @@ pub fn validate_guest_binary(path: &Path) -> BoxliteResult<()> {
         )));
     }
 
-    if has_pt_interp(&data) {
+    if has_pt_interp(data) {
         tracing::warn!(
             path = %path.display(),
             "Guest binary is dynamically linked — it may fail inside the VM"
@@ -127,6 +124,11 @@ fn has_pt_interp(data: &[u8]) -> bool {
 mod tests {
     use super::*;
 
+    /// Stand-in for the path these checks only ever name in error messages.
+    fn guest_path() -> &'static Path {
+        Path::new("/runtime/boxlite-guest")
+    }
+
     /// Create a minimal valid 64-bit little-endian ELF header for testing.
     fn make_elf_header(machine: u16, add_interp: bool) -> Vec<u8> {
         let mut data = vec![0u8; 128];
@@ -154,76 +156,51 @@ mod tests {
 
     #[test]
     fn test_valid_binary_matching_arch() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("boxlite-guest");
-
         let machine = match std::env::consts::ARCH {
             "x86_64" => EM_X86_64,
             "aarch64" => EM_AARCH64,
             _ => return,
         };
 
-        std::fs::write(&path, make_elf_header(machine, false)).unwrap();
-        assert!(validate_guest_binary(&path).is_ok());
+        assert!(validate_guest_bytes(&make_elf_header(machine, false), guest_path()).is_ok());
     }
 
     #[test]
     fn test_wrong_arch() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("boxlite-guest");
-
         let machine = match std::env::consts::ARCH {
             "x86_64" => EM_AARCH64,
             "aarch64" => EM_X86_64,
             _ => return,
         };
 
-        std::fs::write(&path, make_elf_header(machine, false)).unwrap();
-        let err = validate_guest_binary(&path).unwrap_err();
+        let err = validate_guest_bytes(&make_elf_header(machine, false), guest_path()).unwrap_err();
         assert!(err.to_string().contains("compiled for"));
         assert!(err.to_string().contains("but host is"));
     }
 
     #[test]
     fn test_not_elf() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("boxlite-guest");
-        std::fs::write(&path, b"not an elf file at all").unwrap();
-
-        let err = validate_guest_binary(&path).unwrap_err();
+        let err = validate_guest_bytes(
+            b"not an elf file at all, but long enough to reach the magic check",
+            guest_path(),
+        )
+        .unwrap_err();
         assert!(err.to_string().contains("not a valid ELF"));
     }
 
     #[test]
     fn test_too_small() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("boxlite-guest");
-        std::fs::write(&path, b"tiny").unwrap();
-
-        let err = validate_guest_binary(&path).unwrap_err();
+        let err = validate_guest_bytes(b"tiny", guest_path()).unwrap_err();
         assert!(err.to_string().contains("too small"));
     }
 
     #[test]
-    fn test_missing_file() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("nonexistent");
-
-        let err = validate_guest_binary(&path).unwrap_err();
-        assert!(err.to_string().contains("Cannot read"));
-    }
-
-    #[test]
     fn test_32bit_elf() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("boxlite-guest");
-
         let mut data = vec![0u8; 64];
         data[0..4].copy_from_slice(&ELF_MAGIC);
         data[4] = 1; // 32-bit class
-        std::fs::write(&path, &data).unwrap();
 
-        let err = validate_guest_binary(&path).unwrap_err();
+        let err = validate_guest_bytes(&data, guest_path()).unwrap_err();
         assert!(err.to_string().contains("not 64-bit"));
     }
 
@@ -235,17 +212,13 @@ mod tests {
 
     #[test]
     fn test_dynamically_linked_binary_warns() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("boxlite-guest");
-
         let machine = match std::env::consts::ARCH {
             "x86_64" => EM_X86_64,
             "aarch64" => EM_AARCH64,
             _ => return,
         };
 
-        std::fs::write(&path, make_elf_header(machine, true)).unwrap();
         // Should still pass (warning only, not error)
-        assert!(validate_guest_binary(&path).is_ok());
+        assert!(validate_guest_bytes(&make_elf_header(machine, true), guest_path()).is_ok());
     }
 }

--- a/src/boxlite/src/vmm/mod.rs
+++ b/src/boxlite/src/vmm/mod.rs
@@ -9,6 +9,7 @@ pub mod controller;
 pub mod engine;
 pub mod exit_info;
 pub mod factory;
+pub mod guest_binary;
 pub mod guest_check;
 #[cfg(feature = "krun")]
 pub mod krun;

--- a/src/shared/build.rs
+++ b/src/shared/build.rs
@@ -1,6 +1,92 @@
-//! Build script to compile Protocol Buffer definitions.
+//! Build script to compile Protocol Buffer definitions and stamp the build
+//! with the git commit it came from.
 
+use std::path::PathBuf;
 use std::process::Command;
+
+/// Emits `BOXLITE_GIT_COMMIT`, the short commit of the checkout being built.
+///
+/// Read back as [`crate::GIT_COMMIT`](../src/lib.rs) via `option_env!`, so a
+/// build with no git checkout to read — a published crate, a vendored source
+/// tree, a container without `.git` — simply reports no commit.
+///
+/// Lives in the shared crate rather than in `boxlite`'s own build script so any
+/// workspace member can report the same commit from one emission point. Today
+/// the only consumer is the host's embedded-runtime cache directory name.
+struct GitProvenance {
+    /// Crate root; also the cwd every `git` call runs in.
+    manifest_dir: PathBuf,
+}
+
+impl GitProvenance {
+    fn new(manifest_dir: PathBuf) -> Self {
+        Self { manifest_dir }
+    }
+
+    /// Emit the commit plus the `rerun-if-changed` watches that keep it honest.
+    ///
+    /// Without the watches cargo would replay a cached build-script run after
+    /// HEAD moved and stamp the build with a commit that no longer describes
+    /// it — a silently wrong label is worse than none.
+    fn emit(&self) {
+        if !self.is_tracked_here() {
+            return;
+        }
+        let Some(commit) = self.git(&["rev-parse", "--short", "HEAD"]) else {
+            return;
+        };
+        self.watch("HEAD");
+        // Committing on the current branch leaves HEAD untouched and moves only
+        // the branch ref, which lives in `packed-refs` until written out loose —
+        // so both are watched.
+        if let Some(branch) = self.git(&["symbolic-ref", "--quiet", "HEAD"]) {
+            self.watch(&branch);
+        }
+        self.watch("packed-refs");
+        println!("cargo:rustc-env=BOXLITE_GIT_COMMIT={}", commit);
+    }
+
+    /// True when this crate's own manifest is tracked by the repository the
+    /// `git` calls resolve to.
+    ///
+    /// Guards against stamping an unrelated enclosing repository: a crate
+    /// unpacked under `~/.cargo/registry/` is inside a git repo whenever the
+    /// user keeps `$HOME` under version control, but is never tracked by it.
+    fn is_tracked_here(&self) -> bool {
+        self.git(&["ls-files", "--error-unmatch", "Cargo.toml"])
+            .is_some()
+    }
+
+    /// Watch a path inside the git directory, resolved through `--git-path` so
+    /// linked worktrees (whose `.git` is a file) reach the real location.
+    ///
+    /// Absent paths are skipped: cargo treats a missing `rerun-if-changed`
+    /// target as always-dirty, which would re-run this script on every build.
+    fn watch(&self, git_relative: &str) {
+        let Some(path) = self.git(&["rev-parse", "--git-path", git_relative]) else {
+            return;
+        };
+        // `--git-path` may answer relative to the cwd; join is a no-op when absolute.
+        let path = self.manifest_dir.join(path);
+        if path.exists() {
+            println!("cargo:rerun-if-changed={}", path.display());
+        }
+    }
+
+    /// Run git in the crate root, returning trimmed stdout on success.
+    fn git(&self, args: &[&str]) -> Option<String> {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(&self.manifest_dir)
+            .output()
+            .ok()?;
+        if !output.status.success() {
+            return None;
+        }
+        let text = String::from_utf8(output.stdout).ok()?.trim().to_string();
+        (!text.is_empty()).then_some(text)
+    }
+}
 
 fn get_protoc_version() -> Result<(u32, u32), Box<dyn std::error::Error>> {
     let output = Command::new("protoc").arg("--version").output()?;
@@ -27,6 +113,8 @@ fn get_protoc_version() -> Result<(u32, u32), Box<dyn std::error::Error>> {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    GitProvenance::new(std::env::var("CARGO_MANIFEST_DIR")?.into()).emit();
+
     let mut config = tonic_build::configure()
         .build_server(true)
         .build_client(true);

--- a/src/shared/src/lib.rs
+++ b/src/shared/src/lib.rs
@@ -3,6 +3,23 @@
 //! This crate contains common types, protocols, and utilities
 //! used by both the host-side runtime (boxlite) and guest agent.
 
+/// Short git commit of the checkout this build came from.
+///
+/// `None` when the build script found no git checkout to read (published
+/// crate, vendored source, container without `.git`) — see `build.rs`.
+///
+/// Provenance, never correctness. The same commit can produce different bytes
+/// (debug vs release, a dirty tree), and a binary reached through
+/// `BOXLITE_RUNTIME_DIR` need not come from it at all — so nothing may depend
+/// on two artifacts sharing a commit meaning they share contents.
+///
+/// It may still *appear* in a cache path, where it costs a split for
+/// byte-identical content and buys the ability to say which checkout produced
+/// an artifact. That trade is only worth taking where the split is bounded —
+/// see `EmbeddedRuntime::dir_name`, and note the guest rootfs key deliberately
+/// declines it.
+pub const GIT_COMMIT: Option<&str> = option_env!("BOXLITE_GIT_COMMIT");
+
 pub mod constants;
 pub mod errors;
 pub mod layout;
@@ -39,3 +56,40 @@ pub use generated::files_server::{Files, FilesServer};
 
 // All generated types
 pub use generated::*;
+
+#[cfg(test)]
+mod tests {
+    /// A missing commit is only legitimate when there is no tracked checkout to
+    /// read — the condition `build.rs` gates on.
+    ///
+    /// The skip is decided by asking git directly rather than by inspecting
+    /// [`GIT_COMMIT`]: a test that skips itself whenever the value is absent
+    /// would go quiet precisely when the build script has stopped stamping, and
+    /// every consumer would silently degrade to "no commit".
+    #[test]
+    fn commit_is_stamped_when_built_from_a_tracked_checkout() {
+        // Both probes, because `build.rs` needs both to succeed: an unborn
+        // branch has a tracked manifest but no commit to name, and skipping
+        // there is correct rather than a regression.
+        let stampable = [
+            ["ls-files", "--error-unmatch", "Cargo.toml"],
+            ["rev-parse", "--short", "HEAD"],
+        ]
+        .iter()
+        .all(|args| {
+            std::process::Command::new("git")
+                .args(args)
+                .current_dir(env!("CARGO_MANIFEST_DIR"))
+                .output()
+                .is_ok_and(|probe| probe.status.success())
+        });
+        if !stampable {
+            return;
+        }
+
+        assert!(
+            super::GIT_COMMIT.is_some(),
+            "build.rs must stamp BOXLITE_GIT_COMMIT when built from a tracked checkout"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

The guest rootfs cache key came from `BOXLITE_GUEST_HASH`, a compile-time digest, but the binary it describes is resolved at run time by `find_binary`, which ranks `BOXLITE_RUNTIME_DIR` above the embedded runtime cache. A guest rebuilt after boxlite was compiled kept the old key, so an existing cache entry was reused and the VM booted the previous guest. `GuestBinary` becomes the single resolution point, which makes that divergence unrepresentable.

## Changes

- `GuestBinary` resolves, validates and identifies the guest binary once. One read feeds both the ELF check and the digest, and `version_key`, GC retention and the injected bytes all derive from that one value.
- The reconciliation guard is deleted rather than extended. It only ran on a cache miss, so the cache-hit path — the silent one — was never covered.
- `BOXLITE_GUEST_HASH` and its build-script emitter are removed, along with the now-dead `validate_guest_binary`.
- `sha2` 0.10 → 0.11, which is what makes always-hashing affordable: 0.10's portable backend costs ~690 ms debug / ~36 ms release on the 18 MB guest. `digest` 0.11 drops `LowerHex`, so 16 digest sites move to `hex::encode`.
- `BaseDiskManager::gc_orphans` reclaims base disks that no `base_disk` row and no backing chain claims. The per-kind collectors iterate DB records, so a file whose row is gone was unreclaimable; one real cache held 7 files against 1 row.
- The extracted runtime cache directory is stamped with the build's commit for provenance. Correctness still comes from the manifest hash, and the commit is deliberately kept out of the rootfs version key.

## How to verify

- `make test:unit:rust`
- End to end: `make guest` to rebuild the guest without rebuilding boxlite, then start a box. The cache key moves and a new rootfs is built instead of the stale one being reused; starting again with an unchanged guest hits the cache.

## Risks / rollout

- `gc_orphans` deletes files. It removes one only when no `base_disk` row of any kind names it *and* nothing backs onto it, walking chains from both box overlays and from the bases themselves. It fails closed on a database error and skips anything inside a 5-minute grace window.
- Two tests (`id_tracks_the_bytes_on_disk`, `version_key_follows_the_guest_binary_on_disk`) cannot have a revert-and-watch-it-fail red side, because they call a symbol the fix introduces. That gap is recorded at both test sites; they were checked by mutation and by a booted VM instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic cleanup of unused base disk files, while protecting active and recently created data.
  - Added build commit information to runtime cache naming when available.
  - Improved guest runtime identification so cache updates reflect changes to the guest binary.

- **Bug Fixes**
  - Recovery now attempts orphaned disk cleanup without interrupting the overall recovery process.
  - Improved validation and tracking of guest runtime binaries.
  - Standardized digest handling to preserve consistent image and cache verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->