### PR TITLE
feat(ci): deploy the head of an open PR, not only main

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -161,8 +161,11 @@ is enabled. The workflow is dormant until repository variable
 
 ### `deploy-infra.yml`
 
-Previews or deploys the full stack from one commit already on `main` (current
-`main` by default) on a native AMD64 GitHub runner, for a
+Previews or deploys the full stack from one commit — already on `main` (current
+`main` by default), or the head of an open pull request in this repository, so a
+change can reach a stage before it merges; a fork's head is refused because the
+resolved commit is checked out with write permissions and run after the deploy
+role is configured — on a native AMD64 GitHub runner, for a
 `workflow_dispatch`-selected `stage` (an allowlisted `choice` input, `dev`
 today). Each component is built by its own job, and the two legs share only
 `resolve-ref`, so they run side by side: the reusable C/Runner workflows produce
@@ -203,7 +206,7 @@ adding it to whichever of those lists should reach it.
 
 `commit` is how `deploy-infra.yml` builds the API for the commit it deploys; the
 `ref` input is call-only, so no dispatch can tag an image for a commit the
-main-ancestry guard never saw. The two tag shapes cannot collide, which matters
+deployable-commit guard never saw. The two tag shapes cannot collide, which matters
 because the repository is `IMMUTABLE` and a collision would be unrepairable.
 `promote` copies an exact manifest registry-side, addressed by digest, and
 verifies the digest survived; it never rebuilds. The dispatched operations run

--- a/.github/workflows/build-apps-api-image.yml
+++ b/.github/workflows/build-apps-api-image.yml
@@ -101,8 +101,9 @@ jobs:
           ref: refs/tags/v${{ inputs.version }}
           persist-credentials: false
 
-      # The caller resolved this and proved it is a commit on main (deploy-infra.yml resolve-ref);
-      # the operation guard below re-checks its shape rather than trusting the input's provenance.
+      # The caller resolved this and proved it is a commit on main, or the head of an open pull
+      # request in this repository — never a fork's (deploy-infra.yml resolve-ref); the operation
+      # guard below re-checks its shape rather than trusting the input's provenance.
       - name: Checkout the selected commit
         if: inputs.ref != ''
         uses: actions/checkout@v5

--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -1,7 +1,8 @@
 name: Deploy stack
 run-name: Deploy ${{ inputs.stage }} stack
 
-# A build deploy sources both deployable components from one commit on main, each in its own job:
+# A build deploy sources both deployable components from one commit — on main, or the head of an
+# open pull request when a change needs a real stage before it merges — each in its own job:
 #
 #   Api    → Build commit Api image ───────────────→ per-commit ECR tag
 #   Runner → Build C SDK → Build Runner Binary ────→ private per-commit S3 object
@@ -26,7 +27,7 @@ on:
         default: false
         type: boolean
       ref:
-        description: 'Full SHA of any commit already on main. Defaults to current main.'
+        description: 'Full SHA of a commit on main, or the head of an open PR. Defaults to current main.'
         required: false
         type: string
 
@@ -40,9 +41,14 @@ concurrency:
 
 jobs:
   resolve-ref:
-    name: Resolve main commit
+    name: Resolve deployable commit
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
+    # A job-level block replaces the workflow-level one rather than merging with it, so
+    # contents: read is restated. pull-requests: read is what lets a PR head qualify below.
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       sha: ${{ steps.ref.outputs.sha }}
     steps:
