### PR TITLE
feat(githooks): install the gate from make setup, drop install.sh

### DIFF
--- a/.agents/hooks/preflight-commit-push.sh
+++ b/.agents/hooks/preflight-commit-push.sh
@@ -67,7 +67,7 @@ project_dir="${CLAUDE_PROJECT_DIR:-$repo_root}"
 audit_file="$project_dir/.agents/state/last-audit.json"
 handoff_file="$project_dir/.agents/state/last-audit-handoff.json"
 # Transition mirrors. Where core.hooksPath is configured absolute rather than the
-# relative value install.sh sets, one installed hook serves every worktree, so a
+# relative value `make setup` sets, one installed hook serves every worktree, so a
 # commit-msg from BEFORE this move can be the one that runs while this gate —
 # reached through the .claude/hooks symlink — is the one that writes. That hook
 # reads the legacy paths and cannot be taught the new ones, so this gate leaves

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -14,7 +14,7 @@ fi
 if [[ "$is_agent" == 1 ]]; then
   repo_root="$(git rev-parse --show-toplevel)"
   # Same reason as resolve_gate in pre-commit/pre-push: where core.hooksPath is
-  # configured absolute rather than the relative value install.sh sets, this one
+  # configured absolute rather than the relative value `make setup` sets, this one
   # hook can run for worktrees on either side of the marker move. Take whichever
   # location the gate that just ran actually wrote to. Absent from both still
   # means no audit, which still blocks.

--- a/.githooks/githooks.test.sh
+++ b/.githooks/githooks.test.sh
@@ -701,7 +701,7 @@ rm -rf "$R"
 echo
 echo "## transition compat: hooks and trees on either side of the .agents move"
 # Where core.hooksPath is configured absolute rather than the relative value
-# install.sh sets, ONE installed hook runs for every worktree whatever commit it
+# `make setup` sets, ONE installed hook runs for every worktree whatever commit it
 # sits on. Both directions must keep working,
 # and neither may ever run unguarded.
 COMPAT="$(mktemp -d)"
@@ -759,6 +759,130 @@ for legacy in .claude/.last-audit.json .claude/.last-audit-handoff.json \
   check_eq "legacy mirror $legacy stays gitignored (tree hash must not move)" "$r" "yes"
 done
 rm -rf "$COMPAT"
