### PR TITLE
docs(infra): point the removed image check at #1045

### DIFF
--- a/apps/infra/scripts/deployment-environment.mjs
+++ b/apps/infra/scripts/deployment-environment.mjs
@@ -121,11 +121,11 @@ function requireHostname(name, value) {
  * Reject a malformed entry here, where it costs nothing, rather than after SST
  * has begun mutating the stack.
  *
- * The parsed images are deliberately not returned: nothing downstream compares
- * them to the running API, because /api/config does not advertise an image list
- * (apps/api/src/config/dto/configuration.dto.ts has no such field, and never
- * has). A post-deploy check against it asserted a contract the API does not
- * implement and failed every apply that set this variable.
+ * The parsed images are deliberately not returned. A post-deploy check compared
+ * them to /api/config, which carries no image list yet: that field is the
+ * acceptance criterion for #1045, and the check landed ahead of the API work it
+ * tests, so every apply that set this variable failed (#1119). Reinstate the
+ * comparison together with #1045, not before.
  */
 function validateConfiguredSystemImages(rawImages) {
   for (const entry of (rawImages ?? '')

--- a/apps/infra/scripts/proxy-deployment-verify.test.mjs
+++ b/apps/infra/scripts/proxy-deployment-verify.test.mjs
@@ -572,10 +572,10 @@ test('rejects a public API config from a stale release', async () => {
 })
 
 test('verifies a public API config that does not advertise an image list', async () => {
-  // /api/config has no supportedImages field and never has, so comparing one
-  // against it failed every apply that set BOXLITE_SYSTEM_IMAGES. The images
-  // below are what that variable used to resolve to; passing them must not
-  // reintroduce an assertion on a field the API does not implement.
+  // /api/config carries no supportedImages field yet (#1045), so comparing one
+  // against it failed every apply that set BOXLITE_SYSTEM_IMAGES (#1119). The
+  // images below are what that variable used to resolve to; passing them must
+  // not reintroduce the assertion before #1045 ships.
   const verification = await verifyPublicDeployment({
     ...publicDeploymentOptions(async (url) =>
       url.includes('/health')


### PR DESCRIPTION
Both comments left by #1120 read as though /api/config was never meant to
carry an image list — "has no such field, and never has", "a contract the
API does not implement". That is true of the code today and wrong about
the intent: #1045 specifies `supportedImages` on that response, down to
the same alias and ref the removed check asserted, and it is still open.

Left as-is, the next reader concludes the field was a mistake rather than
that the check outran the API work. Both comments now name #1045 as what
reinstates the comparison and #1119 as why it went away.

Comment text only; `git diff -U0` reports no changed executable line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal comments to clarify the planned system-image comparison behavior and its relationship to the configuration API.
  * Added historical context and issue references for the unavailable supported-images field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->