### PR TITLE
feat(agents): watch CI and PR feedback after every push

### DIFF
--- a/.agents/hooks/post-remote-write-watch.sh
+++ b/.agents/hooks/post-remote-write-watch.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# PostToolUse hook: after a successful remote write, tell the agent to arm a
+# Monitor on the pr-watch event stream.
+#
+# This is the Claude Code *consumer* of the watch. The producer is universal —
+# .githooks/pre-push starts .agents/watch/pr-watch.sh for every agent and every
+# human. This hook only bridges that stream into a Claude session. Codex,
+# opencode, and humans read the same log directly.
+#
+# Registered from .claude/settings.json (hooks.PostToolUse, matcher "Bash"):
+# the vendor directory registers, .agents/ implements.
+#
+# Design notes
+# ------------
+# * Advisory, not `decision: "block"`. The push has already happened, so a block
+#   cannot undo it — it can only nag. Worse, the auto-fix loop this arms itself
+#   ends in a push, so a hard block here would deadlock that loop.
+#
+# * Matcher scope: PreToolUse/PostToolUse matchers are tool-name-only, so this
+#   registers on the broad `Bash` matcher and does its own filtering, exiting 0
+#   immediately on unrelated commands. Same shape as
+#   .claude/hooks/preflight-commit-push.sh:55 and preflight-pr-review.sh:52 —
+#   segment-anchored so `echo "git push"` does not match, newline-normalized so
+#   a verb on line 2 does.
+#
+# * `git push` is matched, but so are the `gh pr` writes. The pre-push arm
+#   already covers PR creation transitively (a push always precedes it), so the
+#   gh cases exist to re-attach a Monitor in a session that pushed earlier, or
+#   where the push happened outside this session.
+#
+# Tests: bash .agents/hooks/post-remote-write-watch.test.sh
+set -euo pipefail
+
+payload="$(cat)"
+command="$(printf '%s' "$payload" | jq -r '.tool_input.command // ""')"
+
+normalized="${command//$'\n'/;}"
+work="${normalized#"${normalized%%[![:space:]]*}"}"
+if [[ "$work" =~ (^|[[:space:]]*(\&\&|\|\||\;|\||\&|\$\(|\(|\`)[[:space:]]*)([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]+[[:space:]]+)*git[[:space:]]+push([[:space:]]|$) ]]; then
+  :
+elif [[ "$work" =~ (^|[[:space:]]*(\&\&|\|\||\;|\||\&|\$\(|\(|\`)[[:space:]]*)([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]+[[:space:]]+)*gh[[:space:]]+pr[[:space:]]+(create|edit|ready|comment|review)([[:space:]]|$) ]]; then
+  :
+else
+  exit 0
+fi
+
+[[ "${BOXLITE_PR_WATCH:-1}" == "0" ]] && exit 0
+
+# tool_response is a string for some tools and an object for Bash; accept both
+# rather than assuming a shape.
+response="$(printf '%s' "$payload" \
+  | jq -r 'if (.tool_response | type) == "string"
+           then .tool_response
+           else ((.tool_response.stdout // "") + "\n" + (.tool_response.stderr // ""))
+           end' 2>/dev/null || echo '')"
+
+# A failed push leaves nothing new to watch. PostToolUse never sees the exit
+# code, so the decision has to come from git's own output.
+#
+# Match the whole `error:`/`fatal:` class, not a list of specific messages. A
+# local pre-push hook that exits non-zero — this repo's own audit gate — prints
+# ONLY `error: failed to push some refs`: no `fatal:`, no `[rejected]`. An
+# earlier version enumerated messages, missed that one, and announced a blocked
+# push as a successful remote write.
+#
+# Fails closed: over-matching costs an un-armed watch, under-matching reports a
+# push that never happened.
+failure_re='(^|[[:space:]])(fatal|error):|\[(remote )?rejected\]|Everything up-to-date|Permission denied'
+if [[ "$response" =~ $failure_re ]]; then
+  exit 0
+fi
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+branch="$(git -C "$repo_root" branch --show-current 2>/dev/null || echo '')"
+[[ -z "$branch" ]] && exit 0
+
+slug="$(git -C "$repo_root" remote get-url origin 2>/dev/null \
+        | sed -e 's#^git@[^:]*:##' -e 's#^[a-z+]*://[^/]*/##' -e 's#\.git$##')"
+
+# Prefer the PR the command just produced; fall back to the branch's open PR.
+pr_number="$(printf '%s' "$response" \
+  | sed -n 's#.*/pull/\([0-9][0-9]*\).*#\1#p' | head -1)"
+if [[ ! "$pr_number" =~ ^[0-9]+$ ]]; then
+  pr_number="$(gh pr list --repo "$slug" --head "$branch" --state open \
+                --json number --jq '.[0].number // empty' 2>/dev/null || echo '')"
+fi
+
+state_dir="$(git -C "$repo_root" rev-parse --git-path pr-watch 2>/dev/null || echo '')"
+[[ -z "$state_dir" ]] && exit 0
+[[ "$state_dir" != /* ]] && state_dir="$repo_root/$state_dir"
+event_log="$state_dir/${branch//\//-}.jsonl"
+
+pr_line="No open PR for '${branch}' yet — the watcher polls until one appears."
+if [[ "$pr_number" =~ ^[0-9]+$ ]]; then
+  pr_line="Watching PR #${pr_number} — https://github.com/${slug}/pull/${pr_number}"
+fi
+
+context="A remote write just succeeded on branch '${branch}'.
+${pr_line}
+
+.githooks/pre-push has armed the watcher. Arm a Monitor on its event stream now,
+in this exact form:
+
+  Monitor({
+    command: 'bash ${repo_root}/.agents/watch/pr-watch-stream.sh \"${event_log}\"',
+    description: 'CI checks + PR comments on ${branch}',
+    persistent: true,
+  })
+
+Each line is one JSON event. Kinds: check (one per check as it concludes),
+checks_done, comment, review, review_comment, watch_start, watch_end.
+The stream ends itself at watch_end — do not arm a second Monitor for this
+branch, and do not poll \`gh pr checks\` by hand while it runs.
+
+When an event arrives:
+  * bucket 'fail' or 'cancel' -> read the real failure with
+      gh run view <run-id> --log-failed
+    then follow ${repo_root}/.agents/watch/escalation-policy.md, which decides
+    what you may fix unattended and what needs the human. Read it before editing.
+  * a new comment or review    -> summarize it for the user; apply the same
+    policy before acting on it.
+  * send a PushNotification for a failing required check ('Lint (conclusion)',
+    'Test (conclusion)') or a new human review — not for routine passes.
+
+If the user asked you not to watch this one, skip the Monitor and say so."
+
+jq -nc --arg c "$context" '{
+  hookSpecificOutput: {
+    hookEventName: "PostToolUse",
+    additionalContext: $c
+  }
+}'
+exit 0

--- a/.agents/hooks/post-remote-write-watch.test.sh
+++ b/.agents/hooks/post-remote-write-watch.test.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Tests for .agents/hooks/post-remote-write-watch.sh
+#
+# Covers:
+#   1. Command matcher: git push / gh pr writes vs. unrelated bash, chained and
+#      multi-line forms, literal mentions.
+#   2. Failure handling: a rejected or no-op push must not arm anything.
+#   3. PR-number resolution from the tool response.
+#
+# `gh` is stubbed on PATH — this suite makes no network calls.
+#
+# Run with:  bash .agents/hooks/post-remote-write-watch.test.sh
+# Exits non-zero on any failure.
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+HOOK="$REPO_ROOT/.agents/hooks/post-remote-write-watch.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+STUB="$TMP/bin"
+mkdir -p "$STUB"
+cat > "$STUB/gh" <<'EOF'
+#!/usr/bin/env bash
+# Only `gh pr list --json number` is reached from the hook.
+printf '%s\n' "${STUB_PR_NUMBER:-}"
+EOF
+chmod +x "$STUB/gh"
+export PATH="$STUB:$PATH"
+
+pass=0
+fail=0
+
+# Feed a PostToolUse payload; report "armed" when the hook injects context.
+run() {
+  local desc="$1" cmd="$2" resp="$3" expect="$4" out decision
+  out=$(jq -nc --arg c "$cmd" --arg r "$resp" \
+          '{tool_input:{command:$c}, tool_response:{stdout:$r, stderr:""}}' \
+        | "$HOOK" 2>/dev/null)
+  if [[ -z "$out" ]]; then
+    decision="passthrough"
+  elif printf '%s' "$out" | jq -e '.hookSpecificOutput.additionalContext' >/dev/null 2>&1; then
+    decision="armed"
+  else
+    decision="parse_error"
+  fi
+  if [[ "$decision" == "$expect" ]]; then
+    pass=$((pass + 1)); printf '  PASS  %s\n' "$desc"
+  else
+    fail=$((fail + 1)); printf '  FAIL  %s  (got=%s expected=%s)\n' "$desc" "$decision" "$expect"
+  fi
+}
+
+export STUB_PR_NUMBER=42
+
+echo "## Matcher: should pass through"
+run "ls"                          "ls"                        ""  "passthrough"
+run "git status"                  "git status"                ""  "passthrough"
+run "git commit (not a push)"     "git commit -m x"           ""  "passthrough"
+run "gh pr list"                  "gh pr list"                ""  "passthrough"
+run "gh pr view"                  "gh pr view 42"             ""  "passthrough"
+run "gh issue create"             "gh issue create -t x"      ""  "passthrough"
+run "echo literal git push"       "echo 'git push'"           ""  "passthrough"
+run "echo literal gh pr create"   "echo 'gh pr create'"       ""  "passthrough"
+run "heredoc body mentions push"  $'git commit -m "$(cat <<\'EOF\'\nmentions `git push`\nEOF\n)"' "" "passthrough"
+
+echo
+echo "## Matcher: should arm"
+run "git push direct"             "git push"                  ""  "armed"
+run "git push with args"          "git push -u origin feat"   ""  "armed"
+run "gh pr create"                "gh pr create -t x"         ""  "armed"
+run "gh pr ready"                 "gh pr ready 42"            ""  "armed"
+run "gh pr comment"               "gh pr comment 42 -b hi"    ""  "armed"
+run "gh pr review"                "gh pr review 42 -a"        ""  "armed"
+run "chained with &&"             "cd x && git push"          ""  "armed"
+run "chained with ;"              "echo done; git push"       ""  "armed"
+run "env var prefix"              "FOO=bar git push"          ""  "armed"
+run "newline before verb"         $'cd x\ngit push'           ""  "armed"
+
+echo
+echo "## Failed remote writes must not arm"
+run "rejected push"               "git push" "! [rejected] main -> main (fetch first)" "passthrough"
+run "fatal push"                  "git push" "fatal: repository not found"             "passthrough"
+run "everything up-to-date"       "git push" "Everything up-to-date"                   "passthrough"
+run "permission denied"           "git push" "Permission denied (publickey)"           "passthrough"
+run "remote rejected"             "git push" "! [remote rejected] main -> main (pre-receive hook declined)" "passthrough"
+# git's generic summary line. A local pre-push hook that exits non-zero (this
+# repo's own audit gate) prints ONLY this — no 'fatal:', no '[rejected]' — so
+# without it the hook reports a blocked push as a successful remote write.
+run "pre-push hook declined"      "git push" "error: failed to push some refs to 'github.com:boxlite-ai/boxlite.git'" "passthrough"
+run "src refspec error"           "git push" "error: src refspec main does not match any" "passthrough"
+
+echo
+echo "## Opt-out"
+out=$(jq -nc '{tool_input:{command:"git push"}, tool_response:{stdout:"",stderr:""}}' \
+      | BOXLITE_PR_WATCH=0 "$HOOK" 2>/dev/null)
+if [[ -z "$out" ]]; then
+  pass=$((pass + 1)); printf '  PASS  BOXLITE_PR_WATCH=0 passes through\n'
+else
+  fail=$((fail + 1)); printf '  FAIL  BOXLITE_PR_WATCH=0 passes through (got output)\n'
+fi
+
+echo
+echo "## PR resolution"
+ctx() {
+  jq -nc --arg c "$1" --arg r "$2" \
+     '{tool_input:{command:$c}, tool_response:{stdout:$r, stderr:""}}' \
+   | "$HOOK" 2>/dev/null | jq -r '.hookSpecificOutput.additionalContext // ""'
+}
+
+got="$(ctx "gh pr create -t x" "https://github.com/boxlite-ai/boxlite/pull/1234")"
+if [[ "$got" == *"PR #1234"* ]]; then
+  pass=$((pass + 1)); printf '  PASS  PR number read from the create URL\n'
+else
+  fail=$((fail + 1)); printf '  FAIL  PR number read from the create URL\n'
+fi
+
+got="$(ctx "git push" "")"
+if [[ "$got" == *"PR #42"* ]]; then
+  pass=$((pass + 1)); printf '  PASS  falls back to the branch'"'"'s open PR\n'
+else
+  fail=$((fail + 1)); printf '  FAIL  falls back to the branch'"'"'s open PR (got: %.60s)\n' "$got"
+fi
+
+STUB_PR_NUMBER="" got="$(ctx "git push" "")"
+if [[ "$got" == *"No open PR"* ]]; then
+  pass=$((pass + 1)); printf '  PASS  no PR yet still arms, noting the watcher polls\n'
+else
+  fail=$((fail + 1)); printf '  FAIL  no PR yet still arms, noting the watcher polls\n'
+fi
+
+got="$(ctx "git push" "")"
+if [[ "$got" == *"escalation-policy.md"* && "$got" == *"pr-watch-stream.sh"* ]]; then
+  pass=$((pass + 1)); printf '  PASS  context names the stream script and the policy\n'
+else
+  fail=$((fail + 1)); printf '  FAIL  context names the stream script and the policy\n'
+fi
+
+echo
+printf 'post-remote-write-watch: %d passed, %d failed\n' "$pass" "$fail"
+(( fail == 0 ))

--- a/.agents/hooks/post-remote-write-watch.test.sh
+++ b/.agents/hooks/post-remote-write-watch.test.sh
@@ -13,7 +13,12 @@
 # Exits non-zero on any failure.
 set -uo pipefail
 
-REPO_ROOT="$(git rev-parse --show-toplevel)"
+# Resolve from THIS script's location, not the caller's cwd. `git rev-parse
+# --show-toplevel` returns whatever checkout the shell happens to sit in, so
+# running this suite from another directory silently tests that checkout's hook
+# instead of the one shipped beside these tests — a reverted-hook two-side check
+# then reports a false pass.
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 HOOK="$REPO_ROOT/.agents/hooks/post-remote-write-watch.sh"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
@@ -122,7 +127,10 @@ else
   fail=$((fail + 1)); printf '  FAIL  falls back to the branch'"'"'s open PR (got: %.60s)\n' "$got"
 fi
 
-STUB_PR_NUMBER="" got="$(ctx "git push" "")"
+# Prefix form, not a bare assignment: `VAR="" got="$(…)"` is TWO assignments, so
+# the empty value would persist and silently re-point every later case at the
+# no-PR branch. `ctx` is a function, so the prefix scopes it to this call.
+got="$(STUB_PR_NUMBER="" ctx "git push" "")"
 if [[ "$got" == *"No open PR"* ]]; then
   pass=$((pass + 1)); printf '  PASS  no PR yet still arms, noting the watcher polls\n'
 else

--- a/.agents/watch/escalation-policy.md
+++ b/.agents/watch/escalation-policy.md
@@ -1,0 +1,63 @@
+# CI auto-fix escalation policy
+
+Read by any agent consuming a `pr-watch` event stream. Plain Markdown, not a
+Claude-specific format, so Codex and opencode follow the same rule.
+
+The watcher only reports. This file decides what an agent may do about a red
+check or a review comment **without asking a human first**.
+
+## Hard limits
+
+- **At most 2 auto-fix attempts per PR head.** After the second push fails to
+  turn CI green, stop and report. A third attempt means the diagnosis is wrong,
+  and each one costs a full CI run.
+- **Never** auto-fix by weakening a test, loosening an assertion, adding a skip,
+  or widening an allow-list to make a check pass. Fix the code under test.
+  (CLAUDE.md → Test: "Never weaken a test to force it green".)
+- **Never** auto-push to `main`.
+- Always read the actual failure (`gh run view <run-id> --log-failed`) before
+  editing. The check name is not the diagnosis.
+- Reproduce locally with the smallest relevant `make` target before pushing a
+  fix. A fix that was never run locally is a guess.
+
+## Stop and ask a human
+
+<!-- ─────────────────────────────────────────────────────────────────────────
+TODO(user, learning-mode): this list is the actual contract — it decides when an
+agent may edit your code unattended. Same convention as the ack-instruction
+block in .claude/hooks/preflight-pr-review.sh:116.
+
+Below is a DRAFT default. Replace it with your rule. Things worth deciding:
+
+  • Infra/flaky failures (cache miss, network, runner OOM, timeout) — is
+    `gh run rerun --failed` allowed automatically, or is any rerun your call?
+  • A fix that would touch files outside the PR's own diff — scope creep. Ask,
+    or allow when the fix is obviously local to the failure?
+  • Review comments from `boxlite-agent` / `coderabbitai` — auto-address the
+    mechanical ones (typos, missing null-check), ask on design calls? Or never
+    auto-address review feedback at all?
+  • `e2e-local` / `e2e-cloud` — label-gated `pull_request_target` workflows,
+    expensive and slow. Auto-retry, or always ask?
+  • Anything touching .githooks/, .claude/, or .agents/ — the gate machinery
+    itself. Auto-fix, or always ask?
+
+Keep it to conditions, not prose. Each line should be checkable.
+──────────────────────────────────────────────────────────────────────────── -->
+
+Draft default — escalate rather than act when **any** of these hold:
+
+1. The failure has no code signal: runner OOM, network error, cache miss,
+   timeout, or a job that never started. Report it and name the run; do not
+   edit code and do not rerun without being asked.
+2. The fix would touch a file not already in this PR's diff
+   (`git diff --name-only origin/main...HEAD`).
+3. The failing job is `e2e-local` or `e2e-cloud`.
+4. The change would touch `.githooks/`, `.claude/`, `.codex/`, or `.agents/` —
+   the gate and watch machinery itself.
+5. A review comment asks for a design change, a rename in a shared spec, or
+   anything whose "right answer" depends on product intent.
+6. Two auto-fix attempts have already been made on this PR head.
+7. The same check fails again with a *different* error after a fix — the
+   original diagnosis was wrong.
+
+Otherwise: fix it, push, and report what changed and why.

--- a/.agents/watch/pr-watch-stream.sh
+++ b/.agents/watch/pr-watch-stream.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Replay-and-follow one pr-watch event log, then stop when the watch ends.
+#
+# Separated from pr-watch.sh because the two have opposite jobs: that script
+# PRODUCES events from GitHub, this one DELIVERS a log to whoever is watching.
+# Consumers point a Monitor (or a plain terminal) at this.
+#
+# Why not `tail -f`: the stream has to stop on its own when the watch is over,
+# and `tail -f | while read … exit` cannot do that — the `exit` runs in the
+# pipeline's subshell and leaves `tail` following the file forever. Polling the
+# line count keeps termination in the same shell that decides to terminate.
+#
+# Usage: pr-watch-stream.sh <event-log> [poll-seconds]
+set -uo pipefail
+
+log="${1:-}"
+poll="${2:-5}"
+
+if [[ -z "$log" ]]; then
+  printf 'usage: pr-watch-stream.sh <event-log> [poll-seconds]\n' >&2
+  exit 2
+fi
+
+# The log is created by pre-push at arm time, but a consumer can start first.
+deadline=$(( SECONDS + ${PR_WATCH_STREAM_WAIT:-120} ))
+while [[ ! -f "$log" ]]; do
+  if (( SECONDS >= deadline )); then
+    printf '{"kind":"stream_error","message":"no event log at %s"}\n' "$log"
+    exit 1
+  fi
+  sleep "$poll"
+done
+
+sent=0
+while :; do
+  total="$(wc -l < "$log" 2>/dev/null | tr -d ' ')"
+  total="${total:-0}"
+  if (( total > sent )); then
+    sed -n "$(( sent + 1 )),${total}p" "$log"
+    sent="$total"
+  fi
+  # Checked after flushing so the terminal event is always delivered first.
+  if sed -n "1,${total}p" "$log" 2>/dev/null | grep -q '"kind":"watch_end"'; then
+    exit 0
+  fi
+  sleep "$poll"
+done

--- a/.agents/watch/pr-watch.sh
+++ b/.agents/watch/pr-watch.sh
@@ -16,10 +16,18 @@
 #   pr-watch.sh --pr <number>                   # watch a known PR
 #   pr-watch.sh --pr <number> --once            # one poll pass, then exit
 #
+# The polling loop runs until the PR is MERGED or CLOSED. Going quiet is NOT a
+# reason to stop; losing contact with GitHub or hitting the lifetime backstop is.
+# (It also exits early for --once, on TERM/INT, when another watcher already
+# holds the branch lock, and when no PR ever appears.)
+#
 # Env:
 #   BOXLITE_PR_WATCH=0        disable entirely (checked by the caller and here)
 #   PR_WATCH_INTERVAL         poll seconds (default 30; GitHub rate limits)
-#   PR_WATCH_IDLE_TIMEOUT     give up after this many idle seconds (default 7200)
+#   PR_WATCH_IDLE_TIMEOUT     give up after this long with no SUCCESSFUL poll
+#                             (default 7200) — contact lost, not silence
+#   PR_WATCH_MAX_LIFETIME     absolute cap for a PR that never merges
+#                             (default 604800 = 7 days; 0 disables the cap)
 #
 # Design notes
 # ------------
@@ -35,7 +43,12 @@
 set -uo pipefail
 
 readonly DEFAULT_INTERVAL=30
+# Time without a SUCCESSFUL poll — i.e. contact lost — not time without events.
 readonly DEFAULT_IDLE_TIMEOUT=7200
+# Backstop for a PR that is never merged or closed. A week is an arbitrary
+# default, chosen long enough that it is not what normally ends a watch; override
+# with PR_WATCH_MAX_LIFETIME, or 0 to remove the cap.
+readonly DEFAULT_MAX_LIFETIME=604800
 readonly BODY_MAX_CHARS=600
 
 branch=""
@@ -43,16 +56,25 @@ sha=""
 pr_number=""
 once=0
 
+# Print the header block: every comment line after the shebang, stopping at the
+# first non-comment. A hardcoded line range silently truncates --help the moment
+# the header grows.
 usage() {
-  sed -n '2,20p' "$0" | sed 's/^# \{0,1\}//'
+  awk 'NR==1 {next} /^#/ {sub(/^# ?/, ""); print; next} {exit}' "$0"
   exit "${1:-0}"
+}
+
+# `shift 2` on a lone flag shifts nothing and leaves $1 in place, so the same
+# case branch matches forever. Require the value before consuming it.
+need_value() {
+  [[ -n "${2+set}" ]] || { printf 'pr-watch: %s requires a value\n' "$1" >&2; usage 1; }
 }
 
 while (( $# )); do
   case "$1" in
-    --branch) branch="${2:-}"; shift 2 ;;
-    --sha)    sha="${2:-}";    shift 2 ;;
-    --pr)     pr_number="${2:-}"; shift 2 ;;
+    --branch) need_value "$1" ${2+"$2"}; branch="$2";    shift 2 ;;
+    --sha)    need_value "$1" ${2+"$2"}; sha="$2";       shift 2 ;;
+    --pr)     need_value "$1" ${2+"$2"}; pr_number="$2"; shift 2 ;;
     --once)   once=1; shift ;;
     -h|--help) usage 0 ;;
     *) printf 'pr-watch: unknown argument: %s\n' "$1" >&2; usage 1 ;;
