### PR TITLE
refactor(infra): give AWS resource names a workload slot

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -169,7 +169,7 @@ today). Each component is built by its own job, and the two legs share only
 a Linux AMD64 Runner with `<workspace-version>+<sha>` identity and stage it in
 the stage's private commit-keyed S3 path, while `build-api` calls
 `build-apps-api-image.yml` for the same commit and pushes
-`boxlite-<stage>-api:v<version>-<sha>`. The deploy itself compiles neither.
+`boxlite-app-<stage>-api:v<version>-<sha>`. The deploy itself compiles neither.
 Deployment safety tests first enforce the Runner lifecycle options. Dispatch defaults to
 preview-only; `apply=true` repeats the full structured preview and deploys only
 when the Runner safety gate accepts the
@@ -193,7 +193,7 @@ adding it to whichever of those lists should reach it.
 ### `build-apps-api-image.yml` / `deploy-release.yml`
 
 `build-apps-api-image.yml` has three operations, all writing immutable tags into
-`boxlite-<stage>-api`:
+`boxlite-app-<stage>-api`:
 
 | Operation | Entry point                | Checks out    | Tag                  | Target        |
 | --------- | -------------------------- | ------------- | -------------------- | ------------- |

--- a/.github/workflows/build-apps-api-image.yml
+++ b/.github/workflows/build-apps-api-image.yml
@@ -193,8 +193,8 @@ jobs:
           set -euo pipefail
           registry="$(aws sts get-caller-identity --query Account --output text).dkr.ecr.${AWS_REGION}.amazonaws.com"
           aws ecr get-login-password --region "$AWS_REGION" | docker login --username AWS --password-stdin "$registry"
-          echo "target=${registry}/boxlite-${TARGET_STAGE}-api" >> "$GITHUB_OUTPUT"
-          echo "source=${registry}/boxlite-${SOURCE_STAGE}-api" >> "$GITHUB_OUTPUT"
+          echo "target=${registry}/boxlite-app-${TARGET_STAGE}-api" >> "$GITHUB_OUTPUT"
+          echo "source=${registry}/boxlite-app-${SOURCE_STAGE}-api" >> "$GITHUB_OUTPUT"
 
       - name: Verify bootstrap repositories and target tag
         id: target
@@ -204,14 +204,14 @@ jobs:
           OPERATION: ${{ steps.artifact.outputs.operation }}
         run: |
           set -euo pipefail
-          target_name="boxlite-${TARGET_STAGE}-api"
+          target_name="boxlite-app-${TARGET_STAGE}-api"
           aws ecr describe-repositories --region "$AWS_REGION" --repository-names "$target_name" >/dev/null || {
             echo "ECR repository $target_name is missing; update apps/infra/ci/github-deploy-role.yaml for $TARGET_STAGE first" >&2
             exit 1
           }
           source_digest=""
           if [ "$OPERATION" = promote ]; then
