### PR TITLE
fix(libkrun-sys): keep libkrunfw's libc dependency aarch64-only

### DIFF
--- a/scripts/build/build-shim.sh
+++ b/scripts/build/build-shim.sh
@@ -64,9 +64,10 @@ build_shim_binary() {
 
     if [ "$OS" = "linux" ]; then
         # Go c-archive crashes with musl TLS; use glibc + crt-static instead.
-        # crt-static only works because libkrun-sys gives libkrunfw a libc
-        # DT_NEEDED (LibFixup::ensure_libc_dependency); without it a static
-        # binary cannot dlopen it on aarch64.
+        # Whether crt-static can dlopen libkrunfw depends on libkrunfw's own libc
+        # DT_NEEDED, which LibFixup::enforce_libc_dependency sets per target arch:
+        # aarch64 needs the entry (a static binary cannot otherwise resolve it),
+        # x86_64 needs it absent (it would pull in the deployment host's libc).
         # relocation-model=static avoids static-pie which is incompatible with Go c-archive relocations.
         # --target is required so RUSTFLAGS (crt-static, relocation-model) don't leak into
         # proc-macro compilation — proc-macros are dylibs and can't use crt-static.

--- a/src/deps/libkrun-sys/build.rs
+++ b/src/deps/libkrun-sys/build.rs
@@ -440,8 +440,8 @@ impl LibFixup {
         run_command(&mut cmd, &format!("fix install name for {}", lib_name));
     }
 
-    /// Gives a library that does not already depend on libc a `DT_NEEDED`
-    /// entry for it.
+    /// Holds a library's libc `DT_NEEDED` entry to what the target
+    /// architecture requires: present on aarch64, absent everywhere else.
     ///
     /// libkrunfw is a kernel blob linked `-nostdlib`, so it declares no
     /// dependencies at all. A `+crt-static` shim cannot dlopen such a library
@@ -451,14 +451,20 @@ impl LibFixup {
     /// fails as `undefined symbol: _dl_var_init`, naming the library, which
     /// does not reference it. Depending on libc pulls `ld.so` into scope.
     ///
-    /// Libraries that already link libc are left alone, so this only ever
-    /// touches one that would otherwise be unloadable from a static binary.
+    /// This is deliberately aarch64-only, and enforced in both directions:
+    /// added where it is required, removed where it is not. Elsewhere the entry
+    /// makes a portable static shim load the deployment host's libc as a second
+    /// libc, and the dlopen fails as `Couldn't find or load libkrunfw.so.5` — on
+    /// the target machine, long after the build looked green. Enforcing it here,
+    /// where the dependency is decided, is what keeps the two from drifting.
     ///
-    /// Gated on a glibc host: `libc.so.6` is glibc's soname, and build scripts
-    /// compile for the host, so a musl host would otherwise be stamped with a
-    /// dependency it cannot resolve.
+    /// The architecture that decides is the *target* (`CARGO_CFG_TARGET_ARCH`),
+    /// since the artifact is loaded wherever it is deployed, not where it is
+    /// built. The enclosing `cfg` is about the host instead: `libc.so.6` is
+    /// glibc's soname and build scripts compile for the host, so a musl host
+    /// would otherwise be stamped with a dependency it cannot resolve.
     #[cfg(all(target_os = "linux", target_env = "gnu"))]
-    fn ensure_libc_dependency(lib_path: &Path) {
+    fn enforce_libc_dependency(lib_path: &Path) {
         const LIBC: &str = "libc.so.6";
         let lib_path_str = lib_path.to_str().expect("Invalid library path");
 
@@ -466,10 +472,29 @@ impl LibFixup {
             .args(["--print-needed", lib_path_str])
             .output()
             .unwrap_or_else(|e| panic!("Failed to read DT_NEEDED of {}: {}", lib_path_str, e));
-        if String::from_utf8_lossy(&needed.stdout)
+        let has_libc = String::from_utf8_lossy(&needed.stdout)
             .lines()
-            .any(|entry| entry.trim() == LIBC)
-        {
+            .any(|entry| entry.trim() == LIBC);
+
+        if env::var("CARGO_CFG_TARGET_ARCH").as_deref() != Ok("aarch64") {
+            if !has_libc {
+                return;
+            }
+            // Strip rather than fail: this also runs over a cached OUT_DIR, so an
+            // artifact stamped by an earlier build heals on the next one instead of
+            // wedging it. libkrunfw is `-nostdlib`, so no dependency is its own
+            // natural state.
+            let mut cmd = Command::new("patchelf");
+            cmd.args(["--remove-needed", LIBC, lib_path_str]);
+            run_command(&mut cmd, &format!("remove {} dependency", LIBC));
+            println!(
+                "cargo:warning=Removed {} dependency from {} (only aarch64 needs it)",
+                LIBC, lib_path_str
+            );
+            return;
+        }
+
+        if has_libc {
             return;
         }
 
@@ -531,7 +556,7 @@ impl LibFixup {
                             println!("cargo:warning=Renamed {} to {}", filename, soname);
                             Self::fix_install_name(&soname, &new_path);
                             #[cfg(target_env = "gnu")]
-                            Self::ensure_libc_dependency(&new_path);
+                            Self::enforce_libc_dependency(&new_path);
                             continue;
                         }
                     }
@@ -539,7 +564,7 @@ impl LibFixup {
 
                 Self::fix_install_name(&filename, &path);
                 #[cfg(all(target_os = "linux", target_env = "gnu"))]
-                Self::ensure_libc_dependency(&path);
+                Self::enforce_libc_dependency(&path);
 
                 // macOS: re-sign after modifying
                 #[cfg(target_os = "macos")]


### PR DESCRIPTION
## Summary

`LibFixup` stamps a `libc.so.6` DT_NEEDED onto `libkrunfw.so.5` so a `+crt-static`
shim can `dlopen` it on aarch64, where the glibc static-dlopen path needs `ld.so`
reachable through its own dependency scope. It did that on every `linux-gnu`
target. On x86_64 the entry is not needed and is actively harmful: the static shim
resolves the deployment host libc as a second libc, and the load then fails with
the `libkrunfw.so.5` could-not-be-found error and `libkrun status=-2` — on the
target machine, not in the build.

Every CI-built x86_64 runtime has carried this since `ea34a8c4` (2026-07-29), the
commit that introduced the stamping.

## Call graph

Before

```
LibFixup::ensure_libc_dependency  (fn · src/deps/libkrun-sys/build.rs:461)  ← BUG: adds libc.so.6 on every linux-gnu target, arch unconditioned
  └─ patchelf --add-needed libc.so.6 → libkrunfw.so.5  (artifact · src/deps/libkrun-sys/build.rs:502)  — stamped into the shipped runtime
       └─ boxlite-shim dlopen  (static x86_64 · src/boxlite/src/jailer/sandbox/bwrap.rs:126)  ← BUG: second libc, load fails
```

After

```
LibFixup::enforce_libc_dependency  (fn · src/deps/libkrun-sys/build.rs:467)  — one place decides, both directions
  ├─ aarch64 → patchelf --add-needed libc.so.6  (fn · src/deps/libkrun-sys/build.rs:502)  — required for static dlopen
  └─ else    → patchelf --remove-needed libc.so.6  (fn · src/deps/libkrun-sys/build.rs:488)  — heals a cached OUT_DIR instead of wedging it
       └─ boxlite-shim dlopen  (static x86_64 · src/boxlite/src/jailer/sandbox/bwrap.rs:126)  — resolves, no host libc pulled in
```

## Changes

- Gate the `--add-needed` on `CARGO_CFG_TARGET_ARCH == "aarch64"`, and
  `--remove-needed` elsewhere. Renamed `ensure_` to `enforce_` because the
  function now enforces the invariant in both directions rather than only adding.
- Remove rather than reject: `LibFixup::fix` also runs over a cached `OUT_DIR`, so
  an artifact stamped by an earlier build heals on the next build instead of
  failing it. `libkrunfw` is built `-nostdlib`, so declaring nothing is its
  natural state.
- Scope is safe by construction: both `LibFixup::fix` call sites
  (`src/deps/libkrun-sys/build.rs:909`, `:978`) pass `lib_prefix = "libkrunfw"`,
  and `fix` filters on that prefix, so no other library reaches this code.
- `scripts/build/build-shim.sh` explained `crt-static` in terms of the old
  unconditional entry, which is now wrong on x86_64. Its comment tracks the
  per-arch rule and the renamed symbol.

## How to verify

Root cause was isolated to a single variable on a live x86_64 runner — same host,
same shim, one DT_NEEDED entry apart:

| libkrunfw md5 | difference | box start |
| --- | --- | --- |
| `1dd5c06a` | clean | `krun_start_enter called`, boots |
| `3a03ad96` | clean plus `patchelf --add-needed libc.so.6` | fails, `status=-2` |

On a Linux x86_64 host, after this change:

```
readelf -d target/release/build/boxlite-*/out/runtime/libkrunfw.so.5 | grep NEEDED
```

prints nothing. On aarch64 it lists `libc.so.6`.

## Risks / rollout

The aarch64 path is unchanged — the same condition that previously applied to all
`linux-gnu` targets, now named explicitly.

Three things reviewers should know, none of them papered over:

1. **No Linux build has run.** This host is Darwin/arm64, so the function is
   excluded by `#[cfg(all(target_os = "linux", target_env = "gnu"))]` and cannot
   compile locally. It was type-checked with standalone `rustc` for
   `x86_64-unknown-linux-gnu` and `aarch64-unknown-linux-gnu` (both clean).
2. **The `--remove-needed` call stays unexecuted even in CI.** CI starts from a
   fresh `OUT_DIR` and the released tarball is `-nostdlib`, so `has_libc` is
   false and the function returns before invoking `patchelf`. CI exercises the
   guard, not the strip. The strip fires only against a locally cached artifact
   stamped by a pre-fix build.
3. **Nothing in CI catches re-introduction of an unconditional `--add-needed`.**
   No `build.rs` in this repo carries tests and `cargo test` does not run
   build-script code, so there is no in-crate seam. A post-build
   `patchelf --print-needed` assertion in `build-runtime.yml` would close it and
   is a deliberate follow-up, not an impossibility.

Fixes #1144

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux build compatibility across supported CPU architectures.
  * Corrected handling of required system library dependencies for ARM-based and x86-based builds.

* **Chores**
  * Updated build documentation to clarify architecture-specific requirements for Linux deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->