### PR TITLE
ci(e2e-cloud): run only from a deploy or a dispatch

### DIFF
--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -8,6 +8,8 @@ run-name: Deploy ${{ inputs.stage }} stack
 #
 # The final deploy sets one BOXLITE_ARTIFACT_SOURCE=build selector for both. A release deploy uses
 # the other selector and consumes the API image / Runner tarball published for VERSION instead.
+#
+# An applied deploy then runs E2E cloud against the stack it just wrote, from that same commit.
 
 on:
   workflow_dispatch:
@@ -252,3 +254,24 @@ jobs:
       - name: Remove materialized configuration
         if: always()
         run: rm -f apps/infra/.env
+
+  # E2E cloud has no automatic trigger of its own; a deploy is the one
+  # event that makes running it meaningful, because only here are the
+  # deployed stack and the SDKs under test the same commit.
+  #
+  # Gated on `apply`: without it the deploy job only previews, so the
+  # stack is whatever it already was and the suite would just spend dev
+  # capacity re-testing it. The `if` carries no status check function, so
+  # the default success() still applies and a failed deploy skips this.
+  #
+  # The stage is always `dev`, so the suite's own BOXLITE_DEV_API_URL
+  # default is the right target and no api_url is passed.
+  e2e:
+    name: E2E suite against ${{ inputs.stage }}
+    needs: [resolve-ref, deploy]
+    if: ${{ inputs.apply }}
+    uses: ./.github/workflows/e2e-cloud.yml
+    with:
+      ref: ${{ needs.resolve-ref.outputs.sha }}
+    secrets:
+      BOXLITE_DEV_API_KEY: ${{ secrets.BOXLITE_DEV_API_KEY }}

--- a/.github/workflows/e2e-cloud.yml
+++ b/.github/workflows/e2e-cloud.yml
@@ -45,55 +45,52 @@
 # account needs provisioning work on the dev stack that nothing else
 # currently needs.
 #
-# Triggers mirror e2e-local: push on main, a label-gated PR trigger, and
-# manual dispatch. The `e2e-cloud` label is the cost gate — every run
-# consumes dev-stack capacity, so PRs opt in rather than run by default.
+# Triggers: exactly two, and both require write access to the repo.
 #
-# Fork PRs: DENIED, and this is the one place the model diverges from
-# e2e-local. There, untrusted code runs in a job holding no secrets, so a
-# maintainer label is purely a cost decision. Here the suite needs the
-# API key in the same job that builds and runs the PR's own code, and
-# GitHub has no secret-safe way to hand a credential from a privileged
-# job to an unprivileged one — job outputs are plaintext. So a labeled
-# fork run would hand arbitrary code a live maintainer credential for
-# the dev stack; a conftest.py is enough to exfiltrate it. Same-repo PRs
-# are allowed because their authors already have write access.
+#   workflow_call      deploy-infra.yml, after it applies a stack, on the
+#                      commit it just deployed (the `ref` input).
+#   workflow_dispatch  a human, against whatever is deployed right now.
 #
-# The event is still pull_request_target with head-SHA pinning so the
-# trigger surface matches e2e-local. Enabling forks needs more than
-# relaxing `should-run`: the run would first have to mint a scoped,
-# short-lived key (CreateApiKeyDto takes `permissions` and `expiresAt`)
-# and pass only that to the test step.
+# Nothing fires on its own any more. Push-on-main and the label-gated
+# pull_request_target trigger both ran the suite against a dev stack
+# whose deployed commit was unrelated to the commit under test, so a red
+# run said as much about how stale the stack was as about the change.
+# Hanging the suite off a deploy makes client and server the same commit;
+# every other run is someone asking for one.
 #
