### PR TITLE
feat(infra): bootstrap deployment prerequisites, protect the prod stage

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -159,20 +159,26 @@ is enabled. The workflow is dormant until repository variable
 4. Trigger a new push, pull request update, or manual dispatch and verify CodeQL analysis uploads successfully.
 5. Roll back by setting `CODEQL_ADVANCED_SETUP_ENABLED=false` and re-enabling default setup.
 
-### `deploy-dev-api.yml`
+### `deploy-infra.yml`
 
-Previews or deploys the full dev stack from `main` on a native AMD64 GitHub
-runner. Deployment safety tests first enforce the Runner lifecycle options.
-Dispatch defaults to preview-only; `apply=true` repeats the full structured
-preview and deploys only when the Runner safety gate accepts the plan. Routine
-control-plane deployment rejects every Runner create, delete, replacement, or
-protected-property change; the routine workflow does not provision Runners.
-The job rejects partial `--target`/`--exclude` deploys so provider changes and
-resources reconcile together. It is serialized, uses the protected `dev`
-Environment, and authenticates to AWS with short-lived OIDC credentials. Docker
-runs entirely in CI; no developer machine or public SSH builder participates.
+Previews or deploys the full stack from `main` on a native AMD64 GitHub
+runner, for a `workflow_dispatch`-selected `stage` (an allowlisted `choice`
+input, `dev` today). Deployment safety tests first enforce the Runner lifecycle
+options. Dispatch defaults to preview-only; `apply=true` repeats the full
+structured preview and deploys only when the Runner safety gate accepts the
+plan. Routine control-plane deployment rejects every Runner create, delete,
+replacement, or protected-property change; the routine workflow does not
+provision Runners. The job rejects partial `--target`/`--exclude` deploys so
+provider changes and resources reconcile together. It is serialized, uses the
+selected stage's protected GitHub Environment, and authenticates to AWS with
+short-lived OIDC credentials. Docker runs entirely in CI; no developer machine
+or public SSH builder participates.
 
-Required `dev` Environment configuration:
+The `stage` input is an allowlist rather than free text, so a
+required-reviewers Environment cannot be targeted by an unbootstrapped or
+misspelled name. Adding a stage means adding it to that `options` list.
+
+Required Environment configuration (per stage):
 
 - Variable `AWS_DEPLOY_ROLE_ARN`
 - Variable `AWS_REGION` (defaults to `ap-southeast-1`)

--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -1,8 +1,16 @@
-name: Deploy dev stack
+name: Deploy stack
+run-name: Deploy ${{ inputs.stage }} stack
 
 on:
   workflow_dispatch:
     inputs:
+      stage:
+        description: 'Stage to deploy (must already be bootstrapped — see apps/infra/README.md)'
+        required: true
+        default: dev
+        type: choice
+        options:
+          - dev
       apply:
         description: Preview again, then deploy the full stack
         required: true
@@ -14,20 +22,21 @@ permissions:
   id-token: write
 
 concurrency:
-  group: deploy-dev-stack
+  group: deploy-${{ inputs.stage }}-stack
   cancel-in-progress: false
 
 jobs:
   deploy:
-    name: Deploy dev stack
+    name: Deploy ${{ inputs.stage }} stack
     if: github.ref == 'refs/heads/main'
-    environment: dev
+    environment: ${{ inputs.stage }}
     runs-on: ubuntu-24.04
     timeout-minutes: 90
     env:
       AWS_REGION: ${{ vars.AWS_REGION || 'ap-southeast-1' }}
       AWS_DEFAULT_REGION: ${{ vars.AWS_REGION || 'ap-southeast-1' }}
-      IAM_PERMISSIONS_BOUNDARY_STAGE: dev
+      STAGE: ${{ inputs.stage }}
+      IAM_PERMISSIONS_BOUNDARY_STAGE: ${{ inputs.stage }}
 
     steps:
       - name: Checkout main
@@ -47,7 +56,7 @@ jobs:
         with:
           role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
-          role-session-name: deploy-dev-stack-${{ github.run_id }}
+          role-session-name: deploy-${{ inputs.stage }}-stack-${{ github.run_id }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -77,20 +86,20 @@ jobs:
 
       - name: Install SST providers
         working-directory: apps/infra
-        run: npm run --silent sst -- install --stage dev
+        run: npm run --silent sst -- install --stage "$STAGE"
 
       - name: Preview the full stack
         shell: bash
         working-directory: apps/infra
         run: |
           set -euo pipefail
-          npm run --silent sst -- diff --stage dev --policy . --json |
+          npm run --silent sst -- diff --stage "$STAGE" --policy . --json |
             node scripts/deployment-preview.mjs
 
       - name: Deploy the full stack
         if: ${{ inputs.apply }}
         working-directory: apps/infra
-        run: npm run deploy -- --stage dev --policy .
+        run: npm run deploy -- --stage "$STAGE" --policy .
 
       - name: Remove materialized configuration
         if: always()

--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -73,6 +73,10 @@ jobs:
         working-directory: apps/infra
         run: npm test
 
+      - name: Verify deploy role IAM boundary permissions
+        working-directory: apps/infra
+        run: node scripts/verify-deploy-role-boundary.mjs
+
       - name: Materialize stage configuration
         shell: bash
         env:
@@ -88,9 +92,17 @@ jobs:
         working-directory: apps/infra
         run: npm run --silent sst -- install --stage "$STAGE"
 
+      # Cloudflare's OAuth catalog has no DNS-edit scope for the wrangler
+      # client, so these stay hand-made scoped API tokens. Supplying them as
+      # Environment secrets is optional: scripts/sst-with-cloudflare.mjs
+      # prefers an already-set env var and otherwise reads SSM, so a stage
+      # seeded via SSM keeps working with these unset.
       - name: Preview the full stack
         shell: bash
         working-directory: apps/infra
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_DEFAULT_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_DEFAULT_ACCOUNT_ID }}
         run: |
           set -euo pipefail
           npm run --silent sst -- diff --stage "$STAGE" --policy . --json |
@@ -99,6 +111,9 @@ jobs:
       - name: Deploy the full stack
         if: ${{ inputs.apply }}
         working-directory: apps/infra
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_DEFAULT_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_DEFAULT_ACCOUNT_ID }}
         run: npm run deploy -- --stage "$STAGE" --policy .
 
       - name: Remove materialized configuration

--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -92,11 +92,13 @@ jobs:
         working-directory: apps/infra
         run: npm run --silent sst -- install --stage "$STAGE"
 
-      # Cloudflare's OAuth catalog has no DNS-edit scope for the wrangler
-      # client, so these stay hand-made scoped API tokens. Supplying them as
-      # Environment secrets is optional: scripts/sst-with-cloudflare.mjs
-      # prefers an already-set env var and otherwise reads SSM, so a stage
-      # seeded via SSM keeps working with these unset.
+      # These stay hand-made scoped API tokens. Cloudflare's `cf` CLI can mint
+      # an OAuth token carrying dns_records:edit, but it expires in about an
+      # hour and is renewed through a browser, which this unattended job has
+      # no way to complete. Supplying them as Environment secrets is optional:
+      # scripts/sst-with-cloudflare.mjs prefers an already-set env var and
+      # otherwise reads SSM, so a stage seeded via SSM keeps working with
+      # these unset.
       - name: Preview the full stack
         shell: bash
         working-directory: apps/infra

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ on:
       - '.github/workflows/lint.yml'
       - '.github/workflows/config.yml'
       - '.github/workflows/build-runtime.yml'
-      - '.github/workflows/deploy-dev-api.yml'
+      - '.github/workflows/deploy-infra.yml'
       - 'apps/infra/**'
       - 'scripts/release/**'
   # No path filter on pull_request: the `Lint (conclusion)` job is a required
@@ -85,7 +85,7 @@ jobs:
               - '.github/workflows/lint.yml'
             infra:
               - 'apps/infra/**'
-              - '.github/workflows/deploy-dev-api.yml'
+              - '.github/workflows/deploy-infra.yml'
               - 'make/test.mk'
             install_script:
               - 'scripts/release/**'

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Every CLI command also works against a running server with `--url`: `boxlite --u
 ```bash
 git clone https://github.com/boxlite-ai/boxlite && cd boxlite/apps/infra
 npm install
-npm run deploy -- --stage production
+npm run deploy -- --stage prod
 ```
 
 Needs an AWS account, a Cloudflare-managed domain, and Docker. Full guide → [`apps/infra/README.md`](./apps/infra/README.md).

--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ Every CLI command also works against a running server with `--url`: `boxlite --u
 ```bash
 git clone https://github.com/boxlite-ai/boxlite && cd boxlite/apps/infra
 npm install
+npm run login                          # browser sign-in: AWS, GitHub, Auth0
+npm run bootstrap -- --stage prod      # IAM role, GitHub Environment, secrets
 npm run deploy -- --stage prod
 ```
 

