### PR TITLE
Fix infra-local main boot on Apple Silicon

### DIFF
--- a/apps/infra-local/compose/_local_arm64.py
+++ b/apps/infra-local/compose/_local_arm64.py
@@ -131,20 +131,36 @@ def export_ghcr_env() -> None:
 
 def fix_runtime_cache() -> None:
     """maturin editable builds leave the SDK runtime cache missing the big
-    boxlite-guest/shim binaries; copy them from the cargo build output."""
+    runtime binaries; copy the freshly built runtime from cargo output.
+
+    The cache key is only the package version, so a local editable build of
+    main can share `v0.9.7` with an older release build. Refresh the cache from
+    the current worktree whenever the built runtime is newer, not only when
+    files are missing.
+    """
     base = Path.home() / "Library" / "Application Support" / "boxlite" / "runtimes"
     caches = sorted(base.glob("v*"))
     if not caches:
         return
     cache = caches[0]
-    if (cache / "boxlite-guest").is_file():
+    runtime_dirs = [
+        d for d in REPO.glob("target/debug/build/boxlite-*/out/runtime")
+        if (d / "boxlite-guest").is_file() and (d / "boxlite-shim").is_file()
+    ]
+    if not runtime_dirs:
         return
-    for d in REPO.glob("target/debug/build/boxlite-*/out/runtime"):
-        if (d / "boxlite-guest").is_file():
-            for f in ("boxlite-guest", "boxlite-shim"):
-                shutil.copy2(d / f, cache / f)
-            print(f"  patched runtime cache: boxlite-guest+shim -> {cache}")
-            return
+    runtime = max(runtime_dirs, key=lambda d: (d / "boxlite-shim").stat().st_mtime)
+    cache_shim = cache / "boxlite-shim"
+    if cache_shim.is_file() and cache_shim.stat().st_mtime >= (runtime / "boxlite-shim").stat().st_mtime:
+        return
+    copied = []
+    for f in ("boxlite-guest", "boxlite-shim", "debugfs", "mke2fs", "libkrunfw.5.dylib"):
+        src = runtime / f
+        if src.is_file():
+            shutil.copy2(src, cache / f)
+            copied.append(f)
+    if copied:
+        print(f"  refreshed runtime cache from local build: {', '.join(copied)} -> {cache}")
 
 
 def ensure_shared_target() -> None:
@@ -179,13 +195,34 @@ def ensure_submodules() -> None:
 
 
 def ensure_native_lib() -> None:
-    """Build the real libboxlite.a (the Go runner links it) if missing."""
-    if (REPO / "target" / "debug" / "libboxlite.a").is_file():
+    """Build the real libboxlite.a (the Go runner links it) if missing/stale."""
+    lib = REPO / "target" / "debug" / "libboxlite.a"
+    if lib.is_file() and _native_lib_has_current_go_symbols(lib):
         return
     ensure_shared_target()
     ensure_submodules()
     print("  building native libboxlite.a (real libkrun — slow on first run, shared cache after)...")
     subprocess.run(["make", "dev:go"], cwd=str(REPO), check=True)
+
+
+def _native_lib_has_current_go_symbols(lib: Path) -> bool:
+    """Catch stale shared-cache libboxlite.a before Go runner link time."""
+    try:
+        out = subprocess.run(
+            ["nm", "-g", str(lib)],
+            capture_output=True,
+            text=True,
+            timeout=20,
+            check=False,
+        ).stdout
+    except Exception:
+        return False
+    required = (
+        "_boxlite_advanced_options_new",
+        "_boxlite_box_network",
+        "_boxlite_volume_create",
+    )
+    return all(sym in out for sym in required)
 
 
 def _boxlite_is_local_build() -> bool:

--- a/apps/infra-local/compose/native.py
+++ b/apps/infra-local/compose/native.py
@@ -356,18 +356,38 @@ def _l1_running(cfg: InfraConfig) -> bool:
     async def go() -> bool:
         orchestrator.ensure_home_env(cfg)
         infos = await orchestrator.get_runtime().list_info()
-        return any((i.name or "") == "boxlite-local-postgres" for i in infos)
+        return any(
+            (i.name or "") == "boxlite-local-postgres"
+            and (i.state.status or "").lower() == "running"
+            for i in infos
+        )
 
     return asyncio.run(go())
 
 
 async def _ensure_l1_async(cfg: InfraConfig) -> bool:
-    """Bring the whole L1 up if postgres isn't running. True if (re)created."""
+    """Bring the whole L1 up unless every daemon box is running. True if (re)created."""
     orchestrator.ensure_home_env(cfg)
