### PR TITLE
fix(ci): grant deploy-infra's reusable calls contents: write

### DIFF
--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -70,6 +70,12 @@ jobs:
   build-c:
     name: Build commit C SDK
     needs: resolve-ref
+    # The called workflow's release-upload job declares contents: write, and a callee cannot go
+    # past what its caller grants (see the caller-grant test in release-deployment-safety.test.mjs
+    # for what is documented and what is inferred). Granted here rather than at workflow level so
+    # the deploy job below keeps contents: read.
+    permissions:
+      contents: write
     uses: ./.github/workflows/build-c.yml
     with:
       ref: ${{ needs.resolve-ref.outputs.sha }}
@@ -78,6 +84,12 @@ jobs:
   build-runner:
     name: Build commit Runner
     needs: [resolve-ref, build-c]
+    # The called workflow's release-upload job declares contents: write, and a callee cannot go
+    # past what its caller grants (see the caller-grant test in release-deployment-safety.test.mjs
+    # for what is documented and what is inferred). Granted here rather than at workflow level so
+    # the deploy job below keeps contents: read.
+    permissions:
+      contents: write
     uses: ./.github/workflows/build-runner-binary.yml
     with:
       ref: ${{ needs.resolve-ref.outputs.sha }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,10 +20,7 @@ on:
       - 'make/quality.mk'
       - 'make/test.mk'
       - '.pre-commit-config.yaml'
-      - '.github/workflows/lint.yml'
-      - '.github/workflows/config.yml'
-      - '.github/workflows/build-runtime.yml'
-      - '.github/workflows/deploy-infra.yml'
+      - '.github/workflows/**'
       - 'apps/infra/**'
       - 'scripts/release/**'
   # No path filter on pull_request: the `Lint (conclusion)` job is a required
@@ -85,7 +82,11 @@ jobs:
               - '.github/workflows/lint.yml'
             infra:
               - 'apps/infra/**'
-              - '.github/workflows/deploy-infra.yml'
+              # Every workflow, not just deploy-infra.yml: the infra suite asserts across the
+              # whole directory (caller/callee permissions, Environment allowlists, the staging
+              # step), so a change to any workflow can break it. Naming one file here meant
+              # editing a reusable workflow skipped the suite that guards it.
+              - '.github/workflows/**'
               - 'make/test.mk'
             install_script:
               - 'scripts/release/**'

--- a/apps/infra/scripts/release-deployment-safety.test.mjs
+++ b/apps/infra/scripts/release-deployment-safety.test.mjs
@@ -440,16 +440,79 @@ test('the deployment workflows cap the token they hand their jobs', () => {
     const workflow = load(readFileSync(join(REPO_ROOT, '.github/workflows', entry), 'utf8'))
     assert.equal(workflow.permissions?.contents, 'read', `${entry} must default its token to contents: read`)
 
-    // A job may raise its own, but only deliberately: pin who does and why.
+    // A job may raise its own, but only deliberately. Two reasons appear here:
+    //   upload-to-release — actually writes (uploads release assets)
+    //   build-c / build-runner — write nothing; they call a workflow whose release-upload job
+    //     declares contents: write (see the caller-grant test below). Granting per job rather
+    //     than at the top keeps `deploy` at contents: read.
+    const expectedWriters = new Set(['upload-to-release', 'build-c', 'build-runner'])
     for (const [jobName, job] of Object.entries(workflow.jobs ?? {})) {
       if (!job.permissions) continue
       const raised = Object.entries(job.permissions).filter(([, level]) => level === 'write')
       assert.ok(
-        raised.length === 0 || ['upload-to-release', 'deploy', 'publish'].includes(jobName),
+        raised.length === 0 || expectedWriters.has(jobName),
         `${entry} job '${jobName}' raises ${JSON.stringify(raised)} without being an expected writer`,
       )
     }
   }
+})
+
+test('a job calling a reusable workflow grants at least what that workflow asks for', () => {
+  // Documented: "permissions can only be maintained or reduced—not elevated—throughout the
+  // chain" — https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows
+  //
+  // Measured: dispatching deploy-infra at 32cfa5c3, where the build-c job granted less than
+  // build-c.yml asks for, produced a startup_failure with zero jobs, zero logs and zero
+  // annotations — GitHub said only "a workflow file issue". actionlint exits 0 on that file.
+  //
+  // Inferred: that the elevation is what rejected the run. The docs describe the ceiling, not
+  // what happens when a callee asks past it, and GitHub never named a cause. If a dispatch
+  // shows the callee simply running with a reduced token instead, revisit this comment.
+  const directory = join(REPO_ROOT, '.github/workflows')
+  const LOCAL = './.github/workflows/'
+  const RANK = { none: 0, read: 1, write: 2 }
+  const readWorkflow = (file) => load(readFileSync(join(directory, file), 'utf8'))
+
+  // The widest permission any job in the callee asks for, following nested calls.
+  const required = (file, seen = new Set()) => {
+    if (seen.has(file)) return {}
+    seen.add(file)
+    const workflow = readWorkflow(file)
+    const widest = {}
+    const merge = (permissions) => {
+      if (!permissions || typeof permissions !== 'object') return
+      for (const [scope, level] of Object.entries(permissions)) {
+        if ((RANK[level] ?? 0) > (RANK[widest[scope]] ?? 0)) widest[scope] = level
+      }
+    }
+    merge(workflow.permissions)
+    for (const job of Object.values(workflow.jobs ?? {})) {
+      merge(job.permissions)
+      if (typeof job.uses === 'string' && job.uses.startsWith(LOCAL)) {
+        merge(required(job.uses.slice(LOCAL.length), seen))
+      }
+    }
+    return widest
+  }
+
+  let checked = 0
+  for (const entry of readdirSync(directory).filter((file) => /\.ya?ml$/.test(file))) {
+    const workflow = readWorkflow(entry)
+    for (const [jobName, job] of Object.entries(workflow.jobs ?? {})) {
+      if (typeof job.uses !== 'string' || !job.uses.startsWith(LOCAL)) continue
+      // A job-level block replaces the workflow-level one rather than merging with it.
+      const granted = job.permissions ?? workflow.permissions ?? {}
+      for (const [scope, level] of Object.entries(required(job.uses.slice(LOCAL.length)))) {
+        assert.ok(
+          (RANK[granted[scope]] ?? 0) >= (RANK[level] ?? 0),
+          `${entry} job '${jobName}' grants ${scope}: ${granted[scope] ?? 'none'} but ` +
+            `${job.uses.slice(LOCAL.length)} needs ${level}`,
+        )
+      }
+      checked += 1
+    }
+  }
+  assert.ok(checked >= 11, `expected every local reusable call to be swept, saw ${checked}`)
 })
 
 test('every workflow that selects a deployment Environment does so from an allowlist', () => {


### PR DESCRIPTION
Dispatching deploy-infra after #1122 merged failed at startup with no jobs, no logs and no annotations: "This run likely failed because of a workflow file issue." The workflow last started successfully at caeff696, before that PR added the two reusable calls.

build-c.yml and build-runner-binary.yml each declare an upload-to-release job requesting contents: write, while deploy-infra granted only contents: read. GitHub documents that permissions can only be maintained or reduced, not elevated, through a call chain. Those upload jobs sit behind a release `if:` gate, but the failing run produced no jobs at all, so that gate cannot be assumed to keep their declaration out of what the caller has to grant.

Grant per calling job rather than at workflow level so the deploy job keeps contents: read. Neither callee uses OIDC, so replacing the workflow-level block on those two jobs loses nothing they need.

Guard it by shape instead of by name: the contract test walks every local `uses: ./.github/workflows/...` call, follows nesting, and fails when a caller grants less than its callee asks for. actionlint exits 0 on the file GitHub rejected, so nothing else in the repo catches this.

Point both of lint.yml's workflow path lists at the whole directory. The infra filter named deploy-infra.yml alone, so editing a reusable workflow skipped the suite that guards how it is called; the push trigger named four files, and now runs on any workflow-touching push to main. Neither merge_group nor pull_request filters paths, so the required conclusion check is unaffected.

## Summary
<!-- 1-2 sentences: what this changes and why. -->

## Call graph
<!-- Required. The end-to-end path this PR touches, before and after; one line
     per hop, only the hops that change. Worked example and the bug-fix markers:
     CONTRIBUTING.md#commit--pr-messages. -->

Before
<!-- replace with the hops: fn_name (Type · path/file.rs:LOC) — role -->

After
<!-- replace with the same hops, post-change -->

Fixes #<!-- issue number — bug fixes only; delete this line otherwise -->

## Changes
- <!-- notable change — what changed, not a restatement of the diff -->

## How to verify
- <!-- a command or step a reviewer can run -->

## Risks / rollout
- <!-- only if any; delete this section otherwise -->

<!-- Describe the change, not the process: no pasted logs, no AI/conversation
     narrative, no secrets. Keep it tight and delete sections that don't apply. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow permissions so reusable build workflows can complete successfully while deployment remains appropriately restricted.
  * Expanded workflow change detection to cover all workflow files, ensuring relevant validation runs consistently.

* **Tests**
  * Added coverage for permission requirements across nested reusable workflows.
  * Updated safety checks to reflect the approved permission boundaries for release workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->