### PR TITLE
fix(runtime): support fuse mounts with minimal permissions

### DIFF
--- a/openapi/box.openapi.yaml
+++ b/openapi/box.openapi.yaml
@@ -1594,8 +1594,6 @@ components:
       properties:
         advanced:
           $ref: "#/components/schemas/CreateBoxAdvancedOptions"
-        security:
-          $ref: "#/components/schemas/SecurityPreset"
         name:
           type: string
           description: Unique name within the workspace
@@ -1692,6 +1690,13 @@ components:
       properties:
         capabilities:
           $ref: "#/components/schemas/CreateContainerCapabilities"
+        fuse:
+          type: boolean
+          default: false
+          description: |
+            Allow FUSE filesystems in the box. The server expands this to the
+            minimum required runtime permissions: CAP_SYS_ADMIN and /dev/fuse,
+            while keeping the server-side sandbox security policy in force.
 
     CreateContainerCapabilities:
       type: object

--- a/src/boxlite/src/jailer/mod.rs
+++ b/src/boxlite/src/jailer/mod.rs
@@ -552,6 +552,7 @@ impl<S: Sandbox> Jailer<S> {
         SandboxContext {
             id: &self.box_id,
             paths,
+            device_paths: self.security.device_paths.clone(),
             resource_limits: &self.security.resource_limits,
             network_enabled: self.security.network_enabled,
             sandbox_profile: self.security.sandbox_profile.as_deref(),

--- a/src/boxlite/src/jailer/sandbox/bwrap.rs
+++ b/src/boxlite/src/jailer/sandbox/bwrap.rs
@@ -107,6 +107,10 @@ impl Sandbox for BwrapSandbox {
             .dev_bind_if_exists("/dev/net/tun", "/dev/net/tun")
             .with_proc()
             .tmpfs("/tmp");
+        for device in &ctx.device_paths {
+            bwrap_cmd.dev_bind_if_exists(device, device);
+            tracing::debug!(path = %device.display(), "bwrap: dev-bind");
+        }
 
         // =====================================================================
         // Bind all pre-computed paths (system dirs + user volumes)
@@ -193,6 +197,7 @@ mod tests {
         let ctx = SandboxContext {
             id: "test-box",
             paths: vec![],
+            device_paths: vec![],
             resource_limits: limits,
             network_enabled: false,
             sandbox_profile: None,
@@ -237,6 +242,7 @@ mod tests {
             let ctx = SandboxContext {
                 id: "test-box",
                 paths: vec![],
+                device_paths: vec![],
                 resource_limits: limits,
                 network_enabled: false,
                 sandbox_profile: None,

--- a/src/boxlite/src/jailer/sandbox/composite.rs
+++ b/src/boxlite/src/jailer/sandbox/composite.rs
@@ -125,6 +125,7 @@ mod tests {
         SandboxContext {
             id: "test",
             paths: vec![],
+            device_paths: vec![],
             resource_limits: limits,
             network_enabled: false,
             sandbox_profile: None,

--- a/src/boxlite/src/jailer/sandbox/landlock.rs
+++ b/src/boxlite/src/jailer/sandbox/landlock.rs
@@ -88,6 +88,7 @@ mod tests {
         SandboxContext {
             id: "test",
             paths: vec![],
+            device_paths: vec![],
             resource_limits: limits,
             network_enabled: false,
             sandbox_profile: None,

--- a/src/boxlite/src/jailer/sandbox/mod.rs
+++ b/src/boxlite/src/jailer/sandbox/mod.rs
@@ -119,6 +119,8 @@ pub struct SandboxContext<'a> {
     pub id: &'a str,
     /// Pre-computed filesystem path access rules.
     pub paths: Vec<PathAccess>,
+    /// Device nodes explicitly allowed inside the sandbox.
+    pub device_paths: Vec<PathBuf>,
     /// Resource limits (for cgroup configuration).
     pub resource_limits: &'a ResourceLimits,
     /// Whether network access is enabled.

--- a/src/boxlite/src/litebox/init/tasks/guest_init.rs
+++ b/src/boxlite/src/litebox/init/tasks/guest_init.rs
@@ -10,7 +10,9 @@ use super::{InitCtx, log_task_error, task_start};
 use crate::net::constants::{GATEWAY_IP, GUEST_CIDR, GUEST_INTERFACE};
 use crate::pipeline::PipelineTask;
 use crate::portal::GuestSession;
+use crate::portal::interfaces::container::ContainerAdvancedConfig;
 use crate::portal::interfaces::{ContainerInitConfig, GuestInitConfig, NetworkInitConfig};
+use crate::runtime::advanced_options::ContainerCapabilities;
 use async_trait::async_trait;
 use boxlite_shared::ContainerDevice;
 use boxlite_shared::errors::{BoxliteError, BoxliteResult};
@@ -71,6 +73,11 @@ impl PipelineTask<InitCtx> for GuestInitTask {
                 }),
                 crate::runtime::options::NetworkSpec::Disabled => None,
             };
+            let devices = requested_devices(&ctx.config.options);
+            let capabilities = requested_capabilities(
+                &ctx.config.options.advanced.capabilities,
+                ctx.config.options.advanced.fuse,
+            );
             let bootstrap = GuestBootstrapConfig {
                 guest: GuestInitConfig {
                     volumes: volume_mgr.build_guest_mounts(),
@@ -83,14 +90,8 @@ impl PipelineTask<InitCtx> for GuestInitTask {
                     mounts: container_mounts.clone(),
                     ca_certs: ctx.ca_cert_pem.iter().cloned().collect(),
                     tty: ctx.config.options.tty,
-                    devices: if ctx.config.options.advanced.nested_virtualization {
-                        vec![kvm_device()]
-                    } else {
-                        Vec::new()
-                    },
-                    advanced: crate::portal::interfaces::container::ContainerAdvancedConfig {
-                        capabilities: ctx.config.options.advanced.capabilities.clone(),
-                    },
+                    devices,
+                    advanced: ContainerAdvancedConfig { capabilities },
                 },
             };
 
@@ -164,4 +165,41 @@ fn kvm_device() -> ContainerDevice {
         destination: "/dev/kvm".to_string(),
         file_mode: Some(0o666),
     }
+}
+
+/// The guest VM's FUSE character device, republished into the OCI workload so
+/// a process such as `mount-s3` can create a userspace filesystem.
+fn fuse_device() -> ContainerDevice {
+    ContainerDevice {
+        source: "/dev/fuse".to_string(),
+        destination: "/dev/fuse".to_string(),
+        file_mode: Some(0o666),
+    }
+}
+
+fn requested_devices(options: &crate::runtime::options::BoxOptions) -> Vec<ContainerDevice> {
+    let mut devices = Vec::new();
+    if options.advanced.nested_virtualization {
+        devices.push(kvm_device());
+    }
+    if options.advanced.fuse {
+        devices.push(fuse_device());
+    }
+    devices
+}
+
+fn requested_capabilities(
+    capabilities: &ContainerCapabilities,
+    fuse: bool,
+) -> ContainerCapabilities {
+    let mut capabilities = capabilities.clone();
+    if fuse
+        && !capabilities.add.iter().any(|capability| {
+            capability.eq_ignore_ascii_case("SYS_ADMIN")
+                || capability.eq_ignore_ascii_case("CAP_SYS_ADMIN")
+        })
+    {
+        capabilities.add.push("SYS_ADMIN".to_string());
+    }
+    capabilities
 }

--- a/src/boxlite/src/rest/runtime.rs
+++ b/src/boxlite/src/rest/runtime.rs
@@ -127,7 +127,7 @@ impl RuntimeBackend for RestRuntime {
 
         // A server that does not advertise the capability policy would accept
         // the request and drop the field, silently granting default privileges.
-        if !options.advanced.capabilities.is_empty() {
+        if !options.advanced.capabilities.is_empty() || options.advanced.fuse {
             self.client.require_linux_capabilities_enabled().await?;
         }
 
@@ -308,6 +308,16 @@ mod tests {
         }
     }
 
+    fn fuse_options() -> BoxOptions {
+        BoxOptions {
+            advanced: crate::AdvancedBoxOptions {
+                fuse: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
     async fn json_server(bodies: Vec<&'static str>) -> (u16, tokio::task::JoinHandle<Vec<String>>) {
         let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
         let port = listener.local_addr().unwrap().port();
@@ -393,6 +403,21 @@ mod tests {
         let error = match RuntimeBackend::create(&runtime, capability_options(), None).await {
             Err(error) => error,
             Ok(_) => panic!("an old server must not silently ignore a capability policy"),
+        };
+
+        assert!(matches!(error, BoxliteError::Unsupported(_)));
+        assert_eq!(server.await.unwrap(), ["GET /v1/config HTTP/1.1"]);
+    }
+
+    #[tokio::test]
+    async fn fuse_requires_server_capability_advertisement_before_create() {
+        let (port, server) = json_server(vec![r#"{"capabilities":{}}"#]).await;
+        let runtime =
+            RestRuntime::new(&BoxliteRestOptions::new(format!("http://127.0.0.1:{port}"))).unwrap();
+
+        let error = match RuntimeBackend::create(&runtime, fuse_options(), None).await {
+            Err(error) => error,
+            Ok(_) => panic!("an old server must not silently ignore fuse policy"),
         };
 
         assert!(matches!(error, BoxliteError::Unsupported(_)));

--- a/src/boxlite/src/rest/types.rs
+++ b/src/boxlite/src/rest/types.rs
@@ -182,11 +182,12 @@ impl CreateBoxRequest {
             secrets,
             detach: Some(options.detach),
             tty: options.tty.then_some(true),
-            advanced: (!options.advanced.capabilities.is_empty()).then(|| {
-                CreateBoxAdvancedOptions {
+            advanced: (!options.advanced.capabilities.is_empty() || options.advanced.fuse).then(
+                || CreateBoxAdvancedOptions {
                     capabilities: options.advanced.capabilities.clone(),
-                }
-            }),
+                    fuse: options.advanced.fuse,
+                },
+            ),
             // The deprecated remove-on-stop flag was never applied by the cloud
             // control-plane mapper. Keep remote defaults unchanged and only send
             // the modern lifecycle fields when callers explicitly configure them.
@@ -200,6 +201,12 @@ impl CreateBoxRequest {
 #[derive(Debug, Serialize)]
 pub(crate) struct CreateBoxAdvancedOptions {
     pub capabilities: ContainerCapabilities,
+    #[serde(skip_serializing_if = "is_false")]
+    pub fuse: bool,
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 #[derive(Debug, Serialize)]
@@ -682,16 +689,40 @@ mod tests {
         let advanced = req.advanced.as_ref().expect("custom policy is serialized");
         assert_eq!(advanced.capabilities.add, ["SYS_ADMIN"]);
         assert_eq!(advanced.capabilities.drop, ["CAP_NET_RAW"]);
+        assert!(!advanced.fuse);
 
         let json = serde_json::to_value(&req).expect("serialize create request");
         assert_eq!(
             json["advanced"]["capabilities"],
             serde_json::json!({"add": ["SYS_ADMIN"], "drop": ["CAP_NET_RAW"]})
         );
+        assert!(json["advanced"].get("fuse").is_none());
 
         let defaults = CreateBoxRequest::from_options(&BoxOptions::default(), None);
         let defaults_json = serde_json::to_value(defaults).expect("serialize defaults");
         assert!(defaults_json.get("advanced").is_none());
+    }
+
+    #[test]
+    fn test_create_box_request_carries_fuse_without_security() {
+        let opts = BoxOptions {
+            advanced: crate::AdvancedBoxOptions {
+                fuse: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let req = CreateBoxRequest::from_options(&opts, None);
+        let advanced = req.advanced.as_ref().expect("fuse policy is serialized");
+        assert!(advanced.fuse);
+
+        let json = serde_json::to_string(&req).expect("serialize create request");
+        assert!(json.contains("\"fuse\":true"));
+        assert!(
+            !json.contains("security"),
+            "fuse must not carry a REST security override: {json}"
+        );
     }
 
     #[test]

--- a/src/boxlite/src/runtime/advanced_options.rs
+++ b/src/boxlite/src/runtime/advanced_options.rs
@@ -167,6 +167,13 @@ pub struct SecurityOptions {
     /// If None, uses the built-in modular sandbox profile.
     pub sandbox_profile: Option<PathBuf>,
 
+    /// Linux device nodes to expose to the host-side shim sandbox.
+    ///
+    /// Empty by default. Expert features such as FUSE opt in explicitly so
+    /// ordinary boxes do not inherit extra device access.
+    #[serde(default)]
+    pub device_paths: Vec<PathBuf>,
+
     /// Allow network access inside the sandbox profile.
     ///
     /// Cross-platform: feeds the macOS seatbelt network policy and the Linux
@@ -242,6 +249,7 @@ impl Default for SecurityOptions {
                 max_cpu_time: None, // VM config handles this
             },
             sandbox_profile: None,
+            device_paths: Vec::new(),
             network_enabled: default_network_enabled(),
         }
     }
@@ -273,6 +281,7 @@ impl SecurityOptions {
             env_allowlist: Vec::new(),
             resource_limits: ResourceLimits::default(),
             sandbox_profile: None,
+            device_paths: Vec::new(),
             network_enabled: default_network_enabled(),
         }
     }
@@ -489,6 +498,12 @@ impl SecurityOptionsBuilder {
     /// Add an environment variable to the allowlist.
     pub fn allow_env(&mut self, var: impl Into<String>) -> &mut Self {
         self.inner.env_allowlist.push(var.into());
+        self
+    }
+
+    /// Expose one Linux device node to the host-side shim sandbox.
+    pub fn allow_device(&mut self, path: impl Into<PathBuf>) -> &mut Self {
+        self.inner.device_paths.push(path.into());
         self
     }
 
@@ -717,4 +732,13 @@ pub struct AdvancedBoxOptions {
     #[doc(hidden)]
     #[serde(default)]
     pub nested_virtualization: bool,
+
+    /// Allow FUSE filesystems inside the box.
+    ///
+    /// This is intentionally narrower than disabling the sandbox: it grants the
+    /// container `CAP_SYS_ADMIN` and republishes `/dev/fuse`, while leaving the
+    /// rest of the security profile intact. Use for workloads such as
+    /// `mount-s3` that mount a userspace filesystem.
+    #[serde(default)]
+    pub fuse: bool,
 }

--- a/src/boxlite/src/runtime/options.rs
+++ b/src/boxlite/src/runtime/options.rs
@@ -605,12 +605,36 @@ impl BoxOptions {
     }
 
     pub fn sanitize(&self) -> BoxliteResult<()> {
-        self.sanitize_common()?;
+        let mut normalized = self.clone();
+        normalized.apply_advanced_feature_defaults();
+        normalized.sanitize_common()?;
 
-        if let Some(kernel) = &self.advanced.kernel {
+        if let Some(kernel) = &normalized.advanced.kernel {
             kernel.sanitize()?;
         }
         Ok(())
+    }
+
+    /// Apply derived expert settings for opt-in features.
+    pub(crate) fn apply_advanced_feature_defaults(&mut self) {
+        if self.advanced.fuse {
+            if !self.advanced.capabilities.add.iter().any(|capability| {
+                capability.eq_ignore_ascii_case("SYS_ADMIN")
+                    || capability.eq_ignore_ascii_case("CAP_SYS_ADMIN")
+            }) {
+                self.advanced.capabilities.add.push("SYS_ADMIN".into());
+            }
+            let fuse = PathBuf::from("/dev/fuse");
+            if !self
+                .advanced
+                .security
+                .device_paths
+                .iter()
+                .any(|path| path == &fuse)
+            {
+                self.advanced.security.device_paths.push(fuse);
+            }
+        }
     }
 }
 
@@ -1282,6 +1306,29 @@ mod tests {
 
         let legacy: BoxOptions = serde_json::from_str("{}").unwrap();
         assert!(!legacy.advanced.nested_virtualization);
+    }
+
+    #[test]
+    fn fuse_applies_minimal_derived_permissions() {
+        let mut options = BoxOptions {
+            advanced: AdvancedBoxOptions {
+                fuse: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let default_security = options.advanced.security.clone();
+
+        options.apply_advanced_feature_defaults();
+
+        assert_eq!(options.advanced.capabilities.add, vec!["SYS_ADMIN"]);
+        assert_eq!(
+            options.advanced.security.device_paths,
+            vec![PathBuf::from("/dev/fuse")]
+        );
+        let mut expected_security = default_security;
+        expected_security.device_paths = vec![PathBuf::from("/dev/fuse")];
+        assert_eq!(options.advanced.security, expected_security);
     }
 
     #[test]

--- a/src/boxlite/src/runtime/rt_impl.rs
+++ b/src/boxlite/src/runtime/rt_impl.rs
@@ -1687,6 +1687,8 @@ async fn sanitize_local_options(
     features: &ExperimentalFeatures,
     options: BoxOptions,
 ) -> BoxliteResult<BoxOptions> {
+    let mut options = options;
+    options.apply_advanced_feature_defaults();
     features.require_for_options(&options)?;
     tokio::task::spawn_blocking(move || {
         options.sanitize()?;

--- a/src/cli/src/cli.rs
+++ b/src/cli/src/cli.rs
@@ -951,6 +951,13 @@ pub struct ManagementFlags {
     /// Starting the box fails if the host cannot provide it.
     #[arg(long = "nested-virtualization", hide = true)]
     pub nested_virtualization: bool,
+
+    /// Allow FUSE filesystems in the box.
+    ///
+    /// Grants only the minimum runtime permissions needed by tools such as
+    /// mount-s3: CAP_SYS_ADMIN plus /dev/fuse.
+    #[arg(long)]
+    pub fuse: bool,
 }
 
 impl ManagementFlags {
@@ -975,6 +982,9 @@ impl ManagementFlags {
         }
         if self.nested_virtualization {
             opts.advanced.nested_virtualization = true;
+        }
+        if self.fuse {
+            opts.advanced.fuse = true;
         }
         Ok(())
     }
@@ -1247,6 +1257,7 @@ mod tests {
             detach: false,
             rm: false,
             security: None,
+            fuse: false,
         };
 
         let error = flags
@@ -1856,6 +1867,7 @@ mod tests {
             rm: false,
             security: Some("disable".to_string()),
             nested_virtualization: false,
+            fuse: false,
         };
         let mut opts = BoxOptions::default();
         flags.apply_to(&mut opts).expect("setting must apply");
@@ -1874,6 +1886,7 @@ mod tests {
             rm: false,
             security: None,
             nested_virtualization: false,
+            fuse: false,
         };
         let mut opts = BoxOptions::default();
         flags
@@ -1894,6 +1907,7 @@ mod tests {
             rm: false,
             security: Some("ultra".to_string()),
             nested_virtualization: false,
+            fuse: false,
         };
         let mut opts = BoxOptions::default();
         let err = flags
@@ -1919,5 +1933,22 @@ mod tests {
             .expect("nested virtualization should apply");
 
         assert!(opts.advanced.nested_virtualization);
+    }
+
+    #[test]
+    fn fuse_flag_applies_minimal_box_options() {
+        let cli = Cli::try_parse_from(["boxlite", "run", "--fuse", "alpine:latest"])
+            .expect("fuse flag should parse");
+        let Commands::Run(args) = cli.command else {
+            panic!("expected run command");
+        };
+
+        let mut opts = BoxOptions::default();
+        args.management
+            .apply_to(&mut opts)
+            .expect("fuse should apply");
+
+        assert!(opts.advanced.fuse);
+        assert_eq!(opts.advanced.security, boxlite::SecurityOptions::default());
     }
 }

--- a/src/cli/src/commands/serve/mod.rs
+++ b/src/cli/src/commands/serve/mod.rs
@@ -771,6 +771,7 @@ fn build_box_options(req: &CreateBoxRequest) -> Result<BoxOptions, boxlite::Boxl
                 add: req.advanced.capabilities.add.clone(),
                 drop: req.advanced.capabilities.drop.clone(),
             },
+            fuse: req.advanced.fuse,
             ..Default::default()
         },
         auto_stop: req.auto_stop,
@@ -1344,6 +1345,21 @@ mod tests {
         let opts = build_box_options(&req).expect("build capability options");
         assert_eq!(opts.advanced.capabilities.add, vec!["SYS_ADMIN"]);
         assert_eq!(opts.advanced.capabilities.drop, vec!["CAP_NET_RAW"]);
+    }
+
+    #[test]
+    fn build_box_options_carries_fuse_from_the_wire_without_security_override() {
+        let req: super::types::CreateBoxRequest =
+            serde_json::from_str(r#"{"image":"alpine:latest","advanced":{"fuse":true}}"#)
+                .expect("fuse request must deserialize");
+
+        let opts = build_box_options(&req).expect("build fuse options");
+        assert!(opts.advanced.fuse);
+        assert_eq!(
+            opts.advanced.security,
+            boxlite::SecurityOptions::default(),
+            "REST clients may request fuse, but not override server sandbox policy"
+        );
     }
 
     #[test]

--- a/src/cli/src/commands/serve/types.rs
+++ b/src/cli/src/commands/serve/types.rs
@@ -66,6 +66,7 @@ pub(super) struct CreateBoxRequest {
 #[serde(default, deny_unknown_fields)]
 pub(super) struct CreateBoxAdvancedOptions {
     pub capabilities: ContainerCapabilitiesRequest,
+    pub fuse: bool,
 }
 
 #[derive(Clone, Default, Deserialize)]

--- a/src/guest/src/container/spec.rs
+++ b/src/guest/src/container/spec.rs
@@ -70,6 +70,7 @@ fn resolve_device(device: ProtoContainerDevice) -> BoxliteResult<LinuxDevice> {
         }
     }
 
+    ensure_well_known_device(&source)?;
     let metadata = std::fs::symlink_metadata(&source)
         .map_err(|error| unsupported_device(&source, format!("is unavailable: {error}")))?;
     let typ = if metadata.file_type().is_char_device() {
@@ -111,6 +112,21 @@ fn resolve_device(device: ProtoContainerDevice) -> BoxliteResult<LinuxDevice> {
 
 fn unsupported_device(path: &Path, problem: String) -> BoxliteError {
     BoxliteError::Unsupported(format!("container device {} {problem}", path.display()))
+}
+
+fn ensure_well_known_device(path: &Path) -> BoxliteResult<()> {
+    if path != Path::new("/dev/fuse") || path.exists() {
+        return Ok(());
+    }
+
+    nix::sys::stat::mknod(
+        path,
+        nix::sys::stat::SFlag::S_IFCHR,
+        nix::sys::stat::Mode::from_bits_truncate(0o666),
+        nix::sys::stat::makedev(10, 229),
+    )
+    .or_else(|error| if path.exists() { Ok(()) } else { Err(error) })
+    .map_err(|error| unsupported_device(path, format!("could not be created: {error}")))
 }
 
 /// A device path must be absolute, free of `.`/`..`, and name something strictly


### PR DESCRIPTION
Split out of #1056. Adds an opt-in `--fuse` flag (`advanced.fuse`) that grants a box the minimum runtime permissions FUSE filesystems need: `CAP_SYS_ADMIN` and a `/dev/fuse` device node, in both the sandbox layer (bwrap/landlock) and the guest container spec. Advertised over REST via `CreateBoxAdvancedOptions.fuse`; older servers that predate the capability are rejected rather than silently ignoring the request.

Unrelated to volume mounts — split out because it grants a new sandbox capability (`CAP_SYS_ADMIN` + device access) and deserves independent review from the storage API work in #1056.

Test plan:
- `BOXLITE_DEPS_STUB=1 cargo test -p boxlite --lib --features rest fuse` — 3 tests pass
- `BOXLITE_DEPS_STUB=1 cargo test -p boxlite-cli fuse` — 2 tests pass
- `BOXLITE_DEPS_STUB=1 cargo test -p boxlite-cli --bin boxlite cli::tests::` — 64/64 pass, no regressions