@@ -63,6 +85,7 @@ done
 
 interval="${PR_WATCH_INTERVAL:-$DEFAULT_INTERVAL}"
 idle_timeout="${PR_WATCH_IDLE_TIMEOUT:-$DEFAULT_IDLE_TIMEOUT}"
+max_lifetime="${PR_WATCH_MAX_LIFETIME:-$DEFAULT_MAX_LIFETIME}"
 
 repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 state_dir="$(git -C "$repo_root" rev-parse --git-path pr-watch 2>/dev/null || echo "$repo_root/.git/pr-watch")"
@@ -96,11 +119,34 @@ seen_file="$state_dir/${safe_branch}.seen"
 lock_dir="$state_dir/${safe_branch}.lock"
 touch "$event_log" "$seen_file" 2>/dev/null || true
 
-# Atomic single-instance guard: repeated pushes to the same branch must not
-# stack daemons all polling the same PR.
-if ! mkdir "$lock_dir" 2>/dev/null; then
-  exit 0
-fi
+# Single-instance guard: repeated pushes to the same branch must not stack
+# daemons all polling the same PR.
+#
+# The traps below release the lock on EXIT/TERM/INT, but SIGKILL, an OOM kill, or
+# a host crash cannot run them — and a lock left behind that way would silently
+# suppress every future watcher for the branch. So a lock whose owning PID is
+# gone is reclaimed rather than obeyed.
+#
+# Only the fast path (`mkdir` succeeds) is atomic. Reclaiming a stale lock is
+# rm-then-mkdir, so two watchers racing on the SAME stale lock can both win and
+# briefly stack. That is deliberate: the alternative is the old behaviour, where
+# one stale lock suppressed the branch's watcher permanently.
+acquire_lock() {
+  local owner
+  if mkdir "$lock_dir" 2>/dev/null; then
+    printf '%s' "$$" > "$lock_dir/pid"
+    return 0
+  fi
+  owner="$(cat "$lock_dir/pid" 2>/dev/null || echo '')"
+  if [[ "$owner" =~ ^[0-9]+$ ]] && kill -0 "$owner" 2>/dev/null; then
+    return 1                      # a live watcher owns this branch
+  fi
+  rm -rf "$lock_dir"
+  mkdir "$lock_dir" 2>/dev/null || return 1
+  printf '%s' "$$" > "$lock_dir/pid"
+  return 0
+}
+acquire_lock || exit 0
 # Signal traps must exit explicitly. A bare `trap '<cleanup>' TERM` runs the
 # handler and then RESUMES the loop — the daemon would survive every kill short
 # of SIGKILL, and each push would leave another one running.
