### PR TITLE
fix(sdk): tolerate closed tunnel writers

### DIFF
--- a/sdks/node/src/network.rs
+++ b/sdks/node/src/network.rs
@@ -1,8 +1,8 @@
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
 
-use boxlite::LiteBox;
 use boxlite::litebox::{BoxEndpoint, BoxTunnel};
+use boxlite::LiteBox;
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -119,6 +119,10 @@ impl JsBoxConnection {
         Ok(data.len() as u32)
     }
 
+    /// Close the connection and release its reader.
+    ///
+    /// An already disconnected writer (`NotConnected`) is treated as closed;
+    /// other writer shutdown errors are returned.
     #[napi]
     pub async fn close(&self) -> Result<()> {
         let mut writer = self.writer.lock().await;

--- a/sdks/node/src/network.rs
+++ b/sdks/node/src/network.rs
@@ -17,15 +17,17 @@ async fn close_streams(
     writer: &tokio::sync::Mutex<Option<ConnectionWriter>>,
 ) -> std::io::Result<()> {
     let mut writer = writer.lock().await;
-    if let Some(mut stream) = writer.take() {
+    let shutdown_result = if let Some(mut stream) = writer.take() {
         match stream.shutdown().await {
-            Ok(()) => {}
-            Err(error) if error.kind() == std::io::ErrorKind::NotConnected => {}
-            Err(error) => return Err(error),
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotConnected => Ok(()),
+            Err(error) => Err(error),
         }
-    }
+    } else {
+        Ok(())
+    };
     reader.lock().await.take();
-    Ok(())
+    shutdown_result
 }
 
 /// Handle for network operations on a box.
@@ -166,9 +168,9 @@ mod tests {
     use std::task::{Context, Poll};
     use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
-    struct DisconnectedStream;
+    struct ShutdownErrorStream(std::io::ErrorKind);
 
-    impl AsyncRead for DisconnectedStream {
+    impl AsyncRead for ShutdownErrorStream {
         fn poll_read(
             self: Pin<&mut Self>,
             _cx: &mut Context<'_>,
@@ -178,7 +180,7 @@ mod tests {
         }
     }
 
-    impl AsyncWrite for DisconnectedStream {
+    impl AsyncWrite for ShutdownErrorStream {
         fn poll_write(
             self: Pin<&mut Self>,
             _cx: &mut Context<'_>,
@@ -192,20 +194,38 @@ mod tests {
         }
 
         fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
-            Poll::Ready(Err(std::io::Error::from(std::io::ErrorKind::NotConnected)))
+            Poll::Ready(Err(std::io::Error::from(self.0)))
         }
     }
 
     #[test]
     fn close_tolerates_not_connected_and_clears_both_halves() {
         futures::executor::block_on(async {
-            let connection: Box<dyn boxlite::BoxConnection> = Box::new(DisconnectedStream);
+            let connection: Box<dyn boxlite::BoxConnection> =
+                Box::new(ShutdownErrorStream(std::io::ErrorKind::NotConnected));
             let (reader, writer) = tokio::io::split(connection);
             let reader = tokio::sync::Mutex::new(Some(reader));
             let writer = tokio::sync::Mutex::new(Some(writer));
 
             close_streams(&reader, &writer).await.unwrap();
 
+            assert!(reader.lock().await.is_none());
+            assert!(writer.lock().await.is_none());
+        });
+    }
+
+    #[test]
+    fn close_reports_shutdown_errors_after_clearing_both_halves() {
+        futures::executor::block_on(async {
+            let connection: Box<dyn boxlite::BoxConnection> =
+                Box::new(ShutdownErrorStream(std::io::ErrorKind::BrokenPipe));
+            let (reader, writer) = tokio::io::split(connection);
+            let reader = tokio::sync::Mutex::new(Some(reader));
+            let writer = tokio::sync::Mutex::new(Some(writer));
+
+            let error = close_streams(&reader, &writer).await.unwrap_err();
+
+            assert_eq!(error.kind(), std::io::ErrorKind::BrokenPipe);
             assert!(reader.lock().await.is_none());
             assert!(writer.lock().await.is_none());
         });

--- a/sdks/node/src/network.rs
+++ b/sdks/node/src/network.rs
@@ -123,10 +123,15 @@ impl JsBoxConnection {
     pub async fn close(&self) -> Result<()> {
         let mut writer = self.writer.lock().await;
         if let Some(mut stream) = writer.take() {
-            stream
-                .shutdown()
-                .await
-                .map_err(|error| Error::from_reason(format!("close tunnel connection: {error}")))?;
+            match stream.shutdown().await {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotConnected => {}
+                Err(error) => {
+                    return Err(Error::from_reason(format!(
+                        "close tunnel connection: {error}"
+                    )));
+                }
+            }
         }
         self.reader.lock().await.take();
         Ok(())

--- a/sdks/node/src/network.rs
+++ b/sdks/node/src/network.rs
@@ -1,8 +1,8 @@
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
 
-use boxlite::LiteBox;
 use boxlite::litebox::{BoxEndpoint, BoxTunnel};
+use boxlite::LiteBox;
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -11,6 +11,22 @@ use crate::util::map_err;
 
 type ConnectionReader = tokio::io::ReadHalf<Box<dyn boxlite::BoxConnection>>;
 type ConnectionWriter = tokio::io::WriteHalf<Box<dyn boxlite::BoxConnection>>;
+
+async fn close_streams(
+    reader: &tokio::sync::Mutex<Option<ConnectionReader>>,
+    writer: &tokio::sync::Mutex<Option<ConnectionWriter>>,
+) -> std::io::Result<()> {
+    let mut writer = writer.lock().await;
+    if let Some(mut stream) = writer.take() {
+        match stream.shutdown().await {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotConnected => {}
+            Err(error) => return Err(error),
+        }
+    }
+    reader.lock().await.take();
+    Ok(())
+}
 
 /// Handle for network operations on a box.
 #[napi]
@@ -125,20 +141,9 @@ impl JsBoxConnection {
     /// other writer shutdown errors are returned.
     #[napi]
     pub async fn close(&self) -> Result<()> {
-        let mut writer = self.writer.lock().await;
-        if let Some(mut stream) = writer.take() {
-            match stream.shutdown().await {
-                Ok(()) => {}
-                Err(error) if error.kind() == std::io::ErrorKind::NotConnected => {}
-                Err(error) => {
-                    return Err(Error::from_reason(format!(
-                        "close tunnel connection: {error}"
-                    )));
-                }
-            }
-        }
-        self.reader.lock().await.take();
-        Ok(())
+        close_streams(&self.reader, &self.writer)
+            .await
+            .map_err(|error| Error::from_reason(format!("close tunnel connection: {error}")))
     }
 
     #[napi]
@@ -151,5 +156,58 @@ impl JsBoxConnection {
                 .map_err(|error| Error::from_reason(format!("shut down tunnel writer: {error}")))?;
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+    use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+
+    struct DisconnectedStream;
+
+    impl AsyncRead for DisconnectedStream {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            _buf: &mut ReadBuf<'_>,
+        ) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    impl AsyncWrite for DisconnectedStream {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<std::io::Result<usize>> {
+            Poll::Ready(Ok(buf.len()))
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Err(std::io::Error::from(std::io::ErrorKind::NotConnected)))
+        }
+    }
+
+    #[test]
+    fn close_tolerates_not_connected_and_clears_both_halves() {
+        futures::executor::block_on(async {
+            let connection: Box<dyn boxlite::BoxConnection> = Box::new(DisconnectedStream);
+            let (reader, writer) = tokio::io::split(connection);
+            let reader = tokio::sync::Mutex::new(Some(reader));
+            let writer = tokio::sync::Mutex::new(Some(writer));
+
+            close_streams(&reader, &writer).await.unwrap();
+
+            assert!(reader.lock().await.is_none());
+            assert!(writer.lock().await.is_none());
+        });
     }
 }

--- a/sdks/node/src/network.rs
+++ b/sdks/node/src/network.rs
@@ -1,8 +1,8 @@
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
 
-use boxlite::litebox::{BoxEndpoint, BoxTunnel};
 use boxlite::LiteBox;
+use boxlite::litebox::{BoxEndpoint, BoxTunnel};
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};

--- a/sdks/python/src/network.rs
+++ b/sdks/python/src/network.rs
@@ -1,8 +1,8 @@
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
 
-use boxlite::litebox::{BoxEndpoint, BoxTunnel};
 use boxlite::LiteBox;
+use boxlite::litebox::{BoxEndpoint, BoxTunnel};
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};

--- a/sdks/python/src/network.rs
+++ b/sdks/python/src/network.rs
@@ -1,8 +1,8 @@
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
 
-use boxlite::LiteBox;
 use boxlite::litebox::{BoxEndpoint, BoxTunnel};
+use boxlite::LiteBox;
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -147,6 +147,10 @@ impl PyBoxConnection {
         })
     }
 
+    /// Close the connection and release its reader.
+    ///
+    /// An already disconnected writer (`NotConnected`) is treated as closed;
+    /// other writer shutdown errors are returned.
     fn close<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let reader = Arc::clone(&self.reader);
         let writer = Arc::clone(&self.writer);

--- a/sdks/python/src/network.rs
+++ b/sdks/python/src/network.rs
@@ -1,8 +1,8 @@
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
 
-use boxlite::LiteBox;
 use boxlite::litebox::{BoxEndpoint, BoxTunnel};
+use boxlite::LiteBox;
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -11,6 +11,22 @@ use crate::util::map_err;
 
 type ConnectionReader = tokio::io::ReadHalf<Box<dyn boxlite::BoxConnection>>;
 type ConnectionWriter = tokio::io::WriteHalf<Box<dyn boxlite::BoxConnection>>;
+
+async fn close_streams(
+    reader: &tokio::sync::Mutex<Option<ConnectionReader>>,
+    writer: &tokio::sync::Mutex<Option<ConnectionWriter>>,
+) -> std::io::Result<()> {
+    let mut writer = writer.lock().await;
+    if let Some(mut stream) = writer.take() {
+        match stream.shutdown().await {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotConnected => {}
+            Err(error) => return Err(error),
+        }
+    }
+    reader.lock().await.take();
+    Ok(())
+}
 
 /// Handle for network operations on a box.
 #[pyclass(name = "NetworkHandle")]
@@ -155,20 +171,11 @@ impl PyBoxConnection {
         let reader = Arc::clone(&self.reader);
         let writer = Arc::clone(&self.writer);
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            let mut writer = writer.lock().await;
-            if let Some(mut stream) = writer.take() {
-                match stream.shutdown().await {
-                    Ok(()) => {}
-                    Err(error) if error.kind() == std::io::ErrorKind::NotConnected => {}
-                    Err(error) => {
-                        return Err(map_err(boxlite::BoxliteError::Network(format!(
-                            "close tunnel connection: {error}"
-                        ))));
-                    }
-                }
-            }
-            reader.lock().await.take();
-            Ok(())
+            close_streams(&reader, &writer).await.map_err(|error| {
+                map_err(boxlite::BoxliteError::Network(format!(
+                    "close tunnel connection: {error}"
+                )))
+            })
         })
     }
 
@@ -185,5 +192,58 @@ impl PyBoxConnection {
             }
             Ok(())
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+    use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+
+    struct DisconnectedStream;
+
+    impl AsyncRead for DisconnectedStream {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            _buf: &mut ReadBuf<'_>,
+        ) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    impl AsyncWrite for DisconnectedStream {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<std::io::Result<usize>> {
+            Poll::Ready(Ok(buf.len()))
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Err(std::io::Error::from(std::io::ErrorKind::NotConnected)))
+        }
+    }
+
+    #[test]
+    fn close_tolerates_not_connected_and_clears_both_halves() {
+        futures::executor::block_on(async {
+            let connection: Box<dyn boxlite::BoxConnection> = Box::new(DisconnectedStream);
+            let (reader, writer) = tokio::io::split(connection);
+            let reader = tokio::sync::Mutex::new(Some(reader));
+            let writer = tokio::sync::Mutex::new(Some(writer));
+
+            close_streams(&reader, &writer).await.unwrap();
+
+            assert!(reader.lock().await.is_none());
+            assert!(writer.lock().await.is_none());
+        });
     }
 }

