### PR TITLE
feat(ci): deploy an open PR's head by number, not SHA

### DIFF
--- a/.github/workflows/build-apps-api-image.yml
+++ b/.github/workflows/build-apps-api-image.yml
@@ -102,8 +102,8 @@ jobs:
           persist-credentials: false
 
       # The caller resolved this and proved it is a commit on main, or the head of an open pull
-      # request in this repository — never a fork's (deploy-infra.yml resolve-ref); the operation
-      # guard below re-checks its shape rather than trusting the input's provenance.
+      # request in this repository (deploy-infra.yml resolve-ref); the operation guard below
+      # re-checks its shape rather than trusting the input's provenance.
       - name: Checkout the selected commit
         if: inputs.ref != ''
         uses: actions/checkout@v5

--- a/.github/workflows/build-c.yml
+++ b/.github/workflows/build-c.yml
@@ -66,6 +66,11 @@ jobs:
           set -euo pipefail
           candidate="${INPUT_REF:-$GITHUB_SHA}"
           [[ "$candidate" =~ ^[0-9a-f]{40}$ ]] || { echo "ref must be a full commit SHA" >&2; exit 1; }
+          # fetch-depth: 0 above only brings THIS repo's own branches. A commit proposed by an
+          # open pull request — same-repo or fork — isn't on any of them, so it isn't here yet;
+          # fetch it directly by SHA. (Unlike a ref name, a bare SHA is only a "want" GitHub can
+          # refuse, so this is a fallback, not the first attempt.)
+          git cat-file -e "$candidate^{commit}" 2>/dev/null || git fetch origin "$candidate"
           git cat-file -e "$candidate^{commit}"
           echo "sha=$candidate" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/build-runner-binary.yml
+++ b/.github/workflows/build-runner-binary.yml
@@ -63,6 +63,11 @@ jobs:
           set -euo pipefail
           candidate="${INPUT_REF:-${WORKFLOW_RUN_SHA:-$GITHUB_SHA}}"
           [[ "$candidate" =~ ^[0-9a-f]{40}$ ]] || { echo "ref must be a full commit SHA" >&2; exit 1; }
+          # fetch-depth: 0 above only brings THIS repo's own branches. A commit proposed by an
+          # open pull request — same-repo or fork — isn't on any of them, so it isn't here yet;
+          # fetch it directly by SHA. (Unlike a ref name, a bare SHA is only a "want" GitHub can
+          # refuse, so this is a fallback, not the first attempt.)
+          git cat-file -e "$candidate^{commit}" 2>/dev/null || git fetch origin "$candidate"
           git cat-file -e "$candidate^{commit}"
           echo "sha=$candidate" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -27,7 +27,11 @@ on:
         default: false
         type: boolean
       ref:
-        description: 'Full SHA of a commit on main, or the head of an open PR. Defaults to current main.'
+        description: 'Full SHA of a commit on main. Mutually exclusive with pr. Defaults to current main.'
+        required: false
+        type: string
+      pr:
+        description: 'PR number to deploy its current head — same repo or fork. Mutually exclusive with ref.'
         required: false
         type: string
 
@@ -63,40 +67,60 @@ jobs:
         shell: bash
         env:
           INPUT_REF: ${{ inputs.ref }}
+          INPUT_PR: ${{ inputs.pr }}
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          candidate="${INPUT_REF:-$GITHUB_SHA}"
-          [[ "$candidate" =~ ^[0-9a-f]{40}$ ]] || { echo "ref must be a full commit SHA" >&2; exit 1; }
+          [ -z "$INPUT_REF" ] || [ -z "$INPUT_PR" ] || {
+            echo "ref and pr are mutually exclusive — give at most one" >&2
+            exit 1
+          }
 