@@ -132,26 +178,31 @@ emit() {
 seen() { grep -qxF "$1" "$seen_file" 2>/dev/null; }
 mark_seen() { printf '%s\n' "$1" >> "$seen_file"; }
 
-# Field separator for jq @tsv rows. NOT a literal tab: bash treats tab as an IFS
-# *whitespace* character, so `read` collapses runs of them into one delimiter and
-# every row with an empty field (a check with no `workflow`, a comment with no
-# `path`) silently shifts its remaining values one column left. US (0x1f) is
-# non-whitespace, so each occurrence delimits exactly one field.
-readonly FS=$'\037'
+# Record/field separators for the rows jq hands to `read`.
+#
+# NOT a literal tab: bash treats tab as an IFS *whitespace* character, so `read`
+# collapses runs of them and every row with an empty field (a check with no
+# `workflow`, a comment with no `path`) silently shifts its remaining values one
+# column left. US/RS are non-whitespace, so each occurrence delimits exactly one
+# field or record.
+#
+# These also let us drop @tsv entirely. @tsv escapes \n \r \t \\ inside values,
+# which then have to be un-escaped — and un-escaping by hand corrupts a backslash
+# followed by t, r or n. C:\temp arrives as C:\\temp, and a left-to-right pass
+# reads the second backslash plus `t` as an escaped tab, yielding C:\<TAB>emp.
+# (C:\dir, a\b and \d+ round-trip intact; only those three letters collide.)
+# Emitting raw values between control-character separators means
+# nothing is ever escaped, so nothing has to be decoded: review bodies keep their
+# real newlines, tabs, quotes, and backslashes.
+#
+# Residual: a body containing a literal 0x1f/0x1e byte would split a field or
+# record. Traded knowingly — those control bytes are far rarer in PR prose than
+# the \t / \r / \n sequences the escaping approach corrupted.
+readonly FS=$'\037'   # unit separator  — between fields
+readonly RS=$'\036'   # record separator — between rows
 
-# jq's @tsv escapes \t \n \r \\ inside values, so the only real tab bytes in its
-# output are separators — safe to translate wholesale.
-tsv_rows() { jq -r "$1" | tr '\t' "$FS"; }
-
-# Undo @tsv's escaping for free text, so multi-line review bodies reach the event
-# as real newlines. jq re-escapes them when building the JSON, keeping one line.
-unescape_tsv() {
-  local s="$1"
-  s="${s//\\t/$'\t'}"
-  s="${s//\\r/$'\r'}"
-  s="${s//\\n/$'\n'}"
-  printf '%s' "${s//\\\\/\\}"
-}
+# $1 is a jq expression producing an ARRAY per row.
+rows() { jq -j "$1"' | join("\u001f") + "\u001e"'; }
 
 truncate_body() {
   local body="$1"
@@ -215,7 +266,7 @@ poll_checks() {
   total="$(printf '%s' "$checks" | jq 'length')"
   (( total == 0 )) && return 1
 
-  while IFS="$FS" read -r name bucket state workflow link; do
+  while IFS="$FS" read -r -d "$RS" name bucket state workflow link; do
     [[ -z "$name" ]] && continue
     local key="check:${link:-$name}:${bucket}"
     seen "$key" && continue
@@ -223,12 +274,20 @@ poll_checks() {
     emit check name "$name" bucket "$bucket" state "$state" \
                 workflow "$workflow" url "$link"
   done < <(printf '%s' "$checks" \
-            | tsv_rows '.[] | select(.bucket != "pending")
-                        | [.name, .bucket, .state, (.workflow // ""), (.link // "")] | @tsv')
+            | rows '.[] | select(.bucket != "pending")
+                    | [.name, .bucket, .state, (.workflow // ""), (.link // "")]')
 
   concluded="$(printf '%s' "$checks" | jq '[.[] | select(.bucket != "pending")] | length')"
-  if (( concluded == total )) && ! seen "checks_done:${total}"; then
-    mark_seen "checks_done:${total}"
+  # Key on the identity of the concluded set, not its size. One watcher spans the
+  # whole PR, so a re-run or a new push produces a fresh set of job URLs; keying
+  # on the count alone would report the first completion and stay silent for
+  # every later one, including a run that goes from green to red.
+  local done_key
+  done_key="checks_done:$(printf '%s' "$checks" \
+    | jq -r '[.[] | "\(.link // .name):\(.bucket)"] | sort | join("|")' \
+    | shasum -a 256 | awk '{print $1}')"
+  if (( concluded == total )) && ! seen "$done_key"; then
+    mark_seen "$done_key"
     emit checks_done \
       total "$total" \
       failed "$(printf '%s' "$checks" | jq '[.[] | select(.bucket == "fail" or .bucket == "cancel")] | length')" \
@@ -251,23 +310,23 @@ poll_conversation() {
             --json state,comments,reviews 2>/dev/null || true)"
   printf '%s' "$view" | jq -e 'type == "object"' >/dev/null 2>&1 || return 1
 
-  while IFS="$FS" read -r id author body url; do
+  while IFS="$FS" read -r -d "$RS" id author body url; do
     [[ -z "$id" ]] && continue
     seen "comment:$id" && continue
     mark_seen "comment:$id"
-    emit comment author "$author" body "$(truncate_body "$(unescape_tsv "$body")")" url "$url"
+    emit comment author "$author" body "$(truncate_body "$body")" url "$url"
   done < <(printf '%s' "$view" \
-            | tsv_rows '.comments[]? | [.id, (.author.login // "?"), (.body // ""), (.url // "")] | @tsv')
+            | rows '.comments[]? | [(.id|tostring), (.author.login // "?"), (.body // ""), (.url // "")]')
 
-  while IFS="$FS" read -r id author review_state body; do
+  while IFS="$FS" read -r -d "$RS" id author review_state body; do
     [[ -z "$id" ]] && continue
     seen "review:$id" && continue
     mark_seen "review:$id"
     emit review author "$author" state "$review_state" \
-                body "$(truncate_body "$(unescape_tsv "$body")")" \
+                body "$(truncate_body "$body")" \
                 url "https://github.com/$slug/pull/$pr_number"
   done < <(printf '%s' "$view" \
-            | tsv_rows '.reviews[]? | [.id, (.author.login // "?"), (.state // ""), (.body // "")] | @tsv')
+            | rows '.reviews[]? | [(.id|tostring), (.author.login // "?"), (.state // ""), (.body // "")]')
 
   pr_state="$(printf '%s' "$view" | jq -r '.state // "OPEN"')"
 }
@@ -277,14 +336,14 @@ poll_inline_comments() {
   inline="$(gh api "repos/$slug/pulls/$pr_number/comments?per_page=100" 2>/dev/null || true)"
   printf '%s' "$inline" | jq -e 'type == "array"' >/dev/null 2>&1 || return 0
 
-  while IFS="$FS" read -r id author path body url; do
+  while IFS="$FS" read -r -d "$RS" id author path body url; do
     [[ -z "$id" ]] && continue
     seen "inline:$id" && continue
     mark_seen "inline:$id"
     emit review_comment author "$author" path "$path" \
-                        body "$(truncate_body "$(unescape_tsv "$body")")" url "$url"
+                        body "$(truncate_body "$body")" url "$url"
   done < <(printf '%s' "$inline" \
-            | tsv_rows '.[] | [.id, (.user.login // "?"), (.path // ""), (.body // ""), (.html_url // "")] | @tsv')
+            | rows '.[] | [(.id|tostring), (.user.login // "?"), (.path // ""), (.body // ""), (.html_url // "")]')
 }
 
 # ── main ─────────────────────────────────────────────────────────────────────
@@ -301,20 +360,16 @@ fi
 
 emit watch_start url "https://github.com/$slug/pull/$pr_number" interval "$interval"
 
-last_progress=$SECONDS
+started=$SECONDS
+last_contact=$SECONDS
 while :; do
   poll_checks
   poll_inline_comments
-  pr_state="OPEN"        # poll_conversation overwrites; a failed poll keeps watching
-  poll_conversation
-
-  # Any new line written since the last pass counts as progress.
-  if [[ -s "$seen_file" ]]; then
-    current_seen="$(wc -l < "$seen_file" 2>/dev/null | tr -d ' ')"
-    if [[ "${current_seen:-0}" != "${previous_seen:-}" ]]; then
-      previous_seen="$current_seen"
-      last_progress=$SECONDS
-    fi
+  # Cleared each pass: only a successful poll may declare a terminal state, so a
+  # failed one leaves this empty and the watch continues.
+  pr_state=""
+  if poll_conversation; then
+    last_contact=$SECONDS
   fi
 
   if [[ "$pr_state" == "MERGED" || "$pr_state" == "CLOSED" ]]; then
@@ -324,8 +379,19 @@ while :; do
 
   (( once )) && break
 
-  if (( SECONDS - last_progress > idle_timeout )); then
-    emit watch_end reason "idle for ${idle_timeout}s"
+  # Give up on LOST CONTACT, never on silence. A PR with green CI awaiting human
+  # review emits nothing for hours or days; an earlier version measured "time
+  # since the last new event" and so stopped watching long before the merge it
+  # was supposed to report. A poll that reaches GitHub and confirms the PR is
+  # still open IS liveness, even when it yields no new events.
+  if (( SECONDS - last_contact > idle_timeout )); then
+    emit watch_end reason "no contact with PR for ${idle_timeout}s"
+    break
+  fi
+
+  # Absolute backstop so an abandoned PR cannot leak a poller forever.
+  if (( max_lifetime > 0 && SECONDS - started > max_lifetime )); then
+    emit watch_end reason "max lifetime ${max_lifetime}s reached before merge"
     break
   fi
 

--- a/.agents/watch/pr-watch.sh
+++ b/.agents/watch/pr-watch.sh
@@ -1,0 +1,333 @@
+#!/usr/bin/env bash
+# Agent-agnostic CI + PR-comment watcher.
+#
+# Armed by .githooks/pre-push after a push, so it runs identically for Claude
+# Code, Codex, opencode, and a human at a terminal. Emits one JSON object per
+# line — to stdout and to an append-only log — as checks conclude and as
+# comments/reviews arrive.
+#
+# Consumers:
+#   Claude Code  .agents/hooks/post-remote-write-watch.sh arms a Monitor on the log
+#   other agents tail the log, or run this in the foreground
+#   humans       tail -f "$(git rev-parse --git-path pr-watch)"/<branch>.jsonl
+#
+# Usage:
+#   pr-watch.sh --branch <name> [--sha <sha>]   # arm for a just-pushed branch
+#   pr-watch.sh --pr <number>                   # watch a known PR
+#   pr-watch.sh --pr <number> --once            # one poll pass, then exit
+#
+# Env:
+#   BOXLITE_PR_WATCH=0        disable entirely (checked by the caller and here)
+#   PR_WATCH_INTERVAL         poll seconds (default 30; GitHub rate limits)
+#   PR_WATCH_IDLE_TIMEOUT     give up after this many idle seconds (default 7200)
+#
+# Design notes
+# ------------
+# * No `set -e`: a daemon must outlive a transient `gh` failure. Every network
+#   call is `|| true`-guarded and its output validated before use.
+# * Every terminal bucket is emitted, not just `pass`. A watcher that reports
+#   only success is indistinguishable from one that died — silence must never
+#   read as "still green".
+# * De-dup is by a stable key per observation, persisted next to the log, so a
+#   restarted watcher does not replay the whole history.
+#
+# Tests: bash .agents/watch/pr-watch.test.sh
+set -uo pipefail
+
+readonly DEFAULT_INTERVAL=30
+readonly DEFAULT_IDLE_TIMEOUT=7200
+readonly BODY_MAX_CHARS=600
+
+branch=""
+sha=""
+pr_number=""
+once=0
+
+usage() {
+  sed -n '2,20p' "$0" | sed 's/^# \{0,1\}//'
+  exit "${1:-0}"
+}
+
+while (( $# )); do
+  case "$1" in
+    --branch) branch="${2:-}"; shift 2 ;;
+    --sha)    sha="${2:-}";    shift 2 ;;
+    --pr)     pr_number="${2:-}"; shift 2 ;;
+    --once)   once=1; shift ;;
+    -h|--help) usage 0 ;;
+    *) printf 'pr-watch: unknown argument: %s\n' "$1" >&2; usage 1 ;;
+  esac
+done
+
+[[ "${BOXLITE_PR_WATCH:-1}" == "0" ]] && exit 0
+
+interval="${PR_WATCH_INTERVAL:-$DEFAULT_INTERVAL}"
+idle_timeout="${PR_WATCH_IDLE_TIMEOUT:-$DEFAULT_IDLE_TIMEOUT}"
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+state_dir="$(git -C "$repo_root" rev-parse --git-path pr-watch 2>/dev/null || echo "$repo_root/.git/pr-watch")"
+[[ "$state_dir" != /* ]] && state_dir="$repo_root/$state_dir"
+mkdir -p "$state_dir"
+
+# Slug from the remote URL rather than `gh repo view` — deterministic, offline,
+# and correct before the push has landed.
+repo_slug() {
+  local url
+  url="$(git -C "$repo_root" remote get-url origin 2>/dev/null || echo '')"
+  case "$url" in
+    git@*:*)      printf '%s' "${url#*:}" ;;
+    https://*|ssh://*) printf '%s' "${url#*://*/}" ;;
+    *)            printf '%s' "$url" ;;
+  esac | sed 's/\.git$//'
+}
+slug="$(repo_slug)"
+
+if [[ -z "$branch" && -n "$pr_number" ]]; then
+  branch="pr-${pr_number}"
+fi
+if [[ -z "$branch" ]]; then
+  printf 'pr-watch: need --branch or --pr\n' >&2
+  usage 1
+fi
+
+safe_branch="${branch//\//-}"
+event_log="$state_dir/${safe_branch}.jsonl"
+seen_file="$state_dir/${safe_branch}.seen"
+lock_dir="$state_dir/${safe_branch}.lock"
+touch "$event_log" "$seen_file" 2>/dev/null || true
+
+# Atomic single-instance guard: repeated pushes to the same branch must not
+# stack daemons all polling the same PR.
+if ! mkdir "$lock_dir" 2>/dev/null; then
+  exit 0
+fi
+# Signal traps must exit explicitly. A bare `trap '<cleanup>' TERM` runs the
+# handler and then RESUMES the loop — the daemon would survive every kill short
+# of SIGKILL, and each push would leave another one running.
+trap 'rm -rf "$lock_dir"' EXIT
+trap 'rm -rf "$lock_dir"; exit 143' TERM
+trap 'rm -rf "$lock_dir"; exit 130' INT
+
+now_iso() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+
+# One event = one line of JSON on stdout and in the log. jq builds it so bodies
+# with quotes/newlines can't corrupt the stream.
+emit() {
+  local kind="$1"; shift
+  local line
+  line="$(jq -nc \
+    --arg ts "$(now_iso)" \
+    --arg kind "$kind" \
+    --arg pr "$pr_number" \
+    --arg branch "$branch" \
+    --args '$ARGS.positional
+            | ($ARGS.positional | length) as $n
+            | reduce range(0; $n; 2) as $i ({}; .[$ARGS.positional[$i]] = $ARGS.positional[$i+1])
+            | {ts:$ts, kind:$kind, pr:$pr, branch:$branch} + .' \
+    "$@" 2>/dev/null)"
+  [[ -z "$line" ]] && return 0
+  printf '%s\n' "$line" | tee -a "$event_log"
+}
+
+seen() { grep -qxF "$1" "$seen_file" 2>/dev/null; }
+mark_seen() { printf '%s\n' "$1" >> "$seen_file"; }
+
+# Field separator for jq @tsv rows. NOT a literal tab: bash treats tab as an IFS
+# *whitespace* character, so `read` collapses runs of them into one delimiter and
+# every row with an empty field (a check with no `workflow`, a comment with no
+# `path`) silently shifts its remaining values one column left. US (0x1f) is
+# non-whitespace, so each occurrence delimits exactly one field.
+readonly FS=$'\037'
+
+# jq's @tsv escapes \t \n \r \\ inside values, so the only real tab bytes in its
+# output are separators — safe to translate wholesale.
+tsv_rows() { jq -r "$1" | tr '\t' "$FS"; }
+
+# Undo @tsv's escaping for free text, so multi-line review bodies reach the event
+# as real newlines. jq re-escapes them when building the JSON, keeping one line.
+unescape_tsv() {
+  local s="$1"
+  s="${s//\\t/$'\t'}"
+  s="${s//\\r/$'\r'}"
+  s="${s//\\n/$'\n'}"
+  printf '%s' "${s//\\\\/\\}"
+}
+
+truncate_body() {
+  local body="$1"
+  if (( ${#body} > BODY_MAX_CHARS )); then
+    printf '%s… [truncated, see url]' "${body:0:$BODY_MAX_CHARS}"
+  else
+    printf '%s' "$body"
+  fi
+}
+
+# ── discovery ────────────────────────────────────────────────────────────────
+
+# Wait for the pushed sha to appear on the remote. Arming happens in pre-push,
+# i.e. BEFORE the push completes, so polling the PR immediately would race.
+wait_for_push_landed() {
+  [[ -z "$sha" ]] && return 0
+  local deadline=$(( SECONDS + 300 ))
+  while (( SECONDS < deadline )); do
+    local remote_sha
+    remote_sha="$(git -C "$repo_root" ls-remote origin "refs/heads/$branch" 2>/dev/null | awk '{print $1}')"
+    [[ "$remote_sha" == "$sha" ]] && return 0
+    sleep 5
+  done
+  emit warn message "pushed sha never appeared on origin/$branch; watching anyway" sha "$sha"
+  return 0
+}
+
+# A push may precede `gh pr create` by minutes. Polling for the PR to appear is
+# what lets one pre-push arm cover PR creation too — no `gh` hook needed.
+resolve_pr_number() {
+  [[ -n "$pr_number" ]] && return 0
+  local deadline=$(( SECONDS + 900 )) found
+  while (( SECONDS < deadline )); do
+    found="$(gh pr list --repo "$slug" --head "$branch" --state open \
+              --json number --jq '.[0].number // empty' 2>/dev/null || true)"
+    if [[ "$found" =~ ^[0-9]+$ ]]; then
+      pr_number="$found"
+      emit pr_found url "https://github.com/$slug/pull/$found"
+      return 0
+    fi
+    (( once )) && return 1
+    sleep "$interval"
+  done
+  return 1
+}
+
+# ── polling ──────────────────────────────────────────────────────────────────
+
+# Emits every check that has left `pending`, including skips, exactly once.
+# Matrix jobs share a name in this repo (the `${{ matrix.* }}` expression is not
+# expanded in the check name), so `link` is the de-dup discriminator.
+poll_checks() {
+  local checks
+  checks="$(gh pr checks "$pr_number" --repo "$slug" \
+              --json name,state,bucket,workflow,link 2>/dev/null || true)"
+  if ! printf '%s' "$checks" | jq -e 'type == "array"' >/dev/null 2>&1; then
+    return 1
+  fi
+
+  local total concluded
+  total="$(printf '%s' "$checks" | jq 'length')"
+  (( total == 0 )) && return 1
+
+  while IFS="$FS" read -r name bucket state workflow link; do
+    [[ -z "$name" ]] && continue
+    local key="check:${link:-$name}:${bucket}"
+    seen "$key" && continue
+    mark_seen "$key"
+    emit check name "$name" bucket "$bucket" state "$state" \
+                workflow "$workflow" url "$link"
+  done < <(printf '%s' "$checks" \
+            | tsv_rows '.[] | select(.bucket != "pending")
+                        | [.name, .bucket, .state, (.workflow // ""), (.link // "")] | @tsv')
+
+  concluded="$(printf '%s' "$checks" | jq '[.[] | select(.bucket != "pending")] | length')"
+  if (( concluded == total )) && ! seen "checks_done:${total}"; then
+    mark_seen "checks_done:${total}"
+    emit checks_done \
+      total "$total" \
+      failed "$(printf '%s' "$checks" | jq '[.[] | select(.bucket == "fail" or .bucket == "cancel")] | length')" \
+      passed "$(printf '%s' "$checks" | jq '[.[] | select(.bucket == "pass")] | length')" \
+      skipped "$(printf '%s' "$checks" | jq '[.[] | select(.bucket == "skipping")] | length')"
+  fi
+  return 0
+}
+
+# Issue comments + review submissions. Inline review threads live in neither of
+# these and are fetched separately below.
+#
+# Reports the PR state by assigning the global `pr_state`, NOT by echoing it.
+# `emit` writes events to stdout, so a caller using `state=$(poll_conversation)`
+# would capture every comment and review into that variable instead of letting
+# them reach the event stream — they'd survive only in the log file.
+poll_conversation() {
+  local view
+  view="$(gh pr view "$pr_number" --repo "$slug" \
+            --json state,comments,reviews 2>/dev/null || true)"
+  printf '%s' "$view" | jq -e 'type == "object"' >/dev/null 2>&1 || return 1
+
+  while IFS="$FS" read -r id author body url; do
+    [[ -z "$id" ]] && continue
+    seen "comment:$id" && continue
+    mark_seen "comment:$id"
+    emit comment author "$author" body "$(truncate_body "$(unescape_tsv "$body")")" url "$url"
+  done < <(printf '%s' "$view" \
+            | tsv_rows '.comments[]? | [.id, (.author.login // "?"), (.body // ""), (.url // "")] | @tsv')
+
+  while IFS="$FS" read -r id author review_state body; do
+    [[ -z "$id" ]] && continue
+    seen "review:$id" && continue
+    mark_seen "review:$id"
+    emit review author "$author" state "$review_state" \
+                body "$(truncate_body "$(unescape_tsv "$body")")" \
+                url "https://github.com/$slug/pull/$pr_number"
+  done < <(printf '%s' "$view" \
+            | tsv_rows '.reviews[]? | [.id, (.author.login // "?"), (.state // ""), (.body // "")] | @tsv')
+
+  pr_state="$(printf '%s' "$view" | jq -r '.state // "OPEN"')"
+}
+
+poll_inline_comments() {
+  local inline
+  inline="$(gh api "repos/$slug/pulls/$pr_number/comments?per_page=100" 2>/dev/null || true)"
+  printf '%s' "$inline" | jq -e 'type == "array"' >/dev/null 2>&1 || return 0
+
+  while IFS="$FS" read -r id author path body url; do
+    [[ -z "$id" ]] && continue
+    seen "inline:$id" && continue
+    mark_seen "inline:$id"
+    emit review_comment author "$author" path "$path" \
+                        body "$(truncate_body "$(unescape_tsv "$body")")" url "$url"
+  done < <(printf '%s' "$inline" \
+            | tsv_rows '.[] | [.id, (.user.login // "?"), (.path // ""), (.body // ""), (.html_url // "")] | @tsv')
+}
+
+# ── main ─────────────────────────────────────────────────────────────────────
+
+command -v gh >/dev/null 2>&1 || { printf 'pr-watch: gh not found\n' >&2; exit 127; }
+command -v jq >/dev/null 2>&1 || { printf 'pr-watch: jq not found\n' >&2; exit 127; }
+
+wait_for_push_landed
+
+if ! resolve_pr_number; then
+  emit watch_end reason "no open PR found for branch"
+  exit 0
+fi
+
+emit watch_start url "https://github.com/$slug/pull/$pr_number" interval "$interval"
+
+last_progress=$SECONDS
+while :; do
+  poll_checks
+  poll_inline_comments
+  pr_state="OPEN"        # poll_conversation overwrites; a failed poll keeps watching
+  poll_conversation
+
+  # Any new line written since the last pass counts as progress.
+  if [[ -s "$seen_file" ]]; then
+    current_seen="$(wc -l < "$seen_file" 2>/dev/null | tr -d ' ')"
+    if [[ "${current_seen:-0}" != "${previous_seen:-}" ]]; then
+      previous_seen="$current_seen"
+      last_progress=$SECONDS
+    fi
+  fi
+
+  if [[ "$pr_state" == "MERGED" || "$pr_state" == "CLOSED" ]]; then
+    emit watch_end reason "PR ${pr_state}"
+    break
+  fi
+
+  (( once )) && break
+
+  if (( SECONDS - last_progress > idle_timeout )); then
+    emit watch_end reason "idle for ${idle_timeout}s"
+    break
+  fi
+
+  sleep "$interval"
+done

--- a/.agents/watch/pr-watch.test.sh
+++ b/.agents/watch/pr-watch.test.sh
@@ -1,0 +1,310 @@
+#!/usr/bin/env bash
+# Tests for .agents/watch/pr-watch.sh and the arm point in .githooks/pre-push.
+#
+# Runs against a scratch repo with a stubbed `gh` on PATH — no network, and no
+# chained framework hook to trigger.
+#
+# Covers:
+#   1. Event emission: one per concluded check, every terminal bucket, dedup.
+#   2. The empty-field regression: a check with no `workflow` must not shift
+#      `link` into the workflow column.
+#   3. Single-instance lock.
+#   4. pre-push arming: branch refs armed, deletions/tags skipped, opt-out.
+#
+# Run with:  bash .agents/watch/pr-watch.test.sh
+# Exits non-zero on any failure.
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+WATCHER="$REPO_ROOT/.agents/watch/pr-watch.sh"
+PREPUSH="$REPO_ROOT/.githooks/pre-push"
+TMP="$(mktemp -d)"
+trap 'pkill -f "pr-watch.sh --branch" 2>/dev/null; rm -rf "$TMP"' EXIT
+
+pass=0
+fail=0
+
+ok() { pass=$((pass + 1)); printf '  PASS  %s\n' "$1"; }
+no() { fail=$((fail + 1)); printf '  FAIL  %s\n     %s\n' "$1" "${2:-}"; }
+
+check() {
+  local desc="$1" actual="$2" expect="$3"
+  if [[ "$actual" == "$expect" ]]; then ok "$desc"; else no "$desc" "got=[$actual] want=[$expect]"; fi
+}
+
+# ── scratch repo + gh stub ───────────────────────────────────────────────────
+
+REPO="$TMP/repo"
+mkdir -p "$REPO"
+git init -q "$REPO"
+# A local bare remote, not a github URL: the watcher's first act is an ls-remote
+# wait, and this keeps that offline and instant instead of dialing out.
+git init -q --bare "$TMP/origin.git"
+git -C "$REPO" remote add origin "$TMP/origin.git"
+git -C "$REPO" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+
+# pre-push resolves the watcher against ITS repo root, so the scratch repo needs
+# its own copy — the hook under test must find it where a real checkout would.
+mkdir -p "$REPO/.agents/watch"
+cp "$WATCHER" "$REPO/.agents/watch/pr-watch.sh"
+SCRATCH_WATCHER="$REPO/.agents/watch/pr-watch.sh"
+
+STUB="$TMP/bin"
+mkdir -p "$STUB"
+
+# Fixture knobs the stub reads at call time, so a test can change CI state
+# without rewriting the stub.
+export FIXTURE_DIR="$TMP/fixtures"
+mkdir -p "$FIXTURE_DIR"
+
+cat > "$STUB/gh" <<'STUB_EOF'
+#!/usr/bin/env bash
+case "$1 $2" in
+  "pr checks")  cat "$FIXTURE_DIR/checks.json" ;;
+  "pr view")    cat "$FIXTURE_DIR/view.json" ;;
+  "pr list")    cat "$FIXTURE_DIR/prnumber.txt" 2>/dev/null || true ;;
+  "api "*|"api")
+                cat "$FIXTURE_DIR/inline.json" ;;
+  *) exit 1 ;;
+esac
+STUB_EOF
+chmod +x "$STUB/gh"
+export PATH="$STUB:$PATH"
+
+write_fixtures() {
+  cat > "$FIXTURE_DIR/checks.json" <<'EOF'
+[
+  {"name":"CodeQL","state":"SUCCESS","bucket":"pass","workflow":"","link":"https://gh/runs/1"},
+  {"name":"Lint (conclusion)","state":"SUCCESS","bucket":"pass","workflow":"Lint and Format","link":"https://gh/runs/2"},
+  {"name":"Test (conclusion)","state":"FAILURE","bucket":"fail","workflow":"Test","link":"https://gh/runs/3"},
+  {"name":"Rust Tests","state":"SKIPPED","bucket":"skipping","workflow":"Test","link":"https://gh/runs/4"},
+  {"name":"E2E local","state":"IN_PROGRESS","bucket":"pending","workflow":"E2E local","link":"https://gh/runs/5"}
+]
+EOF
+  cat > "$FIXTURE_DIR/view.json" <<'EOF'
+{"state":"OPEN",
+ "comments":[{"id":"C1","author":{"login":"boxlite-agent"},"body":"line one\nline two","url":"https://gh/c/1"}],
+ "reviews":[{"id":"R1","author":{"login":"coderabbitai"},"state":"COMMENTED","body":"nit"}]}
+EOF
+  cat > "$FIXTURE_DIR/inline.json" <<'EOF'
+[{"id":"I1","user":{"login":"coderabbitai"},"path":"src/main.rs","body":"inline note","html_url":"https://gh/i/1"}]
+EOF
+  printf '42\n' > "$FIXTURE_DIR/prnumber.txt"
+}
+write_fixtures
+
+run_watch() { (cd "$REPO" && bash "$WATCHER" "$@" 2>&1); }
+events_of() { grep "\"kind\":\"$1\"" <<<"$2" 2>/dev/null; }
+reset_state() { rm -rf "$REPO/.git/pr-watch"; }
+
+# ── 1. event emission ────────────────────────────────────────────────────────
+
+echo "## Event emission"
+reset_state
+OUT="$(run_watch --pr 42 --once)"
+
+check "every line is valid JSON" \
+  "$(jq -e . <<<"$OUT" >/dev/null 2>&1 && echo yes || echo no)" "yes"
+
+check "emits 4 concluded checks, not the pending one" \
+  "$(events_of check "$OUT" | wc -l | tr -d ' ')" "4"
+
+check "emits the FAILING check (silence != success)" \
+  "$(events_of check "$OUT" | jq -r 'select(.bucket=="fail") | .name')" "Test (conclusion)"
+
+check "emits the skipped check too" \
+  "$(events_of check "$OUT" | jq -r 'select(.bucket=="skipping") | .name')" "Rust Tests"
+
+check "no checks_done while one check is still pending" \
+  "$(events_of checks_done "$OUT" | wc -l | tr -d ' ')" "0"
+
+check "emits the issue comment" \
+  "$(events_of comment "$OUT" | jq -r '.author')" "boxlite-agent"
+
+check "emits the review" \
+  "$(events_of review "$OUT" | jq -r '.author + ":" + .state')" "coderabbitai:COMMENTED"
+
+check "emits the inline review comment with its path" \
+  "$(events_of review_comment "$OUT" | jq -r '.path')" "src/main.rs"
+
+# ── 2. the empty-field regression ────────────────────────────────────────────
+#
+# `IFS=$'\t' read` collapses runs of tabs, so a check with an empty `workflow`
+# used to shift `link` one column left — CodeQL reported its URL as its workflow
+# name and an empty url. Guard both columns.
+
+echo
+echo "## Regression: empty field must not shift columns"
+CODEQL="$(events_of check "$OUT" | jq -c 'select(.name=="CodeQL")')"
+check "empty workflow stays empty" \
+  "$(jq -r '.workflow' <<<"$CODEQL")" ""
+check "link lands in url, not workflow" \
+  "$(jq -r '.url' <<<"$CODEQL")" "https://gh/runs/1"
+check "populated workflow still lands correctly" \
+  "$(events_of check "$OUT" | jq -r 'select(.name=="Lint (conclusion)") | .workflow')" "Lint and Format"
+
+# ── 3. body handling ─────────────────────────────────────────────────────────
+
+echo
+echo "## Body handling"
+check "multi-line comment body survives as one JSON line with real newlines" \
+  "$(events_of comment "$OUT" | jq -r '.body' | wc -l | tr -d ' ')" "2"
+
+# ── 4. dedup + lock ──────────────────────────────────────────────────────────
+
+echo
+echo "## Dedup and locking"
+OUT2="$(run_watch --pr 42 --once)"
+check "second pass re-emits nothing" \
+  "$(events_of check "$OUT2" | wc -l | tr -d ' ')" "0"
+
+# A new check appearing is still emitted after the dedup pass.
+jq '. + [{"name":"New Job","state":"SUCCESS","bucket":"pass","workflow":"Test","link":"https://gh/runs/9"}]' \
+  "$FIXTURE_DIR/checks.json" > "$FIXTURE_DIR/checks.tmp" && mv "$FIXTURE_DIR/checks.tmp" "$FIXTURE_DIR/checks.json"
+OUT3="$(run_watch --pr 42 --once)"
+check "a newly-concluded check IS emitted after dedup" \
+  "$(events_of check "$OUT3" | jq -r '.name')" "New Job"
+
+mkdir -p "$REPO/.git/pr-watch/pr-42.lock"
+OUT4="$(run_watch --pr 42 --once)"
+check "held lock makes a second instance exit silently" \
+  "$(printf '%s' "$OUT4" | wc -c | tr -d ' ')" "0"
+rmdir "$REPO/.git/pr-watch/pr-42.lock"
+
+# ── 5. terminal states ───────────────────────────────────────────────────────
+
+echo
+echo "## Terminal states"
+reset_state
+jq '[.[] | select(.bucket != "pending")]' "$FIXTURE_DIR/checks.json" > "$FIXTURE_DIR/checks.tmp" \
+  && mv "$FIXTURE_DIR/checks.tmp" "$FIXTURE_DIR/checks.json"
+OUT5="$(run_watch --pr 42 --once)"
+check "checks_done fires once all checks conclude" \
+  "$(events_of checks_done "$OUT5" | jq -r '.failed')" "1"
+
+reset_state
+jq '.state = "MERGED"' "$FIXTURE_DIR/view.json" > "$FIXTURE_DIR/view.tmp" && mv "$FIXTURE_DIR/view.tmp" "$FIXTURE_DIR/view.json"
+OUT6="$(run_watch --pr 42)"     # no --once: must still exit, PR is MERGED
+check "merged PR ends the watch without --once" \
+  "$(events_of watch_end "$OUT6" | jq -r '.reason')" "PR MERGED"
+
+write_fixtures
+
+# ── 6. the stream reader ─────────────────────────────────────────────────────
+
+echo
+echo "## Stream reader"
+STREAM="$REPO_ROOT/.agents/watch/pr-watch-stream.sh"
+SLOG="$TMP/stream.jsonl"
+printf '%s\n' '{"kind":"watch_start"}' '{"kind":"check","bucket":"pass"}' > "$SLOG"
+( sleep 2; printf '%s\n' '{"kind":"check","bucket":"fail"}' >> "$SLOG"
+  sleep 2; printf '%s\n' '{"kind":"watch_end","reason":"PR MERGED"}' >> "$SLOG" ) &
+SOUT="$(bash "$STREAM" "$SLOG" 1)"
+SRC=$?
+wait
+
+check "replays existing lines and follows new ones" \
+  "$(printf '%s\n' "$SOUT" | wc -l | tr -d ' ')" "4"
+check "delivers watch_end before terminating" \
+  "$(printf '%s\n' "$SOUT" | tail -1 | jq -r '.kind')" "watch_end"
+check "exits 0 at watch_end instead of following forever" "$SRC" "0"
+
+MISSING="$(PR_WATCH_STREAM_WAIT=2 bash "$STREAM" "$TMP/does-not-exist.jsonl" 1 2>/dev/null)"
+check "a log that never appears reports an error instead of hanging" \
+  "$(printf '%s' "$MISSING" | jq -r '.kind')" "stream_error"
+
+# ── 7. pre-push arming ───────────────────────────────────────────────────────
+#
+# Drive the hook the way git does: ref updates on stdin. is_agent is forced off
+# so the audit gate is skipped — this suite tests the arm, not the gate.
+
+echo
+echo "## pre-push arming"
+
+ZERO="0000000000000000000000000000000000000000"
+SHA="1111111111111111111111111111111111111111"
+
+# TERM does not take effect while the daemon sits in `sleep`: bash runs a trap
+# only after the foreground child returns. Polling for actual absence keeps a
+# still-dying watcher from being misread as the NEXT case's arm.
+kill_watchers() {
+  pkill -f "pr-watch.sh --branch" 2>/dev/null
+  local deadline=$(( SECONDS + 15 ))
+  while (( SECONDS < deadline )); do
+    pgrep -f "pr-watch.sh --branch" >/dev/null 2>&1 || return 0
+    sleep 1
+  done
+  pkill -9 -f "pr-watch.sh --branch" 2>/dev/null
+  sleep 1
+}
+
+# A daemon that ignores SIGTERM is unkillable in practice, and every push would
+# leave another one polling. Guards the signal traps in pr-watch.sh: a bare
+# `trap '<cleanup>' TERM` runs the handler and then RESUMES the loop.
+term_kills_daemon() {
+  kill_watchers
+  reset_state
+  ( cd "$REPO" && nohup bash "$SCRATCH_WATCHER" --branch termprobe --sha deadbeef \
+      >/dev/null 2>&1 & )
+  sleep 2
+  pgrep -f "pr-watch.sh --branch termprobe" >/dev/null 2>&1 || { echo "never-started"; return; }
+  pkill -TERM -f "pr-watch.sh --branch termprobe" 2>/dev/null
+  # Generous: bash defers a trap until the foreground `sleep` returns.
+  local deadline=$(( SECONDS + 20 ))
+  while (( SECONDS < deadline )); do
+    pgrep -f "pr-watch.sh --branch termprobe" >/dev/null 2>&1 || { echo "died"; return; }
+    sleep 1
+  done
+  echo "survived"
+  pkill -9 -f "pr-watch.sh --branch termprobe" 2>/dev/null
+}
+
+arm() {
+  local stdin_line="$1" ; shift
+  kill_watchers
+  reset_state
+  # The watcher's first act is a bounded ls-remote wait against the local bare
+  # remote, so it stays alive long enough to observe without touching a network.
+  (cd "$REPO" && printf '%s\n' "$stdin_line" \
+    | env -u CLAUDECODE -u CODEX_SANDBOX -u AGENT_GATED ${@+"$@"} \
+      bash "$PREPUSH" origin "$TMP/origin.git" >/dev/null 2>&1)
+  sleep 1
+  local result
+  if pgrep -f "pr-watch.sh --branch" >/dev/null 2>&1; then result=armed; else result=idle; fi
+  kill_watchers
+  printf '%s' "$result"
+}
+
+check "branch push arms a watcher" \
+  "$(arm "refs/heads/feat $SHA refs/heads/feat $ZERO")" "armed"
+
+check "branch DELETION arms nothing" \
+  "$(arm "refs/heads/feat $ZERO refs/heads/feat $SHA")" "idle"
+
+check "tag push arms nothing" \
+  "$(arm "refs/tags/v1 $SHA refs/tags/v1 $ZERO")" "idle"
+
+check "BOXLITE_PR_WATCH=0 opts out" \
+  "$(arm "refs/heads/feat $SHA refs/heads/feat $ZERO" BOXLITE_PR_WATCH=0)" "idle"
+
+check "daemon dies on SIGTERM (traps must exit, not resume)" \
+  "$(term_kills_daemon)" "died"
+
+# The gate's own exit code must be untouched by the arm.
+reset_state
+(cd "$REPO" && printf 'refs/heads/feat %s refs/heads/feat %s\n' "$SHA" "$ZERO" \
+  | env -u CLAUDECODE -u CODEX_SANDBOX -u AGENT_GATED bash "$PREPUSH" origin url >/dev/null 2>&1)
+check "hook still exits 0 after arming" "$?" "0"
+kill_watchers
+
+# A missing watcher must not break pushes for checkouts that predate this file.
+reset_state
+mv "$SCRATCH_WATCHER" "$TMP/moved-watcher.sh"
+(cd "$REPO" && printf 'refs/heads/feat %s refs/heads/feat %s\n' "$SHA" "$ZERO" \
+  | env -u CLAUDECODE -u CODEX_SANDBOX -u AGENT_GATED bash "$PREPUSH" origin url >/dev/null 2>&1)
+check "absent watcher does not fail the push" "$?" "0"
+mv "$TMP/moved-watcher.sh" "$SCRATCH_WATCHER"
+
+echo
+printf 'pr-watch: %d passed, %d failed\n' "$pass" "$fail"
+(( fail == 0 ))

--- a/.agents/watch/pr-watch.test.sh
+++ b/.agents/watch/pr-watch.test.sh
@@ -15,11 +15,22 @@
 # Exits non-zero on any failure.
 set -uo pipefail
 
-REPO_ROOT="$(git rev-parse --show-toplevel)"
+# Resolve from THIS script's location, not the caller's cwd. Same reasoning as
+# .agents/hooks/post-remote-write-watch.test.sh: cwd-derived paths make a
+# two-side check silently exercise a different checkout's copy and report a pass.
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 WATCHER="$REPO_ROOT/.agents/watch/pr-watch.sh"
 PREPUSH="$REPO_ROOT/.githooks/pre-push"
 TMP="$(mktemp -d)"
-trap 'pkill -f "pr-watch.sh --branch" 2>/dev/null; rm -rf "$TMP"' EXIT
+# Match ONLY this suite's scratch watcher. A bare "pr-watch.sh --branch" pattern
+# also matches a real watcher following a real PR on this machine, so running the
+# tests would silently kill it. Set once $REPO exists; the trap reads it lazily.
+# The fallback matters: this trap is armed before $REPO is assigned, and an empty
+# pattern is never the cleanup being asked for. On this host (BSD pkill) it errors
+# with "empty (sub)expression"; do not rely on that being the failure mode
+# everywhere.
+watcher_pat() { printf '%s' "${REPO:-__pr_watch_no_repo__}/.agents/watch/pr-watch.sh"; }
+trap 'pkill -f "$(watcher_pat)" 2>/dev/null; rm -rf "$TMP"' EXIT
 
 pass=0
 fail=0
@@ -94,6 +105,27 @@ EOF
 write_fixtures
 
 run_watch() { (cd "$REPO" && bash "$WATCHER" "$@" 2>&1); }
+
+# Every blocking call below waits on the code under test deciding to exit. If
+# that decision regresses the suite would hang and CI would report a timeout
+# instead of a named failing assertion, so bound them and let the assertion fail.
+# macOS ships no coreutils `timeout`; a watchdog subshell is portable.
+with_deadline() {
+  local secs="$1"; shift
+  ( "$@" ) & local job=$!
+  # The watchdog MUST NOT inherit stdout. It is a background child of the same
+  # command substitution, so while it holds the write end open `$(…)` cannot
+  # return — every call would block for the full deadline even when the job
+  # finished immediately.
+  ( sleep "$secs"; kill -TERM "$job" 2>/dev/null ) >/dev/null 2>&1 & local dog=$!
+  # Report the JOB's status. Returning the watchdog's would mask every exit code
+  # with the 143 from killing it, so an exit-code assertion could never pass.
+  local rc=0
+  wait "$job" 2>/dev/null || rc=$?
+  kill "$dog" 2>/dev/null
+  wait "$dog" 2>/dev/null || true
+  return "$rc"
+}
 events_of() { grep "\"kind\":\"$1\"" <<<"$2" 2>/dev/null; }
 reset_state() { rm -rf "$REPO/.git/pr-watch"; }
 
@@ -150,6 +182,23 @@ echo "## Body handling"
 check "multi-line comment body survives as one JSON line with real newlines" \
   "$(events_of comment "$OUT" | jq -r '.body' | wc -l | tr -d ' ')" "2"
 
+# Backslashes, tabs and quotes must all survive verbatim. @tsv escaped only the
+# first two — quotes pass through it untouched — and the hand-written decoder
+# then corrupted a backslash followed by t, r or n, hence `C:\temp` and `C:\new`
+# in the fixture. Escaped, `C:\temp` is `C:\\temp`, and a left-to-right pass
+# reads the second backslash plus `t` as a tab. A backslash before any other
+# letter (`C:\dir`, `a\b`, `\d+`) round-tripped fine, so a fixture without
+# t/r/n would have passed against the buggy decoder. The quote still earns its
+# place: it crosses the raw-separator to JSON re-encode boundary.
+reset_state
+jq '.comments[0].body = "win C:\\temp and C:\\new plus a \"quote\" and\ttab"' \
+  "$FIXTURE_DIR/view.json" > "$FIXTURE_DIR/v.tmp" && mv "$FIXTURE_DIR/v.tmp" "$FIXTURE_DIR/view.json"
+OUTB="$(run_watch --pr 42 --once)"
+check "backslashes survive verbatim (no escape-decoding corruption)" \
+  "$(events_of comment "$OUTB" | jq -r '.body')" \
+  "$(printf 'win C:\\temp and C:\\new plus a "quote" and\ttab')"
+write_fixtures
+
 # ── 4. dedup + lock ──────────────────────────────────────────────────────────
 
 echo
@@ -165,11 +214,33 @@ OUT3="$(run_watch --pr 42 --once)"
 check "a newly-concluded check IS emitted after dedup" \
   "$(events_of check "$OUT3" | jq -r '.name')" "New Job"
 
+# A lock owned by a LIVE process must be obeyed. $$ is this suite, definitely alive.
 mkdir -p "$REPO/.git/pr-watch/pr-42.lock"
+printf '%s' "$$" > "$REPO/.git/pr-watch/pr-42.lock/pid"
 OUT4="$(run_watch --pr 42 --once)"
-check "held lock makes a second instance exit silently" \
+check "lock held by a LIVE owner makes a second instance exit silently" \
   "$(printf '%s' "$OUT4" | wc -c | tr -d ' ')" "0"
-rmdir "$REPO/.git/pr-watch/pr-42.lock"
+
+# SIGKILL/OOM/reboot leaves a lock no trap could clear. Obeying it forever would
+# silently suppress every future watcher for the branch.
+#
+# Earn a provably-dead PID instead of hardcoding a "big" one: PID ranges are
+# platform-specific (macOS tops out at 99999, Linux pid_max is often 4194304),
+# so no literal is portably unusable. Spawn, reap, then assert it is gone.
+( exit 0 ) & dead_pid=$!
+wait "$dead_pid" 2>/dev/null
+kill -0 "$dead_pid" 2>/dev/null && no "fixture: PID $dead_pid still alive" "cannot test stale lock"
+printf '%s' "$dead_pid" > "$REPO/.git/pr-watch/pr-42.lock/pid"
+OUT4b="$(run_watch --pr 42 --once)"
+check "STALE lock (dead owner) is reclaimed, not obeyed" \
+  "$(events_of watch_start "$OUT4b" | jq -r '.pr')" "42"
+
+# A lock dir with no pid file at all — e.g. written by an older version.
+rm -rf "$REPO/.git/pr-watch/pr-42.lock"; mkdir -p "$REPO/.git/pr-watch/pr-42.lock"
+OUT4c="$(run_watch --pr 42 --once)"
+check "lock with no owner recorded is reclaimed" \
+  "$(events_of watch_start "$OUT4c" | jq -r '.pr')" "42"
+rm -rf "$REPO/.git/pr-watch/pr-42.lock"
 
 # ── 5. terminal states ───────────────────────────────────────────────────────
 
@@ -182,11 +253,67 @@ OUT5="$(run_watch --pr 42 --once)"
 check "checks_done fires once all checks conclude" \
   "$(events_of checks_done "$OUT5" | jq -r '.failed')" "1"
 
+check "checks_done does not repeat for the same set" \
+  "$(events_of checks_done "$(run_watch --pr 42 --once)" | wc -l | tr -d ' ')" "0"
+
+# A CI re-run keeps the check COUNT identical but produces new job URLs. Keying
+# the summary on the count alone reported the first completion and then went
+# silent forever — including for a re-run that turned red.
+jq '[.[] | .link |= sub("/runs/"; "/runs/re-") | .bucket = "pass" | .state = "SUCCESS"]' \
+  "$FIXTURE_DIR/checks.json" > "$FIXTURE_DIR/checks.tmp" && mv "$FIXTURE_DIR/checks.tmp" "$FIXTURE_DIR/checks.json"
+OUT5b="$(run_watch --pr 42 --once)"
+# 5 concluded checks by now: the 4 from write_fixtures plus the "New Job" added
+# in the dedup section above. All flipped to pass, so 0 failed / 5 passed.
+check "checks_done re-fires after a re-run with the same check count" \
+  "$(events_of checks_done "$OUT5b" | jq -r '.failed + "/" + .passed')" "0/5"
+
 reset_state
 jq '.state = "MERGED"' "$FIXTURE_DIR/view.json" > "$FIXTURE_DIR/view.tmp" && mv "$FIXTURE_DIR/view.tmp" "$FIXTURE_DIR/view.json"
-OUT6="$(run_watch --pr 42)"     # no --once: must still exit, PR is MERGED
+OUT6="$(with_deadline 30 run_watch --pr 42)"   # no --once: must still exit, PR is MERGED
 check "merged PR ends the watch without --once" \
   "$(events_of watch_end "$OUT6" | jq -r '.reason')" "PR MERGED"
+
+write_fixtures
+
+# ── 5b. watch until merged, not until quiet ──────────────────────────────────
+#
+# The whole point of the watch is to still be running at merge time. A PR with
+# green CI awaiting human review produces NO new events for hours; an earlier
+# version measured "time since the last new event" and quit long before the
+# merge it existed to report.
+
+echo
+echo "## Runs until merged, not until quiet"
+
+# Everything already seen, PR open, nothing new will ever arrive: the classic
+# awaiting-review state. Must keep polling rather than call it idle.
+reset_state
+run_watch --pr 42 --once >/dev/null            # prime .seen so nothing is new
+QUIET="$(PR_WATCH_INTERVAL=1 PR_WATCH_IDLE_TIMEOUT=3 PR_WATCH_MAX_LIFETIME=6 with_deadline 40 run_watch --pr 42)"
+check "a quiet OPEN PR is not treated as idle" \
+  "$(events_of watch_end "$QUIET" | jq -r '.reason')" \
+  "max lifetime 6s reached before merge"
+
+# Same silence, but now the polls themselves fail: contact is genuinely lost.
+reset_state
+run_watch --pr 42 --once >/dev/null
+mv "$FIXTURE_DIR/view.json" "$FIXTURE_DIR/view.hidden"
+printf 'not json\n' > "$FIXTURE_DIR/view.json"
+LOST="$(PR_WATCH_INTERVAL=1 PR_WATCH_IDLE_TIMEOUT=2 PR_WATCH_MAX_LIFETIME=60 with_deadline 40 run_watch --pr 42)"
+check "lost contact DOES end the watch" \
+  "$(events_of watch_end "$LOST" | jq -r '.reason')" \
+  "no contact with PR for 2s"
+mv "$FIXTURE_DIR/view.hidden" "$FIXTURE_DIR/view.json"
+
+# A merge that lands mid-watch must still be reported, after the quiet stretch.
+reset_state
+run_watch --pr 42 --once >/dev/null
+( sleep 3; jq '.state = "MERGED"' "$FIXTURE_DIR/view.json" > "$FIXTURE_DIR/v.tmp" \
+    && mv "$FIXTURE_DIR/v.tmp" "$FIXTURE_DIR/view.json" ) &
+LATE="$(PR_WATCH_INTERVAL=1 PR_WATCH_IDLE_TIMEOUT=30 PR_WATCH_MAX_LIFETIME=60 with_deadline 40 run_watch --pr 42)"
+wait
+check "a merge after a quiet stretch is still reported" \
+  "$(events_of watch_end "$LATE" | jq -r '.reason')" "PR MERGED"
 
 write_fixtures
 
@@ -199,7 +326,7 @@ SLOG="$TMP/stream.jsonl"
 printf '%s\n' '{"kind":"watch_start"}' '{"kind":"check","bucket":"pass"}' > "$SLOG"
 ( sleep 2; printf '%s\n' '{"kind":"check","bucket":"fail"}' >> "$SLOG"
   sleep 2; printf '%s\n' '{"kind":"watch_end","reason":"PR MERGED"}' >> "$SLOG" ) &
-SOUT="$(bash "$STREAM" "$SLOG" 1)"
+SOUT="$(with_deadline 30 bash "$STREAM" "$SLOG" 1)"
 SRC=$?
 wait
 
@@ -228,13 +355,13 @@ SHA="1111111111111111111111111111111111111111"
 # only after the foreground child returns. Polling for actual absence keeps a
 # still-dying watcher from being misread as the NEXT case's arm.
 kill_watchers() {
-  pkill -f "pr-watch.sh --branch" 2>/dev/null
+  pkill -f "$(watcher_pat)" 2>/dev/null
   local deadline=$(( SECONDS + 15 ))
   while (( SECONDS < deadline )); do
-    pgrep -f "pr-watch.sh --branch" >/dev/null 2>&1 || return 0
+    pgrep -f "$(watcher_pat)" >/dev/null 2>&1 || return 0
     sleep 1
   done
-  pkill -9 -f "pr-watch.sh --branch" 2>/dev/null
+  pkill -9 -f "$(watcher_pat)" 2>/dev/null
   sleep 1
 }
 
@@ -247,16 +374,16 @@ term_kills_daemon() {
   ( cd "$REPO" && nohup bash "$SCRATCH_WATCHER" --branch termprobe --sha deadbeef \
       >/dev/null 2>&1 & )
   sleep 2
-  pgrep -f "pr-watch.sh --branch termprobe" >/dev/null 2>&1 || { echo "never-started"; return; }
-  pkill -TERM -f "pr-watch.sh --branch termprobe" 2>/dev/null
+  pgrep -f "$(watcher_pat) --branch termprobe" >/dev/null 2>&1 || { echo "never-started"; return; }
+  pkill -TERM -f "$(watcher_pat) --branch termprobe" 2>/dev/null
   # Generous: bash defers a trap until the foreground `sleep` returns.
   local deadline=$(( SECONDS + 20 ))
   while (( SECONDS < deadline )); do
-    pgrep -f "pr-watch.sh --branch termprobe" >/dev/null 2>&1 || { echo "died"; return; }
+    pgrep -f "$(watcher_pat) --branch termprobe" >/dev/null 2>&1 || { echo "died"; return; }
     sleep 1
   done
   echo "survived"
-  pkill -9 -f "pr-watch.sh --branch termprobe" 2>/dev/null
+  pkill -9 -f "$(watcher_pat) --branch termprobe" 2>/dev/null
 }
 
 arm() {
@@ -270,7 +397,7 @@ arm() {
       bash "$PREPUSH" origin "$TMP/origin.git" >/dev/null 2>&1)
   sleep 1
   local result
-  if pgrep -f "pr-watch.sh --branch" >/dev/null 2>&1; then result=armed; else result=idle; fi
+  if pgrep -f "$(watcher_pat)" >/dev/null 2>&1; then result=armed; else result=idle; fi
   kill_watchers
   printf '%s' "$result"
 }
@@ -304,6 +431,29 @@ mv "$SCRATCH_WATCHER" "$TMP/moved-watcher.sh"
   | env -u CLAUDECODE -u CODEX_SANDBOX -u AGENT_GATED bash "$PREPUSH" origin url >/dev/null 2>&1)
 check "absent watcher does not fail the push" "$?" "0"
 mv "$TMP/moved-watcher.sh" "$SCRATCH_WATCHER"
