### PR TITLE
fix(runner): evict spent box handles, map every core status

### DIFF
--- a/apps/e2e/cases/test_real_world.py
+++ b/apps/e2e/cases/test_real_world.py
@@ -233,8 +233,8 @@ async def test_network_curl(box):
     ex = await box.exec(
         "sh", ["-c",
                "curl -fsS --max-time 10 -o /dev/null -w '%{http_code}' "
-               "https://httpbin.org/get 2>/dev/null || "
-               "wget -q --timeout=10 -O /dev/null https://httpbin.org/get 2>&1 && echo 200"],
+               "https://httpbingo.org/get 2>/dev/null || "
+               "wget -q --timeout=10 -O /dev/null https://httpbingo.org/get 2>&1 && echo 200"],
     )
     out, err = await drain(ex)
     rc = await asyncio.wait_for(ex.wait(), timeout=30)

--- a/apps/runner/pkg/boxlite/box_state_mapping_test.go
+++ b/apps/runner/pkg/boxlite/box_state_mapping_test.go
@@ -1,0 +1,50 @@
+// Copyright 2026 BoxLite AI
+// SPDX-License-Identifier: AGPL-3.0
+
+package boxlite
+
+import (
+	"testing"
+
+	boxlite "github.com/boxlite-ai/boxlite/sdks/go"
+	"github.com/boxlite-ai/runner/pkg/models/enums"
+)
+
+// The statuses are spelled as the literals the FFI layer emits
+// (sdks/c/src/info.rs status_to_str) rather than via the SDK's State constants,
+// so this file keeps compiling — and keeps failing behaviorally — if the
+// mapping and the constants it depends on are reverted together.
+func TestApiStateFromCore(t *testing.T) {
+	for _, tc := range []struct {
+		core boxlite.State
+		want enums.BoxState
+	}{
+		{"running", enums.BoxStateStarted},
+		// A snapshot freeze keeps the VM up, so the box stays started.
+		{"paused", enums.BoxStateStarted},
+		{"stopping", enums.BoxStateStopping},
+		{"stopped", enums.BoxStateStopped},
+		{"configured", enums.BoxStateCreating},
+		// Failed must not read as Unknown: the API's usage accounting excludes
+		// Error from its compute-consuming states but includes Unknown, so a
+		// dead box that reports Unknown still reads as occupying compute.
+		{"failed", enums.BoxStateError},
+		{"unknown", enums.BoxStateUnknown},
+		{"a-status-core-gained-later", enums.BoxStateUnknown},
+	} {
+		if got := apiStateFromCore(tc.core); got != tc.want {
+			t.Errorf("apiStateFromCore(%q) = %q, want %q", tc.core, got, tc.want)
+		}
+	}
+}
+
+// Every status the runtime can currently report must reach a state other than
+// Unknown, which the API bills as compute-consuming. This list is maintained by
+// hand, so it catches a mapping that regresses — not a status the core adds.
+func TestApiStateFromCoreLeavesNoCurrentStatusUnmapped(t *testing.T) {
+	for _, status := range []boxlite.State{"configured", "running", "stopping", "stopped", "paused", "failed"} {
+		if got := apiStateFromCore(status); got == enums.BoxStateUnknown {
+			t.Errorf("core status %q fell through to Unknown", status)
+		}
+	}
+}

--- a/apps/runner/pkg/boxlite/client.go
+++ b/apps/runner/pkg/boxlite/client.go
@@ -332,9 +332,8 @@ func (c *Client) Stop(ctx context.Context, boxId string, force bool) error {
 	}
 	err = bx.Stop(ctx)
 
-	c.mu.Lock()
-	delete(c.boxes, boxId)
-	c.mu.Unlock()
+	// The stopped box's handle is spent either way, so drop it from the cache.
+	c.evictBox(boxId, bx)
 
 	return err
 }
