### PR TITLE
fix(migrations): repair box.autoStop column drift from #1135

### DIFF
--- a/apps/api/src/migrations/pre-deploy/1785900000000-fix-box-auto-stop-column-drift-migration.ts
+++ b/apps/api/src/migrations/pre-deploy/1785900000000-fix-box-auto-stop-column-drift-migration.ts
@@ -1,0 +1,46 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+/**
+ * Repairs environments where `AddBoxLifecycleSeconds1784250000000` already
+ * executed before it was amended (#1135) to rename straight to `autoStop`.
+ * TypeORM tracks migrations by class name, so an environment that ran the
+ * earlier revision keeps whatever intermediate column name that revision
+ * produced (`autoPause`, or the older `autoStopInterval`) and never
+ * re-runs the amended version — the code has expected `autoStop` since
+ * #1135 landed, so any of those environments fail closed with
+ * "column ... does not exist" on every box operation.
+ *
+ * Idempotent and safe on a fresh database: if `autoStop` already exists,
+ * both branches below are skipped.
+ */
+export class FixBoxAutoStopColumnDrift1785900000000 implements MigrationInterface {
+  name = 'FixBoxAutoStopColumnDrift1785900000000'
+
+  private async hasColumn(queryRunner: QueryRunner, column: string): Promise<boolean> {
+    const rows = await queryRunner.query(
+      `SELECT 1 FROM information_schema.columns WHERE table_name = 'box' AND column_name = $1`,
+      [column],
+    )
+    return rows.length > 0
+  }
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    if (await this.hasColumn(queryRunner, 'autoPause')) {
+      await queryRunner.query(`ALTER TABLE "box" RENAME COLUMN "autoPause" TO "autoStop"`)
+    } else if (await this.hasColumn(queryRunner, 'autoStopInterval')) {
+      await queryRunner.query(`ALTER TABLE "box" RENAME COLUMN "autoStopInterval" TO "autoStop"`)
+    }
+
+    await queryRunner.query(`ALTER TABLE "box" DROP CONSTRAINT IF EXISTS "box_auto_pause_interval_nonnegative"`)
+    await queryRunner.query(`ALTER TABLE "box" DROP CONSTRAINT IF EXISTS "box_auto_stop_interval_nonnegative"`)
+    await queryRunner.query(
+      `ALTER TABLE "box" ADD CONSTRAINT "box_auto_stop_interval_nonnegative" CHECK ("autoStop" >= 0)`,
+    )
+  }
+
+  public async down(): Promise<void> {
+    // Pure drift repair — there is no single prior name to roll back to
+    // (different environments drifted to different names), and a
+    // consistent database never needs this migration reverted.
+  }
+}


### PR DESCRIPTION
## Summary

#1135 amended the unreleased pre-deploy migration `AddBoxLifecycleSeconds1784250000000` in place to rename straight to `autoStop`. TypeORM tracks migrations by class name, not content — any environment that already ran the pre-amend revision keeps the old column name (`autoPause`, or the older `autoStopInterval`) and silently never re-runs the amended version, since it's already recorded as applied.

This is exactly what broke `dev`: every box query against that column now fails with `column ... does not exist`, surfaced to clients as a generic 500 — including lookups by a nonexistent box ID, which 500 instead of 404 because the SQL error fires before the "not found" check ever runs.

This adds an idempotent follow-up migration that detects whichever name is still on disk (`autoPause` or `autoStopInterval`) and repairs it to `autoStop`, matching what every already-deployed instance of the `Box` entity expects since #1135 landed. It's a no-op on a database that's already correct (fresh installs, or environments that got the manual SQL fix from #1135's PR description).

## Test plan

Verified locally against three scenarios with a scratch Postgres 16 instance:
- [x] Drifted schema (migration chain run through the pre-#1135 revision, leaving `autoPause`): this migration renames it to `autoStop` and fixes the check constraint name.
- [x] Re-running the migration chain afterward reports `No migrations are pending` (confirms TypeORM's tracking prevents double-application/double-rename).
- [x] Fresh schema (migration chain run through the current, post-#1135 revision, which already produces `autoStop` directly): this migration runs and is a safe no-op.
- [x] `npx eslint` and `npx prettier --check` both pass on the new file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed legacy box auto-stop settings so existing configurations continue to work correctly.
  * Standardized auto-stop validation and removed outdated constraints.
  * Applied the repair safely without affecting already-correct configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->