### PR TITLE
fix(infra): stop the wrapper tests inheriting artifact selectors

### DIFF
--- a/apps/infra/scripts/sst-event-log-security.test.mjs
+++ b/apps/infra/scripts/sst-event-log-security.test.mjs
@@ -35,6 +35,26 @@ async function fileExists(filePath) {
   }
 }
 
+// These tests spawn the deploy wrapper and drive it with stubbed `aws`/`curl`/`sst` binaries, so
+// the artifact mode they exercise has to be the one they state — never one inherited from the
+// shell they happen to run in. `npm test` runs inside deploy-infra.yml's deploy job, which exports
+// all four selectors at job scope; inheriting them puts the wrapper in build mode, where the Api
+// preflight looks up a commit image, gets nothing back from the stubbed `aws`, and throws ~300ms
+// in — before the release path these fixtures were written for is ever reached. The failure reads
+// as a timeout because waitFor is still polling for a file the wrapper died before writing.
+const ARTIFACT_SELECTOR_KEYS = [
+  'BOXLITE_ARTIFACT_SOURCE',
+  'API_ARTIFACT_SOURCE',
+  'RUNNER_ARTIFACT_SOURCE',
+  'BOXLITE_ARTIFACT_REF',
+  'API_ARTIFACT_REF',
+  'RUNNER_ARTIFACT_REF',
+]
+
+function inheritedEnvironment() {
+  return Object.fromEntries(Object.entries(process.env).filter(([key]) => !ARTIFACT_SELECTOR_KEYS.includes(key)))
+}
+
 async function waitFor(predicate, description, timeoutMs = 5_000) {
   const deadline = Date.now() + timeoutMs
   while (Date.now() < deadline) {
@@ -133,7 +153,7 @@ setInterval(() => {}, 1_000)
   const wrapper = spawn(process.execPath, ['scripts/sst-with-cloudflare.mjs', 'synthetic-test', '--stage', 'ci'], {
     cwd: new URL('..', import.meta.url),
     env: {
-      ...process.env,
+      ...inheritedEnvironment(),
       PATH: `${fakeBin}:${process.env.PATH}`,
       SST_BIN_PATH: fakeSst,
       CLOUDFLARE_API_TOKEN: 'synthetic-cloudflare-token',
@@ -200,7 +220,7 @@ setInterval(() => {}, 1_000)
   const wrapper = spawn(process.execPath, ['scripts/sst-with-cloudflare.mjs', 'synthetic-test', '--stage', 'ci'], {
     cwd: new URL('..', import.meta.url),
     env: {
-      ...process.env,
+      ...inheritedEnvironment(),
       PATH: `${fakeBin}:${process.env.PATH}`,
       SST_BIN_PATH: fakeSst,
       CLOUDFLARE_API_TOKEN: 'synthetic-cloudflare-token',
@@ -264,7 +284,7 @@ setInterval(() => {}, 1_000)
   const wrapper = spawn(process.execPath, ['scripts/sst-with-cloudflare.mjs', 'synthetic-test', '--stage', 'ci'], {
     cwd: new URL('..', import.meta.url),
     env: {
-      ...process.env,
+      ...inheritedEnvironment(),
       PATH: `${fakeBin}:${process.env.PATH}`,
       SST_BIN_PATH: fakeSst,
       CLOUDFLARE_API_TOKEN: 'synthetic-cloudflare-token',
@@ -331,7 +351,7 @@ if (args[0] === 'state' && args[1] === 'export') {
   const wrapper = spawn(process.execPath, ['scripts/sst-with-cloudflare.mjs', 'diff', '--stage', 'ci'], {
     cwd: infraRoot,
     env: {
-      ...process.env,
+      ...inheritedEnvironment(),
       PATH: `${fakeBin}:${process.env.PATH}`,
       SST_BIN_PATH: fakeSst,
       CLOUDFLARE_API_TOKEN: 'synthetic-cloudflare-token',
@@ -386,7 +406,7 @@ setInterval(() => {}, 1_000)
   const wrapper = spawn(process.execPath, ['scripts/sst-with-cloudflare.mjs', 'diff', '--stage', 'ci'], {
     cwd: infraRoot,
     env: {
-      ...process.env,
+      ...inheritedEnvironment(),
       PATH: `${fakeBin}:${process.env.PATH}`,
       SST_BIN_PATH: fakeSst,
       CLOUDFLARE_API_TOKEN: 'synthetic-cloudflare-token',
@@ -454,7 +474,7 @@ setInterval(() => {}, 1_000)
   const wrapper = spawn(process.execPath, ['scripts/sst-with-cloudflare.mjs', 'deploy', '--stage', 'ci'], {
     cwd: new URL('..', import.meta.url),
     env: {
-      ...process.env,
+      ...inheritedEnvironment(),
       PATH: `${fakeBin}:${process.env.PATH}`,
       AWS_CLI_PATH: fakeAws,
       SST_BIN_PATH: fakeSst,
@@ -506,7 +526,7 @@ test('rejects an argument delimiter before guarded SST commands start', async ()
 
   const wrapper = spawn(process.execPath, ['scripts/sst-with-cloudflare.mjs', 'diff', '--stage', 'ci', '--'], {
     cwd: new URL('..', import.meta.url),
-    env: { ...process.env, SST_BIN_PATH: fakeSst },
+    env: { ...inheritedEnvironment(), SST_BIN_PATH: fakeSst },
     stdio: 'ignore',
   })
 


### PR DESCRIPTION
## Summary

`deploy-infra.yml`'s deploy job cannot complete: `Run deployment safety tests` fails
on `interrupts Runner release preflight without starting SST`, reported as a
five-second timeout. The tests spawn the deploy wrapper with `...process.env`, and
`npm test` runs inside that job — so the wrapper inherits the job's artifact
selectors and takes a mode the fixture never intended.

## Call graph

Before

```
Run deployment safety tests  (workflow step · .github/workflows/deploy-infra.yml:218)  — inherits the job env set at :125-128
  └─ spawn wrapper  (test · apps/infra/scripts/sst-event-log-security.test.mjs:474)  ← BUG: spreads ...process.env, so the child inherits ARTIFACT_SOURCE=build and BOXLITE_ARTIFACT_REF
       └─ verifyApiImage  (fn · apps/infra/scripts/sst-with-cloudflare.mjs:234)  ← BUG: build+ref makes it look up a commit image; the stubbed aws returns nothing, so it throws ~300ms in
            └─ waitFor  (fn · apps/infra/scripts/sst-event-log-security.test.mjs:38)  — polls 5s for a file the wrapper died before writing, so an early exit reads as slowness
```

After

```
Run deployment safety tests  (workflow step · .github/workflows/deploy-infra.yml:218)  — job env unchanged
  └─ inheritedEnvironment  (fn · apps/infra/scripts/sst-event-log-security.test.mjs:54)  — drops the six mode/ref selector keys
       └─ spawn wrapper  (test · apps/infra/scripts/sst-event-log-security.test.mjs:477)  — each spawn states its own mode
            └─ verifyApiImage  (fn · apps/infra/scripts/sst-with-cloudflare.mjs:234)  — no longer entered on an inherited ref
```

Fixes #1139

## Changes

- `inheritedEnvironment()` strips `BOXLITE_ARTIFACT_SOURCE`, `API_ARTIFACT_SOURCE`,
  `RUNNER_ARTIFACT_SOURCE` and the three matching `*_ARTIFACT_REF` keys, and is used
  at all seven wrapper spawns in the file.
- Only the `deploy` spawn can actually reach the artifact preflight —
  `sst-with-cloudflare.mjs:216` gates it on the subcommand, so the `synthetic-test`
  and `diff` spawns route elsewhere and pass either way. The other six are filtered
  because the leak is uniform and the next test that drives `deploy` would inherit
  it too.
- Both the source keys and the per-component refs are listed, so a mode added later
  cannot re-enter the same way.

## How to verify

```
cd apps/infra && npm test
```

300/300. The discriminator is the environment, not the diff — a clean shell never
exercises the filter. Export what the deploy job exports:

```
BOXLITE_ARTIFACT_SOURCE=build API_ARTIFACT_SOURCE=build \
RUNNER_ARTIFACT_SOURCE=build BOXLITE_ARTIFACT_REF=<40-hex> \
  node --test apps/infra/scripts/sst-event-log-security.test.mjs
```

On `main` that is 12/13, failing the release-preflight test at ~5s. With this
change, 13/13 — and the full suite stays 300/300 under the same env.

## Risks / rollout

Fixture-only; no production path changes. A real deploy resolves the real AWS CLI
and does a real ECR lookup, so the preflight itself was never wrong — only the
test's assumption that its own environment was clean.

Known and deliberately not fixed here: the wrapper calls
`loadDeploymentEnvironment()` itself, and dotenv's `override: false` means a local
`apps/infra/.env` can still fill selectors this filter leaves unset. That is inert
in CI, where `.env` is written after the test step, but a developer working in build
mode locally can still hit the same confusing timeout. Sealing it means changing
production wrapper behaviour, which is outside this change.

This unblocks the deploy job's first gate only. `Preview the full stack` has not run
since before the selectors were introduced, so what it does next is unverified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test reliability by preventing inherited artifact-selection settings from affecting SST, AWS, and curl test processes.
  * Ensured test commands run with a consistent, sanitized environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->