--- a/apps/api/src/box/constants/curated-images.constant.ts
+++ b/apps/api/src/box/constants/curated-images.constant.ts
@@ -8,8 +8,8 @@ import { BadRequestError } from '../../exceptions/bad-request.exception'
 
 /**
  * Curated-image gate: boxes may only boot from a fixed, operator-controlled set of images,
- * because the runner pulls with its own private-registry token and must never be handed an
- * arbitrary user-supplied image. The gate is deliberately thin and sits only at the request
+ * because the runner pulls with whatever registry credentials it was deployed with and must
+ * never be handed an arbitrary user-supplied image. The gate is deliberately thin and sits only at the request
  * boundary (BoxService create / warm-pool); everything downstream treats the resolved ref as
  * an opaque OCI ref. When per-org custom images land, delete this file and its call sites --
  * no other layer knows the curated set exists.

--- a/apps/api/src/common/utils/api-key.spec.ts
+++ b/apps/api/src/common/utils/api-key.spec.ts
@@ -62,7 +62,7 @@ describe('api-key', () => {
       expect(extractKeyDisplayPrefix(generateApiKeyValue('acme', 'svc'))).toBe('acme_svc_')
     })
 
-    it('falls back to the first 3 chars for legacy Daytona values (display unchanged)', () => {
+    it('falls back to the first 3 chars for legacy dtn_ values (display unchanged)', () => {
       expect(extractKeyDisplayPrefix('dtn_0000000000000000000000000000000000000000000000000000000000000000')).toBe(
         'dtn',
       )

--- a/apps/api/src/common/utils/api-key.ts
+++ b/apps/api/src/common/utils/api-key.ts
@@ -88,8 +88,8 @@ export function generateApiKeyValue(prefix: string, keyClass: ApiKeyClass): stri
  * computationally infeasible to brute-force regardless of hash speed.
  * Slow KDFs exist to defend *low-entropy human passwords*; they impose
  * latency on every auth request without adding security for random
- * high-entropy tokens. Matches the upstream `daytonaio/daytona`
- * implementation byte-for-byte and the documented pattern used by
+ * high-entropy tokens. Matches the upstream implementation
+ * byte-for-byte and the documented pattern used by
  * Stripe, GitHub, Doppler, and other API-key providers.
  */
 export function generateApiKeyHash(value: string): string {
@@ -99,7 +99,7 @@ export function generateApiKeyHash(value: string): string {
 /**
  * Non-secret prefix used for masked display (`blk_live_••••abc`). Returns the
  * `{prefix}_{class}_` head for current keys; for legacy single-segment values
- * (Daytona `dtn_…`) falls back to the first 3 characters, matching the
+ * (`dtn_…`) falls back to the first 3 characters, matching the
  * pre-existing stored `keyPrefix` so already-issued rows render unchanged.
  */
 export function extractKeyDisplayPrefix(value: string): string {

--- a/apps/api/src/config/configuration.ts
+++ b/apps/api/src/config/configuration.ts
@@ -74,7 +74,7 @@ const configuration = {
   // Default to empty string - dashboard will then hit '/api'
   dashboardBaseApiUrl: process.env.DASHBOARD_BASE_API_URL || '',
   // Currently unconsumed (upstream-port residue): nothing reads `systemSourceRegistry`.
-  // Box images are a fixed curated set of digest-pinned ghcr.io refs pulled directly by
+  // Box images are a fixed curated set of tag-pinned ghcr.io refs pulled directly by
   // the runner (see box/constants/curated-images.constant.ts), not mirrored from a source
   // registry. Kept as a reserved surface for a future per-org custom-image path.
   systemSourceRegistry: {

--- a/apps/api/src/config/configuration.ts
+++ b/apps/api/src/config/configuration.ts
@@ -73,7 +73,7 @@ const configuration = {
   dashboardUrl: process.env.DASHBOARD_URL,
   // Default to empty string - dashboard will then hit '/api'
   dashboardBaseApiUrl: process.env.DASHBOARD_BASE_API_URL || '',
-  // Currently unconsumed (Daytona-port residue): nothing reads `systemSourceRegistry`.
+  // Currently unconsumed (upstream-port residue): nothing reads `systemSourceRegistry`.
   // Box images are a fixed curated set of digest-pinned ghcr.io refs pulled directly by
   // the runner (see box/constants/curated-images.constant.ts), not mirrored from a source
   // registry. Kept as a reserved surface for a future per-org custom-image path.

--- a/apps/eslint.config.mjs
+++ b/apps/eslint.config.mjs
@@ -9,7 +9,7 @@ export default [
   ...nx.configs['flat/javascript'],
   {
     // Workspace-wide ignores. Patterns are relative to this config (apps/).
-    // Adapted from upstream daytonaio/daytona (root-level config) for the
+    // Adapted from the upstream project's root-level config for the
     // BoxLite layout where lint scripts run with cwd=apps/ instead of root.
     ignores: [
       '**/dist',

--- a/apps/infra-local/compose/_local_arm64.py
+++ b/apps/infra-local/compose/_local_arm64.py
@@ -4,9 +4,10 @@ and a no-op when its work is already done (or its tools are absent), so it is
 safe to call on every `up`.
 
 Why these exist (gaps `compose up` otherwise assumes are pre-handled):
-  • image pulls (L1 images + the box base) need registry auth or they hit the
-    anonymous Docker Hub rate limit / a private-ghcr 401 — the BoxLite puller
-    does NOT read ~/.docker/config.json, so creds must be threaded in.
+  • image pulls (L1 images, and any private box base) need registry auth or
+    they hit the anonymous Docker Hub rate limit / a private-ghcr 401 — the
+    BoxLite puller does NOT read ~/.docker/config.json, so creds must be
+    threaded in. The curated box base itself is public.
   • the maturin *editable* SDK build does not embed boxlite-guest/shim into the
     runtime cache, so box boot fails with "boxlite-guest not found".
   • the box base is pulled from the published multi-arch agent image
@@ -56,8 +57,9 @@ def dockerhub_creds() -> tuple[str | None, str | None]:
 
 
 def ghcr_creds() -> tuple[str | None, str | None]:
-    """(username, token) for ghcr.io, so the runner can pull the private
-    multi-arch agent image. Resolution order, each per-developer (no shared
+    """(username, token) for ghcr.io. The curated agent images are public, so
+    these are optional; they are required only for a private image ref.
+    Resolution order, each per-developer (no shared
     secret to distribute):
       1. explicit env (GHCR_USERNAME/GHCR_TOKEN or BOXLITE_GHCR_*)
       2. the GitHub CLI token (`gh auth token`) — its scope already covers
@@ -119,8 +121,8 @@ def export_dockerhub_env() -> None:
 
 def export_ghcr_env() -> None:
     """Thread ghcr.io creds into os.environ under the names the runner reads
-    (GHCR_USERNAME/GHCR_TOKEN via envconfig) so it can pull the private
-    multi-arch agent image. No-op if none resolve."""
+    (GHCR_USERNAME/GHCR_TOKEN via envconfig) so it can pull a private image
+    ref. No-op if none resolve."""
     u, t = ghcr_creds()
     if u and t:
         os.environ.setdefault("GHCR_USERNAME", u)
@@ -237,13 +239,12 @@ def resolve_agent_image() -> str | None:
 
     The published agent image is multi-arch (linux/arm64 included), so the
     runner pulls the host-matching arch straight from ghcr — no local build or
-    L1-registry push. Returns the remote ref when ghcr creds are available (the
-    runner needs them to pull a private image), else None so the caller leaves
-    the curated default in place — now the same multi-arch tag, so a missing-
-    creds failure surfaces as an explicit, logged pull error."""
+    L1-registry push. Returns the remote ref when ghcr creds are available, else
+    None so the caller leaves the curated default in place — which is the same
+    multi-arch tag, and public, so an anonymous pull still succeeds."""
     u, t = ghcr_creds()
     if not (u and t):
         print("  no ghcr.io creds (try `gh auth login` or `docker login ghcr.io`) — "
-              "runner can't pull the arm64 agent image; boxes won't boot")
+              "using the curated default, which is public and pulls anonymously")
         return None
     return REMOTE_AGENT_IMAGE

--- a/apps/infra/.env.example
+++ b/apps/infra/.env.example
@@ -96,7 +96,10 @@ OIDC_AUDIENCE=https://dev.example.com/api
 # [required for private box images] ghcr pull credential. The built-in curated
 # images are public, so a default deploy needs neither variable; set BOTH when
 # any image ref is private — whether via BOXLITE_SYSTEM_*_IMAGE or appended
-# through BOXLITE_SYSTEM_IMAGES. When set, the token
+# through BOXLITE_SYSTEM_IMAGES (comma-separated `name=ref`, e.g.
+# `hermes=ghcr.io/acme/hermes-agent:v3`; unlike the INERT vars in section 4n,
+# this one IS read — the API's curated-image allowlist accepts every entry).
+# When set, the token
 # is stored in Secrets Manager and each runner fetches it at boot via its
 # instance-role (never baked into user-data); unset = no ghcr auth wired, and
 # any private pull 401s. Use a bot/fine-grained token scoped to read:packages

--- a/apps/infra/.env.example
+++ b/apps/infra/.env.example
@@ -93,11 +93,14 @@ OIDC_AUDIENCE=https://dev.example.com/api
 # v2 runners self-report their address via healthcheck, so no IP wiring is needed.
 #   RUNNERS=3  # only when state already contains default + runner-2 + runner-3
 #
-# [required for private box images] ghcr pull credential. Runners pull box images
-# straight from private ghcr.io, so set BOTH to enable: the token is stored in
-# Secrets Manager and each runner fetches it at boot via its instance-role (never
-# baked into user-data). Unset = no ghcr auth wired (private pulls 401). Use a
-# bot/fine-grained token scoped to read:packages — not a personal PAT.
+# [required for private box images] ghcr pull credential. The built-in curated
+# images are public, so a default deploy needs neither variable; set BOTH when
+# any image ref is private — whether via BOXLITE_SYSTEM_*_IMAGE or appended
+# through BOXLITE_SYSTEM_IMAGES. When set, the token
+# is stored in Secrets Manager and each runner fetches it at boot via its
+# instance-role (never baked into user-data); unset = no ghcr auth wired, and
+# any private pull 401s. Use a bot/fine-grained token scoped to read:packages
+# — not a personal PAT.
 #   GHCR_USERNAME=boxlite-ci-bot
 #   GHCR_TOKEN=ghp_xxx
 
@@ -256,8 +259,8 @@ OIDC_AUDIENCE=https://dev.example.com/api
 # OTEL_COLLECTOR_API_KEY=                                   # collector→API key; default: ADMIN_API_KEY
 
 # 4n. System box images. The live images are the three digest-pinned refs in
-# sst.config.ts (BOXLITE_SYSTEM_{BASE,PYTHON,NODE}_IMAGE), pulled from ghcr.io with the
-# runner's GHCR_TOKEN. The vars below are currently INERT — no code reads them (Daytona-
+# sst.config.ts (BOXLITE_SYSTEM_{BASE,PYTHON,NODE}_IMAGE), pulled anonymously from
+# ghcr.io — they are public. The vars below are currently INERT — no code reads them (Daytona-
 # port residue, see apps/api configuration.ts); setting them has no effect. Documented
 # only as reserved names for a future source-registry path.
 # BOXLITE_SYSTEM_IMAGE_TAG=v0.1.0

--- a/apps/infra/.env.example
+++ b/apps/infra/.env.example
@@ -258,7 +258,7 @@ OIDC_AUDIENCE=https://dev.example.com/api
 # OTEL_EXPORTER_OTLP_HEADERS=                               # e.g. authorization=Bearer xxx
 # OTEL_COLLECTOR_API_KEY=                                   # collector→API key; default: ADMIN_API_KEY
 
-# 4n. System box images. The live images are the three digest-pinned refs in
+# 4n. System box images. The live images are the three tag-pinned refs in
 # sst.config.ts (BOXLITE_SYSTEM_{BASE,PYTHON,NODE}_IMAGE), pulled anonymously from
 # ghcr.io — they are public. The vars below are currently INERT — no code reads them (upstream-
 # port residue, see apps/api configuration.ts); setting them has no effect. Documented

--- a/apps/infra/.env.example
+++ b/apps/infra/.env.example
@@ -260,7 +260,7 @@ OIDC_AUDIENCE=https://dev.example.com/api
 
 # 4n. System box images. The live images are the three digest-pinned refs in
 # sst.config.ts (BOXLITE_SYSTEM_{BASE,PYTHON,NODE}_IMAGE), pulled anonymously from
-# ghcr.io — they are public. The vars below are currently INERT — no code reads them (Daytona-
+# ghcr.io — they are public. The vars below are currently INERT — no code reads them (upstream-
 # port residue, see apps/api configuration.ts); setting them has no effect. Documented
 # only as reserved names for a future source-registry path.
 # BOXLITE_SYSTEM_IMAGE_TAG=v0.1.0

--- a/apps/infra/.env.example
+++ b/apps/infra/.env.example
@@ -30,7 +30,14 @@ IAM_PERMISSIONS_BOUNDARY_STAGE=dev
 # Subdomain for this stack (e.g. dev.boxlite.ai, staging.boxlite.ai)
 STACK_DOMAIN=dev.example.com
 
-# Cloudflare credentials — token needs Zone:Read + DNS:Edit on your domain
+# Cloudflare credentials — create an ACCOUNT-owned token with Zone:Read +
+# DNS:Edit. apps/infra/README.md#cloudflare-api-token has a link that pre-fills
+# those permissions in the dashboard form; the link carries no zone parameter,
+# so scope the token to the zone serving STACK_DOMAIN there. Cloudflare's docs
+# require a dashboard-created token before any token can be minted via API, so
+# `npm run bootstrap` prompts for this value once per stage and stores it in
+# SSM. See that README section for why the browser login used for
+# AWS/GitHub/Auth0 cannot cover this one.
 CLOUDFLARE_DEFAULT_ACCOUNT_ID=
 CLOUDFLARE_API_TOKEN=
 

--- a/apps/infra/README.md
+++ b/apps/infra/README.md
@@ -22,12 +22,12 @@ for any of them.
 
 | Prerequisite | How |
 | --- | --- |
-| **AWS credentials** | `aws login` — browser sign-in, AWS CLI 2.32.0+. No IAM user, no access keys, and no IAM Identity Center setup. Signing in as the account root works. |
+| **AWS credentials** | **auto** — `npm run login` runs `aws login` (browser sign-in, AWS CLI 2.32.0+). No IAM user, no access keys, and no IAM Identity Center setup. Signing in as the account root works. |
 | **AWS GitHub OIDC provider** | **auto** — created if the account doesn't already have one |
 | **Deployment role + permissions boundary** | **auto** — `ci/github-deploy-role.yaml` deployed via CloudFormation |
-| **GitHub Environment** (named exactly as the stage) with required reviewers | **auto** — `gh auth login` first. Protection rules need a public repo, or GitHub Pro/Team/Enterprise on a private one; without them the Environment is still created, unprotected. |
-| **An Auth0 tenant** (or any OIDC provider) | Tenant signup is manual — Auth0 has no API for it. Everything inside it (SPA app, custom API, post-login Action, logout discovery) is **auto** via `auth0 login` + `npm run bootstrap -- --provision-auth0`. |
-| **A Cloudflare-managed domain** | Manual. You must own the domain and delegate nameservers, and Cloudflare's `wrangler` OAuth catalog has no DNS-edit scope — so a hand-made API token with `Zone:Read` + `DNS:Edit` is required. See [Secrets & credentials](#secrets--credentials). |
+| **GitHub Environment** (named exactly as the stage) with required reviewers | **auto** — `npm run login` first. Protection rules need a public repo, or GitHub Pro/Team/Enterprise on a private one; without them the Environment is still created, unprotected. |
+| **An Auth0 tenant** (or any OIDC provider) | Tenant signup is manual — Auth0 has no API for it. Everything inside it (SPA app, custom API, post-login Action, logout discovery) is **auto** via `npm run login` + `npm run bootstrap -- --provision-auth0`. |
+| **A Cloudflare-managed domain** | Manual. You must own the domain and delegate nameservers, and Cloudflare documents only dashboard creation for a first API token. Create an **account-owned** token with `Zone:Read` + `DNS:Edit`. See [Cloudflare API token](#cloudflare-api-token). |
 | **An existing SST stack whose Runner inventory matches `RUNNERS`** | Manual — first-Runner provisioning is not implemented here. See [Deploying to your own AWS account](#deploying-to-your-own-aws-account). |
 | **AWS CLI + GitHub CLI** (and `auth0` CLI for `--provision-auth0`) | Installed by you; the bootstrap checks for them and fails with the exact fix. |
 
@@ -43,13 +43,11 @@ npm install
 cp .env.example .env        # stage config: STACK_DOMAIN, OIDC_ISSUER_BASE_URL, OIDC_AUDIENCE
 $EDITOR .env
 
-aws login                   # browser sign-in; no IAM user or access keys needed
-gh auth login               # if not already authenticated
+npm run login               # browser sign-in for AWS, GitHub, and Auth0
 npm run bootstrap -- --stage dev
 
 # Optional: also provision the Auth0 tenant's app/API/Action in one pass.
 # Not idempotent — Auth0 has no upsert, so rerunning creates duplicates.
-auth0 login
 npm run bootstrap -- --stage dev --provision-auth0
 ```
 
@@ -61,7 +59,7 @@ touch CloudFormation or its own IAM policy — see
 [Native AMD64 CI deployment](#native-amd64-ci-deployment)). In order it:
 
 1. checks the AWS CLI is ≥2.32.0 and that credentials resolve, pointing at
-   `aws login` if not;
+   `npm run login` if not;
 2. registers the GitHub OIDC provider if the account lacks one;
 3. creates/updates the GitHub Environment named after the stage, requiring the
    authenticated user as reviewer (`--reviewers 123,456` to override);
@@ -195,7 +193,7 @@ single laptop's `.env`:
 
 Grant each API token only the permissions and resources required for its
 documented use; the Cloudflare token needs `Zone:Read` and `DNS:Edit` for the
-managed zone. Rotate tokens regularly and immediately after suspected
+managed zone (see [Cloudflare API token](#cloudflare-api-token)). Rotate tokens regularly and immediately after suspected
 disclosure, updating the value in SSM or the SST secret store. Never put token
 values in command arguments, echo them, enable shell tracing around
 secret-handling commands, or copy secret-bearing logs or workflow output into
@@ -219,6 +217,78 @@ streams can contain provider credentials; SST state and non-secret diagnostics
 are left in place. If an existing event log is ever found to contain a provider
 token, rotate that token immediately, then run any wrapped SST command to remove
 the stale event log.
+
+### Cloudflare API token
+
+`npm run login` covers the AWS, GitHub, and Auth0 sessions with a browser
+sign-in; it cannot cover this one, so `npm run bootstrap` prompts for the value
+instead. Cloudflare states why directly:
+
+> "Before you can do this, you must create an API token in the Cloudflare
+> dashboard that can create subsequent tokens."
+>
+> "The API Token Template `Create additional tokens` must be used to generate
+> the token. The option for `API Tokens::Edit` is not available in any other
+> template or in the Custom Token builder."
+> — [Create tokens via API](https://developers.cloudflare.com/fundamentals/api/how-to/create-via-api/)
+
+So even the token-minting capability itself originates from a dashboard visit.
+
+Create it with this link, which pre-fills the permissions:
+
+[**Create the token →**](https://dash.cloudflare.com/?to=/:account/api-tokens&permissionGroupKeys=%5B%7B%22key%22%3A%22zone%22%2C%22type%22%3A%22read%22%7D%2C%7B%22key%22%3A%22dns%22%2C%22type%22%3A%22edit%22%7D%5D&name=BoxLite%20deploy)
+
+It opens the **account** token form with `Zone:Read` + `DNS:Edit` already
+selected — you pick the zone and confirm. Cloudflare is explicit that this is
+still a human step: "Template URLs only pre-fill the token creation form. Users
+must still complete the token creation process in the dashboard."
+([Template URLs](https://developers.cloudflare.com/fundamentals/api/how-to/account-owned-token-template/))
+
+Account ownership is what Cloudflare recommends for exactly this use:
+
+> "Account API tokens allow you to set up durable integrations that can act as
+> service principals with their own specific set of permissions. This approach
+> is ideal for scenarios like CI/CD ... where it is important that the
+> integration continues working, even long after the user who configured the
+> integration may have left your organization altogether."
+> — [Account-owned tokens](https://developers.cloudflare.com/fundamentals/api/get-started/account-owned-tokens/)
+
+Grant `Zone:Read` and `DNS:Edit`, restricted to the zone serving
+`STACK_DOMAIN`. The link carries no zone parameter by design — "Account token
+template URLs do not use `accountId` or `zoneId` parameters. Resource scoping
+for account tokens is configured during token creation in the dashboard" — so
+you pick the zone in the form. Creating an account-owned token requires Super
+Administrator on the account — though the template-URL page says "Super
+Administrator **or** Administrator", so the two Cloudflare pages disagree; try
+Administrator if that is the role you hold.
+
+`npm run bootstrap` prompts for the value once per stage and stores it in SSM,
+so this is a one-time step — the token is never pasted again.
+
+**Why the browser login used for AWS, GitHub, and Auth0 does not work here.**
+Cloudflare's `cf` CLI does grant `dns_records:edit` through a browser OAuth
+flow, and that token is accepted by the v4 API. It still cannot replace this
+token: the access token expires in about an hour, it is not permitted to manage API
+tokens, and refresh tokens are single-use: "Refresh tokens are single-use, so a
+long-lived process such as `wrangler dev` would otherwise send a stale value and
+get a 401 from the token endpoint"
+([`flow.ts`](https://github.com/cloudflare/workers-sdk/blob/main/packages/workers-auth/src/flow.ts)).
+A static CI secret cannot track that rotation, and two concurrent jobs sharing
+one refresh token would break the chain for both. Cloudflare also "does not
+support Client Credentials, Implicit, Resource Owner Password Credentials,
+Device Authorization, or other OAuth grant types for third-party clients"
+([OAuth clients](https://developers.cloudflare.com/fundamentals/oauth/create-an-oauth-client/)),
+so no machine-to-machine grant exists to sidestep the browser.
+
+Projects with the same unattended-DNS problem land in the same place:
+[cert-manager](https://cert-manager.io/docs/configuration/acme/dns01/cloudflare/)
+("API Tokens are recommended for higher security"),
+[external-dns](https://kubernetes-sigs.github.io/external-dns/latest/docs/tutorials/cloudflare/)
+("the token should be granted Zone `Read`, DNS `Edit` privileges, and access
+to `All zones`"), and
+[SST's own Cloudflare guide](https://sst.dev/docs/component/cloudflare/)
+("create an account token in the Cloudflare dashboard under Manage Account >
+API Tokens").
 
 ### App secrets
 

--- a/apps/infra/README.md
+++ b/apps/infra/README.md
@@ -16,12 +16,20 @@ and CloudFront.
 
 ## Prerequisites
 
-- A **Cloudflare-managed domain** (SST creates ACM certs + DNS records automatically)
-- An **Auth0 tenant** (or any OIDC provider — see `.env.example` for setup steps)
-- A protected GitHub **`dev` Environment** with required reviewers
-- An AWS GitHub OIDC provider and the deployment role described below
-- An existing SST stack whose Runner inventory exactly matches `RUNNERS`
-- **AWS CLI** and **GitHub CLI** for one-time CI bootstrap only
+`npm run bootstrap` (below) provisions everything marked **auto** — you only
+need to be logged in to each service; it does not need long-lived credentials
+for any of them.
+
+| Prerequisite | How |
+| --- | --- |
+| **AWS credentials** | `aws login` — browser sign-in, AWS CLI 2.32.0+. No IAM user, no access keys, and no IAM Identity Center setup. Signing in as the account root works. |
+| **AWS GitHub OIDC provider** | **auto** — created if the account doesn't already have one |
+| **Deployment role + permissions boundary** | **auto** — `ci/github-deploy-role.yaml` deployed via CloudFormation |
+| **GitHub Environment** (named exactly as the stage) with required reviewers | **auto** — `gh auth login` first. Protection rules need a public repo, or GitHub Pro/Team/Enterprise on a private one; without them the Environment is still created, unprotected. |
+| **An Auth0 tenant** (or any OIDC provider) | Tenant signup is manual — Auth0 has no API for it. Everything inside it (SPA app, custom API, post-login Action, logout discovery) is **auto** via `auth0 login` + `npm run bootstrap -- --provision-auth0`. |
+| **A Cloudflare-managed domain** | Manual. You must own the domain and delegate nameservers, and Cloudflare's `wrangler` OAuth catalog has no DNS-edit scope — so a hand-made API token with `Zone:Read` + `DNS:Edit` is required. See [Secrets & credentials](#secrets--credentials). |
+| **An existing SST stack whose Runner inventory matches `RUNNERS`** | Manual — first-Runner provisioning is not implemented here. See [Deploying to your own AWS account](#deploying-to-your-own-aws-account). |
+| **AWS CLI + GitHub CLI** (and `auth0` CLI for `--provision-auth0`) | Installed by you; the bootstrap checks for them and fails with the exact fix. |
 
 ## Deploy an existing stack
 
@@ -33,40 +41,49 @@ stage; that operation is not implemented in this repository yet.
 cd apps/infra
 npm install
 cp .env.example .env        # stage config: STACK_DOMAIN, OIDC_ISSUER_BASE_URL, OIDC_AUDIENCE
+$EDITOR .env
 
-# Cloudflare provider credentials live in SSM (per stage). Read each value
-# without terminal echo, then pass it through stdin instead of process argv:
-printf 'Cloudflare API token: ' >&2
-IFS= read -rs secret_value; printf '\n' >&2
-printf '%s' "$secret_value" | aws ssm put-parameter --region ap-southeast-1 \
-  --type SecureString --name /boxlite/dev/cloudflare-api-token --value file:///dev/stdin
-unset secret_value
-printf 'Cloudflare account ID: ' >&2
-IFS= read -rs secret_value; printf '\n' >&2
-printf '%s' "$secret_value" | aws ssm put-parameter --region ap-southeast-1 \
-  --type SecureString --name /boxlite/dev/cloudflare-account-id --value file:///dev/stdin
-unset secret_value
+aws login                   # browser sign-in; no IAM user or access keys needed
+gh auth login               # if not already authenticated
+npm run bootstrap -- --stage dev
 
-# Required application secret. There is no placeholder fallback because a wrong
-# client ID makes every interactive login fail. SST reads an omitted value from stdin.
-printf 'OIDC client ID: ' >&2
-IFS= read -rs secret_value; printf '\n' >&2
-printf '%s' "$secret_value" | npm run sst -- secret set OIDC_CLIENT_ID --stage dev
-unset secret_value
+# Optional: also provision the Auth0 tenant's app/API/Action in one pass.
+# Not idempotent — Auth0 has no upsert, so rerunning creates duplicates.
+auth0 login
+npm run bootstrap -- --stage dev --provision-auth0
+```
 
-# Bootstrap the short-lived GitHub OIDC role. The account's GitHub OIDC provider
-# already exists when the E2E CI setup has been run.
-aws cloudformation deploy --region ap-southeast-1 \
-  --stack-name boxlite-dev-github-deploy \
-  --template-file ci/github-deploy-role.yaml \
-  --capabilities CAPABILITY_NAMED_IAM
+`npm run bootstrap` (`scripts/bootstrap-environment.mjs`) is the one-time
+environment preparation step — safe to re-run, including to pick up a change to
+`ci/github-deploy-role.yaml` on an account that already has a stack. It signs in
+as **you**, not as the scoped role it provisions (that role deliberately can't
+touch CloudFormation or its own IAM policy — see
+[Native AMD64 CI deployment](#native-amd64-ci-deployment)). In order it:
 
-# In the protected GitHub `dev` Environment, configure:
-#   variable AWS_DEPLOY_ROLE_ARN = the stack's RoleArn output
-#   variable AWS_REGION          = ap-southeast-1
-#   secret   DEPLOY_ENV          = the contents of this .env file
-gh secret set DEPLOY_ENV --env dev < .env
+1. checks the AWS CLI is ≥2.32.0 and that credentials resolve, pointing at
+   `aws login` if not;
+2. registers the GitHub OIDC provider if the account lacks one;
+3. creates/updates the GitHub Environment named after the stage, requiring the
+   authenticated user as reviewer (`--reviewers 123,456` to override);
+4. optionally provisions Auth0 (`--provision-auth0`);
+5. seeds the Cloudflare credentials into SSM and `OIDC_CLIENT_ID` into the SST
+   secret store — prompting, or reading `CLOUDFLARE_API_TOKEN`,
+   `CLOUDFLARE_DEFAULT_ACCOUNT_ID`, `OIDC_CLIENT_ID` from the environment for a
+   non-interactive run;
+6. deploys the `ci/github-deploy-role.yaml` stack and writes its role ARN plus
+   `AWS_REGION` and `DEPLOY_ENV` into that Environment.
 
+Steps 1-3 and 6 are idempotent. Step 4 is **not** — Auth0 offers no upsert, so
+rerunning with `--provision-auth0` creates duplicate applications. In step 5 the
+two Cloudflare SSM parameters are skipped when already seeded (pass `--force` to
+replace them), while `OIDC_CLIENT_ID` is prompted for and rewritten every run
+unless it is supplied through the environment. See the header comment
+in `scripts/bootstrap-environment.mjs` for the full flag list — there's no
+`--help` flag, only the doc comment.
+
+Then trigger the deployment:
+
+```bash
 # The workflow is manual and accepts runs only from main. It updates an existing
 # stack; initial Runner provisioning is intentionally a separate operation.
 gh workflow run deploy-infra.yml --ref main -f stage=dev -f apply=false
@@ -83,6 +100,31 @@ and the CloudFront domain.
 If a build fails on a transient registry or package-mirror error, rerun the
 workflow — SST resumes from the failed step.
 
+### Deploying to your own AWS account
+
+`npm run bootstrap` plus the steps above prepare the AWS/GitHub account
+layer — IAM role, runtime permissions boundary, SSM credentials, GitHub
+Environment wiring — for any AWS account, any stage name, and any fork (it
+resolves the GitHub repo from `gh repo view`, or `--repo owner/name`). The
+deploy workflow itself is stage-agnostic too — `stage` is a `workflow_dispatch`
+input threaded through the GitHub Environment, the IAM boundary check, and
+every `sst` command — but its `options` list is a deliberate allowlist, not
+free text, so a required-reviewers Environment can't be targeted by an
+unbootstrapped or misspelled stage name. Deploying a stage other than `dev`
+means bootstrapping it first (`npm run bootstrap -- --stage <name>`), then
+adding `<name>` to the `stage` input's `options` in
+`.github/workflows/deploy-infra.yml` before it's selectable.
+
+Preparing the account layer is necessary but not sufficient for a genuinely
+from-zero deployment: as stated above, this workflow only reconciles an
+**existing** stack whose Runner inventory already matches `RUNNERS`.
+First-Runner provisioning — the stateful EC2/KVM host,
+[protected against replacement](#runner-lifecycle) by design — is a
+separately designed and reviewed operation not implemented in this repository
+yet. Until it lands, standing up a stack in a brand-new account still needs
+that piece done by hand before the guarded workflow above has anything to
+reconcile.
+
 ## Native AMD64 CI deployment
 
 `.github/workflows/deploy-infra.yml` runs the deployment on GitHub's native
@@ -90,8 +132,9 @@ workflow — SST resumes from the failed step.
 run in CI; a developer Mac needs neither Docker Desktop nor the Docker CLI. The
 workflow checks both the kernel and Docker engine architecture before SST runs.
 
-The job is manual, serialized, restricted to `main`, and bound to the protected
-GitHub `dev` Environment. GitHub OIDC supplies short-lived AWS credentials; no
+The job is manual, serialized, restricted to `main`, and bound to the selected
+stage's protected GitHub Environment (`dev` today — see [Deploying to your own
+AWS account](#deploying-to-your-own-aws-account) for adding another). GitHub OIDC supplies short-lived AWS credentials; no
 AWS access keys are stored in GitHub. `DEPLOY_ENV` materializes the stage's
 gitignored `.env` only for the job and is deleted even if deployment fails.
 
@@ -121,22 +164,34 @@ The role template grants only the AWS control-plane actions used by this SST
 stack. IAM mutation is limited to `boxlite-*` roles, policies, and instance
 profiles. Every role created by SST must carry the stage's runtime permissions
 boundary, which excludes IAM mutation and limits workloads to the data-plane APIs
-they need. Its trust policy accepts only OIDC tokens for `boxlite-ai/boxlite`
-using the `dev` Environment. Redeploy the bootstrap stack whenever this policy or
-boundary changes. `IAM_PERMISSIONS_BOUNDARY_STAGE` must match both the SST stage
+they need. Its trust policy accepts only OIDC tokens for the bootstrapped repo
+using that stage's Environment (`boxlite-ai/boxlite`'s `dev` Environment,
+by default). Rerun `npm run bootstrap -- --stage dev` (from
+[Deploy an existing stack](#deploy-an-existing-stack)) whenever this policy or
+boundary changes — it's idempotent, so rerunning it when nothing changed is a
+no-op. `IAM_PERMISSIONS_BOUNDARY_STAGE` must match both the SST stage
 and the template's `GitHubEnvironment`; deployment fails before creating roles if
 they differ. Keep required reviewers enabled on that Environment.
+
+After the safety tests and before any AWS resource is touched, a
+`Verify deploy role IAM boundary permissions` step
+(`scripts/verify-deploy-role-boundary.mjs`) reads the assumed role's own IAM
+policies — using only the read-only actions already granted to it — and fails
+immediately with a pointer back to `npm run bootstrap` if they don't grant
+`iam:PutRolePermissionsBoundary` for the current stage's boundary. Without it,
+the same gap surfaces as a wall of duplicate `AccessDenied` errors from every
+role SST manages, and only at the final `Deploy the full stack` step.
 
 ## Secrets & credentials
 
 Three homes, one access gate — **AWS IAM**. Nothing secret lives in git or a
 single laptop's `.env`:
 
-| What                                                                                                                              | Where                                                                        | Set with                                                         |
-| --------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | ---------------------------------------------------------------- |
-| **App secrets** — SSH host/private keys, Auth0 Management API id + secret, `SVIX_AUTH_TOKEN`, `POSTHOG_API_KEY`, `OIDC_CLIENT_ID` | SST secret store (encrypted in SST state, per stage)                         | Non-echoing prompt + SST stdin procedure below                   |
-| **Cloudflare provider creds** — `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_DEFAULT_ACCOUNT_ID`                                           | AWS SSM (`SecureString`, per stage)                                          | Non-echoing prompt + AWS CLI `file:///dev/stdin` procedure above |
-| **Stage config** — `STACK_DOMAIN`, `OIDC_ISSUER_BASE_URL`, `OIDC_AUDIENCE`, toggles                                               | GitHub Environment secret `DEPLOY_ENV`; local `.env` is the bootstrap source | `gh secret set DEPLOY_ENV --env dev < .env`                      |
+| What                                                                                                                              | Where                                                                        | Set with                                                                     |
+| --------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| **App secrets** — SSH host/private keys, Auth0 Management API id + secret, `SVIX_AUTH_TOKEN`, `POSTHOG_API_KEY`, `OIDC_CLIENT_ID` | SST secret store (encrypted in SST state, per stage)                         | `OIDC_CLIENT_ID`: `npm run bootstrap`. The rest: non-echoing prompt + SST stdin procedure below |
+| **Cloudflare provider creds** — `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_DEFAULT_ACCOUNT_ID`                                           | AWS SSM (`SecureString`, per stage); optionally GitHub Environment secrets, which the workflow exports and which take precedence | `npm run bootstrap` (see [Deploy an existing stack](#deploy-an-existing-stack)) |
+| **Stage config** — `STACK_DOMAIN`, `OIDC_ISSUER_BASE_URL`, `OIDC_AUDIENCE`, toggles                                               | GitHub Environment secret `DEPLOY_ENV`; local `.env` is the bootstrap source | `npm run bootstrap`, which runs `gh secret set DEPLOY_ENV --env <stage> < .env` |
 
 Grant each API token only the permissions and resources required for its
 documented use; the Cloudflare token needs `Zone:Read` and `DNS:Edit` for the

--- a/apps/infra/README.md
+++ b/apps/infra/README.md
@@ -69,8 +69,8 @@ gh secret set DEPLOY_ENV --env dev < .env
 
 # The workflow is manual and accepts runs only from main. It updates an existing
 # stack; initial Runner provisioning is intentionally a separate operation.
-gh workflow run deploy-dev-api.yml --ref main -f apply=false
-gh workflow run deploy-dev-api.yml --ref main -f apply=true
+gh workflow run deploy-infra.yml --ref main -f stage=dev -f apply=false
+gh workflow run deploy-infra.yml --ref main -f stage=dev -f apply=true
 ```
 
 `OIDC_CLIENT_ID` is required. Other app secrets (SSH keys, Auth0 Management API,
@@ -85,7 +85,7 @@ workflow — SST resumes from the failed step.
 
 ## Native AMD64 CI deployment
 
-`.github/workflows/deploy-dev-api.yml` runs the deployment on GitHub's native
+`.github/workflows/deploy-infra.yml` runs the deployment on GitHub's native
 `ubuntu-24.04` AMD64 runner. Docker, Buildx, image compilation, and the daemon all
 run in CI; a developer Mac needs neither Docker Desktop nor the Docker CLI. The
 workflow checks both the kernel and Docker engine architecture before SST runs.
@@ -385,7 +385,7 @@ For Auth0 specifically:
 | **ClickHouse Cloud** | Managed OTel storage                  | external service; configured by env                                      |
 | **ClickStack**       | Logs/traces/metrics explorer          | external ClickHouse Cloud UI                                             |
 
-Run the `Deploy dev stack` workflow again to redeploy. See
+Run the `Deploy stack` workflow (`deploy-infra.yml`) again to redeploy. See
 [Public hostnames](#public-hostnames) below for the rationale behind the
 dashboard-vs-API split.
 
@@ -393,10 +393,10 @@ dashboard-vs-API split.
 
 ```bash
 # Preview the protected GitHub deployment environment without mutation.
-gh workflow run deploy-dev-api.yml --ref main -f apply=false
+gh workflow run deploy-infra.yml --ref main -f stage=dev -f apply=false
 
 # After the preview passes review, evaluate again and apply the full stack.
-gh workflow run deploy-dev-api.yml --ref main -f apply=true
+gh workflow run deploy-infra.yml --ref main -f stage=dev -f apply=true
 
 npm run sst -- diff --stage dev     # preview changes
 npm run sst -- unlock --stage dev   # recover from "concurrent update detected"

--- a/apps/infra/README.md
+++ b/apps/infra/README.md
@@ -697,5 +697,7 @@ service, and the dashboard's configured API base URL.
 Figures are approximate (ap-southeast-1 on-demand). The **Runner and the load
 balancers dominate** — the NAT is ~$16, not a headline cost. Whole-stack removal
 requires a separate reviewed Proxy and Runner decommission runbook, which is not
-implemented here. S3 buckets and RDS snapshots are retained in production
-(`--stage production`) per SST's default.
+implemented here. S3 buckets and RDS snapshots are retained only on the `prod`
+stage (`--stage prod`): `sst.config.ts` sets `removal: 'retain'` for it and
+`'remove'` for every other stage. SST's own default is `retain` for all stages,
+so any stage other than `prod` is deliberately more disposable than stock SST.

--- a/apps/infra/README.md
+++ b/apps/infra/README.md
@@ -75,15 +75,15 @@ flowchart TB
 
 ## Prerequisites
 
-`npm run login` and `npm run bootstrap` set up everything except three things
-you bring yourself:
+`npm run login` and `npm run bootstrap` set up everything except the accounts
+and the stack itself:
 
 | You provide | Notes |
 | --- | --- |
 | An AWS account | `npm run login` runs `aws login` — no IAM user, no access keys |
 | A GitHub repo | `npm run login` runs `gh auth login` |
 | A Cloudflare domain + API token | One manual step — see [Cloudflare API token](#cloudflare-api-token) |
-| An OIDC tenant (Auth0 or any compliant IdP) | Signup is manual; the app, API, and Action are automated |
+| An OIDC tenant | Signup is always manual. `--provision-auth0` creates the app, API, and post-login Action **only on Auth0**; any other compliant IdP needs those created by hand |
 | An existing stack whose Runner count matches `RUNNERS` | First-Runner provisioning is not implemented here |
 
 ## Deploy an existing stack
@@ -119,9 +119,12 @@ list is an allowlist, so a typo cannot target a protected Environment.
 
 ## Secrets & credentials
 
-Nothing secret lives in git. Access is **AWS IAM only** — anyone who can deploy
-can read every secret, so onboard by granting AWS access and offboard by
-revoking it. Secrets are per-stage; seed each stage you run.
+Nothing secret lives in git, but there are **two** control planes, and
+offboarding means revoking both. Most secrets live in AWS, where anyone who can
+deploy can read them. The rest are GitHub Environment secrets (see the table
+below), reachable by anyone who can administer the repository or run the
+workflow — revoking AWS access does not touch those. Secrets are per-stage; seed
+each stage you run.
 
 | What | Stored in | Set by |
 | --- | --- | --- |
@@ -193,8 +196,11 @@ reviewed migration. Never combine them.
 **Deploys self-verify.** After a successful deploy the wrapper checks that the
 NLB listener forwards to the Proxy service's target group with healthy targets,
 probes `/health` over both the base and a wildcard hostname, and confirms
-`/api/config` reports the expected issuer, version, and Proxy host. A failed
-check exits nonzero without mutating anything.
+`/api/config` reports the expected issuer, version, and Proxy host. The check is
+read-only and exits nonzero on failure — it does **not** roll back. By the time
+it runs the deploy has already applied its changes, so a failure means the stack
+is live in the state that failed the check; recover by fixing forward or
+redeploying a known-good revision.
 
 **`/api/*` bypasses CloudFront on purpose.** CloudFront caps WebSockets at 10
 minutes, which would kill `exec`/`attach` sessions. Use

--- a/apps/infra/README.md
+++ b/apps/infra/README.md
@@ -1,773 +1,265 @@
 # BoxLite Infra (SST on AWS)
 
 > **Based on [Daytona](https://github.com/daytonaio/daytona)** by Daytona
-> Platforms Inc., licensed under AGPL-3.0. This infrastructure configuration
-> is a modified deployment of the BoxLite control plane, rebranded as BoxLite.
-> See the project root `LICENSE` file and individual source file headers for
-> full license terms.
+> Platforms Inc., licensed under AGPL-3.0. This infrastructure configuration is
+> a modified derivative of that work. See `apps/infra/LICENSE`,
+> `apps/LICENSES/AGPL-3.0.txt`, and individual source file headers for full
+> license terms. (The repository root `LICENSE` is Apache-2.0 and covers other
+> components; `apps/NOTICE` maps which license applies where.)
 
-Guarded deployment of an existing BoxLite control-plane stack: ECS Fargate
-services, an EC2 Runner with nested KVM, RDS Postgres, ElastiCache Redis, S3,
-and CloudFront.
+Deploys the BoxLite control plane: ECS Fargate services, an EC2 Runner with
+nested KVM, RDS Postgres, ElastiCache Redis, S3, and CloudFront.
 
-- **Region:** `AWS_REGION` (defaults to `ap-southeast-1`)
-- **IaC:** SST v4 (Pulumi under the hood)
-- **Cost at rest:** ~$570/month always-on — Runner + load balancers dominate
+- **Region** — `AWS_REGION`, default `ap-southeast-1`
+- **IaC** — SST v4 (Pulumi underneath)
+- **Cost** — ~$570/month always-on; see [Cost](#cost)
+
+**Where the "why" lives:** design rationale sits in `sst.config.ts` comments,
+next to the code it explains. This file is the runbook.
+
+## Architecture
+
+```mermaid
+flowchart TB
+    browser(["Browser"])
+    sdk(["SDK / CLI"])
+    idp(["OIDC IdP<br/>Auth0 · Okta · Keycloak · Dex"])
+    ghcr(["ghcr.io"])
+
+    subgraph edge["public edge"]
+        cf["CloudFront<br/>STACK_DOMAIN"]
+        alb["Api ALB<br/>api.STACK_DOMAIN<br/>idle timeout 1h"]
+        nlb["Proxy NLB · TLS 443<br/>proxy + *.proxy.STACK_DOMAIN"]
+    end
+
+    subgraph vpc["VPC · private subnets"]
+        api["Api · NestJS<br/>:3000"]
+        proxy["Proxy<br/>:4000"]
+        runner["EC2 c8i.2xlarge Runner<br/>nested KVM · :3003"]
+        box[["box microVM"]]
+
+        subgraph store["state"]
+            pg[("RDS Postgres")]
+            redis[("ElastiCache Redis")]
+            s3[("S3")]
+        end
+
+        subgraph obs["internal ALBs by default"]
+            otel["OtelCollector<br/>:4318"]
+            jaeger["Jaeger<br/>:16686"]
+            pgadmin["PgAdmin<br/>:80"]
+            maildev["MailDev<br/>:1080"]
+        end
+    end
+
+    browser -->|"dashboard SPA"| cf
+    cf --> alb
+    browser -->|"/api/* · WS · SSE"| alb
+    sdk -->|"/api/*"| alb
+    browser -->|"port preview"| nlb
+
+    alb --> api
+    nlb --> proxy
+    proxy --> box
+    runner --> box
+
+    api --> pg
+    api --> redis
+    api -->|"vended STS creds"| s3
+    api -->|"schedule boxes"| runner
+    api -.->|"validate JWT via JWKS"| idp
+    api --> otel
+    otel --> jaeger
+    runner -->|"pull box images"| ghcr
+```
 
 ## Prerequisites
 
-`npm run bootstrap` (below) provisions everything marked **auto** — you only
-need to be logged in to each service; it does not need long-lived credentials
-for any of them.
+`npm run login` and `npm run bootstrap` set up everything except three things
+you bring yourself:
 
-| Prerequisite | How |
+| You provide | Notes |
 | --- | --- |
-| **AWS credentials** | **auto** — `npm run login` runs `aws login` (browser sign-in, AWS CLI 2.32.0+). No IAM user, no access keys, and no IAM Identity Center setup. Signing in as the account root works. |
-| **AWS GitHub OIDC provider** | **auto** — created if the account doesn't already have one |
-| **Deployment role + permissions boundary** | **auto** — `ci/github-deploy-role.yaml` deployed via CloudFormation |
-| **GitHub Environment** (named exactly as the stage) with required reviewers | **auto** — `npm run login` first. Protection rules need a public repo, or GitHub Pro/Team/Enterprise on a private one; without them the Environment is still created, unprotected. |
-| **An Auth0 tenant** (or any OIDC provider) | Tenant signup is manual — Auth0 has no API for it. Everything inside it (SPA app, custom API, post-login Action, logout discovery) is **auto** via `npm run login` + `npm run bootstrap -- --provision-auth0`. |
-| **A Cloudflare-managed domain** | Manual. You must own the domain and delegate nameservers, and Cloudflare documents only dashboard creation for a first API token. Create an **account-owned** token with `Zone:Read` + `DNS:Edit`. See [Cloudflare API token](#cloudflare-api-token). |
-| **An existing SST stack whose Runner inventory matches `RUNNERS`** | Manual — first-Runner provisioning is not implemented here. See [Deploying to your own AWS account](#deploying-to-your-own-aws-account). |
-| **AWS CLI + GitHub CLI** (and `auth0` CLI for `--provision-auth0`) | Installed by you; the bootstrap checks for them and fails with the exact fix. |
+| An AWS account | `npm run login` runs `aws login` — no IAM user, no access keys |
+| A GitHub repo | `npm run login` runs `gh auth login` |
+| A Cloudflare domain + API token | One manual step — see [Cloudflare API token](#cloudflare-api-token) |
+| An OIDC tenant (Auth0 or any compliant IdP) | Signup is manual; the app, API, and Action are automated |
+| An existing stack whose Runner count matches `RUNNERS` | First-Runner provisioning is not implemented here |
 
 ## Deploy an existing stack
 
-This workflow cannot create the first Runner or recover a missing one. Complete
-a separately reviewed Runner provisioning operation before using it for a new
-stage; that operation is not implemented in this repository yet.
+This updates an existing stack. It cannot create or replace a Runner.
 
 ```bash
 cd apps/infra
 npm install
-cp .env.example .env        # stage config: STACK_DOMAIN, OIDC_ISSUER_BASE_URL, OIDC_AUDIENCE
-$EDITOR .env
+cp .env.example .env && $EDITOR .env   # STACK_DOMAIN, OIDC_ISSUER_BASE_URL, OIDC_AUDIENCE
 
-npm run login               # browser sign-in for AWS, GitHub, and Auth0
-npm run bootstrap -- --stage dev
+npm run login                          # browser sign-in: AWS, GitHub, Auth0
+npm run bootstrap -- --stage dev       # IAM role, GitHub Environment, secrets
 
-# Optional: also provision the Auth0 tenant's app/API/Action in one pass.
-# Not idempotent — Auth0 has no upsert, so rerunning creates duplicates.
+# Optional, and NOT idempotent — Auth0 has no upsert, so this duplicates apps:
 npm run bootstrap -- --stage dev --provision-auth0
+
+gh workflow run deploy-infra.yml --ref main -f stage=dev -f apply=false  # preview
+gh workflow run deploy-infra.yml --ref main -f stage=dev -f apply=true   # deploy
 ```
 
-`npm run bootstrap` (`scripts/bootstrap-environment.mjs`) is the one-time
-environment preparation step — safe to re-run, including to pick up a change to
-`ci/github-deploy-role.yaml` on an account that already has a stack. It signs in
-as **you**, not as the scoped role it provisions (that role deliberately can't
-touch CloudFormation or its own IAM policy — see
-[Native AMD64 CI deployment](#native-amd64-ci-deployment)). In order it:
+`npm run bootstrap` is safe to re-run. It prompts once per stage for the
+Cloudflare token and `OIDC_CLIENT_ID`, then stores them in SSM and the SST
+secret store; `--force` replaces already-seeded values. Its full flag list is in
+the script's header comment.
 
-1. checks the AWS CLI is ≥2.32.0 and that credentials resolve, pointing at
-   `npm run login` if not;
-2. registers the GitHub OIDC provider if the account lacks one;
-3. creates/updates the GitHub Environment named after the stage, requiring the
-   authenticated user as reviewer (`--reviewers 123,456` to override);
-4. optionally provisions Auth0 (`--provision-auth0`);
-5. seeds the Cloudflare credentials into SSM and `OIDC_CLIENT_ID` into the SST
-   secret store — prompting, or reading `CLOUDFLARE_API_TOKEN`,
-   `CLOUDFLARE_DEFAULT_ACCOUNT_ID`, `OIDC_CLIENT_ID` from the environment for a
-   non-interactive run;
-6. deploys the `ci/github-deploy-role.yaml` stack and writes its role ARN plus
-   `AWS_REGION` and `DEPLOY_ENV` into that Environment.
+A deploy takes 10–15 minutes and prints the service URLs. On a transient
+registry error, just rerun — SST resumes from the failed step.
 
-Steps 1-3 and 6 are idempotent. Step 4 is **not** — Auth0 offers no upsert, so
-rerunning with `--provision-auth0` creates duplicate applications. In step 5 the
-two Cloudflare SSM parameters are skipped when already seeded (pass `--force` to
-replace them), while `OIDC_CLIENT_ID` is prompted for and rewritten every run
-unless it is supplied through the environment. See the header comment
-in `scripts/bootstrap-environment.mjs` for the full flag list — there's no
-`--help` flag, only the doc comment.
-
-Then trigger the deployment:
-
-```bash
-# The workflow is manual and accepts runs only from main. It updates an existing
-# stack; initial Runner provisioning is intentionally a separate operation.
-gh workflow run deploy-infra.yml --ref main -f stage=dev -f apply=false
-gh workflow run deploy-infra.yml --ref main -f stage=dev -f apply=true
-```
-
-`OIDC_CLIENT_ID` is required. Other app secrets (SSH keys, Auth0 Management API,
-Svix, PostHog) are optional and set per-stage in the SST secret store — see
-[Secrets & credentials](#secrets--credentials).
-
-A full reconciliation typically takes 10–15 minutes. Output prints service URLs
-and the CloudFront domain.
-
-If a build fails on a transient registry or package-mirror error, rerun the
-workflow — SST resumes from the failed step.
-
-### Deploying to your own AWS account
-
-`npm run bootstrap` plus the steps above prepare the AWS/GitHub account
-layer — IAM role, runtime permissions boundary, SSM credentials, GitHub
-Environment wiring — for any AWS account, any stage name, and any fork (it
-resolves the GitHub repo from `gh repo view`, or `--repo owner/name`). The
-deploy workflow itself is stage-agnostic too — `stage` is a `workflow_dispatch`
-input threaded through the GitHub Environment, the IAM boundary check, and
-every `sst` command — but its `options` list is a deliberate allowlist, not
-free text, so a required-reviewers Environment can't be targeted by an
-unbootstrapped or misspelled stage name. Deploying a stage other than `dev`
-means bootstrapping it first (`npm run bootstrap -- --stage <name>`), then
-adding `<name>` to the `stage` input's `options` in
-`.github/workflows/deploy-infra.yml` before it's selectable.
-
-Preparing the account layer is necessary but not sufficient for a genuinely
-from-zero deployment: as stated above, this workflow only reconciles an
-**existing** stack whose Runner inventory already matches `RUNNERS`.
-First-Runner provisioning — the stateful EC2/KVM host,
-[protected against replacement](#runner-lifecycle) by design — is a
-separately designed and reviewed operation not implemented in this repository
-yet. Until it lands, standing up a stack in a brand-new account still needs
-that piece done by hand before the guarded workflow above has anything to
-reconcile.
-
-## Native AMD64 CI deployment
-
-`.github/workflows/deploy-infra.yml` runs the deployment on GitHub's native
-`ubuntu-24.04` AMD64 runner. Docker, Buildx, image compilation, and the daemon all
-run in CI; a developer Mac needs neither Docker Desktop nor the Docker CLI. The
-workflow checks both the kernel and Docker engine architecture before SST runs.
-
-The job is manual, serialized, restricted to `main`, and bound to the selected
-stage's protected GitHub Environment (`dev` today — see [Deploying to your own
-AWS account](#deploying-to-your-own-aws-account) for adding another). GitHub OIDC supplies short-lived AWS credentials; no
-AWS access keys are stored in GitHub. `DEPLOY_ENV` materializes the stage's
-gitignored `.env` only for the job and is deleted even if deployment fails.
-
-The workflow first runs deployment safety tests that require every Runner to
-retain `protect: true` and the AMI/user-data ignore rules. It then runs a full
-`sst diff --json` and passes the structured plan through
-`scripts/deployment-preview.mjs`. The gate rejects creating, replacing, or
-deleting a Runner instance and any in-place Runner change other than provider
-association or tags. Workflow dispatch defaults to a preview-only run; set
-`apply=true` only after reviewing it. An apply run repeats the same guarded
-preview before the full-stack deploy:
-
-```bash
-npm run deploy -- --stage dev
-```
-
-Both commands deliberately avoid `--target` and `--exclude`. Pulumi treats both
-as partial updates, which cannot safely migrate a provider while omitted
-resources still reference the old provider. Full reconciliation also avoids
-silently accumulating stack drift. The deployment wrapper rejects partial
-deploy selectors; targeted `diff` remains available for read-only inspection.
-The Runner EC2 identity and binary remain stable through the lifecycle controls
-under [Runner lifecycle](#runner-lifecycle), and the matching release-asset
-preflight always runs before deployment.
-
-The role template grants only the AWS control-plane actions used by this SST
-stack. IAM mutation is limited to `boxlite-*` roles, policies, and instance
-profiles. Every role created by SST must carry the stage's runtime permissions
-boundary, which excludes IAM mutation and limits workloads to the data-plane APIs
-they need. Its trust policy accepts only OIDC tokens for the bootstrapped repo
-using that stage's Environment (`boxlite-ai/boxlite`'s `dev` Environment,
-by default). Rerun `npm run bootstrap -- --stage dev` (from
-[Deploy an existing stack](#deploy-an-existing-stack)) whenever this policy or
-boundary changes — it's idempotent, so rerunning it when nothing changed is a
-no-op. `IAM_PERMISSIONS_BOUNDARY_STAGE` must match both the SST stage
-and the template's `GitHubEnvironment`; deployment fails before creating roles if
-they differ. Keep required reviewers enabled on that Environment.
-
-After the safety tests and before any AWS resource is touched, a
-`Verify deploy role IAM boundary permissions` step
-(`scripts/verify-deploy-role-boundary.mjs`) reads the assumed role's own IAM
-policies — using only the read-only actions already granted to it — and fails
-immediately with a pointer back to `npm run bootstrap` if they don't grant
-`iam:PutRolePermissionsBoundary` for the current stage's boundary. Without it,
-the same gap surfaces as a wall of duplicate `AccessDenied` errors from every
-role SST manages, and only at the final `Deploy the full stack` step.
+**Adding a stage:** run `npm run bootstrap -- --stage <name>`, then add `<name>`
+to the `stage` input's `options` in `.github/workflows/deploy-infra.yml`. That
+list is an allowlist, so a typo cannot target a protected Environment.
 
 ## Secrets & credentials
 
-Three homes, one access gate — **AWS IAM**. Nothing secret lives in git or a
-single laptop's `.env`:
+Nothing secret lives in git. Access is **AWS IAM only** — anyone who can deploy
+can read every secret, so onboard by granting AWS access and offboard by
+revoking it. Secrets are per-stage; seed each stage you run.
 
-| What                                                                                                                              | Where                                                                        | Set with                                                                     |
-| --------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| **App secrets** — SSH host/private keys, Auth0 Management API id + secret, `SVIX_AUTH_TOKEN`, `POSTHOG_API_KEY`, `OIDC_CLIENT_ID` | SST secret store (encrypted in SST state, per stage)                         | `OIDC_CLIENT_ID`: `npm run bootstrap`. The rest: non-echoing prompt + SST stdin procedure below |
-| **Cloudflare provider creds** — `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_DEFAULT_ACCOUNT_ID`                                           | AWS SSM (`SecureString`, per stage); optionally GitHub Environment secrets, which the workflow exports and which take precedence | `npm run bootstrap` (see [Deploy an existing stack](#deploy-an-existing-stack)) |
-| **Stage config** — `STACK_DOMAIN`, `OIDC_ISSUER_BASE_URL`, `OIDC_AUDIENCE`, toggles                                               | GitHub Environment secret `DEPLOY_ENV`; local `.env` is the bootstrap source | `npm run bootstrap`, which runs `gh secret set DEPLOY_ENV --env <stage> < .env` |
+| What | Stored in | Set by |
+| --- | --- | --- |
+| App secrets (`OIDC_CLIENT_ID`, Auth0 Management API, Svix, PostHog) | SST secret store | `npm run bootstrap`; others via `npm run sst -- secret set <NAME> --stage <stage>` reading stdin |
+| Cloudflare creds (`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_DEFAULT_ACCOUNT_ID`) | AWS SSM SecureString, or GitHub Environment secrets (which win) | `npm run bootstrap` |
+| Stage config (`STACK_DOMAIN`, `OIDC_*`, toggles) | GitHub Environment secret `DEPLOY_ENV` | `npm run bootstrap` |
 
-Grant each API token only the permissions and resources required for its
-documented use; the Cloudflare token needs `Zone:Read` and `DNS:Edit` for the
-managed zone (see [Cloudflare API token](#cloudflare-api-token)). Rotate tokens regularly and immediately after suspected
-disclosure, updating the value in SSM or the SST secret store. Never put token
-values in command arguments, echo them, enable shell tracing around
-secret-handling commands, or copy secret-bearing logs or workflow output into
-issues.
+Never pass secret values as command arguments or echo them. Rotate on any
+suspected disclosure. `npm run secrets -- --stage dev` lists what is set.
 
-`VERSION` is optional; it controls the release reported by `/api/config` and
-defaults to the canonical workspace version in `Cargo.toml`.
-
-The Cloudflare creds can't be `sst.Secret`: the provider initializes in `app()`
-before `run()` (where secrets exist), so it reads them from the environment.
-`scripts/sst-with-cloudflare.mjs` — wired into `npm run deploy`/`remove`,
-`npm run secrets`, and `npm run sst` — fetches them from SSM and exports them
-before invoking sst. `sst dev` is disabled for this stateful stack because a
-long-running process cannot refresh the Runner state baseline before every
-update.
-**Run sst through these npm scripts**, not bare `npx sst`, so the creds load.
-SST 4.6.11 exposes no supported deploy option to disable or redact this event
-stream, so the wrapper removes Pulumi's transient
-`.sst/pulumi/**/eventlog.json` before and after every wrapped SST command. These event
-streams can contain provider credentials; SST state and non-secret diagnostics
-are left in place. If an existing event log is ever found to contain a provider
-token, rotate that token immediately, then run any wrapped SST command to remove
-the stale event log.
+Run SST through the npm scripts, never bare `npx sst` — the wrapper loads
+Cloudflare creds from SSM, enforces the Runner safety policy, and scrubs
+Pulumi event logs that can contain provider credentials. `sst dev` is disabled.
 
 ### Cloudflare API token
 
-`npm run login` covers the AWS, GitHub, and Auth0 sessions with a browser
-sign-in; it cannot cover this one, so `npm run bootstrap` prompts for the value
-instead. Cloudflare states why directly:
+The one credential a browser login cannot provide: Cloudflare only issues a
+first API token through the dashboard.
 
-> "Before you can do this, you must create an API token in the Cloudflare
-> dashboard that can create subsequent tokens."
->
-> "The API Token Template `Create additional tokens` must be used to generate
-> the token. The option for `API Tokens::Edit` is not available in any other
-> template or in the Custom Token builder."
-> — [Create tokens via API](https://developers.cloudflare.com/fundamentals/api/how-to/create-via-api/)
+**[Create the token →](https://dash.cloudflare.com/?to=/:account/api-tokens&permissionGroupKeys=%5B%7B%22key%22%3A%22zone%22%2C%22type%22%3A%22read%22%7D%2C%7B%22key%22%3A%22dns%22%2C%22type%22%3A%22edit%22%7D%5D&name=BoxLite%20deploy)**
 
-So even the token-minting capability itself originates from a dashboard visit.
+That link opens the **account** token form with `Zone:Read` + `DNS:Edit`
+pre-selected. Pick the zone serving `STACK_DOMAIN`, confirm, and paste the value
+when `npm run bootstrap` prompts. Account-owned tokens survive the creator
+leaving the org; creating one needs Administrator or Super Administrator.
 
-Create it with this link, which pre-fills the permissions:
-
-[**Create the token →**](https://dash.cloudflare.com/?to=/:account/api-tokens&permissionGroupKeys=%5B%7B%22key%22%3A%22zone%22%2C%22type%22%3A%22read%22%7D%2C%7B%22key%22%3A%22dns%22%2C%22type%22%3A%22edit%22%7D%5D&name=BoxLite%20deploy)
-
-It opens the **account** token form with `Zone:Read` + `DNS:Edit` already
-selected — you pick the zone and confirm. Cloudflare is explicit that this is
-still a human step: "Template URLs only pre-fill the token creation form. Users
-must still complete the token creation process in the dashboard."
-([Template URLs](https://developers.cloudflare.com/fundamentals/api/how-to/account-owned-token-template/))
-
-Account ownership is what Cloudflare recommends for exactly this use:
-
-> "Account API tokens allow you to set up durable integrations that can act as
-> service principals with their own specific set of permissions. This approach
-> is ideal for scenarios like CI/CD ... where it is important that the
-> integration continues working, even long after the user who configured the
-> integration may have left your organization altogether."
-> — [Account-owned tokens](https://developers.cloudflare.com/fundamentals/api/get-started/account-owned-tokens/)
-
-Grant `Zone:Read` and `DNS:Edit`, restricted to the zone serving
-`STACK_DOMAIN`. The link carries no zone parameter by design — "Account token
-template URLs do not use `accountId` or `zoneId` parameters. Resource scoping
-for account tokens is configured during token creation in the dashboard" — so
-you pick the zone in the form. Creating an account-owned token requires Super
-Administrator on the account — though the template-URL page says "Super
-Administrator **or** Administrator", so the two Cloudflare pages disagree; try
-Administrator if that is the role you hold.
-
-`npm run bootstrap` prompts for the value once per stage and stores it in SSM,
-so this is a one-time step — the token is never pasted again.
-
-**Why the browser login used for AWS, GitHub, and Auth0 does not work here.**
-Cloudflare's `cf` CLI does grant `dns_records:edit` through a browser OAuth
-flow, and that token is accepted by the v4 API. It still cannot replace this
-token: the access token expires in about an hour, it is not permitted to manage API
-tokens, and refresh tokens are single-use: "Refresh tokens are single-use, so a
-long-lived process such as `wrangler dev` would otherwise send a stale value and
-get a 401 from the token endpoint"
-([`flow.ts`](https://github.com/cloudflare/workers-sdk/blob/main/packages/workers-auth/src/flow.ts)).
-A static CI secret cannot track that rotation, and two concurrent jobs sharing
-one refresh token would break the chain for both. Cloudflare also "does not
-support Client Credentials, Implicit, Resource Owner Password Credentials,
-Device Authorization, or other OAuth grant types for third-party clients"
-([OAuth clients](https://developers.cloudflare.com/fundamentals/oauth/create-an-oauth-client/)),
-so no machine-to-machine grant exists to sidestep the browser.
-
-Projects with the same unattended-DNS problem land in the same place:
-[cert-manager](https://cert-manager.io/docs/configuration/acme/dns01/cloudflare/)
-("API Tokens are recommended for higher security"),
-[external-dns](https://kubernetes-sigs.github.io/external-dns/latest/docs/tutorials/cloudflare/)
-("the token should be granted Zone `Read`, DNS `Edit` privileges, and access
-to `All zones`"), and
-[SST's own Cloudflare guide](https://sst.dev/docs/component/cloudflare/)
-("create an account token in the Cloudflare dashboard under Manage Account >
-API Tokens").
-
-### App secrets
-
-```bash
-printf 'SVIX auth token: ' >&2
-IFS= read -rs secret_value; printf '\n' >&2
-printf '%s' "$secret_value" | npm run sst -- secret set SVIX_AUTH_TOKEN --stage dev
-unset secret_value
-npm run sst -- secret load .env.secrets --stage dev # bulk-load an ignored secret dotenv
-npm run secrets -- --stage dev                      # list what's set
-```
-
-Secret names match the env keys the services expect, but values in the ordinary
-deployment `.env` are not consumed as SST application secrets. `OIDC_CLIENT_ID`
-has no fallback and must exist before deploy. Unset optional secrets resolve to
-empty (feature off). A changed value takes effect on the next `npm run deploy`.
-
-### Onboarding / offboarding
-
-Access is **AWS IAM only**: anyone who can deploy (read SST state + SSM, run
-`sst deploy`) can read every secret. Onboard by granting that AWS access;
-offboard by revoking it. There's no secret file or vault to hand over. Secret
-values and the SSM params are **per-stage** — seed each stage you run.
-
-## After deployment
-
-Nothing needs to be fed back into `.env`. Existing Runner EC2 instances
-self-report their addresses through healthchecks and remain visible in the
-dashboard Runner table or `GET /admin/runners`.
-
-### Runner inventory
-
-The default runner is auto-seeded by the API at boot. `RUNNERS` records the
-expected total (1-100), including the default Runner:
-
-```bash
-# Existing inventory: default (#1) + runner-2 + runner-3.
-echo "RUNNERS=3" >> .env
-```
-
-Routine control-plane deployment requires this inventory to match the current
-SST checkpoint exactly. It will not create a first Runner, scale out, or replace
-a missing Runner. A separately designed and reviewed provisioning operation is
-required so unknown preview-time secrets and network IDs cannot bypass the
-control-plane safety gate; none is implemented in this repository yet.
-
-Each extra runner gets its own EC2 + minted token. Because the API only
-auto-seeds the single default, the extras are registered with the control plane
-by a post-deploy step (`RegisterExtraRunners` in `sst.config.ts`, which runs
-`scripts/register-runners.mjs` against the admin API once the API is healthy).
-It's idempotent — re-running `sst deploy` won't duplicate rows. Scaling down is
-also excluded from routine deployment; see
-[Runner decommission and recovery](#runner-decommission-and-recovery).
-
-### Custom system images
-
-Add supported images through `BOXLITE_SYSTEM_IMAGES` as documented in
-`.env.example`, for example
-`sandbaseai-hermes=sam2026go/hermes-agent:boxlite-noexpose-20260726`. Runners
-cache exact image refs, so publish updated bytes under a new immutable tag or
-digest; do not repush a mutable tag and expect an existing cache to refresh.
-
-> **Note:** `CLOUDFRONT_DOMAIN` is no longer needed — SST Router resolves
-> it automatically via your `STACK_DOMAIN`. The dashboard's API base URL
-> is likewise derived: `DASHBOARD_BASE_API_URL` defaults to
-> `https://api.<STACK_DOMAIN>` and is substituted into the bundled JS at
-> container start (see `apps/api/src/main.ts`).
-
-The dashboard derives one canonical `/api` URL from that injected value and
-uses it for both runtime requests and every generated SDK/CLI example. Remote
-URLs must use HTTPS; an HTTP fallback is accepted only on a loopback host.
-
-## Public hostnames
-
-Four public DNS names, three different fronting layers:
-
-| Hostname                 | Fronted by        | Purpose                                                           |
-| ------------------------ | ----------------- | ----------------------------------------------------------------- |
-| `<STACK_DOMAIN>`         | CloudFront Router | Dashboard SPA + static assets (cache-friendly, edge-served)       |
-| `api.<STACK_DOMAIN>`     | Api ALB (direct)  | REST API, WebSocket `/attach`, build-log streaming, file transfer |
-| `proxy.<STACK_DOMAIN>`   | Proxy NLB (TLS)   | Port-preview wildcard `<port>-<boxId>.proxy.<domain>`             |
-| `*.proxy.<STACK_DOMAIN>` | Proxy NLB (TLS)   | Wildcard alias of the above (per-box preview hosts)               |
-
-**Why `/api/*` bypasses CloudFront.** CloudFront imposes a non-configurable
-10-minute idle cap on WebSocket connections — even with WS Ping frames and
-ALB-level keepalive tuning, a session through CF dies at 10 minutes. Origin
-read timeout is configurable up to 60 seconds without an AWS Support case
-(we set 60 s in `sst.config.ts`'s Router transform), so SSE streams with
-multi-minute no-byte gaps also fail under CF. Only the dashboard SPA
-(immutable hashed assets) benefits from CDN caching, so only that path is
-CF-fronted. The dashboard's bundled JS picks up
-`DASHBOARD_BASE_API_URL=https://api.<STACK_DOMAIN>` at container start (see
-`apps/api/src/main.ts::replaceInDirectory`) so all its `/api/*` fetches go
-direct to the Api ALB.
-
-**SDK and CLI base URL.** Use `https://api.<STACK_DOMAIN>/api` for SDK and CLI
-profiles, especially for long-lived operations (`exec`, `attach`, SSE, and
-uploads). The CloudFront-routed `https://<STACK_DOMAIN>/api` path is only for
-short request/response calls; WebSocket execution attach is not a supported
-CloudFront path.
-
-## Proxy deployment safety
-
-The Proxy NLB, TLS listener, and target group are protected Pulumi resources.
-An immutable topology change therefore fails instead of silently replacing a
-target group during a partial deploy. Proxy and API task updates use ECS rolling
-deployments and wait for steady state. Proxy targets must pass `GET /health`.
-
-After every successful `npm run deploy`, `scripts/sst-with-cloudflare.mjs`
-queries AWS and verifies that the NLB listener forwards to the target group
-attached to the Proxy ECS service and that the group has at least the desired
-number of healthy targets. It then probes `/health` through both the base Proxy
-hostname and a deliberately invalid `deployment-probe.<PROXY_DOMAIN>` wildcard
-hostname, which verifies the wildcard DNS record and TLS certificate without a
-live box. The API `/api/config` probe also checks the exact OIDC issuer, release
-version, and Proxy template host. A failed check makes the deploy command exit nonzero; it reports the
-mismatch but does not mutate or roll back AWS resources.
-Deploys and removals require `--stage <stage>` (or `SST_STAGE`) so SST, the
-verifier, and destructive operations cannot target different stages.
-
-A deliberate NLB or target-group migration must be performed as a separate
-operation. First set all three Proxy transform `opts.protect` values to `false`
-and deploy that metadata-only change without changing topology. Then carry out
-the separately reviewed migration or `sst remove`; restore protection afterward
-if the stack remains. This prevents a topology replacement from being mixed
-into the same deploy that disables protection.
-
-## WebSocket session length
-
-The Api ALB has `idle_timeout: 3600` (1 hour) via the SST
-`transform.loadBalancer` hook in `sst.config.ts`. Proxy traffic uses the TLS
-NLB described above. The API setting pairs with three layers per AWS's
-"WebSocket through ALB" guidance:
-
-- **App-layer WS Ping every 15s** sent by the runner
-  (`apps/runner/pkg/api/controllers/{boxlite_exec_attach,proxy}.go`). The
-  API proxies these frames transparently via `http-proxy-middleware`'s raw
-  socket pipe, so they refresh both the runner↔Api ALB and the Api ALB↔client
-  TCP segments. Required by AWS HTTP 408 troubleshooting: "Sending a TCP
-  keep-alive does not prevent this timeout. Send at least 1 byte of data
-  before each idle timeout period elapses."
-- **ALB `idle_timeout=3600`** so a brief network pause inside an active
-  session doesn't cause an RST.
-- **Node `httpServer.keepAliveTimeout = 65 * 60 * 1000`** in
-  `apps/api/src/main.ts` (must be ≥ ALB idle, per AWS HTTP 502
-  troubleshooting: "keep-alive duration of the target is shorter than the
-  idle timeout value of the load balancer").
-
-If you raise or lower the ALB idle, keep the Node `keepAliveTimeout`
-strictly greater than it.
-
-## OIDC provider setup (Auth0 example)
-
-The stack delegates all authentication to an external OIDC provider. The API
-validates JWTs via JWKS and probes the issuer's `/.well-known/openid-configuration`
-once at startup. Any standards-compliant IdP works (Auth0, Okta, Keycloak, Dex,
-Cognito, etc.) — the only hard requirement is that the JWKS URL be reachable
-from the API container.
-
-For IdPs that don't advertise `end_session_endpoint` in their discovery doc
-(Dex is the common case — see `dexidp/dex#1697`), the dashboard's logout flow
-transparently falls back through BoxLite's own `/api/auth/end-session` route.
-No operator action needed; the API auto-detects and the dashboard auto-uses it.
-
-For Auth0 specifically:
-
-1. **SPA Application** — create in Auth0. Set **Allowed Callback URLs** to
-   include both:
-   - `https://<STACK_DOMAIN>` — dashboard (web).
-   - `http://127.0.0.1:5555/callback` — `boxlite auth login --method browser`
-     (Rust CLI). RFC 8252 §8.3 requires the IPv4 loopback literal, not
-     `localhost`; no alias needed. If you change the port via the CLI's
-     `--callback-port` flag, add the matching URL here too.
-
-   Set **Allowed Logout URLs** to `https://<STACK_DOMAIN>`.
-
-2. **Custom API** — identifier becomes `OIDC_AUDIENCE` (e.g. `https://dev.boxlite.ai/api`)
-3. **Post-Login Action** — Auth0 access_tokens don't include `email_verified` by default;
-   without it BoxLite suspends the user's organization. Use
-   `functions/auth0/setCustomClaims.onExecutePostLogin.js`, copied from upstream BoxLite
-   with its AGPL-3.0 SPDX header preserved.
-   Deploy → Actions → Flows → Login → drag onto flow → Apply.
-4. **RP-Initiated Logout End Session Endpoint Discovery** — required so the SPA's
-   logout fully terminates the Auth0 session (otherwise the browser silently
-   re-authenticates via the still-alive Auth0 cookie and "Sign out" looks like a
-   page refresh). Dashboard → Settings → Advanced → "Login and Logout" → enable
-   the toggle. For tenants created on or after 14 November 2023 this is the
-   default; older tenants need the manual flip. After enabling, restart the API
-   service so its cached discovery probe re-fetches and stops emitting the
-   BoxLite fallback. ([Auth0 docs](https://auth0.com/docs/authenticate/login/logout/log-users-out-of-auth0))
-5. **Machine-to-Machine app** (optional, for account linking) — authorize for Auth0 Management API
-   with permissions: `read:users`, `update:users`, `read:connections`,
-   `create:guardian_enrollment_tickets`, `read:connections_options`. A root
-   issuer safely derives Auth0's `/api/v2/` prefix and `/oauth/token` endpoint.
-   If the provider issuer has a path, set `OIDC_MANAGEMENT_API_BASE_URL` and
-   `OIDC_MANAGEMENT_API_TOKEN_URL` to the provider's exact endpoints; the API
-   refuses to guess either value from the issuer path.
-6. **`OIDC_ISSUER_BASE_URL` env var** — set to Auth0's canonical issuer
-   **with the trailing slash** (e.g. `https://dev-xxxxx.us.auth0.com/`).
-   Auth0's discovery doc reports `issuer` with a trailing slash, and
-   spec-compliant OIDC clients (the Rust CLI's `openidconnect` crate,
-   `coreos/go-oidc` strict mode, etc.) require byte-for-byte match between
-   the URL they discover at and the `issuer` field in the returned doc.
-   Without the slash, browser/device-code flows fail with
-   `unexpected issuer URI`. apps/api passes this value through to
-   `/api/config` verbatim — fix it at the source, not in the consumer.
-
-## Service URLs
-
-| Service              | Purpose                               | Exposure                                                                 |
-| -------------------- | ------------------------------------- | ------------------------------------------------------------------------ |
-| **Dashboard SPA**    | Browser UI (static assets via CDN)    | `https://<STACK_DOMAIN>` (CloudFront)                                    |
-| **Api**              | REST API + WebSocket `/attach`        | `https://api.<STACK_DOMAIN>` (public ALB)                                |
-| **Proxy**            | `<port>-<id>.proxy.<domain>` previews | `https://*.proxy.<STACK_DOMAIN>` (public TLS NLB)                        |
-| **Jaeger**           | Trace viewer (no auth)                | internal ALB (set `JAEGER_PUBLIC=true` to expose)                        |
-| **OtelCollector**    | OTLP ingest + health                  | internal ALB (in-VPC emitters only)                                      |
-| **PgAdmin**          | Postgres admin UI                     | internal ALB (set `PGADMIN_PUBLIC=true` to expose)                       |
-| **MailDev**          | Mock SMTP + web UI (no auth)          | internal ALB only — no public option (`MAILDEV_PUBLIC=true` is rejected) |
-| **ClickHouse Cloud** | Managed OTel storage                  | external service; configured by env                                      |
-| **ClickStack**       | Logs/traces/metrics explorer          | external ClickHouse Cloud UI                                             |
-
-Run the `Deploy stack` workflow (`deploy-infra.yml`) again to redeploy. See
-[Public hostnames](#public-hostnames) below for the rationale behind the
-dashboard-vs-API split.
+Cloudflare offers no machine-to-machine OAuth grant for third-party clients, so
+this cannot be automated. Its `cf` CLI can mint a DNS-capable OAuth token, but
+it expires in about an hour and its refresh tokens are single-use — unusable as
+a stored CI secret. cert-manager, external-dns, and SST's own Cloudflare guide
+all require the same manual token.
 
 ## Common commands
 
 ```bash
-# Preview the protected GitHub deployment environment without mutation.
-gh workflow run deploy-infra.yml --ref main -f stage=dev -f apply=false
-
-# After the preview passes review, evaluate again and apply the full stack.
-gh workflow run deploy-infra.yml --ref main -f stage=dev -f apply=true
-
-npm run sst -- diff --stage dev     # preview changes
-npm run sst -- unlock --stage dev   # recover from "concurrent update detected"
-npm run sst -- shell --stage dev    # open shell with SST-linked env vars
+npm run sst -- diff --stage dev      # preview changes
+npm run sst -- unlock --stage dev    # recover from "concurrent update detected"
+npm run sst -- shell --stage dev     # shell with SST-linked env vars
+npm run runner:update -- --stage dev # roll the Runner binary, one host at a time
 ```
 
-> The workflow routes deployment through `scripts/sst-with-cloudflare.mjs` so
-> Cloudflare credentials load from SSM. Bare `npx sst …` skips that integration.
-> The wrapper also requires the repository's mandatory Runner policy for every
-> `diff` and `deploy`, and requires the SST subcommand to be the first argument.
-> `sst dev` is disabled.
-> Before each diff or deploy it exports the encrypted SST checkpoint, keeps
-> only a non-secret hash of every non-default Runner input except the four
-> deliberately mutable fields (AMI, user data, declared tags, and
-> provider-expanded tags),
-> and compares current state with desired Runner properties. The current SST
-> CLI cannot save and later apply one exact preview plan, so apply performs a
-> fresh state export and evaluation. The policy blocks every Runner create,
-> unsafe property change, changed protection, or changed identity even if the
-> human-readable preview stream is incomplete. A separate actor can still
-> change backend state between that export and Pulumi acquiring its update lock;
-> the protected Environment
-> and serialized workflow reduce this residual window but cannot eliminate it.
+Every deploy and removal requires an explicit `--stage` so the deployer, the
+verifier, and destructive operations cannot target different stages.
 
-## Runner lifecycle
+## Operating rules
 
-The Runner EC2 instance (`tag:Name=boxlite-runner-default`) holds load-bearing state:
-`/var/lib/boxlite` on its root disk, plus the in-memory libkrun VMs that back
-running boxes. **It must not be replaced by routine deploys.** Two Pulumi
-resource options on `sst.config.ts`'s Runner enforce that:
+**The Runner holds state.** `/var/lib/boxlite` and the live microVMs are on its
+root disk, so `sst.config.ts` marks it `protect: true` with
+`ignoreChanges: ['ami', 'userDataBase64']`. Routine deploys never replace it.
+The CI gate rejects any Runner create, delete, replace, or protected-property
+change — so scaling out, scaling down, and first-Runner provisioning are all
+separate reviewed operations that this repository does not implement.
 
-- `ignoreChanges: ["ami", "userDataBase64"]` — Ubuntu publishes new AMIs
-  monthly and Cargo.toml version bumps rewrite the embedded `RUNNER_VERSION`.
-  Without this option, either change would replace the EC2. With it, neither
-  change is acted on — a version bump instead reaches the running fleet through
-  the rolling upgrade below.
-- `protect: true` — refuses any deletion attempt, including a stray
-  `pulumi destroy` or stack-wide teardown.
+**Version bumps reach the fleet by rolling upgrade, not replacement.** A deploy
+runs `scripts/runner-update-binary.mjs` per host over SSM, chained so hosts
+upgrade one at a time. Each host verifies the release checksum before stopping
+its service, and restores its backup if the new binary fails to report healthy.
 
-### Upgrading the runner binary
+**Runners cache image refs exactly.** `BOXLITE_SYSTEM_IMAGES` (comma-separated
+`name=ref`) adds box images without a code deploy, but publish updated bytes
+under a new tag or digest — repushing a mutable tag leaves already-cached
+Runners serving the old image.
 
-The Runner binary version is pinned to `Cargo.toml`'s `version` field at the
-repo root. Treat a release that changes the API-to-Runner protocol as a
-capability-gated two-phase rollout:
+**Proxy topology is protected.** The NLB, TLS listener, and target group refuse
+replacement. A deliberate migration is two deploys: first set the three Proxy
+`opts.protect` values to `false` and ship that metadata-only change, then do the
+reviewed migration. Never combine them.
 
-1. Publish the matching Runner tarball and checksum, then deploy the API and
-   infrastructure. The deploy preflight refuses to mutate SST when those
-   assets are absent. Existing detached box creates remain routable to older
-   Runners; requests that need the new foreground/command session capability
-   fail explicitly until a compatible Runner is available.
-2. Upgrade Runners one at a time with the command below. The API filters those
-   requests to Runners at the required version, and each upgraded Runner only
-   becomes schedulable after the control plane reports that exact version.
+**Deploys self-verify.** After a successful deploy the wrapper checks that the
+NLB listener forwards to the Proxy service's target group with healthy targets,
+probes `/health` over both the base and a wildcard hostname, and confirms
+`/api/config` reports the expected issuer, version, and Proxy host. A failed
+check exits nonzero without mutating anything.
 
-Routine infrastructure deploys reconcile the full stack. They may update the
-Runner's provider association or tags in place, but the preview gate rejects
-creation, replacement, deletion, or other instance changes. The mandatory
-policy also requires the exact current inventory and identity, `protect: true`,
-only the two intended `ignoreChanges` properties, and equality of all other
-non-default inputs during preview and apply. The EC2 stays in place; a version
-change is delivered during the full deployment by the sequential
-`UpgradeRunnerBinary-*` SSM commands described below.
-
-Detached requests that use legacy Runner capabilities remain available during
-the compatibility window; requests needing the new Runner version fail
-explicitly until the rolling binary upgrade reaches that Runner.
-
-This bounded compatibility window is intentional: silently discarding a
-requested command or foreground lifecycle would be data loss, while sending it
-to an older Runner would be a protocol error.
-
-A version bump then lands on the next deploy:
-
-```bash
-npm run deploy -- --stage dev
-```
-
-`sst.config.ts` declares one `UpgradeRunnerBinary-*` command per Runner, each
-depending on the previous one. The intent is that the fleet upgrades **one host
-at a time** — the dependency chain, rather than anything in the script, is what
-should keep two Runners from restarting at once, and a failed host should stop
-the roll with the hosts not yet visited still serving. Each command runs
-[`scripts/runner-update-binary.mjs`](scripts/runner-update-binary.mjs) against a
-single instance id taken straight from the Pulumi graph, so extra Runners
-(`RUNNERS > 1`) are covered too. The sequencing has not yet been observed on a
-real deploy — only the script's own sequential loop has.
-
-Per host, over AWS SSM Run Command: the release tarball and its SHA-256 sidecar
-are downloaded and verified before the systemd unit is stopped — so a failed,
-missing-sidecar, or corrupt fetch never takes the Runner down — then the live
-binary is backed up, `/usr/local/bin/boxlite-runner` swapped, and the unit
-restarted. The host counts as done only once the Runner's HTTP health route
-reports the new version; if it does not come up, the backup is restored and the
-command fails. Asset URLs and the stable-version rule come from
-[`runner-release-assets.mjs`](scripts/runner-release-assets.mjs), the same
-resolver the deploy preflight uses, so an unreleasable target is rejected before
-any host is touched. The binary itself exposes no `--version` flag, so its health
-route is the only version oracle available here.
-
-The step is a converge, not a reinstall. A host is left completely alone when it
-is already serving the target version, when it is still bootstrapping (its
-user-data installs that same version anyway), or when it is serving something
-**newer** than `Cargo.toml` declares — that last case is refused rather than
-silently reverted, since a Runner ahead of the repo is usually a deliberate
-hand-install. Version ordering understands prereleases: `0.9.10` outranks
-`0.9.9`, and `0.9.8-alpha` is treated as older than `0.9.8`, so promoting a
-prerelease host to the matching release is an upgrade, not a refused downgrade.
-
-To upgrade out of band — after an interrupted roll, or to pin a version without
-deploying:
-
-```bash
-npm run runner:update              # version from Cargo.toml, every running Runner
-npm run runner:update -- 0.9.5     # explicit version
-INSTANCE_IDS=i-0abc… npm run runner:update   # one specific host
-ALLOW_DOWNGRADE=1 npm run runner:update -- 0.9.5   # deliberate rollback
-```
-
-> The Runner is **not** drained first. Files under `/var/lib/boxlite` survive,
-> but boxes running on the host being upgraded take the restart; the unit's
-> `TimeoutStopSec=60` only buys a graceful VM shutdown. Cordoning through the
-> admin API (`PATCH /runners/:id/scheduling`) would need a control-plane Runner
-> id, an operator key, and the organization-infrastructure flag, none of which
-> the deploy path has — so treat any Runner upgrade as disruptive and drain it
-> yourself when that matters.
-
-### Runner decommission and recovery
-
-The routine workflow intentionally does not provision, decommission, or recover
-Runner EC2 instances. Do not change `protect: true` or edit SST state as part of
-a normal deployment. A separate reviewed runbook must cover control-plane
-draining, pinned-box checks, the exact cloud and SST-state operations, and
-post-operation verification before any Runner is removed or recreated. That
-break-glass operation is not implemented in this repository yet.
-
-## Architecture
-
-```
-                                static SPA + assets
-  Browser ─────▶ CloudFront (Router) ─────▶ Api ALB ──▶ NestJS
-                 <STACK_DOMAIN>            (cacheable)    │
-                                                          │
-                 /api/* — REST + WS /attach + SSE + files │
-  Browser/SDK ─────────────────────▶ Api ALB direct ──────┘
-                                     api.<STACK_DOMAIN>
-                                     idle_timeout=1h  (for long WS sessions)
-
-  Browser ───▶ Proxy NLB ───▶ Proxy ECS ───▶ box port (toolbox + user-app previews)
-                proxy.<STACK_DOMAIN> + *.proxy.<STACK_DOMAIN>
-                TLS:443 → TCP:4000
-
-                          ┌───────┬────────┬────────┐
-                          │  RDS  │ Redis  │   S3   │  Api → DB/Redis (linked);
-                          │  PG   │        │ bucket │  S3 via vended STS creds
-                          └───────┴────────┴────────┘
-  private VPC
-                          ┌────────────────────────────────┐
-                          │  EC2 c8i.2xlarge Runner        │
-                          │  (nested KVM; pulls box images  │
-                          │   from ghcr.io)                │
-                          └────────────────────────────────┘
-
-Auth: OIDC provider (Auth0/Okta/Keycloak/Dex/…) ← Api validates JWT via JWKS;
-      /api/auth/end-session provides RP-initiated-logout fallback for IdPs
-      that don't advertise end_session_endpoint in discovery
-```
+**`/api/*` bypasses CloudFront on purpose.** CloudFront caps WebSockets at 10
+minutes, which would kill `exec`/`attach` sessions. Use
+`https://api.<STACK_DOMAIN>/api` for SDK and CLI profiles; the CloudFront path
+is only for short request/response calls.
 
 ## Troubleshooting
 
-**"concurrent update detected"** — run `npm run sst -- unlock --stage dev` and retry.
+**"concurrent update detected"** — `npm run sst -- unlock --stage dev`, then retry.
 
 **Service stuck at `rolloutState: FAILED` with 1 running task** — stale event
-from an earlier failed deploy. If `runningCount == desiredCount` the service
-is fine; ignore it.
+from an earlier failed deploy. If `runningCount == desiredCount`, ignore it.
 
-**Api crashes with `Failed to fetch OpenID configuration`** — the API can't
-reach `<OIDC_ISSUER_BASE_URL>/.well-known/openid-configuration`. Check network
-egress from the API container to the IdP, and confirm `OIDC_ISSUER_BASE_URL`
-points at a working host. apps/api strips a trailing slash _only_ when composing
-its own internal discovery URL; the value is exposed to clients via `/api/config`
-verbatim — see the next two entries.
+**`Failed to fetch OpenID configuration`** — the API cannot reach
+`<OIDC_ISSUER_BASE_URL>/.well-known/openid-configuration`. Check egress from the
+API container and that the issuer host works.
 
-**CLI fails with `unexpected issuer URI`** — the trailing slash on
-`OIDC_ISSUER_BASE_URL` doesn't match what the IdP's discovery doc returns
-under `issuer`. Auth0 always reports the issuer with a trailing slash; spec-
-compliant OIDC clients (including the Rust CLI's `openidconnect` crate)
-demand byte-for-byte match. Fix: set `OIDC_ISSUER_BASE_URL` to the form your
-IdP returns (Auth0: `https://dev-xxxxx.us.auth0.com/` _with_ slash). See
-the OIDC setup section above. The Rust CLI tolerates this with a one-shot
-retry that toggles the trailing slash, so the user-visible failure here is
-typically the web dashboard, not the CLI — but treat any `unexpected issuer
-URI` as a config bug on the API side.
+**`unexpected issuer URI`** — `OIDC_ISSUER_BASE_URL` does not byte-match what
+the IdP's discovery doc reports as `issuer`. Auth0 includes a trailing slash.
 
-**CLI fails with `Callback URL mismatch. The provided redirect_uri is not in
-the list of allowed callback URLs`** — Auth0 rejected the CLI's redirect URI.
-Add `http://127.0.0.1:5555/callback` to the SPA Application's
-**Allowed Callback URLs** in the Auth0 dashboard (see the OIDC setup section
-above). The dashboard's web flow uses `https://<STACK_DOMAIN>` and has always
-been registered; the CLI's loopback URL is a separate entry that's easy to
-forget.
+**`Callback URL mismatch`** — add `http://127.0.0.1:5555/callback` to the Auth0
+SPA app's Allowed Callback URLs. The CLI's loopback URL is a separate entry from
+the dashboard's.
 
-**Dashboard shows `Authentication Error: No end session endpoint` on logout** —
-the API's IdP-discovery probe failed at startup, so the dashboard never
-received the `end_session_endpoint` fallback. Check API logs for the
-`OIDC discovery probe failed; treating as 'unknown' (fail-closed)` warning;
-fix the underlying connectivity to the IdP and the next `/api/config` request
-self-heals.
+**`No end session endpoint` on logout** — the API's IdP discovery probe failed
+at startup. Fix connectivity; the next `/api/config` self-heals.
 
-**"Organization is suspended: Please verify your email address"** — Auth0 access_token
-missing `email_verified` claim. Deploy the Post-Login Action described above.
+**"Organization is suspended: Please verify your email address"** — the access
+token lacks `email_verified`. Deploy the post-login Action
+(`npm run bootstrap -- --provision-auth0`).
 
-**Runner never reaches `READY`** — the runner pairs to its DB row by token
-(`BOXLITE_RUNNER_TOKEN`, baked into the EC2's user-data, must equal the row's
-`apiKey`), then self-reports its address via `POST /runners/healthcheck` using
-`RUNNER_DOMAIN` (set from EC2 instance metadata at boot). Check the runner's
-systemd logs (`aws ssm start-session` → `journalctl -u boxlite-runner`) for auth
-or connectivity errors to the API.
+**Runner never reaches `READY`** — its `BOXLITE_RUNNER_TOKEN` must equal the DB
+row's `apiKey`. Check `journalctl -u boxlite-runner` via `aws ssm start-session`.
 
-**Box preview cannot connect** — verify that the NLB listener target group
-matches the Proxy ECS service attachment and has a registered target. Do not
-switch the listener to a replacement target group until its Proxy target passes
-`/health`.
+**Box preview cannot connect** — check that the NLB listener's target group
+matches the Proxy service attachment and has a healthy registered target.
 
-**Dashboard terminal cannot connect** — the terminal uses the direct API host,
-not the Proxy NLB. Verify `https://api.<STACK_DOMAIN>/api/config`, the API ECS
-service, and the dashboard's configured API base URL.
+**Dashboard terminal cannot connect** — it uses the direct API host, not the
+Proxy. Verify `https://api.<STACK_DOMAIN>/api/config`.
 
-**Docker build fails with "broken pipe"** — transient ECR push failure. Retry deploy.
+**Docker build "broken pipe"** — transient ECR push failure. Retry.
 
-## Cost (ap-southeast-1, always-on)
+## Cost
 
-| Resource                              | Monthly   |
-| ------------------------------------- | --------- |
-| EC2 c8i.2xlarge (Runner)              | ~$325     |
-| Load balancers (5 ALB + 2 NLB)        | ~$115     |
-| 7x Fargate 0.25 vCPU / 0.5 GB         | ~$65      |
-| 2x NAT EC2 (`t4g.nano`) + public IPv4 | ~$16      |
-| RDS `t4g.micro` Postgres              | ~$15      |
-| ElastiCache Redis                     | ~$15      |
-| CloudFront + S3 + CloudWatch Logs     | ~$20      |
-| **Total**                             | **~$570** |
+ap-southeast-1 on-demand, approximate:
 
-Figures are approximate (ap-southeast-1 on-demand). The **Runner and the load
-balancers dominate** — the NAT is ~$16, not a headline cost. Whole-stack removal
-requires a separate reviewed Proxy and Runner decommission runbook, which is not
-implemented here. S3 buckets and RDS snapshots are retained only on the `prod`
-stage (`--stage prod`): `sst.config.ts` sets `removal: 'retain'` for it and
-`'remove'` for every other stage. SST's own default is `retain` for all stages,
-so any stage other than `prod` is deliberately more disposable than stock SST.
+| Resource | Monthly |
+| --- | --- |
+| EC2 c8i.2xlarge (Runner) | ~$325 |
+| Load balancers (5 ALB + 2 NLB) | ~$115 |
+| 7x Fargate 0.25 vCPU / 0.5 GB | ~$65 |
+| CloudFront + S3 + CloudWatch Logs | ~$20 |
+| 2x NAT EC2 (`t4g.nano`) + public IPv4 | ~$16 |
+| RDS `t4g.micro` Postgres | ~$15 |
+| ElastiCache Redis | ~$15 |
+| **Total** | **~$570** |
+
+Only the `prod` stage retains S3 buckets and RDS snapshots on removal
+(`removal: 'retain'`); every other stage is disposable. Whole-stack teardown
+needs a separate reviewed Proxy and Runner decommission runbook, which is not
+implemented here.
+
+## Reference
+
+- `.env.example` — every configuration variable, with required/optional tiers
+- `sst.config.ts` — the stack itself; comments carry the design rationale
+- `scripts/*.mjs` — each script's header comment documents its flags
+- `.github/workflows/deploy-infra.yml` — the guarded CI deployment

--- a/apps/infra/functions/auth0/setCustomClaims.onExecutePostLogin.js
+++ b/apps/infra/functions/auth0/setCustomClaims.onExecutePostLogin.js
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+/**
+ * Auth0 Post-Login Action: copy the caller's identity claims onto the access
+ * token.
+ *
+ * Auth0 does not put `email`, `email_verified`, or `name` in an access token by
+ * default — they live in the ID token. The API authenticates from the access
+ * token alone (apps/api/src/auth/jwt.strategy.ts), so these are the claims an
+ * Auth0 access token must carry. (That strategy also reads `sub`, and
+ * `cid`/`uid`/`username` on other providers' tokens; none of those need setting
+ * here.) Without `email_verified` it creates the user with
+ * `emailVerified: false`, which suspends the user's organization; without
+ * `email`/`name` the user is created as 'Unknown' with an empty address.
+ *
+ * Install with `npm run bootstrap -- --provision-auth0`, which creates,
+ * deploys, and binds this Action to the post-login flow. To do it by hand:
+ * Auth0 Dashboard → Actions → Library → Build Custom → paste this body →
+ * Deploy → Flows → Login → drag onto the flow → Apply.
+ */
+exports.onExecutePostLogin = async (event, api) => {
+  if (event.authorization) {
+    api.accessToken.setCustomClaim('email_verified', event.user.email_verified)
+    api.accessToken.setCustomClaim('email', event.user.email)
+    api.accessToken.setCustomClaim('name', event.user.name)
+  }
+}

--- a/apps/infra/package.json
+++ b/apps/infra/package.json
@@ -11,6 +11,7 @@
     "sst": "node scripts/sst-with-cloudflare.mjs",
     "secrets": "node scripts/sst-with-cloudflare.mjs secret list",
     "runner:update": "node scripts/runner-update-binary.mjs",
+    "login": "node scripts/login.mjs",
     "bootstrap": "node scripts/bootstrap-environment.mjs",
     "verify-deploy-role": "node scripts/verify-deploy-role-boundary.mjs"
   },

--- a/apps/infra/package.json
+++ b/apps/infra/package.json
@@ -10,7 +10,9 @@
     "test": "node --test scripts/*.test.mjs",
     "sst": "node scripts/sst-with-cloudflare.mjs",
     "secrets": "node scripts/sst-with-cloudflare.mjs secret list",
-    "runner:update": "node scripts/runner-update-binary.mjs"
+    "runner:update": "node scripts/runner-update-binary.mjs",
+    "bootstrap": "node scripts/bootstrap-environment.mjs",
+    "verify-deploy-role": "node scripts/verify-deploy-role-boundary.mjs"
   },
   "devDependencies": {
     "@pulumi/aws": "^7.24.0",

--- a/apps/infra/scripts/auth0-provisioning.mjs
+++ b/apps/infra/scripts/auth0-provisioning.mjs
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+/*
+ * Pure argument/payload construction for provisioning an Auth0 tenant through
+ * the `auth0` CLI, replacing the six manual dashboard steps in
+ * apps/infra/README.md's "OIDC provider setup" section.
+ *
+ * The device-code token minted by `auth0 login` already carries the scopes all
+ * of this needs (create:clients, create:resource_servers, create:actions,
+ * update:actions, update:tenant_settings), so there is no
+ * create-an-M2M-app-first chicken-and-egg.
+ *
+ * Two operations have no first-class CLI verb and go through `auth0 api`, the
+ * raw Management API passthrough:
+ *   - binding a deployed Action to the post-login flow (`auth0 actions deploy`
+ *     explicitly does NOT bind: "Before an action can be bound to a flow, the
+ *     action must be deployed")
+ *   - flipping the tenant's RP-initiated-logout discovery setting
+ *
+ * Creating the tenant itself has no Management API and stays manual.
+ */
+
+const LOOPBACK_CALLBACK = 'http://127.0.0.1:5555/callback'
+
+function requireHostname(name, value) {
+  if (!value || value !== value.trim() || value.includes('/')) {
+    throw new Error(`${name} '${value}' must be a bare hostname`)
+  }
+  return value
+}
+
+/*
+ * Callback URLs must cover both front ends that complete an OIDC redirect:
+ * the dashboard SPA, and the Rust CLI's `auth login --method browser`, which
+ * RFC 8252 §8.3 requires to use the IPv4 loopback literal rather than
+ * `localhost`.
+ */
+export function spaApplicationArgs({ stackDomain, name = 'boxlite-dashboard' }) {
+  requireHostname('stackDomain', stackDomain)
+  const dashboardUrl = `https://${stackDomain}`
+  return [
+    'apps',
+    'create',
+    '--name',
+    name,
+    '--type',
+    'spa',
+    '--callbacks',
+    `${dashboardUrl},${LOOPBACK_CALLBACK}`,
+    '--logout-urls',
+    dashboardUrl,
+    '--json',
+  ]
+}
+
+// The API identifier becomes OIDC_AUDIENCE verbatim; it is an opaque
+// identifier to Auth0, not a URL it ever dereferences.
+export function customApiArgs({ stackDomain, name = 'boxlite-api' }) {
+  requireHostname('stackDomain', stackDomain)
+  return ['apis', 'create', '--name', name, '--identifier', `https://${stackDomain}/api`, '--json']
+}
+
+export function createActionArgs({ code, name = 'boxlite-custom-claims', runtime = 'node18' }) {
+  if (!code || !code.trim()) throw new Error('the post-login Action body is required')
+  return ['actions', 'create', '--name', name, '--trigger', 'post-login', '--runtime', runtime, '--code', code, '--json']
+}
+
+export function deployActionArgs(actionId) {
+  if (!actionId) throw new Error('actionId is required to deploy an Action')
+  return ['actions', 'deploy', actionId]
+}
+
+/*
+ * PATCH /api/v2/actions/triggers/post-login/bindings replaces the whole
+ * binding list, so callers must pass every binding they intend to keep — a
+ * bare single-entry payload silently unbinds anything else already on the
+ * flow.
+ */
+export function bindActionArgs({ actionId, displayName = 'boxlite-custom-claims', existingBindings = [] }) {
+  if (!actionId) throw new Error('actionId is required to bind an Action')
+  const preserved = existingBindings
+    .filter((binding) => binding?.action?.id !== actionId && binding?.display_name !== displayName)
+    .map((binding) => ({
+      ref: { type: 'action_id', value: binding.action.id },
+      display_name: binding.display_name,
+    }))
+
+  const bindings = [...preserved, { ref: { type: 'action_id', value: actionId }, display_name: displayName }]
+  return ['api', 'patch', 'actions/triggers/post-login/bindings', '--data', JSON.stringify({ bindings })]
+}
+
+// Without this the dashboard's "Sign out" only clears BoxLite's own session:
+// the still-live Auth0 cookie silently re-authenticates and logout looks like
+// a page refresh.
+export function enableRpLogoutDiscoveryArgs() {
+  return [
+    'api',
+    'patch',
+    'tenants/settings',
+    '--data',
+    JSON.stringify({ oidc_logout: { rp_logout_end_session_endpoint_discovery: true } }),
+  ]
+}

--- a/apps/infra/scripts/auth0-provisioning.mjs
+++ b/apps/infra/scripts/auth0-provisioning.mjs
@@ -3,8 +3,8 @@
 
 /*
  * Pure argument/payload construction for provisioning an Auth0 tenant through
- * the `auth0` CLI, replacing the six manual dashboard steps in
- * apps/infra/README.md's "OIDC provider setup" section.
+ * the `auth0` CLI, replacing the manual dashboard steps a fresh tenant would
+ * otherwise need. Reached through `npm run bootstrap -- --provision-auth0`.
  *
  * The device-code token minted by `auth0 login` already carries the scopes all
  * of this needs (create:clients, create:resource_servers, create:actions,

--- a/apps/infra/scripts/auth0-provisioning.mjs
+++ b/apps/infra/scripts/auth0-provisioning.mjs
@@ -79,8 +79,12 @@ export function deployActionArgs(actionId) {
  */
 export function bindActionArgs({ actionId, displayName = 'boxlite-custom-claims', existingBindings = [] }) {
   if (!actionId) throw new Error('actionId is required to bind an Action')
+  // Require action.id in the filter, not just a mismatch: a binding without an
+  // `action` object passes an inequality test and then throws in the map. A
+  // binding whose Action has been deleted is the shape to expect, and losing
+  // the whole rebind to one of those is worse than dropping it.
   const preserved = existingBindings
-    .filter((binding) => binding?.action?.id !== actionId && binding?.display_name !== displayName)
+    .filter((binding) => binding?.action?.id && binding.action.id !== actionId && binding.display_name !== displayName)
     .map((binding) => ({
       ref: { type: 'action_id', value: binding.action.id },
       display_name: binding.display_name,

--- a/apps/infra/scripts/auth0-provisioning.test.mjs
+++ b/apps/infra/scripts/auth0-provisioning.test.mjs
@@ -71,6 +71,21 @@ test('bindActionArgs preserves other bindings already on the flow', () => {
   ])
 })
 
+test('bindActionArgs skips a binding whose Action is gone instead of throwing', () => {
+  // A binding can arrive with no `action` object once the Action behind it is
+  // gone. Dereferencing that while rebuilding the list throws before the PATCH
+  // is built, so bootstrap dies with the new Action deployed but never bound —
+  // nothing is unbound, but the stage is left half-provisioned.
+  const args = bindActionArgs({
+    actionId: 'act_new',
+    existingBindings: [{ display_name: 'legacy-orphan' }, { action: { id: 'act_other' }, display_name: 'keeper' }],
+  })
+  assert.deepEqual(JSON.parse(valueAfter(args, '--data')).bindings, [
+    { ref: { type: 'action_id', value: 'act_other' }, display_name: 'keeper' },
+    { ref: { type: 'action_id', value: 'act_new' }, display_name: 'boxlite-custom-claims' },
+  ])
+})
+
 test('bindActionArgs does not duplicate itself when already bound', () => {
   const args = bindActionArgs({
     actionId: 'act_123',

--- a/apps/infra/scripts/auth0-provisioning.test.mjs
+++ b/apps/infra/scripts/auth0-provisioning.test.mjs
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  bindActionArgs,
+  createActionArgs,
+  customApiArgs,
+  deployActionArgs,
+  enableRpLogoutDiscoveryArgs,
+  spaApplicationArgs,
+} from './auth0-provisioning.mjs'
+
+function valueAfter(args, flag) {
+  const index = args.indexOf(flag)
+  return index === -1 ? undefined : args[index + 1]
+}
+
+test('spaApplicationArgs registers both the dashboard and the CLI loopback callback', () => {
+  const args = spaApplicationArgs({ stackDomain: 'dev.example.com' })
+  // RFC 8252 §8.3 requires the IPv4 loopback literal, not `localhost`.
+  assert.equal(valueAfter(args, '--callbacks'), 'https://dev.example.com,http://127.0.0.1:5555/callback')
+  assert.equal(valueAfter(args, '--logout-urls'), 'https://dev.example.com')
+  assert.equal(valueAfter(args, '--type'), 'spa')
+})
+
+test('spaApplicationArgs rejects a URL where a hostname is required', () => {
+  assert.throws(() => spaApplicationArgs({ stackDomain: 'https://dev.example.com' }), /must be a bare hostname/)
+  assert.throws(() => spaApplicationArgs({ stackDomain: '' }), /must be a bare hostname/)
+})
+
+test('customApiArgs derives the identifier that becomes OIDC_AUDIENCE', () => {
+  assert.equal(valueAfter(customApiArgs({ stackDomain: 'dev.example.com' }), '--identifier'), 'https://dev.example.com/api')
+})
+
+test('createActionArgs targets the post-login trigger with the supplied body', () => {
+  const args = createActionArgs({ code: 'exports.onExecutePostLogin = async () => {}' })
+  assert.equal(valueAfter(args, '--trigger'), 'post-login')
+  assert.equal(valueAfter(args, '--code'), 'exports.onExecutePostLogin = async () => {}')
+})
+
+test('createActionArgs refuses an empty Action body', () => {
+  assert.throws(() => createActionArgs({ code: '   ' }), /Action body is required/)
+})
+
+test('deployActionArgs deploys by id, which is a distinct step from binding', () => {
+  assert.deepEqual(deployActionArgs('act_123'), ['actions', 'deploy', 'act_123'])
+  assert.throws(() => deployActionArgs(''), /actionId is required/)
+})
+
+test('bindActionArgs binds the deployed Action to the post-login flow', () => {
+  const args = bindActionArgs({ actionId: 'act_123' })
+  assert.deepEqual(args.slice(0, 3), ['api', 'patch', 'actions/triggers/post-login/bindings'])
+  assert.deepEqual(JSON.parse(valueAfter(args, '--data')), {
+    bindings: [{ ref: { type: 'action_id', value: 'act_123' }, display_name: 'boxlite-custom-claims' }],
+  })
+})
+
+test('bindActionArgs preserves other bindings already on the flow', () => {
+  // The PATCH replaces the entire binding list, so an unrelated Action already
+  // on the post-login flow must be carried through or it is silently unbound.
+  const args = bindActionArgs({
+    actionId: 'act_new',
+    existingBindings: [{ action: { id: 'act_other' }, display_name: 'someone-elses-action' }],
+  })
+  assert.deepEqual(JSON.parse(valueAfter(args, '--data')).bindings, [
+    { ref: { type: 'action_id', value: 'act_other' }, display_name: 'someone-elses-action' },
+    { ref: { type: 'action_id', value: 'act_new' }, display_name: 'boxlite-custom-claims' },
+  ])
+})
+
+test('bindActionArgs does not duplicate itself when already bound', () => {
+  const args = bindActionArgs({
+    actionId: 'act_123',
+    existingBindings: [{ action: { id: 'act_123' }, display_name: 'boxlite-custom-claims' }],
+  })
+  assert.deepEqual(JSON.parse(valueAfter(args, '--data')).bindings, [
+    { ref: { type: 'action_id', value: 'act_123' }, display_name: 'boxlite-custom-claims' },
+  ])
+})
+
+test('enableRpLogoutDiscoveryArgs flips the tenant logout-discovery setting', () => {
+  const args = enableRpLogoutDiscoveryArgs()
+  assert.deepEqual(args.slice(0, 3), ['api', 'patch', 'tenants/settings'])
+  assert.deepEqual(JSON.parse(valueAfter(args, '--data')), {
+    oidc_logout: { rp_logout_end_session_endpoint_discovery: true },
+  })
+})
+

--- a/apps/infra/scripts/bootstrap-environment.mjs
+++ b/apps/infra/scripts/bootstrap-environment.mjs
@@ -31,12 +31,13 @@
  *   --force      see decideSsmOverwrite() in environment-bootstrap.mjs
  *   --provision-auth0
  *                Create the Auth0 SPA app, custom API, and post-login Action
- *                (requires `auth0 login` first). NOT idempotent — Auth0 has no
+ *                (requires `npm run login` first). NOT idempotent — Auth0 has no
  *                upsert for apps or APIs, so rerunning creates duplicates.
  *
- * AWS credentials: run `aws login` (browser sign-in, AWS CLI 2.32.0+) — no IAM
- * user, access keys, or IAM Identity Center setup required. An existing profile
- * or SSO session is used as-is if one is already active.
+ * Sign-in: run `npm run login` first, which walks the browser sign-in for every
+ * provider this needs (AWS via `aws login`, AWS CLI 2.32.0+ — no IAM user,
+ * access keys, or IAM Identity Center setup required). An existing profile or
+ * SSO session is used as-is if one is already active.
  *
  * Non-interactive use (e.g. wiring this into a more-privileged automation
  * later): set CLOUDFLARE_API_TOKEN, CLOUDFLARE_DEFAULT_ACCOUNT_ID, and
@@ -48,6 +49,7 @@ import { existsSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+import { hasFlag, parseFlag } from './cli-flags.mjs'
 import { loadDeploymentEnvironment, resolveAwsRegion } from './deployment-environment.mjs'
 import {
   GITHUB_OIDC_PROVIDER_URL,
@@ -86,26 +88,16 @@ const SST_WRAPPER_PATH = join(INFRA_ROOT, 'scripts', 'sst-with-cloudflare.mjs')
 const ACTION_SOURCE_PATH = join(INFRA_ROOT, 'functions', 'auth0', 'setCustomClaims.onExecutePostLogin.js')
 
 const CLOUDFLARE_CREDENTIALS = [
-  { envVar: 'CLOUDFLARE_API_TOKEN', param: 'cloudflare-api-token', label: 'Cloudflare API token' },
+  {
+    envVar: 'CLOUDFLARE_API_TOKEN',
+    param: 'cloudflare-api-token',
+    // Cloudflare issues the first API token through the dashboard only, so
+    // this cannot be obtained by a browser login the way AWS/GitHub/Auth0 are.
+    // Account-owned keeps the integration working after the creator leaves.
+    label: 'Cloudflare API token (account-owned, Zone:Read + DNS:Edit)',
+  },
   { envVar: 'CLOUDFLARE_DEFAULT_ACCOUNT_ID', param: 'cloudflare-account-id', label: 'Cloudflare account ID' },
 ]
-
-function parseFlag(args, name) {
-  for (let index = 0; index < args.length; index += 1) {
-    if (args[index] === `--${name}`) {
-      const value = args[index + 1]
-      if (!value || value.startsWith('-')) throw new Error(`--${name} requires a value`)
-      return value
-    }
-    const inline = args[index].match(new RegExp(`^--${name}=(.*)$`))?.[1]
-    if (inline !== undefined) return inline
-  }
-  return undefined
-}
-
-function hasFlag(args, name) {
-  return args.includes(`--${name}`)
-}
 
 function requireStageEnvFile() {
   if (!existsSync(ENV_PATH)) {
@@ -118,7 +110,7 @@ function requireGhAuthenticated() {
   try {
     execFileSync('gh', ['auth', 'status'], { stdio: 'ignore', timeout: 15_000, killSignal: 'SIGTERM' })
   } catch (cause) {
-    throw new Error('GitHub CLI is not authenticated; run `gh auth login` first', { cause })
+    throw new Error('GitHub CLI is not authenticated; run `npm run login` first', { cause })
   }
 }
 
@@ -177,7 +169,7 @@ function currentAwsIdentity(awsCliPath, region) {
     })
   } catch (cause) {
     throw new Error(
-      'no usable AWS credentials. Run `aws login` and complete the browser sign-in ' +
+      'no usable AWS credentials. Run `npm run login`, which opens the `aws login` browser sign-in ' +
         '(no IAM user or access keys needed; signing in as the account root works), then rerun this command. ' +
         'An existing profile or SSO session works too — this step only needs `sts:GetCallerIdentity` to succeed.',
       { cause },
@@ -413,7 +405,7 @@ function provisionAuth0({ stackDomain }) {
   try {
     execFileSync('auth0', ['tenants', 'list'], { stdio: 'ignore', timeout: 30_000, killSignal: 'SIGTERM' })
   } catch (cause) {
-    throw new Error('the auth0 CLI is not authenticated; run `auth0 login` and complete the browser consent', { cause })
+    throw new Error('the auth0 CLI is not authenticated; run `npm run login` and complete the browser consent', { cause })
   }
 
   const app = auth0Json(spaApplicationArgs({ stackDomain }))

--- a/apps/infra/scripts/bootstrap-environment.mjs
+++ b/apps/infra/scripts/bootstrap-environment.mjs
@@ -81,6 +81,9 @@ import { resolveAwsCliPath } from './proxy-deployment-verify.mjs'
 import { resolveSstStage } from './sst-stage.mjs'
 
 const SCRIPT_NAME = 'bootstrap-environment'
+// The one stage that must never end up with an unreviewed deploy path. Matches
+// PRODUCTION_STAGE in sst.config.ts, which gates retain-on-removal.
+const PROTECTED_STAGE = 'prod'
 const INFRA_ROOT = fileURLToPath(new URL('..', import.meta.url))
 const TEMPLATE_PATH = join(INFRA_ROOT, 'ci', 'github-deploy-role.yaml')
 const ENV_PATH = join(INFRA_ROOT, '.env')
@@ -182,6 +185,14 @@ function currentAwsIdentity(awsCliPath, region) {
   return identity
 }
 
+// A blank answer at the prompt, or an env var set to '', would otherwise be
+// stored as a real secret and only surface as an auth failure at deploy time.
+function requireNonEmptySecret(label, value) {
+  const trimmed = value?.trim()
+  if (!trimmed) throw new Error(`${label} cannot be empty`)
+  return trimmed
+}
+
 // No native masked-input in node:readline — a minimal raw-mode reader avoids
 // pulling in a prompt dependency for two secrets. TTY-gated: a non-interactive
 // caller (CI, a script) must supply the value through the matching env var
@@ -202,26 +213,37 @@ function promptSecret(label) {
       stdin.pause()
       stdin.removeListener('data', onData)
     }
-    const onData = (char) => {
-      switch (char) {
-        case '\n':
-        case '\r':
-        case '\u0004':
-          cleanup()
-          process.stdout.write('\n')
-          resolvePrompt(value)
-          break
-        case '\u0003':
-          cleanup()
-          process.stdout.write('\n')
-          reject(new Error('interrupted'))
-          break
-        case '\u007f':
-        case '\b':
-          value = value.slice(0, -1)
-          break
-        default:
-          value += char
+    // Raw mode delivers a chunk, not a keystroke: a pasted token arrives as one
+    // string, usually with its terminator attached. Comparing the chunk itself
+    // sends the whole paste to `default`, so the secret keeps the trailing
+    // control character and the prompt never resolves. Step through characters,
+    // and stop at the first terminator so anything typed after it is ignored.
+    let settled = false
+    const onData = (chunk) => {
+      for (const char of chunk) {
+        if (settled) return
+        switch (char) {
+          case '\n':
+          case '\r':
+          case '\u0004':
+            settled = true
+            cleanup()
+            process.stdout.write('\n')
+            resolvePrompt(value)
+            break
+          case '\u0003':
+            settled = true
+            cleanup()
+            process.stdout.write('\n')
+            reject(new Error('interrupted'))
+            break
+          case '\u007f':
+          case '\b':
+            value = value.slice(0, -1)
+            break
+          default:
+            value += char
+        }
       }
     }
     stdin.on('data', onData)
@@ -252,7 +274,7 @@ function putSsmSecureParameter(awsCliPath, region, name, value) {
 async function ensureCloudflareCredentials({ awsCliPath, region, stage, force }) {
   for (const { envVar, param, label } of CLOUDFLARE_CREDENTIALS) {
     const name = ssmParameterName(stage, param)
-    const fromEnv = process.env[envVar]
+    const fromEnv = process.env[envVar]?.trim()
     if (fromEnv) {
       putSsmSecureParameter(awsCliPath, region, name, fromEnv)
       console.log(`[${SCRIPT_NAME}] ${label} ... set from ${envVar}`)
@@ -265,7 +287,7 @@ async function ensureCloudflareCredentials({ awsCliPath, region, stage, force })
       continue
     }
 
-    const value = await promptSecret(`${label}: `)
+    const value = requireNonEmptySecret(label, await promptSecret(`${label}: `))
     putSsmSecureParameter(awsCliPath, region, name, value)
     console.log(`[${SCRIPT_NAME}] ${label} ... set`)
   }
@@ -275,8 +297,11 @@ async function ensureCloudflareCredentials({ awsCliPath, region, stage, force })
 // call) so this stays the one place that knows how to reach the sst binary —
 // see scripts/sst-with-cloudflare.mjs's own header comment for why.
 async function ensureOidcClientId(stage) {
-  const fromEnv = process.env.OIDC_CLIENT_ID
-  const value = fromEnv ?? (await promptSecret('OIDC client ID: '))
+  // `?.trim() || undefined` rather than `??`: an env var set to the empty
+  // string is a misconfiguration, not a choice to store nothing, and `??` would
+  // accept it and seed an empty secret that only fails at deploy time.
+  const fromEnv = process.env.OIDC_CLIENT_ID?.trim() || undefined
+  const value = requireNonEmptySecret('OIDC client ID', fromEnv ?? (await promptSecret('OIDC client ID: ')))
   execFileSync(process.execPath, [SST_WRAPPER_PATH, 'secret', 'set', 'OIDC_CLIENT_ID', '--stage', stage], {
     input: value,
     encoding: 'utf8',
@@ -359,6 +384,19 @@ function ensureGithubEnvironment({ repo, stage, reviewerIds }) {
   } catch (error) {
     const stderr = error.stderr?.toString() ?? ''
     if (!isProtectionUnavailableError(stderr) || reviewerIds.length === 0) throw error
+
+    // Fail closed on the protected stage. Everywhere else an unprotected
+    // environment is a downgrade worth taking to keep bootstrap moving; for
+    // prod it would silently produce the thing the reviewers exist to prevent
+    // — a stage anyone who can run the workflow can deploy unreviewed.
+    if (stage === PROTECTED_STAGE) {
+      throw new Error(
+        `refusing to create the GitHub '${stage}' environment without required reviewers: ` +
+          'deployment protection rules need a public repository, or GitHub Pro/Team/Enterprise ' +
+          'on a private one. Enable protection for this repository, then rerun.',
+        { cause: error },
+      )
+    }
 
     // Protection rules need a public repo, or a paid plan on a private one.
     // The environment itself still has to exist for vars/secrets to land, so

--- a/apps/infra/scripts/bootstrap-environment.mjs
+++ b/apps/infra/scripts/bootstrap-environment.mjs
@@ -1,0 +1,566 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+/*
+ * Idempotent, human-run environment preparation for a BoxLite SST
+ * deployment: the GitHub OIDC deploy role + runtime IAM boundary
+ * (ci/github-deploy-role.yaml), the Cloudflare provider credentials in SSM,
+ * the OIDC_CLIENT_ID SST secret, and the GitHub `<stage>` Environment
+ * variables/secret the deploy workflow reads. See apps/infra/README.md's
+ * "Deploy an existing stack" section for the full prerequisite list this
+ * script does NOT cover (Cloudflare domain, Auth0/OIDC tenant, an existing
+ * Runner — first-Runner provisioning is a separate, not-yet-built operation).
+ *
+ * Safe to re-run any number of times: every step reconciles to the desired
+ * state instead of failing on "already exists". Requires AWS credentials
+ * with IAM/SSM/CloudFormation access — deliberately NOT the scoped deploy
+ * role this script provisions, which cannot touch CloudFormation or its own
+ * IAM policy by design (see the CreateBoundedBoxLiteRoles /
+ * SetBoxLiteRoleBoundary statements in ci/github-deploy-role.yaml) — and a
+ * `gh` CLI authenticated against the target repo.
+ *
+ * Usage: node scripts/bootstrap-environment.mjs [--stage dev] [--repo owner/name]
+ *                                               [--reviewers 123,456] [--force]
+ *   --stage      SST stage to bootstrap (default: dev, or SST_STAGE). The GitHub
+ *                Environment must be named exactly this — the deploy role's trust
+ *                policy pins `repo:<owner>/<repo>:environment:<stage>`.
+ *   --repo       GitHub repo as owner/name (default: `gh repo view` in this checkout —
+ *                a community fork resolves to itself automatically)
+ *   --reviewers  Comma-separated numeric GitHub user ids required to approve a
+ *                deployment (default: whoever is authenticated with `gh`)
+ *   --force      see decideSsmOverwrite() in environment-bootstrap.mjs
+ *   --provision-auth0
+ *                Create the Auth0 SPA app, custom API, and post-login Action
+ *                (requires `auth0 login` first). NOT idempotent — Auth0 has no
+ *                upsert for apps or APIs, so rerunning creates duplicates.
+ *
+ * AWS credentials: run `aws login` (browser sign-in, AWS CLI 2.32.0+) — no IAM
+ * user, access keys, or IAM Identity Center setup required. An existing profile
+ * or SSO session is used as-is if one is already active.
+ *
+ * Non-interactive use (e.g. wiring this into a more-privileged automation
+ * later): set CLOUDFLARE_API_TOKEN, CLOUDFLARE_DEFAULT_ACCOUNT_ID, and
+ * OIDC_CLIENT_ID in the environment and no prompts fire.
+ */
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { loadDeploymentEnvironment, resolveAwsRegion } from './deployment-environment.mjs'
+import {
+  GITHUB_OIDC_PROVIDER_URL,
+  MINIMUM_AWS_CLI_VERSION,
+  cloudFormationDeployChanged,
+  cloudFormationParameterOverrides,
+  decideSsmOverwrite,
+  githubDeployRoleStackName,
+  hasGitHubOidcProvider,
+  isAwsCliVersionAtLeast,
+  ssmParameterName,
+  validateGitHubRepo,
+} from './environment-bootstrap.mjs'
+import {
+  bindActionArgs,
+  createActionArgs,
+  customApiArgs,
+  deployActionArgs,
+  enableRpLogoutDiscoveryArgs,
+  spaApplicationArgs,
+} from './auth0-provisioning.mjs'
+import {
+  environmentApiPath,
+  githubEnvironmentPayload,
+  isProtectionUnavailableError,
+  parseReviewerIds,
+} from './github-environment.mjs'
+import { resolveAwsCliPath } from './proxy-deployment-verify.mjs'
+import { resolveSstStage } from './sst-stage.mjs'
+
+const SCRIPT_NAME = 'bootstrap-environment'
+const INFRA_ROOT = fileURLToPath(new URL('..', import.meta.url))
+const TEMPLATE_PATH = join(INFRA_ROOT, 'ci', 'github-deploy-role.yaml')
+const ENV_PATH = join(INFRA_ROOT, '.env')
+const SST_WRAPPER_PATH = join(INFRA_ROOT, 'scripts', 'sst-with-cloudflare.mjs')
+const ACTION_SOURCE_PATH = join(INFRA_ROOT, 'functions', 'auth0', 'setCustomClaims.onExecutePostLogin.js')
+
+const CLOUDFLARE_CREDENTIALS = [
+  { envVar: 'CLOUDFLARE_API_TOKEN', param: 'cloudflare-api-token', label: 'Cloudflare API token' },
+  { envVar: 'CLOUDFLARE_DEFAULT_ACCOUNT_ID', param: 'cloudflare-account-id', label: 'Cloudflare account ID' },
+]
+
+function parseFlag(args, name) {
+  for (let index = 0; index < args.length; index += 1) {
+    if (args[index] === `--${name}`) {
+      const value = args[index + 1]
+      if (!value || value.startsWith('-')) throw new Error(`--${name} requires a value`)
+      return value
+    }
+    const inline = args[index].match(new RegExp(`^--${name}=(.*)$`))?.[1]
+    if (inline !== undefined) return inline
+  }
+  return undefined
+}
+
+function hasFlag(args, name) {
+  return args.includes(`--${name}`)
+}
+
+function requireStageEnvFile() {
+  if (!existsSync(ENV_PATH)) {
+    throw new Error(`${ENV_PATH} does not exist; run \`cp .env.example .env\` and fill it in first`)
+  }
+  return ENV_PATH
+}
+
+function requireGhAuthenticated() {
+  try {
+    execFileSync('gh', ['auth', 'status'], { stdio: 'ignore', timeout: 15_000, killSignal: 'SIGTERM' })
+  } catch (cause) {
+    throw new Error('GitHub CLI is not authenticated; run `gh auth login` first', { cause })
+  }
+}
+
+function resolveRepo(args) {
+  const override = parseFlag(args, 'repo')
+  if (override) return validateGitHubRepo(override)
+
+  let nameWithOwner
+  try {
+    nameWithOwner = execFileSync('gh', ['repo', 'view', '--json', 'nameWithOwner', '--jq', '.nameWithOwner'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 15_000,
+      killSignal: 'SIGTERM',
+    }).trim()
+  } catch (cause) {
+    throw new Error(
+      "could not determine the GitHub repository from `gh repo view`; run this from the repo's working directory or pass --repo owner/name",
+      { cause },
+    )
+  }
+  return validateGitHubRepo(nameWithOwner)
+}
+
+/*
+ * `aws login` (browser sign-in with AWS Management Console credentials) is the
+ * lowest-friction way to get credentials here: it needs no IAM user, no
+ * long-lived access keys, and no IAM Identity Center — which itself takes a
+ * separate console setup. It landed in AWS CLI 2.32.0, so an older CLI can't
+ * be pointed at it.
+ */
+function requireAwsCliWithLoginSupport(awsCliPath) {
+  const versionBanner = execFileSync(awsCliPath, ['--version'], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: 15_000,
+    killSignal: 'SIGTERM',
+  })
+  if (!isAwsCliVersionAtLeast(versionBanner)) {
+    throw new Error(
+      `AWS CLI ${MINIMUM_AWS_CLI_VERSION}+ is required for \`aws login\` (found ${versionBanner.trim().split(' ')[0]}); ` +
+        'upgrade the CLI, or supply credentials another way before rerunning',
+    )
+  }
+  return versionBanner
+}
+
+function currentAwsIdentity(awsCliPath, region) {
+  let stdout
+  try {
+    stdout = execFileSync(awsCliPath, ['sts', 'get-caller-identity', '--region', region, '--output', 'json'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 15_000,
+      killSignal: 'SIGTERM',
+    })
+  } catch (cause) {
+    throw new Error(
+      'no usable AWS credentials. Run `aws login` and complete the browser sign-in ' +
+        '(no IAM user or access keys needed; signing in as the account root works), then rerun this command. ' +
+        'An existing profile or SSO session works too — this step only needs `sts:GetCallerIdentity` to succeed.',
+      { cause },
+    )
+  }
+  const identity = JSON.parse(stdout)
+  if (!identity.Account || !identity.Arn) {
+    throw new Error('aws sts get-caller-identity returned an unexpected response')
+  }
+  return identity
+}
+
+// No native masked-input in node:readline — a minimal raw-mode reader avoids
+// pulling in a prompt dependency for two secrets. TTY-gated: a non-interactive
+// caller (CI, a script) must supply the value through the matching env var
+// instead of hanging on a prompt that can never be answered.
+function promptSecret(label) {
+  if (!process.stdin.isTTY) {
+    throw new Error(`${label} has no value and stdin is not a TTY to prompt for one; set the matching env var instead`)
+  }
+  process.stdout.write(label)
+  return new Promise((resolvePrompt, reject) => {
+    const { stdin } = process
+    stdin.resume()
+    stdin.setRawMode(true)
+    stdin.setEncoding('utf8')
+    let value = ''
+    const cleanup = () => {
+      stdin.setRawMode(false)
+      stdin.pause()
+      stdin.removeListener('data', onData)
+    }
+    const onData = (char) => {
+      switch (char) {
+        case '\n':
+        case '\r':
+        case '\u0004':
+          cleanup()
+          process.stdout.write('\n')
+          resolvePrompt(value)
+          break
+        case '\u0003':
+          cleanup()
+          process.stdout.write('\n')
+          reject(new Error('interrupted'))
+          break
+        case '\u007f':
+        case '\b':
+          value = value.slice(0, -1)
+          break
+        default:
+          value += char
+      }
+    }
+    stdin.on('data', onData)
+  })
+}
+
+function ssmParameterExists(awsCliPath, region, name) {
+  try {
+    execFileSync(awsCliPath, ['ssm', 'get-parameter', '--region', region, '--name', name], {
+      stdio: 'ignore',
+      timeout: 15_000,
+      killSignal: 'SIGTERM',
+    })
+    return true
+  } catch {
+    return false // ParameterNotFound (or a transient error — the put below is the real signal)
+  }
+}
+
+function putSsmSecureParameter(awsCliPath, region, name, value) {
+  execFileSync(
+    awsCliPath,
+    ['ssm', 'put-parameter', '--region', region, '--type', 'SecureString', '--name', name, '--value', 'file:///dev/stdin', '--overwrite'],
+    { input: value, encoding: 'utf8', stdio: ['pipe', 'ignore', 'pipe'], timeout: 15_000, killSignal: 'SIGTERM' },
+  )
+}
+
+async function ensureCloudflareCredentials({ awsCliPath, region, stage, force }) {
+  for (const { envVar, param, label } of CLOUDFLARE_CREDENTIALS) {
+    const name = ssmParameterName(stage, param)
+    const fromEnv = process.env[envVar]
+    if (fromEnv) {
+      putSsmSecureParameter(awsCliPath, region, name, fromEnv)
+      console.log(`[${SCRIPT_NAME}] ${label} ... set from ${envVar}`)
+      continue
+    }
+
+    const exists = ssmParameterExists(awsCliPath, region, name)
+    if (decideSsmOverwrite({ exists, force }) === 'skip') {
+      console.log(`[${SCRIPT_NAME}] ${label} ... already set (use --force to change)`)
+      continue
+    }
+
+    const value = await promptSecret(`${label}: `)
+    putSsmSecureParameter(awsCliPath, region, name, value)
+    console.log(`[${SCRIPT_NAME}] ${label} ... set`)
+  }
+}
+
+// Routed through the same wrapper `npm run deploy`/`diff` use (not a bare sst
+// call) so this stays the one place that knows how to reach the sst binary —
+// see scripts/sst-with-cloudflare.mjs's own header comment for why.
+async function ensureOidcClientId(stage) {
+  const fromEnv = process.env.OIDC_CLIENT_ID
+  const value = fromEnv ?? (await promptSecret('OIDC client ID: '))
+  execFileSync(process.execPath, [SST_WRAPPER_PATH, 'secret', 'set', 'OIDC_CLIENT_ID', '--stage', stage], {
+    input: value,
+    encoding: 'utf8',
+    stdio: ['pipe', 'inherit', 'inherit'],
+    timeout: 60_000,
+    killSignal: 'SIGTERM',
+    cwd: INFRA_ROOT,
+  })
+  console.log(`[${SCRIPT_NAME}] OIDC_CLIENT_ID ... set${fromEnv ? ' from OIDC_CLIENT_ID env' : ''}`)
+}
+
+/*
+ * The deploy role's trust policy federates to this provider, but the provider
+ * is account-global and CreateOpenIDConnectProvider rejects a duplicate URL
+ * with EntityAlreadyExists — so detect before creating. Any account that has
+ * ever wired GitHub Actions to AWS already has one. The thumbprint is
+ * deliberately omitted: since July 2023 IAM validates GitHub's OIDC endpoint
+ * against trusted root CAs, so pinning one would only create rotation work.
+ */
+function ensureGitHubOidcProvider({ awsCliPath, region }) {
+  const listOutput = JSON.parse(
+    execFileSync(awsCliPath, ['iam', 'list-open-id-connect-providers', '--region', region, '--output', 'json'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 15_000,
+      killSignal: 'SIGTERM',
+    }),
+  )
+  if (hasGitHubOidcProvider(listOutput)) {
+    console.log(`[${SCRIPT_NAME}] GitHub OIDC provider ... already registered`)
+    return
+  }
+
+  execFileSync(
+    awsCliPath,
+    [
+      'iam',
+      'create-open-id-connect-provider',
+      '--region',
+      region,
+      '--url',
+      GITHUB_OIDC_PROVIDER_URL,
+      '--client-id-list',
+      'sts.amazonaws.com',
+    ],
+    { stdio: ['ignore', 'ignore', 'pipe'], timeout: 30_000, killSignal: 'SIGTERM' },
+  )
+  console.log(`[${SCRIPT_NAME}] GitHub OIDC provider ... created`)
+}
+
+function authenticatedGitHubUserId() {
+  return Number(
+    execFileSync('gh', ['api', 'user', '--jq', '.id'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 15_000,
+      killSignal: 'SIGTERM',
+    }).trim(),
+  )
+}
+
+/*
+ * The deploy workflow binds to `environment: <stage>` and the role's trust
+ * policy pins `repo:<owner>/<repo>:environment:<stage>`, so this must exist
+ * under exactly the stage name before either works. `gh variable set --env`
+ * does NOT create it.
+ */
+function ensureGithubEnvironment({ repo, stage, reviewerIds }) {
+  const payload = githubEnvironmentPayload({ reviewerIds })
+  try {
+    execFileSync('gh', ['api', '--method', 'PUT', environmentApiPath(repo, stage), '--input', '-'], {
+      input: JSON.stringify(payload),
+      stdio: ['pipe', 'ignore', 'pipe'],
+      timeout: 30_000,
+      killSignal: 'SIGTERM',
+    })
+    const reviewers = reviewerIds.length > 0 ? `required reviewers: ${reviewerIds.join(', ')}` : 'no required reviewers'
+    console.log(`[${SCRIPT_NAME}] GitHub ${stage} environment ... ready (${reviewers})`)
+    return
+  } catch (error) {
+    const stderr = error.stderr?.toString() ?? ''
+    if (!isProtectionUnavailableError(stderr) || reviewerIds.length === 0) throw error
+
+    // Protection rules need a public repo, or a paid plan on a private one.
+    // The environment itself still has to exist for vars/secrets to land, so
+    // fall back to an unprotected one rather than blocking the bootstrap.
+    execFileSync('gh', ['api', '--method', 'PUT', environmentApiPath(repo, stage), '--input', '-'], {
+      input: JSON.stringify(githubEnvironmentPayload({ reviewerIds: [] })),
+      stdio: ['pipe', 'ignore', 'inherit'],
+      timeout: 30_000,
+      killSignal: 'SIGTERM',
+    })
+    console.warn(
+      `[${SCRIPT_NAME}] GitHub ${stage} environment ... created WITHOUT required reviewers ` +
+        '(deployment protection rules need a public repository, or GitHub Pro/Team/Enterprise on a private one). ' +
+        'Anyone who can run the workflow can deploy this stage unreviewed.',
+    )
+  }
+}
+
+function auth0Json(args) {
+  return JSON.parse(
+    execFileSync('auth0', args, {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 60_000,
+      killSignal: 'SIGTERM',
+    }),
+  )
+}
+
+function auth0Run(args) {
+  execFileSync('auth0', args, { stdio: ['ignore', 'ignore', 'pipe'], timeout: 60_000, killSignal: 'SIGTERM' })
+}
+
+/*
+ * Collapses the five manual Auth0 dashboard steps in README's "OIDC provider
+ * setup" into API calls. The `auth0 login` device-code token already carries
+ * every scope this needs, so there is no create-an-M2M-app-first step.
+ *
+ * Not idempotent the way the AWS/GitHub steps are: Auth0 has no upsert for
+ * applications or APIs, so rerunning creates duplicates. Gated behind an
+ * explicit flag for that reason.
+ */
+function provisionAuth0({ stackDomain }) {
+  try {
+    execFileSync('auth0', ['tenants', 'list'], { stdio: 'ignore', timeout: 30_000, killSignal: 'SIGTERM' })
+  } catch (cause) {
+    throw new Error('the auth0 CLI is not authenticated; run `auth0 login` and complete the browser consent', { cause })
+  }
+
+  const app = auth0Json(spaApplicationArgs({ stackDomain }))
+  const clientId = app.client_id ?? app.clientId
+  if (!clientId) throw new Error('auth0 apps create returned no client_id')
+  console.log(`[${SCRIPT_NAME}] Auth0 SPA application ... created (client_id ${clientId})`)
+
+  const api = auth0Json(customApiArgs({ stackDomain }))
+  console.log(`[${SCRIPT_NAME}] Auth0 custom API ... created (audience ${api.identifier})`)
+
+  const actionCode = readFileSync(ACTION_SOURCE_PATH, 'utf8')
+  const action = auth0Json(createActionArgs({ code: actionCode }))
+  const actionId = action.id
+  if (!actionId) throw new Error('auth0 actions create returned no id')
+
+  // deploy != bind: an Action must be deployed before it can be bound, and
+  // the CLI has no bind verb, so the binding goes through the raw API.
+  auth0Run(deployActionArgs(actionId))
+  const existingBindings = auth0Json(['api', 'get', 'actions/triggers/post-login/bindings']).bindings ?? []
+  auth0Run(bindActionArgs({ actionId, existingBindings }))
+  console.log(`[${SCRIPT_NAME}] Auth0 post-login Action ... created, deployed, and bound`)
+
+  auth0Run(enableRpLogoutDiscoveryArgs())
+  console.log(`[${SCRIPT_NAME}] Auth0 RP-initiated logout discovery ... enabled`)
+
+  // OIDC_CLIENT_ID is an SST secret, not a .env key — seeded below by
+  // ensureOidcClientId. Only OIDC_AUDIENCE belongs in .env.
+  console.log(`[${SCRIPT_NAME}] add to .env: OIDC_AUDIENCE=${api.identifier}`)
+  console.log(`[${SCRIPT_NAME}] supply this when prompted for the OIDC client ID: ${clientId}`)
+}
+
+function deployGithubDeployRoleStack({ awsCliPath, region, stage, repo }) {
+  const stackName = githubDeployRoleStackName(stage)
+  const overrides = cloudFormationParameterOverrides({ repo, stage })
+
+  const deployStdout = execFileSync(
+    awsCliPath,
+    [
+      'cloudformation',
+      'deploy',
+      '--region',
+      region,
+      '--stack-name',
+      stackName,
+      '--template-file',
+      TEMPLATE_PATH,
+      '--capabilities',
+      'CAPABILITY_NAMED_IAM',
+      '--no-fail-on-empty-changeset',
+      '--parameter-overrides',
+      ...overrides,
+    ],
+    { encoding: 'utf8', stdio: ['ignore', 'pipe', 'inherit'], timeout: 300_000, killSignal: 'SIGTERM' },
+  )
+  console.log(deployStdout.trim())
+  console.log(
+    `[${SCRIPT_NAME}] ${stackName} ... ${cloudFormationDeployChanged(deployStdout) ? 'created/updated' : 'already up to date'}`,
+  )
+
+  const roleArn = execFileSync(
+    awsCliPath,
+    [
+      'cloudformation',
+      'describe-stacks',
+      '--region',
+      region,
+      '--stack-name',
+      stackName,
+      '--query',
+      "Stacks[0].Outputs[?OutputKey=='RoleArn'].OutputValue",
+      '--output',
+      'text',
+    ],
+    { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 30_000, killSignal: 'SIGTERM' },
+  ).trim()
+  if (!roleArn) throw new Error(`${stackName} produced no RoleArn output`)
+  return roleArn
+}
+
+function ghVariableSet({ repo, stage, name, value }) {
+  execFileSync('gh', ['variable', 'set', name, '--repo', repo, '--env', stage, '--body', value], {
+    stdio: ['ignore', 'inherit', 'inherit'],
+    timeout: 30_000,
+    killSignal: 'SIGTERM',
+  })
+}
+
+function ghSecretSetFromFile({ repo, stage, name, filePath }) {
+  execFileSync('gh', ['secret', 'set', name, '--repo', repo, '--env', stage, '--body-file', filePath], {
+    stdio: ['ignore', 'inherit', 'inherit'],
+    timeout: 30_000,
+    killSignal: 'SIGTERM',
+  })
+}
+
+function wireGithubEnvironment({ repo, stage, region, roleArn }) {
+  ghVariableSet({ repo, stage, name: 'AWS_DEPLOY_ROLE_ARN', value: roleArn })
+  ghVariableSet({ repo, stage, name: 'AWS_REGION', value: region })
+  ghSecretSetFromFile({ repo, stage, name: 'DEPLOY_ENV', filePath: requireStageEnvFile() })
+  console.log(`[${SCRIPT_NAME}] GitHub ${stage} environment ... AWS_DEPLOY_ROLE_ARN, AWS_REGION, DEPLOY_ENV set`)
+}
+
+async function main() {
+  // Every other consumer (sst-with-cloudflare.mjs, sst.config.ts) loads the
+  // stage dotenv first; without it AWS_REGION/STACK_DOMAIN from .env are
+  // silently ignored and the stage lands in the default region.
+  loadDeploymentEnvironment()
+  const args = process.argv.slice(2)
+  const stage = resolveSstStage(args)
+  const force = hasFlag(args, 'force')
+  const region = resolveAwsRegion()
+  const awsCliPath = resolveAwsCliPath()
+  const reviewerIds = parseReviewerIds(parseFlag(args, 'reviewers'))
+
+  requireStageEnvFile()
+  requireGhAuthenticated()
+  const repo = resolveRepo(args)
+  requireAwsCliWithLoginSupport(awsCliPath)
+  const identity = currentAwsIdentity(awsCliPath, region)
+
+  console.log(`[${SCRIPT_NAME}] stage=${stage} region=${region} repo=${repo}`)
+  console.log(`[${SCRIPT_NAME}] AWS identity ... ${identity.Arn}`)
+
+  // Default the reviewer to whoever is running this, so the environment comes
+  // out actually protected rather than nominally so.
+  const effectiveReviewerIds = reviewerIds.length > 0 ? reviewerIds : [authenticatedGitHubUserId()]
+
+  ensureGitHubOidcProvider({ awsCliPath, region })
+  ensureGithubEnvironment({ repo, stage, reviewerIds: effectiveReviewerIds })
+  if (hasFlag(args, 'provision-auth0')) {
+    const stackDomain = process.env.STACK_DOMAIN
+    if (!stackDomain) throw new Error('STACK_DOMAIN must be set in .env before --provision-auth0 can build callback URLs')
+    provisionAuth0({ stackDomain })
+  }
+  await ensureCloudflareCredentials({ awsCliPath, region, stage, force })
+  await ensureOidcClientId(stage)
+  const roleArn = deployGithubDeployRoleStack({ awsCliPath, region, stage, repo })
+  wireGithubEnvironment({ repo, stage, region, roleArn })
+
+  console.log(
+    `[${SCRIPT_NAME}] done. Preview next: gh workflow run deploy-infra.yml --repo ${repo} --ref main -f stage=${stage} -f apply=false`,
+  )
+}
+
+try {
+  await main()
+} catch (error) {
+  console.error(`${SCRIPT_NAME}: ${error.message}`)
+  process.exit(1)
+}

--- a/apps/infra/scripts/cli-flags.mjs
+++ b/apps/infra/scripts/cli-flags.mjs
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+/*
+ * Long-flag parsing shared by the human-run scripts (`npm run bootstrap`,
+ * `npm run login`). One rule in one place: a flag that takes a value must
+ * actually carry one, so `--stage --force` fails loudly instead of silently
+ * treating `--force` as the stage name.
+ */
+
+export function parseFlag(args, name) {
+  for (let index = 0; index < args.length; index += 1) {
+    if (args[index] === `--${name}`) {
+      const value = args[index + 1]
+      // A following flag is a missing value, not the value itself.
+      if (!value || value.startsWith('-')) throw new Error(`--${name} requires a value`)
+      return value
+    }
+    const inline = args[index].match(new RegExp(`^--${name}=(.*)$`))?.[1]
+    if (inline !== undefined) return inline
+  }
+  return undefined
+}
+
+export function hasFlag(args, name) {
+  return args.includes(`--${name}`)
+}

--- a/apps/infra/scripts/cli-flags.test.mjs
+++ b/apps/infra/scripts/cli-flags.test.mjs
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { hasFlag, parseFlag } from './cli-flags.mjs'
+
+test('parseFlag reads both the separated and inline forms', () => {
+  assert.equal(parseFlag(['--stage', 'dev'], 'stage'), 'dev')
+  assert.equal(parseFlag(['--stage=dev'], 'stage'), 'dev')
+})
+
+test('parseFlag returns undefined when the flag is absent', () => {
+  assert.equal(parseFlag(['--force'], 'stage'), undefined)
+  assert.equal(parseFlag([], 'stage'), undefined)
+})
+
+test('parseFlag rejects a flag whose value is the next flag', () => {
+  // `--stage --force` must not silently adopt '--force' as the stage name.
+  assert.throws(() => parseFlag(['--stage', '--force'], 'stage'), /--stage requires a value/)
+  assert.throws(() => parseFlag(['--stage'], 'stage'), /--stage requires a value/)
+})
+
+test('parseFlag treats an empty inline value as empty, not missing', () => {
+  // Distinguishes "flag absent" (undefined) from "flag given empty" (''), so a
+  // caller can tell them apart. login.mjs treats both as "all providers".
+  assert.equal(parseFlag(['--only='], 'only'), '')
+})
+
+test('parseFlag does not match a flag that merely starts with the name', () => {
+  assert.equal(parseFlag(['--stagey=x'], 'stage'), undefined)
+})
+
+test('hasFlag detects a bare boolean flag only when exact', () => {
+  assert.equal(hasFlag(['--force'], 'force'), true)
+  assert.equal(hasFlag(['--forced'], 'force'), false)
+  assert.equal(hasFlag([], 'force'), false)
+})

--- a/apps/infra/scripts/deploy-role-boundary.mjs
+++ b/apps/infra/scripts/deploy-role-boundary.mjs
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+/*
+ * Pure IAM-policy-document checks for `verify-deploy-role-boundary.mjs` — a
+ * CI preflight that catches "the bootstrap CloudFormation stack was never
+ * (re)deployed" in seconds, using only the read-only IAM permissions already
+ * granted to the deploy role (the ReadIamAndAccountMetadata statement in
+ * ci/github-deploy-role.yaml), instead of the ~2-minute wall of duplicate
+ * iam:PutRolePermissionsBoundary AccessDenied errors a real `sst deploy`
+ * produces when this is missing.
+ *
+ * This does not reimplement AWS's full policy evaluation (explicit Deny,
+ * SCPs, permission boundaries on the deploy role itself, and so on) — it
+ * only answers "is there an Allow statement a reasonable operator would
+ * expect to grant this call", which is enough to catch the missing-bootstrap
+ * case fast without becoming a policy simulator. A false pass here still
+ * fails safely: the real deploy step re-checks it for real.
+ */
+
+import { runtimeBoundaryPolicyArn } from './environment-bootstrap.mjs'
+
+const ASSUMED_ROLE_ARN_PATTERN = /^arn:aws:sts::\d{12}:assumed-role\/([^/]+)\/[^/]+$/
+
+export function parseAssumedRoleName(arn) {
+  const match = typeof arn === 'string' ? arn.match(ASSUMED_ROLE_ARN_PATTERN) : null
+  if (!match) {
+    throw new Error(`'${arn}' is not an assumed-role ARN (expected arn:aws:sts::<account>:assumed-role/<role>/<session>)`)
+  }
+  return match[1]
+}
+
+function asArray(value) {
+  if (value === undefined) return []
+  return Array.isArray(value) ? value : [value]
+}
+
+function iamPatternToRegExp(pattern) {
+  if (typeof pattern !== 'string') return /(?!)/ // matches nothing
+  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*').replace(/\?/g, '.')
+  return new RegExp(`^${escaped}$`, 'i')
+}
+
+/*
+ * Recognizes the `Condition.StringEquals` operator the actual template uses
+ * (SetBoxLiteRoleBoundary in ci/github-deploy-role.yaml). A statement with no
+ * condition on `conditionKey` is an unconditional — and therefore sufficient
+ * — grant of the action; a policy redesigned around a different condition
+ * operator would need this updated too.
+ */
+export function policyDocumentsAllow(policyDocuments, { action, resource, conditionKey, conditionValue }) {
+  for (const document of policyDocuments) {
+    for (const statement of asArray(document?.Statement)) {
+      if (statement?.Effect !== 'Allow') continue
+      if (!asArray(statement.Action).some((pattern) => iamPatternToRegExp(pattern).test(action))) continue
+      if (!asArray(statement.Resource).some((pattern) => iamPatternToRegExp(pattern).test(resource))) continue
+
+      const requiredValues = statement.Condition?.StringEquals?.[conditionKey]
+      if (requiredValues === undefined || asArray(requiredValues).includes(conditionValue)) return true
+    }
+  }
+  return false
+}
+
+/**
+ * @param {{
+ *   callerArn: string,        // sts:GetCallerIdentity Arn
+ *   accountId: string,        // sts:GetCallerIdentity Account
+ *   stage: string,
+ *   policyDocuments: object[],// parsed IAM PolicyDocument JSON (inline + managed, current version)
+ *   appName?: string,
+ * }} args
+ */
+export function verifyDeployRoleGrantsBoundaryPermission({ callerArn, accountId, stage, policyDocuments, appName = 'boxlite' }) {
+  const roleName = parseAssumedRoleName(callerArn)
+  const boundaryArn = runtimeBoundaryPolicyArn({ accountId, appName, stage })
+  // A synthetic-but-representative role ARN under the namespace SST creates
+  // roles in — not a real resource, just something the policy's `role/
+  // boxlite-*`-style Resource pattern should match.
+  const probeResource = `arn:aws:iam::${accountId}:role/${appName}-${stage}-verify-probe`
+
+  const grants = policyDocumentsAllow(policyDocuments, {
+    action: 'iam:PutRolePermissionsBoundary',
+    resource: probeResource,
+    conditionKey: 'iam:PermissionsBoundary',
+    conditionValue: boundaryArn,
+  })
+  return { roleName, boundaryArn, grants }
+}

--- a/apps/infra/scripts/deploy-role-boundary.mjs
+++ b/apps/infra/scripts/deploy-role-boundary.mjs
@@ -42,6 +42,20 @@ function iamPatternToRegExp(pattern) {
 }
 
 /*
+ * IAM treats condition *key names* case-insensitively, so a policy written with
+ * `iam:PermissionsBoundary` must match a lookup for `IAM:PermissionsBoundary`.
+ * Only the key is folded — the values `StringEquals` compares stay
+ * case-sensitive, which is why the caller still uses an exact `includes`.
+ */
+function stringEqualsValues(condition, conditionKey) {
+  const stringEquals = condition?.StringEquals
+  if (!stringEquals) return undefined
+  const wanted = conditionKey.toLowerCase()
+  const match = Object.keys(stringEquals).find((key) => key.toLowerCase() === wanted)
+  return match === undefined ? undefined : stringEquals[match]
+}
+
+/*
  * Recognizes the `Condition.StringEquals` operator the actual template uses
  * (SetBoxLiteRoleBoundary in ci/github-deploy-role.yaml). A statement with no
  * condition on `conditionKey` is an unconditional — and therefore sufficient
@@ -55,7 +69,7 @@ export function policyDocumentsAllow(policyDocuments, { action, resource, condit
       if (!asArray(statement.Action).some((pattern) => iamPatternToRegExp(pattern).test(action))) continue
       if (!asArray(statement.Resource).some((pattern) => iamPatternToRegExp(pattern).test(resource))) continue
 
-      const requiredValues = statement.Condition?.StringEquals?.[conditionKey]
+      const requiredValues = stringEqualsValues(statement.Condition, conditionKey)
       if (requiredValues === undefined || asArray(requiredValues).includes(conditionValue)) return true
     }
   }

--- a/apps/infra/scripts/deploy-role-boundary.test.mjs
+++ b/apps/infra/scripts/deploy-role-boundary.test.mjs
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { parseAssumedRoleName, policyDocumentsAllow, verifyDeployRoleGrantsBoundaryPermission } from './deploy-role-boundary.mjs'
+
+const ACCOUNT_ID = '123456789012'
+const CALLER_ARN = `arn:aws:sts::${ACCOUNT_ID}:assumed-role/boxlite-app-dev-deploy/deploy-dev-stack-30606029374`
+
+// Mirrors ci/github-deploy-role.yaml's GitHubDeployRole inline policy verbatim
+// (Sid: SetBoxLiteRoleBoundary), so a change to the real template that this
+// check can no longer see is caught by editing this fixture, not by a live
+// AWS surprise.
+function boundedRoleStatements(boundaryArn) {
+  return [
+    {
+      Sid: 'ReadIamAndAccountMetadata',
+      Effect: 'Allow',
+      Action: ['iam:GetRole', 'iam:ListRolePolicies', 'sts:GetCallerIdentity'],
+      Resource: '*',
+    },
+    {
+      Sid: 'ManageBoxLiteRoles',
+      Effect: 'Allow',
+      Action: ['iam:AttachRolePolicy', 'iam:UpdateRole'],
+      Resource: [`arn:aws:iam::${ACCOUNT_ID}:role/boxlite-*`],
+    },
+    {
+      Sid: 'SetBoxLiteRoleBoundary',
+      Effect: 'Allow',
+      Action: 'iam:PutRolePermissionsBoundary',
+      Resource: `arn:aws:iam::${ACCOUNT_ID}:role/boxlite-*`,
+      Condition: { StringEquals: { 'iam:PermissionsBoundary': boundaryArn } },
+    },
+  ]
+}
+
+test('parseAssumedRoleName extracts the role name from an assumed-role ARN', () => {
+  assert.equal(parseAssumedRoleName(CALLER_ARN), 'boxlite-app-dev-deploy')
+})
+
+test('parseAssumedRoleName rejects a non-assumed-role ARN', () => {
+  assert.throws(
+    () => parseAssumedRoleName(`arn:aws:iam::${ACCOUNT_ID}:role/boxlite-app-dev-deploy`),
+    /is not an assumed-role ARN/,
+  )
+})
+
+test('policyDocumentsAllow matches the real SetBoxLiteRoleBoundary statement', () => {
+  const boundaryArn = `arn:aws:iam::${ACCOUNT_ID}:policy/boxlite-dev-runtime-boundary`
+  const allowed = policyDocumentsAllow([{ Statement: boundedRoleStatements(boundaryArn) }], {
+    action: 'iam:PutRolePermissionsBoundary',
+    resource: `arn:aws:iam::${ACCOUNT_ID}:role/boxlite-dev-verify-probe`,
+    conditionKey: 'iam:PermissionsBoundary',
+    conditionValue: boundaryArn,
+  })
+  assert.equal(allowed, true)
+})
+
+test('policyDocumentsAllow rejects when the condition value is for a different stage', () => {
+  const devBoundaryArn = `arn:aws:iam::${ACCOUNT_ID}:policy/boxlite-dev-runtime-boundary`
+  const productionBoundaryArn = `arn:aws:iam::${ACCOUNT_ID}:policy/boxlite-production-runtime-boundary`
+  const allowed = policyDocumentsAllow([{ Statement: boundedRoleStatements(devBoundaryArn) }], {
+    action: 'iam:PutRolePermissionsBoundary',
+    resource: `arn:aws:iam::${ACCOUNT_ID}:role/boxlite-production-verify-probe`,
+    conditionKey: 'iam:PermissionsBoundary',
+    conditionValue: productionBoundaryArn,
+  })
+  assert.equal(allowed, false)
+})
+
+test('policyDocumentsAllow reproduces today\'s incident: policy has no boundary-set statement at all', () => {
+  const boundaryArn = `arn:aws:iam::${ACCOUNT_ID}:policy/boxlite-dev-runtime-boundary`
+  const [readOnly, manageRoles] = boundedRoleStatements(boundaryArn) // drop SetBoxLiteRoleBoundary
+  const allowed = policyDocumentsAllow([{ Statement: [readOnly, manageRoles] }], {
+    action: 'iam:PutRolePermissionsBoundary',
+    resource: `arn:aws:iam::${ACCOUNT_ID}:role/boxlite-dev-verify-probe`,
+    conditionKey: 'iam:PermissionsBoundary',
+    conditionValue: boundaryArn,
+  })
+  assert.equal(allowed, false)
+})
+
+test('policyDocumentsAllow treats an unconditional allow as sufficient', () => {
+  const allowed = policyDocumentsAllow(
+    [
+      {
+        Statement: [
+          { Effect: 'Allow', Action: 'iam:PutRolePermissionsBoundary', Resource: `arn:aws:iam::${ACCOUNT_ID}:role/boxlite-*` },
+        ],
+      },
+    ],
+    {
+      action: 'iam:PutRolePermissionsBoundary',
+      resource: `arn:aws:iam::${ACCOUNT_ID}:role/boxlite-dev-verify-probe`,
+      conditionKey: 'iam:PermissionsBoundary',
+      conditionValue: `arn:aws:iam::${ACCOUNT_ID}:policy/boxlite-dev-runtime-boundary`,
+    },
+  )
+  assert.equal(allowed, true)
+})
+
+test('policyDocumentsAllow ignores a Deny statement instead of treating it as a grant', () => {
+  const boundaryArn = `arn:aws:iam::${ACCOUNT_ID}:policy/boxlite-dev-runtime-boundary`
+  const allowed = policyDocumentsAllow(
+    [
+      {
+        Statement: {
+          Effect: 'Deny',
+          Action: 'iam:PutRolePermissionsBoundary',
+          Resource: `arn:aws:iam::${ACCOUNT_ID}:role/boxlite-*`,
+        },
+      },
+    ],
+    {
+      action: 'iam:PutRolePermissionsBoundary',
+      resource: `arn:aws:iam::${ACCOUNT_ID}:role/boxlite-dev-verify-probe`,
+      conditionKey: 'iam:PermissionsBoundary',
+      conditionValue: boundaryArn,
+    },
+  )
+  assert.equal(allowed, false)
+})
+
+test('policyDocumentsAllow finds a grant in a second (e.g. managed) policy document', () => {
+  const boundaryArn = `arn:aws:iam::${ACCOUNT_ID}:policy/boxlite-dev-runtime-boundary`
+  const inlineOnlyReadAccess = { Statement: [{ Effect: 'Allow', Action: 'iam:GetRole', Resource: '*' }] }
+  const managedGrantsBoundary = { Statement: boundedRoleStatements(boundaryArn) }
+  const allowed = policyDocumentsAllow([inlineOnlyReadAccess, managedGrantsBoundary], {
+    action: 'iam:PutRolePermissionsBoundary',
+    resource: `arn:aws:iam::${ACCOUNT_ID}:role/boxlite-dev-verify-probe`,
+    conditionKey: 'iam:PermissionsBoundary',
+    conditionValue: boundaryArn,
+  })
+  assert.equal(allowed, true)
+})
+
+test('verifyDeployRoleGrantsBoundaryPermission ties the caller ARN, account, and stage together', () => {
+  const boundaryArn = `arn:aws:iam::${ACCOUNT_ID}:policy/boxlite-dev-runtime-boundary`
+  const result = verifyDeployRoleGrantsBoundaryPermission({
+    callerArn: CALLER_ARN,
+    accountId: ACCOUNT_ID,
+    stage: 'dev',
+    policyDocuments: [{ Statement: boundedRoleStatements(boundaryArn) }],
+  })
+  assert.deepEqual(result, { roleName: 'boxlite-app-dev-deploy', boundaryArn, grants: true })
+})
+
+test('verifyDeployRoleGrantsBoundaryPermission reports false for the actual failed run (2026-07-31)', () => {
+  // The exact shape of https://github.com/boxlite-ai/boxlite/actions/runs/30606029374/job/91078321370:
+  // boxlite-app-dev-deploy has no statement granting iam:PutRolePermissionsBoundary at all.
+  const result = verifyDeployRoleGrantsBoundaryPermission({
+    callerArn: CALLER_ARN,
+    accountId: ACCOUNT_ID,
+    stage: 'dev',
+    policyDocuments: [
+      { Statement: [{ Effect: 'Allow', Action: 'iam:GetRole', Resource: '*' }] },
+    ],
+  })
+  assert.equal(result.grants, false)
+})

--- a/apps/infra/scripts/environment-bootstrap.mjs
+++ b/apps/infra/scripts/environment-bootstrap.mjs
@@ -46,9 +46,9 @@ export function runtimeBoundaryPolicyArn({ accountId, appName, stage }) {
   return `arn:aws:iam::${accountId}:policy/${appName}-${stage}-runtime-boundary`
 }
 
-// Matches the `--stack-name` used in apps/infra/README.md's manual bootstrap
-// procedure, so a stack deployed by hand before this script existed is
-// recognized (and updated in place) rather than duplicated.
+// CloudFormation stack name for the GitHub deploy role. Stable per stage so
+// `cloudformation deploy` updates the existing stack in place rather than
+// creating a second one; changing it would orphan whatever is already deployed.
 export function githubDeployRoleStackName(stage) {
   requireStageLike('stage', stage)
   return `boxlite-${stage}-github-deploy`

--- a/apps/infra/scripts/environment-bootstrap.mjs
+++ b/apps/infra/scripts/environment-bootstrap.mjs
@@ -8,7 +8,11 @@
  * covered by unit tests instead of only being exercised against live AWS.
  */
 
-const STAGE_LIKE_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]*$/
+// No underscore: the stage is interpolated into a CloudFormation stack name
+// (githubDeployRoleStackName), and CloudFormation accepts only alphanumerics
+// and hyphens. Allowing `dev_blue` here would pass validation and then fail at
+// `cloudformation deploy`, after bootstrap had already made external changes.
+const STAGE_LIKE_PATTERN = /^[A-Za-z0-9][A-Za-z0-9-]*$/
 const GITHUB_REPO_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_.-]*\/[A-Za-z0-9][A-Za-z0-9_.-]*$/
 const ACCOUNT_ID_PATTERN = /^\d{12}$/
 

--- a/apps/infra/scripts/environment-bootstrap.mjs
+++ b/apps/infra/scripts/environment-bootstrap.mjs
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+/*
+ * Pure helpers for `bootstrap-environment.mjs` — the idempotent, human-run
+ * environment preparation script. Kept side-effect-free (no AWS/GitHub CLI
+ * calls) so the naming, ARN construction, and idempotency decisions are
+ * covered by unit tests instead of only being exercised against live AWS.
+ */
+
+const STAGE_LIKE_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]*$/
+const GITHUB_REPO_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_.-]*\/[A-Za-z0-9][A-Za-z0-9_.-]*$/
+const ACCOUNT_ID_PATTERN = /^\d{12}$/
+
+// `aws login` (browser-based AWS Management Console credentials) is what lets a
+// self-hoster bootstrap without minting long-lived access keys. It shipped in
+// AWS CLI 2.32.0, so an older CLI silently lacks the whole flow and the
+// operator would be sent to the IAM console instead.
+export const MINIMUM_AWS_CLI_VERSION = '2.32.0'
+export const GITHUB_OIDC_PROVIDER_URL = 'https://token.actions.githubusercontent.com'
+const AWS_CLI_VERSION_PATTERN = /^aws-cli\/(\d+)\.(\d+)\.(\d+)/
+
+function requireStageLike(name, value) {
+  if (!value || !STAGE_LIKE_PATTERN.test(value)) {
+    throw new Error(`${name} '${value}' must match ${STAGE_LIKE_PATTERN}`)
+  }
+  return value
+}
+
+export function validateGitHubRepo(repo) {
+  if (!repo || !GITHUB_REPO_PATTERN.test(repo)) {
+    throw new Error(`repo '${repo}' must look like 'owner/name'`)
+  }
+  return repo
+}
+
+// Mirrors sst.config.ts's own `${$app.name}-${$app.stage}-runtime-boundary`
+// interpolation (apps/infra/sst.config.ts:125) — this script and the SST run
+// must agree on the boundary policy name without either importing the other.
+export function runtimeBoundaryPolicyArn({ accountId, appName, stage }) {
+  if (!accountId || !ACCOUNT_ID_PATTERN.test(accountId)) {
+    throw new Error(`accountId '${accountId}' must be a 12-digit AWS account id`)
+  }
+  requireStageLike('appName', appName)
+  requireStageLike('stage', stage)
+  return `arn:aws:iam::${accountId}:policy/${appName}-${stage}-runtime-boundary`
+}
+
+// Matches the `--stack-name` used in apps/infra/README.md's manual bootstrap
+// procedure, so a stack deployed by hand before this script existed is
+// recognized (and updated in place) rather than duplicated.
+export function githubDeployRoleStackName(stage) {
+  requireStageLike('stage', stage)
+  return `boxlite-${stage}-github-deploy`
+}
+
+export function cloudFormationParameterOverrides({ repo, stage }) {
+  validateGitHubRepo(repo)
+  requireStageLike('stage', stage)
+  return [`GitHubRepository=${repo}`, `GitHubEnvironment=${stage}`]
+}
+
+// `aws cloudformation deploy --no-fail-on-empty-changeset` exits 0 whether or
+// not anything changed; the only signal is this literal stdout line, so the
+// script can report "already up to date" instead of claiming every rerun
+// made a change.
+export function cloudFormationDeployChanged(stdout) {
+  return !stdout.includes('No changes to deploy')
+}
+
+export function ssmParameterName(stage, param) {
+  requireStageLike('stage', stage)
+  if (!param) throw new Error('param is required')
+  return `/boxlite/${stage}/${param}`
+}
+
+/**
+ * `/boxlite/<stage>/<param>` already holds a value from a previous run —
+ * decide what this run does about it.
+ *
+ * This script has to stay idempotent for two different operators: BoxLite's
+ * own reruns, and a community fork's operator running it against their own
+ * AWS account, possibly months apart. "Already exists" therefore needs a
+ * deliberate answer instead of whatever a generic overwrite-or-skip default
+ * would do:
+ *
+ *   'skip'   — leave the existing value alone. Safest: never clobbers a
+ *              token that may have been rotated or hand-edited since the
+ *              last run. Matches how `sst-with-cloudflare.mjs` already
+ *              treats a credential found in the environment — used as-is,
+ *              never re-probed (scripts/sst-with-cloudflare.mjs:164-165).
+ *   'prompt' — always re-collect and overwrite. Simplest mental model: the
+ *              parameter always ends up matching whatever was just typed,
+ *              at the cost of retyping a token on every rerun.
+ *
+ * `force` is the operator's explicit `--force` CLI flag and should always
+ * win, in whichever direction makes sense for the answer below.
+ *
+ * @param {{ exists: boolean, force: boolean }} args
+ * @returns {'skip' | 'prompt'}
+ */
+export function decideSsmOverwrite({ exists, force }) {
+  if (!exists) return 'prompt' // nothing to protect yet
+  return force ? 'prompt' : 'skip'
+}
+
+// `aws --version` prints e.g. `aws-cli/2.35.11 Python/3.14.6 Darwin/27.0.0 source/arm64`.
+export function parseAwsCliVersion(versionOutput) {
+  const match = AWS_CLI_VERSION_PATTERN.exec((versionOutput ?? '').trim())
+  if (!match) {
+    throw new Error(`could not parse an AWS CLI version from '${versionOutput}' (expected 'aws-cli/X.Y.Z ...')`)
+  }
+  return { major: Number(match[1]), minor: Number(match[2]), patch: Number(match[3]) }
+}
+
+export function isAwsCliVersionAtLeast(versionOutput, minimum = MINIMUM_AWS_CLI_VERSION) {
+  const actual = parseAwsCliVersion(versionOutput)
+  const [major, minor, patch] = minimum.split('.').map(Number)
+  const ordered = [
+    [actual.major, major],
+    [actual.minor, minor],
+    [actual.patch, patch],
+  ]
+  for (const [left, right] of ordered) {
+    if (left !== right) return left > right
+  }
+  return true
+}
+
+/*
+ * IAM OIDC providers are account-global and `CreateOpenIDConnectProvider`
+ * rejects a duplicate URL with EntityAlreadyExists — so a bootstrap that
+ * unconditionally creates one breaks on every account that has ever wired
+ * GitHub Actions to AWS. Detect first, create only when genuinely absent.
+ */
+export function hasGitHubOidcProvider(listOutput, url = GITHUB_OIDC_PROVIDER_URL) {
+  const host = url.replace(/^https:\/\//, '')
+  const providers = listOutput?.OpenIDConnectProviderList ?? []
+  return providers.some(({ Arn }) => typeof Arn === 'string' && Arn.endsWith(`:oidc-provider/${host}`))
+}

--- a/apps/infra/scripts/environment-bootstrap.mjs
+++ b/apps/infra/scripts/environment-bootstrap.mjs
@@ -35,7 +35,7 @@ export function validateGitHubRepo(repo) {
 }
 
 // Mirrors sst.config.ts's own `${$app.name}-${$app.stage}-runtime-boundary`
-// interpolation (apps/infra/sst.config.ts:125) — this script and the SST run
+// interpolation (apps/infra/sst.config.ts:131) — this script and the SST run
 // must agree on the boundary policy name without either importing the other.
 export function runtimeBoundaryPolicyArn({ accountId, appName, stage }) {
   if (!accountId || !ACCOUNT_ID_PATTERN.test(accountId)) {

--- a/apps/infra/scripts/environment-bootstrap.test.mjs
+++ b/apps/infra/scripts/environment-bootstrap.test.mjs
@@ -32,7 +32,7 @@ test('runtimeBoundaryPolicyArn rejects a malformed account id', () => {
   )
 })
 
-test('githubDeployRoleStackName matches the README manual bootstrap stack name', () => {
+test('githubDeployRoleStackName stays stable per stage so a re-run updates one stack', () => {
   assert.equal(githubDeployRoleStackName('dev'), 'boxlite-dev-github-deploy')
 })
 

--- a/apps/infra/scripts/environment-bootstrap.test.mjs
+++ b/apps/infra/scripts/environment-bootstrap.test.mjs
@@ -32,6 +32,15 @@ test('runtimeBoundaryPolicyArn rejects a malformed account id', () => {
   )
 })
 
+test('githubDeployRoleStackName rejects a stage CloudFormation cannot name', () => {
+  // CloudFormation stack names allow only alphanumerics and hyphens. An
+  // underscore has to be refused up front: bootstrap makes external changes
+  // before it ever calls `cloudformation deploy`, so accepting `dev_blue` here
+  // means failing partway through with a half-provisioned stage.
+  assert.throws(() => githubDeployRoleStackName('dev_blue'), /must match/)
+  assert.equal(githubDeployRoleStackName('dev-blue'), 'boxlite-dev-blue-github-deploy')
+})
+
 test('githubDeployRoleStackName stays stable per stage so a re-run updates one stack', () => {
   assert.equal(githubDeployRoleStackName('dev'), 'boxlite-dev-github-deploy')
 })

--- a/apps/infra/scripts/environment-bootstrap.test.mjs
+++ b/apps/infra/scripts/environment-bootstrap.test.mjs
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  GITHUB_OIDC_PROVIDER_URL,
+  cloudFormationDeployChanged,
+  cloudFormationParameterOverrides,
+  decideSsmOverwrite,
+  githubDeployRoleStackName,
+  hasGitHubOidcProvider,
+  isAwsCliVersionAtLeast,
+  parseAwsCliVersion,
+  runtimeBoundaryPolicyArn,
+  ssmParameterName,
+  validateGitHubRepo,
+} from './environment-bootstrap.mjs'
+
+test('runtimeBoundaryPolicyArn matches sst.config.ts interpolation', () => {
+  assert.equal(
+    runtimeBoundaryPolicyArn({ accountId: '123456789012', appName: 'boxlite', stage: 'dev' }),
+    'arn:aws:iam::123456789012:policy/boxlite-dev-runtime-boundary',
+  )
+})
+
+test('runtimeBoundaryPolicyArn rejects a malformed account id', () => {
+  assert.throws(
+    () => runtimeBoundaryPolicyArn({ accountId: '12345', appName: 'boxlite', stage: 'dev' }),
+    /must be a 12-digit AWS account id/,
+  )
+})
+
+test('githubDeployRoleStackName matches the README manual bootstrap stack name', () => {
+  assert.equal(githubDeployRoleStackName('dev'), 'boxlite-dev-github-deploy')
+})
+
+test('cloudFormationParameterOverrides validates repo shape and stage', () => {
+  assert.deepEqual(cloudFormationParameterOverrides({ repo: 'boxlite-ai/boxlite', stage: 'dev' }), [
+    'GitHubRepository=boxlite-ai/boxlite',
+    'GitHubEnvironment=dev',
+  ])
+  assert.throws(() => cloudFormationParameterOverrides({ repo: 'not-a-repo', stage: 'dev' }), /must look like/)
+})
+
+test('validateGitHubRepo accepts a community fork owner/name', () => {
+  assert.equal(validateGitHubRepo('someone-else/boxlite'), 'someone-else/boxlite')
+  assert.throws(() => validateGitHubRepo(''), /must look like/)
+  assert.throws(() => validateGitHubRepo('boxlite'), /must look like/)
+})
+
+test('cloudFormationDeployChanged reads the no-op sentinel line', () => {
+  assert.equal(cloudFormationDeployChanged('\nWaiting for changeset to be created..\nNo changes to deploy. Stack boxlite-dev-github-deploy is up to date\n'), false)
+  assert.equal(cloudFormationDeployChanged('\nSuccessfully created/updated stack - boxlite-dev-github-deploy\n'), true)
+})
+
+test('ssmParameterName is stage-scoped', () => {
+  assert.equal(ssmParameterName('dev', 'cloudflare-api-token'), '/boxlite/dev/cloudflare-api-token')
+  assert.throws(() => ssmParameterName('dev', ''), /param is required/)
+})
+
+test('decideSsmOverwrite skips an existing parameter unless --force is set', () => {
+  assert.equal(decideSsmOverwrite({ exists: true, force: false }), 'skip')
+  assert.equal(decideSsmOverwrite({ exists: true, force: true }), 'prompt')
+})
+
+test('decideSsmOverwrite always prompts when the parameter does not exist yet', () => {
+  assert.equal(decideSsmOverwrite({ exists: false, force: false }), 'prompt')
+  assert.equal(decideSsmOverwrite({ exists: false, force: true }), 'prompt')
+})
+
+test('parseAwsCliVersion reads the real `aws --version` banner', () => {
+  assert.deepEqual(parseAwsCliVersion('aws-cli/2.35.11 Python/3.14.6 Darwin/27.0.0 source/arm64'), {
+    major: 2,
+    minor: 35,
+    patch: 11,
+  })
+})
+
+test('parseAwsCliVersion rejects output that is not an AWS CLI banner', () => {
+  assert.throws(() => parseAwsCliVersion('aws-cli/2.x'), /could not parse an AWS CLI version/)
+  assert.throws(() => parseAwsCliVersion(''), /could not parse an AWS CLI version/)
+})
+
+test('isAwsCliVersionAtLeast gates the aws login flow on 2.32.0', () => {
+  // `aws login` shipped in 2.32.0; older CLIs lack the browser flow entirely.
+  assert.equal(isAwsCliVersionAtLeast('aws-cli/2.35.11 Python/3.14.6'), true)
+  assert.equal(isAwsCliVersionAtLeast('aws-cli/2.32.0 Python/3.12.0'), true)
+  assert.equal(isAwsCliVersionAtLeast('aws-cli/2.31.9 Python/3.12.0'), false)
+  assert.equal(isAwsCliVersionAtLeast('aws-cli/1.42.0 Python/3.12.0'), false)
+})
+
+test('isAwsCliVersionAtLeast compares numerically, not lexicographically', () => {
+  // '2.9.0' > '2.32.0' under string comparison; it must not be accepted.
+  assert.equal(isAwsCliVersionAtLeast('aws-cli/2.9.0 Python/3.12.0'), false)
+  assert.equal(isAwsCliVersionAtLeast('aws-cli/2.320.0 Python/3.12.0'), true)
+})
+
+test('hasGitHubOidcProvider detects an already-registered provider', () => {
+  const listOutput = {
+    OpenIDConnectProviderList: [
+      { Arn: 'arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com' },
+      { Arn: 'arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/ABC' },
+    ],
+  }
+  assert.equal(hasGitHubOidcProvider(listOutput), true)
+})
+
+test('hasGitHubOidcProvider reports absence so the bootstrap creates one', () => {
+  assert.equal(hasGitHubOidcProvider({ OpenIDConnectProviderList: [] }), false)
+  assert.equal(hasGitHubOidcProvider({}), false)
+  assert.equal(
+    hasGitHubOidcProvider({
+      OpenIDConnectProviderList: [{ Arn: 'arn:aws:iam::123456789012:oidc-provider/gitlab.com' }],
+    }),
+    false,
+  )
+})
+
+test('hasGitHubOidcProvider does not match a lookalike suffix', () => {
+  // A provider whose host merely ENDS with the GitHub host must not count —
+  // creating a duplicate would fail with EntityAlreadyExists either way, but a
+  // false positive would skip a genuinely required creation.
+  assert.equal(
+    hasGitHubOidcProvider({
+      OpenIDConnectProviderList: [{ Arn: 'arn:aws:iam::123456789012:oidc-provider/evil-token.actions.githubusercontent.com' }],
+    }),
+    false,
+  )
+  assert.equal(GITHUB_OIDC_PROVIDER_URL, 'https://token.actions.githubusercontent.com')
+})

--- a/apps/infra/scripts/github-environment.mjs
+++ b/apps/infra/scripts/github-environment.mjs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+/*
+ * Pure helpers for creating the deployment stage's GitHub Environment.
+ *
+ * The deploy workflow binds to `environment: ${{ inputs.stage }}` and reads
+ * `AWS_DEPLOY_ROLE_ARN`/`AWS_REGION`/`DEPLOY_ENV` from it, and the AWS trust
+ * policy pins `repo:<owner>/<repo>:environment:<stage>` — so the Environment
+ * must exist, under exactly that name, before any of it works.
+ *
+ * `PUT /repos/{owner}/{repo}/environments/{name}` is create-or-update, which
+ * is what makes rerunning the bootstrap safe.
+ */
+
+// Protection rules are a paid feature on private repositories: "Users with
+// GitHub Free plans can only configure environments for public repositories."
+// A self-hoster on a private free repo can still deploy — they just get an
+// unprotected environment — so a 422 here must not abort the bootstrap.
+const PROTECTION_UNAVAILABLE_PATTERN = /(only available|not available|upgrade|advanced security|payment)/i
+
+export function githubEnvironmentPayload({ reviewerIds = [] } = {}) {
+  if (!Array.isArray(reviewerIds)) throw new Error('reviewerIds must be an array of numeric GitHub actor ids')
+  for (const id of reviewerIds) {
+    if (!Number.isInteger(id) || id <= 0) {
+      throw new Error(`reviewer id '${id}' must be a positive integer (GitHub user/team id, not a login)`)
+    }
+  }
+
+  return {
+    // GitHub rejects an empty `reviewers` array differently across plans; omit
+    // the key entirely when there is nobody to require, so an unprotected
+    // environment is still created cleanly.
+    ...(reviewerIds.length > 0 ? { reviewers: reviewerIds.map((id) => ({ type: 'User', id })) } : {}),
+    deployment_branch_policy: null,
+  }
+}
+
+export function environmentApiPath(repo, stage) {
+  return `repos/${repo}/environments/${stage}`
+}
+
+/*
+ * Distinguish "this plan cannot do protection rules" (degrade: the environment
+ * itself still needs to exist) from a real failure the operator must fix.
+ */
+export function isProtectionUnavailableError(stderr) {
+  return PROTECTION_UNAVAILABLE_PATTERN.test(stderr ?? '')
+}
+
+export function parseReviewerIds(rawReviewers) {
+  if (rawReviewers === undefined || rawReviewers === '') return []
+  return rawReviewers
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .map((entry) => {
+      if (!/^\d+$/.test(entry)) {
+        throw new Error(`--reviewers expects numeric GitHub user ids, received '${entry}'`)
+      }
+      return Number(entry)
+    })
+}

--- a/apps/infra/scripts/github-environment.test.mjs
+++ b/apps/infra/scripts/github-environment.test.mjs
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  environmentApiPath,
+  githubEnvironmentPayload,
+  isProtectionUnavailableError,
+  parseReviewerIds,
+} from './github-environment.mjs'
+
+test('githubEnvironmentPayload requires the named reviewers as User entries', () => {
+  assert.deepEqual(githubEnvironmentPayload({ reviewerIds: [583231] }), {
+    reviewers: [{ type: 'User', id: 583231 }],
+    deployment_branch_policy: null,
+  })
+})
+
+test('githubEnvironmentPayload omits reviewers entirely when there are none', () => {
+  // An empty `reviewers` array is handled inconsistently across plans; omitting
+  // the key still creates the (unprotected) environment.
+  const payload = githubEnvironmentPayload({ reviewerIds: [] })
+  assert.equal('reviewers' in payload, false)
+  assert.deepEqual(payload, { deployment_branch_policy: null })
+})
+
+test('githubEnvironmentPayload rejects logins where GitHub requires numeric ids', () => {
+  assert.throws(() => githubEnvironmentPayload({ reviewerIds: ['dorianzheng'] }), /must be a positive integer/)
+  assert.throws(() => githubEnvironmentPayload({ reviewerIds: [0] }), /must be a positive integer/)
+  assert.throws(() => githubEnvironmentPayload({ reviewerIds: 583231 }), /must be an array/)
+})
+
+test('environmentApiPath targets the stage-named environment the trust policy pins', () => {
+  assert.equal(environmentApiPath('boxlite-ai/boxlite', 'dev'), 'repos/boxlite-ai/boxlite/environments/dev')
+  assert.equal(environmentApiPath('someone/fork', 'production'), 'repos/someone/fork/environments/production')
+})
+
+test('isProtectionUnavailableError recognizes the paid-plan rejection', () => {
+  assert.equal(
+    isProtectionUnavailableError('Environments are only available in public repositories for this account'),
+    true,
+  )
+  assert.equal(isProtectionUnavailableError('You must upgrade to use deployment protection rules'), true)
+})
+
+test('isProtectionUnavailableError does not swallow a genuine failure', () => {
+  assert.equal(isProtectionUnavailableError('HTTP 404: Not Found'), false)
+  assert.equal(isProtectionUnavailableError('Bad credentials'), false)
+  assert.equal(isProtectionUnavailableError(''), false)
+  assert.equal(isProtectionUnavailableError(undefined), false)
+})
+
+test('parseReviewerIds accepts a comma-separated id list', () => {
+  assert.deepEqual(parseReviewerIds('583231,99'), [583231, 99])
+  assert.deepEqual(parseReviewerIds(' 583231 , 99 '), [583231, 99])
+  assert.deepEqual(parseReviewerIds(''), [])
+  assert.deepEqual(parseReviewerIds(undefined), [])
+})
+
+test('parseReviewerIds rejects a login so the failure is not deferred to the API', () => {
+  assert.throws(() => parseReviewerIds('dorianzheng'), /numeric GitHub user ids/)
+  assert.throws(() => parseReviewerIds('583231,dorianzheng'), /numeric GitHub user ids/)
+})

--- a/apps/infra/scripts/login-providers.mjs
+++ b/apps/infra/scripts/login-providers.mjs
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+/*
+ * The identity providers a deployment needs, and how to check and obtain a
+ * session for each. `npm run login` walks this list; `npm run bootstrap`
+ * only verifies it, so the two cannot disagree about what "logged in" means.
+ *
+ * Every entry is a browser sign-in: no provider here needs a long-lived key
+ * pasted into a terminal. Cloudflare is the exception the deployment still
+ * carries — its API token is issued from the dashboard, so it is a secret
+ * prompted for during bootstrap rather than a login performed here.
+ */
+
+export const LOGIN_PROVIDERS = [
+  {
+    key: 'aws',
+    label: 'AWS',
+    command: 'aws',
+    // `aws login` (CLI 2.32.0+) exchanges a browser Management Console session
+    // for short-lived credentials — no IAM user, no access keys, and no IAM
+    // Identity Center setup, which itself takes a separate console visit.
+    statusArgs: ['sts', 'get-caller-identity'],
+    loginArgs: ['login'],
+    required: true,
+  },
+  {
+    key: 'github',
+    label: 'GitHub',
+    command: 'gh',
+    statusArgs: ['auth', 'status'],
+    loginArgs: ['auth', 'login'],
+    required: true,
+  },
+  {
+    key: 'auth0',
+    label: 'Auth0',
+    command: 'auth0',
+    // Only needed for `bootstrap --provision-auth0`; a deployment whose OIDC
+    // provider is already configured never installs this CLI.
+    statusArgs: ['tenants', 'list'],
+    loginArgs: ['login'],
+    required: false,
+  },
+]
+
+export function selectProviders(requestedKeys) {
+  if (!requestedKeys || requestedKeys.length === 0) return LOGIN_PROVIDERS
+
+  const known = new Map(LOGIN_PROVIDERS.map((provider) => [provider.key, provider]))
+  return requestedKeys.map((key) => {
+    const provider = known.get(key)
+    if (!provider) {
+      throw new Error(`unknown provider '${key}' (expected one of ${[...known.keys()].join(', ')})`)
+    }
+    return provider
+  })
+}
+
+/**
+ * What `npm run login` should do about one provider.
+ *
+ *   'skip'         already authenticated — never re-open a browser for a
+ *                  working session
+ *   'login'        needs a browser sign-in
+ *   'missing-cli'  the CLI is not installed; for an optional provider that is
+ *                  reported and stepped over, for a required one it fails
+ */
+export function decideLoginAction({ cliInstalled, authenticated, force }) {
+  if (!cliInstalled) return 'missing-cli'
+  if (authenticated && !force) return 'skip'
+  return 'login'
+}
+
+export function summarizeLoginResults(results) {
+  // A required provider whose CLI is absent is just as blocking as one whose
+  // sign-in failed — bootstrap cannot proceed without it either way.
+  const failed = results.filter(
+    (result) => result.status === 'failed' || (result.status === 'missing-cli' && result.required),
+  )
+  const skippedOptional = results.filter((result) => result.status === 'missing-cli' && !result.required)
+  return {
+    ok: failed.length === 0,
+    failed: failed.map((result) => result.label),
+    skippedOptional: skippedOptional.map((result) => result.label),
+  }
+}

--- a/apps/infra/scripts/login-providers.test.mjs
+++ b/apps/infra/scripts/login-providers.test.mjs
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { LOGIN_PROVIDERS, decideLoginAction, selectProviders, summarizeLoginResults } from './login-providers.mjs'
+
+test('every provider is a browser sign-in with a status probe', () => {
+  // A provider without a status probe would re-open a browser on every run.
+  for (const provider of LOGIN_PROVIDERS) {
+    assert.ok(provider.statusArgs.length > 0, `${provider.key} has no status probe`)
+    assert.ok(provider.loginArgs.length > 0, `${provider.key} has no login command`)
+  }
+  assert.deepEqual(
+    LOGIN_PROVIDERS.map((provider) => provider.key),
+    ['aws', 'github', 'auth0'],
+  )
+})
+
+test('only Auth0 is optional — AWS and GitHub are always needed', () => {
+  const optional = LOGIN_PROVIDERS.filter((provider) => !provider.required).map((provider) => provider.key)
+  assert.deepEqual(optional, ['auth0'])
+})
+
+test('selectProviders defaults to every provider', () => {
+  assert.equal(selectProviders().length, LOGIN_PROVIDERS.length)
+  assert.equal(selectProviders([]).length, LOGIN_PROVIDERS.length)
+})
+
+test('selectProviders narrows to the requested providers in order', () => {
+  assert.deepEqual(
+    selectProviders(['github', 'aws']).map((provider) => provider.key),
+    ['github', 'aws'],
+  )
+})
+
+test('selectProviders rejects an unknown provider instead of silently skipping it', () => {
+  assert.throws(() => selectProviders(['cloudflare']), /unknown provider 'cloudflare'/)
+})
+
+test('decideLoginAction leaves a working session alone', () => {
+  assert.equal(decideLoginAction({ cliInstalled: true, authenticated: true, force: false }), 'skip')
+})
+
+test('decideLoginAction signs in when there is no session', () => {
+  assert.equal(decideLoginAction({ cliInstalled: true, authenticated: false, force: false }), 'login')
+})
+
+test('decideLoginAction re-authenticates on --force', () => {
+  assert.equal(decideLoginAction({ cliInstalled: true, authenticated: true, force: true }), 'login')
+})
+
+test('decideLoginAction reports a missing CLI rather than trying to run it', () => {
+  assert.equal(decideLoginAction({ cliInstalled: false, authenticated: false, force: false }), 'missing-cli')
+  assert.equal(decideLoginAction({ cliInstalled: false, authenticated: true, force: true }), 'missing-cli')
+})
+
+test('summarizeLoginResults passes when nothing failed', () => {
+  const summary = summarizeLoginResults([
+    { label: 'AWS', status: 'skip', required: true },
+    { label: 'GitHub', status: 'logged-in', required: true },
+  ])
+  assert.deepEqual(summary, { ok: true, failed: [], skippedOptional: [] })
+})
+
+test('summarizeLoginResults reports an absent optional CLI without failing', () => {
+  const summary = summarizeLoginResults([
+    { label: 'AWS', status: 'skip', required: true },
+    { label: 'Auth0', status: 'missing-cli', required: false },
+  ])
+  assert.equal(summary.ok, true)
+  assert.deepEqual(summary.skippedOptional, ['Auth0'])
+})
+
+test('summarizeLoginResults fails when a REQUIRED CLI is absent', () => {
+  // Absent and required is as blocking as a failed sign-in: bootstrap cannot
+  // proceed without it, so the run must not report success.
+  const summary = summarizeLoginResults([
+    { label: 'AWS', status: 'missing-cli', required: true },
+    { label: 'GitHub', status: 'logged-in', required: true },
+  ])
+  assert.equal(summary.ok, false)
+  assert.deepEqual(summary.failed, ['AWS'])
+  assert.deepEqual(summary.skippedOptional, [])
+})
+
+test('summarizeLoginResults fails when a login failed', () => {
+  const summary = summarizeLoginResults([
+    { label: 'AWS', status: 'failed', required: true },
+    { label: 'GitHub', status: 'logged-in', required: true },
+  ])
+  assert.equal(summary.ok, false)
+  assert.deepEqual(summary.failed, ['AWS'])
+})

--- a/apps/infra/scripts/login.mjs
+++ b/apps/infra/scripts/login.mjs
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+/*
+ * Sign in to every identity provider a deployment needs, in one command.
+ *
+ * `npm run bootstrap` only ever *verifies* these sessions and fails with a
+ * pointer back here, so the check and the fix cannot drift apart. Each
+ * provider is a browser sign-in; an already-working session is left alone
+ * rather than re-opened.
+ *
+ * Usage: node scripts/login.mjs [--only aws,github] [--force]
+ *   --only   comma-separated subset (aws, github, auth0); default is all
+ *   --force  re-authenticate even where a session already works
+ *
+ * Requires a TTY: every provider here opens a browser and waits for a
+ * callback, which cannot complete unattended. CI supplies credentials through
+ * OIDC and job env instead, and never runs this.
+ */
+
+import { execFileSync, spawnSync } from 'node:child_process'
+
+import { hasFlag, parseFlag } from './cli-flags.mjs'
+import { decideLoginAction, selectProviders, summarizeLoginResults } from './login-providers.mjs'
+
+const SCRIPT_NAME = 'login'
+
+function isCliInstalled(command) {
+  return spawnSync('command', ['-v', command], { shell: true, stdio: 'ignore' }).status === 0
+}
+
+function isAuthenticated(provider) {
+  try {
+    execFileSync(provider.command, provider.statusArgs, {
+      stdio: 'ignore',
+      timeout: 30_000,
+      killSignal: 'SIGTERM',
+    })
+    return true
+  } catch {
+    return false
+  }
+}
+
+/*
+ * stdio is inherited so the CLI can print its verification code, open the
+ * browser, and read a confirmation keypress. No timeout: the operator is
+ * completing a browser flow at human speed, and killing it mid-redirect would
+ * leave a half-finished authorization.
+ */
+function runLogin(provider) {
+  const { status } = spawnSync(provider.command, provider.loginArgs, { stdio: 'inherit' })
+  return status === 0
+}
+
+function main() {
+  const args = process.argv.slice(2)
+  const force = hasFlag(args, 'force')
+  const only = parseFlag(args, 'only')
+  const providers = selectProviders(only ? only.split(',').map((key) => key.trim()).filter(Boolean) : undefined)
+
+  if (!process.stdin.isTTY) {
+    throw new Error('a browser sign-in needs a TTY; run this from an interactive shell')
+  }
+
+  const results = []
+  for (const provider of providers) {
+    const cliInstalled = isCliInstalled(provider.command)
+    const authenticated = cliInstalled && isAuthenticated(provider)
+    const action = decideLoginAction({ cliInstalled, authenticated, force })
+
+    if (action === 'missing-cli') {
+      const detail = provider.required ? 'install it, then rerun' : 'only needed for --provision-auth0'
+      console.log(`[${SCRIPT_NAME}] ${provider.label} ... \`${provider.command}\` not installed (${detail})`)
+      results.push({ ...provider, status: 'missing-cli' })
+      continue
+    }
+    if (action === 'skip') {
+      console.log(`[${SCRIPT_NAME}] ${provider.label} ... already signed in (--force to redo)`)
+      results.push({ ...provider, status: 'skip' })
+      continue
+    }
+
+    console.log(`[${SCRIPT_NAME}] ${provider.label} ... opening browser sign-in`)
+    const ok = runLogin(provider)
+    // Re-probe rather than trusting the exit status: some CLIs exit 0 after a
+    // cancelled or partially-completed browser flow.
+    const verified = ok && isAuthenticated(provider)
+    console.log(`[${SCRIPT_NAME}] ${provider.label} ... ${verified ? 'signed in' : 'FAILED'}`)
+    results.push({ ...provider, status: verified ? 'logged-in' : 'failed' })
+  }
+
+  const summary = summarizeLoginResults(results)
+  for (const label of summary.skippedOptional) {
+    console.log(`[${SCRIPT_NAME}] ${label} was skipped; install its CLI if you need it`)
+  }
+  if (!summary.ok) {
+    throw new Error(`sign-in failed for: ${summary.failed.join(', ')}`)
+  }
+  console.log(`[${SCRIPT_NAME}] done. Next: npm run bootstrap -- --stage <name>`)
+}
+
+try {
+  main()
+} catch (error) {
+  console.error(`${SCRIPT_NAME}: ${error.message}`)
+  process.exit(1)
+}

--- a/apps/infra/scripts/release-deployment-safety.test.mjs
+++ b/apps/infra/scripts/release-deployment-safety.test.mjs
@@ -14,7 +14,7 @@ const SST_WRAPPER = join(REPO_ROOT, 'apps/infra/scripts/sst-with-cloudflare.mjs'
 const RUNNER_POLICY_PROJECT = join(REPO_ROOT, 'apps/infra/PulumiPolicy.yaml')
 const RUNNER_POLICY_ENTRY = join(REPO_ROOT, 'apps/infra/policies/runner/index.js')
 const RUNNER_POLICY_DEFINITIONS = join(REPO_ROOT, 'apps/infra/policies/runner/definitions.cjs')
-const DEV_DEPLOY_WORKFLOW = join(REPO_ROOT, '.github/workflows/deploy-dev-api.yml')
+const DEPLOY_WORKFLOW = join(REPO_ROOT, '.github/workflows/deploy-infra.yml')
 const LINT_WORKFLOW = join(REPO_ROOT, '.github/workflows/lint.yml')
 const DEV_DEPLOY_ROLE = join(REPO_ROOT, 'apps/infra/ci/github-deploy-role.yaml')
 const CLOUDFORMATION_SCHEMA = DEFAULT_SCHEMA.extend([
@@ -103,9 +103,9 @@ test('SST deploy does not depend on a laptop-managed remote builder', () => {
   }
 })
 
-test('manual dev deployment previews and reconciles the full stack in guarded GitHub CI', () => {
-  assert.ok(existsSync(DEV_DEPLOY_WORKFLOW), 'the dev stack deployment workflow is missing')
-  const source = readFileSync(DEV_DEPLOY_WORKFLOW, 'utf8')
+test('deployment previews and reconciles the full stack in guarded GitHub CI', () => {
+  assert.ok(existsSync(DEPLOY_WORKFLOW), 'the stack deployment workflow is missing')
+  const source = readFileSync(DEPLOY_WORKFLOW, 'utf8')
   const workflow = load(source)
   const safetyTestStep = workflow.jobs.deploy.steps.find((step) => step.name === 'Run deployment safety tests')
   const materializeStep = workflow.jobs.deploy.steps.find((step) => step.name === 'Materialize stage configuration')
@@ -114,6 +114,8 @@ test('manual dev deployment previews and reconciles the full stack in guarded Gi
   const deployStep = workflow.jobs.deploy.steps.find((step) => step.name === 'Deploy the full stack')
 
   assert.match(source, /workflow_dispatch:/)
+  assert.equal(workflow.on.workflow_dispatch.inputs.stage.type, 'choice')
+  assert.ok(workflow.on.workflow_dispatch.inputs.stage.options.includes('dev'))
   assert.deepEqual(workflow.on.workflow_dispatch.inputs.apply, {
     description: 'Preview again, then deploy the full stack',
     required: true,
@@ -122,7 +124,7 @@ test('manual dev deployment previews and reconciles the full stack in guarded Gi
   })
   assert.equal(workflow.on.workflow_dispatch.inputs.runner_create_allowlist, undefined)
   assert.match(source, /if: github\.ref == 'refs\/heads\/main'/)
-  assert.match(source, /environment: dev/)
+  assert.match(source, /environment: \$\{\{ inputs\.stage \}\}/)
   assert.match(source, /id-token: write/)
   assert.match(source, /runs-on: ubuntu-24\.04/)
   assert.match(source, /uname -m[\s\S]*x86_64/)
@@ -131,6 +133,10 @@ test('manual dev deployment previews and reconciles the full stack in guarded Gi
   assert.match(source, /role-to-assume: \$\{\{ vars\.AWS_DEPLOY_ROLE_ARN \}\}/)
   assert.match(source, /secrets\.DEPLOY_ENV/)
   assert.equal(workflow.jobs.deploy.env.RUNNER_CREATE_ALLOWLIST, undefined)
+  // Every sst step passes --stage "$STAGE"; without this job env they would all
+  // run with an empty stage.
+  assert.equal(workflow.jobs.deploy.env.STAGE, '${{ inputs.stage }}')
+  assert.equal(workflow.jobs.deploy.env.IAM_PERMISSIONS_BOUNDARY_STAGE, '${{ inputs.stage }}')
   assert.match(source, /node apps\/infra\/scripts\/deploy-environment-validation\.mjs apps\/infra\/\.env/)
   assert.doesNotMatch(materializeStep.run, /grep/)
   assert.ok(safetyTestStep, 'the deployment safety test step is missing')
@@ -143,7 +149,7 @@ test('manual dev deployment previews and reconciles the full stack in guarded Gi
   assert.notEqual(materializeConfigIndex, -1, 'the stage configuration is not materialized')
   assert.ok(validateConfigIndex > materializeConfigIndex, 'DEPLOY_ENV must be validated after it is materialized')
   assert.ok(installStep, 'the SST provider installation step is missing')
-  assert.equal(installStep.run, 'npm run --silent sst -- install --stage dev')
+  assert.equal(installStep.run, 'npm run --silent sst -- install --stage "$STAGE"')
   assert.ok(previewStep, 'the full-stack preview step is missing')
   assert.equal(previewStep.if, undefined, 'Preview validation must not be conditional')
   assert.equal(previewStep['continue-on-error'], undefined, 'Preview failures must stop deployment')
@@ -152,14 +158,14 @@ test('manual dev deployment previews and reconciles the full stack in guarded Gi
     previewStep.run,
     [
       'set -euo pipefail',
-      'npm run --silent sst -- diff --stage dev --policy . --json |',
+      'npm run --silent sst -- diff --stage "$STAGE" --policy . --json |',
       '  node scripts/deployment-preview.mjs',
       '',
     ].join('\n'),
   )
   assert.ok(deployStep, 'the full-stack deployment step is missing')
   assert.equal(deployStep.if, '${{ inputs.apply }}')
-  assert.equal(deployStep.run, 'npm run deploy -- --stage dev --policy .')
+  assert.equal(deployStep.run, 'npm run deploy -- --stage "$STAGE" --policy .')
   assert.ok(
     workflow.jobs.deploy.steps.indexOf(previewStep) < workflow.jobs.deploy.steps.indexOf(deployStep),
     'Preview validation must complete before deployment',

--- a/apps/infra/scripts/release-deployment-safety.test.mjs
+++ b/apps/infra/scripts/release-deployment-safety.test.mjs
@@ -9,6 +9,8 @@ import { fileURLToPath } from 'node:url'
 import test from 'node:test'
 import { DEFAULT_SCHEMA, Type, load } from 'js-yaml'
 
+import { verifyDeployRoleGrantsBoundaryPermission } from './deploy-role-boundary.mjs'
+
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..')
 const SST_WRAPPER = join(REPO_ROOT, 'apps/infra/scripts/sst-with-cloudflare.mjs')
 const RUNNER_POLICY_PROJECT = join(REPO_ROOT, 'apps/infra/PulumiPolicy.yaml')
@@ -108,6 +110,9 @@ test('deployment previews and reconciles the full stack in guarded GitHub CI', (
   const source = readFileSync(DEPLOY_WORKFLOW, 'utf8')
   const workflow = load(source)
   const safetyTestStep = workflow.jobs.deploy.steps.find((step) => step.name === 'Run deployment safety tests')
+  const boundaryCheckStep = workflow.jobs.deploy.steps.find(
+    (step) => step.name === 'Verify deploy role IAM boundary permissions',
+  )
   const materializeStep = workflow.jobs.deploy.steps.find((step) => step.name === 'Materialize stage configuration')
   const installStep = workflow.jobs.deploy.steps.find((step) => step.name === 'Install SST providers')
   const previewStep = workflow.jobs.deploy.steps.find((step) => step.name === 'Preview the full stack')
@@ -174,6 +179,12 @@ test('deployment previews and reconciles the full stack in guarded GitHub CI', (
     workflow.jobs.deploy.steps.indexOf(safetyTestStep) < workflow.jobs.deploy.steps.indexOf(previewStep),
     'Runner lifecycle contracts must be tested before the deployment preview',
   )
+  assert.ok(boundaryCheckStep, 'the IAM boundary preflight step is missing')
+  assert.ok(
+    workflow.jobs.deploy.steps.indexOf(safetyTestStep) < workflow.jobs.deploy.steps.indexOf(boundaryCheckStep) &&
+      workflow.jobs.deploy.steps.indexOf(boundaryCheckStep) < workflow.jobs.deploy.steps.indexOf(previewStep),
+    'The IAM boundary preflight must run after safety tests and before the deployment preview',
+  )
   assert.ok(
     workflow.jobs.deploy.steps.indexOf(materializeStep) < workflow.jobs.deploy.steps.indexOf(installStep) &&
       workflow.jobs.deploy.steps.indexOf(installStep) < workflow.jobs.deploy.steps.indexOf(previewStep),
@@ -181,6 +192,45 @@ test('deployment previews and reconciles the full stack in guarded GitHub CI', (
   )
   assert.doesNotMatch(`${previewStep.run}\n${deployStep.run}`, /--(?:target|exclude)(?:[=\s]|$)/)
   assert.doesNotMatch(source, /setup-qemu/)
+})
+
+test('the checked-in deploy role satisfies the CI IAM boundary preflight', () => {
+  // The preflight gates every deploy, so the template it inspects must actually
+  // grant what it looks for. Reads the real ci/github-deploy-role.yaml rather
+  // than a hand-copied fixture, so template drift fails here instead of wedging
+  // CI on the next run.
+  const template = load(readFileSync(DEV_DEPLOY_ROLE, 'utf8'), { schema: CLOUDFORMATION_SCHEMA })
+  const accountId = '123456789012'
+  const stage = 'dev'
+  const policyDocuments = template.Resources.GitHubDeployRole.Properties.Policies.map(
+    (policy) => policy.PolicyDocument,
+  )
+
+  // `!Ref BoxLiteRuntimePermissionsBoundary` yields that ManagedPolicy's ARN at
+  // deploy time; the YAML parser leaves the logical id. Resolve it through the
+  // resource's declared ManagedPolicyName so renaming the policy — which would
+  // break the real grant — fails this test instead of passing vacuously.
+  const boundaryPolicyName = template.Resources.BoxLiteRuntimePermissionsBoundary.Properties.ManagedPolicyName.replace(
+    '${GitHubEnvironment}',
+    stage,
+  )
+  const boundaryArn = `arn:aws:iam::${accountId}:policy/${boundaryPolicyName}`
+
+  const resolved = JSON.parse(
+    JSON.stringify(policyDocuments)
+      .replaceAll('${AWS::Partition}', 'aws')
+      .replaceAll('${AWS::AccountId}', accountId)
+      .replaceAll('${GitHubEnvironment}', stage)
+      .replaceAll('"BoxLiteRuntimePermissionsBoundary"', JSON.stringify(boundaryArn)),
+  )
+
+  const { grants } = verifyDeployRoleGrantsBoundaryPermission({
+    callerArn: `arn:aws:sts::${accountId}:assumed-role/boxlite-${stage}-github-deploy/session`,
+    accountId,
+    stage,
+    policyDocuments: resolved,
+  })
+  assert.equal(grants, true, 'ci/github-deploy-role.yaml must grant iam:PutRolePermissionsBoundary for the stage boundary')
 })
 
 test('package scripts disable long-running SST dev for the stateful stack', () => {

--- a/apps/infra/scripts/sst-config-contract.test.mjs
+++ b/apps/infra/scripts/sst-config-contract.test.mjs
@@ -121,6 +121,31 @@ test('requires the OIDC client ID through the SST secret store', () => {
   }
 })
 
+test('data-protection guards key off the stage that actually exists: prod', () => {
+  // SST state has app/boxlite/prod.json and no production.json — the real
+  // stage is `prod`. The deployed prod stack carries retainOnDelete and
+  // deletionProtection because it was deployed from a branch that already
+  // compared against 'prod'; main still said 'production', so deploying prod
+  // from main would have computed isProd === false and reset them. One
+  // constant, both call sites, so the two guards cannot drift apart again.
+  assert.match(source, /const PRODUCTION_STAGE = 'prod'/)
+  assert.match(source, /removal: input\?\.stage === PRODUCTION_STAGE \? 'retain' : 'remove'/)
+  assert.match(source, /const isProd = \$app\.stage === PRODUCTION_STAGE/)
+})
+
+test('no stage-name comparison hardcodes a bare production literal', () => {
+  // NODE_ENV / ENVIRONMENT: 'production' are Node runtime values, not stages,
+  // and must survive; a stage comparison against the string must not.
+  assert.doesNotMatch(source, /stage === 'production'/)
+  assert.doesNotMatch(source, /stage === "production"/)
+  assert.match(source, /NODE_ENV: 'production'/)
+})
+
+test('the prod stage keeps deletion protection and a final snapshot', () => {
+  assert.match(source, /args\.deletionProtection = isProd/)
+  assert.match(source, /args\.skipFinalSnapshot = !isProd/)
+})
+
 test('does not restore the removed SSH gateway deployment', () => {
   assert.doesNotMatch(source, /SshGateway|SSH_GATEWAY|SSH_PRIVATE_KEY_B64|SSH_HOST_KEY_B64/)
   assert.doesNotMatch(environmentExample, /SSH_GATEWAY|SSH_PRIVATE_KEY_B64|SSH_HOST_KEY_B64/)

--- a/apps/infra/scripts/sst-config-contract.test.mjs
+++ b/apps/infra/scripts/sst-config-contract.test.mjs
@@ -113,7 +113,8 @@ test('requires the OIDC client ID through the SST secret store', () => {
   assert.doesNotMatch(environmentExample, /^OIDC_CLIENT_ID=/m)
 
   const deploymentGuide = extractSection(readme, '## Deploy an existing stack', '## Secrets & credentials')
-  assert.match(deploymentGuide, /npm run sst -- secret set OIDC_CLIENT_ID/)
+  assert.match(deploymentGuide, /npm run bootstrap/)
+  assert.match(deploymentGuide, /OIDC_CLIENT_ID/)
   assert.doesNotMatch(deploymentGuide, /App secrets .* are optional/)
   for (const documentation of [readme, environmentExample]) {
     assert.doesNotMatch(documentation, /secret set (?:[A-Z_]+|<NAME>)\s+["']?<[^>\n]+>["']?\s+--stage/)

--- a/apps/infra/scripts/sst-config-contract.test.mjs
+++ b/apps/infra/scripts/sst-config-contract.test.mjs
@@ -136,8 +136,13 @@ test('data-protection guards key off the stage that actually exists: prod', () =
 test('no stage-name comparison hardcodes a bare production literal', () => {
   // NODE_ENV / ENVIRONMENT: 'production' are Node runtime values, not stages,
   // and must survive; a stage comparison against the string must not.
-  assert.doesNotMatch(source, /stage === 'production'/)
-  assert.doesNotMatch(source, /stage === "production"/)
+  //
+  // Match any comparison operator and any quote form. Pinning `stage ===
+  // 'production'` alone let the inverse, loose equality, and a template
+  // literal through — a guard could compare against the wrong stage name and
+  // this test would still pass, which is exactly what it exists to prevent.
+  assert.doesNotMatch(source, /\bstage\b\s*(?:===|!==|==|!=)\s*(?:'production'|"production"|`production`)/)
+  assert.doesNotMatch(source, /(?:'production'|"production"|`production`)\s*(?:===|!==|==|!=)\s*\bstage\b/)
   assert.match(source, /NODE_ENV: 'production'/)
 })
 

--- a/apps/infra/scripts/verify-deploy-role-boundary.mjs
+++ b/apps/infra/scripts/verify-deploy-role-boundary.mjs
@@ -119,6 +119,12 @@ function main() {
 try {
   main()
 } catch (error) {
+  // Print the cause chain: failures here are wrapped with `{ cause }`, and the
+  // wrapper text alone ("could not read the deploy role's IAM policies") does
+  // not say whether the ARN was the wrong shape or the AWS CLI itself failed.
   console.error(`${SCRIPT_NAME}: ${error.message}`)
+  for (let cause = error.cause; cause; cause = cause.cause) {
+    console.error(`${SCRIPT_NAME}:   caused by: ${cause.message ?? cause}`)
+  }
   process.exit(1)
 }

--- a/apps/infra/scripts/verify-deploy-role-boundary.mjs
+++ b/apps/infra/scripts/verify-deploy-role-boundary.mjs
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+/*
+ * CI preflight: confirm the assumed deploy role can actually attach the
+ * runtime IAM permissions boundary before `sst diff`/`sst deploy` run.
+ * apps/infra/sst.config.ts requires every role it manages to carry that
+ * boundary (see the $transform there); if the bootstrap CloudFormation
+ * stack (ci/github-deploy-role.yaml, provisioned by
+ * scripts/bootstrap-environment.mjs) was never (re)deployed for this role,
+ * every one of those roles fails identically with an
+ * iam:PutRolePermissionsBoundary AccessDenied — a ~2-minute wall of
+ * duplicate errors, discovered only after install + tests + preview already
+ * ran. This step catches the same gap in seconds, using only the read-only
+ * IAM actions the deploy role already has (ReadIamAndAccountMetadata in
+ * ci/github-deploy-role.yaml).
+ *
+ * Usage: node scripts/verify-deploy-role-boundary.mjs
+ * Reads the SST stage from IAM_PERMISSIONS_BOUNDARY_STAGE (already required
+ * in the deploy workflow's job-level env, and by sst.config.ts itself).
+ */
+
+import { execFileSync } from 'node:child_process'
+
+import { parseAssumedRoleName, verifyDeployRoleGrantsBoundaryPermission } from './deploy-role-boundary.mjs'
+import { loadDeploymentEnvironment, resolveAwsRegion } from './deployment-environment.mjs'
+import { resolveAwsCliPath } from './proxy-deployment-verify.mjs'
+
+const SCRIPT_NAME = 'verify-deploy-role-boundary'
+
+function requireStage(environment = process.env) {
+  const stage = environment.IAM_PERMISSIONS_BOUNDARY_STAGE
+  if (!stage) throw new Error('IAM_PERMISSIONS_BOUNDARY_STAGE is required to identify the provisioned runtime boundary')
+  return stage
+}
+
+function awsJson(awsCliPath, region, args) {
+  const stdout = execFileSync(awsCliPath, [...args, '--region', region, '--output', 'json'], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: 15_000,
+    killSignal: 'SIGTERM',
+  })
+  return JSON.parse(stdout)
+}
+
+function fetchInlinePolicyDocuments(awsCliPath, region, roleName) {
+  const { PolicyNames } = awsJson(awsCliPath, region, ['iam', 'list-role-policies', '--role-name', roleName])
+  return PolicyNames.map(
+    (policyName) =>
+      awsJson(awsCliPath, region, ['iam', 'get-role-policy', '--role-name', roleName, '--policy-name', policyName])
+        .PolicyDocument,
+  )
+}
+
+function fetchAttachedManagedPolicyDocuments(awsCliPath, region, roleName) {
+  const { AttachedPolicies } = awsJson(awsCliPath, region, ['iam', 'list-attached-role-policies', '--role-name', roleName])
+  return AttachedPolicies.map(({ PolicyArn }) => {
+    const { Policy } = awsJson(awsCliPath, region, ['iam', 'get-policy', '--policy-arn', PolicyArn])
+    const { PolicyVersion } = awsJson(awsCliPath, region, [
+      'iam',
+      'get-policy-version',
+      '--policy-arn',
+      PolicyArn,
+      '--version-id',
+      Policy.DefaultVersionId,
+    ])
+    return PolicyVersion.Document
+  })
+}
+
+function main() {
+  // CI supplies these as job env, but `npm run verify-deploy-role` locally
+  // needs the stage dotenv.
+  loadDeploymentEnvironment()
+  const region = resolveAwsRegion()
+  const stage = requireStage()
+  const awsCliPath = resolveAwsCliPath()
+
+  let identity
+  try {
+    identity = awsJson(awsCliPath, region, ['sts', 'get-caller-identity'])
+  } catch (cause) {
+    throw new Error('could not call `aws sts get-caller-identity`', { cause })
+  }
+
+  let policyDocuments
+  try {
+    const roleName = parseAssumedRoleName(identity.Arn)
+    policyDocuments = [
+      ...fetchInlinePolicyDocuments(awsCliPath, region, roleName),
+      ...fetchAttachedManagedPolicyDocuments(awsCliPath, region, roleName),
+    ]
+  } catch (cause) {
+    throw new Error(`could not read the deploy role's IAM policies for stage '${stage}'`, { cause })
+  }
+
+  const { roleName, boundaryArn, grants } = verifyDeployRoleGrantsBoundaryPermission({
+    callerArn: identity.Arn,
+    accountId: identity.Account,
+    stage,
+    policyDocuments,
+  })
+
+  if (!grants) {
+    throw new Error(
+      `deploy role '${roleName}' has no policy statement allowing iam:PutRolePermissionsBoundary for ` +
+        `${boundaryArn} on role/boxlite-*. apps/infra/sst.config.ts requires every SST-managed role to carry ` +
+        `this boundary. Run \`node scripts/bootstrap-environment.mjs --stage ${stage}\` with AWS admin ` +
+        'credentials (it redeploys ci/github-deploy-role.yaml), then confirm the GitHub environment variable ' +
+        `AWS_DEPLOY_ROLE_ARN for '${stage}' still points at that stack's RoleArn output. ` +
+        'See apps/infra/README.md#deploy-an-existing-stack.',
+    )
+  }
+
+  console.log(`[${SCRIPT_NAME}] ${roleName} grants iam:PutRolePermissionsBoundary for ${boundaryArn}`)
+}
+
+try {
+  main()
+} catch (error) {
+  console.error(`${SCRIPT_NAME}: ${error.message}`)
+  process.exit(1)
+}

--- a/apps/infra/sst.config.ts
+++ b/apps/infra/sst.config.ts
@@ -481,7 +481,7 @@ export default $config({
         // straight from ghcr.io, and these three are public so no GHCR_TOKEN is required.
         // BOXLITE_SYSTEM_IMAGES appends more images
         // (comma-separated `name=ref`) without a code deploy — empty means built-ins only.
-        // IMAGE_TAG and the SOURCE_REGISTRY_* block are inert Daytona-port residue (no consumer
+        // IMAGE_TAG and the SOURCE_REGISTRY_* block are inert upstream-port residue (no consumer
         // — see apps/api configuration.ts), kept only as reserved names for a future registry path.
         BOXLITE_SYSTEM_IMAGE_TAG: envOr('BOXLITE_SYSTEM_IMAGE_TAG', 'v0.1.0'),
         BOXLITE_SYSTEM_BASE_IMAGE: envOr(

--- a/apps/infra/sst.config.ts
+++ b/apps/infra/sst.config.ts
@@ -18,6 +18,12 @@
 //   5. observability               10. runner (EC2 + nested KVM)
 // ─────────────────────────────────────────────────────────────────────────────
 
+// The one stage that holds real user data. Both the `removal` policy and the
+// RDS deletion-protection/final-snapshot guards key off this exact name, so it
+// lives in one place rather than being spelled out at each use — a mismatch
+// between the two silently leaves the real stack unprotected.
+const PRODUCTION_STAGE = 'prod'
+
 // Container ports each service listens on internally
 const PORTS = {
   API: 3000,
@@ -87,7 +93,7 @@ export default $config({
 
     return {
       name: 'boxlite',
-      removal: input?.stage === 'production' ? 'retain' : 'remove',
+      removal: input?.stage === PRODUCTION_STAGE ? 'retain' : 'remove',
       home: 'aws',
       providers: {
         aws: {
@@ -224,11 +230,11 @@ export default $config({
     // Durable state survives accidental teardown the way the runner does (§10).
     // `removal: 'retain'` (above) already keeps prod resources on `sst remove`, but it
     // does NOT stop a targeted destroy, a replace-on-immutable-change, or an AWS-console
-    // delete — so production also gets RDS deletion-protection + a final snapshot.
+    // delete — so prod also gets RDS deletion-protection + a final snapshot.
     // S3 versioning is on in every stage: cheap, and the only guard against an
     // object-level overwrite/delete (which `removal` never covers). Redis is a
     // transient cache, so it needs neither.
-    const isProd = $app.stage === 'production'
+    const isProd = $app.stage === PRODUCTION_STAGE
     // Unique-but-stable suffix for the DB final snapshot: a fixed name would collide
     // with the snapshot a prior teardown of the same stage already created (RDS requires
     // unique final-snapshot ids). RandomId is stable across deploys (no drift) and is

--- a/apps/infra/sst.config.ts
+++ b/apps/infra/sst.config.ts
@@ -478,7 +478,8 @@ export default $config({
         DEFAULT_TEMPLATE: envOr('DEFAULT_TEMPLATE', 'boxlite/base'),
         // Box base images: the three *_IMAGE refs below are the built-in curated set the API
         // gates box creation to (apps/api curated-images.constant.ts); the runner pulls them
-        // straight from ghcr.io with its GHCR_TOKEN. BOXLITE_SYSTEM_IMAGES appends more images
+        // straight from ghcr.io, and these three are public so no GHCR_TOKEN is required.
+        // BOXLITE_SYSTEM_IMAGES appends more images
         // (comma-separated `name=ref`) without a code deploy — empty means built-ins only.
         // IMAGE_TAG and the SOURCE_REGISTRY_* block are inert Daytona-port residue (no consumer
         // — see apps/api configuration.ts), kept only as reserved names for a future registry path.
@@ -887,13 +888,16 @@ export default $config({
     })
 
     // ── Runner ghcr pull credential (private image access) ────────────────────
-    // Runners pull box images straight from private ghcr.io (the self-hosted
-    // registry was removed). The pull TOKEN is stored in Secrets Manager and
-    // fetched by each runner at boot via its instance-role — NOT baked into
-    // user-data/IMDS — so scaled-out runners pick it up automatically and a
-    // rotated token only needs a secret update + a runner restart. The username
-    // (a non-secret bot account) is baked directly. Env-gated: set GHCR_TOKEN
-    // (+ GHCR_USERNAME) in apps/infra/.env to enable; unset = no ghcr auth wired.
+    // Runners pull box images straight from ghcr.io (the self-hosted registry
+    // was removed). The curated defaults (BOXLITE_SYSTEM_*_IMAGE, above) are
+    // public, so this credential is needed only for a private ref — whether set
+    // there or appended through BOXLITE_SYSTEM_IMAGES. When
+    // set, the pull TOKEN is stored in Secrets Manager and fetched by each
+    // runner at boot via its instance-role — NOT baked into user-data/IMDS — so
+    // scaled-out runners pick it up automatically and a rotated token only needs
+    // a secret update + a runner restart. The username (a non-secret bot
+    // account) is baked directly. Env-gated: set GHCR_TOKEN (+ GHCR_USERNAME)
+    // in apps/infra/.env to enable; unset = no ghcr auth wired.
     const ghcrUsername = process.env.GHCR_USERNAME?.trim() || ''
     const ghcrToken = process.env.GHCR_TOKEN?.trim() || ''
     const ghcrSecret =

--- a/apps/runner/README.md
+++ b/apps/runner/README.md
@@ -315,7 +315,7 @@ transition and which entry point triggers each.
   one PTY would race on stdin and split stdout output unpredictably.
 - **Detach without kill** lets a client survive transient connection
   drops (LB idle timeout, network blip) without losing the running
-  process. Matches the E2B / Daytona model.
+  process. Matches the E2B model.
 - **Reap escalation (SIGHUP → SIGTERM → SIGKILL)** mirrors the standard
   Unix shutdown sequence used by systemd, Kubernetes, and Docker.
   Cooperative processes (`bash`, `python -i`, `psql`) clean up on SIGHUP.

--- a/apps/runner/pkg/boxlite/client.go
+++ b/apps/runner/pkg/boxlite/client.go
@@ -106,7 +106,7 @@ func boxRuntimeEnv(ctx context.Context, boxDto dto.CreateBoxDTO) map[string]stri
 
 // buildImageRegistries assembles the runtime-scoped OCI registry list handed to boxlite-core:
 // the existing insecure (HTTP, no-auth) registries, plus — when ghcr credentials are provided —
-// a single authenticated ghcr.io HTTPS entry so core can pull our private first-party images
+// a single authenticated ghcr.io HTTPS entry so core can pull private images
 // directly from ghcr (no self-hosted registry mirror required). Auth is runtime-scoped because
 // boxlite.Runtime.Create has no per-call credential parameter. When ghcrUsername/ghcrToken are
 // empty this is byte-for-byte the previous behavior (anonymous), so it is safe to ship dark.

--- a/apps/runner/pkg/boxlite/client_ghcr_test.go
+++ b/apps/runner/pkg/boxlite/client_ghcr_test.go
@@ -17,7 +17,7 @@ func findRegistry(registries []boxlite.ImageRegistry, host string) (boxlite.Imag
 
 // When ghcr creds are present, buildImageRegistries must add exactly one authenticated
 // ghcr.io HTTPS entry alongside the unchanged insecure registries. This is the runtime-scoped
-// auth that lets boxlite-core pull our private first-party images directly (no self-hosted
+// auth that lets boxlite-core pull private images directly (no self-hosted
 // mirror). The asserted data is produced by the production helper, not the test body.
 func TestBuildImageRegistries_GhcrAuthAddedWhenCredsPresent(t *testing.T) {
 	registries := buildImageRegistries([]string{"10.0.0.5:5000"}, "boxlite-ci", "ghp_secret")

--- a/src/boxlite/tests/gvproxy_backend.rs
+++ b/src/boxlite/tests/gvproxy_backend.rs
@@ -5,7 +5,7 @@
 //! These exercise the cross-process contract between the core-side
 //! `GvproxyBackend` control client and a real shim-side `GvproxyInstance`.
 
-use std::net::SocketAddr;
+use std::net::{SocketAddr, TcpListener};
 use std::path::PathBuf;
 use std::sync::mpsc::RecvTimeoutError;
 use std::time::Duration;
@@ -175,6 +175,66 @@ async fn live_gvproxy_backend_expose_list_unexpose_roundtrip() {
     assert!(
         !has_local(&backend.list_forwards().await.unwrap()),
         "forward should be absent after unexpose"
+    );
+}
+
+/// A host port the OS refuses on permission grounds must surface gvproxy's own
+/// bind failure through `/services/forwarder/expose`, not a synthesized
+/// conflict string. Companion to the CLI suite's busy-port test, which covers
+/// the EADDRINUSE half of the same contract.
+///
+/// This has to live here rather than in the CLI suite: `-p` cannot request a
+/// specific host address, leaving `PortSpec::host_ip` unset, which resolves to
+/// the wildcard — and Darwin applies the reserved-port check only to a named
+/// address, so a wildcard bind of port 80 succeeds there. Naming an address is
+/// refused on Darwin, and on any host that restricts privileged ports whatever
+/// the address, so this is where the permission path stays reachable; the
+/// guard below skips wherever the bind is permitted.
+#[tokio::test]
+async fn live_gvproxy_backend_expose_privileged_port_surfaces_permission_denied() {
+    // The premise is "binding a privileged port is refused here". Root, a
+    // CAP_NET_BIND_SERVICE binary, or a lowered `ip_unprivileged_port_start`
+    // removes it and would leave the test asserting against a successful bind.
+    if TcpListener::bind("127.0.0.1:80").is_ok() {
+        eprintln!(
+            "SKIP live_gvproxy_backend_expose_privileged_port_surfaces_permission_denied: \
+             host allows binding 127.0.0.1:80 (root / CAP_NET_BIND_SERVICE / \
+             low ip_unprivileged_port_start)"
+        );
+        return;
+    }
+
+    let dir = tempfile::Builder::new()
+        .prefix("bl-live-gvproxy-privport-")
+        .tempdir_in("/tmp")
+        .unwrap();
+    let (_instance, backend, _, control_sock) = backend_for(&dir);
+    wait_for_services(&backend, control_sock).await;
+
+    let local = "127.0.0.1:80";
+    let error = backend
+        .expose(local, "192.168.127.2:80", TransportProtocol::Tcp)
+        .await
+        .expect_err("a privileged host port must not publish");
+
+    let error = format!("{error}");
+    assert!(
+        error.contains("/services/forwarder/expose"),
+        "error should name the endpoint that failed: {error}"
+    );
+    assert!(
+        error.to_ascii_lowercase().contains("permission denied"),
+        "error should carry the OS bind failure verbatim, not a generic \
+         conflict string: {error}"
+    );
+    assert!(
+        !backend
+            .list_forwards()
+            .await
+            .expect("list forwards")
+            .iter()
+            .any(|forward| forward.local == local),
+        "a refused expose must not leave a forward registered"
     );
 }
 

--- a/src/boxlite/tests/gvproxy_backend.rs
+++ b/src/boxlite/tests/gvproxy_backend.rs
@@ -5,6 +5,7 @@
 //! These exercise the cross-process contract between the core-side
 //! `GvproxyBackend` control client and a real shim-side `GvproxyInstance`.
 
+use std::io::ErrorKind;
 use std::net::{SocketAddr, TcpListener};
 use std::path::PathBuf;
 use std::sync::mpsc::RecvTimeoutError;
@@ -192,16 +193,31 @@ async fn live_gvproxy_backend_expose_list_unexpose_roundtrip() {
 /// guard below skips wherever the bind is permitted.
 #[tokio::test]
 async fn live_gvproxy_backend_expose_privileged_port_surfaces_permission_denied() {
-    // The premise is "binding a privileged port is refused here". Root, a
-    // CAP_NET_BIND_SERVICE binary, or a lowered `ip_unprivileged_port_start`
-    // removes it and would leave the test asserting against a successful bind.
-    if TcpListener::bind("127.0.0.1:80").is_ok() {
-        eprintln!(
-            "SKIP live_gvproxy_backend_expose_privileged_port_surfaces_permission_denied: \
-             host allows binding 127.0.0.1:80 (root / CAP_NET_BIND_SERVICE / \
-             low ip_unprivileged_port_start)"
-        );
-        return;
+    // The premise is "binding a privileged port is refused *on permission
+    // grounds*". Root, a CAP_NET_BIND_SERVICE binary, or a lowered
+    // `ip_unprivileged_port_start` removes it. So does an unrelated failure:
+    // if something already holds :80 the bind fails with AddrInUse, and
+    // treating that as the premise would assert a permission error gvproxy is
+    // never going to produce. Proceed only on an explicit PermissionDenied.
+    match TcpListener::bind("127.0.0.1:80") {
+        Err(error) if error.kind() == ErrorKind::PermissionDenied => {}
+        Ok(_) => {
+            eprintln!(
+                "SKIP live_gvproxy_backend_expose_privileged_port_surfaces_permission_denied: \
+                 host allows binding 127.0.0.1:80 (root / CAP_NET_BIND_SERVICE / \
+                 low ip_unprivileged_port_start)"
+            );
+            return;
+        }
+        Err(error) => {
+            eprintln!(
+                "SKIP live_gvproxy_backend_expose_privileged_port_surfaces_permission_denied: \
+                 probing 127.0.0.1:80 failed with {:?} ({error}), not PermissionDenied, \
+                 so the premise cannot be established",
+                error.kind()
+            );
+            return;
+        }
     }
 
     let dir = tempfile::Builder::new()

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -137,7 +137,7 @@ Multiple profiles coexist in one file via `--profile <name>` (or `BOXLITE_PROFIL
 # Browser OIDC against a control plane (default for `auth login` on a TTY).
 # Requires the IdP admin to have registered `http://127.0.0.1:5555/callback`
 # in the SPA application's Allowed Callback URLs — see apps/infra/README.md
-# "OIDC provider setup" for the one-time setup.
+# "Callback URL mismatch" for the one-time setup.
 boxlite --profile cloud auth login --url https://<your-control-plane>/api
 
 # Same target, headless (SSH / no browser): prints a code + URL to type into
@@ -231,7 +231,7 @@ echo "$KEY" | boxlite --profile local auth login --url http://localhost:8100 --a
 
 Browser and device flows fail with "Callback URL mismatch" until the IdP
 knows about the CLI's loopback URL. For Auth0 see
-`apps/infra/README.md` "OIDC provider setup" — add
+`apps/infra/README.md` "Callback URL mismatch" — add
 `http://127.0.0.1:5555/callback` to the SPA Application's
 **Allowed Callback URLs**. For Dex see `apps/dex/config.yaml` — the same
 URL goes under the `boxlite` static client's `redirectURIs`, plus

--- a/src/cli/tests/gvproxy_port_conflict.rs
+++ b/src/cli/tests/gvproxy_port_conflict.rs
@@ -119,11 +119,18 @@ fn gvproxy_privileged_port_fails_fast_with_named_error() {
     // sysctl `net.ipv4.ip_unprivileged_port_start` lowered). The test
     // premise is "bind privileged port fails"; without that, the test
     // is meaningless.
-    if TcpListener::bind("127.0.0.1:80").is_ok() {
+    //
+    // Probe the wildcard, because that is what publication binds: `-p 80:80`
+    // leaves `PortSpec::host_ip` unset, which resolves to 0.0.0.0. Darwin
+    // applies the reserved-port check only to a named address, so `0.0.0.0:80`
+    // succeeds there while every specific address returns EACCES — probing
+    // 127.0.0.1 would report the premise as holding when it does not, and the
+    // test would then fail against a box that published port 80 correctly.
+    if TcpListener::bind("0.0.0.0:80").is_ok() || TcpListener::bind("[::]:80").is_ok() {
         eprintln!(
             "SKIP gvproxy_privileged_port_fails_fast_with_named_error: \
-             host allows binding port 80 (root / CAP_NET_BIND_SERVICE / \
-             low ip_unprivileged_port_start)"
+             host allows binding port 80 on the wildcard address (Darwin / root / \
+             CAP_NET_BIND_SERVICE / low ip_unprivileged_port_start)"
         );
         return;
     }

--- a/src/cli/tests/gvproxy_port_conflict.rs
+++ b/src/cli/tests/gvproxy_port_conflict.rs
@@ -6,6 +6,7 @@
 
 mod common;
 
+use std::io::ErrorKind;
 use std::net::TcpListener;
 use std::process::Command;
 use std::time::Instant;
@@ -126,13 +127,32 @@ fn gvproxy_privileged_port_fails_fast_with_named_error() {
     // succeeds there while every specific address returns EACCES — probing
     // 127.0.0.1 would report the premise as holding when it does not, and the
     // test would then fail against a box that published port 80 correctly.
-    if TcpListener::bind("0.0.0.0:80").is_ok() || TcpListener::bind("[::]:80").is_ok() {
-        eprintln!(
-            "SKIP gvproxy_privileged_port_fails_fast_with_named_error: \
-             host allows binding port 80 on the wildcard address (Darwin / root / \
-             CAP_NET_BIND_SERVICE / low ip_unprivileged_port_start)"
-        );
-        return;
+    //
+    // Only an explicit PermissionDenied establishes the premise. A wildcard :80
+    // held by another process fails with AddrInUse, which is a conflict rather
+    // than a refusal — running on that would assert a permission error the box
+    // cannot produce.
+    for address in ["0.0.0.0:80", "[::]:80"] {
+        match TcpListener::bind(address) {
+            Err(error) if error.kind() == ErrorKind::PermissionDenied => {}
+            Ok(_) => {
+                eprintln!(
+                    "SKIP gvproxy_privileged_port_fails_fast_with_named_error: \
+                     host allows binding {address} (Darwin / root / \
+                     CAP_NET_BIND_SERVICE / low ip_unprivileged_port_start)"
+                );
+                return;
+            }
+            Err(error) => {
+                eprintln!(
+                    "SKIP gvproxy_privileged_port_fails_fast_with_named_error: \
+                     probing {address} failed with {:?} ({error}), not PermissionDenied, \
+                     so the premise cannot be established",
+                    error.kind()
+                );
+                return;
+            }
+        }
     }
 
     let ctx = common::boxlite();


### PR DESCRIPTION
## What changed

Three independent commits, reviewable and revertable in isolation.

### `refactor(ci)!` — rename `deploy-dev-api.yml` → `deploy-infra.yml`, add a `stage` input

The workflow deploys the whole control-plane stack, not just the API, and
hardcoded `dev` in seven places. It now takes the stage as a
`workflow_dispatch` `choice` input threaded through the GitHub Environment,
`IAM_PERMISSIONS_BOUNDARY_STAGE`, the concurrency group, the role session name,
and every `sst` command. The input is an allowlist rather than free text, so a
required-reviewers Environment cannot be targeted by an unbootstrapped or
misspelled name.

### `feat(infra)` — `npm run bootstrap`

Standing up a stage previously meant a documented sequence of console clicks and
hand-copied values. One command now does it, against credentials the operator
already has:

1. checks AWS CLI ≥ 2.32.0 and that credentials resolve, pointing at `aws login`
   (browser sign-in — no IAM user, no access keys, no IAM Identity Center)
2. registers the GitHub OIDC provider only if the account lacks one
   (`CreateOpenIDConnectProvider` rejects duplicates)
3. creates the stage's GitHub Environment with the authenticated user as
   required reviewer, degrading to an unprotected environment **with a warning**
   where protection rules need a paid plan
4. optionally provisions Auth0 behind `--provision-auth0`
5. seeds the Cloudflare SSM parameters and the `OIDC_CLIENT_ID` SST secret
6. deploys the deploy-role stack and writes its ARN into the Environment

Steps 1–3 and 6 are idempotent; step 4 is not, and says so.

Also adds a CI preflight that reads the assumed role's own IAM policies before
any AWS resource is touched, replacing the wall of duplicate `AccessDenied`
errors that [this failed run](https://github.com/boxlite-ai/boxlite/actions/runs/30606029374/job/91078321370)
produced, and adds `functions/auth0/setCustomClaims.onExecutePostLogin.js`,
which the README referenced but which did not exist in the repo.

### `fix(infra)!` — protect the `prod` stage

`removal`, RDS `deletionProtection`, `skipFinalSnapshot` and the final-snapshot
identifier all keyed off `stage === 'production'`. **No such stage exists** —
SST state holds `app/boxlite/prod.json` in two buckets and no `production.json`.

The deployed prod stack is protected today only because it was deployed from a
branch that already compared against `'prod'`; several unmerged branches carry
that change. `main` still computed `isProd === false` for stage `prod`, so
deploying prod from `main` would have reset `deletionProtection` to false and
taken no final snapshot.

The comparison now goes through a single `PRODUCTION_STAGE` constant so the
removal policy and the database guards cannot drift apart. `NODE_ENV` and
`ENVIRONMENT` keep the value `production` — they are Node runtime settings, not
stage names.

## Verification

- `apps/infra` suite: 202 pass / 0 fail (was 173 — 29 new tests)
- `make test`: exit 0
- Two-side check on the prod fix: reverting `sst.config.ts` fails 2 of the 3 new
  contract tests; restoring passes all 202
- The IAM preflight test parses the real `ci/github-deploy-role.yaml` rather than
  a copied fixture — renaming the boundary policy makes it fail

## Not verified

**None of the bootstrap flow has run against live AWS, GitHub, or Auth0.** It is
structural and unit-level only; the Auth0 path is documentation-verified with no
live tenant. The first real `npm run bootstrap` is still the actual test.

`make test:apps:infra-config` (the tsc gate for `sst.config.ts`) did not finish
locally — it was still installing SST providers. CI covers it.

## Breaking changes

- `deploy-dev-api.yml` is now `deploy-infra.yml` and takes a `stage` input;
  `gh workflow run` invocations must be updated.
- A stage literally named `production` is no longer treated as production.
  Nothing in this repository's SST state carries that name, but anyone who
  followed the previous root-README instruction (`--stage production`, now
  `--stage prod`) must migrate — their next deploy would otherwise drop
  `removal: retain`, RDS deletion protection, and the final snapshot.

## Follow-ups not in this PR

- First-Runner provisioning is still unimplemented, so a genuinely from-zero
  deploy cannot complete.
- Cloudflare is the one prerequisite that cannot reach browser-OAuth: `wrangler`
  has no DNS scope. Cloudflare's newer `cf` CLI does register `dns_records:edit`,
  so whether its OAuth token is accepted where the Pulumi provider expects
  `CLOUDFLARE_API_TOKEN` is worth a follow-up experiment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added stage-selectable infrastructure deployments with protected environments and credential management.
  - Added guided environment bootstrapping for AWS, GitHub, secrets, deployment roles, and optional Auth0 setup.
  - Added provider login commands and Auth0 claims for verified email, email address, and name.
- **Bug Fixes**
  - Standardized production configuration on the `prod` stage.
  - Added deployment preflight checks to verify required permissions.
- **Documentation**
  - Updated deployment, authentication, retention, and public image credential guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->