### PR TITLE
fix(infra): stop verifying an image list /api/config never returns

### DIFF
--- a/apps/infra/scripts/deployment-environment.mjs
+++ b/apps/infra/scripts/deployment-environment.mjs
@@ -117,20 +117,28 @@ function requireHostname(name, value) {
   return url.hostname
 }
 
-function parseExpectedSupportedImages(rawImages) {
-  return (rawImages ?? '')
+/*
+ * Reject a malformed entry here, where it costs nothing, rather than after SST
+ * has begun mutating the stack.
+ *
+ * The parsed images are deliberately not returned: nothing downstream compares
+ * them to the running API, because /api/config does not advertise an image list
+ * (apps/api/src/config/dto/configuration.dto.ts has no such field, and never
+ * has). A post-deploy check against it asserted a contract the API does not
+ * implement and failed every apply that set this variable.
+ */
+function validateConfiguredSystemImages(rawImages) {
+  for (const entry of (rawImages ?? '')
     .split(',')
     .map((entry) => entry.trim())
-    .filter(Boolean)
-    .map((entry) => {
-      const separator = entry.indexOf('=')
-      const name = separator > 0 ? entry.slice(0, separator).trim() : ''
-      const ref = separator > 0 ? entry.slice(separator + 1).trim() : ''
-      if (!name || !ref) {
-        throw new Error(`Invalid BOXLITE_SYSTEM_IMAGES entry '${entry}', expected 'name=ref'`)
-      }
-      return { name, ref }
-    })
+    .filter(Boolean)) {
+    const separator = entry.indexOf('=')
+    const name = separator > 0 ? entry.slice(0, separator).trim() : ''
+    const ref = separator > 0 ? entry.slice(separator + 1).trim() : ''
+    if (!name || !ref) {
+      throw new Error(`Invalid BOXLITE_SYSTEM_IMAGES entry '${entry}', expected 'name=ref'`)
+    }
+  }
 }
 
 export function resolvePublicDeploymentConfig(environment = process.env, workspaceVersion = readWorkspaceVersion()) {
@@ -165,7 +173,7 @@ export function resolvePublicDeploymentConfig(environment = process.env, workspa
   const expectedOidcIssuer = optionalPublicOidcIssuer(environment) ?? requireOidcIssuer(environment)
   const proxyTemplateOrigin = proxyTemplateUrl.origin
   const releaseVersion = resolveReleaseVersion(workspaceVersion, environment)
-  const expectedSupportedImages = parseExpectedSupportedImages(environment.BOXLITE_SYSTEM_IMAGES)
+  validateConfiguredSystemImages(environment.BOXLITE_SYSTEM_IMAGES)
 
   return {
     stackDomain,
@@ -179,6 +187,5 @@ export function resolvePublicDeploymentConfig(environment = process.env, workspa
     expectedOidcIssuer,
     expectedProxyTemplateUrl: proxyTemplateOrigin,
     expectedVersion: releaseVersion,
-    expectedSupportedImages,
   }
 }

--- a/apps/infra/scripts/deployment-environment.test.mjs
+++ b/apps/infra/scripts/deployment-environment.test.mjs
@@ -115,10 +115,6 @@ test('derives the public deployment probes from the same deployment environment'
       expectedOidcIssuer: 'https://auth.dev.boxlite.ai/',
       expectedProxyTemplateUrl: 'https://preview.dev.boxlite.ai',
       expectedVersion: '0.9.7',
-      expectedSupportedImages: [
-        { name: 'sandbaseai-hermes', ref: 'sam2026go/hermes-agent:boxlite-noexpose-20260726' },
-        { name: 'tools', ref: 'example.test/tools:1' },
-      ],
     },
   )
 })

