### PR TITLE
test(cli): fix local platform assumptions

### DIFF
--- a/src/cli/tests/gvproxy_port_conflict.rs
+++ b/src/cli/tests/gvproxy_port_conflict.rs
@@ -113,19 +113,33 @@ fn gvproxy_port_conflict_fails_fast_with_named_error() {
 /// "address already in use"), proving that the expose path preserves the
 /// backend's actual bind failure instead of synthesizing one conflict string.
 #[test]
+#[cfg_attr(
+    not(target_os = "linux"),
+    ignore = "privileged-port permissions are Linux-specific; gvproxy may have different bind permissions from the test process on other hosts"
+)]
 fn gvproxy_privileged_port_fails_fast_with_named_error() {
     // Skip when the runner happens to have permission to bind <1024
     // (root, fcap'd binary, container with CAP_NET_BIND_SERVICE,
     // sysctl `net.ipv4.ip_unprivileged_port_start` lowered). The test
     // premise is "bind privileged port fails"; without that, the test
     // is meaningless.
-    if TcpListener::bind("127.0.0.1:80").is_ok() {
-        eprintln!(
-            "SKIP gvproxy_privileged_port_fails_fast_with_named_error: \
-             host allows binding port 80 (root / CAP_NET_BIND_SERVICE / \
-             low ip_unprivileged_port_start)"
-        );
-        return;
+    match TcpListener::bind("127.0.0.1:80") {
+        Ok(_) => {
+            eprintln!(
+                "SKIP gvproxy_privileged_port_fails_fast_with_named_error: \
+                 host allows binding port 80 (root / CAP_NET_BIND_SERVICE / \
+                 low ip_unprivileged_port_start)"
+            );
+            return;
+        }
+        Err(error) if error.kind() != std::io::ErrorKind::PermissionDenied => {
+            eprintln!(
+                "SKIP gvproxy_privileged_port_fails_fast_with_named_error: \
+                 port 80 probe failed for a reason other than permission denial: {error}"
+            );
+            return;
+        }
+        Err(_) => {}
     }
 
     let ctx = common::boxlite();

--- a/src/cli/tests/stress_disk.rs
+++ b/src/cli/tests/stress_disk.rs
@@ -668,9 +668,9 @@ fn bystander_writes_keep_progressing_while_peer_fills_its_disk() {
     );
 
     assert!(
-        after > before,
+        after >= before + 2,
         "bystander's background writer must keep progressing during a peer's \
-         fill — at least one new line should land in /work/log; \
+         fill — at least two new lines should land in /work/log; \
          before={before} after={after}"
     );
 

--- a/src/cli/tests/stress_disk.rs
+++ b/src/cli/tests/stress_disk.rs
@@ -668,9 +668,9 @@ fn bystander_writes_keep_progressing_while_peer_fills_its_disk() {
     );
 
     assert!(
-        after > before + 5,
+        after > before,
         "bystander's background writer must keep progressing during a peer's \
-         fill — at least a handful of new lines should land in /work/log; \
+         fill — at least one new line should land in /work/log; \
          before={before} after={after}"
     );
 

--- a/src/cli/tests/stress_disk.rs
+++ b/src/cli/tests/stress_disk.rs
@@ -655,10 +655,10 @@ fn bystander_writes_keep_progressing_while_peer_fills_its_disk() {
             "--",
             "sh",
             "-c",
-            "rm -f /tmp/fill.done /tmp/fill.out; \
-         i=0; while dd if=/dev/zero of=/fill.$i bs=1M count=1; do \
+            "rm -f /tmp/fill.done /tmp/fill.err; \
+         i=0; while dd if=/dev/zero of=/fill.$i bs=1M count=1 2>/tmp/fill.err; do \
             i=$((i + 1)); sleep 0.25; \
-          done > /tmp/fill.out 2>&1; touch /tmp/fill.done",
+          done; touch /tmp/fill.done",
         ],
         Duration::from_secs(15),
     );
@@ -717,7 +717,7 @@ fn bystander_writes_keep_progressing_while_peer_fills_its_disk() {
     let fill = exec_sh(
         home.path.as_path(),
         &victim,
-        "cat /tmp/fill.out",
+        "cat /tmp/fill.err",
         Duration::from_secs(15),
     );
     let fill_out = String::from_utf8_lossy(&fill.stdout) + String::from_utf8_lossy(&fill.stderr);

--- a/src/cli/tests/stress_disk.rs
+++ b/src/cli/tests/stress_disk.rs
@@ -12,7 +12,7 @@
 use assert_cmd::Command;
 use boxlite_test_utils::home::PerTestBoxHome;
 use std::path::Path;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 /// `boxlite --home <home> <args...>` with a timeout.
 fn boxlite(home: &Path, args: &[&str], timeout: Duration) -> std::process::Output {
@@ -618,18 +618,18 @@ fn bystander_writes_keep_progressing_while_peer_fills_its_disk() {
         id: bystander.clone(),
     };
 
-    // Start a background appender in the bystander (one line per ~100 ms).
-    let _ = exec_sh(
+    let prepare_bystander = exec_sh(
         home.path.as_path(),
         &bystander,
-        "mkdir -p /work && \
-         ( while true; do echo tick >> /work/log; sleep 0.1; done ) </dev/null >/dev/null 2>&1 & \
-         echo $! > /tmp/loop.pid",
+        "mkdir -p /work && : > /work/log",
         Duration::from_secs(15),
     );
+    assert!(
+        prepare_bystander.status.success(),
+        "prepare bystander: {}",
+        String::from_utf8_lossy(&prepare_bystander.stderr)
+    );
 
-    // Let the loop settle, then snapshot.
-    std::thread::sleep(Duration::from_secs(1));
     let line_count = |id: &str| -> u64 {
         let out = exec_sh(
             home.path.as_path(),
@@ -644,34 +644,92 @@ fn bystander_writes_keep_progressing_while_peer_fills_its_disk() {
     };
     let before = line_count(&bystander);
 
-    // Victim fills its rootfs.
+    // Run the fill in the guest background. Separate host-side CLI processes
+    // cannot overlap because a BOXLITE_HOME has an exclusive runtime lock.
+    let start_fill = boxlite(
+        home.path.as_path(),
+        &[
+            "exec",
+            "-d",
+            &victim,
+            "--",
+            "sh",
+            "-c",
+            "rm -f /tmp/fill.done /tmp/fill.out; \
+         i=0; while dd if=/dev/zero of=/fill.$i bs=1M count=1; do \
+            i=$((i + 1)); sleep 0.25; \
+          done > /tmp/fill.out 2>&1; touch /tmp/fill.done",
+        ],
+        Duration::from_secs(15),
+    );
+    assert!(
+        start_fill.status.success(),
+        "start victim fill: {}",
+        String::from_utf8_lossy(&start_fill.stderr)
+    );
+
+    let deadline = Instant::now() + Duration::from_secs(300);
+    let mut writes_during_fill = 0;
+    let mut observed = before;
+
+    loop {
+        let done = exec_sh(
+            home.path.as_path(),
+            &victim,
+            "test -e /tmp/fill.done",
+            Duration::from_secs(15),
+        );
+        if done.status.success() {
+            break;
+        }
+
+        if writes_during_fill < 2 {
+            let write = exec_sh(
+                home.path.as_path(),
+                &bystander,
+                "echo tick >> /work/log",
+                Duration::from_secs(15),
+            );
+            let still_running = exec_sh(
+                home.path.as_path(),
+                &victim,
+                "test ! -e /tmp/fill.done",
+                Duration::from_secs(15),
+            );
+            if write.status.success() && still_running.status.success() {
+                writes_during_fill += 1;
+                observed = line_count(&bystander);
+            }
+        }
+
+        if Instant::now() >= deadline {
+            let _ = exec_sh(
+                home.path.as_path(),
+                &victim,
+                "pkill dd 2>/dev/null; true",
+                Duration::from_secs(15),
+            );
+            panic!("victim fill did not complete within 300 seconds");
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+
     let fill = exec_sh(
         home.path.as_path(),
         &victim,
-        "dd if=/dev/zero of=/fill bs=1M 2>&1; true",
-        Duration::from_secs(120),
+        "cat /tmp/fill.out",
+        Duration::from_secs(15),
     );
     let fill_out = String::from_utf8_lossy(&fill.stdout) + String::from_utf8_lossy(&fill.stderr);
     assert!(
         fill_out.contains("No space left"),
-        "victim fill must hit ENOSPC"
-    );
-
-    let after = line_count(&bystander);
-
-    // Stop the loop before doing anything else.
-    let _ = exec_sh(
-        home.path.as_path(),
-        &bystander,
-        "kill $(cat /tmp/loop.pid) 2>/dev/null; true",
-        Duration::from_secs(10),
+        "victim fill must hit ENOSPC; output:\n{fill_out}"
     );
 
     assert!(
-        after >= before + 2,
-        "bystander's background writer must keep progressing during a peer's \
-         fill — at least two new lines should land in /work/log; \
-         before={before} after={after}"
+        writes_during_fill >= 2 && observed >= before + 2,
+        "bystander must complete at least two writes while a peer's fill is \
+         still running; writes={writes_during_fill} before={before} observed={observed}"
     );
 
     assert_alive(home.path.as_path(), &victim, "after filling its own rootfs");


### PR DESCRIPTION
Keep CLI integration assertions focused on portable behavior instead of Linux-only permissions or host performance.

Test plan:
- [x] Run the gvproxy port-conflict test binary on macOS (2 passed, 1 skipped)
- [x] Run the disk-isolation bystander test against real VMs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved privileged-port regression test handling across different permission and probing environments.
  * Enhanced disk stress testing to verify concurrent activity during disk exhaustion and confirm expected write failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->