-    infos = await orchestrator.get_runtime().list_info()
-    if any((i.name or "") == "boxlite-local-postgres" for i in infos):
+    runtime = orchestrator.get_runtime()
+    infos = await runtime.list_info()
+    l1_infos = [i for i in infos if (i.name or "").startswith("boxlite-local-")]
+    expected = {
+        f"boxlite-local-{name}"
+        for name, spec in SERVICES.items()
+        if not spec.one_shot
+    }
+    running = {
+        i.name
+        for i in l1_infos
+        if (i.name or "") in expected and (i.state.status or "").lower() == "running"
+    }
+    if expected <= running:
         ok("L1 boxes already running")
         return False
+    if l1_infos:
+        states = ", ".join(f"{i.name}={i.state.status}" for i in l1_infos)
+        warn(f"L1 boxes are not healthy ({states}) — recreating")
+        await orchestrator.down(cfg, SERVICES, wipe=True)
     log("L1 boxes not running — starting...")
     await orchestrator.up(cfg, SERVICES)
     return True

--- a/apps/infra-local/compose/orchestrator.py
+++ b/apps/infra-local/compose/orchestrator.py
@@ -96,6 +96,7 @@ def _build_box_options_with_volumes(spec: ServiceSpec, config: InfraConfig, volu
         cmd=cmd,
         entrypoint=spec.entrypoint,
         working_dir=spec.working_dir,
+        user=spec.user,
     )
 
 

--- a/apps/infra-local/compose/services.py
+++ b/apps/infra-local/compose/services.py
@@ -42,6 +42,7 @@ class ServiceSpec:
     cmd: Optional[list[str] | Callable[["InfraConfig"], list[str]]] = None
     entrypoint: Optional[list[str]] = None   # overrides image entrypoint (e.g. ["sh"]); None keeps image default
     working_dir: Optional[str] = None
+    user: Optional[str] = None
     depends_on: list[str] = field(default_factory=list)
     healthcheck: Optional[HealthCheck] = None
     one_shot: bool = False
@@ -248,6 +249,7 @@ SPEC_DEX = ServiceSpec(
     # so we can run the inline script that env-substitutes the config.
     entrypoint=["sh"],
     cmd=["-c", _DEX_ENTRYPOINT],
+    user="root",
     healthcheck=HealthCheck(
         http_url="http://127.0.0.1:25556/dex/.well-known/openid-configuration",
         interval_s=2.0,
@@ -300,6 +302,7 @@ SPEC_PGADMIN = ServiceSpec(
         # Force IPv4 bind (image default is [::]:80 dual-stack).
         "PGADMIN_LISTEN_ADDRESS": "0.0.0.0",
     },
+    user="root",
     depends_on=["postgres"],
     healthcheck=HealthCheck(
         http_url="http://127.0.0.1:25051/misc/ping",


### PR DESCRIPTION
Refresh infra-local local build artifacts and recreate unhealthy L1 boxes so current main can boot cleanly on Apple Silicon.

Test plan:
- [x] `make dev:go`
- [x] `make up`
- [x] `make status`
- [x] `python -m py_compile compose/_local_arm64.py compose/native.py compose/orchestrator.py compose/services.py`