--- a/apps/infra/scripts/proxy-deployment-verify.mjs
+++ b/apps/infra/scripts/proxy-deployment-verify.mjs
@@ -264,7 +264,6 @@ export async function verifyPublicDeployment({
   expectedOidcIssuer,
   expectedProxyTemplateUrl,
   expectedVersion,
-  expectedSupportedImages = [],
   fetchImpl = globalThis.fetch,
   requestTimeoutMs = 15_000,
 }) {
@@ -286,22 +285,6 @@ export async function verifyPublicDeployment({
   const expectedProxyTemplate = parseAbsoluteHttpsUrl(expectedProxyTemplateUrl, 'Expected Proxy template URL')
   if (typeof expectedVersion !== 'string' || expectedVersion.trim() === '') {
     throw new Error('Expected API version is required')
-  }
-  if (!Array.isArray(expectedSupportedImages)) {
-    throw new Error('Expected supported images must be an array')
-  }
-  for (const image of expectedSupportedImages) {
-    if (
-      !image ||
-      typeof image !== 'object' ||
-      Array.isArray(image) ||
-      typeof image.name !== 'string' ||
-      image.name === '' ||
-      typeof image.ref !== 'string' ||
-      image.ref === ''
-    ) {
-      throw new Error('Each expected supported image must contain a non-empty name and ref')
-    }
   }
 
   const proxyHealth = await fetchJson(fetchImpl, proxyHealthUrl, 'Public Proxy health check', requestTimeoutMs)
@@ -347,25 +330,6 @@ export async function verifyPublicDeployment({
   const actualVersion = apiConfig?.version
   if (actualVersion !== expectedVersion) {
     throw new Error(`Public API version ${actualVersion ?? 'missing'} does not match expected ${expectedVersion}`)
-  }
-
-  if (expectedSupportedImages.length > 0) {
-    const actualSupportedImages = apiConfig?.supportedImages
-    if (!Array.isArray(actualSupportedImages)) {
-      const expectedNames = expectedSupportedImages.map(({ name }) => name).join(', ')
-      throw new Error(`Public API supported images ${expectedNames} are missing`)
-    }
-    for (const expectedImage of expectedSupportedImages) {
-      const actualImage = actualSupportedImages.find((image) => image?.name === expectedImage.name)
-      if (!actualImage) {
-        throw new Error(`Public API supported images are missing ${expectedImage.name}`)
-      }
-      if (actualImage.ref !== expectedImage.ref) {
-        throw new Error(
-          `Public API image ${expectedImage.name} ref ${actualImage.ref ?? 'missing'} does not match expected ${expectedImage.ref}`,
-        )
-      }
-    }
   }
 
   return {

--- a/apps/infra/scripts/proxy-deployment-verify.test.mjs
+++ b/apps/infra/scripts/proxy-deployment-verify.test.mjs
@@ -571,29 +571,25 @@ test('rejects a public API config from a stale release', async () => {
   )
 })
 
-test('rejects a public API config that omits or changes a configured image', async () => {
-  const expectedSupportedImages = [
-    { name: 'sandbaseai-hermes', ref: 'sam2026go/hermes-agent:boxlite-noexpose-20260726' },
-  ]
-  const apiConfig = (supportedImages) => ({
-    version: '0.9.7',
-    oidc: { issuer: 'https://auth.dev.boxlite.ai/' },
-    proxyTemplateUrl: 'https://proxy.dev.boxlite.ai',
-    ...(supportedImages === undefined ? {} : { supportedImages }),
+test('verifies a public API config that does not advertise an image list', async () => {
+  // /api/config has no supportedImages field and never has, so comparing one
+  // against it failed every apply that set BOXLITE_SYSTEM_IMAGES. The images
+  // below are what that variable used to resolve to; passing them must not
+  // reintroduce an assertion on a field the API does not implement.
+  const verification = await verifyPublicDeployment({
+    ...publicDeploymentOptions(async (url) =>
+      url.includes('/health')
+        ? jsonResponse(200, { status: 'ok' })
+        : jsonResponse(200, {
+            version: '0.9.7',
+            oidc: { issuer: 'https://auth.dev.boxlite.ai/' },
+            proxyTemplateUrl: 'https://proxy.dev.boxlite.ai',
+          }),
+    ),
+    expectedSupportedImages: [{ name: 'sandbaseai-hermes', ref: 'sam2026go/hermes-agent:boxlite-noexpose-20260726' }],
   })
-  const verifyImages = (supportedImages) =>
-    verifyPublicDeployment({
-      ...publicDeploymentOptions(async (url) =>
-        url.includes('/health') ? jsonResponse(200, { status: 'ok' }) : jsonResponse(200, apiConfig(supportedImages)),
-      ),
-      expectedSupportedImages,
-    })
 
-  await assert.rejects(verifyImages(undefined), /supported images.*sandbaseai-hermes.*missing/i)
-  await assert.rejects(
-    verifyImages([{ name: 'sandbaseai-hermes', ref: 'sam2026go/hermes-agent:old' }]),
-    /image sandbaseai-hermes.*sam2026go\/hermes-agent:old.*boxlite-noexpose-20260726/i,
-  )
+  assert.equal(verification.version, '0.9.7')
 })
 
 test('retries public deployment probes a bounded number of times', async () => {


### PR DESCRIPTION
Post-deploy verification compared `apiConfig.supportedImages` against the
images named in BOXLITE_SYSTEM_IMAGES. That field does not exist on
/api/config and never has: apps/api/src/config/dto/configuration.dto.ts
shapes the response and has no such property, and `git log -S` over
apps/api/src/config/ finds no commit that added one. The check asserted a
contract the API does not implement.

It is gated on BOXLITE_SYSTEM_IMAGES being non-empty, so no CI path armed
it — only a real .env did. Every apply that set the variable therefore
failed, and failed late: verification runs after `sst deploy` exits 0
(scripts/sst-with-cloudflare.mjs:259), so it reported a broken deployment
that had in fact already applied cleanly.

The BOXLITE_SYSTEM_IMAGES format check stays. It rejects a malformed entry
before SST mutates the stack, which is unrelated to the response
assertion, so the parser becomes validateConfiguredSystemImages and drops
its return value rather than being deleted. The variable still configures
the API through sst.config.ts, unchanged.

Two tests cover the removal. The resolved deployment config must not carry
an expectation of that field, and a public API config without one must
verify. The second passes the images the variable used to resolve to;
note it pins the old parameter name, so it catches a reintroduction under
that name and not under a new one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deployment configuration now validates system image entries without exposing obsolete image-list details.
  * Deployment verification succeeds when the public configuration does not include supported image information.
  * Removed checks that required public APIs to expose and match supported image lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->