### PR TITLE
fix(api): keep open usage periods in step with their boxes

### DIFF
--- a/apps/api/src/usage/services/expected-usage-period.spec.ts
+++ b/apps/api/src/usage/services/expected-usage-period.spec.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2025 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { BoxState } from '../../box/enums/box-state.enum'
+import { BOX_STATES_CONSUMING_COMPUTE } from '../../organization/constants/box-consuming-states.constant'
+import { ExpectedOpenPeriod, expectedOpenPeriod, sameShape } from './expected-usage-period'
+
+const box = { cpu: 2, gpu: 1, mem: 4, disk: 10 }
+const FULL_COMPUTE = { cpu: 2, gpu: 1, mem: 4, disk: 10 }
+const DISK_ONLY = { cpu: 0, gpu: 0, mem: 0, disk: 10 }
+
+describe('expectedOpenPeriod', () => {
+  // Every state is listed so a new BoxState cannot be added without deciding
+  // what it bills — the exhaustiveness check below fails until it appears here.
+  const cases: [BoxState, ExpectedOpenPeriod][] = [
+    [BoxState.STARTED, FULL_COMPUTE],
+    [BoxState.STOPPING, DISK_ONLY],
+    [BoxState.STOPPED, DISK_ONLY],
+    [BoxState.ERROR, null],
+    [BoxState.ARCHIVED, null],
+    [BoxState.DESTROYING, null],
+    [BoxState.DESTROYED, null],
+    [BoxState.CREATING, null],
+    [BoxState.STARTING, null],
+    [BoxState.RESTORING, null],
+    [BoxState.RESIZING, null],
+    [BoxState.UNKNOWN, null],
+    // No code in this repository puts a box into ARCHIVING, so it carries no
+    // price. Deciding one here would be inventing a billing rule for a state
+    // the product does not have yet.
+    [BoxState.ARCHIVING, null],
+  ]
+
+  it.each(cases)('bills %s as expected', (state, expected) => {
+    expect(expectedOpenPeriod({ ...box, state })).toEqual(expected)
+  })
+
+  it('covers every box state', () => {
+    expect(cases.map(([state]) => state).sort()).toEqual(Object.values(BoxState).sort())
+  })
+
+  it('bills nothing for a box that no longer exists', () => {
+    // the roll-over relies on this: a deleted box must not have its period
+    // reopened, or it accrues forever with nothing left to reconcile against
+    expect(expectedOpenPeriod(null)).toBeNull()
+    expect(expectedOpenPeriod(undefined)).toBeNull()
+  })
+
+  it('charges a stopped box for disk but not for compute', () => {
+    const stopped = expectedOpenPeriod({ ...box, state: BoxState.STOPPED })
+
+    expect(stopped).toEqual({ cpu: 0, gpu: 0, mem: 0, disk: box.disk })
+  })
+
+  it('does not bill the states quota counts before a box is usable', () => {
+    // quota counts CREATING/STARTING because the runner has already pinned the
+    // resources; billing deliberately does not charge for a box the tenant
+    // cannot use yet. Divergence here is a pricing decision, not a bug.
+    const notYetBillable = [BoxState.CREATING, BoxState.STARTING, BoxState.RESTORING]
+
+    for (const state of notYetBillable) {
+      expect(BOX_STATES_CONSUMING_COMPUTE).toContain(state)
+      expect(expectedOpenPeriod({ ...box, state })).toBeNull()
+    }
+  })
+})
+
+describe('sameShape', () => {
+  it('accepts a period that already charges the right resources', () => {
+    expect(sameShape(FULL_COMPUTE, FULL_COMPUTE)).toBe(true)
+  })
+
+  it.each(['cpu', 'gpu', 'mem', 'disk'] as const)('rejects a period whose %s differs', (resource) => {
+    expect(sameShape({ ...FULL_COMPUTE, [resource]: FULL_COMPUTE[resource] + 1 }, FULL_COMPUTE)).toBe(false)
+  })
+
+  it('tolerates an immaterial fractional difference in a period row', () => {
+    // Box resources are integers, but period resources are double precision;
+    // avoid needlessly splitting a period whose fractional difference is immaterial.
+    expect(sameShape({ ...FULL_COMPUTE, cpu: FULL_COMPUTE.cpu + 5e-7 }, FULL_COMPUTE)).toBe(true)
+  })
+
+  it('still rejects a difference larger than that tolerance', () => {
+    expect(sameShape({ ...FULL_COMPUTE, cpu: FULL_COMPUTE.cpu + 1e-4 }, FULL_COMPUTE)).toBe(false)
+  })
+})

--- a/apps/api/src/usage/services/expected-usage-period.ts
+++ b/apps/api/src/usage/services/expected-usage-period.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2025 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { BoxState } from '../../box/enums/box-state.enum'
+
+/** The resources an open usage period charges for. */
+export interface UsagePeriodShape {
+  cpu: number
+  gpu: number
+  mem: number
+  disk: number
+}
+
+/** The box fields that decide what its open period should charge. */
+export interface BillableBox extends UsagePeriodShape {
+  state: BoxState
+}
+
+export type ExpectedOpenPeriod = UsagePeriodShape | null
+
+/** States that must have an open period. */
+export const BOX_STATES_WITH_OPEN_PERIOD: BoxState[] = [BoxState.STARTED, BoxState.STOPPING, BoxState.STOPPED]
+
+/** States that must not have one — the box has stopped consuming anything. */
+export const BOX_STATES_WITHOUT_OPEN_PERIOD: BoxState[] = [
+  BoxState.ERROR,
+  BoxState.ARCHIVED,
+  BoxState.DESTROYING,
+  BoxState.DESTROYED,
+]
+
+/** Of the states above, the ones that keep paying for disk but not compute. */
+export const BOX_STATES_BILLING_DISK_ONLY: BoxState[] = [BoxState.STOPPING, BoxState.STOPPED]
+
+// Every remaining state is in neither list and bills nothing, the same answer a
+// terminal box gets: CREATING, STARTING and UNKNOWN, plus RESTORING, RESIZING
+// and ARCHIVING, which no writer in this repository ever assigns.
+//
+// Answering "nothing" rather than "leave whatever is there alone" is safe
+// because the only caller that acts on that answer destructively is the
+// reconcile pass, and its candidate query is restricted to the two lists above,
+// so it is never handed a box mid-transition. The one way it can see one is a
+// box whose state moved between the scan and the repair — and there the period
+// it would close is a drifted one it was picked up to correct anyway.
+
+// Box resources are integers, while usage-period resources are double
+// precision. Normal writes therefore compare exactly; this tolerance is a
+// defensive guard for non-canonical period rows, preventing an immaterial
+// fractional difference from causing an unnecessary close/reopen split.
+const RESOURCE_EPSILON = 1e-6
+
+/**
+ * What the box's open usage period should charge, given the state it is in
+ * right now: full compute while running, disk alone once it has stopped, and
+ * nothing at all otherwise.
+ *
+ * This is the single source of truth for the state -> period rule, shared by
+ * the event handler, the daily roll-over and the reconcile pass. It deliberately
+ * does not reuse `BOX_STATES_CONSUMING_COMPUTE`: quota counts CREATING and
+ * STARTING because the runner has already pinned the resources, while billing
+ * does not charge for a box the tenant cannot use yet. The two answer different
+ * questions — see the note in usage.service.ts.
+ */
+export function expectedOpenPeriod(box: BillableBox | null | undefined): ExpectedOpenPeriod {
+  if (!box) {
+    return null
+  }
+  if (box.state === BoxState.STARTED) {
+    return { cpu: box.cpu, gpu: box.gpu, mem: box.mem, disk: box.disk }
+  }
+  if (BOX_STATES_BILLING_DISK_ONLY.includes(box.state)) {
+    return { cpu: 0, gpu: 0, mem: 0, disk: box.disk }
+  }
+  return null
+}
+
+/** Whether a period already charges what it should, within resource tolerance. */
+export function sameShape(period: UsagePeriodShape, expected: UsagePeriodShape): boolean {
+  return (['cpu', 'gpu', 'mem', 'disk'] as const).every(
+    (resource) => Math.abs(period[resource] - expected[resource]) < RESOURCE_EPSILON,
+  )
+}