+
+# ── 8. argument parsing ──────────────────────────────────────────────────────
+#
+# `shift 2` on a flag with no value shifts nothing and leaves $1 in place, so the
+# same case branch matches forever — the process spins instead of erroring.
+
+echo
+echo "## Argument parsing"
+
+arg_result() {
+  local out
+  out="$(with_deadline 10 bash "$WATCHER" "$@" 2>&1)"
+  if printf '%s' "$out" | grep -q "requires a value"; then echo "rejected"
+  elif [[ -z "$out" ]]; then echo "hung-or-silent"
+  else echo "other"; fi
+}
+
+check "--branch with no value is rejected, not spun on" "$(arg_result --branch)" "rejected"
+check "--sha with no value is rejected"                 "$(arg_result --sha)"    "rejected"
+check "--pr with no value is rejected"                  "$(arg_result --pr)"     "rejected"
+
+check "--help prints the whole Env section, not a truncated one" \
+  "$(bash "$WATCHER" --help 2>&1 | grep -c 'PR_WATCH_INTERVAL\|PR_WATCH_IDLE_TIMEOUT\|PR_WATCH_MAX_LIFETIME')" "3"
 
 echo
 printf 'pr-watch: %d passed, %d failed\n' "$pass" "$fail"

--- a/.claude/hooks/preflight-commit-push.test.sh
+++ b/.claude/hooks/preflight-commit-push.test.sh
@@ -11,7 +11,11 @@
 # Exits non-zero on any failure.
 set -uo pipefail
 
