### PR TITLE
fix(gvproxy)!: apply allow_net to the host alias IP

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -303,8 +303,8 @@ See [Configuring Networking](./guides/README.md#configuring-networking) for deta
 2. **Use host network:**
    - Box A exposes port
    - Box B connects to `host.boxlite.internal:port`
-   - This bypasses `allow_net`; if networking is enabled, host loopback
-     services are reachable from inside the box
+   - With an empty `allow_net`, host loopback services are reachable from
+     inside the box; a non-empty `allow_net` must list `"192.168.127.254"`
 
 3. **External service:**
    - Both boxes connect to Redis/database on host or network

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -339,8 +339,9 @@ async with boxlite.SimpleBox(image="alpine:latest") as box:
 
 `host.boxlite.internal` is a built-in BoxLite hostname that resolves to the
 host loopback proxy address. It is not a Docker compatibility alias.
-Security note: any service bound to host loopback is reachable from inside the
-box while networking is enabled.
+Security note: with an empty `allow_net`, any service bound to host loopback is
+reachable from inside the box. A non-empty `allow_net` must list
+`"192.168.127.254"` for the alias to be reachable.
 
 ### Network Metrics
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -164,10 +164,13 @@ Structured network configuration for outbound connectivity.
   a host falls back to TCP; add the IP or CIDR to keep UDP open.
 - The gateway's DNS resolver and DHCP are internal services and stay reachable
   regardless of `allow_net`.
-- `host.boxlite.internal` is always available as a built-in hostname for
-  reaching host loopback services and is not governed by `allow_net`.
-- Security: when networking is enabled, any service bound to host loopback can
-  be reached from inside the box via `host.boxlite.internal` or `192.168.127.254`.
+- `host.boxlite.internal` is a built-in hostname that resolves to
+  `192.168.127.254` and reaches host loopback services. The DNS record is
+  always served, but egress to that address is governed by `allow_net`: add
+  `"192.168.127.254"` to reach it under a non-empty allowlist.
+- Security: with an empty or omitted `allow_net`, any service bound to host
+  loopback is reachable from inside the box via `host.boxlite.internal` or
+  `192.168.127.254`; allowing `"192.168.127.254"` opens all of them.
 
 **Supported patterns:**
 - Exact hostname: `"api.openai.com"`

--- a/src/boxlite/src/net/constants.rs
+++ b/src/boxlite/src/net/constants.rs
@@ -26,8 +26,8 @@ pub const HOST_HOSTNAME: &str = "host.boxlite.internal";
 ///
 /// gvproxy NATs traffic sent to this IP to `127.0.0.1` on the host.
 /// The built-in [`HOST_HOSTNAME`] alias resolves to this address.
-/// This destination is always allowed while networking is enabled, even when
-/// `allow_net` would otherwise restrict outbound traffic.
+/// Egress to this address is governed by `allow_net`: add `"192.168.127.254"`
+/// to reach it under a non-empty allowlist. The DNS record is always served.
 pub const HOST_IP: &str = "192.168.127.254";
 
 /// Guest IP with subnet prefix (for static IP assignment in guest)

--- a/src/boxlite/tests/network_spec.rs
+++ b/src/boxlite/tests/network_spec.rs
@@ -495,10 +495,11 @@ async fn udp_filter_blocks_direct_ip_datagram() {
     litebox.stop().await.unwrap();
 }
 
-/// The UDP twin of `host_alias_reaches_host_loopback_service_with_restrictive_allowlist`:
-/// tightening UDP must not cut the host alias, which is always allowed.
+/// The UDP twin of `host_alias_blocked_by_restrictive_allowlist`. The host
+/// alias NATs to host loopback, so it is an egress destination and an
+/// allowlist that does not name it must drop the datagram.
 #[tokio::test]
-async fn udp_reaches_host_alias_with_restrictive_allowlist() {
+async fn udp_to_host_alias_blocked_by_restrictive_allowlist() {
     let home = boxlite_test_utils::home::PerTestBoxHome::new();
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
@@ -516,14 +517,53 @@ async fn udp_reaches_host_alias_with_restrictive_allowlist() {
     let litebox = runtime.create(opts, None).await.unwrap();
     litebox.start().await.unwrap();
 
-    // The host alias NATs to loopback, so bind where the datagram lands.
+    // The host alias NATs to loopback, so bind where the datagram would land.
     let (port, received, receiver) = start_host_udp_receiver("127.0.0.1:0", Duration::from_secs(8));
     let command = nc_udp_command(HOST_IP, port);
-    let _ = run_stdout(&litebox, "sh", &["-c", &command]).await;
+    let probe = run_stdout(&litebox, "sh", &["-c", &command]).await;
+    assert_udp_probe_ran(&probe);
+
+    let leaked = received.recv_timeout(Duration::from_secs(5));
+    assert!(
+        leaked.is_err(),
+        "UDP to unlisted host alias {HOST_IP} escaped the allowlist: {:?}",
+        leaked.map(|bytes| String::from_utf8_lossy(&bytes).into_owned())
+    );
+
+    receiver.join().unwrap();
+    litebox.stop().await.unwrap();
+}
+
+/// Listing the host alias restores it: policy matches the pre-NAT address
+/// while the forwarder dials the NAT-translated loopback, so the datagram
+/// still reaches the host.
+#[tokio::test]
+async fn udp_reaches_host_alias_when_listed() {
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .unwrap();
+
+    let opts = BoxOptions {
+        network: NetworkSpec::Enabled {
+            allow_net: vec![HOST_IP.into()],
+        },
+        ..common::alpine_opts()
+    };
+
+    let litebox = runtime.create(opts, None).await.unwrap();
+    litebox.start().await.unwrap();
+
+    let (port, received, receiver) = start_host_udp_receiver("127.0.0.1:0", Duration::from_secs(8));
+    let command = nc_udp_command(HOST_IP, port);
+    let probe = run_stdout(&litebox, "sh", &["-c", &command]).await;
+    assert_udp_probe_ran(&probe);
 
     let payload = received
         .recv_timeout(Duration::from_secs(5))
-        .expect("host alias UDP should still be delivered under a restrictive allowlist");
+        .expect("a listed host alias should still deliver UDP");
     assert_eq!(String::from_utf8_lossy(&payload), UDP_PROBE_MARKER);
 
     receiver.join().unwrap();
@@ -613,9 +653,12 @@ async fn host_alias_reaches_host_loopback_service() {
     litebox.stop().await.unwrap();
 }
 
+/// Resolution and egress are separate policies: the built-in DNS record is
+/// always served, but reaching the address it hands out is governed by
+/// `allow_net`.
 #[tokio::test]
 #[ignore = "requires VM runtime (run with make test)"]
-async fn host_alias_reaches_host_loopback_service_with_restrictive_allowlist() {
+async fn host_alias_blocked_by_restrictive_allowlist() {
     let home = boxlite_test_utils::home::PerTestBoxHome::new();
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
@@ -639,13 +682,49 @@ async fn host_alias_reaches_host_loopback_service_with_restrictive_allowlist() {
         "host alias should still resolve under restrictive allowlist, got: {nslookup}"
     );
 
+    let (port, stop_server, server) = start_host_http_server_expect_no_connection();
+    let command = wget_url_command(&format!("http://{HOST_HOSTNAME}:{port}/"));
+    let out = run_stdout(&litebox, "sh", &["-c", &command]).await;
+
+    assert!(
+        out.contains("EXIT:") && !out.contains("EXIT:0"),
+        "unlisted host alias should not reach host loopback, got: {out}"
+    );
+
+    let _ = stop_server.send(());
+    server.join().unwrap();
+    litebox.stop().await.unwrap();
+}
+
+/// Listing the alias IP restores host loopback access: policy is matched on
+/// the pre-NAT address, the dial still lands on 127.0.0.1.
+#[tokio::test]
+#[ignore = "requires VM runtime (run with make test)"]
+async fn host_alias_reaches_host_loopback_service_when_listed() {
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .unwrap();
+
+    let opts = BoxOptions {
+        network: NetworkSpec::Enabled {
+            allow_net: vec![HOST_IP.into()],
+        },
+        ..common::alpine_opts()
+    };
+
+    let litebox = runtime.create(opts, None).await.unwrap();
+    litebox.start().await.unwrap();
+
     let (port, server) = start_host_http_server("boxlite-host-alias-allowlist");
     let command = wget_url_command(&format!("http://{HOST_HOSTNAME}:{port}/"));
     let out = run_stdout(&litebox, "sh", &["-c", &command]).await;
 
     assert!(
         out.contains("boxlite-host-alias-allowlist"),
-        "host alias should bypass allowlist filtering for internal host access, got: {out}"
+        "a listed host alias should reach host loopback, got: {out}"
     );
 
     server.join().unwrap();

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/allow_net_filter_test.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/allow_net_filter_test.go
@@ -8,36 +8,56 @@ import (
 	"gvisor.dev/gvisor/pkg/tcpip"
 )
 
+// testFilter builds a filter exactly the way gvproxy_create does, via the
+// production newAllowNetFilter. Constructing NewAllowNetFilter directly here
+// would let the set of always-allowed internal addresses drift between the
+// tests and the box that actually runs.
+func testFilter(rules ...string) *AllowNetFilter {
+	cfg := testGvproxyConfig()
+	cfg.AllowNet = rules
+	return newAllowNetFilter(cfg)
+}
+
 func TestAllowNetFilter_ExactIP(t *testing.T) {
-	f := NewAllowNetFilter([]string{"1.2.3.4", "5.6.7.8"}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
+	f := testFilter("1.2.3.4", "5.6.7.8")
 	assertTrue(t, f.MatchesIP(net.ParseIP("1.2.3.4")), "1.2.3.4 allowed")
 	assertTrue(t, f.MatchesIP(net.ParseIP("5.6.7.8")), "5.6.7.8 allowed")
 	assertFalse(t, f.MatchesIP(net.ParseIP("9.9.9.9")), "9.9.9.9 blocked")
 }
 
 func TestAllowNetFilter_CIDR(t *testing.T) {
-	f := NewAllowNetFilter([]string{"10.0.0.0/8"}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
+	f := testFilter("10.0.0.0/8")
 	assertTrue(t, f.MatchesIP(net.ParseIP("10.1.2.3")), "in range")
 	assertTrue(t, f.MatchesIP(net.ParseIP("10.255.255.255")), "end of range")
 	assertFalse(t, f.MatchesIP(net.ParseIP("11.0.0.1")), "out of range")
 }
 
 func TestAllowNetFilter_InternalIPsAlwaysAllowed(t *testing.T) {
-	f := NewAllowNetFilter([]string{"1.2.3.4"}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
+	f := testFilter("1.2.3.4")
 	assertTrue(t, f.MatchesIP(net.ParseIP("192.168.127.1")), "gateway always allowed")
 	assertTrue(t, f.MatchesIP(net.ParseIP("192.168.127.2")), "guest always allowed")
-	assertTrue(t, f.MatchesIP(net.ParseIP("192.168.127.254")), "host alias IP always allowed")
+}
+
+// The host alias is not an internal address: it NATs to the host's loopback,
+// so an unlisted alias must be denied like any other destination.
+func TestAllowNetFilter_HostAliasObeysAllowlist(t *testing.T) {
+	assertFalse(t, testFilter("1.2.3.4").MatchesIP(net.ParseIP("192.168.127.254")),
+		"host alias denied when the allowlist does not cover it")
+	assertTrue(t, testFilter("192.168.127.254").MatchesIP(net.ParseIP("192.168.127.254")),
+		"host alias allowed once listed")
+	assertTrue(t, testFilter("192.168.127.0/24").MatchesIP(net.ParseIP("192.168.127.254")),
+		"host alias allowed by a covering CIDR")
 }
 
 func TestAllowNetFilter_NilWhenEmpty(t *testing.T) {
-	f := NewAllowNetFilter([]string{}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
+	f := testFilter()
 	if f != nil {
 		t.Error("empty rules should return nil filter")
 	}
 }
 
 func TestAllowNetFilter_ExactHostname(t *testing.T) {
-	f := NewAllowNetFilter([]string{"api.openai.com"}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
+	f := testFilter("api.openai.com")
 	assertTrue(t, f.MatchesHostname("api.openai.com"), "exact match")
 	assertTrue(t, f.MatchesHostname("API.OPENAI.COM"), "case insensitive")
 	assertFalse(t, f.MatchesHostname("evil.com"), "not in list")
@@ -46,7 +66,7 @@ func TestAllowNetFilter_ExactHostname(t *testing.T) {
 }
 
 func TestAllowNetFilter_Wildcard(t *testing.T) {
-	f := NewAllowNetFilter([]string{"*.example.com"}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
+	f := testFilter("*.example.com")
 	assertTrue(t, f.MatchesHostname("api.example.com"), "subdomain matched")
 	assertTrue(t, f.MatchesHostname("deep.sub.example.com"), "deep subdomain matched")
 	assertFalse(t, f.MatchesHostname("example.com"), "base domain not matched by wildcard")
@@ -54,17 +74,17 @@ func TestAllowNetFilter_Wildcard(t *testing.T) {
 }
 
 func TestAllowNetFilter_IPOnlyNoHostnameRules(t *testing.T) {
-	f := NewAllowNetFilter([]string{"1.2.3.4", "10.0.0.0/8"}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
+	f := testFilter("1.2.3.4", "10.0.0.0/8")
 	assertFalse(t, f.HasHostnameRules(), "IP-only rules have no hostname rules")
 }
 
 func TestAllowNetFilter_MixedRules(t *testing.T) {
-	f := NewAllowNetFilter([]string{
+	f := testFilter(
 		"1.2.3.4",
 		"10.0.0.0/8",
 		"api.openai.com",
 		"*.anthropic.com",
-	}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
+	)
 	assertTrue(t, f.MatchesIP(net.ParseIP("1.2.3.4")), "exact IP")
 	assertTrue(t, f.MatchesIP(net.ParseIP("10.50.0.1")), "CIDR")
 	assertTrue(t, f.MatchesHostname("api.openai.com"), "exact hostname")
@@ -73,23 +93,23 @@ func TestAllowNetFilter_MixedRules(t *testing.T) {
 }
 
 func TestAllowNetFilter_TrailingDotStripped(t *testing.T) {
-	f := NewAllowNetFilter([]string{"api.openai.com"}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
+	f := testFilter("api.openai.com")
 	assertTrue(t, f.MatchesHostname("api.openai.com."), "trailing dot stripped")
 }
 
 func TestAllowNetFilter_HostWithPort(t *testing.T) {
-	f := NewAllowNetFilter([]string{"api.openai.com:443"}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
+	f := testFilter("api.openai.com:443")
 	assertTrue(t, f.MatchesHostname("api.openai.com"), "port stripped from rule")
 	assertTrue(t, f.HasHostnameRules(), "should have hostname rules")
 }
 
 func TestAllowNetFilter_EmptyHostname(t *testing.T) {
-	f := NewAllowNetFilter([]string{"api.openai.com"}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
+	f := testFilter("api.openai.com")
 	assertFalse(t, f.MatchesHostname(""), "empty hostname never matches")
 }
 
 func TestDecideTCPRoute_CIDRUsesStandardForward(t *testing.T) {
-	f := NewAllowNetFilter([]string{"104.18.26.0/24"}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
+	f := testFilter("104.18.26.0/24")
 
 	inRange := net.IP([]byte{104, 18, 26, 120})
 	if got := decideTCPRoute(inRange, 80, f, nil); got != tcpRouteStandardForward {
@@ -103,7 +123,7 @@ func TestDecideTCPRoute_CIDRUsesStandardForward(t *testing.T) {
 }
 
 func TestResolveTCPDestination_HostAliasUsesPreNATIPForPolicy(t *testing.T) {
-	filter := NewAllowNetFilter([]string{"example.com"}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
+	filter := testFilter("example.com")
 	hostAlias := tcpip.AddrFrom4Slice(net.ParseIP("192.168.127.254").To4())
 	loopback := tcpip.AddrFrom4Slice(net.ParseIP("127.0.0.1").To4())
 	nat := map[tcpip.Address]tcpip.Address{
@@ -115,8 +135,16 @@ func TestResolveTCPDestination_HostAliasUsesPreNATIPForPolicy(t *testing.T) {
 	if !policyIP.Equal(net.ParseIP("192.168.127.254")) {
 		t.Fatalf("expected policy IP to remain host alias, got %v", policyIP)
 	}
-	if got := decideTCPRoute(policyIP, 80, filter, nil); got != tcpRouteStandardForward {
-		t.Fatalf("expected host alias policy check to bypass hostname filtering, got %v", got)
+	// The pre-NAT address is what the allowlist is matched against, so an
+	// allowlist that does not name the alias blocks it. Port 8080 keeps this
+	// on the address path: 80 and 443 would route to SNI/Host inspection,
+	// which is the hostname mechanism rather than the address check.
+	if got := decideTCPRoute(policyIP, 8080, filter, nil); got != tcpRouteBlock {
+		t.Fatalf("expected an unlisted host alias to be blocked, got %v", got)
+	}
+	// An allowlist that does name it forwards, on any port.
+	if got := decideTCPRoute(policyIP, 8080, testFilter("192.168.127.254"), nil); got != tcpRouteStandardForward {
+		t.Fatalf("expected a listed host alias to standard-forward, got %v", got)
 	}
 
 	dialIPBytes := dialAddress.As4()

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/forked_tcp_test.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/forked_tcp_test.go
@@ -133,7 +133,7 @@ func TestMitmRouting_AllowlistAndSecrets_MitmPriority(t *testing.T) {
 	matcher := NewSecretHostMatcher(secrets)
 
 	// Also create an allowlist filter that includes the same host
-	filter := NewAllowNetFilter([]string{"api.example.com"}, "192.168.127.1", "192.168.127.2", "192.168.127.254")
+	filter := testFilter("api.example.com")
 
 	// Both should match
 	if !matcher.Matches("api.example.com") {

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/forked_udp_test.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/forked_udp_test.go
@@ -20,10 +20,7 @@ func ipv4Addr(t *testing.T, s string) tcpip.Address {
 }
 
 func TestUDPDestinationAllowed_IPAndCIDRRules(t *testing.T) {
-	filter := NewAllowNetFilter(
-		[]string{"1.2.3.4", "10.0.0.0/8"},
-		"192.168.127.1", "192.168.127.2", "192.168.127.254",
-	)
+	filter := testFilter("1.2.3.4", "10.0.0.0/8")
 
 	cases := []struct {
 		dest string
@@ -35,7 +32,7 @@ func TestUDPDestinationAllowed_IPAndCIDRRules(t *testing.T) {
 		{"11.1.2.3", false, "outside every rule"},
 		{"8.8.8.8", false, "unapproved resolver"},
 		{"192.168.127.1", true, "gateway is always allowed"},
-		{"192.168.127.254", true, "host alias is always allowed"},
+		{"192.168.127.254", false, "host alias NATs to host loopback, so it obeys the allowlist"},
 	}
 
 	for _, tc := range cases {
@@ -49,10 +46,7 @@ func TestUDPDestinationAllowed_IPAndCIDRRules(t *testing.T) {
 // hostname-only allowlist must therefore deny UDP outright — otherwise a
 // guest bypasses the rule by addressing the resolved IP directly.
 func TestUDPDestinationAllowed_HostnameOnlyRulesDenyEverything(t *testing.T) {
-	filter := NewAllowNetFilter(
-		[]string{"api.openai.com", "*.example.com"},
-		"192.168.127.1", "192.168.127.2", "192.168.127.254",
-	)
+	filter := testFilter("api.openai.com", "*.example.com")
 
 	for _, dest := range []string{"1.2.3.4", "93.184.216.34", "8.8.8.8"} {
 		if udpDestinationAllowed(ipv4Addr(t, dest), filter) {
@@ -69,10 +63,7 @@ func TestUDPDestinationAllowed_HostnameOnlyRulesDenyEverything(t *testing.T) {
 // Link-local is denied regardless of the allowlist: ec2MetadataAccess opens
 // IMDS over TCP only, so a UDP hole there would be pure added egress.
 func TestUDPDestinationAllowed_LinkLocalAndBroadcastDenied(t *testing.T) {
-	filter := NewAllowNetFilter(
-		[]string{"169.254.0.0/16", "255.255.255.255"},
-		"192.168.127.1", "192.168.127.2", "192.168.127.254",
-	)
+	filter := testFilter("169.254.0.0/16", "255.255.255.255")
 
 	if udpDestinationAllowed(ipv4Addr(t, "169.254.169.254"), filter) {
 		t.Error("link-local must be denied even when a CIDR rule covers it")

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/main.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/main.go
@@ -237,6 +237,23 @@ func buildDNSZones(config GvproxyConfig) []types.Zone {
 	return dnsZones
 }
 
+// newAllowNetFilter builds the egress allowlist for a box. It is the single
+// place that decides which addresses are exempt from allow_net, so the test
+// harness can build its filter the same way and a change here cannot pass
+// unnoticed.
+//
+// The gateway and guest addresses are the virtual network's own endpoints
+// rather than egress destinations. config.HostIP is deliberately not among
+// them: it NATs to the host's loopback (buildTapConfig below), which makes it
+// a real destination that must obey allow_net like any other. Its DNS record
+// is still served unconditionally — resolving the alias is not egress.
+//
+// Returns nil when allow_net is empty, which the transport handlers read as
+// "forward everything".
+func newAllowNetFilter(config GvproxyConfig) *AllowNetFilter {
+	return NewAllowNetFilter(config.AllowNet, config.GatewayIP, config.GuestIP)
+}
+
 func buildTapConfig(config GvproxyConfig, protocol types.Protocol) *types.Configuration {
 	nat := make(map[string]string)
 	gatewayVirtualIPs := []string{config.GatewayIP}
@@ -432,7 +449,7 @@ func gvproxy_create(configJSON *C.char, errOut **C.char) C.longlong {
 		if len(config.AllowNet) > 0 || instance.secretMatcher != nil {
 			var allowNetFilter *AllowNetFilter
 			if len(config.AllowNet) > 0 {
-				allowNetFilter = NewAllowNetFilter(config.AllowNet, config.GatewayIP, config.GuestIP, config.HostIP)
+				allowNetFilter = newAllowNetFilter(config)
 			}
 			// Fatal on purpose: the handlers left behind are upstream's
 			// unfiltered forwarders, so a box that starts anyway would carry

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/udp_filter_test.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/udp_filter_test.go
@@ -68,7 +68,7 @@ func startNetwork(t *testing.T, allowNet []string) *guestTap {
 	}
 
 	if len(cfg.AllowNet) > 0 {
-		filter := NewAllowNetFilter(cfg.AllowNet, cfg.GatewayIP, cfg.GuestIP, cfg.HostIP)
+		filter := newAllowNetFilter(cfg)
 		if err := installAllowNetHandlers(vn, tapConfig, tapConfig.Ec2MetadataAccess, filter, nil, nil); err != nil {
 			t.Fatalf("installAllowNetHandlers: %v", err)
 		}
@@ -411,6 +411,94 @@ func TestAllowNetBlocksUnlistedUDP(t *testing.T) {
 	}
 	t.Fatalf("allow_net=%v: UDP to unlisted %s reached the host listener from %s: %q",
 		allowedCIDR, unlistedIP, from, buf[:n])
+}
+
+// TestAllowNetBlocksHostAliasUDP is the reproducer for the host-alias bypass.
+// 192.168.127.254 NATs to the host's loopback, so it is an egress destination
+// like any other: a guest reaching it under a restrictive allowlist would put
+// every service bound to host loopback outside the reach of allow_net.
+func TestAllowNetBlocksHostAliasUDP(t *testing.T) {
+	cfg := testGvproxyConfig()
+	conn, port := listenUDP(t)
+	tap := startNetwork(t, []string{allowedCIDR})
+
+	tap.send(t, udpFrame(t, cfg.HostIP, port, []byte(probePayload)))
+
+	if err := conn.SetReadDeadline(time.Now().Add(forwardWindow)); err != nil {
+		t.Fatalf("SetReadDeadline: %v", err)
+	}
+	buf := make([]byte, 2048)
+	n, from, err := conn.ReadFrom(buf)
+	if err != nil {
+		return // timed out: the datagram was dropped, which is the contract
+	}
+	t.Fatalf("allow_net=%v: UDP to host alias %s reached host loopback from %s: %q",
+		allowedCIDR, cfg.HostIP, from, buf[:n])
+}
+
+// TestAllowNetBlocksHostAliasTCP is the TCP twin: the same allowlist, the same
+// host alias destination, over the transport that carries SNI/Host.
+func TestAllowNetBlocksHostAliasTCP(t *testing.T) {
+	cfg := testGvproxyConfig()
+	ln, port := listenTCP(t)
+	tap := startNetwork(t, []string{allowedCIDR})
+
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err == nil {
+			accepted <- conn
+		}
+	}()
+
+	tap.send(t, tcpSynFrame(t, cfg.HostIP, port))
+
+	select {
+	case conn := <-accepted:
+		_ = conn.Close()
+		t.Fatalf("allow_net=%v: TCP to host alias %s was forwarded to host loopback",
+			allowedCIDR, cfg.HostIP)
+	case <-time.After(forwardWindow):
+	}
+}
+
+// TestAllowNetForwardsListedHostAlias pins the other half of the contract:
+// once the alias is listed, policy still matches the pre-NAT address while the
+// forwarder dials the NAT-translated loopback, so the host stays reachable.
+func TestAllowNetForwardsListedHostAlias(t *testing.T) {
+	cfg := testGvproxyConfig()
+	conn, udpPort := listenUDP(t)
+	ln, tcpPort := listenTCP(t)
+	tap := startNetwork(t, []string{cfg.HostIP})
+
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		c, err := ln.Accept()
+		if err == nil {
+			accepted <- c
+		}
+	}()
+
+	tap.send(t, udpFrame(t, cfg.HostIP, udpPort, []byte(probePayload)))
+	if err := conn.SetReadDeadline(time.Now().Add(forwardWindow)); err != nil {
+		t.Fatalf("SetReadDeadline: %v", err)
+	}
+	buf := make([]byte, 2048)
+	n, _, err := conn.ReadFrom(buf)
+	if err != nil {
+		t.Fatalf("a listed host alias must forward UDP, but the datagram was dropped: %v", err)
+	}
+	if string(buf[:n]) != probePayload {
+		t.Fatalf("forwarded payload = %q, want %q", buf[:n], probePayload)
+	}
+
+	tap.send(t, tcpSynFrame(t, cfg.HostIP, tcpPort))
+	select {
+	case c := <-accepted:
+		_ = c.Close()
+	case <-time.After(forwardWindow):
+		t.Fatal("a listed host alias must forward TCP to host loopback")
+	}
 }
 
 // TestAllowNetHostnameRulesAlsoBindUDP covers the hostname-only allowlist,


### PR DESCRIPTION
## Summary

`192.168.127.254` — the built-in host alias that gvproxy NATs to host loopback — was exempt from `allow_net`, so a box with a restrictive allowlist could still reach every service bound to `127.0.0.1` on the host, over both TCP and UDP. It is now an ordinary egress destination.

## Changes

- Drop `config.HostIP` from the filter's always-allow set. The alias is a NAT to host loopback, not a virtual-network endpoint like the gateway and guest addresses, so it belongs under policy.
- Build the filter through a single `newAllowNetFilter(config)`. The Go test harness previously duplicated the argument list, which is why a one-line policy change was invisible to `go test`; all test construction now routes through the production helper.
- Resolution is unchanged: the built-in DNS record for `host.boxlite.internal` is still served unconditionally — resolving the alias is not egress. Reaching it requires listing `"192.168.127.254"` or a covering CIDR.
- Tests: tap-level reproducers for both transports plus a routing guard that pins pre-NAT policy matching against post-NAT dialing; the four Rust integration cases now cover blocked-and-listed on both TCP and UDP.
- Docs: four sites stated the alias was not governed by `allow_net`.

## How to verify

```
make test:unit:gvproxy FILTER='HostAlias'
make test:integration:rust FILTER='host_alias'
```

Manually: start a box with `allow_net: ["example.com"]`, then `wget http://host.boxlite.internal:<port>/` against a host loopback listener — the connection is refused while `nslookup host.boxlite.internal` still returns `192.168.127.254`. Adding `"192.168.127.254"` to `allow_net` restores it.

## Risks / rollout

Breaking change. Existing callers that set a non-empty `allow_net` and rely on `host.boxlite.internal` must add `"192.168.127.254"`. Boxes with an empty or omitted `allow_net` are unaffected.

Granularity is address-level: allowing the alias opens every port bound to host loopback. `allow_net` has no port dimension, so this is not expressible more narrowly today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