+
+echo
+echo "## installer: make setup points git at this layer"
+# The hooks above only run once core.hooksPath names .githooks. Nothing in the
+# repo can ship that — it is per-clone config, not content — so `make setup` sets
+# it, and this asserts the one line that arms everything else in this file.
+#
+# NOT wrapped in a subshell: check_eq increments pass/fail, and a subshell would
+# discard both, leaving these cases unable to fail the suite.
+# SCRIPT_DIR must be EMPTY, not preset: setup-common.sh only sources common.sh
+# when SCRIPT_DIR is unset-or-empty, and common.sh is where command_exists lives.
+# Presetting it left command_exists undefined, so `! command_exists prek` was
+# always true, prek was never reached, and the cases that depend on it silently
+# graded a path that had not run. The assertion below fails first and by name.
+# shellcheck disable=SC2034  # consumed by setup-common.sh
+SCRIPT_DIR=""
+# shellcheck source=/dev/null
+source "$REPO_ROOT/scripts/setup/setup-common.sh" >/dev/null 2>&1
+check_eq "the installer's own dependencies are loaded (else the cases below are inert)" \
+  "$(type -t command_exists)" "function"
+
+install_probe() {  # dir [PATH override] -> the configured value, or empty
+  # PATH is passed as a variable, not via `env`: install_git_hooks_best_effort is
+  # a shell function, and `env` cannot invoke one.
+  local dir="$1" probe_path="${2:-$PATH}"
+  # Belt to the fixture assertion's braces: PROJECT_ROOT="" falls back to
+  # $SCRIPT_DIR/.. inside the installer — the developer's real clone. The section
+  # guard above is what actually covers every case; this catches a future caller
+  # that passes an unset variable.
+  [ -n "$dir" ] || { printf 'install_probe: empty target refused\n' >&2; return 1; }
+  ( PROJECT_ROOT="$dir" CI="" PATH="$probe_path" install_git_hooks_best_effort ) >/dev/null 2>&1
+  git -C "$dir" config --local core.hooksPath
+}
+
+INST="$(mktemp -d)"
+# Assert the fixture before anything can use it, because an empty INST is not
+# inert: `git -C ""` is a NO-OP -C, not an error, so every git call below silently
+# targets the shell's cwd — the developer's clone. Measured consequences of that,
+# not hypothesised: local user.name/user.email written into the shared .git/config,
+# a real commit landed on their current branch, and core.hooksPath unset, all while
+# the suite printed green. The PROJECT_ROOT="" -> $SCRIPT_DIR/.. fallback inside the
+# installer is a second route to the same clone.
+# At the fixture, not at each call site: the git calls immediately below run before
+# any installer call, and two cases invoke the installer directly.
+case "$INST" in
+  /tmp/*|/private/var/folders/*|/var/folders/*) ;;
+  *) printf 'installer fixture refused: INST=[%s]\n' "$INST" >&2; exit 1 ;;
+esac
+git -C "$INST" init -q
+git -C "$INST" config user.email t@t.test
+git -C "$INST" config user.name tester
+mkdir -p "$INST/.githooks"
+printf 'repos: []\n' > "$INST/.pre-commit-config.yaml"
+git -C "$INST" add -A
+git -C "$INST" commit -qm base
+
+# Relative, so each worktree resolves it to its own checkout. An absolute value
+# would make one installed copy serve every worktree whatever commit it sits on —
+# the situation resolve_gate() in pre-commit/pre-push exists to survive.
+check_eq "make setup sets core.hooksPath to a relative .githooks" \
+  "$(install_probe "$INST")" ".githooks"
+
+# A linked worktree's .git is a FILE, not a directory. Testing for a directory
+# named .git skipped installation in every worktree; ask git instead.
+git -C "$INST" worktree add -q "$INST-wt" -b installer-wt
+mkdir -p "$INST-wt/.githooks"
+printf 'repos: []\n' > "$INST-wt/.pre-commit-config.yaml"
+git -C "$INST" config --unset core.hooksPath
+wt_dot_git="dir"; [ -f "$INST-wt/.git" ] && wt_dot_git="file"
+check_eq "a linked worktree's .git is a file (the case the guard must survive)" \
+  "$wt_dot_git" "file"
+check_eq "make setup installs from inside a linked worktree" \
+  "$(install_probe "$INST-wt")" ".githooks"
+
+# Order is load-bearing: prek refuses to install while core.hooksPath is set, and
+# the gate chains into the hooks prek writes. Setting the gate first left
+# .git/hooks empty, so pre-commit chained into a file that did not exist and
+# lint-fix silently stopped running. Assert BOTH ends survive one run.
+git -C "$INST" config --unset core.hooksPath
+rm -f "$INST/.git/hooks/pre-commit" "$INST/.git/hooks/pre-push"
+prek_hooks_before="$(find "$INST/.git/hooks" -maxdepth 1 -type f ! -name '*.sample' 2>/dev/null | wc -l | tr -d ' ')"
+check_eq "fixture starts with no framework hooks" "$prek_hooks_before" "0"
+inst_gate="$(install_probe "$INST")"
+prek_hook_state="missing"; [ -f "$INST/.git/hooks/pre-commit" ] && prek_hook_state="present"
+check_eq "one run leaves BOTH the gate and the hooks it chains into" \
+  "$inst_gate:$prek_hook_state" ".githooks:present"
+
+# Re-running must not regress either end — the unset-then-reset is what makes it
+# idempotent, since prek would otherwise refuse on the second pass.
+inst_gate2="$(install_probe "$INST")"
+prek_hook_state2="missing"; [ -f "$INST/.git/hooks/pre-commit" ] && prek_hook_state2="present"
+check_eq "a second run is idempotent" \
+  "$inst_gate2:$prek_hook_state2" ".githooks:present"
+
+# The gate does not depend on prek, so it must still install where prek is absent.
+git -C "$INST" config --unset core.hooksPath
+check_eq "core.hooksPath is set even with prek unavailable" \
+  "$(install_probe "$INST" /usr/bin:/bin)" ".githooks"
+
+# A core.hooksPath in the user's GLOBAL config makes prek refuse just the same,
+# and clearing it is not ours to do — so the run has to name that case instead of
+# reporting a generic failure. GIT_CONFIG_GLOBAL redirects the global file for
+# this probe only; the real ~/.gitconfig is never read or written.
+git -C "$INST" config --unset core.hooksPath
+GLOBAL_CFG="$(mktemp)"
+printf '[core]\n\thooksPath = /nonexistent-global-hooks\n' > "$GLOBAL_CFG"
+global_warn="$( GIT_CONFIG_GLOBAL="$GLOBAL_CFG" PROJECT_ROOT="$INST" CI="" \
+                install_git_hooks_best_effort 2>&1 )"
+global_named=no
+case "$global_warn" in *"set globally to '/nonexistent-global-hooks'"*) global_named=yes ;; esac
+check_eq "a global core.hooksPath is diagnosed by name, not left generic" \
+  "$global_named" "yes"
+check_eq "the user's global config is never modified" \
+  "$(git config --file "$GLOBAL_CFG" core.hooksPath)" "/nonexistent-global-hooks"
+rm -f "$GLOBAL_CFG"
+
+# CI is deliberately exempt: runners carry no agent marker, so gating is moot and
+# a push there must not arm a watcher.
+git -C "$INST" config --unset core.hooksPath
+( PROJECT_ROOT="$INST" CI=true install_git_hooks_best_effort ) >/dev/null 2>&1
+check_eq "CI=true installs nothing" "$(git -C "$INST" config --local core.hooksPath)" ""
+
+git -C "$INST" worktree remove --force "$INST-wt"
+rm -rf "$INST"
 
 echo
 echo "RESULT: $pass passed, $fail failed"

--- a/.githooks/install.sh
+++ b/.githooks/install.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-# Point this clone's git hooks at .githooks/ — the agent-agnostic gate layer.
-# Per-clone config (run once per clone/worktree checkout):
-#   bash .githooks/install.sh
-# The framework-managed hooks in .git/hooks (prek fmt/lint, test matrix) keep
-# running: .githooks/* chain to them after the gate.
-set -euo pipefail
-git config core.hooksPath .githooks
-echo "core.hooksPath -> .githooks (agent-agnostic gate active; framework hooks chained)"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -2,8 +2,8 @@
 # Universal (agent-agnostic) commit gate: enforces the same audited-dossier
 # contract as .agents/hooks/preflight-commit-push.sh, but from git's own hook
 # interface — it fires for ANY process that runs `git commit`, whichever coding
-# agent drives it, including agents with no hook system of their own. Install:
-# .githooks/install.sh (sets core.hooksPath). The PreToolUse gate detects the
+# agent drives it, including agents with no hook system of their own. Installed
+# by `make setup` (sets core.hooksPath). The PreToolUse gate detects the
 # installation and delegates, so the audit artifact keeps exactly one consumer.
 #
 # Humans are not gated: enforcement binds only when a harness marker is present
@@ -27,7 +27,7 @@ is_agent=0
 repo_root="$(git rev-parse --show-toplevel)"
 
 # Resolve the delegated gate. A worktree checked out at a pre-migration commit
-# has no .agents/hooks/, yet it can still be THIS hook that runs. install.sh
+# has no .agents/hooks/, yet it can still be THIS hook that runs. `make setup`
 # sets core.hooksPath RELATIVE, where each worktree uses its own copy and this
 # cannot happen; a clone configured with an ABSOLUTE path has one installed hook
 # serving every worktree, whatever commit each sits on, and then it can.

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -14,7 +14,7 @@ is_agent=0
 repo_root="$(git rev-parse --show-toplevel)"
 
 # Resolve the delegated gate. A worktree checked out at a pre-migration commit
-# has no .agents/hooks/, yet it can still be THIS hook that runs. install.sh
+# has no .agents/hooks/, yet it can still be THIS hook that runs. `make setup`
 # sets core.hooksPath RELATIVE, where each worktree uses its own copy and this
 # cannot happen; a clone configured with an ABSOLUTE path has one installed hook
 # serving every worktree, whatever commit each sits on, and then it can.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,8 +62,8 @@ Key test entry points:
 
 ### Watching CI and PR feedback
 
-Once the hooks are installed (`bash .githooks/install.sh` — once per clone or
-worktree), every `git push` arms a background watcher via
+Once the hooks are installed (`make setup`, once per clone),
+every `git push` arms a background watcher via
 [`.githooks/pre-push`](./.githooks/pre-push), so it
 runs the same for a human, Claude Code, Codex, or any other agent. It waits for
 the push to land, waits for a PR to appear (which covers a later `gh pr create` —

--- a/scripts/setup/setup-common.sh
+++ b/scripts/setup/setup-common.sh
@@ -525,29 +525,64 @@ install_git_hooks_best_effort() {
     fi
 
     local root_dir="${PROJECT_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
-    local git_dir="$root_dir/.git"
     local config_path="$root_dir/.pre-commit-config.yaml"
 
-    if [ ! -d "$git_dir" ]; then
-        print_warning ".git directory not found at $git_dir; skipping hook installation"
+    # Ask git, rather than testing for a directory named .git: in a linked
+    # worktree .git is a FILE pointing at the real gitdir, so the directory test
+    # returned early and installed nothing in any worktree.
+    if ! (cd "$root_dir" && git rev-parse --git-dir >/dev/null 2>&1); then
+        print_warning "not a git repository at $root_dir; skipping hook installation"
         return 0
     fi
+
+    # prek first, gate second, and the redirect cleared in between — the order is
+    # load-bearing. prek writes .git/hooks/{pre-commit,pre-push} and refuses
+    # outright while core.hooksPath is set ("Cowardly refusing to install hooks
+    # with core.hooksPath set"), while the gate CHAINS into the very files prek
+    # writes (.githooks/pre-commit -> --git-common-dir/hooks/pre-commit). Set the
+    # redirect first and prek installs nothing, so the gate chains into a file
+    # that does not exist and lint-fix and the test matrix silently stop running.
+    # Clearing up front also makes a re-run of `make setup` idempotent.
+    (cd "$root_dir" && git config --unset core.hooksPath) 2>/dev/null || true
 
     if [ ! -f "$config_path" ]; then
         print_warning ".pre-commit-config.yaml not found at $config_path; skipping hook installation"
-        return 0
-    fi
-
-    if ! command_exists prek; then
+    elif ! command_exists prek; then
         print_warning "prek not available; skipping hook installation"
-        return 0
+    else
+        # Local scope only — a user's global config is theirs. But prek refuses on
+        # a global core.hooksPath too, and would then fail with a generic message
+        # while the gate still reports success, so name that case exactly. Inside
+        # this branch, not above it: elsewhere prek was never going to run, and the
+        # warning would contradict the one already printed.
+        local global_hooks_path
+        global_hooks_path="$(git config --global core.hooksPath 2>/dev/null || true)"
+        if [ -n "$global_hooks_path" ]; then
+            print_warning "core.hooksPath is set globally to '$global_hooks_path'; prek cannot install while it is. Clear it with: git config --global --unset core.hooksPath"
+        fi
+        print_step "Installing pre-commit and pre-push hooks... "
+        if (cd "$root_dir" && prek install -t pre-commit -t pre-push --overwrite); then
+            print_success "installed"
+        else
+            print_warning "Hook installation failed; continuing setup"
+        fi
     fi
 
-    print_step "Installing pre-commit and pre-push hooks... "
-    if (cd "$root_dir" && prek install -t pre-commit -t pre-push --overwrite); then
-        print_success "installed"
+    # Point git at the tracked gate layer (.githooks/pre-commit, pre-push,
+    # commit-msg). This is what makes the agent audit gate fire for any process
+    # that runs git, not just for harnesses we have wired.
+    #
+    # Relative, not absolute: git resolves a relative core.hooksPath against each
+    # worktree's own root, so a linked worktree runs the hooks it contains rather
+    # than the main checkout's. Absolute would make one installed copy serve every
+    # worktree whatever commit it sits on.
+    #
+    # Reached whether or not prek ran: the branches above warn rather than return,
+    # because the gate does not depend on prek.
+    if (cd "$root_dir" && git config core.hooksPath .githooks); then
+        print_success "core.hooksPath -> .githooks (agent gate active)"
     else
-        print_warning "Hook installation failed; continuing setup"
+        print_warning "Could not set core.hooksPath; the agent gate will not run"
     fi
 }
 


### PR DESCRIPTION
## Summary

The agent gate only fires once `core.hooksPath` names `.githooks`, and that is
per-clone config — nothing in the repo can ship it, verify it, or notice when it
goes away. Installing it was a prose line in CONTRIBUTING pointing at a script
whose own documentation lived inside hooks that only run once it has been run.
`make setup` already installs git hooks, so it sets the redirect too, and
`.githooks/install.sh` is deleted.

## Call graph

Before
```
make setup                        (make/setup.mk:4)
  └─ run_dev_extras               (scripts/setup/setup-common.sh:581)
       └─ bootstrap_prek_and_hooks
            ├─ install_prek_best_effort       (:486)  — the prek binary
            └─ install_git_hooks_best_effort  (:521)
                 ├─ [ ! -d "$root_dir/.git" ] → return   — in a worktree .git is a
                 │                                          FILE, so this installed
                 │                                          nothing at all there
                 └─ prek install                          — .git/hooks only

  bash .githooks/install.sh       (.githooks/install.sh:8)   — separate, manual,
                                                                unenforced
```

After
```
make setup                        (make/setup.mk:4)
  └─ run_dev_extras               (scripts/setup/setup-common.sh:581)
       └─ bootstrap_prek_and_hooks
            ├─ install_prek_best_effort       (:486)  — the prek binary
            └─ install_git_hooks_best_effort  (:521)
                 ├─ git rev-parse --git-dir              — works in a worktree
                 ├─ git config --unset core.hooksPath    — prek refuses while set
                 ├─ prek install                         — .git/hooks
                 └─ git config core.hooksPath .githooks  — the gate, armed last
```

## Changes

- `core.hooksPath` is set by `make setup`; `.githooks/install.sh` is removed and
  its six references repointed.
- **Relative, not absolute.** Git resolves a relative `core.hooksPath` against
  each worktree's own root, so a linked worktree runs the hooks it contains.
  Absolute makes one installed copy serve every worktree at whatever commit it
  sits on — the situation `resolve_gate()` in `pre-commit`/`pre-push` exists to
  survive.
- **Order is load-bearing.** prek refuses outright while `core.hooksPath` is set
  (`Cowardly refusing to install hooks with core.hooksPath set`), and the gate
  *chains into* the hooks prek writes. Setting the gate first leaves `.git/hooks`
  empty, so `pre-commit` chains into a file that is not there and lint-fix and
  the test matrix stop running, swallowed as a warning. Clearing up front also
  makes a re-run idempotent.
- A `core.hooksPath` in the user's **global** config defeats prek the same way.
  That is diagnosed by name with the exact remedy, never cleared — it is not
  ours to clear.
- prek's absence now warns instead of returning, so the gate installs without it.
  CI keeps its early return: runners carry no agent marker, so gating is moot and
  a push there should not arm a watcher.
- Fixes a guard that skipped hook installation in **every worktree**: it tested
  for a directory named `.git`, and in a linked worktree `.git` is a file
  pointing at the real gitdir.

## How to verify

```
bash .githooks/githooks.test.sh
```

Expected 74/0. Eleven of those are new and cover the installer: relative value,
installation from inside a linked worktree, both ends surviving one run, a second
run being idempotent, prek-absent, global-scope diagnosis, and CI exemption.

Run it with `env -u CLAUDECODE` if your shell exports it — 7 pre-existing cases
fail under an ambient agent marker because the fixture's own setup commits get
blocked by the gate under test. That is present on `main` too (56/7 there) and is
fixed by #1125, not here.

## Risks / rollout

Existing clones keep whatever `core.hooksPath` they already have until someone
re-runs `make setup`; the value then becomes relative. A clone that deliberately
set an absolute path — one hook serving every worktree — would change behaviour
on the next setup run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved setup support for linked worktrees.
  * Added automatic local Git hook configuration through `make setup`.
  * Added diagnostics for globally configured hook paths.

* **Bug Fixes**
  * Hook setup is now safer to rerun and remains non-blocking when optional prerequisites are unavailable.

* **Documentation**
  * Updated contributor instructions and hook guidance to use `make setup` instead of the removed installer script.

* **Tests**
  * Added coverage for hook installation, worktrees, chaining, reruns, diagnostics, and CI behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->