### PR TITLE
fix(rest): keep sandbox security server-owned

### DIFF
--- a/openapi/box.openapi.yaml
+++ b/openapi/box.openapi.yaml
@@ -1236,10 +1236,6 @@ components:
               type: integer
               description: Default disk size in GB
               example: 10
-            security_preset:
-              type: string
-              description: Default security preset
-              example: standard
             auto_delete:
               type: integer
               description: Default AutoDelete interval in seconds; 0 disables AutoDelete
@@ -1305,11 +1301,6 @@ components:
               type: boolean
               description: Whether box export is supported
               example: true
-            supported_security_presets:
-              type: array
-              items:
-                type: string
-              example: [development, standard, maximum]
             idempotency_key_lifetime:
               type: string
               description: How long idempotency keys are retained (ISO 8601 duration)
@@ -1589,13 +1580,12 @@ components:
       description: |
         REST-supported configuration for creating a new box. Host port
         publication is intentionally absent; use the box network tunnel
-        endpoint for remote service access.
+        endpoint for remote service access. Sandbox security is server policy
+        and cannot be relaxed by clients.
       additionalProperties: false
       properties:
         advanced:
           $ref: "#/components/schemas/CreateBoxAdvancedOptions"
-        security:
-          $ref: "#/components/schemas/SecurityPreset"
         name:
           type: string
           description: Unique name within the workspace
@@ -1773,19 +1763,6 @@ components:
           description: |
             Placeholder string visible inside the guest.
             Defaults to `<BOXLITE_SECRET:{name}>` when omitted.
-
-    SecurityPreset:
-      type: string
-      description: |
-        Security isolation preset:
-        - `development`: Minimal isolation for debugging
-        - `standard`: Recommended for most use cases (jailer + seccomp on Linux)
-        - `maximum`: All isolation features enabled (untrusted workloads)
-      enum:
-        - development
-        - standard
-        - maximum
-      default: standard
 
     Snapshot:
       type: object

--- a/openapi/box.openapi.yaml
+++ b/openapi/box.openapi.yaml
@@ -1580,8 +1580,11 @@ components:
       description: |
         REST-supported configuration for creating a new box. Host port
         publication is intentionally absent; use the box network tunnel
-        endpoint for remote service access. Sandbox security is server policy
-        and cannot be relaxed by clients.
+        endpoint for remote service access. The sandbox isolation preset is
+        server policy and cannot be selected by clients. Expert callers may
+        still request container capability additions and removals through
+        `advanced.capabilities`; those deltas do not select the host sandbox
+        policy.
       additionalProperties: false
       properties:
         advanced:

--- a/openapi/reference-server/server.py
+++ b/openapi/reference-server/server.py
@@ -176,7 +176,6 @@ class CreateBoxRequest(BaseModel):
     auto_resume: Optional[bool] = None
     detach: Optional[bool] = False
     advanced: Optional[CreateBoxAdvancedOptions] = None
-    security: Optional[str] = None
 
 
 class StopBoxRequest(BaseModel):
@@ -436,15 +435,6 @@ def build_box_options(req: CreateBoxRequest) -> boxlite.BoxOptions:
             (v["host_path"], v["guest_path"], v.get("read_only", False))
             for v in req.volumes
         ]
-    if req.security:
-        presets = {
-            "development": boxlite.SecurityOptions.development,
-            "standard": boxlite.SecurityOptions.standard,
-            "maximum": boxlite.SecurityOptions.maximum,
-        }
-        if req.security in presets:
-            kwargs["security"] = presets[req.security]()
-
     return boxlite.BoxOptions(**kwargs)
 
 
@@ -593,7 +583,6 @@ async def get_config():
             "cpus": 2,
             "memory_mib": 512,
             "disk_size_gb": 10,
-            "security_preset": "standard",
             "auto_delete": 0,
         },
         "overrides": {},
@@ -612,7 +601,6 @@ async def get_config():
             "clone_enabled": True,
             "export_enabled": True,
             "import_enabled": True,
-            "supported_security_presets": ["development", "standard", "maximum"],
             "idempotency_key_lifetime": "PT24H",
         },
     }

--- a/openapi/reference-server/tests/test_handle_cache.py
+++ b/openapi/reference-server/tests/test_handle_cache.py
@@ -29,19 +29,6 @@ def _install_boxlite_stub() -> None:
         def __init__(self, *args, **kwargs):
             pass
 
-    class _SecurityOptions:
-        @staticmethod
-        def development():
-            return object()
-
-        @staticmethod
-        def standard():
-            return object()
-
-        @staticmethod
-        def maximum():
-            return object()
-
     module.Boxlite = _Noop
     module.Options = _Noop
     module.BoxOptions = _Noop
@@ -51,7 +38,6 @@ def _install_boxlite_stub() -> None:
     module.ExportOptions = _Noop
     module.SnapshotOptions = _Noop
     module.CopyOptions = _Noop
-    module.SecurityOptions = _SecurityOptions
     sys.modules["boxlite"] = module
 
 
@@ -164,6 +150,17 @@ class HandleCacheTests(unittest.IsolatedAsyncioTestCase):
             SERVER.CreateBoxRequest.model_validate(
                 {"ports": [{"guest_port": 3000}]}
             )
+
+    def test_create_request_rejects_client_security_policy(self) -> None:
+        for field in ("security", "security_settings"):
+            with self.subTest(field=field), self.assertRaises(ValidationError):
+                SERVER.CreateBoxRequest.model_validate({field: "development"})
+
+    async def test_config_does_not_advertise_client_security_controls(self) -> None:
+        config = await SERVER.get_config()
+
+        self.assertNotIn("security_preset", config["defaults"])
+        self.assertNotIn("supported_security_presets", config["capabilities"])
 
     def test_dedicated_ports_route_is_removed(self) -> None:
         paths = {route.path for route in SERVER.app.routes}


### PR DESCRIPTION
Remove client-selectable sandbox security presets from the Box REST contract and reference server.

Test plan:
- [x] `uv run --with fastapi --with pyjwt --with python-multipart --with sse-starlette --with uvicorn --with python-dotenv python -m unittest discover -s openapi/reference-server/tests -v`
- [x] Parse `openapi/box.openapi.yaml` with PyYAML and verify all local `$ref` targets
- [x] `ruff check openapi/reference-server/tests/test_handle_cache.py`
- [x] `python3 -m py_compile openapi/reference-server/server.py openapi/reference-server/tests/test_handle_cache.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Removed client-configurable security presets from box creation requests.
  * Sandbox security is now controlled exclusively by server policy.
  * Removed security preset details from server configuration and capability responses.
  * Existing requests that specify security presets may require updates.

* **Validation**
  * Requests using the removed security fields are now rejected.
  * Advanced container capability options remain available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->