-REPO_ROOT="$(git rev-parse --show-toplevel)"
+# Resolve from THIS script's location, not the caller's cwd. `git rev-parse
+# --show-toplevel` returns whichever checkout the shell sits in, so running this
+# suite from another worktree silently tests THAT checkout's copy instead of the
+# one shipped beside these tests, and a two-side check reports a false pass.
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 HOOK="$REPO_ROOT/.claude/hooks/preflight-commit-push.sh"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT

--- a/.claude/hooks/preflight-pr-review.test.sh
+++ b/.claude/hooks/preflight-pr-review.test.sh
@@ -11,7 +11,11 @@
 # Exits non-zero on any failure.
 set -uo pipefail
 
-REPO_ROOT="$(git rev-parse --show-toplevel)"
+# Resolve from THIS script's location, not the caller's cwd. `git rev-parse
+# --show-toplevel` returns whichever checkout the shell sits in, so running this
+# suite from another worktree silently tests THAT checkout's copy instead of the
+# one shipped beside these tests, and a two-side check reports a false pass.
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 HOOK="$REPO_ROOT/.claude/hooks/preflight-pr-review.sh"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT

--- a/.claude/hooks/preflight-verdict-check.test.sh
+++ b/.claude/hooks/preflight-verdict-check.test.sh
@@ -33,7 +33,11 @@ unset VERDICT_GATE_HARD_BLOCK
 # Without this, a machine with the `claude` CLI would call a live model mid-suite.
 export VERDICT_CLASSIFIER_CMD='false'
 