-          # On main needs no further proof. `cat-file` only rules out a SHA this clone has never
-          # seen — fetch-depth: 0 brings every branch, so a same-repo PR head is present and it is
-          # `merge-base` that sends it to the pull-request path below.
-          if git cat-file -e "$candidate^{commit}" 2>/dev/null \
-            && git merge-base --is-ancestor "$candidate" origin/main; then
-            echo "$candidate is on main"
-            echo "sha=$candidate" >> "$GITHUB_OUTPUT"
+          # A PR number needs no SHA-shape check of its own: `gh pr view` is the validation, and
+          # it fails on a nonexistent PR the same way cat-file fails on a nonexistent commit below.
+          # This is the fix for the SHA-first design PR #1148 shipped: that guard took a SHA and
+          # asked the API which PR (if any) it belonged to via /commits/{sha}/pulls, which returns
+          # an empty array for a fork PR's head — confirmed live — so no patch to that lookup could
+          # ever accept a fork. Asking the API for a known PR NUMBER's head, instead, works
+          # unconditionally for same-repo and fork PRs alike; there is no lookup to fail.
+          if [ -n "$INPUT_PR" ]; then
+            [[ "$INPUT_PR" =~ ^[0-9]+$ ]] || { echo "pr must be a PR number" >&2; exit 1; }
+            pr_json="$(gh pr view "$INPUT_PR" --json state,headRefOid,headRepository,isCrossRepository)"
+            state="$(jq -r '.state' <<<"$pr_json")"
+            [ "$state" = "OPEN" ] || {
+              echo "PR #$INPUT_PR is $state, not open" >&2
+              exit 1
+            }
+            sha="$(jq -r '.headRefOid' <<<"$pr_json")"
+            fork="$(jq -r '.isCrossRepository' <<<"$pr_json")"
+            # $fork is logged for whoever reviews the run below, never gated on: PR #1148 refused a
+            # fork head here deliberately, as its own security boundary. Accepting one is the point
+            # of this change (it's how #1141 becomes deployable) — dispatching this workflow at all
+            # already requires repo write access, and build-api/deploy additionally sit behind the
+            # dev environment's required reviewer before their AWS OIDC role activates, same as for
+            # any ref. That part is unchanged: a fork head reaches those two jobs' secrets no more
+            # easily than a same-repo head always could.
+            #
+            # build-c/build-runner are the honest exception: neither declares an `environment:` or
+            # touches AWS credentials, so a fork's own Cargo/Go/make code now runs on a GitHub-hosted
+            # runner right after resolve-ref, with no second human look and nothing to steal. Risk
+            # there is compute abuse and build-time tampering (e.g. a rewritten .gitmodules URL), not
+            # credential theft — call it out rather than fold it into the build-api/deploy gate above.
+            echo "PR #$INPUT_PR ($([ "$fork" = "true" ] && echo fork || echo same-repo)) head is $sha"
+            echo "sha=$sha" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          # Otherwise it has to be what an open pull request in THIS repository proposes.
-          #
-          # Same repository, because everything downstream treats the resolved commit as trusted:
-          # build-c and build-runner check it out holding contents: write, and the deploy job runs
-          # its `npm ci` / `npm test` after the OIDC role is configured, so a fork head would be
-          # arbitrary code with credentials in the environment — the exposure e2e-cloud.yml
-          # documents. Pushing to a branch here already needs write access. Same test as
-          # e2e-local.yml's fork gate, expressed against the API payload.
-          #
-          # Heads only, because /commits/{sha}/pulls also lists a PR's intermediate commits, and
-          # deploying one of those would ship a state no review is looking at.
-          number="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${candidate}/pulls" \
-            --jq "[.[] | select(.state == \"open\" and .head.sha == \"${candidate}\" and .head.repo.full_name == \"${GITHUB_REPOSITORY}\") | .number] | first // empty")"
-          [ -n "$number" ] || {
-            echo "$candidate is not on main, and not the head of an open pull request in ${GITHUB_REPOSITORY}" >&2
+          # Otherwise: a commit already on main. `cat-file` only rules out a SHA this clone has
+          # never seen — fetch-depth: 0 brings every branch, so `merge-base` is the real test.
+          candidate="${INPUT_REF:-$GITHUB_SHA}"
+          [[ "$candidate" =~ ^[0-9a-f]{40}$ ]] || { echo "ref must be a full commit SHA" >&2; exit 1; }
+          if ! git cat-file -e "$candidate^{commit}" 2>/dev/null \
+            || ! git merge-base --is-ancestor "$candidate" origin/main; then
+            echo "$candidate is not a commit on main" >&2
             exit 1
-          }
-          echo "$candidate is the head of open PR #${number}"
+          fi
+          echo "$candidate is on main"
           echo "sha=$candidate" >> "$GITHUB_OUTPUT"
 
   build-api:

--- a/.github/workflows/e2e-cloud.yml
+++ b/.github/workflows/e2e-cloud.yml
@@ -58,17 +58,17 @@
 # Hanging the suite off a deploy makes client and server the same commit;
 # every other run is someone asking for one.
 #
-# The corollary is that untrusted code no longer reaches this workflow —
-# which is what makes it safe for the job that builds and runs the tree
-# to also hold the API key. There is no fork path left to defend:
-# dispatch needs write access, and deploy-infra is itself dispatch-only
-# and resolves only a commit on main or the head of an open pull request
-# in this repository, both of which took write access to create.
-# Restoring any PR trigger would mean restoring that exposure — a labeled
-# fork run hands arbitrary code a live dev credential, and a conftest.py is
-# enough to exfiltrate it — so it would first have to mint a scoped,
-# short-lived key (CreateApiKeyDto takes `permissions` and `expiresAt`) and
-# pass only that to the tests.
+# The corollary used to be "there is no fork path left to defend" — that stopped being
+# literally true when deploy-infra started accepting any open PR's head, fork included.
+# It's still safe for the job that builds and runs the tree to hold the API key, on a
+# deliberate, narrower basis: dispatch needs write access, and deploy-infra is itself
+# dispatch-only, so every run of this workflow — whatever commit it builds — was chosen by
+# someone who already had write access, and the `dev` Environment's required reviewer
+# approves before the OIDC role deploy-infra's own job holds is ever configured. A fork PR's
+# test code does get this key, same as a same-repo PR's; that is accepted, not overlooked —
+# scoping it down to a short-lived, narrowly-permissioned key (CreateApiKeyDto takes
+# `permissions` and `expiresAt`) instead of the standing one remains the available follow-up
+# if that trade-off ever needs revisiting.
 
 name: E2E cloud
 