--- a/apps/api/src/usage/services/usage.service.integration.spec.ts
+++ b/apps/api/src/usage/services/usage.service.integration.spec.ts
@@ -7,10 +7,14 @@ import { createServer, Server } from 'node:http'
 import { AddressInfo } from 'node:net'
 import { Redis } from 'ioredis'
 import { DataSource, IsNull, Not, Repository } from 'typeorm'
+import { Box } from '../../box/entities/box.entity'
+import { BoxLastActivity } from '../../box/entities/box-last-activity.entity'
 import { BoxState } from '../../box/enums/box-state.enum'
 import { BOX_WARM_POOL_UNASSIGNED_ORGANIZATION } from '../../box/constants/box.constants'
 import { RedisLockProvider } from '../../box/common/redis-lock.provider'
 import { CustomNamingStrategy } from '../../common/utils/naming-strategy.util'
+import { Migration1741087887225 } from '../../migrations/1741087887225-migration'
+import { AddBoxLifecycleSeconds1784250000000 } from '../../migrations/pre-deploy/1784250000000-add-box-lifecycle-seconds-migration'
 import { AddBoxUsagePeriods1785250000000 } from '../../migrations/pre-deploy/1785250000000-add-box-usage-periods-migration'
 import { AddBoxUsageExportOutbox1786100000000 } from '../../migrations/pre-deploy/1786100000000-add-box-usage-export-outbox-migration'
 import { BoxUsagePeriod } from '../entities/box-usage-period.entity'
@@ -19,17 +23,24 @@ import { BoxUsageExportOutbox, UsageExportStatus } from '../entities/box-usage-e
 import { UsageExportOutboxService } from './usage-export-outbox.service'
 import { UsageExportPublisherService } from './usage-export-publisher.service'
 import { UsageService } from './usage.service'
+import { expectedOpenPeriod } from './expected-usage-period'
 
-// The two cron jobs are a destructive archive transaction and a roll-over that
-// rewrites resources — neither is observable without a real database, and the
+// The three cron jobs are a destructive archive transaction, a roll-over that
+// rewrites resources, and a reconcile pass built on a left join from box to the
+// ledger — none is observable without a real database, and the
 // at-most-one-open-period invariant lives in a Postgres partial index whose
 // WHERE clause no schema differ compares. The schema here is built by running
-// the migration, so these tests exercise the DDL that actually ships. Runs only
+// the migrations, so these tests exercise the DDL that actually ships. Runs only
 // when a Postgres and a Redis are reachable; skipped otherwise.
 const describeIfDatabase = process.env.DB_HOST && process.env.REDIS_HOST ? describe : describe.skip
 
 const DAY_MS = 24 * 60 * 60 * 1000