-# Runbook: docs/ci/e2e-local.md covers the shared label/gate mechanics.
+# The corollary is that untrusted code no longer reaches this workflow —
+# which is what makes it safe for the job that builds and runs the tree
+# to also hold the API key. There is no fork path left to defend:
+# dispatch needs write access, and deploy-infra is itself dispatch-only
+# and refuses to run off main. Restoring any PR trigger would mean
+# restoring that exposure — a labeled fork run hands arbitrary code a
+# live dev credential, and a conftest.py is enough to exfiltrate it — so
+# it would first have to mint a scoped, short-lived key (CreateApiKeyDto
+# takes `permissions` and `expiresAt`) and pass only that to the tests.
 
 name: E2E cloud
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'src/boxlite/**'
-      - 'src/shared/**'
-      - 'src/cli/**'
-      - 'src/guest/**'
-      - 'sdks/**'
-      - 'apps/e2e/**'
-      - '**/Cargo.toml'
-      - 'Cargo.lock'
-      - '.github/workflows/e2e-cloud.yml'
-  pull_request_target:
-    types: [labeled, synchronize]
-    branches: [main]
-    paths:
-      - 'src/boxlite/**'
-      - 'src/shared/**'
-      - 'src/cli/**'
-      - 'src/guest/**'
-      - 'sdks/**'
-      - 'apps/e2e/**'
-      - '**/Cargo.toml'
-      - 'Cargo.lock'
+  workflow_call:
+    inputs:
+      ref:
+        # The commit the caller deployed. Without it the suite would build
+        # its SDKs from whatever main points at now, while the stack under
+        # test runs the commit deploy-infra selected — deploy-infra takes an
+        # arbitrary main commit, so those are not always the same thing.
+        description: 'Full commit SHA to build the SDKs and CLI from.'
+        required: true
+        type: string
+    secrets:
+      BOXLITE_DEV_API_KEY:
+        # Named rather than inherited. `inherit` passes every secret the
+        # caller holds, which for deploy-infra means DEPLOY_ENV and the
+        # Cloudflare API token as well — none of the suite's business.
+        # Its AWS access is not a secret and so was never at stake here;
+        # that comes from OIDC, and `permissions` below is what withholds
+        # it.
+        description: 'Dev-stack boxlite API key for profile p1.'
+        required: true
   workflow_dispatch:
     inputs:
       api_url:
@@ -104,24 +101,36 @@ on:
         # always non-empty on a dispatch run, so BOXLITE_DEV_API_URL
         # would be silently ignored exactly when someone is trying to
         # dispatch against the configured stack.
+        #
+        # No `ref` here either: a dispatch already chooses its own ref in
+        # the UI, and github.sha follows it.
 
-# pull_request_target's default token is write-capable — keep the
-# inherited token read-only, as e2e-local does.
+# A called workflow inherits the caller's token, and per GitHub's reuse
+# docs permissions "can only be maintained or reduced — not elevated".
+# Declaring the floor here is therefore what keeps deploy-infra's
+# `id-token: write` — its AWS entry — out of the job that builds and runs
+# the tree. Widening this hands that job the deploy role.
 permissions:
   contents: read
 
 # Single global group: every run targets the same dev stack, so two in
 # flight would race over shared boxes.
 #
-# A newer push queues behind the in-progress run instead of cancelling
-# it. The `box` fixture's teardown is the only thing that deletes the
-# boxes a run creates: auto_remove is a no-op over REST (see
+# A later run queues behind the in-progress one instead of cancelling it.
+# The `box` fixture's teardown is the only thing that deletes the boxes a
+# run creates: auto_remove is a no-op over REST (see
 # deprecated_auto_remove_does_not_change_rest_lifecycle_defaults) and the
 # API defaults autoDelete to disabled, so a run killed mid-suite strands
 # every box it had open — they auto-stop after 15 min but are never
 # deleted. Note this bounds the damage rather than eliminating it:
 # GitHub retains only the newest *pending* run per group, so intermediate
-# queued pushes are still superseded before they ever start.
+# queued runs are still superseded before they ever start.
+#
+# Unverified for the call path: GitHub's reuse-workflows doc says nothing
+# either way about workflow-level concurrency inside a called workflow,
+# and this is the repo's only reusable workflow that declares it. If a
+# deploy turns out not to queue behind a suite already running against
+# the stack it just replaced, this is why.
 concurrency:
   group: e2e-cloud
   cancel-in-progress: false