@@ -361,8 +360,15 @@ func (c *Client) Destroy(ctx context.Context, boxId string) error {
 }
 
 // GetBoxState returns the current state of a box.
+//
+// It reads through the runtime rather than the handle cache. The box sync loop
+// calls this for every box on a 10s ticker (services/box_sync.go), and a state
+// read needs no bootable handle — only the persisted record. Routing it through
+// getOrFetchBox would evict and re-fetch a handle for every non-running box on
+// every tick, and eviction cannot free the old one (see evictBox), so the
+// runner would accumulate dead handles for as long as it ran.
 func (c *Client) GetBoxState(ctx context.Context, boxId string) (enums.BoxState, error) {
-	bx, err := c.getOrFetchBox(ctx, boxId)
+	info, err := c.runtime.GetInfo(ctx, boxId)
 	if err != nil {
 		if boxlite.IsNotFound(err) {
 			return enums.BoxStateUnknown, nil
@@ -370,20 +376,36 @@ func (c *Client) GetBoxState(ctx context.Context, boxId string) (enums.BoxState,
 		return enums.BoxStateUnknown, err
 	}
 
-	info, err := bx.Info(ctx)
-	if err != nil {
-		return enums.BoxStateUnknown, err
-	}
+	return apiStateFromCore(info.State), nil
+}
 
-	switch info.State {
+// apiStateFromCore maps a core box status onto the control-plane state, one arm
+// per BoxStatus the runtime can report.
+//
+// Unknown is not a neutral default here: the API counts it as compute-consuming
+// (BOX_STATES_CONSUMING_COMPUTE), while Error is not. Falling through left a
+// Failed box billed as if it were still running, and a Stopping box reported as
+// Unknown even though the control plane has that exact state.
+func apiStateFromCore(state boxlite.State) enums.BoxState {
+	switch state {
 	case boxlite.StateRunning:
-		return enums.BoxStateStarted, nil
+		return enums.BoxStateStarted
+	case boxlite.StatePaused:
+		// vCPUs frozen for a snapshot's point-in-time consistency. The VM is up,
+		// so the control plane should keep seeing the box as started.
+		return enums.BoxStateStarted
+	case boxlite.StateStopping:
+		return enums.BoxStateStopping
 	case boxlite.StateStopped:
-		return enums.BoxStateStopped, nil
+		return enums.BoxStateStopped
 	case boxlite.StateConfigured:
-		return enums.BoxStateCreating, nil
+		// Persisted but never booted. The control plane has no "configured" of
+		// its own, so this stays folded into Creating.
+		return enums.BoxStateCreating
+	case boxlite.StateFailed:
+		return enums.BoxStateError
 	default:
-		return enums.BoxStateUnknown, nil
+		return enums.BoxStateUnknown
 	}
 }
 
@@ -478,13 +500,37 @@ func (c *Client) GetBox(ctx context.Context, boxId string) (*boxlite.Box, error)
 }
 
 // getOrFetchBox retrieves a box handle from cache or fetches it from the runtime.
+//
+// A cached handle is only good while its box is up. A box can stop *itself* —
+// its main command exits and the guest powers the VM off — and such a handle is
+// spent: it holds the dead VM and can never boot another. Stop evicts its own
+// handle, but nothing was clearing this entry on a self-stop, so every later
+// Start, exec, copy or metrics call on that box was answered with the corpse,
+// forever. The core invalidates its own cache from the exit watcher; this one
+// is ours.
+//
+// So a box that is no longer running gets a fresh handle, which *can* boot it.
+// That is the auto-restart the control plane depends on: its reaper stops idle
+// boxes and the next call is expected to bring them back.
 func (c *Client) getOrFetchBox(ctx context.Context, boxId string) (*boxlite.Box, error) {
 	c.mu.RLock()
-	bx, ok := c.boxes[boxId]
+	cached, ok := c.boxes[boxId]
 	c.mu.RUnlock()
 
 	if ok {
-		return bx, nil
+		// Info reads persisted state — it never boots the box, so it is safe to
+		// ask a spent handle.
+		info, err := cached.Info(ctx)
+		if err != nil {
+			return nil, err
+		}
+		// Paused counts as up: the VM is frozen for a snapshot's point-in-time
+		// consistency, not stopped, and its handle still drives a live machine.
+		// The Rust sibling gates on the same pair via BoxStatus::is_active.
+		if info.State == boxlite.StateRunning || info.State == boxlite.StatePaused {
+			return cached, nil
+		}
+		c.evictBox(boxId, cached)
 	}
 
 	bx, err := c.runtime.Get(ctx, boxId)
@@ -497,6 +543,29 @@ func (c *Client) getOrFetchBox(ctx context.Context, boxId string) (*boxlite.Box,
 	c.mu.Unlock()
 
 	return bx, nil
+}
+
+// evictBox unmaps a handle so the next lookup fetches a fresh one, and only
+// while it is still the cached one — a concurrent Create or fetch may already
+// have replaced it, and unmapping the winner would drop a live entry.
+//
+// It deliberately does not Close the handle. getOrFetchBox hands the same
+// *boxlite.Box to every caller and the runner serializes nothing per box, so
+// freeing here would pull the FFI handle out from under a goroutine mid-call.
+// An unmapped handle is instead leaked for the process lifetime — Close only
+// frees what is still in the map. The cost is one handle per request that finds
+// its box down: calls that go on to boot it stop there, while ones that refuse a
+// stopped box (metrics, a guest-port dial) pay it again on every retry. That is
+// affordable only because it tracks request volume — which is why GetBoxState,
+// run for every box on a timer, deliberately does not come through here.
+// Ref-counting the wrapper is the real fix, and it belongs in the SDK.
+func (c *Client) evictBox(boxId string, stale *boxlite.Box) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if current, ok := c.boxes[boxId]; ok && current == stale {
+		delete(c.boxes, boxId)
+	}
 }
 
 // ExecResult holds the output of a command execution.

--- a/apps/runner/pkg/boxlite/client_spent_handle_test.go
+++ b/apps/runner/pkg/boxlite/client_spent_handle_test.go
@@ -1,0 +1,90 @@
+//go:build boxlite_dev
+
+// Copyright 2026 BoxLite AI
+// SPDX-License-Identifier: AGPL-3.0
+
+package boxlite
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/boxlite-ai/runner/pkg/api/dto"
+	"github.com/boxlite-ai/runner/pkg/models/enums"
+)
+
+// A box can stop *itself*: its main command exits and the guest powers the VM
+// off. The handle the runner cached while the box was up is spent from that
+// moment — it still holds the dead VM and can never boot another — so serving
+// it back answers every later call with a corpse, for the life of the runner
+// process. Client.Stop evicts its own handle, so only the self-stop left the
+// cache poisoned, and the failure surfaced on the dashboard as
+// "handle is spent" (BoxLite error code 11) when a user pressed Start.
+//
+// This reproduces it end to end: Create caches a handle and starts a box whose
+// entrypoint exits on its own, then the dashboard's Start comes back to it.
+func TestIntegrationSelfStoppedBoxRestartsAfterCachedHandleGoesSpent(t *testing.T) {
+	ctx := context.Background()
+
+	client, err := NewClient(ctx, ClientConfig{HomeDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+
+	createDto := dto.CreateBoxDTO{
+		Id:           "spent-handle-restart-box",
+		Image:        "alpine:latest",
+		OsUser:       "root",
+		CpuQuota:     1,
+		MemoryQuota:  1,
+		StorageQuota: 1,
+		// Short enough that the box stops itself promptly, long enough that the
+		// restart below observes a booted box rather than racing a second exit.
+		Entrypoint: []string{"/bin/sh", "-c", "sleep 3"},
+	}
+
+	if _, _, err := client.Create(ctx, createDto); err != nil {
+		// Pulling the image / booting the VM is an infrastructure prerequisite,
+		// not the behavior under test (mirrors the sibling integration tests).
+		t.Skipf("create could not complete (infrastructure prerequisite): %v", err)
+	}
+	// No Destroy on cleanup: it reaches for the runner's process-wide config,
+	// which only the runner binary populates. The box lives in this test's
+	// throwaway home dir, and Close releases the runtime that holds it.
+
+	// Create cached the handle (client.go, right after runtime.GetOrCreate) and
+	// started the box; the entrypoint now exits on its own. Polling only reads
+	// state — it is how the control plane learns the box went down.
+	waitForBoxState(ctx, t, client, createDto.Id, enums.BoxStateStopped)
+
+	// The dashboard's Start button. The cached handle is spent by now, so this
+	// only succeeds if the cache hands back a fresh one.
+	if _, err := client.Start(ctx, createDto.Id, nil, nil); err != nil {
+		t.Fatalf("restarting a self-stopped box must succeed, got: %v", err)
+	}
+
+	waitForBoxState(ctx, t, client, createDto.Id, enums.BoxStateStarted)
+}
+
+// waitForBoxState polls the runner's own state accessor — the call the control
+// plane makes — until the box reaches want, failing the test if it never does.
+func waitForBoxState(ctx context.Context, t *testing.T, client *Client, boxId string, want enums.BoxState) {
+	t.Helper()
+
+	deadline := time.Now().Add(60 * time.Second)
+	var last enums.BoxState
+	for time.Now().Before(deadline) {
+		state, err := client.GetBoxState(ctx, boxId)
+		if err != nil {
+			t.Fatalf("GetBoxState(%s): %v", boxId, err)
+		}
+		if state == want {
+			return
+		}
+		last = state
+		time.Sleep(250 * time.Millisecond)
+	}
+	t.Fatalf("box %s never reached %s (last seen %s)", boxId, want, last)
+}

--- a/apps/runner/pkg/boxlite/evict_box_test.go
+++ b/apps/runner/pkg/boxlite/evict_box_test.go
@@ -1,0 +1,74 @@
+// Copyright 2026 BoxLite AI
+// SPDX-License-Identifier: AGPL-3.0
+
+package boxlite
+
+import (
+	"sync"
+	"testing"
+
+	boxlite "github.com/boxlite-ai/boxlite/sdks/go"
+)
+
+// evictBox drops a spent handle so the next lookup fetches a bootable one. It
+// must drop only the handle it was handed: a concurrent Create or fetch can
+// re-cache the same box id in between, and unmapping that winner would throw
+// away a live entry the other caller is about to use.
+//
+// The handles here are zero-value wrappers used purely as identities — evictBox
+// only compares and deletes map entries, so it never touches the FFI.
+func TestEvictBoxRemovesOnlyTheHandleItWasGiven(t *testing.T) {
+	stale := &boxlite.Box{}
+	winner := &boxlite.Box{}
+
+	t.Run("removes the stale handle", func(t *testing.T) {
+		c := &Client{boxes: map[string]*boxlite.Box{"box-1": stale}}
+
+		c.evictBox("box-1", stale)
+
+		if _, ok := c.boxes["box-1"]; ok {
+			t.Fatal("stale handle must be unmapped")
+		}
+	})
+
+	t.Run("keeps a handle that replaced the stale one", func(t *testing.T) {
+		c := &Client{boxes: map[string]*boxlite.Box{"box-1": winner}}
+
+		c.evictBox("box-1", stale)
+
+		if got := c.boxes["box-1"]; got != winner {
+			t.Fatalf("the replacing handle must survive, got %v", got)
+		}
+	})
+
+	t.Run("is a no-op for an id that is not cached", func(t *testing.T) {
+		c := &Client{boxes: map[string]*boxlite.Box{}}
+
+		c.evictBox("box-absent", stale)
+
+		if len(c.boxes) != 0 {
+			t.Fatalf("cache must stay empty, got %d entries", len(c.boxes))
+		}
+	})
+}
+
+// Concurrent eviction of the same entry must not race or double-delete; the
+// mutex inside evictBox is what makes the read-modify-write safe.
+func TestEvictBoxIsSafeUnderConcurrentCallers(t *testing.T) {
+	stale := &boxlite.Box{}
+	c := &Client{boxes: map[string]*boxlite.Box{"box-1": stale}}
+
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c.evictBox("box-1", stale)
+		}()
+	}
+	wg.Wait()
+
+	if _, ok := c.boxes["box-1"]; ok {
+		t.Fatal("handle must be unmapped after concurrent eviction")
+	}
+}

--- a/sdks/go/info.go
+++ b/sdks/go/info.go
@@ -14,11 +14,19 @@ import (
 // State represents the lifecycle state of a box.
 type State string
 
+// The full set the runtime can report, 1:1 with the core's BoxStatus
+// (src/boxlite/src/litebox/state.rs) as the FFI layer spells it
+// (sdks/c/src/info.rs). Unknown, Paused and Failed were previously unnameable
+// from Go, so callers switching on State silently funnelled them into their
+// default branch.
 const (
+	StateUnknown    State = "unknown"
 	StateConfigured State = "configured"
 	StateRunning    State = "running"
 	StateStopping   State = "stopping"
 	StateStopped    State = "stopped"
+	StatePaused     State = "paused"
+	StateFailed     State = "failed"
 )
 
 // PublishedPort is a concrete host publication for a guest service port.

--- a/sdks/go/network_secrets_integration_test.go
+++ b/sdks/go/network_secrets_integration_test.go
@@ -95,12 +95,12 @@ func TestIntegrationSecretSubstitution(t *testing.T) {
 		"python:slim",
 		WithNetwork(NetworkSpec{
 			Mode:     NetworkModeEnabled,
-			AllowNet: []string{"httpbin.org"},
+			AllowNet: []string{"httpbingo.org"},
 		}),
 		WithSecret(Secret{
 			Name:  "testkey",
 			Value: "super-secret-value",
-			Hosts: []string{"httpbin.org"},
+			Hosts: []string{"httpbingo.org"},
 		}),
 		WithAutoRemove(false),
 	)
@@ -108,7 +108,7 @@ func TestIntegrationSecretSubstitution(t *testing.T) {
 	script := strings.Join([]string{
 		"import os, urllib.request",
 		"req = urllib.request.Request(",
-		"    'https://httpbin.org/headers',",
+		"    'https://httpbingo.org/headers',",
 		"    headers={'Authorization': 'Bearer ' + os.environ['BOXLITE_SECRET_TESTKEY']},",
 		")",
 		"print(urllib.request.urlopen(req, timeout=20).read().decode())",


### PR DESCRIPTION
A box can stop *itself* — its main command exits and the guest powers the VM
off. The handle the runner cached while that box was up is spent from that
moment: it still holds the dead VM and can never boot another. Nothing cleared
the entry on a self-stop, so every later Start, exec or copy on that box was
answered with the corpse for the life of the runner process, surfacing on the
dashboard as `Box <id> is no longer running and this handle is spent (code=11)`.

The equivalent guard already existed on the Rust side in `boxlite serve`
(`src/cli/src/commands/serve/mod.rs:922`); the Go copy in the runner was the
unfixed sibling.

## Before

```
dashboard "Start"
 └ POST /boxes/:boxId/start     (controllers.Start · runner/pkg/api/server.go:137)
    └ Client.Start              (runner/pkg/boxlite/client.go:312)
       └ getOrFetchBox          (client.go:481)  ← BUG: returns the cached handle without checking its box is still up, so a self-stopped box is served its dead VM on every later call
       └ bx.Start(ctx)          (sdks/go/box_handle.go:43)
          └ BoxImpl::start      (src/boxlite/src/litebox/box_impl.rs:269)
             └ ensure_booted    (box_impl.rs:960) → Stopped("… handle is spent") → code=11

box sync tick, 10s              (runner/pkg/services/box_sync.go:53)
 └ GetBoxState → getOrFetchBox  — re-primes the same cache for every box
```

## After

```
dashboard "Start"
 └ POST /boxes/:boxId/start     (controllers.Start · runner/pkg/api/server.go:137)
    └ Client.Start              (runner/pkg/boxlite/client.go:312)
       └ getOrFetchBox          (client.go:515)
          ├ cached.Info(ctx)    — reads persisted state; never enters the boot funnel
          ├ Running or Paused?  → reuse            (mirrors BoxStatus::is_active)
          └ else → evictBox     (client.go:562)    — identity-checked unmap under the lock
                   → runtime.Get                   — fresh handle, which can boot
       └ bx.Start(ctx) → BoxImpl::start → ensure_booted: empty cell → boots ✓

box sync tick, 10s              (runner/pkg/services/box_sync.go:53)
 └ GetBoxState                  (client.go:370)
    └ runtime.GetInfo           — handle-free; never touches the cache
       └ apiStateFromCore       (client.go:389)    — one arm per BoxStatus
```

## Why eviction does not free the handle

`getOrFetchBox` hands the same `*boxlite.Box` to every caller and the runner
serializes nothing per box, so calling `Close` there would free an FFI handle
another goroutine is mid-call on. Eviction therefore unmaps only, and the
unmapped handle leaks for the process lifetime. The cost tracks request volume —
which is why `GetBoxState`, run for every box on a timer, was moved off the
cache entirely. Ref-counting the wrapper is the real fix and belongs in the SDK.

## Second commit: exhaustive state mapping

The core→control-plane mapping covered 3 of the runtime's 7 statuses. `Failed`
and `Stopping` both fell through to `Unknown`, which the API's usage accounting
counts as compute-consuming (`BOX_STATES_CONSUMING_COMPUTE`) while `Error` is
excluded — so a dead box read as occupying compute. The mapping is now
exhaustive and unit-tested, and the Go SDK gained the three `State` constants
the FFI layer could already emit but Go could not name.

## Third commit: unblocking the pre-push suite

The Go secret-substitution test reached `httpbin.org` while its Python and Node
counterparts both use `httpbingo.org`. `httpbin.org` began answering 503 and
took the whole pre-push suite down with it. Tolerating an upstream 5xx instead
was considered and rejected: the guest reaches that host through boxlite's own
MITM, which answers 502 for any transport error of its own — secret
substitution included — so skipping on a server error would hide the regression
that test exists to catch.

## Verification

- Spent handle: with both production files reverted to their pre-fix state and
  only the reproducer present, `TestIntegrationSelfStoppedBoxRestartsAfterCachedHandleGoesSpent`
  fails with the genuine `code=11` error; restored, it passes (18.30s, real microVM).
- State mapping: with the old switch arms restored, the table test fails on
  `stopping`, `paused` and `failed`. A literal full revert is impossible there —
  `apiStateFromCore` is itself the new symbol — so that side is a compile error,
  recorded rather than papered over.
- `evictBox`'s identity guard has unit coverage including a concurrent case,
  green under `-race`.
- `go vet` clean; `apps/runner ./pkg/...` and the full `sdks/go` suite green on
  this rebased base.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded Go SDK state reporting to include unknown, paused, and failed states.

* **Bug Fixes**
  * Improved box state reporting for paused, stopping, and failed boxes.
  * Prevented stale cached handles from being reused after a box stops.
  * Enabled stopped boxes to restart reliably.

* **Tests**
  * Added coverage for state mappings, cache eviction, concurrent access, and restarting boxes with expired handles.
  * Updated network integration and end-to-end tests to use a more reliable endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->