### PR TITLE
refactor(build): drop unused --dest-dir/--libs-dir from build scripts

### DIFF
--- a/scripts/build/build-guest.sh
+++ b/scripts/build/build-guest.sh
@@ -7,10 +7,9 @@
 #   - musllinux: scripts/setup/setup-musllinux.sh
 #
 # Usage:
-#   ./build-guest.sh [--dest-dir DIR] [--profile PROFILE]
+#   ./build-guest.sh [--profile PROFILE]
 #
 # Options:
-#   --dest-dir DIR      Directory to copy the guest binary to
 #   --profile PROFILE   Build profile: release or debug (default: release)
 
 set -e
@@ -22,27 +21,19 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 source "$SCRIPT_DIR/common.sh"
 source "$SCRIPT_DIR/setup/setup-common.sh"
 
-# Capture original working directory before any cd commands
-ORIG_DIR="$(pwd)"
-
 # Parse command-line arguments
 parse_args() {
-    DEST_DIR_ARG=""
     PROFILE="release"
 
     while [[ $# -gt 0 ]]; do
         case $1 in
-            --dest-dir)
-                DEST_DIR_ARG="$2"
-                shift 2
-                ;;
             --profile)
                 PROFILE="$2"
                 shift 2
                 ;;
             *)
                 echo "Unknown option: $1"
-                echo "Usage: $0 [--dest-dir DIR] [--profile PROFILE]"
+                echo "Usage: $0 [--profile PROFILE]"
                 exit 1
                 ;;
         esac
