### PR TITLE
fix(infra-local): keep dex sqlite in writable tmp

### DIFF
--- a/apps/infra-local/compose/services.py
+++ b/apps/infra-local/compose/services.py
@@ -187,7 +187,7 @@ issuer: ${DEX_ISSUER}
 storage:
   type: sqlite3
   config:
-    file: /var/dex/dex.db
+    file: /tmp/dex.db
 web:
   http: 0.0.0.0:5556
   allowedOrigins: ['*']
@@ -223,7 +223,7 @@ staticPasswords:
 
 _DEX_ENTRYPOINT = """\
 set -e
-mkdir -p /var/dex /tmp
+mkdir -p /tmp
 cat > /tmp/dex-config.yaml <<'__CFG__'
 """ + _DEX_CONFIG + """\
 __CFG__


### PR DESCRIPTION
Keep infra-local Dex from exiting on startup by placing its sqlite database in /tmp, which is writable inside the box.

Test plan:
- [x] `BOXLITE_RUNTIME_DIR=/Users/ngolosong/Documents/ws/boxlite-main/target/debug/build/boxlite-0e31d2a810d73afb/out/runtime make restart COMPONENTS=dex`
- [x] `BOXLITE_RUNTIME_DIR=/Users/ngolosong/Documents/ws/boxlite-main/target/debug/build/boxlite-0e31d2a810d73afb/out/runtime make up`
- [x] `BOXLITE_RUNTIME_DIR=/Users/ngolosong/Documents/ws/boxlite-main/target/debug/build/boxlite-0e31d2a810d73afb/out/runtime make status`