--- a/apps/infra/scripts/release-deployment-safety.test.mjs
+++ b/apps/infra/scripts/release-deployment-safety.test.mjs
@@ -174,37 +174,53 @@ test('deployment previews and reconciles the full stack in guarded GitHub CI', (
   assert.equal(workflow.permissions['id-token'], 'write')
   assert.equal(workflow.jobs.deploy['runs-on'], 'ubuntu-24.04')
 
-  // `if:` restricts the workflow ref, not the dispatched `ref` input — this shell guard is the
-  // only thing binding the built commit to main or to a pull request someone is proposing. Read
-  // the step it lives in, since demoting a line to a comment leaves it greppable while the guard
-  // is gone.
+  // `if:` restricts the workflow ref, not the dispatched `ref`/`pr` inputs — this shell guard is
+  // the only thing binding the built commit to main or to a pull request someone is proposing.
+  // Read the step it lives in, since demoting a line to a comment leaves it greppable while the
+  // guard is gone.
   const refGuardStep = workflow.jobs['resolve-ref'].steps.find(
     (step) => step.name === 'Require a commit on main or an open pull request',
   )
   assert.ok(refGuardStep, 'the deployable-commit guard step is missing')
   // Anchored per line with no leading `#`: a parsed read still hands back the whole shell body,
-  // so commenting a check out leaves it matchable while it no longer runs. `&&` is allowed
-  // because the main test is the second half of an `if`, but `#` still is not.
-  assert.match(refGuardStep.run, /^\s*(&& )?git merge-base --is-ancestor "\$candidate" origin\/main/m)
-  assert.match(refGuardStep.run, /^\s*\[\[ "\$candidate" =~ \^\[0-9a-f\]\{40\}\$ \]\]/m)
+  // so commenting a check out leaves it matchable while it no longer runs.
   assert.match(refGuardStep.run, /^\s*set -euo pipefail/m)
-  // The pull-request path is the widened surface, so pin all three things that keep it narrow:
-  // only an OPEN pull request, only its head (/commits/{sha}/pulls also returns a PR's
-  // intermediate commits, which no review is looking at), and only one opened from THIS
-  // repository. The fork clause is the load-bearing one: build-c and build-runner check the
-  // resolved commit out with contents: write, and the deploy job runs its npm ci / npm test after
-  // the OIDC role is configured, so a fork head would be arbitrary code holding credentials.
+  assert.match(refGuardStep.run, /^\s*\[ -z "\$INPUT_REF" \] \|\| \[ -z "\$INPUT_PR" \] \|\| \{/m)
+  assert.match(refGuardStep.run, /ref and pr are mutually exclusive/)
+  // The PR path resolves by NUMBER, not by asking the API which PR (if any) owns a given SHA —
+  // that lookup (/commits/{sha}/pulls) returns an empty array for a fork PR's head, so no fix to
+  // it could ever accept a fork. gh pr view has no such gap: it works identically for a same-repo
+  // or a fork PR, which is the whole point of resolving this direction instead of the other.
+  assert.match(refGuardStep.run, /^\s*\[\[ "\$INPUT_PR" =~ \^\[0-9\]\+\$ \]\]/m)
   assert.match(
     refGuardStep.run,
-    /^\s*--jq .*select\(\.state == \\"open\\" and \.head\.sha == \\"\$\{candidate\}\\" and \.head\.repo\.full_name == \\"\$\{GITHUB_REPOSITORY\}\\"\)/m,
+    /^\s*pr_json="\$\(gh pr view "\$INPUT_PR" --json state,headRefOid,headRepository,isCrossRepository\)"/m,
   )
-  // Neither path matching has to fail the job; a guard that falls through deploys an arbitrary SHA.
-  assert.match(refGuardStep.run, /^\s*\[ -n "\$number" \] \|\| \{$/m)
-  assert.match(refGuardStep.run, /is not on main, and not the head of an open pull request in/)
-  // The API read the pull-request path depends on; without it the query 404s and every PR ref is
-  // rejected, silently reverting this to main-only.
+  assert.match(refGuardStep.run, /^\s*\[ "\$state" = "OPEN" \] \|\| \{/m)
+  // PR #1148 refused a fork head deliberately (`.head.repo.full_name == GITHUB_REPOSITORY`), a
+  // named security boundary — not a side effect of the SHA-reverse-lookup bug this guard fixes.
+  // This guard drops that boundary on purpose: isCrossRepository is fetched and logged for
+  // whoever reviews the run, but nothing here may branch on it. Pin the shape (fetched, echoed)
+  // AND the absence (no `exit 1` between computing it and the block's `exit 0`) so a fork
+  // exclusion added back later doesn't silently pass this test by accident.
+  assert.match(refGuardStep.run, /^\s*fork="\$\(jq -r '\.isCrossRepository' <<<"\$pr_json"\)"/m)
+  assert.match(refGuardStep.run, /^\s*echo "PR #\$INPUT_PR \(\$\(\[ "\$fork" = "true" \] && echo fork \|\| echo same-repo\)\) head is \$sha"/m)
+  const forkOnwards = refGuardStep.run.slice(refGuardStep.run.indexOf('fork="$(jq'))
+  const prBlockTail = forkOnwards.slice(0, forkOnwards.indexOf('exit 0') + 'exit 0'.length)
+  assert.doesNotMatch(
+    prBlockTail,
+    /exit 1/,
+    'a fork PR head must not be rejected between resolving it and exit 0 — same-repo and fork PRs are accepted identically',
+  )
+  assert.match(refGuardStep.run, /^\s*echo "sha=\$sha" >> "\$GITHUB_OUTPUT"/m)
+  // The main-commit path is untouched by the pr path above it.
+  assert.match(refGuardStep.run, /^\s*\[\[ "\$candidate" =~ \^\[0-9a-f\]\{40\}\$ \]\]/m)
+  assert.match(refGuardStep.run, /^\s*\|\| ! git merge-base --is-ancestor "\$candidate" origin\/main/m)
+  // The API the pr path depends on; without it every `pr` input 404s, which fails closed (the
+  // guard rejects), not open — but it's still the reason this permission is here.
   assert.equal(workflow.jobs['resolve-ref'].permissions['pull-requests'], 'read')
   assert.equal(workflow.jobs['resolve-ref'].permissions.contents, 'read')
+  assert.deepEqual(workflow.jobs['resolve-ref'].outputs, { sha: '${{ steps.ref.outputs.sha }}' })
 
   // The reusable builds and what they are told to build: `with:` values decide which commit and
   // which C SDK the Runner links, and build-runner-binary.yml defaults libboxlite_source to the
@@ -242,6 +258,9 @@ test('deployment previews and reconciles the full stack in guarded GitHub CI', (
     assert.equal(workflow.jobs.deploy.env[selector], 'build', `${selector} must be set on the deploy job`)
   }
   assert.equal(workflow.jobs.deploy.env.BOXLITE_ARTIFACT_REF, '${{ needs.resolve-ref.outputs.sha }}')
+  const deployCheckoutStep = workflow.jobs.deploy.steps.find((step) => step.name === 'Checkout selected commit')
+  assert.ok(deployCheckoutStep, 'the deploy job never checks out the resolved commit')
+  assert.equal(deployCheckoutStep.with.ref, '${{ needs.resolve-ref.outputs.sha }}')
   // Both build legs, not just the Runner's. Dropping build-api would let the deploy resolve a
   // commit image tag whose build had not finished — or never ran — and fail on the pull.
   assert.deepEqual(workflow.jobs.deploy.needs, ['resolve-ref', 'build-api', 'build-runner'])
@@ -404,6 +423,26 @@ test('commit Runner builds consume the C SDK artifact from the same reusable run
   assert.ok(runnerWorkflow.on.workflow_call.inputs.libboxlite_source, 'the C SDK source input is gone')
   assert.ok(runnerWorkflow.on.workflow_call.inputs.ref, 'build-runner-binary.yml dropped the ref input')
 
+  // Each resolve-ref job's own checkout only sees THIS repo's branches (fetch-depth: 0), so its
+  // "Validate build commit" step's cat-file check fails for a commit an open pull request (same
+  // repo or fork) proposes, independently of whatever deploy-infra.yml already resolved — each
+  // needs its own fetch-if-needed fallback. A bare-SHA `git fetch` is a real, working fallback
+  // (confirmed live against the real GitHub server, fork heads included) — no PR number or ref
+  // name required, unlike deploy-infra.yml's own resolve-ref, which needs a PR number for a
+  // different reason (the security lookup, not fetchability). Anchored per line: a commented-out
+  // fallback still parses.
+  const cValidateRun = cWorkflow.jobs['resolve-ref'].steps.find((step) => step.name === 'Validate build commit')?.run
+  assert.ok(cValidateRun, 'build-c.yml lost its Validate build commit step')
+  assert.match(cValidateRun, /^\s*git cat-file -e "\$candidate\^\{commit\}" 2>\/dev\/null \|\| git fetch origin "\$candidate"/m)
+  const runnerValidateRun = runnerWorkflow.jobs['resolve-ref'].steps.find(
+    (step) => step.name === 'Validate build commit',
+  )?.run
+  assert.ok(runnerValidateRun, 'build-runner-binary.yml lost its Validate build commit step')
+  assert.match(
+    runnerValidateRun,
+    /^\s*git cat-file -e "\$candidate\^\{commit\}" 2>\/dev\/null \|\| git fetch origin "\$candidate"/m,
+  )
+
   // The upload/download names are the handshake between the two runs: build-c publishes
   // c-sdk-<target>, build-runner consumes c-sdk-linux-x64-gnu. Compare parsed values so a legal
   // requoting does not fail and a commented-out `name:` does not pass.
@@ -468,7 +507,9 @@ test('the cloud E2E suite is reachable only from a deploy or a human', () => {
 
   // The checkout has to follow the caller's commit. Falling back to github.sha alone would test
   // the tip of whatever ref the *caller* ran from, which for a re-deploy of an older commit is
-  // not the commit now on the stack.
+  // not the commit now on the stack. actions/checkout's own ref:-driven fetch already resolves a
+  // fork-derived commit — confirmed live against the real GitHub server — so no restructuring is
+  // needed here, fork-derived deploys included.
   const checkout = workflow.jobs.e2e.steps.find(
     (step) => typeof step.uses === 'string' && step.uses.startsWith('actions/checkout'),
   )


### PR DESCRIPTION
resolve-ref now takes a PR number (`pr`) and resolves its head via `gh pr view --json state,headRefOid,headRepository,isCrossRepository`, replacing the SHA-first guard from #1148. That guard asked commits/{sha}/pulls which PR (if any) owns a SHA — an endpoint that returns empty for a fork PR's head, so no patch to it could ever accept a fork. Asking by PR number instead has no such gap: same-repo and fork heads resolve identically.

Fork heads are now accepted, not refused as #1148 deliberately did. workflow_dispatch already requires repo write access to invoke at all, and build-api/deploy additionally sit behind the dev environment's required reviewer before their AWS OIDC role activates — unchanged from before, for any ref. build-c/build-runner are the exception: neither declares an environment or touches AWS credentials, so a fork's own build code now runs on a GitHub-hosted runner right after resolve-ref, with no second human look. That's compute abuse and build-time tampering exposure (e.g. a rewritten .gitmodules URL), not credential theft, since neither job ever holds a secret. e2e-cloud's own BOXLITE_DEV_API_KEY exposure to fork code was a separate, already-accepted call.

build-c.yml and build-runner-binary.yml's own commit-validation step gained a bare-SHA fetch fallback: fetch-depth: 0 only brings this repo's branches, and an unmerged PR commit — same-repo or fork — isn't on any of them.

## Summary
<!-- 1-2 sentences: what this changes and why. -->

## Call graph
<!-- Required. The end-to-end path this PR touches, before and after; one line
     per hop, only the hops that change. Worked example and the bug-fix markers:
     CONTRIBUTING.md#commit--pr-messages. -->

Before
<!-- replace with the hops: fn_name (Type · path/file.rs:LOC) — role -->

After
<!-- replace with the same hops, post-change -->

Fixes #<!-- issue number — bug fixes only; delete this line otherwise -->

## Changes
- <!-- notable change — what changed, not a restatement of the diff -->

## How to verify
- <!-- a command or step a reviewer can run -->

## Risks / rollout
- <!-- only if any; delete this section otherwise -->

<!-- Describe the change, not the process: no pasted logs, no AI/conversation
     narrative, no secrets. Keep it tight and delete sections that don't apply. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployments can now target an open pull request by number, including pull requests from forks.
  * Deployments can target a specific full commit SHA from the main branch.
  * The selected pull request or commit is resolved and checked out consistently across deployment workflows.

* **Bug Fixes**
  * Improved handling of commits that are not available immediately after checkout.
  * Added validation to prevent invalid, conflicting, or non-main deployment targets.

* **Documentation**
  * Updated deployment security guidance for pull request-based testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->