-            source_name="boxlite-${SOURCE_STAGE}-api"
+            source_name="boxlite-app-${SOURCE_STAGE}-api"
             source_digest=$(aws ecr describe-images --region "$AWS_REGION" --repository-name "$source_name" \
               --image-ids "imageTag=$TAG" --query 'imageDetails[0].imageDigest' --output text) || {
                 echo "$source_name:$TAG has not been published" >&2

--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -167,7 +167,7 @@ jobs:
         run: |
           set -euo pipefail
           account_id=$(aws sts get-caller-identity --query Account --output text)
-          bucket="boxlite-${STAGE}-artifacts-${account_id}"
+          bucket="boxlite-app-${STAGE}-artifacts-${account_id}"
           archive="boxlite-runner-v${VERSION}-${BOXLITE_ARTIFACT_REF}-linux-amd64.tar.gz"
           test -f "dist/runner/$archive"
           test -f "dist/runner/$archive.sha256"

--- a/apps/infra/README.md
+++ b/apps/infra/README.md
@@ -121,8 +121,8 @@ Both deployable components use one source selector:
 
 | Mode      | API                                                        | Runner                                                           |
 | --------- | ---------------------------------------------------------- | ---------------------------------------------------------------- |
-| `build`   | immutable `boxlite-<stage>-api:v<version>-<sha>` in ECR    | CI builds that commit and stages a private S3 tarball + checksum |
-| `release` | immutable `boxlite-<stage>-api:<version>` in ECR           | GitHub Release tarball + checksum for the same `<version>`       |
+| `build`   | immutable `boxlite-app-<stage>-api:v<version>-<sha>` in ECR    | CI builds that commit and stages a private S3 tarball + checksum |
+| `release` | immutable `boxlite-app-<stage>-api:<version>` in ECR           | GitHub Release tarball + checksum for the same `<version>`       |
 
 Both modes hand SST an image reference, so no deploy compiles the API. The one
 exception is a build with no API ref — set neither `BOXLITE_ARTIFACT_REF` nor

--- a/apps/infra/ci/github-deploy-role.yaml
+++ b/apps/infra/ci/github-deploy-role.yaml
@@ -22,7 +22,9 @@ Resources:
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
     Properties:
-      RepositoryName: !Sub boxlite-${GitHubEnvironment}-api
+      # <namespace>-<workload>-<stage>-<name>, the grammar scripts/resource-name.mjs composes.
+      # This side declares the name; apiImageRepository resolves it. Both are pinned by tests.
+      RepositoryName: !Sub boxlite-app-${GitHubEnvironment}-api
       ImageTagMutability: IMMUTABLE
       ImageScanningConfiguration:
         ScanOnPush: true
@@ -34,7 +36,8 @@ Resources:
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
     Properties:
-      BucketName: !Sub boxlite-${GitHubEnvironment}-artifacts-${AWS::AccountId}
+      # Same grammar; the account id is the attribute S3's global namespace requires.
+      BucketName: !Sub boxlite-app-${GitHubEnvironment}-artifacts-${AWS::AccountId}
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
@@ -133,7 +136,12 @@ Resources:
               - s3:ListBucketVersions
               - s3:PutBucketTagging
             Resource:
+              # Both the legacy boxlite-<stage>-* shape and the boxlite-app-<stage>-* grammar
+              # scripts/resource-name.mjs composes. The boundary intersects with every identity
+              # policy, so a bucket outside these prefixes is denied no matter what SST grants —
+              # which is how a rename escapes the boundary silently.
               - !Sub arn:${AWS::Partition}:s3:::boxlite-${GitHubEnvironment}-*
+              - !Sub arn:${AWS::Partition}:s3:::boxlite-app-${GitHubEnvironment}-*
               - !Sub arn:${AWS::Partition}:s3:::boxlite-volume-*
           - Sid: BoxLiteBucketObjects
             Effect: Allow
@@ -144,7 +152,10 @@ Resources:
               - s3:GetObject
               - s3:PutObject
             Resource:
+              # The Runner reads its own binary from boxlite-app-<stage>-artifacts-<acct>/runner/*
+              # under the instance profile, at boot and on every SSM upgrade.
               - !Sub arn:${AWS::Partition}:s3:::boxlite-${GitHubEnvironment}-*/*
+              - !Sub arn:${AWS::Partition}:s3:::boxlite-app-${GitHubEnvironment}-*/*
               - !Sub arn:${AWS::Partition}:s3:::boxlite-volume-*/*
           - Sid: AssumeBoxLiteRuntimeRoles
             Effect: Allow

--- a/apps/infra/scripts/api-artifact.mjs
+++ b/apps/infra/scripts/api-artifact.mjs
@@ -17,11 +17,14 @@
  * there would make the local path depend on the remote one.
  *
  * The repository is named rather than looked up: the stage bootstrap
- * (ci/github-deploy-role.yaml) creates `<app>-<stage>-api` because CI has to push into it before
- * any deploy can read it, so the consumer cannot be the thing that creates it.
+ * (ci/github-deploy-role.yaml) creates it because CI has to push into it before any deploy can
+ * read it, so the consumer cannot be the thing that creates it. Both sides spell the name through
+ * the same grammar — see resource-name.mjs.
  */
 
 import { execFileSync } from 'node:child_process'
+
+import { awsResourceName } from './resource-name.mjs'
 
 // ECR's own rule, minus the uppercase it never allows: a stage that cannot name a repository
 // should fail here rather than as an opaque AWS validation error mid-deploy.
@@ -30,7 +33,7 @@ const REPOSITORY_NAME = /^[a-z0-9][a-z0-9._/-]{1,255}$/
 const IMAGE_TAG = /^[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}$/
 
 export function apiImageRepository({ app, stage }) {
-  const repository = `${app}-${stage}-api`
+  const repository = awsResourceName({ app, stage, name: 'api' })
   if (!REPOSITORY_NAME.test(repository)) {
     throw new Error(`Api stage '${stage}' does not produce a valid ECR repository name`)
   }

--- a/apps/infra/scripts/api-artifact.test.mjs
+++ b/apps/infra/scripts/api-artifact.test.mjs
@@ -21,10 +21,10 @@ const fakeCli = (result) => {
 }
 
 test('the image reference is the bootstrapped repository, not one the deploy invents', () => {
-  assert.equal(apiImageRepository({ app: 'boxlite', stage: 'dev' }), 'boxlite-dev-api')
+  assert.equal(apiImageRepository({ app: 'boxlite', stage: 'dev' }), 'boxlite-app-dev-api')
   assert.equal(
     apiImageReference({ ...STAGE, accountId: '123456789012' }),
-    '123456789012.dkr.ecr.ap-southeast-1.amazonaws.com/boxlite-dev-api:1.2.3',
+    '123456789012.dkr.ecr.ap-southeast-1.amazonaws.com/boxlite-app-dev-api:1.2.3',
   )
   assert.throws(
     () => apiImageRepository({ app: 'boxlite', stage: 'Feature One' }),
@@ -42,7 +42,7 @@ test('a release names a version and a build names a commit, in the same reposito
   assert.notEqual(apiImageTag({ version: '1.2.3', ref: REF }), apiImageTag({ version: '1.2.3' }))
   assert.equal(
     apiImageReference({ ...STAGE, accountId: '123456789012', ref: REF }),
-    `123456789012.dkr.ecr.ap-southeast-1.amazonaws.com/boxlite-dev-api:v1.2.3-${REF}`,
+    `123456789012.dkr.ecr.ap-southeast-1.amazonaws.com/boxlite-app-dev-api:v1.2.3-${REF}`,
   )
   assert.throws(() => apiImageTag({ version: '1.2.3 4', ref: REF }), /does not produce a valid image tag/)
 })
@@ -50,7 +50,7 @@ test('a release names a version and a build names a commit, in the same reposito
 test('a published tag is confirmed by digest before SST is allowed to run', () => {
   const { calls, run } = fakeCli(`${DIGEST}\n`)
   assert.deepEqual(verifyApiImage(STAGE, { awsCliPath: '/fake/aws', run }), {
-    repository: 'boxlite-dev-api',
+    repository: 'boxlite-app-dev-api',
     tag: '1.2.3',
     digest: DIGEST,
   })
@@ -58,7 +58,7 @@ test('a published tag is confirmed by digest before SST is allowed to run', () =
   assert.equal(calls.length, 1)
   const { args } = calls[0]
   assert.deepEqual(args.slice(0, 2), ['ecr', 'describe-images'])
-  assert.equal(args[args.indexOf('--repository-name') + 1], 'boxlite-dev-api')
+  assert.equal(args[args.indexOf('--repository-name') + 1], 'boxlite-app-dev-api')
   assert.equal(args[args.indexOf('--image-ids') + 1], 'imageTag=1.2.3')
   assert.equal(args[args.indexOf('--region') + 1], 'ap-southeast-1')
 })
@@ -68,7 +68,7 @@ test('a commit image is looked up by its own tag, not the bare version', () => {
   // confirm an image that exists and deploy a different one that may not.
   const { calls, run } = fakeCli(`${DIGEST}\n`)
   assert.deepEqual(verifyApiImage({ ...STAGE, ref: REF }, { awsCliPath: '/fake/aws', run }), {
-    repository: 'boxlite-dev-api',
+    repository: 'boxlite-app-dev-api',
     tag: `v1.2.3-${REF}`,
     digest: DIGEST,
   })
@@ -81,7 +81,7 @@ test('an absent tag is refused even though the CLI exits zero', () => {
   for (const empty of ['None\n', '', '   ']) {
     assert.throws(
       () => verifyApiImage(STAGE, { awsCliPath: '/fake/aws', run: fakeCli(empty).run }),
-      /boxlite-dev-api:1\.2\.3 is unavailable: no image digest was returned/,
+      /boxlite-app-dev-api:1\.2\.3 is unavailable: no image digest was returned/,
     )
   }
 })
@@ -90,10 +90,10 @@ test('a failed lookup names the repository and tag it could not resolve', () => 
   const denied = Object.assign(new Error('exited 254'), { stderr: 'AccessDeniedException' })
   assert.throws(
     () => verifyApiImage(STAGE, { awsCliPath: '/fake/aws', run: fakeCli(denied).run }),
-    /Api image boxlite-dev-api:1\.2\.3 is unavailable: AccessDeniedException/,
+    /Api image boxlite-app-dev-api:1\.2\.3 is unavailable: AccessDeniedException/,
   )
   assert.throws(
     () => verifyApiImage({ ...STAGE, ref: REF }, { awsCliPath: '/fake/aws', run: fakeCli(denied).run }),
-    new RegExp(`Api image boxlite-dev-api:v1\\.2\\.3-${REF} is unavailable: AccessDeniedException`),
+    new RegExp(`Api image boxlite-app-dev-api:v1\\.2\\.3-${REF} is unavailable: AccessDeniedException`),
   )
 })

--- a/apps/infra/scripts/artifact-source.test.mjs
+++ b/apps/infra/scripts/artifact-source.test.mjs
@@ -98,7 +98,7 @@ test('a component ref wins over the global one, the way its source key does', ()
 
 test('staging only a Runner locally leaves the Api building from the checkout', () => {
   // What `npm run runner:build-artifact` prints. Reading the global ref for the Api here would
-  // resolve boxlite-<stage>-api:v<version>-<sha> — a tag only deploy-infra.yml ever pushes — and
+  // resolve boxlite-app-<stage>-api:v<version>-<sha> — a tag only deploy-infra.yml ever pushes — and
   // refuse the deploy at preflight, with no published image the developer could point at.
   const local = { RUNNER_ARTIFACT_SOURCE: 'build', RUNNER_ARTIFACT_REF: REF }
   assert.deepEqual(resolve('runner', local), { kind: 'build', ref: REF, refKey: 'RUNNER_ARTIFACT_REF', version: '1.2.3' })

--- a/apps/infra/scripts/release-deployment-safety.test.mjs
+++ b/apps/infra/scripts/release-deployment-safety.test.mjs
@@ -11,6 +11,8 @@ import { DEFAULT_SCHEMA, Type, load } from 'js-yaml'
 
 import { verifyDeployRoleGrantsBoundaryPermission } from './deploy-role-boundary.mjs'
 import { liveText } from './live-source.mjs'
+import { apiImageRepository } from './api-artifact.mjs'
+import { runnerArtifactsBucketName } from './runner-artifact.mjs'
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..')
 const SST_WRAPPER = join(REPO_ROOT, 'apps/infra/scripts/sst-with-cloudflare.mjs')
@@ -781,6 +783,7 @@ test('dev deploy role trusts only the repository GitHub Environment identity', (
     ],
     Resource: [
       'arn:${AWS::Partition}:s3:::boxlite-${GitHubEnvironment}-*',
+      'arn:${AWS::Partition}:s3:::boxlite-app-${GitHubEnvironment}-*',
       'arn:${AWS::Partition}:s3:::boxlite-volume-*',
     ],
   })
@@ -790,6 +793,7 @@ test('dev deploy role trusts only the repository GitHub Environment identity', (
     Action: ['s3:AbortMultipartUpload', 's3:DeleteObject', 's3:DeleteObjectVersion', 's3:GetObject', 's3:PutObject'],
     Resource: [
       'arn:${AWS::Partition}:s3:::boxlite-${GitHubEnvironment}-*/*',
+      'arn:${AWS::Partition}:s3:::boxlite-app-${GitHubEnvironment}-*/*',
       'arn:${AWS::Partition}:s3:::boxlite-volume-*/*',
     ],
   })
@@ -811,7 +815,7 @@ test('the stage bootstrap owns artifact stores needed before an SST deploy can s
     DeletionPolicy: 'Retain',
     UpdateReplacePolicy: 'Retain',
     Properties: {
-      RepositoryName: 'boxlite-${GitHubEnvironment}-api',
+      RepositoryName: 'boxlite-app-${GitHubEnvironment}-api',
       ImageTagMutability: 'IMMUTABLE',
       ImageScanningConfiguration: { ScanOnPush: true },
       EncryptionConfiguration: { EncryptionType: 'AES256' },
@@ -822,7 +826,7 @@ test('the stage bootstrap owns artifact stores needed before an SST deploy can s
     DeletionPolicy: 'Retain',
     UpdateReplacePolicy: 'Retain',
     Properties: {
-      BucketName: 'boxlite-${GitHubEnvironment}-artifacts-${AWS::AccountId}',
+      BucketName: 'boxlite-app-${GitHubEnvironment}-artifacts-${AWS::AccountId}',
       BucketEncryption: {
         ServerSideEncryptionConfiguration: [{ ServerSideEncryptionByDefault: { SSEAlgorithm: 'AES256' } }],
       },
@@ -858,4 +862,50 @@ test('one release selector resolves the API and Runner to the same published ver
   assert.match(source, /const runnerSource = resolveArtifactSource\('runner'\)/)
   assert.match(source, /await verifyRunnerArtifact\(runnerSource/)
   assert.doesNotMatch(source, /verifyRunnerReleaseAssets\(publicDeploymentConfig\.releaseVersion\)/)
+})
+
+test('every hand-written spelling of an artifact name agrees with the composer', () => {
+  // The defect this guards: the name is declared in CloudFormation, resolved in JS, and written
+  // by hand in the workflow that produces the artifact. Renaming the first two and not the last
+  // two leaves a bootstrap that creates boxlite-app-dev-api and a build that pushes to
+  // boxlite-dev-api — the workflow's own "repository is missing" guard fires and the deploy
+  // fails, with every unit test still green. CloudFormation and bash cannot import
+  // awsResourceName, so agreement is asserted here instead.
+  const template = readDeployTemplate()
+  const apiWorkflow = readFileSync(API_IMAGE_BUILD_WORKFLOW, 'utf8')
+  const deployWorkflow = readFileSync(DEPLOY_WORKFLOW, 'utf8')
+
+  const declaredRepository = template.Resources.ApiImagesRepository.Properties.RepositoryName
+  const declaredBucket = template.Resources.RunnerArtifactsBucket.Properties.BucketName
+  assert.equal(declaredRepository, 'boxlite-app-${GitHubEnvironment}-api')
+  assert.equal(declaredBucket, 'boxlite-app-${GitHubEnvironment}-artifacts-${AWS::AccountId}')
+
+  // Resolved: the same grammar, through the composer the deploy actually calls.
+  assert.equal(apiImageRepository({ app: 'boxlite', stage: 'dev' }), 'boxlite-app-dev-api')
+  assert.equal(
+    runnerArtifactsBucketName({ app: 'boxlite', stage: 'dev', accountId: '123456789012' }),
+    'boxlite-app-dev-artifacts-123456789012',
+  )
+
+  // Written by hand, in the two producers. Anchored per line so a commented-out spelling cannot
+  // satisfy the match, and the old shape is refused outright rather than merely not found.
+  assertShellLine(apiWorkflow, /boxlite-app-\$\{TARGET_STAGE\}-api/)
+  assertShellLine(apiWorkflow, /boxlite-app-\$\{SOURCE_STAGE\}-api/)
+  assertShellLine(deployWorkflow, /bucket="boxlite-app-\$\{STAGE\}-artifacts-\$\{account_id\}"/)
+  assert.doesNotMatch(liveShell(apiWorkflow), /boxlite-\$\{(TARGET|SOURCE)_STAGE\}-api/)
+  assert.doesNotMatch(liveShell(deployWorkflow), /boxlite-\$\{STAGE\}-artifacts/)
+})
+
+test('the runtime boundary admits the bucket the Runner is actually pointed at', () => {
+  // The boundary intersects with every identity policy SST writes, so a bucket outside its
+  // prefixes is denied however generous the grant. Renaming the bucket without widening the
+  // boundary denied the Runner its own binary — at boot and on every SSM upgrade — while every
+  // other test stayed green, because CI pushes with the deploy role's s3:* rather than the
+  // instance profile. Derive the name, do not spell it.
+  const bucket = runnerArtifactsBucketName({ app: 'boxlite', stage: 'dev', accountId: '123456789012' })
+  const prefixes = findStatement(readRuntimeBoundaryStatements(), 'BoxLiteBucketObjects').Resource.map((arn) =>
+    arn.replace('arn:${AWS::Partition}:s3:::', '').replace('${GitHubEnvironment}', 'dev'),
+  )
+  const admits = prefixes.some((pattern) => new RegExp(`^${pattern.replace(/\*/g, '.*')}$`).test(`${bucket}/runner/x`))
+  assert.ok(admits, `no BoxLiteBucketObjects prefix admits ${bucket}/runner/*; prefixes: ${prefixes.join(', ')}`)
 })

--- a/apps/infra/scripts/resource-name.mjs
+++ b/apps/infra/scripts/resource-name.mjs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+/*
+ * How the Api image repository and the Runner artifacts bucket are spelled.
+ *
+ *   <namespace>-<workload>-<stage>-<name>[-<attribute>...]
+ *
+ * The workload slot exists because the account holds more than one: the application stack, the
+ * ops console (boxlite-ops-console*), and the e2e fleet (boxlite-e2e-*). Without it nothing
+ * distinguishes a workload token from a stage — `boxlite-e2e-runner` reads equally as stage=e2e
+ * or workload=e2e — and a reader cannot parse a name back into its parts.
+ *
+ * Eight files touch one of these two names, but only THREE spell it, because they cannot call
+ * JavaScript: ci/github-deploy-role.yaml declares both, deploy-infra.yml writes the bucket into a
+ * shell variable, and build-apps-api-image.yml writes the image name. Everything else — this
+ * module's two callers and their callers — goes through awsResourceName and never re-spells the
+ * string. Those three are what release-deployment-safety.test.mjs pins, which is what turns a
+ * drift into a test failure instead of a deploy that cannot find its own artifact.
+ *
+ * A fourth place is easy to miss and is not a spelling at all: ci/github-deploy-role.yaml's
+ * runtime permissions boundary allows S3 by ARN prefix. A boundary intersects with every identity
+ * policy, so a bucket outside its prefixes is denied whatever the stack grants — renaming without
+ * widening it denied the Runner its own binary while every test stayed green.
+ *
+ * Deliberately NOT applied to the other AWS names this repository owns, each for its own reason:
+ *
+ *   boxlite-<stage>-github-deploy    live, and its ARN is stored in the dev GitHub environment
+ *                                    variable AWS_DEPLOY_ROLE_ARN, so renaming needs a re-bootstrap
+ *   boxlite-<stage>-runtime-boundary live, and attached as a permissions boundary to existing
+ *                                    roles, so renaming the policy is a migration
+ *   SST-managed resources            SST derives <app>-<stage>-<LogicalId>-<hash> from the app
+ *                                    name, so moving those means renaming the SST app and
+ *                                    replacing every resource it manages
+ *
+ * The first two are ordinary CloudFormation resources, not SST-named — they are excluded because
+ * they already exist and are referenced elsewhere, not because anything makes them unrenamable.
+ */
+
+// The application stack, as distinct from the ops-console and e2e workloads in the same account.
+const WORKLOAD = 'app'
+
+export function awsResourceName({ app, stage, name, attributes = [] }) {
+  return [app, WORKLOAD, stage, name, ...attributes].join('-')
+}

--- a/apps/infra/scripts/runner-artifact-build.test.mjs
+++ b/apps/infra/scripts/runner-artifact-build.test.mjs
@@ -52,8 +52,8 @@ test('builds Linux AMD64 with the commit in both the version and archive identit
 
   assert.equal(result.identity, `${VERSION}+${REF}`)
   assert.equal(result.archive, ARCHIVE)
-  assert.equal(result.bucket, `boxlite-dev-artifacts-${ACCOUNT}`)
-  assert.equal(result.prefix, `s3://boxlite-dev-artifacts-${ACCOUNT}/runner/${REF}`)
+  assert.equal(result.bucket, `boxlite-app-dev-artifacts-${ACCOUNT}`)
+  assert.equal(result.prefix, `s3://boxlite-app-dev-artifacts-${ACCOUNT}/runner/${REF}`)
   assert.equal(existsSync(result.outputDirectory), false, 'the temporary build output is removed after staging')
 
   const docker = calls.find((call) => call.command === 'docker')
@@ -173,7 +173,7 @@ test('the repository root is resolved from this module, not the caller working d
 
 test('the printed next step scopes the ref to the Runner it just staged', () => {
   // This stages a Runner and nothing else. Printing the global BOXLITE_ARTIFACT_REF would also
-  // point the Api at boxlite-<stage>-api:v<version>-<sha> — a tag only deploy-infra.yml pushes —
+  // point the Api at boxlite-app-<stage>-api:v<version>-<sha> — a tag only deploy-infra.yml pushes —
   // and the deploy would be refused at preflight with no image the developer could produce.
   // Read from source: main() runs only as a script, so nothing here can execute it.
   const source = readFileSync(fileURLToPath(new URL('./runner-artifact-build.mjs', import.meta.url)), 'utf8')

--- a/apps/infra/scripts/runner-artifact.mjs
+++ b/apps/infra/scripts/runner-artifact.mjs
@@ -24,6 +24,7 @@ import { promisify } from 'node:util'
 import { resolveAwsRegion } from './deployment-environment.mjs'
 import { resolveAwsCliPath } from './proxy-deployment-verify.mjs'
 import { resolveRunnerReleaseAssets, verifyRunnerReleaseAssets } from './runner-release-assets.mjs'
+import { awsResourceName } from './resource-name.mjs'
 
 const BUILD_ARTIFACT_BUCKET_KEY = 'RUNNER_ARTIFACT_BUCKET'
 // The S3 naming rules that matter here: lowercase, no underscores, 3-63 characters. Anything
@@ -37,7 +38,10 @@ const execFileAsync = promisify(execFile)
 // deploy that installs it — no stack output to read first. Derived in one place because two
 // callers need the same answer: the stack that creates it, and the preflight that reads it.
 export function runnerArtifactsBucketName({ app, stage, accountId }) {
-  const bucket = `${app}-${stage}-artifacts-${accountId}`
+  // The account id is an attribute, not part of the name: S3's namespace is global, so the
+  // bucket needs a qualifier no other account can claim. ECR is scoped per account and region
+  // already, which is why apiImageRepository takes none.
+  const bucket = awsResourceName({ app, stage, name: 'artifacts', attributes: [accountId] })
   if (!BUCKET_NAME.test(bucket)) {
     throw new Error(`artifact stage '${stage}' does not produce a valid S3 bucket name`)
   }

--- a/apps/infra/scripts/runner-artifact.test.mjs
+++ b/apps/infra/scripts/runner-artifact.test.mjs
@@ -76,7 +76,7 @@ esac`,
 test('the bootstrap, deploy preflight, and local stager derive one bucket name', () => {
   assert.equal(
     runnerArtifactsBucketName({ app: 'boxlite', stage: 'dev', accountId: '123456789012' }),
-    'boxlite-dev-artifacts-123456789012',
+    'boxlite-app-dev-artifacts-123456789012',
   )
   assert.throws(
     () => runnerArtifactsBucketName({ app: 'boxlite', stage: 'Feature_One', accountId: '123456789012' }),


### PR DESCRIPTION
## Summary

The account holds more than one workload — the application stack, the ops console,
the e2e fleet — but the names carry no slot for it, so nothing distinguishes a
workload token from a stage. `boxlite-e2e-runner` parses equally as `stage=e2e` or
`workload=e2e`.

This adds the slot for the two names that hold nothing yet, so the rename is a
recreate rather than a migration.

## Call graph

Before

```
runnerArtifactsBucketName  (fn · apps/infra/scripts/runner-artifact.mjs:40)  — spells the bucket name inline
  └─ buildRunnerUserData  (fn · apps/infra/sst.config.ts:858)  — bakes it into the instance fetch command
       └─ RunnerRolePolicy  (aws.iam.RolePolicy · apps/infra/sst.config.ts:916)  — grants s3:GetObject on it
            └─ BoxLiteBucketObjects  (IAM boundary Sid · apps/infra/ci/github-deploy-role.yaml:158)  ← BUG: allows only boxlite-<stage>-*/*, so a renamed bucket is denied by intersection while every test stays green

apiImageRepository  (fn · apps/infra/scripts/api-artifact.mjs:35)  — spells the repository name inline
  └─ Resolve publish operation  (workflow step · .github/workflows/build-apps-api-image.yml:196)  ← BUG: re-spells the same name by hand, so renaming one side trips the workflow's own "repository is missing" guard
```

After

```
awsResourceName  (fn · apps/infra/scripts/resource-name.mjs:38)  — the one composer
  ├─ runnerArtifactsBucketName  (fn · apps/infra/scripts/runner-artifact.mjs:44)  — derives, no longer spells
  │    └─ RunnerRolePolicy  (aws.iam.RolePolicy · apps/infra/sst.config.ts:916)  — grants s3:GetObject
  │         └─ BoxLiteBucketObjects  (IAM boundary Sid · apps/infra/ci/github-deploy-role.yaml:158)  — now admits boxlite-app-<stage>-*/*
  └─ apiImageRepository  (fn · apps/infra/scripts/api-artifact.mjs:36)  — derives, no longer spells

RunnerArtifactsBucket  (AWS::S3::Bucket · apps/infra/ci/github-deploy-role.yaml:40)  — declares the same grammar
ApiImagesRepository  (AWS::ECR::Repository · apps/infra/ci/github-deploy-role.yaml:27)  — declares the same grammar
Stage commit Runner artifact  (workflow step · .github/workflows/deploy-infra.yml:170)  — hand-written, pinned by test
Resolve publish operation  (workflow step · .github/workflows/build-apps-api-image.yml:196)  — hand-written, pinned by test
```

## Changes

- **One composer.** Eight files touch one of these names; only three *spell* it,
  because they cannot call JavaScript — the CloudFormation template and the two
  shell steps. Everything else goes through `awsResourceName`.
- **The permissions boundary had to move with the name.** `boxlite-app-<stage>-…`
  falls outside `boxlite-<stage>-*`, and that boundary is the `PermissionsBoundary`
  on 15 live roles including `boxlite-dev-runner`. Without widening it, the
  `s3:GetObject` grant reduces to Deny and the Runner cannot fetch its own binary —
  at boot and on every SSM upgrade. CI never sees it, because the deploy role holds
  `s3:*` on `*`.
- **Legacy prefixes kept.** `boxlite-dev-artifacts-…` and `boxlite-dev-db-backups-…`
  still exist; dropping the old prefix would strand them.
- **Not applied** to `boxlite-<stage>-github-deploy` (its ARN lives in the
  `AWS_DEPLOY_ROLE_ARN` environment variable, so renaming needs a re-bootstrap),
  `boxlite-<stage>-runtime-boundary` (attached to live roles), or the ~31
  SST-managed names (SST derives them from the app name, so moving them replaces
  every resource it manages, including roles attached to running services). Each
  reason is recorded in `resource-name.mjs`.

## How to verify

```
cd apps/infra && npm test
```

300/300. Two-sided, run manually:

- Remove only the `boxlite-app-<stage>-*/*` boundary ARN → `the runtime boundary
  admits the bucket the Runner is actually pointed at` and the boundary `deepEqual`
  both fail. Restore → 300/300.
- Revert the template, the resolver, or either workflow spelling independently →
  `every hand-written spelling of an artifact name agrees with the composer` fails
  in each case.

## Risks / rollout

**Ordering matters.** After merge the deployed CloudFormation stack still holds the
old names, so `main` briefly describes resources that do not exist. Before the next
dev deploy:

```
npm run bootstrap -- --stage dev
```

That creates `boxlite-app-dev-api` and `boxlite-app-dev-artifacts-<acct>`. Both
carry `DeletionPolicy: Retain` and `UpdateReplacePolicy: Retain`, so the old pair is
**orphaned, not deleted** — delete them by hand once a deploy has proved the new
names, not before.

Nothing fires automatically: all three AWS-touching workflows are
`workflow_dispatch`/`workflow_call` only. A dispatch before the re-bootstrap fails
fast on the workflow's own guard (`ECR repository … is missing`) rather than
half-deploying.

One bound this desynchronises without fixing: `boxlite-app-` costs four more
characters, so the real S3 stage budget drops from 32 to 28 while
`GitHubEnvironment` still declares `MaxLength: 32`. It fails loudly —
CloudFormation rejects the bucket at bootstrap, `runnerArtifactsBucketName` throws
at preflight — and no live stage exceeds four characters, so it is a follow-up
rather than a blocker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure**
  * Standardized API image repositories and Runner artifact buckets to use the `boxlite-app-` naming convention.
  * Updated deployment workflows and permissions to support the new resource names while maintaining compatibility with legacy resources.

* **Documentation**
  * Updated deployment and image naming guidance to reflect the new convention.

* **Tests**
  * Expanded validation to ensure consistent resource naming across build, deployment, CloudFormation, and access-control configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->