### PR TITLE
fix(tunnel)!: own half-close in core, tolerate a hung-up peer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,6 +607,7 @@ dependencies = [
  "cbindgen",
  "futures",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/docs/reference/c/README.md
+++ b/docs/reference/c/README.md
@@ -709,11 +709,9 @@ BoxliteErrorCode boxlite_network_tunnel(
     CBoxTunnelHandle** out_tunnel,
     CBoxliteError* out_error
 );
-BoxliteErrorCode boxlite_tunnel_endpoint(
+BoxliteErrorCode boxlite_tunnel_uri(
     CBoxTunnelHandle* tunnel,
-    BoxliteEndpointType* out_type,
     char** out_uri,
-    int32_t* out_fd,
     CBoxliteError* out_error
 );
 BoxliteErrorCode boxlite_tunnel_connect(
@@ -729,9 +727,10 @@ Each `CBoxTunnelHandle` owns exactly one connection.
 descriptor that the caller must close; a second call returns `InvalidState`.
 Release the tunnel handle with `boxlite_tunnel_free()` after connecting or when
 discarding an unconsumed tunnel.
-`boxlite_tunnel_endpoint()` returns either an allocated remote URI or a borrowed
-local descriptor. Free the URI with `boxlite_free_string()`, and keep the tunnel
-alive while using a borrowed descriptor.
+`boxlite_tunnel_uri()` reports where a remotely served tunnel can be reached, as
+an allocated string the caller frees with `boxlite_free_string()`. It writes NULL
+for a local tunnel, whose descriptor is already a live connection rather than an
+address — reach those with `boxlite_tunnel_connect()`.
 
 Create another tunnel handle for each additional or concurrent connection.
 This differs from `boxlite_options_add_port()`, which creates a persistent,

--- a/docs/reference/nodejs/README.md
+++ b/docs/reference/nodejs/README.md
@@ -261,7 +261,8 @@ live binding data yet, so box, get, or list info may report
 | Operation | Signature | Description |
 |-----------|-----------|-------------|
 | Prepare | `await box.network.tunnel(port)` | Return a `JsBoxTunnel` or `BoxTunnel` for one TCP connection |
-| Inspect | `tunnel.endpoint(): string \| number` | Return the remote URI or borrowed local file descriptor |
+| Inspect | `tunnel.uri(): string \| null` | Public URL of a remotely served tunnel; `null` for a local one |
+| Descriptor | `connection.fileno(): number` | Borrowed fd, as on a `net.Socket`; throws when remotely served |
 | Connect | `await tunnel.connect()` | Consume the tunnel and return its bidirectional connection |
 | Read/write | `await connection.read(maxBytes)`, `await connection.write(data)` | Exchange bytes with the service |
 | Close | `await connection.close()` | Close the connection |

--- a/docs/reference/nodejs/README.md
+++ b/docs/reference/nodejs/README.md
@@ -262,7 +262,6 @@ live binding data yet, so box, get, or list info may report
 |-----------|-----------|-------------|
 | Prepare | `await box.network.tunnel(port)` | Return a `JsBoxTunnel` or `BoxTunnel` for one TCP connection |
 | Inspect | `tunnel.uri(): string \| null` | Public URL of a remotely served tunnel; `null` for a local one |
-| Descriptor | `connection.fileno(): number` | Borrowed fd, as on a `net.Socket`; throws when remotely served |
 | Connect | `await tunnel.connect()` | Consume the tunnel and return its bidirectional connection |
 | Read/write | `await connection.read(maxBytes)`, `await connection.write(data)` | Exchange bytes with the service |
 | Close | `await connection.close()` | Close the connection |

--- a/docs/reference/python/README.md
+++ b/docs/reference/python/README.md
@@ -291,7 +291,8 @@ Both `boxlite.Box` and `boxlite.SimpleBox` expose `box.network`.
 | Operation | Signature | Description |
 |-----------|-----------|-------------|
 | Prepare | `await box.network.tunnel(port) -> BoxTunnel` | Prepare one connection to a TCP service in the box |
-| Inspect | `tunnel.endpoint() -> str \| int` | Return the remote URI or borrowed local file descriptor |
+| Inspect | `tunnel.uri() -> str \| None` | Public URL of a remotely served tunnel; `None` for a local one |
+| Descriptor | `connection.fileno() -> int` | Borrowed fd, as `socket.fileno()`; raises when remotely served |
 | Connect | `await tunnel.connect() -> BoxConnection` | Consume the tunnel and return its bidirectional byte stream |
 | Read/write | `await connection.read(max_bytes)`, `await connection.write(data)` | Exchange bytes with the service |
 | Close | `await connection.close()` | Close the connection |

--- a/docs/reference/python/README.md
+++ b/docs/reference/python/README.md
@@ -292,7 +292,6 @@ Both `boxlite.Box` and `boxlite.SimpleBox` expose `box.network`.
 |-----------|-----------|-------------|
 | Prepare | `await box.network.tunnel(port) -> BoxTunnel` | Prepare one connection to a TCP service in the box |
 | Inspect | `tunnel.uri() -> str \| None` | Public URL of a remotely served tunnel; `None` for a local one |
-| Descriptor | `connection.fileno() -> int` | Borrowed fd, as `socket.fileno()`; raises when remotely served |
 | Connect | `await tunnel.connect() -> BoxConnection` | Consume the tunnel and return its bidirectional byte stream |
 | Read/write | `await connection.read(max_bytes)`, `await connection.write(data)` | Exchange bytes with the service |
 | Close | `await connection.close()` | Close the connection |

--- a/docs/reference/rust/README.md
+++ b/docs/reference/rust/README.md
@@ -365,8 +365,12 @@ pub struct BoxState {
 |-----------|-----------|-------------|
 | Get handle | `LiteBox::network(&self) -> NetworkHandle` | Get box-scoped network operations |
 | Prepare | `async fn tunnel(&self, target: SocketAddr) -> BoxliteResult<BoxTunnel>` | Prepare one TCP connection |
-| Inspect | `BoxTunnel::endpoint(&self) -> BoxEndpoint` | Return `Uri` for remote or a borrowed `FileDescriptor` for local |
-| Connect | `BoxTunnel::connect(self) -> BoxliteResult<Box<dyn BoxConnection>>` | Consume the tunnel into its bidirectional byte stream |
+| Inspect | `BoxTunnel::uri(&self) -> Option<&str>` | Public URL of a remotely served tunnel; `None` for a local one |
+| Descriptor | `BoxConnection::raw_fd(&self) -> Option<RawFd>` | Borrowed fd; `None` for a remotely served connection |
+| Take fd | `BoxConnection::into_fd(self) -> BoxliteResult<OwnedFd>` | Consume the connection and own its descriptor |
+| Connect | `BoxTunnel::connect(self) -> BoxliteResult<BoxConnection>` | Consume the tunnel into its bidirectional byte stream |
+| Split | `BoxConnection::into_split(self) -> (BoxReader, BoxWriter)` | Halves that read and write concurrently |
+| Half-close | `BoxWriter::shutdown(&mut self) -> BoxliteResult<()>` | Signal EOF; a peer that already hung up is success, not an error |
 
 `BoxTunnel` represents exactly one connection; its consuming `connect(self)`
 enforces that at the type boundary. Request another tunnel for each additional

--- a/scripts/test/e2e/sdks/node/e2e_tunnel.ts
+++ b/scripts/test/e2e/sdks/node/e2e_tunnel.ts
@@ -26,9 +26,9 @@ async function requestOverTunnel(
   readDelay = 0,
 ): Promise<Buffer> {
   const tunnel = await box.network.tunnel(port)
-  const endpoint = tunnel.endpoint()
-  if (typeof endpoint !== 'string') {
-    throw new Error('expected REST tunnel endpoint URL for the cloud box')
+  const uri = tunnel.uri()
+  if (uri === null) {
+    throw new Error('expected a public tunnel URL for the cloud box')
   }
   const socket = await tunnel.connect()
   const chunks: Buffer[] = []

--- a/sdks/c/Cargo.toml
+++ b/sdks/c/Cargo.toml
@@ -18,6 +18,7 @@ default = []
 boxlite = { workspace = true, features = ["rest"] }
 futures = "0.3"
 tokio = { version = "1.37", features = ["io-util", "net", "rt", "rt-multi-thread"] }
+tracing = "0.1"
 
 [dev-dependencies]
 boxlite = { workspace = true, features = ["rest"] }

--- a/sdks/c/README.md
+++ b/sdks/c/README.md
@@ -508,11 +508,9 @@ BoxliteErrorCode boxlite_network_tunnel(
     CBoxTunnelHandle** out_tunnel,
     CBoxliteError* out_error
 );
-BoxliteErrorCode boxlite_tunnel_endpoint(
+BoxliteErrorCode boxlite_tunnel_uri(
     CBoxTunnelHandle* tunnel,
-    BoxliteEndpointType* out_type,
     char** out_uri,
-    int32_t* out_fd,
     CBoxliteError* out_error
 );
 BoxliteErrorCode boxlite_tunnel_connect(
@@ -528,9 +526,10 @@ Each `CBoxTunnelHandle` owns exactly one connection.
 the caller must close; a second call returns `InvalidState`. Release the tunnel
 handle with `boxlite_tunnel_free()` after connecting or when discarding an
 unconsumed tunnel.
-`boxlite_tunnel_endpoint()` returns either an allocated remote URI or a borrowed
-local descriptor. Free the URI with `boxlite_free_string()`, and keep the tunnel
-alive while using a borrowed descriptor.
+`boxlite_tunnel_uri()` reports where a remotely served tunnel can be reached, as
+an allocated string the caller frees with `boxlite_free_string()`. It writes NULL
+for a local tunnel, whose descriptor is already a live connection rather than an
+address — reach those with `boxlite_tunnel_connect()`.
 
 Create another tunnel handle for every additional or concurrent connection.
 This differs from `boxlite_options_add_port()`, which creates a persistent,

--- a/sdks/c/include/boxlite.h
+++ b/sdks/c/include/boxlite.h
@@ -76,12 +76,6 @@ typedef enum BoxlitePortProtocol {
   BoxlitePortProtocolUdp = 1,
 } BoxlitePortProtocol;
 
-// The kind of endpoint exposed by a box tunnel.
-typedef enum BoxliteEndpointType {
-  BoxliteEndpointTypeUri = 0,
-  BoxliteEndpointTypeFileDescriptor = 1,
-} BoxliteEndpointType;
-
 typedef enum BoxliteRegistryTransport {
   BoxliteRegistryTransportHttps = 0,
   BoxliteRegistryTransportHttp = 1,
@@ -684,18 +678,16 @@ enum BoxliteErrorCode boxlite_network_tunnel(CBoxNetworkHandle *network,
 // Release a tunnel handle and any unconsumed connection. Accepts NULL.
 void boxlite_tunnel_free(CBoxTunnelHandle *tunnel);
 
-// Inspect a prepared tunnel without transferring ownership.
+// Read the public URL of a remotely served tunnel, without consuming it.
 //
-// `out_type` selects the valid output: URI returns an allocated `*out_uri`
-// that the caller must release with `boxlite_free_string`; FileDescriptor
-// returns a borrowed `*out_fd` valid only while the tunnel remains alive.
-// Unused outputs are initialized to NULL and -1. Errors are returned as a
+// On success `*out_uri` is an allocated string the caller must release with
+// `boxlite_free_string`, or NULL for a local tunnel — a local descriptor is
+// already a live connection, so it has no address; use
+// `boxlite_tunnel_connect` for those. Errors are returned as a
 // `BoxliteErrorCode` and described through `out_error` when provided.
-enum BoxliteErrorCode boxlite_tunnel_endpoint(CBoxTunnelHandle *tunnel,
-                                              enum BoxliteEndpointType *out_type,
-                                              char **out_uri,
-                                              int32_t *out_fd,
-                                              CBoxliteError *out_error);
+enum BoxliteErrorCode boxlite_tunnel_uri(CBoxTunnelHandle *tunnel,
+                                         char **out_uri,
+                                         CBoxliteError *out_error);
 
 // Consume a tunnel's single connection and return its owned file descriptor.
 //

--- a/sdks/c/src/network.rs
+++ b/sdks/c/src/network.rs
@@ -21,7 +21,11 @@ async fn connection_fd(
     let (sdk, mut bridge) = tokio::net::UnixStream::pair()
         .map_err(|error| BoxliteError::Network(format!("create SDK socket bridge: {error}")))?;
     tokio::spawn(async move {
-        let _ = tokio::io::copy_bidirectional(&mut connection, &mut bridge).await;
+        // The relay is detached, so a failure here has nowhere to be returned;
+        // the caller only sees EOF on its half. Log it so it is diagnosable.
+        if let Err(error) = tokio::io::copy_bidirectional(&mut connection, &mut bridge).await {
+            tracing::debug!(%error, "box tunnel bridge relay ended");
+        }
     });
     sdk.into_std()
         .map(std::os::fd::OwnedFd::from)
@@ -242,8 +246,8 @@ pub unsafe extern "C" fn boxlite_tunnel_connect(
             let connection = handle.connect()?;
             // A socket-backed connection already owns exactly the descriptor
             // the caller wants, so surrender it instead of inserting another
-            // socket pair and copy task. Only the in-memory remote transport
-            // needs that bridge.
+            // socket pair and copy task. Only the remote transport, whose
+            // socket belongs to the HTTP client, needs that bridge.
             match connection.raw_fd() {
                 Some(_) => connection.into_fd(),
                 None => connection_fd(connection).await,

--- a/sdks/c/src/network.rs
+++ b/sdks/c/src/network.rs
@@ -2,23 +2,21 @@
 
 use std::ffi::CString;
 use std::net::SocketAddr;
-use std::os::fd::{BorrowedFd, IntoRawFd};
+use std::os::fd::IntoRawFd;
 use std::os::raw::c_char;
 use std::ptr;
 use std::sync::Arc;
 
 use tokio::runtime::Runtime as TokioRuntime;
 
-use boxlite::litebox::{
-    BoxEndpoint, BoxTunnel as CoreBoxTunnel, NetworkHandle as CoreNetworkHandle,
-};
+use boxlite::litebox::{BoxTunnel as CoreBoxTunnel, NetworkHandle as CoreNetworkHandle};
 use boxlite::{BoxConnection, BoxliteError};
 
 use crate::error::{BoxliteErrorCode, error_to_code, null_pointer_error, write_error};
 use crate::{CBoxHandle, CBoxNetworkHandle, CBoxTunnelHandle, CBoxliteError};
 
 async fn connection_fd(
-    mut connection: Box<dyn BoxConnection>,
+    mut connection: BoxConnection,
 ) -> Result<std::os::fd::OwnedFd, BoxliteError> {
     let (sdk, mut bridge) = tokio::net::UnixStream::pair()
         .map_err(|error| BoxliteError::Network(format!("create SDK socket bridge: {error}")))?;
@@ -40,14 +38,6 @@ pub struct BoxNetworkHandle {
 pub struct BoxTunnelHandle {
     handle: Option<CoreBoxTunnel>,
     tokio_rt: Arc<TokioRuntime>,
-}
-
-/// The kind of endpoint exposed by a box tunnel.
-#[repr(C)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum BoxliteEndpointType {
-    BoxliteEndpointTypeUri = 0,
-    BoxliteEndpointTypeFileDescriptor = 1,
 }
 
 /// Borrow the box's network capability into a new owned handle.
@@ -160,19 +150,17 @@ pub unsafe extern "C" fn boxlite_tunnel_free(tunnel: *mut CBoxTunnelHandle) {
     }
 }
 
-/// Inspect a prepared tunnel without transferring ownership.
+/// Read the public URL of a remotely served tunnel, without consuming it.
 ///
-/// `out_type` selects the valid output: URI returns an allocated `*out_uri`
-/// that the caller must release with `boxlite_free_string`; FileDescriptor
-/// returns a borrowed `*out_fd` valid only while the tunnel remains alive.
-/// Unused outputs are initialized to NULL and -1. Errors are returned as a
+/// On success `*out_uri` is an allocated string the caller must release with
+/// `boxlite_free_string`, or NULL for a local tunnel — a local descriptor is
+/// already a live connection, so it has no address; use
+/// `boxlite_tunnel_connect` for those. Errors are returned as a
 /// `BoxliteErrorCode` and described through `out_error` when provided.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn boxlite_tunnel_endpoint(
+pub unsafe extern "C" fn boxlite_tunnel_uri(
     tunnel: *mut CBoxTunnelHandle,
-    out_type: *mut BoxliteEndpointType,
     out_uri: *mut *mut c_char,
-    out_fd: *mut i32,
     out_error: *mut CBoxliteError,
 ) -> BoxliteErrorCode {
     unsafe {
@@ -180,48 +168,31 @@ pub unsafe extern "C" fn boxlite_tunnel_endpoint(
             write_error(out_error, null_pointer_error("tunnel"));
             return BoxliteErrorCode::InvalidArgument;
         }
-        if out_type.is_null() {
-            write_error(out_error, null_pointer_error("out_type"));
-            return BoxliteErrorCode::InvalidArgument;
-        }
         if out_uri.is_null() {
             write_error(out_error, null_pointer_error("out_uri"));
             return BoxliteErrorCode::InvalidArgument;
         }
-        if out_fd.is_null() {
-            write_error(out_error, null_pointer_error("out_fd"));
-            return BoxliteErrorCode::InvalidArgument;
-        }
-        *out_type = BoxliteEndpointType::BoxliteEndpointTypeUri;
         *out_uri = ptr::null_mut();
-        *out_fd = -1;
 
         let tunnel_ref = &*tunnel;
         match tunnel_ref.handle.as_ref() {
             Some(handle) => {
-                match handle.endpoint() {
-                    BoxEndpoint::Uri(uri) => {
-                        let uri = match CString::new(uri) {
-                            Ok(uri) => uri,
-                            Err(_) => {
-                                write_error(
-                                    out_error,
-                                    BoxliteError::Internal(
-                                        "tunnel endpoint contains a NUL byte".into(),
-                                    ),
-                                );
-                                return BoxliteErrorCode::Internal;
-                            }
-                        };
-                        *out_type = BoxliteEndpointType::BoxliteEndpointTypeUri;
+                let Some(uri) = handle.uri() else {
+                    return BoxliteErrorCode::Ok;
+                };
+                match CString::new(uri) {
+                    Ok(uri) => {
                         *out_uri = uri.into_raw();
+                        BoxliteErrorCode::Ok
                     }
-                    BoxEndpoint::FileDescriptor(fd) => {
-                        *out_type = BoxliteEndpointType::BoxliteEndpointTypeFileDescriptor;
-                        *out_fd = fd;
+                    Err(_) => {
+                        write_error(
+                            out_error,
+                            BoxliteError::Internal("tunnel URI contains a NUL byte".into()),
+                        );
+                        BoxliteErrorCode::Internal
                     }
                 }
-                BoxliteErrorCode::Ok
             }
             None => {
                 let error = BoxliteError::InvalidState(
@@ -265,40 +236,25 @@ pub unsafe extern "C" fn boxlite_tunnel_connect(
             write_error(out_error, error);
             return code;
         };
-        if let BoxEndpoint::FileDescriptor(fd) = handle.endpoint() {
-            // The local descriptor is already the tunnel. Duplicate it for the
-            // caller instead of inserting another socket pair and copy task.
-            let fd = BorrowedFd::borrow_raw(fd)
-                .try_clone_to_owned()
-                .map_err(|error| {
-                    BoxliteError::Network(format!("duplicate local tunnel descriptor: {error}"))
-                });
-            drop(handle);
-            return match fd {
-                Ok(fd) => {
-                    *out_fd = fd.into_raw_fd();
-                    BoxliteErrorCode::Ok
-                }
-                Err(error) => {
-                    let code = error_to_code(&error);
-                    write_error(out_error, error);
-                    code
-                }
-            };
-        }
+        // `connect` registers the descriptor with the reactor, so it needs the
+        // runtime even though it is not itself async.
+        let owned_fd = tunnel_ref.tokio_rt.block_on(async {
+            let connection = handle.connect()?;
+            // A socket-backed connection already owns exactly the descriptor
+            // the caller wants, so surrender it instead of inserting another
+            // socket pair and copy task. Only the in-memory remote transport
+            // needs that bridge.
+            match connection.raw_fd() {
+                Some(_) => connection.into_fd(),
+                None => connection_fd(connection).await,
+            }
+        });
 
-        match handle.connect() {
-            Ok(connection) => match tunnel_ref.tokio_rt.block_on(connection_fd(connection)) {
-                Ok(fd) => {
-                    *out_fd = fd.into_raw_fd();
-                    BoxliteErrorCode::Ok
-                }
-                Err(error) => {
-                    let code = error_to_code(&error);
-                    write_error(out_error, error);
-                    code
-                }
-            },
+        match owned_fd {
+            Ok(fd) => {
+                *out_fd = fd.into_raw_fd();
+                BoxliteErrorCode::Ok
+            }
             Err(error) => {
                 let code = error_to_code(&error);
                 write_error(out_error, error);

--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -121,7 +121,7 @@ The same one-connection workflow works with local and remote runtimes:
 
 - `box.Network() (*Network, error)` returns box-scoped network operations.
 - `network.Tunnel(ctx, port) (*BoxTunnel, error)` prepares one TCP connection.
-- `tunnel.Endpoint() (BoxEndpoint, error)` returns a remote URI or borrowed local file descriptor.
+- `tunnel.URI() (string, error)` returns the public URL of a remotely served tunnel, or an empty string for a local one.
 - `tunnel.Connect(ctx) (net.Conn, error)` consumes the tunnel's single connection.
 
 Call `Tunnel` again for each additional or concurrent connection, and close the

--- a/sdks/go/tunnel.go
+++ b/sdks/go/tunnel.go
@@ -13,21 +13,6 @@ import (
 	"os"
 )
 
-// BoxEndpointType identifies how clients can reach a box service tunnel.
-type BoxEndpointType int
-
-const (
-	BoxEndpointTypeURI BoxEndpointType = iota
-	BoxEndpointTypeFileDescriptor
-)
-
-// BoxEndpoint describes the URI or prepared descriptor for a box service tunnel.
-type BoxEndpoint struct {
-	Type BoxEndpointType
-	URI  string
-	FD   int
-}
-
 // Network is a box-scoped handle for network operations.
 type Network struct {
 	handle *C.CBoxNetworkHandle
@@ -63,7 +48,7 @@ func (n *Network) Close() error {
 	return nil
 }
 
-// Tunnel prepares a one-shot endpoint for a service port inside the box.
+// Tunnel prepares a one-shot connection target for a service port inside the box.
 func (n *Network) Tunnel(ctx context.Context, port uint16) (*BoxTunnel, error) {
 	if n == nil || n.handle == nil {
 		return nil, ErrRuntimeClosed
@@ -93,30 +78,25 @@ func (t *BoxTunnel) Close() error {
 	return nil
 }
 
-// Endpoint returns the remote URI or borrowed local file descriptor.
-func (t *BoxTunnel) Endpoint() (BoxEndpoint, error) {
+// URI returns the public URL of a remotely served tunnel. It is empty for a
+// local tunnel, whose descriptor is already a live connection rather than an
+// address — use Connect for those.
+func (t *BoxTunnel) URI() (string, error) {
 	if t == nil || t.handle == nil {
-		return BoxEndpoint{}, ErrRuntimeClosed
+		return "", ErrRuntimeClosed
 	}
 
-	var endpointType C.enum_BoxliteEndpointType
 	var uri *C.char
-	var fd C.int32_t
 	var cerr C.CBoxliteError
-	code := C.boxlite_tunnel_endpoint(t.handle, &endpointType, &uri, &fd, &cerr)
+	code := C.boxlite_tunnel_uri(t.handle, &uri, &cerr)
 	if code != C.Ok {
-		return BoxEndpoint{}, freeError(&cerr)
+		return "", freeError(&cerr)
 	}
-
-	switch endpointType {
-	case C.BoxliteEndpointTypeUri:
-		defer C.boxlite_free_string(uri)
-		return BoxEndpoint{Type: BoxEndpointTypeURI, URI: C.GoString(uri), FD: -1}, nil
-	case C.BoxliteEndpointTypeFileDescriptor:
-		return BoxEndpoint{Type: BoxEndpointTypeFileDescriptor, FD: int(fd)}, nil
-	default:
-		return BoxEndpoint{}, fmt.Errorf("boxlite returned unknown endpoint type %d", endpointType)
+	if uri == nil {
+		return "", nil
 	}
+	defer C.boxlite_free_string(uri)
+	return C.GoString(uri), nil
 }
 
 // Connect consumes the tunnel's single raw byte stream.

--- a/sdks/go/tunnel_test.go
+++ b/sdks/go/tunnel_test.go
@@ -24,8 +24,8 @@ func TestBoxNetworkRejectsClosedHandle(t *testing.T) {
 
 func TestTunnelMethodsRejectClosedHandle(t *testing.T) {
 	var tunnel *BoxTunnel
-	if _, err := tunnel.Endpoint(); !errors.Is(err, ErrRuntimeClosed) {
-		t.Fatalf("Endpoint() error = %v, want ErrRuntimeClosed", err)
+	if _, err := tunnel.URI(); !errors.Is(err, ErrRuntimeClosed) {
+		t.Fatalf("URI() error = %v, want ErrRuntimeClosed", err)
 	}
 	if _, err := tunnel.Connect(context.Background()); !errors.Is(err, ErrRuntimeClosed) {
 		t.Fatalf("Connect() error = %v, want ErrRuntimeClosed", err)

--- a/sdks/node/lib/native-contracts.ts
+++ b/sdks/node/lib/native-contracts.ts
@@ -345,13 +345,15 @@ export interface JsNetworkHandle {
 
 /** Internal contract implemented by the native N-API tunnel binding. */
 export interface NativeBoxTunnel {
-  /** Return the public endpoint for this tunnel. */
-  endpoint(): string | number;
+  /** Public URL of a remotely served tunnel, or null for a local one. */
+  uri(): string | null;
   /** Consume the tunnel and return its bidirectional byte stream. */
   connect(): Promise<NativeBoxConnection>;
 }
 
 export interface NativeBoxConnection {
+  /** Borrowed descriptor; the connection still owns and closes it. */
+  fileno(): number;
   read(maxBytes: number): Promise<Buffer>;
   write(data: Buffer): Promise<number>;
   shutdownWrite(): Promise<void>;

--- a/sdks/node/lib/native-contracts.ts
+++ b/sdks/node/lib/native-contracts.ts
@@ -352,8 +352,6 @@ export interface NativeBoxTunnel {
 }
 
 export interface NativeBoxConnection {
-  /** Borrowed descriptor; the connection still owns and closes it. */
-  fileno(): number;
   read(maxBytes: number): Promise<Buffer>;
   write(data: Buffer): Promise<number>;
   shutdownWrite(): Promise<void>;

--- a/sdks/node/lib/simplebox.ts
+++ b/sdks/node/lib/simplebox.ts
@@ -298,9 +298,9 @@ export class BoxTunnel {
   /** Wrap the native tunnel handle for a box service port. */
   constructor(private readonly tunnel: NativeBoxTunnel) {}
 
-  /** Return the public endpoint for this service. */
-  endpoint(): string | number {
-    return this.tunnel.endpoint();
+  /** Public URL of a remotely served tunnel, or null for a local one. */
+  uri(): string | null {
+    return this.tunnel.uri();
   }
 
   /** Consume the tunnel and return its bidirectional byte stream. */

--- a/sdks/node/src/network.rs
+++ b/sdks/node/src/network.rs
@@ -28,12 +28,6 @@ pub struct JsBoxTunnel {
 pub struct JsBoxConnection {
     reader: Arc<tokio::sync::Mutex<Option<ConnectionReader>>>,
     writer: Arc<tokio::sync::Mutex<Option<ConnectionWriter>>>,
-    /// Borrowed from the halves, which close it; `None` for a remote pipe.
-    /// Cleared by `close` so a closed connection never reports a descriptor
-    /// the kernel may since have handed to someone else.
-    raw_fd: Arc<Mutex<Option<i32>>>,
-    /// Whether this transport ever had one, to tell "closed" from "no fd".
-    has_fd: bool,
 }
 
 #[napi]
@@ -81,37 +75,16 @@ impl JsBoxTunnel {
             .map_err(|_| Error::from_reason("tunnel lock poisoned"))?
             .take()
             .ok_or_else(|| Error::from_reason("tunnel connection has already been consumed"))?;
-        let connection = tunnel.connect().map_err(map_err)?;
-        let raw_fd = connection.raw_fd();
-        let (reader, writer) = connection.into_split();
+        let (reader, writer) = tunnel.connect().map_err(map_err)?.into_split();
         Ok(JsBoxConnection {
             reader: Arc::new(tokio::sync::Mutex::new(Some(reader))),
             writer: Arc::new(tokio::sync::Mutex::new(Some(writer))),
-            raw_fd: Arc::new(Mutex::new(raw_fd)),
-            has_fd: raw_fd.is_some(),
         })
     }
 }
 
 #[napi]
 impl JsBoxConnection {
-    /// Borrowed descriptor, like a `net.Socket`'s fd. The connection still
-    /// owns and closes it. Throws for a remotely served connection, which is
-    /// an in-memory pipe rather than a socket.
-    #[napi]
-    pub fn fileno(&self) -> Result<i32> {
-        if !self.has_fd {
-            return Err(Error::from_reason(
-                "a remotely served connection has no local descriptor",
-            ));
-        }
-        (*self
-            .raw_fd
-            .lock()
-            .map_err(|_| Error::from_reason("fd lock poisoned"))?)
-        .ok_or_else(|| Error::from_reason("connection is closed"))
-    }
-
     #[napi]
     pub async fn read(&self, max_bytes: u32) -> Result<Buffer> {
         if max_bytes == 0 {
@@ -145,10 +118,6 @@ impl JsBoxConnection {
 
     #[napi]
     pub async fn close(&self) -> Result<()> {
-        // Drop the number before the halves close it.
-        if let Ok(mut cached) = self.raw_fd.lock() {
-            *cached = None;
-        }
         let mut writer = self.writer.lock().await;
         if let Some(mut stream) = writer.take() {
             stream.shutdown().await.map_err(map_err)?;

--- a/sdks/node/src/network.rs
+++ b/sdks/node/src/network.rs
@@ -2,15 +2,15 @@ use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
 
 use boxlite::LiteBox;
-use boxlite::litebox::{BoxEndpoint, BoxTunnel};
+use boxlite::litebox::BoxTunnel;
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 use crate::util::map_err;
 
-type ConnectionReader = tokio::io::ReadHalf<Box<dyn boxlite::BoxConnection>>;
-type ConnectionWriter = tokio::io::WriteHalf<Box<dyn boxlite::BoxConnection>>;
+type ConnectionReader = boxlite::BoxReader;
+type ConnectionWriter = boxlite::BoxWriter;
 
 /// Handle for network operations on a box.
 #[napi]
@@ -28,6 +28,12 @@ pub struct JsBoxTunnel {
 pub struct JsBoxConnection {
     reader: Arc<tokio::sync::Mutex<Option<ConnectionReader>>>,
     writer: Arc<tokio::sync::Mutex<Option<ConnectionWriter>>>,
+    /// Borrowed from the halves, which close it; `None` for a remote pipe.
+    /// Cleared by `close` so a closed connection never reports a descriptor
+    /// the kernel may since have handed to someone else.
+    raw_fd: Arc<Mutex<Option<i32>>>,
+    /// Whether this transport ever had one, to tell "closed" from "no fd".
+    has_fd: bool,
 }
 
 #[napi]
@@ -54,8 +60,9 @@ impl JsNetworkHandle {
 
 #[napi]
 impl JsBoxTunnel {
+    /// Public URL of a remotely served tunnel, or `null` for a local one.
     #[napi]
-    pub fn endpoint(&self) -> Result<Either<String, i32>> {
+    pub fn uri(&self) -> Result<Option<String>> {
         let handle = self
             .handle
             .lock()
@@ -63,10 +70,7 @@ impl JsBoxTunnel {
         let tunnel = handle
             .as_ref()
             .ok_or_else(|| Error::from_reason("tunnel connection has already been consumed"))?;
-        match tunnel.endpoint() {
-            BoxEndpoint::Uri(uri) => Ok(Either::A(uri)),
-            BoxEndpoint::FileDescriptor(fd) => Ok(Either::B(fd)),
-        }
+        Ok(tunnel.uri().map(str::to_owned))
     }
 
     #[napi]
@@ -78,16 +82,36 @@ impl JsBoxTunnel {
             .take()
             .ok_or_else(|| Error::from_reason("tunnel connection has already been consumed"))?;
         let connection = tunnel.connect().map_err(map_err)?;
-        let (reader, writer) = tokio::io::split(connection);
+        let raw_fd = connection.raw_fd();
+        let (reader, writer) = connection.into_split();
         Ok(JsBoxConnection {
             reader: Arc::new(tokio::sync::Mutex::new(Some(reader))),
             writer: Arc::new(tokio::sync::Mutex::new(Some(writer))),
+            raw_fd: Arc::new(Mutex::new(raw_fd)),
+            has_fd: raw_fd.is_some(),
         })
     }
 }
 
 #[napi]
 impl JsBoxConnection {
+    /// Borrowed descriptor, like a `net.Socket`'s fd. The connection still
+    /// owns and closes it. Throws for a remotely served connection, which is
+    /// an in-memory pipe rather than a socket.
+    #[napi]
+    pub fn fileno(&self) -> Result<i32> {
+        if !self.has_fd {
+            return Err(Error::from_reason(
+                "a remotely served connection has no local descriptor",
+            ));
+        }
+        (*self
+            .raw_fd
+            .lock()
+            .map_err(|_| Error::from_reason("fd lock poisoned"))?)
+        .ok_or_else(|| Error::from_reason("connection is closed"))
+    }
+
     #[napi]
     pub async fn read(&self, max_bytes: u32) -> Result<Buffer> {
         if max_bytes == 0 {
@@ -121,12 +145,13 @@ impl JsBoxConnection {
 
     #[napi]
     pub async fn close(&self) -> Result<()> {
+        // Drop the number before the halves close it.
+        if let Ok(mut cached) = self.raw_fd.lock() {
+            *cached = None;
+        }
         let mut writer = self.writer.lock().await;
         if let Some(mut stream) = writer.take() {
-            stream
-                .shutdown()
-                .await
-                .map_err(|error| Error::from_reason(format!("close tunnel connection: {error}")))?;
+            stream.shutdown().await.map_err(map_err)?;
         }
         self.reader.lock().await.take();
         Ok(())
@@ -136,10 +161,7 @@ impl JsBoxConnection {
     pub async fn shutdown_write(&self) -> Result<()> {
         let mut writer = self.writer.lock().await;
         if let Some(stream) = writer.as_mut() {
-            stream
-                .shutdown()
-                .await
-                .map_err(|error| Error::from_reason(format!("shut down tunnel writer: {error}")))?;
+            stream.shutdown().await.map_err(map_err)?;
         }
         Ok(())
     }

--- a/sdks/node/tests/tunnel.test.ts
+++ b/sdks/node/tests/tunnel.test.ts
@@ -14,10 +14,10 @@ describe("SimpleBox", () => {
     vi.restoreAllMocks();
   });
 
-  test("endpoint returns the prepared local file descriptor", async () => {
+  test("uri returns the remote URL without consuming the tunnel", async () => {
     const { SimpleBox } = await import("../lib/simplebox.js");
-    const endpoint = vi.fn(() => 42);
-    const nativeTunnel = { endpoint, connect: vi.fn() };
+    const uri = vi.fn(() => "https://3000-box.proxy.example.test");
+    const nativeTunnel = { uri, connect: vi.fn() };
     const tunnelNative = vi.fn(async () => nativeTunnel);
     const box = new SimpleBox({ image: "alpine:latest" }) as SimpleBox & {
       _box: { network: { tunnel: typeof tunnelNative } };
@@ -25,9 +25,22 @@ describe("SimpleBox", () => {
     box._box = { network: { tunnel: tunnelNative } };
 
     const tunnel = await box.network.tunnel(3000);
-    expect(tunnel.endpoint()).toBe(42);
+    expect(tunnel.uri()).toBe("https://3000-box.proxy.example.test");
     expect(tunnelNative).toHaveBeenCalledWith(3000);
     expect(nativeTunnel.connect).not.toHaveBeenCalled();
+  });
+
+  test("uri is null for a local tunnel, which is reached by connecting", async () => {
+    const { SimpleBox } = await import("../lib/simplebox.js");
+    const nativeTunnel = { uri: vi.fn(() => null), connect: vi.fn() };
+    const tunnelNative = vi.fn(async () => nativeTunnel);
+    const box = new SimpleBox({ image: "alpine:latest" }) as SimpleBox & {
+      _box: { network: { tunnel: typeof tunnelNative } };
+    };
+    box._box = { network: { tunnel: tunnelNative } };
+
+    const tunnel = await box.network.tunnel(3000);
+    expect(tunnel.uri()).toBeNull();
   });
 
   test("connect consumes the tunnel once", async () => {
@@ -39,7 +52,7 @@ describe("SimpleBox", () => {
       .mockRejectedValueOnce(
         new Error("tunnel connection has already been consumed"),
       );
-    const nativeTunnel = { endpoint: vi.fn(), connect };
+    const nativeTunnel = { uri: vi.fn(), connect };
     const box = new SimpleBox({ image: "alpine:latest" }) as SimpleBox & {
       _box: { network: { tunnel: () => Promise<typeof nativeTunnel> } };
     };

--- a/sdks/node/tests/tunnel.test.ts
+++ b/sdks/node/tests/tunnel.test.ts
@@ -17,7 +17,8 @@ describe("SimpleBox", () => {
   test("uri returns the remote URL without consuming the tunnel", async () => {
     const { SimpleBox } = await import("../lib/simplebox.js");
     const uri = vi.fn(() => "https://3000-box.proxy.example.test");
-    const nativeTunnel = { uri, connect: vi.fn() };
+    const connection = { read: vi.fn(), write: vi.fn(), close: vi.fn() };
+    const nativeTunnel = { uri, connect: vi.fn(async () => connection) };
     const tunnelNative = vi.fn(async () => nativeTunnel);
     const box = new SimpleBox({ image: "alpine:latest" }) as SimpleBox & {
       _box: { network: { tunnel: typeof tunnelNative } };
@@ -28,6 +29,9 @@ describe("SimpleBox", () => {
     expect(tunnel.uri()).toBe("https://3000-box.proxy.example.test");
     expect(tunnelNative).toHaveBeenCalledWith(3000);
     expect(nativeTunnel.connect).not.toHaveBeenCalled();
+
+    // Reading the address must leave the tunnel usable, not consume it.
+    await expect(tunnel.connect()).resolves.toBe(connection);
   });
 
   test("uri is null for a local tunnel, which is reached by connecting", async () => {

--- a/sdks/python/boxlite/simplebox.py
+++ b/sdks/python/boxlite/simplebox.py
@@ -36,9 +36,9 @@ class BoxTunnel:
         """Consume the tunnel and return its bidirectional byte stream."""
         return await self._tunnel.connect()
 
-    def endpoint(self) -> str | int:
-        """Return the cloud URI or borrowed local file descriptor."""
-        return self._tunnel.endpoint()
+    def uri(self) -> str | None:
+        """Return the public URL of a remote tunnel, or ``None`` for a local one."""
+        return self._tunnel.uri()
 
 
 class NetworkHandle:

--- a/sdks/python/boxlite/sync_api/_network.py
+++ b/sdks/python/boxlite/sync_api/_network.py
@@ -19,9 +19,9 @@ class SyncBoxTunnel:
         """Consume the tunnel and return its bidirectional byte stream."""
         return self._box._sync(self._tunnel.connect())
 
-    def endpoint(self):
-        """Return the cloud URI or borrowed local file descriptor."""
-        return self._tunnel.endpoint()
+    def uri(self):
+        """Return the public URL of a remote tunnel, or ``None`` for a local one."""
+        return self._tunnel.uri()
 
 
 class SyncNetworkHandle:

--- a/sdks/python/src/network.rs
+++ b/sdks/python/src/network.rs
@@ -2,15 +2,15 @@ use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
 
 use boxlite::LiteBox;
-use boxlite::litebox::{BoxEndpoint, BoxTunnel};
+use boxlite::litebox::BoxTunnel;
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 use crate::util::map_err;
 
-type ConnectionReader = tokio::io::ReadHalf<Box<dyn boxlite::BoxConnection>>;
-type ConnectionWriter = tokio::io::WriteHalf<Box<dyn boxlite::BoxConnection>>;
+type ConnectionReader = boxlite::BoxReader;
+type ConnectionWriter = boxlite::BoxWriter;
 
 /// Handle for network operations on a box.
 #[pyclass(name = "NetworkHandle")]
@@ -29,6 +29,12 @@ pub(crate) struct PyBoxTunnel {
 pub(crate) struct PyBoxConnection {
     reader: Arc<tokio::sync::Mutex<Option<ConnectionReader>>>,
     writer: Arc<tokio::sync::Mutex<Option<ConnectionWriter>>>,
+    /// Borrowed from the halves, which close it; `None` for a remote pipe.
+    /// Cleared by `close` so a closed connection never reports a descriptor
+    /// the kernel may since have handed to someone else.
+    raw_fd: Arc<Mutex<Option<i32>>>,
+    /// Whether this transport ever had one, to tell "closed" from "no fd".
+    has_fd: bool,
 }
 
 #[pymethods]
@@ -54,8 +60,9 @@ impl PyNetworkHandle {
 
 #[pymethods]
 impl PyBoxTunnel {
-    fn endpoint(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
-        let endpoint = self
+    /// Public URL of a remotely served tunnel, or `None` for a local one.
+    fn uri(&self) -> PyResult<Option<String>> {
+        Ok(self
             .handle
             .lock()
             .map_err(|_| {
@@ -69,11 +76,8 @@ impl PyBoxTunnel {
                     "tunnel connection has already been consumed".into(),
                 ))
             })?
-            .endpoint();
-        match endpoint {
-            BoxEndpoint::Uri(uri) => Ok(uri.into_pyobject(py)?.into_any().unbind()),
-            BoxEndpoint::FileDescriptor(fd) => Ok(fd.into_pyobject(py)?.into_any().unbind()),
-        }
+            .uri()
+            .map(str::to_owned))
     }
 
     fn connect<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
@@ -93,10 +97,13 @@ impl PyBoxTunnel {
                     ))
                 })?;
             let connection = tunnel.connect().map_err(map_err)?;
-            let (reader, writer) = tokio::io::split(connection);
+            let raw_fd = connection.raw_fd();
+            let (reader, writer) = connection.into_split();
             Ok(PyBoxConnection {
                 reader: Arc::new(tokio::sync::Mutex::new(Some(reader))),
                 writer: Arc::new(tokio::sync::Mutex::new(Some(writer))),
+                raw_fd: Arc::new(Mutex::new(raw_fd)),
+                has_fd: raw_fd.is_some(),
             })
         })
     }
@@ -104,6 +111,26 @@ impl PyBoxTunnel {
 
 #[pymethods]
 impl PyBoxConnection {
+    /// Borrowed descriptor, as `socket.fileno()`. The connection still owns
+    /// and closes it. Raises for a remotely served connection, which is an
+    /// in-memory pipe rather than a socket.
+    fn fileno(&self) -> PyResult<i32> {
+        if !self.has_fd {
+            return Err(map_err(boxlite::BoxliteError::Unsupported(
+                "a remotely served connection has no local descriptor".into(),
+            )));
+        }
+        (*self
+            .raw_fd
+            .lock()
+            .map_err(|_| map_err(boxlite::BoxliteError::Internal("fd lock poisoned".into())))?)
+        .ok_or_else(|| {
+            map_err(boxlite::BoxliteError::InvalidState(
+                "connection is closed".into(),
+            ))
+        })
+    }
+
     fn read<'py>(&self, py: Python<'py>, max_bytes: usize) -> PyResult<Bound<'py, PyAny>> {
         if max_bytes == 0 {
             return Err(pyo3::exceptions::PyValueError::new_err(
@@ -150,14 +177,15 @@ impl PyBoxConnection {
     fn close<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let reader = Arc::clone(&self.reader);
         let writer = Arc::clone(&self.writer);
+        let raw_fd = Arc::clone(&self.raw_fd);
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            // Drop the number before the halves close it.
+            if let Ok(mut cached) = raw_fd.lock() {
+                *cached = None;
+            }
             let mut writer = writer.lock().await;
             if let Some(mut stream) = writer.take() {
-                stream.shutdown().await.map_err(|error| {
-                    map_err(boxlite::BoxliteError::Network(format!(
-                        "close tunnel connection: {error}"
-                    )))
-                })?;
+                stream.shutdown().await.map_err(map_err)?;
             }
             reader.lock().await.take();
             Ok(())
@@ -169,11 +197,7 @@ impl PyBoxConnection {
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let mut writer = writer.lock().await;
             if let Some(stream) = writer.as_mut() {
-                stream.shutdown().await.map_err(|error| {
-                    map_err(boxlite::BoxliteError::Network(format!(
-                        "shut down tunnel writer: {error}"
-                    )))
-                })?;
+                stream.shutdown().await.map_err(map_err)?;
             }
             Ok(())
         })

--- a/sdks/python/src/network.rs
+++ b/sdks/python/src/network.rs
@@ -29,12 +29,6 @@ pub(crate) struct PyBoxTunnel {
 pub(crate) struct PyBoxConnection {
     reader: Arc<tokio::sync::Mutex<Option<ConnectionReader>>>,
     writer: Arc<tokio::sync::Mutex<Option<ConnectionWriter>>>,
-    /// Borrowed from the halves, which close it; `None` for a remote pipe.
-    /// Cleared by `close` so a closed connection never reports a descriptor
-    /// the kernel may since have handed to someone else.
-    raw_fd: Arc<Mutex<Option<i32>>>,
-    /// Whether this transport ever had one, to tell "closed" from "no fd".
-    has_fd: bool,
 }
 
 #[pymethods]
@@ -96,14 +90,10 @@ impl PyBoxTunnel {
                         "tunnel connection has already been consumed".into(),
                     ))
                 })?;
-            let connection = tunnel.connect().map_err(map_err)?;
-            let raw_fd = connection.raw_fd();
-            let (reader, writer) = connection.into_split();
+            let (reader, writer) = tunnel.connect().map_err(map_err)?.into_split();
             Ok(PyBoxConnection {
                 reader: Arc::new(tokio::sync::Mutex::new(Some(reader))),
                 writer: Arc::new(tokio::sync::Mutex::new(Some(writer))),
-                raw_fd: Arc::new(Mutex::new(raw_fd)),
-                has_fd: raw_fd.is_some(),
             })
         })
     }
@@ -111,26 +101,6 @@ impl PyBoxTunnel {
 
 #[pymethods]
 impl PyBoxConnection {
-    /// Borrowed descriptor, as `socket.fileno()`. The connection still owns
-    /// and closes it. Raises for a remotely served connection, which is an
-    /// in-memory pipe rather than a socket.
-    fn fileno(&self) -> PyResult<i32> {
-        if !self.has_fd {
-            return Err(map_err(boxlite::BoxliteError::Unsupported(
-                "a remotely served connection has no local descriptor".into(),
-            )));
-        }
-        (*self
-            .raw_fd
-            .lock()
-            .map_err(|_| map_err(boxlite::BoxliteError::Internal("fd lock poisoned".into())))?)
-        .ok_or_else(|| {
-            map_err(boxlite::BoxliteError::InvalidState(
-                "connection is closed".into(),
-            ))
-        })
-    }
-
     fn read<'py>(&self, py: Python<'py>, max_bytes: usize) -> PyResult<Bound<'py, PyAny>> {
         if max_bytes == 0 {
             return Err(pyo3::exceptions::PyValueError::new_err(
@@ -177,12 +147,7 @@ impl PyBoxConnection {
     fn close<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let reader = Arc::clone(&self.reader);
         let writer = Arc::clone(&self.writer);
-        let raw_fd = Arc::clone(&self.raw_fd);
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            // Drop the number before the halves close it.
-            if let Ok(mut cached) = raw_fd.lock() {
-                *cached = None;
-            }
             let mut writer = writer.lock().await;
             if let Some(mut stream) = writer.take() {
                 stream.shutdown().await.map_err(map_err)?;

--- a/sdks/python/tests/test_dev_tunnel_e2e.py
+++ b/sdks/python/tests/test_dev_tunnel_e2e.py
@@ -71,9 +71,9 @@ async def _wait_for_http_server(
         tunnel = await box.network.tunnel(port)
 
 
-def _host_for_endpoint(endpoint: str | int) -> str:
-    if isinstance(endpoint, str) and endpoint.startswith(("http://", "https://")):
-        return endpoint.split("://", 1)[1].split("/", 1)[0]
+def _host_for_uri(uri: str | None) -> str:
+    if uri is not None and uri.startswith(("http://", "https://")):
+        return uri.split("://", 1)[1].split("/", 1)[0]
     return "localhost"
 
 
@@ -250,20 +250,20 @@ async def _assert_binary_tunnel(box, port: int) -> None:
         await server.kill()
 
 
-async def _assert_tunnel_endpoint_and_one_shot_connects(
+async def _assert_tunnel_uri_and_one_shot_connects(
     box,
     port: int,
     marker: bytes,
-    assert_endpoint,
+    assert_uri,
 ):
     server = await _serve_marker_http(box, port, marker)
 
     try:
         first_tunnel = await box.network.tunnel(port)
-        endpoint = first_tunnel.endpoint()
-        assert_endpoint(endpoint)
+        uri = first_tunnel.uri()
+        assert_uri(uri)
 
-        host = _host_for_endpoint(endpoint)
+        host = _host_for_uri(uri)
         first = await _wait_for_http_server(box, port, first_tunnel, host, marker)
         second_tunnel = await box.network.tunnel(port)
         second = await _http_get(second_tunnel, host, marker)
@@ -274,33 +274,58 @@ async def _assert_tunnel_endpoint_and_one_shot_connects(
         await server.kill()
 
 
-def _assert_local_endpoint(endpoint: int) -> None:
-    assert isinstance(endpoint, int)
-    assert endpoint >= 0
+def _assert_local_uri(uri: str | None) -> None:
+    # A local tunnel is already a live connection, so it has no address.
+    assert uri is None
 
 
-def _assert_cloud_endpoint(port: int):
-    def check(endpoint: str) -> None:
-        assert endpoint.startswith(("http://", "https://"))
-        assert str(port) in endpoint
+def _assert_cloud_uri(port: int):
+    def check(uri: str | None) -> None:
+        assert uri is not None
+        assert uri.startswith(("http://", "https://"))
+        assert str(port) in uri
 
     return check
 
 
 @pytest.mark.integration
-async def test_local_box_tunnel_endpoint_and_one_shot_connects(shared_runtime):
+async def test_local_box_tunnel_uri_and_one_shot_connects(shared_runtime):
     async with boxlite.SimpleBox(
         image=LOCAL_IMAGE,
         runtime=shared_runtime,
         memory_mib=512,
         cpus=1,
     ) as box:
-        await _assert_tunnel_endpoint_and_one_shot_connects(
+        await _assert_tunnel_uri_and_one_shot_connects(
             box,
             LOCAL_PORT,
             LOCAL_MARKER,
-            _assert_local_endpoint,
+            _assert_local_uri,
         )
+
+
+async def test_local_connection_fileno_is_cleared_by_close(shared_runtime):
+    """A closed connection must not keep reporting its descriptor.
+
+    The halves close the socket, so the kernel is free to hand that number to
+    something else; returning it afterwards would point callers at whatever
+    took its place.
+    """
+    async with boxlite.SimpleBox(
+        image=LOCAL_IMAGE,
+        runtime=shared_runtime,
+        memory_mib=512,
+        cpus=1,
+    ) as box:
+        tunnel = await box.network.tunnel(LOCAL_PORT)
+        connection = await tunnel.connect()
+
+        fd = connection.fileno()
+        assert isinstance(fd, int) and fd >= 0
+
+        await connection.close()
+        with pytest.raises(RuntimeError, match="closed"):
+            connection.fileno()
 
 
 @pytest.mark.integration
@@ -315,7 +340,7 @@ async def test_local_box_tunnel_binary_integrity(shared_runtime):
 
 
 @pytest.mark.e2e
-async def test_dev_cloud_tunnel_endpoint_and_one_shot_connects():
+async def test_dev_cloud_tunnel_uri_and_one_shot_connects():
     from boxlite import ApiKeyCredential, Boxlite, BoxliteRestOptions
 
     api_key = _required_env("BOXLITE_API_KEY")
@@ -334,11 +359,11 @@ async def test_dev_cloud_tunnel_endpoint_and_one_shot_connects():
     box = await runtime.get(box_id)
     assert box is not None, f"dev box {box_id!r} was not found"
 
-    await _assert_tunnel_endpoint_and_one_shot_connects(
+    await _assert_tunnel_uri_and_one_shot_connects(
         box,
         port,
         CLOUD_MARKER,
-        _assert_cloud_endpoint(port),
+        _assert_cloud_uri(port),
     )
 
 

--- a/sdks/python/tests/test_dev_tunnel_e2e.py
+++ b/sdks/python/tests/test_dev_tunnel_e2e.py
@@ -304,30 +304,6 @@ async def test_local_box_tunnel_uri_and_one_shot_connects(shared_runtime):
         )
 
 
-async def test_local_connection_fileno_is_cleared_by_close(shared_runtime):
-    """A closed connection must not keep reporting its descriptor.
-
-    The halves close the socket, so the kernel is free to hand that number to
-    something else; returning it afterwards would point callers at whatever
-    took its place.
-    """
-    async with boxlite.SimpleBox(
-        image=LOCAL_IMAGE,
-        runtime=shared_runtime,
-        memory_mib=512,
-        cpus=1,
-    ) as box:
-        tunnel = await box.network.tunnel(LOCAL_PORT)
-        connection = await tunnel.connect()
-
-        fd = connection.fileno()
-        assert isinstance(fd, int) and fd >= 0
-
-        await connection.close()
-        with pytest.raises(RuntimeError, match="closed"):
-            connection.fileno()
-
-
 @pytest.mark.integration
 async def test_local_box_tunnel_binary_integrity(shared_runtime):
     async with boxlite.SimpleBox(

--- a/sdks/python/tests/test_tunnel.py
+++ b/sdks/python/tests/test_tunnel.py
@@ -79,13 +79,19 @@ async def test_info_rejects_when_box_is_not_started():
 
 @pytest.mark.asyncio
 async def test_uri_returns_remote_url_without_consuming_the_tunnel():
+    connection = _FakeConnection()
     box = SimpleBox.__new__(SimpleBox)
     box._started = True
-    box._box = _FakeBox(_FakeTunnel([], "https://3000-box.proxy.example.test"))
+    box._box = _FakeBox(
+        _FakeTunnel([connection], "https://3000-box.proxy.example.test")
+    )
 
     tunnel = await box.network.tunnel(3000)
     assert tunnel.uri() == "https://3000-box.proxy.example.test"
     assert box._box.network.ports == [3000]
+
+    # Reading the address must leave the tunnel usable, not consume it.
+    assert await tunnel.connect() is connection
 
 
 @pytest.mark.asyncio

--- a/sdks/python/tests/test_tunnel.py
+++ b/sdks/python/tests/test_tunnel.py
@@ -21,12 +21,12 @@ class _FakeConnection:
 
 
 class _FakeTunnel:
-    def __init__(self, connections: list[_FakeConnection], endpoint: str | int) -> None:
+    def __init__(self, connections: list[_FakeConnection], uri: str | None) -> None:
         self.connections = connections
-        self.endpoint_value = endpoint
+        self.uri_value = uri
 
-    def endpoint(self) -> str | int:
-        return self.endpoint_value
+    def uri(self) -> str | None:
+        return self.uri_value
 
     async def connect(self) -> _FakeConnection:
         return self.connections.pop(0)
@@ -78,14 +78,24 @@ async def test_info_rejects_when_box_is_not_started():
 
 
 @pytest.mark.asyncio
-async def test_endpoint_returns_local_file_descriptor():
+async def test_uri_returns_remote_url_without_consuming_the_tunnel():
     box = SimpleBox.__new__(SimpleBox)
     box._started = True
-    box._box = _FakeBox(_FakeTunnel([], 42))
+    box._box = _FakeBox(_FakeTunnel([], "https://3000-box.proxy.example.test"))
 
     tunnel = await box.network.tunnel(3000)
-    assert tunnel.endpoint() == 42
+    assert tunnel.uri() == "https://3000-box.proxy.example.test"
     assert box._box.network.ports == [3000]
+
+
+@pytest.mark.asyncio
+async def test_uri_is_none_for_a_local_tunnel():
+    box = SimpleBox.__new__(SimpleBox)
+    box._started = True
+    box._box = _FakeBox(_FakeTunnel([], None))
+
+    tunnel = await box.network.tunnel(3000)
+    assert tunnel.uri() is None
 
 
 @pytest.mark.asyncio

--- a/src/boxlite/src/lib.rs
+++ b/src/boxlite/src/lib.rs
@@ -33,7 +33,7 @@ mod rest;
 mod rootfs;
 mod volumes;
 
-pub use litebox::{BoxConnection, BoxTunnel, LiteBox};
+pub use litebox::{BoxConnection, BoxReader, BoxTunnel, BoxWriter, LiteBox};
 pub use portal::GuestSession;
 pub use runtime::{AuthHandle, BoxliteRuntime, ImageHandle, Principal};
 

--- a/src/boxlite/src/litebox/mod.rs
+++ b/src/boxlite/src/litebox/mod.rs
@@ -23,7 +23,7 @@ pub use copy::CopyOptions;
 pub(crate) use crash_report::CrashReport;
 pub use exec::{BoxCommand, ExecResult, ExecStderr, ExecStdin, ExecStdout, Execution, ExecutionId};
 pub(crate) use manager::BoxManager;
-pub use network::{BoxConnection, BoxEndpoint, BoxTunnel, NetworkHandle};
+pub use network::{BoxConnection, BoxReader, BoxTunnel, BoxWriter, NetworkHandle};
 pub use snapshot::SnapshotHandle;
 pub use state::{BoxState, BoxStatus, HealthState, HealthStatus};
 

--- a/src/boxlite/src/litebox/network.rs
+++ b/src/boxlite/src/litebox/network.rs
@@ -66,16 +66,20 @@ impl Transport for tokio::net::UnixStream {
     }
 }
 
+/// The remote transport: an HTTP CONNECT stream hyper has upgraded.
+///
+/// Its descriptor is unreachable by construction — hyper owns the socket, it
+/// may be TLS-framed, and `Upgraded` can hold already-read tunnel bytes that no
+/// descriptor would carry. So both fd accessors decline.
 #[cfg(feature = "rest")]
-impl Transport for tokio::io::DuplexStream {
+impl Transport for hyper_util::rt::TokioIo<hyper::upgrade::Upgraded> {
     fn into_split(self: Box<Self>) -> (Box<dyn ReadTransport>, Box<dyn WriteTransport>) {
-        // No native split on an in-memory pipe, so this one pays the mutex.
+        // No native split, so this one pays `tokio::io::split`'s mutex.
         let (reader, writer) = tokio::io::split(*self);
         (Box::new(reader), Box::new(writer))
     }
 
     fn raw_fd(&self) -> Option<std::os::fd::RawFd> {
-        // In-memory pipe: there is no descriptor.
         None
     }
 
@@ -122,9 +126,9 @@ impl BoxConnection {
 
     /// The descriptor behind this connection, borrowed.
     ///
-    /// `None` for a remotely served connection, which is an in-memory pipe
-    /// rather than a socket. The connection retains ownership and closes it,
-    /// matching `socket.fileno()`.
+    /// `None` for a remotely served connection: hyper owns that socket and it
+    /// may be TLS-framed, so no descriptor of ours carries its bytes. The
+    /// connection retains ownership and closes it, matching `socket.fileno()`.
     pub fn raw_fd(&self) -> Option<std::os::fd::RawFd> {
         self.inner.raw_fd()
     }
@@ -368,24 +372,6 @@ mod tests {
             };
             assert!(result.is_ok(), "split={split} should tolerate ENOTCONN");
         }
-    }
-
-    /// The transport used for real remote tunnels — an in-memory duplex pipe —
-    /// reports no descriptor and refuses to surrender one.
-    #[cfg(feature = "rest")]
-    #[tokio::test]
-    async fn duplex_backed_connection_reports_and_refuses_a_descriptor() {
-        let (local, _peer) = tokio::io::duplex(64);
-        let connection = BoxConnection::new(local);
-
-        assert_eq!(connection.raw_fd(), None);
-        let error = connection
-            .into_fd()
-            .expect_err("an in-memory pipe has no descriptor");
-        assert!(
-            error.to_string().contains("no local descriptor"),
-            "unexpected error: {error}"
-        );
     }
 
     #[tokio::test]

--- a/src/boxlite/src/litebox/network.rs
+++ b/src/boxlite/src/litebox/network.rs
@@ -1,26 +1,226 @@
 //! Network sub-resource on LiteBox.
 
+use std::io::ErrorKind;
 use std::net::SocketAddr;
-use std::os::fd::{AsRawFd, OwnedFd};
+use std::os::fd::OwnedFd;
+use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt, ReadBuf};
 
 use boxlite_shared::errors::{BoxliteError, BoxliteResult};
 
 use crate::runtime::backend::BoxNetworkBackend;
 
-/// A descriptor for a box service tunnel.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum BoxEndpoint {
-    /// A URI clients can use to reach a remote box service.
-    Uri(String),
-    /// A borrowed descriptor for the prepared local connection.
-    FileDescriptor(i32),
+/// Combines the two byte-stream traits into something boxable.
+///
+/// `dyn AsyncRead + AsyncWrite` is rejected by rustc (E0225: only auto traits
+/// may be additional), so a supertrait alias is the sanctioned workaround.
+/// Deliberately **private**: callers get the concrete [`BoxConnection`], never
+/// this. Same arrangement as `hyper`'s `pub(super) trait Io` behind `Upgraded`.
+pub(crate) trait Transport: AsyncRead + AsyncWrite + Send + Unpin {
+    /// Split into owned halves, preferring the transport's own split.
+    ///
+    /// A real socket hands back lock-free halves; only transports without a
+    /// native split pay `tokio::io::split`'s shared mutex.
+    fn into_split(self: Box<Self>) -> (Box<dyn ReadTransport>, Box<dyn WriteTransport>);
+
+    /// The descriptor, borrowed — `None` when this transport has none.
+    ///
+    /// The transport keeps ownership and closes it on drop, so this is the
+    /// `socket.fileno()` contract rather than a transfer.
+    fn raw_fd(&self) -> Option<std::os::fd::RawFd>;
+
+    /// Give up the descriptor entirely, transferring ownership to the caller.
+    ///
+    /// Consuming, and it cannot hand the transport back on failure: the
+    /// underlying `into_std` takes `self` by value. Ask
+    /// [`raw_fd`](Self::raw_fd) first if you need the transport to survive the
+    /// question.
+    fn into_fd(self: Box<Self>) -> BoxliteResult<OwnedFd>;
 }
 
-/// Public byte-stream capability for a box service connection.
-pub trait BoxConnection: tokio::io::AsyncRead + tokio::io::AsyncWrite + Send + Unpin {}
+pub(crate) trait ReadTransport: AsyncRead + Send + Unpin {}
+impl<T: AsyncRead + Send + Unpin> ReadTransport for T {}
 
-impl<T> BoxConnection for T where T: tokio::io::AsyncRead + tokio::io::AsyncWrite + Send + Unpin {}
+pub(crate) trait WriteTransport: AsyncWrite + Send + Unpin {}
+impl<T: AsyncWrite + Send + Unpin> WriteTransport for T {}
+
+impl Transport for tokio::net::UnixStream {
+    fn into_split(self: Box<Self>) -> (Box<dyn ReadTransport>, Box<dyn WriteTransport>) {
+        let (reader, writer) = tokio::net::UnixStream::into_split(*self);
+        (Box::new(reader), Box::new(writer))
+    }
+
+    fn raw_fd(&self) -> Option<std::os::fd::RawFd> {
+        Some(std::os::fd::AsRawFd::as_raw_fd(self))
+    }
+
+    fn into_fd(self: Box<Self>) -> BoxliteResult<OwnedFd> {
+        // Deregisters from the reactor; the caller owns the descriptor after.
+        (*self)
+            .into_std()
+            .map(OwnedFd::from)
+            .map_err(|error| BoxliteError::Network(format!("detach tunnel descriptor: {error}")))
+    }
+}
+
+#[cfg(feature = "rest")]
+impl Transport for tokio::io::DuplexStream {
+    fn into_split(self: Box<Self>) -> (Box<dyn ReadTransport>, Box<dyn WriteTransport>) {
+        // No native split on an in-memory pipe, so this one pays the mutex.
+        let (reader, writer) = tokio::io::split(*self);
+        (Box::new(reader), Box::new(writer))
+    }
+
+    fn raw_fd(&self) -> Option<std::os::fd::RawFd> {
+        // In-memory pipe: there is no descriptor.
+        None
+    }
+
+    fn into_fd(self: Box<Self>) -> BoxliteResult<OwnedFd> {
+        Err(BoxliteError::Unsupported(
+            "a remotely served tunnel connection has no local descriptor".into(),
+        ))
+    }
+}
+
+/// A bidirectional byte stream to a service inside a box.
+///
+/// Opaque on purpose: the transport behind it is an implementation detail, so
+/// swapping one never breaks callers.
+pub struct BoxConnection {
+    inner: Box<dyn Transport>,
+}
+
+/// Read half of a [`BoxConnection`].
+pub struct BoxReader {
+    inner: Box<dyn ReadTransport>,
+}
+
+/// Write half of a [`BoxConnection`].
+pub struct BoxWriter {
+    inner: Box<dyn WriteTransport>,
+}
+
+impl BoxConnection {
+    pub(crate) fn new<T: Transport + 'static>(transport: T) -> Self {
+        Self {
+            inner: Box::new(transport),
+        }
+    }
+
+    /// Split into halves that can read and write concurrently.
+    ///
+    /// Bidirectional traffic needs this: holding one lock across a large write
+    /// would stall reads for its whole duration.
+    pub fn into_split(self) -> (BoxReader, BoxWriter) {
+        let (reader, writer) = self.inner.into_split();
+        (BoxReader { inner: reader }, BoxWriter { inner: writer })
+    }
+
+    /// The descriptor behind this connection, borrowed.
+    ///
+    /// `None` for a remotely served connection, which is an in-memory pipe
+    /// rather than a socket. The connection retains ownership and closes it,
+    /// matching `socket.fileno()`.
+    pub fn raw_fd(&self) -> Option<std::os::fd::RawFd> {
+        self.inner.raw_fd()
+    }
+
+    /// Consume the connection and take ownership of its descriptor.
+    ///
+    /// The caller must close the result. Errors for a remotely served
+    /// connection, which has no descriptor to give.
+    pub fn into_fd(self) -> BoxliteResult<OwnedFd> {
+        self.inner.into_fd()
+    }
+}
+
+/// Treat an already-disconnected peer as a completed half-close.
+///
+/// The normal end of a one-shot tunnel is the peer hanging up first, and macOS
+/// reports `ENOTCONN` for `shutdown(2)` on an AF_UNIX socket whose peer is gone
+/// where Linux reports success. Every other error still propagates.
+///
+/// This lives at the `poll_shutdown` layer so *every* route reaches it —
+/// `BoxWriter::shutdown`, `AsyncWriteExt::shutdown` on either public type, and
+/// `copy_bidirectional` — rather than only the paths the SDKs happen to use.
+fn tolerate_disconnected_peer(poll: Poll<std::io::Result<()>>) -> Poll<std::io::Result<()>> {
+    match poll {
+        Poll::Ready(Err(error)) if error.kind() == ErrorKind::NotConnected => Poll::Ready(Ok(())),
+        other => other,
+    }
+}
+
+impl BoxWriter {
+    /// Half-close the write side, signalling EOF to the peer.
+    ///
+    /// Errors are mapped into [`BoxliteError`]; the disconnected-peer tolerance
+    /// itself comes from this type's [`AsyncWrite`] impl.
+    pub async fn shutdown(&mut self) -> BoxliteResult<()> {
+        AsyncWriteExt::shutdown(self)
+            .await
+            .map_err(|error| BoxliteError::Network(format!("shut down tunnel writer: {error}")))
+    }
+}
+
+impl AsyncRead for BoxConnection {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.inner).poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for BoxConnection {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        Pin::new(&mut self.inner).poll_write(cx, buf)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        tolerate_disconnected_peer(Pin::new(&mut self.inner).poll_shutdown(cx))
+    }
+}
+
+impl AsyncRead for BoxReader {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.inner).poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for BoxWriter {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        Pin::new(&mut self.inner).poll_write(cx, buf)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        tolerate_disconnected_peer(Pin::new(&mut self.inner).poll_shutdown(cx))
+    }
+}
 
 /// The transport a [`BoxTunnel`] was built over — fixed at construction,
 /// never transitions. Not a state machine.
@@ -31,15 +231,15 @@ enum TunnelTransport {
     #[cfg(feature = "rest")]
     Remote {
         uri: String,
-        connection: Box<dyn BoxConnection>,
+        connection: BoxConnection,
     },
 }
 
 /// A one-shot box service tunnel target.
 ///
-/// [`endpoint`](Self::endpoint) lends the descriptor; [`connect`](Self::connect)
-/// consumes the tunnel, so a second connect is a move error at compile time
-/// rather than a runtime state check.
+/// [`uri`](Self::uri) reports where a remote tunnel can be reached;
+/// [`connect`](Self::connect) consumes the tunnel, so a second connect is a
+/// move error at compile time rather than a runtime state check.
 pub struct BoxTunnel {
     transport: TunnelTransport,
 }
@@ -54,24 +254,27 @@ impl BoxTunnel {
     }
 
     #[cfg(feature = "rest")]
-    pub(crate) fn remote<C>(uri: String, connection: C) -> Self
+    pub(crate) fn remote<T>(uri: String, connection: T) -> Self
     where
-        C: BoxConnection + 'static,
+        T: Transport + 'static,
     {
         Self {
             transport: TunnelTransport::Remote {
                 uri,
-                connection: Box::new(connection),
+                connection: BoxConnection::new(connection),
             },
         }
     }
 
-    /// Describe the prepared tunnel without opening another connection.
-    pub fn endpoint(&self) -> BoxEndpoint {
+    /// Where clients can reach a remote box service.
+    ///
+    /// `None` for a local tunnel: its descriptor *is* the connection, so there
+    /// is no address to hand out — use [`connect`](Self::connect) instead.
+    pub fn uri(&self) -> Option<&str> {
         match &self.transport {
-            TunnelTransport::Local(fd) => BoxEndpoint::FileDescriptor(fd.as_raw_fd()),
+            TunnelTransport::Local(_) => None,
             #[cfg(feature = "rest")]
-            TunnelTransport::Remote { uri, .. } => BoxEndpoint::Uri(uri.clone()),
+            TunnelTransport::Remote { uri, .. } => Some(uri),
         }
     }
 
@@ -79,7 +282,7 @@ impl BoxTunnel {
     ///
     /// Must run inside a tokio runtime — the local descriptor is registered
     /// with the reactor here.
-    pub fn connect(self) -> BoxliteResult<Box<dyn BoxConnection>> {
+    pub fn connect(self) -> BoxliteResult<BoxConnection> {
         match self.transport {
             TunnelTransport::Local(fd) => {
                 let stream = std::os::unix::net::UnixStream::from(fd);
@@ -87,7 +290,7 @@ impl BoxTunnel {
                     BoxliteError::Network(format!("configure tunnel descriptor: {error}"))
                 })?;
                 tokio::net::UnixStream::from_std(stream)
-                    .map(|stream| Box::new(stream) as Box<dyn BoxConnection>)
+                    .map(BoxConnection::new)
                     .map_err(|error| {
                         BoxliteError::Network(format!("open tunnel descriptor: {error}"))
                     })
@@ -111,7 +314,7 @@ impl NetworkHandle {
         Self { network_backend }
     }
 
-    /// Establish a one-shot tunnel and return its prepared endpoint and connection.
+    /// Establish a one-shot tunnel to a service port inside the box.
     pub async fn tunnel(&self, target: SocketAddr) -> BoxliteResult<BoxTunnel> {
         self.network_backend.tunnel(target).await
     }
@@ -119,12 +322,14 @@ impl NetworkHandle {
 
 #[cfg(test)]
 mod tests {
+    use std::os::fd::AsRawFd;
+
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::UnixStream;
 
     use super::*;
 
-    // Double-connect and endpoint-after-connect need no runtime tests: connect()
+    // Double-connect and uri()-after-connect need no runtime tests: connect()
     // takes `self`, so both are move errors at compile time.
 
     #[cfg(feature = "rest")]
@@ -133,10 +338,7 @@ mod tests {
         let (stream, mut peer) = UnixStream::pair().unwrap();
         let tunnel = BoxTunnel::remote("https://3000-box.proxy.example.test".to_string(), stream);
 
-        assert_eq!(
-            tunnel.endpoint(),
-            BoxEndpoint::Uri("https://3000-box.proxy.example.test".to_string())
-        );
+        assert_eq!(tunnel.uri(), Some("https://3000-box.proxy.example.test"));
 
         let mut connection = tunnel.connect().unwrap();
         peer.write_all(b"one").await.unwrap();
@@ -145,21 +347,169 @@ mod tests {
         assert_eq!(&response, b"one");
     }
 
+    /// The tolerance must sit on the trait impl, not only on the inherent
+    /// method: a Rust caller holding the public connection can reach
+    /// `poll_shutdown` through `AsyncWriteExt` or `copy_bidirectional` without
+    /// ever touching `BoxWriter::shutdown`.
     #[tokio::test]
-    async fn local_tunnel_hands_back_the_transport_fd() {
+    async fn async_write_shutdown_also_tolerates_a_hung_up_peer() {
+        for split in [false, true] {
+            let (stream, peer) = UnixStream::pair().unwrap();
+            let fd = OwnedFd::from(stream.into_std().unwrap());
+            let connection = BoxTunnel::local(fd).connect().unwrap();
+            drop(peer);
+
+            let result = if split {
+                let (_reader, mut writer) = connection.into_split();
+                AsyncWriteExt::shutdown(&mut writer).await
+            } else {
+                let mut connection = connection;
+                AsyncWriteExt::shutdown(&mut connection).await
+            };
+            assert!(result.is_ok(), "split={split} should tolerate ENOTCONN");
+        }
+    }
+
+    /// The transport used for real remote tunnels — an in-memory duplex pipe —
+    /// reports no descriptor and refuses to surrender one.
+    #[cfg(feature = "rest")]
+    #[tokio::test]
+    async fn duplex_backed_connection_reports_and_refuses_a_descriptor() {
+        let (local, _peer) = tokio::io::duplex(64);
+        let connection = BoxConnection::new(local);
+
+        assert_eq!(connection.raw_fd(), None);
+        let error = connection
+            .into_fd()
+            .expect_err("an in-memory pipe has no descriptor");
+        assert!(
+            error.to_string().contains("no local descriptor"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn local_tunnel_has_no_uri_and_connects_over_its_own_fd() {
         let (stream, mut peer) = UnixStream::pair().unwrap();
         let fd = OwnedFd::from(stream.into_std().unwrap());
-        let transport_fd = fd.as_raw_fd();
         let tunnel = BoxTunnel::local(fd);
 
-        // Zero-copy contract: the endpoint IS the transport fd, not a bridge.
-        assert_eq!(tunnel.endpoint(), BoxEndpoint::FileDescriptor(transport_fd));
-        assert_eq!(tunnel.endpoint(), BoxEndpoint::FileDescriptor(transport_fd));
+        // A local descriptor is a live connection, not an address.
+        assert_eq!(tunnel.uri(), None);
 
         let mut connection = tunnel.connect().unwrap();
         peer.write_all(b"one").await.unwrap();
         let mut response = [0; 3];
         connection.read_exact(&mut response).await.unwrap();
         assert_eq!(&response, b"one");
+    }
+
+    /// Zero-copy contract: the descriptor the connection surrenders IS the
+    /// original transport, not a bridged copy — so bytes written to the peer
+    /// arrive on it with no copy task in between.
+    #[tokio::test]
+    async fn connection_surrenders_the_original_transport_fd() {
+        let (stream, mut peer) = UnixStream::pair().unwrap();
+        let fd = OwnedFd::from(stream.into_std().unwrap());
+        let transport_fd = fd.as_raw_fd();
+
+        let connection = BoxTunnel::local(fd).connect().unwrap();
+        // Borrowing reports the same descriptor without consuming anything.
+        assert_eq!(connection.raw_fd(), Some(transport_fd));
+
+        let taken = connection.into_fd().expect("local yields its fd");
+        assert_eq!(taken.as_raw_fd(), transport_fd);
+
+        peer.write_all(b"one").await.unwrap();
+        let recovered = std::os::unix::net::UnixStream::from(taken);
+        recovered.set_nonblocking(true).unwrap();
+        let mut recovered = UnixStream::from_std(recovered).unwrap();
+        let mut response = [0; 3];
+        recovered.read_exact(&mut response).await.unwrap();
+        assert_eq!(&response, b"one");
+    }
+
+    /// A writer whose `poll_shutdown` fails with a chosen kind.
+    ///
+    /// The real-socket behaviour this guards is platform-specific — macOS
+    /// reports `ENOTCONN`, Linux reports success — so a `UnixStream` test would
+    /// pass on Linux with or without the guard and prove nothing there. Driving
+    /// `poll_shutdown` directly pins the branch on every platform.
+    struct FailingShutdown(ErrorKind);
+
+    impl AsyncWrite for FailingShutdown {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            _: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<std::io::Result<usize>> {
+            Poll::Ready(Ok(buf.len()))
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_shutdown(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Err(std::io::Error::new(self.0, "injected")))
+        }
+    }
+
+    fn writer_failing_with(kind: ErrorKind) -> BoxWriter {
+        BoxWriter {
+            inner: Box::new(FailingShutdown(kind)),
+        }
+    }
+
+    /// The #1110 fix: a peer that already hung up ends a one-shot tunnel
+    /// normally, so teardown reports success.
+    #[tokio::test]
+    async fn shutdown_treats_an_already_disconnected_peer_as_success() {
+        let mut writer = writer_failing_with(ErrorKind::NotConnected);
+        assert!(writer.shutdown().await.is_ok());
+    }
+
+    /// The guard must stay narrow — it is not a blanket swallow.
+    #[tokio::test]
+    async fn shutdown_still_reports_every_other_failure() {
+        for kind in [
+            ErrorKind::BrokenPipe,
+            ErrorKind::ConnectionReset,
+            ErrorKind::PermissionDenied,
+        ] {
+            let error = writer_failing_with(kind)
+                .shutdown()
+                .await
+                .expect_err("only NotConnected is tolerated");
+            assert!(
+                error.to_string().contains("shut down tunnel writer"),
+                "{kind:?} should surface as a network error, got: {error}"
+            );
+        }
+    }
+
+    /// Bytes still reach the peer through the split halves, and a real
+    /// close after the peer is gone does not error.
+    #[tokio::test]
+    async fn split_halves_carry_traffic_and_close_after_peer_hangs_up() {
+        let (stream, mut peer) = UnixStream::pair().unwrap();
+        let fd = OwnedFd::from(stream.into_std().unwrap());
+        let (mut reader, mut writer) = BoxTunnel::local(fd).connect().unwrap().into_split();
+
+        writer.write_all(b"ping").await.unwrap();
+        let mut got = [0; 4];
+        peer.read_exact(&mut got).await.unwrap();
+        assert_eq!(&got, b"ping");
+
+        peer.write_all(b"pong").await.unwrap();
+        let mut back = [0; 4];
+        reader.read_exact(&mut back).await.unwrap();
+        assert_eq!(&back, b"pong");
+
+        drop(peer);
+        writer
+            .shutdown()
+            .await
+            .expect("teardown after hangup is ok");
     }
 }

--- a/src/boxlite/src/litebox/network.rs
+++ b/src/boxlite/src/litebox/network.rs
@@ -441,10 +441,41 @@ mod tests {
         }
     }
 
+    impl AsyncRead for FailingShutdown {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            _: &mut Context<'_>,
+            _: &mut ReadBuf<'_>,
+        ) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Ok(())) // immediate EOF; these tests only drive shutdown
+        }
+    }
+
+    impl Transport for FailingShutdown {
+        fn into_split(self: Box<Self>) -> (Box<dyn ReadTransport>, Box<dyn WriteTransport>) {
+            let (reader, writer) = tokio::io::split(*self);
+            (Box::new(reader), Box::new(writer))
+        }
+
+        fn raw_fd(&self) -> Option<std::os::fd::RawFd> {
+            None
+        }
+
+        fn into_fd(self: Box<Self>) -> BoxliteResult<OwnedFd> {
+            Err(BoxliteError::Unsupported("test double".into()))
+        }
+    }
+
     fn writer_failing_with(kind: ErrorKind) -> BoxWriter {
         BoxWriter {
             inner: Box::new(FailingShutdown(kind)),
         }
+    }
+
+    /// The unsplit type has its own `poll_shutdown`, so it needs its own
+    /// injection: the real-socket test above cannot pin it on Linux.
+    fn connection_failing_with(kind: ErrorKind) -> BoxConnection {
+        BoxConnection::new(FailingShutdown(kind))
     }
 
     /// The #1110 fix: a peer that already hung up ends a one-shot tunnel
@@ -453,6 +484,9 @@ mod tests {
     async fn shutdown_treats_an_already_disconnected_peer_as_success() {
         let mut writer = writer_failing_with(ErrorKind::NotConnected);
         assert!(writer.shutdown().await.is_ok());
+
+        let mut connection = connection_failing_with(ErrorKind::NotConnected);
+        assert!(AsyncWriteExt::shutdown(&mut connection).await.is_ok());
     }
 
     /// The guard must stay narrow — it is not a blanket swallow.
@@ -471,6 +505,11 @@ mod tests {
                 error.to_string().contains("shut down tunnel writer"),
                 "{kind:?} should surface as a network error, got: {error}"
             );
+
+            let error = AsyncWriteExt::shutdown(&mut connection_failing_with(kind))
+                .await
+                .expect_err("only NotConnected is tolerated");
+            assert_eq!(error.kind(), kind, "the unsplit type must stay as narrow");
         }
     }
 

--- a/src/boxlite/src/rest/client.rs
+++ b/src/boxlite/src/rest/client.rs
@@ -358,7 +358,7 @@ impl ApiClient {
     pub(crate) async fn connect_box_network_tunnel(
         &self,
         uri: &str,
-    ) -> BoxliteResult<tokio::io::DuplexStream> {
+    ) -> BoxliteResult<hyper_util::rt::TokioIo<hyper::upgrade::Upgraded>> {
         use http_body_util::Empty;
         use hyper::{Method, Request, Uri};
         use hyper_util::rt::TokioIo;
@@ -399,12 +399,11 @@ impl ApiClient {
         let upgraded = hyper::upgrade::on(response)
             .await
             .map_err(|e| BoxliteError::Network(format!("CONNECT upgrade failed: {e}")))?;
-        let (local, mut pump_end) = tokio::io::duplex(64 * 1024);
-        let mut remote = TokioIo::new(upgraded);
-        tokio::spawn(async move {
-            let _ = tokio::io::copy_bidirectional(&mut pump_end, &mut remote).await;
-        });
-        Ok(local)
+        // The upgraded stream is already AsyncRead + AsyncWrite, so hand it
+        // over directly. Bridging it through `tokio::io::duplex` would only buy
+        // a concrete type we already have, at the cost of a buffer, a pump task
+        // and a copy of every byte in both directions.
+        Ok(TokioIo::new(upgraded))
     }
 
     /// Prepare a box service tunnel and return its public descriptor.
@@ -710,6 +709,19 @@ mod tests {
         let mut response = [0; 4];
         stream.read_exact(&mut response).await.unwrap();
         assert_eq!(&response, b"ping");
+
+        // A remotely served connection has no descriptor to lend or surrender:
+        // hyper owns the socket and may hold already-read tunnel bytes.
+        let connection = crate::litebox::BoxConnection::new(stream);
+        assert_eq!(connection.raw_fd(), None);
+        let error = connection
+            .into_fd()
+            .expect_err("an upgraded remote stream has no descriptor");
+        assert!(
+            error.to_string().contains("no local descriptor"),
+            "unexpected error: {error}"
+        );
+
         server.await.unwrap();
     }
 

--- a/src/boxlite/src/runtime/backend.rs
+++ b/src/boxlite/src/runtime/backend.rs
@@ -142,7 +142,7 @@ pub(crate) trait BoxBackend: Send + Sync {
 /// network data-plane capabilities directly.
 #[async_trait]
 pub(crate) trait BoxNetworkBackend: Send + Sync {
-    /// Establish a one-shot tunnel and return its prepared endpoint and connection.
+    /// Establish a one-shot tunnel to a service port inside the box.
     async fn tunnel(&self, target: SocketAddr) -> BoxliteResult<BoxTunnel>;
 }
 

--- a/src/cli/src/commands/network/tunnel.rs
+++ b/src/cli/src/commands/network/tunnel.rs
@@ -3,7 +3,6 @@
 use std::net::SocketAddr;
 
 use anyhow::{Context, Result, anyhow};
-use boxlite::litebox::BoxEndpoint;
 use clap::Args;
 
 use crate::cli::GlobalFlags;
@@ -33,14 +32,9 @@ pub async fn execute(args: TunnelArgs, global: &GlobalFlags) -> Result<()> {
         .network()
         .tunnel(SocketAddr::new(guest_ip, args.port))
         .await?;
-    let url = match tunnel.endpoint() {
-        BoxEndpoint::Uri(uri) => uri,
-        BoxEndpoint::FileDescriptor(_) => {
-            return Err(anyhow!(
-                "boxlite network tunnel requires a remote REST profile (--url or --profile)"
-            ));
-        }
-    };
+    let url = tunnel.uri().ok_or_else(|| {
+        anyhow!("local boxes have no public URL; point boxlite at a remote service with --url or --profile")
+    })?;
     println!("{url}");
     Ok(())
 }


### PR DESCRIPTION
Closing a box tunnel on macOS raised `Socket is not connected (os error 57)` whenever the
peer had already hung up — which is the normal end of a one-shot tunnel. `shutdown(2)` on
an AF_UNIX socket whose peer is gone returns `ENOTCONN` on macOS and `Ok` on Linux, and the
SDKs surfaced that divergence straight to the caller.

Owning half-close inside the core fixes it once for every SDK. That is also what made the
connection type worth redesigning: `BoxConnection` was a blanket-impl marker trait, so the
core had no type of its own on which to hang the guard.

Fixes #1110

## Call graph

```
Before

python: await tunnel.connect(); await connection.close()
└─ PyBoxTunnel.connect (pyo3 · sdks/python/src/network.rs:79)
   └─ NetworkHandle::tunnel (SocketAddr · src/boxlite/src/litebox/network.rs:115)
      └─ BoxNetworkBackend::tunnel (trait · src/boxlite/src/runtime/backend.rs:146)
         └─ RestBackend
            ├─ prepare_box_tunnel (uri · src/boxlite/src/rest/client.rs:411)
            └─ connect_box_network_tunnel (DuplexStream · src/boxlite/src/rest/client.rs:358)
               ├─ hyper CONNECT → Upgraded
               └─ duplex(64 KiB) + copy_bidirectional   ← relay #1, 64 KiB per connection
   → BoxTunnel

   BoxTunnel::endpoint (BoxEndpoint · src/boxlite/src/litebox/network.rs:70)
      ← an address enum carrying a live descriptor (Uri | FileDescriptor);
        every SDK matched both arms and re-derived what to do with an fd
   BoxTunnel::connect (Box<dyn BoxConnection> · src/boxlite/src/litebox/network.rs:82)
      ← blanket impl over AsyncRead+AsyncWrite, so the core owned no behaviour
        and had nowhere to attach a shutdown policy

   connection.close (pyo3 · sdks/python/src/network.rs:150)
   └─ AsyncWriteExt::shutdown (tokio · sdks/python/src/network.rs:156)   ← BUG: this calls
      UnixStream::poll_shutdown → shutdown(2) directly, and on macOS that returns ENOTCONN
      once the peer is gone; it escapes as "network error: shut down tunnel writer: Socket
      is not connected (os error 57)"

c: boxlite_tunnel_connect (int fd · sdks/c/src/network.rs:244)
   ├─ local  → endpoint() → try_clone_to_owned()   dup(2), then drop the original
   └─ remote → connect() → connection_fd (OwnedFd · sdks/c/src/network.rs:20)
               └─ UnixStream::pair + copy_bidirectional   ← relay #2, stacked on #1
                  `let _ =` discarded every relay failure silently

After

python: await tunnel.connect(); await connection.close()
└─ PyBoxTunnel.connect (pyo3 · sdks/python/src/network.rs:77)
   └─ NetworkHandle::tunnel (SocketAddr · src/boxlite/src/litebox/network.rs:322)
      └─ BoxNetworkBackend::tunnel (trait · src/boxlite/src/runtime/backend.rs:146)
         └─ RestBackend
            ├─ prepare_box_tunnel (uri · src/boxlite/src/rest/client.rs:410)
            └─ connect_box_network_tunnel (TokioIo<Upgraded> · src/boxlite/src/rest/client.rs:358)
               └─ hyper CONNECT → returned as-is; relay #1 deleted
   → BoxTunnel

   BoxTunnel::uri (Option<&str> · src/boxlite/src/litebox/network.rs:277)
      → address only; None means "local, already a live connection", so no SDK
        has to know a descriptor can hide inside an address
   BoxTunnel::connect (BoxConnection · src/boxlite/src/litebox/network.rs:289)
      └─ pub struct BoxConnection (src/boxlite/src/litebox/network.rs:97)
         over pub(crate) trait Transport (src/boxlite/src/litebox/network.rs:22)
      → opaque public type over a sealed private trait, so the core owns the behaviour

   connection.close (pyo3 · sdks/python/src/network.rs:147)
   └─ BoxWriter::shutdown (src/boxlite/src/litebox/network.rs:166)
      └─ BoxWriter::poll_shutdown (src/boxlite/src/litebox/network.rs:224)
         └─ tolerate_disconnected_peer (src/boxlite/src/litebox/network.rs:154)   FIX
            ├─ ErrorKind::NotConnected → Ok(())
            └─ every other error       → propagates unchanged

c: boxlite_tunnel_connect (int fd · sdks/c/src/network.rs:219)
   └─ connect() → match connection.raw_fd()
      ├─ Some → into_fd()       moves the descriptor; the dup is gone
      └─ None → connection_fd (OwnedFd · sdks/c/src/network.rs:18)
                └─ the one remaining relay, remote only
                   tracing::debug! on failure instead of `let _ =`
```

## Behaviour

`BoxTunnel::uri()` replaces `endpoint()`, and `BoxEndpoint` is deleted. A local tunnel now
reports `None` instead of a descriptor variant — reach it with `connect()`.

`shutdown` treats only `ENOTCONN` as success; every other error still propagates, which
`shutdown_still_reports_every_other_failure` covers.

On the remote path one of two stacked relays is gone — the core hands hyper's upgraded
stream to the SDK directly. The C SDK still bridges to a socket pair because its API
returns an `int` and TLS state cannot cross a descriptor. Local C tunnels no longer dup.

## Verification

Both reproducers from #1110 pass. Two-side verified by hand: with `tolerate_disconnected_peer`
removed, closing the tunnel fails with `RuntimeError: network error: shut down tunnel
writer: Socket is not connected (os error 57)`; restored, it passes. The guard's boundary is
pinned by two unit tests that do run in the default matrix —
`shutdown_treats_an_already_disconnected_peer_as_success` and
`shutdown_still_reports_every_other_failure` — the second asserting that `BrokenPipe`,
`ConnectionReset` and `PermissionDenied` still propagate, so the tolerance cannot widen
into a blanket swallow.

One coverage gap worth knowing, pre-existing rather than introduced here: `make test:unit:rust`
runs `-p boxlite --no-default-features --lib`, and `rest` is not a default feature, so the
`rest`-gated half of this change type-checks but never executes — `impl Transport for
TokioIo<Upgraded>`, `remote_tunnel_exposes_uri_and_yields_its_connection`, and the
`raw_fd()`/`into_fd()` assertions in `rest/client.rs`. The cloud tunnel e2e skips
without credentials. `make lint`
runs clippy with `--all-features` over that path, but no target runs it, and dropping the
duplex pump lands squarely on it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a consistent `uri()` API across C, Go, Node.js, Python, and Rust SDKs for retrieving remote tunnel URLs.
  * Local tunnels now report no public URI while remaining accessible through connection APIs.
  * Added connection splitting, file-descriptor access, and writer shutdown support where applicable.

* **Bug Fixes**
  * Improved tunnel connection and shutdown handling, including graceful peer disconnects and clearer errors when no public URI is available.

* **Documentation**
  * Updated SDK references, examples, and tests to reflect the new tunnel URI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->