### PR TITLE
fix(infra): unblock the first real deploy and finish the login flow

### DIFF
--- a/apps/infra/ci/github-deploy-role.yaml
+++ b/apps/infra/ci/github-deploy-role.yaml
@@ -128,6 +128,13 @@ Resources:
                   - application-autoscaling:*
                   - autoscaling:*
                   - cloudfront:*
+                  # Separate IAM service prefix, so `cloudfront:*` does not
+                  # reach it — a wildcard never crosses the `service:` colon.
+                  # sst.aws.Router keeps its route table in a CloudFront
+                  # KeyValueStore, so every apply calls DescribeKeyValueStore
+                  # and then the key writes. A preview never touches it, which
+                  # is why `apply=false` passes without this.
+                  - cloudfront-keyvaluestore:*
                   - cloudwatch:*
                   - ec2:*
                   - ecr:*

--- a/apps/infra/scripts/bootstrap-environment.mjs
+++ b/apps/infra/scripts/bootstrap-environment.mjs
@@ -61,6 +61,7 @@ import {
   hasGitHubOidcProvider,
   isAwsCliVersionAtLeast,
   ssmParameterName,
+  sstPlatformState,
   validateGitHubRepo,
 } from './environment-bootstrap.mjs'
 import {
@@ -88,6 +89,13 @@ const INFRA_ROOT = fileURLToPath(new URL('..', import.meta.url))
 const TEMPLATE_PATH = join(INFRA_ROOT, 'ci', 'github-deploy-role.yaml')
 const ENV_PATH = join(INFRA_ROOT, '.env')
 const SST_WRAPPER_PATH = join(INFRA_ROOT, 'scripts', 'sst-with-cloudflare.mjs')
+// Generous but bounded: a healthy platform install completed in ~85s here.
+const SST_INSTALL_TIMEOUT_MS = 240_000
+// The cold attempt gets a shorter leash than that, because a recovery sits
+// behind it: giving up early costs at worst an npm install that would not have
+// been needed, while waiting the full budget on an install that is not
+// progressing costs four minutes of silence.
+const SST_COLD_INSTALL_TIMEOUT_MS = 90_000
 const ACTION_SOURCE_PATH = join(INFRA_ROOT, 'functions', 'auth0', 'setCustomClaims.onExecutePostLogin.js')
 
 const CLOUDFLARE_CREDENTIALS = [
@@ -111,9 +119,22 @@ function requireStageEnvFile() {
 
 function requireGhAuthenticated() {
   try {
-    execFileSync('gh', ['auth', 'status'], { stdio: 'ignore', timeout: 15_000, killSignal: 'SIGTERM' })
+    // Capture stderr rather than discarding it: `gh auth status` validates the
+    // token over the network, so it also exits non-zero when github.com is
+    // unreachable. Only gh's own text separates that from a missing session,
+    // and the advice below is right for just one of them.
+    execFileSync('gh', ['auth', 'status'], {
+      stdio: ['ignore', 'ignore', 'pipe'],
+      encoding: 'utf8',
+      timeout: 15_000,
+      killSignal: 'SIGTERM',
+    })
   } catch (cause) {
-    throw new Error('GitHub CLI is not authenticated; run `npm run login` first', { cause })
+    const detail = cause.stderr?.trim()
+    throw new Error(
+      `GitHub CLI is not authenticated; run \`npm run login\` first${detail ? ` (gh said: ${detail})` : ''}`,
+      { cause },
+    )
   }
 }
 
@@ -293,22 +314,101 @@ async function ensureCloudflareCredentials({ awsCliPath, region, stage, force })
   }
 }
 
-// Routed through the same wrapper `npm run deploy`/`diff` use (not a bare sst
-// call) so this stays the one place that knows how to reach the sst binary —
-// see scripts/sst-with-cloudflare.mjs's own header comment for why.
+const SST_PLATFORM_DIR = join(INFRA_ROOT, '.sst', 'platform')
+
+/*
+ * Install SST's platform (pulumi, bun, ~560 provider packages) before anything
+ * that is timed tightly.
+ *
+ * On a clean checkout the first sst call of any kind pays this cost, and until
+ * this step existed that call was `secret set` a few lines below — a one-second
+ * operation whose timeout was sized accordingly, so the install was killed
+ * mid-flight and surfaced as a bare ETIMEDOUT with SST's real error buried in
+ * .sst/log/sst.log.
+ *
+ * The npm fallback below covers an install that starts and does not finish,
+ * leaving package.json written but node_modules empty — a state observed on
+ * this machine, where an `sst install` was still running after ten minutes
+ * while npm populated the same tree in 42s. The cause was never isolated: a
+ * later cold run completed through sst's own bun in 85s under the same proxy,
+ * so do not read this as "bun is broken". It is recovery from a stuck install,
+ * whatever stuck it. sst still has to run once first regardless, since it is
+ * what writes .sst/platform/package.json.
+ */
+function ensureSstPlatform(stage) {
+  if (sstPlatformState(SST_PLATFORM_DIR) === 'ready') {
+    runSst(['install', '--stage', stage], { timeout: SST_INSTALL_TIMEOUT_MS, label: 'install the SST platform' })
+    console.log(`[${SCRIPT_NAME}] SST platform ... ready`)
+    return
+  }
+
+  console.log(`[${SCRIPT_NAME}] SST platform ... installing (first run: pulumi + providers, a minute or two)`)
+  try {
+    runSst(['install', '--stage', stage], { timeout: SST_COLD_INSTALL_TIMEOUT_MS, label: 'install the SST platform' })
+  } catch (error) {
+    if (sstPlatformState(SST_PLATFORM_DIR) !== 'deps-missing') throw error
+    console.warn(
+      `[${SCRIPT_NAME}] SST platform ... sst's installer did not finish and left no deps; ` +
+        'retrying those with npm',
+    )
+    execFileSync('npm', ['install', '--no-audit', '--no-fund'], {
+      cwd: SST_PLATFORM_DIR,
+      stdio: ['ignore', 'inherit', 'inherit'],
+      timeout: SST_INSTALL_TIMEOUT_MS,
+      killSignal: 'SIGTERM',
+    })
+    runSst(['install', '--stage', stage], { timeout: SST_INSTALL_TIMEOUT_MS, label: 'install the SST platform' })
+  }
+  console.log(`[${SCRIPT_NAME}] SST platform ... ready`)
+}
+
+/*
+ * Every sst call goes through the wrapper `npm run deploy`/`diff` use (not a
+ * bare sst binary) so this stays the one place that knows how to reach it —
+ * see scripts/sst-with-cloudflare.mjs's own header comment for why.
+ *
+ * sst writes its own diagnosis to .sst/log/sst.log and prints only "Unexpected
+ * error occurred" to the terminal, so a failure here is worthless without that
+ * file's tail attached.
+ */
+function runSst(args, { input, timeout, label }) {
+  try {
+    execFileSync(process.execPath, [SST_WRAPPER_PATH, ...args], {
+      ...(input === undefined ? {} : { input }),
+      encoding: 'utf8',
+      stdio: [input === undefined ? 'ignore' : 'pipe', 'inherit', 'inherit'],
+      timeout,
+      killSignal: 'SIGTERM',
+      cwd: INFRA_ROOT,
+    })
+  } catch (cause) {
+    const hint = cause.code === 'ETIMEDOUT' ? ` after ${Math.round(timeout / 1000)}s` : ''
+    throw new Error(`could not ${label}${hint}${sstLogTail()}`, { cause })
+  }
+}
+
+function sstLogTail(lines = 5) {
+  try {
+    const tail = readFileSync(join(INFRA_ROOT, '.sst', 'log', 'sst.log'), 'utf8').trimEnd().split('\n').slice(-lines)
+    return tail.length ? `\n  last lines of .sst/log/sst.log:\n${tail.map((line) => `    ${line}`).join('\n')}` : ''
+  } catch {
+    return '' // no log yet — the wrapper's own stderr is all there is
+  }
+}
+
 async function ensureOidcClientId(stage) {
   // `?.trim() || undefined` rather than `??`: an env var set to the empty
   // string is a misconfiguration, not a choice to store nothing, and `??` would
   // accept it and seed an empty secret that only fails at deploy time.
   const fromEnv = process.env.OIDC_CLIENT_ID?.trim() || undefined
   const value = requireNonEmptySecret('OIDC client ID', fromEnv ?? (await promptSecret('OIDC client ID: ')))
-  execFileSync(process.execPath, [SST_WRAPPER_PATH, 'secret', 'set', 'OIDC_CLIENT_ID', '--stage', stage], {
+  // 120s, not 60s: the platform is warm by now, but this still writes to the
+  // stage's secret store over the network and a slow link should not look like
+  // a broken one.
+  runSst(['secret', 'set', 'OIDC_CLIENT_ID', '--stage', stage], {
     input: value,
-    encoding: 'utf8',
-    stdio: ['pipe', 'inherit', 'inherit'],
-    timeout: 60_000,
-    killSignal: 'SIGTERM',
-    cwd: INFRA_ROOT,
+    timeout: 120_000,
+    label: 'set the OIDC_CLIENT_ID secret',
   })
   console.log(`[${SCRIPT_NAME}] OIDC_CLIENT_ID ... set${fromEnv ? ' from OIDC_CLIENT_ID env' : ''}`)
 }
@@ -531,9 +631,19 @@ function ghVariableSet({ repo, stage, name, value }) {
   })
 }
 
+/*
+ * The gh installed here (2.92.0) has no --body-file, and passing it makes gh
+ * print usage and exit non-zero. It takes --body, or reads the value from
+ * stdin when --body is omitted; --env-file is a different feature entirely
+ * (many secrets named by a dotenv file, not one secret whose value is that
+ * file). Passing the whole file on stdin is what stores DEPLOY_ENV as a single
+ * secret, and keeps the contents out of argv where other processes could read
+ * them.
+ */
 function ghSecretSetFromFile({ repo, stage, name, filePath }) {
-  execFileSync('gh', ['secret', 'set', name, '--repo', repo, '--env', stage, '--body-file', filePath], {
-    stdio: ['ignore', 'inherit', 'inherit'],
+  execFileSync('gh', ['secret', 'set', name, '--repo', repo, '--env', stage], {
+    input: readFileSync(filePath),
+    stdio: ['pipe', 'inherit', 'inherit'],
     timeout: 30_000,
     killSignal: 'SIGTERM',
   })
@@ -579,6 +689,8 @@ async function main() {
     provisionAuth0({ stackDomain })
   }
   await ensureCloudflareCredentials({ awsCliPath, region, stage, force })
+  // Before the first timed sst call, not inside it — see ensureSstPlatform.
+  ensureSstPlatform(stage)
   await ensureOidcClientId(stage)
   const roleArn = deployGithubDeployRoleStack({ awsCliPath, region, stage, repo })
   wireGithubEnvironment({ repo, stage, region, roleArn })
@@ -591,6 +703,14 @@ async function main() {
 try {
   await main()
 } catch (error) {
+  // Print the cause chain. Several checks here wrap a tool failure in advice
+  // ("GitHub CLI is not authenticated; run `npm run login` first"), and the
+  // advice is only right for one of the ways that tool can fail — `gh auth
+  // status` also exits non-zero when it cannot reach github.com. Without the
+  // cause an operator whose session is fine is sent to re-authenticate.
   console.error(`${SCRIPT_NAME}: ${error.message}`)
+  for (let cause = error.cause; cause; cause = cause.cause) {
+    console.error(`${SCRIPT_NAME}:   caused by: ${cause.message ?? cause}`)
+  }
   process.exit(1)
 }

--- a/apps/infra/scripts/environment-bootstrap.mjs
+++ b/apps/infra/scripts/environment-bootstrap.mjs
@@ -12,6 +12,9 @@
 // (githubDeployRoleStackName), and CloudFormation accepts only alphanumerics
 // and hyphens. Allowing `dev_blue` here would pass validation and then fail at
 // `cloudformation deploy`, after bootstrap had already made external changes.
+import { existsSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+
 const STAGE_LIKE_PATTERN = /^[A-Za-z0-9][A-Za-z0-9-]*$/
 const GITHUB_REPO_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_.-]*\/[A-Za-z0-9][A-Za-z0-9_.-]*$/
 const ACCOUNT_ID_PATTERN = /^\d{12}$/
@@ -141,4 +144,19 @@ export function hasGitHubOidcProvider(listOutput, url = GITHUB_OIDC_PROVIDER_URL
   const host = url.replace(/^https:\/\//, '')
   const providers = listOutput?.OpenIDConnectProviderList ?? []
   return providers.some(({ Arn }) => typeof Arn === 'string' && Arn.endsWith(`:oidc-provider/${host}`))
+}
+
+/*
+ * Whether sst's platform directory is usable. sst writes package.json on its
+ * first run and only then installs the deps, so "package.json but no
+ * node_modules" is the signature of an install that started and did not finish
+ * — which is exactly what a stalled bun leaves behind.
+ */
+export function sstPlatformState(dir) {
+  if (!existsSync(join(dir, 'package.json'))) return 'absent'
+  try {
+    return readdirSync(join(dir, 'node_modules')).length > 0 ? 'ready' : 'deps-missing'
+  } catch {
+    return 'deps-missing'
+  }
 }

--- a/apps/infra/scripts/environment-bootstrap.test.mjs
+++ b/apps/infra/scripts/environment-bootstrap.test.mjs
@@ -3,6 +3,9 @@
 
 import assert from 'node:assert/strict'
 import test from 'node:test'
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
 import {
   GITHUB_OIDC_PROVIDER_URL,
@@ -15,6 +18,7 @@ import {
   parseAwsCliVersion,
   runtimeBoundaryPolicyArn,
   ssmParameterName,
+  sstPlatformState,
   validateGitHubRepo,
 } from './environment-bootstrap.mjs'
 
@@ -138,4 +142,22 @@ test('hasGitHubOidcProvider does not match a lookalike suffix', () => {
     false,
   )
   assert.equal(GITHUB_OIDC_PROVIDER_URL, 'https://token.actions.githubusercontent.com')
+})
+
+test('sstPlatformState tells a finished install from an interrupted one', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'sst-platform-'))
+  // sst has not run at all yet.
+  assert.equal(sstPlatformState(dir), 'absent')
+
+  // sst wrote package.json, then its bundled bun stalled before the deps
+  // landed. This is the state that must trigger the npm recovery rather than
+  // being reported as a working platform.
+  writeFileSync(join(dir, 'package.json'), '{}')
+  assert.equal(sstPlatformState(dir), 'deps-missing')
+
+  mkdirSync(join(dir, 'node_modules'))
+  assert.equal(sstPlatformState(dir), 'deps-missing', 'an empty node_modules is not a finished install')
+
+  mkdirSync(join(dir, 'node_modules', '@pulumi'))
+  assert.equal(sstPlatformState(dir), 'ready')
 })

--- a/apps/infra/scripts/login-providers.mjs
+++ b/apps/infra/scripts/login-providers.mjs
@@ -23,6 +23,8 @@ export const LOGIN_PROVIDERS = [
     statusArgs: ['sts', 'get-caller-identity'],
     loginArgs: ['login'],
     required: true,
+    // Formula name, not the binary name — `aws` ships as `awscli`.
+    install: { manager: 'brew', formula: 'awscli' },
   },
   {
     key: 'github',
@@ -31,6 +33,7 @@ export const LOGIN_PROVIDERS = [
     statusArgs: ['auth', 'status'],
     loginArgs: ['auth', 'login'],
     required: true,
+    install: { manager: 'brew', formula: 'gh' },
   },
   {
     key: 'auth0',
@@ -41,8 +44,34 @@ export const LOGIN_PROVIDERS = [
     statusArgs: ['tenants', 'list'],
     loginArgs: ['login'],
     required: false,
+    install: { manager: 'brew', formula: 'auth0' },
   },
 ]
+
+export const INSTALL_MANAGERS = {
+  brew: { command: 'brew', args: (formula) => ['install', formula], label: 'Homebrew' },
+}
+
+/**
+ * What to do about a provider whose CLI is absent.
+ *
+ *   'offer-install'  we know a recipe and its package manager is present, so
+ *                    the operator can be asked
+ *   'report'         no recipe, or the manager itself is missing — say how to
+ *                    get the CLI and move on rather than installing a package
+ *                    manager as a side effect of logging in
+ */
+export function decideMissingCliAction({ install, managerAvailable }) {
+  if (!install || !INSTALL_MANAGERS[install.manager]) return 'report'
+  return managerAvailable ? 'offer-install' : 'report'
+}
+
+/** The exact command line for a recipe, for both running and printing. */
+export function installCommand(install) {
+  const manager = INSTALL_MANAGERS[install?.manager]
+  if (!manager) return null
+  return { command: manager.command, args: manager.args(install.formula), label: manager.label }
+}
 
 export function selectProviders(requestedKeys) {
   if (!requestedKeys || requestedKeys.length === 0) return LOGIN_PROVIDERS

--- a/apps/infra/scripts/login-providers.test.mjs
+++ b/apps/infra/scripts/login-providers.test.mjs
@@ -4,7 +4,14 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { LOGIN_PROVIDERS, decideLoginAction, selectProviders, summarizeLoginResults } from './login-providers.mjs'
+import {
+  LOGIN_PROVIDERS,
+  decideLoginAction,
+  decideMissingCliAction,
+  installCommand,
+  selectProviders,
+  summarizeLoginResults,
+} from './login-providers.mjs'
 
 test('every provider is a browser sign-in with a status probe', () => {
   // A provider without a status probe would re-open a browser on every run.
@@ -37,6 +44,33 @@ test('selectProviders narrows to the requested providers in order', () => {
 
 test('selectProviders rejects an unknown provider instead of silently skipping it', () => {
   assert.throws(() => selectProviders(['cloudflare']), /unknown provider 'cloudflare'/)
+})
+
+test('decideMissingCliAction offers an install only when the manager is there', () => {
+  const install = { manager: 'brew', formula: 'auth0' }
+  assert.equal(decideMissingCliAction({ install, managerAvailable: true }), 'offer-install')
+  // Installing Homebrew itself is not something `npm run login` should do as a
+  // side effect, so without it the operator is told how instead.
+  assert.equal(decideMissingCliAction({ install, managerAvailable: false }), 'report')
+})
+
+test('decideMissingCliAction reports a provider it has no recipe for', () => {
+  assert.equal(decideMissingCliAction({ install: undefined, managerAvailable: true }), 'report')
+  assert.equal(decideMissingCliAction({ install: { manager: 'apt', formula: 'auth0' }, managerAvailable: true }), 'report')
+})
+
+test('installCommand names the formula, which differs from the binary', () => {
+  const aws = LOGIN_PROVIDERS.find((provider) => provider.key === 'aws')
+  assert.equal(aws.command, 'aws')
+  assert.deepEqual(installCommand(aws.install), { command: 'brew', args: ['install', 'awscli'], label: 'Homebrew' })
+  assert.equal(installCommand(undefined), null)
+})
+
+test('every provider carries an install recipe', () => {
+  // A missing recipe silently degrades the prompt back to "install it yourself".
+  for (const provider of LOGIN_PROVIDERS) {
+    assert.ok(installCommand(provider.install), `${provider.key} has no install recipe`)
+  }
 })
 
 test('decideLoginAction leaves a working session alone', () => {

--- a/apps/infra/scripts/login.mjs
+++ b/apps/infra/scripts/login.mjs
@@ -19,14 +19,64 @@
  */
 
 import { execFileSync, spawnSync } from 'node:child_process'
+import { accessSync, constants } from 'node:fs'
+import { delimiter, join } from 'node:path'
+import { createInterface } from 'node:readline/promises'
 
 import { hasFlag, parseFlag } from './cli-flags.mjs'
-import { decideLoginAction, selectProviders, summarizeLoginResults } from './login-providers.mjs'
+import {
+  decideLoginAction,
+  decideMissingCliAction,
+  installCommand,
+  selectProviders,
+  summarizeLoginResults,
+} from './login-providers.mjs'
 
 const SCRIPT_NAME = 'login'
 
+// Walk PATH directly rather than shelling out to `command -v`. A shell here
+// meant either `shell: true` with concatenated args — which Node now warns
+// about as an injection risk (DEP0190) — or interpolating the name into a
+// `sh -c` string, which has the same shape. Neither is worth it to answer
+// "is this binary on PATH".
 function isCliInstalled(command) {
-  return spawnSync('command', ['-v', command], { shell: true, stdio: 'ignore' }).status === 0
+  return (process.env.PATH ?? '').split(delimiter).some((dir) => {
+    if (!dir) return false
+    try {
+      accessSync(join(dir, command), constants.X_OK)
+      return true
+    } catch {
+      return false
+    }
+  })
+}
+
+async function confirm(question) {
+  const rl = createInterface({ input: process.stdin, output: process.stdout })
+  try {
+    return /^y(es)?$/i.test((await rl.question(question)).trim())
+  } finally {
+    rl.close()
+  }
+}
+
+/*
+ * Offer to install a missing CLI, and report whether it is now present.
+ * Declining is not a failure: an optional provider is stepped over, and a
+ * required one still fails through the normal missing-cli path below.
+ */
+async function offerInstall(provider) {
+  const recipe = installCommand(provider.install)
+  const printable = `${recipe.command} ${recipe.args.join(' ')}`
+  if (!(await confirm(`        Install with ${recipe.label}? [y/N] `))) {
+    console.log(`[${SCRIPT_NAME}] ${provider.label} ... skipped (install it with \`${printable}\`)`)
+    return false
+  }
+  console.log(`        $ ${printable}`)
+  const { status } = spawnSync(recipe.command, recipe.args, { stdio: 'inherit' })
+  // Re-probe rather than trusting the exit status: a formula can report
+  // success while leaving nothing on PATH (a keg-only pour, for instance).
+  return status === 0 && isCliInstalled(provider.command)
 }
 
 function isAuthenticated(provider) {
@@ -53,7 +103,7 @@ function runLogin(provider) {
   return status === 0
 }
 
-function main() {
+async function main() {
   const args = process.argv.slice(2)
   const force = hasFlag(args, 'force')
   const only = parseFlag(args, 'only')
@@ -65,13 +115,27 @@ function main() {
 
   const results = []
   for (const provider of providers) {
-    const cliInstalled = isCliInstalled(provider.command)
+    let cliInstalled = isCliInstalled(provider.command)
+
+    if (!cliInstalled) {
+      const recipe = installCommand(provider.install)
+      const missing = decideMissingCliAction({
+        install: provider.install,
+        managerAvailable: Boolean(recipe) && isCliInstalled(recipe.command),
+      })
+      console.log(`[${SCRIPT_NAME}] ${provider.label} ... \`${provider.command}\` not installed`)
+      if (missing === 'offer-install') {
+        cliInstalled = await offerInstall(provider)
+      } else {
+        const how = recipe ? `install it with \`${recipe.command} ${recipe.args.join(' ')}\`` : 'install it, then rerun'
+        console.log(`[${SCRIPT_NAME}] ${provider.label} ... ${how}`)
+      }
+    }
+
     const authenticated = cliInstalled && isAuthenticated(provider)
     const action = decideLoginAction({ cliInstalled, authenticated, force })
 
     if (action === 'missing-cli') {
-      const detail = provider.required ? 'install it, then rerun' : 'only needed for --provision-auth0'
-      console.log(`[${SCRIPT_NAME}] ${provider.label} ... \`${provider.command}\` not installed (${detail})`)
       results.push({ ...provider, status: 'missing-cli' })
       continue
     }
@@ -101,7 +165,7 @@ function main() {
 }
 
 try {
-  main()
+  await main()
 } catch (error) {
   console.error(`${SCRIPT_NAME}: ${error.message}`)
   process.exit(1)

--- a/apps/infra/scripts/release-deployment-safety.test.mjs
+++ b/apps/infra/scripts/release-deployment-safety.test.mjs
@@ -233,6 +233,24 @@ test('the checked-in deploy role satisfies the CI IAM boundary preflight', () =>
   assert.equal(grants, true, 'ci/github-deploy-role.yaml must grant iam:PutRolePermissionsBoundary for the stage boundary')
 })
 
+test('the deploy role grants the CloudFront KeyValueStore prefix Router needs', () => {
+  // `cloudfront:*` does not reach `cloudfront-keyvaluestore:*` — an IAM
+  // wildcard never crosses the `service:` colon, and these are two service
+  // prefixes. sst.aws.Router stores its route table in a KeyValueStore, so
+  // without this grant every apply dies on DescribeKeyValueStore while every
+  // preview passes, because a preview makes no KV call.
+  const template = load(readFileSync(DEV_DEPLOY_ROLE, 'utf8'), { schema: CLOUDFORMATION_SCHEMA })
+  const actions = template.Resources.GitHubDeployRole.Properties.Policies.flatMap((policy) =>
+    policy.PolicyDocument.Statement.flatMap((statement) =>
+      Array.isArray(statement.Action) ? statement.Action : [statement.Action],
+    ),
+  )
+  assert.ok(
+    actions.includes('cloudfront-keyvaluestore:*'),
+    'ci/github-deploy-role.yaml must grant cloudfront-keyvaluestore:*; cloudfront:* does not cover it',
+  )
+})
+
 test('package scripts disable long-running SST dev for the stateful stack', () => {
   const packageJson = JSON.parse(readFileSync(join(REPO_ROOT, 'apps/infra/package.json'), 'utf8'))
 

--- a/apps/infra/scripts/sst-config-contract.test.mjs
+++ b/apps/infra/scripts/sst-config-contract.test.mjs
@@ -146,6 +146,23 @@ test('no stage-name comparison hardcodes a bare production literal', () => {
   assert.match(source, /NODE_ENV: 'production'/)
 })
 
+test('every local Command pins dir, so it runs from the app root', () => {
+  // command.local.Command executes from the Pulumi process's cwd, which is
+  // .sst/platform — not the app root. A bare `node scripts/...` therefore
+  // resolves to .sst/platform/scripts and fails with "Cannot find module".
+  // Only an apply runs these, so a preview cannot catch a missing dir.
+  const commands = source.split(/new command\.local\.Command\(/).slice(1)
+  assert.ok(commands.length > 0, 'expected at least one command.local.Command in sst.config.ts')
+  for (const block of commands) {
+    const properties = block.slice(0, block.indexOf('triggers:'))
+    assert.match(
+      properties,
+      /dir: \$cli\.paths\.root/,
+      'each command.local.Command must set `dir: $cli.paths.root` or its script path resolves under .sst/platform',
+    )
+  }
+})
+
 test('the prod stage keeps deletion protection and a final snapshot', () => {
   assert.match(source, /args\.deletionProtection = isProd/)
   assert.match(source, /args\.skipFinalSnapshot = !isProd/)

--- a/apps/infra/sst.config.ts
+++ b/apps/infra/sst.config.ts
@@ -1043,6 +1043,12 @@ export default $config({
       new command.local.Command(
         'RegisterExtraRunners',
         {
+          // `dir` is required: command.local.Command runs from the Pulumi
+          // process's cwd (.sst/platform), not the app root, so a bare
+          // `scripts/...` resolves to .sst/platform/scripts and fails with
+          // "Cannot find module". $cli.paths.root is the same anchor SST uses
+          // for user-relative paths (platform/src/components/component.ts).
+          dir: $cli.paths.root,
           create: 'node scripts/register-runners.mjs',
           update: 'node scripts/register-runners.mjs',
           environment: {
@@ -1089,6 +1095,7 @@ export default $config({
       previousUpgrade = new command.local.Command(
         `UpgradeRunnerBinary-${label}`,
         {
+          dir: $cli.paths.root, // see RegisterExtraRunners above
           create: 'node scripts/runner-update-binary.mjs',
           update: 'node scripts/runner-update-binary.mjs',
           environment: {


### PR DESCRIPTION
Fixes #1117

Two defects made `apply=true` impossible. Both sit on steps a preview never reaches, so every green `apply=false` run passed over them.

## Call graph

Before
```
Deploy the full stack             (workflow · .github/workflows/deploy-infra.yml:113)
  ├─ ApiCdn route table           (sst.aws.Router · apps/infra/sst.config.ts:313)  ← BUG: role grants only cloudfront:*, so DescribeKeyValueStore is denied (apps/infra/ci/github-deploy-role.yaml:130)
  └─ UpgradeRunnerBinary-default  (command.local.Command · apps/infra/sst.config.ts:1099)  ← BUG: no dir, so `node scripts/…` resolves under .sst/platform and throws "Cannot find module"
```

After
```
Deploy the full stack             (workflow · .github/workflows/deploy-infra.yml:113)
  ├─ ApiCdn route table           (sst.aws.Router · apps/infra/sst.config.ts:313)  — role adds cloudfront-keyvaluestore:* (apps/infra/ci/github-deploy-role.yaml:137)
  └─ UpgradeRunnerBinary-default  (command.local.Command · apps/infra/sst.config.ts:1099)  — runs from the app root via dir: $cli.paths.root (apps/infra/sst.config.ts:1098)
```

**Key:** an IAM wildcard never crosses the `service:` colon, and Pulumi runs local Commands from `.sst/platform` rather than the app root — neither is observable from a preview.

`RegisterExtraRunners` (`apps/infra/sst.config.ts:1052`) carried the same missing `dir` and is fixed with it, though its `extraRunners.length > 0` gate means it is not firing today.

## Bootstrap could not reach either step

- `gh secret set --body-file` is not a flag on the `gh` installed here (2.92.0); it printed usage and exited non-zero, so `DEPLOY_ENV` was never written. The file now goes in on stdin, which also keeps its contents out of `argv`.
- The first `sst` call of any kind pays for installing the platform, and that call was `secret set` — budgeted at 60s for a one-second operation. The install is now an explicit step ahead of anything timed tightly.
- Failures wrapped a tool error in advice right for only one of the ways that tool fails: `gh auth status` also exits non-zero when github.com is unreachable, and the operator was told to re-authenticate a working session. The cause chain and `gh`'s own text now print.

## Regression tests

Both deploy defects get one, each confirmed to fail against the unfixed tree — reverted: 228/230 with exactly those two failing; restored: 230/230. They are source-text contracts, so they run in `npm test` with no AWS and no deploy; previously the only place either defect was reachable was a real apply. The `dir` contract asserts every `command.local.Command`, not just the two known sites.

## Also

`npm run login` offers to install a missing CLI via Homebrew rather than only naming it, re-probing PATH afterwards instead of trusting the formula's exit code. Its PATH probe no longer shells out, removing a `DEP0190` warning about unescaped args under `shell: true`.

## Verification

- `npm test` 230/230
- `aws cloudformation validate-template` exit 0
- `tsc --noEmit` on `sst.config.ts` exit 0
- The IAM grant is already live in AWS via `npm run bootstrap`; run 30740721581 showed 0 `AccessDenied`

Branched fresh off `46612b54` rather than reusing `worktree-silly-hatching-reddy`, which had diverged after #1113 squash-merged.

https://claude.ai/code/session_0165FPy2EKbJ9KvKLLmUaETT


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Login setup can detect missing AWS, GitHub, and Auth0 command-line tools and offer supported Homebrew installations.
  - Deployment setup now installs and validates required SST platform components automatically.
  - Deployments can manage CloudFront KeyValueStore resources.

- **Bug Fixes**
  - Improved diagnostics and recovery for failed installations, authentication, secret uploads, and deployment setup.
  - Local SST commands now consistently run from the application root for more reliable execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->