### PR TITLE
fix(rest): send explicit auto_stop with remove-on-stop

### DIFF
--- a/src/boxlite/src/rest/types.rs
+++ b/src/boxlite/src/rest/types.rs
@@ -188,9 +188,15 @@ impl CreateBoxRequest {
                 }
             }),
             // The deprecated remove-on-stop flag was never applied by the cloud
-            // control-plane mapper. Keep remote defaults unchanged and only send
-            // the modern lifecycle fields when callers explicitly configure them.
-            auto_stop: options.auto_stop,
+            // control-plane mapper. Keep remote defaults unchanged, but make the
+            // modern remove-on-stop spelling explicit enough that the server does
+            // not combine `auto_delete=1` with its default auto-stop interval.
+            auto_stop: options.auto_stop.or_else(|| {
+                options
+                    .auto_delete
+                    .is_some_and(|value| value > 0)
+                    .then_some(0)
+            }),
             auto_delete: options.auto_delete,
             auto_resume: options.auto_resume,
         }
@@ -717,6 +723,17 @@ mod tests {
         let req = CreateBoxRequest::from_options(&modern, None);
         assert_eq!(req.auto_stop, Some(900));
         assert_eq!(req.auto_delete, Some(3600));
+    }
+
+    #[test]
+    fn remove_on_stop_sends_zero_autostop() {
+        let opts = BoxOptions {
+            auto_delete: Some(1),
+            ..Default::default()
+        };
+        let req = CreateBoxRequest::from_options(&opts, None);
+        assert_eq!(req.auto_stop, Some(0));
+        assert_eq!(req.auto_delete, Some(1));
     }
 
     #[test]


### PR DESCRIPTION
Split out of #1056. Deprecated `auto_remove` translates to `auto_delete=1` client-side, but the REST wire format left `auto_stop` unset in that case, letting the server apply its own default auto-stop interval on top of an immediate-delete request. Send `auto_stop=0` explicitly whenever `auto_delete` is a positive remove-on-stop value and the caller has not set `auto_stop` themselves.

Unrelated to volume mounts or the fuse sandbox change — a single-line lifecycle-timing fix bundled into the same commit as both, split out for independent review.

Test plan:
- `BOXLITE_DEPS_STUB=1 cargo test -p boxlite --lib --features rest rest::types` — 17/17 pass, including new `remove_on_stop_sends_zero_autostop`