### PR TITLE
docs(contributing): mandate before/after call graph in PR descriptions

### DIFF
--- a/.claude/hooks/preflight-pr-review.sh
+++ b/.claude/hooks/preflight-pr-review.sh
@@ -157,26 +157,50 @@ if (( body_supplied )); then
   has_line '^[[:space:]]*#{2,}[[:space:]]*call[[:space:]]+graph[[:space:]]*$' \
     || missing+="
   - a '## Call graph' section"
-  has_line '^[[:space:]]*before([[:space:]]|:|$)' \
+  # Shared with the Before-section extractor below, so the header shape can
+  # never drift between "is there a Before label" and "where does Before end".
+  before_re='^[[:space:]]*before([[:space:]]|:|$)'
+  after_re='^[[:space:]]*after([[:space:]]|:|$)'
+  has_line "$before_re" \
     || missing+="
   - a 'Before' graph"
-  has_line '^[[:space:]]*after([[:space:]]|:|$)' \
+  has_line "$after_re" \
     || missing+="
   - an 'After' graph"
 
   # Hops must be real: `fn_name (Type · path/file.ext:LOC)`. Requiring two
   # file:LOC references is what an unfilled template cannot fake — its Before
   # and After labels are literal text, but its hop lines are HTML comments.
-  hop_lines="$(grep -cE '[A-Za-z0-9_./-]+\.[A-Za-z]+:[0-9]+' <<<"$pr_body" || true)"
+  hop_re='[A-Za-z0-9_./-]+\.[A-Za-z]+:[0-9]+'
+  hop_lines="$(grep -cE "$hop_re" <<<"$pr_body" || true)"
   (( hop_lines >= 2 )) \
     || missing+="
   - 2+ hop lines carrying 'path/file.ext:LOC' (found ${hop_lines})"
 
   # Bug-fix extras — only decidable when --title was inspectable above.
   if [[ "$pr_title" =~ ^fix(\([^\)]+\))?!?: ]]; then
-    has_line 'bug:' \
+    # "Mark the faulty hop" is literal: the marker has to sit on a hop line
+    # inside the Before graph. A `BUG:` loose in prose, or down in After, marks
+    # nothing. The arrow is deliberately not required — `←`, `<-` and a bare
+    # `BUG:` all read the same, and mandating one Unicode glyph is typing
+    # friction, not signal. The word boundary keeps `debug:` from qualifying.
+    # Rule order is load-bearing: reset on After, then print, then set on
+    # Before — that sequence is what keeps the two header lines themselves out
+    # of the captured section, so a marker on the `Before` line marks no hop.
+    before_graph="$(awk -v before_re="$before_re" -v after_re="$after_re" '
+      $0 ~ after_re  { in_before = 0 }
+      in_before      { print }
+      $0 ~ before_re { in_before = 1 }
+    ' <<<"$body_lc")"
+    marker_re='(^|[^[:alnum:]_])bug:'
+    # Same line, either order: `hop … ← BUG: why` or `← BUG: why … hop`.
+    marked_hop() {
+      grep -qE "${hop_re}.*${marker_re}" <<<"$before_graph" ||
+        grep -qE "${marker_re}.*${hop_re}" <<<"$before_graph"
+    }
+    marked_hop \
       || missing+="
-  - fix: PR — '← BUG: <what goes wrong>' on the faulty hop in Before"
+  - fix: PR — '← BUG: <what goes wrong>' on a hop line inside the Before graph"
     has_line '(fixes|closes|resolves)[[:space:]]+#[0-9]+' \
       || missing+="
   - fix: PR — an issue link, 'Fixes #<n>'"

--- a/.claude/hooks/preflight-pr-review.sh
+++ b/.claude/hooks/preflight-pr-review.sh
@@ -26,6 +26,11 @@
 #   arbitrary string is rare and the failure mode is "let one PR through
 #   without ack," not a destructive action.
 #
+# * Two deterministic content checks run before the ack gate — a Conventional-
+#   Commit `--title`, and a `--body` carrying the before/after call graph
+#   (CONTRIBUTING.md #commit--pr-messages). Both only fire when the flag is
+#   actually present and inspectable; neither consumes the ack marker.
+#
 # * One-shot consumption: the marker file is `rm -f`'d on the allow path so
 #   each successive gh pr command forces a fresh ack, even at the same HEAD.
 #   Mirrors the trade-off in preflight-commit-push.sh.
@@ -109,6 +114,92 @@ if [[ -n "$pr_title" ]]; then
   types: feat fix docs refactor test chore perf ci build
 
 Fix --title and retry. See CONTRIBUTING.md #commit--pr-messages."