@@ -52,20 +58,45 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Require a commit already on main
+      - name: Require a commit on main or an open pull request
         id: ref
         shell: bash
         env:
           INPUT_REF: ${{ inputs.ref }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           candidate="${INPUT_REF:-$GITHUB_SHA}"
           [[ "$candidate" =~ ^[0-9a-f]{40}$ ]] || { echo "ref must be a full commit SHA" >&2; exit 1; }
-          git cat-file -e "$candidate^{commit}"
-          git merge-base --is-ancestor "$candidate" origin/main || {
-            echo "$candidate is not a commit on main" >&2
+
+          # On main needs no further proof. `cat-file` only rules out a SHA this clone has never
+          # seen — fetch-depth: 0 brings every branch, so a same-repo PR head is present and it is
+          # `merge-base` that sends it to the pull-request path below.
+          if git cat-file -e "$candidate^{commit}" 2>/dev/null \
+            && git merge-base --is-ancestor "$candidate" origin/main; then
+            echo "$candidate is on main"
+            echo "sha=$candidate" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Otherwise it has to be what an open pull request in THIS repository proposes.
+          #
+          # Same repository, because everything downstream treats the resolved commit as trusted:
+          # build-c and build-runner check it out holding contents: write, and the deploy job runs
+          # its `npm ci` / `npm test` after the OIDC role is configured, so a fork head would be
+          # arbitrary code with credentials in the environment — the exposure e2e-cloud.yml
+          # documents. Pushing to a branch here already needs write access. Same test as
+          # e2e-local.yml's fork gate, expressed against the API payload.
+          #
+          # Heads only, because /commits/{sha}/pulls also lists a PR's intermediate commits, and
+          # deploying one of those would ship a state no review is looking at.
+          number="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${candidate}/pulls" \
+            --jq "[.[] | select(.state == \"open\" and .head.sha == \"${candidate}\" and .head.repo.full_name == \"${GITHUB_REPOSITORY}\") | .number] | first // empty")"
+          [ -n "$number" ] || {
+            echo "$candidate is not on main, and not the head of an open pull request in ${GITHUB_REPOSITORY}" >&2
             exit 1
           }
+          echo "$candidate is the head of open PR #${number}"
           echo "sha=$candidate" >> "$GITHUB_OUTPUT"
 
   build-api:
@@ -128,7 +159,7 @@ jobs:
       BOXLITE_ARTIFACT_REF: ${{ needs.resolve-ref.outputs.sha }}
 
     steps:
-      - name: Checkout selected main commit
+      - name: Checkout selected commit
         uses: actions/checkout@v5
         with:
           ref: ${{ needs.resolve-ref.outputs.sha }}

--- a/.github/workflows/e2e-cloud.yml
+++ b/.github/workflows/e2e-cloud.yml
@@ -62,11 +62,13 @@
 # which is what makes it safe for the job that builds and runs the tree
 # to also hold the API key. There is no fork path left to defend:
 # dispatch needs write access, and deploy-infra is itself dispatch-only
-# and refuses to run off main. Restoring any PR trigger would mean
-# restoring that exposure — a labeled fork run hands arbitrary code a
-# live dev credential, and a conftest.py is enough to exfiltrate it — so
-# it would first have to mint a scoped, short-lived key (CreateApiKeyDto
-# takes `permissions` and `expiresAt`) and pass only that to the tests.
+# and resolves only a commit on main or the head of an open pull request
+# in this repository, both of which took write access to create.
+# Restoring any PR trigger would mean restoring that exposure — a labeled
+# fork run hands arbitrary code a live dev credential, and a conftest.py is
+# enough to exfiltrate it — so it would first have to mint a scoped,
+# short-lived key (CreateApiKeyDto takes `permissions` and `expiresAt`) and
+# pass only that to the tests.
 
 name: E2E cloud
 
@@ -76,8 +78,9 @@ on:
       ref:
         # The commit the caller deployed. Without it the suite would build
         # its SDKs from whatever main points at now, while the stack under
-        # test runs the commit deploy-infra selected — deploy-infra takes an
-        # arbitrary main commit, so those are not always the same thing.
+        # test runs the commit deploy-infra selected — that is any commit on
+        # main or an open pull request's head, so the two are not always the
+        # same thing.
         description: 'Full commit SHA to build the SDKs and CLI from.'
         required: true
         type: string

--- a/apps/infra/README.md
+++ b/apps/infra/README.md
@@ -134,7 +134,8 @@ OtelCollector are built from it on every path, so a ref naming another commit
 would deploy two.
 
 `.github/workflows/deploy-infra.yml` is the normal path. It accepts the full SHA
-of any commit already on `main` (current `main` by default) and builds each
+of any commit already on `main` (current `main` by default), or the head of an
+open pull request in this repository — never a fork's — and builds each
 component in its own job — the Linux x64 C SDK and Runner on one leg, the API
 image on the other, sharing only the ref resolution — then stages the
 commit-keyed Runner object and deploys both. The Runner reports
@@ -238,8 +239,10 @@ all require the same manual token.
 ## Common commands
 
 ```bash
-# Preview a specific commit already on main instead of current main.
-gh workflow run deploy-infra.yml --ref main -f stage=dev -f apply=false -f ref=<full-main-commit-sha>
+# Preview a specific commit instead of current main: one already on main, or the head of an open
+# pull request in this repository (a fork's head is refused). Dispatch stays --ref main either way;
+# the job conditions test the launch branch, not this input.
+gh workflow run deploy-infra.yml --ref main -f stage=dev -f apply=false -f ref=<full-commit-sha>
 
 gh workflow run build-apps-api-image.yml --ref main -f operation=build -f version=0.9.8
 gh workflow run build-apps-api-image.yml --ref main -f operation=promote -f stage=prod -f version=0.9.8

--- a/apps/infra/scripts/release-deployment-safety.test.mjs
+++ b/apps/infra/scripts/release-deployment-safety.test.mjs
@@ -175,17 +175,36 @@ test('deployment previews and reconciles the full stack in guarded GitHub CI', (
   assert.equal(workflow.jobs.deploy['runs-on'], 'ubuntu-24.04')
 
   // `if:` restricts the workflow ref, not the dispatched `ref` input — this shell guard is the
-  // only thing binding the built commit to main. Read the step it lives in, since demoting the
-  // line to a comment leaves it greppable while the guard is gone.
+  // only thing binding the built commit to main or to a pull request someone is proposing. Read
+  // the step it lives in, since demoting a line to a comment leaves it greppable while the guard
+  // is gone.
   const refGuardStep = workflow.jobs['resolve-ref'].steps.find(
-    (step) => step.name === 'Require a commit already on main',
+    (step) => step.name === 'Require a commit on main or an open pull request',
   )
-  assert.ok(refGuardStep, 'the main-ancestry guard step is missing')
+  assert.ok(refGuardStep, 'the deployable-commit guard step is missing')
   // Anchored per line with no leading `#`: a parsed read still hands back the whole shell body,
-  // so commenting the guard out leaves it matchable while it no longer runs.
-  assert.match(refGuardStep.run, /^\s*git merge-base --is-ancestor "\$candidate" origin\/main/m)
+  // so commenting a check out leaves it matchable while it no longer runs. `&&` is allowed
+  // because the main test is the second half of an `if`, but `#` still is not.
+  assert.match(refGuardStep.run, /^\s*(&& )?git merge-base --is-ancestor "\$candidate" origin\/main/m)
   assert.match(refGuardStep.run, /^\s*\[\[ "\$candidate" =~ \^\[0-9a-f\]\{40\}\$ \]\]/m)
   assert.match(refGuardStep.run, /^\s*set -euo pipefail/m)
+  // The pull-request path is the widened surface, so pin all three things that keep it narrow:
+  // only an OPEN pull request, only its head (/commits/{sha}/pulls also returns a PR's
+  // intermediate commits, which no review is looking at), and only one opened from THIS
+  // repository. The fork clause is the load-bearing one: build-c and build-runner check the
+  // resolved commit out with contents: write, and the deploy job runs its npm ci / npm test after
+  // the OIDC role is configured, so a fork head would be arbitrary code holding credentials.
+  assert.match(
+    refGuardStep.run,
+    /^\s*--jq .*select\(\.state == \\"open\\" and \.head\.sha == \\"\$\{candidate\}\\" and \.head\.repo\.full_name == \\"\$\{GITHUB_REPOSITORY\}\\"\)/m,
+  )
+  // Neither path matching has to fail the job; a guard that falls through deploys an arbitrary SHA.
+  assert.match(refGuardStep.run, /^\s*\[ -n "\$number" \] \|\| \{$/m)
+  assert.match(refGuardStep.run, /is not on main, and not the head of an open pull request in/)
+  // The API read the pull-request path depends on; without it the query 404s and every PR ref is
+  // rejected, silently reverting this to main-only.
+  assert.equal(workflow.jobs['resolve-ref'].permissions['pull-requests'], 'read')
+  assert.equal(workflow.jobs['resolve-ref'].permissions.contents, 'read')
 
   // The reusable builds and what they are told to build: `with:` values decide which commit and
   // which C SDK the Runner links, and build-runner-binary.yml defaults libboxlite_source to the
@@ -668,7 +687,7 @@ test('API publishing builds once and promotes that exact image without rebuildin
 
   // Commit mode: how deploy-infra.yml builds the Api for the commit it deploys. `ref` is what
   // selects it, so it has to be call-only — a dispatch that could set it would let someone tag an
-  // image for a commit the main-ancestry guard never saw.
+  // image for a commit the deployable-commit guard never saw.
   assert.deepEqual(Object.keys(workflow.on.workflow_call.inputs).sort(), ['ref', 'stage'])
   assert.equal(workflow.on.workflow_dispatch.inputs.ref, undefined)
   assert.equal(workflow.on.workflow_call.inputs.ref.required, true)


### PR DESCRIPTION
## Summary

`deploy-infra` could only build a commit already on `main`, so a change had to merge
before it could run on a real stage. The ref guard now also accepts a commit that is the
head of an open pull request in this repository.

## Call graph

Before

```
resolve-ref  (job · .github/workflows/deploy-infra.yml:43)
  └─ Require a commit already on main  (step · .github/workflows/deploy-infra.yml:55)
       └─ merge-base --is-ancestor $candidate origin/main  (.github/workflows/deploy-infra.yml:65)  — rejects every unmerged commit
            └─ build-api / build-c / build-runner / deploy  (job · .github/workflows/deploy-infra.yml:113)  — unreachable for a PR
```

After

```
resolve-ref  (job · .github/workflows/deploy-infra.yml:43)  — adds pull-requests: read, drops inherited id-token: write
  └─ Require a commit on main or an open pull request  (step · .github/workflows/deploy-infra.yml:61)
       ├─ 40-hex shape check  (.github/workflows/deploy-infra.yml:70)  — validated before any use
       ├─ cat-file -e && merge-base --is-ancestor  (.github/workflows/deploy-infra.yml:75)  — on main: accept, exit 0
       └─ gh api repos/{repo}/commits/{sha}/pulls  (.github/workflows/deploy-infra.yml:93)
            ├─ select .state == "open", .head.sha == candidate, .head.repo.full_name == GITHUB_REPOSITORY
            └─ else reject  (.github/workflows/deploy-infra.yml:97)
```

The three `if: github.ref == ...refs/heads/main...` job gates are untouched
(`deploy-infra.yml:45`, `:147`, `build-apps-api-image.yml:82`). They test the launch
branch, not the `ref` input, so dispatch still happens from `main` and only the ref guard
widened.

## What reviewers should know

- The `deploy` job configures the OIDC role (`deploy-infra.yml:183`) and then runs
  `npm ci` / `npm test` from the resolved commit, so unreviewed same-repo code can now
  execute with dev deploy credentials. Previously it had to clear the branch protection on
  `main` first. That is the point of the feature and the real widening.
- Fork heads are refused explicitly via `.head.repo.full_name`, the same test
  `e2e-local.yml:126` already applies to this threat. As it happens
  `/commits/{sha}/pulls` returns nothing for a fork head today, but the guard does not
  rely on that.
- `stage` still allowlists `dev` alone, so a PR deploy replaces shared dev. A dedicated
  throwaway stage would need bootstrapping and is not in this PR.
- An open PR stacked on another feature branch also qualifies, since the guard has no
  `.base.ref` check. Still same-repo and write-gated, but worth knowing.

## Verification

- `actionlint` on `deploy-infra.yml`, `e2e-cloud.yml`, `build-apps-api-image.yml` — clean.
- `npm test` in `apps/infra` — 300/300.
- Reverting all five non-test files while keeping the new test fails 299/300 with
  `the deployable-commit guard step is missing`; restoring passes 300/300.
- Per-clause mutations each break their own assertion: dropping the fork clause, flipping
  `open` to `closed`, dropping `.head.sha`, commenting out `merge-base`, neutering the
  empty-result check, and removing `pull-requests: read`.
- The field shape of the endpoint was checked against real pull requests rather than
  assumed: a same-repo head matches, open cross-repo heads return an empty array, an
  intermediate commit of an open PR is listed but rejected by the `.head.sha` clause, and
  a squash-merged head is reported `closed` and refused.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Commit-based infrastructure deployments can now target the head of an open pull request from the repository.
  * Deployments continue to reject commits from forks and non-deployable pull request commits.

* **Documentation**
  * Updated deployment guidance and workflow descriptions to explain supported commit selection and authorization behavior.
  * Clarified that deployed commits may differ from the current `main` branch.

* **Tests**
  * Expanded deployment safety checks for pull-request commit validation and permission handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->