@@ -53,18 +44,6 @@ parse_args() {
         echo "Invalid profile: $PROFILE"
         echo "Run with --profile release or --profile debug"
         exit 1
-    fi
-
-    # Resolve destination path to absolute path
-    if [ -n "$DEST_DIR_ARG" ]; then
-        # If relative, make it absolute relative to original working directory
-        if [[ "$DEST_DIR_ARG" != /* ]]; then
-            DEST_DIR="$ORIG_DIR/$DEST_DIR_ARG"
-        else
-            DEST_DIR="$DEST_DIR_ARG"
-        fi
-    else
-        DEST_DIR=""
     fi
 }
 
@@ -153,32 +132,14 @@ build_guest_binary() {
     fi
 }
 
-# Copy binary to destination
-copy_to_destination() {
-    if [ -z "$DEST_DIR" ]; then
-        echo "✅ Guest binary built successfully (no destination specified)"
-        echo "Binary location: $PROJECT_ROOT/target/$GUEST_TARGET/$PROFILE/boxlite-guest"
-        return 0
-    fi
-
-    # Relative paths are relative to caller's working directory (already correct behavior)
-    # Absolute paths are used as-is
-    echo "📦 Copying to destination: $DEST_DIR"
-    mkdir -p "$DEST_DIR"
-    cp "$PROJECT_ROOT/target/$GUEST_TARGET/$PROFILE/boxlite-guest" "$DEST_DIR/"
-
-    echo "✅ Guest binary built and copied to $DEST_DIR"
-    echo "Binary info:"
-    ls -lh "$DEST_DIR/boxlite-guest"
-    file "$DEST_DIR/boxlite-guest"
-}
-
 # Main execution
 main() {
     check_prerequisites
     setup_rust_target
     build_guest_binary
-    copy_to_destination
+
+    echo "✅ Guest binary built successfully"
+    echo "Binary location: $PROJECT_ROOT/target/$GUEST_TARGET/$PROFILE/boxlite-guest"
 
     echo ""
     print_success "Done! Guest binary is ready for packaging."

--- a/scripts/build/build-runtime.sh
+++ b/scripts/build/build-runtime.sh
@@ -1,14 +1,13 @@
 #!/bin/bash
-# Build boxlite-runtime directory with all binaries and libraries
+# Populate cargo's OUT_DIR/runtime with all binaries and libraries
 #
-# This script creates a complete runtime directory that contains everything
+# This script completes the runtime directory that contains everything
 # needed to run BoxLite: shim binary, guest binary, and all FFI libraries.
 #
 # Usage:
-#   ./build-runtime.sh [--dest-dir DIR] [--profile PROFILE]
+#   ./build-runtime.sh [--profile PROFILE]
 #
 # Options:
-#   --dest-dir DIR      Destination directory (default: cargo OUT_DIR/runtime)
 #   --profile PROFILE   Build profile: release or debug (default: release)
 #
 # The runtime directory will contain:
@@ -24,20 +23,15 @@ SCRIPT_DIR="$(cd "$SCRIPT_BUILD_DIR/.." && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 source "$SCRIPT_DIR/common.sh"
 
-# Capture original working directory before any cd commands
-ORIG_DIR="$(pwd)"
-
 # Print help message
 print_help() {
     cat <<EOF
 Usage: build-runtime.sh [OPTIONS]
 
-Build boxlite-runtime directory with all binaries and libraries.
+Populate cargo's OUT_DIR/runtime with all binaries and libraries.
 
 Options:
-  --dest-dir DIR      Destination directory (default: cargo OUT_DIR/runtime)
   --profile PROFILE   Build profile: release or debug (default: release)
-  --libs-dir DIR      Directory containing FFI libraries (if not provided, will build and collect)
   --help, -h          Show this help message
 
 The runtime directory will contain:
@@ -52,12 +46,6 @@ Examples:
   # Build debug runtime
   ./build-runtime.sh --profile debug
 
-  # Build runtime in custom directory
-  ./build-runtime.sh --dest-dir /tmp/my-runtime
-
-  # Build runtime with pre-collected libraries
-  ./build-runtime.sh --libs-dir /path/to/libs
-
   # Full workflow
   bash scripts/build/build-guest.sh
   bash scripts/build/build-shim.sh
@@ -68,22 +56,12 @@ EOF
 
 # Parse command-line arguments
 parse_args() {
-    DEST_DIR_ARG=""
     PROFILE="release"
-    LIBS_DIR_ARG=""
 
     while [[ $# -gt 0 ]]; do
         case $1 in
-            --dest-dir)
-                DEST_DIR_ARG="$2"
-                shift 2
-                ;;
             --profile)
                 PROFILE="$2"
-                shift 2
-                ;;
-            --libs-dir)
-                LIBS_DIR_ARG="$2"
                 shift 2
                 ;;
             --help|-h)
@@ -103,29 +81,6 @@ parse_args() {
         echo "Invalid profile: $PROFILE"
         echo "Run with --profile release or --profile debug"
         exit 1
-    fi
-
-    # Set destination if provided (otherwise resolved after collect_libraries)
-    if [ -z "$DEST_DIR_ARG" ]; then
-        DEST_DIR=""
-    else
-        # Resolve destination path to absolute path
-        if [[ "$DEST_DIR_ARG" != /* ]]; then
-            DEST_DIR="$ORIG_DIR/$DEST_DIR_ARG"
-        else
-            DEST_DIR="$DEST_DIR_ARG"
-        fi
-    fi
-
-    # Resolve libs directory if provided
-    if [ -n "$LIBS_DIR_ARG" ]; then
-        if [[ "$LIBS_DIR_ARG" != /* ]]; then
-            LIBS_DIR="$ORIG_DIR/$LIBS_DIR_ARG"
-        else
-            LIBS_DIR="$LIBS_DIR_ARG"
-        fi
-    else
-        LIBS_DIR=""
     fi
 }
 
@@ -202,22 +157,6 @@ build_guest() {
 
 # Find and collect FFI libraries
 collect_libraries() {
-    # If caller provided libs directory, use it
-    if [ -n "$LIBS_DIR" ]; then
-        echo ""
-        print_section "Using provided libraries directory..."
-
-        if [ ! -d "$LIBS_DIR" ]; then
-            print_error "Libraries directory not found: $LIBS_DIR"
-            exit 1
-        fi
-
-        RUNTIME_LIBS_DIR="$LIBS_DIR"
-        print_success "Using libraries from: $RUNTIME_LIBS_DIR"
-        return 0
-    fi
-
-    # Otherwise, build and collect libraries
     echo ""
     print_section "Collecting FFI libraries..."
 
@@ -267,47 +206,27 @@ collect_libraries() {
     print_success "Found libraries at: $RUNTIME_LIBS_DIR"
 }
 
-# Create runtime directory and copy all components
+# Add the binaries alongside the libraries cargo already staged
 assemble_runtime() {
     echo ""
     print_section "Assembling runtime directory..."
 
-    if [ "$DEST_DIR" = "$RUNTIME_LIBS_DIR" ]; then
-        # Outputting to cargo OUT_DIR/runtime — libs are already there, just add binaries
-        mkdir -p "$DEST_DIR"
+    # The libraries are already in place — only the binaries are missing
+    mkdir -p "$RUNTIME_LIBS_DIR"
 
-        print_step "Copying boxlite-shim... "
-        cp "$SHIM_BINARY" "$DEST_DIR/"
-        echo "✓"
+    print_step "Copying boxlite-shim... "
+    cp "$SHIM_BINARY" "$RUNTIME_LIBS_DIR/"
+    echo "✓"
 
-        print_step "Copying boxlite-guest... "
-        cp "$GUEST_BINARY" "$DEST_DIR/"
-        echo "✓"
-    else
-        # Separate destination — full copy
-        rm -rf "$DEST_DIR"
-        mkdir -p "$DEST_DIR"
-
-        # Copy binaries
-        print_step "Copying boxlite-shim... "
-        cp "$SHIM_BINARY" "$DEST_DIR/"
-        echo "✓"
-
-        print_step "Copying boxlite-guest... "
-        cp "$GUEST_BINARY" "$DEST_DIR/"
-        echo "✓"
-
-        # Copy all libraries (preserve symlinks)
-        print_step "Copying libraries... "
-        cp -P "$RUNTIME_LIBS_DIR"/* "$DEST_DIR/" 2>/dev/null || true
-        echo "✓"
-    fi
+    print_step "Copying boxlite-guest... "
+    cp "$GUEST_BINARY" "$RUNTIME_LIBS_DIR/"
+    echo "✓"
 
     # Sign shim on macOS (always, to ensure proper entitlements)
-    if [ "$OS" = "macos" ] && [ -f "$DEST_DIR/boxlite-shim" ]; then
+    if [ "$OS" = "macos" ] && [ -f "$RUNTIME_LIBS_DIR/boxlite-shim" ]; then
         echo ""
         print_section "Signing boxlite-shim... "
-        "$SCRIPT_BUILD_DIR/sign.sh" "$DEST_DIR/boxlite-shim"
+        "$SCRIPT_BUILD_DIR/sign.sh" "$RUNTIME_LIBS_DIR/boxlite-shim"
         echo "✓"
     fi
 
@@ -318,17 +237,17 @@ assemble_runtime() {
 show_summary() {
     echo ""
     print_section "Runtime Directory Summary"
-    echo "Location: $DEST_DIR"
+    echo "Location: $RUNTIME_LIBS_DIR"
     echo ""
     echo "Contents:"
-    ls -lh "$DEST_DIR" | tail -n +2 | while read -r line; do
+    ls -lh "$RUNTIME_LIBS_DIR" | tail -n +2 | while read -r line; do
         echo "  $line"
     done
     echo ""
 
     # Show file types
     echo "File types:"
-    for file in "$DEST_DIR"/*; do
+    for file in "$RUNTIME_LIBS_DIR"/*; do
         if [ -f "$file" ]; then
             local filename
             local filetype
@@ -351,12 +270,7 @@ main() {
     build_shim
     build_guest
     collect_libraries
-
-    # Resolve default destination after collect_libraries discovers RUNTIME_LIBS_DIR
-    if [ -z "$DEST_DIR" ]; then
-        DEST_DIR="$RUNTIME_LIBS_DIR"
-    fi
-    echo "Destination: $DEST_DIR"
+    echo "Destination: $RUNTIME_LIBS_DIR"
 
     assemble_runtime
     show_summary

--- a/scripts/build/build-shim.sh
+++ b/scripts/build/build-shim.sh
@@ -2,10 +2,9 @@
 # Universal script to build boxlite-shim binary on macOS or Linux
 #
 # Usage:
-#   ./build-shim.sh [--dest-dir DIR]
+#   ./build-shim.sh [--profile PROFILE]
 #
 # Options:
-#   --dest-dir DIR    Directory to copy the shim binary to
 #   --profile PROFILE   Build profile: release or debug (default: release)
 #
 # Note: On macOS, the binary is automatically signed with hypervisor entitlements
@@ -20,27 +19,19 @@ SCRIPT_DIR="$(cd "$SCRIPT_BUILD_DIR/.." && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 source "$SCRIPT_DIR/common.sh"
 
-# Capture original working directory before any cd commands
-ORIG_DIR="$(pwd)"
-
 # Parse command-line arguments
 parse_args() {
-    DEST_DIR_ARG=""
     PROFILE="release"
 
     while [[ $# -gt 0 ]]; do
         case $1 in
-            --dest-dir)
-                DEST_DIR_ARG="$2"
-                shift 2
-                ;;
             --profile)
                 PROFILE="$2"
                 shift 2
                 ;;
             *)
                 echo "Unknown option: $1"
-                echo "Usage: $0 [--dest-dir DIR]"
+                echo "Usage: $0 [--profile PROFILE]"
                 exit 1
                 ;;
         esac
@@ -51,18 +42,6 @@ parse_args() {
         echo "Invalid profile: $PROFILE"
         echo "Run with --profile release or --profile debug"
         exit 1
-    fi
-
-    # Resolve destination path to absolute path
-    if [ -n "$DEST_DIR_ARG" ]; then
-        # If relative, make it absolute relative to original working directory
-        if [[ "$DEST_DIR_ARG" != /* ]]; then
-            DEST_DIR="$ORIG_DIR/$DEST_DIR_ARG"
-        else
-            DEST_DIR="$DEST_DIR_ARG"
-        fi
-    else
-        DEST_DIR=""
     fi
 }
 
@@ -115,38 +94,15 @@ sign_binary() {
     # Always sign the build output (cargo produces unsigned binaries)
     echo "📦 Signing boxlite-shim with hypervisor entitlements..."
     "$SCRIPT_BUILD_DIR/sign.sh" "$SHIM_BINARY_PATH"
-
-    # Also sign the destination copy if it exists (cp strips entitlements)
-    if [ -n "$DEST_DIR" ] && [ -f "$DEST_DIR/boxlite-shim" ]; then
-        "$SCRIPT_BUILD_DIR/sign.sh" "$DEST_DIR/boxlite-shim"
-    fi
-}
-
-# Copy binary to destination
-copy_to_destination() {
-    if [ -z "$DEST_DIR" ]; then
-        echo "✅ Shim binary built successfully (no destination specified)"
-        echo "Binary location: $SHIM_BINARY_PATH"
-        return 0
-    fi
-
-    # Relative paths are relative to caller's working directory (already resolved)
-    # Absolute paths are used as-is
-    echo "📦 Copying to destination: $DEST_DIR"
-    mkdir -p "$DEST_DIR"
-    cp "$SHIM_BINARY_PATH" "$DEST_DIR/"
-
-    echo "✅ Shim binary built and copied to $DEST_DIR"
-    echo "Binary info:"
-    ls -lh "$DEST_DIR/boxlite-shim"
-    file "$DEST_DIR/boxlite-shim"
 }
 
 # Main execution
 main() {
     build_shim_binary
-    copy_to_destination
     sign_binary
+
+    echo "✅ Shim binary built successfully"
+    echo "Binary location: $SHIM_BINARY_PATH"
 
     echo ""
     echo "🎉 Done! Shim binary is ready."


### PR DESCRIPTION
## Summary

`--dest-dir` and `--libs-dir` let a caller redirect the assembled runtime elsewhere. Since #316 moved the runtime into cargo's `OUT_DIR` and embedded it via `include_bytes!`, no caller names a destination any more — `make/build.mk`, `make/dist.mk`, and `build-runtime.sh`'s own invocations pass `--profile` or nothing, and `--libs-dir` never had a caller at all. This drops both flags and the code only they could reach.

## Call graph

Before

```text
make runtime
  parse_args           (build-runtime · scripts/build/build-runtime.sh:70)    — accepts --dest-dir, --libs-dir
    └─ collect_libraries  (build-runtime · scripts/build/build-runtime.sh:206)   — if LIBS_DIR: use it, return early
    └─ main               (build-runtime · scripts/build/build-runtime.sh:356)   — DEST_DIR ?= RUNTIME_LIBS_DIR, always true
    └─ assemble_runtime   (build-runtime · scripts/build/build-runtime.sh:275)   — branches on DEST_DIR; else-arm rm -rf's it
         ├─ copy_to_destination (build-shim · scripts/build/build-shim.sh:126)   — unreachable, DEST_DIR always empty
         │    └─ sign_binary    (build-shim · scripts/build/build-shim.sh:109)   — re-signs the dest copy, never fires
         └─ copy_to_destination (build-guest · scripts/build/build-guest.sh:157) — unreachable, DEST_DIR always empty
```

After

```text
make runtime
  parse_args           (build-runtime · scripts/build/build-runtime.sh:58)     — --profile only
    └─ collect_libraries  (build-runtime · scripts/build/build-runtime.sh:159)   — resolves cargo OUT_DIR/runtime
    └─ assemble_runtime   (build-runtime · scripts/build/build-runtime.sh:210)   — single path; signs shim at :229
         ├─ main           (build-shim · scripts/build/build-shim.sh:100)         — build, sign, report location
         │    └─ sign_binary (build-shim · scripts/build/build-shim.sh:88)        — signs $SHIM_BINARY_PATH
         └─ main           (build-guest · scripts/build/build-guest.sh:136)       — build, report location
```

The shim keeps its hypervisor entitlements: `build-shim.sh` no longer re-signs a destination copy because there is no copy, and `assemble_runtime` signs the shim after staging it into `OUT_DIR/runtime` — the copy that actually ships.

## Changes

- `build-runtime.sh`: `assemble_runtime` collapses to the single `OUT_DIR` path, dropping the `rm -rf` + full-copy arm; `collect_libraries` loses its provided-libs early return; `RUNTIME_LIBS_DIR` replaces the `DEST_DIR` alias so one variable no longer names two things.
- `build-shim.sh` / `build-guest.sh`: `copy_to_destination` removed, along with the now-unused `ORIG_DIR`. `build-shim.sh`'s usage line previously advertised only `--dest-dir` while silently accepting `--profile`; it is now accurate.
- `SKIP_SHIM_BUILD` is deliberately untouched — `build_shim()` is byte-identical to `main`'s.

## How to verify

- `bash -n scripts/build/build-{runtime,shim,guest}.sh` — clean.
- `bash scripts/build/build-runtime.sh --dest-dir /tmp/x` — exits 1, unknown option; `--profile bogus` still reaches profile validation.
- `git grep -nE -- '--dest-dir|--libs-dir|DEST_DIR'` — no hits outside this diff.
- `make runtime` — assembles into `target/<profile>/build/boxlite-*/out/runtime`, shim signed.

## Risks / rollout

- `shellcheck` reports the same codes before and after, per file. All three scripts were run end-to-end in an isolated worktree against both `main` and this branch — six runs, all exit 0, matching artifacts and identical macOS signing identifiers.
- Those runs used a superset of this diff that also removed `SKIP_SHIM_BUILD`; that block was restored before commit, so what ships is a strict subset of what was built, and the restored branch is unreachable — the repo contains no `SKIP_SHIM_BUILD` setter.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Simplified build commands to accept only the build profile.
  * Build outputs are now assembled and reported in their standard generated locations.
  * Removed support for custom destination and library directories.
  * Streamlined binary signing and runtime assembly workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->