+  fi
+fi
+
+# Deterministic body check: a supplied PR body must carry the before/after
+# end-to-end call graph mandated by CONTRIBUTING.md #commit--pr-messages.
+#
+# Only inspected when the command actually supplies a body. `gh pr ready` and
+# editor-driven `gh pr create` carry nothing to read, and the editor path opens
+# .github/pull_request_template.md, which already holds the section.
+pr_body=""
+body_supplied=0
+if [[ "$command" =~ (^|[[:space:]])(--body-file|-F)[[:space:]]+([^[:space:]]+) ]]; then
+  body_supplied=1
+  body_path="${BASH_REMATCH[3]//[\"\']/}"
+  [[ -r "$body_path" ]] && pr_body="$(cat "$body_path")"
+elif [[ "$command" =~ (^|[[:space:]])(--body|-b)[[:space:]]+\"([^\"]*)\" ]]; then
+  # Covers both `--body "…"` and `--body "$(cat <<'EOF' … EOF)"`: the capture stops
+  # at the next `"`, so a body containing a double quote truncates and fails the
+  # checks below — closed, not open.
+  body_supplied=1
+  pr_body="${BASH_REMATCH[3]}"
+elif [[ "$command" =~ (^|[[:space:]])(--body|-b)[[:space:]]+\'([^\']*)\' ]]; then
+  body_supplied=1
+  pr_body="${BASH_REMATCH[3]}"
+elif [[ "$command" =~ (^|[[:space:]])(--body|-b|--fill|--fill-first|--fill-verbose|-f)([[:space:]]|=|$) ]]; then
+  # A body flag we cannot read (unquoted `--body`), or `--fill`, which supplies no
+  # body of its own — commit text is not a PR description.
+  body_supplied=1
+  pr_body="$command"
+fi
+
+if (( body_supplied )); then
+  # Line-start anchors below: an extracted body begins mid-line, glued to the flag.
+  pr_body=$'\n'"$pr_body"
+  body_lc="$(tr '[:upper:]' '[:lower:]' <<<"$pr_body")"
+  # Herestrings, not pipes: `grep -q` exits on first match and would SIGPIPE the
+  # writer, which `set -o pipefail` would then read as a failed check.
+  has_line() { grep -qE "$1" <<<"$body_lc"; }
+  missing=""
+
+  has_line '^[[:space:]]*#{2,}[[:space:]]*call[[:space:]]+graph[[:space:]]*$' \
+    || missing+="
+  - a '## Call graph' section"
+  has_line '^[[:space:]]*before([[:space:]]|:|$)' \
+    || missing+="
+  - a 'Before' graph"
+  has_line '^[[:space:]]*after([[:space:]]|:|$)' \
+    || missing+="
+  - an 'After' graph"
+
+  # Hops must be real: `fn_name (Type · path/file.ext:LOC)`. Requiring two
+  # file:LOC references is what an unfilled template cannot fake — its Before
+  # and After labels are literal text, but its hop lines are HTML comments.
+  hop_lines="$(grep -cE '[A-Za-z0-9_./-]+\.[A-Za-z]+:[0-9]+' <<<"$pr_body" || true)"
+  (( hop_lines >= 2 )) \
+    || missing+="
+  - 2+ hop lines carrying 'path/file.ext:LOC' (found ${hop_lines})"
+
+  # Bug-fix extras — only decidable when --title was inspectable above.
+  if [[ "$pr_title" =~ ^fix(\([^\)]+\))?!?: ]]; then
+    has_line 'bug:' \
+      || missing+="
+  - fix: PR — '← BUG: <what goes wrong>' on the faulty hop in Before"
+    has_line '(fixes|closes|resolves)[[:space:]]+#[0-9]+' \
+      || missing+="
+  - fix: PR — an issue link, 'Fixes #<n>'"
+  fi
+
+  if [[ -n "$missing" ]]; then
+    deny "PR description is missing the mandated before/after call graph.
+
+Missing:${missing}
+
+Shape — one line per hop, only the hops this PR changes:
+  Before
+    exec_box            (BoxHandle · src/boxlite/src/portal/exec.rs:88)
+      └─ open_console   (Jailer · src/boxlite/src/jailer/console.rs:41)  ← BUG: returns before the socket binds
+  After
+    exec_box            (BoxHandle · src/boxlite/src/portal/exec.rs:88)
+      └─ open_console   (Jailer · src/boxlite/src/jailer/console.rs:41)  — awaits the bind future
+
+Read the real call sites before writing the graph — a graph with invented
+symbols or stale line numbers is worse than none.
+
+Rewrite the body and retry. Rule and full example: CONTRIBUTING.md
+#commit--pr-messages; section layout: .github/pull_request_template.md."
   fi
 fi
 

--- a/.claude/hooks/preflight-pr-review.sh
+++ b/.claude/hooks/preflight-pr-review.sh
@@ -192,17 +192,35 @@ if (( body_supplied )); then
   before_graph="$(section "$before_re" "$after_re")"
   after_graph="$(section "$after_re" "$before_re")"
 
-  # Hops must be real: `fn_name (Type · path/file.ext:LOC)`, and each graph
-  # needs one of its own. A body-wide count lets a prose-only After ride along
-  # on Before's hops, which is not an end-to-end before/after graph. Counting
-  # per section is also what an unfilled template cannot fake — its labels are
-  # literal text, but its hop lines are HTML comments.
-  hop_re='[A-Za-z0-9_./-]+\.[A-Za-z]+:[0-9]+'
+  # Each graph needs a hop of its own, shaped like the documented
+  # `fn_name (Type · path/file.ext:LOC)`. Matching a bare `file.ext:LOC` was
+  # too loose — one occurs mid-sentence — so a paragraph mentioning a file in
+  # passing counted as a graph.
+  #
+  # What it actually requires: a `(` to the left of the reference and a `)` to
+  # the right. Not a balanced group, and neither side is stricter than the
+  # other. Being permissive is deliberate — a Type half carries its own
+  # parentheses in `(fn(u32) -> u32 · src/x.rs:5)`, and refusing to cross them
+  # denied a hop conforming to CONTRIBUTING.md's documented shape. The cost is
+  # that an unrelated parenthetical straddling the reference also satisfies it.
+  #
+  # So this only reaches "shaped like a hop". It cannot tell a real graph from
+  # a fabricated one, and no pattern here could — that judgment is left to the
+  # human on the typed `reviewed:` ack below.
+  #
+  # Per graph, not body-wide: a body-wide count lets a prose-only After ride
+  # along on Before's hops, which is not an end-to-end before/after graph. It
+  # is also what an unfilled template cannot fake — its labels are literal
+  # text, but its hop lines are HTML comments.
+  hop_re='\(.*[A-Za-z0-9_./-]+\.[A-Za-z]+:[0-9]+.*\)'
   before_hops="$(grep -cE "$hop_re" <<<"$before_graph" || true)"
   after_hops="$(grep -cE "$hop_re" <<<"$after_graph" || true)"
+  # Reports what is checked — a parenthesised reference — rather than naming
+  # parts (`fn_name`, `Type`) the pattern does not require; the canonical shape
+  # is printed in full below.
   (( before_hops >= 1 && after_hops >= 1 )) \
     || missing+="
-  - a hop line carrying 'path/file.ext:LOC' in each graph (found ${before_hops} in Before, ${after_hops} in After)"
+  - a hop line with a parenthesised 'path/file.ext:LOC' in each graph, shaped as below (found ${before_hops} in Before, ${after_hops} in After)"
 
   # Bug-fix extras — only decidable when --title was inspectable above.
   if [[ "$pr_title" =~ ^fix(\([^\)]+\))?!?: ]]; then

--- a/.claude/hooks/preflight-pr-review.sh
+++ b/.claude/hooks/preflight-pr-review.sh
@@ -157,8 +157,8 @@ if (( body_supplied )); then
   has_line '^[[:space:]]*#{2,}[[:space:]]*call[[:space:]]+graph[[:space:]]*$' \
     || missing+="
   - a '## Call graph' section"
-  # Shared with the Before-section extractor below, so the header shape can
-  # never drift between "is there a Before label" and "where does Before end".
+  # Shared with the section extractor below, so the header shape can never
+  # drift between "is there a Before label" and "where does Before end".
   before_re='^[[:space:]]*before([[:space:]]|:|$)'
   after_re='^[[:space:]]*after([[:space:]]|:|$)'
   has_line "$before_re" \
@@ -168,14 +168,41 @@ if (( body_supplied )); then
     || missing+="
   - an 'After' graph"
 
-  # Hops must be real: `fn_name (Type · path/file.ext:LOC)`. Requiring two
-  # file:LOC references is what an unfilled template cannot fake — its Before
-  # and After labels are literal text, but its hop lines are HTML comments.
+  # Lines strictly between a graph's header and whichever comes first: the
+  # other graph's header, or the next markdown heading. Rule order is
+  # load-bearing: reset on a stop, then print, then set on the header — that
+  # sequence is what keeps the header lines themselves out of the section, so a
+  # marker on the `Before` line marks no hop.
+  #
+  # Only the heading stop is fence-aware. Graphs get drawn inside a ``` fence,
+  # where a `## entry` line is drawing rather than structure, and honouring it
+  # stranded every hop that followed. The graph labels are honoured fenced or
+  # not, because CONTRIBUTING.md's own example wraps both labels and all their
+  # hops in a single fence — gating the labels the same way left that example
+  # extracting to nothing and denied for having no hops at all.
+  section() {
+    awk -v start_re="$1" -v stop_re="$2" '
+      /^[[:space:]]*```/                        { fenced = !fenced }
+      $0 ~ stop_re && in_section                { in_section = 0 }
+      !fenced && /^[[:space:]]*##/ && in_section { in_section = 0 }
+      in_section                                { print }
+      $0 ~ start_re                             { in_section = 1 }
+    ' <<<"$body_lc"
+  }
+  before_graph="$(section "$before_re" "$after_re")"
+  after_graph="$(section "$after_re" "$before_re")"
+
+  # Hops must be real: `fn_name (Type · path/file.ext:LOC)`, and each graph
+  # needs one of its own. A body-wide count lets a prose-only After ride along
+  # on Before's hops, which is not an end-to-end before/after graph. Counting
+  # per section is also what an unfilled template cannot fake — its labels are
+  # literal text, but its hop lines are HTML comments.
   hop_re='[A-Za-z0-9_./-]+\.[A-Za-z]+:[0-9]+'
-  hop_lines="$(grep -cE "$hop_re" <<<"$pr_body" || true)"
-  (( hop_lines >= 2 )) \
+  before_hops="$(grep -cE "$hop_re" <<<"$before_graph" || true)"
+  after_hops="$(grep -cE "$hop_re" <<<"$after_graph" || true)"
+  (( before_hops >= 1 && after_hops >= 1 )) \
     || missing+="
-  - 2+ hop lines carrying 'path/file.ext:LOC' (found ${hop_lines})"
+  - a hop line carrying 'path/file.ext:LOC' in each graph (found ${before_hops} in Before, ${after_hops} in After)"
 
   # Bug-fix extras — only decidable when --title was inspectable above.
   if [[ "$pr_title" =~ ^fix(\([^\)]+\))?!?: ]]; then
@@ -184,14 +211,6 @@ if (( body_supplied )); then
     # nothing. The arrow is deliberately not required — `←`, `<-` and a bare
     # `BUG:` all read the same, and mandating one Unicode glyph is typing
     # friction, not signal. The word boundary keeps `debug:` from qualifying.
-    # Rule order is load-bearing: reset on After, then print, then set on
-    # Before — that sequence is what keeps the two header lines themselves out
-    # of the captured section, so a marker on the `Before` line marks no hop.
-    before_graph="$(awk -v before_re="$before_re" -v after_re="$after_re" '
-      $0 ~ after_re  { in_before = 0 }
-      in_before      { print }
-      $0 ~ before_re { in_before = 1 }
-    ' <<<"$body_lc")"
     marker_re='(^|[^[:alnum:]_])bug:'
     # Same line, either order: `hop … ← BUG: why` or `← BUG: why … hop`.
     marked_hop() {

--- a/.claude/hooks/preflight-pr-review.test.sh
+++ b/.claude/hooks/preflight-pr-review.test.sh
@@ -121,7 +121,14 @@ echo
 echo "## Body check: a supplied --body must carry the before/after call graph"
 
 GRAPH=$'## Call graph\n\nBefore\n  exec_box (BoxHandle · src/portal/exec.rs:88)\n    open_console (Jailer · src/jailer/console.rs:41)\n\nAfter\n  exec_box (BoxHandle · src/portal/exec.rs:88)\n    open_console (Jailer · src/jailer/console.rs:41)'
-FIX_GRAPH=$'## Call graph\n\nBefore\n  exec_box (BoxHandle · src/portal/exec.rs:88)\n    open_console (Jailer · src/jailer/console.rs:41)  <- BUG: returns before the socket binds\n\nAfter\n  exec_box (BoxHandle · src/portal/exec.rs:88)\n    open_console (Jailer · src/jailer/console.rs:41)\n\nFixes #1042'
+FIX_GRAPH=$'## Call graph\n\nBefore\n  exec_box (BoxHandle · src/portal/exec.rs:88)\n    open_console (Jailer · src/jailer/console.rs:41)  ← BUG: returns before the socket binds\n\nAfter\n  exec_box (BoxHandle · src/portal/exec.rs:88)\n    open_console (Jailer · src/jailer/console.rs:41)\n\nFixes #1042'
+# The arrow glyph is not part of the contract — ASCII `<-`, or none at all, reads
+# the same. What is enforced is the marker's position: on a hop line, in Before.
+FIX_ASCII="${FIX_GRAPH/← BUG:/<- BUG:}"
+FIX_BARE="${FIX_GRAPH/← BUG:/BUG:}"
+FIX_MARK_IN_AFTER=$'## Call graph\n\nBefore\n  exec_box (BoxHandle · src/portal/exec.rs:88)\n    open_console (Jailer · src/jailer/console.rs:41)\n\nAfter\n  exec_box (BoxHandle · src/portal/exec.rs:88)\n    open_console (Jailer · src/jailer/console.rs:41)  ← BUG: returns before the socket binds\n\nFixes #1042'
+FIX_MARK_OFF_HOP=$'## Call graph\n\nBefore\n  ← BUG: open_console returns too early\n  exec_box (BoxHandle · src/portal/exec.rs:88)\n    open_console (Jailer · src/jailer/console.rs:41)\n\nAfter\n  exec_box (BoxHandle · src/portal/exec.rs:88)\n    open_console (Jailer · src/jailer/console.rs:41)\n\nFixes #1042'
+FIX_DEBUG_ONLY=$'## Call graph\n\nBefore\n  exec_box (BoxHandle · src/portal/exec.rs:88)\n    open_console (Jailer · src/jailer/console.rs:41)  debug: enabled\n\nAfter\n  exec_box (BoxHandle · src/portal/exec.rs:88)\n    open_console (Jailer · src/jailer/console.rs:41)\n\nFixes #1042'
 FEAT='--title "feat(api): add a cool thing"'
 FIX='--title "fix(portal): await console bind"'
 
@@ -148,12 +155,17 @@ run_body "unfilled template → deny"           "gh pr create $FEAT --body-file 
 run_body "--fill (no body of its own) → deny" "gh pr create $FEAT --fill"                                   "deny"
 run_body "fix: graph w/o BUG marker → deny"   "gh pr create $FIX --body \"$GRAPH\""                         "deny"
 run_body "fix: BUG but no issue link → deny"  "gh pr create $FIX --body \"${FIX_GRAPH%%$'\n\n'Fixes*}\""    "deny"
+run_body "fix: BUG marked in After → deny"    "gh pr create $FIX --body \"$FIX_MARK_IN_AFTER\""             "deny"
+run_body "fix: BUG off any hop line → deny"   "gh pr create $FIX --body \"$FIX_MARK_OFF_HOP\""              "deny"
+run_body "fix: 'debug:' is not a marker → deny" "gh pr create $FIX --body \"$FIX_DEBUG_ONLY\""              "deny"
 run_body "--body-file prose → deny"           "gh pr create $FEAT --body-file $TMP/prose.md"                "deny"
 
 run_body "gh pr ready (no body flag) → allow" "gh pr ready 42"                                              "passthrough"
 run_body "valid graph body → allow"           "gh pr create $FEAT --body \"$GRAPH\""                        "passthrough"
 run_body "--body-file with graph → allow"     "gh pr create $FEAT --body-file $TMP/body.md"                 "passthrough"
 run_body "fix: graph + BUG + issue → allow"   "gh pr create $FIX --body \"$FIX_GRAPH\""                     "passthrough"
+run_body "fix: ASCII '<- BUG:' → allow"       "gh pr create $FIX --body \"$FIX_ASCII\""                     "passthrough"
+run_body "fix: bare 'BUG:' (no arrow) → allow" "gh pr create $FIX --body \"$FIX_BARE\""                     "passthrough"
 
 echo
 echo "RESULT: $pass passed, $fail failed"

--- a/.claude/hooks/preflight-pr-review.test.sh
+++ b/.claude/hooks/preflight-pr-review.test.sh
@@ -129,6 +129,20 @@ FIX_BARE="${FIX_GRAPH/← BUG:/BUG:}"
 FIX_MARK_IN_AFTER=$'## Call graph\n\nBefore\n  exec_box (BoxHandle · src/portal/exec.rs:88)\n    open_console (Jailer · src/jailer/console.rs:41)\n\nAfter\n  exec_box (BoxHandle · src/portal/exec.rs:88)\n    open_console (Jailer · src/jailer/console.rs:41)  ← BUG: returns before the socket binds\n\nFixes #1042'
 FIX_MARK_OFF_HOP=$'## Call graph\n\nBefore\n  ← BUG: open_console returns too early\n  exec_box (BoxHandle · src/portal/exec.rs:88)\n    open_console (Jailer · src/jailer/console.rs:41)\n\nAfter\n  exec_box (BoxHandle · src/portal/exec.rs:88)\n    open_console (Jailer · src/jailer/console.rs:41)\n\nFixes #1042'
 FIX_DEBUG_ONLY=$'## Call graph\n\nBefore\n  exec_box (BoxHandle · src/portal/exec.rs:88)\n    open_console (Jailer · src/jailer/console.rs:41)  debug: enabled\n\nAfter\n  exec_box (BoxHandle · src/portal/exec.rs:88)\n    open_console (Jailer · src/jailer/console.rs:41)\n\nFixes #1042'
+# Each graph needs a hop of its own — one section cannot borrow the other's.
+AFTER_PROSE=$'## Call graph\n\nBefore\n  exec_box (BoxHandle · src/portal/exec.rs:88)\n    open_console (Jailer · src/jailer/console.rs:41)\n\nAfter\n  the same hops, but the socket is awaited first'
+BEFORE_PROSE=$'## Call graph\n\nBefore\n  exec_box calls open_console, which returns early\n\nAfter\n  exec_box (BoxHandle · src/portal/exec.rs:88)\n    open_console (Jailer · src/jailer/console.rs:41)'
+# Hops sit past the graphs, in a later section — neither graph gets credit.
+HOPS_OUTSIDE=$'## Call graph\n\nBefore\n  exec_box calls open_console\n\nAfter\n  exec_box awaits open_console\n\n## Changes\n- exec_box (BoxHandle · src/portal/exec.rs:88)\n- open_console (Jailer · src/jailer/console.rs:41)'
+# Graphs drawn in ``` fences, with `##` and `after` lines as graph content:
+# inside a fence they are drawing, not markdown structure, so neither may end
+# a section early and strand its hops.
+FENCED=$'## Call graph\n\nBefore\n\n```text\n## entry\n  exec_box (BoxHandle · src/portal/exec.rs:88)\n    open_console (Jailer · src/jailer/console.rs:41)\n```\n\nAfter\n\n```text\n## entry\n  exec_box (BoxHandle · src/portal/exec.rs:88)\n    open_console (Jailer · src/jailer/console.rs:41)\n```'
+# The repo's own worked example must clear the gate it documents — including
+# its shape, which wraps both labels AND their hops in one fence. Lifted from
+# CONTRIBUTING.md at run time so the doc and the hook cannot drift apart.
+CONTRIB_FENCE="$(awk '/^```text$/ {i=1; print; next} i && /^```$/ {print; exit} i {print}' "$REPO_ROOT/CONTRIBUTING.md")"
+CONTRIB_BODY="## Call graph"$'\n\n'"$CONTRIB_FENCE"
 FEAT='--title "feat(api): add a cool thing"'
 FIX='--title "fix(portal): await console bind"'
 
@@ -151,6 +165,9 @@ Before
 
 After
   exec_box awaits open_console\""                                                                           "deny"
+run_body "prose-only After → deny"            "gh pr create $FEAT --body \"$AFTER_PROSE\""                  "deny"
+run_body "prose-only Before → deny"           "gh pr create $FEAT --body \"$BEFORE_PROSE\""                 "deny"
+run_body "hops outside both graphs → deny"    "gh pr create $FEAT --body \"$HOPS_OUTSIDE\""                 "deny"
 run_body "unfilled template → deny"           "gh pr create $FEAT --body-file $REPO_ROOT/.github/pull_request_template.md" "deny"
 run_body "--fill (no body of its own) → deny" "gh pr create $FEAT --fill"                                   "deny"
 run_body "fix: graph w/o BUG marker → deny"   "gh pr create $FIX --body \"$GRAPH\""                         "deny"
@@ -162,6 +179,8 @@ run_body "--body-file prose → deny"           "gh pr create $FEAT --body-file 
 
 run_body "gh pr ready (no body flag) → allow" "gh pr ready 42"                                              "passthrough"
 run_body "valid graph body → allow"           "gh pr create $FEAT --body \"$GRAPH\""                        "passthrough"
+run_body "fenced graphs w/ '##' inside → allow" "gh pr create $FEAT --body \"$FENCED\""                     "passthrough"
+run_body "CONTRIBUTING.md's own example → allow" "gh pr create $FIX --body \"$CONTRIB_BODY\""                "passthrough"
 run_body "--body-file with graph → allow"     "gh pr create $FEAT --body-file $TMP/body.md"                 "passthrough"
 run_body "fix: graph + BUG + issue → allow"   "gh pr create $FIX --body \"$FIX_GRAPH\""                     "passthrough"
 run_body "fix: ASCII '<- BUG:' → allow"       "gh pr create $FIX --body \"$FIX_ASCII\""                     "passthrough"

--- a/.claude/hooks/preflight-pr-review.test.sh
+++ b/.claude/hooks/preflight-pr-review.test.sh
@@ -132,6 +132,11 @@ FIX_DEBUG_ONLY=$'## Call graph\n\nBefore\n  exec_box (BoxHandle · src/portal/ex
 # Each graph needs a hop of its own — one section cannot borrow the other's.
 AFTER_PROSE=$'## Call graph\n\nBefore\n  exec_box (BoxHandle · src/portal/exec.rs:88)\n    open_console (Jailer · src/jailer/console.rs:41)\n\nAfter\n  the same hops, but the socket is awaited first'
 BEFORE_PROSE=$'## Call graph\n\nBefore\n  exec_box calls open_console, which returns early\n\nAfter\n  exec_box (BoxHandle · src/portal/exec.rs:88)\n    open_console (Jailer · src/jailer/console.rs:41)'
+# Free-form prose that happens to name a file and line. A bare `file.ext:NN`
+# occurs mid-sentence all the time; only the parenthesised hop shape counts.
+PROSE_WITH_LOC=$'## Call graph\n\nBefore\nThis refactor touches exec_box.rs:88 and improves things...\n\nAfter\nThis refactor touches open_console.rs:41 and improves things...'
+# A Type half carrying its own parens is ordinary Rust, not a malformed hop.
+PARENS_IN_TYPE=$'## Call graph\n\nBefore\n  on_ready (fn(u32) -> u32 · src/portal/exec.rs:88)\n\nAfter\n  on_ready (fn(u32) -> Result<u32> · src/portal/exec.rs:91)'
 # Hops sit past the graphs, in a later section — neither graph gets credit.
 HOPS_OUTSIDE=$'## Call graph\n\nBefore\n  exec_box calls open_console\n\nAfter\n  exec_box awaits open_console\n\n## Changes\n- exec_box (BoxHandle · src/portal/exec.rs:88)\n- open_console (Jailer · src/jailer/console.rs:41)'
 # Graphs drawn in ``` fences, with `##` and `after` lines as graph content:
@@ -168,6 +173,7 @@ After
 run_body "prose-only After → deny"            "gh pr create $FEAT --body \"$AFTER_PROSE\""                  "deny"
 run_body "prose-only Before → deny"           "gh pr create $FEAT --body \"$BEFORE_PROSE\""                 "deny"
 run_body "hops outside both graphs → deny"    "gh pr create $FEAT --body \"$HOPS_OUTSIDE\""                 "deny"
+run_body "prose w/ incidental file:LOC → deny" "gh pr create $FEAT --body \"$PROSE_WITH_LOC\""              "deny"
 run_body "unfilled template → deny"           "gh pr create $FEAT --body-file $REPO_ROOT/.github/pull_request_template.md" "deny"
 run_body "--fill (no body of its own) → deny" "gh pr create $FEAT --fill"                                   "deny"
 run_body "fix: graph w/o BUG marker → deny"   "gh pr create $FIX --body \"$GRAPH\""                         "deny"
@@ -181,6 +187,7 @@ run_body "gh pr ready (no body flag) → allow" "gh pr ready 42"                
 run_body "valid graph body → allow"           "gh pr create $FEAT --body \"$GRAPH\""                        "passthrough"
 run_body "fenced graphs w/ '##' inside → allow" "gh pr create $FEAT --body \"$FENCED\""                     "passthrough"
 run_body "CONTRIBUTING.md's own example → allow" "gh pr create $FIX --body \"$CONTRIB_BODY\""                "passthrough"
+run_body "parens inside the Type half → allow" "gh pr create $FEAT --body \"$PARENS_IN_TYPE\""              "passthrough"
 run_body "--body-file with graph → allow"     "gh pr create $FEAT --body-file $TMP/body.md"                 "passthrough"
 run_body "fix: graph + BUG + issue → allow"   "gh pr create $FIX --body \"$FIX_GRAPH\""                     "passthrough"
 run_body "fix: ASCII '<- BUG:' → allow"       "gh pr create $FIX --body \"$FIX_ASCII\""                     "passthrough"

--- a/.claude/hooks/preflight-pr-review.test.sh
+++ b/.claude/hooks/preflight-pr-review.test.sh
@@ -118,5 +118,43 @@ run "good --title + valid marker → allow"  'gh pr create --title "feat(api): a
 run "marker consumed after allow → deny"   'gh pr create --title "feat(api): add a cool thing"'  "deny"
 
 echo
+echo "## Body check: a supplied --body must carry the before/after call graph"
+
+GRAPH=$'## Call graph\n\nBefore\n  exec_box (BoxHandle · src/portal/exec.rs:88)\n    open_console (Jailer · src/jailer/console.rs:41)\n\nAfter\n  exec_box (BoxHandle · src/portal/exec.rs:88)\n    open_console (Jailer · src/jailer/console.rs:41)'
+FIX_GRAPH=$'## Call graph\n\nBefore\n  exec_box (BoxHandle · src/portal/exec.rs:88)\n    open_console (Jailer · src/jailer/console.rs:41)  <- BUG: returns before the socket binds\n\nAfter\n  exec_box (BoxHandle · src/portal/exec.rs:88)\n    open_console (Jailer · src/jailer/console.rs:41)\n\nFixes #1042'
+FEAT='--title "feat(api): add a cool thing"'
+FIX='--title "fix(portal): await console bind"'
+
+printf '%s' "$GRAPH" > "$TMP/body.md"
+printf 'Adds a thing. Tested locally.\n' > "$TMP/prose.md"
+
+# A fresh marker before EVERY case: the allow path consumes it, so without one
+# a later case would deny for want of an ack and look like a body-check pass.
+run_body() {
+  write_marker "reviewed: body cases"
+  run "$@"
+}
+
+run_body "prose body, no graph → deny"        "gh pr create $FEAT --body \"Adds a thing. Tested locally.\"" "deny"
+run_body "graph missing After → deny"         "gh pr create $FEAT --body \"${GRAPH%%$'\n\n'After*}\""       "deny"
+run_body "labels but no file:LOC → deny"      "gh pr create $FEAT --body \"## Call graph
+
+Before
+  exec_box calls open_console
+
+After
+  exec_box awaits open_console\""                                                                           "deny"
+run_body "unfilled template → deny"           "gh pr create $FEAT --body-file $REPO_ROOT/.github/pull_request_template.md" "deny"
+run_body "--fill (no body of its own) → deny" "gh pr create $FEAT --fill"                                   "deny"
+run_body "fix: graph w/o BUG marker → deny"   "gh pr create $FIX --body \"$GRAPH\""                         "deny"
+run_body "fix: BUG but no issue link → deny"  "gh pr create $FIX --body \"${FIX_GRAPH%%$'\n\n'Fixes*}\""    "deny"
+run_body "--body-file prose → deny"           "gh pr create $FEAT --body-file $TMP/prose.md"                "deny"
+
+run_body "gh pr ready (no body flag) → allow" "gh pr ready 42"                                              "passthrough"
+run_body "valid graph body → allow"           "gh pr create $FEAT --body \"$GRAPH\""                        "passthrough"
+run_body "--body-file with graph → allow"     "gh pr create $FEAT --body-file $TMP/body.md"                 "passthrough"
+run_body "fix: graph + BUG + issue → allow"   "gh pr create $FIX --body \"$FIX_GRAPH\""                     "passthrough"
+
+echo
 echo "RESULT: $pass passed, $fail failed"
 exit $(( fail > 0 ? 1 : 0 ))

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,19 @@
 ## Summary
 <!-- 1-2 sentences: what this changes and why. -->
 
+## Call graph
+<!-- Required. The end-to-end path this PR touches, before and after; one line
+     per hop, only the hops that change. Worked example and the bug-fix markers:
+     CONTRIBUTING.md#commit--pr-messages. -->
+
+Before
+<!-- replace with the hops: fn_name (Type · path/file.rs:LOC) — role -->
+
+After
+<!-- replace with the same hops, post-change -->
+
+Fixes #<!-- issue number — bug fixes only; delete this line otherwise -->
+
 ## Changes
 - <!-- notable change — what changed, not a restatement of the diff -->
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,5 +106,6 @@ Every change goes: understand → research → design → implement → test →
 - Words: as concise and simple as possible, unless explicitly asked otherwise.
 - A simple call graph (func name, class name, file name, LOC, short annotation) is the first choice when explaining code.
 - Commit/PR text: describe the change, not the process that produced it. Conventional-Commit subject ≤72; no process/AI narrative, pasted logs, or secrets. See [CONTRIBUTING.md](./CONTRIBUTING.md#commit--pr-messages).
+- Every PR description carries a before/after end-to-end call graph — same shape as the graph above. Bug fixes mark the faulty hop `← BUG: …` in *Before* and link the issue (`Fixes #<n>`). Enforced by `.claude/hooks/preflight-pr-review.sh`; rule and example in [CONTRIBUTING.md](./CONTRIBUTING.md#commit--pr-messages).
 
 Adapted from Clean Code (Robert C. Martin) via the polygala-inc AGENTS.md distillation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,22 @@ Write for a reviewer skimming in ~30 seconds. Describe the change, not the proce
 
 - Title: a Conventional-Commit subject (same rule as above).
 - Description: fill in [`.github/pull_request_template.md`](./.github/pull_request_template.md); delete sections that don't apply.
+- **Call graph (required):** the end-to-end path the PR touches, *before* and *after* — one line per hop, `fn_name  (Type · path/file.rs:LOC)  — role`, flow shown by arrows or indent. Only the hops that change; elide the rest with `…`. Same shape as the graphs used to explain code elsewhere in this repo.
+- **Bug fixes** additionally mark the defect in the *Before* graph — `← BUG: <what goes wrong>` on the faulty hop — and link the issue with `Fixes #<n>`.
+
+```text
+Before
+  exec_box            (BoxHandle · src/boxlite/src/portal/exec.rs:88)
+    └─ open_console   (Jailer · src/boxlite/src/jailer/console.rs:41)  ← BUG: returns before the socket binds
+         └─ attach_stdio (Guest · src/guest/src/io.rs:12)              — never reached
+
+After
+  exec_box            (BoxHandle · src/boxlite/src/portal/exec.rs:88)
+    └─ open_console   (Jailer · src/boxlite/src/jailer/console.rs:41)  — awaits the bind future
+         └─ attach_stdio (Guest · src/guest/src/io.rs:12)
+
+Fixes #1042
+```
 
 **Never put in a commit or PR** the process that produced the change (conversation / AI / step-by-step narrative), pasted logs or tickets, or secrets.
 


### PR DESCRIPTION
## Summary

Every PR description must now carry the end-to-end call graph it touches, before and after — the same shape already used to explain code in this repo. Bug fixes additionally mark the faulty hop and link the issue. The rule is documented in three places and mechanically enforced by the existing PR preflight hook.

## Call graph

Before — line numbers as of `origin/main`

```text
gh pr create --body …
  └─ matcher            (preflight-pr-review.sh:52)   — gh pr create|edit|ready
       └─ title check   (preflight-pr-review.sh:103)  — Conventional-Commit ≤72
            └─ ack gate (preflight-pr-review.sh:189)  — user-typed `reviewed:`
                                                        body never inspected
```

After — line numbers as of this branch

```text
gh pr create --body …
  └─ matcher            (preflight-pr-review.sh:57)   — gh pr create|edit|ready
       └─ title check   (preflight-pr-review.sh:108)  — Conventional-Commit ≤72
            └─ body extraction (preflight-pr-review.sh:126)
            │                                         — --body / --body-file / heredoc
            └─ graph check     (preflight-pr-review.sh:148)
            │                                         — deny unless the body has
            │                                           `## Call graph`, Before, After,
            │                                           and a parenthesised
            │                                           path/file.ext:LOC hop inside
            │                                           each graph
            └─ fix: extras     (preflight-pr-review.sh:226)
            │                                         — `BUG:` on a hop line inside the
            │                                           Before graph, plus `Fixes #<n>`
            └─ ack gate (preflight-pr-review.sh:341)  — unchanged
```

The per-section hop requirement carries the weight: an unfilled template has the headings but zero hop lines, a graph reduced to prose cannot borrow the other one's hops, and an incidental file mention in a sentence is not a hop. Commands with no body flag (`gh pr ready`) are untouched; `--fill` is denied, because commit text is not a PR description.

## Changes

- `CONTRIBUTING.md` — the rule plus a worked example under **Commit & PR messages**; single source of truth for the format.
- `.github/pull_request_template.md` — a `## Call graph` skeleton (Before / After / `Fixes #`), pointing at CONTRIBUTING for the example rather than repeating it.
- `CLAUDE.md` — one pointer bullet under **Communication**.
- `.claude/hooks/preflight-pr-review.sh` — the body check above. Additive: it runs before the ack gate and does not consume the ack marker.
- `.claude/hooks/preflight-pr-review.test.sh` — 24 body cases covering prose bodies, a missing *After*, labels without `file:LOC`, a prose-only graph, hops outside both graphs, the unfilled template, `--fill`, the bug-fix omissions, and the shapes that should pass.

### Review rounds

**`6a4a6b1b`** — the bug marker was accepted anywhere in the body, so a `fix:` PR passed with it sitting in prose or in the *After* graph, and `debug:` satisfied it outright. It now has to sit on a hop line inside *Before*. The arrow glyph is deliberately not policed — `←`, `<-` and a bare `BUG:` are all accepted, since mandating one Unicode character is typing friction rather than signal; `CONTRIBUTING.md` still prescribes `←`, so the style guide stays stricter than the linter.

**`c82ef77a`** — hops were counted body-wide, so two *Before* hops carried a prose-only *After*, and a pair of hop-free graphs passed on references sitting in a later section. Both graphs are now extracted and each must carry a hop of its own. Only the heading bound is fence-aware: an earlier cut gated the graph labels on fences too, which made CONTRIBUTING's own example — it wraps both labels and all hops in one fence — extract to nothing. The suite now lifts that example out of the doc at run time, so the documented shape and the enforced shape cannot drift.

**`43f7ae0f`** — the hop pattern matched a bare `path/file.ext:LOC`, which turns up mid-sentence, so `Before` / `After` labels over two lines of prose counted as two graphs. The reference must now sit between a `(` and a `)`. Not a balanced group: the left side stays permissive because a Type half carries its own parens in `(fn(u32) -> u32 · src/x.rs:5)`, and refusing to cross them denied a hop conforming to the documented shape. Nothing here can tell a real graph from a fabricated one — the typed ack is that control, and the code now says so instead of leaving the deny text to imply otherwise.

## How to verify

```
bash .claude/hooks/preflight-pr-review.test.sh   # 54 passed, 0 failed
```

Two-side check: with `preflight-pr-review.sh` restored from the preceding commit and only the test file modified, each round's new deny cases fail with `got=passthrough expected=deny`. Restored, 54/54.

## Risks / rollout

- A body containing a double quote truncates extraction and fails the checks — closed, not open, so the failure mode is a false denial rather than a bypass. Documented at the extraction branch; not covered by a test.
- An *unclosed* ``` fence suppresses the heading bound, letting a prose-only *After* borrow hops from a later section. Not a regression — the body-wide count accepted the same body — and it needs markdown that GitHub would render as a code block swallowing the rest of the description.
- `--body-file` is matched anywhere in the command and wins over `--body`, so chaining `git commit -F msg.txt && gh pr create --body "…"` reads the commit-message file as the PR body and denies. Same fail-closed trade-off already documented for `--draft`.
- Graph labels are matched at line start anywhere in the body, so a prose line beginning `Before ` or `After ` re-partitions the graphs. Pre-existing: the label presence checks have the identical looseness.
- The hop pattern is not a balanced group — an unrelated parenthetical straddling the reference satisfies it. Accepted so that a Type half carrying its own parens is not denied; no pattern can tell a real graph from a fabricated one, which is what the typed ack is for.
- `--draft` continues to skip the hook entirely, unchanged.