@@ -134,52 +143,20 @@ env:
   API_URL: ${{ inputs.api_url || vars.BOXLITE_DEV_API_URL || 'https://api.dev.boxlite.ai/api' }}
 
 jobs:
-  # =========================================================================
-  # Gate: PRs require the 'e2e-cloud' label (only maintainers can add it).
-  # Same-repo PRs re-run while labeled. Fork PRs never run — see the header:
-  # this workflow's only job holds a live dev API key.
-  # =========================================================================
-  should-run:
-    runs-on: ubuntu-latest
-    outputs:
-      run: ${{ steps.check.outputs.run }}
-    steps:
-      - name: Check trigger conditions
-        id: check
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
-          LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
-        run: |
-          if [ "$EVENT_NAME" != "pull_request_target" ]; then
-            echo "run=true" >> "$GITHUB_OUTPUT"   # push / workflow_dispatch
-            exit 0
-          fi
-          if ! echo "$LABELS" | jq -e 'index("e2e-cloud")' > /dev/null 2>&1; then
-            echo "run=false" >> "$GITHUB_OUTPUT"  # label is the cost gate
-            exit 0
-          fi
-          if [ "$HEAD_REPO" = "$GITHUB_REPOSITORY" ]; then
-            echo "run=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "run=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::Fork PRs cannot run E2E cloud: the suite needs a live dev API key in the same job that runs the PR's code. Use workflow_dispatch from a maintainer branch instead."
-          fi
-
+  # No trigger gate: workflow_dispatch needs write access and
+  # workflow_call only reaches here from deploy-infra, which is itself
+  # dispatch-only. There is no untrusted event left to filter.
   e2e:
     name: E2E suite (cloud)
-    needs: should-run
-    if: needs.should-run.outputs.run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v5
         with:
-          # pull_request_target resolves to the BASE branch by default,
-          # which would silently test main instead of the PR. Pin the head
-          # SHA the maintainer approved when labeling; push/dispatch keep
-          # github.sha. Same-repo heads only — see `should-run`.
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          # On a call, the commit the caller deployed. On a dispatch,
+          # inputs.ref is undefined and github.sha is the ref chosen in the
+          # UI — the same commit either way, never the caller's default.
+          ref: ${{ inputs.ref || github.sha }}
           persist-credentials: false
 
       # ── Health check ──────────────────────────────────────────────