-REPO_ROOT="$(git rev-parse --show-toplevel)"
+# Resolve from THIS script's location, not the caller's cwd. `git rev-parse
+# --show-toplevel` returns whichever checkout the shell sits in, so running this
+# suite from another worktree silently tests THAT checkout's copy instead of the
+# one shipped beside these tests, and a two-side check reports a false pass.
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 HOOK="$REPO_ROOT/.claude/hooks/preflight-verdict-check.sh"
 
 pass=0

--- a/.claude/hooks/rule-recency.test.sh
+++ b/.claude/hooks/rule-recency.test.sh
@@ -15,7 +15,11 @@
 # Exits non-zero on any failure.
 set -uo pipefail
 
-REPO_ROOT="$(git rev-parse --show-toplevel)"
+# Resolve from THIS script's location, not the caller's cwd. `git rev-parse
+# --show-toplevel` returns whichever checkout the shell sits in, so running this
+# suite from another worktree silently tests THAT checkout's copy instead of the
+# one shipped beside these tests, and a two-side check reports a false pass.
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 HOOK="$REPO_ROOT/.claude/hooks/rule-recency.sh"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT

--- a/.claude/hooks/run-verdict-audit.test.sh
+++ b/.claude/hooks/run-verdict-audit.test.sh
@@ -11,7 +11,11 @@
 # Run with:  bash .claude/hooks/run-verdict-audit.test.sh
 set -uo pipefail
 
