### PR TITLE
fix(e2e): report missing docker cli

### DIFF
--- a/apps/scripts/local-dex-env.mjs
+++ b/apps/scripts/local-dex-env.mjs
@@ -103,11 +103,12 @@ function ensureDocker() {
   })
 
   if (result.status !== 0) {
+    const details = trimOutput(result.stderr || result.stdout || result.error?.message)
     throw new Error(
       [
         'Docker is required for the local Dex E2E environment.',
         'Start Docker Desktop, then run this command again.',
-        trimOutput(result.stderr || result.stdout),
+        details,
       ]
         .filter(Boolean)
         .join(os.EOL),
@@ -543,5 +544,5 @@ function bindShutdown(child) {
 }
 
 function trimOutput(output) {
-  return output.trim().split(/\r?\n/).slice(-8).join(os.EOL)
+  return output?.trim().split(/\r?\n/).slice(-8).join(os.EOL) || ''
 }


### PR DESCRIPTION
Report a clear Docker prerequisite error when the local E2E helper cannot spawn the docker CLI.

Test plan:
- [x] npm run e2e:local -- -- true
- [x] scripts/test/e2e/run.sh --timeout=120