--- a/apps/infra/scripts/release-deployment-safety.test.mjs
+++ b/apps/infra/scripts/release-deployment-safety.test.mjs
@@ -22,6 +22,7 @@ const RELEASE_DEPLOY_WORKFLOW = join(REPO_ROOT, '.github/workflows/deploy-releas
 const API_IMAGE_BUILD_WORKFLOW = join(REPO_ROOT, '.github/workflows/build-apps-api-image.yml')
 const BUILD_C_WORKFLOW = join(REPO_ROOT, '.github/workflows/build-c.yml')
 const BUILD_RUNNER_WORKFLOW = join(REPO_ROOT, '.github/workflows/build-runner-binary.yml')
+const E2E_CLOUD_WORKFLOW = join(REPO_ROOT, '.github/workflows/e2e-cloud.yml')
 const LINT_WORKFLOW = join(REPO_ROOT, '.github/workflows/lint.yml')
 const DEV_DEPLOY_ROLE = join(REPO_ROOT, 'apps/infra/ci/github-deploy-role.yaml')
 const CLOUDFORMATION_SCHEMA = DEFAULT_SCHEMA.extend([
@@ -186,6 +187,19 @@ test('deployment previews and reconciles the full stack in guarded GitHub CI', (
   assert.equal(workflow.jobs['build-runner'].uses, './.github/workflows/build-runner-binary.yml')
   assert.equal(workflow.jobs['build-runner'].with.libboxlite_source, 'artifact')
   assert.equal(workflow.jobs['build-runner'].with.ref, '${{ needs.resolve-ref.outputs.sha }}')
+
+  // The suite that proves the deploy is the third call of that shape, and the two values that
+  // make it worth running are just as much contract. Drop `with.ref` and it builds its SDKs from
+  // tip-of-main against whatever commit was deployed; drop the apply gate and it spends dev-stack
+  // capacity re-testing a stack the run only previewed.
+  assert.equal(workflow.jobs.e2e.uses, './.github/workflows/e2e-cloud.yml')
+  assert.equal(workflow.jobs.e2e.with.ref, '${{ needs.resolve-ref.outputs.sha }}')
+  assert.equal(workflow.jobs.e2e.if, '${{ inputs.apply }}')
+  // Named, not `inherit` — which would also hand the suite DEPLOY_ENV and the Cloudflare token.
+  assert.equal(workflow.jobs.e2e.secrets.BOXLITE_DEV_API_KEY, '${{ secrets.BOXLITE_DEV_API_KEY }}')
+  // `needs` carries the ordering the `if` relies on: no status-check function appears in that
+  // expression, so the default success() is what stops the suite running behind a failed deploy.
+  assert.deepEqual(workflow.jobs.e2e.needs, ['resolve-ref', 'deploy'])
 
   // Both components resolve to the one commit the build jobs actually produced. The stage secret
   // cannot redirect that: deploy-environment-validation.mjs rejects the selector keys outright.
@@ -384,6 +398,37 @@ test('commit Runner builds consume the C SDK artifact from the same reusable run
   )
 })
 
+test('the cloud E2E suite is reachable only from a deploy or a human', () => {
+  const workflow = load(readFileSync(E2E_CLOUD_WORKFLOW, 'utf8'))
+
+  // The whole point of the trigger surface: this job builds and runs the tree in the same job
+  // that holds a live dev API key, so no event may reach it that an outsider can raise. Compare
+  // the parsed trigger keys as a set rather than asserting the two we want are present — the
+  // failure to catch is a *re-added* `pull_request_target`, which every presence check passes.
+  assert.deepEqual(Object.keys(workflow.on).sort(), ['workflow_call', 'workflow_dispatch'])
+
+  // Read the callee's own declarations: a commented-out `workflow_call:` still satisfies a
+  // substring match while making deploy-infra's call dead.
+  assert.ok(workflow.on.workflow_call, 'e2e-cloud.yml is no longer callable as a reusable workflow')
+  assert.equal(workflow.on.workflow_call.inputs.ref.required, true)
+  assert.equal(workflow.on.workflow_call.secrets.BOXLITE_DEV_API_KEY.required, true)
+
+  // A callee inherits the caller's token and may only narrow it, so this line — not anything in
+  // deploy-infra.yml — is what keeps `id-token: write`, the deploy role's entry, away from a job
+  // that executes the checked-out tree.
+  assert.equal(workflow.permissions?.contents, 'read')
+  assert.equal(workflow.permissions?.['id-token'], undefined)
+
+  // The checkout has to follow the caller's commit. Falling back to github.sha alone would test
+  // the tip of whatever ref the *caller* ran from, which for a re-deploy of an older commit is
+  // not the commit now on the stack.
+  const checkout = workflow.jobs.e2e.steps.find(
+    (step) => typeof step.uses === 'string' && step.uses.startsWith('actions/checkout'),
+  )
+  assert.ok(checkout, 'the e2e job no longer checks out a ref')
+  assert.equal(checkout.with.ref, '${{ inputs.ref || github.sha }}')
+})
+
 test('release deployment consumes one published version for both components', () => {
   const source = readFileSync(RELEASE_DEPLOY_WORKFLOW, 'utf8')
   const workflow = load(source)
@@ -436,6 +481,9 @@ test('the deployment workflows cap the token they hand their jobs', () => {
     'build-runner-binary.yml',
     'deploy-infra.yml',
     'deploy-release.yml',
+    // The deploy path's third reusable callee. Its cap does more work than the others': it is
+    // what narrows the inherited deploy token, so it belongs under the same guard.
+    'e2e-cloud.yml',
   ]) {
     const workflow = load(readFileSync(join(REPO_ROOT, '.github/workflows', entry), 'utf8'))
     assert.equal(workflow.permissions?.contents, 'read', `${entry} must default its token to contents: read`)


### PR DESCRIPTION
Push-on-main and the label-gated `pull_request_target` trigger both ran the
cloud E2E suite against a dev stack whose deployed commit was unrelated to the
commit under test. A red run said as much about how stale the stack was as
about the change.

Hang the suite off the deploy instead. `deploy-infra` calls it as a reusable
workflow once it has applied a stack, passing the commit it deployed, so client
and server are the same tree. Manual dispatch is the only other way in.

With no PR event left there is nothing untrusted to filter, so the `should-run`
label/fork gate goes with it. Being called by a privileged workflow is new, so
the two things that contain it are stated where they act: the API key is named
rather than inherited (`inherit` would also hand the suite `DEPLOY_ENV` and the
Cloudflare token), and `permissions: contents: read` is what keeps the caller's
`id-token: write` out of the job that builds and runs the tree.

## Call graph

```
Before
  push[main] / pull_request_target[labeled,synchronize]  (trigger · .github/workflows/e2e-cloud.yml:73)
    └─ should-run                                        (gate job · .github/workflows/e2e-cloud.yml:142)   label check, fork check
         └─ e2e  needs: should-run                       (suite job · .github/workflows/e2e-cloud.yml:169)
              └─ checkout ref: pull_request.head.sha     (actions/checkout · .github/workflows/e2e-cloud.yml:180)
                   stack under test = whatever dev happens to run

After
  deploy  (applies the stack)                            (deploy job · .github/workflows/deploy-infra.yml:100)
    └─ e2e  if: inputs.apply                             (caller job · .github/workflows/deploy-infra.yml:269)
         └─ uses: ./.github/workflows/e2e-cloud.yml      (reusable call · .github/workflows/deploy-infra.yml:273)
              with ref: needs.resolve-ref.outputs.sha
              secrets: BOXLITE_DEV_API_KEY
              └─ workflow_call                           (trigger · .github/workflows/e2e-cloud.yml:74)
                   └─ e2e  (no gate job)                 (suite job · .github/workflows/e2e-cloud.yml:149)
                        └─ checkout ref: inputs.ref      (actions/checkout · .github/workflows/e2e-cloud.yml:159)
                             stack under test = the commit just deployed
```

## Tests

The deployment safety suite already pins the entrypoint and inputs of the two
reusable workflows `deploy-infra` calls, on the grounds that a `uses:` target is
contract rather than prose. This is the third, so it is pinned the same way.

- `release-deployment-safety.test.mjs:195` — the caller side: `uses`, `with.ref`,
  `if`, `secrets`, `needs`.
- `release-deployment-safety.test.mjs:401` — a new test for the callee side. The
  trigger set is compared as a whole rather than presence-checked, because the
  failure worth catching is a re-added `pull_request_target`, which every
  presence check passes.
- `release-deployment-safety.test.mjs:486` — `e2e-cloud.yml` joins the token-cap
  allowlist. It is now the deploy path's third reusable callee.

`make test:apps:infra` → 291/291. Reverting both workflow files with the tests
in place gives 289/2, failing on `['pull_request_target','push','workflow_dispatch']`
vs `['workflow_call','workflow_dispatch']` and on `jobs.e2e` being undefined.

## Notes

- Neither workflow has been executed on GitHub; verification here is static.
- The `concurrency` block is unchanged and carries a comment saying so: GitHub's
  reuse-workflows doc says nothing either way about workflow-level concurrency
  inside a called workflow, and this is the repo's only reusable workflow that
  declares it. Worst case is a deploy that does not queue behind a suite already
  running against the stack it replaced.
- The `e2e-cloud` repository label is now unused. It lives in repo settings, so
  there is nothing to remove here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cloud end-to-end tests now run automatically after infrastructure deployments when changes are applied.
  * Tests validate the exact deployed commit for more reliable deployment verification.

* **Documentation**
  * Added clarification that applied deployments include cloud end-to-end testing against the deployed commit.

* **Tests**
  * Expanded automated coverage for deployment sequencing, commit selection, permissions, and workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->