-REPO_ROOT="$(git rev-parse --show-toplevel)"
+# Resolve from THIS script's location, not the caller's cwd. `git rev-parse
+# --show-toplevel` returns whichever checkout the shell sits in, so running this
+# suite from another worktree silently tests THAT checkout's copy instead of the
+# one shipped beside these tests, and a two-side check reports a false pass.
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 RUNNER="$REPO_ROOT/.claude/hooks/run-verdict-audit.sh"
 
 pass=0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -34,7 +34,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$CLAUDE_PROJECT_DIR/.agents/hooks/post-remote-write-watch.sh"
+            "command": "$CLAUDE_PROJECT_DIR/.agents/hooks/post-remote-write-watch.sh",
+            "timeout": 15
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -28,6 +28,17 @@
         ]
       }
     ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.agents/hooks/post-remote-write-watch.sh"
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [

--- a/.githooks/githooks.test.sh
+++ b/.githooks/githooks.test.sh
@@ -14,7 +14,11 @@
 # Run with:  bash .githooks/githooks.test.sh
 set -uo pipefail
 
-REPO_ROOT="$(git rev-parse --show-toplevel)"
+# Resolve from THIS script's location, not the caller's cwd. `git rev-parse
+# --show-toplevel` returns whichever checkout the shell sits in, so running this
+# suite from another worktree silently tests THAT checkout's copy instead of the
+# one shipped beside these tests, and a two-side check reports a false pass.
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 pass=0
 fail=0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -123,6 +123,43 @@ if [[ "$is_agent" == 1 ]]; then
   cleanup_push_audit_context
 fi
 
+# Arm the CI + PR-comment watcher for every branch in this push.
+#
+# pre-push is the only choke point every agent AND every human passes through on
+# the way to the remote, and git has no post-push hook — so the watcher starts
+# here and waits for the push to land before polling. It also waits for a PR to
+# appear, which is what lets one arm cover a later `gh pr create` without hooking
+# `gh` (which has no hook system) at all.
+#
+# Deliberately NOT gated on $is_agent: a watch is informational, and a human
+# pushing deserves the same CI signal an agent gets.
+#
+# Best-effort by construction — every failure path returns 0. A watcher that
+# cannot start must never be the reason a push is rejected.
+arm_pr_watch() {
+  local watcher="$repo_root/.agents/watch/pr-watch.sh"
+  [[ -r "$watcher" ]] || return 0
+
+  local log_dir
+  log_dir="$(git -C "$repo_root" rev-parse --git-path pr-watch 2>/dev/null)" || return 0
+  [[ "$log_dir" != /* ]] && log_dir="$repo_root/$log_dir"
+  mkdir -p "$log_dir" 2>/dev/null || return 0
+
+  local local_ref local_sha remote_ref remote_sha branch
+  while read -r local_ref local_sha remote_ref remote_sha; do
+    [[ -n "${remote_ref:-}" ]] || continue
+    is_zero_sha "$local_sha" && continue           # branch deletion — nothing to watch
+    branch="${remote_ref#refs/heads/}"
+    [[ "$branch" != "$remote_ref" ]] || continue   # tag/note ref, not a branch
+    # nohup + disown, not setsid: macOS ships no setsid. Redirecting both streams
+    # to a file keeps git from waiting on an inherited pipe.
+    nohup bash "$watcher" --branch "$branch" --sha "$local_sha" \
+      >> "$log_dir/${branch//\//-}.daemon.log" 2>&1 &
+    disown 2>/dev/null || true
+  done < "$stdin_file"
+}
+[[ "${BOXLITE_PR_WATCH:-1}" == "0" ]] || arm_pr_watch || true
+
 # --git-common-dir, not --git-path: see pre-commit (self-exec recursion).
 chained="$(git rev-parse --git-common-dir)/hooks/pre-push"
 if [[ -x "$chained" && "$(realpath "$chained" 2>/dev/null)" != "$(realpath "$0" 2>/dev/null)" ]]; then

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,32 @@ Key test entry points:
 6. Open a Pull Request
 7. Sign the [BoxLite Contributor License Agreement](./docs/legal/CLA.md) when CLA Assistant asks you to do so
 
+### Watching CI and PR feedback
+
+Once the hooks are installed (`bash .githooks/install.sh` — once per clone or
+worktree), every `git push` arms a background watcher via
+[`.githooks/pre-push`](./.githooks/pre-push), so it
+runs the same for a human, Claude Code, Codex, or any other agent. It waits for
+the push to land, waits for a PR to appear (which covers a later `gh pr create` —
+`gh` has no hook system), then emits one JSON line per event: each check as it
+concludes, plus every new comment, review, and inline review thread.
+
+```bash
+# follow the current branch's events; ends itself when the PR merges or closes
+.agents/watch/pr-watch-stream.sh "$(git rev-parse --git-path pr-watch)/$(git branch --show-current).jsonl"
+
+# watch a specific PR in the foreground, without pushing
+.agents/watch/pr-watch.sh --pr 1234 --once
+```
+
+Events land under `$(git rev-parse --git-path pr-watch)/` — inside `.git/`, so
+they are per-worktree and never tracked. What an agent may fix unattended versus
+what needs a human is defined in
+[`.agents/watch/escalation-policy.md`](./.agents/watch/escalation-policy.md).
+
+Set `BOXLITE_PR_WATCH=0` to disable. It is best-effort by construction: a
+watcher that cannot start never fails your push.
+
 ### Commit & PR messages
 
 Write for a reviewer skimming in ~30 seconds. Describe the change, not the process that produced it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,8 +71,10 @@ the push to land, waits for a PR to appear (which covers a later `gh pr create` 
 concludes, plus every new comment, review, and inline review thread.
 
 ```bash
-# follow the current branch's events; ends itself when the PR merges or closes
-.agents/watch/pr-watch-stream.sh "$(git rev-parse --git-path pr-watch)/$(git branch --show-current).jsonl"
+# follow the current branch's events; ends itself when the PR merges or closes.
+# `/` becomes `-` in the filename, so feature/foo logs to feature-foo.jsonl.
+branch="$(git branch --show-current)"
+.agents/watch/pr-watch-stream.sh "$(git rev-parse --git-path pr-watch)/${branch//\//-}.jsonl"
 
 # watch a specific PR in the foreground, without pushing
 .agents/watch/pr-watch.sh --pr 1234 --once


### PR DESCRIPTION
## Summary

Nothing observed the result of a push — CI outcome and reviewer comments were found only when someone remembered to look. This arms a background watcher on every push that streams each CI check as it concludes and every new comment, review, and inline thread.

## Changes

- `.githooks/pre-push` detaches the watcher for each pushed branch. It is the only choke point every agent *and* every human passes through, so the behavior is identical for a human, Claude Code, Codex, or opencode. Git has no `post-push` hook and `gh` has no hook system, so the watcher waits for the push to land, then polls until a PR appears — one arm covers a later `gh pr create`, comments, edits, and reviews, with no `gh` wrapper.
- `.agents/watch/pr-watch.sh` — producer. Emits one JSON line per event; every terminal bucket including `fail`/`cancel`, so silence can never be mistaken for success.
- `.agents/watch/pr-watch-stream.sh` — replay-and-follow reader that self-terminates at `watch_end`. Split from the producer because `tail -f | while read … exit` cannot stop itself: the `exit` runs in the pipeline subshell.
- `.agents/hooks/post-remote-write-watch.sh` — Claude-side consumer, advisory only. Registered from `.claude/settings.json`; implementations live in `.agents/` so `.codex/` and `.claude/` hold registration, not logic.
- `.agents/watch/escalation-policy.md` — what an agent may fix unattended vs. what needs a human. Carries a `TODO(user)`; the committed list is a draft default.

Existing commit/push/PR gates are untouched — this is additive (`git diff --numstat` shows zero deletions).

## How to verify

```bash
bash .agents/watch/pr-watch.test.sh                    # 28 passed
bash .agents/hooks/post-remote-write-watch.test.sh     # 31 passed
bash .githooks/githooks.test.sh                        # gate behavior unchanged

# against any open PR, no push needed
bash .agents/watch/pr-watch.sh --pr <number> --once
```

## Risks / rollout

- **Cannot reject a push.** `.githooks/pre-push` has no `set -e`; the call site is `… || arm_pr_watch || true`, every internal path returns 0, and it sits after the audit gate's exit paths. Two tests assert the hook still exits 0 and that an absent watcher does not fail a push.
- **Not yet active for pushes from an existing checkout.** `core.hooksPath` points at whichever `.githooks/pre-push` is installed, so the arm goes live after this lands on `main` (or after `bash .githooks/install.sh`). Inherent to any git-hook change — it cannot affect the push that delivers it. All six arming behaviors are covered by tests that invoke the new hook directly.
- Opt out with `BOXLITE_PR_WATCH=0`. Events live under `$(git rev-parse --git-path pr-watch)` — inside `.git/`, per-worktree, untracked by construction.
- A hard `SIGKILL` can strand the per-branch `mkdir` lock; recovery is removing the `.lock` directory.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic monitoring for pushed branches and pull requests.
  - Reports CI checks, reviews, comments, and merge or closure status as events.
  - Supports one-time monitoring, configurable timeouts, duplicate-event prevention, and opt-out controls.
  - Monitoring is best-effort and does not block pushes.

- **Documentation**
  - Added guidance for enabling, using, and disabling PR monitoring.
  - Documented escalation rules for automated CI fixes and human approval.

- **Tests**
  - Added comprehensive coverage for monitoring, event delivery, failure handling, and push-hook behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->