-const TABLES = ['box_usage_periods', 'box_usage_periods_archive', 'box_usage_export_outbox']
+// Cleared between tests. `box` is here because the reconcile pass reads it; the
+// rest of the schema the initial migration builds is left in place untouched.
+const TABLES = ['box_usage_periods', 'box_usage_periods_archive', 'box_usage_export_outbox', 'box']
+// Older than the reconcile pass's grace window, so a box is eligible unless a
+// test deliberately makes it fresh.
+const SETTLED_AGO_MS = 10 * 60 * 1000
 
 describeIfDatabase('UsageService (integration, real Postgres + Redis)', () => {
   let dataSource: DataSource
@@ -41,7 +52,17 @@ describeIfDatabase('UsageService (integration, real Postgres + Redis)', () => {
   // them belong to somebody else and nothing here may write or clear them.
   let ownsTables = false
 
-  const box = { id: 'box-int-1', organizationId: 'org-int-1', region: 'us', cpu: 2, gpu: 1, mem: 4, disk: 10 }
+  // organizationId is a uuid on the box table, so it has to be a real one here
+  // even though the ledger stores it as text.
+  const box = {
+    id: 'box-int-1',
+    organizationId: '5c2f6a48-8f2b-4a1e-9d31-2b7e6f0c1a45',
+    region: 'us',
+    cpu: 2,
+    gpu: 1,
+    mem: 4,
+    disk: 10,
+  }
 
   // The service's own lock keys — cleared individually so a parallel spec
   // sharing this Redis keeps its state.
@@ -50,6 +71,7 @@ describeIfDatabase('UsageService (integration, real Postgres + Redis)', () => {
     'close-and-reopen-usage-periods',
     'archive-usage-periods',
     'publish-usage-exports',
+    'reconcile-usage-periods',
   ]
 
   const openPeriod = (overrides: Partial<BoxUsagePeriod> = {}) =>
@@ -75,34 +97,96 @@ describeIfDatabase('UsageService (integration, real Postgres + Redis)', () => {
       get: () => enabled,
     } as any)
 
-  const serviceForBoxState = (state: BoxState, exportEnabled = false) =>
+  const openPeriods = () => periods.find({ where: { endAt: IsNull() } })
+
+  /**
+   * Inserts a real box row. The reconcile pass joins the box table, so these
+   * cases cannot use the stub above.
+   */
+  const insertBox = (
+    overrides: Partial<typeof box> & { state: BoxState; runnerId?: string; pending?: boolean; updatedAtMsAgo?: number },
+  ) => {
+    const row = {
+      ...box,
+      runnerId: null as string | null,
+      pending: false,
+      updatedAtMsAgo: SETTLED_AGO_MS,
+      ...overrides,
+    }
+    return dataSource.query(
+      `INSERT INTO "box" ("id","organizationId","name","region","osUser","authToken","state","desiredState",
+                          "cpu","gpu","mem","disk","runnerId","pending","updatedAt")
+       VALUES ($1,$2,$3,$4,'root',$5,$6,'started',$7,$8,$9,$10,$11,$12,$13)`,
+      [
+        row.id,
+        row.organizationId,
+        `name-${row.id}`,
+        row.region,
+        `token-${row.id}`,
+        row.state,
+        row.cpu,
+        row.gpu,
+        row.mem,
+        row.disk,
+        row.runnerId,
+        row.pending,
+        new Date(Date.now() - row.updatedAtMsAgo),
+      ],
+    )
+  }
+
+  /**
+   * Everything the control plane runs to keep the ledger in step with box state:
+   * the roll-over settles periods that have grown too long, the reconcile pass
+   * settles periods that disagree with the box they bill for. Reads boxes from
+   * the real table — a plain TypeORM repository satisfies the two methods the
+   * service uses (findOne and createQueryBuilder).
+   *
+   * @param runnerIds shards the reconcile pass will visit on top of the always
+   *   scanned "no runner" shard.
+   */
+  const settleLedger = async (runnerIds: string[] = []) => {
+    const service = new UsageService(
+      periods,
+      new RedisLockProvider(redis),
+      dataSource.getRepository(Box) as any,
+      outboxService(),
+      { find: async () => runnerIds.map((id) => ({ id })) } as any,
+    )
+    await service.closeAndReopenUsagePeriods()
+    await service.reconcileUsagePeriods()
+  }
+
+  const serviceForBoxState = (
+    state: BoxState,
+    exportEnabled = false,
+    boxOverrides: Partial<typeof box> = {},
+  ) =>
     new UsageService(
       periods,
       new RedisLockProvider(redis),
-      {
-        findOne: async () => ({ id: box.id, state }),
-      } as any,
+      { findOne: async () => ({ ...box, state, ...boxOverrides }) } as any,
       outboxService(exportEnabled),
+      { find: async () => [] } as any,
     )
 
   const quoted = TABLES.map((table) => `"${table}"`).join(', ')
-  const dropTables = () => dataSource.query(`DROP TABLE IF EXISTS ${quoted}`)
-  const truncateTables = () => dataSource.query(`TRUNCATE ${quoted}`)
+  // CASCADE because box_last_activity references box.
+  const truncateTables = () => dataSource.query(`TRUNCATE ${quoted} CASCADE`)
 
-  // This spec owns the ledger tables outright — it drops and rebuilds them from
-  // the migration — so it must never be pointed at a database holding real
-  // usage. Each table is checked on its own: one populated table is enough to
-  // refuse, even if the other is missing.
+  // This spec rebuilds the entire public schema from the migrations, so it must
+  // never be pointed at a database holding real data. Every table is checked,
+  // not just the ledger's: one populated table anywhere is enough to refuse.
   const assertDisposableDatabase = async () => {
-    const existing: string[] = (
-      await dataSource.query(`SELECT table_name FROM information_schema.tables WHERE table_name = ANY($1)`, [TABLES])
-    ).map((row: { table_name: string }) => row.table_name)
+    const tables: { table_name: string }[] = await dataSource.query(
+      `SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' AND table_type = 'BASE TABLE'`,
+    )
 
-    for (const table of existing) {
-      const [{ rows }] = await dataSource.query(`SELECT count(*)::int AS rows FROM "${table}"`)
+    for (const { table_name } of tables) {
+      const [{ rows }] = await dataSource.query(`SELECT count(*)::int AS rows FROM "${table_name}"`)
       if (rows > 0) {
         throw new Error(
-          `refusing to run: "${table}" in database "${process.env.DB_DATABASE}" already holds rows — point DB_* at a disposable database`,
+          `refusing to run: "${table_name}" in database "${process.env.DB_DATABASE}" already holds rows — point DB_* at a disposable database`,
         )
       }
     }
@@ -116,18 +200,23 @@ describeIfDatabase('UsageService (integration, real Postgres + Redis)', () => {
       username: process.env.DB_USERNAME,
       password: process.env.DB_PASSWORD,
       database: process.env.DB_DATABASE,
-      entities: [BoxUsagePeriod, BoxUsagePeriodArchive, BoxUsageExportOutbox],
+      entities: [BoxUsagePeriod, BoxUsagePeriodArchive, BoxUsageExportOutbox, Box, BoxLastActivity],
       namingStrategy: new CustomNamingStrategy(),
       synchronize: false,
     }).initialize()
 
-    // Rebuild the schema from the migration every run, so these tests exercise
+    // Rebuild the schema from the migrations every run, so these tests exercise
     // the DDL that ships rather than whatever an earlier run happened to leave.
+    // The whole schema, not just the ledger: the reconcile pass joins the box
+    // table, and box only exists as part of the initial migration.
     await assertDisposableDatabase()
-    await dropTables()
+    await dataSource.query(`DROP SCHEMA public CASCADE`)
+    await dataSource.query(`CREATE SCHEMA public`)
     await dataSource.query(`CREATE EXTENSION IF NOT EXISTS "uuid-ossp"`)
     const queryRunner = dataSource.createQueryRunner()
     try {
+      await new Migration1741087887225().up(queryRunner)
+      await new AddBoxLifecycleSeconds1784250000000().up(queryRunner)
       await new AddBoxUsagePeriods1785250000000().up(queryRunner)
       await new AddBoxUsageExportOutbox1786100000000().up(queryRunner)
       ownsTables = true
@@ -163,9 +252,7 @@ describeIfDatabase('UsageService (integration, real Postgres + Redis)', () => {
   })
 
   beforeEach(async () => {
-    await periods.clear()
-    await archives.clear()
-    await outboxes.clear()
+    await truncateTables()
     await redis.del(...lockKeys)
   })
 
@@ -239,10 +326,9 @@ describeIfDatabase('UsageService (integration, real Postgres + Redis)', () => {
     const serviceWithoutBox = new UsageService(
       periods,
       new RedisLockProvider(redis),
-      {
-        findOne: async () => null,
-      } as any,
+      { findOne: async () => null } as any,
       outboxService(),
+      { find: async () => [] } as any,
     )
 
     await serviceWithoutBox.closeAndReopenUsagePeriods()
@@ -262,6 +348,200 @@ describeIfDatabase('UsageService (integration, real Postgres + Redis)', () => {
     const remaining = await periods.find()
     expect(remaining).toHaveLength(1)
     expect(remaining[0].endAt).toBeInstanceOf(Date)
+  })
+
+  // The ledger is maintained by in-process events, which are fire-and-forget: a
+  // dropped one leaves the open period disagreeing with the box it bills for.
+  // These four assert the invariant the control plane owes its tenants — the
+  // open period matches the box's current state — after everything it runs to
+  // settle the ledger has run. Nothing here reaches for an unwritten method;
+  // each drives the shipped roll-over and states what the ledger should hold.
+  describe('box state versus the open period', () => {
+    it('opens a period for a running box that has none', async () => {
+      // the STARTED event never reached the handler, so nothing was ever opened
+      await insertBox({ state: BoxState.STARTED })
+
+      await settleLedger()
+
+      const open = await openPeriods()
+      expect(open).toHaveLength(1)
+      expect(open[0]).toEqual(
+        expect.objectContaining({
+          boxId: box.id,
+          organizationId: box.organizationId,
+          region: box.region,
+          cpu: box.cpu,
+          gpu: box.gpu,
+          mem: box.mem,
+          disk: box.disk,
+        }),
+      )
+    })
+
+    it('restores compute billing for a running box whose period charges no cpu', async () => {
+      // the box was started again but the STARTED event was lost, so the period
+      // left over from the stop is still open and still charging nothing
+      await insertBox({ state: BoxState.STARTED })
+      await openPeriod({ cpu: 0, gpu: 0, mem: 0 })
+
+      await settleLedger()
+
+      expect(await periods.findOne({ where: { endAt: IsNull() } })).toEqual(
+        expect.objectContaining({ cpu: box.cpu, gpu: box.gpu, mem: box.mem }),
+      )
+    })
+
+    it('follows a disk resize that landed while the box was stopped', async () => {
+      // RESIZING -> STOPPED changed the box's disk; the stopped period's cpu is
+      // already 0, so the STOPPED branch's safeguard never fires
+      await insertBox({ state: BoxState.STOPPED, disk: 100 })
+      await openPeriod({ cpu: 0, gpu: 0, mem: 0, disk: 10 })
+
+      await settleLedger()
+
+      expect(await periods.findOne({ where: { endAt: IsNull() } })).toEqual(expect.objectContaining({ disk: 100 }))
+    })
+
+    it('closes the open period of a box that already reached a terminal state', async () => {
+      // destroyed an hour ago: the box stopped consuming anything, but the
+      // period is younger than the roll-over's one-day cutoff
+      await insertBox({ state: BoxState.DESTROYED })
+      await openPeriod({ startAt: new Date(Date.now() - 60 * 60 * 1000) })
+
+      await settleLedger()
+
+      expect(await openPeriods()).toHaveLength(0)
+    })
+
+    it('reaches boxes assigned to a runner, not just unassigned ones', async () => {
+      const runnerId = 'b41f1d0e-9c3a-4f77-8a2d-6e5b3c1d0af2'
+      await insertBox({ state: BoxState.STARTED, runnerId })
+
+      await settleLedger([runnerId])
+
+      expect(await openPeriods()).toHaveLength(1)
+    })
+
+    it('leaves a box alone until its own event handler has had time to run', async () => {
+      // inside the grace window the handler may still be waiting on the per-box
+      // lock; opening a period here would race it and collide on the index
+      await insertBox({ state: BoxState.STARTED, updatedAtMsAgo: 0 })
+
+      await settleLedger()
+
+      expect(await openPeriods()).toHaveLength(0)
+    })
+
+    it('leaves a box mid-transition alone', async () => {
+      await insertBox({ state: BoxState.STARTING })
+
+      await settleLedger()
+
+      expect(await openPeriods()).toHaveLength(0)
+    })
+
+    it('keeps the period a box already holds while it is mid-transition', async () => {
+      // A box on its way up from STOPPED still holds the disk-only period the
+      // stop opened. expectedOpenPeriod answers null for STARTING exactly as it
+      // does for a terminal box, so the only thing standing between that period
+      // and a close is that STARTING is in neither of the two state lists the
+      // drift predicate matches on. Adding it to BOX_STATES_WITHOUT_OPEN_PERIOD
+      // stops billing disk for every box for the length of its startup.
+      await insertBox({ state: BoxState.STARTING })
+      const held = await openPeriod({ cpu: 0, gpu: 0, mem: 0 })
+
+      await settleLedger()
+
+      expect(await periods.find()).toEqual([expect.objectContaining({ id: held.id, endAt: null })])
+    })
+
+    it('leaves a box alone while a state change is in flight', async () => {
+      await insertBox({ state: BoxState.STARTED, pending: true })
+
+      await settleLedger()
+
+      expect(await openPeriods()).toHaveLength(0)
+    })
+
+    it('does not touch a period that already agrees with its box', async () => {
+      await insertBox({ state: BoxState.STARTED })
+      const settled = await openPeriod()
+
+      await settleLedger()
+      await settleLedger()
+
+      // a rewrite on every pass would shred the ledger into unbillable slivers
+      expect(await periods.find()).toEqual([expect.objectContaining({ id: settled.id, endAt: null })])
+    })
+
+    // The reconcile pass filters candidates in SQL while the repair re-derives
+    // the shape in TypeScript, so the state -> period rule exists twice. This
+    // pins the two together: any state where they disagree is a rule that was
+    // changed on one side only.
+    it.each(Object.values(BoxState))('agrees with expectedOpenPeriod about %s', async (state) => {
+      await insertBox({ state })
+      const expected = expectedOpenPeriod({ ...box, state })
+
+      await settleLedger()
+
+      const open = await openPeriods()
+      if (expected === null) {
+        expect(open).toHaveLength(0)
+        return
+      }
+      expect(open).toHaveLength(1)
+      expect(open[0]).toEqual(expect.objectContaining(expected))
+    })
+  })
+
+  // The roll-over runs on its own schedule and must leave a correct ledger by
+  // itself. Driving it alone here matters: with the reconcile pass also running,
+  // it would paper over a roll-over that carried the wrong figures forward, and
+  // the ledger would still churn out a wrong period every single day.
+  describe('the daily roll-over on its own', () => {
+    const rollOver = (state: BoxState, boxOverrides: Partial<typeof box> = {}) =>
+      serviceForBoxState(state, false, boxOverrides).closeAndReopenUsagePeriods()
+
+    it('carries the resources the box has now, not the ones the closing period held', async () => {
+      await openPeriod({ cpu: 0, gpu: 0, mem: 0, startAt: new Date(Date.now() - DAY_MS - 60_000) })
+
+      await rollOver(BoxState.STARTED)
+
+      expect(await periods.findOne({ where: { endAt: IsNull() } })).toEqual(
+        expect.objectContaining({ cpu: box.cpu, gpu: box.gpu, mem: box.mem }),
+      )
+    })
+
+    it('picks up a disk resize the ledger never heard about', async () => {
+      await openPeriod({ cpu: 0, gpu: 0, mem: 0, disk: 10, startAt: new Date(Date.now() - DAY_MS - 60_000) })
+
+      await rollOver(BoxState.STOPPED, { disk: 100 })
+
+      expect(await periods.findOne({ where: { endAt: IsNull() } })).toEqual(expect.objectContaining({ disk: 100 }))
+    })
+
+    it('stops charging compute for a stopping box whose period still bills it', async () => {
+      // STOPPING bills disk only, exactly like STOPPED — a period that still
+      // charges cpu here has to be cut over, not copied forward
+      await openPeriod({ startAt: new Date(Date.now() - DAY_MS - 60_000) })
+
+      await rollOver(BoxState.STOPPING)
+
+      expect(await periods.findOne({ where: { endAt: IsNull() } })).toEqual(
+        expect.objectContaining({ cpu: 0, gpu: 0, mem: 0, disk: box.disk }),
+      )
+    })
+
+    it('does not reopen a period for a state this repository never assigns', async () => {
+      // ARCHIVING has no writer anywhere in the codebase, so it carries no
+      // price and the roll-over must behave exactly as it did before: close the
+      // over-long period and leave it closed, rather than invent a charge.
+      await openPeriod({ cpu: 0, gpu: 0, mem: 0, startAt: new Date(Date.now() - DAY_MS - 60_000) })
+
+      await rollOver(BoxState.ARCHIVING)
+
+      expect(await openPeriods()).toHaveLength(0)
+    })
   })
 
   it('declares the open-period invariant on the entity as well as in the migration', () => {
@@ -335,6 +615,7 @@ describeIfDatabase('UsageService (integration, real Postgres + Redis)', () => {
             throw new Error('configuration unavailable')
           },
         } as any),
+        { find: async () => [] } as any,
       )
 
       await expect(failing.archiveUsagePeriods()).rejects.toThrow('configuration unavailable')

--- a/apps/api/src/usage/services/usage.service.metrics.spec.ts
+++ b/apps/api/src/usage/services/usage.service.metrics.spec.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+describe('UsageService drift repair telemetry', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+    jest.resetModules()
+  })
+
+  it('creates the drift counter lazily and reuses it across service instances', () => {
+    jest.resetModules()
+    const { metrics } = require('@opentelemetry/api') as typeof import('@opentelemetry/api')
+    const add = jest.fn()
+    const createCounter = jest.fn().mockReturnValue({ add })
+    const getMeter = jest.spyOn(metrics, 'getMeter').mockReturnValue({ createCounter } as any)
+    const { UsageService } = require('./usage.service') as typeof import('./usage.service')
+
+    expect(getMeter).not.toHaveBeenCalled()
+    expect(createCounter).not.toHaveBeenCalled()
+
+    const makeService = () => new UsageService({} as any, {} as any, {} as any, {} as any, {} as any)
+    const firstService = makeService()
+    const secondService = makeService()
+    const firstWarn = jest.fn()
+    const secondWarn = jest.fn()
+    ;(firstService as any).logger = { warn: firstWarn }
+    ;(secondService as any).logger = { warn: secondWarn }
+
+    expect(getMeter).not.toHaveBeenCalled()
+    expect(createCounter).not.toHaveBeenCalled()
+
+    ;(firstService as any).recordDrift('missing', 'box-1')
+    ;(secondService as any).recordDrift('orphan', 'box-2')
+
+    expect(getMeter).toHaveBeenCalledTimes(1)
+    expect(getMeter).toHaveBeenCalledWith('')
+    expect(createCounter).toHaveBeenCalledTimes(1)
+    expect(createCounter).toHaveBeenCalledWith('usage_period_drift_repaired', {
+      description: 'Open usage periods brought back in step with the box they bill for',
+    })
+    expect(add).toHaveBeenNthCalledWith(1, 1, { kind: 'missing' })
+    expect(add).toHaveBeenNthCalledWith(2, 1, { kind: 'orphan' })
+    expect(firstWarn).toHaveBeenCalledWith('Repaired missing usage period drift for box box-1')
+    expect(secondWarn).toHaveBeenCalledWith('Repaired orphan usage period drift for box box-2')
+  })
+})

--- a/apps/api/src/usage/services/usage.service.spec.ts
+++ b/apps/api/src/usage/services/usage.service.spec.ts
@@ -71,12 +71,17 @@ const makeService = (stored: BoxUsagePeriod[] = []) => {
   }
   const boxRepository = { findOne: jest.fn() }
   const usageExportOutboxService = { enqueue: jest.fn().mockResolvedValue(0) }
+  // The reconcile pass builds a left join through the query builder, which this
+  // fake cannot stand in for; its behaviour is covered in
+  // usage.service.integration.spec.ts against a real Postgres.
+  const runnerRepository = { find: jest.fn().mockResolvedValue([]) }
 
   const service = new UsageService(
     usagePeriodRepository as any,
     redisLockProvider as any,
     boxRepository as any,
     usageExportOutboxService as any,
+    runnerRepository as any,
   )
 
   return {

--- a/apps/api/src/usage/services/usage.service.ts
+++ b/apps/api/src/usage/services/usage.service.ts
@@ -6,7 +6,8 @@
 
 import { Injectable, Logger, OnApplicationShutdown } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
-import { IsNull, LessThan, Not, Repository } from 'typeorm'
+import { EntityManager, IsNull, LessThan, Not, Repository } from 'typeorm'
+import { metrics, type Counter } from '@opentelemetry/api'
 import { BoxUsagePeriod } from '../entities/box-usage-period.entity'
 import { OnEvent } from '@nestjs/event-emitter'
 import { BoxStateUpdatedEvent } from '../../box/events/box-state-updated.event'
@@ -25,6 +26,51 @@ import { LogExecution } from '../../common/decorators/log-execution.decorator'
 import { WithInstrumentation } from '../../common/decorators/otel.decorator'
 import { BoxRepository } from '../../box/repositories/box.repository'
 import { UsageExportOutboxService } from './usage-export-outbox.service'
+import { Box } from '../../box/entities/box.entity'
+import { Runner } from '../../box/entities/runner.entity'
+import {
+  BOX_STATES_BILLING_DISK_ONLY,
+  BOX_STATES_WITHOUT_OPEN_PERIOD,
+  BOX_STATES_WITH_OPEN_PERIOD,
+  UsagePeriodShape,
+  expectedOpenPeriod,
+  sameShape,
+} from './expected-usage-period'
+
+/** How many drifted boxes one reconcile pass repairs per runner shard. */
+const RECONCILE_BATCH_SIZE = 100
+
+// A box that changed hands moments ago may still be waiting for its event
+// handler to acquire the renewable per-box lease or finish its ledger write.
+// Reconciling immediately would create avoidable contention and could select
+// stale input, although the shared lease remains the correctness boundary. Two
+// minutes absorbs normal scheduling and database delay before the repair pass
+// treats the mismatch as drift.
+const RECONCILE_GRACE_MS = 2 * 60 * 1000
+
+let driftCounter: Counter | undefined
+
+const getDriftCounter = (): Counter => {
+  if (!driftCounter) {
+    driftCounter = metrics.getMeter('').createCounter('usage_period_drift_repaired', {
+      description: 'Open usage periods brought back in step with the box they bill for',
+    })
+  }
+  return driftCounter
+}
+
+/** What one drifted box looks like, joined against its open period (if any). */
+interface DriftCandidate {
+  box_id: string
+  box_state: BoxState
+  box_cpu: number
+  box_gpu: number
+  box_mem: number
+  box_disk: number
+  box_org: string
+  box_region: string
+  period_id: string | null
+}
 
 @Injectable()
 export class UsageService implements TrackableJobExecutions, OnApplicationShutdown {
@@ -38,6 +84,8 @@ export class UsageService implements TrackableJobExecutions, OnApplicationShutdo
     private readonly redisLockProvider: RedisLockProvider,
     private readonly boxRepository: BoxRepository,
     private readonly usageExportOutboxService: UsageExportOutboxService,
+    @InjectRepository(Runner)
+    private readonly runnerRepository: Repository<Runner>,
   ) {}
 
   async onApplicationShutdown() {
@@ -76,7 +124,7 @@ export class UsageService implements TrackableJobExecutions, OnApplicationShutdo
         case BoxState.STARTED: {
           await this.closeUsagePeriod(event.box.id)
           signal.throwIfAborted()
-          await this.createUsagePeriod(event)
+          await this.openUsagePeriodFor(event.box, event.newState)
           break
         }
         // Billing stops charging compute the moment a stop is requested, while
@@ -87,7 +135,7 @@ export class UsageService implements TrackableJobExecutions, OnApplicationShutdo
         case BoxState.STOPPING:
           await this.closeUsagePeriod(event.box.id)
           signal.throwIfAborted()
-          await this.createUsagePeriod(event, true)
+          await this.openUsagePeriodFor(event.box, event.newState)
           break
         // Safeguards if STOPPING state is skipped
         case BoxState.STOPPED: {
@@ -102,7 +150,7 @@ export class UsageService implements TrackableJobExecutions, OnApplicationShutdo
           if (cpuUsagePeriod) {
             await this.closeUsagePeriod(event.box.id)
             signal.throwIfAborted()
-            await this.createUsagePeriod(event, true)
+            await this.openUsagePeriodFor(event.box, event.newState)
           }
           break
         }
@@ -117,25 +165,39 @@ export class UsageService implements TrackableJobExecutions, OnApplicationShutdo
     }, `box ${event.box.id}`)
   }
 
-  private async createUsagePeriod(event: BoxStateUpdatedEvent, diskOnly = false) {
+  /**
+   * Opens the period the box's current state calls for. A box that bills nothing
+   * (terminal) or whose state is still in flight gets none — the caller has
+   * already closed whatever was open.
+   */
+  private async openUsagePeriodFor(box: Box, state: BoxState) {
+    // The event's newState is the authority on where the box landed; the entity
+    // it carries is a snapshot, and a synthetic transition may have been built
+    // with a state of its own (see the warm-pool claim in box.service.ts).
+    const expected = expectedOpenPeriod({ ...box, state })
+    if (expected === null) {
+      return
+    }
+    await this.createUsagePeriod(box, expected)
+  }
+
+  private async createUsagePeriod(
+    box: Pick<Box, 'id' | 'organizationId' | 'region'>,
+    shape: UsagePeriodShape,
+    entityManager?: EntityManager,
+  ) {
     const usagePeriod = new BoxUsagePeriod()
-    usagePeriod.boxId = event.box.id
+    usagePeriod.boxId = box.id
     usagePeriod.startAt = new Date()
     usagePeriod.endAt = null
-    if (!diskOnly) {
-      usagePeriod.cpu = event.box.cpu
-      usagePeriod.gpu = event.box.gpu
-      usagePeriod.mem = event.box.mem
-    } else {
-      usagePeriod.cpu = 0
-      usagePeriod.gpu = 0
-      usagePeriod.mem = 0
-    }
-    usagePeriod.disk = event.box.disk
-    usagePeriod.organizationId = event.box.organizationId
-    usagePeriod.region = event.box.region
+    usagePeriod.cpu = shape.cpu
+    usagePeriod.gpu = shape.gpu
+    usagePeriod.mem = shape.mem
+    usagePeriod.disk = shape.disk
+    usagePeriod.organizationId = box.organizationId
+    usagePeriod.region = box.region
 
-    await this.boxUsagePeriodRepository.save(usagePeriod)
+    await (entityManager ? entityManager.save(usagePeriod) : this.boxUsagePeriodRepository.save(usagePeriod))
   }
 
   private async closeUsagePeriod(boxId: string) {
@@ -199,19 +261,22 @@ export class UsageService implements TrackableJobExecutions, OnApplicationShutdo
             usagePeriod.endAt = closeTime
             await transactionalEntityManager.save(usagePeriod)
 
-            if (
-              box &&
-              (box.state === BoxState.STARTED || box.state === BoxState.STOPPED || box.state === BoxState.STOPPING)
-            ) {
-              // Create new usage period
+            // Roll over with the resources the box calls for *now*, not the ones
+            // the closing period happened to carry. Copying the old figures kept
+            // any drift alive forever: a period left charging no cpu for a running
+            // box was re-copied every day, and a disk resize that landed while the
+            // box was stopped never reached the ledger at all. A box that is gone
+            // or terminal yields no shape and so is not reopened, which is what
+            // stops a deleted box from accruing.
+            const expected = expectedOpenPeriod(box)
+            if (expected !== null) {
               const newUsagePeriod = BoxUsagePeriod.fromUsagePeriod(usagePeriod)
               newUsagePeriod.startAt = closeTime
               newUsagePeriod.endAt = null
-              if (box.state === BoxState.STOPPED) {
-                newUsagePeriod.cpu = 0
-                newUsagePeriod.gpu = 0
-                newUsagePeriod.mem = 0
-              }
+              newUsagePeriod.cpu = expected.cpu
+              newUsagePeriod.gpu = expected.gpu
+              newUsagePeriod.mem = expected.mem
+              newUsagePeriod.disk = expected.disk
               await transactionalEntityManager.save(newUsagePeriod)
             }
             boxSignal.throwIfAborted()
@@ -221,6 +286,190 @@ export class UsageService implements TrackableJobExecutions, OnApplicationShutdo
         })
       }
     }, lockKey)
+  }
+
+  /**
+   * Brings open periods back in step with the boxes they bill for.
+   *
+   * The ledger is maintained by in-process events, which are fire-and-forget: a
+   * handler that dies, throws, or loses its process leaves the box and its period
+   * disagreeing, and nothing notices. The roll-over cannot: it scans the period
+   * table, so a box with no period at all is invisible to it, and its one-day
+   * cutoff lets a wrong period bill for a further day.
+   *
+   * This pass scans from the *box* side instead, which is why both are needed —
+   * their blind spots are opposite. The roll-over is the only place that can see
+   * a period whose box row was deleted outright; this one is the only place that
+   * can see a box that never got a period.
+   */
+  @Cron(CronExpression.EVERY_5_MINUTES, { name: 'reconcile-usage-periods' })
+  @TrackJobExecution()
+  @LogExecution('reconcile-usage-periods')
+  @WithInstrumentation()
+  async reconcileUsagePeriods() {
+    const lockKey = 'reconcile-usage-periods'
+    const lease = await this.redisLockProvider.acquireLease(lockKey, 300)
+    if (!lease) {
+      return
+    }
+
+    await this.withLease(lease, async (signal) => {
+      signal.throwIfAborted()
+      const graceCutoff = new Date(Date.now() - RECONCILE_GRACE_MS)
+      // Shard by runner so each scan rides a runnerId index rather than reading
+      // the box table end to end. Measured on 20k boxes across 50 runners, the
+      // planner takes box_runnerid_idx (bitmap index scan, ~400 rows rechecked,
+      // ~1.7ms) — runnerId is selective enough on its own that it prefers that
+      // over the composite box_runner_state_desired_idx.
+      //
+      // Every runner is scanned, not just the ready ones: a box stranded on an
+      // unhealthy runner is the likeliest to have missed its event. The trailing
+      // null shard is not optional — a box that
+      // reached DESTROYED or ARCHIVED has had its runnerId cleared, and those are
+      // exactly the boxes whose periods must be closed.
+      const runners = await this.runnerRepository.find({ select: { id: true } })
+      signal.throwIfAborted()
+      const shards: (string | null)[] = [...runners.map((runner) => runner.id), null]
+
+      for (const shard of shards) {
+        signal.throwIfAborted()
+        const candidates = await this.findDriftCandidates(shard, graceCutoff)
+        signal.throwIfAborted()
+        for (const candidate of candidates) {
+          signal.throwIfAborted()
+          await this.repairDrift(candidate)
+          signal.throwIfAborted()
+        }
+      }
+    }, lockKey)
+  }
+
+  /**
+   * Boxes whose open period disagrees with them, in one left join.
+   *
+   * The resource comparison has to be qualified by state. A bare `p.cpu <> b.cpu`
+   * is permanently true for every stopped box — a stopped period *should* charge
+   * no cpu — and those false positives would fill each page and starve the real
+   * drift out of the batch forever.
+   */
+  private findDriftCandidates(runnerId: string | null, graceCutoff: Date): Promise<DriftCandidate[]> {
+    return (
+      this.boxRepository
+        .createQueryBuilder('b')
+        .leftJoin(BoxUsagePeriod, 'p', 'p."boxId" = b.id AND p."endAt" IS NULL')
+        .select([
+          'b.id AS box_id',
+          'b.state AS box_state',
+          'b.cpu AS box_cpu',
+          'b.gpu AS box_gpu',
+          'b.mem AS box_mem',
+          'b.disk AS box_disk',
+          'b."organizationId" AS box_org',
+          'b.region AS box_region',
+          'p.id AS period_id',
+        ])
+        .where(runnerId === null ? 'b."runnerId" IS NULL' : 'b."runnerId" = :runnerId', { runnerId })
+        // Written as equality to match the partial indexes' own `WHERE "pending"
+        // = false`, so the planner may pick one where the data makes it
+        // worthwhile. A null pending predates the column default; both spellings
+        // exclude it.
+        .andWhere('b.pending = false')
+        .andWhere('b."updatedAt" < :graceCutoff', { graceCutoff })
+        .andWhere('b.state IN (:...trackedStates)', {
+          trackedStates: [...BOX_STATES_WITH_OPEN_PERIOD, ...BOX_STATES_WITHOUT_OPEN_PERIOD],
+        })
+        .andWhere(
+          `(
+           (b.state IN (:...withStates) AND (
+                p.id IS NULL
+             OR p.disk <> b.disk
+             -- the ledger stores organizationId as text, the box table as uuid
+             OR p."organizationId" <> b."organizationId"::text
+             OR p.region <> b.region
+             OR (b.state = :started AND (p.cpu <> b.cpu OR p.mem <> b.mem OR p.gpu <> b.gpu))
+             OR (b.state IN (:...diskOnlyStates) AND (p.cpu <> 0 OR p.mem <> 0 OR p.gpu <> 0))
+           ))
+        OR (b.state IN (:...withoutStates) AND p.id IS NOT NULL)
+        )`,
+          {
+            withStates: BOX_STATES_WITH_OPEN_PERIOD,
+            withoutStates: BOX_STATES_WITHOUT_OPEN_PERIOD,
+            diskOnlyStates: BOX_STATES_BILLING_DISK_ONLY,
+            started: BoxState.STARTED,
+          },
+        )
+        .orderBy('b."updatedAt"', 'ASC')
+        .limit(RECONCILE_BATCH_SIZE)
+        .getRawMany<DriftCandidate>()
+    )
+  }
+
+  /**
+   * Re-derives the period from the box and writes only if it still disagrees.
+   *
+   * The SQL above is a wide filter; the authority on what a period should charge
+   * is {@link expectedOpenPeriod}, re-applied here under the per-box lock so a
+   * candidate the event handler fixed in the meantime is left alone. Corrections
+   * start now and are never backdated: the window a box spent mis-billed cannot
+   * be reconstructed (its updatedAt has moved on for unrelated reasons), and
+   * guessing it would replace a known gap with an invented charge.
+   */
+  private async repairDrift(candidate: DriftCandidate): Promise<void> {
+    const lease = await this.acquireLease(candidate.box_id)
+    if (!lease) {
+      return
+    }
+
+    await this.withLease(lease, async (signal) => {
+      signal.throwIfAborted()
+      const box = await this.boxRepository.findOne({ where: { id: candidate.box_id } })
+      signal.throwIfAborted()
+      const expected = expectedOpenPeriod(box)
+
+      const open = await this.boxUsagePeriodRepository.findOne({
+        where: { boxId: candidate.box_id, endAt: IsNull() },
+      })
+      signal.throwIfAborted()
+
+      if (expected === null) {
+        if (!open) {
+          return
+        }
+        await this.closeUsagePeriod(candidate.box_id)
+        signal.throwIfAborted()
+        this.recordDrift('orphan', candidate.box_id)
+        return
+      }
+
+      if (
+        open &&
+        sameShape(open, expected) &&
+        open.organizationId === box.organizationId &&
+        open.region === box.region
+      ) {
+        return
+      }
+
+      await this.boxUsagePeriodRepository.manager.transaction(async (transactionalEntityManager) => {
+        signal.throwIfAborted()
+        if (open) {
+          open.endAt = new Date()
+          await transactionalEntityManager.save(open)
+        }
+        signal.throwIfAborted()
+        await this.createUsagePeriod(box, expected, transactionalEntityManager)
+        signal.throwIfAborted()
+      })
+      signal.throwIfAborted()
+      this.recordDrift(open ? 'stale_shape' : 'missing', candidate.box_id)
+    }, `usage period ${candidate.box_id}`).catch((error) => {
+      this.logger.error(`Error reconciling usage period for box ${candidate.box_id}`, error)
+    })
+  }
+
+  private recordDrift(kind: 'missing' | 'orphan' | 'stale_shape', boxId: string): void {
+    getDriftCounter().add(1, { kind })
+    this.logger.warn(`Repaired ${kind} usage period drift for box ${boxId}`)
   }
 
   @Cron(CronExpression.EVERY_MINUTE, { name: 'archive-usage-periods' })

--- a/apps/api/src/usage/usage.module.spec.ts
+++ b/apps/api/src/usage/usage.module.spec.ts
@@ -9,6 +9,7 @@ import { Test } from '@nestjs/testing'
 import { getRepositoryToken } from '@nestjs/typeorm'
 import { DataSource } from 'typeorm'
 import { Box } from '../box/entities/box.entity'
+import { Runner } from '../box/entities/runner.entity'
 import { BoxRepository } from '../box/repositories/box.repository'
 import { BoxLookupCacheInvalidationService } from '../box/services/box-lookup-cache-invalidation.service'
 import { RedisLockProvider } from '../box/common/redis-lock.provider'
@@ -57,6 +58,7 @@ describe('UsageModule', () => {
         getRepositoryToken(BoxUsagePeriodArchive),
         getRepositoryToken(BoxUsageExportOutbox),
         getRepositoryToken(Box),
+        getRepositoryToken(Runner),
       ]),
     )
     expect(providers).toContain(BoxLookupCacheInvalidationService)

--- a/apps/api/src/usage/usage.module.ts
+++ b/apps/api/src/usage/usage.module.ts
@@ -19,9 +19,12 @@ import { UsageAllocationSnapshotService } from './services/usage-allocation-snap
 import { BoxRepository } from '../box/repositories/box.repository'
 import { BoxLookupCacheInvalidationService } from '../box/services/box-lookup-cache-invalidation.service'
 import { Box } from '../box/entities/box.entity'
+import { Runner } from '../box/entities/runner.entity'
 
 @Module({
-  imports: [TypeOrmModule.forFeature([BoxUsagePeriod, Box, BoxUsagePeriodArchive, BoxUsageExportOutbox])],
+  imports: [
+    TypeOrmModule.forFeature([BoxUsagePeriod, Box, Runner, BoxUsagePeriodArchive, BoxUsageExportOutbox]),
+  ],
   providers: [
     UsageService,
     UsageExportOutboxService,


### PR DESCRIPTION
> **Stacked on #1091.** Base branch is `fix/usage_failure_lt`, not `main`, so the
> diff here is only the six usage files. **Merge #1091 first**; GitHub will then
> retarget this PR to `main` on its own. Reviewing it against `main` before that
> shows #1091's fourteen files as well.
>
> The dependency is branch-level, not code-level: nothing here calls anything
> #1091 adds, and the two touch disjoint files. It is stacked because it was
> written on top of that branch, so rebasing it onto `main` today would be a
> clean no-op — it just has not been done, to keep the diff reviewable.

## Problem

A box's open usage period is maintained by in-process events, which are
fire-and-forget. A handler that throws, or whose process dies mid-transition,
leaves the box and its period disagreeing and nothing notices. Two gaps let that
disagreement persist indefinitely:

**The daily roll-over preserved drift instead of correcting it.** It copied the
closing period's resources into the replacement, so a period charging no cpu for
a running box was re-copied every day, forever. A disk resize that landed while
the box was stopped never reached the ledger at all.

**Nothing ever scanned from the box side.** The roll-over walks the *period*
table, so a box that never got a period is invisible to it — there is no row to
find. Its one-day cutoff also lets a wrong period bill for a further day.

## Approach

`expectedOpenPeriod(box)` becomes the single source of truth for the
state → period rule — full compute while running, disk alone once stopped,
nothing otherwise — and the event handler, the roll-over and the new reconcile
pass all answer the question the same way.

**Roll-over** re-derives resources from the box rather than copying them
forward. A box that is gone or terminal yields no shape and so is not reopened,
which is what stops a deleted box from accruing.

**Reconcile pass** (every 5 min) scans from the box side, which is why both are
needed — their blind spots are opposite. The roll-over is the only thing that
can see a period whose box row was deleted outright; this is the only thing that
can see a box that never got a period.

- Sharded by runner so each scan rides `box_runnerid_idx` rather than reading
  the box table end to end. Measured on 20k boxes across 50 runners: bitmap
  index scan, ~400 rows rechecked, ~1.7 ms. The trailing `runnerId IS NULL`
  shard is not optional — a box that reached DESTROYED or ARCHIVED has had its
  runnerId cleared, and those are exactly the periods that must be closed.
- Two-minute grace window before a box is eligible. The per-box lock's TTL is
  60 s, so a handler can legitimately take a full minute to reach the ledger;
  reconciling inside that window would race it and collide on the
  one-open-period index. Anything under 60 s is provably too short.
- Each candidate is re-checked under the per-box lock against
  `expectedOpenPeriod`, so one the event handler fixed in the meantime is left
  alone. The SQL is a deliberately wide filter, not the authority.
- Repairs are counted on `usage_period_drift_repaired{kind=missing|orphan|stale_shape}`.

## Decisions worth challenging

- **Billing deliberately diverges from quota.** `BOX_STATES_CONSUMING_COMPUTE`
  counts CREATING and STARTING because the runner has already pinned the
  resources; billing does not charge for a box the tenant cannot use yet.
  Divergence here is a pricing decision, not a bug — `expected-usage-period.spec.ts`
  asserts it so nobody "fixes" it by accident.
- **Corrections start now and are never backdated.** The window a box spent
  mis-billed cannot be reconstructed (its `updatedAt` has moved on for unrelated
  reasons), and guessing it would replace a known gap with an invented charge.
- **The resource comparison is qualified by state.** A bare `p.cpu <> b.cpu` is
  permanently true for every stopped box — a stopped period *should* charge no
  cpu — and those false positives would fill each page and starve real drift out
  of the batch forever.
- **A float tolerance is required, not cosmetic.** cpu/gpu/mem/disk are double
  precision on both sides; without `RESOURCE_EPSILON` the pass would rewrite an
  already-correct period on every run, fragmenting the ledger into unbillable
  slivers.
- ARCHIVING bills nothing because no code in this repository assigns it.
  Pricing a state the product does not have yet would be inventing a rule.

No database migration, no API surface change, no client regeneration.

## Verification

Ran against a real Postgres 16 + Redis (`DB_*`/`REDIS_*` pointed at a disposable
database; the integration spec builds its schema by running the migrations, so
it exercises the DDL that ships, and skips when no database is reachable).

| | Result |
|---|---|
| usage suites (unit + integration) | 3 suites / **82 tests** pass |
| full api suite | 58 suites / **321 tests** pass |
| `tsc -p api/tsconfig.spec.json --noEmit` | exit 0 |
| `eslint api/src/usage --max-warnings=0` | clean |
| `prettier --check` | clean |

**Two-side verified.** With the roll-over hunk reverted and everything else
intact, three roll-over assertions fail on the bug itself — a running box's
rolled-over period comes back `cpu: 0, gpu: 0, mem: 0` instead of `2/1/4`:

```
● the daily roll-over on its own › carries the resources the box has now,
  not the ones the closing period held
    - ObjectContaining { "cpu": 2, "gpu": 1, "mem": 4, }
    + BoxUsagePeriod  { "cpu": 0, "gpu": 0, "mem": 0, ... }
```

Restoring the hunk turns all three green. A full revert of every production file
is red too, but only as a compile error, since the reconcile pass is new surface
its specs cannot load without — so the roll-over hunk is the isolation that
carries real signal. Stated plainly: the reconcile tests demonstrate new
behaviour, they do not reproduce a prior bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved usage billing across box states, including compute, disk-only, inactive, and terminal states.
  * Added automatic reconciliation to repair missing, orphaned, or outdated usage periods.
  * Updated rollover processing to reflect current resource usage and avoid terminal boxes.
  * Added tolerance for minor resource-value differences when validating usage periods.

* **Tests**
  * Expanded coverage for billing rules, reconciliation, rollover behavior, resource drift, and idempotency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->