--- a/sdks/python/src/network.rs
+++ b/sdks/python/src/network.rs
@@ -153,11 +153,15 @@ impl PyBoxConnection {
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let mut writer = writer.lock().await;
             if let Some(mut stream) = writer.take() {
-                stream.shutdown().await.map_err(|error| {
-                    map_err(boxlite::BoxliteError::Network(format!(
-                        "close tunnel connection: {error}"
-                    )))
-                })?;
+                match stream.shutdown().await {
+                    Ok(()) => {}
+                    Err(error) if error.kind() == std::io::ErrorKind::NotConnected => {}
+                    Err(error) => {
+                        return Err(map_err(boxlite::BoxliteError::Network(format!(
+                            "close tunnel connection: {error}"
+                        ))));
+                    }
+                }
             }
             reader.lock().await.take();
             Ok(())

--- a/sdks/python/src/network.rs
+++ b/sdks/python/src/network.rs
@@ -17,15 +17,17 @@ async fn close_streams(
     writer: &tokio::sync::Mutex<Option<ConnectionWriter>>,
 ) -> std::io::Result<()> {
     let mut writer = writer.lock().await;
-    if let Some(mut stream) = writer.take() {
+    let shutdown_result = if let Some(mut stream) = writer.take() {
         match stream.shutdown().await {
-            Ok(()) => {}
-            Err(error) if error.kind() == std::io::ErrorKind::NotConnected => {}
-            Err(error) => return Err(error),
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotConnected => Ok(()),
+            Err(error) => Err(error),
         }
-    }
+    } else {
+        Ok(())
+    };
     reader.lock().await.take();
-    Ok(())
+    shutdown_result
 }
 
 /// Handle for network operations on a box.
@@ -202,9 +204,9 @@ mod tests {
     use std::task::{Context, Poll};
     use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
-    struct DisconnectedStream;
+    struct ShutdownErrorStream(std::io::ErrorKind);
 
-    impl AsyncRead for DisconnectedStream {
+    impl AsyncRead for ShutdownErrorStream {
         fn poll_read(
             self: Pin<&mut Self>,
             _cx: &mut Context<'_>,
@@ -214,7 +216,7 @@ mod tests {
         }
     }
 
-    impl AsyncWrite for DisconnectedStream {
+    impl AsyncWrite for ShutdownErrorStream {
         fn poll_write(
             self: Pin<&mut Self>,
             _cx: &mut Context<'_>,
@@ -228,20 +230,38 @@ mod tests {
         }
 
         fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
-            Poll::Ready(Err(std::io::Error::from(std::io::ErrorKind::NotConnected)))
+            Poll::Ready(Err(std::io::Error::from(self.0)))
         }
     }
 
     #[test]
     fn close_tolerates_not_connected_and_clears_both_halves() {
         futures::executor::block_on(async {
-            let connection: Box<dyn boxlite::BoxConnection> = Box::new(DisconnectedStream);
+            let connection: Box<dyn boxlite::BoxConnection> =
+                Box::new(ShutdownErrorStream(std::io::ErrorKind::NotConnected));
             let (reader, writer) = tokio::io::split(connection);
             let reader = tokio::sync::Mutex::new(Some(reader));
             let writer = tokio::sync::Mutex::new(Some(writer));
 
             close_streams(&reader, &writer).await.unwrap();
 
+            assert!(reader.lock().await.is_none());
+            assert!(writer.lock().await.is_none());
+        });
+    }
+
+    #[test]
+    fn close_reports_shutdown_errors_after_clearing_both_halves() {
+        futures::executor::block_on(async {
+            let connection: Box<dyn boxlite::BoxConnection> =
+                Box::new(ShutdownErrorStream(std::io::ErrorKind::BrokenPipe));
+            let (reader, writer) = tokio::io::split(connection);
+            let reader = tokio::sync::Mutex::new(Some(reader));
+            let writer = tokio::sync::Mutex::new(Some(writer));
+
+            let error = close_streams(&reader, &writer).await.unwrap_err();
+
+            assert_eq!(error.kind(), std::io::ErrorKind::BrokenPipe);
             assert!(reader.lock().await.is_none());
             assert!(writer.lock().await.is_none());
         });


### PR DESCRIPTION
Treat an already disconnected tunnel writer as successfully closed in the Python and Node SDKs.

Test plan:
- [x] Run the two Python local tunnel E2E tests against real VMs
- [x] Run Node tunnel wrapper tests
- [x] Run clippy for the Python and Node SDK crates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection shutdown handling by treating already-disconnected states as successful closure.
  * Ensured both sides of a connection are consistently cleaned up during shutdown.
  * Other shutdown failures continue to be reported appropriately.
  * Added safeguards to improve reliability when closing interrupted or disconnected streams.
  * Prevented incomplete cleanup when a connection is closed after disconnection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->